### PR TITLE
Update NASDAQ ITCH FTP Address

### DIFF
--- a/02_market_and_fundamental_data/01_NASDAQ_TotalView-ITCH_Order_Book/01_parse_itch_order_flow_messages.ipynb
+++ b/02_market_and_fundamental_data/01_NASDAQ_TotalView-ITCH_Order_Book/01_parse_itch_order_flow_messages.ipynb
@@ -258,7 +258,7 @@
    },
    "outputs": [],
    "source": [
-    "FTP_URL = 'ftp://emi.nasdaq.com/ITCH/'\n",
+    "FTP_URL = 'ftp://emi.nasdaq.com/ITCH/Nasdaq ITCH/'\n",
     "SOURCE_FILE = '10302019.NASDAQ_ITCH50.gz'"
    ]
   },


### PR DESCRIPTION
The file `10302019.NASDAQ_ITCH50.gz` has been moved to a new folder on the FTP server.