### PR TITLE
fix: AttributeError from feature_name

### DIFF
--- a/12_gradient_boosting_machines/08_making_out_of_sample_predictions.ipynb
+++ b/12_gradient_boosting_machines/08_making_out_of_sample_predictions.ipynb
@@ -619,7 +619,7 @@
     "\n",
     "        test_set = data.iloc[test_idx, :]\n",
     "        y_test = test_set.loc[:, label].to_frame('y_test')\n",
-    "        y_pred = model.predict(test_set.loc[:, model.feature_name()])\n",
+    "        y_pred = model.predict(test_set.loc[:, model.feature_names_])\n",
     "        predictions.append(y_test.assign(prediction=y_pred))\n",
     "\n",
     "    if position == 0:\n",


### PR DESCRIPTION
The attribute of 'model' CatBoostRegressor  should simply be 'feature_names_' rather than using as a method. Please refer to [catboost](https://catboost.ai/docs/concepts/python-reference_catboostregressor.html) API and accept this PR.