### PR TITLE
Fix download_all.py to honor ML4T_DATA_PATH

### DIFF
--- a/data/download_all.py
+++ b/data/download_all.py
@@ -316,13 +316,14 @@ def main():
     parser.add_argument(
         "--force", action="store_true", help="Force re-download even if data exists"
     )
-    # Default to repo's data directory (this script lives in code/data/)
-    repo_root = Path(__file__).parent.parent
+    # Default to None so resolve_data_dir() applies the documented precedence:
+    # explicit --data-path > ML4T_DATA_PATH env var > <repo>/data. A non-None
+    # default here would be treated as an explicit CLI arg and override the env var.
     parser.add_argument(
         "--data-path",
         type=Path,
-        default=repo_root / "data",
-        help="Data storage location (default: <repo>/data/)",
+        default=None,
+        help="Data storage location (default: ML4T_DATA_PATH, else <repo>/data/)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Problem

`data/download_all.py` defines `--data-path` with `default=repo_root / "data"`. `resolve_data_dir()` (in `utils/downloading.py`) gives any non-`None` CLI argument the highest precedence, so this default always overrides the `ML4T_DATA_PATH` environment variable — contradicting the adjacent comment ("ML4T_DATA_PATH takes precedence") and the README quick start.

With `ML4T_DATA_PATH` set, `uv run python data/download_all.py --free-only` writes datasets into `<repo>/data`, and the loaders (which read `ML4T_DATA_PATH`) then raise `DataNotFoundError` despite an apparently successful download.

### Reproduce

```bash
export ML4T_DATA_PATH=/some/other/path   # or set in .env
uv run python data/download_all.py --free-only
uv run python -c "from data import load_etfs; load_etfs()"   # DataNotFoundError
```

## Fix

Default `--data-path` to `None` so `resolve_data_dir()` applies the documented precedence: explicit `--data-path` > `ML4T_DATA_PATH` > `<repo>/data`. Explicit `--data-path` still works, and there is no change in behavior when neither the flag nor the env var is set.
