### PR TITLE
fix(data): make in-container free-data download work (#361)

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -77,10 +77,15 @@ download URL and instructions will be published before launch.
 
 ## Download Commands
 
+> **Times below are rough, indicative estimates only.** Actual duration
+> depends on your bandwidth, the providers' current rate limits, and disk
+> speed — treat them as ballpark, not guarantees.
+
 ### Free Datasets (No API Keys)
 
 ```bash
-# All free datasets at once
+# All free datasets at once (includes the ~1.5 GB firm-characteristics
+# dataset; add --skip-firm-characteristics to leave it out)
 uv run python data/download_all.py --free-only
 
 # Individual datasets (from repo root)
@@ -88,7 +93,7 @@ uv run python data/etfs/market/download.py                           # ~30s
 uv run python data/crypto/market/download.py                         # ~10-15 min (see note)
 uv run python data/factors/ff_download.py                     # ~5s
 uv run python data/factors/aqr_download.py                    # ~5s
-uv run python data/equities/firm_characteristics/download.py  # ~3 min (1.1 GB)
+uv run python data/equities/firm_characteristics/download.py  # ~1.5 GB, largest free dataset; downloads + converts (minutes, bandwidth-dependent)
 uv run python data/futures/positioning/cot_download.py                    # ~2-3 min (CFTC CoT)
 ```
 

--- a/data/download_all.py
+++ b/data/download_all.py
@@ -153,14 +153,22 @@ def download_aqr_factors(data_path: Path):
 
 
 def download_firm_characteristics(data_path: Path):
-    """Download Chen-Pelger-Zhu firm characteristics (free, from GitHub)."""
+    """Download Chen-Pelger-Zhu firm characteristics (free academic dataset).
+
+    The download script fetches the ~1.5 GB Google Drive folder and converts
+    RetChar.csv to parquet in one step (no separate --convert pass needed).
+    """
     print("\n" + "=" * 60)
-    print("FIRM CHARACTERISTICS (Free - GitHub)")
+    print("FIRM CHARACTERISTICS (Free - Chen-Pelger-Zhu academic dataset)")
+    print("=" * 60)
+    print("  Largest free dataset: ~1.5 GB download (RetChar.csv is ~1.1 GB)")
+    print("  followed by a ~1.1 GB CSV -> parquet conversion.")
+    print("  Duration depends on your bandwidth (typically a few minutes).")
+    print("  Per-file download progress is shown below.")
+    print("  Skip with:  python data/download_all.py --skip-firm-characteristics")
     print("=" * 60)
 
-    return run_download_script(
-        "firm_characteristics.py", ["--data-path", str(data_path), "--convert"]
-    )
+    return run_download_script("firm_characteristics.py", ["--data-path", str(data_path)])
 
 
 def download_us_equities(data_path: Path):
@@ -316,6 +324,11 @@ def main():
     parser.add_argument(
         "--force", action="store_true", help="Force re-download even if data exists"
     )
+    parser.add_argument(
+        "--skip-firm-characteristics",
+        action="store_true",
+        help="Skip the large (~1.5 GB) firm-characteristics academic dataset",
+    )
     # Default to None so resolve_data_dir() applies the documented precedence:
     # explicit --data-path > ML4T_DATA_PATH env var > <repo>/data. A non-None
     # default here would be treated as an explicit CLI arg and override the env var.
@@ -348,6 +361,14 @@ def main():
     else:
         mode = "core"
     print(f"Mode:        {mode}")
+
+    # Heads-up on the one large free dataset so readers know what's coming.
+    if mode in ("core", "free-only", "all") and not args.skip_firm_characteristics:
+        print(
+            "\nHeads-up: this run includes the firm-characteristics academic dataset\n"
+            "          (~1.5 GB download + a ~1.1 GB CSV -> parquet conversion).\n"
+            "          Skip it with:  --skip-firm-characteristics"
+        )
 
     # Create data directory
     data_path.mkdir(parents=True, exist_ok=True)
@@ -391,7 +412,15 @@ def main():
     print("=" * 60)
     results["Fama-French"] = download_ff_factors(data_path)
     results["AQR"] = download_aqr_factors(data_path)
-    results["Firm Characteristics"] = download_firm_characteristics(data_path)
+    if args.skip_firm_characteristics:
+        print("\n" + "=" * 60)
+        print("FIRM CHARACTERISTICS - skipped (--skip-firm-characteristics)")
+        print("=" * 60)
+        print("  ~1.5 GB academic dataset (Chen-Pelger-Zhu). Fetch it later with:")
+        print("    python data/equities/firm_characteristics/download.py")
+        print("=" * 60)
+    else:
+        results["Firm Characteristics"] = download_firm_characteristics(data_path)
 
     # === FREE WITH API KEY ===
     if not args.free_only:

--- a/data/equities/firm_characteristics/README.md
+++ b/data/equities/firm_characteristics/README.md
@@ -33,8 +33,15 @@ the original paper:
 
 ## Download
 
+This is the largest free dataset in the book: ~1.5 GB pulled from the
+authors' Google Drive folder (RetChar.csv alone is ~1.1 GB), followed by
+a CSV → parquet conversion. How long it takes depends on your bandwidth
+and disk speed — usually a few minutes, but treat that as indicative, not
+a guarantee. Per-file progress is printed as it runs. A single command
+downloads *and* converts — no separate `--convert` pass is needed.
+
 ```bash
-# Pull raw CSVs + NPZ arrays (~1.1 GB over the network)
+# Download the ~1.5 GB folder and convert to parquet in one step
 uv run python data/equities/firm_characteristics/download.py
 
 # Verify what's already on disk, do not refetch
@@ -43,10 +50,13 @@ uv run python data/equities/firm_characteristics/download.py --check
 # Force a re-download even if files exist
 uv run python data/equities/firm_characteristics/download.py --force
 
-# Convert the raw CSVs to the canonical firm_characteristics_*.parquet
-# files that the loader consumes (run once after a fresh download)
+# Re-run only the CSV → parquet conversion (files already downloaded)
 uv run python data/equities/firm_characteristics/download.py --convert
 ```
+
+It is also fetched automatically as part of `data/download_all.py`. To
+skip it there (e.g. on a metered or space-constrained connection), pass
+`--skip-firm-characteristics`.
 
 Output layout under `$ML4T_DATA_PATH/equities/firm_characteristics/`:
 

--- a/data/equities/firm_characteristics/download.py
+++ b/data/equities/firm_characteristics/download.py
@@ -137,19 +137,25 @@ def extract_zip(zip_path: Path, extract_dir: Path) -> bool:
             temp_dir.mkdir(parents=True, exist_ok=True)
             zf.extractall(temp_dir)
 
-            # Flatten nested structure
-            # Original structure might be: data/char/Char_train.npz
-            # We want: char/Char_train.npz
+            # Flatten nested structure. The published archives wrap their
+            # contents in a single top-level directory (e.g. datasets/char/...
+            # or data/char/...); we want char/... directly under extract_dir.
             for root, _dirs, files in os.walk(temp_dir):
                 root_path = Path(root)
                 rel_root = root_path.relative_to(temp_dir)
-
-                # Skip the top-level 'data' directory if it exists
                 parts = rel_root.parts
-                if parts and parts[0] == "data":
+
+                # Skip macOS archive cruft (__MACOSX/... resource forks)
+                if parts and parts[0] == "__MACOSX":
+                    continue
+
+                # Strip a redundant top-level wrapper directory
+                if parts and parts[0] in ("data", "datasets"):
                     rel_root = Path(*parts[1:]) if len(parts) > 1 else Path(".")
 
                 for file in files:
+                    if file == ".DS_Store":
+                        continue
                     src = root_path / file
                     if rel_root == Path("."):
                         dst = extract_dir / file
@@ -271,11 +277,17 @@ def main():
             print(f"\n[FAIL] Missing {len(missing)} files")
             return 1
 
-    # If all files exist and not forcing, exit
+    # If all source files exist and not forcing, skip download but ensure the
+    # parquet outputs exist (convert only if missing — the CSV read is ~1.1 GB).
     if not missing and not args.force:
-        print("\n[OK] All files already downloaded!")
+        print("\n[OK] All source files already downloaded!")
         print("  Use --force to re-download")
-        return 0
+        all_parquet = (
+            data_dir / "equities" / "firm_characteristics" / "firm_characteristics_all.parquet"
+        )
+        if all_parquet.exists():
+            return 0
+        return 0 if convert_to_parquet(data_dir) else 1
 
     # Try automatic download
     print("\nAttempting automatic download...")
@@ -290,10 +302,11 @@ def main():
 
     # Method 1: Download entire folder (more reliable than single-file IDs)
     print(f"Downloading from Google Drive folder: {GDRIVE_FOLDER_URL}")
+    print("  ~1.5 GB across 4 files (RetChar.csv ~1.1 GB) — per-file progress below.")
     try:
-        gdown.download_folder(
-            GDRIVE_FOLDER_URL, output=str(academic_dir), quiet=False, remaining_ok=True
-        )
+        # NOTE: no remaining_ok kwarg — it was removed in gdown 6.x and passing it
+        # raises TypeError, which silently aborts the (working) folder download.
+        gdown.download_folder(GDRIVE_FOLDER_URL, output=str(academic_dir), quiet=False)
     except Exception as e:
         print(f"Folder download failed: {e}")
 
@@ -313,11 +326,11 @@ def main():
     print("\nDownloading additional academic data files...")
     download_additional_files(academic_dir)
 
-    # Verify
+    # Verify, then convert RetChar.csv -> parquet splits
     found, missing = verify_files(academic_dir)
     if not missing:
         print("\n[OK] Download and extraction complete!")
-        return 0
+        return 0 if convert_to_parquet(data_dir) else 1
 
     # Method 2: Fall back to single-file download
     print("\nFolder download incomplete, trying single-file download...")
@@ -329,7 +342,7 @@ def main():
         if not missing:
             print("\n[OK] Download and extraction complete!")
             zip_path.unlink(missing_ok=True)
-            return 0
+            return 0 if convert_to_parquet(data_dir) else 1
 
     print(f"\nWARNING: {len(missing)} files still missing after download attempts")
     print_manual_instructions(academic_dir)

--- a/data/etfs/market/download.py
+++ b/data/etfs/market/download.py
@@ -58,14 +58,15 @@ def main() -> None:
     from ml4t.data.etfs import ETFDataManager
 
     data_root = resolve_data_dir(args.data_path)
-    manager = ETFDataManager.from_config(args.config)
+    config_path = args.config.expanduser()  # honor --config ~/... like other helpers
+    manager = ETFDataManager.from_config(config_path)
     # ETFDataManager.from_config() absolutizes storage_path against the repo
     # directory, which ignores ML4T_DATA_PATH; passing that absolute path back
     # through resolve_storage_path is a no-op (it preserves absolute paths). Read
     # the raw (relative) config value and re-resolve under the selected data root
     # so ETF data lands alongside every other dataset — $ML4T_DATA_PATH/etfs/market
     # — the same pattern the crypto/fx downloaders use.
-    with open(args.config) as config_file:
+    with open(config_path) as config_file:
         configured_storage = (yaml.safe_load(config_file) or {}).get("etfs", {}).get("storage_path")
     manager.config.storage_path = resolve_storage_path(data_root, configured_storage, "etfs")
 

--- a/data/etfs/market/download.py
+++ b/data/etfs/market/download.py
@@ -8,11 +8,11 @@ from datetime import date
 from pathlib import Path
 
 import polars as pl
-import yaml
 
 from utils.downloading import (
     create_base_parser,
     load_dotenv,
+    load_section,
     print_download_summary,
     print_dry_run_notice,
     print_section,
@@ -66,8 +66,7 @@ def main() -> None:
     # the raw (relative) config value and re-resolve under the selected data root
     # so ETF data lands alongside every other dataset — $ML4T_DATA_PATH/etfs/market
     # — the same pattern the crypto/fx downloaders use.
-    with open(config_path) as config_file:
-        configured_storage = (yaml.safe_load(config_file) or {}).get("etfs", {}).get("storage_path")
+    configured_storage = load_section(config_path, "etfs").get("storage_path")
     manager.config.storage_path = resolve_storage_path(data_root, configured_storage, "etfs")
 
     if args.symbol:

--- a/data/etfs/market/download.py
+++ b/data/etfs/market/download.py
@@ -8,6 +8,7 @@ from datetime import date
 from pathlib import Path
 
 import polars as pl
+import yaml
 
 from utils.downloading import (
     create_base_parser,
@@ -58,9 +59,15 @@ def main() -> None:
 
     data_root = resolve_data_dir(args.data_path)
     manager = ETFDataManager.from_config(args.config)
-    manager.config.storage_path = resolve_storage_path(
-        data_root, str(manager.config.storage_path), "etfs"
-    )
+    # ETFDataManager.from_config() absolutizes storage_path against the repo
+    # directory, which ignores ML4T_DATA_PATH; passing that absolute path back
+    # through resolve_storage_path is a no-op (it preserves absolute paths). Read
+    # the raw (relative) config value and re-resolve under the selected data root
+    # so ETF data lands alongside every other dataset — $ML4T_DATA_PATH/etfs/market
+    # — the same pattern the crypto/fx downloaders use.
+    with open(args.config) as config_file:
+        configured_storage = (yaml.safe_load(config_file) or {}).get("etfs", {}).get("storage_path")
+    manager.config.storage_path = resolve_storage_path(data_root, configured_storage, "etfs")
 
     if args.symbol:
         manager.config.tickers = {

--- a/data/prediction_markets/download.py
+++ b/data/prediction_markets/download.py
@@ -521,6 +521,16 @@ def main() -> None:
     atomic_write_parquet(metadata_df, metadata_path)
     summary["metadata_file"] = str(metadata_path)
 
+    # Kalshi (CFTC-regulated) and Polymarket restrict access by jurisdiction, so
+    # "list markets" can fail at the network layer from some regions even though
+    # the endpoints are up. This dataset is optional; note it rather than failing.
+    if summary.get("kalshi") == "no data" and summary.get("polymarket") == "no data":
+        print(
+            "\nNote: no prediction-market data was retrieved. Kalshi and Polymarket "
+            "geo-restrict API access, so this can happen outside their supported "
+            "regions. It is optional and does not affect the core datasets."
+        )
+
     print_download_summary(summary)
 
 

--- a/data/prediction_markets/download.py
+++ b/data/prediction_markets/download.py
@@ -524,7 +524,12 @@ def main() -> None:
     # Kalshi (CFTC-regulated) and Polymarket restrict access by jurisdiction, so
     # "list markets" can fail at the network layer from some regions even though
     # the endpoints are up. This dataset is optional; note it rather than failing.
-    if summary.get("kalshi") == "no data" and summary.get("polymarket") == "no data":
+    # Fire the note whenever nothing was retrieved from the providers actually
+    # attempted (success sets *_rows; a bare "kalshi"/"polymarket" key means that
+    # provider was tried and returned no data), covering the single-provider case.
+    retrieved_any = "kalshi_rows" in summary or "polymarket_rows" in summary
+    no_data_reported = summary.get("kalshi") == "no data" or summary.get("polymarket") == "no data"
+    if no_data_reported and not retrieved_any:
         print(
             "\nNote: no prediction-market data was retrieved. Kalshi and Polymarket "
             "geo-restrict API access, so this can happen outside their supported "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ x-common: &common
   user: "${UID:-1000}:${GID:-1000}"
   volumes:
     - .:/app:rw
-    - ${ML4T_DATA_PATH:-./data}:/data:ro
+    # Read-write so the in-container download workflow (data/download_all.py)
+    # can populate /data. ML4T_DATA_PATH=/data below points every downloader
+    # here; a read-only mount makes each write fail with "Read-only file system".
+    - ${ML4T_DATA_PATH:-./data}:/data:rw
   environment:
     - ML4T_DATA_PATH=/data
     - ML4T_PATH=/app


### PR DESCRIPTION
Fixes #361 — `data/download_all.py --free-only` inside the `ml4t` Docker container failed for most datasets, and the firm-characteristics dataset never downloaded anywhere. All causes are fixed here; the full free-data flow now works end-to-end.

## Root causes

**1. `/data` mounted read-only (the dominant one).** `docker-compose.yml` mounts the data volume `:ro`, but `ML4T_DATA_PATH=/data` tells every downloader to *write* there. So Crypto, CFTC COT, Fama-French, AQR, and Firm Characteristics all died with:

```
OSError: Read-only file system (os error 30): /data/...
```

Fix: mount `/data` read-write. ETF was the only dataset that "passed" — because it happened to write to `/app/data` (the read-write app mount), see #2.

**2. ETF downloader wrote to the wrong directory.** `ETFDataManager.from_config()` absolutizes `storage_path` against the repo dir, and feeding that absolute path back through `resolve_storage_path` is a no-op — so ETF data landed in `<repo>/data/etfs/market` instead of `$ML4T_DATA_PATH/etfs/market`, where the notebooks look for it. Fix: re-resolve from the raw config value under the selected data root, matching the crypto/fx downloaders.

**3. Prediction markets (Kalshi/Polymarket) — geo-restriction, not a bug.** Both endpoints return HTTP 200 from a supported region; they geo-restrict API access (Kalshi is CFTC-regulated), so `list markets` can fail at the network layer elsewhere. The *traceback* in the report was the same read-only write (fixed by #1); the API calls are already handled gracefully. Added a note that this optional dataset can be skipped.

**4. Firm characteristics never downloaded — three separate bugs.** The Chen-Pelger-Zhu academic dataset (~1.5 GB, hosted on the authors' Google Drive) failed for everyone, not just in Docker. It was *not* a Drive access restriction — the folder downloads fine:

- `gdown.download_folder(...)` was passed `remaining_ok=True`, a kwarg **removed in gdown 6.x**. The call raised `TypeError`, the surrounding `except` swallowed it, and the *working* folder download was abandoned in favor of a single-file fallback whose public link genuinely can't be retrieved — producing the misleading "Gdown can't … check connections and permissions" error. Removing the kwarg lets the full folder (incl. the 1.1 GB `RetChar.csv`) download, with gdown auto-applying the large-file confirm token.
- `extract_zip` only stripped a leading `data/` wrapper, but `datasets.zip` wraps its contents in `datasets/` and ships `__MACOSX` cruft — so the npz arrays landed under `dl_asset_pricing/datasets/…` while `verify_files` expected `dl_asset_pricing/…`, making a successful download look "incomplete." Now strips `data`/`datasets` and skips `__MACOSX`/`.DS_Store`.
- `download_all.py` invoked the script with `--convert` only, which short-circuits straight to conversion and never downloads (`RetChar.csv not found`). `download.py` now converts automatically after a successful download; `download_all.py` calls it plainly.

It stays part of the core free flow, but with an upfront ~1.5 GB heads-up, per-file download progress, and a `--skip-firm-characteristics` opt-out. Documented download times are worded as indicative/bandwidth-dependent.

## Verification

- **Firm characteristics validated end-to-end:** 1.5 GB folder download, correct extraction (11/11 expected files at their expected paths), CSV → parquet conversion (1,218,555 rows across train/test/all), and `load_firm_characteristics()` reads all splits.
- ETF path resolution unit-checked: now resolves to `$ML4T_DATA_PATH/etfs/market` (was `<repo>/etfs/market`).
- In-container `--free-only` run: read-only errors gone; ETF writes to `/data/etfs/market`.
- `docker compose config` valid; YAML + `py_compile` pass; pre-commit green.
- Kalshi/Polymarket endpoints confirmed returning HTTP 200 (issue is regional access).