### PR TITLE
test(data): fast download-logic unit suite + native CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,6 +310,41 @@ jobs:
         run: uvx ruff@0.15.8 format --check utils/ data/ tests/
 
   # ---------------------------------------------------------------------------
+  # Fast native unit tests — download-script logic (no Docker, no network,
+  # no test-data, no secrets). Seconds per PR.
+  #
+  # Notebook tests run against pre-seeded data, so the data/**/download.py code
+  # path is invisible to them — this is how the in-container free-data download
+  # bug (#361) reached readers. These tests exercise that logic directly:
+  # path resolution / output placement, download_all dispatch modes, the
+  # firm-characteristics archive flatten, and download-script registry drift.
+  # ---------------------------------------------------------------------------
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Install minimal test deps
+        # Just the import surface of the download-logic tests (utils/downloading
+        # + data/download_all + firm-char extract_zip). Intentionally NOT the
+        # full project env (no torch/ml4t-*) so this stays a fast per-commit gate.
+        run: |
+          uv venv --python 3.14
+          uv pip install pytest polars pyyaml python-dotenv plotly
+      - name: Run download-logic unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_download_helpers.py \
+            tests/test_firm_characteristics_extract.py \
+            tests/test_download_all_dispatch.py \
+            tests/test_download_scripts_registry.py \
+            -v --tb=short
+
+  # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)
   #
   # Runs the same Python 3.14 environment that readers use.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,6 +337,11 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
+          # utils.config validates that ML4T_DATA_PATH exists at import time.
+          # Point it at the repo's own data/ dir — these tests need no test-data,
+          # only that the import succeeds.
+          printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
           .venv/bin/python -m pytest \
             tests/test_download_helpers.py \
             tests/test_firm_characteristics_extract.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,10 +336,13 @@ jobs:
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}
+          # Override the workflow-level test-data path: this job checks out no
+          # test-data. utils.config validates ML4T_DATA_PATH exists at import and
+          # reads the env var ahead of .env, so point both at the repo's own dirs.
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
         run: |
-          # utils.config validates that ML4T_DATA_PATH exists at import time.
-          # Point it at the repo's own data/ dir — these tests need no test-data,
-          # only that the import succeeds.
+          # utils.config also requires a .env file to exist; create a minimal one.
           printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
             "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
           .venv/bin/python -m pytest \

--- a/tests/test_download_all_dispatch.py
+++ b/tests/test_download_all_dispatch.py
@@ -1,0 +1,101 @@
+"""Dispatch-logic tests for ``data/download_all.py``.
+
+These run the real ``main()`` control flow with the network boundary
+(``run_download_script``, which shells out to each downloader) replaced by a
+recorder. No subprocesses, no network. They pin which datasets each mode
+dispatches — the layer that silently broke in the #361 fixes:
+
+- ``--free-only`` must skip the API-key datasets (macro/FX) but keep the core +
+  factor + firm-char downloads;
+- ``--skip-firm-characteristics`` must omit the 1.5 GB academic pull;
+- firm characteristics must be invoked *plainly* (no ``--convert``, which used
+  to run a conversion over data that had never been downloaded);
+- every dispatched script must carry the selected ``--data-path``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import data.download_all as da
+
+
+@pytest.fixture
+def recorder(monkeypatch, tmp_path):
+    """Replace run_download_script with a call recorder; neutralise dotenv."""
+    calls: list[tuple[str, list]] = []
+
+    def _record(script_name, extra_args=None):
+        calls.append((script_name, list(extra_args or [])))
+        return True
+
+    monkeypatch.setattr(da, "run_download_script", _record)
+    monkeypatch.setattr(da, "load_dotenv", lambda *a, **k: None)
+    return calls
+
+
+def _run(monkeypatch, tmp_path, *cli):
+    monkeypatch.setattr(sys, "argv", ["download_all.py", "--data-path", str(tmp_path), *cli])
+    da.main()
+
+
+def _names(calls):
+    return {name for name, _ in calls}
+
+
+def test_free_only_dispatches_core_and_factors(recorder, monkeypatch, tmp_path):
+    _run(monkeypatch, tmp_path, "--free-only")
+    names = _names(recorder)
+    # core case-study datasets + free factors + firm characteristics
+    assert {
+        "etfs.py",
+        "crypto.py",
+        "prediction_markets.py",
+        "cot.py",
+        "ff_factors.py",
+        "aqr_factors.py",
+        "firm_characteristics.py",
+    } <= names
+    # API-key / paid / large datasets must NOT be dispatched in free-only mode
+    assert "macro.py" not in names
+    assert "fx_pairs.py" not in names
+    assert "us_equities.py" not in names
+
+
+def test_skip_firm_characteristics(recorder, monkeypatch, tmp_path):
+    _run(monkeypatch, tmp_path, "--free-only", "--skip-firm-characteristics")
+    assert "firm_characteristics.py" not in _names(recorder)
+    # the rest of the free tier still runs
+    assert "etfs.py" in _names(recorder)
+
+
+def test_firm_characteristics_invoked_without_convert(recorder, monkeypatch, tmp_path):
+    """firm-char must download plainly — never with ``--convert`` alone."""
+    _run(monkeypatch, tmp_path, "--free-only")
+    fc = [args for name, args in recorder if name == "firm_characteristics.py"]
+    assert len(fc) == 1
+    assert "--convert" not in fc[0]
+    assert "--data-path" in fc[0]
+
+
+def test_core_mode_adds_api_key_datasets(recorder, monkeypatch, tmp_path):
+    """Default (core) mode also dispatches the free-API-key datasets."""
+    _run(monkeypatch, tmp_path)  # no --free-only
+    names = _names(recorder)
+    assert "macro.py" in names
+    assert "fx_pairs.py" in names
+    # but still not the --all-only historical equities pull
+    assert "us_equities.py" not in names
+
+
+def test_every_dispatch_carries_selected_data_path(recorder, monkeypatch, tmp_path):
+    """No dispatched script may be left to guess the data root."""
+    _run(monkeypatch, tmp_path, "--free-only")
+    for name, args in recorder:
+        assert str(tmp_path) in args, f"{name} did not receive the data path: {args}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_download_helpers.py
+++ b/tests/test_download_helpers.py
@@ -1,0 +1,170 @@
+"""Unit tests for the shared download plumbing in ``utils/downloading.py``.
+
+These are fast, deterministic, and network-free. They pin the *contracts* that
+every ``data/**/download.py`` script relies on for path resolution and output
+placement — the layer where the #361-class bugs lived:
+
+- a downloader must write under the *selected* data root (``--data-path`` /
+  ``ML4T_DATA_PATH``), never blindly under ``<repo>/data`` (the read-only /
+  wrong-dir bug);
+- ``~`` in a ``--config`` / ``--data-path`` must expand (the Copilot review bug);
+- ``atomic_write_parquet`` must land a complete file and leave no ``.tmp`` behind.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from utils.downloading import (
+    atomic_write_parquet,
+    create_base_parser,
+    flatten_group_values,
+    load_section,
+    resolve_data_dir,
+    resolve_storage_path,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_data_dir — precedence + expansion
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_data_dir_cli_arg_wins_over_env(tmp_path, monkeypatch):
+    """An explicit ``--data-path`` must win over ``ML4T_DATA_PATH``.
+
+    This is the contract that keeps a downloader writing where the reader
+    asked — the mechanism behind the #361 read-only-mount fix.
+    """
+    cli = tmp_path / "cli_root"
+    monkeypatch.setenv("ML4T_DATA_PATH", str(tmp_path / "env_root"))
+    resolved = resolve_data_dir(cli)
+    assert resolved == cli.resolve()
+
+
+def test_resolve_data_dir_expands_user(monkeypatch, tmp_path):
+    """A ``~``-prefixed CLI path is expanded, not taken literally."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    resolved = resolve_data_dir(Path("~/some_data"))
+    assert resolved == (tmp_path / "some_data").resolve()
+    assert "~" not in str(resolved)
+
+
+# ---------------------------------------------------------------------------
+# resolve_storage_path — the exact mechanism behind the ETF wrong-dir bug
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_storage_path_relative_joins_data_root(tmp_path):
+    """A relative configured path is joined under the selected data root."""
+    root = tmp_path / "data_root"
+    resolved = resolve_storage_path(root, "etfs/market", "etfs")
+    assert resolved == root / "etfs/market"
+
+
+def test_resolve_storage_path_absolute_is_preserved(tmp_path):
+    """An absolute configured path is preserved (not re-rooted)."""
+    absolute = tmp_path / "elsewhere" / "etfs"
+    resolved = resolve_storage_path(tmp_path / "data_root", str(absolute), "etfs")
+    assert resolved == absolute
+
+
+def test_resolve_storage_path_falls_back_when_unconfigured(tmp_path):
+    """With no configured path, the fallback is used under the data root."""
+    root = tmp_path / "data_root"
+    assert resolve_storage_path(root, None, "etfs") == root / "etfs"
+
+
+def test_resolve_storage_path_expands_user(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    resolved = resolve_storage_path(tmp_path / "data_root", "~/abs_etfs", "etfs")
+    assert resolved == (tmp_path / "abs_etfs")
+
+
+# ---------------------------------------------------------------------------
+# load_section — YAML section reader used by the ETF/crypto/fx downloaders
+# ---------------------------------------------------------------------------
+
+
+def test_load_section_reads_named_section(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("etfs:\n  storage_path: etfs/market\n  start: '2010-01-01'\n")
+    section = load_section(cfg, "etfs")
+    assert section == {"storage_path": "etfs/market", "start": "2010-01-01"}
+
+
+def test_load_section_missing_section_returns_empty(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("etfs:\n  storage_path: etfs/market\n")
+    assert load_section(cfg, "nonexistent") == {}
+
+
+def test_load_section_expands_user(tmp_path, monkeypatch):
+    """``load_section`` must honour ``~`` so ``--config ~/foo.yaml`` works."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("etfs:\n  storage_path: etfs/market\n")
+    section = load_section("~/config.yaml", "etfs")
+    assert section == {"storage_path": "etfs/market"}
+
+
+# ---------------------------------------------------------------------------
+# flatten_group_values — grouped symbols/pairs flattening
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_group_values_dedups_and_preserves_order():
+    groups = {
+        "large_cap": {"symbols": ["SPY", "QQQ", "SPY"]},
+        "bonds": {"symbols": ["TLT", "QQQ"]},
+        "not_a_dict": ["ignored"],
+    }
+    assert flatten_group_values(groups, "symbols") == ["SPY", "QQQ", "TLT"]
+
+
+def test_flatten_group_values_empty():
+    assert flatten_group_values({}, "symbols") == []
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_parquet — complete write, no temp residue
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_parquet_writes_and_roundtrips(tmp_path):
+    df = pl.DataFrame({"symbol": ["AAA", "BBB"], "timestamp": [1, 2]})
+    out = tmp_path / "nested" / "dir" / "data.parquet"
+    atomic_write_parquet(df, out)
+
+    assert out.exists()  # parent dirs created
+    assert pl.read_parquet(out).equals(df)
+    # no leftover temp file
+    assert not (out.parent / f".{out.name}.tmp").exists()
+    assert list(out.parent.glob(".*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# create_base_parser — the standard download CLI flags
+# ---------------------------------------------------------------------------
+
+
+def test_create_base_parser_has_standard_flags(tmp_path):
+    parser = create_base_parser("test")
+    args = parser.parse_args(["--data-path", str(tmp_path), "--dry-run", "--force", "--verbose"])
+    assert args.data_path == tmp_path
+    assert args.dry_run is True
+    assert args.force is True
+    assert args.verbose is True
+
+
+def test_create_base_parser_defaults(tmp_path):
+    parser = create_base_parser("test")
+    args = parser.parse_args([])
+    assert args.data_path is None
+    assert args.dry_run is False
+    assert args.force is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_download_scripts_registry.py
+++ b/tests/test_download_scripts_registry.py
@@ -1,0 +1,66 @@
+"""Coverage-ratchet tests for the download-script registry.
+
+``download_all.py`` dispatches by shelling out to the paths in
+``DOWNLOAD_SCRIPTS``. If a downloader is renamed or moved without updating the
+map, dispatch silently degrades to "Script not found" at runtime — invisible to
+CI until a reader hits it. These tests keep the map and the on-disk scripts in
+lock-step, in both directions, and fail when a *new* ``download.py`` is added
+without wiring it in (so coverage can't rot as later beats ship more datasets).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import data.download_all as da
+
+DATA_DIR = Path(da.__file__).parent
+
+
+def _discovered_download_scripts() -> set[str]:
+    """All download scripts on disk, as paths relative to ``data/``."""
+    found = set(DATA_DIR.glob("**/download.py")) | set(DATA_DIR.glob("**/*_download.py"))
+    return {str(p.relative_to(DATA_DIR)) for p in found}
+
+
+@pytest.mark.parametrize("script_name,relative_path", sorted(da.DOWNLOAD_SCRIPTS.items()))
+def test_registered_script_exists(script_name, relative_path):
+    """Every entry in DOWNLOAD_SCRIPTS resolves to a real file."""
+    assert (DATA_DIR / relative_path).is_file(), (
+        f"DOWNLOAD_SCRIPTS['{script_name}'] -> {relative_path} does not exist; "
+        "a downloader was renamed/moved without updating download_all.py"
+    )
+
+
+def test_every_download_script_is_registered():
+    """Coverage ratchet: no download script may be orphaned from the registry."""
+    registered = set(da.DOWNLOAD_SCRIPTS.values())
+    discovered = _discovered_download_scripts()
+    unregistered = discovered - registered
+    assert not unregistered, (
+        f"download scripts present on disk but missing from DOWNLOAD_SCRIPTS: "
+        f"{sorted(unregistered)} — wire them into download_all.py (or rename)."
+    )
+
+
+def test_free_tier_scripts_present():
+    """The free datasets a reader gets with `download_all.py --free-only` all ship."""
+    free_tier = [
+        "etfs/market/download.py",
+        "crypto/market/download.py",
+        "prediction_markets/download.py",
+        "futures/positioning/cot_download.py",
+        "factors/ff_download.py",
+        "factors/aqr_download.py",
+        "equities/firm_characteristics/download.py",
+        "macro/download.py",
+        "fx/market/download.py",
+    ]
+    missing = [p for p in free_tier if not (DATA_DIR / p).is_file()]
+    assert not missing, f"free-tier download scripts missing: {missing}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_firm_characteristics_extract.py
+++ b/tests/test_firm_characteristics_extract.py
@@ -1,0 +1,115 @@
+"""Unit tests for the firm-characteristics archive handling.
+
+``extract_zip`` flattens the published Chen-Pelger-Zhu archives, which wrap
+their contents in a single top-level ``data/`` or ``datasets/`` directory and
+(when zipped on macOS) ship ``__MACOSX`` resource forks + ``.DS_Store`` files.
+A mismatch here silently lands the ``.npz`` files at the wrong depth, which
+``verify_files`` then reports as "missing" — exactly the bug fixed in the
+firm-char end-to-end repair. These synthetic-zip tests lock the flatten rule
+without pulling the real ~1.5 GB dataset.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from data.equities.firm_characteristics.download import EXPECTED_FILES, extract_zip
+
+
+def _make_zip(zip_path: Path, entries: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for arcname, content in entries.items():
+            zf.writestr(arcname, content)
+
+
+def test_extract_zip_strips_datasets_wrapper(tmp_path):
+    """A ``datasets/`` wrapper is stripped so files land directly under the dir."""
+    zip_path = tmp_path / "datasets.zip"
+    _make_zip(
+        zip_path,
+        {
+            "datasets/RetChar.csv": b"Date,RET\n20000101,0.01\n",
+            "datasets/char/Char_train.npz": b"fake-npz",
+            "datasets/macro/macro_test.npz": b"fake-npz",
+        },
+    )
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    assert extract_zip(zip_path, extract_dir) is True
+    assert (extract_dir / "RetChar.csv").exists()
+    assert (extract_dir / "char" / "Char_train.npz").exists()
+    assert (extract_dir / "macro" / "macro_test.npz").exists()
+    # wrapper directory itself must NOT survive
+    assert not (extract_dir / "datasets").exists()
+
+
+def test_extract_zip_strips_data_wrapper(tmp_path):
+    """The alternate ``data/`` wrapper is stripped identically."""
+    zip_path = tmp_path / "data.zip"
+    _make_zip(zip_path, {"data/char/Char_valid.npz": b"x"})
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    assert extract_zip(zip_path, extract_dir) is True
+    assert (extract_dir / "char" / "Char_valid.npz").exists()
+    assert not (extract_dir / "data").exists()
+
+
+def test_extract_zip_skips_macos_cruft(tmp_path):
+    """``__MACOSX`` resource forks and ``.DS_Store`` files are dropped."""
+    zip_path = tmp_path / "datasets.zip"
+    _make_zip(
+        zip_path,
+        {
+            "datasets/RetChar.csv": b"data",
+            "datasets/.DS_Store": b"junk",
+            "__MACOSX/datasets/._RetChar.csv": b"resource-fork",
+        },
+    )
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    assert extract_zip(zip_path, extract_dir) is True
+    assert (extract_dir / "RetChar.csv").exists()
+    assert not (extract_dir / ".DS_Store").exists()
+    assert not (extract_dir / "__MACOSX").exists()
+    # the resource-fork file must not have leaked in under any name
+    assert not any(p.name == "._RetChar.csv" for p in extract_dir.rglob("*"))
+
+
+def test_extract_zip_cleans_temp_dir(tmp_path):
+    """The intermediate ``_temp_extract`` scratch dir is removed."""
+    zip_path = tmp_path / "datasets.zip"
+    _make_zip(zip_path, {"datasets/RetChar.csv": b"data"})
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    extract_zip(zip_path, extract_dir)
+    assert not (extract_dir / "_temp_extract").exists()
+
+
+def test_extract_zip_returns_false_on_bad_archive(tmp_path):
+    """A corrupt archive fails gracefully (returns False, no raise)."""
+    bad = tmp_path / "broken.zip"
+    bad.write_bytes(b"not a real zip")
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+    assert extract_zip(bad, extract_dir) is False
+
+
+def test_expected_files_manifest_is_sane():
+    """The published dataset ships 11 files across RetChar/Macro/char/macro/RF."""
+    assert len(EXPECTED_FILES) == 11
+    assert "RetChar.csv" in EXPECTED_FILES
+    assert all(size > 0 for size in EXPECTED_FILES.values())
+    # the three split families each contribute a train/valid/test triple
+    for prefix in ("char/", "macro/", "RF/"):
+        assert sum(1 for k in EXPECTED_FILES if k.startswith(prefix)) == 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Adds the first layer of the public-repo download-test coverage plan: a fast,
deterministic, **network-free** unit suite for the `data/**/download.py` logic,
plus a native `test-unit` CI job that runs it on every PR.

## Why

Notebook CI runs against **pre-seeded** test data, so no test ever executes a
`data/**/download.py` script. That is the systemic gap that let the in-container
free-data download bug (#361) reach readers — and every bug fixed in #362 was
invisible to CI. This suite exercises the download logic directly.

## Coverage — 48 tests

| File | Locks |
|------|-------|
| `test_download_helpers.py` | `resolve_data_dir` precedence (`--data-path` > `ML4T_DATA_PATH`) + `~` expansion; `resolve_storage_path` (the ETF wrong-dir mechanism); `load_section` `~` expansion; `flatten_group_values`; `atomic_write_parquet` (complete write, no `.tmp` residue); `create_base_parser` flags |
| `test_firm_characteristics_extract.py` | `extract_zip` flattens `data/`/`datasets/` wrappers and drops `__MACOSX`/`.DS_Store` on synthetic zips — the flatten-mismatch bug, **without the 1.5 GB pull** |
| `test_download_all_dispatch.py` | `download_all.main()` dispatch: `--free-only` skips API-key datasets, `--skip-firm-characteristics` honored, firm-char invoked **without `--convert`**, every script carries the selected `--data-path` |
| `test_download_scripts_registry.py` | every `DOWNLOAD_SCRIPTS` entry resolves to a real file; every on-disk `download.py` is registered (coverage ratchet — fails when a new dataset is added unwired) |

These would have caught **four of the five** bugs fixed in #362.

## CI

New `test-unit` job: native (no Docker), installs only the import surface
(`pytest polars pyyaml python-dotenv plotly` — no torch/ml4t-*), no test-data,
no secrets. Runs in seconds on every PR. Mutation-checked locally: reintroducing
the `--convert` regression and an unregistered download script both fail the
suite.

## Scope

This is **Phase 1** of `work/2026-07-06-public-test-suite/PLAN.md` (highest ROI,
regression-locks the #362 fixes). Phases 2–4 (container first-contact smoke,
live external drift with auto-issues, un-skipping fixture-gated weekly notebooks)
follow separately.
