### PR TITLE
test(data): download-suite Phases 2-4 — container smoke, drift detector, coverage ratchet

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,0 +1,100 @@
+# ML4T 3rd Edition — Container first-contact smoke (Phase 2b)
+#
+# Runs the reader's ACTUAL first command through docker compose, in the reader's
+# real image, and proves the free-data download can write to /data. This is the
+# only layer that catches compose/mount/env regressions like #361 (the `/data`
+# read-only mount) — a unit test can't, because it never composes the container.
+#
+# Cost control: the ml4t image is ~12 GB, so per-PR we run this ONLY when the
+# compose/env surface changes (docker-compose.yml, envs/**). The download-script
+# *logic* is covered deterministically by the native `test-unit` job on every PR
+# (tests/test_download_helpers.py et al.) and the static mount contract by
+# tests/test_compose_mounts.py — neither needs the image. The weekly run exercises
+# the full path regardless and files an issue if the reader's first contact breaks.
+
+name: Container Smoke
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Monday 06:00 UTC
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker-compose.yml'
+      - 'envs/**'
+      - '.github/workflows/container-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  container-smoke:
+    name: container-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: First-contact download in the composed container
+        id: smoke
+        env:
+          # Point the compose data mount at a workspace dir we own, so we can
+          # assert the downloaded files actually land on the host side of the
+          # bind mount (proves the mount is writable AND correctly wired).
+          ML4T_DATA_PATH: ${{ github.workspace }}/_smoke_data
+        run: |
+          set -o pipefail
+          mkdir -p "$ML4T_DATA_PATH"
+
+          # The reader's real first command, scoped to a single symbol so the
+          # pull is tiny. --user root mirrors the documented in-container
+          # download invocation and still fails hard on a read-only mount (even
+          # root cannot write to a `:ro` bind), so this catches the #361 class.
+          docker compose run --rm --user root ml4t \
+            python data/etfs/market/download.py --symbol SPY 2>&1 | tee smoke.log
+
+          echo "----- assertions -----"
+          # 1. No read-only-mount failure (the #361 signature).
+          if grep -qi "Read-only file system" smoke.log; then
+            echo "FAIL: container hit a read-only /data mount (#361 regression)"
+            exit 1
+          fi
+          # 2. The download actually populated the host side of the /data mount.
+          out="$ML4T_DATA_PATH/etfs/market/etf_universe.parquet"
+          if [ ! -f "$out" ]; then
+            echo "FAIL: expected $out on the host mount, but it is missing"
+            echo "Contents of $ML4T_DATA_PATH:"
+            find "$ML4T_DATA_PATH" -maxdepth 3 -print || true
+            exit 1
+          fi
+          echo "OK: $out present ($(du -h "$out" | cut -f1)) — /data mount is writable and wired"
+
+      - name: Open issue on weekly failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = 'container-smoke: first-contact download failed';
+            const q = `repo:${owner}/${repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q });
+            if (existing.data.total_count > 0) {
+              const num = existing.data.items[0].number;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: num,
+                body: `Failed again in the weekly container smoke: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo, title,
+                body: `The weekly container first-contact smoke failed.\n\n` +
+                      `The reader's \`docker compose run … data/etfs/market/download.py --symbol SPY\` ` +
+                      `did not populate \`/data\` in the composed \`ml4t\` container.\n\n` +
+                      `This is the #361 class (compose mount / env wiring). Run: ${runUrl}`,
+                labels: ['weekly-flake'],
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,7 +317,11 @@ jobs:
   # path is invisible to them — this is how the in-container free-data download
   # bug (#361) reached readers. These tests exercise that logic directly:
   # path resolution / output placement, download_all dispatch modes, the
-  # firm-characteristics archive flatten, and download-script registry drift.
+  # firm-characteristics archive flatten, download-script registry drift, the
+  # compose /data-mount contract (static regression-lock for #361), and the
+  # drift-coverage ratchet (every free dataset keeps a live external smoke).
+  # The networked container smoke (Phase 2b) and live drift pulls (Phase 3) run
+  # in container-smoke.yml / weekly-external.yml, not here.
   # ---------------------------------------------------------------------------
   test-unit:
     runs-on: ubuntu-latest
@@ -350,6 +354,8 @@ jobs:
             tests/test_firm_characteristics_extract.py \
             tests/test_download_all_dispatch.py \
             tests/test_download_scripts_registry.py \
+            tests/test_compose_mounts.py \
+            tests/test_download_coverage.py \
             -v --tb=short
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/weekly-external.yml
+++ b/.github/workflows/weekly-external.yml
@@ -172,3 +172,125 @@ jobs:
         run: |
           echo "Weekly pytest exited with code ${{ steps.pytest_chapters.outputs.exit_code }}"
           exit 1
+
+  # ---------------------------------------------------------------------------
+  # Phase 3 — live external drift smoke.
+  #
+  # One tiny REAL pull per free data source (tests/test_external_drift.py, marked
+  # `drift`). Catches upstream provider/schema drift: when a source moves,
+  # renames a file, or changes its payload shape, the matching test fails and we
+  # file a deduped issue. No billed APIs — key-gated sources (FRED, OANDA) skip
+  # when their free key is absent; geo-restricted sources (Kalshi/Polymarket)
+  # skip when blocked. Flake-tolerant via pytest-rerunfailures when available.
+  # ---------------------------------------------------------------------------
+  weekly-drift:
+    name: weekly-drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ml4t/ml4t:latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Install git
+        run: apt-get update -qq && apt-get install -y -qq git >/dev/null
+
+      - uses: actions/checkout@v6
+
+      - name: Run external drift smoke
+        id: pytest_drift
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          # NO-SPEND POLICY: only FREE keys. Billed APIs stay unset → their
+          # drift tests skip rather than charge.
+          FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+          EDGAR_IDENTITY: ${{ secrets.EDGAR_IDENTITY }}
+        run: |
+          set +e
+          # utils.config requires a .env file to exist; create a minimal one and
+          # point the data path at the repo's own data/ dir (no test-data here).
+          printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
+          # Flake tolerance only if pytest-rerunfailures is installed in the image.
+          RERUN_ARGS=""
+          if python -c "import pytest_rerunfailures" 2>/dev/null; then
+            RERUN_ARGS="--reruns 2 --reruns-delay 30"
+          fi
+          python -m pytest tests/test_external_drift.py -m drift \
+            -v --tb=short $RERUN_ARGS \
+            --junitxml=junit-drift.xml
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Upload junit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-drift
+          path: junit-drift.xml
+          retention-days: 30
+
+      - name: Open issues for drifted sources
+        if: always() && steps.pytest_drift.outputs.exit_code != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let xml;
+            try {
+              xml = fs.readFileSync('junit-drift.xml', 'utf8');
+            } catch (e) {
+              core.info('No junit-drift.xml found; nothing to file.');
+              return;
+            }
+
+            // Dependency-free junit parse: <testcase> blocks with a child
+            // <failure>/<error> are real drift (skips are not failures).
+            const testcaseRe = /<testcase\b[^>]*>([\s\S]*?)<\/testcase>|<testcase\b[^>]*\/>/g;
+            const attrRe = (name) => new RegExp(`${name}="([^"]*)"`);
+            const failures = [];
+            let m;
+            while ((m = testcaseRe.exec(xml)) !== null) {
+              const block = m[0];
+              const body = m[1] || '';
+              if (!/<failure\b|<error\b/.test(body)) continue;
+              const nameMatch = block.match(attrRe('name'));
+              if (nameMatch) failures.push(nameMatch[1]);
+            }
+            core.info(`Found ${failures.length} drifted source(s).`);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            for (const name of failures) {
+              // test_etf_yahoo_reachable -> etf_yahoo
+              const source = name.replace(/^test_/, '').replace(/_reachable$/, '');
+              const title = `external-drift: ${source}`;
+              const q = `repo:${owner}/${repo} is:issue is:open in:title "external-drift: ${source}"`;
+              const existing = await github.rest.search.issuesAndPullRequests({ q });
+              if (existing.data.total_count > 0) {
+                const num = existing.data.items[0].number;
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: num,
+                  body: `Drifted again in the weekly run: ${runUrl}`,
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner, repo, title,
+                  body: `The weekly external drift smoke failed for \`${name}\`.\n\n` +
+                        `An upstream free data source appears to have moved, renamed a ` +
+                        `file, or changed its payload schema.\n\n` +
+                        `Run: ${runUrl}\n\n` +
+                        `Dedupes by source — comments append on subsequent failures.`,
+                  labels: ['external-drift', 'weekly-flake'],
+                });
+              }
+            }
+
+      - name: Fail job if drift smoke failed
+        if: steps.pytest_drift.outputs.exit_code != '0'
+        run: |
+          echo "Drift smoke exited with code ${{ steps.pytest_drift.outputs.exit_code }}"
+          exit 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,6 +389,12 @@ def pytest_configure(config):
         "To execute locally, set ML4T_TEST_TIER=on_demand alongside `pytest -m on_demand`; "
         "without the env var, matching items are collected but skipped.",
     )
+    config.addinivalue_line(
+        "markers",
+        "drift: live external drift smoke (Phase 3) — one tiny real pull per free "
+        "data source. Network-bound; runs only in the scheduled weekly-external "
+        "workflow's `drift` job, never per-PR.",
+    )
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -34,14 +34,16 @@
 02_financial_data_universe/15_survivorship_bias_detection:
   timeout: 300
 02_financial_data_universe/16_provider_comparison:
-  skip: true
-  skip_reason: "YahooFinanceProvider.fetch_ohlcv() makes network calls \u2014 CI has no guaranteed internet"
+  # Live Yahoo Finance pulls. Runs in the weekly tier (GitHub runners have
+  # internet); flake-retried on transient network hiccups. Phase 3's drift smoke
+  # is the early-warning if Yahoo itself changes.
   tier: weekly
+  reruns: 2
   timeout: 300
 02_financial_data_universe/17_complete_pipeline:
-  skip: true
-  skip_reason: "YahooFinanceProvider.fetch_ohlcv() makes network calls \u2014 CI has no guaranteed internet"
+  # Live Yahoo Finance pulls. See 16_provider_comparison.
   tier: weekly
+  reruns: 2
   timeout: 300
 02_financial_data_universe/18_data_management:
   timeout: 300

--- a/tests/test_compose_mounts.py
+++ b/tests/test_compose_mounts.py
@@ -1,0 +1,117 @@
+"""Phase 2a — deterministic compose-mount contract (regression-lock for #361).
+
+The in-container free-data download bug (#361) was that ``docker-compose.yml``
+mounted the reader's data directory **read-only** (``:ro``), so every downloader
+failed with ``Read-only file system`` the moment it tried to write to
+``/data``. The functional container smoke (Phase 2b, ``container-smoke.yml``)
+catches that end-to-end, but a full 12 GB image pull is too heavy to run per PR.
+
+This test pins the exact compose contract behind that fix, statically, in
+milliseconds: the data volume is writable and ``ML4T_DATA_PATH`` points at the
+mount. No Docker, no network — just parse the compose file. If someone flips the
+mount back to ``:ro`` or repoints ``ML4T_DATA_PATH``, this fails on the PR that
+does it, not weeks later in a reader's terminal.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+# Services a reader actually runs the download workflow in. Benchmark/db-only
+# services don't mount /data for writes and are out of scope here.
+_WRITE_SERVICES = ("ml4t", "ml4t-gpu")
+
+
+def _load_compose() -> dict:
+    # SafeLoader resolves YAML anchors/aliases and ``<<`` merge keys, so each
+    # service dict already carries the merged ``x-common`` volumes/environment.
+    return yaml.safe_load(COMPOSE_FILE.read_text())
+
+
+# Container target ``/data`` with an optional trailing mode. Anchored at the end
+# so an interpolated source like ``${ML4T_DATA_PATH:-./data}`` — which itself
+# contains ``:`` — can't be mistaken for the target/mode.
+_DATA_MOUNT_RE = re.compile(r":(?P<target>/data)(?::(?P<mode>[a-zA-Z]+))?$")
+
+
+def _data_mounts(service: dict) -> list[tuple[str, str]]:
+    """``(volume_string, mode)`` for every mount whose container target is ``/data``.
+
+    ``mode`` is ``""`` when the entry omits an explicit rw/ro suffix.
+    """
+    mounts = []
+    for vol in service.get("volumes", []):
+        if not isinstance(vol, str):
+            continue  # long-form mounts not used for /data here
+        m = _DATA_MOUNT_RE.search(vol)
+        if m:
+            mounts.append((vol, m.group("mode") or ""))
+    return mounts
+
+
+def test_compose_file_exists():
+    assert COMPOSE_FILE.exists(), f"missing {COMPOSE_FILE}"
+
+
+@pytest.mark.parametrize("service_name", _WRITE_SERVICES)
+def test_data_mount_is_writable(service_name):
+    """The reader's /data mount must be read-write (the #361 fix)."""
+    compose = _load_compose()
+    service = compose["services"][service_name]
+    mounts = _data_mounts(service)
+    assert mounts, f"{service_name}: no /data volume mount found"
+    for vol, mode in mounts:
+        assert mode != "ro", (
+            f"{service_name}: /data is mounted read-only ('{vol}') — this is the "
+            f"#361 bug; the in-container download workflow cannot write to /data"
+        )
+        assert mode == "rw", (
+            f"{service_name}: /data mount '{vol}' must be explicitly ':rw' so the "
+            f"download workflow can populate it"
+        )
+
+
+@pytest.mark.parametrize("service_name", _WRITE_SERVICES)
+def test_data_path_env_points_at_mount(service_name):
+    """ML4T_DATA_PATH inside the container must be the /data mount target.
+
+    Every downloader resolves its output root from ML4T_DATA_PATH; if it doesn't
+    equal the writable mount, files land somewhere the host mount can't see
+    (the ETF wrong-dir class of bug).
+    """
+    compose = _load_compose()
+    env = compose["services"][service_name].get("environment", [])
+    # environment is a list of "KEY=VALUE" strings in this compose file.
+    env_map = {}
+    for item in env:
+        if isinstance(item, str) and "=" in item:
+            key, _, value = item.partition("=")
+            env_map[key] = value
+    assert env_map.get("ML4T_DATA_PATH") == "/data", (
+        f"{service_name}: ML4T_DATA_PATH is {env_map.get('ML4T_DATA_PATH')!r}, "
+        f"expected '/data' (the writable mount target)"
+    )
+
+
+def test_no_service_mounts_data_readonly():
+    """Defensive: no service anywhere reintroduces a read-only /data mount."""
+    compose = _load_compose()
+    offenders = []
+    for name, service in compose.get("services", {}).items():
+        if not isinstance(service, dict):
+            continue
+        for vol, mode in _data_mounts(service):
+            if mode == "ro":
+                offenders.append(f"{name} -> {vol}")
+    assert not offenders, f"read-only /data mount(s) found: {offenders}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_download_coverage.py
+++ b/tests/test_download_coverage.py
@@ -1,0 +1,90 @@
+"""Phase 4 — coverage ratchet: every free dataset keeps a live drift smoke.
+
+Phase 1 keeps ``download_all.py``'s registry in lock-step with the on-disk
+scripts. Phase 3 adds a live external drift smoke per free source. This test
+welds the two together so coverage can't rot as later beats ship more datasets:
+a newly shipped free dataset must appear in the free-tier list (Phase 1) *and*
+carry a drift test (Phase 3), or CI fails on the PR that adds it.
+
+Deterministic and network-free — it only introspects test modules and the
+download registry, so it runs in the fast per-PR ``test-unit`` job.
+"""
+
+from __future__ import annotations
+
+import tests.test_external_drift as drift
+from tests.test_download_scripts_registry import DATA_DIR, FREE_TIER_SCRIPTS
+
+# Maps each free-tier download script (the Phase 1 SSOT) to the drift-source key
+# it must be smoke-tested under in tests/test_external_drift.py. Keep this in
+# lock-step with FREE_TIER_SCRIPTS — the tests below fail loudly if it drifts.
+FREE_SCRIPT_TO_DRIFT_SOURCE = {
+    "etfs/market/download.py": "etf",
+    "crypto/market/download.py": "crypto",
+    "prediction_markets/download.py": "prediction_markets",
+    "futures/positioning/cot_download.py": "cot",
+    "factors/ff_download.py": "fama_french",
+    "factors/aqr_download.py": "aqr",
+    "equities/firm_characteristics/download.py": "firm_characteristics",
+    "macro/download.py": "fred",
+    "fx/market/download.py": "fx",
+}
+
+
+def _drift_test_names() -> set[str]:
+    return {
+        name for name in dir(drift) if name.startswith("test_") and callable(getattr(drift, name))
+    }
+
+
+def test_every_free_script_is_mapped_to_a_drift_source():
+    """A new free dataset can't ship without declaring its drift source.
+
+    When a later beat adds a free dataset to FREE_TIER_SCRIPTS, this fails until
+    the author maps it here (which in turn forces a DRIFT_SOURCES entry and a
+    drift test via the checks below).
+    """
+    mapped = set(FREE_SCRIPT_TO_DRIFT_SOURCE)
+    free = set(FREE_TIER_SCRIPTS)
+    unmapped = free - mapped
+    assert not unmapped, (
+        f"free-tier download scripts with no drift-source mapping: {sorted(unmapped)} — "
+        f"add them to FREE_SCRIPT_TO_DRIFT_SOURCE and give each a drift test."
+    )
+    stale = mapped - free
+    assert not stale, (
+        f"drift-source mappings for scripts no longer in FREE_TIER_SCRIPTS: {sorted(stale)} — "
+        f"remove them (the dataset was dropped or renamed)."
+    )
+
+
+def test_mapped_scripts_exist_on_disk():
+    """Every mapped free script resolves to a real file (catches a rename)."""
+    missing = [rel for rel in FREE_SCRIPT_TO_DRIFT_SOURCE if not (DATA_DIR / rel).is_file()]
+    assert not missing, f"mapped free-tier scripts missing on disk: {missing}"
+
+
+def test_drift_sources_match_mapping():
+    """``DRIFT_SOURCES`` and the free-script mapping are bidirectionally consistent."""
+    declared = set(drift.DRIFT_SOURCES)
+    mapped = set(FREE_SCRIPT_TO_DRIFT_SOURCE.values())
+    assert declared == mapped, (
+        f"DRIFT_SOURCES {sorted(declared)} != mapped free sources {sorted(mapped)} — "
+        f"a source is declared without a script mapping (or vice versa)."
+    )
+
+
+def test_every_drift_source_has_a_test():
+    """Each declared drift source is backed by a ``test_<source>*`` function."""
+    names = _drift_test_names()
+    for source in drift.DRIFT_SOURCES:
+        assert any(n.startswith(f"test_{source}") for n in names), (
+            f"drift source '{source}' has no test_{source}* function in "
+            f"tests/test_external_drift.py — declared but not smoke-tested."
+        )
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_download_scripts_registry.py
+++ b/tests/test_download_scripts_registry.py
@@ -18,6 +18,23 @@ import data.download_all as da
 
 DATA_DIR = Path(da.__file__).parent
 
+# The free datasets a reader gets with ``download_all.py --free-only`` (no API
+# key, or a free key). Single source of truth: the registry ratchet below pins
+# that these ship, and ``tests/test_download_coverage.py`` (Phase 4) pins that
+# each keeps a live drift smoke — so a newly shipped free dataset can't land
+# without both a registry entry and an external-drift test.
+FREE_TIER_SCRIPTS = (
+    "etfs/market/download.py",
+    "crypto/market/download.py",
+    "prediction_markets/download.py",
+    "futures/positioning/cot_download.py",
+    "factors/ff_download.py",
+    "factors/aqr_download.py",
+    "equities/firm_characteristics/download.py",
+    "macro/download.py",
+    "fx/market/download.py",
+)
+
 
 def _discovered_download_scripts() -> set[str]:
     """All download scripts on disk, as paths relative to ``data/``."""
@@ -47,18 +64,7 @@ def test_every_download_script_is_registered():
 
 def test_free_tier_scripts_present():
     """The free datasets a reader gets with `download_all.py --free-only` all ship."""
-    free_tier = [
-        "etfs/market/download.py",
-        "crypto/market/download.py",
-        "prediction_markets/download.py",
-        "futures/positioning/cot_download.py",
-        "factors/ff_download.py",
-        "factors/aqr_download.py",
-        "equities/firm_characteristics/download.py",
-        "macro/download.py",
-        "fx/market/download.py",
-    ]
-    missing = [p for p in free_tier if not (DATA_DIR / p).is_file()]
+    missing = [p for p in FREE_TIER_SCRIPTS if not (DATA_DIR / p).is_file()]
     assert not missing, f"free-tier download scripts missing: {missing}"
 
 

--- a/tests/test_external_drift.py
+++ b/tests/test_external_drift.py
@@ -1,0 +1,237 @@
+"""Phase 3 — live external drift smoke (weekly, flake-tolerant, auto-issue).
+
+One tiny **real** pull per FREE data source. Each test asserts the source is
+reachable, returns non-empty data, and still carries the schema our download
+scripts depend on. When an upstream provider moves, renames a file, or changes
+its payload shape, the matching test fails and the weekly workflow opens a
+deduped GitHub issue — this is the drift detector.
+
+Design rules (mirror ``work/2026-07-06-public-test-suite/PLAN.md``):
+- **Tiny props only** — 2 symbols / a short window / a single product-year.
+  Never a full-universe or full-history pull.
+- **No billed APIs.** Only free sources run. Key-gated free sources (FRED,
+  OANDA) skip cleanly when their free key is absent; geo-restricted sources
+  (Kalshi / Polymarket) skip when blocked rather than fail.
+- **Provider-level, not script-level.** We call the same providers the
+  ``data/**/download.py`` scripts use, so a provider/API change surfaces here
+  without writing files or pulling gigabytes.
+
+Marked ``@pytest.mark.drift`` and collected only by the weekly ``drift`` job —
+never per-PR (they touch the network).
+
+``DRIFT_SOURCES`` is the public contract that ``tests/test_download_coverage.py``
+(Phase 4) ratchets against: every free dataset must keep a drift smoke here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.drift
+
+# The free data sources this module keeps a live drift smoke for. Phase 4's
+# coverage ratchet asserts every free ``data/**/download.py`` maps to an entry
+# here, so a newly shipped free dataset can't land without a drift test.
+DRIFT_SOURCES: tuple[str, ...] = (
+    "etf",  # data/etfs/market/download.py            (Yahoo Finance)
+    "crypto",  # data/crypto/market/download.py          (Binance public)
+    "fama_french",  # data/factors/ff_download.py             (Ken French library)
+    "aqr",  # data/factors/aqr_download.py            (AQR research)
+    "cot",  # data/futures/positioning/cot_download.py (CFTC)
+    "fred",  # data/macro/download.py                   (FRED — free key)
+    "firm_characteristics",  # data/equities/firm_characteristics/download.py (Google Drive)
+    "fx",  # data/fx/market/download.py               (OANDA — free key)
+    "prediction_markets",  # data/prediction_markets/download.py     (Kalshi + Polymarket)
+)
+
+# A short, recent window keeps every pull tiny and deterministic in size.
+_START = "2024-01-02"
+_END = "2024-01-10"
+
+
+def _assert_schema(df, required: set[str], source: str) -> None:
+    """A source is healthy only if it returns non-empty data with our columns."""
+    import polars as pl
+
+    assert isinstance(df, pl.DataFrame), f"{source}: expected a polars DataFrame"
+    assert not df.is_empty(), f"{source}: reachable but returned zero rows (drift?)"
+    missing = required - set(df.columns)
+    assert not missing, f"{source}: missing expected column(s) {sorted(missing)} — schema drift"
+
+
+# ---------------------------------------------------------------------------
+# No-key free sources — always run in the weekly job.
+# ---------------------------------------------------------------------------
+
+
+def test_etf_yahoo_reachable():
+    """ETF universe download source (Yahoo Finance) — canonical OHLCV schema."""
+    from ml4t.data.providers.yahoo import YahooFinanceProvider
+
+    provider = YahooFinanceProvider()
+    try:
+        df = provider.fetch_ohlcv("SPY", _START, _END, "daily")
+    finally:
+        provider.close()
+    _assert_schema(df, {"timestamp", "symbol", "open", "high", "low", "close"}, "etf/yahoo")
+
+
+def test_crypto_binance_reachable():
+    """Crypto premium-index source (Binance public) — canonical premium schema."""
+    from ml4t.data.providers.binance_public import BinancePublicProvider
+
+    provider = BinancePublicProvider(market="futures")
+    try:
+        df = provider.fetch_premium_index(
+            "BTCUSDT", start="2024-01-01", end="2024-01-05", interval="8h"
+        )
+    finally:
+        provider.close()
+    _assert_schema(df, {"timestamp", "symbol", "premium_index_close"}, "crypto/binance")
+
+
+def test_fama_french_reachable():
+    """Fama-French factor source (Ken French library) — ff3 factors present."""
+    from ml4t.data.providers.fama_french import FamaFrenchProvider
+
+    provider = FamaFrenchProvider()
+    try:
+        df = provider.fetch("ff3", frequency="monthly", start="2023-01-01", end="2023-06-30")
+    finally:
+        provider.close()
+    # Ken French renames/reformats his CSV zips periodically; pin the columns
+    # the book's factor pipeline reads.
+    _assert_schema(df, {"timestamp", "Mkt-RF", "SMB", "HML", "RF"}, "fama_french")
+
+
+def test_aqr_reachable():
+    """AQR factor source — quality-minus-junk panel reachable (wide country panel)."""
+    from ml4t.data.providers.aqr import AQRFactorProvider
+
+    provider = AQRFactorProvider()
+    try:
+        # No date filter: the provider's date-string filter path is brittle and
+        # the monthly QMJ panel is already small. We only need reachability +
+        # that the Excel workbook still parses to a timestamped frame.
+        df = provider.fetch("qmj_factors")
+    finally:
+        provider.close()
+    _assert_schema(df, {"timestamp"}, "aqr")
+    assert df.width >= 2, "aqr: QMJ workbook parsed but carries no factor columns — layout drift"
+
+
+def test_cot_cftc_reachable(tmp_path, monkeypatch):
+    """CFTC Commitment-of-Traders source — one product-year panel."""
+    from ml4t.data.cot import COTConfig, COTFetcher
+
+    # cot_reports writes a scratch .txt into the CWD; keep it out of the repo.
+    monkeypatch.chdir(tmp_path)
+    fetcher = COTFetcher(COTConfig(products=["ES"], start_year=2024, end_year=2024))
+    df = fetcher.fetch_product("ES")
+    _assert_schema(df, {"report_date", "open_interest"}, "cot")
+
+
+def test_firm_characteristics_gdrive_listing():
+    """Firm-characteristics source (Google Drive folder) — listing still resolves.
+
+    Lists the folder without downloading (``skip_download=True``), catching a
+    moved/renamed folder or a gdown API change — the class of bug that broke the
+    firm-char download — for a fraction of a second and zero of the ~1.5 GB.
+    """
+    import os
+
+    import gdown
+
+    from data.equities.firm_characteristics.download import GDRIVE_FOLDER_URL
+
+    listing = gdown.download_folder(GDRIVE_FOLDER_URL, skip_download=True, quiet=True)
+    assert listing, "firm_characteristics: Google Drive folder listing is empty (moved/renamed?)"
+    # The raw folder holds the source files the downloader fetches, then extracts:
+    # RetChar.csv (the ~1.1 GB characteristics table the converter reads) and
+    # datasets.zip (the char/macro/RF numpy splits). A rename of either breaks the
+    # download, so pin their presence by basename rather than the extracted layout.
+    names = {os.path.basename(getattr(f, "path", str(f))) for f in listing}
+    for required in ("RetChar.csv", "datasets.zip"):
+        assert required in names, (
+            f"firm_characteristics: '{required}' missing from Drive folder "
+            f"(found {sorted(names)}) — upstream dataset renamed/moved"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Key-gated free sources — skip cleanly when the free key is absent (no charge).
+# ---------------------------------------------------------------------------
+
+
+def test_fred_reachable():
+    """Treasury/macro source (FRED) — free API key required, skip if unset."""
+    if not os.getenv("FRED_API_KEY"):
+        pytest.skip("FRED_API_KEY not set — free-key source, nothing to charge")
+
+    from ml4t.data.providers.fred import FREDProvider
+
+    provider = FREDProvider()
+    try:
+        # DGS10 = 10-Year Treasury constant maturity, a stable free series.
+        df = provider.fetch_ohlcv("DGS10", _START, _END, "daily")
+    finally:
+        provider.close()
+    _assert_schema(df, {"timestamp"}, "fred")
+
+
+def test_fx_oanda_reachable():
+    """FX source (OANDA) — free API key required, skip if unset."""
+    if not os.getenv("OANDA_API_KEY"):
+        pytest.skip("OANDA_API_KEY not set — free-key source, nothing to charge")
+
+    from ml4t.data.providers.oanda import OandaProvider
+
+    provider = OandaProvider(api_key=os.environ["OANDA_API_KEY"])
+    try:
+        df = provider.fetch_ohlcv("EUR_USD", _START, _END, "daily")
+    finally:
+        close = getattr(provider, "close", None)
+        if callable(close):
+            close()
+    _assert_schema(df, {"timestamp", "open", "high", "low", "close"}, "fx/oanda")
+
+
+# ---------------------------------------------------------------------------
+# Geo-restricted free source — skip (not fail) when the region blocks access.
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_markets_reachable():
+    """Prediction-markets source (Kalshi) — geo-restricted, skip when blocked.
+
+    Kalshi and Polymarket restrict API access by jurisdiction, so a listing can
+    fail at the network layer from some regions even though the endpoints are
+    up. This dataset is optional; a geo/network block skips rather than fails so
+    the weekly job doesn't file spurious drift issues from a blocked runner.
+    """
+    try:
+        from ml4t.data.providers.kalshi import KalshiProvider
+    except ImportError:
+        pytest.skip("Kalshi provider not installed")
+
+    provider = KalshiProvider()
+    try:
+        markets = provider.list_markets(limit=1)
+    except Exception as exc:  # network/geo block — optional dataset
+        pytest.skip(f"Kalshi unreachable from this runner (likely geo-restricted): {exc}")
+    finally:
+        close = getattr(provider, "close", None)
+        if callable(close):
+            close()
+
+    if not markets:
+        pytest.skip("Kalshi reachable but returned no markets (geo-filtered)")
+    assert isinstance(markets, list) and markets[0].get("ticker"), (
+        "prediction_markets: Kalshi listing shape changed (no 'ticker') — schema drift"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-m", "drift"]))


### PR DESCRIPTION
Completes the public-repo download test suite (Phase 1 shipped in #363). Each new layer catches a distinct failure class the notebook tests can't see — they run against pre-seeded data and never exercise the download path (the gap that let #361 reach readers).

## Phase 2 — container first-contact smoke (the #361 class)
- **`tests/test_compose_mounts.py`** (deterministic, per-PR `test-unit` job): pins the compose contract behind the #361 fix — `/data` mounted `:rw` (not `:ro`) and `ML4T_DATA_PATH=/data` — by parsing `docker-compose.yml`. End-anchored regex so the `${ML4T_DATA_PATH:-./data}` default's own colon can't be mistaken for the mount target. Mutation-checked: flipping the mount to `:ro` fails it.
- **`.github/workflows/container-smoke.yml`** (weekly + on compose/env changes): runs the reader's real `docker compose run … data/etfs/market/download.py --symbol SPY` in the `ml4t` image and asserts a parquet lands on the host side of the mount with no `Read-only file system`. The only layer a unit test can't reach. The ~12 GB image pull is kept **off** the per-PR path (download *logic* is already covered natively by Phase 1).

## Phase 3 — live external drift detector
- **`tests/test_external_drift.py`** (`drift` marker): one tiny **real** pull per free source — ETF/FX, crypto, Fama-French, AQR, CFTC COT, FRED, firm-char folder listing, prediction markets — asserting reachable + non-empty + canonical schema. Provider-level, tiny props, no writes, no gigabytes. Key-gated free sources (FRED/OANDA) skip when the free key is absent; geo-restricted Kalshi/Polymarket skip when blocked. **No billed APIs.**
- **`weekly-external.yml` `weekly-drift` job**: runs the smoke weekly with `pytest-rerunfailures` flake retry and opens a **deduped `external-drift: <source>` issue** when an upstream source moves, renames a file, or changes schema.

## Phase 4 — coverage ratchet + un-skip
- **`tests/test_download_coverage.py`**: welds Phase 1's free-tier list, `DRIFT_SOURCES`, and the drift tests together so a newly shipped free dataset can't land without a drift smoke. Deterministic, runs in `test-unit`.
- Promote the free-tier script list to a shared `FREE_TIER_SCRIPTS` constant (single source of truth).
- **`overrides.yaml`**: un-skip `02_financial_data_universe/16_provider_comparison` and `17_complete_pipeline` (were hard-skipped as "no guaranteed internet"). Now `tier: weekly` + `reruns: 2`, so they run in the weekly job and skip on per-PR (tier gate). Validated via papermill in the `ml4t` container with the weekly job's real inputs (FRED secret + test-data): **both pass**.
- Register the `drift` marker in `conftest.py`.

## Validation
- Deterministic suite (compose + coverage + registry): **58 passed** in a replica of the minimal-deps `test-unit` env (no ml4t/torch).
- Drift smoke locally: **8 passed, 1 skipped** (FX/OANDA — no key).
- Container smoke: run locally against the real 12 GB image — parquet lands on the host mount.
- Un-skipped notebooks: both pass under the real papermill harness in-container.
- `ruff check` + `ruff format --check` clean; all pre-commit hooks pass.

No-spend policy preserved throughout: only free/free-key sources, billed APIs stay unset and their tests skip.