### PR TITLE
Release ETF case study — research-design front half (notebooks 01–05)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ case_studies/*/backtest/
 case_studies/*/strategy/
 case_studies/*/evaluation/
 case_studies/*/exploration/
+case_studies/*/config/exploration/
+case_studies/*/config/cv_config.json
+case_studies/*/eligibility.csv
 case_studies/*/registry.db
 case_studies/*/results/
 case_studies/*/*_v1_contaminated/

--- a/case_studies/etfs/01_feasibility_analysis.ipynb
+++ b/case_studies/etfs/01_feasibility_analysis.ipynb
@@ -1,0 +1,2274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0b7f3b12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002869,
+     "end_time": "2026-05-15T05:20:56.557945+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:20:56.555076+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "# ETF Case Study: Feasibility Analysis\n",
+    "\n",
+    "This notebook tests whether the ETF dataset can deliver on the strategy declared\n",
+    "in `config/setup.yaml`. `setup.yaml` is the canonical, hand-curated source of\n",
+    "truth: universe, costs, decision schedule, mapping class, labels, sweep grid,\n",
+    "and evaluation protocol. This notebook does not write it. Instead, it produces\n",
+    "the evidence that justifies its values: universe breadth over time, point-in-\n",
+    "time eligibility, return distributions at multiple horizons relative to\n",
+    "transaction costs, a walk-forward fold demonstration, and an edge-to-cost\n",
+    "ratio. Findings persist to `config/exploration/feasibility_report.json`.\n",
+    "\n",
+    "## Learning Objectives\n",
+    "\n",
+    "- Verify the data delivers what `setup.yaml` assumes (breadth, costs, holdout)\n",
+    "- Implement point-in-time eligibility (no survivorship bias within the universe)\n",
+    "- Test whether typical price moves exceed transaction costs at candidate horizons\n",
+    "- Demonstrate the walk-forward structure has adequate breadth per fold\n",
+    "- Persist findings as a stable artifact downstream notebooks can cite\n",
+    "\n",
+    "## Book Reference\n",
+    "\n",
+    "Chapter 6, Sections 6.2-6.6\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- ETF data available via `load_etfs()`\n",
+    "- `config/setup.yaml` exists (canonical strategy spec)\n",
+    "- Understanding of walk-forward cross-validation (Section 6.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d4a71623",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:20:56.566313Z",
+     "iopub.status.busy": "2026-05-15T05:20:56.565833Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.423323Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.422509Z"
+    },
+    "papermill": {
+     "duration": 4.863845,
+     "end_time": "2026-05-15T05:21:01.424384+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:20:56.560539+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"ETF Case Study: Feasibility Analysis.\"\"\"\n",
+    "\n",
+    "import json\n",
+    "import warnings\n",
+    "from datetime import UTC, datetime\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import polars as pl\n",
+    "import seaborn as sns\n",
+    "import yaml\n",
+    "\n",
+    "from data import load_etfs\n",
+    "from utils.paths import get_case_study_dir\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "sns.set_style(\"whitegrid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eee4b4b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.431298Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.431075Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.433873Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.433214Z"
+    },
+    "papermill": {
+     "duration": 0.00625,
+     "end_time": "2026-05-15T05:21:01.434265+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.428015+00:00",
+     "status": "completed"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "CASE_STUDY_ID = \"etfs\"\n",
+    "START_DATE = \"2006-01-01\"\n",
+    "ADV_THRESHOLD = 10e6\n",
+    "MAX_SYMBOLS = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5bd2e63",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002839,
+     "end_time": "2026-05-15T05:21:01.440088+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.437249+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dfbfd735",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.451156Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.450678Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.506384Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.501895Z"
+    },
+    "papermill": {
+     "duration": 0.07904,
+     "end_time": "2026-05-15T05:21:01.522681+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.443641+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "CASE_DIR = get_case_study_dir(\"etfs\")\n",
+    "CASE_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "EXPLORATION_DIR = CASE_DIR / \"config\" / \"exploration\"\n",
+    "EXPLORATION_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "with open(CASE_DIR / \"config\" / \"setup.yaml\") as f:\n",
+    "    SETUP = yaml.safe_load(f)\n",
+    "\n",
+    "STRATEGY_ID = SETUP[\"strategy_id\"]\n",
+    "START_DATE = \"2006-01-01\"\n",
+    "END_DATE = \"2025-12-31\"\n",
+    "HOLDOUT_START = str(SETUP[\"evaluation\"][\"holdout_start\"])\n",
+    "\n",
+    "\n",
+    "def as_float(value: object) -> float:\n",
+    "    \"\"\"Convert Polars scalar outputs to plain float.\"\"\"\n",
+    "    return float(str(value))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "291a1c6f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026615,
+     "end_time": "2026-05-15T05:21:01.568642+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.542027+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section A: Orientation (Section 6.2)\n",
+    "\n",
+    "ETFs provide diversified exposure across asset classes with high liquidity and\n",
+    "low costs. This case study explores price-based signals at monthly cadences,\n",
+    "where turnover economics are manageable.\n",
+    "\n",
+    "`setup.yaml` declares the trading setup. This notebook asks whether the data\n",
+    "delivers on those declarations:\n",
+    "\n",
+    "- **Universe**: Is point-in-time breadth adequate across the sample period?\n",
+    "- **Costs**: Do typical moves exceed the cost grid at candidate horizons?\n",
+    "- **Evaluation**: Do walk-forward folds carry enough cross-sectional breadth?\n",
+    "- **Holdout**: Is the holdout cleanly separated from training data?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b25acfa0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005745,
+     "end_time": "2026-05-15T05:21:01.583568+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.577823+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section B: Universe and Cost Feasibility (Sections 6.3-6.4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c66daa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007128,
+     "end_time": "2026-05-15T05:21:01.599276+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.592148+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### B.1 Load and Explore the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e09592f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.612126Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.611439Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.786020Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.784167Z"
+    },
+    "papermill": {
+     "duration": 0.181168,
+     "end_time": "2026-05-15T05:21:01.786626+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.605458+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 100 ETFs, 470,662 rows\n",
+      "Period: 2006-01-03 to 2025-12-31\n"
+     ]
+    }
+   ],
+   "source": [
+    "etf_data = load_etfs()\n",
+    "\n",
+    "start_dt = pl.Series([START_DATE]).str.to_date(\"%Y-%m-%d\").item()\n",
+    "end_dt = pl.Series([END_DATE]).str.to_date(\"%Y-%m-%d\").item()\n",
+    "\n",
+    "prices = (\n",
+    "    etf_data.filter(pl.col(\"timestamp\").is_between(start_dt, end_dt))\n",
+    "    .select([\"symbol\", \"timestamp\", \"close\", \"volume\"])\n",
+    "    .sort([\"symbol\", \"timestamp\"])\n",
+    ")\n",
+    "\n",
+    "n_symbols = prices[\"symbol\"].n_unique()\n",
+    "print(f\"Loaded {n_symbols} ETFs, {len(prices):,} rows\")\n",
+    "print(f\"Period: {prices['timestamp'].min()} to {prices['timestamp'].max()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f888225b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005298,
+     "end_time": "2026-05-15T05:21:01.797458+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.792160+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "**Note**: The `close` column from `load_etfs()` is adjusted for splits and\n",
+    "dividends. We verify this by checking SPY's 2006 price level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6fca2e56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.810380Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.810013Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.824971Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.824135Z"
+    },
+    "papermill": {
+     "duration": 0.022982,
+     "end_time": "2026-05-15T05:21:01.825665+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.802683+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SPY 2006 first close: $87.23 (adjusted -- verified)\n"
+     ]
+    }
+   ],
+   "source": [
+    "spy_2006 = prices.filter((pl.col(\"symbol\") == \"SPY\") & (pl.col(\"timestamp\").dt.year() == 2006))\n",
+    "spy_first_close = as_float(spy_2006[\"close\"].first())\n",
+    "assert spy_first_close < 130, (\n",
+    "    f\"SPY 2006 close={spy_first_close:.2f} looks unadjusted (expected ~$90-100 adjusted)\"\n",
+    ")\n",
+    "print(f\"SPY 2006 first close: ${spy_first_close:.2f} (adjusted -- verified)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d40fddb4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003369,
+     "end_time": "2026-05-15T05:21:01.832229+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.828860+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### B.2 Universe Selection: Rolling Point-in-Time Methodology\n",
+    "\n",
+    "A critical mistake in backtesting is using **end-of-sample information** to select\n",
+    "the universe. For example, filtering to \"ETFs with ADV > $50M\" using today's volume\n",
+    "excludes ETFs that had sufficient volume historically but have since declined.\n",
+    "\n",
+    "The correct approach is **rolling selection**: at each decision point, use only\n",
+    "information available at that time.\n",
+    "\n",
+    "For this case study, we will:\n",
+    "1. First explore the historical distribution of dollar volume\n",
+    "2. Set a threshold that is realistic but lenient (this is a demo, not production)\n",
+    "3. Implement point-in-time universe membership"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa00b04a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003395,
+     "end_time": "2026-05-15T05:21:01.840668+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.837273+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Exploratory Analysis: Dollar Volume Distribution Over Time\n",
+    "\n",
+    "Before setting thresholds, we need to understand how dollar volume has evolved.\n",
+    "A threshold that seems reasonable today may have excluded most ETFs in 2007."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f01388ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.848212Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.848090Z",
+     "iopub.status.idle": "2026-05-15T05:21:01.875443Z",
+     "shell.execute_reply": "2026-05-15T05:21:01.874140Z"
+    },
+    "papermill": {
+     "duration": 0.033555,
+     "end_time": "2026-05-15T05:21:01.877750+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.844195+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>year</th><th>median_$M</th><th>p75_$M</th><th>p90_$M</th><th>n_etfs</th></tr><tr><td>i32</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>2006</td><td>14.5</td><td>70.2</td><td>445.3</td><td>71</td></tr><tr><td>2007</td><td>23.0</td><td>119.5</td><td>627.6</td><td>82</td></tr><tr><td>2008</td><td>43.2</td><td>174.1</td><td>984.3</td><td>85</td></tr><tr><td>2009</td><td>46.0</td><td>170.2</td><td>722.1</td><td>86</td></tr><tr><td>2010</td><td>53.0</td><td>233.2</td><td>679.4</td><td>87</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>2021</td><td>253.1</td><td>626.7</td><td>1327.6</td><td>100</td></tr><tr><td>2022</td><td>313.0</td><td>742.3</td><td>1613.2</td><td>100</td></tr><tr><td>2023</td><td>257.2</td><td>634.4</td><td>1283.1</td><td>100</td></tr><tr><td>2024</td><td>262.1</td><td>656.1</td><td>1402.3</td><td>100</td></tr><tr><td>2025</td><td>342.8</td><td>854.2</td><td>1996.2</td><td>100</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 5)\n",
+       "┌──────┬───────────┬────────┬────────┬────────┐\n",
+       "│ year ┆ median_$M ┆ p75_$M ┆ p90_$M ┆ n_etfs │\n",
+       "│ ---  ┆ ---       ┆ ---    ┆ ---    ┆ ---    │\n",
+       "│ i32  ┆ f64       ┆ f64    ┆ f64    ┆ u32    │\n",
+       "╞══════╪═══════════╪════════╪════════╪════════╡\n",
+       "│ 2006 ┆ 14.5      ┆ 70.2   ┆ 445.3  ┆ 71     │\n",
+       "│ 2007 ┆ 23.0      ┆ 119.5  ┆ 627.6  ┆ 82     │\n",
+       "│ 2008 ┆ 43.2      ┆ 174.1  ┆ 984.3  ┆ 85     │\n",
+       "│ 2009 ┆ 46.0      ┆ 170.2  ┆ 722.1  ┆ 86     │\n",
+       "│ 2010 ┆ 53.0      ┆ 233.2  ┆ 679.4  ┆ 87     │\n",
+       "│ …    ┆ …         ┆ …      ┆ …      ┆ …      │\n",
+       "│ 2021 ┆ 253.1     ┆ 626.7  ┆ 1327.6 ┆ 100    │\n",
+       "│ 2022 ┆ 313.0     ┆ 742.3  ┆ 1613.2 ┆ 100    │\n",
+       "│ 2023 ┆ 257.2     ┆ 634.4  ┆ 1283.1 ┆ 100    │\n",
+       "│ 2024 ┆ 262.1     ┆ 656.1  ┆ 1402.3 ┆ 100    │\n",
+       "│ 2025 ┆ 342.8     ┆ 854.2  ┆ 1996.2 ┆ 100    │\n",
+       "└──────┴───────────┴────────┴────────┴────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Compute daily dollar volume\n",
+    "prices_with_dv = prices.with_columns((pl.col(\"close\") * pl.col(\"volume\")).alias(\"dollar_volume\"))\n",
+    "\n",
+    "# Annual statistics: median dollar volume across all ETF-days in each year\n",
+    "annual_dv_stats = (\n",
+    "    prices_with_dv.with_columns(pl.col(\"timestamp\").dt.year().alias(\"year\"))\n",
+    "    .group_by(\"year\")\n",
+    "    .agg(\n",
+    "        pl.col(\"dollar_volume\").median().alias(\"median_dv\"),\n",
+    "        pl.col(\"dollar_volume\").quantile(0.25).alias(\"p25_dv\"),\n",
+    "        pl.col(\"dollar_volume\").quantile(0.75).alias(\"p75_dv\"),\n",
+    "        pl.col(\"dollar_volume\").quantile(0.90).alias(\"p90_dv\"),\n",
+    "        pl.col(\"symbol\").n_unique().alias(\"n_etfs\"),\n",
+    "    )\n",
+    "    .sort(\"year\")\n",
+    ")\n",
+    "\n",
+    "# Display as DataFrame (values in millions)\n",
+    "annual_dv_stats.select(\n",
+    "    [\n",
+    "        \"year\",\n",
+    "        (pl.col(\"median_dv\") / 1e6).round(1).alias(\"median_$M\"),\n",
+    "        (pl.col(\"p75_dv\") / 1e6).round(1).alias(\"p75_$M\"),\n",
+    "        (pl.col(\"p90_dv\") / 1e6).round(1).alias(\"p90_$M\"),\n",
+    "        \"n_etfs\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9fef469",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004933,
+     "end_time": "2026-05-15T05:21:01.887195+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.882262+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Visualize the Dollar Volume Evolution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "744559a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:01.900124Z",
+     "iopub.status.busy": "2026-05-15T05:21:01.899540Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.183569Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.182465Z"
+    },
+    "papermill": {
+     "duration": 0.292428,
+     "end_time": "2026-05-15T05:21:02.184348+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:01.891920+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAGGCAYAAABmGOKbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA62ZJREFUeJzs3XdUFGf78PHvLiy9SbMh2MECih3F3ntL7CXGaKKxpmJ5Yo0Yo8ZYosYYa4xGYw+aRE2ixm7swV6xAiq9LLv7/uHL/NwAyioIi9fnHM5xZ+6ZuWbvXeSau6kMBoMBIYQQQgghhBBC5Dh1XgcghBBCCCGEEEIUVJJ0CyGEEEIIIYQQuUSSbiGEEEIIIYQQIpdI0i2EEEIIIYQQQuQSSbqFEEIIIYQQQohcIkm3EEIIIYQQQgiRSyTpFkIIIYQQQgghcokk3UIIIYQQQgghRC6RpFsIIYQQQgghhMglknQLIYR45Xx9fZk3b57yeuPGjfj6+hIREZGHUb2Yw4cP4+vry+HDh/M6lFdi3rx5+Pr6vpJr9e3bl759+yqv09/rnTt3vpLrh4SE0KRJk1dyrddFREQEvr6+bNy4Ma9DEUKIV8YyrwMQQgjxxMaNGxkzZkyW+9etW8fatWvZtGnTc8/VuXNnpk+fTt++fTly5EimZcLCwihTpkyW53g6sbKwsMDBwQEvLy+qVatGjx49KFu27HPjyG/at29PXFwcf/zxByqVKtMyPXr04ObNm+zduxdLy4L93+R/P3NWVlY4Ozvj6+tLw4YN6dKlCw4ODi99nfv37/PTTz/RrFkzKlSo8NLny0n5ObZHjx7x7bffsmfPHu7cuYOtrS3+/v706dOHxo0b53V4innz5jF//vznlqtVqxahoaGvICIhhMhfCvZfE0IIYYZGjBiBl5dXhu3e3t50796doKAgZVtERARz586le/fuVK9e3ahsuiJFivDBBx9kOF/hwoWfG0u9evXo2LEjBoOB+Ph4zp8/z+bNm/nxxx/56KOPGDBggKm3l6fat2/PrFmzOHbsGDVr1sywPyIigpMnT9KnT58Cn3A/Lf0zl5aWRlRUFEeOHGHatGksX76cb775Bj8/P6XskCFDGDx4sEnnf/DgAfPnz6d48eImJbZLly416Tov4lmxTZkyBYPBkOsxZObq1au89dZbPHz4kC5duuDv709sbCzbtm3jvffe4+233+bTTz/Nk9j+q3nz5ka/cxITE5k4cSLNmzenefPmynZ3d3eKFy/O6dOnX6vvlxBCyG88IYTIZxo0aIC/v3+m+1xdXQkMDFRenzlzhrlz51K1alU6duyY6TGOjo5Z7nuekiVLZjj2ww8/ZMiQIUyfPp3SpUvTsGHDFzp3bkpKSsLW1jbD9vbt2zN79my2bduWadL9yy+/YDAYaN++/asIM9/472fu3Xff5eDBg7z33nsMHTqUsLAwbGxsALC0tMz1hCm9/qysrHL1Os+j0Wjy5LparZaRI0cSGxvLDz/8QJUqVZR9b731Fh999BHff/89/v7+tGnT5pXFlZaWhl6vz1Avfn5+Rg9mHj58yMSJE/H19c30d4+1tXWuxyqEEPmJjOkWQghhkkKFCjF79mwsLS1ZuHCh0b7o6GjGjh1L3bp18ff3p0OHDtnqDp+ZXbt2MXjwYIKDg6lcuTLNmjVjwYIF6HQ6o3J9+/alXbt2nD17lt69e1OlShVmz56d6TmLFi1KzZo1+fXXX9FqtRn2b9++HW9vbyXJ+ffff3nnnXeoVq0agYGB9O/fn5MnTz439iZNmhASEpJhe1ZjlMPCwpg/fz7169cnMDCQESNGEBcXR2pqKp9//jlBQUEEBgYyZswYUlNTM5x3y5YtdOnShYCAAGrVqsXo0aO5e/fuc+N8lqCgIIYOHcrt27fZunWrsj2zMd1///03PXv2pEaNGgQGBtKyZUulDg4fPswbb7wBwJgxY/D19TUa0/us+vvv+5VOr9cze/Zs6tWrR9WqVXnvvfcy3G926uB5sWU2pjsxMZHp06fTsGFDKleuTMuWLVm6dGmGFnFfX18mT57Mrl27aNeuHZUrV6Zt27bs3bv3WW87AL/99hsXL15k0KBBRgk3PBnqMXnyZJycnJR5EaKioqhYsWKmXbyvXr2Kr68vq1evVrbFxsby+eefK/fQvHlzvv32W/R6vVImfez10qVLWb58Oc2aNcPf358rV648N/5nyWxMd0hICIGBgdy5c4d3332XwMBA6tevzw8//ADAhQsX6NevH1WrVqVx48Zs27Ytw3mzc09CCJFXpKVbCCHymfj4eB4+fGi0TaVSUahQoRc6n06ny3A+a2tr7O3tXzjGYsWKUbNmTQ4fPkx8fDwODg4kJyfTt29fbt68Se/evfHy8mLnzp2EhIQQGxtL//79TbrGpk2bsLOzY8CAAdjZ2XHo0CHmzp1LfHx8hm61jx8/ZtCgQbRt25YOHTrg5uaW5Xnbt2/P//73P/bv3280LvbChQtcvHiR999/H4BLly7Ru3dv7O3teeedd7C0tGTdunX07duX1atXZ0iGXsa3336LjY0NgwcP5saNG6xevRpLS0tUKhWxsbEMGzaMU6dOsXHjRooXL86wYcOUYxcuXMjXX39N69ateeONN3j48CGrV6+md+/ebN68GScnpxeOq2PHjsyePZv9+/fTrVu3TMtcunSJd999F19fX0aMGIGVlRU3btzgn3/+AaBMmTKMGDEiwzCIatWqKecwpf7S71mlUjFo0CCio6NZsWIFb731Flu2bFFa5LMjO7E9zWAwMGTIECVZr1ChAvv27WPGjBncv3+fsWPHGpU/fvw4v/32G7169cLe3p5Vq1YxYsQI/vjjj2d+n/fs2QNAp06dMt3v6OhI06ZN2bRpEzdu3MDHx4eaNWuyY8cOo88GPJm7wcLCglatWgFPehH06dOH+/fv06NHD4oWLcqJEyeYPXs2kZGRjBs3zuj4jRs3kpKSQrdu3ZQx/7lBp9MxaNAgatSowUcffcS2bduYPHkytra2fPXVV7Rv354WLVqwdu1aPv30U6pWrUqJEiVe6J6EEOJVk6RbCCHymbfeeivDNisrK86cOfNC57t69arROHD4v4nWXka5cuU4ePAgERER+Pn5sW7dOq5cucKXX35Jhw4dgCeTkvXt25c5c+bQtWtXkyblmjVrllEC1bNnTz777DN+/PFHRo8ebdTFNTIykkmTJtGjR4/nnrdly5ZMmTKF7du3GyXd27dvB1C6ls+ZMwetVsuPP/6o/HHfqVMnWrVqxZdffmnUcviydDodq1atUrozP3r0iF9++YX69euzZMkSAHr37s3NmzfZuHGjkljdvn2befPmMWrUKN577z3lfC1atKBz586sWbPGaLupihQpgqOjI7du3cqyzN9//41Wq2XJkiW4urpm2O/u7k6DBg2eOQzClPoDiImJISwsTPk8VaxYkVGjRvHTTz/Rr1+/bN5d9mJ72u7duzl06BCjRo1iyJAhwJN6GTFiBCtXrqRPnz5GY5uvXLlCWFiYsq127dp07NiRX375hT59+mR5nStXruDo6Ejx4sWzLJPenfvKlSv4+PjQpk0bPvvsMy5evEj58uWVcjt27KBmzZq4u7sDsGzZMm7dusWmTZsoWbIk8OR76unpydKlS3n77bcpWrSocvy9e/f4/fffM63bnJSSkkKHDh149913gSffw/r16zN27Fhmz56tdKOvW7curVu3ZvPmzQwfPvyF7kkIIV416V4uhBD5zGeffcayZcuMftITrxdRvHjxDOd75513XjpOOzs7ABISEgDYu3cvHh4etGvXTimj0Wjo27cviYmJHD161KTzP51wp7f+16hRg6SkJK5evWpU1srKii5dumTrvM7OzjRs2JA9e/aQmJgIPGnB/OWXX6hcuTKlSpVCp9Px999/06xZMyXhBvD09KRdu3YcP36c+Ph4k+7nWTp27Gg0fjggIACDwUDXrl2NygUEBHD37l3S0tIA+P3339Hr9bRu3ZqHDx8qP+7u7vj4+OTIMmZ2dnZKHWcmvSV99+7dL9yV15T6gycPP55+gNOqVSs8PDz466+/Xuj62bV3714sLCwydHl/++23MRgMGbqO161b1ygJ9/Pzw8HB4ZkPMeDJd+p5PVHS96d/Dps3b46lpSVhYWFKmYsXL3L58mWjcd87d+6kevXqODk5GX1m6tati06ny/A9bdGiRa4n3OnefPNN5d9OTk6UKlUKW1tbWrdurWwvXbo0Tk5ORu+hqfckhBCvmrR0CyFEPhMQEJDlRGovws7Ojrp16+bY+dKlJ6zpf/zfvn0bHx8f1Grj57npy5LduXPHpPNfunSJOXPmcOjQoQwJblxcnNHrwoULmzTpVvv27fn999/ZvXs37du3559//uH27dtKK+nDhw9JSkqiVKlSGY4tU6YMer2eu3fvUq5cOZPuKSvFihUzeu3o6AiQoXXO0dERvV5PXFwchQoV4vr16xgMBlq0aJHpeXNiwrPExMRndvdu06YN69evZ/z48cyaNYugoCCaN29Oq1atMnwWsmJq/fn4+Bi9VqlU+Pj4cPv27Wyf40Xcvn0bT0/PDD020j/j/71+Zq2rzs7OxMbGPvM69vb2PHr06Jll0h+EpH//XF1dqVOnDjt27GDUqFHAk67llpaWRjOI37hxgwsXLmTo/ZLuv0NRMltJITdYW1tnSO4dHR0pUqRIhuX9HB0djd5DU+9JCCFeNUm6hRBCvJBLly5hYWGRK3+Ux8bG0qdPHxwcHBgxYgTe3t5YW1tz7tw5Zs6cmaFF1ZRxvACNGzfG0dGR7du30759e7Zv346FhQVt27bNydvIQKfTYWFhkWF7VslpVtvTJ+3S6/WoVCqWLFmS6XnTeyO8qHv37hEXF2fUWvtfNjY2/PDDDxw+fJg///yTffv2ERYWxrp16/j+++8zjSuzc7wqWdVBbsjqOs9bhqxMmTKEh4dz586dDA9k0l24cAGAsmXLKtvatm3LmDFjCA8Pp0KFCuzYsYM6deoYJbN6vZ569epl2dslvXt2uldVN1m9V9l5D029JyGEeNUk6RZCCGGyO3fucPToUapWraq0+hUvXpwLFy6g1+uNksX0ruBZJQ+ZOXLkCI8fP2b+/PlGS3tFRETkSPxWVla0bNmSLVu2EBUVxc6dO6lTpw4eHh7Ak1ZDW1tbrl27luHYq1evolarnzlGNKvWzDt37hh1V39Z3t7eGAwGvLy8Mm2Vf1lbtmwBIDg4+Jnl1Go1QUFBBAUFMWbMGBYtWsRXX33F4cOHqVu3boaWypd148YNo9cGg4EbN24Yzaqe3TowJbbixYtz8OBBZfLAdOmf8WeNwTZFo0aN2L59O5s3b2bo0KEZ9sfHx7N7925Kly5t1OrfrFkzPvvsM6WL+fXr15Ux0um8vb1JTEzMld4veaUg3pMQomCRMd1CCCFM8vjxYz744AN0Op3RJF0NGjQgMjLSaExpWloaq1atws7OLtN1sbOSnrQ/3ZqVmprKmjVrcuAOnmjfvj1arZbPPvuMhw8fGq3NbWFhQb169di9e7dRoh8VFcX27dupXr36MyeFK1GiBKdOnTJa3uuPP/546WW8/qtFixZYWFgwf/78DK2nBoPhuV2Un+XgwYN88803eHl5KRPjZebx48cZtlWoUAFAuf/0NdOf1606uzZv3mw05GDnzp1ERkbSoEEDZVt268CU2Bo0aIBOp1OWskq3fPlyVCqV0fVfRsuWLSlbtixLlizJMIGiXq9nwoQJxMTEZJip3MnJieDgYHbs2MEvv/yCRqOhWbNmRmVat27NiRMn2LdvX4brxsbGKvMFmJOCeE9CiIJFWrqFECKf2bt3b4aJwuDJMkY52UqaHdevX2fLli0YDAYSEhI4f/48O3fuJDExkZCQEKMko3v37qxbt46QkBDOnTtH8eLF+fXXX/nnn38YO3asSTOXBwYG4uzsTEhICH379kWlUilx5JRatWpRpEgRdu/ejY2NjdG4V4BRo0Zx4MABevXqRa9evbCwsGDdunWkpqby8ccfP/Pcb775Jr/++ivvvPMOrVu35ubNm2zbtu2Z3bRfhLe3N6NGjWLWrFncvn2bZs2aYW9vT0REBLt27aJbt24MHDjwuedJ/8zpdDqioqI4fPgwf//9N8WKFWPhwoVYW1tneeyCBQs4duwYDRs2pHjx4kRHR7NmzRqKFCmiLMHl7e2Nk5MTa9euxd7eHjs7OwICAl748+zs7EyvXr3o0qWLsmSYj4+P0bJm2a0DU2Jr0qQJtWvX5quvvuL27dv4+vry999/s3v3bvr3759j9WtlZcXcuXPp37+/cp+VK1cmLi6O7du3c+7cOd5+++1Mh0O0adOGjz/+mDVr1hAcHJxhybiBAweyZ88e3nvvPTp37kylSpVISkri4sWL/Prrr+zevfuVTZyWUwriPQkhChZJuoUQIp+ZO3dupttDQ0NfedL9999/8/fff6NWq3FwcMDLy4tOnTrRvXt3o7Gk8GTs56pVq5g5cyabNm0iPj6eUqVKERoaatLM1ACFChVi0aJFfPHFF8yZMwcnJyc6dOhAUFBQtpLI7FCr1bRt25alS5fSuHHjDA8FypUrxw8//MCsWbNYvHgxBoOBgIAAvvzyy+eu0V2/fn1CQkJYtmwZ06ZNo3Llysr95LTBgwdTsmRJli9fzoIFC4AnS33Vq1ePJk2aZOsc6Z85jUaDi4sL5cuXZ+zYsXTp0uW5D0uaNGnC7du3+fnnn3n06BGFChWiVq1aDB8+XJkQTqPRMH36dGbPns3EiRNJS0t7qc/ze++9x4ULF/j2229JSEggKCiICRMmKK3WkP06MCU2tVrNwoULmTt3LmFhYcq66Z988glvv/32C91LVsqUKcPWrVv59ttv2bNnDxs3bsTGxobKlSuzcOHCLOu2SZMm2NjYkJCQYDRreTpbW1tWrVrF4sWL2blzJ5s3b8bBwYGSJUsa1Zk5KYj3JIQoWFSGnGw2EEIIIYQQQgghhELGdAshhBBCCCGEELlEkm4hhBBCCCGEECKXSNIthBBCCCGEEELkEkm6hRBCCCGEEEKIXCJJtxBCCCGEEEIIkUsk6RZCCCGEEEIIIXKJJN3ZYDAY0Ol0yOpqQgghhBBCCCFMIUl3Nuj1ek6ePIler8/rUMRz6PV6Tp8+LXVlJqS+zIvUl/mROjMvUl/mRerL/EidmZeCVF+SdIsCxWAwoNVqpVeCmZD6Mi9SX+ZH6sy8SH2ZF6kv8yN1Zl4KUn1J0i2EEEIIIYQQQuQSSbqFEEIIIYQQQohcIkm3EEIIIYQQQgiRSyTpFkIIIYQQQgghcollXgdQkOh0OrRabV6H8VrT6XQAJCcnY2FhkcfR5B6NRlOg708IIYQQQoiCQpLuHGAwGLh37x6PHz/O61BeewaDAUtLS27cuIFKpcrrcHKVi4sLRYoUKfD3KYQQQgghhDmTpDsHpCfcnp6e2NnZSRKUhwwGA0lJSdja2hbYejAYDCQmJvLgwQMAihYtmscRCSGEEEIIIbIiSfdL0ul0SsLt5uaW1+G89gwGA3q9HhsbmwKbdAPY2toC8ODBAzw9PaWruRBCCCGEEPlUnk6ktnjxYrp27UpgYCBBQUEMHTqUq1evGpVJSUlh0qRJ1K5dm8DAQIYPH05UVJRRmTt37jB48GCqVKlCUFAQX3zxBWlpaUZlDh8+TOfOnalcuTLNmzdn48aNOXIP6WO47ezscuR8QmRX+mdO5hEQQgghhBAFQXR0NNevX+f69evcuHGDBw8ecOPGDWVbdHR0Xof4QvK0pfvIkSP07t0bf39/dDods2fPZuDAgfzyyy9KQjFt2jT++usv5syZg6OjI1OmTGHYsGGsXbsWeNLS/O677+Lu7s7atWt58OABn376KRqNhg8++ACAW7du8e6779KjRw9mzpzJwYMHGT9+PB4eHtSvXz9H7qUgt6qK/Ek+c0IIIYQQoqCIjo5mzJgxz2xQ0mg0hIaGml0P4zxNupcuXWr0evr06QQFBXHu3Dlq1qxJXFwcP//8MzNnziQoKAh4koS3adOGkydPUrVqVfbv38/ly5dZtmwZ7u7uVKhQgZEjRzJz5kyGDRuGlZUVa9euxcvLi5CQEADKlCnD8ePHWb58eY4l3UIIIYQQQgghXkxcXNxze3BqtVri4uIk6X4ZcXFxADg7OwNw9uxZtFotdevWVcqUKVOGYsWKKUn3yZMnKV++PO7u7kqZ4OBgJk6cyOXLl6lYsSInT55Ukvany0ybNs2k+NKXo/rvNoPBoPw8LTU1NUM399xkaWmJlZXVK7tefpReB/+ti4Io/TOn0+ky/Wyag/S4zTX+143Ul/mROjMvUl/mRerL/Eid5W96vT7b5fJTHWZnbqV8k3Tr9XqmTZtGtWrVKF++PABRUVFoNBqcnJyMyrq5uREZGamUeTrhBpTXzysTHx9PcnIyNjY22YrxzJkzmW63tLQkKSnJ6IOSmprK6dOnSUpKyta5c4KtrS0BAQE5lnhPmDCBbdu2GW0LCgpiwYIFyuuYmBhmzJjB3r17UalUNG3alI8//vilx7gPGjSI48ePZ9geHBzM3Llznxvfq3zf80pKSgparZbz58/ndSgvLavvlsifpL7Mj9SZeZH6Mi9SX+ZH6ix/Sl+Z53kuXLjAo0ePcjma7Ktevfpzy+SbpHvSpElcunSJNWvW5HUoWfL398/wJCM5OZkbN25ga2ubIXlPS0vD3t4ejUaT67FptVpSU1OxsrLKsUndLCwsqF+/vlGPgP+ef+TIkURGRvL999+TlpbG2LFjCQ0NZdasWS917QULFhh1L3n8+DGdOnWiTZs2yvUziy/9vS7IS4alU6vVaDQaypYtm+0HR/mNTqfjzJkzmX63RP4j9WV+pM7Mi9SXeZH6Mj9SZ/nbjRs3slXO19cXHx+fXI4mZ+WLpHvy5Mn8+eefrF69miJFiijb3d3d0Wq1xMbGGrV2R0dH4+HhoZQ5ffq00fnSZzd/usx/ZzyPiorCwcHBpGTFwsIiwxfUwsIClUql/KRLf21lZYW1tXW2r/GiVCoVWq02QxzP0rdvX8qVKwfAli1bsLS0pGfPnowcOdIofk9Pz0yPv3LlCvv27WPDhg34+/sDMH78eAYPHsynn35K4cKFMz1u3rx57Nq1i549e7Jw4UIeP35Mo0aNmDp1Ko6OjgAUKlTI6JiwsDBsbGxo3bq1cn+ZxZe+hrUp74O5Sr/HzD6X5qYg3MPrROrL/EidmRepL/Mi9WV+pM7yJ7U6ewtrqdVqs6u/PF0yzGAwMHnyZH7//XdWrFhBiRIljPZXrlwZjUbDwYMHlW1Xr17lzp07VK1aFYCqVaty8eJFo+njDxw4gIODA2XLllXKHDp0yOjcBw4cUM7xOtu0aRMWFhasX7+ecePGsXz5ctavX6/sP3LkCEFBQbRs2ZIJEyYYdeU4ceIETk5OSsINULduXdRqdYYHIf918+ZNduzYwaJFi/juu+8IDw9n4sSJWZb/+eefadu2bYZW/GfFJ4QQQgghhBB5LU9buidNmsT27dv55ptvsLe3V8ZgOzo6YmNjg6OjI127dmX69Ok4Ozvj4ODA1KlTCQwMVBLm4OBgypYtyyeffMLHH39MZGQkc+bMoXfv3srY5h49evDDDz8wY8YMunbtyqFDh9ixYweLFy/Oq1vPN4oWLcrYsWNRqVSULl2aixcvsnz5crp160b9+vVp3rw5Xl5e3Lp1i9mzZzNo0CDWrVuHhYUFUVFRuLq6Gp3P0tISZ2dnpS6zkpKSwowZM5TW8PHjx/Puu+8SEhKi9FBId/r0aS5evMjnn39utD2z+AYPHsz333+fA++MEEIIIYQQQry8PE26f/zxR+BJN+enhYaG0qVLFwDGjh2LWq1mxIgRpKamEhwczIQJE5SyFhYWLFq0iIkTJ9K9e3dsbW3p3LkzI0aMUMqUKFGCxYsXExoaysqVKylSpAhTp06V5cKAKlWqGHXDrlq1KsuWLUOn09G2bVtlu6+vL76+vjRr1kxpXc6OwMBA5d/t27dn8uTJwJNk/+nu54GBgej1eq5du5Yh6d6wYQPly5cnICDAaHtW8R07dozGjRtnKz4hhBBCCCFE3nN0dESj0Tx3ne704ajmJE+T7gsXLjy3jLW1NRMmTDBKtP+rePHiLFmy5JnnqV27Nps3bzY1RPGUEiVKUKhQIW7cuEFQUBDu7u48fPjQqExaWhoxMTFK4vz0e+7g4GDyNRMTE/nll1+MHqI8L75bt26ZfB0hhBBCCCFE3ilUqBA9evTA2toavV6PSqXi1q1b1KpVSxnD7ejoaHZrdEM+mUhN5J3/jr0+deoUPj4+mU5OcO/ePR4/fqwk1IGBgcTGxnL27FkqV64MwKFDh9Dr9UqrdFYzC969e5f79+8rrd0nT55ErVZTqlQpo3I7d+4kNTWVDh06PPde/hufEEIIIYQQwjwcPXqUVatW0bdvX3x9fUlOTiYhIQEfHx8sLc07bc3TidRE3rtz5w6hoaFcvXqV7du3s3r1avr160dCQgJffPEFJ0+eJCIigoMHDzJ06FB8fHyUbvllypShfv36/O9//+P06dMcP36cKVOm0LZt2yxnLk9nbW1NSEgI58+f59ixY0ydOpXWrVtn2rW8WbNmGWYzzyo+b2/vbHd9F0IIIYQQQuQ9vV7P5s2bKVu2LN7e3gVuFSLzfmRgBp41JiE/XKdTp04kJyfz5ptvYmFhQb9+/ejevTspKSlcvHiRzZs3ExcXh6enJ/Xq1WPkyJHKBHUAM2fOZMqUKfTv3x+1Wk2LFi0YP378c6/r7e1N8+bNGTRoEDExMTRq1CjDEIKrV69y/PjxTCdGs7CwyDS+ESNGGMUnhBBCCCGEyN+OHDnCvXv36Nu3L7a2tnkdTo6TpDuXWFpaYm9vT0JCAqmpqa/kmvb29iZ3vbC0tGTcuHFMmjTJaLuNjQ1Lly597vEuLi7MmjXLpGum69WrF7169cpyf+nSpbMc959VfOnrdAshhBBCCCHyP71ez5YtWyhXrlyBbOUGSbpzjZWVFYGBgaSlpb2ya1paWkorrxBCCCGEEMJsGAwGGjRogK2tbYFs5QZJunOVlZWVJMFCCCGEEEIIkQWDwYCfnx86na5AtnKDJN2vtVWrVuXJdYcPH87w4cPz5NpCCCGEEEKI/OHQoUOcOHGCBg0a4OLiktfh5BpJuoUQQgghhBBCvFI6nY7Nmzfj7OyMtbV1gW3lBlkyTAghhBBCCCHEK3b48GHu379PnTp1CuxY7nSSdAshhBBCCCGEeGV0Oh1btmyhfPnylChRokC3coMk3UIIIYQQQgghXqGrV68SFRX1WrRyg4zpFkIIIYQQQgjxCpUqVYqRI0dib29f4Fu5QZJuIYQQQgghhBCvyL1799BoNGg0GmxsbPI6nFdCku5cpNPp0Ov1r+x6arUaCwuLV3Y9IYQQQgghhMgunU7H7NmzKVGiBG3atHktWrlBku5co9PpiIiIQKvVvrJrajQavLy8cizx9vX1zXT7xx9/zDvvvANAkyZNuH37ttH+Dz/8kMGDB7/UtbVaLYsXL2bz5s3cv3+fUqVK8dFHH9GgQQOjcj/88ANLly4lMjISPz8/xo8fT9myZV/q2kIIIYQQQoicd/DgQSIjI2nTps1r08oNknTnGr1ej1arRa1WY2mZ+29zWloaWq0WvV6fY0n3/v37jV7v3buXcePG0bJlS6PtI0aMoFu3bspre3v7l772nDlz2Lp1K1OnTqV06dLs27ePYcOGsXbtWipWrAhAWFgYoaGhTJo0iSpVqrBixQreeecdNm7ciJ2d3UvHIIQQQgghhMgZaWlpbN26FT8/v9dixvKnSdKdyywtLV9J0g2QmppqUvm+fftSrlw5ALZs2YKlpSU9e/Zk5MiRqFQqPDw8jMrv3r2b2rVrU6JECaPt9vb2Gco+y7x589i1axc9e/Zk4cKFPH78mEaNGjF16lQcHR2VeIYMGULDhg0B6NWrFwcPHuT7779n5syZACxbtoxu3brRtWtXACZNmsSff/7Jli1beP/99016L4QQQgghhBC5J72Vu23btq9VKzfIkmGvvU2bNmFhYcH69esZN24cy5cvZ/369RnKRUVF8ddff/HGG29k2LdkyRJq165Np06d+O6770hLS3vudW/evMmOHTtYtGgR3333HeHh4UycOFHZr9VqsbKyMjrG2tqaf/75B3jygOHcuXPUrVtX2a9WqwkKCuL06dPZvX0hhBBCCCHEK2BnZ0edOnXw8vJ6rVq5QVq6X3tFixZl7NixqFQqSpcuzcWLF1m+fLlRd3F4kpzb29vTokULo+19+/alYsWKODs7c+LECWbPnk1kZCRjxox55nVTUlKYMWMGhQsXBmD8+PG8++67hISE4OHhQXBwMMuXL6dmzZp4e3tz8OBBfv/9d3Q6HQCPHj1Cp9Ph5uZmdF53d3euXLnysm+LEEIIIYQQIgeVKVMGOzu7166VG6Sl+7VXpUoVoydNVatW5caNG0pym+7nn3+mffv2WFtbG20fMGAAtWvXxs/Pj549e/Lpp5+yevVqpat7YGCg8vPZZ58pxxUtWlRJuNPL6fV6rl27BsC4cePw8fGhdevWVK5cmcmTJ9OlSxfUavnICiGEEEIIYS7S0tJYuXIlV65cwcrK6rVr5QZp6RbZcOzYMa5du8acOXOeW7ZKlSqkpaURERFB6dKl2bx5s7LPwcEh29d0dXXlm2++ISUlhcePH+Pp6cnMmTOV8eSFChXCwsKC6Ohoo+OioqIytH4LIYQQQggh8sbff//NH3/8QcmSJSlSpEheh5MnpNnwNfff8c+nTp3Cx8fHaAb0DRs2UKlSJfz8/J57vvDwcNRqtZL4+vj4KD9PJ8N3797l/v37yuuTJ0+iVqspVaqU0fmsra0pXLgwaWlp/PbbbzRt2hQAKysrKlWqxMGDB5Wyer2eQ4cOERAQYMI7IIQQQgghhMgNaWlpbNu2jQoVKlC8ePHXspUbpKX7tXfnzh1CQ0Pp3r07//77L6tXr+bTTz9V9sfHx7Nz506jbelOnDjBqVOnqFOnDvb29pw4cYLQ0FA6dOiAs7PzM69rbW1NSEgIn376KfHx8UydOpXWrVsrs6CfOnWK+/fvU6FCBe7fv8+8efPQ6/XK+uDwpGv7p59+SuXKlQkICGDFihUkJSXRoUOHHHp3hBBCCCGEEC/q77//5uHDh3To0OG1HMudTpLuXJadmbzz8jqdOnUiOTmZN998EwsLC/r160f37t2V/b/88gsGg4F27dplONbKyoqwsDDmz59PamoqXl5evPXWWwwYMOC51/X29qZ58+YMGjSImJgYGjVqxIQJE5T9KSkpzJkzh1u3bmFnZ0fDhg2ZMWMGTk5OSpk2bdrw8OFD5s6dS2RkJBUqVGDJkiXSvVwIIYQQQog8ZjAY2LFjx2vfyg2SdOcatVqNRqNBq9WavH72i9JoNCZPNGZpacm4ceOYNGlSpvu7d+9ulIQ/rVKlSvz0008mx5muV69e9OrVK9N9tWrVIiws7Lnn6NOnD3369FFeGwwGEhMTXzgmIYQQQgghxMtTqVQMGjSIyMjI17qVG/I46T569ChLly7l7NmzREZGsmDBApo1a6bs9/X1zfS4jz/+WOlm3KRJE27fvm20/8MPP2Tw4MHK6/PnzzN58mTOnDmDq6srffr0YdCgQblwR//HwsICLy8v9Hp9rl7naWq12mgsthBCCCGEEEK8amlpaaSmpqJSqfDw8HitW7khj5PuxMREfH196dq1K8OGDcuwf//+/Uav9+7dy7hx42jZsqXR9hEjRhitK21vb6/8Oz4+noEDBxIUFMSkSZO4ePEiY8eOxcnJKcsW3JxiYWEhSbAQQgghhBDitbJv3z62bNnCW2+9pczZ9DrL06S7YcOGNGzYMMv9/62g3bt3U7t2bWXZqHT29vZZVubWrVvRarVMmzYNKysrypUrR3h4OMuWLcv1pDu/W7VqVZ5cd/jw4QwfPjxPri2EEEIIIYTIPWlpaWzfvh0vLy8cHR1f+1ZueMGk+86dO9y5c4ekpCRcXV0pV64cVlZWOR2bkaioKP766y+mT5+eYd+SJUtYuHAhRYsWpV27drz11ltYWj65tZMnT1KjRg2j+IKDg1myZAkxMTHPnWX7aTqdLtNtBoNB+RF5K70OXoe6SP/M6XS6TD+b5iA9bnON/3Uj9WV+pM7Mi9SXeZH6Mj9SZ6/GX3/9xaNHj+jQoQNWVlYvPNz26frKz4l7dno2ZzvpjoiI4McffyQsLIx79+4ZJTUajYYaNWrQrVs3WrZsafJkXtmxadMm7O3tadGihdH2vn37UrFiRZydnTlx4gSzZ88mMjKSMWPGAE+SdS8vL6Nj3N3dlX2mJN1nzpzJdLulpSVJSUmvdPy2eLakpKS8DiHXpaSkoNVqOX/+fF6H8tKy+m6J/Enqy/xInZkXqS/zIvVlfqTOco9Op2Pz5s2UKFGCpKQkLl68+MLn0mq1qFQqzpw5k6+T7urVqz+3TLaS7qlTp7Jp0yaCg4MZOXIkAQEBeHp6YmNjQ0xMDBcvXuT48ePMnTuXBQsWMG3aNAICAl76Bp72888/0759e6ytrY22P708lZ+fHxqNhgkTJvDhhx/meOu7v79/hicZycnJ3LhxA1tb29d+Vr78wGAwkJSUhK2tbb7+cuaE9Bnyy5Yta7afPZ1Ox5kzZzL9bon8R+rL/EidmRepL/Mi9WV+pM5yX2RkJE5OTjRt2pRSpUq91N/jiYmJXLt2DX9/f6UXs7nKVvS2trbs2rWLQoUKZdjn5uZGUFAQQUFBDBs2jL1793Lv3r0cTbqPHTvGtWvXmDNnznPLVqlShbS0NCIiIihdujTu7u5ERUUZlUl/nd7inV2ZTYxmYWGBSqVSfkT+8DrUR/o9FoQJ+wrCPbxOpL7Mj9SZeZH6Mi9SX+ZH6iz3uLm58fbbbyt/o76M9OMLQn1lK+n+8MMPs33CBg0avHAwWdmwYQOVKlXCz8/vuWXDw8NRq9W4ubkBULVqVebMmYNWq0Wj0QBw4MABSpUqZVLXciGEEEIIIYQQmTt16hQAVlZWODk55XE0+YvJg6/nzp2bYV3sF5WQkEB4eDjh4eHAk3Hj4eHh3LlzRykTHx/Pzp07efPNNzMcf+LECZYvX8758+e5desWW7duJTQ0lA4dOigJdfv27dFoNIwbN45Lly4RFhbGypUrjbqlCyGEEEIIIYR4MVqtluXLl7Nr1y6sra0LfI9TU5mcdO/evZvmzZvTv39/tm3bRmpq6gtf/OzZs3Tq1IlOnToBEBoaSqdOnZg7d65S5pdffsFgMNCuXbsMx1tZWREWFkafPn1o27YtixYt4q233mLKlClKGUdHR5YuXUpERARdunRh+vTpDB069LVfLuxVOHz4ML6+vsTGxgKwceNGatSokcdRCSGEEEIIIXLSX3/9RUxMDHXq1MkwB5d4gSXDtmzZwr///svGjRv5/PPPmTx5Mm3atKFr164mj+OuXbs2Fy5ceGaZ7t27Z5kgV6pUiZ9++um51/Hz82PNmjUmxZYX0id3iI6Oxs3NLdcneQgJCWHTpk10796dyZMnG+2bNGkSa9asoXPnzpku0/Yi2rRp88x12YUQQgghhBDmRavV8ssvv1C5cmWKFi0qrdyZeKFp4CpWrEjFihX59NNP+eOPP9i4cSO9evWiVKlSvPHGG3Tp0gVHR8ecjrVA27t3L/PnzycyMlLZ5uHhwbBhw3JlnHy6okWLEhYWxtixY5UZsFNSUti+fTvFihXL0WvZ2NiY7SzbQgghhBBCiIzSW7nfeOMNaeXOwkstqG0wGEhLS0Or1WIwGHB2duaHH36gYcOGhIWF5VSMBd7evXuZMGGCUcINT6bcnzBhAnv37s21a1esWJGiRYvy22+/Kdt+++03ihYtSoUKFZRter2exYsX06RJEwICAujQoQM7d+40Otdff/1Fy5YtCQgIoG/fvhnG/v+3e/nNmzcZMmQIdevWJTAwkK5du3LgwAGjY5o0acKiRYsYM2YMgYGBNGrUiHXr1uXkWyCEEEIIIYR4QYGBgXTq1ElauZ/hhZLus2fPMnnyZOrXr8+0adOoUKECYWFhrF69mt9++43Ro0czderUnI61QNLpdMyfP/+ZZebPn49Op8u1GLp27crGjRuV1z///DNdunQxKrN48WI2b97MpEmT+OWXX3jrrbf4+OOPOXLkCAB3795l2LBhNG7cmM2bN/Pmm28ya9asZ143MTGRhg0bsnz5cjZt2kT9+vV57733jCbSA1i2bBmVK1dm8+bN9OrVi4kTJ3L16tUcunshhBBCCCHEizAYDACUK1dOWrmfweTu5e3bt+fq1avUq1ePzz//nMaNG2cYd9y2bVs+//zzHAvSHP35558sW7aMxMTEZ5ZLTU1VJhrLSmRkJF26dMHKyuqZ5ezs7Hj77bdNHjfdoUMHZs2apbRM//PPP8yePVtJqFNTU1m8eDHLli0jMDAQgBIlSnD8+HHWrVtHrVq1+PHHH/H29iYkJASA0qVLc/HiRZYsWZLldf38/IyWgRs1ahS7du1iz5499OnTR9neoEEDevfuDcCgQYNYvnw5hw8fpnTp0ibdpxBCCCGEECJnpKamKg2x5cqVk1buZzA56W7VqhVvvPEGhQsXzrKMq6sr58+ff6nAzN26deu4efNmjp3veYl5urVr15qcdLu6utKoUSM2bdqEwWCgUaNGuLq6Kvtv3LhBUlISb7/9ttFxWq1W6YJ+5cqVDBPpVa1a9ZnXTUhIYP78+fz5559ERkai0+lITk7O0NLt6+ur/FulUuHu7k50dLRJ9yiEEEIIIYTIOX/++Sd3797F0dFRWrmfw+Sk+/3338+NOAqcHj168P333+dISzeAk5NTtlq6e/ToYVKc6bp27arMYD5hwgSjfen3sHjx4gwPW54X07N88cUXHDhwgE8//RRvb29sbGwYMWIEWq3WqJylpfHHVKVSKV1ZhBBCCCGEEK9WamqqMmN5kSJFpJX7OV5o9vJ79+6xe/du7t69myFBGjNmTI4EZu4aNmyYrRZnnU5Hz549M0yi9jQPDw9+/PHHXF0+rH79+mi1WlQqFcHBwUb7ypQpg5WVFXfu3KFWrVqZHl+mTBn27NljtO3UqVPPvOaJEyfo3LkzzZs3B560fP938jUhhBBCCCFE/vLnn38SHx9P7dq1pZU7G0xOug8ePMiQIUMoUaIEV69epVy5cty+fRuDwUDFihVzI8YCzcLCgmHDhmVoXX7asGHDcjXhTo9jx44dyr+f5uDgwNtvv01oaCgGg4Hq1asTFxfHP//8g4ODA507d1Za9r/44gvefPNNzp07x6ZNm555TR8fH37//XeaNGmCSqVizpw56PX6XLtHIYQQQgghxMsLDw/H399fWrmzyeSke9asWbz99tuMGDGCwMBA5s2bh6urKx999BH169fPjRgLvAYNGjBp0qQ8Waf7aQ4ODlnuGzVqFK6urixevJiIiAgcHR2pWLEi7733HgDFihVj3rx5hIaGsnr1agICAhg9ejRjx47N8pwhISGMHTuWHj16UKhQIQYNGkRCQkKO35cQQgghhMjfoqOjiYuLy3K/o6Mjbm5urzAi8Sy9e/fmzp070sqdTSqDiYNjAwMD2bJlC97e3tSsWZM1a9ZQrlw5zp8/z9ChQzN0MS4IdDodJ0+epGrVqhlagZOTk7l27RqlSpXCxsbmpa9z5swZoqOjcXNzw9/fP9dbuAsag8FAYmIidnZ2Bf6pW05+9vLKs75bIv+R+jI/UmfmRerLvEh95Zzo6GjGjBmTYdjq0zQaDaGhoS+VeEudvbyUlBSuXLmCtbU1KpUqV/8GTUpK4vLlyzRt2jTDHE/mxuR1uu3s7JQvhIeHh9EM3Y8ePcq5yF5DFhYWVK1alaZNm8ovAyGEEEII8VqIi4t7ZsINT1bNeVZLuHg1/vzzT2bNmkV0dLS0cpvA5EcGVapU4fjx45QpU4aGDRvyxRdfcPHiRX7//XeqVKmSGzEKIYQQQgghhMhDKSkp/PLLLwQEBODu7l7ge5XmJJOT7jFjxijjbocPH05CQgJhYWGULFmSkJCQHA9QCCGEEEIIIUTe+uOPP0hISJAZy1+AyUl3iRIllH/b2dkpazsLIYQQQgghhCh4UlJSCAsLo0qVKnh6ekort4nMe0S6EEIIIYQQQohcZTAYqF27NmXKlJFW7heQraS7Zs2a2X6aceTIkZcKSAghhBBCCCFE/qFWq6lTpw4qlUpauV9AtpLup9dafvz4MQsXLiQ4OJiqVasCcPLkSfbv38/QoUNzJUghhBBCCCFEwXTmzJm8DkE8w+7du4mMjKRKlSo4OTnldThmKVtJd+fOnZV/Dx8+nBEjRtCnTx9lW79+/Vi9ejUHDhzgrbfeyvEghRBCCCGEEAXPtm3b2LhxI2q1Gr1en2U5tVqNo6PjK4xMACQnJ7N582bKly+vrM0tTGfymO79+/fz0UcfZdhev359Zs2alSNBCSGEEEIIIQoug8HAzz//zC+//ELDhg2pVKlSlmWPHTvGkSNHOHToEG3btn2FUYrdu3eTlJRErVq1ZCz3S1CbeoCLiwu7d+/OsH337t24uLjkREyiAAgJCZHhBsDhw4fx9fUlNjYWgI0bN1KjRo08jkoIIYQQIm+tXbuWX375haZNmxIcHEzx4sWz/OnYsSO1a9dmw4YN7Nu3L69Df20kJyezY8cOqlSpgoeHh7RyvwSTW7qHDx/O+PHjOXLkCAEBAQCcPn2affv2MWXKlBwP8HUQHR1NXFxclvsdHR1xc3PL8evGx8fz9ddfs2vXLqKjo6lYsSJjx45V6hWePIWcO3cu69evJzY2lmrVqjFx4kRKliwJQEREBE2bNmXz5s1UqFAhx2M0J3379sXPz49x48Yp2wIDA9m/f790hxJCCCGEeIqtrS0tW7akZs2a2NraPrd8u3btSExMJDo6muTkZGxsbF5BlK+3EydOkJycLK3cOcDkpLtLly6UKVOGlStX8vvvvwNQunRp1qxZQ5UqVXI8wIIuOjqaMWPGoNVqsyyj0WgIDQ3N8cR7/PjxXLp0iRkzZuDp6cnWrVsZMGAAYWFhFC5cGIAlS5awatUqpk+fjpeXF19//TUDBw4kLCzMbL58Wq0WjUaTJ9e2srLCw8MjT64thBBCCJGf6HQ6zp49i4+PDxUqVECj0WQ7eVar1XTv3p34+Hju37+Pg4NDrjRKif9TvXp1NBoNbm5u0sr9krLdvfzgwYPodDoAqlSpwqxZs9i0aRObNm1i1qxZknC/oLi4uGcm3PAkaXxWS/iLSE5O5rfffuPjjz+mZs2a+Pj4MHz4cHx8fFizZg3wpJV75cqVDBkyhGbNmuHn58eMGTN48OABu3btAqBp06YAdOrUCV9fX/r27Wt0naVLlxIcHEzt2rWZNGnSM+913rx5dOzYkbVr19KwYUOqVKnCyJEjM9z7+vXrad26Nf7+/rRq1YoffvhB2RcREUG1atUICwujT58++Pv7s23bNgA2bNhA27ZtqVy5MsHBwUyePFk5LjY2lnHjxlGnTh2qVatGv379OH/+fIbYNm/eTJMmTahevTqjR48mPj4eeNKd/siRI6xcuRJfX198fX2JiIjI0L08M7t27aJz5874+/vTtGlT5s+fT1paWtaVJ4QQQghhZrRaLd988w3z5s3jwoULJiXc6VQqFQ4ODvz9999MnDiRu3fv5lK0IioqipiYGOzt7c2moS0/y3bSPX78eIKCgvjwww8JCwtTkg1hntLS0tDpdBm+RNbW1vzzzz/AkwQ2MjKSunXrKvsdHR2pUqUKJ06cAJ4kwADLly9n//79zJs3Tyl7+PBhbt68yYoVK5g+fbrykOZZbt68yY4dO1i0aBHfffcd4eHhTJw4Udm/detWvv76a0aPHk1YWBgffPABc+fOzXDeWbNm0a9fP8LCwggODmbNmjVMnjyZbt26sW3bNr755hu8vb2V8iNHjiQ6OpolS5awceNGKlWqRP/+/Xn8+LFRbLt372bRokUsXryYo0ePsmTJEgDGjRtHYGAg3bp1Y//+/ezfv5+iRYs+rxo4duwYn376qRLr5MmT2bhxI4sWLXrusUIIIYQQ5iA1NZW5c+dy+vRpOnXqhKen5wt3D1epVEoL7KxZs3j06FEORyuSkpKYOHEiO3fulG78OSTbSffu3btZuXIlZcqU4fvvv6du3boMGDCAVatWcefOndyM0Ww9fvyY69evG/1ERkYCT572Xb9+PdtP6O7evas86IiNjc1w3nv37pkUm4ODA4GBgXzzzTfcv38fnU7Hli1bOHnyJA8ePABQYv1v1x03NzeioqIAcHV1BZ5MsOfh4WE0mZ6zszOfffYZZcqUoXHjxjRs2JCDBw8+M66UlBRmzJhBhQoVqFmzJuPHjycsLEyJZd68eYSEhNCiRQtKlChBixYt6N+/P+vWrTM6T//+/ZUynp6eLFy4kAEDBtC/f39KlSpFQECAsrzdsWPHOH36NHPnzsXf35+SJUvy6aef4uTkxK+//qqc02AwEBoaSvny5alRowYdOnRQ7sfR0VF5Yuvh4YGHhwcWFhbPrYf58+czePBgOnfuTIkSJahXrx4jR45k7dq1zz1WCCGEECK/S05O5quvvuLChQt07dqVypUrv3TLqaOjIwMGDCA5OZlZs2aRkJCQQ9EKeJL3JScn4+vrK63cOcSkMd1+fn74+fkxdOhQ7t+/z549e9izZw9ffvklpUqVokmTJjRp0gR/f/9sne/o0aMsXbqUs2fPEhkZyYIFC2jWrJmyPyQkJEMLZnBwMEuXLlVeP378mClTpvDHH3+gVqtp0aIF48aNw97eXilz/vx5Jk+ezJkzZ3B1daVPnz4MGjTIlFt/IX/++Sdbtmwx2lanTh3effddHj58yKRJk7J9rm+//ZZBgwZRt25djh49yurVq432V6pUKdOl3J5lxowZjB07lgYNGmBhYUHFihVp27Yt586dM+k8WSlbtqxR4unh4cHFixefeUzRokWV8eTwZCIyvV7PtWvXsLe35+bNm4wbN47//e9/Spm0tLQME5VVrlxZ+Xd0dDQPHjwgKCgo02teuHCBxMREateubbQ9OTmZmzdvKq+LFy+Og4OD8trT05Po6Ohn3s/znD9/nn/++ceoZVun05GSkkJSUlK2JhYRQgghhMivdDodaWlpvPnmm5QrVw4rK6scOa+bmxt9+/bl+++/Z8OGDfTr10/GHeeApKQkduzYQWBgoMxLlINMnkgtXeHChenZsyc9e/YkMTGRvXv3smfPHt555x0GDBjAe++999xzJCYm4uvrS9euXRk2bFimZerXr09oaKjy+r9f1I8++ojIyEiWLVuGVqtl7NixfPbZZ8qa4fHx8QwcOJCgoCAmTZrExYsXGTt2LE5OTnTv3v1Fbz9bGjVqRNWqVY22pT8McHV1ZcKECdy9e5dvv/32uecaPHiw8jCjZs2alClTxmj/i3T98Pb2ZvXq1SQmJhIfH4+npyejRo2iRIkSAMoXLTo6Gk9PT+W46Oho/Pz8nnt+S0vjj5dKpcJgMJgcZ7rExEQApkyZkmEOAbXauNPG08nq857QJSQk4OHhwapVqzLsezqZ/+/9AC91P/DknoYPH06LFi0y7JMni0IIIYQwV3FxcSQmJqJSqejcuTP29vY5PrFtiRIlGDBgAA4ODjx8+BBXV1dJvF/Srl27SE1NpWbNmvK3aA564aT7aWlpabRq1YpWrVqh0+mIiYnJ1nENGzakYcOGzyzzrNmfr1y5wr59+9iwYYOSkI4fP57BgwfzySefULhwYbZu3YpWq2XatGlYWVlRrlw5wsPDWbZsWa4n3S4uLlmuXa7RaJRlt7KjaNGiSiurk5MTTk5OORDhE3Z2dtjZ2RETE8P+/fv5+OOPAfDy8sLDw4ODBw8qy4HFx8dz6tQpevbsqdwHoEyy97Lu3r3L/fv3ldbukydPolarKVWqFO7u7nh6enLr1i06dOiQ7XM6ODhQvHhxDh48SJ06dTLsr1SpElFRUVhYWODl5fXCsWs0GvR6vUnHVKxYkWvXruHj4/PC1xVCCCGEyE8eP37Ml19+iVqtpmfPnjg4OGTaeJETvL29SU1N5ezZs9y7d49u3bpJ4v0SrKysCAoKklbuHJbtMd3pvv32W8LCwpTXI0eOpFatWjRo0IDz589jYWGhjPPNCUeOHCEoKIiWLVsyYcIEo8kSTpw4gZOTk1F39rp166JWqzl9+jTwJGmrUaOGUQt5cHAw165dy/bDgYJq37597N27l1u3bvH333/Tr18/SpcuTZcuXYAnLdP9+vVj4cKF7N69mwsXLvDJJ5/g6empDANwc3PDxsaGffv2ERUV9dKzrFtbWxMSEsL58+c5duwYU6dOpXXr1soXf8SIEXz77besXLmSa9euceHCBX7++WeWLVv2zPMOHz6cZcuWsXLlSq5fv865c+eUlu26detStWpV3n//ffbv309ERAT//PMPX331FWfOnMl27MWLF+fUqVNERETw8OHDbCXg77//Plu2bGH+/PlcunSJK1eu8Msvv/DVV19l+7pCCCGEEPlFdHQ006dPJz4+npYtW+Zqwp3OysqKBw8esHPnzgxDO4VpqlevTlBQkLRy5zCTvwFr165l5syZAPz9998cOHCA7777jh07djBjxgy+//77HAuufv36NG/eHC8vL27dusXs2bMZNGgQ69atw8LCgqioqAwJvqWlJc7OzsrEW1FRURlaL93d3ZV9zs7O2Y4ns9ZcnU6HwWBQfkzl4OCARqN57jrdDg4OL92V+b/i4uKYPXs29+7dw8XFhebNmzN69GgsLS2Va73zzjskJSXx2WefERsbS/Xq1VmyZAlWVlYYDAYsLCwYN24c33zzDXPnzqV69eqsWrVKOf6/MT/rfTIYDHh7e9O8eXMGDRpETEwMjRo14rPPPlOOeeONN7C2tub7779nxowZ2NnZUa5cOfr372903v9ep1OnTiQnJ7NixQpmzJiBi4sLLVu2VMosXryYOXPmMGbMGB49eoS7uzs1atTAzc3N6FzPup8BAwYQEhJC27ZtSU5OZteuXUbHZXae4OBgFi5cyDfffMOSJUuwtLSkdOnSvPHGG8+t7/Tz6XS6HOtp8Kqlx22u8b9upL7Mj9SZeZH6Mi9SXxk9ePCAWbNmodPp6NatG15eXqjVapN7Ar6IoKAgHj9+zJYtW3BwcKBx48YZykidZS0xMZHt27dToUIFHB0dX0mdPc/T9ZWfey9kZ/JklcHETC4gIIBff/2VokWLMnXqVFJTU5k8eTLXrl2jW7duHD169IWC9fX1zTCR2n/dunWLZs2asXz5coKCgli0aBGbNm0ymmEannzphg8fTq9evXj77bfx8vIyWpP58uXLtG3blrCwsAxjozOj0+k4efJklvstLS0pUaLECz8Revjw4TNnXbS3t8/R3gP51aJFi/jzzz9l5u5sSklJ4datW7KmtxBCCCHyhevXr7N//36CgoIoVKhQhjl3cpvBYODAgQNcv36dli1bUrZs2Vd6fXN25MgRjh07RqtWrfJN3qHValGpVLi5ueXrpLt69erPLWNyS7eTkxN3796laNGi7Nu3j1GjRgEoLW65qUSJEhQqVIgbN24QFBSEu7s7Dx8+NCqTlpZGTEyM0h3Z3d1dWd4qXfrr9Bbv7PL398/wJCM5OZkbN25ga2v7wuvY2dnZvdBxBY1Go0GtVr/U+2EwGJRZv/PzlzMnqNVqNBoNZcuWNds1FHU6HWfOnMn0uyXyH6kv8yN1Zl6kvsyL1Nf/iYyMxMnJCU9PT8qVK4eLi8srT7jTlStXjg0bNlC0aFEqVKhg1CgmdZa5xMREli5dSrVq1ahWrVq+6VqemJjItWvX8Pf3z/UhCrnN5OhbtGjBRx99hI+PD48fP6ZBgwYAhIeH5/pkUPfu3ePx48dKQh0YGEhsbCxnz55Vlog6dOgQer2egIAAAKpWrcqcOXPQarXKpF8HDhygVKlSJnUthyddB/77BbWwsEClUik/4sWlv3858T6+DvWRfo+ZfS7NTUG4h9eJ1Jf5kTozL1Jf5uV1r68rV64we/ZsgoODqVq1Kq6urnmWcMOTRokePXoQFxfHgwcPsLW1NVqOFqTO/mv37t1otVpq1aqVr5arTa+jglBfJn8jxowZQ+/evSlTpgzLli1TlsCKjIykV69eJp0rISGB8PBwwsPDAYiIiCA8PJw7d+6QkJDAF198wcmTJ4mIiODgwYMMHToUHx8f6tevD0CZMmWoX78+//vf/zh9+jTHjx9nypQptG3bVvlytW/fHo1Gw7hx47h06RJhYWGsXLmSAQMGmHrrIpcNHz5cJr8QQgghhDATFy5c4Msvv8Td3V0ZC5yXCXc6lUqFg4MD27ZtY/r06URHR+d1SPlWSkoKv//+O9WqVTO5F7DIPpNbujUaDQMHDsyw/a233jL54mfPnqVfv37K6/T1uDt37szEiRO5ePEimzdvJi4uDk9PT+rVq8fIkSONZiKfOXMmU6ZMoX///qjValq0aMH48eOV/Y6OjixdupTJkyfTpUsXChUqxNChQ3N9uTAhhBBCCCEKqrNnzzJ37ly8vLzo2LEjbm5u+SLhTqdWq2nSpAmXLl1i5syZjBs3Ll+14uYX1tbWDBo0iLS0tHzTrbwgeqHO8devX+fw4cNER0dnmNlu2LBh2T5P7dq1uXDhQpb7ly5d+txzuLi4MGvWrGeW8fPzY82aNdmOSwghhBBCCJG1AwcOULJkSdq3b4+rq2u+HNZXqFAh+vfvz3fffcfs2bP5+OOP8zqkfEWr1ZKWlpZveigUZCYn3T/99BMTJ06kUKFCuLu7G33BVCqVSUm3EEIIIYQQwnzEx8djYWFB06ZNSUlJwdnZOV8m3OmKFi1K7969WbFiBbt376ZIkSJ5HVK+sX37dk6ePEn37t1xcXHJ63AKNJOT7oULFzJq1CgGDx6cG/EIIYQQQggh8qH9+/fzww8/MGDAAJydnfN9wp2udOnSvPfee9jY2Mj47v8vISGB3377jSpVqki3+1fA5H4EMTExtG7dOjdiEUIIIYQQQuRDe/bsYenSpVSsWBEnJyccHBzMIuFOV7RoUWxsbPj333/ZuHFjXoeT53777Td0Oh01atSQsdyvgMkt3a1atWL//v307NkzN+IRQgghhBBC5CM7duzgp59+onbt2jRu3BhHR8e8DumFWFtbk5CQwOHDh3FycqJly5Z5HdIrER0dTVxcnPI6KSmJnTt34ufnh1ar5fHjx9K9PJeZnHT7+Pjw9ddfc+rUKcqXL59hofKnZyMX5iMkJITp06fndRgm2bhxI9OmTePYsWOv9Lrz5s1j165dL7W82eHDh+nXrx9Hjx7Fyckp0zJ5dX9CCCGEEOni4+PZsWMHwcHB1K9fHwcHh7wO6aVUqVIFKysr1q1bh5OTE0FBQXkdUq6Kjo5mzJgxaLXaDPvOnDnDmTNnsLS0ZPTo0ZJ45yKTk+5169ZhZ2fHkSNHOHLkiNE+lUolSXcB89tvv7F27VrOnTvH48eP2bx5MxUqVDAqk5KSwvTp0wkLCyM1NZXg4GAmTJigrPUXERFB06ZNUavV/Pnnn8oa6gAPHjygUaNG6HQ6du/ejZeXV6ZxNGnShH79+r3Q0nRCCCGEEMI0BoOBtLQ0DAYDAwcOxN7eHjs7u7wO66WpVCo6duxIYmIiS5cuxcnJiUqVKuV1WLkmLi4u04T7aWlpaSQkJEjSnYtMTrr37NmTG3GIPPDw4UO++OILDh8+TFRUFMePH6dChQrMnDlTWQs9MTGRatWq0bp1a6P1z582bdo0/vrrL+bMmYOjoyNTpkxh2LBhrF271qhc4cKF2bx5M++++66ybfPmzRQuXJg7d+7k3o0+JTU11WiddyGEEEIIYUyv1/PDDz9w69YtunbtWmAS7nRqtZoePXqwZcsW9Hq9/H0oct1LLchmMBgwGAw5FYt4xUJDQzl58iQzZsygYcOGTJkyhRIlShjVaadOnRg2bFiWXW/i4uL4+eefCQkJISgoiMqVKzNt2jROnDjByZMnjcp26tQpw8QVP//8M506dXpmnH379uX27duEhobi6+uLr6+v0f59+/bRunVrAgMDeeedd4iMjFT2hYSEMHToUBYuXEhwcDCtWrUC4O7du4wcOZIaNWpQq1YthgwZQkREhHLc4cOHeeONN6hatSo1atSgR48e3L592+i6mzdvpkmTJlSvXp3Ro0cTHx+v7EtNTWXq1KkEBQXh7+9Pz549OX369DPvc+PGjTRq1IgqVarw/vvv8/jx42eWF0IIIYTIaXq9nmXLlvHHH39QtmxZLC0tC1TCnU6j0dC1a1csLS25du0a9+/fz+uQRAH2Qkn35s2bad++PQEBAQQEBNC+fXs2b96cw6GZv4SEBBISEoyS2NTUVBISEkhJScm0rF6vV7ZptVoSEhJITk7OVllThYeH06lTJ2rVqoWjoyN16tTh448/NmkGw7Nnz6LVaqlbt66yrUyZMhQrVixD0t2kSRNiYmKUMcrHjh0jNjaWxo0bP/Ma8+bNo0iRIowYMYL9+/ezf/9+ZV9ycjLff/89M2bMYPXq1dy9e5c5c+YYHX/w4EGuXbvGsmXLWLx4MVqtVukm9cMPP/Djjz9iZ2fHO++8Q2pqKmlpabz//vvUrFmTrVu3sm7dOrp37240Q+fNmzfZvXs3ixYtYvHixRw9epQlS5Yo+2fMmMGvv/7K9OnT2bRpEz4+PrzzzjtZJtKnTp1i3Lhx9O7dm82bN1O7dm0WLlz4zPdFCCGEECInpaWlsXjxYg4cOEC7du2oUaNGgV5OSqVS4ejoyLp165g5cyYxMTF5HVKOS01NzesQBC+QdC9btoyJEyfSoEED5syZw5w5c6hfvz4TJ05k+fLluRCi+XJwcMDBwYGoqChl25dffomDgwPDhg0zKuvp6YmDgwM3b95Uti1YsAAHBwcGDhxoVLZkyZI4ODgQHh6ubHuR975atWps3LiRP/74w+Rj00VFRaHRaDJMBubm5mbU4gxPnih26NCBn3/+GXjSyt2hQwc0Gs0zr+Hi4oKFhQX29vZ4eHjg4eGh7NNqtUyaNAl/f38qVapE7969M8w1YGdnx9SpUylXrhzlypUjLCwMvV7P559/jq+vL2XKlCE0NJS7d+9y5MgR4uPjiYuLo3Hjxnh7e1OmTBk6d+5MsWLFlHMaDAZCQ0MpX748NWrUoEOHDhw8eBB40iV/7dq1fPLJJzRs2JCyZcsyZcoUrK2t2bBhQ6b3uHLlSurXr8+gQYMoVaoU/fr1Izg4+DnvvhBCCCFEzjlx4gTHjx+nY8eOBAYGYmNjk9ch5Tq1Wk2HDh1ITExk9uzZJCUl5XVIL02r1XL+/Hml67zIeyaP6V61ahUTJ0406hLctGlTypUrx7x582SiKzMSEhLC4sWLCQ0N5ebNm4SHh9OjR49cXQ6ua9eu9OjRgw8++ICdO3eybt06dDrdC5/P1tYWb29v5bWHhwcPHz40KlO+fHmjcTrnz5/n5s2bVKtWzahcSkoKN2/eJDg4mC5dujBw4EDq1atHUFAQrVu3xtPTUylbvHhxo9k7PT09iY6OBp60gmu1WqPzazQaAgICuHLlSqb3ceXKFZo1a2a0rWrVquzbty+7b4UQQgghxAvR6/WoVCpKly7N22+/TbFixV6rMc6enp707duX77//nnnz5jF69OjnNgrlR/fu3eOvv/5i//79JCQk8MEHHxg1/om8Y3LSHRkZSWBgYIbtgYGBGVo2X3fpY3yfHgfz8ccfM2rUqAxLrT148ADAqAvP+++/z6BBg7CwsDAqe/369QxlX+Rhh52dHaNHj2b06NEMHTqUBg0aEBoailqtpnv37tk6h7u7O1qtltjYWKPW7ujoaKMW6XS+vr6ULl2aDz74gDJlylC+fHmjFntT/fd9VKlUGeYZ+G+3qMTERCpVqsTMmTMznM/V1RV4Mt69b9++7Nu3jx07djBnzhyWLVtG1apVM70uIPMbCCGEEMLsJCUlMXfuXAICAihVqtRrl3Cn8/b2pkePHvz444+cOHGCmjVrGg0tzM8MBgNfffUVZ86cwdbWloCAACpXroyNjU2BHI9vjkzuXu7j48OOHTsybA8LC6NkyZI5EVOBYW9vj729vdEX1srKCnt7+wzjptPLqtX/VyUajQZ7e/sMXXuyKvsynJyc6NGjBw0aNDBpXejKlSuj0WiUrtUAV69e5c6dO0qC+l9du3blyJEjdO3aNdvX0Wg0RmPYX0alSpW4ceMGbm5u+Pj4GP04Ojoq5SpWrMi7777L2rVrKV++PNu3b8/W+b29vdFoNPzzzz/KNq1Wy5kzZyhbtmymx5QpUybDRGunTp16gbsTQgghhMiehIQEvvzyS65fv45Go8HW1va1TLjT+fn5MWLECJydnYmNjc3rcJ7p7t27rF+/ntjYWB4/fkzhwoVp374977//Pq1ataJ06dLY2dnh4OCQaWPR0ywtLbG3t39Fkb+eTG7pHj58OKNHj+bo0aNK99l//vmHQ4cOZZjASuRv06ZNo1mzZlSoUAGdTsehQ4c4cuQIQ4YMUco8fvyYu3fvKi3x165dA560cHt4eODo6EjXrl2ZPn06zs7OODg4MHXqVAIDA7NMurt160arVq0yjAN/luLFi3P06FHatm2LRqNRWqRfRPv27Vm6dClDhgxh5MiRypJlv//+O++88w5arZaffvqJJk2a4OnpybVr17h+/TodO3bM1vnt7Ozo2bMnM2bMwNnZmWLFivHdd9+RnJzMG2+8kekxffv2pWfPnixdupSmTZuyf/9+6VouhBBCiFwTGxvLzJkziY6Oplu3bpQuXdosu1TnNDc3N5KSkvjpp58oUqQI7du3z+uQFFqtluPHj/Pnn39y4cIF7Ozs8PT0xNPTk9q1a2NjY2PUKAdP5kYaPXo0CQkJWZ7X3t5e1ujOZSYn3S1btuSnn35i+fLl7N69G4DSpUuzfv16KlasmOMBitxTrFgxpk+fzvXr10lKSlJan/v27auU2bNnD2PGjFFejx49GoBhw4YxfPhwAMaOHYtarWbEiBGkpqYSHBzMhAkTsryupaWlyUnziBEj+Oyzz2jWrBmpqalcuHDBpOOfZmtry+rVq5k5cybDhg0jISGBwoULExQUhIODA8nJyVy9epVNmzbx+PFjPD096d27Nz169Mj2NT766CMMBgOffPIJCQkJVK5cme+++w5nZ+dMy1etWpUpU6Ywb9485s6dS1BQEEOGDOGbb7554fsUQgghxOstOjqauLi4TPdt2LCB6OhounfvTsmSJZ/bGvo6sbW1Ra/Xs3HjRpydnWnQoEFehwTA/PnzOX36ND4+PrRv3x5fX1/s7e2f2zvBxcVFkuo8pjLIQNTn0ul0nDx5kqpVq2YYX52cnMy1a9coVaqUWc/wGBISwvTp0/M6jJdmMBhITEzEzs7ObMbhvKiC8Nl71ndL5D9SX+ZH6sy8SH2Zl/xeX9HR0YwZM+aZy8paWFgwYsQI3N3dX2FkeUev13PhwgV8fX0ztAhnVnbdunX8+++/DBs2LNM5rXKTVqvl2LFj/PXXX7Rs2ZKiRYty6dIlVCoVRYoUybRVu6BJSkri8uXLNG3a1OwfCmUr+vj4eGWm5vTJwbLy9IzOQgghhBBCiFcvLi7umQk3PHlwkJKS8ooiMi9qtZo333yTFStWsGjRIkJCQihVqlSuX/fevXv8+eefygzkJUuWJDo6Gjs7O0qUKPFaj7k3Z9lKumvWrMn+/ftxc3OjRo0ambYgGgwGVCrVS81ELfJOQWjlFkIIIYQQIqdYWlrSu3dvfv/9d+BJ63NujHvXarVotVpsbGzYv38/+/fvx9/fn0qVKr02rdoFXbaS7hUrVihjUVeuXJmrAQkhhBBCCCFEfmBjY0Pbtm2Ji4vjzJkzlCxZ8qUm9H3anTt3+Ouvv/j777+pU6cOwcHBlC9fngoVKmRrrLYwH9lKumvVqpXpv4UQQgghhBD5Q1paGlevXuXcuXMkJibmdTgFhlqtxt7enqVLl2Jtbc3YsWNfaomty5cvs379ei5evIidnZ2yRnpaWhqurq7Sql0AZSvpPn/+fLZP6Ofn98LBCCGEEEIIIUxz/fp1Nm/ezIULF0hOTsbW1pYyZcrkdVgFiqWlJd26dWPp0qV8+eWX9OnTJ8vJvRwdHXFzczPadufOHRISEvD29iY+Pp7U1FQ6dOhAuXLlcHR0lOXaCrhsJd2dOnVCpVLxvInOZUy3EEIIIYQQuSc2NpZ///2Xc+fOUaxYMerVq8fjx495/PgxtWvXxtvbm2LFivHo0SPOnj2b1+EWKF5eXnTo0IENGzbw+eefZ1lOo9EQGhqKo6Mjx44d488//+TSpUuULVuW7t27Y21tTe/evWWs9mskW0l3+nrcQgghhBBCiFfv1KlT/Pzzz9y6dQsADw8PbG1tuX37NjY2NvTr1w+NRqMsX5bV+tzi5Xh6ej63jFar5dKlS6xatYrExERKliyptGprNBrs7OxeQaQiP8lW0l28ePHcjkMIIYQQQojXnl6vJyIignPnznHu3DmqVKlCzZo1iYuLw9nZGX9/f0qWLEmhQoWwsrLKsouzvb09lpaWpKWlZXktS0vLlxqbLLKmUqkIDAykQoUKFC5cWFq1X3M53tLdtGnTFw5GCCGEEEKI10360rt79uxh8+bNxMXFodFo8Pb2Jjk5mbt37+Lp6UnXrl3RaDSZLt/7Xy4uLowePZqEhIQsy9jb2+Pi4pKDdyLSJSUl0bx5cxmrLYBsJt3vv/9+tk4mY7rNV0hIiNmt1T1v3jx27drFli1bXul1Q0JCiI2N5Ztvvnnhc2zcuJFp06Zx7NixLMvk1f0JIYQQInelpKRw/vx5zp07x9mzZ2nVqhUVK1ZEr9dTuXJlvL29KVGiBLa2tlhZWb1wC6mLi4sk1XnE3t5eEm6hyPHZy01x9OhRli5dytmzZ4mMjGTBggU0a9YMeDIWYs6cOezdu5dbt27h4OBA3bp1+fDDDylcuLByjiZNmnD79m2j83744YcMHjzYKP7Jkydz5swZXF1d6dOnD4MGDcqVeypoQkJC2LRpk9G24OBgli5dqrx+/PgxU6ZM4Y8//kCtVtOiRQvGjRundFc6fPgw/fr1w8nJif3792Ntba0ce/r0ad58800ALly4kGUcvr6+Rp8PIYQQQohXLTo6WhkrrdfrefDgATdu3FCS4sxmrU4vC0+Wnlq3bh2///47Op0OZ2dnZamoqKgoSpUqRfny5bPsMi6EME95+o1OTEzE19eXrl27MmzYMKN9ycnJ/PvvvwwZMgQ/Pz9iY2P5/PPPGTJkCBs3bjQqO2LECLp166a8fnpsSnx8PAMHDiQoKIhJkyZx8eJFxo4di5OTE927d8/dG8znHj58yBdffMHhw4eJiori+PHjVKhQgZkzZ2JlZaWUq1+/PqGhocrrp/cBfPTRR0RGRrJs2TK0Wi1jx47ls88+Y9asWUbl7O3t+f3332nXrp2ybcOGDRQrVow7d+7k0l0aS01NzRC/EEIIIcTzREdHM2bMGLRabZZl0metdnNz48GDB8q47PDwcAYMGICXlxdOTk40adIEb29vPD09sbKyynaXcSGEecpW0r1y5UplevuVK1c+s2y/fv2yffGGDRvSsGHDTPc5OjqybNkyo23/+9//ePPNN7lz5w7FihVTttvb2+Ph4ZHpebZu3YpWq2XatGlYWVlRrlw5wsPDWbZs2WufdIeGhnL69GlmzJjBihUr6Nu3L/v27cuwNJyVlVWW7++VK1fYt28fGzZswN/fH4Dx48czePBgPvnkE6NeCZ06deLnn39Wku7k5GTCwsLo27fvM7tqN2nSBPi/YQ7Fixdnz549yv7Nmzczd+5cYmJiaNCgAWPGjFFmhezbty/lypXDwsKCrVu3Ur58eVatWsXFixeZMWMGx48fx9bWlnr16jFmzBhcXV0B2LlzJwsWLODGjRvY2tpSoUIFvvnmG6PZJpcuXao8aGjTpg1jx45VuhHFxMTw+eef88cff5CamkrNmjUZP348JUuWzPI+v/32W5YvX05SUhKtW7dWYhFCCCFE3ouLi3tmwg1PemrGxcWxevVqTp48iVqtpnjx4lSrVg2tVktMTAx+fn5oNBqZVEuI10i2ku7ly5fTvn17rK2tWb58eZblVCqVSUm3qeLj41GpVDg5ORltX7JkCQsXLqRo0aK0a9eOt956S+mWc/LkSWrUqGHUuhkcHMySJUuIiYnB2dk529fX6XSZbjMYDMrP05KSkgCwsbFRnl5qtVrS0tKwsLAwiim9rLW1tfJLOC0tDa1Wm+2ypnZFCg8Pp1OnTtSsWZOff/6Z2rVrU7t2bQDlXgwGA0eOHCEoKAgnJyfq1KnDyJEjKVSoEAAnTpzAycmJypUrK8cEBQWhVqs5deoUzZs3V7Z36NCBpUuXcvv2bYoVK8avv/5K8eLFqVixotE1/2v9+vXUrVuXadOmUb9+fSwsLJT3++bNm+zatYuFCxcSGxvLqFGjWLZsGR9//LFyzk2bNtGzZ0/WrFkDPEmI+/fvzxtvvMGYMWNITk5m5syZjBo1ihUrVvDgwQM+/PBDPvroI5o1a0ZCQgLHjx9Hr9cr1z18+DAeHh6sWLGCGzdu8MEHH+Dn56f0uAgJCeHGjRt88803ODg4MHPmTAYPHsz27dvRaDRG7y/Ajh07mDdvHp999hnVqlVj69atrFq1ihIlSmT5vqTHotPpMv1smoP0uM01/teN1Jf5kTozL1Jf+Vt6F/HnuXv3LqVLl6ZkyZJ4e3vj4OCAlZWVspSXqecTOScnvmO2trbZmhXe1tZW6vglPV1f+bknyH+/25nJVpb2dKvi0/9+lVJSUpg5cyZt27bFwcFB2d63b18qVqyIs7MzJ06cYPbs2URGRjJmzBgAoqKi8PLyMjqXu7u7ss+UpPvMmTOZbre0tCQpKSnDFyu9RfeHH35QrrNu3TpWrVpFixYtGDFihFK2a9eupKSksHTpUqV1eMuWLSxZsoSGDRsqSSRAr169iI2NZcGCBfj4+ABPWmZbtWqV7XsB8Pf3Z8OGDZQsWRKdTkdiYmKGMrVr16Zhw4YUK1aMiIgI5s+fzzvvvMPy5cuxsLDgzp07FCpUKMOxTk5O3Llzh8TERFJSUgCws7OjXr16/PTTTwwePJiffvqJ9u3bK/szuz48eWgBTx4ypA8dSExMRKvVotfr+eyzz5Ttbdq04ciRI8qDCb1ej7e3t9FkgN999x3ly5fnvffeU7b973//o3Xr1oSHh5OYmEhaWhrBwcG4urri6upKiRIllOvqdDocHR358MMPsbCwoEiRIgQHB7N//37atWvHzZs32bNnD8uWLVMeKEyePJk2bdoQFhZG8+bNSU1NxWAwKPe8bNkyOnbsSJs2bQAYPHgw+/fvJzU1Ncv3JSUlBa1Wm2tzLrxKWX23RP4k9WV+pM7Mi9RX/vTgwYNslbt27Rru7u6o1WoePnzIw4cPczkyYarLly+/1PHt27cnOTk5y/02Njbcv3+f+/fvv9R1XndarRaVSsWZM2fyddJdvXr155Yxi1katFotI0eOxGAwMGnSJKN9AwYMUP6d3l1nwoQJfPjhhzk+dtff3z/Dk4zk5GSlC3J6cvhftra2Srfk9O7HlpaWRl2V0z9IppS1sbFRtltZWRmVyY7x48ezePFivvrqK27evMmlS5fo0aMHPXr0UMp07txZ+XeVKlUICAigefPmnD17lqCgIGUM0n+vrVKplJjSJ06ztbXlzTffZNq0aXTt2pUzZ84wb948jh8/DvDc+K2trY3KaDQavLy8jLq+Fy1alEePHmFra4tKpUKtVuPv72903JUrVzh+/DjBwcEZrhEZGUm9evUICgqie/fuBAcHU69ePVq2bKk8OLGwsKB8+fI4OjoqxxUpUoSLFy9iZ2fHnTt3sLS0pFatWsrnxc7OjlKlShEREYGdnR1WVlZG79v169fp1auXUZzVq1fn8OHDWb4varUajUZD2bJls/zs5Xc6nY4zZ85k+t0S+Y/Ul/mROjMvUl/5240bN7JVrmzZskbDIEX+odPpuHz5MmXLlpXvmBlITEzk2rVr+Pv7m/3kgiZHbzAY2LlzJ4cPH+bhw4cZWnfnz5+fY8HBk4R71KhR3LlzhxUrVhi1cmemSpUqpKWlERERQenSpXF3dycqKsqoTPrr9Bbv7LKwsMjwBbWwsEClUik/TwsLCwOMu5f36NGDN954QzkuXfrkcNbW1sr2zp07065duwxlf/zxxwxlW7dubfITIHt7ez744AM++OADhg4dSoMGDQgNDUWtVmc53t3b25tChQpx8+ZN6tati4eHBw8fPjS6dlpaGjExMXh4eBi9LyqVioYNGzJhwgTGjRtH48aNcXV1Ndr/LP99j1UqFZaWlkbb1Go1er3eqE7SE/B0iYmJNG7cmI8++ijDNTw8PLC0tGTZsmX8888//P3336xevZo5c+bw008/UaJEiUyvq1KplDU2s4o3s+3ZLf+s9yOzz6W5KQj38DqR+jI/UmfmReorf8ruGOz0h/4i/7KwsJA6MgPpvwcLwu9Ekz9tn3/+OZ988onSYufo6Gj0k5PSE+4bN26wfPlyZRzxs4SHh6NWq5XlGqpWrcqxY8eMJr44cOAApUqVMqlr+YuwtbXNkPBpNBplzcXMyj79CyB9PEh2y74MJycnevToQYMGDZ65dvS9e/d4/Pix0rocGBhIbGwsZ8+eVcocOnQIvV5PQEBAhuMtLS3p2LEjR44coWvXrtmOT6PR5NgYt0qVKnHp0iWKFy+Oj4+P0U96q7JKpaJ69eqMGDGCzZs3o9Fo2LVrV7bOX6ZMGdLS0jh16pSy7dGjR1y7do2yZctmeczT5YEMr4UQQgiRd2SsvRDiRZmcqW3dupX58+dnOeu4KRISErh586byOiIigvDwcJydnfHw8GDEiBH8+++/LF68GJ1OR2RkJADOzs5YWVlx4sQJTp06RZ06dbC3t+fEiROEhobSoUMHJaFu3749CxYsYNy4cQwaNIhLly6xcuVKZcz362zatGk0a9aMChUqoNPpOHToEEeOHGHIkCHAk/qZP38+LVu2xN3dnVu3bvHll1/i4+ND/fr1gSfJYv369fnf//7HpEmT0Gq1TJkyhbZt2xrNXP60kSNHMnDgwGw9RElXvHhxDh48SLVq1bCysnqpBya9evXip59+4oMPPuCdd97BxcWFGzduEBYWxtSpUzl79iwHDx6kXr16uLm5cerUKR4+fEjp0qWzdf6SJUvStGlT5T1Jn0itcOHCNG3aNNNj+vXrR0hICJUrV6ZatWps27aNS5cuKWPJhRBCCJF30tLSWL9+fV6HIYQwUyYn3Q4ODhkmJntRZ8+eNZrtPH0t6M6dOzNs2DBl0raOHTsaHbdy5Upq166NlZUVYWFhzJ8/n9TUVLy8vHjrrbeMxnk7OjqydOlSJk+eTJcuXShUqBBDhw597ZcLAyhWrBjTp0/n+vXrJCUlKa3Pffv2BZ505bh48SKbN28mLi4OT09P6tWrx8iRI41a32fOnMmUKVPo378/arWaFi1aMH78+Cyva2VlZfJyWJ9++inTp09n/fr1FC5c+KUm9CtcuDA//vgjM2fOZODAgaSmplKsWDHq16+PWq3GwcGBo0ePsmLFCuLj4ylWrBghISEmPWgKDQ3l888/57333kOr1VKjRg2+/fZbZZz+f7Vp04abN2/y5ZdfkpKSQsuWLenZsyf79+9/4fsUQgghxMtLS0tj4cKFXLp0SRnGlhVLS0tlclchhEinMmS1HlEWNm3axL59+5g2bZrZTt5kKp1Ox8mTJ6latWqmE6ldu3aNUqVKmfX7ERISwvTp0/M6jJeWPiO4nZ1dvp7lMCcUhM/es75bIv+R+jI/UmfmReorf0pNTWX+/PmUL1+eEiVKkJqaCjz5m+P69euULFlS+ZvD3t4eFxeXPIxWPIter+fChQv4+vrKmG4zkJSUxOXLl2natOnrN5Fa69at2b59O0FBQXh5eWV4AzZt2pRjwQkhhBBCCJEX0tLSiIyMxMrKijZt2mBjY2PU00+v1xMXF0exYsUkgRNCPJPJSfenn37KuXPn6NChA+7u7gW+NfF1URBauYUQQgghckJaWhqLFy/m/PnzDBo0CCcnpxxfilYI8fowOen+66+/+O6776hRo0ZuxCOEEEIIIUSe0el0LF68mBMnTtCxY0ccHR0l4RZCvBST+8IUKVLkuWtlCyGEEEIIYW7SE+5//vmHjh07UrlyZaytrfM6LCGEmTM56Q4JCeHLL78kIiIiN+IxWybORyfES5PPnBBCCJGz7t+/z7///isJtxAiR5ncvfzjjz8mKSmJ5s2bY2Njk2EJpCNHjuRYcOYg/f4TExOxtbXN42jE6yQxMREgy2XIhBBCCJE9er0enU6HjY0NgwcPxtHRURJuIUSOMTnpHjt2bG7EYbYsLCxwcXHhwYMHAK/FUlX5mcFgICUlBbVaXWDrIX1ZtAcPHuDi4iLLygghhBAvQa/Xs2TJEhISEmjTpo0k3EKIHGdy0t25c+fciMOsFSlSBEBJvEXeMRgMaLVaNBpNgU2607m4uCifPSGEEEKYLj3hPnLkCB06dMDa2loSbiFEjjPvVcbzCZVKRdGiRfH09ESr1eZ1OK81nU7H+fPnKVu2bIFuAdZoNAX6/oQQQojcptfr+e6775SEOyAgQBJuIUSukKQ7B1lYWEgilMd0Oh0ANjY2UhdCCCGEyNKRI0c4fPgw7du3l4RbCJGrJOkWQgghhBCvFYPBgK+vL/369cPb21sSbiFErpKkWwghhBBCvBb0ej0rVqygdOnSFClShBIlSkjCLYTIdSav0y2EEEIIIYS50ev1LF++nH379hEdHY1Go8HGxiavwxJCvAZMaumOjo5Gq9UqMyanpaUxb948jh8/TuXKlRk5cqSsVS2EEEIIIfKV9IR7//79tG3blqpVq0rCLYR4ZUxq6R4/fjybNm1SXi9dupT169fj7+/Pnj17CA0NzfEAhRBCCCGEeBlbtmxREu7AwEBJuIUQr5RJSfeFCxeoXbu28nrLli2MHz+eTz/9lNmzZ7Nnz54cD1AIIYQQQoiXERgYSMeOHSXhFkLkiWx1Lx8zZgwADx48YPny5axfv57U1FSuXbvG77//zr59+zAYDDx8+FApK63eQgghhBAir+j1esLCwqhatSopKSn4+/tLwi2EyBPZSrrTE+ijR4/StWtXGjZsSFhYGBcvXuSrr74C4NGjR9LFXAghhBBC5DmDwcDq1av5888/0el0knALIfKUSROpNWrUiHHjxtGkSRN27drFO++8o+w7ffo0ZcqUyfEAhRBCCCGEyC6DwcCqVav4448/aN26tSTcQog8Z1LS/fHHH+Pg4MD58+d56623eOutt5R9p0+fpkePHjkdnxBCCCGEENm2Zs0a/vjjD9q0aUP16tUl4RZC5DmTkm5ra2tGjRqV6b7hw4fnRDxCCCGEEEK8MA8PD1q3bi0JtxAi3zAp6RZCCCGEECK/MRgMnD17Fm9vb0qWLImlpaUk3EKIfCNbS4YNHDiQkydPPrdcfHw83377LT/88MPLxiWEEEIIIcRzGQwGfvzxR2bPns3Jkycl4RZC5DvZaulu1aoVw4cPx9HRkcaNG1O5cmU8PT2xtrYmNjaWy5cvc/z4cfbu3UvDhg355JNPcjtuIYQQQgjxmjMYDKxdu5bff/+dli1b4uXlJQm3ECLfyVbS/eabb9KxY0d27NjBjh07+Omnn4iLiwNApVJRtmxZgoOD2bBhg8xgLoQQQgghcl16wv3bb7/RokULatasia2tbV6HJYQQGWR7TLeVlRUdO3akY8eOAMTFxZGcnIyLiwsajeaFLn706FGWLl3K2bNniYyMZMGCBTRr1kzZbzAYmDt3LuvXryc2NpZq1aoxceJESpYsqZR5/PgxU6ZM4Y8//kCtVtOiRQvGjRuHvb29Uub8+fNMnjyZM2fO4OrqSp8+fRg0aNALxSyEEEIIIfJeWloa165do0WLFtSqVUsSbiFEvpWtMd2ZcXR0xMPD44UTboDExER8fX2ZMGFCpvuXLFnCqlWrmDhxIj/99BO2trYMHDiQlJQUpcxHH33E5cuXWbZsGYsWLeLYsWN89tlnyv74+HgGDhxIsWLF2LhxI5988gnz589n3bp1Lxy3EEIIIYTIGwaDgZiYGJKSkujSpYsk3EKIfC9PZy9v2LAhDRs2zHSfwWBg5cqVDBkyRGn9njFjBnXr1mXXrl20bduWK1eusG/fPjZs2IC/vz8A48ePZ/DgwXzyyScULlyYrVu3otVqmTZtGlZWVpQrV47w8HCWLVtG9+7dX9m9CvMSHR2tDKHIjKOjI25ubq8wIiGEECL7Cur/YwaDgfXr17Nv3z4GDRqEvb29JNxCiHwv3y4ZFhERQWRkJHXr1lW2OTo6UqVKFU6cOEHbtm05ceIETk5OSsINULduXdRqNadPn6Z58+acPHmSGjVqYGVlpZQJDg5myZIlxMTE4OzsnO2YdDpdztycyDXpdfQydRUdHc24ceNIS0vLsoylpSWff/65Wf7Bkp/kRH2JV0fqy/xInZmXnKqvgvr/mMFgYOPGjezYsYOmTZtia2uLtbU1er0+T+KR75f5kTozL0/Xl0qlyuNosmZhYfHcMvk26Y6MjATI8J+Bm5sbUVFRAERFReHq6mq039LSEmdnZ+X4qKgovLy8jMq4u7sr+0xJus+cOWPaTYg88zJ19eDBg2f+oQJPxpEdP34cT0/PF76O+D/y3TIvUl/mR+rMvLxsfRXE/8cMBgOHDh3i+PHjVKlSBTc3N27evJnXYQFw+fLlvA5BmEjqzDxotVpUKhVnzpzJ10l39erVn1sm3ybd+ZG/v3+2nmSIvKPT6Thz5sxL1dWNGzeyVc7X1xcfH58XuoZ4IifqS7w6Ul/mR+rMvORUfRXE/8eioqJYsmQJTZo0oU6dOvmiS7lOp+Py5cuULVtWvl9mQurMvCQmJnLt2jX8/f2xtDTvtPWFoo+NjeXXX3/l5s2bDBw4EBcXF86dO4e7uzuFCxfOkcA8PDyAJ12knn4KGx0djZ+fH/Ckxfrhw4dGx6WlpRETE6Mc7+7urrSMp0t/nd7inV0WFhbyBTUTL1NXanX25hdUq9Xyecgh8t0yL1Jf5kfqzLy8bH1l9/8xg8GQ7z8XBoMBg8GAnZ0d7777Lk5OTtjZ2eV1WEYsLCyy/Z6L/EHqzDyk/34qCP+HmZx0nz9/ngEDBuDo6Mjt27fp1q0bLi4u/Pbbb9y9e5cZM2bkSGBeXl54eHhw8OBBKlSoADyZifzUqVP07NkTgMDAQGJjYzl79iyVK1cG4NChQ+j1egICAgCoWrUqc+bMQavVKjOtHzhwgFKlSpnUtVwIIYQQoiBZt24dI0aMIDExkQ0bNuDm5oa7uztubm64ubnh5eX1Srp0PmvStz/++IOHDx/Svn37fJlwCyFEdpicdE+fPp3OnTvzySefEBgYqGxv2LAhH330kUnnSkhIMBqPExERQXh4OM7OzhQrVox+/fqxcOFCfHx88PLy4uuvv8bT01OZzbxMmTLUr1+f//3vf0yaNAmtVsuUKVNo27at0uLevn17FixYwLhx4xg0aBCXLl1i5cqVjBkzxtRbF0IIIYQoMMqVK0dERAQxMTE8ePCAy5cvExMTg16vR6PR8MUXX2BpacmKFStITU3Fzc0NDw8P3NzcqFChAk5OTi8dQ3R0NGPGjEGr1WZZRq1W06hRI4oWLfrS1xNCiLxgctJ95swZJk+enGF74cKFlcnLsuvs2bP069dPeR0aGgpA586dmT59OoMGDSIpKYnPPvuM2NhYqlevznfffYe1tbVyzMyZM5kyZQr9+/dHrVbTokULxo8fr+x3dHRk6dKlTJ48mS5dulCoUCGGDh0qy4UJIYQQ4rVWsmRJnJyccHBw4O2330an05GWlkZsbCzx8fHcu3cPAI1GQ0xMDP/++y8xMTGkpKQwePBg/Pz82LVrF4cPH1Zax93d3fHz86NixYrodDp0Op3RCjL/FRcX98yEG0Cv1+fZDOVCCJETTE66raysiI+Pz7D9+vXrGWYSf57atWtz4cKFLPerVCpGjhzJyJEjsyzj4uLCrFmznnkdPz8/1qxZY1Js4vX1vP/800VGRuLt7S1jgoQQQuQru3btMqm8Wq1GrVZjaWmJtbU19vb2RvvbtWuHXq9Hp9Oh1+tJTExEpVJx7949HB0dKVOmDHFxcdy8eZOzZ88SHR2Nq6srd+7cYd68eTg4OODq6oq7uztFihThjTfeQKVScffuXZKSknLy1oUQIl8yOelu0qQJCxYsYM6cOcq2O3fuMHPmTFq0aJGTsQnxyun1erZt2/bcchYWFvz444/s37+foUOHGvW+EEIIIfJKSkoKly5dQq1WP7N12NLSMkNynRWVSmU0kZGNjY2yLyAggICAAKOkPL213GAw0KZNG2JiYoiLi+PRo0fExMRw48YNNBoN06ZNIzEx8eVuWAghzIDJSXdISAgjRoygbt26pKSk0LdvX6KioqhatSqjR4/OjRiFeGUePHjAlStXaNmyJT4+PlkuT2Bvb8/NmzfZuHEjoaGhjB49WibmE0IIkafSE98BAwZkOTFZOnt7e1xcXHLs2umt5YDyINrBwUEZh53eRTw9Rq1WyxtvvMGNGzf466+/ciwOIYTIj0xOuh0dHVm2bBnHjh3jwoULJCYmUqlSJerWrZsb8QnxSjk6OvLee+9hb29v9CQ/My4uLjg6OrJmzRqmTp3KBx98IJO8CCGEyBOXL19m5cqVvPHGG1hbW1O8ePG8DsnI00l5Ol9fXxwcHCTpFkIUeC+8yniNGjWoUaNGTsYiRJ65cuUKO3fupFmzZlhbWz834U5XqlQpBg0axOrVq/n3339xd3dXlqYTQgghXoV79+4xZ84c3N3dUavVODg45HVIQgghnvJCSffp06c5fPgwDx8+zDBeSJbiEuYmOjqauXPn4uLiglarpVChQiYd7+npyfDhw0lMTOTu3bukpKRQrly5XIpWCCGE+D8xMTHMmjULOzs7OnToQKFChV7J2tpCCCGyz+Ske9GiRcyZM4dSpUrh7u5utE9+yQtzk5yczNdff41araZ9+/a4uLi80OdYo9Hg6OjIkSNH2L59O926daNVq1a5ELEQQgjxhF6vZ+7cuaSkpNC7d288PT3N7m8xe3t7LC0tSUtLy7KMKZO+CSFEfmRy0r1y5UqmTZtGly5dciMeIV4ZvV7Pt99+y/379+nduzeFCxd+qeW/1Go1NWvW5O7du6xbt47o6Gh69uwpS4oJIYTIFSqVigYNGmAwGChatKhZ/n/j4uLC6NGjSUhIyLJMTk/6JoQQr5rJSbdaraZatWq5EYsQr5ynpydlypTBx8dHWQrlZVhYWNC5c2dcXFzYtWsXDx8+5N1338XKyioHohVCCCHAYDBw/PhxSpUqReHChbG1tc1ytQ1z4OLiIkm1EKJAM/mRaP/+/fnhhx9yIxYhXpmYmBgSExOpXr06FSpUyPHJzxo3bkzXrl1JTEzk8ePHGAyGHD2/EEKI19eWLVtYsGABJ06cwNraWibwFEKIfM7kx6IDBw5k8ODBNGvWjLJly2Z4sjp//vwcC06I3HDp0iW+/PJLunXrho+PT7ZnKjdVtWrVqFy5MtHR0Vy/fp2SJUvi6emZK9cSQgjxevjrr7/YsmULjRo1olSpUsqa2EIIIfIvk5PuqVOncvjwYWrXrv3Ck04JkVeioqKYN28exYoVo1ixYrk+MUt6t/Lly5eTlJTEqFGjKF26dK5eUwghRMF06tQpVq5cSfXq1QkKCsLW1javQxJCCJENJifdmzZtYt68eTRq1CgXwhEi9yQlJTFnzhw0Gg3t27fH2dn5lVzXysqK/v37s3LlSr744gvee+89AgMDX8m1hRBCFBwHDx6kXLlyNG3aVNbiFkIIM2LymG4XFxdKlCiRG7EIkavWr19PVFQUnTp1euXLqri4uDBo0CC8vLyYN28e+/bte2XXFkIIYd4MBgNarZbWrVvTpk0bnJyc8jokIYQQJjA56R42bBjz5s0jKSkpN+IRItc0adKEN954A29v7xyZqdxUtra29O/fnxo1aqDRaJ65PIoQQggBEBsby+TJkzl69CiJiYm4urrK0D4hhDAzJncvX7VqFTdv3qRu3bp4eXllmEht06ZNORacEDnh2LFjeHp6kpycTOnSpfN0lldLS0s6depEQkICN2/e5Ny5c3Tq1Mmsl3oRQgiRO1JSUvj666+JiopCpVLh6OholmtxCyHEi0hOTiYxMTGvw8gRJv+l36xZs9yIQ4hccf78eRYtWkStWrVo3Lhxrs1Ubip7e3vCw8PZsWMHly5dYuTIkdjZ2eV1WEIIIfIJvV7P4sWLuXXrFj169KB48eKScAshXgt6vZ47d+4QERFBTExMgVh61+Ske9iwYbkRhxA57sGDB8yfPx9vb2+Cg4NzfaZyU1WoUIHevXuzbt06pk6dyocffoibm1tehyWeEh0dTVxcXJb7HR0dpc6EELliw4YNnDp1ii5dulC6dGnpESWEeC0kJCRw7do1Hj9+jKWlZYH53Vcw7kKI/0hMTGTOnDnY2NjQrl27VzZTuan8/PwYOHAgq1evZsqUKUyePFkmyMknoqOjGTNmDFqtNssyGo2G0NBQSbyFEDmuatWqWFpaUrFiRWX5SSGEKKjSW7dv376NTqfDy8sLrVb7+nYv9/Pze+YEHuHh4S8VkBA54caNG8THx9OtW7dXPlO5qby8vBg8eDCnT58mNjYWGxsb+QMrH4iLi3tmwg2g1WqJi4uTpFsIkWNu3bqFt7c3arWagIAArK2t8zokIYTIVQkJCVy9epXY2FgcHR3x9PRErVYTExOT16HlGJOT7vnz5xu9TktLIzw8nE2bNjF8+PAcC0yIF2UwGChSpAiDBg3C2dnZLMbAubq60qBBA+Li4jh8+DCenp7Ur18/r8MSQgjxCp07d45t27YRExNDUFCQrMUthCjQ9Ho9t2/f5s6dO+j1eooXL15g5zjKkYnUWrVqRdmyZQkLC+PNN9/MkcCEeBF//fUXhw8fpmPHjjg4OJjVOBC1Wo2joyM3b95k+/btREdH07Fjx3zdSi+EECJn3Lx5k4ULF1K4cGGqVasmCbcQokCLj4/n2rVrxMTE4OTkpLRuF1Q5dmdVq1bl0KFDOXU6IUwWHh7ODz/8gF6vx9LS0iy75KnVat58803q1avHli1bWLp0KTqdLq/DEkIIkYuioqKYPXs2rq6u1KpVCxcXl7wOSQghcoVer+fWrVucO3eOuLg4vLy8KFKkSIFOuCGHJlJLTk5m5cqVeHp65sTphDDZvXv3mD9/PiVLlqRKlSpm3TVFrVbTpk0bXFxcCAsLw9bWll69ekmL9yuk1+s5f/58XochhHhNnDx5ErVaTYcOHYiLi5Pf90KIAik+Pl4Zu/06tG4/zeSku2bNmkb/GRgMBhISErCxseHLL7/M0eCEyI7ExES+/vpr7OzsaNOmDY8ePcrrkHJE3bp1KVSoEK6urkRHR+Pq6vra/GLKKwkJCezdu5fdu3cTHR2d1+EIIQq49LVn/f39cXd3p1ChQsTHx+dxVEIIkbOeHrudPjO5OTeQvQiTk+4xY8YYJd0qlQpXV1eqVKmSb5dlEgWbRqOhfPny+Pr64uHhwePHj/M6pBxToUIFtFotV65c4ZtvvmHgwIEUL148r8MqkA4cOMCKFSvQ6XRUrFiR2rVrExYW9tzjHj16RMmSJXM/QCFEgaLX61m8eDFeXl6ULVtWHqwKIQqk123sdlZMTrq7dOmSG3FkqUmTJty+fTvD9l69ejFhwgT69u3LkSNHjPZ1796dyZMnK6/v3LnDxIkTOXz4MHZ2dnTq1IkPP/zQrCbZEpl78OABlpaWBAUFYWdnVyC/xBqNBltbW2JjY5k2bRrDhw/Hz88vr8Mye3q9nlOnTmEwGChfvjx2dnbUrl2bgIAAXF1dSUpK4rfffiMtLe2Z51myZAkjRoyQOhFCmGTdunUcPXqU4sWLY2tri6WlJXq9Pq/DEkKIHPHfmclfx9btp2Ur6zRlbGNO/+G5YcMGo4mkLl26xIABA2jVqpWyrVu3bowYMUJ5bWtrq/xbp9Px7rvv4u7uztq1a3nw4AGffvopGo2GDz74IEdjFa/W7t27+fHHH3nnnXcoXLhwgf6Dxd3dnXfffZeVK1cya9YsBg4cSJ06dfI6LLOUkJDAvn372L17N1FRUQQEBGBnZ4eNjQ1NmzZFo9EAYGNjw+jRo0lISMjyXAaDgW3btjFr1iz69u1LgwYNXtVtCCHM2K+//spvv/1GixYtqFy5MlZWVnkdkhBC5Ji4uDiuX7/+2rduPy1bSXenTp1QqVTK2KOsqFQqwsPDcySwdK6urkavv/32W7y9valVq5ayzcbGBg8Pj0yP379/P5cvX2bZsmW4u7tToUIFRo4cycyZMxk2bJj8R2emzp07x5o1a6hRowbu7u5mOVO5qezt7Rk4cCDr1q1j6dKl+Pj4ULRo0bwOy6zcuHGDadOmodPpqFChAq1bt8bb2xsbG5tM/zNwcXF57izCAwcO5Oeff2bZsmUkJCTQunXrXIpeiIInOjqauLi4LPc7Ojri5ub2CiPKfSdPnmTt2rXUrVuXmjVrYmNjk9chCSFEjtDr9URERHD37l30ej0lSpQwagx9nWUr6d69e3dux5EtqampbN26lQEDBhiNK9+2bRtbt27Fw8ODxo0bM3ToUKWCT548Sfny5XF3d1fKBwcHM3HiRC5fvkzFihVf+X2Il3P37l0WLFhA6dKladSo0WvVVcXKyopevXpx7do1EhMTefz4MU5OTq/908Os6PV6Tp8+zbVr12jevDkWFhYEBwfj5+eHm5sb1tbWLz1LsJWVFd27d6dw4cK4u7srT3Vl9mEhni06OpoxY8ag1WqzLKPRaAgNDS1QiXeJEiVo0qQJtWrVeq3+/xJCFGxxcXFcu3aN2NhYnJ2d8fDwkL9Pn5KtpDu/TNy0a9cu4uLi6Ny5s7KtXbt2FCtWDE9PTy5cuMDMmTO5du0a8+fPB56sffl0wg0oryMjI026vqyXnD8sX74cBwcHWrdujYODg1GX8vQ6Ksh1pVKpKF26NImJiaxYsQK9Xk+3bt1ISUnJ8hgHB4d8+UdrbtVXYmIi+/fvZ8+ePURFRSkTFVlaWhIcHKx0ITcYDM/twZNdjRo1Ijk5mWvXrrF371569uyZoaeOuXsdvl8FTX6us5iYmGcm3ABarZaYmJgCsW71nTt3UKvVpKamUr16dezs7DIMicrP9SUykvoyP1JnOU+n03H79m3u3r2LwWCgWLFi2NraYjAYXvp9Tv8dqdPp8nUCb2Fh8dwyLzST2M2bN1mxYgVXrlwBoGzZsvTr1w9vb+8XOV22/fzzzzRo0IDChQsr27p37678O3326rfeeoubN2/meDxnzpzJ0fMJ0xkMBgICAoiPjyc6OjrL5cEuX778iiPLG/b29hw4cIDTp08/s5yFhQV9+vTB0dHxFUVmmpz8bmm1WlasWEFqaiolSpTA398fDw8P7t2790p+YUdHRxMeHs7EiRNp27at0e+rgkJ+F5qf/FhnDx48yFa5CxcumP1SkPHx8axfvx4nJyfq1q2LjY3NM3vDvC7/hxUUUl85T6fTkZqa+tzvyouSOssZSUlJPHjwgKSkJGxsbHB0dOTevXs5en6VSsXZs2fzdQ/C6tWrP7eMyUn3vn37GDJkCBUqVKBatWoA/PPPP7Rt25ZFixZRr1490yPNhtu3b3PgwAHmzZv3zHJVqlQBnozd9Pb2xt3dPUNCEhUVBZDlOPCs+Pv7Z+tJhsh5BoOBXbt24efnh62tLfb29pnOPq/T6bh8+TJly5Z9LerK19cXV1dXtm3b9sxyOp0Ob29vfHx8XlFk2aPT6Thz5sxLfbf0ej1nzpxh//799OjRA61WS5s2bShcuDBubm5YWVm98l/Ufn5+rFnz/9q77/gmy/1//K+sZjTpSltoS1ktZba0bLACfkHPMU6WfMAF6pF5cKFWPcoQxYHb40JEBBQHoKKooB5FBUE5lCHQAd2le6Rtmnlfvz/43ddpOtOStEn7fj4eeTS9ciW5kiv3eN/X+hBffPEFFixY4DQHhS9zR32RzuXNdZaTk+NSvsGDB3vdvqs9TCYTnn32Wcjlctxwww2IiIho8QJgTzuG+TqqL/dijKG6uhplZWUwGo2w2+0QBAF6vR56vR5arfaS34PqzD3E1m1xmGNcXJxHxm4bjUYUFBRgxIgRvJeir2p30P3CCy9gwYIFWLlypVP6hg0bsGHDBo8F3bt27YJer8fUqVNbzSdO5CYG1ImJiXjrrbdQXl7Ou9cePHgQWq0WsbGx7SqDTCajDbSL7Nu3Dx9//DGuv/56JCYmtjkBnkwm8+puKO4UHR3tUj6pVOq1v9+ObFsmk4nPQl5aWoqoqChkZmZCr9cjISGhS3fOoaGhuPvuu/Hxxx9j48aNiIyM9OmgoTHaF/oeb6qzsrIynDhxAqdPn3Ypvzfvu9pit9vx5ptvoqKiAvPmzUNkZKRLn6UnHcO6A6qvS2OxWFBaWory8nKYTCYwxhAQEACNRgOj0YjCwkIUFRVBo9FAr9cjNDT0kicgpDrrOKPRiOzsbBiNRgQFBSE0NNRj36X4ut50DOuodgfd586dw8svv9wkfdasWdiyZYs7ytSEIAjYtWsXbrzxRqfWzdzcXOzZswdTpkxBUFAQ0tLSsH79eowdO5YvXZacnIzY2Fg89NBDePDBB1FaWoqXX34ZN998M81c7iNOnDiBHTt2YMKECYiPj+8RM5V7QlvrTfua119/Henp6Rg6dCj+9re/oW/fvlCr1V5zEFWpVLjllltw9uxZ2O12VFdXt9hDg5DuRhAElJWVITc3F3l5ecjNzUVSUhJGjRqFv/76C9u3b3d5nPb777+Pf/3rXz657WRnZyMrKwszZ85Ev379fP6kkRB3EQQBlZWVKCsrQ1VVFex2O1QqFXr16uXUoi3O3VNbW4uqqipkZ2cjPz8fAQEB0Ov1CAkJ8fkWUF8hzkxeUFAAiURCM5O3U7uPYCEhIThz5gz69+/vlH7mzBmPTdR08OBBFBYWYtasWU7pCoUChw4dwgcffACTyYSIiAhcddVVWLp0Kc8jk8nw1ltvYfXq1Zg7dy7UajVmzJjhtK438V4FBQV48803MWjQIEyePJlmer0Ef/31F3r37o3U1FSkpaUhIiIC4eHh6NWrF8LDw736YoY4C/n333+P6dOno1evXrjssstwxRVXuG0Wck+QyWQYPnw4TCYTdu/ejby8PNx7771eO7aekI6or69Hfn4+8vLyMGrUKPj7+2PLli347bffAFyceyI8PByVlZXIz89HSEgIVq5cifLycmzatKnN19fr9cjJyYGfnx9effVVxMXFITExESNGjPDqEz7GGMLCwrB48WIEBgb65EUDQtytvr4epaWlKCsrQ319PaRSKQIDAxEcHNziRSmpVIqAgAAEBATA4XDAaDSiqqoKlZWVUCgUCAwMRGhoKIKDg73mwnt305mt291Vu48Ac+bMwRNPPMEPrsDFMd0bN27EggUL3F0+ABdbq9PS0pqkR0REYNu2bW0+PyoqChs3bvRE0YiHZWVlITg4GAaDAQEBAV1dHJ+mVquRl5eHgoICZGZm4siRI7BarQCASZMmYd68eaiqqsK+ffvQu3dvHoy7OyBvuC6vIAgoKSlBTk4O33k3XJdXnIX8+++/R2lpKSIjI1FSUgK1Wo0+ffr4zNVtjUaDgQMH4siRI1izZg3uu+8+r1kVgnQ/7dnG2kNsmRKfu2nTJpw9e5bPkyK+fr9+/RAbG4vIyEj06tULAQEBkMvlkMvlTifVtbW1Lr3v+PHjIZVKUV5ejgEDBiAtLQ0HDx6EVCrFoEGDcP/993tdz7UffvgB586dw9SpU6HT6byufIR0JofDgfLycpSWlqKmpgZ2ux1arRZ9+vRp94UzmUyG4OBgBAcHw2q1orq6GhUVFSgrK4NKpUJISAj0ej2dM7qJIAjIy8vjM5NT63bHuRx0OxwOyGQyLFu2DFqtFu+99x5efPFFAEB4eDiWL1+O2267zWMFJT2LIAiQSCQYNGgQ5s+fj6CgIK9syfQlwcHBCAwMxGWXXYYJEybAbrejpqYGZWVlUCqVyMvLQ3FxMTIyMnD48GEekAcHB2Pt2rWQy+X44osvoNPp0KtXLx6Ut+dk0tV1eZ966imEhYXhu+++w1dffYVhw4Z5ZRfy9oiNjcXdd9+Nbdu2Yd26dVi8eDGf+JEQd3Hn2tdmsxmHDh1Cbm4ucnNzUVBQAJvNhqeeegp2ux0OhwMDBw7E+PHjERYWxvcHcrkcsbGxbW6n4nCL1oa+yOVyaLVaKJVKhIeH48Ybb4TdbkdJSQnS09NRVVWF/Px8qNVqvP322+jfvz+SkpIwZMiQLuu9c/ToUWzfvh3jxo2DRCK55LGnhPiqmpoalJaWoqKiAmazGQqFgp+LuOM47ufnh7CwMISFhaG+vh5VVVVO479DQkIQGhpKQWIHGY1GZGVloaamBsHBwdDr9T55/uUtXA66J0+ejBkzZmD27NlYsGABFixYwK9Su2M2QUJEjDG8//77UCqVGDVqFAICAmgjdyOpVAqpVAqFQgG1Wo3w8HD+mE6nw4ABA5wCcqvViry8PAAXx9eLaaJHH30U0dHR+PPPP2E0GlsNyGtqalxal3fXrl24/vrrERMTg0WLFiE0NNRru5C3R3h4OBYvXozt27fjm2++8dhsn6TncnUbq6mpgV6v52Ov8/Ly+NhrrVaLm266CXV1ddi+fTv0ej3Cw8MxceJEhIWFoaKiAgqFAldeeWWT1uv2CAoKwn333Ye6uroW8/j7+zcZ+y2XyxEZGYnIyEgIggCr1YrS0lLo9XocP34cP//8M+RyOQYPHowlS5bA39+/Q+XriIyMDLz99tsYOnQopk6d2qnvTYg3sNlsKCsrQ1lZGWprayEIAnQ6HXr37u3RHh9qtZqvDS2O/xYvFup0Oh6A07wKbWvcut23b1+6eOgGLgfd8+fPx+eff45NmzYhKSkJs2fPxtVXX00njMTtvvvuO/zyyy+45pproFaraRxcG1xtLXLl5K+1gFwQBNx9992w2+0wGo18nfT6+nrk5OQgNTUVJ0+edArIZ8+ejWnTpuHChQs4c+aMy0GzSqWC0Wjk47S6E41Gg4ULF6K6uhqFhYUAgAEDBtCFJdKpsrOzERUVhSNHjuDdd98F8L+x1wEBAcjPzwdjDPfffz+USiUPrt39Ow0KCnJ5QrXmSKVSqFQqqFQqzJw5EzabDRcuXEBGRgZKSkpQXFwMrVaL7du3o1evXkhMTERcXJxHjitlZWV45ZVXEBkZiauvvprmbiA9hiAIMBqNKC0tRWVlJaxWK2+F1mq1nXp8k0gk0Ol00Ol0vFzi+O/c3FwEBASgpqYGDoeDjrvNMBqNOH/+POrq6hAUFESt227k8lFn2bJlWLZsGQ4fPoxdu3bhySefxFNPPYWrr74ac+bMoW6SxC1SU1PxySefYNKkSS4tDUY63lrUXo0D8l69evHHBEHAddddh6uvvtopINfpdMjJycGZM2fwzTffOAXkrRk6dGi3PmGVy+XQ6/WoqqrCv//9b/Tr1w/Lly+niQJJpzl58iSio6Oh0WgwZ84c9OrVCzqdDgqF4pJar7uSRCKBn58f+vXrh379+vFWcHHM+e+//479+/dDqVRiyJAhWLhwIQIDA932/gEBARg/fjxGjBiB4OBgn++ZQ0hbzGaz01JfABAYGIioqCivmHNFKpXyC3s2mw3V1dWorKxEcXExgIvLe4rjv3v69upwOJCbm4vi4mI+dptat92r3Zd6x48fj/Hjx+OJJ57A3r17sWvXLsydOxcxMTGYPXs2Fi5c6Ilykh6gsLAQb731FgYPHozLL7+cApB2uNTWokvVVkCelJSE+Ph4ZGZmYseOHW2+Xk85+AUFBWHGjBn49NNP8eSTT+K+++5z6l1AiKvq6uqQkZGBP/74w6X8SUlJkMvlCAsLc9peu5OGreA33XQTrFYr8vPzkZGRgfz8fJSXl8Nms+GLL75AQEAAEhMTERMT02KrTsMJ6hqyWCwoKSlBWFgYxowZA51O12P2YaTnEQSBT1xWWVkJQRCgUqkQERHh1cMpFAoFn+HcarVCoVCgqKgIxcXFUKlU0Ov10Ov1Xv0ZPKW6uhpZWVm8dTs0NJT2YR7Q4f5V/v7+mDNnDubMmYOffvoJDz/8MJ577jkKukmHBQUFYfz48Rg1alS3buXsaRoG5CEhIV1dHK8zbNgw3HXXXfjwww+xdu1a/POf/8TgwYO7uljEy1VXVyM9PR1JSUlgjOHll19GZmamyxcrlUqlV7REdRaJRAKlUomYmBjExMTA4XDwseDV1dU4evQo9u7dC41Gg2HDhuH//u//nCaac2WCOplMhhUrVlBXTNIt1dXV8bHaZrMZUqmUT4rmaz1j/Pz80Lt3b8hkMtTW1qK6upqP/9ZqtbwFvLv3tmzYug2AWrc9rMNBd319Pb755hvs2rULR48eRd++fXHnnXe6s2ykh7DZbCgtLYVUKsWECROolYD0OFFRUVi0aBE+/fRTGI1GmM1mOvARJ4wxHDx4EGlpaUhPT+cnSUuXLkVISAgmTZqEadOmwWq1YvPmzV1cWu8nk8n4xEtz586FxWJBTk4OMjIykJ2dzbuk//DDD/Dz80OvXr3anKDO4XDAYrF0RvEJ6RQ2mw0VFRV8qS9BEODv79+hpb68lVarhVardRr/fe7cOeTm5iIwMBB6vR4hISE+d2GhLdXV1cjOzkZtbS21bneSdgfd//3vf7Fz5058++23cDgc+Nvf/oZ77rkHY8eO9UT5SDfSUte8Xbt2ISMjA/Pnz0e/fv2olYD0SAEBAVi4cCFqa2uRm5uLrKwsXHnllbQ99ECMMVy4cAFpaWkoLCzE7NmzYbVa8cUXX0AikSA6Ohrjxo1DdHQ0goODIZfLERcXB4lEgoKCgq4uvs8Rl/UaPHgwBg8eDLvdzlvBCwoKcPbsWZfnoyCkOxAnRROHYCgUCj72ubsekxqO/7bb7aiqqkJVVRXKy8vh5+fntP63t34HgiDAbrfDZrPB4XDAbre3eDMajQCodbszuRx0b9y4Ebt27UJ2djZGjBiBhx56CNdccw0tF0Zc4krXvA8++AD33Xdfl45NJp7lzpnWuyOpVAqdTofU1FR89tlnOHv2LBYtWkQHxB6irq4O7733HtLT01FbWwupVIqIiAhkZmZCJpPh9ttvh1KphJ+fH2QyWbOtErSNXTq5XM5nN58zZw7MZjP+/PNPfPfdd11cMkI8R5x0sLS0FCaTCYwx6HQ6REZGdvtu1o3J5XKEhoYiNDQUVquVT74mjv8ODQ1FSEiIx2IgQRB40Gyz2Xig3DCQdjgcTsG1zWaDIAhgjDndBEGAVCqFRCKBRCKBVCqFTCZDQEAA9Ho9tW53IpeD7k2bNuH666/HK6+8gri4OE+WiXRDrqwda7fb+SQOpHtqPNM6YwzZ2dno378/3/G7Y6Z1XyaRSJCUlASJRILPP/8cTz/9NO69914aD9+N2Gw2ZGdnIy0tDWlpaXw5vrq6OhiNRiQkJKBPnz6IioqCv78/n1HcFbSNuZdUKoVGo0FMTExXF4UQtxMEAVVVVSgtLUVVVRVsNhtUKhXCw8Oh1WopIAP48JJevXrBZDKhqqoKeXl5fPy32P28uYvjjLEWA2S73d6kZdpqtcLhcMDhcLgUPEulUsjlcr6fkslk/CauQuGJpR5Jx7gcdP/yyy89atIVQohnNJxpXRAE1NTUIDIykg4KjSQmJiI4OJhPsLZmzRq3Lm9EXNfS0BiRTqdzmnSrMYvFgtraWuj1emRkZOD555+HzWaDn58foqOj0bdvXxQWFkIqlWLevHlQKBSXNH6QtjFCSGvMZjNKSkr4pGgSiQSBgYEICgryyBr23YVGo4FGo+H7VXHWb3H9b5lMxgNsMdgWW58BON0XA2eJRMIDY7lcDoVCwe83DJzF4Jr4Lpe3LAq4CSGkc/Xr1w+LFy9GamoqampqoFKpoFQqu7pYPYorQ2MUCgXWr1/PA2+TyYT09HSkp6fj7NmzyMnJ4TNi2+12XH755ejTpw8iIiL4LOJ0MkUI8SSbzYbKykqUl5ejuroadrsd/v7+iIyMpCVa20kqlSIwMBCBgYFwOByorq5GdXU1D6BlMhkfBtQ4cBbvk56HLmcRQogXCw4OxpQpU1BTU4MjR45AJpPh+uuvp25/ncSVoTE2mw2///47hgwZgr59++Lw4cP44IMPEBAQgOjoaEyfPh3R0dGoq6uDSqXCFVdcQUE2IcTjzGYzKisrUVVVBaPRCJvNBrlcjuDgYN4ySy6NTCZDSEgIDQEjbaKgm3hcXV0dvv76664uBiE+SyqVIiAgABUVFfjtt99w4cIF3HXXXdQN0It89tlnuPzyyzF58mQEBwdj0aJFCAkJgZ+fHxQKBV0k8XE0QR3xFfX19SgvL0dVVRVqa2tht9uhUCig0+kQEBDQ4yZFI8RbtOuMzW6346uvvkJycjJCQ0M9VSbSjTgcDqxZswZVVVVdXRRCfJpEIoHBYEBISAj27t2L0tJS3HvvvdDpdF1dtG6rpqYG2dnZLuW96aabMGjQICgUCoSFhVGQ3c00nqCuOTRBHekqNTU1vEW7rq4ODocDfn5+CA4Ohk6nowu0hHiBdm2Fcrkcq1atwt69ez1VHtJNFBQU8LEu06dPh81mw2effdbVxSLE502YMAGhoaHYsWMH3nvvPSxfvpy6CF4ik8mEgoICfps1axYYY3jllVdw7tw5l14jNDSUxkV2cw0nqCOkK4kTeVVVVaGiogJmsxmCIPDlrLRaLR0XCPEy7b70lZCQgDNnziAqKsoT5SE+zmKx4Msvv8S3336LqVOnYuzYsRg4cCAsFgt1zSPETWJjY7Fo0SLYbDYUFRUhKCiIth0XmM1mFBYWor6+HsOHD0d9fT0ee+wxVFZWArjYjT8kJATDhg2DRqNBcnIyRowYgS+++KKLS04I6enE5b2qqqpQWVkJq9UKQRCg0WgQHh4Of39/miuCEC/W7qB73rx5eOaZZ1BUVIThw4dDrVY7PT5kyBC3FY74DsYYjh07hu3bt8NoNCI5ORmjRo2Cv78/ZDIZNBoNdc0jxI3CwsIgCAIuXLiADRs24O9//zvGjBlzSUtbdaZLXYarNVarFVarFVqtFrm5udi5cycKCgpQXl4OAAgJCcGKFStgt9uRkJAAnU6HsLAw6PV6qFQqPstsXFwcCgoKOlQGQgi5VHa7nQfaVVVVsFgskEgk8Pf3R0hICF1sJcSHtDvovv/++wEA69at42kSiQSMMUgkEpw5c8Z9pSM+Iz8/H6+99hpiY2Mxc+ZMREVFNZmsg7rmEeJeUqkU4eHhiImJwY4dO/DJJ59AEIQW8zde2qqrdGQZrtacO3cOJ06cQF5eHgoLC1FSUoLk5GRce+21KCsrQ11dHWJjYzF+/Hjo9XqEhYXxWXynT59OrUOEEK9htVp5a3Z1dTVsNhukUim0Wi3CwsKaNHYRQnxDu4PuH374wRPlID7Ibrfj4MGDGDt2LORyOW677TZERUXB39+fJhEipJPI5XLMnDkTfn5+OHToUKt5bTYbampqujzodnUZroZlLS4uRl5eXpOx1zExMfjzzz/x66+/IiwsDNHR0UhMTERUVBQqKioQEBCAW265pcNro9Ks1YQQTxOX9qqsrERNTQ3sdjtkMhl0Oh0CAwNpxnFCuoF2B900lpsAwOnTp7F161aUlJQAuNjVNSYmhmbIJKSLJCUltRl0+5rdu3djyZIlEAQBb7/9NrKysqDRaBAWFoaIiAjU1taisLAQ8fHxGD16NO8WLpVK3Xbhj2atJoR4Ql1dHZ9xXFzay8/PjwfaCoWiq4tICHGjDkdImZmZKCwsbNJaMW3atEsuFPFe1dXV2LFjB37//Xf07dsXt99+O/r06QOVStXVRSOEuMBms8FisWDr1q0oLi7m6RKJBNdccw2GDBmCo0eP4ueff3YKXAcOHIjrrrsOJpMJGzZsgEQi4Y9LJBLcfffdUKlU+PLLL5GTk+P0+OTJk5GQkIC0tDR8//33MJlMLpW1qKgIZ8+ehUqlwrRp06BSqaDT6aBQKHjLdWf0qqGhMYSQS8UYQ21tLW/RNplMEASBL+0VEBBAM44T0o21O+jOy8vDsmXLkJ6ezsdyA+AnPjSmu3s7cuQITpw4AYPBgISEBJotkxAfc+HCBT4HR8OLZYwxVFRUIDc3F0ajEQqFgu/fgYvdH3Nzc1FRUcHzizfg4rFBqVSipqYGVquV5wGAkpIS5OTkoLi4GHV1dTCbzS6V9frrr0dISAhkMhkCAgLc8vkJIaSziEt7VVRUoKqqCmazGQ6HA2q1GqGhodDpdHQORUgP0e6g+6mnnkKfPn3w/vvvY9q0afjss89QWVmJZ599Fg8//LAnyki62Pnz55GWloaJEyeif//+uPPOOxEaGkpdyQnxQUqlEmq1GldddVWLeYYPH47hw4c7Bd0A+PI0c+fObfFEsbXeToMGDcKgQYNQUFCAd955p82y+vn50X6GEOJTGi/tZbFYwBiDv78/Le1FSA/W7rOZY8eOYcuWLQgJCeHj5saMGYP7778f69atw+eff+6BYpKuUFdXh507d+Knn35CREQE+vTpA41Gg169etFEaYT4KKlU2uEujIIgQCqV8nHTHUWBNCGkOxEnfhTHaFutVr60l16vh0aj6eoiEkK6WLvPfARB4LO0BgcHo6SkBAMHDkRUVBSysrLcXkDSNQ4ePIgdO3bAarVi2rRpGDVqFHWDIoQQQgjBxUC7vLwcFy5cQHV1NRwOB6RSKXQ6HcLDw2lpL0KIk3YH3YMGDUJaWhqio6MxcuRIvPvuu1AoFPjkk08QHR3t1sK99tpreP31153SBgwYgG+//RYAYLFY8Mwzz2Dv3r2wWq1ITk7GqlWrEBoayvMXFhZi9erVOHz4MDQaDW688UY88MAD1NLSCkEQcOrUKfTt2xeTJ09GeHg4LVdBiJfzpaWtfKmshBAislqtqKysREVFBYxGI6xWK2pqahAWFobg4GA6VyKEtKjdkeeSJUtQX18PAFixYgUWLVqEm2++GUFBQXjppZfcXsBBgwZh8+bN/P+G3SKffvpp/Pzzz3j55Zeh0+nw5JNPYvny5dixYwcAwOFwYNGiRQgNDcWOHTtQUlKChx9+GAqFAvfff7/by+rLLBYLvvzySwQHB2Po0KFITk6Gn58f1Go1dSUnxAf40tJWvlRWQkjP1nANbaPRCLvdDoVCAZ1OB61WC5lMhtDQUJp5nBDSqnYH3Zdffjm/369fP3z77beoqqpCYGCgR4IzmUyGsLCwJuk1NTXYuXMnNmzYgIkTJwK4GIQbDAakpqYiMTERv/76KzIzM7F582aEhoZi6NChuOeee7BhwwYsX76crkj+/44dO4bt27ejuroaU6dORXR0NHQ6HR1ACPExvrS0lS+VlRDSs5jNZlRUVKCiosJpDe2goCAEBATw3pIOh6OLS0oI8RVu6WPtyROnnJwcJCcnQ6lUIjExEQ888AAiIyNx6tQp2Gw2TJo0ieeNiYlBZGQkD7pTU1MRFxfn1N08OTkZq1evRmZmJoYNG9ausnS3navJZMKmTZtw/PhxxMbGYsaMGYiIiOAXIwRB6OIStp9YR92trrorqi/fQvXle6jOfAvVV9epq6vjM47X1tbC4XDAz88PAQEBTdbQFutHPE/yxfOlnorqzLeI9STOmeCtXGmodCnoXr58uctv2ngM9qVISEjA+vXrMWDAAJSWluLf//43br75ZuzZswdlZWVQKBRN1m7V6/UoLS0FAJSVlTkF3AD4/2Ke9jh58mQHP4l3EWcgFscmTZw4EVFRUaivr+82k+FlZmZ2dRFIO1B9+RaqL99DdeZbqL46h9lshslkQm1tLcxmMwRBgFwuh0qlglqthsPh4Mt/tSYnJ6dzCkzchurMN9TX10MikeDUqVNePdx19OjRbeZxKejW6XSXXJiOmDJlCr8/ZMgQjBw5EldccQW++eYbqFSqTi9PfHy8z3e5Pnv2LLZv344bb7wRer0ec+fOhUaj6TYTyzkcDmRmZiI2Ntbn66onoPryLVRfvofqzLdQfXkWYwy1tbV8jLbJZILD4YBer+djtNvTmiYIAnJyctCvXz+vboUj/0N15luMRiMKCgowYsQIKBSKri7OJXEp0lq/fr2ny+GSgIAA9O/fH7m5uZg0aRJsNhuMRqNTa3d5eTkfAx4aGooTJ044vUZZWRkANDtOvC0ymcxnD4LV1dXYsWMHfv/9d/Tt2xcWiwVyuRxarbari+YRMpmMdqY+hOrLt1B9+R6qM99C9eU+giDwQLuiooK3aKvVavTq1avdgXZzpFKpz54f9lRUZ75B3DZ9OQYT+VTzZl1dHfLy8hAWFsaveBw6dAh/+9vfAADnz59HYWEhEhMTAQCJiYl46623UF5eDr1eD+Di+tNarRaxsbFd9THcqry8HDU1NS0+rtPpUFZWhldeeQUSiQQGgwEJCQnw9/enAzohhBBCuh1BEGA0GnmLtsVigSAI0Gg06NWrFzQaDZ0DEUI6lUtB94033uhyP/rdu3dfUoEaevbZZ3HFFVcgMjISJSUleO211yCVSnHttddCp9Nh1qxZeOaZZxAYGAitVot169YhKSmJB93JycmIjY3FQw89hAcffBClpaV4+eWXcfPNN3eLmcvLy8vxyCOPwGaztZhHoVDgvvvuQ0JCAsaNG4fQ0NBu05WcEEIIIQS4GGiL46/FQBsAD7T9/f29ekwoIaR7cyn6mj59uqfL0ayioiLcf//9qKqqQkhICEaPHo1PPvkEISEhAIBHH30UUqkUK1asgNVqRXJyMlatWsWfL5PJ8NZbb2H16tWYO3cu1Go1ZsyYgRUrVnTJ53G3mpqaVgNuALDZbCgqKsKVV14JlUpFBxxCCCGEdAuCIKCyshJVVVWoqKiA1WqFRCKBv78/9Ho9NBpNVxeREEIAeGD2cnd66aWXWn1cqVRi1apVToF2Y1FRUdi4caO7i+ZT/P39oVaru7oYhBBCCCGXxG6389bsyspK2Gw2SCQSaLVahIeH0/kOIcQrdbif8alTp3Du3DkAwKBBg9q95jXpPNS6TQghhBBfZbPZeJBtNBphtVohlUqh0+kQEBDQJSvaEEJIe7Q76C4vL8d9992HI0eO8FnDjUYjxo8fj5deeol3/SaEEEIIIV2rpqYGBQUFMJlMkEqlkEgkkEqlTe6L/4u3hv/LZDKntIaPNfdaDfOIz21vA4DVam0SaMvlcuh0OkRERHSLuXkIIT1Hu4PuJ598EnV1dfj6668RExMDAMjMzMTDDz+MdevW4cUXX3R7IQkhhBBCiOtqa2tRUFCAiooKMMag1WrBGANjDHa7HYIg8P8b3gA4/RXvN/xfDKAb/m0cVEskEjDG+CzhjYN1MSBvHPBLpVLY7XY+b41cLkdAQAACAgIo0CaE+Kx2B92//PILNm/ezANuAIiNjcWqVatwxx13uLVwhBBCCCHEdXV1dTzYFgQBer0eQUFBbhtq1jBYF+83DuAb/+9wOACg2ec5HI4m+SUSCXQ6HQIDA6FQKNxSbkII6UrtDroFQWh2ByiXyyEIglsKRQghhBBCXFdfX4/CwkKUlJSAMYaQkBAEBQW5fT1qWt+aEELar917zgkTJuCpp55CcXExTysuLsb69esxceJEtxaOtE6n07V5BVgul8Pf37+TSkQIIYSQzmQ2m3Hu3DmcOHECRUVFCAwMxMCBAxESEkIBMiGEeIl2t3Q/8cQTWLJkCaZNm4bevXsDuLie9qBBg/D888+7vYCkZXq9HuvXr0dNTQ2Ai5OllJeXOwXZ/v7+CAoK6qISEkIIIcQTLBYLb9m22+0ICgqCXq+nQJsQQrxQu4PuiIgI7N69GwcPHsT58+cBADExMZg0aZLbC0faptfrodfrAQBVVVVQKBR8VnlCCCGEdC9WqxUXLlxAcXExrFYrD7ZlMllXF40QQkgLOrROt0QiwWWXXYbLLrvM3eUhhBBCCCGN2Gw2XLhwAUVFRbBarQgICEB0dDQF24QQ4gPaFXQLgoBdu3Zh//79KCgogEQiQVRUFP7+97/jhhtucNvMmIQQQggh5GKwXVRUxINtrVaLPn36QC7vULsJIYSQLuDyHpsxhiVLluDnn3/GkCFDEBcXB8YYzp07h5SUFOzbtw9vvPGGJ8tKCCGEENIj2O12FBUVobi4GPX19dBqtYiMjKQltAghxAe5HHTv2rULf/zxB95//31MmDDB6bFDhw5h2bJl+Pzzz3HjjTe6u4yEEEIIIT2CIAh8gjSTyQR/f3/0798ffn5+XV00QgjpNIIgICsrCzk5OTh+/DiSkpJ8ejiNy0H3119/jcWLFzcJuAFg4sSJuPvuu7Fnzx4KugkhhBBC2kkQBFy4cAE5OTkICAiAWq2mYJsQ0iOdOHECu3btQnV1NQDgp59+QlhYGJYvX47Jkyd3cek6xuV1JdLS0nD55Ze3+PjkyZNx9uxZtxSKEEIIIaQnEAQBJSUlOHHiBM6fPw+Hw4E+ffogOjqaAm5CSI9z4sQJbN68mQfcotLSUqxatQoHDhzoopJdGpdbuqurq/nSVM3R6/VNvhxCCCGEENKUIAgoLy9HQUEB6urqoFAoEBUVBZlMBqVS2dXFI4SQTidO2t2a119/HZdddpnPdTV3Oeh2OBytzpQpk8ngcDjcUihCCCGEkO6IMYaKigoUFBSgpqaGB9sajYbOowjBxcDr/PnzMBqNCAgIwMCBAyGVutw5l/iompoaHDhwoM1G3NLSUpw8eRKJiYmdUzA3adfs5SkpKS12dbJarW4rFCGEEEJId1NRUYH8/HzU1tZCJpPxYJsQclHjsbwAEBgYiJkzZyIhIaELS0bczWq1IisrC2lpaUhPT0dBQYHLzy0vL/dgyTzD5aB7xowZbeahSdQIIYQQQpxVVVUhPz8fRqMRUqkUvXv3hlar7epiEeJVxLG8jVVXV2Pz5s1YuHAhBd4+TJwsMi0tDWlpacjKyoLNZuvQa7U25NlbuRx0r1+/3pPlIIQQQkgPJQgC6uvrYbfbIZfL4efn1y3Wo66urkZBQQFvtevVqxd0Ol0Xl4oQ7+PKWN7du3djxIgR1NXch1RXV/MgOz09HbW1tS3mjY6ORlJSEn766ScYjcYW84WFhSE+Pt4TxfUol4NuQgghhJCOEgQBVqsVJpMJFosFZrPZ6a8gCGCMQSKRQCKRQCaTwc/Pj98UCgWUSiUUCgW/L5fLvfIE3Gg0oqCgAFVVVQAuniQGBAR0baEI8VLV1dU4cuRIm2N5q6qqcOLECYwcORISiaSTSkfaw2Kx4Ny5czzQLi4ubjFvUFAQRo4cibFjx2LixIkICQkBAIwePRqrVq1q8XnLly/3uUnUAAq6CSGEEOImjLEmAbV4s1gscDgcPLiWyWS8VVun00GlUkEul8Nut8Nms/G/tbW1/HmCIEAikUAqlfK/jQPzhn/FW2cF5rW1tSgoKEBFRQWAi10gg4KCOuW9CfEFRqMReXl5yMvLQ35+PvLz89u1+tGWLVvg7++PyMhIREVF8Vt4eLhPBmK+ThAE5Ofn8yA7Ozu7xQkhlUolhg4ditGjR2PSpEkYMGBAsxdPJk+ejDVr1uD1119HaWkpT/f1dbop6CaEEEJIu1itVqeA2mw2o76+nrdYOxwOHlhLpVIolUpotVoolUreWt2RlirGmFNALt7q6+tRU1PDA3PGmFNgLgb3jYPzxoF6R9XV1SE/Px+VlZUQBIEH29QaR3qympoapwA7Ly/PLcsL19XVISMjAxkZGTxNLpejd+/eiIqK4gF5ZGQk1Gr1Jb8fcVZRUcGD7IyMDJhMpmbzSSQS9O/fH0lJSZg4cSJGjhzp8n528uTJuOyyy5Camopjx44hKSkJiYmJPn1hhYJuQgghhDRhs9matFSL9+12Ow+uZTIZ7wru7+8PpVLpsRZmiUTCX7s1DocDVquVB+ji/fr6eqdWc6lUyoNzcX3sxq3kjQP0hoF0fX09CgoKUFZWBofDwYNtb+zyTogn1dTU8MBaDLLF4RWtUavV6N+/P2JjY/HTTz+hpqam1byDBg1CdnZ2kzG/drudt5w3pNfreWt4ZGQkIiIiwBjr0Gfsqerr65GZmcnHZTdsfW4sNDQUI0eOxLhx4zB+/HgEBgZ2+H1lMhlfFszXA26Agm5CCCGkx7Lb7c0G1vX19XxWWbGroFwuh0KhgEqlgp+fH2+19sYAUyaTQa1Wt9rKJQiCU2t5e7uzy2QyVFVVwW63Izg4GCEhIV75XRDibrW1tU6t13l5ee0OsIcOHYrhw4cjOjqaX8gaM2ZMq2N5U1JSeNfiiooKZGRk4OzZs8jIyMD58+dRVFTUJKAuLy9HeXk5Tpw4wdOUSiX69OmDPn368IC8V69eHQrqfG1NcVfK63A4kJOTg/T0dKSlpSE3NxeCIDT7emq1GsOHD+ddxvv27dsZH8MnUdBNCCEtsFgsqK+v5zez2Qy1Wo2QkBDodDqvPrASIhIEAXV1dbBarU3GWdtsNt5iLbb2ipOUBQQE8ODa11sYmiN2e1cqlS3madid3Wq18sBcnGldq9VCr9fTvoB4vY4Gh7W1tU1asCsrK9t8nkqlajbAbu092zOWNyQkBOPHj8f48eN5Wn19vdO6z+fOnUNOTg6sVqvT+4iTfZ07d46nyWQy3j29Yct4axfufG1N8ZbKO2PGDERGRvIu45mZmTCbzc2+hlQqRUxMDEaNGoWJEydixIgR3fL44AleHXS//fbb2LdvH86fPw+VSoWkpCSsXLkSAwcO5HluvfVWHDlyxOl5c+fOxdq1a/n/hYWFWL16NQ4fPgyNRoMbb7wRDzzwAORyr/74hJBOIp5E19fXw2Qy8b92ux12ux0AeDBSWVmJoqIiKJVK6PV6BAcHQ6fT0dhN4hUEQUBtbS3q6upgMplgNBqbdPNsOIGZv78/D6zpmNhUw+7sGo2mq4tDSIe4GhzW1dU1acF2JcBWKpVOAfaIESPaDLBbIo7lPXnyJMrLy6HX6xEfH+9SYKdWqzFs2DAMGzaMpzkcDhQUFPBW28zMTGRmZjZZukrMV1BQ4JQeEhLiNE48KioKwcHBOHnypE+tKd7aGujvv/9+q8/t3bs3Ro4cifHjx2PcuHHw9/f3UCm7N68+wh45cgQ333wz4uPj4XA48OKLL+LOO+/E119/7XTwu+mmm7BixQr+f8OrUg6HA4sWLUJoaCh27NiBkpISPPzww1AoFLj//vs79fMQQrqWw+HgQXXDINtisYAxBkEQnFr6AgMDeUtYw6C6traWBzOFhYVQqVROATghnUEQBJhMJtTV1fGbOGbZ4XDw7uBKpRLh4eHQaDTdYu1rQojrWgu2Nm/ejFGjRsHhcCAvL4/Put+ahgH2kCFDMGLECPTt29etvT0ajuV1x2v17dsXffv2xfTp0+FwOJCamop+/frh/PnzfDKwc+fO4cKFC026p1dUVKCiogInT57kaSqVig+/acnOnTsRGRnJzy3Emzh0peEQFnelt3Tfbrfj7NmzLn9n/v7+iI+Px5gxYzBp0iRERES070snzfLqoHvTpk1O/z/zzDOYOHEi/vrrL4wdO5anq1QqhIWFNfsav/76KzIzM7F582aEhoZi6NChuOeee7BhwwYsX768zclYCCG+RxCEJoF1w5mV7XY7b+1TqVTw9/eHSqVyeXyqVquFVqsFYwx1dXWorq5Gbm4uCgoKoNFoEBISgpCQELoaTNxGEASYzWanVuy6ujoeYIsTmWm1Wmg0GqhUKkilUjgcDlgsFmi1WuoCSEgPIwgCdu3a1Wqe//73vy0+5ufn59SCPWzYMPTv379bDKcIDg7GuHHjMG7cOJ5mNpub7Z5usVicnttS1+uGjEYjnnrqKbeX25OmT5+OmTNnYvDgwd2ijr2NVwfdjYkzGjaeCW/Pnj348ssvERYWhiuuuAJLly7lrd2pqamIi4tDaGgoz5+cnIzVq1cjMzPTqQtKW1pad85biCdfLU120BOIdeTtdUUuutT6EgShybhr8SZuC1Kp1CkgEYPr5gIQxli7yyJO1iSOmzUajcjKykJ+fj4PwIODg7tF11TavjqPeLGoYSu23W6Hw+Hgk3mJvz2VStXk9yz+lsXjQU8+LvgSqi/f4k315XA4UFFRgeLiYn7Lzc11eYkuPz8/9OvXDzExMRg8eDCGDx+Ofv36tbhv8VWtHccUCgXi4uIQFxfH0wRBQGFhITIzM3H27FmcO3cOaWlpLS6T5cvGjRuHuLg4r6pjXznvcOWitoT5yLz5giBgyZIlMBqN+Oijj3j6xx9/jMjISISHhyMtLQ0bNmxAQkICXn/9dQDA448/jsLCQqdW8/r6eiQmJuKdd97BlClT2nxvsSuKtzOZTKiurqY1CUm3ZLPZYLVa+dI/FosFVquVBxbimsBi93Dx1hWte2KrpDjZkkwmg0qlglar5WNoCRGJM4iLE5017CIOwGnIQ1f9pgkh3sHhcKCqqgqVlZWoqKhAZWUlv3U0+DcYDJg6dSq1brooMzMTb731Vpv5+vXrxyddlclkfInCxv+L9xunNU5v+Lfx/ZbySqVS5ObmYuvWrW2Wd/HixYiNjXXHV9TjjB49us08PtPSvWbNGmRkZODDDz90Sp87dy6/P3jwYISFhWHBggXIzc11+7T1rk7k0FWqqqpQVFR0SWvi+TqHw4HMzEzExsZ6dV2Ri5qrL5vNBpPJxINWsWu42MrHGINCoeDBq9hy7a2BrCAIMBqNMBqNsFqtMJlMkEqlfIkhlUrV1UV0GW1fl85ms/GWa7El22Kx8N+2RqPhPSPUavUlj8EWBAE5OTno168fnVD7AKov3+LJ+rLZbCgpKXFquS4pKUFZWZnbW9b/3//7f24bQ+3tHA4HTp48eUnn9PHx8fjss89QVlbWYp6wsDC88847XnGsdDgc+Oabb9os74wZM7yivA25o768hU8E3WvXrsVPP/2Ebdu2oXfv3q3mHTlyJAAgJycHffv2RWhoqNPafAD4j66lceAtEa8keauGV7p6OvoevJ/YGixOSGaxWGAymWC1WvnkH2ILnxhYi399aaZwmUwGvV4PvV4Ph8MBo9GI6upqVFdXIy8vD4GBgQgODoZer/faCweN0fblmsYzidfW1sJsNvMAW+wBIY7/92T9iy0fxDdQfXk/cQmuc+fOweFwYNCgQR3aL5rNZpSUlKCoqAjFxcX8b0VFRZNJvVoik8nQq1cv9OnTB/369cOAAQMQGxuLPn364Pbbb3dafquxsLAwJCYm9rjf26Wc08tkMvzzn/9sdU1xb5o3ytfK2xxvj8Fc4dVBN2MMTz75JPbv34+tW7ciOjq6zeecOXMGwP8C6sTERLz11lt82QEAOHjwILRaLXWhIKQTmc1m3sInBiJWqxUlJSWw2+18UrPg4OB2TWrmS2QyGYKDgxEcHAyHw4Hq6moYjUZUVFQgNzcXAQEBfBI2mmXat7gyk7g4I744DtuXLh4RQv6n8RJc+/fvb3N9ZpPJxANq8VZUVOS0nF9bFAoFevfujejoaB5cDxo0CH369Glxyb/ly5e3GWz5ejDTFdqzprg38LXydkdeHXSvWbMGX331Fd544w34+/vzH4lOp4NKpUJubi727NmDKVOmICgoCGlpaVi/fj3Gjh2LIUOGALg4aVpsbCweeughPPjggygtLcXLL7+Mm2++2auv6BDiy8QutGJwXVtbC5vNBofDAYlEAoVCAbVajaCgIAiCgIEDB/a4g75MJuMBts1mcwrA5XI5goKCeIBOAbh3YYzxmcTFFmxxJnHxAlJzM4kTQnxfW0tw/d///R/0er1TgF1UVMQnA3aFn58foqKieHA9cOBAxMbGIiIiot3HSgq2POdS1hTvCr5W3u7Gq4NuccK0W2+91Sl9/fr1mDlzJhQKBQ4dOoQPPvgAJpMJERERuOqqq7B06VKeVyaT4a233sLq1asxd+5cqNVqzJgxw2ldb0JIxzXXhVZs4RPHX6vVagQEBECtVjtd7BKXOurpFAoFQkNDERoaCqvVCqPRiMrKSpSWlsLPzw+BgYF8HXD6vtxPEARYrVbY7XZ+Ey8SiYG0zWZzeqzxTOL+/v58NnGqI0K6J1eW4NqxY4fLr6dWq3lw3b9/fwwcOBAxMTHo1auXWy/UUbDlOe5cU7wz+Fp5uxOvDrrT0tJafTwiIgLbtm1r83WioqKwceNGdxWLkB5LXP+6YRdak8nk1IVW7CIudqEl7ePn5+cUgFdXV6OyshJlZWVQKBR8Arbg4GBqPW1GRwJocfZ7xhi/DwASiQRSqRQSicRphliNRgOlUgmNRtNil05CSPfAGENlZSUKCgpw8uRJl5fgakir1SIqKgp9+/blwXVsbCz0en2nDTOhYIuQrkVnC4SQFjUchy3exIBFJpNBqVRSF1oP8vPzQ1hYGMLCwmCxWFBdXY2ysjKUlJRAqVTy7udBQUHd8rvvrABaJpNBLpdDLpdDKpXSslyE9FAOhwPFxcUoKCjgt8LCwnavyTxy5EhMmjQJMTExGDhwIIKDgz1UYkKIr6CgmxACwHkctthNXFwHu+E4bHE5IwpKOpdSqUR4eDjCw8NhNptRVVXFxwuKAXhISAgCAgI6PQAXZ5sXb4wxvn5645s47KC5vI2DawqgCSGeYrFYUFhYyIPr/Px8FBUVwW63X/JrL1iwgFqVCSFOKOgmpAcSBKFJgN1wKSOxm3hISAg0Gg1NOuhlVCoVXz6xvr4eVVVVKCoqQlFREZRKJUJCQqDX6+Hv7+8U6DYOhMU0MagVH2+cLt7sdjsKCwthNpubBM4AeIAsEvNIJBL+mEQi4d0pxfvi/60F0OJ9CqAJIe1lNBqdWq8LCgpQVlbm0pJcgYGBvEv4oEGD8O6776KioqLF/GFhYYiPj3dn8Qkh3QAF3YR0c+JMyzU1Nc2OwxbXCqaljHyTOHkXcHFJmurqahQWFqKoqAhSqbTZQLhxkNw4+G0cFIutygBgt9v5hRmpVMpvDfM2TJPJZE6v0R27wRPizcT1pI1GIwICAjBw4ECv3Q4vtayCIKC8vBz5+fkoLCxEfn4+CgoKXJo5XCKRIDw8nK9xPXjwYAwdOpQvNyvy9/enJbgIIe1GQTchzWg4YZjZbIbJZOItdi211DUOWMT74glDcwFN4zwAms3f1v2Gz5dIJE5dxWtra/lMyzKZDAqFAlqtlgdr3nryRdpPo9FAo9EAAF+mraVAGIBTQOwKh8MBq9XaoWVrCCGdr/F60gDaXE+6q7S3rHa7HRcuXGgy/tpisbT5XgqFAn369OHrXA8dOhRxcXH8AmZraAkuQkhHUNBNejyr1QqTyYT6+nqYTCZ+X2wJlkqlvFUPgFMrYXN/Rc11W2vc4tic5l6vcSDfWOPHBUEAAMjlch6IqdVqmmm5B9FqtV1dBEJIF2prPemFCxd6TeDdVlnnz5+P4OBg3nJdUFCA4uJifqxrjUaj4d3D4+LiMHToUAwYMOCSLhyKS3Clpqbi2LFjSEpKQmJiIl2MJIS0iM7ASY8htl43DK5NJhOfLEzsMuvn5wetVguVStXla+6KJxSNuwM3DMibyyN+DkIIIT2PIAjYuXNnq3k+/PBDZGdnNztEpLm/jdM68pzm/jLG8Omnn7ZZVlfo9Xr0798fsbGxPMDu3bu3R4ZMNVyCiwJuQkhbKOgm3ZLNZuPdwhsG2Q1br2UyGdRqNQ+wlUql141lpq7fhBBCWiMIAkpLS1FYWMhvOTk5qKura/V5FosF//nPfzqplO4llUoRERHB17seMmQIhgwZgoCAgK4uGiGENIuCbuLTBEGAxWLhk4PV1dUhOzsbVVVVvEVYKpXCz88P/v7+fKIw6mZNCCHE15hMJqfgWpw00WazdXXRPC4+Ph5TpkzBkCFDMGjQIOrNRQjxKRR5EJ9hs9n45GbNtV6LE0QxxhAYGAh/f38olUpqLSaEEOJTxFm4CwoK+GRhhYWFqKqqcun5CoXCpUB8yZIliImJ4cfRxssJiv83Xm6w4a215zX8v6XHSktL8ccff7RZ1jvuuIPWviaE+CwKuonXEZe4ajjuur6+HhaLhR+wZTIZb71WqVRQqVRQKBT88eDgYBpfRQghxOvV19ejsLCQB9ZZWVmorKx0KWiWSCQICwtD//79MWDAAMTFxWHIkCEIDw/H/PnznWbXbiwsLAyzZs3q8mOlw+HAvHnz2iwrrX1NCPFlFHSTLmW3253GXYst2Xa73WkGbpVKhaCgID72mlqvCSGk++gJa0kLgoCysrIm3cMrKytdel+VSoXo6GindaQHDRrU4jJXy5cv94n1pGUymc+UlRBCOoqCbtIpBEHgQXXDm8Vi4d3TxDWkxXHXKpWKxmwRQkg31x3XkhZbrxuPvbZarS69j9h6PXDgQL6OdERERLsm+/Sl9aR9qayEENIRFHQTt3I4HDy4NpvNvAXbarXy4FqcOVypVCIwMJAH2N7aqkEIIb5IEARkZmbi3LlzcDgcGDRokNftZ7vTWtIJCQkQBAEFBQUut14rlUr07dsXAwYMQExMDAYNGoT6+nqMHz/eLS274nrSJ0+eRHl5OfR6PeLj472y1diXykoIIe1FQTfpELvdzlurxeC6Ycu13W6HTCbj60UHBgZCqVRCpVLRAZQQQjyscYvs/v37u6T1WBAEWK1WfqywWCz8vslkwldffdXq87dt24YRI0Y0aeFljDXJK6a19lhH0xhjSE9Pb7WsJ06caPXx5sZeR0REOF0IcTgcSE1NbfV12qvhetLezpfKSggh7UFBN2mVOGO42Wx2WvdabLkWg2uZTAaVSsVbrpVKJQXXpNvwpfGmhLij9ZgxBqvVyvf94k28uNrS/cbBtcViuaTPYrPZcOzYsUt6jc6mVCoRHR2N/v378zWk4+LiWhx7TQghpPujoJsA+F9w3bhbuM1maza4DgoKglKppOCadHu+NN6UeJYvXHwRBAG7du1qNc9HH32ErKwsHjC3dGuu1Ze0bunSpZg1a5bX/S4IIYR0LQq6e5jGwXXjlmtxOS6xW7i41jWNuSbuRuNNPccXgkORr5S1My++OBwOp2E77bmJqz+0xmw246effnJrmRvy8/ODRqOBWq2GWq2GRqOBRqOBv78//6vValFZWYndu3e3+XqPPfYYhg0bBgBO3cybm1RMTHN3vlOnTuGJJ55os6zeuB8jhBDS9Sjo7qYajqEzmUz8r9VqBWPMKbhWKpV8vWtajsuZrwQEIl8pr7eMN22N3W5vs8Vw165dGDp0KBQKRSeVqm2+1DLvK2Vt78UXQRCcAuHWAujGE0+6o0t2R4mrR4iBslqt5oGyGCyLN51OB61WC61WC51OxwNptVrtcu8nh8OBX3/9tc31ma+44oou71E1adIkhIWF0VrShBBCOoSC7m7EaDQiNzcXFovFKbiWSqVQKBRQKpXQ6XS8W7g3BmPexFcCApGvlNddrceMMdjtdlitVn6zWCyw2Wz8vphus9mc/nflZrPZ2ixDdXU1HnroIb6NNb7J5fJm091xa2779aWW+Y6UVdyntXZzOBw8n3jf4XC0+bzWXm/v3r2tfpYPPvgAYWFhTmObO5vYuiyTyVBeXt5m/iVLliAxMRE6nY4H1Z198ciX1mf2pbISQgjxPhJGg7baJM4mOnjwYPj7+/PuZjabjY91briedH19PQA4BbZ2ux02m+2S8opj7Pz8/PiB3eFwwGq1QiqVIicnBydOnIBWq+XP9ff3h1wu53ntdjskEonT64oBulwu568rCAJsNtsl5RXHg19qXvH7Edntdr6ut/jZxLwOhwOFhYUYMGAAZDJZs3nFCYKAiyeqYn02zHv69OlmAwLRbbfdhmHDhjm9LgB+st0wKGquDC3lFetIDOIaf+8t5T1z5kyr5b399tsxdOjQFuuzudd1te7FGesbft9ms5nXsxi4iEMbPv74Y5hMphbLqlQqkZCQwAPohoF140C6J+++xN+In58fD/DLysogCEKLz5HL5YiJiQFwsZ5FEomEz9AsPl9Ma5zXYrHw30VzeQVB4PfF9IZpwMVtsKKiotWyAhe3z4YBdHcml8ubtCarVCr4+/sjMDAQAQEBPEAW0/R6PbRaLfz9/fkFBplMhltuuaXVFtnQ0FBs3rzZqVW64bGk4f5W3L5bOu64mlcikUClUjWb97fffmt1fWar1QqHw8F/58D/9j0AnCYo60he8eIYcPG3aTabW8x76NAhvPXWW05lDQ0NxfLlyzFlyhQAbZ8bqFSqFs8jGp5viEtrduZ5RMP6bE9eT/1OmqvP9uRtT9135HficDhw9uxZJCUlQSaT8fps6TfVWt23Vp/uON9srj7d8TvpjH1ER34nLdVnfX09jh07htGjR/OyuXMf4Y667+jvpDvuIwAgNTUV8fHxcDgcXruPaPgdtoSaOtth9uzZTq2IH3/8MQwGA1599VWnfDNnzoTBYEBJSQlP+/zzz2EwGPDcc8855Z03bx4MBgNycnJ42rfffguDwYC1a9c65V2wYAEMBgMyMjJ42o8//giDwYDHHnsMSqUSWq0WvXv3xqZNm7B69WpkZ2fzvKdPn0ZKSgrefPNNp9d9/fXXkZKSgrNnz/K0jIwMpKSk4JVXXnHK+8477yAlJQUnT57kadnZ2UhJScHzzz/vlHfz5s1ISUnB0aNHedqFCxeQkpKCtWvX4r///S8yMzMhCAK2b9+OlJQUHDp0iOctLy9HSkoKVq9e7fS6n3zyCVJSUnDgwAGeZjQakZKSgscff9wp7+eff46UlBR8//33PM1sNiMlJQUpKSlOJ/179+5FSkoKvv766za7FX/88cdISUnB559/zieas9lsePTRR5GSkoKSkhLU1dWhtrYW+/fvR0pKCrZt24bKykpUVFSgrKwMq1at4t/7hQsXUFhYyMuwceNGZGdnIysrC+fOncPatWv593P27FmcOXMGX375JVJSUvDqq6/i448/brW8H374IVJSUvDMM8/gyy+/xO7du/HZZ59hzZo1SElJwRtvvIH33nsPGzduxIsvvsi/yxdeeAHPPfcc1q9fj8ceewwpKSn417/+hUceeQQPPfQQVq5ciUcffZSnPf7441i9ejWeeeYZvPDCC9iwYQNefPFFvPLKK3jjjTewefPmVgNu4OLO9o8//sCJEydw5swZZGRkICcnBxcuXEBFRQVqa2v5BQB38/PzQ1hYGPr06YPevXu79Jw+ffqgf//+/H+dTge1Wu10gcUTxJ1/TU0NKioqUFJS0mYQa7fbkZaWhrS0NGRmZvJbRkYGH1+flZWFrKwsnD9/nt/Pzc3lt+LiYuTl5SEvLw8FBQUoKChAfn4+v3/hwgUUFRWhqKiI3y8pKUFpaSm/tXVxQCReXPGVgFun0yEiIgIxMTEIDw8HcPH3MWPGDNx2221YunQpP+FZt24dPvjgA+zatQt33XUX7HY7Jk6ciA8//BAbN27Eyy+/jFOnTuHHH3/EzJkzsWDBAsyaNQtmsxmrVq3C7t270adPHwQFBUGhUODWW2+FwWBAbm4uli9f3mo5BUHAddddh9OnT/O0X375BQaDAQ8//LBT3mXLlsFgMDjNIH7kyBEYDAbcc889TnkfeOABGAwGp/34yZMnYTAYsHjxYqe8jz32GAwGA3788UdMnjwZH330Ee677z4AQHBwMD766CNMnjwZALB27VoYDAZ8++23/Pk5OTkwGAyYN2+e0+s+99xzMBgM+Pzzz3laSUkJDAYDZs6c6ZT31VdfhcFgcNp/VldXw2AwwGAwOOV95513YDAYcP78eXz00Ud46aWX8NBDDwEAysrKMG7cOJ53y5YtMBgMeOedd5xeQ3xdV84j5syZ0yXnEQ0tXrwYBoPB6Xh/6NAhGAwGPPDAA05577nnHhgMBhw5coSnHTt2DAaDAcuWLXPK+/DDD8NgMOCXX37haadPn4bBYMBdd93llPeJJ56AwWBwOoZnZWXBYDDg1ltvdcr79NNPw2AwYM+ePTytsLAQBoMBc+bMccr74osvwmAwYOfOnTytvLwcBoMB1113nVPeN954AwaDAdu3b+dpdXV1PG/DfdmmTZtgMBiwadMmnuZwOHjd19XV8fTt27fDYDDgjTfecHq/6667DgaDwanHys6dO2EwGPDiiy865RV/J4WFhTxtz549MBgMePrpp53yivuIrKwsnvb999/DYDA0ma/grrvugsFg8Jp9hCgjIwMGgwELFixwytuefcSGDRvw2GOP4YsvvuBp7txHbNmyhaeZzWaeVwy+AffsI7oq1mioM/cRZ86c8ep9hCuoeznpVOI6p3V1ddi6dSuAi12gg4ODO+X9HQ4Hampq+P9nzpzh493FA9Hx48eddnjNEa90/fbbb/jtt9+aPP7ss882STt+/DiOHz/eJH3jxo1N0jIyMppc8ACAzz77rElafn5+q2UFwHsMVFZW4j//+U+Tx8+dO9ckzWq1NvvaDQ8cnUmhUPAWz4CAAOj1eiiVSkgkEpw5cwZSqRRXXnklVCoV1Go1jh49ioyMDEyaNAlTp06FRqOBw+Hg3UN37NjB87799tvYtWsX5syZw3fotbW1TXasjYWFheH999+HTCbDFVdcAeBiV+OgoCAAwNatW/Hee+/hyiuvxD/+8Q9YLBZYLBYsXboUVqsVK1euhEajgdlsxu+//44DBw5g4MCBGD9+PF+uad++fbDZbIiPj4dcLofVakVpaSlKSkr4hTaxF4ErXeI9QSqVQiKRQCKR8Em8xNUOxN4OYs8HtVrNey+0JSgoiPfcKS0thclkQnh4OPR6PaRSKb+IIJPJMHr0aEgkEshkMmRmZqKkpASxsbG814vNZsMPP/wAiUSCmTNn8vIdPXoU6enpSExMxNixY/nriifNs2fPbna7a86HH34IrVYLAHj//fexZcsWjB49GitWrOB53n77bQBAXFwcwsLC+HflTpMnT8aaNWuwYcMGp/2d2Hrc+ETPG8hkMsTFxQGAU0uINxLXkh48eHCTk1tCCCGkOdS93AW+0L2cMYYDBw7g9OnT6Nu3L/r06QOJRHJJ3Ybd3b28pTGcoltuuQWJiYltdi+3Wq2oq6vjXY1NJhNvVa6rq0NpaSn8/Pz4TL7iREXiLO3EdVKplHeLF4OUhuOVxTRxtvuG3XDEfEqlEnK5nHd/bu4iRWMPPPAAhg0bBpVKheDgYL59eLrraOO8P/zwA5566qkWy7lmzRreGtfV3cJSU1N5S2Frnn76acTHx8NisfBttmFwLO4jxM8hkUhgsVj4dn/q1CkkJiby760j3QddLetLL73k9F6d3XUUuPg7nj9/vkvdtTt6fPBU11GLxYKjR4/i5MmTGDNmDN+/dueuo529j3B311HqXu6dXUepe3n32UdQ93Lf2kcA3ad7OQXdLhAPgg0DQm9y4MCBJuPhvG0CLUEQsHbt2lZbkDUaDe+CIwbKJpOpyf2uamltLCIiAhqNBlKplLf0ifcb/y/eb5ynuXxiANRSvsaPl5SUYN++fW2W94477kBcXJzTOOCGgXLjv2JA7U4OhwPz5s1rcwbgjz76yGu2tea2r4bjTb1FZ3y37toX+trv4MCBA61OoNXw4ou38fbjF3FG9eVbqL58D9WZb+lO9dWjupdv374dmzZtQmlpKYYMGYLHH3/ca4LSjmrpZLC5GYDF2Z5buoljJ8X7reVtTx6Hw8FbnVtjMplc7sbZHg0nKBKXuBGXuRFv4kRFgYGB0Ol0eOihh1qdATgsLAxbt271ih2Aw+HAsWPH2gxg5s+f3+Xllcl8bwbgyZMn47LLLsPJkydRXl4OvV6P+Ph4ryoj4FvfrS+VFfhfd21fuPhCCCGEEO/TY4LuvXv3Yv369VizZg1GjhyJLVu24M4778S3334LvV7v0mvU1dVBp9PxLh/iJD/iWtcN8wEXux407BpktVohk8mcujq0J6/JZAJjDCqVCjKZDA6HA6+++iqfZKjhCaqYtnnzZt5lreFsz83lFVtPgf8tzeMteRUKBQ+cxXVkAwMDeZCs1Wr5TL+1tbUYPXo0goKCeDcWPz8/3vWDMcYn89JoNE3qU6FQYMWKFVi1apVTGcTWZgBYtGgRzGazS3Xvjt9J47pvnLdhACN+lw3Lu3jxYpjNZkil0ibdrARBcHpdu90Oi8XSYl6xu7j4XmazGRKJBBqNxqW8Y8aMcQpgxPKGh4djxYoVmDx5Ml/nGAD8/f3564rd+cSWegAt5rVYLLDb7bxFv3HdtyevRqNx6ubcWt0395vqrH3EmDFjkJKSgnfffRdlZWX8+9Hr9ViyZIlTcNjcb6qtum84OZxYnx39nUyePBmPPvoo3nzzTZSXl/PPFhoairvuugtjxoxBQ5da9x39nYj1OXnyZIwdOxapqamorq5G7969ER8fD6lUesl178l9RHNLmHWk7jtzH9E4b3vqviv3Ea7Wvat5ZTKZx88jWqvPjvxOmqvPS/mdNFef7viduGsfIa4aIGp4HnGpv5POPo/o6O/EF/cR4hwoDYcz+uI+AvB8rNFafXbGPkL8Hrx9H9GwblrEeojZs2ezNWvW8P8dDgdLTk5mb7/9dpvPtdvt7M8//2T+/v6spKSEp69bt44BYHfddZdTfo1GwwCwrKwsnvbSSy8xAGz+/PlOeUNDQxkAdurUKZ72zjvvMADshhtucMrbr18/BoAdOXKEMcbYsWPH2NChQxkAFhwczKZOncpvYhlGjhzJ04YPH84AsICAAKe8Op2OAWDx8fE8LSEhgQFg/v7+TnkDAwMZADZs2DCelpSUxAAwtVrtlFev1zMALCEhgV1zzTVs6tSpbPTo0QwA8/Pzc8obFhbGALBZs2axffv2sSNHjrDvvvuOAWCBgYFMEAT+Pdx+++0MAHvuued4Wn5+PgPA5HI5+/PPP5ndbmeMMbZ06VIGgK1atYrnraysZAAYAGa1Wnn6ypUrGQC2cuVKxhhjP//8M5s1axbPe9lll7E5c+awn3/+ma1atYoBYEuXLnWqI7lczgCw/Px8nvbcc88xAOz22293yit+l+np6Tzt9ddfZwDY7NmznfJGRkYyAOzYsWM8bfPmzQwAMxgMvLxz5sxharWaAWBJSUm8vJ988gkDwKZMmeL0uiNHjmQA2L59+3jaV199xQCwMWPGOOWdNGkSA8B2797N0/7zn//w30ND06dPZwDYtm3beNqRI0cYANavXz/G2P+2q8TERAaAvfXWWzzvqVOnGAAWGhrq9Lrz589nANhLL73E07KyshgAptFonPLeddddDABbt24dTyspKeH12dA999zDALBHH32Up9XW1vK8tbW1PP3RRx9lANg999zj9BpiXm/YRxw6dIgdO3aMff/99+ypp55iANj06dOd8g4bNowBYP/5z3942u7duxkANmnSJKe8Y8aMYQDYF198wbevffv28X1MQ1OmTGEA2CeffMLTfv31VwaAxcbGOuU1GAwMAFuzZg37/vvv2bFjx9iff/7JALDIyEinvLNnz2YA2Ouvv87T0tPT+T6iobb2EQ1dyj6CMcasVivPW1lZydO9aR9x2WWX8X0iY4zFxsYyAOzXX3/lad64jxDdcMMNDAB75513eFp33UeI+8XOOo9gjLFt27a5bR/x1Vdf8TR37iM2b97M044dO+ZV+4jff/+db1++uo8QzyNE3XkfMW/ePAaAvfDCCzzNl/YRop6yjxD3iT///LNX7yNc0SNauq1WK/766y8sWrSIp0mlUkyaNMlpiQNf01r354aCgoIQGBgImUyGv/76C/7+/hg9ejSf/Co9PR01NTUYN24cEhMTedqJEycQGhqKe++9l7cUr1y5EqmpqViwYAGuueYaKJVKHD9+HLNmzUJERAT27NnDJ9C67rrrsHfvXtx333249dZbMW/ePKeZdJszZcoUXHnllQDgtFyBeKWrM02ePBnjxo3jywWsX78ekyZNgkwmc1rCwluI3aAHDBiAvLw8rFixArfeeitkMhk+/fTTri5eE+IMwIGBgQDAr76SSyd+twBQVFTUtYVxQd++fTFt2jQAFydMIYQQQgjpTnrERGrFxcWYPHkyduzYgaSkJJ7+3HPP4Y8//mgzILHb7Th+/Dj69+8PrVbrNV0+Tp48iUceeaTVLuNSqZTPVtzV3cIOHjyI9evXt9i9/IEHHsDll19+SV0+BEFAdnY2hg0bBplM1qHuPtQtrPO6hYnj0QcPHgyVStWjuo66Wvfe1C1MLpcjPT0dw4YN4/XRnbuOtlSfvrSPMJvNSEtL47Mrd7TufanrqC/vIxwOB06fPo3+/fvz79eX9hE9rXu5IAjIysrC8OHDIZPJfHIf4evnEe2t+7q6Ovz1119ISEjgn9mX9hGN83b3fYREIsHp06cxePBgvlKSN+4jxImVW2skpKDbhaDbarU6LfxOCCGEEEIIIYQAaHOG9R7RvTw4OBgymaxJd+zy8nKEhoa2+Xy5XM4nzOmKbs6EEEIIIYQQQrxTW8Mke0TQ7efnh+HDh+PQoUOYPn06gItdBA4dOoRbbrmlzedLpVKXFj0nhBBCCCGEEEIa6hFBNwAsXLgQDz/8MEaMGIGEhARs2bIF9fX1mDlzZlcXjRBCCCGEEEJIN9Vjgm6DwYCKigq8+uqrKC0txdChQ/Huu++61L2cEEIIIYQQQgjpiB4xkRohhBBCCCGEENIVaGFcQgghhBBCCCHEQyjoJoQQQgghhBBCPISCbkIIIYQQQgghxEMo6CaEEEIIIYQQQjyEgm7S6d5++23MmjULSUlJmDhxIpYuXYrz58875bFYLFizZg3Gjx+PpKQk/POf/0RZWZlTnsLCQtx9990YOXIkJk6ciGeffRZ2u50/npKSgsGDBze5XXPNNS2WLT8/v9nnpKamuvU78DXuqrN169Zh5syZGDFiBG644YZm3+vs2bOYP38+4uPjMWXKFGzcuLHN8rX1W+hpOqu+Dh8+jCVLliA5ORmJiYm44YYb8OWXX7ZZvua2sa+//vrSPrQP66z66uj+jbavpjqrzl577bVm6ywxMbHV8tE25swd9XX27Fncf//9mDJlChISEnD11Vdjy5YtTd7r8OHDmDFjBkaMGIErr7wSu3btarN8HTnudWedVV/79u3DwoULMWHCBIwaNQpz587FL7/80mrZ6DyxeZ1VZ4cPH272+y8tLW21fF6xjTFCOtkdd9zBdu7cydLT09mZM2fYP/7xDzZ16lRWV1fH8zzxxBNsypQp7ODBg+zkyZPspptuYnPnzuWP2+12du2117IFCxaw06dPs59++omNHz+evfDCCzyP0WhkJSUl/HbhwgU2btw49uqrr7ZYtry8PBYXF8cOHjzo9Fyr1eqZL8NHuKPOGGPsySefZNu2bWMPPvggu/7665u8T01NDZs0aRJ74IEHWHp6Ovvqq69YQkIC27FjR4tlc+W30NN0Vn29+eab7KWXXmJHjx5lOTk57P3332dDhgxhP/74Y6vli4uLYzt37nTaxsxms3s+vA/qrPrqyP6Ntq/mdVad1dbWOtVVSUkJMxgM7OGHH261fLSNOXNHfX366afsySefZIcPH2a5ubns888/ZwkJCWzr1q08T25uLhs5ciRbv349y8zMZFu3bmVDhw5lBw4caLFsHTnudXedVV/r1q1j77zzDjt+/DjLyspiL7zwAhs+fDj766+/WiwbnSc2r7Pq7Pfff2dxcXHs/PnzTt+/w+FosWzeso1R0E26XHl5OYuLi2NHjhxhjF0MlocPH86++eYbniczM5PFxcWxY8eOMcYY++mnn9iQIUNYaWkpz/Phhx+yUaNGMYvF0uz77N+/nw0ePJjl5+e3WBZxZ3r69Gk3fLLuqyN11tCrr77a7Anm9u3b2dixY53q8Pnnn2d/+9vfWixLR34LPY2n6qs5//jHP1hKSkqreeLi4tj+/ftd/wA9jKfqqyP7N9q+XNNZ29iZM2dYXFwc++OPP1rNR9tY6y61vkSrV69mt956K///ueeeY9dcc41TnnvvvZfdcccdLb5GR457PY2n6qs5BoOBvfbaay0+TueJrvFUnYlBd3V1tctl8ZZtjLqXky5XU1MDAAgMDAQAnDp1CjabDZMmTeJ5YmJiEBkZybvvpKamIi4uDqGhoTxPcnIyamtrkZmZ2ez7fPbZZ5g0aRKioqLaLNOSJUswceJEzJs3Dz/88ENHP1q31ZE6c0VqairGjBkDPz8/npacnIysrCxUV1e3+Jz2/hZ6Gk/VV0vvFRQU1GY+sYvZ7Nmz8dlnn4Exdknv2514ur7as3+j7cs1nbWNffrpp+jfvz/GjBnTZl7axlrmrvpqvL9LTU3FxIkTnfIkJye3+hodOe71NJ6qr8YEQUBdXZ1LxzA6T2ydp+vsxhtvRHJyMhYuXIijR4+2WhZv2cbknfZOhDRDEAQ8/fTTGDVqFOLi4gAAZWVlUCgUCAgIcMqr1+v5mI2ysjKnk0AA/P/mxnUUFxfjwIED2LBhQ6vl0Wg0SElJwahRoyCRSLBv3z4sW7YM//73vzFt2rQOf87upKN15oqysjL06dPHKU2s17KyMr7zbvyc9vwWehpP1ldje/fuxcmTJ7F27dpW861YsQITJkyAWq3Gr7/+ijVr1sBkMuG2227r8Ht3F56sr47s32j7altnbWMWiwV79uzBP/7xjzbz0jbWMnfV13//+1988803ePvtt3laS9tLbW0tzGYzVCpVk9fpyHGvJ/FkfTW2adMmmEwmXH311S3mofPEtnmyzsLCwrBmzRqMGDECVqsVn376KW677TZ88sknGD58eLOv4y3bGAXdpEutWbMGGRkZ+PDDDz36Pp9//jl0Oh2mT5/ear6QkBAsXLiQ/5+QkICSkhJs2rSJdqb/v86qM+IenVVfv//+Ox599FGsW7cOgwYNajXvsmXL+P1hw4ahvr4emzZtooAAnq0v2r95RmdtY/v370ddXR1mzJjRZl7axlrmjvpKT0/H0qVLsWzZMiQnJ7uxdKSxzqqvPXv24N///jfeeOMN6PX6Fl+L9qNt82SdDRw4EAMHDuT/jxo1Cnl5eXj//ffx/PPPX1K5PY26l5Mus3btWvz000/YsmULevfuzdNDQ0Nhs9lgNBqd8peXlyMsLIznaTwLrPi/mEfEGMPOnTtxww03OHUtcdXIkSORm5vb7ud1R5dSZ65orV4btx648pz2vHd35On6Eh05cgRLlizBI488ghtvvLHdzx85ciSKiopgtVrb/dzupLPqq6G29m+0fbWuM+vs008/xdSpU1vcF7aGtrGL3FFfmZmZWLBgAebOnYulS5c6PdbS9qLVaptt5W7tOeJjPZmn60v09ddf41//+hdefvllp+7PrqLzxP/prDprKD4+vsPHsc7cxijoJp2OMYa1a9di//792LJlC6Kjo50eHzFiBBQKBQ4dOsTTzp8/j8LCQr5MSmJiItLT01FeXs7zHDx4EFqtFrGxsU6vd+TIEeTk5GD27NkdKu+ZM2d6/MmlO+rMFYmJifjzzz9hs9l42sGDBzFgwIAWu/+057fQU3RWfQEXl+9YtGgRVq5ciblz53aovGfOnEFgYGCHLop1B51ZX421tX+j7at5nV1neXl5OHz48CUdx2gbu/T6ysjIwG233YYbb7wR9913X5P3SUxMxO+//+6UdvDgwVbrvCPHve6us+oLAL766is88sgjeOGFFzB16tQOlZfOEzu3zho7e/Zsm8cxr9jGOnXaNkIYY6tWrWKjR49mhw8fdpruv76+nud54okn2NSpU9mhQ4fYyZMn2dy5c5tdMuyOO+5gZ86cYQcOHGATJkxodhmblStXsjlz5jRblq1bt7LbbruN/79r1y62Z88elpmZyTIzM9mbb77JhgwZwj777DM3fgO+xx11xhhj2dnZ7PTp0+zxxx9nV111FTt9+jQ7ffo0n1HSaDSySZMmsQcffJClp6ezr7/+mo0cOdJpWYd9+/Y5zTjZnt9CT9FZ9XXo0CE2cuRI9sILLzi9T2VlJX+NxvX1ww8/sE8++YSlpaWx7Oxstn37djZy5Ej2yiuvePZL8WKdVV+u7N9o+3JNZ9WZ6KWXXmLJycnMbrc3KQttY21zR32lpaWxCRMmsJUrVzq9Rnl5Oc8jLhn27LPPsszMTLZt27YmS4Y1Pu9w5bjX03RWfX355Zds2LBhbNu2bU55jEYjz0Pnia7prDrbvHkz279/P8vOzmZpaWls3bp1bMiQIezgwYM8j7duYxLGaDpL0rkGDx7cbPr69esxc+ZMABcnjHnmmWfw9ddfw2q1Ijk5GatWrXK6klVQUIDVq1fjyJEjUKvVmDFjBh544AHI5f+bqqCmpgbJycl47LHHcNNNNzV5z9deew27d+/Gjz/+CADYvXs3Nm7ciMLCQshkMgwcOBB33nkn/v73v7vzK/A57qqzW2+9FUeOHGnyOj/88AOf5OLs2bNYu3YtTp48ieDgYNxyyy24++67ed5du3bhkUceQVpaGk9z5bfQk3RWfaWkpGD37t1NHh83bhy2bt0KoGl9HThwAC+++CJycnIAAH379sW8efNw0003QSrtmZ2vOqu+XNm/0fblms7cJwqCgCuuuKLFlh/axtrmjvp67bXX8Prrrzd5jaioKH4OAVzs/bN+/XpkZmaid+/eWLp0KX8P8XUanncAbR/3eprOqq+Wtr8ZM2bgmWee4a9D54lt66w627hxIz755BMUFxdDrVYjLi4Oy5Ytw4QJE3h+b93GKOgmhBBCCCGEEEI8pGde8iSEEEIIIYQQQjoBBd2EEEIIIYQQQoiHUNBNCCGEEEIIIYR4CAXdhBBCCCGEEEKIh1DQTQghhBBCCCGEeAgF3YQQQgghhBBCiIdQ0E0IIYQQQgghhHgIBd2EEEIIIYQQQoiHUNBNCCGEEEIIIYR4CAXdhBBCSA/EGMOCBQtw5513Nnls+/btGDNmDIqKirqgZIQQQkj3QkE3IYQQ0gNJJBKsX78ex48fx44dO3h6Xl4eNmzYgH/961/o3bu3W9/TZrO59fUIIYQQX0BBNyGEENJDRURE4LHHHsOzzz6LvLw8MMbw2GOP4bLLLsOwYcNw1113ISkpCZMmTcKDDz6IiooK/twDBw5g3rx5GDNmDMaPH49FixYhNzeXP56fn4/Bgwdj7969uOWWWxAfH489e/Z0xcckhBBCupSEMca6uhCEEEII6TpLly5FTU0NrrrqKrzxxhv4+uuvcc0112DOnDm44YYbYLFYsGHDBtjtdnzwwQcAgO+++w4SiQSDBw+GyWTCK6+8goKCAnzxxReQSqXIz8/HtGnTEBUVhZSUFAwdOhRKpRLh4eFd/GkJIYSQzkVBNyGEENLDlZeX45prrkF1dTVee+01pKen4+jRo9i0aRPPU1RUhClTpuDbb7/FgAEDmrxGRUUFJk6ciD179iAuLo4H3Y8++ihuv/32zvw4hBBCiFeRd3UBCCGEENK19Ho95s6dix9++AHTp0/Hl19+icOHDyMpKalJ3tzcXAwYMADZ2dl49dVXcfz4cVRWVkK8hn/hwgXExcXx/CNGjOi0z0EIIYR4Iwq6CSGEEAK5XA6ZTAYAMJlMuOKKK7By5com+cLCwgAAixcvRlRUFNatW4fw8HAIgoBrr722yWRpGo3G84UnhBBCvBgF3YQQQghxMnz4cHz33XeIioqCXN70VKGyshJZWVlYt24dxowZAwD4888/O7uYhBBCiE+g2csJIYQQ4mT+/Pmorq7G/fffjxMnTiA3Nxe//PILHnnkETgcDgQGBiIoKAgff/wxcnJycOjQITzzzDNdXWxCCCHEK1HQTQghhBAnvXr1wkcffQRBEHDnnXfiuuuuw9NPPw2dTgepVAqpVIqXXnoJf/31F6699lqsX78eDz30UFcXmxBCCPFKNHs5IYQQQgghhBDiIdTSTQghhBBCCCGEeAgF3YQQQgghhBBCiIdQ0E0IIYQQQgghhHgIBd2EEEIIIYQQQoiHUNBNCCGEEEIIIYR4CAXdhBBCCCGEEEKIh1DQTQghhBBCCCGEeAgF3YQQQgghhBBCiIdQ0E0IIYQQQgghhHgIBd2EEEIIIYQQQoiHUNBNCCGEEEIIIYR4CAXdhBBCCCGEEEKIh/x/GO2EcQy3MBwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "years = annual_dv_stats[\"year\"].to_numpy()\n",
+    "median_dv = annual_dv_stats[\"median_dv\"].to_numpy() / 1e6\n",
+    "p75_dv = annual_dv_stats[\"p75_dv\"].to_numpy() / 1e6\n",
+    "p90_dv = annual_dv_stats[\"p90_dv\"].to_numpy() / 1e6\n",
+    "\n",
+    "ax.fill_between(years, median_dv, p75_dv, alpha=0.3, color=\"#606060\", label=\"p50-p75\")\n",
+    "ax.fill_between(years, p75_dv, p90_dv, alpha=0.2, color=\"#808080\", label=\"p75-p90\")\n",
+    "ax.plot(years, median_dv, \"o-\", color=\"#404040\", linewidth=2, label=\"Median\")\n",
+    "ax.plot(years, p90_dv, \"s--\", color=\"#606060\", linewidth=1, label=\"90th percentile\")\n",
+    "\n",
+    "# Show potential thresholds\n",
+    "ax.axhline(10, color=\"black\", linestyle=\":\", linewidth=1.5, label=\"$10M threshold\")\n",
+    "ax.axhline(50, color=\"#404040\", linestyle=\":\", linewidth=1.5, label=\"$50M threshold\")\n",
+    "\n",
+    "ax.set_xlabel(\"Year\")\n",
+    "ax.set_ylabel(\"Dollar Volume ($ millions/day)\")\n",
+    "ax.set_title(\"ETF Dollar Volume Distribution Over Time\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "ax.set_ylim(0, None)\n",
+    "sns.despine()\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04d7f7a5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005324,
+     "end_time": "2026-05-15T05:21:02.195928+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.190604+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Interpretation\n",
+    "\n",
+    "The figure shows that:\n",
+    "- Dollar volume has grown substantially over time (market growth + ETF adoption)\n",
+    "- A \\$50M/day threshold would have excluded many ETFs in early years\n",
+    "- A \\$10M/day threshold is more inclusive historically\n",
+    "\n",
+    "**For this demo case study**, we use a lenient threshold ($10M) to maintain a\n",
+    "broad universe (the sample of 100 ETFs has already been selected based on liquidity). A production system might use higher thresholds but would need\n",
+    "to account for the changing market structure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f132d88",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006295,
+     "end_time": "2026-05-15T05:21:02.207821+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.201526+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Implement Rolling Universe Selection\n",
+    "\n",
+    "The proper point-in-time approach: at the end of each year, compute trailing ADV\n",
+    "and select ETFs for the following year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "777c4175",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.220221Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.219751Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.271566Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.270488Z"
+    },
+    "papermill": {
+     "duration": 0.059889,
+     "end_time": "2026-05-15T05:21:02.272372+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.212483+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eligible ETFs per year (ADV threshold: $10M):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>eligible_year</th><th>n_eligible</th></tr><tr><td>i32</td><td>u32</td></tr></thead><tbody><tr><td>2007</td><td>43</td></tr><tr><td>2008</td><td>53</td></tr><tr><td>2009</td><td>67</td></tr><tr><td>2010</td><td>67</td></tr><tr><td>2011</td><td>75</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>2022</td><td>95</td></tr><tr><td>2023</td><td>96</td></tr><tr><td>2024</td><td>93</td></tr><tr><td>2025</td><td>93</td></tr><tr><td>2026</td><td>95</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 2)\n",
+       "┌───────────────┬────────────┐\n",
+       "│ eligible_year ┆ n_eligible │\n",
+       "│ ---           ┆ ---        │\n",
+       "│ i32           ┆ u32        │\n",
+       "╞═══════════════╪════════════╡\n",
+       "│ 2007          ┆ 43         │\n",
+       "│ 2008          ┆ 53         │\n",
+       "│ 2009          ┆ 67         │\n",
+       "│ 2010          ┆ 67         │\n",
+       "│ 2011          ┆ 75         │\n",
+       "│ …             ┆ …          │\n",
+       "│ 2022          ┆ 95         │\n",
+       "│ 2023          ┆ 96         │\n",
+       "│ 2024          ┆ 93         │\n",
+       "│ 2025          ┆ 93         │\n",
+       "│ 2026          ┆ 95         │\n",
+       "└───────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# For each ETF, compute trailing 252-day ADV at each month-end\n",
+    "# Then apply threshold to create point-in-time universe membership\n",
+    "\n",
+    "# Simplification for demo: compute annual ADV and apply to next year.\n",
+    "# Note: annual granularity is coarser than the monthly decision cadence.\n",
+    "# An ETF that becomes illiquid in March remains \"eligible\" through December.\n",
+    "# Production systems would recompute eligibility at each decision date using\n",
+    "# a trailing window (e.g., 63-day or 126-day rolling ADV).\n",
+    "annual_adv = (\n",
+    "    prices_with_dv.with_columns(pl.col(\"timestamp\").dt.year().alias(\"year\"))\n",
+    "    .group_by([\"symbol\", \"year\"])\n",
+    "    .agg(\n",
+    "        pl.col(\"dollar_volume\").mean().alias(\"avg_dv\"),\n",
+    "        pl.col(\"timestamp\").count().alias(\"n_days\"),\n",
+    "    )\n",
+    "    .filter(pl.col(\"n_days\") >= 200)  # Require most of the year\n",
+    "    .sort([\"symbol\", \"year\"])\n",
+    ")\n",
+    "\n",
+    "# Threshold: $10M/day average (lenient for demo)\n",
+    "ADV_THRESHOLD = 10e6\n",
+    "\n",
+    "eligible_by_year = (\n",
+    "    annual_adv.filter(pl.col(\"avg_dv\") >= ADV_THRESHOLD)\n",
+    "    .with_columns((pl.col(\"year\") + 1).alias(\"eligible_year\"))\n",
+    "    .select([\"symbol\", \"eligible_year\", \"avg_dv\"])\n",
+    ")\n",
+    "\n",
+    "# Count eligible ETFs per year\n",
+    "eligibility_counts = (\n",
+    "    eligible_by_year.group_by(\"eligible_year\")\n",
+    "    .agg(pl.col(\"symbol\").n_unique().alias(\"n_eligible\"))\n",
+    "    .sort(\"eligible_year\")\n",
+    ")\n",
+    "\n",
+    "print(f\"Eligible ETFs per year (ADV threshold: ${ADV_THRESHOLD / 1e6:.0f}M):\")\n",
+    "eligibility_counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e85734ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004418,
+     "end_time": "2026-05-15T05:21:02.282085+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.277667+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Point-in-Time Universe: Eligibility Mask\n",
+    "\n",
+    "**Critical**: We do NOT filter to a fixed asset list based on full-sample eligibility.\n",
+    "That would use future information (survivorship bias). Instead, we create a\n",
+    "point-in-time eligibility table that downstream code uses at each decision date.\n",
+    "\n",
+    "The rule: an ETF is tradable in year Y if it met the ADV threshold in year Y-1.\n",
+    "\n",
+    "**Two-Layer Bias Assessment**:\n",
+    "\n",
+    "Understanding survivorship bias in this case study requires distinguishing two layers:\n",
+    "\n",
+    "- **Layer 1 (universe composition)**: The 100 ETFs were selected *after the fact*\n",
+    "  based on their relevance and liquidity at sample end (2025). ETFs that were liquid\n",
+    "  in 2007 but have since been delisted or merged are excluded. This bias **cannot be\n",
+    "  fully resolved** without historical constituent data, which is not readily available\n",
+    "  for ETFs. It inflates apparent signal quality by removing negative outcomes.\n",
+    "\n",
+    "- **Layer 2 (eligibility within the universe)**: Given the 100-ETF sample, the\n",
+    "  point-in-time ADV filter correctly prevents using future liquidity information.\n",
+    "  An ETF is only tradable in year Y if it met the threshold in year Y-1. This layer\n",
+    "  **is** point-in-time correct.\n",
+    "\n",
+    "The two layers partially work at cross purposes: the rolling filter creates rigor at\n",
+    "Layer 2 while Layer 1 already embeds the bias it's trying to avoid. Readers should\n",
+    "understand which bias is mitigated (within-universe eligibility) and which is not\n",
+    "(universe composition).\n",
+    "\n",
+    "Additionally, the $10M ADV threshold is not inflation-adjusted. Ten million\n",
+    "dollars in 2006 had different purchasing power than in 2025. A more rigorous\n",
+    "approach would step down the threshold for earlier years (e.g., scale by CPI\n",
+    "or market cap growth). We proceed with the fixed threshold for simplicity---the\n",
+    "100-ETF universe was already curated for liquidity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "171ab4e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.295790Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.295380Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.309497Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.308866Z"
+    },
+    "papermill": {
+     "duration": 0.023415,
+     "end_time": "2026-05-15T05:21:02.310172+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.286757+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Candidate universe: 100 ETFs (all assets in dataset)\n",
+      "Point-in-time eligibility determined annually based on prior-year ADV\n",
+      "\n",
+      "Eligible ETFs by year:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>eligible_year</th><th>n_eligible</th></tr><tr><td>i32</td><td>u32</td></tr></thead><tbody><tr><td>2007</td><td>43</td></tr><tr><td>2008</td><td>53</td></tr><tr><td>2009</td><td>67</td></tr><tr><td>2010</td><td>67</td></tr><tr><td>2011</td><td>75</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>2022</td><td>95</td></tr><tr><td>2023</td><td>96</td></tr><tr><td>2024</td><td>93</td></tr><tr><td>2025</td><td>93</td></tr><tr><td>2026</td><td>95</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 2)\n",
+       "┌───────────────┬────────────┐\n",
+       "│ eligible_year ┆ n_eligible │\n",
+       "│ ---           ┆ ---        │\n",
+       "│ i32           ┆ u32        │\n",
+       "╞═══════════════╪════════════╡\n",
+       "│ 2007          ┆ 43         │\n",
+       "│ 2008          ┆ 53         │\n",
+       "│ 2009          ┆ 67         │\n",
+       "│ 2010          ┆ 67         │\n",
+       "│ 2011          ┆ 75         │\n",
+       "│ …             ┆ …          │\n",
+       "│ 2022          ┆ 95         │\n",
+       "│ 2023          ┆ 96         │\n",
+       "│ 2024          ┆ 93         │\n",
+       "│ 2025          ┆ 93         │\n",
+       "│ 2026          ┆ 95         │\n",
+       "└───────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# All assets in the dataset are candidates\n",
+    "ASSETS = prices[\"symbol\"].unique().sort().to_list()\n",
+    "\n",
+    "# Eligibility table: which assets are tradable in which years\n",
+    "# eligibility_by_year already has (asset, eligible_year) pairs\n",
+    "eligibility_table = eligible_by_year.select([\"symbol\", \"eligible_year\"]).unique()\n",
+    "\n",
+    "# Summary: how many ETFs eligible per year\n",
+    "eligibility_summary = (\n",
+    "    eligibility_table.group_by(\"eligible_year\")\n",
+    "    .agg(pl.col(\"symbol\").count().alias(\"n_eligible\"))\n",
+    "    .sort(\"eligible_year\")\n",
+    ")\n",
+    "\n",
+    "print(f\"\\nCandidate universe: {len(ASSETS)} ETFs (all assets in dataset)\")\n",
+    "print(\"Point-in-time eligibility determined annually based on prior-year ADV\")\n",
+    "print(\"\\nEligible ETFs by year:\")\n",
+    "eligibility_summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11cba159",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005219,
+     "end_time": "2026-05-15T05:21:02.320683+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.315464+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### B.3 Trading Cost Analysis: Horizon Feasibility\n",
+    "\n",
+    "A fundamental question for any trading strategy is: **at which holding periods\n",
+    "do typical price moves exceed transaction costs?**\n",
+    "\n",
+    "This analysis informs which horizons are worth exploring, without prescribing\n",
+    "a specific signal type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26619feb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006627,
+     "end_time": "2026-05-15T05:21:02.332738+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.326111+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Return Distributions at Multiple Horizons\n",
+    "\n",
+    "We compute returns at daily, weekly, and monthly frequencies and examine their\n",
+    "distributions relative to transaction costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "07ebabdf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.348111Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.347681Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.606820Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.602508Z"
+    },
+    "papermill": {
+     "duration": 0.268625,
+     "end_time": "2026-05-15T05:21:02.607952+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.339327+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Daily returns: 470,562 observations\n",
+      "Weekly returns: 97,586 observations\n",
+      "Monthly returns: 22,369 observations\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filter to universe assets\n",
+    "universe_prices = prices.filter(pl.col(\"symbol\").is_in(ASSETS)).sort([\"symbol\", \"timestamp\"])\n",
+    "\n",
+    "# Daily returns\n",
+    "daily_returns = (\n",
+    "    universe_prices.with_columns(\n",
+    "        (pl.col(\"close\") / pl.col(\"close\").shift(1) - 1).over(\"symbol\").alias(\"return\")\n",
+    "    )\n",
+    "    .filter(pl.col(\"return\").is_not_null())\n",
+    "    .select([\"symbol\", \"timestamp\", \"return\"])\n",
+    ")\n",
+    "\n",
+    "# Weekly returns (resample to week-end)\n",
+    "weekly_prices = (\n",
+    "    universe_prices.with_columns(pl.col(\"timestamp\").dt.strftime(\"%G-W%V\").alias(\"week\"))\n",
+    "    .group_by([\"symbol\", \"week\"])\n",
+    "    .agg(pl.col(\"close\").last().alias(\"close\"), pl.col(\"timestamp\").max().alias(\"timestamp\"))\n",
+    "    .sort([\"symbol\", \"timestamp\"])\n",
+    ")\n",
+    "weekly_returns = weekly_prices.with_columns(\n",
+    "    (pl.col(\"close\") / pl.col(\"close\").shift(1) - 1).over(\"symbol\").alias(\"return\")\n",
+    ").filter(pl.col(\"return\").is_not_null())\n",
+    "\n",
+    "# Monthly returns\n",
+    "monthly_prices = (\n",
+    "    universe_prices.with_columns(pl.col(\"timestamp\").dt.strftime(\"%Y-%m\").alias(\"month\"))\n",
+    "    .group_by([\"symbol\", \"month\"])\n",
+    "    .agg(pl.col(\"close\").last().alias(\"close\"), pl.col(\"timestamp\").max().alias(\"timestamp\"))\n",
+    "    .sort([\"symbol\", \"timestamp\"])\n",
+    ")\n",
+    "monthly_returns = monthly_prices.with_columns(\n",
+    "    (pl.col(\"close\") / pl.col(\"close\").shift(1) - 1).over(\"symbol\").alias(\"return\")\n",
+    ").filter(pl.col(\"return\").is_not_null())\n",
+    "\n",
+    "print(f\"Daily returns: {len(daily_returns):,} observations\")\n",
+    "print(f\"Weekly returns: {len(weekly_returns):,} observations\")\n",
+    "print(f\"Monthly returns: {len(monthly_returns):,} observations\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "891a1867",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006906,
+     "end_time": "2026-05-15T05:21:02.622058+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.615152+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Summary Statistics by Horizon\n",
+    "\n",
+    "The key question: what fraction of absolute price moves exceed the round-trip cost?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1741425a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.640603Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.639838Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.766969Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.765377Z"
+    },
+    "papermill": {
+     "duration": 0.13998,
+     "end_time": "2026-05-15T05:21:02.769517+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.629537+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Extract absolute returns\n",
+    "daily_abs = daily_returns[\"return\"].abs().to_numpy()\n",
+    "weekly_abs = weekly_returns[\"return\"].abs().to_numpy()\n",
+    "monthly_abs = monthly_returns[\"return\"].abs().to_numpy()\n",
+    "\n",
+    "# Cost assumptions: per-leg cost 10 bps → round-trip 20 bps\n",
+    "PER_LEG_COST_BPS = 10\n",
+    "ROUND_TRIP_COST_BPS = 2 * PER_LEG_COST_BPS\n",
+    "ROUND_TRIP_COST = ROUND_TRIP_COST_BPS / 10_000  # 0.0020\n",
+    "\n",
+    "\n",
+    "# Build summary DataFrame\n",
+    "def compute_return_stats(data: np.ndarray, horizon: str) -> dict:\n",
+    "    \"\"\"Compute return distribution statistics for a given horizon.\"\"\"\n",
+    "    return {\n",
+    "        \"horizon\": horizon,\n",
+    "        \"median_pct\": np.median(data) * 100,\n",
+    "        \"mean_pct\": np.mean(data) * 100,\n",
+    "        \"std_pct\": np.std(data) * 100,\n",
+    "        \"p75_pct\": np.percentile(data, 75) * 100,\n",
+    "        \"p95_pct\": np.percentile(data, 95) * 100,\n",
+    "        \"pct_above_20bps\": (data > ROUND_TRIP_COST).mean() * 100,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "return_stats = pl.DataFrame(\n",
+    "    [\n",
+    "        compute_return_stats(daily_abs, \"Daily\"),\n",
+    "        compute_return_stats(weekly_abs, \"Weekly\"),\n",
+    "        compute_return_stats(monthly_abs, \"Monthly\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc4ade74",
+   "metadata": {
+    "papermill": {
+     "duration": 0.018882,
+     "end_time": "2026-05-15T05:21:02.808069+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.789187+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "**Return Distribution Summary** (absolute returns):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d60ccd20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.846301Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.845441Z",
+     "iopub.status.idle": "2026-05-15T05:21:02.861620Z",
+     "shell.execute_reply": "2026-05-15T05:21:02.859309Z"
+    },
+    "papermill": {
+     "duration": 0.046689,
+     "end_time": "2026-05-15T05:21:02.865855+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.819166+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>horizon</th><th>median %</th><th>mean %</th><th>std %</th><th>p75 %</th><th>p95 %</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Daily&quot;</td><td>0.56</td><td>0.91</td><td>1.14</td><td>1.19</td><td>2.91</td></tr><tr><td>&quot;Weekly&quot;</td><td>1.3</td><td>1.99</td><td>2.27</td><td>2.67</td><td>6.11</td></tr><tr><td>&quot;Monthly&quot;</td><td>2.85</td><td>4.02</td><td>4.13</td><td>5.53</td><td>11.78</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 6)\n",
+       "┌─────────┬──────────┬────────┬───────┬───────┬───────┐\n",
+       "│ horizon ┆ median % ┆ mean % ┆ std % ┆ p75 % ┆ p95 % │\n",
+       "│ ---     ┆ ---      ┆ ---    ┆ ---   ┆ ---   ┆ ---   │\n",
+       "│ str     ┆ f64      ┆ f64    ┆ f64   ┆ f64   ┆ f64   │\n",
+       "╞═════════╪══════════╪════════╪═══════╪═══════╪═══════╡\n",
+       "│ Daily   ┆ 0.56     ┆ 0.91   ┆ 1.14  ┆ 1.19  ┆ 2.91  │\n",
+       "│ Weekly  ┆ 1.3      ┆ 1.99   ┆ 2.27  ┆ 2.67  ┆ 6.11  │\n",
+       "│ Monthly ┆ 2.85     ┆ 4.02   ┆ 4.13  ┆ 5.53  ┆ 11.78 │\n",
+       "└─────────┴──────────┴────────┴───────┴───────┴───────┘"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "return_stats.select(\n",
+    "    [\n",
+    "        \"horizon\",\n",
+    "        pl.col(\"median_pct\").round(2).alias(\"median %\"),\n",
+    "        pl.col(\"mean_pct\").round(2).alias(\"mean %\"),\n",
+    "        pl.col(\"std_pct\").round(2).alias(\"std %\"),\n",
+    "        pl.col(\"p75_pct\").round(2).alias(\"p75 %\"),\n",
+    "        pl.col(\"p95_pct\").round(2).alias(\"p95 %\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2e33752",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024898,
+     "end_time": "2026-05-15T05:21:02.908368+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.883470+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "**Fraction of moves exceeding cost threshold** (round-trip = 20 bps):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1fcf1699",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:02.934686Z",
+     "iopub.status.busy": "2026-05-15T05:21:02.933955Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.024865Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.022434Z"
+    },
+    "papermill": {
+     "duration": 0.110164,
+     "end_time": "2026-05-15T05:21:03.026936+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:02.916772+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>horizon</th><th>10 bps %</th><th>20 bps %</th><th>30 bps %</th><th>50 bps %</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Daily&quot;</td><td>86.7</td><td>76.6</td><td>67.8</td><td>53.7</td></tr><tr><td>&quot;Weekly&quot;</td><td>93.7</td><td>88.6</td><td>84.0</td><td>75.4</td></tr><tr><td>&quot;Monthly&quot;</td><td>96.9</td><td>94.3</td><td>92.1</td><td>87.7</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 5)\n",
+       "┌─────────┬──────────┬──────────┬──────────┬──────────┐\n",
+       "│ horizon ┆ 10 bps % ┆ 20 bps % ┆ 30 bps % ┆ 50 bps % │\n",
+       "│ ---     ┆ ---      ┆ ---      ┆ ---      ┆ ---      │\n",
+       "│ str     ┆ f64      ┆ f64      ┆ f64      ┆ f64      │\n",
+       "╞═════════╪══════════╪══════════╪══════════╪══════════╡\n",
+       "│ Daily   ┆ 86.7     ┆ 76.6     ┆ 67.8     ┆ 53.7     │\n",
+       "│ Weekly  ┆ 93.7     ┆ 88.6     ┆ 84.0     ┆ 75.4     │\n",
+       "│ Monthly ┆ 96.9     ┆ 94.3     ┆ 92.1     ┆ 87.7     │\n",
+       "└─────────┴──────────┴──────────┴──────────┴──────────┘"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Cost threshold analysis\n",
+    "COST_THRESHOLDS_BPS = [10, 20, 30, 50]\n",
+    "\n",
+    "cost_exceedance = []\n",
+    "for horizon, data in [(\"Daily\", daily_abs), (\"Weekly\", weekly_abs), (\"Monthly\", monthly_abs)]:\n",
+    "    row = {\"horizon\": horizon}\n",
+    "    for cost_bps in COST_THRESHOLDS_BPS:\n",
+    "        row[f\"{cost_bps}_bps\"] = (data > cost_bps / 10_000).mean() * 100\n",
+    "    cost_exceedance.append(row)\n",
+    "\n",
+    "cost_df = pl.DataFrame(cost_exceedance)\n",
+    "cost_df.select(\n",
+    "    [\n",
+    "        \"horizon\",\n",
+    "        pl.col(\"10_bps\").round(1).alias(\"10 bps %\"),\n",
+    "        pl.col(\"20_bps\").round(1).alias(\"20 bps %\"),\n",
+    "        pl.col(\"30_bps\").round(1).alias(\"30 bps %\"),\n",
+    "        pl.col(\"50_bps\").round(1).alias(\"50 bps %\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62df1643",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008922,
+     "end_time": "2026-05-15T05:21:03.045302+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.036380+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Visualize Return Distributions\n",
+    "\n",
+    "The visualization shows return distributions at each horizon with cost reference lines.\n",
+    "Note how the distributions widen as the horizon increases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ec8d3492",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:03.077923Z",
+     "iopub.status.busy": "2026-05-15T05:21:03.076143Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.732412Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.731116Z"
+    },
+    "papermill": {
+     "duration": 0.678149,
+     "end_time": "2026-05-15T05:21:03.733612+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.055463+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABVoAAAGMCAYAAAAr7xnGAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxWZJREFUeJzs3XdYU9f/B/B3EpIwwp4CTlTQIoporYgbJ1pFrbOuuhVn1ap1T+qqs7WOatU6+nWjVlutdVVr1Trr3uAClD0Skvz+4Mn9ERlCGEF4v56HR3Lvyb2fc8Ac7ueee45Iq9VqQUREREREREREREQGExs7ACIiIiIiIiIiIqIPHROtRERERERERERERPnERCsRERERERERERFRPjHRSkRERERERERERJRPTLQSERERERERERER5RMTrURERERERERERET5xEQrERERERERERERUT4x0UpERERERERERESUT0y0EhEREREREREREeUTE61ERERElKU9e/bA09MTnp6eWLlyZZGff9KkScL5//77b2G7bluzZs2KPCZjt4khmjVrJsRcmvTu3Vuod3h4uLHDISIiolLAxNgBEBER0Ydl5cqVWLVqVbb7LS0tcfHixfeWyyg4OBihoaHo3bs3Lly4kG255s2b47vvvsvxWJMmTcLevXv1tpmYmMDW1ha1atXCwIEDUatWrVzFlZXw8HDh+NWqVUNgYKDBxypKGZNsIpEIMpkMVlZWKFeuHPz9/dGjRw/Y29sX6Dn//vtv4ecZGBiIatWqFejxC4sugWppaYl+/foZN5gP0N9//40+ffoAANzc3PDHH3/o7c/42aD7v09ERERUEjDRSkRERCVeWloaIiMj8fvvv+PPP//Etm3b4OPjY9CxIiIi9JJEH0qiNSOtVovU1FRERkYiMjISly5dwo8//ojFixfrjRJt3Lgxfv75ZwCAq6trns9z4cIFoa3c3NzynGgdOnQounTpAgBFOhozY8zvJlrz2yZUdKZOnYr4+HgAgJOTk5GjISIiotKAiVYiIiIyWKNGjTBkyBC9bSYm6X9edO7cGfXr1xe27969G3v27MnyfQ4ODpmOPXToUDRs2FBvm62tbZ7i69SpEzp37oxXr15hyZIliIiIgEqlws6dOw1OtBaVpKQkmJubF8qxly9fDmtrazx9+hTbt2/HrVu3kJiYiFGjRukloe3t7Qt8lGtu6OpeoUIFVKhQocjPnxNjtQnlnu73p7RNlUBERETGxzlaiYiIyGD29vaoU6eO3pfusXxXV1e97RlH/737vqySaeXLl890bA8PjzzFp4shKCgIvXv3Fra/fPkyU9mLFy9i6NCh+OSTT+Dt7Y1mzZphwYIFiI2NFcr07t1beCQaAPbu3SvMATlp0iShTFbzQq5cuVLYrks4A/rzZz5//hwjR46En58f2rVrB0B/ntIzZ85g+fLlaNSoEWrUqIHu3bvj9u3beWoTAPD29kb9+vXRrVs3/PLLL/D19QUAqFQqvce4s5uPNDw8HF9++SUCAgLw0UcfoU6dOmjbti0mT54sxOPp6ak3dcTkyZMz1T8vdc84R2tG4eHhGDZsGHx9fVGvXj3MmjULSUlJwv6///47089I5925XnU/I52IiIhMZXKao/XJkyeYPHkyGjduDG9vb9SrVw+DBg3CuXPn9Mq9G9Pp06fRuXNn1KhRA02aNMHmzZv1yqekpOCbb75By5Yt4e3tjVq1aqFZs2YICQnB77//nmW7ZOfNmzf46quvULduXfj5+eHLL79EdHQ0ACAhIQG1atUS6qvVaoX3qdVqfPLJJ/D09ES9evWgUqnydN7cSkhIwLfffos2bdrAx8cHvr6++Oyzz7Bjxw69eAD9n9+dO3fQv39/+Pr6Cjdxsvq/mPH/YVZfGf9vGhrL48ePMXToUPj6+uLjjz/G9OnTkZqaWijtRURERMULR7QSERFRqZAxMfLuY8T/+9//MH36dGg0GmFbREQENm3ahJMnT2Lnzp2wtrYu9Bj79OmDZ8+eAUCW55s5c6awHwD+/fdfDB8+HL/99pswkjivZDIZJkyYgJ49ewIALl26hJcvX8LFxSXL8mlpaRgwYAAeP34sbIuPj0d8fDwePHiA2rVrw8vLK89xvK/uWUlMTESvXr2ExHlSUhK2bduGZ8+eYf369XmOIT+uXbuGfv36ITExUdgWExODU6dO4fTp05g+fbrQxhlduHAB+/fvF373Xrx4gXnz5qFy5crw9/cHAMyePRu7d+8W3qNSqRAREYGIiAiYmpqiRYsWuY6zX79+uHPnjvD64MGDuHfvHnbt2gWFQoHWrVtj7969iIiIwKVLl1CnTh0A6b9rb9++BQC0atUKUqk0D62TO7GxsejevTsePnyot/3atWu4du0aLly4gKVLl2Z6X1xcHPr06YOYmBijxxIbG4tu3brpxbJz507Y2tpi7NixBRYfERERFU9MtBIREZHB9u7dm2nhqYJa3Gby5MmYPHmy3rYFCxagU6dOuT7G8+fPcfHiRbx+/RpbtmwBAEgkEmHeTwB49eoVZs+eDY1GAwsLC4wbNw4VKlTAoUOHsGfPHjx69AhLly7FrFmzMHXqVFy4cAFz584FoD8FQlbTH+RVdHQ0Jk+ejCpVqmS5SvrLly8xfvx4VKhQAfPmzcOLFy8QERGBM2fOoEmTJgaf18fHBxKJBGq1GgBw69atbBOtDx8+FJKs/v7++OKLL6BWqxEeHo6TJ08KCbiff/5Zb7qIjFNBVKxYMc91z0pMTAw++ugjTJs2DS9fvsTixYuRnJyM06dP448//tCbbzY3dNNd9OrVCwDg6OiIZcuWAQDkcnm279NqtZg8ebKQZG3VqhU6d+6MK1euYM2aNdBoNJg/fz6aNm2KMmXK6L03IiICzZs3x2effYawsDAcOnQIALBjxw4h0Xr8+HEA6XPGfvXVV1AoFHjx4gX++ecfKBSKPNUxKSkJ3377LVJTU/HNN9/g7du3uHPnDnbu3InevXujS5cuwv/psLAwIdGqiwEAgoKCcn0+3ajg3Fi6dKmQ2KxatSpGjRqFmJgYLFq0CLGxsTh06BACAwPRtm1bvffFx8fD3t4ec+bMgaurqzBCNyvvTmly48YNLFiwAED64me6EfmGxpKQkIBKlSphzpw5uH//PpYvXw4gPdnKRCsREVHJx0QrERERlVh79uzRexS4bNmymDZtGvz8/IRtv/76K5RKJYD0BJluNGbnzp3x66+/Ijk5GYcOHcKMGTPg6empN1JNNwVCQZk8eTK6du2a7f4ePXpg0KBBAIBHjx5hyZIlANIfWc8PqVQKGxsbIUGlW0AoKxlHzjo6OqJChQpwc3ODWCzG559/LuyrU6eO3iPzuqkgsvO+umfn22+/Rfny5QEAkZGRWLNmDQDg2LFjeU60urq66k1xIZPJcvXzvXXrFu7fvw8gvU2WLFkCqVSKxo0b48GDBzh69ChUKhWOHj2aaXEte3t7LFu2DDKZDDVq1BASrU+fPhXK6JLXlpaWKFeuHDw8PCCTyfRuGOTW7NmzhQRuWloapk6dCiC9vXr37i1M5fH48WMcOXIEU6dOhVQqxYkTJwCkjwavW7duns/7PhqNBr/++qvwesmSJahatSoAIDU1FXPmzAGQPgL33eQmACxatAgNGjR473ky/owjIiIwevRoAOm/18uXL0elSpXyHcvSpUtRrVo1tGzZEmFhYXj48CHevn2L+Ph4WFpa5qo9iIiI6MPERCsREREZLKvFsApiZCeQ9WJYWY2EzIsXL17oPXoPQO8R+HcTszrx8fF4/fp1tqM8C0rTpk1z3P/xxx8L32dcGCynxGhuKJVK4bFwADkmgypUqIA6derg4sWL2L9/P/bv3w9TU1N4eXmhRYsW6NOnD2QyWZ5jeF/ds2JjYyMkWQHoLXD27s+5MGX8HapevbreY/U1atTA0aNHM5XTqVmzptBeNjY2wva4uDjh+86dO2PNmjW4ffs2OnbsCIlEggoVKqBhw4YYMGBApqkwcpKxjWrUqCF8n7G9OnfujCVLliAmJganT59GpUqV8OjRIwBA27ZtIRbnfpmHjKOCdTKOdNZ58+aNMB+ymZmZkNh8N+as2lAul+cqyZpRfHw8hgwZgqioKADAtGnThGPkJxaFQoFq1aoJr9/9mTLRSkREVLIx0UpEREQGK+gRnRm9bwRkboSEhGDIkCE4fPgwJk+ejLS0NMyfPx9+fn56yZDcyLjAUm5lnPM1YyIzO+9LUltZWQnfSyQS4ft3F+bJqytXrujFmlPbiMVirF27Fr/88gvOnj2LBw8e4Pnz57hy5QquXLmCp0+fYvbs2XmOoSAS9CKRKMdtuqkRgPRkWlHIKqaMMs5Hm908u2PGjEHVqlXx22+/4c6dO3j27BkePHiABw8e4K+//sLevXsNmqM3u9iCg4OxfPlypKWl4cCBA3oJWd1CZbmV1ajgdxcHy21c2bG3t89TeZVKhZEjR+LevXsAgP79+6N79+4FEsu78wtn/Lnk9/8pERERFX+5vx1NRERE9AGSyWTo2LEjOnbsCCA92ZZxtfgKFSoI34eEhODOnTuZvq5cuYJKlSoBgN5ovozJSZ2MI9YiIyOFcmfPnn1vrHlN6hQEpVKJxYsXC699fX1zHLmr1WphYWGB/v37Y/369Thx4gTOnTsHd3d3AMDvv/8ulM1Yn6zaKiND6h4TE6M3bcLVq1eF78uWLQtA/+ehG70IAKdPn35vLO+LWSfj79B///2HtLQ04fW1a9eyLJdXQUFBWL58OY4cOYLLly+jVatWAIC7d+9mObIyO9evX88yNl17AemjUBs1agQAOHHihDCdQfny5fWSrgXJzs5OuJGQlJQkJEHfjTOrNszr78706dOFZG/z5s0xceLEAouFiIiISjeOaCUiIiKDRUdH4+LFi5m2+/j4GPT4eGEaOHAg9u7dC61Wiz/++AMPHjyAh4cHWrdujSVLlkCpVGLt2rUQiUSoVasWUlJSEB4ejvPnzyM1NRUbN24EoD+q9NKlSzh58iQsLCxQsWJF2Nvb6z3KPnfuXHTp0gV//vlnnpJhhe3GjRsIDw/H48ePsW3bNmEVeqlUikmTJuX43levXqFfv35o06YNKleuDHt7e4SHhwsjRHXz3QL6o/t+++03uLu7w8TEpEB/P7788ksMGzYML1++xObNm4XtzZs3BwC4u7tDLBZDo9Hg/PnzWLp0KSwsLLB27dpsj2ltbY2YmBi8fv0aBw4cgKurKxwcHLJNrFWrVg0eHh548OABIiMjMX78eAQHB+PatWtC4lkqlQrJ0bzq0aMHqlWrBh8fHzg7OyMxMREPHjwQ9mds8/eZPn06xo0bh9TUVHz77bfCdl176XTp0gV//PEHUlJScPPmTQB5WwQrr8RiMdq2bYsdO3YAAMaPH4+QkBDExsbq3RjJ64jad61du1aYtsDOzg49evTA5cuXhf26/8dFEQsRERGVPEy0EhERkcFOnTqFU6dOZdp+/PhxYYRjceHh4YHGjRvjzz//hFarxcaNGzF37ly4uLhg+vTpmD59OpRKpV4iRSfj3KgeHh5wdHREZGQkwsPDMXjwYADAggUL0KlTJ3Tp0gWbNm2CRqPBf//9JzxGX6lSJWEVc2PTLQCUkbm5ORYvXiysup6TR48e4bvvvstyX8Zk3McffwyRSAStVouTJ0/i5MmTAAru98PS0hIREREYPny43vYGDRoIC2FZWlqibdu2OHjwIDQaDX744QcA6T/HhISELI9br149HD16FGq1GhMmTACQ/jh9aGholuVFIhFCQ0PRr18/JCYm4tdff9VbTEkkEmHKlCkoU6aMQfWMjo7Gtm3bsG3btkz7KleuDE9Pz1wfSywWY8yYMXrbqlatim7duulta9y4sfB7rlPYicWxY8fiwoULePjwIW7fvo2QkBC9/UFBQWjTpk2+zpFxJPObN28wcOBAvf26/8dFEQsRERGVPJw6gIiIiEqN/v37C9/v379fSCJ99tln2Lp1K1q2bAkHBweYmJjAwcEBPj4+GD58OGbMmCG8z8TEBN999x38/PxgYWGR6RweHh5YvHgxypcvD6lUiqpVq2LZsmVZrk5uLCKRCFKpFI6OjvD19cXw4cPx22+/ZRrVmBVra2uEhITg448/hqOjI6RSKUxNTeHp6YkxY8Zg2rRpQllPT09888038PDwKJQRzlZWVvj555/RsGFDmJubw8bGBt27d8fKlSv1HiefOnUqWrduDXNzc1haWqJjx47YunVrtsedNm0a2rRpAzs7u1zH4uPjgz179iA4OBjOzs4wMTGBtbU1GjZsiB9//BE9e/Y0uJ6DBw9G8+bN4ebmBjMzM0ilUri5uaF79+746aef9ObrfZ/NmzejTZs2UCgUsLCwQFBQEDZu3Ai5XK5XzsTERJhuAwC8vLzg4eFhcB1yw8bGBr/88guGDBmCihUrQiaTwdzcHDVq1MDMmTOxZMmSIpteozjFQkRERB8OkZazshMRERER0Tv++ecffP755wDSH58fNGiQkSMiIiIiKt44dQAREREREQlSUlKQkJCA7du3AwAkEgnat29v5KiIiIiIij8mWomIiIiISDBo0CBcuHBBeN25c2e4uLgYMSIiIiKiDwMTrURERERElImtrS1atmyJyZMnGzsUIiIiog8C52glIiIiIiIiIiIiyiexsQMgIiIiIiIiIiIi+tAx0UpERERERERERESUT0y0EhEREREREREREeUTE61ERERERERERERE+cREKxEREREREREREVE+MdFKRERERERERERElE9MtBIRERERERERERHlExOtRERERERERERERPnERCsRERERERERERFRPjHRSkRERERERERERJRPTLQSERERERERERER5RMTrURERERERERERET5xEQrERERERERERERUT4x0UpERERERERERESUT0y0EhEREREREREREeUTE61ERERERERERERE+cREKxEREREREREREVE+MdFKRERERERERERElE9MtBIRERERERERERHlExOtRERERERERERERPnERCsRERERERERERFRPjHRSlRM7dmzB56enggPDxe29e7dG7179zZiVPm3cuVKeHp6GjsMIiL6wOj6jzdv3uRYbtKkSWjWrFkRRVU4svobgIiIKCNPT0/Mnj37veVKQp8SHh4OT09P7Nmzx9ihEL0XE61E+aDrtHRfNWrUQEBAAAYMGIDNmzcjISHB2CHmKKfOWVe369evF3FURERkbIcPH4anpyd+//33TPs+/fRTeHp64vz585n2NWnSBN27dy+KEItMs2bNMGTIkCz3/f333/D09MSRI0eKOCoiIiosGa/xLl68mGm/VqtF48aN4enpmW3/UFAuX76MlStXIi4urlDPkxeTJk2Cr69vtvtzmwAmKqmYaCUqAKNGjcLChQsxc+ZMYcTp/Pnz8emnn+L27dsGHbNDhw64du0a3NzcCjJUoxs2bBiuXbtm7DCIiCgHfn5+AIBLly7pbU9ISMC9e/dgYmKCy5cv6+178eIFXrx4gdq1axdZnCVVSf0bgIjoQyKXy3Hw4MFM2y9cuICXL19CJpMVegz//vsvVq1aVawSrcbg5uaGa9euoUOHDsYOhei9mGglKgCNGjVChw4d0LlzZwwZMgQbNmzAxo0bER0djeHDhyMlJSXPx5RIJJDL5RCJRIUQcdFLSkoCAJiYmEAulxs5GiIiyomzszPc3d0zJVr//fdfaLVatG7dOtM+3WtdkpbyTtdXlrS/AYiIPkSNGzfGkSNHkJaWprf94MGD+Oijj+Do6GikyEqPtLQ0KJVKiEQiyOVySCQSY4dE9F5MtBIVkvr162P48OGIiIjAgQMHhO23b9/GpEmT0Lx5c9SoUQMNGjTA5MmT8fbtW733v28uncTERNSqVQtz587NtO/ly5eoVq0afvjhh4KtFIBz586hZ8+eqFWrFurUqYNhw4bhwYMHemV08+jdv38fX375JerWrYuePXvq7dOZNGmS3vQLGb9WrlwplIuOjsaUKVPg7++PGjVq4NNPP8XevXv1zqubu2fDhg3YuXMnAgMD4e3tjc6dO3MULRFRHvn5+eHWrVt6NwsvX76MKlWqoGHDhrh69So0Go3ePpFIpDeidf/+/ejUqRN8fHzw8ccfY+zYsXjx4kWmc129ehUDBgyAn58fatasic8//zxTIjcrERERaNGiBdq1a4eoqKhM+7VaLZo1a4Zhw4Zl2peamgo/Pz9Mnz79vefJq//++w8DBw5E7dq14evri759++LKlSt6ZXT9/IULFzBz5kzUr18fjRs31tun+xtA13dm9TVp0iThmElJSQgNDUXjxo3h7e2NVq1aYcOGDdBqtXrn1j3WeezYMbRr1w7e3t4ICgrCqVOnCrwtiIg+VEFBQYiJicHZs2eFbUqlEkePHkX79u2zfE9Bfg6vXLkSCxcuBAA0b95c+Nx/9/owr5/lX331FerVqweVSpVp3xdffIFWrVrl3DAGyOu13KZNmxAYGIgaNWrgwYMHmeZo1U3dk9XXu/O0//zzzwgKCoK3tzcCAgIwa9asTCOEe/fujXbt2uH+/fvo3bs3atasiYYNG2LdunUF3hZU8pkYOwCikqxDhw5YunQpzpw5g65duwIA/vrrLzx79gydOnWCo6Mj7t27h19++QX379/HL7/8kuvRKxYWFggMDMSvv/6KyZMn693dO3jwILRabbZ/AGSUmpqa5cIiulE1Gf31118YNGgQ3N3dERISgpSUFGzduhU9evTAnj174O7urld+9OjRKF++PMaOHZvpjwudbt26oX79+nrbTp8+jbCwMNjZ2QEAUlJS0Lt3bzx9+hS9evWCu7s7jhw5gkmTJiEuLg59+/bVe//BgweRmJiIbt26QSQSYf369Rg5ciSOHTsGqVT63jYhIqL0ROv+/ftx9epV1KtXD0B6MtXX1xe1a9dGfHw87t69Cy8vL2FfpUqVYGtrCwD4/vvvsXz5crRp0wZdunTBmzdvsHXrVvTq1Qv79u2DlZUVgPQbeIMGDYK3tzdCQkIgEomwZ88e9O3bF9u2bYOPj0+W8T19+hR9+/aFtbU1fvzxR6HPyEgkEqF9+/bYsGEDYmJiYGNjI+z7448/kJCQgE8//fS9bZGWlpZlXxkfH59p271799CrVy9YWFhg4MCBMDExwc6dO9G7d29s3boVNWvW1Cs/a9Ys2NnZYcSIEVn2vQDQokULlCtXTm/bzZs38dNPPwn11mq1GDZsGP7++2906dIF1apVw+nTp7Fw4UK8evUKU6ZM0Xv/pUuX8Ntvv6Fnz56wsLDAli1bMGrUKJw4cUL4GRIRlWZubm6oVasWDh06JNwIO3XqFOLj49G2bVts2bJFr3xBfw63aNECjx8/xsGDBzF58mThszljf2fIZ3mHDh2wb98+nDlzBk2bNhW2R0ZG4vz58xgxYkSu2ud9i1Pq5PVabs+ePUhNTUXXrl0hk8lgbW2td2MXADw8PIQktE58fDxCQ0P12mflypVYtWoV/P390aNHDzx69Ajbt2/H9evXsX37dr1rw9jYWAwcOBAtWrRAmzZtcPToUSxevBhVq1YVfv5EucFEK1EhcnFxgaWlJZ49eyZs69mzJ7744gu9crVq1cK4ceNw6dIl1KlTJ9fH79ixI8LCwnD27Fk0atRI2H7gwAHUrVsXrq6u7z3Grl27sGvXrlydb+HChbC2tsbOnTuFi9XAwEAEBwdj5cqV+Oabb/TKe3l5YcmSJTke09fXV28y9SdPnmDOnDlo0KCBsKDKzp078eDBAyxatEi4IO7evTt69+6NZcuWoXPnzlAoFMIxnj9/jt9++w3W1tYAgIoVK2L48OGZ/pggIqLsZZyntV69ekhLS8O1a9cQHByMcuXKwcHBAZcuXYKXlxcSEhJw9+5ddO7cGUD6SNOVK1dizJgxGDp0qHDMli1bIjg4GNu2bcPQoUOh1Woxc+ZM1KtXD+vXrxduNnbv3h1BQUFYtmwZfvzxx0yxPXjwAP369YOzszM2bNggfN5npWPHjlizZg1+/fVX9OjRQ9h+4MABuLm55WqqgzNnzmS6KZidZcuWQaVSYfv27ShbtqwQQ+vWrbFo0SJs3bpVr7y1tTU2bdqU4+OQXl5eQkIbSL+4XbZsGapWrYqQkBAAwPHjx3H+/HmMGTNGGMHbq1cvjBo1Cps3b8bnn3+ul6x98OABDh8+LGyrV68eOnTogEOHDuHzzz/PVV2JiEq69u3bY8mSJUhJSYGpqSnCwsJQt25dODs7Zypb0J/DXl5eqF69Og4ePIjAwMBMg1pyc4ysfPLJJ3BxccGBAwf0ro0OHToEjUaTqxuQSUlJue4X83ot9/LlS/z+++96CdN3R/E6ODjozdeqS3JLpVKEhoYCSO8rf/jhBwQEBGDdunUQi9Mf6K5UqRJmz56NAwcOCH+3AMDr16/xzTffoGPHjgCALl26oFmzZti9ezcTrZQnnDqAqJCZm5sjMTFReG1qaip8rxtNqhvdcvPmzTwd29/fH05OTggLCxO23b17F3fu3MlVBwmkP4aycePGTF8DBgzQK/f69WvcunULwcHBeiOCvLy84O/vj5MnT2Y6dl5Xnk5KSkJISAisrKywZMkS4aLz1KlTcHR0RLt27YSyUqkUvXv3RlJSEv755x+947Rt21bvoluXvM6Y8CYiopx5eHjAxsZGeIT/9u3bSEpKEm6O+fr6CgtiXblyBWq1Wkha/v7779BoNGjTpg3evHkjfDk4OKB8+fL4+++/AQC3bt3C48eP0b59e7x9+1Yop7uA++effzKNYrl37x569+4NNzc3bNq0KcckK5B+s61mzZp6fWVMTAxOnz6N9u3b5+pJkpo1a2bZV3711Vd65dRqNc6ePYvAwEAhyQoATk5OaNeuHS5duoSEhAS993Tt2jVPc86p1Wp8+eWXSExMxOrVq2Fubg4gva+USCTCopw6X3zxBbRabaZHSf39/fUu+L28vKBQKNhXEhFl0KZNG6SmpuLEiRNISEjAn3/+me1Tg8b4HDbkGGKxGO3btxee7NA5cOAAfH199fqv7Mjl8iz7xY0bN2Yqm9druZYtW2b5lEpOVq9ejRMnTiA0NBSVK1cGkP40pkqlQp8+fYQkKwB89tlnUCgUma5fzc3N9ZK3MpkMNWrUYL9IecYRrUSFLCkpCfb29sLrmJgYrFq1CocPH0Z0dLRe2aweQcyJrpPcvn07kpOTYWZmhrCwMMjlcrRu3TpXx3BxcYG/v3+m7S9fvtR7/fz5cwDpF6zv8vDwwJkzZ5CUlCRc8AHI8q5rTqZNm4anT59ix44deo+6REREoHz58nodpO68GWPTKVOmjN5r3UV4aV+tk4goL0QiEXx9fXHx4kVoNBpcvnwZ9vb2KF++PID0ROvPP/8MAELCVZdoffz4MbRaLVq2bJnlsU1MTIRyADIlLDOKj4/XS6YOHToUDg4O2LBhAywsLHJVlw4dOmDOnDmIiIiAm5sbjhw5ApVKlevVi21tbbPsK99NkL558wbJycnZ9pUajQYvXrxAlSpVhO157SuXLVuG8+fP44cfftC7uI6IiICTk5PeqCDdeXX7M3q3rwTS+0v2lURE/8/Ozg7169fHwYMHkZKSArVane0cpsb4HDb0GB07dsS6detw7NgxdOzYEQ8fPsTNmzcxa9asXJ1XIpFk2S9mJa/XcnntF0+dOoXVq1djyJAhej8b3XErVaqkV14mk6Fs2bKZfh4uLi6Zbr5aW1vjzp07eYqHiIlWokL08uVLxMfH610IjRkzBv/++y8GDBiAatWqwdzcHBqNBgMHDsx2HtOcdOzYERs2bBAmQT948CCaNGkCS0vLgqyKQeRyea7L/vTTTzh48CAWLVqEatWq5eu82Y0MMqR9iYhKMz8/P5w4cQJ3794V5mfV8fX1Feadu3TpEpycnIRRMBqNBiKRCOvWrcvyM1l3U073uTxx4sRsP/sz3sADgFatWmHv3r0ICwvL9ZMTQUFBWLBgAcLCwjB06FAcOHAA3t7emS6+jCEvfeWxY8ewbt06jB49Wm/KIEOwryQiyp127dph2rRpiIqKQqNGjYQ5xvOrID6HDT1G5cqV8dFHH+HAgQPo2LEjDhw4AKlUijZt2uT63IUl4xOg7/Ps2TNMmDAB/v7+GDNmTL7Om5enS4hywkQrUSHav38/ACAgIABA+gTb586dw8iRI4U51YD/H9FjiKpVq6J69eoICwuDi4sLnj9/jqlTp+Yr7qzo5nt99OhRpn0PHz6Era1tpovh3Lp48SIWLlyIvn37ZjnlgZubG+7cuQONRqN3J/Thw4d6sRERUcHKOE/r5cuX9Ras8Pb2hkwmw99//41r167pJf7KlSsHrVYLd3f3LEd36ugSswqFItcjYyZOnAiJRIJZs2bBwsIiVws/2tjYoEmTJggLC0P79u1x+fLlTIuSFAQ7OzuYmZll21eKxeIsRx/lxqNHj/DVV18hMDBQb95bHTc3N5w7dw4JCQl6o6l0faWbm5tB5yUiKu1atGiBGTNm4MqVK/j222+zLVcYn8O5XSjZEB07dkRoaChev34tDNZ533Q8hiisa7mUlBSMHDkSlpaWWLp0aaYRs7rjPnz4UG86BKVSifDw8Fz/3UGUV5yjlaiQnDt3Dt999x3c3d2F5GF2d8l++umnfJ2rQ4cOOHv2LH766SfY2Njke5RLVpycnFCtWjXs27dP71GUu3fv4uzZswZPEP769WuMGTMGtWvXxsSJE7Ms06hRI0RGRuLw4cPCtrS0NGzZsgXm5uaoW7euQecmIqKceXt7Qy6XIywsDK9evdIb0SqTyfDRRx9h27ZtSEpK0ltUqmXLlpBIJFi1alWmUTVarRZv374Vjl+uXDn8+OOPevOZ62S3ovGcOXPQqlUrTJo0CcePH89VXTp06ID79+9j4cKFkEgkCAoKytX78kIikaBBgwY4fvy43sIdUVFROHjwIPz8/DI9UpobiYmJCAkJgbOzM0JDQ7O88G7UqBHUarUwnYPOpk2bIBKJCuVvAyKi0sDCwgIzZ87EyJEj0axZs2zLFcbnsJmZGYC8TzGXG+3atYNIJMK8efPw7NmzXK/xkVeFdS03Y8YMPH78GKtWrcoyQezv7w+pVIotW7bo/S2ya9cuxMfHc4ErKjQc0UpUAE6dOoWHDx9CrVYjKioKf//9N86ePQtXV1d8//33wmOBCoUCdevWxfr166FSqeDs7IyzZ89mWkUxr9q1a4dFixbh999/R48ePSCVSguiWplMnDgRgwYNQrdu3dClSxekpKRg69atsLS01Buhmxdz587FmzdvMHDgQBw6dEhvn6enJ7y8vNCtWzfs3LkTkyZNws2bN+Hm5oajR48KI5IMuWglIqL30y0EcfHiRchkMnh7e+vt9/X1xY8//ggAeonWcuXKYcyYMViyZAkiIiIQGBgICwsLhIeH49ixY+jatSsGDBgAsViMuXPnYtCgQWjXrh06deoEZ2dnvHr1Cn///TcUCgXWrFmTKS6xWIxFixZhxIgRGDNmDNauXfve1Y8bN24MGxsbHDlyBI0aNdKbP70gjRkzBn/99Rd69uyJnj17QiKRYOfOnVAqlZgwYYJBx1y1ahXu37+PYcOGZUoslytXDr6+vmjWrBnq1auHb7/9FhEREfD09MTZs2dx/Phx9O3bV28aIyIiypvg4OD3limMz+GPPvoIAPDtt9+ibdu2kEqlaNq0qcFPEmZkZ2eHhg0b4siRI7CyskKTJk3yfcysFMa13J9//ol9+/ahVatWuHPnjt48qhYWFggMDISdnR2GDBmCVatWYeDAgWjWrBkePXqEbdu2oUaNGoWWWCZiopWoAKxYsQJA+uqJNjY2qFq1KqZMmYJOnTpl6jiWLFmCOXPmYNu2bdBqtWjQoAHWrVuHhg0bGnx+BwcHNGjQACdPnsz1wh6G8Pf3x/r167FixQqsWLECJiYmqFu3LiZMmJCr1Smz8vbtW6jVaixYsCDTvpCQEHh5ecHU1BRbtmzB4sWLsXfvXiQkJKBixYpYsGABOnXqlN9qERFRDvz8/HDx4kV89NFHkMlkevtq166NH3/8ERYWFvDy8tLbN3jwYFSoUAGbNm3C6tWrAaQvNNGgQQO9EUH16tXDzp078d1332Hr1q1ISkqCo6MjfHx80K1bt2zjkkqlWLFiBQYNGoThw4dj06ZNqFmzZrblZTIZ2rZti23bthVqX1mlShX8/PPPWLJkCX744QdotVr4+Phg0aJFOcaXE90I4O+//z7TvuDgYPj6+kIsFuP777/HihUrcPjwYezZswdubm6YOHEivvjii3zViYiI3q8wPod9fHwwevRo7NixA6dPn4ZGo8Hx48cLJNEKpD/tceLECbRp0yZTH19QCuNaTvfEy9GjR3H06FG9fW5ubggMDAQAjBw5EnZ2dti6dSsWLFgAa2trdO3aFePGjSu0wUlEIi1nvCcqEUaMGIG7d+/i999/N3YoRERExdL8+fOxa9cunD17Vngck4iIqLQ6duwYRowYgZ9//hl16tQxdjhEJQLnaCUqAV6/fl3oo1mJiIg+ZKmpqThw4ABatWrFJCsRERGA//3vfyhbtqze9D9ElD+cOoDoA/bs2TNcvnwZu3btgomJSY6PWBIREZVG0dHR+Ouvv3D06FHExMSgT58+xg6JiIjIqA4dOoQ7d+7gzz//xNdff53lIotEZBgmWok+YP/88w8mT54MV1dXhIaGwtHR0dghERERFSv379/H+PHjYW9vj6lTp6JatWrGDomIiMioxo0bB3Nzc3Tp0gU9e/Y0djhEJQrnaCUiIiIiIiIiIiLKJ87RSkRERERERERERJRPTLQC0Gq1UKvV4OBeIiIqjdgPEhFRace+kIiICgITrQA0Gg2uXLmCtLS0XL9n6dKlmDlzJpYuXVqgsSiVSkyZMgVTpkyBUqks0GPnRKPR4Nq1a9BoNEV2zuKI7cA20GE7sA10SkP939cPFlafV9CM0Yfy/4nh2HaGYbsZjm1nmNLSXln1hR9K/5edwvidN9b1KlDy/g+XtPoAJa9OJa0+QMmrU3GsDxfDyiAvdy+XLl2KiIgIuLm5Ydy4cYUYVdHQarVQqVSl/g4u24FtoMN2YBvolKb6Z1fXktbnFST+PzEc284wbDfDse0MU9raK2N9P/T+r6T9zrM+xV9Jq1NJqw9Q8upUHOvDEa1ERERERERERERE+cREKxEREREREREREVE+MdFKRERERERERERElE9MtBIRERERERERERHlExfDIiJ6D61Wi7S0NKjVamOHUqR09U1JSYFEIjFyNIVLKpWW+DoSEeVHSegLS1O/Zgj2hUREOVOr1VCpVMYOI19KWl9Y0PUpiL6QiVYDjRs3DnFxcbCysjJ2KERUiJRKJV6/fo2kpCRjh1LktFotTExM8OTJE4hEImOHU6hEIhHc3d2hUCiMHUqxxD6PqHRTKpV48eLFB98XlqZ+zRDsCzNj/0dEOgkJCQgPDy9Wq9sboqT1hQVdn4LoC5loNdC4ceOMHQIRFYEnT57AxMQErq6ukMlkJaIzyi2tVovk5GSYmZmV6HprtVpERkYiPDwcVapUKRF3dgsa+zyi0kuj0eDRo0eQSCQffF9YWvo1Q7AvzBr7PyIC0kdNhoeHw9zcHI6Ojh90H1LS+sKCrE9B9YVMtBIR5UCj0cDV1RXm5ubGDqXIabVayGQyiMXiEtEJ58TR0RGPHz+GSqXixSURUQZKpRIajQZly5b94PvC0tSvGYJ9IRFR1lQqFbRaLRwdHWFmZmbscPKlpPWFBV2fgugLuRgWEdF7iMWl96OyJHS+uVFa6klEZKiS0hfy8z57bBsiopyVlM/JklIPnYKsT0EciyNaDRQfHw+tVguRSARLS0tjh0NEVCh0n3NUurHPI6KSgv0a5QX7PyIqiUpaX1jc6lMybk0bQbVq1WBtbY1q1aoZOxQiIqJCxT6PiIhKI/Z/RESUVxzRmsHbt2/f+1iUmZkZV+IkIipCnp6e2LdvHy9yikBCQkKW/aBudVWtVouYmBjI5fIPfn4qIqIPCfvCopOSkgKVSgVAv/9LTEwUykilUshkMqPER0RUWn0ofSETrRmEhYUhJiYm2/3W1tbo2LEjE61EVOxcvHgRa9aswdWrV6HVauHq6or27dujb9+++boQqF69Ovbu3Yvq1avnqrxSqcTs2bPx119/4e3bt3B2dsbAgQPRpUsXoUxCQgJmzJiBEydOwNTUFL169cKIESMMjpEKzl9//YWEhIRM21NSUoR/z5w5g4CAACZaiajYKay+MK8XduwLP2z37t1DamoqAAgJV5VKhatXrwIA5HI5vLy8mGglomKJfaHxMdGaQVxcHN68eWPsMIiI9CQkJODx48eoVq0aJBIJ3r59ixcvXgjJzxMnTmDcuHEYPXo0Fi5cCDs7Ozx48ADr1q1DZGQk3NzciizWtLQ0ODo6YtOmTShbtiyuXr2KQYMGwcXFBQEBAQCAOXPmICYmBn/++Seio6PRv39/uLm5oWPHjkUWJ2UtMTER8fHxmbZrNBrh36wSsUREhel9/SDAvpAKTkpKinCDMeOI1uTkZGOGRUSlHPvCDwcTrUREebR06VIsXboUAKBWq6HRaCAWiyGRSPTKVa9eHUuXLoWNjQ3c3d0BAJ9++ikuX7783nOMGzcO48aNy3KftbW1sCCDVqvF3LlzMWjQIPTr108o4+HhgdDQUOH19evXMW/ePNy/fx9OTk4YPnw42rVrBwC4efMmZs2ahfv370MqlcLX1xdr1qzBZ599BgDo0aMHxGIxhgwZgoEDB+LFixdCMs7KygplypQR6m5ubo7Ro0cL561Vqxa8vb3x66+/wsbGBqmpqTh48CBWrlwJKysrWFlZ4fPPP8euXbvQuHFjREVFQalUQiwWw9raGq6urgCAc+fOYcSIEXj79i3q1KmD0NBQ2NvbIzw8HM2bN8eYMWOwc+dOJCcno02bNpgyZQpkMhliYmLw9ddf48KFC9BqtShXrhxWrlxZpH9kEBGVRLq+MKd+UK1Ww8vLC1u2bBH6QSD/fWHGfhDIW184f/78PPWFupE33bt3h1gsRq9evRAcHIyUlBSIRKIsn/h4ty8sU6YMPvroIxw5cgR2dnYQiUQ4dOgQtm/fLvSFPXv2xM8//4yqVasCyNy/AsCvv/6K4cOHIzY2FgEBAZg3bx4sLS2FvnDKlCn46aefkJiYyL6QiKgIlMa+UCQSoUePHujYsSPS0tJgYmICGxsbODo66k1B9m5f+NFHH8HHxwdHjx6Fra0ttFptpr6wVatW+Omnn1C5cmXhfc7OznB0dBRev9sXzp07FxYWFggPD0dgYGCx6AuZaCUiyqO4uDhERES8t5yDgwOkUqnetsjIyFy9Ny4uLtt9YrFY6MQeP36M8PBwoXPM7lgDBw5ESEgIunfvjn///RdDhgxBmTJl4Ofnhzlz5qBp06bYsWMH0tLShEfj/ve//8HLywvbt28XLiQfP36MqVOn4pNPPkH//v0RERGB58+fo2zZslmeOzU1FXfu3EGLFi3g6emJW7duIS0tDQ0aNBDKVKtWDWvWrMGrV6/g4uICMzMzaDQa4XE9ANizZw+WLFkCd3d3jBo1CjNnzsTKlSuF/WfPnsWBAweQnJyMwYMHY+3atQgJCcGPP/4ItVqNU6dOQSaT4e7du7CwsHhv+xMRUc5y2xc6Oztn2pbfvjBjPwjkvi8cNGgQhg8fjh49euDKlSu56gt37doFT09P7NixA9WqVcOrV68gkUgwe/ZsVK5cOddT6zx48ABdunRBpUqVcP78eahUKlSpUkXYb29vjwcPHqBChQrQarVZ9q8nTpzA5s2bER8fjzlz5mD+/PlYsGCBcPPzzJkz2LdvH/tCIqIiUhr7Qnd3d8TGxsLa2hrjxo1DjRo10KJFC2g0GpQpUybbcz969Ai3bt3Cp59+iipVquDChQtQqVSoUKGCUKZixYrCuTLWM6Os+sJ58+YVq77QqInWf/75Bxs2bMCNGzcQGRmJ1atXIzAwEED6PDjLli3DqVOn8OzZMygUCvj7++PLL7/U+yWNiYnBnDlzcOLECYjFYrRs2RJff/01/3ggokJjZWUl3PlSq9UA0u8gSiQSiEQi4bW9vT1MTU313uvo6IgyZcoIj2ID0Huf7r2pqam4efMmzMzMYGtrq3eMjI+J6KY7SU1Nxa1bt6DVaiGTyeDi4iLMJ/3nn39CoVCgVatWePXqFRQKBQICArBz5074+fnBxMQEz58/x+vXr+Hi4oK6detmWe+UlBQkJCRg7dq1MDc3B5A+SufJkydwcXHJlFTWarX4+uuv4ebmhsaNG0MqlUKpVMLc3BxyuVwoZ25ujsTERLi7u+vNgZ1xDtBOnTqhcuXKsLS0xKhRozBw4EBoNBqhHceOHSvcCR0yZAi+/fZbhISEwMTEBDExMXjy5Am8vLyK/cTpREQfCl1fmFM/qFar9Uah6LZbW1vr/T2fVT+oVquRlJSEhw8f5tgPAsCrV6+E7QkJCZn6QQDYvn07rK2t0axZM9y/fx/W1tZo0aIF9u3bl6e+UBf3smXL8OLFi/e2k1arxaJFi1ChQgW0bdsWYrEYZmZmMDU1RVpaGoD0/lUikSAlJSXH/rV///4oW7Ys4uPj0atXL0yaNAmzZ89GVFQUAGDkyJHsC4mIilBp7AstLS2FkbTr1q0DkJ40fvPmTbaJVl1fWL58ebRv3x5isRimpqYwNTXVG1yjUCiQnJyc6boyo6z6wlmzZiE6OhpA8egLjZpoTUpKgqenJzp37oyQkBC9fSkpKfjvv/8wbNgweHl5IS4uDvPmzcOwYcOwZ88eodz48eMRGRmJjRs3QqVSYcqUKZg+fTqWLFlS1NUholIi4+Mb4eHhUKvVsLCwQHx8PCpWrAgg/Y6dpaWl3gq1ALB+/XrExMSgTJkykMvlSExMxPPnz1GhQgVYWFhAqVTi3r17sLOzg52dHZKTk/Hy5ctsY9F1uMnJyahatSpEIpHQgVSpUgUymQwvX76Ek5MToqOj4eTkBEdHR1SsWBEXLlxAamoq5s+fj1WrVqFDhw6wtLREv3798Pnnn2c6V1JSEsRisXARCEDouN/tELVaLWbOnIlHjx5h5syZiIuLQ1xcHKKiopCcnAylUilMxh4VFQUzMzOoVCrcvXsXGo0G5ubmcHFxEcq4u7sjISEBCoUClpaWSEtLw5s3bxAZGQkAKF++vHBuV1dX4Q+NAQMGIDU1FaNHj0ZCQgLatGmD8ePHZ0qAExFR3uj6wrz2g5GRkVixYkWB9YNA+uOTQPqNu3LlymXqBwEgOjoa9vb2MDMzg5OTE+Li4qBQKPDkyRMAwPz58xEaGooOHTrA1tYWn3/+eZZ9YV5k7As3bdoEsVgMjUaDtLQ0pKamwsQk/VIsKSkJycnJegNFsupfra2todVqkZCQgLJly0KlUuH27duwsbEBAGG6Hd337AuJiAoX+8J0Go0m05QJOrq+8OXLl/jmm2+g0WggEomgVquRmpqqNwAnMTERpqamuHXrFqRSKaytreHg4KCXgM6qL7xz506x6guNmmht3LgxGjdunOU+S0tLbNy4UW/btGnT8Nlnn+H58+dwdXXFgwcPcPr0aezatQs1atQAAEydOhWDBw/GxIkTsxyenROtVitMeJ7dfuD/R7DpvPs6P9Rqtd55CvLY7ztvxn9LK7YD20AnY/3f99kAADY2Nnj16hWUSiWA9IumsmXLCp2q7hiRkZGoUKGCkKy0sbFBUlIS3rx5A3Nzc7x580a4+wgAMpkMKSkpiIqKyhSHVqtFhQoV4ObmhrNnzwqfg7pOMz4+HnZ2dnBxccHr16+hUChgZ2cHIP1pAAcHB6GD+uabbxAeHo5bt27hyy+/RM2aNeHt7a13N1Y3B8+7bSGRSKBSqfQWjJg9ezauXbuGjRs3QqPRQCqVwsTEBLa2tpBIJDh16hSaN28OAPjvv/9Qvnx5REZGCvPRvXr1Co8fPxbm50lNTUVqairu3r2L8PBwSKVSyOVyYbGKy5cvo3z58lAoFIiIiICzszO0Wi3Mzc0xfvx4jB8/HuHh4Rg2bBh+/vlnfPHFF3p10LVtVp+7arU62z8ciIgo3fv6QSD9QiwyMhIVK1YU+kGZTCb0gxYWFkI/qBsVo/us143azIqXlxfc3Nxw7NgxDBs2DM7OzkI/aG9vDyD90fyoqCjY2tpCLBbDwcEBUVFRQr9Yrlw5TJkyBRKJBBEREejfv78wz3jGC7zc0mq1mDVrFq5du4ZNmzZBq9Xiv//+g0ajgUKhgImJCe7fvw9vb2+kpaXhyZMnwvysACASiYT+VSciIgJ3796Fqakp1Gq10BfqLlLPnTuH2rVro0yZMnj+/LlwLWRhYYEJEyZgwoQJePbsGYYNG4Zt27Zl6guJiCh/SmNfmJqaiujoaOH6NaOMfeFPP/2EuLg43L59W6iziYkJHj16BG9vbwDpo3KrVq2KChUqICkpCa9evUJaWpreSNms+kJTU9Ni1Rd+UHO0JiQkQCQSwcrKCgDw77//wsrKSkguAIC/vz/EYjGuXbuGFi1a5On4iYmJiI2NzXa/VCpFUlISXr58KfzRo1KpcOXKlbxXJhsqlUqI4erVqzkOmS4M169fL9LzFVdsB7aBjkqlglKphFwuzzLZqtsmEomgUCiER/kVCoVeklKj0SA1NRVarRaPHz/OdAxTU1OhjO57Hd1dNt1xMq4ADwCTJ0/GhAkTkJSUhAYNGsDS0hIRERH47rvvMHbsWAQEBGD27Nk4fPgw+vXrhytXriAsLAwzZsxAWloa9u7diwYNGsDV1RWJiYkQi8UQiUTQaDSwt7fHkydP4OnpKdQ1Y2wZ66DbPmfOHFy+fBkbN27Um6AdSJ86oWXLlli/fj18fHwQHx+P3bt3o2vXrnBxcRH+2HBzc8Pdu3eFFe43bdqEVatWwdraGgsXLkSbNm2EkboAsHXrVixbtgwPHjzA999/j6CgIGg0Gvz555+oUKECypUrJ8xjpNFokJSUpBdXamqqMDIoK35+flluJyKidCYmJrC0tERMTAy0Wi0sLS2FEZs6SqUyx34QSP88zjh1DAC9JymyotFoMGLECMyZMwcJCQlo2LAhFAoFHj58iCVLlmDEiBGoU6cO1q9fj+3bt6Nbt264evUqTp06hcWLFwMA9u3bh4CAADg4OCA+Pl5vQRMHBwc8ffo0T48Zzp49G5cvX8ZPP/0Ea2trqNVqeHh4QK1W482bNwgICMCyZcvw7bff4tmzZzh48CDGjx+f4zH379+PVq1awczMDLNnz0bDhg1RtmxZ3Lp1CwAQFhaGChUqID4+HmvXrkX79u0BpM9nV6FCBeGGpImJCW8gEhEVgtLWF6pUKjx58gTW1tZCsjajjH1hcnIy1Go1KlSoAIlEgvj4eDRo0ADffvstli1bhujoaOzduxejR4+GmZkZzMzMIBKJhGSpbq7WrPpCNzc33LlzB0Dx6As/mERramoqFi9ejKCgIOFRmoyZdx0TExNYW1sLj5PmhYWFhTDcOiuWlpYwNzeHu7s7wsLChEdfa9WqledzZUepVAox1KxZUxjiXdjUajWuX7+OGjVqlOo/vNgObAMdXTtIpVLIZDKIRKIs7+LptonFYtja2grztbm6ugqdgUgk0pvEu3z58pluomQs8275d7frXuv+rV69OmbMmIF9+/Zh27ZtEIlEsLe3R+vWreHs7AyZTIYZM2Zg06ZNWLt2LZycnDBz5kx89NFHAIDz589jyZIlSEpKgr29PSZMmCDsGzVqFObPn4/p06ejV69eaNmyJYYMGQI/Pz8MHTpUGAUqlUohFosRERGB7du3QyaTCXNuA0D79u0xa9YsAMDMmTMxduxYtGrVCqampujUqROaNGkCU1NTvbpJJBJh/rpPP/0U/fr1Q1RUFBo0aIAhQ4bAwsJC2B8YGIjOnTsjPj4ejRo1wrBhwyAWi/Hs2TPMnz8f0dHRMDc3R8uWLdGnT59Mn61isRhSqRSVK1fO9PhIaR/dDQAjRowQRjQTEWXH1tYWz58/B6D/6J6O7oZc+fLlM32eGDJqVOfly5fw9vbGihUrsHHjRuzcuRMajQbOzs7o3LkzHB0dkZCQgCVLlmD16tX49ttvhZWWdQM2/vrrLyxatEjoCydOnChcTI4ePRpz587F1KlTMWjQIAwePBhjxoyBh4cHpk+fnimeiIgIbNu2DTKZDM2aNRO2t2/fHrNnz4a5uTmGDh2KtWvXolGjRpDL5WjVqhU6duwolM3Yv+p8+umn6NOnD6KiolCnTh2MHTsWZmZmSE5OBpDeF4aEhCAxMRFt27bF0KFDAQBPnjzB3Llz9frCHj16GNzexvDDDz/gt99+w8OHD2FqagpfX1+MHz8elSpVEsr07t0bFy5c0Htft27dMHv2bIPPO3v2bPZ/RJQnpaUv7N+/P/r06YNatWph4sSJmeLJ2Bc2bdoUWq0WIpEIn376KWbPng0zMzOMHDkSq1atQqNGjWBqaopevXrp9YW65LJKpRJGrGbVF5qamharvvCD6DFUKhVGjx4tDDsuLNklUjLuB9Ifk/34448LJYaMEyBLJJIiT3QZ45zFEduBbZDR+z4bdGUsLS2FTjXjiFbdfrlcDpFIBJVKpTcpeUZyuRzx8fF679WNvnw3Dt33upGswcHBANITg3fu3IGtra3QIVWtWhU//PADHBwchPffv38fALBw4cIsY9FqtejSpQu6du0KkUiElJQU3L9/HytXrhTusOpGnJqbm0MkEsHd3V24m5gdExMTjBs3Dh4eHjAzM0Nqairu3bunN29rWlqacIGpO17fvn0BpM/h/fTpUzg5OQmJ7ebNmwsdbmJiolDvfv36oV+/fjnGk7Ft+XuftYxz4BIRZUehUAhPP2TVz+n6QaVSme3Ctbp+MKN3n0J4V1JSEmxtbeHp6YlGjRrp9YMZHzesXr06tm3bJjy5oesHgez7QgD47LPP8Nlnn+lty2kxrIwja7JjZmaGGTNmwNnZWehfk5OTM/WvutcZ+0JdP+jh4QHg/5+uad26NZo1a4bExES9z+3c9oXF2YULF9CrVy/UqFEDarUaS5cuxYABA3Do0CG9UV5du3bFqFGjhNfvjgjLq4zTORAR5UZp6AtVKhUePXqEhQsXwt3dPctr5Yx9oa6fe3dQi0KhwLRp04SFpt+lmyZOd332ofSFxT7RqlKpMGbMGDx//hw//fST3i+qg4OD8JiuTlpaGmJjYzOt6kZEVNhEIhGqVKkifP8uiUQCBwcHYSJzc3Nz4TF23YhYOzs7REdH48WLF8LE5zExMTmeVy6XIy4uTnhM//Xr1wbFHx4eDhMTkyzn1wHSpzDQzYHq6uoKrVaLFy9ewNraWhhxo+t03d3dYW5ujtTUVMTGxsLS0lJYUfnFixcwNzcXLn7kcjksLS3x4sULuLq6CnO0yuXyTH98aLVaPH/+HC4uLnoJ0ZiYGNjb2yMmJibHJxOIiKjwlPR+EEh/+kytVgvTiOlG0MhkMqFfunv3LlxcXGBlZQW1Wo3IyEhYWVnBxMQEarUa0dHRSEtLE/qr3PSvOln1g7pEY0pKCuLi4kpkP7hhwwa916Ghoahfvz5u3ryptyq2qalpvq8DDV23ozgqjLUXjLWmiO58Gf/90JW0+gAlr04Z66P7bMjN54OuL8y4Tfe9bm7Ud/vCxMRESCQS2NjY6PWFtra2SElJEfrCrNbtAHLuC7OLOavjREREwMTEJNs1j9LS0vDo0SNIpVK4uLgITxgCEEbo6sq4u7vDzMwMMpkMMplMr/+Ki4tDQkICypcvD61Wq7cwpFgsRnJyMl68eAEbGxtIJJJMddAdSzc1nO7aMmNf+L51VrJrk+zW7sjtgJxinWjVJVmfPHmCzZs3C6tr6/j6+iIuLg43btwQJs89f/48NBoNfHx8jBEyEZVy7/vwdXJygkQiQWRkJFQqFcRiMczMzISLAplMhrJly+Lly5d48+YNzMzM4OzsjIiIiGyP6eLigoiICDx8+BAmJiZwcHAw6I8b3aTtOXF3d8eLFy+EOYWsrKz07pBqtVoolUrhkRiRSISEhARER0cLi2JZW1tnugjSHffJkycQiUSwsLBA+fLl9aZQAIC3b9/CxMREmKtbR6PR4OHDh1AoFMJk70REVPRKej/4+vVrvcTvgwcPAAAVKlQQBoTokrEAhFFLT58+FRZXNDMzQ8WKFfVG9byvf9XJqh/U9XtPnjyBs7NzqegHdSO93k0qh4WF4cCBA3B0dETTpk0xfPjwPI9qTUpKEkYUZ0WtViMpKQkPHz7M1e9McVCQay8Ye00RoOStJVHS6gOUvDrdu3cPJiYmSEtLyzLZmt1aFhlfZ1zTwsHBAWKxGJGRkVAqlZBIJDA1NYWDgwM0Gg0kEgnc3d2FvlB3E+nFixfZrtvh5OSE58+f4+HDh8KNTV2C+N04Mr5PVx/da90cslmtywEAcXFxUCqVUCqVmZ7e0E0zoFarhb5Qd5yyZcvi9evXePLkCTQaDWQyGVxdXYVEM5A+eOb169fQarWQSqWws7ODvb19pljevn0LiUQCCwsLYZ9uWlFdX2hjY5PpfbqnSzMmh9+V09oduV23w6iJ1sTERDx9+lR4rVvxWncRPmrUKPz333/44YcfhLvBQHqHKpPJ4OHhgYYNG2LatGmYNWsWVCoV5syZg6CgoGyz7wXl4MGDwuM97dq1K9RzEVHx5e7unuP+dx+5FolEcHBw0HuE/11WVlaZEokZbzTZ2trqvZbJZKhYsaJe+Xcvsjw9PTOdp3LlynqvM85zlh0TExOULVs22/0ymUy48aV7nZvj6v6YeB87Ozu9ublzM1UB5d+1a9eEqR0aNGhg7HCIqBj5kPrBdy8cDekH3d3d31vnjP2gWCxGuXLl3nvc9/WvOu/2g0B6G5emvlCj0WD+/PmoXbu23qP97dq1g6urK5ycnHDnzh0sXrwYjx49wqpVq/J0fHNzc+FG7/nz55Gamgq5XI5PPvkEQPp0BObm5qhevXrBVaqQFMbaC8ZaUwQoeWtJlLT6ACWvTrr6VKlSRXjqIatp5d7XL2TVDxjSF2b8/H+3P5DL5e/tC3WfmRqNRvice7cvfPcY78qqH3qXXC4X1vzQMTU1zbE/NDc3F6YBeB97e3u9umk0GlSoUCHbhY0z0o2uzU5Oa3fkllETrTdu3ECfPn2E1wsWLAAABAcHIyQkBH/88QcAoEOHDnrv27x5M+rVqwcAWLx4MebMmYO+fftCLBajZcuWmDp1aqHHPnToUERERMDNzQ3h4eGFfj4iMh5DHjmgDwt/xjnbunUrYmJiYGNjw0QrUSnFz8mS70P5Gc+aNQv37t3Dtm3b9LZ369ZN+N7T0xOOjo7o168fnj59mqtkt07GJMry5csRFRUFBwcH1K9fX9gP5P4R0uKgIOegN/aaIsY8b2EpafUBSl6dMv7e52fBquIg42f9h14XoHDqk9+1O4yaaK1Xr16Od19zc2fWxsYGS5YsKciwiIj0JCUl5XsxBSredI/+laQ/CImICoLusWD2hSXfh9AXzp49G3/++Se2bt2a41y6QPpoSyD9MdK8JFqJiN6l+1xUKpXsC0u4gugLi/UcrURExmZtbS1MJG5ubl4i7vrllu4RS92KlCWVRqNBZGQkzM3NhQnciYgonW5hjpLQF5aWfs0Qxb0v1Gq1mDNnDn7//Xds2bIlV9Ms3Lp1CwC4SDIR5ZuJiQnMzc0RGRkJqVSaaR2JD0lJ6wsLsj4F1RcWv16UiKgYcXZ2hlgsNngF4w9dxvl7SjLdHHol4Y8NIqKCphs5WBL6wtLSrxmiOPeFs2bNwsGDB/Hdd9/BwsJCWLvD0tISpqamePr0KcLCwtC4cWPY2Njgzp07WLBgAerWrQsvLy8jR09EHzqRSIQyZcrg0aNHePLkibHDybeS1hcWZH0Koi9kopWIKAe6TtXJyQkqlcrY4RQprVYrLPpXHC+6CpJMJitRf2wQERWkktIXlqZ+zRDFuS/cvn07AKB379562xcsWIBOnTpBKpXi3Llz2Lx5M5KSklCmTBm0bNkSw4cPN0a4RFQCyWQyVKlSRXi0/ENV0vrCgq5PQfSFTLQSEeWCMSZ0b9asGSIiIjJt79mzJ2bMmIHw8HA0b948y/cuW7YMbdq0QUxMDCZNmoS///4b5cuXx/z58/VWyZ01axbKli2LL774ItMxdI9hmJqaFutOeOXKlTh27Bj2799v7FCIiEo0Y/SFarUaK1euxIEDBxAVFQUnJycEBwdj+PDhQt8UFRWFxYsX48yZM4iPj0edOnUwbdo0VKhQQTjOggULsHfvXpiammL8+PH49NNPhX2//vor9u/fjzVr1hRp3QrS33//jT59+uCff/7JtEp1SfC+tTvKlCmDrVu3FlE0RFRaicVig1eiz4+EhAQsX74cx44dQ3R0NKpXr44pU6bAx8cny/LTp0/Hzp07MXnyZPTr1w9A+tyjX3/9NY4fPw57e3vMnDlTb5Hb9evX48WLF5g2bVpRVKnAZLxm3bt3L+bPn4+LFy8aNSYmWomIiqldu3ZBrVYLr+/du4f+/fujdevWANIvKs6cOaP3np07d2LDhg1o1KgRAGDNmjVITEzEnj17sH37dkydOhV79uwBAFy5cgVXr17F1KlT3xvLq1evYG9vXyznbSMiopJr3bp12L59O7755htUrlwZN27cwOTJk2FpaYk+ffpAq9VixIgRMDExwXfffQeFQoFNmzahf//+OHToEMzNzfHHH3/g4MGDWL9+Pe7du4epU6ciICAAdnZ2iI+Px7Jly7Bx48b3xhIXFwexWAyFQlEENSciIko3depU3Lt3DwsXLoSTkxMOHDiA/v374/Dhw3B2dtYr+/vvv+Pq1atwcnLS275z507cvHkTO3bswPHjxzF+/Hj89ddfEIlEePbsGf73v/9h9+7d743lzZs3sLCwgFwuL9A6liTF89kQIiKCnZ0dHB0dha8TJ06gXLly+PjjjwGkjyzKuN/R0RHHjh1DmzZtYGFhAQB48OAB2rZti4oVK6Jbt254+PAhAEClUmHGjBmYNWtWrkYn/e9//0Pjxo3xzTffvHdUSVY0Gg3WrVuHFi1awNvbG02aNMH3338v7L9z5w769OkDHx8f1KtXD9OmTUNiYqKw/++//0aXLl1Qq1Yt1KlTB927d0dERAT27NmDVatW4fbt2/D09ISnp6eQSC4pVq5cKdRN96VLtgNAamoqZs2ahXr16sHX1xcjR45EVFSUESMmIio4//77L5o3b44mTZrA3d0drVu3RkBAAK5duwYAePz4Ma5cuYKZM2fCx8cHlSpVwsyZM5GSkoJDhw4BSO8LP/74Y9SoUQOtW7eGQqFAeHg4AGDRokXo0aMHXF1d3xvL7du30aBBA4wfPx5nz56FRqPJc33++OMPdO7cGTVq1EC9evUwYsQIYV9sbCwmTpyIunXrombNmhg4cCAeP34s7I+IiMDQoUNRt25d1KpVC0FBQTh58iTCw8PRp08fAEDdunXh6emJSZMm5Tk2IiIqflJSUvDbb79hwoQJqFu3LsqXL4+RI0eifPny2LZtm17ZV69eYc6cOVi8eDGkUqnevgcPHqBZs2aoUqUKunbtijdv3uDt27cAgJkzZ2L8+PG5upF48uRJBAQEYPr06fj3338NqtOuXbsQFBQEb29vBAQEYPbs2cK+58+fY9iwYfD19UXt2rUxevRovWub27dvo3fv3sL+Tp064b///sPff/+NyZMnIz4+XrhmWrlypUHx5RcTrUREHwClUokDBw6gc+fO2T7Gf+PGDdy6dQtdunQRtnl5eeH8+fNIS0vD6dOn4enpCSD90RDdRWduDBo0CF9//TUePHiATp06ITg4GJs3b8abN29y9f4lS5Zg3bp1GD58OA4fPozFixfDwcEBAJCUlIQBAwbA2toau3btwrJly/DXX39hzpw5AIC0tDSMGDECdevWxYEDB7Bz505069YNIpEIbdu2xRdffIEqVargzJkzOHPmDNq2bZurmD4kGet35swZvT+q5s+fjxMnTmDZsmXYsmULXr9+jZCQECNGS0RUcHx9fXH+/Hk8evQIQPoF1qVLl4QnN3Rz5WUcWSMWiyGTyXDp0iUA6X3hjRs3EBsbi//++w8pKSkoX748Ll68iJs3b2aa9zM7devWxbp16yCTyTBq1Cg0bdoUS5cuFW5ivs+ff/6JkJAQNG7cGPv27cNPP/2k99jnpEmTcOPGDXz//ffYuXMntFotBg8eLMyLO3v2bCiVSmzduhVhYWEYP348zM3NUaZMGeFi8siRIzhz5gy+/vrrXMVERETFW1paGtRqdaYRpHK5HJcvXxZeazQaTJgwAQMGDECVKlUyHcfLywuXLl1CSkoKzp07B0dHR9ja2uLAgQOQy+Vo0aJFruJp3749Fi1ahLi4OPTt2xetWrXCmjVr8OLFi1y9f9u2bZg9eza6du2KsLAwfPfddyhXrpxQh+HDhyM2NhZbtmzBxo0b8ezZM4wdO1Z4//jx4+Hi4oJdu3Zhz549GDx4MExMTODr64spU6ZAoVAI10xZTY9XFPgMqIEUCgUsLS356BARFYljx44hPj4ewcHB2ZbZtWsXPDw8ULt2bWHb4MGDMXPmTLRo0QJubm6YN28eHj9+jH379mHHjh2YPn06zp49C29vb8ydOxeWlpZZHlsul6Nt27Zo27YtoqOjERYWhr1792LhwoVo1KgRgoOD0bRp0yynFkhISMDmzZsxffp0If5y5cqhTp06AICDBw9CqVTim2++gbm5OYD0eYWGDh2K8ePHw8TEBPHx8WjatKnQCXt4eAjHNzc3F0b3llTZ1S8+Ph67d+/G4sWLUb9+fQDpide2bdviypUrqFWrVoGcXy6Xw9TUlI8IEVGRGzx4MBISEtCmTRtIJBKo1WqMHTtWmGO1UqVKcHV1xZIlSzB79myYmZlh06ZNePnypbAyfcOGDfHpp5/is88+g0wmQ2hoKMzMzDBr1iwsWLAA27dvx5YtW2Bra4s5c+ZkeYEKpC8K9vHHH+Pjjz/G9OnTcezYMezbtw8bNmzARx99hODgYLRr1y7bvnTNmjVo27YtRo0aJWzz8vICkD4y948//sD27duFfnzx4sVo0qSJ8LTK8+fP0apVK+GmadmyZYXjWFtbAwDs7e1L5BytxmJmZgZzc3OYmZkZOxQiKqUUCgV8fX3x3XffoVKlSnBwcMDBgwdx5coV4doISJ9qx8TERHjC4V2dO3fGnTt3EBQUBGtrayxbtgyxsbFYsWIFtmzZgm+//RaHDx9GuXLlMH/+/ExTEuiYmJigSZMmaNKkCeLj44V5zlesWIGPP/4YHTt2ROvWrbOdy/b7779H//790bdvX2Gb7qbjuXPncPfuXRw/fhxlypQBACxcuBBBQUG4du0afHx88Pz5cwwYMEC4HixfvjySkpIgk8lgaWkJkUhk9OtCJloNdPv2bWOHQESlyO7du9GoUaNsO7yUlBQcPHgw0+q6lpaWWLJkid62Pn36YMKECQgLC0N4eDiOHDmCadOmYfXq1bl61NDe3h79+vVDv379cPLkSUyePBnHjx/Hvn37UK1atUzlHz58CKVSiU8++STL4z148ACenp5CkhUAateuDY1Gg0ePHqFu3bro1KkTBgwYgAYNGqB+/fpo06ZNpnmHSrInT54gICAAcrkctWrVwpdffglXV1fcuHEDKpUK/v7+QlkPDw+4uroanGjVarWZtmV8nEe3P+P8wcWFWq3Wi68oYtSdozi2R3HHtjOMsdpNJBIZZWHEw4cPIywsDIsXL0blypVx+/ZtzJ8/H46OjggODoaJiQlWrFiBqVOn4uOPP4ZEIkH9+vXRqFEjaLVa4TMhJCQEI0aMEFYmXr16NerXrw8TExN8//33OHDgAE6cOIGJEyfmagoauVyOoKAgBAUF4dGjR/jyyy8xc+ZMpKam6l08ZqR76iSrz9kHDx7AxMQEPj4+wn4bGxtUrFgRDx48gFarRe/evTFr1iycOXMG9evX10u66t6Tsc7vymlfTtRqdZEvglZc5GbuXiKiwrZw4UJMmTIFjRo1gkQiQfXq1REUFISbN28CSH+ycfPmzdizZ0+2fbVUKsWMGTOg1WqRlJQEc3NzTJkyBb1798Z///2H48ePY//+/Vi/fj3mzp2bq8fuLS0t0bVrV3Tt2hXXrl3DuHHj8NVXX0GhUCAwMDBT+ejoaLx+/VoYIPKuBw8ewMXFRUiyAkDlypVhZWWFhw8fwsfHB/3798fUqVOxf/9++Pv7o1WrVsKTksUFE61ERMVcREQE/vrrrxw7uyNHjiAlJQUdO3bM8Vi7d++GlZUVAgMDERISgubNm0MqlaJ169ZYsWJFruJJSEjA0aNHsX//fly8eBF169bFxIkT9UaZZlQQoyAXLFiA3r174/Tp0/j111+FhUsKasRmcebj44MFCxagYsWKiIyMxOrVq9GrVy+EhYUhKioKUqk00+gle3t7YSRXXiQkJCAuLi7HMiKRCElJSXj27JnwyG5xoVKpEBsbCwC4evVqprmpCtP169eL7FwlDdvOMEXdbo6OjnBxcREeYy8qCxcuRL9+/dC0aVMA6aM4nzx5gh9++AGtWrUCkD6qddu2bYiPj0daWhpsbW3Rp08fVKtWDUlJSZmO+d9//2H//v3Yvn079u/fD19fX5iamqJJkyb4+uuvERkZKcx1np20tDScP38ehw4dwsmTJ+Hm5obRo0cjMDAwy3MC6f2hUqnMcn9qaiqA9Ol0MiY1NRoNVCoVkpKSEBQUBD8/P5w5cwbnzp3D2rVrMW7cOHTv3l14f3JycpZPl8hkMkRHRyMiIiLHemXHz8/PoPcREVH+lStXDlu3bkVSUhISEhLg5OSEMWPGCE82XLx4EdHR0UJfCaTfJPvmm2+wefNm/PHHH5mOef78edy7dw9z584VnlI0NzdHmzZt8PPPP+cqrtTUVPzxxx/Yv38/zpw5g2rVquGLL77IdoBNQVwXjhw5Eu3atcPJkydx6tQprFixAgsWLEC7du3yfeyCwkQrEVExt2fPHtjb26NJkybZltm9ezeaNWsGOzu7bMu8efMGq1evxvbt2wGkd75paWkA/n/un+yo1WqcOXMGBw4cwLFjx+Di4oKOHTsiNDT0vQuIVKhQAaampjh//rzeY446Hh4e2Lt3r3BnFQAuX74MsViMihUrCuWqV6+O6tWrY8iQIejWrRsOHjyIWrVqQSqVGrQgyYeicePGwvdeXl6oWbMmmjZtil9//TXbR3IMpVAo3jtKTqFQwNzcPNvR1cakVCqFx2dr1qwJmUxW6OdUq9W4fv06atSoUWpHfBmKbWcYY7WbbkRrUd7AANKf2DA1NdV76kEul0Or1eptAyC8fvz4Mf777z+MGTNGr4xuFM+CBQswefJkODg4QCKRCMfS9YlyuTzTsXVu3ryJAwcO4NChQ0hLS0NQUBC2bNmSqznPPT09cfnyZfTo0SPTvmrVqiEtLQ337t0Tpg54+/Ytnjx5Ai8vLyGeSpUqoVKlSujTpw+WLFmCffv24YsvvhCmM5PJZNnG7uTkZNDjlBx1TkRUPJibm8Pc3ByxsbE4c+YMJkyYAADo0KGD3hNuADBgwAB06NABnTp1ynSc1NRUYdEs3bQ8uice3nddqNVqcenSJezbtw9HjhyBhYUFPv30U0yYMCHbgTc6CoUCbm5uOHfuXJbJWA8PD7x8+RIvXrwQRrXev38fcXFxeseuWLEiKlasiH79+mHs2LE4cOAA2rVrB6lUWiz6LCZaiYiKMY1Ggz179qBjx45ZjlAB0h8r/+eff7B27docjzVv3jx88cUXQoKsdu3a2L9/PwICArBz5069uV3ftWbNGmzcuBFt27bFxo0bcyz7LrlcjkGDBmHRokWQSqWoXbs23rx5g3v37uGzzz5D+/btsWLFCkyaNAkhISF48+YN5syZgw4dOsDBwQHPnj3DL7/8gmbNmsHJyQmPHj3C48eP0aFDBwCAm5sbwsPDcevWLTg7O0OhUBRJgs1YrKysUKFCBTx9+hT+/v5QqVSIi4vTG9UaHR1t8NxE73s0WLe/OCbGJBKJXnxFGWNRn68kYdsZprS0W7NmzbBmzRq4urqicuXKuHXrFjZt2qS3OOSvv/4KOzs7uLq64s6dO5g/fz4CAwPRsGHDTMfbu3cv7Ozs0Lx5cwDpIzVXrVqFq1ev4tSpU6hcubJww+ZdFy9eRL9+/dCwYUPMmDEDTZo0yVN/ExISgn79+qFcuXIICgpCWloaTp48icGDB6NixYpo3rw5pk+fjlmzZkGhUGDx4sVwdnZGYGAgRCIR5s2bh0aNGqFChQqIi4vDhQsX4OHhAZFIBHd3d4hEIpw8eRKNGzeGXC7PNCrXGFM/EBFR/p0+fRparRYVK1bE06dPsXDhQlSqVElIotra2sLW1lbvPVKpFA4ODqhUqVKm461btw6NGjVC9erVAaRfFy5atAidOnXC1q1bc7zW279/P2bMmIHAwEAsW7YM/v7+EIvFua7LyJEjMWPGDNjb26NRo0ZITEzE5cuX0bt3b/j7+6Nq1aoYP348pkyZArVajZkzZwqLOKekpGDhwoVo1aoV3N3d8fLlS9y4cUMYyevm5oakpCScO3cOnp6eMDMzM8oc20y0GmjChAl4+/YtbG1tsWjRImOHQ0Ql1F9//YXnz5+jc+fO2ZbZvXs3XFxcEBAQkG2Z06dP4+nTp3qfV59//jlu3LiBzz77DD4+PjmuVN+hQwcMHDjQ4Mc9hg8fDolEghUrVuD169dwdHRE9+7dAaQvNLFhwwbMmzcPXbp0gZmZGVq2bCnMF2tmZoaHDx9i7969iImJgZOTE3r16iW8v1WrVvj999/Rp08fxMXFYcGCBVneuS0pEhMT8ezZMzg6OsLb2xtSqRTnzp0THqF9+PAhnj9/XqDTKuzatUsYcdy/f/8COy4R0ftMnToVy5cvx6xZsxAdHQ0nJyd069YNI0aMEMpERkYiNDRUuMnUoUOHTHOWA0BUVBQ2bNiAHTt2CNt0870NGTIEdnZ2+Oabb7KNxcPDA6dOncrx6ZGc1KtXD8uXL8d3332HtWvXQqFQoG7dusL+BQsWYN68eRg6dChUKhXq1KmDtWvXCqOINRoNZs+ejZcvX0KhUKBhw4aYPHkyAMDZ2RkjR47EkiVLMHnyZOGpE8qfH374AQkJCVAoFBgyZIixwyGiUio+Ph5Lly7Fy5cvYWNjg5YtW2Ls2LEGPWVy9+5d/P7779i/f7+wrXXr1rhw4QJ69eqFihUrZlrjI6P69evj7NmzBi8MHxwcjNTUVGzatAkLFy6EjY0NWrduDSD9huB3332HOXPm4PPPP4dIJELDhg0xbdo0AIBYLEZMTAy++uorREVFwdbWFi1atMDQoUMBpCeMu3fvjjFjxiAmJgYhISEYOXKkQXHmh0hryIzoJYxarcaVK1dw8uRJREVFZVvOzs4Offv2haOjI9zd3RERESGMpCooSqUSM2fOBADMnDmzyEZl6dqgVq1apWJ0RHbYDmwDHbYD9CZKL82jYIy9CMg333yDpk2bwtXVFa9fv8bKlStx69YtHD58GHZ2dpgxYwZOnTqFBQsWQKFQYO7cuQCgl0h4H93vu+7RnHdNnDgRMTExsLGxwffff4/WrVvDxsamoKpYYIzRh/KzwnBsO8Ow3QzHfs0wxu4Hi4ru/1ZKSgpSUlIAAN27d0dUVBQcHByEftXMzAw1a9Z87zy+xUFhfF4Y63oVKHmffyWtPkDJq1NJqw9Q8vrC4lgfjmglIiIqxl6+fIlx48YhJiYGdnZ28PPzwy+//CKMqJoyZQrEYjFGjRoFpVKJgIAAzJgxw8hRExERERERlT5MtBIRERVj3377bY775XI5ZsyYweQqERERERGRkeV+xloiIiIiIiIiIiIiyhITrURERERERERERET5xEQrERFlq6RM+k5ERASwXyMiIippfWFxqw8TrURElC2NRmPsEIiIiAoM+zUiIirtSlpfWNzqw0QrERFlSaPR4NatW8Wu4yIiIjIE+zUiIirtSlpfWBzrw0QrERERERERERERUT6ZGDuAD1VQUBDevHkDOzs7Y4dCRERUqGrUqIHExERYWFgYOxQiIqIiU69ePcTHx8PS0tLYoRAR0QeCiVYD/fDDD8YOgYiIqEj07t3b2CEQEREVubFjxxo7BCIi+sBw6gAiIiIiIiIiIiKifGKilYiIiIiIiIiIiCifmGglIiIiIiIiIiIiyifO0WqgOnXq4OXLl3BxccHFixeNHQ4REVGhmTdvHmJjY2FtbY3Q0FBjh0NERFQkhg8fLiyA/N133xk7HCIi+gAw0Wqgly9fIiIiwthhEBERFbrY2FjExMQYOwwiIqIi9ebNG0RFRRk7DCIi+oBw6gAiIiIiIiIiIiKifGKilYiIiIiIiIiIiCifjJpo/eeffzB06FAEBATA09MTx44d09uv1WqxfPlyBAQEwMfHB/369cPjx4/1ysTExODLL79E7dq1UadOHUyZMgWJiYlFWAsiIiIiIiIiIiIq7YyaaE1KSoKnpydmzJiR5f5169Zhy5YtmDlzJn755ReYmZlhwIABSE1NFcqMHz8e9+/fx8aNG7FmzRpcvHgR06dPL6oqEBERERERERERERl3MazGjRujcePGWe7TarXYvHkzhg0bhsDAQADAwoUL4e/vj2PHjiEoKAgPHjzA6dOnsWvXLtSoUQMAMHXqVAwePBgTJ06Es7NznuLRarXQarU57gcAtVqtt/3d1/mhVqv1zlOQx37feTP+W1qxHdgGOmwHtoGOWq2GRCIxdhhERERERERUzBk10ZqT8PBwREZGwt/fX9hmaWmJmjVr4t9//0VQUBD+/fdfWFlZCUlWAPD394dYLMa1a9fQokWLPJ0zMTERsbGx2e6XSqVISkrCy5cvoVKpAAAqlQpXrlzJW+VyoFKphBiuXr0KqVRaYMfOjevXrxfp+YortgPbQIftwDYAAD8/P2OHQERERERERMVcsU20RkZGAgDs7e31ttvb2yMqKgoAEBUVBTs7O739JiYmsLa2Ft6fFxYWFrC2ts52v6WlJczNzeHu7i4kQKVSKWrVqpXnc2VHqVQKMdSsWRMymazAjp0TtVqN69evo0aNGqV65BbbgW2gw3ZgG+iU9hG9RERERERElDvFNtFqDCKRCCKRKMf9ADIlHAoyASGRSPTOU9TJDWOcszhiO7ANdNgObAMiIiIiIiKi3Ci2iVZHR0cAQHR0NJycnITt0dHR8PLyAgA4ODjgzZs3eu9LS0tDbGys8P7CsnDhQiQlJcHc3LxQz0NERGRsnTt3hlKpFJ6yyOmmJBERUUkxaNAgpKamQi6XGzsUIiL6QBTbRKu7uzscHR1x7tw5VKtWDQCQkJCAq1evokePHgAAX19fxMXF4caNG/D29gYAnD9/HhqNBj4+PoUaX8+ePQv1+ERERMVFvXr1hO/lcjnEYjFiYmLe+z65XA4zM7NCjIyIiKjwNG/ePNM2ExMTiMViJCYmvvf9Uqm0yKaCIyKi4sGoidbExEQ8ffpUeB0eHo5bt27B2toarq6u6NOnD77//nuUL18e7u7uWL58OZycnBAYGAgA8PDwQMOGDTFt2jTMmjULKpUKc+bMQVBQEJydnY1VLSIiohJLKpVCqVTi3LlzSEhIyLacQqFAQEAAE61ERFSiSCQSpKWl4e7du0hNTc22nFwuh5eXFxOtRESljFETrTdu3ECfPn2E1wsWLAAABAcHIzQ0FIMGDUJycjKmT5+OuLg4+Pn5Yf369XqPbixevBhz5sxB3759IRaL0bJlS0ydOrXI60JERFSaJCQkID4+3thhEBERGUVqaiqSk5ONHQYRERUzRk201qtXD3fu3Ml2v0gkwujRozF69Ohsy9jY2GDJkiWFEV6O7ty5g7S0NJiYmMDT07PIz09ERFRUXr58CY1GA7FYjDJlyhg7HCIioiLx7NkzqNVqSCQSlC1b1tjhEBHRB6DYztFa3DVv3hwRERFwc3NDeHi4scMhIiIqNEuXLkVMTAxsbGywZcsWY4dDRESlzA8//IDffvsNDx8+hKmpKXx9fTF+/HhUqlRJKJOamorQ0FAcPnwYSqUSAQEBmDFjBhwcHAw+74QJExAVFQUHBwfs2LGjIKpCREQlnNjYARARERERERFl58KFC+jVqxd++eUXbNy4EWlpaRgwYACSkpKEMvPnz8eJEyewbNkybNmyBa9fv0ZISIgRoyYiotKII1qJiIiIiIio2NqwYYPe69DQUNSvXx83b95E3bp1ER8fj927d2Px4sWoX78+gPTEa9u2bXHlyhXUqlXLCFETEVFpxEQrERERERERfTB0izFaW1sDSF9kWaVSwd/fXyjj4eEBV1fXPCdatVottFptlttzU+7d8mq1OtfnLmi6cxdkDGq1Wq9uRVm/wqiPMZW0+gAlr04lrT5AyatTUdZHIpHkqhwTrURERERERPRB0Gg0mD9/PmrXro2qVasCAKKioiCVSmFlZaVX1t7eHpGRkXk6flJSEhISEoRz6f6Ni4sDAMhkMmg0GiQmJgrlsqJWq5GUlISHDx9CqVTmKYaCdv369QI7lkqlQmxsLADg6tWrkEqlBXbs3CrI+hQHJa0+QMmrU0mrD1Dy6lQU9fHz88tVOSZaiYiIiIiI6IMwa9Ys3Lt3D9u2bSuU45ubm0MsTl/KJOO/uiSuhYUFxGKx8G92zMzMYG5ujurVqxdKnLmhVqtx/fp11KhRI9cjsd5HqVQKI4lr1qwJmUxWIMfNjcKojzGVtPoAJa9OJa0+QMmrU3GsDxOtREREREREVOzNnj0bf/75J7Zu3QoXFxdhu4ODA1QqFeLi4vRGtUZHR8PR0TFP5xCJRBCJRFluz025d8sXhwt/iURSYHFIJBK9uhmjfsY6b2EpafUBSl6dSlp9gJJXp+JUn+xvwREREREREREZmVarxezZs/H777/jp59+QtmyZfX2e3t7QyqV4ty5c8K2hw8f4vnz51wIi4iIihRHtBIREREREVGxNWvWLBw8eBDfffcdLCwshHlXLS0tYWpqCktLS3Tu3BmhoaGwtraGQqHA3Llz4evry0QrEREVKSZaiYiIiIiIqNjavn07AKB379562xcsWIBOnToBAKZMmQKxWIxRo0ZBqVQiICAAM2bMKPJYiYiodGOiNY9089H8888/UKvVxWYOCCIiKh3Wrl2LJUuWoE+fPvj6668BAKmpqQgNDcXhw4f1Li4dHBwK5JxTpkyBVqvNcS46IiKiwnLnzp33lpHL5ZgxY0aBJldXr14NjUaT46JXREREGTHRmgdmZmaQSCSIjIyEiYkJTEzSm0/36Mq7ZRUKRVGHSEREJdi1a9ewY8cOeHp66m2fP38+Tp48iWXLlsHS0hJz5sxBSEgIduzYUSDntbGxKZDjEBERfUjs7e2NHQIREX1gmGjNA5lMhpSUFBw8eBCxsbHZlrO2tkbHjh2ZaCUiogKTmJiICRMmYO7cufj++++F7fHx8di9ezcWL16M+vXrA0hPvLZt2xZXrlzh3HRERERERERFhIlWA8TGxuLNmzfGDoOIiEqR2bNno3HjxvD399dLtN64cQMqlQr+/v7CNg8PD7i6uhqUaNVqtbnar9Vqcyyr26dWq/N0/vxQq9V65y2Kc+vOUZT1LCnYdoZhuxmObWcYTpdGRESUe0y0Gujff/+FSqWCVCqFr6+vscMhIqIS7NChQ/jvv/+wa9euTPuioqIglUphZWWlt93e3j7LqW1ykpCQgLi4uEzbz58/j9TUVMjlcnTp0gUajQZJSUlZltURiURISkrCs2fPoFQq8xSHoVQqlfDEydWrVyGVSovkvABw/fr1IjtXScO2MwzbzXBsu7zz8/MzdghGcfDgQaSkpMDU1BTt2rXL03tNTEwgFouRmJj43rJSqRQymczQMImIqBhhotVAZ8+eRXx8PCwtLZloJSKiQvPixQvMmzcPP/74I+RyeaGeS6FQZDnS6/jx44iJiYGNjQ369u0LsVgMc3PzHEeFKRQKmJubw9nZuTBD1qNUKmFtbQ0AqFmzZpFctKrValy/fh01atTgiK88YtsZhu1mOLadYUrzCOCtW7ciKioKDg4OeU60SiQSpKWl4e7du0hNTc22nFwuh5eXFxOtREQlBBOtRERExdjNmzcRHR2NTp06CdvUajX++ecf/Pzzz9iwYQNUKhXi4uL0RrVGR0fD0dExz+cTiUS52i8SiXIsq9tXlMkMiUSid96iPjcTN4Zh2xmG7WY4th0VpdTUVCQnJxs7DCIiKiJMtBIRERVjn3zyCcLCwvS2TZ48GZUqVcKgQYNQpkwZSKVSnDt3Dq1atQIAPHz4EM+fP+dCWEREREREREWIiVYiIqJiTKFQoGrVqnrbzM3NYWNjI2zv3LkzQkNDYW1tDYVCgblz58LX15eJViIiIiIioiLERCsREdEHbsqUKRCLxRg1ahSUSiUCAgIwY8YMY4dFRERERERUqjDRSkRE9IHZsmWL3mu5XI4ZM2YwuUpERERERGREYmMHQERERERERERERPShY6KViIiIiIiIiIiIKJ+YaCUiIiIiIiIiIiLKJ87RaiA7OzvI5XJYWFgYOxQiIqJC5ezsDDMzM1hZWRk7FCIioiLj7u4OCwsL2NraGjsUIiL6QDDRaqCePXsaOwQiIqIi8eWXXxo7BCIioiK3ePFiY4dAREQfGE4dQERERERERERERJRPTLQSERFRoRCJRMYOgYiIiIiIqMhw6gAiIiIqcHK5HGKxGDExMbkqa2ZmVvhBERERERERFSImWg20f/9+JCcnw8zMDB06dDB2OERERIVm/fr1SEhIgEKhwLRp03L1HqlUCqVSiXPnziEhISHbcgqFAgEBAUy0EhFRsTN//nzExsbC2toaU6ZMMXY4RET0ASjWiVa1Wo2VK1fiwIEDiIqKgpOTE4KDgzF8+HDhcUStVosVK1bgf//7H+Li4lC7dm3MnDkTFSpUKNTYnj17hvj4eFhaWhbqeYiIiIzt7t27iImJgY2NTZ7fm5CQgPj4+IIPioiIqJBdu3YNUVFRcHBwMHYoRET0gSjWc7SuW7cO27dvx/Tp03H48GGMHz8e69evx5YtW/TKbNmyBTNnzsQvv/wCMzMzDBgwAKmpqUaMnIiIiIiIiIiIiEqTYp1o/ffff9G8eXM0adIE7u7uaN26NQICAnDt2jUA6aNZN2/ejGHDhiEwMBBeXl5YuHAhXr9+jWPHjhk5eiIiIiIiIiIiIiotivXUAb6+vvjll1/w6NEjVKxYEbdv38alS5cwadIkAEB4eDgiIyPh7+8vvMfS0hI1a9bEv//+i6CgoDydT6vVQqvV5qpcbl6r1eo8nV/3nozvN+QYhtCdp6jOV1yxHdgGOmwHtoGOWq2GRCIxdhhERERERERUzBXrROvgwYORkJCANm3aQCKRQK1WY+zYsfj0008BAJGRkQAAe3t7vffZ29sjKioqz+dLTExEbGxstvsTEhKg0WiQmJgIjUYDANBoNJneI5VKkZSUhJcvX0KpVOYpBpVKJRzv6tWrkEqleaxF/ly/fr1Iz1dcsR3YBjpsB7YBAPj5+Rk7BCIiIiqBTExMIBaLkZiYmKvyUqkUMpmskKMiIiJDFetE66+//oqwsDAsWbIElStXxq1bt7BgwQJhUayCZmFhAWtr62z3KxQKiMViWFhYQCxOn3VBLBZneo+lpSXMzc3h7u6e5xiUSqVwvJo1axZZJ6pWq3H9+nXUqFGjVI/cYjuwDXTYDmwDndI+opeIiIgKj0QiQVpaGu7evfvedUbkcjm8vLyYaCUiKsaKdaJ14cKFGDx4sDAFgKenJ54/f44ffvgBwcHBcHR0BABER0fDyclJeF90dDS8vLzyfD6RSASRSJSrcrl5bUhiQiKR6L2/qJMbxjhnccR2YBvosB3YBkRERESFLTU1FcnJycYOg4iI8qlYL4aVkpKSKYkpkUiEOUzd3d3h6OiIc+fOCfsTEhJw9epV+Pr6FmmsREREREREREREVHoV6xGtTZs2xZo1a+Dq6ipMHbBx40Z07twZQPrI0T59+uD7779H+fLl4e7ujuXLl8PJyQmBgYFGjp6IiIiIiIiIiIhKi2KdaJ06dSqWL1+OWbNmCdMDdOvWDSNGjBDKDBo0CMnJyZg+fTri4uLg5+eH9evXQy6XF2psNWvWRGpqaqGfh4iIyNgaNmyI5ORkmJmZGTsUIiKiItO2bVskJibCwsLC2KEQEdEHolgnWhUKBb7++mt8/fXX2ZYRiUQYPXo0Ro8eXYSRpV90EhERlQbt27c3dghERERFrk+fPsYOgYiIPjDFeo5WIiIiIiIiIiIiog+BQSNanz17hrJlyxZ0LERERERERESUBRMTE4jFYiQmJr63rFQqhUQiKYKoiIgoI4MSrS1atEDdunXRpUsXtG7dmvOUEhERERERERUiiUSCtLQ03L17F6mpqdmWk8vl8PLyYqKViMgIDEq07t27F7t370ZoaCjmzJmDtm3bokuXLvDx8Sno+IqtVatWIT4+HpaWlggJCTF2OERERIVm4sSJiImJgY2NDbZs2WLscIiIiIpE9+7dERUVBQcHB+zYscPY4QhSU1ORnJxs7DCIiCgLBs3RWq1aNUydOhWnT5/G/Pnz8fr1a/Ts2RPt2rXDxo0b8ebNm4KOk4iIiIiIiIiIiKjYytdiWCYmJmjZsiVWrFiB8ePH48mTJ/jmm2/QuHFjTJw4Ea9fvy6oOImIiIiIiIiIiIiKLYOmDtC5fv06du/ejcOHD8PMzAxffPEFunTpglevXmHVqlUYPnw4du3aVVCxEhERERERERERERVLBiVaN27ciD179uDRo0do1KiRMIpVLE4fIFu2bFmEhoaiWbNmBRosERERERERERERUXFkUKJ1+/bt6Ny5M4KDg+Hk5JRlGTs7O8ybNy9fwX3IRCKRsUMgIiIiIiL64P3zzz/YsGEDbty4gcjISKxevRqBgYHC/kmTJmHv3r167wkICMCGDRuKOlQiIirlDEq0/vjjj3B1dRVGsOpotVq8ePECrq6ukMlkCA4OLpAgPzRmZmaQSCSIjIzMVVmFQlEEUREREREREX14kpKS4Onpic6dOyMkJCTLMg0bNsSCBQuE1zKZrKjCIyIiEhiUaG3RogXOnDkDe3t7ve0xMTFo3rw5bt26VSDBfahkMhlSUlJw8OBBxMbGZlvO2toaHTt2ZKKViIiIiIgoG40bN0bjxo1zLCOTyeDo6FhEEREREWXNoESrVqvNcntSUhLkcnm+AipJYmNj8ebNG2OHQUREREREVKJduHAB9evXh5WVFT755BOMGTMGtra2eT6OVqvN8nr33W3Zlcvt8Qwtl5uyun1qtRoymQxqtTpXx80NtVqtd/yCPHZuzp3x3w9dSasPUPLqVNLqA5S8OhVlfSQSSa7K5SnRqnsUQyQSYfny5TAzMxP2qdVqXLt2DV5eXnk5JBEREZVynNeciIjyo2HDhmjRogXc3d3x7NkzLF26FIMGDcLOnTtzfWGsk5SUhISEBACARqMR/o2LiwOQPnJWo9EgMTFRKJeVgi6Xl7JisRharRbx8fFwcXHJ8SlLkUiEiIgIpKWl5XhuHZVKJRzv6tWrkEqluXpfQbp+/XqRn7MwlbT6ACWvTiWtPkDJq1NR1MfPzy9X5fKUaP3vv/8ApN8hu3v3rt6Hqkwmg5eXF7744ou8HPKD1b59e6jV6jx33ERERB+aAQMGIC0tDSYmBj0IkyO5XA6xWIyYmJhclc14k5eIiAgAgoKChO89PT3h6emJwMBAYZRrXpibmwtrkUyZMgVKpRIymQxWVlYAAAsLC4jFYuHf7BR0ubyUtba2hlarxaNHjxAdHQ0LC4ssb2qamprCy8sL3t7eOZ43I6VSCWtrawBAzZo1i3QuXLVajevXr6NGjRol4jq8pNUHKHl1Kmn1AUpenYpjffJ0xbRlyxYAwOTJk/H111+X6rlFy5cvb+wQiIiIioSnp2ehHVsqlUKpVOLcuXM5js5RKBQICAhgopWIiN6rbNmysLW1xZMnT/KcaBWJREJSslatWrkql9vjFUS5vJRNTU1FYmIiJBJJluV12/KSnMh4LIlEYpTEhrHOW1hKWn2AklenklYfoOTVqTjVx6ChKRlXcyQiIiLKr4SEBMTHxxs7DCIiKgFevnyJmJgYLo5FRERFLteJ1pCQEISGhkKhUCAkJCTHsqtWrcp3YERERARs27YN27dvR0REBACgSpUqGD58uLD6cmpqKkJDQ3H48GEolUoEBARgxowZcHBwMGbYREREBSYxMRFPnz4VXoeHh+PWrVuwtraGtbU1Vq1ahVatWsHBwQHPnj3DokWLUL58eTRs2NCIURMRUWmU60SrpaVllt+XVk+ePBHmaOU0AkREVFhcXFwwfvx4lC9fHlqtFvv27cOIESOwd+9eVKlSBfPnz8fJkyexbNkyWFpaYs6cOQgJCcGOHTsKLIY7d+4Ic7SWKVOmwI5LRESUGzdu3ECfPn2E17onLIODgzFz5kzcvXsX+/btQ3x8PJycnNCgQQOMHj063/OHXrlyBSqVClKpNMdpBIiIiHRynWjNOF0Apw4AwsLCEB8fD0tLy/eO8CUiIjJUs2bN9F6PHTsW27dvx5UrV+Di4oLdu3dj8eLFwhx08+fPR9u2bXHlyhWDLgq1Wm2mbRs2bEBMTAxsbGyEkbRarTbLsu8ep6DLqdXqbMuo1Wq9cjmVLSi6cxTFuUoatp1h2G6GY9sZpjgsAFyvXj3cuXMn2/0bNmwolPOGhoYiKioKDg4OBXoDk4iISi6D5mhNSUmBVqsVFqSIiIjA77//jsqVKyMgIKBAAyQiIqJ0arUaR44cQVJSEnx9fXHjxg2oVCr4+/sLZTw8PODq6mpQojUhIQFxcXGZtmdMhiYmJkKj0SApKSnLsjpWVlYFWk4kEiEpKQnPnj2DUqnMsoxKpUJsbCwA4OrVq5BKpdker6Bdv369yM5V0rDtDMN2MxzbLu/8/PyMHQIREdEHwaBE6/Dhw9GiRQv06NEDcXFx+OyzzyCVSvH27VtMmjQJPXv2LOg4iYiISq07d+6ge/fuSE1Nhbm5OVavXo3KlSvj1q1bkEqlsLKy0itvb2+PyMjIPJ9HoVBkOdJLt7qwSCSChYUFxGIxzM3NcxwVVtDlFAoFzM3N4ezsnG0ZpVIJa2trAEDNmjXz/chobqjValy/fh01atQw+oivDw3bzjBsN8Ox7QzDEcBERES5Z1Ci9ebNm5g8eTIA4OjRo3BwcMC+fftw9OhRrFixgolWIiKiAlSxYkVh7rmjR4/iq6++wtatWwvlXLqk6vv2i0SiHMsWVrmckiMSiUSvXFEmUor6fCUJ284wbDfDse2I0pmYmEAsFiMxMfG9ZaVSaZHcwCQi+tAZPHWAhYUFAODMmTNo2bIlxGIxatWqhefPnxdogERERKWdTCYTFl709vbG9evXsXnzZrRp0wYqlQpxcXF6o1qjo6Ph6OhorHCJiIjoAyCRSJCWloa7d+8iNTU123JyuRxeXl5MtBIR5YLYkDeVK1cOx44dw4sXL3DmzBk0aNAAQPqFnUKhKNAAiYiISJ9Go4FSqYS3tzekUinOnTsn7Hv48CGeP3/O1ZGJiIgoV1JTU5GcnJztV05JWCIi0mfQiNYRI0Zg/PjxWLBgAerXrw9fX18AwNmzZ1GtWrUCDZCIiKg0W7JkCRo1aoQyZcogMTERBw8exIULF7BhwwZYWlqic+fOCA0NhbW1NRQKBebOnQtfX18mWomIiIiIiIqYQYnW1q1bw8/PD5GRkfDy8hK2169fH4GBgQUWHBERUWkXHR2Nr776Cq9fv4alpSU8PT2xYcMG4WmSKVOmQCwWY9SoUVAqlQgICMCMGTOMHDUREREREVHpY1CiFQAcHR0zzf/m4+OT74CIiIjo/82fPz/H/XK5HDNmzCgVydX3LdRFRERERERkTAYlWpOSkrB27VqcP38e0dHR0Gg0evuPHz9eIMERERERAekJZbFYjJiYmGzLKJVKqFQqiMUGTUFPRERERESULwYlWqdOnYoLFy6gQ4cOcHR0LJUjTEJCQowdAhERUZFYuHChsUOAVCqFUqnEuXPnkJCQkGWZtLQ0vHnzBnZ2dkUcHRERlUQ7duwwdghERPSBMSjReurUKfzwww/w8/Mr6HiIiIiIspWQkID4+Pgs96nVaqSlpRVxREREREREROkMerbOysoKNjY2BRwKERERERERERER0YfJoETr6NGjsXz5ciQnJxd0PJm8evUK48ePR7169eDj44P27dvj+vXrwn6tVovly5cjICAAPj4+6NevHx4/flzocRERERERERGVdCYmJhCLxUhMTERiYiLS0tKQlpYmvM74pVQqjR0uEZFRGTR1wMaNG/H06VP4+/vD3d0dJib6h9m7d2+BBBcbG4sePXqgXr16WLduHWxtbfHkyRNYW1sLZdatW4ctW7YgNDQU7u7uWL58OQYMGIDDhw9DLpcXSBxZOX36NFJTUyGXy9GwYcNCOw8REZGxhYWFITk5GWZmZhg8eLCxwyEiIioSmzdvRmJiIiwsLNCnTx9jh2M0EokEaWlpuHv3LhISEhAXFwcAuHbtGqRSqVBOLpfDy8sLMpnMWKESERmdQYnWwMDAgo4jS+vWrYOLiwsWLFggbCtbtqzwvVarxebNmzFs2DAhpoULF8Lf3x/Hjh1DUFBQocV29epVxMfHw9LSkolWIiIq0U6fPo2YmBjY2Ngw0UpERKXG4cOHERUVBQcHh1KdaNVJTU1FSkoKNBoNACAlJYVzoxMRvcOgRGtISEhBx5GlP/74AwEBARg1ahT++ecfODs7o2fPnujatSsAIDw8HJGRkfD39xfeY2lpiZo1a+Lff//Nc6JVq9VCq9XmqlxOr3N7PK1WC5FIBLVaLWxTq9XCe9Rqtd6+wqQ7T1Gdr7hiO7ANdNgObAMdtVoNiURi7DCIiIiIiIiomDMo0QoAcXFxOHr0KJ4+fYoBAwbAxsYGN2/ehIODA5ydnQskuGfPnmH79u3o378/hg4diuvXr2Pu3LmQSqUIDg5GZGQkAMDe3l7vffb29oiKisrz+RITExEbG5vt/oSEBGg0GiQmJgp38TQaTab3ZCyX0/F0UyBEREQIyVWlUinMfRseHi48diGTyfD69etCv2OYcf7b0oztwDbQYTuwDQDAz8/P2CEQERERERFRMWdQovX27dvo378/LC0tERERga5du8LGxga//fYbXrx4gYULFxZIcFqtFt7e3hg3bhwAoHr16rh37x527NiB4ODgAjlHRhYWFnrzv75LoVBALBbDwsICYnH6OmJisTjTezKWy+l49vb2UKlUOHLkiJCQVavVePHiBQBg9+7dkEgksLa2RnBwMLy9vfNbxWyp1Wpcv34dNWrUKNUjt9gObAMdtgPbQKe0j+glIiIiIiKi3DEo0RoaGorg4GBMnDgRvr6+wvbGjRtj/PjxBRaco6MjPDw89LZVqlQJR48eFfYDQHR0NJycnIQy0dHR8PLyyvP5RCIRRCJRrsrl9Dqvx4uLi8Pbt28BpI+QValUAICYmBiIxWLhGEWR6JBIJKU6oaLDdmAb6LAd2AZEREREREREuSE25E3Xr19H9+7dM213dnYWHucvCLVr18ajR4/0tj1+/Bhubm4AAHd3dzg6OuLcuXPC/oSEBFy9elUvAUxERERERERERERUmAxKtMpkMiQkJGTa/vjxY9jZ2eU7KJ2+ffvi6tWrWLNmDZ48eYKwsDD88ssv6NmzJ4D0EaN9+vTB999/j+PHj+POnTuYOHEinJycEBgYWGBxEBEREREREREREeXEoKkDmjVrhtWrV2PZsmXCtufPn2Px4sVo2bJlQcUGHx8frFq1CkuXLsXq1avh7u6O/2vvzsOjrO7//79mSSbLTAIkICJWKm0SVkHcwCCFUrHgAgK9LipSlar4lYq2WhGrCCpEilXBpSgolroC1lZAP0I/xeujRqEWLIsalbqgZUkwy0ySmSRzfn9wZX4Eskwms+f5uC6vmHveue/3OQz3Ie859znz5s3TpZdeGoi59tprVVNTo7vvvluVlZUaNmyYVq5cKYfDEbY8AAAAAAAAAKA1IRVa586dq5tuuknDhw+X1+vVlVdeqdLSUg0ZMkS33HJLWBMcPXq0Ro8e3eLrFotFc+bM0Zw5c8J6XQAAAAAAAAAIVkiFVpfLpWeeeUYffPCBPv74Y1VXV2vAgAEaMWJEuPOLW6eeeqpqamqUnp4e61QAAIiovLw8ud1uOZ3OWKcCAEDUDB48WBUVFcrOzo51KgnBbrfLarXK4/G0GZuSkqLU1NQoZAUA0dXuQqvf79crr7yizZs365tvvpHFYtEpp5yi7t27yxgji8USiTzjzmWXXRbrFAAAiIpf/vKXsU4BAIComzdvXqxTSCg2m0319fUqKSmR1+ttMc7hcKigoIBCK4Ck1K5CqzFGN9xwg9566y0VFBQoLy9Pxhh9/vnnmjt3rt588009/vjjkcoVAAAAAADEMa/Xq5qamlinAQAx0a5C6yuvvKLt27dr9erVOu+885q8VlxcrBtvvFGvvvqqJk6cGM4cAQAAAAAAACCutavQunHjRs2aNeuEIqskDR8+XNddd51ee+01Cq0AACAmrFarLBaLysvL23wk0eFwsNY6AAAAgLBpV6H1k08+0W233dbi6xdccIHWrFnT4aQSwfPPPy+Px6PMzEz9/Oc/j3U6AABEzIMPPqjKykplZWVp6dKlsU6nVVarVX6/X++++65qa2tbjHM6nSosLKTQCgBo0a233qrvvvtOXbt2jfvxDwAQH9pVaK2oqFBOTk6Lr+fk5KiioqLDSSWCI0eOqKqqqtVFvgEASAYHDx5UeXl5Qq235na7EypfAED82b9/v0pLS+XxeGKdCgAgQVjbE9zQ0CC7veXarM1mU0NDQ4eTAgAAAAAAAIBE0q4ZrcYYzZ07t8U1z3w+X1iSAgAAAAAAAIBE0q5C66RJk9qMYSMsAAAAAAAAAJ1NuwqtixcvjlQeAAAAAAAAAJCw2rVGKwAAAAAAAADgRBRaAQAAAAAAAKCD2rV0AAAAAAAAQKjsdrusVqs8Hk+bsSkpKS1uxg0A8YhCKwAAAAAAiAqbzab6+nqVlJTI6/W2GOdwOFRQUEChFUBCodAaovPPP191dXVKSUmJyvUsFktUrgMAwPEuvvhieb1eORyOWKcCAEDUTJ8+XbW1tUpLS4t1KknJ6/WqpqYm1mkAQFhRaA3R0KFDo3at9PR02Ww2HT58OKhYp9MZhawAAJ3FBRdcEOsUAACd2Pbt27Vq1Srt3r1bhw8f1mOPPaaxY8cGXjfGaNmyZVq7dq0qKyt15pln6p577lGfPn06dN2LL764g5kDADobCq0JIDU1VbW1tdqwYYMqKipajMvOztbEiRMptAIAAABIGtXV1crPz9fkyZM1e/bsE15/6qmntGbNGhUVFal379565JFHNHPmTG3atImnMQAAUUWhNYFUVFToyJEjsU4DAAAAAKJm1KhRGjVqVLOvGWP0pz/9STfccENgluuSJUs0YsQIbdmyRRMmTGjXtYwxMsbEbVx7z3ns13DleOx5m/u5cLW58bWGhoZmvya6ZGuPlHxtSrb2SMnXpmi2x2azBRVHoTVEbrdbfr9fVquVGaQAgKRWXl4uY4wsFotOPvnkWKcTNqx/DgCJb//+/Tp8+LBGjBgROOZyuXTGGWdox44d7S60VldXy+12S5K+++67wO98Xbt2lXT0aUO/3y+PxxOIa06440I5Z3V1tSSpqqoqbDlWVlaqvr5eklRZWSm73d5sXDja3NDQoOrqau3bt08+ny9wfNeuXS3+TCJKtvZIydemZGuPlHxtikZ7hg0bFlQchdYQrV69WlVVVXK5XM0+vgIAQLJYtGiRysvL1aVLF61ZsybW6YSFw+GQ1WpVeXl5ULHp6emRTwoA0G6N+1jk5OQ0OZ6Tk6PS0tJ2ny8jI0NWq1WSdP3116u0tFS5ubl64YUXJEmZmZmyWq2Bry0Jd1wo58zIyJDb7ZbL5Wr2w8VQcvT7/YHialZWVpNCa7jbnJ6eroyMDPXv31/S0cLrrl27NGjQoKBnlsWzZGuPlHxtSrb2SMnXpnhsD4VWAADi2IoVK/Tmm29q3759SktL09ChQ3Xrrbfq9NNPD8R4vV4VFRVp06ZN8vl8Kiws1Pz585WbmxvDzONbSkqKfD6fiouLW51N43Q6VVhYSKEVADoJi8XSbFHy+GMtxQV7vlDj2nvOYOLbm2Nb5w1XmxtfO754YrPZ4qagEg7J1h4p+dqUbO2Rkq9N8dSe1j8yAwAAMbVt2zZdccUVevnll/XMM8+ovr5eM2fODDwOKB2dcfqPf/xDDz/8sNasWaNDhw7xtEWQ3G63qqqqWvyvrcc4AQCx1b17d0lSWVlZk+NlZWV84AgAiDpmtAIAEMdWrVrV5PuioiINHz5ce/bs0dlnn62qqiqtX79eS5cu1fDhwyUdLbyOHz9eO3fu1JAhQ9p1vWA2zGj8GswGFtGMO/Z4uK/b0gL7ybahQDTRd6Gh30JH34WmoaEhbmYJNad3797q3r27iouL1a9fP0lHP0T78MMPNW3atBhnBwDobCi0AgCQQBo3tMjOzpYk7d69W3V1dU02Aenbt6969erV7kKr2+1WZWXlCcePLUp6PJ7ABhvNxTbKysqKelxDQ4Pq6+tljFFNTU1YrmuxWFRdXa2vv/66yUYcx0u2DQWiib4LDf0WOvqu/YLdACRSPB6Pvvrqq8D3+/fv10cffaTs7Gz16tVLM2bM0BNPPKHTTjtNvXv31iOPPKIePXpo7NixMcwakZCamhrrFACgVRRaAQBIEH6/X4sWLdKZZ56pvLw8SVJpaalSUlKUlZXVJDYnJyewQUiwnE5nszO9jl2L7dgNNlqbFRaLuIaGBtntdlksljbXVA32uk6nUxkZGTrppJNavGa8LcCfKOi70NBvoaPvQhMPM4B3796tGTNmBL5fvHixJGnSpEkqKirStddeq5qaGt19992qrKzUsGHDtHLlSjkcjliljDCw2+2yWq3yeDyBYz179lRtbe0JsSkpKRRhAcQFCq0AACSIBQsW6NNPP9Xzzz8fsWu0tXlFezbWiHbcscfDfd22ijLxtAB/oqHvQkO/hY6+SzznnnuuPvnkkxZft1gsmjNnjubMmRPFrBBpNptN9fX1KikpkdfrlTFGbrdbTqezydjtcDhUUFBAoRVAXKDQCgBAAli4cKG2bt2qP//5z+rZs2fgeG5ururq6lRZWdlkVmtZWVlggxAAAIBE5fV6VVNTE1jCyGaztfnBMADEijXWCQAAgJYZY7Rw4UJt3rxZzz77rE499dQmrw8cOFApKSkqLi4OHNu3b5++/fbbdm+EBQAAAAAIHTNaAQCIYwsWLNCGDRv0+OOPKzMzM7DuqsvlUlpamlwulyZPnqyioiJlZ2fL6XTqvvvu09ChQym0hklbs2Z4VBEAAACARKE1ZNOmTZPf75fVyqRgAEDkvPDCC5KkK6+8ssnxxYsX6/LLL5ckzZs3T1arVTfddJN8Pp8KCws1f/78sOXw61//utOOeQ6HQ1arVeXl5S3G5OTkqKqqSg6Ho81NuAAAieP3v/+9GhoaWNM3zjW3aVZL2DQLQKQlVKH1ySef1IMPPqgZM2bozjvvlHR0vZaioiJt2rSpyS+Xubm5Ec0lJycnoucHAEBSq5t/NHI4HJo/f35Yi6vHOnZN2M4mJSVFPp9PxcXFcrvdJ7zeuDFHz549NXLkSAqtAJBEjl+uB/Hp+E2zWsKmWQCiIWEKrf/+97/14osvKj8/v8nxRYsW6a233tLDDz8sl8ule++9V7Nnz9aLL74Yo0wBAECycbvdqqqqOuG4MUaVlZVyOp0xyAoAADRq3DQLAGIpIQqtHo9Ht912m+677z498cQTgeNVVVVav369li5dquHDh0s6WngdP368du7c2e616YwxMsbENK6l/w/mfMYYWSwWNTQ0tHnN4zX+TCg/m0zoB/qgEf1AHzTikUEAAAAAQDASotC6cOFCjRo1SiNGjGhSaN29e7fq6uo0YsSIwLG+ffuqV69eIRVaPR6PKioqWnzd7XbL7/fL4/Fo+/btqq+vl91uV15eXotxwZ6vMc7v96u+vl6SVFFRIavVGvT5srOzJUnffPNNmwXe1NRUHTp0KHCtRrt27Wr15zoL+oE+aEQ/0AeSNGzYsFinEFPvv/++fD6fUlNTNXHixFinAwBAVPz973+X1+uVw+HQj3/841inAwBIAHFfaN24caP27t2rdevWnfBaaWmpUlJSlJWV1eR4Tk5OYFfm9sjMzAwUK5vjdDpltVqVmZmpbdu2qaqqSi6XS2effXaLccGerzHO7/fr4MGDko4WTq1Wa9Dny8nJUV1dnd544402C7KTJk3SwIEDA8caGhq0a9cuDRo0qFPP3KIf6ING9AN90Kizz+iVpPXr16u8vFxdunSh0AoA6DSeeuoplZaWKjc3l0IrACAocV1o/e9//6v7779fTz/9tBwOR8SvZ7FYZLFYgopr7ftQztcY19L/t+d8lZWV+u6779rMv7nCic1m69QFlUb0A33QiH6gDwAAAAAACEZcF1r37NmjsrIyXX755YFjDQ0N2r59u5577jmtWrVKdXV1qqysbDKrtaysTN27d49FygAAAAAAAAA6obgutJ533nl67bXXmhy74447dPrpp+vaa6/VySefrJSUFBUXF2vcuHGSpH379unbb79t9/qsAAAAHRHMUycAAAAAkldcF1qdTucJG01lZGSoS5cugeOTJ09WUVGRsrOz5XQ6dd9992no0KEUWgEAQNQ4HA5ZrVaVl5cHFZuenh75pAAAQIDdbpfVapXH42kzNiUlRampqVHICkCyietCazDmzZsnq9Wqm266ST6fT4WFhZo/f36s0wIAAJ1ISkqKfD6fiouL5Xa7W4xzOp0qLCyk0AoAQJTZbDbV19erpKREXq+3xTiHw6GCggIKrQBCknCF1jVr1jT53uFwaP78+RRXAQBAzLndblVVVcU6DQAA0AKv16uamppYpwEgSVljnQAAAAAAAAAAJDoKrQAAAAAAAADQQQm3dEC8yMzMbPIVAIBklZ2d3eQrAACdQbdu3Zp8BQCgLRRaQ3T11VfHOgUAAKLizjvvjHUKAABE3eOPPx7rFAAACYZCaydlsVhOOMauigAAAACAzsxut8tqtcrj8bQZm5KSwu/RAJqg0NoJpaeny2az6fDhw02OZ2Vl6ciRIyfEOp3OaKYHAAAAAEBM2Gw21dfXq6SkRF6vt8U4h8OhgoICCq0AmqDQ2gmlpqaqtrZWGzZsUEVFhSTJGKOqqiq5XK7AbNfs7GxNnDiRQisAAAAAoFPxer2qqamJdRoAEgyF1hC9/vrrqq2tVVpamn7605/GOp2QVFRUBGawGmNUUVGhurq6ZpcVAAB0XmvWrJHH41FmZqZ++9vfxjqdhMc4CwCJ4aGHHgpMRrnllltinQ7iDEsMAGgOhdYQff7554FBFwCAZLZr1y6Vl5erS5cusU4l4TkcDlmtVpWXlwcVm56eHvmkAADNev/991VaWqrc3NxYp4I4xBIDAJpDoRUAACBKUlJS5PP5VFxcLLfb3WKc0+lUYWEhhVYAAOIcSwwAOBaFVgAAgChzu92qqqqKdRoAAAAAwsga6wQAAAAAAAAAINFRaAUAAAAAAACADqLQCgAAAAAAAAAdRKEVAAAAAAAAADqIQisAAAAAAECUpaamxjoFAGFmj3UCiG8WiyXWKQAA0CkxBgMAkPjsdrusVqs8Hs8Jr/Xs2VO1tbWB71NSUii+AgmOQmuI+vfvr9raWqWlpcU6lYhJT0+XzWbT4cOHg4p1Op1RyAoAEG3nnHOOqqurlZGREetUOg2HwyGr1ary8vKgYtPT0yOfFAB0MqNHj5bb7eb3HHSIzWZTfX29SkpK5PV6A8eNMYH3l8VikcPhUEFBAYVWIMFRaA3RmDFjYp1CxKWmpqq2tlYbNmxQRUVFi3HZ2dmaOHEi/wABgCQ1ZcqUWKfQ6aSkpMjn86m4uFhut7vFOKfTqcLCQgqtABAB119/faxTQBLxer2qqakJfG+Mkcfjkc1m4ykWIIlQaEWbKioqdOTIkVinAQBAp+N2u1VVVRXrNAAAAAAEgc2wAAAAAAAAAKCDKLQCAAAAAAAAQAexdECIVqxYEVi4mrV7AADJ7K677lJFRYWys7O1cuXKWKcDAEBUXH311SorK1NOTo6eeeaZWKcDAEgAFFpDVFdXJ5/Pp7q6ulinAgBARHm9XtXW1iotLS3WqaAZbKABANLy5cv16KOPNjn2/e9/X2+88UbI56ypqVF1dbUyMjI6mh4AoJOg0AoAAJCgHA6HrFarysvLg4pNT0+PfFIAECM//OEPm8w8tdlsMcwGaB+73S6r1SqPxxNUfEpKilJTUyOcFYD2otAKAECc2759u1atWqXdu3fr8OHDeuyxxzR27NjA68YYLVu2TGvXrlVlZaXOPPNM3XPPPerTp0/skkZUpKSkyOfzqbi4WG63u8U4p9OpwsJCCq0AkprNZlP37t07dA5jjIwxzR4PJi7Y84Ua195zHvs1XDkee96W+ioSfdNWe2L1ZxJq3PHtsdlsqq+vV0lJiWpra1s9l9PpVF5eXlBFWbvdLrs9OqWfhoaGJl8TXbK1R0q+NkWzPcF+eEehFWHBY4sAEDnV1dXKz8/X5MmTNXv27BNef+qpp7RmzRoVFRWpd+/eeuSRRzRz5kxt2rRJDocjBhkj2txut6qqqmKdBgDE1JdffqnCwkI5HA4NGTJEv/nNb9SrV692naO6ujrwwZXf7w98rayslCSlpqbK7/fL4/G0+gFXuONCOWd1dbUktTg+hJJjZWWl6uvrJUmVlZVNCnjR6pvj2xOrP5NwxTW2pzGurKyszfdCQ0ODfD6f/v3vfwf+nJuTnp6ufv366cCBA/L5fK2eM5x27doVtWtFQ7K1R0q+NkWjPcOGDQsqjkIrOiw9PV02m02HDx8OKtbpdEYhKwBIHqNGjdKoUaOafc0Yoz/96U+64YYbArNclyxZohEjRmjLli2aMGFCNFMFACAmBg8erMWLF+v73/9+4OmPK664Qq+99lq7fv/IyMiQ1WqVpCZfs7KyJEmZmZmyWq2Bry0Jd1wo58zIyJDb7ZbL5Wp2YkwoOfr9/kBxNSsrq0mhNdJ9Y4xRVVXVCe2J1Z9JR+OOb08o7wWr1drqLDubzaaMjAz179+/1fOFS0NDg3bt2qVBgwYlxdIdydYeKfnaFI/todCKDktNTVVtba02bNigioqKFuOys7M1ceJECq0AEEb79+/X4cOHNWLEiMAxl8ulM844Qzt27Gh3oTWYxwsbv7YWG4u44x/Hi2Z+sbpue+IsFktcPSaWbI+uRQv9Fjr6LjQNDQ1x88tra479QLKgoEBnnHGGRo8erddff11Tp04N+jwWi6XZouTxx1qKC/Z8oca195zBxLc3x7bOG+m+idV1IxUXbPtCuXbja9H+O2yz2RLivhGsZGuPlHxtiqf2UGhF2FRUVOjIkSOxTgMAOpXGpwlycnKaHM/JyVFpaWm7zuV2uwOPRh7r2GKex+MJPI7YXGyjrKysqMc1NDSovr5exhjV1NRENb947hfp6BMlxhgdPnw48ChsS2w2mw4cOBB4NDTSku3RtWih30JH37VfsI9LxpOsrCz16dNHX331VaxTAQB0InFdaF2xYoXefPNN7du3T2lpaRo6dKhuvfVWnX766YEYr9eroqIibdq0ST6fT4WFhZo/f75yc3NjmDkAAInH6XQ2O9Pr2Jkrxz6O2NqssFjENTQ0yG63y2KxtLnpUzivW1lZGdf9IkldunRRQ0ODtm/f3uamWSNHjtTAgQNbjAmXeHzUKxHQb6Gj70KTqDOAPR6Pvv766w5vjgUAQHvEdaF127ZtuuKKKzRo0CA1NDToD3/4g2bOnKmNGzcqIyNDkrRo0SK99dZbevjhh+VyuXTvvfdq9uzZevHFF2OcPQAAkdf4C2RZWZl69OgROF5WVqaCgoJ2n6+tR9Xa8xhitOPa89hduK57/OP68dgvx8a1tWFHLB4xjKdHvRIJ/RY6+i45PfDAAxo9erR69eqlQ4cOafny5bJarbr44otjnRoQM3a7XVarVR6Pp83YlJQUpaamRiErILnFdaF11apVTb4vKirS8OHDtWfPHp199tmqqqrS+vXrtXTpUg0fPlzS0cLr+PHjtXPnTg0ZMiRiuY0bN0719fVNFv8GACDaevfure7du6u4uFj9+vWTdHQJgA8//FDTpk0LyzWmT58un8/HP74BAHHrwIED+vWvf63y8nJ169ZNw4YN08svv6xu3bqFfM6bb75ZXq9XDocjjJkC0WOz2VRfX6+SkhJ5vd4W4xwOhwoKCvi3HhAGCVUlrKqqknR0UyVJ2r17t+rq6ppsANK3b1/16tUrpEJreza6+MEPftDk+46er7nNLI7/+XBtxNHSdY/92tHztfS6FN+PH7FJAn3QiH6gDxrFwyYgHo+nyRpz+/fv10cffaTs7Gz16tVLM2bM0BNPPKHTTjtNvXv31iOPPKIePXpo7NixYbn+4MGDw3IeAAAi5aGHHgr7Oc8777ywnxOIBa/Xq5qamlinAXQKCVNo9fv9WrRokc4880zl5eVJkkpLS5WSkqKsrKwmsTk5OYHNQdrD4/GooqKixdfdbrf8fn9E4/x+f2DziYqKClmt1qhct9GxG2mE+7opKSmqra3VZ599Jp/P12Kc1LQfYoFNEuiDRvQDfSDFfhOQ3bt3a8aMGYHvFy9eLEmaNGmSioqKdO2116qmpkZ33323KisrNWzYMK1cuZIZOAhJsDsdAwAAAGgqYQqtCxYs0Keffqrnn38+YtfIzMwMzJZtjtPplNVqjWic3+/XwYMHJR2duWu1WqNyXWOMKisrlZWVFfgFK9zX7dGjh5xOp9LS0lqMaZSWlhZYhzea2CSBPmhEP9AHjeJhRu+5556rTz75pMXXLRaL5syZozlz5kQxKyQjh8Mhq9Wq8vLyoOPb2ngMAAAA6CwSotC6cOFCbd26VX/+85/Vs2fPwPHc3FzV1dUFCoSNysrKQtpdsq2NJI6NO3DgQOBx0pNPPrnD52tuM4vjfz6U87U3LthjoVzX4XCotrZWGzZsaHXma3Z2tiZOnCiXy9XmNSOFTRLog0b0A30A6csvvwysS97SmIfkkJKSIp/Pp+Li4lY3zZKOftBaWFhIoRVA0iopKQmMf41PVQJoHeu8orOL60KrMUb33nuvNm/erDVr1ujUU09t8vrAgQOVkpKi4uJijRs3TpK0b98+ffvttxHdCEuS1q9fr6qqKrlcLs2ePTui10o2FRUVOnLkSKzTAAAE6bHHHlN5ebm6dOnCenWdhNvtDqyNDwCd1d13363S0lLl5ubqxRdfjHU6QFzw+Xyqq6tr8fWePXuqtrZWKSkpFF3RKcV1oXXBggXasGGDHn/8cWVmZgbWXXW5XEpLS5PL5dLkyZNVVFSk7OxsOZ1O3XfffRo6dGjEC60AAAAAAACdSV1dnT7++GN5vd4TXjPGyO12Kzc3VwUFBRRa0SnFdaH1hRdekCRdeeWVTY4vXrxYl19+uSRp3rx5slqtuummm+Tz+VRYWKj58+dHPVcAAAAAAIBk5/V6VVNTc8JxY4w8Ho+cTmcMsgLiQ1wXWlvb+KORw+HQ/PnzKa4CAAAAAAAAiJm4LrSi8wpm8y0AABBbjNcAACQ+u90uq9Uqj8fTapzFYpExJkpZAYmJQiviTnp6umw2W2BN3mDieTQBAIDocjgcslqtKi8vDyo2PT098kkBAIB2s9lsqq+vV0lJSbNrrzZyuVzq06dP9BIDEhCFVsSd1NRU1dbWasOGDaqoqGg1Njs7WxMnTqTQCgBAlKWkpMjn86m4uFhut7vFOKfTqcLCQgqtAADEuZbWXm3kcDiimA2QmCi0Im5VVFToyJEjsU4DAAC0wu12q6qqqtWYlpYYYDdiAACST7BLEUhHP7jl3wNIJhRaAQAAEDGtLTGQk5PTpEjLEgMAACQ+u90e1FIEDodDBQUFFFqRVCi0IuGxEQcAAPGrpSUGjDFyu91yOp2yWCwsMQAAQJJpaykCIBlRaA3RtddeG+sUoPZtnMWmWQAQmoULF8oYwwdb6JDjlxgwxqiyspL3FoC49fTTT3OPAgC0C4XWELEIdHwIduMsNs0CgNClpaXFOgUAAKIuIyMj1ikAABIMhVYkBTbOAgAg8TFrDAAAAImMQisAAABirrVNs5qLZS1XAAASm91ul9VqlcfjaTM2JSWFTbOQECi0hmjbtm3yer1yOBw655xzYp0OghDsLBm7nb8WAHCszZs3q6amRunp6ZoxY0as00GSamnTrOOxaRaAaFm3bp08Ho8yMzM1ZcqUWKcDJB2bzab6+nqVlJTI6/W2GJeZmam8vLygCrI2m00NDQ1txlG4RaRQUQrRtm3bVFVVJZfLRaE1AbRn06wePXpEISMASBybN29WeXm5unTpQqEVEXf8plnNYYkBANGwbt06lZaWKjc3l0IrEEFer1c1NTUtvu5wOIIqyLpcLvXp06fNOIfDoYKCAgqtiAgKregUgt00KysrS+PGjYtiZgAAoD1YYgAAgM4pmIJsMHFAJFFoRafS1qZZxpgoZgMAANqLJQYAAAAQryi0AsexWq2xTgEAALQhmCUGAAAAOoI9XNBevGOAY6Snpys9Pb3VWa/HxjqdzihkBQAAQsFargAA4Hh2u11WqzWozbVOOeWUKGSEZEKhFTiGw+GQ1+vVxo0bVVlZ2WJcdna2Jk6cSKEVAIA4xVquAACgOTabLajNtRwOh773ve9FMTMkAwqtQDMqKir03XfftRrDLBkAAOJXe9ZyHTlyJIVWAAA6mbY2zTLGBP17v8/nU11dXZtxKSkpSk1NDTpHJB4KrUAI0tPTZbPZdPjw4aBimfkKAEBstLWWKzNfAQBAc+x2u9LS0lRbW9tqnMVikd/v1yeffNLqDNnMzEzl5eUFtWQBBdnERaEVCEFqaqpqa2u1YcMGVVRUtBiXnZ2tSZMmUWgFACBOMfMVAAA0x263q6GhQZ999lmrBVSXy6U+ffq0OUPW4XAEtWRBewqyEkXZeEOhNUQnnXSSXC6XMjIyYp0KYqiioqLVjbOY+QogGXzve99Tt27duEchqTHzFcDxfvjDH6p79+7q0qVLrFMBEEO1tbWtzmp1OBztOl+4CrKNsQUFBRRa4wiF1hBNnTo11ikgATDzFUAymD17dqxTAGIu2Jmv3bp10/DhwynIAkng3nvvjXUKADqxtgqyiE8UWoEoYOYrAADJoa2Zr06nk6UIAAAAOikKrUAcYOYrAADJhaUIAABAPGKZgcii0ArEEWa+AgDQOXRkEy5+QQIAANLRDbusVmtQG2fZbDY1NDSoZ8+era45y+ZaHUOhNURr165VdXW1MjIyWK8VUcPMVwCx8Oijj8rtdsvpdOr++++PdTpAUgll5mtOTs4JP2OxWGS321VXV9fmNZkhCwTnrrvuUnl5ubp06cJ6rQDiks1mC2rjLJfLpT59+qikpESlpaVyOp2yWCwnxGVmZiovL69dhdu2dLbCLYXWEB08eFBVVVVyuVyxTgWdUKRnvnammyCAtn311VeBXzQBRNfxM1+NMYEPPo79BalHjx4644wz2KwLCKNPP/1UpaWlys3NjXUqANCqtjbOcjgckqTa2lp5PB7ZbLZmC60Oh6PdhdvW4hwOhwoKCjpVjYFCK5CEgp35etJJJ+niiy8+oSCblZV1QiGXpQgAAIidxpmvxhhVVlbKGNPkF6TGMTqcm3UVFhZSaAUAoBMKtnDbVlwoSxu05fgZsvFWxKXQCiSxtma+Zmdnn1CQNcYEZms3/gLXUkG2ORRkAQCIf20VZCU1O9MFAAAgWKEsbdBaXHNLG7S05mysliyg0AqgSUHWGKOKigrV1dUFfsFqriDbHAqyAAAkh+bWhm1JsOvDhjuuMU9m3QIAEN/CNUP2+KUNWlpSKRJrzWZmZrYZI1FoBdAOocyQbU6wBVmLxRJYmy4Y4S7e2u3cIgEAndPxa8O2Jtj1YcMd1971ZlNTU+Pu8UIAANB+jQVZY0yza85GYq3ZYcOGBZVb0lQRnnvuOa1atUqHDx9WQUGB7rrrLg0ePDjWaQGdUrgKsr1799aoUaPajJMiU7zt2bNnmzFAPGEsBBBuwSwx0J71YcMdF0wxuLEg6/V6lZOT0+I5mUmbHBgLAQCNwjWTtj2SotC6adMmLV68WAsWLNAZZ5yhZ599VjNnztQbb7yhnJycWKcHoAXBFGSDiWuMDWfxtkePHho/fnyb1w22cNueAm88LavAzJ/EwVgIoLMKtiD77rvv6sCBAyc8Xtgo3DNpY7WkQmcuGDMWAgBiLSkKrc8884x+9rOfafLkyZKkBQsWaOvWrVq/fr2uu+66GGcHIJrCVbzNzs6W1+vVxo0bVVlZ2WJcsIXbYOPCPTO3o3FZWVlN+inZC8uJjLEQAFrndrtVUVEhY0yzhdZwz6SN1ZIKkVh6oUuXLm3GxAPGQgBArCV8odXn82nPnj26/vrrA8esVqtGjBihHTt2BHUOY4yktv8BkZWVJb/fry5dusjpdMrv98vpdCo3N7fFOKvVGtT5GuMaGhoCC+zm5OTIZrN16HzBxhljlJ6erszMzMA/PKNx3Y7ERfLaXbt2lc1mi/p14yGO90LTOKvV2mqcxWKR3++XxWIJS1xqaqqqq6v1zjvvqLq6usW47t27a8iQIRGNM8aopqZG6enpgfdCuK/btWtXFRYWtrlIeXsKt+EuBhtj1L17d1mt1rjdgbujY2HjONhSwdvpdKqurk5Op1Pp6emB8a+1/ohFXH19vdLS0mS32+V0OpWSkhKV69psNmVkZMRtv0QiLlzntNlsgfddvLc5nuKO7bdY5xfLa7c3zuVyqWvXri3e69p7Pkmtxhlj4jrOZrOptrZWu3btana35kZpaWkaNWpUXI+DUvjGwsbHSKWjG5/U1NQoMzNTaWlpko6uX9zQ0CCHwxH4meaEOy7UczqdTqWlpTX7ZxfK+Xw+X6CPHA5Hk7E20n3T+N4+vj2x+jPpaNzx7Yn0eyEacY1titf8Qonz+/1N7gvxlF+o5wz3fSGWcdG6LzgcDjU0NAQ1FlpMW39qce7gwYO64IIL9OKLL2ro0KGB40uWLNH27du1du3aNs/h8/m0a9euSKYJAEhwQ4YMafUDmFjq6FjIOAgAaEs8j4MSYyEAIPKCGQsTfkZrONjtdg0aNCjuP6UFAMROW7OqExnjIACgLck8DkqMhQCAtgUzFiZ8obXxEe+ysrImx8vKyk54pL8lVquVDV8AAAmro2Mh4yAAINExFgIA4kHCfyyZmpqqAQMGqLi4OHDM7/eruLi4ySMjAAAkK8ZCAEBnx1gIAIgHCT+jVZKuvvpq3X777Ro4cKAGDx6sZ599VjU1Nbr88stjnRoAAFHBWAgA6OwYCwEAsZYUhdbx48fryJEjWrZsmQ4fPqx+/fpp5cqVQS8dAABAomMsBAB0doyFAIBYsxhjTKyTAAAAAAAAAIBElvBrtAIAAAAAAABArFFoBQAAAAAAAIAOotAKAAAAAAAAAB1EoRUAAAAAAAAAOigpC63PPfecxowZo0GDBmnq1Kn697//3Wr866+/rosuukiDBg3SJZdcorfeeqvJ68YYPfLIIyosLNTgwYN11VVX6YsvvohgC8Ij3P3w5ptv6pprrtG5556r/Px8ffTRR5FMPyzC2Qd1dXX6/e9/r0suuURDhgxRYWGhfvvb3+rgwYORbkaHhfu9sHz5cl100UUaMmSIzj77bF111VX68MMPI9mEDgt3Hxzr7rvvVn5+vlavXh3mrMMv3P0wd+5c5efnN/lv5syZkWxCh0XivfD5559r1qxZGjZsmIYMGaLJkyfr22+/jVQTgsJYGDrGjtBwnw1dZ7kvhVu4+83j8WjhwoW64IILNHjwYI0fP14vvPBCJJsQM+3pu08//VS/+tWvNGbMmFb/Hrb3zyMakm0sTMbxKdnGjmS7nyfjfTbZ7n/hbs+KFSs0efJkDR06VMOHD9f/+3//T/v27YtgC04UiT+jRk8++aTy8/N1//33hznrY5gks3HjRjNgwACzbt068+mnn5rf/e535qyzzjKlpaXNxn/wwQemX79+5qmnnjKfffaZeeihh8yAAQPMJ598EohZsWKFGTZsmNm8ebP56KOPzKxZs8yYMWNMbW1ttJrVbpHoh7/85S9m+fLl5uWXXzZ5eXlm79690WpOSMLdB5WVleaqq64yGzduNJ9//rnZsWOHmTJlipk0aVI0m9VukXgv/O1vfzPvvPOO+eqrr0xJSYmZN2+eOfPMM01ZWVm0mtUukeiDRm+++aa59NJLTWFhoXnmmWci3JKOiUQ/3H777WbmzJnm0KFDgf/Ky8uj1aR2i0QffPnll+acc84xDzzwgNmzZ4/58ssvzZYtW1o8ZzQwFoaOsSM03GdD11nuS+EWiX773e9+Z8aOHWvee+898/XXX5sXX3zR9OvXz2zZsiVazYqK9vbdhx9+aIqKisyGDRvM+eef3+zfw/aeMxqSbSxMxvEp2caOZLufJ+N9Ntnuf5FozzXXXGPWr19vSkpKzEcffWSuvfZa86Mf/ch4PJ4It+aoSLTp2NjRo0ebSy65xNx3330RaoExSVdonTJlilmwYEHg+4aGBlNYWGhWrFjRbPycOXPMdddd1+TY1KlTzV133WWMMcbv95vzzz/frFy5MvB6ZWWlGThwoNmwYUMEWhAe4e6HY3399dcJUWiNZB80+vDDD01eXp755ptvwpN0BESjH6qqqkxeXp559913w5N0mEWqDw4cOGBGjhxpSkpKzOjRo+O+ABCJfrj99tvNDTfcEJmEIyASfXDzzTebW2+9NTIJh4ixMHSMHaHhPhu6znJfCrdI9NuECRPMo48+2iRm0qRJ5g9/+EMYM4+99vbdsVr6e9iRc0ZKso2FyTg+JdvYkWz382S8zybb/S8S7TleWVmZycvLM9u2betIqkGLVJvcbre58MILzTvvvGOmT58e0UJrUi0d4PP5tGfPHo0YMSJwzGq1asSIEdqxY0ezP7Nz504NHz68ybHCwkLt3LlTkrR//34dPny4yTldLpfOOOOMFs8Za5Hoh0QTrT5wu92yWCzKysoKS97hFo1+8Pl8eumll+RyuZSfnx+23MMlUn3g9/t12223aebMmfrhD38YkdzDKZLvhW3btmn48OEaN26c5s+fr++++y7s+YdDJPrA7/dr69at6tOnj2bOnKnhw4dr6tSp2rJlS8Ta0RbGwtAxdoSG+2zoOst9Kdwi9Z4bOnSo/vd//1cHDx6UMUbvvfee/vOf/6iwsDAi7YiFUPouFufsqGQbC5NxfEq2sSPZ7ufJeJ9NtvtftK5dVVUlScrOzg7bOVsSyTYtXLhQo0aNanLuSEmqQut3332nhoYG5eTkNDmek5Oj0tLSZn+mtLRUubm5LcYfPnw4cCzYc8ZaJPoh0USjD7xer5YuXaoJEybI6XSGJ/Ewi2Q//OMf/9DQoUM1ePBgrV69Wk8//bS6desW3gaEQaT64KmnnpLdbteMGTPCn3QERKofRo4cqQceeECrV6/Wbbfdpu3bt+vaa69VQ0ND+BvRQZHog7KyMlVXV+upp57SyJEj9fTTT+snP/mJZs+erW3btkWmIW1gLAwdY0douM+GrrPcl8ItUu+5u+66Sz/4wQ90wQUXaODAgfrlL3+p+fPn6+yzzw5/I2IklL6LxTk7KtnGwmQcn5Jt7Ei2+3ky3meT7f4XjWv7/X4tWrRIZ555pvLy8sJyztZEqk0bN27U3r179Zvf/KajKQbFHpWrAEmmrq5Oc+bMkTFGCxYsiHU6MXHuuefq1Vdf1XfffaeXX35ZN998s9auXXvCTTEZ7d69W3/605/0yiuvyGKxxDqdmJowYULg/xs3wxo7dmxglmuy8/v9kqQf//jHuuqqqyRJ/fr107/+9S+9+OKLOuecc2KYHeINY0fwuM+GjvtS6NasWaOdO3fqiSeeUK9evfTPf/5TCxYsUI8ePaIyAwaIlWQZn5Jt7EjG+zn32cSyYMECffrpp3r++edjnUrI/vvf/+r+++/X008/LYfDEZVrJtWM1q5du8pms6msrKzJ8bKyshM+WWmUm5t7QmX82Pju3bsHjgV7zliLRD8kmkj2QV1dnW6++WZ9++23evrpp+N6RlIk+yEjI0OnnXaahgwZokWLFslut2vdunXhbUAYRKIP/vnPf6qsrEyjR49W//791b9/f33zzTd64IEHNGbMmMg0pIOidV849dRT1bVrV3355ZcdTzrMItEHXbt2ld1uV9++fZvE9O3bN2a7ezMWho6xIzTcZ0PXWe5L4RaJfqutrdVDDz2kO+64Q2PGjFFBQYGmT5+u8ePHa9WqVZFpSAyE0nexOGdHJdtYmIzjU7KNHcl2P0/G+2yy3f8ife2FCxdq69atevbZZ9WzZ88Ony8YkWjTnj17VFZWpssvvzxwX9i2bZvWrFmj/v37R+RJzKQqtKampmrAgAEqLi4OHPP7/SouLtbQoUOb/ZkhQ4bovffea3Ls3Xff1ZAhQyRJvXv3Vvfu3Zuc0+1268MPP2zxnLEWiX5INJHqg8Z/iHz55ZdavXq1unbtGpH8wyWa7wW/3y+fz9fhnMMtEn1w2WWX6W9/+5teffXVwH89evTQzJkztXLlyoi1pSOi9V44cOCAysvLA7+MxJNI9EFqaqoGDRqk//znP01ivvjiC51yyinhbUCQGAtDx9gRGu6zoess96Vwi0S/1dfXq66u7oRZcDabTcaY8DYghkLpu1ics6OSbSxMxvEp2caOZLufJ+N9Ntnuf5G6tjFGCxcu1ObNm/Xss8/q1FNPDUe6QYlEm8477zy99tprTe4LAwcO1CWXXKJXX31VNpstXOn//yK2zVaMbNy40QwcONC88sor5rPPPjN33XWXOeuss8zhw4eNMcbcdtttZunSpYH4Dz74wPTv39+sWrXKfPbZZ2bZsmVmwIAB5pNPPgnErFixwpx11llmy5Yt5uOPPzY33HCDGTNmjKmtrY16+4IViX747rvvzN69e83WrVtNXl6e2bhxo9m7d685dOhQ1NsXjHD3gc/nM7NmzTIXXHCB+eijj8yhQ4cC/3m93pi0MRjh7gePx2MefPBBs2PHDrN//36za9cuM3fuXDNw4EBTUlISkza2JRJ/H46XCLthh7sf3G63KSoqMjt27DBff/21effdd82kSZPMhRdeGLd/JyLxXnjzzTfNgAEDzEsvvWS++OILs2bNGtOvXz+zffv2qLevEWNh6Bg7QsN9NnSd5b4UbpHot+nTp5sJEyaY9957z3z11Vdm/fr1ZtCgQea5556Levsiqb195/V6zd69e83evXvN+eefb4qKiszevXvNF198EfQ5YyHZxsJkHJ+SbexItvt5Mt5nk+3+F4n2zJ8/3wwbNsy8//77Te4LNTU1EW9PpNp0vOnTp5v77rsvYm1IukKrMcasWbPG/OhHPzIDBgwwU6ZMMTt37gy8Nn36dHP77bc3id+0aZO58MILzYABA8yECRPM1q1bm7zu9/vNww8/bEaMGGEGDhxofvGLX5h9+/ZFpS0dEe5+WL9+vcnLyzvhv2XLlkWlPaEIZx98/fXXzbY/Ly/PvPfee1FrUyjC2Q+1tbXmxhtvNIWFhWbAgAHm/PPPN7NmzTIffvhh1NoTinD/fTheohQAwtkPNTU15pprrjHnnXeeGTBggBk9erT53e9+F9NfqoIRiffC2rVrzU9+8hMzaNAgc+mll5rNmzdHvB1tYSwMHWNHaLjPhq6z3JfCLdz9dujQITN37lxTWFhoBg0aZMaNG2eefvpp4/f7o9KeaGpP37V0H5s+fXrQ54yVZBsLk3F8SraxI9nu58l4n022+1+429PSfWH9+vUJ26bjRbrQajEmiZ6FAQAAAAAAAIAYSKo1WgEAAAAAAAAgFii0AgAAAAAAAEAHUWgFAAAAAAAAgA6i0AoAAAAAAAAAHUShFQAAAAAAAAA6iEIrAAAAAAAAAHQQhVYAAAAAAAAA6CAKrQAAAAAAAADQQRRagQh7//33lZ+fr8rKyohd48orr9T9998fsfMDABAqxkEAQGfHWAh0HhRagTDYsWOH+vXrp+uuuy7WqQRl//79ys/P10cffdThc82dO1f5+fnKz8/XgAEDNGbMGC1ZskRerzfoc0TjHx4AgMhhHGQcBIDOjrGQsRCQKLQCYbFu3TpNnz5d27dv18GDB2OdTtSNHDlSb7/9trZs2aJ58+bppZde0rJly2KSS11dXUyuCwCdGeMg4yAAdHaMhYyFgEShFegwj8ejTZs2adq0afrRj36kv/zlL83G/etf/9Ill1yiQYMG6Wc/+5lKSkoCr33zzTeaNWuWzj77bA0ZMkQTJkzQW2+9FXh927ZtmjJligYOHKjCwkItXbpU9fX1LeaUn5+vLVu2NDl21lln6ZVXXpEk/fjHP5YkTZw4Ufn5+bryyisDcWvXrtVPf/pTDRo0SBdddJGee+65NvsgNTVV3bt318knn6yxY8dqxIgRevfddwOv+/1+rVixQmPGjNHgwYN16aWX6o033pB09JPUGTNmSJLOPvts5efna+7cuZKkMWPGaPXq1U2uddlll2n58uVN2vr8889r1qxZGjJkiP74xz9q+fLluuyyy/Tqq69qzJgxGjZsmG655Ra53e422wIAaB/GQcZBAOjsGAsZC4FGFFqBDnr99dd1+umn6/TTT9ell16q9evXyxhzQtySJUs0d+5crVu3Tt26ddOsWbMCn7QtXLhQPp9Pf/7zn/Xaa6/p1ltvVUZGhiTp4MGDuu666zRo0CD99a9/1T333KN169bpiSeeCDnntWvXSpJWr16tt99+OzBI/e1vf9MjjzyiW265RZs2bdKvf/1rLVu2rMV/KDSnpKREO3bsUEpKSuDYihUr9Oqrr2rBggXauHGjrrrqKt12223atm2bTj755MD133jjDb399tu6884729WeRx99VD/5yU/02muvafLkyZKkr776Sn//+9/1xz/+UStWrND27dv11FNPteu8AIC2MQ42xTgIAJ0PY2FTjIXozOyxTgBIdOvWrdOll14q6ejjElVVVdq2bZvOPffcJnGzZ8/W+eefL0kqKirSqFGjtHnzZo0fP17ffvutxo0bp/z8fEnSqaeeGvi5559/Xj179tTdd98ti8Wivn376uDBg1q6dKluvPFGWa3t/7ykW7dukqQuXbqoe/fugePLly/X3LlzdeGFFwby+Oyzz/TSSy9p0qRJLZ5v69atGjp0qOrr6+Xz+WS1WnXXXXdJknw+n1asWKFnnnlGQ4cODZz3gw8+0EsvvaRzzjlH2dnZkqScnBxlZWW1uz0XX3xxYDBtZIzR4sWL5XQ6JUmXXnqpiouLdcstt7T7/ACAljEOMg4CQGfHWMhYCDSi0Ap0wL59+7Rr1y499thjkiS73a7x48dr3bp1JwyqQ4YMCfx/ly5d9P3vf1/79u2TJM2YMUP33HOP3n77bY0YMUIXXnihCgoKJEmff/65hg4dKovFEvj5YcOGqbq6WgcOHFCvXr3C0pbq6mp99dVXuvPOOwMDoiTV19fL5XK1+rPnnnuu7rnnHtXU1Gj16tWy2WwaN26cJOnLL79UTU2NrrnmmiY/U1dXp379+oUl94EDB55w7JRTTgkMqJLUo0cPlZWVheV6AICjGAePYhwEgM6LsfAoxkLgKAqtQAesW7dO9fX1GjlyZOCYMUapqam6++672xyMGk2dOlWFhYXaunWr3nnnHT355JO6/fbbm6yT0x4Wi+WER1VaW79HOjqoStK9996rM844o8lrbX1Cmp6ertNOO02StGjRIl122WVau3atpk6dGjjvihUrdNJJJzX5udTU1Dbbcbzm2tH4SM2x7PYTb2/NPb4DAAgd4+BRjIMA0HkxFh7FWAgcRaEVCFF9fb3++te/au7cuYHHPxrdeOON2rBhg6ZNmxY4tnPnzsAnjRUVFfriiy90+umnB14/+eSTNW3aNE2bNk0PPvigXn75ZV155ZXq27ev/ud//kfGmMAg88EHHygzM1M9e/ZsNrdu3brp0KFDge+/+OIL1dTUBL5vXCunoaEhcCw3N1c9evTQ119/HXjsJRRWq1XXX3+9ioqKdMkll6hv375KTU3Vt99+q3POOafZn2kun+ba4Xa7tX///pBzAwCED+Ng8xgHAaDzYCxsHmMhOjMKrUCItm7dqoqKCk2ZMuWETykvvPBCrVu3rsmg+vjjj6tr167KycnRQw89pK5du2rs2LGSpPvvv18XXHCB+vTpo8rKSr3//vvq27evJOnnP/+5nn32Wd1777264oor9J///EfLly/X1Vdf3eKniuedd56ee+45DR06VA0NDVq6dGmThchzcnKUlpam//u//1PPnj3lcDjkcrl000036b777pPL5dLIkSPl8/m0e/duVVZW6uqrrw66by666CItWbJEzz33nGbOnKlrrrlGixcvljFGw4YNU1VVlf71r3/J6XRq0qRJOuWUU2SxWLR161aNGjVKDodDmZmZOu+88/SXv/xFY8aMkcvl0rJly0JafwgAEH6Mgy1jHASAzoGxsGWMheisKLQCIVq3bp1GjBjR7KMg48aN08qVK/Xxxx8Hjv3mN7/R/fffry+++EL9+vXTE088EXhMwu/3a+HChTpw4ICcTqdGjhypO+64Q5J00kkn6cknn9SSJUv08ssvq0uXLpoyZYpuuOGGFnO7/fbbNW/ePF1xxRXq0aOH5s2bpz179gRet9vt+t3vfqfHHntMy5Yt01lnnaU1a9Zo6tSpSktL06pVq7RkyRJlZGQoLy9Pv/jFL9rVN3a7XdOnT9fKlSs1bdo03XzzzerWrZtWrFih/fv3y+VyqX///po1a1agjb/61a/04IMP6o477tDEiRNVVFSk66+/Xvv379f1118vl8ulOXPm8OklAMQJxsGWMQ4CQOfAWNgyxkJ0VhbDAhUAAAAAAAAA0CHMtwYAAAAAAACADqLQCgAAAAAAAAAdRKEVAAAAAAAAADqIQisAAAAAAAAAdBCFVgAAAAAAAADoIAqtAAAAAAAAANBBFFoBAAAAAAAAoIMotAIAAAAAAABAB1FoBQAAAAAAAIAOotAKAAAAAAAAAB1EoRUAAAAAAAAAOuj/A+eOGxXJGkqvAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1400x400 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
+    "\n",
+    "# Use grayscale for book compatibility\n",
+    "horizons = [\n",
+    "    (\"Daily\", daily_abs, \"#404040\"),\n",
+    "    (\"Weekly\", weekly_abs, \"#707070\"),\n",
+    "    (\"Monthly\", monthly_abs, \"#a0a0a0\"),\n",
+    "]\n",
+    "\n",
+    "for ax, (label, data, color) in zip(axes, horizons, strict=False):\n",
+    "    # Use different x-limits to show the actual distribution shape\n",
+    "    if label == \"Daily\":\n",
+    "        xlim = 0.06\n",
+    "    elif label == \"Weekly\":\n",
+    "        xlim = 0.10\n",
+    "    else:\n",
+    "        xlim = 0.15\n",
+    "\n",
+    "    # Histogram\n",
+    "    bins = np.linspace(0, xlim, 40)\n",
+    "    ax.hist(data[data < xlim], bins=bins, density=True, alpha=0.7, color=color, edgecolor=\"white\")\n",
+    "\n",
+    "    # Cost reference line\n",
+    "    ax.axvline(ROUND_TRIP_COST, color=\"black\", linestyle=\"--\", linewidth=2, label=\"Cost: 20 bps\")\n",
+    "\n",
+    "    # Statistics annotation\n",
+    "    median_val = np.median(data)\n",
+    "    frac_above = (data > ROUND_TRIP_COST).mean()\n",
+    "    ax.axvline(median_val, color=\"#404040\", linestyle=\"-\", linewidth=1.5, alpha=0.7)\n",
+    "\n",
+    "    stats_text = f\"Median: {median_val * 100:.2f}%\\n{frac_above:.0%} > cost\"\n",
+    "    ax.text(\n",
+    "        0.95,\n",
+    "        0.95,\n",
+    "        stats_text,\n",
+    "        transform=ax.transAxes,\n",
+    "        ha=\"right\",\n",
+    "        va=\"top\",\n",
+    "        fontsize=10,\n",
+    "        bbox=dict(boxstyle=\"round,pad=0.3\", facecolor=\"white\", alpha=0.8),\n",
+    "    )\n",
+    "\n",
+    "    ax.set_xlabel(\"Absolute Return\")\n",
+    "    ax.set_title(f\"{label} Horizon\")\n",
+    "    ax.set_xlim(0, xlim)\n",
+    "    ax.legend(loc=\"upper right\", fontsize=9)\n",
+    "\n",
+    "axes[0].set_ylabel(\"Density\")\n",
+    "fig.suptitle(\"ETF Return Distributions by Horizon\", fontsize=12, fontweight=\"bold\")\n",
+    "sns.despine()\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c53dd24f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006155,
+     "end_time": "2026-05-15T05:21:03.746920+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.740765+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Interpretation\n",
+    "\n",
+    "The return distributions clearly differ by horizon. Looking at the tables above:\n",
+    "\n",
+    "- **Daily**: Median moves are small relative to costs. A majority of moves exceed\n",
+    "  the 20 bps threshold, but high-turnover strategies operate with thin margins.\n",
+    "- **Weekly**: Moves are larger, providing reasonable headroom over costs.\n",
+    "- **Monthly**: Moves comfortably exceed costs in the vast majority of cases.\n",
+    "\n",
+    "**Connecting costs to the cost model**: The cost exceedance table above spans\n",
+    "10 to 50 bps round-trip. Our stated cost model (5--15 bps per leg, i.e., 10--30\n",
+    "bps round-trip) maps directly to the 10, 20, and 30 bps columns. For large liquid\n",
+    "ETFs (SPY, QQQ) at the low end (10 bps RT), even daily moves exceed costs ~75%\n",
+    "of the time. For smaller thematic ETFs at the high end (30 bps RT), only monthly\n",
+    "moves are comfortably above cost in most observations. The choice of horizon\n",
+    "therefore depends on the *cost tier* of the ETFs you're trading, not just the\n",
+    "horizon in isolation.\n",
+    "\n",
+    "**This analysis guides but does not dictate**: We establish that all three horizons\n",
+    "are feasible. Chapter 7 will test features at each horizon."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e97e073",
+   "metadata": {},
+   "source": [
+    "#### Cost-Regime Choice: per-Share + Tiered Spread\n",
+    "\n",
+    "`setup.yaml::costs.model = per_share_plus_spread` — costs are declared as\n",
+    "a per-share commission plus a per-asset half-spread in dollars per share,\n",
+    "not as a flat bps rate.\n",
+    "\n",
+    "**Commission.** The `per_share = 0.0035` value is IBKR Pro Tiered's top\n",
+    "tier (the rate readers see at the broker when they execute monthly ETF\n",
+    "rotations at retail scale). This is the library default in\n",
+    "`ml4t-backtest` set because we downloaded IBKR Pro pricing for exactly\n",
+    "this purpose — the cost dispatcher has nothing to invent.\n",
+    "\n",
+    "**Spread.** The per-asset half-spread map in\n",
+    "`setup.yaml::costs.asset_spreads` ties each ticker to an industry-\n",
+    "knowledge tier: mega-ETFs (SPY/QQQ/IWM/EFA/EEM/DIA/VTI/VOO) at 0.5¢,\n",
+    "sector XL* funds at 1¢, default 2¢ for thematic/regional/factor ETFs.\n",
+    "This is a *reasoned simplification* — ETF nominal prices do not drift\n",
+    "much over the validation window, so a static map is defensible — but it\n",
+    "is **not** an empirical measurement. We do not have AlgoSeek-grade NBBO\n",
+    "quotes spanning the broad ETF universe; the analogous case study with\n",
+    "measured per-asset spreads is `nasdaq100_microstructure`, which has\n",
+    "AlgoSeek minute-bar NBBO close quotes for its 100-ticker NASDAQ-100\n",
+    "universe. The nasdaq100 measurements are NOT a proxy for liquid-ETF\n",
+    "spreads: they cover different securities under different microstructure.\n",
+    "The tiered ETF map should be read as \"what an institutional trader\n",
+    "knowledgeable about US ETFs would assert as the going rate\" rather than\n",
+    "as a quote-grounded estimate. The cost sensitivity sweep in `16_costs.py`\n",
+    "probes how robust this assumption is across both bps and per-share\n",
+    "grids."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e503a26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005847,
+     "end_time": "2026-05-15T05:21:03.759557+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.753710+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### B.4 Feasibility Ratio\n",
+    "\n",
+    "A simple edge-to-cost ratio confirms that typical signal magnitude\n",
+    "comfortably exceeds transaction costs before proceeding further."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "161c9b4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:03.773168Z",
+     "iopub.status.busy": "2026-05-15T05:21:03.772887Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.778187Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.777523Z"
+    },
+    "papermill": {
+     "duration": 0.013262,
+     "end_time": "2026-05-15T05:21:03.778578+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.765316+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median monthly |return|: 0.0285 (284.6 bps)\n",
+      "Round-trip cost: 0.0020 (20 bps)\n",
+      "Edge-to-cost ratio: 14.2x\n",
+      "Assessment: PROCEED\n"
+     ]
+    }
+   ],
+   "source": [
+    "median_monthly_abs_return = float(np.median(monthly_abs))\n",
+    "feasibility_ratio = median_monthly_abs_return / ROUND_TRIP_COST\n",
+    "print(\n",
+    "    f\"Median monthly |return|: {median_monthly_abs_return:.4f} ({median_monthly_abs_return * 10000:.1f} bps)\"\n",
+    ")\n",
+    "print(f\"Round-trip cost: {ROUND_TRIP_COST:.4f} ({ROUND_TRIP_COST * 10000:.0f} bps)\")\n",
+    "print(f\"Edge-to-cost ratio: {feasibility_ratio:.1f}x\")\n",
+    "print(f\"Assessment: {'PROCEED' if feasibility_ratio > 1.0 else 'KILL -- edge too thin'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc4ef5b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004118,
+     "end_time": "2026-05-15T05:21:03.787253+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.783135+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section C: Design Decisions\n",
+    "\n",
+    "Design decisions are the strategy choices encoded in `setup.yaml` that the\n",
+    "feasibility evidence above supports. They are justified here, not in the YAML."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c984b7c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004759,
+     "end_time": "2026-05-15T05:21:03.795997+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.791238+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### C.1 Decision Cadence\n",
+    "\n",
+    "Monthly month-end is the conventional cadence for cross-asset momentum studies\n",
+    "(Moskowitz, Ooi, and Pedersen 2012; Asness, Moskowitz, and Pedersen 2013), which\n",
+    "makes our results directly comparable to published benchmarks. However, the choice\n",
+    "deserves scrutiny rather than deference.\n",
+    "\n",
+    "A **weekly (5-day) cadence** would multiply effective sample size roughly 4x\n",
+    "(~1,040 weekly vs ~240 monthly decision dates), improving IC estimate stability\n",
+    "per fold. Purging becomes cheaper: a 1-week purge burns 5 trading days vs 21 for\n",
+    "monthly. The cost analysis above confirms that weekly absolute returns comfortably\n",
+    "exceed the 20 bps round-trip threshold for most of the universe.\n",
+    "\n",
+    "The complications are real: turnover increases mechanically (even if signals are\n",
+    "slow-moving, weekly rebalancing amplifies noise-driven rank changes), and coupling\n",
+    "signal horizon with decision cadence requires care---you can evaluate a signal weekly\n",
+    "but still use 4-week forward labels, at the cost of overlapping labels that demand\n",
+    "proper purge/embargo handling.\n",
+    "\n",
+    "We treat cadence as a **first-class parameter**. `setup.yaml` declares the\n",
+    "default monthly cadence (`decision.cadence: monthly_month_end`) and exposes\n",
+    "`fwd_ret_5d` as a weekly-horizon label variant for comparison."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2540f1ba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004728,
+     "end_time": "2026-05-15T05:21:03.805842+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.801114+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### C.2 Kill Conditions\n",
+    "\n",
+    "Kill conditions are falsifiable checkpoints --- if any triggers, the strategy\n",
+    "is abandoned or substantially reworked. Defining them upfront prevents\n",
+    "post-hoc rationalization. The thresholds below are anchored to the feasibility\n",
+    "evidence above (cost-exceedance and edge-to-cost analysis):\n",
+    "\n",
+    "- **KC1 (IC floor)**: IC < 0.01 with t-stat < 2.0 across all lookback horizons\n",
+    "  (3M-12M). Gate: Chapter 8 feature evaluation.\n",
+    "- **KC2 (edge-cost)**: Edge-to-cost ratio < 1.0x after realistic transaction\n",
+    "  costs. Gate: Chapter 7 label evaluation / Chapter 17 backtest. B.4 above\n",
+    "  tests this gate on raw return magnitudes before the model is even trained.\n",
+    "- **KC3 (EW underperformance)**: Equal-weight benchmark posts a higher Sharpe\n",
+    "  and lower max drawdown than the strategy across all test folds. Gate:\n",
+    "  Chapter 17 backtest."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa78dd29",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005838,
+     "end_time": "2026-05-15T05:21:03.818006+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.812168+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### C.3 Mapping Class\n",
+    "\n",
+    "`setup.yaml` declares the simplest credible mapping: **long-only, equal-weight,\n",
+    "top-N** (`mapping.class: long_only_rank_and_rebalance`, `sizing: equal_weight`).\n",
+    "Long-only is appropriate because (a) most ETFs are difficult or expensive to\n",
+    "short, (b) the target audience for this case study is long-only portfolio\n",
+    "construction, and (c) it isolates the ranking signal from short-side\n",
+    "complexity. Equal-weight is the minimal-assumption sizing rule---it avoids\n",
+    "introducing a secondary optimization (risk-parity, inverse-vol) that would\n",
+    "confound evaluation of the ranking signal itself. Chapter 18 explores\n",
+    "alternative weighting schemes via the `backtest.sweep.allocators` grid in\n",
+    "`setup.yaml`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1e96af3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010044,
+     "end_time": "2026-05-15T05:21:03.833873+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.823829+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section D: Walk-Forward Structure (Section 6.5)\n",
+    "\n",
+    "We verify that the data supports the walk-forward design declared in\n",
+    "`setup.yaml::evaluation` (`n_splits`, `train_size`, `val_size`, `holdout_start`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34308bc8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00929,
+     "end_time": "2026-05-15T05:21:03.850756+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.841466+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### D.1 Effective Sample Size and Data Coverage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "e814d528",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:03.869030Z",
+     "iopub.status.busy": "2026-05-15T05:21:03.868429Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.876971Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.875625Z"
+    },
+    "papermill": {
+     "duration": 0.018432,
+     "end_time": "2026-05-15T05:21:03.878050+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.859618+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data Coverage:\n",
+      "  Period: 2006-01 to 2025-12\n",
+      "  Decision points (months): 240\n",
+      "  Approx years: 20.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_decision_dates = monthly_prices[\"month\"].n_unique()\n",
+    "first_month = monthly_prices[\"month\"].min()\n",
+    "last_month = monthly_prices[\"month\"].max()\n",
+    "n_years = n_decision_dates / 12\n",
+    "\n",
+    "print(\"Data Coverage:\")\n",
+    "print(f\"  Period: {first_month} to {last_month}\")\n",
+    "print(f\"  Decision points (months): {n_decision_dates}\")\n",
+    "print(f\"  Approx years: {n_years:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17896078",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010883,
+     "end_time": "2026-05-15T05:21:03.900362+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.889479+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### D.2 Walk-Forward Fold Demonstration\n",
+    "\n",
+    "`case_studies/utils/cv_window.py` owns the operational splits; this cell\n",
+    "reproduces the fold boundaries from canonical `setup.yaml` parameters to verify\n",
+    "the data supports the declared design. Each fold has:\n",
+    "\n",
+    "- **Train period**: `setup.yaml::evaluation.train_size`\n",
+    "- **Test period**: `setup.yaml::evaluation.val_size`\n",
+    "- **Purge gap**: 1 month between train end and test start (matches the 21D\n",
+    "  buffer for the 1-month primary label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ab8b78c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:03.927601Z",
+     "iopub.status.busy": "2026-05-15T05:21:03.927125Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.952014Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.950867Z"
+    },
+    "papermill": {
+     "duration": 0.041426,
+     "end_time": "2026-05-15T05:21:03.953034+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.911608+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 8 walk-forward folds\n",
+      "Last fold test end: 2023-12-29  |  Holdout start: 2024-01-01\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_splits_declared = int(SETUP[\"evaluation\"][\"n_splits\"])\n",
+    "purge_months = 1  # matches setup.yaml::labels.buffer (21D) at monthly cadence\n",
+    "train_months = 10 * 12  # setup.yaml::evaluation.train_size = 10Y\n",
+    "test_months = 1 * 12  # setup.yaml::evaluation.val_size = 1Y\n",
+    "step_months = 1 * 12  # consecutive, non-overlapping\n",
+    "\n",
+    "# Get sorted list of decision dates (month-ends)\n",
+    "decision_dates = (\n",
+    "    monthly_prices.select(\"timestamp\").unique().sort(\"timestamp\")[\"timestamp\"].to_list()\n",
+    ")\n",
+    "\n",
+    "# Holdout boundary\n",
+    "holdout_start_dt = pl.Series([HOLDOUT_START]).str.to_date(\"%Y-%m-%d\").item()\n",
+    "cv_dates = [d for d in decision_dates if d < holdout_start_dt]\n",
+    "\n",
+    "# Generate splits\n",
+    "splits = []\n",
+    "test_start_idx = train_months\n",
+    "\n",
+    "while test_start_idx + test_months <= len(cv_dates):\n",
+    "    train_start_idx = test_start_idx - train_months\n",
+    "    train_end_idx = test_start_idx - purge_months  # purge gap\n",
+    "    test_end_idx = test_start_idx + test_months\n",
+    "\n",
+    "    split = {\n",
+    "        \"fold\": len(splits) + 1,\n",
+    "        \"train_start\": cv_dates[train_start_idx].strftime(\"%Y-%m-%d\"),\n",
+    "        \"train_end\": cv_dates[train_end_idx - 1].strftime(\"%Y-%m-%d\"),\n",
+    "        \"test_start\": cv_dates[test_start_idx].strftime(\"%Y-%m-%d\"),\n",
+    "        \"test_end\": cv_dates[test_end_idx - 1].strftime(\"%Y-%m-%d\"),\n",
+    "        \"purge_months\": purge_months,\n",
+    "    }\n",
+    "    splits.append(split)\n",
+    "    test_start_idx += step_months\n",
+    "\n",
+    "print(f\"Generated {len(splits)} walk-forward folds\")\n",
+    "\n",
+    "# Sanity check: verify all folds fit within pre-holdout data\n",
+    "assert len(splits) == n_splits_declared, (\n",
+    "    f\"Expected {n_splits_declared} folds (setup.yaml), got {len(splits)}\"\n",
+    ")\n",
+    "last_test_end = splits[-1][\"test_end\"]\n",
+    "print(f\"Last fold test end: {last_test_end}  |  Holdout start: {HOLDOUT_START}\")\n",
+    "assert last_test_end < HOLDOUT_START, (\n",
+    "    f\"Last fold ({last_test_end}) overlaps holdout ({HOLDOUT_START})\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "482c45f7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007004,
+     "end_time": "2026-05-15T05:21:03.968357+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.961353+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "**Walk-forward fold summary:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c40ee76f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:03.985938Z",
+     "iopub.status.busy": "2026-05-15T05:21:03.985567Z",
+     "iopub.status.idle": "2026-05-15T05:21:03.994973Z",
+     "shell.execute_reply": "2026-05-15T05:21:03.994010Z"
+    },
+    "papermill": {
+     "duration": 0.022768,
+     "end_time": "2026-05-15T05:21:03.998159+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:03.975391+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fold</th><th>train_start</th><th>train_end</th><th>test_start</th><th>test_end</th><th>purge_months</th></tr><tr><td>i64</td><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>1</td><td>&quot;2006-01-31&quot;</td><td>&quot;2015-11-30&quot;</td><td>&quot;2016-01-29&quot;</td><td>&quot;2016-12-30&quot;</td><td>1</td></tr><tr><td>2</td><td>&quot;2007-01-31&quot;</td><td>&quot;2016-11-30&quot;</td><td>&quot;2017-01-31&quot;</td><td>&quot;2017-12-29&quot;</td><td>1</td></tr><tr><td>3</td><td>&quot;2008-01-31&quot;</td><td>&quot;2017-11-30&quot;</td><td>&quot;2018-01-31&quot;</td><td>&quot;2018-12-31&quot;</td><td>1</td></tr><tr><td>4</td><td>&quot;2009-01-30&quot;</td><td>&quot;2018-11-30&quot;</td><td>&quot;2019-01-31&quot;</td><td>&quot;2019-12-31&quot;</td><td>1</td></tr><tr><td>5</td><td>&quot;2010-01-29&quot;</td><td>&quot;2019-11-29&quot;</td><td>&quot;2020-01-31&quot;</td><td>&quot;2020-12-31&quot;</td><td>1</td></tr><tr><td>6</td><td>&quot;2011-01-31&quot;</td><td>&quot;2020-11-30&quot;</td><td>&quot;2021-01-29&quot;</td><td>&quot;2021-12-31&quot;</td><td>1</td></tr><tr><td>7</td><td>&quot;2012-01-31&quot;</td><td>&quot;2021-11-30&quot;</td><td>&quot;2022-01-31&quot;</td><td>&quot;2022-12-30&quot;</td><td>1</td></tr><tr><td>8</td><td>&quot;2013-01-31&quot;</td><td>&quot;2022-11-30&quot;</td><td>&quot;2023-01-31&quot;</td><td>&quot;2023-12-29&quot;</td><td>1</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 6)\n",
+       "┌──────┬─────────────┬────────────┬────────────┬────────────┬──────────────┐\n",
+       "│ fold ┆ train_start ┆ train_end  ┆ test_start ┆ test_end   ┆ purge_months │\n",
+       "│ ---  ┆ ---         ┆ ---        ┆ ---        ┆ ---        ┆ ---          │\n",
+       "│ i64  ┆ str         ┆ str        ┆ str        ┆ str        ┆ i64          │\n",
+       "╞══════╪═════════════╪════════════╪════════════╪════════════╪══════════════╡\n",
+       "│ 1    ┆ 2006-01-31  ┆ 2015-11-30 ┆ 2016-01-29 ┆ 2016-12-30 ┆ 1            │\n",
+       "│ 2    ┆ 2007-01-31  ┆ 2016-11-30 ┆ 2017-01-31 ┆ 2017-12-29 ┆ 1            │\n",
+       "│ 3    ┆ 2008-01-31  ┆ 2017-11-30 ┆ 2018-01-31 ┆ 2018-12-31 ┆ 1            │\n",
+       "│ 4    ┆ 2009-01-30  ┆ 2018-11-30 ┆ 2019-01-31 ┆ 2019-12-31 ┆ 1            │\n",
+       "│ 5    ┆ 2010-01-29  ┆ 2019-11-29 ┆ 2020-01-31 ┆ 2020-12-31 ┆ 1            │\n",
+       "│ 6    ┆ 2011-01-31  ┆ 2020-11-30 ┆ 2021-01-29 ┆ 2021-12-31 ┆ 1            │\n",
+       "│ 7    ┆ 2012-01-31  ┆ 2021-11-30 ┆ 2022-01-31 ┆ 2022-12-30 ┆ 1            │\n",
+       "│ 8    ┆ 2013-01-31  ┆ 2022-11-30 ┆ 2023-01-31 ┆ 2023-12-29 ┆ 1            │\n",
+       "└──────┴─────────────┴────────────┴────────────┴────────────┴──────────────┘"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "splits_df = pl.DataFrame(splits)\n",
+    "splits_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2390088c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006329,
+     "end_time": "2026-05-15T05:21:04.014689+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.008360+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "#### Universe Breadth per Fold\n",
+    "\n",
+    "We verify that each fold has adequate cross-sectional breadth by counting\n",
+    "eligible ETFs in each test period. Thin early folds would weaken cross-sectional\n",
+    "signals (quintile sorting requires reasonable N)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "181982ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:04.033390Z",
+     "iopub.status.busy": "2026-05-15T05:21:04.033011Z",
+     "iopub.status.idle": "2026-05-15T05:21:04.044756Z",
+     "shell.execute_reply": "2026-05-15T05:21:04.043129Z"
+    },
+    "papermill": {
+     "duration": 0.023109,
+     "end_time": "2026-05-15T05:21:04.046360+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.023251+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eligible ETFs per fold test period:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fold</th><th>test_year</th><th>n_eligible</th></tr><tr><td>i64</td><td>i64</td><td>i64</td></tr></thead><tbody><tr><td>1</td><td>2016</td><td>88</td></tr><tr><td>2</td><td>2017</td><td>94</td></tr><tr><td>3</td><td>2018</td><td>96</td></tr><tr><td>4</td><td>2019</td><td>96</td></tr><tr><td>5</td><td>2020</td><td>95</td></tr><tr><td>6</td><td>2021</td><td>95</td></tr><tr><td>7</td><td>2022</td><td>95</td></tr><tr><td>8</td><td>2023</td><td>96</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 3)\n",
+       "┌──────┬───────────┬────────────┐\n",
+       "│ fold ┆ test_year ┆ n_eligible │\n",
+       "│ ---  ┆ ---       ┆ ---        │\n",
+       "│ i64  ┆ i64       ┆ i64        │\n",
+       "╞══════╪═══════════╪════════════╡\n",
+       "│ 1    ┆ 2016      ┆ 88         │\n",
+       "│ 2    ┆ 2017      ┆ 94         │\n",
+       "│ 3    ┆ 2018      ┆ 96         │\n",
+       "│ 4    ┆ 2019      ┆ 96         │\n",
+       "│ 5    ┆ 2020      ┆ 95         │\n",
+       "│ 6    ┆ 2021      ┆ 95         │\n",
+       "│ 7    ┆ 2022      ┆ 95         │\n",
+       "│ 8    ┆ 2023      ┆ 96         │\n",
+       "└──────┴───────────┴────────────┘"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fold_breadth = []\n",
+    "for split in splits:\n",
+    "    test_year = int(split[\"test_start\"][:4])\n",
+    "    n_eligible = eligibility_table.filter(pl.col(\"eligible_year\") == test_year).height\n",
+    "    fold_breadth.append(\n",
+    "        {\n",
+    "            \"fold\": split[\"fold\"],\n",
+    "            \"test_year\": test_year,\n",
+    "            \"n_eligible\": n_eligible,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "fold_breadth_df = pl.DataFrame(fold_breadth)\n",
+    "print(\"Eligible ETFs per fold test period:\")\n",
+    "fold_breadth_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b86b4323",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006423,
+     "end_time": "2026-05-15T05:21:04.060498+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.054075+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "All folds have 70+ eligible ETFs, which is sufficient for cross-sectional ranking\n",
+    "and quintile construction. The early folds have fewer ETFs because some symbols\n",
+    "(e.g., ARKK, XLC) had not yet launched---this is the correct point-in-time behavior,\n",
+    "not a data problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f0eb91c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006059,
+     "end_time": "2026-05-15T05:21:04.073641+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.067582+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section E: Eligibility Artifact\n",
+    "\n",
+    "Point-in-time (asset, year) eligibility is the one decision-relevant artifact\n",
+    "this notebook generates (everything else lives in `setup.yaml`). It is keyed by\n",
+    "year because the ADV filter runs annually; downstream labels and features\n",
+    "consume it to enforce point-in-time membership."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e12e83ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:04.091000Z",
+     "iopub.status.busy": "2026-05-15T05:21:04.090631Z",
+     "iopub.status.idle": "2026-05-15T05:21:04.103089Z",
+     "shell.execute_reply": "2026-05-15T05:21:04.101516Z"
+    },
+    "papermill": {
+     "duration": 0.024538,
+     "end_time": "2026-05-15T05:21:04.104529+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.079991+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Written: case_studies/etfs/eligibility.csv (1,670 asset-year pairs)\n"
+     ]
+    }
+   ],
+   "source": [
+    "eligibility_path = CASE_DIR / \"eligibility.csv\"\n",
+    "eligibility_table.select([\"symbol\", \"eligible_year\"]).sort([\"symbol\", \"eligible_year\"]).write_csv(\n",
+    "    eligibility_path\n",
+    ")\n",
+    "print(f\"Written: {eligibility_path} ({len(eligibility_table):,} asset-year pairs)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "892f9629",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006471,
+     "end_time": "2026-05-15T05:21:04.117402+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.110931+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Section F: Findings vs `setup.yaml`\n",
+    "\n",
+    "The canonical strategy declarations live in `config/setup.yaml`. This section\n",
+    "enumerates each declared knob alongside the feasibility evidence above that\n",
+    "motivates it. Setup.yaml is not regenerated here --- it is the hand-curated\n",
+    "source of truth, and this notebook reads it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "53eed81f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:04.137924Z",
+     "iopub.status.busy": "2026-05-15T05:21:04.137135Z",
+     "iopub.status.idle": "2026-05-15T05:21:04.168859Z",
+     "shell.execute_reply": "2026-05-15T05:21:04.166912Z"
+    },
+    "papermill": {
+     "duration": 0.043822,
+     "end_time": "2026-05-15T05:21:04.170463+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.126641+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==============================================================================\n",
+      "Setup.yaml knobs vs feasibility evidence\n",
+      "==============================================================================\n",
+      "\n",
+      "universe.n_assets = 100\n",
+      "  -> point-in-time eligible per fold: min=88, max=96\n",
+      "  -> sufficient for cross-sectional ranking (>=70 per fold)\n",
+      "\n",
+      "decision.cadence = monthly_month_end\n",
+      "  -> median |monthly return| = 2.85%; 94% exceed 20bps RT\n",
+      "\n",
+      "costs.model = per_share_plus_spread\n",
+      "  -> at 20bps RT: edge-to-cost = 14x at monthly horizon\n",
+      "  -> daily moves > 20bps: 77%\n",
+      "  -> weekly moves > 20bps: 89%\n",
+      "\n",
+      "labels.primary = fwd_ret_21d\n",
+      "  -> median |21d return| = 2.85% = 14x a 20bps cost\n",
+      "\n",
+      "labels.variants = ['fwd_ret_5d']\n",
+      "  -> median |weekly return| = 1.30% (89% > 20bps)\n",
+      "\n",
+      "evaluation.n_splits = 8\n",
+      "  -> generated 8 folds; declared count matches\n",
+      "  -> holdout 2024-01-01 to 2025-12-31; last test ends 2023-12-29\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Numbers used in the side-by-side report\n",
+    "median_d_abs_pct = float(np.median(daily_abs) * 100)\n",
+    "median_w_abs_pct = float(np.median(weekly_abs) * 100)\n",
+    "median_m_abs_pct = float(np.median(monthly_abs) * 100)\n",
+    "frac_d_above_20 = float((daily_abs > 0.0020).mean())\n",
+    "frac_w_above_20 = float((weekly_abs > 0.0020).mean())\n",
+    "frac_m_above_20 = float((monthly_abs > 0.0020).mean())\n",
+    "n_eligible_min = int(min(fb[\"n_eligible\"] for fb in fold_breadth))\n",
+    "n_eligible_max = int(max(fb[\"n_eligible\"] for fb in fold_breadth))\n",
+    "n_folds_generated = int(len(splits))\n",
+    "\n",
+    "print(\"=\" * 78)\n",
+    "print(\"Setup.yaml knobs vs feasibility evidence\")\n",
+    "print(\"=\" * 78)\n",
+    "\n",
+    "print()\n",
+    "print(f\"universe.n_assets = {SETUP['universe']['n_assets']}\")\n",
+    "print(f\"  -> point-in-time eligible per fold: min={n_eligible_min}, max={n_eligible_max}\")\n",
+    "print(\"  -> sufficient for cross-sectional ranking (>=70 per fold)\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"decision.cadence = {SETUP['decision']['cadence']}\")\n",
+    "print(\n",
+    "    f\"  -> median |monthly return| = {median_m_abs_pct:.2f}%; \"\n",
+    "    f\"{frac_m_above_20 * 100:.0f}% exceed 20bps RT\"\n",
+    ")\n",
+    "\n",
+    "print()\n",
+    "print(f\"costs.model = {SETUP['costs']['model']}\")\n",
+    "print(f\"  -> at 20bps RT: edge-to-cost = {feasibility_ratio:.0f}x at monthly horizon\")\n",
+    "print(f\"  -> daily moves > 20bps: {frac_d_above_20 * 100:.0f}%\")\n",
+    "print(f\"  -> weekly moves > 20bps: {frac_w_above_20 * 100:.0f}%\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"labels.primary = {SETUP['labels']['primary']}\")\n",
+    "print(\n",
+    "    f\"  -> median |21d return| = {median_m_abs_pct:.2f}% = \"\n",
+    "    f\"{(median_m_abs_pct / 100) / 0.002:.0f}x a 20bps cost\"\n",
+    ")\n",
+    "\n",
+    "print()\n",
+    "print(f\"labels.variants = {SETUP['labels']['variants']}\")\n",
+    "print(\n",
+    "    f\"  -> median |weekly return| = {median_w_abs_pct:.2f}% ({frac_w_above_20 * 100:.0f}% > 20bps)\"\n",
+    ")\n",
+    "\n",
+    "print()\n",
+    "print(f\"evaluation.n_splits = {SETUP['evaluation']['n_splits']}\")\n",
+    "print(f\"  -> generated {n_folds_generated} folds; declared count matches\")\n",
+    "print(\n",
+    "    f\"  -> holdout {SETUP['evaluation']['holdout_start']} \"\n",
+    "    f\"to {SETUP['evaluation']['holdout_end']}; \"\n",
+    "    f\"last test ends {splits[-1]['test_end']}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18f64435",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006493,
+     "end_time": "2026-05-15T05:21:04.185419+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.178926+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Persist Feasibility Findings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "7753284e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:04.198377Z",
+     "iopub.status.busy": "2026-05-15T05:21:04.198166Z",
+     "iopub.status.idle": "2026-05-15T05:21:04.202519Z",
+     "shell.execute_reply": "2026-05-15T05:21:04.202164Z"
+    },
+    "papermill": {
+     "duration": 0.011708,
+     "end_time": "2026-05-15T05:21:04.203024+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.191316+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Written: case_studies/etfs/config/exploration/feasibility_report.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "feasibility_report = {\n",
+    "    \"case_study_id\": \"etfs\",\n",
+    "    \"computed_at_utc\": datetime.now(UTC).isoformat(),\n",
+    "    \"data_period\": {\"start\": START_DATE, \"end\": END_DATE},\n",
+    "    \"universe\": {\n",
+    "        \"n_assets_declared\": int(SETUP[\"universe\"][\"n_assets\"]),\n",
+    "        \"n_eligible_per_fold_min\": n_eligible_min,\n",
+    "        \"n_eligible_per_fold_max\": n_eligible_max,\n",
+    "    },\n",
+    "    \"return_distribution_abs_pct\": {\n",
+    "        \"daily_median\": median_d_abs_pct,\n",
+    "        \"weekly_median\": median_w_abs_pct,\n",
+    "        \"monthly_median\": median_m_abs_pct,\n",
+    "    },\n",
+    "    \"cost_exceedance_at_20bps_pct\": {\n",
+    "        \"daily\": frac_d_above_20 * 100,\n",
+    "        \"weekly\": frac_w_above_20 * 100,\n",
+    "        \"monthly\": frac_m_above_20 * 100,\n",
+    "    },\n",
+    "    \"feasibility_ratio_monthly_at_20bps\": float(feasibility_ratio),\n",
+    "    \"walk_forward\": {\n",
+    "        \"n_folds_generated\": n_folds_generated,\n",
+    "        \"n_splits_declared\": int(SETUP[\"evaluation\"][\"n_splits\"]),\n",
+    "        \"holdout_start\": HOLDOUT_START,\n",
+    "        \"last_test_end\": splits[-1][\"test_end\"],\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "report_path = EXPLORATION_DIR / \"feasibility_report.json\"\n",
+    "with open(report_path, \"w\") as f:\n",
+    "    json.dump(feasibility_report, f, indent=2)\n",
+    "print(f\"Written: {report_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6754dc30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004881,
+     "end_time": "2026-05-15T05:21:04.212085+00:00",
+     "exception": false,
+     "start_time": "2026-05-15T05:21:04.207204+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Key Takeaways\n",
+    "\n",
+    "1. **Universe**: Two-layer bias assessment---universe composition has survivorship\n",
+    "   bias (Layer 1, not fully resolvable, the 100 ETFs were chosen backward-looking);\n",
+    "   within-universe eligibility is point-in-time correct (Layer 2, via $10M ADV\n",
+    "   threshold applied annually with one-year lag). 70+ eligible ETFs per fold.\n",
+    "2. **Cost feasibility**: All three horizons clear the 20bps round-trip threshold,\n",
+    "   but the margin depends on the cost tier---large liquid ETFs (10 bps RT) support\n",
+    "   daily strategies, while smaller thematic ETFs (30 bps RT) require monthly\n",
+    "   holding periods. `setup.yaml` accommodates both via tiered `costs.asset_spreads`.\n",
+    "3. **Cadence**: Monthly month-end as default for literature comparability;\n",
+    "   weekly tested as a variant via `labels.variants: [fwd_ret_5d]`.\n",
+    "4. **Mapping**: Long-only equal-weight top-N as simplest credible baseline;\n",
+    "   alternative allocators sweep in `setup.yaml::backtest.sweep.allocators`\n",
+    "   (explored in Chapter 17--18).\n",
+    "5. **Evaluation**: 8 walk-forward folds with verified holdout separation\n",
+    "   (`evaluation.holdout_start` enforced).\n",
+    "6. **Kill conditions**: KC2 (edge-to-cost > 1.0x) already cleared---feasibility\n",
+    "   ratio at monthly horizon is comfortably above 1.0 on raw return magnitudes.\n",
+    "   KC1 (IC floor) and KC3 (EW underperformance) are tested in later chapters.\n",
+    "\n",
+    "**Known limitations**:\n",
+    "- Layer 1 survivorship bias is documented but not resolved.\n",
+    "- Annual eligibility granularity is coarser than monthly decision cadence.\n",
+    "- The $10M ADV threshold is not inflation-adjusted.\n",
+    "\n",
+    "**Artifacts written**:\n",
+    "- `eligibility.csv`: point-in-time (asset, year) membership.\n",
+    "- `config/exploration/feasibility_report.json`: summary numbers downstream\n",
+    "  notebooks and the chapter README can cite without re-running this notebook.\n",
+    "\n",
+    "**Next**: Chapter 7 creates labels at the monthly and weekly horizons declared\n",
+    "in `setup.yaml::labels`."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "tags,-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 12.346499,
+   "end_time": "2026-05-15T05:21:07.680721+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/etfs/01_feasibility_analysis.ipynb",
+   "output_path": "case_studies/etfs/01_feasibility_analysis.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-15T05:20:55.334222+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/case_studies/etfs/01_feasibility_analysis.py
+++ b/case_studies/etfs/01_feasibility_analysis.py
@@ -1,0 +1,940 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: tags,-all
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # ETF Case Study: Feasibility Analysis
+#
+# This notebook tests whether the ETF dataset can deliver on the strategy declared
+# in `config/setup.yaml`. `setup.yaml` is the canonical, hand-curated source of
+# truth: universe, costs, decision schedule, mapping class, labels, sweep grid,
+# and evaluation protocol. This notebook does not write it. Instead, it produces
+# the evidence that justifies its values: universe breadth over time, point-in-
+# time eligibility, return distributions at multiple horizons relative to
+# transaction costs, a walk-forward fold demonstration, and an edge-to-cost
+# ratio. Findings persist to `config/exploration/feasibility_report.json`.
+#
+# ## Learning Objectives
+#
+# - Verify the data delivers what `setup.yaml` assumes (breadth, costs, holdout)
+# - Implement point-in-time eligibility (no survivorship bias within the universe)
+# - Test whether typical price moves exceed transaction costs at candidate horizons
+# - Demonstrate the walk-forward structure has adequate breadth per fold
+# - Persist findings as a stable artifact downstream notebooks can cite
+#
+# ## Book Reference
+#
+# Chapter 6, Sections 6.2-6.6
+#
+# ## Prerequisites
+#
+# - ETF data available via `load_etfs()`
+# - `config/setup.yaml` exists (canonical strategy spec)
+# - Understanding of walk-forward cross-validation (Section 6.5)
+
+# %%
+"""ETF Case Study: Feasibility Analysis."""
+
+import json
+import warnings
+from datetime import UTC, datetime
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+import seaborn as sns
+import yaml
+
+from data import load_etfs
+from utils.paths import get_case_study_dir
+
+warnings.filterwarnings("ignore")
+sns.set_style("whitegrid")
+
+# %% tags=["parameters"]
+CASE_STUDY_ID = "etfs"
+START_DATE = "2006-01-01"
+ADV_THRESHOLD = 10e6
+MAX_SYMBOLS = 0
+
+# %% [markdown]
+# ## Configuration
+
+# %%
+CASE_DIR = get_case_study_dir("etfs")
+CASE_DIR.mkdir(parents=True, exist_ok=True)
+EXPLORATION_DIR = CASE_DIR / "config" / "exploration"
+EXPLORATION_DIR.mkdir(parents=True, exist_ok=True)
+
+with open(CASE_DIR / "config" / "setup.yaml") as f:
+    SETUP = yaml.safe_load(f)
+
+STRATEGY_ID = SETUP["strategy_id"]
+START_DATE = "2006-01-01"
+END_DATE = "2025-12-31"
+HOLDOUT_START = str(SETUP["evaluation"]["holdout_start"])
+
+
+def as_float(value: object) -> float:
+    """Convert Polars scalar outputs to plain float."""
+    return float(str(value))
+
+
+# %% [markdown]
+# ---
+#
+# ## Section A: Orientation (Section 6.2)
+#
+# ETFs provide diversified exposure across asset classes with high liquidity and
+# low costs. This case study explores price-based signals at monthly cadences,
+# where turnover economics are manageable.
+#
+# `setup.yaml` declares the trading setup. This notebook asks whether the data
+# delivers on those declarations:
+#
+# - **Universe**: Is point-in-time breadth adequate across the sample period?
+# - **Costs**: Do typical moves exceed the cost grid at candidate horizons?
+# - **Evaluation**: Do walk-forward folds carry enough cross-sectional breadth?
+# - **Holdout**: Is the holdout cleanly separated from training data?
+
+# %% [markdown]
+# ---
+#
+# ## Section B: Universe and Cost Feasibility (Sections 6.3-6.4)
+
+# %% [markdown]
+# ### B.1 Load and Explore the Data
+
+# %%
+etf_data = load_etfs()
+
+start_dt = pl.Series([START_DATE]).str.to_date("%Y-%m-%d").item()
+end_dt = pl.Series([END_DATE]).str.to_date("%Y-%m-%d").item()
+
+prices = (
+    etf_data.filter(pl.col("timestamp").is_between(start_dt, end_dt))
+    .select(["symbol", "timestamp", "close", "volume"])
+    .sort(["symbol", "timestamp"])
+)
+
+n_symbols = prices["symbol"].n_unique()
+print(f"Loaded {n_symbols} ETFs, {len(prices):,} rows")
+print(f"Period: {prices['timestamp'].min()} to {prices['timestamp'].max()}")
+
+# %% [markdown]
+# **Note**: The `close` column from `load_etfs()` is adjusted for splits and
+# dividends. We verify this by checking SPY's 2006 price level.
+
+# %%
+spy_2006 = prices.filter((pl.col("symbol") == "SPY") & (pl.col("timestamp").dt.year() == 2006))
+spy_first_close = as_float(spy_2006["close"].first())
+assert spy_first_close < 130, (
+    f"SPY 2006 close={spy_first_close:.2f} looks unadjusted (expected ~$90-100 adjusted)"
+)
+print(f"SPY 2006 first close: ${spy_first_close:.2f} (adjusted -- verified)")
+
+# %% [markdown]
+# ### B.2 Universe Selection: Rolling Point-in-Time Methodology
+#
+# A critical mistake in backtesting is using **end-of-sample information** to select
+# the universe. For example, filtering to "ETFs with ADV > $50M" using today's volume
+# excludes ETFs that had sufficient volume historically but have since declined.
+#
+# The correct approach is **rolling selection**: at each decision point, use only
+# information available at that time.
+#
+# For this case study, we will:
+# 1. First explore the historical distribution of dollar volume
+# 2. Set a threshold that is realistic but lenient (this is a demo, not production)
+# 3. Implement point-in-time universe membership
+
+# %% [markdown]
+# #### Exploratory Analysis: Dollar Volume Distribution Over Time
+#
+# Before setting thresholds, we need to understand how dollar volume has evolved.
+# A threshold that seems reasonable today may have excluded most ETFs in 2007.
+
+# %%
+# Compute daily dollar volume
+prices_with_dv = prices.with_columns((pl.col("close") * pl.col("volume")).alias("dollar_volume"))
+
+# Annual statistics: median dollar volume across all ETF-days in each year
+annual_dv_stats = (
+    prices_with_dv.with_columns(pl.col("timestamp").dt.year().alias("year"))
+    .group_by("year")
+    .agg(
+        pl.col("dollar_volume").median().alias("median_dv"),
+        pl.col("dollar_volume").quantile(0.25).alias("p25_dv"),
+        pl.col("dollar_volume").quantile(0.75).alias("p75_dv"),
+        pl.col("dollar_volume").quantile(0.90).alias("p90_dv"),
+        pl.col("symbol").n_unique().alias("n_etfs"),
+    )
+    .sort("year")
+)
+
+# Display as DataFrame (values in millions)
+annual_dv_stats.select(
+    [
+        "year",
+        (pl.col("median_dv") / 1e6).round(1).alias("median_$M"),
+        (pl.col("p75_dv") / 1e6).round(1).alias("p75_$M"),
+        (pl.col("p90_dv") / 1e6).round(1).alias("p90_$M"),
+        "n_etfs",
+    ]
+)
+
+# %% [markdown]
+# #### Visualize the Dollar Volume Evolution
+
+# %%
+fig, ax = plt.subplots(figsize=(10, 4))
+
+years = annual_dv_stats["year"].to_numpy()
+median_dv = annual_dv_stats["median_dv"].to_numpy() / 1e6
+p75_dv = annual_dv_stats["p75_dv"].to_numpy() / 1e6
+p90_dv = annual_dv_stats["p90_dv"].to_numpy() / 1e6
+
+ax.fill_between(years, median_dv, p75_dv, alpha=0.3, color="#606060", label="p50-p75")
+ax.fill_between(years, p75_dv, p90_dv, alpha=0.2, color="#808080", label="p75-p90")
+ax.plot(years, median_dv, "o-", color="#404040", linewidth=2, label="Median")
+ax.plot(years, p90_dv, "s--", color="#606060", linewidth=1, label="90th percentile")
+
+# Show potential thresholds
+ax.axhline(10, color="black", linestyle=":", linewidth=1.5, label="$10M threshold")
+ax.axhline(50, color="#404040", linestyle=":", linewidth=1.5, label="$50M threshold")
+
+ax.set_xlabel("Year")
+ax.set_ylabel("Dollar Volume ($ millions/day)")
+ax.set_title("ETF Dollar Volume Distribution Over Time")
+ax.legend(loc="upper left")
+ax.set_ylim(0, None)
+sns.despine()
+
+fig.tight_layout()
+plt.show()
+
+# %% [markdown]
+# #### Interpretation
+#
+# The figure shows that:
+# - Dollar volume has grown substantially over time (market growth + ETF adoption)
+# - A \$50M/day threshold would have excluded many ETFs in early years
+# - A \$10M/day threshold is more inclusive historically
+#
+# **For this demo case study**, we use a lenient threshold ($10M) to maintain a
+# broad universe (the sample of 100 ETFs has already been selected based on liquidity). A production system might use higher thresholds but would need
+# to account for the changing market structure.
+
+# %% [markdown]
+# #### Implement Rolling Universe Selection
+#
+# The proper point-in-time approach: at the end of each year, compute trailing ADV
+# and select ETFs for the following year.
+
+# %%
+# For each ETF, compute trailing 252-day ADV at each month-end
+# Then apply threshold to create point-in-time universe membership
+
+# Simplification for demo: compute annual ADV and apply to next year.
+# Note: annual granularity is coarser than the monthly decision cadence.
+# An ETF that becomes illiquid in March remains "eligible" through December.
+# Production systems would recompute eligibility at each decision date using
+# a trailing window (e.g., 63-day or 126-day rolling ADV).
+annual_adv = (
+    prices_with_dv.with_columns(pl.col("timestamp").dt.year().alias("year"))
+    .group_by(["symbol", "year"])
+    .agg(
+        pl.col("dollar_volume").mean().alias("avg_dv"),
+        pl.col("timestamp").count().alias("n_days"),
+    )
+    .filter(pl.col("n_days") >= 200)  # Require most of the year
+    .sort(["symbol", "year"])
+)
+
+# Threshold: $10M/day average (lenient for demo)
+ADV_THRESHOLD = 10e6
+
+eligible_by_year = (
+    annual_adv.filter(pl.col("avg_dv") >= ADV_THRESHOLD)
+    .with_columns((pl.col("year") + 1).alias("eligible_year"))
+    .select(["symbol", "eligible_year", "avg_dv"])
+)
+
+# Count eligible ETFs per year
+eligibility_counts = (
+    eligible_by_year.group_by("eligible_year")
+    .agg(pl.col("symbol").n_unique().alias("n_eligible"))
+    .sort("eligible_year")
+)
+
+print(f"Eligible ETFs per year (ADV threshold: ${ADV_THRESHOLD / 1e6:.0f}M):")
+eligibility_counts
+
+# %% [markdown]
+# #### Point-in-Time Universe: Eligibility Mask
+#
+# **Critical**: We do NOT filter to a fixed asset list based on full-sample eligibility.
+# That would use future information (survivorship bias). Instead, we create a
+# point-in-time eligibility table that downstream code uses at each decision date.
+#
+# The rule: an ETF is tradable in year Y if it met the ADV threshold in year Y-1.
+#
+# **Two-Layer Bias Assessment**:
+#
+# Understanding survivorship bias in this case study requires distinguishing two layers:
+#
+# - **Layer 1 (universe composition)**: The 100 ETFs were selected *after the fact*
+#   based on their relevance and liquidity at sample end (2025). ETFs that were liquid
+#   in 2007 but have since been delisted or merged are excluded. This bias **cannot be
+#   fully resolved** without historical constituent data, which is not readily available
+#   for ETFs. It inflates apparent signal quality by removing negative outcomes.
+#
+# - **Layer 2 (eligibility within the universe)**: Given the 100-ETF sample, the
+#   point-in-time ADV filter correctly prevents using future liquidity information.
+#   An ETF is only tradable in year Y if it met the threshold in year Y-1. This layer
+#   **is** point-in-time correct.
+#
+# The two layers partially work at cross purposes: the rolling filter creates rigor at
+# Layer 2 while Layer 1 already embeds the bias it's trying to avoid. Readers should
+# understand which bias is mitigated (within-universe eligibility) and which is not
+# (universe composition).
+#
+# Additionally, the $10M ADV threshold is not inflation-adjusted. Ten million
+# dollars in 2006 had different purchasing power than in 2025. A more rigorous
+# approach would step down the threshold for earlier years (e.g., scale by CPI
+# or market cap growth). We proceed with the fixed threshold for simplicity---the
+# 100-ETF universe was already curated for liquidity.
+
+# %%
+# All assets in the dataset are candidates
+ASSETS = prices["symbol"].unique().sort().to_list()
+
+# Eligibility table: which assets are tradable in which years
+# eligibility_by_year already has (asset, eligible_year) pairs
+eligibility_table = eligible_by_year.select(["symbol", "eligible_year"]).unique()
+
+# Summary: how many ETFs eligible per year
+eligibility_summary = (
+    eligibility_table.group_by("eligible_year")
+    .agg(pl.col("symbol").count().alias("n_eligible"))
+    .sort("eligible_year")
+)
+
+print(f"\nCandidate universe: {len(ASSETS)} ETFs (all assets in dataset)")
+print("Point-in-time eligibility determined annually based on prior-year ADV")
+print("\nEligible ETFs by year:")
+eligibility_summary
+
+# %% [markdown]
+# ---
+#
+# ### B.3 Trading Cost Analysis: Horizon Feasibility
+#
+# A fundamental question for any trading strategy is: **at which holding periods
+# do typical price moves exceed transaction costs?**
+#
+# This analysis informs which horizons are worth exploring, without prescribing
+# a specific signal type.
+
+# %% [markdown]
+# #### Return Distributions at Multiple Horizons
+#
+# We compute returns at daily, weekly, and monthly frequencies and examine their
+# distributions relative to transaction costs.
+
+# %%
+# Filter to universe assets
+universe_prices = prices.filter(pl.col("symbol").is_in(ASSETS)).sort(["symbol", "timestamp"])
+
+# Daily returns
+daily_returns = (
+    universe_prices.with_columns(
+        (pl.col("close") / pl.col("close").shift(1) - 1).over("symbol").alias("return")
+    )
+    .filter(pl.col("return").is_not_null())
+    .select(["symbol", "timestamp", "return"])
+)
+
+# Weekly returns (resample to week-end)
+weekly_prices = (
+    universe_prices.with_columns(pl.col("timestamp").dt.strftime("%G-W%V").alias("week"))
+    .group_by(["symbol", "week"])
+    .agg(pl.col("close").last().alias("close"), pl.col("timestamp").max().alias("timestamp"))
+    .sort(["symbol", "timestamp"])
+)
+weekly_returns = weekly_prices.with_columns(
+    (pl.col("close") / pl.col("close").shift(1) - 1).over("symbol").alias("return")
+).filter(pl.col("return").is_not_null())
+
+# Monthly returns
+monthly_prices = (
+    universe_prices.with_columns(pl.col("timestamp").dt.strftime("%Y-%m").alias("month"))
+    .group_by(["symbol", "month"])
+    .agg(pl.col("close").last().alias("close"), pl.col("timestamp").max().alias("timestamp"))
+    .sort(["symbol", "timestamp"])
+)
+monthly_returns = monthly_prices.with_columns(
+    (pl.col("close") / pl.col("close").shift(1) - 1).over("symbol").alias("return")
+).filter(pl.col("return").is_not_null())
+
+print(f"Daily returns: {len(daily_returns):,} observations")
+print(f"Weekly returns: {len(weekly_returns):,} observations")
+print(f"Monthly returns: {len(monthly_returns):,} observations")
+
+# %% [markdown]
+# #### Summary Statistics by Horizon
+#
+# The key question: what fraction of absolute price moves exceed the round-trip cost?
+
+# %%
+# Extract absolute returns
+daily_abs = daily_returns["return"].abs().to_numpy()
+weekly_abs = weekly_returns["return"].abs().to_numpy()
+monthly_abs = monthly_returns["return"].abs().to_numpy()
+
+# Cost assumptions: per-leg cost 10 bps → round-trip 20 bps
+PER_LEG_COST_BPS = 10
+ROUND_TRIP_COST_BPS = 2 * PER_LEG_COST_BPS
+ROUND_TRIP_COST = ROUND_TRIP_COST_BPS / 10_000  # 0.0020
+
+
+# Build summary DataFrame
+def compute_return_stats(data: np.ndarray, horizon: str) -> dict:
+    """Compute return distribution statistics for a given horizon."""
+    return {
+        "horizon": horizon,
+        "median_pct": np.median(data) * 100,
+        "mean_pct": np.mean(data) * 100,
+        "std_pct": np.std(data) * 100,
+        "p75_pct": np.percentile(data, 75) * 100,
+        "p95_pct": np.percentile(data, 95) * 100,
+        "pct_above_20bps": (data > ROUND_TRIP_COST).mean() * 100,
+    }
+
+
+return_stats = pl.DataFrame(
+    [
+        compute_return_stats(daily_abs, "Daily"),
+        compute_return_stats(weekly_abs, "Weekly"),
+        compute_return_stats(monthly_abs, "Monthly"),
+    ]
+)
+
+# %% [markdown]
+# **Return Distribution Summary** (absolute returns):
+
+# %%
+return_stats.select(
+    [
+        "horizon",
+        pl.col("median_pct").round(2).alias("median %"),
+        pl.col("mean_pct").round(2).alias("mean %"),
+        pl.col("std_pct").round(2).alias("std %"),
+        pl.col("p75_pct").round(2).alias("p75 %"),
+        pl.col("p95_pct").round(2).alias("p95 %"),
+    ]
+)
+
+# %% [markdown]
+# **Fraction of moves exceeding cost threshold** (round-trip = 20 bps):
+
+# %%
+# Cost threshold analysis
+COST_THRESHOLDS_BPS = [10, 20, 30, 50]
+
+cost_exceedance = []
+for horizon, data in [("Daily", daily_abs), ("Weekly", weekly_abs), ("Monthly", monthly_abs)]:
+    row = {"horizon": horizon}
+    for cost_bps in COST_THRESHOLDS_BPS:
+        row[f"{cost_bps}_bps"] = (data > cost_bps / 10_000).mean() * 100
+    cost_exceedance.append(row)
+
+cost_df = pl.DataFrame(cost_exceedance)
+cost_df.select(
+    [
+        "horizon",
+        pl.col("10_bps").round(1).alias("10 bps %"),
+        pl.col("20_bps").round(1).alias("20 bps %"),
+        pl.col("30_bps").round(1).alias("30 bps %"),
+        pl.col("50_bps").round(1).alias("50 bps %"),
+    ]
+)
+
+# %% [markdown]
+# #### Visualize Return Distributions
+#
+# The visualization shows return distributions at each horizon with cost reference lines.
+# Note how the distributions widen as the horizon increases.
+
+# %%
+fig, axes = plt.subplots(1, 3, figsize=(14, 4))
+
+# Use grayscale for book compatibility
+horizons = [
+    ("Daily", daily_abs, "#404040"),
+    ("Weekly", weekly_abs, "#707070"),
+    ("Monthly", monthly_abs, "#a0a0a0"),
+]
+
+for ax, (label, data, color) in zip(axes, horizons, strict=False):
+    # Use different x-limits to show the actual distribution shape
+    if label == "Daily":
+        xlim = 0.06
+    elif label == "Weekly":
+        xlim = 0.10
+    else:
+        xlim = 0.15
+
+    # Histogram
+    bins = np.linspace(0, xlim, 40)
+    ax.hist(data[data < xlim], bins=bins, density=True, alpha=0.7, color=color, edgecolor="white")
+
+    # Cost reference line
+    ax.axvline(ROUND_TRIP_COST, color="black", linestyle="--", linewidth=2, label="Cost: 20 bps")
+
+    # Statistics annotation
+    median_val = np.median(data)
+    frac_above = (data > ROUND_TRIP_COST).mean()
+    ax.axvline(median_val, color="#404040", linestyle="-", linewidth=1.5, alpha=0.7)
+
+    stats_text = f"Median: {median_val * 100:.2f}%\n{frac_above:.0%} > cost"
+    ax.text(
+        0.95,
+        0.95,
+        stats_text,
+        transform=ax.transAxes,
+        ha="right",
+        va="top",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.8),
+    )
+
+    ax.set_xlabel("Absolute Return")
+    ax.set_title(f"{label} Horizon")
+    ax.set_xlim(0, xlim)
+    ax.legend(loc="upper right", fontsize=9)
+
+axes[0].set_ylabel("Density")
+fig.suptitle("ETF Return Distributions by Horizon", fontsize=12, fontweight="bold")
+sns.despine()
+fig.tight_layout()
+plt.show()
+
+# %% [markdown]
+# #### Interpretation
+#
+# The return distributions clearly differ by horizon. Looking at the tables above:
+#
+# - **Daily**: Median moves are small relative to costs. A majority of moves exceed
+#   the 20 bps threshold, but high-turnover strategies operate with thin margins.
+# - **Weekly**: Moves are larger, providing reasonable headroom over costs.
+# - **Monthly**: Moves comfortably exceed costs in the vast majority of cases.
+#
+# **Connecting costs to the cost model**: The cost exceedance table above spans
+# 10 to 50 bps round-trip. Our stated cost model (5--15 bps per leg, i.e., 10--30
+# bps round-trip) maps directly to the 10, 20, and 30 bps columns. For large liquid
+# ETFs (SPY, QQQ) at the low end (10 bps RT), even daily moves exceed costs ~75%
+# of the time. For smaller thematic ETFs at the high end (30 bps RT), only monthly
+# moves are comfortably above cost in most observations. The choice of horizon
+# therefore depends on the *cost tier* of the ETFs you're trading, not just the
+# horizon in isolation.
+#
+# **This analysis guides but does not dictate**: We establish that all three horizons
+# are feasible. Chapter 7 will test features at each horizon.
+
+# %% [markdown]
+# #### Cost-Regime Choice: per-Share + Tiered Spread
+#
+# `setup.yaml::costs.model = per_share_plus_spread` — costs are declared as
+# a per-share commission plus a per-asset half-spread in dollars per share,
+# not as a flat bps rate.
+#
+# **Commission.** The `per_share = 0.0035` value is IBKR Pro Tiered's top
+# tier (the rate readers see at the broker when they execute monthly ETF
+# rotations at retail scale). This is the library default in
+# `ml4t-backtest` set because we downloaded IBKR Pro pricing for exactly
+# this purpose — the cost dispatcher has nothing to invent.
+#
+# **Spread.** The per-asset half-spread map in
+# `setup.yaml::costs.asset_spreads` ties each ticker to an industry-
+# knowledge tier: mega-ETFs (SPY/QQQ/IWM/EFA/EEM/DIA/VTI/VOO) at 0.5¢,
+# sector XL* funds at 1¢, default 2¢ for thematic/regional/factor ETFs.
+# This is a *reasoned simplification* — ETF nominal prices do not drift
+# much over the validation window, so a static map is defensible — but it
+# is **not** an empirical measurement. We do not have AlgoSeek-grade NBBO
+# quotes spanning the broad ETF universe; the analogous case study with
+# measured per-asset spreads is `nasdaq100_microstructure`, which has
+# AlgoSeek minute-bar NBBO close quotes for its 100-ticker NASDAQ-100
+# universe. The nasdaq100 measurements are NOT a proxy for liquid-ETF
+# spreads: they cover different securities under different microstructure.
+# The tiered ETF map should be read as "what an institutional trader
+# knowledgeable about US ETFs would assert as the going rate" rather than
+# as a quote-grounded estimate. The cost sensitivity sweep in `16_costs.py`
+# probes how robust this assumption is across both bps and per-share
+# grids.
+
+# %% [markdown]
+# ### B.4 Feasibility Ratio
+#
+# A simple edge-to-cost ratio confirms that typical signal magnitude
+# comfortably exceeds transaction costs before proceeding further.
+
+# %%
+median_monthly_abs_return = float(np.median(monthly_abs))
+feasibility_ratio = median_monthly_abs_return / ROUND_TRIP_COST
+print(
+    f"Median monthly |return|: {median_monthly_abs_return:.4f} ({median_monthly_abs_return * 10000:.1f} bps)"
+)
+print(f"Round-trip cost: {ROUND_TRIP_COST:.4f} ({ROUND_TRIP_COST * 10000:.0f} bps)")
+print(f"Edge-to-cost ratio: {feasibility_ratio:.1f}x")
+print(f"Assessment: {'PROCEED' if feasibility_ratio > 1.0 else 'KILL -- edge too thin'}")
+
+# %% [markdown]
+# ---
+#
+# ## Section C: Design Decisions
+#
+# Design decisions are the strategy choices encoded in `setup.yaml` that the
+# feasibility evidence above supports. They are justified here, not in the YAML.
+
+# %% [markdown]
+# ### C.1 Decision Cadence
+#
+# Monthly month-end is the conventional cadence for cross-asset momentum studies
+# (Moskowitz, Ooi, and Pedersen 2012; Asness, Moskowitz, and Pedersen 2013), which
+# makes our results directly comparable to published benchmarks. However, the choice
+# deserves scrutiny rather than deference.
+#
+# A **weekly (5-day) cadence** would multiply effective sample size roughly 4x
+# (~1,040 weekly vs ~240 monthly decision dates), improving IC estimate stability
+# per fold. Purging becomes cheaper: a 1-week purge burns 5 trading days vs 21 for
+# monthly. The cost analysis above confirms that weekly absolute returns comfortably
+# exceed the 20 bps round-trip threshold for most of the universe.
+#
+# The complications are real: turnover increases mechanically (even if signals are
+# slow-moving, weekly rebalancing amplifies noise-driven rank changes), and coupling
+# signal horizon with decision cadence requires care---you can evaluate a signal weekly
+# but still use 4-week forward labels, at the cost of overlapping labels that demand
+# proper purge/embargo handling.
+#
+# We treat cadence as a **first-class parameter**. `setup.yaml` declares the
+# default monthly cadence (`decision.cadence: monthly_month_end`) and exposes
+# `fwd_ret_5d` as a weekly-horizon label variant for comparison.
+
+# %% [markdown]
+# ### C.2 Kill Conditions
+#
+# Kill conditions are falsifiable checkpoints --- if any triggers, the strategy
+# is abandoned or substantially reworked. Defining them upfront prevents
+# post-hoc rationalization. The thresholds below are anchored to the feasibility
+# evidence above (cost-exceedance and edge-to-cost analysis):
+#
+# - **KC1 (IC floor)**: IC < 0.01 with t-stat < 2.0 across all lookback horizons
+#   (3M-12M). Gate: Chapter 8 feature evaluation.
+# - **KC2 (edge-cost)**: Edge-to-cost ratio < 1.0x after realistic transaction
+#   costs. Gate: Chapter 7 label evaluation / Chapter 17 backtest. B.4 above
+#   tests this gate on raw return magnitudes before the model is even trained.
+# - **KC3 (EW underperformance)**: Equal-weight benchmark posts a higher Sharpe
+#   and lower max drawdown than the strategy across all test folds. Gate:
+#   Chapter 17 backtest.
+
+# %% [markdown]
+# ### C.3 Mapping Class
+#
+# `setup.yaml` declares the simplest credible mapping: **long-only, equal-weight,
+# top-N** (`mapping.class: long_only_rank_and_rebalance`, `sizing: equal_weight`).
+# Long-only is appropriate because (a) most ETFs are difficult or expensive to
+# short, (b) the target audience for this case study is long-only portfolio
+# construction, and (c) it isolates the ranking signal from short-side
+# complexity. Equal-weight is the minimal-assumption sizing rule---it avoids
+# introducing a secondary optimization (risk-parity, inverse-vol) that would
+# confound evaluation of the ranking signal itself. Chapter 18 explores
+# alternative weighting schemes via the `backtest.sweep.allocators` grid in
+# `setup.yaml`.
+
+# %% [markdown]
+# ---
+#
+# ## Section D: Walk-Forward Structure (Section 6.5)
+#
+# We verify that the data supports the walk-forward design declared in
+# `setup.yaml::evaluation` (`n_splits`, `train_size`, `val_size`, `holdout_start`).
+
+# %% [markdown]
+# ### D.1 Effective Sample Size and Data Coverage
+
+# %%
+n_decision_dates = monthly_prices["month"].n_unique()
+first_month = monthly_prices["month"].min()
+last_month = monthly_prices["month"].max()
+n_years = n_decision_dates / 12
+
+print("Data Coverage:")
+print(f"  Period: {first_month} to {last_month}")
+print(f"  Decision points (months): {n_decision_dates}")
+print(f"  Approx years: {n_years:.1f}")
+
+# %% [markdown]
+# ### D.2 Walk-Forward Fold Demonstration
+#
+# `case_studies/utils/cv_window.py` owns the operational splits; this cell
+# reproduces the fold boundaries from canonical `setup.yaml` parameters to verify
+# the data supports the declared design. Each fold has:
+#
+# - **Train period**: `setup.yaml::evaluation.train_size`
+# - **Test period**: `setup.yaml::evaluation.val_size`
+# - **Purge gap**: 1 month between train end and test start (matches the 21D
+#   buffer for the 1-month primary label)
+
+# %%
+n_splits_declared = int(SETUP["evaluation"]["n_splits"])
+purge_months = 1  # matches setup.yaml::labels.buffer (21D) at monthly cadence
+train_months = 10 * 12  # setup.yaml::evaluation.train_size = 10Y
+test_months = 1 * 12  # setup.yaml::evaluation.val_size = 1Y
+step_months = 1 * 12  # consecutive, non-overlapping
+
+# Get sorted list of decision dates (month-ends)
+decision_dates = (
+    monthly_prices.select("timestamp").unique().sort("timestamp")["timestamp"].to_list()
+)
+
+# Holdout boundary
+holdout_start_dt = pl.Series([HOLDOUT_START]).str.to_date("%Y-%m-%d").item()
+cv_dates = [d for d in decision_dates if d < holdout_start_dt]
+
+# Generate splits
+splits = []
+test_start_idx = train_months
+
+while test_start_idx + test_months <= len(cv_dates):
+    train_start_idx = test_start_idx - train_months
+    train_end_idx = test_start_idx - purge_months  # purge gap
+    test_end_idx = test_start_idx + test_months
+
+    split = {
+        "fold": len(splits) + 1,
+        "train_start": cv_dates[train_start_idx].strftime("%Y-%m-%d"),
+        "train_end": cv_dates[train_end_idx - 1].strftime("%Y-%m-%d"),
+        "test_start": cv_dates[test_start_idx].strftime("%Y-%m-%d"),
+        "test_end": cv_dates[test_end_idx - 1].strftime("%Y-%m-%d"),
+        "purge_months": purge_months,
+    }
+    splits.append(split)
+    test_start_idx += step_months
+
+print(f"Generated {len(splits)} walk-forward folds")
+
+# Sanity check: verify all folds fit within pre-holdout data
+assert len(splits) == n_splits_declared, (
+    f"Expected {n_splits_declared} folds (setup.yaml), got {len(splits)}"
+)
+last_test_end = splits[-1]["test_end"]
+print(f"Last fold test end: {last_test_end}  |  Holdout start: {HOLDOUT_START}")
+assert last_test_end < HOLDOUT_START, (
+    f"Last fold ({last_test_end}) overlaps holdout ({HOLDOUT_START})"
+)
+
+# %% [markdown]
+# **Walk-forward fold summary:**
+
+# %%
+splits_df = pl.DataFrame(splits)
+splits_df
+
+# %% [markdown]
+# #### Universe Breadth per Fold
+#
+# We verify that each fold has adequate cross-sectional breadth by counting
+# eligible ETFs in each test period. Thin early folds would weaken cross-sectional
+# signals (quintile sorting requires reasonable N).
+
+# %%
+fold_breadth = []
+for split in splits:
+    test_year = int(split["test_start"][:4])
+    n_eligible = eligibility_table.filter(pl.col("eligible_year") == test_year).height
+    fold_breadth.append(
+        {
+            "fold": split["fold"],
+            "test_year": test_year,
+            "n_eligible": n_eligible,
+        }
+    )
+
+fold_breadth_df = pl.DataFrame(fold_breadth)
+print("Eligible ETFs per fold test period:")
+fold_breadth_df
+
+# %% [markdown]
+# All folds have 70+ eligible ETFs, which is sufficient for cross-sectional ranking
+# and quintile construction. The early folds have fewer ETFs because some symbols
+# (e.g., ARKK, XLC) had not yet launched---this is the correct point-in-time behavior,
+# not a data problem.
+
+# %% [markdown]
+# ---
+#
+# ## Section E: Eligibility Artifact
+#
+# Point-in-time (asset, year) eligibility is the one decision-relevant artifact
+# this notebook generates (everything else lives in `setup.yaml`). It is keyed by
+# year because the ADV filter runs annually; downstream labels and features
+# consume it to enforce point-in-time membership.
+
+# %%
+eligibility_path = CASE_DIR / "eligibility.csv"
+eligibility_table.select(["symbol", "eligible_year"]).sort(["symbol", "eligible_year"]).write_csv(
+    eligibility_path
+)
+print(f"Written: {eligibility_path} ({len(eligibility_table):,} asset-year pairs)")
+
+# %% [markdown]
+# ---
+#
+# ## Section F: Findings vs `setup.yaml`
+#
+# The canonical strategy declarations live in `config/setup.yaml`. This section
+# enumerates each declared knob alongside the feasibility evidence above that
+# motivates it. Setup.yaml is not regenerated here --- it is the hand-curated
+# source of truth, and this notebook reads it.
+
+# %%
+# Numbers used in the side-by-side report
+median_d_abs_pct = float(np.median(daily_abs) * 100)
+median_w_abs_pct = float(np.median(weekly_abs) * 100)
+median_m_abs_pct = float(np.median(monthly_abs) * 100)
+frac_d_above_20 = float((daily_abs > 0.0020).mean())
+frac_w_above_20 = float((weekly_abs > 0.0020).mean())
+frac_m_above_20 = float((monthly_abs > 0.0020).mean())
+n_eligible_min = int(min(fb["n_eligible"] for fb in fold_breadth))
+n_eligible_max = int(max(fb["n_eligible"] for fb in fold_breadth))
+n_folds_generated = int(len(splits))
+
+print("=" * 78)
+print("Setup.yaml knobs vs feasibility evidence")
+print("=" * 78)
+
+print()
+print(f"universe.n_assets = {SETUP['universe']['n_assets']}")
+print(f"  -> point-in-time eligible per fold: min={n_eligible_min}, max={n_eligible_max}")
+print("  -> sufficient for cross-sectional ranking (>=70 per fold)")
+
+print()
+print(f"decision.cadence = {SETUP['decision']['cadence']}")
+print(
+    f"  -> median |monthly return| = {median_m_abs_pct:.2f}%; "
+    f"{frac_m_above_20 * 100:.0f}% exceed 20bps RT"
+)
+
+print()
+print(f"costs.model = {SETUP['costs']['model']}")
+print(f"  -> at 20bps RT: edge-to-cost = {feasibility_ratio:.0f}x at monthly horizon")
+print(f"  -> daily moves > 20bps: {frac_d_above_20 * 100:.0f}%")
+print(f"  -> weekly moves > 20bps: {frac_w_above_20 * 100:.0f}%")
+
+print()
+print(f"labels.primary = {SETUP['labels']['primary']}")
+print(
+    f"  -> median |21d return| = {median_m_abs_pct:.2f}% = "
+    f"{(median_m_abs_pct / 100) / 0.002:.0f}x a 20bps cost"
+)
+
+print()
+print(f"labels.variants = {SETUP['labels']['variants']}")
+print(
+    f"  -> median |weekly return| = {median_w_abs_pct:.2f}% ({frac_w_above_20 * 100:.0f}% > 20bps)"
+)
+
+print()
+print(f"evaluation.n_splits = {SETUP['evaluation']['n_splits']}")
+print(f"  -> generated {n_folds_generated} folds; declared count matches")
+print(
+    f"  -> holdout {SETUP['evaluation']['holdout_start']} "
+    f"to {SETUP['evaluation']['holdout_end']}; "
+    f"last test ends {splits[-1]['test_end']}"
+)
+
+# %% [markdown]
+# ### Persist Feasibility Findings
+
+# %%
+feasibility_report = {
+    "case_study_id": "etfs",
+    "computed_at_utc": datetime.now(UTC).isoformat(),
+    "data_period": {"start": START_DATE, "end": END_DATE},
+    "universe": {
+        "n_assets_declared": int(SETUP["universe"]["n_assets"]),
+        "n_eligible_per_fold_min": n_eligible_min,
+        "n_eligible_per_fold_max": n_eligible_max,
+    },
+    "return_distribution_abs_pct": {
+        "daily_median": median_d_abs_pct,
+        "weekly_median": median_w_abs_pct,
+        "monthly_median": median_m_abs_pct,
+    },
+    "cost_exceedance_at_20bps_pct": {
+        "daily": frac_d_above_20 * 100,
+        "weekly": frac_w_above_20 * 100,
+        "monthly": frac_m_above_20 * 100,
+    },
+    "feasibility_ratio_monthly_at_20bps": float(feasibility_ratio),
+    "walk_forward": {
+        "n_folds_generated": n_folds_generated,
+        "n_splits_declared": int(SETUP["evaluation"]["n_splits"]),
+        "holdout_start": HOLDOUT_START,
+        "last_test_end": splits[-1]["test_end"],
+    },
+}
+
+report_path = EXPLORATION_DIR / "feasibility_report.json"
+with open(report_path, "w") as f:
+    json.dump(feasibility_report, f, indent=2)
+print(f"Written: {report_path}")
+
+# %% [markdown]
+# ---
+#
+# ## Key Takeaways
+#
+# 1. **Universe**: Two-layer bias assessment---universe composition has survivorship
+#    bias (Layer 1, not fully resolvable, the 100 ETFs were chosen backward-looking);
+#    within-universe eligibility is point-in-time correct (Layer 2, via $10M ADV
+#    threshold applied annually with one-year lag). 70+ eligible ETFs per fold.
+# 2. **Cost feasibility**: All three horizons clear the 20bps round-trip threshold,
+#    but the margin depends on the cost tier---large liquid ETFs (10 bps RT) support
+#    daily strategies, while smaller thematic ETFs (30 bps RT) require monthly
+#    holding periods. `setup.yaml` accommodates both via tiered `costs.asset_spreads`.
+# 3. **Cadence**: Monthly month-end as default for literature comparability;
+#    weekly tested as a variant via `labels.variants: [fwd_ret_5d]`.
+# 4. **Mapping**: Long-only equal-weight top-N as simplest credible baseline;
+#    alternative allocators sweep in `setup.yaml::backtest.sweep.allocators`
+#    (explored in Chapter 17--18).
+# 5. **Evaluation**: 8 walk-forward folds with verified holdout separation
+#    (`evaluation.holdout_start` enforced).
+# 6. **Kill conditions**: KC2 (edge-to-cost > 1.0x) already cleared---feasibility
+#    ratio at monthly horizon is comfortably above 1.0 on raw return magnitudes.
+#    KC1 (IC floor) and KC3 (EW underperformance) are tested in later chapters.
+#
+# **Known limitations**:
+# - Layer 1 survivorship bias is documented but not resolved.
+# - Annual eligibility granularity is coarser than monthly decision cadence.
+# - The $10M ADV threshold is not inflation-adjusted.
+#
+# **Artifacts written**:
+# - `eligibility.csv`: point-in-time (asset, year) membership.
+# - `config/exploration/feasibility_report.json`: summary numbers downstream
+#   notebooks and the chapter README can cite without re-running this notebook.
+#
+# **Next**: Chapter 7 creates labels at the monthly and weekly horizons declared
+# in `setup.yaml::labels`.

--- a/case_studies/etfs/02_labels.ipynb
+++ b/case_studies/etfs/02_labels.ipynb
@@ -1,0 +1,743 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ec2aaa55",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003499,
+     "end_time": "2026-03-24T01:49:42.483336+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:42.479837+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# ETFs: Label Engineering\n",
+    "\n",
+    "This notebook implements label engineering for the ETFs case study.\n",
+    "Labels encode the economic hypothesis: can risk-adjusted momentum predict\n",
+    "forward returns across a multi-asset ETF universe?\n",
+    "\n",
+    "## Learning Objectives\n",
+    "\n",
+    "- Compute regression labels at 21-day (primary) and 5-day (variant) horizons\n",
+    "- Construct cross-sectional quintile labels for relative ranking prediction\n",
+    "- Filter to eligible ETFs before computing quintiles (point-in-time)\n",
+    "- Evaluate label quality: class balance, IC of raw momentum baseline\n",
+    "- Generate walk-forward CV configuration from `setup.yaml`\n",
+    "\n",
+    "## Book Reference\n",
+    "\n",
+    "Chapter 7, Section 7.2 (Label Engineering)\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) must have been run (produces `eligibility.csv`)\n",
+    "- ETF data available via `load_etfs()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "49bc7ca7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:42.488728Z",
+     "iopub.status.busy": "2026-03-24T01:49:42.488604Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.013117Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.012538Z"
+    },
+    "papermill": {
+     "duration": 1.527403,
+     "end_time": "2026-03-24T01:49:44.013393+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:42.485990+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/libraries/ml4t-engineer/src/ml4t/engineer/features/ml/__init__.py:9: UserWarning: Feature 'cyclical_encode': lookback=0 but has period/window parameter. Consider using lookback='period' or specifying the actual lookback.\n",
+      "  from ml4t.engineer.features.ml.cyclical_encode import *  # noqa: F403\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"ETFs: Label Engineering.\"\"\"\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "import numpy as np\n",
+    "import polars as pl\n",
+    "\n",
+    "from data import load_etfs\n",
+    "from utils.modeling import get_cv_config\n",
+    "from utils.paths import get_case_study_dir\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "CASE_DIR = get_case_study_dir(\"etfs\")\n",
+    "LABELS_DIR = CASE_DIR / \"labels\"\n",
+    "\n",
+    "\n",
+    "def as_float(value: object | None) -> float | None:\n",
+    "    \"\"\"Convert Polars scalar outputs to plain float for summaries.\"\"\"\n",
+    "    if value is None:\n",
+    "        return None\n",
+    "    return float(str(value))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08ee88ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Production defaults — Papermill injects overrides for CI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ee77f82",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001444,
+     "end_time": "2026-03-24T01:49:44.015945+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.014501+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Load Data\n",
+    "\n",
+    "Load ETF prices and point-in-time eligibility. The eligibility table\n",
+    "ensures quintile labels are computed only on ETFs that were tradable at\n",
+    "each decision date, avoiding inflation of the cross-section breadth\n",
+    "in early years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4d8536bb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.018517Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.018273Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.059369Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.058609Z"
+    },
+    "papermill": {
+     "duration": 0.042928,
+     "end_time": "2026-03-24T01:49:44.059783+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.016855+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ETF Universe: 100 assets, 470,662 rows\n",
+      "Date range: 2006-01-03 to 2025-12-31\n",
+      "Eligibility: 1,670 (asset, year) pairs\n"
+     ]
+    }
+   ],
+   "source": [
+    "prices = (\n",
+    "    load_etfs()\n",
+    "    .select([\"symbol\", \"timestamp\", \"open\", \"high\", \"low\", \"close\", \"volume\"])\n",
+    "    .sort([\"symbol\", \"timestamp\"])\n",
+    ")\n",
+    "\n",
+    "# Load eligibility table from 01_feasibility_analysis.py\n",
+    "eligibility = pl.read_csv(CASE_DIR / \"eligibility.csv\")\n",
+    "\n",
+    "n_assets = prices[\"symbol\"].n_unique()\n",
+    "date_range = f\"{prices['timestamp'].min()} to {prices['timestamp'].max()}\"\n",
+    "print(f\"ETF Universe: {n_assets} assets, {len(prices):,} rows\")\n",
+    "print(f\"Date range: {date_range}\")\n",
+    "print(f\"Eligibility: {len(eligibility):,} (asset, year) pairs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd19798",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001092,
+     "end_time": "2026-03-24T01:49:44.062306+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.061214+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note**: The `close` column from `load_etfs()` is adjusted for splits and\n",
+    "dividends (verified in [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) via SPY 2006 price level check)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16a7b219",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.000884,
+     "end_time": "2026-03-24T01:49:44.064184+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.063300+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Label Functions\n",
+    "\n",
+    "Two label types:\n",
+    "\n",
+    "1. **Regression** (`fwd_ret_Nd`): Simple forward return over $N$ trading days.\n",
+    "   Non-overlapping at monthly cadence avoids serial correlation in targets.\n",
+    "\n",
+    "2. **Quintile classification** (`fwd_quintile_Nd`): Cross-sectional quintile of\n",
+    "   forward returns. Ranks ETFs relative to peers at each date. Computed only\n",
+    "   on eligible ETFs to keep quintile boundaries meaningful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3db9b600",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.066848Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.066660Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.069240Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.068667Z"
+    },
+    "papermill": {
+     "duration": 0.004497,
+     "end_time": "2026-03-24T01:49:44.069596+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.065099+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_regression_labels(df: pl.DataFrame, horizon: int = 21) -> pl.DataFrame:\n",
+    "    \"\"\"Create forward return labels for regression.\n",
+    "\n",
+    "    Uses close-to-close returns shifted forward by `horizon` trading days.\n",
+    "    \"\"\"\n",
+    "    return df.with_columns(\n",
+    "        (pl.col(\"close\").shift(-horizon).over(\"symbol\") / pl.col(\"close\") - 1).alias(\n",
+    "            f\"fwd_ret_{horizon}d\"\n",
+    "        )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7ab8ba1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000881,
+     "end_time": "2026-03-24T01:49:44.071439+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.070558+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Apply Labels\n",
+    "\n",
+    "We compute two label types:\n",
+    "- `fwd_ret_21d`: Primary regression label (matches monthly rebalancing)\n",
+    "- `fwd_ret_5d`: Variant regression label (tests weekly horizon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "394bbafa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.073728Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.073642Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.108092Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.107470Z"
+    },
+    "papermill": {
+     "duration": 0.036093,
+     "end_time": "2026-03-24T01:49:44.108452+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.072359+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created regression labels: fwd_ret_21d, fwd_ret_5d\n"
+     ]
+    }
+   ],
+   "source": [
+    "labels_df = prices.sort([\"symbol\", \"timestamp\"])\n",
+    "\n",
+    "# Regression labels at two horizons\n",
+    "labels_df = create_regression_labels(labels_df, horizon=21)\n",
+    "labels_df = create_regression_labels(labels_df, horizon=5)\n",
+    "print(\"Created regression labels: fwd_ret_21d, fwd_ret_5d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdc002c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001522,
+     "end_time": "2026-03-24T01:49:44.111615+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.110093+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Label Distribution Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c98fb860",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.114712Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.114627Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.121327Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.120886Z"
+    },
+    "papermill": {
+     "duration": 0.008818,
+     "end_time": "2026-03-24T01:49:44.121806+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.112988+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regression (fwd_ret_21d): 468,562 samples\n",
+      "  Mean: 0.0066, Std: 0.0601\n",
+      "\n",
+      "Regression (fwd_ret_5d): 470,162 samples\n",
+      "  Mean: 0.0016, Std: 0.0306\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Regression 21d\n",
+    "ret21 = labels_df.select(\"fwd_ret_21d\").drop_nulls()\n",
+    "print(f\"Regression (fwd_ret_21d): {len(ret21):,} samples\")\n",
+    "print(f\"  Mean: {ret21['fwd_ret_21d'].mean():.4f}, Std: {ret21['fwd_ret_21d'].std():.4f}\")\n",
+    "\n",
+    "# Regression 5d\n",
+    "ret5 = labels_df.select(\"fwd_ret_5d\").drop_nulls()\n",
+    "print(f\"\\nRegression (fwd_ret_5d): {len(ret5):,} samples\")\n",
+    "print(f\"  Mean: {ret5['fwd_ret_5d'].mean():.4f}, Std: {ret5['fwd_ret_5d'].std():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d68799ef",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001261,
+     "end_time": "2026-03-24T01:49:44.124846+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.123585+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Label Autocorrelation\n",
+    "\n",
+    "With daily labels at a 21-day horizon, consecutive labels overlap by 20 days,\n",
+    "creating strong mechanical autocorrelation. This has implications for IC\n",
+    "estimation (requires HAC adjustment) and purge gap sizing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a91d34ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.127232Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.127145Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.131489Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.131100Z"
+    },
+    "papermill": {
+     "duration": 0.00592,
+     "end_time": "2026-03-24T01:49:44.131739+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.125819+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Label autocorrelation (SPY fwd_ret_21d):\n",
+      "  Lag  1: 0.934\n",
+      "  Lag  5: 0.727\n",
+      "  Lag 21: -0.059\n"
+     ]
+    }
+   ],
+   "source": [
+    "spy_labels = labels_df.filter(pl.col(\"symbol\") == \"SPY\").sort(\"timestamp\")\n",
+    "spy_ret21 = spy_labels[\"fwd_ret_21d\"].drop_nulls().to_numpy()\n",
+    "\n",
+    "acf_lags = [1, 5, 21]\n",
+    "print(\"Label autocorrelation (SPY fwd_ret_21d):\")\n",
+    "for lag in acf_lags:\n",
+    "    if len(spy_ret21) > lag:\n",
+    "        acf_val = np.corrcoef(spy_ret21[lag:], spy_ret21[:-lag])[0, 1]\n",
+    "        print(f\"  Lag {lag:2d}: {acf_val:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ae49a95",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001068,
+     "end_time": "2026-03-24T01:49:44.133844+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.132776+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Baseline IC: Raw Momentum vs Labels\n",
+    "\n",
+    "Before feature engineering, we establish baseline signal quality.\n",
+    "The IC of raw 126-day momentum against each label type sets the bar\n",
+    "that engineered features must clear."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b8bf0165",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.136255Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.136167Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.213510Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.213084Z"
+    },
+    "papermill": {
+     "duration": 0.079083,
+     "end_time": "2026-03-24T01:49:44.213913+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.134830+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline IC (raw 126d momentum):\n",
+      "  vs fwd_ret_21d: mean=0.0237, t-stat=5.02\n",
+      "  vs fwd_ret_5d:  mean=0.0224, t-stat=4.54\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute raw 126d momentum as baseline signal\n",
+    "baseline_df = labels_df.with_columns(\n",
+    "    (pl.col(\"close\") / pl.col(\"close\").shift(126).over(\"symbol\") - 1).alias(\"raw_mom_126d\")\n",
+    ").drop_nulls(subset=[\"raw_mom_126d\", \"fwd_ret_21d\"])\n",
+    "\n",
+    "\n",
+    "# IC = rank correlation between signal and label\n",
+    "def compute_ic_by_date(df: pl.DataFrame, signal_col: str, label_col: str) -> pl.DataFrame:\n",
+    "    \"\"\"Compute cross-sectional rank IC at each date.\"\"\"\n",
+    "    # Rank both signal and label within each date\n",
+    "    ranked = df.with_columns(\n",
+    "        pl.col(signal_col).rank().over(\"timestamp\").alias(\"_signal_rank\"),\n",
+    "        pl.col(label_col).rank().over(\"timestamp\").alias(\"_label_rank\"),\n",
+    "    )\n",
+    "\n",
+    "    # Pearson correlation of ranks = Spearman IC\n",
+    "    ic_by_date = (\n",
+    "        ranked.group_by(\"timestamp\")\n",
+    "        .agg(\n",
+    "            pl.corr(\"_signal_rank\", \"_label_rank\").alias(\"ic\"),\n",
+    "            pl.len().alias(\"n\"),\n",
+    "        )\n",
+    "        .filter(pl.col(\"n\") >= 20)  # Need sufficient cross-section for reliable IC\n",
+    "        .sort(\"timestamp\")\n",
+    "    )\n",
+    "    return ic_by_date\n",
+    "\n",
+    "\n",
+    "ic_21d = compute_ic_by_date(baseline_df, \"raw_mom_126d\", \"fwd_ret_21d\")\n",
+    "\n",
+    "# Also compute for 5d label\n",
+    "baseline_5d = labels_df.with_columns(\n",
+    "    (pl.col(\"close\") / pl.col(\"close\").shift(126).over(\"symbol\") - 1).alias(\"raw_mom_126d\")\n",
+    ").drop_nulls(subset=[\"raw_mom_126d\", \"fwd_ret_5d\"])\n",
+    "ic_5d = compute_ic_by_date(baseline_5d, \"raw_mom_126d\", \"fwd_ret_5d\")\n",
+    "\n",
+    "ic_21d_mean = as_float(ic_21d[\"ic\"].mean()) if len(ic_21d) > 0 else None\n",
+    "ic_5d_mean = as_float(ic_5d[\"ic\"].mean()) if len(ic_5d) > 0 else None\n",
+    "\n",
+    "\n",
+    "def _fmt_ic(mean, ic_series):\n",
+    "    if mean is None or len(ic_series) == 0:\n",
+    "        return \"N/A (insufficient cross-section)\"\n",
+    "    t = mean / (ic_series.std() / np.sqrt(len(ic_series)))\n",
+    "    return f\"mean={mean:.4f}, t-stat={t:.2f}\"\n",
+    "\n",
+    "\n",
+    "print(\"Baseline IC (raw 126d momentum):\")\n",
+    "print(f\"  vs fwd_ret_21d: {_fmt_ic(ic_21d_mean, ic_21d['ic'])}\")\n",
+    "print(f\"  vs fwd_ret_5d:  {_fmt_ic(ic_5d_mean, ic_5d['ic'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c6a613f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001021,
+     "end_time": "2026-03-24T01:49:44.216148+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.215127+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Interpretation**: The baseline IC sets expectations for downstream feature\n",
+    "engineering. The IC range for 126-day momentum against monthly returns is\n",
+    "consistent with the cross-asset momentum literature (Moskowitz, Ooi, and\n",
+    "Pedersen 2012). The 5-day label IC helps assess whether weekly rebalancing\n",
+    "could improve signal capture despite higher turnover costs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d16fe25e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00095,
+     "end_time": "2026-03-24T01:49:44.218094+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.217144+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Save Artifacts\n",
+    "\n",
+    "Outputs:\n",
+    "- `labels/fwd_ret_21d.parquet` -- Primary regression label\n",
+    "- `labels/fwd_ret_5d.parquet` -- Variant regression label\n",
+    "- `cv_config.json` -- Walk-forward CV configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e3863016",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T01:49:44.220466Z",
+     "iopub.status.busy": "2026-03-24T01:49:44.220387Z",
+     "iopub.status.idle": "2026-03-24T01:49:44.257469Z",
+     "shell.execute_reply": "2026-03-24T01:49:44.256911Z"
+    },
+    "lines_to_next_cell": 0,
+    "papermill": {
+     "duration": 0.038873,
+     "end_time": "2026-03-24T01:49:44.257949+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.219076+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved labels/fwd_ret_21d.parquet, labels/fwd_ret_5d.parquet\n",
+      "Saved cv_config.json (n_splits=8)\n"
+     ]
+    }
+   ],
+   "source": [
+    "labels_out = labels_df\n",
+    "label_keys = [\"timestamp\", \"symbol\"]\n",
+    "\n",
+    "LABELS_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "# Regression labels\n",
+    "labels_out.select(label_keys + [\"fwd_ret_21d\"]).drop_nulls().write_parquet(\n",
+    "    LABELS_DIR / \"fwd_ret_21d.parquet\"\n",
+    ")\n",
+    "labels_out.select(label_keys + [\"fwd_ret_5d\"]).drop_nulls().write_parquet(\n",
+    "    LABELS_DIR / \"fwd_ret_5d.parquet\"\n",
+    ")\n",
+    "print(\"Saved labels/fwd_ret_21d.parquet, labels/fwd_ret_5d.parquet\")\n",
+    "\n",
+    "# CV config\n",
+    "cv_config = get_cv_config(\"etfs\")\n",
+    "cv_config.to_json(CASE_DIR / \"config\" / \"cv_config.json\")\n",
+    "print(f\"Saved cv_config.json (n_splits={cv_config.n_splits})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0c4884e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001997,
+     "end_time": "2026-03-24T01:49:44.261695+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.259698+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Results Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdefb89d",
+   "metadata": {
+    "lines_to_next_cell": 0,
+    "papermill": {
+     "duration": 0.001841,
+     "end_time": "2026-03-24T01:49:44.265713+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.263872+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f098c638",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001293,
+     "end_time": "2026-03-24T01:49:44.268587+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T01:49:44.267294+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **Two regression horizons** (21d primary, 5d variant) enable horizon\n",
+    "   sensitivity analysis: if IC is higher at 5d, weekly rebalancing may\n",
+    "   improve signal capture despite higher costs\n",
+    "2. **Baseline IC** of raw 126d momentum establishes the bar for Ch8 features\n",
+    "3. **CV config** saved from `setup.yaml` ensures downstream chapters use\n",
+    "   identical walk-forward splits\n",
+    "\n",
+    "**Next**: `03_financial_features.py` builds engineered features and evaluates them\n",
+    "against these labels."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.377546,
+   "end_time": "2026-03-24T01:49:45.187651+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/etfs/02_labels.ipynb",
+   "output_path": "/tmp/ml4t_3987651_02_labels.ipynb",
+   "parameters": {
+    "MAX_SYMBOLS": 5,
+    "START_DATE": "2024-06-01"
+   },
+   "start_time": "2026-03-24T01:49:41.810105+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/case_studies/etfs/02_labels.py
+++ b/case_studies/etfs/02_labels.py
@@ -1,0 +1,277 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # ETFs: Label Engineering
+#
+# This notebook implements label engineering for the ETFs case study.
+# Labels encode the economic hypothesis: can risk-adjusted momentum predict
+# forward returns across a multi-asset ETF universe?
+#
+# ## Learning Objectives
+#
+# - Compute regression labels at 21-day (primary) and 5-day (variant) horizons
+# - Construct cross-sectional quintile labels for relative ranking prediction
+# - Filter to eligible ETFs before computing quintiles (point-in-time)
+# - Evaluate label quality: class balance, IC of raw momentum baseline
+# - Generate walk-forward CV configuration from `setup.yaml`
+#
+# ## Book Reference
+#
+# Chapter 7, Section 7.2 (Label Engineering)
+#
+# ## Prerequisites
+#
+# - [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) must have been run (produces `eligibility.csv`)
+# - ETF data available via `load_etfs()`
+
+# %%
+"""ETFs: Label Engineering."""
+
+import warnings
+
+import numpy as np
+import polars as pl
+
+from data import load_etfs
+from utils.modeling import get_cv_config
+from utils.paths import get_case_study_dir
+
+warnings.filterwarnings("ignore")
+
+CASE_DIR = get_case_study_dir("etfs")
+LABELS_DIR = CASE_DIR / "labels"
+
+
+def as_float(value: object | None) -> float | None:
+    """Convert Polars scalar outputs to plain float for summaries."""
+    if value is None:
+        return None
+    return float(str(value))
+
+
+# %%
+# Production defaults — Papermill injects overrides for CI
+
+# %% [markdown]
+# ## 1. Load Data
+#
+# Load ETF prices and point-in-time eligibility. The eligibility table
+# ensures quintile labels are computed only on ETFs that were tradable at
+# each decision date, avoiding inflation of the cross-section breadth
+# in early years.
+
+# %%
+prices = (
+    load_etfs()
+    .select(["symbol", "timestamp", "open", "high", "low", "close", "volume"])
+    .sort(["symbol", "timestamp"])
+)
+
+# Load eligibility table from 01_feasibility_analysis.py
+eligibility = pl.read_csv(CASE_DIR / "eligibility.csv")
+
+n_assets = prices["symbol"].n_unique()
+date_range = f"{prices['timestamp'].min()} to {prices['timestamp'].max()}"
+print(f"ETF Universe: {n_assets} assets, {len(prices):,} rows")
+print(f"Date range: {date_range}")
+print(f"Eligibility: {len(eligibility):,} (asset, year) pairs")
+
+# %% [markdown]
+# **Note**: The `close` column from `load_etfs()` is adjusted for splits and
+# dividends (verified in [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) via SPY 2006 price level check).
+
+# %% [markdown]
+# ## 2. Label Functions
+#
+# Two label types:
+#
+# 1. **Regression** (`fwd_ret_Nd`): Simple forward return over $N$ trading days.
+#    Non-overlapping at monthly cadence avoids serial correlation in targets.
+#
+# 2. **Quintile classification** (`fwd_quintile_Nd`): Cross-sectional quintile of
+#    forward returns. Ranks ETFs relative to peers at each date. Computed only
+#    on eligible ETFs to keep quintile boundaries meaningful.
+
+
+# %%
+def create_regression_labels(df: pl.DataFrame, horizon: int = 21) -> pl.DataFrame:
+    """Create forward return labels for regression.
+
+    Uses close-to-close returns shifted forward by `horizon` trading days.
+    """
+    return df.with_columns(
+        (pl.col("close").shift(-horizon).over("symbol") / pl.col("close") - 1).alias(
+            f"fwd_ret_{horizon}d"
+        )
+    )
+
+
+# %% [markdown]
+# ## 3. Apply Labels
+#
+# We compute two label types:
+# - `fwd_ret_21d`: Primary regression label (matches monthly rebalancing)
+# - `fwd_ret_5d`: Variant regression label (tests weekly horizon)
+
+# %%
+labels_df = prices.sort(["symbol", "timestamp"])
+
+# Regression labels at two horizons
+labels_df = create_regression_labels(labels_df, horizon=21)
+labels_df = create_regression_labels(labels_df, horizon=5)
+print("Created regression labels: fwd_ret_21d, fwd_ret_5d")
+
+# %% [markdown]
+# ## 4. Label Distribution Summary
+
+# %%
+# Regression 21d
+ret21 = labels_df.select("fwd_ret_21d").drop_nulls()
+print(f"Regression (fwd_ret_21d): {len(ret21):,} samples")
+print(f"  Mean: {ret21['fwd_ret_21d'].mean():.4f}, Std: {ret21['fwd_ret_21d'].std():.4f}")
+
+# Regression 5d
+ret5 = labels_df.select("fwd_ret_5d").drop_nulls()
+print(f"\nRegression (fwd_ret_5d): {len(ret5):,} samples")
+print(f"  Mean: {ret5['fwd_ret_5d'].mean():.4f}, Std: {ret5['fwd_ret_5d'].std():.4f}")
+
+# %% [markdown]
+# ### Label Autocorrelation
+#
+# With daily labels at a 21-day horizon, consecutive labels overlap by 20 days,
+# creating strong mechanical autocorrelation. This has implications for IC
+# estimation (requires HAC adjustment) and purge gap sizing.
+
+# %%
+spy_labels = labels_df.filter(pl.col("symbol") == "SPY").sort("timestamp")
+spy_ret21 = spy_labels["fwd_ret_21d"].drop_nulls().to_numpy()
+
+acf_lags = [1, 5, 21]
+print("Label autocorrelation (SPY fwd_ret_21d):")
+for lag in acf_lags:
+    if len(spy_ret21) > lag:
+        acf_val = np.corrcoef(spy_ret21[lag:], spy_ret21[:-lag])[0, 1]
+        print(f"  Lag {lag:2d}: {acf_val:.3f}")
+
+# %% [markdown]
+# ## 5. Baseline IC: Raw Momentum vs Labels
+#
+# Before feature engineering, we establish baseline signal quality.
+# The IC of raw 126-day momentum against each label type sets the bar
+# that engineered features must clear.
+
+# %%
+# Compute raw 126d momentum as baseline signal
+baseline_df = labels_df.with_columns(
+    (pl.col("close") / pl.col("close").shift(126).over("symbol") - 1).alias("raw_mom_126d")
+).drop_nulls(subset=["raw_mom_126d", "fwd_ret_21d"])
+
+
+# IC = rank correlation between signal and label
+def compute_ic_by_date(df: pl.DataFrame, signal_col: str, label_col: str) -> pl.DataFrame:
+    """Compute cross-sectional rank IC at each date."""
+    # Rank both signal and label within each date
+    ranked = df.with_columns(
+        pl.col(signal_col).rank().over("timestamp").alias("_signal_rank"),
+        pl.col(label_col).rank().over("timestamp").alias("_label_rank"),
+    )
+
+    # Pearson correlation of ranks = Spearman IC
+    ic_by_date = (
+        ranked.group_by("timestamp")
+        .agg(
+            pl.corr("_signal_rank", "_label_rank").alias("ic"),
+            pl.len().alias("n"),
+        )
+        .filter(pl.col("n") >= 20)  # Need sufficient cross-section for reliable IC
+        .sort("timestamp")
+    )
+    return ic_by_date
+
+
+ic_21d = compute_ic_by_date(baseline_df, "raw_mom_126d", "fwd_ret_21d")
+
+# Also compute for 5d label
+baseline_5d = labels_df.with_columns(
+    (pl.col("close") / pl.col("close").shift(126).over("symbol") - 1).alias("raw_mom_126d")
+).drop_nulls(subset=["raw_mom_126d", "fwd_ret_5d"])
+ic_5d = compute_ic_by_date(baseline_5d, "raw_mom_126d", "fwd_ret_5d")
+
+ic_21d_mean = as_float(ic_21d["ic"].mean()) if len(ic_21d) > 0 else None
+ic_5d_mean = as_float(ic_5d["ic"].mean()) if len(ic_5d) > 0 else None
+
+
+def _fmt_ic(mean, ic_series):
+    if mean is None or len(ic_series) == 0:
+        return "N/A (insufficient cross-section)"
+    t = mean / (ic_series.std() / np.sqrt(len(ic_series)))
+    return f"mean={mean:.4f}, t-stat={t:.2f}"
+
+
+print("Baseline IC (raw 126d momentum):")
+print(f"  vs fwd_ret_21d: {_fmt_ic(ic_21d_mean, ic_21d['ic'])}")
+print(f"  vs fwd_ret_5d:  {_fmt_ic(ic_5d_mean, ic_5d['ic'])}")
+
+# %% [markdown]
+# **Interpretation**: The baseline IC sets expectations for downstream feature
+# engineering. The IC range for 126-day momentum against monthly returns is
+# consistent with the cross-asset momentum literature (Moskowitz, Ooi, and
+# Pedersen 2012). The 5-day label IC helps assess whether weekly rebalancing
+# could improve signal capture despite higher turnover costs.
+
+# %% [markdown]
+# ## 6. Save Artifacts
+#
+# Outputs:
+# - `labels/fwd_ret_21d.parquet` -- Primary regression label
+# - `labels/fwd_ret_5d.parquet` -- Variant regression label
+# - `cv_config.json` -- Walk-forward CV configuration
+
+# %%
+labels_out = labels_df
+label_keys = ["timestamp", "symbol"]
+
+LABELS_DIR.mkdir(parents=True, exist_ok=True)
+
+# Regression labels
+labels_out.select(label_keys + ["fwd_ret_21d"]).drop_nulls().write_parquet(
+    LABELS_DIR / "fwd_ret_21d.parquet"
+)
+labels_out.select(label_keys + ["fwd_ret_5d"]).drop_nulls().write_parquet(
+    LABELS_DIR / "fwd_ret_5d.parquet"
+)
+print("Saved labels/fwd_ret_21d.parquet, labels/fwd_ret_5d.parquet")
+
+# CV config
+cv_config = get_cv_config("etfs")
+cv_config.to_json(CASE_DIR / "config" / "cv_config.json")
+print(f"Saved cv_config.json (n_splits={cv_config.n_splits})")
+# %% [markdown]
+# ## 7. Results Collection
+
+# %%
+# %% [markdown]
+# ## Key Takeaways
+#
+# 1. **Two regression horizons** (21d primary, 5d variant) enable horizon
+#    sensitivity analysis: if IC is higher at 5d, weekly rebalancing may
+#    improve signal capture despite higher costs
+# 2. **Baseline IC** of raw 126d momentum establishes the bar for Ch8 features
+# 3. **CV config** saved from `setup.yaml` ensures downstream chapters use
+#    identical walk-forward splits
+#
+# **Next**: `03_financial_features.py` builds engineered features and evaluates them
+# against these labels.

--- a/case_studies/etfs/03_financial_features.ipynb
+++ b/case_studies/etfs/03_financial_features.ipynb
@@ -1,0 +1,5143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "19ddb599",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001881,
+     "end_time": "2026-03-24T02:22:15.050003+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:15.048122+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# ETFs: Feature Engineering\n",
+    "\n",
+    "This notebook implements feature engineering for the ETFs case study.\n",
+    "Features are organized around the core hypothesis: cross-asset momentum\n",
+    "combined with regime conditioning.\n",
+    "\n",
+    "## Learning Objectives\n",
+    "\n",
+    "- Compute risk-adjusted momentum scores including skip-recent (12-1)\n",
+    "- Construct cross-sectional ranks for primary horizon features only\n",
+    "- Implement regime indicators (yield curve slope, SPY-TLT correlation)\n",
+    "- Enforce point-in-time eligibility on the feature matrix\n",
+    "- Diagnose feature quality via autocorrelation and rank stability\n",
+    "\n",
+    "## Book Reference\n",
+    "\n",
+    "Chapter 8, Section 8.2 (Price-Derived Features)\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) (produces `eligibility.csv`)\n",
+    "- [`02_labels`](02_labels.ipynb) (produces label parquet files and `config/cv_config.json`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f87a91de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:21.955441Z",
+     "iopub.status.busy": "2026-04-09T01:05:21.955324Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.427490Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.426792Z"
+    },
+    "papermill": {
+     "duration": 1.298855,
+     "end_time": "2026-03-24T02:22:16.350759+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:15.051904+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ".venv/lib/python3.14/site-packages/ml4t/engineer/features/ml/__init__.py:9: UserWarning: Feature 'cyclical_encode': lookback=0 but has period/window parameter. Consider using lookback='period' or specifying the actual lookback.\n",
+      "  from ml4t.engineer.features.ml.cyclical_encode import *  # noqa: F403\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"ETFs: Feature Engineering.\"\"\"\n",
+    "\n",
+    "import itertools\n",
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "import polars as pl\n",
+    "from ml4t.diagnostic.evaluation.stats import benjamini_hochberg_fdr\n",
+    "from ml4t.diagnostic.metrics import compute_ic_hac_stats\n",
+    "from ml4t.engineer.features.momentum import adx, aroon, cci, macd, rsi, stochastic\n",
+    "from ml4t.engineer.features.regime import choppiness_index, hurst_exponent\n",
+    "from ml4t.engineer.features.trend import ema, sma\n",
+    "from ml4t.engineer.features.volatility import natr\n",
+    "from ml4t.engineer.features.volume import obv\n",
+    "from scipy.stats import spearmanr\n",
+    "\n",
+    "from data import load_etfs, load_macro\n",
+    "from utils.paths import get_case_study_dir\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "CASE_DIR = get_case_study_dir(\"etfs\")\n",
+    "FEATURES_DIR = CASE_DIR / \"features\"\n",
+    "\n",
+    "NUMERIC_DTYPES = {\n",
+    "    pl.Boolean,\n",
+    "    pl.Int8,\n",
+    "    pl.Int16,\n",
+    "    pl.Int32,\n",
+    "    pl.Int64,\n",
+    "    pl.UInt8,\n",
+    "    pl.UInt16,\n",
+    "    pl.UInt32,\n",
+    "    pl.UInt64,\n",
+    "    pl.Float32,\n",
+    "    pl.Float64,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def as_float(value: object | None) -> float | None:\n",
+    "    \"\"\"Convert Polars scalar outputs to plain float for plotting.\"\"\"\n",
+    "    if value is None:\n",
+    "        return None\n",
+    "    return float(str(value))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8bc23671",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Production defaults — Papermill injects overrides for CI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b37bcab6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001972,
+     "end_time": "2026-03-24T02:22:16.354869+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.352897+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ad5f486f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.429520Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.429371Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.432107Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.431401Z"
+    },
+    "papermill": {
+     "duration": 0.004421,
+     "end_time": "2026-03-24T02:22:16.361222+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.356801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Feature parameters\n",
+    "REGIME_THRESHOLD = 0.005  # 0.5% yield curve slope\n",
+    "\n",
+    "# Multi-horizon lookback periods (trading days)\n",
+    "MOMENTUM_HORIZONS = [5, 10, 21, 42, 63, 126, 189, 252]\n",
+    "VOLATILITY_HORIZONS = [21, 63, 126, 252]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9af2ae73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001888,
+     "end_time": "2026-03-24T02:22:16.365050+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.363162+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "02f6d515",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.433347Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.433262Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.513795Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.513060Z"
+    },
+    "papermill": {
+     "duration": 0.056674,
+     "end_time": "2026-03-24T02:22:16.423617+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.366943+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ETF Universe: 100 assets, 470,662 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "prices = (\n",
+    "    load_etfs()\n",
+    "    .select([\"symbol\", \"timestamp\", \"open\", \"high\", \"low\", \"close\", \"volume\"])\n",
+    "    .sort([\"symbol\", \"timestamp\"])\n",
+    ")\n",
+    "\n",
+    "# Load eligibility for PIT filtering\n",
+    "eligibility = pl.read_csv(CASE_DIR / \"eligibility.csv\")\n",
+    "if \"symbol\" in eligibility.columns and \"symbol\" not in eligibility.columns:\n",
+    "    eligibility = eligibility\n",
+    "\n",
+    "assets_list = sorted(prices[\"symbol\"].unique().to_list())\n",
+    "n_assets = prices[\"symbol\"].n_unique()\n",
+    "print(f\"ETF Universe: {n_assets} assets, {len(prices):,} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "147971b6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00322,
+     "end_time": "2026-03-24T02:22:16.430720+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.427500+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Yield Curve Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cfc407ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.515459Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.515299Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.540412Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.539621Z"
+    },
+    "papermill": {
+     "duration": 0.008419,
+     "end_time": "2026-03-24T02:22:16.441472+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.433053+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yield curve data: 9,495 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "macro_data = load_macro()\n",
+    "\n",
+    "# Compute yield curve slope from dgs10 and dgs2\n",
+    "yield_curve = (\n",
+    "    macro_data.select([\"timestamp\", \"dgs10\", \"dgs2\"])\n",
+    "    .with_columns(\n",
+    "        (pl.col(\"dgs10\") / 100).alias(\"yield_10y\"),\n",
+    "        (pl.col(\"dgs2\") / 100).alias(\"yield_2y\"),\n",
+    "        ((pl.col(\"dgs10\") - pl.col(\"dgs2\")) / 100).alias(\"slope\"),\n",
+    "    )\n",
+    "    .select([\"timestamp\", \"yield_10y\", \"yield_2y\", \"slope\"])\n",
+    "    .drop_nulls()\n",
+    "    .sort(\"timestamp\")\n",
+    ")\n",
+    "\n",
+    "print(f\"Yield curve data: {len(yield_curve):,} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "649dc630",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001949,
+     "end_time": "2026-03-24T02:22:16.445564+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.443615+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Feature Engineering\n",
+    "\n",
+    "Features are organized into focused families aligned with the momentum +\n",
+    "regime hypothesis. We avoid feature inflation by ranking only primary\n",
+    "horizons and keeping a curated set of MA ratios."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "392bf438",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001932,
+     "end_time": "2026-03-24T02:22:16.449458+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.447526+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.1 Momentum and Returns\n",
+    "\n",
+    "Multi-horizon raw returns, skip-recent momentum (12-1 and 6-1), risk-adjusted\n",
+    "momentum (Sharpe-like), and momentum acceleration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1c6ddc96",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.541949Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.541798Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.547268Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.546629Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005976,
+     "end_time": "2026-03-24T02:22:16.457392+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.451416+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_momentum_features(df: pl.DataFrame) -> pl.DataFrame:\n",
+    "    \"\"\"Momentum, volatility, and risk-adjusted returns.\"\"\"\n",
+    "    df = df.sort([\"symbol\", \"timestamp\"])\n",
+    "\n",
+    "    # Multi-horizon raw returns (clip(1e-8) guards against div-by-zero → inf)\n",
+    "    momentum_cols = [\n",
+    "        (\n",
+    "            pl.col(\"close\") / pl.col(\"close\").shift(h).over(\"symbol\").clip(lower_bound=1e-8) - 1\n",
+    "        ).alias(f\"ret_{h}d\")\n",
+    "        for h in MOMENTUM_HORIZONS\n",
+    "    ]\n",
+    "    df = df.with_columns(momentum_cols)\n",
+    "\n",
+    "    # Skip-recent momentum (Jegadeesh and Titman 1993)\n",
+    "    # 12-1: 252d return excluding most recent 21d\n",
+    "    # 6-1: 126d return excluding most recent 21d\n",
+    "    df = df.with_columns(\n",
+    "        (pl.col(\"ret_252d\") - pl.col(\"ret_21d\")).alias(\"skip_recent_12_1\"),\n",
+    "        (pl.col(\"ret_126d\") - pl.col(\"ret_21d\")).alias(\"skip_recent_6_1\"),\n",
+    "    )\n",
+    "\n",
+    "    # Log returns for volatility\n",
+    "    df = df.with_columns(pl.col(\"close\").log().diff().over(\"symbol\").alias(\"log_return\"))\n",
+    "\n",
+    "    # Multi-horizon volatility (annualized)\n",
+    "    volatility_cols = [\n",
+    "        pl.col(\"log_return\").rolling_std(h).over(\"symbol\").mul(np.sqrt(252)).alias(f\"vol_{h}d\")\n",
+    "        for h in VOLATILITY_HORIZONS\n",
+    "    ]\n",
+    "    df = df.with_columns(volatility_cols)\n",
+    "\n",
+    "    # Volatility-adjusted momentum (Sharpe-like)\n",
+    "    sharpe_cols = [\n",
+    "        (\n",
+    "            pl.col(\"log_return\").rolling_sum(h).over(\"symbol\")\n",
+    "            / pl.col(\"log_return\").rolling_std(h).over(\"symbol\")\n",
+    "            * np.sqrt(252 / h)\n",
+    "        ).alias(f\"sharpe_{h}d\")\n",
+    "        for h in MOMENTUM_HORIZONS\n",
+    "    ]\n",
+    "    df = df.with_columns(sharpe_cols)\n",
+    "\n",
+    "    # Momentum acceleration\n",
+    "    df = df.with_columns(\n",
+    "        (pl.col(\"ret_21d\") - pl.col(\"ret_63d\")).alias(\"mom_accel_short\"),\n",
+    "        (pl.col(\"ret_63d\") - pl.col(\"ret_126d\")).alias(\"mom_accel_medium\"),\n",
+    "        (pl.col(\"ret_126d\") - pl.col(\"ret_252d\")).alias(\"mom_accel_long\"),\n",
+    "    )\n",
+    "\n",
+    "    # Volatility ratios (short/long)\n",
+    "    df = df.with_columns(\n",
+    "        (pl.col(\"vol_21d\") / pl.col(\"vol_63d\")).alias(\"vol_ratio_short\"),\n",
+    "        (pl.col(\"vol_63d\") / pl.col(\"vol_126d\")).alias(\"vol_ratio_medium\"),\n",
+    "    )\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6ad44b8",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001973,
+     "end_time": "2026-03-24T02:22:16.461358+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.459385+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.2 Technical Indicators\n",
+    "\n",
+    "Curated set: oscillators (RSI, MACD, ADX, CCI, Stochastic, Aroon),\n",
+    "select MA ratios (SMA 50/200, EMA 26 only -- review recommended dropping\n",
+    "the rest), Bollinger %B, and NATR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d3e82b85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.548517Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.548419Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.552272Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.551785Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005628,
+     "end_time": "2026-03-24T02:22:16.468920+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.463292+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_technical_features(df: pl.DataFrame) -> pl.DataFrame:\n",
+    "    \"\"\"Technical indicators and trend features.\"\"\"\n",
+    "    # Oscillators\n",
+    "    df = df.with_columns(\n",
+    "        rsi(\"close\", period=7).over(\"symbol\").alias(\"rsi_7\"),\n",
+    "        rsi(\"close\", period=14).over(\"symbol\").alias(\"rsi_14\"),\n",
+    "        macd(\"close\", fast_period=12, slow_period=26).over(\"symbol\").alias(\"macd_line\"),\n",
+    "        adx(\"high\", \"low\", \"close\", period=14).over(\"symbol\").alias(\"adx_14\"),\n",
+    "        cci(\"high\", \"low\", \"close\", period=14).over(\"symbol\").alias(\"cci_14\"),\n",
+    "        cci(\"high\", \"low\", \"close\", period=21).over(\"symbol\").alias(\"cci_21\"),\n",
+    "        stochastic(\"high\", \"low\", \"close\", fastk_period=14).over(\"symbol\").alias(\"stoch_k\"),\n",
+    "    )\n",
+    "\n",
+    "    # Aroon oscillator\n",
+    "    df = (\n",
+    "        df.with_columns(aroon(\"high\", \"low\", timeperiod=25).over(\"symbol\").alias(\"_aroon_struct\"))\n",
+    "        .with_columns(\n",
+    "            (\n",
+    "                pl.col(\"_aroon_struct\").struct.field(\"up\")\n",
+    "                - pl.col(\"_aroon_struct\").struct.field(\"down\")\n",
+    "            ).alias(\"aroon_diff\")\n",
+    "        )\n",
+    "        .drop(\"_aroon_struct\")\n",
+    "    )\n",
+    "\n",
+    "    # MA ratios -- curated set (SMA 50/200, EMA 26 only)\n",
+    "    df = df.with_columns(\n",
+    "        (pl.col(\"close\") / sma(\"close\", period=50).over(\"symbol\")).alias(\"sma_ratio_50\"),\n",
+    "        (pl.col(\"close\") / sma(\"close\", period=200).over(\"symbol\")).alias(\"sma_ratio_200\"),\n",
+    "        (pl.col(\"close\") / ema(\"close\", period=26).over(\"symbol\")).alias(\"ema_ratio_26\"),\n",
+    "    )\n",
+    "\n",
+    "    # Bollinger %B\n",
+    "    df = df.with_columns(\n",
+    "        pl.col(\"close\").rolling_mean(20).over(\"symbol\").alias(\"_bb_mid\"),\n",
+    "        pl.col(\"close\").rolling_std(20).over(\"symbol\").alias(\"_bb_std\"),\n",
+    "    )\n",
+    "    df = df.with_columns(\n",
+    "        (\n",
+    "            (pl.col(\"close\") - (pl.col(\"_bb_mid\") - 2 * pl.col(\"_bb_std\")))\n",
+    "            / (4 * pl.col(\"_bb_std\"))\n",
+    "        ).alias(\"bb_pctb_20\")\n",
+    "    ).drop([\"_bb_mid\", \"_bb_std\"])\n",
+    "\n",
+    "    # NATR\n",
+    "    df = df.with_columns(\n",
+    "        natr(\"high\", \"low\", \"close\", period=14).over(\"symbol\").alias(\"natr_14\"),\n",
+    "    )\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a52a50b8",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001923,
+     "end_time": "2026-03-24T02:22:16.472837+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.470914+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.3 Regime, Risk, Volume, and Distance Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9aa6c3e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.554544Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.553847Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.571376Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.570733Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.013025,
+     "end_time": "2026-03-24T02:22:16.487809+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.474784+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_regime_volume_features(df: pl.DataFrame) -> pl.DataFrame:\n",
+    "    \"\"\"Regime indicators, risk metrics, volume features, distance extremes.\"\"\"\n",
+    "    # Regime indicators\n",
+    "    df = df.with_columns(\n",
+    "        choppiness_index(\"high\", \"low\", \"close\", period=14).over(\"symbol\").alias(\"chop_14\"),\n",
+    "        hurst_exponent(\"close\", period=100).over(\"symbol\").alias(\"hurst_100\"),\n",
+    "    )\n",
+    "\n",
+    "    # Maximum drawdown\n",
+    "    df = df.with_columns(\n",
+    "        (\n",
+    "            (pl.col(\"close\") - pl.col(\"close\").rolling_max(63).over(\"symbol\"))\n",
+    "            / pl.col(\"close\").rolling_max(63).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"max_dd_63d\"),\n",
+    "        (\n",
+    "            (pl.col(\"close\") - pl.col(\"close\").rolling_max(126).over(\"symbol\"))\n",
+    "            / pl.col(\"close\").rolling_max(126).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"max_dd_126d\"),\n",
+    "    )\n",
+    "\n",
+    "    # Volume features (winsorize relative volume at 1st/99th)\n",
+    "    df = df.with_columns(\n",
+    "        (\n",
+    "            pl.col(\"volume\")\n",
+    "            / pl.col(\"volume\").rolling_mean(21).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"vol_ratio_21d_raw\"),\n",
+    "        (\n",
+    "            pl.col(\"volume\")\n",
+    "            / pl.col(\"volume\").rolling_mean(63).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"vol_ratio_63d_raw\"),\n",
+    "    )\n",
+    "    df = df.with_columns(\n",
+    "        pl.col(\"vol_ratio_21d_raw\")\n",
+    "        .clip(\n",
+    "            pl.col(\"vol_ratio_21d_raw\").quantile(0.01).over(\"timestamp\"),\n",
+    "            pl.col(\"vol_ratio_21d_raw\").quantile(0.99).over(\"timestamp\"),\n",
+    "        )\n",
+    "        .alias(\"vol_ratio_21d\"),\n",
+    "        pl.col(\"vol_ratio_63d_raw\")\n",
+    "        .clip(\n",
+    "            pl.col(\"vol_ratio_63d_raw\").quantile(0.01).over(\"timestamp\"),\n",
+    "            pl.col(\"vol_ratio_63d_raw\").quantile(0.99).over(\"timestamp\"),\n",
+    "        )\n",
+    "        .alias(\"vol_ratio_63d\"),\n",
+    "    ).drop([\"vol_ratio_21d_raw\", \"vol_ratio_63d_raw\"])\n",
+    "\n",
+    "    # OBV z-score\n",
+    "    df = df.with_columns(obv(\"close\", \"volume\").over(\"symbol\").alias(\"_obv\"))\n",
+    "    df = df.with_columns(\n",
+    "        (\n",
+    "            (pl.col(\"_obv\") - pl.col(\"_obv\").rolling_mean(63).over(\"symbol\"))\n",
+    "            / pl.col(\"_obv\").rolling_std(63).over(\"symbol\")\n",
+    "        ).alias(\"obv_zscore_63d\"),\n",
+    "    ).drop(\"_obv\")\n",
+    "\n",
+    "    # Consistency and distance from extremes\n",
+    "    df = df.with_columns(\n",
+    "        (pl.col(\"log_return\") > 0)\n",
+    "        .cast(pl.Float64)\n",
+    "        .rolling_mean(63)\n",
+    "        .over(\"symbol\")\n",
+    "        .alias(\"pct_positive_63d\"),\n",
+    "    )\n",
+    "    df = df.with_columns(\n",
+    "        (\n",
+    "            pl.col(\"close\") / pl.col(\"close\").rolling_max(252).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"dist_52w_high\"),\n",
+    "        (\n",
+    "            pl.col(\"close\") / pl.col(\"close\").rolling_min(252).over(\"symbol\").clip(lower_bound=1e-8)\n",
+    "        ).alias(\"dist_52w_low\"),\n",
+    "    )\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a606bcae",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.002031,
+     "end_time": "2026-03-24T02:22:16.492033+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.490002+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.4 Cross-Asset Correlation Feature\n",
+    "\n",
+    "Rolling 63-day correlation between SPY and TLT captures the equity-bond\n",
+    "relationship. When this flips from negative to positive, diversification\n",
+    "breaks down -- a valuable regime indicator for cross-asset rotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a2c502a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.572988Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.572885Z",
+     "iopub.status.idle": "2026-04-09T01:05:27.575817Z",
+     "shell.execute_reply": "2026-04-09T01:05:27.575252Z"
+    },
+    "papermill": {
+     "duration": 0.00474,
+     "end_time": "2026-03-24T02:22:16.498763+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.494023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_cross_asset_features(df: pl.DataFrame) -> pl.DataFrame:\n",
+    "    \"\"\"Compute cross-asset correlation features (SPY vs TLT).\"\"\"\n",
+    "    # Extract SPY and TLT log returns\n",
+    "    spy_ret = (\n",
+    "        df.filter(pl.col(\"symbol\") == \"SPY\")\n",
+    "        .select([\"timestamp\", \"log_return\"])\n",
+    "        .rename({\"log_return\": \"_spy_ret\"})\n",
+    "    )\n",
+    "    tlt_ret = (\n",
+    "        df.filter(pl.col(\"symbol\") == \"TLT\")\n",
+    "        .select([\"timestamp\", \"log_return\"])\n",
+    "        .rename({\"log_return\": \"_tlt_ret\"})\n",
+    "    )\n",
+    "\n",
+    "    # Join SPY and TLT returns on date\n",
+    "    corr_df = spy_ret.join(tlt_ret, on=\"timestamp\", how=\"inner\").sort(\"timestamp\")\n",
+    "\n",
+    "    # Rolling 63-day correlation\n",
+    "    corr_df = corr_df.with_columns(\n",
+    "        pl.rolling_corr(pl.col(\"_spy_ret\"), pl.col(\"_tlt_ret\"), window_size=63).alias(\n",
+    "            \"corr_spy_tlt_63d\"\n",
+    "        )\n",
+    "    ).select([\"timestamp\", \"corr_spy_tlt_63d\"])\n",
+    "\n",
+    "    # Broadcast to all assets\n",
+    "    return df.join(corr_df, on=\"timestamp\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78bd41a1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002089,
+     "end_time": "2026-03-24T02:22:16.502871+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.500782+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Apply All Feature Groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5b590e00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:05:27.576919Z",
+     "iopub.status.busy": "2026-04-09T01:05:27.576816Z",
+     "iopub.status.idle": "2026-04-09T01:06:26.774197Z",
+     "shell.execute_reply": "2026-04-09T01:06:26.773731Z"
+    },
+    "papermill": {
+     "duration": 27.939101,
+     "end_time": "2026-03-24T02:22:44.443963+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:16.504862+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2026-04-08 21:05:28 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2026-04-08 21:05:28 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape after feature computation: (470662, 59)\n"
+     ]
+    }
+   ],
+   "source": [
+    "features_raw = (\n",
+    "    prices.pipe(compute_momentum_features)\n",
+    "    .pipe(compute_technical_features)\n",
+    "    .pipe(compute_regime_volume_features)\n",
+    "    .pipe(compute_cross_asset_features)\n",
+    ")\n",
+    "\n",
+    "print(f\"Shape after feature computation: {features_raw.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "776ce437",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002104,
+     "end_time": "2026-03-24T02:22:44.448407+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.446303+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.5 Cross-Sectional Ranking\n",
+    "\n",
+    "Rank only the primary horizon features to avoid multicollinearity from\n",
+    "ranking every horizon. Three rank features: `ret_126d_rank`,\n",
+    "`sharpe_126d_rank`, `vol_63d_rank`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3a336db8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:26.775302Z",
+     "iopub.status.busy": "2026-04-09T01:06:26.775211Z",
+     "iopub.status.idle": "2026-04-09T01:06:26.840405Z",
+     "shell.execute_reply": "2026-04-09T01:06:26.839938Z"
+    },
+    "papermill": {
+     "duration": 0.042449,
+     "end_time": "2026-03-24T02:22:44.492914+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.450465+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Rank only primary features (review recommendation)\n",
+    "RANK_FEATURES = [\"ret_126d\", \"sharpe_126d\", \"vol_63d\"]\n",
+    "\n",
+    "rank_exprs = [\n",
+    "    (pl.col(col).rank().over(\"timestamp\") / pl.col(col).count().over(\"timestamp\")).alias(\n",
+    "        f\"{col}_rank\"\n",
+    "    )\n",
+    "    for col in RANK_FEATURES\n",
+    "]\n",
+    "features_raw = features_raw.with_columns(rank_exprs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55d2ebe8",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.003153,
+     "end_time": "2026-03-24T02:22:44.498703+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.495550+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.6 Regime Indicators\n",
+    "\n",
+    "Two regime features from the yield curve:\n",
+    "1. Binary regime (slope > 0.5%)\n",
+    "2. Continuous yield curve slope\n",
+    "3. Rolling z-score of slope (review recommendation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3a8fe789",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:26.841663Z",
+     "iopub.status.busy": "2026-04-09T01:06:26.841578Z",
+     "iopub.status.idle": "2026-04-09T01:06:26.916659Z",
+     "shell.execute_reply": "2026-04-09T01:06:26.916169Z"
+    },
+    "papermill": {
+     "duration": 0.052318,
+     "end_time": "2026-03-24T02:22:44.553789+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.501471+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regime Distribution: shape: (2, 2)\n",
+      "┌────────┬────────┐\n",
+      "│ regime ┆ count  │\n",
+      "│ ---    ┆ ---    │\n",
+      "│ i32    ┆ u32    │\n",
+      "╞════════╪════════╡\n",
+      "│ 0      ┆ 168549 │\n",
+      "│ 1      ┆ 302113 │\n",
+      "└────────┴────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "def add_regime_indicators(\n",
+    "    df: pl.DataFrame, yield_curve: pl.DataFrame, threshold: float = 0.005\n",
+    ") -> pl.DataFrame:\n",
+    "    \"\"\"Add regime indicators from yield curve data.\"\"\"\n",
+    "    regime_df = (\n",
+    "        yield_curve.with_columns(\n",
+    "            pl.when(pl.col(\"slope\") > threshold).then(1).otherwise(0).alias(\"regime\"),\n",
+    "            pl.col(\"slope\").alias(\"yield_curve_slope\"),\n",
+    "            # Rolling z-score of slope\n",
+    "            (\n",
+    "                (pl.col(\"slope\") - pl.col(\"slope\").rolling_mean(252))\n",
+    "                / pl.col(\"slope\").rolling_std(252)\n",
+    "            ).alias(\"yield_curve_zscore\"),\n",
+    "        )\n",
+    "        .select([\"timestamp\", \"regime\", \"yield_curve_slope\", \"yield_curve_zscore\"])\n",
+    "        .sort(\"timestamp\")\n",
+    "    )\n",
+    "\n",
+    "    return df.sort(\"timestamp\").join_asof(regime_df, on=\"timestamp\", strategy=\"backward\")\n",
+    "\n",
+    "\n",
+    "features_raw = add_regime_indicators(features_raw, yield_curve, threshold=REGIME_THRESHOLD)\n",
+    "\n",
+    "regime_dist = features_raw.group_by(\"regime\").agg(pl.len().alias(\"count\"))\n",
+    "print(\"Regime Distribution:\", regime_dist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b84e142f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002102,
+     "end_time": "2026-03-24T02:22:44.558246+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.556144+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.7 Point-in-Time Eligibility Filter\n",
+    "\n",
+    "Join features to eligibility.csv to ensure features are only kept for\n",
+    "ETFs that were tradable at each date. This prevents inflation of the\n",
+    "cross-section breadth in early years when fewer ETFs met the ADV threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "0a8ddc48",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:26.917749Z",
+     "iopub.status.busy": "2026-04-09T01:06:26.917597Z",
+     "iopub.status.idle": "2026-04-09T01:06:26.975502Z",
+     "shell.execute_reply": "2026-04-09T01:06:26.974974Z"
+    },
+    "papermill": {
+     "duration": 0.03723,
+     "end_time": "2026-03-24T02:22:44.597527+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.560297+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eligibility filter: 470,662 -> 396,186 rows (74,476 dropped)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add year for eligibility join\n",
+    "features_raw = features_raw.with_columns(pl.col(\"timestamp\").dt.year().alias(\"_year\"))\n",
+    "\n",
+    "elig_pairs = eligibility.select(\n",
+    "    pl.col(\"symbol\"),\n",
+    "    pl.col(\"eligible_year\").alias(\"_year\"),\n",
+    ")\n",
+    "\n",
+    "# Semi-join: keep only rows where (asset, year) exists in eligibility\n",
+    "features_eligible = features_raw.join(elig_pairs, on=[\"symbol\", \"_year\"], how=\"semi\").drop(\"_year\")\n",
+    "\n",
+    "n_dropped = len(features_raw) - len(features_eligible)\n",
+    "print(\n",
+    "    f\"Eligibility filter: {len(features_raw):,} -> {len(features_eligible):,} rows ({n_dropped:,} dropped)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e79a86b5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002133,
+     "end_time": "2026-03-24T02:22:44.601962+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.599829+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Prepare Final Feature Matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "82f958ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:26.977109Z",
+     "iopub.status.busy": "2026-04-09T01:06:26.976960Z",
+     "iopub.status.idle": "2026-04-09T01:06:27.075482Z",
+     "shell.execute_reply": "2026-04-09T01:06:27.074944Z"
+    },
+    "papermill": {
+     "duration": 0.053892,
+     "end_time": "2026-03-24T02:22:44.657918+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.604026+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No features with >5% missing after warmup drop\n",
+      "\n",
+      "Feature Summary\n",
+      "  Total features: 57\n",
+      "  Rows: 396,186\n",
+      "  Assets: 99\n",
+      "  Date range: 2007-01-03 to 2025-12-31\n",
+      "\n",
+      "Feature categories:\n",
+      "  Momentum (raw): 8\n",
+      "  Skip-recent: 2\n",
+      "  Sharpe: 8\n",
+      "  Volatility: 5\n",
+      "  Vol ratios: 4\n",
+      "  Technical: 8\n",
+      "  Trend (MA): 3\n",
+      "  Regime/macro: 6\n",
+      "  Risk (DD): 2\n",
+      "  Ranks: 3\n",
+      "  Other: 8\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Columns to exclude from feature set\n",
+    "exclude_cols = {\n",
+    "    \"timestamp\",\n",
+    "    \"symbol\",\n",
+    "    \"open\",\n",
+    "    \"high\",\n",
+    "    \"low\",\n",
+    "    \"close\",\n",
+    "    \"volume\",\n",
+    "    \"log_return\",\n",
+    "}\n",
+    "\n",
+    "feature_cols = [c for c in features_eligible.columns if c not in exclude_cols]\n",
+    "non_numeric_feature_cols = [\n",
+    "    c for c in feature_cols if features_eligible.schema[c] not in NUMERIC_DTYPES\n",
+    "]\n",
+    "feature_cols = [c for c in feature_cols if c not in non_numeric_feature_cols]\n",
+    "\n",
+    "assert \"log_return\" not in feature_cols, \"log_return must be excluded (contemporaneous with label)\"\n",
+    "unexpected_feature_keys = {\"timestamp\", \"symbol\"} & set(feature_cols)\n",
+    "assert not unexpected_feature_keys, (\n",
+    "    f\"Feature matrix leaked key columns: {sorted(unexpected_feature_keys)}\"\n",
+    ")\n",
+    "assert not non_numeric_feature_cols, (\n",
+    "    f\"Non-numeric columns leaked into features: {non_numeric_feature_cols}\"\n",
+    ")\n",
+    "required_core_features = {\n",
+    "    \"ret_21d\",\n",
+    "    \"sharpe_126d\",\n",
+    "    \"rsi_14\",\n",
+    "    \"ema_ratio_26\",\n",
+    "    \"yield_curve_slope\",\n",
+    "    \"corr_spy_tlt_63d\",\n",
+    "    \"max_dd_63d\",\n",
+    "}\n",
+    "missing_core_features = required_core_features - set(feature_cols)\n",
+    "assert not missing_core_features, f\"Missing core curated features: {sorted(missing_core_features)}\"\n",
+    "\n",
+    "# Prepare final DataFrame\n",
+    "features = (\n",
+    "    features_eligible.select([\"timestamp\", \"symbol\"] + feature_cols)\n",
+    "    .drop_nulls(subset=[\"sharpe_126d\"])  # Drop warmup rows\n",
+    "    .sort([\"timestamp\", \"symbol\"])\n",
+    ")\n",
+    "\n",
+    "# Missing values check\n",
+    "high_missing = [\n",
+    "    (c, features[c].null_count() / len(features))\n",
+    "    for c in feature_cols\n",
+    "    if features[c].null_count() / len(features) > 0.05\n",
+    "]\n",
+    "if high_missing:\n",
+    "    print(\"Features with >5% missing after warmup drop:\")\n",
+    "    for col, pct in high_missing:\n",
+    "        print(f\"  {col}: {pct:.1%}\")\n",
+    "else:\n",
+    "    print(\"No features with >5% missing after warmup drop\")\n",
+    "\n",
+    "print(\"\\nFeature Summary\")\n",
+    "print(f\"  Total features: {len(feature_cols)}\")\n",
+    "print(f\"  Rows: {len(features):,}\")\n",
+    "print(f\"  Assets: {features['symbol'].n_unique()}\")\n",
+    "print(f\"  Date range: {features['timestamp'].min()} to {features['timestamp'].max()}\")\n",
+    "\n",
+    "# Feature category counts\n",
+    "cats = {\n",
+    "    \"Momentum (raw)\": sum(\n",
+    "        1 for c in feature_cols if c.startswith(\"ret_\") and not c.endswith(\"_rank\")\n",
+    "    ),\n",
+    "    \"Skip-recent\": sum(1 for c in feature_cols if c.startswith(\"skip_\")),\n",
+    "    \"Sharpe\": sum(1 for c in feature_cols if c.startswith(\"sharpe_\") and not c.endswith(\"_rank\")),\n",
+    "    \"Volatility\": sum(\n",
+    "        1 for c in feature_cols if c.startswith(\"vol_\") and not c.startswith(\"vol_ratio\")\n",
+    "    ),\n",
+    "    \"Vol ratios\": sum(1 for c in feature_cols if c.startswith(\"vol_ratio\")),\n",
+    "    \"Technical\": sum(\n",
+    "        1\n",
+    "        for c in feature_cols\n",
+    "        if any(c.startswith(p) for p in [\"rsi_\", \"macd\", \"adx_\", \"cci_\", \"stoch_\", \"aroon\"])\n",
+    "    ),\n",
+    "    \"Trend (MA)\": sum(1 for c in feature_cols if any(c.startswith(p) for p in [\"sma_\", \"ema_\"])),\n",
+    "    \"Regime/macro\": sum(\n",
+    "        1\n",
+    "        for c in feature_cols\n",
+    "        if any(c.startswith(p) for p in [\"regime\", \"yield_\", \"chop_\", \"hurst_\", \"corr_spy\"])\n",
+    "    ),\n",
+    "    \"Risk (DD)\": sum(1 for c in feature_cols if c.startswith(\"max_dd\")),\n",
+    "    \"Ranks\": sum(1 for c in feature_cols if c.endswith(\"_rank\")),\n",
+    "    \"Other\": 0,  # computed below\n",
+    "}\n",
+    "accounted = sum(cats.values())\n",
+    "cats[\"Other\"] = len(feature_cols) - accounted\n",
+    "\n",
+    "print(\"\\nFeature categories:\")\n",
+    "for cat, count in cats.items():\n",
+    "    if count > 0:\n",
+    "        print(f\"  {cat}: {count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c771c6b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002123,
+     "end_time": "2026-03-24T02:22:44.662357+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.660234+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Feature Diagnostics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4e3d39b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002019,
+     "end_time": "2026-03-24T02:22:44.666449+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.664430+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.1 Autocorrelation (Signal Persistence)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "96c71dce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:27.077169Z",
+     "iopub.status.busy": "2026-04-09T01:06:27.077052Z",
+     "iopub.status.idle": "2026-04-09T01:06:27.639137Z",
+     "shell.execute_reply": "2026-04-09T01:06:27.638381Z"
+    },
+    "papermill": {
+     "duration": 0.410347,
+     "end_time": "2026-03-24T02:22:45.078863+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:44.668516+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6-Month Sharpe Autocorrelation:\n",
+      "shape: (3, 3)\n",
+      "┌─────┬──────────┬──────────┐\n",
+      "│ lag ┆ mean_acf ┆ std_acf  │\n",
+      "│ --- ┆ ---      ┆ ---      │\n",
+      "│ i64 ┆ f64      ┆ f64      │\n",
+      "╞═════╪══════════╪══════════╡\n",
+      "│ 1   ┆ 0.988964 ┆ 0.002837 │\n",
+      "│ 5   ┆ 0.946673 ┆ 0.013299 │\n",
+      "│ 21  ┆ 0.794334 ┆ 0.047909 │\n",
+      "└─────┴──────────┴──────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "acf_results = []\n",
+    "sample_assets = assets_list\n",
+    "for asset in sample_assets:\n",
+    "    scores = features.filter(pl.col(\"symbol\") == asset)[\"sharpe_126d\"].drop_nulls().to_numpy()\n",
+    "    for lag in [1, 5, 21]:\n",
+    "        if len(scores) > lag + 10:\n",
+    "            acf = np.corrcoef(scores[lag:], scores[:-lag])[0, 1]\n",
+    "            acf_results.append({\"symbol\": asset, \"lag\": lag, \"acf\": acf})\n",
+    "\n",
+    "acf_df = pl.DataFrame(acf_results)\n",
+    "acf_summary = acf_df.group_by(\"lag\").agg(\n",
+    "    pl.col(\"acf\").mean().alias(\"mean_acf\"),\n",
+    "    pl.col(\"acf\").std().alias(\"std_acf\"),\n",
+    ")\n",
+    "print(\"6-Month Sharpe Autocorrelation:\")\n",
+    "print(acf_summary.sort(\"lag\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19d65232",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002161,
+     "end_time": "2026-03-24T02:22:45.084067+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.081906+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.2 Rank Stability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cd3f5a80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:27.640456Z",
+     "iopub.status.busy": "2026-04-09T01:06:27.640361Z",
+     "iopub.status.idle": "2026-04-09T01:06:27.677955Z",
+     "shell.execute_reply": "2026-04-09T01:06:27.676778Z"
+    },
+    "papermill": {
+     "duration": 0.023201,
+     "end_time": "2026-03-24T02:22:45.109388+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.086187+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monthly rank persistence (correlation): 0.813\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly = (\n",
+    "    features.with_columns(pl.col(\"timestamp\").dt.truncate(\"1mo\").alias(\"month\"))\n",
+    "    .group_by([\"month\", \"symbol\"])\n",
+    "    .agg(pl.col(\"sharpe_126d_rank\").last().alias(\"rank_end\"))\n",
+    "    .sort([\"symbol\", \"month\"])\n",
+    "    .with_columns(pl.col(\"rank_end\").shift(1).over(\"symbol\").alias(\"rank_prev\"))\n",
+    "    .drop_nulls()\n",
+    ")\n",
+    "\n",
+    "rank_corr = np.corrcoef(monthly[\"rank_prev\"].to_numpy(), monthly[\"rank_end\"].to_numpy())[0, 1]\n",
+    "print(f\"Monthly rank persistence (correlation): {rank_corr:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d50196b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002282,
+     "end_time": "2026-03-24T02:22:45.114184+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.111902+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Save Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "e8de2b2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:27.679378Z",
+     "iopub.status.busy": "2026-04-09T01:06:27.679227Z",
+     "iopub.status.idle": "2026-04-09T01:06:27.966340Z",
+     "shell.execute_reply": "2026-04-09T01:06:27.965775Z"
+    },
+    "lines_to_next_cell": 0,
+    "papermill": {
+     "duration": 0.169856,
+     "end_time": "2026-03-24T02:22:45.286188+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.116332+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved 57 features to case_studies/etfs/features/financial.parquet\n",
+      "  396,186 rows, 99 assets\n"
+     ]
+    }
+   ],
+   "source": [
+    "FEATURES_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "features.write_parquet(FEATURES_DIR / \"financial.parquet\")\n",
+    "print(f\"Saved {len(feature_cols)} features to {FEATURES_DIR / 'financial.parquet'}\")\n",
+    "print(f\"  {len(features):,} rows, {features['symbol'].n_unique()} assets\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd48b04d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002936,
+     "end_time": "2026-03-24T02:22:45.291623+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.288687+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note on frequency**: The feature matrix is saved at daily frequency\n",
+    "(all trading days), while the decision cadence is monthly month-end.\n",
+    "This means ~21 rows per decision point. Features are saved daily for\n",
+    "flexibility (enabling weekly variant analysis), but downstream modeling\n",
+    "(Ch11+) should sample at the decision cadence. The IC evaluation below\n",
+    "uses all daily cross-sections with HAC adjustment for the resulting\n",
+    "autocorrelation in overlapping 21-day labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86498def",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002074,
+     "end_time": "2026-03-24T02:22:45.295925+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.293851+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Feature Evaluation\n",
+    "\n",
+    "We evaluate each feature's predictive power using cross-sectional Spearman IC\n",
+    "against 21-day forward returns. Two critical adjustments:\n",
+    "\n",
+    "- **HAC standard errors** (Newey-West): Overlapping 21-day returns create\n",
+    "  autocorrelated IC time series, inflating naive t-statistics\n",
+    "- **BH-FDR correction**: With 57 simultaneous tests, naive p-values overstate\n",
+    "  significance; we control the false discovery rate at 5%\n",
+    "\n",
+    "The cross-sectional IC on date $t$ is:\n",
+    "\n",
+    "$$IC_t = \\rho_S\\bigl(f_{t,i},\\; r_{t \\to t+21, i}\\bigr)$$\n",
+    "\n",
+    "where $f_{t,i}$ is the feature value for asset $i$ on date $t$.\n",
+    "\n",
+    "**Caveat**: This is a preliminary evaluation of financial features only.\n",
+    "The authoritative evaluation — covering both financial and temporal features\n",
+    "with consistent methodology — is in [`05_evaluation`](05_evaluation.ipynb). Results may differ\n",
+    "due to different feature sets and evaluation scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "024e6c65",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:27.967633Z",
+     "iopub.status.busy": "2026-04-09T01:06:27.967501Z",
+     "iopub.status.idle": "2026-04-09T01:06:28.071903Z",
+     "shell.execute_reply": "2026-04-09T01:06:28.067105Z"
+    },
+    "papermill": {
+     "duration": 0.055015,
+     "end_time": "2026-03-24T02:22:45.353061+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.298046+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evaluation set: 394,233 rows (4,759 dates x 99 assets)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load 21-day forward return labels\n",
+    "labels = pl.read_parquet(CASE_DIR / \"labels\" / \"fwd_ret_21d.parquet\")\n",
+    "label_col = \"fwd_ret_21d\"\n",
+    "\n",
+    "eval_df = features.join(\n",
+    "    labels.select([\"timestamp\", \"symbol\", label_col]), on=[\"timestamp\", \"symbol\"], how=\"inner\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Evaluation set: {len(eval_df):,} rows \"\n",
+    "    f\"({eval_df['timestamp'].n_unique():,} dates x {eval_df['symbol'].n_unique()} assets)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e121481f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00223,
+     "end_time": "2026-03-24T02:22:45.357902+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.355672+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Cross-Sectional IC with HAC Adjustment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ff45e482",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:06:28.079516Z",
+     "iopub.status.busy": "2026-04-09T01:06:28.079137Z",
+     "iopub.status.idle": "2026-04-09T01:07:51.740955Z",
+     "shell.execute_reply": "2026-04-09T01:07:51.740356Z"
+    },
+    "papermill": {
+     "duration": 57.733832,
+     "end_time": "2026-03-24T02:23:43.093871+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:22:45.360039+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computed IC stats for 53 features (4,759 dates)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute cross-sectional Spearman IC per feature per date\n",
+    "dates = eval_df[\"timestamp\"].unique().sort().to_list()\n",
+    "n_dates = len(dates)\n",
+    "ic_matrix = np.full((n_dates, len(feature_cols)), np.nan)\n",
+    "\n",
+    "for i, date_val in enumerate(dates):\n",
+    "    group = eval_df.filter(pl.col(\"timestamp\") == date_val)\n",
+    "    y = np.asarray(group[label_col].to_numpy(), dtype=float)\n",
+    "    valid_y = ~np.isnan(y)\n",
+    "    if valid_y.sum() < 10:\n",
+    "        continue\n",
+    "    for j, feat in enumerate(feature_cols):\n",
+    "        if group[feat].dtype not in NUMERIC_DTYPES:\n",
+    "            continue\n",
+    "        x = np.asarray(group[feat].to_numpy(), dtype=float)\n",
+    "        valid = valid_y & ~np.isnan(x)\n",
+    "        if valid.sum() >= 5:\n",
+    "            rho, _ = spearmanr(x[valid], y[valid])\n",
+    "            ic_matrix[i, j] = rho\n",
+    "\n",
+    "# Build per-feature HAC statistics\n",
+    "ic_stats = {}\n",
+    "for j, feat in enumerate(feature_cols):\n",
+    "    ic_series = ic_matrix[:, j]\n",
+    "    valid_ic = ic_series[~np.isnan(ic_series)]\n",
+    "    if len(valid_ic) < 30:\n",
+    "        continue\n",
+    "    stats = compute_ic_hac_stats(pl.DataFrame({\"ic\": valid_ic}), ic_col=\"ic\")\n",
+    "    ic_stats[feat] = stats\n",
+    "\n",
+    "print(f\"Computed IC stats for {len(ic_stats)} features ({n_dates:,} dates)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55a6ee75",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002255,
+     "end_time": "2026-03-24T02:23:43.107112+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:43.104857+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### BH-FDR Multiple Testing Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "4d0c906b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:51.741929Z",
+     "iopub.status.busy": "2026-04-09T01:07:51.741849Z",
+     "iopub.status.idle": "2026-04-09T01:07:51.745881Z",
+     "shell.execute_reply": "2026-04-09T01:07:51.745508Z"
+    },
+    "papermill": {
+     "duration": 0.007766,
+     "end_time": "2026-03-24T02:23:43.117012+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:43.109246+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Feature Evaluation Summary\n",
+      "  Features tested: 53\n",
+      "  Naive significant (p<0.05): 16\n",
+      "  FDR-significant (q<0.05): 13\n",
+      "  Inflation factor: 1.2x\n",
+      "\n",
+      "Top 10 by IC:\n",
+      "shape: (10, 7)\n",
+      "┌──────────────────┬──────────┬───────────┬─────────────┬───────────┬────────────┬─────────────────┐\n",
+      "│ feature          ┆ ic_mean  ┆ hac_tstat ┆ naive_tstat ┆ p_value   ┆ adjusted_p ┆ significant_fdr │\n",
+      "│ ---              ┆ ---      ┆ ---       ┆ ---         ┆ ---       ┆ ---        ┆ 05              │\n",
+      "│ str              ┆ f64      ┆ f64       ┆ f64         ┆ f64       ┆ f64        ┆ ---             │\n",
+      "│                  ┆          ┆           ┆             ┆           ┆            ┆ bool            │\n",
+      "╞══════════════════╪══════════╪═══════════╪═════════════╪═══════════╪════════════╪═════════════════╡\n",
+      "│ dist_52w_low     ┆ 0.076355 ┆ 5.834005  ┆ 16.152049   ┆ 5.7695e-9 ┆ 3.0578e-7  ┆ true            │\n",
+      "│ vol_252d         ┆ 0.058948 ┆ 3.67656   ┆ 10.401608   ┆ 0.000239  ┆ 0.004222   ┆ true            │\n",
+      "│ natr_14          ┆ 0.05722  ┆ 3.704387  ┆ 10.388454   ┆ 0.000214  ┆ 0.004222   ┆ true            │\n",
+      "│ vol_126d         ┆ 0.056434 ┆ 3.555592  ┆ 10.029753   ┆ 0.000381  ┆ 0.005046   ┆ true            │\n",
+      "│ vol_63d          ┆ 0.05091  ┆ 3.239456  ┆ 9.110108    ┆ 0.001206  ┆ 0.008736   ┆ true            │\n",
+      "│ vol_63d_rank     ┆ 0.05091  ┆ 3.239456  ┆ 9.110108    ┆ 0.001206  ┆ 0.008736   ┆ true            │\n",
+      "│ vol_21d          ┆ 0.050691 ┆ 3.302222  ┆ 9.232101    ┆ 0.000966  ┆ 0.008736   ┆ true            │\n",
+      "│ skip_recent_12_1 ┆ 0.041785 ┆ 2.919424  ┆ 8.21859     ┆ 0.003523  ┆ 0.017045   ┆ true            │\n",
+      "│ ret_189d         ┆ 0.041107 ┆ 2.918157  ┆ 8.220979    ┆ 0.003538  ┆ 0.017045   ┆ true            │\n",
+      "│ ret_252d         ┆ 0.040336 ┆ 2.838828  ┆ 7.997445    ┆ 0.004547  ┆ 0.020083   ┆ true            │\n",
+      "└──────────────────┴──────────┴───────────┴─────────────┴───────────┴────────────┴─────────────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "feat_names = list(ic_stats.keys())\n",
+    "p_values = [ic_stats[f][\"p_value\"] for f in feat_names]\n",
+    "fdr_result = benjamini_hochberg_fdr(p_values, alpha=0.05, return_details=True)\n",
+    "\n",
+    "eval_summary = pl.DataFrame(\n",
+    "    {\n",
+    "        \"feature\": feat_names,\n",
+    "        \"ic_mean\": [ic_stats[f][\"mean_ic\"] for f in feat_names],\n",
+    "        \"hac_tstat\": [ic_stats[f][\"t_stat\"] for f in feat_names],\n",
+    "        \"naive_tstat\": [ic_stats[f][\"naive_t_stat\"] for f in feat_names],\n",
+    "        \"p_value\": p_values,\n",
+    "        \"adjusted_p\": fdr_result[\"adjusted_p_values\"].tolist(),\n",
+    "        \"significant_fdr05\": fdr_result[\"rejected\"].tolist(),\n",
+    "    }\n",
+    ").sort(\"ic_mean\", descending=True)\n",
+    "\n",
+    "n_naive_sig = sum(1 for p in p_values if p < 0.05)\n",
+    "n_fdr_sig = int(fdr_result[\"n_rejected\"])\n",
+    "inflation = n_naive_sig / max(n_fdr_sig, 1)\n",
+    "\n",
+    "print(\"\\nFeature Evaluation Summary\")\n",
+    "print(f\"  Features tested: {len(feat_names)}\")\n",
+    "print(f\"  Naive significant (p<0.05): {n_naive_sig}\")\n",
+    "print(f\"  FDR-significant (q<0.05): {n_fdr_sig}\")\n",
+    "print(f\"  Inflation factor: {inflation:.1f}x\")\n",
+    "print(\"\\nTop 10 by IC:\")\n",
+    "print(eval_summary.head(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9788628f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003556,
+     "end_time": "2026-03-24T02:23:43.124286+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:43.120730+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note on date-level features**: Features like `regime_binary`,\n",
+    "`yield_curve_slope`, `corr_spy_tlt_63d`, and `choppiness_63d` are identical\n",
+    "across all symbols on a given date. Their cross-sectional IC is zero by\n",
+    "construction because they cannot differentiate between assets. These features\n",
+    "add value through interactions with cross-sectional features (e.g., conditional\n",
+    "momentum) rather than standalone ranking ability."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64458903",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002123,
+     "end_time": "2026-03-24T02:23:43.129048+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:43.126925+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### IC Bar Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "764e5a56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:51.746786Z",
+     "iopub.status.busy": "2026-04-09T01:07:51.746712Z",
+     "iopub.status.idle": "2026-04-09T01:07:52.724425Z",
+     "shell.execute_reply": "2026-04-09T01:07:52.723999Z"
+    },
+    "papermill": {
+     "duration": 1.062994,
+     "end_time": "2026-03-24T02:23:44.194239+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:43.131245+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#95a5a6",
+           "#2ecc71",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6"
+          ]
+         },
+         "text": [
+          "0.076",
+          "0.059",
+          "0.057",
+          "0.056",
+          "0.051",
+          "0.051",
+          "0.051",
+          "-0.043",
+          "0.042",
+          "0.041",
+          "0.040",
+          "0.034",
+          "0.029",
+          "-0.026",
+          "0.024",
+          "0.023",
+          "0.023",
+          "-0.020",
+          "0.020",
+          "-0.020"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "dist_52w_low",
+          "vol_252d",
+          "natr_14",
+          "vol_126d",
+          "vol_63d",
+          "vol_63d_rank",
+          "vol_21d",
+          "mom_accel_long",
+          "skip_recent_12_1",
+          "ret_189d",
+          "ret_252d",
+          "sma_ratio_200",
+          "pct_positive_63d",
+          "mom_accel_short",
+          "skip_recent_6_1",
+          "ret_126d",
+          "ret_126d_rank",
+          "max_dd_63d",
+          "ret_63d",
+          "mom_accel_medium"
+         ],
+         "y": [
+          0.07635483496346775,
+          0.05894811022065204,
+          0.05721956547277099,
+          0.056434302982184055,
+          0.05090995251982655,
+          0.05090995251982655,
+          0.050691280996018585,
+          -0.04325755427324245,
+          0.04178482635486817,
+          0.04110730011268391,
+          0.040335762919327035,
+          0.033548199627978344,
+          0.029383844733022125,
+          -0.02609920732671317,
+          0.02408747298706548,
+          0.02338393916006296,
+          0.02338393916006296,
+          -0.020294611560483112,
+          0.02014832251655958,
+          -0.020024239111810494
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Top 20 Features by |IC| (green = FDR-significant at 5%)"
+        },
+        "xaxis": {
+         "tickangle": 45,
+         "title": {
+          "text": "Feature"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean IC"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAgAElEQVR4Xuydd3xUxRqG3zRIQgkkEKo0pUkTkCIgTUDpSC8KRECqoghKVSAiTaRJ70249Kp0pEoTREB6k94JPf3+voMbdlNPy5LdvOcf7yUzc2aeb3b3OXOmuERGRkaCFwmQAAmQAAmQAAmQAAk4KQEXCq+TRpbNIgESIAESIAESIAESUAhQeNkRSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QdIgARIgARIgARIgAScmgCF16nDy8aRAAmQAAmQAAmQAAlQeNkHSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QdIgARIgARIgARIgAScmgCF16nDy8aRAAmQAAmQAAmQAAlQeNkHSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QdIgARIgARIgARIgAScmgCF16nDy8aRAAmQAAmQAAmQAAlQeNkHSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QdIgARIgARIgARIgAScmgCF16nDy8aRAAmQAAmQAAmQAAlQeNkHSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QdIgARIgARIgARIgAScmgCF16nDy8aRAAmQAAmQAAmQAAlQeNkHSIAESIAESIAESIAEnJoAhdepw8vGkQAJkAAJkAAJkAAJUHjZB0iABEiABEiABEiABJyaAIXXqcPLxpEACZAACZAACZAACVB42QechsBb1dvjww8q4Luv2tqlTR+0/BoVShdB/y8+TtT73bh9D+816YGfBnbF+5VLabrX/sMnEfDlMNR6rwxGDuisKS8Tk4BZBP69egtDxs7DX8fPIiIiAp3b1McnzWuZVTzLMUjgzIUraNnle7xdLD8mDfvSYGnMTgJJk0CSEt5CldWJyhcdGqNDqzp2Ibp5559Ys3EPTp+/gpu378E3fVrlS+GzTxoiW+YMMerwy4otWLhiMy5fvw2fNKlQtUIJfPlpE6RN7Z1gfe/cC0Klht3jTPdmvlxYMnVgguVoTfDrln24c+8BWjd5X2vWJJU+KQivRU6twRQvnBfzf+5nw+reg0eYu2QDft/zF65cvwU3Nzdkz5IRbxV6A43rVELBvDmj0usV3qfPgtEgoB/SpPbGggn94ZkyRZKKlyNURj4bvQInxVnVtk0/QK8uzTFo1GwsXvN7VDovzxTwS++DQvlzoU61d1ClfHG4uLjYlBM9j4eHO7L4+6Jq+RKKEKZO5WUaoqfPnqNUzU4oX6owpo7saVq50QuK7T7h4RFKP3zw8DEa1a4ED3c35MmZFcdOXsDsxevxy8QBKPbm64lWJzUFT1uwFnlyZMV775ZQk1xTGj1ll6vXFUEPn8R6n08/qovu7RtF/W3Okg34Zflm3HvwEPIbMeCL1ngjdzabvCMnLsLuA8ewYmZgjH5oSbh11yF81n8cvv+mHT6s+a6mNjIxCTgCgSQlvD9NWWzDbM/B4zhx5hI+blwDKTzco/72bpmiKPVWAbvwlVG8h4+foEKpIsiSyQ+Xr93Cph0HkSaVN5ZOG4SsVtIrX2xjpi1F2ZJvomyJN3Htxh0s/3UnChfIjXnj+8HV1fYHL3oDLMJbpEBulC5eMEb7MmX0RauG1Uxv92f9xuLE2X+x+X+jTC/bngUmBeF9HhyC7X8cwYbf92PD7wfQ57NWyJfnNZQu/rK/HvnnHLr0Ga38oElfLpQvF8LCw5W+vvfPf5T/vWz6YBR4I4eCT6/wWvqjPCTJDyEv7QQswluj0tt4Lat/jALk4bdi2WJRwtupdT24u7vh+fMQ/Hv1Jnbs/RvSJ+TBd0T/ThARtlwW4ZU8Hu7uePL0Of46fgaHjp6BfAfM+7m/IodmXMEhofji25+Vvtbtkw/NKDLWMmK7j/T3ll0CMS7wcxuhXP7rDmza8Se+7tIcuXNkSbQ6qSm4TO3OeK9CCfzQp4Oa5JrS6ClbhNcnTWpUr1gyxr3KlHhTeXCRa+vuw5Dv776ff4Q38+XE+BnLcf3WXayZOxTubi/6jjxcV2/2ldK2hN4QSR85fOwMNi36ESlSeGhqJxOTQFInkKSENzqs78fMw8KVW/DH2omqRkgTA/bazX+gRsW3bT78MuLb+4epCGheEz07NVNuKz9WlRt1x1uF8mLqyK+inqIXrdqKwNFzY3zZx1ZXi/BaRo0Soz2xlUnh1Uc6vikNE2atwMQ5q5QfnjxWP+YPgh6jXtu+CAsLx6ThPWKMbMlD0g/jFqBTm3oonD+3UjE9whsSEorqzXtCRpfHDO6mr4HMBYvwTvjhC1Qu91acRCzyeuC3yfD28oxKJ98L42Ysw/xlm1C3RjkM6/tp1N/iytPnh2lYvXE3xgZ+hmrvxhQeRwuLheGv84cjZ/ZMSbL6eqRUbUP0lC3CW7JIPowfEvcbP7m/9JXjpy9i9ewhSnX2HvoH7XqMwKLJ3ykPTXKNnLQIu/fHP7praYtMbWgQ0F+ZFta0bmW1TWQ6EnAIAg4rvHsOHsPE2auUUTEZUZGRlh6fNsHruV6+yrGMcC2fEYgFyzdhy65DePYsWBmBHfBlG+X1oZ7r0eOnKFunCz6oUhqjvuuiFGF50v5pYBe8X7l0VLEyulOmVmfUrlY2wdEDLcIrI4izFv2mTLWQ9pcsmh9fdWxq8ypr9NQl2LbnL9y6cx/yqtEvfVp8UKUMOn1cDz5pUyl1lC9H+ZKMfm1fPlZ5FV6iRge0a1ELPTo2tUlS++PeypQOy+tRyyiOzBN9Hhys1E3m7ck0ia86vcirps73gx5h4uyV2LnvqFJv/wzplZGLgOa1or7A44qZZYS3QumimDhnJc5dugZ/v3RK/ZvVr6pk27LzED4fMA6De32CRrUr2hQlfapDzx8xvH9H5TV0Qpce4bWIsIiPCFBcV2hYeNTonh7htfTH6KNqlvuJEE+ZvwYrf9uFuw8eInNGX+TNkx3yWtM6z6e9fsTVG3cwbWRP5e2F9CeZg7l16Whlyo702Z9nrsC2PYchMi9vQWRKhszPtH6jIe2ZufBXrNqwS3nzkTZNKuU1/1edmkU9zFr60NC+HZRyl67djpu37yuvv7/p2kL5jNv7Miq8lvr2HDwJv23dZ/P6Pi7htfTDz9s1QseP66pqsojK+JnL8fc/5/H4yVNkzZwRpYrlh4weZ/RLp5Tx9gefombVsgj8+pOoMm/deYAX3xOHERYWhpzZMyvCfujoaZuBBks/kO+7CbNXKm8ivL1SonrFt9GzczOb6TLW95FpO8MnLLRpg0zV2LdukvId8ePk/2HLkp+U/me5/jl9ET/PWqGMdMt0CHlgrFm1DFp++J4y8KDme03KUlvnIlUDEBERaVPHXK9lxrp5w+JkLyPZEtMz56/g9t0HCI+IQI6s/krflzeSlukresqWm6oVXvn+lmvGT18r/5XvvHpt+mL8958rbxVkdLdG868wpHfCo7uWxorwpvL2VKZB8SIBZyLgkMIr0tL92/F4PVdWRTqDg0Ox4redyqtDmQ/2es6sSowswiuvEbP4+ylSePn6LeXLWtIsmxGo65Wh5UulbbMP0Ktzc+VeU+atUUZyVs76HnlzZ7fpI7U++kb5EZEpEPFdaoXX8kMhX2jl3i6Ex0+eYdHKrXj2PBgrZw2Bf4YXP3AycpsyZQplbqh8gV2/dQ9rNu5WRv0soirzumQqibwGs7RF8soPjHxpaxVemeJx914Q5LWb3LNowTyK9Kqps7zKb9E5EFeu3VIEVWT34uUb+HXLXtR/v7wyVzK+S4RX5qnKj5EsJpN509I++UGySKzco0qjL5Qf9ujzamWupoi2yH5KFa/z9Ahvo/bfKgK5a9X4qFeOCX2h6BFeGSVetm47dq362eY1uuVeX373MzZuP4h3yxRBofy5FUbyQCjSGl14RURdXVyQwdcHBfLmgDzwyYONsGzacRCCg0PQrF4V5e9//n0a67bstXlIioyMRLd+Y7F7/1E0qVsZefO8hktXbmDhii3KtA35YZW+ZhFeedCSq1LZYopIbNt9GK6urspr1nQ+qRPCpchyQpeU55suTULJDI/wWm5w8uy/kNi3aPBe1CLHuITXMkonr6nVTGG6cv22UraIbYMPKiifgaMnzmPD9gMYM6hb1Mh0dOGVh2CRm1t3H6BW1TLKw8q5i9ewfe8RyAOR9Zs1kUeJbXh4OArmy4X8eV7D0ZPnIe2S9RSyrsJyWd/n3MWrmL14A2T6ggi8fDfJXGV5oIxNeGWRZcdvRiG9T2rUeq+s8lAl/yYPAb8tGI4c2TKp+l6Tuqit86oNu5UpKTLtx/IQLH0wvtF1+c5t/fkPynS1zP5+cHN1xcmzl5TPlPUaEz1lS91FeIsUyIOBX7WFp2cKpEubOta5t18NmqgMLFjWdsiiwFZdv1e+2+R7ftTkxdix7whWzvw+zrm70T8E8gA7dcEa/LFmovIdzosEnIWAwwmvPPFXb/4VUnl5Ysm0QVEjCyIFdT7ujbeLFcDk4T1shLfv563Q8sNqUR94GakSGZbRChFmrZfIhIwYW782+mHcfCxYvlmZBys/HNaXzF8Tody2dIwq4Y0tkYzI7lk9QZHW91v0RJsmH0SNnEp6GTWr9XFvBDSrabOgIXpZUm+p//pfRkTNSYxrSoOIo1bhLVEkH4b3+9RmbrPaOh89eQHNOw2KsWhCFl+JIFkv5IqNkQivPGzIK3zLgkKRn/oB/eDrk0aZXiDXiAkLIQs9LD+g8m8icRUbdkejWhVV77qgR3jfqtYObxXOi9ljeqvudnqEt2nHgcoI/YxRL0Z+rC+R+k7fjFLmcnZuXT/qT5YdHaIL7/6/TqJ3t5Zo/t8ouSXDwB9nK6P28pCVKWP6qHIG/TQHK9fvwq6V45UfTBHgrwMnK59LmbNsuWTEU0bJpv/YC++8XShKeKuWL47BX3+C9D4vhFQWjnYfMF71YhrpB6GhYfHylc+omjnr8S1ak9FNy3SRuOTVuhKlanZU+vDccX2Vf44rj+W7xHoed3yNmbnoV0VsNi760WYhrXzuIiMioj6L0YVXHnRnLPwVc8b2sRk9t7yFiC68MrdzaN9Po0RQHniadxqMB0GPsHnxT1FVjH4fGYzoP3xGjMGA6MIro6y1P/5GeWBdPj3Q5uFGRntl1DWuh5TYvtdEeNXWWc+0g+gxkfr3GDhBediQUWvLpafs6IvWZC53+dJF8E3XlsiR7eVc8iVrf8fgn+YoMRRhl+lzO/YewYaFPyI4JESZuzukd3tUrVASo6csVtYVRCLyxch8p2bKw0f068BfJ9H2i2HKqLGsReFFAs5CwOGEV75MmncerCwG+qhRdZs49Bs2HWs27cG+dZOVUS3LCK+M2Mnok+WS0azKjb6wGW1RG1CRhc69f0Ld6uUgr16tf/zly2fnyvExvpRlJODshavYs2ZCvLeJb9Gal1dKRU4srwjlx1p2jLC+Puo2RJmqIAIhl4xCzFu2UVlE9e+Vm3j05GnUqzvLCICkM1N4ZeRPtsCyvtTW+fipixBRk1f93/VoG+vIZHwA41q0ZhELGVUViZJYiARbr3b+36qtGDx6rjIKn5BYW+qgVXhl1Kx4jQ4QoUtobp51O/UIb9UmXypiIqOE0S8Z3d21/6jSV613bohLeGVEOvrrXRm1LVdXtkkrjT6ft7K5xa59R5VpI5Y+Jv3rwuUbykI860umF5Wv3015QJNYWE+Lse5DMs2lQv3P0KVNfXQNSHjBlYwGhofbvqKOzsAzpYeqha/xLVqTxYh1qr+Y+qJGeGVrOXkAWD3nB5s8Mv9S3sTcf/BIeSMh03FkBNR6AZU8pMpUEutLpuqIuM/+33plnqZsj9esXtU4F8dGF1Fhmv/116Jeh1vKjkt4Y+sHss7if6u34q9NM+Dm5qoUoVd4LZ9/mT4lbYvrUvu9ZpnSEL3vxlZnPVIqixLnLtkIeSC8ceuuso5DLlksdmTLjKjq6yl70txVym+WvKV69PgZDhw5qUyJke+v1bN/iJqSJlOFvhs5EzKSLJf8fVi/T5U3XPJA8/sfR7Bq1vcYNWUxlq3dju+/aQ8XVxf0GzpN2Ynh664tYmC2/A6pndoV33cy/0YCSYmAwwmv5QdI9gqU1dHW19T5azB2+jKsnTtUWfUbl/BKHhGPimWKKgtD1F7yg9z+qxF4I3d2ZeRM5rBZLsuoTHS5lr9rHeGNb9GaSJnIWVyXLHT635TvEPToiTL6Il/KIiWl3sqvvPI8fe6yMgdv3vi+kNFYuRJbeNXWWerSre9YZT6hiJhs6STbdMmrTcuOBfHFKi7hnf7LOmXe34qZ3yNfnhfTTZp1HKS8+t70v1GKIMjIsvx4RJey+O6nVXilLHuN8MrIfPuWtdGlbYMYTfjwkxdz84SH9aVFeO/ef4iKH34e70fH8hmt27oPzv97Pc60lsWfcQmvxEW4xTaXXO1nV286s+bwyv1lWzCZjy6jcXJF35bMUkcR+46y28N/q+zl32ObCyqfc/m8SyzkNbbsICNTPmSLL5m+Va9Guaj5u1KGtYjK94M8sLRqWB3yBsz60iK8lrdlhzZOi5oGpFd4LSP+8S0Q1PK9FpfwxlZnrVIqb6Padn/xxki2WiuYNwd80qbGqvW7sHX3IRzdOisKqday4+qrloEDedsi84StL3kLJiPtMr1Cvs9kapK8CQ38up3yFrNKY1l0WRzf9WijZJORYHlzIr9X0S95OyLfpbENKun9HDEfCSQFAg4rvNFfjwpMyzxaeaKX119xCa+8eipevT2qVSwZtegsoWDI/DUZ2ZUFFFNG9lTmlllfk+euVhaNWGTb+m81W8kc3pQJypSaObyWH0l5JR7btjFyH3mtbxn1iT5tw7JoS4vwygIky8IzS7viW7QWfYRXbZ2lbInNrv1/K4uj/v7nHE6du6zcUl7LyTze+K64hNcSGxlZs8zvtuyeIaPhMq+wXtt+6Nf9Y2VhjNpLj/DKyPKNW/ewe/XPiTqHV4S3w0d1bKYsWNpVp3UfpPb2VKbkWF9ahNfSV2U0XualxnbJQ6eMUElfkX2GrRdLWaeXhYUyUhmX8Mqr82LvqRdeWegmr23ju0Qmrd/6xJXWLOG1vFWQt1IiEnJZPhfyVkTmjMv8S5me0LBWxThZxVVPER6ZXiKj27JwTeb1ypQW+Zxb1hRYi6glfrF9trUIrwwwyECDmcI7ceiXqPSO7WCGpd1avtfiEt7Y6qxVSmVbwQN/nVK+062nGAwdvwC/rNicKMIrDzTynWM9Dzyu/mBZ2Ceju2HhEcoDo/XcYss0GOu4WcqyvImSByF5IOJFAs5CwOGEVySoRZdAZdV29IMSZIuWdVv+SHBKw6UrNyELyWSKgJo9KWVKgLwGLlbodcjog/W2Q5aOYBHJ6KvvZUSifL1uyi4Nw/t1jLffqBFey2jl4ikDlRHQuK5vR87EsnU78PeWmVGvGiVtbMIr8yNlE3jreWeSVuZLF6vWTpm7Gf00MS3Cq7bOsbVFXud/1PV7pE7lrcwB1CO8soXc+q37sHfdpKhX+A8fP1UO+ZAt5zL4+UAODPl92ZgYDzLx3U+P8FrmTYr8idjEdRndpUFen8uem7G9spST185fuq601/owBC3CK32jTO1Oyn7RIijxXR2/HqU8vOxMYKGeWcKbGHN49W5LZuFi2WrM+nMb2zQIy1aMar+b4uJ+8MgptOk+VFn0ZpnWYi280r9KffAp3ns35kP/qxJey3e7PFzHdQqblu81LcIro90V3ylms21cfH26ZquvldFzy3xsS9rYhFdr2XHd1zKdL/rBE9HTRx/dtYzYygFI8tZHrviE1/I7NGJAJ9R+r6yzuA7bQQJwOOGV0R6ZiP9i14PBUfM8ZdGWjFzJBv+Th3+lhDa2EV6Ze9hn6DTl9DTrV9xx9QXZGmnw6DnKpuQirHFtxi3zykSgZOukKSNe3F8uy9zQ6NuVxXY/NcJ74d/rqNumL8qUKIjJw3rYLDqQXSpkSx+ZqiCjzTKyad1Gkbz+w6cr0ms9wiuvt6SdMuoY/XSnak17KLIpIxmWOXoy5eDrwCkoXviNWLcliz7Cq7bOUncRqSIF89jgkde18uAgo+dahVd2efiw3QBlTpts1WN9ya4MW3cdVkbfZas6rUfv6hFemT8u8ZP5mCKK0bfakm2iho6fj3Ytaxvah1embIjIi6hFvyxC8/MP3VGlXHHlzzKyPnneasjfYtuWLLYtmmQhmixIsyw6s76PyIuM8Mooo8xtlwVuskWWnFBofclorCwYlJOhzBLexJjDq1d4ZQGWfBZlgVb0kdvYhFfi0H3AOGWbQ7V7ocrn8c28uWwWDj57HqI8kMjrdstr7OhTDUSI5TMn++Nati6TeajyuZCH/OiL1mKbw2vmCK/lu112PFg2PTBqnqr0F8uiNVmcpvZ7TYvwylZe3vLWY9K3qrTg489+UKaQbFw4Muo3QabtdO8/Dhev3LAZ4dVatnwO5HvY8jZKKiRseg6apBx6tHDiABSN52Q6mbIh2wvKYlLL1oCyZkV+wwZ82VppnxzzLAvYdqwYF6O9XLSmqgswkQMScDjhFcay9YushlX2Z3yvjLItmWx7I1/y8mVgOVbRIrwyvUHm+8q8UPkwy8pd61eLccVNtnuRJ3lZCNCyYTVla6bol2xjY/mxsLw6l1NwZOTr2s27WL5uO/K/nkPZLs0ijHHdT43wSl6LsMjJTzItI0N6H5z/95qyrZQcSyqjhyKZMldT5pXJKVFy0IH8XbYiEk7WwmtZBV+yaD5lC6PL124rr79k2oblB61EkbzKYi7Z91hemUpbRNZi24c3uvCqrbPl9bGs5JcHl5QpUij7ga7ftl8ZqWyTwNHHMrInV+V33sIbubLh7v0g/Lp1nxI3me8oWxpZX38cPI72PUcq/yRzskV6tVyxCa+ak9ZkWzxZ1CVyIbsTyDxMEWDZU1m2pJIRGesHFT2L1mSkafWG3dixcnyMrfdkzmfdNn2UfiB9Q/q3nGp46fIN5YdVrfBKvVp0Hozbd4OU0WSZZy2vQ/ceOqHEzbK/qpQpo7zSbnkYK1uioCIJ8lZBtsAK7PWJslDRLOHVEsOE0mqd0mA5NU36gTyE//HncWUvVOEjOxxYb3cX10I3ySur5I+fuoCxgz9T9lON75JyZNGSzHWXuaShoeFY//t+nDh9SfmcW+QouvBa+r98f8meyJERkcr8UzkBUGJmb+GVNsp3kbxN8/dLr7QnbRpvyGi1LLKUXVXkgVjt95oW4bXsvCPbusnvxcNHT2NM47KOgWXnCenzZYoXVLZ2k+9XN1cXZZcJ6zm8Wsu27F4h34HyICNb8+05cEzZY1cWmsnRv3FdErtqzb7C4F4BytaSlku+D2RBt7yBlLc63wyZgno1yiu7r0S/RJhlBHjv2omxvs1M6DPDv5NAUiXgkMIrMGW3hMlzbQ+e+KJDk6hFSZLGIrwyD2nnviPKll6ywXnzBlUVeYp+tn30IMkTuyy4ie+yLByRNDJ6LFuTyelwV6/fjtpcv8enTW1GK+IqT63wSn550pd7yQiNyKxsw1WqeEFlP1RZeS2XjHTJGeoXr9xU2l3v/XKK9MnInLXwSlo57GHpuu3Kj7OUJYIuwitf3vIaXqTzydNnKPVWQXzerqGynVRcB0/EJrxq6iz3loUZv+/5C5eu3lSOk5ZRQlmgoebVmgiv/ADJFj4ijyKOIuXfdGtpM1pi4S+jaXI6nqyQl5GahPpD9LjFJrwWObVOK/thRt/z9/rNu5j1v9+UH3LplyLl2bJkxLuli6Bh7Yo29dUjvDLqJwsA5W2DjG5Hv2RutCy0FMn09kypPOjItkcvtg/7StmfV664pMFSnvRZmcMpMZODQuQBS0amalQupYwuWo7GlVfo85ZuwNpNfyg7Nkhs5dQt2WtX9lyW+bTOILwWLiL0ctCLLFJr8H6FWKU1vp0d5LPQqmugcvCGbA8lfSiuS2IpI59//PkPbt2+ryxck+lOMi3C+m1JbAdPyCjfzzOXK3u5ZvTzUYQqJDQMMg3Jen6nFnnUu2jN0j6ZWjNl3mpln9/ISCgDG7Ibhny3CVe132ta6ixvv4aMmYed+/5GSGgo3nm7cIw3QtH5z168HvOXbsT9oMfKA7Z8T0mdo8/h1Vq2DFbMWbxBmdMtn315AMr9WmY0rlNZWWMQ3/eUDFBs2fmnzeiu1FvKGDFxETbvOKg0o0alUsq+5rHtNy7T1eQhOPp3VlKVGNaLBNQSSNLCq7YRcaWLb5cGo2Uzv+MTEOmU43e7BjSIdXFXQi2Mb0pDQnm1/F2P8FqOFpbRJ5mLp+aShxrZyF5OJrQ8NKnJxzTORUB2Vflty15lhJdX8iJgObhiYM+2aFKHRwsnr+g7f2spvM4fY7YwDgIyGiIPRbI1mZ5jppOy8EqTZZROXk/K3sLRt3UTIbaejy6j3V37jsHfJ84pWxVZb4nFDuScBGR6gFzWU61kNFLeask0iOhz3p2TAltlTUDWS8gOH3KqYVzrVUiMBByVAIXXUSPHehsiIHMUZScDEUHrRYZaCk3qwitbVcl8RzkFbfaYPjYHEojUyDHQMv1ADkPYdUC2szqnrOhXc5ytFk5MmzQJyCI0Wdwoe3TLUdsyj1zmvN+5+wDzJ/SPWjSZNGvPWt9gxZYAACAASURBVJlNQOaB9x06TfWJhmbfn+WRQGIToPAmNmGWnyQJyNxFWfioZveMuBqQ1IVX6m1Zcd222Qfo1bl5VFPk+F+ZPyxzcGX+8Ou5sioLOWUhC6/kQUC2r+oVOBmnz19WDiqQ0xzl0Ao5rET+yyv5EDh26sVBGm8Xk12OeiSfhrOlyYqAUwtvsookG0sCJEACJEACJEACJBArAQovOwYJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8Dp1eNk4EiABEiABEiABEiABCi/7AAmQAAmQAAmQAAmQgFMToPA6dXjZOBIgARIgARIgARIgAQov+wAJkAAJkAAJkAAJkIBTE6DwOnV42TgSIAESIAESIAESIAEKL/sACZAACZAACZAACZCAUxOg8BoM77W7zwyWwOwkQAIkQAIkQALJkUBWP6/k2OxX0mYKr0HsFF6DAJmdBEiABEiABJIpAQqv/QJP4TXImsJrECCzkwAJkAAJkEAyJUDhtV/gKbwGWVN4DQJkdhIgARIgARJIpgQovPYLPIXXIGsKr0GAzE4CJEACJEACyZQAhdd+gafwGmRN4TUIkNlJgARIgARIIJkSoPDaL/AUXoOsKbwGATI7CZAACZAACSRTAhRe+wWewmuQNYXXIEBmJwESIAESIIFkSoDCa7/AU3gNsqbwGgTI7CRAAiRAAiSQTAlQeO0XeAqvQdYUXoMAmZ0ESIAESIAEkikBCq/9Ak/hNciawmsQILOTAAmQAAmQQDIlQOG1X+ApvAZZU3gNAmR2EiABEiABEkimBCi89gs8hdcgawqvQYDMTgIkQAIkQALJlACF136Bp/AaZE3hNQiQ2UmABEiABEggmRKg8Nov8BReg6wpvAYBMjsJkAAJkAAJJFMCFF77BZ7Ca5A1hdcgQGYnARIgARIggWRKgMJrv8BTeA2ypvAaBMjsJEACJEACJJBMCVB47Rd4Cq9B1hRegwCZnQRIgARIgASSKQEKr/0CT+E1yJrCaxAgs5MACZAACZBAMiVA4bVf4Cm8BllTeA0CZHYSIAESIAESSKYEKLz2CzyF1yBrCq9BgMxOAiRAAiRAAsmUAIXXfoGn8BpkTeE1CJDZSYAESIAESCCZEqDw2i/wFF6DrK2F99S5S1i6ejPc3dxQpUIplC5RKKr0R0+e4uepi5A6tTf8fH3QslFNjJ+2CCGhYQgLC0NkZCR6dw/AgcPHcejISURERqBzQBODtWN2EiABEiABEiCBpEqAwmu/yFB4DbK2Ft5hY2aha4dmSOXlhYHDJ2Nwn85Rpf+6aRfS+aRBudLFEDhqOnp1aw3PlCmUvy9ZtQn538iF3Lmy4duhE5X/LVe7jz6Eh7ubwRoyOwmQAAmQAAmQQFIkQOG1X1QovAZZWwtvvx8mYkjfLkqJ/YZMwJB+XaNKn7d4HUoVL4QCeXNh7OQFaNG4FvwzpMe9+0GY+ctq9Oz6Mf45dR5Hjp9Gi4YfYP2W3XBzd0P1SmUN1pDZSYAESIAESIAEkiIBCq/9okLhNcjaWniHj5uNbu2bwcvTE4NGTMag3rYjvL7p0qJsqaIIHDUNvbq1UUZ4x0z5BU3qVUe2LBnx79UbypSIHp0/wvY9f+L582C8X7WcwRoyOwmQAAmQAAmQQFIkQOG1X1QovAZZR5/DK9MT3F3dULViaWUOb8BnAzFr/EDIHN7xUxfC29tLGdmVObynz17C9j2H0KH1h1G1mDRrCYJDQhEWFq7Is2Xag8FqMjsJkAAJkAAJkEASI0DhtV9AKLwGWXOXBoMAmZ0ESIAESIAEkikBCq/9Ak/hNciawmsQILOTAAmQAAmQQDIlQOG1X+ApvAZZU3gNAmR2EiABEiABEkimBCi89gs8hdcgawqvQYDMTgIkQAIkQALJlACF136Bp/AaZG0R3kcRzxAU/sRgabbZPVzdkcktnallsjASIAESIAESIIGkQYDCa784UHgNsrYI7+ngqxhx5394GhFssMSX2eumLosW6SoDLi6mlcmCSIAESIAESIAEkgYBCq/94kDhNcjaIryngq+g382ZeGKi8DZNWwkB6atTeA3GiNlJgARIgARIICkSoPDaLyoUXoOsKbwGATI7CZAACZAACSRTAhRe+wWewmuQNYXXIEBmJwESIAESIIFkSoDCa7/AU3gNsqbwGgTI7CRAAiRAAiSQTAlQeO0XeAqvQdYUXoMAmZ0ESIAESIAEkikBCq/9Ak/hNciawmsQILOTAAmQAAmQQDIlQOG1X+ApvAZZU3gNAmR2EiABEiABEkimBCi89gs8hdcgawqvQYDMTgIkQAIkQALJlACF136Bp/AaZE3hNQiQ2UmABEiABEggmRKg8Nov8BReg6wpvAYBMjsJkAAJkAAJJFMCFF77BZ7Ca5A1hdcgQGYnARIgARIggWRKgMJrv8BTeA2ypvAaBMjsJEACJEACJJBMCVB47Rd4Cq9B1hRegwCZnQRIgARIgASSKQEKr/0CT+E1yJrCaxAgs5MACZAACZBAMiVA4bVf4Cm8BllTeA0CZHYSIAESIAESSKYEKLz2CzyF1yBrCq9BgMxOAiRAAiRAAsmUAIXXfoGn8BpkTeE1CJDZSYAESIAESCCZEqDw2i/wFF6DrCm8BgEyOwmQAAmQAAkkUwIUXvsFnsJrkPWrEN5HT57i56mLkDq1N/x8fdCyUU2bVvy6aRdOnr2IZ8+D0b5VA7i4uaLv4PEomD+Pkq5ru6ZYsORXPHr0BMGhoQhoVR/+fukNkmB2EiABEiABEiABLQQovFpoGUtL4TXGD69CeEVo0/mkQbnSxRA4ajp6dWsNz5QpolrS74eJGNK3C85euIydew+j3vsVMWzsLPhn9MPbxd7EO6WLYshP0xHYpwuuXr+NDVv34JNW9Q2SYHYSIAESIAESIAEtBCi8WmgZS0vhNcbvlQjvvMXrUKp4IRTImwtjJy9Ai8a14J/h5QitRXjv3Q/CzF9Wo2fXj5VWRkZGonfgeAzu3RnrNu7ElWs34e7uhpDQMHzRsaVBEsxOAiRAAiRAAiSghQCFVwstY2kpvMb4vRLhlRFe33RpUbZUUQSOmoZe3drYjPB+O3QSBvfpjHMXLmPH3sP4qHEteHi4Ky3t/8MEDOj5KVKm8FD+/8pft8HLMyXer1ouVhLRp0dk8veLSnfq3CUsXb0Z7m5uqFKhFEqXKIRRE+cjNDQUHh4eKFm0gDLtYvueQ0qek2cuYODXHZEti79B6sxOAiRAAiRAAo5PgMJrvxhSeA2yfhVTGmQO7/ipC+Ht7aWM7Moc3i079+Pa9dv4uGltiKT+c/qCMoe3Y+uGuHrzNlau2wavlCmR742caFinKjZu+wMnTp2HRwoPdGzTGG5urrGSiD49IqBFvah0w8bMQtcOzZDKywsDh09WJHva3BV4/PQpXCKhTJNImza1kv7ps+cYN2Uhen8REOt9EpqXPGHGYhmjxrPnIfiyUyvcfRAUY17ynbsPsG7TTkW4m9avAf+Mvgajy+wkQAIkQAIkkHgEKLyJxzZ6yRReg6xfhfAarLKm7HFNj5BCLH9T/veQCRjSr2tU2YePncKRY6fRtnld5d9mzF+JSuVL4o3cr8V6//jmJV+9fgur129H54AmWL52K3LnyIoc2TPbzEuu8u7bkJHtbFn98ezpc7RsXJPCqynSTEwCJEACJGBvAhRe+xGn8Bpk7ezCG316hPUI7/Bxs9GtfTN4eXpi0IjJGNS7M0JDw5TpEzLCvO/Po5D0IqzL1mzB55+2iJN2fPOS/z5+BifOXECzBjWwbedBhEWEoXqlskpZ1vOSvx81TVmId+3GbfyybH3U3GWDIWZ2EiABEiABEkgUAhTeRMEaa6EUXoOsnV14o0+PkGkCAZ8NxKzxAyFzeJes2gR3VzdUrVhamcP744R5iIiIwPPnwcr2Z36+6TB09Ex0bNsIvul94qQd37xkEea1G3YqZYg458mZDYULvhFjXnLvwePwU2APBD18jClzluObz9sYjC6zkwAJkAAJkEDiEaDwJh7b6CVTeA2ydnbhNYhHdfaE5iXLHN7w8HAEh4SiR+eP8PeJMzHmJW/avhcHDh2Hm5s7mjesgZzZs6i+PxOSAAmQAAmQgL0JUHjtR5zCa5D1qxDeY88vITgyxGDNX2Z3hStypswIX9e0ppXJgkiABEiABEiABOInQOG1Xw+h8BpkbXfhjYzE2Psrsf3RUYM1f5k9o7sP+vm3RA6PjKaVyYJIgARIgARIgAQovEmlD1B4DUbiVQjvj3eXYsvjvwzW/GV2f/d0GJypDXJ6cH9c06CyIBIgARIgARJIgABHeO3XRSi8Blk7s/BeD7uPW2H3EGmQkXX2tK6pkSdFJhNLZFEkQAIkQAIk4JgEKLz2ixuF1yBrZxbeo8EX0ef6TIQj3CCll9k7+tVF/TRl4WJVYiQicTVUxNo8tXaJdEFGDx+kdHlxwpz1pfX0uG5fD0PuXNmVIhrUrIQ8ubJj/uJ1OHHmIn7o3y1ONloP09i26wA2btsLOc1ODhSRQ0RkL+PFqzaiUZ33UKJYwTjvFf1gDuuDRGJrb/Q2pUrlrey4If/9pOXLw0VMCzwLIgESIAESiEGAwmu/TkHhNciawqsNYGzCG45IDL+1GGdCrmgrLJ7U2Tz88GWGRvBzSxMjldbT4+Q45gx+6eGTNrVykIaLywtdHzxyKr7t9WmctdB6mMajJ8+wfc9BpEyRAh/Wqoy8r+dUyl6zYQeyZc4Yp/DGdjBH8aIFouoVW3tja9O/V29g8/b9FF7TeiELIgESIIH4CVB47ddDKLwGWVN4tQGMS3i/uT4dx4MvaissntQ5PTJhSOaAeIX33v0gzPxltc0BFfGdHjdn0VoUKfQGShR5IZMJCa/ewzQeP3mKoWNnY0jfLqqEN76DOaSA+E7Ls24Thde07seCSIAESEAVAQqvKkymJKLwGsRI4dUGMCkIr5bT477t1VFpoEwRWLh8PQq8kQuW0dOEhFfvYRohIaEYNHJq1FHNakZ4ox/MYT3CG729rZvWibVNFF5tfZmpSYAESMAoAQqvUYLq81N41bOKNSWFVxvApCC80U+Pc3F1xYhxszFy0BcxTo8rmD+3clKcnBInUxm+7NRKafDMBSuxe/8R1K5eAY3rVYsVQmyHaYyZtABV3i2FYoXzIfphGit+3YbTZy8qxzM3qFVFSXPwr3+U0+VSp/ZG8w/fx+v/zSWOfsPoZd178DCqTdHb6+XtGaNN12/exuJVm3Dx32toWr8Gypcppi2wTE0CJEACJKCZAIVXMzLdGSi8utG9yEjh1QYwKQivthozNQmQAAmQAAkkDgEKb+Jwja1UCq9B1hRebQApvNp4MTUJkAAJkIDzEqDw2i+2Tim8x05dwMAfZ+PshSvImjkD+nzWCu+WKRon1fjS79x3FJ2+GWWT18PDHX9tms4RXh39lMKrAxqzkAAJkAAJOCUBCq/9wup0wivzH99v2QstGryHZvWrYvuevzB49FxsWDgSvuliblGVUHoR3sDRc7B0+uCoqMimVGlSe1N4dfRTCq8OaMxCAiRAAiTglAQovPYLq9MJ7/7DJ9F9wDjsXj0Brq4v9ktt2nEgmtevioa1KsYgm1B6Ed4hY+dh/S8jYo0KpzRo66xJQnj/20dXW83jSR0BwMX20Ay5RaTN8Rom3S0y9sM5rA/yMONO5h0BYkZtWAYJkAAJOCcBCq/94up0wrt49TYsW7cD/5vyXRTFrwMnI1NGX3zVqWkMsgmlF+Ht2nc00vukQdrU3ihdvCC6d2is/G+5rt99pvz3ZPAV9Ls5E08igk2LXtO0lRCQvnrUQQdKwZGRGHl3KbY8/su0+/i7p0NgpjbI6eFvU+bfiXDSWqdYTlqTgye+TqR9eDNEO3jiSPB5zLq30TR2UlDzdFVQxisfXKwE90H4U0y7tw5Xw+6adq+cKTKhS/o6SOnqEVWmnE73V/BFnA++atp9pKCinnmQN2VWU8tMjoXJ84nZz1fJkSPbbAcCfMq1A+SYt8ji5/VK7pscb+p0wjtnyQZs2fkn5o7rGxXPb0fOhIe7OwZ82TpGjBNKfz/oEW7evq+csnXj1l2MmrwYGf18MHrQiyNlI/4bcdt/7wJ6/DvNVOFtma4yvsxZG+5urlH1Dg2LQN8Lv2Dzo8Om9VcR3p9ytkMhH1vB2XH7NHpcnm7q0cLd/OuhbdaKcPtv9F0a8Sw0HB1OTzT94IlxeTogR6r0NpzW3zqKPldmm8ZOChqQtQUaZCoJVyuzufH0Ibqem4LzoTdMu1eBlK9hSt7OSJsiZVSZEZHAwut78OONZabdRwoanf1TVM6Y39Qyk2NhIWERSOH+8vObHBmwzQ5CwOzXRA7S7FddTevfjVddF2e/v9MJr4zYrli/CwsnDoiKnYzw+mdMj56dmsWIp9b0h4+dQZvuQ3Fk8wxl5JVTGrR9RF71lIb9z07hu5tztVU6gdS9/ZujondhmxHeoPAn6HtjpunCOyxTO5sRXqna+sd/Yuyd5aa2aXjm9ijqmdvUMlkYCZAACZCALQFOabBfj3A64d13+AS+/PZn7F79c9RUgMYdvkOz+lXQpE7lGGS1pt994Bi++X4Kdq0ar5RF4dXWWSm82nhZp5YRXgqvfn7MSQIkQAJJjQCF134RcTrhlWNZqzfvidZN3kfTupWxY9/f+HbETGXRWUa/dIiIiESHniPRttkHylZlCaWfsfBXZM+SAcUKvYEHQY/Rf/gMlCyaT9nqjMKrvaNSeLUzs+Sg8Opnx5wkQAIkkBQJUHjtFxWnE15Bd+Sfcxj80xycvXAVWTP7oVeXFqhavrhCNSw8HMXea4dBPQPQuE4l5d/iS7/it52YvXg9rly7rWxFVqNSKXz5aRN4eaag8OropxReHdD+y5LchFeOS5a9Lp49D1GOdHazmssuxyWfPHsRz54Ho32rBsjk76dQ2rrzADZu24th336Gjdv+wJHjZ/Ag6BHq16yE0iUK64fPnCRAAiSQCAQovIkANY4inVJ47YePUxq0sqbwaiX2Mn1yEt6r129h9frt6BzQBMvXbkXuHFlRvGiBKBj9fpiIIX274OyFy9i59zACWtTD38fP4PTZSzh64gwG9e4clfbmrbuYu3gdenWLuWhVEp06dwlLV2+Gu5sbqlQohdIlCkXlffTkKX6eugipU3vDz9cHLRvVVP526fI19PxuDJbMfLFdocj14pWbMPmnfko5vEiABEhADQEKrxpK5qSh8BrkyDm82gBSeLXxsk6dnIRX5PXEmQto1qAGtu08iLCIMFSvVDaG8N67H4SZv6xG8wY1sG7zLnRs0wjfDZtkI7wyUly5fEkUKvB6rPCHjZmFrh2aIZWXFwYOn4zBfV7Ksowkp/NJg3KliyFw1HRFmp8+faYI9J279/F9365RZX7/03T07h5A4dXfxZmTBJIdAQqv/UJO4TXImsKrDSCFVxuv5Cq8MsK7dsNOdGzbCMvWbEGenNlsRni/HTpJEdNzFy5jx97DyJopA06dvQR3dzfsPXgUXds1RbHC+TF93nJUfKckihbKGyd4y2ixJOg3ZAKG9HspsfMWr0Op4oVQIG8ujJ28AA3rVcOSVZvQqW1jDB87y0as1QivnmkaY6b8goy+6dCqSa14R6P19yzmJAESeFUEKLz2I0/hNciawqsNIIVXG6/kKrzSbpHD8PBwBIeEokfnj3DvwUOMGDcbIwd9ARl5/ef0BWUOb8fWDeGf0TcKlWWEd+TPc3H3XhCy+PsidepUaPdRg1jhDx83G93aN4OXpycGjZhsI7FyH990aVG2VFEEjpqGxnWrYdVvvyNtmlSKWH9Yuyo+rF1FKTch4dUzTWPpmi2IiAhHaEiYIrzxjUbr71nMSQIk8KoIUHjtR57Ca5A1hVcbQAqvNl7JWXj1k9KWU+bwyqitu6sbqlYsrczhDfhsIGaNHwiZwzt+6kJ4e3vBP0P6qDm8cgfrqRNrNuzAynXbUPbtovioSU14eXnGqITWaRoyshwSGoIc2bPg4KHjivDGNxqtrdVMTQIkkBQIUHjtFwUKr0HWFF5tACm82nhRePXzSmo5tU7TCA0NQ1hYmLLLhJzy+HW3Nliw7Lc4R6OTWntZHxIggYQJUHgTZmRWCgqvQZIUXm0AKbzaeFF49fNKijmjT9P4fc9BXLt+Gx83rR3nNA0ZgbaM8MY2Gp0U28k6kQAJqCNA4VXHyYxUFF6DFCm82gBSeLXxovDq58WcJEACJJDUCVB47RchCq9B1hRebQApvNp4UXj184qR08UFiIw0sUAWRQIkQALGCFB4jfHTkpvCq4VWLGkpvNoAUni18Uquwrv+0UHsfXZCP6xoOT3gjkbpKqJAimyxerBpN5Kz4ejUZuJkWSTg1AQovPYLL4XXIGsKrzaAFF5tvJKr8C4K+h1z7m/SDytaTk/XFBiSKQBvpsxh85erYXex99lJhEaGmnavrO5+qOhdxLTyWBAJkIDzEqDw2i+2FF6DrCm82gBSeLXxovDq52WdMy7hPRdyDf1vzMGDiMfm3AhAnTRl0MW3LlxkCoXVdTLkCkIizBNrV7gis0d6ZHBLa1rdWRAJkIB9CVB47cebwmuQNYVXG0AKrzZeFF79vJKS8Mosh4n31mDtw73mNAiAr1tqBGYKQJ4UmU0rkwWRAAnYlwCF1368KbwGWVN4tQGk8GrjReHVzys5C++Zc5ewePVmBUHt6u/ircL5onDE9rcZ81fiftAjBD18hM4BTZA1c0Yl/Y8T5iFn9sxoUr+6OYFgKSRAAjYEKLz26xAUXoOsKbzaAFJ4tfGi8OrnlZyF13JccooUKTBszAwM6PlpFI7Y/hYZGalMwdiwdQ88U6ZEpfIlldPnwsLD4e7mRuE1pxuyFBKIQYDCa79OQeE1yJrCqw0ghVcbLwqvfl7JWXitjz3+dugkDO7TOQpHXH9bsW4b9v15DH17fILDR04qspspoy9OnL5A4TWnG7IUEqDwvsI+QOE1CJ/Cqw0ghVcbLwqvfl7JWXiHj5uDzzs0g0cKD/zw0wx828t6hDfuvx3++yTkNLeHj54oxxrfvR+Ee/cfovfnbZHJ38+cYLAUEiCBKAIc4bVfZ6DwGmRN4dUGkMKrjReFVz+v5Cy8J89cxNI1m+Hm4or3q5VDiSIFEPDZQMwaPxCx/W38tEUICQ3D48dPENCqPnJke7EQ7tiJsxzhNacLshQSiJUAhdd+HYPCa5A1hVcbQAqvNl4UXv28krPwmkONpZAACSQ2AQpvYhN+WT6F1yBrCq82gBRebbwovPp5UXjNYcdSSIAEEo8AhTfx2EYvmcJrkDWFVxtACq82XhRe/bwovOawi6+UR0+e4uepi5A6tTf8fH3QslFNm+QTZiyWw5bx7HkIvuzUCmcvXsaKtVsRGhaGPDmzo1XjmpAt0R49eoLg0FBlOoW/X/rErzjvQAJJhACF136BoPAaZE3h1QaQwquNF4VXPy8Krzns4ivl1027kM4nDcqVLobAUdPRq1treKZMoWS5ev0WVq/fruzru3ztVuTOkRXFixaIKq7nt6Pxfb+uGPLTdAT26YKr128r26J90qp+4lecdyCBJEKAwmu/QOgS3tt3H2DZuh2oUbkU8uTIYlPb8/9ex8bfD6BpvSrwTZfGfi15RXei8GoDT+HVxovCq59XchXe4NAQhISYd4SxcHRzdYG3l3eMYMxbvA6lihdCgby5MHbyArRoXAv+GV6M0P59/AxOnLmAZg1qYNvOgwiLCEP1SmWVv23deQD37gehcb1qigxfuXYT7u5uysK5Lzq2NCfoLIUEHIAAhdd+QdIlvGOmLcXmnX9ixczv4eHuZlNb2bvxw4D+qFWtLDq3dv4ndQqvts5K4dXGi8Krn1dyFd57Qffx17HDyj66Zl1v5HoduV/LAxcX2xJlhNc3XVqULVUUgaOmoVe3NjYjvGs37ETHto2wbM0W5MmZTRnhFcF1dXVFg1qVbQpb+es2eHmmxPtVy5lVbZZDywn6CQAAIABJREFUAkmeAIXXfiHSJbwfftIfjetURquG1WKt6fxlm7Dit51YNn2w/Vryiu5E4dUGnsKrjReFVz+v5Cq8dx/cwx8H9yAsPMwceAAK5nsT+XLliyG8Mod3/NSF8Pb2UkZ2ZQ7vlp37ce36bXzctDZkDm94eDiCQ0LRo/NH2LJjH5as3ozC+fModWvToh72HzqGE6fOK3sGd2zTGG5urqbVmwWRQFInQOG1X4R0CW+pmp0wfVQvFHvz9VhreujoGXToORJ/bphqv5a8ojtReLWBp/Bq40Xh1c+Lwpv4wmtOdFgKCSRfAhRe+8Vel/CWqNEBU0f2xNvF8sda0z8OHkfXvmNwaOM0+7XkFd2JwqsNPIVXGy8Kr35eFF4Krzm9h6WQQOIRoPAmHtvoJesS3sYdvkO1d0uiU+t6sdZ07PRl+H3PYWWOr7NfFF5tEabwauNF4dXPi8JL4TWn97AUEkg8AhTexGNrivDOXbIB42Ysw/yf+6PAGzlsyjx64jzadB+Kzm3qo0OrOvZrySu6E4VXG3gKrzZeFF79vCi8FF5zeg9LIYHEI0DhTTy2pgivrP7t0ns09h06gaoViuPNfLkQGRmJY6cuYNvuw3irUF7MGNULKVJ42K8lr+hOFF5t4Cm82nhRePXzovAmvvBeD7+P8AjzdoNwcXGBr1saeLm82Mv3VVyPlYV4i5QdI7Jny6RsnWZ9TZq1RNk+TRbjyWEasnfw0RPnlG3WmtSrhhLFCirJN277Azv+OITv+3Z9Fc3gPR2EAIXXfoHSNaVBqifSu3j171i7aQ8u/HtdqXHO7JlQ872yaFG/arKQXWkzhVdbZ6XwauNF4dXPi8Kb+MI78s5SHH52xpwgAcjkkR5fZ2yKLG6+ppWptSDrrdYGjZiCAT0/havri/3Y5DANy1ZrC5evx1uF86NgvtzK3y5fvYFVv/2Obu2b4/CxU7hw8SqOHDuFQb07x1kFudfJsxfx7Hkw2rdqgEz+flFpT527hKWrN8PdzQ1VKpRCscL58OOEuXBzdUVERAS+/rwt/r1yA1KPFB4e8EmbGp+2bhjrvaKXVbpEIZt00U/Ek900jhw/gwdBj1C/ZiWULlEYg0dORapU3nj69Cl6fdY2avs5rXyZ3pYAhdd+PUK38Nqvikn7ThRebfGh8GrjReHVz4vCm/jCO/DmPOx7dtKcIAHI6uGHwMxtkfUVCq8cplG2ZGHkfT0nRoyfg04BjZE2dSqljXKYxulzl5RRXxnZFQGsUOYt5Q3nuGmLUOu9cvDy9MSvW3Yr8vndsEnxCm+/HyZiSN8uOHvhMnbuPYyAFi/XxQwbMwtdOzRDKi8vDBw+GYP7vBTnkT/PReumteGf0RcyKi5Xn8DxGDrgs1hjEV9Z8Z2Id/PWXcxdvE45QU/aKPcaO3UhGtethmxZMpoW9+RcEIXXftHXJbwydeHNvLminnqjVzc8PAInzl5C4fwvnnyd+aLwaosuhVcbLwqvfl4UXgqvnt6zbtNOZPRLr4xqDhwxGd/27Bj1W3fl2i38tnk3OrT+UBlZLVY4P/LkyIapc5ehWqUyeDN/HkWET529pJwct/fgUWXag/WRytZ1sgivTIeY+ctq9Oz6cdSfLX+Tf+g3ZAKG9HsxNeLS5WtYtGITvvm8jfL/5eTTMZPnKyfeNahVJdYmx1WWReLjOhFPRn4rly+JQgVebEE6evIChISEKQJsGfXWw5h5XhKg8NqvN+gS3kKV2+LAb5Ph7eUZa00fPn6Kd+p0wfHfZ9uvJa/oThRebeApvNp4UXj186LwUnj19J6Hj55g/PRFSO3liaxZ/NGkfnWMmjgf71cpi8IF38D4aYuU0c7QsHD06NwKw8fNxqPHT+Dvlx4+6dKibfO6UbdNaIT326GTlJHbcxcuY0e0EV4pt1v7ZsqI8aARk5WR4sN/n8SeA3+jw8cfxpg2KCO8g3t3hoeHe4xmx1aWJZH1NA3LiXgF8+fB9HnLUfGdkihaKK9Neb8s+w0F8+aOU+L1ME/OeSi89ou+buHN4u+LGMfu/FfvyIhI3Lh9j8JrMI5N01ZCQPrqtpwjI/Hj3aXY8vgvg6W/zO7vng6DM7VBTg9/mzKPBl9En+szEQ7zFqVQePWHrUDK1zAsUzukdLVdDLr+8Z8Ye2e5/oJjyTk8c3sU9Xx1b2gWBf2OOfc3mdYmT9cUGJIpAG+mtN1V5lzINfS/MQcPIh6bdq86acqgi2/dqFfNUnAkgIn31mDtw72m3cfXLTUCMwUgT4rMNmXa86Q1Z5zSYFqAVBQkc3j/OX1BmcPbsXVDuLi6YsS42Rg56AvIvNslqzbB3dUNVSuWRvas/ujedyQqlC6mlPxepbIIDQ3F5h37FQFP55Mm3jm81mXJHN4xkxagyrsv5gZHPxHvp0nzcfdeEOR3PnXqVKhfqwpmzF+pjFo/Dw5WRq3jGvBS0WwmsSJA4bVfd9AtvLIHr4d7zCdJqbocIzl1/hoKr8E4Unj1A8zpkQlDMgfAzy2NTSH7n53Cdzfn6i84lpy9/ZujondhuODFXDq5gsKfoO+NmTgfesO0e1F49aOk8OpnJznjOlqYwmuMK3PrJxDfQjw58vrnqYuQOrU3/Hx9lCOvZdeM6Avxoi/WexXHWlN49fcBrTl1CW/DdgPwy8QBca7SfPL0OT7+bAiWzwjUWh+HS88pDdpCxhFebbysU1N49bOj8OpnR+E1xo65E4dAfAvxZORcRrzLlS6GwFHTlTnHnilfbHVnWYjXstEHWL1+OzoHNMHytVuRO0fWVzJNg8KbOP0jtlJ1Ca/9qpf070Th1RYjCq82XhRe/bysc1J4jXHkCK8xfsxtPoH4FuLJThuyiK9A3lwYO3kBWjSuBf8M6ZVKWBbiKYvrz1xAswY1sG3nQYRFhKF6pbLmVzSBEim89kNO4TXImsKrDSCFVxsvCq9+XhReLlrT3HtcgDv37ir73Jp1ubi4Il3adPBwdzOrSJYDKIsFoy/qs4Cx3ks5cNQ09Or2YkcL64V4sS3Wi2s3jcQETuFNTLq2ZVN4DbKm8GoDSOHVxovCq58XhZfCq7X3yOlpuw7swv2g+1qzxpneJ206lHu7HFJ62J4e9/TZMwSHBZt2HynI0yMlvDy9bMoMiwjHkyePEaEsnTTnEon3SZXGZmGmOSWrLyX6oj7rhXh5cmfH+KkL4e3tpYzsyhxe2bvYeiFeu48axFisxzm86vk7YkoKr8GoUXi1AaTwauNF4dXPi8JL4dXae+wpvNduXcdfxw5prWK86UsWLQV/P3+bDZSeBT/HgSP78PixeTuR+Kb3Rdni75ha9+RaGEd47Rd5Cq9B1hRebQApvNp4UXj186LwUni19h57Cu/VG9dw4Mh+rVWMN33ZEmWRKUPmGMK75+BuPHr8yLR7ZfDNgAqlKphWXnIuiMJrv+hTeA2ypvBqA0jh1caLwqufF4WXwqu191B41RGj8KrjpCYVhVcNJXPSGBZe2fD6zr0gPHryLEaN8uTIYk4tk3ApFF5twaHwauNF4dXPi8JL4dXaeyi86ohReNVxUpOKwquGkjlpDAnv4WNn8M33U3D1xp1Ya8OjhY0FiQdP6OfHgyf0s5OcPGlNPz+etKafXVYPPwRmbousbr76CzGQk8KrDl6SEN6X5/yoq3RCqcxb05fQnWz+TuHVhMtQYkPC2yCgP3zSpsJnnzREBl8fuLra9sAc2TIZqpwjZOYIr7YocYRXGy+O8OrnxRFejvBq7T0UXnXEXrXwPnn2GCfOnkRwsHm7XGRInwH58uSz+84TFF51fc6MVIaE963q7TFmUDdULveWGXVxyDIovNrCRuHVxovCq58XhZfCq7X3UHjVEXvVwvvoyWPsObgHz54/VVdhFamyZ82BkkVKWB0QryKTCUkovCZAVFmEIeFt3nkwGtaqiKZ1K6u8nfMlo/BqiymFVxsvCq9+XhReCq/W3kPhVUeMwquOk5pUFF41lMxJY0h4d+77G4Gj52LxlIFIkcI9Ro28vTzNqWUSLoXCqy04FF5tvCi8+nlReCm8WnsPhVcdMQqvOk5qUlF41VAyJ40h4S1UuW28teCiNWNB4qI1/fy4aE0/O8nJRWv6+XHRmn52XLSmn53kTC778HJKg7F+klxzGxLeQ0dPx8utRJF8Ts+VI7zaQswRXm28OMKrnxdHeDnCq7X3cIRXHTGO8KrjpCYVR3jVUDInjSHhNacKjl0KhVdb/Ci82nhRePXzovBSeLX2HgqvOmIUXnWc1KSi8KqhZE4aw8J78uy/OHL8LJ4+i7k9SEDzmubUMgmXQuHVFhwKrzZeFF79vCi8FF6tvYfCq44YhVcdJzWpKLxqKJmTxpDwrt64G32HTkdGPx/cvhuEHNn84e7ujnMXr0JOWVszd6g5tUzCpVB4tQWHwquNF4VXPy8KL4VXa++h8KojRuFVx0lNKgqvGkrmpDEkvHVb98EHVUqja8CHqNSwO2aP6Y3cObLgq0ETIfN3WzWsZk4tk3ApFF5twaHwauNF4dXPi8JL4dXaeyi86ohReNVxUpOKwquGkjlpDAlv8RodsHDiABR4IwdqtvoGw/t9iqJvvo712/ZjwqwVHOE1GCPu0qAfIHdp0M9OcnKXBv38uEuDfnbcpUE/O8nJXRr08+PBE/rZOUpOQ8JbqmYnTBnxFUoUyYv2PUei+rsl0ax+Vfxx8Di69B2DwxunOQoH3fXkCK82dBzh1caLI7z6eXGElyO8WnsPR3jVEeMIrzpOalJxhFcNJXPSGBLe+gH9ULd6ObRvWRtzl2zAvGWb8FXHpli6bjsePXqK/035zpxaJuFSKLzagkPh1caLwqufF4WXwqu191B41RGj8KrjpCYVhVcNJXPSGBLeg0dOISIiEqWLF8Dz4BD0GDgBcvparuyZMfLbzspUB2e/KLzaIkzh1caLwqufF4WXwqu191B41RGj8KrjpCYVhVcNJXPSGBLe2KoQGRkJFxcXc2rnAKVQeLUFicKrjReFVz8vCi+FV2vvofCqI0bhVcdJTSoKrxpK5qQxLLxPnz3Hn3+fwY3bd9GkTmWEh0dATmCT3Roy+PqYU8skXAqFV1twKLzaeFF49fOi8FJ4tfYeCq86YhRedZzUpKLwqqFkThpDwiuHTnT65ieEhIQi6NETHP99tlKrbn3Hwjd9Ggzu9Yk5tUzCpVB4tQWHwquNF4VXPy8KL4VXa++h8KojRuFVx0lNKgqvGkrmpDEkvG2/GIY38+ZEry7NUbhKQJTwbtl5CCMmLsSGhSPNqWUSLoXCqy04FF5tvCi8+nlReCm8WnsPhVcdMQqvOk5qUlF41VAyJ40h4ZVtyVbMDET2LBlRqHLbKOGVkd/mnQbhr80zzKllEi6FwqstOBRebbwovPp5UXgpvFp7D4VXHTEKrzpOalJReNVQMieNIeEtV7crZo/tg3x5stsI77ote/HjpEXYtnSMObVMwqVQeLUFh8KrjReFVz8vCi+FV2vvofCqI0bhVcdJTSoKrxpK5qQxJLz9h8+ALFob3r8T3qrWThnhPXfpGrr0Ho3ypYvg2y9bm1PLJFwKhVdbcCi82nhRePXzovBSeLX2HgqvOmIUXnWc1KSi8KqhZE4aQ8Ib9PAJPu31I67dvIN7Dx7htaz+uHL9NvK//hpmjv4GPmlSmVPLJFwKhVdbcCi82nhRePXzovBSeLX2HgqvOmIUXnWc1KSi8KqhZE4aQ8IrVZBtyHYfOIrjpy8iMiIS+V/PgUrlisHdzc2cGibxUii82gJE4dXGi8KrnxeFl8KrtfdQeNURo/Cq46QmFYVXDSVz0hgWXnOq4bilUHi1xY7Cq40XhVc/LwovhVdr76HwqiNG4VXHSU0qCq8aSuak0SW8c5dsUHX31k3eV5XOkRNReLVFj8KrjReFVz8vCi+FV2vvofCqI0bhVcdJTSoKrxpK5qTRJbyyBZlnyhRImdIj3lrsWT3BnFom4VIovNqCQ+HVxovCq58XhZfCq7X3UHjVEaPwquOkJhWFVw0lc9LoEt7P+o3FvsMn0LReFbRt+kGyOEI4LtwUXm0dkcKrjReFVz8vCi+FV2vvofCqI0bhVcdJTSoKrxpK5qTRJbxy67MXrmL6wnWQU9UafFAen7SojSz+vubUyoFKofBqCxaFVxsvCq9+XhReCq/W3kPhVUeMwquOk5pUFF41lMxJo1t4Lbe/duMOZi76DWs27UGNSqXwVcemSOeT2pzaOUApFF5tQaLwauNF4dXPi8JL4dXaeyi86ohReNVxUpOKwquGkjlpDAtvaGgYVvy2E1PmrUF4RARmjf4GuXNkMad2SaCUiIhI5dQ4aWNoWBjee7ckBvUMUOYwy0Xh1RYkCq82XhRe/bwovBRerb2HwquOGIVXHSc1qSi8aiiZk0a38D4PDsHStdsxY+E6eLi7o33L2mjwQQWkSBH/QjZzqm2/Uhat2oo5i9djwtAv4e2VEr0GT0KxQm+gZ6dmFF4dYaDw6oD2X5YCKV/DsEztkNLV9jO2/vGfGHtnuf6CY8k5PHN7FPXMbWqZWgpbFPQ75tzfpCVLvGk9XVNgSKYAvJkyh026cyHX0P/GHDyIeGzaveqkKYMuvnXh4uISVWYkgIn31mDtw72m3cfXLTUCMwUgT4rMNmXefXAPfxzcg7BwCq9W2BRedcQovOo4qUlF4VVDyZw0uoR3xsJfFQlMlzY12reqjVrvlXXagybadB+K9yqUgGWLte1/HMHgn+Zgy5KfKLw6+iCFVwc0Cq9+aP/lpPAaQ1gw35vIlysfrBxeKXDgzXnY9+ykscKtcmf18ENg5rbI6vZq1oNQeNWFksKrjpOaVBReNZTMSaNLeGVbMt90aVChdNEYX4DW1fqhTwdzavkKS6nUsDsCv/4EFcsWU2px6cpN1ProGxxcPxVeninw6Gmo8u9HHv2L3tdn4klEsGm1bZa2Ijpnfh+urq5RZYZHROL7a4ux5fFfpt3H390HQ7O2RV5v25Gi/Q/P4ZtrsxCOcNPu1dmvDpplKAdXq1/OkPAIdP93Ko4HXzLtPjk9/DEi2yfI4uljU+bvQf/g2+vzTLuPFNTXvylqpH/Lpk13gh+h55UZOB9607R7FUiZHaNf64BU7i+m08gVGQmsvLcPo2+vNO0+UtCILO1Q1ucNU8tUW1hEZCRm396K2fc2q82SYDoR3qFZ2qJkGttR6+OPr6DPNbNHeEvjq8wN4Ob2coQ3PAIYfWMVVps8wvtD1rZ4M1U2m/ZfvXUbO/ebO8JbKF9BFM1fEG6u1m2KRJ/Lc7D32akE+atNkNXDF8OyBSCXZwa1WUxNFxwahs27d+B+0H3TyvVJmw5V3imP1J6eNp/bM5cvY//h/abdRwoqV/Id5M6W1eZ3+eGTp9i2dxcePX5k2r1EeKuXr2jTH0wrXEVBdx48xPZ9u/Hs+VMVqdUleS1rDpQv+Tbcrfq4upzGUqXxdq634sZoJG5uXcLbd+g0VbVyBuEtXasTxg/pjjLFCyptvnn7Pqo2+RI7V45XpN9ynXt8B5ee3kEk5OWlOZe3qyfK+uW2+fIS4d177zyeR4SYcxMArnBFvtSZkM07nU2ZJx/exNXn90y7jxTk454KJdPniNGm3XfOIhTmvYJ1gysKp82GDJ62CyiPPriGWyFBprbJzyMN3kqf3abMoOBg/BV0CWEmPiy4ww0VMuS1+ZER4f3rwRXcCzXvx0wakiVlerzpY/sAdOP5Q5x8eB3hiDCNn0zPeMf39Rht2n/vIh6HPzPtPoALXvPyRb40/jZlXnpyH+ee3EKkiW3ylDb5vQHr301ZCyCf22cmfm5d4Io3Uvsjh3d6mzbduBeEBw/Nm6IhhcuahRyZM9g81Embdt87i5AIcz+3+dNkQRavtDZtuno7CI+emNsmb09PvJbZDy8VHpDv13NXbiIy0rw+LlNbXsuUAV5W+9bL5/bK7Xt4+uy5iX0cSO3lhWz+tv3hybNgXL193+Q2ueL17JlifG4vXr+D58HmDfoovxlpUiFrBtvfpqDHT3HzXhAiBaRJl7urO3Jly2jTpohI4Py1WwgNeTGwZdbl55MW/r4v/cGscllO/AR0CW9ygiojvEN6t0eF0kWUZsc1wpucmLCtyZPApWd38PWVmbgadtc0AGW9C2B49rY2o6GmFc6CnIbAvzduYvvenaa25+2ixVEgVx642HlEz9RGJKHCRD6Pnz2Hw8fNe/sobwIrln0Xr2WyfVC1V7Ploe7g8WM4dc68txgpPDxQscy7yJLhxbQdjvDaK5oAhTcB1q0//wHVK76NjxvXUFJu23MYg0bNwe/Lxij/37JLg/1CxjuRwKshcD3sHgbcmG2q8JbxLoCBGT+WAVheJBAngTv372DX/l2mEipeuDhyZs2BeOflmXpHJy8sMhLnL1/E3yeOmNZQEd7ypSrAL72faWVqLej4mRM4c95c4X3n7fJIn/bFqDXn8GqNiP70FN4E2C1Yvgnzl23GpGGyS4Mnvho0EW/my4k+n7Wi8Orvd8zpgAQovA4YNCepMoXXAQJJ4VUVJBnhpfCqQmV6IgpvAkjDwyMwfMJCrN64G2FhYahSvriyD6/IL0d4Te+PLDAJE6DwJuHgOHnVKLwOEGAKr6ogUXhVYUqURBReg1g5pcEgQGZ3GAIUXocJldNVlMLrACGl8KoKEoVXFaZESUThNYiVwmsQILM7DAEKr8OEyukqSuF1gJBSeFUFicKrClOiJKLwGsRK4TUIkNkdhgCF12FC5XQVpfA6QEgpvKqCROFVhSlRElF4DWKl8BoEyOwOQ4DC6zChcrqKUngdIKQUXlVBovCqwpQoiSi8BrFSeA0CZHaHIUDhdZhQOV1FKbwOEFIKr6ogUXhVYUqURBReg1gpvAYBMrvDEKDwOkyonK6iFF4HCCmFV1WQKLyqMCVKIgqvQawUXoMAmd1hCFB4HSZUTldRCq8DhJTCqypIFF5VmBIlEYXXIFYKr0GAzO4wBCi8DhMqp6sohdcBQkrhVRUkCq8qTImSiMJrECuF1yBAZncYAhRehwmV01WUwusAIaXwqgoShVcVpkRJROE1iJXCaxAgszsMAQqvw4TK6SpK4XWAkFJ4VQWJwqsKU6IkovAaxErhNQiQ2R2GAIXXYULldBWl8DpASCm8qoJE4VWFKVESUXgNYqXwGgTI7A5DgMLrMKFyuopSeB0gpBReVUGi8KrClCiJKLwGsVJ4DQJkdochQOF1mFA5XUUpvA4QUgqvqiBReFVhSpREFF6DWCm8BgEyu8MQoPA6TKicrqIUXgcIKYVXVZAovKowJUoiCq9BrBRegwCZ3WEIUHgdJlROV1EKrwOElMKrKkgUXlWYEiURhdcgVgqvQYDM7jAEKLwOEyqnqyiF1wFCSuFVFSQKrypMiZKIwmsQK4XXIEBmdxgCFF6HCZXTVZTC6wAhpfCqChKFVxWmRElE4TWIlcJrECCzOwwBCq/DhMrpKkrhdYCQUnhVBYnCqwpToiSi8BrESuE1CJDZHYYAhddhQuV0FaXwOkBIKbyqgkThVYUpURJReA1ipfAaBMjsDkOAwuswoXK6ilJ4HSCkFF5VQaLwqsKUKIkovAaxUngNAmR2hyFA4XWYUDldRSm8DhBSCq+qIFF4VWFKlEQUXoNYKbwGATK7wxCg8DpMqJyuohReBwgphVdVkCi8qjAlSiIKr0GsFF6DAJndYQhQeB0mVE5XUQqvA4SUwqsqSBReVZgSJRGF1yBWCq9BgMzuMAQovA4TKqerKIXXAUJK4VUVJAqvKkyJkojCaxArhdcgQGZ3GAIUXocJldNVlMLrACGl8KoKEoVXFaZESUThNYiVwmsQILM7DAEKr8OEyukqSuF1gJBSeFUFicKrClOiJKLwGsRK4TUIkNkdhgCF12FC5XQVpfA6QEgpvKqCROFVhSlRElF4DWKl8BoEyOwOQ4DC6zChcrqKUngdIKQUXlVBovCqwpQoiSi8BrFSeA0CZHaHIUDhdZhQOV1FKbwOENLISPx7/QrOXjhjWmVdXFxQrFAx+Pr4mlamloIiAdy8dQNPnj3Rki3etC4urvDP4I/U3qmUdFn9vEwrmwXFT4DCa7CHUHgNAmR2hyFA4XWYUDldRSm8jhHS4OAQREZGmFpZN1dXeKRIYWqZmgpzcQEiRX0T56LwJg7X2Eql8BpkTeE1CJDZHYYAhddhQuV0FaXwOl1I2aD/CFB47dcVKLwGWVN4DQJkdochQOF1mFA5XUUpvE4XUjaIwmv3PkDhNYicwmsQILM7DAEKr8OEyukqSuF1upCyQRReu/cBCq9B5BRegwCZ3WEIUHgdJlROV1EKr+OFNDw8AqMnL4D8t1K5Eij7dpGoRixY8ivu3A9CBt90aNW4JsZOXYjnz4ORNVMGfNysDqL/Pam0/satu5i5YCVkRm+Hjz6Ef8YXi+mitzVvntcwbd4KPA8OxvtVy6F08cJxsuCUBvtFl8JrkDWF1yBAZncYAhRehwmV01WUwut4If3n1HlcvnpDEb5RE+fjqy4fKY2IiIjE+Km/oHunVvhp0nx82akVZDcGuQJ/nIp+PTrE+fdXTWHh8vWoXP5tRXB37j2EFg0/UKoUV1sfPn6CmfNWokbVd2JlIXkpvPaLKoXXIGsKr0GAzO4wBCi8DhMqp6sohdcxQnru4hUsWbkJhQq+Dr/0PoCLC8qVKoofJ8xDz64fK414/OQp5i35FZ3bNsbEmYvRpnldpPL2wrETZ/HP6fOoVa1CrH9/VQSs23Tl2k20blYHEZGRmP9fG6Ree/YfibWtS1ZtQoG8ufHo8ZNY/07htW9UKbwGeVN4DQJkdochQOF1mFA5XUUpvI4XUi0jvCfPXMQfB/7GJ63qxzsC/KopWI/w7tp3GM0/fD/OEd51m3bCy9MTVd8tFecIMIXXvhGl8BrkTeE1CJDZHYaUrJmdAAAgAElEQVQAhddhQuV0FaXwOl5ILfNaIyJezOEtU7IIvh44FiMGdo+ao5vRLx1aNqqJFh16o2zJF3N8P23TGMvXblHm+Fr+nlRab5nDK/Vp/9GHSh33HjyKNs3qKHN0LW318UmLH8fPQREZ6fZLhxYNa9r8XVhYLk5psF90KbwGWVN4DQJkdochQOF1mFA5XUWDHj/EjZvXTW2Xb3o/ZPTNYGqZLIwEtBKg8Golpj89hVc/OyUnhdcgQGZ3GAIUXocJlfNVVJbFu5h72pUc8fp/9q4DvKpiWy9C7yCgFBFQFESkKCC9995L6D0QOiQhgRBKQoAkQKih996L9N57EwSlIyKKSEdUyvv+xdvnnhxOkrPL2eQka973vnsvObNn5p/Zs/9Z86+13jgxg1bcmwQZkTMQEMLrDFTtP1MIr06shfDqBFCquwwCQnhdZqqko4KAIOAiCAjhNW+ihPDqxFoIr04ApbrLICCE12WmSjoqCAgCLoKAEF7zJkoIr06shfDqBFCquwwCQnhdZqqko4KAIOAiCAjhNW+ihPDqxFoIr04ApbrLICCE12WmKs53NKpMXEeOn6N9R06Tm5sb9evWitZu2k3Xbv7KGa98e3egB4+e0KoNO+jly5fk2bFZnMdJBhj7ERDCa94cCeHVibUQXp0ASnWXQUAIr8tMVZzuaHSZuhAaCpm7EAM1V46PKd8XuRiLybOWU/MGVWnpmm2UKGFCevnqFXVp24gSJ0oYp7GSwcV+BITwmjdHQnh1Yi2EVyeAUt1lEBDC6zJTFec6+t/LVxQ2aT6lTp2CM3PZy9SFQSsZvQ4ePUsJ3N5m+Xr46AnNWrSOU9silS0sv7v3n6DESRJR6e8KxTmsZECuhYAQXvPmSwivTqyF8OoEUKq7DAJCeF1mquJ0Rx218H6a42PK/GEGmrdkA3Vq04BSpUxBo8LnkFePtnTizAX659+XVLZE4TiNlQwu9iMghNe8ORLCqxNrIbw6AZTqLoOAEF6Xmao431FFw6tk4lIyeB0+cY4OHDlDCRIkYEvukFFTKFWKFJQ8WRKqVbUMa3h37j1GSZMlIc8OTSlJksRxHisZYOxGQAivefMjhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0GASG8LjNV0lFBQBBwEQSE8Jo3UUJ4dWIthFcngFLdZRAQwusyUyUdFQQEARdBQAiveRMlhFcn1kJ4dQIo1V0Ggd9ePqCwe8vp7ssHhvW5UPLcNCBDY6IEhj1SHiQICAKCgMsgIITXvKkSwqsTayG8OgGU6i6DwAv6j/56+YTe0BvD+uxGbpQ5UTpKIIzXMEzlQYKAIOA6CAjhNW+uhPDqxFoIr04ApbogIAgIAoKAIBBPERDCa97EC+HVibUQXp0ASnVBQBAQBAQBQSCeIiCE17yJF8KrE2shvDoBlOqCgCAgCAgCgkA8RUAIr3kTL4RXJ9ZCeHUCKNUFAUFAEBAEBIF4ioAQXvMmXgivTqyF8OoEUKq7LAJHjp+jfUdOk5ubG/Xr1orc3N6GWrj7x32avWgtu7Z1btWAPsz0AT17/jd19x5Fs8KH0PmLV2n7niP05Mkz6ti6PuX4OIvLYiAdFwQEAUFADwJCePWgp66uEF51eL3zayG8OgGU6i6LwLiIRdTXoyV9v30/5crxMeX7IhePZcnqLVS+VBF69eo17T9yilo0rE4z5q+h+389pAE921BCNzdKkCABHT99gZ48fU4VyxR1WQyk44KAICAI6EFACK8e9NTVjZOE9/xP12lo6Fy6cv02Zc2ckXx7tqQy3xWIEpnofr//6A/k4RMWqW7ixInozPaZ/G9CeNUtOPm1ayMwf9lGuvPbPerStiHNXryeBni2poNHz1ICtwRUsujbd2zqnBXUplltev3mDS1csYlyZc9CObJnpR17j1K3Dk0oUcKEdOb8z7R45Wby7dOe0qdL49qgSO8FAUFAENCIgBBejcBpqBbnCO9//72kau5e1KJ+JWpWryLtPXSGho+bT1uXhNAH6VK/A1FMvwfhHTFuHq2cOdxSFxe3qVOlEMKrYcFJlbiDgLWF99McH9OXdiy8B46epufPX9Dr16/p5LlL1KBmeapaoQSDcP3Wr3Ts1AVqVr9q3AFFRiIICAKCgAoEhPCqAEvnT+Mc4T12+hL19p9AB9dPtmgKm3YdSs3rVaSGNcu+A1dMvwfhDQpfQFsWj7ELtVh4da5Aqe6yCBw+cY4OHDnD8gRoeJet3Up5PstBWbN8yBpelE7/r+HFf584YylbeI+eOE+o+/z539SqaS36NEc2l8VAOi4ICAKCgB4EhPDqQU9d3ThHeJev302rvt9Hy6YFWJDwHhFBH2X6gPp7NH0HnZh+D8Lr6TeO0qdNTWlSpaBihb+k3p0b839HEcKrbsHJrwUBQUAQEAQEAUHgLQJCeM1bCS5FeB89fkav37y2i06qFMkJ2tp5K7bSzv0naf4EP8vvhoTMpsSJEpF/3zbv1I3p9w8ePaHf7z2gtGlSsfd5WMRyypQhLY0b1oOf9eaNcWlWzZt2aUkQEATMQOCf/15T0sRuZjQlbQgCgoALIoAbMinmIOBShLdZ12H06Mkzu8gE9GtLJYp8RbDYrtlygJZM8bf8DhbeDzOlpwEezd6pq/b3p89fpra9g+nsjll8lSsWXnMWqrQiCAgCgoAgIAjENQTEwmvejLoU4XUElqOnL1LfIZPo4PpJTEhRGncOoGb1KlCT2uXfeYTa3x88fp58AqfRgXUT+VlCeB2ZFfmNICAICAKCgCAgCNgiIITXvDUR5wjvv//+R1WaD6A2TapR0zrlad/RczRkzGx2OsuUIR29fv2GOg8IoXbNqnOosph+P2vJJvo4S0Yq+FVuevjoKQ0ePYu+LfAFhzoTwmveQpWWBAFBQBAQBASBuIaAEF7zZjTOEV5Ad/bHqzR87Dy6cv1Xypo5A3l1b0EVSxVmVF++ekUFK3WkYQPaU+Pa5fjfovv9ms37ae7yLXT7zj0ORVa1XFHq26UJJU+WRAiveetUWhIEBAFBQBAQBOIcAkJ4zZvSOEl4zYNPJA1mYi1tCQKCgCAgCAgCcQkBIbzmzaYQXp1Yi4ZXJ4BSXRAQBAQBQUAQiKcICOE1b+KF8OrEWgivTgCluiAgCAgCgoAgEE8REMJr3sQL4dWJtRBenQBKdUFAEBAEBAFBIJ4iIITXvIkXwqsTayG8OgGU6oKAICAICAKCQDxFQAiveRMvhFcn1kJ4dQIo1QUBQUAQEAQEgXiKgBBe8yZeCK9OrIXw6gRQqgsCgoAgIAgIAvEUASG85k28EF6dWAvh1QmgVBcEBAFBQBAQBOIpAkJ4zZt4Ibw6sRbCqxNAqS4ICAKCgCAgCMRTBITwmjfxQnh1Yi2EVyeAUl0QEAQEAUFAEIinCAjhNW/ihfDqxFoIr04ApbogIAgIAoKAIBBPERDCa97EC+HVibUQXp0ASnVBQBAQBAQBQSCeIiCE17yJF8KrE2shvDoBlOqCgCAgCAgCgkA8RUAIr3kTL4RXJ9ZCeHUCKNUFAUFAEBAEBIF4ioAQXvMmXgivTqyF8OoEUKoLAoKAICAICALxFAEhvOZNvBBenVgL4dUJoFQXBAQBQUAQEATiKQJCeM2beCG85mEtLQkCgoAgIAgIAoKAICAIvAcEhPC+B9ClSUFAEBAEBAFBQBAQBAQB8xAQwmse1tKSICAICAKCgCAgCAgCgsB7QEAI73sAXZoUBAQBQUAQEAQEAUFAEDAPASG85mEtLQkCgoAgIAgIAoKAICAIvAcEhPC+B9ClSUFAEBAEBAFBQBAQBAQB8xAQwmse1u+lpdev35CbW4L30razGjVrTGa1A5zMasusdpw19/JcQUAQEAQEAUFACwJCeLWg5iJ1Xr16TR36jaYJgb0obeqUTu31f/+9pO37TlLNSt85tZ2bt3+n0IhlNDGwl1PbwcP9x8ymRrXKUqGvcju1rbg4JgC2eddRqlT6G0qSJLFT8Xv89DmlSZXCqW3g4WatcbR1/MwlypY5I2XNnNGp48KYXr56TcmTJXFqO2aO6e69v+jGL3ep+Df5nDomHB6fPf+bUpuw9swak5nvrVljiovvrVMXdhx+uBBekyf3h4vXaOGq7XTn9/tUvmQhatOkGiVOlJD+fvEv3bl7jz7Lmc2wHm3fd4JCpy6jzYvGONXKiw2lb8BkOvXDz7Rk6hDK8fFHho3B9kEjJyykZ89fUNDATk5rAw/+869HVKX5AFo/N4iyZ/3QqW3FxTHNWLSRxs9YSWOHdqcqZYs6Zf3hQNdjUDivu48yfcBr4uu8uZwyV8oav/7Lb7RyxnCnEsQjp34kT9/xNKh3K2pYs6xTxoOHHj5xgfoETKIkiRNR7SolqV/XprwXOaMoY8IBsm+Xpk7DDySqfZ9RlPGDdHwoTpc2lTOGQ7/fe0BtewfT4yfPqEC+zyjQpyNl/CCtU9pSxlTwq9w0yq+LU9pQHor3NmL+et7Hv/j0Y6e1ZdY8vY/3tnm9itSzY0NKltT5h0inTVAcfbAQXhMndsvuYzRw5HRq2aAyYfNasWEPZcqQlvz7tiVP33GUNk1KGjesh2E9atdnFFvYWjeuatgzbR+kbCh/PnjEba3ZvJ+++foLGjagPSVM6GZouyC6FRr3ofkT/Chv7k8Mfbbtw6bMXUsXr9xyuiU5Lo4JH815y7dS51a1ad+Rs/Tk6XOaFNSHPsyYztA5u3z9NjXs6E9HNk6lazfvUM/BE2jBRD/DDyjKGsdHOnvWTHT6/BXq3q4+Na1T3tDx4GEghj0HTaCq5YoQDsdZPspAw7zaU+ZMHxjeVp8hkxirXp0akV/wdEqfNjX59WpleDvKmDq516Lffr9PB46do5Ah3ahw/s8NbUshUXguyOe6rQepS6s61LJhZUPbwcMWrd5BG7YdpKURAbR4zU7e9xZPHkyJEycytC1lTJ/myEpPn/1Nfz14zOsBe6zRRXlvYYjBYahCqcLk49nCaWNy9jy9j/e2XdNqbMw6cvJHGj24KxUpmMfoaZLn6UBACK8O8NRUvf3bPWrQYTAF+3WhymW+5ap4IZt5DKPEiRJRyhTJaHJwX8MsHyADLT0DaffK8fxslEtXbvHVr1HXpNZkd0bIAL7a+/ff/6hRpyHUoUVNalCjjBqIYvwtPjKwWs8dP5B/++bNGzp88gIVKZDH0Gvz/16+ospN+1HokG5UtFBebuve/Yd0994Dwy2IcW1Mykdz9jgfi4UIh7wUyZPRkL5tYpxjR34AAv3vfy8pdcrkVLlZf7bslvmuAKHtW7/+QSO8O/Bjzv14lb7feYR8e7Z05LF2f2NvjV+5/it5B0bQgomDLO+W5gasKirEMKBfW6pdpQTBgh08cRFlz/YhtW1SzYgm+BmQ0OAWZv6KrbRp11FaMsWfnv/9D1Vr4UUrpg9lkm1UsR0TngtyOGvJJto4P9ioZkghhiWK5Cf/Pq0pQYIE9MudP6hGSx/avXIcZcpgzGFLwe7i5Zts4d20cDST684DQqlu1ZJUp2pJHtPSdbsoebKkVK9aKc1jtDcmrOctu47SxKDemp9rr6LtewuZUA+/8TTAoxlbsI0qZs3T+3xvgdXqTftoztLNtMHANW7UHMTn5wjhNWn2py/cQD9cuh7JYggZQ+cBIXylqJDdA8d+IFiC8dHGpq21DA2dS8mTJyXv7s0Jz5y7bAtd+PkGdW9bj2UUeou9DQXPBAlt2nUY1a9eilo2rKK3GUt9PLd2G1/q79GMShXNz9abecu30MuXr9jiYaReDx+V2Us20aqZw+nna7e5na17jvHVPK4ujbJcx7Ux2SO7mEBYXiER6dO5MR9O9OIXEDqHLfwt6leijTsOU/jMVbR+7kh6+uw5/f3iH/ok20dMdrt4h3GbuGLUUqJa43jWy5ev6aert/ixX36eQ7dkwx4xxLOhEwVxu//gMbejV2v72x9/UYtuw2nXinH06tUratwlgPEBlifP/UzfFviCibbeOULf344pnAL6tWMCrxS0g38/tGGylml5p449EoUf4YCPwzeslFXLFzXESg4CPSmoF0vPsA5x+Bo71JMu/HSDYIXF/IDsQs4zfUx/zWQxqjFhXPfuP6Kbt+9Srk+yUIb0aXRjGNV7a/QaN2ueYsN7u2DlNpo8dy2NHNiJvvsmn6EHY90THo8fIITXpMmHReP4mYsUMbo/twiyCxkDikJ2YQVOlCgh7Tt8lprWraC5ZzidV2jUh6UMO/efJLeEbiyjgE4vRfKkmp9rXfGff/+jCbNWkUfrupGcNkKmLqVdB06zpShVyuT04p9/DdEyHTx+nryGT6Xm9SuyFCRv7hx8VVm2eEHdZMMWEPfuIyjHx5np3l8P6fK129S4djlqVrei4VfycW1Ms5duotLFCkTS/k2avYZWbNxDXVvXpT2HTtODR09p6qi+uvSOcOjyHTmdVs0cwTKgum39qFvbelSj4luHSSPILp4T1RrH7Qk069DopU6VnB4/eU5TgvvSR5nSa3639h/9gR49eUq1K/+PGOI9Hhg0jQ9duXNmpas3f6Mgn05UrPDbWwetpWO/MVSyaH7q2KImH+Qmzl5jsbaClHT1DuPbjc9zaddwKgQeGtrw4T0o3xc5ubu4PcEhP3fObDS4T2utQ4hU79e7f9KaTfvJs319i5Hgzt0/qU2vkVSmeEF22F275QB1bV2Hib2eAn3r2R+v0pTgPryWy9TvSXtXh1vWsxFkF/2zNyYckHG4W75+NxPpqzfvUKtGVXRb/+29t85Y42bN0/t+b/Eu9xkykfekW7/+TgePnWcJzzdfGyvh0bOO42tdIbwmzTwsAZAYfJUnF1/1R8xfF4nsKh+IRZMH63YWgGWjVY9AJh/uDSpbPpDQz+HUies4WIt6d2pk2FUfBjNu+gq+Qp4f7suyCZy0YUEqVSQ/W2b1WI2WrdtFY6evoHrVSpN7g0qUM3tmxs/oMWGzrNV6IOOCQ0K18kUtGjZcxeL/8eEBAba2WmlZRnFxTNY4QAe9bP1umjN+IH36SRb+k0/gNCaperWi0E2CXFQoWYhgTZk/0Y/y58llGNmNaj5hqYY0Cbcvk0f2oa+//JRvG9ZvPUizxnprWQZ262CNQYOPd7lnh4ZMbCCl6O47jlbMGKYr6gqsxV28QqnAl58yaYIUCWNRLHAPHz1l7WHDWmWpQsnCqscEgo69DtKM9OlS07CwueynAGlV+MyVrEVdOGkwy4S27T1OiRIm5MOKngODdSeZ7PYOZunYwB7u/CcQD7zXe1dPoA/SpVY9JqUCLO44hDx8/JT3iP1Hz9G2paF8+DGK7EbVORweF6zaRiWLfEVhAZ70/O8XLKuAZMdIrahZa9yZ82SLoVljwm1q34BJFOjTib8dKCs37mVH9bVzAjWvO6loDAJCeI3B0aGnQN8KQjhs7Dz6Jv/nFstuVNeZDj00ih+BuCW1CgeFj2XbPsFUutjXTLhP/XCZNmw7xNf2Rlh93yG7L1+xxzesVIOCZ7CebYy/h54hscXNjDHZtoNOY852HThFfbs04WvEsIjl5N6wsm7Hpbg4JuBlj+zi3z18wujTT7KSt2cLXWsBlUEGYSXHNTxCx1lbdpvVrUCvXr/m63k3NzfDog/gVuPi5Vvk29OdegyaQEE+HZn0FqnehQ5vmGI5HOFd1xOODU4vPkHT+P30HhHBH89m9Sqy9bVd0+pUoshXjN/LV6/ILYGb6lsO3LwgbBz+s371MmxdRnQDRQMLxzzvEVOpd6fGFl2qoxMGzM/+eMXiWLVt7wnWV0NuAoeobm3q0e6Dp8k/ZDYfWEC48b8nBfXWLAFQ+maPROFvWButegbR/jUT+cClt+w9fJau3vyValQsTlk+/CAS2c2f99P/X3uvKEnixKrnxl7foLEuVa8HO2Vu23Oco0TAHwTWWTi+wnihFL1rz4w1btY8KZiYMSZ7ZBftz1z8PcsUV84YpnfZSX2dCAjh1Qmg2uogOLgWg/cw9F62ZBchlrbuOc4ezNUrFFP7+Ch/D6tUqWJfsxOCUqCjq1j6m0jOZSDGn+XMqko/jGvK4WPnUbc2dSld2tTUc3A4e6mChAT0b0ef5shCTToHsJUXhNuo4swxWfcRjnLDwubRsmkBHBtVIVsIibVjWZjlp7BoQ5YCbZ3W4uiYYEXTEzbI0THhw5osWRLVFkVoxsuWKGix7AIPHBI27zpCy6cP02Vls4etQnY/zpKJrly/TcmSJSW3BAnYGo/bhmlj+vO18+5Dpylj+rRMUrWUwaNnUbYsGZm0wWoI0lul7Le0Y/9JWjcniP8N1iSv4RG0etZbyYWWAqvxui0HCM5/ivwJnvmL1+7gdnBNf++vRxQ6dSnLAzzbN9DSDNeJSlsJHSrWM+QNRpYff75BLXsE0bihnkyAUXBwGTFuPm1cEMwWX62kDdfmOMh7tKlr6TLmpE2vYLaSI1KE0QWW3bHTlrOzH6KFpE6ZgtcdSunvvmZiijHBylercnGOhqG24Carurs3nd4+kwk02rv7x1907dZv/C1BVA84bEI2tOvgaYtjr9p28Hsz1rij82SUJM6MMUHKgEMd5kIpmAtI8aaHDOCDuZT3i4AQ3veIvy3ZVWK/dm5Zmy78dJ1SJk/GoU30OK9heNdv/UbQpe5bOzGSpQvORCW+/YolAihKf6aH9NccMgin2Z0HTtHU4L506vxlGj1pMfn0cGcLT+Na5TiRAwrGComDls3f7DENGD6VvvoiJ7VvXsOyWmBd7Nh/DB1cN4n/TXGUePnqpUWnrXZpOTpPwBLX+PAQh05aS3FkTAoRaly7POs99RTcAGzYfog/xHAqw1qDRQTXy3i+nsQRIITVWgzgUGFwwCpeuzutmTXinWgDsDzOXb6FdfJaox5s2nmU5i7fTIun+DOJAZnq4hVGYwZ3Zetkqx5BdP6n63ydrydKCQhOo85DWKcMCyLG2N13LFUs9TbM4KET56n7wHHsPAVSrCexDDS9ObJntkQ3wDyD6Db3GM6Or2i/bZPqVKnMN3qWgKUuHGoxB7YaXvSjd5fGlCFdGvLwDqPBfdvQd4W/1NUm5gfSkDpVSvLtzKPHz2jt1gP0x70HVKZ4Ad3OrpjrTv1D2EENFv1egyewxMG2gMD7Bs9gvwMtIcVAoOu09aO+nZtY5gGk98btuzRhRC968OgJ1Wnjx46IWA+QrGktZq1x6/7ZzhP+hogYkOZ5d2+h+pbBduzvY0wguz6BETR6sAdVLFWYk6Fs3H6YXr95TXWrlrLI8rTOk9RTj4AQXvWYGVYDWp9Kpb+1aEHxkavaYgAdWDuJr/na9QlmRzO98T7hmd2okz/tXRVuuXKFRQWb84Z5I9kCZpSsAlfZV27c4YQDKLi6atDRnz5Il4YtpE+fPmciDCt3zUrFOWqElmLmmGAdyJ0rG18lM7l9+Yq6eIVQzuxZmNhE5xWsZmyOjCkqj2o17eC3MY0pOi9xtW3Zkt3A8Qvo+x2HOakCtJCQ10C7rkdbCUu0ogEtWKkj7Vk9PtJhCut71MTFtHxagC6pAYhH/2FTmGAM7d+ew3thPUC+g9sZD5+xrO2sWfE7XVZXYIyQdYgQgpjWkDAo7UDGAKvRpSu/IC4KzQrz1hVq8K+HTyh92lSRHb56B1OVskU4wgGctPoPnUz9ujYzJJOiX/AM+uKz7Jb3SVlPyu3XnKWbqFblEhwRRc9hHxZP7KEK2f3p6i+sXf4sR1bWvG7Yfpia1avwTj/Urm9l7Z0+f5kCQudyshrrgnf2yo1fafSgrmofHen3mAfcysEZCodErDmsBRy8EGIOe2rKlMl5T9Jzk2bmGscAbecJ/6aMCxZsfKcQWUjPd9DsMeEmCVIkheyC6A4Jmc1adXwL1287SOOGeWo6/OhaRPG8shDeWLAAoOvFdSusGQgGD0cPbFogpecvXaeO7m+ta7CMwEKg5fSOlw+bSKtGVenkuZ9o6rx15N+3DVuhjCK76COIABxWihX6klo2qkxL1u6iwyfOs+MSgucfPX2ROvQdzRtyxOh+uj5oZo0JH0poJ/t3bcqSjWkL1vPVFayVcFaBxz4SbyixiPUsqejGZBTZRf+iG9Ozv19E0nPqIR1oC1ZVWDhg2cW17qwl33MMW8gPUBDZ483rN4boemHFLVCpA53YMt0SwsvI9Y3+wnEJY4DnP+YcB0aF7MKBCHpbWH1xU1OuREE9y4F143DWhBQJ1/8K2QVJgCXvyMkLnOQDFmcjSlTaypApS+n+w8eGZPoCVr4jZ/AasE5GgguiYvMAACAASURBVFsfWGMhRYE8AJnS9OigcW0O7SRuJ6CBrdPGly2FCFWHgvbwb5sWjdZ802SNOZI1QAaCg71SjHxn8cyrN36lwPAF9HXeTzkzHopCduE0CbyQpQ8HSD0hy8xc49bzhPF5+oWzMzIkfXBuff7iH3YUheVcz02QmWOCvAG3fXD6VCQ8iFaCqEIo0IBPnL1adL1GbFoqniGEVwVYzvopBPV46WEBwCZcs5UPZxPL81l2JoS4utpz6AxbZ7VeX8IKOWXeOtp7+AyTaySGQOxao8kAMIL3MDSI2PxhtVPIrvJBg/YUMYn1WiLMHBM0ogjf9NfDxxwHGGG2ED/ZSLIL7KIak9EfTrRlb0xPnj03lOzavjM1WnozsbX2/keQdoSymzRSfzB9aP5K1PGkU1un87tju76Bb/CkxdTZvZZhCRagp8bVK8iuImNAP+BgqfewYIsfrKM4rFjvA5A76I3Pq7QDr38cqJXoBvh3XMVCEjXcu4MlaY7evRBzPnYaoq6UYm0/3iuQXej+h3t1oNGTF/N+Z+1zoKdNWNjmrdjKFn7rOanUpB+vOy1GBNv+4DCPG6554b78J9t3Frcm0+avZxJnVEY2RI3BYQRkVxmDketBGaNZaxyGBYSERIg5hJpb9f1eGuHTkTr1H0OrZwXSJ9mMS/Nu1phg2U2VInmkAz1iayNG9LFNEXqWtdRViYAQXpWAOePnsD606D6cY0Qi7BZOs57t6rM1AhadAcOmsjMCrnWUU70R/XAG2VX6BWIRFL6QPNrWZcuuQnbxQUNSDVxVTZ6z1iJ9MGI8eIYzx2TdR6NkDI6M2xlk1167RsoYohoX4pbCGomUtgrBb9kjkKqVL8aWOCOSHmAN2DvMKXOG60Y4+uB9MyLdMUKFIWYtNKLOLEhu0L7vKNqyOESX/CO6PuKGxlpXr2groTlULKM795+iNKlTWLIQah0z1hsiDEAj3LzbCA6TZp1wx0jiBseyMxeuRLJQw3EzIGQO7V41ng8nRqw9kF7c1Nkju4iCAfkICD6IvnXEGS0Yor8l63pSWEB3XRIGR9o2a43j0APLrpIsBmutl/8EvjVBgg8QRWh79Ug2lPGaNaZ+Q6dQ6WL5WcKllJETFrL+X4nLb8Tac2Qe4/tvhPDGkhWAjRCRDt6GWfqcxg3rSYkTJ2StHq4vEbLHa0QEVSxdmDo01+dAZCYxVEiNu2cgfZ4rG6eBtbawgJz8cPEaX//qLUJ2tSNoBtlF70ZNWszxV7EOELh/yJjZbN3DFWxCNze2mOPqHsk+9BTEeq3m7kW+PVqyRt76gBLo3ZH2HD7DV8FTR/Wjr/K8TYqgteB6HjcZXt2ba32EQ/XwoUeWtNWzRxiSNSymRu05EqEOwpmFTl3Gt0SQWOktiOiBKBe41UIEAmcUrG9Eigkf0ZMK5stN3+88zFEhhg5oT7UqFedIFUYk3EDfoUmH7lRJr239bkGHClnP2QtXaGlEgO4MXEitPbh3a0u0C2dgh2eatcaBHZI2tG9Wg6O8DBo1k6OqQO8KqzikAuNnrOBwfXqLWWMCaUf86WkhA1iSAa01kvHg4I/45Eb5F+jFIz7UF8IbS2cZInt40uM6Ubm+hFQADhJ6wl4pw7WX2clZUJw4+xM7+uxcMZYdLJSCFx16s7LFC3AkB1iC9RSzxhRVJh89fY+qrr0sSM5ox14WJGe0A2/14Qg/teMw63arlCvCWvIUyZIy2T1+9hKnaIXTV4sGlSKtF7X9QYIF6BijssZDcoPDpOJgqfb5yu9hFfXwHkvtmlW3ZHvT+qyY6uFDuXz9248lnJacWRBxAqGUYLmGZQ3JNbJlycQOZY8eP6XWPUfSoN6tdFvbcC2/fMMeJrzOHBOsr4gJjtS8kHUN7OnOjnlGJdywngtl7UV1kAS2OIhpTXuttAVjAfZWSBqUWxNnrAkz1zj0u0gsg70P0ieF7GJcSNaD78a4YT10D9PMMSGqzoRZq+mff//lrIO4ycCtkGKkQcZG3ErBmAUHaSnOQUAIr3Nw1f1UxJKEqH35tKGE9JyxoSixJdXqErGx1G8/mIL9OlPJIvl5KMqLjigNIPJwbuvcqrbmcFGxAZ/42AetV3GQ8WAdQXtqS0iRrASWXziD4cOgpyjPRpIAvEuIfqKU4ImLCBkQR/p21tME14X0CBZqte+GloaVaA2O1gVZzfhBOtU6X4TwQhxh/GftNgM5hCGcNe/ee0ATg3rRjn0nWQeuN6EM9hX/MbPZggddvzML2lLGhbmyJaR6Em7Y9lt59pef56SwgG6R1gb0m4gLrCd0ndKe2vWgFV8z1zhI7/RFG8mvZ8tIemf4syCRTK+OjejuH/c5cgkipWgtZo4JfX3x4h/LHmR9I1m9YjH6fscRgtRhWUSAhCzTOqEx1BPC6yRg9T4W8WxxescVnDMKLFsoapwAxkxeQodPXmCnErWB+xGvcs7SzTRqUFeOEtFz0AT+uCnpeZHiFAk3tIYpw1i0jMleVjVH8EYMWSN0ZDG1pWVMMT3T3t/hZAWNqJrg6IgggAx00JVDk6ilRGV9hbQHDlp7V4dreSzXsX42iC3kC8p6R2KUHoPG09xwX05JrKeAoPuPnsUxsxG1w5ECTTsKLI1qCrShsAA5mvIXH9muXqGcQjjEv5slzbiaNuFRjgQXG+YHczW8p7COg6DWqFiMk3AYUcwibkpfnZlwQ3l23tyf8C0d5AuKZhfOw3DaQwIRpFvWU46dvsQxmRV9tSPPQnKhnJ9kVn17gsx/nu0aOPzN0LrGrceAeOfnLl7j8JYgwcfOXKR//vmPM9lBa54z+0c00reLJk27lvcWcizEqIZjnZ4wilHJ7+AcWr96aWpat4IjUym/UYmAEF6VgJn1c2gQce2FrC0IqG90wYY8MGg6k1dHSS+uo9duPch6pLAh3an4t/lUdwukCo4J1mRX9UOiqKBlTLDyocDDGVExHPXWBvGAw01MHxpYEBBPdfn63XT7zj3OOtexRS0L0Y9p7GrGdPn6bZo0ew0fSmBtLF+yMPXr2oTjwsZUQA6hEa9XvZTDZArWMhDH4ePmsbOldXarmNpT/g49G/S01iHdcAhBEgJoSNF3ZKeCw6a1HMaR50Oju2nXUX72vqPnmLS1aVyNrXq4QscaxMfFiIIPGNqDY40jpPfkuZ9p8OiZVKro10x6HHV40zJPGB+C4PuPmcUJYZAgQ03548+HVK+dHxN6hFXC4QHvcJYPM9C44T0MkSGoJfJabxasx+3MhBuIl5spY3pO5gHfjEtXf6HalUtwGDnEIUfsZJBhI4qje5HSFjTTm3Yd4St1yMngMOpIUbMX4Xla17h1XyC1gvHnk6wfMklHRAofT3futxG3KY6+t4iRHjR+Ae0/eo4zLYL4IqYuIm448r5bj8nWv0D5G95RyFMyZ0pPuXN9TL06NuQ5kmIcAkJ4jcPS8CfBS/nPvx6q0mbhQwDHD0c2A7UbmDJAWHxGjJ8fKa2uo4MHmTl17mcOpO+MonZMIBAtuo+gm7fvcvpZNVmQYvrQwIIAjTI2R69uzalAvk8JpBTRK6qWK0q9OzVyCAJHxgRNLJJJwCmmWd0KlDRpEibZ+PeFEwc5lJhAK5mCJadW64G0Yvowhw9PysCxHtCukjEOhyqkbMbV+fQQL3r05CkNCp7Jz0WaajUF7wI0cymSv7WiHT9ziTbtPEKpUqbgAwcOOEYWRz+eSpujJy+hlRv3qF53WucJB699R85ye2oLnIlA3GDVQrKQrB9ljKStVPs829+rGZNRiRycmXADhwKsaezDOBgiZjN8GXJmz8ze+npi5NrDOqa9yLoO+tPMYxjHJkYscTW3DI7sRdZtaV3jUa2nYjU92DKOOM1GlZjeW4QB7DwghLMZzhrrw5FdQFqx30KOh7TBaoui8Vbq4cYQiaiCBnbm0H9IzBM0YSHLsBw1SKntQ3z8vRDeWDzrU+evY29VR0+QSlB6ZHJB2k5nkV5cLcE7+MjGKZE0kbEFSjWbMhxmYOVFEgw1ZFcZa1QfGswFwhD9++9LSpo0MSdZgDUAH0E4HkYsWK9KrxjdmEBievlPpGrlijKh7t2psSXhAeKClitRyOFIBGqIh4IBPqDV3b05K1fF0trTz1qTXZAyhagiBjU86uH0GNtLTB9Ppf96152WeYKlDNEQlk4dohnGHn5vJSbWjkSaH2ZT0ZEx4X2bvnAjk7QKJQtR1zZ1daVVVrpgRsINo3CK6jmOkF5FL40QbWrJrtKuo/ur3jVuO06QxIqN+9KpbTM4Lb2RJar3Fnrveu0H8VqD/n/3wdM0dpgnW16xX23ff5KjfOgpCtkN9OnE4deU0qTLUGpRv2KkcGZ62pG6REJ4Y/EqcPTjiSEoZPf6rbu8GSDerR7SC+vkw0dPOeVo8uRJ+ToZLzhOuzh5wtlozriBsRY9RzZlozZkex+aJWt30vwV2zjQPUhu+MxVdPbHK7owszcm6B6rNu/PiTDg8Q3Nb4e+oyjItzPHA9VS7BEPrC+ExcqQLg2lSJ6UMzrBgvrr3XtMQEBKN84P1uVgOXnOGnZmtCa7uOVo3yeYCuTLTX69WmoZjul1YnpvjVp39uYJIZCePv+bSWCyZEnILYEbPfv7b5aewMM9NKC7JXmEFs0sDmuw8hqVOMF2cqIjvdaxbWH1QuKKY6cv0ooZw3TLKsxKuOHsxRgd6Y2J7KqRicS0v0a3xtW0Y40XvkdKRApn4GjvvYVWHf4nkEXBgATZARzLNi8ao3vNYQz4ziIZz5C+bSORXejkYUFGmmojrdnOwM2VnimEN5bPVkwfT1uyixBm0G926DdaE+lFfFRo85p0CeDsb8gm9uTZ33ztjIKrOFjx+nVpYrHuIlUoTr9q9EZanL7UOpgpmzLGlC1zRk5+AdIO7//oNuRHT55xrFHoOx21ruNDgytCRaaAmJ4IeaTEk0Vay9L1e7B2z1onjGvONKlTErLPOVJsxwQv+T4Bk2jXinGW6giBc/TUxUiZyzBubKKwIDiSrlUhHg1rlmHdJjZ56F5Bdh4/eUaYC4wJZB6ObgO6NeeYknoKnvnq1SuLZRdk19P37bimju6nO1A/nqPWyUfrxxnvLW5C4IUPyxSwd29QKdp1hzqQC2EtIOmMI5plJXPcQM8W3E7N1gPpi1wfU+YPP2BZyH8vX7JXO24YGtUsa9HvKul9kWVMzXuLOUmQgBx+L7SsB3uk117yFay/4rW7saUSoZ70FEcSbuh5PuqqdfrSuvZgycc7i3V0+vxl9jVAdkhEwojKsqvFARV70ZI1O1l/7ugaxyGrTa+RlDF9GpYoqZFTAEMjk5HYm0/r9xZ/7zQghBrWKEs1K31n+Xm5hr0pdEg3S+IVHCQgw4JT4qDerVXLVWzXHki1T2AEO5kiJrkU4xAQwmsclk57UkykF2Rm1OQlHCIIhEoJJQTS26ROeYdjPcI5JVXKZEw4ENN20KgZNHlkn2gjMuDD2dV7LFt8EQvS0Y+nI9dv1oDCsuThE0Yd3Wuxfgo6VUckG9ZjAo6B4xdwRAG0H5WMASQUjnm4zpo0so/DGqrrt36zxEjG6RxOKQg9hAISjes4YATrOwo2ytCIZZxCs33zGg4n37AeE0hV065DadfK8RaLw7jpK+jHn2/SjND/acvOInzU5CVs/ZsY2NuhMYF4/HH/IR8WcPiBo1KnFjWpWb2KUa51jAlaUWiJ3RK6OUTa7D3MmuxODu6rOqRWdC+jo2vPqIDwIPJwYsIHEbFg7a07aGQhgUECFhzM4LAHS7daS6oj763yzlYsVZgdHNW8t4gcA6mVo8558GgH2VZbrIk8UgLD0obYq3DiVQo8+Jt3G057V4XznmdUiSrhht7nx2QVtX6+UTplvLddvEJ5DvDfo5Ix6HVAdWSNK+MDwcOt0LY9x2lpxBCHnGpRF9ZQ+CV0cq+ldyocro/9GUVJcY0bThiD1s4JinTAxzs7a8km2r73OC2YNJizB2opCtkdPdiD8H5KMRYBIbzG4um0p9kjvXjJrE/IYRHL6eKVmzQz1MtCspInTeKQRc9ex2P6eCofzv4eTdkSjI+Smo+no8RD6RusZP2GTuaPXsiQbprIFMbUc3A4Z/qKSXsFb2bkckdWH0esotYYXr3xK1sHvLq1oA/Sp+bMVAguPnuszztEHaS1q89YtgBqCUSP8F344LRrWp0OnbjAhATe+PYcA+cu30JL1+7iMakNieQo6cW8IpsUyuyx3vRZTvWB1FkCcuEKGU12lTmKae0pSVHgoNKyYRXW0UHKobUohODDjOkp0KfjO48BXrCy4YYGBR/a1ClTUNfWdVQ3Gd17a/3OYq0hPJba9zamA7g1xlhrmxeNVv3+WD9j3vKtfCCEbGZmmBcfHCDdAZFD5IMeHRrwbQMs2mrXtD1wrRNuqAY/hgqOkF6sTcwJJEkIT4VbGUcO91E1jfcWkg14/SNFdHRFrwMqDnZRrXHbdkOmLqW/Hjzh+OyOlpjeW+vnYE3gNkIPdjBUtPIMpCIF89AH6dPwvgZjC0Ix2iuQZZ3/6QZNHdXX0SFZfgcDS41W3gQtr5Bd1fA5VEEIr0MwxY4f4UOD4NQIxo+NqXHnANq6JMRy1QtLb+n6PdnKax0n98efb/DpHlfsaktUH09c39dq7UPffZPPkp9ey8fT0Q0MG0+HvqPZMqmV7Cpjx5hGT17M5BOEJrpSo6UPa6FxJai2wBowdd46DoOFoP0I26XE4sSzYFVRNmPE0kSyhR3L1TtmQV+LGMdwqECSElgJC+f/PFJ3rdtq6RnIUgstQe8dIb0XL9/kkHqQdyCcmJYCgog+Oyop0dJGVGtPiZHp37c15fs8J01fuIF+uHSNVs5Qf0iw7pdCeutXL8NXpJi3ibNWc6gjjBWe/duXhfGa2L7vBC1bv9tyeFU7PuW9tU2djCvtAcOmcKhDkHgUvLeIDbtpwSiHiWlMpBfYwuKFAzlC8XVvW191GC7Ehu42cCz59mzF1/NDQmazJAUpyo+cukj1q5ci354tuR38/7Pnf/O6h3VMq4UNeCiJKdRi7ujvoyO9inQjYkw/ev78HwqNWEofZ/lQdzZAxdKLW4PoLO56HVBt13h0mKzbepBD+alNExzTNwO+BsETF/LhH5Krfl2aWqRlyOCGMIfQuDta8K2DBO73/9/HbQ0J0MfnyZ2d4wLjvUBa6WObIhx9fKTfOXvtaepUHKokhNfFJtPa0QQE8Ks8uQgWVhSEv6rawos/ktYJBJCOdOai7/mDg8QPkB+oKfh4wjnJ1vqIjQVWFkQFUDRO2BhwwldDEGPawIwku8q4cTULPKK7MoaVtmnXYWx1K6gydqkj+CJPPMIUNa1TgWYs3siZq7YsHuNIVVW/QeB778AIjrmM1K0d+o3hKzroRLUUfDxhdbPnRAayi/imIPdayS76ZIZWFO3Yrr2oAsJv23si0nW6FtxQB4TALUECXndoG7roiYG9WArUrk8wVSr9LX2UKT2FTVvOhFRPIhaMJXfObPxxf/7iH8tHHhEJEIovLKA7W66UvcOReM3W446K9FrrbUFOV36/lyCz2b40TLcFFppUWHcL589Nn2T7iCOs7Nx/kkkuyO78lVsJWSoRIg/hGbUUW02llmfEVMce6bWnU4Z869zFq5YMlTE9N7q/41kggM52QLVe45CivX79miUnyZIm5TmBpliJ3w15lJY1HtU3A2u7SdehVKn0N5wQBXOJ+OKIIIO4wBu2H6J54b6qQn3aYorMhdZpnJERFYdGGJTgNApCbO8Wx5G5M2PtOdKPuPobIbwuPLOw8sKSVvCrzyjvZ5/Q0nW7KHu2Dy0epdZDg7UEV9/Q52p9GaGrm7nk+0iZlUBw4ISwc8U4SmOVtlVtOlNbpy9oTkEynUF2rXHBFe/CVTsoQ/rUjA2kGcji8+tvf9LOAyfZCgpHBCMKgqZ7tq9vccoCEW3dM4jJzt///Muxer/5OrJlVku7CE0GS1jLhpUt1eGwcvnaL/Tin//4MIQQaUaH9jGK7KLTarWi8KTGAcYRRy9bTBUnn6wfZaBq7l7k26PlO4lBvt95hGNjomBNaLktsW23Y/8xVL1CMWpSuzz/CUQN2nHEaM6VIws7y2COcMhFwWFFS0EsVDgbwvKvFLxvyHgYMfp/MXlh3YNVGWTBUfJrS3rtkTa0icD9P/50g9KkTmFx9tEyFus6b/eeYFoxfWikVKxVmg9gSQ8y0mkp0KDDeBBTUhnl2cpepbYta6cvaLhhGcTh2tqBFYRx1pLvOdzgF59m52gsejJ8oY9mOKDynP9+n+q286PkyZLSy5ev+NCFbwjWdLbMmVjn37Zpdc0HE3ukt/OAUMry0Qd8uFcKbjhxyIckCRpmHJT0FERVgJ7cOnFIc49h5NGmHiVKlJAPJ1oPW94jIqhGpe8cSv4DrTmcxWFZluIYAkJ4HcMp1v4KoVpAQm/+cpeKFMrLJCeqjz6cnSo360dHNk7VpEfEdUuV5v3fkUyUrteTNbHlShRknLSmM1WcvqC9goMaNhSkmDVCxhDVBGLTxHUurAzAjaMPvHlDqVIko28L5LHEr8WYrly/zR7vsJppIYsgtyAzrRtXtXSndc+RNKRfG4ed/RxZiLCewHq8ft5Ii0UNxAR6yvHDezjyCId/A61p8W/ysWeyEZZd64ZjujZXfouPaHff8fTk2XO2ljpK1uwN0jYgPH4zfNx8vtIM8fegdGlSsb62YY0yutN/wokQETqUDHVwwoJjIOJbo+AqFeQEyUNwEENGLBxU1N7QIOEGInmsnjmCrcdvSc8iXs+KZlghKLAsQ14zelBXKvNdAYfWAQ5XiAoBIgZHWWgQ7UUdQeQTaNk7tKgZ6TDmUCN2frRo9XaOOgBvdqXggFyhUR8OkYdoLFpLTLdOynNBOhCRpWihvOTft63mQwmeZ7v2kAIY6wFWeDjrnjhzidchHL2UGNVaxueILAnPhSQL7yCi/iCzmRaiCE3r9n0nac54nyiJGYwxuw6cptu//UGf5sjKkQkcPbhintKmScXkGftA4aqdWeYHR1ul4HYBll0jyC6eieyQ+C7hefgOQEpYu40v35hYSwm1zI0jsaiV506YtYrXA8i34gitpc34VEcIbzyabbwc+IAe3jjF4Q3FFh5c3cxY9D1NG9OPr3VmL91M2NSwydgSDT3pTBUt2N0//qLVs0fY7S+u6JAt6eGjJ/Tg0VN2CtOSPCKmTRmSEGgtYQGDBhekFxYEtamVYaVp32c0O2mATCAEFRzovl8wirHExn/+0nVVYcqiWr6w5j9+8pzbQn97D5lIH2ZIRyN9O/M4EMUBGMOKroW8K+0q2sC/Hjymbm3rvSNjwPz8fO0XtsBlzqTeczk60gtyA6shQlLhynT20k20cfthWjzF3zDtL64oh4TOpurli3F0kGC/Lpz9DR+4A2sn6nOIefyMWvcaSe2bVaf8eXMxGYSOF/1H8R05gy5ducmRQjB3geEL2DkLGn61BRrvRWt2sMMNpEgg0YgWgcOKbUGUEqyXBRMH6Q41h5ue9VsPUrYsmahW5RL06PFTwiFvUO9WVLrY12qHEen3eH8mz11DyyICeB6wnnv7T6AECdzYaQjjvHbrDhUtmNeSyU9Ng9GRXowLexOIBm6EkKYdh6GhA9RlA4yuP406DeG1DQtykE9HJlOQcIDM6ZELoc3oSC+yhw0NnUu7D53mfSppkiSsM3dvWFmT/CC6/RXPRUQbaL2/zvs2EyXCHk4ORnQcxyyx1jK/yk37Ud+uTS0OyUaTXWCHd7BPwET68/4jqlq+KEvR7j94RGtmB1KSxInZl+LHyzf40GedttnRkGrRkV6M9fQPlylr5gysxUbUF5/AaXxw1RsWUs274aq/FcLrqjMXRb8ha4DODdccuEpKhBPofy/pp6u36OjpSyxniCk6QUyQwNFg3IyV/GxshiABZb6z//HSk85UIb2wcHRp9dZbHYRm/MyV/N9TpUjOVqX06VJz2lhsRNDAKmlqYxqH9d+j2pRh3UPAfmjAlI8MNmlsMhODekfSSjvSHiQU/YZOYR0bYqRCS4vQZVv3HKNhY+fxmOBtXrJofho5sDPPnV/wdOrRvoGqaAewOiBByLotB+CmTHk+zU7hgT2ZUPUfOoXuP3zMUQCAFcgBDivwDMc1MDzf1RR8PDv1D4lEYkCqJ8xaTXOWbuIPF+Q3kHMg4gGsYmMmL2XnQ0eslfZIL9rENSI8p0G2EQsUmlfIBCA5UDuGqMarfIxxvT122nLOkuft2YJqtvKhA+sm6bLooU0cCCBjOH3+Cn2WIwt5e7pbHK6+qdqZZljp8RGWCTFA4RCjRd6AKAdIcYtrUKy56FIrB4TO4T3E0Wt9e/jhRqh2m4HssIk1fffeA5oY1IsJAkIojvH3sFTDelUbCQVrDDIAyIEg09m86xglS5qYZoR4EcKhQWpVsshXdPn6r3zws3XkdGSN2yO9iKYBXShunnBIhTX8i8+y89ysmxuk6WBn2xdIQJBQ5sSW6ews1WPQBCa9m3Yd5WRAyn7oyBii+o090guyi0M5JEK9Ojaiju412diA20FozLFfacmmaG9/xaHLd+R0yvlxZgoP7GUhbIiOA4usWmc2jBPSEPgr4JuBfuO2QrHs4oYBz8V3pUX9SpYELDi84KZFjSMb1h4c4A6fuEA5P8lMnd1rs+Gg28Bx9Nvvf3J2SxxUsEZg+d196AyNDF9AG+aPcmjPs0d6QXbb9Q5muQ3WHeRQXt1b0Owlm+jO73/SsAHt9SyHeFFXCG8cmmZFCnDt1m/UoXlNzvMNUoWCDFllihfkjyn0kXqvXmBdg0brsxxZo3X80pvOFJsTrva+yvM2sDxIGT6WU0b1tVjx8FGCBQsh0ayTOqidWmzK8OxdNHkwV8VzQe7hlAdtY4lv81nC0cC6BAy16Onwcb96oDVl/gAAIABJREFU8w5fuWKTBaHrPnAcW41rVynBGzLCr8FaffDYD9wXreG54MQBQpArexb66+FjgtXo7UbZnD8IiEAAa2+Ojz/Sde2HjydiHE8K6s0bP1Iaw1kJ/xtWKugV2/UexQ6WsFLVqVKSSaqjxZb0Yh3AeWns0O5MpoEXHDhBRhAyyDpFp6Nt2PsdLEQga5ASoID0YlwI7zSwh7ueR8dYt267QdSnUyMLwYDkAc5mxzdHaL6hibFRIrZkwzcA3uzWul9H6lr/Bu9I6NSltGF+MP8zwgpi3uCwV6NiMfYFwOEH8+c1PIJWzxqhOp4uHLBgQYaeN2/uHFS3Wik+DCDT4aadR2nBRD/eL5B6e83sEZr0jrak1737CG4HTrzYS70DpxEStEyeu5Z2LAtTnUzBHq6cLKJeD04ogz0GOCGtMw5IyN6oR65h3Z6tAyoO8jdxIB3clR1TcTszPcSLSRr6AO2t1hsh4IhQawXyfUZwCG7cZSjfVqRNnYpvHhHVBXsTinVMc7XrDsRwWNjcSGRXkQZ5tK7LkWwQPQeHBhyUOL64e20OC6mn9PKfwLdq2PNgSEDiEBzAob1es3kfO1aqCTdmS3ohowgImU2bFo6mBG5uNGbyYrp28zdKkSIZfZQxPUcTkhI9AkJ449gKUayisM7A8morngdJaNhxMJ809YTusYZNTTpTI+AG6cDVP0gvsooZQXaVfoHEI5UjLKHlG/Xh5A0gniCpbfuMYush9GJGFuRqb1yrXCRtL+YJzhH4QGglu7Z9DApf8NbKFtjL8idYKqo068+6ZaM0biAwlZr0Y62h9QFk1ff7OLQUAserIbtKZxWtKKwmIDTrtx2i+RP8mODAu7laCy/Ga/zwnpo/yraYYT0gp/0Y/64WT3lIg2BB3rz7KIcJBAFAgpcKJfUHisd8wMEHpBDWKViYYSECmUOKZeCJDFV6C+YITpRw5EmVMgVbRt+8Ifrr0RPaffAUZ1ucGeatSeuv9A1WwXrt/Gj04K6c+QvvFMgFnj1ueA+eNxBrWBMD+rXVFCbPFgdE04DTHfSwtVoPpHnhb7OwwWkTlmYlHBwOSCA8+fPkcgjK9dsOsqwFVmjUhTwHln4UEBFEq4H1E/GCjSo4GMJ5FpZwzBMI552796lQ/twEKygOgSA6OJRoddCz7iusythzkDZX+TYgOxzmS4+l3x4e2AcSJUpEQ/q2sRBcRMTZuWJsJOdnrViCyINwYq/YsvsYjRg/n5ZMGWJJuIO/w+fg3//+U334ttcnGDCadhlKO5aHRTpUQWeO92zssB6qyK7SBkgvrPpIlgTDT6ueQbR2TiCvP+wVkAdBTgH5kdqsdVqxdeV6Qnhdefai6Ht0pLe77zi29sHCZ0QBIXA0nakR7SnPAOlFrFJcm+q17NrrF2QhIBvQ1yoFIaQ27TzCxNCogg2tUJVOtGfVeIsG2llZxmCZatmoSiRJizM0biAAINewRCjF6OxVsOzhOvTna7c5rBuuKjOmT0vjhnmyZnnb3uN09cYdypcnJ1UoWUiX1hbXpH0DJrHeFR9+HIggdUFWJcSzhUQAFiMQeS2xja3XEuLJghgqBAMWREhDoG2EYyAIvhHJFUCWPHzGcrrhTz7+iP75518m2iB0eT77hKUAWi151uMBdsPHzmMr5cPHTynrRxl5jkDoIe9BHyCnqVnxO/Js34Cr4roWWkgtnu6Imw3yDH09MrTB+ourcSXcE9436P1B6suVLKRJfgBZC/ZROACCyE+avYbaNq3GxBOyE+wRsMSWK17QcjOlZb9QLJXHTl9kx0ZIdnBrh3CUr16/4TYh54EfBQ7mjma5jKovWGvQ/isWefwO/gtrNx+w3HppGYe9OnBKRjxqxaKL38DAMNK3kyEh2KzbRAIgzIW1szD2I/fugdSoVllNh2/bMeF9wqFq25IQy17jjKxpuHHEHtG8fkU+DCHSypzxA3kdw0iCfQ83dzUqfmdxUDVqzuLCc4TwxoVZtDMGhfTCuqF8PKE9hTMCNjRYDPYdOcsviZL+VisUMWVk0/rc6OrhegxXiF99kZMJr9EJCiDZqOHuTRsXjOKPNU7T/YdN5cw9sLgZWWDlgjwCFiJodj19x/HjjbLsKn1F9jJskHCCQgg5Z5BdtIWPfe3WA2nogPYcu9ZosmuNPa6yYTWEYxKIFMgSSBQsmIgacvbCVQ7VFzrkf578WuYORAbvD4jZjv0nCRpXxHpVvMExRqS53bI4RJeFCla2Tv3HcIQSRPSAfhMfuRzZM3M6XzhNGuXYGNN7yxbF3++zM5Feko3reBRbsovEEZCfdPEKY8KIOcNBEzdUSnxxNfOFuYFsYtGkwUQJiErW8aTtS0NZAgCy2zdgMpN6SGFQcLWe65Osqsk15GPrth7gvmJ/Rd8R1QCWXjigYt9FfOBOLWuxXlRPgRMhHOJgxcXV/IWfbtCccT4WzTMSOKzcuJflG3oKbrGqt/Sm8OE9eT+CMQFX8ohAAR8GvQ6o1n3DzdyxM5do/LAefLDCrcmIcfNp29JQPtgZ5VSLNkGuixb6kjq2qMldcMZ+BOyQCAoHrZ4dGtLxsz+RT2CEahmDI/OHva2H33gO2amQXfi2+IfM5sM9DuBwnIO0AvIRKf9DQAhvHF4NIL3Q42EDwWaPq3OQKjizIVg2tFq45tNLBgBhVB9P9AHpGA8cO0dpUqVkK44SsgjxEXFFqzb1IxzzJsxcxWlGj566yN7fMWVM0zLNcEpYsmYH1a9Rhg6fvMAfx3nhfkyuERsTmzLGgtSmSixEXM86ek2q9AlOCMETF9P1W3fYcpMxfRrDyS7awhqYNGcN7Tl8hp3jfvvjvmEyBlt8YS0aM2UJvXz1mqAjrl+9tCGWFHvziBi5VcsWYashdHTPnr1gh0Ic6kBM2vYeydYxvdZXpW3oHOGoAg2qdUG4MlyTW8ej1rLuoN9cvGYHH04QfgrEF6QQ1hsjHRujem9B7v1GzqCDJ96GBATxwR4BRyBYrY6cvGDRNDs6PlhFcXDEHMEq36pHIGdJU+YEBxUk5Nix/xR9U+BzSkAJNFuolq/fTTMWf0/JkiSmdGlTc6KBV69eMdn988EjjlOOQwPkG9B6Yq1ACqO2YG8DsYCVEiHk6rTxZQ2+ItcBMWnY0Z/bz/VJFrWPt/v7Co37UOiQ7pGcZUG2kKbXiHjhSM4AGUPunFmZWEMXjwM+fDGMcEBVBgW5AazJOLAirBi0wnDS/eTjDw13qv3h0nUmiEhyUeirz/iQotaHwJHJw83MnGWb+VYBh4PQgO6aZAyOtIXQk9iDYNnFd7RljyAaN9STQ7qh4JYNB4iNC4Kdqvd3pK+x6TdCeGPTbDixL7gGgZ4IHvNwlOraug5HC0D4FziegRhouUK07rJtOlN8xGB9w3Vpu2Y1+FoRHqWwTtz89Q8+AeNjAGuImgL9FTYX68Dfauqr+S2kDXC+gYWlQc0yrA1s03MkZ3rCxw1XtoeOn6cVM4bxtTaSEzjqiWvbD1hgz1644hSya90WPIsHjZ7pNLJr3Ras13AM0aLZVTNP+C0ODpWa9mNHH2s9G0gaQvlosRja6wPkGtC9wsnGtmB9KA43OGgaVZzp2Ki8twirhHXexTuU5Q2I7wmSitBHIAk4LA8ePVO31QpyAFy/W68JxfoKQjo/3Fd1xAZbnEHSb935g/J9noMzfVmTXVjA4KCK+NuKdVbvPOHQBQfQtbMDIx3god+EhVQhInrbgdFioKc7Z/OyLti/QR5RYETQs5fDSIIIA1gLcBY22gHVut+Q6tz94wF9nTcXZ4BzllMtDh9wwkPoQq0+BI7OXZ8hk9ipUY2DmqPPtvc73Noi4YWt0xo0ykG+nTTJdvT0JzbXFcIbm2fHwL5Bg4hNUbGwQpt1/PQldoiA9zecCHD1ptcKpqQzBeGANernq79EkhwgNAysBbhWUuu1aiAcmh4F/Op3GMz6RmsPfYzz4s836I/7D3WRSFiMIJ0wWp5hb7C4DlMThkcTYERsHUSMXDMKDkKwqCFxg/WtAcgU/jcsIQkTJtRNCKBbb9kjkAL6tbMkW8G84cAC6yJ7od+8w1Khtk2qGTJ0Zzs2Ks6acPqC9/e6uf9LWoIBwOq3dfcxzc431iAgvjCItOJHYE12YX0FITWq2Hu2oh1GeEbsV7PCvC1RD2Cpxc2A2oIrecgpJo/sE6kq3mlYl2EtRcp1REPRU3B4C4tYxlZpJe4qSCMIPfYNxCJHpIApwX01W8it++csB1R7GDjbqRb7AxzYFGmDnnmITXVhKUdYvHZNq7+z9hCe78HDJxzn24zvSmzCxV5fhPDG9hlyQv/gDIHrN+jpQEARmxPON3D+0WMZsO4q2iheqxs7O1hbYjls1NDJhnw4nQBNtI+EtbfnoAm0e9X4SHFQkboVcXSNinJg9rjiUntILYqrd9xgKAVX6H2GTOTYx5AIQHKAmw09Xs2wpvkETWfSAW0trGALVm3jw1BYgCc7F7XtHczX9uiPnmKmYyP0r8jeaJ1AwWjnG9z0eHiPpXbNqnMsVFvrK4gJ9LCQCyG4vp4CaQ2u+0FEQaQVsqvIKfDeIowj5CnQwiL6x5Ip/qplVjjYNerkz5FxYNFVCggW9N4fpEtDz57/zck2Rnh31OUQCL0m5EKwVNasVJwadBjM/cUYob3FOHCtDt8GvcUMB1Slj2Y51erFJLbVx5rGIRKRGhRpH2RJ3iOmEvTf0JTDYRT7khGp62Pb+NX0RwivGrTiyG9h3Z21eBOT2+LffkW9OzYy3AoHi1fRGl1pzriBlpi/Rn84zZ4OfDw9Bo6l7UvDLFYgZzl+OXtssNh5tmtgCdMTXXuQCsAarDYxgLPHYO/50M55+o3nP/n2cGfLHQgBPMJxhY41j6tnXNPDsqenYI1zKurXbzhmKpyGtu05zskpQHxwfQqSbU/6oLZdsxwbIXdB4P55E/yYzDvrncX19etXr1lWpehqEbt07LQVtHD1dtbB37x9l9o3q2FYqC8kGECIOa9uzdk737rg4I+sYrh5UiuxUp4DrSgyvUH3OtyrPV26fIt6DArntQDnTWhtkeK5YL7ckQ5katcCfo91h3TT8MW4ePkW+fZ0tySnAOktUr0LHd4wJdoY6Y60a6YDqrOdakECcQODg0JcK8iAincH4csQhxwpvqGXh/4aezcSMyFZyro5QYZ/610JSyG8rjRbBvUVVyC46oCTQ3TZlvQ2hwxliKYA6zE0RhDRu5qMwRYD7xER9Mtv96hLq9oEBw8lTJmjaTD1YmpUfSSCQDpUJLuAY1JUBb9r32cUtW1anQPtu0IBAT1+9hIVK5SXI1Eg0xayySkFf6/u7sUezkqUBT3jghygurs3nd4+kwk1QuYh7Swsh3BiA9mBk46eMF9mOTYCB8ScRZxXSFHg3OWsdxakbcKsVYRkALC+grwhtjJSHsOvAJbmxl0CaPzwHqodQe3NJzS7l6/9wtpk64I9CvpO3EbplRxAEgEHLKQcRtSOauWKRiLsiIrTeUAIp2I3okBbnS1LRksSD2Rkq1L2W5ZXgNyg6F17ZjmgmuFUG126aOv5wNqbMm8tJ0uBv0jhrz+nPp0a607YZMScR7dX44CNWM3Q2iOkpnXWURg5ShbJz6Q4vhYhvPFw5mFdQaw+Mwr0ZWERy9mzW2vwbTP6qaYNeMjimhJZ7FxZxhAT6VXILggiHFiqlCvCxFdLWls1+Br52/7DpvA1HlIaW5ebt3/XTW6U58HSW6etH/Xt3IQqlfmG/xmk98btuzRhRC/OMtfVO4wjHeiNlWqWYyOu6Gu08qZAn06mON/A+la2QS+WE1gnK0Fs089yZn1Hn6hljUCvC4K4YIIfx1JGUcju7HE+LKFAZJbyJQoakskM40HyDiUqjdJnI9cessnNXb6ZFk/x5z0dFmqEeEOmNGjJMeZRExdzdja9NzRmOaA626k2JtILOQ1CmX2aIyundEd2OUQZggU1aGAni25fyxo0ow4MTcgYGj6iZ6TmcNjKnjWTarmOGX02qw0hvGYhHQfawQkclmG1IXbgBf7y1UtDMlHFFhjnLt/CRMDVLLu2+EVFehWyW6JIfvLv05otlrgSK1k0P3VvGzkcV2yZE3v9gD4d132Q1lhbWCE7QGg5HMiQ+rNr67qa0kQrbcKrveegcOrWth41rl2eDwU4WMLpBxZyJDtA6KvGtcvx1bnWYqpjo4kOhyAZuP5HzFylIAFL3XZ+5NerpWF7B/StkEr06tjoHbKLqDIVG/elSSN7c3ZFvWXQqJmcVMM2SxkiOiCaCwqchKuULaK5qbfxwadwBJyh/dvzIQ7+E1h/ILvwOUiVMhmVKvo1O2up3butO2amA6qznWqjIr24rWnadSgfFrDnIYEDcINGeveh0/w+N6ltbKZNzZMfRcUbv9zl6Egrpg+1JDPCT7G+Ef8Y6yJDujTUoUVNUyIdGT0+Pc8TwqsHPReui+t4hJxx1HNT8XYGcY0Y3d+FRy5dj4n02pJdJeIBrvlevX7NBLJVo6qUPFkSlwATxAPyAvf6lThm87Wbd/iDAGeyju616MSZSxz4HqmQ4dSmtSBOc2D4Ak7UAB2dLY4c4zRwGvXs2JDjEkv5HwLQt1ZpPoAmBPaigvk+Y+3zgOFT6dHjp+yMo0cOYg9nW8sufoPU18vW76Ll04YaMjVKKmXIMxrVLscHHmTow1oL8ffgWxPEbm6IdOV1K2huEzcwOLzhcIcoF9CtK2QXWeeqVyzGTmxwroUlGP2R8ta6j3VmfSCBQzX2O2hf4Xjac/AE+rZAHpc65CtrOWLBeo4UU79aaUqcOCFn6Hv6/AXL2O7df8A3r3jfzAjvGVvWmxDe2DITJvcDGyIyOMHDPCbS68ywQSYPW5qLAgGQsyVrdrJjFxKFgCDCsmubFAQWDsQWhWV0esgAXZEOzJwMeOO/evWGalb6jmN9wjEJVtkgn46sywueuIj1vG2swoghuoPtdbSjfY7q0ABtLDzfkQpWSmQEsCd5DZ/KIZYQKhHyD2TiSpc2leFQwaGwdLECkeYXIe06NK/J8bWVAkKkJ8scrNS4Yv7umy9ZWzkkdDZVL1+MEwLBme3Rk6dUu40vHVg70fKuab1JU/psTXatx4L4x4Xzf85Z4WJzgbzFf/QsGj24a4zfJoxDj1MtSC8SXzSt89ZqW7hqZ1o3J9Byc4d1iMPxofWTLRGMcDjD4QHyJWhiY2uBE+XRUz+yhXrUpMWcKAmWfySxQRKOnftP0dot+znEnVKuXP+VJURqk0HFVgxs+yWE11Vmygn9dIT0Ctl1AvAu+Eg4Mt2+c4+qVSjGFqI5SzezYwwcfVypIHVv1eb96cSW6Zy2F04+IL2bdh2l9GlTsZMZCj6EuP7btHB0JMcPR8eKoO9IB2x9aIBDU0vPEVS9wnfspQ/Jw7kfr9KG7YcJljgpxI5qsIRnzJCWLb1mFYRvgkV5+7IwojdvCLIDHE7g9IPkOEZYmKEfRig8WBSh8YasxtuzBdVs5UMH1k1iMqL3Jg1Eupq7F/n2aBmJuOMA26zrMJo2ph/LNeDIhkREKVMkfydihVmYR9eOI98m1DfCqVaRgOB5VZsPYAKoOHMfOPYD9Ro8gY5vnmZZA8B4w/ZDNG3BBmpSuxzHto/tpVoLLwro35YK5/+CU9eD9GbKmJ4zOs4M9eLuKwel6SH9+WAUF4sQ3rg4qyrGFN3GImRXBZBx+KcR89fTyo17qGLpb2nv4TPUunFVviorWceTlkwdYpjzlxkQwmKHEGLIxobkB3Dy6eEXzqlA4diD62B7191q+4bngUArlhJY+vChQaggxADGdXfbXsH8wbZOsau2Hfm9MQggMU/WjzJyZIpFq3ewha9lw8pUuey3hjn4ImLI3y/+saRlBuld+f1eqlu1FCeyMWq/RbY/6yx/WOOwUjarW5EPWiBxYyYvYT0qYvVaOwkag6YxT4mJ9DrDqRZyExx0B/ZoSX/cf8AOfy3qV7RLavGOI3YwMjjq0WEbg1b0T2nRfQR1aF6D+6nsRZeu3qIRXh3ZUh3VrYAZfTOzDSG8ZqIdS9uyt7HYbr7JkyflEFyI+QjNT+3KJQyxesRSSKRbVgjAiQNXvdUrFCM4k+Da+c0boh8uXaMdy8I0WUDfJ8CQL/z625+cZRBZtUAIcN1c/Nt8hpBd27EpHxiE5psU1Ju95REsvqv3WHYoWjRpsCFRAd4npka2rda/AI5buLKFJAXacrXJc+AIWKquJx9O4KSEiB6KhQ9Oujv2neThwSqmRHfQMl44RCEO8Bj/rparcBAs7KUotgk4tLRhW0chu41rlePwkCjzVmylcdOWU8GvcrPmV2/0BiP6GdUzoiK9znSq3b7vBC1du4tvYKC1t80+Csv8R5nSc5dh5UUGR9uICM7ERMuzcRuHDH0zQr04mQv2pO37jvNhK76QXeAmhFfL6omDdZSNJXz421Am1psv/reHz1jO1gLSc/qHy6xrg+A9rmp94uAUax4SrEFXbvzK8Usx7/B0Hz52Hk0Z1ZcdcfDxmTZ/PVuuYMGM7QVXmMPC5tKx0xfJo01daljzbRICIyy79saOLEj3HzyKRHbxPsGyC8KN7GaLJvvrihIR2zFX07+YLHu2z8L1PG4ekFAkTeqUnHFM7TqEVhNk1jrd9sYdh3mdN6pVjuMEw1lzzGAPXdmqTv1wmWBNLv5NPpY2oE2jLLu2uCgZNetWLWkhu/DbwI3NzDAvfo8Rqso6RrWaeTLrt7brwWynWsyPsp6Aab12flS2eEGOtQwrPXTSiPoR28vSdbtowsxV1KROeQ63hjHFJ7IrhDe2r1CT+4dwJjmzZ+YsPtYB4Xv5T2Bv1klBfdgzHxaVFt2GU9c2dQ0LF2TyUKU5FQjASSM0YjmTCmSR2n/0HE0M6sUfbeXjg5BFPj3cqUaFYrHaYmQ9bOg24SmfO1c2p5FdtAeMPkibmnGBI0nHfqMjyRgu/HSD8n2RQw6PVpOjlvSiKixyvf0nsnVWLwFB6uiWnoHs1AYLH5x8QIphCNi8aLSKt+fdn8IpC+9QzYrf0cuXr5xi2VVahYVXCZ2oEB5rGcP5n64bktRDFyAOVMZ6gIUcc2GmU+0ffz6k/sMmc6QQpQCzgJA5vP8h7BykL2oPWA4M2Sk/wQEHGQdLFc0f78iuEF6nLKm49VBc38AJQtE8KqMbOHI6a7/aWnm1x62Ry2hsEQAJaN0ziCaN7BOJ7CJWL7L3LFm7ky5cuk6LpvhTmlQpXAZAZ1l27QFQo6U3Na9fSd4bB1aHFtKLaBzTF26kVTOHO9BC1D8JCl/AZNTb093i5NOwVjkqUbubISl70bKzLLv2RvXr3T+pThtfdsBDVJK4VpzlVItDVK1WA6l3p8Yc4QUF+vuKTfqyI5urlvhm2VXmSSQNrrpiTer31Zt3qMuAUNq5YqylRejaENoJ3p25c33MV3045UqJ+wjgwwmtZFTXim17B7PVv12z6hYwrL2gYyNC9kJUOaOfuHr/rpYHLZ4yRHO4M2f0KzY/Uw3phRMW4qZ++kkWzoilpyBebro0KdlSrGiw8TxY6ZH62Ihie5NmxDOjegaigQAbJPaIzZpdLRg426kWtzLdB46lXp0aUd7cOVgW8OTZc1o6dQh3F85rSCeN29HMmT7QMgTT6yAZFIfE+3/9uOkdeE8NCuF9T8C7SrOQLzTuHEB1q5WiNo2r0rmL18j7/zNuIZQSpA/Hz/xECyb6ucqQpJ86EYC8pXHnIaRkYVN03AjXU6/dIOrn0ZRqVSpu+Rh06j+GvZ6LFc6rs+XYUx2EH1p2ODmpKUhuMHPxRk45i4ODlJgRsPYvgBygi1coW9kQPxUxxOGkhjUJnXmJb7+iUYO6RNLixtzCu784c+EKa22RhALX1iC90PPCIx+hxVyx+AXPoHv3H7H23pXSg8eEtRlOtXBMGxY2j9OFFyuUl/z7tqVMGdLShFmrac7STSwbwYHLs319dnqElGTM5KUUMqSbyyToiQnnuPB3IbxxYRadPAbELoVn/g8Xr1GSJImofbMa5NGmHt35/U9q0MGflk71p89yZnNyL+TxsQmBvYfPUtniBSKF3eruO5YzlSESAUgwLB/I7gNN5UjfzrE2qgdIaNFCeemTbB86BLFi3Ua61sF9WjtUx/pHSNqRO2c20eyqQM7avwApnF+/eUMDPJqxvwGkAW5ubux9/mHGdPxUeKXDiQ3RNyqWLswHLjgIqinQikLu0rNDQ6pavqhTZDpT56/j/TSm5D9q+h3Vb2G8wKEACT3iUnlfTrVT5q7lsHLY75DIBvtCu96j+FCESDB1qpTkRD6xseDguHz9burkXis2ds9pfRLC6zRo496D8ZLgo5EoYUIeHK7IkIQA3sbI0DJ57hoqUjCvyBvi3tRHOyJ7YbdchexiYPhQDQyazik3YyK9UUk5HJ1yLR8akLqkSRI72kSc/x3wAOlNnzY1ZyuzDkOmhChbvWk/x7ZFhjOEjnr2/G/OKqm2IKoC0vKCxCBSg9HFUckGnELhZJkvT07K8qG2a3O1Bzujx+qs570Pp1pYcys16cfpyK3jGAPjISGzmUjGVrKrzIO91Mr25ggHyuBJi6mzey1dYfmcNf9qniuEVw1a8lsLAodOnKehoXM5NNnsJZv4Cuf6L3f5owIPUCnxAwE4dUDjbR1j1pXIrjJLjpBevWRX7YdG+T2sRSj4sMJaHlsTBZi54qMivYHjF9C2vcc57TXihaNAQ160ehfat3aiU6y0escdE+lFhr66bX0px8eZCRp6JBBoWreC6mYdWePKQ3ELMWn2Gjp88gIldHOj8iULU7+uTVjeEVuLmU61SA8Ox0ZkYlSKEvM4Nlt2becuJtKrOFbuPnSak280qlnWEoM4tq6D6PolhNcVZ+099xkkp0H7wRwGKF3a1NSlVW22QGGDXDzFn3u49RKiAAAZjUlEQVSH8CcxWcve8zCkeYMQ2LDtEAflhzOMQnYTJCAOU0ZviF69fk2vX7/mmL2x2WEmOkJgFNnVQnrx0UGmpJu379K0Mf05NawUYjkDLL3I/FfmuwK0cfthGjF+Ps2f4GdJHAGcfr52m8MoHt4wWfX6g5b3waMnTg+/GB3pvXrjV6rfYTCd2jqDnr/4h30qAn068vukFFg5HXm3HCG9iD+MNMhN65SnZnUrUNKkSfj6G/++cOKgWJ0kxSynWuxztVsPpKED2lPVckXY4INsdq5EdmPai6yjiMBfZ9+Rc7Rw1TaOc13AxLTfRu51QniNRDOePAub66jJS6jMd19bPgStegRR93b1qGC+3IQUmpt2HeHYhZA8SIkfCChkF1mIsFniI4C4vW/wf2+IShfNz/FMY3OxRwjsZXWaPHctwaIEa2vvTo00Wb5isq4oOCEbF6y8iA4gZDfy6nn9+o1F0lC1+QC2QiFEnlLgzNam10gOo+fVvbnqpYd17DUigupVLxUj6dVrFbUlvSDqCRO68R6KqDjI+gVyjwMmMvUF9G/H48E6On7mElu1HSnRkd59R85SL/+JVK1cUcJ4EI6rXImC/FhoVsuVKERf5cnpSDPv7TdmOdXCp2XMlCX08tVrunP3T56f2C5jiGpSbPeiqELmhUYso3t/PqTRg7u+t/nV07AQXj3oSV1GAPKGKXPXUYcWNWlk+AIqVexr1vVCYycl/iCAwPaIXAAHtQWrttG1m3dYF+tqBYRg0KiZNDW4L1+HW0ekuHrjDrXtE0yli33NQfCh8QQBQdxXtU5RClnBBxrvi70iZNex1QNr7zdVO9OZHbMsEQiAa3ffcfTixb80f6If30IheQGSPqRPl5oqlvrGIUdKR0ivUVZRkN7vdxyhEd4dKCB0DmVIn4ZDoyE5CSyI3y8YZdESIwmQ1hjS9kgv1nrV5v2pa+u61LxeRb6l69B3FAX5do5kTXZsRt7vr8x0qoWx59sCX7gs2VVmCmsJkU9g2e83dDLd+f0+p55WtOsv/vmX3LuPIEhsEM6sUe1ymvXk72t1COF9X8jHoXbxwt/94z59lOkDGtS7FXusSomfCMBpCBEaEBsTFl+/Xi1dEgjr2MHWH88GHQbzgQ4RApSCa/WKpb9hAqylWH9o4AyDG5SsmTNSdGT30ZNnHCapfvVSnOZUClHrniOpVuXiTNau3fqNwydiLU4P6c+Hb+CMdYnDyl8PH1OSxG9j6jqSJSs60mu0VVRZe4h3jmxvSP2LPRVrr23T6mxJVA5Lc5ZuprnhvpriOlsf7CCHQKzePgGTOMmQUhas3EZHT12kSSN7u+wSc7ZTLRwK06ZJ6bL4WHdcWXsnz/3Ma0ohu9iT4KQOsgt5AzS9nKZ6dP9Yb/G3Hp8Q3jixTN/fIBBM32/UDHZUg35Jicn6/nokLccGBCBrQXHVKz57GF6/9RtbOOD8ZB3HFB8CxH91b1BJM/TKhwYWPjhe4VqeCVoUMgbEPN608whNmbeOLTLd29XX3HZcqYjwiZ6+4+jJs7/p3v2HfADx7t6C46DCwRbObBODerM1DgUHleLf5uO4qY4Ue6TX2VZRaIgRQQQWaVybL40IYKuaYtlFSmpY4jq3rB1JyuHIePAb64MdrN+Iabtr5XjL+sZ7/OPPN2lGqGNyCUfbNet3ccWp1iy87LUDsttjUDj9/eIf9iFA6EmUUZMW0+Mnz/hGz1WKEF5XmSnppyDgQggs37CH7j94RN3a1HOhXkffVRCqRp38ae+qcItVEN7avQZPoA3zRrJVFkQrbeqUDjkQRdUasiD1HBzO2cKUBB5R/RZWdJCUEV4dqESRr+IM1loHAk3v1Zu/cnIIRVIF7emiNTtofrhvpHjhSJrz+MlzVbGUFdKLBAOIZ+uoVRRkder89dSxRU3OyKWmoM1LV25Rrk+yUKqUyd+RMcCa3abnSArx99C9BpCcAvKQdk2r06ETFwhxgiHtceW1FVecatWsGSN/i4Phw8dPI5Hd53+/oOYew6lhzbKRsmoa2a4zniWE1xmoyjMFAUGAfr/3wKVD2NibQlyTw2rUqlFVOnnuJ5o6bx35923D1kTFuQ1/05tqG6R39OTFNHusjyWZQlRLasS4+UywfTxbyKqzQQCp0Rt19Kd5E/yooJVnOa6h67UfREP6tmE5ipqC+VdikTtqFUX0gBUb9tDyDbsp2LeLxRFMTbv4bVSa3U4DQviWAYRaT8HYIJPYffA0pUubii3HhfN/rueRsaZuXHCqfR9gwkESIf4Uy64iEUngloBJsPIuvI++qW1TCK9axOT3goAgEG8RgLUNMoK9h8+wFRGOmogAoJDdzB9+QPcfPKHPcmQhv16tNEVvUMCFFzg+NNFpTOHM1MU7lLy6NbdoO+Pt5NgZOKy7IJuwlisFH+yO/UaztdTRyAbRYarGKgqJQveB49jJMctHGVRNFWQsHfqNpkCfTpE0u9v3nWAny5UzhksoyGgQjStOtaoWjcE/VsguHjs5uC8h/CR03pBiZUiXhvdDJf61wU0b8jghvIbAKA8RBASB+IqAbdgyXKuHTF1K5y9dp4WTBumG5fT5y+w1DQtL6pTJOS4qnAMfPHxCv8CxqWFldqIT/fy7UMNaeeP2XRo2oD3/Ec5+nr7jCVeycPZKY0D2NEesota3HR37j6GKpQo7rB2ObgHtOniaBgZN44Q/cMZDJr8z5y9T+nRp6Ou8uXSvvbj2gLjiVPu+5sXDJ4z+/fclk903b15z6vinz19wNJ579x9QWMRyTkYVW0mvEN73tXKkXUFAEHB5BKJKSAGS2ql/CJ3YMk03EYWFsm3vYNbzVq9QjBAe6OXLVxxmC7pOZ6S8dfmJ+f8BgAA29xhGVcsVpUwZ0tLMxd9TruxZaNzwHqy1dlbBTYBimYezY6ueQeTRui5nJBw9eYkhulhbsrt511EaGjaXPsn2ET199pzyfPYJhQZ003TlDOlE7lzZYow9rOAH0n/j1l2u4wolLjrVmoE79rW8uXOwIyhig8OhEQ68SDyEGOs795+itVv2s3NobCxCeGPjrEifBAFBwCUQWLhqO4fA8u/T2kJslStzJKWAvteIAtKLOKydWtSM9ck7jBivkc+4/+Axa1/v/vEXVShVmKPJuLklMLKJSM+C/nrPodOR5h6W5tMXLlPmTB9wlIhq5Yvpah/RFZp0DqAB3ZqxZRex0HsOmkBjBntQpTLfsM6875BJ9G2BPJqcihyJPWw9AITTg+W60Fe5CdKLUX5dHAr3pgsEHZXjolOtDjg0Va3WwosC+relwvm/4OgoIL2ZMqanxWt20MxQL03PdHYlIbzORlieLwgIAvEGAduYnwkTJuSMVQjflyd3dk3WNgU8Ib2usYxg0UUq6OXTAtjaioK4pcvW7eYwc0YVa+c5WLFrVipObZpUszwe0Qm27DnGqWC1FLWkFxZnePTDedK6H1raNqNOXHSqNQM3pQ2s8Q7Na1CVskVI2fcuXb1FI7w68qErNhYhvLFxVqRPgoAg4HII2JLdG7d/p97+E/hjAK0orrjh1QxnN60FpBca1FljvTkLl5TYicCi1Tto0ert5NuzJbm5udHwsfPYAtava1PuMNJuI37u13k/pZQp3sY11VNK1O7OjnAIjaeUfkOnUOZM6clbR/QOR0kv0mx37DeGPNrUdQmyqwdrqfsWgR37T1JYxDKaEepFH2fJxPvc9n3H+fYCN18Hjp2jNKlScrpvJLFA+fHnG5yO/f/auxconco9juO/zIx0QUqplFNWhHNEIreUrJBuU6icOCE6KNMUMpPcx+UMZRgcud8iMnIripBySyJRqFNO6arENBEyOev/dObNaJiZ993zzjZ991qt1Zr33c9+9ufZy/q9z34u+TXfgMDL04sAAgh4IDD/1dVuM4hRA2PdRA7bktj+8bcJZRERhTRl9qt6f/sneqb3IyG9UrdJcXn5St4DCoqQZNsNJ0+Y6xbst2EUtn30oSO/qMeg8VqzcZtbUcGWR3umdydVr3K1rId0/bsfuNU9cnt07jFC1a4pp4da3OYmNGasPfzSxAQ3jGLSrMVuTK9tEJTbI7vQS9jNrWjB+b6tfGHP+L131lfntvco/ddf3dCrw4ePqM39TbQvNU2TXlisyUlx+uzLPYob8Jymjngq33ZjJfAWnGePO0EAgXwWsKELFm5twf6NW3Zq4rPdM9WoYYtuqnltRQ2IaxdUTW3Cmi1FlrFbWFCFcFK+CNizYUvI2YTDpH6ddf55RfX25u3qmTjR/SjqmThBiT07uhUccnvY63kbQ2sT8SxkHPnlqJITYlywsPHLw8enKLZ9M7cyRDA9yhZ6B4+aqfhH/67IyEgXoB9s3ki2zjE9u7ltrYL1/c+/3KPdX+1xP6b6DZuqjz7Z7d5AFTmzsLtRm0xpk0XtrUawz7dXYgReryQpBwEEEPi/gG1lW6zo2YFX2PZnmxm+aNlaTRkeHxjbmVuw7HrbsipvxepN2vnpbrWIbqC0n35mrdbconv0/aWrNmrI6JlaMGVQptAZN3CsXlu5QcP6dQ4q7GZUz56N9Zu2u7VRr69awW1GkrFRhU1usxn2b6x9T0N6dXQ/umxDgajISFWuWDbXdzh68jxteG+HPv70C4Yx5FqvYJ5gEylr3d5JM0b3zLQsmf37Y8sqHv982/NjE9xsW/RwHgTecGpzLQQQKNAC23buUtkyl7itYG2srfXk1bqukidh9/hg82TCc4q+tW6Olo2yIBTbe6RWrduiZrff6NbM5Ai/gPWy7k/9SX27tQlc3IYx2GvevOj5ympXNhtmYatVWI+c9bzZ8Im7b70hKAwLLa+98Y5SxvcLaSvtoC7OSb4TsKE0NZp00OSk+MCPqKye7y++/k72n43jtR9e4TwIvOHU5loIIFCgBbr1H+Mmk9lkpTfXb9H0lGX69LOvdEzHQurZPREtNz29ttmCLRBvY0aH9g5uXdYC3Whhurl1Gz9QdxvDmNzD/SjKy7BrYytHTZqnSUlxmXZls1t96+331TFumOtNDnW9VAu9tiRZn66/h/gwcXIZHwrMXrDCvVV4pM3dbs1p2/b8+B9z9tms+Su0ZEZivvxIIvD68KGhSgggcHoK/LA/TQ88kqA7bqmtuxrX0dQXX3OvkScPjwt6GMPJJHISegm7/nqOFi5d4yYvFi92jtuJLy96du2ObTUP202u3JW/zY7POGwYg4Xd2PbNXQ9v7esquVn0oRwHDh4KalxwKNfkXP8K2DKMtuOaTcA8fhhDVm8cwn0XBN5wi3M9BBAo0ALf7d3vdiGySWs2ueypmFa6qOR5eXLPGaG36W31dGOtKu4aFnRsG2LCbp6Qh1yorczQpFV3DYhrH9KY3dxWxMbwduj+rHv7cE+Teu45mfPyKrU+bu3e3JbJ9xHISsA2XzmafjQw5OrEsGtLmCUkTdVj7Zu5VUTCdRB4wyXNdRBAAIE8ELDQu2fvfpW+uKS+/navHn7yGQ3t1dHN/mcYQx6Ae1CkhV7r5Q3XYT9+bm8V7wJGuCcKheseuY4/BbIKu7Yzmx2jBz/htikO10HgDZc010EAAQTCIGC9K4/1Slad6n/ViISYkHZ3C0N1uUQYBN55b4fiB47T8jnDwnA1LoHAbwK2zfRDXRLd2wzbfCJjc578CLt2TQIvTyYCCCBQwAQs9CaOnqlxQ7pm2n2rgN0mt5NDgSNHflGLTv1Vv07V3yYURUTk8Ey+hoB3AjE9k/Vj2gE9l9g10LObsVGKDbM5fqdA7676e0kE3rxQpUwEEEAgnwUs9BY5M0o1qlbI55pweT8I2LAG2wnQ1mPOr61d/eBAHfJHwLYV/kfMIK2YkxQYzmNhN2H4dG3YvN2tYhPKtus5uSsCb06U+A4CCCCAAAIIIIBAUAK201rTdr00b9IAXX7pRW4L7BPDrg29sbkIedXTS+ANquk4CQEEEEAAAQQQQCCnAjPnLdfY6QsV3biuvtubqq07Pg307K7f9KHbrMfeQMS0axrYmjinZefkewTenCjxHQQQQAABBBBAAIGQBGxoTeceI7QvNS1T2I15Ollt7musr77dq/XvfqjEnh1UvcrVIV3rxJMJvJ5yUhgCCCCAAAIIIIDAyQSsN/eqK0q7Mbv2/xZ2+3RprTsa1nanvLT4TU2etUSLpg32FJHA6yknhSGAAAIIIIAAAghkJ5BV2LVzpqcs1egp8zUovr1qVqvk2U5+BN7sWoTPEUAAAQQQQAABBDwVsJVkUtN+cluxZxz2t8d7j1Sn1tGyiW5rNmzT0N6dVK1yuZCvTeANmZACEEAAAQQQQAABBEIRWL1hq57oM8ptVNG4fg1XVMrLq/T83GWaP3lAKEW7cwm8IRNSAAIIIIAAAggggECwAlmFXStrwsxX9OrKDUoZ3y/YogPnEXhDJqQABBBAAAEEEEAAgWAFbCjDz4cOq9FN1QNFrFizWU/2H6NxQ7vpumvKB1s0gTdkOQpAAAEEEEAAAQQQ8FzAwm7cgOeU2LOjGtS91pPy6eH1hJFCEEAAAQQQQAABBEIVWLl2s7oneBt2rU4E3lBbhvMRQAABBBBAAAEEPBGw4Q1H04/q5jre9OxmVIrA60nzUAgCCCCAAAIIIICAXwUIvH5tGeqFAAIIIIAAAggg4IkAgdcTRgpBAAEEEEAAAQQQ8KsAgdevLUO9EEAAAQQQQAABBDwRIPB6wkghCCCAAAIIIIAAAn4VIPD6tWWoFwIIIIAAAggggIAnAgReTxgpBAEEEEAAAQQQQMCvAgRev7YM9UIAAQQQQAABBBDwRIDA6wkjhSCAAAIIIIAAAgj4VYDA69eWoV4IIIAAAggggAACnggQeD1hpBAEEEAAAQQQQAABvwoQeP3aMtQLAQQQQAABBBBAwBMBAq8njBSCAAIIIIAAAggg4FcBAq9fW4Z6IYAAAggggAACCHgiQOD1hJFCEEAAAQQQQAABBPwqQOD1a8tQLwQQQAABBBBAAAFPBAi8njBSCAIIIIAAAggggIBfBQi8fm0Z6oUAAnkq0GPweC14bc0frnFJqQv0+uxnQ772tp27dH+Hflq9YKRKFC8acnkUgAACCCAQvACBN3g7zkQAgdNYwALvrt3fKL7zA5nuonBUpCqW+0vId0bgDZmQAhBAAAHPBAi8nlFSEAIInE4CFni//yFV44Z2y7LaqT8e0NAxs7RizSYdPZquv119peJjWqp82cvc95+fu0wzXnpde77fp6ioSFW4qoy6drhPlSuW1b7UNN0QHZOp3FrVKmnisO669599Vb92FT3a9p7A5zFPj1DJ84urT9c27m+VG7RV365ttWHzdi1f/a4qlb9C05J7KLs6nU7+1BUBBBAIpwCBN5zaXAsBBHwjYIH3u72pGpP4RKY6RUZEKD39Vz3wSIJKX1JSHR+M1llFCuuFecu1ZOXbemX6v3T2WUU0e8EKnVGokOsNTk9P1+RZS7Rp60d6Y+4IFSp0hta8s00duj+rhVMGqnixc10oLl70nBwH3sJRUWoR3UDXVi6nqMhI3XB95Wzr5BtcKoIAAgj4TIDA67MGoToIIBAegZON4V0yI1H/3f2NegyeoJVzhysqMsJV6NixY6ob3VmJT3dUvZqV/1DJz7/8Vk1axmnRtMEqW+YSnWxIQ057eAfFP6w7G9UJXOfN9VtyXafwSHIVBBBAwP8CBF7/txE1RACBPBCwwOuCbWyrTKWXv/IyTZy1WKMmzcvyqn27tdG9d9TXnu/3a3rKUteru3ffj0o7cFD7U3/S7LF93PCHUAPvyAGxql+naqAOY6YtyLZOecBEkQgggECBECDwFohm5CYQQCC3Aqcaw/vvKfO1aNlaLZkxJMtiD/58SLe1itfll16oVs0a6vJLL3LDIFp06p+jwHtTrSrq/NCpx/CeGHizq1Nu75/vI4AAAn8mAQLvn6m1uVcEEAgInCrwLn9rk2J7j9TCqYPc8ITjDwu2m7d9rNaxg/XmvGRdUKKY+zhjolpGD+9/dn2p6LZPa8WcJJW6sESgiHZdhqjMZaXUp0vrwN9srO+lpS7INGntxMCbXZ0iIgrRuggggAACJxEg8PJoIIDAn1LgVIH3aHq6W0P3wMFDevzh5rri8ov11bd7NW/JW3qweSOVKV1KDVt0VcumDXVznWv1xdd79OLCldq6Y1egh/fgz4dV7+4YN/HsrsZ1XVnVKpdT8sS5bnUHWw6t2LnnaO7iVVq1bovuu7P+KQNvdnWqUbXCn7IduWkEEEAgJwIE3pwo8R0EEChwAjlZlmz4hBStXLNZ+1PTdFHJEqpZrZJi2zdzS4i9vGyd7HMbv2tLkrVseoviBowNBF4DW7R0rZLGz9EP+9N0W4OaGvTUwy749hoySW+9/b7OPaeIWjVrpI1bduriC0ucMvBaebYs2anqVOAaiRtCAAEEPBIg8HoESTEIIIAAAggggAAC/hQg8PqzXagVAggggAACCCCAgEcCBF6PICkGAQQQQAABBBBAwJ8CBF5/tgu1QgABBBBAAAEEEPBIgMDrESTFIIAAAggggAACCPhTgMDrz3ahVggggAACCCCAAAIeCRB4PYKkGAQQQAABBBBAAAF/ChB4/dku1AoBBBBAAAEEEEDAIwECr0eQFIMAAggggAACCCDgTwECrz/bhVohgAACCCCAAAIIeCRA4PUIkmIQQAABBBBAAAEE/ClA4PVnu1ArBBBAAAEEEEAAAY8E/gc9vemkiZTxlgAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "top20 = eval_summary.sort(pl.col(\"ic_mean\").abs(), descending=True).head(20)\n",
+    "colors = [\"#2ecc71\" if sig else \"#95a5a6\" for sig in top20[\"significant_fdr05\"].to_list()]\n",
+    "\n",
+    "fig_ic = go.Figure(\n",
+    "    go.Bar(\n",
+    "        x=top20[\"feature\"].to_list(),\n",
+    "        y=top20[\"ic_mean\"].to_list(),\n",
+    "        marker_color=colors,\n",
+    "        text=[f\"{ic:.3f}\" for ic in top20[\"ic_mean\"].to_list()],\n",
+    "        textposition=\"outside\",\n",
+    "    )\n",
+    ")\n",
+    "fig_ic.update_layout(\n",
+    "    title=\"Top 20 Features by |IC| (green = FDR-significant at 5%)\",\n",
+    "    xaxis_title=\"Feature\",\n",
+    "    yaxis_title=\"Mean IC\",\n",
+    "    xaxis_tickangle=45,\n",
+    "    height=500,\n",
+    ")\n",
+    "fig_ic.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56ca1018",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002816,
+     "end_time": "2026-03-24T02:23:44.200110+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:44.197294+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Naive vs HAC t-Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "68c614c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:52.725340Z",
+     "iopub.status.busy": "2026-04-09T01:07:52.725243Z",
+     "iopub.status.idle": "2026-04-09T01:07:52.771087Z",
+     "shell.execute_reply": "2026-04-09T01:07:52.770651Z"
+    },
+    "papermill": {
+     "duration": 0.012423,
+     "end_time": "2026-03-24T02:23:44.215312+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:44.202889+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertemplate": "%{text}<br>Naive t: %{x:.2f}<br>HAC t: %{y:.2f}<extra></extra>",
+         "marker": {
+          "color": [
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#2ecc71",
+           "#95a5a6",
+           "#2ecc71",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#2ecc71",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#2ecc71"
+          ],
+          "size": 8
+         },
+         "mode": "markers",
+         "text": [
+          "dist_52w_low",
+          "vol_252d",
+          "natr_14",
+          "vol_126d",
+          "vol_63d",
+          "vol_63d_rank",
+          "vol_21d",
+          "skip_recent_12_1",
+          "ret_189d",
+          "ret_252d",
+          "sma_ratio_200",
+          "pct_positive_63d",
+          "skip_recent_6_1",
+          "ret_126d",
+          "ret_126d_rank",
+          "ret_63d",
+          "sharpe_189d",
+          "sharpe_252d",
+          "vol_ratio_63d",
+          "vol_ratio_21d",
+          "sharpe_63d",
+          "hurst_100",
+          "vol_ratio_short",
+          "ret_42d",
+          "macd_line",
+          "sma_ratio_50",
+          "sharpe_126d",
+          "sharpe_126d_rank",
+          "ema_ratio_26",
+          "chop_14",
+          "sharpe_42d",
+          "ret_21d",
+          "ret_10d",
+          "dist_52w_high",
+          "adx_14",
+          "rsi_14",
+          "stoch_k",
+          "sharpe_21d",
+          "rsi_7",
+          "aroon_diff",
+          "sharpe_10d",
+          "ret_5d",
+          "sharpe_5d",
+          "cci_14",
+          "cci_21",
+          "obv_zscore_63d",
+          "bb_pctb_20",
+          "vol_ratio_medium",
+          "max_dd_126d",
+          "mom_accel_medium",
+          "max_dd_63d",
+          "mom_accel_short",
+          "mom_accel_long"
+         ],
+         "type": "scatter",
+         "x": [
+          16.152049300038176,
+          10.4016075507356,
+          10.388454162685514,
+          10.029752836301446,
+          9.110108471151076,
+          9.110108471151076,
+          9.232100519933594,
+          8.218590383587179,
+          8.220978593170363,
+          7.997444789955963,
+          6.887362192807514,
+          8.186887848035505,
+          4.880859086460087,
+          4.765151116013638,
+          4.765151116013638,
+          4.160837207788063,
+          3.4409608081391028,
+          2.667595782857911,
+          4.685548712968539,
+          4.503854002005327,
+          1.7023350863586446,
+          2.210259353934044,
+          1.8968433729235636,
+          1.0167630917702568,
+          0.912949865812349,
+          0.5764095782358744,
+          0.586641688037098,
+          0.586641688037098,
+          0.11602668864737901,
+          0.0014786410254454996,
+          -0.5696204916308858,
+          -0.5431032988927165,
+          -1.1830453071757785,
+          -1.2454355612086927,
+          -2.0217830995934047,
+          -1.8104989769452282,
+          -1.9609186885402357,
+          -2.0358756479022198,
+          -2.2470797325178724,
+          -2.475057762826856,
+          -2.3656876386894536,
+          -2.123022458926743,
+          -2.627904830616295,
+          -2.851685560525629,
+          -3.369633808832531,
+          -4.4289020641172065,
+          -3.544083548045368,
+          -4.178142840935981,
+          -3.335857730998786,
+          -4.1065294803346735,
+          -4.253847606584472,
+          -5.390760069296785,
+          -9.031261408364609
+         ],
+         "y": [
+          5.834005019092565,
+          3.6765596240559644,
+          3.7043872909673716,
+          3.555592461440577,
+          3.2394555703663532,
+          3.2394555703663532,
+          3.3022224684007857,
+          2.9194236402879574,
+          2.918156556048707,
+          2.8388275468469115,
+          2.474236613106108,
+          2.937766542448768,
+          1.747348851929744,
+          1.7115295450864112,
+          1.7115295450864112,
+          1.5081599494213997,
+          1.2178393307802715,
+          0.938059192142907,
+          2.448682615011774,
+          2.657100493202423,
+          0.6109556024524677,
+          0.805944302791836,
+          0.7248235863782979,
+          0.3805937615063145,
+          0.33606620274217774,
+          0.21843795338999042,
+          0.21008057130443764,
+          0.21008057130443764,
+          0.04674901467319806,
+          0.0006331314014872545,
+          -0.2094292533829732,
+          -0.21185456006750342,
+          -0.5012716633084335,
+          -0.45201844829752075,
+          -0.7285093028667483,
+          -0.7142616013391783,
+          -0.8648356441358066,
+          -0.7866126714130235,
+          -0.970219840517687,
+          -0.9496682299908759,
+          -0.9915025741432272,
+          -1.1138186484473513,
+          -1.355641518077316,
+          -1.2935594256603116,
+          -1.4152383696541506,
+          -1.6839853594872638,
+          -1.5068102705734643,
+          -1.498681127326364,
+          -1.2265919383787087,
+          -1.4822663322878429,
+          -1.5979827251125371,
+          -1.9605131891481573,
+          -3.2137996939842584
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "dash": "dash"
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -9.531261408364609,
+          16.652049300038176
+         ],
+         "y": [
+          -9.531261408364609,
+          16.652049300038176
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Naive vs HAC-Adjusted t-Statistics"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Naive t-stat"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "HAC t-stat"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAgAElEQVR4XuydB3hURReGv5RND6GELkjvRXrvAgIW7CiKXRELYi8/NuyiqNh7FzsWmvTeey+RDqEGEkjbJPs/c8PGlN3c3b177m52v/s8PiqZmTPznpvwZvbcuSE2m80GXiRAAiRAAiRAAiRAAiQQoARCKLwBmlkuiwRIgARIgARIgARIQCNA4eWNQAIkQAIkQAIkQAIkENAEKLwBnV4ujgRIgARIgARIgARIgMLLe4AESIAESIAESIAESCCgCVB4Azq9XBwJkAAJkAAJkAAJkACFl/cACZAACZAACZAACZBAQBOg8AZ0erk4EiABEiABEiABEiABCi/vARIgARIgARIgARIggYAmQOEN6PRycSRAAiRAAiRAAiRAAhRe3gMkQAIkQAIkQAIkQAIBTYDCG9Dp5eJIgARIgARIgARIgAQovLwHSIAESIAESIAESIAEApoAhTeg08vFkQAJkAAJkAAJkAAJUHh5D5AACZAACZAACZAACQQ0AQpvQKeXiyMBEiABEiABEiABEqDw8h4gARIgARIgARIgARIIaAIU3oBOLxdHAiRAAiRAAiRAAiRA4eU9QAIkQAIkQAIkQAIkENAEKLwBnV4ujgRIgARIgARIgARIgMLLe4AESIAESIAESIAESCCgCVB4Azq9XBwJkAAJkAAJkAAJkACFl/cACZAACZAACZAACZBAQBOg8AZ0erk4EiABEiABEiABEiABCi/vARIgARIgARIgARIggYAmQOEN6PRycSRAAiRAAiRAAiRAAhRe3gMkQAIkQAIkQAIkQAIBTYDCG9Dp5eJIgARIgARIgARIgAQovLwHSIAESIAESIAESIAEApoAhTeg08vFkQAJkAAJkAAJkAAJUHh5D5AACZAACZAACZAACQQ0AQpvQKeXiyMBEiABEiABEiABEqDw8h4gARIgARIgARIgARIIaAIU3oBOLxdHAiRAAiRAAiRAAiRA4eU9QAIkQAIkQAIkQAIkENAEKLwBnV4ujgRIgARIgARIgARIgMLLe6DMElixdhtuGfMK3hl3P/r1aFtm11F44oG4poBIDBdBAiRAAiRQpgn4nfBOnb0cj4z7QIP6yN3DcPO1FxUB/MWkaRj/4Y+Y/9vbSKyY4Bb819+fhC9/mo7v3x+L1s3qu9W3LDQecuPjiImOws8fP1tiulnZVrQdcAeuGNwT4x69tcTXN27bjWEjn9P+fMJz92JAr/ZOl3zyVBq+/nkG5i1ZhwOHjyIsLAznVa+MC5o3wFUX90LThue7hWvkY29i4fINaFC3Jv744kWX+zqTwxfe+gY/TJ6NyV+8gIZ1z3N5PFcbHj95Gj/+MQf9erRDkwa1Xe3mUjt3hFd9rxw/eQojrh7o0tiFG+07eAQff/s3Vm/YgcNHT8ASHo5aNSqjTYuGGNyvM9q1aqQ198ZaSxvD0+/JT777G/Vq1yjxi46n47kNkB1IgARIgATKFAG/FV4ls3l5efhn0huIjooogGpEeH+bugAzF6zGo6OGoW7t6mUqUa5M1ojwvvbeD5j0xxyEhYWiW4eWeOv5ex2GXL8lCaOemIDTqWfRo1MrNG9UBzm5udi6cy+Wrd6i/fevnz7vsgiqcXpefj/i42KQcjrNLUl1JodKRuctXY+nx4xA9aqVXEHnVpttu/bhytufxguP3YbLB/Vwq69eY3eE976n3sbWXfsw68c39IYt8vUlqzZh1BNvITwsFBf2bI8aVSvhzNkMbNj6LzZu/RdVEstj7i9vaX28sdbSxvD0e7LTkLvRr3tbvPTEHUXW5ul4bgFkYxIgARIggTJHwG+F9/F7r8cr736Ph0Zeg1uHDfaK8Ja57Lg5YU+F12azod81D6JV0/qIsIRj5sLVWDR5ImJjoorM4NTpM7j05ieRk5OLD159sMQu+aHk43jpne8w8qZL0aJxXZdm/9Nf8/DcG1/i7XH3YfTYibhj+MV44I6rXOrrjhy6NKCLjbwhgc5CubMmT4V30PBHkXomHT9/9CxqVEssMhW18/vNL//gqdE3miK8LiIv0cyZ8Ho6HvuRAAmQAAkENgG/Fd4fP3oGb33yC7bt3Id/Jo1HTHSklglHO7xTZi/D1z/NwKEjx3E67SziYqLRuV0zjLppqPYxuf2y953985uoVrkirrhtrPYX/8xJ4xESElIk0zfe95L2ce60714t+PMZ81Zo8Xf8ewDh4WFo16oxHrrrmiIxHN0u7sRRu5zvfzkZC5dvxNHjKaiSWAHNGp2PW4YNRssmpUukp8K7av123DT6Zbz57D2IiAjHvU++jZefvAOXDuhWZDnvffE73v/qD7zy5J24ZEBXp98Z1pxcWMLDXPrOUTW4J06m4s+vXsJVdzyDtDPpmPHD6yX6Zmdbtdh/zFiE1LR01KlVTdtFnjx9UUEN73e/zcJL73xb0HfRHxNRISFe+/9hdz+v/XvSB08XGVvJ9u/TF2HdzE8L/nzn7gOY+Plv2LDlX5w5m44a1SqjQ+vGGDniUuw/dBTq3ih+XXNJbzzz0M3aH6v75t3Pf8fcJWuhfklQu8yq1EP94hYa+t995sqanEG87cHXsGzNlhJf1iv1sZe29O3eFhNfuL/UHK3ZuKPUtW5P2o9X3/0eew4k42RKqvY90bRhHdx+/RD06tJaG1tvjOLfk6pPafwrVyqPln1vQV6ercjc1f0w5ZtXCn4+2L/H7Y227NiDd7/4HWs27kRubh7q1a6OQX074frL+yEiwqIb06WbmY1IgARIgAT8loBfC6/aSRx+zwsYc+fV2l+i6nIkvEqENmxJ0sQzIT5WE6Lp81bAas3B5M9fQPmEuCJ97X8ZfvXzDKiP8r96+wm0b924IElqp7L/sIdx/21X4q4bLynSV4lC1/bNtY+AJ02eg4zMLEz+4kXtY2Bnl6txVDnAdXePw4FDR3HtZX012d2zPxlTZy/DZQO74ZFRw0q9kTwV3ufe/Ap/z1yChZMnIiw0FD0uvx8XNK+PD199qEg89TH+weTjUCIZHuaa0JY24WMnTqHPVWNwzy1DcfeIy/DZD1Px5kc/aVLasmm9gq5qB1p9BL9g2Xp0bNMEzRvX1URS1f0qubQ/tPbvvsNYv3mXVls8S+1SeyC8Bw4f08oVlFgNvag7oiIjtI/5Z8xfibeeu1eb149/zoWSf1UP3bZlQ22eqkRG1TCrX1iuues5ZGVl49pL+2h15qpOVv1Sdtt1g/HgXddo7V1dkzN+i1du0lip+ltV626/lMSpOZd2qRISVboy+fMXkVAu1mnTEymppa5V/VL28bd/ajXbap3q+03Na+O2f7XvqbYtG0FvjOLCq8e/d9cL8MeMxdqnAs0a1cGVQ3pq81clMRf2aOdQeNWu+V2PvYEKCXFafbL6GaH+TJV2qF9oQ0NDS825ismLBEiABEigbBPwa+FVH4vf+ch4bNq+W6tTVA9kuVrDq3af1M6qekBLiUlhWbYLr/rLuM9VD2hi8/wj/z3IpR6IefvTXzHzxzdQvUpFHD56EgOvexg3XX2RVmJhv5QYD77xcdxy7SCMvv3KUsXBlTj2B8eK14amZ2Rh74Fk3YfBlPAqQS7tKv7QmpLsXleMRrf2LfDa2JFa1/+9+hn+/GcxFvz2TsEvC+rPL7jwNlzQoiG+fOtxr9z16sG3V9/7QduZUzt09l80brxqAFRJi/2aMW8lHnz2Pe2XD/VLiP1y9vH/h1//qe3QeiK8n0+aijc+/En7VKFmoY/71T1gy8vTSgBKK2l4dvyXUJ8EqF+CqlauUDBX9UuF2o22l4q4uyZHwD0tabBzV+KnZK554zpoXL+2JpD2T1Ls8dwt31C71uqXxS7tm2ufBKirtDGKC68r/NWYzkoaio+ndoKH3PgY1M72b5+OK3I/q91edd9Nnr5QN+deueE5CAmQAAmQgM8I+L3wqp3b60aN0+o6VX2nI+FVf6mpj7rVLtrOfw/gdOoZqI/V1aVE9M4biu7SFv64854n39J24Bb89rb20aa6Lr35KVSulIDP3nhU+3+7ICjprlihXJFk3XBv/i7Zp+MfKTWJrsTZvH0PrrnrWa1c4JkHby7ysJ4rd4gSXrXzrHaDi1+5eXn48sfpJU5pULt0Ix97AxNfHI2+3dpo3Rat2Ii7Hn0Dzzx4E665tI/2Z0pk2gy4Q2uj2updagy101r4ali3prZzbb9UmYHaFVQPudkvlevDR05gzs8TCj7+H/PMu9qcFvw+sQgTCeFVjF7/YBL+98CNuPbSvkVKEOxzdCZwate26yX3YGDvjnji/uFF1r5o+UbcP/YdfPvuU9pJCO6uyRFvZ8KrSjt27ztcpIva/VRlPvZr2pzl+PqXf7RPRuyXxRKu7ZI+Ouq6gk8s9IRX5eDHP+dou+DqF8jMrGxtOCW89u8Jd4TXFf5qfFeF1/49pXbW1Q67o8vVmHr3PL9OAiRAAiTgvwT8XngVOiVkqp5S7bj+9OfcEseSKXn4Z/4q7SGq/uqp82qVtI8pH3j6Xdx36xVa7aW6HNULzlywSmun6lcH9u5QsBv16lN34eL+XbR+z0/4WjuGytmldqJVzXFplytxVH9VP6tqP9XH0mrnTX1Mrj6GdeX4K09KGp546RNtR/Knj57V6nfVlZObh2vvek6rHVYfTdsvd3Z47bushZn07NwaH7wyRvsj9dH1wOsegdrNVXWU9uvnv+ZD7fJ9MeFxrXxBXUNv+Z8mnr99Nq4IYgnhVdKmymhUra4qhVH3lKrVvnRAV63MQV3OBE71VeUCpV1q/YqDu2tyNKYz4XVU3/vwyGtxy7BBJYZRNew7kvZrn6KoXyqWrtqs7Wyrmmp1D5Ymq/aaaVWjfPlF3XF+rWooFxejPbioxvjszfxfGN0RXlf4qzFdFV4l9g8//wHee+kBbTfb0eVqzFITyy+SAAmQAAn4NYEyIbz2j/rVx9nqFIHC5/Dad3CuG9oPT42+oeDhM/UXeZeLR+kKr9ph7HXlaLRr2UjbuVTneP789zws+P2dglpIVS+oThNQH+Xbd4ELZ1V9DKx33qsrcdSYard60YoNmLtknbb7pkoz1PXi47c73LktPA93hVd9zNtj6H04m57p8CZVD/KpnVZ7ffJltzyF5KMnsfjPdw3X8KqyEfVQorOr8ENgl4x4AtHRkZqUF77cFl6bDZM+LPqLiaOH1lQJifolQNV4ql+0lJyrGtFvJj6p5dmZwKl6YlUeonbo1f3o6FK1vkoK3V2TO8Jr5CeOKjFRn2h8+OqD2rFzztaqSmG6X3Yfzq9ZFV+89ZhWbmS/VCmReljQE+FVY+jx90R43395TMGDdI74uBLTCFf2JQESIAES8C2BMiG8CtHdj0/Auk07cf0VF0LtHtqfRv975lI89uJH+HzCY+jUpmkBTVeFV5PJt7/BT3/Ow9xf38KVt4/V/qIvXNP76fdTMOHjnzXhUruunl56cRyNm3zsJG645wXExcZoZ9SWdrkrvPZdZ/WLhKplLHwpyVMPRT16z3W46dyLDdT/qwfLCtdFO5qPK6c0qB1OdTDGyBGXlRhC8T6YfAzzf3tHO+1B7Vgq8Ve/hBQ+5cAd4VWnUKScPoM/vyz6YgtHwlt8QvZTLIZfcSGevP8G7ZSOy2/9XwkO6un/TkNGomObplCCVdrl7pocjaWOcdu0bTdUiY6rlxLV0JBQh6Uaagz1QNiTL3+i1XMP6dfZ6VqPHEtB36vHaA8b3nvr5UXCFxdeZ7xUJ0efuujxV19XpSM9u7QuqBO29yk+nr0kqvjxhnq8iudcrz2/TgIkQAIk4N8Eyozw2ndy1dPgaifNLrzqaCYlD0/ePxzDr+iv0Va7pB9/+5f24JJeSYNqbx9blUMoCfxm4lMFT9+rr6t6yEtuehKd2jbFh688CFXraL9UzaI68kg9ka536cVR4yhpKnxCgRpTfcSujlv7++uXSw3hrvCqUpClq7dopzMUP0ZMzaP3laNRo2piQbmGOlVBcVAvBFFCV/hkCzWxo8dP4eWJ3+K264eUeg5v0p6DWp20Mwmxf1Ru//jfXh7x+ti7MbhfJ42Bkup3Pv1VK38o/mphRw+tqdKNKbOXYvZPbxaUJqh5jHnmPew7dLTgWDJVTtKsYZ0iD5xlZGZrInvlkF5aXbN605zaGS986oI9MY+O+1CrJVf1q6qOtfCl5Evt8KrdYnfX5Cjx4yZ8jV/+nq/tuMfFRuvdftrX1Tm76qHEJ+4bXuIhSFWnfccj47Fu0y7toT310J2ztapPLNpddCf6dG2jnaFsv1Td9iPjPkSrpvUKdnhL41VcUF3hr2JdetOTiImJKnHMXPHxlOD3v/Yh7fSRXz8dV+RUCvtDa+u37NLNuUtw2YgESIAESMBvCZQZ4VUE1YNf9geh7MKr/pIeeuv/cOjICQzu2wkJ5eK0j6IPHj4GJSquCK8aW31cv2v3QdSuWbXI2bv2zNnPoK1Vowou7NkOiRUS8O++Q5i9aA36dmvr8HW9jrJeWhz7a5XVDrOqX42MiNDOMZ0+d0WRnVZnd5M7wpuekal9JK0esFJn7jq61MkCqmZ62nevoXbNKloT9TY19fCVKoNQQqfql5UAq1089cuHEqHfP38Bjeo5f6XvO5/9io+++Us7b1e9krj4ZT+uTNVQqyf91VFfl4x4Ujujt0+3NtrxUur4K/WLjyrLcEV4VW3q7Q+/DpW/np1baSdvLFi6HlFREdoY9nN41Y6v2uVUddNNG9aG1ZqrHXG3dcderaSh1blXUqtdzN37k7Xdb1Xmon4RU2UYakf+urufx7ETp7WacFV7re7RZWu2arm0PzDp7poc5UcdvaZ2edVrgFV96v5Dx7SHO9XpC86ufQePQr14Ql1qbqpGXNUqq7OQlWwqpo/dc12R1xU7W6vaCVas1P1av04NrfxhxdqtCA8PR9sWDQuEV8VyNkZxQXWVv6oT/u63mdoJK+rTCXUUofoFytGOseKkfrmrUqmCltdy8TFQO7iqZlkdS6b6uJJzv/0pzomRAAmQAAnoEihTwqt2QK++M7+Os/AB++ov8ecnfKWVPMTGRGu1eiOuGqhJrKvCa/+LsvDZu8Xpqd1ftfuo5qHOCFYP5nRo01Q7b7Vx/Vq6sFWD0uKonTBVP6mkfu/BI1q9stoRVA92qY+X9S53hPevf5bg8Zc+xrsvjdZ26Rxd9t3z4kzUKQpf/DhNEwYljqEhIahZvTJ6dGyJK4b0RP3za5Q6VSVcKk+/fPKc03bq5Q5KoNTRYpHnXgzw4tvfYt3mXYiPjcagvp3RpX0z7SE/V4RXBVJ12Iq/klJ1YsRt1w3BstWbi7x4QpVOKJFSO99Hj6VoMqjKWNRH94V33tUvR+Pe+hqbt+9GhMWCW68bXHBWtJJG9QmDyqN6eYj6JUwxGdC7g7ZLbN9NVy9YcHVNzkCpl5T8MmW+thOr7sfv3x9bqvCqcdQnDerYObXGQ8nHNOEvFx+rSerdN12mHU9W+HK2VvVLk6r5nTl/FfJsNk2eR910GZ5948siNbxqLGdjFBdUV/mrkqUX3/pGO4s522pFl/YttBdpOCuRUOUvH33zp3ZGsM0G7cUT6hcq9b2rfnFxJed633/8OgmQAAmQgP8S8Dvh9V9UnFlZIaDqrVUd8IqpH5Z4PXJZWQPnSQIkQAIkQAIk4D0CFF7vseRIfkJAnSGs6mWX/v2+n8yI0yABEiABEiABEvAlAQqvL+kzttcIqJdFqNKCA4ePQtVC209U8FoADkQCJEACJEACJFBmCVB4y2zqOPHCBFQ98j/zVmolDP26t8Oj9wwrcjYsaZEACZAACZAACQQvAQpv8OaeKycBEiABEiABEiCBoCBA4Q2KNHORJEACJEACJEACJBC8BCi8wZt7rpwESIAESIAESIAEgoIAhTco0sxFkgAJkAAJkAAJkEDwEqDwBm/uuXISIAESIAESIAESCAoCFN6gSDMXSQIkQAIkQAIkQALBS4DCG7y558pJgARIgARIgARIICgIUHiDIs1cJAmQAAmQAAmQAAkELwEKb/DmnisnARIgARIgARIggaAgQOENijRzkSRAAiRAAiRAAiQQvAQovMGbe66cBEiABEiABEiABIKCAIU3KNLMRZIACZAACZAACZBA8BKg8AZv7rlyEiABEiABEiABEggKAhTeoEgzF0kCJEACJEACJEACwUuAwhu8uefKSYAESIAESIAESCAoCFB4gyLNXCQJkAAJkAAJkAAJBC8BCm/w5p4rJwESIAESIAESIIGgIEDhDYo0c5EkQAIkQAIkQAIkELwEKLzBm3uunARIgARIgARIgASCggCFNyjSzEWSAAmQAAmQAAmQQPASoPAGb+65chIgARIgARIgARIICgIU3qBIMxdJAiRAAiRAAiRAAsFLgMIbvLnnykmABEiABEiABEggKAhQeIMizVwkCZAACZAACZAACQQvAQpv8OaeKycBEiABEiABEiCBoCBA4Q2KNHORJEACJEACJEACJBC8BCi8wZt7rpwESIAESIAESIAEgoIAhTco0sxFkgAJkAAJkAAJkEDwEqDwBm/uuXISIAESIAESIAESCAoCFN6gSDMXSQIkQAIkQAIkQALBS4DCG7y558pJgARIgARIgARIICgIUHiDIs1cJAmQAAmQAAmQAAkELwEKb/DmnisnARIgARIgARIggaAgQOENijRzkSRAAiRAAiRAAiQQvAQovMGbe66cBEiABEiABEiABIKCAIU3KNLMRZIACZAACZAACZBA8BKg8AZv7rlyEiABEiABEiABEggKAhTeoEgzF0kCJEACJEACJEACwUuAwhu8uefKSYAESIAESIAESCAoCFB4gyLNXCQJkAAJkAAJkAAJBC8BCm/w5p4rJwESIAESIAESIIGgIEDhDYo0c5EkQAIkQAIkQAIkELwEKLzBm3uunARIgARIgARIgASCggCFNyjSzEWSAAmQAAmQAAmQQPASoPAGb+65chIgARIgARIgARIICgIU3qBIMxdJAiRAAiRAAiRAAsFLgMJrMPeHTmS4NUKkJRRx0RacSM1yqx8bu04gLDQEiQmROJKS6XontnSLQFx0OMrFWJCWkYO0dKtbfdnYdQJVykfhZFoWcnJtrndiS7cIVIyPQHpmDjKteW71Y2PXCaifFXk2G85k5LjeyY9b1qgU7cez49ScEaDwGrw3KLwGAQp0p/AKQC02JIVXnrGKQOGV50zhlWdM4ZVnzAj6BCi8+oxKbUHhNQhQoDuFVwAqhVceqoMIFF557BReecYUXnnGjKBPgMKrz4jCa5CR2d0pvPLEucMrz5g7vOYwpvDKc6bwyjNmBH0CFF59RhReg4zM7k7hlSdO4ZVnTOE1hzGFV54zhVeeMSPoE6Dw6jOi8BpkZHZ3Cq88cQqvPGMKrzmMKbzynCm88owZQZ8AhVefEYXXICOzu1N45YlTeOUZU3jNYUzhledM4ZVnzAj6BCi8+owovAYZmd2dwitPnMIrz5jCaw5jCq88ZwqvPGNG0CdA4dVnROE1yMjs7hReeeIUXnnGFF5zGFN45TlTeOUZM4I+AQqvPiMKr0FGZnen8MoTp/DKM6bwmsOYwivPmcIrz5gR9AlQePUZUXgNMjK7O4VXnjiFV54xhdccxhReec4UXmOMt2UcxOq0JKTlZqB9fAM0jq6B+DDvvO3tsRc+QpMGtXHLsEHGJumF3pu278az47/Ert0HUKNaIp64bzh6dGrlhZHzh6DwGkTJF08YBCjQncIrALXYkBReecYUXnMYU3jlOVN4PWf8QNLnmHtqU5EBakRUwIQGt6JJdE3PBz7X01+E12rNwcDrH8F1Q/vh2sv6Yv6SdXh+wteY8cPrqFg+3vA6KbxeQEjh9QJELw9B4fUyUAfDUXjlGVN4zWFM4ZXnTOH1jPEfJ1bg6T2THHZuH18fnzW6x7OBz/WaPH0Rnn79c4SGhCA8PAwd2zTF+y+PQddL78Gom4Ziyuxl2LpjD759byyefu0z7D90DDZbHpo2rINnHrwJDermC/eh5ON46Z3vsGrDdkRHRWBg7454/N7rkZ1txVuf/IIZ81bCmpODi/p0xCN3D4PFEl5i3ivWbsPose9g8Z/vITQ0RPv6NXc9i2GX9cUVg3saWqe9M3d4DWKk8BoEKNCdwisAtdiQFF55xhRecxhTeOU5U3g9Yzw66XPMK7a7W3ik9e3e9GzgQr0c7fAq4a1bqzpG3TwU1atWQmLF8tj57340qFMTEREW/PzXXMxdshZfTHgcObm5uOK2p9Gn6wW47fohOH7yNH79ez4eGTUML0/8DoePnsDLT9wJm82GUU9MwIBeHXDDlf1LzPunP+fi1ykL8ONHzxR87dFxH6Jq5Yp4aOQ1htepBqDwGsRI4TUIUKA7hVcAKoVXHqqDCFXKR+FkWhZycm0+iR8MQSm88lmm8HrG+Nbt72H1mSSnnT9tNAod4ht4Nvi5Xs6E9/M3H9Nqe+3X3zOXYuqcZdi5+yDSMzIRFhqKBb+/g9UbduCBpydi3q9vIywstKC9Etz2F92Fv756SavHVdf0uSswefpCfPjqQyXm/NXPMzB74Wp8/c6TBV9Tu8+W8HCMHTPC0BrtnSm8BjFSeA0CFOhO4RWASuGVh0rh9QljCq88drOFNyfHitUrFqNFq3aIjfNO/WdhSjUqeeeBMT3yvtzhLSy8f89aitffn4TnH7lVK3s4cPgobhr9Mpb8+R7U177+eQZ++ujZIss5kZKKnpffr+0Q26/c3FzUqlGliNTav6Z2eH+fvgg/vD+2oL3a4a1SuQIeHnmtHiqXvk7hdQmT80YUXoMABbpTeAWgUnjloVJ4fcKYwiuP3UzhTdq5FUsXzkFG+lnUqd8I/QcN9foCzRLe0mp428XVx+eNjdXwKjBPvPSJVot723WDCzipkobCwqt2WhPi4wpKC3buPlAgvKvWb8eDz6JL6jsAACAASURBVL6n7fDaa2/VQHl5NrS76E7888PrqFypvG4Olq/dijFPv4vFf76LkJD8Gt6r7ngG117WB1df3Fu3vysNKLyuUCqlDYXXIECB7hReAagUXnmoFF6fMKbwymM3Q3hTThzH/DnTcOzIYW1BDRo3Q9ceFyIyKsrrCzRLeNXEHe3yVo+ogLe8dErD25/+iq079+L1sSORkZmNKonltYfWCgvvJ9/9rZUbjH9mFM6mZ+KND3+EOkJM7fCqB9Muu+V/2gNptw4bhLQz6fhlynzcf9uV2hFjx06e0h5gq1QhAUqU9x5IxqUDupXIiRqn/7CHMeLqgbjmkt5YsHwDnn7tc0z//jWXhNmVJFN4XaFE4TVIydzuFF553nxoTZ6xisAaXnnOFF55xpLCm5WZiRVL52P7lg3ag1Hx5cqjV79BqF6zltjCzBRetQh1Du+qtF1Iy8k/h7dJTE2vncObfOwkHhg7Edt27dMeKHtt7MgSwqsk95FxH2DZ6i04r0YVDOjZHt9PnqUJr7r27E/GK+9+h7WbdiEqMgKD+nbSJFcJ9Ltf/Kad0nAyJRW1albBzddchMsH9XCYm/VbkvD8m19h1+6DqFGtEh4ZdR36dmvjtTxSeA2i5A6vQYAC3Sm8AlC5wysPlTu8PmFM4ZXHLiW8aamn8NukL5Gdna0tok37Lmjf2bFMeXOVZguvN+cezGNReA1mn8JrEKBAdwqvAFQKrzxUCq9PGFN45bFLCa+a+Z+/fIeQ0BBtV7dcQgX5xQCg8JqC2etBKLwGkVJ4DQIU6E7hFYBK4ZWHSuH1CWMKrzx2SeFVJQ0SdbqlUaHwyt8zEhEovAapUngNAhToTuEVgErhlYdK4fUJYwqvPHZJ4ZWffckIFF5fUDcek8JrkCGF1yBAge4UXgGoFF55qBRenzCm8Mpjp/DKM2YEfQIUXn1Gpbag8BoEKNCdwisAlcIrD5XC6xPGFF557J4K74Y1K3B+vQZIKF9RfpJuROAOrxuw/KgphddgMii8BgEKdKfwCkCl8MpDpfD6hDGFVx67u8J79MhhzJ81FadSTqDGebUxZOgw+Um6EYHC6wYsP2pK4TWYDAqvQYAC3Sm8AlApvPJQKbw+YUzhlcfuqvCq48WWL56LbZvXa5OKiY1D1579ULd+Y/lJuhGBwusGLD9qSuE1mAwKr0GAAt0pvAJQKbzyUCm8PmFM4ZXH7orwJu1QrwSejYyMdO3Vss1atkWHLj1gsUTIT9DNCBReN4H5SXMKr8FEUHgNAhToTuEVgErhlYdK4fUJYwqvPPbShDf1dArmz56G5EMHtIlUqlxVO1O3UmIV+Yl5GIHC6yE4H3ej8J5LQOqZdNw65lXcMfxiDOzdoSAtC5dvxMjH3iiSJoslHOtmfqr9GYXXx3ewg/AUXvmc8NXC8oxVBL5aWJ4zhVeecWnCu2PrRk14IyIi0L5zTzRv1VZ+QgYjUHgNAvRRdwovgLc//RWTpy/EiZRUvD727hLCO27CV/jl0+cLUhQCID4uhsLro5tWLyyFV4+Q8a9TeI0zdGUECq8rlIy1ofAa4+dKb72ShpVLF6BF63aIjol1ZTift6Hw+jwFHk2AwlsI29V3Povbrx9SQnhffPsbTP/+NYeAucPr0X0n2onCK4pXG5zCK8+YO7zmMKbwynPWE175GXg3AoXXuzzNGo3C64Lw3vPkBFRIiEe5uBh0bNMUo++4SvtvdVF4zbpVXY9D4XWdlactKbyeknOvH3d43ePlSWsKryfU3OtD4XWPF1vLEKDw6ghvyuk0HDmWgoRycUg+egJvfPgTKldKwITn7tV6ppzJdiszlrBQREWEIS3D6lY/NnadQGhICOJjLDh91r3cuB6BLdU9HB0RhszsXGRk5xKIEIGEmAicybQiN88mFIHDxkWFI8uaB2tuHmEIEMjKykT5+DjYYNN+XgTCVSHO/06OCASu0mug8OoIb/EErN20EzeNfhnrZ32mHZ2SkeXeN3BoKBAeFopsK3+4St3cISFApCUUmdlkLMU4PCwElvBQ5OTaYM0hZynOkRH5Pyts9F0pxIiwhCI3Nw/0Xe8izsnJwaKF87Fu7WrcceedSEiooP28CIQrOjIsEJYRdGug8LopvItXbsJjL3yERX9M1HqypMH/vmdY0iCfE5Y0yDNWEVjSIM+ZJQ3eZ3xg324smDMdZ8+kaYP3638RWl3QFmcycrwfzAcjsobXB9C9EJLCqyO8n/0wFedVT0Tr5g1w6vQZ/O/Vz9CuVSM8cd9wCq8XbkCJISi8ElSLjknhlWdM4TWHMYXXe5wz0s9i0fyZ2JO0Qxs0vlx59Ok/BA3r10GezUbh9R5qjuQBAQovAHUKw5TZy3DmbAYiIyJgsYThjy9eROVK5fH7tIX48qfpOHDomHYU2YBeHTDmzqsRHZVfw8MdXg/uOuEuFF5hwDylQR7wuQjc4ZVHTeE1zthms2HLxjVQx4tZrVaEhYWjTYcuaN2mI0LDwsCH1owz5gjGCVB4DTKk8BoEKNCdwisAtdiQ3OGVZ8wdXnMYU3iNc/779x9w+OB+baCatc5Hj74XIT4+oWBgCq9xxhzBOAEKr0GGFF6DAAW6U3gFoFJ45aE6iMAdXnnsFF7jjLduWofVKxajS4++qN+waYkBKbzGGXME4wQovAYZUngNAhToTuEVgErhlYdK4fUJYwqvd7BnZ2UhIjLS4WAUXu8w5ijGCFB4jfFjDa9BfhLdKbwSVIuOyZIGecYqAnd45TlTeOUZU3jlGTOCPgEKrz6jUltwh9cgQIHuFF4BqNzhlYfKHV6fMKbwymOn8MozZgR9AhRefUYUXoOMzO5O4ZUnzh1eecbc4TWHMYW3dM5Hkg/i1MkTaNyslccJofB6jI4dvUiAwmsQJnd4DQIU6E7hFYDKHV55qNzh9QljCq9j7Komd9miOdi+dSNCQ8Nw7Y13IC6+nEc5ovB6hI2dvEyAwmsQKIXXIECB7hReAagUXnmoFF6fMKbwlsS+c9tmTXYzMzMQEhKCFq3bo33n7ggPt3iUIwqvR9jYycsEKLwGgVJ4DQIU6E7hFYBK4ZWHSuH1CWMK73/YU0+nYO7MKTiafEj7w0qVq2pvSqtQMdFQbii8hvCxs5cIUHgNgqTwGgQo0J3CKwCVwisPlcLrE8YUXiAvLxdrVizB+rUrkJebqx0v1rFLLzRtcYFXckLh9QpGDmKQAIXXIEAKr0GAAt0pvAJQKbzyUCm8PmFM4QUyM9Ix6euPtNcCN2jUFF16XoioqGiv5YPC6zWUHMgAAQqvAXiqK4XXIECB7hReAagUXnmoFF6fMKbw5mNP2rEV0TGxqHFeba/ngcLrdaQc0AMCFF4PoBXuQuE1CFCgO4VXACqFVx4qhdcnjCm88tgpvPKMGUGfAIVXn1GpLSi8BgEKdKfwCkCl8MpDpfD6hDGFVx47hVeeMSPoE6Dw6jOi8BpkZHZ3Cq88cb54Qp6xisBXC8tzDgbhzcmxenykmDcyQOH1BkWOYZQAhdcgQe7wGgQo0J3CKwCVO7zyULnD6xPGgS68+/ftxoJZU9G8dTtc0K6zTxhTeH2CnUGLEaDwGrwlKLwGAQp0p/AKQKXwykOl8PqEcaAKb/rZM1i8YBb2JO3QuFZKrIIrht3sE8YUXp9gZ1AKr3fvAQqvd3l6YzQKrzcolj4GSxrkGasILGmQ5xxowmuz2bBp/SqsXr4YVmu2dqZu+0490KxlG+2tab64KLy+oM6YxQlwh9fgPUHhNQhQoDuFVwAqd3jloXKH1yeMA0l4jx9N1t6UdirlhCa3jZu10l4gERkV5RO29qAUXp/iZ/BzBCi8Bm8FCq9BgALdKbwCUCm88lApvD5hHCjCm7RzK+bM+EtjWLVaTXTvMwAVK1X2CdPiQSm8fpGGoJ8EhdfgLUDhNQhQoDuFVwAqhVceKoXXJ4wDRXizs7Mx9Y8f0aJVOzRo3MwnLJ0FpfD6VTqCdjIUXoOpp/AaBCjQncIrAJXCKw+VwusTxoEivD6B52JQCq+LoNhMlACF1yBeCq9BgALdKbwCUCm88lApvD5hTOGVx07hlWfMCPoEKLz6jEptQeE1CFCgO4VXACqFVx4qhdcnjCm88tgpvPKMGUGfAIVXnxGF1yAjs7tTeOWJ81gyecYqAo8lk+dcFoQ3IyMd61YtQ8euPREWFi4PxcsRKLxeBsrhPCJA4fUI23+duMNrEKBAdwqvAFTu8MpD5Q6vTxj7u/BuWLsSq5cvgno9cNsOXdGuU3efcDISlMJrhB77eosAhdcgSQqvQYAC3Sm8AlApvPJQKbw+Yeyvwntw/14smvcPUk+nICQ0FK3adEC7jt24w+uTu6Ro0BqVov1gFpyCuwQovO4SK9aewmsQoEB3Cq8AVAqvPFQKr08Y+5vwpqWewpIFs7FvT5LGo0q1GujVbzDKV6joEz7eCModXm9Q5BhGCVB4DRKk8BoEKNCdwisAlcIrD5XC6xPG/iS8a1ctxaplCzUO6u1oXXtc6Hdn6nqSJAqvJ9TYx9sEKLwGiVJ4DQIU6E7hFYBK4ZWHSuH1CWN/Et5Vyxdh7colaNS0BTp36+vzVwJ7KyEUXm+R5DhGCFB4jdADQOE1CFCgO4VXACqFVx4qhdcnjP1JeHNzc3DsyGFUq1HLJyykglJ4pchyXHcIUHjdoeWgLYXXIECB7hReAagUXnmoFF6fMPYn4fUJABOCUnhNgMwQugQovLqISm9A4TUIUKA7hVcAKoVXHiqF1yeMKbzy2Cm88owZQZ8AhVefUaktKLwGAQp0p/AKQKXwykOl8PqEsVnCa7Vm4+SJY6haraZP1unLoBReX9JnbDsBCq/Be4HCaxCgQHcKrwBUCq88VAqvTxibIby7k7ZrR43l5uZi2Ii7EBER4ZO1+ioohddX5Bm3MAEKr8H7gcJrEKBAdwqvAFQKrzxUCq9PGEsK79kzaVgwZzoO7NutrU2dpTvw4itRLqGCT9bqq6AUXl+RZ1wKrxfvAQqvF2F6aSgKr5dAljJMXHQ41F9iaRk5SEu3ygcM0ghVykfhZFoWcnJtQUpAftkSwpuXl4cNa1dgzYolUCcvWCwRaNepG1q0bo+QkBD5RflZBAqvnyUkSKfDHV6DiafwGgQo0J3CKwCVO7zyULnD6xPG3hbeI4cPYv7sqTh9KkVbT516DdGtV3/ExMb5ZH3+EJTC6w9Z4BwovAbvAQqvQYAC3Sm8AlApvPJQKbw+YexN4c3MzMA3n07U1hEdE4te/Qah1vn1fLIufwpK4fWnbATvXCi8BnNP4TUIUKA7hVcAKoVXHiqF1yeMvSm8agErly6AzZaHth27ITzc4pM1+VtQCq+/ZSQ450PhNZh3Cq9BgALdKbwCUCm88lApvD5h7G3h9cki/DwohdfPExQk06PwGkw0hdcgQIHuFF4BqBReeagUXp8wpvDKY6fwyjNmBH0CFF59RqW2oPAaBCjQncIrAJXCKw+VwusTxhReeewUXnnGjKBPgMKrz4jCa5CR2d0pvPLEeSyZPGMVgceSyXN2VXjVA2lL5s9C7Tr10aBxM/mJBVAECm8AJbMML4XCazB53OE1CFCgO4VXACp3eOWhcofXJ4xdEd5tm9dj2eK5sGZnIzYuHtfffLdP5lpWg1J4y2rmAmveFF6D+aTwGgQo0J3CKwCVwisPlcLrE8alCW/KyeOYO3MKThw7os2tSrUa6NN/SNC9Kc1oYii8RgmyvzcIUHjPUUw9k45bx7yKO4ZfjIG9OxSwzcuzYfwHk/D7tIWw5uSgX492eO7hWxAVmf8udAqvN25D745B4fUuT0ejsaRBnrEmWHzTmjhoR8Kbk2PFqmWLsHnDaqi3pkVFRaNz975o2KS5+HwCMQCFNxCzWvbWROEF8Panv2Ly9IU4kZKK18feXUR4J/0xB1/9NB3vvTwGMdGReOT5D9C6eQM8PPJaCq+f3u8UXvnEUHjlGVN4zWFcXHiPJB/E7Ol/4uyZNG0CjZu21GQ3IjLSnAkFYBQKbwAmtQwuicJbKGlX3/ksbr9+SBHhvWn0y+jXvS1GXD1Qazl/6Xo8/+ZXmP3zmxReP73hKbzyiaHwyjOm8JrDuLjwnko5gV++/xwJ5Sui14WDUaVqdXMmEsBRKLwBnNwytDQKr47w9rpiNMY9eit6dm6ttdx74AgG3/AYVk3/GNFRESxp8MObncIrnxQKrzxjCq85jB2VNBw6sA81zqttzgSCIAqFNwiSXAaWSOHVEd6Og0di4ouj0alNU63lkWMp6Hv1GCycPBEVy8cj5Uy2W2m2hIUiKiIMaRlWt/qxsesEQkNCEB9jwemz7uXG9Qhsqe7h6IgwZGbnIiM7l0CECCTEROBMphW5eTahCBw2LiocWdY8WHPzCEOIQHREOGywaT8vAuGqEJf/DA+vskWAwqsjvGqH98XHb0f3ji21lsV3eDOy3PsGDg0FwsNCkW3lD1epb5WQECDSEorMbDKWYhweFgJLeChycm2w5pCzFOfIiPyfFTb6rhRiRFhCkZubB/quGGJYwkO0e1j9vAiEKzoyLBCWEXRroPDqCO+I+19C/57tceNVA7SWc5esxXNvfIV5v76l/T9PafC/7xmWNMjnhCUN8oxVBJ7S4H3O+/YkaS+PsF+unMPr/VkE14gsaQiufPvraim8OsL73W8z8e2vs/DBK+qUhig89Nz7aNbofDxx33AKr5/e1RRe+cRQeOUZU3i9yzgt9TQWzJ6GQwf3oe+AS1C/UX6ZGoXXu5wdjUbhlWfMCPoEKLwAXnz7G0yZvQxnzmYgMiICFksY/vjiRVSuVF77qOvV937An/8sRk5ODvp0a6Odw6vklzu8+jeYL1pQeOWpU3jlGVN4vcd4zcolWL18kTZgeLgFPfoMLHg9MIXXe5ydjUThlWfMCPoEKLz6jEptwZIGgwAFulN4BaAWG5LCK8+Ywmuc8eGD+zF/9jSkpZ7SBqtTvxG69+qP6JjYgsEpvMY5641A4dUjxK+bQYDCa5AyhdcgQIHuFF4BqBReeagOIrCG1zPsWZmZWLpoNnZu26wNEBsXjx59L0Kt2nVLDEjh9YyxO70ovO7QYlspAhReg2QpvAYBCnSn8ApApfDKQ6Xweo3xP1N+w97du7TxLmjXGW07dkVYWLjD8Sm8XsPudCAKrzxjRtAnQOHVZ1RqCwqvQYAC3Sm8AlApvPJQKbxeY5xy8jgWzZup1eqWr1Cx1HEpvF7DTuGVR8kIBghQeA3AU10pvAYBCnSn8ApApfDKQ6Xw+oQxhVceO3d45Rkzgj4BCq8+I+7wGmRkdncKrzxxPrQmz1hFYA2vPGcKrzxjCq88Y0bQJ0Dh1WdE4TXIyOzuFF554hReecYUXnMYU3jlOVN45Rkzgj4BCq8+IwqvQUZmd6fwyhOn8MozpvCWZGyz2bBl01oc3L8XAwZf7pUkUHi9grHUQSi88owZQZ8AhVefEYXXICOzu1N45YlTeOUZU3iLMj5x/Kj2prTjx45oX7j48utQvWYtw4mg8BpGqDsAhVcXERuYQIDCaxAyH1ozCFCgO4VXAGqxISm88owpvPmMrdZsrFy6EFs2roHa4Y2OjkHnHv3Q4NyrgY1mgsJrlKB+fwqvPiO2kCdA4TXImMJrEKBAdwqvAFQKrzxUBxGC/aG13UnbsWTBbKSfPaPRadriAnTs2hsRERFeyweF12sonQ5E4ZVnzAj6BCi8+oxKbUHhNQhQoDuFVwAqhVceKoW3gIDVasXMqb9ptbrqqlApEb36DkLlqtW9ngcKr9eRlhiQwivPmBH0CVB49RlReA0yMrs7hVeeOEsa5BmrCMG8w/v7T1/j1MkTaN+5O1q0bo+QkBAR6BReEaxFBqXwyjNmBH0CFF59RhReg4zM7k7hlSdO4ZVnHOzCeyrlJCwWC2Lj4kVhU3hF8WqDU3jlGTOCPgEKrz4jCq9BRmZ3p/DKE6fwyjMOduE1hzBA4ZUnTeGVZ8wI+gQovPqMKLwGGZndncIrT5zCK8+YwmsOYwqvPGcKrzxjRtAnQOHVZ0ThNcjI7O4UXnniFF55xoEsvGmpp7QjxsolVDAHZClRKLzyKaDwyjNmBH0CFF59RhReg4zM7k7hlSdO4ZVnHIjCm5eXi7Url2Ld6uXayQuXXzNC7GE0VzNE4XWVlOftKLyes2NP7xGg8BpkyWPJDAIU6E7hFYBabEgKrzzjQBPewwf3Y96sKTiTloqIyEh07NJLO1fX1xeFVz4DFF55xoygT4DCq8+IO7wGGZndncIrT5zCK884UIQ3MzMDS+bPQtLOrRo09Ya0Lj0vRFRUtDkQdaJQeOXTQOGVZ8wI+gQovPqMKLwGGZndncIrT5zCK884EIR366Z1WLF0PrKzshBfrjx69RuE6jVrmQPPxSgUXhdBGWhG4TUAj129RoDCaxAlSxoMAhToTuEVgFpsSAqvPOOyLrx7d+/CP1N+00C17dAV7Tp1Nweam1EovG4C86A5hdcDaOzidQIUXoNIKbwGAQp0p/AKQKXwykN1EKGsv2lt1bKFaNS0hV+cxuAsgRRe+VubwivPmBH0CVB49RmV2oLCaxCgQHcKrwBUCq881AAUXp9AczMohddNYB40p/B6AI1dvE6AwmsQKYXXIECB7hReAagUXnmoFF6fMKbwymOn8MozZgR9AhRefUbc4TXIyOzuFF554qzhlWesIvhzSYN6EE0dL1bWLwqvfAYpvPKMGUGfAIVXnxGF1yAjs7tTeOWJU3jlGfur8Ko3pG1avwqrli3C4KHXoGq1mubAEIpC4RUCW2hYCq88Y0bQJ0Dh1WdE4TXIyOzuFF554hReecb+KLxHkw9h/uypOJVyUgPQonV7dOnR1xwYQlEovEJgKbzyYBnBLQIUXrdwlWzMGl6DAAW6U3gFoBYbksIrz9ifhDc7OxvLF8/Fts3rtYXHxMaha89+qFu/sTkgBKNQeAXhnhuaO7zyjBlBnwCFV59RqS0ovAYBCnSn8ApApfDKQ3UQwR9qeJN2bMXShbORkZGOkJAQNGvZFh269IDFEuETJt4OSuH1NtGS41F45Rkzgj4BU4V3zcYdaNm0PizhYUVmdvzkaah/mjSorT9jP2tB4fWzhACg8MrnhDu88oz9YYd34dwZBbu6FSomonf/IUisXNWcxZsUhcIrD5rCK8+YEfQJmCq8zXvfjPm/vY3EiglFZqZEePTYiVg4eaL+jP2sBYXXzxJC4TUlIRReUzD7/JSGQwf24Z8pv6JDl57azq7a4Q20i8Irn1EKrzxjRtAn4DfCe8fD47F6xsf6M/azFhReP0sIhdeUhFB4TcHsc+FVqwyU48ecZYzCK38vU3jlGTOCPgFThPeFt77RZvLD5Nm4fFAPREX+V/uVbbVi/tL1aNaoDj54ZYz+jP2sBYXXzxJC4TUlIRReUzD7hfCas1LfRaHwyrOn8MozZgR9AqYI792PT9BmsmDZenRu1wwRFkvBzKIiLWhY9zwMv7I/EuJj9WfsZy0ovH6WEAqvKQmh8JqCmcJrAmYKrzxkCq88Y0bQJ2CK8NqnoXZ6x9x5NWJjovRnVkZaUHj9L1F8aE0+JxReecYqguQpDadPpWDv7l1o1aaDOYvx0ygUXvnEUHjlGTOCPgFThVd/OmWvBYXX/3JG4ZXPCYVXnrGU8Obm5mD1isXYsHYlbHl5GHr1jahctbo5C/LDKBRe+aRQeOUZM4I+AVOFVx09Nm7C11i7aSfSMzJLzG7VdD60pp8yttAjQOHVI2T86xRe4wxdGcHbO7z79+3GwjnTcfZMmha+YZPm6NK9HyKjAudTN1e4Fm5D4XWXmPvtKbzuM2MP7xMwVXgffPZ97Np9ACOuHohX3/tBK2+oVKEcXn3vewy7rC/uvOES769QeETu8AoD9mB4Cq8H0NzsQuF1E5iHzb0lvBnpZ7Fo/kzsSdqhzSS+XHn06T8EVavX9HBmgdONwiufS28J75m8DHx0cio2Zv6LIzmnUDW8PFpG1cNdFQcjLjRafiHnItSoZF4s0xYVBIFMFd6ul96D8U/fja7tW+DCax7E+688iEb1zsMXk6Zhw9YkTHju3jKHnMLrfymj8MrnhMIrz1hFMCq8NpsNWzauwcqlC2C1WhEWFo42HbqgdZuOCA0r+gIgc1bkf1EovPI58Zbwjjr0LnZnHy4x4XoR1fFeDfP8gcIrf89IRDBVeFv3uw0/fvSM9ka1K29/Wtvh7d6xJZat3oIxz7yLpX+/L7FG0TEpvKJ4PRqcwusRNrc6UXjdwuVxY6PCq+p1f/7uM6SlnkaNmrXRs98gxJcr+uIfjycXIB0pvPKJ9Ibwrs/8F48nf+Z0sq9Uuw2to+rJLwYAhdcUzF4PYqrw9r7yATw1+gb079keY1/7HHl5eXjx8dvx01/z8NbHP2PJX+95fYHSA1J4pQm7Pz6F131m7vag8LpLzLP2RoVXRT2wbw+ysjJQv2FTzyYR4L0ovPIJ9obwfntqNr47NcfpZO+sOBiXl+smvxgKrymMJYKYKryPv/QxqiZW0HZ2N23fjetHjcP5Nati/6GjWl3vg3ddI7FG0TEpvKJ4PRqcwusRNrc6UXjdwuVxY28Ir8fBg6QjhVc+0RReecaMoE/AVOEtPp0NW5KwaOUm1KtdHQN7dyiT72mn8OrfZGa3oPDKE6fwyjNWESi88pwpvPKMvSG8LGmQz1OgRzBVeNds3IGWTevDEl70YQl1XJn6R9X2lrWLwut/GaPwyueEwivP2FXhzc7ORkTEf69rN2dmgROFwiufS28Ir5rlo8mfYmPm7hITbhlVF69Vu11+IecisIbXNNReDWSq8DbvfTPm//Y2EisWfWhCifDosROxcPJEry7OjMEovGZQdi8Ghdc9Xp60pvB6Qs39PqXt8B49chjzZv6tPYzWvc9A9wdnD40AhVf+RvCW8KpjMkm0YgAAIABJREFUyVQd7/rM3dppDXUjqqN1VF0ML9+Xx5LJp7HMR/Ab4b3j4fFYPcP/XjyxcPlGjHzsjSKJtljCsW7mp9qfUXj973uAwiufEwqvPGNnO7zZWVlYvmQetm1er00iJjYOw0bcqR05xst9AhRe95m528NbwutuXKn23OGVIis7rinC+8Jb32ir+GHybFw+qAeiIv/7+C3basX8pevRrFEdfPDKGNnVejC6Et5xE77CL58+X9A7RB3cHhdD4fWApxldKLzylCm88owdCe/ObZuxbNEcZGZmaM88tGjdHu07d0d4uMWcCQVgFAqvfFIpvPKMGUGfgCnCe/fjE7SZLFi2Hp3bNUOE5b8fzlGRFjSsex6GX9kfCfGx+jM2uYUS3hff/gbTv3/NYWTu8JqcEBfCUXhdgGSwCYXXIEAXu9tLGk6ePIm5M6fgaPIhrWelylW1N6VVqJjo4khs5owAhVf+3qDwyjNmBH0CpgivfRpqp1cdSRYbU3be266E954nJ6BCQjzKxcWgY5umGH3HVdp/q4vCq3+Tmd2CwitPnMIrz1hFUMK7aetO/PHrD1pAi8WCjl17o1nLNuZMIAiiUHjlk0zhlWfMCPoETBXeU6fP4MSpVNQ/v4Y2s70HjmDxyk1o0bgOWjWrrz9bH7RIOZ2GI8dSkFAuDslHT+CND39C5UoJBa9BTjmT7dasLGGhiIoIQ1qG1a1+bOw6gdCQEMTHWHD6rHu5cT0CW6p7ODoiDJnZucjIziUQIQIJMRE4fTYTn3/yPmqqN6X17Y/o6GihaME5bFxUOLKsebDm5gUnABNWHR0RDhts2s+LQLgqxPFUlLKYR1OF98Fn30N4WBheGzsSx06cwsUjnoAlPBxnzqbjtbF3Y0Cv9n7PcO2mnbhp9MtYP+szrYYuI8u9b+DQUCA8LBTZVv5wlUp2SAgQaQlFZjYZSzEODwuBJTwUObk2WHPIWYpzZET+z4rMzExERpadT8akeEiMG2EJRW5uHui7EnTzx7SEh8Bmg/bzIhCu6MiiR6sGwpqCYQ2mCm+vK0bj5SfvQNf2LfDtrzPx1c8zMPXbVzFj7gp88eM0/FrowTB/ha92pB974SMs+iP/CDWWNPhfpljSIJ8TljTIM1YR+OIJec4saZBnzJIGecaMoE/AVOFtM+AO/P31y6hZLVGTxshIC55/5Fbt1cJDb/mfXx5L9tkPU3Fe9US0bt4AqiTjf69+hnatGuGJ+4ZTePXvL5+0oPDKY6fwyjOm8JrDmMIrz5nCK8+YEfQJmCq8l4x4AvfeegV6dGqFgdc9jAfuuBpXDukJVSbwwNPvai+l8Lfr92kL8eVP03Hg0DHtKLIBvTpoD95FR+XX8HCH198yBlB45XNC4fUO45wcK9auXIoL2nfRHkgrfnGH1zucSxuFwivPmMIrz5gR9AmYKryTpy/Cs+O/QExMlFbL+/c3r2inHTz9+uc4ejwFH776kP6M/awFhdfPEgIKrxkZofAap7x/324smDUV6eln0bxVW3TteSGF1zhWt0eg8LqNzO0OFF63kbGDAAFThVfNf9X67dietB99ul6AGtUSkZObi0+/m4Iu7ZujtZ+e1FAadwqvwF1pcEju8BoE6EJ3Cq8LkJw0ST97Bovnz8Sef3dqLRLKV0CvfoNRtXpNCq/nWD3uSeH1GJ3LHSm8LqNiQ0ECpguv4Fp8MjSF1yfYSw1K4ZXPCYXXfcY2mw2bN6zGqmWLYLVma68CbtexG1q26YBQdXyLg4slDe5zdrcHhdddYu63p/C6z4w9vE/AJ8KbmZWN60eNwytP3YVG9c7z/qpMHJHCayJsF0NReF0EZaAZhdc9eMePJmP+7Gk4eeKY1rFGzdrodeFgxMWXK3UgCq97nD1pTeH1hJp7fSi87vFiaxkCPhHe9IxMdBg0Et+/P7ZMljEUTgWFV+bGNDIqhdcIPdf6Unhd42RvtXLpAqxbvQwxsXHo2rMf6tZv7NIAFF6XMBlqROE1hM+lzhRelzCxkTABCq9BwBRegwAFulN4BaAWG5LC6x7j3NwcrF6xGG3ad3V4GoOz0Si87nH2pDWF1xNq7vWh8LrHi61lCFB4DXKl8BoEKNCdwisAlcIrD9VBBAqvPHZHwnsmLwOzzqxFUvYhhCAE/eLaoHVUPfnJBGgECm+AJraMLcsnwmvNycW3v/yDi/t3QeVK5csYsqLTpfD6X/oovPI54Q6vPGMVgcIrz7m48C5J34KXj/2AHFvRV2ZXC6+IL84re0dnyhPUj0Dh1WfEFvIETBXeD7/+EyOuHoiY6MgiK9u1+yDWbNqJay7pLb9iL0eg8HoZqBeGo/B6AaLOEBTeooCyMjMRGRXldfAUXq8jLRgwOScF352ag305ydiReQitoupq//yeugRn8zIdBu4V2xKPVx4mN6kAHZnCG6CJLWPLMlV4m/e+WXubWmLFhCKYtuzYg5tGv4KV0z4sY/j4pjV/TBiFVz4rFN58xkp0ly2eo52pe83w2xEdE+tV+BRer+IsGEyVLNx76F0cyTlVIoANQIiTsJXCyuHbWo/JTCqAR6XwBnByy9DS/EJ4p8xehhcmfI2lf79fhtDlT5U7vP6XMgqvfE4ovMC2zeuxYul8TXpj4+LRf9BQVK5a3avwKbyu41QSq6640GjdTr+nLsbHJ6c6bWeDTavdLX4pGZ5e50Xd8dmgKAEKL+8IfyBgivBeevNT2lqT9hxEnVrVEBYWVrB2q9WKfQeP4qarB+LRe67zByZuzYHC6xYuUxpTeOUxB7Pwnko5ifmzp+Jo8iGEhIaiVZsO2gsk1IskvH1ReEsn+lvqYsw9sxa7rUeQW6jm9obyfXFZua5O5fejk1MwOXWJ28JbLjQWP9Z+0ttpDvjxKLwBn+IysUBThPeLSdM0GOM//BF3j7gMsTH/1bpFRkagYd2a6HBBkzIBrPgkKbz+lzYKr3xOglF47UeLbVi7Era8PFSpVkN7JXD5ChXFgFN4HaM9kpOCOw++hSyb1eFOrOo1vHxf3FC+n8MBPBXeppG18Wb1u8TyHagDU3gDNbNla12mCK8dyYx5K9Gn6wWIiLCULUqlzJbC63+ppPDK5yQYhXfS1x8jLfUULBER6NytD5o0by0OmsLrGPEtB99EsvUESqu3jQuNws+1xzocQK+kwVGn8JAwfFJzDKqFVxDPe6AFoPAGWkbL5npMFd6yiaj0WVN4/S+rFF75nASj8G5ct1J7NXDnbn1FTmRwlLVgEF51WoK7EjloT36ZXGnCq74+zUm9rar3vfnAeIenMXSOaYqHEq/EhyenYHd2MiJDLGgdXQ9XluvuUn2w/Hdf2YtA4S17OQvEGVN4DWaVwmsQoEB3Cq8A1GJDBqPwylMtGSFQhVe90OHlYz/ioPV4waJDQ0JwdUIv3Fy+vy5qo8KrAijRVqUNm7J240xuJqqEl0f/uLYYWkrtr+7E2MAhAQovbwx/IEDhNZgFCq9BgALdKbwCUCm88lAdRAgk4V2f+a92MsK/2YfO7cw6OgXBhkvLdcGoipeUytsV4VUC+9V5j+jmja8W1kVkuAGF1zBCDuAFAhRegxApvAYBCnSn8ApApfDKQw1g4VWy+3jyZ9oKnR35ZV9+KEIwpc4LpfL+r4Y3v6jB0bm5Y6sMR9eYZrp5o/DqIjLcgMJrGCEH8AIBCq9BiBRegwAFulN4BaAGsPBardlYuWQBomNj0aZ9F3F4356ajVln1hS89KBeRHXcWXEwWkfVKxE7UHZ4nzv6LZalbz23Pr3KWxum1Xmp1DxszNqjCXSeLU8TaPurIsIQii6xTXFJfGeHPB0NSuEVv+VB4ZVnzAj6BEwR3q0792L8Bz/isXuvR6N65xWZ1Y5/D+DV977HE/cOR4O6NfVn7GctKLx+lhAAFF75nARKDe/upO1YPH8WMtLPaufo3nj7fbBY5E6RUbKrXmfr6Hq3xj2oH1GjyJcCRXhHHXoXu7MPu7TDqwR2uo7w2iGpc3iXpW/R/rdzTDNcUa6b2zc/hddtZG53oPC6jYwdBAiYIrz/e/UzJB87iU/HO66nuvOR8ahVowrGjhkhsETZISm8snw9GZ3C6wk19/qUdeE9k5aK+bOm4tDBfdrCy1eohD79hyCxSjX3QLjZ2l576qhby8yauDW8L2rXrI2Y6BitiS+F93TqKWxL2o7DR/NFVc2pdo3aqHd+fUS4+UvBo8mfYmPmbpeENyQkFFPPH+cmWc+bU3g9Z+dqTwqvq6TYTpKAKcI7aPijuOeWy3HxhY4/LvzrnyV4/6vJmPbda5JrFRmbwiuC1dCgFF5D+FzqXFaFNy8vDxvXrsTqFYuhXiRhsUSgXaduaNG6PUJCHFWCuoTDpUbqVIBbDox32rZ6ejwu3Z//Ap5uHbqjcsVEnwlvttWKmQv+gTXHWmK+tWrURruWbV1as71R0ZIG58eJqeKEPnEt8VjiMLfGN9KYwmuEnmt9KbyucWIrWQKmCG+bAXfg24lPoXnjOg5Xs2FLEkbc/xLWzcp/qKEsXRRe/8sWhVc+J2VReNUrgWdO/Q3q3+o6v24DdO89ADGxcfLAAKizX6/e5/xhrMLCW71KNXRq09lnwrstaRu27drmlMuAngMKdqFdgaeOIbv30HtFmhauvVVfUMeS9YptYarsqrgUXlcyaKwNhdcYP/b2DgFThLfzxaPw+tiR6NGplcNZz1m0Bo+/9DFWTP3QO6sycRQKr4mwXQxF4XURlIFmZVF4MzPSMenrj7Rd3Z4XDkat2nUNEPCs61X7xjl82YEarWVKVXQ9Wrtg4KEDh/pMeFdvXIP9h/LLPRxd9h1odygo6f321BztYb2zeRmoGl5BO/PWlZMU3InjblsKr7vE3G9P4XWfGXt4n4ApwnvbQ6+hZrVEPP/IrQ5X8NgLH2k1vl+9/YT3Vyg8IoVXGLAHw1N4PYDmZpeyKLxqiUeSD6JSYhWEh8s9mFYaSmevtI3IC8OVe5qjnDXSL4R347aNSNqb5FXhdfMWM605hVceNYVXnjEj6BMwRXjnLlmLe598G/974EZcc0kfhIWFajPLyc3Ft7/OxOvvT8L4p+/GoL6d9GfsZy0ovH6WEJ7SYEpCyqrwmgJHJ8iS9C2YnLoE+84mI8wagvicCG1nt7DsRkdHY2DPgT7b4d21Jwmbtm90upLBfYe4/eCaP7B3NAcKr3xmKLzyjBlBn4Apwqum8cHXf+Ddz39HpQrl0Lh+be3sxG079yHldBpuHTYYD428Rn+2ftiCwut/SeEOr3xOKLzGGe87uBdrNq11OFCTBk3QpH4TnwlvaQ+t1T+/Plo2aWkcgJ+MQOGVTwSFV54xI+gTME141VR27j6AKbOW4d99h7SZnV+zGgb17YhmjRw/zKY/fd+3oPD6PgfFZ0Dhlc+JPwrvoQP7UOO8/2pg5SkYj6AeDkvak1TkNITCQunLY8nSM9Kxddc2nE47jYyMdCSUS0C1ytXRoE594wv3oxEovPLJoPDKM2YEfQKmCm9p09m0fTdaNDb/IRJ9RKW3oPAaJej9/hRe7zMtPqI/CW9mZgaWzJ+FpJ1b0aFLT1zQrrM8AC9H2LhtE46dPIb0jLPIzc2DOj5NnXVbr9Z5qFenESIjor0ckcPZCVB45e8FCq88Y0bQJ+BT4T16/BT+mrkEf0xfhKS9h7B53pf6M/azFhReP0sIa3hNSYi/CO+WjWuxYul8WLOztXV37Nobrdt2NIWBt4LMXTJX20V1dsVGx6B/zwHeCsdxihGg8MrfEhReecaMoE/AdOHNzMrGrIWr8eeMxViyajMSysXiot4dcXH/LmjToqH+jP2sBYXXzxJC4TUlIb4W3hPHj2L+7Gk4ceyItt4q1Wpob0orl1DBlPW7EkTVwaamndZkNiE+QTu31v4GNXv/A4f3Y9WG1brDdWrTCdWrVNdtxwbuE6Dwus/M3R4UXneJsb0EAVOE12azYc3GnZg8fRFmzFuBnJxc9O3eFtPmLMevnz6PJg3KVt1d4URQeCVuS2NjsqTBGD9XevtKeHNyrFi5dCE2b1gN9XMlKioanbv3RcMmzV2Ztmlt1Gt5l69bAVUHW/gq/sDXsjXLkXws/9W9pV32h9j02vHr7hOg8LrPzN0eFF53ibG9BAFThHfAsIdxMPk42rVqhMsGdsfA3h0QFxuN5r1vpvBKZDXIx6Twyt8AvhLeJQtma7KrribNW6NT196IiPzv7Fr5lbsWYcaCGcjIyHDYuPBLGxatXITjJ4/rDkrh1UXkcQMKr8foXO5I4XUZFRsKEjBFeJXYdm7XDHePuEyTXvs76ym8gpkN4qEpvPLJ95XwZqSfxYwpv6FLj76oWq2m/EKLRVA7t+pNbcVLEwo3U23mLp3ndG6F5XXtpjXYe9D5G81sNiAkBPDkzWamwymjASm88omj8MozZgR9AqYI77wl6/DHjEWYu2QdKlcqj8sGdMOlA7th0PBHucOrnyO2cJMAhddNYB4095XwejBVw11ULa56CcO+QmJqCbdAiasqUSh+HTt5HItXLnIaN7FiIrp36K59/Wx6OmYu/Mdp27w8oEJCAvp07WN4HRzAMQEKr/ydQeGVZ8wI+gRMEV77NE6nndXqdidPW4iN23Zrf3zXjZfg+ssvRGLFBP3Z+mEL1vD6X1IovPI5CSbhLe01u44eJnNnh1dlasvOzdjx784iSVMv5omNjss/luz8hggNDZdPapBGoPDKJ57CK8+YEfQJmCq8hafz777D2nFk6liyYydOoXPb5vhk/MP6M/azFhReP0sIT2kwJSFlXXjVrq261Fm3etfkGZOdNim8W1u4UWk1vM5OXFCv87Vf9pc7+PLFE3pcAuXrFF75TFJ45Rkzgj4BnwmvfWp5eTYsW7MZk6ctwmtjR+rP2M9aUHj9LCEUXlMSIiG86sURWzetx5Ch1xbU+Xt7MUoqtydtK/JmM/UKX1We4OzyRHgPHz2MNRvXFImjxq9VozbatWzr8rIovC6j8rghhddjdC53pPC6jIoNBQn4XHgF12bK0BReUzC7FYQlDW7h8qixN4U3LfUUFs6dgYP792pz6XXhYDRq0sKjeamd23/3JiE9M/84MHX+rZJMtZOrJHT52uUOxy3tFARPhFcFUXNRdb85ufm7ydUrV0NCufJurYvC6xYujxpTeD3C5lYnCq9buNhYiIApwvvQc++7NP03nhnlUjt/akTh9ads5M+FwiufE28Ib15uLtavXYG1K5ciNzcHFotFezVws5ZtdXd4lUzuP7QPh4/kn2Gr+iZWqIRtSdtL7KqqB8zUm8pWrFvu9AgwderCACdvMyutPMHdHVt3M0PhdZeY++0pvO4zc7cHhdddYmwvQcAU4b378QkFc1eHxS9cvgFtWzZEXGxMkTV98MoYiTWKjknhFcXr0eAUXo+wudXJqPAeOXwQc2dOgdrdVVed+o3QvVd/RMfEOp2Hktzko4e1lzns3r8bWdlZLs9ZienxlGNOz8ZVAw0dONTheM5OXbCLtCt1wC5PtFhDCq+n5FzvR+F1nZWnLSm8npJjP28SMEV4C084JzcXrfvdhh8/egYtGtf15lp8MhaF1yfYSw1K4ZXPiRHhnTvzb+zavkWbZFx8OfToMxDn1S79Z0HRN5fZAIQ4XaT97NrCDdTDZfZX/Trr6Ex4VXsVf9+h/dprgtVVrXJ11K6ZXyoheVF4Jenmj03hlWdM4ZVnzAj6BCi8+oxKbUHhNQhQoDuFVwBqsSGNCO/sGX9iT9IOtLygPdp16o6wMP0jt1x9I5mapiPhVbuxiRUr4fDRZIdwysUnoK8fnnVL4ZW/lym88owpvPKMGUGfAIVXnxGF1yAjs7tTeOWJGxHeU6dP4XDyQZw4naLtmFpzsmEJj4DahW3ZpKXDt5gVfnDMkdAWXrGzHd62Ldpi7pK5JWp8VV9/fZMZhVf+XqbwyjOm8MozZgR9AhRefUYUXoOMzO5O4ZUn7o7w7j90ENFR0UisWFErDVi0cnEJ6bRLqrO62NJOSii52pIlDy0at4Q621bV/27dtQ0Z505xiI6KQYPz67l9eoI84fwIFF550hReecYUXnnGjKBPwBThXb/lvwPVc3PzcON9L+KFx25DvfNrFJlh62YlX9OpvwTftmBJg2/5O4pO4ZXPiZ7wqnrZ2YtmIjMrGyHnym2V1IaFhSJPvS/X4ZUvqnY5LdzEVeGNjIhCVnZmkdHV63/VznFZvCi88lmj8MozpvDKM2YEfQKmCG/z3jfrzwTA5nlfutTOzEbqxRjjP5iE36cthDUnB/16tMNzD9+CqMgIbRoUXjOz4VosCq9rnIy0sgvvzn2HkZGVow2l6mBzrdnIyEjHio1rkJmV4VhrbTYnx47lC68jQV2+dlmR+lslzwixIaTQw2vVq1RDyyatEB5uKXi4TJ3DK/1gmRGOen0pvHqEjH+dwmucod4IFF49Qvy6GQRMEd6DycddWkvNaokutTOz0aQ/5uCrn6bjvZfHICY6Eo88/wFaN2+Ah0deS+E1MxFuxKLwugHLg6b7Du7FngN7cDr1NHJy8wp2cLPT0nD2+HHExsUjvFIlhIY6P0mhtLCOhFeVIixbuxyp505JsPdXkqvelObuCx08WLZPulB45bFTeOUZU3jlGTOCPgFThFd/Gv7b4qbRL6Nf97YYcfVAbZLzl67H829+hdk/v0nh9dO0UXjlElN8p1VFysnKQtqRZO3f6kqsUg2Ij0NIaKjDiTh/6Mx5SYN9IHUmbkbGWVgsEYiJig5Y0bWvl8Irdy/bR6bwyjOm8MozZgR9AhReHUa9rhiNcY/eip6dW2st9x44gsE3PIZV0z9GdFQESxr07zHTW1B4PUN+/ORxHDpyCKlpqYiKikKd8+poJyfYL/XA2dyl8wr+35aXh7MnjiPjVP7LI0LCwhBfuQouaNMJW3fln7Pr6LKhaCnCf21siI6OQZ8ufct0GYJn9B33ovB6k6bjsSi88owpvPKMGUGfAIVXh1HHwSMx8cXR6NSmqdbyyLEU9L16DBZOnoiK5eORZXX2AI7jgdWnvGFhIbDmqN0sXhIE1ENSlrBQZOe4lxuJuZSVMectX4qkfftKTLdCuQRcMfAi7c937tmNBStXaP+ddeYMzhw7iryc/Prd6IQExCZW1nZ12zZvjrVbNmvn4Tq6VH6Kfy0qIhK1qldH2+YtEBfr/G1rZYWnt+YZER4Ka26eU5beihPM41jCQpCbZ0MefySL3QbhYSHaPaw4B8IVaXH86VUgrC2Q10Dh1cmu2uF98fHb0b1j/lPexXd4A/nm4NqCg8DBI0fxx+zZThfbs317tGjUEOu3bcfiNWu00oWUfXu19mGWCMRXqwZLVFRB/w4tWyDtbAa2/fvf6SyFB+/TqRPKxcXheEoKIiMsSKxQQfuHFwmQAAmQAAlIEaDw6pAdcf9L6N+zPW68aoDWcu6StXjuja8w79e3tP8/kZrtVm4s4SGIjgxH6lmrW/3Y2HUCqnQ0ITYCKWnu5cb1CP7fMjvbis07tyAl9TSs1nwONavVRItG+Z9UFL4279iCTTu2Ol1U+XLlMbBnPxw9fgxzly3Q2qUlJyMsMhIxDkS1T+eeqJJYGVt2bsO2pB3Iyc3RTlMIDw9H5ws6oHrVav4P0E9mWD4uAmnp2cjlhxViGYmPCUdWdi6y+ambGOOYqDBthzcjK1cshpkDVyqXf0oTr7JFgMKrk6/vfpuJb3+dhQ9eUac0ROGh595Hs0bn44n7hms9eSyZ/93wwV7Dq87Anbd0rvaSheKXxWJB9/bdijzstXbTGuw9WLKcwd5XHe3V59xrd+csmVvipATVTtXlwhaC2jVro13Ltv53U5TRGbGGVz5xrOGVZ8waXnnGjKBPgMKrw0i9KOPV937An/8sRk5ODvp0a6Odw6vkl8Krf4P5okWwC++uPUnYtH2jU/Tq7WJKYO3n025L2oZtu7Y5bV9YeJVEr9m0BuoBN/ul3qJWtXJVVE2siupVqvsi5QEbk8Irn1oKrzxjCq88Y0bQJ0Dh1WdUagvu8BoEKNA90IRXO/d2/z7k5eUiIiICWdZsrUxByWdihURUr1pde1mD/dq4bSOS9jqun9V2Y21A947dUfncCQzqqK/FKxc5zUTbFm1Qu+b5Rb6uXjwRYssGQiORls7yHIHbWBuSwitF9r9xKbzyjCm88owZQZ8AhVefEYXXICOzuweS8M5ZPBun09IKXu6Qz9IGmy2kyJ81adBEewGDulZvXIP9h5yXKCjhVa/abVDnP0let2Uddu/fDZs1B6lHkhFbKRGW6GhUqlARPTr2LJFCvVcLm53zQI1H4ZXPLIVXnjGFV54xI+gToPDqM6LwGmRkdveyJrxqp1b9Y82xwhJu0V7Rq8oNkvbuwsZtmxzic/TyhqEDh2pt9UoUVJtuHf7b4bUHWLpoDjatW6X9b8Uq1dDrwsFFzuEtPBEKrzl3NYVXnjOFV54xhVeeMSPoE6Dw6jOi8BpkZHb3siS8qlxBSa160Cwk5L+d28JC6+zNZMX/vE+X3trDaEqe5yyeo52OUPLKf5vZgJ4DEBMdo3358MH9mDdrCs6kpSIiMhIdu/RC0xYXlJo2Cq85dzWFV54zhVeeMYVXnjEj6BOg8OozovAaZGR297IivEpM/1nwj1ZTq17GoHeVbGc/xD2/s1141X+rutwVa5dru8b2y/6yB3s5Q2ZmBpYumIVd544ka9CoKbr0vBBRUdF6UwGFVxeRVxpQeL2CsdRBKLzyjCm88owZQZ8AhVefEYXXICOzu/tCeO1lCWqtlvDwIsd+OVu/vfTA1R3c/HHyd2gdXfaShsJfO3z0ME6nnYZ6LbDa/a1UIVF7WG130nYsmDMd2VlZKJdQAT37XoTqNWu5nCoKr8uoDDWk8BrC51JnCq9LmAw1ovAawsfOXiJA4TUIkqc0GAQo0N1s4XVSEjzfAAAgAElEQVT0kJg6nqtNi7YFR38pId5X6KzbShUTcSLleKnHgbmDpvBDa670O5p8CH//Pgmt23ZEm/ZdEBoW5kq3gjYUXrdwedyYwusxOpc7UnhdRuVxQwqvx+jY0YsEKLwGYVJ4DQIU6G6m8Jb2gJhdQtUu6/K1y0usVElmbk7+m4ec1e86x5O/0xsbE4daNc4rOKHBHZxZmZmILPRKYHf6UnjdoeV5Wwqv5+xc7UnhdZWU5+0ovJ6zY0/vEaDwGmRJ4TUIUKC7p8KrdmGPnjiK1LRUhISEQL1woVqV6gW7tMWnqsoElq9b4fCNZqrt/9u77/gqqoQP47/0BBJ6E1BRFBVUpIMICAFRbKuioiiuLq64q2LBvqjoYu/YV117VyyLYgGkF1FEUPTFinQIoSekvp8ZTUziTc7cO/dMyM1z/9qVc+bMfGd0nx3nznW+FOZ8OWzSlEnlnqWt6pBLnrOt6pnekkcg9mxZfb9qRvBauHBDbJLgte9M8No3JnjtG7OCWYDgNRtVOYLg9QloYXokwbtg8UKtWrPSvdNa9hnZxMQk96dyy/6CmHPH9oslX3iKWOf1X1X9qEPFw/cSvE0aNXF/aKI6f9WM4LVw4RK8waBWWIXgtc9O8No3ZgWzAMFrNiJ4fRoFPd1r8Dp3aLO3btay5cu0K29X6W5W/BJZyZ1aZ0DJmxVKBlf1hoXEhET16NzTELyhv4RWrGLFVfLltFDv0C1rvHPHdn2zZJG69uxjjZ7gtUZbbsPc4bXvTPDaNyZ47RuzglmA4DUbEbw+jYKebgpe06MIofa35JVfFZ/ZrSp466VnqMshXTRt7qeeCZw7t85rw5x9nPflfOXk5JSbe/AB5X8hrewfFhcXa+nihVo4b5YKCvKVOfgE7bv/b7++Fu0PwRtt0dDbI3jtOxO89o0JXvvGrGAWIHjNRgSvT6Ogp1cVvM4PPHw6d9rvz91W/oqvivtcclc11BsZKrsbe1iHw9SmdRt9OOPDP4VryfYrBnPZty04++q8UiwnZ4fS0uqqblqd0h+LqLh/G9ev1bSPJ2lzdpb7R633bKM+A45WekY9K/wErxXWP22U4LXvTPDaNyZ47RuzglmA4DUbEbw+jWxMd+6A5hcUuAFY8othJetUFbzODzKUPFNr+sGHsn9e2R1eZ82yz92W/Gfnrw/u99uvmVV2t7bi+s7PCg/qe1SlX5IL5ZiXl6cFcz7Vt18vlnOHt07ddPXuO1Bt2razwV66TYLXKm/pxgle+84Er31jgte+MSuYBQhesxHB69MomtOdL4wt+XZJuTcj1K9XX507dCr9sYeqgvf7n3/Q0u+WuLtkCt6S/U5LS9PgvoPd/+r8FPAXSxdVekgl2yx5NKHsQCe2nUcNnC/FrV2/WqvXrSn94tsezVq4rxZzfhzC6+eH5cs0d8YU5eTsdN8q0f6QzurWq4+SkpK9biLicQRvxHRhTSR4w+KKaDDBGxFbWJMI3rC4GGxJgOD1CctbGnwChjHd+cLYtDnTQr4doewXy6oK3rLvxDUHb7H7M7u9OvUsF6JT50zT1m1b/rTnddPqqkWzFu6rzJxfM7P9efeNF7Vu7So1btpc/TKPUeMmzWwvWbp9gjcYaoLXvjPBa9+Y4LVvzApmAYLXbFTlCILXJ2AY08venQ01reQ526qC1+tbFpw3LHQ5tKsaN2wc8hED507vhk1ZysndKec1YSU/2RvG4fgemr1po1avXKEOh3b2va1wN0DwhisW2XiCNzK3cGYRvOFoRTaW4I3MjVnRFSB4fXoSvD4Bw5he1a+aOZvpfHAn7dVqb5ne0lDZmxZSklPVrEkzNW3U2N0On8oFCN5grg6C174zwWvfmOC1b8wKZgGC12zEHV6fRtGabgpeL3d4S/bFeZ42K3uj+4Uy57lZ51fVqvOHHKJlFNR2CN5gpAle+84Er31jgte+MSuYBQhesxHB69MoWtPLvmEh1Dadn/F1nuU13eGN1v7Y3s6u3FylpKbaXiai7RO8EbGFPYngDZss7AkEb9hkYU8geMMmY4IFAYLXJyqPNPgEDHP6/EXztGb92j/NKvv+2poevJuzN+nTj/+npORkHfuXYWEKBTOc4A3GmeC170zw2jcmeO0bs4JZgOA1G3GH16dRtKc7Xxjbsm2r+6MMob4wVlODt7CwQJ8vmK3Fn893yZzgPfXMv6lueka0CX1vj+D1TehpAwSvJyZfgwheX3yeJhO8npgYZFmA4PUJzB1en4AWptfE4P11xU+aOXWydmzf5orsf2AH9Toik0caLFwfNWmTBK/9s0Xw2jcmeO0bs4JZgOA1G3GH16dR0NNrUvDm7NyhWdM/1s8//J/LlFGvgfoPOlbN92gVNFtY63GHNyyuiAcTvBHTeZ5I8HqminggwRsxHROjKEDw+sTkDq9PQAvTa0rwbtmcrbdeeeb3X1+Tuvbso05de1kQif4mCd7om4baIsFr35ngtW9M8No3ZgWzAMFrNuIOr0+joKfXlOB1XCa+9pySk5LVN/MYZdSrHzRVxOsRvBHThTWR4A2LK6LBBG9EbGFNInjD4mKwJQGC1ycsd3h9AlqYXpOCNzc3x/354pr2IXiDOWMEr31ngte+McFr35gVzAIEr9lot7rDu7YgWz/lrdWPeau1b3JL7ZPcQi0SG/o8itiaXpOCt6bKE7zBnDmC174zwWvfmOC1b8wKZgGC12y02wTvx9s/1xOb3tf2otzSfUqPT9XfGw3RoPQuPo8kdqYTvPbPJcFr39hZgeC170zw2jcmeO0bs4JZgOA1G+0Wwevc2b149UPlYrdkx5zondDyIu70/g6yuwTvl5/PU9t2Bykjo+Y8m+v1bweC16uUv3EErz8/L7MJXi9K/sYQvP78mB0dAYLXp2NQz/A6d3fv3fhWpXs7ttlwHV6nvc+jiY3p1R2869etcX8pzXkLw55776ujjx8aG7BljoLgDeaUErz2nQle+8YEr31jVjALELxmo93iDu8Lm6foxc1TK92X4Q0G6KwGmT6PJjamV1fw5u3apXmzpuq7ZUtcSOcX0g7vO1Bt9t0/NmAJ3sDPI8Frn5zgtW9M8No3ZgWzAMFrNtotgpc7vN5PVHUE7/Jvv3Zj13nrQlxcnA7u2FVdex6hxMQk7zteg0ZyhzeYk0Xw2ncmeO0bE7z2jVnBLEDwmo12i+B1nuE9d+Xdle7Lf1uP4Rne33WCDN6tW7I17eNJWr92tbt646bN3V9Ka9ioic8ra/eeTvAGc34IXvvOBK99Y4LXvjErmAUIXrPRbhG8zk5Udpf38iYn85aGMmcpyOBd9vVizZr2oZJTUtS9Vz8ddPBhPq+omjGd4A3mPBG89p0JXvvGBK99Y1YwCxC8ZqPdJnidHXHu9C7J/VHrCjareWIDHZK6L3d2K5yhIIPXWXrB3Ok65LBuSkur4/NqqjnTCd5gzhXBa9+Z4LVvTPDaN2YFswDBazbarYLX5+7WiulBB2+tQK1wkARvMGed4LXvTPDaNyZ47RuzglmA4DUbEbw+jYKeTvDaFyd47Rs7KxC89p0JXvvGBK99Y1YwCxC8ZiOC16dR0NOjGbzOq8ac53P5lBcgeIO5Ighe+84Er31jgte+MSuYBQhesxHB69Mo6OnRCN6Cgnx9Pn+WvlnypU47a6T7Tl0+fwgQvMFcDQSvfWeC174xwWvfmBXMAgSv2Yjg9WkU9HS/wbvi5x80Y+pk5ezc4e56n/6DdWCHjkEfxm69HsEbzOkheO07E7z2jQle+8asYBYgeM1GBK9Po6CnRxq8O3ds16xPP9IvP33v7nL9Bg3VL3OImu/RKuhD2O3XI3iDOUUEr31ngte+McFr35gVzAIEr9mI4PVpFPT0cIO3uLhYSxcv1MJ5s+Q8ypCQkKgu3XvrkE7dFB8fH/Tu14j1CN5gThPBa9+Z4LVvTPDaN2YFswDBazYieH0aBT093OB9+/XntWHdGnc3W++1j/oOOJpndg0njeAN5qomeO07E7z2jQle+8asYBYgeM1GBK9Po6Cnhxu8X3/1hb78fJ4O75upfdoeEPTu1sj1CN5gThvBa9+Z4LVvTPDaN2YFswDBazYieH0aBT093OB19i8/L09JyclB72qNXY/gDebUEbz2nQle+8YEr31jVjALELwGo5nzl2jU1feUG5WUlKgvP37S/Wurs3LMymVGpCTFKz0tSVlbd4U1j8HeBSIJXu9bZ6QjQPAGcx0QvPadCV77xgSvfWNWMAsQvB6C95b7ntUbT95cOjJOUkZ6HYLXfH1VywiC1z47wWvf2FmB4LXvTPDaNyZ47RuzglmA4PUQvOMfeF6TX7oz5Eju8JovsqBHlA3etat/VfamLB108GFB70ZMr0fwBnN6CV77zgSvfWOC174xK5gFCF4PwfvP6+5Tw/oZqpdeR907HaTR5w91/7PzIXjNF1nQI5zgrZtcpHfem6Tvv/vGXX7YORcoI6N+0LsSs+sRvMGcWoLXvjPBa9+Y4LVvzApmgVobvLvy8rUzJzekUEJCQmnQZm/ZpnUbslW/XrrWrs/SPY+9pqaN6+u+cRe5c7O355mVy4xISohXanKCtuXkhzWPwd4Fln39lWZNn6qcnBylZ2Ro0NHHac+92njfACONAs41nJacoNy8QuXkFRrHMyAygfp1krU9N1+FRcWRbYBZRoH01ETtyi9SfmGRcSwDIhNIS05UsYrdf17EwqdhOl9wronnsdYG73sfzdHDz7wd8py1bdNSD996acg/W7R0uc4ZfZsWf/KU4uLilLMrvL+Bnd8xSEyIV14+/3CN9t8wm7Ky9P7772n1qpXuD0Z0695TvY/oq8TExGgvVeu3l5gQp6TEeBUUFiu/gGvZ1gWRkvzbPyuK6V1bxEpOildhYZHoXWvESkqMc69h558XsfBJS0mIhcOodcdQa4M30jM9+7Oluvrfj2vWOxPcTfBIQ6SS0ZtXWFigzxfM1leLPlNxUZGaNt9DQ08+SQUJ6dFbhC2VE+CRhmAuCB5psO/MIw32jXmkwb4xK5gFCF6D0VMvv6/WezRRxw77afOW7frXHU+py6HtdO3Fwwle8/UVyIhdubl67YX/uP/KrEfv/mrf4VA1qZ+iddmhH1kJZKdifBGCN5gTTPDadyZ47RsTvPaNWcEsQPAajCZ+MFPPvDZZK1dvcF9FdlS/brrs76cqLfW3Z3i4w2u+yIIY4fw0cEb9BkpNTROvJbMvTvDaN3ZWIHjtOxO89o0JXvvGrGAWIHjNRlWOIHh9AlqYTvBaQK2wSYLXvjHBG4wxwWvfmeC1b8wKZgGC12xE8Po0Cno6wWtfnOC1b0zwBmNM8Np3JnjtG7OCWYDgNRsRvD6N/E7fuGGd+w7dlNRUT5sieD0x+RpE8Pri8zyZRxo8U0U8kOCNmM7zRILXMxUDLQoQvD5xeaTBJ2AV0/Pz8/TZnBn6ZukiHdj+UB3Rf7CnxQheT0y+BhG8vvg8TyZ4PVNFPJDgjZjO80SC1zMVAy0KELw+cQlen4CVTP9h+TLNnTlVOTt3uCPaH9JJvfsN8rQYweuJydcggtcXn+fJBK9nqogHErwR03meSPB6pmKgRQGC1ycuwesTsML07du2avon72v1qhXunzRo2Fj9Bx2rJs1aeF6I4PVMFfFAgjdiurAmErxhcUU0mOCNiC2sSQRvWFwMtiRA8PqEJXh9Av4+vaioSEsWfeb+gITzQxJJScnq0qO3Du7Y1f1Fu3A+BG84WpGNJXgjcwt3FsEbrlj44wne8M3CnUHwhivGeBsCBK9PVYLXJ+Dv05cuXug+wuB82rRtp8P7ZKpuekZEGyd4I2ILaxLBGxZXxIMJ3ojpPE8keD1TRTyQ4I2YjolRFCB4fWISvD4Bf5/u3NWdNPFVderWS3vuva+vjRK8vvg8TSZ4PTH5HkTw+iY0boDgNRL5HkDw+iZkA1EQIHh9IhK8PgEtTCd4LaBW2CTBa9/YWYHgte9M8No3JnjtG7OCWYDgNRtVOYLg9QloYTrBawGV4LWPGmIFgtc+O8Fr35jgtW/MCmYBgtdsRPD6NAp6OsFrX5w7vPaNucMbjDHBa9+Z4LVvzApmAYLXbETw+jRau/pXzZs1TceedIaSkpJ8bs08neA1G/kdQfD6FfQ2nzu83pz8jCJ4/eh5m0vwenNilF0BgtenL480VA6Yk7NTc2dMkfMjEs6nc7fD1aXHET7FzdMJXrOR3xEEr19Bb/MJXm9OfkYRvH70vM0leL05McquAMHr05fgDQ24bOmXWjB3uvJ27VJ8QoI6duquzt0PV3x8gk9x83SC12zkdwTB61fQ23yC15uTn1EErx89b3MJXm9OjLIrQPD69CV4ywNmb9qoaR9PUtaGde4fNGvR0v2ltHr1G/qU9j6d4PVuFelIgjdSufDmEbzheUUymuCNRC28OQRveF6MtiNA8Pp0JXj/APxs7gx9+fk89y+kpqapV59M7XdAe5/C4U8neMM3C3cGwRuuWGTjCd7I3MKZRfCGoxXZWII3MjdmRVeA4PXpSfD+AbhgznQt/mK+Dmh/qHr27q/klBSfupFNJ3gjcwtnFsEbjlbkYwneyO28ziR4vUpFPo7gjdyOmdETIHh9WhK8fwAWFOQra+N6NW/Ryqeqv+kErz8/L7MJXi9K/scQvP4NTVsgeE1C/v+c4PVvyBb8CxC8Pg0JXp+AFqYTvBZQK2yS4LVv7KxA8Np3JnjtGxO89o1ZwSxA8JqNqhxB8PoEtDCd4LWASvDaRw2xAsFrn53gtW9M8No3ZgWzAMFrNiJ4JeXl5Sl704Zqf1zBy+kieL0o+RvDHV5/fl5nE7xepSIfR/BGbud1JsHrVYpxNgUIXp+6teEOr/PDEXNnTlVRUZGGjbhAycnJPtXsTid47fo6Wyd47Rs7KxC89p0JXvvGBK99Y1YwCxC8ZqNae4d327YtmjXtQ61c8bNr0LBREw0+7mRl1GvgU83udILXri/Ba9+3ZAWC1741wWvfmOC1b8wKZgGC12xU64K3qLBQixct0KLP5qqwsEBJSUnq1quv2h/SWXFxcT7F7E8neO0bc4fXvjF3eIMxJnjtOxO89o1ZwSxA8JqNalXwrluzyv2ltG1bN7vHvU/bA9S730Cl1anrUyq46QSvfWuC174xwRuMMcFr35ngtW/MCmYBgtdsVGuCNydnp1546iH3eOumZ6jvgKPVeq99fAoFP53gtW9O8No3JniDMSZ47TsTvPaNWcEsQPCajWpN8DoHumDudPd4u3TvrYSERJ861TOd4LXvTvDaNyZ4gzEmeO07E7z2jVnBLEDwmo1qVfD65NgtphO89k8DwWvfmOANxpjgte9M8No3ZgWzAMFrNiJ4fRoFPZ3gtS9O8No3JniDMSZ47TsTvPaNWcEsQPCajQhen0ZBTyd47YsTvPaNCd5gjAle+84Er31jVjALELxmo5gI3pydOzRnxhS1abu/2u5/kM+j3r2nE7z2zw/Ba9+Y4A3GmOC170zw2jdmBbMAwWs2qvHB+/VXX2jhvBnuzwOnZ9TTGeeM8nnUu/d0gtf++SF47RsTvMEYE7z2nQle+8asYBYgeM1GNTZ4szau1/QpHyhrwzr3GFq0bK1+mceoXv2GPo96955O8No/PwSvfWOCNxhjgte+M8Fr35gVzAIEr9moxgVvfn6ePps7U98s+ULFxcVKS6ujXn0y1bZdbD/KUHKiCF6fF7WH6QSvB6QoDOGnhaOAaNgEwWvfmOC1b8wKZgGC12xUo4J37epf9cnkd+U8s+t8DuzQUT0OP1LJKSk+j7TmTCd47Z8rgte+MXd4gzEmeO07E7z2jVnBLEDwmo1qVPBuzs7SGy89rfoNGqnfwCFq1nwPn0dY86YTvPbPGcFr35jgDcaY4LXvTPDaN2YFswDBazaqUcHr7OzqlSvUsvVePo+s5k4neO2fO4LXvjHBG4wxwWvfmeC1b8wKZgGC12xU44LX5yHV+OkEr/1TSPDaNyZ4gzEmeO07E7z2jVnBLEDwmo0IXp9GQU8neO2LE7z2jQneYIwJXvvOBK99Y1YwCxC8ZqPdKnhX/PyD9mrT1udex/Z0gtf++SV47RsTvMEYE7z2nQle+8asYBYgeM1Gu0Xwbt2S7b5Td+3qlRp4zF+0T9t2Pvc8dqcTvPbPLcFr35jgDcaY4LXvTPDaN2YFswDBazaq9uBdOG+mFi2c6+6H83qxPv0Ha9/9DvS557E7neC1f24JXvvGBG8wxgSvfWeC174xK5gFCF6zUbUF75pVv+rTTyZp+7atiouL00EHH6buvfopKTnZ517H9nSC1/75JXjtGxO8wRgTvPadCV77xqxgFiB4zUaBB29ubo7mzvhE3//fMnft5i1auXd1GzZu4nNva8d0gtf+eSZ47RsTvMEYE7z2nQle+8asYBYgeM1GgQfvR5Pe0i8/fa+0OnXVq88Atd2/dvwksM9TUTqd4I2WZOXbIXjtGxO8wRgTvPadCV77xqxgFiB4fzfaun2nzrvsDp0//DgNPrJbqVxRUbHufvQVTfxgpvILCpTZp4vGjTlXqSm/PVawOivHrFxmREpSvNLTkpS1dVel83Zs36ZlS7/UYV17KjExKaztM1gieO1fBQSvfWOCNxhjgte+M8Fr35gVzAIEr6QHnnxTb0+eqazsrbpr7IXlgveVd6bq2dcm6+HbLlOdtBRdefOj6thhP40Zdbq14DWfNkZUJUDw2r8+CF77xgRvMMYEr31ngte+MSuYBQjeMkan/v0mjTzz2HLBe87o25R5RGeNOHWwO3L63MW6+d5nNeX1ewle8/VVLSMIXvvsBK99Y4I3GGOC174zwWvfmBXMAgSvIXj7nTxat1x1nvr27OiO/GXlOg0562otnPyE0lKTrTzSYD5tjOAOb/VeAwRvMP7NGqRq07ZdKigsDmbBWrgKwWv/pBO89o1ZwSwQ08G7ZesOFRUXhVRIr5OmpKTEcn8W6g5v9yGjNGH8aPXo9NsXx9ZtyNaAUy/TzLcnqFGDDGVvzzMrlxmRlBCv1OQEbcvJD2seg70LxMfFKaNOkrbsCO/ceF+Bkc41nJacoNy8QuXkFQJiSaB+nWRtz81XYRHBa4lY6amJ2pVfpPzC0P9bYWvd2rTdtOREFavY/edFLHwapvNq0Jp4HmM6eE+/YJy2bNsR8rzcePk56tW1gzF4nTu8468ZqSO6H+KOrXiHN2dXeH8Dx8dLiQnxysvnH662/oaJi5OcLwfm5mFsyzgxIU5JifHuncf8ApxtOack//bPimJ61xaxkpPiVVhYJHrXGrGSEuPcazhW/k1FWkqCPSy2bE0gpoM3XLVQd3hHXHKrBvXtqrOHHuVubtqcRRp3z7P69M373f9u4y0N4e4348sL8Ayv/SuCRxrsGzsr8EiDfWceabBvzCMN9o1ZwSxA8JYxChW8L771sV548xM9ervzloZUXTHuEbVvt7euvXg4wWu+vqplBMFrn53gtW9M8AZjTPDadyZ47RuzglmA4JU0/oHnNWnKPG3fkaOU5GQlJSXonf+OV9PGDdx/1XXHwy/r3Y9mq6CgQP17d3Lfw+vEL3d4zRdYdYwgeO2rE7z2jQneYIwJXvvOBK99Y1YwCxC8ZqMqR/BIg09AC9MJXguoFTZJ8No3JniDMSZ47TsTvPaNWcEsQPCajQhen0ZBTyd47YsTvPaNCd5gjAle+84Er31jVjALELxmI4LXp1HQ0wle++IEr31jgjcYY4LXvjPBa9+YFcwCBK/ZiOD1aRT0dILXvjjBa9+Y4A3GmOC170zw2jdmBbMAwWs2Inh9GgU9neC1L07w2jcmeIMxJnjtOxO89o1ZwSxA8JqNCF6fRkFPJ3jtixO89o0J3mCMCV77zgSvfWNWMAsQvGYjgtenUdDTCV774gSvfWOCNxhjgte+M8Fr35gVzAIEr9mIEQgggAACCCCAAAI1WIDgrcEnj11HAAEEEEAAAQQQMAsQvGYjRiCAAAIIIIAAAgjUYAGCtwafPHYdAQQQQAABBBBAwCxA8JqNoj7ixxVrNHTkDZry+r1qWD+jdPtFRcW6+9FXNPGDmcovKFBmny4aN+ZcpaYkR30fassGd+Xlq/NR5//pcF96ZKw6tm9bWxiiepxLv/tJN939jL7/aaVatmiiay8erj49Do3qGrV9Y8MuvFlLlv1YjuHS84fq/OHH1XYa38f/zoez9dTL7+vdZ8aX2xbXtW/a0g1UZnzv46+59mU/vbsdrCfuGhO9xdkSApUIELwBXxp/u+JOLf9xpbKyt2rWOxPKBe8r70zVs69N1sO3XaY6aSm68uZH1bHDfhoz6vSA9zJ2lisJXud/3Jo2aVh6YHXTUpWQEB87BxrQkeTnF2jwmVfqjL9k6vQTB2j6nC91833P6cOX71KjBn/8n7eAdidml3GC9+QhfXV0/+6lx5ianKTk5KSYPWbbB7Z+42adM/pWZW/ZrmZNGpYLXq7r6OhXZeys4ATv+qzNuu6Ss0oXTExIcP/3jg8CtgUIXtvCIba/MydX3Y4Z9afgPWf0bco8orNGnDrYnTV97mLdfO+z7p1gPpEJlASvY9iiaaPINsKsUoEFi77V6LEPava7Dys+Ps7966ddcJOGnTjADTQ+0RFwgnf4SQN1/FGHR2eDbKVU4NM5X+reJ14vF7xc19G9QEIZlwSv8384brnqvOguyNYQ8CBA8HpAivaQyoK338mj3X8Q9O3Z0V3yl5XrNOSsq7Vw8hNKS+WxhkjOQ0nwNm5YT3XSUtWubWuN/tspatumVSSbq/VzXnt3mt6cNEOvPn5jqcVVtzym5k0b6YpRp9V6n2gBOMH7y69rVbdOqvvYyHnDhujIww+L1uZr9XZCxRjXdXQviaqC96WJnyi9bh05/0w+dmBP99rmg0AQAgRvFJQLC4u0dfuOSrfUoF664uJ+uyES/YQAAA1PSURBVBvmfCoL3u5DRmnC+NHq0ekgd9y6DdkacOplmvn2BP51cQVdr+bOc9FfLftBzZs01PadOXr+jY8057Ol+t/zt/NsdATX/rOvf6gpMz/Xcw9eVzr7hrueVlJiosZeNiKCLTIllMCy5b8ovW6aioulmfMX6+7HXtNLD/9LB+2/N2A+BULFGNe1T9QK0ysL3hWr1qmgsEjO4znf/vCrxt3zjC44+wSdeVJmdHeArSEQQoDgjcJl4dyJveCqeyrd0ptP3uzeqTEFr3OHd/w1I3VE90PcodzhrfzkhGtesiUnlLsec4GevPtKdTm0XRTOfu3ahHMnbOLkWXr5kbGlB+7c4W3WtCHPmlu8FEaOucu9Xi8ccaLFVWrHpiu7w8t1Hb3zX1nwVlzhiRfe07zPv9HT910dvcXZEgKVCBC81XBpVHaHd8Qlt2pQ3646e+hR7l5Nm7NI4+55Vp++eX817GVsLpmTm6cex47SxKdu4bGGCE7x/EXLdNkND2n2uw+V/luLoeffqNNP7K9Tjzsygi0yxYvAmf+4xX2e1/myIB9/AqFijOvan2nF2V6D9/7/vCHnru+9N/0zujvA1hAIIUDwVsNlUVnwvvjWx3rhzU/06O3OWxpSdcW4R9S+3d7ua5/4RCYwddYXWr0uy71rnpKcpAeeetN9S8brT4wr/dJVZFuunbPy8vI1aNgY94uVpx1/pGbM/0o33Pm0Jr90p5o2blA7UaJ81KvWbpTznOOxmT3dtwlMnrZA9//ndfcxHL546R87VIxxXft3LbuFyoL3lvue01FHdlPbvVtq2fIVuvrfj+mWq/6mzD6do7sDbA0Bgrf6r4FTRt6gNeuztGXrDtXPqKs9WzYr/QKQ86/b73j4Zb370WwVFBSof+9O7nt4nfjlE5nA4m9+0F2PvKLvf17lbqDroQfoukuGu18E4hOZgGPqvD3k+59WqWWLxrryH2doQO9OkW2MWX8S2Lxlu8be+ZQc5x07c7X/Pq005sJh6trxALR8CKxZv0mnjByrgoJC5eTuUkZ6HZ1wVG9dc9GZ7la5rn3g/j7VZHzbhBc1dfYibdy0xf0/b389bbD7ekM+CAQhwB3eIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQQAABBBBAAIEgBAjeIJRZAwEEEEAAAQQQQKDaBAjeaqNnYQQQqEpg4OlXaM26LF183skaNeKE0qETP5ipB596U9PeuN8T4M6cXHU7ZpTGjTlXQ4/r52lOJIMuvOY+tWrRRP+69OxIppeb0/Xov2v8Nedr8JHdwtpWpPPCWoTBCCCAQA0UIHhr4EljlxGoDQJO8LZs3ljLlq/QR6/cpYb1M9zDDjd4CwoL9cGU+erYYT/t1aqZNTqC1xotG0YAAQR8CxC8vgnZAAII2BBwgvfCESfq2dc/VM/O7XXdJcNDBu/Cxd/p1gdf0Op1WcrPL1Drlk018oxjdfxRh5fu1mGDRuqeG/6h/r076ahhV+jkY/vpH+ecWPrn3/+0Sieee73eeuoWHdB2T23ZukN3PfqKps7+QgUFhTr4gH10zcXD1W7f1iEP9d/3P6+X355S7s+en3CdOh/SLuR4J8Ifenqi/vfJXG3K3qoWzRppYJ8uuvyC03TCX6/XDz+vKp0XHx+nJVP/K9NxVjbPxrlhmwgggEBNEyB4a9oZY38RqCUCTvD+869/Uf166br8xof0v+dvV+s9mv7pDu/8Rcu0+Ovv3bhMr5umT2Z8rseef1dv/GecDtxvL1erJHgz+3TWhKff0qRP5mnyS3eWSt792Kv6bNG3evXxG1VYWKQz/3GLWu3RRKNGnKi01GS9PHGKPpg2X5Oev1110lL/dAZ27MzVJWMf1B7NGuvS84e6f+7sd1JiQsiz9ehz72ji+zN1+/UXqHHDelq2/Be99/EcPXzrpdq8ZbsyT7tc1148XEcefpg7v0mj+jIdZ2XzasnlwmEigAACVQoQvFwgCCCwWwqUBO9Jx/TR2RePd2PyzrGjPD3S0H/opRp19gk6/cQBfwrelWs2aPAZV6rkDmxRUbEGnHqZe8f3tBP6a8a8xbrutic17c37S4O1uLhYvU+8SHdcP0p9ehwS0ivUIw278vJVWFhYOj4pMVFJSYm69IaHlLtrlx6744qQ2/L6LG7F4/Q6b7c84ewUAgggYFGA4LWIy6YRQCBygbLBu2jpcp198a3uXVvnbmjZL605UfnqO1M1Y/5XWr12o5y7rZs2b9Xlfz9N5w475k/B6/yFcy+7XXu2bKabrzxPsxYs0SX/elDT33pAGel15Nx9dR43CPW5acxfdepxR3oOXieCnYAu+Zx1yiD3zu3U2Yt06Q0TtFer5ure6SB16rCfBvbt6t5Ndj6hwtXLcRK8kV9vzEQAgdgWIHhj+/xydAjUWIGywescxMXXP6DcXfkaktmjXPBedN0D+u7HXzXyjCE6cP+93Wi96Lr73TCtLHjf+2iObrn/Oc2Y+KBuuPNpJSQk6LbrznetHnnmbffxgg9e/OORBy+Ioe7w/rRijbZu31k6vWmj+mrZoon7339dvd59/GLJtz9pzsKl7hf0Xn38Jveucqhw9XKcBK+XM8UYBBCojQIEb2086xwzAjVAoGLw/vDLav3l3Ot17MBemv/FN+5ryZxHDQ7NPE93jb1QR/fvXnpUzhe4Tjr6iEqDN3dXnvqdPFpXjDpddzz0kh6/8wp17XiAO3/KzC80+oYJevfZW7XvXnuUk3Ke701IiA+pd9mND7mx7dw1Nn2cL60lJvzxfO+336/QKSNv0Dv/Ha/99mnlPj5x7UXDddygXu6mvB5nxXmm/eDPEUAAgdoiQPDWljPNcSJQwwQqBq+z+2PvfNp9hrdp4/ql7+E9fsS1at6skf42bIi2bt+hj6Yv1ORpCzRm1OmVBq+zrXH3POO+JcH5QljZu7lOjJ5+wTj30QjnC2ht9mzhvgHCWXfE0KPU7bADQ0o+/N+Jeu29T3XfuH+6f+48ruBsO9THuVt98IH7ul9KS01J1puTpuuNSdM19fX73P9+zujblBAfr6v+eYY2ZG1xnxv2cpyh5tWw087uIoAAAlYECF4rrGwUAQT8CoQK3nUbsnXM8KtUv17d0uD95v9+1o13P6PlP610v9h21ikD9crbU3XykL5VBq/zKMGwUePcqD1/+HHldtd5Ldn9T76habMXafOWbWrWpKF6dG6v0SNPqTRinTlXj39Mn335ndJSU/TkPVeWviWiosW7H83WSxOn6Odf17p3bw8+cB9dccFpat+ujTvUOabrb39SziMRLZo1dt8o4eU4Q83zex6YjwACCMSCAMEbC2eRY0AAAQQQQAABBBCoVIDg5eJAAAEEEEAAAQQQiGkBgjemTy8HhwACCCCAAAIIIEDwcg0ggAACCCCAAAIIxLQAwRvTp5eDQwABBBBAAAEEECB4uQYQQAABBBBAAAEEYlqA4I3p08vBIYAAAggggAACCBC8XAMIIIAAAggggAACMS1A8Mb06eXgEEAAAQQQQAABBAhergEEEEAAAQQQQACBmBYgeGP69HJwCCCAAAIIIIAAAgQv1wACCCCAAAIIIIBATAsQvDF9ejk4BBBAAAEEEEAAAYKXawABBBBAAAEEEEAgpgUI3pg+vRwcAggggAACCCCAAMHLNYAAAggggAACCCAQ0wIEb0yfXg4OAQQQQAABBBBAgODlGkAAAQQQQAABBBCIaQGCN6ZPLweHAAIIIIAAAgggQPByDSCAAAIIIIAAAgjEtADBG9Onl4NDAAEEEEAAAQQQIHi5BhBAAAEEEEAAAQRiWoDgjenTy8EhgAACCCCAAAIIELxcAwgggAACCCCAAAIxLUDwxvTp5eAQQAABBBBAAAEECF6uAQQQQAABBBBAAIGYFiB4Y/r0cnAIIIAAAggggAACBC/XAAIIIIAAAggggEBMCxC8MX16OTgEEEAAAQQQQAABgpdrAAEEEEAAAQQQQCCmBQjemD69HBwCCCCAAAIIIIAAwcs1gAACCCCAAAIIIBDTAgRvTJ9eDg4BBBBAAAEEEECA4OUaQAABBBBAAAEEEIhpAYI3pk8vB4cAAggggAACCCBA8HINIIAAAggggAACCMS0AMEb06eXg0MAAQQQQAABBBAgeLkGEEAAAQQQQAABBGJagOCN6dPLwSGAAAIIIIAAAggQvFwDCCCAAAIIIIAAAjEt8P/HAwUgHIhnAAAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sig_colors = [\n",
+    "    \"#2ecc71\" if sig else \"#95a5a6\" for sig in eval_summary[\"significant_fdr05\"].to_list()\n",
+    "]\n",
+    "\n",
+    "fig_tstat = go.Figure()\n",
+    "fig_tstat.add_trace(\n",
+    "    go.Scatter(\n",
+    "        x=eval_summary[\"naive_tstat\"].to_list(),\n",
+    "        y=eval_summary[\"hac_tstat\"].to_list(),\n",
+    "        mode=\"markers\",\n",
+    "        marker=dict(color=sig_colors, size=8),\n",
+    "        text=eval_summary[\"feature\"].to_list(),\n",
+    "        hovertemplate=\"%{text}<br>Naive t: %{x:.2f}<br>HAC t: %{y:.2f}<extra></extra>\",\n",
+    "    )\n",
+    ")\n",
+    "naive_tstat_min = as_float(eval_summary[\"naive_tstat\"].min())\n",
+    "naive_tstat_max = as_float(eval_summary[\"naive_tstat\"].max())\n",
+    "hac_tstat_min = as_float(eval_summary[\"hac_tstat\"].min())\n",
+    "hac_tstat_max = as_float(eval_summary[\"hac_tstat\"].max())\n",
+    "assert naive_tstat_min is not None and naive_tstat_max is not None\n",
+    "assert hac_tstat_min is not None and hac_tstat_max is not None\n",
+    "t_range = [\n",
+    "    min(naive_tstat_min, hac_tstat_min) - 0.5,\n",
+    "    max(naive_tstat_max, hac_tstat_max) + 0.5,\n",
+    "]\n",
+    "fig_tstat.add_trace(\n",
+    "    go.Scatter(\n",
+    "        x=t_range,\n",
+    "        y=t_range,\n",
+    "        mode=\"lines\",\n",
+    "        line=dict(dash=\"dash\", color=\"gray\"),\n",
+    "        showlegend=False,\n",
+    "    )\n",
+    ")\n",
+    "fig_tstat.update_layout(\n",
+    "    title=\"Naive vs HAC-Adjusted t-Statistics\",\n",
+    "    xaxis_title=\"Naive t-stat\",\n",
+    "    yaxis_title=\"HAC t-stat\",\n",
+    "    height=500,\n",
+    ")\n",
+    "fig_tstat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7789a1d4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003467,
+     "end_time": "2026-03-24T02:23:44.222282+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:44.218815+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Feature Correlation Heatmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "3397ee24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:52.772138Z",
+     "iopub.status.busy": "2026-04-09T01:07:52.771948Z",
+     "iopub.status.idle": "2026-04-09T01:07:59.647694Z",
+     "shell.execute_reply": "2026-04-09T01:07:59.647259Z"
+    },
+    "papermill": {
+     "duration": 5.713428,
+     "end_time": "2026-03-24T02:23:49.939152+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:44.225724+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorscale": [
+          [
+           0.0,
+           "rgb(5,48,97)"
+          ],
+          [
+           0.1,
+           "rgb(33,102,172)"
+          ],
+          [
+           0.2,
+           "rgb(67,147,195)"
+          ],
+          [
+           0.3,
+           "rgb(146,197,222)"
+          ],
+          [
+           0.4,
+           "rgb(209,229,240)"
+          ],
+          [
+           0.5,
+           "rgb(247,247,247)"
+          ],
+          [
+           0.6,
+           "rgb(253,219,199)"
+          ],
+          [
+           0.7,
+           "rgb(244,165,130)"
+          ],
+          [
+           0.8,
+           "rgb(214,96,77)"
+          ],
+          [
+           0.9,
+           "rgb(178,24,43)"
+          ],
+          [
+           1.0,
+           "rgb(103,0,31)"
+          ]
+         ],
+         "type": "heatmap",
+         "x": [
+          "ret_5d",
+          "ret_10d",
+          "ret_21d",
+          "ret_42d",
+          "ret_63d",
+          "ret_126d",
+          "ret_189d",
+          "ret_252d",
+          "skip_recent_12_1",
+          "skip_recent_6_1",
+          "vol_21d",
+          "vol_63d",
+          "vol_126d",
+          "vol_252d",
+          "sharpe_5d",
+          "sharpe_10d",
+          "sharpe_21d",
+          "sharpe_42d",
+          "sharpe_63d",
+          "sharpe_126d",
+          "sharpe_189d",
+          "sharpe_252d",
+          "mom_accel_short",
+          "mom_accel_medium",
+          "mom_accel_long",
+          "vol_ratio_short",
+          "vol_ratio_medium",
+          "rsi_7",
+          "rsi_14",
+          "macd_line",
+          "adx_14",
+          "cci_14",
+          "cci_21",
+          "stoch_k",
+          "aroon_diff",
+          "sma_ratio_50",
+          "sma_ratio_200",
+          "ema_ratio_26",
+          "bb_pctb_20",
+          "natr_14",
+          "chop_14",
+          "hurst_100",
+          "max_dd_63d",
+          "max_dd_126d",
+          "vol_ratio_21d",
+          "vol_ratio_63d",
+          "obv_zscore_63d",
+          "pct_positive_63d",
+          "dist_52w_high",
+          "dist_52w_low",
+          "corr_spy_tlt_63d",
+          "ret_126d_rank",
+          "sharpe_126d_rank",
+          "vol_63d_rank",
+          "regime",
+          "yield_curve_slope",
+          "yield_curve_zscore"
+         ],
+         "y": [
+          "ret_5d",
+          "ret_10d",
+          "ret_21d",
+          "ret_42d",
+          "ret_63d",
+          "ret_126d",
+          "ret_189d",
+          "ret_252d",
+          "skip_recent_12_1",
+          "skip_recent_6_1",
+          "vol_21d",
+          "vol_63d",
+          "vol_126d",
+          "vol_252d",
+          "sharpe_5d",
+          "sharpe_10d",
+          "sharpe_21d",
+          "sharpe_42d",
+          "sharpe_63d",
+          "sharpe_126d",
+          "sharpe_189d",
+          "sharpe_252d",
+          "mom_accel_short",
+          "mom_accel_medium",
+          "mom_accel_long",
+          "vol_ratio_short",
+          "vol_ratio_medium",
+          "rsi_7",
+          "rsi_14",
+          "macd_line",
+          "adx_14",
+          "cci_14",
+          "cci_21",
+          "stoch_k",
+          "aroon_diff",
+          "sma_ratio_50",
+          "sma_ratio_200",
+          "ema_ratio_26",
+          "bb_pctb_20",
+          "natr_14",
+          "chop_14",
+          "hurst_100",
+          "max_dd_63d",
+          "max_dd_126d",
+          "vol_ratio_21d",
+          "vol_ratio_63d",
+          "obv_zscore_63d",
+          "pct_positive_63d",
+          "dist_52w_high",
+          "dist_52w_low",
+          "corr_spy_tlt_63d",
+          "ret_126d_rank",
+          "sharpe_126d_rank",
+          "vol_63d_rank",
+          "regime",
+          "yield_curve_slope",
+          "yield_curve_zscore"
+         ],
+         "z": {
+          "bdata": "AAAAAAAA8D/dAcMUOxDkP7RAxSADB9s/eBBnsgYF0z+jjF6un9DOPxA7uS2Shsc/VQCOKXHDwj9NXTkEwiLAP4OL0KGKJZU/ico7tEUrmT9Y26JYl2qeP9Qv1YdyFKY/os62Pvfppz/t0JPkfHipP9VFjebzVe0/2S814n144z8B+bMsvTraP1aAI+tSQNI/Y8G9BnxEzT9fvAhzGqXFP/bd4KDJnMA/YaeMxGOHuz+kGmz2hqV3P6FRyntK4qC/EPYhkEVPir8Qv7VYTdeavxh4IlKCvX6/y+GNd6uJ6D9p+qlsnMnjP5jsgKw77NA/U/N7J8y2bT8y5uecTwTpP/5GUWOoeeY/btsSmiSa5z/BuidrsY/NP0C2BCHwSd0/UccThgP0zT9MoX0Cy1nlP6a3t0qJCec/5Avf51HKd7+xqMkYLnuzv0CTJJ00AJM/63S+mjKL2D862zYdRy3TP5bE/2z7PsC/HZPe4o3mvb9/gU8ZFHXWPxuc/rj47MY/etRT6CkRzj8LJ+H7TzXMP7JL3/MNuWq/BR9FO3CXwT/9zPdbr9e9P8mnl2ae7Z8/VcR737u4ez/NhB8qTapiv+1Ikk6Dyp4/3QHDFDsQ5D8AAAAAAADwPy7CNDbcK+Q/hJrVtrbX2j+Gyxyih2DVP+NwH62CBs8/NARCV/dDyT8MMO+wlETFP4Plf6zVT4k/n8SW62JJhz9NP4yvadyKP22wAkqLk6s/VIAEOHZWsD+j3cRBXCyyP4ocaW4MSeM/+AhTZX1w7T9Lm7tR3DfjP/o3Z3A9ptk/tYIp6ll11D//wj1X+unMP36vdOpmnMY/Qj1kvcNDwj+xjW172PqVP/HuNLJrrqC/S9HaMcvRjb97Nn3oX+a3v90CN5SE9pa//e5VGRDI6T9a0V1ltCToPzcrb9IabOA/TfWJqcD8ZT8UYfUv2/HpP3p2rlpS5ek/PljVTvvt6T9QbZl1ZN3bP05ra8yELuQ/KDvy40lb1D8sL2fnyxLqPxPlO4yFLuo/Y2aACERfn7+TyGjEKXq+v86wDk1lt5g/k2mHbJk23j+J6j2OP9PXPyxrk/Yuvb+/chYygVZywb+upCB406zdP6NchnWONs8/8lAOIePK0j/X8D8flNLSP7tg4U/4BZC/N++y9gU0yD9KYj7G6/TEPwKL7tWlNaM/C6ty5NiWdj85Yf2S7EYvv6mL+I9m7KI/tEDFIAMH2z8uwjQ23CvkPwAAAAAAAPA/gh1Ne0+05D+I0F5KGsXgPwJXD1bLbNc/YItKy0+E0z/nWJox7I/PPxazgcwYvYk/prgVojcujz90VXOVA7O2v+qrxFSK75Y/ORe1mHDwqj+CBNfQJvyzP2PQ4AACY9o/KfI3i32m4z9CiObuhX7tPyR5x6fSjOM/50j3Dh623z/8pJ4UTO7VP2/eabG4pNE/5D/b9mOsyz+VWjm1/Lp6PxO8LXdhpKC/2dDlbWptkb/hONofoHDTv+4/mSjRorm/uqOBGtT05T8PW5j4st3pPy3DEWmt3uk/xnH04VmZTL8XMsqrI43iP69bZOIQe+c/fA9D4Oww4z+JY8GuR1zoP3gqqWXuXes/ymXFC8Fx3j/I9c/stJTrP+imfdbzzuY/TP1EgAirub+0fm67/wq0v1+zczxWlaA/RgLMss3v4j+UIvEj2x3fP7Au+PAr1rC/mJ5qU0Fnwr9ojG/24qTiPxJQKI2hhNc/bWkcQKMB2T+x8kP0XHXaP1W+aT4a74i/AVdgd0Bb0T/G/iXqqkjOP85gTvgtV5o/UmWtM58skj8HCqZp8qp7P33EkHA8jLM/eBBnsgYF0z+EmtW2ttfaP4IdTXtPtOQ/AAAAAAAA8D+3MNb0cKvoP0TLuwVhpuA/fFXM+Pa+2z984DyYbrjWP2PYCNenN8k/cUyNUVi40j+x1eFrtr/Cv61+pUcjxJ+/S98Erd+Fmz89dCyqPDKzPzd9/sIeM9M/YzGgij4Z2z8xEVcAnQLkP88j/044Ye0/X5df/Xnf5j/yn1bGJv/ePzpXb6HLR9k/fWSaB9ke1D9Ah4Rx+kjdv/Vg9aIPZJq/3UUumMpRob+hTr8t+bXUv9+JzMQquMq/n9VoOVm+3z9pcVeHKfjlPyUDKX4IEuk/Gq6TAB12oD+6b/3UGGHZP7otXRXZu98/y44myZ+Q2j8ZMBIECRbjP/8Iz8AQguw//x3CzFwQ5T/VaoONElzmP2NC4jT2/t4/9L8C79i5wr8sJ4PgW3t9vzsgjG3oQ34/LC7V7Kct5T+QhzTK05DiPwfX3lRNloW/4gB6IJoFuL+QiUPXn7njP7nCLNEJ2+A/f6YlQH6U3j8Hp0gAsvHgPxRssY9ypHE/ex5eMIaS2D92yv4jAsPVP8dMUU/UhpA/rGgFvQ08qT/1gMmaXjySP5dLyzSowLo/o4xerp/Qzj+Gyxyih2DVP4jQXkoaxeA/tzDW9HCr6D8AAAAAAADwP9qYKPfw3uQ/woAbXaMY4T+bvBG1mCTcPzHSo0FM/NM/IL7/ZcyQ3j8VO2PVk47Cv47i60WypLW/3KmIS9REfT9R+YZ/pW6yP+T+N7L6NNA/P6cMmPV61j+vmRv24obgP8rerIjuVuc/C1j0ToYU7T/bupWUACvjP2pDVgkV5t4/gj8fdVXh2D+zLbOyNxrpv16d20M6g5q/K87t3o5Fo7+MQiYeBuDIv+gmGyDmrtW/oZ8npgyp2j+z8Wdki77iP+2BRoEeUuU/pX6K54F4oj8ZC8bIh2LVP/31ZQEhRdo/cK45wtph1j/8R7m6z+3eP8pdMwvRBec/o0tPtu3I6D/FkRtO5qPiP97rjZlOw9k/avHkmJ9vw78Gsk1Yon1uPy3EUFpY/pC/17wtex0/5D/RoMqeqsnjP7/tkS7PyoW/3NSnTr0cqL8uRhximt3hP1vywqTWzOU/GHn2ZOq24D9CjKcJ3VzjP2LBoketsqE/XKRnDd+E3j9OaeOEmcDaP2knCq4J+Y0/b0T2I7qRsz/a+WomQ/KfPyMlihucgsE/EDu5LZKGxz/jcB+tggbPPwJXD1bLbNc/RMu7BWGm4D/amCj38N7kPwAAAAAAAPA/L2sz4u3/6D9gAGeTfhnlPwM+H1D6gOI/4MEAt1Ds7D+SXgNTvz3Fv2CZltbH2cS/SY3pVw2tvL91Uo7ureN8P4FtU4Rplck/tA5iBNLx0D9BGPgovrPXP1ANmfADOOA/jVv5WBL+4z/LWhkV2M7sP4ERQ54ihOY/Psdwae3y4j/6Mb+vmYDgv88H2sSfa+a/5fSeDirMrb+/SUR1XHGqvznWHzDCxcq/DByxsebY0z/Po7QefUHbP3x6CHPRKt4/MEKK8dFSgT9UdCnwngbQPwGl0binbdM/UL9hFoJR0T/NgteXuQTWP8HccVEaZN8/Ql7ITydm7T/k95lnLHLaP1wLxFR68tI/dmBpBVF2xr/ki1bkDA+BP8nGIhNZVa6/mgB/7O4N3z/qNZvqYCTkP6IaVM4ZaoS/A1v4uioAkL9/84zojnXZPxJ94+obw+E/scgY2o5k4z8nB3ANLUTmPyRlheODX70/SVMGyU4G5z/X4B5H0b3jP7mkSXjiv3U/IJ5S4zxguT9aw7DYo+auPxt+SnMKt8k/VQCOKXHDwj80BEJX90PJP2CLSstPhNM/fFXM+Pa+2z/CgBtdoxjhPy9rM+Lt/+g/AAAAAAAA8D+hIqNl2b3qP/oWJDSyseg/tGeYM5+f5j+4qZSEIlDGv16oiDwuesa/YpCmXL7jxL8j8UVpRv6tv1MoLqSfasU/2eXIGjbGzD8pDO6CuV7UP/piHhDEqNs/02M4wka44D9KmSRrk2fnP9Bd4FW8rOw/p4PggeL15z+cTHOx8g3bv4pOpD1KeuG/vHE+qZVn27+Df/DnG9ekv9RulsN17ba/feNKhgYF0T9rwbQDgDXXP3CuWC0f3tk/VJN6xJubZr/0G+5vzeLKPxU84oNxYdA/feHjNAK+zj9HAsgH4QTTP7Nx7UiTHdo/e2ABUMXA6z9z1AFbIurVP76SA3+7E9A/lEewUSEtx7+Qaf/gc6ltP/8POOWf35y/xmwhLTdI2z9crlLj4HPhP29IBuxpQIe/0W+ffXVWjb8B1ymEegjVPzrvQVCgRuA/nmtjbgds5D8/iyeDSUPmPwlk0JV6jrg/OXtfAf574j+f+++ZZWXgP+cst9E3GH0/Mpkmi+lUtz+832hxbQK0P0lA46THYcY/TV05BMIiwD8MMO+wlETFP+dYmjHsj88/fOA8mG641j+bvBG1mCTcP2AAZ5N+GeU/oSKjZdm96j8AAAAAAADwP+3gfQ8Ol+4/hEOfUztJ4z86RngXB2nFv2tAVAe9Vca/CYlARVngxb/SSMe8am+9v2DRCLY268I/j4qd85AZyT8g0TV4MTDRP9K21X/2V9c/Cg4EUz8+3D9xB95+kxHkP+vrQUBDmOg/YboROghx7D+uO3a4ic7Wv66iY7izXN6/t470gwkI579mPSMj87CTvzn8PtmHZKm/NuKGJKT3zD/ah6bosofTP+bmar0KsdU/v5DHe3y5b79mRzrYKzTHP/+SlSNAxcs/IJuV9Pnxyj+AL3bBLtTPPw7wLPZUK9U/D0NjnSRa5z+bTKI8zerRP+FmbZZEQMs/K7875J/Wxb9yvoPzEHhFP5KiEMvV2oy/j207yhUi1z+AIVg6mbzdP4Pe9fOwaDg/hjrfrE3fcz+JCB+LDiPRP60UPtFiY90/KheUu02l4z+6SKetEibkP5XPdXOC9bQ/g1YXmc+Z4D/3FdnoCNndPwxKYwTRZnI/eOY+Pj6DuT9NEGH0ER25P3k3gQj2tsI/g4vQoYollT+D5X+s1U+JPxazgcwYvYk/Y9gI16c3yT8x0qNBTPzTPwM+H1D6gOI/+hYkNLKx6D/t4H0PDpfuPwAAAAAAAPA/WAOnhb8H5D+QJLRhhr3Avzhs+xqsscW/QqQZ/b1hxr9wT0je+gjAv5/KUry0Cac/JPYWlCZopj8jcudcB76mP1+gwC1ogcs/mmX9U9mD1D/8yuhRQ6LhP0Qhjpt60eY/tYxASmRW6z/3q3kMJ7jXv3r3GbImPN+/bt/785Tj578SQthVkXKxP+hJ6ZiN1JS/FJH2P7UFrT+kPyMtR5y7P2aKuzZ0k8I/76cch+x1hz8Je5pq8uujP6023qEPiKU/4rXpKv49sD+BrQCqhtywP0wEe1BVQ8A/awJQ4s/E4z8Up4ptn/WyP+tGf4cfTaU/fsa1FAGXwL+hFvC0+4SJP9Em0GcuxpK/ooqPt7QFyz/YJkJ8wQTWP6klNYfHdpY/jvfhAEBfqj9TwV4rsDe/P6t22VjbL9g/DIsVLVGE4D8GABFDWHHhP5k5gcQHiLY/NIuuUYey3T+Gz6X+nePaPyBgOUizdoQ/kKM1nz/iuD+YJ50h7Yq5P/HL6eFwHsE/ico7tEUrmT+fxJbrYkmHP6a4FaI3Lo8/cUyNUVi40j8gvv9lzJDeP+DBALdQ7Ow/tGeYM5+f5j+EQ59TO0njP1gDp4W/B+Q/AAAAAAAA8D/okzGgVwy+v5c45+MDpsS/FAo7D+u4vr8/qC7XhXtkv5tWVVJ6Gqc/o9tLpTCBoj/LuAZfDOafP+1qOD3WkNI/65v2sJaK3T/E1WBgeUHqPz3kPLRwYeQ/At9g2ZVJ4T8Dx+oUtyjiv7AlgKHFVOi/0AB7OhHbq7/dZCpTOlqzPwqEmQ07fMa/p1N5qkDxqz92AeJtU7XAPwyvxVVAscc/hvLuX1y4kz9xVrEezKmiP88yjjJ5kaQ/NuyHdhp5qT846DjeQYSxPzolcFpLOsg/oX8aYVyr6D/boFuTNGK7P5rpykrvlaM/rmTCZ80Zv7+M2ViRBLugPzfGf/rHz7K/xY4QhScF0T8rllvJohrdPxDSp51n7JI/J0w87njTqD9JsQU4LsPHP80hlPGf6dw/EkzBUNhs3j/vcpnFZPziP9fGdwiJ4b0/HodOsgTt5D8tPsh/8S7iPxmOeKLB6og/SGMbM48ZuT/N0CU/pS2wPyI0Bpzgxcg/WNuiWJdqnj9NP4yvadyKP3RVc5UDs7a/sdXha7a/wr8VO2PVk47Cv5JeA1O/PcW/uKmUhCJQxr86RngXB2nFv5AktGGGvcC/6JMxoFcMvr8AAAAAAADwP+Oafb6vfO0/qjnHeArI6z8MmUAWThvqP0fZQMfExa+/dLcIFt75vL9BErmrQODNvwkP3uS1dtO/cceximCK1L8y/d5k+b3Wv0t8l0nS8de/FE6Zh/VH2L9CPyQXqna1P3CJ6vHmHaU/S/nF7CekmD8l3RIb733SPwlZuzursM4/8MqzyA4lwr+WQ2rMbNDNv1WyjK9tzca/WpAcdAI+ob9HOHtEuYS4v9VsNzagocG/zhGTSO7kt7/W3oSicjbOv/s+6qT3O7+/9a66yVmyyL9KVPeZrY+rv2MjVmT5JsG/81h2boTH7j84OtIRKyGVv1vdM8jsqaE/QPwNm01j4792EsFVZVzkvy+PemzjKJC/eg5d5BAgqz/0owrWgGPMv+jHOswzJce/FXyCmJP55L8WsdMBF53QPzCaBMoN1a6/F/Q+cx6xqr77UOoS/CDIvxf08QpySOg/DXXjBIgnZD9LJ1n2X2ikPwkmVogfJ6U/1C/Vh3IUpj9tsAJKi5OrP+qrxFSK75Y/rX6lRyPEn7+O4utFsqS1v2CZltbH2cS/XqiIPC56xr9rQFQHvVXGvzhs+xqsscW/lzjn4wOmxL/jmn2+r3ztPwAAAAAAAPA/pJC9UV1m7j8z2GcjxF3sP4zyu5Ui6ae/Ov3NdWNIsb+6VbppaUq9v3ZxeAfqQ8m/JOZb1Ez30b/inU4mElnXv1E8b18cvNi/83vhXGaH2b/M5eoY54e3PyxyTT7dz7U/hAfe3xZDnz82vRCRsnaovyNfMhIeR84/iB/2h/zGtb93oXHC7wzCv11qCkkDUK+/BTZa9uMQtr/lRMgFYiWtvyS+ig0XF7O/tWAQqNlVrr+jBsnKGhW8v2g760K3G06/WjLmYVzjxL8ob9alYb+gP2A5fiqKSbO/WTrnywM07j+pm3+eu+1qPy9BwEPcfKM/f7Y7J+gP4b8O92qFhzTjv0NMrl4WXWy/kWwFQSbRkr+Y5m459nrDv7WCgBIRzsO/7jhzQpp95L9y9FBfUbzTP72iftSANrW/ARC885nJcr8TcJVueb/Jv/7kFQj5n+k/a2PyJcBTbz/AEpoP8BmmP5zcAvsOka0/os62Pvfppz9UgAQ4dlawPzkXtZhw8Ko/S98Erd+Fmz/cqYhL1ER9P0mN6VcNrby/YpCmXL7jxL8JiUBFWeDFv0KkGf29Yca/FAo7D+u4vr+qOcd4CsjrP6SQvVFdZu4/AAAAAAAA8D9wmNChLzDuP8ZXdQUT6aO/cU09k2N8qr9fRlKUoZe0v4eZb9/gM8G/ejINGgyWx78QfF7FXSPVv/umU747ydi/attsrTYL2r/vic1cdbxkP6IlhHpyU7k/fdMfiF3+sT88qwAm0jyzv5hv+aQIO5q/af6RlySBsL+pnf7nu+q5v5b7Qmg/KIa/Z6Usrq4Ju78y6Dw0coClv6V2g7r4iKq/hoXwhmQ4qL8quU0e/0m0vzSXNiPCoac/j86qzbL3ur8IexvYn2OwP+lsdChgc6u/f/OhOLfM7D8u3tHSvSWVP5TdgEhZqnG/FzxxP2ID3r8+xk4q5EPhv5d/nHn972M/LH8rnmSQk79NsAzq+6+8v0yfBtXaL7u/QLO+ju9K478MGAPPeIDXP2+P3VHaBbK/9lUxvKTPPz8N/QugXBLKv6rAwhItI+k/HIf6pJ0FmT/eddIyfcypP8/K0hcpfLU/7dCT5Hx4qT+j3cRBXCyyP4IE19Am/LM/PXQsqjwysz9R+YZ/pW6yP3VSju6t43w/I/FFaUb+rb/SSMe8am+9v3BPSN76CMC/P6gu14V7ZL8MmUAWThvqPzPYZyPEXew/cJjQoS8w7j8AAAAAAADwP2td20z1Q6C/fLnlUBCupL/nevaHvsKrv50gvBL9+7W/2QAAiwsMvr+nSXtKLtXKv0qzaiuq2NK/begO0tTV179/0BLJ1uSrvz9DcZGNWWq/6rwRBXvOuz8DxMKxa9ixv1OcCb2eE7S/ZRac0yPXp78FA07TpHixv0V4mg4T0Jc/HHNGMdNlvL8flWdu5Yafv/riQMnheKG/cWUUObusob8MG7SRR5qrv+MNNjLVA7Y/vm3YdiwpdD/Pedu3LWa3PwinF4A9CaO/i0Lc8pk36z9QZMn21h6cP98lLiBAV6K/zkXswmYP2r+TfJhB2CHdvxZCHv6er34/cdEyAN1qgr8sy765nnWzv9UKGaKGBbC/aBnPennX4L/iwH8s03jePwHQ38R+M7C/whJVibyUlz+9zKHfwPbFv8lmg5TNk+g/ljwsiUD0tD9PHSo16gS3P7efd2qrUsE/1UWN5vNV7T+KHGluDEnjP2PQ4AACY9o/N33+wh4z0z/k/jey+jTQP4FtU4Rplck/UygupJ9qxT9g0Qi2NuvCP5/KUry0Cac/m1ZVUnoapz9H2UDHxMWvv4zyu5Ui6ae/xld1BRPpo79rXdtM9UOgvwAAAAAAAPA/ie8f/XZd5T/8rZRbgGPdP1CSrlTSqtU/amO+8lV20j8tcBmjZkvNPy6KI+cTqcg/lZuVqg7yxT/57DPX1yyNv4oabdyn0KS/sGUEu6fBmL8atYG2seOkvzfv0GCclZy/NJ7LN2m66j/LSN0tuNblP1jdSava89E/Hzb0j4Zenz+NKfzjeIDqP9Jl0n5b/ec/KG+STD1S6T89WEjOX5nRP3fic+1n4tw/lZXAJxEl0D+L0x7hDY7kPyWVMHkMoug/V9vAUBntuL9Lf6F9jfm7v5+65MknrXc/7jFoBt9V3T8S9nY1K1nYPw81Bl9+6r+/U+EUHYg9vr/Lu1PJarPaP25vZfl7zs4/PRpirRWC1D8cjORu95vHPzTvEpDc6oK/c4HBFvK+wT/qJCWbZgzFP+NIUkHbCai//doH7PKedT8tcO6TFhtmv1uRwN/3G5s/2S814n144z/4CFNlfXDtPynyN4t9puM/YzGgij4Z2z8/pwyY9XrWP7QOYgTS8dA/2eXIGjbGzD+Pip3zkBnJPyT2FpQmaKY/o9tLpTCBoj90twgW3vm8vzr9zXVjSLG/cU09k2N8qr98ueVQEK6kv4nvH/12XeU/AAAAAAAA8D/+5LK3UYDlP2Zg/r1TQt4/PsN4ZlKS2T84z1WL3XbTP5PpwNKAgdA/rS1MpCMOzT9/yuYhNHhkv7bvEO+UtKS/zk0XVW/Hn79iIvoIyiu/vxadaPr2J6y/5zQjp/JW7D87npobM9bqPwHFq4oD+uA//Bo8PFikpz94C/1w2XfrP63a9Ls/qes/0zD4lpHN6z9j83AnEe3fP1wn4euJ2uM/b4pLgLH/1T/OVCi7SfroP4dWsvW7/us/bUm8zYmQw7/kToxx35jGv7jWIBfVQoo/Txwlatcv4j95dnJbCnjePzbfjWGn4L6/bMQJdV+4wb+nUZ/H5Q7hP0H58C/UJdQ/n0NFepDS2T+OYTrBg2XPP3RGMKVcT46/rAMrwbhGyD/GydiLW6nMPzhU2zbI6K+/UGcLj1p7Q78PLv5O4k99v9iegqEaypw/AfmzLL062j9Lm7tR3DfjP0KI5u6Ffu0/MRFXAJ0C5D+vmRv24obgP0EY+Ci+s9c/KQzugrle1D8g0TV4MTDRPyNy51wHvqY/y7gGXwzmnz9BErmrQODNv7pVumlpSr2/X0ZSlKGXtL/nevaHvsKrv/ytlFuAY90//uSyt1GA5T8AAAAAAADwP9XC2sMACuY/nz8TFBx94j+8SX2jyfraPx7w5NbcAtc/KWdlKD2h0z8L4NXkkVF0v1scE6nGQaK/G3BgCAYYor95KX+IhUXVvxetO/5vgr+/hZYrb9Aa6D/1XiQJoW7sP/a28AwuWuk/XyHkT1SKtD9hb9wm0jDkPzS4gcYJ9+g/l1frVJrf5D8zeTb9C37qPwzCFBA53uk/kI2QDILK3j/NZlH07NnpP0xnZ928Z+g/+0gF7TUazr9zQJ4x9vO4v2Ropd9lUJY/iaY8rWfb5T95Nlbpo9fiP2EhCUAHia6/z7GIk2Nxwb/Puypz25nkP+SsLsLSuNs/qOc+bgAk4D8+tj04xqrVP4OEL9039pW/1GRfKkPU0D+5XIEqWcbTPzfXHcF/7be/p2Mi0PdHhT/v7WmejWhYvybczYR0aa8/VoAj61JA0j/6N2dwPabZPyR5x6fSjOM/zyP/Tjhh7T/K3qyI7lbnP1ANmfADOOA/+mIeEMSo2z/SttV/9lfXP1+gwC1ogcs/7Wo4PdaQ0j8JD97ktXbTv3ZxeAfqQ8m/h5lv3+Azwb+dILwS/fu1v1CSrlTSqtU/ZmD+vVNC3j/VwtrDAArmPwAAAAAAAPA/LhMxzceu6T8T7YoHSUriP9x0Dv8PKt8/ohFBujpz2j9jnZevB1fcvxSZWDGTi5u/YNuGdN2Cp79i22kn4U3Uv9GJsGM9ec2/5KxFE+ij4T8z99THjjjoP17dim+HX+g/R6DioB/MvT+5hRCcVV7cP7nNircci+E/zFW3keZw3T9+dTwP+QPlPz3ayBBsbuo/4Vvr0RR25D+Bsm84rfvkPxBt+ZzzI+E/bLjukyFi0795HzMZOn2UvwXna79KQHa/PAV7bezS5z/Ka+Xto+7lP9o9eNH2m4a/ZGmciE0str8M4cEQBFrlP7s73X9aveI/qlECc0ck4z8mZcm9eHnbP5bX8xgPXI+/niEe3i4M1z8Aj6UXOzfbP+2Ss6F/AMG/wWWXAD+yoj+yyGW46QVnP5OKr44IpbQ/Y8G9BnxEzT+1ginqWXXUP+dI9w4ett8/X5df/Xnf5j8LWPROhhTtP41b+VgS/uM/02M4wka44D8KDgRTPz7cP5pl/VPZg9Q/65v2sJaK3T9xx7GKYIrUvyTmW9RM99G/ejINGgyWx7/ZAACLCwy+v2pjvvJVdtI/PsN4ZlKS2T+fPxMUHH3iPy4TMc3Hruk/AAAAAAAA8D9X2r9MkmXmP3HLaF8ivuI/9gyLG3Tb3z/5lRldN13nvz4YdeCOEaC/BOsoqwldp79J1ByTop/Fv/KpXBfh3ta/RSdgrAr83T9rCLuGkOXkP0N3+wih6OQ/E55Fc3qouz9wy4Jn6BnYPxHkbalidd0/FOn6kEgH2T/S9fD/GVPhP5aujetzceU/sHAqmYWQ5z9cJ2uPKXPhP9ljj62w5Nw/UpDJ7XAk1b/xhtaLpSF/vwXTja6b45+/Z8dwjCH+5j+7q9a2qknnP4Y02gQGVI+/jigbGQBzpr+nuTlZp2PjP5Gkh+BBcOc/Whlk3Kjm5D/7XAJW/MreP0iD8dHmLIg/gSsVGEEW3D/sfTyiSo7gPz3orb9BxcS/vQhjRGAKsD9AfaMaEteIP3BXDahpILo/X7wIcxqlxT//wj1X+unMP/yknhRM7tU/8p9Wxib/3j/bupWUACvjP8taGRXYzuw/Spkka5Nn5z9xB95+kxHkP/zK6FFDouE/xNVgYHlB6j8y/d5k+b3Wv+KdTiYSWde/EHxexV0j1b+nSXtKLtXKvy1wGaNmS80/OM9Vi9120z+8SX2jyfraPxPtigdJSuI/V9q/TJJl5j8AAAAAAADwP4d4T/fqEOo/V1xBRayQ5j+RVNhadSLev+8NHcaOyOS/r4Ro0K7srr/iO08tFqalv5GjyHZcnse/t/Y5ZtWd1j8hkAJf7OPeP7+fhgdgkN0/wsF9AVAZrT+uM3EuGkbSP1U504efA9Y/ibeLuglo0z9AsCKNzzTZP+N2s/l3Ot0/bVg9EhXU6j++dN8nK3bYPzU8o2gihNU/a1Ot4m6c1784n+gbF7Vuv/c6FURWjrC/e8YtYurW4j/6wD/5J0nnPxTxXE1FP4m/x/3P2NKmjr/5tK+c8r3cP3xqP3JP++I/KlPRdpth5z8WkU4lc1vhP6fRemiEybM/5xe/w2QQ5D+SRAzuSS3nP0jsh2D4rMi/PcaMx7sdtj/Ag8NPyUqkP6esWRku5sM/9t3goMmcwD9+r3TqZpzGP2/eabG4pNE/OldvoctH2T9qQ1YJFebeP4ERQ54ihOY/0F3gVbys7D/r60FAQ5joP0Qhjpt60eY/PeQ8tHBh5D9LfJdJ0vHXv1E8b18cvNi/+6ZTvjvJ2L9Ks2orqtjSvy6KI+cTqcg/k+nA0oCB0D8e8OTW3ALXP9x0Dv8PKt8/cctoXyK+4j+HeE/36hDqPwAAAAAAAPA/HlEsmteU6z9k5DK97lnYv3nqp/arTt+/XTU6wQsI2r9/3KDetkehv8Hofc1OxLG/Y0ToRKRJ0z9WMfSKUynaP3qSc1bFztg/UlFQmNGLpD/nI9vSV4rOP5Fqvdbtb9I/ISjMoLv90D/5f7CWwJDVP0nPBuvrotc/8alOUvTi6D/kYya6J5TTP5WPv8AZHNI/y6xBgTim2L9lmy7v3552vzALDNQNiqG/fUdMME8F4T+OFFx3OOPkP68xJxlT3Ye/BkCO11Lmh7+JSM0Tv+jXP5v07uzDOeE/g9oeOQEE6D8s5kU7DszgP/bxfyBeRLA/s19llJXk3z9Sl1LBDzDjP+/ppezyH8q/DF8krAIKtD8d4drKIdysP1nKzVhM3ME/YaeMxGOHuz9CPWS9w0PCP+Q/2/ZjrMs/fWSaB9ke1D+CPx91VeHYPz7HcGnt8uI/p4PggeL15z9huhE6CHHsP7WMQEpkVus/At9g2ZVJ4T8UTpmH9UfYv/N74Vxmh9m/attsrTYL2r9t6A7S1NXXv5WblaoO8sU/rS1MpCMOzT8pZ2UoPaHTP6IRQbo6c9o/9gyLG3Tb3z9XXEFFrJDmPx5RLJrXlOs/AAAAAAAA8D8xkNx4JeTTv21jm2sfCtu/Eat3zRQp5b9vpxnURF+Kv3gbWpE7S6K/JkrbmF2d0D/1bf6LrUXWP2ZZSIqhdNQ/tGNhSG3fpz973vAhRozKP2vAHlA+bs8/XgHFoUfyzT+MOcJxvDfSP5mFSxdwnNI/OmsnTIDR5D/fZmt0fPDOP2Leg6V7+84/zrUXJ8bK2L99AtY166iCv1cJvFztd5K/NBVLS9kz3j98loSrSJDiP5OOkHaFLUa/sIX4zr9Kej+8gg3cKt7TP0zdrrS06t4/FiRlOOL85j8G4BiHrmXcP9SbPfepTLA/KNyfCcZh3D/QIvSKD2vhPytoRijiAsy/2H38stogtD+DspwaTYuyP7WTEhTDcL0/pBps9oaldz+xjW172PqVP5VaObX8uno/QIeEcfpI3b+zLbOyNxrpv/oxv6+ZgOC/nExzsfIN27+uO3a4ic7Wv/ereQwnuNe/A8fqFLco4r9CPyQXqna1P8zl6hjnh7c/74nNXHW8ZD9/0BLJ1uSrv/nsM9fXLI2/f8rmITR4ZL8L4NXkkVF0v2Odl68HV9y/+ZUZXTdd57+RVNhadSLev2TkMr3uWdi/MZDceCXk078AAAAAAADwP8WyldHMNoA/aE8p2yc4pD96MQS2MQyTP2IYsT1f89Q/Pi1BTMERnr/jWftPbAvDvwaDTOJ9ANC/GXnpMkSvqL+VNOj0Akp+vxHKsjDeo4a/Vv9eDye8hL8Rsvf+OAazv2vvP6Ff19G/qCFwOhZv4r/91BgVWCzAvy7rVy8o9Ye/uFMXi5NPtT9kJGe5v9Krv7LM4HyPQaQ/TQdSFRcH1L9ZxRFXDlvYvzDklJtKbZ+/neV+4lC5pb/KzY/cqFDQv2+XjiF8G+K/OHyu/VSP1b91rq5bOufcvwwkuYlm06W/2LiFUzDd2L8g4GVInB7Wv7vMbq8fHIW/DKcetbDdsL/p9+lGeD2Yv4gLEin5+7y/oVHKe0rioL/x7jSya66gvxO8LXdhpKC/9WD1og9kmr9endtDOoOav88H2sSfa+a/ik6kPUp64b+uomO4s1zev3r3GbImPN+/sCWAocVU6L9wierx5h2lPyxyTT7dz7U/oiWEenJTuT8/Q3GRjVlqv4oabdyn0KS/tu8Q75S0pL9bHBOpxkGivxSZWDGTi5u/Phh14I4RoL/vDR3Gjsjkv3nqp/arTt+/bWObax8K27/FspXRzDaAPwAAAAAAAPA/XBSpgiugoz/p2ax2Rv25v8m+QvtCj5i/3KFZryk/pr+JNHmAJ/+nv+X25FFt+qa/jMJ7HR1hlj9IkFEfyQSjv3Wa2wWWfKS/PiJih14Rq7+VMHxiamqgv7KktvqQhJ6/QHp/Kwoa4L+qosyaRc+mv8iDKgRWD6O/vkQAtJH9pj/KY/T4/BVVv9sDOn1sL7E/eqvSkSVvsb/a0u7ZTdPOv+UZ0nPCf1g/O75cHlrqmL/rasfOCw6jv9yKJ3kxBsK/ArUMPuV00798shL9A6zav2O86BmoHrW/X6p7dw8c4L/+HMQMyI7cv6enIZc6A6O/S8fHhbfOs7+dlkb0LrOxvyXgeC3hWcS/EPYhkEVPir9L0doxy9GNv9nQ5W1qbZG/3UUumMpRob8rzu3ejkWjv+X0ng4qzK2/vHE+qZVn27+3jvSDCQjnv27f+/OU4+e/0AB7OhHbq79L+cXsJ6SYP4QH3t8WQ58/fdMfiF3+sT/qvBEFe867P7BlBLunwZi/zk0XVW/Hn78bcGAIBhiiv2DbhnTdgqe/BOsoqwldp7+vhGjQruyuv101OsELCNq/Eat3zRQp5b9oTynbJzikP1wUqYIroKM/AAAAAAAA8D9gMlDVdkpmv9gUKFhxaL2/HdrRNfK/oL/8N5nE3Lyiv7OfbB6V6Ki/LLk7+BU3kz+ZJBFt2C2Xv35sdqfKrJi/1WOJra8qqL8TqZHYu9mdv3lHSt6PZZu/uY+HZ0Rzyb/Ns3/2sWWYvyvPE6pNspq/CUcAFK2RkT/TsQ6pE8eCP4ULSuK79qe/ySXmU2jLo7/gm/vg7butv6Jo7iBFr4u/jhtvD0ADlb9B9PfA60uTvycjm2hj9cK/SKJbUs8gzr+jgyVlVaLRvz4ujDuf+5C/380Dg985uL8ZCHkejPS0vw1i8v57wqe/jbXp4aQLq78i+IRGu724v2wMZT+alae/EL+1WE3Xmr97Nn3oX+a3v+E42h+gcNO/oU6/Lfm11L+MQiYeBuDIv79JRHVccaq/g3/w5xvXpL9mPSMj87CTvxJC2FWRcrE/3WQqUzpasz8l3RIb733SPza9EJGydqi/PKsAJtI8s78DxMKxa9ixvxq1gbax46S/YiL6CMorv795KX+IhUXVv2LbaSfhTdS/SdQck6Kfxb/iO08tFqalv3/coN62R6G/b6cZ1ERfir96MQS2MQyTP+nZrHZG/bm/YDJQ1XZKZr8AAAAAAADwP5gYbqdSVLg/Az5yzbDzw78ZmARBFbDQv/WJT/JY7dS/k5JMZpl2xz8Xa4kNl9m5vzPu8lhpBsa/zf0ZJNWmt7+iKf8qynbWv8WEmYT/K9W/HzzzG+qpvb8dEI0Ip4LNvxMGBgmsl8S/6gOwGNJvwz/ZHdKvTpiyv2/M7v/QyXM/SpUECSTKz78kRugBWbPEv4ZvZvBLuqC/FNMXmK57yT890QC/aJHMv3OgJpdDFru/RoT2gMWsu7+EgnbRaljBvznrusMAGKI/cqP+8+CiXL+7b0fsPtpPP74MynZlsIK/STQao2bKeb/mxQmdOriQvwLsKKD7iqG/GHgiUoK9fr/dAjeUhPaWv+4/mSjRorm/34nMxCq4yr/oJhsg5q7VvznWHzDCxcq/1G6Ww3Xttr85/D7Zh2Spv+hJ6ZiN1JS/CoSZDTt8xr8JWbs7q7DOPyNfMhIeR84/mG/5pAg7mr9TnAm9nhO0vzfv0GCclZy/Fp1o+vYnrL8XrTv+b4K/v9GJsGM9ec2/8qlcF+He1r+Ro8h2XJ7Hv8Hofc1OxLG/eBtakTtLor9iGLE9X/PUP8m+QvtCj5i/2BQoWHFovb+YGG6nUlS4PwAAAAAAAPA/iaujXIr2s788lmptZP7Cv2CbtvxVm8W/ovKi4pbKtT/hmah+cOqrv+2goeu827S/3PiglXJzp79dgP3/tYq7vzfv6LPLbcW//faPdJPYzL/VddTRP/27vw7J85T5ZbS/xVDTL/0cyz8B75yubxWsv504g9mBGL8/5ZzALNoO0b9pYdZnbGPQv2APNhHlJJy/LY1pKZYkbr8J8tAe+pfEv+rDRnVHE8m/w56gsrvuxb+TrOkF7VPHv/HdchKiwLG/MD+idiVFlr+OvOeFBkCXv/5+XXU4arg/vKK+hWnvsL+koEZSuJ+lvzYrRvpTHa6/y+GNd6uJ6D/97lUZEMjpP7qjgRrU9OU/n9VoOVm+3z+hnyemDKnaPwwcsbHm2NM/feNKhgYF0T824oYkpPfMPxSR9j+1Ba0/p1N5qkDxqz/wyrPIDiXCv4gf9of8xrW/af6RlySBsL9lFpzTI9envzSeyzdpuuo/5zQjp/JW7D+Flitv0BroP+SsRRPoo+E/RSdgrAr83T+39jlm1Z3WP2NE6ESkSdM/JkrbmF2d0D8+LUFMwRGev9yhWa8pP6a/HdrRNfK/oL8DPnLNsPPDv4mro1yK9rO/AAAAAAAA8D8LbUK55t7tP4uASFog3OE/Ywzb4gUprT/4CVsdgP7tP3IHbqJQ/O0/LCLtfOYz7j8o/BjJYVThP6MJFyURZ+Y/N9aentG82T8IP8obh83rP1HQUQ9asO4/hHA652qaxr9b8ZPyY7rEv3Nu8FFpFZU/Mqe//S0f5T9BDeTSBcbhP4Oclx3kMr+/Cc5LbVm3wr/wcx5m+ALjPyieAugxZdc/wTReIFsR3j8GSHl5vT/SP0EyDqM1RJe/LKwtJX/Syz/OqeDKnlTQP3bShW0VHbO/YgTvsg0hiz/ACw5kO1xwP9M83/DobKg/afqpbJzJ4z9a0V1ltCToPw9bmPiy3ek/aXFXhyn45T+z8Wdki77iP8+jtB59Qds/a8G0A4A11z/ah6bosofTP6Q/Iy1HnLs/dgHibVO1wD+WQ2rMbNDNv3ehccLvDMK/qZ3+57vqub8FA07TpHixv8tI3S241uU/O56aGzPW6j/1XiQJoW7sPzP31MeOOOg/awi7hpDl5D8hkAJf7OPeP1Yx9IpTKdo/9W3+i61F1j/jWftPbAvDv4k0eYAn/6e//DeZxNy8or8ZmARBFbDQvzyWam1k/sK/C21Cuebe7T8AAAAAAADwP9DFe7wTVug/EOYNQeKJtz/HXoIav9DqP0D02VbmP+0/JzgxPjlM6z+XkG8t7y3nP4DfwNIbb+s/VpLu4/Fw4T++LKZ3dTTtP7lpkc3GWe0/mdwJV0tO0L/uRoaUpcXBv1bVRat4s44/drWY0WDy6D9QPFOvXLrlPzXDX88GPLa/dZ++i14Ewr9M0uIgxmHmP/DOqbRnOd8/1IgPwj+X4j/nFsn0l9TXP/dFSnA3LZS/Qy5d8bgz0z9LQqI1DYnWP9uj8I4DV7u/f/HeIF/Glj9ycesPU1BTPzinJUJ9g7A/mOyArDvs0D83K2/SGmzgPy3DEWmt3uk/JQMpfggS6T/tgUaBHlLlP3x6CHPRKt4/cK5YLR/e2T/m5mq9CrHVP2aKuzZ0k8I/DK/FVUCxxz9Vsoyvbc3Gv11qCkkDUK+/lvtCaD8ohr9FeJoOE9CXP1jdSava89E/AcWrigP64D/2tvAMLlrpP17dim+HX+g/Q3f7CKHo5D+/n4YHYJDdP3qSc1bFztg/ZllIiqF01D8Gg0zifQDQv+X25FFt+qa/s59sHpXoqL/1iU/yWO3Uv2CbtvxVm8W/i4BIWiDc4T/QxXu8E1boPwAAAAAAAPA/GeTBghTBfT8HY2ia3LzcPzWOw8jKlOM/5ERBX6ac3j9suG1s4mzoP7Jln7JaVuw/eVUZtpEo4z8c4kFBtkHoP9Yo4fMwu+I/0tTFYN1yx79+yxzxYnirv5VJpxNV5o8/GeFCx65B5T9uH4RGZJziP8V56XdmYJe/5hityg62vL/zgHMGXr/jP7wBLB26Ud8/0JrVTFi53z/2EG84txXeP7xEevtBap4/L0CjSYZf1j8xjeKaXzjVP+kLI6pyhZm/fzwvOir2gj/1uUC56ZOiv1udfrbYIrY/U/N7J8y2bT9N9YmpwPxlP8Zx9OFZmUy/Gq6TAB12oD+lforngXiiPzBCivHRUoE/VJN6xJubZr+/kMd7fLlvv++nHIfsdYc/hvLuX1y4kz9akBx0Aj6hvwU2WvbjELa/Z6Usrq4Ju78cc0Yx02W8vx829I+GXp8//Bo8PFikpz9fIeRPVIq0P0eg4qAfzL0/E55Fc3qouz/CwX0BUBmtP1JRUJjRi6Q/tGNhSG3fpz8ZeekyRK+ov4zCex0dYZY/LLk7+BU3kz+TkkxmmXbHP6LyouKWyrU/Ywzb4gUprT8Q5g1B4om3PxnkwYIUwX0/AAAAAAAA8D9HM3Jh6OqQP4u9yKaYVIY/SeoMEs89mD9UxoUGYyCwP5UzA/FPDpU/R6lt6YoHmT+2I2ntTYV7P4OOFwMBs48/gxhALYJ+mr/V/4ccjBfRvyQlTqtQ0Ko/aJ7AQO8joj+tIQi/SfS0P4eW0w/mN6A/JBGcDWetwT+xLvHHCvmrP5eh1xWMJrQ/BaJvESVvsz8dxzdlPBy1v6Hdc2EHP4e/JdXzybq2rz/jFkvRKfK+P/NIhkwKkby/EVfLnZk4lb9g0q0FJql8vwg3yN6PJpk/MubnnE8E6T8UYfUv2/HpPxcyyqsjjeI/um/91Bhh2T8ZC8bIh2LVP1R0KfCeBtA/9Bvub83iyj9mRzrYKzTHPwl7mmry66M/cVaxHsypoj9HOHtEuYS4v+VEyAViJa2/Mug8NHKApb8flWdu5Yafv40p/ON4gOo/eAv9cNl36z9hb9wm0jDkP7mFEJxVXtw/cMuCZ+gZ2D+uM3EuGkbSP+cj29JXis4/e97wIUaMyj+VNOj0Akp+v0iQUR/JBKO/mSQRbdgtl78Xa4kNl9m5v+GZqH5w6qu/+AlbHYD+7T/HXoIav9DqPwdjaJrcvNw/RzNyYejqkD8AAAAAAADwP0Z9fP8bCe4/x5lVUUPc7T/lNyFw9sfcPzlUgVtuGeM/XTYjEIHA1D+D9XU5r5rpPyusPnSoMu4/E4+XSvv5wL+fgXp046y4v0eGxjVaNI4/mt8SKbQ74j8JPv6dYRHePzQ21PZ/5b6/02SliSEJwb+dO3CffTLgPyYe7VlaodI/+xhgR/c02T+E44iRuhrOP3Ezbf2k7pe/wgJlRkgmxj9dj15KiOnJP4aiX/LVoKy/C4k4Q88tgT+xJsoAmGJwP7m7NA/br58//kZRY6h55j96dq5aUuXpP69bZOIQe+c/ui1dFdm73z/99WUBIUXaPwGl0binbdM/FTzig3Fh0D//kpUjQMXLP6023qEPiKU/zzKOMnmRpD/VbDc2oKHBvyS+ig0XF7O/pXaDuviIqr/64kDJ4Xihv9Jl0n5b/ec/rdr0uz+p6z80uIHGCffoP7nNircci+E/EeRtqWJ13T9VOdOHnwPWP5Fqvdbtb9I/a8AeUD5uzz8RyrIw3qOGv3Wa2wWWfKS/fmx2p8qsmL8z7vJYaQbGv+2goeu827S/cgduolD87T9A9NlW5j/tPzWOw8jKlOM/i73IpphUhj9GfXz/GwnuPwAAAAAAAPA/1WN+cZTU7D8+WdnEiI/jP5IMUCV02+Y/Ux8OZr0y2T9dGvzW1MvrP31g0yaFle8/zqTzPdK0xb+5SapNQ66+v7dMJb4BMYk/DK4EofGu5D8nnukXnjzhP+Y7TAsgSru/1Lq0l949wr/ylLrsuJLiPzst+xZsEtY/uczgt//93D+oYCKNoiXSP66crIl2+Jm//JRqPT7wyj+ydPKL/0rPPwjTtz52T7G/TgecNfwPgj+7Av8XjnxQP5fScI9Dr6M/btsSmiSa5z8+WNVO++3pP3wPQ+DsMOM/y44myZ+Q2j9wrjnC2mHWP1C/YRaCUdE/feHjNAK+zj8gm5X0+fHKP+K16Sr+PbA/NuyHdhp5qT/OEZNI7uS3v7VgEKjZVa6/hoXwhmQ4qL9xZRQ5u6yhvyhvkkw9Uuk/0zD4lpHN6z+XV+tUmt/kP8xVt5HmcN0/FOn6kEgH2T+Jt4u6CWjTPyEozKC7/dA/XgHFoUfyzT9W/14PJ7yEvz4iYodeEau/1WOJra8qqL/N/Rkk1aa3v9z4oJVyc6e/LCLtfOYz7j8nODE+OUzrP+REQV+mnN4/SeoMEs89mD/HmVVRQ9ztP9VjfnGU1Ow/AAAAAAAA8D9oXHnCdJHcP+M79NI9teM/wYdff2uA1j9KimSzE/TpP91jYuXPzu0/aA5epRqbwb8nP1GLYjzBvymp5EVUzJA/UGvchSUD4z/+B+uaM8PfP7W73hsaFcG/WL6UIJM2wr8P+8Sgb5XgP02op3vMNtQ/7uhgClsc2z8W3Mf6HqbQP5WkMZQJkqC/eaGzmnbwyD/T1JArNJLMP2XBzuh1jK6/ATSkgI1olT8aloFDeaOQP4eZYb4ynqE/wbona7GPzT9QbZl1ZN3bP4ljwa5HXOg/GTASBAkW4z/8R7m6z+3eP82C15e5BNY/RwLIB+EE0z+AL3bBLtTPP4GtAKqG3LA/OOg43kGEsT/W3oSicjbOv6MGycoaFby/KrlNHv9JtL8MG7SRR5qrvz1YSM5fmdE/Y/NwJxHt3z8zeTb9C37qP351PA/5A+U/0vXw/xlT4T9AsCKNzzTZP/l/sJbAkNU/jDnCcbw30j8Rsvf+OAazv5UwfGJqaqC/E6mR2LvZnb+iKf8qynbWv12A/f+1iru/KPwYyWFU4T+XkG8t7y3nP2y4bWzibOg/VMaFBmMgsD/lNyFw9sfcPz5Z2cSIj+M/aFx5wnSR3D8AAAAAAADwP/KK8SEQPOc/1N+1uDFv3D9Od9n5p4jkP2JloFilgeI/Ko68LkqWzL8kRiZXmw2nv/r+FYC3eFa/GlohtpCm4z+pt+eqswXhPwL2l6okE4+/P49gzZJ5u78KBCb2bzPiPyiFv0A6ONo/dgJ2u4hF3T8OhieQwb7TPzLhEQaqxJW/QvbsllbAzz9devtbfLzSP3h5cB0rB7e/4zlbCKqtgT9yxXbqlBx6v8ST4YKEIaU/QLYEIfBJ3T9Oa2vMhC7kP3gqqWXuXes//wjPwBCC7D/KXTML0QXnP8HccVEaZN8/s3HtSJMd2j8O8Cz2VCvVP0wEe1BVQ8A/OiVwWks6yD/7Puqk9zu/v2g760K3G06/NJc2I8Khpz/jDTYy1QO2P3fic+1n4tw/XCfh64na4z8MwhQQOd7pPz3ayBBsbuo/lq6N63Nx5T/jdrP5dzrdP0nPBuvrotc/mYVLF3Cc0j9r7z+hX9fRv7KktvqQhJ6/eUdK3o9lm7/FhJmE/yvVvzfv6LPLbcW/owkXJRFn5j+A38DSG2/rP7Jln7JaVuw/lTMD8U8OlT85VIFbbhnjP5IMUCV02+Y/4zv00j214z/yivEhEDznPwAAAAAAAPA/P/5HdzIr5D8wPj1XwPnsPz/NhIltgOY/W++HYFPqwL9UvYiwMfmuv7Q0utmC2pQ/14S4m5jH5j/l2yuG6D/jP+xYiCyxd6e/doNhYfqswL9iurGoxnnlPy16BfMmsN8/flqSYwlK3z/fHYZIXqPgP4WEJU7YCne/XQ67k+Nj1z+Rwlf0QYDUP7yMTK51g5k/O41GxZC+pT9Wo9aoAvyMP36bv8yDwrg/UccThgP0zT8oO/LjSVvUP8plxQvBcd4//x3CzFwQ5T+jS0+27cjoP0JeyE8nZu0/e2ABUMXA6z8PQ2OdJFrnP2sCUOLPxOM/oX8aYVyr6D/1rrrJWbLIv1oy5mFc48S/j86qzbL3ur++bdh2LCl0P5WVwCcRJdA/b4pLgLH/1T+QjZAMgsreP+Fb69EUduQ/sHAqmYWQ5z9tWD0SFdTqP/GpTlL04ug/OmsnTIDR5D+oIXA6Fm/iv0B6fysKGuC/uY+HZ0Rzyb8fPPMb6qm9v/32j3ST2My/N9aentG82T9Wku7j8XDhP3lVGbaRKOM/R6lt6YoHmT9dNiMQgcDUP1MfDma9Mtk/wYdff2uA1j/U37W4MW/cPz/+R3cyK+Q/AAAAAAAA8D/YiHOHbvXgPyWqHlS7stg/UjNYvQbKyb+tVyHaq1c8v2dJGSf9/6a/6/DKKAkf4z/7UouClHjmP0b2jYbQRom/luSbpxyVoL/AvycYx6zfP4In66HyOuQ/0FPJKmz+5T/ObcOo/gDoP3A+m5w+17g/ittr+QSH5T9F2cIb56riPygymW3mKGQ/Lyn5eJDBuD/GqVAt2B+vP+3Dbr7QAck/TKF9AstZ5T8sL2fnyxLqP8j1z+y0lOs/1WqDjRJc5j/FkRtO5qPiP+T3mWcscto/c9QBWyLq1T+bTKI8zerRPxSnim2f9bI/26BbkzRiuz9KVPeZrY+rvyhv1qVhv6A/CHsb2J9jsD/Pedu3LWa3P4vTHuENjuQ/zlQou0n66D/NZlH07NnpP4Gybzit++Q/XCdrjylz4T++dN8nK3bYP+RjJronlNM/32ZrdHzwzj/91BgVWCzAv6qizJpFz6a/zbN/9rFlmL8dEI0Ip4LNv9V11NE//bu/CD/KG4fN6z++LKZ3dTTtPxziQUG2Qeg/tiNp7U2Fez+D9XU5r5rpP10a/NbUy+s/SopksxP06T9Od9n5p4jkPzA+PVfA+ew/2Ihzh2714D8AAAAAAADwPyWE+oP25es/bOIJftJDtb+SEvY1LQO8vyR5CLW6I54/OUdxKUYN5T+7iH9+k2LhPxb5pxb1NLi/IUefBRXewr8TTXqQ/wvkP6ZHYkXHbto/q8srrVD02z/tsBj/mD7dP0EXjfpuR4q/4SDwrxC70z8VBOKHBwHRP35BrXQXYaQ/FeaHD+i+nT9tAjz7BFaHP2UU8gWRqLQ/pre3SokJ5z8T5TuMhS7qP+imfdbzzuY/Y0LiNPb+3j/e642ZTsPZP1wLxFR68tI/vpIDf7sT0D/hZm2WREDLP+tGf4cfTaU/munKSu+Voz9jI1Zk+SbBv2A5fiqKSbO/6Wx0KGBzq78IpxeAPQmjvyWVMHkMoug/h1ay9bv+6z9MZ2fdvGfoPxBt+ZzzI+E/2WOPrbDk3D81PKNoIoTVP5WPv8AZHNI/Yt6DpXv7zj8u61cvKPWHv8iDKgRWD6O/K88Tqk2ymr8TBgYJrJfEvw7J85T5ZbS/UdBRD1qw7j+5aZHNxlntP9Yo4fMwu+I/g44XAwGzjz8rrD50qDLuP31g0yaFle8/3WNi5c/O7T9iZaBYpYHiPz/NhIltgOY/JaoeVLuy2D8lhPqD9uXrPwAAAAAAAPA/xmVQm2Nsxb9kp6toYlS/v3t8ytM9Uos/3mECZqum5D+9nS8fai7hP8DQJ6gnery/JkdTIR04wr9hIGh1D3niP4Ja0vft1dU/0LjKRybj3D8SnzMJQ7TRP0WSt6yZsZi/e8SV2fA8yj86tJk0C5TOPxNk04x8X7G/CTkdPnl9gz9RWFY2XWZmPxNfDq/R6KQ/5Avf51HKd79jZoAIRF+fv0z9RIAIq7m/9L8C79i5wr9q8eSYn2/Dv3ZgaQVRdsa/lEewUSEtx78rvzvkn9bFv37GtRQBl8C/rmTCZ80Zv7/zWHZuhMfuP1k658sDNO4/f/OhOLfM7D+LQtzymTfrP1fbwFAZ7bi/bUm8zYmQw7/7SAXtNRrOv2y47pMhYtO/UpDJ7XAk1b9rU63ibpzXv8usQYE4pti/zrUXJ8bK2L+4UxeLk0+1P75EALSR/aY/CUcAFK2RkT/qA7AY0m/DP8VQ0y/9HMs/hHA652qaxr+Z3AlXS07Qv9LUxWDdcse/gxhALYJ+mr8Tj5dK+/nAv86k8z3StMW/aA5epRqbwb8qjrwuSpbMv1vvh2BT6sC/UjNYvQbKyb9s4gl+0kO1v8ZlUJtjbMW/AAAAAAAA8D844Fe4sRuVPxHs11ikL5o/92DE9cXp47/0mC/yqe7kv6D+lf7nIZc/+IW8gRwosT9OozjxKqLOv9UPGuMY98e/0omuC6OP5b96Qt4Wii3RPyYTFvZ1ubG/UB8TsNFEcb/+aSCHzMLIv5pu3VYzmug/yfVDPehmLT8zI0DVwGeoP5tvKvR4pqY/sajJGC57s7+TyGjEKXq+v7R+brv/CrS/LCeD4Ft7fb8Gsk1Yon1uP+SLVuQMD4E/kGn/4HOpbT9yvoPzEHhFP6EW8LT7hIk/jNlYkQS7oD84OtIRKyGVv6mbf5677Wo/Lt7R0r0llT9QZMn21h6cP0t/oX2N+bu/5E6Mcd+Yxr9zQJ4x9vO4v3kfMxk6fZS/8YbWi6Uhf784n+gbF7Vuv2WbLu/fnna/fQLWNeuogr9kJGe5v9Krv8pj9Pj8FVW/07EOqRPHgj/ZHdKvTpiyvwHvnK5vFay/W/GT8mO6xL/uRoaUpcXBv37LHPFieKu/1f+HHIwX0b+fgXp046y4v7lJqk1Drr6/Jz9Ri2I8wb8kRiZXmw2nv1S9iLAx+a6/rVch2qtXPL+SEvY1LQO8v2Snq2hiVL+/OOBXuLEblT8AAAAAAADwP8SKFhDjmaq/clxRTxcyrL/XLajkiamgv6NaxGvzY7e/NdEyxLRqu792ZIK4cs2wvycw/4g6XKe/rXTOycsYl79Ijqd77ZebPwROw3Vu1p2/tR2idcFSfL9IInOvZdSRv4Eex1RtRIG/ryU124fMrT/7lUxE14axP258hbB5eU8/QJMknTQAkz/OsA5NZbeYP1+zczxWlaA/OyCMbehDfj8txFBaWP6Qv8nGIhNZVa6//w845Z/fnL+SohDL1dqMv9Em0GcuxpK/N8Z/+sfPsr9b3TPI7KmhPy9BwEPcfKM/lN2ASFmqcb/fJS4gQFeiv5+65MknrXc/uNYgF9VCij9kaKXfZVCWPwXna79KQHa/BdONrpvjn7/3OhVEVo6wvzALDNQNiqG/Vwm8XO13kr+yzOB8j0GkP9sDOn1sL7E/hQtK4rv2p79vzO7/0MlzP504g9mBGL8/c27wUWkVlT9W1UWreLOOP5VJpxNV5o8/JCVOq1DQqj9HhsY1WjSOP7dMJb4BMYk/KankRVTMkD/6/hWAt3hWv7Q0utmC2pQ/Z0kZJ/3/pr8keQi1uiOeP3t8ytM9Uos/EezXWKQvmj/EihYQ45mqvwAAAAAAAPA/r6ozDGstqr+ZQqoeJV+xv2JXxAIfCom//0GTzVPDkr/vHVWbl+GHv2GJl9/MKXA/H8I8Y0yXq7+1Y4HG1KWfv4k01qEUbZA/QTq08W0+mL+qBBhxfsymvzxoXUvdCqQ/FqrGkOgnub8OZxy314etv9k9vp8Ppqm/63S+mjKL2D+TaYdsmTbeP0YCzLLN7+I/LC7V7Kct5T/XvC17HT/kP5oAf+zuDd8/xmwhLTdI2z+PbTvKFSLXP6KKj7e0Bcs/xY4QhScF0T9A/A2bTWPjv3+2OyfoD+G/FzxxP2ID3r/ORezCZg/av+4xaAbfVd0/Txwlatcv4j+JpjytZ9vlPzwFe23s0uc/Z8dwjCH+5j97xi1i6tbiP31HTDBPBeE/NBVLS9kz3j9NB1IVFwfUv3qr0pElb7G/ySXmU2jLo79KlQQJJMrPv+WcwCzaDtG/Mqe//S0f5T92tZjRYPLoPxnhQseuQeU/aJ7AQO8joj+a3xIptDviPwyuBKHxruQ/UGvchSUD4z8aWiG2kKbjP9eEuJuYx+Y/6/DKKAkf4z85R3EpRg3lP95hAmarpuQ/92DE9cXp479yXFFPFzKsv6+qMwxrLaq/AAAAAAAA8D+LFeFMY1HtP3DjS6zPEJi/np8LoR1Qtb+JpwDUdRnkP7FiBFlJDOA/nrRi82hl6j/v6AkeXYnMP8kKdoLSgIw/5lOEE3DI0j8w8TxtVDLZP9hQ5HFo6tq/mwaBhKm2rz/lEtGjUPaQPwCvrTRilak/Ots2HUct0z+J6j2OP9PXP5Qi8SPbHd8/kIc0ytOQ4j/RoMqeqsnjP+o1m+pgJOQ/XK5S4+Bz4T+AIVg6mbzdP9gmQnzBBNY/K5ZbyaIa3T92EsFVZVzkvw73aoWHNOO/PsZOKuRD4b+TfJhB2CHdvxL2djUrWdg/eXZyWwp43j95Nlbpo9fiP8pr5e2j7uU/u6vWtqpJ5z/6wD/5J0nnP44UXHc44+Q/fJaEq0iQ4j9ZxRFXDlvYv9rS7tlN086/4Jv74O27rb8kRugBWbPEv2lh1mdsY9C/QQ3k0gXG4T9QPFOvXLrlP24fhEZknOI/rSEIv0n0tD8JPv6dYRHePyee6ReePOE//gfrmjPD3z+pt+eqswXhP+XbK4boP+M/+1KLgpR45j+7iH9+k2LhP72dLx9qLuE/9Jgv8qnu5L/XLajkiamgv5lCqh4lX7G/ixXhTGNR7T8AAAAAAADwP0BXUpVyRpi/uP9ZGYNHqr9wmbvrYyziPzn6+p81AOE/kdiyPnJk7T87w/EQFTrRP31A3MVDpac/xN1qvkby2T8PkWt0RxngP7yxj47829y/BroEV4r7sz++nyMhrQ+aP7shA9BXDrU/lsT/bPs+wL8sa5P2Lr2/v7Au+PAr1rC/B9feVE2Whb+/7ZEuz8qFv6IaVM4ZaoS/b0gG7GlAh7+D3vXzsGg4P6klNYfHdpY/ENKnnWfskj8vj3ps4yiQv0NMrl4WXWy/l3+cef3vYz8WQh7+nq9+Pw81Bl9+6r+/Nt+NYafgvr9hIQlAB4muv9o9eNH2m4a/hjTaBAZUj78U8VxNRT+Jv68xJxlT3Ye/k46QdoUtRr8w5JSbSm2fv+UZ0nPCf1g/omjuIEWvi7+Gb2bwS7qgv2APNhHlJJy/g5yXHeQyv781w1/PBjy2v8V56XdmYJe/h5bTD+Y3oD80NtT2f+W+v+Y7TAsgSru/tbveGxoVwb8C9peqJBOPv+xYiCyxd6e/RvaNhtBGib8W+acW9TS4v8DQJ6gnery/oP6V/uchlz+jWsRr82O3v2JXxAIfCom/cONLrM8QmL9AV1KVckaYvwAAAAAAAPA/Q0CEq3Nj7D/pg6mUdLOhv375QGKHf0O/hLo4XSCUl78n7mNGvXWDv0HItAdxiog/49cgvGFJfz/iftSTvp11P7vsXm+INY4/A+LHazrXSr+CDCGBdyOCv5GDw/BkCYm/HZPe4o3mvb9yFjKBVnLBv5iealNBZ8K/4gB6IJoFuL/c1KdOvRyovwNb+LoqAJC/0W+ffXVWjb+GOt+sTd9zP4734QBAX6o/J0w87njTqD96Dl3kECCrP5FsBUEm0ZK/LH8rnmSQk79x0TIA3WqCv1PhFB2IPb6/bMQJdV+4wb/PsYiTY3HBv2RpnIhNLLa/jigbGQBzpr/H/c/Y0qaOvwZAjtdS5oe/sIX4zr9Kej+d5X7iULmlvzu+XB5a6pi/jhtvD0ADlb8U0xeYrnvJPy2NaSmWJG6/Cc5LbVm3wr91n76LXgTCv+YYrcoOtry/JBGcDWetwT/TZKWJIQnBv9S6tJfePcK/WL6UIJM2wr8/j2DNknm7v3aDYWH6rMC/luSbpxyVoL8hR58FFd7CvyZHUyEdOMK/+IW8gRwosT810TLEtGq7v/9Bk81Tw5K/np8LoR1Qtb+4/1kZg0eqv0NAhKtzY+w/AAAAAAAA8D9GeGkYaiCzvyPqt/DSa5C/uGVhtFTgo78xK6Mf33Siv37yNNQ5KJg/8kCFwE5gkT96v1PjBgOSPy6JJFoKyIU/zsqIZa95kT+DAQxYEO5pP1y4QM2Rl2A/f4FPGRR11j+upCB406zdP2iMb/bipOI/kIlD15+54z8uRhximt3hP3/zjOiOddk/AdcphHoI1T+JCB+LDiPRP1PBXiuwN78/SbEFOC7Dxz/0owrWgGPMv5jmbjn2esO/TbAM6vuvvL8sy765nnWzv8u7U8lqs9o/p1Gfx+UO4T/Puypz25nkPwzhwRAEWuU/p7k5Wadj4z/5tK+c8r3cP4lIzRO/6Nc/vIIN3Cre0z/KzY/cqFDQv+tqx84LDqO/QfT3wOtLk7890QC/aJHMvwny0B76l8S/8HMeZvgC4z9M0uIgxmHmP/OAcwZev+M/sS7xxwr5qz+dO3CffTLgP/KUuuy4kuI/D/vEoG+V4D8KBCb2bzPiP2K6sajGeeU/wL8nGMes3z8TTXqQ/wvkP2EgaHUPeeI/TqM48Sqizr92ZIK4cs2wv+8dVZuX4Ye/iacA1HUZ5D9wmbvrYyziP+mDqZR0s6G/RnhpGGogs78AAAAAAADwP2A+yccu++Q/axUiPOEG3z9cYCse7ofVP0bfl7nE1JS/6uXFyCYu0T/ah8TDf/LTP3IQc9wFSrq/QlMRnucenT8ikxB/QRiCP9UUCL+fybU/G5z+uPjsxj+jXIZ1jjbPPxJQKI2hhNc/ucIs0Qnb4D9b8sKk1szlPxJ94+obw+E/Ou9BUKBG4D+tFD7RYmPdP6t22VjbL9g/zSGU8Z/p3D/oxzrMMyXHv7WCgBIRzsO/TJ8G1dovu7/VChmihgWwv25vZfl7zs4/QfnwL9Ql1D/krC7C0rjbP7s73X9aveI/kaSH4EFw5z98aj9yT/viP5v07uzDOeE/TN2utLTq3j9vl44hfBviv9yKJ3kxBsK/JyObaGP1wr9zoCaXQxa7v+rDRnVHE8m/KJ4C6DFl1z/wzqm0ZznfP7wBLB26Ud8/l6HXFYwmtD8mHu1ZWqHSPzst+xZsEtY/Taine8w21D8ohb9AOjjaPy16BfMmsN8/gifrofI65D+mR2JFx27aP4Ja0vft1dU/1Q8a4xj3x78nMP+IOlynv2GJl9/MKXA/sWIEWUkM4D85+vqfNQDhP375QGKHf0O/I+q38NJrkL9gPsnHLvvkPwAAAAAAAPA/KZWQWxYg4D9ZR68XbqbeP2PM/2c8yoa/tONNK46t2j8KLck+uzrdP9zc+rxanbO/7mw+bKaRnD/dBo/vSt+SP3vyFz3x4sA/etRT6CkRzj/yUA4h48rSP21pHECjAdk/f6YlQH6U3j8YefZk6rbgP7HIGNqOZOM/nmtjbgds5D8qF5S7TaXjPwyLFS1RhOA/EkzBUNhs3j8VfIKYk/nkv+44c0KafeS/QLO+ju9K479oGc96edfgvz0aYq0VgtQ/n0NFepDS2T+o5z5uACTgP6pRAnNHJOM/Whlk3Kjm5D8qU9F2m2HnP4PaHjkBBOg/FiRlOOL85j84fK79VI/VvwK1DD7ldNO/SKJbUs8gzr9GhPaAxay7v8OeoLK77sW/wTReIFsR3j/UiA/CP5fiP9Ca1UxYud8/BaJvESVvsz/7GGBH9zTZP7nM4Lf//dw/7uhgClsc2z92Ana7iEXdP35akmMJSt8/0FPJKmz+5T+ryyutUPTbP9C4ykcm49w/0omuC6OP5b+tdM7JyxiXvx/CPGNMl6u/nrRi82hl6j+R2LI+cmTtP4S6OF0glJe/uGVhtFTgo79rFSI84QbfPymVkFsWIOA/AAAAAAAA8D/2biWax0/QPy6WTNkBGKY/a96u/13a2j9EuVfRLP7gP/BhArM9EN6/vtLKVwhEsD+MyW2gs+6OPxD1eUmgYbU/Cyfh+081zD/X8D8flNLSP7HyQ/Rcddo/B6dIALLx4D9CjKcJ3VzjPycHcA0tROY/P4sng0lD5j+6SKetEibkPwYAEUNYceE/73KZxWT84j8WsdMBF53QP3L0UF9RvNM/DBgDz3iA1z/iwH8s03jePxyM5G73m8c/jmE6wYNlzz8+tj04xqrVPyZlyb14eds/+1wCVvzK3j8WkU4lc1vhPyzmRTsOzOA/BuAYh65l3D91rq5bOufcv3yyEv0DrNq/o4MlZVWi0b+EgnbRaljBv5Os6QXtU8e/Bkh5eb0/0j/nFsn0l9TXP/YQbzi3Fd4/Hcc3ZTwctb+E44iRuhrOP6hgIo2iJdI/FtzH+h6m0D8OhieQwb7TP98dhkheo+A/zm3DqP4A6D/tsBj/mD7dPxKfMwlDtNE/ekLeFoot0T9Ijqd77ZebP7VjgcbUpZ+/7+gJHl2JzD87w/EQFTrRPyfuY0a9dYO/MSujH990or9cYCse7ofVP1lHrxdupt4/9m4lmsdP0D8AAAAAAADwP74NmjQ2Tp8/agPtYyGF4D9zrT02R8LWP0puCCxXKtk/6uEXkuNgwD9qApmOS+S7P2uJKUfK6s8/skvf8w25ar+7YOFP+AWQv1W+aT4a74i/FGyxj3KkcT9iwaJHrbKhPyRlheODX70/CWTQlXqOuD+Vz3VzgvW0P5k5gcQHiLY/18Z3CInhvT8wmgTKDdWuv72iftSANrW/b4/dUdoFsr8B0N/EfjOwvzTvEpDc6oK/dEYwpVxPjr+DhC/dN/aVv5bX8xgPXI+/SIPx0eYsiD+n0XpohMmzP/bxfyBeRLA/1Js996lMsD8MJLmJZtOlv2O86BmoHrW/Pi6MO5/7kL8567rDABiiP/HdchKiwLG/QTIOozVEl7/3RUpwNy2Uv7xEevtBap4/od1zYQc/h79xM239pO6Xv66crIl2+Jm/laQxlAmSoL8y4REGqsSVv4WEJU7YCne/cD6bnD7XuD9BF436bkeKv0WSt6yZsZi/JhMW9nW5sb8ETsN1btadv4k01qEUbZA/yQp2gtKAjD99QNzFQ6WnP0HItAdxiog/fvI01DkomD9G35e5xNSUv2PM/2c8yoa/LpZM2QEYpj++DZo0Nk6fPwAAAAAAAPA//2OMVutvOb9+l5pWlrhdv8XSwAMRZIA/xJ99FJSa2L/xvCf6IxTev8h3yK/LI9E/BR9FO3CXwT8377L2BTTIPwFXYHdAW9E/ex5eMIaS2D9cpGcN34TeP0lTBslOBuc/OXtfAf574j+DVheZz5ngPzSLrlGHst0/HodOsgTt5D8X9D5zHrGqvgEQvPOZyXK/9lUxvKTPPz/CElWJvJSXP3OBwRbyvsE/rAMrwbhGyD/UZF8qQ9TQP54hHt4uDNc/gSsVGEEW3D/nF7/DZBDkP7NfZZSV5N8/KNyfCcZh3D/YuIVTMN3Yv1+qe3cPHOC/380Dg985uL9yo/7z4KJcvzA/onYlRZa/LKwtJX/Syz9DLl3xuDPTPy9Ao0mGX9Y/JdXzybq2rz/CAmVGSCbGP/yUaj0+8Mo/eaGzmnbwyD9C9uyWVsDPP10Ou5PjY9c/ittr+QSH5T/hIPCvELvTP3vEldnwPMo/UB8TsNFEcb+1HaJ1wVJ8v0E6tPFtPpi/5lOEE3DI0j/E3Wq+RvLZP+PXILxhSX8/8kCFwE5gkT/q5cXIJi7RP7TjTSuOrdo/a96u/13a2j9qA+1jIYXgP/9jjFbrbzm/AAAAAAAA8D/BAAd/8mrqPy7BYbSbVHi/viVxdsbtc794JHfJStB5v4EDZ3kaunS//cz3W6/XvT9KYj7G6/TEP8b+JeqqSM4/dsr+IwLD1T9OaeOEmcDaP9fgHkfRveM/n/vvmWVl4D/3FdnoCNndP4bPpf6d49o/LT7If/Eu4j/7UOoS/CDIvxNwlW55v8m/Df0LoFwSyr+9zKHfwPbFv+okJZtmDMU/xsnYi1upzD+5XIEqWcbTPwCPpRc7N9s/7H08okqO4D+SRAzuSS3nP1KXUsEPMOM/0CL0ig9r4T8g4GVInB7Wv/4cxAzIjty/GQh5Hoz0tL+7b0fsPtpPP46854UGQJe/zqngyp5U0D9LQqI1DYnWPzGN4ppfONU/4xZL0Snyvj9dj15KiOnJP7J08ov/Ss8/09SQKzSSzD9devtbfLzSP5HCV/RBgNQ/RdnCG+eq4j8VBOKHBwHRPzq0mTQLlM4//mkgh8zCyL9IInOvZdSRv6oEGHF+zKa/MPE8bVQy2T8PkWt0RxngP+J+1JO+nXU/er9T4wYDkj/ah8TDf/LTPwotyT67Ot0/RLlX0Sz+4D9zrT02R8LWP36XmlaWuF2/wQAHf/Jq6j8AAAAAAADwP5JKzxTSM86/YRaa9t6Ugr//CnqHAlmFv8bdpu3eW3C/yaeXZp7tnz8Ci+7VpTWjP85gTvgtV5o/x0xRT9SGkD9pJwquCfmNP7mkSXjiv3U/5yy30TcYfT8MSmME0WZyPyBgOUizdoQ/GY54osHqiD8X9PEKckjoP/7kFQj5n+k/qsDCEi0j6T/JZoOUzZPoP+NIUkHbCai/OFTbNsjor7831x3Bf+23v+2Ss6F/AMG/Peitv0HFxL9I7Idg+KzIv+/ppezyH8q/K2hGKOICzL+7zG6vHxyFv6enIZc6A6O/DWLy/nvCp7++DMp2ZbCCv/5+XXU4arg/dtKFbRUds7/bo/COA1e7v+kLI6pyhZm/80iGTAqRvL+Gol/y1aCsvwjTtz52T7G/ZcHO6HWMrr94eXAdKwe3v7yMTK51g5k/KDKZbeYoZD9+Qa10F2GkPxNk04x8X7G/mm7dVjOa6D+BHsdUbUSBvzxoXUvdCqQ/2FDkcWjq2r+8sY+O/Nvcv7vsXm+INY4/LokkWgrIhT9yEHPcBUq6v9zc+rxanbO/8GECsz0Q3r9KbggsVyrZP8XSwAMRZIA/LsFhtJtUeL+SSs8U0jPOvwAAAAAAAPA/2v0x+VBFVD8lNVH8Z/Bmv0+ap48ZmWY/VcR737u4ez8Lq3Lk2JZ2P1JlrTOfLJI/rGgFvQ08qT9vRPYjupGzPyCeUuM8YLk/Mpkmi+lUtz945j4+PoO5P5CjNZ8/4rg/SGMbM48ZuT8NdeMEiCdkP2tj8iXAU28/HIf6pJ0FmT+WPCyJQPS0P/3aB+zynnU/UGcLj1p7Q7+nYyLQ90eFP8FllwA/sqI/vQhjRGAKsD89xozHux22PwxfJKwCCrQ/2H38stogtD8Mpx61sN2wv0vHx4W3zrO/jbXp4aQLq79JNBqjZsp5v7yivoVp77C/YgTvsg0hiz9/8d4gX8aWP388Lzoq9oI/EVfLnZk4lb8LiThDzy2BP04HnDX8D4I/ATSkgI1olT/jOVsIqq2BPzuNRsWQvqU/Lyn5eJDBuD8V5ocP6L6dPwk5HT55fYM/yfVDPehmLT+vJTXbh8ytPxaqxpDoJ7m/mwaBhKm2rz8GugRXivuzPwPix2s610q/zsqIZa95kT9CUxGe5x6dP+5sPmymkZw/vtLKVwhEsD/q4ReS42DAP8SffRSUmti/viVxdsbtc79hFpr23pSCv9r9MflQRVQ/AAAAAAAA8D/7Wkko4X7qPwG4lP2eA6Q/zYQfKk2qYr85Yf2S7EYvvwcKpmnyqns/9YDJml48kj/a+WomQ/KfP1rDsNij5q4/vN9ocW0CtD9NEGH0ER25P5gnnSHtirk/zdAlP6UtsD9LJ1n2X2ikP8ASmg/wGaY/3nXSMn3MqT9PHSo16gS3Py1w7pMWG2a/Dy7+TuJPfb/v7WmejWhYv7LIZbjpBWc/QH2jGhLXiD/Ag8NPyUqkPx3h2soh3Kw/g7KcGk2Lsj/p9+lGeD2Yv52WRvQus7G/IviERru9uL/mxQmdOriQv6SgRlK4n6W/wAsOZDtccD9ycesPU1BTP/W5QLnpk6K/YNKtBSapfL+xJsoAmGJwP7sC/xeOfFA/GpaBQ3mjkD9yxXbqlBx6v1aj1qgC/Iw/xqlQLdgfrz9tAjz7BFaHP1FYVjZdZmY/MyNA1cBnqD/7lUxE14axPw5nHLfXh62/5RLRo1D2kD++nyMhrQ+aP4IMIYF3I4K/gwEMWBDuaT8ikxB/QRiCP90Gj+9K35I/jMltoLPujj9qApmOS+S7P/G8J/ojFN6/eCR3yUrQeb//CnqHAlmFvyU1Ufxn8Ga/+1pJKOF+6j8AAAAAAADwPy8uDShsFro/7UiSToPKnj+pi/iPZuyiP33EkHA8jLM/l0vLNKjAuj8jJYobnILBPxt+SnMKt8k/SUDjpMdhxj95N4EI9rbCP/HL6eFwHsE/IjQGnODFyD8JJlaIHyelP5zcAvsOka0/z8rSFyl8tT+3n3dqq1LBP1uRwN/3G5s/2J6CoRrKnD8m3M2EdGmvP5OKr44IpbQ/cFcNqGkguj+nrFkZLubDP1nKzVhM3ME/tZMSFMNwvT+ICxIp+fu8vyXgeC3hWcS/bAxlP5qVp78C7Cig+4qhvzYrRvpTHa6/0zzf8OhsqD84pyVCfYOwP1udfrbYIrY/CDfI3o8mmT+5uzQP26+fP5fScI9Dr6M/h5lhvjKeoT/Ek+GChCGlP36bv8yDwrg/7cNuvtAByT9lFPIFkai0PxNfDq/R6KQ/m28q9Himpj9ufIWweXlPP9k9vp8Ppqm/AK+tNGKVqT+7IQPQVw61P5GDw/BkCYm/XLhAzZGXYD/VFAi/n8m1P3vyFz3x4sA/EPV5SaBhtT9riSlHyurPP8h3yK/LI9E/gQNneRq6dL/G3abt3ltwv0+ap48ZmWY/AbiU/Z4DpD8vLg0obBa6PwAAAAAAAPA/",
+          "dtype": "f8",
+          "shape": "57, 57"
+         },
+         "zmax": 1,
+         "zmid": 0,
+         "zmin": -1
+        }
+       ],
+       "layout": {
+        "height": 800,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Feature Correlation (Spearman, 154 pairs > 0.7)"
+        },
+        "width": 800
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAMgCAYAAADbcAZoAAAgAElEQVR4XuyddXwVR9uG73iCu7tLcSvuWtzd3d3d3UtxLW5FC8Wlxa1QCsXdXeLJ95vhO3kje5Indg6Be/9535LZmdlrZ/fMtc+Ija+vry94kAAJkAAJkAAJkAAJkAAJkIAFCNhQQCxAmUWQAAmQAAmQAAmQAAmQAAloAhQQNgQSIAESIAESIAESIAESIAGLEaCAWAw1CyIBEiABEiABEiABEiABEqCAsA2QAAmQAAmQAAmQAAmQAAlYjAAFxGKoWRAJkAAJkAAJkAAJkAAJkAAFhG2ABEiABEiABEiABEiABEjAYgQoIBZDzYJIgARIgARIgARIgARIgAQoIGwDJEACJEACJEACJEACJEACFiNAAbEYahZEAiRAAiRAAiRAAiRAAiRAAWEbIAESIAESIAESIAESIAESsBgBCojFULMgEiABEiABEiABEiABEiABCgjbAAmQAAmQAAmQAAmQAAmQgMUIUEAshpoFkQAJkAAJkAAJkAAJkAAJUEDYBkiABEiABEiABEiABEiABCxGgAJiMdQsiARIgARIgARIgARIgARIgALCNkACJEACJEACJEACJEACJGAxAhQQi6FmQSRAAiRAAiRAAiRAAiRAAhQQtgESIAESIAESIAESIAESIAGLEaCAWAw1CyIBEiABEiABEiABEiABEqCAsA2QAAmQAAmQAAmQAAmQAAlYjAAFxGKoWRAJkAAJkAAJkAAJkAAJkAAFhG2ABEiABEiABEiABEiABEjAYgQoIBZDzYJIgARIgARIgARIgARIgAQoIGwDJEACJEACJEACJEACJEACFiNAAbEYahZEAiRAAiRAAiRAAiRAAiRAAWEbIAESIAESIAESIAESIAESsBgBCojFULMgEiABEiABEiABEiABEiABCgjbAAmQAAmQAAmQAAmQAAmQgMUIUEAshpoFkQAJkAAJkAAJkAAJkAAJUEDYBkiABEiABEiABEiABEiABCxGgAJiMdQsiARIgARIgARIgARIgARIgALCNkACJEACJEACJEACJEACJGAxAhQQi6FmQSRAAiRAAiRAAiRAAiRAAhQQtgESIAESIAESIAESIAESIAGLEaCAWAw1CyIBEiABEiABEiABEiABEqCAsA1YhcCV63fQoMMoTBzcHtUqFLFKHSKz0NMXrqFVr4moUrYQpgzrFJlFMW8SIIEIIvDZ1Q1NuozF2/cfsW35eMSKES2CcmY2JEACJEAC/glECQHZfeAU+o35xeyda1m/Evp1bhjhd1aV+/L1WzSvVzHC847oDI+cuIRNOw/j0tVbeP/hExLEj4O0KZOifIl8qF6xKJydHCO6yHDlFx4Befn6HdZvO4iyxfMhS4ZUAeoxZd46LN+wB2vmDUOubOnDVcewnvzZ1R01Ww1BzBjRsPrnoQHYe3l7Y8cff2HjjsO49+gZPn1yRZzYMZElQ0oUK5hT3yt2esJKPuzn3b7/BNWaDzLbblZv2Y/xs381W8ClA0tgb2dn+Hf1bHYZPBMVSxXAtBGdw17JcJz5NTwX4ag+Hj55gam/rMep81fh7uGJTOlSoH2z6ihTNI8o29zl28LT08ts2m6ta6Nj8+r674+fvkTttsNRukgeTBjcTpQ/E5EACZAACYSOQJQSkAol8yNlskRBrjB/rswo8WOu0F25IHW3IbPw78372L9+miC1dZL4+PhiyMTF2P7Hn0iaKB5KF82DuHFi4cWrtzh++rL+MS1bPC9mj+lunQqaKTU8AnLt5n3UaTscYwe0Qa3KxQOUsGX3Uew7eg79OzdE2lRJrXLNi1bvxMxFm7Bx4Uhky5TGrw7e3j7oMGAaTpz9B9kzp0H+nJnh6OiAB4+f49T5f/Hm3QeM6tsKdauWtEq9v8dC3dw9cO/hM4yZsRIXrtwIUUBUe4sXJ2YQVD3b1YOtrU2Qf7917zEadRqNT5/dUKl0QasJyNfwXIS1fb199xG12gyFm5sHav9UArFiRMeeQ6fw3+2HmD+pN4oXyhli1rOXbIaXl3eQdEpmft28D93b1EGHZtX8/m4Szs2LRwf5yBFiYUxAAiRAAiQQIoEoJSA/j++JUkVyh3hREZUgKgjIglU7oH5ca1YqhpF9WsLBwd7v8pWc7Nj3F/46ewWThnSIKCwRkk9kCUiEVC4cmXh4eKJ8w77I80NGzBzdNUBOO/edwIBxC9CyQSX06xQwYufp5Y2d+/7SnSsljDwsQ6DQT53w8ZOrX2HmImdh6ZC++/AJDTuOQvrUyXH64r+6o2ytCIhlaH4pRbXltVv3o27VUojm4hTuoucu3YpfVm7DqjlDkDdHRp2fq5sHqrccjJjRXbBlyZgwl7Fi415M/nkt1s0fgRxZ0vrlo6Il6jkukDszh1CGmS5PJAESIAHzBL4pAVE/fEvX7sa2vcf1l/9YMaPriECfjg0CDGuZsXAjDv11Ec9fvoEa8xs/bixUKl0IHZtVR+xY0TWtNr0n4+T5q0HIHdkySw+tyVuhHdo0qoLeHeoHSPNTs4FIniQBFk7pq/9dDYlq3HmM/hFzc3fHsnW/4/6j53pYV5+OX87de/i0/nf1Rc/e3g75cmZGnw71kSFt8mDbruo4lanXC4kSxMXWpWPhYG88BERxMf3N19cXa7bux7rfDuov77FjxdBDmXq0rYPYMb9cuzra95uKR09fYtGUvvprvuLl4+ODg5tmYMP2Q/rf9qyZjE07j2Db3j/x5u0HzBrTTQui5D4YCcj1Ww8wae4a3H34FK/fvNcssmZMg7aNf0LJwl8iXOcv/4dm3cYH4VK/WimM6NNSc5w6fz0ObJyOJAnj6XTSazZFLhRLdY1/HDmjh3vkzZEJw3u30BGmkI6Df16AElcVcQosEtMXbMCStbsh/apqqo/qYK3esg8Hjp+Hq6s7fsyXDcN6Ba2PpB3tOnASKzfsxeNnL6E6yDGiuej8OreoGaC9mco2usdx48TUbVoNT3ny7DU27ToCNSwue6Y0GNW3JZIlSYjFa3Zi257jeix99sxpdWQnTcokfvhCW4/w3JPg7pl65nS7/vMCfl62NcQIiPTemaJdz1++xdp5w/RzWqxgDpGAmN4Z4we1w9Pnr7F51xH9rsqQNgUGdm0MFfE1HVKORs9FcM94NBdn/Z7YuvuYfk+od556H6kI0E9lfwz2MVASnq9Se8SMHg2Na5VDkzrlEDd20KhRSM+S6e8q2qmEYPuKgM+9+vCiPsD8sW6qfueG9lBDJSs26oscWdNh3oReQU5XQ+7WbzuEEzvnRYhIhbZ+TE8CJEAC3zKBb0ZAVCez65BZ+PP0ZdSrVgoZ06XEvYdPsXbrAR1CV2PxbWy+DJFQHUQnJ0ekSJoQ0aM548nz19jxx5/6q7VJHP48cwWqw/jk+asAX6srlymk8wmtgCRLkgCvXr9DobzZdJk5s6bTEmLqGJQplhdF8mfXX2OVHLi6ueO3ZeOQKEEcs+3v4PHz6DZ0tq6f+qouOSb9vBYrN+7VnaGCebJqydiy6wjSpU6mO1+muSKqc6I6QrY2NkgQLzayZEyFDx8/a5Fat+2gFhB1TW5u7iiQOwvU3IYmtcujYO4sovtgJCDHTl3Gwl+3I2vG1LpM1elQ9+HytdtYMWuQFoFXb95j/fZDurNYu0oJvy+iarhV7uwZDAVEes2mTrfqbKl5GKpj/uzFGz2UTc0nUXxCOsbPXq07jMe3zYWLc8B5N2reyugZK7W0KnkN6TDVR+WTNFF8LaYPnjzHyXNXkT51MmxeMsZPLKXtaN6Kbfj76i3dmVTC+f7DZ+w5fFqz/m3pWMSJHUNXy1S20T1WbUQJiOKkhh2psfJqeMvvh04hWeIEug29eP0WpQrn1vmqf1dRgK1Lx/g9g6GtR3juSUic1d+3/n4MQyctCVFAFk3ti7SpkulhWE6ODmazVu1ARbTWLxihh42qSEtoBUTddxdnJz03yN3DA4f/uqj5KSFNnSKxLlvK0ZyAmHvG5yzdqgWkzk8lkDl9Krx6804PbVTXrIYWhnSoORsrNuzBlt3HdFKVj5qrp9pTaA4Vxc1bsZ1uS4Ejikq++o+Zj7nje+g2GNrDFD0OPFTSlM+pC/+ida9JmD+pD4oXyhHa7JmeBEiABEggGAJRSkCMrqN8ifz6h8n0YxR4TPDvB0+h7+hfsHhqPxTOn90sCvWFWXUa1Bdf0zwTc0Ow9FfxUEZAVOd50pD2AX6AlfioL3At6lXyi4aoCqroTZVmA9GqQWUdmTB3mDqJy2cO1BIQ0mGaaFujYlGor6um48Cx8+g+bLauQ+uGXzrGSkBOX7ymv7g2rFEmQNamcutXL43+nRsF6GhL74N0CJZpSJO6d2rFLHUENwckcEcrNNdsuq4uLWuiXdNqfp171S5U+9i7doqW1uCO+h1G6o75kmn9gyRT8wCqtRikpUYJjZJRNflcCVeq5F86lP4PU30Gd2+ivySbBFrJn/qbGs6j5hWEtx2pyFPtNsMwpn9rLXXqCO4em77QK2lW83BMkbM5S7dg/srtqFiqIEb2bekXdTTVd9uyccFG9YKrR3juSUjPhfq7VED855U0cXzdqW5ap3yAItR8i5HTluuPGT/mzab/FhYBUavDDe/VHCoaoQ41lLJd36loUKOM/ndzhxFHcwJi9IyrTn+hnzpCvVv9vyfUR54LV276Sb+Eq5q/sXbbAazZsl9H3NQHnDaNftKTyCXHu/efUKR6Fx15UW3N/6E+Tqj3VFjmTb3/+BkVG/bV0aQ543oYVkV9VMlXoT3aNvkJapI6DxIgARIggYgjEKUExGgSeqZ0KVG1fGEd1bjz4Kke3uL/UENWitboqjvy7Zt+mWSoogyrNv8BtTrN/YfP8OHTZ6gfXXX8OneIjoSoIyIFREUO1JKs/g8ViVBf59Uk93hxYwX4W9Ou4/RwMCVO5g41lGzxml3iIT1q+I+K6qgvqJnTpwyQbYWGfZEwfhwdKVKHaXjGrlUTgxRv6pyq4WgqUuH/kN4HcwKilq9dv/0gLv97W0c71CRhdSgBMbEIjYCE5prNXdfew2fQe+TPWDZjIArmCV701FCbcsXzYXD3poa3TV3TnCVb8MfRM1CdK9Ohvmi3a1I1wKR6c/VRCwyUqtMTjWqWxdCezXRES9qOVDtXQxSVKN64/RDv3n/UQ+bU4f8ZCe4e+x9W6L9NHz15CZ0GztBD8RQD02Ealub/S3J46xGaeyJ5XYYkIGcvXddtUj0jtra2ePT0BZRoqOGU/rmdv3wDrXtNRP8ujdG4Vlm/osMiIEbvjCpNB8De3h7bl4/TeUs5BjcEK/AzrkSjYJVOfkNJg4vCStiqNOqjjRqSp1aoU5P+1aIhilvgVewC52dq6+ojyLBA0mWKUChBV9HX0ByzFm/Gwl93hPjurNp8EPLlzKQlhwcJkAAJkEDEEYhSAhLcJHS1hKb62m3uaNWwMvp2bKC/wjXsOBr3Hz3TX2rVJEPVqfjv1gP8vPw3rJozWA/1UUdkC4gajqOG5Zg7fsicVg/hMHeoH1D1QyqNgIyathwbdhzG2T0LgwwPatt3iu6QKqlQR1gFRHofjATENNFXfVmuVakYUqdMor+iqwiEGuO9ZPqXqEJoBCQ012yu02368iwZiqEiY2rOSueWNYN9SlXHUQ0R/PfGfVy6ehO7D5zE67cfMKJ3C6jIkjqCk4A8FdqhRKGcurMfmnbUa8Rc/HHkrI7AqC/cyZLE1x3qnsPn6q+8pqVIwyIg5/7+D827j8f0kV30krOmw9RR9D8vJrz1CM09kbwuQxIQozzUkMRarYfis5s7jv82Vw9Hq9lqKNKmSoIhPZoFOEWJQ6E8WfU8JRXRCG5ytjnBUxl26D9Ni9BfO37W+Us5hkZAVL7L1+/BlF/W6aib+lihhoyq+XThXW1Q1b33qHk6yquEu2e7usHeHlMExDTHy3/isEZA1HOmIs9FC+QIMqwrcGXUUMME8WN/dasISto005AACZDA10zgmxEQNfnbzs5ODyMxOhLFjwPVsTX9sJqGr5jSmoYhhUZA1HAl00RyUz7BTUIPHAExdY6VQKjlWAMfqpOSMa35oQqqI6k6IEqslGCFdATXGW/TZzJu3nkUbgGR3ofAAqKGOxSr0Q2pkyfGspkD/IadqGtSw4PUJNaIFpDA12yu062WzVWCJhWQdk2rolPzGiHdjgB/V196KzXuj4xpk+sVeYITECUvecq3RbkS+fQwLGk7+uf6XaghYipyMqRHU78hXWo4SuGqncMtIKYFAgILiGlTRpOAREQ9QnNPJDciLAKi8h04fqHe1+X4tjm6jap7qCZtB3f4Fz2jdMEJiFoc48adhzi6dTZCwzG0AqLqpURfifHFf27iyrU7Ooqh5nKM7mf8jjV3zSqicvTk31i2/necuXhNRz1aN6qCSqUKws7ONlhWeg5IBdXW82Pq8IAbeu7cfwIDxi7QQ6ik+4GowkxzwtTCBiENBWvUeQzUb4cSfR4kQAIkQAIRR+CbERD1ZVBNrj22bY7ZDcEUtuFTlmLzrqP4+8DSAD9+RgLSY9gc/cOrVlTyf6gVbnKVa6PnRqghMP6P0AiIGj6lhlFtWDBS7wsR2kN9HSxdtycSJ4wLNb7eSGJUnmoisFqe11Re4JV8VAdBLTmZOEHccA/Bkt6HwAKi5kWo4Uuq4961da0AKAILiFq5SH159j9nwXRC4I5WaK45IgSkbL3e+ut//y6NgtxO030wd5/VMDi18tfuXycFKyBqCIv6om5iJW1HpmWAl8748jXedFhaQCKiHl+LgHQcMA1/nf0HZ35foCdoqyiQWl0p8NFrxBy9GljbxlWRJmViw/2MTOeYExDVGS/XoLeeh7Ry9mCEhmNYBMT/Nahlb/uM+lkPW/1r+89+qwUG985S7V0tA64++qj9UNR8C3X9oZ3QrZ5/xVTNz/N/TJizWu/h8fvqyUiVPOj+UEZ1U++ZSk3660nr00eGvCmkep8XyJVFz2niQQIkQAIkEHEEvhkB2bjzMEZOXa6HkASeMKh+dNRwCbXyj2mirP+vX6oDNnTSYigJ8R8BUZuTqWVm/9w+FzGiuwSgXq5+b8SIHk2PITZ9xTv01wX0H7MAeX7IYLgMb+AIyB21+3KLwSiUNyvmT+wdYA8PNffh6n93/YaDmbvlpqVdVd5jB7QNsDKPEos9h07rr49qyVTVCajeYjDU5FbThG6Vr0rTZ9S8AKszhXUIlvQ+BBYQ1VlRS3eqjoH/r41q5Z9+Y+brISCmCIgaQlG8ZjfDZZADd7RCc80RISANOozSQzbUcMHAh2qfaVIlQYPqZYIMgVMrgKnOrP8Jxkb1Ufd00IRF+qu7qQ1L25FaVlp9Qfc/Zl51atVQPvVchHcIljQCEhH1sLSAqM6+Ekv/++xcvnYHTbqMQeF82bFgcp9g38oRMQdEfThRH1DU/KImtcvpZcKl9zM0AqLelUdP/Y0q/7/in+nCTIsJGM398n/xqo0qKVZyoOY8lSmWB20b/YSc2dKH6ZfLtNyuWs7YlId6P6p3p4uTY4DledU7U73vfsiSVq86FvhQ0cKNaunwZWORPk3wy5yruVH5K3ISephuGk8iARIggRAIfDMCoobwqK/vaolSNYfjx7xZdURARTCOnLyEMf1a64636qypr+dq/ws1qV0tH6r2V1D7gaivfP4FZP+xc1BREDUJUe1v8eDxCz1mWa36Y5rEqDbGUqsY/XvjHv6+elvLiPrSZ7QPSGABUfdGLSerltJUK2+pITUJ4sbG7fuPdZ3KFM1rdkiZ6b6qH0k1QVotyasmhKuhCPHjxtbLZp44d1UPB1HXOWPUl03xTCs6Fcn/g15mVi2XuWXXUd0xXvfLCL+OcVgFRHofjOaADJ6wSO8pojZsS58mmR4CcvrCv3rSbd4fMvoJiLoO9VVULTrQol5FfZ/Vtatx4kYdLek1R4SAqK+y2/f+iaO/zQmyL4vahFB1ZJXMKulMlyqZXr74+s0HeoUjNRFdbbam9qVRh6k+av8MNfZeLW+rhrCoHbvVykuDujXxe7wl7UitKFaz9VA8fvZKdy7VM6DKffTkhW77lhKQiKiHOQHZd/Ssns9VskhuqDlUIR1qgrySX8V17W8H9POtViRTy+z6X1kuf6X2+oND0QI/6DljahL6H4fPwsnJQUcNgxsqqeoQFgFRSyKXLZZXRyaVSKuJ9+qa1EIZSoRCwzE0AqL2dClZu4ceKqXKV/u+qMn2avntovl/0MveBneooVqFqnRE1fJF9EcCtUR2eA71wUG9sz29vFCnSknEjOGiWaj3Q+DhV6alrk0LNPgvV70LqzYbhAql8os2FzTNM1JyaSQz4bkmnksCJEAC3zuBb0ZA1I1UnfFVm/bqTp7qnDo62OtOXckfc+kvy6YVm9QPy5R563D34TO9WV31ikV0p0OtKe9fQFSe85b/pjdaUz+CaiK02gtCCYj6kVXRBxU9+PTZFQVyZ0X3NrX1kr/mNiI0EhBVhuo0qQnY6uudEiJ1foE8WdGgeukgq1UZNVj1xVGtaqTGsSsRUqt8qR211QZblcsUROXShfy+3Kq06suk2kvjwSO1EWF03cno0bau3x4QqoywCoj0PhgJiJJANT5735Gz8PH11ft6dG5RQy9p6n8OiCpDzVcZM3Ml/rl+B44ODnpMuZr8bW4jQsk1R4SAqChY18Gz9BfxwJ0WdV/UvVZtRnWe1BKltna2SJk0IapXLIpmdSsEiGCZ6qNW+Dl26pJeble114Y1y2jxMi3La2oTknakOpKjZ6zAxSs3ED2ai97gsXndiqjRaojFBETVN7z1MCcgasiM6mjuWzdND00M6Qi8E7opvfqIoPaeMR1KTtQHiXsPnupNF5WMKIlU0uZ/g0Vz5YVFQNSStWqxjFt3H+v9QNSSy2rlKLXMs+mQcgyNgCgpVhvwmdqpt/eXd5ISihb1K/rtFWTuWlVUTc1pkvAP6f787zqf6Q1GT53/Fx6eXnquVIem1YNs9hmcgKj5Orv2n8D25eNFUqSiJeqd+tcObkQovU9MRwIkQAJSAlFCQKQXw3QkYG0Cpn1L1ByLycM6hqs6wa1EFa6Mv9GTTfOI/Ef8ouKlBjcJPSpeT1Sss9qzp3zDPihWIEe4n+OoeP2sMwmQAAlENgEKSGQTZv7fHQE1/l2Nl9+0aFSI+xwEB4cCErqm89ue4xgycbGOXKgIRlQ9KCDWv3Om+S6BF+ywfs1YAxIgARL4NghQQL6N+8ir+IoIqBV71Jh1NQRl+cxBen+IsBwUkNBRU3Ns1Hya35aNDd2JX1lqCoh1b4iaJ1in7XA95M3/TvDWrRVLJwESIIFviwAF5Nu6n7yar4SAmtTcsudEtGxQCf06NQxTrSggocOmdodXG0CqxQii8kEBsd7dUxvVNu0yFh8+uerVtdRGqDxIgARIgAQingAFJOKZMkcSIAESIAESIAESIAESIAEzBCggbBokQAIkQAIkQAIkQAIkQAIWI0ABsRhqFkQCJEACJEACJEACJEACJEABYRsgARIgARIgARIgARIgARKwGAEKiMVQsyASIAESIAESIAESIAESIAEKCNsACZAACZAACZAACZAACZCAxQhQQCyGmgWRAAmQAAmQAAmQAAmQAAlQQNgGSIAESIAESIAESIAESIAELEaAAmIx1CyIBEiABEiABEiABEiABEiAAsI2QAIkQAIkQAIkQAIkQAIkYDECFBCLoWZBJEACJEACJEACJEACJEACFBC2ARIgARIgARIgARIgARIgAYsRoIBYDDULIgESIAESIAESIAESIAESoICwDZAACZAACZAACZAACZAACViMAAXEYqhZEAmQAAmQAAmQAAmQAAmQAAWEbYAESIAESIAESIAESIAESMBiBCggFkPNgkiABEiABEiABEiABEiABCggbAMkQAIkQAIkQAIkQAIkQAIWI0ABsRhqFkQCJEACJEACJEACJEACJEABYRsgARIgARIgARIgARIgARKwGAEKiMVQsyASIAESIAESIAESIAESIAEKCNsACZAACZAACZAACZAACZCAxQhQQCyGmgWRAAmQAAmQAAmQAAmQAAlQQNgGSIAESIAESIAESIAESIAELEaAAmIx1CyIBEiABEiABEiABEiABEiAAsI2QAIkQAIkQAIkQAIkQAIkYDECFBCLoWZBJEACJEACJEACJEACJEACFBC2ARIgARIgARIgARIgARIgAYsRoIBYDDULIgESIAESIAESIAESIAESoICwDZAACZAACZAACZAACZAACViMAAXEYqhZEAmQAAmQAAmQAAmQAAmQAAWEbYAESIAESIAESIAESIAESMBiBCggFkPNgkiABEiABEiABEiABEiABCggbAMkQAIkQAIkQAIkQAIkQAIWI0ABsRhqFkQCJEACJEACJEACJEACJEABYRsgARIgARIgARIgARIgARKwGAEKiMVQsyASIAESIAESIAESIAESIAEKCNsACZAACZAACZAACZAACZCAxQhQQCyGmgWRAAmQAAmQAAmQAAmQAAlQQNgGSIAESIAESIAESIAESIAELEaAAmIx1CyIBEiABEiABEiABEiABEiAAsI2QAIkQAIkQAIkQAIkQAIkYDECFBCLoWZBJEACJEACJEACJEACJEACFBC2ARIgARIgARIgARIgARIgAYsRoIBYDDULIgESIAESIAESIAESIAESoICwDZAACZAACZAACZAACZAACViMQIQLSO7ybfHLhF4onD97sBexfttBHD5xCb9M7GWYLn+l9tiyZAxSJU9sMRjfY0HuH9/JLtvXR5TOxsNVls7LXZjOTZTO1lV2Hb72jqL8fO2dROlgYydKZ+v2XpTOM2EGUTobHy9ZOi8PWTr3j6J03rGTidIBvqJ0Np6y+wvp9Xp7isq1dfsgSudray9LZ+8gSvfEMYkonZuX7HlLGE1WPx3oVuoAACAASURBVFsbG1G5Xj6y+xbDR/icC+6bjbesjfq4xBZdA3xl1wDhOw2QsZPmJ217dh+eiq7XK04KUTpfBxdROumz6+sYXZTfZ09ZW47u81mUn/Sd4RU9gSg/W+Httfv4UpSfjYfsXerrGEOW34PLonS+nrLnyCtnRVF+0kQ2Efyul/6Wd0tcSlTF+b53RemYyPIEIlxArt96gJTJEiKai3OwV0MBsfzNNiqRAmJ8HyggxlwoIObaCwXEiIxElCkgxm2KAmLMhQJi5h1EATEEQwH5Ovqahr8Pvr7Sz0VfTl+27nccP3MZS6b198tv1LTlcHZ2woAujVCiVnfMm9gLP2ROCw8PT8xctAl7D5+Bp5cXKpUuiH6dGsLBwR6BBeTk+auYOGcNHjx+juyZ0+DSP7ewY+V4UQTk8dOXGD97Nc7+fR0uzo6oWKogBnZtjPb9pqJCyQKoW7WkruvuA6ewZut+/Dp3CG7ceYimXcehT4f6WLb+d3x2dUfWjKmRN0dGtG9aze/aqjUfhF4d6qNM0Ty4+M9NTJy7BvcePEWyJAkwrFdz5M4e8hdrxWfHvr/88nR180DPdnXRrklVrN6yDys27MXrt+/1tfZqXw/FC+WESjNj4Ub8ceQM3N09kD9XZozu3xpxYsXA4jW7ND9V5xKFc2FI96aIGSOa4TUd2TIr2HpTQCggioANIyCGDYEREOPngxEQAy7CiAojIMZtihEQM8LFCIghGEZAvl6xkNYs1BGQl6/foVz93tizdgqSJIwHdw9PlKzdA6vmDEbGtCkCCMiEOavx5PkrTBjUHspzOg+aoYWgaZ3yAQTk2Ys3qNZiEIb1bI6iBXPg/qNnaNlzIrYvHxeigHh5e6N2m+EoXSQ32jT+Cap+m3ceQb/ODUMUkJqthqJW5eJoUL00XJydcOveI8xZuhU7V07Q/P65fhcdB0zDoc0z8er1e9RqMxTTR3RBobxZcfD4BYyZuRJ7106Bk6Ps66fK88iJSxgxdRm2Lh2Dp89f6zqumjMESRLFw8UrN/HZ1Q1liuXFyKnL8fDpC4wd0AZ2trb4bc9xLVbnL/+nBeTn8T0RL05MjJmxEjY2Npg0tIMWkMDXpMQkuHpTQCggFBDzr0sKCAWEQ7DMvCM5BMsQDIdghS9yxSFY0u571E8XagFRl9xp4AwdKVBf8FVUYcWGPVi/YISmYYqAZM+UBvkrdcCOFeN1tEAdew6dxm97jmH+pD4BBGT5hj26Yz17THc/otI5IOf+/g89h8/B4c2zYGdnG+COSCIgp3b94neOitiUqtMTC6f21REcJVD2dnZaZlSn/+6Dp1oITIeKjowf1A45sqYTtYTnL9+iTtthmDqiMwrlyYrzl2+gTZ/JmDe+J/LnzgIH+y/zCby9fZCvYjtsXDRKS53/o03vyahYuiDqV/sy/vHpi9co36APzu9dhLsPn+qojv9rCqneFBAKCAWEAmIiwDkgRm1BOEmAERDDB4lzQMwJHOeAGJGhgIi6k99EojAJiBpSNXvJZuxaNVF/wS9bLC8a1CgTQECSJoqvZSRp4vh+oLy9vZEyWSKsnD04gICMm7UKTk6O6NuxQagFZOf+E1i5cS82LBgZ5IaEVkBUBiqiYGdnp4eTla7bE0unD0CGtMkxesZK7D5wEjGi/28in4pWTBrSQQ+ZCunw8fFF696TtLh1b1PHL/mi1TuxaecRPH/1Vv9teK8WOhqjyj7z+wJEcwk4Gbpq80Ho37khSvyYS+ehIks5yrTGvnVT8fGzaxABCaneFBAKCAWEAkIBCe4NTgExosNJ6MZthhEQM1yEC45QQELqTQb8u6eXN8bNXAV7ezsM7dksdCdbOXWYBMTT00sPuxrVrxUGT1iEgxtn6DkI6jBFQLJlTIN8ldrjj7VTkDB+nCCX6X8OyLzlv+H+4+eYOLh9qAXk7KXr6D3yZx0BsQ20nEWXwTNRJH92NKldXudrNAfEf7RApbl87Q46DZiOMQNaY/6K7X6RnQWrduDJs1cY2bdlmG7ZvBXbcOLsFSyfOShIpEZlqIaOjZ/9K9SQshkju+oIyObFo5E+TfIA5ekISKkCqF+9tP73kCIgIdWbAkIBoYBQQCggFJD/EZCtIkYBoYDo3w6ughWmPmFEnHTwzwu63/jm7Qc9neC7EBAFbuzMVdi1/4T+Eq/mH5gO/5PQ1TyGF6/f6gnh8ePG1nMU7j18iuoVigaIgFy5fgetek7CtBGdkDxJAuzcfxIqMrD714khzgFRw6ZqtBqqJ7i3blgZHz5+xqZdR3SUYdr8Dbj4zw2MHdBWl6smxKvVufxPQg8sIOo6qrccgs+fXdG2SVU0/P/Ijpoc36DDKIzo00JHPN69/wQ1cV4NpTINMTPXoNTwsu5D5+ghVUkTxfNL9tfZK3j45CXKl8iHGNFcMGHuGii5G9O/NQaNX6Qnpo/u1xrOzo7YvvdPlCycWw9VW/jrDsyb0Avx48YKMgck8BCskOpNAaGAUEAoIBQQCggFJPguIZfhNSNcFJCIcIlw5TFl3jo9H/u7ERA1Qbt+h5FYMr0/fsybzVBA1EpOc5dt0atgvX7zHimTJ0LL+pW0qQVeBWvFxr1YsmaXjg6or/uLV+/SE7Ul+4CouRkT567GhSs34ezkiMplCmnpefXmPfqMmod/rt9B9sxpkTNrOj3vIiQBUSt9zV66BWoFqVj/H9lRF6jmm8xctBHXbj7QE8/z5cyEEX1a6sngwR1dB8/C4RMXdYjMdCixqV2lBNTwM7V0sQryF8qbTQtO3Ngx8fGTK6Yt2ICDx8/rhlUg0CpY6347CFc341WwAktVcPWmgFBAKCAUEAoIBYQCQgEJSy+YEZCwUIvYc747ATl94RqGTFqsh1ipVZh4RE0CFBAKCAWEAkIBoYBQQCggYenFUEDCQi1iz/nuBKTv6F+QLnUydG5RI2JJBspNjW+7dfexYRmxY0XH9JFdIrX8kDJXE4A69p9mNlnBPFnRodn/9hUJKT9L/93NTbgTtbRiwpVgbITp4OMtKtlGuLM6hDtl2wjTiSqnFgsQ7kLsaydf0llStpSzjYdsF2KvmIkkxUo3U4b824VsXDp8ZLsuS9uLZCM9DUTYTj2cg86HMwLq6iW7Xk9vWbrYzgFXCDR3Ez1ljxuc/xfMDb49CG6wu/AaHIVbVks7ROLGJ9jNXUHwtZHtSm/jK4NsK9ybx8dJtpoSbGVtwMZd9i6QviM/OMQSvTOi2wmfXeEz7m3nKCrX1kb2DEG4ZZqNsH6+wu+2dh+ei65j6FnZb/nIMrJVO4VUxI/R9lR5Rddx6IWs/c15dliUn0OiNKJ0oUnU0Sbi85SUb25Txe9KQN6++4gy9XrpVbD8r3IlAcg0XxcBCojx/ZD+uErvJgXEDGfhj7DYaIQ//hQQ4/tBATHgQgExbCzSdyQFxPhZo4AYc4kKAtLZSgIyz/euIbTvSkCknS6m+/oJUEAoIIoAIyBm2oGw88kIiJl3HSMgQcAwAmLcVhgBMebCCIgxF2tGQLrYWicC8rMPBeTr71WzhmICFBAKCAXE/OPCIVjGbDgEKygXDsEybiuMgDACogh8S0OwulpJQOYGEhC1tcTYWSvh5uah1yJzcXbEiN4t9VYNUeEI0z4gUeHCWEcZAQoIBYQCQgExEeAQLIO2IIyCUUAoIPpdKhwGyiFYxu0lKgzB6m4lAZltJgIi6+19fakoIF/fPbFojSggFBAKCAWEAhLMa5cCYgiHc0DM/HZQQAzBfEsRkB52aS3aTzMVNsv7jlXKjaxCKSCRRTaK5EsBoYBQQCggFBAKiIkAV8Ey0xa4CpaxiAoXEvmWBKSnlQRkJgUkivSsWU0RAQoIBYQCQgGhgFBAKCAh/GRSQCgg/0+gt711IiDTvRgBEXVsmShqEKCAUEAoIBQQCggFhAJCAfFPgPuAmG8PfawkINMoIFGjY81ayghQQCggFBAKCAWEAkIBoYBQQGT9pn4Oss0cZbnJU03xvC1PHAVScg5IFLhJqoq5y7fFLxN6oXD+7BFaYzdX2a6jgGygp3SNe3jKdm218fIQXa+NtywdbGS7AUO6U7uQi3QjPe9YiUXXq9fcExw2Pp6CVICN23tROp9o8UXpxNvjCjmLNw6M4PbiK20vMip45xBXlNJHONzDQbg7uIu9rN1/9JTtRh3TXtYAbQT319dWtq26l3DZIHvpztaiO6FWNZLtXC69Dhvhu8/W7YOohj7R4ojS+do5iNJJ35G2wnfGC9/oonIT4qMoHYSLAvhEl72rInqpbdlFAOJ24PpWlOXi+06idC1yJxGlE76CIHwFoadLFlG5pRNGE6WreetPUTqnmLJ3riiz/0/U30oCMpkCEprbxLQRReD6rQdImSwhork4R1SWOh8KiBmcgo7TlzNlYkYBCR9nCogxPwpIUC4UEOO2QgEx5kIBMdNeZN8YvksBGeBonQjIJA9GQCK0A/ytZtZz+FwkTRwfD5+8wImzV9C/cyPUrFQMMxdtwt7DZ+Dp5YVKpQuiX6eGcHCw1xh+3bwPyzfswbv3H5E6RRK8evMOhzbN1H8rUas75k3shR8yp4XKO26cmHj4+AUuXPkPObKmw8g+rTBr8WYcOXERSRLFw+ShHZE985fdOi/+cxMT567BvQdPkSxJAgzr1Ry5s2eggATX+CgghnQYAQnfG4sRkKD8pJEDRkCM2x4jIGa4MAJiCIYRkPC9w9XZg6wkIBMoIOG/ed9DDkoSLl29id7t6+OHLGkRM0Y0LFq9E0+ev8KEQe3h6+uLzoNmoELJAmhapzz2HzuHCbNXY+aYbkiTIjF2HTiJBau2mxWQG3ceaqlJmyoJBoxbiPuPnqFH27oonC8blqzZjcfPXmLhlL549uINarUZiukjuqBQ3qw4ePwCxsxcib1rp8DJ0YEREHONkQJCAQHAIVjGDwiHYIVdpMRDbzgEy4xZeIm6EByCZYyJAiJqPsEmGmwlARlPAQn/zfseclACkjdHRjSvV1FfrhKO/JU6YMeK8ToKoY49h07jtz3HMH9SH3QdPAuF82dDk9rl9d+uXL+DbkNmmRUQ/3kv/HUHbt55hMnDOupzT56/iuGTl+KPdVOxeM0u3H3wFGMHtPHDXq35IIwf1E5HTjgEy0xrpIBQQCggZl/VFBAKCOeAhK8nIxZRzgExBG3NOSBDnNKH7+aH8exx7rfCeObXeRonoUfSfQksIK/evNfDqNSwLNPh7e2NlMkSYeXswajRagj6dKiPEj/mCrWArNy4F5eu3sK0EZ31uer/9xw+R8vL6BkrsfvAScSI7uJX7mdXN0wa0gHFC+WkgJi7/xQQCggFhAKiZnlxErphO6CAhK/zQAEx5hcVJqEPs5KAjKGAhO+h+17ODiwgPj6+yFepPf5YOwUJ4wddtaRFjwl6jkitysUjVEAWrNqBJ89eYWTfloboGQFhBEQR4CpYxu2AQ7CMuTACwggIBSR8vRkKSNQVkOHO1omAjHZjBCR8T913cnZgAVGXPXLqcrx4/RYDuzZG/LixoeZx3Hv4FNUrFMWStbt1pGLGqC7w9PTCojW7cOr8VdEQrOAiIA8eP0eDDqMwok8LHfF49/6THqJVKE9WPRSMAkIBoYCYfylRQCggjIAYtwEKSPg6MxSQqCsgI60kICMpIOF76L6Xs40ExNXNA3OXbdGrYL1+8x4pkydCy/qVdNTD3cMTo6evwL6jZ7WclCqSGweOndPzONQReBUs/3NAghMQde65v//DzEUbce3mAz3xPF/OTBjRpyXixYlJAeEQLE2AERBGQBQB7gMStB1QQCggmoBwKJ60j0MBiboCMsrlyyqilj5GuN60dJGRWh7ngEQq3rBnfuzUZajJ5avmDA57JoIzGQExA4lzQAzBcBlewUMVTBIuwxsUDpfhNdfB50aExi8hroJlxIUbERo/R5GxEeFoKwnIcApI+H6AebYxgRev3uLytTvImTUdPru6Y9jkJShVODdaNawcqcjcP76T5S/tkNvIdjX2tZXtzCyrnPqELytXuiFgRG8wCOG2skfzlhBdsvs7d1E6OwcZZzsnGb+CF2S7z3rLNtSGh49styt3L1mGHt6y/KTl+siKhacwYbYE/1sMIrgb6CnkIt0x3clO1g4cPj4Ttas3jl9W8gvpkNyP2M6ytvfWTbYjeTRhmxciFm+0JrlWxSueg+w6pBsH2ni4hnQb9N/fQ7aJ7fm8RUX5Fb98QpTOzktWv9nnX4ny++gmE5BBxVOI8oONbDPZl26yd4t0c9Dpx++J6jf8w1ZROrsavUTpfCF7F1x89lmU34q0eUXpZrpeE6WTUVa/0LKUzs6yd66ocv+faGw060RAhn5mBCQ094lphQTUXI32/abhybOXepPBSqULoVe7unB0dBDmELZkFBBz3GQ/SmKhoYAYgpaKAAXEuJ1SQIJyoYAYtxUKiJl3PQXEEAwFxHyfapyVBGQIBSRsHV2e9XUSoIBQQBQBRkDMdPAZATEEwwhIUCyMgBg/Q4yAGHNhBMSYiyyuYd0IyHgrCchgCsjX2ZFmrcJGgAJCAaGAmH92hCOrOATLDEJJp5xDsMx0xOxk0W8OwTLmxyFY5jr4HIIVtt7S/86aGD1jeLMI0/kDP90I03lf60mchP613hkL1YsCQgGhgFBATAQ4ByRoW7AVjsaUyJbKnXNAjJ83zgEx5sI5IMZcrDkHZJKVBGQABcRCPWMWYxECFBAKCAWEAkIBMd8GKCDGbDgJ3ZgLJ6Ebc/mWJqFPiWGdCEi/j4yAWKRjzEIsQ4ACQgGhgFBAKCAUEBMBroJl3Ba4CpYxl+9xFaypVhKQvhQQy3SMWYplCFBAKCAUEAoIBYQCQgEJ/jeXAkIBMRGYFjOTZTpogUrp8+E/q5QbWYVyDkhkkY0i+VJAKCAUEAoIBYQCQgGhgPgnwGV4zbeHGVYSkF4UkCjSs2Y1RQQoIBQQCggFhAJCAaGAUEAoIKJuE2ZaSUB6UkBCvkFFqnfB0ukDkCVDqpATfwUptu39E0vW7sb25eP8auPq5oEhExfh4j838fbdR6RLnQx9OzbAj/my+aVx9/DEwl93YOe+E3j6/DXqVSuFoT2bGV5Rp4EzULZYXtStWtLiV1yuQR9MHtoBeXMEDRt6PpXtrGnr/klUb993z0XpvB7eEqXzeP5YlO7+vnOidHEyJBOlc4oTQ5gupijd83OyXWDdhiwS5SfdxVm4/yEc7WVL/WRyuyOqHz69EaXzenZflM7ttiz0/P7eU1F+t3f/I0qXKEdCUTrn+LFF6f5sMkGU7tYL2fPWoZBst+c4wp3uvYQNy/nfg6Lr8HwccnuxcXAS5WWfq5Qone3Hl6J0Pp/ei9LZOMrq5/1K1vZ83WU7TN/duFNUv3RtWojS2ThFE6X7N1FBUbp0sR1F6TyFbcph5wxRfu/+eyBKF6+fLD8bX9nO9Di5WVTuhyuXRek+PZG100SFZTuN21RoLyp3WypZfodeyNppizvnReXmSixrf6LMAOkG9nBxdpZmKU43K5Z1hmD1eC/7HRRfiJUTRsoQrKgiIM9fvkWLHuPx5t1HJEoQN4CAKOmYv2o7alYqhoTx42Dr78ewYNV2HNo0EzGiu+jb1nXwLHh5e6Fr69pIkSQh3Dw8kCRhPMNbSgEJiIUCYvzkU0DMcKGAGIKhgATFQgExfoYoIGa4UEAMwVBAzPfO51hJQLpRQL7cFA8PT4yfvRoHjp+Dh6cXsmVKjTH92yBF0oRQAtK+STX8fvAUbt9/jKIFcugv8I6ODjqiMGj8Qjx98QYuTo4onD87xvRvjWguzrhx5yGadh2HPh3qY9n63/HZ1R1HtszS+TWuWQ4H/zyPR09fonTRPBjVtxWcHL9s1LR511EsWbtLRypyZc+g/5YoQRyx2x3+6yKmL9wYQEACn+zl7Y1cZdtg06JRyJoxNU6eu4qR05brc9R1BT5UPUdMXYaLV24gaaL4cHVzR8fmNUQRkJ7D5yJp4vh4+OQFTpy9gv6dG+H8lRs4evKSZpIyaUJ0b1sH5Uvk18Wq9HHjxMSTZy9x7u8bSJsqCaYO74xUyRPpv/uPgKg8m3UbhwFdGqNS6YJgBMS4mTACYsyFERBjLoyAGHNhBCQoF0ZAjNsKIyDGXBgBMSOOsqB9pERA5sbOLO5fRmTCru+uR2R2Vs8rzBGQFRv34uiJS5gyvBPs7GyhOvHZM6VBhrTJtTDkyJIOnVrUQPRozug8aCY6Na+O2lVK4MWrt3j15r3uHHt4eGHsrFV6eFPnFjW0gNRsNRS1KhdHg+ql4eLs5JdfoTxZ0brRT3B0sEefUfNQp0oJtGpYGQeOnce0BeuxYHIf3WmfsWAjHjx5jtljuovhSgTk76u30KrXJC1EKgIy6ee1OHvpOmxtbHS9VQSlV/t6qFiqAHx8fFGv/QioOrdsUBkfP7ui3+hf0KhmWbGAXLp6E73b18cPWdIiZoxoWryUyMSOFR3/3riHdn2n4M9tc7X8KAFRdVDilil9SkyYs1qfM3Hwl5CsSUBSp0iiBa9Noyp+9aCAUEAUAQ7BMvPjzyFYhmA4BCsoFg7BMiOhHIJlCIZDsMRdNMOENlYUkHlWEpDOFJAvbWHBqh06wjFpaAdkSpcCNv5aQ+AhWCOnLkeMGC56DoWaN7FSycvJS3j89BU+fPqM4oVyYtqIzn4RkFO7fgnQ4ALnt2brARw4dg5LpvdHh/7TUKXsj6hRsag+R8lNhYZ9cW7vQnHrDklAPn12Q5MuY1GlbCG0b1pN59tj2ByoqMjAro2ROEFc7Dt2DkMnLcHaecPg4+OD9v2m4fCWmbC3s9PpQzMESwlF3hwZ0bxeRb9rUJGj9dsOQYmJqs/L1++wY+UEpEuVVAuI//S7DpzEyg17sX7BCD8BGdG7BWYt3oyfyv6oxc10UEAoIBQQ868KzgExZkMBoYBwDojxs8E5IMZcvqU5IL/EsU4EpNNbRkB06/r4yVVHAdQQLPXFv1zxfBjcvSmiuTjpCIj/SehT5q3TnfVB3ZroYUk3bj/EsF7NkTFdCt2pPnPxGmaO7ioWkD+OnNXzMTYvHo1qzQfh/cfPcHCw92v1Hz5+xsGNM3T0RXIEJyCqs99xwHSkTpFYDxUziZbq9GdIkxxdW9fyK6JR5zE6ApIscQIsWbPLTwDCKyAPHj9HrdZDdYSlarkiOgqiGK+YNQgZ06YIIiDqemYv2YwtS8b4CYivj6+OxOxYMSHA8DQKCAWEAkIBMRHgJPSgbYGT0I2fDwoIBUQR+B4noc+3koB0pIAEfehu3XuM7kNn6yFGTeuUD1ZAKjfpr0VFRT3UsXrL/lALyNJ1u3Hpn1uYNaYb2vSZrId2qS/7YT3MCYiKMij5UNEFJU/+ozzT5m/A/UfPdB1MR/0OI9G4VjkkT5IAA8ctxIGN0/3+Fp4IiFpl69fNf2Dd/C8RDXWEVkDUfVERp3N/X8eqOYP1nBt1UEAoIBQQCggFxHwboIBQQDQBroJl2BC+RwFZGDdLWLub4Tqv/RvZaprhKsSCJ4d5DogSBzWPI1/OzPD08tJzEprVqYBqFYoEKyDt+k5FimQJ0aVlTVy/9QBjZ65E5vSpQoyAfJlfURC37z1GrxFzMbpfay0xarjR3KVbMWlIez3/Qc2VOH76Mlr4G74UEk8jAXn89CVa9pyoV8Fq2aCSXxZqSJWad3HzziPUbT9Cz7MoUzQP9h87j7GzVuoIg4q8lKvfB22b/ITSRfJowZq+YAN6d6gvngPif0iVGn6lhpqpIWfxYsfEr5v3Qc3B+W3ZWHEERC0CkDt7RnQbOgve3t74eXwvPXeHAkIBoYBQQCggFBATAS7Da6YtUEAoIP9PYJGVBKQdBeTLHdh7+DTmr9wONTwoejQXVK9QVA8RsrW1CVZAVMe935hfcO/hM+TKnh4pkyXC+w+fQxSQ9KmT4drNB4gVIxraNP4JjWuV9XsYNu08gpWb/sDDx88RL24svTrUgC6NQvIOPHn+GnXaDoOXl7depUpN3FbXoeZ1qMnt3YfNDpJH/WqlMKJPS/3vx05dxpRf1uHx0xfIlC4lBvdoih8yp9V/O3XhX4yevgKv37xHqSJ5dLRETa6X7ANiNAdECcza3w4iRnRn1KtaSl+vimRIh2CZ9gFRq2ipVbByZk2nr4MCQgGhgFBAKCAUEApICF0GCggF5P8JLLaSgLSlgITYr4/wBFFlX5EIv3ALZEgBoYBQQCggFBAKCAWEAuKfAPcBMd8elsazzhCs1q85BMsC3eKARYRFQNTeILsPnDRb17ED2yJpIuNNAyPzAr+2enk9+ld0ubbuH0XpvF88FKXzvCfb0fPDPdlO6Nc2nhGVmzSfbCd0F+E+Ms7xY4nKvX9Qtjtu9g07RPn5ilIBwpUKYePtIcrR7u0jUTpbtw+idN6vZbtHewl21FYFuj2V5ffg4EVR/RLkSCNKJ20H6/N0EuV3+eE7UbqhZTOI0sVz+bIaX0iHdBK6yz3Z8+b1PORdq30+vAmpWvrvdkXrydK9k7VRG+GO5LAPus+TUUV83r8W1c/zrqwTcXm+7F2Qa2ArUbkOKdKL0rmnlO2UDeFLyNtXltDx3DZR/TyEvx32dfqK8rPx9RGls72yX5TO9eoFUToIuby/I/sNTDB4rqjcni6yznPphLKdy6vfk+2ELv4xkjUX8Y9bZOyEvsxKAtKKAiJq4xGaKCwCEqEV+IYzo4AY31wKiDEXCogxFwqIMRcKSFAuFBDjtkIBMeZCATHTARN+XYsMAVkRP6tVeoUtXsk+GFulcmEoNMyT0MNQFk/5CglQQCggigAjIMbtgBEQM88HIyBBwDACYtxWGAEx88PPCIgxmCgQAVlpJQFpTgH5CnvRrFKYCVBAKCAUEPOPDwWEAsIhWOY60LKfHQoIBUQTEEYspEP7pPlFRgRkVQLrRECavWQE4GCbAAAAIABJREFURPbWYaooQYACQgGhgFBATAQ4B8SgLXAOSLi+VFNAKCDfmoCstpKANKGARIl+NSspJEABoYBQQCggFJBgXpgUEAoIAE5CN24G3+Mk9DUJswl7WBGbrPGLqxGboZVz4xwQK98AaxdPAaGAUEAoIBQQCoiJAFfBMm4LFBAKiInAWisJSCMKiLW7zCw/IglQQCggFBAKCAWEAkIBCf6XlQJCATERWG8lAWlAAYnI7i/zsjYBCggFhAJCAaGAUEAoIBQQ/wS4D4j59rAhkXWGYNV/ziFY1u4zs/wIJEABoYBQQCggFBAKCAWEAkIBkXWuNlpJQOpRQGQ36HtOVbpuT8wZ1wM/ZE6rMazfdhCHT1zCLxN76f8O/HcJq2cv3mDW4k04dupvvPvwCZOHdkSl0gX1qcvX78HWPcfw4NFzODs5omTh3BjasxmiR3MOkvWV63fQbcgsHNo0U//N1c1NUjx8hGuW2wjXxrMVrrVn4+Uuqp/tp5eidLCT7WrsayvbOdpGykV4He+iy3Zq9/SRLZZuZyNb+1CWCojmYCvi7Cu8v0J8EF4G7KS7Gru+FV0HbO1l6YSpPjvEEqV085btzhzTUXY/7IXt772vo6h+LvbSFhNydg4+HiEnAuBt5yRKJ31XyZ4gSDeshq0QifSZtP/wTHS9njETi9JJV6Ny85KRcbKTXbCjjbeoftJ1Wm28ZL9ZvvZBf/+MKmLjK6ufp43st8NW+LKy8/ws4yL8LeoRM5cov5mu10TpxImE79zll56LsrzzSsZlbMIbovwcCtYQpQtNos2Js4cmeYSlrfPsnwjL62vIiJPQI+EuRLSAKOGo03Y4KpYqgHpVSyFWzOi6QxY3dkxd+62/H0OGNMmRMlkivHrzDj2Gz0XtKsXRumGVIFdHAZH9iFBAjB8MCkj4XhgUkKD8KCDGbYoCYsyFAmLMhQJizCUyBGSLlQSkNgUk9D/Aj5++xPjZq3H27+twcXZExVIFMbBrY3z85IoJc1bj0F8X4OLkhPrVS6Ndk6qwtbXB6i37cfivi0ifJhl27juBwvmzoX3TamjadRz6dKiPZet/x2dXdxzZMivYCj16+hKjp6/AhSs3dHQgf64smD6yM27ceYjGnceiTaMq2Lz7KNzdPdCifiX936qT3rrXJBzdOlufo47dB05hydpd2Lx4dLDlDZu8FFt2H4WTo4O+jk4taiJGNGe/CIjR31WZwR2zl2yGuo5JQzoEm87b2we37z9Gz+FzMbx3CxTK82WznJUb92LFhr348OkzMqdPhYdPnjMCEkIzpoBQQDQBRkAMGwIjIEGxMAJi/M5gBMSYCyMgxlyiQgTktyTWiYDUfMoISKgMxMvbG7XbDEfpIrnRpvFPePn6HTbvPIJ+nRtiyMTF+OzqhpF9W+H9h0/oNmQ2mtYpj7pVS2oBmTp/PTq3qIFSRXJrEXBz90DNVkNRq3JxNKheGi7OTsiQNnmw9ek6eJZO06FZdbx9/1FHC1SeSkBqtxmmpeancoXx8PFz3XFfOWewHjpVo9UQLUNVyxXW+bfvN1UPbWpSu1yI1x/RERAV/UgYPzbuPXyGpy/eIGuGVJpZpnQpAtQle6mWcLC3w7BeLVDnpxL6b/uPncP42b9i6vBOSJMyKfYePo2Fv+6ggFBAAhCQDabgEKwQH/4QEjACEhQQIyDGjYYREGMujIAYc2EExJhLZERAtllJQGpQQEL3E3zu7//Qc/gcHN48C3Z2/xuv7OPji7wV2uK3ZeOQJmUSnemOP/7Chh2HsGrOEC0gJ8/9o+dSmA4lDSoCcmrXL+JKtOkzGfHjxELvjvWRJGG8YPPqNWKujhB0bF4dy9b9jr/O/oNFU/vi+cu3qNykPw5unIHYsaKHWHZEC0iRal3QuFY5NKlTDo4ODpi7bCv+OHwGv6+eBEfH/w0pUkxv3XuEzoNmol+nhqhQMj+6DJ6Jwvmya7FTB4dgcQiWUQOmgJh5rBkBMQTDCEhQLIyAGD9DjIAYc2EExJhLVIiAbLeSgFSngITY/w6QYOf+E3oI0IYFIwP8u4qElKzdA2f3LNTDstRx5uI1HRX5Y93UCBOQW/ceY8q8tTh94RrixYmJhjXLom3jn3QEJLDMjJu1Cvb29hjQpZGO1JSr3xt7107F9j/+xLWb9zFtRGfRxUe4gFTvghmjuvoNqXJ180CByh2wYcEIZMuUJkidpi/YgIdPXuqhZiqSo4aslfjxywQ1CggFhAIC2HISuuG7jJPQg2KRLpRAAaGAKAKchG7cDr6lSeg7kv0g6gtGdKJqj69EdJZWzS/SJ6GfvXQdvUf+rCMgak6E6TBFQLYuHYu0qZLqf46MCIipPDUUTNWlQ79p2LBwpK5LYAHpOGA6ihfKgSa1v0QLOg2cgXw5M+G3PccxqFsTFC0ga3RKXJQw5MiaTucTeBWswH8PqQU07DgK1SoU8auXmvuiBGTfuqlIliRBkNNHz1gJNzd3jB/UDi17TkT1CkVQu8qXIVkUEAoIBYQCYu6dQwGhgHAVLOOng6tgmXlrfIerYO1MniOkbluk/L3qo8uRkq+1Mo10AfHw8ESNVkP1krGtG1bGh4+fsWnXEXRvU0dHO9RE9NH9WxvOAYmIIVjT5m9A5TIFkSl9Sr1MbYOOo/Db0rH45OqGBh1G6TkfavUotbzt2JmrsHPlBCSIF1vfj72Hz2Dk1GWI5uKMfeunBRCo4G6YEptiBXOgWd0KcPfwxL4jZwIswxv47yoyE9yxYcdh/LxsKxZM7oNUyRPr5Xiv/ncPq+YMhpp43nPEXD3EKn3qZDh/+QYGT1ioBah4oZx6KNm2vX9iwuB28PLyxqI1O3H539ucAxLCE8dJ6MaAuApW+F7VnAMSlB/ngBi3Kc4BMebCOSDGXDgHxJhLZMwB2ZnCSgLykAIS6l/guw+eYuLc1bhw5aaeTF65TCG/VbDUBOnDJy7qf69frbSeFG5aBSsiBEStIKVW0Xr15j0SJ4yLzi1qomr5wnoIVr32I/WE86v/3UXqFIkxpEcz5M+V2e/6PD299DCxRrXKolvr2uLrPnn+KoZOWqKHcanVvlTcx/8+IIH/3rBGmRDzXrpuN37dvA+fPrvpSMzg7k21KPn6+kKtrHX6wr948fodUiRJgHZNq6J6haI6TyWAKiKy7+hZJE4YD2WL5cVve45RQCggAQhwDoiZBsE5IIZgOAckKBYOwTJ+hjgHxJgL54AYc4kKc0B2pcoZYp8tMhL8dP/vyMjWanlGegTEalcWQsGSCe1qha5SdXrqpXdVlORbPLgRofFdZQSEERBNgAJCAZHty8eNCM38QFJAKCCKwLc0B2R3atmmjxHdZ6xy71JEZ2nV/KK0gKj5DDMWbDQLUA2BUkv4Gh0SAdmw/RB+P3QKy2YM9MtCRWxu3X1smKdaIWv6yC6huqHhuYZQFWQmsffVI6JsvF89EaVzv/2vKN2ba/dF6T4+lu1w/vbuO1F+0kQxEoe82pnKK2aqoHNwjMpwf/NBVHT6Tm1E6Xw+yHby9n77QpTfx1v3ROkS1G4mSufzXnbfvJ7cFeXn/uiBKJ3b6/eidK4vZPxs/a0yF1zGMVIkFJU7K10rUbqYLrK5SjmTBD9801RYhnguonJdhbtgZ7y1V5Sf19OQn/OP92T31qfNOFGZCe6dEKXz+fBGlM7GSbajtvSZfH7wsKjc61tknY3cHUqJ8otdoIgoHfytVhncCT7ZQo7cq/PdhTuIR793SlQ/KWfPnJVE+Xn6yAzT6ehKUX7vrsj2aohfpqIov675ZX2KWR9k7eXF5D6icuPnl33l9/ks+21zKlFXVK6vnezdZ/P4uig/+zyVRelCk2h3GisJyF3ZPQ7NtVgzbZQWkPCAkwhI3XYj0KJeRT0B/Fs9KCDGd5YCYsyFAmKmvVBADMFQQIJioYAYP0MUEGMuFBBjLtYUkN/TGX/Yjux+YuXbFyO7CIvm/90KiEUpf8WFUUAoIIoAIyDG7YAREGMujIAE5SL9Mk8BoYAoAoyAGLeDqBAB2ZPeOgJS6RYF5CvuTrNqoSVAAaGAUEDMPzUUEAoIh2AZtwEOwTLmwiFYxly+pSFYezLkCW1XK0LSV7p5IULy+VoyYQTka7kTVqoHBYQCQgGhgJgIcA5I0LZAAaGAKAKcA2KmHXyHc0D2ZsprlR5bxf/OW6XcyCqUAhJZZKNIvhQQCggFhAJCATHfBiggFBAKiPnn43uchP5HZusISIXrFJAo0rVmNSUEKCAUEAoIBYQCQgHxI8BVsAwbAyMgjICYCPyRJZ+kexXhaSpcOxfheVozQ0ZArEn/KyibAkIBoYBQQCggFBAKSPA/yBQQCoiJwL5s+a3Seyt/9axVyo2sQikgkUU2iuRLAaGAUEAoIBQQCggFhALinwD3ATHfHvZnt46AlPuHAhJFutaspoSA1+X9kmTweSvbWM7z8W1Rfh/vPxWl83j3SZTuw4PnonQeHz1F6exd7EXp4qRLIkrnGEu2sWEtrxqi/GztbETpnJxlmzqljB9NlN/8hLJlAD2fPxTl9+7WI1G693dlG2F+fukqy++hbPMsb3cvUX6O0R1F6R4tNL9xqv8MojnYifJLJCw3RSxZ/T56+ojKTbB6hCjdm/9C3ogwZsrEorzidxwqSue5b5kondtL2WaU9tFkGxF6fpS1Pa9PsnR39l0RXUeWBrJ9qnw8ZW25yhvZBnkH+hQV1c/DW7bR3/70BUT53frkIUrX7cXfonTC6sF1bn9Zfu6y+o0ZIdvMc+7Zn2XlZiwsSue+eaYoneTZVRnNKybjMqZIfFG5Pk6y30q7z7Ln1yFBClG5oUm0/wdZWw1NnpK05a6ckSSLMmmiXASk08AZKFssL+pWLYlFq3fiyIlL+HXukGCBl67bE3PG9cAPmdOKbsyxU5fRccC0AGkdHOxxcd9i/W9zlm7B7gOn8PTFaySMFxvN61VE0zrlRXlLExWp3gVLpw9Algypgpxy6eotNO48BpcOLIG9XfAdldVb9uPkuX/09RsdFBDjO0IBMeZCATHmQgEx5iLpxFBAjNlRQIy5UECMuXhTQAzBRIaAHMhhHQEpe5kCIu1DR0o6/wLy6s17fPrsilTJg/+CFhYBGTNjBTYtHu13Dep7c8wYX74ST52/HiUK5UL6NMlw9b+76DFsDuZN7IUf82aLsGsOTkBc3Txw7+FTQzkJXAEKSEAijIAYN1FGQMz8qDMCYgiGEZCgWBgBMX6GGAEx5sIIiDGXqBABOZirYIT19UKTUZlLp0OT/KtP+9VHQB49fYkRU5fh4pUbSJooPlzd3NGxeQ0dAVm/7SAOn7iEXyb2goeHJ8bPXo0Dx8/Bw9ML2TKlxpj+bbBg1Q5s2X0UTo4OsLW1QacWNdGmUZVgb4yKgIybtQp71kwW3cBm3cajXIl8aFGvIso16IOx/dvgx3zZcPPOI9RpOxzHts1BrBjRsGH7IRw79bfZaIT/wpSAtG9SDb8fPIXb9x+jaIEcmDy0AxwdHXD7/hPUbz8CZ/cs1Kc8fvoSo6avwLm/ryNenFj6+ru2qqUZKQE5ePy8liWVl+IwvHcLlPgxlz6XERDjW8wIiDEXRkCMuTACYsyFEZCgXDgEy7itcAiWMRcOwTLmYs0hWAdzFxL1DSM6UZmLpyI6S6vm91ULiI+PL+q1H4FCebKiZYPK+PjZFf1G/4JGNcsGEZAVG/fi6IlLmDK8E+zsbHH4r4vInikNMqRNjrBEQLoMnoG4sWNqcSiYJyt6tKur/3/gQ0UjytbvhWnDO6Nw/uwYNH4RUqdIjI7Nq2Pxml1YsGo7RvRuiarlC2PY5KVaBFrWrxTiTVcCkiNLOnRqUQPRozmj86CZ6NS8OmpXKRFAQEyMiuT/QYvVuw+f0Hvkz36MlIDMXrIZPdrWRfFCObBz/wls2nEEBzZOp4AEcxcoIBQQRYBzQIzbASMgQbkwAmLcVhgBMebCCIgxl6gQATmUxzoCUvoCBSTEznNEJVDDm9r3m4bDW2b6zXXwPwTLfwRERTrUF/5JQzsgU7oUsLH53yTd0ArIm3cf8OzFG8SOFQNPn7/CtPkbkDB+bMwY1TXIpQ2ZuBjPX77Fwil9dJkq2vLHkbOYP6k3mnYdpyMjl/65qc+t1XooxgxoI5qLEngI1sipyxEjhgv6dmwQQED+vXEP7fpOxZEts7R4qcM/o8BDsF68eotSdXrq6ImLsyMjIGYaKwWEAkIBMf8mp4BQQDgJ3fj58OYkdEMw39Ik9MP5foyobm6o8il17mSo0n/tib/qCIjqyC9ZswvrF/xvxRVzAvLxkysm/bxWD8FSUYFyxfNhcPemiObiFOoISOCbduHKDbToMQGX9i8JIDaqvNMX/sXymQP95oc8ePwcDTqMwq5fJ6Jtnyn4de5QVGjYBztXTUSlRv1wfNtcP1EIrnEEFpAp89bBy9sbg7o1CSAgITEKLCCfXd1QoHJHnNg5T0d0OATL+C5QQCggFBAKiCLAVbCM2wEFhAKiCHyPq2Adzi9bcSyiBaDU2RMRnaVV8/uqBeTMxWsYOG6h33ChwF/3/UdA/FO8de8xug+drYchqdWpytXvrSMQObKmCxPsP89cwYCxC3B82xx9vhKBEVOW4f6jZ5g3oZeffJgyL1uvN6pVKKJFo1vr2ug6eJYeCqaiFQsm9xHVQSogpy9cw+CJi7B//f9W7QouAkIB4TK8Rg2Qk9DNdSZkS5dyDogxP84BCcqFc0CM2wrngBhz4RwQYy7WnANypIB1BKTkGQqIqAMdEYnc3D1Qrn4ftG3yE0oXyQMlJNMXbEDvDvWDzAFRX/pTJU+EfDkzw9PLC+36TkGzOhW0CKihUMUK5kCzuhXg7uGJeHFiBlu9JWt3I0XSBMiVPQPevvuIoZOWIF/OTDr6oOSj44DpejL32AFt9P+qw8bGVg9pUseAcQtw4Ng5rJw9GNkypcHW34/pSe0dmlVHuyZVRWikAqLmoJRr0BvdW9dGmWJ5ce7v/zB+9q/o3qaO3yR0/8vwUkAoIBQQ4D33ATF8D3EfkKBYGAFhBEQR4D4gxu3ge4yAHC0k23tH1NkLRaISp/4KReqvP+lXHQFR+E5d+Bejp6/A6zfvUapIHh11qFW5eBAB2Xv4NOav3A41BCp6NBdUr1AUvdrX0ytfnTx/VUvEy9fvMLBrYzSsUSbYO6OEYfmGPXj4+IWOblQoWUDnpQTj/cfPKFy1c5Dz06RMgl2rJup/37TzCH5Zsc0vcqPmlJSo1R0rZg1G3hwZRa1CKiAqs5PnrmL0jBVQyxIXyZ8dT569QqNa5VCjYlG9ChYF5H/IuQyvcfNjBMSYCyehG3PhHJCgXDgJ3bitcBK6MRdOQjfmEhUmoR/90UoCcpICIupAM5H1CDTsNBo929UV7UvifeecqKK+72Q7oXvc+UeU38szl0XpHp++I0qXKEcyUTqnODFk6eIGHyUzZRItmWwndNensp3an9UdJqqfg61sJ3QXe1k6Z/svCxiEdMS5czykJPrv3i8fi9K53v5PlO7ZmWuidI/PyHZWT5o3qSg/5/ixROlc4scWpeuYoKko3dTqsj2FZHtMA852snbwxs1bVL8Mp5aK0r27fivkdL6yq4jXfnDIeakUV4Vt9P0rUX62zkFXPzQ60fPxXVF+H+7L3gXPL8refemqyVbkcUgg23H+Zp7GoutIHvNL9D+kw0XY9l5P7RVSVvrvnp/dROkSj5gvSuctbH/X6lcX5bdo5w1RumGjZDvO27s4ifKL2VW2bYDX+gmi/DzefxKl824xSpQujp1sOCtsgt9c2VSY3buHonLtk2URpQtNomOFi4YmeYSlLX7izwjL62vI6KuPgEQ0pCvX72DGgo1ms1XDtEoVyR3RxQbIb/Ouo9h9wPxqBmMHtkXSRPHEdVC7wSdNHB+JE8TFsdN/Q01Y/331ZD0BP6SDAmJMyIkCYgiGAmLcXiggxlwoIEG5UECM2woFxJgLBcSYizUF5HjRYiF1rSLl78X+lH1ciZTCIyHT705AIoGh1bNUywRv2nlYb0CYMW1yDOzWBLmzZxDViwJCAVEEGAExbgeMgBhzYQQkKBdGQMzIOSMghmAYATHTRYkCEZDjxawkIMcpIKKOLRNFDQIUEAoIBcT8s0oBoYBwCJZxG+AQLGMuHIJlzOVbGoL1Z/HiVungFT12zCrlRlahjIBEFtkoki8FhAJCAaGAmAhwDkjQtkABoYAoApwDYtwOvsc5IH+VtI6AFDlCAYkiXWtWU0KAAkIBoYBQQCgg5tsABYQCQgEx/3x8lwJSqoSkexXhaYocPhrheVozQ0ZArEn/KyibAkIBoYBQQCggFBATAa6CZdwWGAFhBMRE4ETpklbpvRU+dMQq5UZWoRSQyCIbRfKlgFBAKCAUEAoIBYQCEvyPNgWEAmIicLKsdQTkxwMUkCjStWY1JQQoIBQQCggFhAJCAaGAUED8E+A+IObbw8lypSTdqwhP8+P+wxGepzUzZATEmvS/grIpIBQQCggFhAJCAaGAUEAoILJO2anypWUJIzhVoX2HIjhH62b3VQpIkepdsHT6AGTJkMq6dL6i0p+9eINZizfh2Km/8e7DJ0we2hGVShfUNVy+fg+27jmGB4+ew9nJESUL58bQns0QPZpzkCtQGzF2GzILhzbN1H9z3TFXdJUfb90WpXvz7z1ROo+Pst1sXRLIdqJO8mN2Ubl28WQ7l9vFTSjKzyalbMdqW9e3ovzOOcj2b4njZC/Kz1m4E7qTcK1+562TROW+uXZflO719SeidF5usl10oyeS7VqdpGBWUbnOSRKJ0tnFlaU7mbqKKL/cSaKL0glvG/59KXveYjnLdiH2HdRcVL9X/4W823jsVLJnPNPPy0Vlvpg1VJTu05OXonQuCeOK0rm/eS9K9/qGrNyUJWQ7OL/4W7YDu3M82bPxcsAC0XVkiuciShfNwVaU7mbLWqJ00RLK2kvCSbL24u7lIyp3eBzZb0y7qhlF+SUvJru/cXL+IMrPq6TsmXS6sleUn8/Hd6J0L/LUEaVL6OAtSudr5yBKZ/fptSidQ4IUonShSXS6onUEpOBeCkho7lOY0lJAAmJTwlGn7XBULFUA9aqWQqyY0WFjA8SNHVMn3Pr7MWRIkxwpkyXCqzfv0GP4XNSuUhytGwbt7FBAKCBGDyUFxPhVRQEx5kIBCcqFAmLcViggxlwoIGbeLVFBQCqVCVPfNrwnFdxzMLxZfFXnWy0CcuTEJUxfuAGPn75CtkypMbx3C6RPnUzDUQLSrG4F7DtyFo+evkS54vkwoncL/bdSdXri5wk9keeHL18ZXrx6iwqN+uHgxul+HXIjwk+evUK1FoP8/uTl/eWrx8V9i3UZo6evwIUrN3QEIX+uLJg+srP++5mL1zBt/nrcvPsISRLFR9vGP6FmpWK4++CpPufytTtImjg+erarizJF8+hzeg6fq//t4ZMXOHH2Cvp3boT61Utj866jWLJ2F96++4hc2TNgVN9WSJQgTogNYvaSzbqOk4Z0CDatt7cPbt9/rMtXPAvl+fKVd+XGvVixYS8+fPqMzOlT4eGT54yAhECdERAzHXJGQAzBMAJi3F4YAQnKhREQ47bCCIgxF0ZAjLlYMwJyprJ1BKTA7xSQEDvMISW4/+gZ6rYbgdljuiP3DxmwedcRrNz4B3aunAAHB3stIKrz3LrRT3BydECfkT+jTtWSaFm/EsbMWAkfX18/IVHDj5Q4zBrTLaRi/cmHN5p3G49SRXKjfdNq6Dp4FjKkTY4Ozarj7fuPOqLQuUUNLRC1Wg/D2AFtUKxgDly/dR9//3sbTWqXR/UWg1GvWkk0qlkOV67dRvehs7F63jCkS5VUC8ClqzfRu319/JAlLWLGiIZL/9zCtAXrsWByHy0nMxZsxIMnzzWDkA4V/UgYPzbuPXyGpy/eIGuGVBjZtxUypQsYWsxeqiUc7O0wrFcL1PnpyzrV+4+dw/jZv2Lq8E5IkzIp9h4+jYW/7qCAUEACEGAExIxwcQiWIRhGQIJiYQTE+BliBMSYCyMgxlyiwhCsM1XKhtRti5S/F9h9IFLytVamVomAzF+5HbfuPcKUYZ38rrtyk/4Y0bslfsyXTQuI/zkga7YewIHj57BkWn8dcejQbyqObJmlZaV2m2Ho3qaOlgnpMXPRJlz+9zYWTe0HW1sbtOkzGfHjxELvjvWRJGE8v2x+WbkN128+wMzRXQNkff7yf+g9ch4ObZoBGzUWCsCwyUu1JKi6KAHJmyMjmter6Hdeh/7TUKXsj6hRsaj+t1dv3qNCw74493/snXV4VEcXxt/YxgmEJCRAgnuB4gWKFWspbsXdKRDcinuB4A7BaXCKu9uHFCheXIN73L5nLiQQdjZ7NtnlRs79p0/JuWdm3ztzd3575szZNV9vt0vV6IomdSqhab1K0FhZYebijdh98DR2rJwAjebzfsnIyChF1y4Dp6Jv50aoUq4oug6aipJF8qFZvcpKO7wFi7dgyQYcAwgDiFCAc0C0xwHngMjnBueAyHXhHBC5LskpB+RM9Up6122mMCi6da8p3KrmUxUAGeGzVEmQ7tPpt5gP3sp7POr8UkZZoH8NILsPncG85ZuxfuFIxb5mq8Ho3rYuMmVMh3a9J2LfWh9YWtCSJ0+evYJ+o+cqvlzTftz+dOveY0yc/RdOnbsG59SOaFS7orLVatikxXCwt1UW819eO/b/T0n8Xj1vWMw/z16yCY+fvlSiJTIAqdFiIN59CFSgKfp6/yEQ+9dOkSaLf9me0GPKiN9jtlQFBYei2C8dsWbeMOTNmVlr8PjMW4OH/i+UbWS1Wg9G744NUfaHggwgADgJXf6uYQBhAGEAkY8BBhAGEKEAJ6HLx0FKTEI/W0MdACmyhQEkwbQkIiAip0JsC4q+fm7SD8N7yyMgS9bsxLmLn7dHXqPaAAAgAElEQVRZ+fptx7lLN5E5ozuiEBULZOLqnIg6iO1Mo/q1RZkS+bVMwyMicObCdXTsOxlr5g/HvqP/4Oadh/AZ3jWWrYiA9Bw2CwfXTyVHQESUpW61svi14g8G69eo0wjUqFJK2folrsCgEAVA9vhNQnp3Fy1/I6csQ3BwCMYObA8BdjWrlFLaFhdHQDgCIhuADCAMIAwgDCBCAT4FSz4OGEAYQKIVOFvz41rsW19FNu/51k2atD1VIiAiB6Reu2GYNup3FM6fU5oD0rNDA1QtXxx37/uj1/BZSl5DuZIff8V/8eotqjbuq0QnfKf0j0lej0upqKgodOrvo+R6fB3RmDx3DX75qThyZvNUjrL9rdMIbPIdjZDQMDTsOBzjBnVQckAENIlcDpFQLnJARJ6FgAKRA9Ltj+lY9UUOyNdbsLbtO4mZvhsxYXAHpR2RVH701EW0/GKblq7+r9lyELMWb1TyR7wypFOO473y3z0snzEIIvHce9hMZYuVSOL/5+INDBo3X4mYlClRAIv9duDvXccwblB7hIdHYMGqrcr2Mz6GN+55xUnoOhbknIQuFYaT0OXjhZPQtXXhJHT5WOEkdLkunIQu10XNJPR/alcx6cJcl/PCm3ar0q6pGlUFQMSHEadgTZ63Bv5PXyjbiL4+BcvTw03JZxAJ3GI7VPSv/9FCdB4wBa/fvoffnKEkba7euKckvoskbeUM20/XwXVTsWzdLmzdc0LJy0jnmgZdWtZG9colFQsBCSJn5M59f7i7OSt9EVvFxP+PnLIUl8QpWG5p4d2hQaxTsL4GEOFr3dZDWLZuNx4+fgbnNKlQuWxR9O/amNR/EfVZsX4PAgKDUbrYdxjUvRlcnJ0gwErkn5w6dxXPX71FRncXtG9WHTWrfMw1CQ0Ng4iI7Dl8BulcnVHxx8LYtPMIA4ge1RlAGECEAnwMr3wccBK6ti6chC4fK5yELteFk9B1vFuSwDG85+qoAyCFNjKAkBbMbJQ0FOBChDp+XeFChFJhuBChrvHChQhlynAERFsVjoDI5xBHQOS6cARExztXxUKE5+p+PmDoW670Cm2gFZH8ln1KSFuqRUAS0mnZvSK3QRxtq+sSdUUMOSnL2P3T5U/tft9/+YH0UcOjokh2RDPYEqvj2hIreWuoJaFJnwKgHWkAmIcGkDzS1APMQLMMs3IwarvmX0QF43L8IpBWkZw6XkgfAoCdJa2aMrXyuxVxvJjhc7Q0rr6ag1ZNOTiC5s+C9nGJvQPsHl8gSR2SkXaa4KP3YSR/lE9LnbseQQ9IbT6wplU+jqRNNVKbwoiaRxVGbDit7ecDS+LqxDPinKQ8C9GOpyXtnfYsivYOSmNDe5u+D6PNIY057ZOsyPixLpe+68q7EH0myt9HvrlMsrPX0CYvsQA7qU1hZAPanIQZrX/UhqOI3x1mxMVBlDltvIhvS8plY2NDMTPI5nx9dQDk+3UMIAY9KDZO3AowgMifD/UVyAAi148BRK4LA4i2Lgwg8rHCACLXhQFErgsDiA5dTAAgFxr8rMrCruDanaq0a6pGk00ExFQCJXe/DCAMIEIBjoDIxwFHQOS6cAREWxeOgMjHCkdAdPxIQwv4kJcgDCDfEEAa/kJ+LsY0LLhmhzHdqe6LAUT1R6BuBxhAGEAYQHTPQQYQBhDqG5oBhAFEKMBbsHT8mJOMtmD920gdACngxwBCfR+zXRJQgAGEAYQBhAEkWgHOAYn/S5sBhAGEASSOd2kyApCLjavF/0WRgDvz/7U9AXcnvls5ApL4nsk37REDCAMIAwgDCANIwl+7DCAMIAwgKQRAmvya8BdGPDzkX7UtHncl3lsYQBLvs/kmPWMAYQBhAGEAYQBJ+OuWAYQBhAEkZQDIpWbqAMh3KxhAEv6mZg+JRgEGEAYQBhAGEAaQhL+SGUAYQBhAUgaAXG5ePeEvjHh4yLd8azzuSry3cAQk8T6bb9IzBhAGEAYQBhAGkIS/bhlAGEAYQFIIgLRQCUCWMYAk/E3NHhKNAgwgDCAMIAwgDCAJfyUzgDCAMICkDAC50qpGwl8Y8fCQd8mWeNyVeG9JURGQ3iNm47tcWdDaBEeo9R89D7mze8Xy/X3ldpgzridKFs2XoBGw6+ApLFi5DfcePoGNtQaVyhTBgG5NYa2xivEbFh6BMVOXw9LSAn94N9fZnqi83m3wNBxYN1WxuUushE79AA7ECud2RDtqu8a2IxbbhVkEsfossWprOLEKLLVuB7WyOognlDwJpB1eT6tRCzgQqwbbEiuhRxEryVOP16WOK+p4CY2gld+mFucjukMEsfo2sagxXgVFkKShfA5H4hiwiqRVrH4SQqsgbkEcpNTK5W72tHapY8Daglax+k0w7VlEEOe4mzVtjL4Ko/XPyZpW1jWS2D9a74C+9nlIYzRvKmuSXcvH50l2VBANJ85J6rvePIo2DkCd5MTvLFDbNafND6IspGchjOxsjV8J/WrrmuT2jWmYZ/FmY7pT3RcDiJEegQxArt96AM/0rgmeAH9t2gfn1I74Pl8OvHn3AX1GzEaV8sXQrU1dpff7j53D2Okr8PrNe9T5pQwDiBGeKXVByQAiF5u4tmMA0TFWKQt3cSsDiLaADCDyQcUAIteFAUTXFybxLZ4SAaRNLSOsMgx3kcf3b8NvSsR3JDkA8fXbjuNnLmPhpL4xso7wWapEBvp3bYy7D55gpM9SXLx2Bx7p0sK7fX38VLqQYmtIBMR76Ezl/of+z3HizCX069IYIsqwcNVWZaGfJrUjGlQvjy6tamPTzqMYOtFXqSYtIhDFC+XB7HE9UbZOd8we31OJunwICMK4GStx4Pg52Fpbo2HNCmjftDrMqSvdLwbRDN8NuH7zAWaO7RFraE2c7YeQ0DAtAFm2dheWrtmF9wGByJXNCw/9n3EERM+kpD4WBhAGEKEAdbxQf/1mANEeVxwBkc81joDIdeEIiI4vOY6AJHhJfq1t7QT7iI+D3Is2xee2RHtPkgOQF6/eolLDXtjtNxluLqkRFhaOcvV6YMnUgcji5YGaLQehQY1yaFy7Ei5du43uf0zHytlDkNXLw2AAuXDlJnp1aIjvcmeBo4Md3r77ACsrK6Xdl6/foUPfSRjRpzWKFswFWQTkSwAZPH4hAoOCMbxPa7x7H4Bug6ejWb3KqF+9nMGDo2O/ycibMzN6tKunF0D2HjmrREcmDe2MzJ4eENu55q/YwgDCABJbAeL2B96CJR84DCByXSggxVuw5NrxFiy5LrwFS8c7iBqJYAAxeM319Q3X2tdJsI/4OMi9YGN8bku09yQ5ABFKdurvgxKF8ij5FvuO/IO5yzdj7fzh+Ofif+g1fDYOrJsCs0+TbMifvnBN64TubesZDCCF8+dAiwZVYx7ek+evsGT1Tpw6dxWv377Hm3cBGNC1MX6r9VOcAJI3R2YUrtIOmxaPQWZPd8Xflt3HsWbLASyfMdigwbFxxxFMW7geGxaNUrZlfXnJIiBdB01FySL5FNgRF+eA0OSmLig5AiLXkxi85y1YOoYjZeEubuUtWNoC8hYs+aDiLVhyXXgLlq7vROJbnAo+ySgH5HqHj9vfv/WVa/6Gb92kSdtLkgAifsWfu2wzNvqOhtgqJbY8NalTETv2/08BhNXzhsWINnvJJjx++hKj+7dNEIBERkahRsuBKJw/J7q0rAV3N2f0HDYLxb7PjaZ1K8UJIO6uzihXtwfO7JwPWxuN0rfT569BREV2+00iP+BdB09j1JRlWDi5r5Lw/vUlA5BarQejd8eGKPtDQQYQstL0LTUMIAwgQgEqsPIWLO3xwhEQ+RziCIhcF46AyHXhJHS5LqZIQr/eMfbuEwOWFgkyzTVvfYLuT2w3J0kACQ0NQ/l63pg2qht+HzwNu/+aBKdU9koEREDBwfVTjR4Befr8NX5q0BNnd81X8k3EJeAnGkAGjl2A7FkyoG3jajHPOHoLVnQERACT2CYmLkMjIGs2H1AiPXMn9EbOrBml40gGIK28x6NmlVKoW60sA4gBs4+6oGQAYQBhANE9sSiRHAYQBhChAJ+CpQMsiFumGEC+HYD816m+AasJ45nmnLvOeM4SgackCSBCNxEJOHTiPArkzQ6f4V0UKUWSuMgBqfdrWTStW1nJAen2x3SsimcOyJdbsESuSamaXTG4R3P8WDy/cvKUWPCLJHcRARHboq7euIeJQzohKDhUyRP5OgdEJKKP7NfG4BwQEcXZuvcEZozuriTGR1+2NtYxoCX+TQYgi/124O9dxzBuUHuEh0dgwaqtuHj1NueA6Jl8DCBygTgHRNcigfY25wiItk4MIAwgDCC63x98DC/t3arLyhQRkBtdGiSsU/G8O8fstfG8M3HelmQBROQy/NZxhBIRKFMif4y6d+77Y+SUpbgkTsFySwvvDg3ifQrW1zkgYguUSOgODglFhdKF4P/0JaqUK6YAiMgP8R4yA9du3lf+7c8hnbROwRL3HjxxXomgNKxRAR2a1SCdglW37RCII32/vg5tmAYXZyds3/c/jJ62DMHBoUoVBLHNa1ivVqhavhhEtGjklGXYc/gM0rk6o+KPhbFp5xEGEAaQ2ApwEnqC3tBUYGUAYQChjgHegiWfkrwFS8ePINRcDGJEBVwHROd3wo2uDRP0fRHfm3PMWhPfWxPlfUkWQBKlmkmwU1yIMGG/aPMWLLl+xPRFTkLX8c6gbF0St3ISuraAnIQuH1SchC7XhZPQdS1ciG9xKvgkoyT0m7//pspqL/vM1aq0a6pGUySArN92GNv3ndSp6egB7eDh5mwqzWP5FZGcKfN0h9Wa16+C8qW+N1lfQg+tIvkOf+FPsnt34w7N7i7NX+i7YJK/yHBahW5Hr89b2OJy7JDRjdSuY47sJLuA27dJdnVCqpPsNDa0qrLuTrQqsFlcHUjtDnxPq8T64d4jkr/X1+/T7G69ItkFv6VVyyY5A5AqQ+yT5nTd55A+FcnlgdY+JLvv3GjPI7eLLcnfi8Bwkp3/h1CSndeM7iS755f1z/M0WWnv2sxjp5HafLt0Msku4MlLkp21kz3JLvR9EMku8AltLL+6+ZrkL0PJzCQ7mNMqlzdN05Lkb0e3kiS7ECIlL/T4eFCKvuteYJg+E+XvEwOukuzCiP17NbA1yZ+VI21Orpp+jOSvz/6JJLvIPGVIdmGbZ5Hs3t1+TLKbV8KbZDe4KO1dGmVNszMLfkdqV+Miz5kl3azD6GZ3lQBkOgNIQp4b35vIFGAAkT8QBhC5LgwgOsYLA4hUGAYQbVkYQORziAFErgsDiFwXNQHkVo9Gqqzksk3zU6VdUzWaIiMgphIzKfplAGEAEQpwBEQ+DjgCIteFIyDaunAERD5WOAIi14UjIHJdkkIE5JZ3Y1WWe9mm/qVKu6ZqlAHEVMomEb8MIAwgDCC6JysDCAMIb8GSjwHegiXXhbdgyXVJTluwbvdsosoKL+sU2pZ5VToXj0YZQOIhWnK6hQGEAYQBhAEkWgHOAdEeCwwgDCBCAc4BkY+DlJgDcrt3U1WWgVknr1SlXVM1ygBiKmWTiF8GEAYQBhAGEAYQ3WOAAYQBhAFE9/xIiQByp08zVVZ4WSatUKVdUzXKAGIqZZOIXwYQBhAGEAYQBhAGkGgF+BQs+VjgCAhHQKIVuNO3uSorvCwTl6vSrqkaZQAxlbJJxC8DCAMIAwgDCAMIAwgDSNxf2gwgDCDRCtzt10KVFV7mP5ep0q6pGmUAMZWyScQvAwgDCAMIAwgDCAMIAwgDyJcKcB0Q3ePh3gBarRxjLwMzjV9qbJeq+mMAUVV+9RtnAGEAYQBhAGEAYQBhAGEAYQChrcnuDWxFMzSyVaZxS4zsUV13DCAm1L/ozx2wYdEoeGVIp9XKYr8duHbzPib80ZHUg6fPX2PawnU48r9/8fZ9AP78oxN+rlBcuXfJ6p3YuPMIHjx6BhtrDcqV/B5/eDeHvZ12FWxReb3b4Gk4sG6qcm/gmgmk9j880F/RWDh6dfUuzZ//e5KdlZ0VyS5dUVpFcluX1CR/mrQuNLs8RUl2kW9pVZd//h+tKnQGZztSu+lT06ryUiumN/tnNqndN//RKpy/uPqM5C/gWQDJzsqWOF4Kas9JWQM2aZ1I7dq60sbV0ar9Sf7KeNHa1ViYkfz9+zSQZBcaEUmycyKeg//88nO9/lzy0uZagdXr9PoSBg8G0N6p7x+9IfmzTUuba+EhtGrzr2/RKpy75KHpEkicG+ZWtEroPcsOJumyoV0xkh3VaFCqvCTTTMTvhG7P/yX5+xBGG/PPOtQn+XP5LhPJ7uiMIyS7egdplcvDMtOeh/nZLaR2wx7dItnN9qBVBe9RgFbhPNLantSuWVgwyc7aiTaPSM4+Gd0f1NoQc6PZeo1dbDRficERA4gJn4KxAEQAR712Q1G1fDE0qF4eqRztYWYGpHH6OKE37jiC7JkzwDO9G16+foseQ2eibrUyaNOomtanYwChLRQZQOQTgwFErgsDiFwXBhBtXRhA5GOFAUSuCwOIXBdVAWRwGxOuHHW79hrjq0q7pmo0WQBIqZpd0arhz9h54BTuPXyK+tXLoXqlkhg3Y6USZSiYLxumjugGp1T2CAwKQbPfR+PB4+eIiopEnhyZMaxXS2TPkgHHTl9CjyHTsXb+CGTx8kBQcCjqtx+K9k2ro/bPP+p9Bif/uYLxM1bhweNnyJcrMy5cvoUty8YqERDha8LMVdh96DSsrCzh4uykQAMlAjJ90Xo8evICEwbH/cteREQkbt9/DO+hMzG0V0uUKJRH6fOytbuwdM0uvA8IRK5sXnjo/4wjIHqeJgMIA4hQgCMg8nHAERBtXTgCovcrMk4DBhAGEKFAUoiAPBjSNmGDPZ53e45aFM87E+dtyQZACuTJhq6takOEBjr0mYh0rs7o1bEBMnu6o/eIOahSrqgCEmHhEfj3yi1l8a/RWGHtlgM4cPwcFk8ZoDyhibP9cObCdayc/QfGTFuB4OBQjBvUXu/TE1ukarQciCHeLVC6eH7cf/QUrbzHY/OSMQqAjJ2+EjfuPMDw3q1hbW2FGYs2IDw8ggQgIvrhmtZJgasnz18jT3YvDO/TGjmzZozVr3zlW8HK0gJDerZEvV/LKn/be+Qsxk5fgUlDOyOzpwd2HTyF+Su2MIAwgMRSgLdgyQcEAwgDCG/Bko8B3oIl14W3YMl1SU5bsB4Mbad3TWgKA8+RC2O5ff32PYZM8MXxM5fgYG+L5vWrKOtcXZfPvDVY9Nf2WH8uXew7zJ/YxxTd1esz2QCIr09/5M7upXzgdn0mxmxXEv8/w3cDBCCM7v+RWrfuOYHt+0/ixp1HCAwKhoW5OQ5vnK78LSwsHI27jIKLcyo88n+B1fOGw87WWq+QS9bsxD8X/8P0Ud1jbL/cglW8WicsnzEYubJ5Kn83JAekVI2uaFKnEprWqwSNlRVmLt6I3QdPY8fKCQpERV+RkVG4de8Rugycir6dGynQ1XXQVJQskg/N6lVWzHgLFm/Bkg1mBhAGEKEA54BojwMGEAYQoQDngMjHQUrMAXk4TP+P0noXjfEwyDhiQay7eg2fjYiICAzp2QL+z16hc38fjB3YDmV/KCj1LgDk2cs3GNT9cyFFSwsL0ho3Ht3Ve0uyBBCRZP1j8fz4rdZPigALVm7FzTuPlGjD1r0nlCjHyL5tULxQHmU7Usse43B88+dEL7EVq0PfScqWp+qVS+oVURiMmbYc1tYa9On0OSErGkBSOdijdK3fcWbnfNjaaAwHkJpdMWXE7zFbqsR2rmK/dMSaecOQN2dmrf6JQfbQ/wV8hndBrdaD0btjw5gByQDCAMIAAqTjJHTpe40BhAGEk9DlX/kMIAwg0Qo8HN6BtC40tlHG4fNjXIaGhqH4r53hN2dozI/vE+f44eXrdxg/SN4/sTZ8/fYDRvVTJ4flaz1SHIAMnegLJ0cH9O7UUNHixp2HsQBEbNFq1nU0PNKlxeX/7mLDwpFwdNB/CsrsJZtw//GzWA8+GkAyuLuiUJV22LZ8vJIoLi5DIiCNOo1AjSql0LTuxyiGyGMRALLHbxLSu2uf8DByyjIEB4dg7MD2yjawmlVKoW61j1uyGEAYQBhAGEB0fTEygDCAMIAwgAgF+BQs3fjwaCTtpD1jA0iGofNiXN6574/qLQbG+mF77daDWL/1EPzmDpM2LQBk1ca9cLC3Q9o0qfBrpR+khxUZu9+6/KU4ABHRkH1HzmLSsC4ICAzG5LmrlUV5dAREEOTDx88xbVQ3dB8yHVaWlpg8rIve5yF8tPaegMnDOiODuwu27j2pRF62rxiv5IB0HjAFjva26NKqtpIf4jNvrbIdi5KEvmbLQcxavBHz/uyt+BLH8V757x6WzxgEkXjuPWymssUqW6b0+OfiDQwaN1+JmJQpUUABnb93HVPyWETOyYJVW3Hx6m3OAdHzRDkJXS4Qn4Il14VPwZLrwqdgaevCp2DJxwonoct14VOw5LqoeQrW41Gd9K4JTWGQfsjcGLdXb9xD/fbDcOnAYpiJY1E/pReIHN/NS8dKmxdrz/CISNhorHDt1gOMmLwEHZvXRJM6FU3RXb0+UxyACOjoO2oOTp69gozp3VClbFGs2rRXAZCjpy5i8PiF2LR4tHLErUjwqdVqMLzb14+JIMSl6NK1u7Bo1TZYWJijYc0KWLhyGzb6fqwDIvbnDRgzTwGH73JnhodbWgUeKAAi2vT1244V6/co0CSShsQePnGSVlRUFIb86YtT567i+au3yOjugvbNqqNmldJKV0WYTkRE9hw+oyTmV/yxMDbtPMIAwgASSwHOAZEPCE5Cl+vCp2Bp68KnYOldb8RpwADCACIUSAqnYD0e3Tlhgz2ed6f/Y07MndERkHO7F8TkAosIyLoth7B6njwC8nWzAlbEWth3Cq0+VTy7rfO2ZAEgxhYlJfnjQoTyp80RELkuHAGR68IRELkuHAHR1oUjIPKxwgDCAJJUAMR/rP5dMaZYR3oM+lwIWMkBqdZJ2W4VfQDTn7P+wotXb/HnEFqEZuqCdR935Azvaoru6vXJAKJXIihH93bqN1mnpUhm79i8BsGTtonYujVl3lqd94pj1cqX+j5evik3hQR8oJiJ3yVodpE0uyjLj8n4+q4I0Co9B4dH6XOl/F1jTvNnTrRDFK3dAGK1XSfzMNLnAGjtRlrRKqGHRtD8WdOKKQNRtHFgRrSLtKBVOA8jfg7q57UiVhq3pA0rWIbTqveaRYSQxkGAVSqSnS31c7x5SPIXkcqdZBf1aWsAyViPkXlYEMkNdcyD+G6hzjWYW5L6ZxZBm+OBURYkf3ag+Yui9i8ygtRuQBTt81LBYuy7K6R2iVMc9sTK72IXAeWK3uaiz9ac+G4OJH5nWRK/izRmtOcWDtq4Co+k6WIbRXtXvQinfefbEF+mxFcunB315/Dqe6Zf/91/nDoLdo+Bnw9LEn3qMWQGxFrlD+8WePbitXJ4kij1ULFMYYhTUdv3mYhWv/2sbMcX16gpy1ClfDFlu/7VG/fRf/RcjOrXVrFX42IAUUP1RNQmA4j8YTCAyHVhAJHrQvzOZABJwLuPAUQuHgOIXBcGELkuDCAJeAl9uvXJ+N8T7iQeHtwHzIx1l4h2iC34ogi2va2NUqqhc4taik14RAQKVmyLEX1aK8W5xSWKc+8/dk6Jkri7OqNVw6oxp8XGozsJvoUBJMESJm0HDCAMIEIBakSAAYQBRCjAERDJOKBGGDgCIp1EHAHR8W7hCIhUGDUjIE8mdFNl4efef4Yq7ZqqUQYQUymbRPwygDCAMIDonqy8BUuuDQMIAwhvwdLx3cFbsKTCJKctWE8nfi44/S2Xeun6fiyYnVwuBpDk8iTj+TkYQBhAGEAYQKIVsOQcEMlgoO2F5xwQ+TziHBC5LpwDItclKeSAPJ3UI54rroTdlq7PtIQ5SGR3M4AksgfyrbvDAMIAwgDCAMIAEteblwFEpg5HQDgCIhRIiUnozyZ7f+ulmtKeW++pqrRrqkYZQEylbBLxywDCAMIAwgDCAMIAEq2AGZ+CJR0MfAqWfI6kSADx6anKCs+t1xRV2jVVowwgplI2ifhlAGEAYQBhAGEAYQBhAIn7S5sBhAEkWoHnU3upssJz9fZRpV1TNcoAYiplk4hfBhAGEAYQBhAGEAYQBhAGkC8V4DogusfDi2m9VVnhufTQXY9OlQ4lsFEGkAQKmNRvZwBhAGEAYQBhAGEAYQBhAGEAoa3oXkzvQzM0spVL90lG9qiuOwYQI+l/485DNPt9DP63bY6RPBrm5t2HQLTpOQHtm1ZH1fLFpDdPnrsGvn7bcfngkpi/P3sbQGooiFi1lXqCRSoNrRqrGfFIQ3K1Ymr1Y2oFZ+J+aWr14zALa9LzsCRWJDeLCCf5o1YufxZKe27vQ2mV0J2saf6ciAVILKjPjXqIPE09EIspIzicposdsYoz9bm9C6UlUlOrLj8PpI0ryjHGqYlj4NwT2rsqjwut8nEYsdJzBPHhprGhjWVis+RK3tRnQW3X3YY2Vno45CfNDmp9D5IzANQxGhBGm2sRRGFsiC9dC+K72YpY38MqklbpPsTMiiQhtd1I4rinbk2zDHlH6h8iac8t0i41yZ+NjQ3JzhCjlzP6GmJuNNu03SYazVdicMQAYqSnoCaATFu4Hpt2HsHL1+8wcUhnKYAsWbMTOw+cwsWrtxlAKM+cupBlAJGqyQAiH2QMINq6MIDIxwq1kjcDiFw/BhC5LgwglAVA3DYvZ/VLuJN4eEjb9c943JV4b2EAicez8ft7P5at3YXnL98gZ1ZPDPi9CWxsNGjadTR6tKuP5et24+27D2jRsCo6t6iltPAhIAjjZqzEgePnYGttjYY1KyjRCnNzMwh4adJlNNo2rob12w8jJCQULRv+rPy/IVeDDsPRrsmvWgCyefcxrN92GMN6t/hQtKYAACAASURBVEKNFgMZQCiiMoBIVeIIiHzwEH8s5AiIRD4GEAYQyis52oYjIHK1OAIi18UUEZBXs/sbMmSNZuvcZYLRfCUGRwwgBj6FbftOYsq8NZg6qhu8MqTDsVMXYa2xgmcGN9Ru/QdaNqiKer+WxeOnr9BloA+2LZ8ArwxuGDx+IQKDgjG8T2u8ex+AboOno1m9yqhfvZwCIHXbDkGHZjXwa6WSePj4GbyHzsSyGYPwXa4s5B7KAOTwyQuY4bsRvj79ILZpVWnUhwGEoigDCAMIZZx8smEA0fFrq4X+vW4MIAwgBkw13oKlQywGkG8IIHMGGDJkjWbr3Hm80XwlBkcMIAY+BZFnUbFMETStWynWnbItWNWa9VeiIz8WL4DCVdph0+IxyOzprty3ZfdxrNlyAMtnDFYA5Ov8kZ7DZiJXNi90alGT3MOvAeT2fX8FZBZN7gvXtKnx6MkLBhDOAdHxEz5t3y1HQDgCIhSgbvvhHBDt8UJMOeAcEB3ffBwB4QiIUEDNHJDXcweS12XGNEzTaZwx3anuiwHEwEfwS9OPUFGuZEG9ACKAoFPzmiiYLxvK1e2BMzvnw9ZGo9x3+vw1JSqy22+SFEDGTFsOS0tL9O/amNzDrwFERD9EpMUsOtktKgph4RGwsrLEjNHdUaZEAXASug55OQIiFYYBhAGEAUQ+BjgJXa4LJ6HLdaHmYnASulw/VQFkvkoA0oEBhLwgTo6GrXuOR5VyxdC4dkUygFQoXUiJgGz0HY0sXh6kCEin/j4oUyI/mtatTJZRVw5ItAOOgAgl9G8JUfRiAGEAIc888ClYOrTiCIi2MBwBMWBiSUw5AiLXj7dgyXUxRQ7ImwWDEjaI43l36vZj43ln4ryNIyAGPpeNO45gztK/MW1UNwUmjp++BHNzc2TwcNHaRhUdAalYprAS7RCJ6CP7tZHmgPzWcYSS8+GZ3g1H/vcvRk9djq3LxsHF2YncQwYQilQMIFKVongLFmX06LLhHBAdv/JyDoiWMAwgCZlpfAyvLvUYQL4hgCwcnLBBHM+7U7cbE887E+dtDCAGPpeoqCgsXbsLfpv2K6dg5crmiYHdmiqnYH2dx/ElgAj4GDt9BQ6eOA8baw0a1qigJJ1Hn4IlbEXC+ZX/7iJTxnQY3KM5ihbMReqd2K4lkuNFG9YaDaysLPD34jFK3seXF0dAlNAGSVOOgMhl4i1Ycl0YQBhAeAuWfAzwFiwdc4PrgMiFSQJ1QN76/kFbRxjZyqnNaCN7VNcdA4i6+iutq1lDhHNAdAwA3oIlFYYBhAFEKMBJ6NrjgAGEAUQowIUI5eMgORUifLd4iCorx1StR6nSrqkaZQAxlbIG+NUFICJhvFO/yTo9FS+UBx2b1zCgJW3ToKBg0v3UqsHvQyNI/qiV1am/LIcT9zXQavwCxB+nYE3YYiIEMScCzSyPAiT9rIkdTGNFq87sTKxMX+XmGVL/qEXAXgTSqvw+DwwltRsURht/H4jjNCyCtjWNOq7aZrckfY4ojS3JDpbWJDvLl3dJdgh8Q7K77kQbp88D9D83F/uPB3Pou7xS0So9vyBWaQ+JoD01DXGOvyS262JHGwPUYp5u9jR/b4Jpc2OqO+3ZTvtwUd8j+/h34ku86oJzJH9hIbTPsb9bMZI/s9AAkt2Zt7Txl8qa9jzaLjxNavdo1Q8kuze5q5DsHDS0Uu03X4eQ/D0uU55kV+7SCZKdWQjteVA3M1inSktq1xCjd0uGGmJuNNtUrUYazVdicMQAkgiegpoREAYQ+QAgru8ZQHTMHwYQuTAMINq6MIDIxwoDiFwXBhC5Lgwgcl1MASDvlw5TZeXo2HKEKu2aqlEGEFMpm0T8MoAwgAgFOAKiY7HDERCpMBwB0ZaFIyA6vvQ4AiIVhiMg8vGSFCIg75cPV2WF59hcnXZN9WEZQEylbBLxywDCAMIAonuy8hYsuTYMIAwgvAVLPjd4C5Zcl+S0BevDCnUiEQ7N1Im8mGo5ywBiKmWTiF8GEAYQBhAGkBgFOAdEazBwDoh8fjCAMIAIBVJiDsiHlerkYjg0VSf3xFTLWQYQUymbRPwygDCAMIAwgDCA6B4DDCAMIEIBTkKXj4OUCCABq9Q5jcq+iTqnb5lqOcsAYiplk4hfBhAGEAYQBhAGEAaQaAX4FCz5WGAAYQCJViDgL3UKAto3VqcAoqmWswwgplI2ifhlAGEAYQBhAGEAYQBhAIn7S5sBhAEkBkD8xqqywrNvNEiVdk3VKAOIqZRNIn4ZQBhAGEAYQBhAGEAYQBhAvlSA64DoHg8Bq8epssKz/22gKu2aqlEGEFMpm0T8MoAwgDCAMIAwgDCAMIAwgDCA0BZuAWvG0wyNbGXfcICRParrLtkDyMoNe3Hy7GXMGNNDqnSpml3h69MfubN7fbMnUaG+t9Kf73JlUdpMSCHCoOBQDB6/AOcv38Sbtx+QNVN69On0G34oklfxHRkZhUlz/LBxxxGEhYejYpkiGNGnNWysP1YfPlS8FOlzP7/3lmSXLktqkl2OOoVJdo4ZXUl2Vp45SHbmDk4kOzP7VCS7cI+POuu9iJXQH4fQqujaW9Gq2VoSKypaEO1OFKSNlzsvgvRKIgyyudmR7HLVyU+yc/B0I9nZZ8tOsjN3cqbZEcdLaM5yJH9hkbQq3cTHhscfaBXnU1tbkPrn40p7Hqmt9Pur25TmK9PUZaS+jXEuSLJ7E0arcu+q0f8ZRIONWn5PavfZpScku8Ldq5PslnVYQrI7/zaYZOf95F+Sna0l7R2UztaM5O9q0zokuzQ5PUh2Fv1nkexCI2hzLWJoa5I/rxoVSXYBt2+T7FIVKUmyCy74C8nO/hGt4nxkIK0i+esspUntOtIKyQPE70qzUNp3jHUq2juc9CE+GQWs/dMQc6PZ2jfoZzRficERA0gSBxABHXOXb0btn3+Ea9rUCmjMW74ZB9ZNhYO9Lfz+3o+la3Zi1riesLO1Rt+Rc1AwX3YFUsTFACKfhgwgcl0YQOS6mDOASIVhANGWhQFEPocYQOS6MIDo+I5WEUAC101UZf1uV7+vKu2aqtEUASC7D52GZ3o3HDh+Dk6O9hjaqyV+KPzxl2sRAWlevwr2HDqDR09eoFKZIhjWqyU0Gv247j10prLIf/L8Ff69cgu5snliwuCOSO/uovg+ff4aJs9djZt3H8HdLS3aNfkVZ//9Dxu2H4a1xgrm5mbo3LI2yv5QAE26jEaHZtWxZstBhISEok3jamjV8GeDn3t4RAQKVmyLdQtGIE+OTGjZYxwq/lgYLRpU/QgcJy5gpM9S7FvrwwASh7oMIAwgQgGOgMjHAUdAtHXhCIh8rHAERK4LR0B0fAEngQhI4PpJBq/NjHGDXb0+xnCTaHykCACZvXQTendsiGLf58aew2ew2G8H9q7xUSBAAEiJQnnQpvGvyv/3Hj4L9aqXIy3+BYDcf/QUPTs0QKaM7pi6YC3Elqg543viof9z1GkzBKP7t8WPxfPj+q37+PfqbcWvbAtW3bZD0Kl5TfxS8Qc88n8O4XvZ9EHIlyuzQYNFgFDrnhNwaMM0BY7K1e2BUf3aoOwPH7cl3Hv4FNWa9ceZnfNha6PhCIiudyDxF23egiUXkLdgyXXhLVjauvAWLPlY4S1Ycl14C5ZcF96CJdfFFFuwAjdMNmhdZixju7q9jeUqUfhJEQDyZQ5IVFQUytbpjmmjuqNw/hwKgHyZA7Jq4z7sO3oWiybr32snIEH4iI4u3LzzCPXaDcW5PQsxb8VmXL/5AFNH/q71oCk5ID2HzUTu7JnQsXkN8kAJCAxG066jUa1iCXRo9vG+4tU6KfkmArLE9fT5a/zUoCeObJoB59SODCAMIIoCnAMiHwgcAZHrwhEQbV04AiIfKxwBkevCERBdX760nCE1c0ACN04hr8uMaWhXp6cx3anuK8UBiFC8VuvB6NGuPn4qXUgLQHYfOqPkUKxfOFLvw/kaQEQ+Rulav+N/2+Zg4hw/JQLRt3OjeAHImGnLYWlpif5dG+vthzAQ8NGpvw8yZUynRDzMPoUxRQRkzIB2ShRGXBwB4SR02YBiAGEAEQpwErr2OOAkdPnc4CR0uS6chC7XJTkloQdumkpalxnbyK62t7FdquovxQGIyJEoU6sblk4fhJxZM2oByJI1O3Hu4g1MG9VN74P5GkAuXruDjn0n4fiWWZi99G/cvPMQPsO7avmp1LAXpoz4HfnzZFX+JjsFq+ugqShVNB+a1q2stx8vXr1V4ENEYwZ2axoDH+LGFt3HonLZokqei7hEHsyIyUtxcP3HCcRJ6HJ5OQdErgsnoesAFeKWPd6Cpa0fb8GSjynegiXXhbdgyXXhLVhyXUyyBevvaXrXZaYwsKslP83VFG19C58pAkD+3nUUk4Z2USISIv/j1Lmr8Js7VFmoiy1YIoejavniuHvfH72Gz8KQni1RrqT+oxwFgKRytFOiKYFBwRjypy/y586K3p0a4s59fzTsOBzjBnVQog8iEf3C5VtoWrcSmv0+Rvk3AQUhoWF4+fotfus4AstmDFKS5U+cuYzhk5dg67JxcHGO+xf7x09eoJX3eOUUrFa/fU5at7SwUBLpV27YgxXr9yp5KXa2Nug9Yjby5sykgAoDiO4pxgDCACIU4C1Y8nHAW7C0deEtWPKxwluw5LrwFiwd379JIAk9aPOMb7E+12rDtqb+H8ZV6Vg8G00RALLYbzvMzM3x8tVbFMqfA6P7t4OH28ezoQWAeHq44da9R3B0sFNOqqJEHcS9AkAePH6G5y/fICwsXEkgF1umRDK7uI6euoipC9YpMOLu5qz4rvNLGZz85wr+mLAIInIx4PcmKFIgpwIgWbw8cPu+vwIhf/RojuKFcut9rPuO/IPuQ6Zr2TWsUR7DerdCREQkJsz6C5t3H0N4eDgqlC6k1AERMMIAwgASrQBvwZKPBQYQBhDegiUfA7wFS64Lb8GS65KctmAFbZmpd21mCgPbGto5xaZo51v5TPYAYkohv96CZcq2TOWbt2DJleUIiFwX3oKlA1R4C5ZUGK4Doi0L1wGRzyGuAyLXheuA6PiOVrEOSNBWWpFLY6/bbKtrb+k3dhvf0h8DiA611287jO37Tup8FqMHtMOEmatinYJl7AcXFh6BTv10H/dWvFAeg07JkvXv9C+0qq33/6FV730dFkGSIU8+WoVz17y0ytYepb4jtWvl6k6yM09N6x9y0yqDm4XRqhC/t6P1zx6hpM9hFh5iVLtLHduT/D0hjpeQYNp48SxGq37snCsdqX/pStCqb1u4pCf5s3CmtfswI228pLamVZmmRq4uP6dVDc7gqCF93u3ZipLs3oTqf76FPVORfJU5d4RktydrcZLd4+Bwkp0bsTp85lIZSf727r5DsvutG63C9NjxB0j+vnf6GPXWd9W+d1afifL3MGIFcTeN/jEg/F1qVI/Ubto8tHeBZtBckr/A8Eia3e8fi/fqu7L8Sht/4UG0d3NESJi+JpW/27UfTbKzOLmWZEctrhqZuwzJH8wtSHZR5pYkO/OgNyQ7TdoMJDtDjIK2zTbE3Gi2tr92MZqvxOCIASQBTyE5REAYQOQDgAFErgsDiFwXBhC5Lgwg2rowgOh4tzCASIVhANHxHa0mgGynwW0ClpfSW22rdTK2S1X9MYCoKr/6jTOAMIAIBaiREgYQBhChAEdAtMcBR0Dkc4MjIHJdOAIi1yVJREB2zFNl8Wb7S0dV2jVVowwgplI2ifhlAGEAYQDRPVl5C5ZcGwYQBhDegiWfG7wFS8f7NBltwQreOV+VFZ7Nzx1UaddUjTKAmErZJOKXAYQBhAGEASRaAc4B0R4LnAMinx8MIAwgQoGUmAMSvGuBKis8m6q0HExVOhePRhlA4iFacrqFAYQBhAGEAYQBRPcYYABhABEKBHISunQgpEgA2b1IlWWgTZW2qrRrqkYZQEylbBLxywDCAMIAwgDCAMIAEq0An4IlHwsMIHJdUiSA7PFVZYVnU7mNKu2aqlEGEFMpm0T8MoAwgDCAMIAwgDCAMIDE/aXNAMIAEq1A8N7FqqzwbCq1VqVdUzXKAGIqZZOIXwYQBhAGEAYQBhAGEAYQBpAvFeA6ILrHQ/C+Jaqs8GwqtlKlXVM1ygBiKmWTiF8GEAYQBhAGEAYQBhAGEAYQBhDawi1k/zKaoZGtrH9qYWSP6rpjADGS/v1Hz0Pu7F5o3eiXGI/fV26HOeN6omTRfAlqZYbvBmzf9z88ef4Krs5OaNGgKprVqxzj89L1Oxg+aQlu3nmI9O4uGNitKcqUKKD8PTIyCpPm+GHjjiMICw9HxTJFMKJPa9hYf6x4HH5xL6lvEU8fkOzenj9Psntw8DLJ7vmVFyS7f54GkOxcNLRqrDmzpKb5y5OWZPfw5GOSXYajB0l2GnMzkp29hlZR28WGpovlVVrV5XD/u6T+vb18jWTn/7/rJLtXt2jVcf0fvif5cyZWBk9XwJXkb9ivI0l2ns52JLtOpTKT7FITn++TD7Sqy/mOzCC1++zcDb12wS/f6rURBllnriDZRR2jVXqOePWE5M/c3olkF/SQ9o58eOBfkr/Za6+S7AYNqECycymUi2R388fOJLucztYkuyBipfEn3RuT/L367xXJrtCePSS78Mgokl3A1N4ku2fnaZXuA18GkvwFEL/byh1YT/J3rjltG49TZtp3YKZpK0ntWrx7RrKLsrIh2Vm+on3HmGcrQfJniFHIgeWGmBvN1rpCc6P5SgyOGECM9BRkAHL91gN4pneFnS1tQunqyqS5q1G2REFky5weV/67ix5DZmD2+J74oXBehIWFo2qTvmhcuyJ+q/UTDh0/j5FTlmHXXxPhnNoRfn/vx9I1OzFrXE/Y2Vqj78g5KJgvO/p0+k1pjgFErjoDiFwXBhC5Lgwgcl0YQLR1YQCRjxUGELkuDCA6vovUBJCDtB9DjLS8jHFjXb6ZsV2q6i9RAsjJf65g4mw/3H3wBGnTpFIW1m0bV8PKDXux5/AZZMqYDnsOnUEqR3v4DO+C3YfOYO3WgzCDGXp3aog6v5RRRBX2C1dtxes375EmtSMaVC+PLq1qkwQvVbMrurSsjW37TuLqf3exftEoLFi5FYdPXkBgUAg8PVzRvV09VC5bFJt2HsXQib4wNzODpaUFihfKg9njeqJsne4KKHyXKws+BARh3IyVOHD8HGytrdGwZgW0b1od5sRfsr/sdPNuY1GpbBG0bFAVp85dQ48h03Fs86wYXw07DkejWj+hbrWyaNljHCr+WFiJmojr0IkLGOmzFPvW+jCAxDESGEAYQIQCHAGRjwOOgGjrwhEQ+VjhCIhcF46AyHVJEhGQQ6tI60hjG1mXa2Jsl6r6S3QAEhERiTK1u2HMwHb4sVh+3HnwBGcuXEeTOhUVoJi+aD16dWiAkkW/w/J1u7Bm80G0bFhVgY5/Lt7A+JkrcXzLbFhZWuDW3UewsrKCm0tqvHz9Dh36TlK2HxUtqD8ULQAki6eHAiwe6dLCwy0t/rv9QPmvUyp7XL1xD+37TMSxv2dCo7GCLALyJYAMHr8QgUHBGN6nNd69D0C3wdOVbVT1q5czaAAEBYeiYsOemDy0i7K1a83mA1i/7TBWzxsW46ffqLlI5+qswFi5uj0wql8blP2hoPL3ew+folqz/jizcz5sbTQcAdGhPgMIAwgDiO5XEwMIAwhvwZLPD96CJdclWW3BOvyXQes2Yxlbl6VtUzRWe6b2k+gAJCw8Aj/82hnd2tRVFucO9rYxGggAOXn2MmaM6aH827lLN9Bz2CwcXD9V+X8BLwUqtsHe1ZMVaBA5E0tW78Spc1fx+u17vHkXgAFdGysRFX2XABBfn/5KXkf0df7yTaz++wAuXLmJgMBgvHj1FluWjUNWL484ASRvjswoXKUdNi0eg8ye7oq7LbuPY82WA1g+Y7C+rsT6uwCZZy/eYP7E3jAzM8PStbuw78hZLJs+KMZORGOsLC0xpGcLFK/WSdGrRKE8yt+fPn+Nnxr0xJFNM5QtWrwFSy4/AwgDCAMIA4hQgHNAdLwjOQdEKgwDSAoAkCN+Bq3bjGVsXaaRsVwlCj+JDkCEKvuPncPcZX/j+s0HSt5Dj3b1Ua5kQSUC8iWAXLt5X4lqHN44PUZMkfi9eckYZPRwQ42WA1E4f050aVkL7m7OCqwU+z43mtatpFf8rwHkweNnqNPmD/Ts0ADVK5VSoiDCZum0gciRJWOcAOLu6qxEIqKjDqLx0+evQcDEbr9JevsSbTBh1l8KTC2ZOgCODh+TVEUEZOPOo/hr9pAYPyIC4uaaRsnzEO2OGdAOPxbPr/ydIyC0ZGsGEAYQBhAGEAYQ3WOAIyBybRhAkj+AhB5dTV63GdNQ8+PH3N3kciVKAIkWV+Ra/LVpHxau3IoTW2cbBCDWGo3yS//ZXfNjTnzyHjoz3gCydc8JrFi/G35zP291+hJABo5dgOxZMii5KtFX9Bas6AjIRt/RyOLlofzZkAhIeEQEhk1cjPuPniq5JdHwIfz879xV9Bw6E8c2z1QiIuKq334YfqtVQcl5adF9rJKn0rx+FeVvIgdlxOSlMVEjjoDIpzIDCAMIAwgDCAMIA0i0AnwKlnwspMRTsEKJJ+0ZGxQ0pRsY26Wq/hIdgIhtTcvW7lKStDO4u2Db3pOYuXgjdq760yAAEbkaAhAG92iu/Povoioisd27ff14RUDE9quO/SZjkU8/ODs5YsX6Pcr2p02LRysRkGkL1yt5IROHdILI0xB5J1/ngIhE9JH92hiUAyLgo1N/H1hrrDC6f1vlv+IyMzNXcjhCQ8NQuVEfJcm8YY3yOPy/fzH0T19FL9e0qbFywx6sWL8Xc8aLU7Bs0HvEbOTNmUk5qldcDCAMIEIBPoZXPg44CV2uC+eAaOvCSejyscJJ6HJdOAldrktSSEIPPb5OlYW7plR9Vdo1VaOJDkBEovYfExYpiedBwSHK4l5ARL5cmQ0CEK8M6bDr4GmMnb4CwSGhqFC6EPyfvkSVcsXiBSDiAfjMW4O/Nu2Hg72NEl1Ytm43ls8YpPRR5Jt4D5kBsS1MtPHnkE5ap2CJvhw8cV6JyDSsUQEdmtXQewrWuw+BKFm9i9bzF7kk25aPV/79wpVbyslWN+88Qnr3tOjbpTF+Kl1I+ZvIixFbtzbvPobw8HBFB5GIH300MAMIAwgDiO7XKwMIAwjngOh4R3IOiFQY3oIlHy/JKQk99ASt5oqxF+6akvWM7VJVf4kOQFRVIwU2zgDCAMIAwgASrQAXItQeCwwgDCBCAd6CJR8HKXIL1skNqqwWNT/UVaVdUzWaIgFEHFu7fd9JnZqOHtAOHm7OptI8ll+1+/Jieh/S53x0lFa5/OxeWnXS98TquN/nplUaz1nnY8RH3+WY0U2fifJ3S7f0NLv8tGOUzYNp1Z4fOH08rUzflc7eUp+J8nezUFqFePNQWlXed36fD3yIqwOPj18h9e/Wftp4CSFWK85S+OMpc/qurNUK6zNR/m6XkTgOXDOQ/B1wo1WtLpnRkeTvU9qXXtvtN2jVowu609p9Wf9XvW0Kg+uXX+i1C4iI1GsjDDo8PkOyu92NVqzr+RX9fRMNOmejVYR+cZ2msd9Zf9Ln6NKA9i7Ytf0WyV/J72nvvgybdpD8pbKmHejhYB5B8neq0s8kO5dctO8E95m0k4reBNP697xpLVL/PMvmJtmZEWuAhQUGk/y5DJpFssPOOSQ7c0cnkh1KErcFRYST/EVZWpPsLD7Q5q+VWyaSP0OMQv+3yRBzo9lqStDq2BmtQRM7SpEAYmJNk5R7BhD542IAkevCAKJjvDCASIVhANGWhQFEPocYQOS6MIDIdVETQMJO/a3KOs+qOA2CVelcPBplAImHaMnpFgYQBhChAEdA5OOAIyByXTgCoq0LR0DkY4UjIHJdOAIi1yUpREDCTm9WZRloVaymKu2aqlEGEFMpm0T8MoAwgDCA6J6sDCAMILwFSz4GeAuWXBfegqXjfZqMtmCFndmiygrPqmgNVdo1VaMMIKZSNon4ZQBhAGEAYQCJVoBzQLTHAgMIA4hQgHNAdLwnU2AOSNjZbaqs8KyK0HLvVOlcPBplAImHaMnpFgYQBhAGEAYQBhDdY4ABhAGEASSOVU9KBJB/tquyDLQq/LnQtSodMHKjDCBGFjSpuWMAYQBhAGEAYQBhAIlWgE/Bko8FjoBwBCRagbBztJPijL0etCr0i7FdquqPAURV+dVvnAGEAYQBhAGEAYQBhAEk7u9jBhAGkGgFws/vVGXxZvk97ahqVToXj0YZQOIhWnK6hQGEAYQBhAGEAYQBhAGEAeRLBbgOiO7xEH5htyrLQMuCVVRp11SNMoCYStkk4jfi0j5ST98fp9mdmryL5M+rdEaSXZpcXiQ7p+9oRbvMHWlFxcwd05DajcxMK4CIKJI7nH2nIRlmTEWz01iYkfxZEYtiOV6m/fLzfO8eUrtHph8i2WUvQSsImDY3zc61SC5SuxZOLiQ781S0wqVvvqPt4bWxNCe1SzXadJ1WtOunzLRxHz6uM6npewdu6rULeRei10YYlP8fbdvDh1WTSf78T9KKZXqUzEfyN6jrapJdoyIeJLsCbcuS7O7tOU+ys3ejFZl8O2gByV92Z1rBOFviWL7ZjlbQzjEjbU66DKMV3HsdRCtEGDy0DUkX9xJ5SXbBrz+Q7BzzFyTZhZWg6Wdz/SDJX+QHWvHcl/lpJzOlsaZ9F0WB9u4zD6MVz7UmvptJonwyCv+X9v1miE+KrWWByhSzJGPDAJJkHpXujhb9uQM2LBoFrwzp0KHvJOTLlQU92tVDWHgE/piwEPuPngMQhR0r/8TWvSewaNU2vA8IwsQhnfCTM+0lwwAi158BRK4LA4hcFwYQbV0YQORjhQFErgsDiFwXBhC5LiYBkIt7VVk5WuavpEq73AO+MAAAIABJREFUpmqUAcRUyn5Dv18CyIPHz2BrYw0XZyccOnEBPvPXYNn0QbCx1iAsLBylanbF34vHIGN6N0RFRsLiv8OknjKAMIAIBTgCIh8HHAGR68IREG1dOAIiHyscAdEBXBwBkQqjagTk0n7SusnYRpbf/WRsl6r6YwD5JH9gUAia/T4aDx4/R1RUJPLkyIxhvVoie5YMioVYuHdpWRvb9p3E1f/uYv2iUbAwN8dIn6W4eO0OPNKlhXf7+vip9MctOR8CgjBuxkocOH4OttbWaFizAto3rQ5zczOs3LAXew6fQRYvD+w5dAY21lYY2qslyv5AC7We/OcKxs9YBQEb+XJlxoXLt7Bl2VglAtJ7xGx8lysLalYtjYoNeyE8PELxX6ZEAdx/9AzXbt6HrY0GdrY2OLxxOngLlo4FJW/BkgrDAMIAIhTgLVja44C3YMnnBm/BkuvCW7DkuiSJLViXD6iycLfMV0GVdk3VKAPIJ2XFdqV/r9xC9swZoNFYYe2WAwo8LJ4yIAZAsnh6oEur2gpsuDinxm8dh6NBjXJoXLsSLl27je5/TMfK2UOQ1csDg8cvRGBQMIb3aY137wPQbfB0NKtXGfWrl1MAZPqi9ejRrj7KlMivbItat+UQ9q310fucnz5/jRotB2KIdwuULp4f9x89RSvv8di8ZEwsAGnd6Bds2X0c67YdwtJpAxW/T56/QsUGvXD54JKYdhhAGECEApwDIh8HnAMi14UBhAGEc0Dkc4NzQOS6JKcckIgrtDwavQs6Aw0s8pY38I7Ebc4A8sXz2brnBLbvP4kbdx4p8CAiHCJKIC4RAfH16Y/c2T8mRf9z8T/0Gj4bB9ZNgZnZx+SqIX/6wjWtE35vXReFq7TDpsVjkNnTXfmbgIE1Ww5g+YzBCoCcPHsZM8b0UP72/OUblK/njTM75yvRibiuJWt2Km1PH9U9xuzLLVjRERAGEF1gwUnoMmUYQBhAhAKchK49DjgJXT43GEAYQIQCKTEJPeIq7fAUYy//LfKUM7ZLVf0xgHySX0QhJs72w8i+bVC8UB489H+Glj3G4fjmWVIA2bH/f1iyeidWzxsW8wBnL9mEx09fKluxytXtEQsoTp+/pkRFdvtN0gIQATvFfumEE1tnI5WDXZwDYsy05bC21qBPp98YQL5Qik/Bkg8bPgVLrgufgiXXhQGEAYRPwZLPDT4FS65LigSQa0dUWbhb5C6jSrumapQB5JOyQyf6wsnRAb07NVT+5cadh3ECiIhC9Bw2CwfXT9UZAdnoO1rJ8xBXXBEQQwBEQM79x88wflAHBhAGEL3vBQYQBhChAB/Dqz0O+Bhe+dxgAGEAEQrwMby6v14jrh/V+91rCgOLXD+awq1qPhlAPkm/YOVW7DtyFpOGdUFAYDAmz12NS9fv6IyAiJyRmi0Hod6vZdG0bmUlB6TbH9Ox6oscEJGIPrJfG2kOyJdbsAwBENGn1t4TMHlYZ2Rwd8HWvSch+r59xXjOASFMI64DIheJt2DJdeEcELkunAOirQsnocvHCieh6wAargMiFSYpJKFH/HeMsNowvolFztLGd6qiRwaQT+IL6Og7ag5Onr2iHFFbpWxRrNq0VyeAiNvu3PfHyClLcUmcguWWFt4dGsQ6BWvs9BU4eOK8cgRuwxoV0KFZjZhTsOILIKLdpWt3KbU8LCzMldO1Fq7cho2+H+uAcA5I3LOJAYQBRCjAW7Dk44C3YGnrwjkg8rHCOSByXTgJXa5LskpCv3FclWW7RY5SqrRrqkYZQEylbBLxu79gCVJP3z6lVW3N/Us2kr+M5WkVxC3TupL8WbrSKqub2cSdYxPdmDnRLtwtB6l/UeYWJLuXUbYkO2tihXNigXOYfzpIQV/jR3MV12ei/P1hQBjJrlgZT5KdV8UCJDvbdGlJdpbuHw+T0HeZ29GqR5vZ2utzpfw9NDsthB4cHknyR3xsCAqPIvmztaRVK/ZxyU/yl9U+7kM1hJNqA2jVfVN3GU1qc7xLYZKdA7FC940PoSR/Y2d9zsuL64bHxy6R/GVr9AvJbmd7WsXvi29pFeebPRCFa413pbejjam73ZqRGnXKSqskH9zxT5K/SNrUgGZ6T5I/t/LEOX7vFsmfXQHaOzcoD61IncOTf0ntRoUEkezeeNL652BOqzgfRXypmUWEk/pn7Ug7eIbk7JNRxM2ThpgbzdYi+w9G85UYHDGAJIan8EUfRNTk1t3H0l45pbKHz/CuRu0xA4hcTgYQuS4MIHJdGEDkujCAaOvCACIfKwwgcl0YQHS8cxlAjLoWVMMZA4gaqieiNhlAGECEAhwB0TEOOAIiFYYjINqycAREPoc4AiLXJZgjIFJhkkQE5Nb/VFnFWWSj7VhRpXPxaJQBJB6iJadbGEAYQBhAdM9o3oIl14YBhAGE+j3IAMIAIhRIVluwbp2iDn+j2llko213M2qjJnTGAGJCcZOCawYQBhAGEAaQaAU4B0R7LHAOSMK+yRhAGECSHYDcPp2wSRHPuy2yFovnnYnzNgaQxPlcvlmvGEAYQBhAGEAYQHSPAQaQhH0dMYAwgCQ/ADmTsEkRz7stshaN552J8zYGkMT5XL5ZrxhAGEAYQBhAGEAYQKIV4FOw5GOBT8GS65IiT8G6c/abrdG+bMgiSxFV2jVVowwgplI2ifhlAGEAYQBhAGEAYQBhAIn7S5sBhAEkWoGIO/+ossKzyEI7YlyVzsWjUQaQeIiWnG5hAGEAYQBhAGEAYQBhAGEA+VIBrgOiezxE3DVurRzqmtIiM61+GtWf2nYMIGo/AZXbZwBhAGEAYQBhAGEAYQBhAGEAoS3IIu6epxka2coi8/dG9qiuOwYQdfWXtn7hyi006TIKF/YtgqVF3BW0g4JDMXj8Apy/fBNv3n5A1kzp0afTb/ihSN5Yvv/edQyL/tqOzUvGxPr3Yz+WISnw/OYrkp2ThwPJLnd92l5GB083kj+NV3aSnbljGpodsf5DeIbvSP6oRo9CrUimDlbmJDtLYil0qt2p4mVJ7d55/J5kl9HJmmSXux6t8rajVzqSP4fs2Uh25k4uNDuHVCS70FzlaXYRtPLMFrRhgIfvaZXpnW3ift9Ed36Oe0HS57AhjL8adXORfGWbt5pkN86Z1renIbRKyjkc9FdzFx37uXZOUv9e3nhNsiviXY1kt6LzcpLdpXe0SuhdH18g+bMlVpJPZ0urhH61SR1Su2lyupPsLAfMJtmFEOdaxJBWJH+eNSqS7ALv3CHZORaiHb0aUqg6yZ/9A1r+QmRQAMnf66y0NYQj7asNMKO91MzCaJXarYnf+aQP+8ko/J46AGKZiQHEkOfEtvFQQEDFvYdPkDu7l967BXTMXb4ZtX/+Ea5pU2PjjiOYt3wzDqybCgd7Wzx78QYte4zF67cf4OaShgGE+DKi1n9gAJEPUQYQuS4MINq6MIDIxwoDiFwXBhC5Lgwgcl1MAyA0SNe7gDPQwDIT7ccVA92qZs4RkG8gvQCKKfPXYveh0wgJCUXRgrkwsl8bpHFyhN/f+7Fs7S48f/kGObN6YsDvTWBvb4uGHYbhzM75BvcuPCICBSu2xboFI5AnR6aY+w8ePw+f+WsZQBhApGOKIyDyqcYRELkuHAHR1oUjIPKxwhEQuS4cAdGxvEkKEZD7/xq8NjPGDZZeBYzhJtH4YAD5Bo9i+KQlePjkOUb3bwsLc3Ns2nkUVcsXx8VrtzFl3hpMHdUNXhnS4dipi7DWWCGzl0e8AeTfK7fQuucEHNowTYmARF8MIB+V4C1Y8gHPAMIAIhTgLVja44C3YMnnBm/BkuvCW7DkuiSrLVj3L36DlaN2E5ZetK3IqnQuHo0ygMRDNENuiYiIRJGq7bF2wQjkyJIx1q1tek5AxTJF0LRupVj/fvu+f7wAJCAwGE27jka1iiXQoVmNWD4ZQBhA4hq3DCAMIAwg8jHAAMIAIhTgHBD5OEiROSAPLhmyDDSaraWncXNOjdaxeDpiAImncNTbRA5GhfreOL1jHuxsYyfc/tK0v7LlqlzJ2Pv64gMgAj469fdBpozpMKpfG5iZxU78YwBhAGEA+awAJ6HLRwNHQDgCwkno8rnBAMIAEq1A+IPL1CWgUe0sPfMZ1Z/azhhATPwEoiMg6xeORLbMGWK11rrneFQpVwyNa8c+NcNQAHnx6q0CH4Xz58DAbk214EM0ygDCAMIAwgCi73XHAMIAwgDCACIU4FOwdL8twx9e0fcqNcnfLTPGPt3UJI18Q6cMIN9A7IFjF+DVm3cY2bcNbGw02LzrGMqV/B5n/72OOUv/xrRR3ZDFywPHT1+Cubk5vDKmI2/BevzkBVp5j1dOwWr1288xn0Yc36vRfD73jgGEAYQBhAFE3+uOAYQBhAGEAYQBJO43ZfjDq/pepSb5u2XGPCbxq5ZTBpBvoPyHgCBMnrcG+4/+g5DQMBT7dApW6lQOWLp2F/w27VdOwcqVzVOJYBhyCta+I/+g+5DpWp+iYY3yGNa7FfyfvUK9dkMQHh6BoOAQODrYoWaV0srWL3FxHRD5AOBjeOW6cB0QHeOF64BIheE6INqycB0Q+RziOiByXbgOiFwXVeuAPFIJQDIwgHyDJTs38a0UYABhABEKcBK6jnHAhQilwvAxvNqy8DG88jnEx/DKdeFjeHWscpLAMbxhj659qyVarHasMuRWpV1TNcoREFMpawS/YeER6NRvsk5PxQvlQcfmsU+7MrTZ7ZlphW1CgmlVg/PVpk2QDOUKkbpqkYZWCd3SzZPkz9yeVrE6SkOr0B3uQquoTeocgJfhtKrL1pa06sIWXx1GoKsfhILVyq3bs9Aq2AeER5I+ctFKWUh2XhVo49TaNS3Jn6XH5xo5cd1APrbZxo7UbognTb/QSGIldNowwNuQCFL/qEerTnejnUefw17/eP5lBK2Cs13roaTP4G1POykmnbUlyR91bnSbVJfk7+nZ6yS7LI1qkuz2tJxCsjv1mlY5us1DWpVnawtaxWpna9pYfti3DelzOGWLnUup66bAlqNI/iKjaP3TzOpD8uf6008ku7BHN0l21nlLkOyCs5cm2dk+o/16bxYWQvL32p32branTTcAtJeaWUQoqX/WDk4kO0OMwh7T5rAhPim2VulzUcySjA0DSJJ5VKbpKAOIXFcGELkuDCByXcwZQKTCMIBoy8IAIp9DDCByXRhA5LqoCyD/mWZBpserVfqcqrRrqkYZQEylbBLxywDCACIUoP7KywDCACIU4AiI9jjgCIh8bnAERK4LR0B0LZKSQATE/4YqKzwrjxyqtGuqRhlATKVsEvHLAMIAwgCie7LyFiy5NgwgDCC8BUs+N3gLllyXZLUFy5+2fc7Yy0Arj+zGdqmqPwYQVeVXv3EGEAYQBhAGkGgFOAdEeyxQo4McAeEIiFCAASQFAMiTW6os3qzcjZtzqsqH+KJRBhC1n4DK7TOAMIAwgDCAMIDEMQZoO0LAAMIAwgCiex4lqwjIk9uqrNys3LOq0q6pGmUAMZWyScQvAwgDCAMIAwgDCANItAJ8CpZ8LPApWHJdUuQpWE9VApB0DCBJZGnN3aQowADCAMIAwgDCAMIAwgAS9zcmAwgDSLQCYU/vUJZXRrexSkc7tt7oDZvIIUdATCRsUnHLAMIAwgDCAMIAwgDCAMIA8qUCXAdE93gIfXZXlSWexi2zKu2aqlEGEFMpm0T8MoAwgDCAMIAwgDCAMIAwgDCA0BZuoc/u0QyNbKVxoxXQNXKzJnPHAGIyaeN2fOn6HXQbPA0H1k01Sg/efQhEm54T0L5pdVQtX0zqc/LcNfD1247LB5fE/D04iFYdl1iclF7FNCyY+LlpVWqjLGmVy6PMaNV7iZ2DWSStwrRZFK0yeAho5WIDw2j+wokVtWkqA24a2udFZDhJQjPiODALo45T2vONsnYg9S/KnPY8QKymHGhhS2rXzoyoM8kbYPmUVrk3MpU7yWOUpf4K58IR5flGOLiQ2vS2y0uymxpwiWRHrrgcRXsWZqG0MRqlsSP2jzYr6WOU9s4IgwWpf6cefSDZlXEjmYH6OcxCA0gOqXPc4q0/yV+kPW2cglihmzr+XlnSKnmn0tCem2XwW9LnNQ9+R7Lzt/Yg2aWxofXPwox26oN5JLESun0qUv8MMQp9ft8Qc6PZaly9jOYrMThiAFHpKRgTQKYtXI9NO4/g5et3mDiksxRAlqzZiZ0HTuHi1dsMIEZ85gwgOsRkAJEKwwCiLQsDiK4XEgOITBkGEPl4YQCR62JtEgB5YMRVBN2VxtWTbpwELBlAjPiQVm7Yi4WrtuL1m/dIk9oRDaqXR5dWtWNaWLZ2F5au2YX3AYHIlc0LD/2fKRGQY6cvoceQ6Vg7fwSyeHkgKDgU9dsPVaIZtX/+kdzDBh2Go12TX7UAZPPuY1i/7TCG9W6FGi0GMoCQFdVvyADCAKIowBEQ6UDgCIi2LBwBkb8zOAIi14UjIHJdVI2AvHiof3FgAguNS0YTeFXPJQOIEbW/dfcRrKys4OaSWolGdOg7CSP6tEbRgrmw98hZjJ2+ApOGdkZmTw/sOngK81dsidmCNXG2H85cuI6Vs//AmGkrEBwcinGD2hvUOxmAHD55ATN8N8LXpx/ENq0qjfowgBikatzGDCAMIAwguucIAwgDCG/B0jU/aFuNGEASI4A8MuIqgu5K45KBbpwELBlAjPiQnjx/hSWrd+LUuat4/fY93rwLwICujfFbrZ/QddBUlCySD83qVVZa/HoLVlhYOBp3GQUX51R45P8Cq+cNh50tLa8h+iN8DSC37/vDe+hMLJrcF65pU+PRkxcMIJwDIh3xtM0enAOi83XBERCOgHAOiHQMMIAwgAgFklUOyEuVACQtA4gRl+zJx1VkZBRqtByIwvlzokvLWnB3c0bPYbNQ7PvcaFq3Emq1HozeHRui7A8FpQAi/lFsxRJRkwmDO6J65ZIGi/M1gIjoR7fB02Fm/umXlqgohIVHwMrKEjNGd0eZEgXASegGyxzrBo6AcASEIyAcAREKcBK6fBwwgDCAJDsAefU4YQuHeN6tcU4fzzsT520cATHSc3n6/DV+atATZ3fNh431xxNiRPQhGkBaeY9HzSqlULdaWXkEJDwCzbqOhke6tLj8311sWDgSjg7U01I+fghdOSDRH5EjIACfgiUf8BwB0aELn4IlFYZPwdKWhQGEAURRgE/Bkg6EZBUBeUU7Oc1Iy8sYNxpn2oljxm7XVP4YQIykrNhCVapmVwzu0Rw/Fs+P/cfOQeR1eLevr0RAFvvtwN+7jil5HeHhEViwaqtyIlX0MbwT5/jh4ePnmDaqG7oPmQ4rS0tMHtbFoN4xgOiXiwGEAUQoQD2ik5oYy0no8nHFOSDaunASesJgn0/BkuvHp2DJdTHFKVghr5/oX2yYwMI6De2YdBM0bRKXDCBGlHXXwdNKonlwSCgqlC4E/6cvUaVcMQVAQkPDMHLKMuw5fAbpXJ1R8cfCytG5AkCOnrqIweMXYtPi0Ujj5Kjkj9RqNViBl+iISVzdHDNtObbtO4kPAUGw1mhgZWWBvxePUfI+vrw4AsIREF3jiCMgCVsUMYAwgHAEhCMgHAHRvVJJThGQkNdPjbhypLuyTpOObpwELBlAksBDMmUXOQckYepyDogO/bgOiFQYrgOiLQvXAUnYzwL0KB0XIpQpzYUI5eOPCxHqXhuEvHmWsIVDPO+2Tk2s6hlP/9/6NgaQb624Ae2JhPFO/SbrvKN4oTzo2LyGAR61TcNObybd/3TrFpLdmXnHSXYaa1qFade8tOqzmSrlJ7Vr5+5MsrNMQ5volgXKkPyZE0/IuWaXk+TPzY6mn50VrTK4BbGqrNmF3aT++W/ZSrK7uPwsyU5jT6u8nTYX7flmqliA1K6dO238WaSlhcb/l5U2X/O7GZb/pe/D7Ln9Rp+J8vcC6WgV4q3GdiT5u7XzP712G/57qddGGEwNvEKyC/QdTrLzP0nz51IgK8nfhQVHSXbXn9IqeVeqm4vk7+EJ2ok8XmUzkfyFj1xCsvOwJ76DLGjgc7F+LVK7Tp6xI/u6bko/ZQXJ3+tgWqX7t91+I/lz+S4zyS4qkhZ3trClvfucOowgtRt5cDnJzsySdgpnWNlmJH9WZrTPGxJJO57YLugFrV0X4xfvC3nznNS2sY2sU7sa26Wq/hhAVJVf/cYZQOTPgAFErgsDiFwXBhC5Lgwg2rowgMjHCgOIjncLA4hUGFUB5C0Nfoy9wrN2ov0gZux2TeWPAcRUyiYRvwwgDCBCAY6AyMcBR0DkunAERFsXjoDomEMcAZEKwxEQ+XhJEhGQt7SorbGXgdZOaY3tUlV/DCCqyq9+4wwgDCAMILrnIQMIAwhvwZKPAd6CJdeFt2DpeGckpy1Y71QCkFQMIOqvmrkHRlOAAYQBhAGEASRaAc4B0R4LDCAMIEIBzgGRj4MUmQPy7pXR1mCGOLJORctxNMSnmrYcAVFT/UTQNgMIAwgDCAMIA4juMcAAwgDCAKJ7fqRIAHn/WpXVm7VjGlXaNVWjDCCmUjaJ+GUAYQBhAGEAYQBhAIlWgE/Bko8FjoBwBCRageD3tFMFjb0MtHGknQBn7HZN5Y8BxFTKJhG/DCAMIAwgDCAMIAwgDCBxf2kzgDCAxADIh7eqrPBsHJxUaddUjTKAmErZJOKXAYQBhAGEAYQBhAGEAYQB5EsFuA6I7vEQ/OGdKis8G4dUqrRrqkYZQEylbBLxywDCAMIAwgDCAMIAwgDCAMIAQlu4BQe8pxka2crG3tHIHtV1xwCirv7S1i9cuYUmXUbhwr5FsLSwIPXw3YdAtOk5Ae2bVkfV8sWk90yeuwa+fttx+eDnSreXmvxK8u9/7inJLuB1MMkuXV7acXLO2Wl27iXyktrVpKUV8jFPTbTLU4rUrllEGMnuTBit0qmrnRXJn40lraqsxoJWMf1WnWqkdm9deEayexlKq0KcJwOtQrdzDtopIRlL5yb1zz49bRxYpKHZPSrRgtRuWlvavDc3oz3ff/xp1bc9nWjVj1d6FSJ9Dv/gcL12dXPS5niFoxv1+hIGa/L8TLJ7EESbk+lsaBW/s2ah7c++RaxKX6FNUdLnWDPnJMmOVo8cKPXvCZI/6lhJb0cbowfylia1S53jXmu3kvwFhtGUeVKX9u7L9mtBUrvv7vqT7DJWpn3HRP7SheTP6vQGkl3kO1qi9cvSrUj+XK1pldCjLGjfbeZBtG1QmjTpSP0zxCg44IMh5kaztbGP/T34+u17DJngi+NnLsHB3hbN61dR1oBJ5WIASYRPKig4FPcePkHu7F6k3k1buB6bdh7By9fvMHFIZymALFmzEzsPnMLFq7cZQAiqMoDIRWIAkevCACLXhQFEWxcGEPlYYQCR68IAItdFVQAJVAlA7GIDSK/hsxEREYEhPVvA/9krdO7vg7ED26HsDzQIJiyFTGrCAGJSeT87X7lhLw4eP49smdNj654TKFk0L7zbN8BIn6U4d+kGbKw1KFowN3yGd8Ht+/5o2GEYzuycb1DvGnQYjnZNftUCkM27j2H9tsMY1rsVarQYyABCUJUBhAFEKMAREPk44AiIti4cAZGPFY6AyHXhCIhclyQRAQmkRZQJSw2DTGzs7GPsQ0PDUPzXzvCbMzTmx+qJc/yUH6LHD+pgkF+1jBlAvpHyAkAmzV2NLi1roXyp7xXgmDDzL2TPkgEdm9fEm3cfsHHHEeXvxgSQwycvYIbvRvj69IPYplWlUR8GEMIzZwBhAGEA0T1RGEAYQHgLlnx+8BYsuS7JagtWUCBhFWF8Extbuxind+77o3qLgcoP1bY2GuXf1249iPVbD8Fv7jDjN24CjwwgJhBV5lIAyMmzlzFjTI+YP7ft/SfSpk6FXp0awt318951YwGI8OM9dCYWTe4L17Sp8ejJCwYQzgGRjnjOAZG/CDgCwhEQzgGRjwEGEAYQoUCKzAEJCvpGK8fYzdjY2sb8w9Ub91C//TBcOrAYZp9yAcXumvkrtmDz0rGq9M/QRhlADFUsnvYyALl17zH+z95Zx1WxbXH8R0uaoNidV6/d3d1d2NiK2IWKjYV67cTuDuzu1ms3iIqigHS+z4wPRM8+nAUc7hDr/POe96xZe+Y3e+bsL2utvZyWbcONu0+RIZ05OrasI6dQaQtApOjHkAmLoaP7/yLAyEiEhoXDwEAfS6YPRbUKJcBF6OIbyhEQjoBwBIQjIJICDCAMIJICXIQungepEUACFQIQ4xgAEhUBuXtiNQwNfxbuSxGQ3YfOY8dKjoDEc6meMg8TAUjUlYaFh+PW/WewHTUfO1dNkQFBmzUgUeNwBATgXbDEzxdHQDgCIilA/as2p2CpzheuARE/Q1wDItaFa0DEuiSHGpAAhQDEJAaAyDUgjfvL6VZRGxbN/Wcbvn7zwdxJ/ZPFQpojIP/RbRIBiLQtbqPa5VEwXw64ffBEh/5TsX/ddASFhDKA/P++8Da84gnK2/CKdaFu0cnb8Cbsr9oMIAwgVFhlAGEAkRRISTUgSQFAJE2HTVoCXV0dTBzeHZ5fv6PfqHmYYt8TdaqV/o9WtgkbhgEkYfqRjxYByOK1e+QdsaRdCzJbpsdAm5ZoWq9SnFOwZjhvwpHT1+DnHwgjQ0MYGOjhwPoZct1HzA9HQDgCom7CcgSEIyAcARHPAU7BShisMoAwgKQ0APEPUKYGxNTkVw2IpKkU7Zg0dx2u3XkMU+M06NKmLgZ0b0FelyptyACi9B1QeHyuARHfAK4BEevCfUDEunAfELEu3AdEVRfuAyKeK9wHRKwL9wFR8xutYCNCP4UAxOwPAFF4+Zjg4RlAEixh4jmQCsb7j56vdoDypYrAtluzBJ2AawFaqC7oRwhpHCtih/PcdYqR/Jllo3UGN8yZj+RP1ywtzc7UgmQXno12HQCtG7BbaBrSuKYGtM4H42rGAAAgAElEQVTl+lEbEGjwSmyEjmN5aN2ZqR3OC2czJ11vvoaFSHbm2a1IdmYF8pLsdC1ondV1ifMlsEhd0rgRkbSuwdRO6J/8NXckl04srRFtXjmko817a0IX8a79ypE0yTHVmWQ305rWOZrkDEA48V70HkIb98O1t6ShS/avR7LbPHgrye61P+0dbvP+HsmfHu2VhtxmNMOH7VuRxs1QgPaM602i9dEKjaA9a2Fju5HOL1fTGiQ7vzfvSXZpK9DmVUgpWgds43c3SeNGBvwg2X3LX5NkZ0FrcA7o0N5BOiG0rXCN0mYknV9cjBhA4qKWelsGEO3omGy9MICIbx11QckAItaPAUSsCwOIqi4MIOK5wgAi1oUBRKwLA4hYl8QAkB/+yqRgmZv+noKVbBee/z9xBpDkfgcTeP4MIAwgkgIcAVEzDzgCIhSGIyCqsnAERPwMcQRErAtHQNQsXpJBBMRXIQCxYABJ4IqXD09SCjCAMIAwgKh/JDkFS6wNAwgDCKdgiZ8NTsES65KSUrB8/WnpX9pe7FmY/uqErm3fSvjjCIgSqiehMRlAGEAYQBhAohTgGhDVucA1IOLngwGEAURSIDXWgPj4KQMgac0YQJLQ8plPJaEKMIAwgDCAMIAwgKifAwwgDCCSAlyELp4HqRFAvBUCkHQMIAld8vLxSUkBBhAGEAYQBhAGEAaQKAV4FyzxXGAAYQCJUuC7QgCSngEkKS2f+VwSqgADCAMIAwgDCAMIAwgDSOy/pgwgDCDRAPJDmRSs9OacgpXQNS8fn4QUYABhAGEAYQBhAGEAYQBhAImpAPcBUT8fvikEIBkYQJLQ6plPJcEKMIAwgDCAMIAwgDCAMIAwgDCA0JZUXgoBSEYGENoNiouV/dRl+KtQHvTs2Cguh5Fsx0xficL5c/7mu2S9Plg+yw6VytK6+ZIG0rLRgLELUadqabRtWgOrtxzG+av3sXnpBC2PAgQGBpF8UgsxfYLDSf48A2idmZ988Sf5K2JpSrLLYkprx5pGn9a914DYadzNN5R0fgU+XyPZQYd2foH5q5L8BYRGkOxM9GldaqndhX+E0Mb96Efr4vz0K22+lMualnS9Vqb6JDtD4pZARpe3kPyFVu1CsvseRHverMO9SP6GWNG6OE/1/pfkj3J/w4idqPPp+dLGNKJ1r6fOUeq99SfOZT/is+ZLfJdam9HeadTryPTpLklnn6ylSXYWfh9Iduf90pHs9Ijv3DLWtN8EfaK/9760d1BIGK2zuj7xnUF8PGBlQntXGRN/20g3A4CRvyfJ1NvIkmRH/U2lrkkSY9Hu5atMClZGC07BIk2iuBj91wDy7JUbcmS1hIlxmric5n9qGxNAvL77wj8gEDmzZdb6OTCAiCVlABHrwgAi1oW6uGMAUdWPAUQ8pxhAxLowgIh1YQAR65IYAPLVl/aHLm0v2DJZ0KBa2+Mmlj+t9QFZt/0ortz6F2vmjYo+16kLNiKNkSHGDOqEt26fMG3BRjx8+gbWmTNieN+2qF2llGwbFwCp3HwQBtq0xJHT1/Dk+VvsWesoRwguXLuPgMBg5LC2xNA+bVCvelnsP34Jk53WQVdHB/r6eihfqgiWzbJD9VZDsWy2nRx18fMPxKwlW3D2yl0YGxmhffNa6NulKXQJfxUZPnkp0qczh7vHF9x99BzFi+TFFPuecF6zB+ev3kMWqwyYO7E/ihXKLV/nvX9fYvbSrXjn9glZs2TCJLvuKFksv/zdh09f4TBvPe49egFrq4wIDApG/+4t5AjIjgNncO7qfSyfbYf7j19h+OQlOLt7UbTOTbqNxcRh3eSITlzPiQGEAURSgCMgan7UOQIiFIYjIKqycARE/AxxBESsC0dAxLokhwjIF4UAxJIBRDxpvn7zQd32I3Bi+3xYZUqH0NAw1GgzDBsWjUOenNZobjMe7ZrVQKeWdfHo6WsMnbgYW5ZNQt6c1nEGkDw5rDGwR0sZZKTF+vPXbvL/prUwxZMX79B3pBMuH1gKQ0MDiFKwYgLIhNlrEBAYhCkje8L3hz+GTFiMrm3qyQt/TR9psf/ijTtGD+yEPDmzYMyMVXj/4TOG9WmLSmWKYu3Wo/D4/BWrnEbi85fvaNV7IhY4DEKF0kVw5tJdOC5yges2Jxjo66NdPwdUKFUEPTo0gl9AIEZNW45OLevEC0Co5yRdHwMIAwgDiPonnVOwxNowgDCAcAqW+NngFCyxLikpBeuLjzIREMu0HAFR+2vdf8wCeREt1XKcvngHKzYdxK5VU3Dn4XOMmLIMZ3cvhM7/c9cnzV0Hy4xpMbR3mzgDyLoFY+S6jqiPFFnYceAs7j9+Cf+AIEgwdMhllgw3sQFI0QK5Ubp+H+xfPwO5c2SR3R06cQU7D53FpiWa6y0kACldvAC6t2sgH7tq8yG8fPMBcyf1l/997c5jTJ67Die2z8OarUfkKND0Mb2jz7tZ93GYOa4v9PR00W/UfJzbuwj6enry9zFTsOIaAaGeEwOI+oUnp2CJteEULLEunIIl1oVrQFR14RoQ8VzhGhCxLlwDItZFyRoQT4UAxIoBRP2izfXcDaxwOYh966bLqUBSylPnVnVw7Mx1bNhxHDtWOkQfvGzDfnh89pIX5HFNwYoJIG4enmjVayLs+rVD07qV5SiIlKa10XkcCuTJHiuAZLHMgBqth+HW8VUwTmMon9vNe08hRUUkaND0+RNAXHa5yilS8x0GyofGTJeattAFR09fg5mpcbRbKfIyZ4ItAoNCsHbrkd/00RaAxHZODCAMIFEKcAqWeC5wBESsC0dAVHXhFCzxXOEULLEunIIl1iU5pGB9VghAMjOAqF+0hYSEomab4XB2HILBE5xxYts8GQikCIidwz84t2eR1iMgh09exeY9J7B9xS+4iQkg42auRv482dC7U+PoE49KwYqKgEjAJKWJSZ+EREBiW+yv3HQIHz97YcrIHioCStAzdsYqnN61IPo7dQDy+Plb9LF3wpVD/0Tb/lkDEjMCwgDyu9y8C5b4+WUAYQCRFOBdsFTnATW6xQDCACIpwClY4nmQklKwPnsrk4KVOR2nYMUaGHBc6CIXYJcomh8LpvyMBISGhcs1IG2aVEeX1vXkGpAhExdjazxrQGJGQKT0K9vR87F2wWhkSGuOzXtOYuMuV+xfP12OgEgF4VJdiNOk/nKkQapP+bMGRCpEnza6V7xqQKiLfSlS08F2KhzsbVCtQgn4+PrLKVpSylqG9Bao294efbo0Qa3KpeQozIKVOzHCtr1KDYivX4B8/lLkqEiBXDIwrd9+DCvmjIguQqeeE0dAOALCEZBYX2fgCAhHQBhAxHOAa0DEujCApHwA+aQQgGRhAIn9B/vRszfyQnvFHHtUq1A82vjN+4+YtnAjHkm7YFllxPB+7eK9C9afNSDSYn3b/jMwM02Ddk1rwmX3CWxaMl4GkE9fvmH4pCV4+vI96tcoJ9dn/LkL1szFm3Hu6j15x672zWqhX9dm5F2w4rLYv/3gORat3oWnL91gZGiAMiUKwsG+BzKkM8f1u0/kXcK+ffdFzcql5GL2Vo2qqQCIJOjOQ+eweM0eGBjooW2TGjh44gqm2PdgAIl9asrfcgSEIyCSAtwHRDwPOALCERDuAyJ+NrgPiFiX1NgH5KO3H2G1oX0T63Rm2neqoEetbcOr4DXw0AlQgHfBEovHRehiXbgIXawL9a/k3AdEVT/uAyKeU9wHRKwL9wER68J9QMS6JEYfEI/vygBI1vQMIAlY7sZ+6J4jF+RCbXWf6WP7wNqK1uU2oSeZlM4lodcS2/E/AgJJ7im72UiObn74QfIXEk7rgF2Y2OE8G7EbsNQThvIhNvyGYZAPxR0QSbtePLlI8udfshnJLjSc1pU3anc6TU6pBYI+xC7OV91p+lHHLWZFe0FTI2GEdkCyZNRuynoRYZoklr//Smu6jAzGtO7HdsaFSeMu8TxPsnsTSXsPf/AN1ujvSwDtYtuYeWj0JRl8Sk+7Vl9i5/K0Rj93JtT0OfX6myYT+XsjPV2SXaUcaUl2Hj9o+qUnzpX8we9J43pZ5CHZWRjSrvfmR1p3aStTWud3aod4s4/3Sddx27AQyY46Lu3NDIQSt8HKZhROOr9IA+02YCaeHmi/vEAEaMqEEX9S08bY+IckEMGIAYQgEsGEIyAEkVKyCQOI+O4ygIh1oYIAA4hYPwYQVV0YQMRzhQFErAsDiFgXBhCxLokBIB8UioBk4whISl6Op75rYwBhAJEU4AiIeB5wBESsC0dAVHXhCIh4rnAERKwL7e/8HAFRtypTMgLi/k2ZFKzsGWgR/uSykuUISHK5U4l0ngwgDCAMIOofLgYQBhBOwRLPAU7BEuvCKVhiXVJSChYDiHYWpAwg2tEx2XphAGEAYQBhAIlSgGtAVOcCAwgDiKQA14CI50FqrAFxUygCkoMjIMl2rc0nLlCAAYQBhAGEAYQBRP0cYABhAGEAUf98pEYAee+lTApWzoycgsUL+RSkAAMIAwgDCAMIAwgDSJQCvAuWeC5wBIQjIFEKvPei7fap7aVizozm2napqD9OwVJUfuUHZwBhAGEAYQBhAGEAYQCJ/feYAYQBJEqBdwoBSC4GEOUXzXwG2lOAAYQBhAGEAYQBhAGEAYQBJD4ri9SYgvX2qzIRkNyZOAISnznKxyRRBRhAGEAYQBhAGEAYQBhAGEDis0xJjQDyRiEAycMAEp8pysdICuw4cAbnrt7H8tl2GgWxn7oMfxXKg54dG2m0TYhBQGAQ6fBIYndSqhmxQTfVHcKIb8HVtz6Qrnf7iRcku9AQWvfZi1PqkPyZ6tI6ZSOStou8Tgitu7BOaCDp/ILMrUl2xNMj398IqkPS2QHE6YJN9z+RPO688IZkd3ZwaZIdtW3wMItSJH8LA5+S7L4E0OZfOmJ3cMospd5bEx3asxaqQ+sOTzk3STTqu0VPh7bRKNEMb7xpHc7zpDMk3VuqkSFoOkfq0DqcB9LcQZcoDPV+pCF2k43U8rvlkz/tGfriH0q6JT9CaP6q5KD9ddwniNZCXJd2e2GkR5v3VJmDwmhPprEBbdz0ZiYkneNixAASF7XU23INiHZ0JHlhAPklEwOIeMowgIh1oS5SSQ8iGEDU6cQAoqoMdcHLACKeVQwgYl0YQMS6JAcAef1FmRSsvJY0yKT+Dipt958ByPDJS5E+nTncPb7g7qPnKF4kL6bY94Tzmj04f/UeslhlwNyJ/VGsUG5Zk7dunzBtwUY8fPoG1pkzYnjftqhd5edf++LqKzaR7/37EuNmrsKnL99hbGSISmWLwXF0L5gYp5EPu3nvKeav2IGXbz8gi1VG9OncBC0bVoXHp6+YuXgLbj14BuM0hmhQszzGDu6MkJBQLFq9G67nbiI0LAwNa5XHqAEdYWCgn6AIyPmr97Fg1U54fPJC0YK5MHmEDfLlyiqfY+Xmg9CzQyN5zHfun1ClXHHMnWgLQ0MD+fvNe05iw87j8PH1Q67sWeD13Qdndy+Sv+MIiHh2cAREzY8DR0CEwnAERDxfKH/LpMIlR0DEGnMERKwLR0DEunAEJOHL7lcKAUg+BpD43TwJGl68ccfogZ2QJ2cWjJmxCu8/fMawPm1RqUxRrN16FB6fv2KV00iEhoWjuc14tGtWA51a1sWjp68xdOJibFk2CXlzWssAQvWl6Wy/eHnD67svcmazQkhIGKY7b0LeXFkx0KYF3D9+QatekzB9TG9ULV8cz169x4Mnr9G1TT207j0ZtSqXRO/OTfD1mw/2HD6PUQM7YtaSLfjo6YVZ4/pBCu0OHLcQ9WuUk4+JbwRE0qltXwcsdhyKkn/lx54j5+Gy6wQOu8ySwUYCkOKF82KATQuYmqTBwHGLMKB7c7RuXB2nLt7GrMVbsMhxCHJnz4wjp69h5aaDDCAaJgYDCAOIpACnYInnAadgqerCERDxXOEIiFgXjoCo+Y1JBilYDCCaVta07//TCEjp4gXQvV0D+cxWbT6El28+YO6k/vK/r915jMlz1+HE9nm48/A5RkxZhrO7F0Ln/3mhk+aug2XGtBjau40MIFRfmmQIDgmFyy5XXLh2X44u/PAPQLUKJTDfYSCWuxzAs5duWDRt8G9ubj94juGTl+DcHmfo6f1KlJSAo2xDWxzaOBNZs2SSjzl+9gb2H7+IFXPs4w0gK1wO4tW7D3CaNCD6PBp1GQ2HET1QsUxRGUDWLRiDwvlzyt9PmbcBZmbGGNm/AwaPd0alskXRpXU9+btHz95gyARnBhAGkN8U4BoQ8YRgAGEA4RQs8RzgGhCxLlwDoma+UMKhAJJDCtZLT19NS8tE+T6/lUWi+FXKqWIAIi367z9+JS/0pY/0/6VFvZQadOzMdWzYcRw7VjpE67Jsw354fPaSoxF/AkhsvjQJ6zBvPV68dscku+4okDc7dhw4K6ddSdAhfWdmaiynUMX8HD51VYaWnSun/PbfpUhK9VZD5ZSxqE94eDhyZLWCy+Lx8QaQqQs2ypENCSiiPj2Gz0arRtXQokEVFQBxWrYdYeHhGDekC1r0nAB72/aoXvFvBhAAXIQufiIYQBhAJAW4BkR1HjCAMIBoWkfE/J4BJOUDyAuFAKQAA0hcHsVftnGBBikCYufwD87tWUSKgCQEQKRIwvihXeWoh/TZsvdUNIAs23gAL9+4Y8GUQb9d9K37zzBiinR+ztDV/bUTQ0REJMo07IcT25xgmTGdilDxTcGSIiBSDcq8yb8iIA07j8YUe3EEJCaA2AybJdesSLAifTgCwrtgiZ5gBhAGEAYQ8RxgAGEAicuqhwGEASQu8yUutgwgcVErhm1cACSqBqRNk+py6pBUAzJk4mJsjVEDEjMFKyEA0nfkPGTPaolBPVri2Ss3TF/kgkL5csoRkDfvP6K97RTMGt9PrgGRIOD+v6/QrmkNtOg5US4w79WxEX74BWD3kfNyepiU/vTlm7dckJ4xfVq5VkUqDG9ev0q8IyBSDUibPg5wdhyM0sULCmtAYqZgxQSQtduO4ujpa1g4dRBCQ8OweusRXL/zmFOwNMxjrgERC8Tb8Ip14SJ0NYsOwu8FF6GLReJteBMGhFyELtaPi9AJLyUNJs8/K5OCVTAzp2DF6+7FBUCkAaTF/7SFG/FI2gXLKiOG92v32y5Y2gIQqQ5llONyvHP/jL+L5ZPTpXx/BETXfVy68VDe1Uo6H2mnLmkXLCmaIO3SNXvpFtx99BJpjAzRqHYFGToCg0KwdP1eeUeqb999kSObFXq0bygfE98IiKSHtAvW/JU78fHzVxQtmFtlFyx1ACLVuEi7iZ28cEsGopqVS+L0xdtyrY304V2wxNOZAYQBRFKAa0DE84CL0FV14SJ08VzhInSxLlyEruY3JhkUoT9TCEAKMYDEiz/4oCSiwMXrD+UNADYtGc8AEss9YQBhAGEAUf+AMIAwgHARuvj54BQsNdHQFFSEzgCinQXtf1aErp3TjZsXKZWr/+j5ag8qX6oIbLs1i5tTLVhLdRgLV+5S66lb2/pypEIbH2mbYamXSokieREQGIxJc9eiZqWS0R3Wff1pHbC1cS4xfRCb3pKHrTnrPMm2YP5fGwTEdkCODLTuqSHhtK6yrudonbLvTatKug5dYodzRNC66IZZZCGNG0z86xTJGQDqPIhRahWra2q33cZLr5JOsWwhS5Jd1nTGJLuhFX727tH0GW5SVJOJ/L2z712S3dewnz2BNH0siB3Ow4mt5IlrDk2nJX9P7QMSBGIndOLJUVPE9KmTlHS1wNhjz0mWMxsWINlF7SipyThNeIAmE/n7SENTkp1uoDfJzkePll7y3Iv2m1XGmnZ+ocS5TDTD1wDaO/eRpz9JlxdeNLuuf9Pe4dNOviSNm9niZy80TZ/hVX7uvqnpExRG+63UJf4ofA+i6VwwEQq3nyoUASnMERBN04y/T0oKuHl4ot+o+XLqltQIsmGtCrDr2za6SSEDiPhuMYCIdWEAEevCACLWhbjGJ70yGUDEMjGAiHVhABHrwgBCet3EavTkkzI1IEWy0CA94Vf433hI0RGQ/0bC5D0KAwgDiKQAR0DE84AjIGJdOAKiqgtHQMRzhSMgYl04AqJmviSDCMjjTz6KLPyKZkmryLiJNSgDSGIpm0z8MoAwgDCAqH9YGUAYQDgFS010i1OwhMJwCpZ4vqSkFCwGEO0scBlAtKNjsvXCAMIAwgDCABKlANeAqM4FBhAGEEkBrgERz4PUWAPy70dlIiDFrDkCkmwX23ziqgowgDCAMIAwgDCAqJ8DDCAMIAwg6p+P1AggjxQCkL8YQHgZn5IUYABhAGEAYQBhAGEAiVKAd8ESzwWOgHAEJEoBBhDtrII5BUs7OiZbLwwgDCAMIAwgDCAMIAwgsf+MM4AwgEQp8NBDmRSs4lk5BSvZLrb5xFUVYABhAGEAYQBhAGEAYQBhAImpAPcBUT8fHigEICUYQHgZn5IUYABhAGEAYQBhAGEAYQBhAGEAoa3uGEBoOmmy4hQsTQrF8/vqrYZi2Ww7/FUoTzw9AMMnL0Xp4gXQvV2DePuIeeCY6StROH/O6C7o0ndBgbSusjrEjtqRunqkc51+/h3JbsfBpyS7mjVyk+wKZDYn2WU2NyLZUbvoHrnvQfK3s2V2kh0iaV1lw81pnbwDQmkt44z0dUnnp6dDMgNtVMDpIm2+7D5F6/LbqBptvuS1NCNdiJWpIcnOtXglkt2igMckO53QYJId9Gid0CMvbyf5C6nShWTnSegK7fGDdg3FrUxIY6bRo81R6twjDQrALyScZHr3E62z9dLzr0j+lrQpTrKzMqF1iNf3/0ry52eUgWRnGkm7v0feB5H8ffEPIdl1+suKZEdNrbr/mXbfFp2j3bf2ZWjv+qeff5Cuw65KLpLdtkefSXbmRrT50rpwJpI//1Dab5axPu3H41sQ7XnLmYH2DiddxP+N7n3wjou51mxLZkunNV9JwREDSCLdBQaQ2IVlABHrwwAi1oUBRKwLA4iqLgwg4rnCACLWhQFErAsDiPo1zF13ZQCkVHYGEI1L9srNB6FH+4Y4fvYG3rl/RtumNdC0biXMWrIFT1++x9/F8mHR1CFIa2Eq+zp/9T4WrNoJj09eKFowFyaPsEG+XFnl7+LqK7aT27L3FNZsPYzv3j+QPp052jWtiYE9WkYfsv3AGbjscsUXL28UzJsDYwd3RvEieXHz3lPMX7EDL99+QBarjOjTuQlaNqwKz6/ecFzkgrsPX8DY2Aj9ujaVfUqfuADIlr0nsXGnK755+yJntsyw69cO1SqUkCMglhnTwuOzl3wOuXNkwbzJA5Ez28+/7MSmm3SsdeaMcP/4BVdvPUL9GuVw+NRV6OroQF9fD+VLFcGyWXYcAVEzYTgCIhaGIyBqFnccAREKwxEQVVk4AiJ+hjgCItaFIyBiXZSMgNxRCEBKM4Bo5A8ZGkoUyYdB0uJeRwf9Rjohs2UGjLBtJy+i7acuR/0aZdG3S1O8//AZbfs6YLHjUJT8Kz/2HDkPl10ncNhlFgwM9OPkS9OZvXr7AQYGBrDKlA5e333Rb9Q8TB3ZE2X/LoQjp69h4cqdWOQ4RIaAyzcewsjQAAXz5UCrXpMwfUxvVC1fHM9evceDJ6/RvW0DtLedggY1y8kpTe4eX9B96EyschoppzlRAeTJi3fyeWxaMgFZrDLg3qOXCAgMQu2qpWUAefHGHfa27eXzkADO3MwEs8f306ibdOz9xy8xol97/FU4j3yc07LtnILFKVjCx4RTsMRvD07BEuvCKViqunAKlniucAqWWBdOwRLrkhxSsG67fde03EyU78vkSJ8ofpVymigpWBKArFswRl7sSp8+I53khXpUdGDJur34/OW7vKhf4XIQr959gNOkAdEaNOoyGg4jeqBimaIygFB9aRLx05dv2LDjOG7cfYLvPj/g7euPsYM6oUOL2uhlNwd1qpVBl9Z1f3Oz3OUAnr10w6Jpg3/77w8ev8LIactxYvu86P8+baELsmXJhN6dGpMB5M7DF+htPxfLZg5H2ZKFYaD/q4bizxoQCZJcdrpix0oHjbqJ6ke4BgTgGhDxU8IAwgAiKcA1IJp+RdR/zwDCACIpwDUg4nmQkmpAbikEIGUZQDS/oP+EhiETnOXogbTQlz6rtxzGyzcfMGeiLaYu2AhTkzQY2b9DtOMew2ejVaNqaNGgigqAxOYrtjOLiIhEM5txKF28IAbatJCjDXYO/6BcycIydDTqMkZOuapR6e/f3DjMWw8zU2OMGtDxt/8upZeNm7UaGdNbRP/3kJBQtG5cHcP7tiUDSJQeuw+fh6eXt1x0PtnOBrmyZ1YpQj935R4Wr92DvWsdNerGACKeDQwgDCCSAlyELp4HDCCaf9/UWTCAMIAwgKh/flISgNx8r0wEpFxOjoBofEPHBUCkCIhUWzFv8q8ISMPOozHFXhwBiS+ASBGX2u3scNt1FdIY/dyxRlqkRwFIT7vZcp1Ep5Z1fru+ZRsP4OUbdyyYMui3/y5FLibOWYOjm+cI9aCmYMU8+Os3H8xcvBlh4eFyStqfEBETQDTpJgKQcTNXI3+ebHKEJurDu2CJpzPXgIh14RoQsS68C5ZYF64BUdWFa0DEc4VrQMS6cA2IWBcla0BuvPumcR2cGAblc9F2nkuMsRPD53+SghUbNEg1IG36OMDZcbAcnRDVgMRMwYovgISGhsnRlAnDusnRmDOX78o1EVK0QoqA7Dt2Ecs3HoCz4xDkyWmNKzcfQVdXV45ESLUes8b3k4+TYOn+v6/QvnkttOkzGXWrlUa3tvWhAx08fPparlupWLooOQJy5dYjuH/8inrVy8DMxBizlm6FdK6Oo3vFCiCadBMBiPOaPZBqTpwm9UdgUIhcC8MAwgAiKcApWOJ5wDUgYl24BkRVF46AcASEIyCpIwJyTSEAqcgAopmD4mx9s6wAACAASURBVBIBkbxJuznNX7kTHz9/RdGCuVV2wdIGgEjjuJ67KUcYgoJDUKtKKXz87CVHPSQAiYyMxMZdrti+/4y8C1ahfDkwbkgXeResSzceYtHq3Xjz/qOcuiXtgiWliHl8+gqn5dtx6/4zBAWHyjUvIwd0wN9F85EB5Plrd8xw3oRnr9wg7X5doXRRONjbIH1a81gBRJNuIgCRamCGT1oi70QmXffcSf0ZQNRMZ46AcAREUoABhAFE8y/eTwsGEAYQBpDUASBX3yoTAamUmyMg1Pcx2yUDBTgCwhEQjoCof1AZQBhAqK9xBhAGEAaQ1AEgV956UV8LWrWrnDujVv0p7SxRUrCUuKg9Ry7g6OlraoeePrYPrK3+e3pMqucVJVTo59ek26UTSutSq+NH66Ib9uENadzwr7QO4u9PXif5c7/6gWT32M2XZGdO7Axeq085kj/XNo4ku5BwWlfZcGKXLTNDWgf7nlbEv/z40xo1hXm60673Pa3D+Q83T5K/18cekuyePqHN51vfac9Hg4dXSeO++Errurz/Cq1D/Cm7KqRxQ4nzxeTJKZK/sE/vNdrppqF1OEe55hp9SQYGn5+S7CICaB2moUfrCB3hSyxMjaA9u4/mrSFdR4lpo0h2AK33++rAQiR/Nn9nIdlJ2QWUj//ycRQzeL9wI9nlXLSFZIdI2v3Qubqb5M/75k2S3bM9t0l2f/WsRrIz6ziCZOe3fQHJzucV7bfXa9hikr8SJgEkO+jokux0QmjvSIMs+Un+4mJ0+Y0yAFIlDwNIXO4T2yZxBRhAxDeIAUSsCwOIWBcGELEuDCACXRhAhJOFAUT8DDGAiHVREkAuKQQgVRlAkviKmk8vTgowgDCASApwBEQ8DzgCItaFIyCqunAERDxXOAIi1oUjIGqWKskgAnLxNS0yHqfFGMG4Wt5MBKvkY5JiUrCSj+RJ60wZQBhAGEDUP5MMIAwgnIIlngOcgiXWhVOwxLqkpBSs86+UAZAa+RhAktYKms8mQQowgDCAMIAwgEQpwDUggrnANSDCB4QBhAFEUiA11oCcUwhAajKAJGi9ywcnMQUYQBhAGEAYQBhAYnkxM4AwgADgInTxM5IaAeTsyy+KrORq5bdUZNzEGpRTsBJL2WTilwGEAYQBhAGEAYQBJEoB3gVLPBcYQBhAohQ4oxCA1GYASSYraz5NkgIMIAwgDCAMIAwgDCAMILH/ZDKAMIBEKXD6hTIRkDoFOAJCWtiyUfJQgAGEAYQBhAGEAYQBhAGEASSmAtwHRP18OPWc1m9K26vAugWttO1SUX+cgqWo/MoPHubxjHQSOsG0pj8Rn9+S/IW8eUKy83v/iWT34tBdkt3N+7QXR9HMpiR/JploTdTMs5uT/N0cvZJkF0ZsGEdyBiBH2jQk08aGmhvLSY7Cv9N0DvvwijSuz5MXNLvXtOZZ/x6gzfsTnrR5XzY9Tb/wY66k63jykdYIM3cm2jztVcqaNG5wOK1pnMXdfSR/oYQGkrqGhiRfeo1saXZvaQ3eqNvm6hgakcYN96K9qyICaXPqvL0Ladza6+xJdjpGtDm6TpfWNNWmJK0RYQhxTnk7DiBdh9djWjPZwjsOkfyRjY4uJZl6Xn9Asnt55DHJrmDLEiS7LCNnkey+/jOFZOfziqZzyPRNJH9F0viR7KBnQLLT9aM1A9TPXoTkLy5GJxUCkHoMIHG5Tcrabtl7Ctdu/4slM4YpeyLE0X39AtDLbg76dmmKBjV//QgEBAZh1pKtuHzzIcLDI1CsUG5MHNYNWbP83JLNzcMTM5w34faDF7DMmBZ9OjdB68bVhaM+evYGQyY44+zuRfL3DCDim8MAItaFAUSsCwOIWBcGEFVdGEDEc4UBRKwLA4hYFyUBxPUZ7Q9sxKUf2axBIY6AkMVS2jA5AYjzmj3Yf/wivL77wmnSgN8AZPqiTfD67oPZE2yhr6cHp+Xb8ezVe6xfOBYhIaFo2WsimtWvjJ4dGuHx83cYPH4RZozrg1qVS6ncAgYQ2ouDAYQBRFKAIyDiecAREFVdOAIiniscARHrwhEQNSvEZBABOf7ssyLL24aFMisybmINmiJSsK7deQynZdvx1u0TMqa3QIcWtdG7U2NIAHLm0h3ky50Vx85ch5GhASaPsEH1in/Leo6duQoXrt1HQGAwclhbYmifNqhXvaz83fDJS2GdOSPcP37B1VuPMHpgJ4SGheP42RvIlT0zzl65CwszU0y2645KZYvJx9z79yVmL92Kd26f5OjEJLvuKFksf5zuXbt+U+QIRswIiM2wWShfsjAG9Wwl+zp35R5mLN6Mk9vn4c7D5xgwdiGuHloGXV0d+fuFq3bJWjg7DpH/7bLLFRt3uuKHfwAK5csJ94+eHAHRcFcYQBhAGEDUPyQMIAwgnIIlfj44BUusS0pKwTr2VBkAaVSYASROC+rENpZSkqq1HCL/xb9queJ44/YJt+4/Q+dWdWQAWbx2D4b1aYtqFYrj8Kmr2H3oPE7vWiCf1v3Hr2BtlRFpLUzx5MU79B3phMsHlsLQ0EAGkPuPX2JEv/b4q3AemJuZwPXcTSzbuF/+b+VLFZb/vX7HMZzeuQA+vv5o1XsiFjgMQoXSRXDm0l04LnKB6zYnGXyoHxGAnLp4G2NnrETnVnXRomFVzP1nmwxKbZvWwJnLdzFx9hpcOfRP9BAHXC/L0LFnzTRIx85cvBnzJg9A7hzWcD13A6s2H2IAYQD5TQGuARFPCI6AiHVhAGEAYQBhAJEUSI01IEefKAMgjYswgFDX0v+JnRSVqNhkAIb0ai0vyM1MjaPH/TMF64uXN2q2GY5bx1fBOI2hHLHYceCsDBr+AUH4+s0Hh1xmIW9OaxlAShcvgO7tGqj1FxkZieqthsqRhjsPX8hRh+ljekfbN+s+DjPH9UXxInnJWogA5NOXb7Cfsgx5c2XFxesPYGFmIte1SJEYKWWrSbexsO3aDJ1b14XvD38s27AfD568lgFk0PhFqFSmGLq2qSefA6dgcQqWaDIygDCASApwEbrqPOAidPGzwQDCAJJaAeTIE9qGE+SFH9GwSRHaxg9Ed4qbpYgULCkKsMLlAJ69dJPTraSIR41Kf8sRkJhF6FIxd7lG/XH18DL4+PqhVa+JsOvXDk3rVpajIJWbD8JG53EokCc7CUCku9ei5wR5vEs3HuLo6Wu/AZA03pwJtqhWgbaLheRPBCCdBjqifbOaaNWoGsLCw7Fk7V5IUY4T25zkaI0U8ZGK0KXoT7YsmWCZMR3MTY1lSJHOz962fXTaGQMIAwgDCMC7YIl/exhAGEB4Fyw16zLeBUsoTGqMgBx+rAyANC3KAKI4Nak7AamWY9v+01iz5bAMGbEByIWr97F5zwlsX+EQ7S6uACJFX6T0L5fF43H28l18/OyFKSN7JEifPwFEirKUrNsHW5ZNxF+F8si+P3/5jtrt7HBqx3y5TuXPT5+RTqhfvSzaN6+FHsNno3n9ytG7YjGAMIAwgDCAqHtJMYAwgDCAMIBICvA2vOqXcgcVApDmDCAJWl9r/WApbUqqd5AW29Jf/4+cuoal6/fh+Na5sQLI63cesB09H2sXjEaGtObYvOckNu5yxf7102ONgBxwvYR5kwfC1CQN1mw9gruPXmDbsklysXoH26lwsLeRIx5STYhUHF+hVJHo7XIpFy+KgPQeMRdpLcwwY2wfuZ5k5eaDOHb6Og5unCm7lDSQdsfy8vbF5t0nfqaWrXCQoyPrtx+ToyWzxvdFWFg4Vm89jIdPXnMNiIabwUXoYoF4G16xLrwNr1gX3oZXVRfehlc8V3gbXrEuvA2vWBclt+E98O9HynJO6zYtitH6OWl94ERymOxTsKQ0p4lz1sppSIFBwTI8TBjWTe6VEVsERKqjWLByJ7btPwMz0zRo17QmXHafwKYl42MFkA07j8PQQB+fPL+hTImCmDqqF6ytMsi35/aD51i0eheevnSTQUH63sG+BzKk09yETkqhOnL6Gvz8A2FkaAgDAz0cWD9DTqeSalek3bWka9TR0UGJonkxdlDnaLCRwGne8u3IkM4CdauVwdDebeSUMukjbdM7baELTl64hcyWGVCnaml5u1/uAxL7E8UAwgAiKcBF6OJ5wEXoqrrwNrziucLb8Ip14W141fwGJ4NtePcrBCAtGUASCYWSgdvk1FeEKmf4W1oHcfh7k1yGvn1KsvN+ROsC+/3pO5K/o7tp45Yu8BMWNX0yFkivyUT+3iwbzd/tLfdI/gKOHifZhUfSOlabGuiR/BXMSOuoXcL7Dslf2FdaR/LgN7SO5J9v0ew8H9D+MrXpkhvpOupb0XSxyk+bL4fG0TrdX/6XtsvKgYEVSdehp/Nzi25Nnw8/QjWZyN/nvbWRZOf7+LlGO700tE7oFjZjNPqSDf49R7KL8P5KstMxtSDZhX2ivasCPb+T/LlOO0qya7XchmSna5aOZLclUyOSXefitKZo/iERJH9e9l1Idh/v0J7x8pdo8yAStHdp8Lpf6dqxnajnHc1zXjr+411aHUGeOgVIumQdO5tk93RgH5Ld91e03/wMh2i/WYUNfEnjRhjS3rn63rRO7Xo5i5PGjYvRvke0ORgXnxTbVn9xBISiU4q0iQ+ASHUi/UfPV6tH+VJFYNutmWJ6MYCIpWcAEevCACLWhQFErAsDiKouDCDiucIAItaFAUSsi5IAsvch7Q9s2l7YtS6eVdsuFfWX7FOw/kv14gMg/+X5xWcsBhAGEEkBjoCI5wFHQMS6cAREVReOgIjnCkdAxLpwBESsS3KIgOxRCEDaMIDEZ5nLxyRVBRhAGEAYQNQ/nQwgDCCcgiWeA5yCJdaFU7DEuqSkFKzdD5SJgLQtwRGQpLqW5vOKhwIMIAwgDCAMIFEKcA2I6lxgAGEAkRTgGhDxPEiNNSA7H9DqT+KxJIv1kPYlsmnbpaL+OAVLUfmVH5wBhAGEAYQBhAFE/RxgAGEAYQBR/3ykRgDZcV8ZAOnwNwOI8qtmPgOtKcAAwgDCAMIAwgDCABKlAO+CJZ4LHAHhCEiUAtvvKQMgHUsygGht8cuOlFeAAYQBhAGEAYQBhAGEAST232MGEAaQKAW23XNXZPHWqWR2RcZNrEE5BSuxlE0mfhlAGEAYQBhAGEAYQBhAGEBiKsB9QNTPh613lQGQzqUYQJLJ0ppPk6IAAwgDCAMIAwgDCAMIAwgDCAMIZdUEbFEIQLowgNBuEFslDwXCH50hnSh1j/tv12+S/L04ROsMfu3RF5K/Rk1p3WLT5ad1EjXLbkka1yRfQZLdj8f/kuzO1bYn2Zkb6pPsslukIdmZG+qS7LI8OUKyC31P6wb84eJ9kr+n+2md7o9+8iP561Y1B8kuUxHaPDDPmZnkr+GPpiS7S5Nrk+zCI2ldnD/7h5H8XXP3Idk1Ob+AZPf+3COSHcWoxGpaF/nQi3so7hDwgdaJ2jhzRpK/L7dpc9TzIe2vp36f/Enj5qlLe/dZ5Ka9+05VG04at3lBmi6hEbQ5eq9WHdK4EeG0zurlLp0l+QsNp52fx6AOJH+fH3iS7CxyWJDsslctTLJLO5jWCT1w03SSP78PtN/egEG0d0Eew0DSuBFGZiQ7PT/a+RlY5Sb5i4vRpjtucTHXmm230rTfLa0NmMiOUnUKVuXmg7BuwRgUzp8zkWVOuPvPX77Dec1uXLz+AD4//DF3Yn80rFVedrxhx3HsO34Rbh88kcbIEDUqlcTE4d1gaqK6+Hz07A2GTHDG2d2L5GMZQMT3hgFErAsDiFgXBhCxLgwgqrowgIjnCgOIWBcGELEuSgKIi0IA0p0BJOGL6aTiIbkAiAQcbfpMRoOa5dCuaU1YmJtCRwdIn9ZclnLfsYvInzsbcmS1gtd3HwybvBStG1dDr46NVaRmAKH9FZABhAFEUoAjIOJ5wBEQVV04AiKeKxwBEevCERCxLskhArLxtjIREJsyHAFJKvxAOo+QkFDMXLwFpy/dRkhoGIoWzAXH0b2R3doSEoD069IMx85cx+v3HqhSrjjmTrSFoaEBAgKD0XXwdLh5fEFkZASKFMgNhxE2yJ/n5zZo0rEDbVriyOlrePL8LfasdUS3ITPQuWVdnLl8Bx8+fUWtKqUwdWRPGBkayMfsOXIBa7cdgbePH/4ull/+zipTOo3XsXjtHtnfnAm2sdqGh0fI1zF88lJMHmGDCqWKyPYuu1yxcacrfvgHoFC+nHD/6MkREA2qM4AwgDCAqH9IGEAYQDgFS/x8cAqWWJeUlIK14dZ7jeu2xDDoUTbpZ+vE5bpTfArWxl2uuHD1PpwmD4Ceni7OXbmHYgVzyyAhQUTxwnkxwKaFnK40cNwiDOjeHK0bV0doWDgePH4lRxYkINl16CzOXrmL9QvHRgNInhzWGNijJawzZ4S1VUbUaW8nL/p7dWoCQwN92E9dhjaNq6Nnx0Y4ffEO5q/cgZVz7WX7hSt3we2jJxY7DtV4v6Toh2XGtHjn/hmfvnxHkfw5MWVkTxTM+/uOCMVq9oCBvh4m2dmgTZPqst9TF29j5uLNmDd5AHLnsIbruRtYtfkQAwgDyG8KcA2IeEJwBIQjIFwDIp4DDCAMIJICqbEGZL1CANKTAUTjejlJGazcdEiOcMyZaCsv2HWk3KX/f/5MwZoybwPMzIwxsv/PYrPDJ6/i6JlrePHmAwICg6Cnq4sL+xZHA8if9SN/+tu67zROX7yNtQtGw3b0fDSuUxEtGlSRj/f67ov6HUfitusqjXpVbjYInVvVRZc2dWFoYICl6/fhxLmbOLZljgxHUZ+IiEi8evdBBqlRAzqifo2yGDR+ESqVKYauberJZpyCxSlYognHAMIAIinAReiq84ABhAFEUoCL0MXzIDUCyLqbykRAepXjCIjGBXNSMvDzD8Scf7bJKVjSAr1utTIYP7QrTIyN5AhITIhwWrYdYeHhGDekCw6fugrp39NG9UL5UkXktCWbYbNw5eA/ZAA5cf4WVm46iD1rpqFZ93Hw9QuAgcGv3Yt++AXgzK6FwmLxmBpK57lw6uDolKrAoBCUa2SLnSsdULSg6g4PC1buhPvHr1gwZSBa9JwAe9v2qF7xbwYQALwLlvjpZABhAGEAEc8BBhAGEAYQ9au61Agga2++U2SZ27tcLkXGTaxBU3wKVkzhXr3zwNCJi9GpZR05IhAbgEx2Woe05maw799edvHijXucAWTd9qO4/+8rODsOQW/7uXJqV5M6FeN8Lzv2n4pm9SujS+ufUQypPkUCkJPb5yFrlkwq/qYtdEFQUDBmjuuLHsNno3n9yvLYHAFhAFE3+RhAGEAYQBhAJAV4G17xPOAICEdAohRYfUMZAOlbngEkzgtoJQ/YsvcUcmazQpkShRAaFoa+I53QrU19eUEfG4Cs3nJYTp+a5zAQ/gFBmL9ih5y+pCkCYtevHRrULI/X7zxg57BUjqBUq1BCLlZfum4f5kzoh4L5cshF5ZduPIRNuwYa5dl56Bz+Wb9Prh/JmS2zvB3v4+fvsGnJeEiF58MdlspAlS9XVtx5+ALjZ62SIybSuOu3H8MB18uYNb4vwsLCsXrrYTx88pprQDSozkXoYoF4G141ESTuAyIUhrfhVZWFt+EVP0O8Da9YF96GV6yLktvwrrquDID0q8AAonHBnJQMpKLrFS4H4ebhCVMTYzSvXwUSJOjq6sQKIBJ0jHJcjmu3HyN7VivUr14WW/ef0gggEgQ8fekGCzMT9O7cBJ1b/WqutPvwebjsPgF3D09kSG+BetXLYsygTiS5pGjK5j0nZRiqUu4vOY0sU4a0iIyMxKS563Dj7hN8+eaD7FkyoW/XpvJ1Sh9pFzApInLywi1ktsyAOlVLY//xiwwgDCC/KcAREI6AcASEIyAcAVH/w8AREI6ARCmw8vpb0rpN20a2FbTfVFHb5xgXf6kqBSsuwsTHNrn0FYl5bSGXd5EuNfQdrcvv22PXSf4O7n1GsqtUiNZtt0CLnzUumj6mWWn+jCxpHbANC5fVNKT8ffhXD5LdsfQ1SHZ50huT7MyIHc5N9Gmd0NNd3UQa1/cxbb68OnyX5G/jOdpfnBpnoXXRLdK6KGlc8xxWJDtTa9q8Wpi1M8mfXRVasWEYscv0mTfepHGzWag2LxUdaOU8hOTv1THN8yCS1tgatc7vII3pt28Nyc77Ja0jObXJ5LtT90njvrxOexcUqkbb8z88hCZgpqJZSed332YOya527rQkOz3dXxu/xHbAlXLVSP5MLU1IdiWOuJLsfIPDSXZunZqT7Cxy0HSJCAsj+ctauTjJTr/LRJKd7gnNG99IjkK+0jqNf2sxhjRuViPa9UYa0N5Buv7fSOMaZvzZOkGbnxXXlAGQ/hUZQLR5H1OUr/gAiJTWJW3Jq+7TrW191KxcMtF0YgARS8sAItaFAUSsCwOIWBcGEFVdGEDEc4UBRKwLA4hYFyUBZLlCADKAASTR1sLJ3nF8AETpi2YAYQCRFOAIiHgecARErAtHQFR14QiIeK5wBESsC0dAxLokhwjIsqtvFFm6DayUR5FxE2tQTsFKLGWTiV8GEAYQBhD1DysDCAMIp2CJ5wCnYIl14RQsNZGcFJSCtfSKMgAyuDIDSDJZWvNpUhRgAGEAYQBhAIlSgGtAVOcCAwgDiKQA14CI50FqrAFZohCADGEAoSxr2Sa5KMAAwgDCAMIAwgASyxwgbrHMKVhiDTkFS6wLp2CJdUkOKViLL79WZIk3tEpeRcZNrEE5BSuxlE0mfhlAGEAYQBhAGEAYQKIU4F2wxHOBIyAcAYlSwPmSMgAyrCoDSDJZWvNpUhRgAGEAYQBhAGEAYQBhAIn9F5MBhAEkSoGFF19Rlldat7Grlk/rPpV0yBEQJdVPAmMzgDCAMIAwgDCAMIAwgDCAxFSA+4Conw8LLigDICOqM4AkgWUzn4K2FGAAYQBhAGEAYQBhAGEAYQBhAKGtrOZdeEkz1LLVyOr5texRWXepOgKSXPp2uJ67gdVbjuCd+yekMTJE3WplMHZIFxgZGkTPntCwcMxYtAn6+nqYOLyb2lklNT4cMsEZZ3cvkm38Nk0hzUC3M3dIdnt3PCHZNWtegGSXoSCte2+GkkVI/vQsMpDsdM3Tk+wiitC690JXn+TvjhetK282c0OSPyM9WhdiA2K34oj1k0jjvj5C63C+7gQtl9amZi7SuBkL0zrYZylPmy8GGTKRxtUlzquISu1I/kLCI0l2VKNjL2ldgytlp3Vxfl6tJmnoJ+4/NNrltaDN5fr3j2v0JRk8GdCHZOdxg9aRPHMJK5K/F9c+kOyMiM9apRF1SP6uLjhDsjMh6mx+4hTJX860RiS7TIa0Tu13mzcj+Uufl/ZuzrRgC8mfD7ETuk/ftiR/eRqXIdn5f/Qi2WUsV4pkF1bDhmRn9O9Jkl2EnzfJzqtUG5JdBiPabxF0dEn+dAN9SHaG6TOT7OJi5HReGQAZVYMBJC73KUnbJhcA2bb/NDKkM0fJYgXg7euHkVOXoX7NchjSq7Ws75nLdzFz8WZ89/6BVo2qMYDEMusYQMTiMICo0YUBRCgMA4iqLAwg4meIAUSsCwOImh/qZAAgc869UGRtO6Ym7Q+3ipxcPAZN8RGQkJBQzFy8Bacv3UZIaBiKFswFx9G9kd3aEhKA9OvSDMfOXMfr9x6oUq445k60haGhAQICg9F18HS4eXxBZGQEihTIDYcRNsifJ5sss3TsQJuWOHL6Gp48f4s9ax3RbcgMdG5ZF2cu38GHT19Rq0opTB3ZMzpSsefIBazddgTePn74u1h++TurTOnifNuWrNuLZy/dsHTmsN+OdVq2HcEhoSoA4rLLFRt3uuKHfwAK5csJ94+eHAHRoDpHQMQCcQRErAtHQMS6cAREVReOgIjnCkdAxLpwBETNO1fBCMjss8oAyNhaDCBxXjArecDGXa64cPU+nCYPgJ6eLs5duYdiBXPLICFBRPHCeTHApgVMTdJg4LhFGNC9OVo3rg4ppenB41fInzubDCS7Dp3F2St3sX7h2GgAyZPDGgN7tIR15oywtsqIOu3tUKFUEfTq1ASGBvqwn7oMbRpXR8+OjXD64h3MX7kDK+fay/YLV+6C20dPLHYcGmd5bEfPR9GCuTGsz++hTxGAnLp4W46OzJs8ALlzWENK51q1+RADCAPIbwpwBIQjIJICnIKlOg84BUv8bHAKllgXTsES65KSUrBmnnke53WbNg4YX7ugNtwkGR8pPgKyctMhOcIxZ6ItCubNDh2dX3mIf6ZgTZm3AWZmxhjZv4N8gw6fvIqjZ67hxZsPCAgMgp6uLi7sWxwNIOsWjEHh/Dmjb+af/rbuO43TF29j7YLRkKChcZ2KaNGgimzv9d0X9TuOxG3XVXGaDPuOXYTzmj3Yu9ZRTsuK+REByKDxi1CpTDF0bVNPNuUaEK4BEU04BhAGEAYQ8RxgAGEAkRTgGhDxPEiNNSAzTisDIBPqMIDEacGstLGffyDm/LNNTsGKiIiUC7jHD+0KE2MjOQISEyKkBXxYeDjGDemCw6euQvr3tFG9UL5UETltyWbYLFw5+A8ZQE6cv4WVmw5iz5ppaNZ9HHz9AmBg8KsY+YdfAM7sWihHXygf13M34bjQBWvmj/oNfKKOFQFIi54TYG/bHtUr/s0AAoBrQNQstImFsZyCJdaPU7DEunAKlqounIIlniucgiXWhVOw1LxzFUzBmn7qGWXJpnWbiXULad2nkg5TfAQkpriv3nlg6MTF6NSyjhwRiA1AJjutQ1pzM9j3by+7ePHGPc4Asm77Udz/9xWcHYegt/1cObWrSZ2K8brfOw+exYpNB7Fijr0cyRF9RADSY/hsNK9fWR5b+nAEhCMgornDERA1YMZF6EJhuAhdVRYuQhc/Q1yELtaFi9DVLIWSQRH6tJPKAMjkegwg8VpAK3XQlr2nkDObFcqUP+Sb+wAAIABJREFUKITQsDD0HemEbm3qo1n9yrECyOoth+X0qXkOA+EfEIT5K3bIi3dNERC7fu3QoGZ5vH7nATuHpXIEpVqFEnKx+tJ1+zBnQj8UzJdDLlK/dOMhbNo10CjNsg375YjMkulD5fqRqI9xGqPfUspEALJ++zEccL2MWeP7IiwsHKu3HsbDJ6+5BkSD6lyELhaIIyAcAZEUYABhAOEaEPG7gGtAxLqkpBqQqSeealy3JYaBQ/3CieFWMZ8pPgIiFV2vcDkINw9PmJoYo3n9KpAgQVdXJ1YAkaBjlONyXLv9GNmzWqF+9bLYuv+URgDJlysrnr50g4WZCXp3boLOrX7t5b778Hm47D4Bdw9PZEhvgXrVy2LMoE4ab37r3pPw7JWbit35vc7IlCEtjp6+junOLggKCoHUPcA4jSEcRvRAg5rlIO0CNm2hC05euIXMlhlQp2pp7D9+kQGEAeQ3BTgCwhEQSQEuQledB1wDIn42GEAYQCQFUmMNiIOrMgAytQEDiMYFc2o1SC59RWLeH25EqOYv2tyIUCgMR0A4AsIREPEc4BQssS6cgiXWhVOw1KwUk0EK1uTjtIbL2l4LT2tIa6Cr7XETy1+Kj4AklnAiv/EBECmtS9qSV92nW9v6qFm5ZKJdxr/dad1nD+yhEX/zVrQcxRy1ad1dDS1pXUz1s/zajSw2sXRNft85TJ2tThoTkuahlsTOpMSX6ufQX93tYzsBY31at1hiI3ToxtgdLrZxX7RrQtJl7XFah/Ne9fOS/OWuX4JkZ2r9K0UxtgP0s+Yh+dM1o/Xp0TU2JfkLzVeJZBcURuuETtw7AN+DwknjmhvS5tWW7LTnN4OBnsZxq/Ytr9FGMsgybj7JbnPunzsNavpE0CQGrY830My+lqYh5e+9Hr8n2RXoQnvWzg5aSfL31juYZFf3+U2SXShRwLwWmueANKD76J6kcS1yW5PsAnvOINmFR9Imgt68ISR/WerVJNmFfqLNgzTFaM9HcKEapHGNPR6S7CKDA0h237PTzs+M+G4h3g7ohtPms5FZWtJ1xMVo4jFlAGR6IwaQuNynVGUbHwBRWiAGEPEdYAAR68IAItaFAUSsCwOIqi4MIOK5wgAi1oUBRM07V0EAmXDssSJLtxmNiioybmINyhGQxFI2mfhlAGEAkRTgCIiaHzmOgAiF4QiIqiwcARE/QxwBEevCERCxLskhAjLuqDIAMqsxA0gyWVrzaVIUYABhAGEAUf+kcAqWWBsGEAYQTsESPxucgiXWJSWlYI098i9leaV1m9lNimndp5IOOQKipPpJYGwGEAYQBhAGkCgFuAZEdS5wDYiav+BzDYhQGAaQlA8gYw4rAyBzmjKAJIFlM5+CthRgAGEAYQBhAGEAUT8HGEAYQCQFuAhdPA9SYxH6qEOPtLUEi5Mfp2Z/xck+qRtzBCSp36FEPj8GEAYQBhAGEAYQBpAoBXgXLPFcYABhAIlSYORBZQBkXnMGkEReErP7/1IBBhAGEAYQBhAGEAYQBpDYf3kZQBhAohQYcYC2lbG213ILWhTXtktF/XEERFH5lR+cAYQBhAGEAYQBhAGEAYQBJKYC3AdE/Xyw268MgCxsGT8AkfrNTZm3AS/fuCNrlkwYN6QLqlVQ31ur44BpePjk915ew/u2Rd8uTbW6aGUA0aqcyc8ZAwgDCAMIAwgDCAMIAwgDCAMIbQ03bN8DmqGWrZxb0Rryxhw2NDQMDTqPQqeWddChRW2cv3IP0xa6wHWbEzKkEzdmlgCkdePqaFjrV5PJNIYGMDSkNUqmXjYDiBqlXrxxR9fBM3D9yHKqlorZLVi5E2u3Hf1t/Crl/sIqp5Eq5ySR8JAJzji7e5H83SzTAqTzbtmO1oEze+3SJH9GuQqS7HTNiZ2oLTKQ/EUapKHZ6dIetPC0WUj+qEY/YEwy1aM1rCb399AhjQqMNqPNg94NaR3O8zSiddQ2K0Cbp7rm6UlXopfOkmSnY2xGsovUo82XoMw0/ULDid2ZifMgnFhJrUecCIdylyHpkreElUa70o6DNdpIBpEl6pHs9uWldZvPZEnrXh/sE0Qat/7uqSQ731tXSXZpK9M6qz+c7kzy9/mBJ8muxM1LJDtqB3FLY1ondL/Vk0jjmlhrnlOSI8/aA0n+iI8Q0h2aS/JnUqoqyS7c051kZ5CPtugMsqbVBxh+e0MaVycshGTnm5H2bjYmvlwidWgvIV3i+RmZWZCuIy5GQ/cqAyCLW9PmQsxruXH3KYZNWozLB/+Bru5PbdvbTkHHFrVlyBB9JADp0qoumtWvHBdZ4mzLAKJGsuQGIJ5e3hg/tGv01ejr6cHE2Ejl6hhAGEBEU572ymcAUfeGZQARK8MAoqoLA4h4rjCAiHVhABHroiSADN5zP86LbW0csLTN33F2s/PgWew5cgE7VjpEHzvacQUyW2aAff/2agHkndsnmJqkkVO2enVsjJqVS8Z5bE0HpHoA+fDpK6Yt2Ii7j14gjZEhyv5dGAumDIQEIF0GTcewPm2xafcJ+Pj6oXv7BhjQvYWs6Za9p7Bm62F89/6B9OnM0a5pTQzs0TL6u3NX7iFf7qw4fPIqKpUtin5dm6HzwOno3akx9hy9gODgENi0byj/W/p4fvWG4yIX3H34AsbGRujXtansk/KRIiDfffzgOLqX0Nxllys27nTFD/8AFMqXE+4fPTkCokHYSI6ACBXiCIh44jCAMIBwBEQ8BzgCItaFIyBq3qXJIAIySCEA+ecPAPHx9UdEpDi8bWZiDAMDfWzc5YrTF2/DZfH4aMEnO62Dgb4+Jtl1F96EJy/ewczUGFJX+ovX72Peip3Y+s9EFCmQi7IkJdukegAZPN4Z+fNkg2235vD29cO+Yxcx0KaFDCAte06ETbsGaNOkOjw+f8PAcQtwZNMc5MxmhVdvP8DAwABWmdLB67sv+o2ah6kje6Ls34VkOJm3YofsR6JGCWyCgkPQuvckGUSa1K0Edw9PDJ+8FC5LxqNogdxySKxBzXLo2bER3D2+oPvQmXIKVeH8OTXeTAlAtu47BTNTE2RMb4EmdSvKxCp9Tl28jZmLN2Pe5AHIncMaruduYNXmQwwgDCC/KcAREPGE4BQssS6cgqWqCwMIA4ikAKdgiedBSkrBGrhbmQjIsra/R0A62E6Fzw9/oeAOI2xQqWwxSBGQfccvYduyXymOUgTEyjI9RvbvoHF9KRn0GemEMiUKRv8BnnQQwSjVA0hv+7nImM4CI/q3RxbLX3UEohSsxl3HYOzgzqhe8W98+vING3Ycx427T/Dd5we8ff0xdlAnuchHApBrt//FkhnDom+ByJ+dw1I5IlG5bDGMnLYcJ7bPi7aXioSyZckUHSGJ7V6+//AZYeERkIqEnr5yw9T5G2Sg6tyqDgaNX4RKZYqha5uf+dOcgsUpWKK5xADCACIpQEzTBgMIAwjXgIjfGQwgKR9A+u+6R1hea99kRbu4p0Fdv/sEdpOX4vLBpdD5f3SpbV8HdGhRi5xl03mgo1wPIhWya/OT6gHk1TsPOC3bBqlQR9oRoGPLOujTuYkcAfmzCL1dvyno3605alUphWY241C6eEE5ypHFKgPsHP5BuZKF0aV1XTKAzHDeBH19ffxdNB/GzVotRy+iPiEhoXKBkLT1WVw/UoTj2u3HWLdwDFr0nAB72/YyNDGAAFyErmahTZxknIIlFopTsMS6cA2Iqi5cAyKeK1wDItaFa0DEuihZA2K7UxkAWdk+7gAirSXrdRyJ7u0aoH2zmrhw/QEmz12H41vnwjJjOkjpVvOW78Cs8f3kjB6pLEHKqGlSpyKsMqXH8bM3sGj1LhzeNPu3P9ITlwyxmqV6AIlSJyw8HLfuP4PtqPnYuWqKvFuAOgD5q3Ae1G5nh9uuq+T0KukjpVPFFUD6j1mAahWKo0iB3Jg4Zw2Obp6jjXuKRat3Q4qKLJgyCD2Gz0bz+pWjdzvgCAhHQDgCAvAuWOJXDUdAVHXhXbDEc4UjIBwBkRRIjbtg9d1xVytrtbg6Wd2Btmvkn37vP34l1zq/fPMBWbNkxKiBnVC7yk9fV2/9K6dYHdsilRdkhrePHybNXQvpGP+AIBTIkw0jB3SUywu0/Un1ADJ/xU40ql0eBfPlgNsHT3ToPxX7102Hf2CQWgCpXrEEKjcfhAnDuqFq+eI4c/kunJZtl6MVsUVApHw9qeYjR1YrXLz+ANMXbcJhl1lIa2GGNn0mo2610ujWtj50oIOHT1/LBUQVSxfVeM8dF7qgfs1yyJcrK568eI8x01fAcXRv1KlWGuu3H8MB18uYNb4vwsLCsXrrYbnBDG/DG7usXIQu1ocjIBwBkRTgFCzVecA1IOJng4vQ1QAcb8MrFCY5bMPbZ7syALKmY/wAROMiUiGDVA8gi9fukXeqkgrJM1umx0Cblmhar1KsKVjSwt713E25uFsqLpdSsj5+9kL9GuViBRApheuvQnnw+Plb5MqeWQaYKKr0+PQVTsu3y1GYoOBQufh85IAOcnqWps+sJVtkCPr6zUcOkfVo30CuRZE+UvhNqic5eeGWvO1anaqlsf/4RQYQDaIygDCASApwEbp4HjCAMIBwBIQjIKk1AtJr2x1Ny7JE+X5dJ1qftUQZPBGcpnoASQRNhS6Tal8RbkSo5i/avA2vUBiOgHAEhCMg4jnAERCOgEgKcBG6eB6kpF2wem5VBkDWd2YA+a/W7ClqnPgCiBRlefXWQ6hFWgtTuc4jIZ9gn6+kw3XCQ0l2ULMntcrBxL2+Adr+TBHGaUnn5x9GMoN/KK11dAStYTWymOqTBj6Si9Zh2iOIdiGewTS7L8HhpPOb6/eEZEfVJULaaJzwCSF2BqfaeQXSdPnwg9YF+9OPYMJVAK2L0DqwGxvQ+jPr+4jfDX+ejLdxFtL5Ue+HIbFYJIzwGFno0e6FZzBNk7RGtM7bJEGkDuxEw3DipDcP9iJ5DDfNRLLT8/tCsgswoc29fTlpi5xO766Rxg3S+Vknqemz/u5HTSby915+tA7dE2po3sJe8hcB2rzyC6G9I3WJv22jDj8lXe8cj40kO91+s0h25sTn7bUfyR3eV61BMqx17RDJTieC8NKQotMhASR/+tkKk+ziYmSz5XZczLVmu7ELbX2gtQET2RFHQBJZ4Cj38QWQxD49BhCxwgwgYl0YQMS6MICIdWEAUdWFAUQ8VxhAxLowgIh1URJAum9WBkBcujKAJPaamP3/hwowgDCASApwBEQ8DzgCItaFIyCqunAERDxXOAIi1oUjIGrAIhlEQLptuvUfrtJ+DbWpW1lFxk2sQTkCkljKJhO/DCAMIAwg6h9WBhAGEE7BEs8BTsES68IpWGJdUlIKVhcXZQBkS3cGkGSytObTpCjAAMIAwgDCABKlANeAqM4FBhAGEEkBrgERz4PUWAPS2eUmZXmldZut3ctp3aeSDjkCoqT6SWBsBhAGEAYQBhAGEPVzgAGEAYQBRP3zkRoBpONGZQBkuw0DSBJYNvMpaEsBBhAGEAYQBhAGEAaQKAV4FyzxXOAICEdAohTosOGGtpZgcfKzo0f5ONkndWOOgCT1O5TI58cAwgDCAMIAwgDCAMIAEvuPLQMIA0iUAu3WKwMgu3oygCTykpjd/5cKMIAwgDCAMIAwgDCAMIAwgMRUgPuAqJ8Pbddd/y+XadFj7e5VQZFxE2tQjoAklrLJxC8DCAMIAwgDCAMIAwgDCAMIAwht4dZ6rTIAsrc3AwjtDqVyq9fvP6J9PwfcOr6KrISvXwB62c1B3y5N0aDmr2Ij13M3sHrLEbxz/4Q0RoaoW60Mxg7pAiNDg2jf9x+/wtJ1+3Dv35cICw/H8S1zkdkyvcrYj569wZAJzji7e5H8XbAPrSuvTgStWzF0aV1lI/WMSLpE6tE6iH8JpHVPDSB2OKcWnhIbecOE2Nn6eH7aNnvvA2id6b2I3Xstid2jR3o9It03ak+EUGL3aGpjyMBQ2p175PmDdB3fAmk6B1M67gHoX9aaNK6e72eSXaQ+7Tny1rMg+aN2YA8Oo+kcHK75uUyfhvaMfyN2rzczpHVCp+74RWxsjZBwmibpdIJI9+JLOO3eWsGf5M9P35xktyFrSZLdoE+0ZmwRer9+p2JzPPX0a9K47t9oHbDXtCtG8kd8dPE9iNYJXYc0KtBjyz2S5cHstHQf/zr9Sf7MDWm/0c+8gkn+PlSqRrKr8+QSyU4njNbpXieU9hwZZMpOGjcuRq3WXIuLudZs9/WpqDVfScERR0AS6S7EFUCc1+zB/uMX4fXdF06TBvwGINv2n0aGdOYoWawAvH39MHLqMtSvWQ5DerWWz16CjsHjnTGsbxtUq1ACkRGRyJjeAoYxACXqMhlANC+IJK1oSwmAAUT8ADGAiHVhAFHVhQFEPFcYQMS6MICIdWEAEeuSGADScrUyALK/LwNIIi3Zk57bkJBQ1GwzHP/MGo5SfxWQT/CLlzfqdxqFM7sWIJ2FGdZsPYIdB84gIDAY1Sv9jQlDu8LczARxBZCoq2/Xbwr6dG7yG4D8qcySdXvx7KUbls4cJn/VbcgMtGxYDW2aVBeK6LLLFRt3uuKHfwAK5csJ94+eHAHRMN0YQMQCcQRErAtHQNTowhEQFWE4AiKeKxwBEevCERCxLkpGQJqvuqrIgvVgv0qKjJtYg3IERIOyjgtdIIXqHUbYyJYbdhzH3Ucv4Ow4BPuPX5IB5J+Zw+UIhWSro6ODORNtExVAbEfPR9GCuTGsTxv88AtAxaYD0bBWedy89xSBQcGoWr44po3qJYPQqYu3MXPxZsybPAC5c1hDSudatfkQAwgDyG8KcAqWeEJwCpY64KIhOqdgqerHAMIAIinAKVhqwCIZpGA1W6kMgByyZQBJLBhKkn4fPn0D21HzcH6vMwwM9NG69yQM7d0GNSuXRO8Rc9GgVnm0b1ZTPvdPX76hXgd73HFdDbePX+JcAyL50BQB2XfsIqR0rb1rHWXoef7aHa16TcSyWXYoV7IQfvgFYsyMlciQzgILpgzEoPGLUKlMMXRtU08+R07B4hQs0YPGAMIAIinANSCq84BrQMTPBteAqFlAE1cyDCDJF0CarLhCvMvaNTvSv7J2HSrsjSMghBvQvMcEDO3dGrmyZ0Yfeyec3rUA+np6aNp9HEYP7IjqFf+WvURGRqJ47V44uX0eAoNDtA4gruduylGWNfNHoXD+nPKYL964o2XPiXh4Zj10dX+Wv1268RB2Dv/g5rEVaNFzAuxt20efIwMIAwgDCMBF6OIXHwMIAwgXoYufDS5CF+uSGovQGy9XBkCODmAAISzZU5bJuu1HcffRS+TOngWRiMTI/h3kC5QjIDXLoX3zWvK/EzMCsvPgWazYdBAr5tijYN5fuzoEBAahQpMB2LPGMfq/n796H9OdN8kg1GP4bDSvXxmtG/+sD2EAYQBhAGEAUfeGZgBhAGEAYQCRFOBdsNSvYxsuv6zIIvf4gCqKjJtYg3IEhKDs128+aNBpFMxMjbFu4Rjky5VVPkqqAZHqKaT0J2nXqcSqAVm2YT8On7qKJdOHwjpzxugzNk5jJNecjHJcDs+v3pjvMFCOwoyYskxOx5JSxdZvP4YDrpcxa3xfhIWFY/XWw3j45DXXgGi477QMd94FS52MvAuWWBneBUtVF94FSzxXeBcssS68C5ZYF94FS6xLYuyC1WCZMgDiOpABhLBkT3kmA8YuxHefH9i+fHL0xUmLfakIffv+M3Lxd0J2wZrhvAlHTl+Dn38gjAwNYWCghwPrZ8AyYzq57uTZKzcVUaW6lEwZ0sI/IAizlmzBmUt35DqVlg2rYnCv1jDQ14O0k9e0hS44eeEWMltmQJ2qpeXtfrkPSOxzlAFErA/vgiXWhXfBUqML74KlIgwXoYvnCu+CJdaFd8ES66LkLlj1/qH1NNH2SvjkoKradqmoP46AKCq/8oNzI0LxPWAAYQCRFOBdsNQBF+0J4V2wVPVjAGEAkRTgInQ1YJEMdsGqu1QZADk1mAFE+VVzMjqD0LBw9B89X+0Zly9VBLbdmil2RcG+30hj60TQusBGGqQh+QsGrfsxtXO5TzDt/IiNt0nXIBlRd8ihdsfdnacMaWw3YofujMSu0FmI3ai7frhLOj9qd+FAoqE3sQvxxx/E7r0/aF10qZGNMOLE6l+A1qUbOrRuxRFpaN2tA0DrRm3+mpZa8DUnrRiS0sE+rRFNE6rGBnq0p42aJqj3/809NE186rvK0oT27nvnQ+sInduEVtfmE0GbA0syl9B0qfL3E7wfkeyof6nue5DWCd3jeyBp3EN9ypLsIojProdfGMkf1ajXxlsk01Nl3Ul230v/bEys6UN93l58o71L35WhpQXVe31T06nJ3+uE0u6vTgTtfhimsyKNGxejOksuxsVca7anh9C6zmttwER2xBGQRBY4qbtnAEnYHWIAEetH5AowgKiZfwwgKsIwgIjnCgOIWBcGELEuDCAJ+82Xjq69WBkAOTOUASThd489JBkFGEASdisYQBhAJAWoi2OOgKjOF+qCiKoxR0DEzyRHQMS6cARErAtHQNSvDWo7X0jYwiGeR58Z9nM305Ty4QhISrmT8bwOBpB4Cvf/wxhAGEAYQNQ/Q5yCpaoNp2CJ5wunYIl14RQssS5KpmDVWqQMgJwdzgCSsBUbH52kFGAASdjtYABhAGEAYQCRFOAaEDULxVBavRUDCAOIpEByqAFhAEnYuinqaI6AaEfHZOuFASRht44BhAGEAYQBhAFE/RzgInSxNlyErg5Yk34Res2F5xO2cIjn0efsasTzyKR5GANI0rwv/9lZMYAkTGoGEAYQBhAGEAYQBpC4/pIwgCRfAKmx4H/sXXV8FdcS/uJ4cHco0FIKRYoVK06BUtzd3Yq7e3B3d7fgUtzd3TUEJ0Lebw7vpgnZmzt7s5ebkNl/Xh+ZnXPOd2b3nm/H7ENA9nYUAqL3ORP5cIyAEJCwbY4QECEgQkCEgAgBEQKi95dECEgEJiCj9+jdbkPk93YqbIie8KJEPCDhZSfsNA8hIGEDXgiIEBAhIEJAhIAIAdH7SyIEJOISkIKj7ENA9nUWAqL3ORP5cIyAEJCwbY4QECEgQkCEgAgBEQKi95dECEjEJSAFRu3Wu92GyO/vXMQQPeFFiXhA7LQTnfpPxs8Z06BB9dIWZ+C55yhmLNqEO/cfI4qbK4oVyIFubWrBzfW/zrbUcX3w2AVwdnZCr/Z1zOo8f+UW2vQch90rxyqZT2+9LY5PAgGOvO69XrzmveCU52RN7P9C3B4BAQE8rVxi4cbsuuzEVDgk/s+sCaaIyutqHJ/ZZTo+s2N6oWu8brbvmZ0IH7zhGczTtzw538+8rtDvfPxZOPv48/QxmymjYTpe1+/PrtFY84MT77l0OLWFpc8xZhyW3J2keVlyz977WpSL5cZbQ/KYPJt/68Pbs4/MvY3izOtKf+cVr3N00piuFjEhgddMG00Wg4eL9yeezU9JmpU1vz6vLrDkXPx5uJSZe46lz5e5ji2tcrP0ufi8Zcmdec2z0+guvGe8yVxeJ/Q9xd6x5vc6Y1GWXHQXnj1f9+Lt28Mif7DGLXj6X5acgw8vCZ2lDIBbrLhcUbZcgZF2IiD/CAFhb5IImkdADwFZsnYn4saOiWyZf8Cr12/Ruf9klCicC20aVlQD7DpwCkPGL4TXqzf4u3QBISChGJ4QEG1whIBo4yIERBsXISAhcRECom0rQkC0cRECoo1LRCAgv4+wDwH5t4sQEOEV/0dg9tLNOHj8AmaO+icQk/5j5ikvRddWNXD73mMMGDMP5y7fQpJE8dC+SWX8kf9XJauHgHwN+ITZq3Hl+j1MHNIu2J9GTl6KTz6+IQjI/BWemLfcE2/evUfGdClx/9FT8YBYsGKmwwLiAdEGUjwg2riIByQkLuIB0bYV8YBo4yIeEDP2Ih4QTWBs4QH5ffguu5yD/+3K8zbZZXJWDCohWFaAZrrl+UtvFKvaEduWjkbC+LHh6+uHQpXaYe7Y7kiTMgnK1+uBKuUKoUaFYjh/+Sba9hqPRZN7I23KJGEiIM26jMZPGVKjXeNKFgnIjv0nlHdkVJ8WSJ0iCSica/rCDUJAhIAEQ0A8IOIBIQQkBCukHUgIlvazISFY2rhICJY2Lt9TCFb+YfYhIAe6CQEJw5H9+7u1edcxyP3rjyqXY+f+k5i6YD1WTO+Hk+euomO/ydi90gMO//+c3nvEbCSI5462jSpZTUDWbNmPcTNXYfWsgSosK+il5QFp1WMs8ubIjNqViitRyQHh2aB4QLRxkhwQbVwkB0QbF8kBCYmL5IBo24rkgGjjIjkgvN9sc1K28IDkG7ozbJOy8u6D3Xl5Plaq/+a3iQckjJCTR2Hq/PVYM3sQ2veZiN9+/RE1/y6KLbuOYO6yrVg2rW/gCJPnrsXDJy8wqGsjqwiI555jGOgxHzNH/4NM6VOGmLkWAfmrQU90alYVBfN8SSwUAsLbcCEgQkAIAckB0bYDyQEJiYvkgGjbiuSAaOMiOSDauESEHBAhILxzlCUpISCWELLwdx8fXxSu1B7jBrZB657jsG3JKLjHiq48IB36TsKeVWMN8YAsX79beVemDu+EDGmTa85Ki4DUbz8M5UvkQ8UyBYWAUDUvqYKlaTsSgqX9oAsBEQIiIVjaNiAhWNq4SAiWNi7fUwhW3iE7wnhytO72Qz2KWXdjOL1LCIgBG0Neib2HTuOXn9JjTL+WSiOVxaUckEp/FkStisVVDkibXuOx2IocEPKcbNxxCBMGtVXJ7KYrahS3QHJD/6ZFQOYs3YJ1ngcwtEcT+Pn5Y8bijTh36abkgFjYd/GAiAdEPCDmHxLxgIgHRAiIEBBCIDKW4c0z2D4E5HBPISAGHNm/LxUU1lStWX/lnSiQO0vg4m7dfYQBHvNwnqpgJYyH9k2rWFUFq2Jat791AAAgAElEQVSj3rhy414I0PauHof4cd2xeecRDBo3Hx8/+oA+8EeN4oq+HeujZOFcIA/NAI/52L7vOBIliIuiv2fH2q37hYAIAQmGgHhAxANCCEgSekg7EA+IeEAIAekDom0HkZKADLITAeklBOT7Yg+RfDXSiFDbAMQDIh4Q8YCIB4QQEAIiBEQIiPl3QWQkILkHbrfLyfFI7y/FhL6XS0Kw7LyT5D3xmLbC7CzqVC6Bwvmy2WyWn969ZukOcOB1d4XywVi+HE9stCwEwOvwQZbcggFbWXJ5siRkycXLwOue6vvRj6Vv8rKLLLkez8+z5D4wO41zD0+JovO6/Dr48LrywoHXbZcr53Cat7+vTxxl4bd7CE/fDwVSsPTFTsuzqw4ZvoRoWroun39qSUT9/cBA3hexGD6vWPpu+MZgyaWLwuuS7Pj+pUV9jh/fWJQhAd9EGVly+Mx7JtkJYQG8zuoO/rxxnV+F9GZrLWxb8aas9RY9uIol9zkar8v9Yx9eZ/XErrz1en/m6YtzhfdV+fWR/az1xmjYjyUHv48sOZcXt1hyXpuXs+T8P/qw5F5eusOSSz94FEvuTNMWLDn3lDx7ST5iDkuf09tnLLkAl6gsOeeXPFwc0/3G0qdHKPcAOxGQPkJA9OyTyIZzBISAaG+QEBBtXISAaOMiBEQbFyEgIXERAqJtK0JAtHERAqKNiz0JyG8DttnlZHe0Twm7jGurQcUDYitkI4heISBCQAgB8YBo24F4QLRxEQ9ISFzEA6JtK+IB0cZFPCDauEQED0iu/vYhIMf6CgGJIEdrmSYHASEgQkCEgJh/UoSACAGBhGBpGoGEYGk/GxKCpY3L9xSClaufnQhIPyEgnHOtyEQQBISACAERAiIExISA5IBo2IIQECEgACQHRPs9GRlzQHL29bTLCe94/5J2GddWg0oIlq2QjSB6hYAIARECIgRECEgoL2whIEJAhICYfUAiIwHJ0cc+BOTEACEgEeRoLdPkICAERAiIEBAhIEJAhICYEJAqWNq2IB4Q8YCYEMjRm1dFkXMG0yNzYmApPeLhXlY8IOF+i2w7QSEgQkCEgAgBEQIiBEQISOi/tUJAhICYEMhuJwJyUgiIbQ/Eov3bIiAERAiIEBAhIEJAhIAIARECEhQB6QNi3h6y99rybQ9q/x/t5KDSdhnXVoOKB8RWyEYQvUJAhIAIARECIgRECIgQECEgQkB4B7dfe9qHgJwaLASEt0NfSfUYOgMpkyVC87rlQ9w/Y9FG7D10Bgsn9rRKd3i7qeugaciUPiUaVNdnLDfvPkLlxn2wc8UYxHGPGbisCbNXY/POI3j87CUSxHVH3SolUbuSvo6Y6zwPYNaSzVg/d3AwuD6943UhDuB2tmZuhutDXsdv37uXWRrvrNjAkru57QZLbu89Xod4L19/lr6W1X5iycWcuIwl98mf13E+gCeGqC68zuVJXHgdsFmL0CHk/JDXSd7v3jWW1gdbdvLkDt5myV2/arnjNyny9+QlL55/4M0ad/t+3vxO9czF0ucTxZ0l5+rDe284fHprUZ+D7weLMiTgFzc1S87Bn9dhmtsJ3cHflzUuwHvYHD/w3i2X/+nAGjfDhBksuQDnKCy5h8xO6Emi8d4Z/uDJRbl3gjU/3+tnWXIOhevw5Px47zTH914sfT4H1rLkXp69wpLzfc+bX/JuQ1j6Xi30YMm5ucdgyblW78aSc3rD64TOfY4cfHkd7J2TZWLNT49Qth72ISCnh+g7U+pZkz1kv5kHJDQC8sLrNd69/6AIyvdwWUNAGnUagWs374Ow+HfdhGAEZNTUZSiYOyvSpU6Ki1dvo13vCZg8rAPyZLd8qH36/BXqtRsCL++3SBg/jhAQISCaj5gQEO03zwMhIJrACAHRgkUIiBYqQkC03y1CQMyd9njPkV0JSPfNdjmqnh5axi7j2mpQwwnIotXbMW+5J16+eq0IRYemVVAg9y8ISkA++fii6T+jkCFtcvRsVwfL1u3CnkNnMGVYB1y7dR81Ww5CoxplsGrzPnz65IN6VUup/2/pontrtx6MTs2qYs6yLXj/4RP2rh4HOoQPHDsfp85dQ9SobmhauyyqlC2s1H346AOP6Suwbe8xNVbOrBkxoEtDRQBWbdqHWUs24ZX3W2TNnB79OzdAwvixsWj1DmzfdxxpUibB9r3HEcXNBX061kPBPFmxduu/6DNyNhwdHODs7ITffv0Rk4fyvmS9//ARuUo3D0FAvl53nTZDUKxgDtSrwi/JtufgaYyZvkIIiBAQISAAxAOi/TYVD0hIXMQDom0r4gEx8wyJB0QTmO/JA5LVTgTkjBAQ8zTg0rU7ilgsmNATiRPGxenz10GH6j9+zx5IQJrUKosO/SYiWtQoGNq9CRwcHEIQkIqNeqNp7XL4s1he3H/4FO37TMT8CT3wc8Y0oXIQIiAVGvTC36ULoFr5IogaxQ1pUyVF1Wb9ULJwLhUSdf/hM9RtOwTTR3ZWYVL9Rs3F/cfPMKhrIzg5OioCUbLwb8obMXraMkwb0QlJEsWDx7QVuPfoKcYPbKsIyPhZq9CucWUUyJ0FG3ccwsoNe1XoFF3WeEDoPg4BIcJUtGoHjO7TEnlzZrbEyQL/LgTkCxQSgqVtMuIBEQ8IISAERAiIhGBpvwskBEsbl8gYgpW12yb22ctIwTPD/jRSnd11GeoBOXnuGiiUaPKQ9siZLRNcnJ0CF2jygDx6+gIvvV7DY0BrODt9+fvXHhDyYhzZNCXw3g59JyJjupSa+SNBETR5QILee/biDXQeMAXblo4KFB3gMR/JEsdH/aqlkKNkE6yY0R8/pEkebDOadRmNMkXz4K+S+dW/U2hUieqdccJzuiIgh09cwITB7dTfnr14hcKV2uP41umIGsXVpgSk57CZyqMzfWQnRd64lxAQISCh2YoQECEgQkC0bUA8INq4iAdEGxfJAdHG5XvygPzS1T4E5OxwISChnnkpoXzlxr14+uIVsmf5AX061EOq5ImUB+TwyYt48sxLhSQVyps1UI8lAjJ43AI4Ozuja6saoY6tRUC27j6K7kNnIF6cWIH3+vj4omKZgqj5dzEUqdwex7ZMQ7SobsF0l6vbHa/fvoeLi3Pgv795+x67VngoL0lQAmLyXBzaOBmxYkSzGQEZPmkJjp66hLljuyFmjGhc7qHkhIAIAREC8h8CEoJl5vAkSeghgBECIgSEEBAPiLYdREYPSJYuG3Wdv4wSPjeirFGqwoUeQz0gQVf0/KU3hoxfCD9/fxW2RASEDvBli+dVYU8UppU+TTJ1iyUC0rzrGBXqVKti6JWftAgIeWV6DZ+JzQuHhwDc3/+z8oCsmjkA6VJ/mYvpIk8OkZQ/i+YJcd/XHpCvCUj3ITPU2jh5K0GVmwvBIgz7jpyDuw+eKPKml3wIAfkPZQnB0n7viAdEGxdJQjdz6JAqWBrA8JJnpQqWtk1JFSxtXKQKljYu9kxCz/KPnQjISCEgZpnTwePncf/RcxQvmAMxokXF0ImL4evrh4FdGgZLQp+9dDMWr96BJVP6IEG82CEISLVm/VXOR4qkCbH/yFkMGrsAG+cPRfy4oZeI1CIgvn7+qNS4D4oVyI46lUvAAQ44d/mm8mxQFSkiC5QwP+CfhogSxRXrPQ+gUN5sSmbi7DUY3rMpMqRLgQePn+Pfo+dU4rclAjJu5ipQPszI3s1VkjslrnMuLQJC5IMImJuri8pTof+ly8HBUYV7cS/xgHxBSgiIEBBCQDwg2nYgOSAhcREPiLatSAiWmWdIktA1gfmeQrB+7mwfAnJ+lBAQs2feqzfvg8Klrty4B8pOyJ39J/TtVE9VlPq6DC95QS5cvY1547pjw7YDwapgVWnaTyWcU8lZCt+iSllUncrSpUVA6J6Hj59j5JSlOH7mCj5+8lXJ551bVEPWn9Lh7bsPGD1tOXb9exJUnStXkCpYFEo2f+U2lQgfN04sFC+YU4WBWSIg1K+jfe8JuHz9LkoUyoURvZtbmroiSZQf4/36HdxjRlfka9m0vioMLG/ZliHuT50iMTYtGGZR76OnL1GpcW/4+fnjw8dPyntSvkR+dGtdU90rfUC0IZQ+IGYOHdIHRBMY6QNi5iul9AEJAYx4QLRtRTwg2riIB8TMu8WOfUAyd+b1HbN4QNMpcGFUOZ13hG9xm4VgWbtscyTCWn1yX+gICAERAkIISAiWth1ICJY2LtIHRAsXCcHSQkX6gGg/Q9IHxNzZhPcc2TMEK3MnOxGQ0UJAbHqmD42AUE7JjdsPNcd3jxUdY/q1suncrFF+/sotVcLX3EVhYYXzZbNGNYzQ7ffwKmtsB9/3LLmAl49Zcr7MjtUfHz5g6bux8ThL7uoRbfv5+uZ9z3nrjePyX6W30CZQtyavZLLD8IWsdXA7nHMLpUVjdkJP+u4Oa36OPpY7YJMi/+ePWPr8Ht1iyX18/IQld2/3GZbcoxM8e77ylGcv7rt3sMa98JDXLXvbQd5+/Nu7CGtc38+8H/9Yd46w9Pk9s/z8Brzn2UrAH/VZY7o+Os+Sw0fenjk48jp5f37P6w7v9/Q+a36Hu89iyeWb2Jkl5xQvMUvuWuxfWHKp3XkhwP48k4Kj51TWuG9v32XJxWzO6wwO5svU6dw21rjeh/ex5B4f5XVC/+zjz9KXacoMltyTsf1YclHixmTJcXF2esN7N7MGpTB0n3csUefkvN9elrL/C/3Ucb0eccNkL44pb5iu8KBIPCDhYRfsOAchINrgCwHRxkUIiDYuQkC0cRECEhIXISDatiIERBsXISDauNiVgHSwEwHxEAJix+OyDG00AkJAhIAQAuIB0bYD8YBo4yIekJC4iAdE21bEA6KNi3hAwnaasScB+bG9fQjIpbFCQMJmNXJ3uEJACIgQECEg5h9JISBCQCQES9sGJARLGxcJwdLG5XsKwcrUbp1dznGXx/1ll3FtNWi4C8Gy1UJFr5kQCckB0QRGQrC07UVCsLRxkRAsM+8XyQEJAYyEYGnbioRgaeMiIVjauNjTAyIExJgTtRAQY3CMsFrEAyIeEPGAiAfEhIAkoYe0BfGAiAeEEJAkdG07iIxJ6BnbrrXLme/K+Ap2GddWgwoBsRWyEUSvEBAhIEJAhIAIATFvA0JAhIAIATH/fERGApKhjX0IyNUJQkAiyNFapslBQAiIEBAhIEJAhIAIATEhIGV4tW1BPCDiATEhkKH1Gs7xynCZqxP/NlynPRWKB8Se6IeDsYWACAERAiIERAiIEBAhIKH/IAsBEQJiQuCHVvYhINcmCQEJB8dmmYJRCPjdu8BS5fiJ1yzM9/41lr4PVy+y5LxvWm5kRoouLD3N0rf+jjdLrmD8aCy5uLHcWHIxEkVnycVbvZklxxVydOBJxo/mzBKM/ZLXuBJvvVj6/B7dZsl9uMWzqzd3eM2urm/m2f3pay9Z88uS0p0ld3LSEpbcqTs8/LKmjM3S1zxXcpbcB7/PLLn4V3kNFf0eWm4g6f+O13TRqVIX1tzc7pxgyfm/fcWSc3B2Ycl99n7OkvO5w7PlxW15tlJ3UTvWuM6JU7Hkrib9nSWX1p2Hiy/PpPB56WDWuC8v8d4ZiQbOZOkLAK9TotO+RSx9Lw4fZck9O8trqPie2RQ318oFrHFv9enEkouWMA5LLn63cSw5p7e85yPAkdfcl1tVyyl1dtb89AgJAdGDlnlZ8YAYg2MwLV0HTUOm9CnRoHppXdpfv32Phh2Go0mtsihZOFfgve8/fMTQCYtx4Ng5+Pt/RuaMqdGrXR0kTRxfydx7+BSDxy3AibPXkCCeOxrX/BMVyxTUHJu6p7fpOQ67V45VfxcCor1FQkC0cRECoo2LEBBtXISAhMRFCIi2rQgB0cZFCIg2LvYkIOlbrtZ1tjNK+PrkikapChd6hIDYYBusISDjZq7C2q378cLrNUb2bhGMgAwauwAvvLwxrGczODs5YeSUpbhy4y7meHSDj48vKjTshXIl8qFBtdK4ePUOWvcYi8HdG6NIvl9DrE4IiHhAtExePCDaLwLxgGjjIh6QkLiIB0TbVsQDoo2LeEC0cYkIHpB0LexDQG5MEQJigyN7+FaZr3wrtKxXAZt2Hsalq7exatZApEiSAGNnrITnnmPw9fNDqSK/4Z8W1ZVMn5Gz4ejgAGdnJ/z264+YPLQDe4FVmvZTHoygHpB67Ybit2yZ0KrBl/i/PQdPY/D4hdi+dBROnruKFt08cGjDZDj+P97GY/oK3L73GOMGtlHy81d4Yt5yT7x59x4Z06XE/UdPxQNiYUfEAyIeEEJACIgQEAnB0rYBCcHSxkVCsMx4LL6jEKx0zVexz3RGCt6YWslIdXbXJR4QxhYQAUmTIgla1q+AJIniIUnCeBg7YwUePX2Bod2bIiAgAC27e6BEoVyoXak4rPGAmKahRUB27D+BboOnoebfxfBXqd8xYtISFC+YE5XLFsKuA6fQa9hMHNwwKXAl6zwPKNKxauYA0L1Dxi/EqD4tkDpFEnjuOYrpCzcIARECEgwB8YCIB4QQkByQkHYgBEQICCEgOSBmPkZEwhyQtM3sQ0BuThMCwjiyf18iREBmj+mq8jroIsKRs1QzbJg3JDAPY+vuoyqEaurwToYTkMfPXqJTv8lImyop9h85i1gxomHC4HZIlTyRCtn6s043NKtdDjUrFsPrN+8wee5anL10UxGQVj3GIm+OzIoY0SUhWBKCpfV0CgERAiIERNsGhIAIARECYv5MFxmT0NM0XWmXQ+6t6ZXtMq6tBhUPCAPZrwkIHfoL/t1WeUNMl7+/P1IkTYj543sYTkBqtByIquUK4+/SBeDn748Js1aDvBzbloyEq6sLjp+5opLQb917jGSJ4yNBvNiIGT2qIil/NeiJTs2qomCerEJAAEgVLDNfsaQKliYwEoJlxl6kClYIYCQHRNtWJAdEGxfJAdHGJSLkgKRpsoJxcjRe5NaMKsYrtaNGISAM8L8mIJ8/ByBHqaaKANBh/+ur+5AZSJ8mGRrVKMPQHlzk6xAs8rZkK9YYiyb3ws8Z0yjhJ8+88EeVDtixbHQwEmTS1LjzSJQomBNVyxdB/fbDUL5EvsCqWOIBEQ+IllGKB0T7URUCIgREPCDiAREPiHhAgiKQuvFy3Wc7I264PbOqEWrCjQ4hIIyt+JqA0C39Rs3Fs5ev0K11TcSL445rt+7jzv3HKF8iP6ii1aVrdzCyd3N8+OiDhPF5tfpJr1YOSKOOI+AeKwYGd2sMN1cXTFu4Hlt2HsH6eUPU7J+/9FbVsV68eo2FK7fh9IXrWDa1r/KOzFm6RXlLhvZoAj8/f8xYvBHnLt2UHBAL+y5J6NoASRlebVykDK82LlKGNyQuUoZX21akDK82LlKGVxsXe5bhTd1oKePkaLzI7VnVjVdqR41CQBjgaxEQIhYT56xWVbBeer1GimQJUb9qKRUmRTkb7XtPwOXrd1Vi+ojezS2OQiFUVEHr7bsPcHN1hYuLE9bNGaw8LM9evMKwiYtVqJWDgwN++SkturWqGZh/Mm+FJ0ZNWYq4sWOhWIEcaNuoEtxjfWl8R2V6B3jMx/Z9x5EoQVwU/T27ylWRPiChb4kQECEghIB4QLTtQMrwhsRFQrC0bUVCsLRxkRAsbVwiQghWqoa8JqEWD346Be7MrqHzjvAtLgQkfO+PzWf3+eZx1hif37xgyfne5HU4f37iPEsf9yU9fQOvu3D5VLyO1Ql/TsCaX6wUPO/W+oVnWfrKXuftB7PBOaK5OLLGTRCVJ+f6gLcOf6+nrHF97/H2zescrwP7y0v3WONu23SdJZc7a0KWXPxMX5qCWrpGF+9rSUT9/eR5Xkf3bV20G45+PQjXXu689mHN76cr61lyH29Z3rdPr96ydMVq+cXja+lyvrTXkoj6u/9r3jvNMWoMnr7nD1lyXmcvsOTmDNrGkmszuSZLzi1NJpbcjQx/suTSuDuz5N75scTgO5nX6f7piRsshennrWHJcTuhY+1olr4nR3m/gR9fvmHpe3WbFzaca9lslr6D5euy5OL9wOuEnn4mLyGb67EIcI3Gmp/z85ssOcf0eVhyeoRSNVikR9ww2TtzahmmKzwoEgJi413w9fNH8y7mX1zUJ6RZnXI2noV59UJAtLERAqKNixAQbVyEgGjjIgQkJC5CQLRtRQiINi5CQLRxsScBSVl/oV3ObHfn1rbLuLYaVAiIrZCNIHqFgAgBIQTEA6JtB+IB0cZFPCAhcfEXD4imsYgHxAw5Fw+IJjARwQOSst4Cu5zw7s6rY5dxbTWoEBBbIRtB9AoBEQIiBMT8wyoERAiIhGBp24CEYGnjIiFY2rh8TyFYKerOs8sJ7978enYZ11aDCgGxFbIRRK8QECEgQkCEgJgQkByQkLYgBEQIiEJAckA0DSEy5oCkqDvXLie8e/Pr22VcWw0qBMRWyEYQvUJAhIAIARECIgTEvA0IARECIgTE/PMRGQlI8jpz7HLCu7+ggV3GtdWgQkBshWwE0SsERAiIEBAhIEJAhICYEJAqWGZsQTwg4gH5PwLJa8+yywnv/sJGdhnXVoMKAbEVshFErxAQISBCQISACAERAiIExMKPthAQISD/RyBZrZl2OeE9WNTYLuPaalAhILZCNoLoFQIiBEQIiBAQISBCQISACAEJioD0ATFvD8lqzrDLCe/B4iZ2GddWgwoBsRWyEUSvEBAhIEJAhIAIARECIgRECIgQEN7BLWmNaTxBg6UeLmlmsEb7qhMCYl/87T663xlet12/R7dZc326/zBL7uLSUyy5tTe9WHJNy/3Akov3U1KWXKzUSVhy0TL8yJJ7deIES+5N/cEsuRjMDuex3Xg9sB0/8LrtOt7m7ZvvA16X2hfHTrPWe33jeZbc0au87tblqvD2LW6mVKxxY6bm2VXWvbxu1CdHlWKN+zmAJYa7zA7n557wupKXOz2dNfDDg+csyr2+x7O9X5bzOi4HHFhhcUwS8H3K61zuHJfX5f71hSuscS+v4r0LPjx/z9KXtng6llyygllZcg+Ld2DJpYjJ64Tuz9IGXK/7N0vSycWJJZd21iqW3Cf/zyy5lz158ffPLjxi6UuWh7dvb+49ZelLN5HXm+LV1L4sfVETuLPkXKvyOtg7fnjN0hfgFp0l5+TNfH6T8d71rEH/L5S0+lQ94obJPlza3DBd4UGREBA77EKRyu0xYXA7/JwxDXv0J8+8MG7mSuw/chbeb95hRK/mKFXkN3X/3GVbsWbrftx78BRR3FxRKG829GpfB9GjRQmh//yVW2jTcxx2rxyr/iYERHsLhIBo4yIERBsXISDauAgBCYmLEBBtWxECoo2LEBBtXOxJQJJUm8w+uxkp+GhZSyPV2V2XEBA7bIFeAkKEo1LjPihZOBeqlC2MWDGjw8EBiOMeU81+zZb9SJ86GVIkTYgXXt5o12ciKpYpgIbVywgB+QoB8YCYIRbiAdEERjwg2vYiHpCQuIgHRNtWxAOijYt4QLRxiQgekCRVJ9nh5Ag8Wt7KLuPaalAhIGFE9tqt+6jdejA6NauKOcu24P2HT9i7ehxOX7iOYRMX4869x0iaOD56d6iLbJnTo/eI2Vi9eR/cXF3g6OiAFvUqoFGNkEQh6LTGz1qFB4+fY3jP0OP//P0/4+bdh2jfZyL6dKyH3L9+cT3OX+GJecs98ebde2RMlxL3Hz0VD4iFfRcPiHhACAEhIEJAJARL2wYkBEsbFwnBMveR6/sJwUpcZWIYT47W3f54RWvrbgyndwkBCePGEAGp0KAX/i5dANXKF0HUKG6IGSMa/m7UC2P6tkLu7D9i17+nMHDsfHguGamIh14PCHk/EsRzx537T/D4mRd+TJ8S/To3QIa0yYPNPnPh+nBxdkLvDvVQ6c+C6m879p/AkPELMapPC6ROkQSee45i+sINQkCEgARDQHJAtA1CCIgQECEgQkAIAckB0baDyJgDkrjy+DCeHK27/fHKttbdGE7vEgISxo0xeUCObJoSqGnm4k24fe8xBnX9L2mtXN3uGNK9CbL8mFY3AclXrhVq/l0MtSoVg6uLCybOWYNte45hy6LhcHV1CRz38+cA3LjzAC27j8U/LaqjRKGcaNVjLPLmyIzalYorOckB4SULiwdEPCDiATH/cpQQrJDYSAiWtr1ICJY2LhKCpY1LRAjBSlRpXBhPjtbd/mRVO+tuDKd3CQEJ48ZoEZABHvOxeedhxIgeNVD7+w8fVQhVgdy/6Ccg5VvBo3/rwJCqDx99kKt0Myyf1hc/ZUgdYgVjpi3H/UfPMaZfS/zVoKcKDyuY50sFFCEgQkC0TF48IOIBIQSkClZIOxAPiHhAxANi/qAUGT0giSp+KeLzra8nq9t/6yFtOp4QkDDCq0VApi3YgEdPXqBf5/qa2otV7agIBXlDOFf15v1RrkQ+1Kr4xYtBeSZEQLYvHaXyS76+iAB9/PhJeVzqtx+G8iXyoWKZLyFZQkCEgAgBAaQMr/abRwiIEBApw6v9bEgIljYukZGAJPx7DOfoZrjM0zUdDddpT4VCQMKIvhYBuffwKao164++neopj4f363c4fPKi8mAQYaCk9d9/y4I6lUvgk48v4sb+Us3K3LV8wx5MmrMG00Z0QspkiVQ53otX72DBhB6gxPP2fSeqEKt0qZLi5Llr6DF0uiI4NPacpVuwzvMAhvZoAj8/f8xYvBHnLt2UHBAL+y4hWNoASRlebVykDK82LlKGNyQuUoZX21akDK82LlKGVxsXe5bhTVhhdBhPjtbd/nRtJ+tuDKd3CQEJ48ZoERBSeeLsVYydsQKXr99Tiec5fsmAvp3qK7JBZKTX8Fl4/tIb3VrXRPW//rA4i9lLN2Phqu149/4j8uf6GT3a1kb8uO4ICAhQlbWOnrqEZy+9kTxxfDSpXRblS+RXOn18fEEeke37jiNRgrgo+nt2rNyeDGoAACAASURBVN26XwiIEJBgCEgIlrZBSBK6Ni6SAxISF8kB0bYVyQHRxkVyQLRxiQg5IAn+GmnxzGYLgWfr/rGFWrvpFAJiN+jDx8A++xazJvLxxmWW3I11vE7o09ZdZemrkDYOSy5zjewsuZgpE7Hk3BLzOqG7/fSlGaSly+/RLUsi6u93M/3JkksYjdeF2C3Al6XPwYfXARvn9rD0fbhxiSV3ZxuvK/SmDddY+vJnScCSy/B3DpZczJSJWXLOCYNXpDN300Bfnr10LRgyt0tLZwCzE7rnDS/WOtLHi8aSSzy3B0vu9s4LFuW8bryyKEMCRc/vZcn5beSVyHx9k9dJOUZynk092HuaNT/Plbx36e8FU7D0ffT+xJJLVzYbS+5twyEsuWQx/iuAEtoNDuB1Gj9fuRxr3FgpYrPkknssYsm9+sSjSC9bVWXpi5UqIUvOLU7okQ8mJZ9evmHpS9iH1xzv8wZeBSfHGLxO6ChcmzU/B9+PLDm4hGygrHWj45tnLH0uifgNn1kKASQoP4Iraqjcs/W8rvOGDmpDZUJAbAguRzXlZHhMW2FWlMK0Cufj/XBwxvtaRgiINmpCQMxYkxAQTWCEgGjbixCQkLgIAdG2FSEg2rgIAdHGxZ4EJH654dYct8J8z/MNXcOsIzwpEAISnnbDDnMRAiIEhBAQD4i2HYgHRBsX8YCExEU8INq2Ih4QM78x4gHRBiYCeEDilx1qh9Ma8Hxjd7uMa6tBhYDYCtkIolcIiBAQISDmH1YhIEJAJARL2wYkBEsbFwnBMkNEv6MQrHh/8sIUjT4GvtjEC301elxb6RMCYitkI4heISBCQISACAExISA5ICFtQQiIEBBCQHJAzLwnI2EOSLwyg+1ywnuxuaddxrXVoEJAbIVsBNErBEQIiBAQISBCQMzbgBAQISBCQEI50ERCAhK39EC7nPBebultl3FtNagQEFshG0H0CgERAiIERAiIEBAhICYEpAqWti2IB0Q8ICYE4pYaYJcT3sutfewyrq0GFQJiK2QjiF4hIEJAhIAIARECIgRECEjoP9pCQISAmBCIU7KfXU54Xp72GddWixUCYitkI4heISBCQISACAERAiIERAiIEJCgCEgfEPP2EKdEX7uc8Ly29bfLuLYaVAiIrZCNIHqFgAgBEQIiBEQIiBAQISBCQISA8A5usYvbJxTq1Xb7hH7xUNEvJQREP2ZhvqNI5faYMLgdfs7I69DpuecoZizahDv3HyOKmyuKFciBbm1qwc31v060vn7+GDx2AZydndCrfR2zc6TGh216jsPulWOVzOvZvKSm21uPs9Y9eQWvA3azvzKw9MXLzOswnSBnFpY+xzi8rsZO7vFZ+vwyFmDJAbyW1V4+Dix9cV143YUd/JjdZ/18WON+2jSDJXdnG89e1q2+wtJXoVJGllzcTClZcnGy8ezFKV4ilj7H2Dx78U2Vk6XP5zPPDpx4Ythxy5s1bs6kMVhydyv9yZJ7cvEFQ473bJS6fYKhC7jbvhZL7sGR+yy5xNl4NnDv4AOWvvvP3rPkyvYowZJbP8STJZcxQzyWXNotPH3Ojjzji+3oyxr3Vof6LLnY6Xm/Cc4ted2qvZmd0P178eaXvFR+1joCfHjv5s8feZ3unaryekS4nN3Cmp9DVN67wD9tbpY+ODqy5AIceHKO71+x9LnGS8qS0yMUu1gvPeKGyb7aMcgwXeFBkRAQO+yCXgKyZO1OxI0dE9ky/4BXr9+ic//JKFE4F9o0rKhmv+vAKQwZvxBer97g79IFhICEsqdCQMyAIwREExghINr2IgQkJC5CQLRtRQiINi5CQMzgEgEIiHtR+5TD9d5pn/K/tjomCwEJI7LXbt1H7daD0alZVcxZtgXvP3zC3tXjcPrCdQybuBh37j1G0sTx0btDXWTLnB69R8zG6s37lPfC0dEBLepVQKMaZXTNYsLs1bhy/R4mDmkX7L6Rk5fik49vCAIyf4Un5i33xJt375ExXUrcf/RUPCAWEBcPiDZA4gHRxkU8INq4iAckJC7iAdG2FfGAaOMiHhAz71w7ekBi/WGfhoCvd9mnAaKuA6oOYSEgOsDSEiUCUqFBL+V5qFa+CKJGcUPMGNHwd6NeGNO3FXJn/xG7/j2FgWPnw3PJSEU89HpAvh63WZfR+ClDarRrXMkiAdmx/4Tyjozq0wKpUyQBhXNNX7hBCIgQkOAIiAdEPCAAJAQrpBlICJb2y1JCsLRxkRAsMz+u31EIVqwi3cJ4crTu9te7h1l3Yzi9SwhIGDfG5AE5smlKoKaZizfh9r3HGNS1UeC/lavbHUO6N0GWH9OGiYCs2bIf42auwupZA1VYVtBLywPSqsdY5M2RGbUrFVeikgMiOSCaJi8ERAiIEBBNGxACIgSEEJAcEG07iIw5IDELdw3jydG629/sGW7djeH0LiEgYdwYLQIywGM+Nu88jBjRowZqf//hI4b3bIYCuX+xmoB47jmGgR7zMXP0P8iUPmSyrRYB+atBTxUeVjBPViEgACQHxIzBCwERAiIERAgIAElCN3PQliR0TWAiJQEp9E8YT47W3f5m70jrbgyndwkBCePGaBGQaQs24NGTF+jXWbtqRrGqHeHRv7XyhnCv5et3Y+qC9Zg6vBMypNWuAqJFQOq3H4byJfKhYpmCQkCEgJg3NyEgQkCEgAgBEQJi9h0pHhDxgJgQiFGwM/foZqjc232jDNVnb2VCQMK4A1oE5N7Dp6jWrD/6dqqnPB7er9/h8MmLyP3rjyohnZLWf/8tC+pULqGSxr8Opfp6SpPnrsXGHYcwYVBbJEn0XylFyjdxcPivFKIWAZmzdAvWeR7A0B5N4OfnjxmLN+LcpZuSA2Jh3yUJXRsgSULXxkWS0LVxkST0kLhIErq2rUgSujYukoRu5p1rxyT0GAU6hfHkaN3tb/ePtu7GcHqXEJAwbowWASGVJ85exdgZK3D5+j2VeJ7jlwzo26m+IhtERnoNn4XnL73RrXVNVP/rj1BnUbFRb1y5cS+EDFXbih/XHZt3HsGgcfPx8aOP6jYRNYor+nasj5KFc8HHxxcUErZ933EkShAXRX/PjrVb9wsBEQISHAHxgIgHRDwg4gERD4h4QP6PgPQBMX9IiP57hzCeHK27/d2/HtbdGE7vEgISTjfmW01LGhFqIy0eEPGAEALSB0TbDqQPSEhcpA+Itq1IHxBtXKQPiBlcIkAfkOj523+rI1qwcd4d+NJA+nu5hIDYeSepKpXHtBVmZ0FhWoXzZbPZLM9WK83SPXk5r8N5yyo/svSlLp2LJeeahNn1Nkkqlj7H6LFZcgEubiw53wQ/sOSMFnL04XVTRgCvYzpX7kbHZqylrFnBs5e/q/LsJWVxnr04J+TaS2rWOhDNnSUX4BKFJecfJwVL7hOcWXJOvKbB8P7Es4NYrjyFO9Py9iNaHMu4/Fj1V9Za43cfz5LbkprXbZ7XxxvKq8y5igz4iyOGOztOseQyNa3KkttYixcXzl1HiZvHWeN6ffRnySWOwrM976l9WPpipOY9Q08L895VnwN4yMRc2Jc1vziFS7LkPr/xYslxhXxz8uwv6qPzLJUBTq4sOb+4IQviaN0Y4Gz5XaDuCxJWHtoEHHw/sObnFjMOS06PULR8wXuw6bk3LLLvD44Ly+3h7l4hIOFuS77thISAaOMtBEQbFyEg5uyF9+MqBCQkfkJAtG1KCIg2LkJAtHERAqKNi00ISN423/ag9v/R3h+aYJdxbTWoEBBbIRtB9AoBEQKiEGB6SoSACAEhBMQDEtIOxAOi/WyIB0QbF/GAmDkkRQAPSNQ8re1ywvtweKJdxrXVoEJAbIVsBNErBEQIiBCQUB5WCcHSBEcIiBAQCcHSfm9ICJaZ39TvKAQrau6WdjnhfTgy2S7j2mpQISC2QjaC6BUCIgRECIgQEBMCkgMS0hZ4GQKAeEDEA0IICAH5/glIlN9a2OWE9/HoFLuMa6tBhYDYCtkIolcIiBAQISBCQISAmLcBISDa2IgHRDwghEBkTEKPkqu5XU54H49NtXrc12/fo2GH4WhSq6xq0RAeLiEg4WEX7DgHISBCQISACAERAiIExISAVMHStgWpgqWNS2QkIG45m9rl1Pbp+HSrxh03c5Xq//bC6zVG9m4hBMQqFOUmwxEQAiIERAiIEBAhIEJAhICE/vMqBEQIiAkBtxxNDD+LcRR+OjGDI2ZWpkrTfmhc808hIGFCUW42DAEhIEJAhIAIARECIgRECIgQkKAISB8Q8/bgmr2xYWcwPYp8Ts7UIx5CVghImOCTm41GQAiIEBAhIEJAhIAIARECIgRECAjvhOX6a0OeoMFSPqdmB9Po/fodPpspoR8jWlS4uARvaCsExOAN+d7Urdy4Fzv/PYkpwzqwlzZm2nLMWrI5mHz+XD9j+sjOIXRQ5/U2Pcdh98qx6m/NHXgdoVsyO1anLsnrQhwlPa8DtqN7fBYOjjHjsuQ+u0RlycHJhSXn756EJcfup8zsyovPvC7E4Opj9nsekzQva73lK2ViyaUqnoMl55o2M0vOyT0eSw4xeN1xA1yjsfQFcO0lFs9efHjNo+HsyOvn7c+0A2dmDf59v+Rj4ZIsl+X1ZuzA61jt/3Nx1pi7fszDknNPHosl9+mND0uu0KIhLDmvXVtYcrGLlGLJneoylCX3/gWvc/Rve3ex9L3x4b2D3J15afz+myaxxnVOxOuE/vDn8ix9jiwpIMHBuSxJ159578iAt7xO6A7Md4tP2tys+bm8uMWS477TPsdIYKg+OPB2xMHvE2tctxjuLLmIKFStWX94v3mnOfW+Heshb87gv5tCQCLiLn/DOVtLQJ6+eIUebWsHztTZyQnRorqFmLkQECEg2ubMOyQIATGDHvOQ4C8EJASAQkC0bUoIiDYuQkC0cRECoo3L90xA9B5NhYDoRSyCy7fvMxFJEsXD/UfPcOj4eXRpWQNVyxfBqk37MGvJJrzyfousmdOjf+cG+OTjg3L1esDf3x9uri5wcnLCkU2W6z6TB8TL+y0GdtF2C85f4Yl5yz3x5t17ZEyXEvcfPRUPiCW74h4oxQOiiaR4QLQNTAhISFyEgAgBIQTEA6JtB+IBMYOLeEAsnWJC/F0IiG7IIvYNREDOXLyOjk2r4udMaRAzRjScuXADo6ctw7QRnRQ58Zi2AvcePcX4gW1hrQdk8ZodiBE9GuLFiYU/i+VBw+plFHA79p/AkPELMapPC6ROkQSee45i+sINQkAsmZUQEE2ExAMiHhBCQEKwQtqBhGBpPxsSgmXmnSEhWGaYhYRgWTqe6P374HELsGnnYbx99wFurq5wcXHCujmDkSBebL2qDJWXPiCGwhlSGRGQ7Fl+QN0qJQP/2KzLaJQpmgd/lcyv/o1qM5eo3hknPKdbRUDuPngCP//PiOLqgss37qH/6LloVqc8av5dFK16jEXeHJlRu9KX+GkJwZIQLDM/h6wnQQiIEBAhINo2IARECAghIDkgYXtHSg4I66f4uxASAmLjbdQiIOXqdgd1pQxaoeDN2/fYtcIDW3Yd0Z2E/vUSyMNx+MRFzPboir8a9ESnZlVRME9WISAAJAndnMFLDogWMpKErm0v4gERD4gkoWs/G0JAhIDY+Fj53agXAmLjrdQiII06jUDFMgXxZ9GQ1VrWbNmvwqSmDu9k9czGzlgJ8oqM6dcK9dsPQ/kS+dR44gERAmLeqISACAEBpApWSCuQKljabw0hIEJACAGpgmX1US3S3ygExMYmoEVAKBZv4uw1GN6zKTKkS4EHj5/j36PnUK9KSRw6fgHdh87A0ql91MwSJ7BcXnagx3yUKJwL6VIlxaVrd9F10FQM7NIIRQtkx5ylW7DO8wCG9mgCPz9/zFi8Eecu3ZQcEEv7LjkgmghJCFbYvu5JEnpI/CQJXdumpAqWNi5SBUsbF6mCpY2LVMGydNix39+FgNgYey0CQkNSsvn8ldtw/+FTxI0TC8UL5kTXVjXw+XMA/hk4BbsPnEJs9xgqLMvSNXTCIuw6cArPX3orwlK/aklU++sPdZuPjy8GeMzH9n3HkShBXBT9PTvWbt0vBMQSqEJAhIAAkBAs7QdFQrBC4iI5INq2IknoZj5aSBK6NjDSB8TS6eS7+bsQkO9mK61biDQiNIObEBAhIEJAzL5UhIAIAZEQLO3HQ3JAwuYlliR0685yEfEuISDhfNeohO6N2w81Z+keK7rK85BLEBAEBAFBQBAQBAQBQUAQiCgICAGJKDsl8xQEBAFBQBAQBAQBQUAQEAS+AwSEgHwHmyhLEAQEAUFAEBAEBAFBQBAQBCIKAkJAIspOyTwFAUFAEBAEBAFBQBAQBASB7wABISDfwSbKEgQBQUAQEAQEAUFAEBAEBIGIgoAQkIiyUzJPQUAQEAQEAUFAEBAEBAFB4DtAQAjId7CJsgRBQBAQBAQBQUAQEAQEAUEgoiAgBCSi7JTMM9whcPXmfTx/+Qr5cv6s5nby3DVEi+qGTOlTGjZXai65cfsh1K9WyhCdYdFn9Hojmz5DNvAbKwmLvRg91TMXb+Deg6f4NcsPSJY4fpjVU5PWc5dv4fGzl0iSMB6y/pQOTk6OVus1cn5GPxtWLyqUG43GzxZzDKozrLbs5++Psxdv4MkzLyRKEAe//JQOzk5OVk/74ycfnL98C17eb5A8SQJkTJcSjo4OVuszcj8igv19DVRY99dq4OVGqxEQAmI1dBH/xnzlzfcQObh+ku4FRjZ99dsPQ5mieVC1XGHMWLQRk+etQ/SoUdCiXnnUqlhcN36mG3x9/bD74GnVsf7gsfPIkTUjZo3uYnd9Rq83sukL78+H0fZn5HrHzliJxWt2IE2KJLhx5wFmju4CBwcHLFm7E8N6NNX9bNy+9xgtu3vgzdv3SJwwHh49eYEE8dwxeWgHJEkUT7c+o+dn9LMR2l6YFqvnnW80fkbaStDNM+pdeuvuI7TsPhbvP3xU5INISPRoUZS9pE6RWLe9HDl1CZ36TYarqzPix3XHw8cvkDhhXIwb2MYqcm30fnxL++Pa3Svvt4jtHiMY1iH295eMmDXG+t9K3RspN4QJASEgYYIvYt98+frdEAsYMGaeOlTXrqT/AB3Z9OUp2xJbFg1HHPeYKFnjH/TrVF/9iDTrMhrblo7SbRwXrtxWpGPTjsNIGD8OypfMh7LF8iFh/Ni6ddENRuszer2RTZ/W80EH1+xZfkDT2uV077HR+oy2FyPfB7lKN8dsj67IkikNFq7army7Q9MqqNCwJ7gHmKAAN+86Wn1xbtuokvJ6+Pt/hseMFbh99zEmDmmney+Mnp/Rz0b15v1RqWwhZMmUNnBt0xasR4Z0KVAk36/q3/R4bo3GL7zbcoMOw5A3R2Y0rllWeSkCAgIwa8lm9YGI7FLv9Wedbqj0Z0E0rF5G3UreldFTl+ParfuYOeofvepg9H4YbX9GvAuyl2iCogWyo2q5IogWNcqX38qdh9Xv718l86NcifxIkjCubuzkBvshIATEftiHy5H/PXoOk+auxZLJvQ2Z3/esL2/Zlti3dgK8X79F8eqdcXTTFHwOCED+8q1wfOt03fhlLlxfvUCH9miKXNky6b7/6xuM1mf0eiObPq0NpRCgviNnY/WsgWHeb1IQFn1G24vWgqx9HxSp3B6LJvZC0sTx4f36HWq0HIA1swch958tcHr7TN3Y0X07lo1GzBjRAu99/fY9SlTvjMMbJ+vWZ/T8jH42cpVuhp0rPBAryHrPXbqJvqPmWGV7RuNn9LNhtC0TfvvWTEDUKK6BU/3w0QcF/26LY1um6rYX2t9l0/oiZbJEgfc+ff4KZWp3seq3w+j9MNr+jHgXPHz8HGu27MdazwOg/yZbHtClIYoXzKkbf7khfCAgBCR87EO4mcXNu49QsWEvnN4xy5A5fc/62vWeoNznXt5v4f3mrQqTOnzyIoZPXKwOR3qv/UfOqhfsgWPnkS9nZpQrng8F8mSFi7N1ccZG6zN6vZFNn7lDVv12Q3HCUz9hNVqf0faiNT9r3weT5qzBu/cf0aVVDaW2UMV2GD+oLXoNm4kN84fqfdTU/fSRhQiN6aK5NewwHHtWjdWtz+j5Gf1sEEEaN6CNylswXRTnX6fNYBzZNEX3eo3GL7zbcvl6PdC7Q91gH4aOnb6MgR7zsX7eEN34dR8yA7myZUTFMgWD2V/bXuOxMRzYs9H2Z+S7gLxPh09cxOot+7D7wCnk+CUjKpT6HX/8nh1uri6690JusB8CQkDsh324GJlcv5QI9+TZSyRNFB9pUyXD42cvkC5VUqvmF5n0vfB6DY/pK/D67Tt0bFpVxQLv+vckXFycUSD3L1bhRzfRF96NOw4pMvLwyXOULpJb/fhZexmlz+j1RjZ9bXqOC7aFPr5+Kqm1fMn86N6mlu7tNVqfaQJG2YtWIqujoyNixoiq+/1CISGUr+EeK7qaJs2RvkaTt9CaL6BDJyxCjOhR0aZhxUDcR05eqkJhrNkLo+dn9LOxaPV2zFm6BXWqlETSRPFA+hev2alC2gZ3a6zb9ozGL7zb8s79J9Fj2AyUKJRLeampcMG2vccxuGtjFRak96rVahAoryRr5vSBtz597qW86T+kTaH+bcqwDmy1Ru+H0fZHCzH6bEA6yWu5acchrN68H/cePkXpP3Kjb8d6bNxE0L4ICAGxL/52Hf3R05do2W0MPn7yVS/UBHHd4R4rBiYNaW9V3kFk0/ctNu/KjXtYvXmfVYcirfkZre9bYPC9jLFs3a5gS6EkajoEDuzaSB0E9V5G6zPaXoxMZKXY+KAXERmqhBXF7b+QGL34kTzlfrx89RpxY8cKUwUsW83PmjWZu2fPwdPqq/GDR88RO1YM9ZGk5t9F4RoOvhqHd1smTG/cfoCNOw6DiALl6JUtlgfpUiezaotWbtxr8b7KZQtZlPla4PPngEB7DktFLd0DW7jB6LOB1nD0wWPVpr2G/VYajYHoC4mAEJBIbBUd+01SX+0pEbNYtU4qJnr6wg0qjnzCoLa6kYls+noMnWERoyHdm1iUCSpgdKlHI/W17zPR4lrGDmhtUcYkENn0aQGz7/AZTF+4EQsn9mTjFppgWPUZaS9GJ7KaCMPbdx8CPSHWgkY6hoxfiM07D8PXz1+FOVb8sxC6tKweZlJj7ZyC3hfas6HnGTNiLlo6jH52bfFsGGnLtsLRKL1kz8MmLsbG7QcD7bls8Xzo1rqm8vTpvYzeX6PPBnrXI/LhEwEhIOFzX77JrApUaKPiV6mKhImA0Eu7cMX2+HfdBN1ziGz6ps5frzC6cOUWLl69gyrlCofArHnd8mwcjS71aLS++Ss8Q6xl6bpdyJ/rZ6RImlD9rW6Vkuz1RjZ9WsDcffAEFRr0wsltlsksB9iw6DPaXoxMZKUvqAM95oGS2MlrQSVQ/y5dAO2bVAmWGMzBiGT6j5mH+w+foUur6sqTcu/hM4yYtATp0ySz6guq0YRB69lYtn43fvv1R6tCTBat3mERmloVi1mUMQkY/ewa/WwYbctGH8i/9vgEXX+xgjmV17tJrbLs/aCPYRSi2L5pFdXThiIaxs5YgZjRo1kVYmf0/hp9NqDkf3PXjFH/oFrz/lYVp2ADLoKGICAExBAYI6YSKh25fekoVVvbREDu3H+Cxp1Hqn/Xe0U2fSZ8PPccRcd+k1GlbGGVq2FtMzOjSz0arU/LHig2msI6KGzPiOt71ke9YoJeVMN+z6HT6jA9x6ObbviM1me0vRiZyFqv3VBV8KFd40qIHze2ivceNnERUiVLjH6d6+vGjpKol0/rp3o6mC4iOTVaDLAqCV3rwDZn2RaUKpIbXf+fOK97kl/dsPfQGVWCeMaozrpVFavaEXHjxEKi+P+t9+T5a0ifOllgZawJg/WXHw46kbA8u+HdlukjwS8/pVV4ma61W//FLz+mQ9pUSdQ/6fn40qKbh9k97N6mJnoMnanLK0p9VLYsHBHMM+j95h1K1+piVZlqo9/1Rp8Nzl+5ZRa/tCmT4MyFG8ibM7Pu50Ru+LYICAH5tniHq9HqtBmCprXLqlhg+qJAyZw79p9A64Z/q8O03iuy6SN8KLGTwtaG9WyGlRv3wMHRAaN6t7AqrtroUo9G69Oyh/uPnqFio944ull/KcrIpq/roGnBluzs7KRCIKmuvSm5Ws8zZ7Q+o+3FyERWOsCsmN4vWNM3+lhChOHgBv1NU6ls6fZlo4OVpX324hWo2tEhK8rwau3b+m0HsH3fCavCWbX0kXeLnjVrSnxTmfBZo/8JVvZ11aZ9OHX+GgZ1baTH7MzKhuVdEN5tOf9frbFuzmBFgk0XVY2bv2KbVYTQEMCDKPmjSgfMG9c90BNNfyKSXr/dMOxcMcaQ4cKyv0afDQxZkCixOwJCQOy+BfabwJmLN/Dh4yfkyf4TqCEaxYr+/lsWXQ2pgs4+sunrN2ou/j16FlOGd8QPaZKrKh+9hs9SXZXpx0DvZXSpR6P1URJr0OvjJx9s3H4IT194qa/Jeq/Ipk8vPt9a3mh7MXL+5J2hpm1Bq8tRN+qqzfph7+rg1cU447bqMVY1lgvacJW+wtOXU2saEWqNSWFANL9jW4ITT878vvaoUMU0qrDn5uZilbeMmrjtWD4GcWPHDByeDqjVWwzAgXWWc7u+nrPRzy4HEz0yRtsy5TOtmjkgWJfyuw+eonKTPlZ9fPHccwzPX3qDwt4of4NC5KiqW40KRVUVRb3XlPnr4Ln7GBrVKKOa4dKzMXPxJpQskgst6v6lVx2M3l+jzwa0oK27j4JItKrgmTie+pBDpXjlijgICAGJOHv1zWZKrmWqq23U9b3qq9ykryqVmCDef53KqUb54HEL0at9Hd3wGV3q0Wh99PU16OXi7Iw0qZKgZb0KSJnsSw6Iniuy6SNs6Cv25p1H8OS5lwqHKVM0d7Cv0nrwM1qf7GoJNQAAIABJREFU0fbSqb/5hn7tm1RWPRSmj+SFE1GMO+VZUcdj03X99gNQh+WyxfKqf2pQvTQbPi/vN3jz9kMwu6UDJZUIppw4a6+gVYiouhaRhqrli+hW9zV2VDHt0IkLWDypN1Il/695HVdxo04j8NMPqdGuSSU4OzmpTt7zlnti+Ybd2LxwOFdNoJzRz+77D59ApYKJFOXJnlk9F1QcgMIUo0V10z0/o22ZPjbde/QUnZtXU+Xqn3t5Y8q8daoi1vzxPXTPj/Dr0LSKItR9Rs4GHdDjxY6l9rZvJ/0hhWR35IFfv+1g4LulfIl8qFy2sOrcrvcyen9N41P+lhFFJIh4EMFq1aACqHw2YTltwXrVqZ46zMsVMRAQAhIx9skms6TOq8vW78LDxy/w+fPnwDG27D6iek/QNbxXM/bYkU0f/Wha8+MYGqBGlnqkcYzWxzYGEQyBAMXwdx4wGQVyZ0WSRHHx+OlL7Dt8FqP6tEChvFl1I2a0PqPthcITzV3lSuRTX30pp4NzfR2io3WPnneV0UnARlch0lrf8g17cPTUJWUvei/Kb2nfe4I64FMJWSJHREJG9mmhPOD2vsgj9fyFN3L9mgnrPQ+gS8saSJIoHgaPW2BVp3ajbfmTjy/Gz1ylksOp9wSRuPy//Yze7euqeeq9cpZqqjqr0+8H5W9QDhh9yKrQoCf2rRmvV124lCcvDzX6pBLj1Ll8gMc81WSXyFJYi0iUr98Tg7o0VI01Tfmr9AGhedfRVhHqcAlgJJiUEJBIsMnmlli9eX/V9yNXtkxwcnQMFBs3cyXaNa6s/r+er4qRTZ+RX3gjghka/ZUysumjH01KSKaqYabr4PHzGD5piYov13sZrU/v+ObkKUH054z6+5oYNT5Hj9FJwEZXIdJaA5EHSoY+4Tmds0QlYyoxTP9NhIN6JTx49EwVHsmcMU2YOkcb6c2jEDGqyJg8SQIV/rNi4x4M6dZEHS6PbTEmv4wNmgVBqjZF4crklbL2oiIIG+YPBeUdUVPCQxsm4c27DyherZNVnelDq3Kmp7qZaT1GvJsLV2qPMf1aInuWDKjbdojy9FJVSOq5Q7ZDVefSpkpqVbQA2QvlflEfoKAVPAtWaGtVTpi1+yj3hQ0BISBhwy9C352tWCPsXzsBMWNEC7YO+jpjTaJjZNNn5Bde2oDQCI1pg0b3bcm2OaP1Gf2VMrLpoyRvet6CNs+jPJoCFdpadcgyWp9R9tKo4wjMGtOFbaccQcpRo+IY9OXZdFHO1eS5a1UfI+5lK3JkdBUiCskJevn4+KqeJUdPX8amBcO4y4Ut9oIGN9r7RmR6ZO/myJguBT589EH5+j2wfu4QFKjQ2qrfIqNs2RzQFBq2++BprN26H5OH8juWm/SNnLIUx09fwbsPH5Etc3pVCICKFlBH77lj9VfE+7qTPI3z77HzyPlLRquS5I14N9N5YO/q8arABr2rNi0YHqzBMeVKVmrSx6oqXUQ6po3ohHSpkioCQjmI9HtMYZl6OsizHyQRtAkCQkBsAmv4Vmr6KtZl4FR0blE9RNfzlt09dL1UI5s+W+1uaITGNKYej5TR+oz+ShnZ9FEp2RKFcqJWxeKBJkRx79v2HreqaIHR+oyyF1sceimH4cOHTyr8iMI6qCLPPwOn4t27D+rLOfeyxdxobKOrEBWpHLystbOzM1InTwzKncmcMTV3uTYjIEZ73ybMXo1zl27in5bV1drqtx+G5nXKq2djwQT9ORZG2fLXQF+4cluRjk07DquyxuWK50OzOuXY+2ESpDCkDdsPqt4dFcsUVKFY1289QJQorsoLZMQ1bcEGUK4TNSPUexnxbi5dqyuG9WyKrD+lQ82WA9GpeTXk+CVD4FSoSh4RTWuKIJDXmJLt61UpCapoR4Qw/29ZVEhcwvj/5WTqXbfIf1sEhIB8W7zDxWhG/whHJn3Xbt1n7SFVxeJelFBnZOKc0fpM6zD6K2Vk00f5OM27eahwxy+Val7Cz/8zpg7rgHRB+gtw7cYofUbbi9HvA8KDwocozIQqVVEDwiVrd6pCGR2bVdUVRmSLudH8jK5CxLUBS3K2Wq/R3jfyIAW96BlJnSIJ+nSsqyoMci+jbdk07txlW7Fm6368ePlaJciXK5Ff5TYYffUeMRsDuzQ0RC39VjXsMFx5XfVeRrybKYxu0py1oGT4h09e4N6DpyhV5LfAqdy48xBnLlxXoWhhud69/6hySuSKeAgIAYl4exbmGRv9oxSZ9NHXFtNFiYmODg7Byia+//ARUdzcdIXUhHf8TOs1+itlZNNHOFIozYmzVwMr1dAXQVdXF6ufaSP0RRT7o4MGhdZQN3TKo5k4uJ3ukqVGr9W0cUZXISK9FIZFh7Zfs/wQrPyrHmOx1XqN9r7pWVNosrZa768lmiBe7Jjo1b6uqlxlbbNZ09yPnroMev89evIc/kEKwFAhF9MX/N0rx4YJFvISUj7nyN76ixYY9W4+e/GGClWjamF+fv6a69FTPMKkILQiEiaZan/9ESb85GbbIyAExPYYh7sRjH5JRzZ9pg2t02YwurSqGexLGL24qTwtJdtxr/COn2kdRn2ljKz6uPbwreUigv0dP3MF3YfOwI8/pET3NrXVwerazfsY0auZLu+R0Wu11V5RzsviNTuQJkUS3LjzADNHd1FJz+T5GdajKXtYW63XKO+baSFEKqkH1dcXFWnIl/O/og2WFm6r9VJXccrBWbNlv+qxUfqP3OrL/k8Z+OFwQedOeQsUevV7rp/h6PRfAZi6bYZg/v9DzvQUcgjNM6/Hg2Srd7OlfdP799CKSJh0SS6IXlS/vbwQkG+Pud1HNPolHdn0mTaQ4mR3rxoL95jRA/f05t1HaNZlNLYvHcXe5/COH3shIhgqAl8TuKDCB9fr7+ZtlL6IYH9UGIPy1aoH+apJh0FK5tWDndFrNe0hhYhRDwYqIWvq8VK+ZH51SLWmWhJ1fp/t0VV93Fi4ajso94B6HVRo2DNcrJfWbYT3zYQfVYWi0sxUfdHF2UnF9I+duRL0pVtPQRRb7W/QZ5UO+2s271c5HNQzRk8OkklPtuKNVe7D16FD1haACeqZN41BpaGpWteRTVPs/mam30VzV5KE8XD15j2VKyJX5EJACEjk2m+1WqNf0pFNn8lkqCRm41p/BjZCo3/ff+QsqCSnnrjb8I5fJHxEbLJkapr39UVfurNn+QFNa+tPZDVKX3i2P1PVKjr0aX3JpcTd9GmSsffL6LWaBqbcFOoRUa9qKdCB6vHTF5i3wlPlqzSpVZY9P5MgJaEvmthLJdx7v36HGi0HYM3sQSrh9vT2mWx9tlovewJMQUqW7jtqDp489ULbxpXgMX2FaqA3vGczpEmZhKnF+N+20KqmURW2vQfPoGgBfvdtk76l63ahRKFcwTrT0yJnLdmsupkbcfUcNlMd6q1phGnE+EF1ELEydy2c2AuVGvfBhT1zdQ1LpHzv4TN45f0GyZIkQKnCvyFRgji6dIiwfREQAmJf/O0yutE/SpFNn2nTjp2+jDa9xuPXn39AiqQJ8Pzla+w7fBot6lXQ9SMS3vEzrdeoL+6RVZ/Ww37u8i30HTnb6mZrX+u0Rp/R9kd9HArny2bIu83ouRmtz7TIolU6qtLDqVMkDlz37XuP0bjTCOxYPkY3FpPmrAHlvHRpVUPdSx6C8YPaotewmbqSdqkSkjVVmrQm3L7PRNY6xg5ozZIzN8b2fcdVONakoe2DlV3mKDV6f8O7vtAwofyLroOnYcuiERzogskY/a63NAEic0FLbFuSJ3I/cfZq/JE/O+LHc1cNNg+fuKiekfDQWNPS/OXvXxAQAhIJLSG8v1TD+/yCNveiRlJbdh1RVT6o3jklKOqJ3SXzC+/rNT0iWl/cB4yZhzJF86B2pf9Ky3IfqcimzxwBqd9uqK7mcqHhSwRErz6j7c80P+q+nSRhXM3pBk22DW09Rs/NSHIUdN75yrWC55KRwXoqUYnVkjX+saoxWp6yLVWJVnqn0EVekKhRXDG0R1MUL5iT9YiF1pwuqAJuo7r5KzwDb6Nws58ypEL6INXb1m79V+VEUE8LvRd5QPqNmouL1+6gXaNKmLZgPXL9+iO6tKwerG+OJb1G20t41xeah4a8g1S+eu/qcZZgC/F3o9/Nuidg4YaCf7fFwC6NUChv1kDJDdsOKg/S2jmDjB5O9NkIASEgNgI2PKs18qsYrTOy6QvvP0pGzy80W6bk0Ulz12LJ5N6GmPz3rO/rZmE+vn6gr5SUK9C9TS3d+Bmlz1b2Ql9RzeVnlK7VhfVl1lZzGzphEX7/7RcUyB0y8fnwyYuIFyeWrvKv9KU54HMAOjavikTx44AI1uipy+Dw/zAivZv7dVKxo6OjqoQVtImlJZ1B7ePyjXuI4x5Dzc10nTx/DWlTJrWqzwZ5ZFbNHID4cd0D9VH4KX2ZnjnqH0tTC/F3OlDmypYJ/TrVVySOOnEP9JiPc5dvYqOOMq1G20tk02erd73RHhUKUSQ7C1q+/OWrN6qT/AnP6brtT26wDwJCQOyDe7gY9ZX3W9WJlX7YjLh27j+pqtRQ3PLXF43l5uaqvuLpucjbcPTUJdy5/0T1AkiaOB5yZc2kkuvsdRn9oxTal2Jr1mi0vtDmQMmFFRv2wukds6yZaoh7vmd9X5eOpOTkxWt2YmDXRlb1FDBKn63s5bcyzTGiV3NNu+g2ZDp6tK2F8iXyh2o3Rj9rpsEyF66v4u8nD+sYAns6RO89eFolgXOv12/fg7yBW3cfDbyFeh706VgPsWJE46rBkPEL0aNtbbY8V/DPOt1Uh+iUyRIF3kI9M06dv2aVxyJv2ZZYPr0fUiRNGKjv7oOnqNykD45unsqdFkzeZHP9O6jQAOXRcC+jbdlo+wvv+mz1rjcqX800P+q7Q2V92zSsGDhlKls9asoyqwg1175EzlgEhIAYi2eE0kZfyOgHydR99tK1O+g/Zl6wNSyd0oe9JvpRpy6uS6b0CZFcR18cn73wxph+Ldn6iHQ06TxSfQ2jRESqJU5x0Z98fNC6YUXVBVXPNXjcAvRsV0fzlnEzV6Fd40osdUb/iJgGrdioN4oVzImW9f4KMQ8qv0kHppKF/2vkZGmyRoTAWBrjw0cfPHzyHOlSJbUkyvp7ZNO37/AZTF+4EQsn9mThY0koLPpCi/G3Jq4/yx8NkCZl6Haxfu7gUJdkq2eN3lUTBrdTpGGOR9dgic703qnZaqBVHZqpMtTzl97KM2BNfxdbrTdHyabYtnSU8uyYLoqbr95igFXrpN+JW3cfoXOLakiRJCGee3lj8ty16h29YALflm21XqNs2ej5hXd9oT2MRr+brclXM82P7Jn6cEVx+6+HEjV1JS+ki4uTEtNTPc3Se1X+bhsEhIDYBtcIoZXc3lOHdwysZU5fsKo166e+wH345IP+o+fqqkxBP+qt6lfA3kNnMGdsV0SL+l93UvoC0rK7B3at8GBjQ11cM6RLgU7NqqqGYxTvOmXeOvzTorrS1axOefxVMvQvqEEHCy0khFy66+YOYX2tNPpHxDRHwi9V8kRoWL0MKpctFAwnyjOZvXQLVkzvx8bPiBAYoxNPI5s+S5t198ETUDW1k9tmWBJl/T0s+oLG+JsGm7NsC0oVyY2u/0+GZk3i/0Kh2R9Xjy2ftWNbpqomaSMnL1XhHKZqWo+fvUT5ej10fcnnrseSnK3W26TzKLU+6hxPZW7Jm0zdvZdv2IMti4ZbmlaIv9Phb/zMVVi5aS+o3CslEOfL9TN6ta+jy6Nuq/UaZctGzy886zP63WzJqKzJVzPppPecpSuot8+SrPzdPggIAbEP7uFiVPqKQImTpjheIiANOwxTVVsopIDc7HpK49EBmn7UqbTopWt3Fbkx1Tl/4fVaxWfqOWjlKt0M+9ZMCAzboh+9AhXaqIMBxRuT12LljP5sLH8p2hAZ06XUlL9y4y4ypE3B0mf0j0hQAkJfhJv8MwrdWtdCiUL/JZtS86uydbvh2JZp7PUaEQJjdOJpZNMXdLOoVGvQi3od7Dl0Wj0jczy6sffVJGi0Pq0JrN92ANv3ncCEQW11z2/YxMXo1rqm7vuC3mDLZ43eVfSRhMJ8hk9agma1y+GnjKmxbN1uvP/wAVOHd2LP3agYd1utl7yh7XtPwJ0HT5A4QVy8fPVadeAe1bsF8ubMzF6nVqgUJctHjxZVlc3Ve9lqvUbZstHzC8/6jH43B90Do/LVbBWiqNduRd4YBISAGINjhNRSrVl/1fzJVMFo0ert8NxzDPPH9wgTAYkaxQ29R8zGhSu3VHz7j+lTYd6Krdi88wjrgG8Cs0ztrhjTrxUypf9CGihErHHnkSpkgAgNdZM9pePLMTX3slShpWThXBb30ugfkaAEhA5F9x89B3l/KDTO5OG5evM+GnUcrqu/iBEhMEHBMDrxNLLp6zooOHl0dnZSZVurlisSWO3IovEFETBan9bYFGZTtVk/XcRXzxosydqqapXpY4nJS0sltenDCT1n9L4Z0r1xsPwGS/PUinEfM225SqzW0wfEVu8Wmj95Pa7cuIeHj5/DPVYMZM6YWldSO+kwen5G6wttn6yxZaPtz2h9tsLP6HezUflqtlqvpedb/m4bBISA2AbXCKGVfnRbdBuDH39IpRLET5y9qnI0iuT7NUwEhH7U6ceOqmNNX7hBxWpGi+qGCYPaIU+On9jYUFm9UVOXqURVJydHUJnHimUKoG2jSqrud+ue47BuTugx5EEHMyIkxBY/wl8TEMKPyFbzrmNUeFzmDKmxbe8x5PglA/p2qs/Gz6j1mgY0KvE0sukLrVQmezODCBqtL+gcKJHz3oOn+DXLDyqUhvIZdv17MszNzEZPXa5CgPSETFqDDfce+hhSonBOXb0HuLpNcpTgPXjcQl0fXWx5wKL8FAp7oRAzapZITerovarnMnp+RuuzlS2TN5mIZOOafwbrbE+hetZ0Qqfqd/Rs/fH7lyaGnz8HwNfPL9hWuLn+l99gbo9shZ/R73qt+VuTr2ar9ep5BkTWOASEgBiHZYTU9OjJC+w6cBLeb96jUJ6s6qsYXfRjRdVg9Hy9o5wRKicaNPmS3PNEFqhaCpVX1HsdOn4BG7YfhPebd6o5VY0KRfWqCJSnnh0J4sW2+n7TjUaXHdYiIPRvVFaQ3OJUkpO+ylK3bM6PkkmfESEwQcEyKvHUpDOy6DP6R9Nofab9IA/A4jU7kCZFEty48wAzR3dRhy0qgDCsh/lOxpwHKluxRsib82dkTJcC7ZtU5twSTIY6JVPZV62Leh3MGt1Ft05b30B9GKiDuZ6wSVvtLTVFpLw5eh8nThgP9N5PEM8dk4d2QJJE8dhQGD0/o/XZypYpfDdzxjQqXJKeBVPYMnX4tibZuU6bwaoTep3KJdSUT1+4jlqtgvev4IQ/G+1RsdW7WcvArMlXs5W9sB8AETQUASEghsIZMZX5+39WiYSmplcRcxX8WZN3hg5WYb2+rtUfVN8PaZLrVk9fxKhKjRFz0z044wajEk9NQ0UWfUb/aBqtz7QfFKJIpWezZEqDhau248KV2+jQtAoqNOxptp8Hw2yUSLbijXF86zT0GTEbFHrWt2N9XV/fyZu3Y9lozeFK1eyCueO6I23KJNzpqHDQMkVza8rvOnAKf+T/la2LBCmRPehFRTwoT+2nH1Jh3MA2bF0d+01SYadGX827jlb5b+Q9Jq8HvfM9ZqzA7buPMXFIO/ZwRtue0fpsZcsm+6XE+3WeBzCkexPkz/UzrCUg1GiSKkxSCCZdRAirNe+vShu/e/cB5ev31JV/OWH2avj4+KFT86q4ceehKuccLYoburWppasogK3ezUblq9nKXtgPgAgaioAQEEPhjFjKKDFxoMc8UPM3+kGirztUc719kyq6+3Wol6gBnY+DIrhg5TbV/4Mqq3x90ZzpIq8I96IDPvUfOHbqsko29ejfChev3lFehgxpk6t1U6gY98r9Z4sQokTkqEfJkU1TuGpsJmeLviymyYYl8VRrwd+zPqN/NI3WZ9oPqgS3aGIv1ceHOm/T1/s1sweB7Pz09plhslM6wJEOIv8UVkleUUqA5paqpZyN0C5q0KenAVlo4YmUW7Zl0QhVLYp7UZnxoBdV7SNCVLZYXvYag95v9McN2kMicEG90FRopET1zji8cTJ3mYbngNjKm2y0LZvsl4A6ePw8ug+ZofInl6zZqcvuTEATAVkza2Cg94n2u03P8di6eIRV4c+0j1Qqm0J2iWzSPlOY3dWb93QVU7DVu9mofDVbvfvYD4AIGoqAEBBD4YxYyuq1G6pcydT/In7c2OpQMGziIqRKlhj9OvNzDUyrNqLsa1AE/2rQU/XE0Op9ceDYeVV3ftGkXmzQOw+YAn9/fzSs8Seu3bwHquhCyaP1q5XCjdsPlQeof+cGbH1agj2HzVSx1VXLF9Gtx6g+JaaBje7LQnrvP3oGKgn8+OlLdVClA1aiBP91V9a76Migz+gfTaP1mfZs0pw1qs9Ol/+X3KVE1PGD2qLXsJnYoKMbtUkfVZcyXX1HzQn2bFFSKuWdzRvXnWUy+cq1wqaFw0KVjeMek6WLhLKXaGI2nHPpul0oXyIfK9/KXAM99kTMCBr9cYP2csnk3sGaxFLTTyp2sWfVWPZ0bWV7FPJLTTn3Hj4Nr1dvVT8p+hhWtMCXHAm9l9G2HJSA0FzoYxaRECIjnFCpr+ffqsdYxIoRXf3OUgnjAR7z4OX9BuMHtrWKgFBFyyObv3z0+q10c2xeNFzpL1ypndXlpI1+N+vdQy15W9mfEXMTHfoREAKiH7Pv5g4KuaC+EiY3MC2MPA41WgzAwQ2TdK/TiLKvQQellyodOqhspOki0jR3bDdVBats3e66vt7Rj/DWxSMDvTtUqSuOewxVG5/CgUrX6qKrT4kWQJRc2HXwNPUFVe9lVJ8S07hG92U5ee4aWvcci+IFc6pqaUV/z47dB05h8rAOyJY5vd7lIrLoM/pH02h9po2jr7LkiTKFYpIXJGoUVwzt0VTtud6LnlXTdfzMFeTMmjGECi4BoYp9y6b11TsFs/K/lmiCSmUKhqpPy/P69Q222gutiYXl4wZ5aMgzG7RzNIWN+fn7q7w97mWr9fYaPgtnL91E3colVJ4efQybvXQz6lcthbo6G87SWoy25R37T6BYgRzBYCJvHs2ZPjjpvagSGRVRuX77AZycnNTv0PQRnVWhBmtK4Jeu1VV1uqcCA/TBgErp039XbdoP+9aM1zs9w9/NNAEjCI2tQhR1AyQ3GIKAEBBDYIyYShp0GKaa3hXI/UvgAqjfBJXd3Lt6nO5FGV329Y8qHTBuQBtk+TGtmsvT569ArvXdK8fic8BnlKvbXVeCZ+FKdK+HyrGgH95iVTth1pguqos3haDReNasOyhQlHhKSbHW6DGqT0lQAmJkXxZKnKSSzeSRojAVCumgL4DjZ63+X3tXHR/V8cSHJGhxlxYptNACRQqUosEtULy4ayCBIAmEoIHgkgQIEtzd3S24FXdocfcE/32+y+8dF733LvuSu9zMPy25fbOz3917t7M78x0Rz6xVbEWf7E2bbH3KvIUN+7GzsxPx4whviq6EPUGOrr7oPi+LIU6vuYhofNE53IgMLzAL1q5aSjWcUYXZqlYSQUPc+OBgCYyMipw4c5l6D5lCO5aN06xa9lrGgQtuPZrWrSjyJRes3C6cc5CiINzOHMFvDvI1Xr56I0KnlPBf/B1Md1ocG9Tr8R4/T5DHdG1TR5DHBMxdQ1eu3zYrp0j2u1n2YRPwlsHqZs688TPyEGAHRB6WVqfJc/h0kQNhTI2JExmEJSG0BtK6UTXV45L1o650CB59JITi1A6nd6hTgtOxJ09fUsKE8cUtCH601IqLl59IsK1dtbTQhdN7hBE1qVOBgo6dI7BygBVGi8g41VH6k1WnRNGn1DqQVZcF9u1ZOUEUb1McEJwCIjzmoIY4cuPx2oI+2ZtU2fpMrXetm9SI9L0Nfqcpvyoqm2RQ+mJDqabmjylsYnIuonO4gcObJWt30t37T+jz58+GYW3adZiqlfuajD/Sq6Op4Ro+l53vh6TrYR5tDYdN6AgsgFUa9xbFbWWJuWu5btv+gpABh3UDRs8k0FWnSZmcsn2fQVWoXlj7ccsBhwPhV7Lkzv3HwjkC01x0Rfa7XrZDI4vVLbo48fPRQ4AdkOjhZ9VPh00Mi2gwWn6UZNO+4oTDf+Yq2rTzEIW8+0DVyhejvi7NRG2RU+eukHuXJpqYb+AsoLYGClLBkUH4x5FTF2ja/PXipNenT7tQMdKmJlf2qY5sB8642JqMuiyl/nIRIXug7VQckF1BJ2nizFWRUqRGhaGt6DOmykT1c2ys0qdNaTbbmWx9yhzJ3qSa+v6Y+3l0KX3N7Tei5/RyQOCw4ZAEoUjFC+cVjF0fPn4irB8tRBmKzY06DRbFB1EY0d7uW+0P38Dl1K3dV1pkWYdNCGXVGoLqG7iCrt+6S+2bORlgPnPhOm3ccYg8ujYRf8uXO4fqqZO9lsF2tXeVv8Ae7+lZ4/uI35DarfuZFeKEd3OJIvkoYKRbOCcEJA2gWzcOl4to4FERFRi3N4eRUfa7WbZDI4vVTfWC4oa6IMAOiC6wslJLRQAbcVAeIvleLQNPZGORfaojq06JYq/suizd+vuTY4mCIjkUP8JpU6UQ8cpgEyuU7yfNU25r+rbtPUaewwPpbXCIcJxRZ+P1m7d06MQFEdqhVWTrk71J1Toete2jS+mrth817fRyQJCk/PjJCypaKA+t3XKA3J0bC8cfRBUrZ3irMS1UGzht+1b7h6vFZC6NrOx8P4TWmhKE3qoV2WsZ+YMgYsA7GvU6Dq6bRK/eBFOlv3uaxXgIBwTv0tQpk5O3e5tQwzp88gLh3b1x/sgoh2tMVIAcRrt48UKFg+E9kyhhQrNukGQdp9wVAAAgAElEQVS/m2U7NLJY3dSuJ26nDwLsgOiDq81qDXn3ns5evCEYPcBkAu55Ozvza27I1mc8MTiJRgEoJACi2rhWh0T2qY6lLhql8jbwCgl5J26JUOMgRbLvKHeurJqKI2KMtqZPmVdsYlCEr2q5P8RGEmGFCP9DsraWzZVe+mRvUvVaz9Gl9JVpl14OCFi6UGEb71DceC1bv5t8+rQXN4/mhCS5e0+hXp0biZs3Y0FxQq1hp3hedr6fzDmBLtlreXTAYjp26hK9CQ4RhBtDPdoS8i5WbtynKQxYGScckP1r/MnVy4/y5fmRPP7PPIfPEVoMx+bE1umqYcFhGCICEGKsCGqDxHdwoE4taqnWI/vdrHQs26GRxeqmGhhuqAsC7IDoAqttKsXJTc9BkylBAgdxw4B444zpU4tCXAhx0iqy9aGye40KxYVtx/+5TDhlxKkREtIzpE1FASN7iB98tSL7VEc2FSXGgSTHdVuD6Nbt+/TlC1HmDGmoTPECVPz3X9UOUzr3v+xNm6XrU4DGqd2GeSPE+sMtHFhwQCNdHHU2ts9QPR966ZO9SdU8oCgekEnpK9Mu2WtPsQ05EaP7dxLx/MEh76lWK09aO9uHStfualblbZljhi7Z4aLQKfOwSfZa/vz5C63bFiRY4upWLyNCsZCTkyhRAk2/GcYOCBxJJJy36j5CJN+DdQ2ED6hxNWTcHNq6eIzqaYPDumvFBHEopAholju6j6VtGvTotZ5lHV4pY5PF6qYaYG6oCwLsgOgCq20qrdG8D9WrUUYwa0GwsUfCKGJVA8f01gyKbH04tdu3yp9SpkhKddp4Ua3KJUXcM35cps5fS6fPXdVUtEn2qY5sKsp9h8+Qi5cvlS6Wn37O+QNduHKLHj15IX5Ec2XPQmMHOau6vZD9o2Rr+pSFjyKYhfP/TA1rOoqCfGBdQ+G/pl2HmnUDIluf5i9oDD4gk9JXptnGydgyN9A4vUYORG/nRsJcbFI7Na9FW/cco3n+npqHAIfBlAStVU+9LjvfT/Zhk6mxmvO5TNYl4/w8hLG6DZwoyF/AyHju0k2R8A7GQbVSu7UXtWtaw0Aeg+dwSw2iGYTeqRXZ72a1/XI720SAHRDbnHddRv2nk7Pg6s+aJYNBP5IBqzdzN+vUTrY+XNvOHO8hXvII40C1ciT7QbB5KF3bVVN4g+xTHdlUlDhFRSHHquWKiTEiobX3kACa6+dJrv39KG/uHCYTHfGc7B8lW9OnfBmwiQbrXMmi+cSf9hw6Td9nTCvmp0vrOpq/k7L1lanjGqkN08f0pr87DY52RXTNg4zgAUuj9IWJsjfQYR0GJI5n/yETDejRgsxJKkZORD2nspQ/z1dKc8jUeWvFwUS5EoXEv/PkyipjeszSIfuwSfZals26hPEunz7EUJMKBxIHj5+jy9dvi3koXlj9DTUAP3rqIoHlEbl4P2ROR4+fvqS9h05R55a1qW3jrweCakT2u1lNn+a0QZjanKWbxQ0/iBmMZdroXuao5GdiAQF2QGIB9LjaJSrDFi2YW1xRK4JrYMS5rjejkrJsfd7j59IXIhrg1oLwAwAKXzCZQMBohUJfmxZEnfgXdu5knorJpqJEgilONZXcFtiKAl2ILUasL8LltiwabXI5yv5RsjV9CsCoHWAs9vbYVGbUvNnQSx/WRGSCpPnT567Rn0XymlwvejeQSekry1bZG2hZdil6ilbrSDuWjafkSZMYVOOGBRXqzUlqN7avUech4kYV71WteXSKHtmHTbLXsjWwLiFBftPOw3T3wRNRTBSUwVqYwzAXst/Nstexog83gp8+fRI1qcLWKarvVFavblmvZATYAZEMqC2rAzsIKG4LGFXFfvj4Gb14+Zp++vErNzmqtaoV2fpQ2blV9+GUNnVK+vDxI+XImkkkFIL+cdm63dSz098ihEytyD4Vk01F2cTZW1QRVm5ANu44TKDdhNPx/MVrwo3Q6R2mcw9k/yjZmj6168lS2iEk8enzl4KhJzoEEpYynpiwQ/YGOjKb+4+aGY41Sc34wDKFoq6/GVXtxmk7kpdxExwdwY1Ul1a16dDx8+Q31JW+S5JIszrZh02KAbLWst6sS6CIxy3GsdOXaFifdprxi+gBFE5cv+0gtfq7qmp9st/NqjvW2BAONW6QUIeFxXoRYAfEeufO4ixfvn6PSZu0nE7I1gfjcAuAYlSIj0XhJkiWTOmoTtVSVL5UYZP2GzeQfSomm4oSp4Adeo+hrJnTk729vcgBGe7ZXpwa3X/0lAIXbBCJj6ZE9o+SrelT8EWYBdYeSAGAP2hVGzg5GhxEU/MQ9nPZ+lDEDLH967cFiZoT8R3syalSCerTtYlg7GKJHAHZG+gjJy8S8kDuPXhMn4wKByKkVWGy0sKchpoisxZvouYNqggiCoSwLFy1Q7AmRXfDq4TErdiwl5au3UWTR7hRmlTJNS0X2YdNsteybNalf+88pGOnL9IROB2nLtKLV29EeBwcRDDlqREcIiGf0VgQjrQr6BSt3ryPgo6epd9/y00zxrmrUSfayH43q+5YY0PcgCC0DLc8LNaLADsg1jt3bHksI6D3qZiM4WGjsffQafEDh7hic+K8Zf8o2Zo+ZR5nL91M81dso9Z/VxOscDj1xKawY/Oa1LBWOc3TLVsfElZBUNC9QwPKlD6NcJImTF9Gyb5LEu1NqubBWdkDsjfQoNtFKGupovnIzv5b4cAWLj409/9J6FrDa0Dnu3LTXrpz7zGlTJ5UbN5AA21u2JQyRcY5OTv3nyC/GStpok83TexQsg+bZK9l2axLSEJPnCgBNatXWRxAIK8HIZlaBMxXFUoXpoY1y1GSxImE07FhxyFKlSIZ/VWlJNWsXJIypU+tRaXVOCDjpi6lA0fPUtvGNcKND0U7WawDAXZArGOe2EoJCMimuZV9KiZhiOFUyGDmMa68LcNGW9OnYFa1iTuNG+RMv/6c3QAjbqlAGWqq6FhEuMvWh8TnTfNHifhxReC4orK1FoYkGWvE2nTI3kBjU39gzcRw4UxaCwfiVkJLWKla3LHBV2Tt1iCqVbmE4d+4aQVBx56VvibV6WWfXmtZVkjXv3ce0M79J2nH/hMUHPKOyhT/TZAB5MuTg+LFU1c36+79xwR66tVbDhD+H/k9Q9zbUKUyRUziHlkD2e9msw0x8WCzrsMibTF/Yj+9umW9khFgB0QyoKzOchGQTXMr+1RMNnKymXn+OX+NEFeshKrhxxi5NMaisIqpGQvwK1XsNyr9R/5wzQ+dOC/COLQy/sioe6LGdnPa/F6lAx1YOzFU0iRuHBB6d2zzNM0qZesDLfAc3770Q+b0BlvAnNaq2wjasWycZvv4AfMRWLxmJ1UuW5RSp0wWSsmMRRstgtVo0qxVBrumzFsrKILDihpmN9m3oYoNstey7JAuY6zgrOH2ImDOGkqcKCHtXeWnaeEgFBP5N7jd2nXgpAi7qv3/kGIt72NNnXJjRkACAuyASACRVVgHArJpbpVRYyP+/OVrUVFd7elVTCAmm5kHCavYFDWvX1mYjyryCD0xlnO7Z6seGsIQsMGaPKJHqAq+UICikXuCTgnaZLUiq+6J0l+9dgNoReCQCLtv23MUzRirPrYaSho7e1P7pk5UvuRX2lMIWGvmLd9KCyf3VztMQzvZ+gLmrqEtu46KDS4KiD549IwCF26gKuWKUucWf2m2z5YeWLJmZ6TDrVimCK3cuFfMvVqRpU+vDb7xOPAOQEFNc0Qv+2SvZdkhXcAKOYg79h0XtyC3bj8QIXEVShUmxxIFzYFSPIOaIhu2HxQV2nF4UK38HzSwR0vN+mS/+zQbYOIB1BaLTLQeWsm2jfWpR4AdEPVYcUsrR0A2zS3Cm0ZNXiyuwRHeBTrABjUdqUeHBtGOq5YBtWxmHlD4Lg4YIKhjIajmjdoQS6cNojdvggn4anVA/Id1E1V/Z433EKxkiuAHuUkXbxGGolZk1T1R+kMYx/YlYyPsHuFPs337Euhp1QpukHDaabzBQMw8qKDz//KtPkNs6YMjvXz9bkJIzYPHzyhD2lQitKa+kyOzYZmYlM59xkfaoq9LE/IcHkhaQkNk6dNrg692jZpqp5d9stey7JCuum37CwehXo2y4lAHbIyyGefAcrZiwx7q69LU1DSE+1z2u0+zASYewGFiWMEtFcgyosvqJttW1hc5AuyA8OqwGQRk09yiyvu1W3docK/W4nR7rm9f8vFbQFmzpCf3Lo1jHVfZzDxwQFbN8BbsTRCcQrn086PNC0eJkzc4PFodkKObpgjWltGTF1PgmN6UK0cWoRsJ0LVaetKRjVNU4yir7onSIW5oohI4nMe3aAudAk315t1H6MHDZwLHmpX+pMwZ06oeY9iGMvTpFYdv9qD4QWkI6LXBl2WgbPv0WsuyQ7qmzltHR09fpItX/hVUssj9AAsW/qsc8KjB2MdvPnm6NlPTVFMbPd59mgwwozHqeBX4NadZhB5mdMePSECAHRAJILIK60BANs0tmGpwco+Yefw/TstxCvNXq34WETMvm5mni+cESp70OxrUqxU52NvTkPFz6NmLV+Tn7RotBwQMLrhFGjlpEXVsVpN+zZ2dlqzZRW+Dg2nKyJ6qF5esuidKhyVqdqEN80dE2T8YZ9TK/iNnqPsAf5H3Ahas/+49pIPHztOUkT3o999+VqvG0E6WPtmbQM0DicMPIM/JnBNoQPLx0yfCrRlC4TKkSyUoWvG90yKWPrey7ZOtT8FadkiXohdzfOHyLeGMoAbIyTNX6OD6yaqnWK/xyn73qR5QNBriu+IxbCptWjAqGlr40ZhEgB2QmESb+4pTCIAGcf+aiZQkccJQDkj1Zh6aEwn1AEY2Mw+YVrr286WrN++IuiLIeZk2qpe4tYjODQgcEAgKcU2YvpwQOgC6YJ++7UIlRJvCSFbdE6WfvzsOpiVTB5rqVvXn9dsPpA7NalLlst9YajbvOkKzl2yixVO09yNLn16bGNXAxIGGCMmLSBBmkzd3durRoSEV//1X1SPFzZZz3wn0NjhEOB9wQlDgb/JwN00n5JY+t7Ltk61PmTBZIV2mbmjQj5ZQLL3GK/vdp3rhR6Ph1Rt3CLl5atjXotENPyoRAXZAJILJqmwLgb9a9yPv3m3EySRuV1CwbdHqnfTzj9/rci1uCeh++vSZwDT18tUbQScL5wuCv8MBwBW4WkFl9sqORTSf6kalX0bdE7X2a20XEWvVm7chVLauqzQWLHP06bWJ0YqPNbdH4cCIpKPHWOrfvblI5tdCtdzabQT9+XteatfESWxIwXQEBiwUl9NCzGDpcyvbPtn6ZK9J2fbJ1id7vDGpz5zK7zFpH/cVHgF2QHhVMAJmIoCwIYRE1Kxcglq4+ggKxVLF8lOjv8pT/PgOZmq17Mdk1BXRa4TYpOEEUWtBr6jsQUgdbmSQbK5UHYazZU4fuBkb3b+zOBFX5MSZyzRg9CxaP3e4Zlhk6eNNjGboVT+AvKRDGwLo98od6PSOGaqfK1qtI+1d5S+K1SkSHPKeytRxJeRNqZV7D59qLkanVreMdrLt02stL1i5PdLhNq1bUTUUsu2TrU8ZCG60cbikNeRPNRCSGoar/F4gt2Z2QkmmsBozEGAHxAzQ+BFGwBYRkF1XBDcgkVWt3XngZCi6WjV4o84LCuf5D3UN1xzOIj5r1bCqGlWijRLSBYYzOzs7ChjRg/YcPEWzlmyinNmykN9QF8qaJYNqfbABm0hUn1YE1cxTJPuO6lQrrVqP0lCWPr02MZoHFAcf6O09hbzd24jQQtyQqhUQMPR3a0FFC+YxPIIQRe/xc2ntHB+1agztwLoEOmDnluHplBet3iHosKs4FtOsV+YDCE8Ca9OtOw/EjU/mDGlFgb5Wf1cTRfbUiF5r2aVf+KKK+4+epSK/5abpY3qpMU20kW2fbH3KQJCEXqJIPgoY6RbOCRkzZQmhvohLm7qqxy274blLN79Wft9+iNKDra9KCXKqWILSp00puyvWpyMC7IDoCC6rjtsIyDoVsxaUZNcVAdVjZBW2kdSPZML4DuqTbis36kXeHm3pj0K/hIP0zIXr5DVqBq2ZFXkF3bAP4VYL1YlbN6pGqFzsNnCSYOcaO9BZJI4ePH6Opo1Wv/mAfiSdnr14gx48eio2WHlz59AU8x3WRhn69NrEWMu6lmGn7ByQHftOkOeI6YKiNVP61GLdbd1zjIZ5tKMKpQtrNhkbSrAttWlUneo7lQ31PGrRzFy8iZZNG6RZr6wHZi7eSLOXbKZ2TWrQzzl/EPlg5y7doBTJktLxM5dpwUQvkQtjSmJyLYPJCiQcWhxL2fbJ1mfsgIAuPHXK5MKBNhYcRA0eO1tTSKGpedP6OdYzvhfDPTuEctK16uH2sYsAOyCxiz/3bsUIRHQqduTURfrlp2w0e0IfKx5ZxKbLriuCJP7Gtb/dBhj3ikrQqEExsGfUVLjGzxSq3J62LR5DaVOnEH9GOFb+8q3pnx0zCRXHQaV5Yut01fNSuraLIBNQikv28ZlGhfLmor//Ki9OaB3rddeU8IhwE+c+4yjk3QexoUyXOgWlSJ6UJvl0N+vkTpY+vTYxqoGOAw1l54AAkms379D67Yfo4eNn4pTXqWJxypn9K021VsGGbe3sYdS+9xjq07VpKCIEJLg7tehDRzdN1apWWnt8N5FgD/IJCDb2YLXDIcTogMX07Pkr8unb3mR/MbmWQUPexm0k7Vvtb9IupYFs+3oMmkTjBnVR3b/ahlgv+9f4k6uXH+XL8yN5GNHKI8+u0t89Nb1L1fartt2+w/8I5sQDR89SiSJ5qWalElS6eAFNB1Zq++J2+iHADoh+2LJmG0RgwcptdPXmXbOqz1o6XLLrisBhqFe9TJTD9ureXDUsTi36kmvbeobNFTYIDdoPpGXTB5NdvHjU3MWHgtZNUq2vYsMetHbOcBEL/eLlG6rQ0I3mT/QSmyQ4NCAh2Lks8gJ0YTvCZgEc/7BRoW2eNn8dnbl4I8KwMVOGytInOw7flN229LnWHBA96zogd+T2vcdi09zbuRH9VaWkmArkOLXtoW0jLXsOUVhu1/IJBlILkCmUqu1CJ7dOp5v/3afmLsNUbfRjci3fvveIfAOXi7wutSLbATHu9937D/ToyXP6/Pmz4c8d3cfS1FFfqcy1hIvCAcF6Qb5bq+4jxKEa3sWofQT6bxSP3bp4jNph69YO7+X12w8KZ+Tug8dUrdwfInSRxToQYAfEOuaJrbQSBEC72biztzg9imsiu65IVCFY5mC3evN+GjphLtWuWlpUxN244xB1bF6LEN4BBwQnecM9TZ+iKn2jhsOde4+pavlitGbzAUqcOAHd/O+BiEs/fe4q5c6ZVfwoqxXcqCB+H7VDFAcEIVSOdbubtV5k6+s+IPKq8xOGdFU7TG5nhMCFK7coR9ZMqnNA9NqgKhtKUF7Dpk4e4wSLXd6fs9PWPUdFHRott42yJxnOdIZ0qUVeAQge/AJX0ImzV2jR5P709PkrcqzXTdxkqhU9cl7gcCBc7f7Dp6J4qFPFP1WFhRnbrNf8zl22hcZNXUrx7OzI3i6eoUvknClEBsc2qy+aarxekJDuNnAiXbz6L+XMlpmQf+HWoQE1q1dJ7XTESLtL1/6jlRv3ml13J0aM5E5CIcAOCC8IRsBMBMDRbyx42S9bt5uWr99N25eOM1Or5T4mu67Ilt1HqYpjUakDxtU8ktvfvX9PVcv9IW5DELOMvAuwk6GWglrBfI6atJCQbPrrT9lECAgczHnLt4pCgohXT5Agvlp1VLRaJxEiBjYtxQG5dfsBtes1Wvxdq8jWh01MWFmydhcVK/RLnLzR04p3TLTXa4NqvKHEOLCpx3zjlhA3eqhPg8Ti2BJQqGKTe+LMFRHymCFtKgoY2UNQmiMc6/CJC1S1nPokedk5L7Cra78JVKlMEcJ7q0KpwrTrwEmaPMKNCubNpRo2vW5oijs5Ew4JihcOXWsGN3BaHA9lIMj3Wz59iMF5Qcgpct6UGk1h+1ENgMSGMvLfJJrDqsxAgB0QM0DjRxgBIIAfubCSMV1qGtCjJZX9swCDxAiEQgAhYB2aOVHpP34TdKrYzGzfd5y6tqlDDZwcNaMlW19EBuw5eJrmr9imielH80D4AQMCejkg2OCnSZXckM9kqZDfuf+YXrx8TbmyZ9Hk3Icdj+ycF4SA4cQfTGHK4UHQsbPkN2MlLQ4YoBlO3P6aksgIOiJ6rlj1TrRtyVjBqGcs5jogpmyL7c9l5b/F9jhsvX92QGx9BfD4zUYAV9PGEt/BIRRvv9mKbehBXOfvOXSanr94RVkypaOqjsU0hzUYwyVbn7FuJDwi/hkV4MFOhHwOLXL6/DUKDnknTilBy4owMdSNURJvtehCW9n6Iuof7F8IZzHnFFXreLi9fJpWY0xRM+Hk2at08/Z9sQ5RtyjHDxmpYL6fYj15F44HmOEK5/853DIAmUS8eKTJeVJufGTlvOC2cc9K5KgkMjgguBUoUbMLHVw/WfPSRThTWEEIFahvi//+9RZDy3sBYXVgOYN9xnLq3FVNNzSh1svHT3Tk5AXCLa2gRc6YhooWyCPeW7EtsvLfYnsctt4/OyC2vgJ4/NIR6D9qZjjqQumdxAGFc5ZtoYkzV1L5koUpbZoUIrzp0PHz5DfUNVwogZrhytbn4uVHni5NKVOGNLRkzU4C/z02CB8+fqRjpy+ZbaeascRGm7AhWO8/fKSd+09QwoTxadb4uMfqFhsYm+pTrxsQ0FC79vejkJD3lD1rJlHbAU4IvnNJkyQWa9m4QKYpO2V/3tXTl7JmSU/uRmxLSh+olXPp6n+a8rdk57yU+stF0BTjXaDcgOwKOkkTZ66iFYFDpMBx8uwVGuG/kJZMHahZH95PpgTsfWoFTkf7XqPpbfA7kcMEJjYQAyC0tWubutSyQRW1qnRpJzv/TRcjWalJBNgBMQkRN2AEIkYA1Jv+M1fSvQeP6ZMR88jDx88NtKpgdmGJGAGEIXm7tw0VrrZuaxDNWLSRVs8aqhk22foKVGgraHaRswGaUNRg+LNIXmHXvsNnaML0ZZo2H7DPlID2V63I1tdzcOiTXMTiI+574aT+4nSVRX8E9HJA6rUbIHIokLek0EpjNLhdmLFog8hrWD59sP4DjKSHsnW7UcAIN5EYrwjer8UK5aFrt+5SZ49xmliXZOe8dOvvT6iLgYKhCJ9KmyoF4QZ8/OAuVCjfT1Jwu3rjDjV2HmIWHXLnPqbZ+ICvWgFTGuqx9OzYkOLHdxBFWQPmrKHenRuRc9/xgtxDYVFTq1NmO9n5bzJtY13qEWAHRD1W3JIRCIUATsLqVi9DpYrmIzt7O8NnLVx8aK6/p/h3vtw5GLVIEChXvzsFjukdqrYBkmPBMX98i3rGFkW9bH1IxBzWp50IYUDNksMbAsSPMQSUlyVrddEUmoQfcVOiZb3I1heRbUvX7RZhGGMGqKcaNTVG/jxyBPSq6wBnGsx8ySKoKI6NdJnaLnRq+4xYmxrkKqDmR7o0XytZI1ysYKV2goY3+N17goNyalugavtk5bzgO4bvJN5LISHvBPsViC6Qa5E7V1azE/dHT14caiwYI/SC7MLX20X1OPVqWLRaR9q7yt8QUoz3HW4djmycIuz0DVwRqw5rTOS/6YUt6/2GADsgvBoYATMRwA/kgTUTwzErxdXEPzNhivSxgLlr6OPHT4J6UxHkNYwJWELz/u/AaelTtj7Q9yIJG4UCQVs6uHdrQUMJWbZ+N63YsFdVAira1asRdb0TLeOUrS+qvhGiU7u1l1kOoZYxcdvQCKAS+i8/ZRUb3rDy/MVrSpgwgaZ8s2pN3UXoTI0KxcPpw63j5DlraNOCkbE2Dc26DqMSRfORc8u/hA0Ibxo0ZjYN9WgrnP5+wwNpx7KYZxbU60YKFN/GgjH+mDWToPbVwqxnrENmHZDqzTxEgUMlDwU5JmDrw+8dChHi8A3OYUzLh4+fRL5STOS/xfTYbLE/dkBscdZ5zNFCQDkVQ7VuJCOnTpkslD6EELVtXD1afdjCw79X6SBuEhIl/Eb/+fHTZ/ry+QvFj28vINCS/CxbH8JTvMfPoW17j1OK5N9RyuRJRTw0QkKu3rhNU0f1osL5TYdfyN7EyNZn7PwZr7v37z+IWipHTl2kDfNG2MKStJgxIoTo+0zpaFHAgHDvF2xeHz15QeMGOau2d+eBk9R7SADlzJ6Zsn+fkRIlSkDv3n2gG//do+u37tLYgV1ilbnvn/PXRJV21AJJmiSRKD6IAnrdBvjT02cvqXPL2tSxeU3V4wUVd/UKf0TYHliUL1lIlS69vmuqOtfQSHYdEDilyHmrVbmkqMuCGkt1q5cWRVRxKNG1ny+tmTVMg4VymlrLfMgZbdzXwg5I3J9jHqFkBPglKAdQMCyZEi3Ve2XrU2y7/u892n/4HwJTDwQbQzieGdKlMmW++Fz2epGtTxkEQtiMxcHBQWxWu7evH6sJyqpAjmON4IB0aVVb3MDNmuARit0IDEqIw9+5zHTcvzEsqJK9K+gU3bp9XySjwwnJ8UMmkduQNnWKWEcQYVMI7wlByFXxAuL2B6FPd+49onx5cmhiwYqqyClO7xHuhZN0U6LXdw3vlMgkU/o0dPn6f1Tg15ymzDN8LrsOCBQfPHaO1m0Lohev3gi2vsa1K6i2R6+Ges2HXvay3qgRYAeEVwgjoBEBfglqBMzKm3/69JlevwkWtyDmiOz1IlufOWPiZ/RFQEmiBl3zhSv/0pSRPQyhngiBQZ7UiVgIgdF31PK0I2crsg0zbq5rVS6hqvK7Xt81hOlGJvMnehFIA87tnq0aEL3qgET33ad6ACob6jUfKrvnZpIRYAdEMqCsLu4jwC/BuD/HGCGKXSEEC7U/8EOMKupgwenevoGm+HvZ60W2PuPZ5OrClrG2FS5xZwYAABq2SURBVAcEtTpA633u0g3y9mhLv+TKRnOWbSaEGMUma5VslBDut3DVDtpz6BQ9e/5a3DLiu1ahdGGzuipUuT3Vqx513pVX9+Ymdev5XYuqc3wPQZVsSpR8MNl1QGS9+0zZr/Xz2JoPrXZye3UIsAOiDiduxQgYEOCXoG0shpbdhovQlG7t6lHa1ClF7POIiQsoW5aMNKhXK9UgyF4vsvUpA+HqwqqnVPeGxjSyKAI3dd46mjZ/nciZSpI4IfkP7WYoWKe7MTHQgdfIGfTPhevUon5lwYSF7xpIIFo1rEotzKg5EVUIlpbh6PVdgw3BIe/p7MXr9PzlV4crd86sZGcXT4t50sM7lc5lvfs0DUZFYz3nQ0X33EQyAuyASAaU1cV9BPglGPfnGCME1zyKjxlXPEeBrsadh1DQukmqQZC9XmTrUwbC1YVVT6nuDQePnU19XZqGYkR69fqt2Jj/kDl9hHS6uhulYwd/1OhMsyf0oV9+ymbo5cSZy9R7yBSz2K9Q16SKY9FoWyzzuzZ2ylIqUiC3SPZHwdWeQyaLavQgMUF+GXI//LxdImQ+i2wgMu0z7kPWuy/aExBGgV7jlW0n61OHADsg6nDiVoyAAQF+CdrGYmjtNoLaNKpOpf/4zTDgB4+eUcOOg0SBQrUie73I1qeMg6sLq51RbicbgVqt+tEwj7aU/5cfDaqRgF6lcW86ummK7O5U69sddEok6cuQP52cabZvX8qd8wcCzS2qiSvVyRFyNX7aMrp2867I91Erer0LZL371I5DbTu9xqu2f24nFwF2QOTiydpsAAF+CdrAJBOR5/DpdP7yrVAVf6/evENgIQJfP6R1o2omwUBoU6b0qeny9dv0+OlzKlEkn3jmxJkrIpxG4do3qej/DRR9aturbcfVhdUiFTPtrty4TVt3H6Wbt+9TcPB7Spz4K2sVGNhy5cgSM0bEUC8obAc64PbNnAw9nrlwXdBAe3RtIv6mpUin7JwS9A/6bdDTgkXsyxeizBnSUJniBVSHwoEmHMxlILPAjc/6ucMNhReh/8XLN1ShoZsm6nG9fotkvftkLx+EImqhY5bdP+uTiwA7IHLxZG02gIDMUzEbgMtqh+gxdKpJ20d6dTTZRmnQqvsIql6hODWs6UjTF6wXxd++S5yIOresRU3rVlKtR2lYpo6ryWf2rvIz2UZpwNWFVUOle8NVm/bR0AnzqESRvPRjtszk4GBPwcHvhDNy+MQFGtizpajREFckLAV0ROPatXyC6uHKzinZd/gMuXj5Uuli+ennnD8Qkr5RiwVhcbmyZ6Gxg5xNVkVv1GkwNW9QRRSDdBs4kao4FqOq5YoZxoTwThT727Z4jOpx6uWAyH73qR6QyoZdPX2pTeNqVDj/z6GeQOjiwJ7q8/NUdsfNdEKAHRCdgGW1cR+BqE6iHz5+TunTpoz7IPAIVSMArn5Um06VIpkILRnUsxVlTJ+aOrqPpa0aNh1KhyiIaUq0nBpzdWFTaMbc5xUa9KDBvVuL+gthBbUyBo+bQ9uXjI05g6ysJ9k5JQgRQ5V2xWFALg4KO8718yTX/n6UN3cOcmlTN0qUcOPZrb8fZcmUjnCFcvfBE/GcIg8fPxNVxnevUO9oyXZAlCK7lj7d+cq1FoVhm9arSB2b1TIk74PeWEvxWksfZ1y3jx2QuD7DPD7dEIiKaaVaU3dR7IqFEVAQQAz43tX+9OLla6rUqBcd2RBAn798oZK1ukTrRxMV258+f0mpUybXzKITdnZQBO7sxRv07MUrs5l5eMajj0DBim1pzyo/SpEsfO0ZhOqUrdeNTm0LjH5HcVSD7JwSbGyD1k4ykAIgxAsHCqjFgk17z0GTacui0SbRfBv8jk6fu0oPHj+jjx8/Rdi+vlNZk3qUBrIdENn6VA9EY8OCldrRpvkjqbf3FIof355G9uskDvzYAdEIZCw3ZwcklieAu7deBFD8aZRXpwgH0MdnGnm6No1TYRLWO1OWYXm3/v6C1vfZi9f04tVrmjHWnQ6dOE8jJy6kVTOHajYSxRFHTFxI67cF0YePn0RlZ6dKJahP1yaU9LvEmvUdPnlBbKQSJHAQdt69/0Tc0Ph6u1CWjGk16+MHzEegWddhIiEbp+7JkiYxKELIz8RZq+j85Zs0z7+f+R3E8Sdl55Q0cfYWdMDKDQjqsPgGLhdOx/MXr6ls3W50eseMGEdVdj6YNTkgcMBRnwnfhxUb9pC3e1vqOXhStA5zYnwCbbxDdkBsfAHw8M1HIH/51pQja+YoFaydPcz8DvjJOIUAwivAdPPy9Rvq0aGhoPfduf8ExY/vEIppS+2gkSiKDWn3Dg0Ehef9R09pwvRllOy7JDSsTzu1agztajTvQ/VqlBHMXxAw84A6FMnQgWN6a9bHD5iPwPV/71HPQZMIpAdpUqUQhS9xO/X46QtRL2LsQGfK9n0G8zuI40/KzinBLUeH3mMoa+b0ZG9vL3JAhnu2F3kc+N4FLthAagobKrAvWLnd5Aw0rVvRZBvjBihKiI34rTsPCLVjMmdIS2WK/0at/q5GyY2c2KiUWpsDoowFBzl9hk2jR0+ea6ogrwlgbiwdAXZApEPKCm0FAVnFrmwFLx6nXASw/jbNHyVYdRR58eoNIfwP4SJaBSFiS6YOpKxZvm1skctUvZk7nypqBVNS+5v/3SckJ4e8e0eJEiakHFkzhpofSd2wGhUI4ABh76HThO9Y8cK/amavM+7CpV94Gu8jpy4Kpi8w40H8h3VTYdXXJijaOHvJZmrXpIZIkj966iKdu3SDUiRLSsfPXKYFE70oQ7pUJvVZiwOCm1/c9BoLaJvhgLVv+o1JzeSAuUGsIsAOSKzCz51bMwIRvQSteTxsu74IdB8w0WQHE4Z0NdlGaVC+gRvN8e0rCtMpguTYVt1GmFW8ra/PdCpaMDfVrV7GoA8n8a5efoIylCXmEUCuAZKVg0PeiaJ1oH5NkCB+zBti4z3iRgG5Vvb2drohsWDlNuFsero209wH3gWTh7sZnCLkcCFsDHmIowMW07Pnr8inb3uTeq3FAZFFaW4SEG6gKwLsgOgKLytnBBgBRuArAnOXbQkHxeI1O6lk0XwGJwJx5molYO4a2rLrKLVtXF3kaqBIYuDCDVSlXFHq3OIvtWoM7Zp2GUo3/r1HBfLmMvwNzDxImv/pxx/E3wJGuGnWyw9oRwCn7cN859HOAyfpw4ePBgUI16tQqrAI9wGbGkvMIABaX9x8+A8NT30NymR81qph1WgZg8MDOA37Vvtr1gPWL9AUK7cnb96GUKnaLnRy63TCLVpzl2Gq9FqLAyKb0lwz4PyAFATYAZECIyuxRQRevn4rXvgO9va2OHweswQEduw7QSs37aVJPt01a8OJ7PL1u2nt1iDBqpMhbSqqVbkE1XdyNIsNa/n6PSZt0MLQY1IZN4gUgc59xlOC+A7UueVf9GPWTOTg4CBuQbCZnDp/LX3+9IUm+qgP0WGoo4dA5Ua9yNujLf1R6JdwilAw0WvUDFozS32+39vgkFB6gkPe07J1u8X3efvScZqN7TFoEmVIl1pQAeOWxi9wBZ04e4UWTe5PCE1yrNeN/tkx06Rea3FAZFOamwSGG+iCADsgusDKSm0BgbyOrURV64CRbuGckDFTlojCVKa44W0BJx5j5AjcvveI6rbtT0c2TmGYGAEDAoUqtxd1PtKkSh4OFSSiY0MMCliWmEEA84ECgWCHg8D5BwkJNvUggkAIlJb5wG9HWMmYLjUN6NGSyv5ZQPOgsCZQ3BC1RuLFiycOIwJG9qCff/xeUGqjeKVx0cPIOrCWIrt6UZprBp4fiBYC7IBECz5+2JYRwI+IY4mCov6Ct3ubUFCA0hRVWTfOH2nLEPHYjRDAj7uxgNVo/baD9PDJM1o6dZBmrKJi0tHKoIPOl6zZGakNFcsUoZUb93KCp+ZZMu+BUn+50PQxveiXn7KFU3Dm4g1y7jNOVUiNeb3zU2ERcGrRl1zb1qPKZYuIj8AM16D9QFo2fTDZxYtHzV18KGideuIH3J4bS3wHB8F0Fl25c/+xCJlEdfbo5ArJfrdEd1xhn5dNaS7bPtanDgF2QNThxK0YgXAIwAHZv8ZfJOnmy/MjeXRpbGiDGO5Kf/fUdCrGEMdtBHDTEXbTkSNbJnJuWZuyZvmWSK4WhciYdLBpnT2hj1o1hnYI+4lM+ro0Ic/hgTR/Itee0AysGQ8gv2fhyu1Uq0pJQdecOGFCQcN74797tGbzAWrRoDJ1aFbTDM38iDkIrN68n4ZOmEu1q5YWNXY27jhEHZvXEuxTcEDw/gctb2wJHI8Hj55S4fw/hzMBtzXx4pG4GVErEb1b9h89S0V+yy0c49gW2ZTmsT0eW+2fHRBbnXked7QRgANydNMUUQwJSXHY+CE5NFHCBLT/yBkaMm4ObV08Jtr9sAJGQC0CYNK5evMuDezRUu0j3M5CEdi+7zht2X3kKw1vyHtKlCgB5fghE1UpV4zKlyxkoVbHXbP2Hf6HUIDw3fv3VLXcH+I2BDfdZy/eoEZ/lafvkiSKtcF39fQVhxjuRodgijGzl26mS1f/i7aDNHXeOhHOFZb+NtYGTSR+e58+fymiEPRkKIvNMcblvtkBicuzy2PTFQHFAUmSOBHhSh0xuBev/ks5s2Wmc5dukluHBtSsXiVdbWDl1oUAivv9c/6aYKwCL/9vv+aUSmIAJp3Gnb3FzZw5gnV8++5DUVndWAr8mtMcdfwMI8AIxAACqMQOhrpff85u6O3IyYtUrFAeunbrLnX2GBftwzCEnbVxG2kRoX+v3wSTj998cROFd1V8B3uqW6MsuTs3EgeALNaBADsg1jFPbKUFIoDK0cunDzHE7oIr/uDxcwSO8jy5sopiVSyMgIIAKG6d+04gMODA+YATglNT8PcjzEaryGbSWbZ+Nw3znU+JEyYQp+3GAopPFkbAlhHAodKeQ6fp+YtXlCVTOqrqWExVcb+YwKxI1Q6i5ke6NClFd6BuLlipnaDhDX73nuCgnNoWqMkU6ACDVvq0KUX4FggzfAOX0+j+nTXp0aPx4HFz6PbdR+TepRFlyZiW/rv7iEZNWkS5cmShvi5N9eiSdeqAADsgOoDKKuM2Amcv3RAVa1kYAS0ItHYbQX/+npfaNXESNLlwWGcs2khBR8/SzPEeWlSJtrKZdJD43MelCTlV/FOzLfwAIxCXEZizbAtNnLmSypcsTGnTpCDcNB46fp78hrpaxEFTs67DqETRfOTc8mv9n11BJ2nQmNk01KMtoXZMv+GBmoqTbtt7TOR84ZADNNCBY93p9Zu3dOjEBTKH4EL22oBDBeIO4+ru9x4+pcadh9DuFXxYIhtvvfSxA6IXsqw3ziJgLVzpcXYCrHRgRat1pL2r/EOx3YD/v0wdV5FLpFVkM+mUq99dbDQQQsjCCDAC3xDAd9TbvW0oitx1W4PEAcLqWUNjHSqEdbbvPUbUAkmaJNHXejGjelK3Af709NlL6tyyNnVsrp60ABv87u3ri1wXFMRE4n2TOhWoZbfhouBhbAsKL25bMpaSJ01iMOXRk+dUq6UnHVw/ObbN4/5VIsAOiEqguBkjoCDADgivBXMQwI9jf7cWVLRgHsPjR09dJO/xc2ntHB9zVIpnkIiJmOgUyb8zWwcenDRrFX36/FnQjbIwAozANwSEcz6mN+XMnsXwR4Qngenw+JZpFgEVaoEgUR5saWWLF6DMGdOKEKo79x5Rvjw5NLFgYYO/Yd4IUffk3oMn1LWfLy2Y5EXFa3SmU9tnxPp4u3hOELfJxjmW0xesp9PnrnGBzlifHfUGsAOiHituyQgIBNgB4YVgDgKoeu45YjpVLluUMqVPTfcfPaWte47RMI92VKF0YVUqt+w+KjYW+fPkoLv3H9OQ8XPowNGzojAa8knqVCtN3ds3MKumQJXGven+w6f0feZ04WzBZoSFEbBVBECL/PHjp1CFZU+fv0ZjApbQPH/POAdLH59pgtK3YU1HESqKQosLJnpR065DLeIGBGxcr14Hh6Iv//fOQ0qWNDGlSpEszs1HXB0QOyBxdWZ5XLohwA6IbtDGecXXbt6h9dsP0cPHzyh92lTkVLF4qFNVUwA41utO4wY5i81BC1cfypolA3VqUUvQUP5754FIxPwxW2ZBB61VDh47F+kjfxbJq1Udt2cE4gwCv1fpQO/ef6BECeMbxvTx02f68vkLxY9vL/52bHPs3YS8f/+BFq7aQXsOnaJnz1/T95nSicMItQcbYScKoVbnL9+ikkXziY+QfP99xrSimnqX1nVifV7hFK3dGkRrtxygB4+ficrvqJlTq3IJTTc9sT4QGzeAHRAbXwA8fO0IsAOiHTN+Qg4CBSu2pT0r/US4FXJKNswbKVhqFEG4RL32AyhorfqqzHIsYy2MQNxFAM69KcFhQGyJ18gZ9M+F69SifmXBhIUkeRRJbNWwKrVoUEWzWWEroaPGBpj6LIXZEeFWKzfupZYNq1Km9Gno/sMnBKIAOF3tmzppHi8/EDsIsAMSO7hzr1aMADsgVjx5sWh69wETI+19wpCuqiyr1tSDRvTrQKjL0cTZm3p2+pt+/+1b9WNUCK7VypMOrIm8r8g6CrvpMG5nCcw3qgDiRoyADSKAnI3ZE/qIYriKnDhzmXoPmaKJ/cpaoKvQoAfNGOceir4ciffteo6i7UvHWcswbN5OdkBsfgkwAFoRYAdEK2LcHgjMXbYlHBCzlmwSTDMeEVQwjgg11OqYNGu1CDW4++AJ/XfnoQiLUARFx06fu0rr5g7XDLpLP99wzxw5dVFsarC5YWEEGAHLRKBWq340zKMt5f/lR4OBSEBHXpc5DHuWfhhRomYX2rJoNCUzYsF69fqtGG/QOr79tcxVGt4qdkCsZabYTotBYHfQKXIsUdBi7GFDrBeBtVsP0La9x8l/qKvqQYByc1fQKZFHgsTYiGSkV0fV+qJquGTNTjp/5RYN7tVaij5WwggwAvIR8A1cQddv3aX2zb6FH525cF1UCvfo2kR0qKV2laUfRngMmyryb3p0aijyPx4+fk5jpyyheHbxaGQ/Oe8++bPEGsMiwA4IrwlGwEwEUPgIbEYRCV6IxrH5ZnbBj8VxBFAdvWHHQXR001SLHCmYZRp1GsynihY5O2wUI/AVAdAEm5Lo1u9YsHIbXb15lwb2aGmqK90/Rw2kIePm0OZdRwx94SZ4QI+WoWqD6G4IdxAtBNgBiRZ8/LAtI1CiVpdIk32rNXWnTQtG2TI8PHYVCIC7f9zUpeTTt72K1vo2uXj131AdgFln3bYg2nf4DG1eyGtZX/RZOyNg2Qggsb1xZ2/av8bfYgzFOwrvUNQrSZDgG0OZxRjIhkSJADsgvEAYATMRKFa9E43y6hTh0+BR93RtSrUqlzRTOz8W1xDArdiStTvp7v0n9PnzZ8PwNu06TNXK/SH+LSt0yhzsUO3ZWOLFi0fPX7ymRQH96defs5ujkp9hBBgBK0TgbXBIKKuDQ97TsnW7afn63RaR5H3lxu1IUf0px/dWiLhtmswOiG3OO49aAgL5y7emHFkzR6lp7exhEnpiFXEBAYQypUieVFRCt7ezMwzJN3A5dWtXX/y7daNqFjVU3M7Y2dlR9/Zf7WNhBBiBuI9AXsdW4QaZMV1qEeJU9s8CsQ4AWL/Cyus3wZT0u8R0eENArNvHBqhDgB0QdThxK0YgHAJRhWAxXIxAWARQw2Pfav9QzC1oU6Rqh1gtYhbVTCFHpZnLMLNofXkFMAKMgHUigBwLY4nv4ECJEyWw6MH0GxEo6Mkb1ipn0Xaycd8QYAeEVwMjYCYCIyYupD7/ZxgxUwU/ZkMIuHtPoV6dG4UjJ3DuO54mD3ezOCQ+f/5Cqzfvo3FTl1lU3LfFAcUGMQKMQKwjAHZAsGNx7mWsT4VqA9gBUQ0VN2QEGAFGIO4iULBSu1CDA8UvTj09XZuJCsMsjAAjYBsIeA6fbnKglkCcYWzk1Rt3qG3PUbRnZfh6RiYHww1iBQF2QGIFdu6UEWAEGAHLQuDfOw9CGeRgb0/p0qai+A72lmUoW8MIMAK6IjBl7lqh/9ylG3T+8i1qUNMxXH+dWtTS1QZTyj9++kRnL96gB4+eUuYMaSlv7hxkZxfP1GP8uQUhwA6IBU0Gm8IIMAKMACPACDACjIAlILBl9xHqMWgyNXBypP5uLcje/ht5Rmzahxpczn3GUci7D3T/0VNKlzqFIPiY5NOd62/F5sRo7JsdEI2AcXNGgBFgBBgBRoARYATiMgKzFm+iafPX0Yh+HQX9LqqMj+nf2SLqbfQYNImy/5CRXNvWo4p/96TtS8YKW89cvEH+Q0PTicflObL2sbEDYu0zyPYzAowAI8AIMAKMACMgCYFBY2bT/iP/UMDIHoS6Ggh38ho5g+49eEJzfPtK6sV8NaVru9DaOT6UKkUygwMCGx3rdmfCDPNhjfEn2QGJcci5Q0aAEWAEGAFGgBFgBCwTgfrtB1LACDdKlyalwcAvX77QMN/55NW9eawbXbRaJ9q2eAylTJHU4IDcuv2A2vUaLf7OYh0IsANiHfPEVjICjAAjwAgwAowAI6A7Am+D31GSxAl178fcDpq7+FCHZk5U+o/fqEwdV6pUpght33ecurapI/JVWKwDAXZArGOe2EpGgBFgBBgBRoARYARsHoHT569RcMg7Kl74V5owfbmogF6qWH7KkyurzWNjTQCwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQiwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQiwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQiwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQiwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQiwA2JNs8W2MgKMACPACDACjAAjwAgwAlaOADsgVj6BbD4jwAgwAowAI8AIMAKMACNgTQj8D/AETef85cOqAAAAAElFTkSuQmCC"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "High-correlation pairs (|rho| > 0.7): 154\n",
+      "  cci_21 x bb_pctb_20: 0.987\n",
+      "  vol_21d x natr_14: 0.962\n",
+      "  rsi_7 x bb_pctb_20: 0.959\n",
+      "  ret_252d x skip_recent_12_1: 0.956\n",
+      "  vol_63d x vol_126d: 0.950\n",
+      "  vol_63d x natr_14: 0.944\n",
+      "  rsi_7 x stoch_k: 0.944\n",
+      "  cci_14 x bb_pctb_20: 0.944\n",
+      "  vol_126d x vol_252d: 0.943\n",
+      "  cci_14 x cci_21: 0.939\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_df = features.filter(pl.col(\"timestamp\").is_in(dates[::5]))\n",
+    "# Rank in polars (fast), then Pearson on ranks = Spearman\n",
+    "corr_matrix = (\n",
+    "    sample_df.select(feature_cols).select(pl.all().rank(method=\"average\")).to_pandas().corr()\n",
+    ")\n",
+    "\n",
+    "high_corr_pairs = [\n",
+    "    (f1, f2, corr_matrix.loc[f1, f2])\n",
+    "    for f1, f2 in itertools.combinations(feature_cols, 2)\n",
+    "    if abs(corr_matrix.loc[f1, f2]) > 0.7\n",
+    "]\n",
+    "\n",
+    "fig_corr = go.Figure(\n",
+    "    go.Heatmap(\n",
+    "        z=corr_matrix.values,\n",
+    "        x=feature_cols,\n",
+    "        y=feature_cols,\n",
+    "        colorscale=\"RdBu_r\",\n",
+    "        zmid=0,\n",
+    "        zmin=-1,\n",
+    "        zmax=1,\n",
+    "    )\n",
+    ")\n",
+    "fig_corr.update_layout(\n",
+    "    title=f\"Feature Correlation (Spearman, {len(high_corr_pairs)} pairs > 0.7)\",\n",
+    "    height=800,\n",
+    "    width=800,\n",
+    ")\n",
+    "fig_corr.show()\n",
+    "\n",
+    "print(f\"\\nHigh-correlation pairs (|rho| > 0.7): {len(high_corr_pairs)}\")\n",
+    "for f1, f2, rho in sorted(high_corr_pairs, key=lambda x: abs(x[2]), reverse=True)[:10]:\n",
+    "    print(f\"  {f1} x {f2}: {rho:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dbdc7e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004169,
+     "end_time": "2026-03-24T02:23:49.947748+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:49.943579+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Expected vs surprising correlations**: Pairs like `ret_126d`/`ret_252d`\n",
+    "and `sharpe_126d`/`sharpe_252d` are correlated by construction (overlapping\n",
+    "lookback windows). Similarly, `vol_252d`/`vol_126d` share data. These\n",
+    "structural correlations are expected and handled by regularization (Ridge/Lasso)\n",
+    "in Ch11. Surprising high correlations (e.g., between volatility and momentum\n",
+    "features) would warrant investigation but are not observed here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c30675f7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019532,
+     "end_time": "2026-03-24T02:23:49.971401+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:49.951869+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Feature Family IC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9cf697cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:59.649063Z",
+     "iopub.status.busy": "2026-04-09T01:07:59.648926Z",
+     "iopub.status.idle": "2026-04-09T01:07:59.655676Z",
+     "shell.execute_reply": "2026-04-09T01:07:59.655391Z"
+    },
+    "papermill": {
+     "duration": 0.010991,
+     "end_time": "2026-03-24T02:23:49.986599+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:49.975608+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Feature Family IC:\n",
+      "shape: (10, 5)\n",
+      "┌───────────────────┬───────────┬────────────┬────────────┬───────────────┐\n",
+      "│ family            ┆ avg_ic    ┆ avg_abs_ic ┆ n_features ┆ n_significant │\n",
+      "│ ---               ┆ ---       ┆ ---        ┆ ---        ┆ ---           │\n",
+      "│ str               ┆ f64       ┆ f64        ┆ u32        ┆ u32           │\n",
+      "╞═══════════════════╪═══════════╪════════════╪════════════╪═══════════════╡\n",
+      "│ distance          ┆ 0.035135  ┆ 0.041219   ┆ 2          ┆ 1             │\n",
+      "│ volatility        ┆ 0.033627  ┆ 0.036805   ┆ 10         ┆ 7             │\n",
+      "│ consistency       ┆ 0.029384  ┆ 0.029384   ┆ 1          ┆ 1             │\n",
+      "│ momentum          ┆ 0.007958  ┆ 0.023319   ┆ 14         ┆ 4             │\n",
+      "│ risk              ┆ -0.018177 ┆ 0.018177   ┆ 2          ┆ 0             │\n",
+      "│ volume            ┆ -0.014516 ┆ 0.014516   ┆ 1          ┆ 0             │\n",
+      "│ trend             ┆ 0.005504  ┆ 0.012862   ┆ 4          ┆ 0             │\n",
+      "│ oscillator        ┆ -0.007866 ┆ 0.008825   ┆ 8          ┆ 0             │\n",
+      "│ risk_adj_momentum ┆ 0.001112  ┆ 0.008073   ┆ 9          ┆ 0             │\n",
+      "│ regime            ┆ 0.003418  ┆ 0.003418   ┆ 2          ┆ 0             │\n",
+      "└───────────────────┴───────────┴────────────┴────────────┴───────────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "FAMILY_MAP = {\n",
+    "    \"ret_\": \"momentum\",\n",
+    "    \"skip_\": \"momentum\",\n",
+    "    \"mom_accel\": \"momentum\",\n",
+    "    \"sharpe_\": \"risk_adj_momentum\",\n",
+    "    \"vol_\": \"volatility\",\n",
+    "    \"natr_\": \"volatility\",\n",
+    "    \"vol_ratio\": \"volume\",\n",
+    "    \"obv_\": \"volume\",\n",
+    "    \"rsi_\": \"oscillator\",\n",
+    "    \"macd\": \"oscillator\",\n",
+    "    \"adx_\": \"oscillator\",\n",
+    "    \"cci_\": \"oscillator\",\n",
+    "    \"stoch_\": \"oscillator\",\n",
+    "    \"aroon\": \"oscillator\",\n",
+    "    \"sma_\": \"trend\",\n",
+    "    \"ema_\": \"trend\",\n",
+    "    \"bb_\": \"trend\",\n",
+    "    \"chop_\": \"regime\",\n",
+    "    \"hurst_\": \"regime\",\n",
+    "    \"regime\": \"regime\",\n",
+    "    \"yield_\": \"regime\",\n",
+    "    \"corr_spy\": \"regime\",\n",
+    "    \"max_dd\": \"risk\",\n",
+    "    \"pct_positive\": \"consistency\",\n",
+    "    \"dist_\": \"distance\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "family_ic = (\n",
+    "    eval_summary.with_columns(\n",
+    "        pl.coalesce(\n",
+    "            [\n",
+    "                pl.when(pl.col(\"feature\").str.starts_with(prefix))\n",
+    "                .then(pl.lit(family))\n",
+    "                .otherwise(pl.lit(None))\n",
+    "                for prefix, family in FAMILY_MAP.items()\n",
+    "            ]\n",
+    "            + [\n",
+    "                pl.when(pl.col(\"feature\").str.ends_with(\"_rank\"))\n",
+    "                .then(pl.lit(\"rank\"))\n",
+    "                .otherwise(pl.lit(\"other\"))\n",
+    "            ]\n",
+    "        ).alias(\"family\")\n",
+    "    )\n",
+    "    .group_by(\"family\")\n",
+    "    .agg(\n",
+    "        pl.col(\"ic_mean\").mean().alias(\"avg_ic\"),\n",
+    "        pl.col(\"ic_mean\").abs().mean().alias(\"avg_abs_ic\"),\n",
+    "        pl.len().alias(\"n_features\"),\n",
+    "        pl.col(\"significant_fdr05\").sum().alias(\"n_significant\"),\n",
+    "    )\n",
+    "    .sort(\"avg_abs_ic\", descending=True)\n",
+    ")\n",
+    "print(\"\\nFeature Family IC:\")\n",
+    "print(family_ic)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eeb2765",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004139,
+     "end_time": "2026-03-24T02:23:49.994954+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:49.990815+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Evaluation Results**:\n",
+    "\n",
+    "- HAC adjustment deflates t-statistics relative to naive, reflecting the\n",
+    "  autocorrelation in overlapping 21-day returns\n",
+    "- BH-FDR correction further culls features that appeared significant only\n",
+    "  due to multiple testing\n",
+    "- Feature correlation heatmap reveals redundancy clusters that downstream\n",
+    "  models should address through regularization or explicit selection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e75068",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004111,
+     "end_time": "2026-03-24T02:23:50.003246+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:49.999135+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Results Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "73b6cfae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-09T01:07:59.656652Z",
+     "iopub.status.busy": "2026-04-09T01:07:59.656576Z",
+     "iopub.status.idle": "2026-04-09T01:07:59.658716Z",
+     "shell.execute_reply": "2026-04-09T01:07:59.658461Z"
+    },
+    "papermill": {
+     "duration": 0.007652,
+     "end_time": "2026-03-24T02:23:50.015111+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:50.007459+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "top_features = (\n",
+    "    eval_summary.filter(pl.col(\"significant_fdr05\"))\n",
+    "    .sort(pl.col(\"ic_mean\").abs(), descending=True)\n",
+    "    .head(5)[\"feature\"]\n",
+    "    .to_list()\n",
+    ")\n",
+    "family_ic_dict = {row[\"family\"]: round(row[\"avg_ic\"], 4) for row in family_ic.to_dicts()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6fb58e1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004085,
+     "end_time": "2026-03-24T02:23:50.023353+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:23:50.019268+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **Skip-recent momentum** (12-1 and 6-1) is the most important literature-standard\n",
+    "   feature that was missing -- it avoids short-term reversal contamination\n",
+    "2. **Cross-sectional ranks** limited to 3 primary features (ret_126d, sharpe_126d,\n",
+    "   vol_63d) to reduce multicollinearity\n",
+    "3. **MA ratio proliferation** reduced from 8 to 3 (SMA 50/200, EMA 26)\n",
+    "4. **Point-in-time eligibility** enforced on feature matrix -- no phantom ETFs\n",
+    "   inflating early-period cross-section breadth\n",
+    "5. **SPY-TLT 63d correlation** added as cross-asset regime indicator\n",
+    "6. **Yield curve z-score** provides continuous regime signal (better than binary)\n",
+    "7. **IC evaluation with HAC + FDR** validates feature significance -- overlapping\n",
+    "   labels inflate naive t-stats; multiple testing further culls spurious features\n",
+    "8. **Gap: regime dynamics**: Cross-sectional features capture relative\n",
+    "   positioning but not market-level regime shifts. Ch9 adds data-driven\n",
+    "   regime detection (HMM) and memory-preserving transforms (FFD) that\n",
+    "   complement the rule-based regime indicators here.\n",
+    "\n",
+    "**Next**: `04_temporal.py` fits HMM regimes and fractional differencing models."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 96.852286,
+   "end_time": "2026-03-24T02:23:51.242757+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/etfs/03_financial_features.ipynb",
+   "output_path": "/tmp/ml4t_3987651_03_financial_features.ipynb",
+   "parameters": {
+    "GARCH_MIN_OBS": 50,
+    "HMM_N_RESTARTS": 1,
+    "MAX_SAMPLE_ASSETS": 3,
+    "MAX_SYMBOLS": 5,
+    "MIN_OBS": 10,
+    "MIN_TRAIN_BARS": 10,
+    "N_RESTARTS": 1,
+    "START_DATE": "2024-06-01"
+   },
+   "start_time": "2026-03-24T02:22:14.390471+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/case_studies/etfs/03_financial_features.py
+++ b/case_studies/etfs/03_financial_features.py
@@ -1,0 +1,960 @@
+# %% [markdown]
+# # ETFs: Feature Engineering
+#
+# This notebook implements feature engineering for the ETFs case study.
+# Features are organized around the core hypothesis: cross-asset momentum
+# combined with regime conditioning.
+#
+# ## Learning Objectives
+#
+# - Compute risk-adjusted momentum scores including skip-recent (12-1)
+# - Construct cross-sectional ranks for primary horizon features only
+# - Implement regime indicators (yield curve slope, SPY-TLT correlation)
+# - Enforce point-in-time eligibility on the feature matrix
+# - Diagnose feature quality via autocorrelation and rank stability
+#
+# ## Book Reference
+#
+# Chapter 8, Section 8.2 (Price-Derived Features)
+#
+# ## Prerequisites
+#
+# - [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) (produces `eligibility.csv`)
+# - [`02_labels`](02_labels.ipynb) (produces label parquet files and `config/cv_config.json`)
+
+# %%
+"""ETFs: Feature Engineering."""
+
+import itertools
+import os
+import warnings
+
+import numpy as np
+import plotly.graph_objects as go
+import polars as pl
+from ml4t.diagnostic.evaluation.stats import benjamini_hochberg_fdr
+from ml4t.diagnostic.metrics import compute_ic_hac_stats
+from ml4t.engineer.features.momentum import adx, aroon, cci, macd, rsi, stochastic
+from ml4t.engineer.features.regime import choppiness_index, hurst_exponent
+from ml4t.engineer.features.trend import ema, sma
+from ml4t.engineer.features.volatility import natr
+from ml4t.engineer.features.volume import obv
+from scipy.stats import spearmanr
+
+from data import load_etfs, load_macro
+from utils.paths import get_case_study_dir
+
+warnings.filterwarnings("ignore")
+
+CASE_DIR = get_case_study_dir("etfs")
+FEATURES_DIR = CASE_DIR / "features"
+
+NUMERIC_DTYPES = {
+    pl.Boolean,
+    pl.Int8,
+    pl.Int16,
+    pl.Int32,
+    pl.Int64,
+    pl.UInt8,
+    pl.UInt16,
+    pl.UInt32,
+    pl.UInt64,
+    pl.Float32,
+    pl.Float64,
+}
+
+
+def as_float(value: object | None) -> float | None:
+    """Convert Polars scalar outputs to plain float for plotting."""
+    if value is None:
+        return None
+    return float(str(value))
+
+
+# %% tags=["parameters"]
+# Production defaults — Papermill injects overrides for CI
+
+# %% [markdown]
+# ## Configuration
+
+# %%
+# Feature parameters
+REGIME_THRESHOLD = 0.005  # 0.5% yield curve slope
+
+# Multi-horizon lookback periods (trading days)
+MOMENTUM_HORIZONS = [5, 10, 21, 42, 63, 126, 189, 252]
+VOLATILITY_HORIZONS = [21, 63, 126, 252]
+
+# %% [markdown]
+# ## 1. Load Data
+
+# %%
+prices = (
+    load_etfs()
+    .select(["symbol", "timestamp", "open", "high", "low", "close", "volume"])
+    .sort(["symbol", "timestamp"])
+)
+
+# Load eligibility for PIT filtering
+eligibility = pl.read_csv(CASE_DIR / "eligibility.csv")
+if "symbol" in eligibility.columns and "symbol" not in eligibility.columns:
+    eligibility = eligibility
+
+assets_list = sorted(prices["symbol"].unique().to_list())
+n_assets = prices["symbol"].n_unique()
+print(f"ETF Universe: {n_assets} assets, {len(prices):,} rows")
+
+# %% [markdown]
+# ### Yield Curve Data
+
+# %%
+macro_data = load_macro()
+
+# Compute yield curve slope from dgs10 and dgs2
+yield_curve = (
+    macro_data.select(["timestamp", "dgs10", "dgs2"])
+    .with_columns(
+        (pl.col("dgs10") / 100).alias("yield_10y"),
+        (pl.col("dgs2") / 100).alias("yield_2y"),
+        ((pl.col("dgs10") - pl.col("dgs2")) / 100).alias("slope"),
+    )
+    .select(["timestamp", "yield_10y", "yield_2y", "slope"])
+    .drop_nulls()
+    .sort("timestamp")
+)
+
+print(f"Yield curve data: {len(yield_curve):,} rows")
+
+# %% [markdown]
+# ## 2. Feature Engineering
+#
+# Features are organized into focused families aligned with the momentum +
+# regime hypothesis. We avoid feature inflation by ranking only primary
+# horizons and keeping a curated set of MA ratios.
+
+# %% [markdown]
+# ### 2.1 Momentum and Returns
+#
+# Multi-horizon raw returns, skip-recent momentum (12-1 and 6-1), risk-adjusted
+# momentum (Sharpe-like), and momentum acceleration.
+
+
+# %%
+def compute_momentum_features(df: pl.DataFrame) -> pl.DataFrame:
+    """Momentum, volatility, and risk-adjusted returns."""
+    df = df.sort(["symbol", "timestamp"])
+
+    # Multi-horizon raw returns (clip(1e-8) guards against div-by-zero → inf)
+    momentum_cols = [
+        (
+            pl.col("close") / pl.col("close").shift(h).over("symbol").clip(lower_bound=1e-8) - 1
+        ).alias(f"ret_{h}d")
+        for h in MOMENTUM_HORIZONS
+    ]
+    df = df.with_columns(momentum_cols)
+
+    # Skip-recent momentum (Jegadeesh and Titman 1993)
+    # 12-1: 252d return excluding most recent 21d
+    # 6-1: 126d return excluding most recent 21d
+    df = df.with_columns(
+        (pl.col("ret_252d") - pl.col("ret_21d")).alias("skip_recent_12_1"),
+        (pl.col("ret_126d") - pl.col("ret_21d")).alias("skip_recent_6_1"),
+    )
+
+    # Log returns for volatility
+    df = df.with_columns(pl.col("close").log().diff().over("symbol").alias("log_return"))
+
+    # Multi-horizon volatility (annualized)
+    volatility_cols = [
+        pl.col("log_return").rolling_std(h).over("symbol").mul(np.sqrt(252)).alias(f"vol_{h}d")
+        for h in VOLATILITY_HORIZONS
+    ]
+    df = df.with_columns(volatility_cols)
+
+    # Volatility-adjusted momentum (Sharpe-like)
+    sharpe_cols = [
+        (
+            pl.col("log_return").rolling_sum(h).over("symbol")
+            / pl.col("log_return").rolling_std(h).over("symbol")
+            * np.sqrt(252 / h)
+        ).alias(f"sharpe_{h}d")
+        for h in MOMENTUM_HORIZONS
+    ]
+    df = df.with_columns(sharpe_cols)
+
+    # Momentum acceleration
+    df = df.with_columns(
+        (pl.col("ret_21d") - pl.col("ret_63d")).alias("mom_accel_short"),
+        (pl.col("ret_63d") - pl.col("ret_126d")).alias("mom_accel_medium"),
+        (pl.col("ret_126d") - pl.col("ret_252d")).alias("mom_accel_long"),
+    )
+
+    # Volatility ratios (short/long)
+    df = df.with_columns(
+        (pl.col("vol_21d") / pl.col("vol_63d")).alias("vol_ratio_short"),
+        (pl.col("vol_63d") / pl.col("vol_126d")).alias("vol_ratio_medium"),
+    )
+
+    return df
+
+
+# %% [markdown]
+# ### 2.2 Technical Indicators
+#
+# Curated set: oscillators (RSI, MACD, ADX, CCI, Stochastic, Aroon),
+# select MA ratios (SMA 50/200, EMA 26 only -- review recommended dropping
+# the rest), Bollinger %B, and NATR.
+
+
+# %%
+def compute_technical_features(df: pl.DataFrame) -> pl.DataFrame:
+    """Technical indicators and trend features."""
+    # Oscillators
+    df = df.with_columns(
+        rsi("close", period=7).over("symbol").alias("rsi_7"),
+        rsi("close", period=14).over("symbol").alias("rsi_14"),
+        macd("close", fast_period=12, slow_period=26).over("symbol").alias("macd_line"),
+        adx("high", "low", "close", period=14).over("symbol").alias("adx_14"),
+        cci("high", "low", "close", period=14).over("symbol").alias("cci_14"),
+        cci("high", "low", "close", period=21).over("symbol").alias("cci_21"),
+        stochastic("high", "low", "close", fastk_period=14).over("symbol").alias("stoch_k"),
+    )
+
+    # Aroon oscillator
+    df = (
+        df.with_columns(aroon("high", "low", timeperiod=25).over("symbol").alias("_aroon_struct"))
+        .with_columns(
+            (
+                pl.col("_aroon_struct").struct.field("up")
+                - pl.col("_aroon_struct").struct.field("down")
+            ).alias("aroon_diff")
+        )
+        .drop("_aroon_struct")
+    )
+
+    # MA ratios -- curated set (SMA 50/200, EMA 26 only)
+    df = df.with_columns(
+        (pl.col("close") / sma("close", period=50).over("symbol")).alias("sma_ratio_50"),
+        (pl.col("close") / sma("close", period=200).over("symbol")).alias("sma_ratio_200"),
+        (pl.col("close") / ema("close", period=26).over("symbol")).alias("ema_ratio_26"),
+    )
+
+    # Bollinger %B
+    df = df.with_columns(
+        pl.col("close").rolling_mean(20).over("symbol").alias("_bb_mid"),
+        pl.col("close").rolling_std(20).over("symbol").alias("_bb_std"),
+    )
+    df = df.with_columns(
+        (
+            (pl.col("close") - (pl.col("_bb_mid") - 2 * pl.col("_bb_std")))
+            / (4 * pl.col("_bb_std"))
+        ).alias("bb_pctb_20")
+    ).drop(["_bb_mid", "_bb_std"])
+
+    # NATR
+    df = df.with_columns(
+        natr("high", "low", "close", period=14).over("symbol").alias("natr_14"),
+    )
+
+    return df
+
+
+# %% [markdown]
+# ### 2.3 Regime, Risk, Volume, and Distance Features
+
+
+# %%
+def compute_regime_volume_features(df: pl.DataFrame) -> pl.DataFrame:
+    """Regime indicators, risk metrics, volume features, distance extremes."""
+    # Regime indicators
+    df = df.with_columns(
+        choppiness_index("high", "low", "close", period=14).over("symbol").alias("chop_14"),
+        hurst_exponent("close", period=100).over("symbol").alias("hurst_100"),
+    )
+
+    # Maximum drawdown
+    df = df.with_columns(
+        (
+            (pl.col("close") - pl.col("close").rolling_max(63).over("symbol"))
+            / pl.col("close").rolling_max(63).over("symbol").clip(lower_bound=1e-8)
+        ).alias("max_dd_63d"),
+        (
+            (pl.col("close") - pl.col("close").rolling_max(126).over("symbol"))
+            / pl.col("close").rolling_max(126).over("symbol").clip(lower_bound=1e-8)
+        ).alias("max_dd_126d"),
+    )
+
+    # Volume features (winsorize relative volume at 1st/99th)
+    df = df.with_columns(
+        (
+            pl.col("volume")
+            / pl.col("volume").rolling_mean(21).over("symbol").clip(lower_bound=1e-8)
+        ).alias("vol_ratio_21d_raw"),
+        (
+            pl.col("volume")
+            / pl.col("volume").rolling_mean(63).over("symbol").clip(lower_bound=1e-8)
+        ).alias("vol_ratio_63d_raw"),
+    )
+    df = df.with_columns(
+        pl.col("vol_ratio_21d_raw")
+        .clip(
+            pl.col("vol_ratio_21d_raw").quantile(0.01).over("timestamp"),
+            pl.col("vol_ratio_21d_raw").quantile(0.99).over("timestamp"),
+        )
+        .alias("vol_ratio_21d"),
+        pl.col("vol_ratio_63d_raw")
+        .clip(
+            pl.col("vol_ratio_63d_raw").quantile(0.01).over("timestamp"),
+            pl.col("vol_ratio_63d_raw").quantile(0.99).over("timestamp"),
+        )
+        .alias("vol_ratio_63d"),
+    ).drop(["vol_ratio_21d_raw", "vol_ratio_63d_raw"])
+
+    # OBV z-score
+    df = df.with_columns(obv("close", "volume").over("symbol").alias("_obv"))
+    df = df.with_columns(
+        (
+            (pl.col("_obv") - pl.col("_obv").rolling_mean(63).over("symbol"))
+            / pl.col("_obv").rolling_std(63).over("symbol")
+        ).alias("obv_zscore_63d"),
+    ).drop("_obv")
+
+    # Consistency and distance from extremes
+    df = df.with_columns(
+        (pl.col("log_return") > 0)
+        .cast(pl.Float64)
+        .rolling_mean(63)
+        .over("symbol")
+        .alias("pct_positive_63d"),
+    )
+    df = df.with_columns(
+        (
+            pl.col("close") / pl.col("close").rolling_max(252).over("symbol").clip(lower_bound=1e-8)
+        ).alias("dist_52w_high"),
+        (
+            pl.col("close") / pl.col("close").rolling_min(252).over("symbol").clip(lower_bound=1e-8)
+        ).alias("dist_52w_low"),
+    )
+
+    return df
+
+
+# %% [markdown]
+# ### 2.4 Cross-Asset Correlation Feature
+#
+# Rolling 63-day correlation between SPY and TLT captures the equity-bond
+# relationship. When this flips from negative to positive, diversification
+# breaks down -- a valuable regime indicator for cross-asset rotation.
+
+
+# %%
+def compute_cross_asset_features(df: pl.DataFrame) -> pl.DataFrame:
+    """Compute cross-asset correlation features (SPY vs TLT)."""
+    # Extract SPY and TLT log returns
+    spy_ret = (
+        df.filter(pl.col("symbol") == "SPY")
+        .select(["timestamp", "log_return"])
+        .rename({"log_return": "_spy_ret"})
+    )
+    tlt_ret = (
+        df.filter(pl.col("symbol") == "TLT")
+        .select(["timestamp", "log_return"])
+        .rename({"log_return": "_tlt_ret"})
+    )
+
+    # Join SPY and TLT returns on date
+    corr_df = spy_ret.join(tlt_ret, on="timestamp", how="inner").sort("timestamp")
+
+    # Rolling 63-day correlation
+    corr_df = corr_df.with_columns(
+        pl.rolling_corr(pl.col("_spy_ret"), pl.col("_tlt_ret"), window_size=63).alias(
+            "corr_spy_tlt_63d"
+        )
+    ).select(["timestamp", "corr_spy_tlt_63d"])
+
+    # Broadcast to all assets
+    return df.join(corr_df, on="timestamp", how="left")
+
+
+# %% [markdown]
+# ### Apply All Feature Groups
+
+# %%
+features_raw = (
+    prices.pipe(compute_momentum_features)
+    .pipe(compute_technical_features)
+    .pipe(compute_regime_volume_features)
+    .pipe(compute_cross_asset_features)
+)
+
+print(f"Shape after feature computation: {features_raw.shape}")
+
+# %% [markdown]
+# ### 2.5 Cross-Sectional Ranking
+#
+# Rank only the primary horizon features to avoid multicollinearity from
+# ranking every horizon. Three rank features: `ret_126d_rank`,
+# `sharpe_126d_rank`, `vol_63d_rank`.
+
+# %%
+# Rank only primary features (review recommendation)
+RANK_FEATURES = ["ret_126d", "sharpe_126d", "vol_63d"]
+
+rank_exprs = [
+    (pl.col(col).rank().over("timestamp") / pl.col(col).count().over("timestamp")).alias(
+        f"{col}_rank"
+    )
+    for col in RANK_FEATURES
+]
+features_raw = features_raw.with_columns(rank_exprs)
+
+# %% [markdown]
+# ### 2.6 Regime Indicators
+#
+# Two regime features from the yield curve:
+# 1. Binary regime (slope > 0.5%)
+# 2. Continuous yield curve slope
+# 3. Rolling z-score of slope (review recommendation)
+
+
+# %%
+def add_regime_indicators(
+    df: pl.DataFrame, yield_curve: pl.DataFrame, threshold: float = 0.005
+) -> pl.DataFrame:
+    """Add regime indicators from yield curve data."""
+    regime_df = (
+        yield_curve.with_columns(
+            pl.when(pl.col("slope") > threshold).then(1).otherwise(0).alias("regime"),
+            pl.col("slope").alias("yield_curve_slope"),
+            # Rolling z-score of slope
+            (
+                (pl.col("slope") - pl.col("slope").rolling_mean(252))
+                / pl.col("slope").rolling_std(252)
+            ).alias("yield_curve_zscore"),
+        )
+        .select(["timestamp", "regime", "yield_curve_slope", "yield_curve_zscore"])
+        .sort("timestamp")
+    )
+
+    return df.sort("timestamp").join_asof(regime_df, on="timestamp", strategy="backward")
+
+
+features_raw = add_regime_indicators(features_raw, yield_curve, threshold=REGIME_THRESHOLD)
+
+regime_dist = features_raw.group_by("regime").agg(pl.len().alias("count"))
+print("Regime Distribution:", regime_dist)
+
+# %% [markdown]
+# ### 2.7 Point-in-Time Eligibility Filter
+#
+# Join features to eligibility.csv to ensure features are only kept for
+# ETFs that were tradable at each date. This prevents inflation of the
+# cross-section breadth in early years when fewer ETFs met the ADV threshold.
+
+# %%
+# Add year for eligibility join
+features_raw = features_raw.with_columns(pl.col("timestamp").dt.year().alias("_year"))
+
+elig_pairs = eligibility.select(
+    pl.col("symbol"),
+    pl.col("eligible_year").alias("_year"),
+)
+
+# Semi-join: keep only rows where (asset, year) exists in eligibility
+features_eligible = features_raw.join(elig_pairs, on=["symbol", "_year"], how="semi").drop("_year")
+
+n_dropped = len(features_raw) - len(features_eligible)
+print(
+    f"Eligibility filter: {len(features_raw):,} -> {len(features_eligible):,} rows ({n_dropped:,} dropped)"
+)
+
+# %% [markdown]
+# ## 3. Prepare Final Feature Matrix
+
+# %%
+# Columns to exclude from feature set
+exclude_cols = {
+    "timestamp",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "log_return",
+}
+
+feature_cols = [c for c in features_eligible.columns if c not in exclude_cols]
+non_numeric_feature_cols = [
+    c for c in feature_cols if features_eligible.schema[c] not in NUMERIC_DTYPES
+]
+feature_cols = [c for c in feature_cols if c not in non_numeric_feature_cols]
+
+assert "log_return" not in feature_cols, "log_return must be excluded (contemporaneous with label)"
+unexpected_feature_keys = {"timestamp", "symbol"} & set(feature_cols)
+assert not unexpected_feature_keys, (
+    f"Feature matrix leaked key columns: {sorted(unexpected_feature_keys)}"
+)
+assert not non_numeric_feature_cols, (
+    f"Non-numeric columns leaked into features: {non_numeric_feature_cols}"
+)
+required_core_features = {
+    "ret_21d",
+    "sharpe_126d",
+    "rsi_14",
+    "ema_ratio_26",
+    "yield_curve_slope",
+    "corr_spy_tlt_63d",
+    "max_dd_63d",
+}
+missing_core_features = required_core_features - set(feature_cols)
+assert not missing_core_features, f"Missing core curated features: {sorted(missing_core_features)}"
+
+# Prepare final DataFrame
+features = (
+    features_eligible.select(["timestamp", "symbol"] + feature_cols)
+    .drop_nulls(subset=["sharpe_126d"])  # Drop warmup rows
+    .sort(["timestamp", "symbol"])
+)
+
+# Missing values check
+high_missing = [
+    (c, features[c].null_count() / len(features))
+    for c in feature_cols
+    if features[c].null_count() / len(features) > 0.05
+]
+if high_missing:
+    print("Features with >5% missing after warmup drop:")
+    for col, pct in high_missing:
+        print(f"  {col}: {pct:.1%}")
+else:
+    print("No features with >5% missing after warmup drop")
+
+print("\nFeature Summary")
+print(f"  Total features: {len(feature_cols)}")
+print(f"  Rows: {len(features):,}")
+print(f"  Assets: {features['symbol'].n_unique()}")
+print(f"  Date range: {features['timestamp'].min()} to {features['timestamp'].max()}")
+
+# Feature category counts
+cats = {
+    "Momentum (raw)": sum(
+        1 for c in feature_cols if c.startswith("ret_") and not c.endswith("_rank")
+    ),
+    "Skip-recent": sum(1 for c in feature_cols if c.startswith("skip_")),
+    "Sharpe": sum(1 for c in feature_cols if c.startswith("sharpe_") and not c.endswith("_rank")),
+    "Volatility": sum(
+        1 for c in feature_cols if c.startswith("vol_") and not c.startswith("vol_ratio")
+    ),
+    "Vol ratios": sum(1 for c in feature_cols if c.startswith("vol_ratio")),
+    "Technical": sum(
+        1
+        for c in feature_cols
+        if any(c.startswith(p) for p in ["rsi_", "macd", "adx_", "cci_", "stoch_", "aroon"])
+    ),
+    "Trend (MA)": sum(1 for c in feature_cols if any(c.startswith(p) for p in ["sma_", "ema_"])),
+    "Regime/macro": sum(
+        1
+        for c in feature_cols
+        if any(c.startswith(p) for p in ["regime", "yield_", "chop_", "hurst_", "corr_spy"])
+    ),
+    "Risk (DD)": sum(1 for c in feature_cols if c.startswith("max_dd")),
+    "Ranks": sum(1 for c in feature_cols if c.endswith("_rank")),
+    "Other": 0,  # computed below
+}
+accounted = sum(cats.values())
+cats["Other"] = len(feature_cols) - accounted
+
+print("\nFeature categories:")
+for cat, count in cats.items():
+    if count > 0:
+        print(f"  {cat}: {count}")
+
+# %% [markdown]
+# ## 4. Feature Diagnostics
+
+# %% [markdown]
+# ### 4.1 Autocorrelation (Signal Persistence)
+
+# %%
+acf_results = []
+sample_assets = assets_list
+for asset in sample_assets:
+    scores = features.filter(pl.col("symbol") == asset)["sharpe_126d"].drop_nulls().to_numpy()
+    for lag in [1, 5, 21]:
+        if len(scores) > lag + 10:
+            acf = np.corrcoef(scores[lag:], scores[:-lag])[0, 1]
+            acf_results.append({"symbol": asset, "lag": lag, "acf": acf})
+
+acf_df = pl.DataFrame(acf_results)
+acf_summary = acf_df.group_by("lag").agg(
+    pl.col("acf").mean().alias("mean_acf"),
+    pl.col("acf").std().alias("std_acf"),
+)
+print("6-Month Sharpe Autocorrelation:")
+print(acf_summary.sort("lag"))
+
+# %% [markdown]
+# ### 4.2 Rank Stability
+
+# %%
+monthly = (
+    features.with_columns(pl.col("timestamp").dt.truncate("1mo").alias("month"))
+    .group_by(["month", "symbol"])
+    .agg(pl.col("sharpe_126d_rank").last().alias("rank_end"))
+    .sort(["symbol", "month"])
+    .with_columns(pl.col("rank_end").shift(1).over("symbol").alias("rank_prev"))
+    .drop_nulls()
+)
+
+rank_corr = np.corrcoef(monthly["rank_prev"].to_numpy(), monthly["rank_end"].to_numpy())[0, 1]
+print(f"Monthly rank persistence (correlation): {rank_corr:.3f}")
+
+# %% [markdown]
+# ## 5. Save Features
+
+# %%
+FEATURES_DIR.mkdir(parents=True, exist_ok=True)
+features.write_parquet(FEATURES_DIR / "financial.parquet")
+print(f"Saved {len(feature_cols)} features to {FEATURES_DIR / 'financial.parquet'}")
+print(f"  {len(features):,} rows, {features['symbol'].n_unique()} assets")
+# %% [markdown]
+# **Note on frequency**: The feature matrix is saved at daily frequency
+# (all trading days), while the decision cadence is monthly month-end.
+# This means ~21 rows per decision point. Features are saved daily for
+# flexibility (enabling weekly variant analysis), but downstream modeling
+# (Ch11+) should sample at the decision cadence. The IC evaluation below
+# uses all daily cross-sections with HAC adjustment for the resulting
+# autocorrelation in overlapping 21-day labels.
+
+# %% [markdown]
+# ## 6. Feature Evaluation
+#
+# We evaluate each feature's predictive power using cross-sectional Spearman IC
+# against 21-day forward returns. Two critical adjustments:
+#
+# - **HAC standard errors** (Newey-West): Overlapping 21-day returns create
+#   autocorrelated IC time series, inflating naive t-statistics
+# - **BH-FDR correction**: With 57 simultaneous tests, naive p-values overstate
+#   significance; we control the false discovery rate at 5%
+#
+# The cross-sectional IC on date $t$ is:
+#
+# $$IC_t = \rho_S\bigl(f_{t,i},\; r_{t \to t+21, i}\bigr)$$
+#
+# where $f_{t,i}$ is the feature value for asset $i$ on date $t$.
+#
+# **Caveat**: This is a preliminary evaluation of financial features only.
+# The authoritative evaluation — covering both financial and temporal features
+# with consistent methodology — is in [`05_evaluation`](05_evaluation.ipynb). Results may differ
+# due to different feature sets and evaluation scope.
+
+# %%
+# Load 21-day forward return labels
+labels = pl.read_parquet(CASE_DIR / "labels" / "fwd_ret_21d.parquet")
+label_col = "fwd_ret_21d"
+
+eval_df = features.join(
+    labels.select(["timestamp", "symbol", label_col]), on=["timestamp", "symbol"], how="inner"
+)
+print(
+    f"Evaluation set: {len(eval_df):,} rows "
+    f"({eval_df['timestamp'].n_unique():,} dates x {eval_df['symbol'].n_unique()} assets)"
+)
+
+# %% [markdown]
+# ### Cross-Sectional IC with HAC Adjustment
+
+# %%
+# Compute cross-sectional Spearman IC per feature per date
+dates = eval_df["timestamp"].unique().sort().to_list()
+n_dates = len(dates)
+ic_matrix = np.full((n_dates, len(feature_cols)), np.nan)
+
+for i, date_val in enumerate(dates):
+    group = eval_df.filter(pl.col("timestamp") == date_val)
+    y = np.asarray(group[label_col].to_numpy(), dtype=float)
+    valid_y = ~np.isnan(y)
+    if valid_y.sum() < 10:
+        continue
+    for j, feat in enumerate(feature_cols):
+        if group[feat].dtype not in NUMERIC_DTYPES:
+            continue
+        x = np.asarray(group[feat].to_numpy(), dtype=float)
+        valid = valid_y & ~np.isnan(x)
+        if valid.sum() >= 5:
+            rho, _ = spearmanr(x[valid], y[valid])
+            ic_matrix[i, j] = rho
+
+# Build per-feature HAC statistics
+ic_stats = {}
+for j, feat in enumerate(feature_cols):
+    ic_series = ic_matrix[:, j]
+    valid_ic = ic_series[~np.isnan(ic_series)]
+    if len(valid_ic) < 30:
+        continue
+    stats = compute_ic_hac_stats(pl.DataFrame({"ic": valid_ic}), ic_col="ic")
+    ic_stats[feat] = stats
+
+print(f"Computed IC stats for {len(ic_stats)} features ({n_dates:,} dates)")
+
+# %% [markdown]
+# ### BH-FDR Multiple Testing Correction
+
+# %%
+feat_names = list(ic_stats.keys())
+p_values = [ic_stats[f]["p_value"] for f in feat_names]
+fdr_result = benjamini_hochberg_fdr(p_values, alpha=0.05, return_details=True)
+
+eval_summary = pl.DataFrame(
+    {
+        "feature": feat_names,
+        "ic_mean": [ic_stats[f]["mean_ic"] for f in feat_names],
+        "hac_tstat": [ic_stats[f]["t_stat"] for f in feat_names],
+        "naive_tstat": [ic_stats[f]["naive_t_stat"] for f in feat_names],
+        "p_value": p_values,
+        "adjusted_p": fdr_result["adjusted_p_values"].tolist(),
+        "significant_fdr05": fdr_result["rejected"].tolist(),
+    }
+).sort("ic_mean", descending=True)
+
+n_naive_sig = sum(1 for p in p_values if p < 0.05)
+n_fdr_sig = int(fdr_result["n_rejected"])
+inflation = n_naive_sig / max(n_fdr_sig, 1)
+
+print("\nFeature Evaluation Summary")
+print(f"  Features tested: {len(feat_names)}")
+print(f"  Naive significant (p<0.05): {n_naive_sig}")
+print(f"  FDR-significant (q<0.05): {n_fdr_sig}")
+print(f"  Inflation factor: {inflation:.1f}x")
+print("\nTop 10 by IC:")
+print(eval_summary.head(10))
+
+# %% [markdown]
+# **Note on date-level features**: Features like `regime_binary`,
+# `yield_curve_slope`, `corr_spy_tlt_63d`, and `choppiness_63d` are identical
+# across all symbols on a given date. Their cross-sectional IC is zero by
+# construction because they cannot differentiate between assets. These features
+# add value through interactions with cross-sectional features (e.g., conditional
+# momentum) rather than standalone ranking ability.
+
+# %% [markdown]
+# ### IC Bar Chart
+
+# %%
+top20 = eval_summary.sort(pl.col("ic_mean").abs(), descending=True).head(20)
+colors = ["#2ecc71" if sig else "#95a5a6" for sig in top20["significant_fdr05"].to_list()]
+
+fig_ic = go.Figure(
+    go.Bar(
+        x=top20["feature"].to_list(),
+        y=top20["ic_mean"].to_list(),
+        marker_color=colors,
+        text=[f"{ic:.3f}" for ic in top20["ic_mean"].to_list()],
+        textposition="outside",
+    )
+)
+fig_ic.update_layout(
+    title="Top 20 Features by |IC| (green = FDR-significant at 5%)",
+    xaxis_title="Feature",
+    yaxis_title="Mean IC",
+    xaxis_tickangle=45,
+    height=500,
+)
+fig_ic.show()
+
+# %% [markdown]
+# ### Naive vs HAC t-Statistics
+
+# %%
+sig_colors = [
+    "#2ecc71" if sig else "#95a5a6" for sig in eval_summary["significant_fdr05"].to_list()
+]
+
+fig_tstat = go.Figure()
+fig_tstat.add_trace(
+    go.Scatter(
+        x=eval_summary["naive_tstat"].to_list(),
+        y=eval_summary["hac_tstat"].to_list(),
+        mode="markers",
+        marker=dict(color=sig_colors, size=8),
+        text=eval_summary["feature"].to_list(),
+        hovertemplate="%{text}<br>Naive t: %{x:.2f}<br>HAC t: %{y:.2f}<extra></extra>",
+    )
+)
+naive_tstat_min = as_float(eval_summary["naive_tstat"].min())
+naive_tstat_max = as_float(eval_summary["naive_tstat"].max())
+hac_tstat_min = as_float(eval_summary["hac_tstat"].min())
+hac_tstat_max = as_float(eval_summary["hac_tstat"].max())
+assert naive_tstat_min is not None and naive_tstat_max is not None
+assert hac_tstat_min is not None and hac_tstat_max is not None
+t_range = [
+    min(naive_tstat_min, hac_tstat_min) - 0.5,
+    max(naive_tstat_max, hac_tstat_max) + 0.5,
+]
+fig_tstat.add_trace(
+    go.Scatter(
+        x=t_range,
+        y=t_range,
+        mode="lines",
+        line=dict(dash="dash", color="gray"),
+        showlegend=False,
+    )
+)
+fig_tstat.update_layout(
+    title="Naive vs HAC-Adjusted t-Statistics",
+    xaxis_title="Naive t-stat",
+    yaxis_title="HAC t-stat",
+    height=500,
+)
+fig_tstat.show()
+
+# %% [markdown]
+# ### Feature Correlation Heatmap
+
+# %%
+sample_df = features.filter(pl.col("timestamp").is_in(dates[::5]))
+# Rank in polars (fast), then Pearson on ranks = Spearman
+corr_matrix = (
+    sample_df.select(feature_cols).select(pl.all().rank(method="average")).to_pandas().corr()
+)
+
+high_corr_pairs = [
+    (f1, f2, corr_matrix.loc[f1, f2])
+    for f1, f2 in itertools.combinations(feature_cols, 2)
+    if abs(corr_matrix.loc[f1, f2]) > 0.7
+]
+
+fig_corr = go.Figure(
+    go.Heatmap(
+        z=corr_matrix.values,
+        x=feature_cols,
+        y=feature_cols,
+        colorscale="RdBu_r",
+        zmid=0,
+        zmin=-1,
+        zmax=1,
+    )
+)
+fig_corr.update_layout(
+    title=f"Feature Correlation (Spearman, {len(high_corr_pairs)} pairs > 0.7)",
+    height=800,
+    width=800,
+)
+fig_corr.show()
+
+print(f"\nHigh-correlation pairs (|rho| > 0.7): {len(high_corr_pairs)}")
+for f1, f2, rho in sorted(high_corr_pairs, key=lambda x: abs(x[2]), reverse=True)[:10]:
+    print(f"  {f1} x {f2}: {rho:.3f}")
+
+# %% [markdown]
+# **Expected vs surprising correlations**: Pairs like `ret_126d`/`ret_252d`
+# and `sharpe_126d`/`sharpe_252d` are correlated by construction (overlapping
+# lookback windows). Similarly, `vol_252d`/`vol_126d` share data. These
+# structural correlations are expected and handled by regularization (Ridge/Lasso)
+# in Ch11. Surprising high correlations (e.g., between volatility and momentum
+# features) would warrant investigation but are not observed here.
+
+# %% [markdown]
+# ### Feature Family IC
+
+# %%
+FAMILY_MAP = {
+    "ret_": "momentum",
+    "skip_": "momentum",
+    "mom_accel": "momentum",
+    "sharpe_": "risk_adj_momentum",
+    "vol_": "volatility",
+    "natr_": "volatility",
+    "vol_ratio": "volume",
+    "obv_": "volume",
+    "rsi_": "oscillator",
+    "macd": "oscillator",
+    "adx_": "oscillator",
+    "cci_": "oscillator",
+    "stoch_": "oscillator",
+    "aroon": "oscillator",
+    "sma_": "trend",
+    "ema_": "trend",
+    "bb_": "trend",
+    "chop_": "regime",
+    "hurst_": "regime",
+    "regime": "regime",
+    "yield_": "regime",
+    "corr_spy": "regime",
+    "max_dd": "risk",
+    "pct_positive": "consistency",
+    "dist_": "distance",
+}
+
+
+family_ic = (
+    eval_summary.with_columns(
+        pl.coalesce(
+            [
+                pl.when(pl.col("feature").str.starts_with(prefix))
+                .then(pl.lit(family))
+                .otherwise(pl.lit(None))
+                for prefix, family in FAMILY_MAP.items()
+            ]
+            + [
+                pl.when(pl.col("feature").str.ends_with("_rank"))
+                .then(pl.lit("rank"))
+                .otherwise(pl.lit("other"))
+            ]
+        ).alias("family")
+    )
+    .group_by("family")
+    .agg(
+        pl.col("ic_mean").mean().alias("avg_ic"),
+        pl.col("ic_mean").abs().mean().alias("avg_abs_ic"),
+        pl.len().alias("n_features"),
+        pl.col("significant_fdr05").sum().alias("n_significant"),
+    )
+    .sort("avg_abs_ic", descending=True)
+)
+print("\nFeature Family IC:")
+print(family_ic)
+
+# %% [markdown]
+# **Evaluation Results**:
+#
+# - HAC adjustment deflates t-statistics relative to naive, reflecting the
+#   autocorrelation in overlapping 21-day returns
+# - BH-FDR correction further culls features that appeared significant only
+#   due to multiple testing
+# - Feature correlation heatmap reveals redundancy clusters that downstream
+#   models should address through regularization or explicit selection
+
+# %% [markdown]
+# ## 7. Results Collection
+
+# %%
+top_features = (
+    eval_summary.filter(pl.col("significant_fdr05"))
+    .sort(pl.col("ic_mean").abs(), descending=True)
+    .head(5)["feature"]
+    .to_list()
+)
+family_ic_dict = {row["family"]: round(row["avg_ic"], 4) for row in family_ic.to_dicts()}
+
+# %% [markdown]
+# ## Key Takeaways
+#
+# 1. **Skip-recent momentum** (12-1 and 6-1) is the most important literature-standard
+#    feature that was missing -- it avoids short-term reversal contamination
+# 2. **Cross-sectional ranks** limited to 3 primary features (ret_126d, sharpe_126d,
+#    vol_63d) to reduce multicollinearity
+# 3. **MA ratio proliferation** reduced from 8 to 3 (SMA 50/200, EMA 26)
+# 4. **Point-in-time eligibility** enforced on feature matrix -- no phantom ETFs
+#    inflating early-period cross-section breadth
+# 5. **SPY-TLT 63d correlation** added as cross-asset regime indicator
+# 6. **Yield curve z-score** provides continuous regime signal (better than binary)
+# 7. **IC evaluation with HAC + FDR** validates feature significance -- overlapping
+#    labels inflate naive t-stats; multiple testing further culls spurious features
+# 8. **Gap: regime dynamics**: Cross-sectional features capture relative
+#    positioning but not market-level regime shifts. Ch9 adds data-driven
+#    regime detection (HMM) and memory-preserving transforms (FFD) that
+#    complement the rule-based regime indicators here.
+#
+# **Next**: `04_temporal.py` fits HMM regimes and fractional differencing models.

--- a/case_studies/etfs/04_model_based_features.ipynb
+++ b/case_studies/etfs/04_model_based_features.ipynb
@@ -1,0 +1,1832 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "56613d1a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004031,
+     "end_time": "2026-03-24T02:03:45.938079+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:45.934048+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "# ETFs: Model-Based Features (Per-Fold Temporal Models)\n",
+    "\n",
+    "This notebook fits temporal models and extracts features that capture\n",
+    "latent market dynamics. All models are fit **per CV fold** on training\n",
+    "data only, eliminating parameter-level look-ahead bias. It produces\n",
+    "features for three model families:\n",
+    "\n",
+    "1. **HMM Regime Detection**: 2-state Gaussian HMM on aggregate market (SPY)\n",
+    "   with filtered (causal) probabilities, regime transition indicators, and\n",
+    "   regime duration features.\n",
+    "2. **Fractional Differencing**: Memory-preserving stationarity transforms\n",
+    "   on 10 reference ETFs spanning all major asset classes.\n",
+    "3. **GARCH(1,1) Conditional Volatility**: Per-ETF volatility forecasts that\n",
+    "   provide each asset's own risk dynamics.\n",
+    "\n",
+    "Each row in the output carries a `fold` column identifying which fold's\n",
+    "model produced it. This enables downstream CV to use the correct\n",
+    "(non-leaked) features for each fold.\n",
+    "\n",
+    "## Learning Objectives\n",
+    "\n",
+    "- Fit temporal models per CV fold to avoid parameter-level look-ahead\n",
+    "- Fit a 2-state HMM with k-means initialization and multiple restarts\n",
+    "- Compute filtered (not smoothed) probabilities for production use\n",
+    "- Derive regime transition and duration features from filtered probs\n",
+    "- Apply fractional differencing with fixed $d$ values by asset class\n",
+    "- Fit per-asset GARCH(1,1) with frozen-parameter filtering\n",
+    "- Combine date-level and per-asset features into a per-fold panel\n",
+    "\n",
+    "## Book Reference\n",
+    "\n",
+    "Chapter 9, Sections 9.1 (Fractional Differencing), 9.3 (GARCH), and\n",
+    "9.5 (Regime Features)\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- [`02_labels`](02_labels.ipynb) (produces label parquet files)\n",
+    "- `03_financial_features.py` (produces `features/financial.parquet`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5617b4d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:45.945084Z",
+     "iopub.status.busy": "2026-03-24T02:03:45.944992Z",
+     "iopub.status.idle": "2026-03-24T02:03:47.559470Z",
+     "shell.execute_reply": "2026-03-24T02:03:47.559098Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 1.618165,
+     "end_time": "2026-03-24T02:03:47.560107+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:45.941942+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/libraries/ml4t-engineer/src/ml4t/engineer/features/ml/__init__.py:9: UserWarning: Feature 'cyclical_encode': lookback=0 but has period/window parameter. Consider using lookback='period' or specifying the actual lookback.\n",
+      "  from ml4t.engineer.features.ml.cyclical_encode import *  # noqa: F403\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"ETFs: Model-Based Features (per-fold HMM + FFD + GARCH).\"\"\"\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import polars as pl\n",
+    "import yaml\n",
+    "from arch import arch_model\n",
+    "from hmmlearn.hmm import GaussianHMM\n",
+    "from ml4t.diagnostic.evaluation.stats import robust_ic\n",
+    "from ml4t.engineer.features.fdiff import ffdiff\n",
+    "from sklearn.cluster import KMeans\n",
+    "\n",
+    "from data import load_etfs\n",
+    "from utils.cv_splits import generate_cv_splits, load_evaluation_config\n",
+    "from utils.paths import get_case_study_dir\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5c611ee9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:47.564876Z",
+     "iopub.status.busy": "2026-03-24T02:03:47.564598Z",
+     "iopub.status.idle": "2026-03-24T02:03:47.566450Z",
+     "shell.execute_reply": "2026-03-24T02:03:47.566172Z"
+    },
+    "papermill": {
+     "duration": 0.004592,
+     "end_time": "2026-03-24T02:03:47.566726+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.562134+00:00",
+     "status": "completed"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Production defaults — Papermill injects overrides for CI\n",
+    "START_DATE = None  # None = use full dataset\n",
+    "N_RESTARTS = 10\n",
+    "GARCH_MIN_OBS = 504  # Minimum observations for GARCH fit (~2 years)\n",
+    "MAX_SYMBOLS = 0  # 0 = all symbols (production)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "37ed4132",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:47.571043Z",
+     "iopub.status.busy": "2026-03-24T02:03:47.570957Z",
+     "iopub.status.idle": "2026-03-24T02:03:47.595274Z",
+     "shell.execute_reply": "2026-03-24T02:03:47.594719Z"
+    },
+    "papermill": {
+     "duration": 0.027018,
+     "end_time": "2026-03-24T02:03:47.595605+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.568587+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prices: 470,662 rows, 100 assets\n"
+     ]
+    }
+   ],
+   "source": [
+    "CASE_DIR = get_case_study_dir(\"etfs\")\n",
+    "\n",
+    "prices = load_etfs()\n",
+    "print(f\"Prices: {len(prices):,} rows, {prices['symbol'].n_unique()} assets\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f50f04e9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001858,
+     "end_time": "2026-03-24T02:03:47.599637+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.597779+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## CV Fold Setup\n",
+    "\n",
+    "We load the walk-forward CV splits from `setup.yaml` and add a holdout\n",
+    "fold. All temporal models are fit per fold on training data only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e0fc5cf0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:47.604300Z",
+     "iopub.status.busy": "2026-03-24T02:03:47.604142Z",
+     "iopub.status.idle": "2026-03-24T02:03:47.611460Z",
+     "shell.execute_reply": "2026-03-24T02:03:47.610856Z"
+    },
+    "papermill": {
+     "duration": 0.010304,
+     "end_time": "2026-03-24T02:03:47.611785+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.601481+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SPY: 5,010 observations (2006-02-02 to 2025-12-31)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate CV splits\n",
+    "cv_splits = generate_cv_splits(prices, case_study_id=\"etfs\", label_buffer=\"21D\")\n",
+    "eval_config = load_evaluation_config(\"etfs\")\n",
+    "\n",
+    "# Add holdout fold: fit on all pre-holdout data, extract for holdout period\n",
+    "holdout_start = str(eval_config[\"holdout_start\"])\n",
+    "holdout_end = str(eval_config.get(\"holdout_end\", prices[\"timestamp\"].max()))\n",
+    "\n",
+    "# The last CV fold's val_end is the boundary before holdout\n",
+    "# For holdout, train on everything up to holdout_start\n",
+    "holdout_fold = {\n",
+    "    \"fold\": len(cv_splits),\n",
+    "    \"train_start\": cv_splits[0][\"train_start\"],\n",
+    "    \"train_end\": holdout_start,\n",
+    "    \"val_start\": holdout_start,\n",
+    "    \"val_end\": str(holdout_end),\n",
+    "}\n",
+    "all_folds = cv_splits + [holdout_fold]\n",
+    "\n",
+    "n_cv = len(cv_splits)\n",
+    "n_total = len(all_folds)\n",
+    "print(f\"CV folds: {n_cv}, plus holdout fold (fold {n_cv})\")\n",
+    "for fold in all_folds:\n",
+    "    label = \"HOLDOUT\" if fold[\"fold\"] == n_cv else f\"Fold {fold['fold']}\"\n",
+    "    print(\n",
+    "        f\"  {label}: train {fold['train_start']}..{fold['train_end']}, \"\n",
+    "        f\"val {fold['val_start']}..{fold['val_end']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e887a92",
+   "metadata": {},
+   "source": [
+    "## Part 1: HMM Regime Detection\n",
+    "\n",
+    "We fit a 2-state Gaussian HMM on SPY returns + volatility **per fold**.\n",
+    "The aggregate market drives regime classification; individual ETFs\n",
+    "inherit it.\n",
+    "\n",
+    "### Why SPY Only\n",
+    "\n",
+    "Using a single aggregate proxy (SPY) rather than per-asset HMMs:\n",
+    "- Avoids overfitting 100 independent HMMs\n",
+    "- Regime is a market-level phenomenon (risk-on/risk-off)\n",
+    "- All ETFs inherit the same regime state, ensuring cross-sectional consistency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43a97cfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spy_full = (\n",
+    "    prices.filter(pl.col(\"symbol\") == \"SPY\")\n",
+    "    .sort(\"timestamp\")\n",
+    "    .with_columns(\n",
+    "        log_ret=(pl.col(\"close\").log().diff() * 100),\n",
+    "        vol_21d=(pl.col(\"close\").log().diff().rolling_std(window_size=21) * 100 * np.sqrt(252)),\n",
+    "    )\n",
+    "    .drop_nulls()\n",
+    ")\n",
+    "\n",
+    "print(\n",
+    "    f\"SPY: {len(spy_full):,} observations ({spy_full['timestamp'].min()} to {spy_full['timestamp'].max()})\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e19853a",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00182,
+     "end_time": "2026-03-24T02:03:47.615604+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.613784+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### K-Means-Seeded HMM Fitting\n",
+    "\n",
+    "K-means clustering provides better initial emission parameters than random\n",
+    "initialization, reducing sensitivity to local optima."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e6d8c796",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:47.620042Z",
+     "iopub.status.busy": "2026-03-24T02:03:47.619854Z",
+     "iopub.status.idle": "2026-03-24T02:03:47.622581Z",
+     "shell.execute_reply": "2026-03-24T02:03:47.622155Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005436,
+     "end_time": "2026-03-24T02:03:47.622855+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:47.617419+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def fit_hmm_kmeans_init(X: np.ndarray, n_states: int, random_state: int = 42) -> GaussianHMM:\n",
+    "    \"\"\"Fit HMM with k-means-seeded initialization.\"\"\"\n",
+    "    kmeans = KMeans(n_clusters=n_states, random_state=random_state, n_init=10)\n",
+    "    kmeans.fit(X)\n",
+    "\n",
+    "    model = GaussianHMM(\n",
+    "        n_components=n_states,\n",
+    "        covariance_type=\"full\",\n",
+    "        n_iter=200,\n",
+    "        random_state=random_state,\n",
+    "        init_params=\"st\",  # Only init startprob and transmat\n",
+    "    )\n",
+    "\n",
+    "    model.means_ = kmeans.cluster_centers_\n",
+    "    model.covars_ = np.array(\n",
+    "        [np.cov(X[kmeans.labels_ == k].T) + np.eye(X.shape[1]) * 1e-6 for k in range(n_states)]\n",
+    "    )\n",
+    "\n",
+    "    model.fit(X)\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e79e549c",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006122,
+     "end_time": "2026-03-24T02:03:50.033381+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.027259+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Label Switching Prevention\n",
+    "\n",
+    "Sort states by variance (ascending) so State 0 is always \"low volatility\"\n",
+    "(calm) and State 1 is always \"high volatility\" (stressed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5ec3601c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.046736Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.046556Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.054166Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.053698Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.017851,
+     "end_time": "2026-03-24T02:03:50.057408+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.039557+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def sort_states_by_variance(model: GaussianHMM) -> np.ndarray:\n",
+    "    \"\"\"Sort HMM states by variance (ascending) for consistent labeling.\"\"\"\n",
+    "    variances = np.array([np.trace(model.covars_[k]) for k in range(model.n_components)])\n",
+    "    return np.argsort(variances)  # Low vol first\n",
+    "\n",
+    "\n",
+    "def relabel_states(states: np.ndarray, probs: np.ndarray, order: np.ndarray) -> tuple:\n",
+    "    \"\"\"Relabel states according to the given order.\"\"\"\n",
+    "    inv_order = np.argsort(order)\n",
+    "    new_states = inv_order[states]\n",
+    "    new_probs = probs[:, order]\n",
+    "    return new_states, new_probs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e78ae17",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006123,
+     "end_time": "2026-03-24T02:03:50.068749+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.062626+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Filtered Probabilities (No Look-Ahead)\n",
+    "\n",
+    "In production, we must use **filtered** probabilities $P(z_t | x_{1:t})$\n",
+    "which condition only on past and present observations. hmmlearn's\n",
+    "`predict_proba()` returns **smoothed** probabilities $P(z_t | x_{1:T})$\n",
+    "which use future data and would introduce look-ahead bias."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6fe164e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.082404Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.082220Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.089465Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.088796Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.014982,
+     "end_time": "2026-03-24T02:03:50.089814+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.074832+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def compute_filtered_probs(model: GaussianHMM, X: np.ndarray) -> np.ndarray:\n",
+    "    \"\"\"Compute filtered probabilities P(state_t | obs_{1:t}).\n",
+    "\n",
+    "    Uses the forward algorithm, then normalizes.\n",
+    "    \"\"\"\n",
+    "    framelogprob = model._compute_log_likelihood(X)\n",
+    "\n",
+    "    n_samples = X.shape[0]\n",
+    "    n_components = model.n_components\n",
+    "\n",
+    "    log_startprob = np.log(model.startprob_ + 1e-300)\n",
+    "    log_transmat = np.log(model.transmat_ + 1e-300)\n",
+    "\n",
+    "    # Forward pass (log-domain for numerical stability)\n",
+    "    fwdlattice = np.zeros((n_samples, n_components))\n",
+    "    fwdlattice[0] = log_startprob + framelogprob[0]\n",
+    "\n",
+    "    for t in range(1, n_samples):\n",
+    "        for j in range(n_components):\n",
+    "            fwdlattice[t, j] = framelogprob[t, j] + np.logaddexp.reduce(\n",
+    "                fwdlattice[t - 1] + log_transmat[:, j]\n",
+    "            )\n",
+    "\n",
+    "    # Normalize to get probabilities\n",
+    "    log_normalizer = np.logaddexp.reduce(fwdlattice, axis=1, keepdims=True)\n",
+    "    filtered = np.exp(fwdlattice - log_normalizer)\n",
+    "\n",
+    "    return filtered"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "007de7e7",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### Derive Regime Features from Filtered Probabilities\n",
+    "\n",
+    "From filtered probabilities, derive three feature types:\n",
+    "1. **regime_prob_stress**: Filtered probability of being in the high-vol state\n",
+    "2. **regime_transition**: Absolute change in stress probability (detects regime shifts)\n",
+    "3. **regime_duration**: Days since last regime change (persistence indicator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1f4b9131",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.096057Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.095887Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.175498Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.175099Z"
+    },
+    "papermill": {
+     "duration": 0.084884,
+     "end_time": "2026-03-24T02:03:50.177857+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.092973+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State 0 (Low-Vol): 69.0% of time, mean ret=0.072%, vol=10.9%\n",
+      "State 1 (High-Vol): 31.0% of time, mean ret=-0.030%, vol=27.3%\n"
+     ]
+    }
+   ],
+   "source": [
+    "def derive_regime_features(\n",
+    "    timestamps: pl.Series,\n",
+    "    filtered_probs: np.ndarray,\n",
+    "    states: np.ndarray,\n",
+    "    order: np.ndarray,\n",
+    ") -> pl.DataFrame:\n",
+    "    \"\"\"Derive regime features from HMM output for a single fold window.\"\"\"\n",
+    "    states_sorted, filtered_sorted = relabel_states(states, filtered_probs, order)\n",
+    "\n",
+    "    regime_prob_stress = filtered_sorted[:, 1]  # P(high-vol state)\n",
+    "\n",
+    "    # Transition: absolute 1-day change in stress probability\n",
+    "    regime_transition = np.abs(np.diff(regime_prob_stress, prepend=regime_prob_stress[0]))\n",
+    "\n",
+    "    # Duration: days since last regime change\n",
+    "    regime_duration = np.zeros(len(states_sorted))\n",
+    "    current_run = 0\n",
+    "    for i in range(len(states_sorted)):\n",
+    "        if i == 0 or states_sorted[i] != states_sorted[i - 1]:\n",
+    "            current_run = 1\n",
+    "        else:\n",
+    "            current_run += 1\n",
+    "        regime_duration[i] = current_run\n",
+    "\n",
+    "    return pl.DataFrame(\n",
+    "        {\n",
+    "            \"timestamp\": timestamps,\n",
+    "            \"regime_prob_stress\": regime_prob_stress,\n",
+    "            \"regime_transition\": regime_transition,\n",
+    "            \"regime_log_duration\": np.log1p(regime_duration),\n",
+    "        }\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b5896fe",
+   "metadata": {},
+   "source": [
+    "### Illustrative Full-Sample HMM Fit\n",
+    "\n",
+    "Before the per-fold loop, we fit one full-sample HMM for visualization\n",
+    "purposes only. This shows readers the regime overlay on SPY and validates\n",
+    "the methodology. **These features are NOT used in the saved output.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2d0e2a06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.194752Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.194620Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.201758Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.200960Z"
+    },
+    "papermill": {
+     "duration": 0.018249,
+     "end_time": "2026-03-24T02:03:50.202188+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.183939+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Transition matrix (rows=from, cols=to):\n",
+      "                  Calm    Stress\n",
+      "        Calm    0.9925    0.0075\n",
+      "      Stress    0.0166    0.9834\n",
+      "\n",
+      "Mean regime duration: calm=133d, stress=60d\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_STATES = 2\n",
+    "X_full = spy_full.select([\"log_ret\", \"vol_21d\"]).to_numpy()\n",
+    "\n",
+    "best_model_illustrative = None\n",
+    "best_ll = -np.inf\n",
+    "\n",
+    "for seed in range(N_RESTARTS):\n",
+    "    try:\n",
+    "        model = fit_hmm_kmeans_init(X_full, n_states=N_STATES, random_state=seed)\n",
+    "        ll = model.score(X_full)\n",
+    "        if ll > best_ll:\n",
+    "            best_ll = ll\n",
+    "            best_model_illustrative = model\n",
+    "    except Exception:\n",
+    "        continue\n",
+    "\n",
+    "print(f\"Illustrative full-sample HMM: best log-likelihood = {best_ll:.1f}\")\n",
+    "\n",
+    "order_illustrative = sort_states_by_variance(best_model_illustrative)\n",
+    "filtered_illustrative = compute_filtered_probs(best_model_illustrative, X_full)\n",
+    "states_illustrative = best_model_illustrative.predict(X_full)\n",
+    "states_sorted_ill, _ = relabel_states(\n",
+    "    states_illustrative, filtered_illustrative, order_illustrative\n",
+    ")\n",
+    "\n",
+    "for k in range(N_STATES):\n",
+    "    mask = states_sorted_ill == k\n",
+    "    label = \"Low-Vol\" if k == 0 else \"High-Vol\"\n",
+    "    mean_ret = X_full[mask, 0].mean()\n",
+    "    mean_vol = X_full[mask, 1].mean()\n",
+    "    pct = mask.mean()\n",
+    "    print(f\"State {k} ({label}): {pct:.1%} of time, mean ret={mean_ret:.3f}%, vol={mean_vol:.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9028209",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005464,
+     "end_time": "2026-03-24T02:03:50.215275+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.209811+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Regime Overlay on SPY (Illustrative)\n",
+    "\n",
+    "Shading stressed periods on SPY cumulative returns shows whether the HMM\n",
+    "captures known market episodes (GFC, COVID, 2022 rate shock)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f1e8a49b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.233293Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.233169Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.301461Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.300716Z"
+    },
+    "papermill": {
+     "duration": 0.077028,
+     "end_time": "2026-03-24T02:03:50.302153+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.225125+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spy_cum = spy_full.with_columns(cum_ret=(pl.col(\"close\") / pl.col(\"close\").first() - 1) * 100)\n",
+    "\n",
+    "fig_regime, ax = plt.subplots(figsize=(12, 5))\n",
+    "dates = spy_cum[\"timestamp\"].to_numpy()\n",
+    "cum_ret = spy_cum[\"cum_ret\"].to_numpy()\n",
+    "ax.plot(dates, cum_ret, linewidth=0.8, color=\"0.3\")\n",
+    "\n",
+    "# Shade stressed periods\n",
+    "stressed = states_sorted_ill == 1\n",
+    "in_stress = False\n",
+    "start = None\n",
+    "for i in range(len(stressed)):\n",
+    "    if stressed[i] and not in_stress:\n",
+    "        start = dates[i]\n",
+    "        in_stress = True\n",
+    "    elif not stressed[i] and in_stress:\n",
+    "        ax.axvspan(start, dates[i], alpha=0.15, color=\"red\", linewidth=0)\n",
+    "        in_stress = False\n",
+    "if in_stress:\n",
+    "    ax.axvspan(start, dates[-1], alpha=0.15, color=\"red\", linewidth=0)\n",
+    "\n",
+    "ax.set_ylabel(\"Cumulative Return (%)\")\n",
+    "ax.set_title(\"SPY with HMM Stress Regimes (full-sample illustrative)\")\n",
+    "fig_regime.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a292625",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002015,
+     "end_time": "2026-03-24T02:03:50.307431+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.305416+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Per-Fold HMM Fitting\n",
+    "\n",
+    "For each fold, we fit the HMM on **training data only**, then apply the\n",
+    "forward algorithm to the full fold window (train_start through val_end)\n",
+    "for filtered probabilities. The model parameters $\\theta$ are estimated\n",
+    "exclusively from training observations, eliminating parameter-level\n",
+    "look-ahead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c847797c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hmm_fold_results = []\n",
+    "\n",
+    "for fold in all_folds:\n",
+    "    fold_idx = fold[\"fold\"]\n",
+    "    train_start, train_end = fold[\"train_start\"], fold[\"train_end\"]\n",
+    "    val_end = fold[\"val_end\"]\n",
+    "\n",
+    "    # Training data: fit HMM parameters\n",
+    "    spy_train = spy_full.filter(\n",
+    "        (pl.col(\"timestamp\") >= pl.lit(train_start).cast(pl.Date))\n",
+    "        & (pl.col(\"timestamp\") < pl.lit(train_end).cast(pl.Date))\n",
+    "    )\n",
+    "    X_train = spy_train.select([\"log_ret\", \"vol_21d\"]).to_numpy()\n",
+    "\n",
+    "    if len(X_train) < 252:\n",
+    "        print(\n",
+    "            f\"  Fold {fold_idx}: insufficient SPY training data ({len(X_train)} obs), skipping HMM\"\n",
+    "        )\n",
+    "        continue\n",
+    "\n",
+    "    # Fit HMM with multiple restarts on training data\n",
+    "    best_fold_model = None\n",
+    "    best_fold_ll = -np.inf\n",
+    "    for seed in range(N_RESTARTS):\n",
+    "        try:\n",
+    "            m = fit_hmm_kmeans_init(X_train, n_states=N_STATES, random_state=seed)\n",
+    "            ll = m.score(X_train)\n",
+    "            if ll > best_fold_ll:\n",
+    "                best_fold_ll = ll\n",
+    "                best_fold_model = m\n",
+    "        except Exception:\n",
+    "            continue\n",
+    "\n",
+    "    if best_fold_model is None:\n",
+    "        print(f\"  Fold {fold_idx}: HMM fitting failed\")\n",
+    "        continue\n",
+    "\n",
+    "    order = sort_states_by_variance(best_fold_model)\n",
+    "\n",
+    "    # Full fold window (train_start through val_end) for filtered probs\n",
+    "    spy_fold = spy_full.filter(\n",
+    "        (pl.col(\"timestamp\") >= pl.lit(train_start).cast(pl.Date))\n",
+    "        & (pl.col(\"timestamp\") <= pl.lit(val_end).cast(pl.Date))\n",
+    "    )\n",
+    "    X_fold = spy_fold.select([\"log_ret\", \"vol_21d\"]).to_numpy()\n",
+    "\n",
+    "    filtered = compute_filtered_probs(best_fold_model, X_fold)\n",
+    "    states = best_fold_model.predict(X_fold)\n",
+    "\n",
+    "    regime_df = derive_regime_features(spy_fold[\"timestamp\"], filtered, states, order)\n",
+    "    regime_df = regime_df.with_columns(pl.lit(fold_idx).alias(\"fold\"))\n",
+    "\n",
+    "    hmm_fold_results.append(regime_df)\n",
+    "    print(\n",
+    "        f\"  Fold {fold_idx}: HMM LL={best_fold_ll:.1f}, {len(regime_df)} dates, \"\n",
+    "        f\"stress={regime_df['regime_prob_stress'].mean():.3f}\"\n",
+    "    )\n",
+    "\n",
+    "hmm_features = (\n",
+    "    pl.concat(hmm_fold_results)\n",
+    "    if hmm_fold_results\n",
+    "    else pl.DataFrame(schema={\"timestamp\": pl.Date, \"fold\": pl.Int64})\n",
+    ")\n",
+    "n_hmm_folds = hmm_features[\"fold\"].n_unique() if len(hmm_features) > 0 else 0\n",
+    "print(f\"\\nHMM features: {len(hmm_features):,} rows across {n_hmm_folds} folds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b496f76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001928,
+     "end_time": "2026-03-24T02:03:50.311483+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.309555+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Part 2: Fractional Differencing (Per Fold)\n",
+    "\n",
+    "Fractional differencing preserves long-range memory while achieving\n",
+    "stationarity. We apply fixed $d$ values by asset class to 10 reference\n",
+    "ETFs spanning all major asset classes in our universe.\n",
+    "\n",
+    "**Why fixed $d$?** Using pre-specified $d$ values avoids parameter estimation\n",
+    "lookahead entirely -- no data-dependent optimization, so the transform is\n",
+    "purely mechanical. We still compute per fold so each fold window gets a\n",
+    "clean series starting from its own `train_start`.\n",
+    "\n",
+    "| Asset Class     | Reference ETFs | $d$ |\n",
+    "|-----------------|---------------|-----|\n",
+    "| US Equities     | SPY, QQQ, IWM | 0.4 |\n",
+    "| Int'l Equities  | EFA, EEM      | 0.4 |\n",
+    "| Fixed Income    | TLT           | 0.5 |\n",
+    "| Gold            | GLD           | 0.4 |\n",
+    "| Real Estate     | VNQ           | 0.4 |\n",
+    "| High Yield      | HYG           | 0.5 |\n",
+    "| Inv. Grade      | LQD           | 0.5 |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7c5aae31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.333922Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.333758Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.336571Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.336064Z"
+    },
+    "papermill": {
+     "duration": 0.005888,
+     "end_time": "2026-03-24T02:03:50.336883+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.330995+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "REFERENCE_ETFS = {\n",
+    "    \"SPY\": 0.4,  # US large-cap equities\n",
+    "    \"QQQ\": 0.4,  # US tech equities\n",
+    "    \"IWM\": 0.4,  # US small-cap equities\n",
+    "    \"EFA\": 0.4,  # International developed\n",
+    "    \"EEM\": 0.4,  # Emerging markets\n",
+    "    \"TLT\": 0.5,  # Long-term treasuries\n",
+    "    \"GLD\": 0.4,  # Gold\n",
+    "    \"VNQ\": 0.4,  # Real estate\n",
+    "    \"HYG\": 0.5,  # High yield bonds\n",
+    "    \"LQD\": 0.5,  # Investment grade bonds\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdeb7b24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001931,
+     "end_time": "2026-03-24T02:03:50.340958+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.339027+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Per-Fold FFD Application\n",
+    "\n",
+    "For each fold, apply fractional differencing to the fold window\n",
+    "(train_start through val_end). The FFD filter uses a fixed-width window\n",
+    "of historical weights, so it only needs a warmup period at the start --\n",
+    "no fitting is involved. Computing per fold ensures the warmup loss\n",
+    "does not leak information across fold boundaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "fb2891a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.345376Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.345289Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.515022Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.514577Z"
+    },
+    "papermill": {
+     "duration": 0.172458,
+     "end_time": "2026-03-24T02:03:50.515343+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.342885+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SPY (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  QQQ (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  IWM (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  EFA (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  EEM (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  TLT (d=0.5): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  GLD (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  VNQ (d=0.4): 5,031 valid / 5,031 total (warmup=0)\n",
+      "  HYG (d=0.5): 4,713 valid / 4,713 total (warmup=0)\n",
+      "  LQD (d=0.5): 5,031 valid / 5,031 total (warmup=0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ffd_fold_results = []\n",
+    "\n",
+    "for fold in all_folds:\n",
+    "    fold_idx = fold[\"fold\"]\n",
+    "    train_start = fold[\"train_start\"]\n",
+    "    val_end = fold[\"val_end\"]\n",
+    "\n",
+    "    fold_frames = []\n",
+    "    for symbol, d in REFERENCE_ETFS.items():\n",
+    "        etf = (\n",
+    "            prices.filter(\n",
+    "                (pl.col(\"symbol\") == symbol)\n",
+    "                & (pl.col(\"timestamp\") >= pl.lit(train_start).cast(pl.Date))\n",
+    "                & (pl.col(\"timestamp\") <= pl.lit(val_end).cast(pl.Date))\n",
+    "            )\n",
+    "            .sort(\"timestamp\")\n",
+    "            .select([\"timestamp\", \"close\"])\n",
+    "        )\n",
+    "\n",
+    "        if len(etf) == 0:\n",
+    "            continue\n",
+    "\n",
+    "        log_close = etf[\"close\"].log()\n",
+    "        ffd_series = ffdiff(log_close, d=d)\n",
+    "\n",
+    "        ffd_df = pl.DataFrame(\n",
+    "            {\n",
+    "                \"timestamp\": etf[\"timestamp\"],\n",
+    "                f\"ffd_{symbol.lower()}\": ffd_series,\n",
+    "            }\n",
+    "        ).drop_nulls()\n",
+    "\n",
+    "        fold_frames.append(ffd_df)\n",
+    "\n",
+    "    if fold_frames:\n",
+    "        ffd_fold = fold_frames[0]\n",
+    "        for df in fold_frames[1:]:\n",
+    "            ffd_fold = ffd_fold.join(df, on=\"timestamp\", how=\"outer_coalesce\")\n",
+    "        ffd_fold = ffd_fold.sort(\"timestamp\").with_columns(pl.lit(fold_idx).alias(\"fold\"))\n",
+    "        ffd_fold_results.append(ffd_fold)\n",
+    "        ffd_cols = [c for c in ffd_fold.columns if c.startswith(\"ffd_\")]\n",
+    "        print(f\"  Fold {fold_idx}: FFD {len(ffd_cols)} series, {len(ffd_fold):,} dates\")\n",
+    "    else:\n",
+    "        print(f\"  Fold {fold_idx}: no FFD series produced (no qualifying ETFs)\")\n",
+    "\n",
+    "ffd_features = pl.concat(ffd_fold_results) if ffd_fold_results else pl.DataFrame()\n",
+    "ffd_col_names = [c for c in ffd_features.columns if c.startswith(\"ffd_\")]\n",
+    "print(f\"\\nFFD features: {len(ffd_col_names)} series, {len(ffd_features):,} rows across folds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dae312b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00256,
+     "end_time": "2026-03-24T02:03:50.520153+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.517593+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Part 3: Per-ETF GARCH(1,1) (Per Fold)\n",
+    "\n",
+    "For each fold, fit GARCH(1,1) on each ETF's **training returns**, then\n",
+    "use `model.fix(params)` to run the variance recursion on the full fold\n",
+    "window (train through val_end) without re-estimating parameters. This\n",
+    "is the **fit-then-filter** paradigm: parameters come from training only,\n",
+    "but conditional volatility is computed for every date in the window.\n",
+    "\n",
+    "The `fix()` method applies frozen parameters to a new data series,\n",
+    "producing a causal conditional volatility path $\\sigma_t$ that depends\n",
+    "only on past returns given the frozen parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8e987fff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.527379Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.527269Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.546354Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.545327Z"
+    },
+    "papermill": {
+     "duration": 0.02357,
+     "end_time": "2026-03-24T02:03:50.547016+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.523446+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "FFD features: 10 series, 5,031 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_symbols = sorted(prices[\"symbol\"].unique().to_list())\n",
+    "if MAX_SYMBOLS > 0:\n",
+    "    all_symbols = all_symbols[:MAX_SYMBOLS]\n",
+    "\n",
+    "print(f\"Fitting GARCH(1,1) on {len(all_symbols)} ETFs across {len(all_folds)} folds...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "252c615f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fit_garch_fold(\n",
+    "    prices_df: pl.DataFrame,\n",
+    "    symbols: list[str],\n",
+    "    fold: dict,\n",
+    "    min_obs: int,\n",
+    ") -> pl.DataFrame:\n",
+    "    \"\"\"Fit GARCH(1,1) per symbol for one fold.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    prices_df : pl.DataFrame\n",
+    "        Full prices panel with timestamp, symbol, close columns.\n",
+    "    symbols : list[str]\n",
+    "        Symbols to fit.\n",
+    "    fold : dict\n",
+    "        Fold dict with train_start, train_end, val_end keys.\n",
+    "    min_obs : int\n",
+    "        Minimum training observations for GARCH fit.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pl.DataFrame\n",
+    "        Conditional volatility for the full fold window with fold column.\n",
+    "    \"\"\"\n",
+    "    fold_idx = fold[\"fold\"]\n",
+    "    train_start = fold[\"train_start\"]\n",
+    "    train_end = fold[\"train_end\"]\n",
+    "    val_end = fold[\"val_end\"]\n",
+    "\n",
+    "    results = []\n",
+    "    n_success = 0\n",
+    "    n_fail = 0\n",
+    "\n",
+    "    for sym in symbols:\n",
+    "        # Get full fold window data (train_start through val_end)\n",
+    "        sym_data = (\n",
+    "            prices_df.filter(\n",
+    "                (pl.col(\"symbol\") == sym)\n",
+    "                & (pl.col(\"timestamp\") >= pl.lit(train_start).cast(pl.Date))\n",
+    "                & (pl.col(\"timestamp\") <= pl.lit(val_end).cast(pl.Date))\n",
+    "            )\n",
+    "            .sort(\"timestamp\")\n",
+    "            .with_columns(ret=pl.col(\"close\").pct_change())\n",
+    "            .drop_nulls(subset=[\"ret\"])\n",
+    "        )\n",
+    "\n",
+    "        # Training returns only\n",
+    "        train_data = sym_data.filter(pl.col(\"timestamp\") < pl.lit(train_end).cast(pl.Date))\n",
+    "\n",
+    "        if len(train_data) < min_obs:\n",
+    "            n_fail += 1\n",
+    "            continue\n",
+    "\n",
+    "        train_returns_pct = (train_data[\"ret\"] * 100).to_numpy()\n",
+    "\n",
+    "        try:\n",
+    "            # Fit on training data\n",
+    "            train_model = arch_model(\n",
+    "                train_returns_pct,\n",
+    "                mean=\"Constant\",\n",
+    "                vol=\"GARCH\",\n",
+    "                p=1,\n",
+    "                q=1,\n",
+    "                dist=\"Normal\",\n",
+    "            )\n",
+    "            train_result = train_model.fit(disp=\"off\", show_warning=False)\n",
+    "\n",
+    "            # Apply frozen parameters to full fold window\n",
+    "            full_returns_pct = (sym_data[\"ret\"] * 100).to_numpy()\n",
+    "            full_model = arch_model(\n",
+    "                full_returns_pct,\n",
+    "                mean=\"Constant\",\n",
+    "                vol=\"GARCH\",\n",
+    "                p=1,\n",
+    "                q=1,\n",
+    "                dist=\"Normal\",\n",
+    "            )\n",
+    "            filtered = full_model.fix(train_result.params)\n",
+    "\n",
+    "            # Annualized conditional vol (input is in % daily)\n",
+    "            cond_vol_ann = filtered.conditional_volatility * np.sqrt(252) / 100\n",
+    "\n",
+    "            sym_result = pl.DataFrame(\n",
+    "                {\n",
+    "                    \"timestamp\": sym_data[\"timestamp\"].to_list(),\n",
+    "                    \"symbol\": [sym] * len(sym_data),\n",
+    "                    \"garch_cond_vol\": cond_vol_ann,\n",
+    "                    \"fold\": [fold_idx] * len(sym_data),\n",
+    "                }\n",
+    "            ).drop_nulls()\n",
+    "\n",
+    "            if len(sym_result) > 0:\n",
+    "                results.append(sym_result)\n",
+    "                n_success += 1\n",
+    "        except Exception:\n",
+    "            n_fail += 1\n",
+    "\n",
+    "    print(f\"  Fold {fold_idx} GARCH: {n_success}/{len(symbols)} fitted, {n_fail} failed/skipped\")\n",
+    "    return pl.concat(results) if results else pl.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb6992ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "garch_fold_results = []\n",
+    "\n",
+    "for fold in all_folds:\n",
+    "    garch_fold = fit_garch_fold(prices, all_symbols, fold, GARCH_MIN_OBS)\n",
+    "    if len(garch_fold) > 0:\n",
+    "        garch_fold_results.append(garch_fold)\n",
+    "\n",
+    "garch_df = pl.concat(garch_fold_results) if garch_fold_results else pl.DataFrame()\n",
+    "garch_cols = [\"garch_cond_vol\"]\n",
+    "\n",
+    "if len(garch_df) > 0:\n",
+    "    n_syms = garch_df[\"symbol\"].n_unique()\n",
+    "    print(\n",
+    "        f\"\\nGARCH features: {len(garch_df):,} rows, {n_syms} assets, {garch_df['fold'].n_unique()} folds\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"  Conditional vol: mean={garch_df['garch_cond_vol'].mean():.3f}, \"\n",
+    "        f\"std={garch_df['garch_cond_vol'].std():.3f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3becf69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002708,
+     "end_time": "2026-03-24T02:03:50.553562+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.550854+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Part 4: Combine and Broadcast to Per-Fold Panel\n",
+    "\n",
+    "HMM regime features and FFD features are date-level (one value per day\n",
+    "shared by all ETFs). GARCH features are per-asset. For each fold, we\n",
+    "broadcast date-level features to all symbols and join with per-asset\n",
+    "GARCH features, producing a `(fold, timestamp, symbol)` panel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1e898785",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:50.558106Z",
+     "iopub.status.busy": "2026-03-24T02:03:50.557983Z",
+     "iopub.status.idle": "2026-03-24T02:03:50.562863Z",
+     "shell.execute_reply": "2026-03-24T02:03:50.562518Z"
+    },
+    "papermill": {
+     "duration": 0.007487,
+     "end_time": "2026-03-24T02:03:50.563099+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:50.555612+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting GARCH(1,1) on 100 ETFs...\n"
+     ]
+    }
+   ],
+   "source": [
+    "fold_panels = []\n",
+    "\n",
+    "for fold in all_folds:\n",
+    "    fold_idx = fold[\"fold\"]\n",
+    "    train_start = fold[\"train_start\"]\n",
+    "    val_end = fold[\"val_end\"]\n",
+    "\n",
+    "    # Get panel skeleton for this fold's date range\n",
+    "    fold_skeleton = (\n",
+    "        prices.filter(\n",
+    "            (pl.col(\"timestamp\") >= pl.lit(train_start).cast(pl.Date))\n",
+    "            & (pl.col(\"timestamp\") <= pl.lit(val_end).cast(pl.Date))\n",
+    "        )\n",
+    "        .select([\"timestamp\", \"symbol\"])\n",
+    "        .unique()\n",
+    "        .sort([\"timestamp\", \"symbol\"])\n",
+    "        .with_columns(pl.lit(fold_idx).alias(\"fold\"))\n",
+    "    )\n",
+    "\n",
+    "    # Get date-level features for this fold\n",
+    "    fold_hmm = (\n",
+    "        hmm_features.filter(pl.col(\"fold\") == fold_idx).drop(\"fold\")\n",
+    "        if len(hmm_features) > 0\n",
+    "        else pl.DataFrame()\n",
+    "    )\n",
+    "    fold_ffd = (\n",
+    "        ffd_features.filter(pl.col(\"fold\") == fold_idx).drop(\"fold\")\n",
+    "        if len(ffd_features) > 0\n",
+    "        else pl.DataFrame()\n",
+    "    )\n",
+    "\n",
+    "    # Combine date-level features\n",
+    "    if len(fold_hmm) > 0 and len(fold_ffd) > 0:\n",
+    "        date_level = fold_hmm.join(fold_ffd, on=\"timestamp\", how=\"outer_coalesce\")\n",
+    "    elif len(fold_hmm) > 0:\n",
+    "        date_level = fold_hmm\n",
+    "    elif len(fold_ffd) > 0:\n",
+    "        date_level = fold_ffd\n",
+    "    else:\n",
+    "        date_level = pl.DataFrame()\n",
+    "\n",
+    "    # Broadcast date-level features to all assets\n",
+    "    if len(date_level) > 0:\n",
+    "        panel = fold_skeleton.join(date_level, on=\"timestamp\", how=\"left\")\n",
+    "    else:\n",
+    "        panel = fold_skeleton\n",
+    "\n",
+    "    # Join per-asset GARCH features\n",
+    "    if len(garch_df) > 0:\n",
+    "        fold_garch = garch_df.filter(pl.col(\"fold\") == fold_idx).drop(\"fold\")\n",
+    "        panel = panel.join(fold_garch, on=[\"timestamp\", \"symbol\"], how=\"left\")\n",
+    "\n",
+    "    fold_panels.append(panel)\n",
+    "\n",
+    "temporal = pl.concat(fold_panels).sort([\"fold\", \"timestamp\", \"symbol\"])\n",
+    "\n",
+    "temporal_cols = [c for c in temporal.columns if c not in (\"timestamp\", \"symbol\", \"fold\")]\n",
+    "print(f\"Combined model-based features: {len(temporal_cols)} columns, {len(temporal):,} rows\")\n",
+    "print(f\"  Assets: {temporal['symbol'].n_unique()}, Folds: {temporal['fold'].n_unique()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fec8bad",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002072,
+     "end_time": "2026-03-24T02:03:52.465075+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.463003+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Quality Check\n",
+    "\n",
+    "Verify that temporal features have reasonable coverage and distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "5e87a8dc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:52.469693Z",
+     "iopub.status.busy": "2026-03-24T02:03:52.469612Z",
+     "iopub.status.idle": "2026-03-24T02:03:52.480274Z",
+     "shell.execute_reply": "2026-03-24T02:03:52.479949Z"
+    },
+    "papermill": {
+     "duration": 0.013348,
+     "end_time": "2026-03-24T02:03:52.480584+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.467236+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  regime_prob_stress            : 469,423/470,662 valid, mean=0.3186, std=0.4508\n",
+      "  regime_transition             : 469,423/470,662 valid, mean=0.0199, std=0.0803\n",
+      "  regime_log_duration           : 469,423/470,662 valid, mean=4.2489, std=1.3018\n",
+      "  ffd_spy                       : 470,662/470,662 valid, mean=0.2299, std=0.0967\n",
+      "  ffd_qqq                       : 470,662/470,662 valid, mean=0.2126, std=0.0785\n",
+      "  ffd_iwm                       : 470,662/470,662 valid, mean=0.2014, std=0.0876\n",
+      "  ffd_efa                       : 470,662/470,662 valid, mean=0.1664, std=0.0807\n",
+      "  ffd_eem                       : 470,662/470,662 valid, mean=0.1490, std=0.0720\n",
+      "  ffd_tlt                       : 470,662/470,662 valid, mean=0.0936, std=0.0655\n",
+      "  ffd_gld                       : 470,662/470,662 valid, mean=0.2111, std=0.0878\n",
+      "  ffd_vnq                       : 470,662/470,662 valid, mean=0.1685, std=0.0757\n",
+      "  ffd_hyg                       : 449,008/470,662 valid, mean=0.0867, std=0.0669\n",
+      "  ffd_lqd                       : 470,662/470,662 valid, mean=0.0934, std=0.0646\n",
+      "  garch_cond_vol                : 470,562/470,662 valid, mean=0.1891, std=0.1325\n"
+     ]
+    }
+   ],
+   "source": [
+    "for col in temporal_cols:\n",
+    "    valid = temporal[col].drop_nulls().len()\n",
+    "    total = len(temporal)\n",
+    "    mean = temporal[col].drop_nulls().mean()\n",
+    "    std = temporal[col].drop_nulls().std()\n",
+    "    print(f\"  {col:30s}: {valid:,}/{total:,} valid, mean={mean:.4f}, std={std:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6342476d",
+   "metadata": {},
+   "source": [
+    "### Per-Fold Feature Stability\n",
+    "\n",
+    "Check that HMM and GARCH features are stable across folds (model\n",
+    "parameters should not drift drastically with overlapping training windows)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bf3d031",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"\\nPer-fold feature means:\")\n",
+    "fold_summary = (\n",
+    "    temporal.group_by(\"fold\")\n",
+    "    .agg([pl.col(c).mean().alias(f\"mean_{c}\") for c in temporal_cols])\n",
+    "    .sort(\"fold\")\n",
+    ")\n",
+    "print(fold_summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2cbdaa8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002126,
+     "end_time": "2026-03-24T02:03:52.484919+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.482793+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Save Artifacts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "1e44e1fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:52.489483Z",
+     "iopub.status.busy": "2026-03-24T02:03:52.489397Z",
+     "iopub.status.idle": "2026-03-24T02:03:52.517320Z",
+     "shell.execute_reply": "2026-03-24T02:03:52.516978Z"
+    },
+    "papermill": {
+     "duration": 0.03081,
+     "end_time": "2026-03-24T02:03:52.517722+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.486912+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved: /tmp/ml4t-test-output/etfs/features/model_based.parquet (470,662 rows, 14 features)\n"
+     ]
+    }
+   ],
+   "source": [
+    "FEATURES_DIR = CASE_DIR / \"features\"\n",
+    "\n",
+    "FEATURES_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "temporal.write_parquet(FEATURES_DIR / \"model_based.parquet\")\n",
+    "print(\n",
+    "    f\"Saved: {FEATURES_DIR / 'model_based.parquet'} \"\n",
+    "    f\"({len(temporal):,} rows, {len(temporal_cols)} features + fold column)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb8549b5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002027,
+     "end_time": "2026-03-24T02:03:52.521952+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.519925+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Incremental Evaluation\n",
+    "\n",
+    "Evaluate feature quality using **validation-period data only** from each\n",
+    "fold. We compute cross-sectional Spearman IC for per-asset features and\n",
+    "time-series IC for date-level features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "74abfbab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:52.526441Z",
+     "iopub.status.busy": "2026-03-24T02:03:52.526364Z",
+     "iopub.status.idle": "2026-03-24T02:03:52.562802Z",
+     "shell.execute_reply": "2026-03-24T02:03:52.562474Z"
+    },
+    "papermill": {
+     "duration": 0.039265,
+     "end_time": "2026-03-24T02:03:52.563204+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.523939+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evaluation panel: 468,562 rows, 100 assets\n"
+     ]
+    }
+   ],
+   "source": [
+    "labels = pl.read_parquet(CASE_DIR / \"labels\" / \"fwd_ret_21d.parquet\")\n",
+    "label_col = \"fwd_ret_21d\"\n",
+    "\n",
+    "# Only evaluate on validation periods (not training periods)\n",
+    "val_rows = []\n",
+    "for fold in all_folds:\n",
+    "    fold_idx = fold[\"fold\"]\n",
+    "    val_start = fold[\"val_start\"]\n",
+    "    val_end = fold[\"val_end\"]\n",
+    "    fold_val = temporal.filter(\n",
+    "        (pl.col(\"fold\") == fold_idx)\n",
+    "        & (pl.col(\"timestamp\") >= pl.lit(val_start).cast(pl.Date))\n",
+    "        & (pl.col(\"timestamp\") <= pl.lit(val_end).cast(pl.Date))\n",
+    "    )\n",
+    "    val_rows.append(fold_val)\n",
+    "\n",
+    "val_temporal = pl.concat(val_rows) if val_rows else temporal\n",
+    "\n",
+    "eval_df = val_temporal.join(labels, on=[\"timestamp\", \"symbol\"], how=\"inner\").drop_nulls(\n",
+    "    subset=[label_col]\n",
+    ")\n",
+    "print(\n",
+    "    f\"Evaluation panel (val periods only): {len(eval_df):,} rows, {eval_df['symbol'].n_unique()} assets\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61a3a148",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002063,
+     "end_time": "2026-03-24T02:03:52.567487+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.565424+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Cross-Sectional IC for Per-Asset Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "0e0428ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:52.572018Z",
+     "iopub.status.busy": "2026-03-24T02:03:52.571930Z",
+     "iopub.status.idle": "2026-03-24T02:03:53.663229Z",
+     "shell.execute_reply": "2026-03-24T02:03:53.662789Z"
+    },
+    "papermill": {
+     "duration": 1.094134,
+     "end_time": "2026-03-24T02:03:53.663620+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:52.569486+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "temporal_ic = {}\n",
+    "\n",
+    "# Per-asset features: cross-sectional IC (rank correlation per date)\n",
+    "per_asset_features = [c for c in temporal_cols if c in garch_cols]\n",
+    "date_level_features = [c for c in temporal_cols if c not in garch_cols]\n",
+    "\n",
+    "for feat in per_asset_features:\n",
+    "    ic_series = (\n",
+    "        eval_df.filter(pl.col(feat).is_not_null())\n",
+    "        .with_columns(\n",
+    "            pl.col(feat).rank(method=\"average\").over(\"timestamp\").alias(\"_feat_rank\"),\n",
+    "            pl.col(label_col).rank(method=\"average\").over(\"timestamp\").alias(\"_label_rank\"),\n",
+    "        )\n",
+    "        .group_by(\"timestamp\")\n",
+    "        .agg(pl.corr(\"_feat_rank\", \"_label_rank\").alias(\"ic\"))\n",
+    "        .sort(\"timestamp\")\n",
+    "    )\n",
+    "    ics = ic_series[\"ic\"].drop_nulls().to_numpy()\n",
+    "    if len(ics) > 50:\n",
+    "        temporal_ic[feat] = {\n",
+    "            \"ic\": float(np.nanmean(ics)),\n",
+    "            \"t_stat\": float(np.nanmean(ics) / (np.nanstd(ics) / np.sqrt(len(ics)))),\n",
+    "            \"p_value\": None,\n",
+    "            \"bootstrap_std\": float(np.nanstd(ics)),\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d788e06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002077,
+     "end_time": "2026-03-24T02:03:53.667948+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:53.665871+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### Time-Series IC for Date-Level Features\n",
+    "\n",
+    "Date-level features (HMM, FFD) are identical across symbols on each date,\n",
+    "so cross-sectional IC is zero by construction. We evaluate them via\n",
+    "time-series correlation with the cross-sectional average return."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "b3a443e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:03:53.672483Z",
+     "iopub.status.busy": "2026-03-24T02:03:53.672395Z",
+     "iopub.status.idle": "2026-03-24T02:04:29.183354Z",
+     "shell.execute_reply": "2026-03-24T02:04:29.182944Z"
+    },
+    "papermill": {
+     "duration": 35.514016,
+     "end_time": "2026-03-24T02:04:29.183974+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:03:53.669958+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "avg_ret = (\n",
+    "    eval_df.group_by(\"timestamp\")\n",
+    "    .agg(pl.col(label_col).mean().alias(\"avg_fwd_ret\"))\n",
+    "    .sort(\"timestamp\")\n",
+    ")\n",
+    "\n",
+    "date_features = (\n",
+    "    val_temporal.select([\"timestamp\"] + date_level_features)\n",
+    "    .unique(subset=[\"timestamp\"])\n",
+    "    .sort(\"timestamp\")\n",
+    ")\n",
+    "eval_ts = date_features.join(avg_ret, on=\"timestamp\", how=\"inner\").drop_nulls()\n",
+    "\n",
+    "for feat in date_level_features:\n",
+    "    x = eval_ts[feat].to_numpy()\n",
+    "    y = eval_ts[\"avg_fwd_ret\"].to_numpy()\n",
+    "    valid = ~(np.isnan(x) | np.isnan(y))\n",
+    "    if valid.sum() < 50:\n",
+    "        continue\n",
+    "    result = robust_ic(x[valid], y[valid], return_details=True)\n",
+    "    temporal_ic[feat] = result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "a68bb556",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-24T02:04:29.188873Z",
+     "iopub.status.busy": "2026-03-24T02:04:29.188784Z",
+     "iopub.status.idle": "2026-03-24T02:04:29.191283Z",
+     "shell.execute_reply": "2026-03-24T02:04:29.191004Z"
+    },
+    "papermill": {
+     "duration": 0.00524,
+     "end_time": "2026-03-24T02:04:29.191502+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:04:29.186262+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Model-Based Feature Evaluation:\n",
+      "shape: (14, 5)\n",
+      "┌────────────────────┬───────────┬───────────┬─────────┬──────────────┐\n",
+      "│ feature            ┆ ic        ┆ t_stat    ┆ p_value ┆ bootstrap_se │\n",
+      "│ ---                ┆ ---       ┆ ---       ┆ ---     ┆ ---          │\n",
+      "│ str                ┆ f64       ┆ f64       ┆ f64     ┆ f64          │\n",
+      "╞════════════════════╪═══════════╪═══════════╪═════════╪══════════════╡\n",
+      "│ regime_prob_stress ┆ 0.169398  ┆ 2.807827  ┆ 0.0     ┆ 0.060331     │\n",
+      "│ ffd_tlt            ┆ 0.070389  ┆ 1.541184  ┆ 0.114   ┆ 0.045672     │\n",
+      "│ ffd_lqd            ┆ 0.066419  ┆ 1.324522  ┆ 0.139   ┆ 0.050146     │\n",
+      "│ garch_cond_vol     ┆ 0.051639  ┆ 9.646657  ┆ null    ┆ 0.37886      │\n",
+      "│ ffd_gld            ┆ 0.044882  ┆ 0.797033  ┆ 0.386   ┆ 0.056311     │\n",
+      "│ …                  ┆ …         ┆ …         ┆ …       ┆ …            │\n",
+      "│ ffd_qqq            ┆ -0.084412 ┆ -1.434737 ┆ 0.09    ┆ 0.058834     │\n",
+      "│ ffd_efa            ┆ -0.110375 ┆ -2.185295 ┆ 0.022   ┆ 0.050508     │\n",
+      "│ ffd_spy            ┆ -0.114751 ┆ -2.089767 ┆ 0.028   ┆ 0.054911     │\n",
+      "│ ffd_vnq            ┆ -0.143298 ┆ -3.032813 ┆ 0.0     ┆ 0.047249     │\n",
+      "│ ffd_iwm            ┆ -0.1577   ┆ -3.099353 ┆ 0.001   ┆ 0.050882     │\n",
+      "└────────────────────┴───────────┴───────────┴─────────┴──────────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "temporal_eval = pl.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"feature\": feat,\n",
+    "            \"ic\": stats[\"ic\"],\n",
+    "            \"t_stat\": stats.get(\"t_stat\", 0.0),\n",
+    "            \"p_value\": stats.get(\"p_value\"),\n",
+    "            \"bootstrap_se\": stats.get(\"bootstrap_std\", stats.get(\"bootstrap_se\", 0.0)),\n",
+    "        }\n",
+    "        for feat, stats in temporal_ic.items()\n",
+    "    ]\n",
+    ").sort(\"ic\", descending=True)\n",
+    "\n",
+    "print(\"\\nModel-Based Feature Evaluation (validation periods only):\")\n",
+    "print(temporal_eval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd0d5f47",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00201,
+     "end_time": "2026-03-24T02:04:29.195576+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:04:29.193566+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "**Interpretation**: GARCH conditional volatility is evaluated via\n",
+    "cross-sectional IC (does higher predicted vol predict lower returns?).\n",
+    "Date-level features (HMM, FFD) are evaluated via time-series IC against\n",
+    "the average market return. Both types add value through different channels:\n",
+    "GARCH enables cross-sectional differentiation, while regime features\n",
+    "enable conditional strategies (e.g., reduce exposure in stress regimes).\n",
+    "\n",
+    "Because all features are now computed per fold with training-only\n",
+    "parameters, the IC values reflect genuine out-of-sample signal strength\n",
+    "rather than in-sample fit quality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "833cb810",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00215,
+     "end_time": "2026-03-24T02:04:29.199725+00:00",
+     "exception": false,
+     "start_time": "2026-03-24T02:04:29.197575+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **Per-fold fitting eliminates parameter look-ahead**: HMM and GARCH\n",
+    "   parameters are estimated on each fold's training window only.\n",
+    "   The `fold` column in the output lets downstream models use the\n",
+    "   correct features for each CV fold.\n",
+    "2. **HMM on aggregate market**: 2-state Gaussian HMM on SPY captures\n",
+    "   market-wide risk-on/risk-off regimes. All ETFs inherit the same state.\n",
+    "3. **Filtered probabilities**: Forward algorithm only -- smoothed probs\n",
+    "   use future data and would introduce observation-level look-ahead bias.\n",
+    "4. **Label switching prevention**: States sorted by variance ensures\n",
+    "   State 0 = calm, State 1 = stressed across all folds.\n",
+    "5. **GARCH fit-then-filter**: `model.fix(params)` applies frozen training\n",
+    "   parameters to the full fold window, producing causal conditional\n",
+    "   volatility without re-estimation.\n",
+    "6. **Fractional differencing**: Fixed $d$ by asset class (equities=0.4,\n",
+    "   fixed income=0.5) requires no fitting, but is computed per fold\n",
+    "   window for clean warmup handling.\n",
+    "7. **Per-ETF GARCH**: Conditional volatility provides asset-specific risk\n",
+    "   dynamics, enabling cross-sectional differentiation (unlike date-level\n",
+    "   features which are shared across all ETFs).\n",
+    "8. **Holdout fold**: A dedicated holdout fold (fit on all pre-holdout\n",
+    "   data) provides features for the final out-of-sample evaluation.\n",
+    "\n",
+    "**Next**: Ch11 models will join financial features (Ch8) with\n",
+    "model-based features (Ch9) and use the `fold` column to ensure each\n",
+    "CV fold uses only training-fitted temporal features."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "tags,-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 44.951602,
+   "end_time": "2026-03-24T02:04:30.229699+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/etfs/04_model_based_features.ipynb",
+   "output_path": "/tmp/ml4t_3987651_04_model_based_features.ipynb",
+   "parameters": {
+    "GARCH_MIN_OBS": 50,
+    "HMM_N_RESTARTS": 1,
+    "MAX_SAMPLE_ASSETS": 3,
+    "MAX_SYMBOLS": 5,
+    "MIN_OBS": 10,
+    "MIN_TRAIN_BARS": 10,
+    "N_RESTARTS": 1,
+    "START_DATE": "2024-06-01"
+   },
+   "start_time": "2026-03-24T02:03:45.278097+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/case_studies/etfs/04_model_based_features.py
+++ b/case_studies/etfs/04_model_based_features.py
@@ -1,0 +1,941 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # ETFs: Model-Based Features (Per-Fold Temporal Models)
+#
+# This notebook fits temporal models and extracts features that capture
+# latent market dynamics. All models are fit **per CV fold** on training
+# data only, eliminating parameter-level look-ahead bias. It produces
+# features for three model families:
+#
+# 1. **HMM Regime Detection**: 2-state Gaussian HMM on aggregate market (SPY)
+#    with filtered (causal) probabilities, regime transition indicators, and
+#    regime duration features.
+# 2. **Fractional Differencing**: Memory-preserving stationarity transforms
+#    on 10 reference ETFs spanning all major asset classes.
+# 3. **GARCH(1,1) Conditional Volatility**: Per-ETF volatility forecasts that
+#    provide each asset's own risk dynamics.
+#
+# Each row in the output carries a `fold` column identifying which fold's
+# model produced it. This enables downstream CV to use the correct
+# (non-leaked) features for each fold.
+#
+# ## Learning Objectives
+#
+# - Fit temporal models per CV fold to avoid parameter-level look-ahead
+# - Fit a 2-state HMM with k-means initialization and multiple restarts
+# - Compute filtered (not smoothed) probabilities for production use
+# - Derive regime transition and duration features from filtered probs
+# - Apply fractional differencing with fixed $d$ values by asset class
+# - Fit per-asset GARCH(1,1) with frozen-parameter filtering
+# - Combine date-level and per-asset features into a per-fold panel
+#
+# ## Book Reference
+#
+# Chapter 9, Sections 9.1 (Fractional Differencing), 9.3 (GARCH), and
+# 9.5 (Regime Features)
+#
+# ## Prerequisites
+#
+# - [`02_labels`](02_labels.ipynb) (produces label parquet files)
+# - `03_financial_features.py` (produces `features/financial.parquet`)
+
+# %%
+"""ETFs: Model-Based Features (per-fold HMM + FFD + GARCH)."""
+
+import warnings
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+import yaml
+from arch import arch_model
+from hmmlearn.hmm import GaussianHMM
+from ml4t.diagnostic.evaluation.stats import robust_ic
+from ml4t.engineer.features.fdiff import ffdiff
+from sklearn.cluster import KMeans
+
+from data import load_etfs
+from utils.cv_splits import generate_cv_splits, load_evaluation_config
+from utils.paths import get_case_study_dir
+
+warnings.filterwarnings("ignore")
+
+
+# %% tags=["parameters"]
+# Production defaults — Papermill injects overrides for CI
+START_DATE = None  # None = use full dataset
+N_RESTARTS = 10
+GARCH_MIN_OBS = 504  # Minimum observations for GARCH fit (~2 years)
+MAX_SYMBOLS = 0  # 0 = all symbols (production)
+
+# %%
+CASE_DIR = get_case_study_dir("etfs")
+
+prices = load_etfs()
+print(f"Prices: {len(prices):,} rows, {prices['symbol'].n_unique()} assets")
+
+# %% [markdown]
+# ## CV Fold Setup
+#
+# We load the walk-forward CV splits from `setup.yaml` and add a holdout
+# fold. All temporal models are fit per fold on training data only.
+
+# %%
+# Generate CV splits
+cv_splits = generate_cv_splits(prices, case_study_id="etfs", label_buffer="21D")
+eval_config = load_evaluation_config("etfs")
+
+# Add holdout fold: fit on all pre-holdout data, extract for holdout period
+holdout_start = str(eval_config["holdout_start"])
+holdout_end = str(eval_config.get("holdout_end", prices["timestamp"].max()))
+
+# The last CV fold's val_end is the boundary before holdout
+# For holdout, train on everything up to holdout_start
+holdout_fold = {
+    "fold": len(cv_splits),
+    "train_start": cv_splits[0]["train_start"],
+    "train_end": holdout_start,
+    "val_start": holdout_start,
+    "val_end": str(holdout_end),
+}
+all_folds = cv_splits + [holdout_fold]
+
+n_cv = len(cv_splits)
+n_total = len(all_folds)
+print(f"CV folds: {n_cv}, plus holdout fold (fold {n_cv})")
+for fold in all_folds:
+    label = "HOLDOUT" if fold["fold"] == n_cv else f"Fold {fold['fold']}"
+    print(
+        f"  {label}: train {fold['train_start']}..{fold['train_end']}, "
+        f"val {fold['val_start']}..{fold['val_end']}"
+    )
+
+# %% [markdown]
+# ## Part 1: HMM Regime Detection
+#
+# We fit a 2-state Gaussian HMM on SPY returns + volatility **per fold**.
+# The aggregate market drives regime classification; individual ETFs
+# inherit it.
+#
+# ### Why SPY Only
+#
+# Using a single aggregate proxy (SPY) rather than per-asset HMMs:
+# - Avoids overfitting 100 independent HMMs
+# - Regime is a market-level phenomenon (risk-on/risk-off)
+# - All ETFs inherit the same regime state, ensuring cross-sectional consistency
+
+# %%
+spy_full = (
+    prices.filter(pl.col("symbol") == "SPY")
+    .sort("timestamp")
+    .with_columns(
+        log_ret=(pl.col("close").log().diff() * 100),
+        vol_21d=(pl.col("close").log().diff().rolling_std(window_size=21) * 100 * np.sqrt(252)),
+    )
+    .drop_nulls()
+)
+
+print(
+    f"SPY: {len(spy_full):,} observations ({spy_full['timestamp'].min()} to {spy_full['timestamp'].max()})"
+)
+
+# %% [markdown]
+# ### K-Means-Seeded HMM Fitting
+#
+# K-means clustering provides better initial emission parameters than random
+# initialization, reducing sensitivity to local optima.
+
+
+# %%
+def fit_hmm_kmeans_init(X: np.ndarray, n_states: int, random_state: int = 42) -> GaussianHMM:
+    """Fit HMM with k-means-seeded initialization."""
+    kmeans = KMeans(n_clusters=n_states, random_state=random_state, n_init=10)
+    kmeans.fit(X)
+
+    model = GaussianHMM(
+        n_components=n_states,
+        covariance_type="full",
+        n_iter=200,
+        random_state=random_state,
+        init_params="st",  # Only init startprob and transmat
+    )
+
+    model.means_ = kmeans.cluster_centers_
+    model.covars_ = np.array(
+        [np.cov(X[kmeans.labels_ == k].T) + np.eye(X.shape[1]) * 1e-6 for k in range(n_states)]
+    )
+
+    model.fit(X)
+    return model
+
+
+# %% [markdown]
+# ### Label Switching Prevention
+#
+# Sort states by variance (ascending) so State 0 is always "low volatility"
+# (calm) and State 1 is always "high volatility" (stressed).
+
+
+# %%
+def sort_states_by_variance(model: GaussianHMM) -> np.ndarray:
+    """Sort HMM states by variance (ascending) for consistent labeling."""
+    variances = np.array([np.trace(model.covars_[k]) for k in range(model.n_components)])
+    return np.argsort(variances)  # Low vol first
+
+
+def relabel_states(states: np.ndarray, probs: np.ndarray, order: np.ndarray) -> tuple:
+    """Relabel states according to the given order."""
+    inv_order = np.argsort(order)
+    new_states = inv_order[states]
+    new_probs = probs[:, order]
+    return new_states, new_probs
+
+
+# %% [markdown]
+# ### Filtered Probabilities (No Look-Ahead)
+#
+# In production, we must use **filtered** probabilities $P(z_t | x_{1:t})$
+# which condition only on past and present observations. hmmlearn's
+# `predict_proba()` returns **smoothed** probabilities $P(z_t | x_{1:T})$
+# which use future data and would introduce look-ahead bias.
+
+
+# %%
+def compute_filtered_probs(model: GaussianHMM, X: np.ndarray) -> np.ndarray:
+    """Compute filtered probabilities P(state_t | obs_{1:t}).
+
+    Uses the forward algorithm, then normalizes.
+    """
+    framelogprob = model._compute_log_likelihood(X)
+
+    n_samples = X.shape[0]
+    n_components = model.n_components
+
+    log_startprob = np.log(model.startprob_ + 1e-300)
+    log_transmat = np.log(model.transmat_ + 1e-300)
+
+    # Forward pass (log-domain for numerical stability)
+    fwdlattice = np.zeros((n_samples, n_components))
+    fwdlattice[0] = log_startprob + framelogprob[0]
+
+    for t in range(1, n_samples):
+        for j in range(n_components):
+            fwdlattice[t, j] = framelogprob[t, j] + np.logaddexp.reduce(
+                fwdlattice[t - 1] + log_transmat[:, j]
+            )
+
+    # Normalize to get probabilities
+    log_normalizer = np.logaddexp.reduce(fwdlattice, axis=1, keepdims=True)
+    filtered = np.exp(fwdlattice - log_normalizer)
+
+    return filtered
+
+
+# %% [markdown]
+# ### Derive Regime Features from Filtered Probabilities
+#
+# From filtered probabilities, derive three feature types:
+# 1. **regime_prob_stress**: Filtered probability of being in the high-vol state
+# 2. **regime_transition**: Absolute change in stress probability (detects regime shifts)
+# 3. **regime_duration**: Days since last regime change (persistence indicator)
+
+
+# %%
+def derive_regime_features(
+    timestamps: pl.Series,
+    filtered_probs: np.ndarray,
+    states: np.ndarray,
+    order: np.ndarray,
+) -> pl.DataFrame:
+    """Derive regime features from HMM output for a single fold window."""
+    states_sorted, filtered_sorted = relabel_states(states, filtered_probs, order)
+
+    regime_prob_stress = filtered_sorted[:, 1]  # P(high-vol state)
+
+    # Transition: absolute 1-day change in stress probability
+    regime_transition = np.abs(np.diff(regime_prob_stress, prepend=regime_prob_stress[0]))
+
+    # Duration: days since last regime change
+    regime_duration = np.zeros(len(states_sorted))
+    current_run = 0
+    for i in range(len(states_sorted)):
+        if i == 0 or states_sorted[i] != states_sorted[i - 1]:
+            current_run = 1
+        else:
+            current_run += 1
+        regime_duration[i] = current_run
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "regime_prob_stress": regime_prob_stress,
+            "regime_transition": regime_transition,
+            "regime_log_duration": np.log1p(regime_duration),
+        }
+    )
+
+
+# %% [markdown]
+# ### Illustrative Full-Sample HMM Fit
+#
+# Before the per-fold loop, we fit one full-sample HMM for visualization
+# purposes only. This shows readers the regime overlay on SPY and validates
+# the methodology. **These features are NOT used in the saved output.**
+
+# %%
+N_STATES = 2
+X_full = spy_full.select(["log_ret", "vol_21d"]).to_numpy()
+
+best_model_illustrative = None
+best_ll = -np.inf
+
+for seed in range(N_RESTARTS):
+    try:
+        model = fit_hmm_kmeans_init(X_full, n_states=N_STATES, random_state=seed)
+        ll = model.score(X_full)
+        if ll > best_ll:
+            best_ll = ll
+            best_model_illustrative = model
+    except Exception:
+        continue
+
+print(f"Illustrative full-sample HMM: best log-likelihood = {best_ll:.1f}")
+
+order_illustrative = sort_states_by_variance(best_model_illustrative)
+filtered_illustrative = compute_filtered_probs(best_model_illustrative, X_full)
+states_illustrative = best_model_illustrative.predict(X_full)
+states_sorted_ill, _ = relabel_states(
+    states_illustrative, filtered_illustrative, order_illustrative
+)
+
+for k in range(N_STATES):
+    mask = states_sorted_ill == k
+    label = "Low-Vol" if k == 0 else "High-Vol"
+    mean_ret = X_full[mask, 0].mean()
+    mean_vol = X_full[mask, 1].mean()
+    pct = mask.mean()
+    print(f"State {k} ({label}): {pct:.1%} of time, mean ret={mean_ret:.3f}%, vol={mean_vol:.1f}%")
+
+# %% [markdown]
+# ### Regime Overlay on SPY (Illustrative)
+#
+# Shading stressed periods on SPY cumulative returns shows whether the HMM
+# captures known market episodes (GFC, COVID, 2022 rate shock).
+
+# %%
+spy_cum = spy_full.with_columns(cum_ret=(pl.col("close") / pl.col("close").first() - 1) * 100)
+
+fig_regime, ax = plt.subplots(figsize=(12, 5))
+dates = spy_cum["timestamp"].to_numpy()
+cum_ret = spy_cum["cum_ret"].to_numpy()
+ax.plot(dates, cum_ret, linewidth=0.8, color="0.3")
+
+# Shade stressed periods
+stressed = states_sorted_ill == 1
+in_stress = False
+start = None
+for i in range(len(stressed)):
+    if stressed[i] and not in_stress:
+        start = dates[i]
+        in_stress = True
+    elif not stressed[i] and in_stress:
+        ax.axvspan(start, dates[i], alpha=0.15, color="red", linewidth=0)
+        in_stress = False
+if in_stress:
+    ax.axvspan(start, dates[-1], alpha=0.15, color="red", linewidth=0)
+
+ax.set_ylabel("Cumulative Return (%)")
+ax.set_title("SPY with HMM Stress Regimes (full-sample illustrative)")
+fig_regime.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ### Per-Fold HMM Fitting
+#
+# For each fold, we fit the HMM on **training data only**, then apply the
+# forward algorithm to the full fold window (train_start through val_end)
+# for filtered probabilities. The model parameters $\theta$ are estimated
+# exclusively from training observations, eliminating parameter-level
+# look-ahead.
+
+# %%
+hmm_fold_results = []
+
+for fold in all_folds:
+    fold_idx = fold["fold"]
+    train_start, train_end = fold["train_start"], fold["train_end"]
+    val_end = fold["val_end"]
+
+    # Training data: fit HMM parameters
+    spy_train = spy_full.filter(
+        (pl.col("timestamp") >= pl.lit(train_start).cast(pl.Date))
+        & (pl.col("timestamp") < pl.lit(train_end).cast(pl.Date))
+    )
+    X_train = spy_train.select(["log_ret", "vol_21d"]).to_numpy()
+
+    if len(X_train) < 252:
+        print(
+            f"  Fold {fold_idx}: insufficient SPY training data ({len(X_train)} obs), skipping HMM"
+        )
+        continue
+
+    # Fit HMM with multiple restarts on training data
+    best_fold_model = None
+    best_fold_ll = -np.inf
+    for seed in range(N_RESTARTS):
+        try:
+            m = fit_hmm_kmeans_init(X_train, n_states=N_STATES, random_state=seed)
+            ll = m.score(X_train)
+            if ll > best_fold_ll:
+                best_fold_ll = ll
+                best_fold_model = m
+        except Exception:
+            continue
+
+    if best_fold_model is None:
+        print(f"  Fold {fold_idx}: HMM fitting failed")
+        continue
+
+    order = sort_states_by_variance(best_fold_model)
+
+    # Full fold window (train_start through val_end) for filtered probs
+    spy_fold = spy_full.filter(
+        (pl.col("timestamp") >= pl.lit(train_start).cast(pl.Date))
+        & (pl.col("timestamp") <= pl.lit(val_end).cast(pl.Date))
+    )
+    X_fold = spy_fold.select(["log_ret", "vol_21d"]).to_numpy()
+
+    filtered = compute_filtered_probs(best_fold_model, X_fold)
+    states = best_fold_model.predict(X_fold)
+
+    regime_df = derive_regime_features(spy_fold["timestamp"], filtered, states, order)
+    regime_df = regime_df.with_columns(pl.lit(fold_idx).alias("fold"))
+
+    hmm_fold_results.append(regime_df)
+    print(
+        f"  Fold {fold_idx}: HMM LL={best_fold_ll:.1f}, {len(regime_df)} dates, "
+        f"stress={regime_df['regime_prob_stress'].mean():.3f}"
+    )
+
+hmm_features = (
+    pl.concat(hmm_fold_results)
+    if hmm_fold_results
+    else pl.DataFrame(schema={"timestamp": pl.Date, "fold": pl.Int64})
+)
+n_hmm_folds = hmm_features["fold"].n_unique() if len(hmm_features) > 0 else 0
+print(f"\nHMM features: {len(hmm_features):,} rows across {n_hmm_folds} folds")
+
+# %% [markdown]
+# ## Part 2: Fractional Differencing (Per Fold)
+#
+# Fractional differencing preserves long-range memory while achieving
+# stationarity. We apply fixed $d$ values by asset class to 10 reference
+# ETFs spanning all major asset classes in our universe.
+#
+# **Why fixed $d$?** Using pre-specified $d$ values avoids parameter estimation
+# lookahead entirely -- no data-dependent optimization, so the transform is
+# purely mechanical. We still compute per fold so each fold window gets a
+# clean series starting from its own `train_start`.
+#
+# | Asset Class     | Reference ETFs | $d$ |
+# |-----------------|---------------|-----|
+# | US Equities     | SPY, QQQ, IWM | 0.4 |
+# | Int'l Equities  | EFA, EEM      | 0.4 |
+# | Fixed Income    | TLT           | 0.5 |
+# | Gold            | GLD           | 0.4 |
+# | Real Estate     | VNQ           | 0.4 |
+# | High Yield      | HYG           | 0.5 |
+# | Inv. Grade      | LQD           | 0.5 |
+
+# %%
+REFERENCE_ETFS = {
+    "SPY": 0.4,  # US large-cap equities
+    "QQQ": 0.4,  # US tech equities
+    "IWM": 0.4,  # US small-cap equities
+    "EFA": 0.4,  # International developed
+    "EEM": 0.4,  # Emerging markets
+    "TLT": 0.5,  # Long-term treasuries
+    "GLD": 0.4,  # Gold
+    "VNQ": 0.4,  # Real estate
+    "HYG": 0.5,  # High yield bonds
+    "LQD": 0.5,  # Investment grade bonds
+}
+
+# %% [markdown]
+# ### Per-Fold FFD Application
+#
+# For each fold, apply fractional differencing to the fold window
+# (train_start through val_end). The FFD filter uses a fixed-width window
+# of historical weights, so it only needs a warmup period at the start --
+# no fitting is involved. Computing per fold ensures the warmup loss
+# does not leak information across fold boundaries.
+
+# %%
+ffd_fold_results = []
+
+for fold in all_folds:
+    fold_idx = fold["fold"]
+    train_start = fold["train_start"]
+    val_end = fold["val_end"]
+
+    fold_frames = []
+    for symbol, d in REFERENCE_ETFS.items():
+        etf = (
+            prices.filter(
+                (pl.col("symbol") == symbol)
+                & (pl.col("timestamp") >= pl.lit(train_start).cast(pl.Date))
+                & (pl.col("timestamp") <= pl.lit(val_end).cast(pl.Date))
+            )
+            .sort("timestamp")
+            .select(["timestamp", "close"])
+        )
+
+        if len(etf) == 0:
+            continue
+
+        log_close = etf["close"].log()
+        ffd_series = ffdiff(log_close, d=d)
+
+        ffd_df = pl.DataFrame(
+            {
+                "timestamp": etf["timestamp"],
+                f"ffd_{symbol.lower()}": ffd_series,
+            }
+        ).drop_nulls()
+
+        fold_frames.append(ffd_df)
+
+    if fold_frames:
+        ffd_fold = fold_frames[0]
+        for df in fold_frames[1:]:
+            ffd_fold = ffd_fold.join(df, on="timestamp", how="outer_coalesce")
+        ffd_fold = ffd_fold.sort("timestamp").with_columns(pl.lit(fold_idx).alias("fold"))
+        ffd_fold_results.append(ffd_fold)
+        ffd_cols = [c for c in ffd_fold.columns if c.startswith("ffd_")]
+        print(f"  Fold {fold_idx}: FFD {len(ffd_cols)} series, {len(ffd_fold):,} dates")
+    else:
+        print(f"  Fold {fold_idx}: no FFD series produced (no qualifying ETFs)")
+
+ffd_features = pl.concat(ffd_fold_results) if ffd_fold_results else pl.DataFrame()
+ffd_col_names = [c for c in ffd_features.columns if c.startswith("ffd_")]
+print(f"\nFFD features: {len(ffd_col_names)} series, {len(ffd_features):,} rows across folds")
+
+# %% [markdown]
+# ## Part 3: Per-ETF GARCH(1,1) (Per Fold)
+#
+# For each fold, fit GARCH(1,1) on each ETF's **training returns**, then
+# use `model.fix(params)` to run the variance recursion on the full fold
+# window (train through val_end) without re-estimating parameters. This
+# is the **fit-then-filter** paradigm: parameters come from training only,
+# but conditional volatility is computed for every date in the window.
+#
+# The `fix()` method applies frozen parameters to a new data series,
+# producing a causal conditional volatility path $\sigma_t$ that depends
+# only on past returns given the frozen parameters.
+
+# %%
+all_symbols = sorted(prices["symbol"].unique().to_list())
+if MAX_SYMBOLS > 0:
+    all_symbols = all_symbols[:MAX_SYMBOLS]
+
+print(f"Fitting GARCH(1,1) on {len(all_symbols)} ETFs across {len(all_folds)} folds...")
+
+
+# %%
+def fit_garch_fold(
+    prices_df: pl.DataFrame,
+    symbols: list[str],
+    fold: dict,
+    min_obs: int,
+) -> pl.DataFrame:
+    """Fit GARCH(1,1) per symbol for one fold.
+
+    Parameters
+    ----------
+    prices_df : pl.DataFrame
+        Full prices panel with timestamp, symbol, close columns.
+    symbols : list[str]
+        Symbols to fit.
+    fold : dict
+        Fold dict with train_start, train_end, val_end keys.
+    min_obs : int
+        Minimum training observations for GARCH fit.
+
+    Returns
+    -------
+    pl.DataFrame
+        Conditional volatility for the full fold window with fold column.
+    """
+    fold_idx = fold["fold"]
+    train_start = fold["train_start"]
+    train_end = fold["train_end"]
+    val_end = fold["val_end"]
+
+    results = []
+    n_success = 0
+    n_fail = 0
+
+    for sym in symbols:
+        # Get full fold window data (train_start through val_end)
+        sym_data = (
+            prices_df.filter(
+                (pl.col("symbol") == sym)
+                & (pl.col("timestamp") >= pl.lit(train_start).cast(pl.Date))
+                & (pl.col("timestamp") <= pl.lit(val_end).cast(pl.Date))
+            )
+            .sort("timestamp")
+            .with_columns(ret=pl.col("close").pct_change())
+            .drop_nulls(subset=["ret"])
+        )
+
+        # Training returns only
+        train_data = sym_data.filter(pl.col("timestamp") < pl.lit(train_end).cast(pl.Date))
+
+        if len(train_data) < min_obs:
+            n_fail += 1
+            continue
+
+        train_returns_pct = (train_data["ret"] * 100).to_numpy()
+
+        try:
+            # Fit on training data
+            train_model = arch_model(
+                train_returns_pct,
+                mean="Constant",
+                vol="GARCH",
+                p=1,
+                q=1,
+                dist="Normal",
+            )
+            train_result = train_model.fit(disp="off", show_warning=False)
+
+            # Apply frozen parameters to full fold window
+            full_returns_pct = (sym_data["ret"] * 100).to_numpy()
+            full_model = arch_model(
+                full_returns_pct,
+                mean="Constant",
+                vol="GARCH",
+                p=1,
+                q=1,
+                dist="Normal",
+            )
+            filtered = full_model.fix(train_result.params)
+
+            # Annualized conditional vol (input is in % daily)
+            cond_vol_ann = filtered.conditional_volatility * np.sqrt(252) / 100
+
+            sym_result = pl.DataFrame(
+                {
+                    "timestamp": sym_data["timestamp"].to_list(),
+                    "symbol": [sym] * len(sym_data),
+                    "garch_cond_vol": cond_vol_ann,
+                    "fold": [fold_idx] * len(sym_data),
+                }
+            ).drop_nulls()
+
+            if len(sym_result) > 0:
+                results.append(sym_result)
+                n_success += 1
+        except Exception:
+            n_fail += 1
+
+    print(f"  Fold {fold_idx} GARCH: {n_success}/{len(symbols)} fitted, {n_fail} failed/skipped")
+    return pl.concat(results) if results else pl.DataFrame()
+
+
+# %%
+garch_fold_results = []
+
+for fold in all_folds:
+    garch_fold = fit_garch_fold(prices, all_symbols, fold, GARCH_MIN_OBS)
+    if len(garch_fold) > 0:
+        garch_fold_results.append(garch_fold)
+
+garch_df = pl.concat(garch_fold_results) if garch_fold_results else pl.DataFrame()
+garch_cols = ["garch_cond_vol"]
+
+if len(garch_df) > 0:
+    n_syms = garch_df["symbol"].n_unique()
+    print(
+        f"\nGARCH features: {len(garch_df):,} rows, {n_syms} assets, {garch_df['fold'].n_unique()} folds"
+    )
+    print(
+        f"  Conditional vol: mean={garch_df['garch_cond_vol'].mean():.3f}, "
+        f"std={garch_df['garch_cond_vol'].std():.3f}"
+    )
+
+# %% [markdown]
+# ## Part 4: Combine and Broadcast to Per-Fold Panel
+#
+# HMM regime features and FFD features are date-level (one value per day
+# shared by all ETFs). GARCH features are per-asset. For each fold, we
+# broadcast date-level features to all symbols and join with per-asset
+# GARCH features, producing a `(fold, timestamp, symbol)` panel.
+
+# %%
+fold_panels = []
+
+for fold in all_folds:
+    fold_idx = fold["fold"]
+    train_start = fold["train_start"]
+    val_end = fold["val_end"]
+
+    # Get panel skeleton for this fold's date range
+    fold_skeleton = (
+        prices.filter(
+            (pl.col("timestamp") >= pl.lit(train_start).cast(pl.Date))
+            & (pl.col("timestamp") <= pl.lit(val_end).cast(pl.Date))
+        )
+        .select(["timestamp", "symbol"])
+        .unique()
+        .sort(["timestamp", "symbol"])
+        .with_columns(pl.lit(fold_idx).alias("fold"))
+    )
+
+    # Get date-level features for this fold
+    fold_hmm = (
+        hmm_features.filter(pl.col("fold") == fold_idx).drop("fold")
+        if len(hmm_features) > 0
+        else pl.DataFrame()
+    )
+    fold_ffd = (
+        ffd_features.filter(pl.col("fold") == fold_idx).drop("fold")
+        if len(ffd_features) > 0
+        else pl.DataFrame()
+    )
+
+    # Combine date-level features
+    if len(fold_hmm) > 0 and len(fold_ffd) > 0:
+        date_level = fold_hmm.join(fold_ffd, on="timestamp", how="outer_coalesce")
+    elif len(fold_hmm) > 0:
+        date_level = fold_hmm
+    elif len(fold_ffd) > 0:
+        date_level = fold_ffd
+    else:
+        date_level = pl.DataFrame()
+
+    # Broadcast date-level features to all assets
+    if len(date_level) > 0:
+        panel = fold_skeleton.join(date_level, on="timestamp", how="left")
+    else:
+        panel = fold_skeleton
+
+    # Join per-asset GARCH features
+    if len(garch_df) > 0:
+        fold_garch = garch_df.filter(pl.col("fold") == fold_idx).drop("fold")
+        panel = panel.join(fold_garch, on=["timestamp", "symbol"], how="left")
+
+    fold_panels.append(panel)
+
+temporal = pl.concat(fold_panels).sort(["fold", "timestamp", "symbol"])
+
+temporal_cols = [c for c in temporal.columns if c not in ("timestamp", "symbol", "fold")]
+print(f"Combined model-based features: {len(temporal_cols)} columns, {len(temporal):,} rows")
+print(f"  Assets: {temporal['symbol'].n_unique()}, Folds: {temporal['fold'].n_unique()}")
+
+# %% [markdown]
+# ### Quality Check
+#
+# Verify that temporal features have reasonable coverage and distributions.
+
+# %%
+for col in temporal_cols:
+    valid = temporal[col].drop_nulls().len()
+    total = len(temporal)
+    mean = temporal[col].drop_nulls().mean()
+    std = temporal[col].drop_nulls().std()
+    print(f"  {col:30s}: {valid:,}/{total:,} valid, mean={mean:.4f}, std={std:.4f}")
+
+# %% [markdown]
+# ### Per-Fold Feature Stability
+#
+# Check that HMM and GARCH features are stable across folds (model
+# parameters should not drift drastically with overlapping training windows).
+
+# %%
+print("\nPer-fold feature means:")
+fold_summary = (
+    temporal.group_by("fold")
+    .agg([pl.col(c).mean().alias(f"mean_{c}") for c in temporal_cols])
+    .sort("fold")
+)
+print(fold_summary)
+
+# %% [markdown]
+# ## Save Artifacts
+
+# %%
+FEATURES_DIR = CASE_DIR / "features"
+
+FEATURES_DIR.mkdir(parents=True, exist_ok=True)
+temporal.write_parquet(FEATURES_DIR / "model_based.parquet")
+print(
+    f"Saved: {FEATURES_DIR / 'model_based.parquet'} "
+    f"({len(temporal):,} rows, {len(temporal_cols)} features + fold column)"
+)
+
+# %% [markdown]
+# ## Incremental Evaluation
+#
+# Evaluate feature quality using **validation-period data only** from each
+# fold. We compute cross-sectional Spearman IC for per-asset features and
+# time-series IC for date-level features.
+
+# %%
+labels = pl.read_parquet(CASE_DIR / "labels" / "fwd_ret_21d.parquet")
+label_col = "fwd_ret_21d"
+
+# Only evaluate on validation periods (not training periods)
+val_rows = []
+for fold in all_folds:
+    fold_idx = fold["fold"]
+    val_start = fold["val_start"]
+    val_end = fold["val_end"]
+    fold_val = temporal.filter(
+        (pl.col("fold") == fold_idx)
+        & (pl.col("timestamp") >= pl.lit(val_start).cast(pl.Date))
+        & (pl.col("timestamp") <= pl.lit(val_end).cast(pl.Date))
+    )
+    val_rows.append(fold_val)
+
+val_temporal = pl.concat(val_rows) if val_rows else temporal
+
+eval_df = val_temporal.join(labels, on=["timestamp", "symbol"], how="inner").drop_nulls(
+    subset=[label_col]
+)
+print(
+    f"Evaluation panel (val periods only): {len(eval_df):,} rows, {eval_df['symbol'].n_unique()} assets"
+)
+
+# %% [markdown]
+# ### Cross-Sectional IC for Per-Asset Features
+
+# %%
+temporal_ic = {}
+
+# Per-asset features: cross-sectional IC (rank correlation per date)
+per_asset_features = [c for c in temporal_cols if c in garch_cols]
+date_level_features = [c for c in temporal_cols if c not in garch_cols]
+
+for feat in per_asset_features:
+    ic_series = (
+        eval_df.filter(pl.col(feat).is_not_null())
+        .with_columns(
+            pl.col(feat).rank(method="average").over("timestamp").alias("_feat_rank"),
+            pl.col(label_col).rank(method="average").over("timestamp").alias("_label_rank"),
+        )
+        .group_by("timestamp")
+        .agg(pl.corr("_feat_rank", "_label_rank").alias("ic"))
+        .sort("timestamp")
+    )
+    ics = ic_series["ic"].drop_nulls().to_numpy()
+    if len(ics) > 50:
+        temporal_ic[feat] = {
+            "ic": float(np.nanmean(ics)),
+            "t_stat": float(np.nanmean(ics) / (np.nanstd(ics) / np.sqrt(len(ics)))),
+            "p_value": None,
+            "bootstrap_std": float(np.nanstd(ics)),
+        }
+
+# %% [markdown]
+# ### Time-Series IC for Date-Level Features
+#
+# Date-level features (HMM, FFD) are identical across symbols on each date,
+# so cross-sectional IC is zero by construction. We evaluate them via
+# time-series correlation with the cross-sectional average return.
+
+# %%
+avg_ret = (
+    eval_df.group_by("timestamp")
+    .agg(pl.col(label_col).mean().alias("avg_fwd_ret"))
+    .sort("timestamp")
+)
+
+date_features = (
+    val_temporal.select(["timestamp"] + date_level_features)
+    .unique(subset=["timestamp"])
+    .sort("timestamp")
+)
+eval_ts = date_features.join(avg_ret, on="timestamp", how="inner").drop_nulls()
+
+for feat in date_level_features:
+    x = eval_ts[feat].to_numpy()
+    y = eval_ts["avg_fwd_ret"].to_numpy()
+    valid = ~(np.isnan(x) | np.isnan(y))
+    if valid.sum() < 50:
+        continue
+    result = robust_ic(x[valid], y[valid], return_details=True)
+    temporal_ic[feat] = result
+
+# %%
+temporal_eval = pl.DataFrame(
+    [
+        {
+            "feature": feat,
+            "ic": stats["ic"],
+            "t_stat": stats.get("t_stat", 0.0),
+            "p_value": stats.get("p_value"),
+            "bootstrap_se": stats.get("bootstrap_std", stats.get("bootstrap_se", 0.0)),
+        }
+        for feat, stats in temporal_ic.items()
+    ]
+).sort("ic", descending=True)
+
+print("\nModel-Based Feature Evaluation (validation periods only):")
+print(temporal_eval)
+
+# %% [markdown]
+# **Interpretation**: GARCH conditional volatility is evaluated via
+# cross-sectional IC (does higher predicted vol predict lower returns?).
+# Date-level features (HMM, FFD) are evaluated via time-series IC against
+# the average market return. Both types add value through different channels:
+# GARCH enables cross-sectional differentiation, while regime features
+# enable conditional strategies (e.g., reduce exposure in stress regimes).
+#
+# Because all features are now computed per fold with training-only
+# parameters, the IC values reflect genuine out-of-sample signal strength
+# rather than in-sample fit quality.
+
+# %% [markdown]
+# ## Key Takeaways
+#
+# 1. **Per-fold fitting eliminates parameter look-ahead**: HMM and GARCH
+#    parameters are estimated on each fold's training window only.
+#    The `fold` column in the output lets downstream models use the
+#    correct features for each CV fold.
+# 2. **HMM on aggregate market**: 2-state Gaussian HMM on SPY captures
+#    market-wide risk-on/risk-off regimes. All ETFs inherit the same state.
+# 3. **Filtered probabilities**: Forward algorithm only -- smoothed probs
+#    use future data and would introduce observation-level look-ahead bias.
+# 4. **Label switching prevention**: States sorted by variance ensures
+#    State 0 = calm, State 1 = stressed across all folds.
+# 5. **GARCH fit-then-filter**: `model.fix(params)` applies frozen training
+#    parameters to the full fold window, producing causal conditional
+#    volatility without re-estimation.
+# 6. **Fractional differencing**: Fixed $d$ by asset class (equities=0.4,
+#    fixed income=0.5) requires no fitting, but is computed per fold
+#    window for clean warmup handling.
+# 7. **Per-ETF GARCH**: Conditional volatility provides asset-specific risk
+#    dynamics, enabling cross-sectional differentiation (unlike date-level
+#    features which are shared across all ETFs).
+# 8. **Holdout fold**: A dedicated holdout fold (fit on all pre-holdout
+#    data) provides features for the final out-of-sample evaluation.
+#
+# **Next**: Ch11 models will join financial features (Ch8) with
+# model-based features (Ch9) and use the `fold` column to ensure each
+# CV fold uses only training-fitted temporal features.

--- a/case_studies/etfs/05_evaluation.ipynb
+++ b/case_studies/etfs/05_evaluation.ipynb
@@ -1,0 +1,4714 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f57dc948",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Feature Evaluation — ETFs\n",
+    "\n",
+    "Consolidated evaluation of Ch8 financial features and Ch9 temporal features\n",
+    "against forward return labels. Produces triage decisions for Ch11 modeling.\n",
+    "\n",
+    "**Learning Objectives**:\n",
+    "- Evaluate individual feature predictive power via Information Coefficient (IC)\n",
+    "- Apply HAC adjustment for overlapping-return autocorrelation\n",
+    "- Control false discovery rate with Benjamini-Hochberg correction\n",
+    "- Assess feature redundancy and family-level signal concentration\n",
+    "- Produce a triage ledger for downstream model selection\n",
+    "\n",
+    "**Book Reference**: Chapter 8, Section 8.5 (Feature Evaluation)\n",
+    "\n",
+    "**Prerequisites**: `03_financial_features.py` and `04_temporal.py` must have run\n",
+    "(produces `features/financial.parquet` and `features/model_based.parquet`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f466e1e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:16.233733Z",
+     "iopub.status.busy": "2026-05-15T05:21:16.233295Z",
+     "iopub.status.idle": "2026-05-15T05:21:24.013776Z",
+     "shell.execute_reply": "2026-05-15T05:21:24.012479Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Feature Evaluation - ETFs case study.\"\"\"\n",
+    "\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "import polars as pl\n",
+    "import yaml\n",
+    "from ml4t.diagnostic.evaluation.stats import benjamini_hochberg_fdr\n",
+    "from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series\n",
+    "from plotly.subplots import make_subplots\n",
+    "from scipy.stats import spearmanr\n",
+    "\n",
+    "from utils.paths import get_case_study_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e19eb193",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:24.030676Z",
+     "iopub.status.busy": "2026-05-15T05:21:24.030223Z",
+     "iopub.status.idle": "2026-05-15T05:21:24.035290Z",
+     "shell.execute_reply": "2026-05-15T05:21:24.034521Z"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Production defaults\n",
+    "MAX_SYMBOLS = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "53a1a626",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:24.045481Z",
+     "iopub.status.busy": "2026-05-15T05:21:24.045133Z",
+     "iopub.status.idle": "2026-05-15T05:21:24.051183Z",
+     "shell.execute_reply": "2026-05-15T05:21:24.050036Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "CASE_STUDY_ID = \"etfs\"\n",
+    "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
+    "EVAL_DIR = CASE_DIR / \"evaluation\"\n",
+    "EVAL_DIR.mkdir(exist_ok=True)\n",
+    "\n",
+    "# ETFs config\n",
+    "PRIMARY_LABEL_FILE = \"fwd_ret_21d.parquet\"\n",
+    "HAC_MAXLAGS = 21  # 21-day forward return\n",
+    "MIN_PERIODS = 10  # 99 symbols\n",
+    "IC_THRESHOLD = 0.01  # Monthly horizon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e636e00",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 0. Load Artifacts & Build Evaluation Panel\n",
+    "\n",
+    "We load the pre-computed feature matrices and labels, then join into a single\n",
+    "evaluation panel. Temporal features include both date-level (HMM regime, FFD)\n",
+    "and per-symbol (GARCH) features, so we join on `[date, symbol]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "030da08e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:24.071082Z",
+     "iopub.status.busy": "2026-05-15T05:21:24.070648Z",
+     "iopub.status.idle": "2026-05-15T05:21:24.955584Z",
+     "shell.execute_reply": "2026-05-15T05:21:24.951423Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Features: (396186, 59)\n",
+      "Temporal: (470662, 16)\n",
+      "Labels: (468562, 3), column: fwd_ret_21d\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load features (normalize date column type to pl.Date for consistent joins)\n",
+    "features = pl.read_parquet(CASE_DIR / \"features\" / \"financial.parquet\").with_columns(\n",
+    "    pl.col(\"timestamp\").cast(pl.Date)\n",
+    ")\n",
+    "temporal = pl.read_parquet(CASE_DIR / \"features\" / \"model_based.parquet\").with_columns(\n",
+    "    pl.col(\"timestamp\").cast(pl.Date)\n",
+    ")\n",
+    "# model_based.parquet now carries one row per (timestamp, symbol, fold);\n",
+    "# drop fold and de-dup so the join doesn't multiply the eval panel by fold count.\n",
+    "if \"fold\" in temporal.columns:\n",
+    "    temporal = temporal.drop(\"fold\").unique(subset=[\"timestamp\", \"symbol\"], keep=\"last\")\n",
+    "\n",
+    "# Load primary label\n",
+    "label_df = pl.read_parquet(CASE_DIR / \"labels\" / PRIMARY_LABEL_FILE).with_columns(\n",
+    "    pl.col(\"timestamp\").cast(pl.Date)\n",
+    ")\n",
+    "label_col = [c for c in label_df.columns if c not in (\"timestamp\", \"symbol\")][0]\n",
+    "\n",
+    "# Load evaluation config from setup.yaml\n",
+    "with open(CASE_DIR / \"config\" / \"setup.yaml\") as f:\n",
+    "    setup_config = yaml.safe_load(f)\n",
+    "eval_config = setup_config.get(\"evaluation\", {})\n",
+    "\n",
+    "print(f\"Features: {features.shape}\")\n",
+    "print(f\"Temporal: {temporal.shape}\")\n",
+    "print(f\"Labels: {label_df.shape}, column: {label_col}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "671ad81a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:24.969977Z",
+     "iopub.status.busy": "2026-05-15T05:21:24.969515Z",
+     "iopub.status.idle": "2026-05-15T05:21:25.278995Z",
+     "shell.execute_reply": "2026-05-15T05:21:25.277717Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Eval panel: 394,233 rows, 99 symbols, 4,759 dates\n",
+      "Features: 57 financial + 14 temporal = 71 total\n",
+      "Label: fwd_ret_21d\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Identify feature columns by source\n",
+    "JOIN_COLS = [\"timestamp\", \"symbol\"]\n",
+    "DATE_COL = \"timestamp\"\n",
+    "\n",
+    "financial_cols = [c for c in features.columns if c not in JOIN_COLS]\n",
+    "temporal_cols = [c for c in temporal.columns if c not in (\"timestamp\", \"symbol\")]\n",
+    "\n",
+    "# Join: features + temporal (on [date, symbol]) + labels\n",
+    "eval_panel = features.join(temporal, on=JOIN_COLS, how=\"left\")\n",
+    "eval_panel = eval_panel.join(label_df, on=JOIN_COLS, how=\"inner\")\n",
+    "\n",
+    "all_feature_cols = financial_cols + temporal_cols\n",
+    "\n",
+    "if MAX_SYMBOLS > 0:\n",
+    "    top = eval_panel.group_by(\"symbol\").len().sort(\"len\", descending=True).head(MAX_SYMBOLS)\n",
+    "    eval_panel = eval_panel.filter(pl.col(\"symbol\").is_in(top[\"symbol\"]))\n",
+    "\n",
+    "n_rows = len(eval_panel)\n",
+    "n_symbols = eval_panel[\"symbol\"].n_unique()\n",
+    "n_dates = eval_panel[DATE_COL].n_unique()\n",
+    "print(f\"\\nEval panel: {n_rows:,} rows, {n_symbols} symbols, {n_dates:,} dates\")\n",
+    "print(\n",
+    "    f\"Features: {len(financial_cols)} financial + {len(temporal_cols)} temporal\"\n",
+    "    f\" = {len(all_feature_cols)} total\"\n",
+    ")\n",
+    "print(f\"Label: {label_col}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b6f6b5e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 0.5 Data Quality Gate\n",
+    "\n",
+    "Verify upstream artifacts are free of critical defects (negative prices,\n",
+    "infinities, extreme returns) before any statistical evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ec9ea315",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:25.297234Z",
+     "iopub.status.busy": "2026-05-15T05:21:25.296819Z",
+     "iopub.status.idle": "2026-05-15T05:21:25.603325Z",
+     "shell.execute_reply": "2026-05-15T05:21:25.598637Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data Quality Gate: 0 CRITICAL, 1 WARNING\n",
+      "  [!] WARNING: 2 features have values |x| > 1e+06: sharpe_5d(172), sharpe_10d(37)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'issues': ['WARNING: 2 features have values |x| > 1e+06: sharpe_5d(172), sharpe_10d(37)'],\n",
+       " 'n_critical': 0,\n",
+       " 'n_warning': 1}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from utils.data_quality import validate_modeling_inputs\n",
+    "\n",
+    "validate_modeling_inputs(\n",
+    "    features_df=eval_panel,\n",
+    "    label_df=eval_panel,\n",
+    "    feature_cols=all_feature_cols,\n",
+    "    label_col=label_col,\n",
+    "    join_cols=JOIN_COLS,\n",
+    "    asset_col=\"symbol\",\n",
+    "    max_abs_return=1.0,  # 21-day ETF returns (max observed ~0.71)\n",
+    "    fail_on_critical=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968684f8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 1. Correctness Screens\n",
+    "\n",
+    "Before evaluating predictive power, we check data quality:\n",
+    "- **Coverage**: fraction of non-null values (threshold: 70%)\n",
+    "- **Staleness**: fraction of unchanged values from prior date (threshold: 50%)\n",
+    "\n",
+    "Features that fail either gate are marked STOP in the triage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e6e20a9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:25.618707Z",
+     "iopub.status.busy": "2026-05-15T05:21:25.618366Z",
+     "iopub.status.idle": "2026-05-15T05:21:32.863331Z",
+     "shell.execute_reply": "2026-05-15T05:21:32.860590Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correctness gate: 67 PASS, 4 FAIL\n",
+      "shape: (4, 3)\n",
+      "┌──────────────────┬──────────┬───────────┐\n",
+      "│ feature          ┆ coverage ┆ staleness │\n",
+      "│ ---              ┆ ---      ┆ ---       │\n",
+      "│ str              ┆ f64      ┆ f64       │\n",
+      "╞══════════════════╪══════════╪═══════════╡\n",
+      "│ aroon_diff       ┆ 1.0      ┆ 0.589     │\n",
+      "│ pct_positive_63d ┆ 1.0      ┆ 0.51      │\n",
+      "│ vol_63d_rank     ┆ 1.0      ┆ 0.596     │\n",
+      "│ regime           ┆ 1.0      ┆ 0.983     │\n",
+      "└──────────────────┴──────────┴───────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "coverage = {}\n",
+    "staleness = {}\n",
+    "\n",
+    "for feat in all_feature_cols:\n",
+    "    col = eval_panel[feat]\n",
+    "    coverage[feat] = col.drop_nulls().len() / n_rows\n",
+    "\n",
+    "    # Staleness: fraction unchanged from prior row within same symbol\n",
+    "    unchanged = (\n",
+    "        eval_panel.sort(JOIN_COLS)\n",
+    "        .select((pl.col(feat) == pl.col(feat).shift(1).over(\"symbol\")).alias(\"same\"))[\"same\"]\n",
+    "        .sum()\n",
+    "    )\n",
+    "    staleness[feat] = float(unchanged) / max(n_rows - n_symbols, 1)\n",
+    "\n",
+    "correctness = {\n",
+    "    feat: coverage[feat] >= 0.70 and staleness[feat] <= 0.50 for feat in all_feature_cols\n",
+    "}\n",
+    "n_pass = sum(correctness.values())\n",
+    "n_fail = len(correctness) - n_pass\n",
+    "print(f\"Correctness gate: {n_pass} PASS, {n_fail} FAIL\")\n",
+    "\n",
+    "if n_fail > 0:\n",
+    "    fail_df = pl.DataFrame(\n",
+    "        {\n",
+    "            \"feature\": [f for f, ok in correctness.items() if not ok],\n",
+    "            \"coverage\": [round(coverage[f], 3) for f, ok in correctness.items() if not ok],\n",
+    "            \"staleness\": [round(staleness[f], 3) for f, ok in correctness.items() if not ok],\n",
+    "        }\n",
+    "    )\n",
+    "    print(fail_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8119a8c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Effective Sample Size\n",
+    "\n",
+    "With daily observations and 21-day forward return labels, consecutive labels\n",
+    "overlap by 20 days. This autocorrelation reduces the effective number of\n",
+    "independent observations:\n",
+    "\n",
+    "$$N_{\\text{eff}} \\approx \\frac{N_{\\text{dates}}}{h} \\times N_{\\text{symbols}}$$\n",
+    "\n",
+    "where $h = 21$ is the label horizon. HAC standard errors (below) account for\n",
+    "this, but raw row counts overstate statistical power."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b1b03edb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:32.886764Z",
+     "iopub.status.busy": "2026-05-15T05:21:32.886373Z",
+     "iopub.status.idle": "2026-05-15T05:21:32.894415Z",
+     "shell.execute_reply": "2026-05-15T05:21:32.892893Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw panel: 394,233 rows (4,759 dates × 99 symbols)\n",
+      "Effective sample size: ~22,374 (226 independent date blocks × 99 symbols)\n",
+      "Overlap reduction factor: 21x\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_eff_dates = n_dates // HAC_MAXLAGS\n",
+    "n_eff = n_eff_dates * n_symbols\n",
+    "print(f\"Raw panel: {n_rows:,} rows ({n_dates:,} dates × {n_symbols} symbols)\")\n",
+    "print(\n",
+    "    f\"Effective sample size: ~{n_eff:,} ({n_eff_dates:,} independent date blocks × {n_symbols} symbols)\"\n",
+    ")\n",
+    "print(f\"Overlap reduction factor: {n_dates / n_eff_dates:.0f}x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d41079d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2. Univariate Association (IC + HAC)\n",
+    "\n",
+    "For each feature that passes correctness, we compute:\n",
+    "- **IC time series**: daily cross-sectional Spearman rank correlation with the label\n",
+    "- **HAC-adjusted t-statistics**: Newey-West standard errors with bandwidth = 21\n",
+    "  (matching the 21-day label horizon) to account for overlapping-return autocorrelation\n",
+    "\n",
+    "Date-level features (identical across all symbols on a given date) produce zero\n",
+    "cross-sectional IC by construction. We detect and flag these separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d064773d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:32.913235Z",
+     "iopub.status.busy": "2026-05-15T05:21:32.912941Z",
+     "iopub.status.idle": "2026-05-15T05:21:32.978894Z",
+     "shell.execute_reply": "2026-05-15T05:21:32.975857Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Date-level features (zero CS variance): ['corr_spy_tlt_63d', 'ffd_eem', 'ffd_efa', 'ffd_gld', 'ffd_hyg', 'ffd_iwm', 'ffd_lqd', 'ffd_qqq', 'ffd_spy', 'ffd_tlt', 'ffd_vnq', 'regime_log_duration', 'regime_prob_stress', 'regime_transition', 'yield_curve_slope', 'yield_curve_zscore']\n"
+     ]
+    }
+   ],
+   "source": [
+    "evaluable_features = [f for f in all_feature_cols if correctness[f]]\n",
+    "\n",
+    "# Detect date-level features (zero cross-sectional variance)\n",
+    "# Compute std per date for all features at once, then check which have ~zero mean std\n",
+    "cs_std_df = eval_panel.group_by(DATE_COL).agg(\n",
+    "    [pl.col(f).std().alias(f) for f in evaluable_features]\n",
+    ")\n",
+    "date_level_features = set()\n",
+    "for feat in evaluable_features:\n",
+    "    mean_std = cs_std_df[feat].drop_nulls().mean()\n",
+    "    if mean_std is not None and mean_std < 1e-10:\n",
+    "        date_level_features.add(feat)\n",
+    "\n",
+    "if date_level_features:\n",
+    "    print(f\"Date-level features (zero CS variance): {sorted(date_level_features)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7ed1b887",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:21:32.989185Z",
+     "iopub.status.busy": "2026-05-15T05:21:32.989020Z",
+     "iopub.status.idle": "2026-05-15T05:25:01.474782Z",
+     "shell.execute_reply": "2026-05-15T05:25:01.474308Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IC progress: 1000/4759 dates\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IC progress: 2000/4759 dates\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IC progress: 3000/4759 dates\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IC progress: 4000/4759 dates\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IC progress: 4759/4759 dates (done)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Batch IC computation: one pass over dates, all features at once\n",
+    "# This is much faster than calling cross_sectional_ic_series per feature\n",
+    "cs_features = [f for f in evaluable_features if f not in date_level_features]\n",
+    "cols_needed = [DATE_COL] + cs_features + [label_col]\n",
+    "eval_sub = eval_panel.select(cols_needed).drop_nulls(subset=[label_col])\n",
+    "\n",
+    "# Group by date and compute Spearman IC for all features per date\n",
+    "dates_list = eval_sub[DATE_COL].unique().sort().to_list()\n",
+    "n_total = len(dates_list)\n",
+    "\n",
+    "# Pre-allocate: dict of feature -> list of (date, ic, n_obs)\n",
+    "ic_series_data = {feat: [] for feat in cs_features}\n",
+    "\n",
+    "for i, dt in enumerate(dates_list):\n",
+    "    cross_section = eval_sub.filter(pl.col(DATE_COL) == dt)\n",
+    "    n_obs = len(cross_section)\n",
+    "    if n_obs < MIN_PERIODS:\n",
+    "        continue\n",
+    "\n",
+    "    label_arr = cross_section[label_col].to_numpy()\n",
+    "    label_valid = ~np.isnan(label_arr)\n",
+    "\n",
+    "    for feat in cs_features:\n",
+    "        feat_arr = cross_section[feat].to_numpy()\n",
+    "        valid_mask = label_valid & ~np.isnan(feat_arr)\n",
+    "        n_valid = int(valid_mask.sum())\n",
+    "        if n_valid >= MIN_PERIODS:\n",
+    "            ic_val, _ = spearmanr(feat_arr[valid_mask], label_arr[valid_mask])\n",
+    "            if not np.isnan(ic_val):\n",
+    "                ic_series_data[feat].append((dt, float(ic_val), n_valid))\n",
+    "\n",
+    "    if (i + 1) % 1000 == 0:\n",
+    "        print(f\"  IC progress: {i + 1}/{n_total} dates\")\n",
+    "\n",
+    "print(f\"  IC progress: {n_total}/{n_total} dates (done)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "037047c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:01.486643Z",
+     "iopub.status.busy": "2026-05-15T05:25:01.486372Z",
+     "iopub.status.idle": "2026-05-15T05:25:02.087254Z",
+     "shell.execute_reply": "2026-05-15T05:25:02.085008Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IC computed for 51 cross-sectional features\n",
+      "Skipped 16 date-level features\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Convert to DataFrames and compute HAC stats\n",
+    "ic_results = {}\n",
+    "ic_timeseries = {}\n",
+    "for feat in cs_features:\n",
+    "    data = ic_series_data[feat]\n",
+    "    if len(data) < 20:\n",
+    "        continue\n",
+    "    dates_f, ics_f, nobs_f = zip(*data, strict=False)\n",
+    "    ic_df = pl.DataFrame({DATE_COL: list(dates_f), \"ic\": list(ics_f), \"n_obs\": list(nobs_f)})\n",
+    "    hac_stats = compute_ic_hac_stats(ic_df, ic_col=\"ic\", maxlags=HAC_MAXLAGS)\n",
+    "    ic_results[feat] = hac_stats\n",
+    "    ic_timeseries[feat] = ic_df\n",
+    "\n",
+    "print(f\"IC computed for {len(ic_results)} cross-sectional features\")\n",
+    "print(f\"Skipped {len(date_level_features)} date-level features\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3d9a668",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Fold-Level Stability\n",
+    "\n",
+    "We divide the evaluation period into approximate annual folds (matching the\n",
+    "CV config's 1-year test windows) and check whether IC sign is consistent\n",
+    "across folds. Features with > 60% positive-IC folds are more robust."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f4c4ee7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:02.108716Z",
+     "iopub.status.busy": "2026-05-15T05:25:02.108128Z",
+     "iopub.status.idle": "2026-05-15T05:25:02.205537Z",
+     "shell.execute_reply": "2026-05-15T05:25:02.204487Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold stability computed for 51 features\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate approximate fold boundaries\n",
+    "all_dates = eval_panel[DATE_COL].unique().sort().to_list()\n",
+    "n_folds = eval_config.get(\"n_splits\", 8)\n",
+    "fold_size = len(all_dates) // n_folds\n",
+    "\n",
+    "fold_boundaries = []\n",
+    "for i in range(n_folds):\n",
+    "    start_idx = i * fold_size\n",
+    "    end_idx = min((i + 1) * fold_size - 1, len(all_dates) - 1)\n",
+    "    fold_boundaries.append((all_dates[start_idx], all_dates[end_idx]))\n",
+    "\n",
+    "fold_stats = {}\n",
+    "for feat in ic_results:\n",
+    "    fold_ics = []\n",
+    "    ts = ic_timeseries[feat]\n",
+    "    for fold_start, fold_end in fold_boundaries:\n",
+    "        fold_ic = ts.filter((pl.col(DATE_COL) >= fold_start) & (pl.col(DATE_COL) <= fold_end))\n",
+    "        if len(fold_ic) >= 5:\n",
+    "            fold_ics.append(float(fold_ic[\"ic\"].mean()))\n",
+    "\n",
+    "    if fold_ics:\n",
+    "        sign_consistency = sum(1 for ic in fold_ics if ic > 0) / len(fold_ics)\n",
+    "        fold_stats[feat] = {\n",
+    "            \"n_folds\": len(fold_ics),\n",
+    "            \"sign_consistency\": sign_consistency,\n",
+    "            \"worst_fold_ic\": min(fold_ics),\n",
+    "            \"best_fold_ic\": max(fold_ics),\n",
+    "            \"median_fold_ic\": float(np.median(fold_ics)),\n",
+    "        }\n",
+    "\n",
+    "print(f\"Fold stability computed for {len(fold_stats)} features\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "509f412d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 3. Multiple Testing (BH-FDR)\n",
+    "\n",
+    "Testing 50+ features simultaneously at $\\alpha = 0.05$ expects ~2.5 false\n",
+    "positives. We apply the Benjamini-Hochberg procedure to control the false\n",
+    "discovery rate. The **inflation factor** measures how much naive significance\n",
+    "overstates true significance:\n",
+    "\n",
+    "$$\\text{Inflation} = \\frac{N_{\\text{naive significant}}}{N_{\\text{FDR significant}}}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "37a10460",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:02.238339Z",
+     "iopub.status.busy": "2026-05-15T05:25:02.237784Z",
+     "iopub.status.idle": "2026-05-15T05:25:02.251795Z",
+     "shell.execute_reply": "2026-05-15T05:25:02.250671Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Features tested: 51\n",
+      "Naive significant (p < 0.05): 13\n",
+      "HAC significant (|t| > 1.96): 13\n",
+      "FDR significant (q < 0.05):   1\n",
+      "Inflation factor (HAC): 1.00x\n",
+      "Inflation factor (FDR): 13.00x\n"
+     ]
+    }
+   ],
+   "source": [
+    "feature_names = list(ic_results.keys())\n",
+    "p_values = [ic_results[f][\"p_value\"] for f in feature_names]\n",
+    "\n",
+    "fdr_result = benjamini_hochberg_fdr(p_values, alpha=0.05, return_details=True)\n",
+    "\n",
+    "eval_summary = pl.DataFrame(\n",
+    "    {\n",
+    "        \"feature\": feature_names,\n",
+    "        \"source\": [\"temporal\" if f in temporal_cols else \"financial\" for f in feature_names],\n",
+    "        \"ic_mean\": [ic_results[f][\"mean_ic\"] for f in feature_names],\n",
+    "        \"hac_se\": [ic_results[f][\"hac_se\"] for f in feature_names],\n",
+    "        \"hac_t\": [ic_results[f][\"t_stat\"] for f in feature_names],\n",
+    "        \"hac_p\": p_values,\n",
+    "        \"fdr_p\": [float(p) for p in fdr_result[\"adjusted_p_values\"]],\n",
+    "        \"fdr_sig\": [bool(r) for r in fdr_result[\"rejected\"]],\n",
+    "        \"naive_t\": [ic_results[f][\"naive_t_stat\"] for f in feature_names],\n",
+    "    }\n",
+    ").sort(pl.col(\"ic_mean\").cast(pl.Float64, strict=False).abs(), descending=True)\n",
+    "\n",
+    "n_significant_naive = sum(1 for p in p_values if p < 0.05)\n",
+    "n_significant_hac = sum(1 for f in feature_names if abs(ic_results[f][\"t_stat\"]) > 1.96)\n",
+    "n_significant_fdr = int(fdr_result[\"n_rejected\"])\n",
+    "\n",
+    "inflation_hac = n_significant_naive / max(n_significant_hac, 1)\n",
+    "inflation_fdr = n_significant_naive / max(n_significant_fdr, 1)\n",
+    "\n",
+    "print(f\"Features tested: {len(feature_names)}\")\n",
+    "print(f\"Naive significant (p < 0.05): {n_significant_naive}\")\n",
+    "print(f\"HAC significant (|t| > 1.96): {n_significant_hac}\")\n",
+    "print(f\"FDR significant (q < 0.05):   {n_significant_fdr}\")\n",
+    "print(f\"Inflation factor (HAC): {inflation_hac:.2f}x\")\n",
+    "print(f\"Inflation factor (FDR): {inflation_fdr:.2f}x\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ce9197b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:02.265394Z",
+     "iopub.status.busy": "2026-05-15T05:25:02.264867Z",
+     "iopub.status.idle": "2026-05-15T05:25:02.272596Z",
+     "shell.execute_reply": "2026-05-15T05:25:02.270946Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Top 15 features by absolute IC:\n",
+      "shape: (15, 9)\n",
+      "┌───────────────┬───────────┬───────────┬──────────┬───┬──────────┬──────────┬─────────┬───────────┐\n",
+      "│ feature       ┆ source    ┆ ic_mean   ┆ hac_se   ┆ … ┆ hac_p    ┆ fdr_p    ┆ fdr_sig ┆ naive_t   │\n",
+      "│ ---           ┆ ---       ┆ ---       ┆ ---      ┆   ┆ ---      ┆ ---      ┆ ---     ┆ ---       │\n",
+      "│ str           ┆ str       ┆ f64       ┆ f64      ┆   ┆ f64      ┆ f64      ┆ bool    ┆ f64       │\n",
+      "╞═══════════════╪═══════════╪═══════════╪══════════╪═══╪══════════╪══════════╪═════════╪═══════════╡\n",
+      "│ dist_52w_low  ┆ financial ┆ 0.076355  ┆ 0.016439 ┆ … ┆ 0.000003 ┆ 0.000178 ┆ true    ┆ 16.152049 │\n",
+      "│ vol_252d      ┆ financial ┆ 0.058948  ┆ 0.020559 ┆ … ┆ 0.004159 ┆ 0.068834 ┆ false   ┆ 10.401608 │\n",
+      "│ natr_14       ┆ financial ┆ 0.05722   ┆ 0.01959  ┆ … ┆ 0.003506 ┆ 0.068834 ┆ false   ┆ 10.388454 │\n",
+      "│ vol_126d      ┆ financial ┆ 0.056434  ┆ 0.020275 ┆ … ┆ 0.005399 ┆ 0.068834 ┆ false   ┆ 10.029753 │\n",
+      "│ vol_63d       ┆ financial ┆ 0.05091   ┆ 0.019977 ┆ … ┆ 0.01085  ┆ 0.078944 ┆ false   ┆ 9.110108  │\n",
+      "│ …             ┆ …         ┆ …         ┆ …        ┆ … ┆ …        ┆ …        ┆ …       ┆ …         │\n",
+      "│ ret_252d      ┆ financial ┆ 0.040336  ┆ 0.018163 ┆ … ┆ 0.026411 ┆ 0.112247 ┆ false   ┆ 7.997445  │\n",
+      "│ sma_ratio_200 ┆ financial ┆ 0.033548  ┆ 0.017222 ┆ … ┆ 0.051477 ┆ 0.187522 ┆ false   ┆ 6.887362  │\n",
+      "│ mom_accel_sho ┆ financial ┆ -0.026099 ┆ 0.01662  ┆ … ┆ 0.116408 ┆ 0.395788 ┆ false   ┆ -5.39076  │\n",
+      "│ rt            ┆           ┆           ┆          ┆   ┆          ┆          ┆         ┆           │\n",
+      "│ skip_recent_6 ┆ financial ┆ 0.024087  ┆ 0.017551 ┆ … ┆ 0.169986 ┆ 0.471106 ┆ false   ┆ 4.880859  │\n",
+      "│ _1            ┆           ┆           ┆          ┆   ┆          ┆          ┆         ┆           │\n",
+      "│ ret_126d      ┆ financial ┆ 0.023384  ┆ 0.017382 ┆ … ┆ 0.178597 ┆ 0.471106 ┆ false   ┆ 4.765151  │\n",
+      "└───────────────┴───────────┴───────────┴──────────┴───┴──────────┴──────────┴─────────┴───────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Top features table\n",
+    "print(\"\\nTop 15 features by absolute IC:\")\n",
+    "print(eval_summary.head(15))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d42c4792",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:02.285202Z",
+     "iopub.status.busy": "2026-05-15T05:25:02.285045Z",
+     "iopub.status.idle": "2026-05-15T05:25:04.004496Z",
+     "shell.execute_reply": "2026-05-15T05:25:04.003086Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#2ecc71",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6",
+           "#95a5a6"
+          ]
+         },
+         "showlegend": false,
+         "text": [
+          "t=4.6",
+          "t=2.9",
+          "t=2.9",
+          "t=2.8",
+          "t=2.5",
+          "t=2.6",
+          "t=2.5",
+          "t=-2.5",
+          "t=2.3",
+          "t=2.3",
+          "t=2.2",
+          "t=1.9",
+          "t=-1.6",
+          "t=1.4",
+          "t=1.3",
+          "t=1.3",
+          "t=-1.3",
+          "t=1.2",
+          "t=-1.2",
+          "t=-1.0",
+          "t=1.0",
+          "t=-1.2",
+          "t=-1.3",
+          "t=-1.4",
+          "t=-1.2"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "dist_52w_low",
+          "vol_252d",
+          "natr_14",
+          "vol_126d",
+          "vol_63d",
+          "vol_21d",
+          "garch_cond_vol",
+          "mom_accel_long",
+          "skip_recent_12_1",
+          "ret_189d",
+          "ret_252d",
+          "sma_ratio_200",
+          "mom_accel_short",
+          "skip_recent_6_1",
+          "ret_126d",
+          "ret_126d_rank",
+          "max_dd_63d",
+          "ret_63d",
+          "mom_accel_medium",
+          "max_dd_126d",
+          "sharpe_189d",
+          "vol_ratio_medium",
+          "bb_pctb_20",
+          "obv_zscore_63d",
+          "cci_21"
+         ],
+         "xaxis": "x",
+         "y": [
+          0.07635483496346775,
+          0.05894811022065204,
+          0.05721956547277099,
+          0.056434302982184055,
+          0.05090995251982655,
+          0.050691280996018585,
+          0.04962564936381018,
+          -0.04325755427324245,
+          0.04178482635486817,
+          0.04110730011268391,
+          0.040335762919327035,
+          0.033548199627978344,
+          -0.02609920732671317,
+          0.02408747298706548,
+          0.02338393916006296,
+          0.02338393916006296,
+          -0.020294611560483112,
+          0.02014832251655958,
+          -0.020024239111810494,
+          -0.016060268548543852,
+          0.01602684766798153,
+          -0.015891984416866452,
+          -0.014715153790111598,
+          -0.014515752367914404,
+          -0.01398576327232167
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": [
+           "#2ecc71",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c",
+           "#e74c3c"
+          ],
+          "size": 7
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "text": [
+          "dist_52w_low",
+          "vol_252d",
+          "natr_14",
+          "vol_126d",
+          "vol_63d",
+          "vol_21d",
+          "garch_cond_vol",
+          "mom_accel_long",
+          "skip_recent_12_1",
+          "ret_189d",
+          "ret_252d",
+          "sma_ratio_200",
+          "mom_accel_short",
+          "skip_recent_6_1",
+          "ret_126d",
+          "ret_126d_rank",
+          "max_dd_63d",
+          "ret_63d",
+          "mom_accel_medium",
+          "max_dd_126d",
+          "sharpe_189d",
+          "vol_ratio_medium",
+          "bb_pctb_20",
+          "obv_zscore_63d",
+          "cci_21",
+          "sharpe_252d",
+          "cci_14",
+          "sharpe_5d",
+          "vol_ratio_63d",
+          "ret_5d",
+          "vol_ratio_21d",
+          "sharpe_10d",
+          "rsi_7",
+          "sharpe_21d",
+          "stoch_k",
+          "sharpe_63d",
+          "rsi_14",
+          "hurst_100",
+          "adx_14",
+          "vol_ratio_short",
+          "dist_52w_high",
+          "ret_10d",
+          "ret_42d",
+          "macd_line",
+          "sma_ratio_50",
+          "sharpe_126d",
+          "sharpe_126d_rank",
+          "ret_21d",
+          "sharpe_42d",
+          "ema_ratio_26",
+          "chop_14"
+         ],
+         "type": "scatter",
+         "x": [
+          16.152049300038176,
+          10.4016075507356,
+          10.388454162685514,
+          10.029752836301446,
+          9.110108471151076,
+          9.232100519933594,
+          8.985858205258696,
+          -9.031261408364609,
+          8.218590383587179,
+          8.220978593170363,
+          7.997444789955963,
+          6.887362192807514,
+          -5.390760069296785,
+          4.880859086460087,
+          4.765151116013638,
+          4.765151116013638,
+          -4.253847606584472,
+          4.160837207788063,
+          -4.1065294803346735,
+          -3.335857730998786,
+          3.4409608081391028,
+          -4.178142840935981,
+          -3.544083548045368,
+          -4.4289020641172065,
+          -3.369633808832531,
+          2.667595782857911,
+          -2.851685560525629,
+          -2.627904830616295,
+          4.685548712968539,
+          -2.123022458926743,
+          4.503854002005327,
+          -2.3656876386894536,
+          -2.2470797325178724,
+          -2.0358756479022198,
+          -1.9609186885402357,
+          1.7023350863586446,
+          -1.8104989769452282,
+          2.210259353934044,
+          -2.0217830995934047,
+          1.8968433729235636,
+          -1.2454355612086927,
+          -1.1830453071757785,
+          1.0167630917702568,
+          0.912949865812349,
+          0.5764095782358744,
+          0.586641688037098,
+          0.586641688037098,
+          -0.5431032988927165,
+          -0.5696204916308858,
+          0.11602668864737901,
+          0.0014786410254454996
+         ],
+         "xaxis": "x2",
+         "y": [
+          4.644799243979996,
+          2.8672168229967703,
+          2.920918435289692,
+          2.7835057355409565,
+          2.5484905288863264,
+          2.6172624246564764,
+          2.5430734069348113,
+          -2.5019799111375485,
+          2.288662752088306,
+          2.2884594990169567,
+          2.2208066174556094,
+          1.9479762460285945,
+          -1.5703160371442408,
+          1.372458206342902,
+          1.3452848174210672,
+          1.3452848174210672,
+          -1.279006873146611,
+          1.1934812248147129,
+          -1.1747040781747424,
+          -0.9738188946252686,
+          0.9561759721124757,
+          -1.179690016521521,
+          -1.2885787414913032,
+          -1.3708409034763038,
+          -1.2087522043467198,
+          0.7226080456318031,
+          -1.1440855854213996,
+          -1.2543378930215137,
+          2.1174858835143358,
+          -1.0454372345102703,
+          2.423088919725733,
+          -0.8693722924491324,
+          -0.8277462682718482,
+          -0.6478307156265332,
+          -0.7548104791275595,
+          0.4829221193665501,
+          -0.5842713049070509,
+          0.6465805721307745,
+          -0.5788476286699612,
+          0.6130909085822979,
+          -0.35585342665912095,
+          -0.44218004949621936,
+          0.30491647319187715,
+          0.2705582651653039,
+          0.17513573998324436,
+          0.1657293406698883,
+          0.1657293406698883,
+          -0.17530775720162634,
+          -0.1658741178236516,
+          0.038394176596357445,
+          0.0005859349645728251
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "gray",
+          "dash": "dash"
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -17.767254230041996,
+          17.767254230041996
+         ],
+         "xaxis": "x2",
+         "y": [
+          -17.767254230041996,
+          17.767254230041996
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Top 25 Features by |IC| (green = FDR-sig)",
+          "x": 0.22,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "HAC vs Naive t-statistics",
+          "x": 0.78,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "height": 450,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "width": 1100,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0,
+          0.44
+         ],
+         "tickangle": -45
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.56,
+          1.0
+         ],
+         "title": {
+          "text": "Naive t"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.0,
+          1.0
+         ]
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "title": {
+          "text": "HAC t"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEwAAAHCCAYAAAD1g1y1AAAgAElEQVR4XuzdB3QUVd8G8CeFAAkkISRUqaFJE5COQAi9I70oKohiA1EsIIgNX1EURVCUImBB6U2k995770gvAUJ6e8//xl2yy26ym51NNpNnzvnO50tm7sz93bu7s8/ee8ctKSkpCdwoQAEKUIACFKAABShAAQpQgAIUoAAFjAJuDEzYGyhAAQpQgAIUoAAFKEABClCAAhSggKkAAxP2CApQgAIUoAAFKEABClCAAhSgAAUoYCbAwIRdggIUoAAFKEABClCAAhSgAAUoQAEKMDBhH6AABShAAQpQgAIUoAAFKEABClCAAqkLcIQJewgFKEABClCAAhSgAAUoQAEKUIACFDATYGDCLkEBClCAAhSgAAUoQAEKUIACFKAABRiYsA9QgAIUoAAFKEABClCAAhSgAAUoQIHUBTjChD2EAhSgAAUoQAEKUIACFKAABShAAQqYCTAwYZegAAUoQAEKUIACFKAABShAAQpQgAIMTNgHKEABClCAAhSgAAUoQAEKUIACFKBA6gIcYcIeQgEKUIACFKAABShAAQpQgAIUoAAFzAQYmLBLUIACFKAABShAAQpQgAIUoAAFKEABBibsAxSgAAUoQAEKUIACFKAABShAAQpQIHUBjjBhD6EABShAAQpQgAIUoAAFKEABClCAAmYCDEzYJShAAQpQgAIUoAAFKEABClCAAhSgAAMT9gEKUIACFKAABShAAQpQgAIUoAAFKJC6AEeYsIdQgAIUoAAFKEABClCAAhSgAAUoQAEzAQYm7BIUoAAFKEABClCAAhSgAAUoQAEKUICBCfsABShAAQpQgAIUoAAFKEABClCAAhRIXYAjTNhDKEABClCAAhSgAAUoQAEKUIACFKCAmQADE3YJClCAAhSgAAUoQAEKUIACFKAABSjAwIR9gAIUoAAFKEABClCAAhSgAAUoQAEKpC7AESbsIRSgAAUoQAEKUIACFKAABShAAQpQwEyAgQm7BAUoQAEKUIACFKAABShAAQpQgAIUYGDCPkABClCAAhSgAAUoQAEKUIACFKAABVIX4AgT9hAKUIACFKAABShAAQpQgAIUoAAFKGAmwMCEXYICFKAABShAAQpQgAIUoAAFKEABCjAwYR+gAAUoQAEKUIACFKAABShAAQpQgAKpC3CECXsIBShAAQpQgAIUoAAFKEABClCAAhQwE2Bgwi5BAQpQgAIUoAAFKEABClCAAhSgAAUYmLAPUIACFKAABShAAQpQgAIUoAAFKECB1AU4woQ9hAIUoAAFKEABClCAAhSgAAUoQAEKmAkwMGGXoAAFKEABClCAAhSgAAUoQAEKUIACDEzYByhAAQpQgAIUoAAFKEABClCAAhSgQOoCHGHCHkIBClCAAhSgAAUoQAEKUIACFKAABcwEGJiwS1CAAhSgAAUoQAEKUIACFKAABShAAQYm7AMUoAAFKEABClCAAhSgAAUoQAEKUCB1AY4wYQ+hAAUoQAEKUIACFKAABShAAQpQgAJmAgxM2CUoQAEKUIACFKAABShAAQpQgAIUoAADE/YBClCAAhSgAAUoQAEKUIACFKAABSiQugBHmLCHUIACFKAABShAAQpQgAIUoAAFKEABMwEGJuwSFKAABShAAQpQgAIUoAAFKEABClCAgQn7AAUoQAEKUIACFKAABShAAQpQgAIUSF2AI0zYQyhAAQpQgAIUoAAFKEABClCAAhSggJkAAxN2CQpQgAIUoAAFKEABClCAAhSgAAUowMCEfYACFKAABShAAQpQgAIUoAAFKEABCqQuwBEm7CEUoAAFKEABClCAAhSgAAUoQAEKUMBMgIEJuwQFKEABClCAAhSgAAUoQAEKUIACFGBgwj5AAQpQgAIUoAAFKEABClCAAhSgAAVSF+AIE/YQClCAAhSgAAUoQAEKUIACFKAABShgJsDAhF2CAhSgAAUoQAEKUIACFKAABShAAQowMGEfoAAFKEABClCAAhSgAAUoQAEKUIACqQtwhAl7CAUoQAEKUIACFKAABShAAQpQgAIUMBNgYMIuQQEKUIACFKAABShAAQpQgAIUoAAFGJiwD1CAAhSgAAUoQAEKUIACFKAABShAgdQFOMKEPYQCFKAABShAAQpQgAIUoAAFKEABCpgJMDBhl6AABShAAQpQgAIUoAAFKEABClCAAgxM2AcoQAEKUIACFKAABShAAQpQgAIUoEDqAhxhwh5CAQpQgAIUoAAFKEABClCAAhSgAAXMBBiYsEtQgAIUoAAFKEABClCAAhSgAAUoQAEGJuwDFKAABShAAQpQgAIUoAAFKEABClAgdQGOMGEPoQAFKEABClCAAhSgAAUoQAEKUIACZgIMTNglKEABClCAAhSgAAUoQAEKUIACFKAAAxP2AQpQgAIUoAAFKEABClCAAhSgAAUokLoAR5iwh1CAAhSgAAUoQAEKUIACFKAABShAATMBBibsEhSgAAUoQAEKUIACFKAABShAAQpQgIEJ+wAFKEABClCAAhSgAAUoQAEKUIACFEhdgCNM2EMoQAEKUIACFKAABShAAQpQgAIUoICZAAMTdgkKUIACFKAABShAAQpQgAIUoAAFKMDAhH2AAhSgAAUoQAEKUIACFKAABShAAQqkLsARJuwhFKAABShAAQpQgAIUoAAFKEABClDATICBCbsEBShAAQpQgAIUoAAFKEABClCAAhRgYMI+QAEKUIACFKAABShAAQpQgAIUoAAFUhfgCBP2EApQgAIUoAAFKEABClCAAhSgAAUoYCbAwIRdggIUoAAFKEABClCAAhSgAAUoQAEKMDBhH6AABShAAQpQgAIUoAAFKEABClCAAqkLcIQJewgFKEABClCAAhSgAAUoQAEKUIACFDATYGDCLkEBClCAAhSgAAUoQAEKUIACFKAABRiYsA9QgAIUoAAFKEABClCAAhSgAAUoQIHUBTjChD2EAhSgAAUoQAEKUIACFKAABShAAQqYCTAwYZegAAUoQAEKUIACFKAABShAAQpQgAIMTNgHKEABClCAAhSgAAUoQAEKUIACFKBA6gIcYaKjHlIp5Pk0a1OsSAEs/+PLNPdzdIff5q3C2s17ce7SVdy7H4GihQLRqXVD9O3aAjlyeBqL37TjEAa+97XF0zWoVRk/fzU01Uup0/YVPIiIsrjPq891xGsvPO1oVYzHX7pyA4tXbEG39k1QINBfs3IzoqCvfvgTC5ZvwtbFE51+um4vfYQaVcpi2Bt9jOf6ff5qfD7+N5NzL/zlM5Qt9Zjx367fDMP02cuxYdt+XL1xB965c6JY4SDUr1UZ3dqFoHDB/MZ9LZ0jrYrFxSeg76DPcevOPfw+YUSWa8O06qf139/44Dus3bLPYrE1nyiPGd8Nw8w5KzBm4izjPrlzeaFgUACeqBiMru0ao0aVcibHHz99EV1e/ND4bx4e7sjnlxehT9XAy8+2R6GgAE2qseCfTRgxZiomjXkbDetUsbnMpKQkfPDFFFXvuZM/xmOFg2w+ljtSgAL6FTC8162Z880j71Nh98LxVMc38OaArhjQp90jCC8M+QI79x1H80Y18e0nr1tFOnziHGbMXo7dB04g7G44AvL5olSxwur98enWT8E7d65MAU75vm2pjs8N/h9883jj+9GD7bq+Zj3eRmCAH/788eFngl0FpGPn+cs2wssrB9o1q5eOoy0f4ui9obXjL1+7hRY9h6J/rzZ46+XuNl2vlmXZdELuRIFsIsDAREcNLV8SUm7fTp6L/Pl88WzXFsZ/zuOTW31oO3ur3Wag+tL8RKUyyO/vi10HjmPZmh3o2LIBPh82wHh6Q2AiX5YkzEm5FQzKh/o1K6d6qRKYlA8uhqdbN3xkv8fLlkCFMsU1q+q23Ufw4tCv8NdPo1C5fCnNys2IgjI7MJEbSglE+r01BlUfD1Y3lqWKF0ZOrxyq+vsOn8Kr74+Du4c7urZtrIKUyOgY7D10EivW70LZUkUx+6ePjFTpCUzGTvoLfy5cg/lTP0XxogUzgj1Ln0MCk/1HTlu8UQsM8FdBhOFLxKi3n4dfXm9ERsXg5Nl/sWzNdhVMvfRMewx+sYvRwXDj3adzczxZtRxiY+Nw4uwlzFqwRn05WPTLaBWUObodOXEeK9bvROc2jVCyWCG7iktISMTzb36B6JhYdSMvoQ43ClAgewukNzC5cesuQrsNQalihXDp6k1sWjAeefN4P4L5x4I16keF0sULo2OrpyD3P3fC7mPzzkPYsuswnu/RCu+80jNTGsHwvi33aPfDI7Dyz7GQe0nDlt7AZMoff8PHOxd6dWqaYfV65vXRyv/HL4Zodk5H7w2tHX8vPAJT//gbtao9bnPwr2VZmgGxIAroQICBiQ4a0VoV2j77vvpiqOUHg61cZy5cQXCJIia7Dxk1Aas37cH2pT+qD0nZDIHJHz+MVL9K27tJYNKicS18+m4/ew+1e39HPxTtPqGGB2R2YGKoSqOnB6Hek5UwZsTLxtpFREajzTPvqT4xc/xw9YtTyk2Clj8XrTX54m1vYCK/1LTp8x6GvNwNz3dvpaGsfouSwOTUucupjkiz9iUiPiEBX3z/B2YtXIPP3utvDDQNN95fDH8J7VvUN+Kp/b79Fd989CpahtTOdFR5/+rSfyQ+fOs5FbpwowAFsrdAegMTGTX5/dT5+H3iCDW6LuX7oUH04NEz6P3aZ2jW8El89eEryOHpYYJ94OgZnDh9Ed07NMmURjC8b3/yTj98Om6GGkWTcvRuegOTzKhMVgpM0uOTle9T01NfHkOBjBJgYJJR0plwHmuBycXL1yG/tu/YewxxcfGoVL4k3ujXBbWrVzBepXwh9fP1UUPqFy3fjGs37uCxIkF466XuaNqwRrpq88P0hZg4fSHWz/sWQfmTp7RkRGAiv3TLaBuZ6iFfzosVLYCeHUPV/7m5uanrmP7Xcsz7ewNu3L6rTAoE5kPLkFp49flOahSE4UPIvOK/fj9cGbXq/S5qVatgEtzExMahRosBeO+1XujbraU6VFzV9KRWT+GHGQtx4vQldGjZwHicjMKZ9ucyyBc2GeJavXJZvPVyN+OIiMTEJMycuwIymujfKzfhm9dbjcZ4rnsryBQma5shMPnxi7fw9aS/cOj4OVV+76ebqakQsskUqjdGjLc4jeHZNz5HXFwc/pw0Ks22Ty3MsBSY/D5/FT4f/zsmjx2a5ogiw8ntDUw+HTdTjVRZP/9beHqY3ozKiAL5pevPRWtwJywcZUs/pqb/iMfelZNV+0dGRaNW64F4//XekP3lC/6V67cw+v0X0aFFAzWaIq0+JteeVvuu37ofrw3/Fv8bPgDy31t3H4G7mxsa1qmKEW8+a/GXyTQbJJ07OBKYyCmlr/Z+9RNcvxWGNbPHwd3dDdYCE/nC0OvVT/HR0OfV9Ku0trv3HqjXz4ZtB3Dz9l31a2yl8qUwqH9n9VoxvK/Mm/KJySgzCWzHT52PC5euISjQX71m5i7dYLHPv/fZT5AvKhkxhTGt+vLvFKBA5gqkNzDpOmCU+vFIfiTo/eqnyJ07J6Z+/a5JZQaP/B5bdh3Cmjnj4JfXx+6Kjv7uV8xftgkb5n9nMvJDRsk17DQI3do1xruv9VLvyem5fzC8b08Z+w5WbdqDpau2YtWfX6t7RNnMAxN5Tx76yY+48O913L0XDh+f3KgQXByvPNcRMp3TsPV85RMEBfipqTzyGSojcV7s3RaD+j8clSj7Tpq5GJNmLsK6ed+qKZwyvXbyb0uweOVWXLt5BwUD86lpS68938mk/uaQEpbIaNaUW90aFTH1G9P2MD8utc+by1dvqZHH1u4N3/10khqpKfXz9PRQI6nlvqtL2+QgPrV7S/lMM7+HPH3uMr6fNl+VKfclRQsFoXb1x/H2wO7Ye/Ck1WuxVJac/9Cxs8by5H64TMmi6NCiPnp0DE13f7G7A/MACmQBAQYmWaCR0nuJlgIT+bVefuUI8M+LF3q2Rq6cXurL9/a9RzF57DuoU/1xdTr5Qnr05Hm0aFxTvXHKl0YJFdZu2YtF0z9Xw0bt3V55fxwOHDmNLYsnGIMKwxebX8a9r4Ibw8gTW8uWESaN6z6hbgZSbjJHVQIBWT+l20ujULpEYXRtF6K+cMqXMwlu3n65u3G6koQ5MgVEPizkGs6cv4LJvy9VYcaot55D+INI5STrNcivLKWKJw/zL1e6mPqAticwOX/pGjw93NGueT0VzMi6DfJr+4w5KzBpxiIMeKYdKpYrqdZmkfnMV67dxqLpo9V5fpy5CJN/W4o3+nVGueBi6svi8nU71Rd8uU5rmwQmUr6UIV/wixTKjy07D2Pr7sMqrJFf0SUIaNlrKCqUKYEJnz+ci3zq3L/o9MIImI8KsHYuewOT14d/hz0HT2DrkonGfpFW+9sbmDTp+iaaN6qF4YMerqtiOIfc0EiY0qdzM1QoW1xNHVq4fDOkncwDE5lDLiNgWjWprV4TdWo8jtLFi9jUx2xpX0NgIn1QprPUr1kJZy9ehQQ+bULrQKa+pLVJUJfW5pXDM01rCUyOn7mEWT+MNClObqpkqp9sqX2JkL/LyCC5dimjasVgq4HJ7CXr8fHX09WvsNUqlUnr8tFvyBj8e/WmugGX19D5S1chZbz8TAe0aVrHYmAyZ+l6fDR2unpPa1T3CTV9aPWm3WptAUtrncgw+JfeGQvztXbSvDjuQAEK6E7A8F4naxsZfvAxVPLe/Qfo8PwHj6xhIp8hch8ma7FJOCvvhzKSTn40SjmSUu5jalerYPcaIIbzGwKNj4e+oNaOMmxLVm7F+5//jMUzPlehTXrvH1IGJqVLFEGrPu+q9eiGvNRNnco8MJERnXLPIdMuZU0r+WK/aMVm9eV8/tTPULxo8vTrlIGJ/G/5weboifNY9dfXKmA3bK37vAeZYi0jENV+H3ynPp/79WqjAoN/r97AxF8WomL5kvj+s0FW+55MF5XPe/l8lYBBNrknTLmWmqWDU/u8kampqd0bvv3xD+o+UYIS+X1O7rUlpB/74StoHVon1XtLWe8vZWAiwU27vsNQrvRj6PV0U3UPIqH+7MXrsGDaZ+p/W7sW87Kknrv2H8eAoV+hcoXS6NY+RLls3H5ATQNbO2dcuvuL7l78rBAFADAw0XE3sBSYyBxZWfRq5Z9fq9BENvnV4en+I5DLy0utzyGbfCGV1D7lF2f5Itaky5toFVoHHw7pa5ecfEj0f+tLvNK3I17v93AhVvNFXyXoqFSuJPr1bK1+MUhrs7boq2FxtW9+mo2d+4/jj4kjTT6Av5w4Cxu2H8Dfv35h9RQSjiz8ZxO2Lf1B7ZPaUEd7ApPYuDjILzUpb7ok2JEv9bIgnHyZM2z3H0SiQYfXMOaDgeqLYI+XP0Y+/7yYNOYtk+uWcCXlnGLzSsnNi3yhlF/LDV92ZYHLXq98or44yg2VbD//tkT92iD9o3CB5AU4Pxk3E6s27FIfoCkX7LUGZ29gIgGeu7s75vz8cI2StNrdnsBERlTJDZeY16tZyaRoWVxPbvYMoZHhj4abY/PApG3TumpItfRTw2ZLH7O1fQ2BifkUtZFfTsPmnQexbu63qdIYFh9My8985IWl/a0t+iq/KhoWD04rMNm+5yj6v/0lvh71qgqZUg7tbh1aW4342rX/BEaP/xVVKpRSwYVs0jevXL9tclk5PD3VQr3SX2u1flnd8Pbr2ca4jxwjf5ObPvMRJhJ4yuJ5jetXU8GfYTNcj6XARKYVyaiioQN7qDCNGwUokH0FzBe4tiRhviDqhGkLIEGtfHbKWkjyOdC48yC1LpRh1Kl8dst9jEwVfefV9K9R0v3ljyDvkRI6GzZ5742JicNvEz5Q/5Te+4eUgYl8hn4x4Q/MXboeK2aNVfcTtkzJkffguu1eVYvBP9Oluboe88BERgy+OmycyWjTvYdO4dk3Rhs/v+W9ffDI8ZDFd2W0iWFbt3Uf5McXGWVjPq03ZVtZmpLj6OeNvdNg5J6naOFAjP80Odyxdrz5KGUJM+SHRxnpK5+Xhi0qOhY5cnio0bO2liXHynXIiOr50z41GXl75dotFCkUmO7+kn3fJVhzPQswMNFx61oKTDo8N1y9EZp/4f5hxiJM/GUBdi5LTt8NU0fMV3QfMHQsomNi8Ov3yR/Atmxnzl9G38H/Q8nHCmH6t++bfOmWFb3lF1750PXw8MDlazfx58K1kFEN8ktBWqGJ3GjI2ifPdk2e8mLYgvL7qaH4T/cbgdPnL6uyU26JiYnqfx5cM039f7lpkSe5yIgL+XUkIiIKDyKj1K/whn20CkxkSo65q0wVkGG5lgIJ+UCTIaoydUZ+LVq+dgf6926rfrF6vGxJyJNJ0tqsrWEivzjJLzP7Vk1R86Zvh91H025D1C83ck75QhvSZbAaiWM+TNbaOV0tMDGEIpaebiAu8kSnPSt/NrlhsBaYDB/0zCNfnm3pY7a2ryEwMR/VYHh9Hlk/PdWmli/5suBpWpv84pVWv5HA5OCxs/jsvRdNipMbMxnGLFt6AxPz65NAYshL3Y3XZJgClXK/4JJFsXj6aBWmNO/xNhISEzGgT3v1K6aMDEu5OKt5YGJwlfcfmTpn2FILTGQf+dU4tEF19csxNwpQIPsKGN7rJHD1T/FFXUQiIqMgIwnMA5PWfd5F3ScrqamChu3dT39SC6cafpwyBAmOBiZ/LVqrftyQH4FkoWt50py8T8qPAYZF8dN7/2AemMj0kla931FPDJQpx5YCkx37jqkf546duggZgSNG8sXecC8jHuaBiYxybdbjLTVt56uRryiyD7+aBgneV8z6St2PyfRdmcb7yL1SUpKaqiP3pvLAAWubpcDE0c+b1O4N5Qeb3+atxv4jp9SIYLmnkv+r+2RF49QsW0MOmeIk9/VVHy+NPl2aq3tf8ye52VpWWk92Er/09pfs+y7BmutZgIGJjlvXUmAia0jIegiy9kLKzfBhu+rPsSpQsRaYvPnhBJw8ewnLfhtjk5xMJ3jhzS9U4j9t3Hs2zc+V8EJGW8gXmx/+l/pK5mkt+tq482BUqVAab/03/NL8omVqkfwqLb/OSFDSo0MTtSZJYICvWm/ir8VrcWjtL+owZwYmMqTy429mqF9WChV4+Phcw/Xm88ujfk2RVdNlDRKZhiMfuvIlURZRHTmkb6qPQLUWmMjK/DL/OeW6MjJkVW52Vs/+BnOWrMcXE35X85VlnQhbNnsDE/nFZP/hU9iyeKLJKKDUzmXPCBN5RKx8+d++9IdH1gCRG4Kd+46pXwBTbvYEJrb0MVvb11pgItPDZI2UtAITqYOWU3LSu+irwdJQb3nCkUy5M9x4D+zbQQV+Mv/7gzFT1JO7ZIiyYU0huXHetOOgSZvICCrD/HcJVMf++Je6kZaQSKZKyRS3d1/tpUIX88BEbtxllM4/v39pHA4uhacVmMgNvUyPs3dEnS2vE+5DAQpkHQF71zCR6Sfy/mFtk3uoEo8lP61NRsxJCG3vY3lTli33TfJZJD9uSHAjo0Vlba4N88cbg+j03j+YByZyXhlZ+eu8VVjxx1d459MfTR4rPO/vjSrokPdOWatDpuD45vVRI1pfe/5pyPu/bOaBifzbd1PmqanIMlJEQhG5Z+3fq61xrTVZG0Wmkvzy7fsWaQsXyJ/qjwGWAhNHP2+s3RueOHMJfV77FD7eudWoGvmhwt8vD/73/e/wyZ3LuHaKrSGHVHjNpr1q/S5pE9lk1OULPVobRyzZWta5i1fV9B75LiBr6lna0ttfss6rmldKAdsFGJjYbpXl9rQ+wiS/cei7oVKGBVnTGmHSc+DHyJEjB2Sx07S2Y6cuQEakyONjf/jfm3YtWClTKGTUiWEoqbVzpRWYyIgaeUxpaouV/rN2h1qgzDDP2HAuWWhs4vQFxsDEML3A0mOF5XqrVy5j8sjk1BZ9NR9hIo9AfeujH9TIHwm00trkA/7sxStqOsOEX+arD2L59dzaZi0wkZuTqbP+xq5/fjI+4tcwBFa+wP44YxHKlHrMOHc4reuSv9sbmPzy5z9qEWJL0yKsnc+ewMQwwkSms8jNRcpNpmbNWboBu/6ZZPLv9gQmtvQxW9vX0cBE6yk5jgQmMhJEbk5lIeWV//06aGnRV0No9+pzHU2evGBLX5NFDeWmdN2WfWrNIVn0TxZqNg9MDMO1ZdqX3MQbtrQCE2lbGeXGESa2tAb3oYB+BewNTORLsUwxsbS22KCR3+OFHq3Ue5Vs8qPBrv3H1NodKaeZ2Ks57PPJ2L73CFb/9Q3aPzcMdWpUtHh+e+8fLAUmMr2oec+30b55fTWKV9aMMwQ+8kVcFq+V+zdDCC51qRL6QpqBiYw6linO4ubtnQvDPv9ZLRpu+OyWNbH+WrwOO5f9qIJyezeZ3pPHJ32PFbb2eWPt3lB+BDMskCtBiWGT6emyGRabtXa8pXtIQxnif+j4WbUeyqqNu9X9n/zIaGtZd+6Go2GnNx4ZFWXJ097+Ym+bcH8KZAUBBiZZoZXSeY2WAhMZTSDp/8o/xxrnecqboUwryJ0rp8kaJuZTR2TBLNlv8Itd1IKUqW3yheWtjyaiXs2K+HLEQLW4rKVNhiiaL6AmU3g69RuhVhKX+a6pbWkFJobhm5bWr5BARxYSk0WyRoyZqkykzoZNftGXMMEwwkSmOshIFHlMc8p1RmR/GZLq4e6uRtEYNsOXV0tPyTEPTGSIa7Pub6mFMad/O8xkpIX8ciRlyaJhstCZDLdNucm1y4gQGR1kbbMUmMjwVTVFq2D+R1aJ79x/JOQDVdpHHvUr0x5s3ewNTORXjFa93lGBmgynNR/JItOEZi1YY7L2jT2BiWENE/PpGFIfWdz1gy+mqBs7eSKRYZN1XCQwM1/DxNKUHFv6mK3t62hgovWUnPQGJvKeIiOhZKHbL0cOhKz9Ipu1p+SMGvuLyUJ4qfU1GT4to6vM3zda9mfVY88AACAASURBVHpHjUCRX8zMAxNZIFb+bv7eZVhbyVJYJ68P+eX3nVd6cg0TW1/83I8COhWwJzCR9z954ouMepP3D/PNfKSufH7LwqIh9ath3EevmayRJcfKvcrhE+fSfILYnoMn0XfQ52oEh3x+mQfE6b1/sBSYyHXJGi1T/liqRsWWLVXUGJg06/G2WsT282EDjFWXsEHeT9MaYSIHiIUswi+jCmUh04mfv2ksxzC9Ve5B5f085SajJmQBfGv3m7KvrJFy+859471uWt3Vls8ba/eGw/83Wa2ht/qvr01O0+e1z9Q1GgITa8ebByYyzUpGG6esn/yb3DsaRorYWpZckEw5lW3B1E9NprTKk4fkYQTp7S9pmfLvFMiKAgxMsmKr2XjNlgITeSOUL8P+vnnUU3Jy58yJecs2QH6Fn/zVO2pepWzyhVQem9q9fRO1uvrVG7cxY/YKtb6JrBIvX26tbTJcXs5RqlhhvPRse7i7uZvsKotdydxL2eRRovLEDvmiI0Mp5YuNDOOXoZiLfhmthi+mtqUVmMgXVVnoTAIHWWRNpgXcvf8AqzbsVo87lXPIAlfyi4g8LvnF3u0QFx+Phf9sVivay6rmhsBEpu7I+h7yWGIZIqrmHj9ZUU2FkVES4ybPgaxSL79gHzx2Rq0NIoGDLYGJ1FGG0MqID/niLkMkZXHNw8fPqYBLptzIY46bdnsLlSuUUlMYAvLlxbmL1zB+6jzVToZV3y15SWDy67yVqlwpXz6IZUFbeQqKhBQpFxCT4w1PLSkfXAzzp35qY49L3s1SmCH+8vSZfm+NQdXHg9WvGjLySG6GZJO1YwaNGA9PT090bt1QPQEoJiZWPf54+bodCC5R1OQGx57ARMqXKV7yS5gstpdyk/VhZJ65fDmWIbPqEdJ7jqqV4mXbt3Kyunk1zHG2FJjY0sdsbV9HAxO7GiqNne15rLA8vUd+UYyKjlGPkly5YZe62ZIFnmWhZ8NmLTCRdpC+cfjEecz8bhiqPF7a6tVJACZPbZKnQdSpXlG1z459R9VTvOTGunG9Jyw+JUfWGFi9cQ+e6dpchY9yY7lk1Va16N1PX76Np2pXMTmnYVQKn5KjZa9iWRTImgL2BCbyeSaja6392LBoxRbIl+mUo1UNn//yWHT5nC5cMABh9x6oEQPyeST3a7IAdVqb3PfJe7B8dsvi3im39N4/WAtMDItpy+L0staTYYSJWktl9TZ8/v4A9YRCOV7uUy5evqGe8JfalBy53qWrt0Ee6y6jU8bLWnYNqhurIQ8pGPje15CnmMnTBQ0jcmUqiozmMDx62JqTOMuj5eU65B5EFuFv16yeQ5831u4N5f5NPnfk3iykfnXcuBWmpknJtaZ8nLG14+VHgZRPyZHRJBN+WYBenZqiYrkSyQu2LtuknjK48JfR6scmW8uSCssIqNeGf6ueTCdTp+RHUwnvZDqshDzp7S9p9VH+nQJZUYCBSVZsNRuv2VJgIofKF5mvf5qNHXuPqi+KFcuWUB8ehrBE9pEvpPJmnD/AVz0KTjb5YJI1AtJay2LvoZN49o3kp65Y2uTDacyIl9Wf5LF38iv/uUtXVeovIYH8yiILg6W20rmh3LQCE9lPvtDKY4Q3bT+Am7fvqRBGbiZkITR5rJts8hg1WRPh/L/XEJjPF00aVEd8QqJaCd4QmMh+8kEi0zhk2Kgs/CZftKQssfrm5znqJkF+5a9cvpQaISMfRrYGJlK+TN2QRUjlBkNuDGTES/1aldUcVXGXtWbkZkLaUH5ll78/3aYhnuvWyuQXAnN3CUwWrtiMpk/VwMbtB1VoJKNr5NcvSwukySgf+fVBHqEsH6T2bJbCDFlQV57QlHIz/yIqN1O//LkMW3cfwfWbd9QXYXmEYZP61dG5TUOTEQX2BiYyjFceiS1De1M+rlCuR+r66be/Yv+R08id00tNwZC+J/Oo96+eqi45tcDE1j5mS/tm1cDE0K4SOImd3IAZFqVL2ebWAhPZR0YSdX/pI/X6kSl0hqc0mfc9WTjwxxkL1Q2zBKyySagrIaaEnsmv00Pqpjrl04Dk5l5GA63ZvAfx8QmoXqUs2oTWVXPtLT3OeMioCWrBQnmyFDcKUCB7C9gTmMioxfXb9mPj/PEWP5fl8bANn34Dz3Rpoe4PDJssgP/b/JXYf/i0eqKO/DAlP/LIDyRtm9VLc6FuKWfqrGVqfZERbz6rvlin3NJ7/2AtMJGyDUFPysBEPi/lSTryw5S8n8u9hlzLu59NsmmESWxsHEK6vKl+ODM8YShlPeR+a/rs5ViyahskQJcRFzLyVu5vnu/RWi1gb22TQOGTcTOwYet+xMbFo22zuuo+x9pmy+dN8meO5XtDCfJ/nbsSd+6Fq7VcOrRogLWb95qMMLF2vNQpZWAi90g//boY+w6fwrUbd9QPmPJZ+3q/zuo+1LBZuhbzsgz7SiAni/8fPXleBVQyvVvujeW+L739JXu/U7D2ehVgYKLXlnWwXtYWfXWwWB6eRQRk/rWEWWvnjkt1eKul6tgbZqSHxN5zyBfrts+8jxFDnk1zWLNcz3ujf8L5i9dsHrabnjrwmMwXkNFbn3wzA5sXfW8yak5uHnsM/FiNGOvcxr7AMPNrxSugAAUoQAEKUIACFNBKgIGJVpI6K4eBic4a1I7qJD+laAh6dGxi0xBg86LtDTPsuDTjruk5hywsK0NaZRpWylFSMg9bRp3I3GdPDw81JFXWtZFFbw0jkNJzjTzGtQT+XrNd/YpWvEgB5M3jg9Pn/1WjueSX25QLM8qvm71f+0z92vbnjx+mOnLLtWrIq6EABShAAQpQgAIU0FqAgYnWojopj4GJThoyHdWQIaQSLqyY9ZXJIri2FpWeMMPWsg37peccMv1MFsSTqUyyToZhfRxZN2bJyi24FXYf7m5uKFvqMTzXvRXaNE2ersVNHwIr1u/ChGnz1XpMcXEJ6vHp7ZvXw4Bn2huHcMtijW9++D12HTihFkyUtU64UYACFKAABShAAQpkXwEGJtm37VlzClCAAhSgAAUoQAEKUIACFKAABawIMDBh16AABShAAQpQgAIUoAAFKEABClCAAmYCDEzYJShAAQpQgAIUoAAFdCEgT5i7GxGHgLxeuqhPdq1EUhJw+34M3NyA/L45syuDbup9614MAv3Yjrpp0GxWEQYm2azBWV0KUIACFKAABSigVwEGJvpoWQYm+mhHQy0YmOirPbNbbRiYZLcWZ30pQAEKUIACFKCATgUYmOijYRmY6KMdGZjoqx2za20YmGTXlme9KUABClCAAhSggM4EGJjoo0EZmOijHRmY6Ksds2ttGJhk15ZnvSlAAQpQgAIUoIDOBBiY6KNBGZjoox0ZmOirHbNrbRiYZNeWZ70pQAEKUIACFKCAzgQYmOijQRmY6KMdGZjoqx2za20YmGTXlme9KUABClCAAhSggM4EGJjoo0EZmOijHRmY6Ksds2ttGJhk15ZnvSlAAQpQgAIUoIDOBBiY6KNBGZjoox0ZmOirHbNrbRiYZNeWZ70pQAEKUIACFKCAzgQYmOijQRmY6KMdGZjoqx2za20YmGTXlme9KUABClCAAhSggM4EGJjoo0EZmOijHRmY6Ksds2ttGJhk15ZnvSlAAQpQgAIUoIDOBBiY6KNBGZjoox0ZmOirHbNrbRiYZNeWZ70pQAEKUIACFKCAzgQYmOijQRmY6KMdGZg4vx3Pnj2LtWvXomvXrvD393f+CbPhGRiYZMNGZ5UpQAEKUIACFKCAHgUYmOijVRmY6KMdGZg4rx2vXLmCVatW4fz58+oktWrVQps2bZx3wmxcMgOTbNz4rDoFKEABClCAAhTQkwADE320JgMTfbQjAxPt2/H27dtYs2YNjh07pgr39vZGw4YNUbduXe1PxhKVAAMTdgQKUIACFKAABShAAV0IMDDRRTOCgYk+2pGBiXbtGB4ejnXr1mHfvn2qUC8vL9SrVw/169dX/83NeQIMTJxny5IpQAEKUIACFKAABTJQgIFJBmI78VQMTJyImwlF37oXg0C/nJlwZv2c8ptvvoGEJrLVrl0bjRs3VqNLuDlfgIGJ8415BgpQgAIUoAAFKECBDBBgYJIByBlwCgYmGYCcgadgYOI49rZt23D9+nWEhobC19fX8QJZgs0CDExspuKOFKAABShAAQpQgAKuLMDAxJVbx/ZrY2Biu1VW2JOBSVZoJV6jNQEGJuwbFKAABShAAQpQgAK6EGBgootm5Bom+mhGYy0YmOisQbNZdRiYZLMGZ3UpQAEKUIACFKCAXgUYmOijZTnCRB/taKgFAxPr7RkTE4NNmzapBVx9fHz01fA6qQ0DE500JKtBAQpQgAIUoAAFsrsAAxN99AAGJvpoRwYm1tsxPj4eO3bswObNmxEdHY06deqgVatW+mp4ndSGgYlOGpLVoAAFKEABClCAAtldgIGJPnoAAxN9tCMDE8vtuGfPHmzYsMH41JsyZcqgefPmKFCggL4aXie1YWCiUUP+Pn81+nRu9khpm3YcxOlzl/FCz9bqb2fOX8aG7QfQqM4TKFOqqEZnZzEUoAAFKEABClCAAgxM9NEHGJjoox0ZmJi245EjR7B27VrcuXNH/aFo0aJo2bIlihUrpq8G11ltGJho0KCRUTEYMWYK+vVqgxOnL0GGWBUMCkDJYoVw6coNnLt4FX27tVRn+nbyXBQIzIeK5UqgWqUyGpydRVCAAhSgAAUoQAEKiAADE330AwYm+mhHBiYP23HKlCm4fPmy+ofAwEA0bdoUFSpU0FdD67Q2DEw0aljDCJN5f280BiYPIqMQERGFXQdOYOyHr6gzTZ+9HM93b4Wps5ahf682Gp2dxVCAAhSgAAUoQAEKMDDRRx9gYKKPdmRg8rAdV61aBRlh0qRJEzzxxBP6amCd14aBiUYN/PNvS1C3RkVUrRj8SIkz56xA6FM1cPHydURFxeLMhcsoWawwWjSuqdHZWQwFKEABClCAAhSgAAMTffQBBib6aEcGJg/bMTY2Fl5eXvpq2GxSGwYm2aShWU0KUIACFKAABSigdwEGJvpoYQYm+mhHBib6asfsWhsGJtm15VlvClCAAhSgAAUooDMBBib6aFAGJvpox+wSmERGRsLb21tfjcbaGAUYmLAzUIACFKAABShAAQroQoCBiS6aEQxM9NGOeg9MoqKisHXrVuzcuRMdOnRApUqV9NVwrI0SYGDCjkABClCAAhSgAAUooAsBBia6aEYGJvpoRmMtbt2LQaBfTt3UyhCU7NixA3FxcapedevWVY8I5qY/AQYmGrTp9di7OBd9HYlIsrk0H/fceCJPCZv3544UoAAFKEABClCAAqkLMDDRRw/hCBN9tKOhFnoJTCQo2bZtGyQokUVcZStfvjxCQkJQqFAhfTUaa2MUYGCiQWc4EnkJA0/+hPsJkTaX1il/HXxcsofN+3NHClCAAhSgAAUoQAEGJtmhDzAw0Vcr6yEwWbNmjQpKDCNKypUrpx4RzKBEX33VUm0YmGjQxgxMNEBkERSgAAUoQAEKUMBBAY4wcRDQRQ5nYOIiDaHRZeghMFm4cCEOHDjAESUa9YmsVAwDEw1ai4GJBogsggIUoAAFKEABCjgowMDEQUAXOZyBiYs0hEaXoYfA5N69e5ApORxRolGnyELFMDDRoLEYmGiAyCIoQAEKUIACFKCAgwIMTBwEdJHDGZi4SENodBl6CEw0omAxWVCAgYkGjcbARANEFkEBClCAAhSgAAUcFGBg4iCgixzOwMRFGkKjy2BgohEki8kUAQYmGrAzMNEAkUVQgAIUoAAFKEABBwUYmDgI6CKHMzBxkYbQ6DJcOTA5f/481q9fj9DQUBQvXlyjGrMYPQkwMNGgNRmYaIDIIihAAQpQgAIUoICDAgxMHAR0kcMZmLhIQ2h0Ga4YmEhQsm7dOly8eFHVsmzZsujdu7dGNWYxehJgYKJBazIw0QCRRVCAAhSgAAUoQAEHBRiYOAjoIoczMHGRhtDoMlwpMJGARIISCUxk8/LyQr169VC/fn3139woYC7AwESDPsHARANEFkEBClCAAhSgAAUcFGBg4iCgixzOwMRFGkKjy3CFwMQ8KJGq1alTB40aNYK3t7dGNWUxehRgYKJBqzIw0QCRRVCAAhSgAAUoQAEHBRiYOAjoIoczMHGRhtDoMlwhMJk+fTouXLigalS1alU0adIE/v7+GtWQxehZgIGJBq3LwEQDRBZBAQpQgAIUoAAFHBRgYOIgoIsczsDERRpCo8twhcDk1KlT2LNnD5o2bYqgoCCNasZisoMAAxMNWpmBiQaILIICFKAABShAAQo4KMDAxEFAFzmcgYmLNIRGl+EKgYlGVWEx2VCAgYkGjc7ARANEFkEBClCAAhSgAAUcFGBg4iCgixzOwMRFGkKjy2BgohEki8kUAQYmGrAzMNEAkUVQgAIUoAAFKEABBwUYmDgI6CKHMzBxkYbQ6DKcGZjEx8djx44d6rHABQoU0OiKWQwFHgowMNGgNzAw0QCRRVCAAhSgAAUoQAEHBRiYOAjoIoczMHGRhtDoMpwVmMiaJBs2bEB4eDjKly+Pnj17anTFLIYCDEw07QMMTDTlZGEUoAAFKEABClAgXQIMTNLF5nIHMTBxuSZx6IK0DkyOHDmCdevW4fbt2+q6ihYtipYtW6JYsWIOXScPpoAlAY4w0aBfMDDRAJFFUIACFKAABShAAQcFGJg4COgihzMwcZGG0OgytApMzp49i9WrV+Pq1avqyuRpN/LUGxldwo0CzhJgYKKBrBaByYr1u/Bk1XIIDPAzuaK5Szfg2KkLGNi3A4Ly+yMyKho//7ZU7TP4xS5wc3PToAYsggIUoAAFKEABCmR9AQYmWb8NpQYMTPTRjoZaaBGYzJ8/H4cOHVJF+vr6okmTJqhWrZq+oFgblxRgYKJBs2gRmEyfvRxxcfFoWKcqDhw5ra6qacMnVYCyYv1OlClZFMEli+LQsbOIiIzGzdt3UffJiipE4UYBClCAAhSgAAUoADAw0UcvYGCij3bUMjDZtWsX1q9fj4YNG6Ju3br6AmJtXFqAgYkGzaNFYGIYYXLrzj2TwCQpKQl/r9mO57u3Ulcqocqv81bi1NnLGPHms/DxzmWswe/zV6NP52YmNZL9p/35D26H3cfwQX3U35au2obrt8JQPrgYnqpdRQMBFkEBClCAAhSgAAUyX4CBSea3gRZXwMBEC0XXKUOLESZSm9jYWHh5eblOxXgl2UKAgYkGzaxFYHLkxHls2H4Arz7X0eSKXh02DjWfKI+nalfF/iOn0b19CP5atBYeHh7o2q6xcd/IqBiMGDMF/Xq1wYnTlyCP2CoYFICQ+slD1Sb+sgCvvfC0+u+ff1uCl55pj6mzlqF/rzbGMqxNC9q88xD2HT6FapXKqBEwUdGx+HHGQsTHJ+Ctgd3h6eGhgSKLoAAFKEABClCAAo4JMDBxzM9VjmZg4iotoc11aBWYaHM1LIUC9gkwMLHPy+LeWgQmGlwGDCNM5v290SQw2X3gBO4/iERog+rqNNv3HMWFf6/hzr1wvNL3YUBjmBbUpW1jrNqwS+1b5fHSqFiupBqhsmrjbvTsGKoCk29++guBAf4Y0Kcd3N25jooW7ccyKEABClCAAhRwTICBiWN+rnI0AxNXaQltriOtwOTatWvIkyeP+j9uFHA1AQYmGrSIqwQmMnKkbo2KqFox2FgrCTre/WwSnqpVBXVrVkLY3fvw982DbXuOonmjJ1G8aEHjvoYRJu7u7iaBSbngYvj51yXo37stcnrlwLWbd7Dn4Elc+Pc6+jzdDH6+PhoosggKUIACFKBA1hJYtGKLGq25ePpokws/fOIcPho7HafP/YsihQIx7I0+aoQmN+cLMDBxvnFGnIGBSUYoZ9w5rAUmYWFhWLNmDeQxwQ0aNECzZqZLC2TcFfJMFLAuwMBEg97hKoGJo1WxNi3o28lzVdE1qpTFtZthaBlSC5NmLkYOTw+88lwn5M7FuYSO2vN4ClCAAhTIOgI3bt3Fc4M/R9i9BygQmM8kMJG1w1r2fge9OjVFj46h2LB1Pz4ZNxMrZn2FAP+8WaeSWfRKGZhk0YYzu2wGJvpoR0MtzAOTiIgItYDr7t27jRWVRwP37NlTXxVnbXQhwMBEg2bUS2CiAQWLoAAFKEABCmQbgfVb9+Obn+eYBCY79x3H4JHjsWXxROOU1e4vf6SmtHZu0yjb2GRWRRmYZJa8tudlYKKtZ2aXZghMYmJisHnzZmzfvl0tHyBbiRIlEBISgpIlS2b2ZfL8FLAowMBEg46hRWBy4PhxnDx/wear8XB3R4Ma1VEwMNDmY7gjBShAAQpQgALaCVgKTGYvXgdZS+yvn0YZT/Tup5PUQuxvD+yu3clZkkUBBib66BgMTPTRjoZaSGBy/tQhNf0mOjpa/XPx4sVVUFKqVCl9VZa10Z0AAxMNmlSLwGT7/v3Ye/SYzVcjT8npENoEhYOCbD6GO1KAAhSgAAUooJ2ApcBkxpwVWLNpD2aOH2480YdfTUMOT0+MHNIXCYlJkC/13JwjIF+0H0THI29uT+ecgKVmiIC04/3IOLi5Ab7eOTLknDyJ8wTuR8Rh/56t2LxpowpKGjUKQfESJZx3QpZsIpDD050iDggwMHEAz3CoKwQmkVHRCAu/j6TERJtrJKELAxebubgjBShAAQpQwETA2giTBcs3Y9YPI437ygiTAkH5MHRgD0TFJCA23vbPapLbJ5CUlIT4hCTwC4J9bi63dxIQl5D8OmFbulzr2H1B8p7nlhSPq1euoHgJTr2xG9DBA/x8GDo6QsjAxBG9/451hcDkzr37WLpuHR5ERtpco2KFC6N9kxDj/jfv3EFMbKzNx8uOPt7eyOfra9cx3JkCFKAABSigBwFLgcmOfccw5MMJ2LJ4Atzk53EAXQeMQo+OTdCt3cPPXD3U3xXrwCk5rtgq9l8Tp+TYb+bKR6T1WGFXvnZeGwUYmGjQB/QSmBw8eRLb9x+wS6RNo0Z4rNDDRxP/Pn81+nQ2fSSYPDFg2p//QB5xPHxQH1X+zDkrkJCQiApliqNezUrGc4bdC8e23UfRpmkdk+vYvPMQ9h0+hWqVyhgfzSg3qhcuX0fXto3h453LruvmzhSgAAUoQAFHBSwFJrGxcWjecyj6dmuJ7u1DsHHHQXz45TQs/+NLBOX3d/SUPD4NAQYm+ugiDEz00Y6GWjAw0Vd7ZrfaMDDRoMX1EpgcOHECW/bstUtE1lF5rFAhdUxkVAxGjJmCfr3aIOxuOK5cuwU3d3d1wyjbxF8W4LUXnlb/vXzdTly7eQf1nqyE8sHFjOc8evI8/liwRt1o7jt0Uv17lcdLo2K5kipwWbVxt3rSgGwjxkxFcIkiaN+iPgID/Ixl2BraHD99EX8tXoeqj5fG060b2lVv7kwBClCAAtlX4OqNO+jy4kjExycgKjoGefN4o0OLBnj/9d4K5cDRM/jkmxk4fe4yihTKj3de7YXQBtWzL1gG1pyBSQZiO/FUDEyciKtx0deuXVOPCJbHAlevbvl9joGJxugsLkMFGJhowM3AJDkwkc0QVmzacdAkMNl94ATuP4h85IZx2p/L0K9nG+PxhhEmdZ+siFUbdhkDk3LBxfDzr0vQv3db5PRKnoc3ffZyPN2qoQpRurZrbCxDFtcLqVcNOXJ4phranL90DUtXbcPjZUugacMaGvQEFkEBClCAAhSgQGYKMDDJTH3tzs3ARDtLZ5UkQcm6detw8mTyD5yBgYF47bXXLJ6OgYmzWoHlZoQAAxMNlBmYPAxMfv5tCerWqIiqFYONsjIy5N3PJuGpWlXQpV1jNbokwD+v+uWtUvmSxik2coBM3xk76S8VohQMymcs49vJc9V/16hSFrFx8ahRpRwWr9yC++ERaNe8PkoXL2zc19HQRoMuwSIoQAEKUIACFMgEAQYmmYDuhFMyMHECqkZF3rhxQwUlx48fVyV6eXmhTp06qFevHnLnzs3ARCNnFuM6AroMTA6fOIePxk7H6XP/okihQAx7o4/Jl3Jz/tT237TjEAa+97XJITJyYf+qKcZ/Y2DyMDBxha69aMUW5M6VEy0a10w1tJGpOBu3H1Drn/Tp3NwVLp3XQAEKUIACFKCAAwIMTBzAc6FDGZi4UGP8dymWgpLatWujfv36VoMSQy04wsT12pNXZLuA7gITGaHQsvc76NWpKXp0DMWGrfvxybiZWDHrKzWqwXxLa38JTD4dNwNzp3xiPFTWvJf5yoaNgYlrBSa2d3/uSQEKUIACFKCAngQYmOijNRmYuF47/v3339i9e7caUWJrUMLAxPXakVdkv4DuApOd+45j8Mjx2LJ4Itzdkx/n1/3lj9RCoZ3bNHpEKK39JTAZ/d2vanV7axsDEwYm9r/0eAQFKEABClCAAloLMDDRWjRzymNgkjnuqZ31wYMH2L59Oxo0aJDmiBLzcjjCxPXak1dku4DuApPZi9dh3t8b8ddPo4wK7346CQWDAvD2wO6PyKS1vwQmrw0fh3x+eeGbxxu1qz+OwQO6qv82bAxMkgOTuPh4REZHA0l2dEA3wDdPHtsP4J4UoAAFKEABClDAigADE310DQYm+mhHQy0YmOirPbNbbXQXmMyYswJrNu3BzPHDjW0pT03J4emJkUP6PtK+ae0vT225fjMMfr55cO3GbXw9aTaC8vth3Mevq7IiYxJwKvYyXj/zM+4nRNrcfzrlr4NhRboiMQlwcwP2HT2E/UeP2Xy8h4cH2oaEIMA/vzrmQUQ4lm/cgAeRtl9DscKF0bxBw+RrAHD87Gls22ffY4XbhjRBUP4gdQ3RMVFYv30b7oaH21yPoIB8CKlTHx4enuqYqzeu4tCJEzYfLzs+8fjjKBhY0K5juDMFKECBrCjg6eEGL0/3rHjpvGYKZIgAA5MMYXb6RNxJNwAAIABJREFUSRiYOJ04Q0/AwCRDuXkyjQV0F5jIiJEFyzdj1g8jjVQywqRAUD4MHdjjET579993+BSeG/w/HFg9FW5uboiMjsepOAlMJtsXmARIYNLlYWBy7LD9gUljCUwC/gtMHmD5pnQGJolJyYHJuTPpCExCEBTwMDBZsWkjwu7ft7mbFsifHy0bNoaHu4c65sLlS1i3Y7vNx8uOTevXR7FCRdUxiYmJuBd+FwmJiTaXIVO3fPP4wtMj+XHF3ChAAQq4qoCnpzsDE1dtHF6XSwgwMHGJZnD4IhiYOExoVwF79+6Fv78/Spcubddxtu7MwMRWKe7nigK6C0x27DuGIR9OwJbFE1SgIVvXAaPQo2MTdGsX8kgb2Lv/ll2H8d5nP2Hzou+NZXFKTvKUHBndsmTtOrsDk46hTZAjR3JYceLceazZts2u10qLBg1QpkRxdUxMXByWrluPW3fu2FxGgJ8f2oQ0ho+VR6HZXBB3pAAFKEABClAgUwUYmGQqv2YnZ2CiGWWqBR09ehRr167F7du3UaBAAbzyyitOOTEDE6ewstAMEtBdYBIbG4fmPYeib7eW6N4+BBt3HMSHX05Ti7YG5feHfJAOGPoVnu/RSj1qOK39p85ahscKB+KJSmVw994DjBgzFU9WLaceVWzYGJi4VmCyeM1a3LQzMGkf2oSBSQa96fA0FKAABShAAWcJMDBxlmzGlsvAxLneZ8+exerVq3H16lV1oqCgIDRt2hTly5d3yokZmDiFlYVmkIDuAhNxO3D0DD75ZgZOn7uMIoXy451XeyG0QXVFGp+QgCea9sfHQ19A13aN1b+ltv+CfzZh+uzl+PfKTfUo4RaNa2HIS92QO5cXAxMAHUKb4LFCDEwy6PXK01CAAhSgAAUokIoAAxN9dA8GJs5pxytXrmDlypW4cOGCOoGfnx9CQkJQrVo155zwv1IZmDiVl4U7WUCXgYmTzR4pniNMGJiYd4rf569Gn87NHukrc5duwLFTFzCwbwc14unytVtYtWG3esLQgD7tMrrr8nwUoAAFKEABXQkwMNFHczIw0b4dZerNpk2bVMG5c+dGw4YNUa9ePe1PZKFEBiYZwsyTOEmAgYkGsAxMGJiYdyN5MlNIvWrIkcMTV67dgpu7u5oiJtuK9TtRpmRRBJdMXqh24/YDKjjp1ampsRh5OtO23UfRpmkdk6LPXryK1Rt3I2dOLzzXraX6299rtuPw8XPo1SkUxYvyaUEavKRZBAUoQAEKZFEBBiZZtOHMLpuBifbteOrUKcydO1eFJPXr14eX18PR8tqfzbREBibOFmb5zhRgYKKBLgMTBibm3cgwwmTTjoMmgcnN23dVwPF891Ymh8haOf17tTH+29GT5/HHgjUY/GIXbNx+EPHx8SgYFICQ+slDJn+YvhCvPt9J/XdUdCy+mPC7egqUTBszbLaOcrEUwmjwsmARFKAABShAgQwXYGCS4eROOSEDE6ewIjIyEt7eD+8VnXOWR0tlYJJR0jyPMwQYmGigysCEgYl5N1q0Ygty58qJFo1rmvzp1WHjUPOJ8niqdlXsP3IaFYKLQZ7U5J07l8kUnpQjTOb9vdEkMJFHYdepURElHns4muTMhSu4dPmGMVCRkxpGuRQpFIgDR06r62ja8EkEBvg9MsrFPITR4GXBIihAAQpQgAIZLsDAJMPJnXJCBiZOYc20QhmYZBo9T6yBAAMTDRAZmDAw0aAbmRQRFxePsZP+Qr+ebVAwKJ/xbzJ95+/V29WTmurXqoyLl6/j+OmLuHX7Hp7v0RoFAv2N+xpGmMjfUwYmSUlJj4xysRTCaF0nlkcBClCAAhRwtgADE2cLZ0z5DEzscw4LC0NCQgICAwPtOzCD9mZgkkHQPI1TBBiYaMDKwISBiQbdSPMibB3lUigonzGE6d6hiebXwQIpQAEKUIACGSXAwCSjpJ17HgYmtvlGRERg/fr12L17N4KDg/HMM8/YdmAG78XAJIPBeTpNBRiYaMDJwISBiQbdiEVQgAIUoAAFKOCgAAMTBwFd5HAGJqk3RExMDDZv3ozt27eraduy1axZE23btnWRFjS9DAYmLtksvCgbBRiY2AiV2m4MTBiYaNCNWAQFKEABClCAAg4KMDBxENBFDmdgYrkhJBzZsWOHCkuio6PVTpUrV0ZoaCjy5Xs4hdtFmtF4GQxMXK1FeD32CDAwsUfLyr4MTBiYmHeNzXv34s7dezb3rty5cqF25crw881r8zHckQIUoAAFKEABUwEGJvroEQxMHm3HY8eO4Z9//kF4eLj6Y5kyZdCsWTMULPjwIQCu2voMTFy1ZXhdtggwMLFFKY19GJgwMDHvIgtXr8GVGzds7l15fXzQvkkI/H191THXb9/GzgMHkSh3DDZuwcWLoXLZsjbuzd0oQAEKUIAC+hNgYKKPNmVg8mg77t+/H4sWLULRokXRsmVLFCtWLMs0NgOTLNNUvFALAgxMNOgWDEwYmGgdmFy9cQOL1q5DYmKizT20ZuVKqF21qnH/E+fO495/v0LYUoiHhwfKFC8Gv7wc5WKLF/ehAAUoQAHXE2Bg4nptkp4rYmBiWe3UqVMomwV/HGNgkp5XAY9xFQEGJhq0BAMTBiauGJis3LIVpy9csLmH58qZE+2bNEFQgOvOgbW5MtyRAhSgAAWypQADE300OwMTfbSjoRYMTPTVntmtNgxMNGhxBiYMTPQamPw+fzX6dG5mUr3IqBh8/PV0jB72Ijw9PNTflq7ahuu3wlA+uBieql1Fg1cVi6AABShAAQrYL8DAxH4zVzyCgYkrtkr6r4mBSfrteGTmCzAw0aANGJgwMNFjYCLByIgxU9CvVxucOH1JPbauYFAAQupXgwQpPTo2MQYmP/+2BC890x5TZy1D/15tNHhVsQgKUIACFKCA/QIMTOw3c8UjslNgcufOHWzcuBH+/v4ICQlxxeZw+JoYmFgm3P3gjPpDzTzBDhuzAOcJMDDRwJaBCQMTPQYmUifDCJN5f29MNTDZvucoLvx7DXfuheOVvh01eFWxCApQgAIUoID9AgxM7DdzxSOyQ2ASFhamghJZzFW23Llz491333XF5nD4mhiYmBL+dmMDJl1ZgfCE5EdD5/XIhXeKdULH/LUdtmYB2gswMNHAlIEJAxO9BiYycqRujYqoWvFh8h0ZFY2Pxk5H+xYNUKp4IVy8fB3+vnmwbc9RNG/0JIoXdf3H22nwsmcRFKAABSjgggIMTFywUdJxSXoOTO7evYsNGzYYgxLhqVWrFho2bIi8Ol14n4HJwxfB8ajL6HH060deFRKa/FVxKIp6BaTjFcNDnCnAwEQDXQYmDEz0Gpho8PJgERSgAAUoQIEME2BgkmHUTj2RHgMTS0FJzZo10ahRI90GJYZOwsDk4cvlxyvLMenqSouvn3HBLyDUn2sBOvXNJR2FMzBJB5r5IQxMGJgwMNHghcQiKEABClCAAg4KMDBxENBFDtdjYLJlyxasXr1aCWeXoISByaMvqNQCk3eKdcQzBRq7yKuQl2EQYGCiQV9gYMLAhIGJBi8kFkEBClCAAhRwUICBiYOALnK4HgMTWTx/zZo1qFevHnx9fV1EOmMugyNMHjovur0TH57/0yL8lHKvolbeMhnTKDyLzQIMTGymsr4jAxMGJgxMNHghsQgKUIACFKCAgwIMTBwEdJHD9RiYuAhtplwGA5OH7OEJUeh2dCyuxoaZtMWTeYIxrfxrmdI+PGnqAgxMNOghDEwYmOgxMLl55w72HjmK+MQEm18lhYOCUKNiRZv3544UoAAFKEABLQUYmGipmXllMTDJPHtnnJmBiamqhCYy0mRXePJjhWvlDVZPyMnrkdsZ/CzTQQEGJg4CyuEMTBiY6DEwuXH7NhavXYfYuDibXyWVygSjcW0+Es1mMO5IAQpQgAKaCjAw0ZQz0wrLaoHJ0aNHkZiYiMqVK2eamSufmIGJK7cOry0tAQYmaQnZ8HcGJgxMGJgkCzAwseENg7tQgAIUoIDTBBiYOI02QwvOKoHJ2bNn1bokV65cgY+PD9588014enpmqFVWOBkDk6zQSrxGawIMTDToGwxMGJgwMGFgosFbCYugAAUoQAEHBRiYOAjoIoe7emAiAcnKlStx4cIFJebn54eQkBBUq1bNRQRd6zIYmLhWe/Bq7BNgYGKfl8W9GZgwMGFgwsBEg7cSFkEBClCAAg4KMDBxENBFDnfVwOT27dtYu3YtZAqObN7e3mjYsCHq1q3rInKueRm3rt5GYOH8iD20D/enTkD8xfNw8/SER4FCyDfyC3gULOyaF86rogAABiYadAMGJgxMGJgwMNHgrYRFUIACZgJVQl/AurnfIjDAz+Qvm3YcwujvfsXyP76kGQVMBBiY6KNDuGJgsmfPHixdulQB58iRQz0euEGDBvDy8tIHejprkRQRDjefvBaPfjDrF0Qsmo2kiAfq70kA3P/7/8YDPD1RaMG6dJ6dh1HA+QIMTDQwZmDCwISBifMCk9/nr0afzs1MiCOjYjBq7DR8NfIVk3//etJstG1WFxXKFNfglc0iKECBzBaoFPI8Nsz/7pHA5Pjpi+j5yifYv2pKZl8iz+9iAgxMXKxB0nk5rhiYyOiSSZMmoUaNGmjcuLEaXZLdNglHotYsR+Ta5Ui8fhWJD8KNBF5VqsNv8DDjaBEZTXJn+CCbiPJ06YM8zw+0aV/uRIGMFmBgooE4AxMGJgxMnBOYSDAy8supGNCnHY6cOI/4+HgUKRSIhnWqYuacFejbraWRfuP2Awi79wDlg4uZBCYr1u/Ck1XLPfKF69KVG/h17ioMH9RHlZGQkIhf567ExSs38OGQviZNaim0kR1k/zIli6JezUpq/z0HT2L/kdMoXCA/2jSto8G7C4ugQPYUkNetbG99NBEfD30BefM8/GISFxeP+cs24l54BOZN+SR7ArHWVgUYmOijc7hiYCKyUVFRyJ3bvke/yiiL6G0bEX/uNDxLlUGueo2Qp9cLLttQiTevIuHGDeSo9ITJNUpYcqN/d+NoEcMfZdSI23//Q0KTgM/Hq//14I9pkLrbsuWq8xT8R/zPll25DwUyXICBiQbkDEwYmJh3o4Wr1+DKjRs29668Pj5o3yQE/r6+6pirN25g0dp16hF1tm41K1dC7apVjbuv3LIVp/9bjMyWMnLlzIn2TZogKCCf2t1VHitsCCvm/b0x1cBk+l/LcfPOXZQqVhhd2zU2Vnn67OWQL1hd2jbGqg3JX8KqPF4aFcuVfCR0OXfxKuYsWY93X+tlPF5CmxFjpqBfrzYIuxuOK9duwc3dHd3bh+DUuX9x6/Y9Y2AiB03+fakKaGpUKWcLO/ehAAUsCNRs9ZL616joWOTK6QU3w904gJw5vVC21GN4//XeHE3G3vOIAAMTfXQKVw1M7NW1FhpIYJKndz97i3PK/jISJGrNP4g9uBcJN+XeVSIQ2dzg3bwNfAe9r/6XTK0Jn/K9xWuQt2jDUYWWbFL7hH02DDE7Ntt0zbmbtobfm8Nt2pc7USCjBRiYaCDOwISBiXk3YmCiwQvrvyJ+/m0JGtSqgkrlSxoLjYyKxsgvp6FbuxAUKZQfV67fRt0aFbH30El4585lcYSJu7t7moGJnODPRWvRvnl9+HjnMp7PENps2nEwzcBEDpo6axn692qjHQJLokA2Fejw/AeY+d0w+PvlyaYCrLa9AgxM7BVzzf0zOjCJiIjAvXv3UKRIEU1Bbg16QY0ssbTJaIx8H4y2uv6HIxeS2roiKcuN2b4RYaM/SPVUAaO+hFfNerg/+TtELp6b5mUFfjcNnqXLpjrCJGXAgqQk5Bs1BjlrNUizbO5AgcwQYGCigToDEwYmDEySBSqVCUbj2rU1eFVpV4RM5dmw/QBefa6jSaEX/r2O8VPn4eVnO6hpNC0a1cQfC1YjMjoGQwf2MNlXQhsJZKpWDDb5dxm9cifsPt56uTtmL1mPvD65ce7SNTxRMRgNalXWrhIsiQIUoAAFbBJgYGITk8vvlFGBSUxMDDZv3owdO3bA19cXr7/+uqY219o3TLW8nHUbIt8Hn2t2TvNFVmUKkP+bw1WAYWm7M+wNxB7e/8ifkpKS4Pbf0D6vytUQ8L/vbZ5iYxhhknD9Km6+2D3Vukk7e4c0g9/QUZoZsCAKaC3AwEQDUQYmDEwYmLhuYKLBS5xFUIACFKBAFhFgYJJFGiqNy3R2YCJroklIImFJdHS0uprKlSujXbt2yJkzp2aItwY9j/hzZx4tTyr4XyBhCBgcPam1RVbl0b1BU+dYLD6tQEcOMgQmVkejqKokIUmm8HToCt8Bg43nij97CuF/TEPsvfvI4ekOGVWTq34jJIYnLxYr18ZHCjva8jze2QIMTDQQZmDCwISBCQMTDd5KUi3C1oVnz168itUbd6t1Hp5LsSius6+P5VOAAhRwBQEGJq7QCo5fgzMDk71792L9+vUI/+9Le5kyZdC0aVMUKpR8P6vlZsvCp1oFJqmdSxZilbDCfLvZrysSbl63EOg8XMk15SiYR6bl/Lfiq7t/Pni37mR1XZZb92IQ6KddEKVlG7EsCqQlwMAkLSEb/s7AhIEJAxMGJja8VTi0y4dfTUNIvWrIkcPTpnVUfpi+EK8+38mhc/JgClCAAllNgIFJVmsxy9frjMDkwoULWLJkCeTxwLI99thjaN68OYoXL+5UNAkyIub+hqS4OMh6HTKyxA3JIzJkk8VOZdFTR7fUFlm1FpjcGzcaUWuXWwhMHo6AKTBtNtyDChv3kfVR4s6eRsLVy/AoXBQ5SpdJcx0WBiaOti6Pz0wBBiYa6DMwYWDCwMQ5gUnY/fvYvn8/omJibH6lFswfiAY1Hv0VxeYCXHRHexaenb14HerUqIgSjxV00drwsihAAQo4R4CBiXNcM7pUZwQmFy9exC+//IKgoCCEhoaiQoUKTqmWrN0hIUTig3C458kLeWRuwo2rFhdXNTyS13wqS3ouLLURJoaFWM3LlfAj7LPhpuuYuHvAPXcuuOX1U+ufmD9eOD3XxsAkPWo8xlUEGJho0BIMTBiYMDBxTmBy5949LFm7DhFRUTa/UksUKYK2IQ8fK3z87DkcP3vW5uNlx7rVnkChwEB1zIPISGzbfwARkZE2lxHg54f6NarD08PD5mPS2nHRii3InSsnWjSuabKr+cKzhYLy4e/V29Wjjbt3aJJWsfw7BVxSICY2DkdOnEPxogURGOBnco237tzDxcvXUaVCaTXiihsFUgowMNFHf3BGYCIyp06dQtmylhdAtUdOjbI4d0at75FykzU7bg8fhKSIByb/Lk/DufvdGCQ9uP/IaQzLmQRNme3Qeh7WFlk1rEGSWv0Mo0ZsGS1ij5NhXwYm6VHjMa4iwMBEg5ZgYMLAxLwb8bHCGrywAGgRmOw7dhzb9u2z64I6Ng1F0YLJozPCIyKweO063PtvrrMtBRUMDISUoWVgYst5uQ8F9CIgI6omTl+ApTO/QIB/XpNq3bkbjvbPDcPbL3dH5zaN9FJl1kMjAQYmGkFmcjHOCkwcrZYEIne//dzkUcEynUam1chmbVqMm0+eR0IU82uxNm3Gnms2LLJqCGxk3RKfjt3SnDJjzznSsy8Dk/So8RhXEWBgokFLMDBhYMLAJFlA68cKMzDR4A2KRVAgCwo88/po1KnxON7o19ni1X83ZR72HzmFX8a9nwVrx0t2pgADE2fqZlzZzgxMZCSGPJnFMEpEauXu7aMevStPgolYPFdVVEIO76atkLPuw2D2zvBBkKfRmG95er2gFjy92b8bEm5csw/qv3k5WgQm9p044/ZmYJJx1jyT9gIMTDQwZWDCwISBCQOTlH2AI0wsv7GG3QvHtt1H0aZpHZMdIqNi8PHX0zF62IvGUTkz56yATL14pksLFAj01+CdmkVkJYEGHV/HuI9eR+3qltcY2Lb7CN76aCK2Lf0hK1WL15oBAgxMMgA5A05hT2Dy4MED9XjguLg4tG/f/pGrMwQjEfNnIWbX1od/9/CAW0K8cfFVWcBUFjI13/wGD0PuZm3UP1t7DK9h2sudYW+YrgeSojA3/wAk3b3z6PUlAe4+PigwbU6mjwRxVtMyMHGWLMvNCAEGJhooMzBhYMLAhIGJswOTu+EPklfXt2PL4+PtUtOCjp48jz8WrMHgF7tg4/aDiI+PR8GgAITUrwaZgtGjYxPj9c6YswItQ2phz8GTaNu0rh215q56EKjWrD9+/f4DVHm8tMXq7D10Ev2GjMH+1VP1UF3WQUMBBiYaYmZiUbYEJhERESoo2b17t/o8kW1Q21bIV/NhKC9TVMJGD7d/1EeKuhvCEGtrhMiuhn2sPXVG/u7TphPCvvzIVFXCkpw54ffOhyYjWTKR3imnZmDiFFYWmkECDEw0gGZgwsCEgQkDE2cGJtGxsVi9Zata08XWLZ+vL0Lr14NPrly2HuL0/VKOMJn398ZUA5Nf565E88Y1sffgqUdGpDj9QnmCTBdo3edd9O/VFl3bPVzAOeVFScA2Y/ZyrPxzbKZfq6ULOHziHD4aOx2nz/2LIoUCMeyNPmhYp6pLXqveLoqBiT5a1FpgknDhNK5P/gE7ouNxJE8AEtySH80bfPsaal09B7/oCHgUKIR8H3yupthYm0JjTcmwAKv53wst2aT+ydoIk5x1nkK+Ef9T03xuD3sD8efOGIvwCCqo/ibXk3jzKqK3bUbU5rXwCi4Pr4qVkbNhM300Wiq1YGCi+ybWdQUZmGjQvAxMGJgwMGFg4uzAZPGatbgVFmbzO1Z+f3+0C23iUoFJXFw8xk76C/16tkHBoHzGukRGRasvl+1bNEBMbCxqVCmHZWu2487d++jVqSmC8nNKjs0Nr5Mdx0ychVUbd2PhtM+Qxye3Sa3uhUeg0wsfILRBDYwc0tflaiz9vGXvd1Tf7dExFBu27scn42ZixayvHlnA1uUuXgcXxMBEB40IIO7MKYT9Ng0IuwVPN8Crdn1Exidg87atOBr0GBLck59CJ0FJnatnkTfa9El2stiprAliLeBIqeSGJOO0HEt6nqWCETh+uvqTtUf3mq8/knKdE2c9eSYrtTQDk6zUWrxWcwEGJhr0CQYmDEwYmDAwYWCiwZspi6DAfwLyJJxuA0apxwb37dYSFcuVQFJSEo6cOA95lHZsbBzmTv7EJde32bnvOAaPHI8tiyfC3T351+/uL3+Enh1D+VSfDOjhDEwyAFmjU8gUl6gVixF39jQkVMjVqCk8S5ZRU2hitieP6DBsEmmcDSiM1aUrJwcld66j1pWzakSJtU1GhdgSmKRVHe8OXeE7YLBxt6jVyxC9fZN66o2MZvHp2F2NHuFmXYCBCXtHVhZgYKJB6zEwYWDCwISBCQMTDd5MWQQFUghcvxmGLyb8jrWb9yE+IUH9xcPDHY3qPIH33+iNxwoHuaTX7MXrIFPO/vpplPH63v10klqv5+2B3V3ymvV0UQxMXKs1Yw/vN15QjlLBxkVNYzasQNg3nwOJiQ8v2M0NPq07IGLZIouVkPhx22NlUeHWFfinEpQYDpbA5Ga/rki4ed0qSvLYkuRg0y23N7wqVUXM7u3G/WWqjf+Q4bpdjDWjegsDk4yS5nmcIcDARANVBiYMTBiYMDBhYKLBmymLoIAFAZmydenKTfUXCUl8vF1nXR5LDSYLFq/ZtAczxw83/vnDr6Yhh6enmkL0ICoe0bHJARA3CuhWIPIBEsaNAo4dgHG5cg8PeLzwJtxCWiP+pY5A5KOjQ5Lc3OBm5wLnFg3zF4Dnd38Ae7YgXq7jv02tUeLhDrfiwXArWxHI45v8F5+8cG/UAvDOk/y/L5wBSgTrtnlYsewlEOiXM3tVWOPaMjDRAJSBCQMT8260cPUaXLlxw+beldfHB+2bhMDfN/mD++qNG1i0dh0SU/7ykkZpNStXQu2qDxcVXLllK05fuGDzNeTKmRPtmzRBUEDy2hI3bt/G4rXrEBsXZ3MZlcoEo3Ht2jbvn9aOssjpkrXrEBEVldauxr+XKFIEbUMeLhS579hxbNu3z+bjZceOTUNRtGBBdUx4RIRyuBcebnMZWj9WWBZ91cMaJlHRMZC62LN5erhDXh/cKJBS4Obtu1i6ahte6Nna5WBkhMmC5Zsx64eRxmuTESYFgvJh6MAeDExcrsV4QekRSFo2BwkLf3sYenh4ADISrHgwPLv0RcLR/UhcMd84eiPlOTw++BoJo9+2eFqZeuf230KulnawuCir2T/KmiQeQz4BnmyQXMSFM0jcvdlYnHujlkBQ8r0rNwpkBwEGJo61MgMTx/zU0QxMGJiYdyMGJhq8sAD1VBgGJlAhgx4Ck2s3b2LV1m12dY6q5cvhiQoV7DqGO+tTICY2Dms378WiFZuxZddh5M6VEzuXTXK5yu7YdwxDPpyALYsnGL/4dR0wSj02u1u7EJe7Xr1dEKfkOK9FZc2R2AN7IGt4xB47lOqJcgSXR9yZExb3kUfsppyqIztd8Q1AWC5vVLpxSSbHWDxO/lUNPkn55yTA098PiW7uQEIiclZ7Erlbd4Is+srNdQQ4Jcd12oJXYr8AAxP7zR45goEJAxMGJskCHGGS7MARJpbfWGXUlYSJ9my1q1RBzSrJi/xxy54Cew+dUiHJ8nU78SAiCg1qVUaXto0QUr86cnrlcDkUWZC2ec+harHa7u1DsHHHQXz45TQs/+NLPvEpA1qLgYntyGrR1bXLEXf2FHKULgtZYyRn3UYWC7g/eTwiF89Rf0trFIjs4xFUAAk3LY+09Xq8CuLOn0ZSVBRu+vhiR9EyuOwbAI/ERPQ5ug3+TzyJmB0PR4SocyIJ3qGtkadzD0TM/R0xRw8jR7GS8G7fBV5P1rW90twzUwQYmGQKO0+qkQADEw0gGZgwMGFgwsAkZR9gYMLARIOPlmxdxOVrt7B45RYsWr4Fl67cQLVKZdCxZQMARcUuAAAgAElEQVR8/M0MzJvyCSqUKe7SPgeO/p+98wCPqmjf/pMGhNAJSFNEUFBAivTeEaQoCggivffepFfpHUQ6ogiKFEHpvUuTKkoRXjpSQ08C73VPPOtm2c2e3T3Jbnbvua7/972aOXNmfs+c4859nnJWhoxfIGfOX5YM6VJLj7b1pFxxfvGOC6NRMImiHHHuL3myc7NE3rgugZlek4SFiker5AKx5J9OTUUePlA5RrTSuknqNVEVa8LPnxX0CXglvQQkTy73Zkz4z3yWXh5WDOuXIpW8uHvbqsmVh0nlmrJhxXI5lzKt6pMoIlzyXz0vxap+ICG16keVFd62RfyePZUkb7wuiYqXYeLVuHiAYukeFExiCSyHjRMCFEwMwEzBhIIJBRMKJhRM7L9M6WFinxF7/PsuKdNYJXitXrGY1KhcXF7LGHWoylmmcbwQTGhH9xHwdcHk6YHd8mDhLAk/f+YlI0AMSVK/qTze9KuEzZ0qz+/fj9bHUgfRRBTzSjK4wPKfzQfRrgmp/ok8XPNT9Co4IvIoKKEcKVtdjt2+qy4L8hPJG/5ICiUNlhR1GqiywuoeL0Ru3X8qSGeSOhkTVrrviTLmzhRMjOHIUdxDgIKJAdwpmFAwoWBCwYSCif2XKQUT+4zYI4pA3grNJF3a1EosqVGpmKmEMAUT7hB7BHxVMEFekfuzp8iLhw9MiKyFziSqUEWebPzVbliNyheijWSZadVq5tXolgmdNFf8kyaRW707SuSNa+qPF5KHyto385o6FipUSEqXLi2JEyd+yawUTOzt9Pj1dwom8ctenG10AhRMDNgRFEwomFAwoWBCwcT+y5SCiX1G7BFF4N79h7Jm015ZuXanHD99Xt579y358P0S0n/0XHqYcJPESMCbBBOE1dydOEIi/vUW8QtJIsmad5DgClVfYnD90yrRxJKYIGleII5sJXXNCz+VcDXqejQ/paq88HshfijX6yfinza9JO/c96Wkqy8ehskT/0CZOHGi5MiRQ8qWLSspUqSwOQUKJo5Yx/P7UjDxfBtxhrYJUDAxYHdQMKFgQsGEggkFE/svUwom9hmxx8sEzl64Iit+3Sk/b9gtKCdcolBuqVUVSV/zemTSV9rQvQS8STC52ay2yTvDnGqqEZOjCRLPjh2W2307WgVvHj6jeY1E8x4xu8r2v/9PLNG6m0QXM28TLeQnph3w+PFjCQ4OtrtJKJjYRRSvOlAwiVfm4mQtCFAwMWBLUDChYELBhIIJBRP7L1MKJvYZsYdtAjgI7z5wXFXM2bTjkAQFBcq+NTOIjASiEfAWwSQmEcRSmIipr0oGAtcPs8SuMW0ZvwQJ5MWzZy91MeUzUcO9nPU1afMOElKzjmG7kYKJYSg9YiAKJh5hBk7CSQIUTJwEZ34ZBRMKJhRMKJhQMLH/MqVgYp8Re+gjgPLCv27ZJ7WrldF3AXv5DAFfEEwSFi4hKfuNNNkU1WxuNo9ZrIAAkbR+E4G48uz4EZv7IXmHXnJ/zlSRRw//y2Fi1jswS1ZJ0fkLebTpF4k4d0YC0qaTREVLiuQrLNeuXZPMmTMbstcomBiC0WMGoWDiMabgRJwgQMHECWiWl1AwoWBCwYSCCQUT+y9TCib2GbEHCZCAawS8RTBB/hJV9tdKsxb6cn/WJHm06sfovV+8EL8Afwl8NbMk7zpAlRWOyosyXCLOn43KRfJCxD80jSSuVF2Cy1dRZYSRbyT83BkJP3lUnuzZIeFnT4tf4hBJVKSkqrKDPlqLiIiQ/fv3y44dO8TPz0+6dOkiQUFBrhmRVXJc5udpA1Aw8TSLcD6OEKBg4ggtG30pmFAwoWBCwYSCif2XKQUT+4zYI4pAqY+s52Ow5LN9+WQiI4FoBPQKJvDKeLpvpzx/+ED8Q5JIcPn3xS8kqUfRvN2nw0veIBAuQifPiyZaaJNGpZzw839J5PVrKsdJcLGS4p/mP3HDfHEQRdAPIoqz7dChQ7J161YJCwtTQ2TLlk2qV68uyZIlc3ZI03X0MHEZoUcNQMHEo8zByThIgIKJg8CsdadgQsGEggkFEwom9l+mFEzsM2KPKALzvv/VhOL5ixcyfuZSafBxRUmXJlU0RE0+rUJkJOCwYIKwlDvD+0arKoMKNKlHTHZJQDDaFBA1wr6bq0Jfnj8Mk4C06SVp/aZun+PJkydl8+bNcuvWLbXkjBkzSsWKFQ0Lx8GYFEyM3k3uHY+CiXv58+6uEaBg4ho/dTUFEwomFEwomFAwsf8ypWBinxF7vEwgIjJS8pRvJktmDpRc2bMQEQnESECPh8k/HZuYSvWaD2aZG4SooxO4fv26rFq1Sq5cuaL+EBoaKhUqVJDs2bMbjoqCieFI3TogBRO34ufNXSRAwcRFgBRMykqmdBRMKJhQMKFgYv9lSsHEPiP2oGDCPeAaAT2CybXqJa3eBF4mr5h5N7k2E++7+u7duzJp0iRJnjy5lClTRvLmzRtri6RgEmto3TIwBRO3YOdNDSJAwcQAkPQwoWBCwYSCCQUT+y9TCib2GbEHBRPuAdcIuCKYBKR5RdLMtUic6tp0vO7qs2fPStasWWN9XRRMYh1xnN6Agkmc4ubNDCZAwcQAoBRMKJhQMKFgQsHE/suUgol9RuxBwYR7wDUCegSTO8P6qISvlo0hOa6xN/JqCiZG0nT/WBRM3G8DzsB5AhRMnGdnupKCCQUTCiYUTCiY2H+ZUjCxz4g9ogjM+na1CcWLFy9k0uxlUv+j8pI2NGU0RC0+q0ZkJBCNgB7BBKV1b/XpIC8ePTRdC++SVCOnWK0+Q8RxT4CCSdwzj807UjCJTbocO7YJUDAxgDAFEwomFEwomFAwsf8ypWBinxF7RBGoULebLhQbl4zT1Y+dfIeAHsEENFCBJvzcGUHFHJTgDXojm8eVFY4rqz158kT27t2rkrnWr18/rm4b430omHiEGQybBAUTw1ByIDcQoGBiBzr+wzt2xvey/NcdEh4RIeVLvieDuzeRRAkTmK6kYELBhIIJBRMKJvb/C0bBxD4j9iABEnCNgF7BxLW7eMfVT58+lX379smePXsEoglay5YtJX369G5fIAUTt5vA0AlQMDEUJweLYwIUTOwA/37lZlmwdK1MG9lFEgcnlB5DZkienNmke+u6FExEpEY5VsmxtoVWbNwkOBzqbUlDQqR62TKSIlkydcnVGzdk5eYt8vz5c71DSIFcOaXQu++a+q/ftVvOXLig+/pECRNK9bJlJU2qKJf3G7duyarNW+RZeLjuMXJmyyqlCxXS3d9ex9v37snPm7fIw8eP7XU1/T1zhgzyQZnSpn8+fOoP2XP4sO7r0bFm+XKS8ZVX1DVhDx8qDvfCwnSP8UpoqBojMCBA9zUxdXzy7Jms2rRZ/rlzR/d4qVOkkGrlykpIokS6r4ntjhRMYpswxycBEqBgYn8PQCiBRwn+TxNKsmXLJmXLlpUMGTLYHyAOelAwiQPIcXgLCiZxCJu3MpwABRM7SBt1GinlS+SXhrUrq57b9vwuQ8YvkE0/jDddSQ8TephYbiMKJsa8qyiYRHGkYJLLmA3FUUiABLyeAAUT2yaOD0KJNnsKJt71qFIw8S57+tpqKJjYsXjpWp1kaM+mUqpIHtXzwqXrUrVBLzmw9msJThQVlkPBhIIJBZMoAvQwieJADxPrL1Z6mPjaTwyulwTingAFE9vMkaNk1qxZqoOneZRYzpqCSdw/O7F5RwomsUmXY8c2AQomdggXqtpapgzvJIXzva16Xr95R8rV7iI7VkyRVCmSyr2H4XLh+TUZ9r+l8uC5/rCBCsnzSMvQKhL5/IX4+4mcPven/HHunG57+/v7S6mCBSVpkqjwiSdPHsqug7/Jo39jUPUMlD5NGimct4Cag5+fyMXLF+XIqZN6LjX1KVWwkCRPlkr987PwJ7L30AG59+CB7jEQNlAsX0ER/wDxE5FrN6/K/qO/674eHQvnzSdpU0eFT7x4HiG7D/0m8EzQ25InTSpF8xWQoKCE6hKw8MP/40DDf9hRyQEtwN9Pdh/ar0Ja9LaQ4GAplr+AJEoUoi4Je3BHtu/fL8//HVPPOO9kyypvvv6mPH8RNYdDx3+Xi1ev6LlU9UmYIIEUz19AQkKiwoIePLwvOw/sV7l79Lasr70qubLnEvxgRfNXMPVeHdUPHLVlP1b7er88fvJU9yAZ0qaVQnneM+3rv//3txw9/Yfu69GxdKHCkixp1LMV/uyx7Dp0QIXm6G2hKVNK0fwFQcCFPfUfh8jn4bLn0G9y5959vVNQ4V1F8r0nQYHG7GtlT7ysHGzaXoja13dl6769Do2Q881ski1zNrWvnd5Tz1/Iv5c79XzjYvNn0dV9DYp+jrL8dw4JAv0lOKExoV4OGYKdSSCeEKBgErOhtm3bJm+++abHhN7Ymi0Fk3jywOmcJgUTnaDYzSMJUDCxYxZ4mAzv3VxKFMqtelp6mOAF8FieSJg8NP0g12PpQD9/Sf3iv/KIEeFP5PkL/fkqcI/AwCDx9w9St3v+PFIiIvQfKnENzrIJghKb5h0Z8UQiHciZgTECAoLU/6G9eBEp4eEOzkH8JEHCYNMBOTLyqURGRupBaOoT4B8gAf8eCnEGefr0sfx3PNIzlJ8EJUgofv8ebp88uS9XblzXc6GpDw7IyZOFqnXgMBQe/tghsQMDQbDx84s6CD1/Hi4REfpzh0QdJP0lMOi/fBUREY9NwoXexQQGJhR/f20OERIR8Uzvpaqf+Rxgi39uXZe7D/Qf8nF9xlfSSVCCKOHoxfNICXdwX+MwGxQUbNrXTj1bAUHib9C+xn548OCuXL990yGW6dKklcTByaO4+kMUhSCrHfv1DIV9nUD8JMqezuzrNClTSbJkqdW+Dgzwk0tXLzokyiYIDJL0r6STgICoffk8MlwiIh3c1/7+EhgYdT2EwGs3LkuYWSlQeyQCAwIlfdp0ak+ghYc/lMvXrjn0vk2eJKmkCU2vnieIRjdvXXUopw32dYZX0kmCf/d1RPhjuXLjmkRE6hcjQxIllgzpMklQoL8kCQ60t2z+nQR8lgAFE+8wPQUT77CjtgoKJt5lT19bDQUTOxZv2HGEVCxVQD7/pJLquWX3YRk8boFsXTYx6sd3hGMih69tsPi43svXr8kv27Y5NPWSBQpIjjeyOnSNL3SGt9Dvf+j37kCS1Goq8Wxqr8Jz9uIF2bzXMc+KyiVKyGsZMhrG4fK1q/LL9u0OjVe6YEF5K8sbpmtWb90sV2/oF36SJUkiVUuXlqQhSRy6r63OEHk379kjZy5e1D1e4kSJpErp0pIqeQp1zT93bsvqLVsc8pzKlS2bFMv/npKrIIDt+f2IHDt9WvccggID5YMyZUz7+u79e7Jm2zZ55EAy4yyZMkrF4iWU9xuEIzYSIAHrBCiYeMfOoGDiHXakYOJddvTV1VAwsWP5b3/aIIuWbZQZX6JKTiLpNni6vPNWZunT4TNf3TNev+4LV67Kmq1bHVpnqQIFJNdbbzp0jS903n3osBxxUDCpXq6cpE8T6lV4Tp8/L5v2OCaYvF+yhLzx6quGcbhw+Yo6pDvSShcqKDmzZVOXIFRqxaZNDgsm1VD9KWlSR24bY9/1O3c5LJhgDvACQ7v+D6o/bXZYMClVCCFWUW3nwUNy1EHBpHq5spIuNGpf37p7V37estVhwaRKqVKGceRAJOCtBHxVMLl06ZKcP39eSpYs6RWmpWDiFWY0LYIeJt5lT19bDQUTOxaPjHwuo6YtllXrd0lERISULZ5PBndvosQTNu8kQMHEOLtSMIliScGEggkFE+PeKxyJBGIi4GuCCYSSLVu2yLl/8+C1adNG0qZNG+83CQWTeG/CaAugYOJd9vS11VAw8TWLc712CVAwsYtIdwcKJhRM6GEigpAcCia6XxvsSAIuEfAVwQRCydatW+Xs2bOKV1BQkBQtWlSKFy8uCRJEVXGMz42CSXy23stzp2DiXfb0tdVQMPE1i3O9dglQMLGLSHcHCiYUTCiYUDDR/cJgRxIwgIC3CyaWQgmQFSpUSEqXLi2JEyc2gKBnDEHBxDPsYNQsKJgYRZLjuIMABRN3UOc9PZoABRPjzEPBhIIJBRMKJsa9UTgSCdgn4M2CyYULF2T+/PkmCO+++66ULVtWUqSISmrtTY2CiTdZU4SCiXfZ09dWQ8HE1yzO9dolQMHELiLdHSiYUDChYELBRPcLgx1JwAAC3iyYAM+kSZMkTZo0UqFCBa/IVWLL5BRMDHgYPGgICiYeZAxOxWECFEwcRsYLvJ0ABRPjLEzBhIIJBRMKJsa9UTgSCdgn4O2CyePHjyU4ONg+iHjeg4JJPDegxfQpmHiXPX1tNRRMfM3iXK9dAhRM7CLS3YGCCQUTCiYUTHS/MNiRBAwg4O2CiQGI4sUQFEzihZl0T5KCiW5U7OiBBCiYeKBROCX3EqBgYhx/CiYUTCiYUDAx7o3CkUjAPoH4KphEREQIcpRkzZrV/iJ9oAcFE+8yMgUT77Knr62GgomvWZzrtUuAgoldRLo7UDChYELBhIKJ7hcGO5KAAQTio2By6NAhVSI4LCxMunTpIsmSJTOARPwegoJJ/Laf5ewpmHiXPX1tNRRMfM3iXK9dAhRM7CLS3YGCCQUTCiYUTHS/MNiRBAwgEJ8Ek5MnT8rmzZvl1q1bauXp06eXDz/80KuTueo1MQUTvaTiRz8KJvHDTpyldQIUTLgzSMCCAAUT47YEBRMKJhRMKJgY90bhSCRgn0B8EEwQerN+/Xq5cuWKWlBoaKiUL19ecuTIYX+BPtKDgol3GZqCiXfZ09dWQ8HE1yzO9dolQMHELiLdHSiYUDChYELBRPcLgx1JwAACniyY3Lt3T1atWiXnzp1TK0XoTbly5SRPnjwGrNy7hqBg4l32pGDiXfb0tdVQMPE1i3O9dglQMLGLSHcHCiYUTCiYUDDR/cJgRxIwgIAnCyZPnz6VCRMmiL+/v5QsWVKKFi1qwIq9cwgKJt5lVwom3mVPX1sNBRNfszjXa5cABRO7iHR3oGBCwYSCCQUT3S8MdiQBAwh4smCC5SEcB7lKEiRIYMBqvXcICibeZVsKJt5lT19bDQUTX7M412uXAAUTu4h0d6BgQsGEggkFE90vDHYkAQMIeLpgYsASfWIICibeZWYKJt5lT19bDQUTX7M412uXAAUTu4h0d6BgQsGEggkFE90vDHYkAQMIuFMwefz4sQQHBxuwCg5BwcS79gAFE++yp6+thoKJr1mc67VLgIKJXUS6O1AwoWBCwYSCie4XBjuSgAEE3CGY3LlzR5UHPnv2rHTt2lUCAwMNWIlvD0HBxLvsT8HEu+zpa6uhYOJrFud67RKgYGIXke4OFEwomFAweVkwuRcWJnjPRD6P1P0sJU6USLJnyaK7PzuSgK8SiEvB5MGDB7J161Y5ePCgCffHH38suXLl8lX8hq2bgolhKD1iIAomHmEGTsJJAhRMnATHy7yXAAUT42xLwYSCiacJJnfu3ZO/L1+W5/g1rrMlT5pUsr32mqn3zdu3JTwiQufVUd2ShoSo/2MjARKIXQJxIZig2s3OnTtl3759Eh4erhaUKVMmKVOmjGTNmjV2F+gjo1Mw8S5DUzDxLnv62moomPiaxbleuwQomNhFpLsDBRMKJp4mmOjevOxIAiQQLwnEpmASEREh+/fvV2IJ8pVQKIm9LULBJPbYumNkCibuoM57GkWAgolRJDmO1xCgYGKcKSmYeI9ggpWcOntOHj99onuDBAUGyusZMxrqWXH91i3BoUVv8/Pzk+RJkkhI4sR6L2E/EiCBeEwgNgWT+/fvy4QJEyiUxMH+oGASB5Dj8BYUTOIQNm9lOAEKJoYj5YDxnQAFE+MsSMHEuwQT43YGRyIBEiCB2CEQm4IJZowwnNDQUIbexI75TKNSMIllwHE8PAWTOAbO2xlKgIKJoTg5mDcQoGBinBUpmFAwMW43ec5If5y5KDmy/ZfTxHxmew6ckICAACmUL4f61//cvieLlm2Qzi0+ibaA02f/J9mzvmp1UdPnr5Bm9T+QhAmC5NHjp4IxkTPl/bKFPAcCZ0ICHkogtgUTD122102Lgol3mZSCiXfZ09dWQ8HE1yzO9dolQMHELiLdHSiYUDDRvVnisKMtsQLixDc/rpdWn1dXs7l4+Yac+utvCU6UUEoVyWOa4YIf1kmhvDnkWXiE3A97JK9lTCu37tyX5EkTS0hIsFy8dMMkmCz/dYcEBgRI9UrFTNc/fRYuEEU+/qCUXLh0Q/37XDmyyKGjf0q5Evnk1837pXzJ/Eow0eZx8s+/KZjE4R7hreIvAQom8dd25jOnYOIddtRWQcHEu+zpa6uhYOJrFud67RKgYGIXke4OFEwomOjeLHHU0Z5YsWLtTvmoSknTbLbsPizJk4ZI/txvmf7djn3HlDiCOjuaYJI50yvq77sPHJf/Xb4hxQrmkueRz+XY6fNy5vxladfkIwkKDDCN8d3yTVKiYC65cDlKMClWIKcEBPir/z117nKpUOo9efT4ibz+anqZOOsH+fD9kpI/95txRIm3IYH4S8BZweTmzZty5MgRqVixYvxdvBfNnIKJFxkT3pb3nkpo8oTetSiuxmcIUDDxGVNzoXoJUDDRS8p+Pwom3iWYxBRG8tuRP+TJ03ApWTi3WvS3P20UkRfyWS1jDx+OzAHCxuVrN+XTmuWibVZbYsXDR09kxsKV0qh2ZfnflRuSOmVy+ev8JSVklC2Wz/6GZw8SIAG3E3BUMIFQsnXrVjl58qSae926dSVHjqiQOjb3EaBg4j72sXFnCiaxQZVjxhUBCiZxRZr3iTcEKJgYZyoKJlEsz1+6LMf+/NMhsHnfziGvpU/v0DUxdb57P0wePHro0HiJEiWS0BQpTNcgjKRaxaKmMJKc2V+XoyfPyrvvZJXnz5/Lqb8umgSTH1dvk8DAAKlRqbj4+/s5dN+YOmMOCG+5czdM7oU9kkzpQ+X+g0eSJCRYeYKYzwHeJN+v3KwEEDYSIAHfIKBXMIFQsm3bNjlx4oQCExQUJAULFpTixYtLYlbVcvtmoWDidhMYOgEKJobi5GBxTICCSRwD5+08nwAFE+NsRMHEOJaeMNKaTXslV/bX5eLlm2o6EExSpUiq/ve+w6fk9JmLUr7ke8ojY/POw/LixXPDPUwwh9w5ssjdew9MgkmW16KEJcs5zFy4SoXGlC/xnqGijSfYgnMgARKwTsCeYGJNKClQoIASSkJCQojVQwhQMPEQQxg0DQomBoHkMG4hQMHELdh5U08mQMHEOOtQMDGOJUciARLwPAIr1+2SOYt/kVXzh0eb3PHT52XQ2Ply5vwlyZAuVPp0+ExKFn7X8xbghTOKSTAJCwuT8ePHq1UHBgaaPEoolHjeRqBg4nk2cWVGFExcocdr3U2Agom7LcD7exwBCibGmYSCiXEsORIJkIDnELjxz11p1GmE3Ln3QNKGpowmmISHR0jl+j2k3oflpW7NcrJt9xEZMmGhrFs8xuSR5Tkr8b6Z2PMwWbFihQq5oUeJZ9uegoln28fR2VEwcZQY+3sSAQomnmQNzsUjCFAwMc4MFEyMY8mRSIAEPI/A1t1HZPzXP0QTTPYf/kM69Z8su1ZNM4WC1Wk1SCUfrlW1lOctwstmZE8w8bLleu1yKJh4l2kpmHiXPX1tNRRMfM3iXK9dAhRM7CLS3YGCSRSqmCq7XL95RzbtPCT1Pyqv+v5+8qwcPvaXSmyaOmUy3aztdURi1IcPH0v6V1K/1PXR46fyzY/rpdXn1dXfUCEGyVNDUyWLVk7X3j34dxLwNQLWBJOlq7bIsjXbZcnMgSYcPYd+Ja+kSSXdWtfxNURxvl4KJnGOPFZuSMEkVrC6bVAKJm5DzxsbQICCiQEQOYR3EaBgYpw9KZhEsVy0bIPky/WmquRy8fINSZokWLnm37x1T9579y1Z/usO+ahKSRP4rxf9rNz5kyZJbJgxTv11QVD6t3TRvLrmgIMgci+89UYmw+bAgUjA0wmgtPSz8HCr00yYIIEkDk4Y7W/WBJMFP6yTTTsOysLJfU19B4yZK0GBgdK/S0N5/DRSnkU893QU8XJ+58+dkdezZJWIyBcSFOgfL9fASf9L4IVIeGTUc0Jbxv9dgXdeAj6TbjNk8pAgt93bG25MwcQbrMg1GEqAgolxOCmYRLHcfeC4hCQOlhTJkpjEirw5s6m/Xb1+S75dvlE6NK0lJ06fF39/f4G4UapIHsmYLtQwY8DD5Of1u6REoXdfmgMOiTMWrlTld+FdEhn5XHb9dlxqVC4ub/xbgcawiXAgEvBgAsMnfSM79h2zOkOImpoXltbBlofJ8rU7ZfH0/qZx4GGSNk1K6d66rkQ+fyHwgmAzjsDp03/I1i1b5Natf6Rxk+aSNGUaSRocaNwNOFKcE4CHyf1H4eLnJ5IsMQ97cW4Ag294/2G4JOOh3WCq+oej6KiflbWeFExc48ervZAABRPjjArB5PfTp3UPGBgQINXKlpX0aYwTCnTfnB1JgARIwEEC1gQTlLfuMmCq7Fo1Vfxw2hORT1oMlLo1y0rtamUcvAO7x0Tg/PnzsnHjRrly5YrqlipVKqlevbokS51BUiVNQHjxmABDcuKx8axMnSE53mVPX1sNBRNfszjXa5cABRO7iHR3uHHrloRHROjuj45JQ5JIsiQhDl3DziRAAiTgDgLWBJNnz8Kl4qfdpWHtylKnehnZvu+oDBg9V9Z+N1rSpE7hjml63T2vXbsmGzZskHPnzqm1JUuWTMqUKSP58uVT3jt3H4ZTMInnVqdgEs8NaDF9CibeZU9fWw0FE1+zONdrlwAFE7uI2IEESIAEfJrA1Ru35ePm/SUiIlIeP3mq8g3VqFRcerevr7ggefOQ8QvkzPnLkiFdaunRtp6UK57Pp5kZsfgnT57I6tWr5cSJE2q44OBgKTJsykwAACAASURBVF26tBQuXNg0PAUTI0i7fwwKJu63gZEzoGBiJE2OFdcEKJjENXHez+MJUDDxeBNxgiRAAiRAAj5KYNKkSfLw4UMpWrSoFC9eXBIkiB56Q8HEOzYGBRPvsKO2Cgom3mVPX1sNBRNfszjXa5cABRO7iNiBBEiABEiABNxC4PLly5IiRQoJCbEeuknBxC1mMfymFEwMR+rWASmYuBU/b+4iAQomLgLk5d5HgIKJcTY9ffZ/kj3rq1YHRInbJ0/DpWTh3OrvP/2yXZWxLZL/HeMmwJFIgARIgAR8igAFE+8wNwUT77CjtgoKJt5lT19bDQUTX7M412uXAAUTu4h0d1i0bIPky/WmREZGyr2wR5IpfaigvG2SkGBJnjRETv110SSYjJn+veTKkUWqlPsvFl33jdiRBEiABEgg3hN4/PixykviSqNg4go9z7mWgonn2MKImVAwMYIix3AXAQom7iLP+3osAQomxplm94HjEpI4WFBYUxNMsryWXt0ApTdPn7moKkkcOvannL94TR49fiKfflheggIDjJsERyIBEiABEvBoAshJsnXrVjlw4IB06tRJhdw42yiYOEvOs66jYOJZ9nB1NhRMXCXI691JgIKJO+nz3h5JgIKJR5qFkyIBEiABEvAyAk+fPpWdO3fK3r17JeLfEvQ1a9aUvHnzOr1SCiZOo/OoCymYeJQ5XJ4MBROXEXIANxKgYOJG+Ly1ZxKgYOKZduGsSIAESIAEvIMAxJH9+/crsQRhOGi5cuWScuXKScqUKV1aJAUTl/B5zMUUTDzGFIZMhIKJIRg5iJsIUDBxE3je1nMJUDDxXNtwZiRAAiRAAvGbwKFDh1T4TVhYmFpI1qxZpUKFCpIuXTpDFkbBxBCMbh+EgonbTWDoBCiYGIqTg8UxAQomcQyct/N8AhRMPN9GnCEJkAAJkED8IxAeHi4TJkxQXiUZMmSQSpUqSebMmQ1dCAUTQ3G6bTAKJm5DHys3pmASK1g5aBwRoGASR6B5m/hDgIJJ/LEVZ0oCJEACJBC/CBw9elSCgoLk7bffjpWJUzCJFaxxPigFkzhHHqs3pGASq3g5eCwToGASy4A5fPwjQMEk/tmMMyYBEiABEiABEKBg4h37gIKJd9hRWwUFE++yp6+thoKJr1mc67VLgIKJXUTsQAIkQAIkQAIeSYCCiUeaxeFJUTBxGJlHX0DBxKPNw8nZIUDBhFuEBCwIUDDhliABEiABEiABxwjcu3dPlQeuXLmyYxca3JuCicFA3TQcBRM3gY+l21IwiSWwHDZOCFAwiRPMvEl8IkDBJD5Zi3MlARIgARJwJwEIJdu3bxdUv0GDYFKkSBG3TYmCidvQG3pjCiaG4nT7YBRM3G4CTsAFAhRMXIDHS72TAAUT77QrV0UCJEACJGAcAQglO3bskIMHD5oGzZ8/v5QqVUqSJ09u3I0cHImCiYPAPLQ7BRMPNYyT06Jg4iQ4XuYRBCiYeIQZOAlPIkDBxJOswbmQAAmQAAl4EgFrQkm+fPmUUJIiRQq3T5WCidtNYMgEKJgYgtFjBqFg4jGm4EScIEDBxAlovMS7CVAw8W77cnUkQAIkQALOEQgPD5exY8fKs2fP1ACeJJRoK6Jg4pxtPe0qCiaeZhHX5kPBxDV+vNq9BCiYuJc/7+6BBCiYeKBROCUSIAESIAGPILB582Z58OCBx3iUWEKhYOIR28TlSVAwcRmhRw1AwcSjzMHJOEiAgomDwNjd+wlQMPF+G3OFJEACJEAC3kmAgol32JWCiXfYUVsFBRPvsqevrYaCia9ZnOu1S4CCiV1E7EACJEACJEACHkmAgolHmsXhSVEwcRiZR19AwcSjzcPJ2SFAwYRbhAQsCFAw4ZYgARIgARLwRQKnT5+W7Nmzx+ulUzCJ1+YzTZ6CiXfYUVsFBRPvsqevrYaCia9ZnOu1S4CCiV1E7EACJEACJOBFBC5cuCDr16+XK1euSK1atSR37tzxdnUUTOKt6aJNnIKJd9iRgol32dFXV0PBxFctz3XbJEDBhJuDBEiABEjAFwhcu3ZNNm7cKGfPnlXLTZIkiVStWlXefvvteLt8Cibx1nQUTLzDdFZXQQ8TLzauDyyNgokPGJlLdIzA3bAwCXv40KGLEidKJKlTpHDoGnYmARIgARIgAXcQuHPnjmzatElOnDihbh8cHCwlS5aUggULSmBgoDumZNg9KZgYhtKtA9HDxK34Db85BRPDkXLAOCRAwSQOYfNWJEACJEACJEACJOBOAqtXr5aDBw+qKQQFBUmRIkWkePHikjBhQndOy7B7UzAxDKVbB6Jg4lb8ht+cgonhSDlgHBKgYBKHsHkrEiABEiABEiABEnAngXnz5snFixeVN0mZMmUkceLE7pyO4femYGI4UrcMSMHELdhj7aYUTGINLQeOAwIUTOIAMm9BAiRAAiRAAiRAAp5A4ObNm8qzJIWXhpFSMPGEXeb6HCiYuM7Qk0agYOJJ1uBcHCVAwcRRYuxPAiRAAiRAAiRAAiTgkQQomHikWRyeFAUTh5F59AUUTDzaPJycHQIUTLhFSMCCwP0Hj+Thw8eS/pXUL7H535UbcuqvixKaKpnkz/2W7DlwQq7euCUF8mSX1zK+QpYkQAIkQAIk4DYCjx498roQG0dhUjBxlJhn9qdg4pl2cXZWFEycJcfrPIGAVwomx0+fl0Fj58uZ85ckQ7pQ6dPhMylZ+F2bvGPqv2PfMWnda1y0a4OCAuXIhtmeYD/OIRYInPrrgvx25A8pXTSvXLx8Q5ImCZZUKZLKzVv35L1335Ktu4+offXWG5nk9Nn/ybkLVyTr6xnVP7ORAAmQAAmQQFwTePr0qezatUv27t0r9erVkyxZssT1FDzmfhRMPMYULk2EgolL+DzuYgomHmcSTsgBAl4nmISHR0jl+j2k3oflpW7NcrJt9xEZMmGhrFs8Rh16LZu9/hBMhk5YID/OHmK61E9EkibxriRpDuwZr+8KD5Of1++SEoXeNQkmeXNmU+uGkLLrt+NSo3JxuXsvTNKkTiF/nr0k/gF+UrZYPq9nwwWSAAmQAAl4DoGIiAjZt2+f7Ny5U548eaImVrZsWSlVqpTnTDKOZ0LBJI6Bx9LtKJjEElg3DUvBxE3geVtDCHidYLL/8B/Sqf9k2bVqmvj7Q9oQqdNqkHxas5zUqvryDwh7/SGYDJ/0jaz9brQhwDkICZAACZAACZAACbhK4NChQ7Jt2za5f/++Gipr1qxSoUIFSZcunatDx+vrKZjEa/OZJk/BxDvsqK2Cgol32dPXVuN1gsnSVVtk2ZrtsmTmQJMtew79Sl5Jk0q6ta7zkn3t9Ydg0q7vBEmZPKkkS5JYCuV7Wzq1+ET9bzYSIAESIAESIAESiEsCp06dkk2bNsmtW7fUbTNkyCCVKlWSzJkzx+U0PPZeFEw81jQOTYyCiUO4PL4zBROPNxEnGAOBeCWY3Lv/UJ6/eG51OUkSBwtyiyz4YZ1s2nFQFk7ua+o3YMxcCQoMlP5dGr50rb3+d+6FyfWbdyR5siRy7cYtGffVUkmTOrlMGNxejYUXABsJkAAJkAAJxAWBRAkCJElwYFzcivfwUAJTp05VYkloaKiUL19ecuTI4aEzdc+0KJi4h7vRd6VgYjRR945HwcS9/Hl31wjEK8GkbqvBci/sodUVD+zaSIoWyCnwGFm+dqcsnt7f1A8eJmnTpJTureu+dK2j/Q8f/0sadRopv2+cI35+USE/bCRAAiRAAiRAAiQQFwTOnDkjYWFhki8f82ZZ403BJC52Yezfg4JJ7DOOyztQMIlL2ryX0QTilWCiZ/H7Dp+SLgOmyq5VU02CxictBkrdmmWldrUyLw3haH8k/Ow1bKbsXDlFz3TYhwRIgARIgARIgARIII4IUDCJI9CxfBsKJrEMOI6Hp2ASx8B5O0MJeJ1g8uxZuFT8tLs0rF1Z6lQvI9v3HZUBo+eqpK2oaIL/kLboPkYa131flRq213/O4l8kU/pQyZMzm9y990D6jZqjSsuiVDEbCZAACZAACZAACZCA5xCgYOI5tnBlJhRMXKHneddSMPE8m3BG+gl4nWCCpf9+8qwMGb9Azpy/LBnSpZYebetJueJRrqsRkZGSp3wzGdy9iXxSrbT6dzH1X/7rDpm/dK1cunJTlRKuVLqgdGlZW4ITJdBPmT1JgARIgARIgARIIAYCjx49UuWBixcvLiEhIWTlJAEKJk6C87DLKJh4mEFcnA4FExcB8nK3EvBKwcStRHlzEiABEiABEiABEtBJ4PHjx7J7927Zt2+fhIeHS+HCheX999/XeTW7WRKgYOIde4KCiXfYUVsFBRPvsqevrYaCia9ZnOslARIgARIgARJwOwEIJXv27FFCybNnz9R83nnnHSlTpoykSZPG7fOLrxOgYBJfLRd93hRMvMOOFEy8y46+uhoKJr5qea6bBEiABEiABEggzglERkbK9u3blVDy9OlTdf+3335bCSVp06aN8/l42w0pmHiHRSmYeIcdKZh4lx19dTUUTHzV8lw3CZAACZAACZBAnBP4448/ZMmSJRRKYok8BZNYAhvHw1IwiWPgsXw7huTEMmAOH6sEKJjEKl4OTgIkQAIkQAIkQAL/Ebh165Zs2rSJHiWxtCkomMQS2DgeloJJHAOP5dtRMIllwBw+VglQMIlVvBycBEiABEiABEiABEggrghQMIkr0rF7Hwomscs3rkenYBLXxHk/IwlQMDGSJsciARIgARIgARIgARJwGwEKJm5Db+iNKZgYitPtg1EwcbsJOAEXCFAwcQEeLyUBEiABEiABEiABEvAcAhRMPMcWrsyEgokr9DzvWgomnmcTzkg/AQom+lmxJwmQAAmQAAmQAAmQgAcToGDiwcZxYGoUTByAFQ+6UjCJB0biFG0SoGDCzUECJEACJEACJEACJOAVBCiYeIUZhYKJd9hRWwUFE++yp6+thoKJr1mc6yUBEiABEiABEiABLyVAwcQ7DEvBxDvsSMHEu+zoq6uhYOKrlue6SYAESIAESIAESMDLCFAw8Q6DUjDxDjtSMPEuO/rqaiiY+KrluW4SIAESIAESIAES8DICFEy8w6AUTLzDjhRMvMuOvroaCia+anmumwRIgARIgARIgAS8jAAFE+8wKAUT77AjBRPvsqOvroaCia9anusmARIgARIgARIgAS8jQMHEOwxKwcQ77EjBxLvs6KuroWDiq5bnukmABEiABEiABEjAywhQMPEOg1Iw8Q47UjDxLjv66moomPiq5bluEiABEiABEiABEiABEiABEiABEiABmwQomHBzkAAJkAAJkAAJkAAJkAAJkAAJkAAJkIAFAQom3BIkQAIkQAIkQAIkQAIkQAIkQAIkQAIkQMGEe4AESIAESIAESIAESIAESIAESIAESIAEYiZADxPuEBIgARIgARIgARIgAa8hcP/BI2naZZS0+KyaVC5T0LQuJIQdO+N7Wf7rDgmPiJDyJd+Twd2bSKKECbxm7d6wkDv3wqT/qLmy+8BxSRISLJ9/UknZki1+ELD1/GH2K9ftkilzf5J/bt+T3DnekOG9m8lrGV+JHwvjLH2WAAUTDzT92b8vS8b0adz6H3Aj5nD89HnJlT2L04TvhT2U+2EP5dUMaZ0e4/DxvyRvzmzi5+fn9BjuvvDFixdy6q8L8s5brzs9FSPs6fTNPehCT+BgxL529dkywiSuzsEIDkasw9UxPGFPuboGXk8C3kRg0uxlsmLtDrl1576M6d8mmmDy/crNsmDpWpk2soskDk4oPYbMkDw5s0n31nW9CUG8X0vXQdMlMjJS+ndpKFdv3JY2vcbLiD7NpVSRPPF+bd6+gJievzPnL0vd1oNl4pD28u7bWWX6ghVy5PgZWTJzoLdj4friOQEKJh5owM4DpiqhYPqXXZwSTcIePJJrN2/Lm1kyOb06V+fw+MkzqfZ5b6leqZh0bvGJU/P49qeNMmfxGpk/sY+8ltFx0eTZs3Cp2aSfFCuQU/p1/jzeiiYn//xbGnUaKaP7t5ayxfI5xdJVe0ZGPpf7Dx5KyuRJnbq/5UX4IZs6ZTJDxnJkEFc5mN8rIjJSAgMCHLm96uvqvjbi2XJ40hYXGDEHVzm4ugZcb8S+NnJPGbEmjkECJBBFoHbLQdK8/gfRBBP8t7R8ifzSsHZl1Wfbnt9lyPgFsumH8cTmIQTw263QB23k+xkDJEe219Ssxsz4XglgX/Zt6SGz5DTsEbD2/E2bt1z+OHNRpgzvpC7HeaVYjXbyy6JRLn0ctTcX/p0EXCVAwcRVgjauv3nrrkyfv0IGdmvs8B1wGGnbZ7z4iZ9TosnIKd/Kz+t3y5zxPeXtNzM7fH9c4OocMMbFy9fVQb9m5RJOiybjZy6V1Rv3OC2aQDhq3OlLKV4wl0uiCdxCM6VP65BwA8+QH37eKrU+KOXUwdrccJt3HZZew75yWjRxxZ74Qdl/9By5d/+hZMuSUb7o1EDy537LoX117uJVGTphgUwc0kG+XbZB/jh7USYP7ah7DHgj7Nh7VKpVLKr7GmsdXeFgPh7cunsN/0p9vXSmubqvjXi2nJm3+TVGzMFVDq6swYh97eq70qh97QoHXksC3krA2oGtdK1OMrRnU5OnwoVL16Vqg15yYO3XEpyIYTmesBfOX7wq1Rr2iWaTH1ZvlWWrt8n3X9ETwRNspGcO1p6/7kNmSLq0qaJ5dJX5uLN6JksWflfPsOxDAm4hQMEklrA/efpMPmzST3q2qyflijvmFYCvnvOW/CoTvv5BCud722HRBNf9duQP+ft/15wWTVydA7DigD104kL5dfM+FXvqjKfJ9r2/S89hM5XrrLOeJq6KJjv2HVOCgb+/n0NzwKG6ymc9JWf215XQ4Yw3grY94fYPDvj/Jwxp77CnibP2xKH48w4jZMaXXSTr6xll4Q/rBF8IBnRtJLWqltL99MAbo/vgGYIQKYRYfT2mmyQOTqT7+svX/pFKn3aX3u3rq1hmZ5uzHFas3SlZM2eQ3G+/oW4N4aV87S6y++dpTk3F1X1txLO1ZOVmmfXdGnnrjUzKnunSpHJoLUbMwVUO2FfDJ34j2/ceVbkIureuIwkSBNldh1H7Gjdydk/hWqP2td0FswMJxHMCmjeYrWWkSJbkJS9Sawe2QlVbq6/b+G2Fdv3mHSlXu4vsWDFFUqUwxoMynqN2+/QRgvxJi4FyfMs8k01Xb9gjXy/6WVYtGOH2+XEC+ghYe/7a952kvIbaN/3INAh+J+N8ULlMIX0DsxcJuIEABRODoT989ERCEkcdBPccOCGDxy+QVfOH6/oRr02l59Cv5NHjp9KrfT0ZMGauw54m85eslaCgQHn0+InM+/5XJZr8c/u+Ohi9kialrhW7OgfM/5MWA+SD8kWkYumC0qrnWIc9TfBFYcHSdTKmf2slurjD0wRz+ObHDTK6Xyv5ZdNeh+Zw9fot5RKMH2HwzHBWNIH7YsseY5VnR1BgoPQaPtNhTxNn7fntTxvk1F8XZVivZqZ9s27rb8rbZUSfllK1fGFd+wmdkOhrxORFSjDBnkyeNET3teu3HZBxXy1R7pttGtV0WjRxlgPi3ifO+lFmjemuRJPw8AjBl0pnBBNX97URz9bRk2el6+Dp0rdjA9mw7YDsO3zSITHQiDm4ygGbZ87iX2T3b8fVfvhq4UolwukJZTRyXzu7pzB/o/a17geJHUkgnhKAJ0irnuNszn7Z7CGm315aJ1seJsN7N5cShXKrbvQw8bwNoXmYHF4/y/TbGf+9+PHnbcx14XnmsjkjWx4mGdOFSpeWtU3XwcNkSI8mzE8Tj2zri1OlYGKw1eu3HapGbNfkIxUG0nfkLHn91XTSskF1XXdC6EKjjiNk49LxkjBBkFOhMTiY/u/yDaXgzvp2tTpUJEuSWGaP66ErE7URc8DXa3hmTB0RFafojPt+qY86yszR3UxhRY647+NAt27rfsWvTNE8kiFdqMrr4mh4Dg7Fcyf0Ut4FaI7MAWFRaUJTyNvZMkvTrqMkc6ZXnBJNug2eLu++k1Ua/Rtz7Wh4jiv23LzzkIodXjV/hBLhtIavPYPGzZOV80cI/uNnr81fulaQNb1xnfdlwOi5cunqzWiiCf45U/o0NodBRvXa1cvI7Tv3pXm3MU6JJq5wwMQWr9gkSGYG0QQJeEt+1EF2r3Lcw8SVfY15GPFsfTn1O5WQWQtxcmRfGzUHVzlgHh83HyDTRnZW3jGOhFsZta9d3VNG7Gt7zx7/TgK+SsDaga1hxxFSsVQBk+i+ZfdhGTxugWxdNtFXMXnculUOk6qtVfiNlsNk9LTFqqoKPjyxxQ8C1p6/qXOXy+lz/5Mpw6JCsvERrGj1drLmmy/Vb2Q2EvBUAhRMDLbMd8s3yeoNu8Xf31+Qw6LBxxVl/Nc/yDdT+upyeceXX8T4rf9+rGlmOAggq3RoymS6vp7CzX3rnt9lQJeGgsN1v1GzRV6IzfAcHB7KFMunQk7QjJjD7O/WqJAgc88EiCbVG/aVJp9WsRueA3bvVW6pXqLpX0ltYtFv1BxVZi6m8Bzkj2nYcaRkez2DiJ+f+gKNpK8fVSkZTTRB9vWYGkJq8ldqLluXTZIUyZOYusKl8ORff8uiKV8oIUZPQ/iCpWgCd3w9YgO+qlUtX0RqVi5uuhVEsYFj5uoKz3HFnnCDrtNqkPrRgq9y5q3XsJkqcSvCzmJqmqfNwil95Y3X0osWnvO/Kzdk1BetZO2W/XLu4hUZP6idHpSCJLjmogl+XEGMCU2VPNr1sbGvzUWT+u2GSvq0qSVRooQSnDCBJEqUQNo2/tDk6m1tMa7sa208V54tJFqd/d1q9SNl3oTephAjjG1LNMH758Dvp6Vk4agvsmiuzAHXu8IB+wcHnG17jqi5rFs81pR7QK9oYsS+NupdqTHVu691PSTsRAIkYDXpK7zLFi3bqMJM4ZGGDxLvvJVZ+nT4jMQ8iECn/lPUb9J+nRvKjX/uKC/bQd2aSPmS+T1olpxKTASsCSbwmMaHZYTF5cqRRb5auEr2HTopP82J+tjMRgKeSoCCiQGWuXLtH7l4+YYUee8d5apfq1l/mT+pj5w+e1Gmz18pJ/78WyqVKiCj+rWKdjcceuHqnzQkWHq0/VRVtcH1+PL6RafPTV9/8eO+VvP+Uq54fmnTsIbJRRGupBnTh76UG+PYqXMy9/tfpHql4jJq6ncya2x3QRgFwnMQ/2l+sERi2jWb9qofD1oddEfmgMMwwo4OHftTKpUuKEN6NFX/kTv2x3lp2uVLWTpzkGR5Lb1aN+bbY+gM+aBCUZO3BP498nIgP4Zla91rvKQNTaHG1Brc35GjoG2jmjbFii++nC2ZMqSRNg1rqst2/XZcOnwxSWaM6qoOs/A02bTjoHxWq6Jd6zfp8qVkeS2DEp/QwiMi5eNm/aVg3hzKrsjirreZiyZvvJZB/jp/SSYN7WC6HHb7+tvV6iuKyuL/SSW1VtgS3iqLZwwwVU2Ce+qmHYeUIKe5FsNu0xesFAhmEDggZCDsxRF77j10UqbNWyFPnz2TahWKSv1aFeTSlZvyWfthUqVsYRUWpJVo/umX7bJz/3EZP6itTQTwcDpx+m81n9YNa5j64dCLL0ZLVm6RPDmzqmSwjsSPa4fL5p99IHsPnpTSRfNEs6er+zomm2qiCcLbIPg8fvJUnjx5JgEBAVIoXw7TpRBP53y3RnnmjOjTQvLnflP9Te++NuLZMl8HmHXsP0Xt5Q3bD6p9Mn9ib9Pzib7wRqtStpDp2YKdINglCAqSSUPam949jjzftva1Xg6WtkAeHSRsbVqvqsqnA+4zR3c15cSBaIJYd/N35e8nz6q+ENZQNaNCyfeUoKt3Xz99Fi5jpn+vwvKyvp5BJgxur96jjjxb1uZguTZ7+1rvu4b9SMCXCQyf9I36XfPg4WNJmCCBBAUFyMp5wyVN6hQq59CoaYtl1fpdEhERIWWL55PB3Zs4lFPLl9nG1drxO6j/6LmC3yQhwYnks48rmH7TxdUceB/nCMT0/GHEZWu2q6IYt+7ck1w53lAJX7VzgnN35FUkEPsEKJgYwBj5NVCWDhmecUjduvuInP/fVenR5lM1Ojwi/P38laCitZnf/Kw8UVo1rKFyneBQ/8uiL9V/tBFK0mfELOnaqo68X7aQ+poLr4lxA6MfTFHOEuKEZW4MCAL12gxRhxyIJZoQAlHDvLoJ4kSR0BPKLoQJ86ZnDijxVrfVIJX8M/+7b8kXI2fL4B5NTAd45KtAjL72MoSQUbVcYalbs1y0g3P52l3VIcYymad2oMHhplWD6nL4xBmZMHOprF08JsYEqnDTx9eiAnmym+6DAxTW/9WobjFa/OyFKwLPhPfefUuxwj836jhSihfKJR+9X1KW/rxVwiMiZOLg9lKqVkdZPH2AQ5VzIJrUaNxXsmd9VaYO7/TfAfTUOYE9EUaFPCWYb3CihCokCZ4LjTuNVAdDJOeERwX6fjW6q6l0NLxhWvcapw7nNSoVk3lL1kpoyuSmkCg99sSBrvOAKUqsw4/KSbN/VB4kU4d3lqs3bqmDM74IfNGxgZpLm97jVWgM3JttNfzYadt7gnRs9rE0rvv+S91wn4AAf6eeQiSQbdB+uLRr/KHy7NCaq/vafDJ47pBEGbmJIPhoVacgmuDfzxnXM5qXhnYthCLk3Ondrr7sOnBcDh79UxZP76/+rGdfG/Fsma8D75cVa3dIqcJ5VKlvNAgI2M+Woon5dT+u3iZIeLtgUp+X7KTn+YZYYmtf373/QAkWjjzfmM+yX7Yrb6T0aVMJhAyIoRBJzEUT8zXsO3xKug6aJm0bfajEranzlsuiqV+okCR87bK3r/FsYa/jeUQp0mnzl6trtRhsPc9WTHOw3Py29rVTDwkvIgESIAESIAESIAEScIkABROX8P138Z17YTJpVlfwAgAAIABJREFU1jJZv/03adf4I1n68xaZO76XOnBaNnxxb9FjjBIqEHsP93Qc8pvV/0AlSUXDQXPE5G+V90W+XG/KxCFRXzTNG0JD9hw8ob6uW4om+BGPw50mllhb5oIf1slf5y6psBnk/Jj5zSrleo98GR2a1pKjp87GOIcuA6eqkAQtJGPohIVKNIKnQPZsr6kcLN/8uF7lUbl9N0yFxOBLjhb6gzmhmhCqn+BAiizZlqIJwlYGjZ2v1pkuTUoZ3b+N6Uu9+ZogIhw6/pcUyf+OIGwHB/GRfVuYumBdOODF5PaHfAQQmiCWoMpQ8/rVpNXn1ZVHChKOHj15TokwqNSCcqCw2aal4yVJSLDuXQRV/ciJM9HEElzcru9E+fD9EibxAQl7m3UbIwiSQihLeHikjJ6+WFat24UoIyXGmQtP+Or+65b9KvQL1XjwdaZCna6y/vtxJjHM3p6C9w6Er0//FbTwNb5dnwlqb+DADFsh9wWShELE6disli4vHdy3wxeTZWC3RsprxYgGe7f/YpLkzZktmliCsV3d19r88FzWbzdM5a9JmiSx/PDzFuUJo3n0aJ4m+HJpnkz5z3OXlMC1bA5CdlKpvd998HTp3eEzVe0JuVrs7Wsjni1zzvBSGvfVUiWOwDtKa/ZEE7xjKpYuoMLB4EWHxKr/u3JTqpQrLPU/Km/3+ba3r1GhQs/zjfnime7Yf7J6R5k/dzGJJhBS3q/fQ3mp4T2JhvfAs2cRMqh7VMl3PCsx7Wt4Cq1at1MWTeunni28W2FjhDFmSh8qKZMnjfF9rWcOmj1i2tdGPDccgwRIgARIgARIgARIwDECFEwc42XqjS/GI6d8q5KZwtW+V7v6yqUM5dCGT1ok+LLa4JOKJi8T89vA6wJiRPfWdU3/GmOlSpFMHdDNG1y+zZNtan/DfRA6gR/9+ELqTEJRJOI8cfq8qnbSpPOXKowFYgHCJCDOfDWqq7qdrTm07TNBhvZspkQhCEYfNe0vr4SmVP8bXgNI2IWQEHyhxeHTmicBDvo48CBBbkzJPG3NQeMBLx7kNfj129Fy7cYtqd1qkBJoOjX/BAkTpOewr+T1V9NLp+YfW7U4DipDJixU68d1EKqadx8jn3xQWiXwNW8IpUF8bf2PKqiQGEfahu0HpHSRPC9VTUKsZ9eWtaVogZxqOBwOEef5+OkzqVWlpMk7AyFBgQH+L5VPhLhWrEBOKVMsr2k6CA1D/K8WCqL9wRZLeADh4A9vEK1BLEHuFRz8EYag7Qfk6LFmT3Ac+9VSWb1xt4QkDpbPPqogjepUFnxhN1I0QagIwqqslaFzdV9jjVjHtr2/q5A5eJGgwfOo94ivlXeDJpocP31eeRuYN4htuFZ7viEYotoT3g+/nzwjvdrVMwlNsflsYU4QZ7Nne1Ud9LV5zJvYy+SZhD54BuHlYS0fDwSP0kXzSslCuZU3SK0qpSRp0sQya9FqaVqvijT9tGqMz7fufW3jPafZAmImwrrAq/PAqQIPnNlje5jESrxDZn+7WpUvNy8rjDw5CBlEX60hlO27FRtNdjV/Lqzta4QpvZYxrRIzNW8TvPexvy9cuiazx/WUPO9ktfmudGQOMe1rR94z7EsCJEACJEACJEACJGAMAQomTnCES32jTiPVV8s3MqdXX1lXrd+tvu4jDwkack6kSplMCQFoEAyWrNqiDr/4QY+Db1BggOnuyBwdEOhvitFEhZmiBd6JMfQEYyKfhLWEonpCHU6f/Z80aD9M5QL459Y90ZKgYrwPPu+tqupoGcq1ieKgonnNaPfH35BH4rff/1CeKThsNu06WokP5qXDrKE2H8My6SH661mHxrdawz7Ss2099SUZogY8Jq7duC1+/n5SomBulbTUmviEe8Bb5P6Dh7Lh+3EmIUCr7GMumkAM+qT5QGnZoFo0Dw8ntlG0SybPWSabdx6Wr8d0l5TJkyjRzT/AX8oWy6e+iP/67aiXbmG+pwIDA18SpVANAIIR7IA17j5wIlriTssBEQoA0Qr7GFVgtIawFOwHW+En5uOgDDa8hbq1qiNnL1yVwePmSbGCudSzonmaTB7awSQMucrN2vXO7GvLcRBmh+TLEDcQhqE1JFHuPXxmNNEkpmcDNoLHEw7yqJaF3Bs48G//aZLyWjFvd+89kGRJQ5QHlhHPFsbGHoD4qXmg2RJNbNkBCRKX/7pTedmUK5HPJFBBMIZgum/NjBhN6My+thwQIYtgNuPLrkr8syWa2JqI5bsW4t3MhatU9Ss0iF7w9DP34MM1CN9BdTHt/YJ3rRaihSTSCJ9EBalDx/4yhVsZOYfYeDY4JgmQAAmQAAmQAAmQgGMEKJjY4YWDC1yq4UqvNZQWff78eTQxYOxXS6LlKTAfFmMMnfiN/H7ijPqRDq8Ly4aDBUI78MUWX7XnLv5Fvp3WTyUp09PMRROEtnQdNF2532vhIjgwr1y3U7mSI6Go5pYPUQHJ0XAgNw/fgXcF8oogxEVrOOzhsPjd9P52EzTNX7JWuc5rZYW1MXD42b7vqMrhATd/LYGo9ndz0QRf5L9bvlGmj+yiB4EsXbVFNu08pPJ+aA35LFDFBB4SMTVbYSMQTVr2GCdfj+lm4vMsPEJ5Et0Pe6Ty0pgLXzHdA2MhrAHeCchvsWbjXhUuA3shqVmHfpNVtvDAwAAp+l5OFX6EQ1vZjzvL75vmRBtaz576vMNw6dmuvrzzZmZV3ho5I3Do1EKicEBHGBOqCWm2R14OJHNFBZVsWf5LxIucOshf8lmtCjaXiK/8hT9oI3t+nm6qWoLEpR+3GCCj+7VW68bh9K0smaIlLkZ+CeTngaCgt2EvYn446Lq6r23d05a4ANEEHkgQQbQ2cdaPqiLVj18Pesl7yHL8glVay8LJfUz5UPB3hOhAvOzaso4px4itedl6tqz1RzWcFt3HKO8Re6IJ3iEIJcQ1CPdCBSe8+2o166e8wDb/MMF0C+y/glVaqbLK5h4dru5rW2tGGeuhExc6LZqYjwtxF15I8KBDBSmEdo0Z0MZU3QiCTMueY+XVDGmjJZy2Njd48CAx9P5fvtK7dVU/e3NwaDB2JgESIAESIAESIAESiDUCFEzsoFXx6+t3RXP/njL3J7nxz12VzFRryMZetHpbdYAw/3Ks52CLMVCB4dWMadVwEEsgdugtWavNQRNN4AJuHjaAr6VIvBn28JFkez2jSjY7eVhHKVUkjyBXRpPOo5QXBkIuICzgENF18HSVVT4kcSI1PA7XVRv0UgKIeeJYa/ggzsB9Hzk5tHwY6If8HT/9ukOFpKzdul8+rlpKJba1bBBNmnUdLSmSJ5U543pY5QDX+E4DpqgvwMh7Ak8Y5NioWLebLJraT1c9d3iLwAPljcwZVL4VW6KJ+Rdq3KP74Bnq4B8REanCmJDfA9fH1CCWDBgzT778oqUSdv48e0k+rlZKFi3bIKlTJFOHWTQIWgmCAk3iwY59RwWH8WWzh5iG17unEA4xok9zmf3tGhUmZZ5kFhVSEF6CxLCY25dftFIJhjE2QpvWb/tNzQkiB/K11Gk5SMYObCu5c0QPPzFfMzyLClVtrcKizEtB4ys87AVvDfMGrh817SefVCstjeu8nBDWFk8IEz+v3yXDe7dQoVGu7Gvze8C2G3ccVEl3EaKCkCM9HhkQAb8YNVvZCPksYmpICI1cP2u/Gx3N2wnJaxFOBZEypmbr2TK/Bh5w5uKTNdEE+VfwHGrvGFT6atT5S8n51utKpENI4fK5w1SIFsShzzuOkPIl3lNVkhIlTKD27c79R6MlUYbo68q+ttxL8GYz30fWRBOEyzT9tIpdkcp8bNgAHoGN61RWYgkqGGkhVugHQRzJYPG82EtIjPf21Ru3Y6wUZc2e9uZg5z9L/DMJkAAJkAAJkAAJkEAcEaBgYge0NfdveC0ghAOJWCE6oOFLeo3GX8jun6eZPA5sHWxxGIGXAtzLNQ8L5I+4/s8duXjpulNiCeaAQ0+LHmNVhRjzAwC8X5DcVfMuQHnh9dsPmNzIIZrgkLxu22/yavo08vDxExnTv40K5dAaqmns2n/MVAZ35/5jpgSx5YrnM/XTcrggbAd8tPXhgD5w7DxZNnuoSgqLsqQIF9ixfPJLSVMxNnK6zBrTPUbRCGWKETKAKh4IIUHoBNhiPWAQU8NXeiS5hVs9DojI9VG1fGGbook2FuyEkJMx/VsrG9ZvN1RVCWpkFrZheV9zsQTJJjv2m6wO1ziMIeEkQhtQftmyQfhCaFPPtp+aksE6sqcqftpdCUf+fn7RxBJU/vm8/XCZNrKzSii8/Ncdgj2y9ceJpkM88lpAGETeF4QhYH1NPq1i97UET5RrN2+pg7QmIiEkBfMw98jAQEieiYP3N1O+UONCmEFOnbfeePWlBMfajTWxBB4rk+Ysc3lfa+NijcgFlDJFUvnf5RvKA2r84PbqWbYnmqBUNpLPokw1RCN4bF26elOJLlpVHezJH1ZvU7k/IFaa55XRqubsXDFFPS8QzTZuP6BC35BPR/PgiOnZKlogl5orRKjqDfso8QueS1qDaNKgw3AVWmOZIBp7ql7boYLnuGWDqBxKbXpPkLfeyGTyosMc4V3296XrykMOYWOTh3UyJRSG55Qr+xpC0PZ9v6sQNDTsSey/+RP7RKtCBe8nvBtmju5uNfmz3Q0qot4X8OLD+9JSLMH1pWt1kllje6j14/mE1wz+OwBbaGE7SFY7Y8FKlZvnu+n97ApllvOyNwc962AfEiABEiABEiABEiCB2CdAwUQHY2uiCXKUDBg7T+rVLKdCA3AAr1OjbLQkoEjgB28EHDaQaBGlhRF+cOyPc+pgA0ECbuFIyIgqDfi6vXBSH4c9S7Ql4DCRNjRlNLEEB5HydbqqEAAt7ALeMagccWj9rGirx5fSf27dVYdFczd7dMKhEYdAVLnBgWX73qPK2wDJLRGmgUShOOC36D5WalUtqSrMmFfDQYgQkpLCm0BrVT7rJaP7tXqpLCsO7/U/LK+bAwQMHEAQvnPnbphEPn8u25dPtun1AU8SCEQoLYpDKRKxImRlZN+W6pCLv8NuK+cPj1blCF/aUTVl45JxJi+iJSs3CwSeKcM7Wd1J5mIJwkdw4IcYAQ8iNAg8rXuPV3sAAsOQnk1NYVDwzIAHiLlQ4ciegqgXVRb4v/LFuCf2IA7OWjJbHJjLfNxZhTKZ56yBgIHKQFleS6cqu6DBk0oL88JzMX3BSjn119/y4fsl1SEdf2/ebbQSkz79sLz8ffGqbNl9RL7/asBLoWgorX3jnzsqdw5yhiD/CRJp3g97qAS78iXzR2NqLpYgOacR+xo3wLPYoN0wNX+wHjVtsSxbs00K5X1bJgz5TzSBwIWQOcvWssdYqVG5uNo7TbqMUsJFsiQhsvO3YzJlWCeVN2b0tMVKJBzUrZFkff2/UCeMhXLOvYd/rcLiICIhf03h/G/LsVPnJV3aVCp3zJXr/1h9tiDEfNJioIwd0MaUd0bLvVOzcoloosln7YapAz/yb5iH+p05f1ntwfWLx5qeWYgE8ESzLMON3EBoWTNnjPZ8u7qvweaLkbPUPoGIiTZ+JpIH74kmmiC305S5y5SAaCnA6XiVqy5I+tp96AyZMqxjtHeldn3eis0Vi4ePHkuzbqMlZ/Yscuv2PRU2BWETgi8SIWdKn1b6dPzMlOdE7/31zMGRsdiXBEiABEiABEiABEgg9ghQMNHJ1ppogtARfKl88PCJVKtQRMqViH7Aw9DmB1wcuIoVyCUdmn6kvqbDDb9h7UrqyzT64bCvN2eJzmmrbviSah7eg/CI3OWayImt89XfIargC3SK5ElsDosqNP1HzVUu+Yj/xxdYHPDhuo6D2KoFI1TOA1sN4ULIzaGF+KDf5x2QlPRjVaoXzTyhrCPr0/ri4I/Eppeu3DAlZMW/w4EUHgBagxs9wqZaN6xh+ncr1+2SKXOWycal49W/MxcGtE7gtnXPEfUlXmvgAjEJOT8sm6VYgr8jNAYJVF9Nn1bCIyKUt0r9WhVU/gSIBviyvnXZpGiHUctx9e4p8EwaEvyS+IV9mzJFsmh5XWBDJOjVbGGNP7wnqn7eWx3CUR4YZWpRIhmCAPZEg1oVVYlf9Fu8crMcOvqnCllqVu8Ddci0bL9s2idzFq+RUV+0kg79JqnDOTxRwAACIg6tyZNF5fsxF0u0xL1G7GuMjfCqybOXqYS7EB1/3rBbhbS16TVeQlOlMIkmtvYkQqa0MBg8S91aR4WZIfRq9ndrZP33Y2PcztgDJT/soAQreDBp4XjYg3VaDZJWn9dQ+X7MG94fEJaQZwP7AfmCEOaBsCd4qWiiyftlC6v5bNl1WOBZhvxD1polS4iG8MDS9jWe35CQRDaTUDu7ryFCZkyfRoX5YB2YI8JwtPLTEE1gD+wNrBUCRvsmH5mSaTvznsA18Ag0D/cxHwfPQtXyRWTtln1K+EUSabxHUGkrYYIEqgy7ZTNP0qt3TjHNQe8Y7EcCJEACJEACJEACJBC7BCiYOMBXb3UGlGJNkCDQdLjQDrj42q9VosFt537/ixw+fkZ96bTVcJgyFxlimi4OqpaeIdb648d9/sot5fD6WUosgXcFvAbM52btQFCn1WB1MIQLulYNCP1wiGlSt4rVr7UxzRchOSi9+u47WZXw9P2KzfLTnKExigUOmEt1xddzhBsM7NbIdAiDN9CO/UejlRWFjfJVbC47V0w1HdL13Asu+cgRMmtsdxPLiqULRFUIGjhN5SyBZ4l5gycODreoNILSxIXy5VB/hl2K12gvaxZ9+ZKLv5F7ytq6YAvkk4GwhBw247/+QeaO7/WSLUx5Xro2khkLV8r3MwYo8QnhUY07j7RahtkWRyQUrVyvu/I8QXJaCC9aw6G1XZMPlcAITouWrVeJY61VOdKucXRfo3+3wTPkk2qlpGCeHALG1Rv1UXsQnhjf/rRRkJdjYNfGKlzLVkN4Bio04ZqfF44wPfcQ2PJXbqEqydjLcQOvlh9Xb1NilHliXXjhwIvEstoU5gaxSQtZuXbztjTu9KUSEuBBEiWa3JB2fSaosBI0CDJ41vQ07GvkUsI1t++GSdMuo6RNoxpWyzhr4zmzrzsPmKqEn+lfdlGiibU8Ql8tXCVfLVwpCRMmkJKF31XeNK62mN6VEOd6DftKvc+0Utq4H6rhwOtrsYXohBAqCF0LJvU2ecfomZ/e97WesdiHBEiABEiABEiABEggdghQMHGQa0yiCQ6Awyd9o5LE4oA0uHtT00ELB/Lnkc+jCRq9hs1UITTaF2nLqeCghLAKHGThgh5TwxflweMXqC+xm3celPfezW4zDwTmWb52F9mxYooSSywTgtq6Dw7F9doOkSplC0vfjg1UDg58ef6oWT/5fsZAUz4DvUjrthosQ3s1k0PH/nwp0S1c8d99O2u0/AV6x7XsZ3kIw5xrNO6rchLAwwWHSxzKew2fKRu+H2vKu4Kv+Dv2HpVqFYvavDVCBJau2iwTh3R4iSW8dhDGBN7mOSu0wUZM/lYyZ0qrPIzQwLdd34myeuFI0/2M3lO2FvJpmyEyqFtj5R1iLRGm+XXg2b7vRFXJxzwUyVoZZns2Q24brBnhUJpXAUS8mk2+UPlyEDoEBoEB/rJ51yFD9zVyjSxcuk7mjO+pBMNdvx2XcV8tUYIJwnQ+aTFAeb9Ylta2tqZ1W39TZazhfVC9UjHVBQfsQePmy6r5w+1hUAmLG3f+UuWbQa4heNZA0EGFJoSxVS5T8KUxLENWrIkmeF8h3AVhVVpCWoz7w89bpdYHpWx6jMAuy9Zsl4HdGiuxpFLpAsp7SGvIp+LKvtbGwRht+4wXP/GLUTTBc3Tn3oMYkw7bhfxvBwgiyMcUk0CMZxMeJvA60uwP8Qq5biBImTesAXszf643lXiohazpfV/rrbKld33sRwIkQAIkQAIkQAIkYBwBCiZOsMQhBIdrHHTNE6N27D9ZHUB6t/9Mdv12TIagGsa3o1WlCfOGEp1T5y5XuTPwhd5aKIwW1oDwCRza7P341iqwwJsBIghyY8yb2NuqaIIf/cjFgR/4esUS7f7w2ED4BDxZIMrg4IFkqzGVm7U1d1TdqVS6oPyyae9LiW4R5gDhyTLpoz0OWtley36WoglCidr1mSipUiaTrK9nUOsYN7CdydsD1yNnQaVPu0vv9vVVJR5rDQdlHJbkRVS4jWW+EISXjJi8yGqSSogtXQZOUYk2UyRLIt/8uF4GdW8Sa3sqJnZIWNymYQ2Vn8ZaIkx7PLW/QzTBwXJwjyY2D+OWY0Ec6z96rhKwCuXNoZKmooy35b43al8rr6ovZ6n8KR2a1jJVfYKQhnAp5A+5cv2WZEofqnKp6G3IP9Jv1FzlpYNnHu8AeCiYh4PFNBYEtu5DZqiS1Sj9ferMRRXmhpLL1hpEjZ7DZipWMXmaWF4Lz5cqn/WUnNlffykBrNZXlRrftE8JfpZiCfq4uq+1+8AW85b8KihnjbC0mDxNtGssS72jtO/8pb9KooQJpd6H5Uy5XKwxsxbaZa0f7oF3EJ5JiNWPnz6Vvy9ek4WT+9oMXYRgDdvNHtsjRtHEWqie3j3GfiRAAiRAAiRAAiRAAnFLgIKJQbzXbzugfvSvmDfM5H6PBKgIz6hTvYzpLnCPh9cIEsUixABhOpYNhwj0efrsmUwb2UXeeC29zVla/vjGl/F6bYYoL4knT55aFU3gyQCxAu77lgd8PTgg+GzYdkBV9UEiV60SiJ5rzfsg0ShCLBbYKKFsLemjrXvoOYRYiiYIwdi885A8ePRYlXS1DJ2BTeFxgINsm0Y1rYomCCVCOEXBPNmtsoTHEcKuMD94/1h6muAeP/2yTVImTybN6lVV+0JrRu4pe7ZBDg3sHYQ7mFdYMr8uaj5LZXjv5kpksFWG2d69rP0duSwW/LBOiRjFC+ZWYqR50mCj9zXyzuBAjCSeEA60BoEAoTEQPGpXL6Nb9NGux/MNEQ0NSWAtxVI9bODpgmpB8GzQqnBZXvfD6q2yYOk6Va0JuW/Mk6NqnibVKxY1JfY1vx65M1ByGnll1Huof+uX1onxB42dL+0afxjNs0Qbx5V9bT4XeOXgOezVvp5K+mvN02Ty0A5StEBO02Xmpd4hUtZtPVjq1iinql39uHqrqniFkuaWTa9YYn4dktxu2/O7yi0FLx+EDVlrEFfTpk4hnQdOVbmYbIkmet5TevYI+5AACZAACZAACZAACcQNAQomZpwhBNjLNaB1x49oHDa0RKfwBDn110X5+INSphGRFDNx4oTSpmHNaNbEoUorT2lpZniWoMIIElG27T1BVaXRXPwt+1r78Q0PEFTnaPhJZXUA+f3EGauiCbxbShfJoyvnSWxtxcPH/5JXQlNarYYDLxhUCwGH58+fx+hp4sghxJFDPsqa4tB8+859ad5tjFXRBLZEpZje7eq9xBL7CaIP8rQgcSUSmVoTTWzxNWpP6bEfyvu+/mo6m2IJPArmLVkrQ3s2lTxmeTAc4alnHrb6xMa+tlcu2JX5xva1pT7qqPKLaGKltfAchACaJ3vW5oQKX2lCU8jb2TKrai9ItGspmiCEcNOOg1Zzlri6r7V5nLt4VRp1HKESLeO9ay08B8//W1kyRXu2zMMi4ZWCMJjm9T9Qw+49eFKV6f52Wr9oQq4zYokeG+L5h+gDwQThOxleSW1TNHHkPaXn3uxDAiRAAiRAAiRAAiQQ+wQomPzLGC7YtZr1V3kTtPK7tvDr/fGNsBtUhkE1FniN4ACO0A5LrxJ8Hd536JSqQNOx32T1VbnBxxVj/IKv58c3XO8tRRN8QddKxGrrwxdq5PDA/eGZ4mjT8l70aPtptGSwjo6j9cdhDflNUOYVpUNj8jTRw8FyHs4c8iFemIsmWPP9B49sCl/W1o4KLOaiCZKFIiTIkRwGeveUs+ytXQfvjop1u8my2UPU3kU405JVW9RBu3Gd99U+RXll8wSZRt7fciy9+1rPHGISTXCA7zFkhvRsV8+QXDp65qOnD95V71VuKWu++TJapZd+o+YIqjY5EsaGMCRL0QSH/5gqXlnO0dl9jeTCCEEyryIE5vAYCU2ZzBSeY3VPhkcoYQLJk5EjxrxUM6pg4R3Sp8Nn6lK972s97M37YB9+2maw8iTCe0p7d1rLc+XMe8rR+bA/CZAACZAACZAACZCA8QQomJgxhafA8T/OyfSRXWySduTH96TZy1QFEIgkMSVXxVfKRp1GqlK2EAm0H/qYhK3DPcIGShTO/VIYSUyHyxYNqsnXi1arvCnmiQmtJYu0t9VwAEBSSK16hzNf68GnRqViksUi5AhflbsPniFrvxttmoY10cSVQwi4RkREOlTZRxNNmn/2gfqSjXKjWsJWe7y0v2uHSyTTnD5/hXzZt6XkfvsNvZeL3j2le8B/O2JfP3j4SGpUil6+Fn/Gvixdq5NMHNJeUD0FCUORoHXbniOqug1yXFg2HMSRuBTCEsQ485AKW3OLaQ7O7Gu9DLS9u3L+8JfETEfCwrT7me9r7DN4QeAQPXnuT6okrq2wDu16y2fL2jpa9xqvkiwP6dHU9Gd4OiC3UNtGNa16ltjiYS6avPFaBkEYCoRjR5oz+xpM4CnzRafPTYmVISzXat5fyhXPr3LqaFW/8O+xj1BRCiWQV67fJc3rfWDVm2Pxik0qhxNy8aB9vehnVcUrpgpLttYKAQc5iAZ0bfSSsIn3FBJ3Q7gybxC08G4xz3Ol933tCHP2JQESIAESIAESIAESiH0CPi+Y4Mf346fPVDUO/IBH7hB4SqB8pWVzRCzBtUigifwjqJZhL7kqvg4jTAYJBhH2YO7pgUMXBARrBzo9WwRfQtv0Hi9nL1yRhZP6WD1MOSKa2BIqHBFNkO8Fog2+zFo2HNhQMWTbT5Oi5Vao33aoYJ7L5w5TYToo2zukRxMZNvEbZTPzUsfSRvSNAAAgAElEQVR6uDjTB2FEDdoPt5nbQc+Y4DRt/gqV88RWvhBb4+jdU6i6cu7CFcmYLo3dMsl69jUOnfOXrpX3cr+lWMMLC2JCurSppf5H5aNNF2VWUWIYwiNEIdgF18TU9MzB8no9+1qPPdAHlZqQl8Vaw/5CYl89nhvm+xpiEd4neXJmU7lZ3sicQSUQjqnZerbWbtkvS1ZtVpVu2jb6UHmufdZ+mPJuaNWguhw+cUYmzFwqaxePcTjvCuajVY7KnvVVp/IaYQx7+xpeHyjBvXP/MXn7zdekfdNasvfgCekzYpaqBAaxePZ3a1QlGstEt8hxg/LgeF9AnOncorbKKWLpzYEy7CiRjSpeEDQtG8QMJLTFs1G6aN5o4WWWfSGWdBs8TSW1LpL/nZfG+v3kWenUf4ps/mFCtHw7SFYdGBAYYylqvfuS/UiABEiABEiABEiABNxLwOcFEyR+xI/0KuUKSZtGH8q9+w9UxY7lc4ZG+yLpzIEOXx8PHvtTiSb2kqtCUMFXSQgF+XK9aRJN7t57oA5HaHrKVVrbTjig4KA9CzH26UJt7jg9ook9rw49oklMYgkmh0NN9UZ9VVJazdsGJX4/bz9cHYSKvBd1eEEyVuQv0HNPy0Xb8m6J6XHUQo9Q9cS8xKojjzAEuhY9xqp1OSqW4D569hQENvQLTpRQrt24pQ58OGCaJ1HV5uzMvsa1EI56D/9aFk39QiXEtGxzFv+iBBWUZLZX5cnZOVjb1whvQ76Tzi0+ccQsyhNG82Ywv/DbnzbI/KXrJOdbr8vRU2djFE2s7WuEt3zQoJcSmFbMG27VBtr9bD1bS1dtkeVrd0qPNnVVieDJs5ep8Ch4TCAx656DJyRdmpQyun8bq+Wr9YCAsHXkxBm77ylbY+nZ1wi/wZ6sXa20IFny0VPnlPh58OhpQRlfiCJ498GTyVqOJ9gW+7pOjbIysGsj01Q00eT8xavy4oWofCbmuaS0jhDYOg+covrAnvBEaVSnsjT9tOpLy7IllkAMHDphgcqP0qtdfanWsI9ULPWeEnzQIAo1aDdMmtX/wG4peD12YR8SIAESiE8EkO8MHwDhYbruuzHqN5rWKtTtJq0/ryGfVCuta0kIr/xl817Z8uNEXf2d6QRPQYSA71w5RX2QYCMBEiABawR8XjC5fTdMVZXBoRIlJJHQ8p8796RYgVyqagkaXMEXLVuvqto44taNQ8GWXYdlyrCOVg9jSHq4YOlaCQoMVHlOcEjQwnMQpoEKFahGgS+h9T6M/hXfke0cU3JVy3FiEk3siSXaWDEJGNYOlfiijH+Pr8PggMMIvEyQMyRPzqzyfpnC6nCDEs62DsKOiCb2BBtbbGNKhKnXHrAvPH0QpuFMs7enICxVb9hHpgzvpPYyxIP2X0xSX9vNQ71wb2eECuwB8MPhevygduqAa60hseiPa7bJX+cuyZzxPW1WUnJmDtr9rO1rzA/hbTUrl9AtmmAOKCvdv0vDaEvBGrsMnCo/fD1YPZsxhefY2lN4npas3CLrt/0WTQi1ZBbTs4VqUj/OGqx+zCG0L13aVCoUDrllkP8GgoEj7yVr9nI1CbS9fY13XdeB02T53KFy594DadVznEqiXK54Pt3r2HPghPIEQjUl7GWUodaaVuod4Y+29iTWiB/z8HzCe79lj7FK+MQczJstsQTPUvPuY6Tbv94wYA4BpVnXUZIrxxtSolAuWbvlN5XbZ1ivZs483ryGBEiABOI1Abxj8UEKoafwAtTCtrEoRwUThEFfuX5LeVLGVqNgEltkOS4JeBcBnxRM8DUUuTzwYxl5AOBlkjY0qozoirU71N8ePX4iW5dNUgcS/IA+f/GK+krsqJcHvmpa+7KPwx5CSiCEIG/Kmb8vq6/XKEOKwwfi33878od8XLXU/9s7D7Aqzm4Lb0tiib3F3o0mttg10VhjL7F37KhYQBRBEEFFmoCCoKAI9hp77y32klhi+WNJjInGEhM1JtbcZ23unAyHmVOAo4D7e5773P//nfLNO3MO51uz9trkOaYfHwOLYfwbyoeSY2AxNyVkIZ387gr/yB89qBMHzmqJJqbefs9duplbejZvWIuc7bvquj60FpVwk/Qa4cPXhDcRqzfto5lTRrH7AkJK1OJNhD+adap/wtkMphaGlogmiRVLkoN3ch1D/UzBcYB2pkr7WoRgQviDSKGMH3++Qx0HedKGWB9DoLEiVEwa049y57L8rYpS0tCgdhXdUh9so5SUYXEbtWijQTTBZ+noqQvUpH71RAk2ljBE22wEh/bo0MSsaKJwQI4G2iary4vw7N3//Q/O2FCGlmii9UxhAY+Sjdw5s3EgqSKEYjGP3JFXr1+Tb+hicnfsS7d/u0+TpseSv4d9gkwi3Os6bYbR4Q3h7HxTxBLMB6IDWjyr3RhwaRQplN9sToolHJNzG3yXRS7eSNM9h8cTS1AKBFEqZoar7unUrg44zCBgo8QQ5U2dWn/BmSYQ50YP6mxyygjdzpY1C3VoWT/eHPAZwvdbm6Z1+bterwwHGTEQcI1zi3BvF63ewZ1yIExq5QAlJ0s5lhAQAkIgpRKAYIKSY2f7bjQxIJq2L5vOv7O1BBOUY5749hI9+OMRZf8gC//Ow/e68jcNv+nQlGDt/KmEHKiAiGV0YG0YZc2SyXD5TpPC2ZWs5G7tPnSaS4Eh0uO3UcfWDci+dzvKkCF9AmRwdtfvED+vC+WX6t9PKZWzzEsICIE3S+CdEExQ1nLmwg9UtmRhXjA+ePiI35LjjeOogZ2oddO61N/Rj9/iwpaPN7c//3qXS2mUgS/2Gz/fpuggF4tFE/z43r7veLw3oTge3m6iI0/AxKGcmzBsfDChVeeDh38aRBNsh6BD9Zc8avdDolZT7ExXi/M69OaAa+w8yJPn1qppHXbCBEeu5HBD/OBXRBO8ycUiAFb4MUO7xlvQbd51lMuZsNDDwB+zR4+f0uJZ7pQ1S2Yuldl98DStjPKiQ8fP0+WrP8XLLEEZxIFjZ9mePz84boG/95sz5OY7l90LlpasqN+wW+tuUdo4WyKEgSVEnOJFCsT7lOJ+YmFsSYehVZv2M3Pjzjh4Jo27J2l9FWBhd/OXuwY2oyaGUf1alah7hya8+fdXfqQhLtMTWGGR64C378jIwY8EBFl6O/enDgMnsqiAEFdLh175Ct7+j/eJYrERi1cIFhgQTSIXbqBRgzrT/iPfsoBg36ctz8HXbUg8EcxSDnrPNToPOXqGcZkQ3hyZcpqo3S143sFIvT2yKJau2U0rIicZ7i0+p/iBVaFsMVo8y0PzucYc0No2V45sBLGqVrUKNGXcAO6qNNA5kHJmz8rfMch2QV6R1mdLfS8GjQ2ku/cessikvK3Dj8jw2HW0cYFvvO8I/Hh89Pgvkx1mjO+z8TNl6XOg3k7vuVa2efr3M2rW3Znvi+PgLgZXx+SQhZxHhPbpWkPL1YHtIJqMdJ/J5XkIeMWz1aFFwsBibIug4r//fkbPnj+nmOXb6PW//xrcLfh3MIOrbWjfdtwivHrlcpqZJSiXxDONrBX1wPNt16W5RZ//xLCVfYSAEBACqYWAIpjsWhFE3YZO5rwqJZzc2GESHLmKKlUoSSWKFuTf5QHhy7gJgCJ+qAUTOJAbdhpt+I0KHniJiED6sKmj+GUf/qZP9I+miU52VK1SWbr5613y8I/m72e4yI0HhJbDJy+wgI5uazlzZOPfI2jWIEMICAEhoCaQ5gWTg8fO8gI8X+6c/BbR32Oo4Qcv3iyi5AXCRP68Oal+7SoJAiwVWFqtIk09SqbeVGIeG3YcZrEGi0YstKGq4w0y6vkVp4nW8S1xUSj7mZoD7O3o2rF8tqfhNAeOnqVxU2bTrhXBlCtnNu6OYkpIQPgpSmgUYQOLQAhPNauWNyzsTB0Diz7kGriO6Bnvjxn+6LlNizIrmiBMF38M7z14SDWrVmAbPN5MaDFSuwD02jhbcj/7d2vFnTomBy+gKp+U4dIaLGiDJjlQxfIlTX67qOeAtx/IQoCbZumaXXT52k0Kmzra5P5aLh+UCf3+8DG3K0YALgfpjgvi4yAL4oOsmQmCYYcBHixkGbfMtrbFsvJMjXfoSSWLFTTMFyJK675u7FLK9kFW8g6Kpe7tG9OIAR15G7g3lq/fTTUql6dh/dobgkmxHzJd8PzjBxMCVpFrkSXz+7osTD3XKLP4tFI5diOZKs/RKgUy3h7PLjIq4DwYN7w7f07RGQpCDEQmvR9Vw1yDqWXjOvRVy/rc5QplNEtmeXB+EMSkVRv3szsH/64lsm3dc5wOHj/LNmT8H7I5EPDaolFtFrYgPML9EhngTJ98FP+ZAxuHCSGUjtJZJJqYKgWytNRH02Hz8hUtWLmNhedeHZtRhbLFCcG1noHz+ZmoXKE0lykdOXmBls32jFfnrr7xeq4ObINjb9p1VFfgwDbIOWrT141bQ7dqXIfLtZ6/eMFlOXC0zV+2Je7ZnDPJ5DOHY81ZtIGFZdxLJe8Gjh6IYGiNnOn99+TXhRAQAkLgnSagCCa7VwZzN0G8wNmwwJdfQJoryYGLJGz+Gjq4LowZqgUT/Hf8LcULCcUBsnLDXnYu7l4Zwi8OkEWC3DS8HFLGkjW7CL/50B1Sa0hJzjv9uMrFCwGLCaRpwQRZEQgKjfBz4rp2fJEHRa6k/V/PNLzVhsK8fvs3XJYDm9+2pf+1sjWmaKloYq67gnJc/OCH6LB7VQg7DvB289Dxc+Q4qLMh2FTrTloimujNQXGtYCGHRf/WJQHxFm3dhnrTMLu4bAG9oRyj7yhf6tauEbVr/plhU4gu+IOHUEpLht61YEGLxYhWFx0cFzZ8OALCfZ3iHAsu06lQgbyGVqKm3C2m2jhrzVmLpVIWAEHCbWRvrtU1NYwXlRA60PkIpVnFChegudPHsitHb5hb2Dp5hbPgAAcU3qDj7fsvt+/zc3T8zEXq1amZZrglzmepaKL3TOFeLF23mzutKNkNivjQpU1Dg2iid22KAyVbtqwUFTg2nrPLeB/1HCqUKU45sn9gKHnDZ7nal4O5lA6CH4aWaKKXm4LvB3QDevzkbw6lgyiCcpAR7jPZ/VOqWCHuloMfXsatsJV5ooSmbtvhdGJrJJ27eI0mBsZQ+LTRLFThs/FF3SomnQh7Dp0hv1lLWBzBfBBwinngOvA27vv//UgflS7KgqRWVyh8NmNXbmMHHcS82f5jdMtz9J4pPSFS6/7plbghZBqldOC0dc8xmj5pODX+rBodOXWBZi/YwF2DEOoMt4lyr7SOnxRXB94cXrh8g91ySkgsXD6eAfMJtu2MGTLw58O4rEnvOcWzB0EYbyDBH2KfT+hiLu2EqCZDCAgBIfCuE1ALJmCB3CeEfSPLz1gwgViBjC/8rYBbBL8h/v33NZ3aPpcxGgsmp85e4cYIu1YGU6ECebhzGkpoHAd35rKcqs0G8QtQ4wFn4/412sGxIpi860+sXL8QsIxAmhZMnL0jOBtDecuNL1QEKGJRhjee6oG3yT/eukOVypcySc6caKK3qMTiCUp4gby5yXFIZw5whPruHbyArYC///mY1XEIDVodIownZUo0MSXYoA3m6MGdeQGHcFDYy5UgVfyhwRt1lNggMFRrwJWzbO1u8nMfwgs6CE1wqSjdd1DGgFKdudPHae4Pa/6O/Sc4K6BRvaq8nyUCkPHB0IUF5RFwEqCkZ9eBUyyevHj5ktKnS8dOC1PuFlNtnNXn0mMJwaPTQE+6ffd3ch8dP4DSeK56i0q4jOAwgmCCNyZ6jgX1wjZ/nlwUuWgD9enSnP76629ymRpJ0cHjKWOG9KQWTSDkoIsM8jxQYmDsRDCeoznRxNQzhXwKWFrRnUTdPUgRK3p0aMrlDnoDJUZoGY3SDFMBseo5gFmfkT5cJ60W7Fr0dOFA0EaffWo4HbIr8LxE+jvzAhmiyIDureKVAsFlMGPuKi4Nw71VB8fCpYA3VA9+f8Rvr9TOGuUk+F649MNP7DqCRRhdU3BORSxB2VZbOzdaHzPNUM+txQMiJLrh4Dgo5xkwxt+qAFs4MvAZcx3ZkyZNj9F1muiJJeaESPWc9Z5rfC5b9R5Pmxb6scMJIpCbbxQFeg5j0cSakRRXR8yKrSwy4bvKOFcE9wN/Dywpg1PPFw4hfOehnDNn9mz83al+1qy5NtlWCAgBIZDWCBgLJvi72NXemzvqwVGsdMlBKSVeGOJvKhyZyDmBIIK/w3qCCVi16u1KHVvV55cKrfu48ktOlEnjZUWVpgPJ392ej2npEMHEUlKynRB4twmkScFEyViAap07Vw5WopXRe4QPvx1E2YglA2UmKJk4efYylSjyIfXr1pLy5Moeb3GqlK3oLSqRe9FliBe7MS79cJOuXP+ZFs5043p+qOW/3fudnjz9hxf/WnWWWnNAyKeW0GDO3YISJPxhQUeQK9d+pkHOgVStcjlqWr86543A1qjUj2rxwbVgMbR1SSD/gUMGAcQKdBRKlz4dLVi5netJseAzHtjXbrQfZ8lQunRsx5/o1JczPawVTZCd8vvDR1S86IcGsQRlHGjBij/QXmP7m7y95to4456aY4ljXP/pNgdQqrt23Lp9j4oUzMdOAlMhs1hY4v8mBcYQ9lGLJvjvRQvlZ2eBOhBUcabAnYTFG9oFK+4Wc2KeMZDLV29yWC86MuFtu55oYo4Djqu3L+YPp0u9mhXN3o+NO4/EC4jFDrhOiCPGc8APLSxUIdKoB54/OCwWzHRjdwP4fjVgIoX7OpoMSx7uNoNaN6ljEF+s7bYzZcYiunrjFpfTofMVnGwQDeGiwByQk1G6RCFyGd5DkwO6Cu0/+h232kXttzJMzQNM1KVLKPPqN9qXHWsoD9ErzzHlVrJEiMTc9IJu8TmGC+b99zLSjMkjDdcBV4+rT6RZ0QQZPJhD5kzvcbhq6RKFk+TqsPZ7xZK/CbKNEBACQkAIaBMwFkywlcvUOXTn7kO6ffeBQTCBo3rbnmO0aZGf4UA79p8kD/95JgUTvPCAKxwv++DQjZ3hZtgf2YBlShbmcHH1MM4DVP8bcrJQsrx39QxDeL7cWyEgBISAMYE0J5jAQo/ARbgeIEgYD5Rx4O3vpxXLsmU+ZO5qiglx1exkg33hyMCbb3SA2XfkW14YouwBdnj1G30ssLFtz45N4wUG3v7tAeeVYPGsvGXHW8/t+0/EiSb5cnNK+If5clPZUkU0n1C9OcA1YLwg0JqD+qB4m9/V3ov2rAphFwZEjEWrd9JPv9yhGlXKU+9OzQz5EnofF9SRFv4wH40cGJdPgbet+EOHNnKoHS1fppjmrsgbKVo4Pw2368D/Dsv8KI9QmhPgzOUDuBYINgN7xLVzNh6KCwAiwScflaDOgydx+UbszAm8cMS14H9TWuoa748/mnDAQGhAuCeuX6+NM0QcOJQgYMHyqQyIDBGx6+jvZ8+pZ4em1LRBdUPXjpEDOnLKO+7BrGmjCR1rMNRlRRA8opduYfcHwtBGDuzEb+FRngNxIMBjKGc9XL/5K4ta6KRk3D0F3Tja9HFldw6yF9TOFEU0gbtmYegETY6Yg9u0uZyNgecSHZhCp4yiQh/mTSB86IklWhzMuVTUk9HigOtQuuoEeQ2nf569IP9ZS2nLkgAaN3m24bMF5wUyPb5ZP4vnj8/87oOn2C2AXJCw+WsJIaTNG9Zkqy9aviJc1dSAoAEnjlqwxPOJTJSxw7rpPpMQZ3+89RsNdw2hdbE+lCNbVnYuIFMGIc3I6kBYdN3qFWmq60DNzxa+V6aFLuF8ktWb91OH5p9z5oYyIHC4+0VzaaFyr3Ff2tm5kYdTX4NrA99neIOHPA1lYDt0DMqXOweX50Ag03qmlO0tESLxOTV+rvHfAyKWcwkMSobwg9Z3wpB4pWpKKZRaSFHfk7v3ISxP4s43mOeaLQc4vA/30RJXhzXCssmHQf5RCAgBISAEEkVASzDBC6C2fd3o5avX5D22P5e84ncOsurQKQ4Okcs/3KRFX+/g0HJTDhP8nWjaLa7U1Mu5fzw3CX6H4ncbxPbWTetQhgwZuCQZv1eCJsUXUZSLgyOzwVejONC7fYvPCeGy+C0gQwgIASGgJpCmBBMsnAaPDWQHCRa8WqPH8Cn8hY2FzkiPUP5Rr9eNBeUneCsKa7nSrSY8Zh1t2HmYti7258PjbejAHq04BBD18VgwqQccGHA9oNRGXQaE9qTb9sWJJko5i9Z8zc0B9fTL1++hhnXjyluM54DrxOL8i3pVDYu10Z5hVPvTj6lP5y8t+jR89/1VXoziTT8GnClYSCLUy1SbX+ODQ8yAE0Pt7sHbAnRXiQwYa3Iu+CMcs3wrTXYZwHk0WCij9AdlB2gTii412AaOA+O2n8qBUYZz9vurlCnT+/xHcX6wCzPTauMMVwBaPVeu8F+JFv7ojp4YRq4jerGbBi3zEFYKuz/speN9IvlYyDTp3OYLzecBC1rU83Zt25BLieAoQMhpunREgRHLuZ4XrUsRBgsnE8pBEE6pHpjbmXP/o5Ub9yVwpmDRSP/+S5ev/Rxv7ur98cxCLIGIgNIE3Bf85wZ1qvBmED4QpoaFLSyyEDeMRSM9DpaKJnockOWD+wjBAdc9w3sEO2DUzzXa9ULw2bY0gMu7IDbUqf4xnb90g9vuoqzm3KVrdPDYOf4hBnFMq7W3mgmCVn1CF9GKOV6GLkj4rIN1z6+a6H5GEVyM56pNs7qGTgDKcfE5gWDzUeliuoHAP9y4RaHz1tCQPm25DA6i2YAxAdzNCGHIpoaxawNi2RcdR3MbZMWSDJGw02BPavJ5dRpu156/p7SeKeU8OL85IVLrew7XCtEJncYgACJse+zk2TTNbQgLHuYGhGU8zxAxFdcQgqkd3GdyZoyeCKs+rjXCsrn5yL8LASEgBISA9QS0BBMcxTdsKS1du4s7okEwwYsFODHXbT3EXeM+q1mRKlUoRVGLN5oUTHCsYa4h7C45sDY0QUYXOi1C+MfvNfy9K1uyCIshpsp04PCcMW81/x6C0xTrAhlCQAgIATWBNCOYWCKW4MLb9/fghQNCCU2JJdgWIY2ooVena+NLHjWUePsPu725YapMAuGotapWMFmukNQ5IF/CKyiW/nn2nLtVdG3XiK79+Csv9rcs9jfbChPlO9gfGQ4QltCerdanFbgzDEQpS9rRwhGBEhUsLLGAQ6aAMrAgR47H2vlTTaJs3AXZM+P47bV6oPwGb/Jfvf6X24rqZa8gywPOo3Xzp7LIEzRnJe08eCqeYGXKtolzYgEIpxFKYNS5KRkzZjC0CTZ1DJRMOHtF0LqYqfTwzyec+zG8X1zALn4wQCwwtT/EGLgRED4K0UldnhMd7MKL+5Huoew6MW5brGaGMrCxw7rzPVHPAUG2WJiaa7FsjgNEk5cvX+kKkUnlALELb4SQRQTXEspvIHzBVYPQ4qF92+u2mDX1kKFcbeve4+yAAstFq3dYlCmU2LIP3OuOgzzp/oM/6PDGcMNnEZ8XZKiYE03wXeQ3axmt2riXZkwZyU4TCEhogQ4XHSzL+OEI51Wwl4PmpSPgFaIjytvQXh3PxZ5Dp60SIvH28KsBHlSvRkV2dykDrcSdvcMtEk0UYRl5TghxVgbuSeZMmdjlY2pYKyyb+96WfxcCQkAICAEhIASEgBAQAiCQJgQTLDZRooAsDpQ0YJz49jLFrNhCz5+/pKF27bnkAwMLLWwPe56eswSuhy5tGxEWws26OZPfBHsuvVAGXCoov9Db3/jRsjZbAvsn5xywsPrmxAVW99G2uF3zz2nf4TPk4zrYItEH88FiHU4ZvAVGKG250kXp5q3fuCWo3sA+CKHEAhB5DljEdx3qzUILumPACQFXRslihTjlXG8oYV54m6AOaUSqOt4m6LmJlOOxe2DmIhrUqw1nrSjDUpePsj2EhtGDOtP/rv8cLzcFJVYIEzUnoEG8QvAv6mvVQgWS4cd4hVPMDFddBnDhOHvPpiqflKajpy5yO2dcC0QTZKAoXT/GDO1KXds20jwO3uLDgQF3B1wP2EcRbPCMIN+nX7cWHKZmarwNDnBFQMhR2vCi/AMtCBG6iTIyZaDdLkqu4DJLzIBj5OstB/hZHTGgk65Lx/jYiRVN0MGlv6M/PzvI81GuD58ZlL6hVEqriwzuF6zHeHaaNqhBM+etNuSDQLDC2zx0mYIbC+2ltYKklbIehGIjBBoCLsQolHKhDMgSIVLhoOcsgmiyduuBeHkmWvdF7zsSbigE0UKgNjWSKiwn5lmRfYSAEBACQkAICAEhIATSPoE0IZjgNuHtOGx644Z147pFdMZAycm9B3/Sqk37aPVcb84dQU92dLkwJXYgVwNlAPZ92hEW256B83lB36xBDc4egYUQjghrylGsFU1sMQdwwkJo6drdnDHgbN+VundoYtVTDrFp54GTHIR77/c/afMiPw6YNB4QOXoMn8zMkOGhLARRggAR5c7d37mspX6tytzWU4slykaQudKwXlUaOCaAM17cR/cxnAplI1iQIdDT1DDFHqLJH4+eJCinUI6HVr3jpswmf/ehzGzTriOcN4OOPMhNQQkDuhutmuvNIa1aY8Gq7dy5pH+3ltSsuzNn60AwUlo34+06cnJgVdUaeIMPMWPG5BHcxQmCBcqF8Hwq5QsIy8yeLQsvfI0H7llgxDLasucY1/xCNEGHmUE92xg6JMFJhRKWJbM8DOVn6uP88ecTOnDsLLVv/hnNXbI5URzwGV2wchv5uQ+l5j3HWsQB147yG9hv4YiBgwEuGDimwAEdkeb4O1POHB+wxdfeJZjtvubaPFv10Fu4cXKLJqZOi1ptuEfgfkO5oFaoKp57ve8oiBAIx4UTSAlIxnMyyDmAqn5S1qyjQ2tulpZj6V2X8ecU9uh+jr7sjqle+SPN3dBpDIISHEbJIW5beKtlMyEgBISAEBACQkAICIF3hIiZGTAAACAASURBVECaEUxwvxTRJGf2rLQozN2QO4BSEHQB8R5nunOKcs9xHCzqEZ6IxciRUxcoLHoNt2hFMCredqJLjbUDCwLXaVGcsVGjivYCwNZzUI6PkgMtocOaazJ1DLRqc/WJ4rIf9cCiFuIJxJDMmTPF62Ck3g65LJGLNnLdKVwdWOAh6BMCTM+vmnJ9Kt6IIyFdr80rsi6QbQKLvynRBC4NPB9awztoAaXPkJ48nfpymUa/0X6UKdN7XLbx+K+/uQUeWtR2a99Yc3+4OtBSb9Esdw6oRdAZBDi81UcgKMQndAuCU8c4q0Q5IEpD/vr7Hz6nm+9cKvxhXm7Dh5azOLdxpxjjiSAb5dade+yUQr4EBkqsvKbH0sflSnApCxbWs/2cNIOSUbYBNwNcNA79vuLuSNZywDnb9HXjtsNtmta1iAMcRN3svZktXESz5q+hMxd+oA2x0/ga4DqBWwZlWejydOnqTRZV9MpPrHm2E7utueBivePqOU30tsdnA6U2aucFRBOE4wZ7O5hs3wsXCbJV4HKCUwnCmzJQIjc5eEG8zgXWsEgu0eT6T79S+vTpDc+L8RxQzuQREE3fX75BvTt/yTXqySVuW3O9sq0QEAJCQAgIASEgBIRA2iaQpgQT3CqIHRA50AVHGVjEYIGg150B26FFbO6c2Q37wDWAEg5LAguT6xFJCXNIrmuBWIEQRrRqUwduoktNxgwZOcFcb8At4egZRisiveKVEsAdM332CkIILdxCWCyidazx+O3eQ84ryZUjG6GjSq1qFWjKuAEs1Bh3NtKbA5LYETx67adfaGWklyFYDOUeodFruANOntw5aHDPNvHKtdTH4xarV37ksF8sTJUBAW72gg109/5DLsWA20Sr7ELtbkEALFpbIyAUGSVgipBNOC+WRkzUdbfgnLVaDaVtSwMTlGWA0/FvL1KeXDk4f0IJNlZfA5wcaCONMiJ1WK81HLCIhjvn3v0/uHWypRyQXwFRyt/dnndBgHH9r0bRqijveCIZutl8f+UGc/6iblXNWwpOKE+xZOD+wkmj9WxZsn9it4Fo4uEXTdMnDefAX1MDJShTZyyk9bHTDJkzKM/pPNiT3XF633UQl5A/tCZ6Kv106w6N8ggjr7H9DFlECGudvWA9f/YSO9ShwYk5hiVuPHRTgrskzGd0vLye5BK3EzNv2UcICAEhIASEgBAQAkIg7RFIc4KJ1uIZzoSJjn2p0Wefat5BdJFBxxy4FxBqWuWTMvy2EqU8CJR8EyMlzCE5rxNvgNvaTaAvv6jBAZQYcHL0GeHDQhQCLfXG7IUb6MmTp/Faq2JbY0FJb/9hrsHswECLWSzekAWBUhPY9pXFGBbD44Z1152Dsh2ENnRJMheEqnUgnNvBbQY7ZPp3b2k1XrW7BWIPWqui3So6DaFUaci46bRxoa9JpxAcPTVa2NPX0VPY4aIMOHail2+lSWayIeA4gHCE7ifqgcV5juxZzYYGYx/FPVGmZGEKn+Zo0T7YDxka5csUj9dhpsewyeTi0NOsQ8sYdt22DnRoXZjZMroZc1fzvVa3grb6xhER3DHI8ClTonBidje7D0reUK6C8kOUakEcRHgyXEp43rQGBCfk4DT+vBp3ccJQO0IQJowsHbQ0xnfh2xxq0SQmZDxlzRLnjFIG3FVoAY2gW/Ww9DvibV6bnFsICAEhIASEgBAQAkIg9RBIs4IJFiwIKUV+xJBebc0uWFE6gTIQBD6WKFqQgySDI1fSvOkunJ3xJkZKmENyXic6FyEToVKF0lS/diXavu8klSj6Ifm4DjJ5GtyHrXuO0eJZHvG2GzUxjMtP9DrhYGMsJOu2HU4ntkbSuYvXaGJgDIVPG83ZHngr/0XdKpzbACEBLedMDUvedJvjlZgSBT13C0Jjh7uFUPsW9enAke84zLhbu4QBr7g2tPa7cfMOOQ/tSp6BMZy1gq4ymTO9z1NGaOqrV6/iZcJoXQuCQ3sMn0p7VofEa5mNN/zgqA7RNcXC2pITvWPZjfbl3BVkWiDjApkoTkO6mm0bDPFujv8YQ2tsreMnl1iCY0PsCYlaTbEzXdkNZenAZ8a4E5TeviilmuA3j46eukC5cmanrJkzsdtIq7QLWTAoo0JJFkQ29Yh7RkP5GGi5bi682Ny1IEwW5UJo6ZzYAQ6lihXk72SUMBq7n1Aihu9pdVg0Mlg69Hdn9wzyhWQIASEgBISAEBACQkAICIGkEkizggkWuyFzV/ObUnN5IWqIyKnYsvsoB6MiJwNva4f2/a/GP6nALdk/JczBknlasg3esiODA10/EN7avvnnmrs9evKUECyKRRb+czu7CewQweIY7orj314iD795tGmRv9nFUMNOjuxqQYcNRSzB4rqtnRutj5nGGRyWjrchmphyt8DxgdbCKI8xfruOa4JYglwPLFgH9GjFobp4ngaPDaR/nr2gjq0b0JWrN+nKtZ+5G4qWcwZi48UrP7JQiIBaOHZevnrNHVuw4MaxezpM5f9esXxJS1EanCbGHWGUAyAjqEihfLp5Mtiuz8hp7LAp9GFeDgJGyRxyUbQGBAXl+lCihbwXtMTWGskplijHtzYEFnPIkf0Di0Uo5TwQte4/fETVKpY1KQJiPvhMLJ7lnkDESYywp8URYsnYyRHUv1srql1Nm7W5BwZZLJt2HubSJHW2EL4Dtu89Tq4je3FuzUDnQApR5bXAmYb/fZbPaHOnkH8XAkJACAgBISAEhIAQEAIWEUizgolFV29mI2RlfFKuhFknQnKcS+8YKWEOtrw+HHvVpv2EbjUQCiCqBEwcRgh9RDkL3pZjEY0FPnIZKlcolWA6KP+Zu3QTrd/2DbcvRqvhoMiV/J+xOIdggLyP0iUKkcvwHlZfjiJgYAEOkSExQ1mQhk0dRfVqVjR7iMQKNVhszl28kZbNjss5UQbKMVZs2EvffX+NypUuQgN7tNYs5UE77okB0Zzfcf7ydQ6a7dCyPjsQkAeDbKBzl66xkGiunbPWRSpOk3Zf1uPgW/XAPcKcAz2H6YomnQZ5cnbN5OCFJsWS85dv0MAx/iwgwYkAMQ4tmevVrERFC+XjzJdCBfJyiY4txBJrRRNbzkHN2JSIozyjUYHOhq40uF9TQhbSye+usDts9KBOujkxiljSt0tzypI5kyFHCrlS3kGx3I2qVZO63PJZzwGiiCWBE4fFK5/CsxuzfCs/d2ijjP0RXIzjVvm4DD1/8ZI7Tc32G6OZB2T2AycbCAEhIASEgBAQAkJACAgBDQKpTjCBUwCdT5Q2tabuqjX2dnk63g6BDTsOExZx84Jc6M7dB+wggHNixpSRLKDATYHFfpP61Sln9g80J4mMErgi4DzAQhiLZORuoCwCnWhu/Hyb6lavSFNdB5p0L5gigLlcvvazpmBjKTl0DvqoVFGLBbjEiCbhMeu4o47riJ7xpoXyJISBmvrcoPVx+/7uFOnvzO4StOb+9vwPFDV9HGXMkJ6+OXGBfr1zj+rWqMiL58QOLMJfv3pt6GKlHGekeygdPf09i2Z6oknjLk6c29GpVQNdZ4lyPAhpONcvt+/T6s376M7dh+wugpMFC+xI/zF07afbdPnqT0nOLDHFwpzTREsswTOPEhOlq5Gp4yMMGZk2xq3S4baYMmMR/Xbvd74+dJfCMDUfCJNlSxbhEhicv/MgTxbGWjWtQ/sOf8tlipOc+yVwiiliCXJF8uXOyQ4khMmidXbzHi7cphjPDAJ10aUH2VDG7iY9sQR5O3CTrIzy4u8AlKwh3LVO9U+4rfSh4+e4rTSyWfS6XSX2WZX9hIAQEAJCQAgIASEgBN5tAqlCMEGbSwSx1qn2MXd4CJrkYLYUQM/W/W7f7rdz9VjQrdlykN8sqwc6sDTrNpZb7ubNlYP6jprGJThzl2yifHlysWjyXkbtdr/KcbD4Ra7FrhVBCYQILP4Q2vpR6WJmn5e3Q8b8Wa11t2zbe5wXpWvnT6WsWTIZToCw1LHDuuuWpGBDZKSgZCMywJndKLsOnKJwXyd+m4+uQHqhyeavwvwWWNxHxK7n1t9od4vFtZZoMnbybA5S1SvDgUh65vz/uOuPWtRBdya4a8yF3Jqfqfkt0Dp65ca93HULbZghPumJFHrOErRCh1BhrpwQn61J02PJ38OeCubPY5gcujOhDAkiYrp0xGGv+PwpLagxn90HT7MIoQyl5bfy34+e+p7CYtbS8tmehm2QAzRuymzatSLY4ORQiyV1q3/C2ypulVZNalOG9OnJa2xcS3eIMAgrRjtrtainJ5Zgn50HTjFPCHnINJkVs45dQhDP0bY8MYHM5u+ibCEEhIAQEAJCQAgIASEgBIhShWACSzfCLvG21W1kb2rRqJbJe2fqx7fc9KQTgJtj3dZDlD9fLmrdpI5J14Legk6ZBQQPLGxdfaLok/IlqV/XFoRMhvb9Pah7hyZmF7hY5KNkYNMiv3gXhryDHNmy8sIstQ9z7hZ0WEKL4C8b1qQPsmRmAQnhrgETh1Le3DkoavEmwjbIrtBymOD4ECyyZctK9i5B1L9bS3YTKGIJ9g2MWJ4gLDS5uSoLdnTgGegcEE80gVsErgeE+qpLjdRzQO5Q9LLNfM9RQhLu68giKwayX9AuN2aGa3JPO97xEDS9bvs35DK8O6EsKCx6Da2JnsJtkI1FE1NlOHBNfVazErX9sp7ufPU+WxAi2/VzZ7GkYd2qNMJ9Jp9/064jnOOiiCbqjBecxMM/mgOVu7VvbBA9IFZvXRIQ77npNtSbhtl1YPcIzoUAVjhLFLFEmbDSJQotte37/JcDBS5jvSNo54og3hQuso07DpNxGQ4ySVASWbViGeoy2IvuPnjI4ucUl4EsgEIEhNvlk48sz9Gx6c2XgwsBISAEhIAQEAJCQAikOQKpQjBBO9pOAz3p9t3fyX10b5PZCSKWJP8zCtcCRCsPxz5cytBl8CTKkzsH3fr1HlUoV5xmeI/QLDMxJ5YoM8Vb5xothtCRjRH8tjh2xTbOO+jRoQmHe5oasPc36TqGO++oWxXDiQBXEgSYtDBQomHc1Qefiwm+c+nqjV8oc+ZMnNOBUgc4SzwCotkVAuGkWqVy7ECA40FroGzj6o1btGDmBF5cw6GBRTLEFnzm+o325W46tnSYGM9LLZrAdQSHhFYZh7Lf7kOnKWjOSloS7sGL+P6OfvTn46cG0QRlHU5e4bQqytumj0Ojzk7cghmsIXoULJCHnR14xuGWgkMCIgZaXEPs0wuhjVy0kQUivfbG5j5bm3cdZbEFogOuHZ+PM+d/YBcX2mkjENh4HDp+nvNtHj1+yp16MGeEL7dsXJudXxhKu3A8TxBX4C65+uMvuqVqWmGy+C6BEKN06/n2wg9UqXypeJklELfQ4azdl59xZg3KxW7/dp/KlIzrWAYHDT7jEErNudBsesPl4EJACAgBISAEhIAQEAJpmkCKF0zw9huOBiwerv90m50meHOqBE6iXWaRgvn4DaiIJbZ5VtUtYSFCHD9zkXwnDKHHT54SWv1mev897kyhXtCbW9CpZwpnQYueLtTos2oczIrF0spIL02xBCJB9NIt7Jj4uFxxGjmwEx05eYFQwjByQEf6vHZlbkmMXAO0WFXa6NqGzJs5Kp7rwyfO88JRPfxmLeXFMEqXDh47x+JJnlzZWfj4MH9u7mYDgQufD60BEebHW7/RcNcQWhfrw44cdChSAl5R+nL52k0a0b8jt9l+00MRTdASOcR7RIKMDvV8MOf+3Vuxu6SnwxQa79CTHv7xmCaHLGTRBKUtd+89TJCbkpzXBPdLnTbD6PCGcG7lrIglOAfKjKa5DaZ8eXLq3gs337n08M/HVBIhtY+ecGciPNPI5VFnmeh9toxLaiBu1GvnwGUr6HaEUqGte49R9/ZNdFsH4/u040BPzh9p26wehy0Pcg6kapXLUdP61bmMB9/FoVNH8XXgnBBNlPIvCBkLVm2jzJkyUc+vmrD7Qy2a4P44es7iTkB6ocH4/MMR1KnNFwSxNsLXycAM7rNNu47S+u3f0MwpIw3Bssl5H+VYQkAICAEhIASEgBAQAkJAIZCiBZPzl67zW0SEVQZNGs6iiFKeg4UEQv/w43vWtNGEH/patm651clDQBFNHj3+i6ICx/I9wcBiyWFCCL3/3n+iiTViiTI7LIQCZ6/gjjbohFG9cjnNiaNlLjpwdG3bkHM2zl26TutifOjkd5cobP5aFhC+qFuV3Eb2SrHZBmi1jDKEUsUKcXtgU0NPBISLovuwybR4lgfdufs7OXqGUcwMN85/OXb6e4NoYurYWIxCaGrTrC6XOSgDi+Bjpy/S3Qd/UO1PK5h1+STPE5bwKLiXQ1yCWCA1DjQ13hrCKjrezJz3NYcFuzjEdUNq3mMcZc2SmctisNC3xbhx8zaHriKsFhlLEGYQUqxk9oBzeOw62rjAV3cO+Bz97/rPHFD7y5177KCA0AAR6/bdB5T9g6ycA4JWvWO8IsjdsQ9ng0DUwoBzJSRqNYfaTh0/kLvcQFys13YECzVlShZm0SbEy4GdV8pAxk+RQvk5TDVmxVYOXP7t/kMa5RFmEE0gvC1avZN++uUO1ahSnsUzJVx12bo9hHyY6CAXFnvwTEKQ+fufZ/T15v000cmO24PHiSahlCtndpowshfz0RromIXWwRF+Y+jGzV9ZeMK9UwYyapat3U1D+rTVFQJtcY/lmEJACAgBISAEhIAQEALvJoEUK5j8cuc+DXDy54Vc3RpxQYLKgJAy3ieSsPBEpknnNl+Qlq373byltrtqtdNkolNfQ66BIpp0bt2QywCQRzJmaNd4IZTJMavrN2+Ts1cErYuZSg//fMILwOH94rIUlJKH5DiPLY+BcheUl6DF7dFTFwn5DnjbrjXMOaYUkaD3CB8u3UDJzA83bnGnIWTLKEGbpq7HXAcXW7Iwd2x0OSqQL7euWILPPAQGdEdRHBi9HKbSoJ5tqGmD6rRlzzHOYvF1G2xxZyJzczL+dwgVKJ/Bcw+hDyJP75E+1KJRbXZooAMPMmQQpGtN1gayfSAOrp7rzQIQSqOKFynAp4eza9fBUyyQxM505VyXERNmkO8Ee7p09SdCp6QZk+McOTv2n6CJATH04uVLGju0G6Hlr3pAMLt89SZ9VrMif4dCDIXApFVKo8VG3ckJeTFoA65kpEB0Q/AsnF5wluCYL1++Mil+wU0I8RVBwygxa93HlY5siuBTo/MVSndM5bpYe/9keyEgBISAEBACQkAICAEhYIpAihFMEARYIG8uLiXAwJtivPVErT3e3k6fs4J+uH6L21MqWRVKEKTcYtsRQFmEX/hS+vmXuxyYibfI/R392dKvFk2SS7DQy+rAQgtCWeTijTTdc3g8sQRzHOMVbvNAz6RShgsK4gYWs1j49Xfy5/wHBGIqi0zlHObEEmU78KrWfAgd3Tyb3QjeQQs4V6Zz6y/iZUKkVtFEb97ouhQydxV/R8ARExU4jgUFiBerN+2nL+pVpR37TvAzUaFs8aTeOs394QKBs2dFpFe8Uhs4rIIjV9H33KGpKDtNypUqmuAY+P5C62aUl5QuXoj83O0N33+4r/W/GkUntkbqzl0RuyB2oBStQ4vPeVs8O27TogxlTHCaoI2zcQYOtlXyoTDnbUsD47mJrBVNkJmzccE0Q84Ijj999go+B1xCiRk1W9rTwXWzKGz+Grr+068UPs3RZuJXYuYn+wgBISAEhIAQEAJCQAikbQIpRjBBFkb9WpW4MwoG3sru/eYM185jcdS9Q2PumoG3pwfWhqbtu5JCrg7OkW72XtTsi5osXGFBjqHnNEnqtNE1pGzJItSu+WfxDoWyLASQOg3pSs26O3Meg+PgLuwswUBOxevXr2nyuAFJnYJN91+0egf99fc/NNyuAyGvovCHeall4zo0YIx/vO4lloolymSRMYESiIIF8rKjAaGjcAlYM1Ki00RLPMM1QWjAc7AwdAIVLVSAgiNX0rZ9x7kMqVjh/LRx5xEOwoUToXyZYtZgsGpbBKo+efKUxo/oGW8/iIp6AbvqDeEgef7iBWfE+IYtobv3H8YrpWrYyZHbQ+PZ1xu4bxCXEYirDpBVRJOwqaMTOPTUx4KYgU4+EKUh6M0PGc8ilDIgmqzcsJdmTB5pko3aaYLyHKXVLxw4EDqReZSY0dZuApUqXoiePXsuYkliAMo+QkAICAEhIASEgBAQAkki8FYFE7wZRjtTWNXxw/33h4/Zdj3FZQBlyJCBZs5bTeiC0qfzl/yWGK1T+zn60fZlgUm6aNnZMgKrN++nb46fNwQ8qvdSRBNuXVqvquYBt+45TgePn6VmDWrw/5kaWi1WsQhDiYnL1EhaPRciQCYOrvQMnE8jBnSkyhVK084DJzn0ddlsTy4HSOkD13Ty7GUKnbeGls+ZxC1ynSaFczkEShcQ8IkcErR/RSaHJQMdRJat200QGHp2bGrRYl3ruFh8I+djYA/tEiFL5mK8DcSNyEUbqE+X5vTXX3/zvYwOHs8lF6YGHA8QwiIDxsbrgnLi28t09uJV5jXbb4zhECFRq2jz7qMsOCilK4mZrzX7QAxAwDByZNQD4i8cQ+giozcgQqD9MPb97sIPNHXGIs4WOX3uikE02XPoDJcWaQ0lDBshsnpiF4KPkXGCjjxaA2U/2B/lTPj+HTd5TpxoEjyecub4gCJi11H7Fp9TscJxpUDmhrFogu9utLhGhyW97whzx0RJD9xl4iwxR0r+XQgIASEgBISAEBACQsAWBN6qYILAQQgggZ7DOGxQ7y0lLhz5FeMmz+bFnNSw2+JR+O+YWDxhkRKzfCvdf/iIJhl1Z1m37RCHNiJ0UnmTbDwjLPb8Zi3hLAds3619Y0NrUuNttcQSbIPyEogLdl2aG5xH+N+PnLpAsxds4DfyKA2C2yRXzmy2hZLIo+PN/amzl6lejYqGcgc4AuAIgdiEfx8ybjq3WEW3obQ2lIU4Ot08/fsfdgm1aFTL5GXqhQYj0yQ4ahUv8pHjAeEFpSzKgGgCIcVYwEhOpggdnTpjIWdyoEMT2u4i1BRtdxFKffzbS+ThN482LfI3KQpd++lX+uef5xxc2m2oN80JcOZrQcjtL7fv8TXoddTRCsO2xiGE7CeEZSOs9vW//xJcKAiTxb1C/tCFyzeofNlidPPWXRb1zIlbar7KdziO/e+/xMIRMqYSOxA4C8eLVjlRYo8p+wkBISAEhIAQEAJCQAgIAUsJvFXBBJOEddzVJ9KkaBIQsZwX3e6je1P75nF1+jJsR0ApgYHYMcJ9JgdPKm+Z4WJoYzeBwqaO4kWj3ug7ypdchnfnt+Y//nyHy046tIhbWKqHnliCbRQXCxZzKLfBgjQ1DSyu8YYd7MAAnZ7wpv3kd5e5PXb7FvXpwJHvaKhde+rWrlGSLg3lU1hcJsVdceDoWSpbqkiydx9BgHObPq7sdMACXF3yYXzRemIJnruvBk7k8FTwDI1ew98JKEVByYYyEBpq6vhJgYwyn8HjpnN4asvGtdkBhLa7Dm4z2N1UpFA+/u8oX6lcoZRFp4pdsY1wzQjoheOu8+BJLMD06NBEUyQwFYZtiWgC0aqXgw/nnaDMbsi4IEIQ8Wz/MYTQVsxh866j3CkHc9ATRE1dHEQT12lRHDBbrZJ2tytL86eS47m26EbIRkJACAgBISAEhIAQEAJCQIPAWxdM0E52vE8U4f/PmDJS02mCeeOHfGoouUjNT5lWCYzPzMW055vT3I0I+RCzYtZRwfy5dTuwbNp5hPYf/Y7b/e5aEWTAgUUh3ERq0cSUWKLsaKu8lDdxn1Ca0fyLmpzJsmP/SZoYEG0QBk+dvcKthdFWGO6qpAwsKsdOjqD+3VqxU0AZj5485bBeBI+aK++xNjfFmvmiVfSZc/+jlRv3JcjJUIcF64klKBNB5x8IdHP8/yvDQckI2tAaiybWzM2abcdPjaSqFctQ705fxtsNJVG4lxB14LzSEmzg3pg2czEdPHaOmjaoQeOGdWNBZP7yrdzJJ3TqKFqyZhdd+uFHLkPSG+bCsFEm1LBuVd0yHIgqCBoO8BhKi7/eSYdPnuccnWmhSyjc15FFE1uPpWt3ccklBBlTQ++5tvX85PhCQAgIASEgBISAEBACQkAh8FYFE7SztHcJIg/HPvRexoz8VtK4POfJX39zuKMM2xPQK4HBQo4zMl685EUOyqKQvWE8sGjEwgvtVJF/0qH55/ECMbEgdveLpgg/Jw5p3bb3BPXq2NTshaU20QRukuNnLtKCVdtpy+IAAytjN5XehestrrW2VxaVdl1bUN3q/7XfPnfxGg1zC6EXL17Re+9lIJ/xg3gxrzVsJZag3Ai5IrlzZmOh7P33M3JOBspzooNdCELKSPdQdp3c/u0+TZoeS/4e9prtqPXcExBNvjl5gZbP9jT7HCV1A3Q1wvMPd4l6LFy9g8vGTDmgIIwgaweuC2S6IJQXrg58DkZ5hHHLXQhCyGUpkC+X7lQTG4YNMXTesi3Uo0NjbkMMJ86ICXHuMQjRzt4RdPDYWdqwwDfZHUbGF7PzwCkKj13HHXX0ht5zndR7KPsLASEgBISAEBACQkAICAFrCLxVwQSlHyjZ6Ne1Bc9Zqzzn8rWfLba3W3Phsm1CAkkpgUE4K4JMh/Rpy2GXWBQPGBPALaBdjbqIJIa9JSGziTlucu+Dso3eI304bPPS1ZsUOHGooQ228owjtHbr4gAO1tQaeovrzJniB6WaWlR2GeLF7YqbN6xJ2/Yep0nTY8jHdXCC/BBbiSWnz/2PJvjOpU6tv+BgZ7SEnRfswrkckwJjaPeh05QxQwYaM7QrdW3biL7efIDq16msKZYojPREE+SZvAn32ZxFG9gNsmSWh6FcBs64gc6BtHNFkMkMGpTaQCgsmD8P4b45TAihdJSORRPcV7hUEGpsbmDfxIRhI0gY7haEpyLvB93GOJPmRwAAGP5JREFU0LEJn02Es2J+M6eMtFkLZvV1QbBp1Xs8TRk/UNPRImKJuadA/l0ICAEhIASEgBAQAkLgTRF4q4LJ0PHB1LppXa6nV8aGHYfJa3qMoTznTYGQ88QRSIybA3kEHQd50v0Hf9DhjeGGN+3IW0AZTnKJJnAbJSZT4U3dW5RkeAUtoM9qVuQyHLTFhmtqmtsQFi6U8eejv3TFEmxjbnGNbdSLSpRRKO6Gu/f/4FBSlOOonVnoWIT2u3tWhxjmYSuxBCf4asBEmuY2mCqWL0krNuylnftPUoTfGEOA6PdXfqTs2bJQ8SIfWnV7LMnpsOqAJjb+5sR52rjjMJUqUYgG92rLQcj9Hf24vGmMfVcuwfEJXUwO/b+iNk3rJjgSnEKTgxfSgaPf8b/tWB5kuH4t0SQx8zYXho05rt12iNZtPUShPqMMgtT67d9QeMxaGje8ByFMt2SxQpwRZauBfBy0iFdak8O1duK7Sxw4qx4iltjqDshxhYAQEAJCQAgIASEgBBJD4K0KJjErthIyL2DJV96eo5QDHVbQSrh+7cqJuSbZx0ICD/98zO1MEUKKco2JTnbcwjUxoonePhBN3P3mUeiUUUnuZIPFX0rtlgHRCELHoyd/0e6VIYYynEPHz5Ozd3gC0cT4FlmzuMa+KKFAGU6Vj0uzw8HLuR+XdChdSm7/9oAWhbkbBCZkANVuPZy78RQqkIfgAFmyZicFThxmNt/EwsfJsBkcBHXaDKOT26JYLNmFEgxfJxYL4GxA2Cha2SZ2QDTZffA0rYzySuwhzO6HnI0la3ZT707NOCeleOECLOK+ePGCkCOy6+Apypk9G4cYN/rsU83jLVq9gyAUDOzZmlv0IrcjKtCZy3EwIA7A+THcrn2inmtLwrARBIwAZoxtSwMMwhqeBy7vOXyGalYpzwKQuZwbs9B0NsAcxk2ZQ+iKhkBblCXBafRlj3H09bwp/Dxi/PPsueG5VpeXJfa8sp8QEAJCQAgIASEgBISAEEgqgbcqmOAHMt7YYiExybkfv7F1mhROkYHOVK5U0aRem+xvggAcCL0cplLrJnWoYb1PyX58EFWrWI4XhWrRBK1v0dlFa+D+odSiSMH87JhIjNBi6U1S3jyPd+hJJYsVtHS3N7odciiQR+E1th/nuCgDoombbxRtXuRHuXNmT/Li+tXrfzm4U+nEAldW0/rV6cHDR1Si6Iea7bnhRMD9PrR+Ft9f8MyYIX2yLpKVnIyBPVpRN3tvLreDcKOIJSjNQVeWHcunJ0kwAUBbuo3QGtjddx4LMhCyBjgFcLlMoQJ5DZ8Pcw8WSozWbD1IId4jWBBAXssoj1DmrhZNzB3H1L+DgSVh2Lb8XFozf3SNghC1dc8xql3tY76H6KKjdM4CG/Vzbc2xZVshIASEgBAQAkJACAgBIWALAm9VMMEF4Udy4OzlbH1H11iX4T2ou5nuCbYA8a4dE/kxH+bLzaGseGOPkFC8Cc6XJ5dhUWhqUQpxwNUnirJkzkR37j5gt4PTkK5098FD6u/oT5/XqkQTnfrqBmHe//1Piliwnn5/+IjLslo0qqV7C1KyTR9ZLXOXbKYhvdtyS1890QQClVKOYHyhybG4Rk4JAndjZ7qy2Kg4TSCiDOjekoIiV9HIAR3jlb8l9zOvzsk4d+kaOUyYSVPHD+TAVyyEnSbNouF2HbhcKSUPONxevHzJ3WwgMg3t246zNlBeVvjDfGZFE7iNRnuGEToh7VkVYnD52EI0sZTjmxBNIIgU/jAvXy+6H/mGLqbt+05QiWIFyWlwF6pbIy6UGIGza7ccJHT0qfxxaQr2crD0MmQ7ISAEhIAQEAJCQAgIASHwRgm8dcFEuVr8wMYbb1OdJt4omTR+MuRXYBEImzwW2iiLevnyJbXsPZ6dJmhzmiFDek0KWPC0s5tAs6Y5csArgk5HeoSyEwWOFCzOPPyiafqk4ZQnV0JHBUo2eo2YSqWKFaLiRQvQ8nV72CEBl5Hx/U/JYsn5S9cJrYNRtoFSg/x547qb6IkmWjCTurj+9c59Sp8hPWdTGOd7KKLJ4RPnKWaGK1Wv/JFNnmq9nAx0Q+E8lcdP2VHi4tCDOrZqYJM52OKg67Yd4nbBSs7GwDEBfB0oXfswf26Tp1QLVtFBLvFEk+ilcQLbmy4vU4smnmPskh3ZBN95dOPn24TrRVetI6e+p/EOPbj8KzT6a+aGz4ky8D3w6vVrdjzJEAJCQAgIASEgBISAEBACKZFAihFMUiKctDYnLGy37DkWb9E63G0GtfvyM2rdtA47TOAK6N6+MXVp21D38vcf+Y4Wf72T5oeMN2yDVroIft0Q62MyyBNzwEJ6064jFBU4lvfHQq63gw8N7t2Gen71X5vhlCyWYN5t7SaQn7s9l8ZgrvuPfEvFihSgSuVLsWiCFrobFkyjvLlzJMviGuUXcP2oO8LA9eA+ug+VL1OMz6EnmsBpol64J+ezrZeTgXOgpOW3ew+pQL7cqW5hHDZ/Df1y+z4FTBzKLXeRXbJ2/lSL0emJJhYfwAYb4rO259Bp6t3py2Q/uvp6EZAb4etkEJYQoDvGK5y2LQ3k/BIZQkAICAEhIASEgBAQAkIgNRAQwSQ13KVkmCNcIdNnryC8NcfbbSU3YJhrMHfIGNyrDYez1qn+CQ3q2drkGdHhZIjLdNqxbHq8xbvdaF8OdERXHGX8/sdjwht1JVQSpSMIgES5jlocgYgSs3wLrYiMC/JM6WLJH38+YTcOSi5On7tCU2YsoqyZM9Gt2/codqYbO2/0SpogfOw/+h3d/OUuVa9UjssSLFlco3QH3UVQdqNkofQYPoWmuAykj0r/l/mjJ5pUqlCKS2JsMd5EyYct5m3qmCi3QklOrhzZiEvI/MZQ9crlrJqGJffVqgOqNkYmDITKVk3qJPYQyb6fcr3ffX+Vvx/UXa2GuYbwXNVd0ZJ9AnJAISAEhIAQEAJCQAgIASGQjAREMElGmCn1UE//fkZd7b3YSYJuOEPHB3GuBEQTlNOMcJ/JC320RvV1H0IZMyS0yD/9+x9uVYvSDwyEd2LMnDKSyxQgIHQY4EGLZ7nHc5hAFJi/fAu5jujJeScoudFqDYvyFg//aO7igoH8B7gTUnK3DCwAD588z+IFsmAQ9BocuYry5slB/bu11HwcUIKDLA+4MkoWL0T7Dn/LGS6eTnb06tUrcvIK5/BWLTcI9p3gO5eQFaGIJr1H+JD3uP4JQpLBGCVVA3vEiV8oeUufLp1umVVyPLtpUTTBc3324jXuQFQgX1zJlbUDIsL85VsJYbjJWYaDcNqR7qEJQoZNzQ9C5PZ9x21aGqUnEqGkqXuHxtSiUW1rEcr2QkAICAEhIASEgBAQAkLgrRAQweStYH+zJ121cR8dO3OJQrzjwhVv/vIbB1gqogn+Nyyk0PZVa+BtsYPbDA5rbNm4Nk1zG0zPX7ykke4zuWQBYY7Hz1ykXp2aGRboxsfxDlrAi3UlCFYtmqDLDo4FdwsCNlPLgIBx/eavVKLIh7wQ/vPRX9R31DTOblFKZIyvZf32b7iVdnSwC4tHEKoGOQfyW3eH/l+x08TU4tpYNHH0nEWf16rM3XHQmjtz5vfZEVGhbPG3gtHWORlv5aJS8EmtycuxlWvLnGNqjv8YWrlhH23efZTWRE+hTO+/l4KJytSEgBAQAkJACAgBISAEhMB/BEQweQeehshFG+nBwz/Jw7Gv4Wph5+8yxIsFitGDOpuk0L6fOzkO7kIo6UA5DUIaZ/uP4YUPsgl+uvUblyp88lHJBMdBZsk/z18QHCrG3XMgmixYtZ0X+CjjGTWwk00dELa61XCE7Nh/kuYv25Igh8X4nAERy7mMyaHff6Ux3174gexdguno5ghNd4/xMdSiSfr06bhzC7q6wEn07Plzvp/1a1e21eWaPa4tczLMntwGGxw4epbKlipCRQrms8HRk35IS0QTW4klljimDh0/R+2bf84d0NB+XIYQEAJCQAgIASEgBISAEEgtBEQwSS13KgnzRJcKhwkzaFWUNzsRMJBlcvjkBXaG+E4YQg3qVElwBmRwoPwjJGoVLQn34H/HwsthQgilo3QsmsDVYGqMnxpJg3q1YceFVsmGVnlOEi71rez6+MlTCopcyYvCGlVMd6LZsOMwlyStnjvZ4OhBt5CqzQbS4Y0Ruq2H4e7xmbmIRZHwaY6EfVCegxDfvatnmO3a8lbApNCTGpeXmZomuklt2nmYAicOo/fey5hCr8h0ZyZbiSWAYaljakCPVuIsSbFPj0xMCAgBISAEhIAQEAJCQI+ACCbvyLMxLXQxuyDGDe/OYod/xDKaGziO4G44f/k6BXgMjUcCZTj2LkH019N/uOsLMjOyZskcTzTJ9P77FBngbNgPwa17D58hX7chBOcDRo9hk2nK+EGGUFJTosnCUDcqU7JImrojEDb2fHOaMmbMQI3qfcptVO1G+VKWLJloumdc2+WFq3fQrgOnDKKUMQCIJAgfbdqgOpc8ITMGQyvTJE3Bs8HFaJWX6Yl+KVUsQR7N0jW76OTZy1wO1q9bSxbMtJwmthRLcHuSwzFlg9sshxQCQkAICAEhIASEgBAQAslCQASTZMGYOg6CLivL1+/hyaL8pdFnn9Kk6TGUJ1cOQ9cc5Uq62nvTsL7t6dNKZWnclNn08uVrigp0jieaXLl2kz6tWNZw8eiIM2CMP1UoU5zb7UI00QolVUSTCaN6U8N6VXl/zA2BtBAQ0tJw851L357/gf7+5xmXLCEkF/kvEwOi6eCxc5Q3Vw7KlTMbhfs6UaECcYG6xiN2xTbu0uLi0IMzTlZs2MvOn/7dW1LJogXJKyiW3S21q1VIS+hsci165WXGoklKFUsABbk1r1+/puYNa9G+I9+yUIKQYDxfimgSNnUU1atZkbft2bGpzcKTE+uYssnNlYMKASEgBISAEBACQkAICIFkJiCCSTIDTS2Hgzth9sL1tGX3MVoZ5UU5s8dlC9y9/wfBjfL7H49o8ay4Mpxnz1/QKI9QLsdRiyZa12osmiBcdphdew4hRahs5kyZWEjRa7mbWvhZMs/LV28SSpIQdPnPs+c0amIYd6pRSpkgHMHBU7p4IQ6A1RuBEcvpwR+PqEXDWhQ6fw2LVsUK5acr13+mDbHTLJnKO7+NNeVlKVksOX/5Brn6RNKmhX6GvJ/wmHW0Yedh2rrYn8uGLly5QR+VKspBxOhslSNbVpvdf3SystYxZbPJyIGFgBAQAkJACAgBISAEhEAyExDBJJmBppbDRcSuo6OnL9KMySMof97/2qUqLUHR/Qa5Jdk+yBJPNHn977/8NtvUUIsmt+8+oB+u3+LgVwTAYqCd8ZDebVMLKqvnCTFq54GTnBFTtmQRdoJgWJv/opz41zv3aaRHKIsrdl1bUM+vmrKI1bzHWDq0fpbV83vXdrCmvAx5P0vW7EyxmSUIoJ2zaAOtmDPJcBvRpaZVb1fyHGNHn9eq9MZvL0QZaxxTb3yCckIhIASEgBAQAkJACAgBIZBIAiKYJBJcat8N2RoYStaI+noU0QTdXyCOqEWTK1dvUpVPyiS4fARpohtPtcrlqPFn1UgRTa7e+IVObI3k3A2cE06LrFkypXZ8JuePMpyz31+jf549o5LFClKEr1OC/JdqlcqZ7U6kdxKIJSjDKZg/T4JSqjQNNpEXZ015GUStjBnSp7iA17lLNlGXto04C6dZN2fym2DPmTbK6DF8Co0c0PGtd0eyxDGVyNsouwkBISAEhIAQEAJCQAgIgTdOQASTN448dZxQTzTRmj06uPQd5UvVKpWl3p2+NAS8amWapI6rT/wsr/30K42ZFM5lOMgqcZw0i549e5Eg/yVD+nRcMmHtWLR6By1bt4dqVi1P3uP6W9SG2NpzpJXtk1pelpI4oCSu8selyb5PO9q65zh5Bs4nx8GdqVmDGrR9/wlat/UQrZ0/NcUJPSmJocxFCAgBISAEhIAQEAJCQAhYS0AEE2uJvUPbK6IJ8h8Whk7QvXK4HUoVL0T9u7UklAccOfU9l4w0+fw/pwnefn/5Rc00TQ8LWbT+Hdy7DXezwbAm/8USOD/cuEVw/tSt/oklm7/T2yRHeVlKAYhSIeTh7FwRxNklR05doLDoNfTTrd+oRpXyXI6DTjkyhIAQEAJCQAgIASEgBISAEEg+AiKYJB/LNHkkLDovX/uZKlcopXt9HQZ4kJdzP8qZIxtNDl5At27fo+fPX9LAnq1YOECZAwJf0/owVcoEh8DH5UrQGPuuaR1Dirq+xJSXpZQLePjnY8qd87+uUd2HTqZBvdpQ84ZpW3hMKfxlHkJACAgBISAEhIAQEAJCQAQTeQaSTGD+8q00c95qypgxI7tMHPp14PamaH+L/I53aZhaoKMPTmLKcN4lfkm91lUb99HcpZu5jTPa7jrbdyW0DHbyCmdnjjqTJ6nnsuX+35w4z0G/KLmx69Kcc4PgYFq1aR8tmOlmy1PLsYWAEBACQkAICAEhIASEgBD4fwIimMijkCwEUBqQK2c2bk+MLjGu06KoRpWPuKPLuzasyX9519jY8no37zpK0cu2kL+HPZ8mIGIZPXr8lBbPcqf3MmZk0cRceZkt52ftsW//9oCWr99DX285QCWKFqTenZpRcORKmjfdhcqWKmLt4WR7ISAEhIAQEAJCQAgIASEgBKwkIIKJlcBkc30CaBu8+9AZWvT1DipeuAAFTBxK6dLBV/HuDUU0QbbLuGHd3z0Ab+GK+4ycRsPs2hs6xbx4+Yr6O/pxQC5KoSwpL3sL0zZ7SuTgbNl9lJau3U2Xr97k7kpD+7Yzu59sIASEgBAQAkJACAgBISAEhEDSCIhgkjR+sreKAAJfw+avpeJFClDHVg3eeTZYoIOJlOG8mUcBnZq6tWtE7Zp/ZjjhgaNnKWz+Gu5alBbGd99fpU/KlZBnKi3cTLkGISAEhIAQEAJCQAgIgRRPQASTFH+LZIJCQAhYQmDdtkM0c97XtHy2JxUumI932bjzMKFUZ+70cZYcQrYRAkJACAgBISAEhIAQEAJCQAgYCIhgIg+DEBACqZLAyg17ad6yLfRR6aI0ybkfFcyfhyaHLKRdB07RoJ6tKV36dLRg5XYKmzqKQ1NlCAEhIASEgBAQAkJACAgBISAErCEggok1tGRbISAEUgSBcxevkfPk2eQ+ug8LJMe/vUgLZk7gcrBdB0/Rjv0nuTtO3y7NqXyZYilizjIJISAEhIAQEAJCQAgIASEgBFIXARFMUtf9ktkKASFARP7hy6hS+VLU9st6zCMkahVt3n3UIJoIJCEgBISAEBACQkAICAEhIASEQFIJiGCSVIKyvxAQAm+MADrFRC/bTI+fPKXYGW5U+ePShnOLaPLGboOcSAgIASEgBISAEBACQkAIvBMERDB5J26zXKQQSP0ELv7vRxrtOYsmjbGjXQdP08FjZ2nBTDdC62ZlzF++lVo1rm0IfU39Vy1XIASEgBAQAkJACAgBISAEhMDbIiCCydsiL+cVAkLAYgKHT16g9dsP0Rd1qhraBkfErqNVm/YnEE0sPqhsKASEgBAQAkJACAgBISAEhIAQMEFABBN5PISAEEjxBGJWbKXgyFUsjtT6tIJhviKapPhbJxMUAkJACAgBISAEhIAQEAKploAIJqn21snEhcC7RWDe0s20cNUOip3pSuVKFTVc/KLVO6hZgxpShvNuPQ5ytUJACAgBISAEhIAQEAJCwOYERDCxOWI5gRAQAslFQE80Sa7jy3GEgBAQAkJACAgBISAEhIAQEAIKARFM5FkQAkIgVREQ0SRV3S6ZrBAQAkJACAgBISAEhIAQSLUERDBJtbdOJi4E3l0Cy9fvoYZ1q0oZzrv7CMiVCwEhIASEgBAQAkJACAgBmxMQwcTmiOUEQkAICAEhIASEgBAQAkJACAgBISAEhEBqIyCCSWq7YzJfISAEhIAQEAJCQAgIASEgBISAEBACQsDmBEQwsTliOYEQEAJCQAgIASEgBISAEBACQkAICAEhkNoIiGCS2u6YzFcICAEhIASEgBAQAkJACAgBISAEhIAQsDkBEUxsjlhOIASEgBAQAkJACAgBISAEhIAQEAJCQAikNgIimKS2OybzFQJCQAgIASEgBISAEBACQkAICAEhIARsTkAEE5sjlhMIASEgBISAEBACQkAICAEhIASEgBAQAqmNgAgmqe2OyXyFgBAQAkJACAgBISAEhIAQEAJCQAgIAZsTEMHE5ojlBEJACAgBISAEhIAQEAJCQAgIASEgBIRAaiMggklqu2MyXyEgBISAEBACQkAICAEhIASEgBAQAkLA5gREMLE5YjmBEBACQkAICAEhIASEgBAQAkJACAgBIZDaCIhgktrumMxXCAgBISAEhIAQEAJCQAgIASEgBISAELA5ARFMbI5YTiAEhIAQEAJCQAgIASEgBISAEBACQkAIpDYCIpiktjsm8xUCQkAICAEhIASEgBAQAkJACAgBISAEbE5ABBObI5YTCAEhIASEgBAQAkJACAgBISAEhIAQEAKpjcD/AWwL9O0Mf22kAAAAAElFTkSuQmCC"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "top_n = min(25, len(eval_summary))\n",
+    "top = eval_summary.head(top_n)\n",
+    "\n",
+    "fig = make_subplots(\n",
+    "    rows=1,\n",
+    "    cols=2,\n",
+    "    subplot_titles=[\n",
+    "        f\"Top {top_n} Features by |IC| (green = FDR-sig)\",\n",
+    "        \"HAC vs Naive t-statistics\",\n",
+    "    ],\n",
+    "    horizontal_spacing=0.12,\n",
+    ")\n",
+    "\n",
+    "# Panel 1: IC bar chart\n",
+    "colors = [\"#2ecc71\" if s else \"#95a5a6\" for s in top[\"fdr_sig\"].to_list()]\n",
+    "fig.add_trace(\n",
+    "    go.Bar(\n",
+    "        x=top[\"feature\"].to_list(),\n",
+    "        y=top[\"ic_mean\"].to_list(),\n",
+    "        marker_color=colors,\n",
+    "        text=[f\"t={t:.1f}\" for t in top[\"hac_t\"].to_list()],\n",
+    "        textposition=\"outside\",\n",
+    "        showlegend=False,\n",
+    "    ),\n",
+    "    row=1,\n",
+    "    col=1,\n",
+    ")\n",
+    "\n",
+    "# Panel 2: HAC scatter\n",
+    "fig.add_trace(\n",
+    "    go.Scatter(\n",
+    "        x=eval_summary[\"naive_t\"].to_list(),\n",
+    "        y=eval_summary[\"hac_t\"].to_list(),\n",
+    "        mode=\"markers\",\n",
+    "        marker=dict(\n",
+    "            color=[\"#2ecc71\" if s else \"#e74c3c\" for s in eval_summary[\"fdr_sig\"].to_list()],\n",
+    "            size=7,\n",
+    "        ),\n",
+    "        text=eval_summary[\"feature\"].to_list(),\n",
+    "        showlegend=False,\n",
+    "    ),\n",
+    "    row=1,\n",
+    "    col=2,\n",
+    ")\n",
+    "max_t = (\n",
+    "    max(\n",
+    "        eval_summary[\"naive_t\"].cast(pl.Float64, strict=False).abs().max() or 1.0,\n",
+    "        eval_summary[\"hac_t\"].cast(pl.Float64, strict=False).abs().max() or 1.0,\n",
+    "    )\n",
+    "    * 1.1\n",
+    ")\n",
+    "fig.add_trace(\n",
+    "    go.Scatter(\n",
+    "        x=[-max_t, max_t],\n",
+    "        y=[-max_t, max_t],\n",
+    "        mode=\"lines\",\n",
+    "        line=dict(dash=\"dash\", color=\"gray\"),\n",
+    "        showlegend=False,\n",
+    "    ),\n",
+    "    row=1,\n",
+    "    col=2,\n",
+    ")\n",
+    "\n",
+    "fig.update_layout(template=\"plotly_white\", height=450, width=1100)\n",
+    "fig.update_xaxes(tickangle=-45, row=1, col=1)\n",
+    "fig.update_xaxes(title_text=\"Naive t\", row=1, col=2)\n",
+    "fig.update_yaxes(title_text=\"HAC t\", row=1, col=2)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fe36d9b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Interpretation**: Points below the diagonal in the right panel show where\n",
+    "HAC adjustment deflates naive t-statistics. With overlapping 21-day returns,\n",
+    "daily IC values are autocorrelated and naive standard errors understate\n",
+    "uncertainty. The green markers survive both HAC and FDR correction — these\n",
+    "features have genuine standalone predictive power."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47346f68",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 4. Shape Diagnostics\n",
+    "\n",
+    "Quantile monotonicity analysis: does the label spread monotonically across\n",
+    "feature quintiles? A monotone relationship (Q1 < Q2 < ... < Q5 or reverse)\n",
+    "suggests a robust, exploitable signal. Non-monotone shapes may indicate\n",
+    "non-linear interactions or noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "60e70a13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:04.060411Z",
+     "iopub.status.busy": "2026-05-15T05:25:04.060071Z",
+     "iopub.status.idle": "2026-05-15T05:25:04.101499Z",
+     "shell.execute_reply": "2026-05-15T05:25:04.100284Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape analysis for 1 features\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_QUANTILES = 5\n",
+    "top_features_for_shape = eval_summary.filter(pl.col(\"fdr_sig\").fill_null(False))[\n",
+    "    \"feature\"\n",
+    "].to_list()[:15]\n",
+    "if not top_features_for_shape:\n",
+    "    top_features_for_shape = eval_summary.head(10)[\"feature\"].to_list()\n",
+    "\n",
+    "monotonicity_scores = {}\n",
+    "quantile_spreads = {}\n",
+    "\n",
+    "for feat in top_features_for_shape:\n",
+    "    valid = eval_panel.select([feat, label_col]).drop_nulls()\n",
+    "    if len(valid) < N_QUANTILES * 20:\n",
+    "        continue\n",
+    "\n",
+    "    valid = valid.with_columns(\n",
+    "        pl.col(feat)\n",
+    "        .qcut(N_QUANTILES, labels=[f\"Q{i + 1}\" for i in range(N_QUANTILES)])\n",
+    "        .alias(\"quantile\")\n",
+    "    )\n",
+    "    q_means = valid.group_by(\"quantile\").agg(pl.col(label_col).mean()).sort(\"quantile\")\n",
+    "    means = q_means[label_col].to_list()\n",
+    "    spread = means[-1] - means[0]\n",
+    "    quantile_spreads[feat] = {\"q_means\": means, \"spread\": spread}\n",
+    "\n",
+    "    mono_corr, _ = spearmanr(range(len(means)), means)\n",
+    "    monotonicity_scores[feat] = float(mono_corr)\n",
+    "\n",
+    "print(f\"Shape analysis for {len(quantile_spreads)} features\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "9b2e7b93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:04.122580Z",
+     "iopub.status.busy": "2026-05-15T05:25:04.122128Z",
+     "iopub.status.idle": "2026-05-15T05:25:04.270326Z",
+     "shell.execute_reply": "2026-05-15T05:25:04.269519Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#e74c3c",
+           "#f39c12",
+           "#95a5a6",
+           "#3498db",
+           "#2ecc71"
+          ]
+         },
+         "showlegend": false,
+         "text": [
+          "0.0040",
+          "0.0039",
+          "0.0052",
+          "0.0083",
+          "0.0133"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "Q1",
+          "Q2",
+          "Q3",
+          "Q4",
+          "Q5"
+         ],
+         "xaxis": "x",
+         "y": [
+          0.00395786106430973,
+          0.0038895872583125635,
+          0.005215263716603622,
+          0.008298399870340579,
+          0.013263235621217367
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "dist_52w_low",
+          "x": 0.14444444444444446,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "height": 250,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Quantile Mean Returns (Top FDR-Significant Features)"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0,
+          0.2888888888888889
+         ]
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.35555555555555557,
+          0.6444444444444445
+         ]
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.7111111111111111,
+          1.0
+         ]
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.0,
+          1.0
+         ]
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.0,
+          1.0
+         ]
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "domain": [
+          0.0,
+          1.0
+         ]
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA4QAAAD6CAYAAAD5jokXAAAgAElEQVR4Xu3ddXwT2d4G8KeKu8PisDgszqKLu7sVl2KlWLFCabHiWoq7S3Fd3FkWWVjkwsLi7lLaUvp+foc32UrSJFDStHnmn7s3ncyc+Z5JmCfHbEJCQkLAjQIUoAAFKEABClCAAhSgAAWsTsCGgdDq6pwXTAEKUIACFKAABShAAQpQQAkwEPJGoAAFKEABClCAAhSgAAUoYKUCDIRWWvG8bApQgAIUoAAFKEABClCAAgyEvAcoQAEKUIACFKAABShAAQpYqQADoZVWPC+bAhSgAAUoQAEKUIACFKAAAyHvAQpQgAIUoAAFKEABClCAAlYqwEBopRXPy6YABShAAQpQgAIUoAAFKMBAyHuAAhSgAAUoQAEKUIACFKCAlQowEFppxfOyKUABClCAAhSgAAUoQAEKMBDyHqAABShAAQpQgAIUoAAFKGClAgyEVlrxvGwKUIACFKAABShAAQpQgAIMhLwHKEABClCAAhSgAAUoQAEKWKkAA6GVVjwvmwIUoAAFKEABClCAAhSgAAMh7wEKUIACFKAABShAAQpQgAJWKsBAaKUVz8umAAUoQAEKUIACFKAABSjAQMh7gAIUoAAFKEABClCAAhSggJUKMBBaacXzsilAAQpQgAIUoAAFKEABCjAQ8h6gAAUoQAEKUIACFKAABShgpQIMhFZa8bxsClCAAhSgAAUoQAEKUIACDIS8ByhAAQpQgAIUoAAFKEABClipAAOhlVY8L5sCFKAABShAAQpQgAIUoAADIe8BClCAAhSgAAUoQAEKUIACVirAQGilFc/LpgAFKEABClCAAhSgAAUowEDIe4ACFKAABShAAQpQgAIUoICVCjAQWmnF87IpQAEKUIACFKAABShAAQowEPIeoAAFKEABClCAAhSgAAUoYKUCDIRWWvG8bApQgAIUoAAFKEABClCAAgyEvAcoQAEKUIACFKAABShAAQpYqQADoZVWPC+bAhSgAAUoQAEKUIACFKAAAyHvAQpQgAIUoAAFKEABClCAAlYqwEBopRXPy6YABShAAQpQgAIUoAAFKMBAyHuAAhSgAAUoQAEKUIACFKCAlQowEFppxfOyKUABClCAAhSgAAUoQAEKMBDyHqAABShAAQpQgAIUoAAFKGClAgyEVlrxvGwKUIACFKAABShAAQpQgAIMhBZ8DxSr0RU1K5WC16COFlxKFs3SBc6cv4YOruNRq3JJTHR3tvTisnxRIBASEoJlG/Zizeb9ePTkBZIkTojf106Gg4N9FBydh7BUgc27j2HY+AXo370ZOraoZanFZLkoQAEKUMDCBGJ8ILz74CkWrd6J42cv49nzV4gfLy7y5sqCpnUqoPpvJSyK++KVf3Ds9F9o27Q6EieMH6ZsTbt64Mbt+7iwb4H29agOhM9fvkGFRi7q+KPdOqFhzXIRfLymLsOaLQeQJHECnNg626L8whdm1OQlWLftkPZledhNlzo5KpUpAud29ZEwQTyTyy9Ga7ccQOVyRZE7RyaT329pb/joH4AGHYYhUcL4WDl7OOLGcUQ7l3E4e/G6waKWKZ4f8yYOMLhfVOwQvi7DH3P22L74rfQvqN12MP6991j92dbWBvHixkH6NClROH8ONK37G/L+nCVCcUK/R/4YL64jsmRMp+7/Vg0rw8bGxuhL+BwcjG17T2D9tkO48+AJPnzwR9IkiZA7R0aULVEQ9aqX0X62dX2mjT6RCTvqOs/230/CbfRcVCxdGIXyZcejpy/h0rkxStftCXPWq77LiOy7UN97wtdj+P3+2OWrvv+jcouJ3wfjZ61S3+EbF3gie+b0UcnBY1GAAhSgQCwViNGB8Ojpv9B3xCwEBwejUtkiyJIxLd6++4hDJ86rB6C61Upj3JAuJj3w/ch6XrZ+D7xnr8beNZOQIW3KMKeSf8QfPnmOGV59tK//qEAoD8DZMqXDliVjwti8ff8RlZr0xaeAICROFD/GBMLuTvXgYG+PDx8/4cLfN3Du0g0UyJ0Vy2cNh4O9nUlVeu3mXTTuPEJvYDbpYBaw8/yV2zFt/gasn+ehDUsSou8/fKot3e17j3Hg2DlUKVcUmX9Ko309a6avockcmyYQtmtaHfY66qxBzXLqnpVQIPXcon4lfAkJUYHs6o07OHPhGqRVTEJP1zZ1wxQ59HvkD6/fvsfB4+dx/9EzODWtDreeLY26xODgL+jmNhknz/6NfLmyoFjBXHB0dMC9h09x+txVvHrzDqMGdECTOhXU8XR9po06kYk76TpP14GTIGFm00Iv7dECAoPU92W+n7OgV8eGJp4laneP7LswskD4/oM/6lcvo3OX3h0bRXkLaEz8PvgUEIjabQarH0Znjv7v35OorUEejQIUoAAFYpNAjA2ET5+/Rt12Q1QLwcLJA5E9S4YwDz5Dx83H7oNnMKR3a7RpXNUi6szUh6AfFQgrlSmMA8fPw2ecKyr8Wkhrs3D1TixcvQPZM2fAP3cexJhAGL5lYMjY+di69zime/VWIceULSY+AOq7vsDAIFRtMQCF8+fENM9eehn2HPoD/Txmqx8jKpcrYgpXlO2rCYSGWnkk3EkrkATc0Jt0ixwybj7+uHBNdbFuVKu89s+63uP/KRBNu47EnfuPcXjTDCRPmsjgtWzfdxJuY+aiffMaGOjcIsz+QZ+DsX3fCSROmCDaDEMXSK5Zgt8E9+4Grys6djD1u1DKqK/uf2T5Y+r3wcpNv2PsjBXYtmyc+iGFGwUoQAEKUCAygRgbCKfOW48Fq3aoX0CldTD8Jg98tdoMQkgI8Pu6ybC3s4P8Ql6kWhd0alkL/bo1C/MWediQVjtNFznZd4DnHNy4dR/PXrxG8JcvyJQ+tfr1v22TatqWNen61KqHF8YN7aJ+kd+w/TCePHuFbJnTq5aHYoVyqfP4LtuKmYs2RSinjOmSsV3Og6fi9t1H2L1qgnYfXYFQHjyli+yWPcfw8PFzJE6UABXLFEb/7s0jdEMNfzJNl9EB3Ztjz6EziBs3DpZMG6x2k65w1VsMRIOaZXHp6i1cvn47QiCU9yxeswv/u3VfteIULZgL/bs1Q46s/4XxHftPYdm6Paq18827D0gYPx5KFc2LHu0ahNlP03Llt2g01m09iL2H//haPwV+xoh+7VTXT0ObvhBx4uxldBkwCX06NUa3tv+1Fsn1z1rkh4MnzuP1m/dIlyaFqk8ZayPdD89d+h/a9h4b4bTN6v6Gkf3bo4Wzp/rbmjkjwuwj5fDbfSxMd19poXnw+DnmTxygWugOnriAL1++4MCGqep65TVjrl1anXyWbMbR05fw9PkrpE6ZDHl/zowOLWqpVtDINgn9vYdNNxj0IguEYumzZItqhZM6l/u5X9emYX6A0XwGxg7pgsdPX2LjjsOqrDmy/oTBvVppPwORlfV7A6EcWz7z0j1W7rvDm6YjjqODOqW+ICF1IPfh8pnDUKRATkO3G6bMXQf50US64hnTnVjXZ1pOIj9WLFq9C//ee6TG9pUonBt7D51FiwaV1A9Yspny+Qh/npK1nSEtaaE3+S6S1lBd3ymaz8WhkxeU3U9pU6JcyYJo37wmUqdMiuv/3IP3rFX49/5jvHz1Vt0HeXJmQedWtcP8oBRV34X6KsLYQGjocy7HN+aaDH0faO6Hc3vna+81OfbO/acx0GsOVvm4o1De7OpyIvs+SJIogfq3I7LvJjmGfPev8vsdfjuPqlZp6QYu373Sil+7cqkwbC9fv0OFRn3QqWVt9O3SxOC9zR0oQAEKUMC6BWJsIGzQYbj6R/SI3wz1MK9rm+S7VgWYNb4j1cOzKYFQHqic+oxF/txZkTZ1CtjZ2uLazTvYe/is+ge2S+s66pSahyD5x1m2CqUKqfAoXdJsbW2xb80kJE2SUD2ALFi1XT0sSCCT12Qr/ktu/JQulVGBULrE9Ro2HcfPXFLjpXJmy6haOFb77VcPqDJGLLLxUKEDoYSh/qN8sHbuSOTPlVWVa+j4+WriCWldDR8IxVE8JXyXLpZPPXCu2XwA/p8CsHnxGPXgKJvP0i3468o/6kFFHnSkC+/uQ2cQFPQZmxeN1l635oFX3GQ8pYRGCdLHzlxSD1HyMGVo0xciTp27gk79JmBonzZo3aiKOowEq2bdRiEgIBDN61VEyuRJ8Odf/4MEWM0PBC9evcXarQcxe7GfamHShATpOvlLvhwmB0K5N2xtbNS5cufMhHfvP6pJXWR8j4QRQ9cuIb2ls5fq3tm8fiUVBmX83M79p1S3uYE9wrZShfcaO2OlCmfHtsxS4+b0bfoC4f6j5+AyYiayZ0mPGhVLICAgCH67jkK6pEn9aMYnaT4Dcg5psZexdAGBgTh04oK6H6XbYuiuqLrKERWBUI67fMNe1VVzikdPVP+tuDqVviAhP9DIDzWbF49Gzqw/Gbrd1NhSz6nL1I9Jcs8Y2nQFwlV++zFm+nL1eZWxfIFBnyFd36VepSdD+EBo6B6RMoQ/j4wflNYh+V5p2aCyKmbBPNlUiA8fCOWeb97NAy9ev0OD6mWQMUNq9YOP3BPD+rRRP5jIjxHzVmxFnpyZ1b0sn+Xjf1zGpWu3sHT6EPUjTlR+F+pzNSYQGvM5l+Mbc02Gvg9MDYT6vg/kc27ou0nKLJ9nCYSNa5dHruyZ8OLVG+w78qcKo+FbzGV/+fdL7q/wP2AZum/5dwpQgAIUsD6BGBsIC1XuhKIFf8aiqW56a00zsYK0XMgDtCmBUNdBv3wJUV3rpAVt//opYR6CpBum56COSJbka9ez34/+CRf3mWHGokXWTcqYFkIJL4O8fOHr3U/9gq/Zdh04rVozF0waiF+L5dPrEToQSmtB9VYDUTBPdkzx6KHCzs/ZfoLnwI7q1+zQgVDGY1ZvOQDtmtZQs9dpNmmhrNV2MDo0r6nGbunbJAw36uQepiufJhD2bN8AXdrU1Y71k4eelZv2Yc/qieqBNrJNX4iQh2HpMhW6Jcdj0hLVKirhNU2qZNrDjpqyFDIz37HNM5EgflxE1kXM1BZCGdcmLWQy3i30Zuy1X7p2Gy26j4ownlEmipEfAuQBPbKtWTcPFToXTh4U6X66AqGMl6vaoj8SSPfM+aPUZDSyPX72EnXaDkaxQrnVfSibJhDKmN0Rrk7aiT00LbUSZuV1Y+pS1z6hg72hUPD39X8h1+3sVF87Tk7Xe+SzLF1GpSXzwPqpRo09k7GL0k1dfriQHy1KFsmrJpOResiU4b+xl5prCP+ZloBRs/Ug9ePC7HGuYca35vutvc5AaMznQ9d3R5Xm/dUPPeG7CocPhMO9F6qQLz8mSbk0m3zmJXDIMXRtmu7I8n0zfmjXKP0u1HefRDapjCbUG/s5N/aaIvs+MDUQ6vs+MKbM8kNLydrdUbV8Mci/Z5pNfiQ8f/mmzhZu6VkwZ9kWnNsz36j7O9IPKP9IAQpQgAKxWiBGBkJNsJPWqsgGzUsLRc+h0+Du6qQeyk0NhHcfPMGy9XvVhBWPn75Qk1nIJt1PL+5fGOYhSNP1U3O3yC/VZev3Ro929dGzw9cJHL43EEr3P5kARIJO6M3fPwBl6vfSOaFG6P1CB8IOLWpi6fo9mDRnDcYN7apmJNy6dKxq9QkfCDXlltbD5MkShzl3m15j1IykEkZlkwdt6c4q4VW62755+151dZIt9IQfmlAkXfuk1UGzacLJ4qmDVVe6yDZNINy6ZAzixHHEq9fvVMuFz9LNqFPlV+2Dkzw0yeyKMuvskD5fu+RptmOnL6GP+wysmDVMjbWLykAoXUZ3LB8f4RKMvXZNuJGgNbJf+0hb+XQ5VWrqqsZQSqCKbNMVCOVHDwnAusbgyrT22/adwOkdvqpMmkAY/jMg56zVxg329vaQOjKmLnVNKiOfc01YMRQIpStdjVaD1OddPveyyXtk0qHZ4/pCgu6TZy9V1275wSj0bLvy3qXr9oQppqODPQaFmnRGQt3MhZuw98gfePP2g3ZfaQGVXgOhJ+EJH9Q0rYPLZw7VtqppDqAvEBrz+fjWQCif1V/r9lAztPp694+0fmTpkrVbD6gfw8RAWollk0Co+ezruw9M/S7UVxCpR32TysgPXCmSJTb6cy7nMOaaojIQ6vo+MPa7Se7/ErWctcMaND0yIqs0zQ+FBzdM0/bgiLSS+UcKUIACFLBagRgZCKW2fqkiLYS5sHCK/tYPTQvh1FG9UK1CMZMCobTOtHcZp26MxrUrIE/OTGq8z5bdx3Dg+DlcOrBY/U3fQ5CEIClj6PGK3xsI6zoNwa27j/TerBLypDuqvi18IJSAW7FJX8iv/b8Wy485413VW8MHQukmJ93l9G3SiiBdT2VzHTlLdauVFhT5NTt92hSq66zMbiizAMqMoLLpC0WaViV5QC1XskCkH0x9SxVICO/mVE8Fd9nkAbZ8w8hn25NrL1+qULQGQl3X3mvodDXmUVroZGZLeTCsVbmUUWPYZLysjPPq0b5BpI66AqFmHJTGJfQB5q3YhukLNmL7snGQ7rSRBcJugyarEHFiW+RLmERVl9Er//sXsgxD6B9idLUsSWuw16BO2m6lcn26xoxJ4D27e14EPwlT0kp79cZdXLxyU3XjlXFbI/u1Q7N6FdX+4YOapvVbLKQ7dejN2ECo6x751kCo+T5o36xGpN2PNROUSDfzhjXKInPGtKqbt1yPjLvWfAdH1XehvpvV0I8BpnzOjb2mHx0ITSnzkrW7MXHOGtUNO1f2jKobsIwfl+8tXZv8OCbf5dJlW/bnRgEKUIACFNAnEGMDoTFjCCf7rsOiNf9NAqFpIZRJREJ3fRSc8JPK9BgyFX9cuK5a4zJlSK31Gzfz6zgOQ4FQxoVIt9aoDIRSRjs7O70L1adOkVRNlKJvCx8IZb+JPmuwZN1uhG6RCx8INQ/rMgGNTLMffosfL44ag6Vp0ZJxS8Nc2mjHM8pyFr/W6WFUIJQp/TsPmKhaLIwNhNIyJeNoLvx9U9W3jP+TmSY1m+a6paVNM6Yq/DVIsJGHXIMthCEhakxq6C2ySWVMaSHUde0SPI6d+UtNSiNjM6X7rWxjBnfWO/2+pmwSCLu0qaO6T0a2RRYIw3dPluPMXb4NMxZuVK2fstRLZIFQxnLK+poy1jeyLaoCoaYVLvSMqfK5kZZBzcyg67cfUuP2ZCKoetV0L2Fg6j8ZMvGUtEzmzJpBe3+ED2rSPVkmFPpzzzxtF1zNeYwNhLruke8OhDpmTdWUS77HpKdD5gxpsHiaW5h1/qQbuHSRNxQITf0u1GdvKBAa+zmX7ytjr8mYQBi+PiObVCb894GxZdasWyvlkR8f5Lvu8rXb6kdOGVMoXf3DbzIeW36QkcmrZDgANwpQgAIUoIA+gRgbCDXjN/TNMipdmqS7mkxRLy0ZsslDYaEqnVR3suF924YxCR8IZaxPqhRJsWzG0DD7fU8glLFx8qu6zCSaMf1/IVNOYMwYQvnHXULB0S0zta1fptzaugKhvCYPx6G7uoUPhDKbq8zqum6uh2ql0rdppuWXcZ0lC+fR7vajA2HopQpGT1uO1Zv3hxlDJvUu429KFM6jltqIbJMJNRp2HB5h6QJ5jyzo/urN+wjdH39kIAxfVhnD16bnaCRMEF9NhhLZVrlpP9UCFrrLo679dQVCuc9a9vBSM+VKd7zQmyzrsWP/SYNdRiXMVmneT40FDf85Cl+OqAiE0tLdoONwNVPmoQ3TtOOmwgcJmY1UWv/l4dpnvKua3MWYTSZTcXCw17trtRYD1AycO1d4q33Cf6ZlwiWZsEjXUgDREQg1n4vQ40HDX5yMl5Sux6HHZGr2+Z5AGNl3oT5gQ4HQ2M+5KdcU2feB1KXU6bEtM7Vjx6XspgRCY8usy0Tu4/6jZuPwyYtqRmjpuh9605Tj0MZp6t8ybhSgAAUoQAF9AjE2EGrWIZSudDJpRuilD+TBcJj3AvUPs/ewbqhT9Vft9Vdp1k89TEvLn52drXpduuQN8pqrxtJolp2Q5QdkTNHe1RO1rWLSXdNl+Aw1/fq3tBDKpCb9PHx0tn4ZEwilZUMmIJBul9L9MvQmDzkyi2Voh/CVrisQ6roxwgdCWQ6jbruhKFkkD3zH9wvzUCzBW7rpyUyD/83u2RqtG31d+1FCgXQxlBkdjeky+i0thKEDoZzPxX2GWmdRloqQJSNkk8l4ZFyjrol3JPxIC6FMwCLd/so16K1zaRJNENq/bor2Aeuffx/AdeRs3H34VOeyE9/TQiiu8sBYIE+2MNXUuudoFXo0P3To+3A37zYKKVMkweyxfSP9BtQVCKVVp2rz/uoHlQ3zPbXjF2UioTpOQ9T4Ts24M30thBt3HMGIiYvCzPaqryDfGwjl3h48dp5aNF4mOZHWYM2mK0hIVz1ZLubl67dYMm1IpD90aI4jn70smdKieb1KEcZzyqyV3d0mq9lgNRPohP9My5i1Dq7jIeMkQ4d0zeu6ZhkNP4YwKlsI5brk+0iWfFnt4x7mPtNMKpMrW0YUrdEVFUsXVut6ajYZnz3Qy1d1W/yWFsLIvgv13SOGAqGxn3P5N8PYa4rs+0Am45FJeWRSLhmfLJuMK5V7XiYV07XshK7vA2O+m+TYR07/hVqVSoaZSVqzdEr4+0T256QyfPCjAAUoQAFjBWJsIFT/QJ66qMamyfpuMvGEPNS/ffdBda+Thap1rTcoY58koMiSAjI7oKyv9teVWyocyhprmkCo+cdepoeX1q6nL15j/7FzsLO1Ud10viUQSreyai0HqklUJKjIkgyyMLyc15hAKA/p0kp46s8rKoCVKpJHhVXpOnT41EV4DewY5kE4qgKhHEfza7i0bFYpXxQpkyXBrbsPlUmlMkVUi5qmhebhkxfqwUXGXMqYpwePnqk14swRCKWsElLb9x2Pv6/fxnTP3urekJa1ls6eePbijWo1k3qV8p46d1WNHZNZY9Om+rr2obR8yOQ98uAuvpr60jyMi0H5UgUhD81HTl5E3LiO6p64sG+Bllyz7tj3BELNL/wyo6wEsDiOjqqsuw+eUYFCyhfZJq3ZW/ccx5HNM8PMaBn+PfqWnZCxoDKrrixsXbNySbXsxKadR1RdSoDQ/PigCYSylErlskWQJmUy/HPnoVq6QMaXyoQ9kbWsSXlMCYQy9lVa+UMQoiZ6kh8spG6kDqQruHQJD73pCxKy1EOrnl6qtV1m2Qzfah/eSRall1bwhAniqR9HsmVKr9bvvH7znrrPZWIZWdNQJjeRLfxnWiYQkVZmWe5EukNnz5xBtVKevXhdHSc6AqH86NW8+yh8+hSI+jXKImP6VLhx64EKiTKhkCw7IcvQbNlzXM1sLEuQSJnPnL+qJgsqkj/nNwXCyL4LvycQGvs5N/aaIvs+kLVMq7UcoIpbq1IpBAYFqaVWZNkhmfzG2EBoTJnlHq3QyEV9b8lnLFnSRLj74KlawqZMsfyYNdYlApv8cPQlJER9VrlRgAIUoAAFIhOI0YFQLkxmApXFomUA/bPnXxeQlwev+ZMGoHSxiF3B5KFRupvKQ/WHj/4o/kse9OnUSC3bEHphejm2jK1bsWGv6iaYI0sGtSC9rL31rWMI5Ziyttv0BRtUi1LypInUTJiliuQ1KhDK+2WymuUb9qgHUwktMguiPIjK+ofSOhF6xs6oDIRyrH1HzqrlHKTl6vPnYOVVvHAeta6fZtICeUjxnLoUFy7fQIL48VTgdWpSHfU7DDNbIJSyyi/7rXt6qSUCpAVDZhCVViT5MUAe2mS5AQmsMqtqtd+Kq4mDHOy/TkJz8/YDeE1bpgKlo4MDOraspSZnkW3dtkNqbUt5iJPxYrLw86k//9a7MP33BEK5BpmISMp758ETVdfyo4fch+EXotb1IZeWb5mUZu6E/ihbQv8EPZEtTC8tX77Lwi5M37dL0zBjkjSBsGalkurz+M+/D9V6hLJ2ocwsq1mjM7IvIlMCoQQ52WRyDZn0RdZnlCVoWjWsonOynchals5fvoGO/SYgbapkWDnbXX0m9W3ykC+fAfnukFAkgcDWzhYZ06VCveplVL3IWFbNputHHmlBGjtzhVqnVFp/f8mfA+Ipy4uE/gFL36RLUd1CKGWVUCiLokuofffBX3Xx/a30L+oHB+lq+NH/E7xnr8a+w2dVwJCJjWTSHo/JS755DGFk34X6/I1pIZT3GvM5N/aaDH0fnLt0A96zVqlxsmIlAVqWtZHeBMYGQmPKbGMDrN1yUHvvBQd//f6tU7U02jWrHmFMqgTu3xr3Rdc2dSNdEoiPRxSgAAUoQAH1TBUi6SkWbZoZEPeumaT+weRGAWsV0KwVJy3cE9y7/zCGyCaV+WEnjUUH1sw0qWuJj1h0mbwUMwrIDwrSG2bb0rHqRyRuFKAABShAgcgEYl0g1Kw9OLTPf+PYeAtQwFoFZEIgGWe0Yf4oo5aq+BYnBkLj1SSkh5+pV3o4SK8FGdcsXQK5UeB7BGTdR5nxVro1y2y73ChAAQpQgAKGBGJdIJRuWNI98f6jZ2pxcs0mC1Bzo4C1CXz0D1Czpko3Npk8xdbWJsoJGAiNJ5VJSG7deYhcOTKpLoY3b99XYy1lzc5pnr2MPxD3pIAeAbnHZAIt+YFBxv9yowAFKEABChgSiHWBUC5YZgOVMUkX/76ppoGX8WHSHYsbBaxR4I8L19QkO+0jWW/ue1wYCI3XW7vlAFb67cejJ88RGPgZ6dOmRK3KJdGtTV2da3waf2TuSQEZZ3gAnlOX6ZxciT4UoAAFKEABfQKxMhCyuilAAQpQgAIUoAAFKEABClDAsAADoWEj7kEBClCAAhSgAAUoQAEKUCBWCjAQxspq5UVRgAIUoAAFKEABClCAAhQwLMBAaNiIe1CAAhSgAAUoQAEKUIACFIiVAgyEsbJaeVEUoAAFKEABClCAAhSgAAUMCzAQGjbiHhSgAAUoQAEKUIACFKAABWKlAANhrKxWXhQFKEABClCAAlVr5iQAACAASURBVBSgAAUoQAHDAgyEho24BwUoQAEKUIACFKAABShAgVgpwEAYK6uVF0UBClCAAhSgAAUoQAEKUMCwAAOhYSPuQQEKUIACFKAABShAAQpQIFYKMBDGymrlRVGAAhSgAAUoQAEKUIACFDAswEBo2Ih7UIACFKAABShAAQpQgAIUiJUCDISxslp5URSgAAUoQAEKUIACFKAABQwLMBAaNuIeFKAABShAAQpQgAIUoAAFYqUAA2GsrFZeFAUoQAEKUIACFKAABShAAcMCDISGjbgHBShAAQpQgAIUoAAFKECBWCnAQBgrq5UXRQEKUIACFKAABShAAQpQwLAAA6FhI+5BAQpQgAIUoAAFKEABClAgVgowEMbKauVFUYACFKAABShAAQpQgAIUMCzAQGjYiHtQgAIUoAAFKEABClCAAhSIlQIMhLGyWnlRFKAABShAAQpQgAIUoAAFDAswEBo24h4UoAAFKEABClCAAhSgAAVipQADYaysVl4UBShAAQpQgAIUoAAFKEABwwIMhIaNuAcFKEABClCAAhSgAAUoQIFYKcBAGCurlRdFAQpQgAIUoAAFKEABClDAsAADoWEj7kEBClCAAhSgAAUoQAEKUCBWCjAQxspq5UVRgAIUoAAFKEABClCAAhQwLMBAaNiIe1CAAhSgAAUoQAEKUIACFIiVAgyEsbJaeVEUoAAFKEABClCAAhSgAAUMCzAQGjbiHv8vULK2M5rXq4h+3ZqpV4aOm48te47j3N75iOPoYJTTpp1H4OjogDpVfjVqf107tXD2xKWrt3S+f5WPOwrlzY537z9i/srtOHP+Ku4+fIrg4C/Iljk9Oraoiarli33zuU19o5Q1VfIkmDnGxdS3cn8KUIACFKAABShAAQr8cAEGwh9OHHtOED4Q7jl0Bn9f/xd9OjeGvZ2dURfaptcYJEoYH3PGuxq1v75A6P8pAO2b1Yjw5wq//oLkSRPh8vXb6NB3PCqVLYI8OTLDwcEe2/adUEFytFsnNKxZ7pvPb8obGQhN0eK+FKAABShAAQpQgALmFmAgNLd4DD5f+ED4LZcSVYEwccL4mDdxgN4ivH7zHsFfviBFssTafQICg1Cz9SCkSp4Ua+eO/Jbim/weBkKTyfgGClCAAhSgAAUoQAEzCjAQmhE7Jp3q3KX/Yeq8DaqlLUmiBChTPD92HTiNNo2raruMTpm7Dmu3HsTpHXPUpX35EoJlG/bAb9dR3H/4DIkTxUfOrD+hXbMa6v0SBs9fvhGGoVSRvFg4ZZBJNBKyDAVCfQds33c8nj5/hZ0rvNUuzoOn4vHTF/BbNFr7lr4jZuHazbvYvWqC9rX+o3xw7+FTrJvrYXJZw3cZvfvgCSb5rsXpc1cRFPQZ+XJlQe+OjVGicG51bDFv3m0Upnv1RpVyRdVrN27fR4MOwzF+aFfUrVZavXbr7iPUdRoCn3GuqPBrIZPKxZ0pQAEKUIACFKAABSggAgyEvA8iCFz4+yba9RmHrJnSoVGtcogbxxEXr/yDrXuPo0PzmnoD4ZxlWzB/xXb07tgIP2fPiGcvXmP3wTNIlyYFRvZrh//duo9BXr5IED8u+nf/Og5Ruo9KaDRlk0CYKEF8TB3VE3HiOMLB3rjuqtJCWLFJXxQrlAszvPqoUy5ZtxuT5qzFqe0+SJggHmSfsvV74aN/ADYu8ETuHJnUflWa90f134pjoHMLU4qK8C2ET569QuPOI1S31g4taipbCdCnzl3B/EkDUbJwHhWsS9frica1ymNgj6/n8122FTMXbVJdYGeO/lp2ed+IiYtwctvXsnOjAAUoQAEKUIACFKCAqQIMhKaKWcH+bXuPwaMnL7Bt2XjEi+uoveLwXUbDtxBKq1aypIng690vjNL7D/7awBJVXUZDTyqTMnkSVP+tBHq0q4+kSRLqraHZi/3gs3SLapGUlknZrt64gyZdRmLuhP4oW6IADp24gJGTFqvAVrlsUfTq2BDPX75BhUYuatxj+VKmtcSFD4RjZ6yATKyzd81kdQ7ZJAA27DQccR0dtV1Zew2djhev32K1j7vap2lXD7X/Hxeu4fjW2apeRk1egiv/u2O27q9WcOvzEilAAQpQgAIUoIDVCTAQWl2VR37BEt4k+HVrWxd9OjUOs7OhQDh47DzsPnAanVrVVl1E8+TMEiZQysGiIhDu2H8K9na2qnXxw8dPaibRNVsOIFf2TFg/zwM2NjYRLlK6uw708kW7ZtXDtPJJGJMWwZYNK6uWTfcJi9QENKlSJFGtm1sWj8GBY+fgMmImTm2fo1o3TdnCB8J67YYifdqUEUKzBFUJrGd2fm1BXbZ+DyRwn97pi1dv3qFq8/7YtXICGnQYhrFDuqJahWKqpfHXYvkwoHtzU4rEfSlAAQpQgAIUoAAFKKAVYCDkzRBGQMbJ1Wg1CJ4DO6Jx7fImBcI37z5gsu9aFaQkqNnZ2eLXovng7uqEn9KlUseKikCoq8qkO6V0q5QxfjImL/S29/BZDPD0Qb1qZeA1qGOEwNjHfQbev/fHgsmDUKFRH0wY3h2pUyZFvfbD1FhDadE7fe4K1viaPhFN+EBYvmEflCtZEGMGdw5TxrVbDsBz6jLsWzNJBcbr/9xDo07uWDZjqPrvnftPYcWsYejnMVvN6DpqYEeUrN0ds8f2VcfjRgEKUIACFKAABShAgW8RYCD8FrVY/B4ZO1e8Zje49WwJp6bVTQqEmp1lzb9bdx/ijwvXMWvxJvycLSOWTBus/izdURMm+L5lJ3Txb//9JNxGz8WCSQNVq5lm27z7GNwnLETLBlUwpHcrna2HKzftw9R56zFnfD+4uM/Ekc0zVOiq4zQEDWqUxbEzl1AgdzbtuEdTql93C2EK+Hr3D3MYnyWbMXvJZm0LYUhICMo26K2W1pDxhRL65L+lpdNj8hI1frK72xQ1ftDUVktTys99KUABClCAAhSgAAVitwADYeyu32+6upqt3fBztp/ULJeaTbpWSpfRlg0q6Z1U5t97j5ElY9ow5xzuvRCnz19VLV+y9RgyFS9evv3mcW9v33+Eo4O9mowl9DbAcw72HT6LAxumapeamLt8m5qIxaVzY3RpXUevhWYGT5nlM13qFBg7pIvad/qCjSoM/nvvEaZ49EK5kgVM9gwfCMdMX46NO2QM4STI2EfZJEA37Dgc8eLGCeMis52+ePUGf125hZ0rvZEhbUp89P+EMvV7o1De7PgUEIg1c0aYXCa+gQIUoAAFKEABClCAAhoBBkLeCxEEJLDIxCo9OzRA+ZKF8ODxc8xdvlUtxdCpZS29gbBy037InzsrqpYvhuTJEuH23ceYsXAjmtWtqG1dm7diG2Ys3KTG68kspoFBQahT5Veja+Ho6UtwG+OLauWLI3uW9LC1tVUTwZw4exl9uzTRBj9NF0wpS7UKxSMcv0CerMiYPrX29XINeuPl63eYOcYFlcoUVq9rJpyRrq8yC2n8eKaNH5RjhA+Ej5+9VF1BkyZOqGYZjRcnDjbuPIyzF69j/sSBKFX062Q3sq3evB+jpy1XM53KjKeaTSacOXjifJi6MBqQO1KAAhSgAAUoQAEKUCCUAAMhbwedAvNXbseKjfvw4aM/smfOoCZdkRkyW9TX30IoIUy6bkpLoYwhlBathrXKoV3TGmo8oWzSJdVz6lIcPnEBgUGfUbtKKTVe0djt6fPXmLN0M85dvqFmQg36HIzsmdOjS+vaaqZRzaZZpkHfcUcN6IAmdSpo/9zPwwdHTl1QM3jGcXTQvl695UA1c+q3tsTpWphefCbLhDHnrqjy582ZWQXk0GFQCvDPnYeQSWjkb92d6mnLtGXPcQwdN191O/2WVktjrbkfBShAAQpQgAIUoEDsF2AgjP11zCukAAUoQAEKUIACFKAABSigU4CBkDdGtAoEBgapRdiN2ZbPHIY8OTMbs+sP22fWIj8sWbfL4PFlEpipo3oZ3I87UIACFKAABShAAQpQIDoFGAijU5/npgAFKEABClCAAhSgAAUoEI0CDITRiM9TU4ACFKAABShAAQpQgAIUiE4BBsLo1Oe5KUABClCAAhSgAAUoQAEKRKMAA2E04vPUFKAABShAAQpQgAIUoAAFolOAgTA69XluClCAAhSgAAUoQAEKUIAC0SjAQBiN+Dw1BShAAQpQgAIUoAAFKECB6BRgIIxOfZ6bAhSgAAUoQAEKUIACFKBANAowEEYjPk9NAQpQgAIUoAAFKEABClAgOgUYCKNTn+emAAUoQAEKUIACFKAABSgQjQIMhNGIz1NTgAIUoAAFKEABClCAAhSITgEGwujU57kpQAEKUIACFKAABShAAQpEowADYTTi89QUoAAFKEABClCAAhSgAAWiU4CBMDr1eW4KRLPAnftPMMjLFy9evUG5UoUw3KUt7OxsI5TqwLFzmOS7Fl++hKBjy1poVvc37T6nzl3Bms0HMM2zl/Y1n6VbsHH7YXwODkaenJkwwd0ZiRPGh77Xo5mBp6cABShAAQpQgAJWK8BAaLVVzwunANC+73h0aF4T5UoWxADPOahY+hfUrVY6DM1H/wDUcRqM1T4jkDBBPDTpMgILJw9C+rQpMWPhRmzZfRwF8mQLEwiPnr6EogVzIl7cOBjuvRB5cmZGm8ZVoe911gUFKEABClCAAhSgQPQIxMhA+OrNO7h7L8KJs5fVA2rbJtXQpXUdvYLG7P/2/Ud0dPVWx6n+W3HtseQBtrvb5DDHdnCwx4V9C6KnxnhWCkSRgLTelW/QB8e3zoKNjQ32Hj6LI6cuYrRbpzBn+OPCNSxeuws+41zV62OmL0f+3NlQv3oZ9f/PXfoflq3fGyYQag4QEBiE/h4+aNOkKkoVyas9rr7Xo+jSeBgKUIACFKAABShAASMFYmQg7Ofhg+DgYLi7OuHR05dwdpuCsUM6o3ypQjov29D+0xdsxObdR/Hi1VtMdHeOEAi9pi7FhgWe2mPbAEiUML6RxNyNApYp8PzlG7Tq4YW9ayapAp69eB0LVm2Hr3f/MAXedeA0jv9xWRsUpdtnHEcHdGpZK9JAKOFyoJcvqlUoDs+BHVTolE3f65apxFJRgAIUoAAFKECB2C0Q4wJhYGAQStR2xpo5I5A7RyZVOxPnrFFhbvzQrhFqy5T9m3b1QOdWtSMEQmkR2b1qQuy+E3h1VicggdCpz1jsXOFtMBCePncVHgPaq/2MDYSyb3DwF4yctBj5c2dFi/qVtMb6Xre6SuAFU4ACFKAABShAgWgWiHGB8PbdR6jjNARnd89DvLiOim/99kNqAos1viMjcJqyv75A2HPoVCRLkkhNilGicB64dGmi/psbBWKygHQZrdi4L474zdB2GT188gLGDO4c5rLOnL+G5Rv3YuboPup1+YEkX66saFCjrPr/kXUZlb9v//0kzl64rg2UmoPrez0mm7LsFKAABShAAQpQIKYJxLhAePXGHTTpMhKXDy7WdkHbvu8k5q3Yhq1Lx0bwN2V/XYFQxh8+efYKSRInxOOnLzDZdx1SpUiCqaO+zqj49mNQTKtzlpcCWoEebhPh1KwmShbJhxET5qNU0fyoXaU07t5/jPOXb6B+jXL46P8JLbuNwKLpwxAvbly06+2FaaNdkCFtKnWci3/fwNrN+zF2WHftcXfuP4kq5Yqp/6+OWyQfGtSqAH2vh64Se1sbxI9rz1qiAAUoQAEKUIACFDCDQIwLhJoWv/N758PR0UERSQvhhm2HsXau/hZCY/bXFQjD14E8JLdzGYeLvy9UgTQw6IsZqomnoMCPEfj37iMM856P12/fq0lfhvRpC3s7Oxw8dg6+y7dg7dxR6sQHjv2J6Qs3IORLCFo3robm9b52/5wydy2OnL6IV6/eIkO61PAZ1w9JkySE2+g5quVQtt9KF8agnq3hYG+n9/XQVydDDR3sIy598WMEeFQKUIACFKAABShg3QIxLhCqMYG1uqvuoZoxhBNmr4aMh5rg/l8LhaZaTdnfmEAok2u4jZ6LY1tmWvedw6unAAUoQAEKUIACFKAABWK8QIwLhCLu4j4TtrY2GN7XCU+fv0LXgZPg0b8DKpcroipk/KxVSJEssXYpCkP7a2pRVyBcuHonfkqXEoXy5cDrN+/VmmpFC/6MIb1bx/jK5wVQgAIUoAAFKEABClCAAtYtECMDobQGuk9YhFPnriBBvLho3bgKnJ3qa2uyTa8xyJA2JbyHd1OvGdpfJsnYsf8U3n/wRxxHRzg42GHL4jFIlSIp/HYdxZJ1u3H/4TO11IRMoe/atal2Qhvrvn149RSgAAUoQAEKUIACFKBATBaIkYEwJoOz7BSgAAUoQAEKUIACFKAABSxFgIHQUmqC5aAABShAAQpQgAIUoAAFKGBmAQZCM4PzdBSwFIEdL//E7pfno704HdNWQuGE2aK9HCwABShAAQpQgAIUsEYBBkJrrHVeMwUArH56FOPv+UW7xYKfe6B4ohzRXg4WgAIUoAAFKEABClijAAOhNdY6r5kCDIS8ByhAAQpQgAIUoAAFADAQ8jaggJUKsIXQSiuel00BClCAAhSgAAVCCTAQ8naggJUKMBBaacXzsilAAQpQgAIUoAADIe8BCvw4Af9PgRgydh4uXb2FzD+lwWSPHkiWJFGEE965/wSDvHzx4tUblCtVCMNd2sLOzhb6Xn/y7BXcJyyE/6cAhIQAw/u2Re4cmXDg+HlMmbsO795/RMrkSTDarRPy5Mxs8AIZCA0ScQcKUIACFKAABSgQ6wXYQhjrq5gXaG4BnyWb8fFTAAZ0b45Vfvtx9cYdeA3qGKEY7fuOR4fmNVGuZEEM8JyDiqV/Qd1qpaHv9eHeC1G6WH7UqlwSF/6+icm+67B85lBcvPIP0qRKhrSpksNv11EcPHEeM7z6GLxsBkKDRNyBAhSgAAUoQAEKxHqBWBkIL1+/DY9JS3Dz9n2kT5sSQ3q3Vg/d+jZj9t+y5zgWrt6JrUvGxPqbghf4fQIS6AY6t0C+XFnw+s17NOvmgb1rJoU56OfgYJRv0AfHt86CjY0N9h4+iyOnLsJjQHudr0urn9vouciVIyM6tqiFazfvYqLPGiycMijMceet2IagoM/o2aGhwYtgIDRIxB0oQAEKUIACFKBArBeIdYFQHoartxqIlg0qo3n9Sjh84gI8py7DntUTkTxpxG57hvZ/+vw12rmMxas375E6ZTIGwlj/kfj+C6zjNATzJw5AujQp1MGK1+yGP3bNDXPg5y/foFUPL21QPHvxOhas2o7Rbp11vu7r3R+Pnr5ES2dP5MqeEcFfvqgfOrJnTq+O++rNOzToMFx1GV0ybTASJYxv8EIYCA0ScQcKUIACFKAABSgQ6wViXSA8c/4aXNxn4PjW2bC1tVEVKC00LepXQqNa5SNUqLH7HzpxAVPmrWcgjPUfie+/QAmEi6e6IVWKpJEGQqc+Y7FzhbfaJ3Qg1PW6BMK5y7epe/rXYvkwa5EfMqRNCXdXpzAFli6jR09fwhSPHgYvhIHQIBF3oAAFKEABClCAArFeINYFwnVbD2LjjiNYO3ektvJk4o40qZKjf/dmESrU2P0ZCGP9ZyHKLrCdyzjVeicTvkiX0abdPLBPR5fRio374ojfDG2X0cMnL2DUwA7Q9fqYwZ1RpXl/bJg3CkmTJERgYBBK1emhWh5lIhrNJi3a7fuO0wbNyC6KgTDKqpwHogAFKEABClCAAjFWINYFwqXr92D/0T+xbMZQbaWMmLgIDvb2EVpTZAdj99cXCN/5f46xlc+C/xiBBSu2IDDoM3p0aIxNOw7h7+u34d6vgwpxKzbsQZsm1eHo6ADnQRPg1KwWShXNhxHe89X/1q5aRu/rPQdPRPP6VVD+18K4ffchhoyegzXzvHDw+J8oUiA3kiROgBUbduP6zbvwGtw10ouTtvPNb05i4gO/H4NgwlHn5nBGPses2nfY2dogfhw7E47AXSlAAQpQgAIUoAAFvlUg1gVCafHz230Mq33ctSbSQpg6VTI162P4zdj99QXCgMDgb7Xn+2KpwEf/T3CfsADX/rmH9GlSYNyQbmps39v3H/Fbo944tGkmEieMj3/vPcJw7wV49fY9ShXJiyG928Dezi7S18dMX47g4C+qVXCAcwvkyp4Jy9bvxtqtBxAQEIhcOTJhhGsHNeuooW3jqxPwvh/9gXB+DmcUipdNW1wbWxs42v/X6mnoOvh3ClCAAhSgAAUoQIFvF4h1gfD0+atwHTFLO3uj0DTpMhLN61dE0zq/RZAydn92Gf32m4zvtEwBdhm1zHphqShAAQpQgAIUoIA5BWJdIJRueVVbDIBT0+poVvc3HDn9F0ZMWITdqyaoST6+fAlBlwET0b55DbUUhaH9NZXBQGjO25LnMocAA6E5lHkOClCAAhSgAAUoYNkCsS4QCrcs1O05ZSlu3n6A9GlTYGCPlqhUprCqCVn/rVDlThg1oAOa1KmgXotsf5nqv3Fnd3z+HAz/TwFqOv961cpgcK9Wll2zLB0FDAgwEPIWoQAFKEABClCAAhSIlYGQ1Ro7BWYv9sPmPccRL24cjHHrhAJ5/ht3prli/0+BGDJ2Hi5dvYXMP6XBZI8eSJYkEfS9Luv3lW/YR+2j2VbPGYEPHz+p8X2PnrxAsqSJ4dG/PYoUyBmrYBkIY1V18mIoQAEKUIACFKDANwkwEH4TG99kboE/LlzDtPkbsGT6ENy68xCuI2fpXFrBZ8lmfPwUoCYQWuW3H1dv3IHXoI7Q97oEwja9xmDH8vFhLumffx/gU0AQ8uXKghNnL2PC7DXYvHi0uS/7h56PgfCH8vLgFKAABShAAQpQIEYIMBDGiGpiISXQxY8XV439lK1+h2HwHd8P6dKkCIPTvu94DHRuoYKcrAHYrJsH9q6ZBH2v6wuEoQ/67v1HyGLzhzdNN1gRl59+gs+ZFwgJMbjrD92hZs5EqJc7caTnYCD8oVXAg1OAAhSgAAUoQIEYIcBAGCOqiYUcNWUpfsmXA/Wrl1EYHVzHo1/XZhG6jUpwmz9xgDYoFq/ZTS3eru91CYQVm7gibarkSJwoPnp3bIxyJQuEAV+37RDOX7qBcUO7GKyI84/84bztAYKjORD2LJEC7QtHvvQEA6HB6uQOFKAABShAAQpQINYLMBD+gCq+c/8JZO3DF6/eoFypQhju0latGxd+O3DsHCb5rlUzn3ZsWUvNiiqbvtc179+29wRmL9msZk6Vzdjz/YBLNdshJRAWK5QLtSuXMhgIF091UzPKyhY6EOp6XeyDg4Ph4GCvupd2GTAJ+9dPQRxHB/X+6//cQ/9RPlgybbBaS9DQxkBoSCji3xf83APFE+Uw/Y18BwUoQAEKUIACFKDAdwswEH43YcQDSPfEDs1rqmUtBnjOQcXSv6ButdJhdvzoH4A6ToOx2mcEEiaIhyZdRmDh5EFImiSRztfTp02p3n/3wVMMGu2rukNqAqEx59N3mYbCp+Z9+iZ00fW6hKzew6fj8rXbsLGxQa1KJTGwRwv130vX78GazQdUQO7Suo62xc9QNch5EidKgLZNqqldpcvonHGu0Lho3t/OZRyG9G6N3DkyKaOm3Tywb80k6Hs9/Hkbdx6BqaN6IVOG1Pj33mO4jJiJCcO7I1f2jIaKqP7OQGgUU5idGAhNN+M7KEABClCAAhSgQFQJMBBGleT/H0eWtSjfoA+Ob52lAtDew2dx5NRFjHbrFOZMMknK4rW74DPOVb0+Zvpy5M+dDenTpND5unSVDPocrNZQdOvZEq4jZ6tAaOz5dF2mvlAaPmTpm9BF3+sSCA+dvIDypQoiKCgYTbuOxOSRPRAQEIjxs1ap1rZPgUFo6eypuneGP5+usp45fw0zF23EkmlDcPvuIxU4d6382kK6Yfth1XqYJWNaSHAMDPoM165NsXbLAfx19RbGDO6s93VpAbS3s0X2LBnw9/V/4eI+A7tXT8Sde4/Rf9Qc1U00T87MRt8lDIRGU2l3ZCA03YzvoAAFKEABClCAAlElwEAYVZL/f5znL9+gVQ8vNZGJbGcvXseCVdvh690/zJl2HTiN439c1gZFn6VbVDdFCYS6Xu/UshamzF2HTBnSqNbG+u2HqUBo7Pl0Xaa+UKoZp6d5j74JXfx2HTU40YuUT0Ls4qmDsWP/KTx78Rp9uzRRh5br+Sl9am1XWUNVMWPhRuz4/RTixHHEqAHtUTj/12UgGnVyR8/2DVG5XBF89P+EwWPn4eqNu8iQNiUmjXBWXT31vX7u0g2MnLgIr968R4rkiVX33uK/5FYBcsm63ar1VrNJy6GMY4xsYyA0VIsR/85AaLoZ30EBClCAAhSgAAWiSoCBMKokQwVCpz5jtUsiRBYIT5+7Co8B7dU7QwdCXa/LGnjLN+zDFI8eCAgMChMIjTmfrsvUF0olfIbe9E3osmnX0Ugnepm1yE+1dg7v2xYNa5ZTQXfWYj8smuKmwq/XtGX4KV0qhD9fFFeJWQ/HQGg6NwOh6WZ8BwUoQAEKUIACFIgqgRgZCGVmSHfvRWp9OGnBkXFlMh5N32Zo/8vXb8Nj0hLcvH1fdV+UMWgy/k+2o6cvobvb5DCHlglILuxboPN00oWzYuO+OOI3Q9tl9PDJC6rbYuhNukAu37gXM0f3US9Ll9F8ubIifZqUOl+3s7VVYcre3g4hISF48Og5CubNhsXTBht1Pn2BUFf41BUIdU3oIoHQ0EQv7z/4q/F73sO6IUfWDJi5aBN27j+lxkqGfPmClg2rGD2OMKpu+h95HAZC03UZCE034zsoQAEKUIACFKBAVAnEyEDYz8NHzQzp7uqER09fwtltCsYO6YzypQrpdIls/6Cgz6jeaiBaNqiM5vUr4fCJC/Ccugx7Vk9E8qSJVCD0mroUGxZ4ao9tAyBRwvh660ACkATUMsXzY6CXL8qWKIAGNcqqSUqkxbBJnQqqC6MshbBurofqdimTmcyfDx6sjgAAF2hJREFUNECdU9fr0pKm2UK3EMpr+s5n6CbRF0qlrKE3fRO6SJdRYyZ6GTlpMUoUzqOdIVRz7I6u3ujXvRny58pqqKgx5u8MhKZXFQOh6WZ8BwUoQAEKUIACFIgqgRgXCAMDg1CitjPWzBmhZpKUbeKcNXjx6i3GD+0awcXQ/hKKZCKR41tnw9ZWoh7UYuYt6ldCo1rlVSCU1jvNjJ7GwMukJ25j5qpxaaWL5VPB1d7ODvuPnsPsJX7YtNBLHeb3o3+qcXQyCUu7ZtVVKI3sdX2BUN/5DJVVXyiV8Cmtr7KVLpYf+iZ00ff6g8fPce/hU5T4JQ9evn6Ltr3HYNYYFzVxi9SHvb09Nu08go07j2DV7OGqJTW2bAyEptckA6HpZnwHBShAAQpQgAIUiCqBGBcIJfxIC9rZ3fMQL66jcli//RA2bj+MNb4jI7gY2n/d1oPYuOMI1s79772yhmCaVMnRv3szFQh7Dp2KZEkSIXHC+Kqly6VLE/XfsWHTF0rHzVypLk+6z8qmb0IXXa8/evICg0bPxb/3HqkJYLq2roNm9Sqq43QeMBHXbtxF0YI/q6BszNp+McmZgdD02mIgNN2M76AABShAAQpQgAJRJRDjAqEsHt6ky0hcPrhY27K0fd9JzFuxDVuXjo3gYmh/WRdv/9E/sWzGUO17R0xcBAd7exVYZPzhk2evkCRxQjx++gKTfdchVYokaq062T58+hxVdcHj6BEIDAzA7fv3EBgUGK1GieLHR7ZMWfElJERvOa6+CESvHQ8RrH8Xs1yDc/HkaJEvMfQVVdpk/d6cxIT7fmYpT2QnmZfDGfnj/NdtWFrq4znaRXu5WAAKUIACFKAABShgDQIxLhBqWvzO750PR0cHVUfSQrhh2+EwrXyayjO0v7QQ+u0+htU+7tr6lhbC1KmSYUD35hHugfOXb6gxexd/X6gCqX9AsDXcJ9F6jR/9P2D3kcN48/59tJYjQ5o0qFGuAr5EEvauPA9ATwsIhD2KJ0fL/En0BkKB3PT6hMUEwoJxs2nrVgJhHAfbaK1rnpwCFKAABShAAQpYi0CMC4RqTGCt7qp7qGYM4YTZq9V6fBPcu0eoN0P7nz5/Fa4jZmkXkpcDSAtk8/oV0bTObxGOJ0snuI2ei2NbZlrLPRLt1/n2/XtsO3DQIgJh/cqVIvVgl1HTbxd2GTXdjO+gAAUoQAEKUIACUSUQ4wKhXLiL+0w1Aczwvk54+vwVug6cBI/+HdTC5LKNn7UKKZIl1i5FEdn+EhirthgAp6bV1QLpR07/hRETFqlJZFKlSIqFq3fip3QpUShfDrx+8x7DvReq8W+asXVRVRE8jn4BBkLT746eJVKgfeFkkb5x9dOjGH8v+ruMMhCaXr98BwUoQAEKUIACFIgqgRgZCKU10H3CIpw6dwUJ4sVF68ZV4OxUX2vSptcYZEibEt7Du6nXDO1/8co/8JyyFDdvP0D6tCkwsEdLVCpTWL1XllZYsm437j98ppaaqFahOFy7NtVOaBO+IoKfPQUCA6Kqfr75ODYJE8I2SeSB4JsPbuY3MhCaDs5AaLoZ30EBClCAAhSgAAWsUSBGBkJLrqiPO/zwYd2y6C2ijS2SDBwBx3y612XUFC7g5GB8eX4+WstqEz8NHIuNhG2S7HrLwUBoehUxEJpuxndQgAIUoAAFKEABaxRgIIziWv/gtwbvFs2O4qOaeDhbWyQfPQ2OBb62curb/Hc1RvDDQyYePGp3t0mYCfFqrIdtkhwMhFFIy0AYhZg8FAUoQAEKUIACFIjFAgyEUVy5DISmgTIQmuZl7N4MhMZKcT8KUIACFKAABShg3QIMhFFc/wyEpoEyEJrmZezeDITGSnE/ClCAAhSgAAUoYN0CDIRRXP8MhKaBMhCa5mXs3gyExkpxPwpQgAIUoAAFKGDdAgyEUVz/DISmgTIQmuZl7N4MhMZKcT8KUIACFKAABShg3QIMhFFc/wyEpoEyEJrmZezeDITGSnE/ClCAAhSgAAUoYN0CDIRRXP8MhKaBMhCa5mXs3gyExkpxPwpQgAIUoAAFKGDdAgyEUVz/DISmgTIQmuZl7N4MhMZKcT8KUIACFKAABShg3QIMhAbq/8uXEEyaswZ+u44i6PNnVC5XFKMGdEDcOI4638lAaNoHioHQNC9j92YgNFaK+1GAAhSgAAUoQAHrFmAgNFD/a7YcwNJ1uzF7nCvix4uDgZ5zUChfDgzo3pyBMAo+OwyEUYCo4xAMhD/GlUelAAUoQAEKUIACsU2AgdBAjbZzGYfKZYvAqWl1tefhkxfhOWUp9q+fwkAYBZ8GBsIoQGQg/DGIPCoFKEABClCAAhSwAgEGQgOVXKGRC7wGdUT5UoXUnnfuP0GtNm44u3se4sWN2G2UXUZN+9QwEJrmZezebCE0Vor7UYACFKAABShAAesWYCA0UP8lanXHzDEuKFk4j9rzybNXqNTUFUc3z0TypInw/E2A9gi2NkCcMwcQsH9n9N5VtraI26ozPv70s95yONjZIO7fXvjy4mK0ltUmXmoE5xsE/ziZ9Zbj8+dPuHztb7z394/WsqZMlgwFcuVHUHCI3nLc+xCMeX++wpdoLSlQI0dCVPgpHmQMrK5N7tXjgZex+eWpaC4p0CNNLWRGem057O1skDSh7jG60V5YFoACFKAABShAAQrEMgEGQgMVKi2EYwZ3RtkSBdSe4VsIQwfCWHZv8HIoEC0CDITRws6TUoACFKAABShgpQIMhAYq3qnPWFQtXwxtm1RTex48cR6jJi/FoY3TrPSW4WVTgAIUoAAFKEABClCAArFFgIHQQE2u3LQPKzb+jjnjZZbRuOg/ygd5f86MIb1bx5Z7gNdBAQpQgAIUoAAFKEABClipAAOhgYoPDv4C79mrsXXvcXz+/BkVyxRW6xBKOORGAQpQgAIUoAAFKEABClAgJgswEEZT7QUEBmH2Yj/s3H8Kz168QepUyVC36q9wdqoPBwf7MKXasuc4Fq7eia1LxkRLaR89eYGp89bj2B+X8NE/ANkypUOH5jVRt1ppbXlmLtqEnftP4/Gzl0iVPIlapqNN46pmL++ff/0PsxZvwl9XbsHW1gYF82aHS6fG6n9lCwkJwdBxC/DnX9fx9MVrpEiaGM3qVUTXNnVgY2Nj1vJu3HEEyzfsxb/3HiFBgngoV7Ig+nVthtQpk0Yox6ETF9DHfQYWTBqEEoVzm7WcxtyrR09fQne3yWHKJffxhX0LzFpWnowCFKAABShAAQpQwDQBBkLTvKJsb+fBUyFBa3jftsieJT2u/3MPXlOXoWjBn+E5sKM6z9Pnr9HOZSxevXmP1CmTRUsgfPPuAxp1dEfBvNnQo30DJEuSCMfOXMLYGSswwrUd6lT9VZV1ku9alC9ZSF3Llf/9Cxf3mfAZ74pSRfJGmZmhA134+yY6uHqjS+s6qF+9DL58+QIJXcvW78HmxWOQKUNqNevmsg17VPhKmSwJrt64g26DJmPF7OEokDuroVNE2d8Xr9mF+Su3Y6hLG2X04tVbTF+wAfcePIXf4tGwt7PTnuvcpf9h1JSlePbiNaaN6m32QGjMvSqB0GvqUmxY4Kktt8TrRAnjR5kZD0QBClCAAhSgAAUoEPUCDIRRb2rwiOcu3UBH1/HYucIb6dOm1O5/6+4jNOwwHJsWeSF75v+m4ZfWoSnz1kdLIJy7fBt2/H5SBSppcdNs67cfwpylW7BvzWTY2dlGuOa2vceiSvmiaNe0ukGPqNqhU/8JyJQ+NUb2bx/mkIO8fPElJASTRjiHeT0wMAinz1/FyEmLsWG+p1pGxByb/6dAVGjUBx79O6BW5ZLaUwZ9DkbtNm7o3Kq2arWU7cbt+3AdOVuNYZWwO3ZwF7MGQmPvVQmEY6Yvx+5VE8xByHNQgAIUoAAFKEABCkSRAANhFEGacpg5y7bg5Nm/sWzG0Ahva9JlpGrd0sxqKjtEZyDs6OqNIgV+Rq+ODcOU9cPHT5A1Gjcu8ETuHJnC/E0CT+Vmrpg8ogd+LZbPFJpv3lfGehat3gVzJw7QrhmpOZjMDDtk7Hyc2u6jPf6Z89fQwXU8UiZPglljXFAgT7ZvPrepb5Rure37jsP5fQvCtATKcSbMXo17j55h5ug+ePj4uWq9nDjCWRlXad7f7IHQ2HtVAmHPoVNVC3LihPFRonAeuHRpov6bGwUoQAEKUIACFKCA5QowEEZD3YybuRLPX77B5JE9Ipxduufl+zlLmAAWnYGwUSd3NK9XEc3rV4pQ1mI1umL2ONcIAWzY+AWqu+u8if3NNi7v7fuP+LVOD2xbNk6NcQy9Xb5+G827jcKlA4vDtHJKC+Hxs5cxdOx8FWxDt9b+yNti/9FzGDVlCY74zYhwGulKKgF20VQ3NO0yEkP7tEHxX76OGYyOQGjsvfrqzTs8efYKSRInxOOnLzDZdx1SpUiCqaN6/UhKHpsCFKAABShAAQpQ4DsFGAi/E/Bb3i6tLqf+vIKl04dEeLu0EDauXR4tG1TW/i06A6G0EMq4xp4ddLcQykQ32bNk0JZVZmQ9c/4qlkwbbNbxY5oWwnkTB0boUikBy917EY5tmamzulo4e6JBjbJooSP0fkv9GnqPoRZCmZhntFtnlKrjDFvb/7rjBgV9Vi2K7ZvXgGvXpoZOEyV/N/Ve1Zz0/OUbaOcyDhd/X2i2HwWi5IJ5EApQgAIUoAAFKGBlAgyE0VDhf135B04u47BrhTfSpUmhLcE/dx6iYcfh2LpkLLJkTGsRgXDBqh3YuvcENi8aHaZ1bd3Wg5DxhXvXTFJjCD8HB2PkxMW4++AJfMa5mjUMaqCke6W08o3s1y5MrQ7wnANbGxtMcO+us7brOg1Bx5a10LBmObPcDapLbVNXuLs6oWalUGMIgz6jVtvBasbTpnV+i1CW6GghNPVe1RT6+B+X4TZ6rt4QbhZonoQCFKAABShAAQpQwKAAA6FBoh+zQz+P2bh15xGG9GmtJpCRWUZHT1uOUkXyRJgUJTpbCD8FBKKO0xDkz5UV3Z3qaWcZ9Z69SjspioTB7m5TEMfRAaPdOqn/lc3Gxhbx4jr+GEAdR7128y5a9vBC55a1ULdaGVlkAuu3HYZMgLPaxx1ZM6WDzNj5+5E/1eyoqVIkxfpth7B0/R7sWP51PKG5ttWb92Pmwk0Y0rs1ShbJi+cvX2PGwo1qCZKVs4cjbpyIbtERCMXDmHtVlkX5KV1KFMqXA6/fvMdw74WqZVmujxsFKEABClCAAhSggOUKMBBGU91I0Jq12A+79p/G0xev1HIIPdrVRzenetqJRh49fYnGnd3x+XMw/D8FqFa3etXKYHCvVmYttUxuIrOcnvjjMmQZCgkrMtFJpTKFVTk04/fCF0paOSVomXOT7piyJuKlq7cgxlKG6Z69kSPr126tDx4/x7gZK3Hp2i18+OiPPDkzY1CPlmadVEbjsWH7YSzfuBf/3n2sWljF02tQJyRNklAnWXQFQmPuVb9dR7Fk3W7cf/hM3afVKhRX3VrN+YOAOe8znosCFKAABShAAQrEFgEGQgupydL1emKud/9oCSamEMgyCC2dPXFm59wwXUhNOYa59l256XccPX0Rvt79zXXKbz5P3xGzVN13alnrm49hrjfGlHvVXB48DwUoQAEKUIACFIjJAgyEFlJ7spC7tKzI5C0yS2Ph/DktpGRhiyETm0hLlbRmli6eX7XC5cz6k0WWVbrhtuk1GvMnDYSjgz3SpEqOFMkSW2RZV27ah407jmC6V288ePQcpYrmtchySqFiyr1qsYAsGAUoQAEKUIACFLAgAQZCC6kM6crYf5QPrv7vDmpWLonxQ7taSMkiFkMmDJHF3J+/eI1hfdvqnADFUgovk+IsWr0TQZ8/Y5WPu8WG14DAIAz3XgBZkiJ5ssT4fe1kSyGMUI6YdK9aLCILRgEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxEgIHQQiqCxaAABShAAQpQgAIUoAAFKGBuAQZCc4vzfBSgAAUoQAEKUIACFKAABSxE4P8A6DKop/IA4T8AAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if quantile_spreads:\n",
+    "    n_show = min(6, len(quantile_spreads))\n",
+    "    feats_to_show = list(quantile_spreads.keys())[:n_show]\n",
+    "    n_rows_fig = (n_show + 2) // 3\n",
+    "    fig = make_subplots(rows=n_rows_fig, cols=3, subplot_titles=feats_to_show)\n",
+    "    for idx, feat in enumerate(feats_to_show):\n",
+    "        r, c = divmod(idx, 3)\n",
+    "        q_means = quantile_spreads[feat][\"q_means\"]\n",
+    "        mono = monotonicity_scores.get(feat, 0)\n",
+    "        fig.add_trace(\n",
+    "            go.Bar(\n",
+    "                x=[f\"Q{i + 1}\" for i in range(len(q_means))],\n",
+    "                y=q_means,\n",
+    "                marker_color=[\n",
+    "                    \"#e74c3c\",\n",
+    "                    \"#f39c12\",\n",
+    "                    \"#95a5a6\",\n",
+    "                    \"#3498db\",\n",
+    "                    \"#2ecc71\",\n",
+    "                ],\n",
+    "                showlegend=False,\n",
+    "                text=[f\"{m:.4f}\" for m in q_means],\n",
+    "                textposition=\"outside\",\n",
+    "            ),\n",
+    "            row=r + 1,\n",
+    "            col=c + 1,\n",
+    "        )\n",
+    "    fig.update_layout(\n",
+    "        template=\"plotly_white\",\n",
+    "        height=250 * n_rows_fig,\n",
+    "        width=900,\n",
+    "        title_text=\"Quantile Mean Returns (Top FDR-Significant Features)\",\n",
+    "    )\n",
+    "    fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab210a0f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Interpretation**: Monotone quintile spreads (Q1 → Q5 increasing or\n",
+    "decreasing) confirm a robust relationship. Non-monotone patterns (e.g.,\n",
+    "U-shaped) suggest non-linear effects that may require interaction terms or\n",
+    "tree-based models to capture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "399cab4a",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "tags": []
+   },
+   "source": [
+    "## 5. Redundancy & Feature Families\n",
+    "\n",
+    "We group features into interpretive families and compute family-level IC\n",
+    "aggregates. Highly correlated feature pairs (|corr| > 0.7) flag redundancy\n",
+    "that downstream modeling should address via clustering or selection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6f132825",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:04.318642Z",
+     "iopub.status.busy": "2026-05-15T05:25:04.318279Z",
+     "iopub.status.idle": "2026-05-15T05:25:04.326621Z",
+     "shell.execute_reply": "2026-05-15T05:25:04.325596Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def assign_feature_family(feature_name: str) -> str:\n",
+    "    \"\"\"Map feature name to family based on prefix.\"\"\"\n",
+    "    FAMILY_MAP = [\n",
+    "        ([\"sharpe_\", \"risk_adj\"], \"risk_adj_momentum\"),\n",
+    "        ([\"skip_recent\", \"mom_\"], \"momentum\"),\n",
+    "        ([\"ret_\"], \"momentum\"),\n",
+    "        ([\"vol_ratio\"], \"vol_ratio\"),\n",
+    "        ([\"vol_\"], \"volatility\"),\n",
+    "        ([\"natr\", \"range_\", \"max_dd\"], \"volatility\"),\n",
+    "        ([\"rsi\", \"macd\", \"adx\", \"cci\", \"stoch\", \"aroon\", \"bb_\"], \"technical\"),\n",
+    "        ([\"sma_\", \"ema_\"], \"trend\"),\n",
+    "        ([\"yield_curve\", \"spy_tlt\", \"regime\", \"chop\", \"hurst\"], \"regime\"),\n",
+    "        ([\"rank_\"], \"cross_sectional\"),\n",
+    "        ([\"obv\", \"turnover\", \"volume\"], \"volume\"),\n",
+    "        ([\"pct_positive\", \"up_ratio\"], \"consistency\"),\n",
+    "        ([\"dist_\"], \"distance\"),\n",
+    "        ([\"corr_\"], \"correlation\"),\n",
+    "    ]\n",
+    "    for prefixes, family in FAMILY_MAP:\n",
+    "        if any(p in feature_name.lower() for p in prefixes):\n",
+    "            return family\n",
+    "    return \"other\"\n",
+    "\n",
+    "\n",
+    "families = {feat: assign_feature_family(feat) for feat in all_feature_cols}\n",
+    "\n",
+    "# Override temporal features with specific families\n",
+    "for feat in temporal_cols:\n",
+    "    if \"regime\" in feat.lower():\n",
+    "        families[feat] = \"temporal_regime\"\n",
+    "    elif \"ffd\" in feat.lower():\n",
+    "        families[feat] = \"temporal_ffd\"\n",
+    "    else:\n",
+    "        families[feat] = \"temporal_other\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "bcb9dbe1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:04.340330Z",
+     "iopub.status.busy": "2026-05-15T05:25:04.340124Z",
+     "iopub.status.idle": "2026-05-15T05:25:07.673984Z",
+     "shell.execute_reply": "2026-05-15T05:25:07.668918Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature pairs with |corr| > 0.7: 157\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pairwise correlation on sampled dates\n",
+    "sample_step = max(1, n_dates // 200)\n",
+    "sample_dates = eval_panel[DATE_COL].unique().sort().to_list()[::sample_step]\n",
+    "corr_data = (\n",
+    "    eval_panel.filter(pl.col(DATE_COL).is_in(sample_dates)).select(evaluable_features).to_pandas()\n",
+    ")\n",
+    "corr_matrix = corr_data.corr(method=\"spearman\")\n",
+    "\n",
+    "high_corr_pairs = []\n",
+    "cols = corr_matrix.columns\n",
+    "for i in range(len(cols)):\n",
+    "    for j in range(i + 1, len(cols)):\n",
+    "        if abs(corr_matrix.iloc[i, j]) > 0.7:\n",
+    "            high_corr_pairs.append((cols[i], cols[j], float(corr_matrix.iloc[i, j])))\n",
+    "\n",
+    "print(f\"Feature pairs with |corr| > 0.7: {len(high_corr_pairs)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b438101b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:07.702801Z",
+     "iopub.status.busy": "2026-05-15T05:25:07.702314Z",
+     "iopub.status.idle": "2026-05-15T05:25:07.721190Z",
+     "shell.execute_reply": "2026-05-15T05:25:07.719396Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (10, 5)\n",
+      "┌───────────────────┬────────────┬────────────┬───────────┬───────────┐\n",
+      "│ family            ┆ n_features ┆ avg_abs_ic ┆ avg_ic    ┆ n_fdr_sig │\n",
+      "│ ---               ┆ ---        ┆ ---        ┆ ---       ┆ ---       │\n",
+      "│ str               ┆ i64        ┆ f64        ┆ f64       ┆ i64       │\n",
+      "╞═══════════════════╪════════════╪════════════╪═══════════╪═══════════╡\n",
+      "│ temporal_other    ┆ 1          ┆ 0.049626   ┆ 0.049626  ┆ 0         │\n",
+      "│ volatility        ┆ 7          ┆ 0.044365   ┆ 0.033978  ┆ 0         │\n",
+      "│ distance          ┆ 2          ┆ 0.041219   ┆ 0.035135  ┆ 1         │\n",
+      "│ momentum          ┆ 14         ┆ 0.023319   ┆ 0.007958  ┆ 0         │\n",
+      "│ volume            ┆ 1          ┆ 0.014516   ┆ -0.014516 ┆ 0         │\n",
+      "│ trend             ┆ 3          ┆ 0.012244   ┆ 0.012244  ┆ 0         │\n",
+      "│ vol_ratio         ┆ 4          ┆ 0.010735   ┆ 0.002789  ┆ 0         │\n",
+      "│ technical         ┆ 8          ┆ 0.009498   ┆ -0.008539 ┆ 0         │\n",
+      "│ risk_adj_momentum ┆ 9          ┆ 0.008073   ┆ 0.001112  ┆ 0         │\n",
+      "│ regime            ┆ 2          ┆ 0.003418   ┆ 0.003418  ┆ 0         │\n",
+      "└───────────────────┴────────────┴────────────┴───────────┴───────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Family-level IC summary\n",
+    "family_ic = {}\n",
+    "fdr_sig_set = set(eval_summary.filter(pl.col(\"fdr_sig\").fill_null(False))[\"feature\"].to_list())\n",
+    "\n",
+    "for feat in ic_results:\n",
+    "    fam = families.get(feat, \"other\")\n",
+    "    family_ic.setdefault(fam, []).append(\n",
+    "        {\n",
+    "            \"feature\": feat,\n",
+    "            \"ic\": ic_results[feat][\"mean_ic\"],\n",
+    "            \"fdr_sig\": feat in fdr_sig_set,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "family_summary = {}\n",
+    "for fam, feats in sorted(family_ic.items()):\n",
+    "    ics = [f[\"ic\"] for f in feats if f[\"ic\"] is not None]\n",
+    "    n_sig = sum(1 for f in feats if f[\"fdr_sig\"])\n",
+    "    family_summary[fam] = {\n",
+    "        \"n_features\": len(feats),\n",
+    "        \"avg_abs_ic\": float(np.mean([abs(ic) for ic in ics])) if ics else 0.0,\n",
+    "        \"avg_ic\": float(np.mean(ics)) if ics else 0.0,\n",
+    "        \"n_fdr_sig\": n_sig,\n",
+    "    }\n",
+    "\n",
+    "if family_summary:\n",
+    "    fam_df = pl.DataFrame([{\"family\": fam, **stats} for fam, stats in family_summary.items()]).sort(\n",
+    "        \"avg_abs_ic\", descending=True\n",
+    "    )\n",
+    "else:\n",
+    "    fam_df = pl.DataFrame(\n",
+    "        schema={\n",
+    "            \"family\": pl.Utf8,\n",
+    "            \"n_features\": pl.Int64,\n",
+    "            \"avg_abs_ic\": pl.Float64,\n",
+    "            \"avg_ic\": pl.Float64,\n",
+    "            \"n_fdr_sig\": pl.Int64,\n",
+    "        }\n",
+    "    )\n",
+    "print(fam_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "023b2853",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:07.743975Z",
+     "iopub.status.busy": "2026-05-15T05:25:07.743428Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.099823Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.098752Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorscale": [
+          [
+           0.0,
+           "rgb(5,48,97)"
+          ],
+          [
+           0.1,
+           "rgb(33,102,172)"
+          ],
+          [
+           0.2,
+           "rgb(67,147,195)"
+          ],
+          [
+           0.3,
+           "rgb(146,197,222)"
+          ],
+          [
+           0.4,
+           "rgb(209,229,240)"
+          ],
+          [
+           0.5,
+           "rgb(247,247,247)"
+          ],
+          [
+           0.6,
+           "rgb(253,219,199)"
+          ],
+          [
+           0.7,
+           "rgb(244,165,130)"
+          ],
+          [
+           0.8,
+           "rgb(214,96,77)"
+          ],
+          [
+           0.9,
+           "rgb(178,24,43)"
+          ],
+          [
+           1.0,
+           "rgb(103,0,31)"
+          ]
+         ],
+         "type": "heatmap",
+         "x": [
+          "ret_5d",
+          "ret_10d",
+          "ret_21d",
+          "ret_42d",
+          "ret_63d",
+          "ret_126d",
+          "ret_189d",
+          "ret_252d",
+          "skip_recent_12_1",
+          "skip_recent_6_1",
+          "vol_21d",
+          "vol_63d",
+          "vol_126d",
+          "vol_252d",
+          "sharpe_5d",
+          "sharpe_10d",
+          "sharpe_21d",
+          "sharpe_42d",
+          "sharpe_63d",
+          "sharpe_126d",
+          "sharpe_189d",
+          "sharpe_252d",
+          "mom_accel_short",
+          "mom_accel_medium",
+          "mom_accel_long",
+          "vol_ratio_short",
+          "vol_ratio_medium",
+          "rsi_7",
+          "rsi_14",
+          "macd_line",
+          "adx_14",
+          "cci_14",
+          "cci_21",
+          "stoch_k",
+          "sma_ratio_50",
+          "sma_ratio_200",
+          "ema_ratio_26",
+          "bb_pctb_20",
+          "natr_14",
+          "chop_14",
+          "hurst_100",
+          "max_dd_63d",
+          "max_dd_126d",
+          "vol_ratio_21d",
+          "vol_ratio_63d",
+          "obv_zscore_63d",
+          "dist_52w_high",
+          "dist_52w_low",
+          "corr_spy_tlt_63d",
+          "ret_126d_rank",
+          "sharpe_126d_rank",
+          "yield_curve_slope",
+          "yield_curve_zscore",
+          "regime_prob_stress",
+          "regime_transition",
+          "regime_log_duration",
+          "ffd_spy",
+          "ffd_qqq",
+          "ffd_iwm",
+          "ffd_efa",
+          "ffd_eem",
+          "ffd_tlt",
+          "ffd_gld",
+          "ffd_vnq",
+          "ffd_hyg",
+          "ffd_lqd",
+          "garch_cond_vol"
+         ],
+         "y": [
+          "ret_5d",
+          "ret_10d",
+          "ret_21d",
+          "ret_42d",
+          "ret_63d",
+          "ret_126d",
+          "ret_189d",
+          "ret_252d",
+          "skip_recent_12_1",
+          "skip_recent_6_1",
+          "vol_21d",
+          "vol_63d",
+          "vol_126d",
+          "vol_252d",
+          "sharpe_5d",
+          "sharpe_10d",
+          "sharpe_21d",
+          "sharpe_42d",
+          "sharpe_63d",
+          "sharpe_126d",
+          "sharpe_189d",
+          "sharpe_252d",
+          "mom_accel_short",
+          "mom_accel_medium",
+          "mom_accel_long",
+          "vol_ratio_short",
+          "vol_ratio_medium",
+          "rsi_7",
+          "rsi_14",
+          "macd_line",
+          "adx_14",
+          "cci_14",
+          "cci_21",
+          "stoch_k",
+          "sma_ratio_50",
+          "sma_ratio_200",
+          "ema_ratio_26",
+          "bb_pctb_20",
+          "natr_14",
+          "chop_14",
+          "hurst_100",
+          "max_dd_63d",
+          "max_dd_126d",
+          "vol_ratio_21d",
+          "vol_ratio_63d",
+          "obv_zscore_63d",
+          "dist_52w_high",
+          "dist_52w_low",
+          "corr_spy_tlt_63d",
+          "ret_126d_rank",
+          "sharpe_126d_rank",
+          "yield_curve_slope",
+          "yield_curve_zscore",
+          "regime_prob_stress",
+          "regime_transition",
+          "regime_log_duration",
+          "ffd_spy",
+          "ffd_qqq",
+          "ffd_iwm",
+          "ffd_efa",
+          "ffd_eem",
+          "ffd_tlt",
+          "ffd_gld",
+          "ffd_vnq",
+          "ffd_hyg",
+          "ffd_lqd",
+          "garch_cond_vol"
+         ],
+         "z": {
+          "bdata": "AAAAAAAA8D/P6frM1mDjP2uEfSI0Xdg/1a073GKO1D8cdEV+a3nSP1engZYMz8Q/Lw7JNtXuwT9ULb7DTEPCP4pPw97E56U/5g8Ef+Xygz9PCDJ7MrhtP8pW5FmJ2JE/fMUOnlybpT9Lako4oTCTPxbQ82+ube0/oIR+Wc4Z4z97+yp8chnZP21p9ESQr9M/tc95qW1Y0T/DRk6nSIrEP0N7kDvUf8E/8jt4LHtRwj/ZmYd3RO6uvzJvn4MR5qQ/ZGKS60xpqb+Couip7Pmiv/cQLrK3WrO/mrrz4C5E6D9dzI+zzM/jP8dEV/CrZtI/LzbaQUX/ZD/K6fZB01boPysfJ9AV8eU/9CVWO2Be5z9dNcMYOhHePwjKab6l+80/C4+AqpEK5T82DMf8msrmP8lVrQfTBKO/k+6E6s2ktr8NSoLFXgCov+9yF0pIO9s/zUkX/SD81D9tANWROJDCvxZYPAQ1QcK/uiEyXWxF2D8H+ChCwC7QP+RLnRJt1co/DtCXoJainr+UuRyYUwHAPxfjJ0NGK7w/RF9dPytkZr9ChOMJKImUv8MZNQJfVbC/A+p9pB3lsL+Klyr09segv2tfyYxK28k/MlEAwwVqxT94UTY/aXfSP9HWxDq/1dI/XkGEssrx0j8YvohK+dOzP3THLyYMjMM/bBBe3nPU0j/35iyQP6DUP2MTN1Ujdc8/NuPq4PDcYL/P6frM1mDjPwAAAAAAAPA/HX7EeKLi4z+jykeGHoHbP7p17sN7htY/zW6A0SkEzD9fy1s3PPnFP1TBP13XTMI/wLlOZ4j3g7/BrV+UT1x/v9J8JY6u9JQ/ThaZeETrsD/lEYb8R4m2P653gi0SmLU/ElLWnSrv4j8ndjBqAnDtPzaNvjZkMOM//CjNRFs82j/oUsCPAXfVP93FUVR7/8s/8TRdcxLrxD87DNpp4j7BP5P1llOvEmW//twV230Pdr+jyBg8DpRnv8SloKGzJ7+/fsCIMm28qb+LPR/FOfHpP3AW7CTqTeg/JpD7coMy4T//SukvKGqdP3cb/BOyzek/P+TODYXS6T8+ANrPKd/pP/t7KhY8puQ/vdtDN7ln0z9rjIDKEP7pP1oP+nTcLuo/xlaJmZm1mr8dj9t3E8/Dv48Zip/ao5C/CHg5uMfX3j9u7WYsTG/XP6IIk8Z8nMS/5sme0U7lxb+WiaZPCiPfP2AIRUrNWtI/sA/OSuZ10z8NF96PwUqqvzPR56MsUcc/UuYERJh+xD9pLNOsSI+kvw3gJnsqMqk/ElLmp9CysL8/yBiZDJu6v3LDhwR8Klu/eYIlidjryD/7yJ0ox5PIP1F2RN9JEdE/EDmWHXdc0T8q/QuVWKnSP3yZK9rZ+qk/lJMOfrYywz8zHsCeJLjLP315PtmDu9I/AS3VXagNzT8krvzok6ljv2uEfSI0Xdg/HX7EeKLi4z8AAAAAAADwP7EDWnhEjeQ/9hdohxXX4D8TLEarwMbWP6fDP1DjIdM/SZ1TDLBOzz8hkamE8JZ6P5wObHTljXa/bwagbeWdtb+FX08kYjmhP5Gi1vV2ibA/JB30FJ0htj9EK+8wA53YP3Y+aOxBQuM/dZO5ZNhz7T8BMeIgtlDjP3mVn2c/gN8/Mux2rKkz1T+tZINIpyfRP+MUX33l8co/DG1uyk4BeT/fTFNjVuCQv75m5jlvmKC/ouCvDlM41b8nSUjvSB23v36Ku1i6quU/L0TDGnyn6T95Uqy+iTbqP5IlDh09O5W/h9F+sbQx4j8Xema3LE/nP+8Pe0X3fOI/c7PtykRv6z/MTG75Sw3eP5bEn2zBNes/Y9K+Z3Zr5j9tazUUvza4v5hNBYqnOLW/LsrMY5X1lj/GWpF8lCPjP9wLa63pyN4/tBRJ6AKgr79qfLd4Vi/Dv8NaF9gJc+I/860bPQ2M2D/d0KqaUZ3aP8E6Qr4ORHy/mGepmvkh0T9p75O1q53NP2ExznKaoH0/xTZAQ+mZrj/lbmGtSjbHv6bd6DL385k/a/Y2B9dQoD/NlordusnIP7sjj3n6McY/YGGfzf7P0T95RiszMX7SP/Mev19mz9Q//y31rLYokj9ODJWHwwi+P4QVuDPc6dA/W4/97tWD0D/lH5cRjEXNP3ZWzPz7SLe/1a073GKO1D+jykeGHoHbP7EDWnhEjeQ/AAAAAAAA8D8hC3zFAOnoP24OKTdz1uA/oP8PjEuJ2z/XRMHlAxvXPxZYn3J658k/lyUdJW2o0j8VVfOHc1PBv7/2nMcjbp6/MREGFMs6oj+2QeovRgK0P1fNWTbdX9Q/S5vtmLpZ2z+JgL3EM7PjP3UQd1xuSO0/oyQQWuTO5j/04TfEdfDeP+LOJzuW49g/yHzJ5VZP1D97SL23Nj7ev81BjTpy+5i/70ENy4G5pL+dFzIzKSTTv9yTOoFC68y/QUYuqoc44D/1O4KD3wrmP/SiHdHN7Og/I8YpBoBWqj91Pah3oDbaP3TGAJGNQuA/2xrkwDAP2z+s3ezHSzXsP4zOO2RYNeU/1Mos1PDC5j99kTRusJDfP8H5cywTbMK/7x0JqAropL/att6ylfJ8v2Z6GVo3TuU/Zh11rheA4j+BaxRl0GGWv26xahGwy7i/hfK234+F4z+lNSPXYEHeP1YxNovtG+E/8zeHul3knT8u6CmGWU3YPw42ezGvA9U/dg6iM6HQW79MUu0Uu568P/hbWPloTdK/1lHH6EmInj8cfvMd4M6bP03V/6GdLMw/Z+r7o+A/yz+BrPLsQKrSPyOkdWGNYNQ/TY0Jn/pl1D+a74a6JuqAPxSObjBYUL8/cQTyWJc2zz/npVgH7KrPP2Z5U0o3J8w/jTIFRUPKvr8cdEV+a3nSP7p17sN7htY/9hdohxXX4D8hC3zFAOnoPwAAAAAAAPA/T21diy4C5T9ai4knEDThP5aU49hDPdw/rL/0hyHw0z8wUyey2W3eP+ON2SoKG8O/mTUYXBIYt794iwhFof1rP+RMnH7w0LA/AHQDhr7M0j+Cq4FGXZ7XP0SkZa7QjeA/OPDGpvBu5z9TaHXT3BbtP4SRTuXeaeM/iWoPSKtO3z+B8vLwFD3ZP2Hvx5ByJem/1CBTUrfflr/M3HruGZukvyI2FJxU5Mi/5DwA2aVx1b/2rggbIP/bP7B2zFpuK+M/pQM/s8hI5T8SaeZ6YMamP+0Mx99U7NY/PlVRXiET3D+y2ZeDjWrXP6hB8tLuA+c/1vbQ3FkD6T8EfxDP30rjPwHn+L7uOts/7By+bbxHxL8VvnilWyWRv9g/U56u15u/Jg9cqE+U5D8wgAyBjzTkP8e18M6yfYO/Ps8n1qc0qL+jwX6U0QDiP2zFJFei/+A/nixVTfNz4z/UjYSZ1EWiPzt/hv3Kwd4/USSj6fjs2j8T7iQI9XpVP+hi7ubF2MI/LjptvE340r94cDfwSK+wPzkWj0pUFZk/nNiYUrEdzT8n1Nor4GvMP0har31Az9M/xAC+wp4L1T//2Gnp443WP8TS2al7n5o/1hh79GAYwj+feVD7BHTNPyAXvA+Hus8/3cv9N8sPzD85XazK1MrAv1engZYMz8Q/zW6A0SkEzD8TLEarwMbWP24OKTdz1uA/T21diy4C5T8AAAAAAADwPzKceNgjz+g/cBcvZpP65D+hcDgSMXziP0tHhZYUxuw/N+4z+SA4xb/Y2ND0G77Evxhwy5d41Lu/uLJqY4Atcz9zFFh/HLjHPwxCbII0MNA/Mp4IIMsC1z8sQCjehCzgP1bbYFm9L+Q/R/f9+Uze7D89p+4lE3bmP6LKuWcA9eI/LITyNkMc4b8/I/lYEDTmvwHU+rjOhq2/CAcfgCiBq7+ong83tIvLv6Hiw+/xztI/WoykvCR/2j9F4U8uWpTePw69hkYAIXw/Y8CRfMO7zD8//doye4LSP5HvyFJBSNA/FsLbroOz3j9UEnK/G17tPz6wJksofdk/abHmBQXy0T9HNfYtOXfGv/hWe4gCCm4/80BZHS/SsL9yBXRw9qzeP0Qnjj0XMeQ/ps19lj5MAD+sUaowHxx3v+TtFMt1Atk/8SZsEsRV4z9Jbb580QbmP+d3S5u5QsA/AJsxl5Ad5z/yTglJM9/jP6SEG8nQgaQ/BEi8OsuZyD+gQSVOrGDSv/ElSF1htr4/FhJqOUrmjT/UZ6Ixo8rMP8TPDO+rw8s/Tc7g4B/b0z9sOdOeLNDVP3UT7exh9NU/9U0cLGt9fT+pOtu6xtu/P5egq2ZOUco/6xW4Hfuvyj8z+1dDR0jGP/tEjr6h6cK/Lw7JNtXuwT9fy1s3PPnFP6fDP1DjIdM/oP8PjEuJ2z9ai4knEDThPzKceNgjz+g/AAAAAAAA8D9t/lt8VazqPyMpm1ATrug/kTp4fK9L5j9Tt82187TFv308SnKtB8a/0T2KRdg5xL/lEceekeesvzYCU+TM0cU/U6kWzus+yz9VPS81/+bTP55HRaX+Tds/Qzv8Vmnr4D+F2d96YjrnPwYClS6Dquw/+uHf1Ebo5z/y8JSrUS/cvz0a8SLP6OC/K/kd3YDI27+jnY5qIjqkv3QOj2HS8ri/VYQpLYPZzz+ErR2jGlLWP9n1zCMuzdk/Ih07ET/mVj9eYC8Mr5vHP/cQkXaX6s4//vaSpLUyzD8e3aZgVTzZP2pgtIXpqus/CkNiNtbg1D+yFXqx5S7OP+TOt8Nkhca/fRT0byc2Y7+zixlVb16bvyLnCGr2fNo/MuKAma5R4T/7XfvqSrCTP1n1xCkJ84c/1k86RBwr1D9to4j/pkDkP2AbwM5EDuY/Rvxr97NrtT/b+ptiUnviP+15bstoXuA/fzStaNA+tD/iuV9rv+vEP7EyZjMBR9S/Ype4UWmzuD8cuH8vuTx7P2o7dOE15s0/ORREJ7euyz8XnVny7G3UP1/kF5094NQ/OrNTqZzt0z+2bHkuxP+XP7mmWeR847g/zay2tKe3zD/NMJyYTM3KP2K75aCZxsM/T273I5fLw79ULb7DTEPCP1TBP13XTMI/SZ1TDLBOzz/XRMHlAxvXP5aU49hDPdw/cBcvZpP65D9t/lt8VazqPwAAAAAAAPA/erzCmryT7j/bfKokaPniP8rI8Y6jj8W/ybNrkcNexr+rJT5abZHFv80eSPoyo72/HArFMdAlxT8mos9RNaXHP28UhTHj/tA/hpB1b8/U1z+Rtjp5uYncPxk5H+t/AuQ/JBoceB6g6D9I8mB/IXLsP3rJITpYWte//92/Kdug3b8gAyhxyB/nv5yqXPm3JZe/ZACrAEwwrr9sQRPcgqbMP1X2lIflZNM/JMDJgzXf1T9d63Pke0QxvxJ4JHOFVcY/uND/ytZAyz8gRAldCerKPx1I5sfdydQ/pw5NQpVP5z8jtx1Raa7RP0OAP5Fakco/BnOiRc/xxb8qGW3p4sZ0P1dowZ5jQZC/7vf0QDny1j8aUNxO+BzePySXHq87BJQ/439Jh0EelT/zExlx9LHQP04P0JFnyuM/4TpQmdT44z+OEQJPY1C1PxvclmYTouA/5J35Jof03T+3ZY4GJ3O2P4bCOA2qzMA/oDbbYutJ0r8YXTJaTninP50xxFfv6J0/7J+G5dvWzT+KAWuCZunMPwf488d609I/GODOeeG10j+K0Nk12urSPy0a2jOm1Xg/ely9PD1kuT+RX53VgI/OP4zvrsqUicI/FPBUjRNBuj+VxsXtpJ3Dv4pPw97E56U/wLlOZ4j3g78hkamE8JZ6PxZYn3J658k/rL/0hyHw0z+hcDgSMXziPyMpm1ATrug/erzCmryT7j8AAAAAAADwPxTQkTkd5eM/ncZk+xscwb/mHqGF+kLGv6DpPZXnica/Q0tYduFHwL9ulpNGVCSxP3Lpx1UOr6E/5Y2x+pWuoz9IX25jQKzMP4YTbprAzdQ/V/ETTdqv4T/cjuDzDuzmP7pikK5hXus/fyZBqQgk2L/k25tGUePev8rS240iyue/rdjGtUlAsj8xunONiHegv+7QgeR5Saw/vn4xpvzmuj8FFH5TZSzCP9xFAdaaYZE/ylNC2QI/oj+XosmIBJOjP+qYZTYW9rE/XLi9RiMavj/jfLZHA77jP8IEan0amLE/Zof9X9iuoz9wpqWeuezAv1U4q9ltWZM/DdhX8wLelL/xEhDV8ZvKP7YXEB53hNY/cDvUAUJepD86KCmM3WqxP+AQ+3xWsb0/AMctvEa64D8qM6p+C0ThP2i+FMQ0L7Y/EgbFJpe13T8pmH2lQQLbP1+IYwDmsbc/BZd2w0t2vz/C2K/HrO3NvyvxZ6aaJZ0/YlYnKo0+jT/kDvTsfUrHP/Bj8+x3/cY/vHWOKj2ezD9F3+mYDpjMP1khLmr/Lsw/sU7Yg0DDgD8gK4yMa06zP+tG1OcL0MU/bQoa+DaTtT8/atUchGWqP/+ADCTGg72/5g8Ef+Xygz/BrV+UT1x/v5wObHTljXa/lyUdJW2o0j8wUyey2W3eP0tHhZYUxuw/kTp4fK9L5j/bfKokaPniPxTQkTkd5eM/AAAAAAAA8D+iW2uxyJe9vyVHRgZskcS/o4Yo7ekbvr/E3b8A/4pxv06vZA9GaaE/NB6LzcWGmz/u0Zxxk1+IPxM5w9/nRdI/LCWNhmqa3T/rgBC2ZzbqPzu6uRXDLuQ/g5cpEiIk4T+Sp+3sBaXiv5bVSuJBPui/cE3x660/p7+7odBWNt60Px48q9ti28a/eyBdW8CGoj94WdWd/eq8P0E3YJn04cY/fRlLn+EBlT+1sOPCpHqKPyD6xAg1W5g/eTs4kVCApD+YhAE8uJPFP2WyLgcLYug/6BGLgy31tT94iWvGwQGYP94FS6plZ76/WELjXKjNoD+uPM9BnZOzv+KH2j8y/88/C5ccCBSx3D+xwudXx6+ZP1BIMKssC64/TgwyCF19xj85SjeH7/HdPz4UqzdzkOI/yK+Ena9jvz/O/cVMPc3kP52iZ/wPK+I//hrz8U0ppj/SVlTtgX3IP1FS6pITeMu/k0+Di96kvD/UazAWGPuUvzFTzVhmHMQ/Q6z1kddoxD/Dp3siEDTLP2WS2D92zs4/8nuR4Crmzj8rKvS62+WDP9im+PAzibg/AMEfnE9guz9FkRsSxIm9P86sUqF4f7k/cng+OYuCt79PCDJ7MrhtP9J8JY6u9JQ/bwagbeWdtb8VVfOHc1PBv+ON2SoKG8O/N+4z+SA4xb9Tt82187TFv8rI8Y6jj8W/ncZk+xscwb+iW2uxyJe9vwAAAAAAAPA/Rv/ymIpz7T+TG4WZC8nrP5GUBZJ8Juo/GyMdszLOsb90Iq48aX64v4YIXG1NfM2/7gTNYGgs078S2qB5MPPUv5vWI1VbnNa/aCtGWiK0179yAUn4GlvYv6dzHOGO67g/y5yv8IXKoT+pdqprZFCfP1TvjzqzfNI/k80XIlfMzT9wbUO0keHAvxKZyQ6Rtsy/ye32k7R7xb/rXlkJMO6dvz32azX3kbS/wBmmVIWxwL+m6TbmFSi0v5BOCVv0qr2/4wr3ttkxyL8sxnx9Ap6wv5UBleN8Y8C/2LVMt0XE7j9ASHXvnpaPv05F47m4+qE/UY9nEjcd47/J07def0rkvwnGh73RWZa/D9nXJD7npT9NfqklskLMvw3HiFEbBeW/HLlrzTwt0T87hYho++ixv9ibOgPnq1Q/mPUMGXuVx7/mqWDw23OlP2m1RIs+IZ8/4tA9lGkD2z9LWg+vBi+jv2sFbBYJGMS/ce7WfENlwL95Jrh0+qrDvywVxIZw6ce/OtHjUHdWwb8ozV1Eg/63v/6g9RH09Kk/QL5rXl5rxT8vYLFe7WjAv52CZBiLVYk/APajEJiXjT9d4GfnoSDvP8pW5FmJ2JE/ThaZeETrsD+FX08kYjmhP7/2nMcjbp6/mTUYXBIYt7/Y2ND0G77Ev308SnKtB8a/ybNrkcNexr/mHqGF+kLGvyVHRgZskcS/Rv/ymIpz7T8AAAAAAADwP01WFVKtU+4/SltBFcVM7D+4tfZVQ/+svykrb3vBeai/RNXit3jaur9JrAKKcYzJvzz9qABEgtK/HD9teVMX179bmwJBMJLYv8sYDeSHiNm/P+oaQBLLvD/yzZccX3qyP2XKN/AxUqI/bfyEskjaqL/3f9gni9bOPyuhATp8J7K/4LxeG555wL8TXY7StyGrv0NhSq11QLW/68zXp2TVor+Yqpjg9E+vv3RZPM0fl6e/UCFSQgjsdz/E9QiMvWfEv5b32oD7KJo/5OpjzKOrsL9ZykH37yjuPy2uj7cvaZM/VWUVZU+ipT/NH3j6PNLgv5C6UIwPLOO/VdawsmJ+lL+ac9/AA9ajvwqEqmHFU8O/sy7AZd2F5L+H2Hxk1lHUP5wiphBA6ra/nLJ53SrNbr/UIH01LSXJvwy/31KTsqY/ZKa1golGqz/zPqh1yvPVP92ampFi7K2/0JcCbsxgx7+KsJcGJNS8v8l+4s/jHMG/y6QLrd/2wr8AzXtl0Xa7vzFEedFjqKW/a7T9n61Jkj+7ARkF9cjHP+LTUbOCKLy/V6Rt0d5noj8iIS0m3PuRPxysPx7pcO0/fMUOnlybpT/lEYb8R4m2P5Gi1vV2ibA/MREGFMs6oj94iwhFof1rPxhwy5d41Lu/0T2KRdg5xL+rJT5abZHFv6DpPZXnica/o4Yo7ekbvr+TG4WZC8nrP01WFVKtU+4/AAAAAAAA8D+W5+aZBjbuP9eNrz95/Jy/R//bqH5El79XcWo9vASyv3AB4dN9dsC/4DiUcDBNyL/t7FQF5sTUv5S8CVdflNi/j68aojz12b8KyLtxMz2VP0/Op/ZlA7Y/NB4VRkJWsz+N9LGuVamxvzq7O8ybi5q/KsiV/UU5o7+2wb6u34G0v1qeHM6aGzs/TzkejSdDur/eTDZaAlh+v4u3Xl+AxZW/bqTnZnq/mL9VHdPf5oqtP4kVCUTAE7m/OLsFsQ1FsT8qIQ+FcwKcvyo2yCm4vuw/6g5XuD1Jpz/pZW/oNdqKvyqffqtzFN2/FxqHdn0L4b+ISMi9ErWOv14vSkpUFaO/nJE3D3MBu7+ppqQEHjjjv12vvyTzU9g/J/rFsf1utL+XtZK6dLBTPx77FFK9jMm/5lWU3Fv7qj8O2b+LewW1P0D28MUZudA/jIuq+wXhqb+r/t82S2XGv5V1pTgsObi/ACbuq1Vru793SPnnKWm9v0qAvsciG7W/AXlRepyOdr+2MLOSbS2SP8ewBQd9l8o/HaC5HzMevL8JYawZS5euP296FcCFgaY/peKZCaoh7D9Lako4oTCTP653gi0SmLU/JB30FJ0htj+2QeovRgK0P+RMnH7w0LA/uLJqY4Atcz/lEceekeesv80eSPoyo72/Q0tYduFHwL/E3b8A/4pxv5GUBZJ8Juo/SltBFcVM7D+W5+aZBjbuPwAAAAAAAPA/dDwK/z/Tpr8GyiEh3wSUvxobjtBv76i/z9yendFgtr8nrjC3HdC/v6Uo/ZGOxcq/gfMW9MzG0r8e4hgiruXXv0bvtaiUo6O/Kti+m56igL+IrA/kJmC8P7d/qDG3766/iXULwBjltL9Ubg+nBkCjv6egnTQgp66/WDQK1Ru2oT9lNdHA5v+7vyacVMldppG/ffUdElX+j79j/Vsxyv+ev6qsMXFG2LY/enACFPqIez9sXQvn7gy1Pw/g8003NJi/HevOdf006z9zZdUEebGoP//3BkLNsKS//nkSlBfX2b97ic+6KVndv1ZBZxum34Q/fWaBMLAshL9QAwSLIaKzvx/MHXWfEOG/8LK+SysX3z8cgae5W+mxv8yrOpru5JY/ptnRRhN/xb+5QNixFza3P3+TCNtvYMA/Zc3/1z3QyT+ry9aRx0Zbv0Y56NfudMe/lWvVKQtDuL++4u2UYJa6vx/igp3Bk7i/Abg9trfprb/0OjsGNSGhP8V019IsHIY/Px93X2WZyz81lAqHpf+9v7JbEhTcJbU/QqPfy/KhrT9q52qNV7nqPxbQ82+ube0/ElLWnSrv4j9EK+8wA53YP1fNWTbdX9Q/AHQDhr7M0j9zFFh/HLjHPzYCU+TM0cU/HArFMdAlxT9ulpNGVCSxP06vZA9GaaE/GyMdszLOsb+4tfZVQ/+sv9eNrz95/Jy/dDwK/z/Tpr8AAAAAAADwP2Cp4jG6DuU/BAgmdpS23D/PhIYrvKHWP8OAHsX9e9Q/V5ondufUyz/+/G5ZEojJP0d7LG2Xcsk/f8yj8/PcsL8915BI94KQP2VT7zlIf6+/Hoqs3TGjqb+D2qV4oDC4v6dd/r05duo/A48QPr/G5T/6B8AbJD7TP20ND49r5Js/yFfQ+M3u6T91KJ/ngKPnP1jPLS4KM+k/fv7e2F6U3T+U3bWPo2rQP9fTQRORbOQ/CH3jnAaH6D9KZTlO6bq7v0RolRc8E8C/vbnuuwBIrb9auLgiPCLfP3TGgUXmc9k/sblDjf+Iwr8S+E/7avjBv7LAuxHUIdw/+bQtvnkT1T8XaO/nqXDHPwMH5TYv16C/nGvSZq7awD9EtBQHD1zEP3Eq6nh/EHu/6biWVuFylr/xQWrMfKy2vwBVZIoBBa6/+efSFKQNlr/9AhwMYdjJP7xBPRrCZ8U/dQW1CPjE0j/wbSxnzizTP/PwBi425tI/rT3u0IgqvT+aVYMG93HBP2KRdJzxK9M/yKei8sc41D/pdMg05ejQP5m0K9uwZrO/oIR+Wc4Z4z8ndjBqAnDtP3Y+aOxBQuM/S5vtmLpZ2z+Cq4FGXZ7XPwxCbII0MNA/U6kWzus+yz8mos9RNaXHP3Lpx1UOr6E/NB6LzcWGmz90Iq48aX64vykrb3vBeai/R//bqH5El78GyiEh3wSUv2Cp4jG6DuU/AAAAAAAA8D8QB9M+UWLlP5xSInUmct4/H88ZNklt2j+wbhqU2GzTP2pz09CIQdA/SlqTuwK4zD8cNnmdVGScvzYLpRDVOpe/hhMrMeMDnL+3RuspdtbBv6Bhql/ziLK/cTs447hr7D+j7xC7R9fqPxWhqUWIcuE/P6lj/9Qdsj/ZjEd3F17rP8J/XNUEk+s//ymoYN266z8s0RA7MBHkP7xlJuSPm9U/DZsKBJHp6D+NKZ/E0v7rPwKm41k5k8G/iyqYJGemyr84Ra6wiAiXv/bAEl4hJeI/ZZ5VcJ3E3T/wIAKcR+TDv9d38XSN3cW/Sz+PcBaZ4T9ooN5ygDXZPzK1UGcm2tA/1YJAVpHTpL+4LCKLHd3GP8E+pGwxfcs/zoVJVk91rL/69HkrPpukP+n8csBMKby/FyR88S80t7+dj94urSRsPwbNLlskjcw/y1hUt+Nayz8yR+gPjn/SP8n14aufmNM/g5M5+2QT1D/GN1xp+Hq1P50/9TSuAsM/VBBa4t+S0D9BnFLxJmvTP+k1BOhN6NA/mTcHEJ9kvr97+yp8chnZPzaNvjZkMOM/dZO5ZNhz7T+JgL3EM7PjP0SkZa7QjeA/Mp4IIMsC1z9VPS81/+bTP28UhTHj/tA/5Y2x+pWuoz/u0Zxxk1+IP4YIXG1NfM2/RNXit3jaur9XcWo9vASyvxobjtBv76i/BAgmdpS23D8QB9M+UWLlPwAAAAAAAPA/2CtXyGS35T81dVR24WviP9M82wFZSNo/5pHgLK2Q1j8HrtIhpE3TP+/EdjU4wni/T+GrVLgOlL8dAPnvdfCnv8iChG3R39a/NiX+ML/NvL+xqu95qCToP2jPk75WX+w/KiqYmyV66T+aA7GiXkewP4+QA6uuMOQ/cCIgIQEA6T/FK2XDWJnkP9rXbiK/4uk/jtrGChg03j8qSZJszc7pP1i4e0UkUOg/zqB99OaBzb9mbgh1uqC5v2wFpUnw6oI/JU1hn5L85T8yYOtM1aziP6KI0FSvzK6/qKfNioNowr8BInESwZXkP1TiFrcv698/Q7Yyx+Gg1T8ap4DtkmqLvxxzSTR9ddA/M5MZ+Vhw0z9UxPnKloJuvw9HCts0dac/DktGlgS/yr9SzzvJ7Yl8v67RPs4a9Kg/VSzJsygXyT8sk1CuDOPGP6GbFw6M+dE/UmJj3daO0j+LcZWuFWPUP9znP7YO4qg/X+zEp+O7uj8qW5WT/avRP55ouO/FRNA//CfwHPpDzz/0Os+en2zNv21p9ESQr9M//CjNRFs82j8BMeIgtlDjP3UQd1xuSO0/OPDGpvBu5z8sQCjehCzgP55HRaX+Tds/hpB1b8/U1z9IX25jQKzMPxM5w9/nRdI/7gTNYGgs079JrAKKcYzJv3AB4dN9dsC/z9yendFgtr/PhIYrvKHWP5xSInUmct4/2CtXyGS35T8AAAAAAADwP9iAfCa9nOk/C+hvJFsc4j9i/2BFaMHeP5aotjg31to/1e7vRoIZ3b8Ugj076sSTv/4UYxMCNa+/QV78uKVF07/xjpmzzvTOv9wVFq5l6eE/QEsnPQ1F6D/iwjiINjfoP86Gp+PXhMA/5BtQKxj03D/m+WgES8XhP48yTAyyzt0/HplBq8c46j/KSOtbyHPkP/uUQIrFYOU/BSdeNQpZ4T/VQgHpYovTvxvhO9H43qa/6VkQabYTl79Uvt6nlfHnP26aGAqD2uU/X5c3PgQZlr8SAUuzl8m2v1YnwnqWRuU/4X2Y+boV4z8Yt13w22fbP9eqaIpvy4Y/enA3w1un1j/FAC2B36zaP6Far+C6VpK/b1FIVv73tj+HNJBC4kjUvzjXATGDSYG/Z1yXlxkWqT89Rj7/ONHMPy61L6+FWsw/Sawd53e00j8n+MEFZ03UP16hLDY4jtM/t5q712dOpj8GL5f5Yri7P6JWfEdCeNA/I9ZUImXczj9xQ4QOsu7NPwYLeQr8FNK/tc95qW1Y0T/oUsCPAXfVP3mVn2c/gN8/oyQQWuTO5j9TaHXT3BbtP1bbYFm9L+Q/Qzv8Vmnr4D+Rtjp5uYncP4YTbprAzdQ/LCWNhmqa3T8S2qB5MPPUvzz9qABEgtK/4DiUcDBNyL8nrjC3HdC/v8OAHsX9e9Q/H88ZNklt2j81dVR24WviP9iAfCa9nOk/AAAAAAAA8D+8c+74LqHmP87cPXcI/eI/NruhtD0p4D/ltWZr/nPnv5+8i8NtyJ2/C4aXk693qr/5FZFyb43FvyMYQ/0+zNa/Lpzim3bv3j+J1hSGrSnlP3KfrZKly+Q/NWbmDOl4vT+wvKTcplDZPxlNI6dfyd4/uD8cQqXb2T9BoTiRzmblP65iYB5F0Oc/3BgT6XoO4j+2izZsEwLeP/YMfVmvqNW/gloEh3EIlL+JUvjuyeylv3bB9rSQTec/sXX5+Vat5z/RlTlQs4CGv21NcV1gvKO/tgO43TWG4z/q/uZC7DTlP+hwDb+ZzN4/siYGb7bmkD/vOctwSlvcP7yIChiyqeA/QNRp+XwZkL+ITpZJIGO8PwfbqZdR6NS/pnclIeIcnj+dIv4d9T6wPyCj+H/gds0/Xxo6vghLzT+1WjX/SaHTP6arHlPx3dQ/iUqUtOWT1T+eM8qrahaoP7YkeWJKaL0/pK8aHOL/zj8TVIHqhdLOP3bV2L+w3sw/bcqm5v7D07/DRk6nSIrEP93FUVR7/8s/Mux2rKkz1T/04TfEdfDeP4SRTuXeaeM/R/f9+Uze7D+F2d96YjrnPxk5H+t/AuQ/V/ETTdqv4T/rgBC2ZzbqP5vWI1VbnNa/HD9teVMX17/t7FQF5sTUv6Uo/ZGOxcq/V5ondufUyz+wbhqU2GzTP9M82wFZSNo/C+hvJFsc4j+8c+74LqHmPwAAAAAAAPA/DTWuWpT66T+1k3BJb53mP9EP/e46Xt+/EAFR1fB+5L/3lTwbniWwv3PxfVzMVqm/VWB95WDHx7/JJ5YWRcHVPxRP+aRkPN4/xKBelAPn3T8bOibWfN+sP6Hz1c1S9NA/+wf5Apw91T82gIa3YKPSP6xSSCdCv9w/wHtlv3nI6j+IrD3IxBjYP3M0NAhEstQ/oqZvUMJ4178F5FQTc26Fv80pg1EW57G/s0aqPpWv4j8wYMfNekvnP7yDv0+Dm3W/ciDvGAicer8mW5ZYk3jcP2c8Thx5T+c/Mgw0zpYo4T/GOkI5Lqu2Pxxrr1Y5JeQ/0nPo2Sg85z/cz5+X17OXP7ry58iep8M/kKJz7DEq079ZnYRKdj+2P0lfx02ACrA/6CRaPsb4zD/60xnFO1bMP5NoJWQWp9M/Nc33iag91T+zueao7p/VP2ihg1O9LKI/v6xyiSRSuj+cyGA8VevLP85r/ToCs8k/SLXPQgzCxz9SamCfi6TVv0N7kDvUf8E/8TRdcxLrxD+tZINIpyfRP+LOJzuW49g/iWoPSKtO3z89p+4lE3bmPwYClS6Dquw/JBoceB6g6D/cjuDzDuzmPzu6uRXDLuQ/aCtGWiK0179bmwJBMJLYv5S8CVdflNi/gfMW9MzG0r/+/G5ZEojJP2pz09CIQdA/5pHgLK2Q1j9i/2BFaMHeP87cPXcI/eI/DTWuWpT66T8AAAAAAADwPx1Texoan+s/j6IbJu9v2b8aDrlAYkPev1dAR0bnl9q//VZOqBphor8P4k+nFb2yv9MMueHwYdI/odi2KGth2T/vo0D5jZnYP9b3LGuxDaY/DFHnvQwMzD9Ndz1TPZ3RP0azed3f/c8/q6Q8H9br1j+F2CGuNtToP9/GqKZeCNM/yYLDvfFB0T+3L+CKZ2fYv0Wdzb+KLYm/uGlHKnQBoL+6HI05ZrfgP1HwITkBw+Q/ik/MCc+HhD+Ew13itJiAP8AcEf+1T9c/WMlqfhLs5z8frxNgvpHgP/xyMeirzas/c67eu2oA4D/PG7nTwzTjP+I0642rA60/YBJpM54FwT8jBrGoHMbUvyc15swlkK8/MXbvHAKlrT+nuk3Z6pjNPxbaOevYoss/jPoAYvzx0z/SUztG31bUP9k39ZcUe9M/plO9qtVhqT+yNbcvvsOyPwTACUSJhc4/qJucrfWvyT83U2A9aIvFPxM81jtJ/da/8jt4LHtRwj87DNpp4j7BP+MUX33l8co/yHzJ5VZP1D+B8vLwFD3ZP6LKuWcA9eI/+uHf1Ebo5z9I8mB/IXLsP7pikK5hXus/g5cpEiIk4T9yAUn4GlvYv8sYDeSHiNm/j68aojz12b8e4hgiruXXv0d7LG2Xcsk/SlqTuwK4zD8HrtIhpE3TP5aotjg31to/NruhtD0p4D+1k3BJb53mPx1Texoan+s/AAAAAAAA8D8797r1KbbUv+TebsNbcdq/9dpv+jY25b8RLv+XBWmUvz4KjqFnWaS/id0i5cXQ0D9I+mU8+17WPz9OjkQlfNQ/BYRmayrMqD9Ljz4a1ZvKP4T2D9iiX88/8BHiLfSuzj+MT8ocuojSPxIU6Makx+Q/4YpxV/HJzz9x4G1KNO7OP3f/28wW4di/5Ql6edvci7+QDGiYCz2Uv0iqdYAqYd4/oJsWAora4j+0Sgrfzet1Pyyx5k33hIc/U/SQcKKv0z8WOi1DwD3nPyq19mBu+9s/xPFrPAtFsD8dutZf2XHcP5YznsPIc+E/rAzSEWm1sD8SqNGbF8O6P5lyP9EU6dK/dvs5uUGpnT8m84eEVqC1P2zt3stGCs4/UzQaPSoazT84xFunhsbSP3y3mnENnNI/Ks5LuzIu0j+1ZiR3Qq+gP8QiLFe0wLA/o2OsNUNr0D8qVsVVRH/CP03M4nHwFr8/LZXFheK817/ZmYd3RO6uv5P1llOvEmW/DG1uyk4BeT97SL23Nj7ev2Hvx5ByJem/LITyNkMc4b/y8JSrUS/cv3rJITpYWte/fyZBqQgk2L+Sp+3sBaXiv6dzHOGO67g/P+oaQBLLvD8KyLtxMz2VP0bvtaiUo6O/f8yj8/PcsL8cNnmdVGScv+/EdjU4wni/1e7vRoIZ3b/ltWZr/nPnv9EP/e46Xt+/j6IbJu9v2b8797r1KbbUvwAAAAAAAPA/l4MwkqyOkj86Xj0yfCGiPxcG9hrE6Go/3ooXqml/1T+p/5ldrmCsv7VDtlOsQMW/CSqhMIM1z7+ixYxGhDKxvynX6AFVxKS/uV66mq1+pb+ilktTzPWkv298Y0CGBtK/EICIQHwT47/ZDVetbbzDvwWH9fXzb6S/6HUu/V+wuT9RreLglASjvx8/CX3bbKg/YkNrhbit1L+yGja9SMzZvyNlXtiNKqC/tjiM4wDPpr9P3jFptOjQv/NIHP8fp9a/kfaWoRo53b9R/HaceGalvxu8XH3sNtm/IjfV7mxH1r8Sz4zxP2hgP1/Z55uY38C/Hih4cxDYyz+fjGKf5Tewv5NM8bs3+Iw/uy4yndfQwb96ZDfWI+/Cv+1pIR8lysS/svNUBCZCyL/VQ3XH0sjJv9fpjvcSq4O/npRKaGE+ub8viVXcjbe2v83Uh32H0b2/GHAzGmclur+c4MIQEz6yPzJvn4MR5qQ//twV230Pdr/fTFNjVuCQv81BjTpy+5i/1CBTUrfflr8/I/lYEDTmvz0a8SLP6OC//92/Kdug3b/k25tGUePev5bVSuJBPui/y5yv8IXKoT/yzZccX3qyP0/Op/ZlA7Y/Kti+m56igL8915BI94KQPzYLpRDVOpe/T+GrVLgOlL8Ugj076sSTv5+8i8NtyJ2/EAFR1fB+5L8aDrlAYkPev+TebsNbcdq/l4MwkqyOkj8AAAAAAADwPwpPTYXgNaA/XxOeyxBPt78Abl1NlAuTv27Qhznya4G/tZuOW1t/l79yio6aLturvxZLa4Bk1Z4/Olocjo75ej/vv8fZeFGBv0pq1H9EypW//YMUxX2ej7/SasWnu2ffv/A0stIJq36/qMZozW2ic7/xbuQDgMahP3UdU9agN5W/TX5UoATssD+tUarcPwCqv/IZCcwTOM2/6YcfC+lCcD9gAvFsnSuYv6c9Qt+LPJa/g3P7LjNK0r/qusBOeZvZv3ft9IMe5ri/8k1rYkkC4L9x5X7g/FPcv4UnfJc3JrG/H9/k34rMwb+3RGMq2Pq4P7jJZxxvRLm/+Mya3drSoT+o0kII63W1v5hB7ugFKba/RjIdvfkdwL99GB1U56zDv10aivVcAcS/umN3jSn4lr9bVkgGAACuvxQhQvOgTaq/u381hVlRqr+66Arsf9aov86GkK4UA5o/ZGKS60xpqb+jyBg8DpRnv75m5jlvmKC/70ENy4G5pL/M3HruGZukvwHU+rjOhq2/K/kd3YDI278gAyhxyB/nv8rS240iyue/cE3x660/p7+pdqprZFCfP2XKN/AxUqI/NB4VRkJWsz+IrA/kJmC8P2VT7zlIf6+/hhMrMeMDnL8dAPnvdfCnv/4UYxMCNa+/C4aXk693qr/3lTwbniWwv1dAR0bnl9q/9dpv+jY25b86Xj0yfCGiPwpPTYXgNaA/AAAAAAAA8D835GgDxweBPxb1r4oqyLu/V0T+EY7Zp78hhY6aPayovztRE26c7Kq/Fyi8qrJ3jj9rlbhr/BelvzLnQXDZu6O/mC7JZb0Irr++kIvvA3mgv/O0kYkp08m/aomZKKlMob9XqqdsmMuhvzYaq44k4ZY/Kk0yvzk7ZD+6c2GBNXOmv64QHpFw06i/3pEggvFcsr85M2/xZQWev4AVQa+0852/RKy9yMLOlL+XKlkSGt7Pv/upmDhwq9G/BSOpSfQzgr+Q1Wtpivq4v6UAz7nM7rW/AeKJMfqbuL+F7JL3YsOev9bqRwY77Lo/iunarOEFnT+4P8ebIxiavwUsJdGetb2/7iXH2WO/u78u4+UCb+S+vwWu3Y85lby/SLuXf2UOvL8D7Gzd7c2Hv11tw7BJx5y/GmqtwPAxwb+2kP3x6lKgv9dMDaUJqHG/F7Li8YGUmz+Couip7Pmiv8SloKGzJ7+/ouCvDlM41b+dFzIzKSTTvyI2FJxU5Mi/CAcfgCiBq7+jnY5qIjqkv5yqXPm3JZe/rdjGtUlAsj+7odBWNt60P1TvjzqzfNI/bfyEskjaqL+N9LGuVamxv7d/qDG3766/Hoqs3TGjqb+3RuspdtbBv8iChG3R39a/QV78uKVF07/5FZFyb43Fv3PxfVzMVqm//VZOqBphor8RLv+XBWmUvxcG9hrE6Go/XxOeyxBPt7835GgDxweBPwAAAAAAAPA/D322V6T5sT+cjz6qNaPGvywlivWC2tG/YeRR/K3m1L997WWQltvHPwkx1M3DS8C/NP2Dz9ehyb8Co3qTotC4vzL+EX/F5NW/yBe7Z3zLvb/25jcQm3XQvxFRhruoH8e/DjDO2Ih8wz9/VEC7Ckm1vwddPvBNa26/Otr93Njlz7+YnO8lL9zEv5F89zzeL5C/FdioqRoiyz/EEQV0pYLNv3y3oxI037y/AS2XaV+Owb/FaKXn8EedPwZoY08u4W0/WLfD/SkSND+H6X34riSNv6rjZAPQuae/+miOpJT2zz8XCWch+V2kP+t5XEsht5a/tuuzHi8wqb9PAR7IYcivvzYcpnwhDry/TKx5Icvst7/NtI5nOmLEv48q3rHR/LU/ziXEdnFrgr9GorKdcF+kv+uCqMNEcrC/ptEVtPOrk78Pb08pVeTMP/cQLrK3WrO/fsCIMm28qb8nSUjvSB23v9yTOoFC68y/5DwA2aVx1b+ong83tIvLv3QOj2HS8ri/ZACrAEwwrr8xunONiHegvx48q9ti28a/k80XIlfMzT/3f9gni9bOPzq7O8ybi5q/iXULwBjltL+D2qV4oDC4v6Bhql/ziLK/NiX+ML/NvL/xjpmzzvTOvyMYQ/0+zNa/VWB95WDHx78P4k+nFb2yvz4KjqFnWaS/3ooXqml/1T8Abl1NlAuTvxb1r4oqyLu/D322V6T5sT8AAAAAAADwP5MZbVUmPrq/NF6oiJdNxL+EB2ARmXzEvyzG2mZAyLU/18d9IXKOtb8S9uBxAZO+v8R+dz45CbG/Wvo+bvvlxL9Rmha+e5zNv3OOGkRL4MC/UT6nmMvKvL9/6u+WB+TKP5X6AqcVHbC/uuhhxjwfwz+xf+V1vG7Rv9tPZt0f5NC/HV99NQoRpb+sZ6g7DvSZvyBejRg6xMS/f+hlLagSxr89RtbY8r3Hvz/ksTmkyK+/3NOmvowfmr8dpct26BaWv2OwQ+2clae/GENXvb9nrb/1fQovrCrUP2Qh2sJVRrW/132M9hfZtr8w1xswPnKlv+aItq5vBbG/mqT5Vzk7u79FEA4vfWq3v+6zEqmVM8C/MXi+PylLpD8dR9vVpBmBv0ELluzBepY/E+Ox/BF9s7/mgnZoBVClv/lwf8iEkMk/mrrz4C5E6D+LPR/FOfHpP36Ku1i6quU/QUYuqoc44D/2rggbIP/bP6Hiw+/xztI/VYQpLYPZzz9sQRPcgqbMP+7QgeR5Saw/eyBdW8CGoj9wbUO0keHAvyuhATp8J7K/KsiV/UU5o79Ubg+nBkCjv6dd/r05duo/cTs447hr7D+xqu95qCToP9wVFq5l6eE/Lpzim3bv3j/JJ5YWRcHVP9MMueHwYdI/id0i5cXQ0D+p/5ldrmCsv27Qhznya4G/V0T+EY7Zp7+cjz6qNaPGv5MZbVUmPrq/AAAAAAAA8D/yXiCrV+/tP43JpU/5qOI/B6cxhnHssT9nNL5gsfvtPzKPezWNAe4/7BoMSOkq7j/fHTgazuTmPzy6AGerE9k/1Hq44Y7j6z/sQNm3Ob7uP2CmrKfCg8W/VlmQTpDgxr/K6m3MYsakv42tJOdoVeU/n04uWoKP4T87sYX4gNnDv0CcUNsIysa/2MPgN5B04z+2nIeasWfdPxgpzyVudtI/QRRThHa+pr+AUuZt3H7KPxtNwulL7M4/lgovr/HqoL9xWCGZLDOXPy+C12qorcO/Nq0HnVlbs7/CeD/9HSeDvzrRxjBvh9A/UtXP2A/XzT+H/8lkCkHWP614O/ARFdc/1tpablj21z//kcvhexW7P58yAMNgocM/DAGswYXv1T+eMdi90sjWPwqJdcFFONM/fzEhcUYHwr9dzI+zzM/jP3AW7CTqTeg/L0TDGnyn6T/1O4KD3wrmP7B2zFpuK+M/WoykvCR/2j+ErR2jGlLWP1X2lIflZNM/vn4xpvzmuj94WdWd/eq8PxKZyQ6Rtsy/4LxeG555wL+2wb6u34G0v6egnTQgp66/A48QPr/G5T+j7xC7R9fqP2jPk75WX+w/QEsnPQ1F6D+J1hSGrSnlPxRP+aRkPN4/odi2KGth2T9I+mU8+17WP7VDtlOsQMW/tZuOW1t/l78hhY6aPayovywlivWC2tG/NF6oiJdNxL/yXiCrV+/tPwAAAAAAAPA/0rK4vs/G6D9tpPtTgwG5P/pw2HOl3+o/6scRUZlS7T9+o4jGxTPrP7Ac/O/mpes/iJu/110q4T8zmG44pVztP7qzZI3NZO0/4wcJGtPKz79if0HbwcXDv8L5sWdds5y/e8yP1OAO6T+jo8Ru+HvlP9wzwpaVqry/arNix0xHxb9o7of1KKTmP3lnvud+SeI/N4b4gf8W2D9eJ64pUuKbvxwUyDFNldI/cthT1iHH1T8KT9UFEzKhv7PZdWEBeKw/nWeOKPKlzr8U+fFzdY+tv7yYNnvcyos/maZ20/Ii0T8TRc7YrrHPP6g1nLaHPdc/z8kTEwwm2D9gU/I+COPYP93hcH6IfrY/xEqX26Newz/WU4khpAfWP9ObuQSn0dU/6qAXuQNk0z9Mu2Tjp9DMv8dEV/CrZtI/JpD7coMy4T95Uqy+iTbqP/SiHdHN7Og/pQM/s8hI5T9F4U8uWpTeP9n1zCMuzdk/JMDJgzXf1T8FFH5TZSzCP0E3YJn04cY/ye32k7R7xb8TXY7StyGrv1qeHM6aGzs/WDQK1Ru2oT/6B8AbJD7TPxWhqUWIcuE/KiqYmyV66T/iwjiINjfoP3KfrZKly+Q/xKBelAPn3T/vo0D5jZnYPz9OjkQlfNQ/CSqhMIM1z79yio6aLturvztRE26c7Kq/YeRR/K3m1L+EB2ARmXzEv43JpU/5qOI/0rK4vs/G6D8AAAAAAADwP2HmCBkwJ4c/cFT6Or5q3j81N5RpJmTkPxK6JxuIlN8//lpqrfl47D/yMbfThVzjP3IUP+YhEOk/CpcnrQhn4z+c4sC80MrGvy6nLqr0n7K/c0PK/iZegz/ee6CyLXvlP4KFRZ6LkOI/6zO6GkWepb+zX2Lkk5HAvy4QncBE7uM/GPyzgiqe3z8EZk6rDzDfPy4d5v1RfaY/UR8/+RjW1T+Zqo6X+X7UPzi6PM0LIKm/TTRC/u+nvD8ii8FFe57Qv5doNbJZ93c/J28VImisoD9Ey17RNObQP7NVgAdDl9A/wO6WUJkc1T8SyhLVRp7VP1QWk5935NQ/iLOLpZtToD9ogEFbT9bCP3AdEzyMJNI/LOFDzLJY0T8W67ELIVHQP6qwq5lZAMa/LzbaQUX/ZD//SukvKGqdP5IlDh09O5W/I8YpBoBWqj8SaeZ6YMamPw69hkYAIXw/Ih07ET/mVj9d63Pke0Qxv9xFAdaaYZE/fRlLn+EBlT/rXlkJMO6dv0NhSq11QLW/TzkejSdDur9lNdHA5v+7v20ND49r5Js/P6lj/9Qdsj+aA7GiXkewP86Gp+PXhMA/NWbmDOl4vT8bOibWfN+sP9b3LGuxDaY/BYRmayrMqD+ixYxGhDKxvxZLa4Bk1Z4/Fyi8qrJ3jj997WWQltvHPyzG2mZAyLU/B6cxhnHssT9tpPtTgwG5P2HmCBkwJ4c/AAAAAAAA8D/KefGdOAScP/OC8LEqdng/Xf9ua93LrD8IZK6Us5+cP9KLHINRgZk/CcFDgj1ljz+a2Yl2gt6VP2k7ZAdbTJa/sYjMJxeX07+dICTRd/auP84LyzjEBaU/t+TH3u5OtD8bUZKGNtalP+98/dkoBcM/5gLfVdNBrz+LGEWw4GSzP9dFxG2poLO/TAIgFOUklL98OPdr7+uwPzM+gOmAY78/Vj6uCkIIhL8sONhRzfiUP4Bzwk/9z7g/y1wfHsiHmr+PZj9QTwipv9X6A/N8g5W/72sYX9zNob/m+JQVIzOVv9IJMsc886W/wemvfaLDqr/jl/6qk42kP+9F3GTlC42/SxEJNcrMPb8XEs3QKHuYvzdqQZio94O/ER/PHhySg7/K6fZB01boP3cb/BOyzek/h9F+sbQx4j91Pah3oDbaP+0Mx99U7NY/Y8CRfMO7zD9eYC8Mr5vHPxJ4JHOFVcY/ylNC2QI/oj+1sOPCpHqKPz32azX3kbS/68zXp2TVor/eTDZaAlh+vyacVMldppG/yFfQ+M3u6T/ZjEd3F17rP4+QA6uuMOQ/5BtQKxj03D+wvKTcplDZP6Hz1c1S9NA/DFHnvQwMzD9Ljz4a1ZvKPynX6AFVxKS/Olocjo75ej9rlbhr/Belvwkx1M3DS8C/18d9IXKOtb9nNL5gsfvtP/pw2HOl3+o/cFT6Or5q3j/KefGdOAScPwAAAAAAAPA/7GGDoGPy7T9TQ7R30NntP9lEsZD8ruM/JeChMWWf0z/BG0HOHaLpP/RykA6NKO4/ahnhf7F9vr+PUIo6yxq9vyTib+AC1Ki/lQplJylo4j8jZJo0k4vdP5iEYIj+BsS/wWIukLp8xb+bV9nSttvgP3s5ILcrXtg/Ax6RWHJyzj9iaIDOzYexv/JdANzwysM/H88pLAbPxz/I690b44KQv3nNP9BpVkg/1Z6WGnUXur84GMyR1yizv77cYLplz6G/Gtnyax4ozD9rxxYmuYfJP5pOEsXAo9M/jtNoKuKb1D9dPfdxuPvVP+vqACirYbs/nXtL4Liywj+VjVivzaDTP6CWLYi/l9Q/5sJhKyrx0D//2/nVHua3vysfJ9AV8eU/P+TODYXS6T8Xema3LE/nP3TGAJGNQuA/PlVRXiET3D8//doye4LSP/cQkXaX6s4/uND/ytZAyz+XosmIBJOjPyD6xAg1W5g/wBmmVIWxwL+Yqpjg9E+vv4u3Xl+AxZW/ffUdElX+j791KJ/ngKPnP8J/XNUEk+s/cCIgIQEA6T/m+WgES8XhPxlNI6dfyd4/+wf5Apw91T9Ndz1TPZ3RP4T2D9iiX88/uV66mq1+pb/vv8fZeFGBvzLnQXDZu6O/NP2Dz9ehyb8S9uBxAZO+vzKPezWNAe4/6scRUZlS7T81N5RpJmTkP/OC8LEqdng/7GGDoGPy7T8AAAAAAADwP/cuTGgMlOw/1v+aJ+J65z9kZab+zNbYP26BDQ+j5es/oCz/7miK7z8o0iUetvDEv1M/hzqz5sC/u+4uT2vKqb8F36qKhw/lPzOZaFQQMOE/bfJ5uj0Dwb+I3okpdBLGv49cCZZxMOM/WGvuORSX3D9Y3GRBXevSP9C5giWSQ6i/ifUzT5ztyD92ENW61nLNP6zLyEW7OZS/vlKO4SIxnT8FbueLtgfEv6YVeKvaCKu/Kwvp6WpGkb8LcJUXMlfOPzGtOYsfz8s/HERxEfLs1D+m4F5DkNPVP9gwuTVx/NY/khkI83SMtz+GGDuhlO7CP5TSFJVljtQ/i6qIoCgy1T894s/4uwrSP1U8t1z+OcK/9CVWO2Be5z8+ANrPKd/pP+8Pe0X3fOI/2xrkwDAP2z+y2ZeDjWrXP5HvyFJBSNA//vaSpLUyzD8gRAldCerKP+qYZTYW9rE/eTs4kVCApD+m6TbmFSi0v3RZPM0fl6e/bqTnZnq/mL9j/Vsxyv+ev1jPLS4KM+k//ymoYN266z/FK2XDWJnkP48yTAyyzt0/uD8cQqXb2T82gIa3YKPSP0azed3f/c8/8BHiLfSuzj+ilktTzPWkv0pq1H9EypW/mC7JZb0Irr8Co3qTotC4v8R+dz45CbG/7BoMSOkq7j9+o4jGxTPrPxK6JxuIlN8/Xf9ua93LrD9TQ7R30NntP/cuTGgMlOw/AAAAAAAA8D/7ttS7ouvjP5hrrhPZpNU/iF9S3sPB6T949JyekK/tPyZaF8NjAsC/ZLAMdV38xL8k6uD6l8Wiv9GQoJsiIuM/bcsVBAVg3z+nwmFbXX/Fv5Nwv4E1XcW/bHgaZmL04D+mAdpDg2faP4RGUXNjrNA/YOtAYMqkqr9TvI52O1HHP9TW6jozeMo/0UR23O5Snb9Nw8TiHX6HPwlnm6Xmor2/tKnHh6rqt7/trswaXfOhv08KxKRogc8/jXCGWKm9zD/K2M0cwK3UPxZ9BUoXt9U/3NLA43t41j+LDbofIMa9P64TCiguycM/CLF1FUAL1T9knhzZFPrVP6eQ3z1Oi9I/mrbg5NYNuL9dNcMYOhHeP/t7KhY8puQ/c7PtykRv6z+s3ezHSzXsP6hB8tLuA+c/FsLbroOz3j8e3aZgVTzZPx1I5sfdydQ/XLi9RiMavj+YhAE8uJPFP5BOCVv0qr2/UCFSQgjsdz9VHdPf5oqtP6qsMXFG2LY/fv7e2F6U3T8s0RA7MBHkP9rXbiK/4uk/HplBq8c46j9BoTiRzmblP6xSSCdCv9w/q6Q8H9br1j+MT8ocuojSP298Y0CGBtK//YMUxX2ej7++kIvvA3mgvzL+EX/F5NW/Wvo+bvvlxL/fHTgazuTmP7Ac/O/mpes//lpqrfl47D8IZK6Us5+cP9lEsZD8ruM/1v+aJ+J65z/7ttS7ouvjPwAAAAAAAPA/u6aRHQrS4z/CzAmON3XtPweG6ZjU+uY/YS6vtRjJwL8TY+1TiXC2v+wkbrxrwWG/kAXKjNL35j8/Q9GJDA7jPwH3oYQjCrG/iJ7nhql9w7+RYuhBM5nlPzoyODb7v94/vfS0Luu04D9oRpCIXHeEv52lXD0DvdY/donkS1W00z+da0oWjq1+v3jz4ufCp7k/n8wQ9kKK0L90sL30G+2Fv8OPQ05Uy30/tKminO1Xzz88RJvHimjNP+ax5GhZmdU/B7YQonzC1j9wV8API4fYP5LjDc+lYpw/WbfJ6w2kwz+Kpe6c6PXSP0FGBFbbUNQ/AE3Lew8k0T/+YBGVqrS7vwjKab6l+80/vdtDN7ln0z/MTG75Sw3eP4zOO2RYNeU/1vbQ3FkD6T9UEnK/G17tP2pgtIXpqus/pw5NQpVP5z/jfLZHA77jP2WyLgcLYug/4wr3ttkxyL/E9QiMvWfEv4kVCUTAE7m/enACFPqIez+U3bWPo2rQP7xlJuSPm9U/jtrGChg03j/KSOtbyHPkP65iYB5F0Oc/wHtlv3nI6j+F2CGuNtToPxIU6Makx+Q/EICIQHwT47/SasWnu2ffv/O0kYkp08m/yBe7Z3zLvb9Rmha+e5zNvzy6AGerE9k/iJu/110q4T/yMbfThVzjP9KLHINRgZk/JeChMWWf0z9kZab+zNbYP5hrrhPZpNU/u6aRHQrS4z8AAAAAAADwP3OWKBPap+A/m+YIl4wu2D/7WKLGEXzJv8XTtg8BRIm/zHnYy7OMqb8CO6mujOTiP7YIhmVqaOY/Rlj/lwQBdz8E0FDy0U+Sv72OH2GrMt8/OZtCLevr5T93o7cdguHnP3leHeJB8rg/864xpKZ95T8GXZow0IziPzCmEutEWKU/0j7LuEq/xz+oWJiEbNjVv4V2fxmFpLs/YUZWa2Ougz+oNKOi3LfQP0ZtjBaKEtA/uXMmoqum1j+kSmKRYRrYPz7ZBrAetNc/wTCVUUSwnj+m8lj/FxLCP2C360ezKdA/Bl5ZWict0D+Cceb5bZHLPw/jN93q8MW/C4+AqpEK5T9rjIDKEP7pP5bEn2zBNes/1Mos1PDC5j8EfxDP30rjPz6wJksofdk/CkNiNtbg1D8jtx1Raa7RP8IEan0amLE/6BGLgy31tT8sxnx9Ap6wv5b32oD7KJo/OLsFsQ1FsT9sXQvn7gy1P9fTQRORbOQ/DZsKBJHp6D8qSZJszc7pP/uUQIrFYOU/3BgT6XoO4j+IrD3IxBjYP9/GqKZeCNM/4YpxV/HJzz/ZDVetbbzDv/A0stIJq36/aomZKKlMob/25jcQm3XQv3OOGkRL4MC/1Hq44Y7j6z8zmG44pVztP3IUP+YhEOk/CcFDgj1ljz/BG0HOHaLpP26BDQ+j5es/iF9S3sPB6T/CzAmON3XtP3OWKBPap+A/AAAAAAAA8D91aOUAP+vrP0cQU1wPArm/HnoQU+jjwL8JlK2nGnKMv4JTXfhswOU/FQ+b9naX4T8Y/OTct1C/v3AzlKmC/Ma/+Xg74SCG5D/BG0Y2khzcP/AfE7xiCN0/XIutXKdbmb+d50LbnAXTP9QldjQ3bdA/waQJ48aMlL/jAtO95yWwP9jxdNv19si/R/J2iR47o7+IHVbOKVWIvx92YkeO8dA/0yujAwfRzj8f1OofX0DXP9Pv+pJ4Btg/ygnFQdne2T/WDzfd/aemPzOxx1YrxcU/i3i9FEdI1T/Iaz7LSt/WPzy3gQaQ1dE/UIpN2miMsb82DMf8msrmP1oP+nTcLuo/Y9K+Z3Zr5j99kTRusJDfPwHn+L7uOts/abHmBQXy0T+yFXqx5S7OP0OAP5Fakco/Zof9X9iuoz94iWvGwQGYP5UBleN8Y8C/5OpjzKOrsL8qIQ+FcwKcvw/g8003NJi/CH3jnAaH6D+NKZ/E0v7rP1i4e0UkUOg/BSdeNQpZ4T+2izZsEwLeP3M0NAhEstQ/yYLDvfFB0T9x4G1KNO7OPwWH9fXzb6S/qMZozW2ic79XqqdsmMuhvxFRhruoH8e/UT6nmMvKvL/sQNm3Ob7uP7qzZI3NZO0/CpcnrQhn4z+a2Yl2gt6VP/RykA6NKO4/oCz/7miK7z949JyekK/tPweG6ZjU+uY/m+YIl4wu2D91aOUAP+vrPwAAAAAAAPA/jK1JlsfixL/ff5iIHwDCv/W6Xc5US6u/Ee/j9RAJ5T9v7RaH/ifhPw2+ARlfl8G/ZX9FqfWFxb++0A0gNvviP9ulCIC0fdw/Mr4MXDAY0j/GFR5A2nGmv/7DLcEmPcg/tf8/kZt2zD+KjNdpLkievx8wGveVPJY/fDre3BQxxL/UAljPy2OwvwAYi7nO1JC/O0mLN9lF0D/kmKLpc7DNP6n6cfvU5tU/+kb2XC6B1j+TAJNTvrXXP5KMN7Fxs7g/QZspY7YAxD/AYO3/9IPVP2CqgHRcgdY//pi7ri+t0j8CW/VKiLrBv8lVrQfTBKO/xlaJmZm1mr9tazUUvza4v8H5cywTbMK/7By+bbxHxL9HNfYtOXfGv+TOt8Nkhca/BnOiRc/xxb9wpqWeuezAv94FS6plZ76/2LVMt0XE7j9ZykH37yjuPyo2yCm4vuw/HevOdf006z9KZTlO6bq7vwKm41k5k8G/zqB99OaBzb/VQgHpYovTv/YMfVmvqNW/oqZvUMJ417+3L+CKZ2fYv3f/28wW4di/6HUu/V+wuT/xbuQDgMahPzYaq44k4ZY/DjDO2Ih8wz9/6u+WB+TKP2CmrKfCg8W/4wcJGtPKz7+c4sC80MrGv2k7ZAdbTJa/ahnhf7F9vr8o0iUetvDEvyZaF8NjAsC/YS6vtRjJwL/7WKLGEXzJv0cQU1wPArm/jK1JlsfixL8AAAAAAADwPwBVhThjHZo/gARhq30Rnj/yT8Q9icTjv7YmqZJx6eS/wKn14hKAlD/Vs7/1C5muP8OCILGuys6/o8Hl3XOZ5b/2AY1MXanRPzcm5Yev6LO/NcUK6qlGar/8jP3lfR/Ivz47lCf30Ks/FsP1g5xInz9txXpBSY/aP58mcJQoSZq/iG7axmlexr9rCw863ufCv3RVfw+tnMa/7PlKm8BGyr8nU+xLLInEv33MdQdZvre/zyMsZmGeoz+7hMYZHxjGP/xNAEELCcS/uJeYHeQbkb86DjDmmSKRvyD4EswexO4/k+6E6s2ktr8dj9t3E8/Dv5hNBYqnOLW/7x0JqAropL8VvnilWyWRv/hWe4gCCm4/fRT0byc2Y78qGW3p4sZ0P1U4q9ltWZM/WELjXKjNoD9ASHXvnpaPvy2uj7cvaZM/6g5XuD1Jpz9zZdUEebGoP0RolRc8E8C/iyqYJGemyr9mbgh1uqC5vxvhO9H43qa/gloEh3EIlL8F5FQTc26Fv0Wdzb+KLYm/5Ql6edvci79RreLglASjv3UdU9agN5W/Kk0yvzk7ZD9/VEC7Ckm1v5X6AqcVHbC/VlmQTpDgxr9if0HbwcXDvy6nLqr0n7K/sYjMJxeX07+PUIo6yxq9v1M/hzqz5sC/ZLAMdV38xL8TY+1TiXC2v8XTtg8BRIm/HnoQU+jjwL/ff5iIHwDCvwBVhThjHZo/AAAAAAAA8D/v5cjnuyKsv1ydm0pyRLO/+9YzKOIop7+9eraOsO+uv0pxX5bUcrS/+/6s9woytb8jIRe0q9+lv1ItnPn8RaA/KGH/Gc/bob+wSjbFinx7v+HWkWNIsom/h7nY1L0hwD/kD0xZi9+FPxUMU69Ou4m/hvCA2D85pL8TnptqMGafP3QCoVMRh7W/wo9NdXXHtL9cjZsOGW6mvzmFf+vAAqW/sdrJPnknlT8mq4YWb5Wkv+0A1a/MCJM/fYVd7j4yt7++um+rWeahv1pY6ZjPEq+/fYk8LsMwob8NSoLFXgCov48Zip/ao5C/LsrMY5X1lj/att6ylfJ8v9g/U56u15u/80BZHS/SsL+zixlVb16bv1dowZ5jQZC/DdhX8wLelL+uPM9BnZOzv05F47m4+qE/VWUVZU+ipT/pZW/oNdqKv//3BkLNsKS/vbnuuwBIrb84Ra6wiAiXv2wFpUnw6oI/6VkQabYTl7+JUvjuyeylv80pg1EW57G/uGlHKnQBoL+QDGiYCz2Uvx8/CX3bbKg/TX5UoATssD+6c2GBNXOmvwddPvBNa26/uuhhxjwfwz/K6m3MYsakv8L5sWdds5y/c0PK/iZegz+dICTRd/auPyTib+AC1Ki/u+4uT2vKqb8k6uD6l8Wiv+wkbrxrwWG/zHnYy7OMqb8JlK2nGnKMv/W6Xc5US6u/gARhq30Rnj/v5cjnuyKsvwAAAAAAAPA/upblPa8LtL/N1bQQ8d62v99GIuQ9v1+/VDtahHikjr/4m/7G/I2jv4/fXHSHXLK/KOMexXYipr8zJsEsJuONP82eFGBMeKG/4QrvCCNCrL+eYeVMtpinv/L59qPEL6u/sdQCt/LKsT+0tmNPxBWdPy8kMYjE8IG/KuV3KogWpb+btNOTXnaQv1k7/NKwfq+/t5VEjBv7tb9VT0gCrnW9vwCXLKNs34K/PEUwQVHttr/sbjnaLax6v3gcaUVIa7C/ZAZ2jXN6mr/73OURyl2gP+9yF0pIO9s/CHg5uMfX3j/GWpF8lCPjP2Z6GVo3TuU/Jg9cqE+U5D9yBXRw9qzePyLnCGr2fNo/7vf0QDny1j/xEhDV8ZvKP+KH2j8y/88/UY9nEjcd47/NH3j6PNLgvyqffqtzFN2//nkSlBfX2b9auLgiPCLfP/bAEl4hJeI/JU1hn5L85T9Uvt6nlfHnP3bB9rSQTec/s0aqPpWv4j+6HI05ZrfgP0iqdYAqYd4/YkNrhbit1L+tUarcPwCqv64QHpFw06i/Otr93Njlz7+xf+V1vG7Rv42tJOdoVeU/e8yP1OAO6T/ee6CyLXvlP84LyzjEBaU/lQplJylo4j8F36qKhw/lP9GQoJsiIuM/kAXKjNL35j8CO6mujOTiP4JTXfhswOU/Ee/j9RAJ5T/yT8Q9icTjv1ydm0pyRLO/upblPa8LtL8AAAAAAADwPy7Sk9rrOu0/p5kX8vHjo7/YeHoDIHy4v2fbfb6ZPuQ/ZdKfYgkk6j98ljyX6n/MPzB8zaM5ZZw/rS1QvKy+0j8autmZfOPYP8xJ+mPDq5S/EDk5EoHXoz82uvHnipjYvxKMBEDiiXw/m2AbIoZKtD/gZgmEypLQPwSDkUk+XdA/39w8XU0c1z+v61esFGrXPzch00l67NU/cTKk4OT2rD/LG8PvBjymP3Hc2uY/HdQ/UhyPFfmf0D+YA4JV6mHOP3BLQXJ17OK/zUkX/SD81D9u7WYsTG/XP9wLa63pyN4/Zh11rheA4j8wgAyBjzTkP0Qnjj0XMeQ/MuKAma5R4T8aUNxO+BzeP7YXEB53hNY/C5ccCBSx3D/J07def0rkv5C6UIwPLOO/FxqHdn0L4b97ic+6KVndv3TGgUXmc9k/ZZ5VcJ3E3T8yYOtM1aziP26aGAqD2uU/sXX5+Vat5z8wYMfNekvnP1HwITkBw+Q/oJsWAora4j+yGja9SMzZv/IZCcwTOM2/3pEggvFcsr+YnO8lL9zEv9tPZt0f5NC/n04uWoKP4T+jo8Ru+HvlP4KFRZ6LkOI/t+TH3u5OtD8jZJo0k4vdPzOZaFQQMOE/bcsVBAVg3z8/Q9GJDA7jP7YIhmVqaOY/FQ+b9naX4T9v7RaH/ifhP7YmqZJx6eS/+9YzKOIop7/N1bQQ8d62vy7Sk9rrOu0/AAAAAAAA8D+zifCaQWSbvx9FaPzLb6u/bz8SeFsr4j8sIZH0mVLtP/1CFrfUytA/9D8NLAx2rT/JIXncgPrZP62A0fd08d8/zh8UJoWTa78pzukQdGaxP4/akzNictm/pm9wFSBwoT8umZ0bPeW0PwX8BLwwNtA/RKNXPsoU0D+NFIQRYivWP273SMV04NY/00yL5ZSQ1D8F9L/aT/KpP8eJK0N+xqA/ezhNhZyq0j9PAc9ASwnMP8Ldr+snC8o/8iiy+AUH5L9tANWROJDCv6IIk8Z8nMS/tBRJ6AKgr7+BaxRl0GGWv8e18M6yfYO/ps19lj5MAD/7XfvqSrCTPySXHq87BJQ/cDvUAUJepD+xwudXx6+ZPwnGh73RWZa/VdawsmJ+lL+ISMi9ErWOv1ZBZxum34Q/sblDjf+Iwr/wIAKcR+TDv6KI0FSvzK6/X5c3PgQZlr/RlTlQs4CGv7yDv0+Dm3W/ik/MCc+HhD+0Sgrfzet1PyNlXtiNKqC/6YcfC+lCcD85M2/xZQWev5F89zzeL5C/HV99NQoRpb87sYX4gNnDv9wzwpaVqry/6zO6GkWepb8bUZKGNtalP5iEYIj+BsS/bfJ5uj0Dwb+nwmFbXX/FvwH3oYQjCrG/Rlj/lwQBdz8Y/OTct1C/vw2+ARlfl8G/wKn14hKAlD+9eraOsO+uv99GIuQ9v1+/p5kX8vHjo7+zifCaQWSbvwAAAAAAAPA/sGUyq31g7D9cZe3FpQ2svwFNPSanHoa/7mJH0jKOZb9pOQnGxTehPyYDrsA3KpE/0mNVQJYchj+h1MIZX5ufP+vqTgzKYqu/v6lOSDUHiD9v/7wtcui9P0xyG4FCxaE/0PvYhi5zub+8kSB1vZu4v2On8rKXjbm/Qwipp/wrwb+BO5TfJTe2v3sd7wEiUIe/6M4ucf/7rr/Y/RSd/VC7vwm7O9JZh8C/9ZUDMkkItb9vH3OEqC5iPxZYPAQ1QcK/5sme0U7lxb9qfLd4Vi/Dv26xahGwy7i/Ps8n1qc0qL+sUaowHxx3v1n1xCkJ84c/439Jh0EelT86KCmM3WqxP1BIMKssC64/D9nXJD7npT+ac9/AA9ajv14vSkpUFaO/fWaBMLAshL8S+E/7avjBv9d38XSN3cW/qKfNioNowr8SAUuzl8m2v21NcV1gvKO/ciDvGAicer+Ew13itJiAPyyx5k33hIc/tjiM4wDPpr9gAvFsnSuYv4AVQa+0852/FdioqRoiyz+sZ6g7DvSZv0CcUNsIysa/arNix0xHxb+zX2Lkk5HAv+98/dkoBcM/wWIukLp8xb+I3okpdBLGv5Nwv4E1XcW/iJ7nhql9w78E0FDy0U+Sv3AzlKmC/Ma/ZX9FqfWFxb/Vs7/1C5muP0pxX5bUcrS/VDtahHikjr/YeHoDIHy4vx9FaPzLb6u/sGUyq31g7D8AAAAAAADwP0PjJAtyMre/ahKnJzpinb/QF3G20vmfvx0yaqlTqqc/LGIal1aamz8jlikRWkWYP/dwjvqc6aA/ct50erZQoL/05iDC5hu1P3bnDYIO8Lw/DcMBe1Otij8b1Uxi25i5v8TK3dr1O7q/lRY644Juvb/XU9ykiJvCv87MKCe+mLy/EFOqDMiEiT9OdhlEGmuov0N4NtIefry/WcRp8X+Dwb/3ecpIXR22v4qmNiIbBqw/uiEyXWxF2D+WiaZPCiPfP8NaF9gJc+I/hfK234+F4z+jwX6U0QDiP+TtFMt1Atk/1k86RBwr1D/zExlx9LHQP+AQ+3xWsb0/TgwyCF19xj9NfqklskLMvwqEqmHFU8O/nJE3D3MBu79QAwSLIaKzv7LAuxHUIdw/Sz+PcBaZ4T8BInESwZXkP1YnwnqWRuU/tgO43TWG4z8mW5ZYk3jcP8AcEf+1T9c/U/SQcKKv0z9P3jFptOjQv6c9Qt+LPJa/RKy9yMLOlL/EEQV0pYLNvyBejRg6xMS/2MPgN5B04z9o7of1KKTmPy4QncBE7uM/5gLfVdNBrz+bV9nSttvgP49cCZZxMOM/bHgaZmL04D+RYuhBM5nlP72OH2GrMt8/+Xg74SCG5D++0A0gNvviP8OCILGuys6/+/6s9woytb/4m/7G/I2jv2fbfb6ZPuQ/bz8SeFsr4j9cZe3FpQ2sv0PjJAtyMre/AAAAAAAA8D/91v4a0erePzoVecmLLtU/LQt4CWJHj79xkrGJX+nQP/QoDLoMtNM/mGyQD8YCk7/ueWhlRai0P8/vYryo5Mu/NtwBMYBYl7/eEYo+n5KjP/we8SKcrck/v3jVb0t4yD+KFt+Lq7bRPw44N7EgntI/43uflWyg0z/U3m2lJ8S0P+TEaFKv970/iThxG2xqzz8nO8muLArQPzeSB2epzc4/tQchY9uly78H+ChCwC7QP2AIRUrNWtI/860bPQ2M2D+lNSPXYEHeP2zFJFei/+A/8SZsEsRV4z9to4j/pkDkP04P0JFnyuM/AMctvEa64D85SjeH7/HdPw3HiFEbBeW/sy7AZd2F5L+ppqQEHjjjvx/MHXWfEOG/+bQtvnkT1T9ooN5ygDXZP1TiFrcv698/4X2Y+boV4z/q/uZC7DTlP2c8Thx5T+c/WMlqfhLs5z8WOi1DwD3nP/NIHP8fp9a/g3P7LjNK0r+XKlkSGt7Pv3y3oxI037y/f+hlLagSxr+2nIeasWfdP3lnvud+SeI/GPyzgiqe3z+LGEWw4GSzP3s5ILcrXtg/WGvuORSX3D+mAdpDg2faPzoyODb7v94/OZtCLevr5T/BG0Y2khzcP9ulCIC0fdw/o8Hl3XOZ5b8jIRe0q9+lv4/fXHSHXLK/ZdKfYgkk6j8sIZH0mVLtPwFNPSanHoa/ahKnJzpinb/91v4a0erePwAAAAAAAPA/X2ceh310zz+M+jmQckesPy+vW+UJ29o/7K+c+Bfa4D+eQLHKVJSHv3x+v3lFq7I/bKoqBdup2b+vxGHigXiYPzMqVt3W/LQ/FuLaUzvG0D9stLY6JS3RPykM+yoFYdU/vj0RcoK41D9KkcvbJlTSP0SdjeuDMaY/5z6N7VhalD/cQcwmspTSP0rHJOv+qcU/1YssTeuKxD+vVa07wrvkv+RLnRJt1co/sA/OSuZ10z/d0KqaUZ3aP1YxNovtG+E/nixVTfNz4z9Jbb580QbmP2AbwM5EDuY/4TpQmdT44z8qM6p+C0ThPz4UqzdzkOI/HLlrzTwt0T+H2Hxk1lHUP12vvyTzU9g/8LK+SysX3z8XaO/nqXDHPzK1UGcm2tA/Q7Yyx+Gg1T8Yt13w22fbP+hwDb+ZzN4/Mgw0zpYo4T8frxNgvpHgPyq19mBu+9s/kfaWoRo53b/qusBOeZvZv/upmDhwq9G/AS2XaV+Owb89RtbY8r3HvxgpzyVudtI/N4b4gf8W2D8EZk6rDzDfP9dFxG2poLO/Ax6RWHJyzj9Y3GRBXevSP4RGUXNjrNA/vfS0Luu04D93o7cdguHnP/AfE7xiCN0/Mr4MXDAY0j/2AY1MXanRP1ItnPn8RaA/KOMexXYipr98ljyX6n/MP/1CFrfUytA/7mJH0jKOZb/QF3G20vmfvzoVecmLLtU/X2ceh310zz8AAAAAAADwP+gLI0MwppU/wSshElZn4D91BB/38pXWP9LpEWwDOb0/lV3BvxQp0D/nIIRpKKjDv2WG72w+ALA/AHsFNa9+pr8P6ZrTW/bEPxo6eOLbo8Q/aRHLEQVozj9gp5tEwoDQP4WY8LoREdU/GKGulI0jmT+p3mQlts/LP5PJLVDQRME/LsJH1SqIzj8QVs76vZHKPxedo+abWNI/DtCXoJainr8NF96PwUqqv8E6Qr4ORHy/8zeHul3knT/UjYSZ1EWiP+d3S5u5QsA/Rvxr97NrtT+OEQJPY1C1P2i+FMQ0L7Y/yK+Ena9jvz87hYho++ixv5wiphBA6ra/J/rFsf1utL8cgae5W+mxvwMH5TYv16C/1YJAVpHTpL8ap4DtkmqLv9eqaIpvy4Y/siYGb7bmkD/GOkI5Lqu2P/xyMeirzas/xPFrPAtFsD9R/HaceGalv3ft9IMe5ri/BSOpSfQzgr/FaKXn8EedPz/ksTmkyK+/QRRThHa+pr9eJ64pUuKbvy4d5v1RfaY/TAIgFOUklL9iaIDOzYexv9C5giWSQ6i/YOtAYMqkqr9oRpCIXHeEv3leHeJB8rg/XIutXKdbmb/GFR5A2nGmvzcm5Yev6LO/KGH/Gc/bob8zJsEsJuONPzB8zaM5ZZw/9D8NLAx2rT9pOQnGxTehPx0yaqlTqqc/LQt4CWJHj7+M+jmQckesP+gLI0MwppU/AAAAAAAA8D8KnjlQzEBVvzVjb5FTLmW/xINOCI4s3r+pT/7XSF7OPy2m9WIHDrm/rELTGEaFrD/pwiJx1KLDP6BuUIZkS98/mcsZe51p4D/3BV+AEWbVP83CQtnD+tU/6phjIogtrz8KZzSrisfZv6kjk44gsaM/2gDpgjDkrD+tki1/1W+5P4xm8HdkFLu/72NgeIH0sL+UuRyYUwHAPzPR56MsUcc/mGepmvkh0T8u6CmGWU3YPzt/hv3Kwd4/AJsxl5Ad5z/b+ptiUnviPxvclmYTouA/EgbFJpe13T/O/cVMPc3kP9ibOgPnq1Q/nLJ53SrNbr+XtZK6dLBTP8yrOpru5JY/nGvSZq7awD+4LCKLHd3GPxxzSTR9ddA/enA3w1un1j/vOctwSlvcPxxrr1Y5JeQ/c67eu2oA4D8dutZf2XHcPxu8XH3sNtm/8k1rYkkC4L+Q1Wtpivq4vwZoY08u4W0/3NOmvowfmr+AUuZt3H7KPxwUyDFNldI/UR8/+RjW1T98OPdr7+uwP/JdANzwysM/ifUzT5ztyD9TvI52O1HHP52lXD0DvdY/864xpKZ95T+d50LbnAXTP/7DLcEmPcg/NcUK6qlGar+wSjbFinx7v82eFGBMeKG/rS1QvKy+0j/JIXncgPrZPyYDrsA3KpE/LGIal1aamz9xkrGJX+nQPy+vW+UJ29o/wSshElZn4D8KnjlQzEBVvwAAAAAAAPA/4t0hgDBu6j8UJqqBbmF5v5IGg6+S83O/JWU1HdQgaT8j38JuMOZMv8crsbjidmO/f2Bj3We0YD9PZex6tQRkP7doqenufVY/HC4JhhhrdL/1mZ+C2RhWv22QjWyP/0E/C0fLXWXUZj9D4MCL4V1ZPwjiqfO5Dma/9ukCyUxCZb8BzuZPgAZiPxfjJ0NGK7w/UuYERJh+xD9p75O1q53NPw42ezGvA9U/USSj6fjs2j/yTglJM9/jP+15bstoXuA/5J35Jof03T8pmH2lQQLbP52iZ/wPK+I/mPUMGXuVx7/UIH01LSXJvx77FFK9jMm/ptnRRhN/xb9EtBQHD1zEP8E+pGwxfcs/M5MZ+Vhw0z/FAC2B36zaP7yIChiyqeA/0nPo2Sg85z/PG7nTwzTjP5YznsPIc+E/IjfV7mxH1r9x5X7g/FPcv6UAz7nM7rW/WLfD/SkSND8dpct26BaWvxtNwulL7M4/cthT1iHH1T+Zqo6X+X7UPzM+gOmAY78/H88pLAbPxz92ENW61nLNP9TW6jozeMo/donkS1W00z8GXZow0IziP9QldjQ3bdA/tf8/kZt2zD/8jP3lfR/Iv+HWkWNIsom/4QrvCCNCrL8autmZfOPYP62A0fd08d8/0mNVQJYchj8jlikRWkWYP/QoDLoMtNM/7K+c+Bfa4D91BB/38pXWPzVjb5FTLmW/4t0hgDBu6j8AAAAAAADwP8Y9JuhN6IS/pXTX2EP6bb+hYL3pFkFyPxdG8MtIt3e/UHnYRQoxSb93glQ1GetfP72QwJuOGGA/x1WYY6BYKr8Awqj9+saBv6T84ZUo3na/bOZraeprYz9jRa/wDQB5P2vrDD0pPV0/gTR2t3nxc78kuSif9sdmv7epbQFzVci/RF9dPytkZr9pLNOsSI+kv2ExznKaoH0/dg6iM6HQW78T7iQI9XpVP6SEG8nQgaQ/fzStaNA+tD+3ZY4GJ3O2P1+IYwDmsbc//hrz8U0ppj/mqWDw23OlPwy/31KTsqY/5lWU3Fv7qj+5QNixFza3P3Eq6nh/EHu/zoVJVk91rL9UxPnKloJuv6Far+C6VpK/QNRp+XwZkL/cz5+X17OXP+I0642rA60/rAzSEWm1sD8Sz4zxP2hgP4UnfJc3JrG/AeKJMfqbuL+H6X34riSNv2OwQ+2clae/lgovr/HqoL8KT9UFEzKhvzi6PM0LIKm/Vj6uCkIIhL/I690b44KQv6zLyEW7OZS/0UR23O5Snb+da0oWjq1+vzCmEutEWKU/waQJ48aMlL+KjNdpLkievz47lCf30Ks/h7nY1L0hwD+eYeVMtpinv8xJ+mPDq5S/zh8UJoWTa7+h1MIZX5ufP/dwjvqc6aA/mGyQD8YCk7+eQLHKVJSHv9LpEWwDOb0/xINOCI4s3r8UJqqBbmF5v8Y9JuhN6IS/AAAAAAAA8D97ZViibmm7P/Jzbp9SYZ4/Z3ASDqIykj9magZ/xwXIP5eYe4JyCOO/DiBus4hg5L8owuTcjL3Sv7P7p5J1iNC/RAt3V4xpjz+uvU0MEGihv19qKpx1c7+/WqjTviAI0b/vEpnCr17Cv/FwEAGercW/QVaPmD/Jpz9ChOMJKImUvw3gJnsqMqk/xTZAQ+mZrj9MUu0Uu568P+hi7ubF2MI/BEi8OsuZyD/iuV9rv+vEP4bCOA2qzMA/BZd2w0t2vz/SVlTtgX3IP2m1RIs+IZ8/ZKa1golGqz8O2b+LewW1P3+TCNtvYMA/6biWVuFylr/69HkrPpukPw9HCts0dac/b1FIVv73tj+ITpZJIGO8P7ry58iep8M/YBJpM54FwT8SqNGbF8O6P1/Z55uY38C/H9/k34rMwb+F7JL3YsOev6rjZAPQuae/GENXvb9nrb9xWCGZLDOXP7PZdWEBeKw/TTRC/u+nvD8sONhRzfiUP3nNP9BpVkg/vlKO4SIxnT9Nw8TiHX6HP3jz4ufCp7k/0j7LuEq/xz/jAtO95yWwPx8wGveVPJY/FsP1g5xInz/kD0xZi9+FP/L59qPEL6u/EDk5EoHXoz8pzukQdGaxP+vqTgzKYqu/ct50erZQoL/ueWhlRai0P3x+v3lFq7I/lV3BvxQp0D+pT/7XSF7OP5IGg6+S83O/pXTX2EP6bb97ZViibmm7PwAAAAAAAPA/efh26YWgvr82aPHBVs+qv6rRlTErLqG/yYdN/9T1yz9nXW1M+mfFP1jGov1Fy84/OzG1ew0c0z8EhGfcUw7QPwD0JZ5Yy82/1886fFdr1D9aTI7geneSvz1At53bxtM/admBitAKvD8Y5Opt//akP8MZNQJfVbC/ElLmp9CysL/lbmGtSjbHv/hbWPloTdK/LjptvE340r+gQSVOrGDSv7EyZjMBR9S/oDbbYutJ0r/C2K/HrO3Nv1FS6pITeMu/4tA9lGkD2z/zPqh1yvPVP0D28MUZudA/Zc3/1z3QyT/xQWrMfKy2v+n8csBMKby/DktGlgS/yr+HNJBC4kjUvwfbqZdR6NS/kKJz7DEq078jBrGoHMbUv5lyP9EU6dK/Hih4cxDYyz+3RGMq2Pq4P9bqRwY77Lo/+miOpJT2zz/1fQovrCrUPy+C12qorcO/nWeOKPKlzr8ii8FFe57Qv4Bzwk/9z7g/1Z6WGnUXur8FbueLtgfEvwlnm6Xmor2/n8wQ9kKK0L+oWJiEbNjVv9jxdNv19si/fDre3BQxxL9txXpBSY/aPxUMU69Ou4m/sdQCt/LKsT82uvHnipjYv4/akzNictm/v6lOSDUHiD/05iDC5hu1P8/vYryo5Mu/bKoqBdup2b/nIIRpKKjDvy2m9WIHDrm/JWU1HdQgaT+hYL3pFkFyP/Jzbp9SYZ4/efh26YWgvr8AAAAAAADwP7OnDsUFlL8/g2k7MWERzr9GaeIvpSHSv/Onk0SxINS/SCk5euhg2L/Bz3GaL+LTvxLeLjftj8a/8drdymdVuj9hz0QzpuTDP4ROqTSTJdC/Hr6x+DNpu7/9TDBoXZOjv0mGvuYETtg/A+p9pB3lsL8/yBiZDJu6v6bd6DL385k/1lHH6EmInj94cDfwSK+wP/ElSF1htr4/Ype4UWmzuD8YXTJaTninPyvxZ6aaJZ0/k0+Di96kvD9LWg+vBi+jv92ampFi7K2/jIuq+wXhqb+ry9aRx0ZbvwBVZIoBBa6/FyR88S80t79SzzvJ7Yl8vzjXATGDSYG/pnclIeIcnj9ZnYRKdj+2Pyc15swlkK8/dvs5uUGpnT+fjGKf5Tewv7jJZxxvRLm/iunarOEFnT8XCWch+V2kP2Qh2sJVRrW/Nq0HnVlbs78U+fFzdY+tv5doNbJZ93c/y1wfHsiHmr84GMyR1yizv6YVeKvaCKu/tKnHh6rqt790sL30G+2Fv4V2fxmFpLs/R/J2iR47o7/UAljPy2Owv58mcJQoSZq/hvCA2D85pL+0tmNPxBWdPxKMBEDiiXw/pm9wFSBwoT9v/7wtcui9P3bnDYIO8Lw/NtwBMYBYl7+vxGHigXiYP2WG72w+ALA/rELTGEaFrD8j38JuMOZMvxdG8MtIt3e/Z3ASDqIykj82aPHBVs+qv7OnDsUFlL8/AAAAAAAA8D9Xv8Z48CPEv6c41OeH/Zw/facX2CJRlj8Z6HOS26aHv62KY8SzHag/q5JQ+ZZSpD8/uVbdjyKfPw6bp+87XZI/Wc4gxicosT8z/rqX+7qfv5SmEfFFgZM/YI13owfBo7+Klyr09segv3LDhwR8Klu/a/Y2B9dQoD8cfvMd4M6bPzkWj0pUFZk/FhJqOUrmjT8cuH8vuTx7P50xxFfv6J0/YlYnKo0+jT/UazAWGPuUv2sFbBYJGMS/0JcCbsxgx7+r/t82S2XGv0Y56NfudMe/+efSFKQNlr+dj94urSRsP67RPs4a9Kg/Z1yXlxkWqT+dIv4d9T6wP0lfx02ACrA/MXbvHAKlrT8m84eEVqC1P5NM8bs3+Iw/+Mya3drSoT+4P8ebIxiav+t5XEsht5a/132M9hfZtr/CeD/9HSeDv7yYNnvcyos/J28VImisoD+PZj9QTwipv77cYLplz6G/Kwvp6WpGkb/trswaXfOhv8OPQ05Uy30/YUZWa2Ougz+IHVbOKVWIvwAYi7nO1JC/iG7axmlexr8TnptqMGafPy8kMYjE8IG/m2AbIoZKtD8umZ0bPeW0P0xyG4FCxaE/DcMBe1Otij/eEYo+n5KjPzMqVt3W/LQ/AHsFNa9+pr/pwiJx1KLDP8crsbjidmO/UHnYRQoxSb9magZ/xwXIP6rRlTErLqG/g2k7MWERzr9Xv8Z48CPEvwAAAAAAAPA/zOe+AHVwuL/boVxawoC5v3JUZs3QoqS/eB7CUDSukb8vRrooqCTAv8/wArY1Xcu/jtX1nBA91L88/ti441bCv/dUODdEx8i//RqwFGwozb+1tYpx5PDCv2tfyYxK28k/eYIlidjryD/NlordusnIP03V/6GdLMw/nNiYUrEdzT/UZ6Ixo8rMP2o7dOE15s0/7J+G5dvWzT/kDvTsfUrHPzFTzVhmHMQ/ce7WfENlwL+KsJcGJNS8v5V1pTgsObi/lWvVKQtDuL/9AhwMYdjJPwbNLlskjcw/VSzJsygXyT89Rj7/ONHMPyCj+H/gds0/6CRaPsb4zD+nuk3Z6pjNP2zt3stGCs4/uy4yndfQwb+o0kII63W1vwUsJdGetb2/tuuzHi8wqb8w1xswPnKlvzrRxjBvh9A/maZ20/Ii0T9Ey17RNObQP9X6A/N8g5W/Gtnyax4ozD8LcJUXMlfOP08KxKRogc8/tKminO1Xzz+oNKOi3LfQPx92YkeO8dA/O0mLN9lF0D9rCw863ufCv3QCoVMRh7W/KuV3KogWpb/gZgmEypLQPwX8BLwwNtA/0PvYhi5zub8b1Uxi25i5v/we8SKcrck/FuLaUzvG0D8P6ZrTW/bEP6BuUIZkS98/f2Bj3We0YD93glQ1GetfP5eYe4JyCOO/yYdN/9T1yz9GaeIvpSHSv6c41OeH/Zw/zOe+AHVwuL8AAAAAAADwP9fZOw7II+4/24Fo6bVU6j+LqU6827LpPz5J+s7vuuA/6iQ5bsITrz89fQ3hnMLTP/g8cRDUjuY/f7KMj7Xq4j/2V/JoBEnbPzrYhzlsZcC/MlEAwwVqxT/7yJ0ox5PIP7sjj3n6McY/Z+r7o+A/yz8n1Nor4GvMP8TPDO+rw8s/ORREJ7euyz+KAWuCZunMP/Bj8+x3/cY/Q6z1kddoxD95Jrh0+qrDv8l+4s/jHMG/ACbuq1Vru7++4u2UYJa6v7xBPRrCZ8U/y1hUt+Nayz8sk1CuDOPGPy61L6+FWsw/Xxo6vghLzT/60xnFO1bMPxbaOevYoss/UzQaPSoazT96ZDfWI+/Cv5hB7ugFKba/7iXH2WO/u79PAR7IYcivv+aItq5vBbG/UtXP2A/XzT8TRc7YrrHPP7NVgAdDl9A/72sYX9zNob9rxxYmuYfJPzGtOYsfz8s/jXCGWKm9zD88RJvHimjNP0ZtjBaKEtA/0yujAwfRzj/kmKLpc7DNP3RVfw+tnMa/wo9NdXXHtL+btNOTXnaQvwSDkUk+XdA/RKNXPsoU0D+8kSB1vZu4v8TK3dr1O7q/v3jVb0t4yD9stLY6JS3RPxo6eOLbo8Q/mcsZe51p4D9PZex6tQRkP72QwJuOGGA/DiBus4hg5L9nXW1M+mfFP/Onk0SxINS/facX2CJRlj/boVxawoC5v9fZOw7II+4/AAAAAAAA8D/DDx4xl9HnPwYCPNV9ouY/iqRnSYEo3D+mWTSyoTunP2DC33b6Rs0/LPX9RGZ/4z+xZkIxKAjeP0qg4e0hxdc/jbZ5nHUbw794UTY/aXfSP1F2RN9JEdE/YGGfzf7P0T+BrPLsQKrSP0har31Az9M/Tc7g4B/b0z8XnVny7G3UPwf488d609I/vHWOKj2ezD/Dp3siEDTLPywVxIZw6ce/y6QLrd/2wr93SPnnKWm9vx/igp3Bk7i/dQW1CPjE0j8yR+gPjn/SP6GbFw6M+dE/Sawd53e00j+1WjX/SaHTP5NoJWQWp9M/jPoAYvzx0z84xFunhsbSP+1pIR8lysS/RjIdvfkdwL8u4+UCb+S+vzYcpnwhDry/mqT5Vzk7u7+H/8lkCkHWP6g1nLaHPdc/wO6WUJkc1T/m+JQVIzOVv5pOEsXAo9M/HERxEfLs1D/K2M0cwK3UP+ax5GhZmdU/uXMmoqum1j8f1OofX0DXP6n6cfvU5tU/7PlKm8BGyr9cjZsOGW6mv1k7/NKwfq+/39w8XU0c1z+NFIQRYivWP2On8rKXjbm/lRY644Juvb+KFt+Lq7bRPykM+yoFYdU/aRHLEQVozj/3BV+AEWbVP7doqenufVY/x1WYY6BYKr8owuTcjL3Sv1jGov1Fy84/SCk5euhg2L8Z6HOS26aHv3JUZs3QoqS/24Fo6bVU6j/DDx4xl9HnPwAAAAAAAPA/euLu8Eko6T+UceozI9vjP3k7LO8WOqM/r2aZfNtBxz/ZQgMxuErmP+wJX1NWouM/5eSN3VGK1z/tMlQdLhTHv9HWxDq/1dI/EDmWHXdc0T95RiszMX7SPyOkdWGNYNQ/xAC+wp4L1T9sOdOeLNDVP1/kF5094NQ/GODOeeG10j9F3+mYDpjMP2WS2D92zs4/OtHjUHdWwb8AzXtl0Xa7v0qAvsciG7W/Abg9trfprb/wbSxnzizTP8n14aufmNM/UmJj3daO0j8n+MEFZ03UP6arHlPx3dQ/Nc33iag91T/SUztG31bUP3y3mnENnNI/svNUBCZCyL99GB1U56zDvwWu3Y85lby/TKx5Icvst79FEA4vfWq3v614O/ARFdc/z8kTEwwm2D8SyhLVRp7VP9IJMsc886W/jtNoKuKb1D+m4F5DkNPVPxZ9BUoXt9U/B7YQonzC1j+kSmKRYRrYP9Pv+pJ4Btg/+kb2XC6B1j8nU+xLLInEvzmFf+vAAqW/t5VEjBv7tb+v61esFGrXP273SMV04NY/Qwipp/wrwb/XU9ykiJvCvw44N7EgntI/vj0RcoK41D9gp5tEwoDQP83CQtnD+tU/HC4JhhhrdL8Awqj9+saBv7P7p5J1iNC/OzG1ew0c0z/Bz3GaL+LTv62KY8SzHag/eB7CUDSukb+LqU6827LpPwYCPNV9ouY/euLu8Eko6T8AAAAAAADwP5Oz6tIHsOg/tdm8U5AfsD8i10Ig+6nZP7oXXXwSDuQ/BltQ5Hi/5j/NSdXJQ5feP852BgxlrMG/XkGEssrx0j8q/QuVWKnSP/Mev19mz9Q/TY0Jn/pl1D//2Gnp443WP3UT7exh9NU/OrNTqZzt0z+K0Nk12urSP1khLmr/Lsw/8nuR4Crmzj8ozV1Eg/63vzFEedFjqKW/AXlRepyOdr/0OjsGNSGhP/PwBi425tI/g5M5+2QT1D+LcZWuFWPUP16hLDY4jtM/iUqUtOWT1T+zueao7p/VP9k39ZcUe9M/Ks5LuzIu0j/VQ3XH0sjJv10aivVcAcS/SLuXf2UOvL/NtI5nOmLEv+6zEqmVM8C/1tpablj21z9gU/I+COPYP1QWk5935NQ/wemvfaLDqr9dPfdxuPvVP9gwuTVx/NY/3NLA43t41j9wV8API4fYPz7ZBrAetNc/ygnFQdne2T+TAJNTvrXXP33MdQdZvre/sdrJPnknlT9VT0gCrnW9vzch00l67NU/00yL5ZSQ1D+BO5TfJTe2v87MKCe+mLy/43uflWyg0z9KkcvbJlTSP4WY8LoREdU/6phjIogtrz/1mZ+C2RhWv6T84ZUo3na/RAt3V4xpjz8EhGfcUw7QPxLeLjftj8a/q5JQ+ZZSpD8vRrooqCTAvz5J+s7vuuA/iqRnSYEo3D+UceozI9vjP5Oz6tIHsOg/AAAAAAAA8D8Bm6a2Gs+6P29/qx2Ygd8/f/yes5j33j/+3fBAqivlP+uEDWKmA98/MyJ+Treutb8YvohK+dOzP3yZK9rZ+qk//y31rLYokj+a74a6JuqAP8TS2al7n5o/9U0cLGt9fT+2bHkuxP+XPy0a2jOm1Xg/sU7Yg0DDgD8rKvS62+WDP/6g9RH09Kk/a7T9n61Jkj+2MLOSbS2SP8V019IsHIY/rT3u0IgqvT/GN1xp+Hq1P9znP7YO4qg/t5q712dOpj+eM8qrahaoP2ihg1O9LKI/plO9qtVhqT+1ZiR3Qq+gP9fpjvcSq4O/umN3jSn4lr8D7Gzd7c2Hv48q3rHR/LU/MXi+PylLpD//kcvhexW7P93hcH6IfrY/iLOLpZtToD/jl/6qk42kP+vqACirYbs/khkI83SMtz+LDbofIMa9P5LjDc+lYpw/wTCVUUSwnj/WDzfd/aemP5KMN7Fxs7g/zyMsZmGeoz8mq4YWb5WkvwCXLKNs34K/cTKk4OT2rD8F9L/aT/KpP3sd7wEiUIe/EFOqDMiEiT/U3m2lJ8S0P0SdjeuDMaY/GKGulI0jmT8KZzSrisfZv22QjWyP/0E/bOZraeprYz+uvU0MEGihvwD0JZ5Yy82/8drdymdVuj8/uVbdjyKfP8/wArY1Xcu/6iQ5bsITrz+mWTSyoTunP3k7LO8WOqM/tdm8U5AfsD8Bm6a2Gs+6PwAAAAAAAPA/pujLzAyoxz96z9O9+MnTP3Vo4ZoHbsY/CNFAwG6m5j88tGNC2O+jP3THLyYMjMM/lJMOfrYywz9ODJWHwwi+PxSObjBYUL8/1hh79GAYwj+pOtu6xtu/P7mmWeR847g/ely9PD1kuT8gK4yMa06zP9im+PAzibg/QL5rXl5rxT+7ARkF9cjHP8ewBQd9l8o/Px93X2WZyz+aVYMG93HBP50/9TSuAsM/X+zEp+O7uj8GL5f5Yri7P7YkeWJKaL0/v6xyiSRSuj+yNbcvvsOyP8QiLFe0wLA/npRKaGE+ub9bVkgGAACuv11tw7BJx5y/ziXEdnFrgr8dR9vVpBmBv58yAMNgocM/xEqX26Newz9ogEFbT9bCP+9F3GTlC42/nXtL4Liywj+GGDuhlO7CP64TCiguycM/WbfJ6w2kwz+m8lj/FxLCPzOxx1YrxcU/QZspY7YAxD+7hMYZHxjGP+0A1a/MCJM/PEUwQVHttr/LG8PvBjymP8eJK0N+xqA/6M4ucf/7rr9OdhlEGmuov+TEaFKv970/5z6N7VhalD+p3mQlts/LP6kjk44gsaM/C0fLXWXUZj9jRa/wDQB5P19qKpx1c7+/1886fFdr1D9hz0QzpuTDPw6bp+87XZI/jtX1nBA91L89fQ3hnMLTP2DC33b6Rs0/r2aZfNtBxz8i10Ig+6nZP29/qx2Ygd8/pujLzAyoxz8AAAAAAADwP7XkBi0II9E/3CmIypRi4D/kgGPz3GjdP4ftM2w/u8I/bBBe3nPU0j8zHsCeJLjLP4QVuDPc6dA/cQTyWJc2zz+feVD7BHTNP5egq2ZOUco/zay2tKe3zD+RX53VgI/OP+tG1OcL0MU/AMEfnE9guz8vYLFe7WjAv+LTUbOCKLy/HaC5HzMevL81lAqHpf+9v2KRdJzxK9M/VBBa4t+S0D8qW5WT/avRP6JWfEdCeNA/pK8aHOL/zj+cyGA8VevLPwTACUSJhc4/o2OsNUNr0D8viVXcjbe2vxQhQvOgTaq/GmqtwPAxwb9GorKdcF+kv0ELluzBepY/DAGswYXv1T/WU4khpAfWP3AdEzyMJNI/SxEJNcrMPb+VjVivzaDTP5TSFJVljtQ/CLF1FUAL1T+Kpe6c6PXSP2C360ezKdA/i3i9FEdI1T/AYO3/9IPVP/xNAEELCcS/fYVd7j4yt7/sbjnaLax6v3Hc2uY/HdQ/ezhNhZyq0j/Y/RSd/VC7v0N4NtIefry/iThxG2xqzz/cQcwmspTSP5PJLVDQRME/2gDpgjDkrD9D4MCL4V1ZP2vrDD0pPV0/WqjTviAI0b9aTI7geneSv4ROqTSTJdC/Wc4gxicosT88/ti441bCv/g8cRDUjuY/LPX9RGZ/4z/ZQgMxuErmP7oXXXwSDuQ/f/yes5j33j96z9O9+MnTP7XkBi0II9E/AAAAAAAA8D/2HP+gEffhP+PBZdKqI+E/cNd2gz7HwL/35iyQP6DUP315PtmDu9I/W4/97tWD0D/npVgH7KrPPyAXvA+Hus8/6xW4Hfuvyj/NMJyYTM3KP4zvrsqUicI/bQoa+DaTtT9FkRsSxIm9P52CZBiLVYk/V6Rt0d5noj8JYawZS5euP7JbEhTcJbU/yKei8sc41D9BnFLxJmvTP55ouO/FRNA/I9ZUImXczj8TVIHqhdLOP85r/ToCs8k/qJucrfWvyT8qVsVVRH/CP83Uh32H0b2/u381hVlRqr+2kP3x6lKgv+uCqMNEcrC/E+Ox/BF9s7+eMdi90sjWP9ObuQSn0dU/LOFDzLJY0T8XEs3QKHuYv6CWLYi/l9Q/i6qIoCgy1T9knhzZFPrVP0FGBFbbUNQ/Bl5ZWict0D/Iaz7LSt/WP2CqgHRcgdY/uJeYHeQbkb++um+rWeahv3gcaUVIa7C/UhyPFfmf0D9PAc9ASwnMPwm7O9JZh8C/WcRp8X+Dwb8nO8muLArQP0rHJOv+qcU/LsJH1SqIzj+tki1/1W+5PwjiqfO5Dma/gTR2t3nxc7/vEpnCr17Cvz1At53bxtM/Hr6x+DNpu78z/rqX+7qfv/dUODdEx8i/f7KMj7Xq4j+xZkIxKAjeP+wJX1NWouM/BltQ5Hi/5j/+3fBAqivlP3Vo4ZoHbsY/3CmIypRi4D/2HP+gEffhPwAAAAAAAPA/IHRG2h2p5D82WUVC53Nhv2MTN1Ujdc8/AS3VXagNzT/lH5cRjEXNP2Z5U0o3J8w/3cv9N8sPzD8z+1dDR0jGP2K75aCZxsM/FPBUjRNBuj8/atUchGWqP86sUqF4f7k/APajEJiXjT8iIS0m3PuRP296FcCFgaY/QqPfy/KhrT/pdMg05ejQP+k1BOhN6NA//CfwHPpDzz9xQ4QOsu7NP3bV2L+w3sw/SLXPQgzCxz83U2A9aIvFP03M4nHwFr8/GHAzGmclur+66Arsf9aov9dMDaUJqHG/ptEVtPOrk7/mgnZoBVClvwqJdcFFONM/6qAXuQNk0z8W67ELIVHQPzdqQZio94O/5sJhKyrx0D894s/4uwrSP6eQ3z1Oi9I/AE3Lew8k0T+Cceb5bZHLPzy3gQaQ1dE//pi7ri+t0j86DjDmmSKRv1pY6ZjPEq+/ZAZ2jXN6mr+YA4JV6mHOP8Ldr+snC8o/9ZUDMkkItb/3ecpIXR22vzeSB2epzc4/1YssTeuKxD8QVs76vZHKP4xm8HdkFLu/9ukCyUxCZb8kuSif9sdmv/FwEAGercW/admBitAKvD/9TDBoXZOjv5SmEfFFgZM//RqwFGwozb/2V/JoBEnbP0qg4e0hxdc/5eSN3VGK1z/NSdXJQ5feP+uEDWKmA98/CNFAwG6m5j/kgGPz3GjdP+PBZdKqI+E/IHRG2h2p5D8AAAAAAADwPzMqqEYoDVm/NuPq4PDcYL8krvzok6ljv3ZWzPz7SLe/jTIFRUPKvr85XazK1MrAv/tEjr6h6cK/T273I5fLw7+VxsXtpJ3Dv/+ADCTGg72/cng+OYuCt79d4GfnoSDvPxysPx7pcO0/peKZCaoh7D9q52qNV7nqP5m0K9uwZrO/mTcHEJ9kvr/0Os+en2zNvwYLeQr8FNK/bcqm5v7D079SamCfi6TVvxM81jtJ/da/LZXFheK817+c4MIQEz6yP86GkK4UA5o/F7Li8YGUmz8Pb08pVeTMP/lwf8iEkMk/fzEhcUYHwr9Mu2Tjp9DMv6qwq5lZAMa/ER/PHhySg7//2/nVHua3v1U8t1z+OcK/mrbg5NYNuL/+YBGVqrS7vw/jN93q8MW/UIpN2miMsb8CW/VKiLrBvyD4EswexO4/fYk8LsMwob/73OURyl2gP3BLQXJ17OK/8iiy+AUH5L9vH3OEqC5iP4qmNiIbBqw/tQchY9uly7+vVa07wrvkvxedo+abWNI/72NgeIH0sL8BzuZPgAZiP7epbQFzVci/QVaPmD/Jpz8Y5Opt//akP0mGvuYETtg/YI13owfBo7+1tYpx5PDCvzrYhzlsZcC/jbZ5nHUbw7/tMlQdLhTHv852BgxlrMG/MyJ+Treutb88tGNC2O+jP4ftM2w/u8I/cNd2gz7HwL82WUVC53NhvzMqqEYoDVm/AAAAAAAA8D8=",
+          "dtype": "f8",
+          "shape": "67, 67"
+         },
+         "zmax": 1,
+         "zmid": 0,
+         "zmin": -1
+        }
+       ],
+       "layout": {
+        "height": 700,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Feature Correlation Matrix (157 pairs above 0.7)"
+        },
+        "width": 800
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAK8CAYAAAAXo9vkAAAgAElEQVR4Xuydd3xUxdfGn00PvVeloyCi0pHepCm9i1IE6SBVuiC9V6WDgNKLIB2lWkBBihTpvfeahLR9P3P5bczmbu65m2ySJe9z/1Iyc2bmO3PvznPPmXMtVqvVCl4kQAIkQAIkQAIkQAIkQAIkEA8ELBQg8UCZTZAACZAACZAACZAACZAACWgEKEC4EEiABEiABEiABEiABEiABOKNAAVIvKFmQyRAAiRAAiRAAiRAAiRAAhQgXAMkQAIkQAIkQAIkQAIkQALxRoACJN5QsyESIAESIAESIAESIAESIAEKEK4BEiABEiABEiABEiABEiCBeCNAARJvqNkQCZAACZAACZAACZAACZAABQjXAAmQAAmQAAmQAAmQAAmQQLwRoACJN9RsiARIgARIgARIgARIgARIgAKEa4AESIAESIAESIAESIAESCDeCFCAxBtqNkQCJEACJEACJEACJEACJEABwjVAAiRAAiRAAiRAAiRAAiQQbwQoQOINNRsiARIgARIgARIgARIgARKgAOEaIAESIAESIAESIAESIAESiDcCFCDxhpoNkQAJkAAJkAAJkAAJkAAJUIBwDZAACZAACZAACZAACZAACcQbAQqQeEPNhkiABEiABEiABEiABEiABChAuAZIgARIgARIgARIgARIgATijQAFSLyhZkMkQAIkQAIkQAIkQAIkQAIUIFwDJEACJEACJEACJEACJEAC8UaAAiTeULMhEiABEiABEiABEiABEiABChCuARIgARIgARIgARIgARIggXgjQAESb6jZEAmQAAmQAAmQAAmQAAmQAAUI1wAJkAAJkAAJkAAJkAAJkEC8EaAAiTfUbIgESIAESIAESIAESIAESIAChGuABEiABEiABEiABEiABEgg3ghQgMQbajZEAiRAAiRAAiRAAiRAAiRAAcI1QAIkQAIkQAIkQAIkQAIkEG8EKEDiDTUbIgESIAESIAESIAESIAESoADhGiABEiABEiABEiABEiABEog3AhQg8YaaDZEACZAACZAACZAACZAACVCAcA2QAAmQAAmQAAmQAAmQAAnEGwEKkHhDzYZIgARIgARIgARIgARIgAQoQLgGSIAESIAESIAESIAESIAE4o0ABUi8oWZDJEACJEACJEACJEACJEACFCBcAwlC4Pjpi2jS/muMGdAOtaqWSpA+sFHXEHj4+ClqtxyAFMmTYsWsIUiW1N81hmklVgTa9ZmA67fuYdP3Y2JlJ7FXPnvxGj7uNAJF330TM8f0SOzD5fhIgARIwC0IvBICZPOOP9Fn+MxogbVqXB19OjV1OVDV7r0Hj9CiUTWX23a1wT37jmL1xt04evI8njx9jnRpUyHn65nxQbkiqF2tNPx8fVzdZKzsxUaA3HvwGCvW70TlskWQL082u36Mn7EcC1duxdIZg/HuW7lj1ceYVP7w0364dPUWalctjdEDPteZ2Lb7L/QcOkP793XfjUDenK851YzR2I0MxSWXnkO/xa9/HsOqOUOR4/VMDruh5mv0N0tx5Od5Dv/e/atv8PPegw7/VujtvPjhm4Ha3+Yu2Ygpc1dHO1QPDwuO7fzOKaauKNyo3VCojWx043NFG87aeNUFyP5DJ/HNgh/x79nL8PLyROGCb6B3xybInT2LiEI9Bz/uNNyw3PfTB2g21bXzt0PoOmgaRvRtg3o1yor2WYAESIAESCB2BF4pAVK1fFG8niWDbsTqzVW5ku/GjoSD2l0HTsW/567glxUTXW7bVQbDw60YOGYeftr+OzJnSIOKpQshdaoUuHv/EX776xhu3LqHymULY9rwbq5q0iV2YiNATp27ggZtv3K4WVi7eS9+3vs3vuzUFDmzZXZJX50xogTI5Wu34enhgW3LxyNT+jR21Zt3HqGJRKvVGiMBYjR2o37GFRfbRu/Lzs3Q0oFQf/Y8EMf+vYB+o+bg8dPnhgJk974jaNGwqm4YWTOlQ5M6lbR/P3DkFH798x+HQ1UbVsXnnx0LnJkyl5Qd881S3Lh9z63us1dZgBw6dgatuo/RnvcfffA+XrwIwZpNexButWLtvOHImD614bzdvPMAy378xWEZdX/+8uvf+H76QBQumDeijBLBh4+fxc/LJ8DHx9sl64JGSIAESIAEHBN4pQTIt6O6o0Kp9+JtLl8FATL7+w2YNn8N6lYvg6G9WsHb2yuCjxInG37+A38cPI6xA9vHGzczDcWVADHTdlyWUQIkXZqUOH3+Khp8WA59Ov7nmVMb8aYdh2mCcMevh+JVgMTVmNVbYzWu7cvG6zZtNrFka1utTSMPyL6/T+DPTdF7Oo3GEPQiGNWa9cFbb+RgGM3/QL3KAqRFt1G4eOUmNv0wFimSJdFGpDxM9dsMxsf1qqB/1+YxXtJdBkzF0ZPnsG3ZBCTx942wo+zXbT0IQ3q1QuNaFWJsnxVJgARIgARkAolKgISEhmHBss1Yv+037c2/iklXHoFeHZpE/IgpJJPnrMKuP47gzr2HCAgMQtrUKVC9Ygl0+LQ2UqZIqlFr03Mc1BvVqNeetVORPFkSFK76Odo0q4me7RvbFVEbUPXGds743tq/294Qjx/cEUEvXuC75Vtw5fodLayrV4eXdVVYjvr3MxeuaaEGRd55E73aN0aenFkNZ1C9Xa7UqAcypEuNHxeMgLeXp8Pyiovtb+rN+9Iff8HydTtx9cYdpEyRTAtl+qJtA6RM/nLs6rJtXuaO762FvChe4eHh2Ll6Mlb+tEv7t61Lx2H1xj1Yv+13PHz0FFOHd9UEopl5cCRA1KZ97DdLcenaLTx4+ERjkT9vDrT9+EOUf/+lh0u9Gf206yjdONWGQW0cFMcJs1Zgx6pJEd4Hs2O2hfcolmqM2/ccwIvgEC1M46ueLTUPk3Sp+c+WNSPy5MiKFT/txM5VkyPORPQeNhO37z5EuZLvaPwih2C5YuxGc7Z20147Lspj1n/UXDSuXRFDeraMGJYarwonUvfF2vnD7e6bqGNXHo3StbugeX3HG0IlClQ4mrqmL1iL3w8cjzMBMn/ZZkyavRIrZg/B22/mNJwm2zyr8S1Z+zN2/HYIgYEvULLIWxjcw36ezTwrVGMd+03WNszqnrBd733QFvWql9HOOKn5/uffC1rI4PKZX0Gdm5mxcJ0WuqaeQ+oefuuN7GjdtCYK5jPuv9k+2dbDlGFdoELw/v7nDHx9vfFRlVLo3aGxnWB8HhCkzZF6Fql7OUumdGj4UXm0alwDKqxNXWrz/+RZgOYhsFhe/pvtUvekCg/csmRsxL/F9LlmW1dNalfE4B4torQzEsq7EVOvtO0lgHox0KpJdd06UQIkaRI/LPl2kHSr8+8kQAIkQAKxIJBoBIjaZHYZOBW//3UMjWpVQN5cr+PytVtY9uMO7Udf/aDYfjSVZ8PX1wevZU6v/dioH7QN23+HijW3CQe1WVIbmpt37tu9xa5RqYRmx1kBon7Q7z94jBKF39LafCd/Lk2E2DbMlcoURqmiBaBEhRIHgUEvsO67kciQLlW002uLW47ux9RRxbHfLsPiVdtQpnhBFC+UXzukunbTHuTKnkU7N2E7K6I2L0o8eVgs2hv9fHmz4emzACghtXz9Tm1DpcYUFPQCxd7Lh9CwMDSv/wGKv5fP1Dw4EiBqMzbnh5+QP292rc2QkFBt03rs1AUsmtpfEwL3Hz7Bip924dvvfkT9muUiQihUuNV7BfI4FCBmx2zbmCqBqd66qg2pEgwqlE2dJ1F8pMsmQJQ3qmrT3uj+eUO0bloDt+4+0P5/ytddcP7yDZ0AccXYjeZMCcWowuzL4bOwacd+zBrbE2VLvKMNTYUSKYGqwlOkMzQqjOWLwdOxcEo/bQ0YXQNGz8XmnX8aChDlqftp0SgtfC11quTw8nQsqKO2ozbPHzTthcJvv4FvRn0hTVHEORJ/Px9kzpBWE/xXb97B/r9PaucL1swfHiHYzTwrjARIWhUO+eCRxlK1pZ47Q3q1RLOOw3Htxh0ttEyJDyXUNu/YjzrVSovn2cz2Sa2Hg0dPa2FLqn11Puefk+e1Fx1KXHzdu7XGSr0w+LTrSJw4fRF1q5dFzmyZcPjYWez8/bBduUWrtmHct8u0e1GFvdou9bLng6a90a1NA7T/tJb2z7F5rh06dlbrz4Bun2jiNvI1dMJCrNq4G39tnqU9R5292vQah7MXrmH78gkOz8WpMydzlmzAvg0zYmTf2f6wPAmQAAn8fyXwSgkQR5P0QbmiUG/41EZKbagib6ZU+S07/4R68zxvQh+8X7RAtPOs3oSOmrZEe4NpO2cSXQiW9lbcSQ+I2jyPHdhO27TbLiV8qjXrjZaNqkd4Q9Tf1A96zU/7oXWTGppnIrrLtmE2swFUNi5cuYlaLfprm5xR/f87IK3CgboNnqb14bOmNbXm1OblryOn0K/Lx2j6v/h7Wz9s7aq35192aga1kbNdZufBbAhWcHCItrlRc6cyZqnL6BxEVA+IM2O2jatzq7r4/JNaEZtQtS7U+ti2bLwmWo0umwBR2XT6jpiNA0dPaaEe0+ev0eLOVUaieUs36QSII5vOjt1ozhx5hpTYrddmMFQ7Py0chX/PXdY8f8qrp7x70jV+5nIs/XEHDm6ZDU9PD8PiZgRI5EPoSuSrFwfKE2h036pGlSfh24XrsHru15p4lS7bPA/o1lwL57G9mFCiWv1t4pBOqF6xuFPPiug8IEqAjB3U3m7DfuzURTTt8LXuDFNA4AvtpYmZMUTtnKPnl1oPyuuiQleLvPPysLV6UfB57/E4cOQ0dq+Zogl95e37etIiXX9GT1+CH9b8jOWzhmheGSX+KzbsroV7DuvzWUQXFLOp89bg5xUTNS9hbJ9rah2o8xjqGaWeVZEv2xwpT4vyNDpzqfND6lxJ387Nok0sYiszf9KXKFn4LWfMsywJkAAJkIATBF4pAeLoEPobuV7XDikqsXDx6i2smTfMbvgqtKJ0nS7aRr7dJy/fzqmN1/drtkNljrpy7TaePg+AOi+hLpVtR3lC1OVKAaI8BzUrl7Drm/JEqLfzKpwgTeoUdn/7pMtILRxMCafoLhWKoTazasxRs0E5qmMLU1GhJ2/mft2uiHo7nz5tqojQA6P4cdsGToWjqQ1M5MvsPEQnQP46fEoLXVKhEmrDo8J41KU2oTYWzggQZ8Yc3bi27T4Alenpu8n9ULyQ8Zv+yAJEZe9p+PkQfNWjhSY4erRrpIU82dqJmgUrtmM3mjNHAkRxVYduVbx9+ZLvadmGVNifEvFRQ2wcrae+I2fj9LmrWiiZdEkCZN3W36A24KlTJkNwSCjOXLgKFTb2LCBQ4x75jXvkth4/ea55P5S3ymyihejmWSVuqNCgO5rVrYxB3T916llhFIKlQgMjXydOX0Lj9kO10KwhPVvZCXiJozPPr+jWgy2r4OSvu0A9Uzv0nQglivaunWYnJG2ejc+bf6R58tTVecAULZRr79qpESFctVsNRPq0KTF/4pdamdg+12wvMSYN7YRqFeyFoPJQzFy8Xgs5fSOXcxnklFfl6o272osE32gOmaswsvL1v9BE40dV3jczHSxDAiRAAiQQAwKvlAAxOoSu3uyrt93RXSoMpneHJlomnqYdhuHK9dvaj1ux997UNt5nzl/V3qJGTs0Y1wJk2OTFWjrZ6C4Vy65i2qO75vywQXvzaNYD8vXEhVi5YTcObp2j2/S07T1eC01QokJdMRUgZufBkQBZsvYXjJr2AzJnTKvFzmd/PZMWCqU8EOpcjXorqS5nBIgzY45uY6pCgz7vPQGzxvZC2RIFDW+zyAJEFVRvXI8cP4ukSf2xY+UkLezDkQBxxdhjIkBUH20eBCUm1cYuTarkph4lauMa9CJEW3/SJQkQR/VtAk6FJ04f4TiL28RZK7Fg+WbtvEpUUR1dn4wEdKGqn6NciXe080zOPCucESCqX+og9K4/DmvrocCbObTwwZqVS4ovEpzpU3TrQYVhNes0HMoDpMIm1ZpNlsRf96xRYa2FPmiLKuWKYsJXHTWcNu/EpKGdUa1CsYh7USW5UC+C1BXb55qtDUcvbWLqAVGZ0zr0neQwrCvyOlFhn+rsjjrk/kmDD6Rlzb+TAAmQAAnEkECiESDqR9TT0xPDv/wvNCAykwxpU2kb24UrtkKFjkQNs7CFITkjQFS4ku0gua0to0PoUT0gts2x2sA5SvuoMrQYfSdi+56D6DHkG01YKYElXUabcRUbfe7i9VgLELPzEFWAqNCQMnW6InvWjPhuSl8k8f8vvlsdfk2dMrnLBUjUMUe3Md138ASUQIuJANn9xxHtrXGnlnXQuXU9bYqiChBXjT2mAsQmZBXztfOHOUx17WhtKQESHByKBZP7SksPMREgymjlRj018fbTwpG6NtTbapX5Sh3qV2/zzV7RzbPygr7ccBfRng/OPCucFSCqrd/++kdL7qAEgUpCoK6R/drqwo4ij8uZPkW3HmyJHNQBbxVeqe7Z5En9tVCryJdNgHxQvqh29ktdaoNevsEXKFLwDUwf+YV2uF2dydj747SIMxWxfa7Z+qeSIyiPYeRryITvtMQX+zfO0JKBmLnUOFRihQePnmDrknGGKXZVOKISoTZxZsY+y5AACZAACThPINEIkPZfTtR+yH9dP93w8OpX4xdgzaa92rcCIsetOxIg6oDt8VMXtYxKka+wsHC8W6WN9uNtC9WIiQBR4VMqjGrl7KHaW1BnLxV+omKyVU789d+NjPaHVW0aVApUW3tRQ7bUD7Q6Z5ExXepYh2CZnYeoAkQd9lYZvTq2qIMun73cqNuuqAJEHaKt99kgTWyqg+iRr6ihRs6MOS4EiGKr1luVskWQKmUyratRBYirxh4TAaISDajQFLWWf9r+h3ZQWYUhmjkArr7toUSrOnshXTERIGqTXuLDDngzd7aIDxFGbmfk1O+xbN1OrFswQswYF7ledPOsvg9R85O+EWvQmWeFswIkKi+VpOCTziOQLGkSw5A2Z/oU3XpQ34QZPG6BFjKlQtfUPasSPfz643S7Z+K1m3c1gRc5BEv1W3Ff+dNu7FozBQ3aDtYSGEQ+E+KK55oKm1UfBIz6Qkk9Cx49eaZllzN72V7U2ASXUT1bCNa4wR3wYeWSZptgORIgARIgAScJJBoBot7CqQwpHVrURtfP6tthUBs8lcFJxberVJOzFv9kF0OsUksOGjtP+zZDZA/I8MmLtbdtv//0TUQqVZvhKo17apsFtZm3CRkVUvHl8Nko9HYeh2l4o3pAVNrOWi0HoETh/Jg1pqfdNzzU2YeTZy5FfKk3unlVmbrUOQdle0TftnaxzWrzu3XXX9i7/x/tq9wq+1LtlgO02HPbgW5lV5Xp9fUMu8PHMQ3BMjsPUQWIEklFqrdDxVKFtPAX26U8CH2Gz9KyhtlCsB48eoqydbs6TIMcVYA4M+a4ECCO5i2qAHHV2J0VIOqeqN/2K6RPk1LLerVpxz4tNa86K2WU/MA2JpVVSx1gVhmJpMtIgKjN94XLN1Cq6Nt2ZmxnCdTZGZWKOfJ18/Z91Gj+pV14kNQH298dzbO6V/qPnosN2/+IeDY486xwRoCo+1q9xCiYP5ddl9VHKlWI1cbFo6MdijN9crQe1Dkb9YVw5Q1QZ8+U51WFgaqwKSUi1LdrbJctlEqlDY7cV9sZFpUARIVLRf2gnyuea0oUK0G4+YexEc/e85euo07rQYianlcld1BCuGqFYsgV5eOjSsTWbT1QSyu9Zck4u2esI8g8hG72LmI5EiABEogdgUQjQFQYi3qTp1JpqoxTJQvn135clQdjz/6jGN7nM23jrX4c1dtz9f0LdQAzNDRM+w6A+oEKDAq2EyC2NKMqg4z6voU6wKgOY6rvZaizFyp0RX1JV2WtUfHq/5y8oIkRdWDW0XdAogoQNXUqneyMReu1sBcV+pEudUpcuHJD61Ol0oWjDSmzTbtKoakOSKuUvCqGv1LpQkibOiXuP3yMfX+f1L71ocZpC1GxZXRSmz319lO95VSHfXNky4TlM4dEnA2JqQAxOw+OzoCoTar6poh6o5o7RxYtvvyvw//Cy8sLhd/OGyFA1NjVm1CVdEB9fVvNsxq7+haIo8PWZsecUAJEjccVY3dWgCjRuWffEe38hC2jkMqGtvO3w9q5jugOftvWns1rGN23N5TA+ePgCa34snU7tNSu6s2yuvLkyILcOV5+58a2FlS4oWrT389XE9/qOzzq31T648gfjFN1Bo2dD3Vwff3CkVrqXGcu2zwrb0+5ku9qoUNq46kO5Ku4f9tH7px5VjgjQGyHwNU6V0kNfH18tO/bqBcB0X1R3jY+Z/qk1oNKY62eX+qZqITuzt8Pad8hsp3hUHbVv6ukFyfPXkKdamWQK3tm7aC5Ev/KCzGibxsd3jqtB2qbfrVuIn/7w1Ywts81lZChTa+xyPl6Zu1sjHoh8+OWX7WMbWq9qnBa26XWsWIXeUy2v9m+d2P244LqjIk6U6RCvCKHgTqzvliWBEiABEhAJpBoBIj2Qxoahu9Xb8PGn/dpm1Mfby9kfy0jypd8V8u3b8vYpA4Vq9jlS9duax+rq12tlPZDqtL4RvaAKJvqgO7qTXug3rqrg9BqM6QEiErFq7wP6ofveUAgir2XH93a1NdS/kb3IUJHAkS1od4iqkPIatOlBJGqX6xQfu1Nn5mDtertrcoco36glRBSWb5SJEuqvbWsUak4alQsEfHmT5VVqTXVtzSuXlcfIkyKymUK44u2DSNChFSfYipAzM6DIwGiRKDKCvbznoPatwvUwVx1dmLoxIV2Z0BUG2rzM3zKYu3bBT7e3visWU3tLXl0HyI0M+aEFCCuGLszAkSFhalwHpWhS90btkutc+UlU1mC1i4YbvdxyqiPE+U5LF27s5a6WXkpol5Rv4Qe+e+Rz8QoobJg+RaoL6GrzEsqtDBD+tT4oGwRdGpVV+d9VG/GP2rRDzUrldSyFTl72eZZHcD+9c+jWtpY9RxoWreSJmgjZwAz+6xwRoAoxsq7ozb4l6/f1p5T6js2nzasairsx2yf1HpQX/dWySyOnDineYHV9366tqmveRojX+pv0xf8qH188+WHCNNq4Y1qbh2lWLbdZ5G//RF1HmL7XFPiSQkZtY7UR0mViFJn7qKei4tOgKiXIR992h9h4eGaJyW6D7VG7rc6D6POm6kwRF4kQAIkQAJxR+CVECBxN3xaJgESiA0B5TE5eebyy/AWL3MfDoxNe66oa5QFyxX2aePVJKBEmgqDG9q7FRp9VOHVHAR7TQIkQAKvCAEKkFdkothNEnBHAraUrq9S2lIKEHdcSQnfJyU+VEjqz8snGGbKSviesgckQAIk8OoToAB59eeQIyCBBCWgQmBU+JT6mnrUD1MmaMeiaZwCxB1nJWH7pM6eqXNY6ryLOvfCiwRIgARIIG4JUIDELV9aJ4FET+Dh45fnRtSh7nkTv4z2K9PuAoICxF1mwj36oc6jtfpiNIq+mw+zxvZ0j06xFyRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQhQgLjTbLAvJEACJEACJEACJEACJJDICVCAJPIJ5vBIgARIgARIgARIgARIwJ0IUIC402ywLyRAAiRAAiRAAiRAAiSQyAlQgCTyCebwSIAESIAESIAESIAESMCdCFCAuNNssC8kQAIkQAIkQAIkQAIkkMgJUIAk8gnm8EiABEiABEiABEiABEjAnQgkOgFSqnZnLJjUF/nyZHMnzhF9+W75Fpw6dwVjB7WPs/5duB0QCj4AACAASURBVHITjdsNwcGtc+KsDRomARIgARIgARIgARIggZgQoACJCbVY1EkIARIUFBSLHr+s+jAoTLQRHGY1LBNuNf67qiyY0OybMCP21dfLYljG28P476ry+HQFxXbS+Xoalknp7SHaSO1tbKPKuQOijcBQmf2tZ8GGdh4GhYrtBIUar5OAkHDRRnCYXCY03Hg8LXJ7i+1YfZKKZaQCXpf/lorA4utvWOZiygKijfuBxuyTC+tMNZA9hY/YzqMXxvMXaGL+/IU1HSbMnerkM6GddP5e4lieBsvPrFlZ3jW0M+jhCbEdX+sLwzK1F8s2Xpi4t7Z2Km7YjkfQM7Gvx54a3xdfLD0k2thZ5p5Y5nHBjwzLJPeRn6/nHho/j/ImkZ9HsMjthG2bZ9jXkJpdxfHeDTDui5eJfoSa+GGTfmP9hN81NZAkXsa/Oak9jbkrG56Pb4hMrvoZvwTOnEx+RkuNdPfPJxXBLOslsQwLJAyBeBMgN27dw9eTFuHvf04jTaoUCA4JRZfW9dDwo/I4cuIc+o+ag1t3H8Lf1wfvFy2A4V9+hiT+fliy9hfs/uMIcufIgo0/78P7Rd/C+MEdceDIKUyctQLnLl1Hpgxp0fbjD1G3ehkoD0i75rWwZeefuHDlBkoXK4hxg9rDx0de7IFBwZg8ZxW27zmAFy+CUfTdNzHsy8+QKkUyzFu6CSvW70RA4AuUe/9dDOz2CZInS4KzF6+heecR6NSqLpau/QVPnwWgReNq6NiijjajyubYb5ZqNr29vZAuTUrkyZFV9IAEB4egQoPu+HZ0dxR6O69m6+79R6jarA92rppk2KeoHhAKEP3NRQGiZ0IB4vxDmAJEz4wCxJ4JBYh+jVCA6JlQgDj//KUAcZ6ZO9WIFwESHm5Fo3ZDUKro22jTrCYeP32OnkO/RbO6lTUBojbW9x8+QbasGRAcHIoRU79HruxZ0KllHU2ATJi1QvvvCqXeg5+vDywWC+p9Nhgj+rZBmeIFcfr8Ffzz7wW0alxdEyAF8+VCx5Z1kDSJHzr1n4KOLWqjfs1yIvehExbi2q27ml1PDw+s2/obqlUojkPHzmgC5NtR3ZEmVXIMn7xY64MKo1ICpG7rQWjZqBoafFgON24/QKf+k7Dp+7HaeEZNW4KzF69iaK/W8PX1xvT5axEaGiYKENVZ1Y7yGgzp2VLr+8IVW3H4+FlMHd5V61t0faIAEacaFCAUIPSA6NcAPSD2TOgB0a8RekD0TOgB0TOhB0Teh/x/LxEvAuTfs5fxee8J2LN2Kjw9X7r/OvabjMplCmsC5EVwCBav2oa9+4/ixq37ePo8AGVLvIOJQzppAmT/3ycwfeQXEXM1c/F6nD53FVOGddHNX9QzIEpUJEvmj94dmhjOdVhYOIpU+xyr5n6NvDlfsyvbpuc4VKtYHI1rVdD+/dbdB/igSS8c2jYXl67dwiddRuLPTTMj6tT8pC/6dfkY5Uq+i+I1O+D76QPxZu7Xtb87E4J17NRFtO/zkpvyntRvMxjd2jTQhJhRn67evGt3BoQeEP3UU4BQgFCAUIAwBMt+DTAES39PMARLz4QhWP/fpYNrxh8vAmT7noOYr0KYZg+J6HVkATJkwnc4e+EaBvdogby5XsOK9bu0ECslMBwJEFU+WVJ/9OnYVBQg42csR2hYGPp3bW5I7M69R6jYsDsObJmNJP6+dmU/atEfX3ZqqgkKdVmtVhSs9Bl+Xj4BzwICdQKkUbuh6PBpbRR55w2UrtNFOwzu7/cy/toZAaLK1241EN3a1Ef21zKiba/x2LFqErw8PWHUp8AXwRQgwv1BAUIBQgFCAUIBQgHCMyD2a4BnQFyzuaYVmUC8CJC/Dp/CgDFz8cuKiQ4FSI3mX2JAt080r4e6lOgwEiAzFq3HuYvXMGloZ5cJEJsHZM28YcidI6udXc3bUKEYGteuqP275AGxCRDlqShUtS02fT8Gr2fJECMBsmD5Zhw+fg45XssEK6wRnhyjPtEDIi98ChAKEAoQChAKEAoQChAKEHnH4N4lQkLDMHLK9/Dy8sSg7p+6d2cj9S5eBIg6iF2lSU90+6w+KpUpjL//OYNR037QwolUCJYKz3otS3p0blUXp89fxYgpi/Fm7mzRekAuqjSz7Ydi9IB22hkQdRD96InzaF6/inYGJHIaXrMeEMWk/6i5ePDoCYb1+Qx+fj74advvKP/+e9oZkDk/bMCM0T2QNnUK3RmQqCFYNgFSuWxhLdQseVJ/7ZD6leu3MWn2Ki0cy2wa3nsPHqNasz6ax2fB5L7InT2LNn3qDEh0feIZEPn+owChAKEAoQChAKEAoQChAJF3DO5bYufvh7X99MNHT1GvRlkKEEdTtf/vkxg2eZF22LxU0QK4efs+mtWrgjrVSuPcxevoM3wmLl+7jXcL5Na8BU+eBkQrQJT93/46hilzV0OJkUwZ0mhZsBT82AiQZ88DMXH2Suz87ZB2LqVYlCxYy9ftRGCQPguWkQC5eecB+o2cjZNnLuPtfDmQOUNaKG+LWQGixqpEzMPHT7F85lcRaFUYmDqE7qhPUQVI6JGt4t1j8bYPO9NVMJEiEJ7G6WLFTqgC/snlYh7GGc3C/ZKJNqy+xu1YXsgpLcOSpRfbsUBIfxtqnMJTNWAJN04najm7X+yHmQLiGjAxvxYP4zVg8TcxN8L8qrFYfY1T6N72yywOOYmQLtZPSFepGjCTUjZUyCrs//dasa9S7mnP5KlFG8FvVRbLeB/fbljGGiKn6IS0Xn38xH54pEhjWCbs4R3RBkJDxDIhRV5mK4zuCjSRF9zX0zjVq/+538R+eJi4L+5keBkhEO0lZ9pGusu/G5qwpM4o9tViIt3vjXTG6Y3TJZHTKEvDufxYXou5IacMDkhm/Kzwg5zu98h947WW7+dJIlfv1PI9LKUVfnpOTjlrFdJgn1t/WOxrviYlxDLPbxizf3Dmpmhj9rozhmWmBJ4Sbfj5yc8b0cgrUEC9bFf7VnpATExW047D0P3zhihZ+C0TpVkkNgQoQPT0KED0TChA7JlQgDi4byhAdFAoQPTrhALEngkFiH6NUIDEZlenr0sBYsBzz76jyJwxLTKmS41f//oHCtaWJeN0B75dOyX/WVuzaS8274j+TfGIfm2ROYPxWzdX9u346YuYPHtVtCY/bVhVy3bliosChALEzDqiAKEAoQfEfg3QA+LgRQU9IDoo9IDo1wk9IGZ+dV1XhgLEgOXEWSuxeuNu7QOEeXNmRb+uzfFegTyuo09L0RKgAKEAMXN7UIBQgFCAUIBIzwqGYOkJUYD8/xMgHSw5pFslTv4e3ZfdKUDiBDeNxpYABQgFiJk1RAFCAUIBQgEiPSsoQChAeAYE6JRAAmSG1fE5HwoQ6cnFvycIAQoQChAzC48ChAKEAoQCRHpWUIBQgFCAAF08EsYD8k04BYj0jOLf3YgABQgFiJnlSAFCAUIBQgEiPSsoQChAKECArgkkQKZHESCbd/yJEVMXIygoWMu5qT56PaRnK+3bde5+xct3QNwdQmLvX9DPC8QhevglMSxjJn2qxVNKrSglVgQ8kqYQ+ypltg1Pmkq0YfVLaVwmNEi0EZZCTvVqCTNOFWkJk1OFItTYhvXoL2JfIc4NIKZy9TJOfyx3wuT8mjAU7mecRvlGkuyilWRCGl4vD+P0qqqBYBNpWsOFFNbJ98wX+2oR2HumzSTaCCpYXSzj8/sywzJWIcWuVjnUOG2pxVdOi+mZxjgdbMi1c+JYYPEQy4RXbmNYJlR+ZCFEWAMpz+wQ+2HmuXclfWHjuRFbAbJdMU4JbEkjryPrEzm1rTVTXmOuKeR2pOHceCo/O187/qNkBnffrW9YJoWvnF7+8hPjZ7T34JZiP9K+lVMsc+fQWcMyD84/FG34p/E3LFPom3GijZsLZ4plXjx8alhm/HQ5fXz7um8Y2si/7CexH3GVhvcLT3m+xM7FoMDUsIsxqOWeVShA3HNeXNorChA9TgoQPRMKEHsmFCAO7hsKEB0UChAH64QCxA4KBYh+jbzqAqRHAgmQyRQgLt0f01gcE6AAoQChB0S/BugB0TOhB8SeCT0gDp6d9IDooNADol8nid0D0tMrYTwgk0LpAYnjLTPNu5IABQgFCAUIBQhDsPRrgCFY9kwYgqVfIwzB0jNhCBbQ2zuXK7dppm1NCLlguqy7F2QIlrvPkAv6RwFCAUIBQgFCAUIBwjMg+jXAMyD2THgGxNym68sEEiDjKEDMTRBLuQcBChAKEAoQChAKEAoQChAKEB5Cd82+rK9PwnhAxgbTA+KaGXzFrNy8fR99hs/CiTOXkDt7Fiyb+RUGjZ2Hnb8dBmDFliXjkC6NfXalotXbYe384ciW1TirS1yioAChAKEAoQChAKEAoQChAKEAcc1uq38CCZDRFCCumcBXzcr4mcvx+MlzDO7RAmFh4Thw5BQmzVmJxdMGwM/XB95eXvCIkrrTHQRI8K/GqTXVPHimz2o4HeFPH4nTJX1HQkolqhqw+MgpOq0hQlpaE6ltLSnSGY/XX0jTC+C6ZwaRiaecCVS0IWRxRabjcipCi5n0xgJX+PiIfZXm2OJjnAJSNWANeSG2I5W5l7uiaMPX0zjN7qMXYaKNNH5S6mnA32Kclta6+wexHfWCw+jySJVetBFepJZYxrJvlXGZUDn1qTU83Liv/knFfngkM77/Qu9cE21AunEAXCnysaGd5D7yDZxKSNPq8ccKsa8WH1+xzJ0CHxmWMZExGJmFNLzhzx6L/fDI+a5YJjxpGuPnq5+JdOtCK79fNU7zqqqXzJpM7Ovft54blimZ2vj+VZWvhhqv6Zt1a4j9SJ1bTh//+NITQzvJMsv3VobCeQxtpC4ufz/CI6n8+9i1xBeG7fTpWlJk4uVvfF+E9/lGtJEznXHKdtFANAUG+uaOadVY1Rv54nys6rtTZZ4BMTkb2/ccRO9hM2CBBd7enmjbvBZmLV6P0NAw+Pl6o2yJdzD56y7Yf+gkxkxfiqs37qDAmzlw9MR5bFg8SvSAdOg7CYUL5kW7T/7bJNRq0R892jdGpdKFUKp2Z7RuUgPbdh/A5Wu3ULpYQYwb1B4+Pi+/zbBwxVYsXr0NT58FIPtrmXD/4WPsWj1F+xsFiH6SKUAcLHwKEDsoFCAO1ggFiA4KBYh+nVCA2DOhANGvkVddgAxOIAEynALE5K49kRUbPG4BMqVPjc6t62kj27D9D6zetAeLpvbX/v/23Yeo1bI/BndvgdLFC+LK9dto1X0Mflo4UhQg23b/hekLfsTGxaM1WydOX0KHvhOxa80UeHl6agKkYL5c6NiyDpIm8UOn/lPQsUVt1K9ZThMl42csw5ThXZE9a0Zs3rEfs77/iQLEYP1RgFCA0APiQJjTA2IHhR4Q/RqhB0TPhB4QPZPE7gH5yi9hPCDDgugBSWTSwtxwJAGycOVWHDp2BtOGd4swaDYEKzg4BBUadMecCb3x9ps5MXr6Ek149OnUVLOlBMiCSX2RL0827f+HTliIZMn80btDE3TqP1nziDSvX0X72/HTF9F14FQKEAqQCAIMwdIvBgoQChCGYNmvAYZg6e8JhmA5EKEMwcLQBBIgQylAzG3YE1spSYCMnPo9fH19NFFgu8wKEFV++OTF8PT0RN/OzVCxYXdNcOTJ+fJsRlQBMn7GcoSGhaF/1+ao03ogerVvjHIlX8bmUoDIcer0gNADQgFCAUIBQgHCMyD2a4BnQMztXIf5G5+lMWfF+VJfBZ5zvpKb1uAZECcmRhIgMxauw5UbdzBmQLsYCZBjpy6iY99JGN73M8xa9BNWzB4SYcdIgKgwr5qVS6JxrQoUIOoQMw+h61Y1PSD0gPAQun4NUIBQgFCAUIA4sQ2MKDo8gQTIYAqQmEzXq19HEiDK89C6+1hMHNIRWTOlw8Zf9mPuko3Y/MMY8QyIjU7tVgMREBCIts0/QtM6lUwJEBX6tXrjHu1QujoUP2/ZJhz79wJDsAyWHD0g9IDQA0IPCAUIBQgFCAVITHanI5MkjAdkYAA9IDGZr1e+jiRA1AAXrdqG+Us3wdPTA41rV8S8JZvw4wLz3wH5bvkWTFuwFnvWTkWKZElMCRB1fmT4lO+xfc8BZMqQBtUqFMeqDbsiBEjY1WMieyuMU5LCW06PK6a9NOGZMPO9CqunlLJSTkhp9TROKWsJl8O4PAIeilwt0phDjVMKqwaktKbW5MYphbVOhsspZa0+UgpHmSusxilY4eEpMrN6SfOr8jUbp0e9Czn1op+X8Zr3iZJS21HHPU2UkQbse++sVEQN2LCMeP8CeJFOPjTpe1844GhiCVikNSA8arQ1bzFeJ5ZQOVWzmbUm3Reh6fOKc/MgxHhAaTxM9FVYz6oTz2D8zDKzFJM/u2E4nrDk8veqvK6o714ZX6GvFTRer6Z+T4zbuB0gP9MyHRbSSgPweqOoYUOhaXNKw8XGC8YpgT+697Nowyv9a2IZCOnUg/ZtEW08uXTLsEzGpq1FG51yNxTLTP9zqmGZ25s2ijb80hina07V4DPRhtdrBcQyMSkwOoEESH8KkJhMF+vEF4GoZ0AoQPTkKUAcMKEAsYNCAeLgiUUBooNCAaJfJxQg9kwoQPRr5FUXIGOSyi8n4mLP1++5mRdWcdGy623yDIjrmTq0OGraDzh/yfHbp5QpkmLS0M4u6wkFiLxLogChAKEHRL8G6AGxZ0IPiH6N0AOiZ0IPiJ5JYveAjEuWMALky2cUIC7bLNOQ6wlQgFCA6FYVQ7B0SChAKEAYgmW/BhiC5cCbwxAsHRSGYAETEkiA9KYAcf2mmRbjjgBDsBiCJW20FCGeAbFfJwzBYggWPSD0gPAMiH4NUIAAE5O/EXebNgPLvZ6eSZB246JRhmDFBVU3s0kBQgFCAaJfA/SA0AMi3RcUIBQgFCAUII62dJMTSID0oABxsx02u2NIgAKEAkTaaNEDol8j9IDQA0IBQgFCAUIB4miDNTVFwnhAvnhCDwi3/K8QgeD71+XeCqlPrSbSJlqFVJKWsFCxH1ZPL7GMJdzYjtXDW7QByOdEJCMewQFSEVi9hPTFZlKSCilYPZ8Yp1XUOmkitW24NMcmUoWKqZg9jNPnan01cV4FHsbrJEzirpqxGq8BD4s8Od7P74prIFzILuYR+Fi0IaWnDveT0w4jXEiRDMAj8JFxXwTuWuUw49TS4cnSy+OVSgjPAFXdI+iZZAXh/sZpPgMtcvpxH0/jdeL14onYDymttDIQ6pPM0I6HVU5LK82v1dtf7quJZ/TsI/cN7bQrklluR3hGB8vDxcl7gWI7RfyN77/wJGlEGyceGT9L3k4mp2K2mrm3pN9YE2ndLcLvVtdMFcXxzji/WiwTcvmkYRmvHG+LNvY172ZYpti2DaIN3+SpxTIxKTAtgQRINwqQmEwX6yQUAQoQR+QpQKJSoQCxJ0IB4uC+MbNJogCxA0cBol9HFCB6JhQgeibuLEC+Sflmgmzpujw+nSDtxkWjPAMSF1TdzCYFCAUIPSD6NUAPiJ6J9IZc8jxpFilAKEDoAbFbA/SA6J81r7oHZEYCCZBOFCButsNmdwwJUIBQgFCAUIAwBMvBGmAIlh0UhmA5WCMMwdJBYQgWMDNVwnhAOj6iB4Rb/leIAAUIBQgFCAUIBQgFiOThogChAOEZEHObu9kJJEDaU4CYm6BXvVRIaBgGjZ2Hnb8dVl9JwJYl47Dxl32Yv3QTnj4PxPjBHfBBuaJ2w+zYbzIqlymMhh+Vd5vhU4BQgFCAUIBQgFCAUIDo1wAPodszoQAxt3WbmzqfuYIuLvX5w1Mutphw5ngGxID9nn1HMWnOSiyeNgB+vj4ICQlFqdqdsf67kXgtSwZYw8Ph42OfcYkCJHqgzILlgI2caAlWZsHSg2MWLDsmzILlYIkwC5YOCgUIBQizYLlmwz0vgQRIWwoQ10ygO1u5//AJKjfuidDQMPj5eqNsiXdw5fodnDp3Bf5+Pkji74e9P07D9Vv3MGTCdzhy/CwyZ0iLwKAX6NCijikPyJ17jzB8ymIcPnYW/v6+aPfJR2j0UQUNS3BwCKbMXY1tuw8gJDQU1SsWR5+OTeHt7YXuX32D1KmS49qNuzh8/AwK5s+Fob1aY+q8Ndiz7wgyZUiDcYM6oMCbOV7a2rtMRi2kHA0PfC7asAgpVsMD5bSYFhNZdiz+SQ37YvGS0/B6ps9iaMMaLKdNvJO9tMgkiZdx2llfL1mBeIQEGY/38BaxH9YQ49SomgGrkKbVBFeruE7k7GMWf+N0o6qrFm9fwzGfyllVZOInzI2/ibkJDJVT2/p4Gq+BDLtniX1FaIhhGY/UcmrbgPc/FttJsneh8X0h9EOr7OFpbCNIfpaIaYfFdQZ4CM8J1clHlToY9jWttzy/t18Y38MZ9n8vcpfWszLwsFgTQzsh4fK9leHoj8bPEh/j+0pVDn8mp432KF7bsJ1w/5QiEyFLNixWOa2716m9Yjtns5QxLJMridzOzRAfQxuek43TyarKyV7LIPb12t5jhmWu/3lDtLHuwkPDMtNv7RJt3Js/QSxjEZ571/b+K9p4rVx+4zLtx4g2MqUy3i+IBqIpsCBNwnhAPntAD0hM5+yVqrdh+x9YvWkPFk3tr/X71t0HqNyoJ07sfvkjHR5uRaN2Q1CiUH60alIDzwIC0WfYTDSrW1kUIKpu4/ZDUa1CMbRuWkMTEy26jcKc8b2RL082jJ6+BDfv3Mfo/u1gtVrRqf9kVC1fDJ80+EATIGcvXsOXnZohZ7ZM6DtyDq5cv40v2jbE+0Xewvylm3Hj9j3NlrooQPTLjgLEwa1IAWIHhQJEv0asFCA6KBQg+nVCAWLPhAJEv0ZedQGyMK0gjuJot9vqvizc4qhpl5tlCJYBUkmAnDxzCe36TMTutVPg5fnyrZ/ZEKx/Tp5H72EzsX35f28Shk1ejKyZ0uGzpjVQtHp7bFg0ClkypdPsbt31F9Zt/RWzxvbSBEjhgnnRolE17W9zftiAcxevY9zgl2/z9h86ia/GLYiwTQFCAUIPiH4N0AOiZ0IPiD0TekD0a4QeED0TekD0TBK7B2RxAgmQFhQgLhdCbmlQEiDb9xzUDqSvmD0kov9mBYgSFP1Hz0Xa1P99iVeFXdWvWQ6fNqyKcvW6IXPGtBF2w8LC8HqWDNp5lKgCZPGqbTh68jwmDumklVf/3f2r6di1eor2/xQgFCAUIBQgDMHSrwGGYNkzsTAES7dIGIKlv28YggV8ny5hPCCf3qMHxC0Fg6s7JQmQA0dOod/IOdixapLTAuTQsbNahq3NP4zVdVuFZxWp3g7bl41H+rSpdH+nAOEZkMiLwsIzILp7hGdA9E9DChAKEJ4B0a8BngGxZ8IzIOZ2kksSSIA0pwAxN0GveilJgAS9CEaVxr3QtvmHqFiqEJQgmTR7JXq2byyeAVEpfhu0/QpVyhbWPB4WWHDs1AXtkHnJwm9h6ISFuPvgEfp1+RhpU6fUznxcvnYLtauWpgeEh9Dtbi0KEP2ThgKEAoSH0PVrgAKEAoSH0F2zM12W/i3XGHLSSrO7J52s4b7FeQbEYG4kAaKq/nn4XwybtAgPHj5BhVKFtMPg9WqUFQWIqnvj1j2Mn7kcB4+eRtCLEO3wee+OTfDuW7kRGBSMb75bq2XBUrZfz5oBrRpX12zTA0IPCD0gzIIVeQ0wC5b+QU4BQgHCLFj6NUAB4poN+fIEEiBNKUBcM4G0Ej8Egn+V0/BafPwMO2PmDIE1KMDYRliYPOAw43SjmgEhHayHiTSunmkzxXq8V7K+L47Hx8M4RaeXp5yG11uwkfzQOrEf1nCZvcXbOJWkNSgw9u2Y6YeJdL8W3ySGfTmTp7rYV18hTaSfiTS8nsLcqE5IM5xqzzyxr9L955E0uWgjqGwLsYz/vuXCfSGnp5ZGbA2VU0KLabAlqIq7j7843qsljJlkSCKn9A4SUjGn3DVH7IeUulgZuFW6taGdMDkLL7Kd2mxoI9zEt1M8U2cUxxN2+6rxOqpsPBZVWUrD+9cNOa17qWvbxb5uSlvRsEzN142fi6pyqLfx82hH7mJiP9Lk1IdbR630+NoTQzsbrhr/XVWumyu1oY1KB7eKfQ3ZIq/p8+v/MLTz+Irc1zfqFzG08bz1SLGvudLJz0bRiIMCKzMkjAek8R16QGIyX/+v6qzZtBebd+yPdswj+rVF5gxp4oUJBYgeMwWIngkFiD0TChD9GrGGUIBEpUIBol8nFCD2TChA9GvkVRcgqxNIgDSkAImXfTMbcREBChAKEHpA9GuAHhA9E3pA7JnQA+Lg2UkPiA4KPSD6dZLYPSBrMhZw0Q7NOTMNbp9wroIbl+YZEDeeHFd1jQKEAoQChAKEIVj6NcAQLHsmDMHSrxGGYOmZMAQL+DGBBEg9ChBXbY1pJz4IUIBQgFCAUIBQgFCA8AyIfg3wDIg9E54BMbcrW58pYTwgdW7RA2JuhljKLQhQgFCAUIBQgFCAUIBQgFCA8BC6a7ZlPyWQAKlNAeKaCaSV+CFAAUIBQgFCAUIBQgFCAUIBQgHimn3Xhixvu8aQk1Zq3TjuZA33Lc4zIO47Ny7rWfBvK0RbYhresFDRBkKNU+hKqUTlBv5XQkjlavGV029KWbDg6SV251SKgmIZXy8PwzI+JtLwelmMc46mO75B7AcEG5oBD09jOybWgFVYA3JHVf7NcLGYxdv4OyAX36gp2pDmxkSmV5jIwium4U37xyKxr9K9ZRE+zqkaCC37idiO95+rDcuYyoJlMV7z0lhUB8RnhZl0zj7Ga0S1c+rdjw3HmyOlnIZXyMKLpGbS8HrK7Two3cqwr2FS3loAmU8bp6UNe3xPXCNeWXKKZUJvXDQuU0FOCS01suPiY6kIqgUfFcvMD3rTsMyn78hph4OFHMjbcxUV+5E2o3EqX2Vg1fG7hnZqvZ5Czp2NTQAAIABJREFUbCdbmdcNy7wx+wfRhte982KZP1v2NCyTMpvc15wNKhnauPR+W7Efb2WS2xGNOCiw8TX59z8mdqU6H107JhV5Zf5OAfLKTFXMO0oBomdHAeJgPVGA2EGhANGvEQoQPRMKEAdMKEDsoFCA6NfIqy5ANr3+Tsw3ZbGo+eHVf2JR272qUoC413zESW8oQChA6AHRrwF6QPRM6AGxZ0IPiH6N0AOiZ0IPiJ5JYveAbM6eMAKk5mUKkDjZKNNo3BCgAKEAoQChAGEIln4NMATLnglDsPRrhCFYDkQoQ7CwOce7cbNhE6zWvCSHFSZIx2LQKD0gMYD2qlWhAKEAoQChAKEAoQDhGRD9GuAZEHsmPANiboe3Jdd75gq6uFSNC0dcbDHhzFGAOMF+38ETGD5lMa7fvIdm9SqjZaNq6DN8Fk6cuYTc2bNg9dyv7awdP30RXQdOxa7VU5xoxfVFKUAoQChAKEAoQChAKEAoQHgI3TV7rK15CrnGkJNWqp877GQN9y1OAeLE3DRuPxTN6lZGraqlEBoahukL1uLxk+cY3KMFwsLCkcTfPusKBYg9XDGzjdm5YBYsO1LMgqVfOMyCpWdCAUIBQgFCAUIBYnajYVxuW97CrjHkpJVqZw85WcN9i1OAmJyb0dOX4Ic1P8PHxxueHhZ0alUPU+auggUWeHt7ovvnjfBJgw+weNU2LFq5DU+fB+DN3Nlw7eYd0x6QhSu2YvHqbXj6LADZX8uE+w8fR9S9euMOhk5ciCPHzyFt6hQIDglFl9b10PCj8toIjOqGXZZddpbQYEMSVhNpafEiwJimiTSukFJ4qhak9ERhYfKsJhFS85lIi3nBT05HKWThhbcL8rhmfnJOHm/gU7mMr5AGMvCZbENKjypl2lIteAhpXFUZYS1dzCCnvUzmbdxOSLhVHK+/NMEqpaxgJc3lfWI7Unpjq4l7KyB/ZbGd5DeN44tNvUQIF9Iom0izbA0OMu6rieeRxcRaO52+mGE7af2F1NQAkvkIqbZP7hS5W0ykyb6T8+WzPrrLKq40IPODk4Y2wu7fEPvqkVF+7t1c8I2hnXT9p4ntSA/6qt/sF23sapRKLLP+qXGa3Q9zJhNt3As2XgOzM8sHlu+8kH+3Gr2d3rAvvsnl1NMFWpQxtJHk4z7ieL2uyOcQTo2bZGgnw3t5xXaS5njNsMyNsu1EG3nSJxfLxKTA9jcTRoBUPU0BEpP5euXrVP/4Swzr8xmKF8qnjWXwuAXIlD41Oreup/3/L7/+jVHTfsCErzoix+uZsW33X5jzwwZTAmTb7gMYP2MZpgzviuxZM2Lzjv2Y9f1PWt3wcCsafv4VypZ4B581rYlHT56h19cz0LROJU2AGNVV/aIAcbD0KED0UChA7JhQgOiXCAWIngkFiJ4JBYg9EwoQ/Rp55QVIviIJsqeteurvBGk3LhqlB8QJqpIA6TxgCt4vUkDzhKjLmRCsTv0no3Sxgmhev4qu7onTl9Ch70TsXjMVnp4v37R07DcZlcsU1gSIUV0KkGgmmAKEAoQeEN0aoAfEHgk9IPrHBD0geib0gOiZJHYPyM9vyV52J7aXpot+cPKg6bLuXpACxIkZkgRIndYD0at9Y5Qr+TI9mzMCxKju9j0HMX/pJqyYPSSit5EFiNQuPSAOJpkChAKEAoQChCFYdmuAIVj6xyJDsPRMGIIF/PK2cfimE1tLp4pWOX7AqfLuXJgCxInZkQRIq+5jULtqKdSvWc5pAaLq1qxcEo1rVdDVPXDkFL4cMQs7V02GLVY4sgAxqksPCD0gGgGeAdEtBJ4B0d8b9IDQAyL9JNIDQg8IBQiwo2DCCJDKxyhApGdUovy7JEC+W74F67f9jtEDPteyZM1duhHH/r1g6gzIwpVbsXrjHowb1F6rO2/Zpoi6L4JDUKVxT7RoVA1VyxeDEiSTZq9Ez/aNtRAso7oUIBQgFCCO1wAFCAUID6HbrwF6QOgB4SF0c9vXne8WN1fQxaUqHf3LxRYTzhw9IE6wlwRIcHAIhk1ejJ/3HkTG9Gm0Mxrrtv5qSoCousOnfI/tew4gU4Y0qFahOFZt2BVRV4kOlQXrwcMnqFy2CC5fu4061UprAkSqyxAsB5PMECw9FB5Ct2PCQ+j6JcJD6HomPISuZ8JD6PZMeAhdv0Ze9UPouwqVcGL36LqiFQ//6TpjCWyJAiSBJyC65qXzI5FDsKLaiFo3/Kyc5lNOfSrlvgWswYHGNKX0nCbnwip9B0TM06tyZ6Y0bs3TR+zN1SS5xDL/yxkQbTlPE+k3pUYy3ftHKgJryAuxjMXX37CMNUhIs6xqW4Wks2bGayZNq9DOlUzyj0MS4QxIsIk0vMmFFKwKiUrVbXQlPbVDnBtI6Y1NcH1R4GVyDKPL/7Lx2zVzAkRKJ2riWRJinBZcTm4MmEnDeynby3DZ6C7JS6bq+QmpmM3Mr8VE6unbQhpeaW7V3zPfP2ZYLOzhXdGMR4ZsYpm7S+cYlknVY6JoQypQe76cDWhLJWktAj97vMxqGd1VMauc2vZ+iJehjWFpCkjDQQZfOeXz2yn8DO34ecr3VqE2xm/uM/YeLfbVenibWObAIOM1kC5/OtFG5vffNizzsE4/0UaOdHIaZdGIgwK7CpeMSbVY16l4SE4/HetG4skABUg8gA4JDUOHL6N/4BYvlB/tP61l1xMKkOgnhgLEng0FiH6tUIDomVCA6JlQgNgzoQDRrxEKED0TChBgd9GEESAVDlKAxMO2/f93ExQgFCBm7wAKEAoQ0AOiWwT0gOjvC3pA9EzoAbFnQg+IuV/ePcXeN1fQxaXKHzAR0eLiNuPKHD0gcUXWjewyBMvBZDAES79hYwiWHROGYDl48ymGRgFiuJiJEEk51Ev6vjxDsBz9BFGAUIAwBMs1m7O9JUq5xpCTVsr9+YeTNdy3OAWI+86Ny3pGAUIBwjMg+jXAMyB6JjwDYs+EZ0D0a4RnQPRMeAZEzySxnwH59f3SLtujOWOo7L7fnSnu1mUpQNx6elzTOQoQChAKEAoQngHRrwGeAbFnwjMg+jXCMyAOPKE8hI5fSyWQAPmDAsQ1O2NaiRcCFCAUIBQgFCAUIBQgDMHSrwGeAbFnwjMg5rZlv5UpY66gi0uV+e03F1tMOHP0gCQc+3hr+clzIT0uAB8hfZ8lNMhEf4UUgCYOylotHnI7QhlLWIhow+phnDYxFHI/bjwLFduRviUhtwKEC61kT+Et9kPIFKrVt7x4LtqRClikdLGSAa0jcipJS6hxmtawJKnFlqR1Euwpp9+Uewo8DTaewZQm0m96WI3TiUpjUTACLHJqaQ+BvZeJAYcKxzN8PeTzG9LkhZu4P62Q27ny2PhZkSuZbCNMWCdeAfel4aj81WIZq49xOlGrp/wcsIQZ3zeWYPkZEOCbRuxr8ofnDcuEpM8r2pAK+NwwTims6j/LaJzGVZU5cdf49zFtEuPfCmVjUsZ3DLv71YMT0nBMrAAgqZA6XPiz1oe7gcbPkgeB8u/axYfynuK9TMbrNSBU+mUDAkKM+5rWX17zedInF9nHpMDvZcvGpFqs65T+9ddY23AXAxQg7jITcdgPChA9XAoQPRMKEHsmFCD6NUIBomdCAaJnQgFiz4QCRL9GXnUB8kd5428IxdWWrtSevXFlOt7tUoDEO/L4b5AChAKEHhAHgkvwlFGAUIDQA+Jg40gPiA4KPSD6dZLYPSD7KiaMAHl/FwVI/O+i2WKMCVCAUIBQgFCAMARLvwYYgmXPhCFY+jXCECw9E4ZgAfsqlY/xniw2Fd/fuSc21d2qLj0gbjUdcdMZChAKEAoQChAKEAoQngHRrwGeAbFnwjMg5vZh+6tUMFfQxaVK/rLbxRYTzpzbCJC5SzZiz76j+OGbgfFKo2LD7pg+8gu8/WbOeG336Mnz+LjTcBzdMR9enp6I2o+of49N5yhAKEAoQChAKEAoQChAKEB4CD02u6n/6v5ZtaJrDDlppcT2XU7WcN/ibiNA7j98gucBgciWNWO80kooARIYFIzL124hX55s2nij9iPq32MD5e6TALH6izDjjBTpveWMFVImF0uInDnDI+ip2Ferp3E2n3A/4+wbWgNCFiyPZ/fEfgQkzyKWCQ03zm5jIqkQpA/mPQ+R5yY4TM6yk0rIxiRbADzDXhgy8Qh6IjKT5lcZsHr7Gdp5Gi5nR3khMEnnLWeDkb/6DTy0GmfTMpMJzdPDeKUkNXE6PMTEBAYKa8lL6IealCCBq7TOlA3vJzcM5zcgWWZxHYWYWPO+Ajfhsaj1wR/GmaVMZacSsrqpdjyfGz+TrCa+MP8ihfEzy9sqZxC0BMvPcQiZCsP95MxEVmG9eljl+/N5mHx3pXh2zXAtdclSVVxrPW//Y1gmexITN5+JDJBhHsbPNU8TWczELIMenuJ4YZHLWIKfGdoJ8kkptuML4zkOgpyhLGVSf7GdmBT4q1qlmFSLdZ3i23bG2oa7GIixADl78Ro+6TISvdo3xncrtiAg8AX2rJ2KIyfOYcw3S3H56i1kyZQOg3u0wHsF8mjjvXHrHr6etAh//3MaaVKlQHBIKLq0roeGH5XHivU7sXvfUcwc0wPKdvPOI9ChRW0s/XEHAgKCMKDbJ7Barfh24ToosfLRB+9jSM+Wmt3g4BBMmbsa23YfQEhoKKpXLI4+HZvC29t4cQ4etwBrN++Fr483PDws6NiyLsqVfEc3ri1LxuGTLiNw9cZdWK3hyJ83h9Z2npxZtfZL1e6M1k1qaO0rUVG6WEGMG9QePj7euH7rHoZNWoTDx8/Cz9cHRd/Nh0lDO+HClZto3G4IDm6dA0f9qFi6UMTfVRuXrt7S7Bw7dRGZM6ZF988bolLpQlr7S9b+gp/3HkTObJnx856D8PP1xlc9W6JcyXe1v1OAOLjdKEB0UKSNoYmfUAoQB0uNAsQeirTOVGkKEP1CogCxZ0IB4mCNUIDooMSVADlQI2EESLEtFCCaSKjbehDq1SiLJrUrwt/PF8mTJUG9NoMwaUhnlCicHzt/O4zhUxZj27Lx8PbyQqN2Q1Cq6Nto06wmHj99jp5Dv0WzupUdChBlu1WT6mjwYXkcP3UBA0bPQ4X330OHlrURHhaONr3GY97EPnj3rdwYPX0Jbt65j9H922kipVP/yahavhg+afCBKPSieh4cjSv765nwz8nzyJMjqyYqVm3YhV1/HMZ3k/tFCJCC+XKhY8s6SJrED536T0HHFrVRv2Y5dBkwVRMq7T+tjUdPnuHHLb+iU8s6dgJEGYnaj8gCJSQ0DLVbDkCjWuXRrG4VjUe3QdOwZMZg5MqWWRMg0+avwRdtG6JsiYLY+Ms+rN6wBztWTaIAiW4FUIBQgNADolsD9IDYI6EHRP8ApQdEz4QeEEfrJHF7QA7UrCzuL+OiQLHNO+LCbILYjLUH5M9NMyM6Pm/pJu1N/Yi+bSL+rVaL/hjV/3N4eXni894TNC+Jp+dLt2jHfpNRuUxhhwJEeVdstpWoKPRBW6xfOArZX3sZovVp11FavdpVS6Fo9fbYsGiU5nFR19Zdf2Hd1l8xa2wvEaojARK5bZuBjT/vw+ad+3H24nUEBAbB08MDe3+cFiFAFkzqGxFONXTCQiRL5o/eHZqgTa9xSJsqBXp2aIxM6f/7gFNkgSEJkEPHzqDn0BnYtXoyLP/7UJjymqRPmxLd2jTQBMj+v09oZ1nUdff+I1Ro0F3zrvj7+dAD4mgVUIBQgFCAUIAwBMtuDTAES/9jwRAsBz+gDMHCwY+qiPvLuChQdOMvcWE2QWy6VIAMm7wYm3fsR7JIMXdqsz52YHuoMw3zl27CitlDIgZqVoCoCiU+7IhlM7/S3virq12fCZqXQ4UqlavXTQtLsl1hYWF4PUsGLJ42QIRqRoAoj8L4GcsxrM9nKF4oP67dvIOWX4zGHz9961CAqLKhYWHo37U5zl++gfEzluGvw6eQJlVyNK1bGW0//tApD8iWnX9i4YqtduxmLFyHG7fva2IvqgBRzIvV6IB9G2cgRbIkFCAUIOAZEP0i4BkQPRN6QOyZ0AOiXyP0gOiZ0APiaJ0kbg/I37XlCBtxAxqDAkV++jkGtdyziksFyOzvN+Dm7fsY2ruVbrRqAz5gzFz8smKiSwWICnMqUr0dti8bj/RpUzlNuUrjnpj8dRcUzJ9Lq2s72xLZs/PV+AVImTwZenVoHFHGrACxdUgJkoNHT6N9n4lYOWeodj7FdgZElYnaj8geEuUB6THkW+xeM8WUB4QChIfQo94IFCAUIDyErl8DPIRuz4QeEP0aoQfEwbaKHhAcqpMwAqTwegoQhxv1qzfuoEn7rzGkV0uULfEOHj95jv2HTqJEofxInSoFqjTpiW6f1UelMoXx9z9nMGraD1oIkaND6FHDoKLzgKi6KuTp7oNH6NflY6RNnVLrmzoMXrtqaVGQqHbKFC+ITxtWxYvgENx/+Fg7hB5ZgKgUwTt+/RsThnTC84AgTJy1AsdPXzTlAZk4ayVqVCqON3K/jqvX76BJh6+xbsEIBAWH2AmQqP1Q50VsAsV2BqTBh+XQvP4H2hmQroOmYWmkMyCRQ7AoQChAKECYBSvqGqAAoQBhFiz9GmAWrChMmAVL3DeqAofrydnRTBlyslChH7c7WcN9i7vUA6KGqYTFlLmrcOrcVS27VJF33sCQXq208KP9f5/EsMmLtCxWpYoW0LwlzepVQZ1qpXVZsJwRICq865vv1mpZqB48fILXs2ZAq8bVtQPy0qUE0qCx83HvwWNNwKj+Rm1biY4+w2dq/X8tSwZULVcUS9f9YkqAqMPh6vyIGnPG9KnRqWVdLYNX1DMgUfuhQr0ie0guXrmpsTuusmBlSIvu7RrZZcEyEiD3TKThlTjdCZBTHl5+ZJyeMUzKq6hSTf7vjItRfwJCwgy7m8RbThGYyt94g+rzv3NKRg3l3f6fNy+6cj4ZjdNeemZ4TUIPz9QvzzZFd91O945oQ0oHrAzcCzSe4wsP5HTOUuZTfxMfJAkKldMK+3sbp9esgTMik/C02Y3LWOV+WG6cEtsJe3DbsMyVgg1EG3cDjFO9vgiVc5SVSfFcbOeO93+hrI4KPzehYvyEcxUXHgaJ/bj+xLjMOxnlNK6Sd0N1IvMW43vYs3F/sa9egQ8Nyyw4a5yaWlUOlW4cAG3fy2DYjkeAcT9U5X8Ckxra2Hf1kTje6nmMn0fKgJQ6PK2/nB4XwpKWvmmi+nHrhfxbMDrd24Zj/uaGvOE78MKYyeMX8u+n9LumOnn3ufFzIENS4xT1yka+dMZrII/HfXENeAQZh1cpA7+HGqfKzpXKOJW6spFcSA3vvXm62Nckjb4Uy8SkwOH61WJSLdZ1Cq3dFmsb7mIgxgLEFQNo2nGYlk62ZOG3XGGONqIhQAGiB0MBomdCARKFCQWIbpFQgOjvGwoQPRMKEHsmFCD6NfKqC5AjDasnyJ7zvdVbE6TduGg0XgWI+tK5OiyeMV1q/PrXP9rBbvWNjST+xh/qiunA12zaqx2Kj+4a0a8tMmf4LzNVTNtx93oUIBQg9IDo1wA9IHom9IDYM6EHRL9G6AHRM6EHRM8ksXtAjjZOGAHy7koKkBjtudV5iNUbd2sfIMybMyv6dW0e8ZHCGBlkJVMEKEAoQChAKEAYgqVfAwzBsmfCECz9GmEIlp4JQ7CAf5rUMLX/cnWhd1ZscbXJBLMXrx6QBBvl//OGKUAoQChAKEAoQChAeAZEvwZ4BsSeCc+AmNswHmtW01xBF5cquGyziy0mnDkKkIRjH28tU4BQgFCAUIBQgFCAUIBQgPAQumu2Xsebf+gaQ05aeXvJJidruG9xChD3nRuX9YwChAKEAoQChAKEAoQChAKEAsQ1W6vjnySQAPmBAsQ1M0gr8ULgWYBxelzVCe8Q4xSdFjMZgYKeGo7HEiKn3/QIllOFWr2MkxZYveX0frAYp4E0k9IyJOOb4vyJqSJD5RSdHi+MmQSlyib2wztUXgMQ8l5K/dA6ERZi2BePEDmVr9VD/oaHtAauecqpQqWs0OmSeIlczaSWDhfSiSbzME4rrToh3TuWoCdiX8OTG6dxVQasnsbsLSbWq9XDmJvns7tiX6UyoanlNW/1SSK2A+G5ZvWU10BAqMWwnaSQ73FLiFzmmXcKw3a8PIz7oSr7BT0wZmIiDbrHpSMyVy/jdRTyhpwiX2rE6/ENqQi6Zqoklul/77hhmeQ+cspgiX3SKwfEfiCJ8fxq9+ejO4Z2wh/dE9vxSG78weaDaUuKNgqdXS+WCS3V1Hi9/rlKtOHxVhnj8frLH5/2TRE3iYZOtPhI7H9cFCiweGNcmE0Qm/SAJAj2+G2UAsQBbwoQB1CMd8oUIHpkFCB6JhQg9kwoQPRrhALEweOXAkQHxZ0FyMmWteJ3I/e/1t5atCFB2o2LRilA4oKqm9mkAKEAoQfEwUZZ8EzQA6JnRg+Ingk9IA6er/SA2EGhB0S/RrxecQ/Iv61rJ8hOL/93PyVIu3HRKAVIXFB1M5sUIBQgFCAUIAzBcuT0M/7aPUOw9MwYguVgMy2Ev1GAJEIB0qZOguz08s+Xw98SpGMxaJQCJAbQXrUqFCAUIBQgFCAUIBQgPAOiXwM8A2LPhGdAzO3wTrWta66gi0vlm7fOxRYTzhwFSMKxj7eWKUAoQChAKEAoQChAKEAoQHgI3TVbr9Pt6rnGkJNW3pzzo5M13Le4ywXIex+0xczRPfB+0QKGo16xfid27zuKmWN6OCxXtHo7rJ0/HNmyZnRferHs2YUrN9G43RAc3DonlpaMq1OAUIBQgFCAUIBQgFCAUIBQgLhmu3W6fQPXGHLSypuz1zhZw32Lu1yAnD5/Fa9nSY8k/sapUClAgPgSIIFBcvrbF6HGJ3L9PIUTu2qNC5mlzNwGlmA5TaslxDilrJmUwRBysIb7JjPTXRNljLmZ6asl2Hi8ocnk9KoBocax7mogSbyN002GS/lktTVgjMQr3DhNr2bCRLpmKX1quIn0jE+DjZmEhMlrPqWfp7gGgsOM2/E0kfpUasRMNi5fTzmdqFVIxSylLlb9lMpIKUuVDSldc4iXv4QEZparX8gzQztm0nE/TfGaoQ1vE+lxPU2U8ZBSIEvgAYR4Gqcw9zCxFr0fXxfZDzpo/JsztHJu0YZ09/VMkk+0Mf3WTrFMeNK0xmU85Hvc+9a/hjaqbwkW+xEUKD8b+36Y39BOUh+5ryUzG+/Ngq2yjYdBcurwcw+Mf7dypJLT5YcIN3FOP5mZb0phfsWZcVzgTMeGMawZu2pvzFwdOwNuVNtpAdKx32S8VyAP2n/6XwqyDz/th14dmqBS6UIoV68bZozpgbffzIng4BBMmbsa23YfQEhoKKpXLI4+HZvC29sLUQXI/kMnMWb6Uly9cQcF3syBoyfOY8PiUaY8IAeOnMLEWStw7tJ1ZMqQFm0//hB1q5eB8sb8tHBkhI2vJy5EqpTJ8UXbBjh78Ro+6TISvdo3xncrtiAg8AXy582OwgXzot0n/42tVov+6NG+sTa2IyfOYcw3S3H56i1kyZQOg3u00FhI1/Vb9zBs0iIcPn4Wfr4+KPpuPkwa2kknQC5dvaWVO3bqIjJnTIvunzfU2lXXkrW/YOuuv5D9tYzY9cdhpEiWFF/1aBHhaTLqGwWIgxmiANFBoQCxR0IBor9vTOxxKUCiYKMA0a8jChA9EwoQPRN3FiBnOzWStn5x8ve8M+Tvp8RJw3Fg1GkBosTE1HmrsfmHsVp3jp48j64Dp2Ln6snw8vS0EyCjpy/BzTv3Mbp/O1itVnTqPxlVyxfDJw0+sBMgt+8+RK2W/TG4ewuULl4QV67fRqvuY+zEQ3Rjv3bzLup9Nhgj+rZBmeIFcfr8Ffzz7wW0alxdFCB1Ww9CvRpl0aR2Rfj7+eL85euYvuBHbFw8WmvuxOlL6NB3InatmYL7D56gXptBmDSkM0oUzo+dvx3G8CmLsW3ZePj6GH90qcuAqciTMyvaf1obj548w49bfkWnlnXsBEhIaBhqtxyARrXKo1ndKjh+6gK6DZqGJTMGI1e2zJoAmbFoHXq2a4zihfJpok4Jpx0rJ+Hxk+eGfaMAoQChB0S/BugBcSAw6AGxg0IPiH6N0APigAk9IDooid0DcrZL4zjYkssm836zUi70ipRwWoCEhISifP0vNC+HevuvvApJk/qjd4cm2pBtHpACb+RA0ertsWHRKM1boC71Bn/d1l8xa2wvOwGycOVWHDp2BtOGd4vAZvYMyMzF63H63FVMGdZFh9yMB+TPTTMj6imPTYUG3TFnQm/Ng6MElBJVfTo1xbylm6A8FEro2C7lHRnV/3MUzJ/LcLrb9BqHtKlSoGeHxsiU/r+vckYOwVLj7zl0BnatngzL/9zgg8ctQPq0KdGtTQNNgOz/+wSmj/xCa0sJOsV66vCuOHTsrGHfKEAoQChAKEAYgqVfAwzBsmfCECwHvxUMwdJBYQgWcK7ryz1vfF95pq+I7ybjrD2nBYjqyYgp3yMsLAz9ujbXxMiSbwchd/YsdgIkc4a02gZZhRLZLlXn9SwZsHjaADsBMnLq9/D19YkQMaq8WQEyZMJ3SJbUXwvtino5K0BU/eGTF8PT0xN9OzdDxYbdsWBSX817MWzyYmzesV9ry3YFBAZh7MD2KFviHcMJOn/5BsbPWIa/Dp9CmlTJ0bRuZS1MLLIA2bLzTyxcsRUrZg+JsDVj4TrcuH1fEz1RBYgqVKf1QHzRtiF+++uYYd8oQChAKEAoQChAKEB4BkS/BngGxJ4Jz4CY22+f/6KZuYIuLpV76jIXW0w4czESIMdPX0TbXuO1TfqqDbuxdMbgiBHYPCBv5c2BItXbYfuy8UifNpVuhJHPgKiN9pUbdzBmQLuIcmYFyIxF63Hu4jVMGtpZ10axGh00cfRGrpeHBB2dAYnsAVFl1PkmZgXiAAAgAElEQVSLjn0nYXjfzzBr0U8RgmD29xtw8/Z9DO3dKsazFRoWhoNHT6N9n4lYOWeodhbGlgVLeUB6DPkWu9dMMeUBUSFbZet21cTcrt8PG/aNAoQChAKEAoQChAKEAoQChIfQY7yFs6t4vvvHrjHkpJXcU5Y6WcN9i8dIgNjevt+5+1A7fN7wo/I6AaJCmIZOWIi7Dx6hX5ePkTZ1Su3g9+Vrt1C7amk7D4gSNK27j8XEIR2RNVM6bPxlP+Yu2YjNP4wRD6FfVKls2w/F6AHttDMg6iC6OsDevH4VNO3wNd4tkEf7b+V9UAfiG9X6P/bOOz6q4mvjz2azm95IoYcOAtI7SpMmUkSa0nsH6UjvvTdpIkhTqoCAUpQiCggIIkjvJQRCCOl1s+/n3vwom7vMuUl2swvv2b+UnDkz98zcu/PdM+e5NU2K0FMDiHQhTTqNRkxMLLq1bYQvPv1IvjapOP7znhMxfkhHOeMh1V1IhfOVyhR9ecTsTdM8d/kWNPioIgoXyI37D5/g814TsXP1FMQlJL4EkBc1IM0bVkfbZnXlGpD+YxbJcPeiBmTX/j8wZ1wfuLk6y0fCpKL2H5aOhVQHIxobAwgDCAMIAwgDCAMIAwgDCAOIZTbktwa3tYyjNHrJP29jGlvYr3m6AUQ6LrRkzY84+uMieUP84vO6ClZsXIJsIxVMPwuLQO6cAXJxuFT4nVoFa+3W/fj2+73Qah3QqkktrNq4FztWq3sPiHQESYILCUayBWSRjzdJfUgF8iOnrUTY80hUr1IKcXEJyJ8nBwkgazb9gkWrpWtbCE9315fX9ve/17Dgm624cuO+XHhermRhjB/SST5WJfos+nY79hw8gdCwCGT190Gfjk3RqG4VhQqWNP5J89fioqSCFeCLgT1amqhgSbUyep0jgp88k/ueOKwLsgek1JSIxpb4+Ba5Ah3ixXKUiAghfSQ+vC20SQi6R/q4e+AMaeNTJKfQxsmLltClbJ6cvUaOI370N6RNMiEbRElNSh3otWJt20Lxd8hxICactEkKviu0ib9znfQRfuOB0Obmvkukj6wl/EkbZ19Poc0fbWaQPm6HRgttelQQy6tKjb1VyPAmEVKSztePkWNNeii+hzV6sbyq1IG2+IdkPw6xz4U2xphI0odGL5bXTHx4k/Rxd7P4bb/5uncmfTi40M+Byz4pKoNv+uT3puMaR0hcO/+8kBzr8+v0szHL4DlCPxojLY2KU7uEPh4fpGVr/auUJa9HU7e70GZXIO3jcIhYkn1ezBV6HIQsuORAQz6jaScq1IvJsVrCQI30NHU1Go2KbyUVJiCCosYFFZObYfGUCd7P7kXapMfg9tB26WmW4Tb55mzIsA97cZBuAPl6zQ5I8rJSETZ/rB8BczUgantlAFFGigFEGRMGENOYMIAo1wgDiDImDCDKmDCAqP12tqwdA4gynlYDkGHtLTt5Kr3lm71epaX9m6ULQAyGZNT9YghmjemF8qWKWPUqpy3agJt3gsz24eXpZrb2w6oDSuVcOjrVa/jcN3ZZsUxRk3empHdsDCCvIscZENNVxBkQ5V3FGRBlTDgDoowJZ0BMY8IZEDPQTb1dVcqiUGmF9H7xp7EdA0jmAcidrzqkcXYsY5535jrLOLIDL+kCEOlFeDOX/IB938+yg0v4/zEEBhAGkDetdAYQBhA+gqVcA3wEy8wTg49gKYLCR7BMQ8JHsNTtKe+OSL8gkboezFvlmfFdRprbVdt0AYhdXQEPhowAH8FShoiPYCljwkewTGPCR7DM/BrMNSCKoPARLOU64SNY5NeyVQw4A5J5GZC7o+g6NGtMcp5pa6zh1iY+GUBsEvbM7ZQBhAGEi9CVa4CL0M1kDbgI3SQoXISuXCNchG4GuPgIVpqD8rYXod8b3SVzN3L/6y1w6mqb9GuNThlArBFVO/PJAMIAwgDCAMI1IMo1wDUgpjHhGhAzWT+uATEXFHqX846rYN0f25WOgRUsck/+1sRrWHgkxs5cjeNnLsovym7foh66t230xp7nrdiCb3/42eTvH1R4HytnD7XCaMUuGUAyPeSZ32FSEC0pq4mLEA4s+elDcuCJd68KbSJviyVapcZXtp4m+8leXizD6+JHy+45+4pt7h++QI6j2ObdpA31K4+aH840hkRhP9pwem408WLJWamD5GePhP0kETLLUuO4h+Kx3D98noyZX4k8pI0zMcc/lO5N+rgUJJYmHvVRQdKHr7MDaZNILAK3B+dIH0lP7ovvz4hnpA+HKp+RNtpIsdy2JlEsjSp1YNRohf0kXDxOjuPC12IZ3tKju5E+HHMWIm3ic5YQ21A3MIBESmb5rFj6VhpAAvHslGx0zYaIx5qcTF6vw+UjQpvYi7QMesQd8XNC6sBv5GJhPwNd3iPHWsv/lQS+OeMmd8+SPlSwAzSgJlnNU5oeCm1BjUPyIB5Lxj3Qo0yxyHhPGfegbhzOzi5qLypNdvfH0c+gNDlUaZx70ioTy8ETlsJgMGDsoA549OSZ/CLtaSO7oXrlUmY9SgDyJPQ5Rn35SkbYUauFqwstOa5yiKrNGEBUh+rtNWQAUc4dA4gyJgwgpjFhAFGuEQYQZUwYQJQxYQBJz34h41vyjHtQO+6M95RxD7YFkAcTeqgNlkXtck1Y+dJfQkIiKjbsjU3LxuG9goHyv89etkl+59yMUebHJwFIWHgUJg+3zRGy14PBAGLRpWGfzhhAGEA4A6JcA5wBUcaEMyCpYqJil8QAwgBimW9+FYuNMyBpvkGtlQF5OLGnZaY9jV5yjl/xsoX08upGHUbizL6VcHHWy/++dc8RbN9zFJuWjzfrWQKQ73f8Cnc3V/j6eKJhncro8sUnaRyFZcwZQCwTR7v2wgDCAMIAwgDCR7CUa4CPYJnGhI9gmfsq5yNYyqjYCyzR47AWgARN7mWTfV+Osctf9nv5+l206D4eFw+vgeZ/NTd7Dp7Ayg278dPaaWbHd+/hYyQZkuGs1+HKzfuYOPc79GzfBG0+q53p18MAkukhz/wOGUAYQBhAGEAYQBhAuAZEuQa4BiQ9exJ645859Sr0OKwGIFPpOsP0RJZqk2P0MkUG5NyBb6DX615mQLbtPorNK8xnQFL7l2Dl5N+XsHr+V1TXFv87A4jFQ2p/DhlAGEAYQBhAGEAYQBhAGEAsk8+hN/7vOoA8mtbHJpu97KOWvuxXrgH5pJd83OpFDcisr3/A02fhmDVWXYZmwTfbIGVF5k3om+nXwwCSzpDXajEQi6cOwPtF8skeNu86hCMnzmPZjEHy/6f+u5puHoeEYeGqbTj2178Ij4zGrDG98HGtinLT7zbvw459x3D/4RM4O+lRo0ppjBnYHm6uzgrXF6/eRv/RC3F42wL5bwwgDCAMIAwgDCAMIAwgDCAMIGp2Y7RN8Ix+tJEVLLKNWGLidcDYxXBw0GDMwA548jQMPYbNwYQhnVG7WlkkJxvRfehsdPr8Y1SrVFJuN3n+OtSrWQEF8uTA5ev38NWU5Zg8vKtsn9kfBpB0RtzSACIBR/Nu41C/ZgW0bFQTnh5ukI70+Xh5yCPc8csxFMybE7lzBCA0LBwDxi1Bs0+qmS0eSg0gEdGx5FUmEVKSLo603KiDIV7cj5GWiaSKYKUOjHqxPKO632bEVprEODJmYW5iOWAZ/oi4Oqj4NnAg9NSdtLQTNW/I1RF+tEYDGRNKnlEbE0b6MDoqoVrRiFhLMTpPsp+YRPF69HYWy8lKHWipNQ8gMjklNf6mj4pbC1pioeiTaHncREfxfSONLzZJfF+oGauRuAGdVTjRRT4WxizOPYCcX4OKRR9vEA9WzVidNOL7QpNM3zeaJOLZKT33tClFpm/8qLg/k3TiNaCLjyLjatTR9+cAd7G88YLYK2Q/lMH4X29SJpgaGETaPM5dVWjjr6HvLW1ksNBHyIZX5/bfZJgUl0CO1a9KBbGNgV5rDlWbCX0sv0Rfb8+S3uRYKfl4TQLdz2NHP2E/TiqeJf6e9HOPvBgzBsEz+6enWYbbZPvKVOJaynaMnbUaJ89egpuLM9o2r4PeHT6V+0kyGFCqdldMHNoZLRrVkP9t+uKNOPTnOTlLks0/Czq1qo/PP/0ow+NKjwOLAUhQ8FNMW7QRZ/69Klfj169ZESP6tUFUdKx8wYePn4OLkxNaNaklvyRFIraNP/6KI8f/QYG8OSAVzlQpXww92jVGu35TMaRnK6zZ/AtiYuNx9MeFwmt7GPwUk+atxbmL1+XsQPlS72HehD64fvsB2vSZgq6tP8H2n39HfHwCOrb6WP5/aZPeZdBM/L5jkdxG+vz821/49oe92L5qkrA/abJ//Pl3OOl18nX07tgU7q7OLzMg5v4u9Sn6LPp2O6TrmDlarKxgMCTj1r0gDBy3BOMGd0SlMkVlt+u27sfaLfsRGR2DIgUC8eDRk5cZEAYQZeSpc78MIMqYMYCYiQkDiCIoDCCmIWEAUd43DCDKmDCAKGNizwDyePaX6dlzZ7hN1mGLMuzDXhxYBEAkymrWdRxqVS2Nrm0aymQlyYAN6/MFRs9YhZjYOEwY2hkRkdHoP3oR2jWvK9OYBCBzlm9Gn46fombV0jIIxMUnoGnnMfisQTV83qQWXJydUDCf+JfmfqMWyjZSJf/ziCg5WyD5lACkWdexMtQ0rFMFD4KeyBv3dYtHyUenPu08WoahRnWqyPMhpa6ko01tm9Uh58fSGRAp++Hv64W7Dx4jOCQMRQsGyjErnD+XyViK1+wEnaMWYwd1RPOG1eW//Xrsb0xbtAFzxvVG3tzZsf/IKVkF4cURLAYQBhAVPwaDMyCm64QzIMr7RsUPjmAAYQDhDIjpGuAMiJnv4Lc8A/JkzgByn2gNg4Ch4h/krdGntXxaBED+/vcaBo5bjCPbF0KrfXVURzp/VrZeN+xcMxV5c2eTr2H3gePYsvsw1i8eLQPIyb//k2spXnwkaJAyIH/tfVXpT1181yGz4OvticG9WskpJZGvQeOXyBmCXh2aYM2mX3D8zH/4Zs5QPHn6HA3aDsehrfPh5elGdamo8choDUjVxn3R5rM6cvpMr9NhyZodOHDkNH7ZOPOluoE0KCmmN+8+RJ+RCzCs9xeoV6M8+o5agCrlistgJ334CBY5feTbbzkDoowhZ0DMxIQzIIqgMIAwgDCAMIC860ewnswbSG80rGARMDiltvdd+FgEQPb8ekI+ArRlxQSTmEiZkBrNBpi8JOX0P1fkrMiBTXMsBiA37wZh9tIfcOrcFWTx9sAXTWujW5uGcgYkNcxMXbgejo6O+KpvazlTU6fVYOz/YQ5+OvAnrty4h7nj1SkbWDoDUrVJX8yf2O/lkarYuARUaNATW1aMR7HCeRVrTXqZzINHT+WjZlImRzqyVr1yKQYQ6ay0ijuTj2Apg8QZENOYcAZEuUY4A6KMCdeAKGPCAMIA8q4DSMj8wSp2GpY38R80z/JObeTRIgBy5vxVDJ7wtZwBkWoiXnxeZEB2rJ6CfIHZ5X+2RgbkRX/SUTBpLD2HzcWWlRPksaQGkF5fzUO1SiXQtllKtqD3iPkoV7Iwdu77AyP7t8UHFd5XNRUSuEjAUKJoftk+dQYk9d8pp1/0mojG9aq+HJdU+yIByMFNc5Ajm7IQa9L8dYiLi8e0kd3RaeAMNKlXFc0+STmSxRkQKtqSQCAXoaeOEgMIAwgXoZuuAS5CVz5LuQhdGRMuQlfG5F0HkKcLh9AbDStY+A2YawWvtnFpEQCRtIg/7TxGlozt8kUDREbFYNveo/iya3M52yEVok8a3sVsDYgljmDNXb4FDT6qiMIFcssytZ/3moidq6cgOjYOn/ecKNd8SOpRkrztlAXrsWfddPhl8ZIjvv/IaUyYswauLs44uHmuCUCJpkQCmw8rlkD7FvUQn5CIg0dPm8jwpv67lJkRfbbsPoKv1+zAillDEJgzqyzHe+naXaxfPApS4fnA8UvkI1aSdNrZC9cxavpKGYAkaTXpKNmu/X9i+qjuSEoy4Jvv9+DC5VtcAyIIOAOIMjgMIAwgDCAMINRWhAGEAYRVsICni4ZSt4pV/u735Ryr+LWFU4sAiDTwO/eDMWPJRpy7eEMuJm/wUaWXKlhSgfSRE//I/96qcS25KPyFCpYlAERSkJJUtELDIpDV3wd9OjZFo7pV5CNYLXtMkAvOL127gzy5smL0gPYoX6rIy1gnJibJx8Raf1Yb/buI5elenyBJ8mzMzG/lY1yS2peU93n9PSCp//6FCpmz1Zt+xobtBxEdEydnYkZ92U4GJaPRKMusnTp3GSHPwpErmx+6t2uEJvU+kIckAaCUETn4+xlk9c+C2h+Wxc59x14CSPLVP8m1lfjottAm4e510sezy3eENtFBz0gf4fcjSBvKwD0rXcPjESiW90uIiKa6Qb4u7Umb5Aix7KwhLIT0EXHzntDGv1Un0kdyKC1HaXgqtol/+IDsJ+5ZuNAmLpSeX4f/vdFV5Mg9l7+wn3l5OpBjDfAUy4kW8aPXUcEsLmQ/sYnibFuhm7+QPpKCxWsg4sZd0oem90zSxvfucaFN8vOnpA+Nq7vQJnjnTtLHtZ3/Cm1K96xJ+vAol/IOJdFHoxFLLSeXoOUpYyGWx/W4d4oaBpKj6fvCUKKe0E8CISksNdb/sUHowzFrbnKs/crQLzhbGHVB6CdkFn18xbd8ynsL3vRxrCBWlpTaaYKuktdzO1c1oU0eHS0XG6MT/8DoEUp/f5IDlY4Xhz8RmhkTaDlnQ+gj8T3x4efkUBzv/UPaGD0JqezQ+6QPB2exhG5SyEPSh/6DVqRNegxClwxLT7MMt/HtNzvDPuzFgcUAxF4u6PVxqClolxS6ajYfKEvvSlmSd/HDAKKcVQYQZUwYQExjwgCiXCMMIMqYMIAoY8IAYhoTBhAzO6u3HECeLR1uk+1ilj6zbNKvNTq1ewCR6hnmr9j6xmuXjkBJEr7mPmoAZMtPh/HL4b+wZv6Ily6kjM3NO+Z/DZYUstL6yvqMXIMlJp0BhAGEMyDKNcAZEGVMOANiGhPOgCjXCGdAlDHhDIgyJu96BuTZsq8ssT1Ls48sKjLZaXZqowZ2DyAZiYsaAGnRfTw6tqwvF4C/qx8GEAYQBhAGED6CpVwDfATLNCZ8BEu5RvgIljImfAQLCFsx0iZbRp+e023SrzU6facBxBoBext9MoAwgDCAMIAwgDCAcA2Icg1wDYhpTDRcA6Jqm/d85ShVdpY28u4xzdIubeaPAcRmoc+8jhlAGEAYQBhAGEAYQBhAGEC4CN0ye6/nq0ZbxlEavXh3m5rGFvZrzgBiv3NjsZExgDCAMIAwgDCAMIAwgDCAMIBYZmsV/u0YyzhKoxevrlPS2MJ+zRlA7HduLDaypLM/k76SY6OENkkPxTK9UuOo+2J5v9inz8lxRAeFkjaJMYlCG61OLK0pNfbKn1Xow9k35T0xos+ncY0oE2iJV0c7uehIHzl8xFKvK/3Okj4MYWL5RslB+A2xzG7ELVrKNypYvI6iHtPyxknxBvJ6HJ0dhTb3Vmwhffi7ieVT3fXiPqQO8no7kf1EJSQLbfw3TyR9hF0TS1a65xTLSksd+PakvzCTDollWuNC6PtT5y5erzHBtBz37X1iGd4iraqQMTMmi+MuOWgQWkfoZ/+gD8l+Eoh+jhWi5YCvRSWQ/Qx4Kpa2NSSL5Z6lDmKWiJV7xo/YTY5jybnlpE1y3nJCm7gdi0kfz6+L17zf2GWkD8dYeq2tuCKWru1RypfsRxMnllHW3DpH+oCRfu4ZnhHPcS393efgKpYMNpYQ3xPyhWjp7y3NOfG+Q5urMB0TBwehTY0f6OfRH1/RUtr0QJQWEWvGpqdZhtt4dp6cYR/24oABxF5mworjYABRBpcBRBkTBhDTmDCAKNcIA4gyJgwgypgwgJjGhAFEuUbeegD5brwVd21vdu3Zif7ByiYDS0enDCDpCNrb1oQBhAGEMyDKNcAZEGVMOANiGhPOgCjXCGdAlDHhDIiZmLzjGZDIdRNsshX06GCbfq1xsQwg1oiqnflkAGEAYQBhAOEjWMo1wEewTGPCR7CUa4SPYJnZ0PARLEStt00mwr29bTIv1tjWMoBYI6p25pMBhAGEAYQBhAGEAYRrQJRrgGtATGPCNSDqNnBRGyepM7SwlXvbcRb2aDt3DCC2i32m9cwAwgDCAMIAwgDCAMIAwgDCReiW2XpFf28bNSq3NrSYiGWu0PpebAYgVZv0xep5X+G9goHWv8q3pIfHIWFYuGobjv31L8IjozFrTC98XCtFQeW7zfuwY98x3H/4BM5OetSoUhpjBraHm6uz4uouXr2N/qMX4vC2BfLfGEAYQBhAGEAYQBhAGEAYQBhALLMhjN5km/dxuH1hm/ePWCZqpl4YQKwR1XT4lICjebdxqF+zAlo2qglPDzdoNICPV4pk3o5fjqFg3pzInSMAoWHhGDBuCZp9Ug1dvviEBJCYbbPIEUXcuCe0ibwbTPpIiIoT2jj7uJM+slUtSdo4+ucQ2jh40bKJyFVU7CNWLKsoNT7rmI8cq7eTWMrVRachfegcxDb6H+hfYp5fE8+vNIjnt58Kx5IUn0SO1dVXLMGavWpx0odL9mykjYOXWHb2z9wfkz4q5qDXI+XkYkgsZQIfQjLYMKwt6ePZjTChjVceT9JHkaVrSJvg2SOENtGPaNlLt2zi+y/47zvkOAI/Eq+T4FPXSR/OhHy15CB07LdCPwV8lD/wpG7gQkht3+n0GTlWt6y07HeW6eL5izfQMrwTfcRxnTijMTlWr9L0M9pQvZ3Qj/7iQbKf5KhwoU1ipRakD70KGd5/Y1yFft7zpdeAziD+7tM9vkqOFRqx5KzkwPBELJVuTBJL1Es+jEliyWdNSVq21iGRfu4h+Ib4mlXIRoOQFT6fhZa4Lpfbm459OiyiN09PR6uMN3H7fGTGndiJB6sCyNET5zFv5RYEBYeiWOE8GDe4IwrkSdk8ShmQ9i3q4eDRM3gY/BR1qpXD+MEd5b/VbD4QX08fiDLvF5L/PyT0Oeq1HoZDW+e93JCbi9+jx6Fo3PHV5CQZUnTg/zm4Su5j0ry1OHfxupxBKF/qPcyb0Ef+++l/rmDu8s24cechsgX4olubhmj68Ye4cz9YbnPhym1kz+qLgd1b4KMPyshtBo5bIv/bg0chOHHmIob3aY1WTWph+97f8e0Pe/E8PAqlihfExKGdEeBH3wCLvt0uj3Hm6J7CpWEwJOPWvSC5fymelcqkbKTXbd2PtVv2IzI6BkUKBOLBoycvMyAMIGZCygCiCAoDSNqfygwgypgxgJjGhAFEuUYYQMw8axhAlEGxZwDZMiPtXxgWaOHWSvwjkQW6yDQXVgOQew8fo0X38Vg0+UuUfr8gtu89inVbD2DPuunQ6RxlAJE2z11aN4STXochE75G80Y10KnVx5g8fx2SjcaXQCIdP5LAYeHk/qoDk2QwoEP/aahZtTR6tGuMfqMWomC+nOjZvgmeR0TJGYU+HT+VAeKzLmMx5auu+LBiCVy9eQ//Xr6Fts3qoknHUWjZuAZaN62Di1du4csxi7Bx6VjkD8wuA8D5SzcwuEcrvP9ePni4u+L8fzcxd8VmrJg1RIaT+Su24v6jJ3IMqI+U/fD39cLdB48RHBKGogUDMWFoZxTOn8ukafGanaBz1GLsoI5o3rC6/Ldfj/2NaYs2YM643sibOzv2HzmFlRt2M4CIgs4AwgDCGRDFGuAMiGlIOAOifIhyBkQZE86AmPmyfdczIFvpkyXUvi89f3drKX6ZaHp82qqN1QBk+bqfcPPuQ8we2/vltTVoOxzjB3dC5XLFZAB5vQbk+x2/4bc//sa3c4fLGYeew+bg6I8LZVhp1nUsvuzaXIYJtZ8F32zDhcu38M2cYXBw0KDrkFnw9fbE4F6tkM0/y0s3y9btwtUb97FgUj8T12cvXMPgCUtxeNt8aKSzUADGzlotQ4I0FglAypYohA4t679s13P4XHxSuzI+rf+B/G+hYRGo98VQ/L1/JTnsqo37os1nddC2eR3odTosWbMDB46cxi8bZ0Kvf/XW0eRkoxzXPiMXYFjvL1CvRnn0HbUAVcoVR7vmdeV+UteAcAbETPgZQBhAGEAYQPgIlska4CNYyu8KPoKljAkfwQJits0m93XWMHBtMcwabm3i02oAMnHeWrlAemivz19eWKeBM/BZg2ryBj01gBw4egYr1v+E7atSpM2adBqNL7s2Q55cWdFtyGz8tnUeHIl03IuOTv59CcOnLJd9+fumHH+6eTcIs5f+gFPnriCLtwe+aFpbPmo1fs4auLu5yJv51z+/HPpLLvzevOKV5vLS73Yi6HGonC0xByCNO4xERFSMDE0vPpFRMTi0db7ZYvHX+5PiMX9iv5dHqmLjElChQU9sWTEexQrnVSyOeSu24MGjp/Ixsk87j8aQnq1QvXIpBhAAXAOifJZwDYgyJlwDoowJZ0BMY8IZEOUa4QyIMiacATGzf33HMyAxP861yabdtdkQm/RrjU6tBiBSBkSqqZCOBb34fNxmOCYMMZ8B+W7LPpy78OqY1epNP+PcxRvImysbjDCagIwoEFLWQTrONHl4V1SrVEJhKh3NOnP+KnoOm4stKyfgtz/O4sbtB5g3oa+JrZQBGTT+axzZvkB1BkTKsjT7pDoa1q6c5rn6otdENK5XVT76JX1iYuNlADm4aQ5yZFMW3E6avw5xcfGYNrI7JLBrUq+q3Lf04QwIF6GnXoAMIAwgXISuXANchG4aE86AKNcIZ0CUMeEMCBCzY16a93mWaOD62WBLuLELH1YDEKkGpHm38Vg4uR/KlihstgZkUI+WqF+zIu7ce4TBE76W6xpqVEn5Ff/ps3DUbz1Mzk6snv/Vy+J1UdSMRiN6fTVPrvVIndGYu3wLGnxUEYUL5JalbD/vNRE7V7Dg33YAACAASURBVE9BfEIiWvWcgOmjesg1IBI0SbUcUkG5VAMi1VlIUCDVgPQfswjfv1YDkvoI1t7fTmLJ6h2YObqH3I9UVP7HqQvo+NoxrTeNf8vuI/h6zQ65fiQwZ1ZZjvfStbtYv3gUpMLzgeOXyEespCL+sxeuY9T0lXLGpFqlkliz6Rfs2v8npo/qjqQkA775fo98/OyFDC8fwTITdT6CpQgKF6Gn/ZnMRejKmHERumlMuAhduUa4CN3Ms4aL0JVBseMi9JidKa85yOyPa9OBmd2l1fqzGoBII5ZUsOau2IJHj5/Kx4hSq2Dlzh4g1zNIBdzScagXv/6/uNreI+YjLDwSm5ape/Pj5et35cJ3qUhb1rD93+fItgVYt20/9hw8IddlZPX3QZ+OTdGobhXZQoIEqWbk9r1HyBaQRR6LdFRM+v9J89fioqSCFeCLgT1amqhgpQYQyde2PUexbtsBPAh6giw+nqhbvTy+6tta1QRKWZ8N2w8iOiYOH1R4H6O+bAe/LF6QwEqqPzl17jJCnoUjVzY/dG/XCE3qpdSaJCQkQsqIHPz9DLL6Z0HtD8ti575jLwHkZkgk2X8CIYlHScFKHbgScpRqJGedtbQUocZoEF6Pxpiifib6aOKjxQYO9DiMDmKJXamDOK1YlpYap/R3KvaPomjpxUQVkodUP646OiaUjZ6QFJauVwN6/mAUS47GJdPyxo7EWFSEDG4P/ianMCZ3OaHN/Qh6/qiwOWnp680de5cc6w29+L1MRNhl/689es32p6UMAORwF99bdy0QM2lw+Z3E8qlhGjcyZu568X0RHkevZ2dHev425EpRYHzT51JEPDnW8WH/CW3cVdzjtNgv4GSIIZ6vr+oa32hIhSSZjmu8gxMZE+dYsbS0JomOq8FTLB0eSruQBHLJsVJKywmUAQDqWeHvTAUeiFXxfI1KEM+Pmu8kak+RBcQ6A6D39ifjmh6DmF2L0tMsw21cP6VFjTLcSSY5sCqAZNI1cDdEBBhAlAFiAFHGhAHENCYMIMo1wgCijAkDiDImDCCmMWEAUa6Rtx1AYn9abJO9p0sT9WqwNhlgGjp9qwBEqm2QpG3f9JHeK5IWpaw0xClDprYeNwMIA4iahz0DCAMIZ0BM1wBnQMxAqIpvQwYQBpB3PQMSu+drFXeC5U1cGpnWK1u+h8zz+FYBSOaF5d3qiQGEAYQBRLkG+AiWMiYMIAwg1LcffVCIj2CljiFnQN7BDMjepdStYpW/uzRMeYH2u/BhAHkXZpG4BgYQBhAGEAYQrgFRrgGuATGNCdeAmPmu4BoQRVC4BgSI/Xm5TXaPLp/0skm/1uiUAcQaUbUznwwgDCAMIAwgDCAMIFyErlwDXIRuGhMuQle3gYv9ZYU6QwtbuTToaWGPtnPHAGK72GdazwwgDCAMIAwgDCAMIAwgDCCsgmWZrVfc/m8s4yiNXpzrd09jC/s1ZwCx37mx2MhuqJDhNRDyNr7OtOQsJSXpoEJ+k5IblYKiMdCypWTwKB8qJHYTHVRISRIDURESaAl5xgdRYlliaQhqFJ18XbTC0VJfXFJjao7VXK8aGWVJrFf0IRQg5aaEeirU+FChGo1EYnpCYpLI5UrdWx568dxJHbgkx5L93I0Tr2kVKq2IJ6RAfV3oZ4mHTjy/j2PoNU8906Rg5CRUsqOS6bi6EUGh4pFy35BTg2FuRYVGxTxpydl2D84JfTgTUupqx6pJFMsbQ0uvASNxj2uS6fsm2kg/o1214qoWx4hH5OQY3JQvC3690dMkehwqlgAp1JtgoKWJXYg59nSi13xsEt1PbGLGZXhdiHvL24mWhnd2zrgUvrkFEHdgFbkurGHgXK+bNdzaxCcDiE3CnrmdMoCYiTcDiCIoDCCmIWEAUd43DCDKmDCAKGPCAGIaEwYQ5RpRk5W3awA5uDpzN3L/6825bheb9GuNThlArBFVO/PJAMIAwhkQ5RrgDIgyJpwBMY0JZ0CUa0RNtoYBhAHknc+A/LrGJjs95zqdbdKvNTplALFGVO3MJwMIAwgDCAMIH8FSrgE+gmUaEz6CpVwjfARLGRM+ggXE/bbWJjs959odbdKvNTplALFGVO3MJwMIAwgDCAMIAwgDCNeAKNcA14CYxoRrQNRt4OIPr1dnaGErp1rtLezRdu4YQGwX+0zrmQGEAYQBhAGEAYQBhAGEAYSL0C2z9Yo/ssEyjtLoxalmuzS2sF9zBhBibnqPmI/aH5ZFi0Y1FJYXr95G/9ELcXjbAtUzHBEVgy6DZqJ720aoX7PCy3b7j5zCNxv34u6DYDg76VGnWjmM6N8WTvpX6hnnL93EktU78M9/N5BkMGDfxlnI6u9DjosBhAGEAYQBhAGEAYQBhAGEAUT1dk1oGH/0e8s4SqMXpxpt0tjCfs0ZQDIRQBau2o6d+44hNCwCs8f2NgGQH3b+hizeHihdvBCeR0Rh6MSlqFezAvp3aSaPUIKOfqMWYkD35qhWqSSMyUb4+nhC/xqgvLiU1GAUt5+WizPGRAojEXH9NrmKw28HCW1iQ6NJH2oMvPL4C81cs2ch3XgUKige6717pI+msZ+QNnpCvjinDy0RmDuLq7Cfkc+3k+OIefyMtHl2+Y7QJuwG7SPmaYzQh4MKmU/PXJ7kWN0C3IQ2+zvNI31UyuUltMnnQ8uahsXScrAPI+PF/SwbRI415KL43vLOp/whIrXTvFMXkf1EbBDHLSroKenDydtdaBN+4wHpI/SaeK3lqBBI+nDQ0VKvbXzE56n39KtM9hOXJJZxXZuzNOnjTgwtLT47+rLQTyIhfyw1fjZSXMC6dc1ZcqxDj8wlbYyFxHFL2LOM9BFxJ1ho4zN0PulDG/OctFl5RSxP3b0EfW9pEqLEz727/5LjUGOQGER8Dxvo55GDq/j+1FRsQg7FqEKmXvPPPqEfrV92sh+No15o89HuBNLHkcHKH4/JRioM4n//QYWV5U2cqre2vFMbebQbANn44684+PsZ5MmVFQePnoGnhxvmTeiDA0fPYOueI9BAgyG9WuGzBtXkUI2YthK/nzyPmNh45M7ujy+7NUfd6uUREvocTbuMwYi+bdC4XlXZ9qupK+Co1WLqCFo/+WHwU4yfswb/XLyO7AG+iI2LR68On77MgKzbuh9rt+xHZHQMihQIxINHT9KUAZHG07LHBHRr09AEQFLP/+LVP+LqjftYMm2A/Kf2/aei6cfV0LxhdbNLRTQuBhBlyBhAlDFhADGNCQOIco0wgChjwgCijAkDiGlMHBhAFIvkrQeQY5ttsm13qva5Tfq1Rqd2BSCLvt2OwT1aokr597F+235s+ekIOraqL0PH2QvXMWPJRhzfvRQ6Ry2k40gSIHh5uuHy9bvoPnQ2/ty1RM4IHDn+jwwdO1dPke2+XrMDW1ZOhIuzmKaTk41o2WM8KpUpik6fN0BUTCyGTVqG1k1rywDy67G/MW3RBswZ1xt5c2eHdGxq5YbdVgGQnsPnoljhvBjQrTkio2JQuVEffFyrIk7/c0WGog8rlsCkYV3g4e5KjosBhAGEMyDKNcAZEGVMOANiGhPOgCjXCGdAlDHhDIiZmLzjGZCEP7dYY09O+tR/0Iq0eVsM7ApATv79HxZPTfnF/9zF6xg0/msc2Z5SX2EwJKNk7S74dfNcZM/qKx9J2rzrMM5fuoHomDg8fRaO3eumI39gSlpvyoL1+O/aHQQ/CcU3s4ehYL6c5JxcunYHPYbNxZEfF8gZE+nzeg1I31ELUKVccbRrXlf+W3pqQKR2VAZkxy/HIB3X+vHbyfKxrGu3HuCzLmOwdPogVChdBJFRsTJgZfH2lLNE1LgYQBhAGEAYQPgIlnIN8BEs05jwESzlGuEjWMqY8BEsIOH4NnJPaQ0DfdUW1nBrE592CyBXbtxDj2Fz8PuOV+eWS9fthp++mwqNRiNvyAf1aIlGdarKWZCqTfpi7cKRKJQvlxxIKWtQvdkANK5bRc4UqPlIx72+/X4vNq8Y/9L8dQD5tPNoDOnZCtUrl7IagOw/chqT56/DqrnD8F7BlHPO128/QNPOY3Dh0Bo4/O8tUH+cuiAD2ulfloMaFwMIAwgDCAMIAwgDCNeAKNcA14CYxoRrQNTsFoGEE3TtpTpPabPSV2metgZ2bP1WAsi/l25hw/YD2LT8FSikBpDpizfi7oPHcibl23nD8X6RfOQ0SMebRkxdid+2virEfB1AOg2cgSb1qqLZJyl1GJbOgGz56TCWr/8Jy2cOQeH8KSAlfWJi41CpYW9sXzX55b8fPXEeUxaux8FNc0CNiwGEAYQBhAGEAYQBhAGEAYSL0MmtoCqDhJM7VNlZ2khf+TNLu7SZv7cSQJ49j4RUIyGBRRYvD2zYfhBrt+7HzjVT5AyIVAMi1WrsWD0F0nGmjT8exPZVk+Dq4iwMdFx8Auq0GoJubRuiVtUycr3FvBVbMLhnK7kGZM2mX7Br/5+YPqo7kpIM+Ob7Pbhw+ZZFakCWfrcTe349gcVTvpSPmL34uDg7yRmfYZOX4cnT55g7vg+MRiMGT1gqH8f6smtzclwMIAwgDCAMIAwgDCAMIAwgDCCW2W8n/LXTMo7S6EVfqWkaW9iv+VsJIIE5s8pg8MPOQ3B3c0bLRjWxbtsBrF88Cl4e7mjebSzmT+yH8qWKyJv1bkNnw9/XGzNG9SBn4q9zlzFp3lo8C4tAzaplcO/hY7kIXgKQhIRETJq/TlbryuqfRX4/iCSrq/Y9IFMXrsfe304iKjoWTno9dDotdq2ZKo+tWdexuHrzvmJ8R39cCL8sXnKdi5TVOfTHWeh0jmj68Yfo16WZXJBPjSv82zHkdceFhgttnl2hZWmjHomlCB0JSVppADmqFiHH6hoglkV09KZleJ2Klhf2kxwdQY6jwXEP0iYXIaGb20cssSt14OchFk9odYyWnI16EEKONeSSWPYy+olYYlfqwNEppXbqTZ/s5XOQ43A1826b1I0oqdej9b4i+6mdz1too9GQLnDxiVjCU/IQlySWxvQeQMsqhlwSy9/6vffqR4s3jbrUVvrM8r0RPYUXHXEvjAyKKyGRHPIfvRYDSmQV9hN+hx6HmufN0DrjhP1s7lyOvF6xCC8w3rs46SOv66v3Pb3JuPcTsZRrdEIy2U9ID/HxjRu/K7+DUjttevhrsp+kwDLie+vcL7QPQnI2ufFA0ofOEEfarLkk/u7rVDKA9OEQI16PmtvnSB9Q8cBJenBd7EfFC580TuIfYh2q0kd81NSA4PRu4VgdvOjvaY1ePNaGf9Dfn/v7fEDHPh0Wiad/SkerjDfRVaBlkjPeS+Z4sBsAyZzL/f/ZCwOIct4ZQJQxYQAxjYmK/QADiJlHKgOIaVAYQJSLRMMAYiYo9C8eDCCmYbMpgJzZY5MNpa58I5v0a41O/18ByPa9v+Pn306+MY5TRnRD9gCaylM7SEwyoNfwN7+cqWKZoujZvrE15k+VTwYQBhDOgCjXAGdAlDHhDIhpTDgDolwjnAFRxoQzIGa2Iu96BuTvvar2X5Y20pVraGmXNvP3/wpAbBZlG3fMAMIAwgDCAMJHsJRrgI9gmcaEj2Ap1wgfwVLGhI9gAYln6WOE1tj66co2sIZbm/hkALFJ2DO3UwYQBhAGEAYQBhAGEK4BUa4BrgExjQnXgKjbnyURL1pU5yXtVo6lP057IzttwQBipxNjyWExgDCAMIAwgDCAMIAwgDCAcBG6ZXZXSecPWMZRGr04lqqXxhb2a84AYr9zY7GRMYAwgDCAMIAwgDCAMIAwgDCAWGZrlfTvQcs4SqMXx5J109jCfs0ZQOx3biw2srAoWj5VrxUrcDgmJ5HjSXYQS0kmGSnBSiA+ibZxchSP9X8vixeOlxpKdCItaentkEjGBEaxH4OOlhFMMIhjYqAuBoATMb/ShThqxP0kGVWotBBhS1QhE6lmrNQc6xLpNa9JFs9fjM6TnF8nRwfSRhdyQ2gT5VOA9EFNn86Bvm8c4iPJfqIdxdLSKpYatMTkqJnf2CTxQtJr6bjHEz6kYLhpxGsg2kjL447yLCaM68Tn/5FxV3FbwMdZLHGt5jlAhSTeQD/39NTNB8DZQewnwSi+FilgSURQ1KjUqVmv7oliGV6jnn5GG7ROwjmmnuFSYx0dEsQmEs9oFQspgbDxc3Ek12t4vFhaXHLgTUiyq/mOpb7r9cnx5Fid3MVy66SDNxgkXfgtvU0z1M6xRO0Mtbenxgwg9jQbVhoLA4gysNQXk5qHIwOIMq7UBocBRBkzBhBlTBhAlDFhADGNCQOIuecv/UMEA4hlNlpJFw9ZxlEavTi+/1EaW9ivOQOI/c6NxUbGAMIAouZXZ86AmK4TzoCk/b6RWnAGxDRunAFRriPOgChjwhkQZUzsOQNiuHTEYnu0tDjSFquZFnO7tmUAsevpsczgGEDSvpHiDIiZX9f4CJYiKHwES7lOGEAYQPgIluka4CNYyueEmu9YuwaQy0cts0FLoxdt0RppbGG/5gwg9js3FhsZAwgDCGdAlGuAa0DMbAq4BsQkKFwDolwjXAOijAnXgChj8q7XgBiuHLPYHi0tjrTvVUuLuV3bMoCkYXqu336Adv2m4q+9y9LQynKmEVEx6DJoJrq3bYT6NSuYdTx3+Ras3vQz/jvy3cu/M4AwgDCAMIBwEbpyDXARumlMuAjdzHcFF6ErgsJF6IDh6p+W29ylwZO2yAdpsLZvUwaQNMyPLQFk4art2LnvGELDIjB7bG+zAPLdln3Yd/gULly+xQBCzCsXoSsDxDUgpjHhGpC0g7vUgo9gmcaNa0CU64hrQJQx4RoQZUzs+gjWteNp2D1azlRbuKrlnNnYEwPIGyZg065DWLd1P0JCn6Nw/twY0a8NnJ31aNt3CgZ0a4H12w4gPCIKHVrVR+8On8peoqJjMX3xRhw+fg4uTk5o1aSWnK1wcNBAgpc2faaga+tPsP3n3xEfn4COrT6W/z8tn5Y9JqBbm4YKAPnpwJ/Yvvd3jB/SCY07jDQBkEfPo8kuohLEsokeTrTspTMhjamjXYCSG5UvhJI/oehCckHJCifTMoNJjmLpRWmopHyxIYGcGxDX8yjJmfQRFkfLKAe4iuUX3VRMoCMh0elAzR15JSkGlNYLJeEpb5QJVWEVCrt4Hk/LljoS1/wkhp4bHRFXLxX354kHEWR0y2QXy/Aa1Mh8ErLRnoQ8pzRIL8LmcTQtga1iqMjlIl5JAzxKkjGbFnFJaKNmLeqoxQiAuh41/VD3DfUMly7UBbT0aZxG/GxUc4yLGqs+7B45N0k+OUmbZIj1b9XUb7hA/BwPS6KlbdU8GulMNi2V7qIRP29ijfRYXTT09+OzRPFYXFV8n1CqiWrWkaebC7kG0mNguHEyPc0y3EZbsHKGfdiLAwYQMzOx97eTmL9iCxZM7o/AnFnx56kLcNLrkDtnAJp2HoOOLeujecPqCHr8DH1GzsPe9TMRmDMAo2esQkxsHCYM7YyIyGj0H70I7ZrXRYtGNWQAadZ1LHq0a4yGdargQdATDBy3BOsWj8L7RfKpXg/mAOT3k+exePUOrJ43HNIxrXpfDGUAISLKAKIMEAOIaUwYQJRrhAFEGRMGEGVMGEBMY8IAolwjbz+A/KV632ZJQ23BSpZ0Z1NfDCBmwi/VWdSuVg5tm9Ux+au5I1iftPtKzo58WLEkytbrhp1rpiJv7mxyu90HjmPL7sNYv3i0DCCp60cGjV+CIgUC0atDE9WLIDWA3Lr3SAaZb+cOg7+vNx4GP2UA4QyIYj1xBkR5i1E/OjOAMIBwBkS5BjgDYi4mnAFJHZV3PgNy85TqfZslDbUFKlrSnU19MYCYCX+DtilQUaNKKRJAJCDo1b4JShUvgBrNBuDMvpVwcdbL7U7/c0XOihzYNMcsgExduB6Ojo74qm9r1YsgNYBI2Q8p06J5cUTDaERikgE6nSMWT/kS1SqVBB/BUoaXMyCcAWEAUa4BPoJlGhMGEAYQPoJlZg3wESwYbp5WvW+zpKG2gHkBIkv2kVm+GEDMRLrzoBmoV6MCWjc1feW9uSzGCwCp9UEZOQOyY/UU5AvMrioD0uureahWqQTaNqurer7fVAPywgFnQKQCAer0MNeAmFtwfATLNCqcAeEMCAMIAwgDCAOIue9Lw60zqvdtljTU5i9vSXc29cUAYib8O345hmVrd2Hh5P4yTBw/fREODg7Imd1PcYzqBYDUrlZWznZIheiThncxWwPyec+Jcs1H7hwBOPbXv5iyYD32rJsOvyxeqhcBAwgXoadeLFyErrx91BTkcgaEMyBchG66BrgIXXlPMIAwgJgFkNt/q963WdJQm6+cJd3Z1BcDiJnwG41GrN26H5t2HpJVsIoUyI2R/dvKKlip6zheBxAJPqYt2oAjJ/6Bs5MerRrXkovOX6hgSbZSwfmla3eQJ1dWjB7QHuVLFVG1AKTjWlJxvNSHk14PnU6LXWumynUfr384A8IZEHMLimtAlFFhAGEAYQBhAGEVLNM1wCpYqrZkMNw+q87QwlbafGUt7NF27hhAMin2tnyHSHh0LHmVhMonIlXIjcYmiSVJDSqORhloVVPyWkArEcKZ2H2qkYv9Ojst0elMBNZbhfh7Fr1YJrL2dfosKiVnKAX1CSFt+jiKlgyOThTLM8YSf5fGoSZ7kUyspW756WWS7GIK74oWDuK4S/aOz+6QHWlixPK317xLkD5CiLnxddWRPgI9aZvQWPH8xRH3uDQIJ+LsmvQDD/WJJGTBfV1oqdCoBFoqdH428T28MPJfaqikKPTHq86TPhJUyGQf6i8++61JpJ/zp5+L1/Tg9fSm6o86keT1PCtWX2ijRor5ZphY7rewC/08Mjqm1GOKPgnb54kNWo6gXOBBhFgWWo3MsppMC2XjqqO//NyJ7xNfLR1Xx1D6uXfTtaAwbjnd6XuYCvxE7+KUCWYl3CJt0mNguHMuPc0y3Eabt0yGfdiLAwaQTJqJNwGIVDDea/jcN46iYpmi6Nm+cYZGyQCiDB8DiDImDCCpYsIAolgkDCDmHsVioGIAUcaMAUQZEwoupBaUDQOIMq7WApCku/9kaF+W3saOeUqnt6ndtWMAyaQp4QwIwBkQ5WLjDIgyJpwBUcaEMyCmMeEMiHKNcAZEGRPOgChjwhkQy2z6ku7SmU3L9GTqxTGPqTqrNfrILJ8MIJkVaRv2wxkQzoDwESzlGuAjWMqY8BEs05jwESzlGuEjWMqY8BEsZUze9SNYSffUHM+0/MbPMZA++m35Xq3jkQHEOnG1K68MIAwgDCAMIFwDolwDXANiGhOuATHz1c01IIqgcA0IkHTvgk32eY6BdM2gTQaWjk4ZQNIRtLetCQMIAwgDCAMIAwgDCBehK9cAF6GbxoSL0NXt8JLu/6fO0MJWjrnpwnsLd2k1dwwgVgut/ThmAGEAYQBhAGEAYQBhAGEA4RoQy+zNkh5csoyjNHpxzFUsjS3s15wBxH7nxmIjO1blA9LX41vPhTbZC2chfeRvIE4NumalfbgUpRUeHNzF8qkOzi7kWBOzEzexCgWkR7EOZD/uerGNkyMtm0hZ/FmKnt9bITHkWAtkdRPaFG5CP/jcsvsJfXiUeJ8ch9bTl7TROLsKbaIKVCN9ULGnFGekDh5GiuU3JRsPYg0sIaRgJR+UWMGnLd4jr7fA0u9Jm6m+4vsvLJHWyQ5wEku91ng/gBxH+eGfCW3WdfuW9PFPeBxpMyhYfI7bkdInB+DjLL7e262bkOPwK56TtDEMWyK0UbNeMaqD0EdAOfq9VO6l6Tcxx5RsKOzH8zH967ExPlroIzpPJTJmTkgibe5Gi1XMsjjTcrEuhPyt06VD5Dg0emfSJvH+NaGN0UBLTxsTxfLGug9bkONwiAsnbRL/OyEeaxL97NR6i79PHhQVrzNpAPn9PMixpscg6cHl9DTLcBvHXEUz7MNeHDCA2MtMWHEcDCDK4DKAKGPCAGIaEzUbOgYQ5TpiADGNCQOIco0wgChjwgCijIk9A0jiwytW3LW92bUuJ/1jk00Glo5OGUDSEbS3rQkDCAMIZ0CUa4AzIMqYcAbENCacAVGuEc6AKGPCGRAz37HveAYkMeiqTbaCuhx0ltImA0tHpwwg6Qja29aEAYQBhAGEAYSPYCnXAB/BMo0JH8FSrhE+gqWMCR/BAhKDxMfhrLVP1OUobC3Xme6XASTTQ575HTKAMIAwgDCAMIAwgHANiHINcA2IaUy4BkTdHi3x0XV1hha20mUvZGGPtnPHAGKh2N97+BjNuo7FmX0rX3r8ZuMeHD1xHhuWjM5QL7FxCRg94xv8898NPA+PQv48OTC01+eoXO5VUfDjkDAsXLUNx/76F+GR0Zg1phc+rlVR7pcBhAGEAYQBhAGEAYQBhAGEi9AztB172Tjx0Q3LOEqjF132gmlsYb/mDCAWmhtzABIaFoHomFgE5syaoV4k6Fi+/ic0/fhD+Pt6Y8cvx7Bi/U84vG0B3N1cZOBo3m0c6tesgJaNasLTww0aDeDjlaL+wADCAMIAwgDCAMIAwgDCAMIAkqHt2CsACb5pGUdp9KLLViCNLezX3C4B5MnT55i8YB3OXbgOFxcn9GjXSN5YS5+B45bAx9sDD4JCcO7iNZQomh8ThnTGwlXbcfTEP8gWkEX+9b94kbyIiY1Hu35TcD8oBEZjMooWyovxgzuiYD5a8vD67Qdo128qhvRshTWbf5F9LZzcHyOnrURwSBhcnPSoUr44Jg/vAlcXZzRoOxz3Hj6Bi7NeHuequcNx9cY9HDlxHstmDJL/TcqGzFu5BUHBoShWOA/GDe6IAnlypHl1JBkMKFW7K7Z9MxFFC+XBom+342HwU8wc3dOsr78b1SH7uHvmkdAmQoX8ZgFCqte3CC2vmqdeStZG9NH6ZRP/3YOW+zUWqSr0oUmmJQLD9fT1eDiIZSA1ibQ8MKv3+AAAIABJREFULgxiH5d6dqVChkdnH5M2CbHifnKUpuVTfQr5C/vJUYOW8HQMoO9PBw8fYT+3c35IXm8uD53QRs27U84Gi6VCpQ7yeDkJ+9lfsAI51rBEsbxmKT+xLLHUwUeX/yT7OVigstDmIbFGpMbZCdnS/yLFMqCSj/aDqgvHMXXqb+S1lPaiZU0b3/5b6CfBoEJ22E28ji42/pgca0BJFWt+9Aqhn2gVz+iEPi2FPvLUK0uONTmRlrbVd50k9ON0ZgfZj8bNU2gTX7Q26UMfH0HaXI0Vr5NAr5TvdNFHR8g16y4eoFxAlQrWbfG7J4wG+nsrOS5WfC2N+5JjdXx2j7RJvHJaaGNMoGWytf7i+yK8eANyHP6e9LORdGLGIPHxrfQ0y3AbXdb8GfZhLw7sDkCSk41o1XOC/Gt+5y8ayKDR4ctpWDl7KN4rGCgDiAQHw/u0Rr7AbPhq6kpI2YcB3VqgSrli+Pb7nxH0+Klsn5hkwL+XbqJg3pzQ63XYuvswDh8/hzXzR5Dxl/po2nkMPmtQDZ83qQUXZyd4ebpBymoE5gxAQkISpixcLx+H6tPxU3kMqY9gbd516CWASH9v0X08Fk3+EqXfL4jte49i3dYD2LNuOnQ6Wmf89QFL19R50Ewc/XGhnAGRsh/+vl64++CxDEdFCwZiwtDOKJw/l9yMAUQ53QwgypgwgJjGhAFEuUYYQJQxCWAAUQSFAcQ0JAwgZr6D33oAuU3uI61hoMuazxpubeLT7gBE2lwPnbQMBzbNeRmQSfPXIWc2P3Rt/YkMIGVLFEKHlvXlv6/csBs3bj/ErLG95P8/efYSxs1a/bL9noMn8POhk7h++yFiYuOgdXDA7zsWkcF+kQH5a++yl7bxCYlYt3U/fj95Xs5iREbHoFqlkpg7vg8JIMvX/YSbdx9i9tjeL/1JWZPxgzuZ1HJQA4uOiUPbvlPwSe1K6NGusWxetXFftPmsDto2rwO9Tocla3bgwJHT+GXjTBm8GEAYQDgDolwDnAFRxoQzIKYx4QyIco1wBkQZE86AKGPyrmdAEp7cobZrVvm7PiCvVfzawqndAci+w6cwcvo38PV5lX5NSEhEs0+qY2D3FgoAkYDg/KWbMgRIH+m/B45bLNdH7Pn1BGYv3YRJw7qgYpmiePDoCToOmI7jP31NxtocgIyfswbXbz3A2EEdUCh/LmzedRin/7mCBZP6kQAycd5auLk6y8XjLz6dBs6QMyyf1qffZC21keCj11fzkCdXVvnol0Yq9JAApElfzJ/YD5XKpLwhUypar9CgJ7asGI9ihfMygJiZbc6AKIPCGRDTmHAGRLlGOAOijAlnQJQx4QyIaUw4A2LmR8C3PAOSEHKX3Edaw0Dvn8cabm3i0+4A5OyF6xgzcxV+3jDTbEBSZ0BEADJu9mp4ebhjSK9Wsi8JKjICIFLGYtSX7eSsh/TZ+OOvLwHkwaMQNOk4CmcPfPNy3K8fwZIyIDfuPMScca8yIB+3GY4JQ9RlQJ4+C5fhQ8r+jOzf9iV8SJ190WsiGterirbN6sp9S/UqEoAc3DQHObL5MYAwgHANiJk1wBkQZVA4A2IaE86AKNcIZ0CUMeEMiDIm73wGJOS+TTbtev/cNunXGp3aHYBIdRtSTUOdamXRvkU9aKDBhSu35DqJymWLpSkDIsng/nbsb8wZ30fOHsxdvhkXr95Odwak+9A5yJXDH307NcXVm/cxZcE6FCkQKGdA4uITUOmT3vhmzjAUKZgbOkctdh84blID0rzbeCyc3A9lSxROUw1IUPBTSNkSSQWr0+evChodtVr5iNWW3Ufw9ZodWDFriKy4JcnxXrp2F+sXj5LXDB/BMvPrCxehK4LCGRDTkHAGRHnfcAZEGRPOgChjwhkQ05hwBsTMd/DbngF5+sAae3LSp94vpbb3XfjYHYBIQZU23LOXbcKZ81cRF58oF58P7f05ShUrkCYAkaBj2ORlOPn3JeTKEYB61cvj+52/phtApFoTyZ9U7F2qeAHkzhGAiMgYGUCkz3eb98lyucnJyVi7cKRcAJ9aBWvuii149PipfDRKrQrWb8fO4suxyrqVVo1rYvyQTnLfqzf9jA3bD8qg9UGF9+VMjV8WLwaQN9ylfARLGRgGEAYQzoCYrgHOgCifE5wBUcaEMyDKmLzzGZDQhzZhAL0vrZhnk4Glo1O7BJB0XAc3EUQg6cKvZHwMocFCm4izYrlKqfHdX/8V+nhy6Sk5jvMhtCytn14r9FMovzfZj997YgndIEKWWOogx5HDZD96bUqdzps+bjrxtUjtfJ3FPrSX6HEYntC/1kRcuiwca9Bx8d+lxqHXngl9BKuQrc3iQcteZi0hlgQeUW88OTdFc4hlPrtUCiR9+DjT8xcUmSD0U+LEcrKfp+euCm2ig8VxlxoXWLqR7Aendglt1KwjB0+xRPKN9bvJcSz54T+hzejRtASrb+n3yH5uVO0htCnoI5ZQlhrHE1K9jwe2JccRepV+NpY7IJZyNRjJbhC5aJjQ6M6Bi6ST6Ce09HT1Q9uEfs6170z2451PvI7yzHp13PlNznRP6Xc1/BCeXTiWVjnE96/U2OBJSMNfpGWjNVr6WZL4QHw9aqRt4eAgvF5tvW7k3Gifq9h8W6BIW+Oa8i6zN32u+ZQix1o0q/g5Tzp4g0FCaFB6m2aond437a9uyFCHVmz8/xJApGNevYbPfWNYpYL1nu1TFKas/cmMsTCAKGeRAUQZEwYQ05gwgCjXCAOIMiYMIMqYMICYxkTLAJKurZRdA8gz8bvT0nXBKhrps4iBWYULuzH5fwkgdhP9TBoIAwgDiJqNIwMIAwhnQEzXAGdAlM9OzoCYAXPOgCiD8o5nQOKfiU+NWGt755RFnG2zVr/W8MsAYo2o2plPBhAGEAYQ5RrgI1hmHlR8BMskKAwgDCB8BEu5BvgIFhAf9tgmOz0nn6w26dcanTKAWCOqduaTAYQBhAGEAYRrQJRrgGtATGPCNSDKNcIAwgBibksX//yJTXZ6Tt7i+kebDCqdnTKApDNwb1MzBhAGEAYQBhAGEAYQLkJXrgEuQjeNCRehq9vdxT8PUWdoYSsnb38Le7SdOwYQ28U+03pmAGEAYQBhAGEAYQBhAGEAYRUsy2y94sNp5TrL9GTqxcnLzxpubeKTAcQmYc/cTkPmDSI7fHBMLHt57ij91s8YQo6yZBGx9K00yCIty5Njdc8tPgOpVVGk5ViyhrAfTVwUOY6HngVJmwAXsbSiQ3wk6UOTFC+0Cd+4gPQRdPwSaXPr6D2hTZIKmc88ZcRzU6AxPb8uuWidc62vuBDvkH8t8nqrBYolHonlLPvffS2U7Kc8Iff7uMmrl4u+ydlVQt44RoUGa6+gU+RYr/dqI7QJ+Y/+0qUU5r7eRK/Ffq2LC8fx065r5LV8WJz+pTD3z/uFfpwdxZKlUmNKivlUjY/IsQa8T4/Vd/4PQj/P4wxkP2Htmght8tQpQfpIiKBleH1Hfy1+vh5cSfbj4CGW4U2u3JL04RhJFwr/Geku9FMxh/jvUmMHJAt9OF49Ro5V46gjbRLvXxfaGBPF3xVSY2N8rNCHtkEvchyOYeLvCsmB4bZY0lmNZLCDZxbhWIIL0nLcubPQ80desBmD+Aj62Z8ev1QbJ096H0X5sJe/M4DYy0xYcRwMIMrgMoAoY8IAYhoTBhDlGmEAUcaEAUQZEwYQ05gwgCjXyNsPIPS7l6yxrXMioMwafVrLJwOItSJrR34ZQBhAOAOiXAOcAVHGhDMgpjHhDIhyjXAGRBkTzoAoY/LOZ0Aiw2yyy3MiMoM2GVQ6O2UASWfg3qZmDCAMIAwgDCB8BEu5BvgIlmlM+AiWco3wESwz3598BAtxkeE22QY6e3jZpF9rdMoAYo2o2plPBhAGEAYQBhAGEAYQrgFRrgGuATGNCdeAqNvAxUVFqDO0sJWzu6eFPdrOHQNIBmO/bc9R/PbHWSybQRd6i7q6fvsB2vWbir/2LkvXiOp8PgSzxvRE2RKFFe0ZQBhAGEAYQBhAGEAYQBhAuAg9XVssRaO4aFpAxjI9mXpxdjMVTwkLj8TYmatx/MxFuLu5oH2LeujetpE1ura4TwaQDIaUAeRVAFkFS7mYWAXLNCasgqVcI6yCpYwJq2ApY8IqWKYxYRUs5RphFSwzPzJYSQUrLppWyszg9tJsc2c3U1WvwROWwmAwYOygDnj05Bl6fzUP00Z2Q/XKpazRvUV9MoCoDOfJs5cwe+km3LkfDF8fT3z+6UeoV6M8GnccJU++k14HrVYrZzCiomMxffFGHD5+Di5OTmjVpJZMpA4OGrm3TbsOYd3W/QgJfY7C+XNjRL82cHbWo23fKRjQrQXWbzuA8IgodGhVH707fKpqhK9nQB48CkH7/lPxVd82+LhWRRwpW5n08TxITPPFPitK+shWQWyj8xFL6kkd6AKVGZzUHWtcxbJ6Ggex9K3kL8m/gPB6jI5O5PU+N9I2em3KnL/p4/i/NSGyMRLyt8eKViLH+jAygbSpUDOP0CZXdbE0qtTYJcBb6EMfWIQch4OaFDMxx1EFqpH9UAqr8SqkbeNVaBPriDWwKICWPi3gphdeT/0htOywb5+JZEymZ68itPHS0bK0V4i11veLYuQ4CnUQy8Xu77yE9PFvRBxp0/7+P0Kb+CSxvKrUOJu7WD41qP8X5Di8C+UibcK7TCdtKAPXBQOEJj5Fxc8AqbFzsXJUN4gsIpZH9QqhpZg1SeJnVnTOMuQ4dBp6/p7EiR+wap7RbsR94Xb9KDlWjc6ZtEkMuiW2SaSf80ZDktCHYwVaFtwhQSzlK3WQePkv8ViTEsnrdfAS7xmevk//0p/D243sJz0GcTG0HHV6/FJtnF1fXU9CQiIqNuyNTcvG4b2CgXLT2cs2ITQsAjNG9aBc2fzvDCAqpsBgSEa1pv0xdWQ3fFihBG7fD8aZ81fR5rPaMJcBGT1jFWJi4zBhaGdEREaj/+hFaNe8Llo0qoG9v53E/BVbsGByfwTmzIo/T12Q4SV3zgA07TwGHVvWR/OG1RH0+Bn6jJyHvetnIjBnADnKFwCSJ1c2+ShX19afyP1JHwYQZfgYQJQxYQAxjQkDiHKNMIAoY8IAoowJA4hpTBhAzGxh3nYAiY0h92XWMHB2cX3p9va9R2jUYSTO7FsJF+eUH6m27jmC7XuOYtPy8dbo3qI+GUBUhDMxyYDKDXujf5dm8qZeOmf34pMaQJKTjShbrxt2rpmKvLlTXpa2+8BxbNl9GOsXj0aXQTNRu1o5tG1Wx6RnczUgn7T7Ss6OqEmlSQAyfnBHLFy1HQ1rV0bnLxq89M8AwgDCGRDlGuAMiDImnAFJBaGcAVEsEs6AKO8bzoAoY/LOZ0Bi6SyQiu1lmk2cXV7tPy9fv4sW3cfj4uE10GhSTlvsOXgCKzfsxk9rp6XZd2Y3YABRGfFDf57D8nW7cPXGfRTIm0M+KlWjSilFBuTps3DUaDbAhEhP/3MFUlbkwKY5aNA2BSqktq9/zAFIyx4T0Kt9E9SuVpYcpQQgxmQjomJisXvtdAT4vToKwwDCAMIAwgDCR7CUa4CPYJnGhI9gmXtOiI/RSi0YQP7/AUisjQDE5TUAeZEBOXfgG+j1KUdBpQzItt1HsXkFZ0DIjfPbZhATG48fdv6GVRv34MSepdjxyzHsP3IKy2cOkS/lRQZkx+opyBeYXf631zMgnQfNQL0aFdC6qekZWUsAiHTMKyg4FH//exXrF4+Cq0vKmVIGEAYQBhAGEAYQBhCuAVGuAa4BMY0J14Co25XG2AhAXF8DELkG5JNe8nGrFzUgs77+AdIP4bPG9lJ3ITa04gyIiuBLkykVjUvF5Dmz+WHvryexZM0O7Pt+Fk6c+Q8jp3+DTcvHyZ6y+WeRsx1SIfqk4V0UNSASsCxbuwsLJ/eXAeX46YtwcHBAzux+ChnetGZAJBne0sULof+YhXJh/NfTBkGrdWAAMTPHXAOiDArXgJjGhGtAlGuEa0CUMeEaEGVMuAbENCZcA2LuS/jtLkKPjrHNESw311dHsKSoDhi7WBY4GjOwA548DUOPYXMwYUhnVSdnVGx/rWrCAKIivFJB+ZiZ38qF57Fx8SiULxdGD2iP4kXyyhmPYZOX4fCf5+Dt5Y5DW+fL8DFt0QYcOfEPnJ30aNW4Fnq0aywvEqPRiLVb92PTzkOyClaRArkxsn9bWQUr9XtA0gMg0ntApCyNpIJVsmh+jB/SCSc/SilGF32CL4UK/+6dU6w8JTUu1KSk0IdrNl9qGHArXpq0cfDwEdponF8Vab3JMCkHoeikQkkrKJZOzXvoxYpczo60j/8d7XzjNf9VmZ7fW/fplybl8BSrer3XlFbBcsvhJ5wbr5Lvk/Or9Rb7kBxQcxxVkI4JpVCWmEzIjwG4G06rzng5idfA6pz0mncmlLQaNBCrukkxe2/9DjL2M7KIFbmC48QKOnI/HmLFrlIFxPev5KPSiKbCsa7ruZa8lv8i40mbfkHnhTbUGpEaU/N7u7VY0Uvy4Vs8JzlW4zCx8lecCkU2jGwn7CcroWQoNXZ/n16v0WXF6o1ejy/Q1xsrVhmKzS9WbJM60CXT9+fdGLGym58LraroRNyfTjf+IK9Xo6NVFRPvXxP7UVHYbSSUshyrfkaPNY5+B4bhilgFy5hsIPuhvuvvF6pP+ijgb/reDLKBSgN7ARDpB/Kxs1ZDUmp1c3FG2+Z1VKunqrxUq5kxgFgttPbjmAFEORcMIMqYMICYxoQBRLlGGECUMWEAUcaEAcQ0JgwgyjXytgOIVG9ri497qgyILcZgqT4ZQCwVSSv6kbIpN+8Eme3By9MN8yb0FfbOAMIAwhkQ5Rqgft1mAGEAodaIFCEGEAYQzoAo18C7ngGJjLYNgHi8psJqxW1nprhmAMmUMNu2EwYQBhAGEAYQPoKlXAN8BMs0JnwES7lG+AiWMiYaPoKFiGjbvAfE040+Ym7bHaf63hlA1MfqrbVkAGEAYQBhAGEAYQDhGhDlGuAaENOYcA2Iuq1eeJRtAMTLnQFE3QyxlV1EgAGEAYQBhAGEAYQBhAGEAYSL0C2zLXtuIwDxZgCxzASyl8yJAAMIAwgDCAMIAwgDCAMIAwgDiGX2XWE2AhAfBhDLTCB7yZwIHChSjuwoNlwsWVm8RTHSR7ZKYhutJy2/qS9o+oZ4c51qXMSSwEYHsayi5DPJN5/weoxasZSo1DicljGHs6N4LHoHWoY32SiWgz2Qvzw5N2EJyaRNuTp5hTa5qtMSus6+3kIf+gJimVepsYOHFzlWjdZRaBORoyzpw1krjmucgZ6b5/G0lCQlobs8O73mC7qJ12O9EXXJ6/XqNYm0GeAhHks2Z3HcpQ6oqDVvXoQcR6GuXwhtDrSZSfo4HUYXiXZ9KJbhpSSwpUF46MX3+NPhHcmx+hQJJG2etZ4gtKGeE1Jj14UDhD78yhQlx6EvUoa0Ccv7gdAmy/ObpA9NUpzQJjY7/TzSqpjA0FixtLROxTPaiXjOu987RV+vKhne62I/amR4E8Rx1Zb/mB5rIn1vGa6fzfBYHQhJ9pBCpi90NtdhDm838nrSYxAWaZsjWD4efAQrPfPFbWwUAQYQZeAZQJQxYQAxjQkDiHKNMIAoY8IAoowJA4hpTBhAzGx+VMCSPQPIMxsBSBYGEBvtpLnbdEWAAYQBhDMgyjXAGRBlTDgDYhoTFT+gcwbEzLcSAwgDyLueAQmNsE0GxNeTMyDp2ghzI9tEgAGEAYQBhAGEj2Ap1wAfwTKNCR/BUq4RPoKljImGj2DhaUS0TTZ0fp7WOVJmi4thGV5bRD2T+2QAYQBhAGEAYQBhAOEaEOUa4BoQ05hwDYi6DVqIjQDEnwFE3QSxlX1EgAGEAYQBhAGEAYQBhAGEAcTIRegW2Zg9CbdNBiTAizMgFpnAd93Jxau30X/0QhzetsAilxoRFYMug2aie9tGqF+zglmfc5dvwepNP+O/I9+9/DsDCAMIAwgDCAMIAwgDCAMIA4hFtmN4bCMAycoAYpkJfNe9WBJAFq7ajp37jiE0LAKzx/Y2CyDfbdmHfYdP4cLlWyYAEhdHS+ZpkhKE05HoQMvS6hPFvwgYVVR0GnUu9LLQ0DK7lBNNslh6EYT0reQ/HrQkaUySWP7WkCyWgpX6oUwC9LQUrCZBRcEcEVeH2OdUWGF00AptjM6eKnzQcYVRHNcIDV2o5+kg1lGmrkW6EH3wZfJ6DJ7ZxTEhYiY1pu5Pg7sfOY6BbsVJm4WRYllaNfLUDvFR4ut1pJ8lIJ4VRhXPAI2KezhRI15rv92m13yDnOLnkdFBR8ZdzZl66tmoDQ8i+0l29xfbJNPPkjBHWibbTUfIj8eHk2N1iIsU2iR45yZ9aJNprXSH6GdCP3HuAWQ/ScRDWk0diYH+KoCW0LimxqHm+8TNKJbplXwk6ejnKzXWROqLDYAaGWVqclxdnCmTdP398XPbZECyWklWOF1ByGAjrgFJYwA3/vgrVn2/B2HPI+Hj7YGWjWqiT6emL72s27ofa7fsR2R0DIoUCMSDR0/kDMifpy9iwNhF2LpyIvIFZkdsXAJadB8nZzOafvyh6lG07DEB3do0VADITwf+xPa9v2P8kE5o3GEkAwgRUQYQMwFiADEJCgOIco0wgChjwgCijAkDiGlMGECUa+RtB5BgGwFINgYQ1fvld87w5p2H0Ol0CPDzlrMRPYbNwcShnVG+VBH8euxvTFu0AXPG9Ube3Nmx/8gprNyw++URrNlLN+HM+avYuHQMpi7cgLi4BEwf1T1NMTIHIL+fPI/Fq3dg9bzhkI5p1ftiKAMIA4hJBDgDolwQnAFRxoQzIKYx4QyIco1wBkQZEyrzwADy7gHIo+fiTG+aNnZpMM7uLX4Rcxpc2dyUMyBpnILgkGf4bvM+nDp3GWHhkXgeEY0RfVvj808/Qt9RC1ClXHG0a57yVuLUR7ASE5PQus9k+GXxxMNHT7F5xQS4ujilaQSpAeTWvUcYOG4Jvp07DP6+3ngY/JQBREVEOQPCGRAGEAYQPoKVag3wESzFTcFHsMwAFx/BQlCYbQAkhw8DiIot3rtnkpxsROOOI1G2RGH06fgpsgVkwaDxX6NC6ffQtlkdfNp5NIb0bIXqlUuZBRDpH6WjWFLWZObonmhUt0qag5QaQKTsR//Ri6Bx+N/hUKMRiUkG6HSOWDzlS1SrVBJcA6IMMwMIAwgDCAMIAwgDCNeAmK4BrgFRty17aCMAyckAom6C3jWrxyFh+KjlIPy9fyWcnVIKKaXswwsA6TRwBprUq4pmn1Q3nwFJMqBd3ynIntUX/127gx9XTYKHO13M9Xoc31QD8sKGMyDqVh0DCAMIAwgDCAMIAwgDCAOIul2DqdWDZ7bJgOTKwhmQ9MzXW99GOkJVtUlfjB7QHh9WLIFDf56DVNcxsHsLOQOyZtMv2LX/T7muIynJgG++3yMrUr2Q4Z29bBMeBIVg4eT++HLsIugcHTF3fJ80xYUBRJIEYhWs1xcNq2ApbyFWwVLGhFWwlDFhAGEAYQBhAEnTJux/xvdtBCC5GUDSM13vRpv9R07LheZx8Qmo9UEZPHocino1KsgAkpCQiEnz1+Hg72eQ1T8Lan9YVpbOlQDkj1MXMHrGKuxcMwU+Xh5y/cinnUbL8PIiYyKK0NSF67H3t5OIio6Fk14PnU6LXWumynUfr3/MZUAS/thCBj9o916hzZnvzpA+3FzFcpN+RX1JH4G1aKlQ9xxiyVGtDyE1CcCxZA3hWNTIYl53LUReT4CrWObTlZCrlDrQJBKyiGfFcyf5CNq9jxzrf9//I7Rx8qLlU30Li+c4d016ft1yZiXHqs0itjldoAnpo5ifCslnwsuvKmRaS2cjfrEa24kc662Dt4Q2O1WMY0H0f2Q/EUtHCW2CTl4lfWQtm19os2XGb6SPup8VFtrcOXKP9JG3ZiBpg5kbhTZ+LmJZaamxp16sjfpv00bkOLzz+ZA2AXM2CG3C4ghpcQBR/T8XX2+JvOQ4NA70D0A+fSYK/RhVfCdp9GL51JjK4muRBuAe9Yi8nj+ixLLCVXLSL37TJMUL+3G48js5DjU/rBlCietRUcMDrfg7SVO1BTlWbdhD0ib53iWhjcaRllvXEJLd13NVI8dRNCst/U46MWPAAJKeqJm24SL0jMfQ7j0wgCiniAFEGRMGkLTfygwgypgxgJjGhAFEuUYYQMw8a1Rk9hlATONmSwC5Fyp+T03av03UtQj09VBn+BZYMYDYeJKkgvFew+e+cRQVyxRFz/aNMzRKBhAGEM6AKNcAZ0CUMeEMiGlMOAOiXCOcATETE86AKILyrmdA7toIQPIwgGRoP8yNMzkCDCAMIAwgDCB8BMvMg5ePYJkExY+PYCkWCR/BUt43fAQLuPPUNhmQvH6cAcnkLTR3l5EIMIAwgDCAMIAwgDCAcA2Icg1wDYhpTLgGRN1u67aNACQfA4i6CWIr+4gAAwgDCAMIAwgDCAMIAwgDCBehW2ZfdstGAJKfAcQyE8heMicCDCAMIAwgDCAMIAwgDCAMIAwgltl33QqxzRGs/P58BMsyM8heMiUCF9s0JPsJOhsstIkLF8sMSo393xNLsHrnFcsdSj5y1SxDjtXRN0Bo4+BO9+NQ9ANxP8ZkchznErKQNpQMr4sKGV7HF2+5f0NvNz77hBzH9X+ekDZhiQahTZHs9AuQshQQy4kGfvQ+OQ43QmZZcuDgYSo/ndrp3QodyH5yeYhloxOTjaSPUw/pl1Hl8xHLiX6fpyzZTzAhsdo0nzgeUge1T+4i+9lcrIHQ5n5sIukju7NYXlNNXOv1qCTs5/slx8lxqDH48MJJoVk2d1p6Opub+HqPFatMDsWPeHZKDrL/8JPQT3Qi/cx6SjwrspbJQY41Z60K/8feWcdHdXR9/LcbF4IEEoLmODvOAAAgAElEQVS7FivuUCjuVqC4S7FixSkUd3d3K14I7u5QNGhCgAQIcd3s+7k3DynLXebcLBs24T37z/PQPXNm7pm5d+ebM+d3SRtdnd+ENnbXxNciNY4NChD6iKrcnhyHfTR9f175IJYVzutKy3U7WYmfFVZ3jpBj1djYkTbRz+8LbfQx9P0JnViu2aZaG3Ic2vBA0ib6FiE9rBHLV0sdaBzFm+2bOei9TakstMQ1eTFGDB5bCEByMoCYMl3cxlIRYABRRp4BRBkTBhDDmKjZKDOAKNcRA4hhTBhAlGuEAUQZEwYQIzFJwgDi5RdkkS1dLrfEea+JJS6GZXgtEfVv3CcDCAMIZ0CUa4AzIMqYcAbEMCacAVGuEc6AKGPCGRBlTL73DMgjCwFIbgaQb7yD5u6+KgIMIAwgDCAMIHwES7kG+AiWYUz4CJZyjfARLCO/n3wECw8tBCB5GEC+aj/Mjb9xBBhAGEAYQBhAGEAYQLgGRLkGuAbEMCZcA6Jug/bgjWWOYOV15yNY6maIrZJEBBhAGEAYQBhAGEAYQBhAGEC4CN0827L7FgKQfAwg5plA9vLlCCzbsA8nz9/E+vkjyDDVbfsHnnkrVawObZ6OjOnTggGEAYQBhAGEAYQBhAGEAYQBhNxSqTK4/9oyGZB86TkDomqC2Mj0CLwLCEJoWDiyZHQnnYSGRUAX+58E48tX/mjfbxKObp2JFM6OOJyvOOkj5EOE0CZDIbH0rdQ4U4U8Qh+O6WnZWqcCRcixUjK7GjtaNlGXoaCwH72VWFpTauwbSds421oJ+7G1oqUIqYAczE7P75sIscSu1Ef+jGLJwxw1clNDASWhm6qQOO5SB1oXep1o7MTStkH5qpNjdbAWy29G6mhZ01chYklLaRAp7cT9jE9DSxOnJ6RtW7crTF5vtkkLSJuJGSuK7wtamRixEBv9XIR+phUfUE84jnU91pLX8jQsirTp6H1DaKNCiRkZnMVyzo+ai69FGkDaAh7kWGOGLhLaqFFtw5BfhT7ciouf4VJjl+KlyLGGFa0vtHHxFcddahwbLpbQDcslXquSDzvQ9+eLUPHlUPev1Jp6ztv8S8vwalX8bkURMrwUXEhjpaR6bSo0JedXG0XLG0ffOiN+luhoyWBtSrG0v0+BBuRYE0u29t5rWoqYHJwJBvnT068ZMMGtRZqwCtY3DHu5Br3Rq30j7D96AfcePsOOFePh/+4Dpi3cLGcwXFO74JeGP6FzqzrYsvsYTpy/iUWTByR4hEMnLIF72tT4vXsLuS0DiDKEDCDKmDCAGMaEAUS5RvQMIIqgMIAo1wkDiGFMGECMPEuSOYDctRCAFGAASfCemBsAkAAke2YP9OrQCB7urnBzTY0aLQdiwrAuqFCyEJ56v8aVmw/QunE1kwHk4RMftOs7EZ4bpyGlixMDyBdWHgMIAwhnQJRrgDMghjHhDIhyjXAGRBkTzoAoY/K9Z0D+fWWZDEhBD86AMFCYEAEJQFbOHIp8ubLIraNjdChTtyf6dGqCZvUqw9npv6NDpmZAeg+fjYJ5ssmQ8/HDGRDOgPARLOUaYABhAOEjWIZrgI9gKe8JPoKljAkfwQLuWAhAfmAAMWH3zU3kDMinACKF5NjZ61i8djceeHkjZ7YM6NelGSqXLWJSBuT6nUeQAOTQpukGMMMAwgDCAMIAwjUgyjXAAMIAwjUgnx0X4xoQVbvV276WyYAUysAZEFUTxEaGETAGIB8twsIjsWnXUSzfsA/n9y00CUCko1eVyxaVa0g+/TCAMIAwgDCAMIAwgHARunINMIAwgJiyV71lIQApzABiynRxm88B5O37QKzd5okWDarKcrn7j1zA/FU7cXDj1AQDyOmLtzBi8nJ4bpoOB3tbBhBiuXENiDJAXIRuGBMuQleuES5CV8aEi9CVMeEi9M829ayCpVgk+mRehM4A8vV7elbB+voYqvbwOYCEhUdg5JQVcuF5eEQkcmfPhBH92qJg3mwJAhC9Xo9mXcegce2KaNP0Z8V4/AIJnUEA1lqxHGykjpa/8Q4Sy14+fh9GxipP2rjCedEnvZNY9tLempa2tSGu1yeYlgjM63+ZGir0sWL52/DctJRkaLRYDvYTBeYvjodQnJXbUXP8IjCSvF4vYo5LZKA1zNM50vLGtlZiaVv707RMa0zldsLrCVAhXeyOYDImfV3LCm1Gvb9D+qDWAOkAQHYtrVv/zjq10BW1RqTGjjbiuXkfTkujBkSIbdyJZ4A0DuqZJtlk9L8pvN73HsXI0KYKfCK0OR5OS5hbEc8jqYMf0zsL+yFuCbmtL/FcU1N0r8bG3Ul8D9upeEZTT3E1ssNqxup8aav4OVCiObkGKDCn6s2kDtRcT2SM+LdAzTqi7mEPG1q+WmfjSMbEKlb8GxoYI35OSB1Qz3mX1+L7V/KhzVWGHKspBjdefjCl2Ve3KZox1Vf7SCoOGECSykwk4jgYQJTBZQBRxoT6YWIAUcaMAUQZEwYQw5gwgCjXCAOIMiYMIMqYJGUAue5jGQAplokBJBG3y+z60wjcefAUs5Zs+2JQ2jargSrligqDxgDCAMIZEOUa4AyIMiacATGMCWdAlGtETVaBMyCGceMMiHIdJfcMyFXvAItsVotnFmepLTIoEzvlDIiJgUtOzRhAGEAYQBhA+AiWcg3wESzDmKiBCzU2DCAMIN/7EawrFgKQEgwgyWn7zWNlAGEAYQBhAGEAYQDhGhDlGuAaEMOYcA2Iuj3j5ReWyYCUzMIZEHUzxFZJIgIMIAwgDCAMIAwgDCAMIAwgVK0fA4i6bdvF5+/VGZrZqnTWNGb2aDl3fATLcrH/Zj0zgDCAMIAwgDCAMIAwgDCAMICYZ+t1wUIAUoYBxDwTyF6+TQQCQ8PJjj4QkqMXfOi3fjraWAn7yZbKgRxHxhRiiV3JgVYjFmhUs9m2jSAULPRi+Vz5Qu6dJa8ntGh9oQ2hqii3pRQ6KblKyQc1v5LNqRfimKRxoOcmj6tYnpE6G65mfiUbK+Ki1ayBgAixpGVqOzqy/R0LkGtg7rvzQhuvKFp62jswQugjMJKWtm3m/JIc64uU+YU2QZH0fZHWQSzBevwZfXShYlax0suTAHE8pItwczJ8H5KxC8sb/Vx4vf4uOciYpbQTP/eu+NIy6G4qZIUzuRDy4y+ukmO9bC9erxlT0DFTo9aU0V58b+mt6H5APOdVKMMjSicehxSwFI9OCuOmy1majGu0tfi3TU3MVAwV4WaQ4Q2JEt/D2bX0b320UzoyJlHEBMWoKCaiJPUdnl4gx2FVsCppY4rBuWfvTGn21W3KZXP9ah9JxQFnQJLKTCTiOBhAlMFlAFHGhAHEMCYMIMo1wgCijAkDiDImDCCGMWEAUa6R5A4gZ59aBkDKZ2cAScTtMrs2dwQYQBhAOAOiXAOcAVHGhDMghjHhDIhyjajZTDOAMIB87xmQM08sAyAVcjCAmHuPzP4SMQIMIAwgDCAMIHwES7kG+AiWYUz4CJZyjfARLCMQykewcOrJ20TctX3ZdaUcaS3Sb2J0ykewEiOqScwnAwgDCAMIAwgDCAMI14Ao1wDXgBjGhGtA1G3gTj62DIBUzskAom6G2CpJRIABhAGEAYQBhAGEAYQBhAGEi9DNsy077uVvHkcJ9FI1Fy0AkECXFjPnDIiZQ79l9zGcOH8TiyYPID0P/HMhfsibHR1b1iZtv8aAAYQBhAGEAYQBhAGEAYQBhAHka3ZT/7U9ZiEA+YkBxDwT+D16SYoAEhASRobantAtjVaheahCVY8ch06vJ22WXPIR2mw57EX60BFyhqfH/kT6cEQ0aQO9WAZSE0VLJGuixTaBjh7kOOysaUlZSpVExRKAlhiJmjWy5sYr8nq2n3kmtDnRpzjpA0RI+qUoSvqYHXaXtPEPF68BZ1sqamQXUHHbwNGKliSNiBVLyhLKqPJAqXVkQ+lKA3gaGCW86OwpaRlX+kkC2EMsX6y3EksKS4OMiBH3pGYcagq77a2+fp1Qob/+mv6tCI+hpZgrZHYRzl8AIfsuNaakttU8S9TcWw4hr4VjjXWiX/wWpRWvRzXXSz+hAeqaqfmlnySAKyGjLfnQUQMB4B8uvrcouW6pHxtiEWhjxM8JyYeds3gtqomJMZsjj/xMbfpV7arndvuq9kmpsVkzIP1Hz0fqVCng4+uP63ceolD+HBg7sCPmLN+Bk+dvIL1bGkwd2QMF82aTY/DM+zXGzVyD2/efwsPdFf27NsNP5YvJ3yXUlyioN/71wrCJS/HaPwAOdrYoW6Igxg/pBEcHe7nZ5Rv3MWPxFng9e4n0bq7o0rouGtWqAN/XbzFx7gZcufUADva2qFmlFP74rTWioqIxe9l2eJ64jOiYGNSqWgqDe7aEjY01vgZATp6/iZlLt8L39TsUyJMVo39vj5xZM8hjLNegNzr+Ulvu87nPa5QvWQhTR3aHrW2cNvz6HYexeutBBAaFIGum9HgXEIjj22fL3zGAKFcHA4gyJtTGkQFEGTMGkISvIwYQZcwYQJQxYQBRxoTa9zOAKGOWWABy+KFlAOTnPAwgRvf7EjQ8euqDIb1aIXuW9Bg6YSlevHyDfl2aoWzxAlix8R/4vnmLpdMGITpGhwbth6N5/cpo1ag67tx/gr4j52LDwlHIkcVDBhC1viii83/3Ae8CgpAloxuiomLw15x1yJE1A3q1bwifV/5o3GkU/hraGRVKFcKDxy9w694TtGn6M5p0Ho2q5Yqic+u6ePs+EDv2ncTgXi0xad4GvPJ7h0nDukGv16PXsFmoUbmk3MZUAJHi1KzrGMwd3xdFf8iFHftPYu22Q9i3dpIMNhKAFMqXAz3bN4SToz16DZuNnu0aoEmdSjhy+iomzd2A2eP7IFsmd+w/egFL1u1hABEsDAaQhG8cGUAYQDgDolwDnAFRxoQzIIYx4QyIco0k9wzIoQeWAZAaeRlAvgggPxbKjXbNa8rfL12/F15PX2LqqB7yvy9cu4vRU1fi0ObpuHb7IX4fuxDHt8+C5n+/aqOmrkQ615To27mpDCBqfVEAEhkVjbXbPHHqwk05uxAcGoaKpQtjxpheWLR2Nx54eWP2uN8M3Fy99RD9R8/DiR1zYPVJ6lsCjhK1umPvmonIkD5OjeDg8UvYdfA0Fk8ZaDKALF67B4+fv8S0UT3jx1H71yEY83sHlCleQAaQlTOHIl+uLPL3Y6evhrOzAwb1+AW/DZ+DsiUK4NcmP8vf3XnwFH1GzGEAYQCJjwAfwTKyGPgIliIofATLMCR8BEt53/ARLGVM+AiWMibf+xGsgw/eUFvPRPm+Vl73RPFrCadmP4L1KTRIm/6bdx/LG33pI/1/aVMvHQ06cOwiVm85iC1LxsRf98LVu+D75p2cjfgcQES+qMCNmb4Kj574YNSAdsidIxO27D4uH7uSoEP6ztnJQT5C9eln35HzMrRsXTLW4L9LmZRKjfvKR8Y+fnQ6HTJncMPaucNNBpA/Z66RMxsSUHz8dOg/GY1rV0TDmuUVADJt4WbE6HQY1udXNOw4AgO7t0ClMkUYQABwDYjyjmAAYQDhGhDlGuAaEMOYcA2Ico1wDYgyJlwDAhy4bxkAqZ2PAcTonj8h0CBlQAaMWYATO2aryoB8DYBImYThfdvIWQ/ps+HvI/EAsnDNbng99cHMsb0NrunKzQf4faw0vjnQfnKwMjZWj+K1uuHQpmlI55pKEQdTj2BJGRCpBmX66P8yILVaD8HYgcYzIJ8CSPt+k+SaFQlWpA9nQLgI/fOFyQDCAMIAwgBC1QgwgDCAcBE69SftuO/33xOLF6jzknCruvnTJ7xREm1hsQzIxxqQpnUryUeHpBqQPiPnYuMnNSBqsylUbLsOmo5MGdKhd4dGePDYG3/NXou8ObPIGZCnL16hRfexmDS8m1wDIkHAzX8fo3m9ymjYcaRcYN6pZW0Eh4Rh+/6T8vEw6fiT//sPckG6a+qUcq2KVBjeoEZ5kzMgUg1I0y5jMGf8b/ixUB6jNSCfHsH6FEBWbPoH/xy9gFl/9kZ0dAyWbdyPi9fu8hEswcLgGhBlcLgI3TAmrIKlXCNcA6KMCdeAKGPCNSCGMeEaEOUaSe41IPssBCD1GECM7+wSkgGRPEib/3Gz1uCOpILl5or+3ZobqGCZC0CkOpTB4xfhuc8bFCmYUz4uFRQcFl/3cebSbVnVShqPpNQlqWBJ2QRJpWvy/A24fscL9na2qP1TaRk6wiOiMH/V37Ii1fuAIGTO6IYOLWrJbUzNgEjxkFSwZizZildv3qJAnmwKFawvAYhU4yKpiR0+dUUGoirliuLo6atyrY30iQx6TzEaYm0dhTaxKnQ+KYUONTKDVaacIsf6Q17xi3gypHIgfUREi6UkD5x4Qvq4Ma4SaUNJ6GpixVKFUgfRTuLr1eppHzEQy6uSF6LSgFoDdRdeID2VzU8X2aVPGadg96VP7x/pNHU/5x+EPuYE3yDH+j4mToVO9ElByOxqVezqqfsvSoVCgJOGlo3WW4mvJ5YUWpakQsXCsyouF8MPirOYk2vlpsIOSmZZcqCNjhD6ibayI/uxjQwU2oRY0zKgj96LxyF1UMRN/Fwj1IDJ65AMTr8IIu283tNSvU2Je3jCMTpL7e4ivsd7ls5MjjU4kpYMzqwX/z762dBvnk5rLb63AnT0c4K8GEnymbjP1cjlU7LQGZxp6elIFc8bNb/31DVTzwpHQkZb8p9YKlh771omA1K/AGdAqHXD31swAqcv3pYFANbNGy6PggFEORkMIImzQBlAlHFlADGMCbWpkKwZQJTriAHEMCYMIMo1wgCijEliAcjuf+n3VSXGr2zDgvR7vxKj38TwadYjWIkxQMqndJSrx5AZXzQrVSw/uretT7kx+/dSHcasJdu+6LdtsxpypsIcH0lmWHqXSuH8ORAWHolRU1egStmi8W9YZwBhAOEMiHINcAZEGRPOgBjGhDMgyjXCGRBlTDgDoozJ954B2XXHMgDS6AcGEHPsm9mHmSLg7euHboNnyEe3pBdB1qpaGgO6Not/SSEDCAMIAwgDCB/BUq4BPoJlGBM+gqVcI3wESxkTPoIF/H3H10w7uIS5afJD3Mupv4dPss+AfA+TkNjXwADCAMIAwgDCAMIAQv3WMIAwgHANCHWXxH2/47ZlAKRpIQYQdTPEVkkiAgwgDCAMIAwgDCAMINQPEgMIAwgDCHWXxH2//ZZlAKRZYQYQdTPEVkkiAgwgDCAMIAwgDCAMINQPEgMIAwgDCHWXxH2/9eZLdYZmtmpRJKOZPVrOHR/Bslzsv1nP74Jp2UQnG614PCpkeEcfFUvX/v3PQ/Kay5XLQtrkTp9CaJMxlVi+UWpMvfNi9zX64bKriYoHASGzG5uClpyNgFgWUY0Eq701XRJoTcgTTTz5jJybXcceC21+Kqtift2dyX7cncXyqEeLlCN9zAm5I7ZRIZGst6FlWnF8rbCf0AptybH6h4mllt+G0RK7eV1peWob6k115Ehpgwsvg0mjmUceCW0WNI97qazok86RlhN1ChO/zTjMiZZzto8RP1/3PI+khopXwbRNh6Ji+U1K/lgaxLXXocKx+ATScsCP/EPI6xlYIZvQZsNt+i3SLnbi+WtegJbHfRVC3xdZ/K8LxxqQsQR5vc7WYnFb39BY0gdtAVBvII+mZAghyWSLh5IrNf1MU/NeE+pRomasVsTPVjo9/SyxTZM4RdtbLAQgvzCAkPcSGyShCDCAKCeDAUQZEwaQz2LCAJIoTzEGEGVYGUCUMWEAUcaEAcQwJpYEkE03fBLl+Ug5bVU0E2WSbL7nDEiymSrTB8oAwgDCGRDlGuAMiDImnAExjAlnQJRrhDMgyphwBkQZk+89A7LxumUApHUxBhDTd8Pc8ptHgAGEAYQBhAGEj2Ap1wAfwTKMCR/BUq4RPoJlJCYR9Bvmv3cAWW8hAGnDAPLN99Dc4VdEgAGEAYQBhAGEAYQBhGtAlGuAa0AMY8I1IOo2W+uueaszNLNV2x8zm9mj5dzxESzLxf6b9cwAwgDCAMIAwgDCAMIAwgDCRejm2XqtvWoZAGlXnAHEPDNoBi8b/j6CC1f/xbwJ/czgLfFchEdEYcTkZbjxrxc+BIYgR9YMGNTjF5QpXkDu9PTF2+gxdIbBAGxsrHHj8HL5v81b+Tf+OXoRr/3fI12alGjXvCbaNP3Z6IDvPHiKPiPm4Pj22fL3DCAMIAwgDCAMIAwgDCAMIAwg5tnnrb7ywjyOEuilQwlaSTKBLi1mnuwzIMkFQCToWLxuDxrVqoB0rqmw88BpLFm3R4YEZycHGUDGz1qD7cvHxS8GSYEuhbOj/O/pi7egUukiyJktA+4+fIZ+o+Zh4eQBKPNjHMB8+vkcQGJ87tILTCOW4dWGvCV9RHt7CW1i3tLStt5HLpP9vLwg9vPviyDSh7O1+HqrdS1F+jjY5L+5+pJxlE4srqhGOtPRxko4ls5pXpFj1UfS8prU/EQ+eUD2E+wtltd86vkv6ePeXXqtXf0gvp5qN8+R/XgHhgtttp2mZYcP96flfmMIfU2ne4fJsca8Ef/Yae2dSB8oWZ+0sXkjnuPYMFr2EsSzJDY4gBzHnWkrhDaFxw4gfUArvm8kB8vC8wj9tCsilr6VGusJifKwhX+QYw14QG9mss7dKPajp4VcNRf/Fvo4P3ghOdYiXauQNk4t+gttQjbPJH0EPhY/5zOOmE760ESJ73HJged7sTz1z5lp+WpthPi+0Ly6T49VxXrVvafki2m5dWjFv336wsb/sPnpBWhi6N8TzZMrwmvWuGcnYwIrW6HNah9aMrhLycTZsK+yEIB0ZACh1425LS5cu4tpCzfjmfdruKZ2wS8Nf0LnVnUgAcixM9fkjfmBYxdhZ2uD0b+3R6UyReQh/DFxKU5duImw8Ehk9kiHvl2a4udKcbre/UfPh4e7K3xe+eP8lTsY0qsVomN0OHj8ErJmcsfxc9fh4uyE0QPaoWyJgnIbKYMxef5GPPd+jQzp02LUgHYoWjBXgi83RqdDkWqdsX3Zn8ifO6sMIBPmrMPBjVNV+WrbZyKqVyqO9s1ryvZrt3lizVZPBIeGIW/OLPB55RefAWEAUYaUAUQZEwYQw5gwgCjXCAOIMiYMIMqYMIAYxoQBRLlGkjuArLhM/9FA1WYugUadEwmoEjgMs5gniwyITheLio36YMKwLqhQshCeer/GlZsP0LpxNRlA5q7YgX5dmqFi6ULYd+Q8tu89iaPb4v7CcvPuY3i4uSKlixPuPXqOroOm4ezu+bC1tZEB5OZdL/zerQV+yJddzjZ4nriMhWt2yf+tVLF88r9XbTmAo1tnIjAoFI07j8TMMb1R+sf8OHbmOsbPXgvPTdNk8EnI59bdx+g4YApO/j0nPgPSe/gspE6ZAi7OjihVLD/6dW0m///PP9JxrmotBmDG6F4yGB05fRUT567H9NE9kS2zBzxPXMLS9XsZQAQTwgDCAMIZEOUa4AyIYUw4A6JcI5wBUcaEMyBGAOM7z4Asv/Q8IVs+s9l2KZXVbL4s7ShZAIiUlShTtyf6dGqCZvUqyxv2j5/Pj2D5v/uAKk3748rBpXCwt5UzFlt2H5dBIzQsAm/fB2Lv2knIkcVDBpAfC+WW6ym+5E/661alxn0xZ3wfXLv9SM7A/DW0c7x9/XbDMHFYVxTKn0P1XErj+LX3X6hTrTS6tYk7FhEQGIw3/gFI6eKM137vMGPxVqRzTYlZf/6m8Dti8nL4vf2ApdMGQqPRoPfw2ShbvGB8TQgfweIjWJ8vGj6Cpbw9GUAYQPgIluEa4CNYynuCj2AZgQs+goVlFgKQrgwgqvfaZjM8dvY6Fq/djQde3vJxKynjUblsETkD8mkRelh4BErW7oHz+xYiMCgEjTuNxIBuzVGvejk5C1KuQW+smTMMubNnUgUg0gU07DhC7u/Mpdv45+gFAwCS+psyojsqli6s6lol+OgxdKZ8xGv8kE4yQBj7XL/zCO37TcLNIysMbKYs2IRL1+9h9ew/4utDpPEN7N4i/tgZAwgDCAMI14AonitcA6IICQMIAwjXgBiuAa4BUbWVw5KLdI2gOk8Js+peOlvCGiRh62SRAfk0flItx6ZdR7F8wz4ZMkQAcur8TazfcQibF4+Jd5FQAJGyL9Lxr7Vzh+P42et49eYdxg7qYNKUStkXCT6krMuwPr9+ET4k52cv38HQv5bgzO55cl9SzciYaavw4uUbLJw0IB4+pO869J+MBjXKoUmdSrItAwgDCAMIAwgDCBehf74GuAhd+dPNAMIAYsqGbvEFywBIjzIMIKbMl8ltpI27VGTdokFVZEyfFvuPXMD8VTvlgm0RgDx57ovuQ2ZgxcwhSJMyBdbvOIw12zyxa9VfwgzIbs8zmD66F5wc7bF8435I2YhNC0fJxeq/dP8TYwa2lzMeUk2IVBxfulh+uSBd9PF9/VYGBUkFq8MvteJNra2s5HqUFZv+QSaPtChSMJcs0ztyygoUL5xHBhUJPiRwkepMpONfH+tNNBqtfMxs1eYD2O15FpOGd0VMjA7LNu7D7XtPuAZEMCFcA6IMDhehG8aEi9CVa4SL0JUx4SJ0ZUy4CN0wJlyErlwjyb0IfeF5ywBIr7IMICbDhCkNpWNO0oZcKjwPj4iU4WFEv7YomDebEECkAu6ZS7Zi065jcHayR/N6VbB2+yGsmzdcCCCrtx6ErY01Xvu9lyHgz8Gd4OGWRh761VsPMXvZNtz38pZBQPp+zMAOSJMqhfDSjp6+hr6j5ipsWtSvIreXZHmlfn18/eXsRo3KJeWjYxJgBIWEoWy9Xoq22TKnx/51kxEVFY1xs9bi8KkrcE+XBtUq/IhdB0//ByAv75Fh18RECW1i39A3W9RTsdxv8BMfchyP998ibS7dEksR5nejJUkdXcXSiimzpiTHcXnwEg5pY78AACAASURBVNImJpaWxqScZHYRj7W2zVPKBWID35E20b5PhDZB9x6RPig50Xv7aR+eb0LJfoqnshfaRO4/QPp48T5MaOPuIu5DatyleAayn0hChzfV7f2kj2jvh0IbjZU16cOqVjfSxvrlbfFzQMU60tiJ12v0C/G1SAM4MWCVcBzVVg8hr0VjpxTw+LzRShQT+mlb2J3sJ4Z4sULgJGUd3+dO/W/TLzUrsHkXORbKQO8pfmadHUlI/QLI2zhOYVL0cR84Sfj923mjKBcIfOIrtMk5K+4dWaKPNvQ9ZYKd71yENg0z05k0fOEo9UfHVj7i+0q2sxZLzkomMcQzGmp+b6wJwZxi//2B9EuB0ejE+wWpndZHLLmudRTvmSQfemvxM3jdO1dyfjsk0ov7Fpynf3fJwZlg0LusCvliE/xaokmyO4KV2EFKLu8VSUgcYhhAFOFiAFGuIAYQw5gwgCjXiBqQZQAxjBsDiHIdMYAY+QVnAFEEJSkDyLxzlgGQPuUYQBKy/01WtqYAiFQn0mOI4VvMP71oSVK3e1v6JWCJFSgGEGVkGUAYQDgDolwDnAExjAlnQJRrhDMgRn6pOQOiCMr3ngGZe1Z8YiCx9nN9y6tXXE2sMZjLL2dAPoukKQBirslILD8MIAwgav5yzRkQzoAwgDCAUL9DDCAMIHwEC5h9xjIA0r8CAwj1jOLvk1AEGEAYQBhAlGuAMyCcAeEaEMM1wDUgynuCa0CUMWEAAWaefmyRXd7vFXNapN/E6JQzIIkR1STmkwGEAYQBhAGEi9CVa4ABhAGEi9A/uy+4CF3VDm7GKcsAyMBKDCCqJoiNkkYEGEAYQBhAGEAYQBhAWAVLuQYYQBhATNmpTTvpZUqzr24zuHKur/aRVBxwBiSpzEQijkP34ibtPTRQaBP94gHp48MNsYTu+7u0lO+Bv+l+iucVS++lyZWaHKuzh9jm2sYbpI+wfw6SNjq92MTZlpZ4zOUqlhMtHERLF8e8eUGONeqF+IH65jIt5/z66kthP+vP01LMNd1pGeV0OcXzt23QIvJ6r3m9Fdrs7F6a9GGlJU3gGxwtNMp5fRPpJOjefaGNRqshfaTsOIy00Ty8ILTRvX9N+tA6iSWsQ25dJX0cGLtPaNN4UUfShzZlnHS66LMh1c/C71v94Ea5QGi0WGr7/eA2pI9XV8SSs5KD0mdPiP0Qzxqpcfjq/17Ka8zZreUnybFmr56XtMkw+C+hzb1etCT0+ycfhD7KnvQkx2H9/jlp809wOqFNLTfx/Ss11luJJXStfMUS9fIANPTDhHqO6yPDyeuFXrxeNRV+IX1ow8VzIznQvhNLS2tsaNlhaMW/j5uDaBn01kUzktdjisGUE7SkvCl+qTZDq+SmTJLN9wwgyWaqTB8oA4gydgwgypgwgBjGhAFEuUYYQJQxYQBRxoQBxDAmDCDKNZLcAWTSMcsAyLCfGEBM3w1zy28eAQYQBhDqL2dShBhAGEA4A2K4BjgDonx2cgZEGRPOgChj8r1nQCYepV+omhibveHV8iSGW4v45AyIRcL+bTtlAGEAYQBRrgE+gmXkr5J8BMsgKAwgDCB8BMsIXPARLPx1hD4unhg7vZEqjkAmRr+J4ZMBJDGimsR8MoAwgDCAMIBwDYhyDXANiGFMuAZEuUYYQBhAjG3pxh22DICM/pmuwUpiW9AvDocBJLnM1FeMkwGEAYQBhAGEAYQBhIvQlWuAi9ANY8JF6Oo2W2MPiYVB1HlJuNXYGvkS3iiJtvjuAaRcg95YOXMo8uXKkkSn4L9hvfEPwJzl23H64i0EBodi6sgeqFW1lGywestB7Dx4Gt4v/WBvZ4vKZYtiZP+2cHK0V1zXnQdP0WfEHBzfPlv+jgGEAYQBhAGEAYQBhAGEAYRVsMyzFRztaRkAGVeTAcQ8M/gNvCQXAJGAo2mX0ahZpSSa16sClxRO0GiA1ClTyFHaeeA0cmXLiMwZ3PAuIBD9Rs9HkzoV0allHRJAoi/uJCOte+8ntAm4Tku9eu0RS9eevyPuQxpAzTq0xnXqXOmFY3XOREtnOuYSF3KF3P2XjNmxnwaRNpTMbpaUSoD83Cnlw+P6NnIcUb60HOXr83eEfu7voh+4+1+HCH20KZuJHGva/GlJmxRZ3YU2tUIakD7OjvlJaBMTS+ua+oXFkP1c9BFLXNc8MpX04XNKLIGstaYlPAstWUj2E3V8i9AmxPsN6cMpo3j+7q0j5GQBBL0MFvaTtUoOchwps9MSnYeJe7hBHlrKN0asaooblauSY42lnAAoc+GU0E+0ivXq06O50Ef4O1rGNXOVAuT1pPxtkrifNWKZXqlxyEt/oY80I+aT47ANpOWNd/o5CP00zEHLgmuiI4Q+rF7SvyfkxQCI8RfLnOujo2g3OvEzS1OuGelDGx5A2mjeUC/qo6XDNdY2wn72gt6MNyroQY7VFINRB2lZelP8Um3G18pPmSSb77+LDEhUVDQmzt2Ao2euIio6BgXyZMX4IZ2RySMdJADp9mt9HDh2EU9e+KJ8yUKYOrI7bG1tEBYeiTa//QVvX3/o9bHInzsbxvzeHrmyx+lGS217tW+E/Ucv4N7DZ9ixYjza9pmA1o2q49jZa3j5+i2qli+GPwd1hJ1t3I2yY/8prNi0Hx8CQ1CkYC75O7e0qcgFMXfFDtnflBHdhbY6Xax8Hf1Hz8fo39ujdLG4xbh2myfWbPVEcGgY8ubMAp9XfvEZEAYQZUgZQJQxYQAxjAkDiHKNMIAoY0KxAwOIMmbhDCDknsCYAQOIYVQsCSAjDqh4t4tJsyxuNKE2/QeAROg2UVx+FwCyZpsnTp2/iWmje8LKSosT526gYJ5sMkhIEFEoXw70bN9QPq7Ua9hs9GzXAE3qVEJ0jA637j6WMwsSkGzbexzHz13Hqll/xANI9swe6NWhETzcXeHh5opqLQbIm/5OrerC1sYaA/9ciKZ1KqFjy9o4evoaZizZgiVTB8r2s5Zsg/crP8wd35ecPCn7kc41JZ77vMFr/wDkz5UFYwd1RJ4chn8xLlilA2ysrTBqQHs0rVtJ9nvk9FVMnLse00f3RLbMHvA8cQlL1+9lABFEnQGEAYQzIMo1wBkQw5hwBkS5RjgDoowJZ0CMxOQ7z4AM228ZAJlUlwGE3FB/S4Ml6/bKGY4pI7vLG3aNdHbpf5/Pj2CNnb4azs4OGNQj7m2f+w6fxz/HLuDR05cIC4+AlVaLUzvnxgPI5/Ujn/vbuPMojp6+ihUzh6D7kBmoU60MGtYsL7d/FxCEGi0H4arnUjIc5er3RuvG1fFr0+qwtbHB/FU7cejEZRzYMEWGo4+f2Fg9Hj9/KYPU4J4tUaNyCfQePhtlixdEm6Zxb/X9vAaEMyDK8DOAMIAwgDCA8BEswzXAR7CU9wQfwVLGhI9gAUP3medYHbk5/MxgSr2CCW2SZO2/iwxISGg4pizYJB/Bkjbo1SsWx/C+beDoYCdnQD6FiGkLNyNGp8OwPr9i35HzkP49bnAnlCqWXz621L7fJJzbs0A1gBw6eQVL1u3BjuXjUL/dMASFhMHGxjp+woNDwnBs2yyjxeKfrgppnLP+/C3+SFV4RBRK1u6OrUvGoECebIoFNHPJVvi8eouZY3uhYccRGNi9BSqVKcIAAoBrQIxsLLkGRBEUBhAGEAYQBhCuATFcA1wDom6/PmSvZQBkan0GEHUzZAGrx8990XfkXLRqVE3OCIgAZPS0lUiZwhkDe7SQR/roqU+CAWTl5n9w89/HmDO+DzoPnCof7apbrUyCr7xljz9Rv0Y5/NokLosh1adIAHJ483RkSK8s6hw3ay0iIiIxcVhXdOg/GQ1qlJP75gwIA4ixxcdF6MqoMIAwgDCAMIAwgDCAJHjDBmDQHrFoiyk+1bSZ3uAHNWbJwua7yIBs+PsIsmR0Q/HCeREdE4Oug6ahbdMa8oZeBCDLNuyTj09NH9MLoWERmLF4i3x8icqADOjWHDWrlMKT574YMGa+nEGpWLqwXKw+f+VOTBnRDXlyZpaLys9cuo32zWuSi2Hr3hNYsGqnXD+SJaO7LMd79+FzrJs3HFLhef8x82Wgypk1A67dfoThk5bKGROp31WbD2C351lMGt4VMTE6LNu4D7fvPeEaEEHU+QiWMjhchG4YEy5CV64RLkJXxoSL0JUxYRUsw5iwCpaxH+PkrYL1++7b5L4uMQxmNixkkltpbyuVIHg99ZH/qC2dApL2j1/6tOw5Tt5Hfvrp37UZuv5az6T+ja4AvV5Pa02arbvEcSQVXS9euwfevn5wcnRAgxrlIUGCVqsRAogEHYPHL8KFq3eRKYMbalQqgY27jpAAIkHAfS9vuDg7onPrumjduFr8hW3fdxJrtx+Cj68f0qR2wc+VSmBo71aqLlzKpqzfcViGofIlf5CPkaVNkxLSFI2auhKXrt+D//tAZEqfFl3b1JOvU/pIKmBSRuTwqStwT5cG1Sr8iF0HT8cDSOTxdWT/0T5iybwXR6+SPvZsE8u0ls7jSvrI0zjuGJno45wxnfB7m1SpKRewy19caKMLoCWDPVPHZZxEn6ypxBKPLra0fKodIbGa6vRKahgIfuBF2jz1FEstrzrylPRRN72z0CZ/Mzp9nCKzWGJX6sAhnVhZbppHa3KsQytlFdpE6OhH4znvILIfVwexlGT62b+RPh57PhTafFL29kW7qkc3kv0E/r1caBPoJZYBlRqnyCqWyT452ZMcR64KYrnm6NBo0ke6QnFqhqLPzQ7ThN9XzupCuYC1VryRulCKfk44u9NSrz/sPSAcS3AUoQcMwKe1WJ46BXH/SgPwKEdvgOxaDxOOVX+EfmZFv38r9GHVIk4sRvSxDRVL+Upt97z+78i0MV+1c9FSzFZRYvlxax8Vm1UN/Vuge/dKHNdIsRyw3NhafL34USnt/3mn2vAPVOgBH3GRtsbalvahFcfkiO2XN9AfndfKS8vy0wNRWvTfpWJOTXFMtJndiL7/PncRHR2Dmq0HyyeDfmn4E06euyHvGT03TUOaVHGvevj8IwGIdKrm47vopO/tbW0MapK/9vK+iwzI1wYhIe2Ty3tFPr0mBhDlDDOAKGPCAGIYEwYQ5RphAFHGhAHEyPOVAcQgKAwgyjWS3AGk30763WgJ2VuqtZ3TmIauz31dun4f/UbNxdk9C+Q/zEufFt3HomXDn+KP7hsDkF8bV5dPEiXWhwEkgZE1BUCk1JckyfulT9tmNVClXNEEjkS9OQMIAwhnQJRrgDMgRgCDMyAGQeEMiHKNcAZEGRPOgBjZj3znGZA+f1sGQOY1STiAbN1zXH5H3ZYlY+Inasj4xfKJmY810MYA5Ln3a1lASTqyJb302tz7VAYQ9ft42dIUAElgF2Y3ZwBhAGEAYQDhI1jKNcBHsAxjwkewlGuEj2ApY8JHsIDe22+afa+mxuGCZobH1AODQhGrN3780tnRQVZlld6VJ9U7r507PL4LSYTJxtoaowa0M9rtvUfP4ezkAKlI4/TFm5i+eCs2LhiJ/LnFR5fVXMNHGwaQhEQrmdoygDCAMIAwgDCAMIBwDYhyDXANyGcx4RoQVTu9nttuqLIzt9Gi5oanZX7p/icCg0ONdjPm9/YoW6IgpAzIzoNnsGnhKIMMiFu61PHvxKPG2WXQNBQvnAc92zWkTFV/zwCiOlTJ15ABhAGEAYQBhAGEAYQBhAGEi9DNs5frvtUyALKkRcKP61+8fg8DRs/H2T3z41/U3azrGPzSsCqa16uiKiCte42X60GkQnZzfRhAzBXJJOyHAYQBhAGEAYQBhAGEAYQBhAHEPJu1bluum8dRAr0s/aVYAlvEKaX+3HIQ2jWviRb1q+DUxVsYPXUlDm6cinSuqSAdt5q+aAsmDe8Gt7Sp5FdIbNx5RH6nnVva1Dh4/BJmL9uGfesmI306WhVO7QAZQNRGKhnbhW6eSI7+hecFoc3OrfdIHw0a5RHapMzpQfpIW5yWmNOmEMvsap1Tkv3E5hdLY+qtaInAG/6RZD+ZXMR+7Kxo6UVChRf6NWPJcTzee4W0WeFpqPn9eYOO1bOTPtLkEkstpy9Lv0TJOjUt16x1ET8EY0s1JceqIxTIo2NpGd7dD96R/VTLLl6v98vTf4G67xss7Ce7E71ea/x7hBzrve4dhDYvL/mSPjyKiWV4n5/3IX2UGxz3QtYvfc5Po6/FIaUd2Y/LocNCm8zE/Ss1drUX38PX69Ymx5EmN73m005fL/TzIUJH9hPUrZnQxr14DtJHmuK0VLquingd2d6l5y82WCz1GltGfC3ShWijjB9N+fQi7wZbCa85Xxp7MiZaQobX5q1Y5l7qQK8l5HEB6F4RUuix9BrQR4SJr6dkffp6I8TPI9nBE/EGXWNL35+wEsfkauqS5FhLZzXfhvnTzrpstgyALG+ZcACRxn3z7mOMm7kGXk9fIkN6Vwzu1Qo/lY/zdf7Kv5COWB3YMEV+D92HwBCMmrpCbiO9FiJ39owY1LMlShTJS8Y7IQYMIAmJVjK1ZQBRThwDiDImDCCGMWEAUa4RBhBlTBhAlDFhADGMCQOIco0kdwDptOmaRXaEK1v9aJF+E6NTBpDEiGoS88kAwgDCGRAjmyTOgCiCwhkQw5BwBkR533AGRBkTzoAY2fR85xmQDhvplzMnxlZwdWvxS5QTo8/E8skAkliRTUJ+GUAYQBhAGED4CJZyDfARLMOY8BEs5RrhI1hGgIuPYKH9BssAyJpfGUCS0Paah0JFgAGEAYQBhAGEAYQBhGtAlGuAa0A+iwnXgFBbKvn7tuvpukpVjhJotK5NiQS2SLrm330GJLm9OHC351ms2PQP9qyeYLBqAgKDMWrKSpy7ckd+OYz09vSuv9YzurKkN6/3GTEHx7fPlr9nAGEAYQBhAGEAYQBhAGEA4SJ082zIf11rGQDZ0I4BxDwz+A28JBcA8Xv7Ae37TURAYIgse/Y5gPw+diF0Op381spXfu/Rc+hMTBzWBZXKKBVJGEBYBevzW4sBhAGEAYQBhAGEAYQBxDwbz1ZrLpvHUQK9bGpPK38l0KXFzL+LDIikcTxx7gYcPXMVUdExKJAnK8YP6YxMHukgAUi3X+vjwLGLePLCF+VLFsLUkd1ha2uDsPBItPntL3j7+kOvj0X+3NkgvTkyV/aM8oRIbXu1b4T9Ry/g3sNn2LFiPNr2mYDWjarj2NlrslZy1fLF8OegjrCztZHb7Nh/Cis27ZdlzIoUzCV/J+kqq/2cOHcDM5duMwAQ6fpK1e2JzYtGI1+uLLKraYs2411AECYP7yb/e+02T6zZ6ong0DDkzZkFPq/84jMg9zrRb67cueWucIiNm+cnLyFDxcJCG5vUtByebbZ8ZD8aJxehjcaGlk2MTpdL3I+Glsd9Fy2Wb5Q6cLDRiGOiFX9PBgPAgxa0bOKy/V6kq841xRKcWavTEskObmLJWdssRNwBWBEyy9KFaOydhNcTlr00eb1U5GkRXsA/NIbsx9lWvJY2Z6ZVTdLYitda+Q70ueCMw6eSY12f6yehTSzoqFDqxWVq0HLOeTo0Eo7jeK9F5LU8C4ggbWp6iTcRgZG0rGnu1GI50ddDxJK00iBT5or7zRF9Alr/KZ4bQlRBamw3pafQh1upAtQwYJuTfg6E5hfLKKfwF//eyIOIFMvFfshIr3lnPb0G/GLEEtbWKp7RqQkpZpsnF8m4Qkv/nujeimWw9dFRdD+xsUIbbRH6RXOacLFEstSB/s0z8XoNoX1oid963xzi55U0gKyuznRMTLBoufqSCa2+vsnmDqW+3kkS8fBdAMiabZ44df4mpo3uCSsrLaRNfME82WSQkCCiUL4c6Nm+IZwc7dFr2Gz0bNcATepUQnSMDrfuPkaubBllINm29ziOn7uOVbP+kKdHaps9swd6dWgED3dXeLi5olqLAShdLD86taoLWxtrDPxzIZrWqYSOLWvj6OlrmLFkC5ZMHSjbz1qyDd6v/DB3fF/V020MQJ6+eIV67YbhysGlcLCPe1hu23cCO/adxObFY3Dk9FVMnLse00f3RLbMHvA8cQlL1+9lABFEnQFEGRwGEMOY0FttBhBjtxgDiGFUGECUq4QBxMidwwCiCEpSBpAWqywDIFs7MoCo3lB/C8Ml6/bKGY4pI7sjT45M8a+a/wgRK2cOjc8cjJ2+Gs7ODhjU4xd5aPsOn8c/xy7g0dOXCAuPgJVWi1M758YDyKdtjfnbuPMojp6+ihUzh6D7kBmoU60MGtYsL7eXMhQ1Wg7CVc+lqsNgDECkt1Q26zoGd46vir82adwSZOxZMxG9h89G2eIF0aZp3F+dPj+CxRkQZfgZQBhAOAOiXAOcATGMCWdAlGuEMyDKmHAGRBmT7z0D0myliqyW6p2fesPtnejsvnpvlrX8LjIgIaHhmLJgk3wEKzZWj+oVi2N43zZwdLCTsxifQsS0hZsRo9NhWJ9fse/IeUj/Hje4E0oVyy8fW2rfbxLO7VmgGkAOnbyCJev2YMfycajfbhiCQsJgY/Pf2zuDQ8JwbNssOfui5iPKgFw/tEzO1EgfKQOyfe9JbFkyBg07jsDA7i3i60EYQOhYM4AwgDCAMIDwESzDNcBHsJT3BB/BUsaEj2ABTVZYBkD+7swAomYvbRGbx8990XfkXLRqVE3OCIgAZPS0lUiZwhkDe7SQx/roqU+CAWTl5n9w89/HmDO+DzoPnCof7apbrYzJ1/7FGpA6PeTjVh9rQKYu2IS37wMxdVQPdOg/GQ1qlJP75gwIwDUgyuXHNSBGfkSJu5SPYCkDxDUgyphwDYgyJlwDYhgTrgEx8ixJ5jUgjZZfMHmf9zUNd3UxfX/5Nf0mRtvvIgOy4e8jyJLRDcUL50V0TAy6DpqGtk1roH6NckIAWbZhn3x8avqYXggNi8CMxVvk40tUBmRAt+aoWaUUnjz3xYAx8+UMSsXSheVi9fkrd2LKiG7IkzOzXKR+5tJttG9eU/XcGQMQqXG/UfOg1Wowsn87+L0NQLfB0zF2YEdUq/gjVm0+AEm+d9LwroiJ0WHZxn24fe8J14AIos4ZEM6AcAaEMyCcAeEMCBehG64BLkJXt11ruOy8OkMzW+3uWtbMHi3n7rsAEKnoevHaPfD29YOTowMa1CgPCRKkDbsoAyJBx+Dxi3Dh6l1kyuCGGpVKYOOuIySA5MyaAfe9vOHi7IjOreuideP/VCO27zuJtdsPwcfXD2lSu+DnSiUwtHcrcoYlad2mXUbJABEeEYkUzo7ydfzxW2u5rZTtGDV1JS5cuwsnB3v82rQ6eraLU7eSVLLGzVqLw6euwD1dGlSr8CN2HTzNAMIAEh8BzoBwBoRVsJRrgAGEAYQBhAGE3KAZMai/xDIAsrc7A4gp8/VdtEku7xX5NNgTnXKTsW/SqqDQJksNOu1nlcZd6ENj50COwzojLdOqp9RCNNTftgGdS3rhWPTWdB1JkF4s3yh1QCk42lIGAHSEvOYfKWjpzK516bhmry2Wg3XIkpmcP62DWPLQOmNO0ofGho4r5eSdm1gSWmqfwlosRxkSQ0sxq5g+RMSID3Odzkvrumcr7Ca85KKjulIhAYobf3Hppw3/yVVO6Celu1j+WGocTsjflh4olmiVfKSsIJbX/HdinFCI6PPmlj9lggIXTwltdCrO4aUgZJajFwwhx5Eiq/h5JDl4Vb2f+PlK9gKk2TFRaOWQXSzFLTW2yV2M7CnUXfx74hj4nPShiRFLykaly0P6oJ6dkoPgKPFzwNaK/j2xI2wcX94gx6q3pX8fdS/ui/0QErtyY+L3UZOHVlnS6Gi531iv68Kx6on5lRprXcTS/QF5aMlgt5T0M4ucHCMGdRefM6XZV7fZ30P8jP7qDr6hg+8iA/IN46XIqKjpWzrWJUnyfukjvdW8SrmialyZZMMAogwbA4gyJgwghjFhAFGuEQYQZUwYQJQxYQAxjAkDiHKNJHcAqb3orEn7sa9tdKBnnMrq9/BhAEngLHIG5MsB4wyIMjbUX8g5A6KMGWdAlDHhDIhhTDgDYuS+UfFbxhkQZZA4A2IYE86AqLiRANRaaBkAOdiLAUTdDLFVkogAZ0A4A8JHsIz85ZqPYCmCwkewDEPCR7CU9w0fwVLGhI9gKWPyvR/BqrHgjEX2d4d6V7BIv4nRKWdAEiOqScwnAwgDCAMIAwjXgCjXANeAGMaEa0CUa4RrQIxk27gGBNXnWwZAjvzGAJLEttg8HFEEGEAYQBhAGEAYQBhA+AgWH8HiInTz7BerzTttHkcJ9HK0T8UEtki65pwBSbpzY7aRMYAwgDCAMIAwgDCAMIAwgDCAmGdr9dNcywDIsb4MIOaZQfbyTSIQGRpC9qMN/0DY0HqUeg0hW0rJ5wKItU9JjjWUkDUNjRbLKkodxBKX4+5kTY7jn6zFSRvfiBihjV+k+HupsX+kTuhjcvBdchzWVDU8gGgiKJScrDSISOLQfAARD8mHb1AkeT2+wRFCmxYFxbK1UmMbIiY2gS/JcQQ5eZA2VFwdrGm53xhibpxBy2L6RdNrOo29lfh6aEVS6IjbzyH8LRkznZOr0EYb+p70EeUo9iE52J5ZLD3d6gm9yQi3Est8rr35ihyrn4o1P7JKVqGfWNDrKDhK/CwZvI+QeQUw1XsVeT1WvaYKbVysxOOQGj8NET+kc2qp3yxAEx1OjlUbJl5LUZlo2eHHH8T3X2o74r6SfpNA/8ZqIb4B7azpG5R6VuitbMiY2by4Rtq8TCeOW3o9PX+wFkuyb89dhRxHa3/695F0YsSg6hyxhLcpPtW0Od6vkhqzZGHDGZBkMU1fN0gGEGX8GECUMaE2ygwgypgxgChjwgBiGBMGEOUaYQAx8pvEAKIMSlIGkNkWApD+DCBftyPm1t80AgwgDCCcAVGuAc6AKGPCGRDDmHAGRLlGOAOijAlnQJQx+d4zIFVmOw1ASgAAIABJREFUnfym+7iPnZ0YUNki/SZGp5wBSYyoJjGfDCAMIAwgDCB8BEu5BvgIlmFM+AiWco3wESwjz04+goXKMy0DICd/ZwBJYltsHo4oAgwgDCAMIAwgDCAMIFwDolwDXANiGBOuAVG3n6w044Q6QzNbnRpI172YuctEc8cZkK8I7ZMXr9Ci2xhcObhUtZegkDB0GjAFXX+th5pVSsa38zxxCcs27Mdzn9ewt7NF9YrF8UefX2Fn+19B2M27jzF/5U7c+NcLMTodDm6YCvd0qRV933nwFH1GzMHx7bPl7xhAGEAYQBhAGEAYQBhAGEC4CF31dk1oWGm6hQBkEAOIeWYwmXtJKIDMWb4Duw6exruAIEwb1dMAQDbtOoo0qVKgaMHc+BAUgkF/LkSNKiXRp1MTOUoSdPw2fA76dW2KiqULQx+rh2tqF9h+Aigfw8kAwipYn99aDCAMIAwgDCAMIAwgDCDm2XhWnHbcPI4S6OX04KoJbJF0zf/fZ0CioqJRpWl/LJjUH8V+yC3PlP+7D6jRajCObZuJVC7OWL5xP7bsPoaw8EhUKlsEI/q2QQpnRyQUQD4ug+bdxqJL67oGAPL5Epm38m888PLG/In95K/a9pmARrUqomld4woIa7d5Ys1WTwSHhiFvzizweeX3XwYkiJas1EaFClepmrSs3tpO7MPGnrwT/MNoecbwGDFgUApX0iD0hOKhkw0taXkgVwnyerzDooU2bwlZTKlxOkLCcci7O+Q4NLQ6I8IpeWMVYw0hJJDv+YvXmXQh78JpSdlIYg30KJqOjAklPa3X0NKZgTapyH7sCWlMNes1grjelCpkPt+F05LPaezFUr066saR7i0iInZRwWTM/PViadt0oH1E2tGS3svciwjH0vvleXKsOhvxWCeffEb6eP6Ovi8WNikg9EMsEbktBSAdNtwgx7rH/RxpE1yjt9BGzXp9+F4sx53PiX5OIIaW9NY8uS4ca3C+auT1vgkV31tqrjdWxb1F/WlNzVvbqbFoY+nnhI3PTTImL9OK7y13bRjpQ09I9y/PUo700fvDA9LGFIMKU4+Z0uyr25wZ8tNX+0gqDv7fA4g0EeNnrYV084/5vb08L6u3HMT1O48wZ3wf7Dp4RgaQBRP7yxkKyVaj0WDKyO6JCiDdh8xAgTzZ0K9LUwSHhKFMvV6oVbUULt+4j/CISFQoVQjjBneSQejI6auYOHc9po/uiWyZPSAd51q6fi8DiOAuo571DCDK4IUygCiCwgCiXCcMIIYxYQBRrhFqEyy1YABRxo0BxDAmlgSQ8lMsAyBnhzKAJBWAMss4bt9/iu6Dp+Pk33NgY2ONJp1HoW/npqhSrig6/z4VNauWQov6cefuXvu/x8+/DMQ1z2XwfuWf4BoQyQeVAdl54DSk41p/rxgvQ8/DJz5o3GkkFk4agJJF8yI4JBxDJyxBmlQumDm2F3oPn42yxQuiTdOf5TEqjmBxBkSxThhAlLcOZ0AMY8IZEOUa4QyIkZhwBkQRFM6AGIZEDXBxBsTIHzOScAak/OSjZtl/JtTJ2T/ojFxCfVrKnjMg/4t8gw4j0LdzE2TN5I4uA6fh6LaZsLayQr12wzCkV0tUKhOXTtTr9Sj0Uycc3jwd4ZFRZgcQzxOX5SzL8hmDkS9XFrnPR0990KjjSNw+tgra/729+cyl2xgwZgEuH1iMhh1HYGD3FvFjZAChbycGEAYQPoKlXAN8BMswJnwES7lG+AiWMiZ8BEsZk+/9CFa5SZYBkHPDGEDoHV4ys1i5+R9cv+OFbJnSQw89BvX4Rb4COQNSpSRaNIgr/EnMDMjWPcexeN0eLJ4yEHlyZIqPYFh4BErX7Ykdy8fH//eT52/irznrZBDq0H8yGtQohyZ14upDGEDoxccAwgDCAMIAwjUghmuAa0CU9wTXgChjwjUgQNmJR+iNRiJYnB9ePRG8WsYlZ0D+F/e37wNRs9VgODs5YOWsociZNYP8jVQDItVTSMefJNWpxKoBWbh6F/YdOY95f/WFh7tr/GpwsLeTa04Gj18Ev7cfMGNMLzkL8/vYhfJxLOmo2KrNB7Db8ywmDe+KmBgdlm3ch9v3nnANiOCeYgBhAGEAYQBhAGEA4SJ0wzXARejqNuNlJlgGQC6MYABRN0PJzKrnH7MQEBiMzYtGx49c2uxLReibdx2Ti7+/RgVrwpx12H/0AkJCw2FnawsbGyvsXjUB6VxTyXUnDx57KyIm1aWkTZMSoWERmDRvA46duSbXqTSqVQG/dWoCG2srSEpe42atxeFTV+CeLg2qVfhRlvuNfw8I14Ao4soAwgDCAMIAwgDCAMIAwgBiyla1zF+HTWn21W0ujIyr9f0ePpwB+R5mkbiGyLAQ8io1kWIbvTUtoRupFcvwhhISrdIggyJpGV5KCYTUASWjAWhpFV7syF6c9PSCkOFNa0tLvboT0qitfcQyktIg/1c6JBwvNT/vw+m58QmKEPbxJoSWzozU0f1E68RaSz1ykKsEeltH4Vj1KmSjwzTiNS91kOLxGWE/AdkrkOuIUiBzUSHDG6VC79fBWrzwqbhLF2JF3DsOVrQm9ItgsXx1VvHUyfEMjhVLCks2c90KCWM/4h0tSwudeKw99tMyvN7vaEnSXZ3EzxvilpCv04+Qi+205gq5Fo8Uo6/nfYkWQj+p7Onnnhchw5vHmZaL1ejp50Dsme3i52KlOHVM0ec1EVcXW/oHJUbF/UnNsb2Ke8uZ+M1x0NDPX5s396iQ4GWq/EIbNxvxfSM3tvrvRczGnM1IV4wcx/DQR6SNKQalx1sGQC6OYgAxZb6+2zbRMTr0GDLji9dXqlh+dG9b32LXzwCS8NAzgChjxgCijAkDiDImDCCGMWEAUa4RBhBlTBhAjPxOJ2EAKTXuUMI3FmZocWl0DTN4SRouOAOSNOYhUUfBAJLw8DKAMIBwBkS5BjgDYuRZwhkQRVA4A2IYEs6AKO+b5J4BKfmnZQDk8hgGkITv6LiFxSLAAJLw0DOAMIAwgDCA8BEs5RrgI1jKmPARLGVMvvcjWCXGeiZ8Y2GGFlfG1jSDl6ThgjMgSWMeEnUUDCAJDy8DCAMIAwgDCAMIA0go14AoFgHXgAAlxlgIQP5kAEn4jo5bWCwCDCAJDz0DCAMIAwgDCAMIAwgDiHINMIAAxUcfTPjGwgwtro6rZQYvScMFZ0CSxjwk6igiwsNJ/5pYsaJIQDSt4hEWI1YcUSHyAZ0KI7H+EXmpsoEdoRZipUI2aqLrD2RnWRzFKh6uKlSwKKWsSo8uk+NQc3b/RVCk0I9/KK1gFU6sgYhoWmFFjVoTtU46ZSdDgliHlGIjDa3WpLlB/whZpUwr7OeFRylysP5h4vtTjQpWBmfxWpQGQc1fmAolO0cb8bMikpLyUaGGl96JvpaQKFoBaWGGwsLYjwn8l5wb6xjxfVNv7R3SR2Q4rej0T6/SQj82MfRz/lageE33W3+NHOvJasGkzYd84nPqKVSoQj0OED9vcjnRMYOWVtuK3DpdeD36X4aT10u9Cd1Wxe9JtIrfviideE07EPeedCH2hNJdWg29jqw++JAx8XbKJbRJ70g/X6lOhruIVeyk9jNjnlBuTPr+x1H0s98kx0Sja+MZQBIjruwzkSLAAKIMLAOIMiYMIJ/FhAFEsUgYQJT3DQOIMiYMIIYxYQBRrpHkDiDFRh5IpB2b2O31v2pbpN/E6JQzIIkR1STmkwGEAYQzIMo1wBkQZUw4A2IYE86AKNcIZ0CUMeEMiDIm33sGpNgICwHIBAaQJLbF5uGIIsAAwgDCAMIAwkewlGuAj2AZxoSPYCnXCB/BUsaEj2ABRYf/Y5GN542JdSzSb2J0yhmQxIhqEvPJAMIAwgDCAMIAwgDCNSDKNcA1IIYx4RoQdRu4IsMsAyA3JzGAqJshtkoSEWAAYQBhAGEAYQBhAGEAYQDhInTzbMsK/7HfPI4S6OXW5LoJbJF0zb9pBqT6LwMxdWR3/FgojyIiRX/ugkWTBqBsiYJJN1oqR/bi5Rs06TwKVw4uVdkizuzm3ceYv3InbvzrhRidDgc3TIV7utSqfez2PIsVm/7BntUTDNowgDCAMIAwgDCAMIAwgDCAMICo3lIJDQsPtRCATGEAMWkGRQDy4LE3MmdIB0cHe5N8J6VGpgCIBB2/DZ+Dfl2bomLpwtDH6uGa2gW2trTcpN/bD2jfbyICAkPglja1EQAJI8OjByGzq0Ixz+ryLmE/Hy6eJ8ex/k+6sKtMsfRCP2lypyH7iQ4TSzwu2HyX9DH8HS2vSRX1OljR8sbpnKyFY9FGR5BjhYbuR09IVmqv0w/coMsXhGM5MYl+eVPuylnI60mV3U1o0yt7d9LHkwdvhTbnxlcnfThFvidtvKJdhDY5nWhpYm2ouB9t+AdyHDFuyj/8fN5IT6wTjZ4eK3RieVTr9y/IsR6t2UloU/XsbtIHKTIA4HWE+L5Ib0tLvX6IJaS2n5wixxp07jhp49R+pNBGE0M/B6wCxPKp73etI8cR8ICevxxjJgv93OrRi+zHJbP4OZ554iLSh42/F2lz3U58XxS2fkf6iHTJILRxePuI9KHKIDxIaKaPoH/rqX5i8lSgTGAV4k/aIJZ4VuhpmWxoxb99b23TkePwSOVE2phiUGjIPlOafXWb21PrfbWPpOLA7BmQqKhoTJy7AUfPXEVUdAwK5MmK8UM6I5NHOnwKID6v/NG2zwQM7d0ataqWQqXGfbFw8gD8kDc7Nvx9BAePX0LWTO44fu46XJydMHpAO1XZEantiXM3kDNbBuw7fB5lSxTAtFE9sWP/KazYtB8fAkNQpGAu/DmoI9zSppLn4fKN+5ixeAu8nr1EejdXdGldF41qVYC0sR8/ey2u334EBwc7dGtTD83rVZHb9B89H6lTpcCrN29x9dYjZM+SHtNH90KWjG6o/esQvHjpBwd7W9l2+YwhKFpQrIktxaJRrYpoWreSyWtDuu6ZS7cxgDCAKNcQA4giJgwgymXCAGIYEwYQ5RphAFHGhAHEyLblOweQHwZbBkDuTGMA+eImec02T5w6fxPTRveElZVWhoGCebIhV/aM8QCSNVN6tPltAjq3qoNm9SrLvj4HkIVrduH3bi1Qqlg+eJ64jFVbDuDo1pmwt4vb1H/pIwHI9MVb0Kt9Q1QpV1S2f/jYBzOWbMGSqQPh4e6KWUu2wfuVH+aO7wsJhBp3GoW/hnZGhVKF8ODxC9y69wTtmtVEi+5jUbNKSXRsWRs+vv5o13cilk4bhHy5ssgA8uipDwZ2b4E8OTNj0rwNSOHsiMnDuyGhGZDgkDCUqddLBjEJhsIjIuWxjBvcSfap9sMAEhcpzoAYWTEMIAwgnAFRrAHOgBiGhDMgymcnZ0CUMeEMCFBw0F61WzOz2v07vb5Z/VnSmdkzIEvW7cWBYxcxZWR35MmRCZpPXuYlZUDG/N4ec5bvQN1qZeSN/cfP5wBy4eq/mDehn/y1Xq+XAWXO+D5G60c+DaAEIJ+2lb7rPmQG6lQrg4Y1y8um7wKCUKPlIFz1XIpFa3fjgZc3Zo/7zWAebt19jEHjFuHQ5v/ekjpu1lpkTJ9WBicJQH4slBvtmteU2+0/egFrt3piy5IxCQaQh0980LjTSCycNAAli+ZFcEg4hk5YgjSpXDBzLJ2q/jhwBhAGkC8+TBhAGEAYQBhA+AiWYg3wESzDkPARLHVb8oIDLQQgMxhAvjhDIaHhmLJgk3wEKzZWj+oVi2N43zZwdLCTMyBSbUNIWDj2rpkUfwRKciYCEOn7hh1HoF+XZvipfDHh6jAGIPXbDUNQSBhsbP47TyhlHY5tm4WpCzfB2ckBg3u2NPArHQEbNmmZXIfx8SMdL2tSpxL6d22mABBp8z93xQ78vWJ8ggFEyqQ06jgSt4+tglYbV2xx5tJtDBizAJcPLFZ3NwBytomPYHEGxOiCYQBhAGEAYQBhAGEAIXYUDCDqtlwFBuxRZ2hmq7uzGpjZo+XcmT0D8umlPH7ui74j56JVo2po0/RnGUCk//V9/Q5Xbz3AunnD44vORQASHaNDxUZ9sHbucDmrIvoYA5DOA6fK4CBlXT7/LFyzG15PfTBzbG+Dr67dfoSRU5bjn/VTjHb3eQbkUwCRjnU1aD8c1w4tUzWzYeERKF23J3YsHx9/fSfP38Rfc9bh8CcZGMoZA0hchPgIlpGVwgDCAMIAwgDCAMIAwgBCbaVUfZ+/v2UA5N5sBpAvTpAEAFIhdvHCeREdE4Oug6ahbdMaqF+jXHwNSNGCudFn5BzodDosmDhArhX5HEB2e56Ri7qdHO2xfON+XL/zCJsWjjI40mVsEMYARDoeJcnbThnRTa7XePn6rZxhaN+8Jp6+eCXXekwa3k2uu5AK0W/++xgtGlRF0y6jUb3ij2jbrAY00OD2/SdyFqXMjwWEGZCIyCiUrtMTy6YPRt5cmWFjbUWqew0ev0guep8xppd85Oz3sQvl41h9OzdVdTNIRgwgDCBfXCwMIAwgDCAMIAwgDCAMIKr3VCLDfP1oJT6zdPSZk/tzGiaGW4v4NHsGxPPEJSxeuwfevn5wcnRAgxrlMaBbc/lo0acqWGHhkbIKVuH8OTBmYAcFgKzeehC2NtZ47fcexQvnwZ+DO8HDjZZXNQYgUmS37zuJtdsPwcfXD2lSu+DnSiUwtHcrOegSjMxetl2GkfRuaWQVrMa1K8L39VtMW7QZV24+QERktFx8PqjnLyhSIKcQQCSfq7ccxOJ1exAbG4s1c4Yhf+6swgkODYuQC9mPnbkmQ46kwvVbpyYyvFCfV37v0bTLKMTE6OQCdqlwXYr7H7+1lptGBtFSoTobcbG7FrRknq3PTeFQo71pKcLn2+i/Kjw59FjYz0lvsVSh1DggWiwR2LtlASrscJ63hbSJiNGTNpSBg41YKjSDNoRyAb21Gnlr8VitvcXzKw0i2kc8N74HjpFj9Tn3lLTxehQgtIk5eJD0cf9VsNDm0OlnpI9rw4uTNhF2cWp7X/rYR9Pzp4kU22iiw8lx6NLQ8sbQRZN+KAMNIQutjQqlXOD+wLj6vy998sxbQfrQ29iRNr6RYpnPDA6kC0RrxD4cfa6RTiIfXCdttJXjnudf+mhixNLiUjtNlHgdvZ4/kRyHLoqWJs44xPBdVJ87/bB+FtmPnYtYPtWhflfShyYmkrS5HOUqtPnRlf4N1hNysTZv7pHjAFRo3YeLn1kqOgE+qcs1Zh+drSTpRhtGy35bBb8R+ol1piV09Tbi363XOvp3LUsaZ/J6TDHI19dCADKXAcSU+VLd5ksQodoBGxpEgAFEuSAYQIzdJAwgn0aFAcS0BykDiGHcGECU64gBxNi9xQDyeVSSMoDk7SN+75lpT0+61YN5jWijZGJh9gyIOa77SwBy58FTWUL3Sx/pqJQkvZvUPtI7SP45+uUXtP31R5cvZnfMcc0MIAwgnAFRrgHOgBh5UnIGxCAonAFRrhHOgChjwhkQZUy+9wxInt8sAyAP5zOAJOoenzMg5g0vAwgDCAMIAwgfwVKuAT6CZRgTPoKlXCN8BEsZEz6CBeTuvdO8GzWV3h4taKzSMumbJckMSNIPW/IaIQMIAwgDCAMIAwgDCNeAKNcA14AYxoRrQNTt73L1sgyAeC1kAFE3Q2yVJCLAAMIAwgDCAMIAwgDCAMIAwkXo5tmW5er5t3kcJdCL16ImCWyRdM05A5J058ZsI2MAYQBhAGEAYQBhAGEAYQBhADHP1ipnjx3mcZRAL48Xq381QwJdf3NzBpBvHvJv32GMz92v7/StN+kj+rlYajDi1WvSx5P9V0mbBxdeCm1OvQ0jfaS2EUsrtm9biPSBiWtJGz2hwksoIsr+HQkZ3ozBXuQ4NDpaOlP3VhzXaG+6n4g3fsKx+Jy6TY7V98or0uahn3iOnY8dJn14+YnlYPefouWAz46uSvYTqRMvglTel0gfMX4+Qht9mAp5zp86kv3YvCaeFZH0vUVp+UQ9f0CO48Iw8Utcy88fQvqwcnUnbR6kFN/n2V1sSB9iQW9Ae2gp6SP4Mb3WUnYfT/qhDLT3TghNHsxcTLmAPpaWFs87X3zNb+aMIfuxT+MitEnV9nfShyaKXq+Hg8Qy2T9lEMssy4MgZHitn14hxwqtWG5dcqB7L5a2pTsBQPwoxZaki5ypAnNpHJrXhOx+mgzkcPW24tcDPENa0kdutxSkjSkGObpbBkCeLGEAMWW+uI2FIsAAogw8A4gyJgwghjFhADHywGIAUQSFAUS5ThhADGPCAGLkWZLMASR7t+0W2dE9XdrMIv0mRqecAUmMqCYxnwwgDCCcAVGuAc6AKGPCGRDDmHAGRLlGOANi5AeeMyCKoHzvGZDsXb/8SojE3AI+XdY8Md1/U98MIN803JbpjAGEAYQBhAEEfARLsQj4CJZhSPgIlvI5wUewlDHhI1hAti5bLLKhe7b8F4v0mxidMoAkRlSTmE8GEAYQBhAGEAYQ5RpgAGEA4RoQwzXANSDqNnDZOm9SZ2hmq2crWpnZo+XcMYBYLvbfrGcGEAYQBhAGEAYQBhAuQleuAQYQBhBTNmNZO200pdlXt3m+svVX+0gqDhhATJyJoX8tQb5cWdCxZe0EeQgKCUOnAVPQ9dd6qFmlZHzbsPAITJq3EWcv34ZOF4uCebNhZL+2yJA+TuXB29cPE+asw9Vbj5DONSW6tK6LJnUqGe37zoOn6DNiDo5vny1/zwDCAMIAwgDCAMIAwgDCAMIqWAnasn3ROEuH9eZxlEAvL1a3SWCLpGvOAGLi3JgCIHOW78Cug6fxLiAI00b1NACQv2avw7uAQEwe0R3WVlaYtmgzHjx+gVWz/kBUVDQadRqJ+jXKoeMvtXH34XP8Nnw2JgzrgqrliimuwBQA0cRECiOhIyR2pcZhj/4V+vjwSCwlKjW+t+0mOSO7n34Q2lRKK5bukxqncbET+nDJSEv3pdm2jxwrJVhpRWmWAnB1EMtApnpHy5oiUiw5K4PqyyfC64l4+pC83sDHYinfJ4fukz6uP3xH2hTOklJoc272BtLHY78QoU0ed2fSR6/SmUmb0OhYoY37s1Okj2hibmID6ZhZNaWla2197wjHEhv8nhyrxlZ8b0XcPEP62NhzndCm7ZZBpA/r9NlIm0dupYQ22VPZkj6iKVnabZNJH+/u0DK8HmMXCP3oNbSMq+a8uHD2/uLN5FjD3oaTNiW2ie+/p6P6kz4c3VMLbdz6jCV9WIW8JW12BaUT2jRwjyZ96FKIfVh7nSN9aGzotRbj81i8BmIpTTZAY030U5qW4dWGBpDXo/UXr2mNNS1xrXcQSzE/safv8cSS4c3SnpbhJ4NkgsGLNe1MaJU0mzCA/G9eyjXojV7tG2H/0Qu49/AZdqwYj8we6TB72XZ4nriM6JgY1KpaCoN7tpRtRk9bCa1GA2trK5Qqlh8LJw1QPcPNu42VMxifZkDa95uEUkXzoXfHxrKfE+duYMLc9Ti8eTqu3X6Inn/Mwvm9C6HVxu1YZy3dhmferzFnfB/532u3eWLNVk8Eh4Yhb84s8Hnll6AMCAOI4fQxgCiXMwOIMiYMIMqYMIB8FhMGEMUiYQAxct8wgCiCkpQBJHO7Nar3fOY09F7b3pzuLOqLAeQTAMme2QO9OjSCh7srPNxcMXvZNrzye4dJw7pBr9ej17BZqFG5JNo0/RmmZEA+zrQxADly+ir+mLAErRtXR8NaFTB1wSb8XKkEmtWrjGNnr2Pk5OU4t/e/v4Dt9jwrQ8eO5eMgtZ04dz2mj+6JbJk94HniEpau38sAIri1OAOiDA5nQAxjwhkQ5RrhDIgyJpwBUcaEMyCGMeEMiBHgSuYZkExtV1lk8+6zjn6hrEUGZkKnDCCfAMjKmUPlug7pIwFHiVrdsXfNxPg6jIPHL8lHqBZPGWh2AHnt/x4Dxy5EjqwZcPriLbg4O2LehH7ImsldPrJVt+0f6N6mPlo3qY6g4FAsXL0Lt+49kQGk9/DZKFu8oAxG0oePYPERLMWzgI9gKULCR7CUvxh8BMswJnwES7lG+AiWMiZ8BEsZk+/9CFam/2PvquOrypnotMXddfFlYWGBxd2huLu7U5ziWqRocXe3xaG42+Isuou7u0NLv98J3y1Pb/LeS9vXR/LPsn25k8kkNzcnmTnTYK4dW27HH7m3tIXjQpxEggIgVgAINv1FqnVityFaCQwMpBTJEtGiSX2lA5B67X2odqViVK1cYQoIDKTJc9cSbjl2LB9DkSJFpJPn/mVB6DfvPqLkSRJQwvhxKGb0qAykVGnWj7q3qU1F8mVTAISIVAyIhdVFARAFQFQMiNkcUDEgxiZRMSDma6eKAbEALlQMCCWvPydMtvH3l7UMk3ZDolEFQKwAkG/fgihn2dYMAGCzb1r6jJhNv6ZJTi3qlbd5XExdsHDb8meplrR0Wn/6I0MaJu/x05dUolZX2rVynBEI0hpr2WMMeRbJRbUrF6emXXypsmeBYFYsdQOibkDUDYgKQjedAyoI3XypVgBEARAVhG7yXqggdKE9XfJ6s4Tqya50f3lr2SLDTJ4CIFYACP48eOwCevriFfXuWJ/ix41NV2/eo9v3HlFlz4IERqvLV2/TmAFt6eOnL5QogTlIsTaqlmJAWnQbTbFjxaDhvVtS5EgRaeaSjeS/+2/auHAEE/PsxWvGjvX81RtasmYHnb14jVbOGMRuR+av8Ge3JSP7tqKAgECavWwznb98Q8WA6LxWKgbE3DgqBsTYJioGxHyOqBgQc5uoGBBzm6gYEGObqBgQ8zkS3lmwktWdESYb9wcr2oZJuyHRqAIgOgAEwGLK/LWMBevFyzeUInkialq7LHOTQsxGlwGT6cq1OywwffQA/qSACxUYtN69/0iRI0WiiBE9aMP84eyG5enzV+Q7ZRlztXJzc6OsmdJS7w71g+NZT7YGAAAgAElEQVRPFq7eTmOnr6B4cWJRqcI5qVOLGhQ7VnSmPWh6h/otop0HTlLihPGoZKEcLFZFywMSeJtPbUsf9Kltv1zly3h67KzuHH16/g53Ds/efI1bp0oafbCXKLM+JSIaiPmLPo3r5iX/cPWocO0ktw6vQrSIfOrMhFE9dMVEeqhPf4yHv716wlOFvt69qlvnxblLXBnPLuiP8S5/fRpJNJAvW2JuO/Ez/nCNtFR5RLEBXBmXrupTdG7vUZgrQ4BFmW6+/qIrJ8vNbdx2Pt+4rFvnwxM+LWbsjnw62Ig3juu2E/jyMVdX96j69MXP92znypg32F+3TqfZfCaYiKkzctu5ntZTt06a2Hyq0Hdf9cm2A2f25urx6IT+uwcBGRat05UTxOP8xjqwYbyujNv+R7m6vr7zhlsn99LZunUOV+GPX7xf9Wl4f5vJz8MQ8Sn/e7L9aypdXUvH5vc3IHZSXRkRb57g2ozc9dd5CAh4eEt/Dnzi060Tb56U4I9NhFd8Sn33tzwKZJ4iREGRour292b09Fy7/pqQT6nPFWKhQtI60+x5zOFnHq5s77AMZxGgAIizjEQI6qEAiLlxFQAxt4kCIMY2UQDEfI4oAGJuEwVAzG2iAIixTRQAsbTBCecApJZ+Xp6Q2tI9XN0hpESHulwFQCSY/GtAILX1HmdVEvKEtGlUSUJL9olQAEQBEHUDYj4H1A2IuU3UDYixTdQNiPkcUTcg5jZRNyDmNnH1G5AkNSfbtyFz8KlHa77nfnOFogCIK4wipw8KgCgAogCIAiDKBct8DigXLGObKBcs8zmiXLDMbaJcsIgS15gYJrvHx391DpN2Q6JRBUBCwqpOJlMBEAVAFABRAEQBEAVAVAyI+RxQMSAmNlExIEI7uMTVJwjVk13p8douskWGmTwFQMLM9KHXsAIgCoAoAKIAiAIgCoAoAKIAiApCl7P3SlRNn9BBTivmUp6s6xZSokNdrgIgoW7y0G9QARAFQBQAUQBEARAFQBQAUQBEARA5e7BEVcbKEWSjlCcbetj4hPNWVwDEecdGmmZfDq3kygp8+VS3ztOjp7kyLi7Xr7Phlj7VLxpoVfFXbjvxMyXXrRM7jT4lIh6O9lsmXRmvT5/i6vGmyTBunegcmt24Ufg0vO4fX+u3c2EfV4+Apw+4dZ6f1afZvbbpAlfGiavPdetUrMGnRo2XMSW3nZhpkunWyXZAf3zx8NmxZXVlBHzjqkF33+hT7ELChSfvdAWV/XsKt6FHx/Splt895tNvZl2xitvOt7361KafHj3iyoiSKJFunRMjV3NlvHui35/UxfSpU9FA8sJZue08ruStWyd5DD4NL2+aXGtQlauHuwAdd/qF+jS8nwN5mhC96NtcV5cI0aNwdX1/X/8dh4B0Uxfpynk1fRC3nagJ9enWI9Xry5UR4Smf9nvbO31Kb88k3GYoKJJ+8tsIt/jfE3Ljk3oHPNKnOQ/6yl+Pgr581O2Qe3E+Da+HAA2v2yv9tSLo62euYd2i6Nv1TsIcXBlpEoQMDW/CymO4bYdEhacbe4aE2DCRqQBImJg9dBtVAMTc3gqAmNtEARBjmygAYj5HFAAxtwlv268AiLnNFACxsAdQAMTMKM4MQBJUGhW6G7n/t/ZsU68waTckGlUAJCSs6mQyFQBRAETdgJjPAXUDYmEzrW5AjIyibkDM54i6ATG3iboBMbeJq9+AJKg4Mkx2es829wmTdkOiUQVAQsKqTiZTARAFQBQAUQBEuWCZzwHlgmVsE+WCZT5HlAuWuU2UCxZR/AojwmSn93wL3/UwTBSzo1EFQOwwWnh7RAEQBUAUAFEARAEQBUBUDIj5HFAxIMY2UTEgYju8eOX4MaBikmyr9cK/v20POHFtBUCceHBkqaYAiAIgCoAoAKIAiAIgCoAoAKKC0OXsrOKVHSpHkI1SXmwbaOMTzltdAZAQGpviNbvQ5OGd6Y8MaWxuYdyMVTRvxVa6uG9B8LOT562lrbv/pkdPX1DCeLGpca0y1LBGaYuyL/x7k7z6TaS9a74nylEARAEQBUAUAFEARAEQBUAUAFEAxOYtmcUH4pYZIkeQjVJebuczyNkoMsyqKwASQqa3F4AsWLWNtu09Tucv3zACIGNnrKQiebNRutTJ6NJ/t6jzgMk0zbcr5cthTjdqCkA+75zH7eWn2/p0hTe2nuTKmLnuX906VVLr0yri4cz1+LR6sdLq0+xGTpiQq2vkTHl16wQ8us2Vce/3Ctw6CaJG0K0T+dsnrgy3Lx906wSd2cGVwRtfCLi754yunM3r/+O2UzCLPgVr+mr88Y2ZWp9iF0pEiK8/BwZ8ys3VdUCJtLp1BFhN6eAdDkUyESWOEVm3neTze3N1vbPvim6dV7f4epQ8u4vbzpeN+pTAr2/w6Zxjpkis286irnw64HwFf9GV8fEl/735tVI2bn8/tNJnsonPeX/RQGQPffrUC9X560Ts1HG5uiYbt1i3zpvPPD4uoped6ujKSPgnnwb949OXXF2T9J+k/275z+TKcI8VT79O0YZcGR6v7nPr7HoVQ7dOiV/41MS8RiLcPcurQuTuwa0T+OSe/rfgsz7FLrcBIgoqqD9H2PorYFd6fEO/uaAgrjpuUaLq1rmXKCdXRqr4+uPLFWClQhzPsAECr3aEDfCx1056zykAImDVqzfvUcOOw6l7m9o0f6U/ffj4mfavnUhnL14j3ynL6PbdR5QsSQIa0LUx/Zn5Vxoweh6t3XqAIkeKSO7ubtSuSVVqUa88t6WNOw7TX1sO0KDuTalS4z5GAMT04UZeI6hUkZzUpFYZ9tOi1dtp4art9Pb9B8qQLiXde/gk+AZEARBz0ysAYm4TBUCMbaIAiPkcUQDEwlqiAIiZURQAMTaJAiAWtj/hHYCUGsDd04VEhVe7fEJCbJjIVABEwOwAIFWb9adq5QpTncrFKWqUyBQzRjSq1qI/jR/UgfLm+J32HDpDPhMW0fblYxjwsPUG5MCxczR53jqaN96b3rz7QJ51e1gFIB8/faGStbvSuIHtKX+uzLTr4CkaMWkJjR3YjlKnSErb9x2nWUs2KQCiM7YKgCgAom5AzOeAugExtom6ATGfI+oGRGDTYFJFARDXAyCxS4ZNMPjr3WET/G77rOc/oQAI30ak3YD8vWV6cO05y7bQrbuPaFivFsF/w63FiD6tKMvvaW0CIDfuPKQuA6fQ3HE9KWH8OHT/0TNdANLPdw49efaKZo3pTm5ubtSh7wTKnzNzcEyIcsFSLlim01q5YJm/6AqAKACiXLCM54BywTJ/J5QLlrlNlAsWUewSYUOH+3pP2ND/CmyVba6iAIiAySwBkKF+i2jr7mMUI/oPH8UPHz/RqH5tqHDerDYBENx+ePWbRG7u//clDgqirwGBFDFiBJo8rBOTp5VRU5fT8TOXacGE3uwWBqVKs37MPaxIvu8+zwqAKACiAIiKATGdAyoGxHyxVwBEARAVA2I8B1QMiMCmkIhiFefH7olJsq3Wm72+tj3gxLUVABEYHEsAZObiTfTw8XMa3KOpRQmlancjvyEd2W2IrcXSDUhAYCANGjOf7tx/TNNGdg0GH5DdtIsvVfYsQNXLF1EABEGhKgjdbMqpGxB1A6IAiAIgKgjdfA4oAKIAiK17NNSPWayXPY85/MzbffrEGQ43EIoCFAARMLYlAHL3wROq02YIDerehN1QvH7zno6dvkR5s//OAtIRtF4oTxZqVNOTPn/5SvHixBRo6XsVUwAC8NG213gWWwKXL/wXxc3NnaJGiUTzV/jThu2HaWTfVhQQEEizl21mLFoaDa8KQjc3vYoBMbeJCkI3tokKQjefIyoI3cJaooLQzYyigtCNTaJiQCxsf8J5EHrMIj2F93QyK749MEamuDCVpQCIgPktARA8duqf/2jC7NV05dpdBgpyZv2NMVgBbACM9B81l569eE29O9anulVKCLRkGYAgKD1/xfZmz6dOkYS2LPalL1++ElzCdh44SYkTxqOShXLQ+m0HgwHIh9WjuW1fX7tPt87UFZe4MtpUy6BbJ37G5FwZCfP9ya3jETuBbh332PG5MgIyFNatE+TmzpXx+lMgt05cj6+6ddwC+HSiboH6Mr7uWcrV4/bWI9w661Zf1q1TtVZGroy4v6XUrRM3p8D4xtWn8kUDHpwx/pKST8/IGz0RAOJ/7QXXJkVS6dNP36lVkSvj8YWnunW+fONTWpa9yafSfuTdRLede0fvcHVNlkefQvfQyotcGZX6l9Wts2X4Nq6M9Jn01wkISLNRX447fxmguBH06W9vePHpYuNlTMXtj0dbfdeLV595M5ooaGAz3XaSF+e7LgZ+1KcFRwMRavfRbSfC+e3c/rpH06dP/ZouP1/G53fcOtc+6dPsphNicdWfAxEf8ynMgzz0KdvRkcCHN/X7ExjA7e+3D/o2cSvEp+H1ePOI207QXc6eQeAb6x7lu5u5tfLkF306fTyXNE50rq72VIhRuLs9jzn8zLuD4xyW4SwCFABxlpEIQT0UADE3rgIg5jZRAMTYJgqAmM8RBUDMbaIAiLlNFAAxtokCIBY2OOEcgEQv1DUEd23WRb8/5Bcm7YZEowqAhIRVTWQiKNxv5mqrLcFNq1gB/smwvaoqAKIAiLoBMZ8DvPNiBUAUAFE3IBbeG3UDYuFTrG5ATI3i6jcg0Qt2sXdL5tBz7w9PcOh5Z3pYARBnGo0Q0kUBEAVAFABRAES5YJnPAeWCZWwT5YJlPkeUC5a5TZQLFlG0Ap1CaMemL/bDkUlh0m5INKoASEhY1clkKgCiAIgCIAqAKACiAIiKATGfAyoGxNgmKgZEbAMXLV9HsYqSa304NkWyxLATpwBI2Nk+1FpWAEQBEAVAFABRAEQBEAVAFABRQehytl5R83aQI8hGKR//nmrjE85bXQEQ5x0baZopAKIAiAIgCoAoAKIAiAIgCoAoACJnaxUlTzs5gmyU8un4dBuf+FEdjKrNu46iVg0qUplifMY7uxsSfFABEEFDhedql5pU4qo/adF53Tod6mbiykhZMrtunUiJk3JlRPo1C7cORY2lWycoQmSujC/x9RNE/j8nva4c92/69Lh42O3Le10ZPIrd7w/ra3O9N/8qeO1yPvVptdq/6+qaokQOrl0jJNAf44ip9dtgDUSLzW2HN8YB8VPzZXBr8Cs8ec+nvYwZSZ/LdX96/ocgehx9qtDfqvzBVTbpAL7v8LZfC+q/W9xWUEGfEjhVfj4dd6bOjXVb2lJ3JFcTAWZiKsOhJn70jj++yWLq06e+m+zN1TVWen7C2jsFW+jKEelv3Pl9dWXEK/w9ma1eCfr6hVeF3uesrlsn9lM+rTtFiKQr42289Fw9ogbqr78Q8NZNn+r1kwAbRYKo+nMg0v1zXF156zwEBD5/yBkc/WB49nZ++awvI2sprq7uAjS8bu/1KcoDnz7gtuMRL7FuHREq5ihR9NdOrhJWKkTJ3cbeRx167tOJmXY9P3HOXyw9w/OXb2jMgHYKgNhlRfWQzRZQAMTcZAqAmNtEARCbXy1SAMSSzRQAMbSKAiDmc0QBEEvvDf/YSwEQY7uFJQCJnKu17R8MCU98PjnLISm1Wg+mlvUrKADikBXVw8IWUABEARB1A2I+B/ip+/ivmAIgCoCoGxDzOaBuQIxtom5AzOdIeL8BiZSjJf8DEQI1vpye45BUBUAcMp962FYLKACiAIgCIAqAKBcs8zmgXLCMbaJcsMzniHLBMreJcsEiipS9ua1bMSn1v5yZZyTn9Zv39C3IsutdjGhRKWJEY/dABUCkDIMSImoBBUAUAFEARAEQBUAUAFExIOZzQMWAmNhExYCIbq2col6dNkPo9VvLsU6DujWh/LkyG+mpAIhTDNvPo4QCIAqAKACiAIgCIAqAKACiAIgKQv959n6WeqoAyM89/rRm837afeg0TfftKmyJ8TNX0dzlW43qF8z9B80a08NMxoV/b5JXv4m0d80E9psCIAqAKACiAIgCIAqAKACiAIgCIMLbLpesqACISw6reKfsBSBPnr+ivp0aBjcUwcODokU1p5w1BSBt3fiUpJ0a69Pfpq5YmNtBjzgJdOu4RY3Ol5EiI7dOkEdEbh1ehcBYSXSrBEUUoe7js5a4BQXqqxLAp7QkD306ynGJ9OmPoUC1OgI0yp55dXWNkDgFz6zkHi2Gbh33pHy60SBOf1kDQfoh5K9j8+d8jKBPurp+cOfPAXc3/hz4HKBPjXkuL5/6NGkO/fn6W/sm3LH5lotPx30gWyFdObGS648vHv70Sp/mM3PD/Fxd45auoFvnXB9frowPzz9y62TdtUt/Dnzl05pGiaA/B9xXjuDqEfkX/ny9l6OO/vrKbYUo6X79HAKR0vLpnN2j82my3/2iT9kd7fVdrrZBHvrUtgGxk3FlBApwE38K0F9LRMgqInvoz4EYD85ydQ2KFJVbJ/Duv/p1rMQCGD3E61Bm/nrk8UGfYhftBd66oKvrt0/89zNCQv0xDshYjGuzkKLh5TbsZBWGT1xMW3Yfo3fvP1LkSJEoYkQP2jB/OCWMHyfMNFV5QCSYvsvAKZQ0cXy69/ApHT15gbzb16PalYvTX1sO0NzlW+jV63eULfOvNKRHM/r85QtVatKXAgMDKXKkiOTh4UF/b+EnlsENyMvX78jH23Lg06LV22nhqu309v0HypAuJd17+CT4BkQBEPNBVgDE3CYpFQAxMooCIOZzRAEQc5soAGJuEwVAjG2iAIj5HFEARMLmM5yLUABEwgACgJy7dI26ta5Nf2RMQzFjRKNzF6/TuJkraebo7gyc+M1cTXcfPqFJPp3sdsFatm4XxYgejeLHjUUVSuWj5nXLM+13HTxFIyYtobED21HqFElp+77jNGvJJgVAdMZWARAFQNQNiPkcUDcgxjb5oG5AzCaJugExf2/UDYiFQz51AyJhd+naIhQAkTC+ACA5sqSnxrXKBEtr4z2OypfMR1XKfM8sjOyTnnV70Knts+wCIHfuP6aAwG8UJVJEunL9Lg0Zt4DaNKpM9auVpA59J1D+nJmpYY3SrC3lgsUfVAVAFABRAEQBEOWCZTwHlAuW+TvB81jCEwqAKADC33WoGqYWUABEwpywBEAqNe5Db959MOJgfvvuA+1Z7Uf+e/62OQjdVE3ccBw7dYnm+fWiKs36Ufc2talIvmwKgAiOpwIgCoAoAKIAiAIgCoCoGBCTdUDFgAjuIlQ1Ry2gAIijFiQiSwCkRffRVL18EapQMp9ZC+v8DzI3qRmjutvd+oTZawi3IuMHd6CmXXypsmcB1p66AREzqQIgCoAoAKIAiAIgCoAoAKIAiNiuQdWSbQEFQCRY1BIAAdvAlHnraFS/1vRbuhR0/9EzOnT8PDWpVYaOnrxIfUbOphUzBrLWkySMx9XCx28ReRbLTelSJaPLV+9Qr2EzyMe7BZUsnIPmr/CnDdsP08i+rSggIJBmL9tM5y/fUDEgOlZVAEQBEAVAFABRAEQBEAVAFADhbsBUhRCxgAIgEsxqCYBALOh2F63ZQfcePKF4cWNR6SK5qFeHevTtWxD19JlOew+foTixYzC3LF4ZOXkp7Tl8hp69eM0AS9PaZahOlRLssS9fvtJQv0W088BJSpwwHpUslIPWbzsYDEB4stXvygLKAsoCygLKAsoCygLKAsoCoWUBBUBCy9KqHWUBZQFlAWUBZQFlAWUBZQFlAWUBUgDECSYBKHSv33pgUZPYsaKzOA9VlAWUBZQFlAWUBZQFlAWUBZQFXMECCoC4wiiqPigLKAsoCygLKAsoCygLKAsoC4QTCygAEk4GSqmpLKAsoCygLKAsoCygLKAsoCzgChZQAMQVRlH1QVlAWUBZQFlAWUBZQFlAWUBZIJxYQAGQcDJQSk1lAWUBZQFlAWUBZQFlAWUBZQFXsIACIK4wiqoPwhb478Y9evbiFRXI9Qd75vT5qxQtamTK+GtKYRmWKoIeefPOo9S0Tlm75dgjQ0Z/XEmG3cYPpQftGWMZqp27dJ3u3n9C2bOkp+RJEtglEnTf56/cpEdPX1DSRPEpW6Z05OHhbpMsGXMNDQYEBtKFKzfp8dMXlCxxAsqcIQ25u7vZpIurV7Znrn36/IXZ9eXrt/RL0oSUIV1Km+3q6DyRNUdMx9cee4TkHAG1fh+vBg414UoyYAhb+/PxE+brDXr15p3d89WhAVAPO2QBBUAcMp9zP1ygsnX2rCMbpwopL0MGGpIhR4YMZI0vXzIf1a5UjGYv3UzTFm6g6FGjULsmlalB9dJCNtEqff0aQHuPnGU5V46cuEA5s2WgueO8Q1WGjP64kgwZc0TWfJUxT2T0Z8LsNbRs3S5KkyIpXb99n+aM8yY3Nzdavn43+fZtLTRfb919RO37+NHbdx8oSaL49PDxc0oYPzZNG9mVkiaOLyQDlWTMtYdPXlD73uPp0+evDAwljBebYseKQVNHdKFECeII6SLDrnoyNCV466wMPQw77Mia9PeZy9R98DSKFCkCJYgXmx48ek5JEsWjiT5ewqBVxjyxd468ev2O5dXStUfWDDR3vPgaLWN8yta33N7dB08oc4bU1K11bcqXM5PuvHUlGeiovf0ZN2MV5cqWgYrmz0bHTl2i7kOnUdQokSlenJgs2TMORib5eFEyOw9ZhBYPVUmaBRQAkWZK5xN05dodM6WGjl/INuANa4httmXIgBIy5MiQka9ie/JfOorixo5JZer1pMHdm7KPbBvvcbRjxVihQbz47y0GOrbsOkaJEsSlymUKUMVSBYQ3P2hEhgzIkdEfV5JhaY5gA54jS3pq3bCS0Pham6+2ypExxjLmfO5ybWmeXy/KkjENLflrJ5t7XVvXoqrN+xFvg6wZrG2vcew0vFOLGuzWIzDwG/nNXk237jyiKSM6C9tVxlzrNngqpU6RhOlSqk532rVyHM1asondzkwe1klIF0t2HT9zFeX+MyO1alDRIRm4XdU2lLybVVnzVcZcq9CoN9WoUISa1y3P+o9bJmz4rt68R3PG9hSyiYx5Yu8cyeHZikoWzkG1KxWnaFGjfF+jdx9ja32VMgWpkmdBSpoonlA/tEoy3r/jZ65YbLNNr3E0oEsjmrNsC21dMkpXL1eSgY7a25/8FdvTgol9KEO6FFS+YS9qUutHQmbMV79Zq1lKgxmjutk0zqpy2FhAAZCwsXuYtXro+HmaumA9LZ82wG4dZMhA4zLk2CoDC9iB9ZPp9Zt3VLpuDzq+ZTp9CwqigpU70Mlts4RskrlYU/YhG9m3Nduw2FNkyEC7MvrjSjIsjQU2poPGzKO1c33sGargZ2yVI2uMTZW2dc4Xr9mFlk7pz04FX795T/XaD6V184ZR3grt6OzOOUI2QV1s9GPGiBZc/827D+RZtwcd2zxNSIas+Vq4qhdtXDiCbSw1AILNR7HqXejQhsnCuphWPHPhKg2fuITWzB7ikAzfycto5cxBdsuwdZ6hIRlzDesA9E6ZPHGw7k+evaLyDb2F10YZ88Te9ejBo2e0zv8grd9+mPDvWDGi0VDv5lS6SC67x8LSg7a+f9Yaz1W2NR3bMp1yeramc7vn2qWjK8mAAXj9yVmmNe1Z7UfIj4a5tnnRSEoY/8etJ9a3krW7Cs9Xu4yuHpJmAQVApJkyfAi6cechVW/en87usm/BQy9lyJAlx1ZdOg+YzNwLXr5+R6/fvmMuU8dOX6JRU5axTZlIOfj3P+xDd/jEBSqQKzNVKl2ACufLRhEjeIg8zurIkAE5MvrjSjKsAZCmnUfSqe1iANPaIGJjaIscWWNsqo+tc37q/HX0/sMn8u5Qj4kqWr0zTRrWifr7zqFNi0YKzVk8g0MLQ9cG6NG86yja99cEIRmy5itudHauGMvcbTQAcvveY2rZYwz7u73l2s37DJyd8J9prwiSIcPWeSZrPekzYjbl/jMDVS9fJLj/GONO/SexjZ5IkTFPHF2PgoKCmHvOWv8DtPfwGcqZNQNVLVuIShTKQZEjRRTphm4dW98/a8LmrfCn+tVKEm5We3esb5deriQDBuD1p27bIdSoVhmqUDIfdR00hcoUy0Nli+cJtp2MdcCugVAP2WUBBUDsMlv4ecg0WDNtquT06OlzSpcqmXAnZMhAYzLkOCrj+cs37Jr2zbv3zPcWrhx7Dp2miBEjUOG8WYVtgoo4bdm86ygDIw8eP6NyxfPSgK6NQ1WGjP64kgyvfhON7P/lawD9c+k6VS5T0KaAT1lyHJ0nlgJy3d3dKWaMqMLvMFxaELuBU0NNn6hRIrEbPNHTYQSHxogelbyaVw+275hpK9g7bUsgrYy51shrBLVuWJG9r0WqdWJ92HXwFHVsXo1qVSwm9P5Bd8Py8fMXdiiQKX0qFvMgUmTIkDnPHJ1rDToMo5t3HlK2zL8Gd//Js5fstjh92hTsb9N9u+qaRsY8kTFHNCVxS7dl11Fau/UgIeaiXIm8NKhbE5HhDa7j6DdnwOh5FtvbsP0QNarpSQ1reHJdw1xJBoxhb39AGtN5wCRKnjQhUVAQPXj8nBFQaAXzFfPHlkMRmyaDqizVAgqASDWncwmTEawpQwasIkOODBkhNUL/Xr9La7cesGkzZqqLDBkh1b/wInflhj1GqiLYetm63eTTqwWLgRAtsuQ4Osb2BuQatgsffsMCAAMmrCiRI4maI7geYj9evHpD8eLEspkBy+bGrDwARq+Pnz5TvhyZ2OkxgFGhPFlsYrLDRtmw4AAibcqkVLFUfookeEouQ0ZIzTP0zdb1ZM3m/dwhqlmxKLcOKnz7FhQ8T5yFnQxg/q8t+21ao2V8c3ADaanMWrKZKnkWIATuL5nST9euriQDHXWkPx8+fqZzF6/R42cvKSAg0KLdROep0GRWlULMAgqAhJhpw16wjGBNGTJgCRlyZMjoO3I2d2BG9GnFrYNTMZysP376kgOauVIAACAASURBVBInjEtZM6WjCB7iLlhoQIaMLgOncHWdMLSjbh1XkmGpoweOnSN87HkfeZ4h7ZHj6BjbG5BrqS8AD+/efwy+CeH11/B3PDdi0hLauvsYfQ0IZO6G1SsUJe/2dW0CMnpzjTdPbdE3PNe1Z57JWk8ctRvmie+UZbR555HgeVKxdAHmYgSgKFJkrEci7YjUkfHNsdYO4h0Ob5zKiETO7OB/lyzJcSUZ6J+M/oiMq6rjHBZQAMQ5xiFEtJARrClDBjonQ44MGTMWbWS2vvjvTbr0322qVcncZaNt48q64wE3hfZ9JtCHj58Y+AAIiR4tCqMkhUuXSJEhA+0sWr3drLkVG/ZQwdx/UIpkidhvjWuV0VXJlWRY6uid+4+parP+dNrOj7wm01Y5MsbY3oBcQzvgFNfHbyEjfQAIwVytVq4wdWlVi+CKJVKGjF9I9x48Je8Oddntyd0HT2n01OX0a5rkNp0oW5prKzfupTzZfxd2jZEBYq7ffsDivuCWg5uU3l4N6M3b94zK808DFyQ92yDW4NDxC4zaGPS3hkWUSUvWfJUx10xvYwx1K1UkF7vh5fULBzxw9+vSuhajRAVN8oTZqylm9Gg0vHdLkakmZU2Da561MntsT6rTdogQAYOMb441PcBIV6NCUWrkNdxu4gNXkgE72dIfGe+w0IRUlULMAgqAhJhpw16wjGBNGTJgCRlyZMjQRmX7vuPUbfA05jOOuA1bEqo16+pL+XNmppb1K7IkXdiIzF2+leUCAd2pSJEhw1o7uw+eZgGYyItgbwmvMpDbxbBgY7jv6Fm26Z7v11vYHDLkyBhjRwNy0eEmnUcy4oXOLWtQgnhx2Kbbd8pSSpU8CQ3u0VTIJgguXjVzMAPcWgGwqdduqMP+1vuPnmMbj9ljewjpIgPEVG8xgLL+no5KFMrOcgGVLJSDxZQgsNV/6WghPQaNnU87D5xkeQmiRo5s9Myo/m2EZMiYZ2hIxlxr19vPqs59vOpT35FzuLeIyJvhv2S00S3b67fvqVwDb2HKZ0tK2LoeXfj3ptW+wNXu3MXrlD9XZu4YyfjmIDEj3ED3HztLL199T5iHAwBQBosWV5KBPsvoj4x3WNT+ql7IWEABkJCxq1NIlRGsKUMGjCFDjgwZ0GX+Cn+WN8C3Xxtas3kfubm70dgB7YR9v3OXa0MH1k02Oj1GRlacup3wnyE09jJkWGvo3sOnhMX5+FYxXSzJCa8yeg0zZjCKEMGD3UohN4AWhC0yQDLkyBhjGQG52EStnjXY6HYObDEAD0c2iSUkBeXlzpXjGLWpVp4+f0WVm/SlozbQ8FqyPW6WMF9FabAtybAVxCBnBPL+AJhdvnqbRkxaSjNHd6OCVbyE3WEM86uIzClLdWTMM8iVMdfs7YPhcyVqdaWFE/sE377iNwDepp19affq8XY3IWM9sqdxGd+c/qPm0j+Xb1Djmp6MMhb2mLdiKzWtXZZ7O63p7Eoy0CcZ/ZHxDtszJ9Qz8iygAIg8WzqdJBnBmjJkwDAy5MiQMXjsAjp0/B+aPqobpU/zC4vDwGKIzM74cIoUbLpwa2KYA+TE2Svk47eI5ScQKTJkoJ19R84aNffp8xfavPMoPXn+kp1YixRXkiHS39CqI2uMHdUXp+NILmfI8ga3wdptBtP+tcasYdba6tB3Arv1M0xgitN7nCTbkojQ9PYCLGVgoYscOaJNN1SmetoKYmAT3GDCVRFrQNl6PWnN7KEsuZkoKMP4wq0oy+9pHR0ih5+XMde27ztBz168pgbVS7FYoaVrd7FDlnpVSzKWQJEyfdEG2r73BLWoV54leMU8Q6K9MsVzU7vGVURESFnT0NC2vcfpry0H6PHTF5QsSXx2CAEqXluKjG8OwPuCCb3p9/Spgps+ff4/6jl0hjAocyUZMIKM/sh4h22ZC6qufAsoACLfpk4vcf22Q4wX3ZEiQwbalyHHFhk1Ww1iVJKGyYvgQoUEZP27NBIyCdwB+vrOJs+iuRl9Ivycd+w/ScN7tRS+VpchA8ri5NiwRIwQgdKkSkrtm1SllMm/x4DwiivJQF+xGd26+2/GkpI4QVwqXzKvUXI1nj203x2VI2OMuw+xnuSvS6uaDPTOGqPvugS/fMQ7IRu0Vq7duk/I8gzWJ5RmdcvpmuXl67f09t1Hozl15/4TRgeMhICixbQ/YCk7euoiLZs6gFL98iMBnp48GSAGNKAnz11hFKgoE+esoWL5/6TAb99o3KD2Qt2B29ipf/6lfp3N1w3crIgUMPosXbvz/7EomdlcRZA/XAejRTV269KTJ2OuYR3o2roWA6oDx8xjh0bx48Ri4zKou5irHtivcKu8cceR4PevsmcBqlmxGHNXFSky1iMADwCfDs2qEuiS0a+Zizcy0Ils77YWRwgcKjftR8PBwmcAVF+8ektl6vUUvjF3JRmwvYz+yHiHbZ0Hqr5cCygAIteeTiUNWWxXbtxDDx49p2/fvgXr5r/3b5azAoXnqyxDBtqRIUeGDHzwbfmwWxvQ67fu0+Zdxwi844kSxKWKpfJRutTJbRp/GTJsavAnqAxXnB5Dp1HhvNkoaeJ49OjJCzpw7B8aO7AdFc2fTdgCsuQ4OsZwF7RWQOGJU2rEdugVUzcfS3V564CMAGVrOq7atI+On7nMxkikyAAxpoHsoCZOkzIJuylCvJBIQfZxa+XivgUiIgg3S8+ev6bc2TPSxu2Hybt9PUqaOD4Nn7iY1s71EZKhVXJ0roGBCK6lWB8Ry4GYKRzUVG3Wjw6sm2STLmFdGRvcYd7NGTuhlqwSgLltr3G0dckoXfVwE4SEm6DtRkb1oX4LWdJZgCt7CBwmzvmLbtx+QK0aVgxu9/zlG4xRrtf/ExD+YZDLwpJyriQD/ZPRHxnvcFjP05+9fQVAXHgGIGto7FgxmKuQh7t7cE9x2te5ZU32/7yTTxky0I4MOTJkyDhRdqYpI+ME1ZVkYOPRq0M95lqjlSMnL9Coqctpw/zhwkMnS45wgyYVEUTL25TYK9ue52QEKFtrFz7xYClzJFO9rSDGHhuYPgPXLWtFlJIbfuxw20RgMlwhV2/eRyN6t2KbZtF4Mhl9gQwQDWxaNJIQ24OkhEc3TaW37z9S6Trd6e8t04WaASC2VuDaJVJkrEewK1zpkOtGAyAYryJVO3Fd7IrV6ELjB7enHFl+o8adRrDbUzAjIvcNbkXB/pY2VTLhG/PiNflkIHvXTNA1jSvJQEdl9EdkLqk6zm0BBUCce3wc0u7PUi3o4PrJFNMgcBQCcdIlGvApQwbalCFHhgwZJ8p6IEYbMJ4bhwwZaEvGCaoryUAwLua8YZI9xMUUripOEAC7ypDjyBi36Daa5o73duj91x5Gsj5kCTfcFGMzNm3BeurUQv/2RDYQgluPYQEbDk6Cj5+9QlsW+9rdX3tAzOcvX9lm2/B2uI33OJo5ujvTAxvPkC4AumMGtKUM6VIQiCwqN+1LGxeMoMJVOwqv0dDRkbmm9XHM9BV08uy/9P7jJ0ZFPKxXC9q44zDLIo4YBpFimtkdzxw6cYFyZc0gzHImYz0C6MA4pkuVjAEQxMNh7YfrIS+bO74z+9dOYqQVWAe2LB5FiRLECe4+4gVrtBrIZfXS8uWI2M1aHVeSgT7K6I9mK9MEq4Y2RHynKs5vAQVAnH+MbNZQe8m9fWZQj3Z1jRZPCGvfx4/lrNArMmQYLjjOoIvNhrTygB6I0R7h3SzJkIG2ZJygupIMUM56Fs1FDaqXDh49+NgjRkeUZAAPypDjyBjLBCAtuo+mjx8/MxcnuJaAUainzwx6//4jlzRBph6wq+nJZ4QIESj1L0kI8SyZM6QWekVlgBjEkYyfuYrc3N3JwyA2ASBAy43CO6SRkY9k8ry1BHecnu3rsr437eJLbRtVZvN18eS+QvZAJUfmmtYIXIw27TzC8nhUL1+EuWJdu3mfokSJxG5o7C0zF28ixBAhGaFIkbEe4cYTQfBNapVhAc+IqSmYJwsN6NLY7HtoqlO5Br3It19rypYpHdVv70Pd29ahnFl/C64GZjoAxcMb9JPAynh3XEkGDCijP9pAYFxNC8gTkPBS9MZOZD6qOiFnAQVAQs62YSZZxksuQ4asBcdRXfROSgwHiXdqgsBGewIYDduQIcNQnowTVFeSAT/4tr39mMvhdxaeFxQQ+I1m+Ha1KUbHETkyxtjROW84R0CyANcYsFYh/8Dy9bsZCUW3NrUpcqSIuuuUTD1kLYgyQAyyTyPzOpIQGhZbboct5SOZv9KfyhbPy9wARQpiLQwL5m3qFElpYLfGjKWPV2TMNV4bCPb18W7Oq2b1d6y/zbuOYjeTIkXGemTYzvsPn4TjevAc3OCmzl9PCJ5/8Pg53b3/hMoWzxMsEgnwzl28xtzV9IqMd8eVZMjaD+jZvJ/vHAYca1cuLjLVVJ0wtoACIGE8ACHRvLMsWrIWHEf7Y3hSArcLdzc3I1pJZDSPEjky1+faUT1k2cNwzsg4QXUlGbAN3HpO/fNfMAsPTi8jcTbalt5De+U44zzBJgxuOsiGjviYKcM7C1GryuiLqW1xg4FNXfYs6VlW9bAoecq3ZXlNYseMbtS8LQDEkt5wWdp54BRNHmY9E7fM/socn+NnrhDWgoePnzE2MK2A/ENzQeLFKljqG27cEHc4ZoAYyYCM9UiPNEHTsU6VElaH4p9L12nvkbOMZCQgwHKsD4+4QcbYuJKMkPj+mQ4gxq3X8JnCyURlvotKlu0WUADEdps5/RPOsmjJWnBk9EcbtEZew8m7Q33GcKIVfPBAX4tAQ70iQw8ZMgx1dPQEFbJcSYYzvJwyxliGDM0WJ8/9S31Gzqbf06ekPl4N2Wbw6o17NLp/G+6tkEw9oA/iUZat20VpUiSl67fv05xx3gQqXtzK+PZtLTR8MoKUkXwQ9LLRohozXp29eI3FP9hbbt55yPKrnPA3TohpTR4AYaE8Wcx+BnFCgVw/iBSsPS9zfBArAderQrn/IHePH6Qljb1G0KL/u4PxiBFk+OXLWI/0SBM0W/JiQeydA9pzMsbGlWTI2g/ojQtcBuFyKprfyNExVs87ZgEFQByzn1M+7SyLlqwFR0Z/tIGCf/HevyYYnXzeuPOQEHy6c8XYcAdAnHIChqFSppsXQ1WObBTL+m0JlNkiR8Z8lSFD0xmn+ogFq2tw4rvO/yAh6JhnE5l6QB/D7OHIo3Hx31ssR0PV5v24umj9kRGkLIet6RMBDGk5PxA39/LVW9p35IywCwiYp0CnDFbCiBE8WKzChDlrCCf4vBgUWeurZtc/S7dkcQ2mNMS23Aq5ml8+vg3WStJE8em/G3eZy4+lIuPdcSUZsucr5AHwb9t3nB4/ecnoqyuVzs/i3FQJHxZQACR8jJNNWjrLoiVrwZHRH82AoPts2aBCcAI2/P3g3/8QkrXxfJRl6CFDhk2T4SerjOR6pgWn7jmypKfWDSsJW8MROTLGWIYMjcEKp9KW4glwWvhrGv3cNTL0MDQ64jeWTunPNgmv37yneu2H0rp5w1ig8Nmdc4TGR0aQsgy2pm6Dp9EvSROwWJo9h89Qz6HTWUzN+CEdzGJLrHUMwdmDxs5nG6hOLWuQ36zVLGHfqH5tKE3KpFx7yBgfbZ6s2LCHJVeNF8c4seTc5VtZZnN7S1j55QPc7j92jl69fkvJkyakssXyUOKEcW3qBsCXtbJkSn+q0XIgWcv5ImNsXEmGrP2ANh64PewycDIVypOVuXLeffiEjp68RDNGdTMiDbBpwFXlULWAAiChau7QacxZFi1ZC46M/miWP3H2Cnn1n0TZ/0hPKZIlpGcv3tCBY2epXZOq3I+sDD1kyDCcRTJO/F1JhqU37PyVmzRozDybE7uZyhKVI2OMkROiWIE/HVowZOghQ4ZhJ6bOX0eIR/H+f5A2bgAmDetE/X3ncIN6NTmyg5Q1ubayNUH3pVP7M4YouF2VL5GPZYqftnADrZk9xKaxA6PWzgMnmTvW1JFdjCiT9QTJGB8ZMvR0tNUvX8Z6tHD1dpoyby2VKJiDEsSPzTLNHzt1ic01U+IBmwbKpDLorK3lfJFhV1eSIWs/oA1BzVaD2KESWA+1sm3vcVqw0p9WzBjkyLCqZ0PJAgqAhJKhQ7MZZ1m0ZC04MvpjyD8O7n//PX8zhhNwvRfOm1Uo6ZsMPWTIMJxLlk7qh45fSOVL5qOGNX5Q0erNP1eSYQ2ANO080qFEd5ALACIiR+YYP3zygpImimdx+AyDgy1VkKGHDCBkqBvYp0DzivcOBbcgoL0d2bc1lS7yYyOhN19lBClbkm8rWxNyRBzfOoPl78hfsT0d3jiF3YCgj6JJFXEDMnjsArp09TZ1blGDZi7eSLmz/07e7esa5bKxZg8ZYyxDhl6+GFv98mWsR0WqdSIf7xZUNH+2YNNt2nGEcJuzfv6wUPkcA9C2aSR+62pJKVeSgf7J6I9mp5xlWrN3zjDnEw43ilbvJOS+GCqTQDWiawEFQFxwgsh4yWXIkLXgyNBFxkfWWWTwpiyupqcuWE/Lpw3gVbX6e3iVYepa8+VrAOEEtnKZgtTHq4GwPRyRI2OeaIriNNhanEa5Bt66bC8y9Rg5eSlzdSic1zxg+tjpSxQ/biwh2ljTIGV3d3fmPmG4ieANkiNBynobZVvZmuq19yFk93789CVt2XWU3bChfx36TKAdnHgyrY/YKOf+MyMN7t6UJYxFTImP3yI6f+UGbebQvDrTAY/MuWZp/G1dj+DqN2dsTyOShRev3rKs7qLgEHrIuI0BYP7yJYC6t61NoPAdMWkJRYsSmXp7NRBmgdNj9SpVJBet3XqAWjWoyHt1CDcEoG4GPXmyJPGpdqXiVKJQDt3ncHuE9zNh/DgEFknEbsFt+dXrd+z2D9TeJQvryzBtQC8GS6uLd0uvlG/YizGrGeYPOn3+Pxo4Zr7Qu8M1lqoQ4hZQACTETRx2DWCBQFZbR6gudx88zdhzLAV2QX7kyJGCE3fxeopbiONnLtPte48JuQmwAObOlpElDgrpIuMDqXcaLaq/DBm8thA4Wb15fzq7ay6vqtXfw6sM0w81GJaWrdtNPr1aGDGf8QzjiByZYwy62NH921pUt/eIWdS3UwOq7FnQ4u8y5rwmOHOxpiw2YJpvNzM7wt1l/5GzNM+vl1WzYtPVt1NDntl1f5eRRVmmTZBAENTGuNHx7deGnbaDzQunsC3rVxDqi7U8HiAJwMaOV2TMNRk2kSFDr6+2rkfTF21g9LlezasHiwX989jpK21K8OhILJjWsGfdHiznTKbfUlPbXuMY0NQC2GeM6s4bYva7HqtXH6/61HfkHFoypZ+uLMy1Ocu2UIdmVWnMtBWM/AE3bi3rV9TNb4XEjD3b1WFABfE8sAlu1+PFiUV37j8m5L5pUa8CA+OixVIM1vGzV5gnAhJgokwe3llXHN4R3D7Wr1YyuN6CVdsYwYzIuyOqq6oXchZQACTkbBvmkvGSp0yeODjLLqgnh4xfaKTXiukDdfXExgOnHMunDzQLTsSp6NPnr2n84PbcvgJ0tOoxhp3wIbgS/Or4UH/+8oU6Nq/OMtbyyvCJi6lf50YWq02c8xd1blnDqgiZH8jqLQYQTp3aN6li1h42INiolSn2I3GVJaUcca3h2QmL8oPHzyhdqmS8qlZ/dyUZB46do1lLNnM/0Dxj2SpHRqbsLCWaUZqU+uO4ccFwi6rLnPNYB7AhgHvffL9eRgHSeLfrd/DRzQwtQxdnkcGbJzgxTpEskW41GX0xbMCRuSZDFxky9Axm63oE9xyc1keJ/CPRJhKSBn0LoogRPVhTIixjlnQSjQXTnoUuf2+dzv43T7m2tHXpKIoVIzoVq9GZufCFVkHs1DDv5pQ1UzoC5fKulePozv0nDBRtXTLKqhp/lmpBu1aNZ2xvOBBBfBP2FVoBEO86eCqT50hZunYnO5x09KDCER3Us6FrAQVAQtfeodoarvfBCIGTFxQsNnXaDGYv+MfPX2jIuAVWGTw0RbHx6NC0Ku0/eo7mT+hlxJuPk5D2ffxoz2o/br+QCfe3dCmoe5vaLAEaXCGmL9xAPdvVZTLaNKpMVcpYPsnVhOu5o+DKfcOCERQrRrRQ2Ywhh0DzuuWpZsWiRu0htmTeCn9aPWuwrk0cca3R22wYNopTN2vFlWTwJh9O6cB+dnrHbF5V3d9tlSMrUzaPKtea0jI3hVgHTvjPYMnZcHoK9xaNQevR0xdUuUlf3c2UDF2cRYZm72/fguj42cv08PFzCgz8kbhv2MTF1P//ByWm64P2rIy+GI67I3NNhi6OypCxHhnaA+8qrxhuonl1DX8XjQXTnsENAnKO4D0B2QI28/h37daD6cC6SbY0HVwX7oIgVEGOn+G9WwrJAHvckU1TmTuVBkAQRF+kaif2d2ulWI0u7NYIoBp9mTK8k5Fr27v3HxmYshfQae0CuNdv78NlozTcD/A6bu/ayZOrfpdjAQVA5NjRKaXg5GX78jHBPPUAIM27+rIF8M27Dyxw0hqFoNYhbeMBKtPLV+8wQKPxxD9/+Yb51Ips7BCweWDd5GB3LZxOFa7qxTYt8CfFDQaPOSZryeaUIV1Ki7b+9/od+i1tCqsyHP1AGjYKm+DUuVXPsdS7YwMjFg74g1ds3JubiMwR1xrDzcbGHUco02+p6NfUP+hU1287xEDnsF4trM5LV5Jh2MnZSzcb9Rl5FfYdPcvm7Hy/3sLvqSw5pg3aminbd8oy6t2xvrDehhVlz3kAECTug+vDqKnLqU3DSpQpQ2pauWEvffj4kfTcSWTo4iwyNBv39JlOyB6e8deUhFgWrRw6/g+Ll0GxluxORl94k0J0rsnQxVEZMtYj2EOGq5+hXR2JBdPkYBx8/BbTly9fqWPzaixWAy5iSAY6fnAH3jCy3/HtPnnuCsFN6eTZK/T67XvKkjEtu83o0qqmkAyAjpmju7Obcfx71czBNH+FP127dd/qPIVgeDrgsBGuWkiQCeIEQ4KTC1du0prN+7nfb0MlP3z8ZKQzbrhWb9pHazbvY/sTkWLJPW78zFUsgWe+nJmYCLybqjivBRQAcd6xcVizOm2GsCRX2mKBK87t+07Qokl9bQYgUaNEpgGj59HFf28yf/rff01FC1dvo627/xZaeBAwhsVWWxDgDtayxxjmtgEggwXxDOeEGknM9DbVMFiZYrkt2s3RD6ShUA2U3Xv4jHCz07N93eDbm/9u3KMW3UZxT3Ecca0x1AVUoH/NGRoMMvEbAB388nFKLVJcSUavYcYZqCNE8KDUKZKwYEuNeUnEJrLkmLZla6ZsEV2t1ZHJYKXNeS1zOE5fcSiB+Y53ekSflrpuRzLeP2eRodkbJ8pblowyYykTSdwnoy+8uSE612TME5n9cWQ9kqkH7OtILJjh+Nx/9IxwU5AhXQresFn8He8f2OIa1vCkssXzMMIHD4Ns9SJCcWiQJFE85u6MvDs4nCmYJwsN6NKYEiWIY1WEFni+9/AZevzsJQUEBFisu3fNBBE1WB30x7QkSRiPBnZrYsRcJizw/xXPXLhKvpOX0cqZiobXVtuFRX0FQMLC6qHUJjYJ7XqPp9/Tp2LB4qf++Y/FaxQvkN1mAIKNBwLHwUg1a8km5l+LYLHJwzoHnzbodQsUiGNnrGQBs1g4cUpfvXxh6tSiBuNo79hvIm2Yb9mXXZOr57bEM6nMD5PhZgxAqm2v8ezGIfNvqWnH/hMsCdKg7uYLrKGOjvTFUA5usVbNGmy0+cNpWc1WA4X9i11Bhh67EW9uGP4uS44mE4Gvd+8/oexZ0jMyiGcvXtOeQ6eFM2Ub6jZuxirm9sRzVbSlv6J1cdDgWSyXcH4KU7ky3j9nkaH1rUStrrRs2gDCxsmwYHP395bvPv/Wioy+mMp2dK6BLQ7zU2NFgovZV5PNJmiGLRWZ/XFkPZKph7WxE4kFM2V7sybLUoJQS3XhUrbn0Bnafeg0ffz0mYrky8q+439kTEMg2rC1IP7SNOO9rTIcqQ8PDMMSMUIEYTIbvXZB+Yzkpif8jQ+iHNFVPRtyFlAAJORs6xSS4Z+85/Bpev32AxXNly2Ysg7XwTgl51H3IU4E9KWRDD48YH3RAi3B6CFajp68SJt2HmHXx0i4Va/qD/YKERnI3wEqQHuKDCpfrV3T02DQO8KFAB8dnAYjOZK1D7UmwxHXGsP+g1QAJ5092tWhFEkT0bOXr2nagvUsyH/xZH1WFE2OK8iQtfGQJQe2xQ3BsnW7KE2KpHT99n2aM86bbRZAVODb13qGZWvzG8Gg+XP9wU5RRd0uIAvZmnFLZnHj2H00zR3nbc8rZdMzMuzqLDJkuPnI6IvhAMiYa428hrNM6I1qejLRZy9eowYdjHNmWHPZlXGLImM9km1XS5NcJBYMIFQrOKxzd3NjsY9agQtSlMiRWVyVrQXfm/XbDrIYSngm2BJHgtgRxCk+egIa3gRUsVR+m7PD26qvaH2A3807j1LTOmWFHkEsmmFBXCtu/zOlT0UTfbyEZKhKYWsBBUDC1v6h0joCJHH9a4sLSqgoZmcjuImx59QHzemdTImeRmGhRN4De3Wws9sWH8PHbRLiZ7bsZ2OMrLwFcv9B/bs0EqZfdgUZsjYesuRgsOAyCGraLBnTMO78i//eYtSXVZv3s5rbQ29u/Fm6JZ3cNpMGjp5HcC0b1K2pkBsGbtusMdSUre9NCyb2obQpk+pOS9yAlC+Z12KdPYfPUImC2XWf7zZ4qrC/uzVBMsZGxkZZhh4yZBjaScZcQwJFsCLCZREFh1d12g5hN6zv338ksCjxYgZl5LxwZD2SbVcZsWAAdt4d6hvRV8NOOPVv27iy8OcAbly7D55ityBgi0IC3ZKFclCxAn8KyTh9/ip17DeBJfyEKzaehVvVNN+u9GfmX4VkgNiGV6wBItD2x4kdw+hxuIGBlDHjIwAAIABJREFU2AKA6siJC5QzawaaO17sQASxKYYFAA/rGECV4YEpT1/1e9hZQAGQsLN9iLcMqlcfv4WEJE4AIbhyBT92l1a1hK87ZdHFLl6zgy2a2BibFuiHglsRvYKNP3IfnDhzhQW/+g3pQJf+u81uH35L+wvrl8Yhbk2O4cmUVgcbd+Qi4blNyBwwmflVNL1wMxU9WlRyd7f9Sj68y5C18ZAlB/YEM9vSKf3ZSSMyfsM1YN28Ycz/+uzOOTZPJwAQPAcADndG3EKOHdCO+7G15G9t2DhYcXjJ2fRcBhG/5b90NEWM8J3eVK84cgAg8xbTkXVNxhyR2RdZcw0AZN1cH0qaOD4bQoyVV79JtG3ZaGGXXRk5Lwznj61rmoyxMWxfRiwYYoX2/jWB5afQCvKatPEeRzsFE1aC+h3ve40KRdktFQCDres8gBDiQUERr7FgIah80ty1DHiKFLio8gpyeVgqsAMSFiIeDy7dAB1bdh+juLFjMrfSSp4FzeKpLMmR7SbL64/6PeQsoABIyNk2zCU36TySBScjP0aCeHHYAuY7ZSmlSp6EBvfQj1HQlHeELtbQAFWa9WN5Myzlxzh84gJzG1o6tb+uzXoMnU6BgYHUvF4FunrjLsvoCiYMXNlev/WA3fAM6dHMZrsjuVK2TOmE/fIdyUeiKScrvwrkybhWD+8yZG08ZMnBuEydv47luvHuUI8NO4JrJw3rxKg4NwlkucYzYJzSyqCx843mNwJkEdu1cGIf3TlfoFIH2rLEV7cONgF6BZsHay6TKzbsocqeBbhxT5Av4wDAERAjY12TOUfgCotEmfuPnaWXr+zPLC1jrnXoO4Hlp8C3ATepQ/0WMsajST6dhAGIrJwX9q5HMsfG5g+JlQdAAd6yQQV2Mq8VuAr1HTmbS1ai1QdgPXHuCl25eodAAY/YD7Bg4b/ajRVPX9yS7V87gW3+NQCCwwysD0c3T+M9bvS7PV4VDx49Y+vZ+u2HCf8GZf5Q7+bsRsaW4oxjbIv+qu4PCygA4sKzAQsO8lEYLlC4hajXbqgu77ehSRyhizWUgw8TNkGGAZsASAsm9GYsWBUb96FjnEUQG7hty8YE396AlStu7BjUrU1tFhRfroG3UE4S0yFH8GWv4TPZKa5IcSQfiSZfVn4VGdfqriBD1kdJlhyMM06UcYKruT7iFgRMNiP7thb+6OId0Qo4/3Nly2A2RXkABGx4jrLCZPdsRTXKF9F9PSzdboq8T7YeAMgAMY6sazLnSP9Rc+mfyzeocU1PFt+GQ6J5K7ZS09plqbFAclbNvjLmGjaFIAMBLauHhwdbW2eN7sGID0Rp22XkvHBkPZLh6mc6Z+0FQ5ockMF49Z9E2f9ITymSJaRnL97QgWNnqV2TqtSiXnmRVyS4DvJ2XP7vNgMjWA/OnL8qDB4KVfFi+wHccGkAZO+RMzRl3jqrMWKmysnwqgDoOXbqEq31P8BcwOB2VbVsIUZ+wIudhD4y3z+bjK8qS7eAAiDSTeo8Apt19WXJ8uArqhXkqajdZjDtXztRSFFZdLFgjJk41Iuy/J6Wtfvk2SvmogLqvm9B36hS4z5c5gokRNq7xo/FXmAhLlW7O/MXBa85TmTQhmi/DDsP5owW3UcLP+tIPhJDAIIAREfzq8i4VncFGbI+SrLkYJxNT+qRKwJMWHB5sqdoLlj2POvoM7JY2yzpYesBgCUZtoIYR9Y1mXMEYAqHMGAq1Mrp8/9Rz6EzaPdqsXwIMuca1tHrtx/Qm7fvGbOf5tKKv8P1BTfFekVGzgsZ6xF0xO0SkgYi6V/SRPGZ7rZS1zoChgztBAIVBH8/ePycHUjgm2zNVcmWdxVMZaKuWJ0HTGbxInDDxvucIG5sBizhygxwJFJkeFUYtoP2t+w6Smu3HmTgu1yJvDSoWxNdVWS+fyJ9VnVCzgIKgIScbcNcMq54ESNhSNuJ0y24LWnXwc3qltPVU9bGAwmCEKzq1bw6i7dAThKc+D1/8YYiR47IbkHwIdYrOEVCQG/VsoXZ8zg9gX99/Wol6cjJiwR2kmkju3Lt7uiJliP5SEwBiKP5VWRcq7uCDFkfJVly9CYhKKhx4mdr+fDxMzfGiSfTXipfBK1ay7HDa5P3u60HADJAjCPrmsw5gsDu4b1aBB/MoG9gOSpTr6ddDEmmtrFlrmEzCMAB9ytHiqM5L2SsR7fuPqL2ffzYDWSSRPFZQH3C+LHZ90GLcRHpoywwZKktkFJkzpBaRA0p5CmYV58+fWbfTLiAISYlw68phW4dNCVleFVY6zByCv21ZT9j3dQrMt8/IeOrSiFmAQVAQsy0YS/YNIDOkkaj+rfRVVQWXSxOoybPW0f+e47Rp89fqVyJPNTHqyHLKXL24lXGEsJj4gFwQM4N0M4CvMD15PjZyzRryWZ2sjyid0u2uOoVGSdajmxeTAGIo/lVZFyru4IMQ3YjMKvgY4vkWrYylcmSg3HGLd/KjXvowaPn9O3bt+Bp6b/3bypX/DujFO/9k72K2EvlK0sPgCgcHuC0M1+OzIxZ62tAIEuKxiOQ0NPBVhDjyLom081n4py/6MbtB9SqYcXg7p2/fIO27j5GvTrWZ38TOSmXMdfgFoos0tNHdTUDISA9gHsMDpBMi+ycFzLWo7a9xlGGdClZninceuAGx2/2arp15xFNGdFZeDrLAEOGjWlUs+u2HWTrgigNrzW3QxDLHN8qRuUrI3ZKhleFZg9kP79w5Qa9evM99gnjJXKbowCI8PR1+ooKgDj9ECkFDS0A/1GcZiG43h6qPRknWo7kI9H6Iiu/ioxrdVeSsfPASeo7cg6BZx+AFrk33r3/QMdOX6YG1UsJv0wy5NRtO4Rix4pBuf/MSB7u7sFtT5yzhjq3rMn+n3cDKaywYEV7qXwFxXOrIdD52fPXlDt7Rtq4/TB5t6/HTqRB7LB2rg/3eVSAi9CoKcv+D2IyUW+vBsxlCCfvonSiQg2FQiW4ofKKSIZpGXMNAAQuOvHixCIf7+ZGav195jJhzdq6ZJSZurJzXshYj6ATqKcN81ThhgcsXbxYQ8MO2guGarUeTLUqFaOKpfIxul1Dqtlcf2akqmUKUakiOe12x4SOY6avYHTwcLMWKTJAjCNeFbh9RQxb0fzZWAxI96HTWB6TeHFisncXbnKTfLy4h4gKgIiMdvioowBI+BinMNXy02ecVNxkjCi2nFSYKi1LjiYXp9xIloVgSWQhFwEksk+0wmpgNCpCR67VXUmGNg4gKkCSvrLF87JNLdz94KIH32WRjZxMObhtOLh+stEmCPJzlW1NJ7fNCpOpYy+Vryxlwaa1ceEIto7gtmn15n00oncrFhQrehoMStKsv6ejEoWy07SFG1g+A/jUdx00RZhIwrA/9rqlOZobRZZNIUfGXAMAObRhMnXqP4n+yJiWev2fvQ3y4SJbuk53Or1jtq7ajuS8kLEeGb6/y6cNMNrMgvq2eddRtO+vCcKmtxcMIRYGLI2Xr95mt0k4OGterzxV9iwoLfEf+tO651irOX5EOmkriHHEqwIZ7pFzCIlUyzfsRU1qlaE6VUowNRHT6TdrNWOznDGqm67qCoCIjGz4qKMASPgYpzDTEidf3QdPo0iRIrBbB1wbJ0kUj2UahduTaJEhB5nbK5TMx/Q49c9/hNNUZJjF4pU4QVyaPqob29joFXtPtAxlyqLOxEnuph1H6Pa9RxQURJQscXwqki8b5cuZiWtWGYuwK8nQDIZTvi2LfdkcwU0ZWH1A75wPuTd2zeXaVaYcb58Z1KNdXeYKZljgmy4SqySsLKeiDCpfWbog5mHMgLZsEwIXjMpN+9LGBSOocNWOwqAMIGbHirFsjLHBGzFpKc0c3Y0KVvGiM5wNsqV+2OuWJis3ioyDGRlzDQAEIBDuSk27+LLAeDCbgTQBuZqGjl/I7K5XHMl5IWM90nRDkjocPhi6jCFzNr4VvBgDyJAFhuBqiABr3PbBxbBK2UIMhJiuCfa8X/h2oJ9HNk2153H2jAwQI9o4mDD3rPZjQfhYpzcvGslcqbUClsCStbty1wHTZKKYry9evWE3d7aSDIjqruqFjAUUAAkZu7qM1AqNelONCkWCr3mxgOPEEP6kc8b2FO6nDDlgrjm4bjLLplqteX+2kMOFBUwgM5dspHMXr9GMUd11dbL3RMtQqAzqzIN/nyev/hOpcJ4s9Fu6FGwj9fT5axY0+Wvq5DRucHvd4EAZH2tXkqGNDxJV5sjyG9WuVIydOoIZDckAG3QcZtMNiCw5wi9ICFaUQeUrSz1kgEaMQ8/2dZlIbHTbNqpMO/afpMWT+wo1Az/0lvUrUsHcf7ANZdl6PWnN7KHsVNWezZi9bmkycqPIOJgRMppAJQ2AIC4N7kq4UQJhCVgGETDdtXUtlshOrziS80LGeiTQTaEqsnXBNwr5rtb5H6D9R88xVyQQUYD1SaSYuk8hZurL1wDy7duaKpb+kV9ERJZhHRkgRrRNuAk2qlWGHSJibiEnWNnieYIfR4qAlj3GCCdnRALhEZOWsHgpxJEhEWr1CkXJu31dh1zbRPuj6jluAQVAHLehS0vAtSlyCKRMnji4nwh4LN/Qm3tSYWgYGXLgXjPPrxf7IGLTgMzlGm84ThELV+3EdeNwxGVJ648M6kycBCMxo7YA46Ss59DptGhSX+o0YBJlzpDGYsCnpoOMD6QrydDsgs02mN+wOUXZf+wc/ZIkAbNzh2bVhN9VGXKKVOtktb3ZY3tSnbZD7MqILtwJCxXDksoX6uDWwLAgNiZ1iqQ0sFtjSp/mF6GuIf/PyXNXqGENT1YfMTXF8v9Jgd++0bhB7YVkGFay1y1NRm4UGQcz6IuMuQZdAOSQqwYFAP7oqYsEdqKMv6akfDn4N7OO5LyQsR5p4wqXsYWrtrF4IWzWDcusMT24c0SmLqaN4aR/084jLCnfX3OGcnVBBdxUGBY3InYQiHVNFICEFIgR6gARgQCm84BJlBxeCkFBjJIY3zmtPHn2krn6ibrIDRm/kO49eEreHeoyb4y7D57S6KnLWd4akVsuUb1VvZCzgAIgIWdbl5DcZ8Rsyv1nBqpukIQMiyH8hHGFKlpkyPHxW0RBRDSwa2PCxxK0vdoVLhY35ALwX2oeJGmqo6P88DKoMxEHcGTj1OC4FeiEZGLwscb1P9zeti8fY9W8Mj6QriRDM9TStbuMN7ge2OAmEdo8GT4oQw7G0VpBgPy5i9cpf67Moq+QlHoyqHylKOKAkC4Dpxg9jfwqaVImYbe0YAUSKTLc0mSw4ck4mEF/nWmu2ZvzQsZ6pI09btYCAwPZKbtp3p2aFYtyp4hMXbiN2VkBY45DK9EEujJAjJ2qBj+G9QeeCo+fvaSAgECL4kTGBw/iQHLVzMFGMTVIlIhEy6IgxtH+qOcds4ACII7Zz+WfbtBhGKO9zZb51+C+4qTi9Zt3lD5tCva36b783Bsy5ODkqGmXkZQgXhz6GhBAaVImZaw3oLFcvWkfdW9bh7mL6RUZ/PAyqDPrt/dhmY61GxAEtOIkF6Dj1et3bHE9t9t6zIKMD6QryXDmFxHuF5qPsgjNpDP3JaR0w62GKfNSSLUFuTLc0mTkRpFxMGNoJ5lzDbTnuNFAxu3hvVvaPRwa9WzTOmV1ZchYj7QGcpdrw25zUv3y4+belg7I1MWWdm2piwSeSKB7wn+mLY8Z1bUVxNjdUAg8iBudnSvHUawY0YKlA/xWbtJXODt8CKilRNpgAQVAbDDWz1h1zeb93G6LnFjIkoObAiTXQiIlUPeh4Eq3WtlCVKJQDq6uMvjhZVBnYuEHg0nKZInIw8ODxYCM7NuKndghc++cpVtYAKi1IuMD6UoyNDvBbQTzA77NLANy4vhUq2IxI19j7iT5v/uJo3Lgo4x8E5t3Hgn2Ua5YugD17lifBcj+jOX4mSuEOJCHj58xlymtwK1TC8wVYSv7/OUrYbNhmF+ljfc4mjn6ewyYocsoz85h6ZYm42AG/ZMx1+7cf8Jc244DdJy9Qq/fvqcsGdNS1kzpGLOctYIDE8TlGRa4PRlSz+bMmoHmjvfWHQoZ65HWAG5AWtQrz9jR7CkydbGnfdNn8K0wLIj/QFwO3K94mcP12pcBYmT0zx4ZIKHJnzOzUVzS7KWb2c2yLble7GlbPSPHAgqAyLGjkhJOLCCLH15Gd+HveuDYOfahh381/KxFi4wPpCvJ0Oy2YNU2WvLXTmpWpxzzC8Yp7vwV/tSmUSWqXbm4qHlJhhxw5oNUoEvrWozjHoBowuzVFDN6NIdOlIU74YQVQbcLd85Cuf8gd48fuVEae42gRf8PQucl3lu0ejuNn7mK3NzdycMd3vDfC1i1tPgFW2iOHXFLAxnHjn0n6Na9R/Tx4xeKGjUSpUmRlDyL5ma+6Lwi62BGxlxDEDrsh9ga3MwiJkeEVQjB+CUL56DalYoTAtjXbztIW3Yfo7ixY1KVMgWpkmdBSpooHs8UJGM90hrB/EDQd4t6FczaRfJLXpGpC68tkd9N50mECB7MtdSWvDchBWJE9A+JOkgL8PbdR0qZPFGweIDomDGisrmnivNbQAEQ5x8jpeH/LSCD/hauTTL44WUMiiP0m6ZUhPbo40oytP6Xre9N4we3p0y/pQ42CW6bQFNqKYmaNbvJkIMYAf8loxntpFYANss18GbxPz9jwW3D4Q1TzGI1bMmNglipCUM7msX12CJDhu0RRzJswmIqkCszpU2VjLAp/PjxMwMjf5++TIO6N2FMfZYKckTw3EVt0VHGXLtz/zHtOXSGdh86TR8/faYi+bJS8QLZ6Y+MacjN7QfQM9XrwaNnLKB6/fbDhH/DJWaod3MqXSSXLV1geWGQCFFGadhxuFUxS6b04zbhbACEq7BABRkgRqCZUKuC2+6NO44wimPElICKv3KZglTZs4DufA01BVVDXAsoAMI1kargLBaQQX/rKD+8LFvIot/EFTp8rDX3M/iAIz7GsGhMYdZ0h00K5clKhfNmMaty7PQllm1XhKHIkbwmsuwKrvnDG6cYBZ7iFgJuc7acisuQAwrghRP7UIpkP07owHbWtLMv7V49XlaXw5WcFRv2sNsBZD82LHOXb2UuMyIlT/m2zPc7dswfwA7PhTYAKVmrGw3p2YwK5TF/b+AiCpYeZOO2VGRvcGXPNbAF4iZj+sINLFv1gXWTuEODDSEyXK/1P0B7D58huF2BahZrE28N4goP5Qo8MIT32PC9DmX1VHNEBHertVsPUJPaZb/fMD95TsgVVq1cYWrVoKKyUTiwgAIg4WCQlIrfLSCD/lazJTbqr968Y1nU9U73Qsr2sug3kXkYG7pGNb9TkiIzPPzKDcvFfQt0uwHXC2wIp/l2oywZf9Ai4iEs6PuPnGX0x3rF0bwmkF2j5UCrtJQItpw7Tt+HHDLqtfdhH58SBbMHq+u/529avGYHLZs2QHg4ZciZvmgDbd97gm2skbzz8dOXNGfZFipTPDe1a1xFWBdXqrhywx6r3SlVJBfbUPA2D4iXQnAx3H0MC+a+LS4pjtoVCQz3r5tkBoQgF4QZRWt0tkqzLBuAyJpriKvbffAUuwVBXgbEUCDTvK03E8gjsmXXUZaED5t15LsQjVWQsQ7ANc5aETlMMfxOHD97mSU1RcI7rQybuJj6d/4eoycSA+noXFPPm1sABwCIK4IrmlZAMtOy+2jaternPOAJb/NEAZDwNmI/sb4y6G/h9jR62grmMgCXLlA01qpUjLq1rhVMiRsaJpZFvwl3lBXTBwYvwvhQIr/EqlmD6f37jwSbiQCQycM7s0zH8/16MXYxrWATUr+DD3Ob0SuO5jWBbLiRWDsxhkvUgol9CPS1egU3Qji9Ndww7Tl0mtE1Z/k9rfDQypADkLtm8z7mJhDsIuBZgGpWLEY/KxtWu95+Vsegj1d96jtyDvFcZGSAGOGJoFMRbj6YU8jnE9OAiQc3blPmr6NL/92ixZMtu/vIBiAy5lr1FgMYWKhRoSg71ACYkzFPkUfkry37hXMzyFgHTHNeYBgRqA/yB+SPEi09faYTiBMQnwe6Z60cOv4PuzVGEWGBFG1P1RO3QIFKHRhrpOm7V6ZeT7sSkoq3rGrKsoACILIsqeSEuAVk0N8iedP12/dpSI9m7LR80cQ+NGLSUhbI5t2hXoj3QWtAFv0mAMi6uT6M7QkFJ39e/SbRtmWjWTZjAB0RAHLCfwZjrRkzbQXLcK8F0CJwGrSGx7fO0LWNo3lNIBw3MXoFYPHU9lncMQJt9LZ9x+nxk5fMLpVK56dkSRJwnzOtYK8c2f79Nivu4g/IADEyTIS8Ct0HT6Vrt+5T/LixWQA3DjjgEpkhXUqWFNEaDawsACJzrs1cvIlOnLtCV67eYXoj9gMsWPiv4SmzJdshI3XfTg1lmFXaOmCqDPJEZcuUziYyCgTYb1kyyiyIPrTd/aQY1sWE9Bo+k4K+BVG3trVZ/AeY9MbNWElu7m40ql8bF+uta3ZHARDXHFeX7JUM+luw8OCUH/67+DdO3HEyVqVpv1D1y5dFvwkqwlgxotPgHk0pgocHDfVbSGAHmeTTyWYAApcW3AyNmrqc2jSsRJkypKaVG/bSh48facao7/Sm1oqjeU0gFydaW5b46rbDYzc5dPw8dRk4mZ1Osuy4D5/Q0ZOXaMaobpQz62/C74UjcmRtLoWVDWcVAwIDCTdMcElLnDAuo3nF3A2vBW4fuCn89PkzRYkcmSVF5NEAy5ojsuQY2h7jc/m/2wyMIAfImfNXuXkVZOohYx2wNJcw57BpFU3cBxmIrYHrZpKExixeuGGx5SYlvM5tZ9YbB2y4td+293iwmmBvG9itiVFuEGfuw8+umwIgP/sM+Mn6jxOtQxumULSokY0ASPmGvYQCLWWZSxb9JlhnOvabyE5hkU8EMS2zRvdgNxi23oBoPvVIPjZh9hqC6wRcD0b0ackNuHQ0rwnsWqfNEFo5c5BDJq7ZahC1bliJPIv+YODBB2rBSn9aMUNctiNyZG7GHDKGEz6MW6X2fSbQh4+fGPgACEH28mkju3JP2Q27A8YmJO/UXNtArcrb9DuTOWTNERlyeLcocO/iuWLJ0EMbHxnrgKWxvnbzPkvct3/tRGeaCkoXBy0AV2rcOiaIFztU3agdVFs9TkQKgKhp8FNZoEqzfuTTszk7dcWNCpLCLV+/h35L+4s0F4LQNiiCI8FA9ebte0Y/C3CFgr8DGMDtQK9gI+dZLJfDp9CO5DWRZTNL7FXvP3yiotU7OcyCJSpH5mZMll2cRU6zrr4seVjL+hXZphbMSWDAOnLiApfoQOvD/qPnqMfQaVQ4bzZKmjgePXrygg4c+4fGDmxHRfNnC7WuYmO+cuMedgKLWxBQ14IxCjFU5YrnoVqVilvduMuaIzLkOIuMkB440Yzshnp0GWg99g1U0KqEnQVkEQ2EXQ9UywqAqDnwU1kALkZw96jkWYAadxrBNgyg0axbpQRFjBghXNrCkXwisjqMjSQ2ZCKJy/TahDscbl4QbK5lVwaQEpWLm6wxA9pR5gw/8oCcPv8fDRwznzYvGincXUfkyNjQCSsazirmLteGDqybHJwwEOojgWCRap0IcUgiBYQHvTrUo4K5/wiufuTkBeY6uGG+9fwPIrJtqQP6aiQSrVe15I88IJ8+0+27jxkwKVEwB/VsX9eiyIdPXggl5+PpI2OuOYsMra+4ucUhigy3PLOM7NkyCLHpabog6aVpmb/Sn8oWz8vmoCphZwFrRAO4UeXFLIad1qplQwsoAKLmg7JAOLaAjHwiuAGxlh14z+EzRpS21kyFHC1Isjd5WCezKgB9+K1p7bK6ltbcuHClDsaZ6b7daP/Rs4QPfrpUyWnSMC+umw3awoa2frWSwW0hqzlyRoAfXrQ4IkfGhk5Uz/BWD4QGA7o2ptx/ZgxWHS5/Pn6LaOPCEULdAYg5uH6yUa4XgPDCVcVBjFBDnEqmDHSG1RGg3rDDMC4bjx4QQVBtogRxdLWQMdecRYbWUZBRFMj1B00f1dUMhIydsZLlFPFqXl3XLhf/vfU9I/uuY5SIJagrQBVLFeDaU2RebNxxmHYeOGVxrRN5XtUJOQv4TlnG4nWa1tH/1oScBkqyLRZQAMQWa6m64d4CS9fustqHBtVLhbv+ycgnAtpLa5m5EaiPoM2IEfSDhD3r9iCfXi0ob/bfzWx4/vIN6j96Lvd0GjdSyLzcrG45go9/10FTCSxcYBNCUOzRUxdp1pge3DFCEO2FKzfp8dMXlCxxAsqcIQ3Xh92SUHvlyNjQcTsZTivsPnia+vrOZjSvSRPFY+O7Y/9JGt6rJZUsnEOoV006j2QxPg2qlw6uv3TtTiYHiR9Dq4AJaeuS0RY3tehXxUa9uW5/eu9euQbe3IBpGXPNWWQYAhDQaMeLE4t8vJsbDScOXIaMW0Bbl4zSHWaAGMyvkX1bG4FdGXMDcUy12wymE/4zZYhTMiRaAHE+IGYBPa8qzm8BBUCcf4yUhhIt4NXPPADx+Nkr9Hv6VLRgQm+JLYWOKBn5RBCYDzcSSwWZqyt7FqBB3fUpcrN7tqKdK8ayQEAUuGNlKdGM/tk9j5AXAWwyp3fM1jVK4apejAhASwzZe8Qsyp75V6pTpQSLFShWows3gBQnyu17j6dPn7+yzW3CeLEpdqwYNHVEF5tOPx2RI2NDFzqzJ2xauX7rPm3edYyePHvJTqcrlspH6VInF1YGz7ft7Uce7u7/T/D4ggICv9EM3642yRFu0EpF5Ih49OQltaxfgQXQgyb685cvdPPOI5qzbDMDv6P669OBIqv76P5tLbaA+d+3UwOq7FnQqqoy5poMGd0GT6Xxgzs4alL2PMDDoQ2TqVP/SfRHxrRGrk6IMytdpzt3LUEmetxiHj5xgQrkykyVShegwvmycQ9SLHUAblzILYTbKKxNiCVBbqHalYtL6a+xCkntAAAgAElEQVQSIs8CYC/sOXQ6l7VNXotKkiMWUADEEeupZ13CAjg9vXbrgXCmXmfqtIx8IgAPNcoX0e1W/y7fs/5aKxUb96FOLWoEs08hQLBWq0G0evYQcndzo0ZeI7juKKVqd6ONC0cy/29kki5ZuystmdKfMXEBxIBAYM9q64nsoBs2QtgMQheNZnnWkk10/spNm1wmHJEjy7/fmeaZo7rIyBPxNSAweAMJN71T//wXzIIFiuVIkSI6qqZNz4PJa8Lsv2j7vuNsU6oVbFQRI4A5iNwgegUgPU3KZLp1Ni6wHtciY67JACCGHfj85Ss9ff6Kvn37kTm8jfc4mjn6O5U3j60MAATxQIj9atrFlx0OYf0BwMMGE9SrO1aMFRorrCObdx1lYOTB42dUrnhe5gIoWnYeOMmSY2KsEZc2Z5w3vXv/gY6dvkzh8cZctN/hoV6t1oON1Pz06TPduveI2jetSu0aVwkPXfjpdVQA5KefAsoAyP5br50PO3ULb0VGPhE9NxBRe6zfdoiGTVhEVcsWZtmGt+4+Rm0aVaZ5K7YyAIKTzJF9W+mKQ1Dv/YfPqGyJPLRh22GKGjUS3br7mIrky0rnLl5jyd14QAi3KIglQL4QDYDAlapY9S42ja8MOYpB58dwy9jkypAhOp9trffh42eWhBCbZI2FTkSGjHdPawd0usg4fvv+Y3ZjiBsYvDtN65TTzYsg064I2h4/cxW5ubuTh7tbsAkQl6WBsZPb9JOJagAEtOAISO86aApduXaH0qVKRojt6Nq6FjWs8cP9TsTOqPPv9bu0dusB4YzseKZo9c7UpVVNBiiHT1zM1jbEl8ENcO+aCaJNq3ohYAG4cxqWiBE9KHWKpCypsCrhwwIKgISPcVJaSrIATrIMCz6MqzftozWb99GuVeMltRJ6YmTkE9m+7wSVKZbbYaXh9oCAdrih4IMNP334bCMeAyxjYCfRKxiL0VOX0aETFyhT+lQ0ok8rAjhcvGYHSyoIVxfeKXfucm2ZKxgYtDQAgiRxLXuMYX8XLTLkWGLQWblxL+XJ/nu4vG0TtZ2lejI2uTJkONKHkHgWQbOgAne0AOgvWLmNvSO/pUtBCOy/+O9Nih0zBp06/x8tndKf5V2xVGTcomhyEZgPetp8OTIZNWVL5nDEta2ZPTQYsABMIf5Ly0tkKtua7eyN4TKUB6alLYt9mWvpw8fPWc6lpVP7U74K7ejsrrmODpt6Xlngp7aAAiA/9fD/fJ3H6ZppAWsGsqeGZg6Bn8/yodNjuHq1bliRCufNyqhdSxfJRbsOnqKOzatRrYrFhJWQJce0QeSwWPLXTpo9lh9ML6xsOKgoAzzIkBEOTGWXioixQjJHuCuivHz9luq392FB7GOmr6CXr94yQK9XcBvDK9bIKrTnENOyc+U4xjpnWGwBIDwdRH53JIbLUD7icHJk+Y1qVyrGbpVgZ4C5Bh2HqRsQkYEIwTr/a++846I6ujD8ClijsWE3thSNJRpjN7bP3og99oaooCjYUARFEQU7omLB2CuW2LuxxSjGXmPX2HvH7vc7Y3bdpey9y84uu+yZ/2Tnzpx55u56z51z3kNhmItWbceu/Ufx6PFz5M6RRSgdqhWzMKNpPLRKAuyAqATF3ZIGATrS123JnZwU47STxsoNr4JCG3btP4bHT54hV44sqFO1TLxvTOMbScYYumNTAinFfFN1d1JNotwOpXbs9EVREI7eklI1dwqZoDovmgczpes1n8saJ+Z8pO7VxNVfUR1JrZ220k+G8yBjDGvjRWEk33+bBzmzO8cy7fGT50iZMoWq3yd6U08hQZrwLyqa+XMjTxzZMlMUSWznGSSkiw01CnOK2SiciiRxy/306URD6Xt05vxV5M2dDRQ+pduOnrqAEkW+UY2f8n2ijpwBnV6KcLLsmVG6eCHxfVbTTMnh0h2fQq1On7uqrTlDv5G5szujTrUy6NGpsRpTuI+ZCJD0+/Ezl9C+WS1kyZxBnJbTSSDJvbdvXttMs/KwMgmwAyKTJo9lswT8R/8WS/LRZhdjpOFzIzdj8m8rReE058zpxQ/5/kOnMWlEr1ihFPENLWMMT79J8PVsgxzZMmPp6h0gzX96+Hn77h3+PvaPUfYYicAs3WOGYL15+06o56RMmRyzJ9ie4popkGQ4DzLGMGUN5riWTmTpze3i8CHIlCGd3hSUE3XvwROMD/BQnJoeuLNlySTqY1DRzkkRK3D45HksnuovFJyqNu0tFOmMbUdOnkdw2CIsnT5U1aX0vVVqpGpnqJHT4dZvDCivhqrKk1oaOVQU2tmzcxN0UPFwKSOHi2yMKdtObOlFiNowMCUW/HnCCZDTTcqVJFKgaVR0tv/wadgeaXvh1AknYbtXsgNiu3vHlieAQNSRswj7bSVu3bmP9zoqLbpFv+wtuZBClQIHuOqFoK3dsg+zFm/A77NHqKIsY4zi1V2FzC7lb1CoA9WGKF+qiJh/z4ETmDgzEisihhu0h+xQaiT1q9RkjNN32FS9aUjCk2LZF03xF2+J7anJcB5kjGFtzMkB6dGxESg0b/ZEH72TAzqR8Bg0QVH5jdZEKlyUrH34xHkhFZvNOSPCQ/rguwK5RTjWgcNnxFt7YxvVVWjlMVx1zQv3gYZV6mj+8GBvg2Z09g4ReSx9u7VA8uROoAKl4XNXo797S8GDxC1+qR2/NDENLiOHy1hW3N+yBFw6DkaQjyuKfV9AOzE527Vb9RcqatysnwA7INa/R2yhRAKUmNykXmX8XLooHBwdtCO39xyJeWG+4t9FC+aXOKP1D1WtmRcixvbXq6FAP+Skt39os2HFGs3qZIxByadBA7uIUA2qTXJgfbh4AKFG0p4VXXoohi7Rw4pSU7O/ssaJacuytTtFaMnYIe5KZiapz2XUiUiqDgg9LFG44Jnz1zAtpI9WrEFtzQvdG+XG7ft48vQ5vsmXS1GwIeYNNmbqEr0/Rb9+AxKWIEGI0EBPi92PVOl+96owbegZfffpRCNqwzRhT2jECiyfOcygPbJyuFjJzmLbbvREdB9cunoTbm0baK+lorekwOjzn7CDmt96oyfmC6QRYAdEGkoeyBYIlKjZBX+unhxLkcnSSZLWxCp83mq8e/dehG9oGuVAjA1fivn/OWVK9soYg+J36U0wFQ3s7jMew/p3EtKb1CLX7QTJjC4JHxKnKfRZ0/qGa5korYE+lzVOfHNReFujTn6qHTs1NttSH8preBH9SqiaGdumz1+Lbu0aGnuZVffXSM6mTpUSFAZKylWBPq74/pu8mBu5SajKKT1s0wIpT4KKf1KIUEIbhXzpNnL+qfZFgxrljXJmTK0DUq+tjyhqqMk3obwSUrGj321yyuglEuW2xNU0tWJk5XDFpWRHxVnLlixsd0p2Cb2vzHUdvfRSavYWzaDEw9o+ZwfE2naE7TELAXqjTW9D6D8PSmiOGW9N4UaureqZZW5rH/Sn2l3FCUOqlJ8LuVFl6Y8fPoK01akpaffLGIMeoAInzMXW3YeQ/ssvkOHLtCIG/OLVm7hw+Tqmj+6HksW+jROnrLfjssYhI+khSLeRagu9nYs6elZIe9pj8xwcKgrR9fdoKZZPD5fDxs/VQxGfk6npJCtx2xr469a8ICeCnCwqnEnfR0ooDxvRW5sAbsheSsh98uxFnMU2qQgffUbJueZuMuqAUPgn5X9RBXhyqKjGUJN6lURhR3LgSQp39ey4izPK/P7Gx4ruv8h1f2BayKfCitwsS0C3IKllZ+bZZBNgB0Q2UR7PKglY4j8mq1y4CqNImUmpKVUvljGGxoZL125h74HjoHASapSkS05jfHUMqI+s/ZU1DtkU8w2dk5MT8uXOLgqbFSmYTwl5kvyccmsozKjwd5/Wf+3GXfzaLQC+vdqCQn6GjZuDUzvnGFy7rMRtawBM6x3k2UbvhOHZ85fiQfurnFmRLm0aVWbWatlPnJyU/fH7WP0pLMVv9Kx4H9p1v3fxTZYja2acu/Qvihf+2qA9MuqA0AR//X0Ka7fuE44Tqdi1alRdFQeZ39/4Jrx+6x4ad/bnPANVOyK/kyX2WL7VPGJcBNgB4fvCLgjwj5btbPP79x/w/EW0OAVR22Ttr6xx1Nptb/3opGzz4jGisJvGAensHSyKgJJEdvkGHqocEBmJ20mJ/Y+13EShTQ1XOk0s9r9OQvmKHBoSdTgcT9iShgOFocbXFkz2Q9MuQxT3RmYdkMT8HdBw2LnvqB4Sqna/butfuPvgEZZND0hKt5DNrIV/o21mqxQNZQdEERF3SAoE+EfL+neRiodRCBbV/qCHD6qcToWlvNyaK9ZCkLW/ssbR0JZRjdn6d069hb92G4aGtSqgbdOa4qKFK7di886DmDfJ1ygHRGbitnrrzdOTQgwp7Ojq9dv4+BHImS0zKpcrrir0SmNRg/aDRIhSrSqlxJ/OX76O5m5DETlzGBySJQMlZe9bO8WkBdC97OT4KSQzZtPkTsmoA2INvwOa9VHNHt1GdaPy580Bjw6NkCdXVpN48sUJIyD7NzphVvBVMgiwAyKDIo9h9QT4R8vqtwhU9Ive4Pbu0hTOmT4VlgqevBB5c2VHQL/YFex1VyRrf2WNQ7bJqsZs/Tun3sKDR8/CfeB4od1PRfYOHT8n6lxUq/Cj0Q6IqYnb6q02X0+Sl/b0C0WlMsWE9Cw9wFPtDzq1ICWrcQEeSJnic25WfJZQnsSIifPQqE4lUayPco1IrpaEHcgBKVqoAEb5Gq6ETmNHv3qDk2cv4fHTT5WlC36dBw4OyRQByPzeWMPvgOKCuUOiEZB5ryXaInhiQYAdEL4R7IIA/2hZ/zaTdn/kjAC9iudUlKyV+3DFt7ey9lfWOERbVjVm69854yy8decBdvx5GE+evUSVcsW1+TCUpE8FLd3afJbVjGtkWYnbxlltnt5Uy8Cjwy/aGh3kdPcfHi5OhHr5T0KRgvn11OkMWUEStaSaRQX76lQrK05DDhw5g5NnL6PlL/+LpfxHY42btgylihcUNYCo+Gjf4VNBjh2JdFAOFuV+TAr0jLNSuzleANCY1vA7oFnbuUvXcf/hY1EQlRrVWSFxAKWK8Oa5W3hUIiDzN5qJJi4BdkASlz/PbiEC/KNlIdAmTNPJOxidW9ZDpbI/aEe5c+8RWnQLEAUKDTVZ+ytrHLJVVjVmE5AmyUtlJW5bAxzKu9i3Zoo2CZ2cMErkpnwNUu7rGzBV5MyYq1HOzZzQQSj49Vcg+VuqMq6pVE4hVxNmROLilZtCOMAS3z+awxp+BzRr7egVjHrVy6FFw6qYuXAdps5djS9Sp4J7Bxe0afIpjJCbZQnI/I22rOU8W0wC7IDwPWEXBPhHy/q32XfUTJw+d1WvyvGFKzdAFaGpFoF4OGlZN86FULhTjqyZYOobS804MmhxNea4KVJ+wpadB3Hl+m1ER79B6tQpkP+rHELp7Jv8uWSgt5kxWnsEon3z2toTEDrBCI1YLpwOqplSpUlvHNs+S3E95LgsWrUdu/YfxaPHn8KnKH+qeqWSBq8lUYAdkROE4EPZ+u5YN28UsmTOoL3mydMXqN7CW1GGW+bvqym/A7JrxZAzuHFhCDKmTycqbAf07YjsWTOh24Bx2LJkrOK+cAf5BGTea/Kt4xGNIcAOiDG0uK/NEiA1k6oVStis/fZguM+I6YrLDPHrZrCPrDeWJBer1HavmmSwi6xqzEp22NLnVJNixMT5qFCqCArkzQknJ0dER78WzsiBw2cwtG8HUf9BqVHS84r1u3D1xh1RhC9nNmdULvcDOv5aF1+qlK5VmsMSn9MpR9f+Y5EnZ1Y4OjqKHBDK1ahdtQxu33uIiIXr4efVTtEUqgNy/MwltG9WSzgQFMpF+R9U+4McnPhay+7D0K55bdSvXg7eQyeLeetUK6PtTiGQVASQFLYMNZkPhTJ+B3r6hqJzq7ooWew7PbPp9GxoX8P5ZLoX0AnR7t/DRHX5mi37IWp9OD58/IiKLj0UnTLFTeMOCSKg5GS+ffsOVESTm/UTYAfE+veILZRIwNAb7rv3HyOr8+e3fxKn5aEsREDWG0t6MFRqVNjSUJNVjVnJDlv6vHrzPqLCPdV2iNkoh4GKEm5bOs7gkujBes7STejSur5I3KbEdqognj5dWhw6cQ4LJ/sZrBljbbyouvfu/cdEzYtyJQsnKL+ATi/mTBwokvs17fCJc+g/fBq2R46Pd8mU09DbfxJy5chC5dRx884DkXeiaXfvPxLVx3eumGh2B0RTLFbG/hSt1kkUMm3TtAa6tXXRJtJTyJtSUVXd+Xv7hwlhjEdPnuPJs+eYNW4A9h8+jZDJi7DqtxEyTOUxJBE49c8V/L5pD9Zv26+YMyhpSh7GRALsgJgIkC+3LQIVXHqImOu4Wt02A7Bx4WjbWhBbq0dA9htLqqfw8PFTZMrwpSo1oJjbQXUDKAn40ZNnRqkKJdVtLVHDFbtWTUL6dLFrvFC4T5WmvXF0a4TB5VNNi6mjvLUP6sSWQpnouzsmfAkePX6GkYOUFZ+shbGMe4SS2YN8XFHs+wLaZT18/EyEDZFksaH2Mvo1jp26gDv3H+Hdu/dxdm3WoIrZHRCZpyglanbBxgUh6B84DcmTOyJkcHfxcslYB4ScL8qDefr8Bfp0bSEEMnbsPSzesOvmqlnLvWRvdtx/+ETUZVm1aQ/u3nskTu8a1qqIksW+tTcUNrledkBsctvY6IQSoEJZo/26x3n5wJEz4NurjaoQkITOz9eZl4CsN5ZUCDF48iKs27oPb9+9R3InRzSoWQEDe7YWMqdqGikQURJxihRO4i3qzdsPRPx4aKAncmV3VjNEkuvTtmeQeEgm5SfdKt8kOzt59iqcPncF88MGG1w3ve3/Y/lEoUZE7cXLV/i5kSeObJmJK//eRjvPIOz5Pcwm2Mm6R0IjVuDS1Ztwa/tZQYwqoJMcr0/P1oKF0omdKcBk5E7JdkDIkaV6QnRfUbhe4ABX9B02xagTEFOY8LXmJeAxaIII26RwTpfaFVG1fAkOvTIvcumjswMiHSkPaM0EqDpw/jw5DZq4Zk6QNS+BbTNAQNYbS0qEpYdir67NhRQpxeNPnBmJdF+kQdDALqr2oH67gWhav7JQ9qJGqkIke0pJ2BFj+6saI6l1unTtFvoGTAGJC2TOmF4UmKQTAHqTSTUnxg31QN7c2Qwum+SNs2XJJORpHR0dMCliBQ6fPI/FU/1Bb/2rNu0tKoDbQpN1j1Rr5qW4XHLaDLWFK7cpjtGmSQ3FPgnNzzGHA6IxlsKmBgbNwL0HjxWruesusO+wqfGu18utGQInzMOMMf0UmXAH+QQof4kc319qVxQvDe1NwEI+UcuPyA6I5ZnzjIlIwFAIViKaxVNbGQG6TzYuGC3UgTSNYvQpTC++EL6YS6BwsKXThyJPrs8P1JRnVK/tALt/C0snFZTg/Or1a6RKmRL582TX42TodiBnhRKmKX8hWbJkyOacEeEhffBdgdwi1I3eiuomUlvZraVnjjXdI56DY0tdRx09K05ONKdNYUG9DeI0JT9HpgNCp5d0WqnbyDmlkxClOjO618xesjHe9TasVQHktFHhVG6JQ+DilRtYuXEP1m7ZJ8QXaE9IUEFXyS1xLONZ1RBgB0QNJe6TZAjE9R9TklkcLwReQyYrUpg4vKdiH8ozmBs6CF/lzKrtS8pCHXsHG0zq1R140MiZKF2iIJrUq6z9M50A9PKbJOROuZlGgArlkToRVQxPoaJauGmzmedqa79HFq7cKhxF315tVQEwJT9HpgNiqhy30mLpt0D3t0GpP39uXgJ0ukwiFqSyt+fACRGOyc36CbADYv17xBYyASagksC8yM2xei5ZvQMVSxfVPjAYkiXVXBw+bzU2/3EQrq3qibwNKogYsWg9alcrDff2v6iypk2PEbh87RaKF/lG259Uheih+dsCX4m/hQd7qxqLOyVNAtZ+j9CDNiX4q82pMSU/R6YDIkuOm0Qooo6ewa07D0Q+iaaNCJ0Pv96f5JGVEvST5p1rvauik65MGdJZr4FsmZYAOyB8M9gVgafPX4pwAidHR7tatz0vdvuew1i5cTemjFSOk9dwogeP5et2Ys2WfUIdiMJ8XGpVQLMGVVWrYS1ft0sROz+8KCJK0h2s6R55Gf1Kj3X0qzeIXLtTfA+2LYtfylf3IlPyc2Q6ILLkuPsHhiPqyFmhuObg4KBd6t6o4/i5zA/8EiERv51U/4d+n9ds/vPzb7TIB6kgQjO5WT8BdkCsf4/YQokEilTtiAqliiI8xDuWEzJ22lKkTJFcJLdySzoErt+6hyau/ojaYFiONOmsmFfCBIwnQL+NMVv2LJkwpE8HVClfXNWApuTnyCwWK0uOu2QtN6xfEIIcWTPprd9YOV9V8LiTUQRmLlyHlRt2o0OLOp+EQu4+wNzIzWhct5JReT5GTcqdpRJgB0QqTh7M2gnQf7JUEZ3qOgQO6KxnLkliUqXcDQtCrH0ZbF88BOghRreRwhLpxN998AjLpgeo5mZIEUiNEhBNtHT1jnjnq1G5lPjP05iEWNXGc0cmkAACdDqs25I7OQmVsoQ0U/JzZHz3ZMlxU07Loqn+IEdMt1Go2YH14QlBw9dIIkBFTWeNHyBqs2gaiVt06Tta9YmdJFN4mAQSYAckgeD4MtskQA7I3tVhIhG4aKEC8OnRSrsQknCt+WtfHOYENtvcXECcdMR8iMqfNwc8OjRCnlyfE8qVFhifIhBVmqaK02qa+8AJ8XYb5NkavqMisGCy4ZoXaubhPkzAWgiQ43Hn3kOULPZdLJMorJEiY5TCY+L67u09eBKlfiiImWPVSd7KkuO2Fq5sR2wCFRr2wObFY2LVE6Lim/vWxl1smDlaFwF2QKxrP9gaMxMgB4QqA1NCISUq0gOln1c7pEqZAnujTmD4+LnYsmSsma3g4W2RACkCXbhyE0P7dLBF89lmJmB2Aj19Q4WjP0DnxY5m0jnLNuGfC/9ilK/xVeqnz18rJJZjSusqLYh+5x8+fipOvKlmjLGN64AYS8xy/X2CpuPjh4/o072FyNEjifNx05YimUMyhAzuZjlDeKYEE2AHJMHo+EJbJKBxQNKkTgUKOaB6AmcvXMPXeXPi1D9X4N21Odo2rWmLS2Ob/yNAkozHT18UylXZsmTED4W/liI6QIpArdwDxQma2kb32PWbd0U1dd1WvPDXaofgfkzAZghUadJbKLsV/i6f1mZK4i7zYyFcvHoT7j7jE/SCh4p3dvYOUa3G9fxFNEZOWiAqwdN3L7mTI5rUr4IBHi3Fyya1jeuAqCVl+X7020ovDDf9EaWdnOr/UM7Sl2nTWN4gntFoAuyAGI2ML7BlAlR5ePnM4drYZlLS+OvQKZBuPCmdlCtZ2JaXZ/e2k+ytx6CJIEUfcj7ICfkiTSpMHeWtFyusBEqGIlDkup0ICl2A1ClTIFWMWHqlqtRK9vHnTMAaCVBy9saFo7WF4N6+fYcSNbuIugzRr9+AHJSjWyMUTafrSE41q3MGEbJFQhKhEcsxxt9d8VrqMGz8XFy/eQ8DerREruzO+PfmPYyeslhUyx7k2UbVGNzJNgi8efMWJH7gnCm9zdYDsg3S8q1kB0Q+Ux7RCgmc/OeyqOjLLWkT6OQdjPI/FUGX1g2EXC45mLMWb8C+gyfx2wQf1YuXoQj08y+eGOjZGg1qlFc9L3dkArZMoG3PIFQoXRQeHT7Vyvlj3xEEjJ2DET6uSJ7cCYNHRSgW8ty6+2+RH0UvAQrkyYGIcQPw/MVL7D98BmoFIMjRIdEJegmhabfuPkQr9+HYuWKiasQs9aoalcU7UlFXpUb3DzfrJcAOiPXuDVsmkYBMjXmJZvFQkgmUrtsNu1eF6an3UD2Dyo17idwftU2GIlC1Zl7i4YnC+7gxAXsgQKGPbv3HIluWTEibJhVIlWj66L7oPSQMDx89hXuHRujWrqFBFOQ8eLk1Q51qZREUOh9pv0iN1o2ro0PvUVB7ckgqVVuXjtMLxbn34DFcOvjir3VTVW8FS72qRmXxjnTaptT+3jRDqQt/nogE2AFJRPg8teUIsANiOdaJORM9YPh7t0fpEoW0Zhw8ehaBE+ZhzdyRRptGSawUT57+yy+MvnbK7FV4/+EDerk2NfpavoAJ2CoBCofZc+A4SAK7SrniyJndWYRT3bh1D0UL5VdUwSLnYf38YBFSQxXIew4OxcIpfihX3x1Ht81ShaWH70RxEqqbz0fOxLFTFzF5ZG9VY1AnlnpVjYo7MgGjCbADYjQyvsAWCbADYou7ZrzNVPXcN3gmalUpLYqH3b73EFt2/Y0gny6oXqmkwQE37zwoHpaKFcqPm7fvY/iEufjz4EmQfCjlkVCBKy+35qprI5Ac5O27D5E7Z5ZY89IDFjcmwARiExg4coaQ8W3RsKoIoaRaHAsn+6FNzxGqT0BIMevZ82g96e1rN+4iXdrUyJg+nWrsLPWqGhV3ZAJGE2AHxGhkfIEtEmAHxBZ3LWE2X7xyA+u27cfd+4+Q1TkjGtQoh6/z5VIcrGpTL4wP8BAPP+17jUSeXNnQvb2LkPC8duOOSGItkDenkG1W0/76+1S83cqXKqJmCO7DBGyKACUEL1q1Hbv2H8Wjx8+RO0cW4bgrOf+6i6RQq9PnrqJi6aLiz7v2H0Pu7M4ghaMenRqr4iErd4OlXlXh5k5MIEEE2AFJEDa+yNYIsANiaztmeXtL1HDFrpWTRLgV5ZKsnx8iVHg0jcJBmroNwb41XOTK8rvDM9oCAb+QWTh+5hLaN6sllLBIuvq3JRvQsUUdtG9eW9USYlZCp/odVO3aGIVCWbkbLPWqasu4ExNIEAF2QBKEjS+yNQLsgNjajiXMXq8hk+O9cOLwngYHrdvGB8GDu4JqdLT2CETf7r/ipx8+V3Sm6souHX3x5+r459CdIOaDlO5natV8EkaBr54FJQEAAAc9SURBVGICiUOA8jfmTBwoCrxq2uET59B/+DRF9SuZFsvO3WCpV5m7w2MxgU8E2AHhO8EuCLADYhfbjHmRm2MtdPbSjUJRxyeO6sy6nalux5TZv8OlVgXcvPMA/964K8I+NI0KqR07dQFr541SBdNzcGisflFHz4qHM3pI48YEkhoBl46DEeTjimLfF9AujRLQKR9KrQqdDMddVu4GFUCMr32bP3dS2z5eDxOwKAF2QCyKmydLLAI79x1F1QolEmt6njcRCazZ8ie27j6EsBG9FK0gGdE/9h0V+SPvYlQv11wc4tdNcZz4OixdvQOnz1/FsH6dEjwGX8gErJVAaMQKXLp6E25tG2hNPHHmkqhI7tOztfibUj0mGY67rNwNOtGJ2UgVj0Qpojaol/W21v1iu5hAYhJgByQx6fPcFidAxahIHSmudvf+Y72Yf4sbxxOahQBVR2/RLQAHN043y/jGDEpKPC27D8O+tZxHYgw37msbBKj2jVJTW8tDd5yFK7fiwpWbGNqng9Lw4nNz5m4ET16E7FkyoeOvdVTZwp2YABOImwA7IHxn2BWBCi494k0irttmADYuHG1XPOxhsVSXYPz0ZRg5yM2iyz174ZrefBRHvnbrPuw5cAKbFvF9ZtHN4MlsmgAls7dyD8Te1WFGrcMcuRsXLt8A1RnZvHiMUbZwZybABPQJsAPCd4RdEShTrztG+3WPc82kP+/bqw1calW0KyZJabF0irV0zQ7cvP0AHz580C5t4x8HULdaWfFvU0KojGFF1dd1W7JkyfD4yXMsDvdH4e/yGTMU92UCdkPgZfQrvbVGv3qDyLU7sXzdTmxbNl4VB3PmbuyNOoH+w8ONqqiuymjuxATsjAA7IHa24fa+3GL/64T8eXIaxLBmTpC9Y7LZ9VN4U/ov04pK6I4ODtp1hEYsR+8uzcS/O7Wsm2jro5MYBwcHeLl9soUbE2AC+gSKVO0YCwmFPA3p0wFVyhdXhSu+3I20X6TGgfXhqsagTs27Buj1ffXqNa5cvw2Pjo3g3v4X1eNwRybABGITYAeE7wq7ImAoBMuuQCTRxVItjz2/hyFd2jR6KyxVpyv+3jQj0VdN+ShtPYNUS/kmusFsABOwMAHK39BtyZ2ckDpVCpOtGBwcISS2W7hUUz3W9j2H9W1J7oh8X+XQq7CuejDuyASYgB4BdkD4hrArApRAOPA/NRa7WridLHZA4DT0c28ZS0zAY9AETB3lnagUPnz4iN837cH46ZFGx7InquE8ORNIAgRI4Y7UsTjPLwlsJi8hSRBgByRJbCMvggkwAWsjUKJmFz2TSNaX3uT69mqLxnUrWZu5bA8TsAoCvqNmKtqREEEJSh537Tsau1bGrs+jOCF3YAJMQDoBdkCkI+UBmQATYALAtRt39DA4OToii3NGJHdyZDxMgAnEQ2DavDXik1P/XMbpc1fRvGHVWD27t3dR5Pfu/XucPHsZd+49RM5szihSMD8cHJIpXscdmAATsAwBdkAsw5lnYQJMgAkwASbABFQS2LwzCn0CpqJ5g6rw924PR8fPohJKQ1C9J4+B4/Hq9VvcvvcQWTKlF+IUU0Z6ca0nJXj8OROwEAF2QCwEmqdhAkyACTABJsAElAnMXrIRMxasRfDgbkJ+N5lDMoz1d0eKFMmVLwbQJ2AK8n2VHb1cm6LGr32xbek4Md6Js5cRNkJfHlvVgNyJCTAB6QTYAZGOlAdkAkyACTABJsAEEkIgYOwc7I06jvCQPvg2f25QKJVfyCzcuvMAc0MHqRqyUiNPrJk7EhnTp9M6IDRO1SZeLAChiiB3YgLmJ8AOiPkZ8wxMgAkwASbABJiACgLN3IYiPNgbWTJn0Pb++PEjgkIXwM+rnYoRgNJ1u2PrkrHIkD6t1gG5ev0OuvQbI/7OjQkwgcQnwA5I4u8BW8AEmAATYAJMgAkAeBn9GmlSpzSJRTvPkejatgEqlf0BlRv3Qs3KpbBtzyH07NxY5JRwYwJMIPEJsAOS+HvAFjABJsAEmAATYAKSCBw7fRHRr16jXMnCmDhzOagC+s9liqHQN3kkzcDDMAEmYCoBdkBMJcjXMwEmwASYABNgAkyACTABJqCaADsgqlFxRybABJgAE2ACTIAJMAEmwARMJcAOiKkE+XomwASYABNgAkyACTABJsAEVBNgB0Q1Ku7IBJgAE2ACTIAJMAEmwASYgKkE2AExlSBfzwSYABNgAkyACTABJsAEmIBqAuyAqEbFHZkAE2ACTIAJMAEmwASYABMwlQA7IKYS5OuZABNgAkyACTABJsAEmAATUE2AHRDVqLgjE2ACTIAJMAEmwASYABNgAqYSYAfEVIJ8PRNgAkyACTABJsAEmAATYAKqCbADohoVd2QCTIAJMAEmwASYABNgAkzAVALsgJhKkK9nAkyACTABJsAEmAATYAJMQDUBdkBUo+KOTIAJMAEmwASYABNgAkyACZhK4P8vpl3nyHZanwAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure(\n",
+    "    data=go.Heatmap(\n",
+    "        z=corr_matrix.values,\n",
+    "        x=corr_matrix.columns.tolist(),\n",
+    "        y=corr_matrix.columns.tolist(),\n",
+    "        colorscale=\"RdBu_r\",\n",
+    "        zmid=0,\n",
+    "        zmin=-1,\n",
+    "        zmax=1,\n",
+    "    )\n",
+    ")\n",
+    "fig.update_layout(\n",
+    "    title=f\"Feature Correlation Matrix ({len(high_corr_pairs)} pairs above 0.7)\",\n",
+    "    template=\"plotly_white\",\n",
+    "    height=700,\n",
+    "    width=800,\n",
+    ")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "352fea32",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Interpretation**: The correlation heatmap reveals clusters of highly\n",
+    "correlated features — particularly within the momentum (multi-horizon\n",
+    "returns) and volatility (multi-horizon realized vol) families. Downstream\n",
+    "modeling in Ch11 should use clustering or PCA within families to reduce\n",
+    "redundancy, or rely on tree-based models that handle correlated inputs\n",
+    "natively."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf7ed89c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 6. Triage & Handoff\n",
+    "\n",
+    "Each feature receives a triage decision:\n",
+    "\n",
+    "| Decision | Criteria |\n",
+    "|----------|----------|\n",
+    "| **PROCEED** | FDR-significant at 5%, OR sign consistent across > 60% of folds AND abs(IC) > 0.01 |\n",
+    "| **STOP** | Correctness failure (coverage < 70% or staleness > 50%) |\n",
+    "| **REVISE** | Everything else — evaluate in multivariate context in Ch11 |\n",
+    "\n",
+    "Date-level features are triaged as REVISE with a note, since their value\n",
+    "lies in regime-conditional interactions rather than standalone cross-sectional IC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "29a99549",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:08.200598Z",
+     "iopub.status.busy": "2026-05-15T05:25:08.200363Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.206154Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.204932Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "triage = {}\n",
+    "for feat in all_feature_cols:\n",
+    "    if not correctness[feat]:\n",
+    "        triage[feat] = (\"STOP\", \"correctness_fail\")\n",
+    "        continue\n",
+    "\n",
+    "    if feat in date_level_features:\n",
+    "        triage[feat] = (\"REVISE\", \"date_level_feature\")\n",
+    "        continue\n",
+    "\n",
+    "    if feat not in ic_results:\n",
+    "        triage[feat] = (\"REVISE\", \"insufficient_data\")\n",
+    "        continue\n",
+    "\n",
+    "    is_fdr_sig = feat in fdr_sig_set\n",
+    "    sign_con = fold_stats.get(feat, {}).get(\"sign_consistency\", 0)\n",
+    "    abs_ic = abs(ic_results[feat][\"mean_ic\"])\n",
+    "\n",
+    "    if is_fdr_sig:\n",
+    "        triage[feat] = (\"PROCEED\", \"fdr_significant\")\n",
+    "    elif sign_con >= 0.60 and abs_ic >= IC_THRESHOLD:\n",
+    "        triage[feat] = (\"PROCEED\", \"stable_and_above_threshold\")\n",
+    "    else:\n",
+    "        triage[feat] = (\"REVISE\", \"not_significant_standalone\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ea0a1b9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:08.239947Z",
+     "iopub.status.busy": "2026-05-15T05:25:08.239355Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.289110Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.284864Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Triage ledger saved: case_studies/etfs/evaluation/triage_ledger.parquet\n",
+      "shape: (3, 2)\n",
+      "┌──────────┬─────┐\n",
+      "│ decision ┆ len │\n",
+      "│ ---      ┆ --- │\n",
+      "│ str      ┆ u32 │\n",
+      "╞══════════╪═════╡\n",
+      "│ PROCEED  ┆ 17  │\n",
+      "│ REVISE   ┆ 50  │\n",
+      "│ STOP     ┆ 4   │\n",
+      "└──────────┴─────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build triage ledger\n",
+    "ledger_rows = []\n",
+    "for feat in all_feature_cols:\n",
+    "    decision, note = triage[feat]\n",
+    "    row = {\n",
+    "        \"feature\": feat,\n",
+    "        \"family\": families.get(feat, \"other\"),\n",
+    "        \"source\": \"temporal\" if feat in temporal_cols else \"financial\",\n",
+    "        \"ic_mean\": ic_results.get(feat, {}).get(\"mean_ic\"),\n",
+    "        \"hac_t\": ic_results.get(feat, {}).get(\"t_stat\"),\n",
+    "        \"hac_p\": ic_results.get(feat, {}).get(\"p_value\"),\n",
+    "        \"fdr_p\": None,\n",
+    "        \"fdr_sig\": False,\n",
+    "        \"sign_consistency\": fold_stats.get(feat, {}).get(\"sign_consistency\"),\n",
+    "        \"worst_fold_ic\": fold_stats.get(feat, {}).get(\"worst_fold_ic\"),\n",
+    "        \"monotonicity\": monotonicity_scores.get(feat),\n",
+    "        \"coverage\": coverage[feat],\n",
+    "        \"staleness\": staleness[feat],\n",
+    "        \"decision\": decision,\n",
+    "        \"note\": note,\n",
+    "    }\n",
+    "    match = eval_summary.filter(pl.col(\"feature\") == feat)\n",
+    "    if len(match) > 0:\n",
+    "        row[\"fdr_p\"] = float(match[\"fdr_p\"][0])\n",
+    "        row[\"fdr_sig\"] = bool(match[\"fdr_sig\"][0])\n",
+    "    ledger_rows.append(row)\n",
+    "\n",
+    "triage_ledger = pl.DataFrame(ledger_rows)\n",
+    "triage_ledger.write_parquet(EVAL_DIR / \"triage_ledger.parquet\")\n",
+    "print(f\"Triage ledger saved: {EVAL_DIR / 'triage_ledger.parquet'}\")\n",
+    "print(triage_ledger.group_by(\"decision\").len().sort(\"decision\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "e45f68e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:08.316048Z",
+     "iopub.status.busy": "2026-05-15T05:25:08.315782Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.435668Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.428494Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IC time series saved: case_studies/etfs/evaluation/ic_timeseries.parquet\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save IC time series (long format)\n",
+    "ic_ts_frames = []\n",
+    "for feat, ts in ic_timeseries.items():\n",
+    "    ic_ts_frames.append(ts.with_columns(pl.lit(feat).alias(\"feature\")))\n",
+    "\n",
+    "if ic_ts_frames:\n",
+    "    ic_ts_all = pl.concat(ic_ts_frames)\n",
+    "    ic_ts_all.write_parquet(EVAL_DIR / \"ic_timeseries.parquet\")\n",
+    "    print(f\"IC time series saved: {EVAL_DIR / 'ic_timeseries.parquet'}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "97600726",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:08.466389Z",
+     "iopub.status.busy": "2026-05-15T05:25:08.465933Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.470521Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.469734Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Write results JSON\n",
+    "proceed_features = sorted(f for f, (d, _) in triage.items() if d == \"PROCEED\")\n",
+    "revise_features = [f for f, (d, _) in triage.items() if d == \"REVISE\"]\n",
+    "stop_features = [f for f, (d, _) in triage.items() if d == \"STOP\"]\n",
+    "\n",
+    "sorted_by_ic = sorted(ic_results.items(), key=lambda x: x[1].get(\"mean_ic\") or 0, reverse=True)\n",
+    "best = sorted_by_ic[0] if sorted_by_ic else (\"n/a\", {})\n",
+    "worst = sorted_by_ic[-1] if sorted_by_ic else (\"n/a\", {})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "006b4efd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T05:25:08.499614Z",
+     "iopub.status.busy": "2026-05-15T05:25:08.499144Z",
+     "iopub.status.idle": "2026-05-15T05:25:08.507371Z",
+     "shell.execute_reply": "2026-05-15T05:25:08.506064Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "TRIAGE SUMMARY: etfs\n",
+      "============================================================\n",
+      "  PROCEED: 17 features\n",
+      "  REVISE:  50 features\n",
+      "  STOP:    4 features\n",
+      "\n",
+      "PROMOTED (PROCEED) features:\n",
+      "  dist_52w_low                              IC=+0.0764  t=4.64  [distance]\n",
+      "  garch_cond_vol                            IC=+0.0496  t=2.54  [temporal_other]\n",
+      "  natr_14                                   IC=+0.0572  t=2.92  [volatility]\n",
+      "  ret_126d                                  IC=+0.0234  t=1.35  [momentum]\n",
+      "  ret_126d_rank                             IC=+0.0234  t=1.35  [momentum]\n",
+      "  ret_189d                                  IC=+0.0411  t=2.29  [momentum]\n",
+      "  ret_252d                                  IC=+0.0403  t=2.22  [momentum]\n",
+      "  ret_63d                                   IC=+0.0201  t=1.19  [momentum]\n",
+      "  sharpe_189d                               IC=+0.0160  t=0.96  [risk_adj_momentum]\n",
+      "  skip_recent_12_1                          IC=+0.0418  t=2.29  [momentum]\n",
+      "  skip_recent_6_1                           IC=+0.0241  t=1.37  [momentum]\n",
+      "  sma_ratio_200                             IC=+0.0335  t=1.95  [trend]\n",
+      "  vol_126d                                  IC=+0.0564  t=2.78  [volatility]\n",
+      "  vol_21d                                   IC=+0.0507  t=2.62  [volatility]\n",
+      "  vol_252d                                  IC=+0.0589  t=2.87  [volatility]\n",
+      "  vol_63d                                   IC=+0.0509  t=2.55  [volatility]\n",
+      "  vol_ratio_63d                             IC=+0.0105  t=2.12  [vol_ratio]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"\\n{'=' * 60}\")\n",
+    "print(f\"TRIAGE SUMMARY: {CASE_STUDY_ID}\")\n",
+    "print(f\"{'=' * 60}\")\n",
+    "print(f\"  PROCEED: {len(proceed_features)} features\")\n",
+    "print(f\"  REVISE:  {len(revise_features)} features\")\n",
+    "print(f\"  STOP:    {len(stop_features)} features\")\n",
+    "print(\"\\nPROMOTED (PROCEED) features:\")\n",
+    "for f in proceed_features:\n",
+    "    ic = ic_results[f][\"mean_ic\"]\n",
+    "    t = ic_results[f][\"t_stat\"]\n",
+    "    print(f\"  {f:40s}  IC={ic:+.4f}  t={t:.2f}  [{families.get(f, '?')}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19b103c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Quality Gate Verdict\n",
+    "\n",
+    "**Fit for modeling.** The triage promotes a broad set of features to PROCEED,\n",
+    "concentrated in the momentum and risk-adjusted momentum families. IC magnitudes\n",
+    "are moderate (0.03--0.04 range), consistent with monthly-horizon cross-sectional\n",
+    "equity signals over a 100-ETF universe. Date-level regime and macro features\n",
+    "are excluded from cross-sectional IC but carry forward as conditioning variables\n",
+    "for tree-based and interaction models in Ch11+."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0fb9b73",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **FDR correction is essential**: With 50+ features, naive p-values\n",
+    "   dramatically overstate the number of true signals. The inflation factor\n",
+    "   quantifies the gap between naive and corrected significance.\n",
+    "\n",
+    "2. **HAC adjustment matters**: Overlapping 21-day returns create\n",
+    "   autocorrelation in the IC time series. Newey-West standard errors\n",
+    "   with bandwidth = 21 properly account for this.\n",
+    "\n",
+    "3. **Date-level features require special handling**: Regime and macro\n",
+    "   features have zero cross-sectional IC by construction. Their value\n",
+    "   emerges through conditional interactions in Ch11 modeling.\n",
+    "\n",
+    "4. **Redundancy within families**: Momentum and volatility features are\n",
+    "   highly correlated. Downstream modeling should cluster or select\n",
+    "   representative features from each family.\n",
+    "\n",
+    "**Next**: `05_linear.py` (Ch11) uses the triage ledger and promoted\n",
+    "features for ridge/lasso baseline modeling."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 236.669733,
+   "end_time": "2026-05-15T05:25:11.493581+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/etfs/05_evaluation.ipynb",
+   "output_path": "case_studies/etfs/05_evaluation.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-15T05:21:14.823848+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/case_studies/etfs/05_evaluation.py
+++ b/case_studies/etfs/05_evaluation.py
@@ -1,0 +1,812 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Feature Evaluation — ETFs
+#
+# Consolidated evaluation of Ch8 financial features and Ch9 temporal features
+# against forward return labels. Produces triage decisions for Ch11 modeling.
+#
+# **Learning Objectives**:
+# - Evaluate individual feature predictive power via Information Coefficient (IC)
+# - Apply HAC adjustment for overlapping-return autocorrelation
+# - Control false discovery rate with Benjamini-Hochberg correction
+# - Assess feature redundancy and family-level signal concentration
+# - Produce a triage ledger for downstream model selection
+#
+# **Book Reference**: Chapter 8, Section 8.5 (Feature Evaluation)
+#
+# **Prerequisites**: `03_financial_features.py` and `04_temporal.py` must have run
+# (produces `features/financial.parquet` and `features/model_based.parquet`).
+
+# %%
+"""Feature Evaluation - ETFs case study."""
+
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import numpy as np
+import plotly.graph_objects as go
+import polars as pl
+import yaml
+from ml4t.diagnostic.evaluation.stats import benjamini_hochberg_fdr
+from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series
+from plotly.subplots import make_subplots
+from scipy.stats import spearmanr
+
+from utils.paths import get_case_study_dir
+
+# %% tags=["parameters"]
+# Production defaults
+MAX_SYMBOLS = 0
+
+# %%
+CASE_STUDY_ID = "etfs"
+CASE_DIR = get_case_study_dir(CASE_STUDY_ID)
+EVAL_DIR = CASE_DIR / "evaluation"
+EVAL_DIR.mkdir(exist_ok=True)
+
+# ETFs config
+PRIMARY_LABEL_FILE = "fwd_ret_21d.parquet"
+HAC_MAXLAGS = 21  # 21-day forward return
+MIN_PERIODS = 10  # 99 symbols
+IC_THRESHOLD = 0.01  # Monthly horizon
+
+# %% [markdown]
+# ## 0. Load Artifacts & Build Evaluation Panel
+#
+# We load the pre-computed feature matrices and labels, then join into a single
+# evaluation panel. Temporal features include both date-level (HMM regime, FFD)
+# and per-symbol (GARCH) features, so we join on `[date, symbol]`.
+
+# %%
+# Load features (normalize date column type to pl.Date for consistent joins)
+features = pl.read_parquet(CASE_DIR / "features" / "financial.parquet").with_columns(
+    pl.col("timestamp").cast(pl.Date)
+)
+temporal = pl.read_parquet(CASE_DIR / "features" / "model_based.parquet").with_columns(
+    pl.col("timestamp").cast(pl.Date)
+)
+# model_based.parquet now carries one row per (timestamp, symbol, fold);
+# drop fold and de-dup so the join doesn't multiply the eval panel by fold count.
+if "fold" in temporal.columns:
+    temporal = temporal.drop("fold").unique(subset=["timestamp", "symbol"], keep="last")
+
+# Load primary label
+label_df = pl.read_parquet(CASE_DIR / "labels" / PRIMARY_LABEL_FILE).with_columns(
+    pl.col("timestamp").cast(pl.Date)
+)
+label_col = [c for c in label_df.columns if c not in ("timestamp", "symbol")][0]
+
+# Load evaluation config from setup.yaml
+with open(CASE_DIR / "config" / "setup.yaml") as f:
+    setup_config = yaml.safe_load(f)
+eval_config = setup_config.get("evaluation", {})
+
+print(f"Features: {features.shape}")
+print(f"Temporal: {temporal.shape}")
+print(f"Labels: {label_df.shape}, column: {label_col}")
+
+# %%
+# Identify feature columns by source
+JOIN_COLS = ["timestamp", "symbol"]
+DATE_COL = "timestamp"
+
+financial_cols = [c for c in features.columns if c not in JOIN_COLS]
+temporal_cols = [c for c in temporal.columns if c not in ("timestamp", "symbol")]
+
+# Join: features + temporal (on [date, symbol]) + labels
+eval_panel = features.join(temporal, on=JOIN_COLS, how="left")
+eval_panel = eval_panel.join(label_df, on=JOIN_COLS, how="inner")
+
+all_feature_cols = financial_cols + temporal_cols
+
+if MAX_SYMBOLS > 0:
+    top = eval_panel.group_by("symbol").len().sort("len", descending=True).head(MAX_SYMBOLS)
+    eval_panel = eval_panel.filter(pl.col("symbol").is_in(top["symbol"]))
+
+n_rows = len(eval_panel)
+n_symbols = eval_panel["symbol"].n_unique()
+n_dates = eval_panel[DATE_COL].n_unique()
+print(f"\nEval panel: {n_rows:,} rows, {n_symbols} symbols, {n_dates:,} dates")
+print(
+    f"Features: {len(financial_cols)} financial + {len(temporal_cols)} temporal"
+    f" = {len(all_feature_cols)} total"
+)
+print(f"Label: {label_col}")
+
+# %% [markdown]
+# ## 0.5 Data Quality Gate
+#
+# Verify upstream artifacts are free of critical defects (negative prices,
+# infinities, extreme returns) before any statistical evaluation.
+
+# %%
+from utils.data_quality import validate_modeling_inputs
+
+validate_modeling_inputs(
+    features_df=eval_panel,
+    label_df=eval_panel,
+    feature_cols=all_feature_cols,
+    label_col=label_col,
+    join_cols=JOIN_COLS,
+    asset_col="symbol",
+    max_abs_return=1.0,  # 21-day ETF returns (max observed ~0.71)
+    fail_on_critical=True,
+)
+
+# %% [markdown]
+# ## 1. Correctness Screens
+#
+# Before evaluating predictive power, we check data quality:
+# - **Coverage**: fraction of non-null values (threshold: 70%)
+# - **Staleness**: fraction of unchanged values from prior date (threshold: 50%)
+#
+# Features that fail either gate are marked STOP in the triage.
+
+# %%
+coverage = {}
+staleness = {}
+
+for feat in all_feature_cols:
+    col = eval_panel[feat]
+    coverage[feat] = col.drop_nulls().len() / n_rows
+
+    # Staleness: fraction unchanged from prior row within same symbol
+    unchanged = (
+        eval_panel.sort(JOIN_COLS)
+        .select((pl.col(feat) == pl.col(feat).shift(1).over("symbol")).alias("same"))["same"]
+        .sum()
+    )
+    staleness[feat] = float(unchanged) / max(n_rows - n_symbols, 1)
+
+correctness = {
+    feat: coverage[feat] >= 0.70 and staleness[feat] <= 0.50 for feat in all_feature_cols
+}
+n_pass = sum(correctness.values())
+n_fail = len(correctness) - n_pass
+print(f"Correctness gate: {n_pass} PASS, {n_fail} FAIL")
+
+if n_fail > 0:
+    fail_df = pl.DataFrame(
+        {
+            "feature": [f for f, ok in correctness.items() if not ok],
+            "coverage": [round(coverage[f], 3) for f, ok in correctness.items() if not ok],
+            "staleness": [round(staleness[f], 3) for f, ok in correctness.items() if not ok],
+        }
+    )
+    print(fail_df)
+
+# %% [markdown]
+# ### Effective Sample Size
+#
+# With daily observations and 21-day forward return labels, consecutive labels
+# overlap by 20 days. This autocorrelation reduces the effective number of
+# independent observations:
+#
+# $$N_{\text{eff}} \approx \frac{N_{\text{dates}}}{h} \times N_{\text{symbols}}$$
+#
+# where $h = 21$ is the label horizon. HAC standard errors (below) account for
+# this, but raw row counts overstate statistical power.
+
+# %%
+n_eff_dates = n_dates // HAC_MAXLAGS
+n_eff = n_eff_dates * n_symbols
+print(f"Raw panel: {n_rows:,} rows ({n_dates:,} dates × {n_symbols} symbols)")
+print(
+    f"Effective sample size: ~{n_eff:,} ({n_eff_dates:,} independent date blocks × {n_symbols} symbols)"
+)
+print(f"Overlap reduction factor: {n_dates / n_eff_dates:.0f}x")
+
+# %% [markdown]
+# ## 2. Univariate Association (IC + HAC)
+#
+# For each feature that passes correctness, we compute:
+# - **IC time series**: daily cross-sectional Spearman rank correlation with the label
+# - **HAC-adjusted t-statistics**: Newey-West standard errors with bandwidth = 21
+#   (matching the 21-day label horizon) to account for overlapping-return autocorrelation
+#
+# Date-level features (identical across all symbols on a given date) produce zero
+# cross-sectional IC by construction. We detect and flag these separately.
+
+# %%
+evaluable_features = [f for f in all_feature_cols if correctness[f]]
+
+# Detect date-level features (zero cross-sectional variance)
+# Compute std per date for all features at once, then check which have ~zero mean std
+cs_std_df = eval_panel.group_by(DATE_COL).agg(
+    [pl.col(f).std().alias(f) for f in evaluable_features]
+)
+date_level_features = set()
+for feat in evaluable_features:
+    mean_std = cs_std_df[feat].drop_nulls().mean()
+    if mean_std is not None and mean_std < 1e-10:
+        date_level_features.add(feat)
+
+if date_level_features:
+    print(f"Date-level features (zero CS variance): {sorted(date_level_features)}")
+
+# %%
+# Batch IC computation: one pass over dates, all features at once
+# This is much faster than calling cross_sectional_ic_series per feature
+cs_features = [f for f in evaluable_features if f not in date_level_features]
+cols_needed = [DATE_COL] + cs_features + [label_col]
+eval_sub = eval_panel.select(cols_needed).drop_nulls(subset=[label_col])
+
+# Group by date and compute Spearman IC for all features per date
+dates_list = eval_sub[DATE_COL].unique().sort().to_list()
+n_total = len(dates_list)
+
+# Pre-allocate: dict of feature -> list of (date, ic, n_obs)
+ic_series_data = {feat: [] for feat in cs_features}
+
+for i, dt in enumerate(dates_list):
+    cross_section = eval_sub.filter(pl.col(DATE_COL) == dt)
+    n_obs = len(cross_section)
+    if n_obs < MIN_PERIODS:
+        continue
+
+    label_arr = cross_section[label_col].to_numpy()
+    label_valid = ~np.isnan(label_arr)
+
+    for feat in cs_features:
+        feat_arr = cross_section[feat].to_numpy()
+        valid_mask = label_valid & ~np.isnan(feat_arr)
+        n_valid = int(valid_mask.sum())
+        if n_valid >= MIN_PERIODS:
+            ic_val, _ = spearmanr(feat_arr[valid_mask], label_arr[valid_mask])
+            if not np.isnan(ic_val):
+                ic_series_data[feat].append((dt, float(ic_val), n_valid))
+
+    if (i + 1) % 1000 == 0:
+        print(f"  IC progress: {i + 1}/{n_total} dates")
+
+print(f"  IC progress: {n_total}/{n_total} dates (done)")
+
+# %%
+# Convert to DataFrames and compute HAC stats
+ic_results = {}
+ic_timeseries = {}
+for feat in cs_features:
+    data = ic_series_data[feat]
+    if len(data) < 20:
+        continue
+    dates_f, ics_f, nobs_f = zip(*data, strict=False)
+    ic_df = pl.DataFrame({DATE_COL: list(dates_f), "ic": list(ics_f), "n_obs": list(nobs_f)})
+    hac_stats = compute_ic_hac_stats(ic_df, ic_col="ic", maxlags=HAC_MAXLAGS)
+    ic_results[feat] = hac_stats
+    ic_timeseries[feat] = ic_df
+
+print(f"IC computed for {len(ic_results)} cross-sectional features")
+print(f"Skipped {len(date_level_features)} date-level features")
+
+# %% [markdown]
+# ### Fold-Level Stability
+#
+# We divide the evaluation period into approximate annual folds (matching the
+# CV config's 1-year test windows) and check whether IC sign is consistent
+# across folds. Features with > 60% positive-IC folds are more robust.
+
+# %%
+# Generate approximate fold boundaries
+all_dates = eval_panel[DATE_COL].unique().sort().to_list()
+n_folds = eval_config.get("n_splits", 8)
+fold_size = len(all_dates) // n_folds
+
+fold_boundaries = []
+for i in range(n_folds):
+    start_idx = i * fold_size
+    end_idx = min((i + 1) * fold_size - 1, len(all_dates) - 1)
+    fold_boundaries.append((all_dates[start_idx], all_dates[end_idx]))
+
+fold_stats = {}
+for feat in ic_results:
+    fold_ics = []
+    ts = ic_timeseries[feat]
+    for fold_start, fold_end in fold_boundaries:
+        fold_ic = ts.filter((pl.col(DATE_COL) >= fold_start) & (pl.col(DATE_COL) <= fold_end))
+        if len(fold_ic) >= 5:
+            fold_ics.append(float(fold_ic["ic"].mean()))
+
+    if fold_ics:
+        sign_consistency = sum(1 for ic in fold_ics if ic > 0) / len(fold_ics)
+        fold_stats[feat] = {
+            "n_folds": len(fold_ics),
+            "sign_consistency": sign_consistency,
+            "worst_fold_ic": min(fold_ics),
+            "best_fold_ic": max(fold_ics),
+            "median_fold_ic": float(np.median(fold_ics)),
+        }
+
+print(f"Fold stability computed for {len(fold_stats)} features")
+
+# %% [markdown]
+# ## 3. Multiple Testing (BH-FDR)
+#
+# Testing 50+ features simultaneously at $\alpha = 0.05$ expects ~2.5 false
+# positives. We apply the Benjamini-Hochberg procedure to control the false
+# discovery rate. The **inflation factor** measures how much naive significance
+# overstates true significance:
+#
+# $$\text{Inflation} = \frac{N_{\text{naive significant}}}{N_{\text{FDR significant}}}$$
+
+# %%
+feature_names = list(ic_results.keys())
+p_values = [ic_results[f]["p_value"] for f in feature_names]
+
+fdr_result = benjamini_hochberg_fdr(p_values, alpha=0.05, return_details=True)
+
+eval_summary = pl.DataFrame(
+    {
+        "feature": feature_names,
+        "source": ["temporal" if f in temporal_cols else "financial" for f in feature_names],
+        "ic_mean": [ic_results[f]["mean_ic"] for f in feature_names],
+        "hac_se": [ic_results[f]["hac_se"] for f in feature_names],
+        "hac_t": [ic_results[f]["t_stat"] for f in feature_names],
+        "hac_p": p_values,
+        "fdr_p": [float(p) for p in fdr_result["adjusted_p_values"]],
+        "fdr_sig": [bool(r) for r in fdr_result["rejected"]],
+        "naive_t": [ic_results[f]["naive_t_stat"] for f in feature_names],
+    }
+).sort(pl.col("ic_mean").cast(pl.Float64, strict=False).abs(), descending=True)
+
+n_significant_naive = sum(1 for p in p_values if p < 0.05)
+n_significant_hac = sum(1 for f in feature_names if abs(ic_results[f]["t_stat"]) > 1.96)
+n_significant_fdr = int(fdr_result["n_rejected"])
+
+inflation_hac = n_significant_naive / max(n_significant_hac, 1)
+inflation_fdr = n_significant_naive / max(n_significant_fdr, 1)
+
+print(f"Features tested: {len(feature_names)}")
+print(f"Naive significant (p < 0.05): {n_significant_naive}")
+print(f"HAC significant (|t| > 1.96): {n_significant_hac}")
+print(f"FDR significant (q < 0.05):   {n_significant_fdr}")
+print(f"Inflation factor (HAC): {inflation_hac:.2f}x")
+print(f"Inflation factor (FDR): {inflation_fdr:.2f}x")
+
+# %%
+# Top features table
+print("\nTop 15 features by absolute IC:")
+print(eval_summary.head(15))
+
+# %%
+top_n = min(25, len(eval_summary))
+top = eval_summary.head(top_n)
+
+fig = make_subplots(
+    rows=1,
+    cols=2,
+    subplot_titles=[
+        f"Top {top_n} Features by |IC| (green = FDR-sig)",
+        "HAC vs Naive t-statistics",
+    ],
+    horizontal_spacing=0.12,
+)
+
+# Panel 1: IC bar chart
+colors = ["#2ecc71" if s else "#95a5a6" for s in top["fdr_sig"].to_list()]
+fig.add_trace(
+    go.Bar(
+        x=top["feature"].to_list(),
+        y=top["ic_mean"].to_list(),
+        marker_color=colors,
+        text=[f"t={t:.1f}" for t in top["hac_t"].to_list()],
+        textposition="outside",
+        showlegend=False,
+    ),
+    row=1,
+    col=1,
+)
+
+# Panel 2: HAC scatter
+fig.add_trace(
+    go.Scatter(
+        x=eval_summary["naive_t"].to_list(),
+        y=eval_summary["hac_t"].to_list(),
+        mode="markers",
+        marker=dict(
+            color=["#2ecc71" if s else "#e74c3c" for s in eval_summary["fdr_sig"].to_list()],
+            size=7,
+        ),
+        text=eval_summary["feature"].to_list(),
+        showlegend=False,
+    ),
+    row=1,
+    col=2,
+)
+max_t = (
+    max(
+        eval_summary["naive_t"].cast(pl.Float64, strict=False).abs().max() or 1.0,
+        eval_summary["hac_t"].cast(pl.Float64, strict=False).abs().max() or 1.0,
+    )
+    * 1.1
+)
+fig.add_trace(
+    go.Scatter(
+        x=[-max_t, max_t],
+        y=[-max_t, max_t],
+        mode="lines",
+        line=dict(dash="dash", color="gray"),
+        showlegend=False,
+    ),
+    row=1,
+    col=2,
+)
+
+fig.update_layout(template="plotly_white", height=450, width=1100)
+fig.update_xaxes(tickangle=-45, row=1, col=1)
+fig.update_xaxes(title_text="Naive t", row=1, col=2)
+fig.update_yaxes(title_text="HAC t", row=1, col=2)
+fig.show()
+
+# %% [markdown]
+# **Interpretation**: Points below the diagonal in the right panel show where
+# HAC adjustment deflates naive t-statistics. With overlapping 21-day returns,
+# daily IC values are autocorrelated and naive standard errors understate
+# uncertainty. The green markers survive both HAC and FDR correction — these
+# features have genuine standalone predictive power.
+
+# %% [markdown]
+# ## 4. Shape Diagnostics
+#
+# Quantile monotonicity analysis: does the label spread monotonically across
+# feature quintiles? A monotone relationship (Q1 < Q2 < ... < Q5 or reverse)
+# suggests a robust, exploitable signal. Non-monotone shapes may indicate
+# non-linear interactions or noise.
+
+# %%
+N_QUANTILES = 5
+top_features_for_shape = eval_summary.filter(pl.col("fdr_sig").fill_null(False))[
+    "feature"
+].to_list()[:15]
+if not top_features_for_shape:
+    top_features_for_shape = eval_summary.head(10)["feature"].to_list()
+
+monotonicity_scores = {}
+quantile_spreads = {}
+
+for feat in top_features_for_shape:
+    valid = eval_panel.select([feat, label_col]).drop_nulls()
+    if len(valid) < N_QUANTILES * 20:
+        continue
+
+    valid = valid.with_columns(
+        pl.col(feat)
+        .qcut(N_QUANTILES, labels=[f"Q{i + 1}" for i in range(N_QUANTILES)])
+        .alias("quantile")
+    )
+    q_means = valid.group_by("quantile").agg(pl.col(label_col).mean()).sort("quantile")
+    means = q_means[label_col].to_list()
+    spread = means[-1] - means[0]
+    quantile_spreads[feat] = {"q_means": means, "spread": spread}
+
+    mono_corr, _ = spearmanr(range(len(means)), means)
+    monotonicity_scores[feat] = float(mono_corr)
+
+print(f"Shape analysis for {len(quantile_spreads)} features")
+
+# %%
+if quantile_spreads:
+    n_show = min(6, len(quantile_spreads))
+    feats_to_show = list(quantile_spreads.keys())[:n_show]
+    n_rows_fig = (n_show + 2) // 3
+    fig = make_subplots(rows=n_rows_fig, cols=3, subplot_titles=feats_to_show)
+    for idx, feat in enumerate(feats_to_show):
+        r, c = divmod(idx, 3)
+        q_means = quantile_spreads[feat]["q_means"]
+        mono = monotonicity_scores.get(feat, 0)
+        fig.add_trace(
+            go.Bar(
+                x=[f"Q{i + 1}" for i in range(len(q_means))],
+                y=q_means,
+                marker_color=[
+                    "#e74c3c",
+                    "#f39c12",
+                    "#95a5a6",
+                    "#3498db",
+                    "#2ecc71",
+                ],
+                showlegend=False,
+                text=[f"{m:.4f}" for m in q_means],
+                textposition="outside",
+            ),
+            row=r + 1,
+            col=c + 1,
+        )
+    fig.update_layout(
+        template="plotly_white",
+        height=250 * n_rows_fig,
+        width=900,
+        title_text="Quantile Mean Returns (Top FDR-Significant Features)",
+    )
+    fig.show()
+
+# %% [markdown]
+# **Interpretation**: Monotone quintile spreads (Q1 → Q5 increasing or
+# decreasing) confirm a robust relationship. Non-monotone patterns (e.g.,
+# U-shaped) suggest non-linear effects that may require interaction terms or
+# tree-based models to capture.
+
+# %% [markdown]
+# ## 5. Redundancy & Feature Families
+#
+# We group features into interpretive families and compute family-level IC
+# aggregates. Highly correlated feature pairs (|corr| > 0.7) flag redundancy
+# that downstream modeling should address via clustering or selection.
+
+
+# %%
+def assign_feature_family(feature_name: str) -> str:
+    """Map feature name to family based on prefix."""
+    FAMILY_MAP = [
+        (["sharpe_", "risk_adj"], "risk_adj_momentum"),
+        (["skip_recent", "mom_"], "momentum"),
+        (["ret_"], "momentum"),
+        (["vol_ratio"], "vol_ratio"),
+        (["vol_"], "volatility"),
+        (["natr", "range_", "max_dd"], "volatility"),
+        (["rsi", "macd", "adx", "cci", "stoch", "aroon", "bb_"], "technical"),
+        (["sma_", "ema_"], "trend"),
+        (["yield_curve", "spy_tlt", "regime", "chop", "hurst"], "regime"),
+        (["rank_"], "cross_sectional"),
+        (["obv", "turnover", "volume"], "volume"),
+        (["pct_positive", "up_ratio"], "consistency"),
+        (["dist_"], "distance"),
+        (["corr_"], "correlation"),
+    ]
+    for prefixes, family in FAMILY_MAP:
+        if any(p in feature_name.lower() for p in prefixes):
+            return family
+    return "other"
+
+
+families = {feat: assign_feature_family(feat) for feat in all_feature_cols}
+
+# Override temporal features with specific families
+for feat in temporal_cols:
+    if "regime" in feat.lower():
+        families[feat] = "temporal_regime"
+    elif "ffd" in feat.lower():
+        families[feat] = "temporal_ffd"
+    else:
+        families[feat] = "temporal_other"
+
+# %%
+# Pairwise correlation on sampled dates
+sample_step = max(1, n_dates // 200)
+sample_dates = eval_panel[DATE_COL].unique().sort().to_list()[::sample_step]
+corr_data = (
+    eval_panel.filter(pl.col(DATE_COL).is_in(sample_dates)).select(evaluable_features).to_pandas()
+)
+corr_matrix = corr_data.corr(method="spearman")
+
+high_corr_pairs = []
+cols = corr_matrix.columns
+for i in range(len(cols)):
+    for j in range(i + 1, len(cols)):
+        if abs(corr_matrix.iloc[i, j]) > 0.7:
+            high_corr_pairs.append((cols[i], cols[j], float(corr_matrix.iloc[i, j])))
+
+print(f"Feature pairs with |corr| > 0.7: {len(high_corr_pairs)}")
+
+# %%
+# Family-level IC summary
+family_ic = {}
+fdr_sig_set = set(eval_summary.filter(pl.col("fdr_sig").fill_null(False))["feature"].to_list())
+
+for feat in ic_results:
+    fam = families.get(feat, "other")
+    family_ic.setdefault(fam, []).append(
+        {
+            "feature": feat,
+            "ic": ic_results[feat]["mean_ic"],
+            "fdr_sig": feat in fdr_sig_set,
+        }
+    )
+
+family_summary = {}
+for fam, feats in sorted(family_ic.items()):
+    ics = [f["ic"] for f in feats if f["ic"] is not None]
+    n_sig = sum(1 for f in feats if f["fdr_sig"])
+    family_summary[fam] = {
+        "n_features": len(feats),
+        "avg_abs_ic": float(np.mean([abs(ic) for ic in ics])) if ics else 0.0,
+        "avg_ic": float(np.mean(ics)) if ics else 0.0,
+        "n_fdr_sig": n_sig,
+    }
+
+if family_summary:
+    fam_df = pl.DataFrame([{"family": fam, **stats} for fam, stats in family_summary.items()]).sort(
+        "avg_abs_ic", descending=True
+    )
+else:
+    fam_df = pl.DataFrame(
+        schema={
+            "family": pl.Utf8,
+            "n_features": pl.Int64,
+            "avg_abs_ic": pl.Float64,
+            "avg_ic": pl.Float64,
+            "n_fdr_sig": pl.Int64,
+        }
+    )
+print(fam_df)
+
+# %%
+fig = go.Figure(
+    data=go.Heatmap(
+        z=corr_matrix.values,
+        x=corr_matrix.columns.tolist(),
+        y=corr_matrix.columns.tolist(),
+        colorscale="RdBu_r",
+        zmid=0,
+        zmin=-1,
+        zmax=1,
+    )
+)
+fig.update_layout(
+    title=f"Feature Correlation Matrix ({len(high_corr_pairs)} pairs above 0.7)",
+    template="plotly_white",
+    height=700,
+    width=800,
+)
+fig.show()
+
+# %% [markdown]
+# **Interpretation**: The correlation heatmap reveals clusters of highly
+# correlated features — particularly within the momentum (multi-horizon
+# returns) and volatility (multi-horizon realized vol) families. Downstream
+# modeling in Ch11 should use clustering or PCA within families to reduce
+# redundancy, or rely on tree-based models that handle correlated inputs
+# natively.
+
+# %% [markdown]
+# ## 6. Triage & Handoff
+#
+# Each feature receives a triage decision:
+#
+# | Decision | Criteria |
+# |----------|----------|
+# | **PROCEED** | FDR-significant at 5%, OR sign consistent across > 60% of folds AND abs(IC) > 0.01 |
+# | **STOP** | Correctness failure (coverage < 70% or staleness > 50%) |
+# | **REVISE** | Everything else — evaluate in multivariate context in Ch11 |
+#
+# Date-level features are triaged as REVISE with a note, since their value
+# lies in regime-conditional interactions rather than standalone cross-sectional IC.
+
+# %%
+triage = {}
+for feat in all_feature_cols:
+    if not correctness[feat]:
+        triage[feat] = ("STOP", "correctness_fail")
+        continue
+
+    if feat in date_level_features:
+        triage[feat] = ("REVISE", "date_level_feature")
+        continue
+
+    if feat not in ic_results:
+        triage[feat] = ("REVISE", "insufficient_data")
+        continue
+
+    is_fdr_sig = feat in fdr_sig_set
+    sign_con = fold_stats.get(feat, {}).get("sign_consistency", 0)
+    abs_ic = abs(ic_results[feat]["mean_ic"])
+
+    if is_fdr_sig:
+        triage[feat] = ("PROCEED", "fdr_significant")
+    elif sign_con >= 0.60 and abs_ic >= IC_THRESHOLD:
+        triage[feat] = ("PROCEED", "stable_and_above_threshold")
+    else:
+        triage[feat] = ("REVISE", "not_significant_standalone")
+
+# %%
+# Build triage ledger
+ledger_rows = []
+for feat in all_feature_cols:
+    decision, note = triage[feat]
+    row = {
+        "feature": feat,
+        "family": families.get(feat, "other"),
+        "source": "temporal" if feat in temporal_cols else "financial",
+        "ic_mean": ic_results.get(feat, {}).get("mean_ic"),
+        "hac_t": ic_results.get(feat, {}).get("t_stat"),
+        "hac_p": ic_results.get(feat, {}).get("p_value"),
+        "fdr_p": None,
+        "fdr_sig": False,
+        "sign_consistency": fold_stats.get(feat, {}).get("sign_consistency"),
+        "worst_fold_ic": fold_stats.get(feat, {}).get("worst_fold_ic"),
+        "monotonicity": monotonicity_scores.get(feat),
+        "coverage": coverage[feat],
+        "staleness": staleness[feat],
+        "decision": decision,
+        "note": note,
+    }
+    match = eval_summary.filter(pl.col("feature") == feat)
+    if len(match) > 0:
+        row["fdr_p"] = float(match["fdr_p"][0])
+        row["fdr_sig"] = bool(match["fdr_sig"][0])
+    ledger_rows.append(row)
+
+triage_ledger = pl.DataFrame(ledger_rows)
+triage_ledger.write_parquet(EVAL_DIR / "triage_ledger.parquet")
+print(f"Triage ledger saved: {EVAL_DIR / 'triage_ledger.parquet'}")
+print(triage_ledger.group_by("decision").len().sort("decision"))
+
+# %%
+# Save IC time series (long format)
+ic_ts_frames = []
+for feat, ts in ic_timeseries.items():
+    ic_ts_frames.append(ts.with_columns(pl.lit(feat).alias("feature")))
+
+if ic_ts_frames:
+    ic_ts_all = pl.concat(ic_ts_frames)
+    ic_ts_all.write_parquet(EVAL_DIR / "ic_timeseries.parquet")
+    print(f"IC time series saved: {EVAL_DIR / 'ic_timeseries.parquet'}")
+
+# %%
+# Write results JSON
+proceed_features = sorted(f for f, (d, _) in triage.items() if d == "PROCEED")
+revise_features = [f for f, (d, _) in triage.items() if d == "REVISE"]
+stop_features = [f for f, (d, _) in triage.items() if d == "STOP"]
+
+sorted_by_ic = sorted(ic_results.items(), key=lambda x: x[1].get("mean_ic") or 0, reverse=True)
+best = sorted_by_ic[0] if sorted_by_ic else ("n/a", {})
+worst = sorted_by_ic[-1] if sorted_by_ic else ("n/a", {})
+
+# %%
+print(f"\n{'=' * 60}")
+print(f"TRIAGE SUMMARY: {CASE_STUDY_ID}")
+print(f"{'=' * 60}")
+print(f"  PROCEED: {len(proceed_features)} features")
+print(f"  REVISE:  {len(revise_features)} features")
+print(f"  STOP:    {len(stop_features)} features")
+print("\nPROMOTED (PROCEED) features:")
+for f in proceed_features:
+    ic = ic_results[f]["mean_ic"]
+    t = ic_results[f]["t_stat"]
+    print(f"  {f:40s}  IC={ic:+.4f}  t={t:.2f}  [{families.get(f, '?')}]")
+
+# %% [markdown]
+# ### Quality Gate Verdict
+#
+# **Fit for modeling.** The triage promotes a broad set of features to PROCEED,
+# concentrated in the momentum and risk-adjusted momentum families. IC magnitudes
+# are moderate (0.03--0.04 range), consistent with monthly-horizon cross-sectional
+# equity signals over a 100-ETF universe. Date-level regime and macro features
+# are excluded from cross-sectional IC but carry forward as conditioning variables
+# for tree-based and interaction models in Ch11+.
+
+# %% [markdown]
+# ## Key Takeaways
+#
+# 1. **FDR correction is essential**: With 50+ features, naive p-values
+#    dramatically overstate the number of true signals. The inflation factor
+#    quantifies the gap between naive and corrected significance.
+#
+# 2. **HAC adjustment matters**: Overlapping 21-day returns create
+#    autocorrelation in the IC time series. Newey-West standard errors
+#    with bandwidth = 21 properly account for this.
+#
+# 3. **Date-level features require special handling**: Regime and macro
+#    features have zero cross-sectional IC by construction. Their value
+#    emerges through conditional interactions in Ch11 modeling.
+#
+# 4. **Redundancy within families**: Momentum and volatility features are
+#    highly correlated. Downstream modeling should cluster or select
+#    representative features from each family.
+#
+# **Next**: `05_linear.py` (Ch11) uses the triage ledger and promoted
+# features for ridge/lasso baseline modeling.

--- a/case_studies/etfs/README.md
+++ b/case_studies/etfs/README.md
@@ -1,0 +1,47 @@
+# Case Study: ETF Cross-Asset Exposures
+
+This case study applies the ML4T workflow to 100 exchange-traded funds spanning equities, fixed income, commodities, currencies, and real estate. ETFs offer a clean laboratory for cross-asset rotation: standardized pricing, deep liquidity, and broad asset-class coverage at a single rebalance cadence.
+
+The configuration is the most cost-favorable in the book — long-only rank-and-rebalance, monthly month-end decisions on a 21-day forward-return label, with a 5--15 bps-per-leg cost model. That cadence makes it the natural setting for the broadest model-family comparison in the book, and the recurring teaching point is the gap between rank correlation (IC) and portfolio Sharpe.
+
+> **Progressive release.** This directory currently ships the first five notebooks — the *research-design front half* of the pipeline: feasibility, labels, feature engineering, and feature evaluation. The modeling, backtest, portfolio-construction, cost, and risk stages (notebooks 06--18) are released progressively as their chapters go public.
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| Asset Class | Multi-asset ETFs |
+| Frequency | Daily data, monthly decisions |
+| Universe | 100 ETFs across 9 categories |
+| History | 2006--2025 |
+| Primary Label | fwd_ret_21d |
+| CV Folds | 8 (10Y train, 1Y val) |
+| Cost Model | Material (5--15 bps per leg) |
+
+## Pipeline (released so far)
+
+| Stage | Notebook | Chapter | Description |
+|-------|----------|---------|-------------|
+| Feasibility | [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) | Ch6 | Universe breadth, point-in-time eligibility, horizon-cost feasibility, walk-forward demonstration |
+| Labels | [`02_labels`](02_labels.ipynb) | Ch7 | 21-day and 5-day forward returns with walk-forward splits |
+| Features | [`03_financial_features`](03_financial_features.ipynb) | Ch8 | Momentum, volatility, and cross-asset ranking features |
+| Temporal | [`04_model_based_features`](04_model_based_features.ipynb) | Ch9 | ARIMA, HMM, and spectral features from walk-forward fits |
+| Evaluation | [`05_evaluation`](05_evaluation.ipynb) | Ch7--9 | Feature-label IC diagnostics across all engineered features |
+
+The notebooks run in order: `01` establishes that the universe is tradeable, `02` writes the label parquet files and the walk-forward CV configuration, `03` and `04` write the feature parquet files, and `05` reads all three to evaluate feature-label information coefficients.
+
+## Running
+
+```bash
+# From repo root — first download the free ETF data (Yahoo Finance, no API key)
+uv run python data/etfs/market/download.py
+
+# Then run the research-design front half in order
+uv run python case_studies/etfs/01_feasibility_analysis.py
+uv run python case_studies/etfs/02_labels.py
+uv run python case_studies/etfs/03_financial_features.py
+uv run python case_studies/etfs/04_model_based_features.py
+uv run python case_studies/etfs/05_evaluation.py
+```
+
+Each notebook is paired with a Jupytext `.py` source of record; open the `.ipynb` for the rendered, executed version. Generated labels, features, and reports are written under `case_studies/etfs/` and are git-ignored — they are reproduced by running the notebooks.


### PR DESCRIPTION
Releases the first five ETF case-study notebooks — the **research-design front half** of the pipeline — into the public repo. Gates the ML4T: Foundations Week-1 go-live (lectures 7 & 8 send students into `01_feasibility_analysis`).

## What's included
| Notebook | Chapter | Stage |
|---|---|---|
| `01_feasibility_analysis` | Ch6 | Universe breadth, point-in-time eligibility, horizon-cost feasibility, walk-forward demo |
| `02_labels` | Ch7 | 21-day / 5-day forward returns + walk-forward CV config |
| `03_financial_features` | Ch8 | Momentum, volatility, cross-asset ranking features |
| `04_model_based_features` | Ch9 | ARIMA / HMM / spectral features from walk-forward fits |
| `05_evaluation` | Ch7–9 | Feature-label IC diagnostics |

Plus a scope-trimmed `case_studies/etfs/README.md` (only these five stages; a progressive-release note points to the later stages). The modeling/backtest/portfolio/cost/risk notebooks (06–18) follow as their chapters go public.

## Verification
Ran all five end-to-end in the public environment against the free ETF data (`data/etfs/market/download.py`) and the `ml4t-*` PyPI packages — every stage exits 0, in order. Grounded feasibility numbers reproduce (median |21d| = 2.85%, edge-to-cost ≈ 14× at 20 bps). Pre-commit clean (ruff, format, py-compile, notebook-sync). Generated `labels/`, `features/`, and reports are git-ignored and reproduced by running the notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)