### PR TITLE
ci: gate what ships — run on push to main, and run the pair-sync guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -342,9 +342,16 @@ jobs:
         with:
           version: "latest"
       - name: Install guard deps
-        run: uv pip install --system jupytext==1.19.3 pytest nbformat
+        # jupytext only: check_notebook_pair_sync.py shells out to the `jupytext`
+        # binary, so it must be on PATH. Deliberately not the project env — this
+        # stays a ~1-minute gate.
+        run: |
+          uv venv --python 3.14
+          uv pip install jupytext==1.19.3 pytest nbformat
       - name: Notebook pairs open in JupyterLab (#372 regression gate)
-        run: python scripts/check_notebook_pair_sync.py
+        run: |
+          source .venv/bin/activate
+          python scripts/check_notebook_pair_sync.py
       # test_no_machine_specific_paths is deselected, not skipped: it is RED today
       # (97 `/home/stefan/...` leaks across 46 notebooks, incl. shipped Ch1
       # factor_regimes). The leaks are in outputs — cosmetic, not breakage — so
@@ -355,6 +362,7 @@ jobs:
       # line. Tracked so it cannot be quietly forgotten.
       - name: Notebook output hygiene
         run: |
+          source .venv/bin/activate
           python -m pytest tests/test_notebook_output_hygiene.py -q \
             --deselect tests/test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,24 @@
 #
 # Trigger policy:
 #   - PR: incremental (path-filtered, only changed chapters)
+#   - Push to main: incremental (same path filter as PR) — see below
 #   - Weekly: full suite on schedule (Monday 6 AM UTC)
 #   - After Docker Publish: full suite (workflow_run trigger)
 #   - Manual: workflow_dispatch with optional run_all flag
-#   - Push to main: NOT triggered (conserves minutes)
+#
+# Push to main was previously NOT triggered, to conserve minutes. Exports land on
+# main as pushes, so nothing CI ran had ever seen what shipped: issue #372 (59 of
+# 122 shipped notebooks would not open in JupyterLab) reached a reader through
+# that gap, and the weekly cron is up to 7 days late. The push run is
+# path-filtered exactly like the PR run, so the marginal cost is one duplicate
+# run per merge — cheaper than one reader-found defect.
 
 name: Tests
 
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
   schedule:
     - cron: '0 6 * * 1'   # Weekly Monday 6 AM UTC
@@ -308,6 +317,46 @@ jobs:
         run: uvx ruff@0.15.8 check utils/ data/ tests/
       - name: Ruff format
         run: uvx ruff@0.15.8 format --check utils/ data/ tests/
+
+  # ---------------------------------------------------------------------------
+  # Reader-facing guards. Always-on, never path-filtered, no Docker, ~1 minute.
+  #
+  # Every other job in this workflow asks "does the notebook run?". None asked
+  # "can a reader open it?" — so issue #372 was invisible to the entire suite
+  # while 59 of 122 shipped notebooks raised File Load Error in JupyterLab.
+  #
+  # check_notebook_pair_sync.py is that missing check, and it already existed:
+  # it was wired into .pre-commit-config.yaml only, so it gated commits and not
+  # pushes. Exports reach main as pushes. This job is where it actually gates.
+  #
+  # Unfiltered by design: a desynced pair is caused by tooling that touches many
+  # chapters at once (papermill metadata, ruff-format, a partial export), so
+  # "only test what changed" is precisely the wrong scope for it.
+  # ---------------------------------------------------------------------------
+  guards:
+    name: guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Install guard deps
+        run: uv pip install --system jupytext==1.19.3 pytest nbformat
+      - name: Notebook pairs open in JupyterLab (#372 regression gate)
+        run: python scripts/check_notebook_pair_sync.py
+      # test_no_machine_specific_paths is deselected, not skipped: it is RED today
+      # (97 `/home/stefan/...` leaks across 46 notebooks, incl. shipped Ch1
+      # factor_regimes). The leaks are in outputs — cosmetic, not breakage — so
+      # they do not justify holding this gate back; but the fix is NOT to run
+      # sanitize_notebook_paths.py, which rewrites source code (it turned a real
+      # Docker mount path in ch02/16_provider_comparison into a relative path).
+      # Fix = make the sanitizer outputs-only and JSON-aware, then delete this
+      # line. Tracked so it cannot be quietly forgotten.
+      - name: Notebook output hygiene
+        run: |
+          python -m pytest tests/test_notebook_output_hygiene.py -q \
+            --deselect tests/test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,


### PR DESCRIPTION
## Why

CI never ran on what readers actually get.

`test.yml` triggered on `pull_request`, `schedule`, `workflow_run` and `workflow_dispatch` — **but not on `push`**, deliberately ("conserves minutes"). Exports land on `main` as direct pushes, so the only net under shipped code was the weekly cron, up to 7 days late.

That is precisely the #372 timeline: 59 of 122 shipped notebooks would not open in JupyterLab, shipped in `d6f4f70`, and **a reader found it, not us**. Of the six defects reported since this repo went public on Jun 19, readers found five (#357, #358, #361, #369, #372); CI found one (#370).

## What

**1. `push: [main]` trigger.** Path-filtered exactly like the PR run, so the marginal cost is one duplicate run per merge — cheaper than one reader-found defect.

**2. A `guards` job** that runs `check_notebook_pair_sync.py` repo-wide. ~1 minute, native, no Docker, never path-filtered.

The check is **not new**. It already existed and it works — verified against the canonical repo, where it catches all 37 unopenable notebooks. It was wired into `.pre-commit-config.yaml` *only*, so it gated commits and never pushes. Every other job in this workflow asks "does the notebook run?" — none asked "**can a reader open it?**". That is why #372 was invisible to the entire test suite.

Unfiltered by design: desynced pairs are caused by tooling that touches many chapters at once (papermill metadata, `ruff-format`, a partial export), so "test only what changed" is exactly the wrong scope.

## Verification

Reproduced the reader's real path — JupyterLab's jupytext contents manager, not a diff proxy — across this tree:

```
notebooks checked : 122
UNOPENABLE        : 0
```

Both guard steps pass locally exactly as CI runs them (`2 passed, 1 deselected`).

## The deselected test

`test_no_machine_specific_paths_in_committed_notebooks` is **deselected, not skipped**, with the reason inline. It is red today (97 `/home/stefan/...` leaks across 46 notebooks, including shipped Ch1 `factor_regimes`). The leaks are in **outputs** — cosmetic, not breakage — so they don't justify holding this gate back. The obvious fix is *not* to run `sanitize_notebook_paths.py`: that script rewrites **source code** (it turned a real Docker mount path in `ch02/16_provider_comparison` into a relative path). Fix = make the sanitizer outputs-only and JSON-aware, then delete the deselect line.

## Follow-up (not in this PR)

Once this is green on `main`, `guards` should become a **required status check** with `enforce_admins: true`. Requiring it before it exists would brick `main`, hence the ordering.

⚠️ **9 notebooks in the canonical repo are unopenable and not covered by any test** (`KNOWN_DESYNCED` pins only 28, covering the empty-tag cause alone) — in Ch20, Ch24 and 5 case studies. They are exactly the Beat 5+ shipping set and must be cleared before those chapters ship, or #372 repeats at launch.