### PR TITLE
Enforce sealed-holdout boundary in feature selection; fix Viterbi look-ahead in regime features

### DIFF
--- a/08_financial_features/05_feature_selection.py
+++ b/08_financial_features/05_feature_selection.py
@@ -57,12 +57,14 @@
 """Feature Selection and Deduplication — reduce feature candidates to a focused production-ready set."""
 
 import warnings
+from datetime import date
 
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 import seaborn as sns
 import statsmodels.api as sm
+import yaml
 from ml4t.diagnostic.metrics import pooled_ic
 from scipy.cluster.hierarchy import fcluster, leaves_list, linkage
 from scipy.spatial.distance import squareform
@@ -101,9 +103,24 @@ if not FEATURES_PATH.exists():
 features_df = pl.read_parquet(FEATURES_PATH)
 prices_df = load_etfs()
 
-# Apply date filter
-features_df = features_df.filter(pl.col("timestamp") >= pl.lit(START_DATE).str.to_date())
-prices_df = prices_df.filter(pl.col("timestamp") >= pl.lit(START_DATE).str.to_date())
+# Holdout boundary: feature selection is a development decision, and the
+# sealed holdout (setup.yaml `evaluation.holdout_start`; see the rule in
+# 06_strategy_definition/02_cv_foundations) must not inform it. Every step
+# below — IC ranking, BH-FDR, stability selection, ML importance — sees only
+# pre-holdout rows, and the forward-return labels computed from the filtered
+# prices never span into the holdout.
+setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
+HOLDOUT_START = date.fromisoformat(setup["evaluation"]["holdout_start"])
+
+# Apply date filters: development window only ([START_DATE, HOLDOUT_START))
+features_df = features_df.filter(
+    (pl.col("timestamp") >= pl.lit(START_DATE).str.to_date())
+    & (pl.col("timestamp") < HOLDOUT_START)
+)
+prices_df = prices_df.filter(
+    (pl.col("timestamp") >= pl.lit(START_DATE).str.to_date())
+    & (pl.col("timestamp") < HOLDOUT_START)
+)
 
 if MAX_SYMBOLS > 0:
     top_symbols = (
@@ -127,6 +144,7 @@ labels_df = (
 
 print(f"Features: {features_df.shape}")
 print(f"Labels: {labels_df.shape}")
+print(f"Development window: {START_DATE} to {HOLDOUT_START} (holdout sealed)")
 
 # %% tags=[]
 all_feature_cols = [c for c in features_df.columns if c not in ["timestamp", "symbol"]]

--- a/08_financial_features/06_robustness_sensitivity.py
+++ b/08_financial_features/06_robustness_sensitivity.py
@@ -52,9 +52,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
+import yaml
 from ml4t.diagnostic.metrics import pooled_ic
 from plotly.subplots import make_subplots
 
+from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
 from utils.style import COLORS  # activates the ml4t Plotly template on import
 
@@ -76,9 +78,24 @@ from data import load_etfs
 
 etfs = load_etfs()
 
+# Sealed-holdout boundary (setup.yaml `evaluation.holdout_start`). Parameter
+# sweeps and robustness diagnostics are development decisions; the sealed
+# holdout must not inform them (see the rule in
+# 06_strategy_definition/02_cv_foundations). Clamp the analysis window so an
+# END_DATE override can never reach into the holdout — every IC below (sweep,
+# RAS, regime-conditional, implementation variants) sees only pre-holdout data.
+setup = yaml.safe_load(
+    (get_case_study_dir("etfs") / "config" / "setup.yaml").read_text()
+)
+HOLDOUT_START = setup["evaluation"]["holdout_start"]
+end_date = min(
+    datetime.strptime(END_DATE, "%Y-%m-%d"),
+    datetime.strptime(HOLDOUT_START, "%Y-%m-%d"),
+)
+
 etfs_filtered = etfs.filter(
     (pl.col("timestamp") >= datetime.strptime(START_DATE, "%Y-%m-%d"))
-    & (pl.col("timestamp") < datetime.strptime(END_DATE, "%Y-%m-%d"))
+    & (pl.col("timestamp") < end_date)
 ).sort(["symbol", "timestamp"])
 
 print(f"ETF data: {len(etfs_filtered):,} rows")

--- a/09_model_based_features/06_path_signatures.py
+++ b/09_model_based_features/06_path_signatures.py
@@ -177,12 +177,15 @@ def create_paths_and_targets(
         targets: Forward returns
         dates: End dates for each window
     """
-    # Compute returns and normalize prices
+    # Compute returns and normalize prices.
+    # NOTE: any volume channel added to the path must be normalized causally
+    # (expanding or rolling stats) — a full-sample z-score like
+    # (volume - volume.mean()) / volume.std() would leak future volume into
+    # every window.
     symbol_df = symbol_df.sort("timestamp")
     symbol_df = symbol_df.with_columns(
         ret=pl.col("close").pct_change(),
         log_ret=pl.col("close").log().diff(),
-        norm_vol=(pl.col("volume") - pl.col("volume").mean()) / pl.col("volume").std(),
     ).drop_nulls()
 
     # Compute forward returns for targets
@@ -390,21 +393,31 @@ print(f"Lag features dimension: {lag_features.shape[1]}")
 # 3. Combined (signatures + lags)
 
 # %%
-# Split data temporally (avoid look-ahead)
+# Split data temporally (avoid look-ahead). Adjacent samples come from
+# overlapping windows: consecutive paths share up to `window_size - 1` rows and
+# each target spans `horizon` rows beyond its window, so we purge
+# `window_size + horizon - 1` samples at each split boundary to keep
+# train/val/test informationally disjoint (the label-buffer rule from
+# 06_strategy_definition/02_cv_foundations).
+PURGE = WINDOW_SIZE + FORECAST_HORIZON - 1
 train_size = int(0.7 * len(paths))
 val_size = int(0.15 * len(paths))
 
+val_start = train_size + PURGE
+val_end = val_start + val_size
+test_start = val_end + PURGE
+
 X_lag_train = lag_features[:train_size]
-X_lag_val = lag_features[train_size : train_size + val_size]
-X_lag_test = lag_features[train_size + val_size :]
+X_lag_val = lag_features[val_start:val_end]
+X_lag_test = lag_features[test_start:]
 
 X_sig_train = logsignatures[:train_size]
-X_sig_val = logsignatures[train_size : train_size + val_size]
-X_sig_test = logsignatures[train_size + val_size :]
+X_sig_val = logsignatures[val_start:val_end]
+X_sig_test = logsignatures[test_start:]
 
 y_train = targets[:train_size]
-y_val = targets[train_size : train_size + val_size]
-y_test = targets[train_size + val_size :]
+y_val = targets[val_start:val_end]
+y_test = targets[test_start:]
 
 # Combined features
 X_comb_train = np.hstack([X_lag_train, X_sig_train])

--- a/09_model_based_features/11_hmm_regimes.py
+++ b/09_model_based_features/11_hmm_regimes.py
@@ -899,7 +899,8 @@ plt.show()
 # %% [markdown]
 # ## Save Regime Features
 #
-# Save regime states for downstream chapters (Ch12 GBM, Ch18 portfolio).
+# Save regime states as a chapter demonstration artifact (see the caveat below
+# for why case-study pipelines must not read it).
 # The cross-join below broadcasts SPY-derived regime states to all symbols
 # in the case study universe - a simplification appropriate for market-level
 # regime features. Per-asset regime models would require individual HMM fits.
@@ -913,6 +914,14 @@ plt.show()
 # strictly live pipeline re-fits the model walk-forward; here we keep a single fit
 # for clarity, and the filtered inference is the part that most affects backtest
 # realism.
+#
+# Because of that parameter-level look-ahead, the artifact filename carries a
+# `_fullsample_demo` suffix: it is a chapter demonstration and **must not be
+# consumed by case-study or holdout-evaluated pipelines** — its EM parameters
+# saw the sealed holdout period. The lookahead-safe version of these features
+# (HMM refit per CV fold, filtered probabilities extracted per fold) is built
+# in `case_studies/etfs/04_model_based_features.py`; downstream chapters should
+# read that per-fold artifact instead.
 
 # %%
 MODEL_DIR = CASE_DIR / "models" / "time_series"
@@ -968,9 +977,11 @@ regime_df = regime_df.select(
     ]
 )
 
-output_path = MODEL_DIR / "regime_states.parquet"
+# `_fullsample_demo`: EM parameters saw the full sample (see caveat above) —
+# not for case-study/holdout-evaluated consumption.
+output_path = MODEL_DIR / "regime_states_fullsample_demo.parquet"
 regime_df.write_parquet(output_path)
-print(f"Saved regime states: {regime_df.shape}")
+print(f"Saved regime states (full-sample demo): {regime_df.shape}")
 
 # %% [markdown]
 # ## Key Takeaways

--- a/09_model_based_features/13_regime_as_feature.py
+++ b/09_model_based_features/13_regime_as_feature.py
@@ -198,9 +198,14 @@ hmm_model = GaussianHMM(
 )
 hmm_model.fit(X_hmm)
 
-# Get regime predictions using filtered (causal) probabilities
-df["regime"] = hmm_model.predict(X_hmm)
+# Filtered (causal) probabilities; hard states are their argmax so both are
+# consistent and use only past/current observations. We deliberately do NOT
+# use `hmm_model.predict(X_hmm)`: that is Viterbi global decoding, which
+# conditions on the entire sample (including future observations) and must
+# not feed test-time expert routing (see 11_hmm_regimes, which saves
+# argmax-of-filtered states for the same reason).
 regime_probs = compute_filtered_probs(hmm_model, X_hmm)
+df["regime"] = regime_probs.argmax(axis=1)
 
 # Label states by volatility (ensure consistent labeling)
 regime_vols = df.groupby("regime")["volatility"].mean()
@@ -257,8 +262,10 @@ X_base = df[base_features].values
 X_regime = df[regime_features].values
 y = df["target"].values
 
-# Time-series cross-validation
-tscv = TimeSeriesSplit(n_splits=N_SPLITS)
+# Time-series cross-validation. gap=5 purges the 5 bars whose forward-return
+# target (shift(-5).rolling(5)) overlaps the test fold — see the label-buffer
+# (purge) discussion in 06_strategy_definition/02_cv_foundations.
+tscv = TimeSeriesSplit(n_splits=N_SPLITS, gap=5)
 
 # Scale features
 scaler_base = StandardScaler()

--- a/case_studies/etfs/03_financial_features.py
+++ b/case_studies/etfs/03_financial_features.py
@@ -43,10 +43,12 @@
 import itertools
 import os
 import warnings
+from datetime import date
 
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
+import yaml
 from ml4t.diagnostic.evaluation.stats import benjamini_hochberg_fdr
 from ml4t.diagnostic.metrics import compute_ic_hac_stats
 from ml4t.engineer.features.momentum import adx, aroon, cci, macd, rsi, stochastic
@@ -669,12 +671,22 @@ print(f"  {len(features):,} rows, {features['symbol'].n_unique()} assets")
 labels = pl.read_parquet(CASE_DIR / "labels" / "fwd_ret_21d.parquet")
 label_col = "fwd_ret_21d"
 
+# Holdout boundary: feature evaluation is a development decision, so the
+# sealed holdout (setup.yaml `evaluation.holdout_start`; see the rule in
+# 06_strategy_definition/02_cv_foundations) must not inform which features
+# look predictive. The label parquet spans the full sample, so restrict the
+# joined evaluation panel to train+validation rows — mirroring the
+# baseline-IC scoping in `02_labels`.
+setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
+holdout_start = setup["evaluation"]["holdout_start"]
+
 eval_df = features.join(
     labels.select(["timestamp", "symbol", label_col]), on=["timestamp", "symbol"], how="inner"
-)
+).filter(pl.col("timestamp") < date.fromisoformat(holdout_start))
 print(
     f"Evaluation set: {len(eval_df):,} rows "
-    f"({eval_df['timestamp'].n_unique():,} dates x {eval_df['symbol'].n_unique()} assets)"
+    f"({eval_df['timestamp'].n_unique():,} dates x {eval_df['symbol'].n_unique()} assets, "
+    f"train+val only, < {holdout_start})"
 )
 
 # %% [markdown]

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -1,0 +1,98 @@
+"""Gate: feature-selection notebooks must scope development analysis pre-holdout.
+
+Feature selection, robustness sweeps, and feature evaluation are development
+decisions; the sealed holdout (``case_studies/etfs/config/setup.yaml`` ->
+``evaluation.holdout_start``) must not inform them (the rule taught in
+``06_strategy_definition/02_cv_foundations``). Regenerating the selection
+artifacts requires the full data downloads, so this test statically checks the
+notebook sources instead: each must read the holdout boundary from
+``setup.yaml`` and apply the holdout filter *before* its first IC computation.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+SETUP_YAML = REPO_ROOT / "case_studies" / "etfs" / "config" / "setup.yaml"
+
+# (notebook source, identifier marking its first IC computation). The filter
+# must be applied earlier in the file than this marker so no IC ranking,
+# BH-FDR discovery, stability selection, or importance ranking ever sees
+# holdout rows.
+HOLDOUT_SCOPED_NOTEBOOKS = [
+    ("08_financial_features/05_feature_selection.py", "ic_by_date"),
+    ("08_financial_features/06_robustness_sensitivity.py", "def compute_momentum_ic_series"),
+    ("case_studies/etfs/03_financial_features.py", "ic_matrix = np.full"),
+]
+
+
+def load_holdout_start() -> str:
+    setup = yaml.safe_load(SETUP_YAML.read_text())
+    return setup["evaluation"]["holdout_start"]
+
+
+def test_setup_yaml_declares_sealed_holdout() -> None:
+    """The holdout window is declared, ISO-formatted, and non-empty."""
+    setup = yaml.safe_load(SETUP_YAML.read_text())
+    holdout_start = date.fromisoformat(setup["evaluation"]["holdout_start"])
+    holdout_end = date.fromisoformat(setup["evaluation"]["holdout_end"])
+    assert holdout_start < holdout_end
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "first_ic_marker"),
+    HOLDOUT_SCOPED_NOTEBOOKS,
+    ids=[rel_path for rel_path, _ in HOLDOUT_SCOPED_NOTEBOOKS],
+)
+def test_holdout_filter_precedes_first_ic_computation(
+    rel_path: str, first_ic_marker: str
+) -> None:
+    source = (REPO_ROOT / rel_path).read_text()
+
+    # The boundary must come from setup.yaml, not a hardcoded literal that can
+    # silently drift from the case-study config.
+    assert "setup.yaml" in source, f"{rel_path}: holdout boundary must be read from setup.yaml"
+    assert "holdout_start" in source, (
+        f"{rel_path}: must read evaluation.holdout_start from setup.yaml"
+    )
+
+    ic_pos = source.find(first_ic_marker)
+    assert ic_pos != -1, (
+        f"{rel_path}: first-IC marker {first_ic_marker!r} not found — "
+        "update HOLDOUT_SCOPED_NOTEBOOKS if the notebook was restructured"
+    )
+
+    filter_pos = source.upper().find("HOLDOUT_START")
+    assert 0 <= filter_pos < ic_pos, (
+        f"{rel_path}: the holdout filter must be applied before the first IC "
+        "computation so selection decisions never see the sealed holdout"
+    )
+
+
+def test_selected_features_artifact_stops_before_holdout() -> None:
+    """If the Ch8 selection artifact has been regenerated locally, its feature
+    panel must not extend into the sealed holdout."""
+    pl = pytest.importorskip("polars")
+
+    # Production location of get_output_dir(8, "feature_selection") from
+    # 05_feature_selection.py: {chapter_dir}/output/{strategy_id}/.
+    artifact = (
+        REPO_ROOT / "08_financial_features" / "output" / "feature_selection"
+        / "features_selected.parquet"
+    )
+    if not artifact.exists():
+        pytest.skip("selection artifact not generated locally (requires full data)")
+
+    holdout_start = date.fromisoformat(load_holdout_start())
+    max_ts = pl.scan_parquet(artifact).select(pl.col("timestamp").max()).collect().item()
+    assert max_ts is not None
+    max_date = max_ts.date() if hasattr(max_ts, "date") else max_ts
+    assert max_date < holdout_start, (
+        f"features_selected.parquet extends to {max_date}, at/after the sealed "
+        f"holdout start {holdout_start} — feature selection saw holdout data"
+    )


### PR DESCRIPTION
## Summary

This PR fixes protocol-consistency leaks found during a systematic audit. The repo's methodological infrastructure (purged walk-forward CV, HAC ICs, FDR corrections, the sealed-holdout rule in 06/02) is excellent — these fixes close the places where individual notebooks drift from the protocol the book itself teaches.

### Fixes

1. **Sealed holdout used in feature selection** — `08_financial_features/05_feature_selection.py`, `06_robustness_sensitivity.py`, and `case_studies/etfs/03_financial_features.py` §6 computed IC rankings, BH-FDR discoveries, stability selection, and importances on the full sample including the sealed holdout (`evaluation.holdout_start` in `setup.yaml`), then persisted the selected features for downstream chapters. Since feature selection is a development decision, any model later evaluated on the holdout inherits an optimistic bias. All three now read `holdout_start` from `setup.yaml` (mirroring the exact idiom `02_labels.py` already uses) and filter `timestamp < holdout_start` before any selection computation — labels built from the filtered prices can no longer span into the holdout.

2. **Viterbi decode mislabeled as filtered** — `09_model_based_features/13_regime_as_feature.py` derived hard regimes from `hmm_model.predict()` (full-sequence Viterbi, which conditions on future observations) under a comment claiming filtered/causal probabilities, and routed *test* samples to per-regime experts with those states. `11_hmm_regimes.py` explicitly warns against exactly this. Hard states are now the argmax of the filtered probabilities, with the comment corrected; the vol-based state relabeling flips states and probs consistently.

3. **Missing purge gap** — same notebook: the target is a 5-day forward return but `TimeSeriesSplit` had no `gap`, so the last 4 training labels at each fold boundary contained test-window returns. Now `gap=5`, with a comment linking the purge rationale in 06/02.

4. **Full-sample HMM artifact made self-describing** — `11_hmm_regimes.py`'s saved regime features (EM parameters fit on the full sample, disclosed in prose) renamed to `regime_states_fullsample_demo.parquet` with an explicit contamination caveat pointing to the clean per-fold implementation in `case_studies/etfs/04`. Repo-wide grep confirmed no readers of the old name.

5. **Path signatures** — removed the dormant full-sample volume z-score from the featurizer (the natural extension point where it would silently leak) with a causal-normalization warning; the 70/15/15 split now purges `window + horizon − 1` samples at both boundaries.

### Tests

New `tests/test_holdout_boundary.py` statically guards that the three fixed notebooks source the boundary from `setup.yaml` and filter before selection (4 passed, 1 by-design skip when the artifact isn't generated locally). Full suite: 437 passed; the one fix-related failure is `test_notebook_sync` correctly flagging the four edited `.py` files as newer than their stamped `.ipynb` twins — **the twins need a re-execution with production data to refresh provenance**, which I couldn't do locally. Happy to adjust if you'd prefer the twins regenerated differently. Hardcoded result narration (e.g., test IC values) will shift slightly on the next production run now that splits are purged; I didn't hand-edit any numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)