### PR TITLE
Reconcile code->public drift: export 40 stranded code-ahead files

### DIFF
--- a/02_financial_data_universe/20_storage_benchmark_file.ipynb
+++ b/02_financial_data_universe/20_storage_benchmark_file.ipynb
@@ -5,17 +5,17 @@
    "id": "47c946bd",
    "metadata": {
     "papermill": {
-     "duration": 0.001493,
-     "end_time": "2026-06-13T02:34:38.269210+00:00",
+     "duration": 0.004681,
+     "end_time": "2026-07-16T20:09:25.110507+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:38.267717+00:00",
+     "start_time": "2026-07-16T20:09:25.105826+00:00",
      "status": "completed"
     }
    },
    "source": [
     "# File-Format Storage Benchmark\n",
     "\n",
-    "**Docker image**: `benchmark`\n",
+    "**Environment**: the locked environment (`uv run`) — see Prerequisites below.\n",
     "\n",
     "**Purpose**: Compare CSV, Parquet, Feather (Arrow IPC), and HDF5 on the same\n",
     "1 M-row OHLCV panel along three axes — write time, read time (with forced\n",
@@ -24,8 +24,8 @@
     "\n",
     "**Learning objectives**:\n",
     "1. Generate a deterministic OHLCV benchmark panel at the L scale that\n",
-    "   chapter §2.4 cites (100 symbols × 10,000 daily rows = 1,000,000 rows).\n",
-    "2. Time write and read for each format with `gc.collect()` between runs.\n",
+    "   chapter §2.4 cites (100 symbols × 10,000 one-minute bars = 1,000,000 rows).\n",
+    "2. Time write and read for each format under one stated timing policy.\n",
     "3. Force materialization on Feather / HDF5 reads so memory-mapped or lazy\n",
     "   reads don't masquerade as instant.\n",
     "4. Quantify the columnar-projection win (read 2 columns vs 9).\n",
@@ -33,9 +33,18 @@
     "\n",
     "**Book reference**: §2.4 — file-based storage benchmarks.\n",
     "\n",
-    "**Prerequisites**: PyTables (HDF5 backend) is only present in the\n",
-    "`benchmark` Docker image. Run locally with `uv run`, or via\n",
-    "`docker compose --profile benchmark run --rm benchmark python …`."
+    "**Prerequisites**: PyTables (the HDF5 backend) ships in the locked\n",
+    "environment, so `uv run python 02_financial_data_universe/20_storage_benchmark_file.py`\n",
+    "from the repo root is all this notebook needs — no database services, unlike\n",
+    "`21_storage_benchmark_database`.\n",
+    "\n",
+    "> **Which environment produced the numbers**: the locked environment\n",
+    "> (`uv sync`, i.e. `uv.lock`), which is what §2.4 reports. The `benchmark`\n",
+    "> Docker image currently resolves a *newer* pandas than `uv.lock` pins, and\n",
+    "> pandas' newer string dtype makes PyTables store the low-cardinality\n",
+    "> `symbol` column about 8 bytes/row wider — enough to move the HDF5 file\n",
+    "> from ~71 MB to ~79 MB for the identical panel. CSV, Parquet, and Feather\n",
+    "> are unaffected. Run this notebook under `uv run` to reproduce §2.4."
    ]
   },
   {
@@ -43,10 +52,10 @@
    "id": "4a438217",
    "metadata": {
     "papermill": {
-     "duration": 0.001083,
-     "end_time": "2026-06-13T02:34:38.271900+00:00",
+     "duration": 0.004458,
+     "end_time": "2026-07-16T20:09:25.119620+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:38.270817+00:00",
+     "start_time": "2026-07-16T20:09:25.115162+00:00",
      "status": "completed"
     }
    },
@@ -60,16 +69,16 @@
    "id": "4012e71c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:38.275285Z",
-     "iopub.status.busy": "2026-06-13T02:34:38.275127Z",
-     "iopub.status.idle": "2026-06-13T02:34:38.277973Z",
-     "shell.execute_reply": "2026-06-13T02:34:38.277526Z"
+     "iopub.execute_input": "2026-07-16T20:09:25.126334Z",
+     "iopub.status.busy": "2026-07-16T20:09:25.126170Z",
+     "iopub.status.idle": "2026-07-16T20:09:25.129205Z",
+     "shell.execute_reply": "2026-07-16T20:09:25.128403Z"
     },
     "papermill": {
-     "duration": 0.005257,
-     "end_time": "2026-06-13T02:34:38.278324+00:00",
+     "duration": 0.006944,
+     "end_time": "2026-07-16T20:09:25.129765+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:38.273067+00:00",
+     "start_time": "2026-07-16T20:09:25.122821+00:00",
      "status": "completed"
     }
    },
@@ -88,16 +97,16 @@
    "id": "4670925a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:38.281082Z",
-     "iopub.status.busy": "2026-06-13T02:34:38.281015Z",
-     "iopub.status.idle": "2026-06-13T02:34:38.282965Z",
-     "shell.execute_reply": "2026-06-13T02:34:38.282566Z"
+     "iopub.execute_input": "2026-07-16T20:09:25.133999Z",
+     "iopub.status.busy": "2026-07-16T20:09:25.133910Z",
+     "iopub.status.idle": "2026-07-16T20:09:25.136031Z",
+     "shell.execute_reply": "2026-07-16T20:09:25.135517Z"
     },
     "papermill": {
-     "duration": 0.003803,
-     "end_time": "2026-06-13T02:34:38.283263+00:00",
+     "duration": 0.004556,
+     "end_time": "2026-07-16T20:09:25.136316+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:38.279460+00:00",
+     "start_time": "2026-07-16T20:09:25.131760+00:00",
      "status": "completed"
     },
     "tags": [
@@ -107,7 +116,7 @@
    "outputs": [],
    "source": [
     "# Production scale follows chapter §2.4 prose (\"L scale, ~1 M OHLCV rows,\n",
-    "# 100 MB in-memory\"). Override via Papermill for CI: BENCHMARK_SCALE = \"S\".\n",
+    "# 64 MB in-memory in Polars\"). Override via Papermill for CI: BENCHMARK_SCALE = \"S\".\n",
     "BENCHMARK_SCALE = \"L\""
    ]
   },
@@ -117,16 +126,16 @@
    "id": "8fd25bcc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:38.285956Z",
-     "iopub.status.busy": "2026-06-13T02:34:38.285889Z",
-     "iopub.status.idle": "2026-06-13T02:34:40.818103Z",
-     "shell.execute_reply": "2026-06-13T02:34:40.817452Z"
+     "iopub.execute_input": "2026-07-16T20:09:25.139677Z",
+     "iopub.status.busy": "2026-07-16T20:09:25.139616Z",
+     "iopub.status.idle": "2026-07-16T20:09:26.182186Z",
+     "shell.execute_reply": "2026-07-16T20:09:26.181706Z"
     },
     "papermill": {
-     "duration": 2.534262,
-     "end_time": "2026-06-13T02:34:40.818636+00:00",
+     "duration": 1.044709,
+     "end_time": "2026-07-16T20:09:26.182563+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:38.284374+00:00",
+     "start_time": "2026-07-16T20:09:25.137854+00:00",
      "status": "completed"
     }
    },
@@ -156,7 +165,8 @@
     "    force_materialize_polars,\n",
     "    generate_ohlcv_data,\n",
     "    save_benchmark_results,\n",
-    "    time_operation,\n",
+    "    time_read,\n",
+    "    time_write,\n",
     "    validate_result,\n",
     ")\n",
     "from utils.style import COLORS\n",
@@ -170,10 +180,45 @@
    "id": "22e4ac8e",
    "metadata": {
     "papermill": {
-     "duration": 0.001908,
-     "end_time": "2026-06-13T02:34:40.822718+00:00",
+     "duration": 0.001627,
+     "end_time": "2026-07-16T20:09:26.185589+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:40.820810+00:00",
+     "start_time": "2026-07-16T20:09:26.183962+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Timing Policy\n",
+    "\n",
+    "Every number below follows one policy, applied identically to all four\n",
+    "formats. A comparison that mixes policies across the things it compares is\n",
+    "not a comparison, so this is stated up front rather than left in the call\n",
+    "sites:\n",
+    "\n",
+    "- **Writes** (`time_write`) — a single shot, no warm-up run. Writing the\n",
+    "  panel is a once-per-dataset operation, so that is what we time.\n",
+    "- **Reads** (`time_read`) — the mean of `TIMING_RUNS` runs after one untimed\n",
+    "  warm-up run. **These are warm-cache numbers.** The file has just been\n",
+    "  written and re-read repeatedly, so it sits in the OS page cache.\n",
+    "\n",
+    "Warm-cache reads are the honest description of the *repeated-access* pattern\n",
+    "a research loop actually has, but they flatter memory-mapped formats: Feather\n",
+    "maps pages that are already resident, so its read number below is close to a\n",
+    "best case. A first read of a cold file off disk narrows the gap to Parquet,\n",
+    "and on a network or object store the compressed format usually wins outright\n",
+    "because it moves fewer bytes. Rankings here are for warm, local, repeated\n",
+    "reads — the caveat that §2.4 attaches to these figures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6559279",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001096,
+     "end_time": "2026-07-16T20:09:26.187826+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T20:09:26.186730+00:00",
      "status": "completed"
     }
    },
@@ -182,7 +227,10 @@
     "\n",
     "`generate_ohlcv_data` returns a deterministic OHLCV panel: per-symbol random\n",
     "walks under a fixed seed so format comparisons aren't muddled by data drift\n",
-    "across runs. At L scale that's 100 symbols × 10,000 rows = 1 M total rows."
+    "across runs. At L scale that's 100 symbols × 10,000 one-minute bars =\n",
+    "1 M total rows, laid out over 26 regular trading sessions (390 bars each), so\n",
+    "the panel carries the overnight and weekend gaps real minute data has. All\n",
+    "symbols share the session grid, as they do in any synchronized bar panel."
    ]
   },
   {
@@ -191,16 +239,16 @@
    "id": "ed3613e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:40.827127Z",
-     "iopub.status.busy": "2026-06-13T02:34:40.826959Z",
-     "iopub.status.idle": "2026-06-13T02:34:41.092792Z",
-     "shell.execute_reply": "2026-06-13T02:34:41.092239Z"
+     "iopub.execute_input": "2026-07-16T20:09:26.190756Z",
+     "iopub.status.busy": "2026-07-16T20:09:26.190603Z",
+     "iopub.status.idle": "2026-07-16T20:09:26.465853Z",
+     "shell.execute_reply": "2026-07-16T20:09:26.465360Z"
     },
     "papermill": {
-     "duration": 0.268628,
-     "end_time": "2026-06-13T02:34:41.093259+00:00",
+     "duration": 0.277491,
+     "end_time": "2026-07-16T20:09:26.466408+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:40.824631+00:00",
+     "start_time": "2026-07-16T20:09:26.188917+00:00",
      "status": "completed"
     }
    },
@@ -271,16 +319,16 @@
    "id": "e038ce37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:41.097273Z",
-     "iopub.status.busy": "2026-06-13T02:34:41.097148Z",
-     "iopub.status.idle": "2026-06-13T02:34:41.099549Z",
-     "shell.execute_reply": "2026-06-13T02:34:41.098993Z"
+     "iopub.execute_input": "2026-07-16T20:09:26.470039Z",
+     "iopub.status.busy": "2026-07-16T20:09:26.469959Z",
+     "iopub.status.idle": "2026-07-16T20:09:26.471513Z",
+     "shell.execute_reply": "2026-07-16T20:09:26.471282Z"
     },
     "papermill": {
-     "duration": 0.004872,
-     "end_time": "2026-06-13T02:34:41.099858+00:00",
+     "duration": 0.003936,
+     "end_time": "2026-07-16T20:09:26.471834+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:41.094986+00:00",
+     "start_time": "2026-07-16T20:09:26.467898+00:00",
      "status": "completed"
     }
    },
@@ -295,10 +343,10 @@
    "id": "a01d084a",
    "metadata": {
     "papermill": {
-     "duration": 0.001198,
-     "end_time": "2026-06-13T02:34:41.102313+00:00",
+     "duration": 0.001168,
+     "end_time": "2026-07-16T20:09:26.474264+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:41.101115+00:00",
+     "start_time": "2026-07-16T20:09:26.473096+00:00",
      "status": "completed"
     }
    },
@@ -315,16 +363,16 @@
    "id": "b656468e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:41.105385Z",
-     "iopub.status.busy": "2026-06-13T02:34:41.105248Z",
-     "iopub.status.idle": "2026-06-13T02:34:42.127074Z",
-     "shell.execute_reply": "2026-06-13T02:34:42.126655Z"
+     "iopub.execute_input": "2026-07-16T20:09:26.477093Z",
+     "iopub.status.busy": "2026-07-16T20:09:26.477021Z",
+     "iopub.status.idle": "2026-07-16T20:09:27.119476Z",
+     "shell.execute_reply": "2026-07-16T20:09:27.119135Z"
     },
     "papermill": {
-     "duration": 1.024324,
-     "end_time": "2026-06-13T02:34:42.127783+00:00",
+     "duration": 0.64463,
+     "end_time": "2026-07-16T20:09:27.120062+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:41.103459+00:00",
+     "start_time": "2026-07-16T20:09:26.475432+00:00",
      "status": "completed"
     }
    },
@@ -332,8 +380,7 @@
    "source": [
     "csv_path = BENCHMARK_DIR / f\"ohlcv_{ACTIVE_SCALE.lower()}.csv\"\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(lambda: ohlcv_df.write_csv(csv_path))\n",
+    "write_time, _ = time_write(lambda: ohlcv_df.write_csv(csv_path))\n",
     "csv_size = csv_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"CSV\", \"write\", write_time, csv_size, total_rows))\n",
     "\n",
@@ -342,8 +389,7 @@
     "    return force_materialize_polars(pl.read_csv(csv_path))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, csv_result = time_operation(read_csv_materialized)\n",
+    "read_time, csv_result = time_read(read_csv_materialized)\n",
     "validate_result(csv_result, total_rows, \"CSV read\")\n",
     "results.append(BenchmarkResult(\"CSV\", \"read\", read_time, csv_size, total_rows))\n",
     "\n",
@@ -352,8 +398,7 @@
     "    return force_materialize_polars(pl.read_csv(csv_path, columns=[\"close\", \"volume\"]))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "columnar_time, _ = time_operation(read_csv_columnar)\n",
+    "columnar_time, _ = time_read(read_csv_columnar)\n",
     "results.append(BenchmarkResult(\"CSV\", \"columnar_read\", columnar_time, csv_size, total_rows))"
    ]
   },
@@ -362,10 +407,10 @@
    "id": "bd7162c7",
    "metadata": {
     "papermill": {
-     "duration": 0.001883,
-     "end_time": "2026-06-13T02:34:42.131640+00:00",
+     "duration": 0.001235,
+     "end_time": "2026-07-16T20:09:27.122810+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:42.129757+00:00",
+     "start_time": "2026-07-16T20:09:27.121575+00:00",
      "status": "completed"
     }
    },
@@ -383,16 +428,16 @@
    "id": "68962a8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:42.134598Z",
-     "iopub.status.busy": "2026-06-13T02:34:42.134515Z",
-     "iopub.status.idle": "2026-06-13T02:34:42.861235Z",
-     "shell.execute_reply": "2026-06-13T02:34:42.860802Z"
+     "iopub.execute_input": "2026-07-16T20:09:27.125743Z",
+     "iopub.status.busy": "2026-07-16T20:09:27.125655Z",
+     "iopub.status.idle": "2026-07-16T20:09:27.594951Z",
+     "shell.execute_reply": "2026-07-16T20:09:27.594644Z"
     },
     "papermill": {
-     "duration": 0.729191,
-     "end_time": "2026-06-13T02:34:42.861975+00:00",
+     "duration": 0.47165,
+     "end_time": "2026-07-16T20:09:27.595640+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:42.132784+00:00",
+     "start_time": "2026-07-16T20:09:27.123990+00:00",
      "status": "completed"
     }
    },
@@ -400,8 +445,7 @@
    "source": [
     "parquet_path = BENCHMARK_DIR / f\"ohlcv_{ACTIVE_SCALE.lower()}.parquet\"\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(lambda: ohlcv_df.write_parquet(parquet_path))\n",
+    "write_time, _ = time_write(lambda: ohlcv_df.write_parquet(parquet_path))\n",
     "parquet_size = parquet_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"Parquet\", \"write\", write_time, parquet_size, total_rows))\n",
     "\n",
@@ -410,8 +454,7 @@
     "    return force_materialize_polars(pl.read_parquet(parquet_path))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, parquet_result = time_operation(read_parquet_materialized)\n",
+    "read_time, parquet_result = time_read(read_parquet_materialized)\n",
     "validate_result(parquet_result, total_rows, \"Parquet read\")\n",
     "results.append(BenchmarkResult(\"Parquet\", \"read\", read_time, parquet_size, total_rows))\n",
     "\n",
@@ -420,8 +463,7 @@
     "    return force_materialize_polars(pl.read_parquet(parquet_path, columns=[\"close\", \"volume\"]))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "columnar_time, _ = time_operation(read_parquet_columnar)\n",
+    "columnar_time, _ = time_read(read_parquet_columnar)\n",
     "results.append(BenchmarkResult(\"Parquet\", \"columnar_read\", columnar_time, parquet_size, total_rows))"
    ]
   },
@@ -430,10 +472,10 @@
    "id": "99fc4f44",
    "metadata": {
     "papermill": {
-     "duration": 0.002124,
-     "end_time": "2026-06-13T02:34:42.866556+00:00",
+     "duration": 0.001401,
+     "end_time": "2026-07-16T20:09:27.598515+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:42.864432+00:00",
+     "start_time": "2026-07-16T20:09:27.597114+00:00",
      "status": "completed"
     }
    },
@@ -452,16 +494,16 @@
    "id": "c18d145d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:42.871545Z",
-     "iopub.status.busy": "2026-06-13T02:34:42.871448Z",
-     "iopub.status.idle": "2026-06-13T02:34:43.694171Z",
-     "shell.execute_reply": "2026-06-13T02:34:43.693725Z"
+     "iopub.execute_input": "2026-07-16T20:09:27.601434Z",
+     "iopub.status.busy": "2026-07-16T20:09:27.601351Z",
+     "iopub.status.idle": "2026-07-16T20:09:28.115775Z",
+     "shell.execute_reply": "2026-07-16T20:09:28.115415Z"
     },
     "papermill": {
-     "duration": 0.826157,
-     "end_time": "2026-06-13T02:34:43.694845+00:00",
+     "duration": 0.517011,
+     "end_time": "2026-07-16T20:09:28.116733+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:42.868688+00:00",
+     "start_time": "2026-07-16T20:09:27.599722+00:00",
      "status": "completed"
     }
    },
@@ -469,8 +511,7 @@
    "source": [
     "feather_path = BENCHMARK_DIR / f\"ohlcv_{ACTIVE_SCALE.lower()}.feather\"\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(lambda: ohlcv_df.write_ipc(feather_path))\n",
+    "write_time, _ = time_write(lambda: ohlcv_df.write_ipc(feather_path))\n",
     "feather_size = feather_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"Feather\", \"write\", write_time, feather_size, total_rows))\n",
     "\n",
@@ -484,8 +525,7 @@
     "    return force_materialize_polars(pl.read_ipc(feather_path))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, feather_result = time_operation(read_feather_materialized)\n",
+    "read_time, feather_result = time_read(read_feather_materialized)\n",
     "validate_result(feather_result, total_rows, \"Feather read\")\n",
     "results.append(BenchmarkResult(\"Feather\", \"read\", read_time, feather_size, total_rows))\n",
     "\n",
@@ -494,8 +534,7 @@
     "    return force_materialize_polars(pl.read_ipc(feather_path, columns=[\"close\", \"volume\"]))\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "columnar_time, _ = time_operation(read_feather_columnar)\n",
+    "columnar_time, _ = time_read(read_feather_columnar)\n",
     "results.append(BenchmarkResult(\"Feather\", \"columnar_read\", columnar_time, feather_size, total_rows))"
    ]
   },
@@ -504,10 +543,10 @@
    "id": "25c44852",
    "metadata": {
     "papermill": {
-     "duration": 0.00163,
-     "end_time": "2026-06-13T02:34:43.698394+00:00",
+     "duration": 0.001241,
+     "end_time": "2026-07-16T20:09:28.119426+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:43.696764+00:00",
+     "start_time": "2026-07-16T20:09:28.118185+00:00",
      "status": "completed"
     }
    },
@@ -525,16 +564,16 @@
    "id": "3b572e8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:43.701286Z",
-     "iopub.status.busy": "2026-06-13T02:34:43.701189Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.759657Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.759059Z"
+     "iopub.execute_input": "2026-07-16T20:09:28.122359Z",
+     "iopub.status.busy": "2026-07-16T20:09:28.122272Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.898018Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.897591Z"
     },
     "papermill": {
-     "duration": 2.060553,
-     "end_time": "2026-06-13T02:34:45.760098+00:00",
+     "duration": 1.777895,
+     "end_time": "2026-07-16T20:09:29.898541+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:43.699545+00:00",
+     "start_time": "2026-07-16T20:09:28.120646+00:00",
      "status": "completed"
     }
    },
@@ -548,8 +587,7 @@
     "        store[\"ohlcv\"] = ohlcv_pandas\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(write_hdf5)\n",
+    "write_time, _ = time_write(write_hdf5)\n",
     "hdf5_size = hdf5_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"HDF5\", \"write\", write_time, hdf5_size, total_rows))\n",
     "\n",
@@ -560,8 +598,7 @@
     "    return force_materialize_pandas(df)\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, hdf5_result = time_operation(read_hdf5_materialized)\n",
+    "read_time, hdf5_result = time_read(read_hdf5_materialized)\n",
     "validate_result(hdf5_result, total_rows, \"HDF5 read\")\n",
     "results.append(BenchmarkResult(\"HDF5\", \"read\", read_time, hdf5_size, total_rows))\n",
     "# Fixed-format HDF5 has no column projection — record the full-read time\n",
@@ -574,10 +611,10 @@
    "id": "823dc6de",
    "metadata": {
     "papermill": {
-     "duration": 0.00221,
-     "end_time": "2026-06-13T02:34:45.763667+00:00",
+     "duration": 0.001241,
+     "end_time": "2026-07-16T20:09:29.901290+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.761457+00:00",
+     "start_time": "2026-07-16T20:09:29.900049+00:00",
      "status": "completed"
     }
    },
@@ -591,16 +628,16 @@
    "id": "2e681fee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.766637Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.766542Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.768717Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.768337Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.904412Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.904259Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.906945Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.906514Z"
     },
     "papermill": {
-     "duration": 0.004214,
-     "end_time": "2026-06-13T02:34:45.769052+00:00",
+     "duration": 0.004695,
+     "end_time": "2026-07-16T20:09:29.907195+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.764838+00:00",
+     "start_time": "2026-07-16T20:09:29.902500+00:00",
      "status": "completed"
     }
    },
@@ -626,16 +663,16 @@
    "id": "b8535111",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.771916Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.771845Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.775485Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.775040Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.910105Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.910033Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.912849Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.912579Z"
     },
     "papermill": {
-     "duration": 0.005522,
-     "end_time": "2026-06-13T02:34:45.775743+00:00",
+     "duration": 0.004683,
+     "end_time": "2026-07-16T20:09:29.913130+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.770221+00:00",
+     "start_time": "2026-07-16T20:09:29.908447+00:00",
      "status": "completed"
     }
    },
@@ -650,7 +687,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>size_mb</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Parquet&quot;</td><td>0.051717</td><td>40.128544</td><td>19.335995</td></tr><tr><td>&quot;Feather&quot;</td><td>0.061134</td><td>76.006204</td><td>16.357512</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.08524</td><td>71.067648</td><td>11.731587</td></tr><tr><td>&quot;CSV&quot;</td><td>0.097835</td><td>135.605212</td><td>10.221269</td></tr></tbody></table></div>"
+       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>size_mb</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Parquet&quot;</td><td>0.052873</td><td>40.129517</td><td>18.913138</td></tr><tr><td>&quot;Feather&quot;</td><td>0.054283</td><td>76.006204</td><td>18.421816</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.088784</td><td>71.067648</td><td>11.263237</td></tr><tr><td>&quot;CSV&quot;</td><td>0.105729</td><td>135.605212</td><td>9.458109</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 4)\n",
@@ -659,10 +696,10 @@
        "│ ---     ┆ ---      ┆ ---        ┆ ---                 │\n",
        "│ str     ┆ f64      ┆ f64        ┆ f64                 │\n",
        "╞═════════╪══════════╪════════════╪═════════════════════╡\n",
-       "│ Parquet ┆ 0.051717 ┆ 40.128544  ┆ 19.335995           │\n",
-       "│ Feather ┆ 0.061134 ┆ 76.006204  ┆ 16.357512           │\n",
-       "│ HDF5    ┆ 0.08524  ┆ 71.067648  ┆ 11.731587           │\n",
-       "│ CSV     ┆ 0.097835 ┆ 135.605212 ┆ 10.221269           │\n",
+       "│ Parquet ┆ 0.052873 ┆ 40.129517  ┆ 18.913138           │\n",
+       "│ Feather ┆ 0.054283 ┆ 76.006204  ┆ 18.421816           │\n",
+       "│ HDF5    ┆ 0.088784 ┆ 71.067648  ┆ 11.263237           │\n",
+       "│ CSV     ┆ 0.105729 ┆ 135.605212 ┆ 9.458109            │\n",
        "└─────────┴──────────┴────────────┴─────────────────────┘"
       ]
      },
@@ -686,16 +723,16 @@
    "id": "dad710a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.778702Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.778630Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.781900Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.781438Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.916023Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.915958Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.918368Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.918102Z"
     },
     "papermill": {
-     "duration": 0.005225,
-     "end_time": "2026-06-13T02:34:45.782207+00:00",
+     "duration": 0.004363,
+     "end_time": "2026-07-16T20:09:29.918773+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.776982+00:00",
+     "start_time": "2026-07-16T20:09:29.914410+00:00",
      "status": "completed"
     }
    },
@@ -710,7 +747,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.004539</td><td>220.311728</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.016443</td><td>60.81547</td></tr><tr><td>&quot;CSV&quot;</td><td>0.028844</td><td>34.668884</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.348754</td><td>2.867354</td></tr></tbody></table></div>"
+       "<small>shape: (4, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.005173</td><td>193.313144</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.016602</td><td>60.234726</td></tr><tr><td>&quot;CSV&quot;</td><td>0.033202</td><td>30.118839</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.364049</td><td>2.746881</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 3)\n",
@@ -719,10 +756,10 @@
        "│ ---     ┆ ---      ┆ ---                 │\n",
        "│ str     ┆ f64      ┆ f64                 │\n",
        "╞═════════╪══════════╪═════════════════════╡\n",
-       "│ Feather ┆ 0.004539 ┆ 220.311728          │\n",
-       "│ Parquet ┆ 0.016443 ┆ 60.81547            │\n",
-       "│ CSV     ┆ 0.028844 ┆ 34.668884           │\n",
-       "│ HDF5    ┆ 0.348754 ┆ 2.867354            │\n",
+       "│ Feather ┆ 0.005173 ┆ 193.313144          │\n",
+       "│ Parquet ┆ 0.016602 ┆ 60.234726           │\n",
+       "│ CSV     ┆ 0.033202 ┆ 30.118839           │\n",
+       "│ HDF5    ┆ 0.364049 ┆ 2.746881            │\n",
        "└─────────┴──────────┴─────────────────────┘"
       ]
      },
@@ -746,16 +783,16 @@
    "id": "6c63bf1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.785361Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.785244Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.788247Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.787889Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.921926Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.921854Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.924396Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.924085Z"
     },
     "papermill": {
-     "duration": 0.005019,
-     "end_time": "2026-06-13T02:34:45.788535+00:00",
+     "duration": 0.004638,
+     "end_time": "2026-07-16T20:09:29.924743+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.783516+00:00",
+     "start_time": "2026-07-16T20:09:29.920105+00:00",
      "status": "completed"
     }
    },
@@ -770,7 +807,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.000944</td><td>1059.261412</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.004249</td><td>235.335149</td></tr><tr><td>&quot;CSV&quot;</td><td>0.016542</td><td>60.451834</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.348754</td><td>2.867354</td></tr></tbody></table></div>"
+       "<small>shape: (4, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>throughput_M_rows_s</th></tr><tr><td>str</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.000882</td><td>1134.128876</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.003791</td><td>263.769748</td></tr><tr><td>&quot;CSV&quot;</td><td>0.022837</td><td>43.788718</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.364049</td><td>2.746881</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 3)\n",
@@ -779,10 +816,10 @@
        "│ ---     ┆ ---      ┆ ---                 │\n",
        "│ str     ┆ f64      ┆ f64                 │\n",
        "╞═════════╪══════════╪═════════════════════╡\n",
-       "│ Feather ┆ 0.000944 ┆ 1059.261412         │\n",
-       "│ Parquet ┆ 0.004249 ┆ 235.335149          │\n",
-       "│ CSV     ┆ 0.016542 ┆ 60.451834           │\n",
-       "│ HDF5    ┆ 0.348754 ┆ 2.867354            │\n",
+       "│ Feather ┆ 0.000882 ┆ 1134.128876         │\n",
+       "│ Parquet ┆ 0.003791 ┆ 263.769748          │\n",
+       "│ CSV     ┆ 0.022837 ┆ 43.788718           │\n",
+       "│ HDF5    ┆ 0.364049 ┆ 2.746881            │\n",
        "└─────────┴──────────┴─────────────────────┘"
       ]
      },
@@ -806,16 +843,16 @@
    "id": "3b64705b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.791581Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.791519Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.795556Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.795143Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.928210Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.928143Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.931966Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.931736Z"
     },
     "papermill": {
-     "duration": 0.006001,
-     "end_time": "2026-06-13T02:34:45.795825+00:00",
+     "duration": 0.00598,
+     "end_time": "2026-07-16T20:09:29.932351+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.789824+00:00",
+     "start_time": "2026-07-16T20:09:29.926371+00:00",
      "status": "completed"
     }
    },
@@ -830,7 +867,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>columnar_time_s</th><th>speedup</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.004539</td><td>0.000944</td><td>4.808012</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.016443</td><td>0.004249</td><td>3.869659</td></tr><tr><td>&quot;CSV&quot;</td><td>0.028844</td><td>0.016542</td><td>1.743691</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.348754</td><td>0.348754</td><td>1.0</td></tr></tbody></table></div>"
+       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>format</th><th>time_s</th><th>columnar_time_s</th><th>speedup</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;Feather&quot;</td><td>0.005173</td><td>0.000882</td><td>5.866797</td></tr><tr><td>&quot;Parquet&quot;</td><td>0.016602</td><td>0.003791</td><td>4.379031</td></tr><tr><td>&quot;CSV&quot;</td><td>0.033202</td><td>0.022837</td><td>1.453865</td></tr><tr><td>&quot;HDF5&quot;</td><td>0.364049</td><td>0.364049</td><td>1.0</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 4)\n",
@@ -839,10 +876,10 @@
        "│ ---     ┆ ---      ┆ ---             ┆ ---      │\n",
        "│ str     ┆ f64      ┆ f64             ┆ f64      │\n",
        "╞═════════╪══════════╪═════════════════╪══════════╡\n",
-       "│ Feather ┆ 0.004539 ┆ 0.000944        ┆ 4.808012 │\n",
-       "│ Parquet ┆ 0.016443 ┆ 0.004249        ┆ 3.869659 │\n",
-       "│ CSV     ┆ 0.028844 ┆ 0.016542        ┆ 1.743691 │\n",
-       "│ HDF5    ┆ 0.348754 ┆ 0.348754        ┆ 1.0      │\n",
+       "│ Feather ┆ 0.005173 ┆ 0.000882        ┆ 5.866797 │\n",
+       "│ Parquet ┆ 0.016602 ┆ 0.003791        ┆ 4.379031 │\n",
+       "│ CSV     ┆ 0.033202 ┆ 0.022837        ┆ 1.453865 │\n",
+       "│ HDF5    ┆ 0.364049 ┆ 0.364049        ┆ 1.0      │\n",
        "└─────────┴──────────┴─────────────────┴──────────┘"
       ]
      },
@@ -872,10 +909,10 @@
    "id": "823d91ad",
    "metadata": {
     "papermill": {
-     "duration": 0.00133,
-     "end_time": "2026-06-13T02:34:45.798514+00:00",
+     "duration": 0.001785,
+     "end_time": "2026-07-16T20:09:29.935712+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.797184+00:00",
+     "start_time": "2026-07-16T20:09:29.933927+00:00",
      "status": "completed"
     }
    },
@@ -891,16 +928,16 @@
    "id": "42d88031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.801830Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.801753Z",
-     "iopub.status.idle": "2026-06-13T02:34:45.803944Z",
-     "shell.execute_reply": "2026-06-13T02:34:45.803558Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.940242Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.940166Z",
+     "iopub.status.idle": "2026-07-16T20:09:29.942051Z",
+     "shell.execute_reply": "2026-07-16T20:09:29.941770Z"
     },
     "papermill": {
-     "duration": 0.004341,
-     "end_time": "2026-06-13T02:34:45.804230+00:00",
+     "duration": 0.004623,
+     "end_time": "2026-07-16T20:09:29.942405+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.799889+00:00",
+     "start_time": "2026-07-16T20:09:29.937782+00:00",
      "status": "completed"
     }
    },
@@ -909,7 +946,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Feather raw handle (memory-mapped, not materialized): 0.0022 s\n"
+      "Feather raw handle (memory-mapped, not materialized): 0.0003 s\n"
      ]
     }
    ],
@@ -922,10 +959,10 @@
    "id": "6dcdd4fe",
    "metadata": {
     "papermill": {
-     "duration": 0.00129,
-     "end_time": "2026-06-13T02:34:45.806894+00:00",
+     "duration": 0.001439,
+     "end_time": "2026-07-16T20:09:29.945623+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.805604+00:00",
+     "start_time": "2026-07-16T20:09:29.944184+00:00",
      "status": "completed"
     }
    },
@@ -939,26 +976,23 @@
    "id": "49e4ebdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:45.810255Z",
-     "iopub.status.busy": "2026-06-13T02:34:45.810159Z",
-     "iopub.status.idle": "2026-06-13T02:34:46.578181Z",
-     "shell.execute_reply": "2026-06-13T02:34:46.577640Z"
+     "iopub.execute_input": "2026-07-16T20:09:29.948678Z",
+     "iopub.status.busy": "2026-07-16T20:09:29.948619Z",
+     "iopub.status.idle": "2026-07-16T20:09:30.917413Z",
+     "shell.execute_reply": "2026-07-16T20:09:30.916986Z"
     },
     "papermill": {
-     "duration": 0.770296,
-     "end_time": "2026-06-13T02:34:46.578521+00:00",
+     "duration": 0.971221,
+     "end_time": "2026-07-16T20:09:30.918171+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:45.808225+00:00",
+     "start_time": "2026-07-16T20:09:29.946950+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
+      "application/json": {
        "data": [
         {
          "marker": {
@@ -967,17 +1001,17 @@
          "orientation": "h",
          "text": [
           "0.005s",
-          "0.016s",
-          "0.029s",
-          "0.349s"
+          "0.017s",
+          "0.033s",
+          "0.364s"
          ],
          "textposition": "outside",
          "type": "bar",
          "x": [
-          0.004539022998263438,
-          0.016443184673941385,
-          0.028844309330452234,
-          0.3487535323171566
+          0.005172953999135643,
+          0.01660171901069892,
+          0.03320181099600935,
+          0.36404922166548204
          ],
          "xaxis": "x",
          "y": [
@@ -994,18 +1028,18 @@
          },
          "orientation": "h",
          "text": [
-          "0.052s",
-          "0.061s",
-          "0.085s",
-          "0.098s"
+          "0.053s",
+          "0.054s",
+          "0.089s",
+          "0.106s"
          ],
          "textposition": "outside",
          "type": "bar",
          "x": [
-          0.051717017990692206,
-          0.06113399033589909,
-          0.08523996067621435,
-          0.09783521434292197
+          0.052873300010105595,
+          0.05428346400731243,
+          0.08878442400600761,
+          0.1057293800113257
          ],
          "xaxis": "x2",
          "y": [
@@ -1030,7 +1064,7 @@
          "textposition": "outside",
          "type": "bar",
          "x": [
-          40.128544,
+          40.129517,
           71.067648,
           76.006204,
           135.605212
@@ -1098,778 +1132,72 @@
         "plot_bgcolor": "#FAFAF9",
         "showlegend": false,
         "template": {
-         "data": {
-          "bar": [
-           {
-            "error_x": {
-             "color": "#2a3f5f"
-            },
-            "error_y": {
-             "color": "#2a3f5f"
-            },
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "bar"
-           }
-          ],
-          "barpolar": [
-           {
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "barpolar"
-           }
-          ],
-          "carpet": [
-           {
-            "aaxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-           }
-          ],
-          "choropleth": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "choropleth"
-           }
-          ],
-          "contour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "contour"
-           }
-          ],
-          "contourcarpet": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "contourcarpet"
-           }
-          ],
-          "heatmap": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmap"
-           }
-          ],
-          "histogram": [
-           {
-            "marker": {
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "histogram"
-           }
-          ],
-          "histogram2d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2d"
-           }
-          ],
-          "histogram2dcontour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2dcontour"
-           }
-          ],
-          "mesh3d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "mesh3d"
-           }
-          ],
-          "parcoords": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "parcoords"
-           }
-          ],
-          "pie": [
-           {
-            "automargin": true,
-            "type": "pie"
-           }
-          ],
-          "scatter": [
-           {
-            "fillpattern": {
-             "fillmode": "overlay",
-             "size": 10,
-             "solidity": 0.2
-            },
-            "type": "scatter"
-           }
-          ],
-          "scatter3d": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatter3d"
-           }
-          ],
-          "scattercarpet": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattercarpet"
-           }
-          ],
-          "scattergeo": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergeo"
-           }
-          ],
-          "scattergl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergl"
-           }
-          ],
-          "scattermap": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermap"
-           }
-          ],
-          "scattermapbox": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermapbox"
-           }
-          ],
-          "scatterpolar": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolar"
-           }
-          ],
-          "scatterpolargl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolargl"
-           }
-          ],
-          "scatterternary": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterternary"
-           }
-          ],
-          "surface": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "surface"
-           }
-          ],
-          "table": [
-           {
-            "cells": {
-             "fill": {
-              "color": "#EBF0F8"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "header": {
-             "fill": {
-              "color": "#C8D4E3"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "type": "table"
-           }
-          ]
-         },
          "layout": {
-          "annotationdefaults": {
-           "arrowcolor": "#2a3f5f",
-           "arrowhead": 0,
-           "arrowwidth": 1
-          },
-          "autotypenumbers": "strict",
-          "coloraxis": {
-           "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-           }
-          },
-          "colorscale": {
-           "diverging": [
-            [
-             0,
-             "#8e0152"
-            ],
-            [
-             0.1,
-             "#c51b7d"
-            ],
-            [
-             0.2,
-             "#de77ae"
-            ],
-            [
-             0.3,
-             "#f1b6da"
-            ],
-            [
-             0.4,
-             "#fde0ef"
-            ],
-            [
-             0.5,
-             "#f7f7f7"
-            ],
-            [
-             0.6,
-             "#e6f5d0"
-            ],
-            [
-             0.7,
-             "#b8e186"
-            ],
-            [
-             0.8,
-             "#7fbc41"
-            ],
-            [
-             0.9,
-             "#4d9221"
-            ],
-            [
-             1,
-             "#276419"
-            ]
-           ],
-           "sequential": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ],
-           "sequentialminus": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ]
-          },
           "colorway": [
-           "#636efa",
-           "#EF553B",
-           "#00cc96",
-           "#ab63fa",
-           "#FFA15A",
-           "#19d3f3",
-           "#FF6692",
-           "#B6E880",
-           "#FF97FF",
-           "#FECB52"
+           "#0a1628",
+           "#D4A84B",
+           "#1a2d4a",
+           "#C87533",
+           "#10b981",
+           "#ef4444"
           ],
           "font": {
-           "color": "#2a3f5f"
-          },
-          "geo": {
-           "bgcolor": "white",
-           "lakecolor": "white",
-           "landcolor": "#E5ECF6",
-           "showlakes": true,
-           "showland": true,
-           "subunitcolor": "white"
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
           },
           "hoverlabel": {
-           "align": "left"
-          },
-          "hovermode": "closest",
-          "mapbox": {
-           "style": "light"
-          },
-          "paper_bgcolor": "white",
-          "plot_bgcolor": "#E5ECF6",
-          "polar": {
-           "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
            }
           },
-          "scene": {
-           "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
            }
           },
-          "shapedefaults": {
-           "line": {
-            "color": "#2a3f5f"
-           }
-          },
-          "ternary": {
-           "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
           "title": {
-           "x": 0.05
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
           },
           "xaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           },
           "yaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           }
          }
         },
@@ -1930,8 +1258,7 @@
          ]
         }
        }
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAGQCAYAAABMPLOTAAAgAElEQVR4XuydBXRbubaG/yRNmZlpygwzZWaGpMzMTZsyU8rMTZmZmZmZmZlxiqHetdV7PLZjx3Ls48T21ltv3TWNrCP9W9L5tLWl4+Ln9+s3OLECrAArwAqwAqwAK8AKsAIOqoALA6+DWpabxQqwAqwAK8AKsAKsACsgFGDg5Y7ACrACrAArwAqwAqwAK+DQCjDwOrR5uXGsACvACrACrAArwAqwAgy83AdYAVaAFWAFWAFWgBVgBRxaAQZehzYvN44VYAVYAVaAFWAFWAFWgIGX+wArwAqwAqwAK8AKsAKsgEMrwMDr0OblxrECrAArwAqwAqwAK8AKMPByH2AFWAFWgBVgBVgBVoAVcGgFGHgd2rzcOFaAFWAFWAFWgBVgBVgBBl7uA6wAK8AKsAKsACvACrACDq0AA69Dm5cbxwqwAqwAK8AKsAKsACvAwMt9gBVgBVgBVoAVYAVYAVbAoRVg4HVo83LjWAFWgBVgBVgBVoAVYAUYeLkPsAKsACvACrACrAArwAo4tAIMvA5tXm4cK8AKsAKsACvACrACrAADL/cBVoAVYAVYAVaAFWAFWAGHVoCB16HNy41jBVgBVoAVYAVYAVaAFWDg5T7ACrACrAArwAqwAqwAK+DQCjDwOrR5uXGsACvACrACrAArwAqwAgy83AdYAVaAFWAFWAFWgBVgBRxaAYcC3oJVO6F8iXwY0r2JQxuNG8cKmKPAx8//wrPVEMSMERXLpvVD9GhRzPk55w1BgcVr9mDS3HXYtWI0EieIy1qxAjZX4N6j52jiNQZ5c6THtOGdbf58fiArYC8KhDvg3XXwLPqMnGtUvya1yqJb29qo32EEaKCf3TFTk1ct4JWtk70YXann/JU7kSZFEpQqksusqvv5+WPjrmPYdfCcsAH9d5JEcZE+TQpULpMfxQvkgIuLi1ll2lvmibPXYsm6vVgytQ9yZE4brqvf02c2jp+9jhUz+iN1ikSiru8+fEaZuj2hjKdw3YBwXLmwAt4HT17Bo+WgUPW/Zy/fYvLc9Thz8RZ++fkjfZpkaNmgMkoWyhlMaXPynr54E7MWb8Wte08QIYIbcmdLh66ta+GvVEmkLWhOGas2H8SaLQfx9OU7xIoRDSUK5YJXy5qIGT2qzvO+//iFmYs3Y8/hc/j46V8kSRQPHpWKokmtcnB1dYx56uDxS/AeMhNDezRF9fKFpfXmjKyAMykQboG3bLE8SJ4kQTBb5MmeAUXzZ8e4Wavx8s17TBzcwWbAa6pO9tZxitTogpKFcsGnV3Ppqr//+AUd+00VL7XM6VOhQJ5MiBTRHY+fvcGxs9fw79fv6NWhHhrULCVdpj1m3LTrGPYfu4hubWojTcrE4bYJV24+QBOv0ejerg4ae5bR1JOB1zomszXw/vzlhyfP32Dk1BW4dP2e2cD76fNX1Gk3DD9/+qFGxcKIES0a9hw+i7sPn2P6iM4oki+7Rhhz8l68dhetekxAiqQJULFUfrEI3rjzGIJ+/8bqWQORKEEck4KbUwYt1qct2Ij8eTIjX65MePn6PTbtOo6sGVNj4aReOiBL89WJc9dRrVwhpEqeCJeu38WRU1fRol4FeLX0MFkve8nQY5gvLl2/jx1LRyJiRHd7qTbXkxWwmQLhFninDOuE4gVzmCWE2h7e0NTJrAbYOHNogLdt70k4feEmBnRpiFpViuvU+Nv3n1iwaidix4qhA1c2bhY/TksB8vpcu/UI25eM0HkJMvBap5vYGnhpzH799kNTeXN3GGYt3oLZy7YJKCQPLKUfP/3g2XoIokeNjDWzB2nKNidvi27j8OjpK2xa6KPxsNLuT522w1CvekmxCDaVZMugeaZsvZ7ImSUdZo7y0uwmrdl6SCwEyAmi7FqduXQLbXpORKfmNdCqQSVNFXr6zMGhExexc/loxI8by1TV7OLvpHet1kMxoGsj1KpczC7qzJVkBWypgN0Cb+cB0/Do6WtsXTxco5ch4KUXO22zHT51GeSxoO2smhWLoFmd8tLbWUpIgyngpYmYts72Hjkvts6SJqZnBd86+6dSB1QvV0hs/09bsAlXbz1Exr9SYNm0vujQdwpevH6H0f1aY/rCjTh3+S6iRY2M2lVLoG2jyiCP3cxFW3D5xn3EiR0DnpWKomX9ijohBFPnb8Chk1fw9v0nfP/xE/HixES54n+jdYPKiBUzmtArT/m2CAr6rdPXaLt70wIfo/3v7KXbaN1zAmpUKBJinLR/QCDcI7iJcszVJF/uTCDvzYMnL5EscTx0buGB0kVyY8ueE1i2fh8eP3uNZEkSoGsrTxQr8J83SvH40At75aYDOHjiEn78+IX8eTKhb+eGSJLwv/hKGX2o7ootZo7sIux0+NQVBAUFYffKMdi083iw2E2KlZ29dJsIH3jz7iMSxo+DTOlSoGmd8siWMbXQ4/fv31i1+QDWbj2Mpy/eIlbM6ChZODc6Na8utmWVpLRn7ZzBWLftCPYdPS+2nwlS+nnptseYwT7/+w0lPLuhfo3gwCELvDsPnsGydfvEbgqVFz1qFJCN2jWuir9SJw1WXxqP5NnbuveUGAMTBrcXC1fy+M1buQNbdp/E+09fRLxrujRJQVux2oBCBVoyZqnv0Vb35l3HQdvxMaJHFfWsXr4QKpbMp6nvzbuPMWvJFly8dh+BgUFIkyIxypf4B/WqlxALA9l2GwNe2j5fsnaP8JzS9n6e7OlFn9XWLDQTPZVHffDgicvwXbLFbA9v3XY+8PcPwIb5Q3UeP2PRJsxdvgPbl45EssTxxd9k8yr9rHaV4ujn1UCn3ObeY/Hq7UfsXDYqxOaaUwa13XvwDIwd0EbMa0oi73eR6l1QsVQ+za7VeN81Yt44sHYC4saOoclLi3ZavMuEAIQ0D9CYpd2taQs26ISItGpYGSUK/hciQoB94tw1HN04RfPeIS+z18BpIu6Wdi0pBQQGonA1LzHH9u1cX/zboZOXsXjNbtx/9ELM8ymSJRT5W9WvBDc3Vx1dCXjpfbF4Su/QdC/+DSvg0Ao4NPASgDTsNAq/fvmhdpViAvwuXL0nXmbN65ZHl1aeUsaVAV560dLkfuPOI1QrV1jESl6+fk+8mChebJB3Y82zCHjjxY6Jtx8+ifhPevlHihRRQCRNrheu3kVgYCCyZ06Lv1Inw/krd/Dg8QsBDkdPX0XubOmRNlVSnL98CxTLN25gO1C4hZLoZRAxYkQkTxIfUaNEFi+c7ftOIldW8oh0Edm27j2J4ZOXibCEmhX/xHxFjxZVwKWxRGEkyzfsF7GgWTKkMqmduZpEjhQRP3/+QtEC2REnZkwcOH5RhEgUyJsZpy/eQrH82QUg7j92Ad+//8T2paOQMH5sUQ8FEKNEjijgNne2DHj26q3wRqdNmQSrZw/SQLiMPlQm2YIWGK4uLogfNyYy/JUCX799x6i+rbFhxzEd4KUXVePOo/H85VvUrlocCeLFFnBOfadq2QIi7pyS8gIu/E82/J0zI17QVuzOo0iTMomAF9JAuz0EbBSTSJD55t0nHD97TfQZymsqUchF96GzMG98d/Es7SQLvL5Lt+HarQcC1GJGjybssefIeQFNa2cPQuxY0XXqmzRxfGHDvDkyIDAoEPWqlxJbzj19fLH3yAUUyZcVWTKkxtv3n8WihBah2sBr6ZgdM2OVAF5a1GZImxwfPn3BvqMXRdjNypn9RV1p4dax/1TEiRUdFUr+I9p17vIdnDx/HVsW+SBlskSQbbch4FX+rWThXCiQJzO+fvspFjg/fv4CLWCUPmvKfiH9ffPu4xg8frFZwEsL3PxVOooY+/GD2ukUT3Ni35HzMHlYRwFq5uS9eO2emPt6d6yH+jV0Q5l8Ji3D+h1HcHzzVAFixpI5ZRCYE6CvmzsY6VIn0ymyevMBiBI5MlbNGiD+naCWwq8Or5+kk4+cAWXr9RI7URTuE1IKaR4gUG/YaaT4ec0KRcSB0H1HL4hnjuzTEpVK5xd/oz45evpKnToPn7Ic67YdhmelYhjo3Ujku33/qVhoKDBPZVGoQoG8WVAsfw4Q1FOcM81rJ7ZMFfO7diKvPC0sj2yYHKLelvQ9/i0rYK8KhFvgNSRomaJ5NBO1jIeXJtu9R86Jl4x2DBlNNOQxPLh2gtSkENKhNaVONHFRufoeg7EzV2HFxgNYNr2fxsunAO+IPi0EGGgnmlwpNm9k31YaDwF5ScvU7QH3CBEwvHdLjWeT4IMOHpGnk6A3pLRy036MmbFaeMRTJE0ospob0tC+zxScvngDZ3fMCuZZMPRsczVJkSS+aIfiBaOJvW2vSeJQzZgBbZH2/7GyFI9HOvXpVF9sl1JSgLd3x7oCspRDcxTnR3/T9wbp19eQPvSMs5dvo2f7OqhTtYTOT/RB59rtR2jUaWQw+9OBmSfPXyNTupRicUIHjaqWLagTN33g2CV0GzoTXVt7ip0H7faQJ7Vlg0oaWCegIw/2tiUjDMa4a1dy4py1WLX5EE5umRbMXrLAa8iudx48E1vVtEAjT5R2fSnMpXvb2qCFh5KOnbmGTv2non3TamjbqIrm35UdA23gtWTMEqQVqeGF0kXy6OhLXnWKbSTvOOWp0WIAfvkFiNhSBdipUgRdFOOp7QnUbr+hduv3g5dvPqBKk35o7FlW2FNJL169Q/UWg9C0djmxvW5pCg3wfv7yDcU9vcWhJpqntJMypmhhTgt0c/IqUEZnAahvaydl/CkLCWPtNqeMMTNWYuWmg8JrTDt22oni1V+9/YA9K8eKfyaPJy00yHOtnWjBRvNwpVL5MbJvyxDNEdI80HvEXOw/egHr5g7RHAilspt1HSsW3FQPWmwp4QaKvvTACg36IHJkd7Eg2rtqrJizaHFAY2Df6nEi1ILGDc0bFJKkfRD46s0HyJQ+lWZeUBpw7vJtEUs9e6w38ufObGk349+zAg6lQLgFXkMHxNKnSa5ZMZsCXnrJFffwRtlif6NXx7o6Rjt+5roAjEWTewmvJ3nNaHtJO6VLnUSEEVBSgDekOnXqPwXXbj/G/tXjdeCCXnSVGvcTYQedW9QU5SkhDRRrpZ+U7TP90IKGHUfCz99fwLt2Im+Au3sEEQ6hJIrxW75xv/AGP33+Bv9++64JX1DaTHnNBd7GXqPx8MlLHNs0RWoQWKoJxRZSmAp5jch7pN0+qru2l14BXuVFoeRVPDl1q5XUbBHK6mPMFlS2PujcuPMYDTqOQOUyBTCgSyMd4FPqsnD1bkyZt17ESZL3UTtVbtxPvOCUrUhj7dlz+Dx6DZ+NueO6459cul5bfaP0Gz0fd+4/E14l/SQLvASIW/eewM6DZ3Hv4XN8/vIV5LmnpB0Xaay+lI+8uxTmQdvKigeb/l0feM0Zs4Y6IP2+cPUuSJoontjJMORJVexEuzvUf4wl2Xbr9wPaPicvPsFY3DgxdYonCKKQIt/RXaXGT0iZQgO8yligxZt+6IES60oLxvo1SotwKPKAyuRVvMOGFpVKHDDNW7RwNZbMKUPxGuuHKVDZFAdMW/+HN/zx6JLH183VLVgIB/WV3OXaih0tCrsJKRmbBygUpmjNLmIHSvvwNJVFDpVB4xZh1uguKJg3qwhlKlGrG0oWyi0WiuTJrdd+OGaN6oJ2fSaL+TtbpjQYNmkpCFq3LPoTqkchD2cu3sbccd3Ejp+ppIxrgniCeU6sACvwnwLhFnhNxcuaAl66TaB0nR4h2lqJnZqzbLuIvdVOFCOl3GkoE9JQo8VARIsSBctn9NMphya6fJXoEEUejOnfWvwtNMBLBy/effyCDfOG6JRPEzwBnHLYhLbYGnceJU5yE+z/nTM94seNjbsPnsF36VYsnNRThERQMhd4aWI+c/Emzu30lYp/toYm9FKil64Sz0b1Vl5WdBOEchgmJODKV7kjiubLJl5s5uhjDvBSvboOmiHi7QjqKOQjZ5a0qFAyn4jPpkQhJOu2H8HJrdODATFpS0BJwE7JWHto25087dNHeKFIvmwh9m9acPz8FSBCGvSTLPAqoQgURkGeU7p+ztXVVWyzdmhaHW0aVQ6xvvTH2m3+xIvqL9b0gdecMWus4UvW7gV5tskbRouK7JnSoHjBnJoYyd2HzoK8cqbmF9l26wPviKkrsHbrIaN2yZohdbA5IjQvpNAAr+K1pQNN+ottYx5embyKd5bOHVCIiHYy18MrU4bi4dVf3NJzDXl4AwIDgp1NMNfDS+cq9J0QyhhqWqccvFvX0mk37dLRAkf7cC+FUlG8L8VP0zvn6JmrWDq1D6o06S90owUkOTAozEy5S57C2cjLS4t/urUoW6bUIkyG5hXtxaPycKVdznBTTmjGDf/GuRVwWOBVJiPyuNWtprsdrZg8dYrEwe5sNNQdZIGXDvRQ6IJ2UoC3dNE84iAapdAAL23tv/3wORjwtuw+XsRVKsCrvPD1vS3KtrklwEsxaBSLRlBPL25TiYDXUk3ocF3tKrrAS8/NVbaNuPrMFPCSp+7PgiO3CGswRx9zgZeeRbsFdLiNthxpC5zSsJ7NxFZvSMBLsYbkmTIFvKfO3xAeIVng9fMLxJxx3UIFvIo3lLzjfTrV02ypfvn6HcVqdpUG3potByFalMjBxoY+8FprzJL3bNfBM7h84wGu334kDvtRTO/gbk2gAO9Un846hx61BTKn3frAq9iYFhmGroaKGiVSsLhTU+PI0N9DA7wiLrey7uJbKXvHgdPoN2o+Jg3tKO7jNScvXSfW3HucwZtbyGO5YcdRHN04WRwgNJbMKUNxUGycPyzYlYDVmlEMbySs9h0oHkXz5v3H/40r5fkUD1+ufi808iyDHhIxvCEBL4UhaYev0DOUmGTtGxOWrt+HCb5rhBbt+04RV0LSzh/tCJw8fwPLp/dD4epeGNK9qU5oCNV1+/7TuHjtDq7cfCji3il2edn0vsGglw6H0gJf8dSHpm/xb1gBR1XAYYGXtpsono+2fenlZkmSAV666/Ha7Yc4sGaCTkgDnRSnFbylIQ2ywDt04hJxSv78Ll+dehgCXgr5KJI/O0b0biEljxKLSYuIkH5DXgYKs7CGJpYCL3lUaFuTYkcphtQcfcwFXn0RKZawedexiBY1iggrWLBqF+iGCHoZK15f+g0tiijsJWG82CZDGswB3v5jFgiIVg7waNdPxsO7Y/9pUFgEATMdPFOSucBLN3s8fPJKE6eolKMPvNYcs8ozyDPWe8RsEbJEB5conppCc7TjpfXtZk679YFXsbHswU6pgWcgU2iAl4qh2GvSRPt2G/p35awBbaWnTPYnxl82L3mOabueYoP1v3JJZdCuyu4VY0JsqjllKHMZzUE0FylJuemBbmmgA2Pa7dL/Ep5SBi2CaDEUUgoppIHeMeRxpYWCdlLso4Q00N+UhRTVjcbV+rlDxHkF8uKS40L5d+2bMvTrRQsR2v2hQ3t08JDOkBga16P6tdK5lSS0/Yx/xwo4kgIOC7xkJDp1TLFhFDNHp1y1E3ngyMMbktdByS8DvLSNSduZ+hOossWpxGhRmWp6eCk0gzwg2jFzBChDJiwCTfLaHl6PloMRNWpknfjfkDo3gVmTLmOE99LQlhmdIF60erc4qUyeE2toYgnwUn0HjF2I7ftOafQwRx9zgJeuuSJgozg87dS0yxh8+foN5I26//glPFsNFi9p7QUDXWHVa/gccWuIEldqLKTBHOClT97SlWZ0Ql4/yQCvcmhQ21tEL9x5K3aIECDZkAa6PotuPVBuAKC6UDlzlm8XV2tpH1qzZMzSTgd9/KRCiX90Dvgo2+rkPadDapUa9YWbqytWzRqouaaP6qQcWrv78JnwDMq0Wx94Cew9Wg0Wt2pMH95ZLPyUROOD+okSUmTJiyS0wKtcP0Zb6UpMKNXLo9UQRI7orhPrak5euqWBwqg2L/TRfLqaFlu12gyFoevKDLVdtgwK4aLDunTgd8ZIL01RynyjvbulXD9GH5igD00oicYb3fayc9lok7dmhDQPKOWsnTNEc6iWvKy0qHr15oO4wlAJPaD5oZhHV3FbEPAbWxaNENWhfy9dtwdiRo8C2pEhOFcS3aZTpmhenRAoJayJQuToKj3txIfWLBlV/FtHV8ChgZc8bBTTRVcglS2WV3jV/P39cfribdAWmv6q35ixZYBXOZl7895jVC1bSGy10TMOn7wS7FS0msBLL9w6bYeK67to9R8QECiuf6L7eMmzow28yol/5QtEBAz6W3P6mtAp9A59JwuPHR1CIe9G5MgR8ezFO5w4f12c7lZuT7CGJuYCL10HR1+LopcMXTVFsXTaoQ/m6GMO8Cp9hOJq6QowOplNAEUwq/2VM0VzOshCUPT81Tts2nkMqVIkwrJp/TQvNmsAr+LFMhSCogAv3Q9s6PAbXc1VuXR+1G47FC9efxAQSQeuaOuVDmJSX5IFXorNJQik31CfpOvATp6/iSfPXot7R7WB15Ixq7SJxjltF8eJHV3cdbxm62EUyptFADcluq6NYnQTxosjYidp0UtXAVI4Ct0mQNcEyrbb0LVkCuDTbSj0AYR4sWPh4dOXYhyWKJhLxwtK8a/3Hj5D0QI5pMKE6JpDGlfkFVy95aA4CEvPiRs7erCr5wyV/eHTv8Jz6x8QoLlGi+4NpzAQJZxBGfPm5CVvfdveE5E6eWIRX/rLzw+bd58Q9y/Tjob2bQo0R9CtKHR9GMW/KsmcMpSwhkJ/ZxXtpnmJrvfLkDaFuKpN+35aChc6e+mWmIepX9N1kRRrL3MlGdUtpHmAIJ9uZ6GY8T9frosq7mEnPQ3dWkFx9cfOXA/2bDrgRgfd9G+NoLCwb99/oUKJv5E8aQJ8/PxNzBe/8Vt4iMm5oJ1ocbdozW4RNqF/ZZmjwwy3jxUwpYBDAy81nl6C8+lewlNXxccACATpXtYyxfKIj0IoH0gISSgZ4KXfEzDOXLxF3MP458MTcVG9/J+PXGhPwGoCL9WDPAATZ6/D4+dvkDhBHOFRpG1K8p5pAy95fkdPWyle9HQDBHnBJw3571PNxjQheKZrgQ4cu4iHT1+JRQTdMJA3R0ZULVdA5zocSzUxF3jpRofjZ6/i5ZuPf8ClanHxctG+0kdWH3OAl+Bg+YZ9YoHz5MUbRHSPIHYQGnqU1tlaJK8zXVO3bvthPH1OH56IJuCMDqxoX5FlDeAl+5bw9Bb9T/8TqgocGrMxXWlEVxuJz9hOWyEggUIz6DBnI48y4stcssBLz6B4ZoJ9utc4auRIKFYgBwr9k1X0Sf145NCOWYJnuu+WbrIg4KC7rOnjJRVLFUDjWmWC3RBBnmoKQ/r9G+LDE3RnKt3XTbG3su029uEJmgMo3p08urTopHrkzZlJlK99QwcBDUH5jqWjpD6/q/+lNcV+5O2cP0H3kK6xsimsY/K89eL0v59/ANKlTopW9Strvk6m3SfMyUsH33yXbBXa08c26Bo4WkDr35WrzKd0hR0d6tJOsmXQOKI5aM3Wg3j+8h1ixogmDid2aemh47Wnsulax+kLNwkQpfhXY/OysbEQ0jxAv6FFNH0kiO4KJz3Tp04mvupG9zDrJyXkRf9ubGVxqv+VNJpPNu06ikvXH4g7wBPEj4OCebKgdaNKYn7TT2Tz2DFjiBuIOLECrICuAuEOeNlArEBoFAjplobQlOcov6Hr927efSquOZJZ3Nmy3Uooh6Fr2mxZj7B61uu3H1G+QW/x0RhT92ibW0c1yza3Lvr5h0xYgk27jmliWC0tj3//RwH6+iaFUNFHLOhjFpxYAVaAgZf7gAMqwMBr2KgUb03xhGF9TRFtbWvfWkAxvF0GTRef1abY2ghufz5F7UxJuauVPLP6H6CxVAc1y7a0bnRAkzzedJc0J+spQLBLIVI7lo40eEOI9Z7EJbEC9qkAe3jt025caz0FGHiNdwk6WEMH0Cjmj0JPwiLRF+aSJIovDvbQJ2aPn7shDj8a+hxtWNQvLJ4Z0odBLK2PmmVbUjcKFaGrwwzdMGBJuc7+WzrcNnDswmBfenR2Xbj9rIC2Agy83B8cQgEGXuNm/Pj5X3i2GiI+m+s7xlscqLN1os9uU3wmxee6urggbaok4jBhlTK6n6K1db3C8nn0JbO2jauAPu5g7aRm2ZbUlT68Mm/5DvGpX+1zDZaU6ey/vX7nEVp1Hy92CSgenhMrwAoYVoCBl3sGK8AKsAKsACvACrACrIBDK8DA69Dm5caxAqwAK8AKsAKsACvACjDwch9gBVgBVoAVYAVYAVaAFXBoBRh4Hdq83DhWgBVgBVgBVoAVYAVYAQZe7gOsACvACrACrAArwAqwAg6tAAOvQ5uXG8cKsAKsACvACrACrAArwMDLfYAVYAVYAVaAFWAFWAFWwKEVYOB1aPNy41gBVoAVYAVYAVaAFWAFGHi5D7ACrAArwAqwAqwAK8AKOLQCDLwObV5uHCvACrACrAArwAqwAqwAAy/3AVaAFWAFWAFWgBVgBVgBh1aAgdehzcuNYwVYAVaAFWAFWAFWgBVg4OU+wAqwAqwAK8AKsAKsACvg0Aow8Dq0eblxrAArwAqwAqwAK8AKsAKqAu+y9fsw3neNRmV39whIljgeKpbKj+Z1yiNiRHebWqBIjS6oXaUYurTyNPrcoKDfmLNsKwrkzYJcWdPp5KvYqC/ixYmJZdP62rTeIT3s5ev3qNd+OLJnToPJwzoigpsbjp25hk79p2K170Bk/CtFuKmrORXZvPs4Bo9fjOkjvFAkXzZzfhosb/0OI0S/Gz+onUXl0I+fvniD7ftOwaNSMSSMH1tTXkj9JjQPffDkFTxaDkKvDvWQJ3s6tOoxAVXLFkSPdnVQtGYXxI8bC1sWDdcpeur8DVix8QCObpoC9whuRh+rr6216648+PTFm7h68yFaNaikUxdr2jY02hr7zQTfNVi15RBmjPRCvlyZRLZGnUchQdyYmDS0ozUfZdOyBo5diK17T+wJHOQAACAASURBVOL09hmIZMGce/jkFXQZNB3r5g5GutTJLG7Dpl3HxDugUqn8OmUZ6zeWPnDZ+r0Y77vWaDGX9s6Bft/85eeP/JU7inHXyLOMpVUw+fvnr96hcuN+aF63fIjvKZMFmZnBPyAQLbqNw/uPX7BoUi+duc3Moqyefcq89Vi77QiObZoiyralTXjs/DHn79+/MWjcIhw6eRkrZ/ZH8iQJrG5nWxRoE+Ad0LURYkaPhm/ff+DspdvYceA0yhbLg3EDLQcQc0SSAd6AwED8XaE9vFvXQtM65XSKX7BqF6JFjYS61Uqa81jV8hKoNO06Br9++WHJ1D6IHCmieJYjAO+NO4+x98g5VC9fBKlTJLJIQ2sC76nzN9Cuz2Qsn9EPWTOk1tQrpH4T2sqXrdcLOTKnwYTB7XH87DV07DcVXVrVwpR560SR+1aPE+CrpKZdxiBKlEjwHd01xEfqa6tG3akC0xduwvIN+3By63Sd+ljTtqHVVv93R09fRecB0zCqXytULJlP82dHAN49h8/h5t3H6Ni8hlgQhzZZG3ibdR2LGNGjYNrwzjpVMtZvQltv5XeKAyZp4vgICgpC20ZV4Orqoim2evnC0O+btoQrqsjnf79h0epdyJsjo8ULfXP0mjR3HdZsOSScJCmTWTbfmvNcmbxhCbw8dv6zUGBgkHC8/PzlJ5x+bm6uMuYLV3lsAry7VoxG4gRxNQ3v6TMbe4+cx/4144XH1FbJUuC1VT1ln7Nj/2n0H7MAS6f1RbaM/8GXIwCvrAYy+ewVePuNmo+T52/gwNrxcHFxEbY+fuYaEiaIg0dPX2F4r+YoV/xvIQFNQkVrdEG7JtXQsn5FGVk0eWwNvGZVzgaZaSKv1WYIUiZLiCnDOuk80RGA11oSOgrwzh7XDZ36TkH/Lg1Ro0KREOWxNfBay1bmlENe5erNBsKrlQea1Cprzk9tkjcsgddaDbT3saPocP/xS9RrN0xq7FhLO2uWEybAS55S2n7dvHA4UiVPqGnProNnsWjNbjx48hIxo0dFrqx/watlTc2K8+37T+gzch6ePH+DT5//RbRoUZAxbQq0aVQZeXNk0NHl4rW7mDp/E67feYRYMaKhYN4s2H3oLBrULGV0q0h58esL3KFpdfEM/Zef0omH9WyGg8cv4vTF2+KnxQvkQK+OdbF1zyls2nUUT1++Q/Ik8eHV0hMlC+XUKd5Um0MytkfLwUiVIhEmDemgk80Q8H7/8RPTFmzE3iMX8PnLV6RImgD1a5RC7aolxG/ppV/c01tsm/fuWE/8G3mQy9TtgWIFcmJI9yaaZ5Su0wOVy+RHtza1xb+9+/AZ0xZswtHTV/Dt+08kT5oAdaoWR52qJQSoUZo4ey027zmBBRN6inqcunATCePTtvwIg0001Ib7j15g5uLNuHzjAag9SRPFxz+5MqJra88Qt2oV4C1WIIfwnjx98VbUkUJbShSUt4fi3dWv8Nzx3dC6x8Rg7VD6Df3BlJ2VvjR/Qg/sPnQOe46cw5cv3xH0Owjr5w7BX6mT4snz16jWdACK5M8hADdd6qTo06m+eO6ZS7fQpudELJ7SGzmz/AVD5X39+gObF/ng4ZNXmpAXKpd2NIz1efp3GkMzF23BxWv3xKqentuucVXkz5PZaPckL928FTt0/k7etAu7ZxvcgSAbxYsTA3/nzIgNO47g5esPSEZjpoUnkiaOi/krd+DUhVug3lT4n2xiwo0eLYqmfJk+aKyy5MXpNXyOwRAgQ8B78vx1zFq8FbfuPxX9rkCezOjSykOzzbd4zR6Qx+zw+kmIFTOaeOzKTQcwZsYq7Fw+GkkS/ln8r916CKOmr8SRDZM1bTGlNfX7QtW80LN9XTFm12w9hBev34HmoCplChpsoj4w0LhetmGf2L5//vIdYsaIKkIUaMu+0N9ZjdpU6VMU8rFt7ykcPXNVzBGlCudG3871ES1qZGl7kHf30vV7Os/KnzuzCM0y1m8snWvqVC0pQuzIATN13kZcvfUQWxfrhgXpzzvGgNeUnYyJaEp7/edRHxkxdYXB4gZ5N4ZHpaLSc7CxOo2cukI4oPauHhtsB4BsvmjNLtx79EJ4w8n7Szsg9B7VzOu7T6B/l0ZYsnY3bj94Jt63taoUR63KRcW43X/sIr78+x2Z06fCQO/GSJsysaYqfUfOw5WbD8Q7JEIENzGG6lUviZoV/1uIyAKvKZvw2DH9nlbelVXLFsLsZVtx5/4zVClbUOf9T44YQ2PH6MQRjv4QJsDbZ+RcHDl1FYfWTdDE8S5dvw9zl21Di/oVkTl9Snz99hMUc0UvPooZo5cbrUQnzVmH3NnSI2H8OPjx86eITbt26yFW+w4SHhpKl2/cR8tu45E6RWLUqFAYkSO548rNh9i27ySa1i4XYmzUucu3hduewhYqlPzjPUucMJ54SRkD3hjRo4rtMYIv2hLzmbwU7hEiIH3a5GjdoDISJYiN+St34cipy9i+dKRmG1qmzcb6yuNnb1C9+QCx3V26SG6dbPqTtrIVce/Rc7SqX0nA3pmLt7B6y0G0b1pN1J0Sxee9efdZxOhQokVDc+9xiB0rOvavHi9gR4kxm+rTGcUKZMfnL9/QoOMIpEmZCDUrFhNblBS36bt0K7q28kRDj9KaiZHiSyNGjAACz/RpkouXZeuGuvGdSkP02/Dp81fUbDkY6dMkQ51qJQRoXL31AOu2HcGa2YN0tvb1NaNBfOfBUyRJGA+VS+cXfW77vpN4/PwN1s8dqgmZMGUPimPavPuEeGkO7tZE8ztqy617T4z2G1PlUt9WYCJqlMii/9PL/8Onz1i1+RD6ezUQCxN6ft6K7ZE9Y2qxgDtw/JJoOyXfJVuxZN0eHNk4Wby0DJXnH+CP+jVKiz6qHeMdUp+nsdS21yR4VCqCQn9nA61faNG0Zc9xsbOgHdahrTvFls9YtEWEpfiOUUIsXJA7WzqjwEvb7kXyZUVjz3KIHj0KJs5eh8vX78Pd3U2M2xKFcuHpi3cYPH6RqA/FVVKS7YPGxhK9dGlsrJ0zOFgW/TFP/dJr4DQUzZ8dlUsXEAu8hat34fuPXwKYaceK2kF9jrzFxQvmEGWShhSbSqCqjAmKD7z/+AVWzPgz3mS0Vl7a1E/ix40pPPwR3d2RL3fGYGcOlMboA8PsZduwYOVO0IIsfdpkAjYI+mmeG9ClodHXk9Kn6CxGyUK5kCNzWuGc2LDjKCqXKYARvVtI2+Puw+cg3QmSu7b2EL+jeTRalMhG+42snWlxbWiuiRI5ohi7q2YNEDsk5DyZO7470qRILOY4Q+cfDAGvjJ2MiWhKe/3nUUwtzbnaacz0VXj28q1oR5JE8Szu/+Xq90LpInk0jg7lWTQvtO45UcBr8QLZ8eOnP2ixR+9bZd4hrZes2yvmQupP9M7duPMoVm46KOZoKrd21eKiSJ/JyxDRPYKot5JooUnzJzlgaG45ffGW6E9j+rdG+RL/iGwywCtjEx47pt/TNG89fvYaEdxcUal0fiSIFxuJE8QR41tJJ85dR4e+U6wWy290wlHhDzYB3k0LfJAgXix8+vIVOw+cEbF95F2jwHzlhUWDjg4V0YtESV++fkcJT2+M7NMKFUr+6fz66d+v31G0ZldxuEdZdTb3HotXbz5gw/xhoElOSZaGNBgDXoqfpclfSZSP4mpXzRqoiXMhr1rNloMwdkAb8ZKiyTu0babn0KQwYupynNgyLZh3Ux8W9x29gB7DfDF9RGcUyfefvqOmrcTGXcewd+VY4YkiMJs8dx2ObpyCqFEiCa8srdjPXroF3zHe4iAPeSr7jZ6n8UrRZHT28h0smdJHJx6ODgCRB4hsT4nKogNBCyb21Am/MNan9dugxFgum95P5/c/fvoJIAopNpEGMcU3zxnrDXpZU/r4+V9UaNAHFLfXz6uBtD3MjeGVtbMCE+RdJ8+7kio17ofsmdKIFwBBWa3WwxAjRhRMGNROQNThDZPEbgh5d6lt5H2jZKw8+pu+tiGFNFBfzpsjvYhp1050UJLCaCg+31gyFotpyHtPNooTKzpmjuqiKU7JN3ZAW5Qrnlfz771HzMXdB0/F+KYk2weN1ZPGYbVyhdCpeY1gWfTHfK3WQxE5ckSdg6uv3n5A1aYDxPxDOtFCjuatWlWKwaulB2geK1Wru/CI//j5S4wBSjVaDETxgjk12sporby0ycs2tEdTqYO/+sDQsONIxIkdXRwI1U5fv/3Q8Zrri6H0Kf15ZOKctaD42N0rxogXpKw9zI3hlS3X2Fyjf4hau33KQTwZD6+MnYz1NVPamwqhII8+eWQp7ll5V8rqYqhOYteo2UAR908HtbUT7VKs3nwIp7bpxuBr9xPSesPOYziwZrymL9Lir0gNL9SuUkJ4/pW0btthDJ+y3GQoY912PkiWJB4mDv6zcykDvDI24bFj+j1N87Cfv7/oDzSWDSV6X9Auk3drT513ldEXQTj6g02AV7u99FLu26m+ZiuG/kZbHt2HztLAiHZ+f/8AdGxWQ+MJpK3bTbuO49a9p/jy7zdxEI6gR8lDg5HAljyH9G/aSS3g1T+17D14Bl6/+6Tx3FAdyBNUuLqXBszNabOh/uK7dJu4LUB/S47y6k/aNEFu3Xsi2OGh81fuoGX38VC8tbfvPwVNNrPHegsPY7Vm/dGpeU3hRU2bKonYPh83azUuXbsvDm1Rqt1mqPBSuekdhqFDIZTO7/IV/6uENNA2r0zSbwN5tAkQCP7q1ywl/lf2pKixGF6CRP+AACyc1Eu6D5oLvLJ2NhbjRTdV0Ip676qxYvt64apdePnmg7iJoVStbpgwuAMK/p1FxO+2aVQFLepVEPKGFDMmC7wE6xTmQosJF63DPVR+QEAg8uXOhNljvI2a01zg1b9JQ+mPSv9UHkSLKfK0kzfbnD5oqKLCa16hHXx6NtfxYih5tYH3w6d/Uap2dxFC06zOn8W6klr3nCDGuOKtpTng05fvWDippxintLU7oGtjMd7osCHNg8VqdtWAi6zWyktbf2EU0pjSBwaKBd9z6Cya16sgdgoypUul4xgwVpaxPnXh6l1xwp/6AkG97JxgLvDKlmtsrlGAlzzRsWJGFx7HnFnSisUO3YRCXnNTwCtrJ2MamtI+JOClnYMmXcaI3Q7txZmsLobqpLwD9M/ZUF66RWPIhCXC01epVD5kzZgacWLF0CnGmNb0rqVdGCXsjX5EJ/y7DpohvMMZ0iYX5RBwkzeYPLS000BjiP6f+pEyt5gCXlmb8Ngx/Z6WPe/i0WqICM/s3KKmzOs83OSxCfDStnvc2NFx5NQVLFy9W3jUKL5TScrKb9boLkiUIF4wceLEiiYG2sadxzB04hIRC1SzYmGxDRIzRjQ07jwK7RpXE3G2dG0UeVtoy1k7DogKtRXwkjf1+av3mtAAerb+RCbbZmM9hbbm6MYL2kbVT/qTNm0bXbv9CDuWjtTJqlx9RfF/NOnTy79ErW5oULM0yhTJg/odR4iwEwobobjrXctHiwk3b/b04qVPqUzdPx5bLyNXvSnxWpYCLz3rwLFLIq6IQIgSXQvWpFY5k9cFGRvEPX18cefBMxFLLmsPc4FXtlxjMEGwRC/JLYt8xFYveQhpHNGBT+pnFK9bsnAu0A0NdHI2W6Y0QhtrAK+yK0ELx9JF8wTrZ1EiuYstVWPJUuD949EeqhMaQM/SfwHK9kFD9VQWyBQHTzrqJ23g1R8v2nn1xxhtqU+etx7HN00ROyKpkicWW77kTW7ftKo4xEu3QtBuCm3ry2ptjZc23QQwee56EcZAcEGhSgXyZBHeuJAWkcb6FMXWe7YeornhQtYe5gKvbLmmgFeBO7ItvUsoZEhJpoBX1k7GxoQp7Y0BL+0SNOgwAkkSxYXvaG+dE/Kyuhiq08ETl0GLs6MbJ4uQEu1EOxUUrkNzGC2yKVFIWfe2tTXeYGNa00K5erlC6Nb2zzkPSvra0tzbtMtoRIsaRXgKKbQhdqxoGDtztQhtIceLofGur5GsTXjsmH5PywKvobFj9EUQjv5gE+DVXj3SDQ0Hjl/EjBFemkGjHBrR3yrT14lCAuh6s0WTe2kOQ1GePOXbaoCXtlMKVets8N5EGeCleFfy+Bi6lsxYSIO+h1cGeGXbbKyvkId3x/5Twe5iNTSxkId3y54TwbamlNhN7VhD8rSTx5zipK/dfiBggw4LlqvfG3Sgqm3vSZg0pL0mNIIOzlH4A4UahJSsAbxK+bSiv3b7oVgAUbjGvPHdxWEnY8nYIKYXLsWNkYdX1h6nL9wUGuhfS2as38iWawwm3rwj7XuJQwMzF29B2WJ5sXzDfpzdOQuzl24VsdgU20oHfeilpVwVYw7wGqu74tEkb6aywDFn7pqxaJPY6ta/lsxYSIO+h1cWeGX7oKG6Kx7e4b1bBLsPlvIb8vBqh2MpZVLcP8GjEv9OMarkeZs7rruIjaexQ3BFW7oU30w7FMfOXNWMG1mtrfHSVupMdn/49CXOXb6DWUu2COCgsWQsGetTyiJQ8fDK2oNCzyh+Xf9aMmP9RrZcWeCl8miRo+2lMgW8snYyNU6MaW8MeL2HzBRnIyj+VfsqQnqOrC6G6qR4ePesHBvi3bsvXr0TB5Xmr9yJZy/fYd/qscIjbgnw0ligd9iOpaNEDLWSKFSLkizwytqEx47p97Qs8BoaO6b6fHj4u82Bl2CKVnW0YqS4zzQpE4utjIoN+yB75rSYN76HTiwoeWAo3jJF0oSgDz/8nSMDfHo112hHp9UJcBUPL/2hWrMBYiVKnmUl0WqVgLduteImL/Sm+JTaVYsFi1u0JvDKttlYJ6EY3lHTVuDE1unBPjKgP2nTISPyZtLl+dq3RPhMWoYte09g36pxOqfJyTNHetevUVLEuFIiOKRTtHSQjU6VKyey6eQ5nUA3FANGB7kypUspfm8p8FJ/oRhP5a5hKpP+jfqN4qE2B3hpK40OwbVtVFXsDMjagw580SE97Rg65bmG+o1suSEBKh1OjBs7prgloXGtcuLAGIWG0AGSzv2nI3f2dCKOWzsm0xzgpfob6/MEba/ffsTGBcN0rhCk8URAqmxNGtJ+ydq94raC45spJvy/E/zWBl7ZPmisf9CCwqNiUbRrUjVYFv0xT55MOiS2YkY/zaKbYKB684Fo4FFaM2cQSJeq3QPp0iQVuz3K7grBIXl2s2RILbbRtT+CI6O1NV7aj56+Dna3NYXOnL18O9gukLYgxvoUXUi//9gF7Fs9XoRGyNqDDv+9//CvJjxKeZaxfiNbrgzwxosTS7w3urWppROHaAp4qY4ydjLW10xpbwh4SY/J89ZhzthuBhf2sroYqpMSw2vIaUBhZNq3KNHv6eD3gDELRT+h+4wtAV46tHnuyh3sXDZKp2q0W0XzvCzwytqEx47p97QM8NJHSgyNnfAAtKbqYHPgpQrRC6Jhp1GIET0ylk7tJ2CLPFQEWvR1s2rlCopQhRt3HmHjzuPo27mBOLRC17PsPHAaw3o0F6BMJ+/JG/Dk+VuxXUjgQok8f8MmLRUvsKL5sosXzrwV28VWuMwXbOjDAhQvRZMhneiPHyeWuIHBmsBL9ZRpszEDKrc0GPoSmaFbGih28O7DZ2hRr6KA2VMXboiDb3S9lPaLXtmeJE/hgTUTNCBMB9oodpK2zLW/NEdA16jTKLEooWuNyIv1+d+v2H/0Il6/+yiu1LIG8FJdZy3ZKkJhMqdPAX//QHGtEsUP0un6RAniGO3rNIhfvnkPj4pF8FeqpHjz/rP4IAJBInlMlK08GXvQDkKFBr3FTRfN6lTA12/fRSwrbQUb6zcy5YYEqOQJoW3FlMkSIGqUKOKKOzrgSXWhr66Rt0h/R8Jc4DVWd4qZ79h3CggQyL50FRyFDdEVc//kzKhzKEXfAHTtFC2U6EtaFBLx4vV7NPYsY/SWhtB6eGX7oLEOQrcFPH351uAXFPXHPN0uQx5bur6Lrub79u0HFq7ZIw6pUniRtvdNuW+cdFNulKADH3StH+1S6I9dGa2t8dKmw5pZM6YSJ+jp8BpB2IxFm1GrcrEQPflKnyqYNytKFMohoOTEuRviukftQ8Oy9qBxQc9VTvfTLSLUV4z1G9lyZYCXzoBQPKn+7pwM8MrYyVhfM6W9PvDSlV0tvMehRKGcwT54lDhhHDGXy+oS0oKPbq/R/wIpXT/18OkrTfjgx09fMW/lTkSlQ5v/39GzBHiV3S/aPaKrL9++/yhCHmlRSGdIzAFeGZvw2DH9npYBXiUW21pfXDQFqdb8e5gALzWAtlJo6yJXtnSYNbqr8FLSACBvIYEpeZCSJoonDuRQnCYBDXXYcbPWYP/RC6AXB3kP61Yrgb6j5ul4eKl82nqhsuhQW9qUSVG3egnheaD7YUP6tDD9lmCSrhaj61foGhXvNrVEPLC1gZeeZarNIRmbthXo6jM6wa+dDHnQyFNOCwoKAaArvpInjY961UuJOw/1E72Q6V5OZcKhv9M2LHnYDS0YaMKlEIvjZ67i7fvPYnuKPH/VyxfSXC1jqYeX7l6mF+TlG/fw6s1H4WGmAyftm1YP0ctIdadBTN7p2DGj4cqNB+IUKgFLzw51dT6IImsP2oqm9tB9vrFjxRA3I1B7jfUbmXJDAlTlxUD3nVI40PDezTV3rjb2Go2rNx8EC7EwF3hDqjt5teeu2C4WF9+//0SC+HGQK8tf4lYCJWbYWD+lcUjX3338RLs0CcTNCtb28NKzZfqgsToq+m6cP0wspLWToXt46at31N9pB0P7Hl6CD+2knKing2sUIqQk8qaSp4xCULQ93/R3U1pb46VNd7vuOHBGXD9EYRi00KhWvjAae5YN8etJSp+iKxtpd4F2WJIkjCMWfsp9sEobZexBCza6aeboqSvw8w9AxVL5xNkLZf7W7zeydpYBXlq837r3LNT38Jqyk7G+Zkp7feA1dJ+1Urb2XCyjt7E6UcjboZOXsGv5GJ3dVbpGjxwDdx88x7uPXxA/TkwUzZ9DOEjixv5zeM0S4KXfk/d6xcb9+CB2cROIee3QiUtme3h57Fhn7MgAL+0WGxo7IbFKePmbqsAbXhrpqPWgL63RdiJ5lugDApwcWwGK46OXD4UX0AKRk3UUIA+5Z+vByJwulTh4xcmxFaDdu4adRoI+3GDqS2uOrcSf1tGdvjWaD0Jfr/rwrFTMGZrMbQylAvY+dhh4Q2n48PAz8oI37ToGri4umD+xR4h30YaH+nIdQq+A4oU09KGR0JfKv1QUoFAFiik1FJvNKjmOAn5+/uKmGfoCJIVmKYc8HaeFoWsJxdpv2HEM60yEh4WudP6VIyjgCGOHgdfOeyLFQ9M2BG3Rj+jTUmdLys6bxtX/vwJ0ULBd78li21j57DOLY30FaJt7/Y5jmDOum9THUaxfAy5RTQXIk99j2Cycu3JXHDrUD0FR89nhvWw6iER3KVOIy4IJPXRuTQjvdef6qa+Ao4wdBl71+wo/gRVgBVgBVoAVYAVYAVYgDBVg4A1D8fnRrAArwAqwAqwAK8AKsALqK8DAa0Bj+kzu799AUFCgVSxA8WJubhEQEOBvlfKokAgR3BEYGCC+jqZ2cnd3h7+/9eru6uomPvgQGGgdfan97u4R4e/vp7YUXH44VIDG1u/fQVA+Z23LKtp2HKrXx11dXeHi4irmFGslNeY9a9UtLMuhuYqSvc9XESJEEFci0tiz58TvDnu2nnl1Z+Bl4DXZYxh4TUrEGcJQAQZey8Vn4LVcQ9kSGHhllbJNPgZe2+gcHp7CwMvAa7IfMvCalIgzhKECDLyWi8/Aa7mGsiUw8MoqZZt8DLy20Tk8PIWBl4HXZD9k4DUpEWcIQwUYeC0Xn4HXcg1lS2DglVXKNvkYeG2jc3h4CgMvA6/JfsjAa1IizhCGCjDwWi4+A6/lGsqWwMArq5Rt8jHw2kbn8PAUBl4GXpP9kIHXpEScIQwVYOC1XHwGXss1lC2BgVdWKdvkY+C1jc7h4SlOB7xb9xwzqbuLqwvwG1a7AYFuJICLK34HWe80q4urK/CbTsiabI7FGehlaM0T8HR6GyRxkPUqb2kdY8aKgWL5cogvMHEKWYG3Ty+EK4noS4O/6f+s152k22fLZ1vax0Nq1J8h6YIgC0R0jRAZcRJnFl9+pMS3NBhWnADr+Pmb+PDxs3Q/C48Zyb62uCVI7bbT7STh5aaJyJEioVj+rCAE4WR9BZwOeJNlKmR9FblEu1egY9uW6OXVAhHceKYxZcw7WxqaysJ/d0IFoqYoj0Q5GsP9/2OIgdc48I6ZsQLzl21wwl7CTQ5JgfKlimDMwPaaMcRqWVcBpwPe2MlzWldBLs0hFOjWpQP6dWvDwCthzTsbPCRycRZnUyBKqspInKsFA68Jw5OHd+TUpZgxb5WzdRFurwkFqpQvjkk+XRh4VeopDLwqCcvF2pcCDLzy9mLgldfKmXIy8MpZm4FXTidnzMXAq67VGXjV1ZdLtxMFGHjlDcXAK6+VM+Vk4JWzNgOvnE7OmIuBV12rM/Cqqy+XbicKMPDKG4qBV14rZ8rJwCtnbQZeOZ2cMRcDr7pWZ+BVV18u3U4UYOCVNxQDr7xWzpSTgVfO2gy8cjo5Yy4GXnWtzsCrrr5cup0owMArbygGXnmtnCknA6+ctRl45XRyxlwMvOpanYFXXX25dDtRgIFX3lAMvPJaOVNOBl45azPwyunkjLkYeNW1OgOvuvpy6XaiAAOvvKEYeOW1cqacDLxy1mbgldPJGXMx8KprdQZedfXl0u1EAQZeeUMx8Mpr5Uw5GXjlrM3AK6eTM+Zi4FXX6gy86urLpduJAgy88oZi4JXXyplyMvDKWZuBV04nZ8zFwKuu1Rl41dWXS7cTBRh45Q3FwCuvlTPlZOCVszYDr5xOzpiLgVddqzPwqqsvl24nCjDwyhuKgVdeK2fKycArZ20GXjmdnDEXCSYKbAAAIABJREFUA6+6VmfgVVdfLt1OFGDglTcUA6+8Vs6Uk4FXztoMvHI6OWMuBl51rc7Aq66+XLqdKMDAK28oBl55rZwpJwOvnLUZeOV0csZcDLzqWp2BV119uXQ7UYCBV95QDLzyWjlTTgZeOWsz8Mrp5Iy5GHjVtToDr7r6cul2ogADr7yhGHjltXKmnAy8ctZm4JXTyRlzMfCqa3UGXnX15dLtRAEGXnlDMfDKa+VMORl45azNwCunkzPmYuBV1+oMvOrqy6XbiQIMvPKGYuCV18qZcjLwylmbgVdOJ2fMxcCrrtUZeNXVl0u3EwUYeOUNxcArr5Uz5WTglbM2A6+cTs6Yi4FXXasz8KqrL5duJwow8MobioFXXitnysnAK2dtBl45nZwxFwOvula3KfCOmrZStKZv5/qaVn35+h3FanbFvtXjED9uLFCe1VsOir9HjhQRKZMlRJWyBVG/ekm4u0cQ/77n8Hn0Gj47mDJzx3XHLz9/dOo/Vedv9LuzO2aKf4udPKe6inLpdqmAIwHv3YfPMXPRJpy7chcBAQFImSwRShbOjWZ1yokxdfbSbcxcvBm37z+DewQ3JEsSH2WL/Y0mtcqifIPe6O/VECUL59Kx4wTfNfjy9QeG9mgKBl677OKqV9qRgDe0Y6h53fLo6eOLhPHjoGf7ujqaHzp5GeNnrcHuleMwcupSzJi3SnWb8APsSwEGXnXtFS6BNzAoCD3a1cbnL99w5eZDzF2+DXFix8CsUV3h6uoigNd3yWYsmtJHR52oUSLh1PmbGDVtBVbOGqD5mwuAGNGjMvCq25fsunRDwHv9ziP4TFqGX35+2Dh/mF20786DZ2jWdQzqVC0Bj0pFECtmdFy9+QDzVuzEoG5NEMHNBXXb+cC7TS2UKpwbAYGBuHz9PnYeOIPJwzpizIxVeP/xC8YOaKNp7+/fv1GhYR8M7d4UBfJmYeC1i55g+0oaAt6b955iyPhFuP/oOc7unGX7SoXiiZaOof3HLmL09JXYvWKMeF8pqe/IeWJx6d2mDgNvKOziDD8xBrz+AYEYPW0lBno3cgYZVGtjuAReaq22F/jb95/wbDUE7ZtWRfXyhf8A79Kt2DBvSDBhjp25Jl7aWxcPNygae3hV60t2XbA+8Pr7B6BK0/4CHOtWK4Ho0aLYRfs69puKuLFjwKdXc536BgX9RmBgIPYcPoe5K7Zj0wIfg+0hOG7dcyIOrJ0AWkBSOn/lDnqPmCte4G5urgy8dtETbF9JfeANCAhE5Sb9xBiqXbU4Yv7f6WD7mpn3REvHkJ+fP0rX7YmJg9vjn1wZxcN//PRD6TrdsXRqX2RKn5qB1zyTOE1uQ8B78MRljJ25Ch8//YtT26Y7jRZqNNTmwLthxxFEihRRx3tEQKsd0qAPvPTfE+esxbOXbzFxcAeTwNtl0HTEiRUDMaNHwd85M6FTixqayZaBV41uZP9l6gMvbft3HzoLh9ZP0vHShOeWBgYGoUDVTpjm00l4Yg2lB09eoXabIWjdoBJKFMqFv1Il1YQKKfmrNh2ADs2qoWLJfOKfhk9ZjojubujVoZ74bw5pCM+9IOzqpg+85y7fQbchM51yDA0evxgR3Nw0Hrndh85i/sqdWDN7EDiGN+z6aHh/ckghDRNnr0W3trXDexPCdf1sDrwEt+SpVRL9d522w0wC75J1e3Hg2EUsmtxLAG/vEXMQLWpkTTkVS+VHf68G+Pj5X7x59wkxY0TD67cfMHnuBiSIFxPjBrYTeRl4w3V/DLPK6QPvum2HsXHncSyf0S/M6mTug//9+h1Fa3YV3tvUKRIZ/fnpCzexdP1eXLx2D+SNypYpLdo1roL8eTKL31B87537z0SIA4U8lKnbE9NHeCFbxtQMvOYaxYny6wPv+u1HxBhaNr2v3ahgrTF0+uJN9Bo+B/vXjBfg6z14BnJmTYdmdcoz8NpNb7B9RRl41dXc5sBLzTF1aE0/D/03eXhfvn4vwJWAd8aijZg5qqtGHdp+Ja+ufrp0/R5adh+PcztnwcXFhYFX3f5kt6XrA+/S9ftw8PhFLJjY027aRB7e/JU7Yu74bsidLb3JelNs7tMXb7Bt3yksWrMHO5aOFAdHyQtct+1Q7F87AVdu3BfbaVsWjdCUxx5ek9I6ZQZ94F22gcbQJcyf0MNu9LDWGKIQIjoAOrhbY+TI8pdYNG5e6IMkCeMy8NpNb7B9RRl41dXcLoD3+4+f8Gg5BN5tPFG+xD8hhjToy3Xi3HX0H70AB9dNEH9iD6+6HcpeSzfk4d285ySWTtU9GBne29e21yTEixsTI/u01KmqEsMbEBiEKJH/CymiTPS3fJU6YPHU3sia4Y8Xlw621a9REmcv30HyxPHRvmk1Bt7wbvwwrp8hDy+NoSVTeodxzcx7vLXG0HjfNfj4+Sv+yZkBW/ac1CyeOaTBPHs4U24GXnWtHS6BV7mlgbaXrt16JA6oJYwfG1N9OgkvbUiH1hau3o1kieMhR5a04pYHiqXKkz2dJv6QgVfdDmWvpesD75lLt9Bz2GwcWj9R9Dl7SdduP0KLbuPgWakIalctiTixouHGnccifnBA18Y4dOISrt56gMaeZZE2ZRJ8/f4DqzcfxOFTl7F+3jBxTRmlxWv2gK5Run3/KZZP74c0KRMz8NpLJwijeuoD79nLt9FjqK/TjiG65aVNz4nIkDYFKpfOh1pVigvLMPCGUQe1g8cy8KprpHAJvMo9vJEiuiNV8kSoVq4Q6tI9vP9/GYcEvJt3HwfF+z5/+U5cRVamaB54tfTQeLUYeNXtUPZauj7wUmxrpcb90NCjDOpULa4TLx7e23jt1kPMWrIVFM7j5x+A1MkToULJfGjkWQbPXr7DkrV7cOHqXbx+9xGxYkRD3hzp0al5DSRPkkDTtNdvP4qryDL+lQKrtK74owwc0hDee0DY1E8feOmmk4qN+ooxVKtyUc3VkGFTO/Oeao0xRE+s0WIgnr14J2J5Y8WMxsBrnhmcLjcDr7omtynwqtsUudIZeOV0crZchu7hvXLzAUZMWS7u4TV2jZez6cTA64wWl2uzoXt4r91+jGETF+P+oxc4t8s+7uGVa23oc7GHN/TaOfovDQHvroNnMWr6Cvz86YfT22c4ugSqto+BV1V5uXB7UcCRvrSmtubs4VVbYfss35G+tKamBRh41VTXvsvmL62paz8GXnX15dLtRAEGXnlDMfDKa+VMORl45azNwCunkzPmYuBV1+oMvOrqy6XbiQIMvPKGYuCV18qZcjLwylmbgVdOJ2fMxcCrrtUZeNXVl0u3EwUYeOUNxcArr5Uz5WTglbM2A6+cTs6Yi4FXXasz8KqrL5duJwow8MobioFXXitnysnAK2dtBl45nZwxFwOvulZn4FVXXy7dThRg4JU3FAOvvFbOlJOBV87aDLxyOjljLgZeda3OwKuuvly6nSjAwCtvKAZeea2cKScDr5y1GXjldHLGXAy86lqdgVddfbl0O1GAgVfeUAy88lo5U04GXjlrM/DK6eSMuRh41bU6A6+6+nLpdqIAA6+8oRh45bVyppwMvHLWZuCV08kZczHwqmt1Bl519eXS7UQBBl55QzHwymvlTDkZeOWszcArp5Mz5mLgVdfqDLzq6sul24kCDLzyhmLgldfKmXIy8MpZm4FXTidnzMXAq67VGXjV1ZdLtxMFGHjlDcXAK6+VM+Vk4JWzNgOvnE7OmIuBV12rM/Cqqy+XbicKMPDKG4qBV14rZ8rJwCtnbQZeOZ2cMRcDr7pWZ+BVV18u3U4UYOCVNxQDr7xWzpSTgVfO2gy8cjo5Yy4GXnWtzsCrrr5cup0owMArbygGXnmtnCknA6+ctRl45XRyxlwMvOpanYFXXX25dDtRgIFX3lAMvPJaOVNOBl45azPwyunkjLkYeNW1OgOvuvpy6XaiAAOvvKEYeOW1cqacDLxy1mbgldPJGXMx8KprdQZedfXl0u1EAQZeeUMx8Mpr5Uw5GXjlrM3AK6eTM+Zi4FXX6gy86urLpduJAgy88oZi4JXXyplyMvDKWZuBV04nZ8zFwKuu1Rl41dWXS7cTBRh45Q3FwCuvlTPlZOCVszYDr5xOzpiLgVddqzPwqqsvl24nCjDwyhuKgVdeK2fKycArZ20GXjmdnDEXA6+6Vnc64J0yZ4WEoi7/z/NbIq9MFmuXR89Uo0xjbaFnWUsLtepuWR1TJE2GGpWKwdVV0VXGrs6Z5+Wt7c7ZcEOtdnEBfltzbIQgrS2fFQoLu0WOi3gpC8Dt/2PIxcUFbm4REBDgH4rSHPcnBLyb9p7Ek6cv7bqRZN8/Xd9G/V8ltf60I3y0IW7sWKhVuYhmDKnUZKct1umAN0iiY7u5uYmBHBQUaJWOocbEHyGCOwIDA2wyUN3d3eHvb72XlqurG+jdHRhoHX3JSPQS8ff3C7W9XOAi6sTJtAIyY8h0KdbLQVD1+3cQgoKCrFeoZEm2HYeW9fGQmuTq6goXF1cxp4Q20fChuU5Jasx7oa1bePodzVWEV35+v8JTtcyuS4QIERAYGCTGnj0nS98d1m67K7+IrC3pf3OSn9+v8LG0Ua2J5hfMwKurmTMAr/m9hH8RXhRg4LXcEtYAXv1aMPAatgsBFiVLFuiWW9zyEhh4LdeQS7CtAk7n4ZWRl4GXgVemn3Ce8KEAA6/ldmDgtVxD2RIYeGWVsk2+8ObhtU2rnfMpDLwG7M7Ay8DrnNOBfbaagddyuzHwWq6hbAkMvLJK2SYfA69tdA4PT2HgZeA12Q85pMGkRJwhDBVg4LVcfAZeyzWULYGBV1Yp2+Rj4LWNzuHhKQy8DLwm+yEDr0mJOEMYKsDAa7n4DLyWayhbAgOvrFK2ycfAaxudw8NTGHgZeE32QwZekxJxhjBUgIHXcvEZeC3XULYEBl5ZpWyTj4HXNjqHh6cw8DLwmuyHDLwmJeIMYagAA6/l4jPwWq6hbAkMvLJK2SYfA69tdA4PT2HgZeA12Q8ZeE1KxBnCUAEGXsvFZ+C1XEPZEhh4ZZWyTT4GXtvoHB6ewsDLwGuyHzLwmpSIM4ShAgy8lovPwGu5hrIlMPDKKmWbfAy8ttE5PDyFgZeB12Q/ZOA1KRFnCEMFGHgtF5+B13INZUtg4JVVyjb5GHhto3N4eAoDLwOvyX7IwGtSIs4Qhgow8FouPgOv5RrKlsDAK6uUbfIx8NpG5/DwFKcD3svX75nUXfke/O/f1vvqMr1QgoKs981xc8qLHy8mkiVOaLLdxjIw8IZaOof84dcPT8JVu1xcXSHGqhXHq2wDXV3d/j+urTdXGHv2n2cFylZN5IscLS4iRIpu8jcMvCYlsloGAqyHT17i05evViszLAr68w6ifq9u348aJTLSpkykWhMZeFWTNtwV7HTAm79UrXBnBDUrRJPSiKH9UKpwrlA/hoE31NI55A/v7/F2yHY5WqNcI8VF/JwtESN2UpNNY+A1KZHVMhBgTZm/Hhu27rdamY5cUMvGNVG3SjG4urqo0kwGXlVkDZeFOh3wxk6eM1waQq1K0Yts1dI5KFf8n1A/goE31NI55A/vbPBwyHY5WqNcoyREooIDECN2cpNNY+A1KZHVMhBgjZy6FDPmrbJamY5c0KBe7dCsdjkGXkc2so3axsBrI6HD6jEMvGGlvOM+l4HXPmzLwBs+7cTAa55dGHjN04tzG1eAgdfBewcDr4MbOAyax8AbBqKH4pEMvKEQzQY/YeA1T2QGXvP04twMvBoFOKTB/OHAIQ3ma+bIv2DgtQ/rMvCGTzsx8JpnFwZe8/Ti3Ay8DLwcw8vzgJUUYOC1kpAqF8PAq7LAoSyegdc84Rh4zdOLczPwMvAy8PI8YCUFGHitJKTKxTDwqixwKItn4DVPOAZe8/Ti3Ay8DLwMvDwPWEkBBl4rCalyMQy8KgscyuIZeM0TjoHXPL04NwMvAy8DL88DVlKAgddKQqpcDAOvygKHsngGXvOEY+A1Ty/OzcDLwMvAy/OAlRRg4LWSkCoXw8CrssChLJ6B1zzhGHjN04tzM/Ay8DLw8jxgJQUYeK0kpMrFMPCqLHAoi2fgNU84Bl7z9OLcDLwMvAy8PA9YSQEGXisJqXIxDLwqCxzK4hl4zROOgdc8vTg3Ay8DLwMvzwNWUoCB10pCqlwMA6/KAoeyeAZe84Rj4DVPL87NwMvAy8DL84CVFGDgtZKQKhfDwKuywKEsnoHXPOEYeM3Ti3Mz8DLwMvDyPGAlBRh4rSSkysUw8KoscCiLZ+A1TzgGXvP04twMvAy8DLw8D1hJAQZeKwmpcjEMvCoLHMriGXjNE46B1zy9ODcDLwMvAy/PA1ZSgIHXSkKqXAwDr8oCh7J4Bl7zhGPgNU8vzs3Ay8DLwMvzgJUUYOC1kpAqF8PAq7LAoSyegdc84Rh4zdOLczPwMvAy8PI8YCUFGHitJKTKxTDwqixwKItn4DVPOAZe8/Ti3Ay8DLwMvDwPWEkBBl4rCalyMQy8KgscyuIZeM0TjoHXPL04NwMvAy8DL88DVlKAgddKQqpcDAOvygKHsngGXvOEY+A1Ty/OzcDLwMvAy/OAlRRg4LWSkCoXw8CrssChLJ6B1zzhGHjN04tz2xHw3n34HDMXbcK5K3cREBCAlMkSoWTh3GhWpxwiR4qIddsOY8XGA3j26h1iRo+Kv1InRb3qpVAsf3aUb9Ab/b0aomThXDotnuC7Bl++/sDQHk0RO3lOp+oPrq6uWLV0DsrpAe/WvScxc/EWvPvwGdkypsHQHk2E1oaSu7s7Nuw4YjT/zMWbsevgWbx6+xEJ4sZCQ48yaFCzlKaoU+dvYNLc9Xj64g3SpU6G7u3qIE/29AgMDLSaLegl4u/vZ7XywmtBo6atFFXr27m+popfvn5HsZpdsW/1OMSPGwuUZ/WWg+LvNGZSJkuIKmULon71knB3jyD+fc/h8+g1fHawZs4d1x05sqRF/sodg/1tydQ+yJE5LRh4w2vv0K2XIeANCvqNSXPWYvPuE/APCBBz6yDvxogaJTJcXFwRGBigU4ix/NSvKB07cxXTFmzC+49fEDVKRDH261YrKf7m5x+AfJU6aMq7tHeO1YULqR//kytjqJ63YcdRHDxxCdOGd9b8vscwX+TKmg6NPMuEqkztHzHwmiehPvDSu6bPyLnBCqlatiB8ejUX//767UdMX7gJx89ew+d/v2FU31YoV/xvgw92c3PH2BnLg40JpY/r/0iZXxdO6oXc2dJp/kx1orqt9h2IjH+l0JmHXVxcxNxcsdQ/6NqqFlxdXcwTgXNbRQEXP79fv61SkhUKufPgGZp1HYM6VUvAo1IRxIoZHVdvPsC8FTsxqFsT3LzzCBPnrBOdOkv6VPj05RtOnLuOV2/eo1vb2hgzY5WYeMcOaKOpze/fv1GhYR8M7d4UBfJmYeAFcP/RCzTsNBLjB7VF9kxpMXvZVly+/gDLZ/QzaMXHz96gbrthRvNPmrsORf7JjrSpkuDm3cfoPtQXU4d3Qv7cmfHwySvxLLIJvYC27TuJCb5rsW3JSMSNHcMKveZPEQy8usAbGBSEHu1q4/OXb7hy8yHmLt+GOLFjYNaormKyJVDwXbIZi6b00bFB1CiREBgYJIB3/dwhSBA/tubv0aJEhpubKwOv1XqtugUZAt41Ww9h2fq9mDysswDUviPniQVO97Z1DAKvsfzerWsJqKjRYiDmjO2G7JnT4tHT12jadTQmDGqHv3Nm1ACv0o/IQWHtFFI/juDmFqrHMfCGSjbVfqQPvP4Bgfjx85fO80ZOXY7kSRKgU/MaAnDrtR+OssXywKNiMcSMERUuLkCcWIbfN+t3HMPiNTuDjQnq44YSAe/RM1eRPk1STBnWSWR5+eYDWnYfjzdvP4r3qAK8xB+9OtaFv38grt16iNY9J2iAWDXBuGCjCoQr4O3Yb6qAIGWVptSavAzkDRwxdQUiuLliQNdGBhtEcNy650QcWDsB9OKmdP7KHfQeMRe7V4wRL2v28AK+S7bg9v2nmDT0jxfv36/fUdzTG5sX+iBF0oTBtJ2zbDtu3n0knb+59ziUKpIbjT3LgH57/c5DzcRAhTfpMgaVS+cTnqDTF29i4ux1ePzsNeLFiYlaVYqjed3yZg9ZBl5d4CUBtb3A377/hGerIWjftCqqly/8B3iXbsWGeUOCaf3Lz18A764Vo5E4Qdxgf2cPr9ndM0x+YAh46aVcslAujafyyKmrIFjYs2qsQeA1lp/6xtlLt9F5wDQcXDcRUSL/8fjW7zAC9WuURLVyhTTAa6wfWUOUkPqxn58/pi3YiL1HLghvdrniedGtTW2xy7Fy0wEsXL0LHz/9KxaCHhWLol2TqmIXyqPVEPG+iRTRHW5ubji2aQrIw0seupdv3uPc5TtIlTwRRvdrLXZPKF2+cR/jZq3Bk2evkSRRPPTzaoCcWf4Sf6O5tW2jqth58Axu3X2M9fN9sHrzfsyYt8oaEjh8GaZCGmih1dhrlHh/ET/MWLQJz1+9x8g+LaW0adVjAkoUzBlsTFC/NQa80aNFBu2SkgOBdpknzl6LeHFiYfqiTVg2ra8GeLXn4Rt3HsNr4HSsnTPIKHxLVZgzhVqBcAO85FUqULUTpvl0Ep5YQ2n9jiOYOn8jurT0wN85Mwg4o60C7VS16QB0aFYNFUvmE/88fMpyRHR3Q68O9cR/M/BCLAASJ4wD7RVs2Xq9MLhbYxTJlz2Y9H1HzUfC+LGk8v/46YcKDXtjTL/Wwo7jfdfg5ev3mDC4vabcIROWIHq0KPBu7YlStbtjaM9mKPx3Vjx69losUOpV/7Mlak5yJuCl8JJI/99SJo3Ii0BAqx3SoD3RKjpOnLMWz16+xcTBHaSAlxYgtNWdPm1SdGxaQ0zslBh4zemZYZfXEPCWqdsTg7s1QdH8f8Y57d5Ubz4Ap7fPFLbWD2kwlv/k1unC+UAOBvK2tWtSDW6urpg6fwMWT+mNaFEja4BX6UdbFw+3uhghAe/Ymavw6u0H+PRsIcYIwUaZonlFuBXtchH4JowfW+wKduw3BQO7NkbeHBlgzMN779FzdGnpifRpk2HcrNWIHi0qRvRuITzdddoNw9j+bZAvdyYcPH4Zo6avwLYlIwQ0E/CmTp4YbRtXQeKE8ZAyWWJMmrOagVeyN5gC3p4+vkiVPLHw7lKq284HCeLFxJPnb/Dq7Sdk+isFBno3Rvo0yQw+MaQ+rizktH9IHt44saIhYsSIePjkJXp3rIdarYdi3dzBKFm7uw7wbt59XIwFf/8AUOgZvdu6t/2z6OJkewXCDfCSl7Foza7YtMAHqVMYjiWlSYtieLfsPSVWyhRbWujvLOja2lNsZ1CieNI7959h8rCOCAgMBHXm6SO8kC1jagbe//evroNmiBVo+6bVND2uWrP+6NS8psE4J+/Bs5AhbTKp/IPGLcLb958xc5SXWIxQyAl5RyYObi9eJk9evMWwiUvEFmiXVh4oWqMLOjStLkJYCIJDm5wJeAluyVOrJPrvOm2HmQTeJev24sCxi1g0uZcA3t4j5ojJWEkVS+VHf68GoB2Vq7ceIGG82Pj24yeWb9gPisPeuGCYiAlm4A1tL7Xt7wwBb+HqXpg0tAPy5cokKkOwRmcfDq2fJDxU+sBrLD/topE3bdXmg9hz+JzoFyfP3xDQ0bJ+RVH279/A9TuPES92dNGPKH7f2slYP+7XuT4KVu0sdjCSJo4vHkv13LLnOKaP6CJAeOm6vcJL/enLVxEe17NdbdSuWsIo8GrH8JK3dtm6fWL7esGqXWKHis6IKMmj5SAM69kc2TKlEcBLYR8051LiGF7zekFIwEte03a9J2Hb0pHiTA+l4h7eAizr1SiJiO7umLVkC/YduYAti3wQMaJ7sIeb6uP6P1CAl+LVqzTtj8ql84vnEIf8U6mDDvD+/OWHzi1qiDn1zbuP4iwL7Q5Q3Dwn2ysQboBXiRucO74bcmdLb1IJiuO59/AZ5izfjhev3ou4GEoPnrxC3bZDsX/tBFy5cR+0yt+yaISmPPbw/vHwJkscD14tPTS6kIeXBqHi+dE2AHl4kySMYzI/eXPpBTJvfHfE0IrXW7v1EOat3IlPn78iS4ZU+Pj5K+pULY4GNUvj4InLIr6UFikUA0zQXaxAcC+zqQ7hTMBLWpg6tKafh/6bPLzkbR83sJ0A3hmLNmLmqK4aaSkMyFCcG43NgtU6w3d0V3HYkIHXVG8MH3835uElMCv8TzZRSRkPr6H85OG9cPWOODdBMbrksbr/+CU69J2MZnXKo36NUmLB6+YWAQEB/qoJYqwfE2CUrtNDhBcoicIUyDEyb3wPeLQahFxZ06Nto8pInDAuevrMFgtyqrdMDO/hk1fE1vma2YNEqN2ug2d0Fuzff/wU3l/aMWPgtcz8IQFvuz6TkTd7BrRuWEnzENJ73MC2mkUd7ToWqtYZK2b0Q+b0qYJVhpxixvp4SB5e2tWgUAYKj9m+dJTYLdAHXv15+NiZa+LAHYXJcLK9AuEGeKnpbXtNQry4MYPF3igxvAGBQZpYMUWqC1fviu0omoCVRFsaFEd29vIdJE8cX8czycALzFq8BXcePsOkIX9OUJN3vZiHt/Cup0oePIZ39tLtuHX/sdH85EkfNnGpiH+b6tNJB3b1uzQ9q1qzgWLbU4l/ozzff/zC6i2HsHDVThzZONnskcDAG3IML72APVoOgXcbT5Qv8U+IIQ364tMLo0gNL6zxHSTCGhh4ze6eYfIDQ8Dbots4lC6SBw09Sos6HTp5GSOmLMf+NeMNxvAay7931VgRn087Adq3GQyduER4swggbAW8hmLRqQ4UIrd9yQgkiPffwUtqs+LVPrVtuvBMU6JdKAV4aRt675FzwhOsJP1bGrSBd+7yHXj15gMGehs+W8LAa1n3Nwa85FzpNXwOti8dIcJxlNSo00hULpMf9Wv86eP0biHg3bGL0N0BAAAgAElEQVR0pMbbr10jilMvVTh3sDFBfdxQUjy8BLxv3n3CqQs3RMw6JVPAe/T0VfhMXoo9Kw2XbZlS/GtTCoQr4L12+xFogvWsVAS1q5YUcTK0ZTF/5U4M6NoY0+avRwq6YqlMQSSKH0dsS9EWQfw4sTC895/rSCgtXrNHTOR0MGv59H5IkzKx5m8MvBC6NPEaLbY2s2ZMjbnLt+PMxVvCW0GJJvwT525gTP/W4r/Jc9Ogw3CD+Ql2O/WfhkgRI2BI96YiZo0SXXGkrI7JqxglciQ8fv4ak+duQLrUScWtG6/ffsDyDfvgWbkYkiWOj50HzmDWkq0ITawfA6/hWxpogXHt1iNxQI08ELQgIRAJKfbx4PFL4tRxob+zCrtOX7QZ9x4+x8qZA8QNDwy8pqbV8PF3Q8C7ctN+rNx0EFN96JaGSGK3J3P6FOjTqYEYsxt2HNYZ+8by05kIcjZ06DsFM0d1EZ7/F6/eoVXPiejaykOERh06cUnEUBbIk1n0I21vq7UUCqkf/4+9sw6PImnC+BvDPdjhcHD4cbgfhxzuevjhFpzgHkjwEByCuwV3d3c43OVwhzsg9j3VfLuXbHYzvbuzs5uk+nn4g2xNd8/b1TO/qanu8fJdildv36FPx4YiXYNycB8+eY5KZQqLqGt/j8bCx+leQQtn6dUzRXgpfWfI+IVYMvX7Dia0cDMy4KUH/WYePhjUvSlKFckjdkY5deE6CufLLgCLgde60TYFvM26+gg/a1H/93ANrN16CLMWb8Z0725inc+0Betx7dYjLPD1NHp/W735oNi5xHBO6Nb9GPY+LPAa/mYIvLRbjmenhmLnG/I9Wr9C64/IJ7lor4BDAS+dPm3dQdBz4a/bYtFDpnSpULlsEbGCkp7o1mw5gGu3HorX4vSanaIV7ZpW1+/KQHXQEzxtRUY5UytnDg6nKgPvdznWbz+C2Uu24PXb98idPbNYyKJ7MKD9CzftOqZ/CqVc6dWb9hu11+0Ba+i6lIdNEWMqPYdNx+GTV5AuTXLUrlwKfzasAhcXJ3z89BnDJiwSN05a+EI5fnQTorQHcwsDr/F9eOkBhHLGKALRiPbhdf2+VVNkoHDp2l0BAHce/C1sC+bNhr6dG+mjIwy85nqnfeyNAS/deCn1aMueE2Kf8zLF84lUJlqARcDrN3dtuLlvyl4XUaNtBuev2CG2gkqYIC6a1ikv8mCpXL5+T/gRgSaVwxa8uVFSLjI/pjcTMxdvFLs0vHn7AenSpBBwpNulhNLdKMeSNKAIbYXSBQTwUnSYXjsfPH4RSRInEDv8RAa81Ee6htGOEDfuPBYP/QXyZsWg7s1EnjMDr9IoRv67MeDdd+RCuIWBhjUsXL1TpBrQ+obiBXOJhWW0ywYVw/ubs7MrfKYujTAnwkaNw9ZvDvDq9kOn48kX6O0aLdY2lktsnUp8tIwCDge8Mp22xoaB13z1CHgDA9XLw3N2dhH7IvKHJ8wfC0c4goHXEUZBuQ/8pTVljexhwYvWzFNdaZcG82qLaB1TgiXW6hQdjmfgjQ6jGMk5mPrSmjmnzcBrjlrR35aBN2qMMQOvY44TA69548LAa55ebG1aAQbeaO4dDLzRfIDtcHoMvHYQ3YImGXgtEE2DQxh4zROZgdc8vdiagVevAKc0mD8dOMJrvmbR+QgG3qgxugy8jjlODLzmjQsDr3l6sTUDLwNvmcIWzwMGXouli5YHMvBGjWFl4HXMcWLgNW9cGHjN04utGXgZeBl4+TqgkgIMvCoJaeNqGHhtLLCF1TPwmiccA695erE1Ay8DLwMvXwdUUoCBVyUhbVwNA6+NBbawegZe84Rj4DVPL7Zm4GXgZeDl64BKCjDwqiSkjath4LWxwBZWz8BrnnAMvObpxdYMvAy8DLx8HVBJAQZelYS0cTUMvDYW2MLqGXjNE46B1zy92JqBl4GXgZevAyopwMCrkpA2roaB18YCW1g9A695wjHwmqcXWzPwMvAy8PJ1QCUFGHhVEtLG1TDw2lhgC6tn4DVPOAZe8/RiawZeBl4GXr4OqKQAA69KQtq4GgZeGwtsYfUMvOYJx8Brnl5szcDLwMvAy9cBlRRg4FVJSBtXw8BrY4EtrJ6B1zzhGHjN04utGXgZeBl4+TqgkgIMvCoJaeNqGHhtLLCF1TPwmiccA695erE1Ay8DLwMvXwdUUoCBVyUhbVwNA6+NBbawegZe84Rj4DVPL7Zm4GXgZeDl64BKCjDwqiSkjath4LWxwBZWz8BrnnAMvObpxdYMvAy8DLx8HVBJAQZelYS0cTUMvDYW2MLqGXjNE46B1zy92JqBl4GXgZevAyopwMCrkpA2roaB18YCW1g9A695wjHwmqcXWzPwMvAy8PJ1QCUFGHhVEtLG1TDw2lhgC6tn4DVPOAZe8/RiawZeBl4GXr4OqKQAA69KQtq4GgZeGwtsYfUMvOYJx8Brnl5szcDLwMvAy9cBlRRg4FVJSBtXw8BrY4EtrJ6B1zzhGHjN04utGXj1CtRv0T1G+YOTsxM6tm2B8qUKWHzebm5uCAwMtPh4wwOdnV3g5AQEBwerVifdRAIDv6lWH1dkWoH7h31YnqiggFtCJMtRF4mSpFHsrbOzM5ycnBEcHKRoK2vg5OQEFxdXBAWpd+2QbduR7ehaNWvxJhw6fs6Ru+kwfav6eyk0qFYazs5ONukT3ztsIqtDVur07dvXUIfsmY06FRSsfLouLi4IDQVCQtQBMrrwE+SpeTOhGwn1L5Q6qlBcXJzhBGU7U9Uw8CopHLN+l5lDWipCcyE0NAQhISFaNivaMmceWts5V1c3s+HRxdlJPFwqFQZeJYXU+50AKzgkFN++Re0H9O++HyLmni2LeHBytl0LDLy209bRao5xwCszALYAXrUjHXTzI4CWAV6Zc47MhoHXWgX5eFsqYE/g1XYe2u4tBgOvLT00fN0EWFSi+hspV1dXBAfbHnhtPTIMvLZW2HHqZ+A1MhYMvIYXaE5pcJwpyz0xVICB13qfYOC1XkPZGhh4ZZXSxo6BVxudHaEVBl4GXkU/5AivokRsYEcFGHitF5+B13oNZWtg4JVVShs7Bl5tdHaEVhh4GXgV/ZCBV1EiNrCjAgy81ovPwGu9hrI1MPDKKqWNHQOvNjo7QisMvAy8in7IwKsoERvYUQEGXuvFZ+C1XkPZGhh4ZZXSxo6BVxudHaEVBl4GXkU/ZOBVlIgN7KgAA6/14jPwWq+hbA0MvLJKaWPHwKuNzo7QCgMvA6+iHzLwKkrEBnZUgIHXevEZeK3XULYGBl5ZpbSxY+DVRmdHaIWBl4FX0Q8ZeBUlYgM7KsDAa734DLzWayhbAwOvrFLa2DHwaqOzI7TCwMvAq+iHDLyKErGBHRVg4LVefAZe6zWUrYGBV1YpbewYeLXR2RFaYeBl4FX0QwZeRYnYwI4KMPBaLz4Dr/UaytbAwCurlDZ2DLza6OwIrTDwMvAq+iEDr6JEbGBHBRh4rRefgdd6DWVrYOCVVUobOwZebXR2hFZiHPAGSXz22xZfWnN2dhGfAja3OAFGvyOu7SdN+Utr5o5bdLaXmUNanr8h8Do7AfRPi6LtPORPC2sxprZugwArOCQU3wIDbd2UTeuneRcSou6nhbWcuzpxGHht6iYOVXmMA94hPtPsMgBOcEIoQs1uO33aNGjdtA5cXcLfwbW90TLwmj1w0fiAvy8vd+izi50sD5Kl+RlOGkCvtvOQgdehHU+ycwRYG3YcwcW/bkke4aBmNMHELc38+5qpM8qdMxuqly8MF62eWAEw8Dqof9mgWzEOeJOky2cDGW1X5e/ly2L5fF+4MfBGKjJftGzng4Y131xXV7vGLGgpUZ5OSJm1Apw1uGky8JoeICcnJ1AUMCgoakcyLXBBxWuV95QlmD53pdpVR/n6PNo3QY+29SMEeGx5YnzvsKW6jlU3A69jjUeE3jDwyg0QX7TkdFLDioH3PxUZeBl4zZ1TdK1i4DWuGgOvud7E9uYowMBrjlp2sGXglROdgVdOJzWsGHgZeGX8iCO8xlVi4DXtPQy8MjOLbSxVgIHXUuU0Oo6BV05oBl45ndSwYuBl4JXxIwZeBl4ZPwlrw8BrrmJsb44CDLzmqGUHWwZeOdEZeOV0UsOKgZeBV8aPGHgZeGX8hIHXXJXY3lIFGHgtVU6j4xh45YRm4JXTSQ0rBl4GXhk/YuBl4JXxEwZec1Vie0sVYOC1VDmNjmPglROagVdOJzWsGHgZeGX8iIGXgVfGTxh4zVWJ7S1VgIHXUuU0Oo6BV05oBl45ndSwYuBl4JXxIwZeBl4ZP2HgNVcltrdUAQZeS5XT6DgGXjmhGXjldFLDioGXgVfGjxh4GXhl/ISB11yV2N5SBRh4LVVOo+MYeOWEZuCV00kNKwZeBl4ZP2LgZeCV8RMGXnNVYntLFWDgtVQ5jY5j4JUTmoFXTic1rBh4GXhl/IiBl4FXxk8YeM1Vie0tVYCB11LlNDqOgVdOaAZeOZ3UsGLgZeCV8SMGXgZeGT9h4DVXJba3VAEGXkuV0+g4Bl45oRl45XRSw4qBl4FXxo8YeBl4ZfyEgddcldjeUgUYeC1VTqPjGHjlhGbgldNJDSsGXgZeGT9i4GXglfETBl5zVWJ7SxVg4LVUOY2OY+CVE5qBV04nNawYeBl4ZfyIgZeBV8ZPGHjNVYntLVWAgddS5TQ6joFXTmgGXjmd1LBi4GXglfEjBl4GXhk/YeA1VyW2t1QBBl5LldPoOAZeOaEZeOV0UsOKgZeBV8aPGHgZeGX8hIHXXJXY3lIFGHgtVU6j4xh45YRm4JXTSQ0rBl4GXhk/YuBl4JXxEwZec1Vie0sVYOC1VDmNjmPglROagVdOJzWsGHgZeGX8iIGXgVfGTxh4zVWJ7S1VgIHXUuU0Oo6BV05oBl45ndSwYuBl4JXxIwZeBl4ZP2HgNVcltrdUAQZeS5XT6DgGXjmhGXjldFLDioGXgVfGjxh4GXhl/ISB11yV2N5SBSwC3rfvP6Js/d6iTTc3V6RN7Y5WjSqjVqWSlvbDJscN9JmH7D+mR8uGFfX1J0mXzyZt2apSY8BL+o+ctBTHzlxBgvhx0aROebRpXMVkF8h+xMTFOH72qkn7uw+foXEnL+xYPgZJEycMV9ebd5/gO2cNjp6+gvcfP8NnQFtULFPI4lN2dnaBkxMQHBxscR2GB0ZF4N118Cz6jpodQQP/8b1R+JfsFmmzbtth7D92AVNHddUf32fkLPySOyua1atgUZ2GB0VF4P3r5n14+S7FnftPkCa1Ozw7NUKpInlN6qFk//zlW0xbsMHknAgMCsaYqSvg6uqCAV0bq6K7LX3c2dkZTk7OCA4OUqWvVImjAq/P1BXiHMOOy4dP/+DXOj2wZ9V4JE+WGGSzatN+YRcndixkSJsS1X8vjsa1yop7HpXI5u/PubKgaLUuEbRcPKU/Cv6cA95TlmD63JWqaR1dKvJo3wQ92taHq4uTOKUd+0+jv7d/hNOr8XtxePVtpf97ZPcvY9qEtU+Z3B2Bgd+MSqjzgwW+fZE/T1a9DfWJ+rZq1hDBGGH9hfyefKhKucLiXJydv58LF/srYBXw7lw+FnHjxsaZCzcxwMcfk0d2RvGCue1/Vv/vQXQFXk+vOQgNDRUX7Kcv3qDroKkY6fknShc1fgMn+5CQYAzo2gTPXr6NYN+hny9u33uC128/YP/aieGAlwD3j06j8PuvBVC3yq9IlDCegFVDKDZn0Bl4v6tFN8xZizdioV//cPLFixsbri4u5kiqt2XgBRLl6YSUWSvobzSBgUGo3nIQGtb4DQ1qlMHhE5cwespybFk8GsmShH+4IyGV7MPOiYY1yiF+vNgAQvVzYv+xixg3YyXevvsoggAMvIEW+bKtDpIF3uCQEPTp2ADvP3zGpWv34L9sC5ImSYiZPj2Eb0U2f4ODQwTwBvgPR4rkSfSnEj9uHMSJE4eB18TgGgIvPTj+++VrOGvvKcuQ7ocU8GhVW/w9svuXsWYM7ZWA9/Cpy8iWOQ38RnqI6uie26b3BLx4+RbLpg/UAy/dk/t2aYTAwGBcuX4P7Twn6oHYVr7M9ZqngFXAGxaOCKro5tG9bV382WMsHj99hdDQEOTImhGDuzfFj5nSiJ6VqdcTHZrVwPb9p3D91gOsnDUUsdxcMMpvGS7+dQfuSRPhW2AQOrWogbpVS2Peiu24c/9veA9oI45/9eY9KjTyxJkdMwUUvHj1Dj7TluPClTsCvts0rox6VX/Fpl3HMGLSYjg7OYkoC0XMpnh1RVSP8H77FoiStbtjxYwhYhLSJJs0Zw1ev/2I0f1aRxh9nf3SqQPExKRizP6ff7+gRM1uEYB3+sINePriLUaFeZrWNUJ1j52+CvuPnRdjljNbBgzr1UJcjCIrDLxhgHfJZqybOzyCXKb8mgxXbNiHBat2CKCiG3DdKqXRsUUNPPr7Beq2HS4i57FjucHFxQVHNviBIrwUcXj64jXOXLyJjOlSYczAdiJqReXi1TsYP3M1Hj5+jh9SuWNgtybIl+tHk/M1+GzEyJV5lx3bWhsC7+kLN9B7xEwcCPDVQ3CTLqPRsEYZ1K5cKkJnlOxpTjx59hre/dvA1dVNREVpHhqWSbPX4Ou3oHDA++TZK3hPWY4Lf90WkcMCeX/C+CHtpQThCK+UTIpGssBLFYV9WPn8zxfUazscnVrWEA8yAnhNzN+v3wIF8NIbs9QpkoXrE40jR3iND5Mh8Bpa3X/0HM27+WDjAq9wD6um7l+mnCGsvRLwJogfB5t3HxcPOsQxNK/dkybGtIUboLuvGvrU1ZsP0G3INKyZM9Sq4JCiM7OBWQqoCLyzkD5NSnRqWQuXr93FjxnTIFYsNwRsPYSDJy6CXtPqgDdTutTo0Lw6Uqd0R6rkSdGq51iUKpIHLRtUwrsPn9Fv9BxxM1ICXmcnZ9CN6/dfC4q0hcd/v0Kb3uMxw6e7gLvoGOG99/AZ6rQZitPbZyOWm7O40QZsO4T1245g6bSBEQZfZ3988zTEjRNL/G7M3tQFo1FHL6RMngQPHj/Ds5fvkOPH9BjSszmyZU6LJQF7cOTkZfgMbAsXF2ccOnEJubJl1D/cmPJEBt7IgTckJDRSv6YHQHqtSuNCUfkuA/0wpEdzFPz5J5iK8N6+/wTd29RDtixpMX7mKiSIH088INGr+YYdR2LcoPYokj8H9h+9KB4gKfpJ0EwPqGHn6w8pk+HRtj/MushobWwIvGu3HMT67UdFNEZXBnjPRaoUSdGjXb0I3VOypzmRwj0RHj55EWFOhK3MGPD2GDpdzI+2Tarh3YdP2LjzGDo2ry4lEQOvlEyKRgQn67YdQuzY36+HVOg6SkAbNqXBEHjp/xQsePz0JSYN6ywFvBTAiRc3DrJlSYMuLWuLsWfgNT1ESsDr6TULGdOl1kd3dTXZEniTJo6PWLFi4d7Dp+jX5Q/UbzcCa/2HoWyD3uGAd+POo4gfL454Q0QpMn/UKoveHRroU2AUHZMNbK6AKsB74uxVdBs6HfMm9EbenFmwbe9J7DhwCrfvPwU5oouzM/aunqAH3jnjeumjjfQk5DFoCnavHC+giUrXwVNRtsQvisB77eYD9Peei61LvPVC0avKNKkop7hStATe67cfihSDy/vmizQFulCT3nOXb8O6eSMiOIzO/vyu2SKnjooxe1MXjDJ1e6JJnQpoWPNXxHJzw8zFm7Dn0DlsWuiFRWt2Y+eB0yL6TgCsq1/Jaxl4/wNeeriji6SuVClXFDV/LxapXz97+QZL1u4GRSIJmugh0bNjAzSo8ZtJ4A2bw0tvV5au3SMAcP7KHXjw+DlG9Gmp70PdNkMx0rMV8uTILIA37Hwlo6iWw0sPZvuPnsf8SZ76c6S3P26uriKabViU7GlO0M3sj9plES9uPEydvw57Dp0Vc4Ie8nXFGPDS69RkiROie7u6ESJ/SvOGgVdJIbnfCXgJbilSqyv0/4YdRioC7+K1u7HvyHksnNxXAK+x+TuoWxPQQ+vl63eR0j0JPv/7BcvW7QXdJ9fPH4mECRJwhNfEUEUGvMQKHfv5YssSbyRKEC9cDbYG3qZ1K4i0qGrli4r7ID0oF67aORzwfvn6DV1b1xZj/+LVW/j6B4i3aUN7NpdzTLayuQJWAW/ihPERGBQkLvJ9OzVC1fJFsW3fSUyavRZDe7YQaQRPnr0U+S4HA3yNAu/uQ+ewcNWOcNEXWeClC8/gcQtEGoSu0Gv22pVLomvrOtESeHUR23M758DFxUkf4V239Ug4DXV66OxPbZ2uvxlThNfQ3iTw1usJ3xFdUOD/Cfv/fvmGEjW7Yvn0gSKiP2HWGpHSQJO8XMn84gmYclAjKwy8/wHv9IXrMcOnh14u0o5A1pRfd/mzNuq2HYpfcmdDh2bVkDplMnh6zRbR3ca1y0kB78Hjl0Cv5VfPHipyWXfsPyUWM+oK+QJFf2lRV3QAXorYbtx1HEum/JcrTRHelCmSoGe7+hFcVcmeNBk/pAOK/JJDpDR8+vwPitfwEHMiZ7aMkQLvnQdP4TtnNU5fuCleydJDSus/Kktd6Bl4pWRSNLI0pYEqpgjv0+evMX5IRwG8xuavsfUNlNNbvGZXzBrTA0UL5GbgtQB4O/afjIJ5f0K7plUjHG1r4O3YoqZIZaB0sq1LfMTbNUPgpU6FTYE5cuqKWHBHaWVcHEMBq4B3zZxh4qJNE1y3EpEiJwTCuleF9Co1MuA9c/EGBo6ZB1oAp4sQhgVeeqK++NdtTBzWSSgWNof38rV7GD5xITYuGGVUzcFjF4hXSBTt1ZVokcNbqxtWzByqz+GdOGs1Xr35IFILDIvI4a3VTaQ76HJ4jdmbumA08/BGzUolxIIfKv/8+1UA77Yl3kiTOrm+ObqR9x4xAw1rlEWTOuUYeCXmt6kcwPNXbpv0a0pBqNSkH05smSZyQKlQjq4OeOm12u5DZzBtdHd9Dwx3aQgLvP7LtuHZizcY0rOZ0R5HB+A9deE6PEfOxoGASfprDL0laVDjV5Hvb1iU7GlOVKtQFI1rlxfA+/HTZwG8hnPCWIRX11ZQcDDOXrqJLgOmYPmMQfgpSzpFj2HgVZRIysBS4KVrZN02w9GzfT1U+q1wpCkNhh2hQEGp2t2wetZQ5MiWiYHXTOClIEDfUXOwdclokSJiWLQAXlpXceLcVdSsWEI0rwS8h09ehtfkJdi1YpyUX7KR7RWwCngNV/RTd2mRGb0+HDOonYCjyf4BoC1+TEV4Kbm/StP+oFcGFUoXxNlLN+A3d51Y/EY5vEdOXcagsfMx3bs7JVph4eqd2HP4nFi0RutEKJ+ufKlfxNZcTnDClRv3RM5M0fw5xbZB9EqfttGiCw49lUV14CWNaQEOLUjq79FYvDrpPMAPg7s3R7lSv4hIa6f+k9G8fgX9tktkTw8k/T2a4OXrd+HsdS5m6oKxdushzFq8GdO9u4mI7rQF63Ht1iMs8PUUT7vp06QQC28o0k/tNq1THtUqFGPglZi7poCXViab8usCebKJqCuNfYlCuXHg+EXxRoVepVGEl16bDhm/EEumfo9m0oKZyICXFro18/DBoO5NRR49rUgn4CucL7t4oIkOwEsPfVWbDxTXmPrVSuPI6Stim77Ni0YhhXsScY3wnRMgtjmia4SSfdg5kTlDWkz2X4Nrtx6KORG2GANeuh5W+q0QsmVJh0dPXqJZV2+smT003MOjKddh4JWYVBImssCr26Xh46d/cOX6fbFAjfxjipeHeHCKbNHa/qMXxGp+mqOxY7li2sKNYiecFTMGI3bs2Ay8ZgJvs64+YivMFvV/N3qkqfsXBQCOnbmKsYPahTvOnEVrlMNLEV7DYgi85C+enRqCovkPnzzH8ImLUSjfT+jTsaGEV7KJFgqoDryUC0VblJ08dx1pf0iB30sXwMpN+00CL50kRXlH+S3Fm7cfUbZkfrEYpMbvxQTwUo6q1+SlYs+71CmSon71MmLLH90uDX8/ewVf/7U4e+kWvnwNFFFMegL/OWcWUK5jnxGzcOPOIwHTFAGNDsBLUe6RvkvF0yZtc0O5hB2afV/4QpGjQpU7ibwh0o8K2VPk/eT56xHs6XeCK9KKYIei87TLQtgFPksCdmNpwB6R91a8YC6RtkCr/ncdPAP/ZVvFIo748eKieoVi6NamruK+g5zS8H1qR3bDjMyv6TiaA5QzVqZ4PhGhrVC6gABeeuCh12gHj19EksQJxJuTyICX+nHu8i1Mnb8eN+48FgvVCuTNikHdm4m3N9EBeOkcL127i9F+y8SOL2lSJ0PP9g1RtsT3PbnpIYFel1IOboa0qcTfIrOn3+nBmx74aE6UKJQLfTt/nxNU6FpFC/++fPkG2ruBFosO6tYMFcsUFKkk2/aeEosNU6VIInasoVQwmcLAK6OSso0s8Or24aU5QbmYFNlrRPvwun7fMjCy+Uv+Qw+idx78LWwL5s2Gvp0biQcbXrRmeoyM5fDuO3Ih3EJaw6Mju39R0It2bAobZTW0p0DO0mkDjHaKfEUWeHX+QhXRtZPeAvRsVy9cXr+yd7KFLRWwCHht2SGqO2xKg9ptRQfgJU0i2w5Jbc3c3NwQGKjeXpoMvGqPkLb1RbVFa7ZUR9t5GMvkBvnWnmNM+vCEtVpZezwDr3nAa63eSsfb8kFSqW3+XVsFGHi11dvs1vjTwnKS8UVLTic1rBh4/1ORgde0Rznql9bUmAPW1MHAy8Brjf/wsZYrwMBruXaaHMnAKyczA6+cTmpYMfAy8Mr4EQOvcZUYeBl4ZeYP26ivgEMCr/qn+V+NnNJgvrqc0mC+ZtH5CAZeBl4Z/2bgZeCV8ZOwNkofnjC3Phl7DpbIqBQ9bBh4HXwcOcIrN0B80ZLTSQ0rBl4GXhk/YuBl4JXxEwZec1Vie0sVYOC1VDmNjmPglROagVdOJzWsGKcb32kAACAASURBVHgZeGX8iIGXgVfGTxh4zVWJ7S1VgIHXUuU0Oo6BV05oBl45ndSwYuBl4JXxIwZeBl4ZP2HgNVcltrdUAQZeS5XT6DgGXjmhGXjldFLDioGXgVfGjxh4GXhl/ISB11yV2N5SBRh4LVVOo+MYeOWEZuCV00kNKwZeBl4ZP2LgZeCV8RMGXnNVYntLFWDgtVQ5jY5j4JUTmoFXTic1rBh4GXhl/IiBl4FXxk8YeM1Vie0tVYCB11LlNDqOgVdOaAZeOZ3UsGLgZeCV8SMGXgZeGT9h4DVXJba3VAEGXkuV0+g4Bl45oRl45XRSw4qBl4FXxo8YeBl4ZfyEgddcldjeUgUYeC1VTqPjGHjlhGbgldNJDSsGXgZeGT9i4GXglfETBl5zVWJ7SxVg4LVUOY2OY+CVE5qBV04nNawYeBl4ZfyIgZeBV8ZPGHjNVYntLVWAgddS5TQ6joFXTmgGXjmd1LBi4GXglfEjBl4GXhk/YeA1VyW2t1QBBl5LldPoOAZeOaEZeOV0UsOKgZeBV8aPGHgZeGX8hIHXXJXY3lIFGHgtVU6j4xh45YRm4JXTSQ0rBl4GXhk/YuBl4JXxEwZec1Vie0sVYOC1VDmNjmPglROagVdOJzWsGHgZeGX8iIGXgVfGTxh4zVWJ7S1VgIHXUuU0Oo6BV05oBl45ndSwYuBl4JXxIwZeBl4ZP2HgNVcltrdUAQZeS5XT6DgGXjmhGXjldFLDioGXgVfGjxh4GXhl/ISB11yV2N5SBRh4LVVOo+MYeOWEZuCV00kNKwZeBl4ZP2LgZeCV8RMGXnNVYntLFYhxwFusQkNLtbLLcUULF8SEUX3h5uIUrn1XVzcEBwchNDTU5v1yc3NDYGCgau04O7vAyQkIDg5WrU4GXtWkVKzozu5eijb2NEiQpQ5SZC4FZ+fwc8YWfdJ2HsZCYOA3W5wGnJ2d4eTkLK4pahUGXtPAO2VeANZt3aeW1NGmnga1KqJ1o8pwNbjf2fIE+d5hS3Udq+4YB7wX/rqtOAJ08SeODA0NUbSVM3CCs4szQiwAPBcnJ+TJ+aMAxLBF2xstA6/cOMcMq09vHzrUiTo5uSAUITRhRb9cXGIhbqLUmvRR23nIwKvJoNq4EQKsew+e4u2nzzZuybbV030yJESte+T3vsZ2c8VPmdPYtuMGtTPwaiq3XRuLccAro7aLi4u4d4aEqBOBtEWkQ9sbLQOvjN+wjX0UcHFxFQ+nat98Zc5G23nIwCszJo5uQ4BFxVbReq3O39XVFcHBISoGhrTqefh2GHjto7s9WmXgNaI6A6/hBYGB1x6Tk9uUU4CBV06nyKw4pcF6DWVrYOCVVUobOwZebXR2hFYYeBl4Ff2Qc3gVJWIDOyrAwGu9+Ay81msoWwMDr6xS2tgx8GqjsyO0wsDLwKvohwy8ihKxgR0VYOC1XnwGXus1lK2BgVdWKW3sGHi10dkRWmHgZeBV9EMGXkWJ2MCOCjDwWi8+A6/1GsrWwMArq5Q2dgy82ujsCK0w8DLwKvohA6+iRGxgRwUYeK0Xn4HXeg1la2DglVVKGzsGXm10doRWGHgZeBX9kIFXUSI2sKMCDLzWi8/Aa72GsjUw8MoqpY0dA682OjtCKwy8DLyKfsjAqygRG9hRAQZe68Vn4LVeQ9kaGHhlldLGjoFXG50doRUGXgZeRT9k4FWUiA3sqAADr/XiM/Bar6FsDQy8skppY8fAq43OjtAKAy8Dr6IfMvAqSsQGdlSAgdd68Rl4rddQtgYGXlmltLFj4NVGZ0dohYGXgVfRDxl4FSViAzsqwMBrvfgMvNZrKFsDA6+sUtrYMfBqo7MjtBLjgJc+GWyqODl9/4W/tBZeIQZeR5iqjtMHmTmkZW8ZeK1Xm4HXeg1layDAojnkyJ8W1t0LIzsn/rSw7IiznaMoEOOAd/POo0a1jxUrNkoUyY2E8eMy8BooxMDrKNPVMfrx6tE5ox0JdXJDIvcsiB03vqYdZeC1Xm4GXus1lK2BgPfE+et4+eqd7CGa2sWOHRuli+SCq8v/I0AmWmfg1XRYuDEVFIhxwJskXT6jsuXNkwsBy2YhpXtiBl4GXhWmVvSt4ua6ukZPziV+eqQuPgzxEyXT9OQZeK2Xm4HXeg1layDg9Z6yBNPnrpQ9RFO7AvlyYcVsL8R2c460XQZeTYeFG1NBAQbe/4vIwGvamzjCq8JMi0ZVMPD+N5iurm4IDg5CaGR5HiqNvS1zDRl4VRokiWoYeCVE0tDElvNKw9PgpiQUYOBl4FV0EwZeRYlilAEDLwOvjMM7OTmBou9BQYEy5jHGhoHXsYaagdexxsOWvWHgZeBV9C8GXkWJYpQBAy8Dr4zDM/AaV4mBV8Z7tLNh4NVOa3u3xMDLwKvogwy8ihLFKAMGXgZeGYdn4GXglfETe9sw8Np7BLRrn4GXgVfR2xh4FSWKUQYMvAy8Mg7PwMvAK+Mn9rZh4LX3CGjXPgMvA6+itzHwKkoUowwYeBl4ZRyegZeBV8ZP7G3DwGvvEdCufQZeBl5Fb2PgVZQoRhkw8DLwyjg8Ay8Dr4yf2NuGgdfeI6Bd+wy8DLyK3sbAqyhRjDJg4GXglXF4Bl4GXhk/sbcNA6+9R0C79hl4GXgVvY2BV1GiGGXAwMvAK+PwDLwMvDJ+Ym8bBl57j4B27TPwMvAqehsDr6JEMcqAgZeBV8bhGXgZeGX8xN42DLz2HgHt2mfgZeBV9DYGXkWJYpQBAy8Dr4zDM/Ay8Mr4ib1tGHjtPQLatc/Ay8Cr6G0MvIoSxSgDBl4GXhmHZ+Bl4JXxE3vbMPDaewS0a5+Bl4FX0dsYeBUlilEGDLwMvDIOz8DLwCvjJ/a2YeC19who1z4DLwOvorcx8CpKFKMMGHgZeGUcnoGXgVfGT+xtw8Br7xHQrn0GXgZeRW9j4FWUKEYZMPAy8Mo4PAMvA6+Mn9jbhoHX3iOgXfsMvAy8it7GwKsoUYwyYOBl4JVxeAZeBl4ZP7G3DQOvvUdAu/YZeBl4Fb2NgVdRohhlwMDLwCvj8Ay8DLwyfmJvGwZee4+Adu0z8DLwKnobA6+iRDHKgIGXgVfG4Rl4GXhl/MTeNgy89h4B7dpn4GXgVfQ2Bl5FiWKUAQMvA6+MwzPwMvDK+Im9bRh47T0C2rXPwMvAq+htDLyKEsUoAwZeBl4Zh2fgZeCV8RN72zDw2nsEtGvfYuDddfAs+o6aHaGn/uN7o/Av2S06g3XbDmP/sQuYOqqr/vg+I2fhl9xZ0axeBYvqNDwoSbp8RuvJmycXApbNQkr3xHBxcUFoKPD67TuMmLgYx89eRYL4cdGkTnm0aVzFZD/evv9o1F534b949Ra8fJfizv0nSJPaHZ6dGqFUkbyiviOnrsBj0JRwdbu5ueL0thlG23N1dUNwcBBCqaM2Lgy86gtMvlK2fm9RMY1z2tTuaNWoMmpVKql+Y1bUONBnHrL/mB4tG1bU12IO8IaEhMJ3zhps3HkMgUFBKFsyP4b2bI44sWMZ7ZWSfbOuPrhy/V64Y7u3rSfm5c27jzB2+krcuvcEgYFByJ/nR/T3aIJ0P6SwQoHID9V2HsZCYOA3m5yLs7MznJycxTVFraIF8NZtOxx3H/wNait5ssSoUq4wurWpC1cXF7VOw+p6DO9rBFjeU5Zg+tyVVtdtiwoK5MuFFbO9ENvNOUL1X78FovMAP/H3RX79ERwcgtDQEPx1877Je5upPn749A/ae05C6z+qoGKZgiZPRccaXf6sjXZNq+rt1m49hFGTl6JPx4aCDwyZhO7ZxQrkxMBuTZEsSUKT9TPw2sKLHLNOq4B31uKNWOjXP9yZxYsb2+KLjaMBb+8RMxESEowBXZvg2cu36DpoKkZ6/onSRb9DqmHx9Jpj1P7XYj8jJASo3LQvGtb4DQ1qlMHhE5cwespybFk8WkxGAl6fqcuxYuZgfbVOABImiGe0LW1vtG4IDAxUzYOdnV3g5AQEBwerVmdUu2jpgHfn8rGIGzc2zly4iQE+/pg8sjOKF8ytmi7WVmQt8K7efABLA3Zj8siuiBc3FgZ4z8XPubKgZ7v6RrumZE/AW7tySVQsU0h/fPy4ceHm5oLjZ//CrbtP8GuxvIgVyw0TZ63GqzcfscDX01oZTB6v7Txk4DUcCAJegqAyxfLh3qOnGODtj0q/FQbBkaOU6AK8BLeeo2bhxct3iB07lh54v337huotB5m8txkbh2kLNmDTrmN4/fYDfAa0UwReemgODArG1iXeiB3LTQR66rUdhn+/BqJpnfJ64J21ZDNWzx6CkOAQPH3xFl0G+uGPWmUjDZhFtXuHo/h1VOyHdcC7ZDPWzR0e4bxfvHoHn2nLceHKHXEzb9O4MupV/VXYrdiwDwtW7cDbdx+RNElC1K1SGh1b1MCjv1+ALl4EQeTQFGU9ssEPFOGlJ/enL17jzMWbyJguFcYMbIcMaVOK+i5evYPxM1fj4ePn+CGVOwZ2a4J8uX4Uv5Wp1xMdmtXA9v2ncP3WA6ycNRQFS1Y2Ok6GEd6vXwNRvKYHlk4dICJcVCbNWYPXbz9idL/WEer49i0QJWt3N2rv3b8Nzl66jR5Dp+JAgC+cnQllgSZdRqNhjTKoXbmUAF6KTm1eNMpo/1Zs2IulAXvx5t0HpE+TEj3bN0CJQrk4wvt/taLaRUsHvPvXTkTSxN+jD/TARA8/3dvWxZ89xuLx01ciepIja0YM7t4UP2ZKY9KvY7m5YJTfMlz86w7ckybCt8AgdGpRA3Wrlsa8Fdtx5/7f8B7QRhz/6s17VGjkiTM7ZoqHU/LdqfPXY/ehcyIKS9GWXu0biHkzYtJiODs5wdXVRby5meLVFeZEeNv0noCyJX7R33AOnbgM7ynLsGP5GKN+rmRPwNu4VllUq1BMf7yLi6vQKYSeKsOUk+evodfwmTi68fubE8M51K1NHf0bFksv3gy8ppXTKsLbsXkNPTDRA9PKjQfEddjcOfRDymQYP3MV9h4+B2cXZyRNnAA5s2YU8+bStbviXrRrxTj9CdduPQT9uzRGsYK5TM6hZy/fRLivndw6M0pGeOlakChhPGTJ8AM27TquB95T56+BgkOm7m2Rza3GnUeLN1tKEd5Vm/YjSaL4KFogpwDrg8cvYe3WgyLCXKJQ7nDAq2MSusa26jlORHiL/JLDZDei2r3D0msVHweoDrz0SpJA7vdfC4rXoI//foU2vcdjhk93AY5046VXuCmTJxFPd/QENqRHcxT8+SeYivDevv8E3dvUQ7YsacUFKUH8eAI6n798i4YdR2LcoPYokj8H9h+9KECboqYEzQS8mdKlRofm1ZE6pTvogvZD1sJSwHv3wVPUajUYxzdPQ9w431+/Bmw7hPXbjmDptIER6rj38BnqtBlq1H7Z9EEI2HoYAVsPYdn0/46laFeqFEnRo109Abzdh04T8JMoQVwUypcDHq1rI1GCeLh++6F4jTR/Ul+kTplUQM3Xb0EoU/xnBt5oBbyzxMNMp5a1cPnaXfyYMY2IVJLfHDxxEZQuRMXQr1MlT4pWPceiVJE8aNmgEt59+Ix+o+eIhykZ4B03YyXoxuzl2Vr4U7ch01ChdEE0qVMO1kZ4CayH9Wqhfyvy4PGLCPMq7GRSsifgpYfb+PHiiAdcOt9ypQoYBd75K3fg0IlLWDi5r9E59M+/X1G25C9W3QcYeB0LeFdu3I+te09i/iRPs+YQ3Rsm+wfgwZPnwl/dXF0wdf4GkRojA7yRzaHoEOGlB2IKZNEbTorMhgXeNZv3Y/32oybvbWoBb4+2dTHAZx42LvBCh36+4oGeHubDAi+9JUuSKAGCQ0Lw4eNnwRWj+rYW91lThYHXqktglDrYKuClmyrdeHSlSrmiqPl7MfT3nitePegKvbpPk4pyFCuJG+uStbtx+sINvPvwSdycPTs2QIMav5kE3rA5vBR1Wrp2j5hcdEN78Pg5RvRpqW+rbpuhGOnZCnlyZBZgMGdcL32Eloxkc3iv3nyARh1H4vyu2SI/jMq2vScxd/k2rJs3IsIgE5T+0WmUUfv180di6bq92Hv4rLgQ6wo9Mbu5uoqoND2N0gUlUcL4eP7yDSb7r0MK90QYP6Qjzl+5LSb4lJFdUDBfdnEx1vZGyykNas9qwwjvibNX0W3odMyb0Bt5c2YRvrbjwCncvv8U//z7BS7Ozti7eoIeeMP6Nfkq5X/vXjkeLi7f8+66Dp4qIqtKwEv1Fq/RVbypSZM6uTh218Ez2LTrKKaN7m418Jas1Q2+IzrrIyz0kFqpST/sWzPRaF6dkj3NM7rmUOr60dOX4eu/DkunDkSOrOnDRXjpIblVz/GYPKKzuOkZm0NqjKm285BTGgzHjN4K6iK8D588F35fp0pp/NmwkllziOotUbMbFk/ph6yZ0opmFq3ehRt3HikCL0UdI5tDUR14N+8+jt2HzmDS8M7ijdDGnUfDAe/itbuw/+h5k/c2tYB33sQ+Yk7/nCszzl66JaL4FAgKC7wzFm3A3Al9xIP7h4//YNWmAzhz8TrWzBmuvzYa9oeBV40rYdSowyrgnb5wPWb49NCfKeXvEsgOHrdAvFbVFXplSnl3lFdVt+1Q/JI7Gzo0q4bUKZPB02u2uCE1rl1OCnjpVcb0hRuwevZQkQO7Y/8psaBMVwgOKPpLi8GsAV5dhPfU1ukiykaFIrzrth4J9ySra1cX4TVmv3zG9wjv+h1HsGTKfznPFOFNmSKJ0XzGC3/dBr3ePbN9pgBuepJdv/0IXrx+h/x5smJoz5ZI94M7R3j/PwBR7aKlA97ECeOLNALysb6dGqFq+aLYtu8kJs1ei6E9W4g0gifPXgpfOBjgaxR4KRVh4aod4fxSFnjff/iM8g37iGiprlBaES30ooczNSK89EBasnAeUb1MhNcc+479J4vrR4dm1fXAe/fhM3ToOwkerWqFWwRoOIcGdm2KjOm+p0ZZWhh4TSunVUrDsxdvBMzQgqrGtcvCo1Wd74Bmxhx69/4TfqvfK9wbOlngzZYlXaRzKKoDL0W+l63bA7HwAhDzjFIJ6E3toXV+2LrnGDbuOi59bwvrMeakNBDw0v2f3oRSIOj3XwtEAF7K4Q2bZvnvl28oXsMDq2YNCRf4CtuHqHbvsPRaxcfZIKWBIinDJy7ExgURc1F10Z0TW6bpV2lTXpQOeOnJkS5UFFnSFcNdGsICr/+ybaCL3ZCezYyOpTXAK3J4a3QR6Qu6HN7vi2A+wGdg2wjtiRzeWt2M2o8Z1A5nLt1Cr2HTcSBgkj5iTBHhBjV+1ec3h6302Jm/MGjMfFCOZ9hC+ZeU6xsSGopJwzox8EZx4F0zZ5iIdFIqiy63myL/BMKU6kKFopWRAe+ZizcwcMw80AI43duIsMC7eO1uXPzrNiYO6yTqC5vD6+zkjGI1PLB18WikcE8Swa8Hj10gcofp7YyumJPD27rXeJQvVQBN65YXhx84fhGj/ZZh98r/ciHDNmqufYtuY1CjYgk0qvmbuBFTriXl7dLK7cpljacv6eZQcEgwJg3rbNV9gIHX/sBLqTdliv0sXmUThFExdw4RwBWp1hkB/iOQKX0qUUdY4L126wE69puMg+u+P3RS0eXwFsmfM9I5ZHhfi8q7NNB5G0Z4T56/Cs+Rs6XvbWE9xlzgpcjtwtW70LJBRXG9NIzwGgIvBcAocr9poRcypP0+roaFgdeqS2CUOtiqCK+hc9GZ00rKRh29UL7UL2IbLyc44cqNe+JCVCBPNhF17e/RWLyGoJsfPYV3bV1bRHjpte6Q8QuxZOr3KGjqFMnEQoGwKQ1hgZcWujXz8MGg7k1F/iJFq05duI7C+bKL17PWAC+9Mu05bJqYVLS10cvX78TkGty9OcqV+p73R/nEyZIk0m9VRon7xuzLl86P4OBQVGzsiaZ1K6B+tdI4cvqK2MKMFqkRaCxYtVNsTUUr2Ok8hk1YhAJ5s6Jv5z/E6vMnz16jfKn8SBAvLsbNXC2esIf1as7A+//pFtUuWsYWremuHBSJpFeE9KBEeaYUYaFtf0xFeCmyVaVpf+FblHt79tIN+M1dJxa/UUrDkVOXMWjsfEz37g7KBVi4eif2HD6nX7RGW+W9evtOQKJ70sQCsOn1cPUKxUGrqSmNwGdAW1C0hHLvzQFeWii2YsN+sdiN3gD1G+2PnNnSC782Nocis3/y7BVo8UqVskXEnKFtiKbOX4dNi7yRKnkSka87dPwCDOnZAkXz/7c1IkXPT1+4HmEOUX7m8N4trLpgM/DaH3jDLlqzdA7RcRQ5jOXmis4ta+Px05diDv2UJZ1IaaAttOhNCL19yP5jBmzbe0IA8bTRXcWitcjmkOF9LX2a1FFy0ZpOW0Pg/fr1K6o2H2jy3kbXD985AfDq20pcP6wBXkNviwC8izeJnY4IjN+8/YBpCzeC3r4unz5QHwxg4LXqkhelD1YdeEmNv5+9gq//WpFn8+VroIiQ9mxfDz/nzCJuUpTg/+XrN5Qpnk9EaCuULiCAlxa89ff2x8HjF5EkcQIRsYoMeKmtc5dviRXmN+48FgvVCBIHdW8mombWAu+LV29EpODk+euIHzcO/qhdVrw61ZU/e4wTuclhV78bs9e92jt3+YaIbtHCvTSpk6Fn+4YoW+L7vsB0EaFI3JOnr8RWZKQJ7SdJC+ZoX9Ex01bg5t3HoJdKtEBvWO8/xeI23of3+2hEJ+D9/M8XsUXZyXPXkfaHFPi9dAGs3LTfJPDS+VOUd5TfUrx5+1HsdfvwyQvU+L2YAF7yEa/JS7Fj/2mkTpEU9auXEXNQt0sDgezMxRvFLg10k0iXJgVa1P9dpANQzn2fEbNELiPBNL3dMAd46cFswqzV2LLnBIKCaKFlPrEPb7y433P/DedQZPb02nnEpEW4dO0eSKOsmdKgZ/v6KJKfdisJwZhpy7F8/b4IF2Ta1YWi1IZziB6UdTtkWHoVZ+B1TOC1ZA6Rr9MbDcqJz5sjs9grnd706a7vtO/r9AUbxRZ4dauUwpY9J8XuKQS8kc0hw/vavjW+0Qp4ae7RmxVT9zYCfko9ChtlpblI63E+ff4XsWPFEpqunTPM6FsmYgZ60KWUBiXgDfttALrGFPklO/p5NBYL1k2VqHbvsPRaxcdZkdIQVcWTXbRGEV7ag1eNYotcNm1vtLxoTQ0/0LKOsCkNardrDvCq3bax+kxtS6ZF29rOQ160psWY6toIm9KgZrtRPaVBp4Wrq6v+wxNq6qN1XQy8Wituv/YsjvDar8vWtczAa75+/KU18zWz9xEMvNqMAAOvfSO8thxlBt6IX1oLqzcDry29j+u2hQIMvP9X1dinhTnC+10cBl5bTD3b1snAa1t9/4tyafmJb47wajOq31th4GXg1dLfuC3bK8DAy8Cr6GUMvIoSxSgDTmn4b7g5wht9I7y2mtSc0mArZS2rl1MaLNMtKh7FwMvAq+i3DLyKEsUoAwZeBl4Zh7fF2gWZdh3dhoHXsUaIgdexxsOWvWHgZeBV9C8GXkWJYpQBAy8Dr4zDM/AaV4mBV8Z7tLNh4NVOa3u3xMDLwKvogwy8ihLFKAMGXgZeGYdn4GXglfETe9sw8Np7BLRrn4GXgVfR2xh4FSWKUQYMvAy8Mg7PwMvAK+Mn9rZh4LX3CGjXPgMvA6+itzHwKkoUowwYeBl4ZRyegZeBV8ZP7G3DwGvvEdCufQZeBl5Fb2PgVZQoRhkw8DLwyjg8Ay8Dr4yf2NuGgdfeI6Bd+wy8DLyK3sbAqyhRjDJg4GXglXF4Bl4GXhk/sbcNA6+9R0C79hl4GXgVvY2BV1GiGGXAwMvAK+PwDLwMvDJ+Ym8bBl57j4B27TPwMvAqehsDr6JEMcqAgZeBV8bhGXgZeGX8xN42DLz2HgHt2mfgZeBV9DYGXkWJYpQBAy8Dr4zDM/Ay8Mr4ib1tGHjtPQLatc/Ay8Cr6G0MvIoSxSgDBl4GXhmHZ+Bl4JXxE3vbMPDaewS0a5+Bl4FX0dsYeBUlilEGDLwMvDIOz8DLwCvjJ/a2YeC19who1z4DLwOvorcx8CpKFKMMGHgZeGUcnoGXgVfGT+xtw8Br7xHQrn0GXgZeRW9j4FWUKEYZMPAy8Mo4PAMvA6+Mn9jbhoHX3iOgXfsMvAy8it7GwKsoUYwyYOBl4JVxeAZeBl4ZP7G3DQOvvUdAu/YZeBl4Fb2NgVdRohhlwMDLwCvj8Ay8DLwyfmJvGwZee4+Adu0z8DLwKnobA6+iRDHKgIGXgVfG4Rl4GXhl/MTeNgy89h4B7dqPccCbPmcpo+rmzpkdi/0nIaV7Yri4uCA0FAgJCVZlJGxx4Xd1dUNwcBBCqaM2Lgy8NhY4ilV/e1Nzoz12jp8WqQr3RfxEyTQ9IxcXV4SGhiAkJETTdqkxbedhLAQGfrPJOTo7O8PJyVlcU9QqtrjuqdU3e9ZDgDVu+grMW7rent0w2fYvebNj3uRBiO3mHGn/XF1dERwcIuZeVC4MvFF59Mzre4wD3s07jxpViCZv6eI/I0G8uAy8Bgox8Jo3qaK79atH54yfopMzEifPBrc48TWVgIHXerkZeK3XULYGAqxjZ6/h9Zv3sodoakcPcWVL5IGLsxMDr6bKc2O2ViDGAa+MoBzhDa8SA6+M17CNvRRg4LVeeQZe6zWUrYGAl4qtovWy/bDWjiO81irIx2utAAOvEcUZeBl4tZ6I3J7lCjDwWq6d7kgGXus1lK2BgVdWKW3sOKVBG50doRUGXgZeRT/kCK+iRGxgRwUYeK0Xn4HXeg1la2DglVVKGzsGXm10doRWGHgZeBX9kIFXUSI2sKMCDLzWi8/Aa72GsjUw8MoqpY0dA682OjtCKwy8DLyKfsjAqygRG9hRAQZe68Vn4LVeQ9kaGHhlldLGjoFXG50doRUGXgZeRT9k4FWUiA3sqAADr/XiM/Bar6FsDQy8skppY8fAq43OMpDOvQAAIABJREFUjtAKA68jjAL3gRVgBVgBVoAVYAVYAVbAZgow8NpMWq6YFWAFWAFWgBVgBVgBVsARFGDgdYRR4D6wAqwAK8AKsAKsACvACthMAQZem0nLFbMCrAArwAqwAqwAK8AKOIICDLwGo1ClaX+kSpFM/9dZY3sgTuzvX8YJW/66eR9evktx5/4TpEntDs9OjVCqSF6TYypjv3n3cSxYtRPr5g43Wc/ZSzcxZd56ODs7ISQkFMN7t0TmDKlt4ksPnzxHMw8fZMmYRtSfKX1qDO/dQrEt6pfvnDXYuPMYAoOCULZkfgzt2dyojmErkzl/w8aXr9+HHftPIRRASvfEGNWvDeLGiTheip1mA1aAFWAFbKiApddFG3ZJquojp67AY9CUcLZubq44vW2G+JvMvU2qIRsYBQYFY8zUFXB1dcGAro2l7+FRdaxsIGG0qpKB12A4a7cegg3zvSId5MDAIFRvOQgNa/yGBjXK4PCJSxg9ZTm2LB6NZEkSRjhWyf7Fq3do22c83r7/jBTuSSIF3nfvPyF+/Lhwc3XBxp1HceveE/Tp2NAmTknAO37makwd1dWs+ldvPoClAbsxeWRXxIsbCwO85+LnXFnQs119o/WYc/6GFbx68x7JkyUWfx4ybgHKlSqAsiXymdVfNmYFWAFWwNYKmHtdtHV/ZOsn4PWZuhwrZg7WH+IEIGGCeFC6t8m2YQu7/ccuYtyMlXj77iNqVSoZDniV+h1Vx8oWOkanOhl4DUazXrvhAjpDgkPQtG4FlCn+c4TxPn3hBnqPmIkDAb4i0kqlSZfRaFijDGpXLmWx/cHjl+A3b12kwBu28rHTVyJvzsyoWq6oTXzy4ZMX6NR/MtKlSYE4sd3QvW19ZJGIJrfpPQFlS/yCZvUqiH4dOnEZ3lOWYcfyMZH209zzD1sZPcm36zMRo/q1QrofUthED670PwW+fQvEuJmrsXXPcbgnTYx2TauKm4o9C81LujE/efYKpYvmRd/OfyBl8iSadGnFhn2Yu3ybAIC6VUujy5+1QFEwtYutdbeFhk+fv8ZI36U4c/E6smfNAM9ODZEv149qS+Pw9Vl6XbT3iRHw0r1m86JRFt/b7HkOk2avwddvQeGAV+keHlXHyp46R4W2GXhNjNKbdx/RpPNobFkyGq4uLuGs1m45iPXbj2LZ9IH6v1MUM1WKpOjRrl6EGmXtzQG+2Uu34MuXr+jeNmJ7tnC8k+euYeHqXZg5prti9RUaeWJYrxYCOqg8ePwCtVoNxvHN0yJNNzDn/MN24p9/v2LYhIWoUrYoypX6RbF/bGCdAqGhoeg5bAZevn6PsYPbgfT39JqFLn/WRsUyhayr3MKjL169g/aek9CnYwNULlsEy9bvw55DZ7F69lD9Q6mFVSsetnjtbsxfuR0ThnRAxnSpxMNdCvekGNitieKx5hjYWndbaEhvpJp4eKPILznQs109nLtyGyMmLcKyaQORNnVyc04/yttael2094kT8HYfOg1JEydEogRxUShfDni0ro1ECeJB9t5mz3MwBrxK/Y6qY2VPnaNC2wy8YUbp3y/fEBoagnhx4+Djp3/QuPNobFo4KsINc0nAHuw/eh7zJ3nqjx4xaTHcXF2N3uRk7WWAj/rlM3UFihbIYfOIGt2s6LWVi4szzl+5hQWrdmCKl3J6Q8la3eA7orO4yVF5/vItKjXph31rJhpN+dCJKHP+hpPq7sNnmDR7FTq2qIU82TNFhTkX5ftIr/umzt8g3kTQ2xAqC1fvxM27j+Hdv43m50fztn674ahYpqD+AZDgsETNrlg1aygypE1psz5RSlHjTqMweWRnfQ7/lRv3xRugncvHqtquLXW3lYaeXnPw4tVbLPDtq7+OUj5o+VIFUKdKxLdhqgrmYJVZel2092m8ff8RlHaWKGF8PH/5BpP91yGFeyKMH9IRsvc2e56DMeBV6ndUHSt76hwV2mbgDTNKz16+QZ+Rs+Hs5ISg4GC0a1rdaD4oPR1u3HUcS6b01x9NEd6UKZIYzVOVtZcBvsn+Adix/zTS/vA9OpIsSQJx4bFFOXLqMqYv3ITYsdzEzWpIj+ZSC+To6XhEn5YoWTiP6JYtI7zNPLzx5WsgEieKL9oqViCXeL3OxTYKfP7nC6q1GAiPVrVRv9qv+kZoAWfs2K4ijUDrMm/Fdqzbdhjr5o0Qvkrl5et3qNi4Hw6snaT3DVv0q1N/PyROFA9jBrbTV799/yksWLlDRJfVKrbW3RYaUsS4da/xWD1rKH7M9H3hKxV629O9Tf0Y9zbG0uuiWj6kVj0X/roNeuV/ZvtMBGw9ZNa9UK0+mFOPqQhvZPfw6DJW5ugUE2wZeC0Y5VMXrsNz5GwcCJgEJ6fvObx/dBqFBjV+Rb2q/0GArmpZexngtaC7mh9CNzmK4DStW160feD4RYz2W4bdK8dF2pfocv6aC65hg/TwRq/w188bKSL/VN5/+IyqzQdg0rBOKFogp4a9ASiSS2DbrU0d1Pi9uL7taQs2gHY0ociircq9h89Qv/1wbJg/EunT/BdFbtVzHArl+0mkeKhVbKm7rTTsN9pf7MxCD7+6cuLsVfQcPgO7V45Hgvhx1ZInStRj6XXR0U7u2Jm/MGjMfOxfOxGy9zZ7noMx4FXqd3QZK3vq7ohtM/BaMCq0cKRq84FiUVv9aqVx5PQVjJi4WCT10yve67cfwndOALz6thKLZpTsdV2ILsC3YsNerNiwX6Q/xIsbG3Tjy5ktvT76N37mKiRLkghtGlcJp350OX8LXCrKHEKvqH/M+AM6tqih7zPdUM5cuonl0wdpfh53HjxFk86jcGj95HDR3VqthmDMwPb4tZjprQKt7SylGOw6eBZzJ/TWV0U+3N97DjYvGq3fPcTaduh4W+puKw3LNeiNcYPbo1C+7EICAmva5rBgvmzo1b6BGrJEqTqUrouOejK0VWba1O5ipx16uB02YREK5M0qruey9zZ7npsx4FXqd1QdK3vqHBXaZuC1cJQuXbsropZ37v+NNKmToWf7hvr0B4pidOw/GZsWeiFD2lSihcjsn754gz86eSEoKBj/fvkq8marVygm9vaNiiU4OAQTZq3Glj0nEBQUhDLF84l9eCk3msqfPcYhTSp3eA/4nu8Z3c4/Ko6ZbJ/p4SX7j+nR+o/K4hB6vdnOcxLmT+yDvDmzGK3GljsYUJS1qcdoHF7vJyLOtH9mz+HTBVyZyjdXa9cAirrS1kfTvbuJ86ZcxyZdvNG4Vjm0aPC7US0sbdsS3WV3XLBEQ5ndIui1sO/wTnq/oDzv5ev3IsB/uLjGGSuUB54kUQIEBweL60KBvNlkXdPh7ZSui456ArT9Jb3VefL0lRi3CqULoFubuvoFyJHd2+x5TpT65zNtOb7Q2hxA9HdQt2Yi11/pnhxVx8qeekeFthl4o8IocR9ZAQdRgPIye4+YhY7Nq4tttybMWoP2zaqj+f+3oDPsphY7GPQYOh1Ozk6oU7k0Nu06ipt3H2Hh5P5GF0iquWvA+4+fxU4ulcsWRu6fMmP6og1igRylduhSncLqYU3b5upu7o4L5mgou1sELQzasOMIOjaviVv3HmHJ2t2Y4dMD+fNkNenN+49eEJBCi6TooYrAigsrwAqwAmoowMCrhopcBysQgxSgnQkWr9klIpo1K5bUR0wMJdBqBwNaYLpq4wEcPX1F7MFM6RbGPgBD/VN71wDSgHYvuXHnsdiVpEWDiuKjMMaKUtsUndbt623seFndLdlxwRwNzdktgvL3N+44AldXN7RtUkW8HVAq67cfwfSFG8UbMt1bIaVj+HdWgBVgBZQUYOBVUoh/ZwVYAUUFCPwCth4WHxvRfYpbZgcDiuTRHrYdmlcX+3yqWSi6mDVzOv12dVruGmBJ25QiQTnBnp0bIVvmtNJSzFm6FbUrl9R/ZENmxwWKTl+7+QDp06aMdD9cWvj34vU7VClbRPRHdreIa7ceiN1Tfs6ZRb+4UXdChnWGPVHa05nyr7u2ro2aFUtIa8CGrAArwAooKcDAq6QQ/84KsAKKCsxctAlL1+0R+1a7J00E2R0MBo6ZhyvX7+Ljpy9iEWOjWmVNRkgVOxHG4NPnf8XuDY1qltHvzSuza8Cjv19g0ZrdYuFpCvfEqFa+mMhZNKdY2jZFWVdvOgj/ZVtR4deC6NKyJpIkThBp07TanD64MW10N5Qqkkdq1wrKk6VV6AV/zobXbz4gS8Y0Yv9w3YNK2AbJjr5iuNivn0jTUNotInf2TOgycApev/2AH1Ilw7MXbzF+SHvkyJpBX61hnWHbmzp/PegjN0umDjCaFmLOOLAtK8AKsAJhFWDgZX9gBVgBqxUgKLp19zFy/ZRR1CWzgwFFXGnBW4D/MHwLDMaEmavx7OVrDO7eDAV//snqPtGC0tQpkyF+vO+LJZV2DThz8QZ6DJshPtVdtmQ+8cGURWt2ibSNVo0qmdUfc9sOWznl+s5YtAm7D51Fu6bV0Lh22UjhjxYNUSSVisyOC6MmL8X7j5/0+3ePm7FSHGtsD2Xqy/uP/yBjuu/brintFkEr+O88+BsLJnmKHG9a1Oc7Z024bewM69SdO30Sum6bYfCf0Ft/PmaJzsasACvACkSiAAMvuwcrwAqoroDSDga08KmphzdSuicRX+XTLfIiQEqcMJ5NVudHtmvA12+BqNd2OIrkz4HeHRsgdYpkQhOK1tLOKbovylkqlLk7FlCKSH/vuYjl5oqpo5S/bqjrl8yOC7Tl0pbdJ/WfRqfdHLwmLxHReaWitFtExcZ90btDA1T6rbC+Kvpq1YoZg/Q71hi2QSkYtSqVwJhpKxArlptdvtandN78OyvACkR9BRh4o/4Y8hmwAg6ngNIOBrRA6+CJSyJ/19XFBWMGtkWqFElteh6R7RpAkcm7D5+iYN5s2HP4nNhzlCLNtI+0GkV2xwJ6EAjYdhj04YyKvxYSH9Qw9wMNpnZc+BYYiPEzVuH12494Rlsh1i6LsiXyo7+3P3L/lBGDezRTPFWl3SIovYK2EtPt00wpIpSTezDA1+hWZHS+9HC0YPUu0JZttFAt7Ec8FDvEBqwAK8AKSCrAwCspFJuxAqyAeQrI7GBA4Dt+5kpcvHoXy6YNtHneprFdA/759wvK1OslvsqWJ3smsZm+56jZSJU8mchtVaso7VhAecOj/JYhMDAIQ3o0Q54cmS1q2tSOCx36+SJp4gQY3a8NXr55Jz4CkT5NClQsUwj1q5eRzp2ObLeIuw+fwWPQFBTOlx1VyxXBxp3H8Pnff+E30iPSc/nw6R/MXrIZ9BWvCUM6hvsUsUUi8EGsACvAChgowMDLLsEKsAKaKUBwuW3vSQFYuvLqzXvQK396pU772GpdaBFXy+5jcHzzNH3T1EfKo92yeLTNu/Px0z+YsWgjNu06jg7NaohPcus+26xm44WrdsbCyX2R+6dMolo6R9oneeXMwVY3Qw8JlI5AhXZa2HXwNLbvOy0+77xy1mBkzSS36wQBc+oUSXg7MqtHhCtgBVgBQwUYeNknWAFWQDMFaDFXyx5jRboAfbCBSsC2Q/DzX4fdq8brPw+sWYf+n6dbqUk/rJk9FGlSJxdN9x01B0HBQZg0rLNNu0I5y6P9lorIcr8uf+CHVO42a492R6Bc2VqVSoo26DPI/UbPwYkt/4G+pY3TLh2v3nxA+2bVxPZo+49exPCJC8X2Yg1q/GZptXwcK8AKsAKqKcDAq5qUXBErwArIKEC7CtCCLPq8dML4cXD0zFX4DGiL8qXyyxxuE5t12w5j/sodAgbvPXoqPmKxZMoAm0ec33/4jKu37qN4wdw2Oa+wlT54/AK9RszAr0XzCu3nrtiOSr8VQq/2Daxum7Yho49F7DxwWizyo0i9R6s6Zm/pZnVHuAJWgBVgBUwowMDLrsEKsAKaK/Dl6zccOHYRHz99RtECOU2u4NeyY5Sbuu/oecSJFQvVKhRF8mSJtWxek7Z06Qa0QC9Xtkwifzeyr7uZ26ng4BDQjhdqLfYzt322ZwVYAVbAlAIMvOwbrAArwAqwAqwAK8AKsALRWgEG3mg9vHxyrAArwAqwAqwAK8AKsAIMvOwDrAArwAqwAqwAK8AKsALRWgEG3mg9vHxyrAArwAqwAqwAK8AKsAIMvOwDQgH6SEDZ+r3F50Z1+3RaIk1gUDCad/VB8mQJ4Teyq9hPlD4dSqu3V88eakmVRo/ZfegcBo6ZG25fUdUq54pYAVaAFWAFWAFWIFopwMCr8nDS15QWr9mF2/eegL54lMI9MXJnz4wG1csgf56sKremXnVqAS9toL9513EEzB2u3zzeFsBLZz5l3jrsPXIOa/1HSH8lSj3FuCZWgBVgBVgBWQU27jwK+oR3qSJ5MG10t3CH0ae3J85ajbIl8sF3RBfxm85eZ0ifIE/7gztqVy6NVo0qyTbLdqyAXgEGXhWdYcue4xg8dgGa16uAMsXzwc3NFfcePsWew2eRwj0phvVqoWJr6lalBvC+e/8JVZsPwPDef6JimYL6DtoKeP/98g21Ww9Bx+Y1UKdKKXUF4dpYAVaAFWAFVFOAAHb8zNVi27rFfv2QM1tGUTe9FazeYiCCgoLxc87M4YB31OSlWDFzMEJDIfZ3pgDHotW7MH+SJwrkzaZa37iimKEAA6+K49ypv5/Y03K6d/inV2qCYDBJ4gSiNdpsftKctThw/IKY5JRC4Nm5EbJl/u/zm3uPnMecpVtA+2WmcE+C4gVyoWf7ekgQPy7OX7ktjr9++yESJYgn9gzt2rquPsrZoa8v0qdNiUQJ4mLDjqOgvTErly2Cvp0b6T9ZSt+uHzd9FfYeOSs+CUoXj/1HL+hTGig6TV9P2rbvFN68/YDUKZOiXMn86N62nknF6Cl9WcAebF/mAycnJ5PAGxgYJKKzVDf1I2fWDOjTqSF+zplFf8z9R88xym8pLl69g8QJ4yN1ymS4c/9JuM+/kvG0BRtw9PRfWDFjkIojyVWxAqwAK8AKqKkAAe+sJVtQslBuvHn/Qf8Vww07jmDN5kP4IVUyBAcHhwdev2U4vW2Gvhu0f3ex6h4Y6fknalYsoWb3uK4YoAADr4qDPHziYpy+cB2Lp/SHe9JERmsm+GzRbQzSpHZH+2bVESe2G1ZvOoCdB89gw/yRIg1g35EL6DtqNjo0r4HSRfPgybPXWLlxHwZ0bYr4cWOjVqshIqJZu3JJ/P38DcZMW45KZQqhV4fvX0wi4D114bq4IJQvVQAPnzzHZP8ADO3VXH+RaOc5EW/efYTHn7UFiJ++cAOUjqDL4Z29dAs27TyGUf1aI1mSRLhx5yG27j0Bv5EeJhXrPMAPWTOl0fdDZ2gY4R03Y6WA634ejfFDymRYt+0INu8+ho0LvATcv//4WZxj4Xw/4Y9a5cRDwdqth3Dk1OUIwHvjziM06uiFvasnmNRcxSHmqlgBVoAVYAUsUEAHvP7je6F2q6FYOWswsmRIg7pth6J7m3ri/hIZ8BLsLl+/DwTIi/366wNIFnSFD4mhCjDwqjjwT1+8QbfBU3Hv4TPkzp4J2X9Mj+xZ06FMsXz6rzYdPnkZQ8cvxK6V4/QR2dDQUPxWvxdG92sj8pv+6DQKuX7KiKE9m4frXUhIKPzmBeD4mavhFoCJBVw+/ji4zlcAMwFv5gyp0d+jsf54AtwMaVJhSM9mOHn+Gjr2mywAkz4BSsUwpaHPyFn48vUrpo3uLq1QxcZ90aNtPVQtXzTcMWGB9+Onf8TiuLGD2+s/JUvn36D9SJQp/jO6tq4jwHvrnpPYuNALlLdFZdfBsxg2YUEE4KVjS9bqhileHiiUL7t0X9mQFWAFWAFWQDsFdMC7fakPBo2dLwIZFJChN5lr5gyFp9fsCMBLOb+6LwHS/Y9Kgxq/oUvLmgy82g1dtGmJgVfloaRJefHqbVy8ehe37/2NC3/dxvNXbzGsV3NUr1AcFDmlVAFjhWC0bpXSKFi5I7w8W6FahWIRzDwG+SFl8mThYPj5y7eo1KQfVs4cjBxZMwjgzf5junCR1v7e/qC+jRvcXuyaQBFTuvDoiiHw7j92EX1GzhRAXChfDvySKwvKlSqAuHFimVSscJVOmDmmRwTwDAu8V67fQ7OuPti1YhxSJk+ir2vEpMV4++4jJo/sAooUU1R5VL9W+t9NAS8Z1PxzEDxa1RGfSeXCCrACrAAr4HgKhAXeOw+eomGHEUiTKjm6/FkLlcsWBgVZIkR4/5/DS2dDgPz0xVssWLkdn/75glWzhvBiZccbZofuEQOvjYeHIpD0lEqv4/etmYhZizdj274T2LRwtNGWCUoJeEf3ax0hUkoHGAPeZy/foHKT/pEC70CfeWLXCALeBat2Yv32Q+H6YGzR2qO/X4j0iis37uPEuasi/WDZ9EEmLzIEvHPG90L+POEXE8gAL6WDvHv/HXi7DJyCVCmShoP6yICXYL93h4bhFsrZeFi5elaAFWAFWAEzFAgLvHQYAe6te4+xfp6XiOIaBV6DHF467q+b99G0i7fYkvKX3I6785EZ0rCpRgow8KooNOWTUhqDYaGoLq0sPbZpigDI3iNnImDuCGTJkDqcKeX30r61ddsOR4E8WTG4R7NwvxMMT567VqQ0rJkzLFz0c6DPXBxa/19Kg2GENyzwUgrEAG9/7F41DkkTJxT1vH77AeUb9gm3aE2XTkC/63JlA/yH48dMaYyqRikNPdvXR5WyRcL9HhZ4aZFa2fq9MHZQe1QoXUDYGaY0jJ6yHNduPcDSqQPCnaOxlAbSrHDVTpgzrhenNKjoy1wVK8AKsAJqKmAIvK/evMc//37Vp9XJAu/5K7fQqud4sVYm7EJnNfvKdUVPBRh4VRzXeu2Gwz1JIlT8rZBYvEWASjsq+C/birZNqop/FGWlp1Oa6F1b10bGdKnEwrNNu46iaZ3yAto27z6O4RMXoXPLWiKnl2CUFrZ1a1sP8eLGQq0/h6BuVVq0VgqUN+wzdTl+/7Ug+nRsKM7GWEpDWOClbWGqNR+ILBl+QOPa5fDqzTus2LAPdx8+0wNvz2HTkeunzCKvNnasWNiw4zDWbT+CncvHIk5s42kNlIqQM1sGkYcbthguWhs7fQUOHLsYbtEanf/GBaNEmoPuCb5N4yooViAX7jz4GwtX7cT7j59MLlqj6HmyJN/hnQsrwAqwAqyAYylgCLyGvZNJabhz/2/MXroZSRMnwgLfvvr8Xsc6U+6NoyrAwKviyJw8dw0bdx3Dlet38fL1ewSHhCJz+tRoXr+CyN/VFdqWbOqCDTh4/KJ4jZ8yeVIU/iUHPFrV0i9uoyjs3OVbxQ4LiRLGR6nCefXbkp29dBO+/gG4cfshEtK2ZOWLolubumLfXxngJZtL1+7Cy3cJHj55gayZ0qJJnXJiIYFulwbaU3jlxgN48Pi5iMDSIrwebevq9040JtvSgD1YtekANi8aFSnwfvsWCL9567B93ynQIrYc2TKiV/v64T7MsXbLQcxeulXokydHZrFtGuUdHwzwDVe339wAnDx/Hcun87ZkKroyV8UKsAKsgKoKWAK8lA6oK5T24J40MSr/Vghtm1RD4kTxVe0fVxb9FWDgjf5jrNkZEshXadZf5AmXKpJX1XYXrt6J3QfPCiDXlU+f/0XNPweje9u6qFWppKrtcWWsACvACrACrAArEH0UYOCNPmPpEGcya/Emsafw6llD9RFnSzpGW5PlzJYJyZMmxL1Hz8Q+wh1b1EDDGr/pq6P9fI+f/Z7PHDbf2JL2+BhWgBVgBVgBVoAViL4KMPBG37G1y5nRZyKbd/URucljBrYN98U1czpE+wZfu/UQ3wKDkO6HFPij1m9oUL2Mvr5Nu46JlIxFfv3FnsVcWAFHUIAWnNaqWAItG1a0uDu6OZQ8WUL4jewqFrLa4vPcYv/uMXPFanf62iMXVoAVYAWiswIMvNF5dPncWIEoqMCB4xexeM0u3L73RCzyTOGeGLmzZxYPPPnzOPY2RGoAL73d2LzrOALmDhcfkqFiC+CleukT33uPnMNa/xG8p2kUnCvcZVaAFZBXgIFXXiu2ZAVYARsrQIslB49dgOb1KqBM8XwiLebew6fYc/gsUrgnxbBeLWzcA+uqtxZ4373/hKrNB2B47z/D7SttK+D998s31G49BB2b1xCfK+fCCrACrEB0VYCBN7qOLJ8XKxAFFejU309sNTTdu1uE3hMMJkmcQPydtvwjCFy3/bDYti9j2pTo0LyGfm9nstl75Lz4bOndh0+Rwj0JihfIpd/phLYLnDRnLa7ffohEtNNJhaLo2rquPspJW/ulT5sSiRLExYYdR0H7PVcuWwR9OzcSKQa6PsxfuR3L1+/Fl6/fkCd7Zty69wR/NqykT2kggF+4ahfoIy7Ud9oof4BHY5OfRV0SsAfLAvZg+zKfcOlAhsAbGBgkorPb9p0C7W2dM2sG9OnUMNy+pPcfPccov6W4ePUOEieMj9Qpk+HO/ScRtvabtmADjp7+Cytm8E4nUXDKcJdZAVZAUgEGXkmh2IwVYAVsrwB9ce/0hetiU3n3pIlMNjhx1mqcOHcN/br8gbSpk+Ps5ZsYMWkJFk3uJ3K66QMvfUfNFhBcumgePHn2Gis37sOArk0RP25s1Go1REQ0a1cuKfbBHjNtOSqVKaT/HDcB76kL11GzYgmUL1VAbA9ICyeH9mou/kaFvppIsNu9XV2xtd/9R88ERLduVEUA77nLt9Ch7ySM7t9G9Imgd+POY2jXtDp+zPiD0XOjvaxpD+9eHRqE+90QeGnB5v6jF8LtZb159zFsXOAl4P79x8/iHAvn+wl/1ConPstK2/rRFx+Pb54Wrm7dR2X2rp4Qqea2H31ugRVgBVgB2ynAwGs7bblmVoAVMFMB+pBKt8FTce/hM7H3M325MHvWdChTLJ9+j2qKaJar31tsURf2y4a9RsxAxrSp0L1tPfzRaZSAzKHMM/o2AAAGn0lEQVQ9m4frAUWG/eYFiK8Vrp49VP+bWMDl44+D6/77WmHmDKnR36Ox3oYWUmZIkwpDejbDP/9+QbkGfTCga+NwW+KFTWmgj7nMWrIZ25eOQby4saWUoK8V9mhbL8JnxcMCL+1dXbZ+b4wd3B7lS+UX9Rp+rZDygLfuOYmNC730O5iY+jw3HVuyVjdM8fLgrxVKjRIbsQKsQFRUgIE3Ko4a95kViMYKEJRevHobF6/exe17f+PCX7fx/NVbDOvVXHzAhSKnrXuNN6oAfdbae0AbFKzcEV6erVCtQrEIdh6D/JAyebJwMPz85VtUatIPK2cORo6sGYx+rbC/t79IpaB9punDLS26jcHWJd4iwqwrYYH3ybNXYscSKvTFwLw5M6FC6YIiAmuqFK7SCTPH9IgAnmGB98r1e2jW1Qe7VowTXybUlRGT/tfe3cdUVcZxAP/+1VYNAo1py0zLO2W7dy0SW+1OYRYmCRfxysiXQriidZOCKAmNqDBfyhCMpkghdMPJwMZFbEAWmGExsawcoJT5MuemaVdgNextv6fu7R7ednOacPiejb/O4ZzzfJ7D9t3D73meUlz8uRObXrVDRopHBfgjZ+USz/mBAq9cEJ2wCk8vmYuIGVN1/GWxaRSgwEgWYOAdyb3PtlNgGAjICKTsuCT/jpctpA8eboctfaPa5npMUGCfFkgolcC7ZmVin5FSubi/wHv23AU8siBj0MDrvT23O3T2fofek9ZkNHrvZ4dUQJYdAS91dqOsIBPjbx/Tr7wE3sI30nCv0aA570vglXIQ2ZlQAq89M1/ZeI9wDxZ4Jew/tyxOM1FuGHwafEUKUIACPgsw8PpMxQspQIFrLSD1pN5lCu7nbXXsRkl5HZqc+bjo6sTMuHRkpiyE9dHpmleSyWUyqUyCZ4hxElY/u0hzXsLwpqIKVdIgG5a4DwmDmWuLsO/Df0saJt89TlNL6x145R2krCD3FTvCH7zHc5/YpCxYZplVDa8sqea9IYqsrxsR/wKWLZ6DeEt4v5RS0pCabIWMVHsf3oFXQnS4NQ3rVyV7Jun1LmlYk1+G1mMn4Nj8oqaNL79Z3KeGV8xCI59E4YY0ljRc6w+c96cABa6bAAPvdaPngylAgd4C85ZmY3SAPyLCpqrJWxJQZUWFbR/UwLYgUv3Ise7tHZDNR+wJMQgxTUJX96/4tOkrjA68BUmPzUZ1/QFkbyzBU09YYJ5mVCs5lDsbkGKbh5tuvAGWhJcQGymT1syQuuG1m8vw8PT7kL48Tt1fJq0NFnjlmtTsd9DWcQorEmPU7+zZ+wX2Nx9B6lKrCryFjhrIyHF0xAOq/vjbtuPI2lCM9956Hqbgu/rtfClFCDaMx4rEuQMGXjmxvmAHGpoOayatOes+R1VxjipzOHL0Ryy0v64spJzi+xNnsH1nLVydXQNOWpPR81EBfvwoKUABCuhSgIFXl93KRlFgeAp8eagVVXVN+K7tB5z7yYXf//gTE+8Yi8XWh1T9rvuQUcnSinpU1e7H6TPn1TJfxskTVMBzh0mZiFZUVqNWWPD3uxnmUJNnWbKWb44id1sl2jtOwk+WJZt5P1KSYj3bYfsSeM9fcKlQ3fx1O8YGBWJ+VBh27dmHmH9GeKWModBRjbaO05CJZrL7oLzfrLDQATvHUfkxdjobUF2SM2jg7em5jLx3d+GjT5rVvacY7kRaslWzMUfF7kZsddSoMgfjlIkIMRnUSg2Nlbmae+cVVapyi7ICLks2PP9q+NYUoIAvAgy8vijxGgpQgAL/g4DrUjdmL8pQE+PM00xX9Ynby2tR39iiVrdwH13dvyA6YTWescVqVpu4qg/mzShAAQoMAQEG3iHQCXwFClCAAm6BLaVO1DYeRPmWLM+I85XoyNJkwYYJuDXQD8dPnVXrCC9/PApxUWGe28l6vgda/q5n9q43vpLn8XcoQAEKDGUBBt6h3Dt8NwpQYMQJyOQ2Wc5MSiDWZdo0O679FwxZN7j12En0XP4N424LQrwlDPPnzPDcT2qgX8t9HyV5GWrNYh4UoAAF9CzAwKvn3mXbKEABClCAAhSgAAXAwMuPgAIUoAAFKEABClBA1wIMvLruXjaOAhSgAAUoQAEKUICBl98ABShAAQpQgAIUoICuBRh4dd29bBwFKEABClCAAhSgAAMvvwEKUIACFKAABShAAV0LMPDqunvZOApQgAIUoAAFKEABBl5+AxSgAAUoQAEKUIACuhZg4NV197JxFKAABShAAQpQgAJ/AYC/r6NT9RbHAAAAAElFTkSuQmCC"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -2013,10 +1340,10 @@
    "id": "cb85e50d",
    "metadata": {
     "papermill": {
-     "duration": 0.002162,
-     "end_time": "2026-06-13T02:34:46.583024+00:00",
+     "duration": 0.002007,
+     "end_time": "2026-07-16T20:09:30.922474+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:46.580862+00:00",
+     "start_time": "2026-07-16T20:09:30.920467+00:00",
      "status": "completed"
     }
    },
@@ -2055,16 +1382,16 @@
    "id": "4cf7002d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T02:34:46.588045Z",
-     "iopub.status.busy": "2026-06-13T02:34:46.587959Z",
-     "iopub.status.idle": "2026-06-13T02:34:46.591251Z",
-     "shell.execute_reply": "2026-06-13T02:34:46.590838Z"
+     "iopub.execute_input": "2026-07-16T20:09:30.927299Z",
+     "iopub.status.busy": "2026-07-16T20:09:30.927117Z",
+     "iopub.status.idle": "2026-07-16T20:09:30.931208Z",
+     "shell.execute_reply": "2026-07-16T20:09:30.930846Z"
     },
     "papermill": {
-     "duration": 0.00632,
-     "end_time": "2026-06-13T02:34:46.591481+00:00",
+     "duration": 0.007444,
+     "end_time": "2026-07-16T20:09:30.931766+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:34:46.585161+00:00",
+     "start_time": "2026-07-16T20:09:30.924322+00:00",
      "status": "completed"
     }
    },
@@ -2074,13 +1401,13 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "📁 Results saved to: 02_financial_data_universe/output/benchmark/file_formats_l.csv\n"
+      "📁 Results saved to: /home/stefan/ml4t/code/02_financial_data_universe/output/benchmark/file_formats_l.csv\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "PosixPath('02_financial_data_universe/output/benchmark/file_formats_l.csv')"
+       "PosixPath('/home/stefan/ml4t/code/02_financial_data_universe/output/benchmark/file_formats_l.csv')"
       ]
      },
      "execution_count": 17,
@@ -2094,6 +1421,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "tags,-all"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -2111,28 +1441,25 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "source_py_blob": "8c69a784d883fe2e5dbc5cbacdbb94d274ab567a",
+   "executed_at": "2026-07-16T20:14:30.989337+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {},
+   "notes": "L scale; locked env (uv.lock, pandas 2.3.3) — the env §2.4 reports; benchmark image drifts to pandas 3 and yields 79 MB HDF5"
+  },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.680618,
-   "end_time": "2026-06-13T02:34:49.310350+00:00",
+   "duration": 7.486638,
+   "end_time": "2026-07-16T20:09:31.952643+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "02_financial_data_universe/20_storage_benchmark_file.ipynb",
    "output_path": "02_financial_data_universe/20_storage_benchmark_file.ipynb",
    "parameters": {},
-   "start_time": "2026-06-13T02:34:37.629732+00:00",
+   "start_time": "2026-07-16T20:09:24.466005+00:00",
    "version": "2.7.0"
-  },
-  "jupytext": {
-   "cell_metadata_filter": "tags,-all"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "ac125d8fd8e3d9a753a030487b56ca00180c7dbb",
-   "executed_at": "2026-06-13T02:34:49.532051+00:00",
-   "executor": "cpu-local",
-   "production": true,
-   "parameters": {},
-   "notes": "executed-state finalization batch (2026-06-13 run)"
   }
  },
  "nbformat": 4,

--- a/02_financial_data_universe/20_storage_benchmark_file.py
+++ b/02_financial_data_universe/20_storage_benchmark_file.py
@@ -16,7 +16,7 @@
 # %% [markdown]
 # # File-Format Storage Benchmark
 #
-# **Docker image**: `benchmark`
+# **Environment**: the locked environment (`uv run`) — see Prerequisites below.
 #
 # **Purpose**: Compare CSV, Parquet, Feather (Arrow IPC), and HDF5 on the same
 # 1 M-row OHLCV panel along three axes — write time, read time (with forced
@@ -25,8 +25,8 @@
 #
 # **Learning objectives**:
 # 1. Generate a deterministic OHLCV benchmark panel at the L scale that
-#    chapter §2.4 cites (100 symbols × 10,000 daily rows = 1,000,000 rows).
-# 2. Time write and read for each format with `gc.collect()` between runs.
+#    chapter §2.4 cites (100 symbols × 10,000 one-minute bars = 1,000,000 rows).
+# 2. Time write and read for each format under one stated timing policy.
 # 3. Force materialization on Feather / HDF5 reads so memory-mapped or lazy
 #    reads don't masquerade as instant.
 # 4. Quantify the columnar-projection win (read 2 columns vs 9).
@@ -34,9 +34,18 @@
 #
 # **Book reference**: §2.4 — file-based storage benchmarks.
 #
-# **Prerequisites**: PyTables (HDF5 backend) is only present in the
-# `benchmark` Docker image. Run locally with `uv run`, or via
-# `docker compose --profile benchmark run --rm benchmark python …`.
+# **Prerequisites**: PyTables (the HDF5 backend) ships in the locked
+# environment, so `uv run python 02_financial_data_universe/20_storage_benchmark_file.py`
+# from the repo root is all this notebook needs — no database services, unlike
+# `21_storage_benchmark_database`.
+#
+# > **Which environment produced the numbers**: the locked environment
+# > (`uv sync`, i.e. `uv.lock`), which is what §2.4 reports. The `benchmark`
+# > Docker image currently resolves a *newer* pandas than `uv.lock` pins, and
+# > pandas' newer string dtype makes PyTables store the low-cardinality
+# > `symbol` column about 8 bytes/row wider — enough to move the HDF5 file
+# > from ~71 MB to ~79 MB for the identical panel. CSV, Parquet, and Feather
+# > are unaffected. Run this notebook under `uv run` to reproduce §2.4.
 
 # %% [markdown]
 # ## Setup
@@ -50,7 +59,7 @@ import time
 
 # %% tags=["parameters"]
 # Production scale follows chapter §2.4 prose ("L scale, ~1 M OHLCV rows,
-# 100 MB in-memory"). Override via Papermill for CI: BENCHMARK_SCALE = "S".
+# 64 MB in-memory in Polars"). Override via Papermill for CI: BENCHMARK_SCALE = "S".
 BENCHMARK_SCALE = "L"
 
 # %%
@@ -78,7 +87,8 @@ from utils.storage_benchmarks import (
     force_materialize_polars,
     generate_ohlcv_data,
     save_benchmark_results,
-    time_operation,
+    time_read,
+    time_write,
     validate_result,
 )
 from utils.style import COLORS
@@ -87,11 +97,36 @@ OUTPUT_DIR = get_output_dir(2, "storage_benchmark")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 # %% [markdown]
+# ## Timing Policy
+#
+# Every number below follows one policy, applied identically to all four
+# formats. A comparison that mixes policies across the things it compares is
+# not a comparison, so this is stated up front rather than left in the call
+# sites:
+#
+# - **Writes** (`time_write`) — a single shot, no warm-up run. Writing the
+#   panel is a once-per-dataset operation, so that is what we time.
+# - **Reads** (`time_read`) — the mean of `TIMING_RUNS` runs after one untimed
+#   warm-up run. **These are warm-cache numbers.** The file has just been
+#   written and re-read repeatedly, so it sits in the OS page cache.
+#
+# Warm-cache reads are the honest description of the *repeated-access* pattern
+# a research loop actually has, but they flatter memory-mapped formats: Feather
+# maps pages that are already resident, so its read number below is close to a
+# best case. A first read of a cold file off disk narrows the gap to Parquet,
+# and on a network or object store the compressed format usually wins outright
+# because it moves fewer bytes. Rankings here are for warm, local, repeated
+# reads — the caveat that §2.4 attaches to these figures.
+
+# %% [markdown]
 # ## 1. Generate the Benchmark Panel
 #
 # `generate_ohlcv_data` returns a deterministic OHLCV panel: per-symbol random
 # walks under a fixed seed so format comparisons aren't muddled by data drift
-# across runs. At L scale that's 100 symbols × 10,000 rows = 1 M total rows.
+# across runs. At L scale that's 100 symbols × 10,000 one-minute bars =
+# 1 M total rows, laid out over 26 regular trading sessions (390 bars each), so
+# the panel carries the overnight and weekend gaps real minute data has. All
+# symbols share the session grid, as they do in any synchronized bar panel.
 
 # %%
 ohlcv_df = generate_ohlcv_data(n_symbols=N_SYMBOLS, n_rows=N_ROWS_PER_SYMBOL)
@@ -132,8 +167,7 @@ results: list[BenchmarkResult] = []
 # %%
 csv_path = BENCHMARK_DIR / f"ohlcv_{ACTIVE_SCALE.lower()}.csv"
 
-gc.collect()
-write_time, _ = time_operation(lambda: ohlcv_df.write_csv(csv_path))
+write_time, _ = time_write(lambda: ohlcv_df.write_csv(csv_path))
 csv_size = csv_path.stat().st_size
 results.append(BenchmarkResult("CSV", "write", write_time, csv_size, total_rows))
 
@@ -142,8 +176,7 @@ def read_csv_materialized() -> pl.DataFrame:
     return force_materialize_polars(pl.read_csv(csv_path))
 
 
-gc.collect()
-read_time, csv_result = time_operation(read_csv_materialized)
+read_time, csv_result = time_read(read_csv_materialized)
 validate_result(csv_result, total_rows, "CSV read")
 results.append(BenchmarkResult("CSV", "read", read_time, csv_size, total_rows))
 
@@ -152,8 +185,7 @@ def read_csv_columnar() -> pl.DataFrame:
     return force_materialize_polars(pl.read_csv(csv_path, columns=["close", "volume"]))
 
 
-gc.collect()
-columnar_time, _ = time_operation(read_csv_columnar)
+columnar_time, _ = time_read(read_csv_columnar)
 results.append(BenchmarkResult("CSV", "columnar_read", columnar_time, csv_size, total_rows))
 
 # %% [markdown]
@@ -166,8 +198,7 @@ results.append(BenchmarkResult("CSV", "columnar_read", columnar_time, csv_size, 
 # %%
 parquet_path = BENCHMARK_DIR / f"ohlcv_{ACTIVE_SCALE.lower()}.parquet"
 
-gc.collect()
-write_time, _ = time_operation(lambda: ohlcv_df.write_parquet(parquet_path))
+write_time, _ = time_write(lambda: ohlcv_df.write_parquet(parquet_path))
 parquet_size = parquet_path.stat().st_size
 results.append(BenchmarkResult("Parquet", "write", write_time, parquet_size, total_rows))
 
@@ -176,8 +207,7 @@ def read_parquet_materialized() -> pl.DataFrame:
     return force_materialize_polars(pl.read_parquet(parquet_path))
 
 
-gc.collect()
-read_time, parquet_result = time_operation(read_parquet_materialized)
+read_time, parquet_result = time_read(read_parquet_materialized)
 validate_result(parquet_result, total_rows, "Parquet read")
 results.append(BenchmarkResult("Parquet", "read", read_time, parquet_size, total_rows))
 
@@ -186,8 +216,7 @@ def read_parquet_columnar() -> pl.DataFrame:
     return force_materialize_polars(pl.read_parquet(parquet_path, columns=["close", "volume"]))
 
 
-gc.collect()
-columnar_time, _ = time_operation(read_parquet_columnar)
+columnar_time, _ = time_read(read_parquet_columnar)
 results.append(BenchmarkResult("Parquet", "columnar_read", columnar_time, parquet_size, total_rows))
 
 # %% [markdown]
@@ -201,8 +230,7 @@ results.append(BenchmarkResult("Parquet", "columnar_read", columnar_time, parque
 # %%
 feather_path = BENCHMARK_DIR / f"ohlcv_{ACTIVE_SCALE.lower()}.feather"
 
-gc.collect()
-write_time, _ = time_operation(lambda: ohlcv_df.write_ipc(feather_path))
+write_time, _ = time_write(lambda: ohlcv_df.write_ipc(feather_path))
 feather_size = feather_path.stat().st_size
 results.append(BenchmarkResult("Feather", "write", write_time, feather_size, total_rows))
 
@@ -216,8 +244,7 @@ def read_feather_materialized() -> pl.DataFrame:
     return force_materialize_polars(pl.read_ipc(feather_path))
 
 
-gc.collect()
-read_time, feather_result = time_operation(read_feather_materialized)
+read_time, feather_result = time_read(read_feather_materialized)
 validate_result(feather_result, total_rows, "Feather read")
 results.append(BenchmarkResult("Feather", "read", read_time, feather_size, total_rows))
 
@@ -226,8 +253,7 @@ def read_feather_columnar() -> pl.DataFrame:
     return force_materialize_polars(pl.read_ipc(feather_path, columns=["close", "volume"]))
 
 
-gc.collect()
-columnar_time, _ = time_operation(read_feather_columnar)
+columnar_time, _ = time_read(read_feather_columnar)
 results.append(BenchmarkResult("Feather", "columnar_read", columnar_time, feather_size, total_rows))
 
 # %% [markdown]
@@ -246,8 +272,7 @@ def write_hdf5() -> None:
         store["ohlcv"] = ohlcv_pandas
 
 
-gc.collect()
-write_time, _ = time_operation(write_hdf5)
+write_time, _ = time_write(write_hdf5)
 hdf5_size = hdf5_path.stat().st_size
 results.append(BenchmarkResult("HDF5", "write", write_time, hdf5_size, total_rows))
 
@@ -258,8 +283,7 @@ def read_hdf5_materialized() -> pd.DataFrame:
     return force_materialize_pandas(df)
 
 
-gc.collect()
-read_time, hdf5_result = time_operation(read_hdf5_materialized)
+read_time, hdf5_result = time_read(read_hdf5_materialized)
 validate_result(hdf5_result, total_rows, "HDF5 read")
 results.append(BenchmarkResult("HDF5", "read", read_time, hdf5_size, total_rows))
 # Fixed-format HDF5 has no column projection — record the full-read time

--- a/02_financial_data_universe/21_storage_benchmark_database.ipynb
+++ b/02_financial_data_universe/21_storage_benchmark_database.ipynb
@@ -5,10 +5,10 @@
    "id": "3e104583",
    "metadata": {
     "papermill": {
-     "duration": 0.003498,
-     "end_time": "2026-07-11T18:54:18.058729+00:00",
+     "duration": 0.022118,
+     "end_time": "2026-07-16T21:00:12.327537+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:18.055231+00:00",
+     "start_time": "2026-07-16T21:00:12.305419+00:00",
      "status": "completed"
     }
    },
@@ -40,8 +40,56 @@
     "1. **Write** - Bulk insert performance\n",
     "2. **Read** - Full table scan\n",
     "3. **Range Query** - 7-day time window (backtesting workflow)\n",
-    "4. **OHLCV Aggregation** - Resample to bars\n",
+    "4. **OHLCV Aggregation** - Resample minute bars to daily bars\n",
     "5. **ASOF Join** - Trade-quote alignment (critical for microstructure)\n",
+    "\n",
+    "## Timing Policy\n",
+    "\n",
+    "One policy, applied identically to every engine. Engines that were timed\n",
+    "under different rules would not belong on the same chart, so the rules are\n",
+    "stated here and enforced by the `time_write` / `time_read` helpers rather\n",
+    "than by per-call arguments:\n",
+    "\n",
+    "- **Writes** (`time_write`) - a single shot, no warm-up, against a table\n",
+    "  created fresh for the run. Bulk load happens once per dataset, so that is\n",
+    "  what we time. Repeating it would append duplicate rows on the append-only\n",
+    "  engines, or require a teardown that is not part of the write.\n",
+    "- **Durability inside the timed region.** PostgreSQL and TimescaleDB commit\n",
+    "  synchronously, so their flush cost is inside the timed call. QuestDB (ILP\n",
+    "  + WAL) and InfluxDB acknowledge before the rows are queryable, so they\n",
+    "  poll to first-queryable via `wait_until_rows_visible` *inside* the timed\n",
+    "  call. Every write time therefore ends at the same event: the data is\n",
+    "  durable and readable.\n",
+    "- **Reads, aggregations, and joins** (`time_read`) - mean of `TIMING_RUNS`\n",
+    "  runs after one untimed warm-up. **These are warm numbers**, on both the OS\n",
+    "  page cache and each server's buffer pool, and they flatter every engine\n",
+    "  that caches. A client cannot drop a server's cache, so a \"cold\" read here\n",
+    "  would be cold for the embedded engines and warm for the servers - neither\n",
+    "  cold nor comparable. Warm and uniform is the measurable choice; §2.4 says\n",
+    "  so where it reports these figures.\n",
+    "- **Every read is validated** against the expected row count. A query that\n",
+    "  silently returns a truncated result would otherwise post the fastest time\n",
+    "  on the chart.\n",
+    "\n",
+    "## What the size column does and does not mean\n",
+    "\n",
+    "Unlike the timings, on-disk size is **not** measured the same way for every\n",
+    "engine, because each engine only exposes its own accounting. Read the size\n",
+    "column as \"what this engine reports it is using\", not as a like-for-like\n",
+    "compression ratio:\n",
+    "\n",
+    "| Engine | Reported by | Counts |\n",
+    "|--------|-------------|--------|\n",
+    "| SQLite / DuckDB | file size on disk | the database file |\n",
+    "| ClickHouse | `system.parts.bytes_on_disk` | **compressed** data parts |\n",
+    "| QuestDB | `table_storage().diskSize` | the table's full on-disk footprint |\n",
+    "| PostgreSQL / TimescaleDB | `pg_total_relation_size` / `hypertable_size` | table **plus indexes** (and, for the hypertable, all its chunks) |\n",
+    "| InfluxDB | *not exposed* | client API reports no per-bucket size, so it is left empty rather than recorded as zero |\n",
+    "\n",
+    "Comparing ClickHouse's compressed parts against PostgreSQL's table-plus-index\n",
+    "total is not a compression comparison. The file-format notebook\n",
+    "(`20_storage_benchmark_file`) is where size is measured identically across\n",
+    "contenders and can be compared directly.\n",
     "\n",
     "## Quick Start\n",
     "\n",
@@ -60,10 +108,10 @@
    "id": "688229a5",
    "metadata": {
     "papermill": {
-     "duration": 0.002876,
-     "end_time": "2026-07-11T18:54:18.064865+00:00",
+     "duration": 0.004781,
+     "end_time": "2026-07-16T21:00:12.348447+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:18.061989+00:00",
+     "start_time": "2026-07-16T21:00:12.343666+00:00",
      "status": "completed"
     }
    },
@@ -77,16 +125,16 @@
    "id": "f6595cb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:18.071702Z",
-     "iopub.status.busy": "2026-07-11T18:54:18.071553Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.250448Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.250044Z"
+     "iopub.execute_input": "2026-07-16T21:00:12.356737Z",
+     "iopub.status.busy": "2026-07-16T21:00:12.356579Z",
+     "iopub.status.idle": "2026-07-16T21:00:12.359033Z",
+     "shell.execute_reply": "2026-07-16T21:00:12.358708Z"
     },
     "papermill": {
-     "duration": 1.183172,
-     "end_time": "2026-07-11T18:54:19.251016+00:00",
+     "duration": 0.007148,
+     "end_time": "2026-07-16T21:00:12.359303+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:18.067844+00:00",
+     "start_time": "2026-07-16T21:00:12.352155+00:00",
      "status": "completed"
     }
    },
@@ -105,7 +153,63 @@
     "import urllib.parse\n",
     "import urllib.request\n",
     "import warnings\n",
-    "from pathlib import Path\n",
+    "from datetime import UTC, timedelta\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fdf0adee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:12.366757Z",
+     "iopub.status.busy": "2026-07-16T21:00:12.366656Z",
+     "iopub.status.idle": "2026-07-16T21:00:12.368295Z",
+     "shell.execute_reply": "2026-07-16T21:00:12.368018Z"
+    },
+    "papermill": {
+     "duration": 0.0059,
+     "end_time": "2026-07-16T21:00:12.368622+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:12.362722+00:00",
+     "status": "completed"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Production scale follows chapter §2.4 prose (\"L scale, ~1 M OHLCV rows\").\n",
+    "# Override via Papermill for CI: BENCHMARK_SCALE = \"S\".\n",
+    "BENCHMARK_SCALE = \"L\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "61e224b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:12.376166Z",
+     "iopub.status.busy": "2026-07-16T21:00:12.376066Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.202189Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.201793Z"
+    },
+    "papermill": {
+     "duration": 0.830591,
+     "end_time": "2026-07-16T21:00:13.202754+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:12.372163+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# storage_benchmarks reads BENCHMARK_SCALE at import time, so the env var must\n",
+    "# be set before the import below.\n",
+    "os.environ[\"BENCHMARK_SCALE\"] = BENCHMARK_SCALE\n",
     "\n",
     "import pandas as pd\n",
     "import plotly.graph_objects as go\n",
@@ -132,29 +236,32 @@
     "    get_scale_config,\n",
     "    save_benchmark_results,\n",
     "    save_chart,\n",
-    "    time_operation,\n",
+    "    time_read,\n",
+    "    time_write,\n",
     "    validate_result,\n",
+    "    wait_until_rows_visible,\n",
     ")\n",
+    "from utils.style import COLORS\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "fb8c2f03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.257904Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.257775Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.259893Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.259530Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.211101Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.210890Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.213083Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.212740Z"
     },
     "papermill": {
-     "duration": 0.006332,
-     "end_time": "2026-07-11T18:54:19.260563+00:00",
+     "duration": 0.006833,
+     "end_time": "2026-07-16T21:00:13.213368+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.254231+00:00",
+     "start_time": "2026-07-16T21:00:13.206535+00:00",
      "status": "completed"
     }
    },
@@ -165,41 +272,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "78da29b1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.267269Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.267171Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.268889Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.268478Z"
-    },
-    "papermill": {
-     "duration": 0.005342,
-     "end_time": "2026-07-11T18:54:19.269124+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T18:54:19.263782+00:00",
-     "status": "completed"
-    },
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Production defaults — Papermill injects overrides for CI"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "2f349afc",
    "metadata": {
     "papermill": {
-     "duration": 0.003251,
-     "end_time": "2026-07-11T18:54:19.275634+00:00",
+     "duration": 0.003474,
+     "end_time": "2026-07-16T21:00:13.220404+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.272383+00:00",
+     "start_time": "2026-07-16T21:00:13.216930+00:00",
      "status": "completed"
     }
    },
@@ -209,20 +289,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c2efe808",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.282097Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.281977Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.337864Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.337323Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.228752Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.228610Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.289524Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.289168Z"
     },
     "papermill": {
-     "duration": 0.059831,
-     "end_time": "2026-07-11T18:54:19.338315+00:00",
+     "duration": 0.065667,
+     "end_time": "2026-07-16T21:00:13.289876+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.278484+00:00",
+     "start_time": "2026-07-16T21:00:13.224209+00:00",
      "status": "completed"
     }
    },
@@ -294,20 +374,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "4a364e17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.352464Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.352314Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.432913Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.432193Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.297998Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.297886Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.350307Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.349769Z"
     },
     "papermill": {
-     "duration": 0.088444,
-     "end_time": "2026-07-11T18:54:19.433542+00:00",
+     "duration": 0.057153,
+     "end_time": "2026-07-16T21:00:13.350745+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.345098+00:00",
+     "start_time": "2026-07-16T21:00:13.293592+00:00",
      "status": "completed"
     }
    },
@@ -356,20 +436,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "7567d712",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.443027Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.442768Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.668682Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.668083Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.360135Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.359789Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.522901Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.522440Z"
     },
     "papermill": {
-     "duration": 0.230475,
-     "end_time": "2026-07-11T18:54:19.669261+00:00",
+     "duration": 0.168482,
+     "end_time": "2026-07-16T21:00:13.523279+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.438786+00:00",
+     "start_time": "2026-07-16T21:00:13.354797+00:00",
      "status": "completed"
     }
    },
@@ -432,20 +512,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0fff2698",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.682595Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.682372Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.689558Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.688986Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.533438Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.533272Z",
+     "iopub.status.idle": "2026-07-16T21:00:13.542220Z",
+     "shell.execute_reply": "2026-07-16T21:00:13.541507Z"
     },
     "papermill": {
-     "duration": 0.014625,
-     "end_time": "2026-07-11T18:54:19.690105+00:00",
+     "duration": 0.014831,
+     "end_time": "2026-07-16T21:00:13.542624+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.675480+00:00",
+     "start_time": "2026-07-16T21:00:13.527793+00:00",
      "status": "completed"
     }
    },
@@ -481,20 +561,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9f8cce62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.698159Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.697952Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.703068Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.702548Z"
+     "iopub.execute_input": "2026-07-16T21:00:13.552505Z",
+     "iopub.status.busy": "2026-07-16T21:00:13.552396Z",
+     "iopub.status.idle": "2026-07-16T21:00:14.185316Z",
+     "shell.execute_reply": "2026-07-16T21:00:14.184534Z"
     },
     "papermill": {
-     "duration": 0.00941,
-     "end_time": "2026-07-11T18:54:19.703393+00:00",
+     "duration": 0.637782,
+     "end_time": "2026-07-16T21:00:14.185747+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.693983+00:00",
+     "start_time": "2026-07-16T21:00:13.547965+00:00",
      "status": "completed"
     }
    },
@@ -503,7 +583,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "○ PyKX/kdb+: Not installed (optional - uv pip install pykx)\n"
+      "\n",
+      "Welcome to KDB-X Community Edition!\n",
+      "For Community support, please visit https://kx.com/slack\n",
+      "Tutorials can be found at https://github.com/KxSystems/tutorials\n",
+      "Ready to go beyond the Community Edition? Email preview@kx.com\n",
+      "\n",
+      "[OK] PyKX/kdb+ 4.0.0: Available (IPC mode, licence /home/ml4t/.pykx/kc.lic)\n"
      ]
     }
    ],
@@ -519,50 +605,59 @@
     "]\n",
     "KX_LICENSE_DIRS = [Path.home() / \".pykx\", Path.home() / \".kx\"]\n",
     "\n",
-    "try:\n",
-    "    os.environ[\"PYKX_UNLICENSED\"] = \"1\"  # Import PyKX without license check\n",
-    "    import pykx as kx\n",
+    "# Look for the q binary and a licence BEFORE importing PyKX. The order matters:\n",
+    "# PyKX must never be imported in unlicensed mode (`PYKX_UNLICENSED=1`), which is\n",
+    "# what this cell used to do. Unlicensed PyKX 4.0 leaves the process in a state\n",
+    "# where later numpy work segfaults — the crash lands in `generate_ohlcv_data`,\n",
+    "# nowhere near this cell, so it reads as a data bug rather than an import one.\n",
+    "# Without a licence there is nothing to benchmark anyway, so we simply do not\n",
+    "# import PyKX at all and skip kdb+.\n",
+    "for q_path in Q_BINARY_LOCATIONS:\n",
+    "    if q_path.exists() and q_path.is_file():\n",
+    "        Q_BINARY = q_path\n",
+    "        break\n",
     "\n",
-    "    # Find q binary\n",
-    "    for q_path in Q_BINARY_LOCATIONS:\n",
-    "        if q_path.exists() and q_path.is_file():\n",
-    "            Q_BINARY = q_path\n",
-    "            break\n",
+    "KX_LICENSE_FILE = next(\n",
+    "    (d / f for d in KX_LICENSE_DIRS for f in (\"kc.lic\", \"k4.lic\") if (d / f).exists()), None\n",
+    ")\n",
     "\n",
-    "    # Check for license\n",
-    "    has_license = any((d / \"kc.lic\").exists() or (d / \"k4.lic\").exists() for d in KX_LICENSE_DIRS)\n",
+    "if Q_BINARY is None or KX_LICENSE_FILE is None:\n",
+    "    print(\"○ PyKX/kdb+: Optional (not configured) — skipping, no result will be claimed\")\n",
+    "    if Q_BINARY is None:\n",
+    "        print(\"    → Get a free personal edition: https://kx.com/kdb-personal-edition-download/\")\n",
+    "        print(f\"    → Install the q binary to: {Q_BINARY_LOCATIONS[0]}\")\n",
+    "    if KX_LICENSE_FILE is None:\n",
+    "        print(f\"    → Place the licence file (kc.lic) in: {KX_LICENSE_DIRS[0]}\")\n",
+    "else:\n",
+    "    try:\n",
+    "        # q resolves its licence from QLIC, not from the file merely existing on\n",
+    "        # disk: without this the q process starts and dies \"no license loaded\".\n",
+    "        os.environ[\"QLIC\"] = str(KX_LICENSE_FILE.parent)\n",
+    "        import pykx as kx\n",
     "\n",
-    "    if Q_BINARY and has_license:\n",
     "        HAS_PYKX = True\n",
     "        benchmark_status[\"kdb+/PyKX\"][\"expected\"] = True\n",
-    "        print(\"[OK] PyKX/kdb+: Available (IPC mode)\")\n",
-    "    else:\n",
-    "        print(\"○ PyKX/kdb+: Optional (not configured)\")\n",
-    "        if not Q_BINARY:\n",
-    "            print(\"    → Get free personal license: https://kx.com/kdb-personal-edition-download/\")\n",
-    "            print(f\"    → Install q binary to: {Q_BINARY_LOCATIONS[0]}\")\n",
-    "        if not has_license:\n",
-    "            print(f\"    → Place license file (kc.lic) in: {KX_LICENSE_DIRS[0]}\")\n",
-    "except ImportError:\n",
-    "    print(\"○ PyKX/kdb+: Not installed (optional - uv pip install pykx)\")"
+    "        print(f\"[OK] PyKX/kdb+ {kx.__version__}: Available (IPC mode, licence {KX_LICENSE_FILE})\")\n",
+    "    except ImportError:\n",
+    "        print(\"○ PyKX/kdb+: Not installed (optional — `uv pip install pykx`)\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1ad26118",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.710494Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.710318Z",
-     "iopub.status.idle": "2026-07-11T18:54:19.713301Z",
-     "shell.execute_reply": "2026-07-11T18:54:19.712797Z"
+     "iopub.execute_input": "2026-07-16T21:00:14.194026Z",
+     "iopub.status.busy": "2026-07-16T21:00:14.193814Z",
+     "iopub.status.idle": "2026-07-16T21:00:14.196974Z",
+     "shell.execute_reply": "2026-07-16T21:00:14.196375Z"
     },
     "papermill": {
-     "duration": 0.007064,
-     "end_time": "2026-07-11T18:54:19.713628+00:00",
+     "duration": 0.00781,
+     "end_time": "2026-07-16T21:00:14.197322+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.706564+00:00",
+     "start_time": "2026-07-16T21:00:14.189512+00:00",
      "status": "completed"
     }
    },
@@ -572,7 +667,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[OK] 2 embedded + 5 server + 0 HFT database(s) available\n"
+      "[OK] 2 embedded + 5 server + 1 HFT database(s) available\n"
      ]
     }
    ],
@@ -596,10 +691,10 @@
    "id": "d7da3d08",
    "metadata": {
     "papermill": {
-     "duration": 0.003162,
-     "end_time": "2026-07-11T18:54:19.720131+00:00",
+     "duration": 0.003635,
+     "end_time": "2026-07-16T21:00:14.204947+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.716969+00:00",
+     "start_time": "2026-07-16T21:00:14.201312+00:00",
      "status": "completed"
     }
    },
@@ -609,20 +704,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f38cdbce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:19.727443Z",
-     "iopub.status.busy": "2026-07-11T18:54:19.727228Z",
-     "iopub.status.idle": "2026-07-11T18:54:21.434552Z",
-     "shell.execute_reply": "2026-07-11T18:54:21.434060Z"
+     "iopub.execute_input": "2026-07-16T21:00:14.213202Z",
+     "iopub.status.busy": "2026-07-16T21:00:14.213066Z",
+     "iopub.status.idle": "2026-07-16T21:00:16.150300Z",
+     "shell.execute_reply": "2026-07-16T21:00:16.149603Z"
     },
     "papermill": {
-     "duration": 1.711694,
-     "end_time": "2026-07-11T18:54:21.434899+00:00",
+     "duration": 1.942109,
+     "end_time": "2026-07-16T21:00:16.150783+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:19.723205+00:00",
+     "start_time": "2026-07-16T21:00:14.208674+00:00",
      "status": "completed"
     }
    },
@@ -686,13 +781,92 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82c8025d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003997,
+     "end_time": "2026-07-16T21:00:16.159018+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:16.155021+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "## Benchmark Windows\n",
+    "\n",
+    "Two derived quantities that every engine below reuses, so that all engines\n",
+    "answer the *same* question and can be validated against the same expected\n",
+    "row count:\n",
+    "\n",
+    "- **Range query**: the first 7 calendar days of the panel — the slice a\n",
+    "  backtest walks. Against session-aware minute bars this covers 5 trading\n",
+    "  sessions, a real fraction of the panel rather than a full scan.\n",
+    "- **Aggregation**: minute bars resampled to **daily** bars. Every engine\n",
+    "  buckets by day; bucketing minute data by minute would be a near-identity\n",
+    "  for the engines that did it and a real reduction for the ones that didn't,\n",
+    "  which is not a comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6d4c9998",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:16.167316Z",
+     "iopub.status.busy": "2026-07-16T21:00:16.167177Z",
+     "iopub.status.idle": "2026-07-16T21:00:16.204471Z",
+     "shell.execute_reply": "2026-07-16T21:00:16.204017Z"
+    },
+    "papermill": {
+     "duration": 0.041959,
+     "end_time": "2026-07-16T21:00:16.204788+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:16.162829+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Panel spans 26 trading sessions: 2024-01-02 09:30:00 → 2024-02-06 13:39:00\n",
+      "Range query  : 2024-01-02 09:30:00 ≤ timestamp < 2024-01-09 09:30:00 → 195,000 rows (19.5% of panel)\n",
+      "Aggregation  : minute bars → 2,600 daily bars\n"
+     ]
+    }
+   ],
+   "source": [
+    "RANGE_QUERY_DAYS = 7\n",
+    "\n",
+    "range_start = ohlcv_df[\"timestamp\"].min()\n",
+    "range_end = range_start + timedelta(days=RANGE_QUERY_DAYS)\n",
+    "range_expected_rows = ohlcv_df.filter(\n",
+    "    (pl.col(\"timestamp\") >= range_start) & (pl.col(\"timestamp\") < range_end)\n",
+    ").height\n",
+    "agg_expected_rows = ohlcv_df.select(\n",
+    "    pl.struct(\"symbol\", pl.col(\"timestamp\").dt.truncate(\"1d\")).n_unique()\n",
+    ").item()\n",
+    "\n",
+    "n_sessions = ohlcv_df.select(pl.col(\"timestamp\").dt.date().n_unique()).item()\n",
+    "print(f\"Panel spans {n_sessions} trading sessions: {range_start} → {ohlcv_df['timestamp'].max()}\")\n",
+    "print(\n",
+    "    f\"Range query  : {range_start} ≤ timestamp < {range_end} \"\n",
+    "    f\"→ {range_expected_rows:,} rows ({range_expected_rows / total_rows:.1%} of panel)\"\n",
+    ")\n",
+    "print(f\"Aggregation  : minute bars → {agg_expected_rows:,} daily bars\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7fe2d48e",
    "metadata": {
     "papermill": {
-     "duration": 0.003158,
-     "end_time": "2026-07-11T18:54:21.441561+00:00",
+     "duration": 0.006483,
+     "end_time": "2026-07-16T21:00:16.219870+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:21.438403+00:00",
+     "start_time": "2026-07-16T21:00:16.213387+00:00",
      "status": "completed"
     }
    },
@@ -707,10 +881,10 @@
    "id": "36dd0a39",
    "metadata": {
     "papermill": {
-     "duration": 0.00306,
-     "end_time": "2026-07-11T18:54:21.447746+00:00",
+     "duration": 0.00377,
+     "end_time": "2026-07-16T21:00:16.228326+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:21.444686+00:00",
+     "start_time": "2026-07-16T21:00:16.224556+00:00",
      "status": "completed"
     }
    },
@@ -726,20 +900,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "777f270a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:21.455260Z",
-     "iopub.status.busy": "2026-07-11T18:54:21.455110Z",
-     "iopub.status.idle": "2026-07-11T18:54:31.603212Z",
-     "shell.execute_reply": "2026-07-11T18:54:31.602804Z"
+     "iopub.execute_input": "2026-07-16T21:00:16.236525Z",
+     "iopub.status.busy": "2026-07-16T21:00:16.236391Z",
+     "iopub.status.idle": "2026-07-16T21:00:18.788000Z",
+     "shell.execute_reply": "2026-07-16T21:00:18.787580Z"
     },
     "papermill": {
-     "duration": 10.152801,
-     "end_time": "2026-07-11T18:54:31.603856+00:00",
+     "duration": 2.556798,
+     "end_time": "2026-07-16T21:00:18.788873+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:21.451055+00:00",
+     "start_time": "2026-07-16T21:00:16.232075+00:00",
      "status": "completed"
     }
    },
@@ -773,8 +947,7 @@
     "        conn.execute(\"CREATE INDEX IF NOT EXISTS idx_symbol_timestamp ON ohlcv(symbol, timestamp)\")\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(write_sqlite)\n",
+    "write_time, _ = time_write(write_sqlite)\n",
     "sqlite_size = sqlite_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"SQLite\", \"write\", write_time, sqlite_size, total_rows))"
    ]
@@ -785,10 +958,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004614,
-     "end_time": "2026-07-11T18:54:31.612037+00:00",
+     "duration": 0.005541,
+     "end_time": "2026-07-16T21:00:18.801752+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:31.607423+00:00",
+     "start_time": "2026-07-16T21:00:18.796211+00:00",
      "status": "completed"
     }
    },
@@ -798,20 +971,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "af17bde2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:31.628156Z",
-     "iopub.status.busy": "2026-07-11T18:54:31.627849Z",
-     "iopub.status.idle": "2026-07-11T18:54:39.037264Z",
-     "shell.execute_reply": "2026-07-11T18:54:39.036099Z"
+     "iopub.execute_input": "2026-07-16T21:00:18.816009Z",
+     "iopub.status.busy": "2026-07-16T21:00:18.815735Z",
+     "iopub.status.idle": "2026-07-16T21:00:27.132192Z",
+     "shell.execute_reply": "2026-07-16T21:00:27.131723Z"
     },
     "papermill": {
-     "duration": 7.419235,
-     "end_time": "2026-07-11T18:54:39.038670+00:00",
+     "duration": 8.325162,
+     "end_time": "2026-07-16T21:00:27.132718+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:31.619435+00:00",
+     "start_time": "2026-07-16T21:00:18.807556+00:00",
      "status": "completed"
     }
    },
@@ -823,8 +996,7 @@
     "    return force_materialize_pandas(df)\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, sqlite_result = time_operation(read_sqlite)\n",
+    "read_time, sqlite_result = time_read(read_sqlite)\n",
     "validate_result(sqlite_result, total_rows, \"SQLite read\")\n",
     "results.append(BenchmarkResult(\"SQLite\", \"read\", read_time, sqlite_size, total_rows))"
    ]
@@ -835,33 +1007,99 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007029,
-     "end_time": "2026-07-11T18:54:39.056976+00:00",
+     "duration": 0.003694,
+     "end_time": "2026-07-16T21:00:27.140434+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:39.049947+00:00",
+     "start_time": "2026-07-16T21:00:27.136740+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "### SQLite OHLCV Aggregation"
+    "### SQLite Range Query\n",
+    "\n",
+    "SQLite stores the timestamps as ISO-8601 text, which sorts lexicographically,\n",
+    "so the string bounds below use the covering `(symbol, timestamp)` index."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "5e4adce4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:39.065304Z",
-     "iopub.status.busy": "2026-07-11T18:54:39.065150Z",
-     "iopub.status.idle": "2026-07-11T18:54:41.519093Z",
-     "shell.execute_reply": "2026-07-11T18:54:41.518669Z"
+     "iopub.execute_input": "2026-07-16T21:00:27.148837Z",
+     "iopub.status.busy": "2026-07-16T21:00:27.148709Z",
+     "iopub.status.idle": "2026-07-16T21:00:29.194575Z",
+     "shell.execute_reply": "2026-07-16T21:00:29.194152Z"
     },
     "papermill": {
-     "duration": 2.458551,
-     "end_time": "2026-07-11T18:54:41.519501+00:00",
+     "duration": 2.051144,
+     "end_time": "2026-07-16T21:00:29.195412+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:39.060950+00:00",
+     "start_time": "2026-07-16T21:00:27.144268+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SQLITE_TS_FMT = \"%Y-%m-%d %H:%M:%S\"\n",
+    "\n",
+    "\n",
+    "def sqlite_range_query():\n",
+    "    with contextlib.closing(sqlite3.connect(sqlite_path)) as conn:\n",
+    "        df = pd.read_sql(\n",
+    "            \"SELECT * FROM ohlcv WHERE timestamp >= ? AND timestamp < ?\",\n",
+    "            conn,\n",
+    "            params=(range_start.strftime(SQLITE_TS_FMT), range_end.strftime(SQLITE_TS_FMT)),\n",
+    "        )\n",
+    "    return force_materialize_pandas(df)\n",
+    "\n",
+    "\n",
+    "range_time, sqlite_range = time_read(sqlite_range_query)\n",
+    "validate_result(sqlite_range, range_expected_rows, \"SQLite range query\")\n",
+    "results.append(BenchmarkResult(\"SQLite\", \"range_query\", range_time, 0, len(sqlite_range)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60c294e",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.003749,
+     "end_time": "2026-07-16T21:00:29.206671+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:29.202922+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "### SQLite OHLCV Aggregation\n",
+    "\n",
+    "`open` is the first price of the session and `close` the last, ordered by\n",
+    "time — not `MIN(open)` / `MAX(close)`, which are a different (and wrong)\n",
+    "statistic. SQLite has no `first`/`last` aggregate, so the OHLCV reduction\n",
+    "needs window functions. That costs SQLite time relative to the engines with\n",
+    "native `first`/`last`, and that cost is the honest answer to \"what does this\n",
+    "aggregation take on SQLite?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "4352efc6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:29.214868Z",
+     "iopub.status.busy": "2026-07-16T21:00:29.214730Z",
+     "iopub.status.idle": "2026-07-16T21:00:34.097112Z",
+     "shell.execute_reply": "2026-07-16T21:00:34.096705Z"
+    },
+    "papermill": {
+     "duration": 4.88726,
+     "end_time": "2026-07-16T21:00:34.097629+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:29.210369+00:00",
      "status": "completed"
     }
    },
@@ -872,9 +1110,10 @@
      "text": [
       "\n",
       "SQLite: 123.3 MB\n",
-      "  Write: 2.523s (0.40M rows/s)\n",
-      "  Read:  1.820s (0.55M rows/s)\n",
-      "  Aggregation: 0.580s (700 daily bars)\n",
+      "  Write: 2.480s (0.40M rows/s)\n",
+      "  Read:  2.006s (0.50M rows/s)\n",
+      "  Range query: 0.494s (195,000 rows)\n",
+      "  Aggregation: 1.202s (2,600 daily bars)\n",
       "  Note: No native ASOF join\n"
      ]
     }
@@ -883,21 +1122,29 @@
     "def sqlite_aggregation():\n",
     "    with contextlib.closing(sqlite3.connect(sqlite_path)) as conn:\n",
     "        query = \"\"\"\n",
-    "            SELECT symbol, date(timestamp) as date,\n",
-    "                   MIN(open) as open, MAX(high) as high, MIN(low) as low,\n",
-    "                   MAX(close) as close, SUM(volume) as volume\n",
-    "            FROM ohlcv GROUP BY symbol, date(timestamp)\n",
+    "            SELECT DISTINCT symbol, date(timestamp) as bar_date,\n",
+    "                   FIRST_VALUE(open) OVER w as open,\n",
+    "                   MAX(high) OVER w as high,\n",
+    "                   MIN(low) OVER w as low,\n",
+    "                   LAST_VALUE(close) OVER w as close,\n",
+    "                   SUM(volume) OVER w as volume\n",
+    "            FROM ohlcv\n",
+    "            WINDOW w AS (\n",
+    "                PARTITION BY symbol, date(timestamp) ORDER BY timestamp\n",
+    "                ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n",
+    "            )\n",
     "        \"\"\"\n",
     "        return pd.read_sql(query, conn)\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "agg_time, agg_result = time_operation(sqlite_aggregation)\n",
+    "agg_time, agg_result = time_read(sqlite_aggregation)\n",
+    "validate_result(agg_result, agg_expected_rows, \"SQLite aggregation\")\n",
     "results.append(BenchmarkResult(\"SQLite\", \"aggregation\", agg_time, 0, len(agg_result)))\n",
     "\n",
     "print(f\"\\nSQLite: {sqlite_size / 1e6:.1f} MB\")\n",
     "print(f\"  Write: {write_time:.3f}s ({total_rows / write_time / 1e6:.2f}M rows/s)\")\n",
     "print(f\"  Read:  {read_time:.3f}s ({total_rows / read_time / 1e6:.2f}M rows/s)\")\n",
+    "print(f\"  Range query: {range_time:.3f}s ({len(sqlite_range):,} rows)\")\n",
     "print(f\"  Aggregation: {agg_time:.3f}s ({len(agg_result):,} daily bars)\")\n",
     "print(\"  Note: No native ASOF join\")"
    ]
@@ -907,10 +1154,10 @@
    "id": "109be216",
    "metadata": {
     "papermill": {
-     "duration": 0.003316,
-     "end_time": "2026-07-11T18:54:41.526308+00:00",
+     "duration": 0.003717,
+     "end_time": "2026-07-16T21:00:34.106060+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:41.522992+00:00",
+     "start_time": "2026-07-16T21:00:34.102343+00:00",
      "status": "completed"
     }
    },
@@ -926,20 +1173,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "ee64cb38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:41.533379Z",
-     "iopub.status.busy": "2026-07-11T18:54:41.533251Z",
-     "iopub.status.idle": "2026-07-11T18:54:42.198378Z",
-     "shell.execute_reply": "2026-07-11T18:54:42.197814Z"
+     "iopub.execute_input": "2026-07-16T21:00:34.114215Z",
+     "iopub.status.busy": "2026-07-16T21:00:34.114108Z",
+     "iopub.status.idle": "2026-07-16T21:00:34.735587Z",
+     "shell.execute_reply": "2026-07-16T21:00:34.735132Z"
     },
     "papermill": {
-     "duration": 0.669407,
-     "end_time": "2026-07-11T18:54:42.198892+00:00",
+     "duration": 0.62672,
+     "end_time": "2026-07-16T21:00:34.736457+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:41.529485+00:00",
+     "start_time": "2026-07-16T21:00:34.109737+00:00",
      "status": "completed"
     }
    },
@@ -977,8 +1224,7 @@
     "    conn.close()\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "write_time, _ = time_operation(write_duckdb, n_runs=1, warmup=False)\n",
+    "write_time, _ = time_write(write_duckdb)\n",
     "duckdb_size = duckdb_path.stat().st_size\n",
     "results.append(BenchmarkResult(\"DuckDB\", \"write\", write_time, duckdb_size, total_rows))\n",
     "\n",
@@ -991,28 +1237,63 @@
     "    return force_materialize_polars(df)\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "read_time, duckdb_result = time_operation(read_duckdb)\n",
+    "read_time, duckdb_result = time_read(read_duckdb)\n",
     "validate_result(duckdb_result, total_rows, \"DuckDB read\")\n",
     "results.append(BenchmarkResult(\"DuckDB\", \"read\", read_time, duckdb_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "7a15cd6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:42.206341Z",
-     "iopub.status.busy": "2026-07-11T18:54:42.206229Z",
-     "iopub.status.idle": "2026-07-11T18:54:43.734013Z",
-     "shell.execute_reply": "2026-07-11T18:54:43.733579Z"
+     "iopub.execute_input": "2026-07-16T21:00:34.745940Z",
+     "iopub.status.busy": "2026-07-16T21:00:34.745810Z",
+     "iopub.status.idle": "2026-07-16T21:00:34.972967Z",
+     "shell.execute_reply": "2026-07-16T21:00:34.972301Z"
     },
     "papermill": {
-     "duration": 1.531914,
-     "end_time": "2026-07-11T18:54:43.734332+00:00",
+     "duration": 0.232289,
+     "end_time": "2026-07-16T21:00:34.973631+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:42.202418+00:00",
+     "start_time": "2026-07-16T21:00:34.741342+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Range query\n",
+    "def duckdb_range_query():\n",
+    "    conn = duckdb.connect(str(duckdb_path), read_only=True)\n",
+    "    df = conn.execute(\n",
+    "        \"SELECT * FROM ohlcv WHERE timestamp >= ? AND timestamp < ?\", [range_start, range_end]\n",
+    "    ).pl()\n",
+    "    conn.close()\n",
+    "    return force_materialize_polars(df)\n",
+    "\n",
+    "\n",
+    "range_time, duckdb_range = time_read(duckdb_range_query)\n",
+    "validate_result(duckdb_range, range_expected_rows, \"DuckDB range query\")\n",
+    "results.append(BenchmarkResult(\"DuckDB\", \"range_query\", range_time, 0, len(duckdb_range)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "736840ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:34.982509Z",
+     "iopub.status.busy": "2026-07-16T21:00:34.982327Z",
+     "iopub.status.idle": "2026-07-16T21:00:36.406562Z",
+     "shell.execute_reply": "2026-07-16T21:00:36.406142Z"
+    },
+    "papermill": {
+     "duration": 1.429104,
+     "end_time": "2026-07-16T21:00:36.406873+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:34.977769+00:00",
      "status": "completed"
     }
    },
@@ -1022,11 +1303,12 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "DuckDB: 42.2 MB\n",
-      "  Write: 0.151s (6.61M rows/s)\n",
-      "  Read:  0.063s (15.83M rows/s)\n",
-      "  Aggregation: 0.024s (700 daily bars)\n",
-      "  ASOF Join: 0.225s (2.22M trades/s)\n"
+      "DuckDB: 45.6 MB\n",
+      "  Write: 0.131s (7.62M rows/s)\n",
+      "  Read:  0.073s (13.77M rows/s)\n",
+      "  Range query: 0.038s (195,000 rows)\n",
+      "  Aggregation: 0.036s (2,600 daily bars)\n",
+      "  ASOF Join: 0.203s (2.47M trades/s)\n"
      ]
     }
    ],
@@ -1035,17 +1317,18 @@
     "def duckdb_aggregation():\n",
     "    conn = duckdb.connect(str(duckdb_path), read_only=True)\n",
     "    result = conn.execute(\"\"\"\n",
-    "        SELECT symbol, date_trunc('day', timestamp) as date,\n",
-    "               FIRST(open) as open, MAX(high) as high, MIN(low) as low,\n",
-    "               LAST(close) as close, SUM(volume) as volume\n",
-    "        FROM ohlcv GROUP BY symbol, date ORDER BY symbol, date\n",
+    "        SELECT symbol, date_trunc('day', timestamp) as bar_date,\n",
+    "               FIRST(open ORDER BY timestamp) as open, MAX(high) as high,\n",
+    "               MIN(low) as low, LAST(close ORDER BY timestamp) as close,\n",
+    "               SUM(volume) as volume\n",
+    "        FROM ohlcv GROUP BY symbol, bar_date ORDER BY symbol, bar_date\n",
     "    \"\"\").pl()\n",
     "    conn.close()\n",
     "    return result\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "agg_time, agg_result = time_operation(duckdb_aggregation)\n",
+    "agg_time, agg_result = time_read(duckdb_aggregation)\n",
+    "validate_result(agg_result, agg_expected_rows, \"DuckDB aggregation\")\n",
     "results.append(BenchmarkResult(\"DuckDB\", \"aggregation\", agg_time, 0, len(agg_result)))\n",
     "\n",
     "# ASOF Join\n",
@@ -1067,13 +1350,14 @@
     "    return result\n",
     "\n",
     "\n",
-    "gc.collect()\n",
-    "asof_time, asof_result = time_operation(duckdb_asof)\n",
+    "asof_time, asof_result = time_read(duckdb_asof)\n",
+    "validate_result(asof_result, N_TICKS_TRADES, \"DuckDB ASOF join\")\n",
     "results.append(BenchmarkResult(\"DuckDB\", \"asof_join\", asof_time, 0, len(asof_result)))\n",
     "\n",
     "print(f\"\\nDuckDB: {duckdb_size / 1e6:.1f} MB\")\n",
     "print(f\"  Write: {write_time:.3f}s ({total_rows / write_time / 1e6:.2f}M rows/s)\")\n",
     "print(f\"  Read:  {read_time:.3f}s ({total_rows / read_time / 1e6:.2f}M rows/s)\")\n",
+    "print(f\"  Range query: {range_time:.3f}s ({len(duckdb_range):,} rows)\")\n",
     "print(f\"  Aggregation: {agg_time:.3f}s ({len(agg_result):,} daily bars)\")\n",
     "print(f\"  ASOF Join: {asof_time:.3f}s ({N_TICKS_TRADES / asof_time / 1e6:.2f}M trades/s)\")"
    ]
@@ -1083,10 +1367,10 @@
    "id": "e916b90e",
    "metadata": {
     "papermill": {
-     "duration": 0.003273,
-     "end_time": "2026-07-11T18:54:43.741217+00:00",
+     "duration": 0.003968,
+     "end_time": "2026-07-16T21:00:36.415069+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:43.737944+00:00",
+     "start_time": "2026-07-16T21:00:36.411101+00:00",
      "status": "completed"
     }
    },
@@ -1101,20 +1385,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "id": "a25c5f48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:43.748609Z",
-     "iopub.status.busy": "2026-07-11T18:54:43.748465Z",
-     "iopub.status.idle": "2026-07-11T18:54:43.753249Z",
-     "shell.execute_reply": "2026-07-11T18:54:43.752875Z"
+     "iopub.execute_input": "2026-07-16T21:00:36.423616Z",
+     "iopub.status.busy": "2026-07-16T21:00:36.423475Z",
+     "iopub.status.idle": "2026-07-16T21:00:36.428186Z",
+     "shell.execute_reply": "2026-07-16T21:00:36.427805Z"
     },
     "papermill": {
-     "duration": 0.009093,
-     "end_time": "2026-07-11T18:54:43.753561+00:00",
+     "duration": 0.009556,
+     "end_time": "2026-07-16T21:00:36.428486+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:43.744468+00:00",
+     "start_time": "2026-07-16T21:00:36.418930+00:00",
      "status": "completed"
     }
    },
@@ -1146,8 +1430,7 @@
     "    def write_arctic():\n",
     "        lib.write(\"ohlcv\", ohlcv_pandas, prune_previous_versions=True)\n",
     "\n",
-    "    gc.collect()\n",
-    "    write_time, _ = time_operation(write_arctic, n_runs=min(2, TIMING_RUNS))\n",
+    "    write_time, _ = time_write(write_arctic)\n",
     "    arctic_size = sum(f.stat().st_size for f in arctic_path.rglob(\"*\") if f.is_file())\n",
     "    results.append(BenchmarkResult(\"ArcticDB\", \"write\", write_time, arctic_size, total_rows))\n",
     "\n",
@@ -1155,10 +1438,16 @@
     "        df = lib.read(\"ohlcv\").data\n",
     "        return force_materialize_pandas(df)\n",
     "\n",
-    "    gc.collect()\n",
-    "    read_time, arctic_result = time_operation(read_arctic, n_runs=min(2, TIMING_RUNS))\n",
+    "    read_time, arctic_result = time_read(read_arctic, n_runs=min(2, TIMING_RUNS))\n",
     "    validate_result(arctic_result, total_rows, \"ArcticDB read\")\n",
     "    results.append(BenchmarkResult(\"ArcticDB\", \"read\", read_time, arctic_size, total_rows))\n",
+    "\n",
+    "    # No range_query for ArcticDB: its server-side `date_range` filter keys off a\n",
+    "    # datetime *index*, and this panel carries `timestamp` as a column (the\n",
+    "    # canonical schema). Pushing the filter down would need a different write\n",
+    "    # layout than the one benchmarked above, so ArcticDB is absent from the\n",
+    "    # range-query chart rather than being timed on a client-side filter that no\n",
+    "    # other engine pays.\n",
     "\n",
     "    def arctic_aggregation():\n",
     "        df = lib.read(\"ohlcv\").data\n",
@@ -1174,8 +1463,7 @@
     "            .reset_index()\n",
     "        )\n",
     "\n",
-    "    gc.collect()\n",
-    "    agg_time, agg_result = time_operation(arctic_aggregation, n_runs=min(2, TIMING_RUNS))\n",
+    "    agg_time, agg_result = time_read(arctic_aggregation, n_runs=min(2, TIMING_RUNS))\n",
     "    results.append(BenchmarkResult(\"ArcticDB\", \"aggregation\", agg_time, 0, len(agg_result)))\n",
     "\n",
     "    print(f\"\\nArcticDB: {arctic_size / 1e6:.1f} MB\")\n",
@@ -1194,10 +1482,10 @@
    "id": "6fc8f7ea",
    "metadata": {
     "papermill": {
-     "duration": 0.003309,
-     "end_time": "2026-07-11T18:54:43.760434+00:00",
+     "duration": 0.004025,
+     "end_time": "2026-07-16T21:00:36.436546+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:43.757125+00:00",
+     "start_time": "2026-07-16T21:00:36.432521+00:00",
      "status": "completed"
     }
    },
@@ -1212,10 +1500,10 @@
    "id": "19ea7605",
    "metadata": {
     "papermill": {
-     "duration": 0.003289,
-     "end_time": "2026-07-11T18:54:43.766977+00:00",
+     "duration": 0.003725,
+     "end_time": "2026-07-16T21:00:36.444079+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:43.763688+00:00",
+     "start_time": "2026-07-16T21:00:36.440354+00:00",
      "status": "completed"
     }
    },
@@ -1230,20 +1518,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "id": "88e16438",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:43.774571Z",
-     "iopub.status.busy": "2026-07-11T18:54:43.774427Z",
-     "iopub.status.idle": "2026-07-11T18:54:46.352098Z",
-     "shell.execute_reply": "2026-07-11T18:54:46.351468Z"
+     "iopub.execute_input": "2026-07-16T21:00:36.452728Z",
+     "iopub.status.busy": "2026-07-16T21:00:36.452523Z",
+     "iopub.status.idle": "2026-07-16T21:00:38.347579Z",
+     "shell.execute_reply": "2026-07-16T21:00:38.346946Z"
     },
     "papermill": {
-     "duration": 2.582723,
-     "end_time": "2026-07-11T18:54:46.352991+00:00",
+     "duration": 1.90026,
+     "end_time": "2026-07-16T21:00:38.348104+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:43.770268+00:00",
+     "start_time": "2026-07-16T21:00:36.447844+00:00",
      "status": "completed"
     }
    },
@@ -1281,7 +1569,7 @@
     "    def write_clickhouse():\n",
     "        ch_client.insert_df(\"ohlcv_benchmark\", ohlcv_pandas)\n",
     "\n",
-    "    ch_write_time, _ = time_operation(write_clickhouse, n_runs=1, warmup=False)\n",
+    "    ch_write_time, _ = time_write(write_clickhouse)\n",
     "    ch_size = (\n",
     "        ch_client.query(\n",
     "            \"SELECT sum(bytes_on_disk) FROM system.parts WHERE table = 'ohlcv_benchmark'\"\n",
@@ -1294,62 +1582,100 @@
     "    def read_clickhouse():\n",
     "        return ch_client.query_df(\"SELECT * FROM ohlcv_benchmark\")\n",
     "\n",
-    "    ch_read_time, ch_result = time_operation(read_clickhouse, n_runs=min(3, TIMING_RUNS))\n",
+    "    ch_read_time, ch_result = time_read(read_clickhouse, n_runs=min(3, TIMING_RUNS))\n",
     "    validate_result(ch_result, total_rows, \"ClickHouse read\")\n",
     "    results.append(BenchmarkResult(\"ClickHouse\", \"read\", ch_read_time, ch_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "id": "29145d1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:46.363444Z",
-     "iopub.status.busy": "2026-07-11T18:54:46.363260Z",
-     "iopub.status.idle": "2026-07-11T18:54:48.200346Z",
-     "shell.execute_reply": "2026-07-11T18:54:48.199782Z"
+     "iopub.execute_input": "2026-07-16T21:00:38.357148Z",
+     "iopub.status.busy": "2026-07-16T21:00:38.357018Z",
+     "iopub.status.idle": "2026-07-16T21:00:38.831468Z",
+     "shell.execute_reply": "2026-07-16T21:00:38.830742Z"
     },
     "papermill": {
-     "duration": 1.842789,
-     "end_time": "2026-07-11T18:54:48.201140+00:00",
+     "duration": 0.479948,
+     "end_time": "2026-07-16T21:00:38.832247+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:46.358351+00:00",
+     "start_time": "2026-07-16T21:00:38.352299+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "if HAS_CLICKHOUSE:\n",
-    "    # Aggregation\n",
+    "    # Range query\n",
+    "    def clickhouse_range_query():\n",
+    "        return ch_client.query_df(\n",
+    "            \"SELECT * FROM ohlcv_benchmark WHERE timestamp >= %(start)s AND timestamp < %(end)s\",\n",
+    "            parameters={\"start\": range_start, \"end\": range_end},\n",
+    "        )\n",
+    "\n",
+    "    ch_range_time, ch_range_result = time_read(clickhouse_range_query, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(ch_range_result, range_expected_rows, \"ClickHouse range query\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"ClickHouse\", \"range_query\", ch_range_time, 0, len(ch_range_result))\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "5eb997da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:00:38.842711Z",
+     "iopub.status.busy": "2026-07-16T21:00:38.842478Z",
+     "iopub.status.idle": "2026-07-16T21:00:38.999899Z",
+     "shell.execute_reply": "2026-07-16T21:00:38.999180Z"
+    },
+    "papermill": {
+     "duration": 0.163256,
+     "end_time": "2026-07-16T21:00:39.000532+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:00:38.837276+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if HAS_CLICKHOUSE:\n",
+    "    # Aggregation — bucket to DAY, matching every other engine.\n",
     "    def clickhouse_ohlcv():\n",
     "        return ch_client.query_df(\"\"\"\n",
-    "            SELECT symbol, toStartOfMinute(timestamp) as bar_time,\n",
+    "            SELECT symbol, toStartOfDay(timestamp) as bar_time,\n",
     "                   argMin(open, timestamp) as open, max(high) as high,\n",
     "                   min(low) as low, argMax(close, timestamp) as close,\n",
     "                   sum(volume) as volume\n",
     "            FROM ohlcv_benchmark GROUP BY symbol, bar_time ORDER BY symbol, bar_time\n",
     "        \"\"\")\n",
     "\n",
-    "    ch_agg_time, ch_agg_result = time_operation(clickhouse_ohlcv, n_runs=min(3, TIMING_RUNS))"
+    "    ch_agg_time, ch_agg_result = time_read(clickhouse_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(ch_agg_result, agg_expected_rows, \"ClickHouse aggregation\")\n",
+    "    results.append(BenchmarkResult(\"ClickHouse\", \"aggregation\", ch_agg_time, 0, len(ch_agg_result)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 24,
    "id": "ca45e132",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:48.208741Z",
-     "iopub.status.busy": "2026-07-11T18:54:48.208638Z",
-     "iopub.status.idle": "2026-07-11T18:54:51.406835Z",
-     "shell.execute_reply": "2026-07-11T18:54:51.406372Z"
+     "iopub.execute_input": "2026-07-16T21:00:39.009836Z",
+     "iopub.status.busy": "2026-07-16T21:00:39.009709Z",
+     "iopub.status.idle": "2026-07-16T21:00:40.079429Z",
+     "shell.execute_reply": "2026-07-16T21:00:40.078611Z"
     },
     "papermill": {
-     "duration": 3.202613,
-     "end_time": "2026-07-11T18:54:51.407366+00:00",
+     "duration": 1.074932,
+     "end_time": "2026-07-16T21:00:40.079840+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:48.204753+00:00",
+     "start_time": "2026-07-16T21:00:39.004908+00:00",
      "status": "completed"
     }
    },
@@ -1384,20 +1710,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "id": "2ec227f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:51.416308Z",
-     "iopub.status.busy": "2026-07-11T18:54:51.416122Z",
-     "iopub.status.idle": "2026-07-11T18:54:52.559180Z",
-     "shell.execute_reply": "2026-07-11T18:54:52.558771Z"
+     "iopub.execute_input": "2026-07-16T21:00:40.089086Z",
+     "iopub.status.busy": "2026-07-16T21:00:40.088864Z",
+     "iopub.status.idle": "2026-07-16T21:00:41.299017Z",
+     "shell.execute_reply": "2026-07-16T21:00:41.298496Z"
     },
     "papermill": {
-     "duration": 1.148414,
-     "end_time": "2026-07-11T18:54:52.559481+00:00",
+     "duration": 1.215334,
+     "end_time": "2026-07-16T21:00:41.299302+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:51.411067+00:00",
+     "start_time": "2026-07-16T21:00:40.083968+00:00",
      "status": "completed"
     }
    },
@@ -1407,10 +1733,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "ClickHouse: 53.1 MB\n",
-      "  Write: 1.107s | Read: 0.373s\n",
-      "  Aggregation: 0.459s (1,000,000 bars)\n",
-      "  ASOF Join: 0.278s (500,000 rows)\n"
+      "ClickHouse: 52.5 MB\n",
+      "  Write: 0.338s | Read: 0.303s\n",
+      "  Range query: 0.098s (195,000 rows)\n",
+      "  Aggregation: 0.022s (2,600 daily bars)\n",
+      "  ASOF Join: 0.270s (500,000 rows)\n"
      ]
     }
    ],
@@ -1424,12 +1751,14 @@
     "            ON t.symbol = q.symbol AND t.timestamp >= q.timestamp\n",
     "        \"\"\")\n",
     "\n",
-    "    ch_asof_time, ch_asof_result = time_operation(clickhouse_asof, n_runs=min(3, TIMING_RUNS))\n",
+    "    ch_asof_time, ch_asof_result = time_read(clickhouse_asof, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(ch_asof_result, N_TICKS_TRADES, \"ClickHouse ASOF join\")\n",
     "    results.append(BenchmarkResult(\"ClickHouse\", \"asof_join\", ch_asof_time, 0, len(ch_asof_result)))\n",
     "\n",
     "    print(f\"\\nClickHouse: {ch_size / 1e6:.1f} MB\")\n",
     "    print(f\"  Write: {ch_write_time:.3f}s | Read: {ch_read_time:.3f}s\")\n",
-    "    print(f\"  Aggregation: {ch_agg_time:.3f}s ({len(ch_agg_result):,} bars)\")\n",
+    "    print(f\"  Range query: {ch_range_time:.3f}s ({len(ch_range_result):,} rows)\")\n",
+    "    print(f\"  Aggregation: {ch_agg_time:.3f}s ({len(ch_agg_result):,} daily bars)\")\n",
     "    print(f\"  ASOF Join: {ch_asof_time:.3f}s ({len(ch_asof_result):,} rows)\")\n",
     "\n",
     "    ch_client.command(\"DROP TABLE IF EXISTS ohlcv_benchmark\")\n",
@@ -1444,10 +1773,10 @@
    "id": "59fd1459",
    "metadata": {
     "papermill": {
-     "duration": 0.003321,
-     "end_time": "2026-07-11T18:54:52.566401+00:00",
+     "duration": 0.003927,
+     "end_time": "2026-07-16T21:00:41.307458+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:52.563080+00:00",
+     "start_time": "2026-07-16T21:00:41.303531+00:00",
      "status": "completed"
     }
    },
@@ -1462,20 +1791,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 26,
    "id": "692dd3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:52.573989Z",
-     "iopub.status.busy": "2026-07-11T18:54:52.573838Z",
-     "iopub.status.idle": "2026-07-11T18:54:56.428784Z",
-     "shell.execute_reply": "2026-07-11T18:54:56.426542Z"
+     "iopub.execute_input": "2026-07-16T21:00:41.316028Z",
+     "iopub.status.busy": "2026-07-16T21:00:41.315926Z",
+     "iopub.status.idle": "2026-07-16T21:00:42.301121Z",
+     "shell.execute_reply": "2026-07-16T21:00:42.300363Z"
     },
     "papermill": {
-     "duration": 3.860823,
-     "end_time": "2026-07-11T18:54:56.430536+00:00",
+     "duration": 0.990319,
+     "end_time": "2026-07-16T21:00:42.301647+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:52.569713+00:00",
+     "start_time": "2026-07-16T21:00:41.311328+00:00",
      "status": "completed"
     }
    },
@@ -1500,10 +1829,29 @@
     "    benchmark_status[\"QuestDB\"][\"tested\"] = True\n",
     "    from questdb.ingress import Sender\n",
     "\n",
-    "    def questdb_query(sql):\n",
-    "        url = f\"http://{DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']}/exec?query={urllib.parse.quote(sql)}\"\n",
-    "        response = urllib.request.urlopen(url, timeout=30)\n",
+    "    def questdb_query(sql, limit: str | None = None):\n",
+    "        \"\"\"Run SQL over QuestDB's HTTP endpoint.\n",
+    "\n",
+    "        `/exec` caps the JSON result set unless an explicit `limit` is given, so\n",
+    "        every full-result query below passes one. Without it the endpoint\n",
+    "        returns a truncated page: a fast time on a wrong answer.\n",
+    "        \"\"\"\n",
+    "        url = (\n",
+    "            f\"http://{DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']}\"\n",
+    "            f\"/exec?query={urllib.parse.quote(sql)}\"\n",
+    "        )\n",
+    "        if limit is not None:\n",
+    "            url += f\"&limit={limit}\"\n",
+    "        response = urllib.request.urlopen(url, timeout=600)\n",
     "        return json.loads(response.read())\n",
+    "\n",
+    "    def questdb_row_count() -> int:\n",
+    "        try:\n",
+    "            payload = questdb_query(\"SELECT count() FROM ohlcv_benchmark\")\n",
+    "        except Exception:\n",
+    "            return 0  # table not created yet\n",
+    "        dataset = payload.get(\"dataset\") or [[0]]\n",
+    "        return int(dataset[0][0])\n",
     "\n",
     "    with contextlib.suppress(Exception):\n",
     "        questdb_query(\"DROP TABLE IF EXISTS ohlcv_benchmark\")\n",
@@ -1516,7 +1864,10 @@
     "        ) timestamp(timestamp) PARTITION BY DAY WAL\n",
     "    \"\"\")\n",
     "\n",
-    "    # Write via ILP\n",
+    "    # Write via ILP. The WAL commit is polled INSIDE the timed region so that\n",
+    "    # QuestDB's write time ends where PostgreSQL's does: when the rows are\n",
+    "    # queryable. The previous fixed sleep sat outside the timed call, which\n",
+    "    # charged QuestDB nothing for durability.\n",
     "    def write_questdb():\n",
     "        with Sender.from_conf(\n",
     "            f\"http::addr={DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']};\"\n",
@@ -1526,28 +1877,37 @@
     "            sender.dataframe(\n",
     "                df_insert, table_name=\"ohlcv_benchmark\", symbols=[\"symbol\"], at=\"timestamp\"\n",
     "            )\n",
+    "        return wait_until_rows_visible(\n",
+    "            questdb_row_count, total_rows, timeout=max(60.0, WAL_FLUSH_TIMEOUT * 20)\n",
+    "        )\n",
     "\n",
-    "    qdb_write_time, _ = time_operation(write_questdb, n_runs=1, warmup=False)\n",
-    "    time_module.sleep(WAL_FLUSH_TIMEOUT)\n",
-    "    results.append(BenchmarkResult(\"QuestDB\", \"write\", qdb_write_time, 0, total_rows))"
+    "    qdb_write_time, qdb_visible = time_write(write_questdb)\n",
+    "    assert qdb_visible == total_rows, f\"QuestDB ingested {qdb_visible:,} of {total_rows:,}\"\n",
+    "    qdb_size = int(\n",
+    "        questdb_query(\n",
+    "            \"SELECT sum(diskSize) FROM table_storage() WHERE tableName = 'ohlcv_benchmark'\"\n",
+    "        )[\"dataset\"][0][0]\n",
+    "        or 0\n",
+    "    )\n",
+    "    results.append(BenchmarkResult(\"QuestDB\", \"write\", qdb_write_time, qdb_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 27,
    "id": "4f4680e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:54:56.455090Z",
-     "iopub.status.busy": "2026-07-11T18:54:56.454944Z",
-     "iopub.status.idle": "2026-07-11T18:55:16.730908Z",
-     "shell.execute_reply": "2026-07-11T18:55:16.730434Z"
+     "iopub.execute_input": "2026-07-16T21:00:42.315428Z",
+     "iopub.status.busy": "2026-07-16T21:00:42.315212Z",
+     "iopub.status.idle": "2026-07-16T21:00:55.225773Z",
+     "shell.execute_reply": "2026-07-16T21:00:55.225209Z"
     },
     "papermill": {
-     "duration": 20.283275,
-     "end_time": "2026-07-11T18:55:16.731382+00:00",
+     "duration": 12.919739,
+     "end_time": "2026-07-16T21:00:55.226453+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:54:56.448107+00:00",
+     "start_time": "2026-07-16T21:00:42.306714+00:00",
      "status": "completed"
     }
    },
@@ -1557,36 +1917,62 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "QuestDB:\n",
-      "  Write (ILP): 0.777s | Read: 2.618s\n",
-      "  OHLCV aggregation: 2.400s (1000000 bars)\n"
+      "QuestDB: 366.5 MB\n",
+      "  Write (ILP, to queryable): 0.820s | Read: 2.613s\n",
+      "  Range query: 0.501s (195,000 rows)\n",
+      "  OHLCV aggregation: 0.013s (2,600 daily bars)\n"
      ]
     }
    ],
    "source": [
     "if HAS_QUESTDB:\n",
-    "    # Read\n",
+    "    # Read — explicit limit so the endpoint returns the whole table, then\n",
+    "    # validated like every other engine's read.\n",
     "    def read_questdb():\n",
-    "        return questdb_query(\"SELECT * FROM ohlcv_benchmark\")\n",
+    "        return questdb_query(\"SELECT * FROM ohlcv_benchmark\", limit=f\"1,{total_rows}\")\n",
     "\n",
-    "    qdb_read_time, _ = time_operation(read_questdb, n_runs=min(3, TIMING_RUNS))\n",
-    "    results.append(BenchmarkResult(\"QuestDB\", \"read\", qdb_read_time, 0, total_rows))\n",
+    "    qdb_read_time, qdb_result = time_read(read_questdb, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(qdb_result, total_rows, \"QuestDB read\")\n",
+    "    results.append(BenchmarkResult(\"QuestDB\", \"read\", qdb_read_time, qdb_size, total_rows))\n",
     "\n",
-    "    # OHLCV aggregation (SAMPLE BY)\n",
+    "    # Range query\n",
+    "    def questdb_range_query():\n",
+    "        sql = (\n",
+    "            \"SELECT * FROM ohlcv_benchmark \"\n",
+    "            f\"WHERE timestamp >= '{range_start.isoformat()}' \"\n",
+    "            f\"AND timestamp < '{range_end.isoformat()}'\"\n",
+    "        )\n",
+    "        return questdb_query(sql, limit=f\"1,{range_expected_rows}\")\n",
+    "\n",
+    "    qdb_range_time, qdb_range_result = time_read(questdb_range_query, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(qdb_range_result, range_expected_rows, \"QuestDB range query\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\n",
+    "            \"QuestDB\", \"range_query\", qdb_range_time, 0, len(qdb_range_result[\"dataset\"])\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "    # OHLCV aggregation (SAMPLE BY) — daily buckets, matching every other engine\n",
     "    def questdb_ohlcv():\n",
-    "        return questdb_query(\"\"\"\n",
+    "        return questdb_query(\n",
+    "            \"\"\"\n",
     "            SELECT symbol, timestamp as bar_time,\n",
     "                   first(open) as open, max(high) as high, min(low) as low,\n",
     "                   last(close) as close, sum(volume) as volume\n",
-    "            FROM ohlcv_benchmark SAMPLE BY 1m ALIGN TO CALENDAR\n",
-    "        \"\"\")\n",
+    "            FROM ohlcv_benchmark SAMPLE BY 1d ALIGN TO CALENDAR\n",
+    "            \"\"\",\n",
+    "            limit=f\"1,{agg_expected_rows}\",\n",
+    "        )\n",
     "\n",
-    "    qdb_agg_time, qdb_agg_result = time_operation(questdb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
-    "    qdb_agg_rows = len(qdb_agg_result.get(\"dataset\", [])) if qdb_agg_result else 0\n",
+    "    qdb_agg_time, qdb_agg_result = time_read(questdb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(qdb_agg_result, agg_expected_rows, \"QuestDB aggregation\")\n",
+    "    qdb_agg_rows = len(qdb_agg_result[\"dataset\"])\n",
+    "    results.append(BenchmarkResult(\"QuestDB\", \"aggregation\", qdb_agg_time, 0, qdb_agg_rows))\n",
     "\n",
-    "    print(\"\\nQuestDB:\")\n",
-    "    print(f\"  Write (ILP): {qdb_write_time:.3f}s | Read: {qdb_read_time:.3f}s\")\n",
-    "    print(f\"  OHLCV aggregation: {qdb_agg_time:.3f}s ({qdb_agg_rows} bars)\")\n",
+    "    print(f\"\\nQuestDB: {qdb_size / 1e6:.1f} MB\")\n",
+    "    print(f\"  Write (ILP, to queryable): {qdb_write_time:.3f}s | Read: {qdb_read_time:.3f}s\")\n",
+    "    print(f\"  Range query: {qdb_range_time:.3f}s ({len(qdb_range_result['dataset']):,} rows)\")\n",
+    "    print(f\"  OHLCV aggregation: {qdb_agg_time:.3f}s ({qdb_agg_rows:,} daily bars)\")\n",
     "\n",
     "    with contextlib.suppress(Exception):\n",
     "        questdb_query(\"DROP TABLE IF EXISTS ohlcv_benchmark\")\n",
@@ -1599,10 +1985,10 @@
    "id": "4faff3c8",
    "metadata": {
     "papermill": {
-     "duration": 0.003337,
-     "end_time": "2026-07-11T18:55:16.740278+00:00",
+     "duration": 0.003873,
+     "end_time": "2026-07-16T21:00:55.234910+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:55:16.736941+00:00",
+     "start_time": "2026-07-16T21:00:55.231037+00:00",
      "status": "completed"
     }
    },
@@ -1617,20 +2003,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "id": "1a583cd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:55:16.747709Z",
-     "iopub.status.busy": "2026-07-11T18:55:16.747570Z",
-     "iopub.status.idle": "2026-07-11T18:55:16.784768Z",
-     "shell.execute_reply": "2026-07-11T18:55:16.783686Z"
+     "iopub.execute_input": "2026-07-16T21:00:55.243524Z",
+     "iopub.status.busy": "2026-07-16T21:00:55.243401Z",
+     "iopub.status.idle": "2026-07-16T21:00:55.275178Z",
+     "shell.execute_reply": "2026-07-16T21:00:55.273547Z"
     },
     "papermill": {
-     "duration": 0.041896,
-     "end_time": "2026-07-11T18:55:16.785514+00:00",
+     "duration": 0.037518,
+     "end_time": "2026-07-16T21:00:55.276364+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:55:16.743618+00:00",
+     "start_time": "2026-07-16T21:00:55.238846+00:00",
      "status": "completed"
     }
    },
@@ -1681,20 +2067,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "id": "d23f8f3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:55:16.805786Z",
-     "iopub.status.busy": "2026-07-11T18:55:16.805498Z",
-     "iopub.status.idle": "2026-07-11T18:56:28.502501Z",
-     "shell.execute_reply": "2026-07-11T18:56:28.501912Z"
+     "iopub.execute_input": "2026-07-16T21:00:55.293272Z",
+     "iopub.status.busy": "2026-07-16T21:00:55.293037Z",
+     "iopub.status.idle": "2026-07-16T21:02:02.562065Z",
+     "shell.execute_reply": "2026-07-16T21:02:02.561414Z"
     },
     "papermill": {
-     "duration": 71.70661,
-     "end_time": "2026-07-11T18:56:28.503148+00:00",
+     "duration": 67.275325,
+     "end_time": "2026-07-16T21:02:02.562547+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:55:16.796538+00:00",
+     "start_time": "2026-07-16T21:00:55.287222+00:00",
      "status": "completed"
     }
    },
@@ -1725,28 +2111,31 @@
     "            data,\n",
     "        )\n",
     "\n",
-    "    ts_write_time, _ = time_operation(write_timescaledb, n_runs=1, warmup=False)\n",
-    "    cur.execute(\"SELECT pg_total_relation_size('ohlcv_benchmark');\")\n",
+    "    ts_write_time, _ = time_write(write_timescaledb)\n",
+    "    # hypertable_size(), not pg_total_relation_size(): a hypertable's rows live\n",
+    "    # in child chunks, so the parent relation is empty and pg_total_relation_size\n",
+    "    # reports ~16 kB of catalog overhead rather than the data.\n",
+    "    cur.execute(\"SELECT hypertable_size('ohlcv_benchmark');\")\n",
     "    ts_size = cur.fetchone()[0]\n",
     "    results.append(BenchmarkResult(\"TimescaleDB\", \"write\", ts_write_time, ts_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
    "id": "bc45921f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:56:28.511302Z",
-     "iopub.status.busy": "2026-07-11T18:56:28.511171Z",
-     "iopub.status.idle": "2026-07-11T18:56:38.870155Z",
-     "shell.execute_reply": "2026-07-11T18:56:38.869727Z"
+     "iopub.execute_input": "2026-07-16T21:02:02.571820Z",
+     "iopub.status.busy": "2026-07-16T21:02:02.571627Z",
+     "iopub.status.idle": "2026-07-16T21:02:13.080489Z",
+     "shell.execute_reply": "2026-07-16T21:02:13.079955Z"
     },
     "papermill": {
-     "duration": 10.364223,
-     "end_time": "2026-07-11T18:56:38.871201+00:00",
+     "duration": 10.514252,
+     "end_time": "2026-07-16T21:02:13.080973+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:56:28.506978+00:00",
+     "start_time": "2026-07-16T21:02:02.566721+00:00",
      "status": "completed"
     }
    },
@@ -1758,27 +2147,27 @@
     "        cur.execute(\"SELECT * FROM ohlcv_benchmark;\")\n",
     "        return cur.fetchall()\n",
     "\n",
-    "    ts_read_time, ts_result = time_operation(read_timescaledb, n_runs=min(3, TIMING_RUNS))\n",
+    "    ts_read_time, ts_result = time_read(read_timescaledb, n_runs=min(3, TIMING_RUNS))\n",
     "    validate_result(ts_result, total_rows, \"TimescaleDB read\")\n",
     "    results.append(BenchmarkResult(\"TimescaleDB\", \"read\", ts_read_time, ts_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 31,
    "id": "50357547",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:56:38.880521Z",
-     "iopub.status.busy": "2026-07-11T18:56:38.880408Z",
-     "iopub.status.idle": "2026-07-11T18:57:14.265084Z",
-     "shell.execute_reply": "2026-07-11T18:57:14.264549Z"
+     "iopub.execute_input": "2026-07-16T21:02:13.090348Z",
+     "iopub.status.busy": "2026-07-16T21:02:13.090127Z",
+     "iopub.status.idle": "2026-07-16T21:02:16.296850Z",
+     "shell.execute_reply": "2026-07-16T21:02:16.296065Z"
     },
     "papermill": {
-     "duration": 35.392178,
-     "end_time": "2026-07-11T18:57:14.268550+00:00",
+     "duration": 3.212445,
+     "end_time": "2026-07-16T21:02:16.297664+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:56:38.876372+00:00",
+     "start_time": "2026-07-16T21:02:13.085219+00:00",
      "status": "completed"
     }
    },
@@ -1788,29 +2177,49 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "TimescaleDB: 0.0 MB\n",
-      "  Write: 71.591s | Read: 2.603s\n",
-      "  OHLCV aggregation: 8.807s (1,000,000 bars)\n"
+      "TimescaleDB: 111.4 MB\n",
+      "  Write: 67.085s | Read: 2.574s\n",
+      "  Range query: 0.507s (195,000 rows)\n",
+      "  OHLCV aggregation: 0.172s (2,600 daily bars)\n"
      ]
     }
    ],
    "source": [
     "if HAS_TIMESCALEDB:\n",
-    "    # Aggregation (time_bucket)\n",
+    "    # Range query\n",
+    "    def timescaledb_range_query():\n",
+    "        cur.execute(\n",
+    "            \"SELECT * FROM ohlcv_benchmark WHERE timestamp >= %s AND timestamp < %s;\",\n",
+    "            (range_start, range_end),\n",
+    "        )\n",
+    "        return cur.fetchall()\n",
+    "\n",
+    "    ts_range_time, ts_range_result = time_read(timescaledb_range_query, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(ts_range_result, range_expected_rows, \"TimescaleDB range query\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"TimescaleDB\", \"range_query\", ts_range_time, 0, len(ts_range_result))\n",
+    "    )\n",
+    "\n",
+    "    # Aggregation (time_bucket) — daily buckets, matching every other engine\n",
     "    def timescaledb_ohlcv():\n",
     "        cur.execute(\"\"\"\n",
-    "            SELECT symbol, time_bucket('1 minute', timestamp) as bar_time,\n",
+    "            SELECT symbol, time_bucket('1 day', timestamp) as bar_time,\n",
     "                   first(open, timestamp) as open, max(high) as high,\n",
     "                   min(low) as low, last(close, timestamp) as close, sum(volume) as volume\n",
     "            FROM ohlcv_benchmark GROUP BY symbol, bar_time ORDER BY symbol, bar_time;\n",
     "        \"\"\")\n",
     "        return cur.fetchall()\n",
     "\n",
-    "    ts_agg_time, ts_agg_result = time_operation(timescaledb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    ts_agg_time, ts_agg_result = time_read(timescaledb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(ts_agg_result, agg_expected_rows, \"TimescaleDB aggregation\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"TimescaleDB\", \"aggregation\", ts_agg_time, 0, len(ts_agg_result))\n",
+    "    )\n",
     "\n",
     "    print(f\"\\nTimescaleDB: {ts_size / 1e6:.1f} MB\")\n",
     "    print(f\"  Write: {ts_write_time:.3f}s | Read: {ts_read_time:.3f}s\")\n",
-    "    print(f\"  OHLCV aggregation: {ts_agg_time:.3f}s ({len(ts_agg_result):,} bars)\")\n",
+    "    print(f\"  Range query: {ts_range_time:.3f}s ({len(ts_range_result):,} rows)\")\n",
+    "    print(f\"  OHLCV aggregation: {ts_agg_time:.3f}s ({len(ts_agg_result):,} daily bars)\")\n",
     "\n",
     "    cur.execute(\"DROP TABLE IF EXISTS ohlcv_benchmark CASCADE;\")\n",
     "    cur.close()\n",
@@ -1824,10 +2233,10 @@
    "id": "8060c355",
    "metadata": {
     "papermill": {
-     "duration": 0.003854,
-     "end_time": "2026-07-11T18:57:14.277465+00:00",
+     "duration": 0.004043,
+     "end_time": "2026-07-16T21:02:16.306848+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:57:14.273611+00:00",
+     "start_time": "2026-07-16T21:02:16.302805+00:00",
      "status": "completed"
     }
    },
@@ -1842,20 +2251,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "id": "4f7b01e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:57:14.285169Z",
-     "iopub.status.busy": "2026-07-11T18:57:14.284987Z",
-     "iopub.status.idle": "2026-07-11T18:57:14.310079Z",
-     "shell.execute_reply": "2026-07-11T18:57:14.309594Z"
+     "iopub.execute_input": "2026-07-16T21:02:16.315827Z",
+     "iopub.status.busy": "2026-07-16T21:02:16.315675Z",
+     "iopub.status.idle": "2026-07-16T21:02:16.339319Z",
+     "shell.execute_reply": "2026-07-16T21:02:16.338802Z"
     },
     "papermill": {
-     "duration": 0.029665,
-     "end_time": "2026-07-11T18:57:14.310513+00:00",
+     "duration": 0.029139,
+     "end_time": "2026-07-16T21:02:16.339894+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:57:14.280848+00:00",
+     "start_time": "2026-07-16T21:02:16.310755+00:00",
      "status": "completed"
     }
    },
@@ -1903,20 +2312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
    "id": "93627806",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:57:14.318594Z",
-     "iopub.status.busy": "2026-07-11T18:57:14.318411Z",
-     "iopub.status.idle": "2026-07-11T18:58:18.634161Z",
-     "shell.execute_reply": "2026-07-11T18:58:18.633472Z"
+     "iopub.execute_input": "2026-07-16T21:02:16.350557Z",
+     "iopub.status.busy": "2026-07-16T21:02:16.350357Z",
+     "iopub.status.idle": "2026-07-16T21:03:26.555158Z",
+     "shell.execute_reply": "2026-07-16T21:03:26.554749Z"
     },
     "papermill": {
-     "duration": 64.320621,
-     "end_time": "2026-07-11T18:58:18.634851+00:00",
+     "duration": 70.210224,
+     "end_time": "2026-07-16T21:03:26.555763+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:57:14.314230+00:00",
+     "start_time": "2026-07-16T21:02:16.345539+00:00",
      "status": "completed"
     }
    },
@@ -1947,7 +2356,7 @@
     "            data,\n",
     "        )\n",
     "\n",
-    "    pg_write_time, _ = time_operation(write_postgres, n_runs=1, warmup=False)\n",
+    "    pg_write_time, _ = time_write(write_postgres)\n",
     "    pg_cur.execute(\"SELECT pg_total_relation_size('ohlcv_benchmark');\")\n",
     "    pg_size = pg_cur.fetchone()[0]\n",
     "    results.append(BenchmarkResult(\"PostgreSQL\", \"write\", pg_write_time, pg_size, total_rows))"
@@ -1955,20 +2364,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 34,
    "id": "6af161db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:58:18.642795Z",
-     "iopub.status.busy": "2026-07-11T18:58:18.642609Z",
-     "iopub.status.idle": "2026-07-11T18:58:26.517761Z",
-     "shell.execute_reply": "2026-07-11T18:58:26.517048Z"
+     "iopub.execute_input": "2026-07-16T21:03:26.564652Z",
+     "iopub.status.busy": "2026-07-16T21:03:26.564534Z",
+     "iopub.status.idle": "2026-07-16T21:03:34.996313Z",
+     "shell.execute_reply": "2026-07-16T21:03:34.995905Z"
     },
     "papermill": {
-     "duration": 7.879984,
-     "end_time": "2026-07-11T18:58:26.518515+00:00",
+     "duration": 8.437249,
+     "end_time": "2026-07-16T21:03:34.997239+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:58:18.638531+00:00",
+     "start_time": "2026-07-16T21:03:26.559990+00:00",
      "status": "completed"
     }
    },
@@ -1980,27 +2389,64 @@
     "        pg_cur.execute(\"SELECT * FROM ohlcv_benchmark;\")\n",
     "        return pg_cur.fetchall()\n",
     "\n",
-    "    pg_read_time, pg_result = time_operation(read_postgres, n_runs=min(3, TIMING_RUNS))\n",
+    "    pg_read_time, pg_result = time_read(read_postgres, n_runs=min(3, TIMING_RUNS))\n",
     "    validate_result(pg_result, total_rows, \"PostgreSQL read\")\n",
     "    results.append(BenchmarkResult(\"PostgreSQL\", \"read\", pg_read_time, pg_size, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 35,
    "id": "75376de7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:58:26.528191Z",
-     "iopub.status.busy": "2026-07-11T18:58:26.528043Z",
-     "iopub.status.idle": "2026-07-11T18:58:38.380165Z",
-     "shell.execute_reply": "2026-07-11T18:58:38.379726Z"
+     "iopub.execute_input": "2026-07-16T21:03:35.007396Z",
+     "iopub.status.busy": "2026-07-16T21:03:35.007267Z",
+     "iopub.status.idle": "2026-07-16T21:03:37.025047Z",
+     "shell.execute_reply": "2026-07-16T21:03:37.024606Z"
     },
     "papermill": {
-     "duration": 11.857198,
-     "end_time": "2026-07-11T18:58:38.380860+00:00",
+     "duration": 2.023067,
+     "end_time": "2026-07-16T21:03:37.025605+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:58:26.523662+00:00",
+     "start_time": "2026-07-16T21:03:35.002538+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if HAS_POSTGRES:\n",
+    "    # Range query\n",
+    "    def postgres_range_query():\n",
+    "        pg_cur.execute(\n",
+    "            \"SELECT * FROM ohlcv_benchmark WHERE timestamp >= %s AND timestamp < %s;\",\n",
+    "            (range_start, range_end),\n",
+    "        )\n",
+    "        return pg_cur.fetchall()\n",
+    "\n",
+    "    pg_range_time, pg_range_result = time_read(postgres_range_query, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(pg_range_result, range_expected_rows, \"PostgreSQL range query\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"PostgreSQL\", \"range_query\", pg_range_time, 0, len(pg_range_result))\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "bcbf7f5d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:03:37.034666Z",
+     "iopub.status.busy": "2026-07-16T21:03:37.034526Z",
+     "iopub.status.idle": "2026-07-16T21:03:39.141487Z",
+     "shell.execute_reply": "2026-07-16T21:03:39.140924Z"
+    },
+    "papermill": {
+     "duration": 2.112327,
+     "end_time": "2026-07-16T21:03:39.142184+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:03:37.029857+00:00",
      "status": "completed"
     }
    },
@@ -2011,17 +2457,18 @@
      "text": [
       "\n",
       "PostgreSQL: 132.8 MB\n",
-      "  Write: 64.311s | Read: 1.960s\n",
-      "  OHLCV aggregation: 2.969s (1,000,000 bars)\n"
+      "  Write: 70.011s | Read: 2.057s\n",
+      "  Range query: 0.451s (195,000 rows)\n",
+      "  OHLCV aggregation: 0.468s (2,600 daily bars)\n"
      ]
     }
    ],
    "source": [
     "if HAS_POSTGRES:\n",
-    "    # Aggregation (date_trunc to the minute; emulates time_bucket without TimescaleDB extension)\n",
+    "    # Aggregation (date_trunc to the day; emulates time_bucket without the TimescaleDB extension)\n",
     "    def postgres_ohlcv():\n",
     "        pg_cur.execute(\"\"\"\n",
-    "            SELECT symbol, date_trunc('minute', timestamp) as bar_time,\n",
+    "            SELECT symbol, date_trunc('day', timestamp) as bar_time,\n",
     "                   (array_agg(open ORDER BY timestamp))[1] as open,\n",
     "                   max(high) as high, min(low) as low,\n",
     "                   (array_agg(close ORDER BY timestamp DESC))[1] as close,\n",
@@ -2030,11 +2477,14 @@
     "        \"\"\")\n",
     "        return pg_cur.fetchall()\n",
     "\n",
-    "    pg_agg_time, pg_agg_result = time_operation(postgres_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    pg_agg_time, pg_agg_result = time_read(postgres_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(pg_agg_result, agg_expected_rows, \"PostgreSQL aggregation\")\n",
+    "    results.append(BenchmarkResult(\"PostgreSQL\", \"aggregation\", pg_agg_time, 0, len(pg_agg_result)))\n",
     "\n",
     "    print(f\"\\nPostgreSQL: {pg_size / 1e6:.1f} MB\")\n",
     "    print(f\"  Write: {pg_write_time:.3f}s | Read: {pg_read_time:.3f}s\")\n",
-    "    print(f\"  OHLCV aggregation: {pg_agg_time:.3f}s ({len(pg_agg_result):,} bars)\")\n",
+    "    print(f\"  Range query: {pg_range_time:.3f}s ({len(pg_range_result):,} rows)\")\n",
+    "    print(f\"  OHLCV aggregation: {pg_agg_time:.3f}s ({len(pg_agg_result):,} daily bars)\")\n",
     "\n",
     "    pg_cur.execute(\"DROP TABLE IF EXISTS ohlcv_benchmark CASCADE;\")\n",
     "    pg_cur.close()\n",
@@ -2048,10 +2498,10 @@
    "id": "304b73d3",
    "metadata": {
     "papermill": {
-     "duration": 0.003638,
-     "end_time": "2026-07-11T18:58:38.390541+00:00",
+     "duration": 0.004828,
+     "end_time": "2026-07-16T21:03:39.153961+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:58:38.386903+00:00",
+     "start_time": "2026-07-16T21:03:39.149133+00:00",
      "status": "completed"
     }
    },
@@ -2066,20 +2516,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 37,
    "id": "ff88443e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:58:38.398260Z",
-     "iopub.status.busy": "2026-07-11T18:58:38.398118Z",
-     "iopub.status.idle": "2026-07-11T18:58:38.450085Z",
-     "shell.execute_reply": "2026-07-11T18:58:38.447472Z"
+     "iopub.execute_input": "2026-07-16T21:03:39.162403Z",
+     "iopub.status.busy": "2026-07-16T21:03:39.162277Z",
+     "iopub.status.idle": "2026-07-16T21:03:39.252123Z",
+     "shell.execute_reply": "2026-07-16T21:03:39.251119Z"
     },
     "papermill": {
-     "duration": 0.058584,
-     "end_time": "2026-07-11T18:58:38.452578+00:00",
+     "duration": 0.095096,
+     "end_time": "2026-07-16T21:03:39.252952+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:58:38.393994+00:00",
+     "start_time": "2026-07-16T21:03:39.157856+00:00",
      "status": "completed"
     }
    },
@@ -2130,20 +2580,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 38,
    "id": "f06b0324",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:58:38.469927Z",
-     "iopub.status.busy": "2026-07-11T18:58:38.469786Z",
-     "iopub.status.idle": "2026-07-11T18:59:04.222024Z",
-     "shell.execute_reply": "2026-07-11T18:59:04.220147Z"
+     "iopub.execute_input": "2026-07-16T21:03:39.267303Z",
+     "iopub.status.busy": "2026-07-16T21:03:39.267098Z",
+     "iopub.status.idle": "2026-07-16T21:04:01.367155Z",
+     "shell.execute_reply": "2026-07-16T21:04:01.366512Z"
     },
     "papermill": {
-     "duration": 25.761099,
-     "end_time": "2026-07-11T18:59:04.223907+00:00",
+     "duration": 22.10621,
+     "end_time": "2026-07-16T21:04:01.367974+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:58:38.462808+00:00",
+     "start_time": "2026-07-16T21:03:39.261764+00:00",
      "status": "completed"
     }
    },
@@ -2185,27 +2635,56 @@
     "                bucket=influx_bucket, org=influx_org, record=points[i : i + batch_size]\n",
     "            )\n",
     "\n",
-    "    influx_write_time, _ = time_operation(write_influxdb, n_runs=1, warmup=False)\n",
-    "    time_module.sleep(WAL_FLUSH_TIMEOUT)\n",
+    "    def influx_row_count() -> int:\n",
+    "        count_flux = f\"\"\"\n",
+    "        from(bucket: \"{influx_bucket}\")\n",
+    "          |> range(start: 0)\n",
+    "          |> filter(fn: (r) => r._measurement == \"ohlcv\" and r._field == \"close\")\n",
+    "          |> count()\n",
+    "          |> group()\n",
+    "          |> sum()\n",
+    "        \"\"\"\n",
+    "        try:\n",
+    "            tables = influx_query_api_probe.query(count_flux, org=influx_org)\n",
+    "        except Exception:\n",
+    "            return 0\n",
+    "        return int(sum(r.get_value() for t in tables for r in t.records))\n",
+    "\n",
+    "    influx_query_api_probe = influx_client.query_api()\n",
+    "\n",
+    "    def write_influxdb_durable():\n",
+    "        write_influxdb()\n",
+    "        # Poll to first-queryable INSIDE the timed region, so InfluxDB's write\n",
+    "        # ends at the same event as PostgreSQL's: rows readable. The previous\n",
+    "        # fixed sleep sat outside the timed call and charged InfluxDB nothing.\n",
+    "        return wait_until_rows_visible(\n",
+    "            influx_row_count, total_rows, timeout=max(120.0, WAL_FLUSH_TIMEOUT * 40)\n",
+    "        )\n",
+    "\n",
+    "    influx_write_time, influx_visible = time_write(write_influxdb_durable)\n",
+    "    assert influx_visible == total_rows, f\"InfluxDB ingested {influx_visible:,} of {total_rows:,}\"\n",
+    "    # size_bytes=0 -> recorded as empty, not as zero: InfluxDB's client API\n",
+    "    # exposes no per-bucket on-disk size, so this engine is absent from the size\n",
+    "    # column rather than claiming it stores the panel for free.\n",
     "    results.append(BenchmarkResult(\"InfluxDB\", \"write\", influx_write_time, 0, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 39,
    "id": "faa59e33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:59:04.240947Z",
-     "iopub.status.busy": "2026-07-11T18:59:04.240638Z",
-     "iopub.status.idle": "2026-07-11T18:59:45.061754Z",
-     "shell.execute_reply": "2026-07-11T18:59:45.061141Z"
+     "iopub.execute_input": "2026-07-16T21:04:01.378932Z",
+     "iopub.status.busy": "2026-07-16T21:04:01.378674Z",
+     "iopub.status.idle": "2026-07-16T21:04:46.933343Z",
+     "shell.execute_reply": "2026-07-16T21:04:46.932854Z"
     },
     "papermill": {
-     "duration": 40.828414,
-     "end_time": "2026-07-11T18:59:45.062494+00:00",
+     "duration": 45.560872,
+     "end_time": "2026-07-16T21:04:46.934072+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:59:04.234080+00:00",
+     "start_time": "2026-07-16T21:04:01.373200+00:00",
      "status": "completed"
     }
    },
@@ -2231,27 +2710,72 @@
     "                rows.append(record.values)\n",
     "        return rows\n",
     "\n",
-    "    influx_read_time, influx_result = time_operation(read_influxdb, n_runs=min(3, TIMING_RUNS))\n",
+    "    influx_read_time, influx_result = time_read(read_influxdb, n_runs=min(3, TIMING_RUNS))\n",
     "    validate_result(influx_result, total_rows, \"InfluxDB read\")\n",
     "    results.append(BenchmarkResult(\"InfluxDB\", \"read\", influx_read_time, 0, total_rows))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 40,
    "id": "c8aef606",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T18:59:45.070848Z",
-     "iopub.status.busy": "2026-07-11T18:59:45.070722Z",
-     "iopub.status.idle": "2026-07-11T19:12:11.981690Z",
-     "shell.execute_reply": "2026-07-11T19:12:11.981276Z"
+     "iopub.execute_input": "2026-07-16T21:04:46.943770Z",
+     "iopub.status.busy": "2026-07-16T21:04:46.943573Z",
+     "iopub.status.idle": "2026-07-16T21:04:56.663490Z",
+     "shell.execute_reply": "2026-07-16T21:04:56.663045Z"
     },
     "papermill": {
-     "duration": 746.918883,
-     "end_time": "2026-07-11T19:12:11.985498+00:00",
+     "duration": 9.725696,
+     "end_time": "2026-07-16T21:04:56.664183+00:00",
      "exception": false,
-     "start_time": "2026-07-11T18:59:45.066615+00:00",
+     "start_time": "2026-07-16T21:04:46.938487+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if HAS_INFLUXDB and benchmark_status[\"InfluxDB\"][\"tested\"]:\n",
+    "    # Range query — Flux range() takes RFC-3339 bounds; the panel timestamps\n",
+    "    # were localized to UTC on write, so the bounds are localized to match.\n",
+    "    range_flux = f\"\"\"\n",
+    "    from(bucket: \"{influx_bucket}\")\n",
+    "      |> range(start: {range_start.replace(tzinfo=UTC).isoformat()}, stop: {range_end.replace(tzinfo=UTC).isoformat()})\n",
+    "      |> filter(fn: (r) => r._measurement == \"ohlcv\")\n",
+    "      |> pivot(rowKey:[\"_time\",\"symbol\"], columnKey:[\"_field\"], valueColumn:\"_value\")\n",
+    "      |> keep(columns:[\"_time\",\"symbol\",\"open\",\"high\",\"low\",\"close\",\"volume\",\"vwap\",\"num_trades\"])\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def influxdb_range_query():\n",
+    "        tables = influx_query_api.query(range_flux, org=influx_org)\n",
+    "        return [r.values for table in tables for r in table.records]\n",
+    "\n",
+    "    influx_range_time, influx_range_result = time_read(\n",
+    "        influxdb_range_query, n_runs=min(3, TIMING_RUNS)\n",
+    "    )\n",
+    "    validate_result(influx_range_result, range_expected_rows, \"InfluxDB range query\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"InfluxDB\", \"range_query\", influx_range_time, 0, len(influx_range_result))\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "943010c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:04:56.673386Z",
+     "iopub.status.busy": "2026-07-16T21:04:56.673250Z",
+     "iopub.status.idle": "2026-07-16T21:07:16.145001Z",
+     "shell.execute_reply": "2026-07-16T21:07:16.144480Z"
+    },
+    "papermill": {
+     "duration": 139.48036,
+     "end_time": "2026-07-16T21:07:16.148852+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:04:56.668492+00:00",
      "status": "completed"
     }
    },
@@ -2262,14 +2786,15 @@
      "text": [
       "\n",
       "InfluxDB:\n",
-      "  Write: 22.738s | Read: 10.160s\n",
-      "  OHLCV aggregation: 183.411s (1,000,000 bars)\n"
+      "  Write (to queryable): 21.880s | Read: 11.388s\n",
+      "  Range query: 2.413s (195,000 rows)\n",
+      "  OHLCV aggregation: 34.692s (2,600 daily bars)\n"
      ]
     }
    ],
    "source": [
     "if HAS_INFLUXDB and benchmark_status[\"InfluxDB\"][\"tested\"]:\n",
-    "    # OHLCV aggregation — bucket to 1-minute bars with the OHLCV-correct\n",
+    "    # OHLCV aggregation — bucket to daily bars with the OHLCV-correct\n",
     "    # reduction per field (first/max/min/last/sum), matching what TimescaleDB,\n",
     "    # QuestDB, and PostgreSQL compute. Single-pass last() across all fields\n",
     "    # would yield semantically wrong open/high/low/volume and would also be\n",
@@ -2279,15 +2804,15 @@
     "      |> range(start: 0)\n",
     "      |> filter(fn: (r) => r._measurement == \"ohlcv\")\n",
     "    open_  = src |> filter(fn: (r) => r._field == \"open\")\n",
-    "                 |> aggregateWindow(every: 1m, fn: first, createEmpty: false)\n",
+    "                 |> aggregateWindow(every: 1d, fn: first, createEmpty: false)\n",
     "    high_  = src |> filter(fn: (r) => r._field == \"high\")\n",
-    "                 |> aggregateWindow(every: 1m, fn: max,   createEmpty: false)\n",
+    "                 |> aggregateWindow(every: 1d, fn: max,   createEmpty: false)\n",
     "    low_   = src |> filter(fn: (r) => r._field == \"low\")\n",
-    "                 |> aggregateWindow(every: 1m, fn: min,   createEmpty: false)\n",
+    "                 |> aggregateWindow(every: 1d, fn: min,   createEmpty: false)\n",
     "    close_ = src |> filter(fn: (r) => r._field == \"close\")\n",
-    "                 |> aggregateWindow(every: 1m, fn: last,  createEmpty: false)\n",
+    "                 |> aggregateWindow(every: 1d, fn: last,  createEmpty: false)\n",
     "    vol_   = src |> filter(fn: (r) => r._field == \"volume\")\n",
-    "                 |> aggregateWindow(every: 1m, fn: sum,   createEmpty: false)\n",
+    "                 |> aggregateWindow(every: 1d, fn: sum,   createEmpty: false)\n",
     "    union(tables: [open_, high_, low_, close_, vol_])\n",
     "      |> pivot(rowKey:[\"_time\",\"symbol\"], columnKey:[\"_field\"], valueColumn:\"_value\")\n",
     "    \"\"\"\n",
@@ -2296,11 +2821,16 @@
     "        tables = influx_query_api.query(agg_flux, org=influx_org)\n",
     "        return [r.values for table in tables for r in table.records]\n",
     "\n",
-    "    influx_agg_time, influx_agg_result = time_operation(influxdb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    influx_agg_time, influx_agg_result = time_read(influxdb_ohlcv, n_runs=min(3, TIMING_RUNS))\n",
+    "    validate_result(influx_agg_result, agg_expected_rows, \"InfluxDB aggregation\")\n",
+    "    results.append(\n",
+    "        BenchmarkResult(\"InfluxDB\", \"aggregation\", influx_agg_time, 0, len(influx_agg_result))\n",
+    "    )\n",
     "\n",
     "    print(\"\\nInfluxDB:\")\n",
-    "    print(f\"  Write: {influx_write_time:.3f}s | Read: {influx_read_time:.3f}s\")\n",
-    "    print(f\"  OHLCV aggregation: {influx_agg_time:.3f}s ({len(influx_agg_result):,} bars)\")\n",
+    "    print(f\"  Write (to queryable): {influx_write_time:.3f}s | Read: {influx_read_time:.3f}s\")\n",
+    "    print(f\"  Range query: {influx_range_time:.3f}s ({len(influx_range_result):,} rows)\")\n",
+    "    print(f\"  OHLCV aggregation: {influx_agg_time:.3f}s ({len(influx_agg_result):,} daily bars)\")\n",
     "\n",
     "    influx_client.close()\n",
     "else:\n",
@@ -2312,10 +2842,10 @@
    "id": "dae43b86",
    "metadata": {
     "papermill": {
-     "duration": 0.003475,
-     "end_time": "2026-07-11T19:12:11.992589+00:00",
+     "duration": 0.004003,
+     "end_time": "2026-07-16T21:07:16.156992+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:11.989114+00:00",
+     "start_time": "2026-07-16T21:07:16.152989+00:00",
      "status": "completed"
     }
    },
@@ -2336,24 +2866,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 42,
    "id": "21c8e7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.000102Z",
-     "iopub.status.busy": "2026-07-11T19:12:11.999976Z",
-     "iopub.status.idle": "2026-07-11T19:12:12.003383Z",
-     "shell.execute_reply": "2026-07-11T19:12:12.003084Z"
+     "iopub.execute_input": "2026-07-16T21:07:16.165825Z",
+     "iopub.status.busy": "2026-07-16T21:07:16.165702Z",
+     "iopub.status.idle": "2026-07-16T21:07:17.879743Z",
+     "shell.execute_reply": "2026-07-16T21:07:17.879157Z"
     },
     "papermill": {
-     "duration": 0.007795,
-     "end_time": "2026-07-11T19:12:12.003773+00:00",
+     "duration": 1.719321,
+     "end_time": "2026-07-16T21:07:17.880303+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:11.995978+00:00",
+     "start_time": "2026-07-16T21:07:16.160982+00:00",
      "status": "completed"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "======================================================================\n",
+      "KDB+/PYKX BENCHMARK (IPC mode)\n",
+      "======================================================================\n",
+      "Starting q server on port 5099...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to q 5.0 (2025-11-17)\n"
+     ]
+    }
+   ],
    "source": [
     "if HAS_PYKX:\n",
     "    print(\"\\n\" + \"=\" * 70)\n",
@@ -2386,13 +2935,32 @@
     "\n",
     "        # Convert data to kdb+ format via IPC\n",
     "        kdb_ohlcv = kx.toq(ohlcv_pandas)\n",
+    "        q[\"ohlcv\"] = kdb_ohlcv\n",
     "\n",
-    "        # Write (serialization)\n",
+    "        # Write — persist a splayed table to disk.\n",
+    "        #\n",
+    "        # This used to time `-8!` (in-memory IPC serialization) and call it a\n",
+    "        # write, while every other engine on the same chart wrote to disk or to a\n",
+    "        # server. That is not the same operation, and it is why kdb+ looked\n",
+    "        # ~40x faster than anything else: it was not doing the work. `set` on a\n",
+    "        # splayed table is the comparable operation — it is what a kdb+ shop\n",
+    "        # actually does to persist a table, and it ends with the data on disk.\n",
+    "        KDB_DIR = BENCHMARK_DIR / f\"kdb_{ACTIVE_SCALE.lower()}\"\n",
+    "        if KDB_DIR.exists():\n",
+    "            shutil.rmtree(KDB_DIR)\n",
+    "        KDB_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "        # PyKX converts a Python str to a q SYMBOL, so the file handles are built\n",
+    "        # here as explicit `:path symbols rather than joined inside q.\n",
+    "        KDB_DB_HANDLE = kx.SymbolAtom(f\":{KDB_DIR}\")\n",
+    "        KDB_TBL_HANDLE = kx.SymbolAtom(f\":{KDB_DIR}/ohlcv/\")\n",
+    "\n",
     "        def write_pykx():\n",
-    "            return q(\"-8!\", kdb_ohlcv)\n",
+    "            # `.Q.en` enumerates the symbol column against the sym file, which a\n",
+    "            # splayed table requires; the whole persist is inside the timed region.\n",
+    "            return q(\"{[dir;tbl] tbl set .Q.en[dir; ohlcv]}\", KDB_DB_HANDLE, KDB_TBL_HANDLE)\n",
     "\n",
-    "        pykx_write_time, serialized = time_operation(write_pykx, warmup=False)\n",
-    "        pykx_size = len(bytes(serialized))\n",
+    "        pykx_write_time, _ = time_write(write_pykx)\n",
+    "        pykx_size = sum(f.stat().st_size for f in KDB_DIR.rglob(\"*\") if f.is_file())\n",
     "        results.append(\n",
     "            BenchmarkResult(\"kdb+/PyKX\", \"write\", pykx_write_time, pykx_size, total_rows)\n",
     "        )\n",
@@ -2404,20 +2972,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 43,
    "id": "23e88657",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.011193Z",
-     "iopub.status.busy": "2026-07-11T19:12:12.011093Z",
-     "iopub.status.idle": "2026-07-11T19:12:12.013294Z",
-     "shell.execute_reply": "2026-07-11T19:12:12.012869Z"
+     "iopub.execute_input": "2026-07-16T21:07:17.889618Z",
+     "iopub.status.busy": "2026-07-16T21:07:17.889487Z",
+     "iopub.status.idle": "2026-07-16T21:07:19.287729Z",
+     "shell.execute_reply": "2026-07-16T21:07:19.287118Z"
     },
     "papermill": {
-     "duration": 0.006428,
-     "end_time": "2026-07-11T19:12:12.013647+00:00",
+     "duration": 1.403349,
+     "end_time": "2026-07-16T21:07:19.288153+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:12.007219+00:00",
+     "start_time": "2026-07-16T21:07:17.884804+00:00",
      "status": "completed"
     }
    },
@@ -2425,12 +2993,29 @@
    "source": [
     "if HAS_PYKX and benchmark_status[\"kdb+/PyKX\"][\"tested\"]:\n",
     "    try:\n",
-    "        # Read (deserialization)\n",
+    "        # Read — load the splayed table back off disk and force materialization,\n",
+    "        # matching the other engines' full scan rather than deserializing a blob\n",
+    "        # that never left memory.\n",
     "        def read_pykx():\n",
-    "            return q(\"-9!\", serialized)\n",
+    "            return q(\"{select from get x}\", KDB_TBL_HANDLE)\n",
     "\n",
-    "        pykx_read_time, _ = time_operation(read_pykx)\n",
+    "        pykx_read_time, pykx_read_result = time_read(read_pykx)\n",
+    "        validate_result(pykx_read_result.pd(), total_rows, \"kdb+ read\")\n",
     "        results.append(BenchmarkResult(\"kdb+/PyKX\", \"read\", pykx_read_time, pykx_size, total_rows))\n",
+    "\n",
+    "        # Range query\n",
+    "        def pykx_range_query():\n",
+    "            return q(\n",
+    "                \"{[s;e] select from ohlcv where timestamp >= s, timestamp < e}\",\n",
+    "                kx.TimestampAtom(range_start),\n",
+    "                kx.TimestampAtom(range_end),\n",
+    "            )\n",
+    "\n",
+    "        pykx_range_time, pykx_range_result = time_read(pykx_range_query)\n",
+    "        validate_result(pykx_range_result.pd(), range_expected_rows, \"kdb+ range query\")\n",
+    "        results.append(\n",
+    "            BenchmarkResult(\"kdb+/PyKX\", \"range_query\", pykx_range_time, 0, len(pykx_range_result))\n",
+    "        )\n",
     "\n",
     "    except Exception as e:\n",
     "        print(f\"\\n⊘ kdb+/PyKX read failed: {e}\")\n",
@@ -2439,20 +3024,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 44,
    "id": "04709feb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.020959Z",
-     "iopub.status.busy": "2026-07-11T19:12:12.020871Z",
-     "iopub.status.idle": "2026-07-11T19:12:12.024320Z",
-     "shell.execute_reply": "2026-07-11T19:12:12.023999Z"
+     "iopub.execute_input": "2026-07-16T21:07:19.297530Z",
+     "iopub.status.busy": "2026-07-16T21:07:19.297408Z",
+     "iopub.status.idle": "2026-07-16T21:07:22.083126Z",
+     "shell.execute_reply": "2026-07-16T21:07:22.082611Z"
     },
     "papermill": {
-     "duration": 0.007541,
-     "end_time": "2026-07-11T19:12:12.024586+00:00",
+     "duration": 2.790961,
+     "end_time": "2026-07-16T21:07:22.083554+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:12.017045+00:00",
+     "start_time": "2026-07-16T21:07:19.292593+00:00",
      "status": "completed"
     }
    },
@@ -2462,7 +3047,12 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "⊘ kdb+/PyKX benchmark skipped\n"
+      "kdb+/PyKX: 68.0 MB\n",
+      "  Write (splayed to disk): 0.027s | Read: 0.062s\n",
+      "  Range query: 0.018s (195,000 rows)\n",
+      "  ASOF Join (aj): 0.168s (500,000 rows)\n",
+      "  OHLCV aggregation: 0.063s (2,600 daily bars)\n",
+      "q server stopped\n"
      ]
     }
    ],
@@ -2478,25 +3068,31 @@
     "        def pykx_asof_join():\n",
     "            return q(\"aj[`symbol`timestamp; trades; quotes]\")\n",
     "\n",
-    "        pykx_asof_time, pykx_asof_result = time_operation(pykx_asof_join)\n",
+    "        pykx_asof_time, pykx_asof_result = time_read(pykx_asof_join)\n",
+    "        validate_result(pykx_asof_result.pd(), N_TICKS_TRADES, \"kdb+ ASOF join\")\n",
     "        results.append(\n",
     "            BenchmarkResult(\"kdb+/PyKX\", \"asof_join\", pykx_asof_time, 0, len(pykx_asof_result))\n",
     "        )\n",
     "\n",
-    "        # Aggregation\n",
+    "        # Aggregation — daily buckets, matching every other engine\n",
     "        def pykx_ohlcv():\n",
     "            return q(\n",
     "                \"{select o:first open, h:max high, l:min low, c:last close, v:sum volume \"\n",
-    "                \"by symbol, bar:`minute$timestamp from x}\",\n",
+    "                \"by symbol, bar:`date$timestamp from x}\",\n",
     "                kdb_ohlcv,\n",
     "            )\n",
     "\n",
-    "        pykx_agg_time, pykx_agg_result = time_operation(pykx_ohlcv)\n",
+    "        pykx_agg_time, pykx_agg_result = time_read(pykx_ohlcv)\n",
+    "        validate_result(pykx_agg_result.pd(), agg_expected_rows, \"kdb+ aggregation\")\n",
+    "        results.append(\n",
+    "            BenchmarkResult(\"kdb+/PyKX\", \"aggregation\", pykx_agg_time, 0, len(pykx_agg_result))\n",
+    "        )\n",
     "\n",
     "        print(f\"\\nkdb+/PyKX: {pykx_size / 1e6:.1f} MB\")\n",
-    "        print(f\"  Write: {pykx_write_time:.3f}s | Read: {pykx_read_time:.3f}s\")\n",
-    "        print(f\"  ASOF Join (aj): {pykx_asof_time:.3f}s ({len(pykx_asof_result)} rows)\")\n",
-    "        print(f\"  OHLCV aggregation: {pykx_agg_time:.3f}s ({len(pykx_agg_result.pd())} bars)\")\n",
+    "        print(f\"  Write (splayed to disk): {pykx_write_time:.3f}s | Read: {pykx_read_time:.3f}s\")\n",
+    "        print(f\"  Range query: {pykx_range_time:.3f}s ({len(pykx_range_result):,} rows)\")\n",
+    "        print(f\"  ASOF Join (aj): {pykx_asof_time:.3f}s ({len(pykx_asof_result):,} rows)\")\n",
+    "        print(f\"  OHLCV aggregation: {pykx_agg_time:.3f}s ({len(pykx_agg_result):,} daily bars)\")\n",
     "\n",
     "        q.close()\n",
     "\n",
@@ -2519,10 +3115,10 @@
    "id": "93f7cdc4",
    "metadata": {
     "papermill": {
-     "duration": 0.003402,
-     "end_time": "2026-07-11T19:12:12.031430+00:00",
+     "duration": 0.004226,
+     "end_time": "2026-07-16T21:07:22.092270+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:12.028028+00:00",
+     "start_time": "2026-07-16T21:07:22.088044+00:00",
      "status": "completed"
     }
    },
@@ -2534,20 +3130,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 45,
    "id": "c5ce3230",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.038863Z",
-     "iopub.status.busy": "2026-07-11T19:12:12.038751Z",
-     "iopub.status.idle": "2026-07-11T19:12:12.049140Z",
-     "shell.execute_reply": "2026-07-11T19:12:12.048764Z"
+     "iopub.execute_input": "2026-07-16T21:07:22.101979Z",
+     "iopub.status.busy": "2026-07-16T21:07:22.101837Z",
+     "iopub.status.idle": "2026-07-16T21:07:22.107763Z",
+     "shell.execute_reply": "2026-07-16T21:07:22.107341Z"
     },
     "papermill": {
-     "duration": 0.014599,
-     "end_time": "2026-07-11T19:12:12.049422+00:00",
+     "duration": 0.011515,
+     "end_time": "2026-07-16T21:07:22.108067+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:12.034823+00:00",
+     "start_time": "2026-07-16T21:07:22.096552+00:00",
      "status": "completed"
     }
    },
@@ -2562,57 +3158,83 @@
       "======================================================================\n",
       "\n",
       "WRITE:\n",
-      "shape: (7, 2)\n",
+      "shape: (8, 2)\n",
       "┌─────────────┬───────────┐\n",
       "│ database    ┆ time_s    │\n",
       "│ ---         ┆ ---       │\n",
       "│ str         ┆ f64       │\n",
       "╞═════════════╪═══════════╡\n",
-      "│ DuckDB      ┆ 0.151361  │\n",
-      "│ QuestDB     ┆ 0.777411  │\n",
-      "│ ClickHouse  ┆ 1.107366  │\n",
-      "│ SQLite      ┆ 2.523193  │\n",
-      "│ InfluxDB    ┆ 22.737715 │\n",
-      "│ PostgreSQL  ┆ 64.310803 │\n",
-      "│ TimescaleDB ┆ 71.591424 │\n",
+      "│ kdb+/PyKX   ┆ 0.0271    │\n",
+      "│ DuckDB      ┆ 0.131278  │\n",
+      "│ ClickHouse  ┆ 0.338364  │\n",
+      "│ QuestDB     ┆ 0.820204  │\n",
+      "│ SQLite      ┆ 2.480352  │\n",
+      "│ InfluxDB    ┆ 21.87997  │\n",
+      "│ TimescaleDB ┆ 67.085046 │\n",
+      "│ PostgreSQL  ┆ 70.010506 │\n",
       "└─────────────┴───────────┘\n",
       "\n",
       "READ:\n",
-      "shape: (7, 2)\n",
+      "shape: (8, 2)\n",
       "┌─────────────┬───────────┐\n",
       "│ database    ┆ time_s    │\n",
       "│ ---         ┆ ---       │\n",
       "│ str         ┆ f64       │\n",
       "╞═════════════╪═══════════╡\n",
-      "│ DuckDB      ┆ 0.063159  │\n",
-      "│ ClickHouse  ┆ 0.372765  │\n",
-      "│ SQLite      ┆ 1.820103  │\n",
-      "│ PostgreSQL  ┆ 1.95951   │\n",
-      "│ TimescaleDB ┆ 2.6025    │\n",
-      "│ QuestDB     ┆ 2.618178  │\n",
-      "│ InfluxDB    ┆ 10.159805 │\n",
+      "│ kdb+/PyKX   ┆ 0.061621  │\n",
+      "│ DuckDB      ┆ 0.072597  │\n",
+      "│ ClickHouse  ┆ 0.303032  │\n",
+      "│ SQLite      ┆ 2.006012  │\n",
+      "│ PostgreSQL  ┆ 2.056755  │\n",
+      "│ TimescaleDB ┆ 2.574295  │\n",
+      "│ QuestDB     ┆ 2.612862  │\n",
+      "│ InfluxDB    ┆ 11.388151 │\n",
       "└─────────────┴───────────┘\n",
       "\n",
+      "RANGE QUERY:\n",
+      "shape: (8, 2)\n",
+      "┌─────────────┬──────────┐\n",
+      "│ database    ┆ time_s   │\n",
+      "│ ---         ┆ ---      │\n",
+      "│ str         ┆ f64      │\n",
+      "╞═════════════╪══════════╡\n",
+      "│ kdb+/PyKX   ┆ 0.017786 │\n",
+      "│ DuckDB      ┆ 0.03848  │\n",
+      "│ ClickHouse  ┆ 0.097757 │\n",
+      "│ PostgreSQL  ┆ 0.450775 │\n",
+      "│ SQLite      ┆ 0.493824 │\n",
+      "│ QuestDB     ┆ 0.500823 │\n",
+      "│ TimescaleDB ┆ 0.506864 │\n",
+      "│ InfluxDB    ┆ 2.413436 │\n",
+      "└─────────────┴──────────┘\n",
+      "\n",
       "AGGREGATION:\n",
-      "shape: (2, 2)\n",
-      "┌──────────┬──────────┐\n",
-      "│ database ┆ time_s   │\n",
-      "│ ---      ┆ ---      │\n",
-      "│ str      ┆ f64      │\n",
-      "╞══════════╪══════════╡\n",
-      "│ DuckDB   ┆ 0.024226 │\n",
-      "│ SQLite   ┆ 0.579919 │\n",
-      "└──────────┴──────────┘\n",
+      "shape: (8, 2)\n",
+      "┌─────────────┬───────────┐\n",
+      "│ database    ┆ time_s    │\n",
+      "│ ---         ┆ ---       │\n",
+      "│ str         ┆ f64       │\n",
+      "╞═════════════╪═══════════╡\n",
+      "│ QuestDB     ┆ 0.013298  │\n",
+      "│ ClickHouse  ┆ 0.021528  │\n",
+      "│ DuckDB      ┆ 0.035739  │\n",
+      "│ kdb+/PyKX   ┆ 0.063335  │\n",
+      "│ TimescaleDB ┆ 0.171883  │\n",
+      "│ PostgreSQL  ┆ 0.468389  │\n",
+      "│ SQLite      ┆ 1.201827  │\n",
+      "│ InfluxDB    ┆ 34.692208 │\n",
+      "└─────────────┴───────────┘\n",
       "\n",
       "ASOF JOIN:\n",
-      "shape: (2, 2)\n",
+      "shape: (3, 2)\n",
       "┌────────────┬──────────┐\n",
       "│ database   ┆ time_s   │\n",
       "│ ---        ┆ ---      │\n",
       "│ str        ┆ f64      │\n",
       "╞════════════╪══════════╡\n",
-      "│ DuckDB     ┆ 0.224874 │\n",
-      "│ ClickHouse ┆ 0.278002 │\n",
+      "│ kdb+/PyKX  ┆ 0.168246 │\n",
+      "│ DuckDB     ┆ 0.20281  │\n",
+      "│ ClickHouse ┆ 0.270113 │\n",
       "└────────────┴──────────┘\n"
      ]
     }
@@ -2637,7 +3259,7 @@
     "    )\n",
     "\n",
     "    # Summary by operation\n",
-    "    for op in [\"write\", \"read\", \"aggregation\", \"asof_join\"]:\n",
+    "    for op in [\"write\", \"read\", \"range_query\", \"aggregation\", \"asof_join\"]:\n",
     "        op_data = results_df.filter(pl.col(\"operation\") == op).sort(\"time_s\")\n",
     "        if len(op_data) > 0:\n",
     "            print(f\"\\n{op.upper().replace('_', ' ')}:\")\n",
@@ -2646,103 +3268,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 46,
    "id": "63a6eb06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.057249Z",
-     "iopub.status.busy": "2026-07-11T19:12:12.057139Z",
-     "iopub.status.idle": "2026-07-11T19:12:12.111177Z",
-     "shell.execute_reply": "2026-07-11T19:12:12.110765Z"
+     "iopub.execute_input": "2026-07-16T21:07:22.117647Z",
+     "iopub.status.busy": "2026-07-16T21:07:22.117522Z",
+     "iopub.status.idle": "2026-07-16T21:07:22.739505Z",
+     "shell.execute_reply": "2026-07-16T21:07:22.738989Z"
     },
     "papermill": {
-     "duration": 0.058557,
-     "end_time": "2026-07-11T19:12:12.111652+00:00",
+     "duration": 0.627207,
+     "end_time": "2026-07-16T21:07:22.739978+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:12.053095+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "if results:\n",
-    "    # Visualization\n",
-    "    fig = make_subplots(\n",
-    "        rows=1, cols=2, subplot_titles=[\"Read Performance\", \"ASOF Join Performance\"]\n",
-    "    )\n",
-    "\n",
-    "    read_data = results_df.filter(pl.col(\"operation\") == \"read\").sort(\"time_s\")\n",
-    "    if len(read_data) > 0:\n",
-    "        fig.add_trace(\n",
-    "            go.Bar(\n",
-    "                y=read_data[\"database\"].to_list(),\n",
-    "                x=read_data[\"time_s\"].to_list(),\n",
-    "                orientation=\"h\",\n",
-    "                marker_color=\"#0a1628\",\n",
-    "                name=\"Read\",\n",
-    "                text=[f\"{t:.3f}s\" for t in read_data[\"time_s\"].to_list()],\n",
-    "                textposition=\"outside\",\n",
-    "            ),\n",
-    "            row=1,\n",
-    "            col=1,\n",
-    "        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "id": "e3d29fd8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:12.119693Z",
-     "iopub.status.busy": "2026-07-11T19:12:12.119580Z",
-     "iopub.status.idle": "2026-07-11T19:12:13.139375Z",
-     "shell.execute_reply": "2026-07-11T19:12:13.139015Z"
-    },
-    "papermill": {
-     "duration": 1.024206,
-     "end_time": "2026-07-11T19:12:13.139673+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:12:12.115467+00:00",
+     "start_time": "2026-07-16T21:07:22.112771+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
+      "application/json": {
        "data": [
         {
          "marker": {
           "color": "#0a1628"
          },
-         "name": "Read",
          "orientation": "h",
          "text": [
-          "0.063s",
-          "0.373s",
-          "1.820s",
-          "1.960s",
-          "2.603s",
-          "2.618s",
-          "10.160s"
+          "0.062s",
+          "0.073s",
+          "0.303s",
+          "2.006s",
+          "2.057s",
+          "2.574s",
+          "2.613s",
+          "11.388s"
          ],
          "textposition": "outside",
          "type": "bar",
          "x": [
-          0.06315887798943247,
-          0.37276500001704943,
-          1.8201026809983887,
-          1.9595104729911934,
-          2.60250027035363,
-          2.618178088334389,
-          10.159805109336352
+          0.06162134600648036,
+          0.07259711433531872,
+          0.3030318653327413,
+          2.0060121643327875,
+          2.0567551873391494,
+          2.574294925002808,
+          2.6128617966605816,
+          11.388150932994904
          ],
          "xaxis": "x",
          "y": [
+          "kdb+/PyKX",
           "DuckDB",
           "ClickHouse",
           "SQLite",
@@ -2755,26 +3332,68 @@
         },
         {
          "marker": {
-          "color": "#D4A84B"
+          "color": "#1a2d4a"
          },
-         "name": "ASOF Join",
          "orientation": "h",
          "text": [
-          "0.225s",
-          "0.278s"
+          "0.018s",
+          "0.038s",
+          "0.098s",
+          "0.451s",
+          "0.494s",
+          "0.501s",
+          "0.507s",
+          "2.413s"
          ],
          "textposition": "outside",
          "type": "bar",
          "x": [
-          0.2248739703403165,
-          0.2780016416606183
+          0.017786318669095635,
+          0.03848034700301165,
+          0.09775662766575503,
+          0.450774805334125,
+          0.49382444033108186,
+          0.5008229903275302,
+          0.5068644943336645,
+          2.4134362653276185
          ],
          "xaxis": "x2",
          "y": [
+          "kdb+/PyKX",
+          "DuckDB",
+          "ClickHouse",
+          "PostgreSQL",
+          "SQLite",
+          "QuestDB",
+          "TimescaleDB",
+          "InfluxDB"
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "#D4A84B"
+         },
+         "orientation": "h",
+         "text": [
+          "0.168s",
+          "0.203s",
+          "0.270s"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          0.168246118662258,
+          0.20280959933491735,
+          0.2701133980056814
+         ],
+         "xaxis": "x3",
+         "y": [
+          "kdb+/PyKX",
           "DuckDB",
           "ClickHouse"
          ],
-         "yaxis": "y2"
+         "yaxis": "y3"
         }
        ],
        "layout": {
@@ -2784,8 +3403,8 @@
            "size": 16
           },
           "showarrow": false,
-          "text": "Read Performance",
-          "x": 0.225,
+          "text": "Full scan",
+          "x": 0.12666666666666668,
           "xanchor": "center",
           "xref": "paper",
           "y": 1.0,
@@ -2797,8 +3416,21 @@
            "size": 16
           },
           "showarrow": false,
-          "text": "ASOF Join Performance",
-          "x": 0.775,
+          "text": "Range query (7-day window)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "ASOF join",
+          "x": 0.8733333333333333,
           "xanchor": "center",
           "xref": "paper",
           "y": 1.0,
@@ -2807,805 +3439,118 @@
          }
         ],
         "height": 500,
+        "margin": {
+         "b": 50,
+         "l": 90,
+         "r": 90,
+         "t": 80
+        },
+        "paper_bgcolor": "#FAFAF9",
+        "plot_bgcolor": "#FAFAF9",
         "showlegend": false,
         "template": {
-         "data": {
-          "bar": [
-           {
-            "error_x": {
-             "color": "#2a3f5f"
-            },
-            "error_y": {
-             "color": "#2a3f5f"
-            },
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "bar"
-           }
-          ],
-          "barpolar": [
-           {
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "barpolar"
-           }
-          ],
-          "carpet": [
-           {
-            "aaxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-           }
-          ],
-          "choropleth": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "choropleth"
-           }
-          ],
-          "contour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "contour"
-           }
-          ],
-          "contourcarpet": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "contourcarpet"
-           }
-          ],
-          "heatmap": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmap"
-           }
-          ],
-          "histogram": [
-           {
-            "marker": {
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "histogram"
-           }
-          ],
-          "histogram2d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2d"
-           }
-          ],
-          "histogram2dcontour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2dcontour"
-           }
-          ],
-          "mesh3d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "mesh3d"
-           }
-          ],
-          "parcoords": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "parcoords"
-           }
-          ],
-          "pie": [
-           {
-            "automargin": true,
-            "type": "pie"
-           }
-          ],
-          "scatter": [
-           {
-            "fillpattern": {
-             "fillmode": "overlay",
-             "size": 10,
-             "solidity": 0.2
-            },
-            "type": "scatter"
-           }
-          ],
-          "scatter3d": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatter3d"
-           }
-          ],
-          "scattercarpet": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattercarpet"
-           }
-          ],
-          "scattergeo": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergeo"
-           }
-          ],
-          "scattergl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergl"
-           }
-          ],
-          "scattermap": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermap"
-           }
-          ],
-          "scattermapbox": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermapbox"
-           }
-          ],
-          "scatterpolar": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolar"
-           }
-          ],
-          "scatterpolargl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolargl"
-           }
-          ],
-          "scatterternary": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterternary"
-           }
-          ],
-          "surface": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "surface"
-           }
-          ],
-          "table": [
-           {
-            "cells": {
-             "fill": {
-              "color": "#EBF0F8"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "header": {
-             "fill": {
-              "color": "#C8D4E3"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "type": "table"
-           }
-          ]
-         },
          "layout": {
-          "annotationdefaults": {
-           "arrowcolor": "#2a3f5f",
-           "arrowhead": 0,
-           "arrowwidth": 1
-          },
-          "autotypenumbers": "strict",
-          "coloraxis": {
-           "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-           }
-          },
-          "colorscale": {
-           "diverging": [
-            [
-             0,
-             "#8e0152"
-            ],
-            [
-             0.1,
-             "#c51b7d"
-            ],
-            [
-             0.2,
-             "#de77ae"
-            ],
-            [
-             0.3,
-             "#f1b6da"
-            ],
-            [
-             0.4,
-             "#fde0ef"
-            ],
-            [
-             0.5,
-             "#f7f7f7"
-            ],
-            [
-             0.6,
-             "#e6f5d0"
-            ],
-            [
-             0.7,
-             "#b8e186"
-            ],
-            [
-             0.8,
-             "#7fbc41"
-            ],
-            [
-             0.9,
-             "#4d9221"
-            ],
-            [
-             1,
-             "#276419"
-            ]
-           ],
-           "sequential": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ],
-           "sequentialminus": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ]
-          },
           "colorway": [
-           "#636efa",
-           "#EF553B",
-           "#00cc96",
-           "#ab63fa",
-           "#FFA15A",
-           "#19d3f3",
-           "#FF6692",
-           "#B6E880",
-           "#FF97FF",
-           "#FECB52"
+           "#0a1628",
+           "#D4A84B",
+           "#1a2d4a",
+           "#C87533",
+           "#10b981",
+           "#ef4444"
           ],
           "font": {
-           "color": "#2a3f5f"
-          },
-          "geo": {
-           "bgcolor": "white",
-           "lakecolor": "white",
-           "landcolor": "#E5ECF6",
-           "showlakes": true,
-           "showland": true,
-           "subunitcolor": "white"
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
           },
           "hoverlabel": {
-           "align": "left"
-          },
-          "hovermode": "closest",
-          "mapbox": {
-           "style": "light"
-          },
-          "paper_bgcolor": "white",
-          "plot_bgcolor": "#E5ECF6",
-          "polar": {
-           "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
            }
           },
-          "scene": {
-           "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
            }
           },
-          "shapedefaults": {
-           "line": {
-            "color": "#2a3f5f"
-           }
-          },
-          "ternary": {
-           "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
           "title": {
-           "x": 0.05
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
           },
           "xaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           },
           "yaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           }
          }
         },
         "title": {
-         "text": "Database Comparison (Scale: L)"
+         "text": "Database Comparison (L scale, 1,000,000 rows, warm reads)"
         },
         "xaxis": {
          "anchor": "y",
          "domain": [
           0.0,
-          0.45
+          0.25333333333333335
          ],
          "title": {
-          "text": "Seconds (log scale, lower is better)"
+          "text": "Seconds (log, lower is better)"
          },
          "type": "log"
         },
         "xaxis2": {
          "anchor": "y2",
          "domain": [
-          0.55,
+          0.37333333333333335,
+          0.6266666666666667
+         ],
+         "title": {
+          "text": "Seconds (log, lower is better)"
+         },
+         "type": "log"
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.7466666666666667,
           1.0
          ],
          "title": {
-          "text": "Seconds (log scale, lower is better)"
+          "text": "Seconds (log, lower is better)"
          },
          "type": "log"
         },
@@ -3622,10 +3567,16 @@
           0.0,
           1.0
          ]
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "domain": [
+          0.0,
+          1.0
+         ]
         }
        }
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAgAElEQVR4XuydBZQUR9eG33VYFveQECC4BtegCe7u7u7u7u4uwV2CO8ElBIdgIbjLwsIuy/7n1v4z38xqz+xMr719vnO+MFtd1f1UTc/Tt29VO/j5+fmBGwmQAAmQAAmQAAmQAAlEUQIOFN4o2rM8LRIgARIgARIgARIgAUWAwsuBQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8HAMkQAIkQAIkQAIkQAJRmgCFN0p3L0+OBEiABEiABEiABEiAwssxQAIkQAIkQAIkQAIkEKUJUHijdPfy5EiABEiABEiABEiABCi8VoyBPGVbo2rZXzCwayMr9uYuEYFAiZpdUTB3Fozu1yoiHE6wxzBy6gpcu3Ufq2YPCvfj3LDjCIZMXIK9ayYiRbJE4X48PYfPwSevz5g9plu4HwsPgARIgARIIGITiHDCu+fwWXQfOstIzcXZCbE93JE6ZXIUzJMFtSoWR6IEca2mumj1TlVXycI5ra4jsgvvweN/Yf32w7h8/S4+eH5CnNjuyJE5LWpVKo5iBXNYzSUy7RgZhPfhkxeo0LAvZozqjKIF/tcv795/xIJVO3DkxEU8evoSMWK4InmShMiXMxMa1vjNbjKql/C+efcBRap0Qu1KxTGkR9Ngh9Wtuw9RrflArJgxALmypYtMw4/HSgIkQAIkoDOBCCu8FX8tiIxpU8L32ze8fe+JS9fu4PylW/CIFRNjB7RGiULWCWuhyh1QqkhujOjd3GrUkVV4v33zw8BxC7F1z3EkS5wAJQrnRNLE8fH2nSdOnLsCEQgRDBGNqL55e/vAwdERckMVUbfR03/HoRMXsXf1BDg4OKjDfO/5CTVaDsbT56/UOM6U7kd4ff6CO/cf4c+zVzCqT0uUL5XfLqcU0YRXTrJRp1GIEzsWZo3uapdzZqUkQAIkQAJRg0CEFd4Jg9oF+uH++9oddOw/FR8/fcbGhcNVpNbSLToL77wV2zF90UZULl0Yw3o2haurixm+A8cu4L3nR1Qr94ulWCNNea/P3ogZwzXCH68IefEaXVGzYjF0b1PbeLyL1+zEpLnrMKxnM/U3001kWPYLyxOQkMBEROFduWk/xs1ahYPrp9jtvCP8YOEBkgAJkAAJhEogUgmvnM2+o+fQdfBM1KhQFMN7+Udpn754jcWrd+Lkuat4/OwVHB0dkT1TGnRsXg05s/o/6pRcv7zl2gYCIn//feYAfPX1xfzfd+DoyYv49+EzfPb2QeofkqFRzdKBBNAQ4c2TIwNmL9uKB4+e4fvkidG2UWVU/K2gWRs79p1UEdVbd//Du/eeSJwoPsqXzI8OTauaCae0OW3hBhXFlnJx43gga8bU6NOhHlKmSGqsUyJ5MxZvxpm/ruPT5y/qGFvUqxCo3YAn6vnRCyVqdlNSsG3pKLi4OIc6OKSACMXarQfVOXrEckfRAtnRrXUtJE4Yz7h/u75T1KP1KcM6YNTUFZAbk3hxPNCqYUXUrVIS9x48wZgZK/HXlX8QM4YbmtUph2Z1yxn3v3LzHuq0GYYx/Vvh+j8PsPPAKRXJzJohFfp2bIAsGVIZy1rTT/KkYPn6Papf2zWpgraNKyOolAY513XbD+Hh4xdwcnJE8qQJUbVMEbNjlZutmUs2Y8/hM3j95j2SJk6ASr8VQptGlcyYGsZI9sxpsHDlH4qf9H2bhpUCiWpQHXH87BW07jURi6f0Qf6cmYxFhk1ainXbDyvBk+h8aJtE9X/fuBebdx3D/YfPlOxn+OkHtGlYGQVyZ1a7ax2jwQnv4RMXsWj1H7j+z7+qvhxZ0qJrq1rIljG12eHJuPBwj4GfUqUI8bC1pjRIJff/e4oKjfpGmycTofU3/04CJEACJBA0gUgnvPIDXqRKRyVOB9ZPVmclP7gT5qzBb0Xz4LtkifDm7Qes334IL9+8x/r5Q5Eu9ffw9f2mZLLjgKnIlS09mtctr/aN7RFTPRYWIf61Tg9UKFUAqVN+h69fv0LyiS9evY2hPZuq3GHDJjKTInliPHvxBo1q/IZ4cT2U1F69eR8TB7dDuZL/e6TcoMNIfJcsITKnSwX3mG44d+kmdh44rdoZP8hfwCUqV6FxP3zz/Ya6VUsqmXz5+h1Onr+KFvXKo1CerKqcCEXjzmOQKEEcJeHyKPfoqb9x5OTfGNytMepUKRnsOJfobedB09GlZQ20blhJ0/dh8rx1kJznArkyo2SRnHj05CVWbd6vJG/DgmEqt1o2Ed4bt/9Vj92L5s+BVCmTYfehMypHeFTflpgyfz2KF/oZaX78DvuOnFPiu2hSb6NwGYRXZFwkrGX9Cvj8xQdT5q2D/G39/GH48Xt/6be0n4SRm6srOjWvjuRJEyCGm6vq74DCu27bIQybvEz1S/5cmVX/3/n3CZ6+eIXpIzqrtmUMNekyRh1/9fJFkTn9jzh78aaSXxl7U4d3NBsj8eLGRhwPd3RsXh2J4sfBys37lVzKBLQcmX8KsQ9mLt6MOcu34tSO2UbOssPCVX8onv07N0CD6r+F2o8ysWvXwdP4JX82FM6bDd/8/PD31TtImSIJuraqqfbXMkalXFDCu37HYQyduBT5cmZUaUZ+ADbvPIZ/Hz3DqlkDFWvDlqV4U8hN4rJp/UI8bkuE18/PDwUrdVC55+MGtAmVBwuQAAmQAAlETwKRTnilmxp3Hq3k9eK+hSqqJo+pY7i5GPMcpYwIY8XG/VC6WB5jJFg+Dy6lQUTa28dHCZFhk88kR/D12/fYtXK8mcxImytnDcTPWdKqzz9/8UbNVkOUkO1bM0lFCP0F7YsSXdNNhEXERYRdcmlFlGu3GaryEEUMg9vqthuuJpmJAJrW2WvEHBw/cwVHNk0LNnI7//ftmLZwI+aO645f8mcPdbQ/fvoSpev1QpF82dQseEdH/xzSvUfOoduQmSpKKhIpmwiviLfpjYFEQkUq5f9N84KFU4kaXVE4XzZ1cyCbQXhT/ZAM25eNMbYl51qyVnclM4aylvbT16++2L16guJsugUU3vb9puDFq3fqBim4bfveE+g7er6KcIuUG7ZR01Zg1eYDWDS5t7o5kE1uihwcHLF3zQTEjxtbfabSFGp2RcnCuTCyT4sQ+0Ambp66cA0ntv1vAqfsIPnWVZoNUOM7beoUyJ8zsxqDhfNlRdzYsczqlMmJnQZMQ9PaZdGrfV2zv4koGvKCtYxR2Tmg8MqxlKrdHb8WzW0mm9LHVZoOwE+pvjNbQcEewivHJTnNci5yE8aNBEiABEiABIIiECmF1yBYx7fOVNHVgJuIhUSa5Mf+1Zv3Kt/XsGnN4fXx+aqiYcvW7VaiaBppE5lJmyoF1swdYtb07xv3qUf36+YNNXsMbygkj+MlSnj15j006jQaM0Z1UatFyOPucg36qChy7w71Agmy7C8pA6Xr9lRRuca1ypi1KxFekdC184Ygawbzx8iGgoZordYZ7ZLGMHzKcjOJM9RVtn5vxHKPYeQq/SEpFmd3zTPKqpSVG5PLN+7h3K55xhsA+bxF9/H4+MnLyM8gvB2aVUP7JlXMzq3PyHk4dOIvnP5jjtkNjaFQaP2UM2t6LJjYM9AYCSi80o5I+7zxPZA9mOhrj2GzceDPCzi5fbZZHvCT56/xa+3uql8kBUU2GSOy7Jn0sekmTGRbPr1/iFekZt3G4unz12Y3WoYdXrx6iyVrdqljkZUcZJMbLBk/PdvVNR5bn1HzsPvgGRzfNlNN9tSyBTdGZd+AwitpEgPHLVIpQZnT/y/tRMpKnvGmnUdwbvd8Lc2albEkwmsYT/8+fIr96/yf+HAjARIgARIggYAEIqXwGiO8+xepWfbyIy15kjv2n4T88EkU0LDJeqGybqhhC0l45TH8svV7cOP2AxWNM932r52kcjplE5n5tWgejO3f2qzMn2cuo03vSZgyrKOKLMsma6hKzueFy/+o6KzpJmvAVilTWH0koizCLBHr3NnS45cC2SErVRgmIBlyOkMawiFFby2N8BoE+dCGqUiS6H/5utK+REPlfOQmQDYR3v8eP8eO5WPMDk9uOG7ffxRI2iQH++adB8bPDcJrysNQkUyyk8l2pjc3lvRT+VIFzCL8hnoDCu/te4/QqtcEPH/5Vi3rJWkkErmUCLdhkwi7LAm2a+W4QN2Qt1wbFBDBHemf/iBjpEqZIhjUrbFZWWH1+NlLbF0yKsSrkQjvk2evsXvV/54sBLXD67cfcPrCNazYsFflTkvOtKHNeu1HqPSe0OrQOkYDCu/UBRuwYOWOEM/j/J75Zk9NQiz8/3+0VHibdxunbhopvFrosgwJkAAJRE8CkU54DTm88kjf8AM3evpKrNy0D01qlVFrkcaNE0tNXJPUAYmAiawatuCEd/+x8+gyaIbKQ5SJZ5JH6+zshD3/L8Gmi+2LzPxWNK+aZGW6BRReifxVbtIPKZIlRuNapfF98iRwc3PBf4+eQ6Jv8ljbdEUEka6Dxy/g9IXrOPf3TbW+6oIJPVXE8djpy2jbZ5Ka7CbpAEFtsmqF5IwGtRnOTyLErRpUDHW0hyS8Im0Xr/yDkybCKxFomQxnuonw3n3wBH+sGGv2uQiv3FQYRMwgvAFzpWWniXPXqmimQXgt7afgXhAS1KQ1ebR/7PTfkJuLE2evQPpP8rEN6RShCa+sE23I9w1u6TrDBL+ArAJ2iEppOH8NJ7abpzQE13ES6ZYUnldv3qlIuzzil+OVtIOQhNeSMRpQeA1jZOboLkgQL06Qh5YtYxqzqH+oAw+ApcLLlAYtVFmGBEiABKI3gUgnvIZVGuTxrQiSbIWrdFS5k5OGtDfrTfkhfPfho5nwSlnJoQy4Dq+kBEjUUiKahnxVqWzcrNVqhn9A4U2b+nusmTPYrL2AKQ2S1yn5nduXj0EakyXUDLmVAYXXtLIHj56jRstBaqKRTIYypD00rVMWvdqZ52NqGcL++bDdkCRRfGxdOgrOTiGvPxtSSkO5Br3hHtM8pcEWwis3LJLSYbpJNFnk35DSYGk/WSK8pu1Kjuuoab9j9ZYD2LJkpJr4GFxKg6wSUqpW4JSGoNrWKryGSWsivAFzc4Pr77Z9JuPY6UvqRkRufLSkNFgyRgMKr+HfkuNtyxeWWCK8nLSm5dvPMiRAAiRAApFKeOXlEx36T1UTwTYtGmGcuf9L1U7InT2D2Sx5mfAjuaKShmAa4f2tbk9kSpfSGIkzDIHuQ2fj/KWbKmpseBmBPC6u2LiveowdUHhl0trq2YOM+Z5fvH1Qs+VgeH7ywv61k1VO5ZqtBzFiynKjMElbksPbsud4nPnrhjHCKxO7ZLKcYaKblJMfcjlWWZ1AVjSQrVbroWoZps2LR6hl0Ew3mcQU2vqrsoTarCWb1ZJug7o1CfTSBVntQl7yUbVsERgmrckyZDKZzjDByRBhbde4ilr2TbbgJM7SCK9M7pJosEToZZPocJWm/VG6WF7jzYyl/aRVeOXGKKBYbtp5FIPGLza+yUtWWBCJ7NG2tnGVDzlOwxMG0yXEwhrhNaSwSP6xYZUOaevsxRtqWa8E8fwnwhk2WTGkarMBKiVGJi9KfxlurIK6kTBMWtM6RqWdgMIr+fG/1emhJs9JbrhbgHWdA45Juy5L1r0JalcuwSs6CZAACZAACQRJIMIKr+FNazJxTB7LXrp+R0X6ZPLN+IFtzSJKIiUiJ/KDJ+vvSt6o/DgnSRgPXl+8zYRXIoQSBevYrLqKdoo4yFJYhhn48li6XIn8amUGie6JhMnj94DCK8uSPZdlyWqVUaK0bc9xtdrAuIFtVO6tbBKVrdJsIJInSYAG1X9Vn/2x/xREjqVOQ4RXlj8bP2s1yhTPC1mpwMHRAbKMmBynRKJlCSzZZB9ZFktkpWaFYkiVMjnevvugJoaJCBlyaoMb6yLb/ccuUEtjyfJtpYrkUvm5wvfk+Wsq39h0RQXDI2thIqkeIsGytFbSRPEDLUtmiwivrA/r7fNVveJYcqglL1XeIiarUggX2SztJ63CW73FIHVzJCseyLiQ85H1a1XfLh2tRNJ0WTK5aZCJWjImZdmvoJYlC0uEV86/WPUuqF6hqFlEf+TUFdjwxxEUzpsVWTKkVhMcpV/+OHBK9aOsTS3HZtgkNULGl2FZMvlcvkuSZiPpLVrHaFDCK58ZbgpkmbNKpQsjccK4ePLslUrHkAmlEv01bJau0iATMOVtgAG3DGl/ML5pUdZOHjtzpVqX2HRtaF7vSYAESIAESMCUQIQVXsNByqN3We81zY/JIeIlqQwBI5kSIZVcz4N/XlATw9L/9AO6tqwJWSNUokqmEV7J6R0ycQn+vnpbLWdmePGEtCcT1lZvPqBeZPFd0oRqnVNnJ0e1WkFA4RWZUS+eWLpFSYMIpCzVJW8xM90kr1cm99z997E6D5FaiaBKtNYgvLK/TMy6cPmWWttX3oAmKRDy0gvTNX0NEj1n2Tb1KmARnPjxYqsIW9ni+TS90EDqEJlev+OQEmXhJVKXI3NaJZoBH02LUKzZckBNSosVKyaKFcgR7IsnwprDK7mywmn9jiMq0pwlfSr07dQg0AsMLO2ngV0bBfrWB8zhlUf7uw+dxt1/n8Dz4yckShhPLd8mkWzTSXsy1mYs3vT/L574oF7+UKl0IfXSEdOXeYQ1wisHLK8WljG9b+0kY4RdIvxyw3L83BU8fPxcpezIuJKXPMh4DbjknEj6svW71dq40ofu7jGQ8aeUaN2oknEJNS1jNDjhlc/laYq8+OXS9bvqZi5xgrjqyYe8Cc6wTJuUs1R4g7tUy0RPmeAom6x2Imtpm4o1L/EkQAIkQAIkEJBAhBNedlH0I2CYtDZ5aAd1Q8DNn4DcnFVo2BfTRnQKcX3m6Mrrn3sPUbXZQLXEW+7s6aMrBp43CZAACZCABgIUXg2QWMS+BCi8wfOVFAZJNZG3s3EzJyAvXPH8+Blzxv4vbYKMSIAESIAESCAoAhRejotwJ0DhDfcu4AGQAAmQAAmQQJQmQOGN0t0bOU6Owhs5+olHSQIkQAIkQAKRlQCFN7L2HI+bBEiABEiABEiABEhAEwEKryZMLEQCJEACJEACJEACJBBZCVB4I2vP8bhJgARIgARIgARIgAQ0EaDwasLEQiRAAiRAAiRAAiRAApGVAIU3svYcj5sESIAESIAESIAESEATAQqvJkwsRAIkQAIkQAIkQAIkEFkJUHgja8/xuEmABEiABEiABEiABDQRoPBqwsRCJEACJEACJEACJEACkZUAhTey9hyPmwRIgARIgARIgARIQBMBCq8mTCxEAiRAAiRAAiRAAiQQWQlQeCNrz/G4SYAESIAESIAESIAENBGg8GrCxEIkQAIkQAIkQAIkQAKRlQCFN7L2HI+bBEiABEiABEiABEhAEwEKryZMLEQCJEACJEACJEACJBBZCVB4I2vP8bhJgARIgARIgARIgAQ0EaDwasLEQiRAAiRAAiRAAiRAApGVAIU3svYcj5sESIAESIAESIAESEATAQqvJkwsRAIkQAIkQAIkQAIkEFkJUHgja8/xuEmABEiABEiABEiABDQRoPBqwsRCJEACJEACJEACJEACkZUAhTey9hyPmwRIgARIgARIgARIQBMBCq8mTCxEAiRAAiRAAiRAAiQQWQlQeCNrz/G4SYAESIAESIAESIAENBGg8GrCxEIkQAIkQAIkQAIkQAKRlQCFN7L2HI+bBEiABEiABEiABEhAEwEKryZMLEQCJEACJEACJEACJBBZCVB4I2vP8bhJgARIgARIgARIgAQ0EaDwasLEQiRAAiRAAiRAAiRAApGVAIU3svaczse9ctN+jJ7+u7FVZycnJE+aEOVL5UfbRpXh6uqi6xG16D5etTlnbLdg2/3n3kNUbTbQ+HcXZyd8lywRShTOqY45toe7TY7Zz88P42evwc4Dp/Dy9TuULJwTM0Z1sUndrIQEohqBQeMXY9POo2hcqwz6dKgX5OkdO30Ji1bvxJ37j/Dx02ckShAXWTKkQu1KJVAwTxazfU7/dR1L1+7G39du49Onz0iaOAGKF/oZrRtWQsL4cczKdh08E/uOnguyzQt7F8AtmOuY4fq3ffkYpEmZ3KIuyVayGbq3ro1mdctZtF9QhXlNCzNCVhCNCVB4o3HnW3Lqhgv+4G6N1Q+K5ycv7DtyDvuPnUejmqXRt2N9S6oLc1lLhLdulZL4JX92ePt8xbm/b2D1lgPImjENVs0aCAcHhzAfi/yAyg/p8F7Nkf6nHxA3diykTJEkzPWyAhKIagQ+f/FG0WqdlcQmiBcbhzZOhdw8m24iwyLFeXJkQMXfCiJ2LHc8fPICf565jEzpfjST5KXrdmPC7DXIlikNqpUtgvjx4uDWnf+wctM+uLm5YsmUPkhtIqjyPT114RqG9WwWCO1vRfPA0THo60FYhLd6i0HqGlmt3C9h7k6D8PKaFmaUrCAaEqDwRsNOt+aUg7rgS2SzZqshePDoGc7ummdNtVbvY4nwiqTXqVLS2NbIqSuU9K6ZM1j9UFq7eXv7qCjzvBXbsXDVHzi7a661VZntZ6jXJpWxEhKIQAR27D+JPiPnqRtQieLOGt1VRWNNt8pNB0DuQzctHAEnJ0ezv/n4fIWLi7P67K8r/6BRp9EoXSwPJg5ubyarDx49R63WQ/Bd0oTYuHCE8W8ivBcu38LRzdMtohIW4bWooVAKG4SX1zRbUmVd0YUAhTe69HQYzzO4C/7QiUuxfsdhnNg2C3HjxFKt+Pp+w+I1O7F51zE8fvoSceN4oEKpAujSqqbxkaHnRy9MXbBBRVuePHsFj1gxkT1TGvRoWwepfkhmdrR7Dp/BjMWbVZTnh+SJ0bF5dazbdkhzSkPAHwfDj+6kIe1RtkQ+vHn3AdMXbcLBPy/g3XtPpEieGE1ql0XtSsWNx3H4xEV06D9VpVCs23YYZy5eVykdEqmS4zfdpo/ojFK/5MInr8/qHPceOYc3bz/gu2QJUbNicTSvW84YWQ6u3tWzByFvubYY0KURXr5+i41/HMXHT15KFEb0boEPH70wcupynPnruuLbtHZZNKzxm/Ew5IdRRPzilX/w8s17JE0UH0ULZEfnFjXMUjkkOrZ93wlMGdYRE+aswc07/6myUpdpfVKx/G3mks04//dNeH3xRvIkCVTUqlWDisZ2Dxy7gAWrdqgom7OzEwrnzYre7espVtxIoFXPibhy4y7++H0cfq3dXcnu5KEdzMCUqNkVGdP+GGK6kuzQaeB0FfU9tH4K4sX1CAR39tItmLV0C2aP6YZiBXOov9taeH/fuE/dPD98/EJd/0oVyYVubWojjkm6VMCUBku+cwFPKjjhteaaZjiO8QPbYuqC9bh59yFqlC+KwycvBntN+/fhM0yatxanL1xXT8zSp/4ebZtURolCOY2HGly93dvU0uWaVqv1UPWELX/OTFiydheevXijovy9O9RTn5luvKZFr2sShTd69bfVZxuc8LbuJT9g93B820yjxEkEZ8+Rs2hRrzzyZM+Ae/89xfRFG1EgV2ZMHd5RHcPTF68xa8kWFMidGUkSxsO7Dx+xdush9WO4Y8VYY+6d5Oc17zZOXVAlSvvm3XtMW7ARX319kTl9Kk05vAGFV0RQjmfRpN4qwlun7TB88PyE9k2qIGWKpDhx7qq6UPbr1AANqv+qjtcgppJLKOWK5M8OL68v8PCIiSVrdmHTzmPYsmSkKpsgXhzEcHNB065jFZtOzasjXZrvVURrxYa9ZrmLwdUrcizCKznHmdP9iMqlC+PJ81eYMn+9+vG+++8TlC6eV/1N0krk5mLp1L7I+3NGdQxHTv6tImCS9xgvjoe6WViwcoc6tt9nDjD7cVq5eT9++vE79OlQH2l+TI5dB09j7MxVmDuuuxJs2a7evI/GnUfjh++SqFzEpInj48HDZ0qCB3VrrMps2HEEQyYuQcVfC6J8qQL4/OWL6mOR4y2LRyKWewyrxx93jPwEnr98i5K1uqFWpeIY0r0Jeo2Yg31Hz+PIpmkqDciwdRsyEwf+vKDyXsuWzIdkiRMEOnl5upS/Qjv8nCUt5k/oGSScO/8+RuUm/dGkVhklOwbhPX/pphJu001yd4PL35VyQV3/ZizehLnLt0HSC2RewL0HT9R1Rb5Lv88aaEzVCEp4tXzngjqp4ITXmmuaiKkcR4pkiVSaiKRjeXt/haurc5DXNLnhrtZ8IGLGcFPXNJkDsWbrARw7fRmGm3w55uDqTZQgji7XNBHe/x4/R65s6Tu/KOYAACAASURBVNCtdS14xHJXQi8BjT2rJ6pUGl7TIv/1xJozoPBaQy0a7mO44K+fP1RFYCWyuefwWYyZsRKmQnnx6m006DBSRSbrVytlJCVRTvkh27hwODKmTRkkQZFYye/r0LQqGlT3j1aKZEl0dOvS0cbHkpeu3UG99iNQtEAOTcIr+cU1KhRVF/Nzl25i4LhF6sdtz+oJSkDlR2r9/GFmxzVq2grsPHgaRzdNV49VDWLatnFldbE33WYt2YzlG/bi9B9zjB/Lj0DbPpMwondzVC9f1Pj5sElLseGPIziwbgqSJIoXbL0SHRbhzZH5J6yaPci4v0wclL7o31lk3J+RRNRFJEoWyaVEIrjtxu0HqNFyMDYvHon0ab5XxeTHSfIg18wdgmwZUxt3lbxD+QEc27+1+qxZt7G49+Apdv4+Du4x3QI14fXZGxKZK5g7s4oWGza5sSnXoA+6t66l8hi5RV8CkvYjN2wrZw1UoirR2Ta9J5ldP4SOROR6Dp+jUg9kk5sruVmuUraIMUInN6gFKrZH7colgh3zki+cu0xrlCme1xhFDm7Smtycd29TO9jOCSi87z0/oVj1Lqpuw3dEdt554LQSecPTI/ksKOHV8p0L6mAMwmuLa5rhu79ocm/FN7Rr2uR561QgYMfysfjx+6TGa49IsNyAyIQ+02tKwHr1uqaJ8MpTt71rJhqvVRJQKVSpg9n1mNe06HctovBGvz636owDrtJgqEQee0sk1LDNXLwZc5Zvxakds80enUteaq4yrdG/c0OjCMvj7xUb9+Lfh0/x9v1HddGUHL16VUthYNdG6t85S7dCy3oV0LF5NbPjLl23J35KlUKT8AY8YRG7IT2aqgkwItSfvL5gw4JhZsVOnLsCefy6dckopE2dwiimy6b1U5NpQvtxkFQGiaie3zMfMdxcjcXlR1zyDicPbY8yxfMFW6/hx6FLyxpqtrlhk1SOYZOXYfeq8SraatgkmiyRF8OqFT5ffdXEnR37TqrIsNygyCZ85RGy/FAbfpzWbD2ojtN06zJoBt6+94Scr/Rd7rKtVWS6V7u6QY4fQyR+5uguZo83pbDcAIncm4qwVYOQO0VqAhJtlXG5a6V/dFVu1ErV7q7ybE1v6gwnKTdox89eUWk5kvok39OurWqqFBoRzoJWCu/pC9cwbURnM5bJkyYw+z4FBB1QeOW45OnWvPE9UCRfNmNxOafcZVqhRoVixicfQQlvaN+54Do64CoNhnLWXNNEeOX6e3HfokCT9YK6ia/ffgT8AEi6lekmUW6Jdh/bMkNFT4OrV69rmghvwvixMXdcD7PjFOGVJ3YdmlXjNS1SX0msP3gKr/XsotWehgv+uIFt1A/U67cfsGzdbly4/A/kM3mMLZvImEiZYWKJKSSRLbnYSEqAPF6SHDy5AMnsaLlQOjg6om3vScifK7O6E3/7zhOFq3RUERyJ5JhuDTuOUkKtZVmypnXKqtw6FxcXlXcqaQmGrWLjfrj/31OVb2q2iXx/9VXCJ4JriPAGtSxRUD8OEsnddeiMEn/TTSb4ScTTcE7B1Wv4cQiYjiGpCxKhPrljtlmeoPz4yo+tRFVkk5QE6Qd5pCfRNHf3GCo/WWRbIlKVShdS5Qz5dgEn8fQYNhuPnr5UE/tkqTWJZsljT5HeoDZJg5ConCz9pmYcmWxfv/oi788ZsGRK32j1neHJ/o/A5Rv3ULftMJXm1NIk53vGoo1YtfkA/lgxNlDuvik/uRa07j0RIsHy1EXyZfOVb4ecWS1PabDFpDVDJDeoJ1bypCN39gyYOLidOoXgcnhD+s4FN3YMwmuLa1pw331pO6hrWoVGfZHmx+8wY6T5zYIhlWnH8jEqVza4evW6phlyeCXKbrrJ08OqZYuoSD6vadHz6kThjZ79bvFZB5XDJo+xqzTtjy/ePti9agJixnDFtIUbsWTNTqxfMAxOAZYbkkbjx/VA/LixVXqDPHaSR+mmW56yrVGuZAElvIYIr6Q4mE6MkvKVGvfD998l0SS8AaXRtD0RZ0mlGN2vVZBMkidJqM7LUuENPcLrH2W1l/DKjYJMQDF9THvl5j3UaTPMYuGVCG+ecm3QqEZp9GofdIT35LmraNlzgqo7i0lqhAFqTDdXTlyz+FsXdXYwrIwS3BnJUwx5mhHSJk8sRk9fqXLQc2ZNh04DpqkI8KENU40TZk33n71sqxI3e0xaCy3CK5NT5SmVvYTXFtc0S4U3tAjvn1tnqGu7vYRX6zVNi/DymhZ1ri2WnAmF1xJa0bhscJPWJI+3+9BZxuif4ZH9+EFt1coMwW2SuydCazrh5Oipv9Gu7xSV8yrCK5ukHEgOrWl0UCKPZev3QpF82cMsvPI4TlIPJK81pLVzLRVeQ37iyD4tzNbflMjvxp1HcWDdZCRO+L8c3oCR47BEQ4RrnrJtIPnGpjcKE+euVZNRLI3wSj/IxEGZBCSPo91jBp58JsdbomY3lCuRH0N7No3G3xSeekAC8mSnWI0uakKoTEQLuI2btUo9fdi3dpKa+CrjTCZ+BdzkyYY84di1crz6rhquNeVK5oesNGC6hq5M0pQlE2XC26ZFtl+WzJDDW7Z4Pozp/7+bZUPk15CyFB7Cq/WaZqnwSv61rL4j0XjpS9m+ffND1Wb+k2C3LRut/t8ewmvJNU2L8PKaFj2vUxTe6NnvFp91cMJrWIv31Zv32Lt6gloqrO/o+dh7+CzqV/8VubOnV7OVRVIPn/hL5fDKxXL5+j2YNHcdpo/srFZqkIlo/ccuxNt3H1C2RH6j8BpyQ2U5LZkEJ6kUA8YuxI3b/yLvz5nCLLyS2yoT4D54flRLkaVL/T0+f/bG3QePcf7SLbVSgWyWCq9wMazS0L5pVTVJTCaySZTK9A1T9orwSvTr1t2HmD2mq4qs7jp4BtMWboD0kzXCe+3WfZUOITO65XFqsiQJ1FJMN+78pyYdySZLpw2esFgt9SZro8bxiIXnr95CciYL5c1qTHuxePBxh0hNwPBillF9W6pHygG3tVsPYviU5Vg8pY+alCYTMOXJiqQ6pUieSOXuHj9zGX8cOBXoLYbyNjaZTCWTO6uW+0U9QfJ/8cR+lVYldZrKc1iXJTM8tpdzMKzSIKvHFC+YQ61GM3PxJk2rNMhSgGFJaQgpwqv1mmap8EoagExQixHDTU0slheCrN12UEXZJc1BJs3aS3ilXq3XNK3Cy2tapL6sWHXwFF6rsEW/nUJaeN0QmZXlqWSJHrnrX7V5Pzb+cUT9CLi6OCtRklUV5NGlLE8laQTTF27E1j3H1QQU+VHq3KI6Js71//EyRHiF9O5Dsg7vJjx68gLJkiREszpl1dq2Wl8tHNKPg9Qv7c9ZtlUt7/X8xRuVGyy5aPLaZJlAZ43wyj7ywyOSKVFwyUE0rMPbrE45YzTKXsIrP06yooMssaYm0mRPh9YNK6NRp1FWCa+cj+RPSj+c+/umWoNTcrllHd6W9SsYvxAi9YvX/IErN+6rPpY1fWWpNFl72PSNV9HvGxR9z7hj/2mQG1cRPEkPCrjJiguSIy43SpJaJN93kWRZ0k9umCQjXG6S5e+yJF7A5cNOnb+Gpet24dK1u2rt6ySJ4qN4oZxo3bCiWb6+tGut8MpTILWm9pqJ6lpm2GSVF5mAZs06vPYSXq3XNEuFV+o1XYdXUtkypPkh2HV4A55fWJ5aSdtar2lahZfXtOh3TaLwRr8+5xmTAAmQAAlYQECtLX74jHqjZFATci2oikVJgATCiQCFN5zAs1kSIAESIIGITUBe4CJPNJat360mmU4Y5L/yAjcSIIHIR4DCG/n6jEdMAiRAAiSgA4GqzQbivedHFCuQAz3b1eXbAnVgziZIwF4EKLz2Ist6SYAESIAESIAESIAEIgQBCm+E6AYeBAmQAAmQAAmQAAmQgL0IUHjtRZb1kgAJkAAJkAAJkAAJRAgCFF6du+HxKy94xHBWy1K9/+SjW+tuLo7wiOmCV++/6NamnGOSuG54+uazbm1qbSiOuwu++fnB0+ur1l3CXM7dzQmuLk546+kd5rq0VuDi5IB4Hq548U6/ftd6bHJc3j6++PTFV+suYS5nzXdP+k2ONSptMgb15B4cu9gxndWrqD/oeC20th/jxnKBj68fPn3W75ph6bHGiuEMZycHvPuo32+LJceYNH4MdS2SpSsj0pYkXgy8/vAFX30jxnFJHyaI7Ybnb81/O79LGDMiYYt0x0Lh1bnLKLw6Aw+mOQpv+PcDhTf8+oDCazl7Cq/lzALuQeHVxpDCq42TpaUovJYSC2N5Cm8YAdpodwqvjUCGoRoKbxjghXFXCq/lACm8ljOj8FrHjMJrHbfQ9qLwhkbIxn+n8NoYqJXVUXitBGfD3Si8NoRpYVUUXguBAaDwWs6MwmsdMwqvddxC24vCGxohG/99/Y7DcHKUl2U6wPfbNxvXHnx1Dg4OcHZ0gI+vfm3KObo6O8D7q55takPq5OgIwA++OuaSSU6zo4MDvurYB6rfnRzgEwH7wNnJUeVR65nPJ9+9+PHiIkP6DDI8NW3M4dWEyapCzOG1CluwOzGH1zqezOG1jltk24vCq3OPJfjhZ51bZHMkQAKmBPr16oL6Depq9V1QeO03fii8tmVL4bWOJ4XXOm6RbS8Kr849FitpJp1bZHMkQAKmBAb174lGDetTeHVcHSO4EUjhte13k8JrHU8Kr3XcItteFF6de4zCqzNwNkcCAQhQeKGWxuOyZJZ9NZjDaxmvoEpzlQZtDJnDq42TpaUovJYSC2N5Cm8YAXJ3EggjAQovhdeaIUThtYaa+T4UXm0MKbzaOFlaisJrKbEwlqfwhhEgdyeBMBKg8FJ4rRlCFF5rqFF4raFG4bWGWuj7UHhDZ2TTEhRem+JkZSRgMQEKL4XX4kHDZcmsQRZoH0Z4tWGk8GrjZGkpCq+lxMJYnsIbRoDcnQTCSIDCS+G1ZggxwmsNNUZ4raFG4bWGWuj7UHhDZ2TTEhRem+JkZSRgMQEKL4XX4kHDCK81yBjhtZIahddKcKHsRuG1D9dga6Xw6gyczZFAAAIUXgqvNV8KRnitocYIrzXUKLzWUAt9Hwpv6IxsWoLCa1OcrIwELCZA4aXwWjxoGOG1BhkjvFZSo/BaCY4RXvuAs7ZWCq+15LgfCdiGAIUXePPBG599fG0DNAy1xHRzUq9Z9/ryNQy16LOrvNTh6zc/fPEOf27BnXEMVyf16vqPnyMmz/ixXfHW0wd+fn76dJrGVuJ5uOLDJx9dXzWvDs1P/S/QRuHV2HEWFmOE10JgYS1O4Q0rQe5PAmEjQOEFHv9zGJ73d4UNJPcmARKwmoCje3LE+Kk+HF1iU3itpmjZjlFOeL/6+qLH0Nk4e/EGfL99g4/PVxTOmxUzRnWxjIydSlN47QSW1ZKARgIUXuDJzX14fXGaRmIsRgIkYGsCTrFTwyPXIAqvrcGGUF+kEN7KTQegVf0KqFS6UKhoDh7/C/NXbMPKWYPg5OSItVsP4s8zl8MsvHsOn0X3obNU+y7OTkiUIC5yZ8+Alg0qIF3q79Xnb959QJEqnYzHGDd2LBTKmxWDuzdBHA939TmFN9QuZAESsCuBoIR34qwVuHztHzx++gL9u7ZAiV/yGI/B3c0J8sgzKm0U3qjUmzyXyEiAwqt/r0U54V25aT8uXbuDcQPbKJq2FN4p89djx4ox8Pb2wX+PX2DV5v3YvvcEVswYgCwZUhmFd9+aiUiSOD6ev3iDnsPnIFumNOjXqQGFV//xzRZJIBCBoIR3y87DSJXyO0yduxJN6lQyE9779x+gUO4MUYokhTdKdSdPJhISoPDq32mRTnjvPniChh1Homntsth75Bw+eH5Co5ql0bDGb1iz9SCmLdgAn69fES9ubHRqXh2fP38xRngvXL6FQeMX448VY42kq7cYhF7t6qJgniwYNnkZ3rz9gKnDO6q/T5q7Dldv3sOiyb1VWyK8u1eNN+ulTgOnq7SJueO6G4X3wPrJSJY4gSq3aPVOnDx/FQsn9qLw6j++2SIJaBJeQ6GWXUegQY1yZsK7Y/dhtG5QLkqRpPBGqe7kyURCAhRe/TstUgpvpcb9lKQ2rVMWz168QaUm/bB1ySgkT5oQy9fvwdWb94OM8IYmvF6fvSEC3LphRaRMkRSdBk7DpkUjlLxKSkNQwrtj30klymd3zQ0kvM9fvkWPYbOQP2dmdGxejcKr//hmiyQQZuFdunIL+neuF6VIUnijVHfyZCIhAQqv/p0WKYW3WrOBOL93PpydZEkboEGHkWjVoCKKF/o5TMIrdV2+fhete01ELPcY6NamNiqUKqDaCE54T/91Hc27jcOlA4vx3vOjWQ6v7Cf5vUum9kH8uP4zMZnDq/8gZ4skYEogpElrQUV45y9bj6HdG0cpiBTeKNWdPJlISIDCq3+nRUrhlZSGE9v8J5DJ1qL7eNSoUAzlS+UPs/BKfbVaD8XrN++xd81ENfEtJOGVCO/wKctwZmfgCK/nRy/MXbENpy9cx7p5Q+Dg4EDh1X+Ms0USMCNgqfAywssBRAIkYGsCFF5bEw29vmglvNf/+RedB82ATCozbCVrdcOoPi1VDq9sqzYfwNptBxEzhhtKFcmlIschCW/nQZLD64s5Y7sFmcN778ETVGzcD0c2TVMrOzDCG/qgZAkSsCcBS4WXObz27A3WTQLRkwCFV/9+j1bC+/HTZ5So2RWr5wzGTz9+pyaidRsyU00oE+G9/99T1G03HEun9lXCW6ftMPXfGdOmNKY0GFZpePjkJVZvOYCtu/8MdpWGjx8/qwjvtr3HcWzzDDg6MsKr/xBniyRgTiAo4ZWJp9/8/NCh1xjUqV4aRQvmhouzs/rO3rv3LwrnyRilMDKlIUp1J08mEhKg8OrfadFKeAWvLCM2e9lWJEoQB5nTp1LpBn061EPenBnRoP1I/Fo0tzGqK6s+iNSunzcUh05cNK7DK7nD/uvwpkerhhWDXYfXPaabkuUebevg5yxpVe8ywqv/IGeLJGBKICjh7TpgIq7euGMGatSAjsiXKwu4Di/HDwmQgK0JUHhtTTT0+iKF8IZ+GpGnBIU38vQVjzRqEuCb1vimtag5snlWkYkAhVf/3qLw6sycwqszcDZHAgEIUHgpvPxSkEB4E6Dw6t8DFF6dmVN4dQbO5kiAwhtoDDCHl18LEghfAhRe/flTeHVmTuHVGTibIwEKL4WX3wISiGAEKLz6dwiFV2fmFF6dgbM5EqDwUnj5LSCBCEaAwqt/h1B4dWZO4dUZOJsjAQovhZffAhKIYAQovPp3CIVXZ+YUXp2BszkSoPBSePktIIEIRoDCq3+HUHh1Zk7h1Rk4myMBCi+Fl98CEohgBCi8+ncIhVdn5hRenYGzORKg8FJ4+S0ggQhGgMKrf4dQeHVmTuHVGTibIwEKL4WX3wISiGAEKLz6dwiFV2fmFF6dgbM5EqDwUnj5LSCBCEaAwqt/h1B4dWZO4dUZOJsjAQovhZffAhKIYAQovPp3CIVXZ+YUXp2BszkSoPBSePktIIEIRoDCq3+HUHh1Zp67WFWdW2RzJEACpgSaNa6HalUrw0EjFnc3J8TzcNVYOnIU46uFI0c/8SijLgEKr/59S+HVmfnh01fh5uwI+bX94vNNt9adnRzg6uyIT198dWvTwQHwiOGMD15fdWtTa0NuLo6qqJ594OLkAGcnR3h569cHTg5ADFcnfNSx37X2QUxXJ3z1/QYfXz+tu4S5nHz3YrrHQJIkyTTXReHVjIoFSYAENBKg8GoEZcNiFF4bwtRS1eNXXkoCHR0d8P6Tj5ZdbFJGBM8jpgtevf9ik/q0VCLnmCSuG56++ayluK5l4ri74JufHzx1lHERJ1cXJ7z19NbtXEWyJTr54p1+/a715OS4vH18db0Js+a7R+HV2qMsRwIkoJUAhVcrKduVo/DajqWmmii8mjDZvRCF1+6IQ22AwhsqIrsVYEqD3dCyYhLQRIDCqwmTTQtReG2KM/TKKLyhM9KjBIVXD8oht0HhDb8+oPCGH3u2TAJCgMKr/zig8OrMnMKrM/BgmqPwhn8/UHjDrw8ovOHHni2TAIU3fMYAhVdn7hRenYFTeJnDazIGmMPrD4PCGzGuQzyK6EuAEV79+57CqzNzCq/OwCm8FF4Kb6BvAYU3YlyHeBTRlwCFV/++p/DqzJzCqzNwCi+Fl8JL4Y0Ylx0eBQkYCVB49R8MFF6dmYvwxnJzhoOjAzy99FuWzNXFEbFiOOPNB/2WxJJlyRLGjphLYskSbX5+fvj4Wb81gmXdWRcXR7z/qF+/y/rLcWPJcnTa+t0BDvCDPuviModX54uPSXOM8IYfe7ZMAkKAwqv/OKDw6sx82IR5cHRwgLyUwfebPmIhpyjtSbt6t+nk4Iiv3/R7wYbW7nRydICfH9RavHptjg7SD+HRBw74qnGsZcuaCQXy5lUvRrH3RuG1N+Hg66fwhh97tkwCFN7wGQMUXp25x0qaSecW2RwJaCcwdvQwVK9aERLptfdG4bU3YQpv+BFmyyQQMgFGePUfIRRenZlTeHUGzuYsIkDhDYyLb1qzaAixMAmQgAYCFF4NkGxchMJrY6ChVUfhDY0Q/x6eBCi8FN7wHH9smwSiCwEKr/49TeHVmTmFV2fgbM4iAhReCq9FA4aFSYAErCJA4bUKW5h2ovCGCZ/lO1N4LWfGPfQjQOGl8Oo32tgSCURfAhRe/fuewqszcwqvzsDZnEUEKLwUXosGDAuTAAlYRYDCaxW2MO1E4Q0TPst3pvBazox76EeAwkvh1W+0sSUSiL4EKLz69z2FV2fmFF6dgbM5iwhQeCm8Fg0YFiYBErCKAIXXKmxh2onCGyZ8lu9M4bWcGffQjwCFl8Kr32hjSyQQfQlQePXvewqvzswpvDoDZ3MWEaDwUngtGjAsTAIkYBUBCq9V2MK0E4U3TPgs35nCazkz7qEfAQovhVe/0caWSCD6EqDw6t/3FF6dmVN4dQbO5iwiQOGl8Fo0YFiYBEjAKgIUXquwhWknCm+Y8Fm+M4XXcmbcQz8CFF4Kr36jjS2RQPQlQOHVv+8jvPBevXkfUxasx8Ur/8DBwQF5cmREz7a18VOqFHaj9eDRM1RvMQjnds83trHn8Fl0HzpL/dvF2QmJEsRF7uwZ0LJBBaRL/b36/M27DyhSpZNxn7ixY6FQ3qwY3L0J4ni4q88pvHbrNlZsAwIBhffRkxdYvGoLLl+7jc+fvZExfSq0b1YLqVJ+F2xrew+fwqoNu/D8xSskSZwQfbs2R8a0P6ryE2etwOVr/+Dx0xcY2bcNShTJjU9ffI11rdywCzv2HsUHz09I/WMKdGheGxnTpbLBmflX4RHDGY6ODnj/yUdzne5uTojn4aq5fGQo+OTmPry+OC0yHCqPkQSiJAEKr/7dGqGF98btB2jYcSSa16uAWhWL4ds3P6zctA/rth/GunlDkTJFErsQC054p8xfjx0rxsDb2wf/PX6BVZv3Y/veE1gxYwCyZEhlFN59ayYiSeL4eP7iDXoOn4NsmdKgX6cGFF679BYrtSWBgMJ75fptXL15FwXzZod7zJhYvnY7/rp0AyvmjAyy2VNnL2Hy3JXo1q4BMqZNheev3iBubA8kS5JQld+y87CS5alzV6Jdk2pmwnvi7CWMm7YEE4Z2VWXWbt6DP/b9iTULx9rsFCm8/igpvDYbUqyIBKwiQOG1CluYdorQwtum9yTEjxcbY/u3NjvJDv2nwiNWTIwb0AZzl2/DsxevMaRHU1XmvecnFKzYHn8fWARnJyf4+HzFzCWbsWPfSXzx9kGpX3Khb8cGiBnDFbfvPcKQiUtw59/HKupTqkhujOjdHFWaDVB/S57U/0d64cReuHnnP4jw7l413uxYOg2crtqYO667UXgPrJ+MZIkTqHKLVu/EyfNXVR2yMcIbpvHKne1MILSUhpev36Feq75Yt2gc4seLE+ho2vYcjWrli6NMyUIhHmnLriPQqkElM+HdtOMgTp79GxOGdVP7vnj1FvVb98Om5ZMQO5Y7lq/doQT4yxdvxIsbG327NLM4+kvhpfDa+SvE6klAEwEKryZMNi0UYYXX1/cbcpdtjanDOqJ4oZ/NTvqPA6cwdsZKHNsyI1ThnTxvHa7cuIfxg9rCPWYM9B+zACmSJ0KvdnXRvt8U5M2REc3qllNRW5FaicaGFOENKLwi0sMmL8PZXXMDCe/zl2/RY9gs5M+ZGR2bV6Pw2nTosjJ7EAhNeI+e/AuzFq3FmgVjVIqR6SbfoQr1OqN5gyrYuvMw/AAULZgTLRtVh5uri1nZoIRXBLff8Ono3amJMcJ77u/rmDa6F27d/hfDJs7HrHF9lew+efYSTs5OSJIwvkUYKLwUXosGDAuTgJ0IUHjtBDaEaiOs8BoitWvnDUHWDKnNTuHMXzfQvPs4XDm0JFThlWjv/Im9kC2jfx237j5Uort/7SR0HjQdCePFQetGlZE8iX9EVjZLhPf0X9fRvNs4XDqwGO89P5rl8Epdkt+7ZGofxI8bm8Kr//hmixYSCEl4nz1/hc79xqN9i9ooVih3oJolL7dJh8HImuknDOrRCl99v2HQ6FkolO9nNKlbMVTh/erri8Urt2L91n2qbIJ4cTBmcGek+TEFbt/7D32Hz0D/rs2QLXM6uLg4W3hm/sUpvBReqwYOdyIBGxOg8NoYqIbqIqzwqghvmVaYOryT1RFemWSTv0I7pEyRVKUsyObn56cmxEh0+Mnz15i+cCOOnLqIRAnioU2jSqhQqoBFwisR3uFTluHMzsARXs+PXpi7YhtOX7iOdfOGqIgYUxo0jEoWCTcCwQmvpDL0HDwJVcqVQLUKJYI8vlev36Juq34Y1qctCuXLocrs2n9cTUKbNb5fqMK7ZvMe7DpwAiP7tUOyJIlw+MQ5zF+2CYumDUGc2LGw+8BxbN9zdUAtGwAAIABJREFUFA8fP0fBPNnRtllNFe21ZKPwUngtGS8sSwL2IkDhtRfZ4OuNsMIrh9y610QkiB8nyBxeeUQ6eWgHLFu/B7fu/IdRfVuqs3zw6DnKNehtzOEV4V01a2CIqzrIZLgT566gQ7+pOLRxKj5+8kK15gMDrdIQVA6vRIl9fHwxZ2y3IHN47z14goqN++HIpmlqZQcKr/6DnC1qJxCU8L5+8w7dB01G2VKFULdamRArq9GsF3q0b4RCebNbLLxjpy5RecFtmtYwtlG9aU8M7NYCuXJkMn727v0HTJi5HMmTJkaHFrW1nxwjvEZWnLRm0bBhYRKwOQEKr82RhlphhBZeWZKscefRaFG/AmpXKm5cpWHFhr1YNXsQMqZNCUkpGDJhCTYvHqkmoo2e/jtWbtpvFN5Jc9fh+u1/MbJPCzWRTPJqJVf3l/zZIEuN5f05IxLEiw1ZEaJu22E4umUGnBwdVWT40IYpSJwwnoIoZU1XaXj45CVWbzmArbv/DHaVho8fP6sI77a9x3Fs8wwVZabwhjomWSAcCQQU3rfvPqDHoMkqYtuwdgXjkbm6OKsnFn9duYkH/z1FlXLF1N/mL9+E67fuYWjv1vD5+g0DR89C4bzZ0aiOf0qDTPD85ueHDr3GoFm98ihaMBd8fB3Ud2PLzkNqFYdRAzqqVR0kwjtp5nIsnT0Cnz56qRvRDOlSwe+bH8bPXIZE8eOZybEWbIzw+lOi8GoZLSxDAvYjQOG1H9vgao7QwisHffn6XUxdsAEXr97G5y/eKko6dXhH5MyaznhOo6evxLHTl5A0cXyV/jBh9hqzVRrmrdiupPPNO09Vplal4mhSqwyGT1mO/UfPqdUbpN4OTauhfKn8ql5pc/2Ow/j61VfJtazaYFiHV1Z/8F+HNz1aNawY7Dq87jHdlJT3aFsHP2dJq+ql8Oo/yNmidgIBhXfPwRNq7dyA29yJ/fFT6h+wetNunD5/BVNH9VRFZOLazEVrceT4ebi5uaJ44dxo2bAaXP9/0lrXARNx9cYds+pEcPPlygJJY1q0cgsOHTuDDx+9kDxpIjSuUxG/FMipJHra/NV4/OQFXFyd8XOWdOjStgHieMTSfnKM8BpZUXgtGjYsTAI2J0DhtTnSUCuM8MJregZ37j9C4y5jMKJ3C5QsnDPUk4uIBSi8EbFXeEwGAqGt0mBLUvIyB28fX7MXT9iy/qDqYoTXnwqF194jjfWTQMgEKLz6j5BIJbyCRyK95y/dQuNaZdQbzyLbRuGNbD0WvY43uguvRLSPnrqIUf3bq45v0HYARvdvi4I50wc7EO4+eKJekHNim/+bGCPDRuGNDL3EY4zKBCi8+vdupBNe/RHZtkUKr215sjbbEogOwitLnM1auhlXrt+Br68vfvw+GSqXL47fihVAQOGV1yQXK5AdqVP4v4QmqC0k4TW8btz0ZTRSx7BJS1VVhhfm2LYXQ6+Nwhs6I5YgAXsSCE545QU7W3cdVtemEr/kUxNzJY1Stu8SxrTnIUX5uim8OncxhVdn4GzOIgJRXXgfP36Ctr3Govxvv6Dib78gYYJ4uHP/IVZt3IXRAzsGEl6B5+7mBEm/oPBaNJRYmARIIAQCQQnvgaNn1MTfCUM7I0WSeJC3zZYonBsNapWn8NpgNFF4bQDRkioovJbQYlm9CUR14R04aibixomFXp2amaGV9bll1YmQUhrUhLwlm7Hz4Gm8e/8RaVOnwLzxPSBrFJumNKzbdghL1+1WrxOPGdNNvYwmtAjvsdOXMXneWjx+9kpNgh3YtZGa8Cpbi+7jUaNCMeOE2gPHLmDJ2l34feYAfPL6jAFjF6q1vuUcfkiRBMum9Vcr1shxyao18qKeGDFc0ahmaTVZVzZGePX+ZrE9EjAnEJTw9hk+HVkz/oRm9SoiQWw3rNp6BCvW/YFls4ZTeG0wgCi8NoBoSRUUXktosazeBKKy8MoqEJXqd8aoAe2QM3uWINGGJLzjZ63G39fuYOLgdkiaOAGu3rqPn35Mjqcv3hiFd9Hqndi+9wQWTuqlVnLRktLw8MkLVGk6QK0rXihvVqzZcgCL1+zEzt/HK3ENSXiXrt2NC1duYeKgdnB2dsa1f+4jQ5of4OzshAYdRqrVbDq3rIFXr9+hZc8J6NOhPooVzEHh1fuLxfZIIACBoIS3bsu+6NymPooWyKGE9/SlO2jdbSR2rJ6uXs/OlIawDSMKb9j4Wbw3hddiZNxBRwJRWXg9P35CtcY9sGT6QHyfIoXFwpuvfFsVtc2e+SezfQ05vLUrlcCp81cxb3xPFUWWzSC8cTzc4fD/b3uUz70+e6NqmcIqh1fkVibizhrd1Vhv2fq90bdjfbXMYkjC+/vGfdh96IxZRFgqkXXFZQ3zk9tnw8nJUdW7ctM+yNrmo/u1ovDq+J1iUyQQFIGghLdKw24Y1rcd8uTIoIT3yu0naNCmPzYsGY+4cWJTeMM4lCi8YQRo6e4UXkuJsbyeBKKy8IYlwpst/Q/qZTR/bp2B+AFeZyzCW73FIMjLOEb2aYnSxfIYu8wgvGvnDVERX8MmL7Fxj+GmhHfszFVqgsqALo2MfxfJLVM8L2pXLhGi8Moa4nOWbcWug6fVOuXVyv2Czi1q4PDJi2rd8BTJEhnrlJd+ZEyXEtNHdKbw6vmlYlskEAQBRnj1HxYUXp2ZU3h1Bs7mLCIQlYVXQEgOb7w4HujZqakZFy05vCK8Cyb0DDbCKxHaTgOmY+KQdiiQK7OqX0tKQ1ARXnk9uqQfSIS3Y/9p+LVoblQtW0TVufGPo9i865jK4TXdRLxlkkufDvWU6Mp/yyvNJTc54MYcXou+FixMAjYnEFwOb/ZMadGkbgUV4V297Shk1Qbm8NoGP4XXNhw110Lh1YyKBcOBQFQX3kePHqNd73GoWKYYKvxWBAnixQ1xlQbTdXglh/fyjbsYP6gdkiaKH2QO77m/b6Lr4JnqbZDyWFKL8P73+DmqNhuIqcM7oWCezFi79RAWrNyBXSv9c3hnLt6Mfx89xYRB7fDJ6wuadx+nlikS4T11/hqSJ02IlCmS4O17T5W327t9PZUD2KDjSPU2yPZNqsDN1RX3/3ui9s+WKQ0jvOHw3WKTJGBKICjh3X/kNBb9vhmThndDiiRx0brXRPX6da7SYJuxQ+G1DUfNtVB4NaNiwXAgENWFV960JuvwzlyySa3D++3btxDX4TUVXkkfmL5oo0of8PzopVZTmDOue6BVGk5duIaew+ZgxqjOSPVDMk2rNBw99TcmzVuHJ89eIW2qFBjUrTEypftRjQBZEaL3yLl49uINEiaIg2wZ00DEWoR3w44jSo5fv/2AWO4xVBS4S8saKqorqzTIa9ZPnr8Kb5+v6lg6Na+OwnmzUnjD4bvFJkkgNOGVvy9bswPbdnMdXnuMFgqvPaiGUCeFV2fgbM4iAtFBeB0dHfD+k49mLqGtw6u5oghUkCkNEagzeCjRkgDftKZ/t1N4dWZO4dUZOJuziACFNzAuCq9FQ4iFSYAENBCg8GqAZOMiFF4bAw2tut5DJkMiTLJ9++YXWnGb/V3mrUi7vr76tQkHwNnRAV/1bFMjsfDoA0e1OpSD7v3uZEEfFCyUD/ny5IKDdJ6dN3l7mbePLz598bVzS/+rXlIaGOHliyd0G3BsiASCIUDh1X9oUHh1Zv74lRfcXZ3UmpwfP3/VrXVXZwfEdHPBu4/eurUpeYQJY7vg5Xv92tR6crFiOKs3U+kpWzFcHOHi7IQPXtofp2s9n+DKyQ1HbHcXvPGMeH1A4Q1r71q/P1MarGfHPUnAFgQovLagaFkdFF7LeIW5tAivNVGmsDbs5uIIj5guePX+S1ir0ry/RNKSxHXD0zefNe+jV8E47i745ucHTy/9bjrk0birixPe6iifLk4OELF88U6/ftfahxReraRsX47Ca3umrJEELCFA4bWElm3KUnhtw1FzLRRezajsWpDCa1e8miqn8GrCZJdCFF67YGWlJKCZAIVXMyqbFaTw2gyltooovNo42bsUhdfehEOvn8IbOiN7laDw2oss6yUBbQQovNo42bIUhdeWNDXUReHVAEmHIhReHSCH0gSFN/z6gMIbfuzZMgkIAQqv/uOAwqszcwqvzsCDaY7CG/79QOENvz6g8IYfe7ZMAhTe8BkDFF6duVN4dQZO4eWkNZMxYM2EUa7DGzG+szwKEohKBBjh1b83Kbw6M6fw6gycwkvhpfAG+hYwwhsxrkM8iuhLgMKrf99TeHVm/uS1F2LKOrwODvj0Rb8lsVycHRHT1RnvP+m3HqucY3wPF7z+oF+bWrvT3c0ZfvCDl44vPXBzcYL0g6eO6/DKSydkOTqt6y/7yQsn/PR5OQlTGrSOVtuXo/DanilrJAFLCFB4LaFlm7IUXttw1FxLyUoNNZdlQRLQk4B7zJjo3LEdsmbJpEuzFF5dMAfZCIU3/NizZRIQAhRe/ccBhVdn5rGS6iMTOp8Wm4sCBGJ7eGDRglnImSObLmdD4dUFM4U3/DCzZRIIlgCFV//BQeHVmTmFV2fgbE4zAQpv0Kg4aU3zEGJBEiABjQQovBpB2bAYhdeGMLVUReHVQollwoMAhZfCGx7jjm2SQHQkQOHVv9cpvDozp/DqDJzNaSZA4aXwah4sLEgCJBAmAhTeMOGzamcKr1XYrN+Jwms9O+5pXwIUXgqvfUcYaycBEjAQoPDqPxYovDozp/DqDJzNaSZA4aXwah4sLEgCJBAmAhTeMOGzamcKr1XYrN+Jwms9O+5pXwIUXgqvfUcYaycBEmCEN/zGAIVXZ/YUXp2BsznNBCi8FF7Ng4UFSYAEwkSAEd4w4bNqZwqvVdis34nCaz077mlfAhReCq99RxhrJwESYIQ3/MYAhVdn9hRenYGzOc0EKLwUXs2DhQVJgATCRIAR3jDhs2pnCq9V2KzficJrPTvuaV8CFF4Kr31HGGsnARJghDf8xoBdhLf/mAVIl/p7NKtbLvzOTEPLj56+RJWm/XFu93wNpW1ThMJrG46sxfYEKLwUXtuPKtZIAiQQFAFGePUfF1YJb912w3H5+t0gj7Z6+aKoUKoA4sX1QMa0KfU/IwtatER49xw+i+5DZ6naXZydkChBXOTOngEtG1RQci/bm3cfUKRKJ+MRxI0dC4XyZsXg7k0Qx8NdfU7htaCDWFRXAkEJ77mL17Bm0x78c/cBXFxckD93VrRtVhOxY/mP54DbV19fLF21DXsPn8LHT15Ik/I7TBjWHTFiuKqix0//jXnLNuDVm3fImTU9+nVpglgesdXfZixYg5NnL+Ht+w9IGD8uqpQrjpqVf7UpA48YznB0dMD7Tz6a6+WrhTWjYkESIAGNBCi8GkHZsJhVwuvj8xXf/PzUYfQaMQepf0iO9k2rqn87OTnC2cnJhodov6osFd4p89djx4ox8Pb2wX+PX2DV5v3YvvcEVswYgCwZUhmFd9+aiUiSOD6ev3iDnsPnIFumNOjXqQGF135dyZptQCAo4d2570+4ubkiW+Z08Pr8GRNnLsePP3yHnh0aBdnivKUbceX6P+jYuh6SJIyPu/8+RLZM6eDq6oInz16iZdfh6N2pKXLlyIgFS9fjxat3GDO4s6rr8rXbSJwoPtzdY+Dh4+cYOm4uendqgjw/Z7bB2flXQeH15/Dk5j68vjjNZlxZEQmQgGUEKLyW8bJFaauE17ThroNnInXK5OjSsobxY9OUhrVbD+LPM5cRN44Hdh86jWRJEmLy0A44feEa5v++HY6OjhjYtRF+K5pH7S8yPXPJZuzYdxJfvH1Q6pdc6NuxAWLGcMXte48wZOIS3Pn3sYrSlCqSGyN6N1f7Xbp2BxPmrME/9x4hhpsr2jaujLpVSuLO/UcYOmmp+lwis78WzYN+HeurH+CAwhtS2xLhFeHdvWq8GfdOA6erY547rrtReA+sn4xkiROocotW78TJ81excGIvCq8tRizrsBsBLSkNB46dwar1u7Bo+pBAx/Hm7Xs0aj8I8yYNRIrkiQP9fdXGXfjr0g1MGNZN/e3zJ09UatQLK+ePVnJsur199wFdB0xA9YqlULlsMXh5fcbEWcvx1+VbgJ8fkidLhEnDexgjx1qhUHgpvFrHCsuRgD0JUHjtSTfounUR3tHTV2L8oLYoWTgnJs9fj/3HzqN00Tzo3LIGjp2+pCT2yKZpKjI8ed46XLlxT5V3jxkDIs8pkidCr3Z10b7fFOTNkVHlBkuU9ead/1T09PnLt6jYuC/6d26ICr8WxCevz3j4+IWKuookv377ATmzpcObtx9UHRV/K4imtcsGEt6Q2g5OeEXMh01ehrO75gYSXjmuHsNmIX/OzOjYvBqFV//xzRYtIKBFeGcuXIM37zwxqEfLQDVL+sO0eatQJH9O7DpwXKU11az8GyqW/kWVHTNlMeLFj4N2TWuqf8fzcEWpmp3Rt0sz5M2ZRX22eOVW7Nx/HO8/eOK7ZIkxdVRPxIsbGxu27seVm7fRv2sLODs74597D5AmZQq4uDhbcIaM8BpgMcJr0bBhYRKwOQEKr82RhlqhLsK7fd9J/D5zgDqYa7fuo07bYWqimJuri/osb7m22LJkJFIkS4SCFdtj/sReyJYxtfrbrbsPlaTuXzsJnQdNR8J4cdC6UWUkT+IfQZVt2fo9OHH2CuaN7xHqCW/edQwHj/+FGSM7BxLekNoOTnhP/3UdzbuNw6UDi/He86NZDq8cjOT3LpnaB/Hj+ucpMoc31C5igXAiEJrwnrlwBWOnL8WMMb2RInmSQEe5+8BxTJr9O6qWL44WDarhzv3/0G/EDAzr1w45s2bA4DFzkDbND2hcp6JReKs06YvmDaqiWKFc6jO5WfX86IWr1+/g5p37aFa/irpObP7jEI6cOI+OLesgbeofrCbECK8/Ogqv1UOIO5KATQhQeG2C0aJKdBHek+evYerwjurA7j54goYdR+LENv8JYLIVrdYZiyb3RvIkCZG/QjukTJFUpSzI5ufnhw+en3Bsyww8ef4a0xduxJFTF5EoQTy0aVRJTZAbN2u1SiuQ1IiA28vX7zB+1mpcun5XlZE0idQpk6m8W9OUBvmRDantkCK8w6csw5mdgSO8UufcFdtw+sJ1rJs3BA4ODhRei4YnC+tJICTh/evKTYyatAjD+rRBlow/BXlYB4+dxZipi7F5+SR4/P+ktrHTliB+vDho06SGpgivacVT561C4oTx0aBmOfW9Xbl+Jw4fP4cvX7xRpmQhNK1X2Xid0MqJwkvh1TpWWI4E7EmAwmtPukHXHaGEV6KhIp2rZg3ET6lSBEvj2zc/nDh3BR36TcWhjVOxfd+JYCO8fUbOQ2wPd/RsV0fl9m7dcxzrtx9WEeeAObwhtR2c8ErU2cfHF3PGdgsyh/fegyeo2LifStmQlR0Y4dV/kLNFbQSCE16ZTDZ0wjwM6tEKP2dNH2xl9x88RqtuI4IVXsnhvXj5FsYP7aLq+OLliYoNg87hlb9Pm7sSPr7fAk2Qe/DoKfqPnIm2TWuiSP6ftZ3c/5ei8FJ4LRowLEwCdiJA4bUT2BCqjXDCO2nuOly//S9G9mmhJn5JHqzk6v6SPxtEOvP+nBEJ4sXGjdsPULftMBzdMkNFfCo06otBXRujbMn8Zjm8kg5RKE9WNKzxG7w+e6N1r4kqahyU8IbWtukqDQ+fvMTqLQewdfefwa7S8PHjZxXh3bb3OI5tnqGiURRe/Qc5W9RGICjhvXbrHgaOmqWkM/f/r5Ygz15k0qdssopDooTxkS+Xfw5upz5jkTnjT2jRoCru/vsIvYdOw/B+7ZQoP376Aq27j8SA7i3wc5b0mL9sA54+f61WaZBUhj0HT6JAnmyI5R4TF6/cwvgZS9GtXQOU+iWfmuyWOFECNRlO8nu79J+Itk1qoEDe7NpOjsJrxokpDRYNGxYmAZsToPDaHGmoFUY44ZW0g3krtitJlMkxSRPHR61KxdGkVhkMn7Ic+4+eU483JVraoWk1lC+VX53kxau3VerC7fuP1GS3do0ro06VkkqMB4xdCPeYbuoxa5b0qXDqwrUghTektk3X4ZXJdf7r8KZHq4YVg12HV9qUtYh7tK2Dn7OkVcdJ4Q11TLJAOBEISnjHz1iGfYdPmR2RCOmWFZPVZ5Kjm+6nH9G8fmX172fPX6k83qs376i1dOtWK4PyvxUx7v/n6YuYt3QDXr99b7YOr5fXF4yYtAA3/rmPL97eSJY4ISqVLYqq5UsYxXrN5j14+85TfZdLlyiIZvUrqzQhSzZGeP1pUXgtGTUsSwK2J0DhtT3T0GoMs/CG1gD/bk6AwssREVEJhDZpzdbHLas0ePv44tMXX1tXHWx9FF4Kr26DjQ2RQAgEKLz6Dw8Kr87MKbw6A2dzmglQeINGxTetaR5CLEgCJKCRAIVXIygbFqPw2hCmlqoovFoosUx4EKDwUnjDY9yxTRKIjgQovPr3OoVXZ+YUXp2BsznNBCi8FF7Ng4UFSYAEwkSAwhsmfFbtTOG1Cpv1O1F4rWfHPe1LgMJL4bXvCGPtJEACBgIUXv3HAoVXZ+YUXp2BsznNBCi8FF7Ng4UFSYAEwkSAwhsmfFbtTOG1Cpv1O1F4rWfHPe1LgMJL4bXvCGPtJEACjPCG3xig8OrMnsKrM3A2p5kAhZfCq3mwsCAJkECYCDDCGyZ8Vu1M4bUKm/U7UXitZ8c97UuAwkvhte8IY+0kQAKM8IbfGKDw6syewqszcDanmQCFl8KrebCwIAmQQJgIMMIbJnxW7UzhtQqb9TtReK1nxz3tS4DCS+G17whj7SRAAozwht8YoPDqzJ7CqzNwNqeZAIWXwqt5sLAgCZBAmAgwwhsmfFbtTOG1Cpv1O1F4rWfHPe1LgMJL4bXvCGPtJEACjPCG3xig8OrMnsKrM3A2p5kAhZfCq3mwsCAJkECYCDDCGyZ8Vu1M4bUKm/U7rd9xGE6ODgAc4Pvtm/UVWbing4MDnB0d4OOrX5tyjq7ODvD+qmeb2sA4OToC8IPvNz9tO9iglKOjAxwdHPBVxz5Q/e7kAB8NfeDo6IiUKX9AiuTJbHC2oVcRz8MV3j6++PTFN/TCNirhEcMZ0g/vP/lortHdzQlyrFFpe3JzH15fnBaVTonnQgKRigCFV//uovDqzPzxKy/EcvP/0f3gpf1HN6yH6ebsiFgxXfD6w5ewVqV5fznHxHHc8OztZ8376FUwdkwXfPPzw8fPX/VqEu6uTnBxccK7j966teni5IC4sVzx8r1+/a715Ci8WknZvhyF1/ZMWSMJWEKAwmsJLduUpfDahqPmWkR4rYkyaW4gmIJuLo7wiOmCVzqKjwhvkrhuePom4glvHHd/4fX00lF43Zzg6uKEt576Cq+I5Yt3FF75aljz3WOEN6xXH+5PAiQQkACFV/8xQeHVmTmFV2fgwTRH4Q3/fmCEN/z6gBHe8GPPlklACFB49R8HFF6dmVN4dQZO4VX5p4zw+g8ERnj9OVB4I8Z1iEcRfQlQePXvewqvzswpvDoDp/BSeE3GAIWXwhsxrkA8iuhOgMKr/wig8OrMnMKrM3AKL4WXwhvoW8AIb8S4DvEooi8BCq/+fU/h1Zk5hVdn4BReCi+Fl8IbMS47PAoSMBKg8Oo/GCi8OjOn8OoMnMJL4aXwUngjxmWHR0ECFN5wHAMUXp3h/3n+JlydHeWdDPD20e+FDE5O8hIIR3jpuMi/gwPg7uas61q3WrvT1cVR3juh60sxZE1c6YfP3vr1e8L4sZE2ZTJOWvv/gcEcXn8QTGnQeqVgORKwDwFGeO3DNaRaKbw6M0+drajOLbK56ErA1cUFkyaMQpli+Si8FF6zrwGFN7peFXjeEYUAhVf/nqDw6sw8VtJMOrfI5qIrAVdXFyxbNBfl/o+9s4Cu4trC8B8nuGuLu5dihZZS6CsUd3d3dwju7u5uLe6lOC1SoIUCxYs7hIQoIW+dk+Y2gSQzZ2buRfrPWm/1kdn7zJlv5H533zNnShWl8FJ4I10Gdy/vh++NHf/VS4P7TQLvnICzZ0p4ZmkAJ9e4b/VFvA4+cTwPPHzjLaWpk3i+835/yB2g8Dr46FF4HQz8P7w5Cu/bB59DGsKYPPMJQkBwyDu/Ojw9XCDGd/kHOu6Nh0Z3Ok4sV7x6HYrAoHfPLbp9iOXuAhdnp/dyGJnoc6J47njuG4zQ0FCjh8EueWKuch+/YIS8dmy/osNA4bXLYQaF1z5co22Vwutg4P/hzVF4KbzRnf7i9dZ+DhzPH10/4nm6Ak5OUjbe9yVBHDcEh4TCL+D9lXMh5UKWvF++nzxTJIolf2167WCx1Dq3kieMhac+gXgV4ljhja5fFF6tI2ZsPYXXGDfDWRRew+iYqEiAwkvhpfAqXjQxhFN4zbOk8OpjSOHVx0k1isKrSsxkPIXXJECm6yZA4aXwUnh1Xy6agRReTUSaARReTUQygMKrj5NqFIVXlZjJeAqvSYBM102AwkvhpfDqvlw0Aym8mog0Ayi8mogovPoQGYqi8BrCZjyJwmucHTPVCFB4KbwUXrVrJqZoCq95lhRefQxZ4dXHSTWKwqtKzGQ8hdckQKbrJkDhpfBSeHVfLpqBFF5NRJoBFF5NRKzw6kNkKIrCawib8SQKr3F2zFQjQOGl8FJ41a4ZVnit4xVVSxRefXxZ4dXHSTWKwqtKzGQ8hdckQKbrJkDhpfBSeHVfLpqBrPBqItIMoPBqImKFVx8iQ1EUXkPYjCdReI2zY6YaAQovhZfCq3bNsMJrHS9WeI2zZIXXOLuYMim89uEabasUXgcD/w9vjsJL4aXwWncDYIXXPEtWePUxpPDq46QaZVfh3bX/BLoNniH75ObqgrRpUqBdkyoo+01h1X7a4r+p0QXTRnRG7mwZDLcRU+KjJ88xatpKHDt9HgEBQfgkdTLUqVwKdauUlmnBr0IwZ+lmbNp9BA+xlphWAAAgAElEQVQfPUOqFElQo8LXaFanHJydnWTM8MnLEBgUjGG9mr21KQqvXQ4bG42CQFTCK87vyXNW4tKVG3ju7YM180cjcaIE0fK7dec+ps5djYtXriNRgvhoXr8Kvi7+uS3+6TNvzFi4DidOnYOTkxNKflkQXdvUt61fumYrNu7Yj5BXIShVojDaN68FVxfxOllAvM4zKDjEoW/84quFww4N37Smfsug8KozezODwquPIYVXHyfVKLsL76S567B12SgEBb3Cpl2HMXraSuxcOVaKopHFjPCK93eLVxq6uDhHu+k2vSfCM5Y7+nSoj3hxY+PK9du4++CJTdJ7DJ2FS1dvYUjPpsia8VOcv3QDXmMXokTRvOjXqQGF18hBZY5dCEQlvE+ePsfRE38gTcpk6D10aozC+yokBC27DEPxwvnQoGZ5/HXlBrxGzcTkkT2RMV0aiOupY+8xSJ8uDepULQMPD3fcunsfBfJkl/uz9+BxzF36I0YP7Ig4sWOj3/Dp+Kb456hfsxyF1y5HXH+jFF79rMIjKbzqzCi8xphReI1x08pyiPAKwQ1fPvuuJaYO64QCebJg1LQVOPDLGbi5uaJymS/RoWlVKaN+/gHoP3o+jp26ID9UP02THEum9MO4Wauxbss+JE4YX+Z0bFYNFf9XDFMX/ID1Ww8glocbWjeqhMHjF+PU7nnwcHdD9yEzkSRRAly+fgu37z3GjJFdEBQcLMX78vXbSJU8Cfp0qIein+eUXSxRtRNG9GmJr4rkeYvdH+evon6H4diyZBTSf5rStl5Ib63WQ7Bt2Wik+yQFK7xaZx3XO4RATEMavF/4oEbTXjEK742bd9Gq23BsXjEZsTzcZZ+HjZ+LZEkTo02TGlKcZy9ah0XThkT5JVIIde7smdCwVnmZ+9OBY1i2dhuWzBgKf/8ATJmzHCfOXETo61CkSpkUE4Z2R6xYYdux18IKbxhZCq/6GUbhVWdG4TXGjMJrjJtWlkOFd//RM+jQfwq2Lx+NBau24/7Dpxg3sC1e+gWgdc/xqFmxJBrW+A6L1+zEqXOXMN6rLVxdXXH+8g1ky/iplNw3K7wbdhzCvBVbsWBibySIFwf9Rs3DnoMnIwnv739ewcqZA5E8aUI8fuqNSo37YVD3xvj2q4I4dfYSOg+chs2LRyJp4gTo7DVNVnSb1y2HfDkzRapEz166GXsPn8K6uYPf4lquQW80qllGDn/gkAat047rHUHArPBe+/sO2nQfgS0rp8gvj+HC6/PSH2MHdcbCFZsghjwEBb/C2fNX5BfTNk1qIk/OzDK2Tos+6NS6HooVyiv/ff3mHbTqOhxbV03Flh0H8NfVaxjUvQWCQpxw+fpNZEybRl7j9lwovBReo+cXhdcouX/zOKRBH0MKrz5OqlF2F94eQ2ciUYJ48kPR2ckJHZpVQ72qpVGwbCssndoPObOml33esvsolq7fLWVy+Q97sHPfcQzo0hDZM6eNtE9vCm+b3hPwVZF8qF/tWxl38cpNVG8xMJLwfpo6Obq0rCHXL1u/G0dOnMPsMd1s7QrJLVksP6p+/xX8/AOxdN0u/HToN1y+dhsZ0qaS/SiYL5usSN+88xCzRnd9i3PjzqNQpEBOtGtcmcKrehYy3i4EzAqvGK/eovMQfF28IBrWLIe/rvyNPsOmIlP6TzBlZE+MmbpYVm37dmmG4kXyY9fPR7F45WYsnjEU8ePFQeUGXTGkT1vkz51V7t/Dx89Qv3U/rF80Fj8fOokjx06ja+s6SJMmtV32P6pGKbwUXqMnG4XXKDkKryo5Cq8qMX3xdhfe8bPXYNVML1m5ERVYsfj4+qFohXY4smk6EiaIK/8mKq1dB83AgR+nyAe+Zi3ZhB0/H0NAYJAU0U7Nq8uHwt4U3mrNveRQiFJfFpDtPPf2RfHKHSIJrxg+Ub/a/+T6MTNWYeOOQ0icKL6NkH9AIBrVKIMmtctGoiaGVoiq7rot+/Hz+slYsnYnK7z6zitGvQcEzAqv2AUxrGHGgrW4euM2Pk2TAmk/SSWHHHl1b4HJs1bg4tW/MXt8P9ve1m3VF51b1UPRgnlirPCKhPWbdmH3/uMICAhEmVLF0KRuJduDn/bCR+Gl8Bo9tyi8RslReFXJUXhViemLt7vwiofWIo7hDe9WTBXeiF2/dvMeWveagN7t6+Lbrz5H6ZrdMGV4R9ssDWJdiaIxV3gL5MlqqwAvWbcLYojDxMHtdRF6+twHX1XpiK1LR+GFrx8adBiOrUvDxuqGL2IMb81Wg7F58QhkSp+GFV5dZBlkbwJWCO+bfew5aDKKFMiNGpW/xaYdB7Bj75FohVeM4c2bI7PtITXxEJuYtUGM4RVL+CwNF6/dkQ+0iXHBXxbJb1csFF4Kr9ETjMJrlByFV5UchVeVmL74dya8YmYDMUXSOK82eOkfIKW2erkSchzsr7+dl2Nn06ZJjucvfFG//XD0aldXDjsQYtm09vcoV7qI3MPwMbwLJ/VG/LhRj+GNKLxim1WaDcCAzg3xbYmCCH39Gn9cuIY0KZPKbY6buRplShZC5gxpZKV57vKtcrjFvvWTZJVaTLN25cZdDOnRBNkyiVka/saAMQuQJ0cGjPNqK/skxvCKqvHAbo1tR0FMWCYEhNOS6TsxGWWeQHTCK87rFz4vUa9VXyyfNRwJE8a3jdHdvucwkiZJhMIFcskOnL90HSmSJpL/X8jtlp0HsXj6UHh6ekBMSdakw2B0b98AxQqHDWkQ43oXTx8ihzSI4Q4Llm/A2MFdENszlpTaEl8UkAJ8+o+LyJQuBVIkS4L7j73Rud94tGlcHUX/Ge9rfu+jboHCS+E1em5ReI2So/CqkqPwqhLTF//OhNf3pb8cE3vw19/h6uoSNktDs6pyjk4x44J4EE1UV+PEjoUqZb9E5xbV5Tyf4oE0kSfG2nZvUwvVy32NyfPW4cfth+QsDc3rlceIKcvx+08L5JPjYpaGiMIb9iF+Q874cPHyTTi7OCNP9gzw6tpYSu+U+T/IYQt37j2Cu5srcmZLj26taiFXtrCxxmJc46wlG7F51xHcf/RMziJRq2JJ9OlY3yYNQnhXbdwb6QgImf5pzQQKr77zklEWEIhKeMVUY9/X6vBW6+JBMvFgWt9h05AlUzo0q1dJxixevQWbtu+XM5vkyp5JzqOb7pNUtvxTZy9i5vy1uPfwMdJ/mgrtmtWSceHLktVbsWnn2/PwCrFeu3E3nnn7wDOWB7775gs0rVdJXuP2XCi8FF6j5xeF1yg5Cq8qOQqvKjF98XYVXn1dsDZKyGy7vpOx/4fJ1jYcTWtiCrRrN+9i3vieNuGNacOs8DrksHAj//yisGTBbHxfqigeeQe+d0z44ol3d0g4LZk6ewqvOrM3MzhLgz6GFF59nFSjPnjhDQ5+hV9PnUfxQnng6+ePXsNm4ZNUyeXMCo5YRMVMzOqQP1dmWUnWWii8WoS43ioCfLXw2yRZ4WWF1+j1ReE1So4VXlVyFF5VYvriP3jhDQoKRv0OI3Dr7kP5+uLihfOgf6cG8i1p7+NC4X0fj8rH2ScKL4U3ujObFV71a57Cq86MFV5jzCi8xrhpZX3wwqu1g+/begrv+3ZEPt7+UHgpvBRe665vCq95lhzSoI8hhVcfJ9UoCq8qMZPxFF6TAJmumwCFl8JL4dV9uWgGUng1EWkGUHg1EckACq8+TqpRFF5VYibjKbwmATJdNwEKL4WXwqv7ctEMpPBqItIMoPBqIqLw6kNkKIrCawib8SQKr3F2zFQjQOGl8FJ41a6ZmKIpvOZZUnj1MWSFVx8n1SgKryoxk/EUXpMAma6bAIWXwkvh1X25aAZSeDURaQZQeDURscKrD5GhKAqvIWzGkyi8xtkxU40AhZfCS+FVu2ZY4bWOV1QtUXj18WWFVx8n1SgKryoxk/EUXpMAma6bAIWXwkvh1X25aAaywquJSDOAwquJiBVefYgMRVF4DWEznkThNc6OmWoEKLwUXgqv2jXDCq91vFjhNc6SFV7j7GLKpPDah2u0rVJ4HQz8P7w5Ci+FN7rT/5lPEAKCQ/RfHaFOCEWo/nidkfE8XQEnJ/j4BevMeHdhrPCaZ88Krz6GFF59nFSjKLyqxEzGU3hNAmS6bgIUXgpvdCfL3cv74Xtjh65zycktPmJlqgWX2J/oilcJovCq0NKOjRPLVc7h6v3y/fwCQeHVPoYigsKrj5NqFIVXlZjJ+Ix5vzbZAtNJQB8BNzdXTBwzEt+VLIRH3oH6khwYlTCuO4KCQ+AXqFBpNNm/uLFc4ezshBcKFcXYHi4Qff2Ylnt/7cHTM1N07ZKTRxLE+6wfXOKm1RWvEkThVaGlHUvh1WYUVUTyhLHw1CcQr0Ks/xXDSI8ovEaoaedQeLUZWRpx5Le/4ObiBCdnICjYcReXizPg5uqCgCDHyQWcgDgeLngZ4MBt6jxa7m5OCA0Fgl857hiIm5iLsxMCg1/r7KX5sCSJ4iNT2hQU3n9QUnjDQFB41a8tDmlQZ/ZmBiu8+hhSePVxUo2i8KoSMxl/94k/jHzomtwsPNycEdfTDU9eOK7SJyppyRN44P6zALPdtzw/fmw3vA4Nha//K8vbjq5BUSl0d3PBc98gh21TfLkS1UlWeMOQG7n2WOFlhVecOxRe87ctCq8+hhRefZxUoyi8qsRMxlN4TQK0KJ3CaxFIE81wSIMJeCZTWeFVB0jhVWfGCq8xZhReY9y0sii8WoQsXk/htRioweYovAbBWZhG4bUQpmJTFF5FYKzwqgOLIoMVXn0YKbz6OKlGUXhViZmMp/CaBGhROoXXIpAmmqHwmoBnMpXCqw6QFV51ZqzwGmNG4TXGTSuLwqtFyOL1FF6LgRpsjsJrEJyFaRReC2EqNkXhVQTGCq86MFZ4DTOj8BpGF2Mihdc+XKNtlcLrYODRbI7C++6PA4X33R0DCq86e1Z41ZmxwmuMGYXXGDetLAqvFiGL11N4LQZqsDkKr0FwFqZReC2EqdgUhVcRGCu86sBY4TXMjMJrGB0rvPZBZ6zVu0/9EdfDFU7OTvDxd9zbcMS0ZHFiucnJtR21iGnJksX3wIPn79+0ZPE83RAqpiULcOC0ZO4ucHNzgfdLO09LFmFqYU5LFvls57RkYTwovOp3QVZ41ZmxwmuMGYXXGDetLFZ4tQhZvH7d1n3y5QOAE0JeO+4FBE5OTnB1dkJwiOO2KfbR3dUJQa8cuU19B8zF2RlAKEJeO+7FE+ILgLOTE17Z8Ri4OLsgXdp0SJUquQRB4aXwRnVFUHj13SciRlF41ZlReI0xo/Aa46aVReHVImTx+jgpcljcIpsjgX8JJE6cCPPnTEeeXGHnGYWXwkvhteYOQeE1z5HTkuljSOHVx0k1isKrSsxkPIXXJECmx0iAwhvzCcIhDWF8WOFVv5FQeNWZscJrjBmF1xg3rSwKrxYhi9dTeC0GyuYiEaDwUnj1XBIUXj2UIsdQeNWZUXiNMaPwGuOmlUXh1SJk8XoKr8VA2RyFV+EcYIWXFV6F0yVSKIXXKLl/8zikQR9DCq8+TqpRFF5VYibjKbwmATI9RgKs8LLCq+cSYYVXDyVWeNUpxZxB4dVHlMKrj5NqFIVXlZjJeAqvSYBMp/CaOAdY4WWF1+jpwwqvUXKs8KqSo/CqEtMXT+HVx8myKAqvZSjZUBQEWOFlhVfPhcEKrx5KrPCqU2KF1wpmFF4rKL7dBoXXPlyjbZXC62Dg/7HNUXgpvHpOeQqvHkoUXnVKFF4rmFF4raBI4bUPRYVWKbwKsBiqTIDCS+HVc9JQePVQovCqU6LwWsGMwmsFRQqvfSgqtErhVYDFUGUCFF4Kr56ThsKrhxKFV50ShdcKZhReKyhSeO1DUaFVCq8CLIYqE6DwUnj1nDQUXj2UKLzqlCi8VjCj8FpBkcJrH4oKrVJ4FWAxVJkAhZfCq+ekofDqoUThVadE4bWCGYXXCooUXtMUN+w4hN0HTmLW6K6G2qLwGsLGJJ0EKLwUXj2nCoVXDyUKrzolCq8VzCi8VlD8jwjvpl1HMH/FVty+/xjx4ngiV7YMGNarGZImTiAJPH7qjYlz1uLAr7/jpV8AsmT4BO2aVMY3xT6zEarUpD9a1iuPit8Vi0Tt2s17uHXnIb7+Ip/8+zc1umDaiM7InS2DriNE4dWFiUEGCUQlvBf/uowZSzbh8rWbSJo4ERZNGxxj60eP/46FKzfj3oNHSJYkIerVKIfvShaVOSfPnMfqH3fJttzc3FDk89xo07QG4sWJLdf7+Qdg4qzl+PXkWXntidyKZUpEub2Ecd0RFBwCv8AQg3urnsZ5eMOYUXjVzx3Ow6vO7M0MvnhCH0MKrz5OqlEf3bRkZy9cQ9OuozFxcHsUKZAT3i9e4siJsyheKA+SJ00oBbdmq0HInCENurWqhUQJ42HfkdMYMWU5hvdujjIlC0mG0Qnvm4ApvKqnHOPtSSAq4b156xbOX72LZ89eYNuewzEKr/cLH9Rt2RedWtVF6RJFcObcXxg0ehZmTxyAtGlSYvuew/DwcEeenFngHxCA8dOXIt2nqdGjfUO5W0J2791/hP7dWuDWnQfoP2I6RvTvgDw5M7+12xRee54JMbdN4VVnT+FVZ0bhNcaMwmuMm1bWRye8azb9jA07D2P1rIFR7vv8lduwdvM+bF8xBq4uLraYxWt3Yvn63dizZgKcnJyiFd6IQxqGTlqKdVv2IXHC+HBzc0XHZtVQuUxxbN59BPOWb8Wjp97IlS09hvZshjQpk8ptscKrdUpyvRkCMQ1pOHD0FBav2hyj8F65fgvte43CzrUz5HUgliYdBqJlw+ooXiTsV42Iy95Dx7Fy3Q4smDoIwa9CUK1xN4zo1wF5c2WRYRNmLpf/7d6uAfz9AzB+xlKcPnsJCA3FJ2mSY9rIHgh1+vc6NLPvenJZ4Q2jROHVc7ZEjqHwqjOj8BpjRuE1xk0r66MT3otXbqJOmyFoVrccvv4iP7JnTgsPdzcbh+bdxsq/9WxXJxKbR0+eo2T1Lti8ZCQypUutS3hFA29WeA8fPwuvsQswa3Q3WUVetm43du47jtWzB0qBoPBqnZJcb4aAWeF9/ToUfYZNRakvC6L010Vx5uxFjJ66GPMneSFRwvhvdW36/NV45u0Lr+4tcPvuQzTtOAgbl01EnNieMnbj9v0QUjxtVC+s3/QTzv11Bf26NIerqyvu37+LdJ+kRvDrMLF2xELhpfAaPc8ovEbJ/ZvHIQ36GFJ49XFSjfrohFcAOHX2Epb/sAcnf/9LjimsUvYr9GpXB+7ubqjW3AsV/1cMTet8H4mV+KDPU6oplkzpi4L5shkW3o4DpuKz3JnRrE452X5oaCi+rNIRa+cMllVeCq/qKcp4FQJmhVdsa+/B45g6d5W8dtxcXdC9QyOU/qrwW904fuqclGEhs2lSJceVazfRtuco7F4/01Yd3nPgV6zZsAfzJ3thw7Z9OHD0N3RoURuZM3wKDmlQObLWxrLCq86TwqvO7M0MCq8+hhRefZxUoz5K4Y0I4c+/bqCz11TUrlwKLetXgL0rvNVbDMTT5y8Q2zOWrRs+vn7ywbZ8OTNReFXPUMYrETArvBcuXUf3gRMxpHcb5M+THdf+vo0BI2ZgQLcWyJc7q60vp8/9hRETFmBI79bIlT2T/LtWhTcwKBgr1m3H/iMnERgYhEplv0LzepUQEPxaaR/NBLPCG0aPwqt+FlF41ZlReI0xo/Aa46aV9dELrwAwbNJSePu8xPiBbTFvxVas33oA25aPfmsM76LVO/DzuklwcXHWXeEtXbMbpgzvaJuloUO/KSheODfqVikdJXtWeLVOSa43Q8Cs8IqH0rbuPoSZ4/raujF03Fx8kiYlmtWrJP929vwVDB43B17dWyJ/BAkWY3irNuqG0V4dkTtH2ENq4iG20NCwMbwRl5t37kuR7tiiJgoVyGtml5VyKbwUXqUTJkIwhdcouX/zWOHVx5DCq4+TatRHJ7z7j57Bo6fP8WXhvEiSMB7OX/4bXQdNR9Pa36NRzTLwfekvZ2nImvFTdG1VE4kTxZezNAybtAS92tdDrYolJUMxS0PT2mVRrnTYdExicXZ2xtY9RyPNw1uz1WDZdrnSRWTMoWN/YMiExZg8rCNyZU0vt3f05DmUKRn2kzCFV/UUZbwKgaiEN35sN9x98hJHjp3B0jVbMWfiADg7OckHLcUiJDdpkkQoXCAXxENrXfqPx7A+bZEvdzZcu3ELvYdNQ6eWdfB1sc9x/tJ1KapiVobP8+eU+WIErhguJBbxkNrDx0/Rv1tzWfHtO3QqhvdrL2dpOP3HRSRLmhhpUiXDCx9fdBswAR2a1cRn+XOp7KKpWAovhdfoCUThNUqOwqtKjsKrSkxf/EcnvOf+uo6ZizdCTE/m89IfKZImQoX/fYH2TarC2Tns4RjxgNqEOWtx8Nff5bRl4mGywd2boEaFr23UhPBevXEnEkUxA0Oh/NkjCe+egycxatoK+PkHonubWqhZoSS27z2Gucu34I6YBziuJwp/lgOj+7Wi8Oo7JxllgkB08/C26T0hUqvZs6THtNG95d/6DpuGLJnS2Sq4u/f/ilU/7JTimjB+XJQtVQwNa1eQsWOnLcGe/b9Gaks8oCYeVBOLGPcrpPfYb2cRxzMWGtQqb5uHV4j16g278NzbF7E9PVCxzJdoUb8S/IM4pMHEITeUyiEN6tgovOrM3sxghVcfQwqvPk6qUR+d8KoCEKLaqNNIFP08J3q0qa2arhzPCq8yMiYoEOCb1mKGxQpvGB8Kr8JF9U8ohVedGYXXGDMKrzFuWln/eeEVgETFd92W/ahWvgRSJkusxczUegqvKXxM1iBA4aXw6rlIKLx6KEWOofCqM6PwGmNG4TXGTSuLwqtFyOL1FF6LgbK5SAQovBRePZcEhVcPJQqvOqWYMzikQR9RCq8+TqpRFF5VYibjKbwmATI9RgIUXgqvnkuEwquHEoVXnRKF1wpmFF4rKL7dBoXXPlyjbZXC62Dg/7HNUXgpvHpOeQqvHkoUXnVKFF4rmFF4raBI4bUPRYVWKbwKsBiqTIDCS+HVc9JQePVQovCqU6LwWsGMwmsFRQqvfSgqtErhVYDFUGUCFF4Kr56ThsKrhxKFV50ShdcKZhReKyhSeO1DUaFVCq8CLIYqE6DwUnj1nDQUXj2UKLzqlCi8VjCj8FpBkcJrH4oKrVJ4FWAxVJkAhZfCq+ekofDqoUThVadE4bWCGYXXCooUXvtQVGiVwqsAi6HKBCi8FF49Jw2FVw8lCq86JQqvFcwovFZQpPDah6JCqxReBVgMVSZA4aXw6jlpKLx6KFF41SlReK1gRuG1giKF1z4UFVql8CrAYqgyAQovhVfPSUPh1UOJwqtOicJrBTMKrxUUKbz2oajQKoVXARZDlQlQeCm8ek4aCq8eShRedUoUXiuYUXitoEjhtQ9FhVZLVWygEM1QElAjEC9ePHTq0BY5smWRiW4uTkgY1x2PvAPVGnJAtOhXUHAI/AJDHLC1sE3EjeUKZ2cnvPAL1r3N2B4ukuHHtFB41Y9mgjhuCA4JhV/AK/VkB2XEieUKIUveL/Wf3w7qmtwMXy2sjzaFVx8n1Si+aU2VmMn4e0/94enuAicnJ/gFOu7G6ebqDE93V7zwCzK5B/rTxT4miuuGpz6O26be3sX2cEUoQuHvQNnycHOBOA6+/vb9MAoN/ZcChTfyGUHhDeNB4dV7p/g3jsKrzuzNDAqvPoYUXn2cVKMovKrETMbffeJvqMpkcrPwcHNGXE83PHnhuEqfqKQlT+CB+88CzHbf8vz4sd3wOjQUvv6O+9IhKoXubi547uu4LwAUXgpvVBcPhVf9lkLhVWdG4TXGjMJrjJtWFoVXi5DF6ym8FgM12ByF1yA4C9M4pMFCmIpNUXgVgQGg8Kozo/AaY0bhNcZNK4vCq0XI4vUUXouBGmyOwmsQnIVpFF4LYSo2ReFVBEbhVQcWRQaHNOjDSOHVx0k1isKrSsxkPIXXJECL0im8FoE00QyF1wQ8k6kUXnWArPCqM2OF1xgzCq8xblpZFF4tQhavp/BaDNRgcxReg+AsTKPwWghTsSkKryIwVnjVgbHCa5gZhdcwuhgTKbz24RptqxReBwOPZnMU3nd/HCi87+4YUHjV2bPCq86MFV5jzCi8xrhpZVF4tQhZvJ7CazFQg81ReA2CszCNwmshTMWmKLyKwFjhVQfGCq9hZhRew+hY4bUPOmOt3n0agNhiHl5nJ7x04ATm7q5O8PRwg/dLx02J5ezkhMTx3PD4hQO2GXHyWR2HhsKrA5KdQyi8dgYcQ/MUXnX2rPCqM2OF1xgzCq8xblpZrPBqEbJ4fY9BE+HsBDg5ASGvLW48hubENp2dgVeOe6mV3EcXZye8ConwJgQ77fI3X3+Jz/Ll0d06hVc3KrsFUnjthlazYQqvJqK3Aii86swovMaYUXiNcdPKovBqEbJ4fZwUOSxukc0JAlMnjcX3330LOOnjQeHVx8meURTe6OmWqNoJCyb2QpYMn9jlEFB41bFSeNWZUXiNMaPwGuOmlUXh1SJk8XoKr8VA/2mOwhs1V75pLTIXq14tvGv/CXQbPEM27ubqgqSJE+DzvNnQon55SyQ1JuGt1KQ/rt64I7cdJ3YsZEyXGhW+/QJ1q5SGi4uz/PvwycuwauNe+f9dXVyQNk1ydGxeHd99XVD+zQrhXbpmKzbu2I+QVyEoVaIw2jevJbf15nLn3iMsXLkRZ89fQUBAELJnTY92TWsifdrUiOfpirVbfsbGHYdw595DJIgfF+X/9yXqVf/e1kz/kTNx/Leztn/Hie2Jjcsm2udGEkOrFF7zyDkPrz6GFF59nFSjKLyqxEzGU3hNAowmncJL4dVzZlkpvJPmrsPWZaMQFBSMW3cfYeWGn7Bl91Esm9YfubKl19OdaGO0hFWCwIMAACAASURBVLd53XIo/21RPHrijd//vILxs9cgb46MmDi4vU14AwKDMLhHEwQHh2D3gRMYNG4hflo7Ucq5WeHde/A45i79EaMHdkSc2LHRb/h0fFP8c9SvWe6tfTp34Qr+/OsaviiUF7E9PbF0zRac/uMils0aLoV31pINyJEtEzKkTYObdx5g6Pi5aNOkBr4rWVS2JYS3WKE8+PbrsH+LH3Hc3d1M8TWSTOE1Qi1yDoVXH0MKrz5OqlEUXlViJuMpvCYBUniVALLCGxmX1cK7c+XYSBvoOGAqgoNfYfaYbjh19hK8xi7EtmWjbTHVmnuhZ9s6+KJgLvm3jTsPY+Gq7bj38AmSJ02E4b2b47PcWRBReP84fxVdBk3HsF7NUbxQbogKb8t65VHxu2K2ds9fuoFarYdg1ayByJM9g6zwBgYFY1ivZraYAt+1lMMkRPtmhbf30KnInT0TGtYqL9v/6cAxLFu7DUtmDNU8Px8/9Ubdln2wdsEYpE2VWD7Q4OMXbMubNHsFnJ2d0blVXZvwliiaH2VK/bu/4cH+/gEYP2MpTp+9BISGIlXKpJgwtDtixXLX7IdqAIVXldjb8RRefQwpvPo4qUZReFWJmYyn8JoESOFVAkjhdazwbt3zC4ZMXIITO2ZrCu++o6cxaNwiTB3eCflyZsKd+4/x+nWoHH4QLrxPnr1A35FzMWFQexTIk0XuTFTCK/7+ff1eqF25FJrUKhtJeIWA7zn4GwZPWCQrvPHjxjYtvHVa9EGn1vVQrFBe2afrN++gVdfh2LpqKjw0qq8HfzmNGQvWYPW8URBj6SMKb2hoKNp0H4EKZUqgYpkSNuG9fuO2/P+fpE6BujXK4rPc2eS/12/6Cef+uoJ+XZrD1dUVl6/fRMa0aeDm5qp0negJpvDqoRRzDIVXH0MKrz5OqlEUXlViJuMpvCYBUniVAFJ4HSu8x05fQLOuY/DH3oX4/fyVGCu8HfpNQf7cmdGiXliVNOIihLdB9f9hzaZ9mD6yM3JkSWdbHZ3wNuo0EgXzZUOn5tUjjeEVic7OTujbsQHqVS0t2zFb4a3coCuG9GmL/LmzyvYePn6G+q37Yf2isUgQP1605+iDh0/Qqe9YtGteC18X+1wOaYgovAtXbMKJM+cxZUQP27CFY7+dReKE8eERywNHjp2RleTpY/ogY7o02LBtHw4c/Q0dWtRG5gyfKl0bqsEUXlVib8dTePUxpPDq46QaReFVJWYynsJrEiCFVwkghdexwisqvEMnLcHx7doV3uotBqJVg4ooU7JQlMIrqp1lvymM/p0bRlofU4W3TpXSaFyzTKQKb0jIa1y+fhttek/EwK6NUOrLAqaF10iFVwxl6DFwAip//w2qlv9G7lNE4V29YRd27/sVE4Z2RaKE8aM9z/uPmIHsmdOhYe0KctjGinXbsf/ISQQGBslhD03qVpKCb/VC4TVPlMKrjyGFVx8n1SgKryoxk/EUXpMAKbxKACm8jhXeTl5iDG8IZo3uiguX/0Ynr2nYs3q8rROlanbFiN4t5BherQrvWK82GDF5GSqVKY6W9SvY2ohKeC9euYkaLQdh9eyByJ0t6jG8PYbOQrw4nhjUvYlp4RVjePPmyGx7SE08xCZmbYhuDO/TZ97o5jURZUsXQ52qZWz7Ei68i1bvwJZdBzFhWHf5UF1My6Axs5EhXRo0qVMxUtjNO/flw3Pigbcvi+RXuk70BFN49VCKOYbCq48hhVcfJ9UoCq8qMZPxFF6TACm8SgApvPYV3vBZGm7feyynAdu087BtloaXfgH4pkYX+SBZpnSpsfvASXQdNB3zx/eUwivG8A4evxjThndCnhwZcffBE7x+/Rqfpv53DG/C+HHRqNMo1K70DZrULit3Rghv+CwNT56+wJk/r2DC7DXInT1DlLM0vJYV3jto13cSWjWogPrV/mdaeMVDaguWb8DYwV0Q2zOWFM0SXxSwCfD2PYeRNEkiFC6QC8+9fdDdayKKFc6HBv885Cb2w93NVY7hXbtlH5au2YZxg7siWbLEch/FQ2tiujd//0AcPfk78uXKBndXFxw+dgbT56/GxOE9kD1LejnbQ7KkiZEmVTK88PFF537j0aZxdRT9Z2yx0sWiEUzhNU+TwquPIYVXHyfVKAqvKjGT8RRekwApvEoAKbz2E97weXjF3LNh8/BmRcsGFSLNwyumKZu5ZBOSJo6PnFnT49ipC+jdvq5tloYftx/EwtU7cP/hE6RMnkTO0pA/V+ZIszTcf/QUTTqPRv1q36Jhje+k8IbPwytkM2PaVKjwvy9Qt2pp2zy4EefhdXJyQvKkCfF9qSLo1qqWnKvX7BheQXXJ6q3YtDPqeXj7DpuGLJnSoVm9Stj181GMn7HsrfN29vh+yJ8zA6o06SP3P+IiHoYTY4TFLAz9RszA9b/v4FVIiHxorUHNcrYKrhBrMRTiubcvYnt64LtvvkDTepUg9tnqhcJrniiFVx9DCq8+TqpRFF5VYibjKbwmAVJ4lQBSeO0jvEoH4T0MtkJ4rditNx9as6JNe7VB4TVPlsKrjyGFVx8n1SgKryoxk/EUXpMAKbxKACm8FN6oThgKr9JlJIMpvOrM3syg8OpjSOHVx0k16r0R3n6j5smfApvW+R4bdhyS493Egx8xLWs2/YxffjuPyUM7qO73O4un8NoHfVRvWjty7HfMWbIeT555I0+OLOjRoZHtgRgxdvB1aCh8/V/JDk2btxq/nPgDz1/4IEmiBKj8fUnUqPStXHfq9wsQD+m8uQzu1QbFi+TDjp+OYN3mn/Dg0RM5nlGMVWzbpOZbk9/H9nCBu5sLnvsG2QdCFK1SeCm8FF5rLjcKr3mOFF59DCm8+jipRjlMeMX4K/FGIfFmIfFwRtJE8fFFwdxo17gyUqVIgojCe+3mPdy68xBff5HPsPCKd92LV3+++Sak8g37oH2TqihXuogqK0viKbyWYHyrkTeF996Dx2jRZSh6dWyCAvmyY8a8NXj6/AXGDu4sc98U3rPnryBZ0kSIHTsWbt99iMFjZqNXx8YomD+nfBlA8KswMRbLnxeuYPDYufJNUeKNTldv3Iarq4ucSumFty8mz1mJnNkyoln9ypH6SeGNfNgSxnVHUHAI/AJD7HNSRNGqVW9ac1iH7bQhVnjVwVJ41Zm9mUHh1ceQwquPk2qUw4S357BZOHfxOvp1aoi8OTMiICAIu/Yflw8XiAcxIgqv3p2IqcJL4dVL8eOIe1N4V/6wQz7BPW5I2K8E4RPjr5g7EsmTJHpLeCNSEE+Vd+k/DtUqlEalsl+/BSj8AZwe7SPPjyoCg4KCMWbaYpnj1b2l/K+YrmnbnsMIDApCkoTx0bNjE/mEuSMWVngjU6bwhvGg8KpffRRedWYUXmPMKLzGuGllOUR4fz9/FQ06DMfGhcORKX2aSH0Sk6sL6Y1pSIN4l/y4Wavl1DqxPNzRplEl1KlcChGFV0yuPmDMAnj7+GLSkA7Yf/SMZoVXbHvRmh1YtfFnvPTzxxef54JXl0ZImCCu5mtB9xw8iYlz1smqoWcsD1mprlUpbDL1zbuPYN7yrXj01Bu5sqXH0J7NkCZlUrmOFV6tU9LY+jeFd9SkhUiYKD7aNqlha7Bakx7o27kpCn2WK0rhFW952v7TETm9UeqUyTB5RA8kTBD5rVHii1qt5r0xvF875M0V9qpXsfx64g9MnL0Cvr4v4erqhhH92yNPzsy4dOVvDBk/FzPG9EHq5Anx6MlTvAx8LaXbEQuFl8Ib1XlG4VW/+ii86swovMaYUXiNcdPKcojwzl66GUIQf5g/NNr+RCe8Dx8/R4VGfdCvUwOU//YL+PkH4PbdR1Ikw4V37IDW6DFsFtzd3DCqXys5f6OeCu/Wn37B5HnrMW9cD6RIlhheYxcgKPiVnBfz1NlL0b4WtOjnOVGkfFssmNgbebJngLfPS1lBFGOQDx8/K9uZNbobMmdIg2XrdmPnvuNyQngh9hRerVPS2Po3hXfgqFnInPFTNKr974T9jdp5oXmDqvi6WIEohVecW74v/fHnhav46+oNNK1XGR7ubpE6tOfAr1i2ZpucYD/i1Eeisuvj+xI37z7AwcMnUadaWaRIngRXrt9Cn6HT0K9LUxT5LDvixPbgGN5/iHJIg7Fz3YosCq86RQqvOjMKrzFmFF5j3LSyHCK8o6evxN+3H8T4EFp0wrtk3S4cPXEOc8Z2f2tfhPD+fOR02PyMqZJhULcmtldKCuHtPmQm4seLHSnPx9cPY/q3kWN4xas2hbw2qRU2obuY77J0zW44sWM2xJuLvMYuxLZlo2351Zp7oWfbOjKneKUO6Nq6JsqWLIx4cf/dRscBU/FZ7sxoVqeczBNV5C+rdMTaOYNllZfCq3VKGltvRYU34pbFONxkSRKhfo3vI3Wo56DJsrLbMMIE+m/2eP/hk9i+9wjGDgobL7xz7xH5Fqk79x6iRNH8aNag2luVY2N7rZ3FCm9kRhzSEMaDwqt97bwZQeFVZ0bhNcaMwmuMm1aWQ4TXTIV3zIxVCA5+hQFd3h4vKYR32sINcmzkpkUjkPqfYQNip4Xwjp+9Bsum9YvEQEzg3ql5dSm84l32rRtWwndfF7TF5C3dTLb1zNsnWuEVb0kSFWCxX6fPXUaubBnQq10dObG8aFMMcxBP64cvQrKnjeiMfDkzUXi1zkiD66Maw3vm7CXbQ2oPnzxD/Vb9oGcMr+jClNkrEBzyGhHH6T589BQN2w3AkhnD5EsColv2HTqJRas2YenMYZFCggL9MGrKEiRNkgTtm9cyuKdqaRReCm9UZwyFV+06EtEUXnVmFF5jzCi8xrhpZTlEeMPH8G5aPFK+FSjiojWGV6vCK6YlK5gvG5b/sAdLpvRFimRhYyP1DGmIqcIrKtKdvKZhz+rxtu6WqtkVI3q3sL0lSawIDArGglXbsefACWxYOBwd+k1B8cK5UbdK6SjZs8KrdUoaW/+m8N69/witug1H/27izVVZMX3BWjx6/MwmwJcuX8W1v++i7LdfyWEyu37+BUUL5kGc2J44c+4Sxk5bjK5t66P0V4VtHVq+bhuERI8fGnm6vE07DiBvrszyVaq3bt+Xb5US43e7tqmPGzfvyvHh2bKkh6ebM0ZOWYz48eKjdZPqxnZUMYvCS+Gl8CpeNNGEU3jNc+QsDfoYUnj1cVKNcojwik6JWRr+/OuGHIubN2cmOUvDzn3HopylIeI8vI+ePIeYSkw8TFa2VJEox/CKeXgXr9kp38kupDdZkoS6hFe89nPqwh/lu+2TJ02EQeMWwj8gUFZjX/oF4JsaXbBq1kBkSpdazgvcddB0GSv6f/TkOXxZOC88Y7ljxY97sHHnEaybOxiHjv2BIRMWY/KwjsiVNb0cEypiy5QMEycKr+opqi8+qnl4Dx87gzmL18uK+5vz8G7YsgeHj/+BCcO6w98/EMMmzMPFyzfkrwUpkyVBxbIlUKVc2EOI4UuTDgNRr/r38vWlEZfZi9fjwJGT8H7hK6cmK1Y4v3ylqqdnLFy4dB1T5q7C3XuP4O7uKr+ctWtRF/HjxtG3YyajKLwUXgqvyYvon3QKr3mOFF59DCm8+jipRjlMeMPn4d2w4zDEHKlicn9RCW3b6O15eN988cSZP69g7IxVuHLjjhwq0LZRJdR+Y5YGsePzVmzFpl1HsHhyH/z2xyVdszTMX7kNazbvg59fgBybO6BLIyROGPZkvhDimUs2IWni+HK4wrFTF9C7fV3kyZERHQdMwYXLNyHe2J4xXWp4dW2E7JnTyrzte49h7vItuHP/MeLF9UThz3JgdL9WFF7Vs1MhPirhjSn9zXl4FTZlOJTz8EZGx4fWDJ9KphM5pEEdIYVXndmbGRRefQwpvPo4qUY5THhVO/axxrPCa58jS+GNmisrvKzwssJrzT2HwmueI4VXH0MKrz5OqlEUXlViJuMpvCYBRpNO4aXw6jmzOEtDGCVWePWcLZFjKLzqzFjhNcaMwmuMm1YWhVeLkMXrKbwWA/2nOQovhVfPmUXhpfDqOU+iiqHwGiX3bx4rvPoYUnj1cVKNovCqEjMZT+E1CZAVXiWAHNIQGReFl8KrdAFFCKbwGiVH4VUlR+FVJaYvnsKrj5NlURRey1BGaogVXlZ49ZxZFF4Kr57zhBVeo5RizmOFVx9XCq8+TqpRFF5VYibjKbwmAbLCqwSQFV5WeKM6YTiGV+kyksGs8KozezODwquPIYVXHyfVKAqvKjGT8RRekwApvEoAKbwUXgqv0iUTbTCF1zxHCq8+hhRefZxUoyi8qsRMxlN4TQKk8CoBpPBSeCm8SpcMhdcaXFG2QuHVB5fCq4+TahSFV5WYyXgKr0mAFF4lgBReCi+FV+mSofBag4vCa4IjhdcEvBhSKbz24RptqxRe+wDnQ2tRc6XwUngpvNbcczikwTxHVnj1MaTw6uOkGkXhVSVmMp7CaxIgK7xKACm8FF4Kr9IlwwqvNbhY4TXBkcJrAh4rvPaBZ6RVCq8Rato5rPCywqt9lgCcliyMEmdp0HO2RI5hhVed2ZsZrPDqY0jh1cdJNYoVXlViJuMpvCYBssKrBJAVXlZ4WeFVumRY4bUGFyu8JjhSeE3AY4XXPvCMtDp0/Dw4O4dlvn5tpAVjOU5OkNsNCTGWbyjLCXBxdkJISKihdJWk/Ply4/PP8kPsp54lfmw3vA4Nha//Kz3hlsTE9nCBu5sLnvsGWdKenkYovBReCq+eK0U7hhVebUZaEazwahEKW0/h1cdJNYoVXlViJuPvPvFHHA9XODk7wdc/2GRr+tPd3ZwRJ5Yrnvk4TracnZ2QJJ47HnkH6u+ogyIpvA4CHcNmEsZ1R1BwCPwCHfctjEMawg4IhzSon/8UXnVmb2ZQePUxpPDq46QaReFVJWYyXgivkQ9dk5uFh5sz4nq64ckLx8mnEN7kCTxw/1mA2e5bnk/htRypcoMUXmVkliVQeNVRUnjVmVF4jTGj8BrjppVF4dUiZPF6Cq/FQA02R+E1CM7CNAqvhTAVm6LwKgLjq4XVgUWRwQqvPowUXn2cVKMovKrETMZTeE0CtCidwmsRSBPNUHhNwDOZSuFVB8gKrzozVniNMaPwGuOmlUXh1SJk8XoKr8VADTZH4TUIzsI0Cq+FMBWbovAqAmOFVx0YK7yGmVF4DaOLMZHCax+u0bZK4XUw8Gg2R+F998eBwvvujgGFV509K7zqzFjhNcaMwmuMm1YWhVeLkMXrKbwWAzXYHIXXIDgL0yi8FsJUbIrCqwiMFV51YKzwGmZG4TWMjhVe+6Az1iqF1xg3q7MovFYTVW+PwqvOzKoMCq86SVZ41ZmxwmuMGYXXGDetLFZ4tQhZvP7Ar+cg5sQVL0gIDIr5zROuri7IkCG9JT3gtGSRMVJ4LTmtTDVC4TWFz1QyhVcdH4VXnRmF1xgzCq8xblpZFF4tQhavL/BVJd0tli71Nbp2bAvdrw+LoWUKL4VX94nnoEAKr4NAR7EZCq86ewqvOjMKrzFmFF5j3LSyKLxahCxeHydFDt0t1qxRBSOHeFF4dRPTH8gKr35W9oqk8NqLrHa7FF5tRm9GUHjVmVF4jTGj8BrjppVF4dUiZPF6Cq/FQA02R+E1CM7CNAqvhTAVm6LwKgLjQ2vqwKLI4Isn9GGk8OrjpBpF4VUlZjKewmsSoEXpFF6LQJpohsJrAp7JVAqvOkBWeNWZscJrjBmF1xg3rSwKrxYhi9dTeC0GarA5Cq9BcBamUXgthKnYFIVXERgrvOrAWOE1zIzCaxhdjIkUXvtwjbZVCq+DgUezOQrvuz8OFN53dwwovOrsWeFVZ8YKrzFmFF5j3LSyKLxahCxeT+G1GKjB5ii8BsFZmEbhtRCmYlMUXkVgrPCqA2OF1zAzCq9hdKzw2gedsVYpvMa4WZ1F4bWaqHp7FF51ZlZlUHjVSbLCq86MFV5jzCi8xrhpZbHCq0XI4vUUXouBGmyOwmsQnIVpFF4LYSo2ReFVBMYKrzowVngNM6PwGkbHCq990BlrlcJrjJvVWRReq4mqt0fhVWdmVQaFV50kK7zqzFjhNcaMwmuMm1YWK7xahCxeT+G1GKjB5ii8BsFZmEbhtRCmYlMUXkVgrPCqA2OF1zAzCq9hdKzw2gedsVYpvMa4WZ1F4bWaqHp7FF51ZlZlUHjVSbLCq86MFV5jzCi8xrhpZbHCG4HQmk0/45ffzmPy0A5a3Ayvp/AaRmdpIoXXUpyGGqPwGsJmSRKFVx0jhVedGYXXGDMKrzFuWlkfnPAOn7wMqzbulfsVy8MdqVMkQYmi+dCqQUUkiB9Ha39jXB+T8O7afwLdBs+Q+W6uLkiaOAE+z5sNLeqXR5YMn8i/P/P2wZeVO9q2kSBeHBQrlBsDuzVG/Lix5d/NCq+ffwAmzlqOX0+eRbw4nqhXoxwqlikR7X4tXbMVG3fsR0hICMqV/gLNG1aHq4uLLX73/l+xcv0OPHz0BMmTJUGfLs2QPXM6XLx8A9Pnrcatuw9kbK7smdC+eS2kSZVcN2NnZyckT+CB+88CdOc4KpDC6yjS0W+HwvvujgGFV509hVedGYXXGDMKrzFuWlkfpPAGBAZhcI8m8PX1x5UbdzBl/g94/PQ51s4ZjHj/iKXWjke1Xkt4J81dh63LRiEoKBi37j7Cyg0/Ycvuo1g2rT9yZUtvE949q8cjebJEePjoGXoMnYU8OTKib8f6lgivkN179x+hf7cWuHXnAfqPmI4R/TsgT87Mb+3S3oPHMXfpjxg9sCMSxY+D3kOno8QXBVC/ZjkZ++uJPzBx9gp0bVsf2TOnx8Mnz5AgXlykTJ5E/v9nz18gZbLECH71Gus27caFS9cxdVQv3WgpvJFRxfZwgbubC577BulmaDbQzcUJQiwfeQeabcryfAqv5Uh1N0jh1Y3KFkjhVWdG4TXGjMJrjJtW1gcpvIFBwRjWq5lt3/z8A1G+YW80rPEdmtUph9lLN+PBo6cY1L2JjHnh64cvKrTD73sXyOrmw8fPMXr6Spw4cwEhIa9R6ssCGN67OSIKr/j7gDEL4O3ji0lDOmD/0TMQwrtz5dhITDsOmIrg4FeYPaabTXj3rpsoRVEsC1Ztxy+//Yn543uaFt7gVyGo1rgbRvTrgLy5ssj2JsxcLv/bvV2Dt45176FTkTt7JjSsVR4ebs44cOQkZi3ZiCUzhsrYNj1Gomq5kihTqliM50loaCh+3PozVv24C+sXhe3/oV9PY/7yjfD29pGV9ga1yqPCd19FaofCS+GN6cSi8Grdnu23nsKrzpbCq86MwmuMGYXXGDetrI9CeMVODhy3EE+evcCMkV1iFF5nJ2fUaTsEubNnRPfWteTwhLMXr+PzvFltwjt2QGv0GDYL7m5uGNWvlYwRQxqiEt6te37BkIlLcGLH7LeEV4h19yEzUOSznOjQrKpp4b199yGadhyEjcsmIk5sT9nexu37sffQcUyLovJap0UfdGpdD8UK5ZXCe//BA9RqORBbV02FE4DydTuhWf3K2LR9P0IBlPjiM7RoWA0e7m5hXxR8XqJFl6EICAiEqKq3alwdNSqWhhDgKg27YczgLnL4wwvfl3jy9DkypE1D4Y3himOFNzIcCq/W7dl+6ym86mwpvOrMKLzGmFF4jXHTyvpohHf6wg04dvq8HF4QU4X38rXbaNJlNA5tmAr3f8QuHJKo8P585DRehYTgk1TJMKhbE4gqpViiE95jpy+gWdcx+GPvQil+EcfwijwxvnfR5N5IlCCeaeG9cu0m2vYchd3rZ8LJKaxfew78ijUb9mD+ZK+3jnXlBl0xpE9b5M+dVQqvj48PytfvIau0L/0C0Lj9QOTOkQle3VviVchreI2cgWKF86NxnQqyLSG2YliDGJu8e98vKFIwDwrkyS7/Xr1JTzRvUBlfF/scceOEjU9+c2GFNzIRCi+FV+uG7Kj1FF510hRedWYUXmPMKLzGuGllfTTCKyq8T5/5YPrIzjEK78Ff/8DkeeuxefGIt9gI4Z22cAMCg4KwadEIpE6Z1BYTU4V36KQlOL797Qqv70t/zF62GcdOXcDaOYOkpJp5aM3KCq+v70vUadkXQ3q3QbHC+eR+7vjpCLbuPogZY/u+xebpM2806zQEq+eNRqxY7jh34QpWrN+BPy9eRdZM6dC6cTVkyZQuUh6Fl8Ib0w2IFV6t27P91lN41dlSeNWZUXiNMaPwGuOmlfVRCK9/QFDYGN7q36Fpne+xZN0uXLp6CyP6tJD7f/POQ3xfv5ccwxte4T28cRrc3Fwj8Qkfw1swXzYs/2EPlkzpixTJEsmY6IS3k5cYwxuCWaO7RjmG9/rNe6jQqC8O/DhFzuxgRnjFGN6qjbphtFdH5M4R9pCaeIgtNDT6Mbx5c2SWD6mJCu/Bo79h5uINtjG81Zv2RPd2DeWQBz3CW7tFH6yYMxLJk4YxEYsYT712424c/vU05kwcQOGN4YpjhTcyHAqv1u3ZfuspvOpsKbzqzCi8xphReI1x08r6IIU34iwNV/++i2kLf5QPqa2bOwRx43hCDDMYNG4RNiwcDs9Y7hg5dTlW/PiTFF4XZ2fUbjME+XJmQtdWNeVDbG+O4RXz8C5esxNrt+yT0pssSUKb8IbP0nD73mM5PdqmnYejnaXh5csAWeHdvPsIDm2YJodHmBFecTDFQ2oPHz9F/27NISq+fYdOxfB+7eUsDQ8fPcWGbfvQslE1ua2fDhzDguUbMHZwFySMHxu9h0xD8SKf2WZpEDM4iJkXBvdqJWdiGDByBooXyouGtSvg4C+n5TCMdJ+mwosXvpi37Ef8ffs+Fk8fAjE12m+/X0Ch/LlktXfj9n3Yve9XzBwXuTLMCm/ky4/CS+HVuiE7aj2FV500hVedGYXXGDMKrzFuWlkfpPCGz8MrxuCmSZkUJYrklfPwJkwQ17a/I6euz5a7kgAAIABJREFUwKFjf8gKbcli+TFu5mrbLA0PHj2TEnzi94sQT2tFNUuDaGjeiq3YtOsIFk/ug9/+uGSbh1dIctg8vFnRskGFaOfhje3pgeyZ06J7m9rInyusImtWeIVsCuk99ttZxPGMJWdHCJ+H9/yl6+jcdyx2rJ1um2t3yeqt2LQz6nl4xfRq0xeswYEjv8HDwx0li3+OFg2qyrHNYmzwyvU78eDRE8T29ETuHBnRokE1fJI6OV76+WPwmNm4cv22fPjt009SolPLOsiU4VNWeFnh1brn2NazwqsbleWBFF51pBRedWYUXmPMKLzGuGllfXDCq7VD7/t6s8JrdP/EkIa4nm548sJx87GywssKb0znK4XX6NVsPo/Cq86QwqvOjMJrjBmF1xg3rSwKrxYhi9dTeC0GarA5vmnNIDgL0yi8FsJUbIrCqwgMAIVXnRmF1xgzCq8xblpZFF4tQhavp/BaDNRgcxReg+AsTKPwWghTsam7l/fD98YOXVlObvHhmbE2nONEnmdbV7JGUDxPV8DJCT5+wVY0Z9c2KLzm8aZIFEu+9fH1azHz+/uzJE8YC099AvEq5P3oF4XXPucGhdc+XKNtlcLrYODRbI7C++6PA4X33R2DZz5BCAgO0d0BMROMPRYKr7VU48RyhZAl75fv5xcICq++403h1cdJNYrCq0rMZDyF1yRAi9IpvBaBNNEMhdcEPJOpz32D4BeoX3hNbi7adAqvtWQpvMZ4ssJrjNuHlkXhdfARo/A6GDgrvBBiKX5GfN8WCu+7OyIUXnX2HNKgzuzNDFZ49TFkhVcfJ9UoCq8qMZPxFF6TAC1KZ4XXIpAmmqHwmoBnMpXCqw6QwqvOjMJrjBmF1xg3rSwKrxYhi9dTeC0GarA5Cq9BcBamUXgthKnYFIVXERhnaVAHFkUGK7z6MFJ49XFSjaLwqhIzGU/hNQnQonQKr0UgTTRD4TUBz2QqhVcdICu86sxY4TXGjMJrjJtWFoVXi5DF6ym8FgM12ByF1yA4C9MovBbCVGyKwqsIjBVedWCs8BpmRuE1jC7GRAqvfbhG2yqF18HAo9kchffdHwcK77s7BhRedfas8KozY4XXGDMKrzFuWlkUXi1CFq+n8FoM1GBzFF6D4CxMo/BaCFOxKQqvIjBWeNWBscJrmBmF1zA6Vnjtg85YqxReY9yszqLwWk1UvT0KrzozqzIovOokWeFVZ8YKrzFmFF5j3LSyWOHVImTx+iTpPtPdYtUqFTDUq6989abZxcPNGXE93fDkhePmY3V2dkLyBB64/yzAbPctz6fwWo5UuUEKrzIyyxIovOooKbzqzCi8xphReI1x08qi8GoRsnj9uq374OIsBNYJIa9fx9i6p6cnCuTLS+G1+BiI5ii8doCq2CSFVxGYheEUXnWYFF51ZhReY8wovMa4aWVReLUIWbz+7hN/xI3lClH9fOHnuPeds8Ib+UBSeC0+sQ00R+E1AM2iFAqvOkgKrzozCq8xZhReY9y0sii8WoQsXk/htRioweYovAbBWZhG4bUQpmJTFF5FYHxoTR1YFBl88YQ+jBRefZxUoyi8qsRMxlN4TQK0KJ3CaxFIE81QeE3AM5lK4VUHyAqvOjNWeI0xo/Aa46aVReHVImTxegqvxUANNkfhNQjOwjQKr4UwFZui8CoCY4VXHRgrvIaZUXgNo4sxkcJrH65slQRIgARIgARIgARI4D0hQOF9Tw4Eu0ECJEACJEACJEACJGAfAhRe+3BlqyRAAiRAAiRAAiRAAu8JAQqvgw9EnbZD4RnLHc5OzsibMxM6t6ju4B44ZnNjZ6zC6T+vIDQ0FEUL5ESXljUcs2GNrQQGBeOrKh2RJ3tGGVmrUkmUKVn4veib1Z3gMbCaKNsjARIgARL4UAlQeB185ITwLpnSFx7ubpZv+erfdzFgzAJcuPw30n2SAoO6NUGBPFmi3M4vJ//ErKWbcP7SDaRIlhjblo22tD9/334g+yCEt1GnkejbsT5yZk1v6TaMNCaEt3HnUVg9a6CRdEM59mYdXaf+y8fgwaNnGDxhMc5dvIanz31w4McpSJo4gQ3VS78ADBy3EPuPnkH8eLHRpmEl1K5cytDxZVJkAnrvQ8HBrzBmxiocOvYHHj15Lu8XHZtXR6niYW+j9PMPQMf+U3Hx6k34+wciY7rU8ovzl4XzWIZ876FTGDtzFR4+eY6CebNhRJ8WSJ404Vvta/U1YsKOn4+hx9BZsq8t61cw3Ve9PMWGVvy4Bz9sOwhx7SdKGA+1KpZEqwYVbX0oWLYV/AOCbP8WrKeN6GyqjzMWbcCKDT/h1asQVPhfMfTrVB+uLi5vtXnzzkNMnrcOJ3//S/Yhb86M6NuhPjJnSGOLPXvhGkZPX4k/L91Agnhx0KFZVdSsUNJQ/6zq15T5P2Du8i1v9eHo5hlIED+O7r6p3HOOnDiHeSu2ys9ndzc3fP1FPvTuUA/x48aW27t64w6GT1mGcxevI7ZnLFT49gt0b1Nbzu/PJXoCFF4Hnx312g1D3Die8sRs27gK8uXMZEkPXr8ORcXGfVGqeAG0blgRm3YdxoxFG7F79Xi5vTeX389fxa27D/H4qTfWbdlvufBG3F6TLqPRp0M9ZM+c1pJ9NdOIEN5vanSR8p04QTz0bFcHyZK8/QFnZhvvknV0/f6vHQMhUD8fPoW0aVKgRY9xbwmvkF1x/k8Y1B7Xb95Dm94TMHtMd3yeN6uVh/4/15bKfUgIgBCgymW/RKrkSbD30G8YOW0FNi8eIY9bUFAwTp27jEzpUsPN1RWHT5zFwLELsf/HKbYPfjOAb997hEqN+2FUv1b4omAujJi8TN4PF0zs9VazWn0NTxBxtdsMgbubK74vVcS08KrwFH2YPG89Cn+WHVkzfoprf99Dl0HT0Lt9PVQuU1x2UQjvurlDkDplUvlvZ2dnuLm+Lad6uW7d8wvGzVqN+RN6Im6c2GjdawLKlSqCNo0qvdXEqbOXcPrcFXxT/DPEje2J6Yt+xK+/nZefUWIR16w4Hu2bVsX/ShSEf0AgfP38kTtbBr3dscVZ2a9XISEICfn3rahCfk+fvYyFk3or9UvlnrN+6wHE8nDH5/myyS9+/UfPR+b0aTC8d3O5zeotBsrPsH6dGuDh42do3n2s/Nw3+uVAaUc+4GAKr4MPnrfPS/nN9eadB/LmsHnxSLi5uZruxelzl9Gi+zgc2TxdXihiKVuvF9o3qYKK3xWLtv1d+09g6oIf7Ca8ov0tu49i+khzVQTTgP5pQFScfV76yw/MnfuOY9tPv5iucOjtm71ZR9eP//IxeObtgy8rd4wkvMGvQvBFhbZScAvmyyaxeY1dKP87rFczvYeTcVEQMHofCm/q+/q95TCvst+8Pczoz79uoFbrwVKIM6X/typo9EAIcfnltz+xaFIf2cS9h0/xba1u2LtuIlImS6zZbFR9HTVtBVKlSIKjJ86hUP7spoXXLM9B4xfBxcUFA7s2kvsjhHfT4pFI84/wau6kRoD4MlkgT1a0a1xZRop7/YzFG7Fz5VjNph8+fi6LDwc3TEWSRPFltd/7hS9G9m2pmasVYGW/3tyW+Fxt16QyKn0X9iVCz2L2nrP1p18wZ+lmbFk6Sm6uaIV2mD6is+3+JWTaM5aH/CWVS/QEKLzv8Oxo2nU0BndvKn/KM7us27ofqzf+jB/mD7U11WXgdNl211Y1o23enhJ2/PRFTJm/HnPGdo+yymx2n83mC/n9X+3u+GntRLNN6cq3J+voOvBfPwZRCa/4ubdcg944tm2W7bxc8eNPEB8qq2Z66TqWDIqagNH7kGhNVFdL1+yGHxcOk1Xd8EUMQbp09RZe+Pqh9FcFMHVYJ0vw9xo2G0kSJ0Dv9nVt7RWr1B5jB7TRHDYRVV8vXrmJfqPmYe3cwWjXZ5IlwmuGp7i/VWvuJYfq1PlnuI4Q3qSJE8qhZrmzZ5DDLj5Nndwwz5LVu2Bgt8a2YSiXr99GlaYDcGr3PM1he7sPnMSIKcuw/4fJcHJygvj187PcWWQl/+GjZ/gsTxZ4dW2MVMm1v3y8uQNW9iti27/9cUn+GnTgx6mI7emhm5vZe47g9OSZDyYObie3OXPJJtx/+AR9OzbAoyfPZLFLsPqqiHXDfXTv3AcUSOF14MESP4sEBb+SD62JSm+NloOwadEIpQsnuu4uWbdL/oQrxgeHL2I8r6j2DujS0OHCK8YeDRq/GLPHdJPf3t+XRfw8FMvDQw4pET+xifFZEZnZs5+OFl4eAyAq4RVj3MW1d27fIvlBK5bNu49g/srtsnrIxTgBo/chMXyhVa8J8mfbN+9Xz719pezuOXhS3s/qV/vWeAcjZHboNwU5sqSVP6GHL2Xq9kS31rVQpmShaLcRVV+FQNZvPxxdWtaUQwpa9RxvifAa5Sk6L4Y3HD5+FitnDID7P8+MiJ/6c2RNBzEmecGqbfjj/DVsWjzC9qugKtjC5dpg+ogucp/FEl4lP7xpGhIliBdtc3fvP0bddsPkeN/wh4bFl52g4GDMHddDFmqGTFyCew+eYOnUfqrdgpX9irhx8ZkqlvChBXo7ZuaeI8a49x4xRz53Iob6iOXcX9fRe/gc3Lh1X/67XtXS6N85+s95vf382OMovA48wn7+gWjSZZQcZB4QGIRmdcrhu68LWtIDo5UAe0mYGGMkfsZJ9s+DQu2aVHkvxkcKyRUPRcSJHQtifJz4cM2S4RNLjoFWI/ZiHd12eQyiFl6z1Rat4/xfXm/kPiTuE10HToe7uyvGebWFi4tztAgrNOqLoT2bRfswrgp7IxXe6Poq9vv46Quy/2KxSniN8BTbn79yGzbuPCy/zEdXcBBjU4tX6iB/GhfDL4wsRiqpYihD484jUb/a/9Cg+v9smxW/upQomk8+7yEW8ZDb9/V74cSO2fIzU2Wxsl/h2xUP2pWo2gmzRne1DSXQ2yej95xjpy+g++CZmDaik6x+i0X0o3StrmhSqywa1yorH8rtPniGZBfV2Gm9ffwvxFF4P5KjLMZ6tewxDuLJ0fBv82KMmRhb9S7H8H4keC3ZDUcLryWd/sAbiW4Mb9HybTFvfA85/lAsYgxcaCjH8Jo93Kr3ISFd4gNd/Hfy0I6aD1CVb9hHPpyjMn4yun0SY3iPnbpge0jt/qOnckhFdGN4Y+pr9yEzIZ6sFw+rieWFz0v5bEbJYvltEmyErSpPsY3Fa3fK4W2iMhrVjBPh/RBf+L+s3AETh7SXU0caWcRYWTG7RbhoiQry9EUboh3DK4aCiFl7qpUrgRb1ykfaZNdB05EyeRLbEBMzwmtlv8I7KX4FEg+Ci/HJ4b8M6WUmviip3nPE8IlOXlMxaXAHWwU97IvAA4jP9ohfBMSQLDE7yPLp/fV26T8ZR+H9SA67GC4hZmkQPw+JaWi27D4if9LatWoc4sWNDfFN8eqNu/KnD7GIm13wq1f46dBvENO3bFg4HM5OTpY8QPeRILVsN8jaMpRKDYkZOcTP4aVqdsWe1ePleM3w6QDFQ2r3Hj7BhEHt5M+C4svirNHd3otfIZR28j0LVrkPidhew2fj6fMXclxu+Bd1MaWVqPKKn23FT9qisiWGDKzdvA/zV22Xw8DSpjE+7jQcmZilQ4w3HT+oLYp8lgMjpizH/YdPbQIc8Z6p1VcfXz+I8y186TlsFvLnyoImtcvKh5SNLio8xTaE+MxfuVU+iCcenhNL+EwMV67fkeOkxWw5AUFBmLd8K/YePiUfWBa/eBlZxENqE+euxcKJveV4eFHZFp9B4QIsZhsQ016KsaWiEtm400iU+rIAxC9+4Yv4kiAE8uCvv8vZCMTsB2Jc8dCJS3D3wRMsnhz2UKHKYmW/wrfbrOsYWdmN2HeVPsV0zxHn+fIf9timFhOzKLXtPVEOnSj+zzR8YvCVuEbEF69vqneR1V3xv+fePug6aAayZfoUXv88nKjSr/9SLIX3IzraYm6+/mMWQDw8Icb6DO7e2FbBEnP6Hfjld9s3QDE3rPgWHHHJkyOjQ+en/YjQx7grZO34Iy0+FPKVDpvCJ+IS/jCNmD5KfAAd+OWM/KAWv4RwHl5rjpPe+9Cd+4/xXZ0eb21UPETWqGYZOQepkJ4rN+5IaRNDj9o3rYJiBXNb01FAfuEXL2h59NT7rXl4I94ztfr6ZoesGtIg2tXLU8R+W7u7/JIQcQmfa1fMcSt+yRA/r4svfuJ+L+ZuFaJkZpm+cANWbox6Hl7BIVe2DHLmjQ07Dsl54t9cxIPW4VNWLlu/Ww7HEEP+CuXLLgUuRbJEhrpnZb/E2OTv6nTHjhVj8UmqZIb6E9M9RwiueGjv970L5BzG4uHHTbuORNqOuE+JB23F8sf5q3JWi0vXbstjWbxQbvTv0tCS6foM7dwHkkTh/UAOFLtJAiRAAiRAAiRAAiRgjACF1xg3ZpEACZAACZAACZAACXwgBCi8H8iBYjdJgARIgARIgARIgASMEaDwGuPGLBIgARIgARIgARIggQ+EAIX3AzlQ7CYJkAAJkAAJkAAJkIAxAhReY9yYRQIkQAIkQAIkQAIk8IEQoPB+IAeK3SQBEiABEiABEiABEjBGgMJrjBuzSIAESIAESIAESIAEPhACFN4P5ECxmyRAAiRAAiRAAiRAAsYIUHiNcWMWCZAACZAACZAACZDAB0KAwvuBHCh2kwRIgARIgARIgARIwBgBCq8xbswiARIgARIgARIgARL4QAhQeD+QA8VukgAJkAAJkAAJkAAJGCNA4TXGjVkkQAIkQAIkQAIkQAIfCAEK7wdyoNhNEiABEiABEiABEiABYwQovMa4MYsESIAESIAESIAESOADIUDh/UAO1Lvq5vqtBzB/5TbsXDnWcBeePHuByk36Y928IUiVPDEuXrmJ6i0G4vCmaUiUIJ7hdt91YpHybTG0ZzOUKVnIsq4sXbcL67cdxObFIyxr014Ndew/BSmSJcaALg2VN3Hq7CU07DgSp3bPg4e7m3K+IxNu3nmI+u2HYeuy0UgQL44jN81tRSDwTY0u6NaqFip+V8wwlwmz18LPPwBeXRvJNuxxDRvunMFEe9wzPqR7tNn9b95tLHJlS49urWsZPAKOSXsVEoKKjfrKz5xC+bM7ZqMf2VYovA44oFf/voup83/A6XOX4fPSH0kTJ0DeHBnlBZYmZVIH9MD4JqwQ3mGTlsoOhH/IfEg305jI2ePD0uzN2/iRVs9c/sMeKYBGBMQq4W3bZxLSpkmOvh3r23bg3F/XUbv1EPyydSbix42tvmNRZPQdOQ9JEsdHjza1LWnvXTTi7fMSMxZtxM9HTuHxU2957LJl+hRNa3+PLwrmehddUtqmWeG99/ApKjXuh23LRiN50oQU3hjof0j36CMnzuHk73+hc4vqSudTeLAVwhvdPSeq+5OhTv6TtGHHIaze+DPWzBlkppn/bC6F186H3sfXDxUa9UXm9GnQskEFJEkUH/cfPsXBX39H1e+/Qs6s6e3cA3PNmxVesf8lq3fB8un9kSNLOtmZD+lmSuEFgl+FwM3VxdyJ9Eb2hyK84ft+/PRFdPKain3rJ8MzlrulLBzVWJveE3Dt73vo0bYOMqZNhafPfSCOQ8rkiVGl7JeO6obh7ZgV3snz1uPK9TuYPrKzrQ/2+NJqeAcNJtrjS/L7eI+2x31IIP8QhDc4+BXc3Fzh5x+IElU7Yv6EXsifK7PBM+a/m0bhtfOx/+Xkn2jRYxx2rx4fYzX32s17GD9rNU6cuQh3dzcUzp8dvTvUQ8pkiW09PHTsLGYs3oC/rt6Cp4c78ubMhElDOsgPYHFBTJ6/Hlv3/ALvF77ImulTWUEuWiCnzA8XjFmju2LinHW4++Cx/NAb2qs5smb8xLYNcfNcsGo7fF/6o0TRvMiTIyPWbt5vG9Lw9+0HGDl1Oc78eQWvXoUgTapk6NGmFkoUzRclyY07D2Pagh+xd91E2/qobqY/bj+IeSu24e79x0iRLBEa1yqL+tW+teX4BwRhxJRl2LX/uORTs0JJGevh4Y5hvZpFuW2tvt64dR8TZq/B8TMXERISgswZPsHg7k2QPXNaXL5+G+Lnz3MXryMwKAiZ0qVGl1Y1bTzFBt/8sBTMRHs/HfoNAYFB/2/vzON8rPY4/g0lO9WtVFRclbKE7KRMZJ2J7PuIYWYsGduEjGUswxiTZQwythh0GWMXkyV7SVlLkTYS0dVeN+7r83Wfn2d+fsvzGw89uZ/zX5nf8zvP+5zzPZ/zPZ9zfvJo8aLSL7xlQIHJffLy166o49HjX8r0cX2VwZurNsuw+DkSPzRc6teurP+vbWSstk+39o3l0qVLMmfxOlm8YpOcPnteihT+h3RqWU+aNnjaxbB07VAZGNlGMrbt1ffv1KKeRIY2uYqxu6VhzpJ1snDZRvn27HnJlze3VCjzqCSO6OGxbYz+OGN8PxmftEhOfPWN9kPwNy8CfY2LQWNmSvr67Zmej4mgS9/M9pt6z1aSCTER1/TuFy9ekqqNI2y3sFzn8ON6/O+//yEV6oVp/bHQ9las9A9f4wbP9TeWITD++fD9gjpt2LpXsmW7RfsfMnS33HKLVu3rb87K0HEpsvfAUbnnrkLyctdmMi4pNZOlIZD+hmfWadVPwjsEZ+rr7mP427Pfy5jJb8i2PQfl0qWLUrn847p78EDhf7iQpSxaI3OXrHfFyDIli+t48mX78lVXMJ/3r7c0c3fq9FkpWCCfNKpT1bWbMG1euqzZuEuZwAJWu0Y56RPWQnLnyql1co8ZVtrQX7/zFKOxQxk/bbEcOnpC8ubOJRhXiG+357xN3tm9X6KGTdVdlRzZswtib4N2A6VF8LMSE9VRvw4LjgMfHZdZEwbof/ub85LnrZDNOz+QoBrlJXV5hu5K7M9Iuarq7u/vL+67PwD9EfPlb7//Ias27ND6v9iwlvQJa659E8VXbEe71G3VL9NjwQZWLff4tHLeGJ13/b076vRw0cJqvwGDR4oVkTmJ0fodkYMSpfDdd2bJSuav3W/2f6fgvc4tjIxCSOhgGdSrnbRpEuQK6OavxUB+IXSIbg03a3hZeEybt0I+++KUbl1gAO5476B0GzBBOrdqII3rVJM/L16UnXsPqfDLk/t2iU9eLMvXbpMR/UPloaKFZdHyDFmycrOsmjdGg7UhMCCAxwwKkzsK5ZNRifNl38FPZfnsWP3Ot7e9L31ipsqgXm2l6lOlJOOdvYJge0fB/K5g3r7nKLn7rkLSs3NTue3WHAK7Ru5ct0uFMo94JDkkbpZc+PEnmTSyl+vf3YMpst0YxMg81apSVvbsO6KietQrXaVhUBX9XGzifNm0fZ+Miu6iGanZi9fKmozdGnS9CV5fdTWYQ9BHdAyR/PnyyIEjxzXIwM8FQX/sxEkp83gxDVzrNu2R6fNXqo8TPmQU98myY+8xctutt0qPzk10Ynpry7uSPC9dVswZLfdZtK64B29/7eo+0QwYmSzb3zsodZ9+SmL6dhIsFKo0DJfZidFSvnQJmZKSJqs27tRJvPhD98nho5/L0PEpMrxfqMuLDMF7Z6ECkjAsQsqVKiG//PqbtrF7MQveXXsPS4/BiTIhJlIz+ef//YNuM5oXLebPG/0RW+rRPdrKXXcWkKmz0/Qz6xaO10WclXERiKXhWt8dk1CxBwvL4N6Be5avc5ix9PgaIT2lesVSMrx/qIoUT8UfI3/jxspYBsf3D34iI/t31kUZ4lybyJESO7CL1K31lC5MmocN0z4A1sjsjZw4Vz757GsZ0S9U42Sg/e2bM+ckqHmULJs1Um0cRjGPYXxv64iRcuniJRncu53kyJFd4qamyvnvf5C0lFjJnj2brN/8rgwcNV1efbmDVC5fUrbs/FCmpCyTAvnzehW8/uo6adZSgT1oQERrqVTuMc28H/r4hGvs4AxF2ceLawzBIh+x8amyj7r6oXvM8NeGVjqLe4xGu9dvO1BjRGjLenLy9DmJiU+RpyuXlWH9Oqkwq9IoQuZPHqx1xcIbArdg/rxqIUExL7ytjG0I3mlz0+WF+jWkf3grnTsx17kX9/cPdI5Cf9x/5Li0fqG2NGv0jHx87AvBvBXeMUQX+yj+YnsglgYr7446IRYOjeoowXWryR//+Y8rBoPL2k27JX228895WOlrN/JvKHhvAG0ErKlzlmsARzagcrmSUj+osit7mzQ3Xbbt3i8Lk1511QbZj0oNw3VVh62LDr1Gq/D0lDHDyhSBe0jv9tKsUS19BoL3C52HaEYS4sYQGEumD1NBhwKxCk/blmWvqa8Y31HkvrtVVBoFQhTCz8heYNKANaNVSG1L5DBwHypyr8u/iw+5B1MEE2Sy44Z0cz0TAhd1xgQF0Va1UXgmAQwDf52WfaVGpTJeBa+vumJSWLpmi4orq4emMBk2eq6qayIyT5YITsjkb0+fkikod3p5rIqMrm0bWeJlDt5W2tWYaOZNGqT9BNu+bZo8J/B6rXkjThdKPQdPkl2rp2kWu3pwD5kU20vrZJSkOct14TMz/nKWAoI3slMT6d4h2GedzYIXWT08Z/UbcZZ4Gv1x8qjeUrt6Of0ebNcFNe8jfbu31H5sZVxYFbzIuF/ru0ePniEXfvhJksb0sdSWTvsj7BANiXtdLvz4s5R69CHNwENgGhl1K4z8jRt/YxlMEBNy5rw1E8eoYUlSIH8ezQbu3ndEOveJk/Wp412Z1cNHT6gIHjsoTAVvVvvbO8snyx0FrxyUNY9h2FZC+4zVcfPgA/do8yHjiziTMCxSgmqWF4ip4g/eryLPKKg76uctw+urroht1YMjtc97Wxy696Ntew7IgNhk2bFiqv6TOWZYaUMr/dI9RmMxmrZum74jEjAoEP/9RiTJO2mTpWCBvNKq+3AJqllBYx0W3oj7MxeulrdSx0vePLkzLbytjG0Iu1mpq2Vr2mSfNiJ3wZuVOer7Cz/K0tdHuNAjI4ODAAAP4ElEQVTMXLBKFqZtVAuTldgeiOC18u4YIyizEi5nw80F/WnM5AXy7trpVpqSf2MiQMF7g7rDTz//qgNn/5FjuuWNlfq0sVG6Uu8x6DXZtGOfx5oYAb5i/e7St3sLj0Lz2ImvJbjTYM3mIkNplOET5siXp87I6/H9XYIXg8TYCkMWDlkfI+tRPaSHbh0ia2wU2BveXHnF0jD3zfVqvXjyiRJSreIT8lzNClLi4SuWCPeXwKoeK/4Bka1d/+QeTFGHXi811e0voyB7OzjudXl//QwV3MiSI9hCkBsl4pWJmon0luH1VVcI+Zy33aZZTE8FomDijDdl684P5dvvzgu2tFFCW9V3bTWaJ0t817ipqR6fhe1ab3V0/4A5eFtpV3zemGjq1qoozbrGyJZliVI9pKesXzheg7axjXjkk8/13z0VcDUmbAjexOE9dYL3VcyCF32pTcRIQT+vWbmMVKtYSrcivWUSDcG7NW2S+tqNggUCMsQDI1tbGhdWBa8d7w6ryJcnv/U4Cd2gMHLNX4OF4v7Dx+TDQ8d0JwDZRxzEg63FCiN/48bfWEaWDpP5YyWKatbOKFjgYpxhJ2hhWobMeGOlbF6amOl9KzwfppYXCN5A+xsWfl37xcueNcmZFqTmMYxtc4gsJADMpWH7aAl5vrqEtWssiJF9u7XIZIuARWhR+tteBa+vuhpCfsXc0Wqb8lQwN2B36fjnJ3V8GcWI5eaYYaUNrXQi9xgNu0K2bNnUKmUUZCprNe2t5zOwEwR7FT6HhTMW3mjL8dMWScuQ2lKoQF7XwhvnAazMeWgL7JJhfvJV3AVvoHMU+uODRe6Vof+7uQPfBWshYtHu1dNk6ZqtfmN7IILXyrsbth/zYVyDweqMXRI9aroceHu2labk35gIUPD+Bd0B4glbeHly3a6TJ4QbtsK9+R1RxYr1u2kWwFNm1RBG2DrCqtooELxfnTqrAcjTISFD8GJlC98qgjkmIfMBFgQTTEDm7AUmfWzlYRJBtgF+T2/ZCQxuZG7MWWOPgrfLi9Ki8RWhbRa8n574Wi0fgQpecPBWVzC/PWdOr4IX2Tx4FbHVX/T+ezTDgKxTiWIPuG4EME+WmPRmLlylGd5rKZ4Er692xXdhojny6ee63ZjxzvuSHBel2XosIFLTMlz+XWyTtug2TC0svhYpELxJY6KkZuXSPl/F3cMLvzFsNjveO6SLOkxs2FGAn9e9eBO8yBAi4wjBa2VcWBW8drx7n5gpkj179kyT/rW0tRM+C0GC8f3u2mT5+NMv/fYPf+NGBa+PsWwIXvdroCB4T585J8j4oz6wLG1YFJ8JkbGLZdwKEkh/M4Qgnmm2F1kVvIiJyFxWC47UBYLZ8+5P8OIlvNUVV95hTHoTvLB7IPa90qutYEELiwC8tBjfxi0k5phhtZ/763ueBC8sHeNfvVrwLpg6RHeXYK/CGFmcHKPWkJ0rk9SScObc92rxMvt3rYxtw8O7aNrQgASvr7jv6UGeBK+R7YfgxcFtf7E9EMFr5d19HaTD+Jg+/+qFmb825b+LUPD+Rb0A22Anvzkji5Jj1FeZmp6hGbm8eXJ5rJEVSwNWqEYgNiwNVSs8IdE92lgSvPiO0o8Vk/4RVzIv8DJd9lV6voc3YfoSwbUw5u0g8wtgK2zrrv2ZrlHxZGkofM+dul1pFEyACOx4blYtDe4gzXX1tzVbr80A6dKmocsiAh8httvhOTRW3ebJ0tiGNbIdWe1WniwNvtoV34OJ5uWhU6RW1bJS6rGH1eeN9/vi69O67Wj4d43tU1gVkK3yVrIqeM3PQyYKh7wSR/R0WRbM/+7L0hDVvYXuMlgZF7g5AYeazL5aHOps+tKruvjAViuKHe+O21aaNqipfG+WgswkxhoynxCj2F731T/8jRssWHyNZXDzNJmbBS/GUli/eNm6fJLr3uNTp7+T51r2dVka3Pn762+GRWzSyJ6ZDth6sjSsXTBOr7pDMSwNE4dHSu0aWbM0+Kor4rMvS8PKt3ZIwowlurVuFPh9saXtSfBa7ef++q8nSwMOYIENhC+Ku6XBsFfB9gUfMhbeaMth8bPVjmccnMVnrYztaxG85vfzN0ehP3qyNCxYtlF3GazEdk8xB3XwFJ+svLsvwTs8Ya5gPIAvS2AEKHgD4xXwX+OWhvlL35IGtauo3QCHkOGlmzJ7mfTu0kxFFbaGmnQeoieXcRgMh8K+OnlGVm7YoVYA3JeJTGr3gQn6943rVNV6IJMGgQsjP7J86eu36YGUBx+413VoDdlB3PVrJcOL7CBsBCkJAzTLBqEbHp2gtgFD8I6YOE/qPVNJitx/t94GgcGHk/7jXu3ukQ0Of3XsNUa2r5jiEvPuwRSCDVulyC4jKCLAjH5t/lWH1jbv2Cex0V30hCpOSiMLXL92JT157qn4quuZ775XmwQyE+EdQvTQyaGPP1PvHt4dmUNkdeOGdNc2w+lk2ANavxDkUfBigRHaJ05PUiM7iYz5ufMX9IRtpSdLSpUKj6tHFd5abPkbE6p7vd235/y1Kz5vTDSoQ+q0oVLq0YeVIW4rwM4B/LvGtWJYgKQsWitR3ZpL9Yql9TYJ48aNdi/W0epkRfDiUB/8reVLP6IZ3S07P5CRifMkfc5oPZXsXsyH1rCAgId8yuw0PbC4PjVebTdWxgVsJHv3H5WE4ZH6mfx588iPP/8iNUJ6yMgBL2l/gkcbY+Ra3h0/nvJ0k156eMl8q0nAAeEv+gD84LAX4YaGkiWKqqcSWU/Yk9DfjVs+/DHyN26sjGV/ghf9GNYbWFtw8PLixYvqCcX9waOju6qlIdD+BuywNODdzT8w4H7wtFX4ZR8nFlDZs93i9dAaFqGVypXUxfzkWUt1YQUx6Kn4qysOdyG2YKcMPyiA+5IPfoRDVEGCzGHbiFhZkDREx/XR419JRHSC4E5hT4IX3++vDfE3iA8YX8ahYPd6ezu0hkPCsL9AcOGwq3Fozfg87FW4xQE/EAL7l3EOAecH5r42SA/OolgZ21kVvIHOUd4OrXVvH6zvYCW2o808xRxP8Qk7q/7me1+CF/bFlsHPWvZ8/0Uhx5FfS8F7nZvl9JnzAgP87vcPy6lvv1MfFG5NwMQDgWFcw4OtrYkzlqin7tff/9CbAKo9VUqzrcahqs07PpCkucvl6LEv9cTmk6X+qafiXdeSzfyXimQID2/Xkpl/2crd0gAU2J7DdiLqBQEO/+3qjbtcghdb/RAYmPjy5cml4g2BGrYFbwVbcu2b1ZUX/3cDhbVryZ6Xtk0vCzAUZC5iE+eppwv3EbZo/Kwc/+LkVdk9cx381RWH9iBk3/vwIw1qJYoVUY8gTnF/deqMXosEOwV8qA2Cqqg/DYLYU4bXEJ6TZi3TOn537oL+UAG8zrhuCZ/DJPVciyj1tnnzx3q8lsxHu7ommvAR6vHDNiIyMMZEg9szjGuAjL+FVxFWB2SA8+TJJY8VL6qBvUalyxaGrAheLMiwfQmmyKZhcYcssrdfoTMEb3JcXxmflKp1Af+Yvh11YjeKv3EBL/zAUTP00BDEu3Htj9GPMbEa15LhmVl99wXLNug4MB8svc6hw9bHw0aFQ4Xb9uzXK6MQY5AZx4HBbh2CM/2CnD9GvsYNKn31tWSZx7I/wYtnwIoUM362HP7kc/V/Ilbi8K/xS2uB9jc8c8PW9yRuykLZsHiCK+56upYMtyBsf/eAxgSIWtyw434tGfoXssq4uhH9Ftclejs176+u+B7E3MXpm/SOdtygg5t4DGEOT+rcJeu0P2Cxj7kjJn62V8FrpZ9j5w5jxps/1tu1ZLhCEG2CBWT9Zyu7riUzOiuyqTj3gduFjHGMrD+uNzQvvPH3/sZ2VgWvv7jvPrCMa8mQOFj79m7Jni2bNG34tPY1I5uNf/MV281zpznmeItP/t7dm+DFggeLis3LXrPtR3VsDTQOfxgFr8Mb6GaoHiYaZO+Wp8R6vJYtK++ICRz3PMI7DDH9dyjwPQ8aO1O9iZ6u+fo7vMP/Yx3//POi/ngMrqoyFgX/jxz+7u+MmNE8LEbC2jWS55+pZNvrDB57+eaLybFXrl607eHX6UHwDcMTjB1Dlr8PAfQ17IbhjmCWwAlQ8AbOjJ/IAgFcvI6MAH5UIisFHikcIiv7RHH55Zff9OL31Rk7ZfX8ONfPhGbluTfyM8iOFCqYj5PMjYRuw3fBpgI7jXnHwYbH8hF/AQFkNfFrc/hhh6wU7F7gfnNkdm/NkUM27fhAxk5Z4NWrnpXvuN6fwY8oIFkAmxoX3tebtn3Px8IbuxxI8ng762Pft92cT6LgvTnb9aZ7K2yx4Ze1sB0LSwO8eLio3fi54pvuhflCJEACjiMAwRs2YIL6n3HzAm7F6dKmkTQIuvyrhiwkQALOJUDB69y2Yc1IgARIgARIgARIgARsIEDBawNEPoIESIAESIAESIAESMC5BCh4nds2rBkJkAAJkAAJkAAJkIANBCh4bYDIR5AACZAACZAACZAACTiXAAWvc9uGNSMBEiABEiABEiABErCBAAWvDRD5CBIgARIgARIgARIgAecSoOB1btuwZiRAAiRAAiRAAiRAAjYQoOC1ASIfQQIkQAIkQAIkQAIk4FwCFLzObRvWjARIgARIgARIgARIwAYCFLw2QOQjSIAESIAESIAESIAEnEuAgte5bcOakQAJkAAJkAAJkAAJ2ECAgtcGiHwECZAACZAACZAACZCAcwlQ8Dq3bVgzEiABEiABEiABEiABGwhQ8NoAkY8gARIgARIgARIgARJwLgEKXue2DWtGAiRAAiRAAiRAAiRgAwEKXhsg8hEkQAIkQAIkQAIkQALOJUDB69y2Yc1IgARIgARIgARIgARsIEDBawNEPoIESIAESIAESIAESMC5BCh4nds2rBkJkAAJkAAJkAAJkIANBCh4bYDIR5AACZAACZAACZAACTiXAAWvc9uGNSMBEiABEiABEiABErCBAAWvDRD5CBIgARIgARIgARIgAecSoOB1btuwZiRAAiRAAiRAAiRAAjYQoOC1ASIfQQIkQAIkQAIkQAIk4FwCFLzObRvWjARIgARIgARIgARIwAYCFLw2QOQjSIAESIAESIAESIAEnEuAgte5bcOakQAJkAAJkAAJkAAJ2ECAgtcGiHwECZAACZAACZAACZCAcwlQ8Dq3bVgzEiABEiABEiABEiABGwhQ8NoAkY8gARIgARIgARIgARJwLgEKXue2DWtGAiRAAiRAAiRAAiRgAwEKXhsg8hEkQAIkQAIkQAIkQALOJUDB69y2Yc1IgARIgARIgARIgARsIEDBawNEPoIESIAESIAESIAESMC5BCh4nds2rBkJkAAJkAAJkAAJkIANBCh4bYDIR5AACZAACZAACZAACTiXAAWvc9uGNSMBEiABEiABEiABErCBwH8B6XYtaN8YGTIAAAAASUVORK5CYII="
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -3633,48 +3584,68 @@
    ],
    "source": [
     "if results:\n",
-    "    asof_data = results_df.filter(pl.col(\"operation\") == \"asof_join\").sort(\"time_s\")\n",
-    "    if len(asof_data) > 0:\n",
+    "    # Visualization — every engine on a panel was timed under the one policy\n",
+    "    # stated at the top, so the bars are comparable.\n",
+    "    _panels = [\n",
+    "        (\"read\", \"Full scan\", COLORS[\"blue\"]),\n",
+    "        (\"range_query\", f\"Range query ({RANGE_QUERY_DAYS}-day window)\", COLORS[\"slate\"]),\n",
+    "        (\"asof_join\", \"ASOF join\", COLORS[\"amber\"]),\n",
+    "    ]\n",
+    "\n",
+    "    fig = make_subplots(\n",
+    "        rows=1,\n",
+    "        cols=len(_panels),\n",
+    "        subplot_titles=[title for _, title, _ in _panels],\n",
+    "        horizontal_spacing=0.12,\n",
+    "    )\n",
+    "\n",
+    "    for col, (op, _title, color) in enumerate(_panels, start=1):\n",
+    "        op_data = results_df.filter(pl.col(\"operation\") == op).sort(\"time_s\")\n",
+    "        if len(op_data) == 0:\n",
+    "            continue\n",
     "        fig.add_trace(\n",
     "            go.Bar(\n",
-    "                y=asof_data[\"database\"].to_list(),\n",
-    "                x=asof_data[\"time_s\"].to_list(),\n",
+    "                y=op_data[\"database\"].to_list(),\n",
+    "                x=op_data[\"time_s\"].to_list(),\n",
     "                orientation=\"h\",\n",
-    "                marker_color=\"#D4A84B\",\n",
-    "                name=\"ASOF Join\",\n",
-    "                text=[f\"{t:.3f}s\" for t in asof_data[\"time_s\"].to_list()],\n",
+    "                marker_color=color,\n",
+    "                text=[f\"{t:.3f}s\" for t in op_data[\"time_s\"].to_list()],\n",
     "                textposition=\"outside\",\n",
     "            ),\n",
     "            row=1,\n",
-    "            col=2,\n",
+    "            col=col,\n",
     "        )\n",
     "\n",
     "    fig.update_layout(\n",
-    "        title_text=f\"Database Comparison (Scale: {ACTIVE_SCALE})\",\n",
+    "        title_text=f\"Database Comparison ({ACTIVE_SCALE} scale, {total_rows:,} rows, warm reads)\",\n",
     "        height=500,\n",
     "        showlegend=False,\n",
+    "        paper_bgcolor=COLORS[\"bg_light\"],\n",
+    "        plot_bgcolor=COLORS[\"bg_light\"],\n",
+    "        # Wider right margin so the 'X.XXXs' value labels don't crop.\n",
+    "        margin=dict(l=90, r=90, t=80, b=50),\n",
     "    )\n",
-    "    # Use log scale for better visibility when timing spans orders of magnitude\n",
-    "    fig.update_xaxes(title_text=\"Seconds (log scale, lower is better)\", type=\"log\")\n",
+    "    # Log scale: timings span orders of magnitude across engines.\n",
+    "    fig.update_xaxes(title_text=\"Seconds (log, lower is better)\", type=\"log\")\n",
     "    fig.show()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 47,
    "id": "e48e9c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:13.149686Z",
-     "iopub.status.busy": "2026-07-11T19:12:13.149575Z",
-     "iopub.status.idle": "2026-07-11T19:12:13.232515Z",
-     "shell.execute_reply": "2026-07-11T19:12:13.232141Z"
+     "iopub.execute_input": "2026-07-16T21:07:22.750766Z",
+     "iopub.status.busy": "2026-07-16T21:07:22.750619Z",
+     "iopub.status.idle": "2026-07-16T21:07:23.620954Z",
+     "shell.execute_reply": "2026-07-16T21:07:23.620466Z"
     },
     "papermill": {
-     "duration": 0.088412,
-     "end_time": "2026-07-11T19:12:13.232943+00:00",
+     "duration": 0.876474,
+     "end_time": "2026-07-16T21:07:23.621263+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:13.144531+00:00",
+     "start_time": "2026-07-16T21:07:22.744789+00:00",
      "status": "completed"
     }
    },
@@ -3703,20 +3674,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 48,
    "id": "ba0df4dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T19:12:13.243854Z",
-     "iopub.status.busy": "2026-07-11T19:12:13.243734Z",
-     "iopub.status.idle": "2026-07-11T19:12:13.246532Z",
-     "shell.execute_reply": "2026-07-11T19:12:13.246181Z"
+     "iopub.execute_input": "2026-07-16T21:07:23.634012Z",
+     "iopub.status.busy": "2026-07-16T21:07:23.633858Z",
+     "iopub.status.idle": "2026-07-16T21:07:23.637944Z",
+     "shell.execute_reply": "2026-07-16T21:07:23.637351Z"
     },
     "papermill": {
-     "duration": 0.008859,
-     "end_time": "2026-07-11T19:12:13.246909+00:00",
+     "duration": 0.011305,
+     "end_time": "2026-07-16T21:07:23.638413+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:13.238050+00:00",
+     "start_time": "2026-07-16T21:07:23.627108+00:00",
      "status": "completed"
     }
    },
@@ -3727,7 +3698,7 @@
      "text": [
       "\n",
       "### BENCHMARK COVERAGE\n",
-      "Tested: 7/7 databases\n",
+      "Tested: 8/8 databases\n",
       "  [FAIL] ArcticDB (embedded)\n",
       "  [OK] ClickHouse (server)\n",
       "  [OK] DuckDB (embedded)\n",
@@ -3736,7 +3707,7 @@
       "  [OK] QuestDB (server)\n",
       "  [OK] SQLite (embedded)\n",
       "  [OK] TimescaleDB (server)\n",
-      "  [FAIL] kdb+/PyKX (hft)\n",
+      "  [OK] kdb+/PyKX (hft)\n",
       "\n",
       "======================================================================\n",
       "[OK] Database benchmark complete!\n",
@@ -3761,26 +3732,104 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "b422d9b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-16T21:07:23.650111Z",
+     "iopub.status.busy": "2026-07-16T21:07:23.649979Z",
+     "iopub.status.idle": "2026-07-16T21:07:23.653428Z",
+     "shell.execute_reply": "2026-07-16T21:07:23.653059Z"
+    },
+    "papermill": {
+     "duration": 0.008882,
+     "end_time": "2026-07-16T21:07:23.653679+00:00",
+     "exception": false,
+     "start_time": "2026-07-16T21:07:23.644797+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Fastest engine per operation (this run):\n",
+      "shape: (5, 3)\n",
+      "┌─────────────┬───────────┬──────────┐\n",
+      "│ operation   ┆ database  ┆ time_s   │\n",
+      "│ ---         ┆ ---       ┆ ---      │\n",
+      "│ str         ┆ str       ┆ f64      │\n",
+      "╞═════════════╪═══════════╪══════════╡\n",
+      "│ aggregation ┆ QuestDB   ┆ 0.013298 │\n",
+      "│ range_query ┆ kdb+/PyKX ┆ 0.017786 │\n",
+      "│ write       ┆ kdb+/PyKX ┆ 0.0271   │\n",
+      "│ read        ┆ kdb+/PyKX ┆ 0.061621 │\n",
+      "│ asof_join   ┆ kdb+/PyKX ┆ 0.168246 │\n",
+      "└─────────────┴───────────┴──────────┘\n",
+      "\n",
+      "Engines benchmarked: ClickHouse, DuckDB, InfluxDB, PostgreSQL, QuestDB, SQLite, TimescaleDB, kdb+/PyKX\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fastest engine per operation, read back off the results actually collected\n",
+    "# in THIS run. Anything not benchmarked here cannot appear.\n",
+    "if results:\n",
+    "    fastest = (\n",
+    "        results_df.drop_nulls(\"time_s\")\n",
+    "        .sort(\"time_s\")\n",
+    "        .group_by(\"operation\", maintain_order=True)\n",
+    "        .first()\n",
+    "        .select([\"operation\", \"database\", \"time_s\"])\n",
+    "    )\n",
+    "    print(\"\\nFastest engine per operation (this run):\")\n",
+    "    print(fastest)\n",
+    "    print(f\"\\nEngines benchmarked: {', '.join(sorted(results_df['database'].unique().to_list()))}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "0fe063ca",
    "metadata": {
     "papermill": {
-     "duration": 0.005091,
-     "end_time": "2026-07-11T19:12:13.257109+00:00",
+     "duration": 0.004443,
+     "end_time": "2026-07-16T21:07:23.662660+00:00",
      "exception": false,
-     "start_time": "2026-07-11T19:12:13.252018+00:00",
+     "start_time": "2026-07-16T21:07:23.658217+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## Key Takeaways\n",
     "\n",
-    "1. **Columnar formats dominate**: DuckDB and ClickHouse offer the best read/write\n",
-    "   throughput thanks to columnar storage and vectorized execution.\n",
-    "2. **ASOF joins vary widely**: kdb+ provides sub-millisecond ASOF joins natively,\n",
-    "   while SQL-based databases require more complex query patterns.\n",
-    "3. **Choose by workload**: DuckDB for embedded analytics, ClickHouse for OLAP at scale,\n",
-    "   TimescaleDB when PostgreSQL compatibility matters, QuestDB for high-ingest streaming.\n",
+    "The engine names below are deliberately absent: which engine wins each\n",
+    "operation is printed by the cell above, from this run's own results, on your\n",
+    "hardware. What generalizes is the shape of the answer, not the ordering:\n",
+    "\n",
+    "1. **Storage layout sets the scan cost.** Engines that store columns\n",
+    "   together and execute vectorized (DuckDB, ClickHouse) scan and aggregate a\n",
+    "   minute panel far faster than row-oriented engines (SQLite, PostgreSQL),\n",
+    "   which must touch every column of every row to answer a query about two.\n",
+    "2. **A range query is a different question from a scan**, and it is the one a\n",
+    "   backtest asks. The `RANGE_QUERY_DAYS`-day window above touches roughly a\n",
+    "   fifth of the panel, so engines that prune by time partition or use a\n",
+    "   time-ordered index separate from those that scan and filter. Ranking\n",
+    "   engines on full scans alone would hide that.\n",
+    "3. **Ingest rate and durability are one number, not two.** The write times\n",
+    "   here all end when the data is queryable, which is why the engines that\n",
+    "   acknowledge early (QuestDB ILP, InfluxDB) do not look free.\n",
+    "4. **The comparison is only as good as its policy.** Every number above is a\n",
+    "   single cold write and a warm mean read, for every engine. Warm reads\n",
+    "   flatter anything with a buffer pool; on a cold cache, or over a network,\n",
+    "   the compressed engines gain. Rerun on your own ingestion path before\n",
+    "   choosing.\n",
+    "\n",
+    "**kdb+/PyKX** is skipped unless you supply a q binary and a license, so it is\n",
+    "absent from the numbers above unless you configured it. The chapter discusses\n",
+    "where it fits; this notebook does not claim a result it did not measure.\n",
     "\n",
     "**Next**: See `20_storage_benchmark_file` for file-format benchmarks (Parquet, Arrow, HDF5)."
    ]
@@ -3805,26 +3854,27 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.14.6"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "691103b19c5f051f7ee1941a0684bb5ba08e7cdb",
+   "executed_at": "2026-07-16T21:08:10.291267+00:00",
+   "executor": "benchmark",
+   "production": true,
+   "parameters": {},
+   "notes": "L scale; benchmark image (uv.lock-pinned: pandas 2.3.3) + all 5 DB services + kdb+/PyKX 4.0 via IPC; 8/8 engines, all reads validated"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1078.971264,
-   "end_time": "2026-07-11T19:12:16.080020+00:00",
+   "duration": 435.042619,
+   "end_time": "2026-07-16T21:07:26.483678+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "02_financial_data_universe/21_storage_benchmark_database.ipynb",
    "output_path": "02_financial_data_universe/21_storage_benchmark_database.ipynb",
    "parameters": {},
-   "start_time": "2026-07-11T18:54:17.108756+00:00",
+   "start_time": "2026-07-16T21:00:11.441059+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "526bd45847a3d65d79061c057ed6a5d6e00f73cd",
-   "executed_at": "2026-07-11T19:12:42.005958+00:00",
-   "executor": "benchmark-docker",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/02_financial_data_universe/21_storage_benchmark_database.py
+++ b/02_financial_data_universe/21_storage_benchmark_database.py
@@ -41,8 +41,56 @@
 # 1. **Write** - Bulk insert performance
 # 2. **Read** - Full table scan
 # 3. **Range Query** - 7-day time window (backtesting workflow)
-# 4. **OHLCV Aggregation** - Resample to bars
+# 4. **OHLCV Aggregation** - Resample minute bars to daily bars
 # 5. **ASOF Join** - Trade-quote alignment (critical for microstructure)
+#
+# ## Timing Policy
+#
+# One policy, applied identically to every engine. Engines that were timed
+# under different rules would not belong on the same chart, so the rules are
+# stated here and enforced by the `time_write` / `time_read` helpers rather
+# than by per-call arguments:
+#
+# - **Writes** (`time_write`) - a single shot, no warm-up, against a table
+#   created fresh for the run. Bulk load happens once per dataset, so that is
+#   what we time. Repeating it would append duplicate rows on the append-only
+#   engines, or require a teardown that is not part of the write.
+# - **Durability inside the timed region.** PostgreSQL and TimescaleDB commit
+#   synchronously, so their flush cost is inside the timed call. QuestDB (ILP
+#   + WAL) and InfluxDB acknowledge before the rows are queryable, so they
+#   poll to first-queryable via `wait_until_rows_visible` *inside* the timed
+#   call. Every write time therefore ends at the same event: the data is
+#   durable and readable.
+# - **Reads, aggregations, and joins** (`time_read`) - mean of `TIMING_RUNS`
+#   runs after one untimed warm-up. **These are warm numbers**, on both the OS
+#   page cache and each server's buffer pool, and they flatter every engine
+#   that caches. A client cannot drop a server's cache, so a "cold" read here
+#   would be cold for the embedded engines and warm for the servers - neither
+#   cold nor comparable. Warm and uniform is the measurable choice; §2.4 says
+#   so where it reports these figures.
+# - **Every read is validated** against the expected row count. A query that
+#   silently returns a truncated result would otherwise post the fastest time
+#   on the chart.
+#
+# ## What the size column does and does not mean
+#
+# Unlike the timings, on-disk size is **not** measured the same way for every
+# engine, because each engine only exposes its own accounting. Read the size
+# column as "what this engine reports it is using", not as a like-for-like
+# compression ratio:
+#
+# | Engine | Reported by | Counts |
+# |--------|-------------|--------|
+# | SQLite / DuckDB | file size on disk | the database file |
+# | ClickHouse | `system.parts.bytes_on_disk` | **compressed** data parts |
+# | QuestDB | `table_storage().diskSize` | the table's full on-disk footprint |
+# | PostgreSQL / TimescaleDB | `pg_total_relation_size` / `hypertable_size` | table **plus indexes** (and, for the hypertable, all its chunks) |
+# | InfluxDB | *not exposed* | client API reports no per-bucket size, so it is left empty rather than recorded as zero |
+#
+# Comparing ClickHouse's compressed parts against PostgreSQL's table-plus-index
+# total is not a compression comparison. The file-format notebook
+# (`20_storage_benchmark_file`) is where size is measured identically across
+# contenders and can be compared directly.
 #
 # ## Quick Start
 #
@@ -72,7 +120,18 @@ import time as time_module
 import urllib.parse
 import urllib.request
 import warnings
+from datetime import UTC, timedelta
 from pathlib import Path
+
+# %% tags=["parameters"]
+# Production scale follows chapter §2.4 prose ("L scale, ~1 M OHLCV rows").
+# Override via Papermill for CI: BENCHMARK_SCALE = "S".
+BENCHMARK_SCALE = "L"
+
+# %%
+# storage_benchmarks reads BENCHMARK_SCALE at import time, so the env var must
+# be set before the import below.
+os.environ["BENCHMARK_SCALE"] = BENCHMARK_SCALE
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -99,18 +158,18 @@ from utils.storage_benchmarks import (
     get_scale_config,
     save_benchmark_results,
     save_chart,
-    time_operation,
+    time_read,
+    time_write,
     validate_result,
+    wait_until_rows_visible,
 )
+from utils.style import COLORS
 
 warnings.filterwarnings("ignore")
 
 # %%
 OUTPUT_DIR = get_output_dir(2, "storage_benchmark")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
-# %% tags=["parameters"]
-# Production defaults — Papermill injects overrides for CI
 
 # %% [markdown]
 # ## Check Available Databases
@@ -266,32 +325,41 @@ Q_BINARY_LOCATIONS = [
 ]
 KX_LICENSE_DIRS = [Path.home() / ".pykx", Path.home() / ".kx"]
 
-try:
-    os.environ["PYKX_UNLICENSED"] = "1"  # Import PyKX without license check
-    import pykx as kx
+# Look for the q binary and a licence BEFORE importing PyKX. The order matters:
+# PyKX must never be imported in unlicensed mode (`PYKX_UNLICENSED=1`), which is
+# what this cell used to do. Unlicensed PyKX 4.0 leaves the process in a state
+# where later numpy work segfaults — the crash lands in `generate_ohlcv_data`,
+# nowhere near this cell, so it reads as a data bug rather than an import one.
+# Without a licence there is nothing to benchmark anyway, so we simply do not
+# import PyKX at all and skip kdb+.
+for q_path in Q_BINARY_LOCATIONS:
+    if q_path.exists() and q_path.is_file():
+        Q_BINARY = q_path
+        break
 
-    # Find q binary
-    for q_path in Q_BINARY_LOCATIONS:
-        if q_path.exists() and q_path.is_file():
-            Q_BINARY = q_path
-            break
+KX_LICENSE_FILE = next(
+    (d / f for d in KX_LICENSE_DIRS for f in ("kc.lic", "k4.lic") if (d / f).exists()), None
+)
 
-    # Check for license
-    has_license = any((d / "kc.lic").exists() or (d / "k4.lic").exists() for d in KX_LICENSE_DIRS)
+if Q_BINARY is None or KX_LICENSE_FILE is None:
+    print("○ PyKX/kdb+: Optional (not configured) — skipping, no result will be claimed")
+    if Q_BINARY is None:
+        print("    → Get a free personal edition: https://kx.com/kdb-personal-edition-download/")
+        print(f"    → Install the q binary to: {Q_BINARY_LOCATIONS[0]}")
+    if KX_LICENSE_FILE is None:
+        print(f"    → Place the licence file (kc.lic) in: {KX_LICENSE_DIRS[0]}")
+else:
+    try:
+        # q resolves its licence from QLIC, not from the file merely existing on
+        # disk: without this the q process starts and dies "no license loaded".
+        os.environ["QLIC"] = str(KX_LICENSE_FILE.parent)
+        import pykx as kx
 
-    if Q_BINARY and has_license:
         HAS_PYKX = True
         benchmark_status["kdb+/PyKX"]["expected"] = True
-        print("[OK] PyKX/kdb+: Available (IPC mode)")
-    else:
-        print("○ PyKX/kdb+: Optional (not configured)")
-        if not Q_BINARY:
-            print("    → Get free personal license: https://kx.com/kdb-personal-edition-download/")
-            print(f"    → Install q binary to: {Q_BINARY_LOCATIONS[0]}")
-        if not has_license:
-            print(f"    → Place license file (kc.lic) in: {KX_LICENSE_DIRS[0]}")
-except ImportError:
-    print("○ PyKX/kdb+: Not installed (optional - uv pip install pykx)")
+        print(f"[OK] PyKX/kdb+ {kx.__version__}: Available (IPC mode, licence {KX_LICENSE_FILE})")
+    except ImportError:
+        print("○ PyKX/kdb+: Not installed (optional — `uv pip install pykx`)")
 
 # %%
 # Availability summary
@@ -339,6 +407,41 @@ quotes_pandas = quotes_df.to_pandas()
 results: list[BenchmarkResult] = []
 
 # %% [markdown]
+# ## Benchmark Windows
+#
+# Two derived quantities that every engine below reuses, so that all engines
+# answer the *same* question and can be validated against the same expected
+# row count:
+#
+# - **Range query**: the first 7 calendar days of the panel — the slice a
+#   backtest walks. Against session-aware minute bars this covers 5 trading
+#   sessions, a real fraction of the panel rather than a full scan.
+# - **Aggregation**: minute bars resampled to **daily** bars. Every engine
+#   buckets by day; bucketing minute data by minute would be a near-identity
+#   for the engines that did it and a real reduction for the ones that didn't,
+#   which is not a comparison.
+
+# %%
+RANGE_QUERY_DAYS = 7
+
+range_start = ohlcv_df["timestamp"].min()
+range_end = range_start + timedelta(days=RANGE_QUERY_DAYS)
+range_expected_rows = ohlcv_df.filter(
+    (pl.col("timestamp") >= range_start) & (pl.col("timestamp") < range_end)
+).height
+agg_expected_rows = ohlcv_df.select(
+    pl.struct("symbol", pl.col("timestamp").dt.truncate("1d")).n_unique()
+).item()
+
+n_sessions = ohlcv_df.select(pl.col("timestamp").dt.date().n_unique()).item()
+print(f"Panel spans {n_sessions} trading sessions: {range_start} → {ohlcv_df['timestamp'].max()}")
+print(
+    f"Range query  : {range_start} ≤ timestamp < {range_end} "
+    f"→ {range_expected_rows:,} rows ({range_expected_rows / total_rows:.1%} of panel)"
+)
+print(f"Aggregation  : minute bars → {agg_expected_rows:,} daily bars")
+
+# %% [markdown]
 # ---
 # # Part 1: Embedded Databases
 # ---
@@ -370,8 +473,7 @@ def write_sqlite():
         conn.execute("CREATE INDEX IF NOT EXISTS idx_symbol_timestamp ON ohlcv(symbol, timestamp)")
 
 
-gc.collect()
-write_time, _ = time_operation(write_sqlite)
+write_time, _ = time_write(write_sqlite)
 sqlite_size = sqlite_path.stat().st_size
 results.append(BenchmarkResult("SQLite", "write", write_time, sqlite_size, total_rows))
 
@@ -386,34 +488,73 @@ def read_sqlite():
     return force_materialize_pandas(df)
 
 
-gc.collect()
-read_time, sqlite_result = time_operation(read_sqlite)
+read_time, sqlite_result = time_read(read_sqlite)
 validate_result(sqlite_result, total_rows, "SQLite read")
 results.append(BenchmarkResult("SQLite", "read", read_time, sqlite_size, total_rows))
 
 # %% [markdown]
+# ### SQLite Range Query
+#
+# SQLite stores the timestamps as ISO-8601 text, which sorts lexicographically,
+# so the string bounds below use the covering `(symbol, timestamp)` index.
+
+
+# %%
+SQLITE_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def sqlite_range_query():
+    with contextlib.closing(sqlite3.connect(sqlite_path)) as conn:
+        df = pd.read_sql(
+            "SELECT * FROM ohlcv WHERE timestamp >= ? AND timestamp < ?",
+            conn,
+            params=(range_start.strftime(SQLITE_TS_FMT), range_end.strftime(SQLITE_TS_FMT)),
+        )
+    return force_materialize_pandas(df)
+
+
+range_time, sqlite_range = time_read(sqlite_range_query)
+validate_result(sqlite_range, range_expected_rows, "SQLite range query")
+results.append(BenchmarkResult("SQLite", "range_query", range_time, 0, len(sqlite_range)))
+
+# %% [markdown]
 # ### SQLite OHLCV Aggregation
+#
+# `open` is the first price of the session and `close` the last, ordered by
+# time — not `MIN(open)` / `MAX(close)`, which are a different (and wrong)
+# statistic. SQLite has no `first`/`last` aggregate, so the OHLCV reduction
+# needs window functions. That costs SQLite time relative to the engines with
+# native `first`/`last`, and that cost is the honest answer to "what does this
+# aggregation take on SQLite?"
 
 
 # %%
 def sqlite_aggregation():
     with contextlib.closing(sqlite3.connect(sqlite_path)) as conn:
         query = """
-            SELECT symbol, date(timestamp) as date,
-                   MIN(open) as open, MAX(high) as high, MIN(low) as low,
-                   MAX(close) as close, SUM(volume) as volume
-            FROM ohlcv GROUP BY symbol, date(timestamp)
+            SELECT DISTINCT symbol, date(timestamp) as bar_date,
+                   FIRST_VALUE(open) OVER w as open,
+                   MAX(high) OVER w as high,
+                   MIN(low) OVER w as low,
+                   LAST_VALUE(close) OVER w as close,
+                   SUM(volume) OVER w as volume
+            FROM ohlcv
+            WINDOW w AS (
+                PARTITION BY symbol, date(timestamp) ORDER BY timestamp
+                ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+            )
         """
         return pd.read_sql(query, conn)
 
 
-gc.collect()
-agg_time, agg_result = time_operation(sqlite_aggregation)
+agg_time, agg_result = time_read(sqlite_aggregation)
+validate_result(agg_result, agg_expected_rows, "SQLite aggregation")
 results.append(BenchmarkResult("SQLite", "aggregation", agg_time, 0, len(agg_result)))
 
 print(f"\nSQLite: {sqlite_size / 1e6:.1f} MB")
 print(f"  Write: {write_time:.3f}s ({total_rows / write_time / 1e6:.2f}M rows/s)")
 print(f"  Read:  {read_time:.3f}s ({total_rows / read_time / 1e6:.2f}M rows/s)")
+print(f"  Range query: {range_time:.3f}s ({len(sqlite_range):,} rows)")
 print(f"  Aggregation: {agg_time:.3f}s ({len(agg_result):,} daily bars)")
 print("  Note: No native ASOF join")
 
@@ -448,8 +589,7 @@ def write_duckdb():
     conn.close()
 
 
-gc.collect()
-write_time, _ = time_operation(write_duckdb, n_runs=1, warmup=False)
+write_time, _ = time_write(write_duckdb)
 duckdb_size = duckdb_path.stat().st_size
 results.append(BenchmarkResult("DuckDB", "write", write_time, duckdb_size, total_rows))
 
@@ -462,10 +602,25 @@ def read_duckdb():
     return force_materialize_polars(df)
 
 
-gc.collect()
-read_time, duckdb_result = time_operation(read_duckdb)
+read_time, duckdb_result = time_read(read_duckdb)
 validate_result(duckdb_result, total_rows, "DuckDB read")
 results.append(BenchmarkResult("DuckDB", "read", read_time, duckdb_size, total_rows))
+
+
+# %%
+# Range query
+def duckdb_range_query():
+    conn = duckdb.connect(str(duckdb_path), read_only=True)
+    df = conn.execute(
+        "SELECT * FROM ohlcv WHERE timestamp >= ? AND timestamp < ?", [range_start, range_end]
+    ).pl()
+    conn.close()
+    return force_materialize_polars(df)
+
+
+range_time, duckdb_range = time_read(duckdb_range_query)
+validate_result(duckdb_range, range_expected_rows, "DuckDB range query")
+results.append(BenchmarkResult("DuckDB", "range_query", range_time, 0, len(duckdb_range)))
 
 
 # %%
@@ -473,17 +628,18 @@ results.append(BenchmarkResult("DuckDB", "read", read_time, duckdb_size, total_r
 def duckdb_aggregation():
     conn = duckdb.connect(str(duckdb_path), read_only=True)
     result = conn.execute("""
-        SELECT symbol, date_trunc('day', timestamp) as date,
-               FIRST(open) as open, MAX(high) as high, MIN(low) as low,
-               LAST(close) as close, SUM(volume) as volume
-        FROM ohlcv GROUP BY symbol, date ORDER BY symbol, date
+        SELECT symbol, date_trunc('day', timestamp) as bar_date,
+               FIRST(open ORDER BY timestamp) as open, MAX(high) as high,
+               MIN(low) as low, LAST(close ORDER BY timestamp) as close,
+               SUM(volume) as volume
+        FROM ohlcv GROUP BY symbol, bar_date ORDER BY symbol, bar_date
     """).pl()
     conn.close()
     return result
 
 
-gc.collect()
-agg_time, agg_result = time_operation(duckdb_aggregation)
+agg_time, agg_result = time_read(duckdb_aggregation)
+validate_result(agg_result, agg_expected_rows, "DuckDB aggregation")
 results.append(BenchmarkResult("DuckDB", "aggregation", agg_time, 0, len(agg_result)))
 
 # ASOF Join
@@ -505,13 +661,14 @@ def duckdb_asof():
     return result
 
 
-gc.collect()
-asof_time, asof_result = time_operation(duckdb_asof)
+asof_time, asof_result = time_read(duckdb_asof)
+validate_result(asof_result, N_TICKS_TRADES, "DuckDB ASOF join")
 results.append(BenchmarkResult("DuckDB", "asof_join", asof_time, 0, len(asof_result)))
 
 print(f"\nDuckDB: {duckdb_size / 1e6:.1f} MB")
 print(f"  Write: {write_time:.3f}s ({total_rows / write_time / 1e6:.2f}M rows/s)")
 print(f"  Read:  {read_time:.3f}s ({total_rows / read_time / 1e6:.2f}M rows/s)")
+print(f"  Range query: {range_time:.3f}s ({len(duckdb_range):,} rows)")
 print(f"  Aggregation: {agg_time:.3f}s ({len(agg_result):,} daily bars)")
 print(f"  ASOF Join: {asof_time:.3f}s ({N_TICKS_TRADES / asof_time / 1e6:.2f}M trades/s)")
 
@@ -541,8 +698,7 @@ if HAS_ARCTICDB:
     def write_arctic():
         lib.write("ohlcv", ohlcv_pandas, prune_previous_versions=True)
 
-    gc.collect()
-    write_time, _ = time_operation(write_arctic, n_runs=min(2, TIMING_RUNS))
+    write_time, _ = time_write(write_arctic)
     arctic_size = sum(f.stat().st_size for f in arctic_path.rglob("*") if f.is_file())
     results.append(BenchmarkResult("ArcticDB", "write", write_time, arctic_size, total_rows))
 
@@ -550,10 +706,16 @@ if HAS_ARCTICDB:
         df = lib.read("ohlcv").data
         return force_materialize_pandas(df)
 
-    gc.collect()
-    read_time, arctic_result = time_operation(read_arctic, n_runs=min(2, TIMING_RUNS))
+    read_time, arctic_result = time_read(read_arctic, n_runs=min(2, TIMING_RUNS))
     validate_result(arctic_result, total_rows, "ArcticDB read")
     results.append(BenchmarkResult("ArcticDB", "read", read_time, arctic_size, total_rows))
+
+    # No range_query for ArcticDB: its server-side `date_range` filter keys off a
+    # datetime *index*, and this panel carries `timestamp` as a column (the
+    # canonical schema). Pushing the filter down would need a different write
+    # layout than the one benchmarked above, so ArcticDB is absent from the
+    # range-query chart rather than being timed on a client-side filter that no
+    # other engine pays.
 
     def arctic_aggregation():
         df = lib.read("ohlcv").data
@@ -569,8 +731,7 @@ if HAS_ARCTICDB:
             .reset_index()
         )
 
-    gc.collect()
-    agg_time, agg_result = time_operation(arctic_aggregation, n_runs=min(2, TIMING_RUNS))
+    agg_time, agg_result = time_read(arctic_aggregation, n_runs=min(2, TIMING_RUNS))
     results.append(BenchmarkResult("ArcticDB", "aggregation", agg_time, 0, len(agg_result)))
 
     print(f"\nArcticDB: {arctic_size / 1e6:.1f} MB")
@@ -618,7 +779,7 @@ if HAS_CLICKHOUSE:
     def write_clickhouse():
         ch_client.insert_df("ohlcv_benchmark", ohlcv_pandas)
 
-    ch_write_time, _ = time_operation(write_clickhouse, n_runs=1, warmup=False)
+    ch_write_time, _ = time_write(write_clickhouse)
     ch_size = (
         ch_client.query(
             "SELECT sum(bytes_on_disk) FROM system.parts WHERE table = 'ohlcv_benchmark'"
@@ -631,23 +792,40 @@ if HAS_CLICKHOUSE:
     def read_clickhouse():
         return ch_client.query_df("SELECT * FROM ohlcv_benchmark")
 
-    ch_read_time, ch_result = time_operation(read_clickhouse, n_runs=min(3, TIMING_RUNS))
+    ch_read_time, ch_result = time_read(read_clickhouse, n_runs=min(3, TIMING_RUNS))
     validate_result(ch_result, total_rows, "ClickHouse read")
     results.append(BenchmarkResult("ClickHouse", "read", ch_read_time, ch_size, total_rows))
 
 # %%
 if HAS_CLICKHOUSE:
-    # Aggregation
+    # Range query
+    def clickhouse_range_query():
+        return ch_client.query_df(
+            "SELECT * FROM ohlcv_benchmark WHERE timestamp >= %(start)s AND timestamp < %(end)s",
+            parameters={"start": range_start, "end": range_end},
+        )
+
+    ch_range_time, ch_range_result = time_read(clickhouse_range_query, n_runs=min(3, TIMING_RUNS))
+    validate_result(ch_range_result, range_expected_rows, "ClickHouse range query")
+    results.append(
+        BenchmarkResult("ClickHouse", "range_query", ch_range_time, 0, len(ch_range_result))
+    )
+
+# %%
+if HAS_CLICKHOUSE:
+    # Aggregation — bucket to DAY, matching every other engine.
     def clickhouse_ohlcv():
         return ch_client.query_df("""
-            SELECT symbol, toStartOfMinute(timestamp) as bar_time,
+            SELECT symbol, toStartOfDay(timestamp) as bar_time,
                    argMin(open, timestamp) as open, max(high) as high,
                    min(low) as low, argMax(close, timestamp) as close,
                    sum(volume) as volume
             FROM ohlcv_benchmark GROUP BY symbol, bar_time ORDER BY symbol, bar_time
         """)
 
-    ch_agg_time, ch_agg_result = time_operation(clickhouse_ohlcv, n_runs=min(3, TIMING_RUNS))
+    ch_agg_time, ch_agg_result = time_read(clickhouse_ohlcv, n_runs=min(3, TIMING_RUNS))
+    validate_result(ch_agg_result, agg_expected_rows, "ClickHouse aggregation")
+    results.append(BenchmarkResult("ClickHouse", "aggregation", ch_agg_time, 0, len(ch_agg_result)))
 
 # %%
 if HAS_CLICKHOUSE:
@@ -686,12 +864,14 @@ if HAS_CLICKHOUSE:
             ON t.symbol = q.symbol AND t.timestamp >= q.timestamp
         """)
 
-    ch_asof_time, ch_asof_result = time_operation(clickhouse_asof, n_runs=min(3, TIMING_RUNS))
+    ch_asof_time, ch_asof_result = time_read(clickhouse_asof, n_runs=min(3, TIMING_RUNS))
+    validate_result(ch_asof_result, N_TICKS_TRADES, "ClickHouse ASOF join")
     results.append(BenchmarkResult("ClickHouse", "asof_join", ch_asof_time, 0, len(ch_asof_result)))
 
     print(f"\nClickHouse: {ch_size / 1e6:.1f} MB")
     print(f"  Write: {ch_write_time:.3f}s | Read: {ch_read_time:.3f}s")
-    print(f"  Aggregation: {ch_agg_time:.3f}s ({len(ch_agg_result):,} bars)")
+    print(f"  Range query: {ch_range_time:.3f}s ({len(ch_range_result):,} rows)")
+    print(f"  Aggregation: {ch_agg_time:.3f}s ({len(ch_agg_result):,} daily bars)")
     print(f"  ASOF Join: {ch_asof_time:.3f}s ({len(ch_asof_result):,} rows)")
 
     ch_client.command("DROP TABLE IF EXISTS ohlcv_benchmark")
@@ -717,10 +897,29 @@ if HAS_QUESTDB:
     benchmark_status["QuestDB"]["tested"] = True
     from questdb.ingress import Sender
 
-    def questdb_query(sql):
-        url = f"http://{DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']}/exec?query={urllib.parse.quote(sql)}"
-        response = urllib.request.urlopen(url, timeout=30)
+    def questdb_query(sql, limit: str | None = None):
+        """Run SQL over QuestDB's HTTP endpoint.
+
+        `/exec` caps the JSON result set unless an explicit `limit` is given, so
+        every full-result query below passes one. Without it the endpoint
+        returns a truncated page: a fast time on a wrong answer.
+        """
+        url = (
+            f"http://{DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']}"
+            f"/exec?query={urllib.parse.quote(sql)}"
+        )
+        if limit is not None:
+            url += f"&limit={limit}"
+        response = urllib.request.urlopen(url, timeout=600)
         return json.loads(response.read())
+
+    def questdb_row_count() -> int:
+        try:
+            payload = questdb_query("SELECT count() FROM ohlcv_benchmark")
+        except Exception:
+            return 0  # table not created yet
+        dataset = payload.get("dataset") or [[0]]
+        return int(dataset[0][0])
 
     with contextlib.suppress(Exception):
         questdb_query("DROP TABLE IF EXISTS ohlcv_benchmark")
@@ -733,7 +932,10 @@ if HAS_QUESTDB:
         ) timestamp(timestamp) PARTITION BY DAY WAL
     """)
 
-    # Write via ILP
+    # Write via ILP. The WAL commit is polled INSIDE the timed region so that
+    # QuestDB's write time ends where PostgreSQL's does: when the rows are
+    # queryable. The previous fixed sleep sat outside the timed call, which
+    # charged QuestDB nothing for durability.
     def write_questdb():
         with Sender.from_conf(
             f"http::addr={DB_CONFIG['questdb']['host']}:{DB_CONFIG['questdb']['http_port']};"
@@ -743,35 +945,69 @@ if HAS_QUESTDB:
             sender.dataframe(
                 df_insert, table_name="ohlcv_benchmark", symbols=["symbol"], at="timestamp"
             )
+        return wait_until_rows_visible(
+            questdb_row_count, total_rows, timeout=max(60.0, WAL_FLUSH_TIMEOUT * 20)
+        )
 
-    qdb_write_time, _ = time_operation(write_questdb, n_runs=1, warmup=False)
-    time_module.sleep(WAL_FLUSH_TIMEOUT)
-    results.append(BenchmarkResult("QuestDB", "write", qdb_write_time, 0, total_rows))
+    qdb_write_time, qdb_visible = time_write(write_questdb)
+    assert qdb_visible == total_rows, f"QuestDB ingested {qdb_visible:,} of {total_rows:,}"
+    qdb_size = int(
+        questdb_query(
+            "SELECT sum(diskSize) FROM table_storage() WHERE tableName = 'ohlcv_benchmark'"
+        )["dataset"][0][0]
+        or 0
+    )
+    results.append(BenchmarkResult("QuestDB", "write", qdb_write_time, qdb_size, total_rows))
 
 # %%
 if HAS_QUESTDB:
-    # Read
+    # Read — explicit limit so the endpoint returns the whole table, then
+    # validated like every other engine's read.
     def read_questdb():
-        return questdb_query("SELECT * FROM ohlcv_benchmark")
+        return questdb_query("SELECT * FROM ohlcv_benchmark", limit=f"1,{total_rows}")
 
-    qdb_read_time, _ = time_operation(read_questdb, n_runs=min(3, TIMING_RUNS))
-    results.append(BenchmarkResult("QuestDB", "read", qdb_read_time, 0, total_rows))
+    qdb_read_time, qdb_result = time_read(read_questdb, n_runs=min(3, TIMING_RUNS))
+    validate_result(qdb_result, total_rows, "QuestDB read")
+    results.append(BenchmarkResult("QuestDB", "read", qdb_read_time, qdb_size, total_rows))
 
-    # OHLCV aggregation (SAMPLE BY)
+    # Range query
+    def questdb_range_query():
+        sql = (
+            "SELECT * FROM ohlcv_benchmark "
+            f"WHERE timestamp >= '{range_start.isoformat()}' "
+            f"AND timestamp < '{range_end.isoformat()}'"
+        )
+        return questdb_query(sql, limit=f"1,{range_expected_rows}")
+
+    qdb_range_time, qdb_range_result = time_read(questdb_range_query, n_runs=min(3, TIMING_RUNS))
+    validate_result(qdb_range_result, range_expected_rows, "QuestDB range query")
+    results.append(
+        BenchmarkResult(
+            "QuestDB", "range_query", qdb_range_time, 0, len(qdb_range_result["dataset"])
+        )
+    )
+
+    # OHLCV aggregation (SAMPLE BY) — daily buckets, matching every other engine
     def questdb_ohlcv():
-        return questdb_query("""
+        return questdb_query(
+            """
             SELECT symbol, timestamp as bar_time,
                    first(open) as open, max(high) as high, min(low) as low,
                    last(close) as close, sum(volume) as volume
-            FROM ohlcv_benchmark SAMPLE BY 1m ALIGN TO CALENDAR
-        """)
+            FROM ohlcv_benchmark SAMPLE BY 1d ALIGN TO CALENDAR
+            """,
+            limit=f"1,{agg_expected_rows}",
+        )
 
-    qdb_agg_time, qdb_agg_result = time_operation(questdb_ohlcv, n_runs=min(3, TIMING_RUNS))
-    qdb_agg_rows = len(qdb_agg_result.get("dataset", [])) if qdb_agg_result else 0
+    qdb_agg_time, qdb_agg_result = time_read(questdb_ohlcv, n_runs=min(3, TIMING_RUNS))
+    validate_result(qdb_agg_result, agg_expected_rows, "QuestDB aggregation")
+    qdb_agg_rows = len(qdb_agg_result["dataset"])
+    results.append(BenchmarkResult("QuestDB", "aggregation", qdb_agg_time, 0, qdb_agg_rows))
 
-    print("\nQuestDB:")
-    print(f"  Write (ILP): {qdb_write_time:.3f}s | Read: {qdb_read_time:.3f}s")
-    print(f"  OHLCV aggregation: {qdb_agg_time:.3f}s ({qdb_agg_rows} bars)")
+    print(f"\nQuestDB: {qdb_size / 1e6:.1f} MB")
+    print(f"  Write (ILP, to queryable): {qdb_write_time:.3f}s | Read: {qdb_read_time:.3f}s")
+    print(f"  Range query: {qdb_range_time:.3f}s ({len(qdb_range_result['dataset']):,} rows)")
+    print(f"  OHLCV aggregation: {qdb_agg_time:.3f}s ({qdb_agg_rows:,} daily bars)")
 
     with contextlib.suppress(Exception):
         questdb_query("DROP TABLE IF EXISTS ohlcv_benchmark")
@@ -844,8 +1080,11 @@ if HAS_TIMESCALEDB:
             data,
         )
 
-    ts_write_time, _ = time_operation(write_timescaledb, n_runs=1, warmup=False)
-    cur.execute("SELECT pg_total_relation_size('ohlcv_benchmark');")
+    ts_write_time, _ = time_write(write_timescaledb)
+    # hypertable_size(), not pg_total_relation_size(): a hypertable's rows live
+    # in child chunks, so the parent relation is empty and pg_total_relation_size
+    # reports ~16 kB of catalog overhead rather than the data.
+    cur.execute("SELECT hypertable_size('ohlcv_benchmark');")
     ts_size = cur.fetchone()[0]
     results.append(BenchmarkResult("TimescaleDB", "write", ts_write_time, ts_size, total_rows))
 
@@ -856,27 +1095,46 @@ if HAS_TIMESCALEDB:
         cur.execute("SELECT * FROM ohlcv_benchmark;")
         return cur.fetchall()
 
-    ts_read_time, ts_result = time_operation(read_timescaledb, n_runs=min(3, TIMING_RUNS))
+    ts_read_time, ts_result = time_read(read_timescaledb, n_runs=min(3, TIMING_RUNS))
     validate_result(ts_result, total_rows, "TimescaleDB read")
     results.append(BenchmarkResult("TimescaleDB", "read", ts_read_time, ts_size, total_rows))
 
 # %%
 if HAS_TIMESCALEDB:
-    # Aggregation (time_bucket)
+    # Range query
+    def timescaledb_range_query():
+        cur.execute(
+            "SELECT * FROM ohlcv_benchmark WHERE timestamp >= %s AND timestamp < %s;",
+            (range_start, range_end),
+        )
+        return cur.fetchall()
+
+    ts_range_time, ts_range_result = time_read(timescaledb_range_query, n_runs=min(3, TIMING_RUNS))
+    validate_result(ts_range_result, range_expected_rows, "TimescaleDB range query")
+    results.append(
+        BenchmarkResult("TimescaleDB", "range_query", ts_range_time, 0, len(ts_range_result))
+    )
+
+    # Aggregation (time_bucket) — daily buckets, matching every other engine
     def timescaledb_ohlcv():
         cur.execute("""
-            SELECT symbol, time_bucket('1 minute', timestamp) as bar_time,
+            SELECT symbol, time_bucket('1 day', timestamp) as bar_time,
                    first(open, timestamp) as open, max(high) as high,
                    min(low) as low, last(close, timestamp) as close, sum(volume) as volume
             FROM ohlcv_benchmark GROUP BY symbol, bar_time ORDER BY symbol, bar_time;
         """)
         return cur.fetchall()
 
-    ts_agg_time, ts_agg_result = time_operation(timescaledb_ohlcv, n_runs=min(3, TIMING_RUNS))
+    ts_agg_time, ts_agg_result = time_read(timescaledb_ohlcv, n_runs=min(3, TIMING_RUNS))
+    validate_result(ts_agg_result, agg_expected_rows, "TimescaleDB aggregation")
+    results.append(
+        BenchmarkResult("TimescaleDB", "aggregation", ts_agg_time, 0, len(ts_agg_result))
+    )
 
     print(f"\nTimescaleDB: {ts_size / 1e6:.1f} MB")
     print(f"  Write: {ts_write_time:.3f}s | Read: {ts_read_time:.3f}s")
-    print(f"  OHLCV aggregation: {ts_agg_time:.3f}s ({len(ts_agg_result):,} bars)")
+    print(f"  Range query: {ts_range_time:.3f}s ({len(ts_range_result):,} rows)")
+    print(f"  OHLCV aggregation: {ts_agg_time:.3f}s ({len(ts_agg_result):,} daily bars)")
 
     cur.execute("DROP TABLE IF EXISTS ohlcv_benchmark CASCADE;")
     cur.close()
@@ -947,7 +1205,7 @@ if HAS_POSTGRES:
             data,
         )
 
-    pg_write_time, _ = time_operation(write_postgres, n_runs=1, warmup=False)
+    pg_write_time, _ = time_write(write_postgres)
     pg_cur.execute("SELECT pg_total_relation_size('ohlcv_benchmark');")
     pg_size = pg_cur.fetchone()[0]
     results.append(BenchmarkResult("PostgreSQL", "write", pg_write_time, pg_size, total_rows))
@@ -959,16 +1217,32 @@ if HAS_POSTGRES:
         pg_cur.execute("SELECT * FROM ohlcv_benchmark;")
         return pg_cur.fetchall()
 
-    pg_read_time, pg_result = time_operation(read_postgres, n_runs=min(3, TIMING_RUNS))
+    pg_read_time, pg_result = time_read(read_postgres, n_runs=min(3, TIMING_RUNS))
     validate_result(pg_result, total_rows, "PostgreSQL read")
     results.append(BenchmarkResult("PostgreSQL", "read", pg_read_time, pg_size, total_rows))
 
 # %%
 if HAS_POSTGRES:
-    # Aggregation (date_trunc to the minute; emulates time_bucket without TimescaleDB extension)
+    # Range query
+    def postgres_range_query():
+        pg_cur.execute(
+            "SELECT * FROM ohlcv_benchmark WHERE timestamp >= %s AND timestamp < %s;",
+            (range_start, range_end),
+        )
+        return pg_cur.fetchall()
+
+    pg_range_time, pg_range_result = time_read(postgres_range_query, n_runs=min(3, TIMING_RUNS))
+    validate_result(pg_range_result, range_expected_rows, "PostgreSQL range query")
+    results.append(
+        BenchmarkResult("PostgreSQL", "range_query", pg_range_time, 0, len(pg_range_result))
+    )
+
+# %%
+if HAS_POSTGRES:
+    # Aggregation (date_trunc to the day; emulates time_bucket without the TimescaleDB extension)
     def postgres_ohlcv():
         pg_cur.execute("""
-            SELECT symbol, date_trunc('minute', timestamp) as bar_time,
+            SELECT symbol, date_trunc('day', timestamp) as bar_time,
                    (array_agg(open ORDER BY timestamp))[1] as open,
                    max(high) as high, min(low) as low,
                    (array_agg(close ORDER BY timestamp DESC))[1] as close,
@@ -977,11 +1251,14 @@ if HAS_POSTGRES:
         """)
         return pg_cur.fetchall()
 
-    pg_agg_time, pg_agg_result = time_operation(postgres_ohlcv, n_runs=min(3, TIMING_RUNS))
+    pg_agg_time, pg_agg_result = time_read(postgres_ohlcv, n_runs=min(3, TIMING_RUNS))
+    validate_result(pg_agg_result, agg_expected_rows, "PostgreSQL aggregation")
+    results.append(BenchmarkResult("PostgreSQL", "aggregation", pg_agg_time, 0, len(pg_agg_result)))
 
     print(f"\nPostgreSQL: {pg_size / 1e6:.1f} MB")
     print(f"  Write: {pg_write_time:.3f}s | Read: {pg_read_time:.3f}s")
-    print(f"  OHLCV aggregation: {pg_agg_time:.3f}s ({len(pg_agg_result):,} bars)")
+    print(f"  Range query: {pg_range_time:.3f}s ({len(pg_range_result):,} rows)")
+    print(f"  OHLCV aggregation: {pg_agg_time:.3f}s ({len(pg_agg_result):,} daily bars)")
 
     pg_cur.execute("DROP TABLE IF EXISTS ohlcv_benchmark CASCADE;")
     pg_cur.close()
@@ -1066,8 +1343,37 @@ if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
                 bucket=influx_bucket, org=influx_org, record=points[i : i + batch_size]
             )
 
-    influx_write_time, _ = time_operation(write_influxdb, n_runs=1, warmup=False)
-    time_module.sleep(WAL_FLUSH_TIMEOUT)
+    def influx_row_count() -> int:
+        count_flux = f"""
+        from(bucket: "{influx_bucket}")
+          |> range(start: 0)
+          |> filter(fn: (r) => r._measurement == "ohlcv" and r._field == "close")
+          |> count()
+          |> group()
+          |> sum()
+        """
+        try:
+            tables = influx_query_api_probe.query(count_flux, org=influx_org)
+        except Exception:
+            return 0
+        return int(sum(r.get_value() for t in tables for r in t.records))
+
+    influx_query_api_probe = influx_client.query_api()
+
+    def write_influxdb_durable():
+        write_influxdb()
+        # Poll to first-queryable INSIDE the timed region, so InfluxDB's write
+        # ends at the same event as PostgreSQL's: rows readable. The previous
+        # fixed sleep sat outside the timed call and charged InfluxDB nothing.
+        return wait_until_rows_visible(
+            influx_row_count, total_rows, timeout=max(120.0, WAL_FLUSH_TIMEOUT * 40)
+        )
+
+    influx_write_time, influx_visible = time_write(write_influxdb_durable)
+    assert influx_visible == total_rows, f"InfluxDB ingested {influx_visible:,} of {total_rows:,}"
+    # size_bytes=0 -> recorded as empty, not as zero: InfluxDB's client API
+    # exposes no per-bucket on-disk size, so this engine is absent from the size
+    # column rather than claiming it stores the panel for free.
     results.append(BenchmarkResult("InfluxDB", "write", influx_write_time, 0, total_rows))
 
 # %%
@@ -1091,13 +1397,37 @@ if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
                 rows.append(record.values)
         return rows
 
-    influx_read_time, influx_result = time_operation(read_influxdb, n_runs=min(3, TIMING_RUNS))
+    influx_read_time, influx_result = time_read(read_influxdb, n_runs=min(3, TIMING_RUNS))
     validate_result(influx_result, total_rows, "InfluxDB read")
     results.append(BenchmarkResult("InfluxDB", "read", influx_read_time, 0, total_rows))
 
 # %%
 if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
-    # OHLCV aggregation — bucket to 1-minute bars with the OHLCV-correct
+    # Range query — Flux range() takes RFC-3339 bounds; the panel timestamps
+    # were localized to UTC on write, so the bounds are localized to match.
+    range_flux = f"""
+    from(bucket: "{influx_bucket}")
+      |> range(start: {range_start.replace(tzinfo=UTC).isoformat()}, stop: {range_end.replace(tzinfo=UTC).isoformat()})
+      |> filter(fn: (r) => r._measurement == "ohlcv")
+      |> pivot(rowKey:["_time","symbol"], columnKey:["_field"], valueColumn:"_value")
+      |> keep(columns:["_time","symbol","open","high","low","close","volume","vwap","num_trades"])
+    """
+
+    def influxdb_range_query():
+        tables = influx_query_api.query(range_flux, org=influx_org)
+        return [r.values for table in tables for r in table.records]
+
+    influx_range_time, influx_range_result = time_read(
+        influxdb_range_query, n_runs=min(3, TIMING_RUNS)
+    )
+    validate_result(influx_range_result, range_expected_rows, "InfluxDB range query")
+    results.append(
+        BenchmarkResult("InfluxDB", "range_query", influx_range_time, 0, len(influx_range_result))
+    )
+
+# %%
+if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
+    # OHLCV aggregation — bucket to daily bars with the OHLCV-correct
     # reduction per field (first/max/min/last/sum), matching what TimescaleDB,
     # QuestDB, and PostgreSQL compute. Single-pass last() across all fields
     # would yield semantically wrong open/high/low/volume and would also be
@@ -1107,15 +1437,15 @@ if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
       |> range(start: 0)
       |> filter(fn: (r) => r._measurement == "ohlcv")
     open_  = src |> filter(fn: (r) => r._field == "open")
-                 |> aggregateWindow(every: 1m, fn: first, createEmpty: false)
+                 |> aggregateWindow(every: 1d, fn: first, createEmpty: false)
     high_  = src |> filter(fn: (r) => r._field == "high")
-                 |> aggregateWindow(every: 1m, fn: max,   createEmpty: false)
+                 |> aggregateWindow(every: 1d, fn: max,   createEmpty: false)
     low_   = src |> filter(fn: (r) => r._field == "low")
-                 |> aggregateWindow(every: 1m, fn: min,   createEmpty: false)
+                 |> aggregateWindow(every: 1d, fn: min,   createEmpty: false)
     close_ = src |> filter(fn: (r) => r._field == "close")
-                 |> aggregateWindow(every: 1m, fn: last,  createEmpty: false)
+                 |> aggregateWindow(every: 1d, fn: last,  createEmpty: false)
     vol_   = src |> filter(fn: (r) => r._field == "volume")
-                 |> aggregateWindow(every: 1m, fn: sum,   createEmpty: false)
+                 |> aggregateWindow(every: 1d, fn: sum,   createEmpty: false)
     union(tables: [open_, high_, low_, close_, vol_])
       |> pivot(rowKey:["_time","symbol"], columnKey:["_field"], valueColumn:"_value")
     """
@@ -1124,11 +1454,16 @@ if HAS_INFLUXDB and benchmark_status["InfluxDB"]["tested"]:
         tables = influx_query_api.query(agg_flux, org=influx_org)
         return [r.values for table in tables for r in table.records]
 
-    influx_agg_time, influx_agg_result = time_operation(influxdb_ohlcv, n_runs=min(3, TIMING_RUNS))
+    influx_agg_time, influx_agg_result = time_read(influxdb_ohlcv, n_runs=min(3, TIMING_RUNS))
+    validate_result(influx_agg_result, agg_expected_rows, "InfluxDB aggregation")
+    results.append(
+        BenchmarkResult("InfluxDB", "aggregation", influx_agg_time, 0, len(influx_agg_result))
+    )
 
     print("\nInfluxDB:")
-    print(f"  Write: {influx_write_time:.3f}s | Read: {influx_read_time:.3f}s")
-    print(f"  OHLCV aggregation: {influx_agg_time:.3f}s ({len(influx_agg_result):,} bars)")
+    print(f"  Write (to queryable): {influx_write_time:.3f}s | Read: {influx_read_time:.3f}s")
+    print(f"  Range query: {influx_range_time:.3f}s ({len(influx_range_result):,} rows)")
+    print(f"  OHLCV aggregation: {influx_agg_time:.3f}s ({len(influx_agg_result):,} daily bars)")
 
     influx_client.close()
 else:
@@ -1180,13 +1515,32 @@ if HAS_PYKX:
 
         # Convert data to kdb+ format via IPC
         kdb_ohlcv = kx.toq(ohlcv_pandas)
+        q["ohlcv"] = kdb_ohlcv
 
-        # Write (serialization)
+        # Write — persist a splayed table to disk.
+        #
+        # This used to time `-8!` (in-memory IPC serialization) and call it a
+        # write, while every other engine on the same chart wrote to disk or to a
+        # server. That is not the same operation, and it is why kdb+ looked
+        # ~40x faster than anything else: it was not doing the work. `set` on a
+        # splayed table is the comparable operation — it is what a kdb+ shop
+        # actually does to persist a table, and it ends with the data on disk.
+        KDB_DIR = BENCHMARK_DIR / f"kdb_{ACTIVE_SCALE.lower()}"
+        if KDB_DIR.exists():
+            shutil.rmtree(KDB_DIR)
+        KDB_DIR.mkdir(parents=True, exist_ok=True)
+        # PyKX converts a Python str to a q SYMBOL, so the file handles are built
+        # here as explicit `:path symbols rather than joined inside q.
+        KDB_DB_HANDLE = kx.SymbolAtom(f":{KDB_DIR}")
+        KDB_TBL_HANDLE = kx.SymbolAtom(f":{KDB_DIR}/ohlcv/")
+
         def write_pykx():
-            return q("-8!", kdb_ohlcv)
+            # `.Q.en` enumerates the symbol column against the sym file, which a
+            # splayed table requires; the whole persist is inside the timed region.
+            return q("{[dir;tbl] tbl set .Q.en[dir; ohlcv]}", KDB_DB_HANDLE, KDB_TBL_HANDLE)
 
-        pykx_write_time, serialized = time_operation(write_pykx, warmup=False)
-        pykx_size = len(bytes(serialized))
+        pykx_write_time, _ = time_write(write_pykx)
+        pykx_size = sum(f.stat().st_size for f in KDB_DIR.rglob("*") if f.is_file())
         results.append(
             BenchmarkResult("kdb+/PyKX", "write", pykx_write_time, pykx_size, total_rows)
         )
@@ -1198,12 +1552,29 @@ if HAS_PYKX:
 # %%
 if HAS_PYKX and benchmark_status["kdb+/PyKX"]["tested"]:
     try:
-        # Read (deserialization)
+        # Read — load the splayed table back off disk and force materialization,
+        # matching the other engines' full scan rather than deserializing a blob
+        # that never left memory.
         def read_pykx():
-            return q("-9!", serialized)
+            return q("{select from get x}", KDB_TBL_HANDLE)
 
-        pykx_read_time, _ = time_operation(read_pykx)
+        pykx_read_time, pykx_read_result = time_read(read_pykx)
+        validate_result(pykx_read_result.pd(), total_rows, "kdb+ read")
         results.append(BenchmarkResult("kdb+/PyKX", "read", pykx_read_time, pykx_size, total_rows))
+
+        # Range query
+        def pykx_range_query():
+            return q(
+                "{[s;e] select from ohlcv where timestamp >= s, timestamp < e}",
+                kx.TimestampAtom(range_start),
+                kx.TimestampAtom(range_end),
+            )
+
+        pykx_range_time, pykx_range_result = time_read(pykx_range_query)
+        validate_result(pykx_range_result.pd(), range_expected_rows, "kdb+ range query")
+        results.append(
+            BenchmarkResult("kdb+/PyKX", "range_query", pykx_range_time, 0, len(pykx_range_result))
+        )
 
     except Exception as e:
         print(f"\n⊘ kdb+/PyKX read failed: {e}")
@@ -1221,25 +1592,31 @@ if HAS_PYKX and benchmark_status["kdb+/PyKX"]["tested"]:
         def pykx_asof_join():
             return q("aj[`symbol`timestamp; trades; quotes]")
 
-        pykx_asof_time, pykx_asof_result = time_operation(pykx_asof_join)
+        pykx_asof_time, pykx_asof_result = time_read(pykx_asof_join)
+        validate_result(pykx_asof_result.pd(), N_TICKS_TRADES, "kdb+ ASOF join")
         results.append(
             BenchmarkResult("kdb+/PyKX", "asof_join", pykx_asof_time, 0, len(pykx_asof_result))
         )
 
-        # Aggregation
+        # Aggregation — daily buckets, matching every other engine
         def pykx_ohlcv():
             return q(
                 "{select o:first open, h:max high, l:min low, c:last close, v:sum volume "
-                "by symbol, bar:`minute$timestamp from x}",
+                "by symbol, bar:`date$timestamp from x}",
                 kdb_ohlcv,
             )
 
-        pykx_agg_time, pykx_agg_result = time_operation(pykx_ohlcv)
+        pykx_agg_time, pykx_agg_result = time_read(pykx_ohlcv)
+        validate_result(pykx_agg_result.pd(), agg_expected_rows, "kdb+ aggregation")
+        results.append(
+            BenchmarkResult("kdb+/PyKX", "aggregation", pykx_agg_time, 0, len(pykx_agg_result))
+        )
 
         print(f"\nkdb+/PyKX: {pykx_size / 1e6:.1f} MB")
-        print(f"  Write: {pykx_write_time:.3f}s | Read: {pykx_read_time:.3f}s")
-        print(f"  ASOF Join (aj): {pykx_asof_time:.3f}s ({len(pykx_asof_result)} rows)")
-        print(f"  OHLCV aggregation: {pykx_agg_time:.3f}s ({len(pykx_agg_result.pd())} bars)")
+        print(f"  Write (splayed to disk): {pykx_write_time:.3f}s | Read: {pykx_read_time:.3f}s")
+        print(f"  Range query: {pykx_range_time:.3f}s ({len(pykx_range_result):,} rows)")
+        print(f"  ASOF Join (aj): {pykx_asof_time:.3f}s ({len(pykx_asof_result):,} rows)")
+        print(f"  OHLCV aggregation: {pykx_agg_time:.3f}s ({len(pykx_agg_result):,} daily bars)")
 
         q.close()
 
@@ -1281,7 +1658,7 @@ if results:
     )
 
     # Summary by operation
-    for op in ["write", "read", "aggregation", "asof_join"]:
+    for op in ["write", "read", "range_query", "aggregation", "asof_join"]:
         op_data = results_df.filter(pl.col("operation") == op).sort("time_s")
         if len(op_data) > 0:
             print(f"\n{op.upper().replace('_', ' ')}:")
@@ -1289,52 +1666,49 @@ if results:
 
 # %%
 if results:
-    # Visualization
+    # Visualization — every engine on a panel was timed under the one policy
+    # stated at the top, so the bars are comparable.
+    _panels = [
+        ("read", "Full scan", COLORS["blue"]),
+        ("range_query", f"Range query ({RANGE_QUERY_DAYS}-day window)", COLORS["slate"]),
+        ("asof_join", "ASOF join", COLORS["amber"]),
+    ]
+
     fig = make_subplots(
-        rows=1, cols=2, subplot_titles=["Read Performance", "ASOF Join Performance"]
+        rows=1,
+        cols=len(_panels),
+        subplot_titles=[title for _, title, _ in _panels],
+        horizontal_spacing=0.12,
     )
 
-    read_data = results_df.filter(pl.col("operation") == "read").sort("time_s")
-    if len(read_data) > 0:
+    for col, (op, _title, color) in enumerate(_panels, start=1):
+        op_data = results_df.filter(pl.col("operation") == op).sort("time_s")
+        if len(op_data) == 0:
+            continue
         fig.add_trace(
             go.Bar(
-                y=read_data["database"].to_list(),
-                x=read_data["time_s"].to_list(),
+                y=op_data["database"].to_list(),
+                x=op_data["time_s"].to_list(),
                 orientation="h",
-                marker_color="#0a1628",
-                name="Read",
-                text=[f"{t:.3f}s" for t in read_data["time_s"].to_list()],
+                marker_color=color,
+                text=[f"{t:.3f}s" for t in op_data["time_s"].to_list()],
                 textposition="outside",
             ),
             row=1,
-            col=1,
-        )
-
-# %%
-if results:
-    asof_data = results_df.filter(pl.col("operation") == "asof_join").sort("time_s")
-    if len(asof_data) > 0:
-        fig.add_trace(
-            go.Bar(
-                y=asof_data["database"].to_list(),
-                x=asof_data["time_s"].to_list(),
-                orientation="h",
-                marker_color="#D4A84B",
-                name="ASOF Join",
-                text=[f"{t:.3f}s" for t in asof_data["time_s"].to_list()],
-                textposition="outside",
-            ),
-            row=1,
-            col=2,
+            col=col,
         )
 
     fig.update_layout(
-        title_text=f"Database Comparison (Scale: {ACTIVE_SCALE})",
+        title_text=f"Database Comparison ({ACTIVE_SCALE} scale, {total_rows:,} rows, warm reads)",
         height=500,
         showlegend=False,
+        paper_bgcolor=COLORS["bg_light"],
+        plot_bgcolor=COLORS["bg_light"],
+        # Wider right margin so the 'X.XXXs' value labels don't crop.
+        margin=dict(l=90, r=90, t=80, b=50),
     )
-    # Use log scale for better visibility when timing spans orders of magnitude
-    fig.update_xaxes(title_text="Seconds (log scale, lower is better)", type="log")
+    # Log scale: timings span orders of magnitude across engines.
+    fig.update_xaxes(title_text="Seconds (log, lower is better)", type="log")
     fig.show()
 
 # %%
@@ -1363,14 +1737,48 @@ print("\n" + "=" * 70)
 print("[OK] Database benchmark complete!")
 print("=" * 70)
 
+# %%
+# Fastest engine per operation, read back off the results actually collected
+# in THIS run. Anything not benchmarked here cannot appear.
+if results:
+    fastest = (
+        results_df.drop_nulls("time_s")
+        .sort("time_s")
+        .group_by("operation", maintain_order=True)
+        .first()
+        .select(["operation", "database", "time_s"])
+    )
+    print("\nFastest engine per operation (this run):")
+    print(fastest)
+    print(f"\nEngines benchmarked: {', '.join(sorted(results_df['database'].unique().to_list()))}")
+
 # %% [markdown]
 # ## Key Takeaways
 #
-# 1. **Columnar formats dominate**: DuckDB and ClickHouse offer the best read/write
-#    throughput thanks to columnar storage and vectorized execution.
-# 2. **ASOF joins vary widely**: kdb+ provides sub-millisecond ASOF joins natively,
-#    while SQL-based databases require more complex query patterns.
-# 3. **Choose by workload**: DuckDB for embedded analytics, ClickHouse for OLAP at scale,
-#    TimescaleDB when PostgreSQL compatibility matters, QuestDB for high-ingest streaming.
+# The engine names below are deliberately absent: which engine wins each
+# operation is printed by the cell above, from this run's own results, on your
+# hardware. What generalizes is the shape of the answer, not the ordering:
+#
+# 1. **Storage layout sets the scan cost.** Engines that store columns
+#    together and execute vectorized (DuckDB, ClickHouse) scan and aggregate a
+#    minute panel far faster than row-oriented engines (SQLite, PostgreSQL),
+#    which must touch every column of every row to answer a query about two.
+# 2. **A range query is a different question from a scan**, and it is the one a
+#    backtest asks. The `RANGE_QUERY_DAYS`-day window above touches roughly a
+#    fifth of the panel, so engines that prune by time partition or use a
+#    time-ordered index separate from those that scan and filter. Ranking
+#    engines on full scans alone would hide that.
+# 3. **Ingest rate and durability are one number, not two.** The write times
+#    here all end when the data is queryable, which is why the engines that
+#    acknowledge early (QuestDB ILP, InfluxDB) do not look free.
+# 4. **The comparison is only as good as its policy.** Every number above is a
+#    single cold write and a warm mean read, for every engine. Warm reads
+#    flatter anything with a buffer pool; on a cold cache, or over a network,
+#    the compressed engines gain. Rerun on your own ingestion path before
+#    choosing.
+#
+# **kdb+/PyKX** is skipped unless you supply a q binary and a license, so it is
+# absent from the numbers above unless you configured it. The chapter discusses
+# where it fits; this notebook does not claim a result it did not measure.
 #
 # **Next**: See `20_storage_benchmark_file` for file-format benchmarks (Parquet, Arrow, HDF5).

--- a/07_defining_the_learning_task/05_signal_evaluation.ipynb
+++ b/07_defining_the_learning_task/05_signal_evaluation.ipynb
@@ -53,10 +53,10 @@
    "id": "9c6d96ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:06.400066Z",
-     "iopub.status.busy": "2026-07-14T01:49:06.399637Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.455988Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.455530Z"
+     "iopub.execute_input": "2026-07-16T11:13:16.792837Z",
+     "iopub.status.busy": "2026-07-16T11:13:16.792449Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.184998Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.184492Z"
     },
     "papermill": {
      "duration": 2.462061,
@@ -109,10 +109,10 @@
    "id": "4f2f6efb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.457659Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.457574Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.459325Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.459030Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.186235Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.186143Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.188081Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.187666Z"
     },
     "papermill": {
      "duration": 0.006521,
@@ -131,7 +131,7 @@
     "OUTPUT_DIR = Path(\"07_defining_the_learning_task/output\")\n",
     "START_DATE = \"2006-01-01\"\n",
     "MAX_SYMBOLS = 0\n",
-    "N_PERMUTATIONS = 200\n",
+    "N_PERMUTATIONS = 1000\n",
     "DECAY_HORIZONS = (1, 2, 3, 5, 7, 10, 15, 21, 42)\n",
     "N_SPLITS = 8"
    ]
@@ -142,10 +142,10 @@
    "id": "3487e74b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.460534Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.460464Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.481475Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.481093Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.188959Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.188853Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.211258Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.210764Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
@@ -198,10 +198,10 @@
    "id": "befd8005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.483058Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.482983Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.504758Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.504349Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.212472Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.212398Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.237501Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.236799Z"
     },
     "papermill": {
      "duration": 0.045836,
@@ -253,10 +253,10 @@
    "id": "799e6b05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.506042Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.505914Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.554015Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.553550Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.238652Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.238520Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.301061Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.300147Z"
     },
     "papermill": {
      "duration": 0.059646,
@@ -346,10 +346,10 @@
    "id": "1c6dcd4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.555225Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.555139Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.607967Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.607472Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.302482Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.302360Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.360048Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.359548Z"
     },
     "papermill": {
      "duration": 0.049568,
@@ -410,10 +410,10 @@
    "id": "bc06adab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.609212Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.609120Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.694622Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.694038Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.361285Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.361199Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.435964Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.435574Z"
     },
     "papermill": {
      "duration": 0.075419,
@@ -473,10 +473,10 @@
    "id": "1c8ad317",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.695951Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.695845Z",
-     "iopub.status.idle": "2026-07-14T01:49:08.728641Z",
-     "shell.execute_reply": "2026-07-14T01:49:08.726499Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.437120Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.437038Z",
+     "iopub.status.idle": "2026-07-16T11:13:19.467494Z",
+     "shell.execute_reply": "2026-07-16T11:13:19.467076Z"
     },
     "papermill": {
      "duration": 0.027126,
@@ -556,10 +556,10 @@
    "id": "c780f2ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:08.732116Z",
-     "iopub.status.busy": "2026-07-14T01:49:08.731679Z",
-     "iopub.status.idle": "2026-07-14T01:49:46.404443Z",
-     "shell.execute_reply": "2026-07-14T01:49:46.404133Z"
+     "iopub.execute_input": "2026-07-16T11:13:19.468527Z",
+     "iopub.status.busy": "2026-07-16T11:13:19.468447Z",
+     "iopub.status.idle": "2026-07-16T11:14:12.854633Z",
+     "shell.execute_reply": "2026-07-16T11:14:12.853637Z"
     },
     "papermill": {
      "duration": 54.906554,
@@ -604,10 +604,10 @@
    "id": "90d9af2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:46.405489Z",
-     "iopub.status.busy": "2026-07-14T01:49:46.405404Z",
-     "iopub.status.idle": "2026-07-14T01:49:46.409077Z",
-     "shell.execute_reply": "2026-07-14T01:49:46.408611Z"
+     "iopub.execute_input": "2026-07-16T11:14:12.857638Z",
+     "iopub.status.busy": "2026-07-16T11:14:12.857412Z",
+     "iopub.status.idle": "2026-07-16T11:14:12.866369Z",
+     "shell.execute_reply": "2026-07-16T11:14:12.865502Z"
     },
     "papermill": {
      "duration": 0.009173,
@@ -708,10 +708,10 @@
    "id": "2e77b8df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:46.409966Z",
-     "iopub.status.busy": "2026-07-14T01:49:46.409872Z",
-     "iopub.status.idle": "2026-07-14T01:49:46.569866Z",
-     "shell.execute_reply": "2026-07-14T01:49:46.569436Z"
+     "iopub.execute_input": "2026-07-16T11:14:12.872027Z",
+     "iopub.status.busy": "2026-07-16T11:14:12.871699Z",
+     "iopub.status.idle": "2026-07-16T11:14:13.048834Z",
+     "shell.execute_reply": "2026-07-16T11:14:13.048424Z"
     },
     "papermill": {
      "duration": 0.195944,
@@ -821,10 +821,10 @@
    "id": "ca2912f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:46.571212Z",
-     "iopub.status.busy": "2026-07-14T01:49:46.571141Z",
-     "iopub.status.idle": "2026-07-14T01:49:47.853596Z",
-     "shell.execute_reply": "2026-07-14T01:49:47.853119Z"
+     "iopub.execute_input": "2026-07-16T11:14:13.049683Z",
+     "iopub.status.busy": "2026-07-16T11:14:13.049613Z",
+     "iopub.status.idle": "2026-07-16T11:14:15.042230Z",
+     "shell.execute_reply": "2026-07-16T11:14:15.041448Z"
     },
     "papermill": {
      "duration": 1.097836,
@@ -16103,10 +16103,10 @@
    "id": "9179093d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:47.856054Z",
-     "iopub.status.busy": "2026-07-14T01:49:47.855907Z",
-     "iopub.status.idle": "2026-07-14T01:49:48.692216Z",
-     "shell.execute_reply": "2026-07-14T01:49:48.691708Z"
+     "iopub.execute_input": "2026-07-16T11:14:15.055465Z",
+     "iopub.status.busy": "2026-07-16T11:14:15.055138Z",
+     "iopub.status.idle": "2026-07-16T11:14:15.949436Z",
+     "shell.execute_reply": "2026-07-16T11:14:15.949093Z"
     },
     "papermill": {
      "duration": 1.089955,
@@ -16189,10 +16189,10 @@
    "id": "fab795e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:48.693076Z",
-     "iopub.status.busy": "2026-07-14T01:49:48.693004Z",
-     "iopub.status.idle": "2026-07-14T01:49:48.695211Z",
-     "shell.execute_reply": "2026-07-14T01:49:48.694952Z"
+     "iopub.execute_input": "2026-07-16T11:14:15.950394Z",
+     "iopub.status.busy": "2026-07-16T11:14:15.950323Z",
+     "iopub.status.idle": "2026-07-16T11:14:15.952773Z",
+     "shell.execute_reply": "2026-07-16T11:14:15.952482Z"
     },
     "papermill": {
      "duration": 0.011657,
@@ -16258,10 +16258,10 @@
    "id": "c856d41f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:48.696102Z",
-     "iopub.status.busy": "2026-07-14T01:49:48.696039Z",
-     "iopub.status.idle": "2026-07-14T01:49:49.935336Z",
-     "shell.execute_reply": "2026-07-14T01:49:49.934817Z"
+     "iopub.execute_input": "2026-07-16T11:14:15.953677Z",
+     "iopub.status.busy": "2026-07-16T11:14:15.953611Z",
+     "iopub.status.idle": "2026-07-16T11:14:17.607696Z",
+     "shell.execute_reply": "2026-07-16T11:14:17.607388Z"
     },
     "papermill": {
      "duration": 0.158069,
@@ -16301,11 +16301,11 @@
          ],
          "xaxis": "x",
          "y": [
-          0.0004291048513759915,
-          0.0004014660060196088,
-          0.0003094410548878116,
-          0.00024743739358667544,
-          0.0002871907500363039
+          0.000429104851375991,
+          0.0004014660060196084,
+          0.00030944105488781124,
+          0.0002474373935866746,
+          0.00028719075003630427
          ],
          "yaxis": "y"
         },
@@ -16331,11 +16331,11 @@
          ],
          "xaxis": "x2",
          "y": [
-          0.00191004971231748,
+          0.0019100497123174796,
           0.001653925340594422,
-          0.0016187229647249633,
-          0.001483196716568715,
-          0.0015538740628940307
+          0.001618722964724965,
+          0.0014831967165687147,
+          0.0015538740628940322
          ],
          "yaxis": "y2"
         },
@@ -16361,11 +16361,11 @@
          ],
          "xaxis": "x3",
          "y": [
-          0.00683639837729798,
-          0.006672028044927792,
+          0.006836398377297981,
+          0.006672028044927795,
           0.007264062668839997,
-          0.0071036136892882575,
-          0.00617137540209761
+          0.007103613689288251,
+          0.006171375402097614
          ],
          "yaxis": "y3"
         }
@@ -16596,10 +16596,10 @@
    "id": "30a833ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:49.936281Z",
-     "iopub.status.busy": "2026-07-14T01:49:49.936195Z",
-     "iopub.status.idle": "2026-07-14T01:49:49.939333Z",
-     "shell.execute_reply": "2026-07-14T01:49:49.938949Z"
+     "iopub.execute_input": "2026-07-16T11:14:17.609230Z",
+     "iopub.status.busy": "2026-07-16T11:14:17.609133Z",
+     "iopub.status.idle": "2026-07-16T11:14:17.612429Z",
+     "shell.execute_reply": "2026-07-16T11:14:17.612016Z"
     },
     "papermill": {
      "duration": 0.035922,
@@ -16712,10 +16712,10 @@
    "id": "eff192f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:49.940273Z",
-     "iopub.status.busy": "2026-07-14T01:49:49.940188Z",
-     "iopub.status.idle": "2026-07-14T01:49:51.141136Z",
-     "shell.execute_reply": "2026-07-14T01:49:51.140780Z"
+     "iopub.execute_input": "2026-07-16T11:14:17.613457Z",
+     "iopub.status.busy": "2026-07-16T11:14:17.613335Z",
+     "iopub.status.idle": "2026-07-16T11:14:18.849992Z",
+     "shell.execute_reply": "2026-07-16T11:14:18.849458Z"
     },
     "papermill": {
      "duration": 0.089379,
@@ -17040,10 +17040,10 @@
    "id": "c0f10bc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:49:51.142610Z",
-     "iopub.status.busy": "2026-07-14T01:49:51.142511Z",
-     "iopub.status.idle": "2026-07-14T01:50:34.463849Z",
-     "shell.execute_reply": "2026-07-14T01:50:34.462889Z"
+     "iopub.execute_input": "2026-07-16T11:14:18.851097Z",
+     "iopub.status.busy": "2026-07-16T11:14:18.850979Z",
+     "iopub.status.idle": "2026-07-16T11:15:01.813388Z",
+     "shell.execute_reply": "2026-07-16T11:15:01.812851Z"
     },
     "papermill": {
      "duration": 55.18345,
@@ -17076,10 +17076,10 @@
    "id": "0af6b7e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:34.468913Z",
-     "iopub.status.busy": "2026-07-14T01:50:34.468603Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.813273Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.811948Z"
+     "iopub.execute_input": "2026-07-16T11:15:01.814683Z",
+     "iopub.status.busy": "2026-07-16T11:15:01.814598Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.265423Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.264366Z"
     },
     "papermill": {
      "duration": 0.075964,
@@ -17349,10 +17349,10 @@
    "id": "4b5c5ad6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.817028Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.816399Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.827877Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.826275Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.267268Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.267064Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.272022Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.271266Z"
     },
     "papermill": {
      "duration": 0.016544,
@@ -17463,10 +17463,10 @@
    "id": "3da00f00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.832311Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.831939Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.839575Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.838619Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.273684Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.273515Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.277912Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.277430Z"
     },
     "papermill": {
      "duration": 0.016102,
@@ -17527,10 +17527,10 @@
    "id": "8e862b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.841703Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.841559Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.847868Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.846900Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.279140Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.278956Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.283172Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.282625Z"
     },
     "papermill": {
      "duration": 0.016334,
@@ -17645,10 +17645,10 @@
    "id": "46590f38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.849799Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.849520Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.854143Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.853590Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.284601Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.284430Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.288969Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.288429Z"
     },
     "papermill": {
      "duration": 0.019376,
@@ -17705,10 +17705,10 @@
    "id": "16512f44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.855153Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.855057Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.861930Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.861445Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.290269Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.290155Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.296774Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.296056Z"
     },
     "papermill": {
      "duration": 0.03618,
@@ -17797,10 +17797,10 @@
    "id": "daf135c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.862866Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.862791Z",
-     "iopub.status.idle": "2026-07-14T01:50:35.997862Z",
-     "shell.execute_reply": "2026-07-14T01:50:35.997100Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.298253Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.298012Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.480174Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.479296Z"
     },
     "papermill": {
      "duration": 0.166484,
@@ -17815,6 +17815,7 @@
    "source": [
     "# Slice eval_df per fold (forward returns computed in §2)\n",
     "fold_results = []\n",
+    "evaluated_dates: list = []  # every date inside a test window — needed for a like-for-like IC\n",
     "\n",
     "for fold_idx, (train_dates, test_dates) in enumerate(splits):\n",
     "    test_data = eval_df.filter(pl.col(\"timestamp\").is_in(test_dates))\n",
@@ -17854,6 +17855,7 @@
     "    else:\n",
     "        fold_mono = float(\"nan\")\n",
     "\n",
+    "    evaluated_dates.extend(test_dates)\n",
     "    fold_results.append(\n",
     "        {\n",
     "            \"fold\": fold_idx + 1,\n",
@@ -17873,10 +17875,10 @@
    "id": "74dfc1e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:35.999579Z",
-     "iopub.status.busy": "2026-07-14T01:50:35.999448Z",
-     "iopub.status.idle": "2026-07-14T01:50:36.003425Z",
-     "shell.execute_reply": "2026-07-14T01:50:36.002490Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.481788Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.481637Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.485036Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.484374Z"
     },
     "papermill": {
      "duration": 0.021098,
@@ -17924,10 +17926,10 @@
    "id": "148daf94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:36.005508Z",
-     "iopub.status.busy": "2026-07-14T01:50:36.005338Z",
-     "iopub.status.idle": "2026-07-14T01:50:36.010797Z",
-     "shell.execute_reply": "2026-07-14T01:50:36.010017Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.486411Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.486255Z",
+     "iopub.status.idle": "2026-07-16T11:15:03.490570Z",
+     "shell.execute_reply": "2026-07-16T11:15:03.490024Z"
     },
     "papermill": {
      "duration": 0.01966,
@@ -17974,10 +17976,10 @@
    "id": "21c6275b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:36.012778Z",
-     "iopub.status.busy": "2026-07-14T01:50:36.012580Z",
-     "iopub.status.idle": "2026-07-14T01:50:37.347116Z",
-     "shell.execute_reply": "2026-07-14T01:50:37.346021Z"
+     "iopub.execute_input": "2026-07-16T11:15:03.492070Z",
+     "iopub.status.busy": "2026-07-16T11:15:03.491925Z",
+     "iopub.status.idle": "2026-07-16T11:15:04.835724Z",
+     "shell.execute_reply": "2026-07-16T11:15:04.835258Z"
     },
     "papermill": {
      "duration": 0.098823,
@@ -18343,20 +18345,27 @@
    "source": [
     "### Interpretation: Full-Sample vs Fold-Level IC\n",
     "\n",
-    "Both numbers below are cross-sectional means (per-date Spearman, then averaged);\n",
-    "they differ only in whether the dates come from the full sample or from disjoint\n",
-    "out-of-sample folds:\n",
+    "The obvious move is to read the full-sample IC against the fold-level mean and\n",
+    "call the difference an aggregation effect — the folds are out of sample, so a\n",
+    "gap looks like the honest shrinkage of an optimistic full-sample number.\n",
     "\n",
-    "| Approach | IC | Interpretation |\n",
-    "|----------|-----|----------------|\n",
-    "| Full-sample cross-sectional | Mean per-date IC over all dates | Optimistic; uses every period |\n",
-    "| Fold-level mean | Mean per-date IC averaged across OOS folds | More realistic estimate |\n",
-    "| Fold-level std | Variation across folds | Measures stability |\n",
+    "That reading is only available if both statistics cover the **same dates**.\n",
+    "Ours do not. The full-sample IC averages every date in the panel. The fold-level\n",
+    "mean averages only dates inside a test window, and with `min_train_pct=0.3` and\n",
+    "eight 63-day folds those windows are roughly 500 consecutive dates near the\n",
+    "front of the sample. The two numbers describe different periods, so their\n",
+    "difference cannot be attributed to aggregation — or to leakage, which the folds\n",
+    "structurally cannot produce, since each fold's IC only ever touches its own test\n",
+    "dates.\n",
     "\n",
-    "**Warning signs**:\n",
-    "- Fold IC varies wildly (high std) → regime-dependent signal\n",
-    "- Many folds with IC ≤ 0 → unreliable signal\n",
-    "- Full-sample IC >> Fold mean → possible overfitting"
+    "The way out is a third number: the same cross-sectional IC, restricted to\n",
+    "exactly the dates the folds evaluated. It splits the gap into two parts we can\n",
+    "name separately:\n",
+    "\n",
+    "| Comparison | Isolates |\n",
+    "|------------|----------|\n",
+    "| Fold-date IC vs full-sample IC | **Period** — is this window unrepresentative? |\n",
+    "| Fold-level mean vs fold-date IC | **Aggregation** — does averaging folds change anything? |"
    ]
   },
   {
@@ -18365,10 +18374,10 @@
    "id": "e49ec816",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:37.350836Z",
-     "iopub.status.busy": "2026-07-14T01:50:37.350492Z",
-     "iopub.status.idle": "2026-07-14T01:50:37.358790Z",
-     "shell.execute_reply": "2026-07-14T01:50:37.357699Z"
+     "iopub.execute_input": "2026-07-16T11:15:04.837298Z",
+     "iopub.status.busy": "2026-07-16T11:15:04.837172Z",
+     "iopub.status.idle": "2026-07-16T11:15:04.928007Z",
+     "shell.execute_reply": "2026-07-16T11:15:04.927563Z"
     },
     "papermill": {
      "duration": 0.018493,
@@ -18384,30 +18393,55 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "=== Full-Sample vs Fold-Level Comparison ===\n",
-      "Full-sample cross-sectional IC: 0.0008\n",
-      "Fold-level mean IC:             0.0637\n",
-      "Difference:                     -0.0629\n",
+      "=== Like-for-Like IC Comparison (21D) ===\n",
+      "Full-sample cross-sectional IC (4,989 dates):   0.0008\n",
+      "Same statistic, fold dates only (504 dates):   0.0637\n",
+      "Fold-level mean IC              (504 dates):   0.0637\n",
       "\n",
-      "[WARNING] Significant difference between full-sample and fold-level IC.\n",
-      "   This may indicate regime effects or data leakage.\n"
+      "--- Decomposition of the full-sample vs fold-level gap ---\n",
+      "Period effect      (fold-date IC - full-sample IC):   0.0629\n",
+      "Aggregation effect (fold mean    - fold-date IC):     0.0000\n",
+      "\n",
+      "Folds evaluate 2012-01-23 to 2014-01-23 — 10% of the panel's dates.\n",
+      "[READ] The gap is a period effect: this window is not the average window.\n",
+      "       It says nothing about overfitting, and nothing about leakage.\n"
      ]
     }
    ],
    "source": [
-    "# Compare full-sample vs fold-level (both cross-sectional means)\n",
+    "# The like-for-like statistic: same per-date Spearman, restricted to fold dates\n",
+    "fold_window = eval_df.filter(pl.col(\"timestamp\").is_in(evaluated_dates))\n",
+    "fold_window_ics = []\n",
+    "for date_df in fold_window.partition_by(\"timestamp\"):\n",
+    "    if len(date_df) < 10:\n",
+    "        continue\n",
+    "    corr, _ = spearmanr(date_df[\"factor\"].to_numpy(), date_df[\"fwd_21d\"].to_numpy())\n",
+    "    if not np.isnan(corr):\n",
+    "        fold_window_ics.append(corr)\n",
+    "fold_window_ic = float(np.mean(fold_window_ics))\n",
+    "\n",
     "full_sample_ic = result.ic.get(\"21D\", float(\"nan\"))\n",
+    "n_all_dates = eval_df[\"timestamp\"].n_unique()\n",
+    "n_fold_dates = len(fold_window_ics)\n",
     "\n",
-    "print(\"\\n=== Full-Sample vs Fold-Level Comparison ===\")\n",
-    "print(f\"Full-sample cross-sectional IC: {full_sample_ic:.4f}\")\n",
-    "print(f\"Fold-level mean IC:             {fold_ic_mean:.4f}\")\n",
-    "print(f\"Difference:                     {full_sample_ic - fold_ic_mean:.4f}\")\n",
+    "print(\"\\n=== Like-for-Like IC Comparison (21D) ===\")\n",
+    "print(f\"Full-sample cross-sectional IC ({n_all_dates:,} dates): {full_sample_ic:>8.4f}\")\n",
+    "print(f\"Same statistic, fold dates only ({n_fold_dates:,} dates): {fold_window_ic:>8.4f}\")\n",
+    "print(f\"Fold-level mean IC              ({n_fold_dates:,} dates): {fold_ic_mean:>8.4f}\")\n",
+    "print(\"\\n--- Decomposition of the full-sample vs fold-level gap ---\")\n",
+    "print(\n",
+    "    f\"Period effect      (fold-date IC - full-sample IC): {fold_window_ic - full_sample_ic:>8.4f}\"\n",
+    ")\n",
+    "print(f\"Aggregation effect (fold mean    - fold-date IC):   {fold_ic_mean - fold_window_ic:>8.4f}\")\n",
     "\n",
-    "if abs(full_sample_ic - fold_ic_mean) > 0.01:\n",
-    "    print(\"\\n[WARNING] Significant difference between full-sample and fold-level IC.\")\n",
-    "    print(\"   This may indicate regime effects or data leakage.\")\n",
+    "fold_span = f\"{min(evaluated_dates)} to {max(evaluated_dates)}\"\n",
+    "coverage_pct = 100 * n_fold_dates / n_all_dates\n",
+    "print(f\"\\nFolds evaluate {fold_span} — {coverage_pct:.0f}% of the panel's dates.\")\n",
+    "if abs(fold_window_ic - full_sample_ic) > abs(fold_ic_mean - fold_window_ic):\n",
+    "    print(\"[READ] The gap is a period effect: this window is not the average window.\")\n",
+    "    print(\"       It says nothing about overfitting, and nothing about leakage.\")\n",
     "else:\n",
-    "    print(\"\\n[PASS] Full-sample and fold-level IC are consistent.\")"
+    "    print(\"[READ] The gap survives on identical dates, so it is an aggregation effect.\")"
    ]
   },
   {
@@ -18426,10 +18460,30 @@
     "## 7.1 Within-Time Permutation Test\n",
     "\n",
     "The text (Section 7.3) recommends a **within-time permutation test** as a\n",
-    "null-distribution benchmark: shuffle asset-label assignments within each\n",
-    "cross-section, breaking the feature-label pairing while preserving cross-sectional\n",
-    "dependence. If the observed IC exceeds the permutation distribution, the feature\n",
-    "ranks the right assets — not just any assets."
+    "null-distribution benchmark: break the feature-label pairing while preserving the\n",
+    "structure of the data, then ask how often chance alone reproduces the observed IC.\n",
+    "Two details decide whether the answer means anything.\n",
+    "\n",
+    "**The null must cover the same dates as the observed statistic.** A null built\n",
+    "from every date in the panel is a distribution of a mean over ~5,000 dates; our\n",
+    "observed statistic is a mean over ~500. The mean of a larger sample is mechanically\n",
+    "less dispersed, so such a null is too narrow by roughly $\\sqrt{5000/500} \\approx 3$\n",
+    "and would reject almost anything. We therefore permute only the fold dates.\n",
+    "\n",
+    "**The null must preserve temporal dependence.** Shuffling assets independently on\n",
+    "each date implies the per-date ICs are independent, so the null mean's standard\n",
+    "error shrinks like $\\sigma/\\sqrt{n_{\\text{dates}}}$. Our labels are 21-day forward\n",
+    "returns sampled daily: consecutive dates share 20 of 21 days of return, so both the\n",
+    "returns and the per-date ICs are strongly autocorrelated, and the true standard\n",
+    "error is much larger. Independent within-date shuffling would understate it by\n",
+    "roughly an order of magnitude.\n",
+    "\n",
+    "The repair is a **block permutation**. We draw one asset relabeling per block of 21\n",
+    "sessions — the label horizon — and hold it fixed across the block. Within a block\n",
+    "each asset's return path stays intact, so the autocorrelation the observed IC\n",
+    "inherits also lives in the null; across blocks the relabelings are independent.\n",
+    "The null then answers the right question: *given how persistent this data is, how\n",
+    "often does a random assignment rank this well over this window?*"
    ]
   },
   {
@@ -18438,10 +18492,10 @@
    "id": "62ea4404",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:37.363540Z",
-     "iopub.status.busy": "2026-07-14T01:50:37.363209Z",
-     "iopub.status.idle": "2026-07-14T01:50:39.110648Z",
-     "shell.execute_reply": "2026-07-14T01:50:39.110138Z"
+     "iopub.execute_input": "2026-07-16T11:15:04.929467Z",
+     "iopub.status.busy": "2026-07-16T11:15:04.929373Z",
+     "iopub.status.idle": "2026-07-16T11:15:04.994283Z",
+     "shell.execute_reply": "2026-07-16T11:15:04.993896Z"
     },
     "papermill": {
      "duration": 1.915425,
@@ -18453,25 +18507,27 @@
    },
    "outputs": [],
    "source": [
-    "# Permutation test: shuffle labels within each date, recompute IC\n",
-    "# Pre-compute group indices for vectorized permutation (avoids slow per-date Python loop)\n",
+    "# Block permutation: one asset relabeling per BLOCK_SESSIONS, restricted to fold dates\n",
     "rng = np.random.default_rng(SEED)\n",
     "n_permutations = N_PERMUTATIONS\n",
+    "BLOCK_SESSIONS = 21  # label horizon — blocks must be at least as long as the overlap\n",
     "\n",
-    "dates_arr = eval_df[\"timestamp\"].to_numpy()\n",
-    "factors_arr = eval_df[\"factor\"].to_numpy()\n",
-    "returns_arr = eval_df[\"fwd_21d\"].to_numpy()\n",
+    "perm_df = fold_window.sort([\"timestamp\", \"symbol\"])\n",
+    "dates_arr = perm_df[\"timestamp\"].to_numpy()\n",
+    "factors_arr = perm_df[\"factor\"].to_numpy()\n",
+    "returns_arr = perm_df[\"fwd_21d\"].to_numpy()\n",
+    "symbol_codes = perm_df[\"symbol\"].cast(pl.Categorical).to_physical().to_numpy()\n",
+    "n_symbols = int(symbol_codes.max()) + 1\n",
     "unique_dates_perm = np.unique(dates_arr)\n",
     "\n",
-    "# Build date group indices once (avoid repeated masking)\n",
-    "date_groups = []\n",
-    "for d in unique_dates_perm:\n",
-    "    idx = np.where(dates_arr == d)[0]\n",
-    "    if len(idx) >= 10:\n",
-    "        date_groups.append(idx)\n",
+    "# Group rows by date; within a date, rows are already in symbol order\n",
+    "date_groups = [np.where(dates_arr == d)[0] for d in unique_dates_perm]\n",
+    "date_groups = [idx for idx in date_groups if len(idx) >= 10]\n",
     "\n",
-    "# Pre-compute factor ranks per date (ranks don't change across permutations)\n",
-    "factor_ranks_by_group = [rankdata(factors_arr[idx]) for idx in date_groups]"
+    "# Ranks are invariant to relabeling, so pre-compute both sides once\n",
+    "factor_ranks_by_group = [rankdata(factors_arr[idx]) for idx in date_groups]\n",
+    "return_ranks_by_group = [rankdata(returns_arr[idx]) for idx in date_groups]\n",
+    "symbols_by_group = [symbol_codes[idx] for idx in date_groups]"
    ]
   },
   {
@@ -18480,10 +18536,10 @@
    "id": "cbf470d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:50:39.112079Z",
-     "iopub.status.busy": "2026-07-14T01:50:39.112007Z",
-     "iopub.status.idle": "2026-07-14T01:51:44.217826Z",
-     "shell.execute_reply": "2026-07-14T01:51:44.216782Z"
+     "iopub.execute_input": "2026-07-16T11:15:04.995616Z",
+     "iopub.status.busy": "2026-07-16T11:15:04.995539Z",
+     "iopub.status.idle": "2026-07-16T11:15:13.514524Z",
+     "shell.execute_reply": "2026-07-16T11:15:13.514040Z"
     },
     "papermill": {
      "duration": 70.617509,
@@ -18498,26 +18554,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Within-Time Permutation Test ===\n",
+      "=== Within-Time Block Permutation Test ===\n",
       "\n",
+      "Dates: 504 (fold windows only, block = 21 sessions)\n",
       "Observed mean IC: 0.0637\n",
-      "Permutation null — mean: -0.0001, std: 0.0015\n",
-      "Permutation p-value (one-sided): 0.0000\n",
-      "Permutations: 200\n"
+      "Permutation null — mean: -0.0005, std: 0.0145\n",
+      "Permutation p-value (one-sided): 0.0010\n",
+      "Permutations: 1000 (finest resolvable p = 0.0010)\n"
      ]
     }
    ],
    "source": [
     "permuted_ics = []\n",
     "for _ in range(n_permutations):\n",
-    "    # Shuffle returns within each date, compute rank correlation\n",
     "    ic_per_date = []\n",
-    "    for i, idx in enumerate(date_groups):\n",
-    "        shuffled = rng.permutation(returns_arr[idx])\n",
-    "        # Spearman = Pearson of ranks\n",
-    "        r_ranks = rankdata(shuffled)\n",
-    "        f_ranks = factor_ranks_by_group[i]\n",
-    "        n = len(f_ranks)\n",
+    "    block_keys = None\n",
+    "    for i, f_ranks in enumerate(factor_ranks_by_group):\n",
+    "        # New relabeling only when a block boundary is crossed\n",
+    "        if i % BLOCK_SESSIONS == 0:\n",
+    "            block_keys = rng.permutation(n_symbols)\n",
+    "        # Same key vector across the block => same asset->asset mapping across the block\n",
+    "        order = np.argsort(block_keys[symbols_by_group[i]], kind=\"stable\")\n",
+    "        r_ranks = return_ranks_by_group[i][order]\n",
     "        corr = np.corrcoef(f_ranks, r_ranks)[0, 1]\n",
     "        if not np.isnan(corr):\n",
     "            ic_per_date.append(corr)\n",
@@ -18525,16 +18583,22 @@
     "        permuted_ics.append(np.mean(ic_per_date))\n",
     "\n",
     "permuted_ics = np.array(permuted_ics)\n",
-    "observed_ic_mean = fold_ic_mean  # Use fold-level mean as the observed statistic\n",
+    "# Observed statistic and null are now the same estimator on the same dates\n",
+    "observed_ic_mean = fold_window_ic\n",
     "\n",
-    "# p-value: fraction of permuted ICs >= observed\n",
-    "p_value_perm = np.mean(permuted_ics >= observed_ic_mean)\n",
+    "# (r + 1) / (B + 1): a permutation p-value can never be exactly zero — the observed\n",
+    "# assignment is itself one of the arrangements under the null\n",
+    "n_at_least = int(np.sum(permuted_ics >= observed_ic_mean))\n",
+    "p_value_perm = (n_at_least + 1) / (len(permuted_ics) + 1)\n",
     "\n",
-    "print(\"=== Within-Time Permutation Test ===\\n\")\n",
+    "print(\"=== Within-Time Block Permutation Test ===\\n\")\n",
+    "print(\n",
+    "    f\"Dates: {len(factor_ranks_by_group):,} (fold windows only, block = {BLOCK_SESSIONS} sessions)\"\n",
+    ")\n",
     "print(f\"Observed mean IC: {observed_ic_mean:.4f}\")\n",
     "print(f\"Permutation null — mean: {permuted_ics.mean():.4f}, std: {permuted_ics.std():.4f}\")\n",
     "print(f\"Permutation p-value (one-sided): {p_value_perm:.4f}\")\n",
-    "print(f\"Permutations: {n_permutations}\")"
+    "print(f\"Permutations: {n_permutations} (finest resolvable p = {1 / (n_permutations + 1):.4f})\")"
    ]
   },
   {
@@ -18543,10 +18607,10 @@
    "id": "ea12564a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:44.219457Z",
-     "iopub.status.busy": "2026-07-14T01:51:44.219311Z",
-     "iopub.status.idle": "2026-07-14T01:51:45.644169Z",
-     "shell.execute_reply": "2026-07-14T01:51:45.643610Z"
+     "iopub.execute_input": "2026-07-16T11:15:13.515738Z",
+     "iopub.status.busy": "2026-07-16T11:15:13.515655Z",
+     "iopub.status.idle": "2026-07-16T11:15:15.150890Z",
+     "shell.execute_reply": "2026-07-16T11:15:15.150524Z"
     },
     "papermill": {
      "duration": 0.093476,
@@ -18573,7 +18637,7 @@
          "opacity": 0.8,
          "type": "histogram",
          "x": {
-          "bdata": "yewkY+MmT7/ZPzo5tHEnv55cY5iaXFE/VERWwBuZWT+xi/8HSEFIv1t9A22GRgy/628PX2R/Tb8hkmFDoj9TP0RNe2p8yGS/agQdvNhZTD/Y/GJNVf5Ov0cMH78MQEq/PcwJnIkRLb9bu8aGvlsRv1ICsKhqO2O/1gb2VinJMr8O3PY+wMthv+Q1w+nnQm8/vp0D80LsQb/Ki+bc7fczv0kjnB2+LUK/UU+FsD2Qaz+t7pVftlBjPwk7qQeA2Uq/LwmfYNxGC7+JN2c8TRooPwFfuUfxNki/QV2OpjUMWL8ZQTETrbEzv5LcSauPSDw/ISpuEh6pM7+j1nxsAqNJP6zt/mizHEM/Az/aVpDjDD9yQkz3PZdmv5EsoYN65Es/N3xvGjsmRr8b7Q5mEQdkP7ItgWjjN1+/wYJ8LCtiQT8oR2sCTBIkv8TnnfpO1F+/n2zoBnZOUr/yogEMFdtXP1i9LjtQIww/sDxPlfsKWb/sf0XE+r82P1wx34dnsFK/WSQne1s9QD8RcfYVHfVVP2jmVJTokG4/6OAiaqhkUT/fC61dsZJhP9rF0PhipSc/Hygvbk2IWr92UiOyYlJFPwC8eXvgbEC/F7YVZyaMQT+rJHOMipBov9IYdJiQWGa/dsZ7qKoaQL+twPAk5ftZP7H4G+6ACGY/ONaBVjIDWD8jpUMOayFUP29a7pDnGWM/m5uC3i8gQr8fdCWUor7rPlHBYeC5wVC/aLZC6WeDRj/gRujVFFg+P8Von7IRfnK/Sd1Cw6MMYb8sH4UYtBlRPwnI+1U/7EK/vb8dSMC6Ub9luECjiig+v4ZOWFbDL0k/0WLDqMgWYr8awK9A9xpeP26feUq75D8/lewmpNHRQb/ycZYVUZdWv/g4uReXa1+/wkM0U9HXW79VIF1xFgU7v1Oza2JAtB4/7pP/v65tYL/PKgmU/8BKPx0OP+WrCDY/KeIYbcSEaD/fa6XCQZhGPy6eXOqZ+ly/zYgrYbXTTr8zSzOR2+w5vz3boARAhmK/XtvzXWbnWL8fl++McH9nv0WWJGACG0G/9W71DOE5QD8ExlHYS51EP8Yx9pVjF1o/W9gZJI8AMz8ywg8o2t85vz+liy80p0O/xjE4AlIGQL/q28JFyhJBP2DlfDzQ0ES/66kE0VpVab8OMyUt7a4+v8Ks88/Xvx2/YNUJd2xYVD98eojxXUdhP3YWVJniH00/tZr1TZZMYb+sSGj32OdMv2mh5ZB7Q1Q/zzhiSfynTT/bg5ju++tHP1LHnFKWDGW/YsXKjjaDOT+3MHa8CkxMPzdz35kVi16/EZmDwEHWXz+nULvOcR1TPyo6SpOpimU/Tre3Yo+wZT/otgRArN9KvygUr4oM20m/yacjTG5eRD+7tXysKVJIP+k/wp6wG1m/6beV08v4Xj+vlZxue4Zkv1CuooymMFS/+CETjzj+L7+OOYT9EQNDP7OeKnpD1VY/3yuczjHLOT9qWgbdM1P1vney4lvotla/tvQaLAv6UT8eMM6kHmpOPwYTWF6GgmM/9xAOPhCgUr+HuHJcl9Y1v3ZjIkPGDGW/VVIEtBSaVD8/7MopRx5AP/Wf4v57gla/uYraoIFsZ7+JkZ3lBP5uv8xofJT9YEG/umsZrlt5Sz+Ok1Ej55NDP/ftBw1wLUq/8fMeq8pzSz9nsUEYUSxcv68Jmb+1zTQ/x0R7sEhSYD+ddLexcu4/v30HsjNMyFm/inQc7z2BWT8vi0j57Ntkv8uQ0QmvvzA/Zm+vmmdl/r7C/ywiXU5EPzbzJMkvvU0/FUbDN5/BZ7+uEjymCMLivlJBvv+yBw2/YSKad6Xm5j744Xh6jwxjPxwdNWuo7FQ/DvWQn0Bicr86jcm2vZthv6ABp/6nOEQ/hMbbed61XD+kYYgMDjZTPzykqQClfVg/j84q953dIT9g7SSHzxoxv3gYZ3CBVlM/8kbkMmGpJT9HcoyRyddgv2wqmFsIfzG/wvZYsOoMXz8vhjgw91paPzQzSdRziiC/qhjbTKJsNb+YeZl+i35gP4D3aRxn81U/ldDIVOuKYj/TDD+XbD5BP+537UGO9Ec/QNHWQecPZ78b60rnrjFQv0jnMkww8kg/ONjGqlDwPD/KXOG6KiVVvw==",
+          "bdata": "vGA6WYU1ir9xxtm09x2aPwjSdcUdfpC/MgGPSdvmir/0Z0+X3WJuPyk4bd4iio6/mylGY42uhT/Z1gp0o1R5P3i8Kn0MX4o/rqhWXE2Pk79Lmv3/p8yaP7q7oaqFrpE/CE7H6dYClL/+VNh2+YKJP3fyJee+2oK/fq7VCjkFaD/DKYVNXYKJP8nr2ePe9Ha/1qi7gSC8ir+Uc09uhfdwv47PAnKd9YO/5H6YbS02Y79BDxsXasV/P4Eu9or1uI4/ZuaVPKHXYL/9HMjkXqSEv1EXPgc4u5G/xSX9/3vpk79+VF4XaTJ4Py0b1TUZa1W/IWmAjU+Gcz+OuDWHWJF/P4o2Dbx0E3m/kzpQQbw1gT9F3rcJRo1yv869YS7nPp6/NF7NJVlAgj9y5KB/zsV0Pyt+nxBGr5A/hOCsKRlAgz/hQqKaD/CSPxCPGGKUFJ6/JzDmwZ0RmD+ePTYXa853v6zFtgUi12i/ZFPEVKF3ej8xHIzVuZ4/v4/izCJzD3u/SFH48wxSdT9+T1+DpouOvx6aAktJ9XK/IRO+WN95TL/FdqyWF0iCP8NZC1d+0YC/1yAbk7hRfL9HMqISPzSIv+hzLdh4l5W/IdSpQp/wcb/dhEl7BDWgP9s4OaP0GFQ/lrjWdDEYjz8cTH7knY1jP0yZwCarkmu/3d/Sfk4QcT9fCRk/ByCiP6PTgbPT0HA/BNLxr9/rk7+JTkr7ML15v3IGyjch9YQ/1hOtHqS4jD+/wdSYkWuJP59Sg/V5FIW/a7pXSXhyhT/uTUY7m8tWP75QWYHQLZ2/cOs4xCNzUT+UzUz0X5SCP0j80w8nbHK/LfwrOqeQlj/Rl+uXTSeSP8OvgnHnVZI/+LSq1tsoib9Jd5kNZ3eavzF837mD2FO/bLmd9C9hf78jctRIny1svz3qKQWjVnI/jCcmeAYMhD/wViliYaGFPxhG0LESTZk/97lYdhOFo78PsWA0yOiMPxu4zaWjD5C/5Fnz3skRkD81ZFYRuT+FP2g+Ccs+Cp0/ZUtqcAUwlD++Q6GGryyQP6mPK66OoU0/yxz4Ue9obL/XGeSnlR+Sv/aTFRVNBmC/Wh9zF0eUhz/Escixt92Sv3PBuP4keoK/CPCjwvkxhT9jkcaWfHCev1HqIYwxbWO/RX0Xm684jT9nAb0gEQZ1P+IOv4xIAYK/XYeyQurQF79iQg7AYQSJP5wwRXELs4i/lsISR4/RZb9Z54+LPRGcP1MCunxZ4m+/hSDJ6iKbg7+ZvJw2SqSlv9FVXNietYC/QTlnZqLPmD+44qw3/d+gv/xAK7PdCFq/hozfbhmWhz80TIR1zNGKvyNs+OEDx5W/Rz9mV7ZCmD9JXGyyV61svx4YC9lB3IM/RO2s3AqWcb9P0hE59kyGv63jCj3Q5Ii/uST/JbPuk7/023pi17pgP4k32lU/yJM/DBBQI1x9ib+3cZGei8txPyH3tkNjCYE/Bdg+NiJ/g7/bBcWcd7OVv5wnGNf8+3C/TfVH51f7UT9xi8rkYa6Evy8wDvlpiXk/8DduM9snYD9FD04bBy95P631Q2C9pJE/dSrU6ltpcD9s3bey35WMP1MHkpyuB2a/6usBK+UzcT+rjIhaweFJP++7fg9yB3M//rKPSr+LZr8ebAMqpauBv1XGHaK5lou/Yo7T5RYOn7/8r9ALenp2P6jXBaKAzZ0/OhcuPYtjdb/b7oI0wF5cv/RfmKs+xZC/H1Vdg7K7dL8aRXpQToF6P82hDEmIH4y/e9K+Bnv0ar89cufu8kuHP/pbe1Ei+pA/Q4BdG+f8jT/D6j35SDFqP8sS899KYKA/CAMDeimDib+OtQvIhXFUP2hQ66VmWXc/MqS8H1S5VD8oKyHJ7xSJP9DvHB5Rz6K/0ZpEoqVRdL9BjJtxvcxav9SOGjb6M30/s/J6FH0Jlb8nWaoh3UiUP4KURR6Gxou/azlUP5EVe7+eT8ZOmTeZP9Llo8W8b4w/nRIBGZUDgr8MTQcV1hyGP0jUYksJOYA/Xfv6nuzdTT8CQATjBj1lPzMv5DnEGIw/vjBjtyVUhD8qqV7N9JJzvy+kbEx3JKS/nlcvIKBFhT/LDg3S6i6Bv1lJ1D1fMH2/eChNUkAOlL9ZSmOgKUxrvw1dYHmF242/Kg7WAiSUfz8oOpBN+FySP10vg8URo3i/bB84mKdbkD92hd3pMEpsP5BGYk1mE5Y//6h6l2Kigz9dN37dJfJEv19ClsUM1ZO/mJt18HjzfD9UJIwnACmOP4D4C0ip3YO/FuSD6I/+fD8u2tpFd86Yv3KGudhXBmw/cj5otkcuUj8yuMy66emAP4MJgz3UPI2/zevKU23WfD8GVctFj7yNP1l6oS/2QpG/ce0Sa1aOhb+afmDqoNVPv39Hx9v74JC/lYICRIldmD9WRPWWZ/16v1BH4jD5uYG/g16ThfUbmr/Tb7clqn9tv/t+Vk9skWi/4g6H1yIniz8bn3yfjfyVP493qLl0LnC/o3/N2/8djL+C//KreUp6vxhyoM2KJk0/aBcFe6QblL8xeHdIQiB4vykkmDlUQZm/jhtwq/H/Lr/6bey6ClScv7Odio2Kc5C/2QIa+OEJlj+3xX7i/XJiP3rIg6+PQpO/RJQdy6uFkj+ImV6bwTtcP1m0ZjuUXog/BKBQ1umwkz/lSytu4jOCvy1Eje1bPZM/IWm9jMrMir8cXHdPgz15P5zYuw3J3me/kr9IFImRjL8vH2dALY9tP8+qcztkioE/EHO2Z+BBhz8jVTnD47p7Py3j9xboCXS/foi9sw3leT8EnrEId2ONvwBX5Bm+sni/H3LO8ugtjb9syX7gfVmcv6UKo4KzSnE/CtFWyKDckT9Vp4aLWo2XP7O8aI3VlhG/2xCzlMEyXr/8gHphAdSRv0/DASc764C//IcB4BWLdL8IGq1xgyZlPwzeQUtG5TI/AfovG28Dlb9y6Zg/UkRyv7dx5wibDnG/y2aIHuUtgr+8Yx9abM+lPz5yfWHGp4m/OeCZANIndj9RJI3q7UpDvx8SoTm1vIo/J8s3wolKlj8GHq+ITyqAPxF/hWs8Kp6/UTBXMpPtTj9kM+ERwzmev7M1K+kPDXO/KqBQ9yQfeD+E4SVrHqSEv6MXk6unmpU/NnhXFrIncT+QX9UXVgqLP3BUZB1uIYc/s1cxtT8YXb+ELVPFst1+P8siP+IFf0y/PRXAZYYCYr8kb/DH/hKPv7bvQBnRr5G/QairzlsVob9smcimic1jvw70BzUCNXK/UUJ+aTxoZD+RCQDeI7yFv0DtTroBLWA/cf68mQrgkT/GMAiTwVGHP+OjbHB7H4u/iloGq7tVoj+w+bEei52Uvyw0EqzCLZQ/X7G9M1vIhL+i9OVds+GDPzWlby70h1W/LSCxGnKtdD9mGQ+WtIyLvxLuwSN/IYE/vBDqzoMjpb9rIvw/podTv9T4bK6fS3s/NZLqWwOLcb8AGA0Xwpw0P7I6Jtu02IG/EjyYv0smaD8V4HRI21B4vxwZ+Fmj5WE/rAUVwB5khL/MMhX8BSx+P6U+5jKP320/T1lTsScxbL8FlepKaAVbvwAxzszSC3y/u/d7eeRHeL8oXoJq1TuQP3DLzSLaLJA/RRMJuavTgb8G7GHGJSRxPz1+PpoMTJY/Gd7iBGREjr+WM03kVeePv8zz9lVID38/lmQ2cj5eiD/49h3l8GmFP7uzC1987IW/bvb+mljwgT+axwce7l6IP5oGyRO29oa/My7MnjPmaz8Iyq/T/hOlv9th8WEqHKi/LM6FxsWqiL/T7BqOOkuVP2iTNXtAbX+/0truldJNgz831mVlVddyvwwuyV/Ykp0/an/QGVQakL+FiFRLKBt3v9xH1AgozIq/2V2SLmo5j7+WkljUq3OTv0/2I0Rqmmg/ykst9q73jj+83a4dAISZv90QM9f5eIE/uFriHaFCkT9lzVRHRBeRP+bBr8iGepM/sTDPxvefgT9AtyUywpp/PxhdVZoiPo+/kwjXgZJjn7+lsWbL+maEPzYVwj+rDoE/hrfIfxtkjj+UCZKh9qqEPzxM3zgEY4K/yyhGPqu4Ub9wRKhfV6WWvwRVj8H+qGY/25vFRkKAmr+mxUC++maav9ZDHSB5cZC//sWCHYTtfD/0VJLBUTFdv+hWjyb8xFa/Wg+Lx7ticb8M+huphOdIv6uCXDg+4k4/oynpPd8Mkb+Nf1gXsv5qv8cxT+4mKPI+Odp6xbE8Ob+S3OyQFT5xv19HdGqDVmk/AJoqyRhagL+vCKmDPLGSv/v0ST87O4O/J8t1Hb50jD9JZ8z/ZM1kv0mlWnADbJA/fCPOgzyOlb9PxD8zTV5nP+gmSuhCrXc/5BedivpSn78B3w8zYkKNPxSHberLK28/if7cgpInk79oOb7v+y+PPxyd6lXsgY+/Exmd+W/ffD/5U7cqlvKCP5u3ZDP/AZ+/3VsAxMn3gT/jkNgSZLlgv4aNcyXQNaQ/ZhReOBKjSL9Ti9/lPxGDP2y6+OmZaok/I3DIIzMFhb9Vnk+W9jCfv+PZp9Dcamq/8w5R1OnMk7/oPGr7oieBv4xTKz34WXs/fqZDoztMjD/2JYU5tfaXP/NWM5jo02k/aTD6FnJslb8zBzbInHCLvxYIFmGqZGw/qdv9xhTMYr+vIXogd/h5P72EvwfEPGa/tdm9KARmpL/6aFh7nseRv/phZI6hoo4/MDPfwbJ4nL8tIxxluriSv0qko10NAZ6/kqDn31icOL/PPLCtdgOFv+QPI1ZfRH+/dilq3pFyWz8t8/lES4czv6OSUsrMPma/mKop2W87cr9UAqb1+T6gP5aT1eCWL1o/hq1upEkBmj+JWDThRRybv4zCtOm6lIi/JTt1Ljt/cz+KBN8qmMx1Pw6lssmIg4E/v5lZO3wBbT9VSDhUEKOHP60WcpNUtpe/qzkCbkj4eT9mM4rcx8h6vxxrE6HGIpc/9BvdYXWahj92F24LYFqFP089kmfzr2c/OfE942/HdT+TgshgsxaLv3p3jblw5oW/WYPV8pM2g7/slM0gVtWRP5+ULgntNJW/NlLf/06ykz/uGtICSqmHPxb3HLbZNp2/zfrVbl3hgD9V3EYQWoCDP98t9pIs0Xy/eK4lIkHpmb8wKC9TNc2Iv3QTs/EaqHc/yZz0JSitaL9iS9WxvW17v+oWxJACkYS/2S74MEB8g7/wPFeRIt6Rv5ODciTVoZG/cmCwBw+Udr/9k/c8eC+Ev3q8MKx1ZXo/bh0wMKpBd7/wNR+B8S+UP186g8z583Y/K/k7GFlpl78eeeONuGR9Pxr8aKELaVO/VSTxdM95m7/KkETuhE5yP+E+1MgJyne/mINqCuSCk7+9WBnQClRkP1EEx0dKejG/ACBv2GXljb/8DsSN68Y8vwhWizNdgGe/mtalngDphL/PW31GYJyJP0X9Pv+pkYQ/Jan8V+WySz+a0wdFSxBwv1cX63V0H5O/uf+3L1g7jj9Nb6hlan1kP+aoMNgIA3A/cA6COMxve7+8fz2INl+KvyGqcxWtIlw/6x2asJTzmb/c4he1nfeKP5w4T5ku1YU/UB8QZholkL98l5sk3UJtvx4TaoRL7Ze/oiv6xlc6gD/Drg5ppUFkP1pRL/WPVno/i+OoWXn9oL/0rX4uTDZXPz9zLwcTtIm//pFDglJxlT/JqGZG6CByv0aeHayruX8/QVX+8CV7gj8ONy59iG2Dvzp01sEP5ni/HqPG87tmnD8xIswSu4Rsv0Ao2QJYJ5a/prc8eGXcmL/Bp4CwOOJ+v09T64OkZ3k/u0ncIzjChb+C8CTQRVOGPyqav0oAh2M/kplvoot3dL+9NoFu5iSMP6veW8UKl18/MThXducgcL+H1D1L+ROgPyW/woNLvJy/W7V0SS6GkT87x9+3lMKWv4qEspjSG5I/NUPDoF3Hk7+7lEbHvehQv4Lx0+J1WYO/SgmrFwZxmb8YxptfIXOSPwDCuQnR7mI/enHnOFEchj/HZDlXy95HP6lpM0uUFnc/1beY3REimD+cJsT7MXaRv0pSUxKYhIQ/aByZzbuMor8hfBls0d9vP6fh8XY9pYe/+WpTWpobnD8CfgQYGmifv0Fefoeor14/MWDv2/8sjb/ZRw1hfAOAv25D3eEC94C/+woLPK4neD8di2wGdT+Qvz0EHt1eWZE/aY1mA0Dogz89j/KCE5lhPykfMfzgNm+/q66XPJpgUz+5UylOZZRyv+Q/GZeXzJA/J6JfJ7CfjD87Q2lLSQSOPxb7QyE8VY+/gN+zrHPokb+znqEQTDVOP6ZWmXATDou/6wHDcniRcj9F8+cEaiJMP4LfeLy8GIy/aFYXyZS6kT+SgulCh7GRv4TuRNljbpg/dv1TohpimT+rO2cfxSV7P9/rfb96T4g/mB5fN7YGiL9Jdz0drYuQPylG1BD1lnQ/bEuBaCv5lT+n5L67UOeFvz/2t+JJX5c/ok/D+PFCeT8lgYDKxrt+P71ka9mSkZi/LH0xb8I1mb9tokT9s66Rv89T/fivG1g/f3gSxlQzfT/sdpCXD/9Rvy+qM4Exw3g/P0Np4H6Gfz+NR5Pxg7OCP5fP2XHPQnk/TXH3I0sVlb9RLOdk9CdQvxUR6H3rtoC/wTCgE8qbmL873zc77hOcvyzZa3eN8HA/dss6hHPGlz831Ng5qZGIv/QoeD+jpHM/EpTcGt5MgL8fR+rNZmSbvxIkQC66JJ8/3VUTRdPQjb/fgGGXwEKRP+RxL+jxLXw/LEVxQEhxYD9Yd+BrEkSRv/S2lsmImW2/zq9rNrOJkj8975FH6Uwpvyyu3h0tb4q/Q09//en+cr/m2HpXsV+JP1FqHpW+wGI/If+O83R6mD9qa+/SprKfP5PxC7M+Kmo/JuZ6n6PFnb8O5HoKD9mUv4BiCeMsfYM//DJ/PgImjT9iOhaab2l3P1caHnrTmX2/+MFyVYQlSz8EQFqaohd1P/4S/oaLbI8/5Pk6U1a+cz9bRtm89KdsP5KMFXd1dVo/18LJ4K8HjT/wmEQLDb6DP9aVeChNp6A/LjyI0JFkir8vbmRd0+SXP8jRu5FFZJW/u3JlTYoaRT/yMffmsm59P/9WmNqhPnC/gGQI+EP+dr+MZwUldayIP/LeenqE4o+/zSUY6HU/iL/yDMhQUryXPwetSmrFnoc/v5S7R4f9fT8yY07NPRaQv02yyy1nV52/RVZxldU5gL+fDi+jvqeLv21xyX02DYu/B4HFH3JOkD85lHJQus1vv6FKRnTBn5E/Pb9rr5p7db/4uULUqwd2P6hKoI6Bp4M/l3woNam5j78cJypK7WiWP3JT2SxoJIc/IwTmvohZWL859x66RU5YP1IvSDY815m/BIJE2I1qk7/qQS8tZT2GPwAdmCubNnc/rAHyO36Efb+B+LGVmIeCv70q1dngQ4q/xxbuhpYemz9GlZGc9ZR4v6dibmAHSX2/Tj2C+kksmb+j+QtoF1V6v54vtE6BH5e/00bmIQe1j79BRpuZmFB5P3hfZbpsvYW/vsgMSvuolz/N5bucZP5hP67lSHawbIM/VBiqXABTjb9ie827TwVhP4b87z9LeKC/5xm0dyCCej8WbFmRS8GAv6ORjIQ6Doa/Ask7AkHYWL+EiGkK0TSPPylx86Spw2g/mh82FmnRaD/jhjAaQWx0v6aILbuHQGG/gHJ+B8e5kj+lrMcMjV5hP/y9/tpIPHg/K468INLLnD9+a4WQA4JxPxhF9VffSoo/V17sV42Agb+fxrsLa76KP4W25hs5LJi/fliLY3mtnD9LfCSOkwmCvzS5w5cYxIy//C2qcvaSeb8J0ODoLdqSP4TlU89AY5g/KYzWRx+Cdz+KLFslD1mEv3S13wdt94C/fO0AHWK5m7/qukcMQL5jv/jZNZPFC5E/AOXTo3exkj/+DISvBGeBv8vCUMrmsiO/CUrEuFOchb8GXyDnNd95v8fBPc00FnC/AfMxzNPGfD89EvK6KvGZvxrbB9E7UZI/Ic2Uf3TEc7+Ahz9KKaGXP6XPc3sVfIe//l1ZlH/pdz+3dakN/QRPPwzdWPm1zma/WfbAiOFrL7/LaIPcQK2Zv9Ea4WBUbmi/dMJHzcFpmb9uEJAQAI1uP29Z4UywHnk/AiyFu7rabD96ycehu+OSv//BIEtdE36/n12tpaGuhj/LtAYmd6+bP1PoJqmUdYA/ve0w2UwaTD8DBfnoQUVzP47mg1Syf3I/epL5RCrEaD+84cBGpGuVPzHfWEx9JGy/Rjr/INyzbb9LJICBcGaVv8i7LklSkJE/YlMgtF5yZr9d7VXQ16+LPysGf5qS8JA/AwLSVvLPhD9yqw0km61pPxa41eT/oZO/OSIYZtQlPr9+kO6KbOCNP+pSGI3ibIM/V1VWVskQnz8JKHDrmAiEP+b7AeuZ030/qoDPdP18kr/seretX7X7Phh0Jl71nZk/BBYIk1zCij+wC5F1WUWGP2K7Igto4Ji/DwBEKbH1hb/wHyO8i52SPwUGFkXK5n0/94YqK/ZngT89i+QvnLd6P4HnWqN535I/hkzeEtpTfr8AaNKcR8eHP2Rg/CsuY5S/2vzV80ZreD/U7Jb/YbeCvwoVGcohs5Q/8Be7R2j/lr8n66jjdNqHP34jwGgnxYC/MHp7OAfwdT/ijkTzrxmIP/W+19+dkJa/pwjELyBDiL/yOAZQUiiUv99Mf+5TyGS/jtThsStbc7/ovrcnPG9nv/jGIb+vIJG/05rkDn7BYz8lALCcpeyTvxzBpxwS/0o/tA8L9/HriT+rCkwxz2aQP9On/AkzpJU/hHFlPucCnj9uMZ4PLv6JP1FAQW9ZEVQ/T+EFgNhlg7/y6iRBbDF5v1kK5sBB/Hs/p+D+X6WZgr/djSBAW/xzP96OBLsPY5O/G4lsAve0kD8bmmsVR7+Lvzd+AEVPP5c/S82M3/oygD+AlV/47iF3v7kS5ACJopm/dvs+ga0IlT91jR0YTBSQv3BmZPSFAJE/jW8+9xEtgr9QL6406+V4P4oNwKM6l4G/S628b8+Nb792FKuZLE5zv7ij4qPyC4u/M8iHMXbnjz8ljjIbEMJuv1WePseE5oK/AW5QUjxUhj8vlLFRmO+CPw14QzcT3pS/3IczA/DUdD9ZFErcoVqXvxv5bBLqCpM/G0KQQ50Noj9k6lq9KRaOv3rw26poWny/jgQ/gDVxc78FI/U9HpB+vyEMvlZZi4i//cbvMzoSg78Ix1KR29KQPztpadrTOZc/jKF+JfV7nr8GV35LL4CAP3r+MiP8WnC/cs/PsdaIlz/vrLUIlt+EPzI7RURJV3m/zuIvo4q9lr/xcX75wTuKv3r0gOLy3Vm/ehDnC/rqcj//FHOejRKZPyMyUY1GFpY/CN4hCP1+n781+f1uijYyv7ky26BQbZc/O/FJN4M3kL9867tVvIFgP1ERmEd821o/COnPaw3BWr8CdZw3ARJqv3Sp0Wps+Za/nm5cE5LqcT85G1RNAoltPzgSbfGsYoA/dusomCg2UL9svN3D3+COv81U+wWNf3G/ct7eTFrdSb9uI1TMLO8xP1FOhREDQYK/V+HHZVj7fj8WoOelSx+Nv4Zsfx2uZ1E/wWdA3hn9gb8l++h074N7P8OX582tJWG/CZ56awhUnT8L5xeVXGaKPwhsu1Dkspm/URJHld2DVD8UqnkJwHFVv0GPpwLNt4i/DrGQRAAVjj8EHywASq9ov9UhbNOEZIC/RoZd22jFbT9PXfSppLZ7P1Hk9pbNe4M/czsCojr9fb92JwUng0+QP7kvPeOGV4M/UpPpiEISfD/yM+kemm1tPzUtMSrICRO/I1BS4n/8fr9mA4tpLxqUP4dyVOJg7I6/DjRsbG6Dk79rD6H5N813PwQit9i/W3E/amwP8Fb2lr9mkNuDVlqGvxAg6lcqE4s/TWB+EG+Cgj8A2HtTajCLvxz8dlBL3pC/Xqkmj1i+fT9NCksVTIxvv9NOEd6CGkG/UXoKvOKlSr/w3x4sOgVuPwp3cGzYxoC/ZCbKMTfhYb+IbVRnu3BxvzUjbiMiCJI/ZZguqfKhir8QrnK7vMeTv9UzBlgakJU/lrTcJbkdjD9Re4oFmz6bP6tarrC2CG2/lduzYGXIgT/XVuCiyiqYv7hSLnYrI5O/grFq87x7Wr/ipdX76u14P9OEULUB8pg/7jH3Zc7ohL9sA0gIph9xPzl7BbyV0JG/U0YuL9h4c79BqGm71E+TP7cjNNnMrUA/khOvNel9g7+hmlsYeMNuP3FiJYqvvX2/KaImJt7zML8MGGc+CDKOP8cbtuW1tmu/NTQjnjvKcr+65OYQk9iBv6Pq3s1EBJM/Pv91+713dT9mI2j80LJ6P4dwpMhmpZA/rwE/XuodTr/NsEJJWb5MP5bYJnoMroq/8znVW073d7/TpwWSr0yRvxf7JxPP6pE/y4tmY4Bwkj+MEBsg6Vadv15FlYhTSpI/eqVIFySCgr9L4CBkDmtzv94o+IN/wZA/f7xTRhxMhD/TZhIxuUBbP0mNzPNxwkq/y7iV6ZdnRz8IWMehX7xxvwChSQGJYo6/tSaUUffkpT8vJzdiLhiEvynK0Ll9ApW/tRwrnFoAiD+Q3L/bmyZxv4nQSdwSXY0/bOYz+YT1hD+/jzEQDYRBv8lstBKOLpi/s5NI4023f78=",
           "dtype": "f8"
          }
         }
@@ -18680,11 +18744,11 @@
          }
         },
         "title": {
-         "text": "Observed IC sits far outside the within-time permutation null"
+         "text": "Within its own window, the factor ranks better than a dependence-aware null"
         },
         "xaxis": {
          "title": {
-          "text": "Mean IC (permuted)"
+          "text": "Mean IC (block-permuted, fold dates only)"
          }
         },
         "yaxis": {
@@ -18694,7 +18758,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAFeCAYAAABn3sxXAAAQAElEQVR4AezdCYBN1R/A8d8bu/rbt0KWEiUSsidLZUspsmQrIfsu+5Y1W8ouFBGlULSQJBSVqJBU9orsym7G/O/vjPe8GW/GnZn3Zt7ynZz77nLOued8zn3v/d59993CLl++FEnCgGOAY4BjgGOAY4BjgGOAYyBYj4Ew4Q8BBBBAQERAQAABBBAIVgEC3mAdWfqFAAIIIIAAAggkRCAIyxDwBuGg0iUEEEAAAQQQQACB6wIEvNctmEMAAfsC5EQAAQQQQCBgBAh4A2aoaCgCCCCAAAII+J8ALQoEAQLeQBgl2ogAAggggAACCCCQYAEC3gTTURAB+wLkRAABBBBAAIHkEyDgTT579owAAggggECoCdBfBJJFgIA3WdjZKQIIIIAAAggggEBSCRDwJpU0+7EvQE4EEEAAAQQQQMCLAgS8XsSkKgQQQAABBLwpQF0IIOAdAQJe7zhSCwIIIIAAAggggICfChDw+unA2G8WORFAAAEEEEAAAQTiEiDgjUuHbQgggAACgSNASxFAAIFYBAh4Y4FhNQIIIIAAAggggEBwCIRawBsco0YvEEAAAQQQQAABBGwLEPDapiIjAgggEEwC9AUBBBAIHQEC3tAZa3qKAAIIIIAAAgiEpECcAW9IitBpBBBAAAEEEEAAgaASIOANquGkMwgg4CMBqkUAAQQQCGABAt4AHjyajgACCCCAAAIIJK1AYO6NgDcwx41WI4AAAggggAACCNgUIOC1CUU2BBCwL0BOBBBAAAEE/EmAgNefRoO2IIAAAggggEAwCdAXPxEg4PWTgaAZCCCAAAIIIIAAAr4RIOD1jSu1ImBfgJwIIIAAAggg4FMBAl6f8lI5AggggAACCNgVIB8CvhIg4PWVLPUigAACCCCAAAII+IUAAa9fDAONsC9ATgQQQAABBBBAIH4CBLzx8yI3AggggAAC/iFAKxBAwLYAAa9tKjIigAACCCCAAAIIBKIAAW8gjpr9NpMTAQQQQAABBBAIeQEC3pA/BABAAAEEQkGAPiKAQCgLEPCG8ujTdwQQQAABBBBAIAQECHjdBplZBBBAAAEEEEAAgeATIOANvjGlRwgggEBiBSiPAAIIBJUAAW9QDSedQQABBBBAAAEEEIgpkPCAN2ZNLCOAAAIIIIAAAggg4IcCBLx+OCiB3qQJk+dIraefD/RuuNq/Z98ByZTnfvnr7yOudckx8/POX007jp845dXd791/UJq27iYFiz0sd9xT0at1J1dldqy8Oa4x+9mgWQcZ/srrMVcn6fKMOe9I5RqNbrrPbPlLyZp1X8eaz45lrIVtbGj5Yk/pO+QVGznJ4m0BX4+tt9vb8sVe0m/oWFe1MZddG5hBwIMAAa8HFFZ5Fjh85Ki06dxPSld+QnLdVUZKPVTXLOt6zyVCZ22X3sPkqWfbRevwqdNnpHu/EVKu2tOSp3B5KV6+tjRs0VGWfvRZtHx2F25Jn06qPFROUqVKaYps+2mnCYBPn/nXLCd0MmPOQjl//qJsWf+hHNwVe+CT0Pq9UU4D8Y8/+9J2VTGtbBeMZ0ZvjUE8d2sr+225ckiJ4ve68k6ZOV+q1nnWtWx3xluWsVkVuftOKZAvr93mhHw+/XA64OXx8XbwVM5bYxvvxlAgmAX8tm8EvH47NP7VsH0HDkmlx56Rb77dKs81bSBvvzFRWjVvaJZ1vW73rxYnb2v0bHD5avVlxSdrpP6TteSNyWNkSN/OUrLEfTJq/DQJDw+PdwPvLJBPli+aKRkz/C/eZeMq8Nfhf6TYvXdLlsyZ4soWUNt8ZRVICE/WeUReHzck0U32tWW/nh3kxVbxD8QT3TEqEF+PLcQI+JMAAa8/jYYft6XPoDGmdV9+/I50erGFPFq1knRs21y++nSxOBwOcW43ma5Nps5625wFzl/0IWnVoY/8c+z4tS0iH1mB4NPPtpd891YSvVygSu0m8rcVeDkzrF67QWo+9ZzZrmeUx0ycIREREc7N0sD6yljPcnTsMViKlqkh9Zq8KC92HSDPt3/JlUdnIiMjpUTFOjLtjQWif1rH5BnzpdKjz0juu8ubM17aFt3mTGvXf2PW61nZR55oLjt++d25yfbjS4PHyIWLF41P765tpNZjD5vAt2+P9rJh1XuSIkUKj3Xt2PWb6Nd09z74mHHRvq3bsNnkdf/68cDBv0wbdYP6qmHbLv118aa2JtO1SeEHqoueOX19xjyzv259h8vZc+dlxNjJ8li9FpK3SAXRsYl5Vtp52YqeNSxT5UnJnLfEtRpvfPhh23YzPjrWJSs9LgOHT5ALFy66MupZR63HtcKa0b5oW6xZcwz9+99Zc9mF9lNtdL1dK82ryc64/vrbXmnWprsUKfmIFCpRVdp3GySxnUGPawx0fxERV80Z/ntKPyrFytWSl8e8Hu2Djn4D0GvAaFETddbng/ZJy3pKa9Z9bZ4Pzg9LeimKemgdzvxjJk43zw1ddr+k4Z0lH8lAy915llXLvbXgfc1m0j9Hj8szzTuYS1r0ufHuByvNep24H3e6vOm7reZYcXpq2+s2bC06zrrdU4rLKuYlDdnyl5K3Fy8T9dBjRp/rW3/cIXopj35josfso0+2sD5s/xBtV/EZOy3o7Mec+e9KlVpNzLcwteu3EjXS7c6UkNciZ92ff7nRPH/uLP6wdOg+WI4dPyk/bv9FmrfpIfq81bOu+uHYuS99TdN1zmV91HEqW7WezkrnXkPN81VfW3UMNe3+fd9Nn7OxlYs5troTHUd9PVV7PTb1uHF/vup4DBoxIc5jW+txT87Xi1lvLpIHH37CXD7VulNfOXL0mCvbzfruysgMAgkUCEtgOYqFkMCVK1dk9dqN0ua5xpIje9ZoPc+WNbO0ff5Zs/3y5SuubXp95Lafd4qekVz5/hw58s8xads5KiD77+w5eaFjX2nc4HH5adMn8uPXH8tzz9Y3gbNW8NXGb6VLr2HyXLP68sOGFTL91eHy3ZafZNjo13SzK819e4ncWTCfbFj1rsyfNcEKKGvKJ6u/NC/+zkwbN22RP/86Ig3q1TKrxk6aKR99ukaGDewuv2xZLX26tZOhoybJZ2vWm+16prpRyy5S8v775OfNn0qf7i/K4JETzTa7Ew1IPvt8vXXWqonkvj3XDcXSpUvr6mvMjX0GvSJ5cueSVcvekn071suIQT1F88fMl++O3KIfPnT9/p0b5PSfP8ms10fJzWw1v3vave0LqflIZena/jlTx6Qxg+Ty5cuSJk1aeXX0IDM+Hds0l/7Dxt9wnae+cf9gBSLvzZsqB37ZKJ7+9M38iUZtJVeO7GYsp0wYJous4KvXgFGesntcp8dAhv/dKgtnTzJt/OX71SafXSvNbGdcjx47IU82aiP333evrFgyR1Z/OF8yZrxVGrbsJFevXtVqoqXYxsCZabEVNIZfCZexw/vKM9bxpx8qPvjw+uUszdv0tMbrrHX2f7T8+M0n8nitqlaQ1y7Wa8XLPfiAnDt/wRWQ6bct2bNlsQK/Lc5dyqbvtkn5sqVcy86ZZ595whxLD9xfVPRY0fRcswbOzfLatLlyf7F7ZNrE4XJ3oYLSrttA2X/gT9d2TzPz31kmE0b2l+/WLZe8uW+3ygwQ/YDpKe/NrGKWmTJznjxYqph1hnqohFsfdFt17COdew+RnNmzydgR/SRVypTSwfqw6xyX+I6d+/7eWbJCJo4eINus1yG9vEIvTXJ+yEnoa5Gz/klT35TG9evKywN7yLdbtknHHoNkwLAJUql8aWtdd9m+8zfrw+VUZ/abPk4eP1Tq1KxqTjboGGoqXKjATZ+zsZWLuUO7z9eF734kD5YsLl9/vsTY6Wux+7Eds15d1tcLPamxZP40Wb54puzdf0jGTJihm0I60fmkEyDgTTrrgN3T/oN/m7YXvedu8xhzUvy+ImaVvoCZGWuiZ+QmjBogefPcLvdZ5UYO7in65rFr9x45ceKUXLGCaH3Rz5Qxg+TPl0f0zVevObSKyqtT50qb55uYNwoNqB8sdb/079Ve9EVVtzvTA8WLSo9OL5iv4jUgqv5wBdHH5SujAiLNt2zFaqlWuZwJ1C9duiyTpr0pw61gV/PqpQE1H60sLZs2kHnvvK/ZZYF1ZkmDiDHDept6H61aSZ595kmzze5kv3X2NcJ6ky5WNMrFbjnNd/jIP1Ki2L3GLXOmjPJU3cekbOnYz55qGfd0M1v3vLHN66UNela66D2FjMEzT9UWvYxl8fsrbigy6ZVBZvzU/YaN1or5i5bKrbekl1fHDBQdywpWMDaoT2dZ+N6H5myXlSXB/+JjZWdc9fgqfl9h0b4XujOfua509NCXZKd1hj/mWT87jS5etLBooFG3VnUZ3LeLPFKlgnz3w8+m6PqvvzOB61TrA0CpB4pJ1iyZzCVCJUsUlQ8+WmXyxJyoowYZGzdHndnc9O1Wad2ysfy+54A5U3bx4iUr+N0qFco+ELPoTZcbN3hCBr7U2Qq6q1kfnEaa59EPP26Ps1z/Xh3NJTr6vO3croVph/u3OHEWvslGbY9e6qCXZYwd3k80+K5coaz07dFOdN2oIb3MOg2gtKrEjF2/nu1NP6Ke9y+JXiPv/EYjoa9F2iZNQ6xxb/fCs9K04ZPSuV1Lc2Jg1NBe1ofhZ6VFk6flRet17ocfo44JzZ/QFJ/nbFz7sPt8faRqRet18Qnz+qCvkdWrVJTvt8Z9vGS2Xs+G9u8m+npf3HptbNrwCev58GNczWEbAl4VCPNqbVQWlAJhNo+SMLeMdxXIJxpQOkGKWW/+DodD9lmf6vUFr2K50vKo9bVk/2Hj5I23FskBK0h05t39+17zC3f9us6Z9NIC/ard/QdyJYrf4yxiHvUygQbWmbRl1wIGDao/+PBTefrJmmb7PuuMlQa9eqmEs159HDLyVatdUWez9h34Sx6q8KD1ppfKlNGJBsz6aDeFhTlM1hRhni9bMBtjmWj7u/UZLnqpxmvT35KtP+6IJafn1Tez9VzqxrWL3v9I6jR4wXzFrUb6VfmhPw9Hy1jYOhPoPsbRNl5b2LPvoDxU8cFoZ6n1DVI3791/UB8SnOJjZWdc9VuJz7/82nxdr33WpJdqnDt/XvZZx058G3pP4buiFdGznMdPnDTr9uw9YJ2tPS/69b3ux5n0mwEN7kwmDxMNZjd9+4PZsm7jt+bDXIWyJWXjN1usM4g/SupUqcyZN5MhHpN7ixRy5U5pnT29w/qgetz6YOpa6WEmz+05XWuzZ8tq5vUr+zP//hfN0Hlpislgc+JuVyBfblPqnsJ3mkedqKU+OtuYmLHT4Evr0pQ6dSrRD/Z7rdcpXU7oa5GW1XSv9aFRHzXlyxvVj6Ju1rrun6MndHOik53n7M12Yvf5mvu262OvdWbPltn6ABt3P/Lmvk2zulK2rFlFz8y7VjCDgI8FbIYyPm4F1fu1QP478kiaNKll567fPLbz5x2/mu13FbzD43bnSn0jdX7lWTYeKQAAEABJREFU+cGCaTKoTydJmyaNLHp/pZSt9pTo5Qea1+FwyIRR/UW/rouZ9GyS5tGULm0afYiWnq5bQ9au32ReSFd/sVHCwyPk8ZrVTR6HIyoQ3fTFBzfUvXntUpNHJyljXF+r7db1dpN6pbICj/0Ho4Jou+U0n541mzt9rNxhvTl+s3mLVK/bTCbPmK+bbKe4bO1UotdvvvLqTOusZGfzdbWOgZ79u2ydlXcvny5tWvfFWOdTxPBMkTL6BwGHI2pc3CvQcXNf9jQfX6ubjavD4RD9gaH2N2bS4NpTG+Jal9JjPyNNEYfDYb51iLkfXdav100mD5MK1gfFDZu2mLOpZ8+eE71EoXyZkuZShk3fbZXyZR6Q+B6vuhtPbY2Maqpu9pjcP+A6M+jzWz8EfbfuQ+vYiUp6Vta53e6je3scjqjjw/04cjii1un+tE6Hw7tj515vQl+LtF3ux5zDEdVm9/FxOBzRLgNxOKLyaFlnCo8Id87G+mj3ORtrBW4b3J11dYoYx7GuC7v2oV7nr6e4D5jYjhdneYfDRt+dmXlEIAECYQkoQ5EQE9AXwAZP1pLZ8941Pxxx776eYZn15jvS6OnHxf0F7Y99B0TP9Djzbt+521zGUCB/XrMqrRWsNq5f1wqqusjalQulVIli8tmar8y2e60zYxq0moV4TvTyB/06Wq8nW7ZylTxeq5r5Sl2rubNAXnOm8Yt13+iix6RnkzSAd9/40/Zd7os3nVeHptZXmK/PeCvaD/GcBfUHIM43VOc698ca1R8SvXb43XlTpFeX1qL9cN/unE9jfVjQeed1jDqvKS5b3X6ztHnLj1KxbCkpW7qE5MqZ3WTfvvNX8xjfyZ0F7pCYntt+/MVUUzB/1AekHNmyyKnTp80652TX7j+cs+ZRg+urkVfNvPvErpWdcS1c6E752vqQoePjvo+45mMbg7jK6LbCdxc0H8rie6mEjol+GJj6xnypUK6kaPBUsVwp0+5vvrUCXmvctH5PKW3a1BJ5Ne6gxFO5hKy7+6784ky5ckQdQwm1srP/hIyds96f3Y7ty5evmA/2BfLlMZvvTcRrkakgnpNsWbPIyZNnopX69bd90ZbTpE4jMV8/7DxnPZWLVrG1YOf5amXzyT87fffJjqk0ZAQIeENmqBPX0f69OpgX2YdrNRb9hfDnX240j7qsL756HZz7HhwOh/ToN1IO/fm36C/P+w0dJ5UrlpF7i9wlGsxMmDxH/vwr6ity/QpXv+J1vsn0tII8vXPA6AnTRLdpQKfX/+pZR/d9eJg3qxrUq2N+GPXp6q9Erz81K62JBge9urSViVPmyDtLPpKTp06LBjfvL/9UFry73Moh0rRRPfn1972i+woPD5ctW3+W6XMWmm3xmfTr1V7Eii0q12wk41+fLdoW7cPYSbPkoRoNo91xwr1e/UX01h93mFX6AzS9Lq5ALPcozZvnNnNmfccv18+838zWVHyTid6i7AerDeqjl4Wo1+q1G25SyvPm5o2fkoOH/jZ3KNAPR/rjw+FjXxf9QJDdCnS1VOmS98vylZ9bQW/UG72erYp5dlx/nLhz1++a3ZXiY2VnXFs1b2DqbtOln2gQpMedeurdFdw/vJlM1yaexuDapjgf9KysXkfesedg6xuJb0Svv9VfrOvdKjZ/vy3Wsnodb+kHipnju2LZ0iafXtf7x94D5pKGCnFcv1vA+oBx0Ho+On+QZQon4SShVnaamJCxc9Y7dtJM0eecXo7Rd8hY64N5uDSoV9tsTuxrkakkHpMypYqLjr/zg9Avv/4hH69aG62GgvnzWK+he6L9kNLOc9ZTuWgVWwt2nq9WNp/8s9N3n+yYSkNGgIA3ZIY6cR3NfXsu2bh6iej1gm8uWGJuqzP37ffMsq53v9RA96Q/vLrv3rulXLX6Uqd+K9EzhW9MGa2bJH26dPLVxs1yX9ma5lq/UpWfkBqPVBb9YZRm0GBgxXuzRX/gU+3xpnJPqUdlwuTZcvnyJd180/TMU7VMwJIhw61S9aFy0fL36NTKOqvc2fwArljZWib41GBXb8CuGQtaQcGS+VPM2eYyVeqJ/lpdz7bqtvgk/TX5prUfSN3aj8j7yz+R1p36Sv1mHeRbK5gZ0LujOTPnqb5/jh6X2g1aiV7Tqbd70qDr5QHdPGWV/916i3Tv2EqeaNTG5Ndbed3M1mNFMVbqONSpUUWqP95MylR5SjSg7t7xhRi57C3myX2brFwyW7Zs225uv9Wu2wCpXqWCjB/Z31XBi62ayEPWh6EylnfOOx+U3/7YK4/XrObarjOdX2xpfcCab/rpvC1ZfKzsjGvmTBll1bJ55vhsfu22Ufqhbc++g6J3BdB2xEyexiBmntiW582aII9Ve0j6Dx0vdxavIk2e7yrrv/5WbrXGVeL4q2AFtXotup7Z1Wxp06Yxv/pPmSJlnNfv6nNBf2Cav+hDoseX3u5KyydVSozVzdqYkLFz1tmjY2tp2rq79XpUQ379bY8se2eG6I9pdXv5MiUlMa9FWkd8UgXrDP2Qfl2lrfWhS8doxLjJ0r51s2hV6Ie3Awf/lCx3PGDGcffv+8Tzczb6c9ZTuWgVWwt2nq9WNp/8s9N3n+yYSkNGgIA3ZIY68R3VoPaNyaNly/qP5Mgf35nbTOmyrnevvWfnF+TTpW+aYOyv3zaZW1a9NWOcuaWQ5tMfnHz07hui1ytqOnFgq7w2dnC0e9PqD8f0jWfv9q9Eb52l+Qf16aLFTXrfXAN8fdmsvDbRM6Ja764tn0erUzc7HA7z5rDmo7dF26Z90VunPVW3hm42Sf9vZnrLr60bV5q+Pv1ETdNWDfpNBg8TvcG/ttd9k74Jvzp6oOj1wbqv4/t/kA8WThf3fbnn13n1VFttvybtt3O/+uMaXad3O9C8mvr2aG/apuv1tmR2bLWce1r81mQZNqC7a5VekqHW275eKZrmTntFXurWVtTEmck5xs7luB71OlPth/5f3NR0+MCe5tISZxkNhPR2aL//+KX8s+d70X2rg65z5tH7GB/69RvTV+dtyTRPfKzsjKv6qeNP33wi2l49jufNHC/p06dzNuWGx5hjoBk8HZ9jhvWReTMn6GaT9Gyt/mrdeXyo73vzp5q7mpgMsUzUR8dbXZ1Z9BjWY0y/xXCu07sDrF/1rnPRXHKk+bSsJr0zim7U4/KRKhV11pW0nJbXFTGPOw0CtbwG2rpdkx6Tuk7z6nJsyZOVmqiNs0zM9miftG59TXDm0YBU17kbJGTstL4qD5UVfa3QY++TD+aa66J1vTPpfvW5HZ/XIk9Gevxpm5316qPeYkyPM513pm4dnpfvv/rIHOvvzHlNurRrKd9+GfUNlObR1zd9HmldmgoXKmDGVo8Lfb5q8vSc9VROx0vr0PHTujWpaVzPVzvHttbjnjy9XujdNvb8HHUZmzPvzfo+z3oujh76kjO79XwaL+7Lrg3MIOBBgIDXA0qorKKfCCCAAAIIIIBAKAgQ8IbCKNNHBBBAAIG4BNiGAAJBLkDAG+QDTPcQQAABBG4U8HTZwY25WIMAAsEiQMBrdyTJhwACCCCAAAIIIBCQAgS8ATlsNBoBBBBIPgH2jAACCASaAAFvoI0Y7UUAAQQQQAABBBCIl4CPAt54tYHMCCCAAAIIIIAAAgj4TICA12e0VIwAAgiICAgIIIAAAskuQMCb7ENAAxBAAAEEEEAAgeAXSM4eEvAmpz77RgABBBBAAAEEEPC5AAGvz4nZAQII2BcgJwIIIIAAAt4XIOD1vik1IoAAAggggAACiROgtFcFCHi9ykllCCCAAAIIIIAAAv4mQMDrbyNCexCwL0BOBBBAAAEEELAhQMBrA4ksCCCAAAIIIODPArQNgbgFCHjj9mErAggggAACCCCAQIALEPAG+ADSfPsC5EQAAQQQQACB0BQg4A3NcafXCCCAAAKhK0DPEQg5AQLekBtyOowAAggggAACCISWAAFvaI23/d6SEwEEEEAAAQQQCBIBAt4gGUi6gQACCCDgGwFqRQCBwBcg4A38MaQHCCCAAAIIIIAAAnEIEPDGgWN/EzkRQAABBBBAAAEE/FWAgNdfR4Z2IYAAAoEoQJsRQAABPxQg4PXDQaFJCCCAAAIIIIAAAt4TSI6A13utpyYEEEAAAQQQQAABBG4iQMB7EyA2I4AAAr4ToGYEEEAAgaQQIOBNCmX2gQACCCCAAAIIIBC7gI+3EPD6GJjqEUAAAQQQQAABBJJXgIA3ef3ZOwII2BcgJwIIIIAAAgkSIOBNEBuFEEAAAQQQQACB5BJgv/EVIOCNrxj5EUAAAQQQQAABBAJKgIA3oIaLxiJgX4CcCCCAAAIIIBAlQMAb5cAUAQQQQAABBIJTgF4hIAS8HAQIIIAAAggggAACQS1AwBvUw0vnbAuQEQEEEEAAAQSCVoCAN2iHlo4hgAACCCAQfwFKIBCMAgS8wTiq9AkBBBBAAAEEEEDAJUDA66Jgxr4AORFAAAEEEEAAgcARIOANnLGipQgggAAC/iZAexBAICAECHgDYphoJAIIIIAAAggggEBCBQh4Eypnvxw5EUAAAQQQQAABBJJRgIA3GfHZNQIIIBBaAvQWAQQQSB4BAt7kcWevCCCAAAIIIIAAAkkk4HcBbxL1m90ggAACCCCAAAIIhIgAAW+IDDTdRACBgBOgwQgggAACXhIg4PUSJNUggAACCCCAAAII+EIg8XUS8CbekBoQQAABBBBAAAEE/FiAgNePB4emIYCAfQFyIoAAAgggEJsAAW9sMjbXp0qVWpIjXblyRVKkSJks+06O/obqPlOkSCERERGMczI9z5LyuIuIuCoORxhjHQJjra/fvji2ztWuI5p8UTd1xv+9Xq79ecvuWnV2HsjjQYCA1wMKqxBAAAEEEEAAAQSCR4CAN3jGkp4gYF+AnAgggAACCISQAAFvCA02XUUAAQQQQACB6AIshYYAAa/bOA8ZM03K12gmj9V/UQaMeF3+O3vOtfW95aukWbt+0qL9AFm/aatrPTMIIIAAAgj4o8D5CxdlwtS3pPELveT5TgOt97C+8tkXG11N/W7rdmnddbBr2V9nyjzS2GPTFn3wifQaPN617fiJUzJw5Oumv627DJaOvUfIx6vXu7bbmZmzYKkpr2ZvLlwWa5E///5H2nQbYsUE/czj30eOuvJeunxZRr/6htRt0snEFO5t1HEoXa2hVK7TQjr3GSW/7N5jymnbdb17Kmv1++Kly2Y7k8QLEPC6GbZu/rR889nbsnj2WLn1lvTyzvufmK0HDh2W+YtXyMyJg2Xs0O4ycsIs4SA0NCEyoZsIIIBA4AkMHj1F9h/8W+bPGC1vThkhw/p2lPGT35TP130TeJ25SYs1yNRgMnOmDLJo9jiZ/frLMmlUX0mRwn6Ys/HbrbJ0xefy5tQRMtfyev+j1fLtDz973POAEa9J9crlZP700dZjWRk8aoor39jX5sruP/bLhGzQE7IAABAASURBVBG9ZdOqBdLu+YaubUP6dJAta9+TFYumSekHisooKzDWjdmyZjbrdZumLm2byUPlS0naNKl1M8kLAvaPBC/szN+ryJs7lzgcDsmU8X8SFhYmkdZ/2uaNm7fKwxVLyy3p00munNmkSKEC8v3WHcIfAggggAAC/ihw4NDfsnHTDzLkpfaSOlUq08Q78+eV1i0ayJsLl5tlnejJm+4DXpGWHfqbs8C//r5PV8vhf45Jv5cnyQtdBkm1J1vJlDfeMesP/XVEeg0aZ86CNmnTO9oZVD1brGc22/UYJkPHTBV9XLvhW1NOJ+u+/l70rKjOH4qjnk/XbJAGz3U3+54yO2q/WiaupGdy06ZNI93btzDv45o3VaqUUrN6JZ21lT7/8hupW6uqpEubVtKnSyt1HnvY+nCw6YayavPH3oPy1OPVzbanHn9Edvz6hxw/eVrOnb8gH366VoZage3dd+Yz2+8qcId51En+vLfrg2TMcKukSplSwqyYw6yIMVn28RqpVyeq/hibWEygAAFvDLhOL42SirVayD/HjkvrZk+brcdOnJTbc2U38zrJc3tOOXr8hM6SEEAAAQQQ8DuBfQf+FH2v0jOH7o0ref89su/gn65Vv/62Vxo9VVPmTRslj1WtIENfmWq2vfP+x1Ls3kIy5/XhsmbZbGlo5dENemazykNlZPGc8TJ9/CCZs+ADcQbJuv3CxUsyzVo/1Dqb/HiNh2XFZ+t0tUkrPv1SdJ0uxFaPfrU/cuIsGTWoq9l3eHiEZr9p2rv/T3mgWBFzsspTZg3E3S8XcJ/XQFzL/HPspNxhnfjSeU135L1NjliBv867pyP/HJcc2bNImtRRZ1/1MVeOrHL4yFH5+/BR+d+tt1guS6V6vdbSvH1/0TPH7uVbtO8nun89g6xnod236fyP23+V8+cvSsWyD+giyUsCBLwxIKeM7S+fLpkuBe7ILXPdrt9xWGd8nVkdDodzVs6dO5ss6fLlS9YT4lyy7PsmfaZNXjwmzp8/J5cuXcTUi6b+evzqOF+4cJ6xDoGx1tdvXxyHzjcmrfvixYsSGXn1huNJjzHNF5XnguSzzjgWu+dOk6/2oxXl4KHD8s/Ro1LYOjupZypfnznf+pp/tfXVekoroDtirjldumK1tOo8QHoMfEXOnj1vfeP5syl/9WqEPFSuhOg+tP4KZYrLtp93mXKHjxyRH376xWzXeb121VM9m7f8JPcXvVty58pm6qxft5o218xrne5JHSMiws02vbdxePgVM++exznfpW0T+WrFXI/pwRL3mHIRERFy5cplM6/lrljvs7pO593ThQsXbmiTrrigz1/rNVt//1P4rjvk3TljpXPrxjJo5GQ59Ndfrnqnjx8gHy+eIs88+Zh07jNS/vvvX9c23c+SDz+T2o9WuuE9XvdBSrgAAa8Hu0wZ/idVrU+w323dabZmz5pFTp8+Y+Z1cvLUacmRLavOyi233JosKXXqNJI+/S2ufddvNUCcKbnaxH69fyzoGKdJk9Y1zhh739hfTHWc06VLz1gn02uqb44Dz8ervn77Yn/mTcmaaN33FL5L/jp8TC5cvBLtmNr12wHrhE4esy5t2nSSOnUqM69lMmbIaC4H0PnHa1aVWa8Ok/uL3Wt+qD1u8jzJYG1PaX0NP/u14TJ38kiTVi99Q5o3etLUERaWQjJmzGjmtY4smbOY99K1G7aIpioVHxRdF1c9adOkkTRW0vKatE1i/el8zKSOKVKkNPsrXKiAbN+1R2J7Dr0+a5E8XLeVx/T9j7tMHfpN7tlzF8287uu/sxclT+7bXMu6TlOB/Hnl9Jn/XO/Bus8TJ8/InQXzS/478litFXm8ZjXJZsUOZUoVl5zZs1pjcSJaPTlz5LDOrNcy1/rqSWytV5MjLKV89c0P8myDx6Pl122mYiYJFghLcMkgLLj9l99NryKuXpV1X2+RwoXym+VK5UrKhs1bRS+KP3nqjPUJd6+ULV3MbGOCAAIIIICAvwnomVt979JLFC5fuWKap9edzp7/vjzftJ5Z1omu07s16Lx+xX6H9TW+/mj7zL9nJWOGW+XhCqWlTYsG8vPO3XJL+nRyz90F5dXp8+Wq9T6pZbS8Xoag857SE1bgvHL1V+bShidqVTVZ4qqn+H2FZceu3+XsufMm7/pvtpjHm03qPFZZLl68ZO7ScOTocZP9ypVw110p+nVvE+1HYfrDMGfSQFwLPFqlgnzy+XpRL016R4tHHi6nm0Tf+3fs+sPM35Yzu7nM8YuvNpvlNdZj4bvyS9bMmSRTxgxS1gpy9bc/ulF/NHj0+Em5q+AdVpD8r/yx76Cuts6+R8qKVetELzvJnCmDWaeTT1avl+L33i3Zs2XRRZIXBQh43TBnznvf3EKkUq0WsnnLz9Ky8RNmaz7rBeCpOtXlhS5DpFv/sdK9QwvXjwBMhkRMKIoAAggggIAvBF7u31kK5MsjLdr1Mz9IGzZ2mvTq/LxoYOfcX2HrzOi8RR9Ko1Y9zQ/QhrzUwWzSH4uVr/Gs+ZHZwiUrpU/X1mb9yIFd5PiJ09KkdW+p16yL9B8xSfQkkdnoYfJA8Xvk7Nnzcvb8eSl5/72uHLHVk8MK9Hp0aCl9hk6Udj1fNu/FrkJxzKRJnVr0ThRhYWGiP557ruMA0R/jOQPzOIq6NukHhGqVy0mzF/vIcx0GWE7lTfCqGbb8uFNGTJihsya9MrSnLF76qTRv11eWfLhKXu7fyazXif5gTQNXvY3piAkzZcyQ7pItSybrQ0KkDBo1WfT63QerN5JZby2RgT1f1CKutPzTtfJk7WquZWa8J0DA62Y55ZV+5hYiehuRBTNGiz7xnJsb1qshum7+9JHWJ95SztU8IoAAAgh4R4BavCygdxro2fE58wMzDQbfnjEm2l0LypQsZr2vjZGp4wbKu3MnmICxiBUAazMG9GhrvR++I29MGmYFbD2kQpkSuto6s5lDRg/uZvIvX/C6vDd3ovnKXjfOfu1l0Tp13j2tWDRVVi6a5r4qznr0zgraphkTBsuIAV3kuzWLo5V1LjSpX1vGv9zLuSjZsmY2+XVfb00dKVPGDpDaj1Z2bbcz80Kzp02f3nljrHUm/ClXEf1B3+LZ413LemZWb32mpmp0e64crm16dlZ/uKfxwuzXhrlMsmTOKIveGOc60/zxu9Ol9AP3ucrpzAJrjGpUq6izJC8LEPB6GZTqEEAAAQQQQAABBPxLILACXv+yS5bW1GzUVTTVa9knWfbPThFAAAEEEEAAgUATIOANtBGjvQgggICIgIAAAgggYF+AgNe+FTkRQAABBBBAAAEE/EvAVmsIeG0xkQkBBBBAAAEEEEAgUAUIeAN15Gg3AgjYFyAnAggggEBICxDwhvTw03kEEEAAAQQQCCWBUO0rAW+ojjz9RgABBBBAAAEEQkSAgDdEBppuImBfgJwIIIAAAggElwABb3CNJ71BAAEEEEAAAW8JUE/QCBDwBs1Q0hEEEEAAAQQQQAABTwIEvJ5UWIeAfQFyIoAAAggggICfCxDw+vkA0TwEEEAAAQQCQ4BWIuC/AgS8/js2tAwBBBBAAAEEEEDACwIEvF5ApAr7AuREAAEEEEAAAQSSWoCAN6nF2R8CCCCAAAIiGCCAQBIKEPAmITa7QgABBBBAAAEEEEh6AQLepDe3v0dyIoAAAggggAACCCRagIA30YRUgAACCCDgawHqRwABBBIjQMCbGD3KIoAAAggggAACCPi9QBAFvH5vTQMRQAABBBBAAAEEkkGAgDcZ0NklAggg4FMBKkcAAQQQiCZAwBuNgwUEEEAAAQQQQACBYBFw9oOA1ynBIwIIIIAAAggggEBQChDwBuWw0ikEELAvQE4EEEAAgWAXIOAN9hGmfwgggAACCCCAgB2BIM5DwBvEg0vXEEAAAQQQQAABBEQIeDkKEEAgPgLkRQABBBBAIOAECHgDYMhqNuoqzhQAzaWJCCCAAAIIhIAAXQwkAQLeQBot2ooAAggggAACCCAQbwEC3niTUQAB+wLkRAABBBBAAIHkFyDgTf4xoAUIIIAAAggEuwD9QyBZBQh4k5WfnSOAAAIIIIAAAgj4WoCA19fCPqy/dpNuwfVjNh9aUTUCCCCAAAIIhK4AAW/ojj09RwABBBDwUwGahQAC3hUg4PWuJ7UhgAACCCCAAAII+JkAAa+fDYj95pATAQQQQAABBBBAwI4AAa8dJfIggAACCPivAC1DAAEEbiJAwHsTIDYjgAACCCCAAAIIBLZAqAS8gT1KtB4BBBBAAAEEEEAgwQIEvAmmoyACCCAQiAK0GQEEEAg9AQLe0BtzeowAAggggAACCISUgMeAN6QE6CwCCCCAAAIIIIBAUAsQ8Ab18NI5BBBIpADFEUAAAQSCQICANwgGkS4ggAACCCCAAAK+FQjs2gl43cZv2pzF0rh1b3m8cSd5edwMuXT5smvre8tXSbN2/aRF+wGyftNW13pmEEAAAQQQQAABBPxbgIDXbXzuL1ZEFs8eJ/Onj5STp87IspVrzdYDhw7L/MUrZObEwTJ2aHcZOWGWXLx0PRg2mZgggIBAgAACCCCAgD8KEPC6jUrFMiXMUpbMGaWEFfwePX7CLG/cvFUerlhabkmfTnLlzCZFChWQ77fuEP4QQAABBBBAAAEPAqzyMwECXg8DcuHiRVm56ispU/I+s/XYiZNye67sZl4neW7PKc5g+OrVq+LrJBJp7TZmilobNY2+zdftoX7fj7nTODIyUjQ5l3lMOvukttZx1pTU+2V/SX9M+WqcrTcK848xTfox9WSu46zJ07aErDODyyTBAgS8Mej04Bw4crJUe6iMlCt9v2urI+w6lcPhcK2/dOmi+DpdtYKemEnbGanBtodtvm4P9XtpzG0cOxetD19Xrlz2+THGmCbdmMZmzTgn/xjENjbeXh8eHu6T57Tzjcnb7aW+hB2bly9fEk3e8nOOL48JE7gexSWsfNCVmv32B+aShQ4vNHb1LXvWLHL69BnX8slTpyVHtqxmOV269OLrFOYIk5jJ4XBImBWEx1yvy75uD/X7fsyvG6eT1KnT+PwYu76/pOwb+3J313FOmzYdY50Er6nu7skxnypVKp+Ms1z7S44+JXafwVg+TZq0ksZK3urbteHlIYECBLxucO8uWyXHT5yWNi0auK0VqVSupGzYvNXcteHkqTPyy+69UrZ0sWh5WEAAAQQQQAABBBDwTwEC3mvjEh4RIZNmvC0ffbZOytdoZtLw8bPM1nx5b5On6lSXF7oMkW79x0r3Di0ktfUJ3WxkkkQC7AYBBBBAAAEEEEiYAAHvNbeUKVLIplULoqVBvdpe2yrSsF4NWTBjtLll2cMVSrnWM4MAAggggECSCrAzBBCItwABb7zJKIAAAggggAACCCAQSAIEvIE0WjbbWrNRV6nZqKtJNouQDQEEEEAAAQQQCFqBgAl42/UcfsMgNHux3w3rWIEAAgg3RxUFAAAQAElEQVQggMB1AeYQQAABkYAJeGMO1rnzF8xdE2KuZxkBBBBAAAEEEEAAAXcBvw94Z81bYu6Y8NOO3ebReQeFZu36ydOPP+LelwTPUxABBBBAAAEEEEAgeAX8PuBt2/IZc+eEBk88Zh6dd1JYNn+SNKlfK3hHhp4hgAACSS/AHhFAAIGgFPD7gNep3rNjC+csjwgggAACCCCAAAII2BaIf8Bru2rvZty4eZu06TZMHqrdMtqlDd7dC7UhgAACCCCAAAIIBJtAwAS8cxYslV6dWsq6lW9Gu7Qh2AaE/iCAQOAI0FIEEEAAgcAQCJiAN2eOrFL4rvySIixgmiz8IYAAAggggAACISDg910MmOgxa5ZMsnTlGjl77rzfo9JABBBAAAEEEEAAAf8RCJiAd+mKNTJu8lvy6NNtuYbXf44fWoKAfQFyIoAAAgggkEwCARPwOm9HFvMxmdzYLQIIIIAAAgggkCABCiW9QMAEvElPwx4RQAABBBBAAAEEgkEgYAJe5/9hLeZjMAwCfUDgRgHWIIAAAggggIC3BAIm4HW/lOHzpbOke/vm0qppPW85UA8CCCCAAAII+KMAbULACwIBE/C69/XWW9JLw3o15Nff97mvZh4BBBBAAAEEEEAAgRsEAjLg1V4cO35S/jp8VGdJCCCAAAIIIIAAAgjEKhAwAW/Ma3cbvtBbnmvyZKwdYwMCCCCAAAKhJ0CPEUDAk0DABLzu1/Dq/JcfzpGa1St56hPrEEAAAQQQQAABBBBwCQRMwKstjoyMlL37/zJJ53UdKf4ClEAAAQQQQAABBEJJIGAC3g8/WWv+L2td+o4WTY/Vf1E++mxdKI0VfUUAAQQQ8K4AtSGAQIgIBEzAu2DJxzK0TwdZsWiySYN7t5O3310RIsNENxFAAAEEEEAAAQQSKhAwAW/KlCmlUrkHxOFwmPRQ+ZISFuZIaL/tlyMnAggggAACCCCAQEALBEzAmyJFmGz6/icX9sbN2yR16tSuZWYQQAABBHwrQO0IIIBAoAoETMDbt2srGT9lnjhvTzZpxtui6wIVnnYjgAACCCCAAAIIJI2AlwNe3zX6vnsKyftvTZCFM18xacmbE6Rokbt8t0NqRgABBBBAAAEEEAgKAb8PePVODMs+/sJgOxwOKZg/t0lLV66Rz77YaNYzQQABBPxOgAYhgAACCPiNgN8HvAuXrJTqlcveAPbIw+Vl8bJVN6xnBQIIIIAAAggggID/CPhDS/w+4L16NVIy/O/WG6wyZrhVzp49d8N6ViCAAAIIIIAAAggg4C7g9wGvI5Y7j129etW9H8wjgEBAC9B4BBBAAAEEfCfg9wFv+Qfvlzfmvy+RkZEuBZ1/Y/4HUrFsCdc6ZhBAAAEEEEAAgYAXoAM+EfD7gLfd8w3lh592SePWvWXclLdk1MTZ0uiFXrLt51+lbctnfIJCpQgggAACCCCAAALBI+D3AW+6tGllxoRB0qVtMzl//qJEWv91a9dcZkwcJLekTxc8I0FPELAvQE4EEEAAAQQQiIeA3we8zr7o5QtDXmonA3q0kQplSjhX84gAAggggAACIStAxxGwJxAwAa+97pALAQQQQAABBBBAAIHoAgS80T1YCkIBuoQAAggggAACoS1AwBva40/vEUAAAQRCR4CeIhCyAgS8STz0NRt1FWdy37VznT66r2ceAQQQQAABBBBAIHECBLyJ8wu+0vQIAQQQQAABBBAIMgEC3iAbULqDAAIIIOAdAWpBAIHgESDgDZ6xpCcIIIAAAggggAACHgQIeD2g2F9FTgQQQAABBBBAAAF/FyDg9fcRon0IIIBAIAjQRgQQQMCPBQh4/XBw9E4N7ikxTfRWPYlpA2URQAABBBBAAIHkFEjKgDc5+2lr38s/WStNWveW8jWayanT/0Yr897yVdKsXT9p0X6ArN+0Ndo2FhBAAAEEEEAAAQT8V4CA121scmbPKi/37yTZsmZ2Wyty4NBhmb94hcycOFjGDu0uIyfMkouXLkfLwwICCCBgX4CcCCCAAAJJKUDA66Zd/sH7pVDBfG5romY3bt4qD1csLbekTye5cmaTIoUKyPdbdwh/CCCAAAIIIIAAAokQSKKiBLw2oI+dOCm358ruypnn9pxy9PgJsxweHi7xSZFy/T/3ctfX2pvTnUdG2svrzOW+P+bjN27J6RURERGvYyw528q+E35cMc4Jtwu04y4i4qpPntP6vqAp0DyCtb36nNbkrf7p2JISLkDAa9POEXadyuFwuEpFRIRLfJJYQaozuZdzrrP7GGkCZ6sZbvXdrKz7/piP37gln1eEXL16NV7HWPK1NdxX7QyJeq9ejbDGOiIk+hrqx2hkpG/G2XpHMP9C3dd/+q/jrCncK89rM7hMEixwPYpLcBXBXzB71ixy+vQZV0dPnjotObJlNctp0qSVNPFIDkeYOK4l93LOdbYfxSFhVuDtuFaXnUf3/TEfv3FLPq80kipVKkkTj2OMvIEyttHbmSpVakmdOo2kYawlTZAbpEzpm+e0XPsLdr9A6V/q1PqcTi1pvHQ8Rw0v04QKhCW0YCiVq1SupGzYvFUuXb4sJ0+dkV9275WypYuFEgF9RQABBBBAAAEEAlaAgNdt6KbPfdfckuz4iVNSu1EH6TV4vNmaL+9t8lSd6vJClyHSrf9Y6d6hhaS2zrqZjUwQ8DMBmoMAAggggAAC0QUIeN082rdqJJtWLXCl8S/3cm1tWK+GLJgxWuZPHykPVyjlWs8MAggggAACCPilAI1CwCVAwOuiYAYBBBBAAAEEEEAgGAUIeJNxVGs26irOlBTNcO5LH5NifwGxDxqJAAIIIIAAAkEvQMAb9ENMBxFAAAEEELi5ADkQCGYBAt5gHl36hgACCCCAAAIIICAEvBwE8RAgKwIIIIAAAgggEHgCBLyBN2a0GAEEEEAguQXYPwIIBJQAAW9ADReNRQABBBBAAAEEEIivAAFvfMXs5ycnAggggAACCCCAgB8IEPD6wSDQBAQQQCC4BegdAgggkLwCBLzJ68/eEUAAAQQQQAABBHws4DcBr4/7SfUIIIAAAggggAACISpAwBuiA0+3EUDAbwVoGAIIIICAlwUIeL0MSnUIIIAAAggggAAC3hDwXh0EvN6zpCYEEEAAAQQQQAABPxQg4PXDQaFJCCBgX4CcCCCAAAII3EyAgPdmQmxHAAEEEEAAAQT8X4AWxiFAwBsHDpsQQAABBBBAAAEEAl+AgDfwx5AeIGBfgJwIIIAAAgiEoAABbwgOOl1GAAEEEEAg1AXof2gJEPCG1njTWwQQQAABBBBAIOQECHhDbsjpsH0BciKAAAIIIIBAMAgQ8AbDKNIHBBBAAAEEfClA3QgEuAABb4APIM1HAAEEEEAAAQQQiFuAgDduH7baFyAnAggggAACCCDglwIEvH45LDQKAQQQQCBwBWg5Agj4mwABr7+NCO1BAAEEEEAAAQQQ8KoAAa9XOe1XRk4EEEAAAQQQQACBpBEg4E0aZ7/bS81GXcWZ/K5xNAgBBEJJgL4igAACPhcg4PU5MTtAAAEEEEAAAQQQSE6BwAh4k1OIfSOAAAIIIIAAAggEtAABb0APH41HAIFQE6C/CCCAAALxFyDgjb8ZJRBAAAEEEEAAAQSSVyBeeyfgjRcXmRFAAAEEEEAAAQQCTYCAN9BGjPYigIB9AXIigAACCCBgCRDwWgj8QwABBBBAAAEEglkg1PtGwBvqRwD9RwABBBBAAAEEglyAgDfIB5juIWBfgJwIIIAAAggEpwABb3COK71CAAEEEEAAgYQKUC7oBAh4g25IE9ehmo26ijMlriZKI4AAAggggAAC/iFAwOsf40ArAk+AFiOAAAIIIIBAgAgQ8AbIQNFMBBBAAAEE/FOAViHg/wIEvP4/RrQQAQQQQAABBBBAIBECBLyJwKOofQFyIoAAAggggAACySVAwJtc8uwXAQQQQCAUBegzAggkgwABbyLRnXc0sPuYyN35pLh7232yAypFAAEEEEAAAQSSUYCA1yb+e8tXSbN2/aRF+wGyftNWm6USmI1iCCCAAAIIIIAAAl4TIOC1QXng0GGZv3iFzJw4WMYO7S4jJ8ySi5cu2yhJFgQQQACBxAhQFgEEEPCGAAGvDcWNm7fKwxVLyy3p00munNmkSKEC8v3WHcIfAggggAACCCCAgP8LBEHA63vkYydOyu25srt2lOf2nHL0+AmzfPLkCUmOdOrUKTlx8qRP9/32228LKXkNFixYIIsWLWIcQuBY1HFeuHAhYx0CY7148WKfjLN5U7ImvG4n7+u203/hwndEk3M5sY/W0PIvEQIEvDbxHGHXqRwOh6tUh6bVJTlSx2aPSEcf7zsiIlxIyWtw9epVcTgcjEMIHIvWMEtk5NXEjXUIOAXDa1KY9X7ii34sb/qsaPJF3dQZ//cCkUgrVoj02nPaqox/iRAIS0TZkCmaPWsWOX36jKu/J0+dlhzZsprlpk2bCgkDjgGOAY4BjgGOAY4BXx4DJuhgYlsgZkYC3pgiHpYrlSspGzZvlUuXL8vJU2fkl917pWzpYh5ysgoBBBBAAAEEEEDA3wQIeG2MSL68t8lTdarLC12GSLf+Y6V7hxaSOlUqGyW9nyU8IkJGTnxDnus4UNp2HyZ//n3E+zuhxiQROH7ilHR6aZS06jxY+g9/TS5cvOhxv+95uCXekaPHZfSrs6XWM+2lceveMm/RRx7LsjIugaTb5mkMY+79ZsfDd1u3S/kazWTzlp9iFmXZTwRuNobOZsZ2POjr+4Sp883zukLN5rJ46WfOIjz6mcBPO3bLc50GSfP2/WX22x94bJ2Op6f368jISBk/ZZ40bdvXVV7XeayElV4TIOC1SdmwXg1ZMGO0zJ8+Uh6uUMpmKe9nW/HZOuss82l5a+oIafDEozJm0lzv74Qak0TgtZkLpVzp+2Xu5JclQ4b/ycIln9yw39huiafXADZ48lH5dMl0GTmwiyz5cLXs2XfohvKsSH6B2MYwZsviOh4uX7ki0+a+J/cWvtNc0x2zLMv+IRDXGDpbGNfxoLe/3PnrHzJ13EBZv/JNqVTuAWcxHv1IQIPTwaOnykudn5M3pwyXtRu+k20/77qhhbG9X3/97Y/yx96DMvv1ofLaqD7y6ZqvZfcf+28on6QrQmBnBLwBNshfb94mtR99yLS6WuWysnP3Hjl3/oJZZhJYAvqiV+exqLGsY43pxm+33dCB2G6JlyNbFilUMJ/o353588qdBfLK30eO6SLJzwRiG8OYzYzreJi36ENp/FQNufWW9KJvtjHLsuwfAnGNobOFcR0Pn67ZIN3bN5eC+XNLypQpRe8I5CzHo/8IaHCaPn068wE0ZYoU8ljVCuayx5gtjO39OuLqVZNVT1yEhTkkRQqH6Gu68OdTAQJen/J6v/Jj1tfguW/LaSrWJ1quHNnk6LGTZplJ4AjohxT9VX7mTBlMo/PmzinHjt842pto/AAAEABJREFUjsfiuCWeKWhN9Mzurt/2SrGihawln/2j4gQK2BnDuI6HQ38dkR279kjN6pUS2AKKJYVAXGPovv/Yjge9I4u+li/7+AupXq+1dOozWg7+ySVr7nb+Mv+P9Z6b2+1Wpfr6/c/RqFuVurfxWCzv1xUevF+uRl6VKnVbSa2GHaRenUckS+aM7kWZ94EAAa8PUH1dpcPhcO0izG3etZKZgBDQT/fOhjocsT8VY7slnpY9/e9/0m/4JBnY60XJlOF/uorkhwJxjaGzubEdD3qtX+/OLZ3ZePRjgdjGMGaTYzse9NIV/cbmo3cmS81qFWT0pNkxi7LsFwIijrDr78Micbx+Oxzi/Au7Nr//0F+SNUtGWbl4irw3d7x8tmaj7NnPJWlOJ189xj5Kvtoj9SZKIHvWzKJ3inBWcvL0v5IjexbnIo8BIqD/176IiKuib3Da5BOnTkv2bDeOY1y3xNOvxV4eO936CrSFVC5fUqsh+aFAXGPobG5sx0N4RIToj9Weeb6X+cGazncfME6++uYHZ1Ee/UQgtjGM2bzYjgcNlrNlySSVK5Qy/1fPqg+VMdd5xizPcvIL5LTec0+d/s/VkJPW63fOHFG3KnWttGZie7/WALdo4UKSNXMmyZs7l9xzdwHZ+eseqwT/fClAwOtLXR/UXaFsCVnz1bem5m9/2C4F8+U2L45mBRO/EbDTkAplrLFct8lkXf3lN1LJGltdOHL0uOw/+LfOSmy3xLtyJVyGjJ4mtR+tLOWtr8dMZiZ+KRDbGGpj9YcuOpY67+l40MuWNq1aIM5UpmQxeXVk72T94ay2leRZwNMYak693GHHrt91NtbntG6sWK6kfL9th85aH3R2SKE7o67TNyuY+I1A4bvyi96RQy830hMPX1jvyfo81wbqj9H0BIbOx/Z+nTVLZvlx+y4JDw83v8HZsesPuZuxVjKfJgJen/J6v/InalUVvchdb0s2Z8FS6dP1Be/vhBqTRKBbu6ayYtV6c1uyg4cOS9Nn6pj9rl3/nSxa+qmZj+2WeD/8tFO+WL9ZBo2aYs786e2qPvl8vSnDxL8EYhtDbeVLQ1+VM//+p7MS2/FgNjIJCIHYxvDPv47I8PEzTR/iOh7aP99Q1n+zVfR2V8s/Xiv9u7c2ZQJ8EnTNdzgcMqxvB/P6q+/FpR64V0oWv8f0c+a8JbJl204zH9v79ZO1q8rpf89KvWbdpH3PEfJ03epSpFABU4aJ7wTCfFc1NftCQM/4DOjRxtyWbNarQ+SOPLl8sRvqTAKBbFkzy/TxA81tyUYN6irp0qY1e322QW3p1+36B5mGHm6Jp7czc571cz7q2V5TARO/E/A0htrIz5fOEj0OdF4fPR0Pus2ZXhvdx9zKzrnMo38JxDaGha1g5t05412Nje14yJjhVpk06iV5a8pw0bHmLg0uMr+buf++wqK3B317+ihp07y+q33jhvWUGtUqmuXY3q/18pfZrw011/DOnz5S6td91ORn4lsBAl7f+lK7HQHyIIAAAggggAACPhQg4PUhLlUjgAACCCAQHwHyIoCAbwQIeH3jSq0IIIAAAggggAACfiJAwOsnA2G/GeREAAEEEEAAAQQQiI8AAW98tMiLAAIIIOA/ArQEAQQQsClAwGsTimwIIIAAAggggAACgSkQ7AFvYI4KrUYAAQQQQAABBBDwmgABr9coqQgBBBDwZwHahgACCISuAAFv6I49PUcAAQQQQAABBEJCIFrAGxI9ppMIIIAAAggggAACISVAwBtSw01nEUDApgDZEEAAAQSCSICAN4gGk64ggAACCCCAAALeFQiO2gh4g2Mc6QUCCCCAAAIIIIBALAIEvLHAsBoBBOwLkBMBBBBAAAF/FiDg9efRoW0IIIAAAgggEEgCtNVPBQh4/XRgaBYCCCCAAAIIIICAdwQIeL3jSC0I2BcgJwIIIIAAAggkqQABb5JyszMEEEAAAQQQcArwiEBSCRDwJpU0+0EAAQQQQAABBBBIFgEC3mRhZ6f2BciJAAIIIIAAAggkToCAN3F+lEYAAQQQQCBpBNgLAggkWICAN8F0FEQAAQQQQAABBBAIBAEC3kAYJfttJCcCCCCAAAIIIIBADAEC3hggLCKAgH8I/LH3oJSv0UwGj54arUG6rOt1e7QNPlro+/IkeXfZKlftO3/dI136jpGWHQZIux7DRbdv/+V313b3mbPnzkuzF/vJlSvh7qv9Yv7wP8fkw0/WJqgt32/bIZ1eGmXK7j90WNp2H2bm/WtCaxBAAIHrAgS81y2YQwABPxJwOBySLWtm+WnHbjl/4aJpmT7qcrYsmcThcJh1STnZd+Av6dRnlDz9+CMyb9pImTFxkPTt2kpOn/nPYzMWLFkpNatXklSpUnrcnpwrj/xzXFau3pDoJuTPe5tkzZJRvv7ux0TXRQUIIICArwRCOuD1FSr1IoCAdwRSpkwhVSqVls+//MZUuGbdJqlWuYxY0a5ERkaK/h3664j0HfaqOZPavH1/+XTNRl1t0sCRU6Ruk07SuHVvGTnxDblwMSpw1jOUz3UaJP2HvyYv9nhZug8YJ0ePnzRl4pq8+c5yqWUFsNomZ75MGTPIQ+VLOhejPX7y+UZ5pEpZ1zo9Mz151kJzRrSJ1abPrf44N363dbtpi5451jb9snuP2eRsq/axU5/RsuXHnebM9/S575p6nmrRTbb+vEvGT5kn2ict6+zL2g3fGRtTkTXZvOUn6drvFWtOZOqcxbJ3/yFp13O4jJo426yLrQ26ccrsRfLM8z2lQ++Rsu7rLbrKlapXLicrV61zLTODAAII+JsAAa+/jQjtQQCBaAL1aleXT64FsR9/vkHq1qgabfuQMdOkcsXSsmDmaJk8pq+8tWi57P5jv8nTonFdWbFoirVtjKRMkUIWLPnYrNfJgUN/S9vnGsrMiYOl1iMVZe7C5bo6zrT/4N/yQPEiceZxbtRAPMw6C50rRzbnKvOYL+/tMuvVIfL6mH4ycep8OXHqtEkjJrwhvTs9Z84c9+jQQvq9/JqER0SYMr/vOSDtnm8kU17pJ6VLFDXrCt2Zz9TTpkV96TlovDxapZy8NWW4VHiwhK2+dHyhsRTMn1dmTLAC/x6t42zDF+s3y/pvtsibVv2TRr0kMS8nub/o3bLt519Nu5gggAAC/ihAwOuPo0KbEEDAJVAgX25zScO3P2yXCxcuWUFabte2f/87K7t+2ysffbrOnKnsawWJ585dlJ93/mby6PaJ0+ZJ175jRK+z3f37PrNeJ3cVuEPyW1/H6/xtObObs50676301+F/zCUZMeurVjnqjG/2bFmkyN0FZfvOP+SnHb/JxYuXZPzUeaYfr05/W878e1YO/nnYFL/bCm7z33G7mXdOKlcoZWZL3FdY0qROJfdbj7ri/vvuTlBf4mrDtp93S92aVeXWW9JL6lSppH7dR3RXrqR9+e/sedFrll0rmUEAAQT8SMB+wOtHjaYpCCAQ/ALmkoXIqH4+/tjDMmzsdKnzWOWoFdemKayztilTppRp4waYM5V6tnLl4inyzJOPyYFDh2XE+FlSo1pFmTCit7Rq9pQVVF6+VlIkRYrrL39hYWESHh51NtWVwcOMBp3bbJ7JTJ06tVWnvR+rORwOKXxXflcftB/rVsyVgvnymFakSZPaPLpPNPDUZW17KisI1XlNuuzsSwrLJ+LqVV1tUnj49Xmzwm3icMTehkiJNGfIndnV3DmvjzpWV639pPXQTt1OQgABBJJb4PorfnK3hP0jgAACsQjUqF5B6tWuKvronuWW9OmkSKEC8vqshaIBl27bs++QHD9xSvSSgjy5c0nRIneJBmJfrP9WNycqPdeknnz6xUaZ/+4Kc9ZZKzt95l/ZsGmrzkZLhQreIX8dPhptnS4sXvqZPoiebd7+y29SrOhdomdp9TKML7663sZN3/9k8iVmopdPqIOzjg2br7fz1lvTy7//Xf+xXVxtKFm8iPlRmga2WtfX30b/gZpe6qFny2MGwpqXhAACCPiDAAGvP4wCbUAAgTgFMmX4n7Rt+YzoY8yMw/q2twLcM9K8XX/zo6pBo6eIntUsU+o+SREWJi3aD5AeA8dK5owZYhaN93LB/Lllyiv95butO6Tpi32lfa8R8srrcyVL5hvr/t+tt0ixe++S3/YciLaf8xcuyLNt+8jQV6ZJn66tJGvmTJI5UwYZM6SbLF25RvSHZzWfaSfLPv4iWrmELGgQqmeJ1aDXoPHmcgRnPQXz55US9xUxNqMmzo6zDfqjtMJ35RP9wZtaHovxA79tP++SR6pUcFbNIwIIhI5AwPSUgDdghoqGIhBaAndZZ0iXvT3JY6dXvDNZdLtuvD1XDhkxoJMsnDVGlrw5Qd6Z9YrkzJ7VBHevje4j86ePlIkjXpJenVrKlLH9tYg8+MB95vIBs2BNiha5U+ZOftmau/HfmMHdpNFTNVwbNK/+eGzZ/EkyffxAGT2omzmL7MrgNtOkfm1Z8dlXbmtEurRtatq4aPY4ebRKede2ksXvkanjBoj+8OyzJTNk7NAeZlvMturKTasW6INJ+qM49TAL1qR40buj9WXUoK7GYPzwXtKzYwtREyub+TDQr3trY9O/R2tdJbG1QTd2bvOsvD6mr8mvj05L3bb6y01Sr05VnSUhgAACfilAwOuXw0KjEAgigRDuigard+TJZc44ByvDkaPHpdHTNc2Z6mDtI/1CAIHAFyDgDfwxpAcIIODHAvoDuhRhUS+17mdm/bjJ8WqanmGuWunBeJUhMwKhKkC/k08g6lU4+fbPnhFAAAEEEEAAAQQQ8KkAAa9PeakcgfgKkB8BBBBAAAEEvC1AwOttUepDAAEEEEAAgcQLUAMCXhQg4PUiJlUhgAACCCCAAAII+J8AAa//jQktsi9ATgQQQAABBBBA4KYCBLw3JSIDAggggAAC/i5A+xBAIC4BAt64dNiGAAIIIIAAAgggEPACBLwBP4T2O0BOBBBAAAEEEEAgFAUIeENx1OkzAgggENoC9B4BBEJMgIA3xAac7iKAAAIIIIAAAqEmQMAb24izHgEEEEAAAQQQQCAoBAh4g2IY6QQCCCDgOwFqRgABBAJdgIA30EeQ9iOAAAIIIIAAAgjEKeClgDfOfbARAQQQQAABBBBAAIFkEyDgTTZ6dowAAkEpQKcQQAABBPxOgIDX74aEBiGAAAIIIIAAAoEv4E89IOD1p9GgLQgggAACCCCAAAJeFyDg9TopFSKAgH0BciKAAAIIIOB7AQJe3xuzBwQQQAABBBBAIG4BtvpUgIDXp7xUjgACCCCAAAIIIJDcAgS8yT0C7B8B+wLkRAABBBBAAIEECBDwJgCNIggggAACCCCQnALsG4H4CRDwxs+L3AgggAACCCCAAAIBJkDAG2ADRnPtC5ATAQQQQAABBBBQAQJeVSAhgAACCCAQvAL0DIGQFyDgDflDAAAEEEAAAQQQQCC4BQh4gwEy/AQAAACkSURBVHt87feOnAgggAACCCCAQJAKEPAG6cDSLQQQQACBhAlQCgEEgk+AgDf4xpQeIYAAAggggAACCLgJEPC6YdifJScCCCCAAAIIIIBAoAgQ8AbKSNFOBBBAwB8FaBMCCCAQAAIEvAEwSDQRAQQQQAABBBBAIOECSRHwJrx1lEQAAQQQQAABBBBAIJECBLyJBKQ4AgggYF+AnAgggAACySHwfwAAAP//N0hTeAAAAAZJREFUAwC3x+KBVNC/UAAAAABJRU5ErkJggg=="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAFeCAYAAABn3sxXAAAQAElEQVR4AezdB4ATRRfA8ZejW5GuqIBKEwUp0hEQpX4gKlWKDZAmXeldiggI0ptSFFDs2FBURKoioICAhWpBpKmIlOP45s2RkDtyd3uN2yR/vEm2zM7O/GayedndxIjTp0+dI2HAGGAMMAYYA4wBxgBjgDEQqmMgQviHAAIIICAiICCAAAIIhKoAAW+o9iztQgABBBBAAAEEkiIQgtsQ8IZgp9IkBBBAAAEEEEAAgQsCBLwXLJhCAAHnAuREAAEEEEAgaAQIeIOmq6goAggggAACCLhPgBoFgwABbzD0EnVEAAEEEEAAAQQQSLIAAW+S6dgQAecC5EQAAQQQQACBtBMg4E07e/aMAAIIIIBAuAnQXgTSRICAN03Y2SkCCCCAAAIIIIDApRIg4L1U0uzHuQA5EUAAAQQQQACBFBQg4E1BTIpCAAEEEEAgJQUoCwEEUkaAgDdlHCkFAQQQQAABBBBAwKUCBLwu7Rjn1SInAggggAACCCCAQHwCBLzx6bAOAQQQQCB4BKgpAgggEIcAAW8cMCxGAAEEEEAAAQQQCA2BcAt4Q6PXaAUCCCCAAAIIIICAYwECXsdUZEQAAQRCSYC2IIAAAuEjQMAbPn1NSxFAAAEEEEAAgbAUiDfgDUsRGo0AAggggAACCCAQUgIEvCHVnTQGAQRSSYBiEUAAAQSCWICAN4g7j6ojgAACCCCAAAKXViA490bAG5z9Rq0RQAABBBBAAAEEHAoQ8DqEIhsCCDgXICcCCCCAAAJuEiDgdVNvUBcEEEAAAQQQCCUB2uISAQJel3QE1UAAAQQQQAABBBBIHQEC3tRxpVQEnAuQEwEEEEAAAQRSVYCAN1V5KRwBBBBAAAEEnAqQD4HUEiDgTS1ZykUAAQQQQAABBBBwhQABryu6gUo4FyAnAggggAACCCCQOAEC3sR5kRsBBBBAAAF3CFALBBBwLEDA65iKjAgggAACCCCAAALBKEDAG4y95rzO5EQAAQQQQAABBMJegIA37IcAAAgggEA4CNBGBBAIZwEC3nDufdqOAAIIIIAAAgiEgQABr18nM4kAAggggAACCCAQegIEvKHXp7QIAQQQSK4A2yOAAAIhJUDAG1LdSWMQQAABBBBAAAEEYgskPeCNXRLzCCCAAAIIIIAAAgi4UICANw065bttOyTr9SXk0OGj8e49R/7SsnzF6njz3Fy8qrzz/vJ48yS0MiXKSGgfwbA+JRx+3r3X9u2vvx1wXZOdjKekVHrXnn3Sok03uen2qnJj0UpJKSLot/FvwNqvNtoxcPLkKf/FSZ4eN2mO1Hng0SRv78YNG7XsKMOffcGNVXNcpw7dBkq3PsMd50/rjCUq1pXX3nw/ravB/h0ITJ+zUKrWbubLGXvet4KJRAkQ8CaKK2bmdl36iR64/Zd63+z6DH7Wf7EsWPyW5CxQRk6dOi2XX5ZFqlUpLxkypLd5Js+YL9XrPWSnE/tQvmxJyZ4ta2I3i5E/dhkatLz/0ecx8oTDTGyHYG1zcsZTUto8fc4rcuLESdmw8h3Ztz3+D2hOy9cAuv+wsU6zk8+BQKDXdWqPlU3fbrPB/7G//nZQQ7IggEAICLi2CQS8yeiaKhXvlHVfb5LIyEhfKWvWb5LCBQvImnUbfct0QucrlS8tmTJllJsL5JO3F82Qq6+6UlclK70ye4JUrlAmzctIVgVcsnFKWLqkKZe0Gr/+/ofcfmshyXZN8j54XdJKszMEEEAAgbASIOBNRndXKFtKjv97Qr765ltfKWvXfyMd2rSU7T/8LEeP/eVbvnLNV1KxXGk7739Lw8Il78qA4ePEeyZEb3WY+/LrNp8+/HHwkDRu1dFeKq58b2N59Y33dLEv+V+G955d/mzlGtEzxjcUqSj1m7SRbzZt8eUPNOFfRukq9eXvf47bS9Ral1vvrGk32br9B3n4iV6i87q8WNlasuLLdXZdoIfTp8/IM2MmyZ1VG4jW43+N28gaY+PNW8dcop0w9SXvrHTsPsieCTpw8E+7TC8H6xlxbZMuaGQugQ58Zpx07/uMFC1zr9xevo4MG/1CjA8bms+btF90+6/9+kbrXPGeB71Z5ItV6yVvoQq+MvwdNFOO/KXtmfn4/L3W1xeuIPc0aCVbv/9RN42R1L9h8yck362VpVTl/9n+/u+/kzbP8hWr7XLvhya9PUB9e/UfZdfrw+jx0y66kqDLA6Xkjicds7pvraf22wMPdRDt+0D70mWFS9YQvRrwwvR5tv+8l3hnzV1k65y/WBUpc1cDGfHcZJ+z6IYmffrFGtHxqWcey1VvKP2GPmfOFP8nT/YaYsucMnOBLVM9dv6422whdizHZakZdJzomeFOPQaJ9rfm1eWxk/c2AT3DWbbafXLNDXfYLB8tXyl65UbHubZNp/1vPdLxqPXx9rsaaRu0j20BAR70qk7ThztL7fsfET3TqWOzW+/homNRy9IxqH4BNo2xSD309ammj3XsLX/8eSjG+o8/+9LuQ8eZmo8eP13Onj1r8+h2sV/X8Y2VhMaB10G9qtVtLnluKStfrvna7sv7sHffr/Y4pPNaZ22reuq8prNno+J9PWvZmj8l+0L362Rsaj7/ZPusz3ApVPJue+zRseq/Xqedms2Z/6pUq9Nc9JhR98HH7LFft/em+PpR8+gYT+hYuGfvL6JjLvq1db8sfmOpbhojJVRf72tk5kuL7HH8pturSpvOfcR7jPYWFtfrWNcntA/NEzuptb531GzY2r536Ph6892PfNkSe8xMqDwtWE0DHTd2/LBLWrbtLkVK3SMF76guHboNtK9h3SZQ8r4u4js+6PFS+8V/ez2+6evDjbfC+dcz2Kcjgr0BaVn/W27KJ9ddm9sEcptsNTRoWW2CuupVKkiFsiVNQPWVXf7Trr2iA7lS+VJ23v/hocYN5JmBPaVkiWJy7JdvbXqkZSNflolTX5QStxeVqePNwbbgTdK+2wDRg5kvQ4CJ+QvfknEj+slXK96WG/JeZ7bpL+fOnQuQ8+JF33y5VK668grRs51an++//thm6j3wWbk+bx5Z9tZc2b11pa1zliyZ7bpAD4NHPi+z5r4qzw7vI9+u/UCKFLpZ7mv2hPz4816bvWK5krLuqwtnwVet2yA5c2STNeu+sevXb9gsmTJmkDtLFbfz+vDKq+/a+dWfLJHxo/rLiwuWyBvvXDgQah5vuuLyy6RMydtl9frofezeu1/+/vsf+eGnPb4D9tqvNtl+Sp8+vXezi55nvbRY2psPMNqGh5rcZywv+GuZTR/uIqVK3CbfrftQend/QgaNGB+jDO33Bk3bSZ5cOUVtJ48bKovMh5xe/UfafOXvLCn/nvjP96a3xtTXOqzfYNfrg63n+Q9LOh9fSu54atW2p/xz/LjMmjRKNq/5QP5Xp7o88FB7O34D7Xfnpk+l9j13SdcOJpgz43fC6IE229//nJCeXdpYlzHP9JHV5orHqHFT7Tp90A8b+iZz791VZMPKd2XhixMle7ZscsZcLZk0dojUq11dOrVrZV8POg71qklCllquJh0XN5vX5pfLXpX5M8fpooBp85bv5ZvNW+W1eVNk7/erbJ5jf/0lDevVlFUfvyavzp9kxmBGad2u50WvH6evsX+O/yuNzAfWM2fOylsLp0vWq68SfU3v2feLzJ78rPz6w1pZ9NJEyXttLrv/uB703vBN320TvTL03utz5MAff0q7J/v5sqtnl15D5ZGWD4qOs2nPD5evNnwrQ0dNtHl0WezXdXxjpZXDcTBu0mwZ+0xf+WXHGnsMszs7/5Dvxrzy+fsL7dyebV/avpz5QvS414WLzYf3yDORMsYcIxo3rCMa9L/h93pO6b6Q8/8SGpvns8V46j90rCz9YLnMnf6cfLr0Zfnj4GH5zHxg88/k1GzhkqX2+LVp9fv2uHi/eX3pByEtK6F+1Dya4jsW6oecpo88KUf/+ltWfvSqqfNY0XtAjx2LeVuJk/rqa+Q3cwVnyfyp8vbiGbJrz34ZPW66VsEmrW8jczIi0OtYMzjZh+bzT6dPn5ZMmTLL86MG2veOTm1bmQ/DY33fZ0nsMTOh8rz7jn3cOPjnYbmvaVspcdutsnTJHPn4nfly9dVXSBPz4TUqKsq7WcBnp8cH3Zh06QQIeJNpXb1K+RhBml7W1QO9Brxrzgctq00wp8FhuTLRZ5ESs8tmjRrIgKefNIHH3TLzhRE2GP1m85Z4i+jXq5OUuuM2uTZPLnmyfWsbZMY+GxRvAQFW/n7gD7nj9lvlhuuvk2uyXi33168pcbVHz17Onvea9OrSTu6+q6K91D166FPmw0EumTN/sS29QrnS8sXqr+xZPw0c/zx0WB5p8aCsWb/Jrl9rgmE9sPkHo/dUryT6Jq3G91avLDWqVZKvN8ZtoUH1WvMBRAtcbQLpiuVKiabVa6ODyTVmndZD18eVHmvdWGpUrWjb3LFtS8mVI7ts/Harzf6y3pdtgnRtm7dODzW+z67zPsxf9KZo8P386AGSI/s1Zv+lZWDvJ+WV196RPw8dses0qF9l6qfbrDUBb5uHm9k+0zMpJ0+eMiYbzXYldXWyU3zjaaXpD73SMMUE5aXNhwW9N/yxVk3MWComb7y7LFH77vnk4+bDRCk7XnUM6IeBV15711fG81NelOZmbHdp/7Dkypnd3uaj28R3m09Clt7CSxYvJj06P27HnQZ53uWBnic8O1Dy57ve1lPXN3uwvtStVc1uq+NdP1jphy8906PrvSm+15jH47HZ9OxWfXNlI0f2bPLqvBdEjwG64vcDf0qB/DfIrUVukcsvu0zuqlRWHryvjq6KM+nZ2XEj+9vX321FC8mIQT1Fg43tO3+226hn20ebSzNTfx1nd5YuIf16dbAfCm2GRDwkZhz06dFeypgPpfo61XGeiN1I8WKFRT/c1K9TQwb16SL3VKsoX33zna8IbUty+8JXmN+EjjO9OqdjI9DY9MtqJ/UMoY69vj07mNdhaTteddz8e+KEXa8PiTHTckqZ47N+sB099Gn7XQ7vGUyn/RjfsfBzc+Vt54+7ZOKzg+3YLlr4Zhk+oIf8ZT7wa101Oa3vNeZYP6RfN1tO8WJFpEWTBqaPNmsRNml943odO92HLcjvQY+lT3VtK8WKFrSvw8b31zXvDY1k8evRZ6l1nCXmmJlQeXL+X+zjhgbAxW8rLFqXgjfnkwL5bpBRQ56WbeYqnh4nz28W8Cm+40PADVh4SQQiLsleQngnFcuXlrVfb7SB2xoTrGkArM3VYE3v29XpNSaIqWzy6ZuCzicm3VqkoC+7bn+jCTj9L7H6VvpNXH9dbt9cThOg6YwGV/qc1NSoYR3Ry7B6qXjitLmy0ZwZi6usPeZS5pkzZ0QPyt48Wvfqd1WQXbv32UXqExl51p5h02C0qnnTr1zhTlm1NvqyqJrFDkbzmrPpduPzDzlzXGOCxsPn5y5+0u1XmsuskeasoQaSOl/RBNqrzdlGN/kseAAAEABJREFUDSTXmjO8GhRfvOWFJXoG/8KcSO5cOcw+j9hFu/f+Knofd4YMGey8Ptx9V3l98qWfTXurVLrTF+zoCg3W9XnXnmgLrcNaE3zrshWr1psPCeXNG2spWbVmg6zfsFkymvL1AK/rk5viG08/mysR+iaeI39p360Eepnto09WSkJXFWLXS+9tf+jxrlKk9D22rPuatbNnJU+Ys9maV9+Qy5YurpOOkxNLLeyO4kX1KcFU2FwxiR1g7//lN9FxrrcEaNtzFihjbwvY/+tvMcqL7zXmvZpyX7O2UqhgAXlx6rMmqLkwRu5vUEvmL3zTXnJ+buIs+fDjLy46gxxjZ2bmlgL5xL+ut5tg0ePxyG5zxs2sFvXUXz3QOnuT3mKjwdrvBw5qFscpMeOglLky5bjgWBmLFr4lxhI9UXDocPRrS1ekRF9oObFTQmMzdv59+3+z/VO1cgXfqiuvuDzGdycSY6aBo7egjOYqVjHzAWZXIvsxvmPhHnM1S09MaKDr3Y8ep7wfuHSZ0/rekPdaze5LObJnFz3z6V2g4y6u17GTfdRs2NoeH3TMlqt+v7dYWfT6u1Kv0eP2Vj5dp7d17f/ld9/6xB4zEypPC4593NCrKp98vtpXP62H3vqkx8jde3/RTeJM8R0f4tyIFakuQMCbTOIqJkjTM5p6FmiNCVrKly1pS6xQtpTs/Gm3HD32l6wyZxQrmXx2RSIf0qdPF2MLj8djDr4xFl00ExFxcbd634QvyuxwgX5ifXHaGLnxhryyxpyxrlG/pUyaPj/erTXI9c+QPt2FWwe8n9LXmA8D+sGgvPHSIFiDGr33T4PRSrFuAYmIiD5z5l+mSNy3amh5kSao3rh5m2ggqR86KpqzvGvN2WPtLyeBZGDLCzVIny5m/8Rus+ZMFytPulh9WrF8GfnSjJEff94rx80l8JImiNDxs9YE5GtNXSuYMRWoXC07sSm+8eTxeOzZK72FIHbSM51O96VvFI1bdZKmD9SXZW/Nk8N7N8oHb7xoNz9tPgjZCX0I1J26PJ6UkKVumiVzJn1KMGXJnDlGHn2NPNCivegHqVfmTJQ/fv5ajuzbZIPVM6cvfDFVNwo8LqLHoscT3bBGDeuJnuXS22h0G2/SKwafvf+K6Aewn3btkSe69hP9cOBd7/RZx4TWWfN7PB4ZN7KfxO43ndcrPZrHafJ4nI+D2IZO96H5Ao1F7+tZ25USfaH78U+Ox6b/Ruen06ePOD8V/eT/OvZ4nJtFbx3zUdurSzweZ/2Y0LEw9nFJy04XcaH+Ho+z+sY3zrVMm6KHu530f/B4Et7HrBdGyVcr3rFp8dwX7Ob6PZVnn59hzvo/aZa/bce0XuW0xw6bQyQxx0wn5WmxsY8bHo9H9MqLvoZip0bmBJBuE1eKz83juRhMb0OJqyyWp5zAhVdAypUZViXdeMN1opc7vjRn4/TMQWUTvChAZvOmq2flXlzwur3/UYMtXR4oZc6cUc5FRb9ZBlp/qZfpm1jUuYvvUapVo4r07v6EvDpvsvTq0kbeem9ZwKrlvzGvaGDy3dbvY6zXWwFuKnCjb5n3U/oXq9dLlQplRH/BopI5E/781BftWU29B9eXOQkT3qB6oTlboIFkaXOZXm/D+MmcydTfLtb9a9CQhKLtJgXy5ZXvtu6w096Hb7ds907a55tNe2Pn2bQ52uWm/NEWWicNzKfMmm8O5KVE66QOq80HC/1AoIGRLczhQ1LHU+FCN9mzNwldrkuoGhvNB4wc5jL+ffXuET1rp2Nhy7adMTYrbM6ufu13+TrGSjOTKWMm8QYBZtb+ObG0GZP4oGdC9UOH3qtduGABOx637fhR9GpFUorU+5ofadFI9EzvzvNfuvOWU+K2otKt46MyY+IImTvjOXuW1/+Sszef9/mn3XtjXJJWT62X3hqheW41Z0s/W7lWJ+NMgV7XgcZKSo0DrUimTNEfPhK651Hz+qeU7gtv2U7Gpjev91mP8R6Px7zWL4xhDVA2fRv9OtZ8iTHTLy3rNppOnz4j27b/IAXyXa+z4qQfbcZ4HvKbS+/7zJUK/6t6Ov70bL93s8TU17tNoOf4XsdO9qHHh0K35BdNBUy9dR/rNmyWSuZKnB4X8+TOqYtky7aYx1ld5/SY6aQ8u5NYD4UL3ix6DNYTWrFWJWtWP1DrLUp6ldFb0I4ffvJO8pyKAgS8KYCrZ29fWrDEXu7Of/7ApcWWv/MOmfniQnspUs/a6bJAqYAJfPQA5f3iQqA8l3KZfuFn2/aYvzagvySx8fxtDPpFHL131nuAil03vXTW7tFmMmrcNHvAOHL0mIyZMNMctHZK20ea+bKXN2d19T7ef/89IXcUv9Uu1zOb+qWuCkk7q2nL8H+oUPYO+yWxyhXLiMfjsUGMBpOvvPa2lC9b2j9roqdbNG0oO37cJXo2IjIyUjZs/E6mzXklRjmtmt0veklUf1Hi0OGjol8kGj7mBWnR5D5zJjGbzauBuQb32u5K5crYZfphSQNzPRNdsVz0VQO7wjzMfGmRfPzZl2Yq8F9Sx5Pa69nHTj0HyWcr14gekPU+4skz5ot+mAu8t4uX6iXa3w78IVu+jw4Q9FvJL0yfFyNj906PycIl74ou10ukeuZt3KQ5vqDupvzXi96f6h8oObGMsZNEzujtKnmvyyOfrlhtt/x+x0/29gYN2O2CJDz06dFe9GyQf9Crv7aw7NMv7a0SGjitXPWV6Bu73lMa1y48Ho/06DtC9ptARn81o++Q5+y9v7cWucVuol8QVOdR46aK3n6ibnqPr45Nm8E8BHpdBxorKTUOzC7lhuuvta+5rd//oLOOU2r0he7cydjUfP5JX5+tmz8gI8dOsWNSXxcDnxlvr9558yXGbMyEGfaWMA1I+wweYz5QRUqjhnVtUU760WaM56Fa5XJyy003StfeQ0WPvb8fOCi9B422/eDdLDH19W4T6Dm+13FS93H7rYXsrW5ad/1QN37ynIuOd9onTo+ZTsoL1LbHWjWyi9t26Sv6IUVfU9t3/mR/HSi+D6d2o3geipgPp/rl1ZfO/xqTXgX2TsezGatSQCAiBcoI+yIqmsBNvxRWMVYAVe7OkqLLNdiK701T7/stflsRyV+sir1fyP9nydIC98knHpYpM+fbuuhPAmkd/jh4SOo2eswu059i0hf/sP7ddFXANLRfd2n4v3tNwDBMSlSoay/tvrN4hv1ykneD8sYnypzZrlShtD0jrMv1loNTp07by706n9ykZ0dteXeW8hWlB2JdFjuQ9GVwOHGT+aCyZP5k+Wj5F1K2WkNp322A6Blw/82vz3utvLdktmzYtMX+JFn7bv2lRrWKMnZEP/9sonXROmkwrisymysElc1Zb70NRINfXeZNs+Yusl9Y8s7Hfk7OeJo3c5zUvLuK9BsyVm4uXk2aP9rV9N16ueKKy8Xpv1uL3CJTxg2Tjt0Git6XN27ybIk9VqqaN+XXjN2HH68QvV+2dJUGpk3rJMP5X8zQDxN79/0i2W4sKXrvnJ6hcmrptJ6x8+lr9JXZz9v/c2GFGg9Ks0e7yNPdnhD9H8XEzhvfvPfMtPdZf4WlQd0a9kyvBvZno6Kks/lQkT1fKdH0/rLPRH8Vw+O5+FKndz/6BbrbTCBQ/u4Hpd6Dj4kGyLMmj/KulgrmGLT0tdmiX/q6+38tpGjpe2XcpNly+vQpX55Ar+u4xkpKjAPdsd7rqkFRg6ZtbT/qz4zp8oRSSvVF7P04GZuxt9H5EYN7WeP7mz8h5Ws8YD+sNKh7j67yJadmPTq1kRZtustt5WrJjh9+9v16hxbkpB81X3xJrxAtnjtJzpw+I1XrNBe9/axRwzp2zPhv57S+/tvEnk7odZyUfehVkXq1qkmN/7WUstXuF/2w1L3T47F37fiY6bS82Du4JuvV9pasy7JkkVZte4i+P/cwHzp/3r3Pd5yKvY2TeX1NzJ4y2l4h1dd/PfO+2tbvRJCTMsiTNAEC3qS5xdiqyQP1RO/xmfr8sBjL9RYAXa4/8eW/Qr+0oMv129S6XO/30Z8b0mWaHjn/s2SH9nwj91SrpFl8aeWyV6X94w/55n/+7gvRS8e6oIJ509PtM5tgSec16T50me5T5wMl/zJ0fZ2aVWX/jjW2Td6fJdM35AM/fWWXaXnvvjpL9GyY5g+UMmbMIHrf1ddfvGvL0qCvorlM5Z9XP6X/uXuD/Qk073L9coWW3/PJmAe411+eKgN7d/Fms8+jh/aWeTPG2em4HtRPy+v8RGtfFg1KdZl6+RaaidgOTvz1/5j3+fsLZeOq90R/XuuBBrWtkb9NyRLFRL30/0Km+YYP6BnjS2xm17ZtWifNq/OadEz8+sNae4uDzmvSy5I/7donOuZ0PlBKznjSPtFvZa/77E37k1nattfmTxH9ZYBA+9Jl+uY6tH93nfQlfYP98uPXZP3nb8ln773iuxdOz2x4M+mX9z588yVRF227Gl12WRa7Wq8eqJUu16S3GOgK9dF8uo2uj20ZaJzodrGTji/dd+zleqVBA8e1n74h3639QPQ1rPvSn0nTvDpmtD7xvcYC5RkzvK/s+Ga53Fwgn+gvU/y4+XPRcjTpa0THvZYfKHnr2r3TY7ZP9CfU9OexcufMESO7lvHWwumya8sXoj8Xp07+r5lAr+u4xkpC4yBQG2NUxm+mT48OvrZ6f5YsUD/Ffj2nRF/4VcM36WRs+jKfn1CPCc8OlB0bl8vm1e/Ls8P62NtRvD/Dp9k0j5PXTrUq5WT7hk9E7xHXe9t1TOv23pRQPzqx09fPkgVTZcu6D0WP4S3N1ahv13wQ47iRUH29485bL33W9xo9Tuq0N8X3Ok5oH94y/J91TOq43bT6PdGkX/p8uls70WORfz7No68ff79Ax0wn5QUy1X3pLRc6ZtVOjwN6zJg3Y6x4j1Oaxz8Fel0Eeg/W96WP354v+v2GNcvfEP3wpG3xvm/oe/wXHy32FR173reCiUQJEPAmiiu0MtOa4BPQL0DWuqeKlLitaPBVnhojgAACCCCQRgIEvGkEz24RSIqA/k8eFr80KSmbsg0CCMQtwBoEEAhxAQLeEO9gmocAAgggkPYCgS53p32tqAEC4SNAwOu0r8mHAAIIIIAAAgggEJQCBLxB2W1UGgEEEEg7AfaMAAIIBJsAAW+w9Rj1RQABBBBAAAEEEEiUQCoFvImqA5kRQAABBBBAAAEEEEg1AQLeVKOlYAQQQEBEQEAAAQQQSHMBAt407wIqgAACCCCAAAIIhL5AWraQgDct9dk3AggggAACCCCAQKoLEPCmOjE7QAAB5wLkRAABBBBAIOUFCHhT3pQSEUAAAQQQQACB5AmwdYoKEPCmKCeFIYAAAggggAACCLhNgIDXbT1CfRBwLkBOBBBAAAEEEHAgQMDrAIksCCCAAAIIIOBmAeqGQPwCBLzx+7AWAQQQQAABBBBAIMgFCHiDvAOpvnMBciKAAAIIIJ/p5VQAABAASURBVIBAeAoQ8IZnv9NqBBBAAIHwFaDlCISdAAFv2HU5DUYAAQQQQAABBMJLgIA3vPrbeWvJiQACCCCAAAIIhIgAAW+IdCTNQAABBBBIHQFKRQCB4Bcg4A3+PqQFCCCAAAIIIIAAAvEIEPDGg+N8FTkRQAABBBBAAAEE3CpAwOvWnqFeCCCAQDAKUGcEEEDAhQIEvC7sFKqEAAIIIIAAAgggkHICaRHwplztKQkBBBBAAAEEEEAAgQQECHgTAGI1AgggkHoClIwAAgggcCkECHgvhTL7QAABBBBAAAEEEIhbIJXXEPCmMjDFI4AAAggggAACCKStAAFv2vqzdwQQcC5ATgQQQAABBJIkQMCbJDY2QgABBBBAAAEE0kqA/SZWgIA3sWLkRwABBBBAAAEEEAgqAQLeoOouKouAcwFyIoAAAggggEC0AAFvtAOPCCCAAAIIIBCaArQKASHgZRAggAACCCCAAAIIhLQAAW9Idy+NcyxARgQQQAABBBAIWQEC3pDtWhqGAAIIIIBA4gXYAoFQFCDgDcVepU0IIIAAAggggAACPgECXh8FE84FyIkAAggggAACCASPAAFv8PQVNUUAAQQQcJsA9UEAgaAQIOANim6ikggggAACCCCAAAJJFSDgTaqc8+3IiQACCCCAAAIIIJCGAgS8aYjPrhFAAIHwEqC1CCCAQNoIEPCmjTt7RQABBBBAAAEEELhEAq4LeC9Ru9kNAggggAACCCCAQJgIEPCGSUfTTAQQCDoBKowAAgggkEICBLwpBEkxCCCAAAIIIIAAAqkhkPwyCXiTb0gJCCCAAAIIIIAAAi4WIOB1cedQNQQQcC5ATgQQQAABBOISIOCNS8bh8gwZMoqbkrfabqqTG+vi8Xjk3Llzruo7dzpFSFRUFE4JvM4jItLJ2bNncUrAKV269BIZiVNCr/X06TMYp8hEj6d/69YTTQmVH0rrz5w5k2inYG2/9/3dwTNZAgiEZcA7dvI8qdeskzRv+3QMkj5Dn5cKtVr60rYdP/vWv/b2MmnZvq+07tBfVq7d6FvOBAIIIIAAAggggIC7BcIy4C1erKAM79c5YM9Mfa6/rF32sk3Fitxs8+zd/7vMX7xUZowfJGOGdJcR42bKyVOn7ToeEAhKASqNAAIIIIBAGAmEZcBbs3pFyX5NVsfdvGrdRqlaqYxcflkWyZM7hxQpWEC+3rhV+IcAAggggAACwS1A7cNDICwD3vi6tufAcVKncQfR2x7OnIm0Wf88fESuy5PTTuvD9dflloOHDuuknD0b6bJ01tRHk9vq5b76REXh5GT84uRs7OKEk5PXk9M8SRlP9k3JPHj38c/x4+a97EVp9ngvebRzf2nZvrd88MkX5j0iuq/WbdgsbboO9M17t3Pbc9l7mgWs4ytL3pN+z0zyrfvj4J/S/5mJtr1tugyUjr2Gy9KPPvetd9KuWfNft9ur2ZwFb8S57d79v0rbboOkdYc+9nn/r7/58p7474SMHD9DajdqJ2XubiI9Bz7nW6f9oMvuqtdaOj89QrZ8/4Ndp3XX5f6pnGn3vydO2PVad9O1/CVDgIDXD69Hp4fls3dmy7NDusuOH3fLgtfeE+8/T8QFKo/H411sv1gQGRnpmmc9SGpyU53cWJezZ6PMQeSsw35zT/9easuzZ88apyicEniNq5N+ue9S90+w7Q8n58eSpIwn7xuTd1wMHj1Vdu/9TWZNHCzTxw2U/j3ayvgp82XZZ6vta1r7Q7+8683v1mdtV6C66XudyDnbFg0MH+8yWK6+6gqZO2W4THmuv70FMa5tA5W3cu0Gefv95TJ9/ACZNm6AvPneJ7L26822/Nj5B46cLFUrlpFZE4aY59IyxFh784yZ+JLs/GmPPDesp6z+cL483rKhr4y+3dvYZa/PHS8lixeR0RPn2HVZr77SLtf8mjo+1kwqlSsp6dNF2PVatraFlHSBC1Fc0ssImS1z5chm21K8WCFp1eR/sv2H6C+t5cyeTY4d+8uu04cjR49JrhzZdVIyZcosmVyUvN8+dVOd3FiXjBmjf13DjXVzU50yZswkGTJkkEwuGuNurIs66Tfr3Vg3N9UJJ+fvF0kZT/ZNyTxonx84eETWrN8kQ/t0kiuvuFIymddw0UK3SJvWjeTl196XTGZe3y9OnY6UPsMmSrvuw6R9z2dk977fJZNZd+TYPzLk2enS8akRUqdJR5k1/03JZJYfPHTMnEWdJA93HCCPdB4oy7/4SjKZ5Zo6PT1Sxk9dIF37Piujnp9jn1d/9a1kOr9+7YYt0rn3KMlk5g/GU85nX34tLZ7oa/c9a8GbpkUimcw2sZMaeTwRksms03pkyZJZenV+VDJnziKZzLIrrrhC6teuLpnMtJO0YtUGqV/nbsl6dVa5JmtWqVezmqxY/Y1kirW92vy8e780blhbMpl1jRvWkW07d8k//56UyLPn5L2PvzDuneX2WwtLJrP+1sIFJZN51lTo5gKSyUznyplDsmTOLOkiouuvy/zT0mUr5IH690omk9ebLAQPSRYg4PWjO/7vCTunn6S+XLdRiha62c5XLl9KdP7U6dNy5Ohf8r0Z2OXK3G7X8YAAAggggIDbBHbv/UX09rsc2a+JUbVSJYqaoPYX37IdP+ySpvfXlnlTR4p+v2XIs1PsuoWvv28CtoIy54Xhsvyt2dLE5NEVestAtSplZfGcsTJt7ECZ8/IboldEdZ2m/06ekqlm+RATaP+vVlVZ+tEKXWzT0g8/F12mM3GVc+jwURkxfqaMHNjV7jsy8qxmTzDt2vOLlLy9iESYADJQ5lHPzxL/2wX8p1es/tpu8sefR+TGvHnstD7ceMO1cuCPP3UyRjrwxyHJlTObZDInTnSFPufJlV1+P3BQfvv9oPmAcblxeVP0toXmbZ+SVes3ajZfat2hr63L6+9+LBNG9vEt905s3rJDTpw4ac/wepfxnHyBsAx423YbKs3aPCV79v1mf4Js4esfWMkHH+5h5/VZL4u0blbfLs9nBv399WqIXi7p1m+MdO/YWjKas152JQ+xBZhHAAEEEAgSgQL5rpfyZUqI/mvcsJbs2/+76MmfEsUKi55lnPbiYnn/45WSPVtW+fuf4+aEz8/msv+n0qbrIOk1aKz8++9/8u3Wnbq5TfdWq+ALOu+tXlE2fbfdbqfbfvPt91K7RmU7//3OwOVsNmWVKl5UCt2c35bXqmn0+7CdScZD3+5tZcNnrwVM1Srd6SvZP2CO8Lt90Zfh/ITH4zk/Ff3k8UTPR507J/8c/9d+WPhwyQzp3eVxGThikhw2V4ajc4rMnzZKViydKy2b1DdnwUfZ3zr3rtPnt95fLvfVvVs8nugydRkp+QJhGfDOmjDY/uyY9+fHHmpU10oue326Xf7OKy/Ik20fkvTp0tnl+tDEHAhenj7KDNQR9n4dXUZCwM0CtZt2leSmei16uLmJ1A0BlwukXfU0kP3ltz9Ez5j612Ljt9ulwI3X+xalT3/hfU7f8zye6CDrHhO4Th83WG4tcot8smKNDBk9RdKZ98T06dPLzOeHyOyJw2xa9sZMe4bYW2CmTBm9k/YMaHVzNnipOcurSQNLPRsabzkmYNR9eAvJYPbnnY7v+ab818umLTsuCh692zg5w5vbnLU9fOSYdxNjd0yuzZPLN++d0F9rOnrsb/s/L9Jler/1ocPH5Lprc4mWoctq3l3J/rLTHeasc+6c2eXHn/fpYl+64vLLpKEJarebM+x//X3ct/zEfyfl05XrpfF9NX3LmEgZgbAMeFOGjlIQQAABBBBwp0C+G64TvR1Pb1E4feaMreRPu/bJ7Pmvy6MtGtp5fdBlX23copOil9hvNFc0NRjTIEyvdOoXs9q2biTfbdtpA7iihW6S56fN9wWWun3soNoWdv6hQe3q9p7WpSbobVCnul2qP/EZVznFbyssW7f/aM8ya+aVazboU4KpXs275OTJUzJgxAty4OAhm19/aemjT1fZaSdneO+tVlE++GSlqJcm3faequXt9no749btP9npa3PnFP3lpk+/WGfnl5vnwrfktz93mvXqq6Rc6eKiP2eqK/fs+1UOHjoit9x0oxz762/5aXd04KtfFtQz6HrbyTVZr9KsNn1gzqYXv7WQ5Dz/nSK7kIcUESDgTRHGpBfClggggAACCKSGwLB+T4qe6W3dvq882nmADB0zVXo9+ahoYOfdX+GCBWTeonek6WM97a0Lg5/uaFdNnr1QKtR6SNp2Gyz681+9u7axy0cM6GLPfDZv85Q0bNlF+j0zQc5GRdl1gR5KFi8qx4+fkOMnTkipErf6ssRVTi4T6PXo+LD0HjJe2vccJus2fOfbJr4JPXP80uRn7O0UervFI536S/f+z/oC8/i29a7TDwh331VeWj7RWx7p2N84VbDBq67fsHmbPDNuuk7a9OyQnrL4zQ+lVfs+suSdZTLM739mNaR3R9HA9aG2T4t+4Bg9uLvkyJbV1OWcDBw5yd6/e2eNpjJz7hIZ0PMJW5734e0PP7O3M3jneU45AQLelLOkJAQQQACBpAuwZQoLXJYls/Ts9Ij9gpkGgwumj7b30Hp3U7bU7fKyWTbluQHy6ovjRPMUMQGwru/fo52sXbZQZk0YKqMH95CKZe/QxebMZi4ZNaibzf/2yy/Iay+ON5fxo3+1SG9z0DJtRr+HpYumyHuLpvotkXjL0ft8tU7Txw2SZ/p3ka+WL46xrXem+YN1ZUT/zt5Z0S/oPWPy677mThkhk8f0l7r33uVb72Ti8ZYP2DYtnDXGnAm/37eJfqFv8eyxvnk9Mzv7hWGipmp0nd+tD3p2Vr+4p2XMnTJSvCbZrrlaFs16Trz3Er//6jQpU/I2X5k6of1R6+5KOklKYQEC3hQGpTgEEEAAAQQQQAABdwkEV8DrLjtqgwACCCCAAAIIIBAEAgS8QdBJVBEBBBCILcA8AggggIBzAQJe51bkRAABBBBAAAEEEHCXgKPaEPA6YiITAggggAACCCCAQLAKEPAGa89RbwQQcC5ATgQQQACBsBYg4A3r7qfxCCCAAAIIIBBOAuHaVgLecO152o0AAggggAACCISJAAFvmHQ0zUTAuQA5EUAAAQQQCC0BAt7Q6k9agwACCCCAAAIpJUA5ISNAwBsyXUlDEHC/QO2mXSUlkvtbSg0RQAABBNwkQMDrpt6gLsEoQJ0RQAABBBBAwOUCBLwu7yCqhwACCCCAQHAIUEsE3CtAwOvevqFmCCCAAAIIIIAAAikgQMCbAogU4VyAnAgggAACCCCAwKUWIOC91OLsDwEEEEAAAREMEEDgEgoQ8F5CbHaFAAIIIIAAAgggcOkFCHgvvbnzPZITAQQQQAABBBBAINkCBLzJJqQABBBAAIHUFqB8BBBAIDkCBLzJ0WNbBMJAoEGrp1Lkfxah/8OJMOCiiQgggAACLhQIoYDXhbpUCQEEEEAAAQQQQCDNBQh407wyuCGfAAAQAElEQVQLqAACCCCQwgIUhwACCCAQQ4CANwYHMwgggAACCCCAAAKhIuBtBwGvV4JnBBBAAAEEEEAAgZAUIOANyW6lUQgg4FyAnAgggAACoS5AwBvqPUz7EEAAAQQQQAABJwIhnIeAN4Q7l6YhgAACCCCAAAIIiBDwMgoQQCAxAuRFAAEEEEAg6AQIeIOuy6gwAggggAACCKS9ADUIJgEC3mDqLeqKAAIIIIAAAgggkGgBAt5Ek7EBAs4FyIkAAggggAACaS9AwJv2fUANEEAAAQQQCHUB2odAmgoQ8KYpPztHAAEEEEAAAQQQSG0BAt7UFqZ85wLkRAABBBBAAAEEUkGAgDcVUCkSAQQQQACB5AiwLQIIpKwAAW/KelIaAggggAACCCCAgMsECHhd1iHOq0NOBBBAAAEEEEAAAScCBLxOlMiDwCUSqN20q6RUukRVZjcIpL0ANUAAAQQSECDgTQCI1QgggAACCCCAAALBLRAuAW9w9xK1RwABBBBAAAEEEEiyAAFvkunYEAEEEAhGAeqMAAIIhJ8AAW/49TktRgABBBBAAAEEwkogYMAbVgI0FgEEEEAAAQQQQCCkBcIy4B07eZ7Ua9ZJmrd9OkbnHjp8VDo/PVIee3KQ9Bs+Uf47edK3/rW3l0nL9n2ldYf+snLtRt9yJhBAIKQFaBwCCCCAQAgIhGXAW7xYQRner/NF3TdxxitSvkwJeXHSMLnqqivllSUf2Dx79/8u8xcvlRnjB8mYId1lxLiZcvLUabuOBwQQQAABBBBAIPQFgruFYRnw1qxeUbJfk/Winlu9frPUq1nFLq93bxVZtX6TnV61bqNUrVRGLr8si+TJnUOKFCwgX2/cKvxDAAEEEEAAAQQQcL9AWAa8gbrl3xP/iccjck3Wq+zqG/Lmlj8PHbHTfx4+ItflyWmn9eH663LLwUOHdVIiIyNdlc6ePSua3FYv99XHnU7nxF3/yTlTH00O62VyX5Kc7htPkbzuHB4LOT5FOnrPOHs2ylE+/9eCfVMyD/7LQn06KirxTsFqYrqWv2QIEPD64UVEXODweC5MaxZPjHUmMtaFJunB210pyrzxaooO6NxVN/fUKSrqrOiB0m0+GmC6KZlY14xy86cTLkpu6zcdS1FR58xrzz1j3G1G3vqcM+PIO81z3OPl3LnEH8fNK9X+hZNrlAl4XdreFD8e2M7lIckCMaO6JBcT/Bvq7Qr6ifr0mTO2MYePHpOcObLZ6ZzZs8mxY3/ZaX04YtblypFdJyVTpkyuShkzZhBNbquX2+qTMWNGyZAhg6v6To30g5arUoRHPB5NEebZPUmt3JSix1N6140nNxl565I+PU5ei/iek+Jk35TMQ3zlhtq6pDgFq4HpWv6SIRCRjG1DbtOKZe+Q5SvW2nZ9/PkaqVzuDjtduXwp+XLdRjl1+rQcOfqXfL9zl5Qrc7tdxwMCSRZgQwQQQAABBBC4JAJhGfC27TZUmrV5Svbs+00q1GopC1//wGJ3a99Cli5baX+WbN/+36VF43p2eb4brpX769WQx7sMlm79xkj3jq0lozk7aFfygAACCCCAAALJEmBjBFJbICK1d+DG8mdNGCxrl73sSw81qmurmSP7NTJt7AD7s2QjB3aVLJkz2+X60KRhLXl5+iiZP22EVK1YWheREEAAAQQQQAABBIJAICwD3iDoF6p4kQALEEAAAQQQQACBpAkQ8CbNja0QQAABBBBIGwH2igACiRYg4E00GRsggAACCCCAAAIIBJMAAW8w9ZbzupITAQQQQAABBBBA4LxA0AS87XsOP1/lC08tn+h7YYYpBBBAAAEELhJgAQIIICASNAFv7M7698R/9ndxYy9nHgEEEEAAAQQQQAABfwHXB7wz5y2xv5X77dad9ll/N1dTy/Z95YH/3ePfliRPsyECCCCAAAIIIIBA6Aq4PuBt93Bj+3u5jRrUtM/e3899a/4Eaf5gndDtGVqGAAJxCtRu2lVSKsW5k/BcQasRQACBkBRwfcDrVe/ZqbV3kmcEEEAAAQQQQAABBBwLJD7gdVx0ymZctW6TtO02VKrUfTjGrQ0puxdKQwABBBBAAAEEEAg1gaAJeOe8/Kb06vywrHjvpRi3NoRah9AeBBAIHgFqigACCCAQHAJBE/DmzpVdCt+SX9JFBE2VhX/hI8D9pOHT17QUAQQQQOAiAdcvCJroMXu2rPLme8vl+L8nXI9KBRFAAAEEEEAAAQTcIxA0Ae+bS5fLc5Pmyr0PtOMeXveMH2qCgHMBciKAAAIIIJBGAkET8Hp/jiz2cxq5sVsEEEAAAQQQQCBJAmx06QWCJuC99DTsEQEEEEAAAQQQQCAUBIIm4NX/u1qgFAqdQBsQuFiAJQgggAACCCCQUgJBE/D638rwyZszpXuHVvJYi4Yp5UA5CCCAAAIIIOBGAeqEQAoIBE3A69/WKy6/TJo0rCU7ftztv5hpBBBAAAEEEEAAAQQuEgjKgFdb8eehI/Lr7wd1koQAAggggAACCCCAQJwCQRPwxr5/t8njT8kjze+Ls2GsQAABBBBAIPwEaDECCAQSCJqA1/8eXp3+/J05UrtG5UBtYhkCCCCAAAIIIIAAAj6BoAl4tcbnzp2TXXt+tUmndRkp8QJsgQACCCCAAAIIhJNA0AS873zwmf2/rHXpM0o01XzwCXn3oxXh1Fe0FQEEEEAgZQUoDQEEwkQgaALel5e8L0N6d5SliybZNOip9rLg1aVh0k00EwEEEEAAAQQQQCCpAkET8KZPn14qly8pHo/HpioVSklEhCep7Xa+HTkRQAABBBBAAAEEglogaALedOkiZO3X3/qwV63bJBkzZvTNM4EAAgggkLoClI4AAggEq0DQBLx9uj4mYyfPE+/Pk02YvkB0WbDCU28EEHCHQO2mXSW5qd5D3d3RGGqBAAIIIBBQIIUD3oD7SJGFtxUtKK/PHSevzHjWpiUvjZNiRW5JkbIpJDwF6rfslexAxxsohacgrUYAAQQQQCA4BFwf8OovMbz1/qdW0+PxyE3589r05nvL5aNPV9nlPCCAAAKuE6BCCCCAAAKuEXB9wPvKkvekxl3lLgK7p2oFWfzWsouWswABBBBAAAEEEEDAPQJuqInrA96oqHNy1ZVXXGR19VVXyPHj/160nAUIIIAAAggggAACCPgLuD7g9cTxy2NRUVH+7WAaAQSCWoDKI4AAAgggkHoCrg94K9xZQmbNf13OnTvnU9DpWfPfkErl7vAtYwIBBBBAAAEEEAh6ARqQKgKuD3jbP9pEvvl2uzRr85Q8N3mujBw/W5o+3ks2fbdD2j3cOFVQKBQBBBBAAAEEEEAgdARcH/BmyZxZpo8bKF3atZQTJ07KOfNft/atZPr4gXL5ZVlCpydoCQLOBciJAAIIIIAAAokQcH3A622L3r4w+On20r9HW6lY9g7vYp4RQAABBBBAIGwFaDgCzgSCJuB11hxyIYAAAggggAACCCAQU4CAN6YHcyEoQJMQQAABBBBAILwFCHjDu/9pPQIIIIBA+AjQUgTCVoCAN2y7noYjgAACCCCAAALhIUDAGx797LyV5EQAAQQQQAABBEJMgIA3xDqU5iCAAAIIpIwApSCAQOgIEPCGTl/SEgQQQAABBBBAAIEAAgS8AVCcLyInAggggAACCCCAgNsFCHjd3kPUDwEEEAgGAeqIAAIIuFiAgNevc/oMfV4q1GrpS9t2/Oxb+9rby6Rl+77SukN/Wbl2o285EwgggAACCCCAAALuFriUAa+7Jc7Xbupz/WXtspdtKlbkZrt07/7fZf7ipTJj/CAZM6S7jBg3U06eOm3X8YAAAggggAACCCDgbgECXgf9s2rdRqlaqYxcflkWyZM7hxQpWEC+3rhV+IcAAggkTYCtEEAAAQQupQABbyztngPHSZ3GHWTs5Hly5kykXfvn4SNyXZ6cdlofrr8utxw8dFgnTZ4zrkqRkZGi6cwZd9XLbfVRo3PnzgkpfgMDZP7iz4NhtE9k5FlXHQvc9prz1ufsWZy8FvE9J8XJvimZh/jKDbV1SXEKVgPTtaH5d4laRcDrB92j08Py2Tuz5dkh3WXHj7tlwWvvifefJ+IClcfj8S4mGAjioDG6E8+ZJ5JIYANdaoDMn06R4nIyQObvHMeDID4euO+DmxltifQ0g9D+ua8tqffa0AaHS3u1raSkC1yI4pJeRshsmStHNtuW4sUKSasm/5PtP0R/aS1n9mxy7Nhfdp0+HDl6THLlyK6TkjFjRlelDBkyiCa31ctt9VEjj8cjHk+EeEjiidNAjTSlqZN44qyfW+rlkfTp07vqWOC215y3Pjg5e89Inz5doseTnP/ntQ6H53Tp0iXaKVhdhH/JEohI1tYhtvHxf0/YFkVGRsqX6zZK0ULRX1qrXL6UnT91+rQcOfqXfL9zl5Qrc7vNywMCCCCAAAIIIHBpBNhLUgUIeP3kHny4h/1JMn2++qorpHWz+nZtvhuulfvr1ZDHuwyWbv3GSPeOrSWjOZNqV/KAAAIIIIAAAggg4GoBAl6/7ln2+nT7c2TvvPKCPNn2IUlvLpV4VzdpWEtenj5K5k8bIVUrlvYu5hkB1wlQIQQQQAABBBCIKUDAG9ODOQQQQAABBBAIDQFagYBPgIDXR8EEAggggAACCCCAQCgKEPCGYq/SJucC5EQAAQQQQACBkBcg4A35LqaBCCBwKQTua/201G7aNUXSpagv+0AgtgDzCISyAAFvKPduiLYtJYKKei16hqgOzUIAAQQQQACB2AIEvLFFmI9HgFUIIIAAAggggEDwCRDwBl+fUWMEEEAAgbQWYP8IIBBUAgS8QdVdVBYBBBBAAAEEEEAgsQIEvIkVc56fnAgggAACCCCAAAIuECDgdUEnUAUEEEAgtAVoHQIIIJC2AgS8aevP3hFAAAEEEEAAAQRSWcA1AW8qt5PiEUAAAQQQQAABBMJUgIA3TDueZiOAgGsFqBgCCCCAQAoLEPCmMCjFIYAAAggggAACCKSEQMqVQcCbcpaUhAACCCCAAAIIIOBCAQJeF3ZKKFYpJf53wN4yQtGHNiVdgC0RQAABBBBISICANyEh1iOAAAIIIIAAAu4XoIbxCBDwxoPDKgQQQAABBBBAAIHgFyDgDf4+pAUIOBcgJwIIIIAAAmEoQMAbhp1OkxFAAAEEEAh3AdofXgIEvOHV37QWAQQQQAABBBAIOwEC3rDrchrsXICcCCCAAAIIIBAKAgS8odCLtAEBBBBAAIHUFKBsBIJcgIA3yDuQ6iOAAAIIIIAAAgjEL0DAG78Pa50LkBMBBBBAAAEEEHClAAGvK7uFSiGAAAIIBK8ANUcAAbcJEPC6rUeoDwIIIIAAAggggECKChDwpiin88LIiQACCCCAAAIIIHBpBAh4L40ze0EAAQQQCCzAUgQQQCDVBQh4U52YHSCAAAIIIIAAAgikpUBwBLxpKcS+EUAAAQQQQAABBIJaRNLtxAAAEABJREFUgIA3qLuPyiOAQCgK1G7aVeJKiVkeija0CQEEEEiKAAFvUtTYBgEEEEAAAQQQQCAtBRK1bwLeRHGRGQEEEEAAAQQQQCDYBAh4g63HqC8CCDgXICcCCCCAAAJGgIDXIPCHAAIIIIAAAgiEskC4t42AN9xHAO1HAAEEEEAAAQRCXICAN8Q7mOYh4FyAnAgggAACCISmAAFvaPZrirUqMT+BFF/eFKsQBSGAAAIIIJDaApQfcgIEvCHXpTQIAQQQQAABBBBAwF+AgNdfg2kEnAuQEwEEEEAAAQSCRICAN0g6imoigAACiRWI7zajxK5L7L7JH04CtBUB9wsQ8Lq/j6ghAggggAACCCCAQDIECHiTgcemzgXIiQACCCCAAAIIpJUAAW9aybNfBBBAAIFwFKDNCCCQBgIEvGmAntq7/F+LnpLY+/Piyp/adaV8BBBAAAEEEEAgtQUIeB0Kv/b2MmnZvq+07tBfVq7d6HCrJGZjMwQQQMBlAnF9KE7M8rrNu7msVVQHAQTCRYCA10FP793/u8xfvFRmjB8kY4Z0lxHjZsrJU6cdbJm4LIl544grr57dTdxeyY0AAgi4V4CaIYAAAikhQMDrQHHVuo1StVIZufyyLJIndw4pUrCAfL1xq/APAQQQQCBxAvc9/DS3XCWOjNwIIJACAiEQ8KaAQgJF/Hn4iFyXJ6cv1/XX5ZaDhw7b+bL3tpSUSkeOHJbkpyOmDE0pUVYIl3FY24ZTguPNjP0jR3BKyOkwTua4o6+p+NNhM5aOmnQkRY51h2XBggUhmxYtWpzottk3JfMQyi6x27Z4ceKdYpcRLPOma/lLhgABr0M8T8QFKo/H49uqY4sa4qbUqeU9oslNdXJjXdRIkxvr5qY6dWpZg/Hk4DXuGicHdU3L8dXJ1C8lX3dnz0ZKKKaoqLMSEeFJdNvebvGQaApFk7jaFBERkWinuMpy+3Jf4MFEkgQikrRVmG2UM3s2OXbsL1+rjxw9JrlyZLfzLVq0EBIGjAHGAGOAMcAYYAyk5hiwQQcPjgViZyTgjS0SYL5y+VLy5bqNcur0aTly9C/5fucuKVfm9gA5WYQAAggggAACCCDgNgECXgc9ku+Ga+X+ejXk8S6DpVu/MdK9Y2vJmCGDgy1TN8u3W3fKI50HSqsO/WT2gjcC7izy7FkZMX6WPNJpgLTrPlR++e3ARfl0XdtuQy9aHioLDh0+Kp2fHimPPTlI+g2fKP+dPBmwaYF+eu7AwUMy6vnZUqdxB2nW5imZt+jdgNuG4kIn4yu42+2s9k4dwn38JOd15t8THI+iNQKNJ12jx/RxU+bbY1LF2q1k8Zsf6eKQS8kdT5u37JAnegyTlk/0Ne/bz8rOn/aEnBENSpwAAa9DryYNa8nL00fJ/GkjpGrF0g63Sr1s586dk0GjpsjTTz4iL00eLp99+ZVs+m77RTtc+tEKc1b6mMyd8ow0anCvjJ7wYow8b3/wmeTKmU38bkuOsT4UZibOeEXKlykhL04aJldddaW8suSDi5oV10/P6f1hje67Vz5cMk1GDOgiS975WH7evf+i7UNtgdPxFWrtjt0epw6MH5HkvM687hyPoiXiGk+6Vn8ic9uOn2TKcwNk5XsvSeXyJXVxyKXkjifd/qFG9eTlGaOk9B3FZNa810POKEUbFAaFEfAGaSfrp9XLLssitxa+WdKnSyc1q1e0t13Ebs7qdZuk7r1V7OK77yon23b+LP+e+M/O//3PcXn3wxXy0IN17XyoPqxev1nq1Yw2qGcsVq3fdFFT4/rpuVw5sknBm/KJ/rs5/w1yc4Eb5LcDf+psSCen4yukEUzjnDowfkSS8zoz1MLxSBWiU1zjSdd+uPxL6d6hldyUP6+kT59e9FeDdHmopeSOp6ioKIk4fybHIx7JnTtHqBHRnkQKEPAmEswt2f/484jkzZPTV50b8uaWPw4e9s17J/40l/PzXpvbzmpgnCdXDjlottUFE2cslK7tW4iexTQnjHVRyCUN7vWYd03Wq2zb1OnPQ0fstP/Dn4ePxPnTc958emZ3+w+75PZiBb2LQvY5wPgKOL5CFuB8w5w6hPv4SYnXGcej84POPMU1njSI0+P3W+9/KjUatpHOvUfJvl8uvk3NFBHUfykxnlo3u08GjJgkFWq1FPV6vMX9QW1C5ZMvQMCbfMNUKUEvaek9t4GSHgx0p54Ijz6dT3F3pcdzIV/E+eltO36225UoVtg+B+uDEycN6L3t83jicYq4sM7juWCm2x77+x/pO3yCDOj1hGS96kpdFPLJE+FvcMEm5Bseq4FOHTxhPn6S8zoLleNRrKETcDY5Tlrg6TNnRK82vbtwktS+u6KMmjBbF4dcSq7TyjUbZOSgrrL8rVnS9P5a8vy0BZJy/ygpGAXC913M5b2lX5QbN7yXBEr6f3zLnTObHD32j68VR44ek9y5on8qzbfQTOTMfo0cOer3k2rH/rb37OrB4INPVtpPv3pj/9btP8rDHfubLYLrLyEntTp7Nkr0TUJbdtg45cyRTSdjpPh+eu6suTQ2bMw0cxmxtdxVoVSM7UJ1xun4CtX2e9vl1CHcx09yX2ehcjzyjpu4npPrpEFgjmxZ5a6Kpe3/+bN6lbLy0659ce0uaJcn10l/UenLtRulUtk7rNPdxmnr9p+C1oOKp4wAAW/KOKZKKVdecbkESrqzwrfkF/0W6/5fD4gGZJ9+sV7059N0nf6ywJ59v+mkVCx3hyw363Rm/Tdb5KZ8ee0BoMNjTWXtspdtmjF+kNxWtKDMmzpCswVdCmSky7wNqWgOestXrLWzH3++RiobE53xd1K7QD89d+ZMpAweNVXq3nuXVLizhG7mKAV7pvjGV7C3LTH1j8+B8RNTMjmvs1A6HsVUuXguOU5aWqXypeTrTVt1Ur7auFUK3hz9HQO7IIQe4nLSK5x6gkabGtdxW39FKV26CNny/Y+aTdZt+M6cFb/eTvMQvgIEvEHa9x6PR4b26SgDR04W/Rmf0iVvlVLFi9rWfLbyK1n05od2ukGd6hJhLk1rnjkvvym9uz5ul4fTQ7f2LWTpspX2Z8n27f9dWjSuZ5vv76RnigP99Nw3326TT1eus856L5imD8yZcVtACD94PHGPrxBu9kVN83jidmD8xORKzussZkmhPZdcpw6PNpGVazaK/iTl2+9/Jv26t3E7WJLqF5fTL+Ykz/CxM2yZcR23PR6PdO/YSrr0GWV/tnPFqq+lV+dH7DY8hK9ARPg2PfhbXuK2wqI/N7Zg2khp2+pBX4MealRX+naLDmz1i2r9e7S1+WY+P1huvD6PL593onixQjJrwmDvbMg958h+jUwbO8D+LNnIgV0lS+bMto3+TrqgSYCfntOfM/OeCfc+69lezR/qKa7xFertjt2+uBwYPzGlkvM68y+J41G0RqDjka65+qorZMLIp2Xu5OEycVTvkP2VhrjGU+GCBeTVOWOVwqYmAY7buqLuPVXk83dfFH1/HDu8l+ThVxqUJawTAW9Yd79LGk81EEAAAQQQQACBVBQg4E1FXIpGAAEEEEAgMQLkRQCB1BEg4E0dV0pFAAEEEEAAAQQQcIkAAa9LOsJ5NciJAAIIIIAAAgggkBgBAt7EaJEXAQQQQMA9AtQEAQQQcChAwOsQimwIIIAAAggggAACwSkQ6gFvcPYKtUYAAQQQQAABBBBIMQEC3hSjpCAEEEDAzQLUDQEEEAhfAQLe8O17Wo4AAggggAACCISFQIyANyxaTCMRQAABBBBAAAEEwkqAgDesupvGIoCAQwGyIYAAAgiEkAABbwh1Jk1BAAEEEEAAAQRSViA0SiPgDY1+pBUIIIAAAggggAACcQgQ8MYBw2IEEHAuQE4EEEAAAQTcLEDA6+beoW4IIIAAAgggEEwC1NWlAgS8Lu0YqoUAAggggAACCCCQMgIEvCnjSCkIOBcgJwIIIIAAAghcUgEC3kvKzc4QQAABBBBAwCvAMwKXSoCA91JJsx8EEEAAAQQQQACBNBEg4E0TdnbqXICcCCCAAAIIIIBA8gQIeJPnx9YIIIAAAghcGgH2ggACSRYg4E0yHRsigAACCCCAAAIIBIMAAW8w9JLzOpITAQQQQAABBBBAIJYAAW8sEGYRcKtArUbtpX7zznLu3DlfFd/+4DOpUKulvPrWMt+y1JzQ/fQZNsG3i0OHj8rg0VOl5RN9pX2P4dK177Py4fJVvvWxJzr0ekZ+3rPfLm7fc7h8vWmrnY79oOWsXr859mLH82riOLOLMr637AvZ/+uBJNVIPTd9tz3BbX/57YD0GjRWtC82bN4WZ/7vtv0gj3cZHHC99lvnp0cGXBd7odN6zVrwhkRFRcXePBnzSdu06v8elVOnT8e78Z79v0u77kPjzcNKBBBwlwABr7v6g9ogEKeAxyNyTdarYwSJH3zypRS+Jb/oujg3TKUVGhS06z7M1OlKWTB9pEwfP1DGDusp6dIFPqys/2aLXJYlk9yc/4ZUqlHwF/vRp6vl19//SNWG6Ji5tfAtMm3sAClzR7FU3VdiCp+78B2J8vswl5htL3Xe/DdcK9mzXS2rv9p8qXfN/hBAIIkCgd+ZklhYsG1GfREINoF6Ne+S9z/+0lZbz9SdPHlabsibx5z1tYvkv5MnZdyU+dK8bW9p0a6PTJ69SLxnzRa/+ZHUadJRHmrXW7r1ezbGmUQ9Izpj7hJ7lrZtt6GyecuO6ALjedQzuZkyZZQu7VqYgNtE4yZvhgzppWb1imbq4j8NtGrcVS7Gis9WfiVP9h4ljR7pIVPnLI6xzjuza+8v9szxI50GyGNPDpJV6zZ5V9ngX88sP9p5oNz7QLsY6zRTZGSkPQOtZ6HPBjh7OHPeEtEz1nq2Us36DZ8ox/7+Rze1Pn2GPm/PXrfq0C/GmWs9aznmhZdEtxv+3AzRcnRbnde2DBw5WXb+uFs034MP95BFb3xoy9QHPRv+0659OmmTeuvZ1I8/XyM7f9ojk2Yustt9u21nvP25w5TfputgadN1iPQeMl5Onor/rKTu7N2PVsh7Zvx88MlKu49/T/wnX6zeYMoYLI8Yw67mDP3uvb9q1ouSjqXGj/aUjk+NkBVmm4synF8QX73iGoNato7Tzk+NtPXStsQ3lt9Y+okdN2qpVz70SsP53fue4hs3Tsa7tqN5m6d85emEzmu/6HSNu8rLe8tW6CQJAQSCQICANwg6iSoi4BWoVK6EDUZP/HfSBr4aAHvX6fPsBW/K2bNnZf7UETJ3yjPyx8HD8trbH+sqKVvqdlm68AVZOPNZqXl3RRk1YY5d7n0okC+vPUs7enBXGT0x5jpvHv9nDYzuuK2wREQ4O4xoEF28WCH/ImTvL7/L8yOekhcnDZPPV31tU4wMZmbgiMlSrkxx256uT7SQgaMmy9Fjf8vho8fk6SHPS6tm9eWlycPl9bnjpUihAmaL6L+//j4uncxl9/w35pWhfTpKuifq9A4AAAxxSURBVIiI6BWxHvfu/01GD+4mi2Y9K9fmziEvvvymzaFB8l2VysjLM0bJpNF9ZO6it21Aaleah/9OnpIXzPKBTz1h5kQOGOsxQ3uY/KNl155fZP6rS+36lyYPk4Wvvy8HDx2x+eJ60A8Khc3Z+ifbNZfp4wZKiWKFJb7+HDpmmtS9p4rMnjhEGtS52wbYcZXtXd6gdjW5u8qd8sD/7rH7+M+MoyGmnB4dW8tcY3jH7UVk2HPTvdl9z5+uXCcr12ywzhNGPi3+Absv0/mJ+OoV1xjs3Ka5HUeTn+tn65XZfJCKq+3H/z1hXN6SCaN6i/bN4tlj5MorLz+/9wtPcY0bb46ExnuRggUkc+bM4r3tY+N32yV9hgy2X7SMEmYsb/ou4Q+GmpeEAAJpLxD4HSDt60UNEEAggIAGl9VNwLL8i3Wil7/r3FMpRq71G7bI1u0/yZN9Rtn046698p05U6iZItJFyGwTzOlZvHc/XCE//LRHF/tSjarl7XT2a7LK7wcOSaQJnO2CFHjQM60a8OXJnTNGaQ/WryHp06eXq668QurUqCwaFPtn0KB1/28HpEnDmnZxCRNgF7o5n2wxbfx26w+iQUmlsnfYdVdfdYXkyJbVTutD226DpX6tqvLoQ/fpbJypbKnb5IrLL7Pr7zZn7TZt2Sl//3Nctv+wS9Spfc/h5izwRPn335PG8gebTx/0bHWEXxBdqkRRuSxLZtFgrZAJXLWuGU2ApG3LZ4Lu3Xt/0c0SleLqT3U5+OcRaVjvbltepXJ3SD5zmd3OJOLh220/SrEit8ithW+2W7VoXNcG9Xrm1y44/7Dpu51Sv3Z166RterD+PefXxHxKqF4JjUH/0uJquxrnzpVdxk2eJy8tfMd8+PlHMmXM6L+paD3iGjfejE7Ge+P77hU9m6zbvPHuJ9K4wb06aVPOHNnkn+MnRANwu4AHBBBwtYDzgNfVzaByCIS+gN7eGBV1zgQe1WT6S69J4Vvy2UAxRss9Ij07tbZnyfQs4eLZz8nIgV1tlh79x0ihm/PLkN4dZMyQ7uZy+Sm73PuQLuLC4UADEz1T7F0X6FnPkG3eutN3y0SgPN5lGtR6PB45ffqMd5F9TheR3j7rQ/oMOn1OJ33pnJyzZ2bTp0vnW5bBBMjnFMMs0eDLPAX8q1m9krz/yZcxLvU3b/u06GX51h36B9zGuzCd2Z/Weepz/X2W7y2eLI3viw68NV+mTBn0yZcy2vpHz2ognMFvPl1EhERGRtmV6dJFiP/tFfphwK4I9BBHf6pLhClTk3ez9OnUzzvn8Nk4pk93od/VNsL0U+ytdX/pjYl3udp4p/2fNV9EPPVKaAz6lyVxtF3Ln2vORjeoU03UvGvfUb4vQnq313qki4gQ/zpr27zjRsy/dBEX2h2RzvRJgA94Ne+uZD6E/WDPnm80Z3Nr31PZbBn9p2VFRUXZDzjRS3hEAAE3C1x4xbu5ltQNAQR8Avqlr4cerCcPN7/4zKWe7Zwx73Vz5ulfm18v++t9of+dPClH//pbKpcvKddkvUr0DLHNkIyHOubN/9Sp0/Ye2QMHD9mSzpyJFL0X1c7Eeri5wA32vlj/xW+9/6kJBCPtGdUPl38pJW+/1X+1ZL3qSrkuTy7fWbYt3/8oP/y8V4rfWlBK3FZIdv60W9Z+/a14//1zPLrdOt+m1QNS4c4S9j5b7xnLRbPGyJKXxsn8aSM0i00rVm2wtxtoAPPqWx9JqeJF5PLLstizxy/MfMUX0P+8e7947xW1Gybx4fq8eWTfL7/brX/57Q/Z7XfP7OWXZTYWF9oQV3+qS47sWeVb84FDC/rtwEHZs+9XnbRJl8fVDzbD+Qc13LbjZ9H7VXWR3musZ6cvN+3XeW9SE/2Clhrpsrh+QSO+eiU0BnWfx/6Kvn9a9xFX2/X+Xv3CpJ7db9G4nui40vuldRtv0nrENW68eZw8a8DcoE5V6TV4vNQ1V1MymjP23u327PtN8puz6nEF/958PCOAgDsECHjd0Q/UAoFECbRsUk+KFrrpom0ebXG/CdTyi36Rq2X7vvJIxwFy9NhfkiVzZmnRqJ40b9PbfgHs8JFjF22b2AV6GXnm84Mkwpwp05+4atN1iDxlAgM96xWorJrVK8rGb2P+bNZ1eXJK64797ZfRqpQvJdUql7lo0+H9O8vKNRtFv5j2/LQFMuip9jZo11svhvXtJPMWvSv6hbZq9R+7qPzWTevLXRVL23t5vUFv7B0ULXyT9Bw4VvTsr55tVUPNM7RPBxPg/iWt2vezZ4X13mH/M7OaJymp2f21ZeqLr4reKvHKkvdj3IrQpGEt+fizNfaLYfrlKK1LkYIX96fud8jTHWSuaXunp0bI+Cnz5Vpjqcs1rVq/0XwYiHnLii6PnXJkv0YG9Gwnz02aa331lzQG9noidjbRL2jpFQW9HabHgDHyZzz3I8dVr4TGYLuHH5SR42daFw1qH20ReCwfOXpMaj7whO2TASMmS97rcoveihK70nGNm9j5Epp/sP69ZhwclQf9bmfQbfQn4O6pVlEnSQiEs0DQtJ2AN2i6ioqGu8Cy16fL9ebNPbbD8H6dpen9texivX9UfzXhlZmj5eXpo2TposlSvkwJu07PeL4xb7xMHNVb2rZuJKs/nG+X68PaZS/rky99/s6ci+6L1JW6n9GDuumkTRow6RfC3po/wX55Sr/QVLvGhcu+NtP5h/q1q9pfBDg/a28V6N31MfslutfnjpeOjzfzrrJ11PtSdcFN+a638y+Zy9gvThpmz1Lrck1lS91uv2g3d8ozsmLpi1K1UnTA7N8eDXr1ErieQdRtYqeb8uWVBdNGivf2Dz07qHn0DOEzJthWSz0rrF/2y50zu66ydb+z5G12Wh/aPdxYNOm0poG92sn99WropE1q7m3P7ebstHrpLSfa/nlTR4j3y3yl7ygmY4f3Er2VokSxwvZyeVz9WbhgAfuFvynP9bfbaB1LFi9q97dtxy5p2fh/djr2Q7f2reShRnV9i9VszgtD7RfStJ4FjIeu1Drpcp3W9GTbh+yX8MY/87R9njymny6+KMVXr/jGYKMGNUXLVhcdx5oCtV375Yv3XrJn6rV/nur8iHWKXZGb4hk3/uNDt/Mf71q2fpjT5Zq2bPvRBNTl7JUGnfemjz9fKw3rVffO8owAAi4XIOB1eQdRPQSCXuB8AzSQbG4CLb38fn4RT6kkoAGz3rqSSsWHTbH9n3lB9LaWzm0ufBjTxustPE0fqC16lUHnSQgg4H4BAl739xE1RCBkBKpWLH3RmbK0bJyeldWUlnVg3+4VGDGgi7zzygtybaxfF8mTK4dUr3yneytOzVwrQMXSToCAN+3s2TMCCCCAAAIIIIDAJRAg4L0EyOwCAecC5EQAAQQQQACBlBYg4E1pUcpDAAEEEEAAgeQLUAICKShAwJuCmBSFAAIIIIAAAggg4D4BAl739Qk1ci5ATgQQQAABBBBAIEEBAt4EiciAAAIIIICA2wWoHwIIxCdAwBufDusQQAABBBBAAAEEgl6AgDfou9B5A8iJAAIIIIAAAgiEowABbzj2Om1GAAEEwluA1iOAQJgJEPCGWYfTXAQQQAABBBBAINwECHjj6nGWI4AAAggggAACCISEAAFvSHQjjUAAAQRST4CSEUAAgWAXIOAN9h6k/ggggAACCCCAAALxCqRQwBvvPliJAAIIIIAAAggggECaCRDwphk9O0YAgZAUoFEIIIAAAq4TIOB1XZdQIQQQQAABBBBAIPgF3NQCAl439QZ1QQABBBBAAAEEEEhxAQLeFCelQAQQcC5ATgQQQAABBFJfgIA39Y3ZAwIIIIAAAgggEL8Aa1NVgIA3VXkpHAEEEEAAAQQQQCCtBQh407oH2D8CzgXIiQACCCCAAAJJECDgTQIamyCAAAIIIIBAWgqwbwQSJ0DAmzgvciOAAAIIIIAAAggEmQABb5B1GNV1LkBOBBBAAAEEEEBABQh4VYGEAAIIIIBA6ArQMgTCXoCAN+yHAAAIIIAAAggggEBoCxDwhnb/Om8dORFAAAEEEEAAgRAVIOAN0Y6lWQgggAACSRNgKwQQCD0BAt7Q61NahAACCCCAAAIIIOAnQMDrh+F8kpwIIIAAAggggAACwSJAwBssPUU9EUAAATcKUCcEEEAgCAQIeIOgk6giAggggAACCCCAQNIFLkXAm/TasSUCCCCAAAIIIIAAAskUIOBNJiCbI4AAAs4FyIkAAgggkBYC/wcAAP//D6wsugAAAAZJREFUAwBtgBlT93n2ZgAAAABJRU5ErkJggg=="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -18720,8 +18784,8 @@
     "    annotation_text=f\"Observed IC={observed_ic_mean:.4f}\",\n",
     ")\n",
     "fig.update_layout(\n",
-    "    title=\"Observed IC sits far outside the within-time permutation null\",\n",
-    "    xaxis_title=\"Mean IC (permuted)\",\n",
+    "    title=\"Within its own window, the factor ranks better than a dependence-aware null\",\n",
+    "    xaxis_title=\"Mean IC (block-permuted, fold dates only)\",\n",
     "    yaxis_title=\"Count\",\n",
     "    height=350,\n",
     "    showlegend=False,\n",
@@ -18742,10 +18806,34 @@
     }
    },
    "source": [
-    "**Interpretation**: The permutation test asks whether the observed IC could arise\n",
-    "from a random assignment of labels to assets within each cross-section. A p-value\n",
-    "near zero confirms that the feature genuinely ranks the right assets at each\n",
-    "decision time — the signal is not an artifact of cross-sectional dependence."
+    "**Interpretation**: over the fold window, the observed IC sits outside every block\n",
+    "permutation, so the factor ranked ETFs better than chance *in 2012-2014*. That is\n",
+    "the only claim the test supports, and it is worth being precise about why.\n",
+    "\n",
+    "Read it against §3, which scored the same factor at IC 0.0008 with a HAC\n",
+    "$t = 0.19$ over the full sample. These are not opposing verdicts about one\n",
+    "quantity — they are two different windows, as the decomposition above showed: the\n",
+    "entire full-sample-vs-fold gap was a period effect, with aggregation contributing\n",
+    "0.0000. The factor worked in the folds' two years and does nothing over twenty.\n",
+    "The folds are not a verdict on the signal; they are a verdict on 2012-2014.\n",
+    "\n",
+    "Two lessons generalize past this factor:\n",
+    "\n",
+    "- **A window that flatters the signal is the default outcome, not a surprise.**\n",
+    "  `min_train_pct=0.3` with eight 63-day folds evaluates the first 10% of the\n",
+    "  panel and never scores 2014 onward. A fold scheme that leaves most of the\n",
+    "  sample unevaluated cannot support a claim about the sample.\n",
+    "- **A null must be as dependent as the data.** Independent within-date shuffling\n",
+    "  put the null's standard deviation near 0.0015; blocking at the label horizon\n",
+    "  puts it near 0.0145 — roughly ten times wider, on identical dates. The first\n",
+    "  null would have called almost any factor significant, which is what a null this\n",
+    "  narrow always does.\n",
+    "\n",
+    "The rest of the evidence points the other way, and §4 already showed it: the\n",
+    "full-sample quintile spread is **negative** at every horizon and monotonicity is\n",
+    "-90%, meaning Q1 out-earns Q5. Cross-sectional 21-day ETF momentum is a\n",
+    "**reversal** signal over this panel. A single favorable window does not overturn\n",
+    "that; it illustrates how easily a fold scheme can hide it."
    ]
   },
   {
@@ -18773,10 +18861,10 @@
    "id": "77e64bf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:45.645384Z",
-     "iopub.status.busy": "2026-07-14T01:51:45.645297Z",
-     "iopub.status.idle": "2026-07-14T01:51:45.652157Z",
-     "shell.execute_reply": "2026-07-14T01:51:45.651331Z"
+     "iopub.execute_input": "2026-07-16T11:15:15.152003Z",
+     "iopub.status.busy": "2026-07-16T11:15:15.151925Z",
+     "iopub.status.idle": "2026-07-16T11:15:15.155640Z",
+     "shell.execute_reply": "2026-07-16T11:15:15.155386Z"
     },
     "papermill": {
      "duration": 0.030187,
@@ -18922,10 +19010,10 @@
    "id": "187f20ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:45.653365Z",
-     "iopub.status.busy": "2026-07-14T01:51:45.653243Z",
-     "iopub.status.idle": "2026-07-14T01:51:45.669131Z",
-     "shell.execute_reply": "2026-07-14T01:51:45.668318Z"
+     "iopub.execute_input": "2026-07-16T11:15:15.156533Z",
+     "iopub.status.busy": "2026-07-16T11:15:15.156472Z",
+     "iopub.status.idle": "2026-07-16T11:15:15.162920Z",
+     "shell.execute_reply": "2026-07-16T11:15:15.162645Z"
     },
     "papermill": {
      "duration": 0.039366,
@@ -18971,10 +19059,10 @@
    "id": "8e9673ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:45.670356Z",
-     "iopub.status.busy": "2026-07-14T01:51:45.670214Z",
-     "iopub.status.idle": "2026-07-14T01:51:45.818310Z",
-     "shell.execute_reply": "2026-07-14T01:51:45.817629Z"
+     "iopub.execute_input": "2026-07-16T11:15:15.163898Z",
+     "iopub.status.busy": "2026-07-16T11:15:15.163829Z",
+     "iopub.status.idle": "2026-07-16T11:15:15.284649Z",
+     "shell.execute_reply": "2026-07-16T11:15:15.284312Z"
     },
     "papermill": {
      "duration": 0.199133,
@@ -19049,10 +19137,10 @@
    "id": "e372a717",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:45.819361Z",
-     "iopub.status.busy": "2026-07-14T01:51:45.819277Z",
-     "iopub.status.idle": "2026-07-14T01:51:48.497450Z",
-     "shell.execute_reply": "2026-07-14T01:51:48.496617Z"
+     "iopub.execute_input": "2026-07-16T11:15:15.285786Z",
+     "iopub.status.busy": "2026-07-16T11:15:15.285700Z",
+     "iopub.status.idle": "2026-07-16T11:15:17.657950Z",
+     "shell.execute_reply": "2026-07-16T11:15:17.657380Z"
     },
     "papermill": {
      "duration": 2.0878,
@@ -19375,10 +19463,10 @@
    "id": "9f5e7cdc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:48.544069Z",
-     "iopub.status.busy": "2026-07-14T01:51:48.543866Z",
-     "iopub.status.idle": "2026-07-14T01:51:48.560906Z",
-     "shell.execute_reply": "2026-07-14T01:51:48.560296Z"
+     "iopub.execute_input": "2026-07-16T11:15:17.703211Z",
+     "iopub.status.busy": "2026-07-16T11:15:17.703103Z",
+     "iopub.status.idle": "2026-07-16T11:15:17.716925Z",
+     "shell.execute_reply": "2026-07-16T11:15:17.716578Z"
     },
     "papermill": {
      "duration": 0.092434,
@@ -19461,10 +19549,10 @@
    "id": "7a824ead",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:48.563099Z",
-     "iopub.status.busy": "2026-07-14T01:51:48.562876Z",
-     "iopub.status.idle": "2026-07-14T01:51:48.572579Z",
-     "shell.execute_reply": "2026-07-14T01:51:48.571679Z"
+     "iopub.execute_input": "2026-07-16T11:15:17.717944Z",
+     "iopub.status.busy": "2026-07-16T11:15:17.717859Z",
+     "iopub.status.idle": "2026-07-16T11:15:17.724356Z",
+     "shell.execute_reply": "2026-07-16T11:15:17.723983Z"
     },
     "papermill": {
      "duration": 0.123275,
@@ -19519,10 +19607,10 @@
    "id": "37dccdc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:48.574673Z",
-     "iopub.status.busy": "2026-07-14T01:51:48.574485Z",
-     "iopub.status.idle": "2026-07-14T01:51:48.577815Z",
-     "shell.execute_reply": "2026-07-14T01:51:48.577310Z"
+     "iopub.execute_input": "2026-07-16T11:15:17.725402Z",
+     "iopub.status.busy": "2026-07-16T11:15:17.725326Z",
+     "iopub.status.idle": "2026-07-16T11:15:17.727759Z",
+     "shell.execute_reply": "2026-07-16T11:15:17.727316Z"
     },
     "papermill": {
      "duration": 0.148549,
@@ -19612,10 +19700,10 @@
    "id": "08ee4003",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T01:51:48.579032Z",
-     "iopub.status.busy": "2026-07-14T01:51:48.578841Z",
-     "iopub.status.idle": "2026-07-14T01:51:48.602747Z",
-     "shell.execute_reply": "2026-07-14T01:51:48.602342Z"
+     "iopub.execute_input": "2026-07-16T11:15:17.728580Z",
+     "iopub.status.busy": "2026-07-16T11:15:17.728509Z",
+     "iopub.status.idle": "2026-07-16T11:15:17.746244Z",
+     "shell.execute_reply": "2026-07-16T11:15:17.745829Z"
     },
     "papermill": {
      "duration": 0.107325,
@@ -19810,11 +19898,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-07-14T01:52:05.799537+00:00",
+   "source_py_blob": "84dc8ff89b0e4afc971b8a50af394a6c3c224590",
+   "executed_at": "2026-07-16T11:16:02.535183+00:00",
    "executor": "nbconvert",
-   "parameters": {},
    "production": true,
-   "source_py_blob": "3258e47bd539747aa4c7ff459b5c8656ec561d12"
+   "parameters": {},
+   "notes": "FIXED incompatible-sample IC comparison: added the like-for-like statistic (same cross-sectional IC on fold dates only), decomposing the full-sample-vs-fold gap into period 0.0629 / aggregation 0.0000 - the entire gap is the window (folds cover 2012-01-23..2014-01-23, 10% of the panel). Removed the 'regime effects or data leakage' misdiagnosis (folds cannot leak). FIXED permutation test: null was built from 4,989 dates against an observed mean over 504, and independent within-date shuffling ignored the 21d label overlap; now blocks at the label horizon on fold dates only (null std 0.0015 -> 0.0145) with (r+1)/(B+1) p-value over 1000 perms (was p=0.0000 from 200, floor 0.005). Now reconciles with S3 (IC 0.0008, HAC t=0.19) as period dependence; states the factor's reversal character. Numbers unchanged elsewhere; scorecard export unaffected. Re-exec."
   },
   "papermill": {
    "default_parameters": {},

--- a/07_defining_the_learning_task/05_signal_evaluation.py
+++ b/07_defining_the_learning_task/05_signal_evaluation.py
@@ -87,7 +87,7 @@ SEED = 42
 OUTPUT_DIR = Path("07_defining_the_learning_task/output")
 START_DATE = "2006-01-01"
 MAX_SYMBOLS = 0
-N_PERMUTATIONS = 200
+N_PERMUTATIONS = 1000
 DECAY_HORIZONS = (1, 2, 3, 5, 7, 10, 15, 21, 42)
 N_SPLITS = 8
 
@@ -894,6 +894,7 @@ for i, (train_dates, test_dates) in enumerate(splits):
 # %%
 # Slice eval_df per fold (forward returns computed in §2)
 fold_results = []
+evaluated_dates: list = []  # every date inside a test window — needed for a like-for-like IC
 
 for fold_idx, (train_dates, test_dates) in enumerate(splits):
     test_data = eval_df.filter(pl.col("timestamp").is_in(test_dates))
@@ -933,6 +934,7 @@ for fold_idx, (train_dates, test_dates) in enumerate(splits):
     else:
         fold_mono = float("nan")
 
+    evaluated_dates.extend(test_dates)
     fold_results.append(
         {
             "fold": fold_idx + 1,
@@ -1025,77 +1027,127 @@ fig.show()
 # %% [markdown]
 # ### Interpretation: Full-Sample vs Fold-Level IC
 #
-# Both numbers below are cross-sectional means (per-date Spearman, then averaged);
-# they differ only in whether the dates come from the full sample or from disjoint
-# out-of-sample folds:
+# The obvious move is to read the full-sample IC against the fold-level mean and
+# call the difference an aggregation effect — the folds are out of sample, so a
+# gap looks like the honest shrinkage of an optimistic full-sample number.
 #
-# | Approach | IC | Interpretation |
-# |----------|-----|----------------|
-# | Full-sample cross-sectional | Mean per-date IC over all dates | Optimistic; uses every period |
-# | Fold-level mean | Mean per-date IC averaged across OOS folds | More realistic estimate |
-# | Fold-level std | Variation across folds | Measures stability |
+# That reading is only available if both statistics cover the **same dates**.
+# Ours do not. The full-sample IC averages every date in the panel. The fold-level
+# mean averages only dates inside a test window, and with `min_train_pct=0.3` and
+# eight 63-day folds those windows are roughly 500 consecutive dates near the
+# front of the sample. The two numbers describe different periods, so their
+# difference cannot be attributed to aggregation — or to leakage, which the folds
+# structurally cannot produce, since each fold's IC only ever touches its own test
+# dates.
 #
-# **Warning signs**:
-# - Fold IC varies wildly (high std) → regime-dependent signal
-# - Many folds with IC ≤ 0 → unreliable signal
-# - Full-sample IC >> Fold mean → possible overfitting
+# The way out is a third number: the same cross-sectional IC, restricted to
+# exactly the dates the folds evaluated. It splits the gap into two parts we can
+# name separately:
+#
+# | Comparison | Isolates |
+# |------------|----------|
+# | Fold-date IC vs full-sample IC | **Period** — is this window unrepresentative? |
+# | Fold-level mean vs fold-date IC | **Aggregation** — does averaging folds change anything? |
 
 # %%
-# Compare full-sample vs fold-level (both cross-sectional means)
+# The like-for-like statistic: same per-date Spearman, restricted to fold dates
+fold_window = eval_df.filter(pl.col("timestamp").is_in(evaluated_dates))
+fold_window_ics = []
+for date_df in fold_window.partition_by("timestamp"):
+    if len(date_df) < 10:
+        continue
+    corr, _ = spearmanr(date_df["factor"].to_numpy(), date_df["fwd_21d"].to_numpy())
+    if not np.isnan(corr):
+        fold_window_ics.append(corr)
+fold_window_ic = float(np.mean(fold_window_ics))
+
 full_sample_ic = result.ic.get("21D", float("nan"))
+n_all_dates = eval_df["timestamp"].n_unique()
+n_fold_dates = len(fold_window_ics)
 
-print("\n=== Full-Sample vs Fold-Level Comparison ===")
-print(f"Full-sample cross-sectional IC: {full_sample_ic:.4f}")
-print(f"Fold-level mean IC:             {fold_ic_mean:.4f}")
-print(f"Difference:                     {full_sample_ic - fold_ic_mean:.4f}")
+print("\n=== Like-for-Like IC Comparison (21D) ===")
+print(f"Full-sample cross-sectional IC ({n_all_dates:,} dates): {full_sample_ic:>8.4f}")
+print(f"Same statistic, fold dates only ({n_fold_dates:,} dates): {fold_window_ic:>8.4f}")
+print(f"Fold-level mean IC              ({n_fold_dates:,} dates): {fold_ic_mean:>8.4f}")
+print("\n--- Decomposition of the full-sample vs fold-level gap ---")
+print(
+    f"Period effect      (fold-date IC - full-sample IC): {fold_window_ic - full_sample_ic:>8.4f}"
+)
+print(f"Aggregation effect (fold mean    - fold-date IC):   {fold_ic_mean - fold_window_ic:>8.4f}")
 
-if abs(full_sample_ic - fold_ic_mean) > 0.01:
-    print("\n[WARNING] Significant difference between full-sample and fold-level IC.")
-    print("   This may indicate regime effects or data leakage.")
+fold_span = f"{min(evaluated_dates)} to {max(evaluated_dates)}"
+coverage_pct = 100 * n_fold_dates / n_all_dates
+print(f"\nFolds evaluate {fold_span} — {coverage_pct:.0f}% of the panel's dates.")
+if abs(fold_window_ic - full_sample_ic) > abs(fold_ic_mean - fold_window_ic):
+    print("[READ] The gap is a period effect: this window is not the average window.")
+    print("       It says nothing about overfitting, and nothing about leakage.")
 else:
-    print("\n[PASS] Full-sample and fold-level IC are consistent.")
+    print("[READ] The gap survives on identical dates, so it is an aggregation effect.")
 
 # %% [markdown]
 # ## 7.1 Within-Time Permutation Test
 #
 # The text (Section 7.3) recommends a **within-time permutation test** as a
-# null-distribution benchmark: shuffle asset-label assignments within each
-# cross-section, breaking the feature-label pairing while preserving cross-sectional
-# dependence. If the observed IC exceeds the permutation distribution, the feature
-# ranks the right assets — not just any assets.
+# null-distribution benchmark: break the feature-label pairing while preserving the
+# structure of the data, then ask how often chance alone reproduces the observed IC.
+# Two details decide whether the answer means anything.
+#
+# **The null must cover the same dates as the observed statistic.** A null built
+# from every date in the panel is a distribution of a mean over ~5,000 dates; our
+# observed statistic is a mean over ~500. The mean of a larger sample is mechanically
+# less dispersed, so such a null is too narrow by roughly $\sqrt{5000/500} \approx 3$
+# and would reject almost anything. We therefore permute only the fold dates.
+#
+# **The null must preserve temporal dependence.** Shuffling assets independently on
+# each date implies the per-date ICs are independent, so the null mean's standard
+# error shrinks like $\sigma/\sqrt{n_{\text{dates}}}$. Our labels are 21-day forward
+# returns sampled daily: consecutive dates share 20 of 21 days of return, so both the
+# returns and the per-date ICs are strongly autocorrelated, and the true standard
+# error is much larger. Independent within-date shuffling would understate it by
+# roughly an order of magnitude.
+#
+# The repair is a **block permutation**. We draw one asset relabeling per block of 21
+# sessions — the label horizon — and hold it fixed across the block. Within a block
+# each asset's return path stays intact, so the autocorrelation the observed IC
+# inherits also lives in the null; across blocks the relabelings are independent.
+# The null then answers the right question: *given how persistent this data is, how
+# often does a random assignment rank this well over this window?*
 
 # %%
-# Permutation test: shuffle labels within each date, recompute IC
-# Pre-compute group indices for vectorized permutation (avoids slow per-date Python loop)
+# Block permutation: one asset relabeling per BLOCK_SESSIONS, restricted to fold dates
 rng = np.random.default_rng(SEED)
 n_permutations = N_PERMUTATIONS
+BLOCK_SESSIONS = 21  # label horizon — blocks must be at least as long as the overlap
 
-dates_arr = eval_df["timestamp"].to_numpy()
-factors_arr = eval_df["factor"].to_numpy()
-returns_arr = eval_df["fwd_21d"].to_numpy()
+perm_df = fold_window.sort(["timestamp", "symbol"])
+dates_arr = perm_df["timestamp"].to_numpy()
+factors_arr = perm_df["factor"].to_numpy()
+returns_arr = perm_df["fwd_21d"].to_numpy()
+symbol_codes = perm_df["symbol"].cast(pl.Categorical).to_physical().to_numpy()
+n_symbols = int(symbol_codes.max()) + 1
 unique_dates_perm = np.unique(dates_arr)
 
-# Build date group indices once (avoid repeated masking)
-date_groups = []
-for d in unique_dates_perm:
-    idx = np.where(dates_arr == d)[0]
-    if len(idx) >= 10:
-        date_groups.append(idx)
+# Group rows by date; within a date, rows are already in symbol order
+date_groups = [np.where(dates_arr == d)[0] for d in unique_dates_perm]
+date_groups = [idx for idx in date_groups if len(idx) >= 10]
 
-# Pre-compute factor ranks per date (ranks don't change across permutations)
+# Ranks are invariant to relabeling, so pre-compute both sides once
 factor_ranks_by_group = [rankdata(factors_arr[idx]) for idx in date_groups]
+return_ranks_by_group = [rankdata(returns_arr[idx]) for idx in date_groups]
+symbols_by_group = [symbol_codes[idx] for idx in date_groups]
 
 # %%
 permuted_ics = []
 for _ in range(n_permutations):
-    # Shuffle returns within each date, compute rank correlation
     ic_per_date = []
-    for i, idx in enumerate(date_groups):
-        shuffled = rng.permutation(returns_arr[idx])
-        # Spearman = Pearson of ranks
-        r_ranks = rankdata(shuffled)
-        f_ranks = factor_ranks_by_group[i]
-        n = len(f_ranks)
+    block_keys = None
+    for i, f_ranks in enumerate(factor_ranks_by_group):
+        # New relabeling only when a block boundary is crossed
+        if i % BLOCK_SESSIONS == 0:
+            block_keys = rng.permutation(n_symbols)
+        # Same key vector across the block => same asset->asset mapping across the block
+        order = np.argsort(block_keys[symbols_by_group[i]], kind="stable")
+        r_ranks = return_ranks_by_group[i][order]
         corr = np.corrcoef(f_ranks, r_ranks)[0, 1]
         if not np.isnan(corr):
             ic_per_date.append(corr)
@@ -1103,16 +1155,22 @@ for _ in range(n_permutations):
         permuted_ics.append(np.mean(ic_per_date))
 
 permuted_ics = np.array(permuted_ics)
-observed_ic_mean = fold_ic_mean  # Use fold-level mean as the observed statistic
+# Observed statistic and null are now the same estimator on the same dates
+observed_ic_mean = fold_window_ic
 
-# p-value: fraction of permuted ICs >= observed
-p_value_perm = np.mean(permuted_ics >= observed_ic_mean)
+# (r + 1) / (B + 1): a permutation p-value can never be exactly zero — the observed
+# assignment is itself one of the arrangements under the null
+n_at_least = int(np.sum(permuted_ics >= observed_ic_mean))
+p_value_perm = (n_at_least + 1) / (len(permuted_ics) + 1)
 
-print("=== Within-Time Permutation Test ===\n")
+print("=== Within-Time Block Permutation Test ===\n")
+print(
+    f"Dates: {len(factor_ranks_by_group):,} (fold windows only, block = {BLOCK_SESSIONS} sessions)"
+)
 print(f"Observed mean IC: {observed_ic_mean:.4f}")
 print(f"Permutation null — mean: {permuted_ics.mean():.4f}, std: {permuted_ics.std():.4f}")
 print(f"Permutation p-value (one-sided): {p_value_perm:.4f}")
-print(f"Permutations: {n_permutations}")
+print(f"Permutations: {n_permutations} (finest resolvable p = {1 / (n_permutations + 1):.4f})")
 
 # %%
 # Visualize permutation distribution vs observed IC
@@ -1134,8 +1192,8 @@ fig.add_vline(
     annotation_text=f"Observed IC={observed_ic_mean:.4f}",
 )
 fig.update_layout(
-    title="Observed IC sits far outside the within-time permutation null",
-    xaxis_title="Mean IC (permuted)",
+    title="Within its own window, the factor ranks better than a dependence-aware null",
+    xaxis_title="Mean IC (block-permuted, fold dates only)",
     yaxis_title="Count",
     height=350,
     showlegend=False,
@@ -1143,10 +1201,34 @@ fig.update_layout(
 fig.show()
 
 # %% [markdown]
-# **Interpretation**: The permutation test asks whether the observed IC could arise
-# from a random assignment of labels to assets within each cross-section. A p-value
-# near zero confirms that the feature genuinely ranks the right assets at each
-# decision time — the signal is not an artifact of cross-sectional dependence.
+# **Interpretation**: over the fold window, the observed IC sits outside every block
+# permutation, so the factor ranked ETFs better than chance *in 2012-2014*. That is
+# the only claim the test supports, and it is worth being precise about why.
+#
+# Read it against §3, which scored the same factor at IC 0.0008 with a HAC
+# $t = 0.19$ over the full sample. These are not opposing verdicts about one
+# quantity — they are two different windows, as the decomposition above showed: the
+# entire full-sample-vs-fold gap was a period effect, with aggregation contributing
+# 0.0000. The factor worked in the folds' two years and does nothing over twenty.
+# The folds are not a verdict on the signal; they are a verdict on 2012-2014.
+#
+# Two lessons generalize past this factor:
+#
+# - **A window that flatters the signal is the default outcome, not a surprise.**
+#   `min_train_pct=0.3` with eight 63-day folds evaluates the first 10% of the
+#   panel and never scores 2014 onward. A fold scheme that leaves most of the
+#   sample unevaluated cannot support a claim about the sample.
+# - **A null must be as dependent as the data.** Independent within-date shuffling
+#   put the null's standard deviation near 0.0015; blocking at the label horizon
+#   puts it near 0.0145 — roughly ten times wider, on identical dates. The first
+#   null would have called almost any factor significant, which is what a null this
+#   narrow always does.
+#
+# The rest of the evidence points the other way, and §4 already showed it: the
+# full-sample quintile spread is **negative** at every horizon and monotonicity is
+# -90%, meaning Q1 out-earns Q5. Cross-sectional 21-day ETF momentum is a
+# **reversal** signal over this panel. A single favorable window does not overturn
+# that; it illustrates how easily a fold scheme can hide it.
 
 # %% [markdown]
 # ## 8. Factor Scorecard Output

--- a/case_studies/cme_futures/config/setup.yaml
+++ b/case_studies/cme_futures/config/setup.yaml
@@ -113,15 +113,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-short equal-weight top-k on both
     # label horizons; long-short is enforced at the backtest config level
     # (allow_short_selling=true).

--- a/case_studies/crypto_perps_funding/config/setup.yaml
+++ b/case_studies/crypto_perps_funding/config/setup.yaml
@@ -81,15 +81,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-short by construction. With only
     # ~20 perps, every label exercises both top-k and quintile axes.
     top_k_grid:

--- a/case_studies/etfs/01_feasibility_analysis.ipynb
+++ b/case_studies/etfs/01_feasibility_analysis.ipynb
@@ -1502,11 +1502,11 @@
     "- **KC1 (IC floor)**: IC < 0.01 with t-stat < 2.0 across all lookback horizons\n",
     "  (3M-12M). Gate: Chapter 8 feature evaluation.\n",
     "- **KC2 (edge-cost)**: Edge-to-cost ratio < 1.0x after realistic transaction\n",
-    "  costs. Gate: Chapter 7 label evaluation / Chapter 17 backtest. B.4 above\n",
+    "  costs. Gate: Chapter 7 label evaluation / Chapter 16 backtest. B.4 above\n",
     "  tests this gate on raw return magnitudes before the model is even trained.\n",
     "- **KC3 (EW underperformance)**: Equal-weight benchmark posts a higher Sharpe\n",
     "  and lower max drawdown than the strategy across all test folds. Gate:\n",
-    "  Chapter 17 backtest."
+    "  Chapter 16 backtest."
    ]
   },
   {
@@ -1531,7 +1531,7 @@
     "construction, and (c) it isolates the ranking signal from short-side\n",
     "complexity. Equal-weight is the minimal-assumption sizing rule---it avoids\n",
     "introducing a secondary optimization (risk-parity, inverse-vol) that would\n",
-    "confound evaluation of the ranking signal itself. Chapter 18 explores\n",
+    "confound evaluation of the ranking signal itself. Chapter 17 explores\n",
     "alternative weighting schemes via the `backtest.sweep.allocators` grid in\n",
     "`setup.yaml`."
    ]
@@ -2213,7 +2213,7 @@
     "   weekly tested as a variant via `labels.variants: [fwd_ret_5d]`.\n",
     "4. **Mapping**: Long-only equal-weight top-N as simplest credible baseline;\n",
     "   alternative allocators sweep in `setup.yaml::backtest.sweep.allocators`\n",
-    "   (explored in Chapter 17--18).\n",
+    "   (explored in Chapter 17).\n",
     "5. **Evaluation**: 8 walk-forward folds with verified holdout separation\n",
     "   (`evaluation.holdout_start` enforced).\n",
     "6. **Kill conditions**: KC2 (edge-to-cost > 1.0x) already cleared---feasibility\n",

--- a/case_studies/etfs/01_feasibility_analysis.py
+++ b/case_studies/etfs/01_feasibility_analysis.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.19.1
+#       jupytext_version: 1.19.3
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -643,11 +643,11 @@ print(f"Assessment: {'PROCEED' if feasibility_ratio > 1.0 else 'KILL -- edge too
 # - **KC1 (IC floor)**: IC < 0.01 with t-stat < 2.0 across all lookback horizons
 #   (3M-12M). Gate: Chapter 8 feature evaluation.
 # - **KC2 (edge-cost)**: Edge-to-cost ratio < 1.0x after realistic transaction
-#   costs. Gate: Chapter 7 label evaluation / Chapter 17 backtest. B.4 above
+#   costs. Gate: Chapter 7 label evaluation / Chapter 16 backtest. B.4 above
 #   tests this gate on raw return magnitudes before the model is even trained.
 # - **KC3 (EW underperformance)**: Equal-weight benchmark posts a higher Sharpe
 #   and lower max drawdown than the strategy across all test folds. Gate:
-#   Chapter 17 backtest.
+#   Chapter 16 backtest.
 
 # %% [markdown]
 # ### C.3 Mapping Class
@@ -659,7 +659,7 @@ print(f"Assessment: {'PROCEED' if feasibility_ratio > 1.0 else 'KILL -- edge too
 # construction, and (c) it isolates the ranking signal from short-side
 # complexity. Equal-weight is the minimal-assumption sizing rule---it avoids
 # introducing a secondary optimization (risk-parity, inverse-vol) that would
-# confound evaluation of the ranking signal itself. Chapter 18 explores
+# confound evaluation of the ranking signal itself. Chapter 17 explores
 # alternative weighting schemes via the `backtest.sweep.allocators` grid in
 # `setup.yaml`.
 
@@ -919,7 +919,7 @@ print(f"Written: {report_path}")
 #    weekly tested as a variant via `labels.variants: [fwd_ret_5d]`.
 # 4. **Mapping**: Long-only equal-weight top-N as simplest credible baseline;
 #    alternative allocators sweep in `setup.yaml::backtest.sweep.allocators`
-#    (explored in Chapter 17--18).
+#    (explored in Chapter 17).
 # 5. **Evaluation**: 8 walk-forward folds with verified holdout separation
 #    (`evaluation.holdout_start` enforced).
 # 6. **Kill conditions**: KC2 (edge-to-cost > 1.0x) already cleared---feasibility

--- a/case_studies/etfs/config/setup.yaml
+++ b/case_studies/etfs/config/setup.yaml
@@ -200,15 +200,16 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
+    # ETFs only: each advancing config contributes its best TWO checkpoints.
+    # latent_factors/sdf reaches its highest allocation-stage Sharpe on its
+    # second-best checkpoint; at 1 that prediction never enters the sweep.
+    checkpoints_per_config: 2
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-only equal-weight top-k. Percentile
     # and quantile axes are commented out; uncomment to add them for any
     # label and the loader will synthesize the schemes automatically.

--- a/case_studies/fx_pairs/config/setup.yaml
+++ b/case_studies/fx_pairs/config/setup.yaml
@@ -76,15 +76,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-short equal-weight top-k on all
     # three label horizons; long-short is enforced at the backtest config
     # level (allow_short_selling=true).

--- a/case_studies/nasdaq100_microstructure/config/setup.yaml
+++ b/case_studies/nasdaq100_microstructure/config/setup.yaml
@@ -325,8 +325,7 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 0   # nasdaq has no expensive allocators (see expensive_allocators below)
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # No expensive allocators on nasdaq. At 15-min frequency the 1.3M-bar
@@ -337,7 +336,6 @@ backtest:
     # cadence is a costs-dominated regime where signal-stage selection
     # carries the entire story.
     expensive_allocators_skip: true
-    expensive_allocators: []
     # Ch16 signal-stage selection. Long-short equal-weight top-k on the
     # 15-min schedule across four labels (5m/15m/60m continuous + 15m
     # direction). The classification label fwd_dir_15m is a first-class
@@ -349,7 +347,8 @@ backtest:
       fwd_ret_60m: [5, 10, 20]
       fwd_dir_15m: [5, 10, 20]
     # Ch17 portfolio: reuses top_k_grid above and sweeps over allocators.
-    # Cheap tier only on nasdaq (see ``expensive_allocators`` above).
+    # Nasdaq runs only the three fast allocators — the moment-based ones are
+    # too slow at intraday frequency (``expensive_allocators_skip: true``).
     # No max_weight cap on inverse_vol — see
     # memory/feedback_max_weight_caps_intentionally_absent.md (would force
     # equal-weight at top_k=5 and defeat the moment-allocator comparison).

--- a/case_studies/sp500_equity_option_analytics/config/setup.yaml
+++ b/case_studies/sp500_equity_option_analytics/config/setup.yaml
@@ -75,15 +75,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-only equal-weight top-k for every
     # label.
     top_k_grid:

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -4,6 +4,10 @@ setup_version: v1
 universe:
   underlying: sp500_constituents
   strategy: atm_straddle
+  # Distinct S&P 500 underlyings with listed options in the tradable price panel
+  # over the full sample (includes index membership churn). Display metadata only
+  # (read by 03_case_study_overview); the backtest counts assets from data.
+  n_assets: 627
 
 decision:
   entry_cadence: weekly_friday
@@ -102,15 +106,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp]
     # Ch16 signal-stage selection. Long-only equal-weight top-k: the short
     # straddle sign convention is handled by the label construction, not
     # by long_short=True.

--- a/case_studies/us_equities_panel/config/setup.yaml
+++ b/case_studies/us_equities_panel/config/setup.yaml
@@ -85,15 +85,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted, inverse_vol — all signal preds
-      allocation_expensive: 10  # risk_parity, mvo_ledoit_wolf, hrp — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted, inverse_vol) take the cheap path.
-    expensive_allocators: [risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted]
     # Ch16 signal-stage selection. Long-short equal-weight top-k on three
     # label horizons (1d primary, 5d/21d variants). The wider top-k grid
     # reflects the larger universe (~3000 names vs ETFs' 100).

--- a/case_studies/us_firm_characteristics/config/setup.yaml
+++ b/case_studies/us_firm_characteristics/config/setup.yaml
@@ -7,6 +7,10 @@ universe:
   exclusions: [ADRs, REITs, financials]
   identifiers: anonymized_permno_based
   note: Filters applied by the data provider before anonymization; cannot be independently verified.
+  # Curated universe size (~2,500 stocks after the filters above); matches the
+  # README and the 10_model_analysis default. Display metadata only (read by
+  # 03_case_study_overview); the backtest counts assets from data.
+  n_assets: 2500
 
 decision:
   cadence: monthly_month_end
@@ -105,15 +109,12 @@ backtest:
     # Notebooks read these via get_top_n_predictions(case_study, stage).
     top_n_predictions:
       signal: 0                 # all signal predictions (eq-weight baseline)
-      allocation_cheap: 0       # score_weighted — all signal preds
-      allocation_expensive: 10  # conformal_weighted — top-10 by signal Sharpe
+      allocation: 10            # top-10 model configs by equal-weight baseline Sharpe
       cost_sensitivity: 1       # top-1 of {signal+allocation} per label
       risk_overlay: 1           # top-1 of {signal+allocation} per label
     # Skip MVO/HRP when allocator runtime is the bottleneck (intraday CSes).
     expensive_allocators_skip: false
-    # Allocators routed through ``allocation_expensive`` (top-10 by signal Sharpe).
     # All others (equal_weight, score_weighted) take the cheap path.
-    expensive_allocators: [conformal_weighted]
     # Ch16 backtest is equal-weight sized within the selected set. The
     # selection rule is one of: top-k (rank), percentile band (long-only
     # cutoff), or quantile buckets (e.g. quintile long-short — combines

--- a/case_studies/utils/backtest_loaders.py
+++ b/case_studies/utils/backtest_loaders.py
@@ -648,10 +648,27 @@ _PRICE_CONFIG = {
     "cme_futures": {
         "entity_col": "product",
         "time_col": "session_date",
-        "close_col": "close",
+        "close_col": "adj_close",
         "ohlcv": True,
         "loader": "cme_futures",
-        "drop_cols": ["bar_count", "session_start", "session_end"],
+        # Backtest fills ride the roll-adjusted series (continuous PnL); rename
+        # adj_* → bare OHLC and drop the raw term-structure series + roll multiplier.
+        "rename_cols": {
+            "adj_open": "open",
+            "adj_high": "high",
+            "adj_low": "low",
+            "adj_close": "close",
+        },
+        "drop_cols": [
+            "raw_open",
+            "raw_high",
+            "raw_low",
+            "raw_close",
+            "cum_ratio",
+            "bar_count",
+            "session_start",
+            "session_end",
+        ],
         "filter": {"tenor": 0},  # Front-month only
     },
     "sp500_options": {

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -118,6 +118,7 @@ def manual_dml_timeseries(
     model_t=None,
     return_residuals: bool = False,
     hac_maxlags: int | None = None,
+    horizon: int | None = None,
 ) -> dict:
     """Walk-forward DML with embargo for temporal data.
 
@@ -144,7 +145,16 @@ def manual_dml_timeseries(
     return_residuals : bool
         If True, include residual arrays in result dict.
     hac_maxlags : int or None
-        HAC (Newey-West) bandwidth. If None, uses cube-root rule: max(1, int(n**(1/3))).
+        HAC (Newey-West) bandwidth. If given, used verbatim. If None, resolved
+        from `horizon` (see below).
+    horizon : int or None
+        Label horizon in observation periods. Overlapping h-period forward
+        returns induce MA(h-1) structure, so the HAC bandwidth must satisfy
+        L >= h - 1. When `hac_maxlags` is None, the bandwidth is
+        `max(horizon - 1, cube-root-of-n)` if `horizon` is given, else the
+        cube-root rule alone. Pass this for any overlapping label of horizon
+        >= ~10 periods, or the standard error is understated and the
+        t-statistic overstated.
 
     Returns
     -------
@@ -216,7 +226,11 @@ def manual_dml_timeseries(
     # Must include intercept: cross-fitting residuals may have non-zero mean
     # when training data varies across folds (expanding window).
     if hac_maxlags is None:
-        hac_maxlags = max(1, int(n_valid ** (1 / 3)))
+        auto = max(1, int(n_valid ** (1 / 3)))
+        # Overlapping h-period labels need L >= h-1; the cube-root rule is
+        # horizon-blind and under-lags long-horizon overlapping returns.
+        hac_maxlags = max(horizon - 1, auto) if horizon else auto
+        hac_maxlags = min(hac_maxlags, max(1, n_valid // 2))
 
     T_const = sm.add_constant(T_v)
     ols_iid = OLS(Y_v, T_const).fit()
@@ -284,6 +298,7 @@ def run_dml_analysis(
     block_size: int = 21,
     seed: int = 42,
     hac_maxlags: int | None = None,
+    horizon: int | None = None,
 ) -> dict:
     """Full DML analysis pipeline: naive OLS, DML, and refutation tests.
 
@@ -308,7 +323,15 @@ def run_dml_analysis(
     seed : int
         Random seed.
     hac_maxlags : int or None
-        HAC bandwidth. If None, uses cube-root rule.
+        HAC bandwidth passed through to the second stage. If None, resolved
+        from `horizon`.
+    horizon : int or None
+        Label horizon in observation periods, forwarded to the second-stage
+        HAC regression so the Newey-West bandwidth satisfies L >= horizon - 1.
+        Pass it for overlapping labels (horizon >= ~10) — e.g.
+        `horizon=embargo_from_buffer(mds.label_buffer)`. When both `horizon`
+        and `hac_maxlags` are None, the bandwidth falls back to the
+        horizon-blind cube-root rule and a warning is emitted.
 
     Returns
     -------
@@ -329,6 +352,17 @@ def run_dml_analysis(
         raise ValueError(f"Treatment '{treatment_col}' has near-zero variance")
     if df[outcome_col].std() < 1e-10:
         raise ValueError(f"Outcome '{outcome_col}' has near-zero variance")
+
+    if hac_maxlags is None and horizon is None:
+        import warnings
+
+        warnings.warn(
+            "run_dml_analysis: no horizon or hac_maxlags given; the second-stage "
+            "HAC bandwidth falls back to the horizon-blind cube-root rule, which "
+            "under-lags overlapping labels of horizon >= ~10 and overstates the "
+            "t-statistic. Pass horizon=embargo_from_buffer(mds.label_buffer).",
+            stacklevel=2,
+        )
 
     _dml_started_at = datetime.now(UTC).isoformat()
     _dml_t0 = time.perf_counter()
@@ -353,6 +387,7 @@ def run_dml_analysis(
         embargo=embargo,
         return_residuals=True,
         hac_maxlags=hac_maxlags,
+        horizon=horizon,
     )
 
     # Confounding bias
@@ -416,7 +451,7 @@ def format_dml_summary(results: dict) -> str:
         "DML ANALYSIS SUMMARY",
         "=" * 60,
         f"Observations: {results['n_obs']:,}",
-        f"HAC bandwidth: {hac_lags} lags (cube-root rule)",
+        f"HAC bandwidth: {hac_lags} lags (max of horizon-1 and cube-root)",
         "",
         f"Naive OLS effect:  {results['naive_effect']:.6f}",
         f"DML effect:        {dml['theta']:.6f}",

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -298,7 +298,10 @@ def _load_base_target_frame(
             .sort(["product", "position", "timestamp"])
             .with_columns(
                 (
-                    (pl.col("close") / pl.col("close").shift(1).over(["product", "position"])).log()
+                    (
+                        pl.col("adj_close")
+                        / pl.col("adj_close").shift(1).over(["product", "position"])
+                    ).log()
                 ).alias(BASE_TARGET_COL)
             )
             .select(["timestamp", "product", "position", BASE_TARGET_COL])

--- a/case_studies/utils/registry/__init__.py
+++ b/case_studies/utils/registry/__init__.py
@@ -93,6 +93,7 @@ from .registration import (
     register_backtest_fold_metrics,
     register_backtest_metrics,
     register_backtest_run,
+    register_cohort_metrics,
     register_epoch_checkpoint,
     register_fold_metrics,
     register_paired_metrics,
@@ -146,6 +147,7 @@ __all__ = [
     "register_backtest_metrics",
     "register_backtest_fold_metrics",
     "register_paired_metrics",
+    "register_cohort_metrics",
     # completeness
     "TrainingRunStatus",
     "BacktestRunStatus",

--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -259,14 +259,33 @@ def _infer_horizon_from_label(label: str | None) -> int:
     `fwd_ret_5d` -> 5, `fwd_dir_21d` -> 21, `fwd_class_1m` -> 21,
     `fwd_carry_8h` -> 1 (one 8h bar). Defaults to 1 when label is missing.
     Callers should always pass `label=` so the HAC lag matches horizon-1.
+
+    Some deployed labels carry no `<number><unit>` token. `ret_to_expiry`
+    (S&P 500 options, hold-to-expiry) overlaps ~35 trading days per its
+    `buffer: 35D` setup — resolving it to 1 silently under-lags the HAC
+    bandwidth (this was the Ch13 §13.9 exposure). It is resolved by name here.
+    Any *other* non-parsing label triggers a warning and a conservative
+    fallback of 1; the caller should pass an explicit horizon at the call site.
     """
     if not label:
         return 1
     import re
 
     s = label.lower()
+    # Named horizons for labels that do not carry a <number><unit> token.
+    if "to_expiry" in s:
+        return 35
     m = re.search(r"(\d+)\s*([dhwm])", s)
     if not m:
+        import warnings
+
+        warnings.warn(
+            f"_infer_horizon_from_label: label {label!r} has no <number><unit> "
+            "token and is not a named horizon; defaulting to horizon=1, which "
+            "under-lags the HAC bandwidth for any overlapping label. Pass an "
+            "explicit horizon at the call site.",
+            stacklevel=2,
+        )
         return 1
     n = int(m.group(1))
     unit = m.group(2)

--- a/case_studies/utils/registry/queries.py
+++ b/case_studies/utils/registry/queries.py
@@ -713,6 +713,7 @@ def resolve_best_predictions(
     stage: str = "signal",
     chapter_filter: str | None = None,
     case_dir: Path | None = None,
+    checkpoints_per_config: int = 1,
 ):
     """Return top-N prediction hashes ranked by backtest Sharpe at a given stage.
 
@@ -733,13 +734,17 @@ def resolve_best_predictions(
         holdout predictions over validation, which produces NULL
         allocation/cost/risk rows in chapter prose.
     top_n : int
-        Number of top predictions to return.
+        Number of top model configs to return. The unit is a distinct
+        ``(family, config_name)``, not a prediction: with
+        ``checkpoints_per_config > 1`` the frame holds more than ``top_n`` rows.
     stage : str
         Pipeline stage to filter by: "signal", "allocation", etc.
     chapter_filter : str, optional
         Chapter-based filter (e.g. "ch16"). Converted to stage internally.
     case_dir : Path, optional
         Override case study directory.
+    checkpoints_per_config : int
+        How many checkpoints each advancing config contributes, best first.
 
     Returns
     -------
@@ -757,15 +762,17 @@ def resolve_best_predictions(
         logger.warning("No registry.db found for '%s'", case_study)
         return pl.DataFrame(schema=_BEST_PREDICTIONS_SCHEMA)
 
-    # Find top-N distinct model configs, each represented by its best checkpoint.
+    # Find top-N distinct model configs, each represented by its best
+    # ``checkpoints_per_config`` checkpoints.
     #
     # A single model config (e.g., latent_factors/sae) may have many prediction
     # hashes — one per checkpoint epoch. Without dedup, the top-N list can be
     # dominated by checkpoints of a single model, hiding model diversity.
     #
-    # Two-stage approach:
-    #   1. Inner: best Sharpe per (family, config_name) — one row per distinct config
-    #   2. Outer: rank configs, take top_n, resolve back to the actual prediction_hash
+    # Three-stage approach:
+    #   1. per_prediction: best Sharpe per prediction_hash
+    #   2. top_configs:    rank (family, config_name) by their best Sharpe, take top_n
+    #   3. ranked:         within each advancing config, keep its best N checkpoints
     #
     # Prefer stage column; fall back to spec_json LIKE for un-migrated DBs.
     stage_clause, stage_params = _stage_filter_clause(stage, chapter_filter)
@@ -778,6 +785,7 @@ def resolve_best_predictions(
         split_clause = "AND p.split = ?"
         params.append(split)
     params.append(str(top_n))
+    params.append(str(max(1, int(checkpoints_per_config))))
 
     query = f"""
         WITH per_prediction AS (
@@ -803,14 +811,25 @@ def resolve_best_predictions(
               {split_clause}
             GROUP BY p.prediction_hash
         ),
-        best_per_config AS (
-            -- Best checkpoint per (family, config_name): one row per distinct model
-            SELECT *,
-                ROW_NUMBER() OVER (
-                    PARTITION BY family, config_name
-                    ORDER BY sharpe DESC, checkpoint_value DESC
-                ) AS rn
+        top_configs AS (
+            -- The advancing model configs, ranked by their best checkpoint's Sharpe
+            SELECT family, config_name
             FROM per_prediction
+            GROUP BY family, config_name
+            ORDER BY MAX(sharpe) DESC
+            LIMIT ?
+        ),
+        ranked AS (
+            -- Rank checkpoints within each advancing config, best first
+            SELECT pp.*,
+                ROW_NUMBER() OVER (
+                    PARTITION BY pp.family, pp.config_name
+                    ORDER BY pp.sharpe DESC, pp.checkpoint_value DESC
+                ) AS rn
+            FROM per_prediction pp
+            JOIN top_configs tc
+              ON pp.family = tc.family
+             AND pp.config_name IS tc.config_name
         )
         SELECT
             prediction_hash,
@@ -821,10 +840,9 @@ def resolve_best_predictions(
             split,
             checkpoint_value,
             sharpe
-        FROM best_per_config
-        WHERE rn = 1
+        FROM ranked
+        WHERE rn <= CAST(? AS INTEGER)
         ORDER BY sharpe DESC
-        LIMIT ?
     """
 
     df = _query_table(case_dir, query, tuple(params))

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -822,6 +822,111 @@ def register_paired_metrics(
 
 
 # ---------------------------------------------------------------------------
+# Registration: Selection-bias cohort metrics (cohort_metrics table)
+# ---------------------------------------------------------------------------
+
+
+# Identity + meta columns that the caller supplies out-of-band; every other
+# key in a cohort's ``metrics`` dict is a bare cohort_metrics column name
+# (matching the flat dict returned by ``compute_cohort_metrics``).
+_COHORT_META_COLS = ("leader_hash", "k_variants", "periods_per_year", "computed_at")
+
+
+def register_cohort_metrics(
+    case_study: str,
+    cohorts: list[dict],
+    *,
+    prune_dangling: bool = True,
+    case_dir: Path | None = None,
+) -> int:
+    """Persist selection-bias cohort rows to ``cohort_metrics``.
+
+    Each entry in ``cohorts`` is a dict with keys ``cohort_type``, ``stage``,
+    ``label``, ``family`` and ``metrics`` — the last being the flat dict
+    returned by :func:`case_studies.utils.uncertainty.compute_cohort_metrics`,
+    which carries ``leader_hash``, ``k_variants``, ``periods_per_year`` and the
+    DSR / RAS / reality-check / PBO columns. Rows are keyed by the
+    ``(cohort_type, stage, label, family)`` identity (matching
+    ``idx_cohort_unique``); an existing row with that identity is replaced.
+
+    When ``prune_dangling`` is set (default), cohort rows whose ``leader_hash``
+    no longer maps to a ``backtest_runs`` row are removed after the writes, so a
+    post-rerun leader shift cannot leave a stale leader row behind.
+
+    Returns the number of dangling rows pruned.
+    """
+    if case_dir is None:
+        case_dir = _case_dir(case_study)
+
+    db = _open_registry(case_dir)
+    try:
+        for c in cohorts:
+            metrics = dict(c["metrics"])  # copy — we pop meta keys below
+            leader_hash = metrics.pop("leader_hash")
+            k_variants = metrics.pop("k_variants")
+            ppy = metrics.pop("periods_per_year")
+            computed_at = metrics.pop("computed_at", None) or _utc_now()
+
+            cohort_type = c["cohort_type"]
+            stage = c.get("stage")
+            label = c["label"]
+            family = c.get("family")
+
+            cols = [
+                "cohort_type",
+                "stage",
+                "label",
+                "family",
+                "leader_hash",
+                "k_variants",
+                "periods_per_year",
+                "computed_at",
+            ]
+            vals: list[object] = [
+                cohort_type,
+                stage,
+                label,
+                family,
+                leader_hash,
+                k_variants,
+                ppy,
+                computed_at,
+            ]
+            for k, v in metrics.items():
+                cols.append(k)
+                vals.append(v)
+
+            # Explicit REPLACE semantics on the identity index (DELETE + INSERT).
+            db.execute(
+                """
+                DELETE FROM cohort_metrics
+                WHERE cohort_type = ?
+                  AND COALESCE(stage, '') = COALESCE(?, '')
+                  AND label = ?
+                  AND COALESCE(family, '') = COALESCE(?, '')
+                """,
+                (cohort_type, stage, label, family),
+            )
+            placeholders = ",".join("?" * len(vals))
+            db.execute(
+                f"INSERT INTO cohort_metrics ({','.join(cols)}) VALUES ({placeholders})",
+                vals,
+            )
+
+        n_pruned = 0
+        if prune_dangling:
+            cur = db.execute(
+                "DELETE FROM cohort_metrics "
+                "WHERE leader_hash NOT IN (SELECT backtest_hash FROM backtest_runs)"
+            )
+            n_pruned = cur.rowcount or 0
+        db.commit()
+        return n_pruned
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # Registration: Causal-DML runs (dedicated causal_runs table)
 # ---------------------------------------------------------------------------
 

--- a/case_studies/utils/registry/specs.py
+++ b/case_studies/utils/registry/specs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -71,12 +72,40 @@ def prediction_hash_from_parts(
     return compute_hash(f"{training_hash}|{cp}|{split}")
 
 
+# Provenance keys under ``backtest_config.metadata`` that must NOT enter the
+# backtest hash: they record where/how a run was launched, not the strategy's
+# identity. ``preset_path`` is an absolute filesystem path — ``/home/.../base.yaml``
+# on the host vs ``/app/.../base.yaml`` in Docker — so including it made the hash
+# non-portable: re-running a sweep from a different path recomputed every hash and
+# silently duplicated the registry. Stripping it here keeps ``spec_json`` (stored
+# separately) fully intact for provenance while making the hash path-independent.
+_HASH_EXCLUDED_METADATA = ("preset_path",)
+
+
+def _hashable_strategy_spec(strategy_spec: dict) -> dict:
+    """Copy of *strategy_spec* with non-portable provenance stripped for hashing."""
+    spec = copy.deepcopy(strategy_spec)
+    backtest_config = spec.get("backtest_config")
+    if isinstance(backtest_config, dict):
+        metadata = backtest_config.get("metadata")
+        if isinstance(metadata, dict):
+            for key in _HASH_EXCLUDED_METADATA:
+                metadata.pop(key, None)
+    return spec
+
+
 def backtest_hash_from_parts(
     prediction_hash: str,
     strategy_spec: dict,
 ) -> str:
-    """Compute backtest_hash from prediction_hash + strategy spec."""
-    return compute_hash(f"{prediction_hash}|{canonical_json(strategy_spec)}")
+    """Compute backtest_hash from prediction_hash + strategy spec.
+
+    Non-portable provenance (see ``_HASH_EXCLUDED_METADATA``) is stripped before
+    hashing so the same strategy hashes identically regardless of where it runs.
+    """
+    return compute_hash(
+        f"{prediction_hash}|{canonical_json(_hashable_strategy_spec(strategy_spec))}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -285,13 +285,24 @@ CIStatus = Literal["excludes_zero_strong", "straddles_zero", "no_data"]
 GateStatus = Literal["pass", "fail", "no_data"]
 
 
+def _missing(x: float | None) -> bool:
+    """True when a bound/estimate carries no information.
+
+    NaN reaches these gates whenever a paired bootstrap could not be computed
+    (no pair row in ``backtest_paired_metrics``). It must be treated exactly
+    like ``None``: every comparison against NaN is False, so an unguarded NaN
+    silently falls through to ``pass``.
+    """
+    return x is None or not np.isfinite(x)
+
+
 def ci_status(lo: float | None, hi: float | None) -> CIStatus:
     """Three-tier CI continuum used uniformly across spine §3 / §6 / §7.
 
     `no_data` is reserved for missing CI bounds (upstream bootstrap not run
     or registry NULLs); it is *not* a low-credibility classification.
     """
-    if lo is None or hi is None:
+    if _missing(lo) or _missing(hi):
         return "no_data"
     if lo > 0 or hi < 0:
         return "excludes_zero_strong"
@@ -303,7 +314,7 @@ def gate1_validation_sharpe_geq_zero(sharpe_ci_lo: float | None) -> GateStatus:
 
     Returns ``no_data`` when the CI lower bound is missing.
     """
-    if sharpe_ci_lo is None:
+    if _missing(sharpe_ci_lo):
         return "no_data"
     return "pass" if sharpe_ci_lo >= 0 else "fail"
 
@@ -319,7 +330,7 @@ def gate2_holdout_diff_not_excludes_zero_negatively(
     point estimate is negative. ``no_data`` when the diff CI status is
     ``no_data`` or ``sharpe_diff`` is missing.
     """
-    if diff_ci_status == "no_data" or sharpe_diff is None:
+    if diff_ci_status == "no_data" or _missing(sharpe_diff):
         return "no_data"
     if diff_ci_status == "excludes_zero_strong" and sharpe_diff < 0:
         return "fail"

--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -199,25 +199,26 @@ def get_allocator_lookback(case_study: str) -> int:
 
 
 _STAGE_DEFAULTS = {
-    "signal": 0,  # 0 = all predictions
-    "allocation": 10,  # legacy uniform-allocator key (notebooks pre-tier-split)
-    "allocation_cheap": 0,  # post-tier-split: cheap allocators see all signal preds
-    "allocation_expensive": 10,  # post-tier-split: expensive allocators see top-10 by signal Sharpe
+    "signal": 0,  # 0 = all predictions (equal-weight baseline)
+    "allocation": 10,  # top-10 model configs by baseline Sharpe
     "cost_sensitivity": 1,  # top-1 of {signal+allocation} per label
     "risk_overlay": 1,  # top-1 of {signal+allocation} per label
 }
 
-_DEFAULT_EXPENSIVE_ALLOCATORS: tuple[str, ...] = ("risk_parity", "mvo_ledoit_wolf", "hrp")
+_DEFAULT_CHECKPOINTS_PER_CONFIG = 1
 
 
 def get_top_n_predictions(case_study: str, stage: str) -> int:
     """Return the top-N predictions to feed into ``stage`` from the upstream stage.
 
     Reads ``backtest.sweep.top_n_predictions[stage]`` with safe fallbacks.
-    ``stage`` is one of ``signal | allocation | allocation_cheap | allocation_expensive
-    | cost_sensitivity | risk_overlay``. Unknown stage names raise ``ValueError``
-    rather than ``KeyError`` so the stack trace clearly distinguishes a typo'd
-    lookup from a missing key in the YAML.
+    ``stage`` is one of ``signal | allocation | cost_sensitivity | risk_overlay``.
+    Unknown stage names raise ``ValueError`` rather than ``KeyError`` so the stack
+    trace clearly distinguishes a typo'd lookup from a missing key in the YAML.
+
+    For ``allocation`` the unit counted is a *model config* — one ``(family,
+    config_name)`` pair — not a prediction. See ``get_checkpoints_per_config``
+    for how many checkpoints each advancing config contributes.
     """
     if stage not in _STAGE_DEFAULTS:
         raise ValueError(f"unknown stage {stage!r}; expected one of {sorted(_STAGE_DEFAULTS)}")
@@ -225,24 +226,22 @@ def get_top_n_predictions(case_study: str, stage: str) -> int:
     return int(block.get(stage, _STAGE_DEFAULTS[stage]))
 
 
+def get_checkpoints_per_config(case_study: str) -> int:
+    """Return how many checkpoints each advancing model config contributes.
+
+    Reads ``backtest.sweep.checkpoints_per_config``. The default of 1 means a
+    config enters the allocation sweep through its single best checkpoint, so
+    a long checkpoint sweep of one model cannot crowd out other model families.
+    """
+    value = load_sweep(case_study).get("checkpoints_per_config")
+    if value is None:
+        return _DEFAULT_CHECKPOINTS_PER_CONFIG
+    return int(value)
+
+
 def get_expensive_allocators_skip(case_study: str) -> bool:
     """Return whether MVO/HRP should be skipped at Ch17 (intraday escape hatch)."""
     return bool(load_sweep(case_study).get("expensive_allocators_skip", False))
-
-
-def get_expensive_allocators(case_study: str) -> tuple[str, ...]:
-    """Return the allocator names routed through the ``allocation_expensive`` tier.
-
-    Reads ``backtest.sweep.expensive_allocators`` from setup.yaml. Falls back
-    to the canonical default ``(risk_parity, mvo_ledoit_wolf, hrp)`` if the
-    key is missing (legacy setup.yaml without the tier split). Allocators
-    not in this list are routed through ``allocation_cheap`` and see all
-    signal-stage predictions.
-    """
-    block = load_sweep(case_study).get("expensive_allocators")
-    if block is None:
-        return _DEFAULT_EXPENSIVE_ALLOCATORS
-    return tuple(str(a) for a in block)
 
 
 def get_cost_grid_half_spread_usd(case_study: str) -> list[float]:
@@ -539,8 +538,10 @@ def get_signal_nasdaq100_schemes_for(
     _required: dict[str, list] = {"direction": directions}
     if "slot_persistent_signal_exit" in methods:
         _required.update(
-            long_q=long_qs, max_slots=max_slots_grid,
-            hold_bars=hold_bars_grid, bars_per_day_grid=bpd_grid,
+            long_q=long_qs,
+            max_slots=max_slots_grid,
+            hold_bars=hold_bars_grid,
+            bars_per_day_grid=bpd_grid,
         )
     if "eq_w_topk" in methods:
         _required["top_k_grid"] = top_k_grid

--- a/data/futures/loader.py
+++ b/data/futures/loader.py
@@ -50,11 +50,17 @@ def load_cme_futures(
     Returns:
         DataFrame with futures prices.
 
-        Daily columns: session_date, product, tenor, open, high, low,
-        close, volume, bar_count, session_start, session_end.
+        Daily columns: session_date, product, tenor, adj_open, adj_high,
+        adj_low, adj_close, raw_open, raw_high, raw_low, raw_close, cum_ratio,
+        volume, bar_count, session_start, session_end. There is no bare
+        ``close``: use ``adj_close`` for returns / momentum / volatility /
+        labels (roll-continuous) and ``raw_close`` for carry / term structure
+        / roll yield / notional / costs (contemporaneous traded levels);
+        ``adj_close == raw_close * cum_ratio``.
 
         Hourly columns: ts_event, product, tenor, open, high, low,
-        close, volume.
+        close, volume. (Hourly bars are per-contract and not roll-adjusted,
+        so they keep bare OHLC.)
 
     Example:
         >>> # Daily data (default) — most notebooks use this

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       dockerfile: envs/ml4t/Dockerfile
     container_name: ml4t-review
     ports:
-      - "8888:8888"
+      - "127.0.0.1:8888:8888"
     command: ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]
 
   # ============================================
@@ -84,7 +84,7 @@ services:
       dockerfile: envs/ml4t/Dockerfile
     container_name: ml4t-review-gpu
     ports:
-      - "8889:8888"
+      - "127.0.0.1:8889:8888"
     command: ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]
     profiles: ["gpu"]
     deploy:
@@ -109,12 +109,29 @@ services:
       dockerfile: envs/benchmark/Dockerfile
     container_name: ml4t-benchmark
     ports:
-      - "8887:8888"
+      - "127.0.0.1:8887:8888"
     profiles: ["benchmark"]
+    # Re-declares the x-common volumes because a service-level `volumes:` key
+    # replaces the anchor's rather than extending it.
+    volumes:
+      - .:/app:rw
+      - ${ML4T_DATA_PATH:-./data}:/data:rw
+      # kdb+/PyKX licence + q binary, mounted read-only from the host at RUNTIME.
+      # Never baked into the image: the licence is personal and must not ship in
+      # a published image. If you have no kdb+ licence these resolve to empty
+      # directories, PyKX finds no licence, and 21_storage_benchmark_database
+      # skips kdb+ and says so. Get a free personal edition from
+      # https://kx.com/kdb-personal-edition-download/ and unpack it to ~/.kx.
+      - ${KX_HOME:-${HOME}/.kx}:/home/ml4t/.kx:ro
+      - ${PYKX_HOME:-${HOME}/.pykx}:/home/ml4t/.pykx:ro
     environment:
       - ML4T_DATA_PATH=/data
       - ML4T_PATH=/app
       - TEST=${TEST:-0}
+      # q resolves its licence from QLIC, not from the file's presence on disk;
+      # without this q starts and immediately fails "no license loaded".
+      - QLIC=/home/ml4t/.kx
+      - QHOME=/home/ml4t/.kx/q
       # Database connections (when running with database services)
       - CLICKHOUSE_HOST=ml4t-clickhouse
       - CLICKHOUSE_PORT=8123
@@ -149,7 +166,7 @@ services:
         - linux/amd64
     container_name: ml4t-benchmark-full
     ports:
-      - "8887:8888"
+      - "127.0.0.1:8887:8888"
     profiles: ["benchmark-full"]
     environment:
       - ML4T_DATA_PATH=/data
@@ -238,8 +255,8 @@ services:
     container_name: ml4t-neo4j
     profiles: ["kg"]
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
     environment:
       - NEO4J_AUTH=${NEO4J_AUTH:-neo4j/password}
     volumes:
@@ -263,7 +280,7 @@ services:
       - POSTGRES_DB=ml4t
       - POSTGRES_USER=postgres
     ports:
-      - "5437:5432"
+      - "127.0.0.1:5437:5432"
     profiles: ["benchmark", "benchmark-full", "databases"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -279,7 +296,7 @@ services:
       - POSTGRES_DB=ml4t
       - POSTGRES_USER=postgres
     ports:
-      - "5436:5432"
+      - "127.0.0.1:5436:5432"
     profiles: ["benchmark", "benchmark-full", "databases"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -295,7 +312,7 @@ services:
       - CLICKHOUSE_USER=default
       - CLICKHOUSE_PASSWORD=
     ports:
-      - "8123:8123"
+      - "127.0.0.1:8123:8123"
     profiles: ["benchmark", "benchmark-full", "databases"]
     deploy:
       resources:
@@ -311,8 +328,8 @@ services:
     image: questdb/questdb:latest
     container_name: ml4t-questdb
     ports:
-      - "9000:9000"
-      - "9009:9009"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9009:9009"
     profiles: ["benchmark", "benchmark-full", "databases"]
     deploy:
       resources:
@@ -335,7 +352,7 @@ services:
       - DOCKER_INFLUXDB_INIT_BUCKET=market_data
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=benchmark-token
     ports:
-      - "8086:8086"
+      - "127.0.0.1:8086:8086"
     profiles: ["benchmark", "benchmark-full", "databases"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/health"]

--- a/envs/benchmark/Dockerfile
+++ b/envs/benchmark/Dockerfile
@@ -45,14 +45,37 @@ RUN python -m venv /opt/ml4t
 # Copy and install dependencies
 WORKDIR /build
 COPY envs/benchmark/pyproject.toml /build/
+COPY pyproject.toml uv.lock /build/root/
+
+# Derive a fully-pinned constraint from uv.lock so this image reproduces the
+# locked environment readers get from `uv sync` (single source of truth:
+# uv.lock), the same way envs/ml4t/Dockerfile does. Without it the resolve below
+# free-resolves to the latest compatible release at build time and drifts off
+# the lock — e.g. it landed pandas 3.0.2 where the lock pins 2.3.3, and pandas 3
+# stores the `symbol` column ~8 bytes/row wider in PyTables, moving Ch2's HDF5
+# benchmark from 71 MB to 79 MB for the identical panel and making §2.4's number
+# unreproducible in the very image the notebook told readers to use.
+# Only packages the lock knows about are pinned; this image's own extras (the
+# database clients, pykx) are absent from the lock and resolve freely.
+# kaleido is excluded: this image deliberately caps it at <1.0 (1.x needs a
+# Chrome runtime this image does not carry — the notebooks' fig.write_image call
+# is wrapped in try/except for exactly that reason), while the lock pins 1.3.0.
+# It only affects static image export, never a benchmark number, so the image's
+# cap wins and the constraint stays out of its way.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
+      | grep -iE '^[a-z0-9._-]+==' \
+      | grep -viE '^kaleido==' \
+      > /tmp/locked-constraints.txt
 
 # Install all dependencies in one go. We deliberately do NOT have a fallback
 # that strips questdb on failure — a successful build must include every
 # database client declared in pyproject.toml so users never hit a runtime
 # `ModuleNotFoundError`.
 RUN /opt/ml4t/bin/pip install --no-cache-dir pip setuptools wheel && \
-    /opt/ml4t/bin/pip install --no-cache-dir /build && \
-    /opt/ml4t/bin/pip install --no-cache-dir "pytest>=8.0" "pytest-timeout>=2.3" "papermill>=2.6" "jupytext>=1.16"
+    /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt /build && \
+    /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
+        "pytest>=8.0" "pytest-timeout>=2.3" "papermill>=2.6" "jupytext>=1.16"
 
 WORKDIR /app
 ENV PATH="/opt/ml4t/bin:$PATH"
@@ -60,10 +83,11 @@ ENV PYTHONPATH="/app"
 
 # Jupyter configuration
 ENV JUPYTER_ENABLE_LAB=yes
+# Token-less, like envs/ml4t/Dockerfile: safe only because compose binds the
+# published port to 127.0.0.1. Origin/XSRF checks stay on - see that file.
 RUN mkdir -p /etc/jupyter && \
     echo "c.ServerApp.token = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.allow_origin = '*'" >> /etc/jupyter/jupyter_server_config.py
+    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py
 
 # Platform detection script
 RUN echo '#!/bin/bash\n\

--- a/envs/benchmark/Dockerfile.full
+++ b/envs/benchmark/Dockerfile.full
@@ -46,10 +46,11 @@ ENV PYTHONPATH="/app"
 
 # Jupyter configuration
 ENV JUPYTER_ENABLE_LAB=yes
+# Token-less, like envs/ml4t/Dockerfile: safe only because compose binds the
+# published port to 127.0.0.1. Origin/XSRF checks stay on - see that file.
 RUN mkdir -p /etc/jupyter && \
     echo "c.ServerApp.token = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.allow_origin = '*'" >> /etc/jupyter/jupyter_server_config.py
+    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py
 
 # Status script
 RUN echo '#!/bin/bash\n\

--- a/envs/benchmark/pyproject.full.toml
+++ b/envs/benchmark/pyproject.full.toml
@@ -40,6 +40,13 @@ dependencies = [
     "influxdb-client>=1.45",
     "questdb>=2.0",
 
+    # kdb+/PyKX — the notebook drives an external q process over IPC. The wheel
+    # ships q itself; a licence is NOT baked into this image (it is personal and
+    # must never be published). Mount ~/.kx and ~/.pykx at runtime and set QLIC —
+    # docker-compose.yml does this for the `benchmark` service. Without a licence
+    # the notebook skips kdb+ and says so.
+    "pykx>=4.0",
+
     # Utilities
     "python-dotenv>=1.0",
     "tqdm>=4.66",

--- a/envs/benchmark/pyproject.toml
+++ b/envs/benchmark/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
     "influxdb-client>=1.45",
     "questdb>=2.0",
 
+    # kdb+/PyKX — the notebook drives an external q process over IPC. The wheel
+    # ships q itself; a licence is NOT baked into this image (it is personal and
+    # must never be published). Mount ~/.kx and ~/.pykx at runtime and set QLIC —
+    # docker-compose.yml does this for the `benchmark` service. Without a licence
+    # the notebook skips kdb+ and says so.
+    "pykx>=4.0",
+
     # Utilities
     "python-dotenv>=1.0",
     "tqdm>=4.66",

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -180,13 +180,15 @@ ENV PYTHONPATH="/app"
 # - NVIDIA_VISIBLE_DEVICES
 # - LD_LIBRARY_PATH (for libnvidia-ml.so, etc.)
 
-# Jupyter configuration - disable token authentication
+# Jupyter runs without a token so the reader's first command is the only step.
+# That is safe only because docker-compose.yml publishes 8888 on 127.0.0.1 alone.
+# Origin and XSRF checks stay ON: loopback does not stop a page the reader browses
+# from POSTing to localhost:8888, and with no token those checks are the only thing
+# standing between a visited web page and code execution on the reader's machine.
 ENV JUPYTER_ENABLE_LAB=yes
 RUN mkdir -p /etc/jupyter && \
     echo "c.ServerApp.token = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.allow_origin = '*'" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.disable_check_xsrf = True" >> /etc/jupyter/jupyter_server_config.py
+    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py
 
 # NOTE: jupyterlab-plotly extension is required for Plotly widget rendering
 # It is installed automatically by plotly pip package - do NOT delete it

--- a/envs/py312/Dockerfile
+++ b/envs/py312/Dockerfile
@@ -58,10 +58,10 @@ ENV PATH="/opt/ml4t/bin:$PATH"
 ENV PYTHONPATH="/app"
 ENV JUPYTER_ENABLE_LAB=yes
 
+# Token-less, like envs/ml4t/Dockerfile: safe only because compose binds the
+# published port to 127.0.0.1. Origin/XSRF checks stay on - see that file.
 RUN mkdir -p /etc/jupyter && \
     echo "c.ServerApp.token = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.allow_origin = '*'" >> /etc/jupyter/jupyter_server_config.py && \
-    echo "c.ServerApp.disable_check_xsrf = True" >> /etc/jupyter/jupyter_server_config.py
+    echo "c.ServerApp.password = ''" >> /etc/jupyter/jupyter_server_config.py
 
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--no-browser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ dependencies = [
     "plotly>=5.20",
     "matplotlib>=3.8",
     "seaborn>=0.13",
-    "kaleido==0.2.1",
+    # kaleido>=1.0: 0.2.1 bundled its own Chromium but drives the deprecated
+    # plotly.io.kaleido.scope.* API, which plotly 6.x emits DeprecationWarnings for
+    # (support removed after Sept 2025). 1.x drives a system/self-provisioned Chrome
+    # (kaleido_get_chrome) and is warning-clean. Static PNG export is used only at
+    # figure-production time; reader-runtime kaleido calls (nb 21) already try/except.
+    "kaleido>=1.3",
     # ===================
     # Machine Learning
     # ===================

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1822,6 +1822,11 @@ case_studies/nasdaq100_microstructure/10_dl_tcn:
     N_EPOCHS: 1
   timeout: 600
 case_studies/nasdaq100_microstructure/11_dl_patchtst:
+  # Needs CUDA: MAX_SYMBOLS=5 of a 15-minute panel is ~26x the rows of the
+  # daily-frequency patchtst notebooks, which share these parameters and
+  # finish in under 180s. On CPU this overruns any sane cell timeout (measured
+  # 625s against a 600s budget); on GPU it completes in 155s.
+  gpu: true
   parameters:
     BATCH_SIZE: 32
     LOOKBACK: 24

--- a/utils/storage_benchmarks.py
+++ b/utils/storage_benchmarks.py
@@ -239,28 +239,6 @@ class BenchmarkResult:
 # =============================================================================
 
 
-def drop_os_caches() -> bool:
-    """Drop OS page caches for accurate cold-cache benchmarking.
-
-    Requires sudo access. Returns True if successful, False otherwise.
-    On Linux: sync; echo 3 > /proc/sys/vm/drop_caches
-    """
-    import subprocess
-
-    try:
-        # Sync first to flush dirty pages
-        subprocess.run(["sync"], check=True, timeout=30)
-        # Drop caches (requires sudo or appropriate permissions)
-        result = subprocess.run(
-            ["sudo", "-n", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"],
-            capture_output=True,
-            timeout=10,
-        )
-        return result.returncode == 0
-    except Exception:
-        return False
-
-
 def time_operation(func, n_runs: int = TIMING_RUNS, warmup: bool = True) -> tuple[float, Any]:
     """Time a function with warm-up and percentile tracking.
 
@@ -311,30 +289,95 @@ def time_operation(func, n_runs: int = TIMING_RUNS, warmup: bool = True) -> tupl
     return mean_time, result
 
 
-def time_cold_cache(func, drop_caches: bool = True) -> tuple[float, Any]:
-    """Time a single cold-cache read operation.
+# -----------------------------------------------------------------------------
+# TIMING POLICY
+# -----------------------------------------------------------------------------
+# One policy, applied to every format and every engine in the chapter §2.4
+# benchmarks. Mixing policies within a single comparison makes the resulting
+# chart meaningless, so all call sites go through `time_write` / `time_read`
+# rather than passing ad-hoc n_runs/warmup arguments to `time_operation`.
+#
+#   Writes -> single shot, no warm-up, against freshly created storage, with
+#             any durability wait (WAL flush, async ingestion) INSIDE the timed
+#             region. Bulk load is a once-per-dataset operation; repeating it
+#             would either append duplicate rows on the append-only engines or
+#             require a teardown that is not part of the operation being timed.
+#
+#   Reads   -> mean of TIMING_RUNS runs after one untimed warm-up run.
+#             These are WARM-CACHE numbers, on both the OS page cache and each
+#             server's own buffer pool, and they are reported as such. A client
+#             cannot drop a database server's caches, so a "cold" client-side
+#             read would be cold for the file formats and warm for the servers:
+#             neither cold nor comparable. Warm-cache timing flatters
+#             memory-mapped formats (Feather) and every engine with a buffer
+#             pool; the notebooks state this where the results are interpreted.
 
-    For fair comparison of file formats, drops OS page caches before reading.
-    This ensures memory-mapped formats (Feather) don't benefit from cached pages.
+
+def time_write(func) -> tuple[float, Any]:
+    """Time a bulk write under the chapter's write policy: one cold shot.
 
     Args:
-        func: Function to time (should be a file read operation)
-        drop_caches: Whether to drop OS caches first (requires sudo)
+        func: Write function. Must create its own storage and include any
+            durability wait, so the timed region ends when the data is durable
+            and queryable.
 
     Returns:
-        (time, result): Execution time and result
+        (time_seconds, result)
     """
-    if drop_caches:
-        cache_dropped = drop_os_caches()
-        if not cache_dropped:
-            print("Warning: Could not drop OS caches (requires sudo)")
-
     gc.collect()
-    start = time.perf_counter()
-    result = func()
-    elapsed = time.perf_counter() - start
+    return time_operation(func, n_runs=1, warmup=False)
 
-    return elapsed, result
+
+def time_read(func, n_runs: int | None = None) -> tuple[float, Any]:
+    """Time a read/aggregation/join under the chapter's read policy: warm mean.
+
+    Args:
+        func: Read function, which must force materialization of its result.
+        n_runs: Timing runs after the untimed warm-up (default: TIMING_RUNS).
+
+    Returns:
+        (mean_time_seconds, result)
+    """
+    gc.collect()
+    return time_operation(func, n_runs=n_runs or TIMING_RUNS, warmup=True)
+
+
+def wait_until_rows_visible(
+    count_func, expected_rows: int, timeout: float = 60.0, poll_seconds: float = 0.05
+) -> int:
+    """Block until an asynchronously-ingesting engine reports `expected_rows`.
+
+    QuestDB (ILP + WAL) and InfluxDB acknowledge a write before the rows are
+    queryable. Call this INSIDE the timed write so that their durability cost
+    lands on the same side of the timed region as the synchronous engines
+    (PostgreSQL/TimescaleDB), which pay it inline. Replaces a fixed sleep, which
+    both under-counts slow ingestion and over-counts fast ingestion.
+
+    Args:
+        count_func: Callable returning the row count currently visible.
+        expected_rows: Row count to wait for.
+        timeout: Seconds to wait before failing.
+        poll_seconds: Delay between polls.
+
+    Returns:
+        The visible row count once it reaches `expected_rows`.
+
+    Raises:
+        TimeoutError: If the rows never become visible. Never returns a short
+            count: a silently-incomplete ingest would produce a fast, wrong
+            write time and a wrong read count downstream.
+    """
+    deadline = time.perf_counter() + timeout
+    visible = 0
+    while time.perf_counter() < deadline:
+        visible = count_func()
+        if visible >= expected_rows:
+            return visible
+        time.sleep(poll_seconds)
+    raise TimeoutError(
+        f"Only {visible:,} of {expected_rows:,} rows visible after {timeout:.0f}s; "
+        "ingestion did not complete."
+    )
 
 
 def validate_result(
@@ -540,6 +583,39 @@ def save_chart(fig: go.Figure, name: str) -> None:
 # =============================================================================
 
 
+# Regular US equity session: 09:30-16:00 ET inclusive of the opening minute,
+# i.e. 390 one-minute bars per trading day.
+SESSION_OPEN_MINUTE = 9 * 60 + 30
+SESSION_BARS = 390
+SESSION_START_DATE = "2024-01-02"  # first business day of 2024
+
+
+def session_minute_grid(n_rows: int, start_date: str = SESSION_START_DATE) -> np.ndarray:
+    """Build `n_rows` one-minute bar timestamps laid out over trading sessions.
+
+    Bars run 09:30-16:00 on consecutive business days, so the grid carries the
+    overnight and weekend gaps a real minute panel has. This matters for the
+    benchmarks in two ways: a calendar-day range query selects a realistic
+    fraction of the panel, and resampling minute bars to daily bars is a real
+    reduction rather than a near-identity.
+
+    Args:
+        n_rows: Number of bars to generate.
+        start_date: First session date (rolled forward to a business day).
+
+    Returns:
+        numpy datetime64[us] array of length `n_rows`, strictly increasing.
+    """
+    n_sessions = int(np.ceil(n_rows / SESSION_BARS))
+    session_days = np.busday_offset(
+        np.datetime64(start_date, "D"), np.arange(n_sessions), roll="forward"
+    )
+    session_open = session_days.astype("datetime64[m]") + np.timedelta64(SESSION_OPEN_MINUTE, "m")
+    bar_offsets = np.arange(SESSION_BARS, dtype="timedelta64[m]")
+    grid = (session_open[:, np.newaxis] + bar_offsets[np.newaxis, :]).ravel()
+    return grid[:n_rows].astype("datetime64[us]")
+
+
 def generate_ohlcv_data(
     n_symbols: int = N_SYMBOLS,
     n_rows: int = N_ROWS_PER_SYMBOL,
@@ -547,15 +623,23 @@ def generate_ohlcv_data(
 ) -> pl.DataFrame:
     """Generate realistic synthetic OHLCV panel data (fully vectorized).
 
-    Creates a panel dataset with multiple symbols and time-series bars.
-    OHLCV constraints are enforced: H >= max(O,C), L <= min(O,C).
+    Creates a panel of one-minute bars for `n_symbols` symbols over consecutive
+    regular trading sessions (390 bars per session). OHLCV constraints are
+    enforced: H >= max(O,C), L <= min(O,C).
+
+    All symbols share one session grid, which is what a synchronized bar panel
+    looks like: every symbol prints a bar for the same minute of the same
+    session. That shared grid, and the low-cardinality symbol column, are
+    genuine properties of bar panels rather than artifacts of the generator, and
+    the dictionary/delta encoding they enable is part of what the format
+    comparison is measuring.
 
     This implementation is fully vectorized using numpy arrays, enabling
     generation of 10M+ rows in seconds (required for XL/XXL scales).
 
     Args:
         n_symbols: Number of unique symbols
-        n_rows: Number of rows per symbol
+        n_rows: Number of one-minute bars per symbol
         seed: Random seed for reproducibility
 
     Returns:
@@ -564,12 +648,8 @@ def generate_ohlcv_data(
     np.random.seed(seed)
     total_rows = n_symbols * n_rows
 
-    # Generate all timestamps at once (vectorized)
-    base_time = np.datetime64("2024-01-01T00:00:00", "us")
-    minute_offsets = np.arange(n_rows, dtype="timedelta64[m]")
-    single_symbol_times = base_time + minute_offsets
-
-    # Tile timestamps for all symbols
+    # One session-aware minute grid, shared by every symbol (see docstring).
+    single_symbol_times = session_minute_grid(n_rows)
     timestamps = np.tile(single_symbol_times, n_symbols)
 
     # Generate symbol array (repeat each symbol n_rows times)

--- a/utils/style.py
+++ b/utils/style.py
@@ -269,6 +269,90 @@ def format_pct_axis(ax: Axes, axis: Literal["x", "y", "both"] = "y") -> None:
         ax.xaxis.set_major_formatter(formatter)
 
 
+def add_message_title(
+    ax: Axes,
+    message: str,
+    subtitle: str | None = None,
+    source: str | None = None,
+) -> None:
+    """Left-aligned takeaway title (a claim, not a label), optional subtitle + source note.
+
+    `message` should state the finding ("Momentum decays beyond a 12-month hold"), not
+    label the axes. `subtitle` carries the qualifier the title omits (metric, universe,
+    frequency, period); `source` is a small bottom-left note. No figure number — the
+    publisher captions separately.
+    """
+    ax.set_title(
+        message,
+        loc="left",
+        color=COLORS["blue"],
+        fontweight="semibold",
+        pad=15 if subtitle else 8,
+    )
+    if subtitle:
+        ax.annotate(
+            subtitle,
+            xy=(0, 1),
+            xycoords="axes fraction",
+            xytext=(0, 4),
+            textcoords="offset points",
+            ha="left",
+            va="bottom",
+            fontsize=9,
+            color=COLORS["neutral"],
+        )
+    if source:
+        ax.figure.text(
+            0.01, 0.005, source, ha="left", va="bottom", fontsize=8, color=COLORS["neutral"]
+        )
+
+
+def label_line_ends(ax: Axes, xpad_points: int = 4, expand_right: float = 0.10) -> None:
+    """Direct-label each labeled line at its last finite point; use instead of a legend.
+
+    Preferred over a legend for <=5 series. Expands the right margin to fit labels.
+    Do not also call ``ax.legend()``. Each label inherits its line's color, so the chart
+    stays legible in grayscale (position + color, no legend lookup).
+    """
+    x0, x1 = ax.get_xlim()
+    ax.set_xlim(x0, x1 + (x1 - x0) * expand_right)
+    for line in ax.get_lines():
+        label = line.get_label()
+        if not label or label.startswith("_"):
+            continue
+        x = np.asarray(line.get_xdata(), dtype=float)
+        y = np.asarray(line.get_ydata(), dtype=float)
+        m = np.isfinite(x) & np.isfinite(y)
+        if not m.any():
+            continue
+        ax.annotate(
+            label,
+            xy=(x[m][-1], y[m][-1]),
+            xytext=(xpad_points, 0),
+            textcoords="offset points",
+            va="center",
+            ha="left",
+            color=line.get_color(),
+            fontsize=9,
+            annotation_clip=False,
+        )
+
+
+def zero_line(ax: Axes, at: float = 0.0, axis: Literal["x", "y"] = "y") -> None:
+    """Thin neutral reference line (zero, benchmark=1.0, mean, threshold) behind the data."""
+    draw = ax.axhline if axis == "y" else ax.axvline
+    draw(at, color=COLORS["neutral"], linewidth=0.8, linestyle="--", zorder=0.5)
+
+
+def upper_triangle_mask(corr: object) -> np.ndarray:
+    """Boolean mask hiding the redundant upper triangle of a symmetric matrix.
+
+    For correlation/covariance heatmaps: ``sns.heatmap(corr, mask=upper_triangle_mask(corr),
+    vmin=-1, vmax=1, center=0, cmap=...)``.
+    """
+    return np.triu(np.ones_like(np.asarray(corr), dtype=bool), k=1)
+
+
 # =============================================================================
 # PLOTLY TEMPLATE (optional — only used if Plotly is installed)
 # =============================================================================
@@ -331,6 +415,11 @@ def _register_plotly_template() -> None:
         )
     )
     pio.templates["ml4t"] = template
+    # Make it the default so every Plotly figure inherits the ML4T font,
+    # backgrounds, gridlines, and colorway — the palette applies repo-wide
+    # without each notebook having to opt in (matplotlib gets this via
+    # matplotlibrc; this is the Plotly equivalent).
+    pio.templates.default = "ml4t"
 
 
 # Auto-register Plotly template on import
@@ -786,6 +875,10 @@ __all__ = [
     "annotate_peak",
     "add_regime_shading",
     "format_pct_axis",
+    "add_message_title",
+    "label_line_ends",
+    "zero_line",
+    "upper_triangle_mask",
     # Book-specific
     "ML4T_STYLE",
     "HAS_PLOTLY",

--- a/uv.lock
+++ b/uv.lock
@@ -914,6 +914,20 @@ wheels = [
 ]
 
 [[package]]
+name = "choreographer"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "logistro" },
+    { name = "platformdirs" },
+    { name = "simplejson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/6c/ff8bf52315064dbeb55cb5067e191120a5b2e58bb648d0d34cf7969dc2c2/choreographer-1.3.0-py3-none-any.whl", hash = "sha256:cea4cb739e4f61625e4b53888a8d3fa1d3bf73948b56753e460ab44da7d8d44f", size = 52622, upload-time = "2026-04-28T22:57:44.015Z" },
+]
+
+[[package]]
 name = "chromadb"
 version = "1.5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3408,15 +3422,17 @@ wheels = [
 
 [[package]]
 name = "kaleido"
-version = "0.2.1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "choreographer" },
+    { name = "logistro" },
+    { name = "orjson" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl", hash = "sha256:ca6f73e7ff00aaebf2843f73f1d3bacde1930ef5041093fe76b83a15785049a7", size = 85153681, upload-time = "2021-03-08T10:27:34.202Z" },
-    { url = "https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb9a5d1f710357d5d432ee240ef6658a6d124c3e610935817b4b42da9c787c05", size = 85808197, upload-time = "2021-03-08T10:27:46.561Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:aa21cf1bf1c78f8fa50a9f7d45e1003c387bd3d6fe0a767cfbbf344b95bdc3a8", size = 79902476, upload-time = "2021-03-08T10:27:57.364Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/2b/680662678a57afab1685f0c431c2aba7783ce4344f06ec162074d485d469/kaleido-0.2.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:845819844c8082c9469d9c17e42621fbf85c2b237ef8a86ec8a8527f98b6512a", size = 83711746, upload-time = "2021-03-08T10:28:08.847Z" },
-    { url = "https://files.pythonhosted.org/packages/88/89/4b6f8bb3f9ab036fd4ad1cb2d628ab5c81db32ac9aa0641d7b180073ba43/kaleido-0.2.1-py2.py3-none-win32.whl", hash = "sha256:ecc72635860be616c6b7161807a65c0dbd9b90c6437ac96965831e2e24066552", size = 62312480, upload-time = "2021-03-08T10:28:18.204Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/9a/0408b02a4bcb3cf8b338a2b074ac7d1b2099e2b092b42473def22f7b625f/kaleido-0.2.1-py2.py3-none-win_amd64.whl", hash = "sha256:4670985f28913c2d063c5734d125ecc28e40810141bdb0a46f15b76c1d45f23c", size = 65945521, upload-time = "2021-03-08T10:28:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/a6d8bb7d228940f01885bd9f327ab7f9d366a9be775c4bf366bf9d9477ae/kaleido-1.3.0-py3-none-any.whl", hash = "sha256:52714dfd38e8f2a114831826200c40bb10d0ca0c11d4272f3f48ad499cd8f8ea", size = 55580, upload-time = "2026-05-04T19:45:27.483Z" },
 ]
 
 [[package]]
@@ -3877,6 +3893,15 @@ wheels = [
 ]
 
 [[package]]
+name = "logistro"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/90/bfd7a6fab22bdfafe48ed3c4831713cb77b4779d18ade5e248d5dbc0ca22/logistro-2.0.1.tar.gz", hash = "sha256:8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047", size = 8398, upload-time = "2025-11-01T02:41:18.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl", hash = "sha256:06ffa127b9fb4ac8b1972ae6b2a9d7fde57598bf5939cd708f43ec5bba2d31eb", size = 8555, upload-time = "2025-11-01T02:41:17.587Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4304,7 +4329,7 @@ requires-dist = [
     { name = "jupyterlab", specifier = ">=4.1" },
     { name = "jupytext", specifier = ">=1.16" },
     { name = "jupytext", marker = "extra == 'dev'", specifier = ">=1.16" },
-    { name = "kaleido", specifier = "==0.2.1" },
+    { name = "kaleido", specifier = ">=1.3" },
     { name = "langgraph", specifier = ">=0.2" },
     { name = "lightgbm", specifier = ">=4.6" },
     { name = "linearmodels", specifier = ">=6.0" },
@@ -7537,6 +7562,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Reconciles the **code-ahead half** of the code↔public drift surface. Public is the sole
survivor repo; a full recount today (public@440fa09 vs code@5afa4b6d) found **436 identical /
53 drifted / 12 public-only**. This PR exports the **40 drifted files where code is ahead and
the copy is one-directional and safe**, so readers stop running stranded-fix versions.

The other 13 drifted files are **public-ahead or public-only and were deliberately left
untouched** (6 chapter READMEs with hero figures, `case_studies/README.md` release note,
`test.yml`/`weekly-external.yml`/`.gitignore`, `conftest.py`, `test_download_scripts_registry.py`).

## Reader-facing fixes readers didn't have

- `02/20`, `02/21` storage benchmarks — the #374 methodology work (closes the stranded fix; #374 reply already posted)
- `07/05_signal_evaluation` — `N_PERMUTATIONS` 200→1000, `evaluated_dates`, like-for-like IC (live defect, no issue filed)
- `etfs/01_feasibility_analysis` — VRP `abs()` sign fix
- registry/causal/darts/backtest_loaders — HAC bandwidth (named-horizon lag), `adj_close` continuous futures, `backtest_hash` portability, cohort metrics, NaN paired-CI verdict guard

## Judgment calls flagged for review

1. **Sweep-config tier-split** — `sweep_config.py` + 9 `setup.yaml` move as one unit; code
   **removed** the `allocation_cheap/expensive` allocator tier-split that public still ships.
   Direction (code→public) per the reconcile proposal; blast radius verified contained to these 10.
2. **`overrides.yaml`** — the one bidirectional file; hand-merged (kept public's Yahoo live-run +
   `drift` marker changes, added code's nasdaq100 `patchtst gpu:true`).
3. **Environment** — `kaleido` 0.2.1→1.3 (+`uv.lock`); reader-runtime kaleido calls already try/except.

Closes the drift half of the reconcile; the collapse step (make shipped paths public-only +
fix `AGENTS.md`) follows separately.
