### PR TITLE
Ch02 22_pandas_polars_benchmark: fix S-scale prose overstating Polars' lead

### DIFF
--- a/02_financial_data_universe/22_pandas_polars_benchmark.ipynb
+++ b/02_financial_data_universe/22_pandas_polars_benchmark.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "59d4434d",
+   "id": "7c32a2a6",
    "metadata": {
     "papermill": {
-     "duration": 0.005322,
-     "end_time": "2026-06-13T02:35:01.885173+00:00",
+     "duration": 0.003652,
+     "end_time": "2026-07-18T20:21:08.488582+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:01.879851+00:00",
+     "start_time": "2026-07-18T20:21:08.484930+00:00",
      "status": "completed"
     }
    },
@@ -63,13 +63,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c7303e7",
+   "id": "b4a91e04",
    "metadata": {
     "papermill": {
-     "duration": 0.003475,
-     "end_time": "2026-06-13T02:35:01.893724+00:00",
+     "duration": 0.00309,
+     "end_time": "2026-07-18T20:21:08.495128+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:01.890249+00:00",
+     "start_time": "2026-07-18T20:21:08.492038+00:00",
      "status": "completed"
     }
    },
@@ -80,20 +80,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "185d5139",
+   "id": "794a92e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:49.734684Z",
-     "iopub.status.busy": "2026-06-16T02:33:49.734304Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.352547Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.351966Z"
+     "iopub.execute_input": "2026-07-18T20:21:08.502606Z",
+     "iopub.status.busy": "2026-07-18T20:21:08.502498Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.652448Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.651860Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 2.358937,
-     "end_time": "2026-06-13T02:35:04.256133+00:00",
+     "duration": 1.154646,
+     "end_time": "2026-07-18T20:21:09.653176+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:01.897196+00:00",
+     "start_time": "2026-07-18T20:21:08.498530+00:00",
      "status": "completed"
     }
    },
@@ -134,19 +134,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f7625699",
+   "id": "346f4acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.354110Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.353852Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.355947Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.355620Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.664050Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.663850Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.665810Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.665443Z"
     },
     "papermill": {
-     "duration": 0.007075,
-     "end_time": "2026-06-13T02:35:04.267106+00:00",
+     "duration": 0.00647,
+     "end_time": "2026-07-18T20:21:09.666043+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.260031+00:00",
+     "start_time": "2026-07-18T20:21:09.659573+00:00",
      "status": "completed"
     },
     "tags": [
@@ -162,19 +162,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "cdcc3f6a",
+   "id": "42d4e1db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.356827Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.356724Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.493418Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.492853Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.672894Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.672810Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.703396Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.703001Z"
     },
     "papermill": {
-     "duration": 0.041778,
-     "end_time": "2026-06-13T02:35:04.312387+00:00",
+     "duration": 0.034838,
+     "end_time": "2026-07-18T20:21:09.704000+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.270609+00:00",
+     "start_time": "2026-07-18T20:21:09.669162+00:00",
      "status": "completed"
     }
    },
@@ -185,13 +185,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b9de5e0",
+   "id": "b5237453",
    "metadata": {
     "papermill": {
-     "duration": 0.003494,
-     "end_time": "2026-06-13T02:35:04.319530+00:00",
+     "duration": 0.003171,
+     "end_time": "2026-07-18T20:21:09.710472+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.316036+00:00",
+     "start_time": "2026-07-18T20:21:09.707301+00:00",
      "status": "completed"
     }
    },
@@ -209,19 +209,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5704f3dc",
+   "id": "3c7064ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.494647Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.494521Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.498259Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.497745Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.717369Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.717260Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.720653Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.720375Z"
     },
     "papermill": {
-     "duration": 0.009176,
-     "end_time": "2026-06-13T02:35:04.332215+00:00",
+     "duration": 0.007431,
+     "end_time": "2026-07-18T20:21:09.721007+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.323039+00:00",
+     "start_time": "2026-07-18T20:21:09.713576+00:00",
      "status": "completed"
     }
    },
@@ -289,13 +289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "528e90df",
+   "id": "8206ab3e",
    "metadata": {
     "papermill": {
-     "duration": 0.00351,
-     "end_time": "2026-06-13T02:35:04.339498+00:00",
+     "duration": 0.0032,
+     "end_time": "2026-07-18T20:21:09.727449+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.335988+00:00",
+     "start_time": "2026-07-18T20:21:09.724249+00:00",
      "status": "completed"
     }
    },
@@ -309,20 +309,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "6f49ef2e",
+   "id": "640e985c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.499170Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.499060Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.527737Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.527358Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.734475Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.734383Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.762060Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.761682Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.032638,
-     "end_time": "2026-06-13T02:35:04.375658+00:00",
+     "duration": 0.032201,
+     "end_time": "2026-07-18T20:21:09.762788+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.343020+00:00",
+     "start_time": "2026-07-18T20:21:09.730587+00:00",
      "status": "completed"
     }
    },
@@ -380,14 +380,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f17d16d1",
+   "id": "9cd71a62",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00361,
-     "end_time": "2026-06-13T02:35:04.383045+00:00",
+     "duration": 0.003171,
+     "end_time": "2026-07-18T20:21:09.771290+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.379435+00:00",
+     "start_time": "2026-07-18T20:21:09.768119+00:00",
      "status": "completed"
     }
    },
@@ -401,19 +401,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "48b6787c",
+   "id": "f440d7c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.528848Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.528749Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.531546Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.531168Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.778598Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.778486Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.780843Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.780559Z"
     },
     "papermill": {
-     "duration": 0.007044,
-     "end_time": "2026-06-13T02:35:04.393680+00:00",
+     "duration": 0.006626,
+     "end_time": "2026-07-18T20:21:09.781218+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.386636+00:00",
+     "start_time": "2026-07-18T20:21:09.774592+00:00",
      "status": "completed"
     }
    },
@@ -438,20 +438,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "fe7652f3",
+   "id": "3cd80913",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.532714Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.532605Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.535723Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.535262Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.794318Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.794182Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.796435Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.796150Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006377,
-     "end_time": "2026-06-13T02:35:04.403616+00:00",
+     "duration": 0.009555,
+     "end_time": "2026-07-18T20:21:09.796932+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.397239+00:00",
+     "start_time": "2026-07-18T20:21:09.787377+00:00",
      "status": "completed"
     }
    },
@@ -470,14 +470,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf54e697",
+   "id": "d200906e",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003488,
-     "end_time": "2026-06-13T02:35:04.410637+00:00",
+     "duration": 0.003179,
+     "end_time": "2026-07-18T20:21:09.803653+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.407149+00:00",
+     "start_time": "2026-07-18T20:21:09.800474+00:00",
      "status": "completed"
     }
    },
@@ -489,19 +489,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "57d2636e",
+   "id": "6f59a0ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.537397Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.537243Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.541598Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.541105Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.810781Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.810668Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.813143Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.812866Z"
     },
     "papermill": {
-     "duration": 0.00658,
-     "end_time": "2026-06-13T02:35:04.420718+00:00",
+     "duration": 0.006845,
+     "end_time": "2026-07-18T20:21:09.813654+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.414138+00:00",
+     "start_time": "2026-07-18T20:21:09.806809+00:00",
      "status": "completed"
     }
    },
@@ -544,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbc77b7c",
+   "id": "62654446",
    "metadata": {
     "papermill": {
-     "duration": 0.003559,
-     "end_time": "2026-06-13T02:35:04.427837+00:00",
+     "duration": 0.003203,
+     "end_time": "2026-07-18T20:21:09.820578+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.424278+00:00",
+     "start_time": "2026-07-18T20:21:09.817375+00:00",
      "status": "completed"
     }
    },
@@ -564,19 +564,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "21c0d90d",
+   "id": "8b7a2426",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.543397Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.543240Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.546195Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.545681Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.827796Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.827689Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.829538Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.829295Z"
     },
     "papermill": {
-     "duration": 0.006258,
-     "end_time": "2026-06-13T02:35:04.437693+00:00",
+     "duration": 0.006186,
+     "end_time": "2026-07-18T20:21:09.830036+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.431435+00:00",
+     "start_time": "2026-07-18T20:21:09.823850+00:00",
      "status": "completed"
     }
    },
@@ -602,14 +602,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "257dd51b",
+   "id": "561ab074",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003474,
-     "end_time": "2026-06-13T02:35:04.444723+00:00",
+     "duration": 0.003217,
+     "end_time": "2026-07-18T20:21:09.836501+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.441249+00:00",
+     "start_time": "2026-07-18T20:21:09.833284+00:00",
      "status": "completed"
     }
    },
@@ -622,19 +622,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "17bf7423",
+   "id": "25f68cfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.547925Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.547758Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.550359Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.549939Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.843627Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.843530Z",
+     "iopub.status.idle": "2026-07-18T20:21:09.845278Z",
+     "shell.execute_reply": "2026-07-18T20:21:09.845005Z"
     },
     "papermill": {
-     "duration": 0.006203,
-     "end_time": "2026-06-13T02:35:04.454460+00:00",
+     "duration": 0.006008,
+     "end_time": "2026-07-18T20:21:09.845689+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.448257+00:00",
+     "start_time": "2026-07-18T20:21:09.839681+00:00",
      "status": "completed"
     }
    },
@@ -649,19 +649,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1f9bf322",
+   "id": "8b685b43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.551972Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.551835Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.821490Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.821050Z"
+     "iopub.execute_input": "2026-07-18T20:21:09.852900Z",
+     "iopub.status.busy": "2026-07-18T20:21:09.852806Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.112395Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.112063Z"
     },
     "papermill": {
-     "duration": 0.28719,
-     "end_time": "2026-06-13T02:35:04.745247+00:00",
+     "duration": 0.263745,
+     "end_time": "2026-07-18T20:21:10.112783+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.458057+00:00",
+     "start_time": "2026-07-18T20:21:09.849038+00:00",
      "status": "completed"
     }
    },
@@ -670,7 +670,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  rolling_mean_20: pandas=0.0012s, polars=0.0012s, speedup=1.0x\n"
+      "  rolling_mean_20: pandas=0.0012s, polars=0.0014s, speedup=0.9x\n"
      ]
     }
    ],
@@ -688,14 +688,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "135df81b",
+   "id": "0f672eee",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004192,
-     "end_time": "2026-06-13T02:35:04.753268+00:00",
+     "duration": 0.003291,
+     "end_time": "2026-07-18T20:21:10.119622+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.749076+00:00",
+     "start_time": "2026-07-18T20:21:10.116331+00:00",
      "status": "completed"
     }
    },
@@ -708,19 +708,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "4f89eef2",
+   "id": "ae1d00e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.822499Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.822395Z",
-     "iopub.status.idle": "2026-06-16T02:33:52.824314Z",
-     "shell.execute_reply": "2026-06-16T02:33:52.823986Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.126955Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.126853Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.128755Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.128490Z"
     },
     "papermill": {
-     "duration": 0.006818,
-     "end_time": "2026-06-13T02:35:04.763688+00:00",
+     "duration": 0.006247,
+     "end_time": "2026-07-18T20:21:10.129104+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.756870+00:00",
+     "start_time": "2026-07-18T20:21:10.122857+00:00",
      "status": "completed"
     }
    },
@@ -735,19 +735,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "36b8ddae",
+   "id": "744576bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:52.825182Z",
-     "iopub.status.busy": "2026-06-16T02:33:52.825121Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.110366Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.109960Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.137615Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.137529Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.411873Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.411448Z"
     },
     "papermill": {
-     "duration": 0.296126,
-     "end_time": "2026-06-13T02:35:05.063418+00:00",
+     "duration": 0.279814,
+     "end_time": "2026-07-18T20:21:10.412194+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:04.767292+00:00",
+     "start_time": "2026-07-18T20:21:10.132380+00:00",
      "status": "completed"
     }
    },
@@ -774,13 +774,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5fb4d0e",
+   "id": "3aeba11b",
    "metadata": {
     "papermill": {
-     "duration": 0.003656,
-     "end_time": "2026-06-13T02:35:05.070934+00:00",
+     "duration": 0.003314,
+     "end_time": "2026-07-18T20:21:10.419156+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.067278+00:00",
+     "start_time": "2026-07-18T20:21:10.415842+00:00",
      "status": "completed"
     }
    },
@@ -794,19 +794,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "429a150f",
+   "id": "5af7bd4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.111332Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.111259Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.113369Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.112946Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.426525Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.426421Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.428416Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.428127Z"
     },
     "papermill": {
-     "duration": 0.006521,
-     "end_time": "2026-06-13T02:35:05.081051+00:00",
+     "duration": 0.006375,
+     "end_time": "2026-07-18T20:21:10.428840+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.074530+00:00",
+     "start_time": "2026-07-18T20:21:10.422465+00:00",
      "status": "completed"
     }
    },
@@ -826,19 +826,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "e8b774d6",
+   "id": "42f9bbe1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.114023Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.113961Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.434114Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.433792Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.436391Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.436286Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.734804Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.734392Z"
     },
     "papermill": {
-     "duration": 0.327931,
-     "end_time": "2026-06-13T02:35:05.412581+00:00",
+     "duration": 0.302896,
+     "end_time": "2026-07-18T20:21:10.735148+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.084650+00:00",
+     "start_time": "2026-07-18T20:21:10.432252+00:00",
      "status": "completed"
     }
    },
@@ -847,7 +847,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  multi_horizon_returns: pandas=0.0085s, polars=0.0017s, speedup=5.1x\n"
+      "  multi_horizon_returns: pandas=0.0085s, polars=0.0022s, speedup=3.9x\n"
      ]
     }
    ],
@@ -868,14 +868,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c30401d",
+   "id": "cbfddf02",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.018506,
-     "end_time": "2026-06-13T02:35:05.436820+00:00",
+     "duration": 0.003345,
+     "end_time": "2026-07-18T20:21:10.742084+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.418314+00:00",
+     "start_time": "2026-07-18T20:21:10.738739+00:00",
      "status": "completed"
     }
    },
@@ -888,19 +888,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "628850aa",
+   "id": "434c8519",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.435140Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.435062Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.437004Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.436688Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.749573Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.749415Z",
+     "iopub.status.idle": "2026-07-18T20:21:10.751976Z",
+     "shell.execute_reply": "2026-07-18T20:21:10.751578Z"
     },
     "papermill": {
-     "duration": 0.006713,
-     "end_time": "2026-06-13T02:35:05.447276+00:00",
+     "duration": 0.006911,
+     "end_time": "2026-07-18T20:21:10.752248+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.440563+00:00",
+     "start_time": "2026-07-18T20:21:10.745337+00:00",
      "status": "completed"
     }
    },
@@ -917,19 +917,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "a1898a1e",
+   "id": "fb1d4dd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.437665Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.437604Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.728044Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.727695Z"
+     "iopub.execute_input": "2026-07-18T20:21:10.759646Z",
+     "iopub.status.busy": "2026-07-18T20:21:10.759517Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.182580Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.182087Z"
     },
     "papermill": {
-     "duration": 0.307058,
-     "end_time": "2026-06-13T02:35:05.757971+00:00",
+     "duration": 0.42724,
+     "end_time": "2026-07-18T20:21:11.182849+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.450913+00:00",
+     "start_time": "2026-07-18T20:21:10.755609+00:00",
      "status": "completed"
     }
    },
@@ -938,7 +938,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  rolling_sharpe_63: pandas=0.0034s, polars=0.0021s, speedup=1.6x\n"
+      "  rolling_sharpe_63: pandas=0.0036s, polars=0.0022s, speedup=1.6x\n"
      ]
     }
    ],
@@ -965,14 +965,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "956c57a8",
+   "id": "90cd0055",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004865,
-     "end_time": "2026-06-13T02:35:05.768047+00:00",
+     "duration": 0.003462,
+     "end_time": "2026-07-18T20:21:11.189958+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.763182+00:00",
+     "start_time": "2026-07-18T20:21:11.186496+00:00",
      "status": "completed"
     }
    },
@@ -985,19 +985,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "beab0156",
+   "id": "2fbdf335",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.728975Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.728905Z",
-     "iopub.status.idle": "2026-06-16T02:33:53.730530Z",
-     "shell.execute_reply": "2026-06-16T02:33:53.730297Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.197313Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.197201Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.199105Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.198783Z"
     },
     "papermill": {
-     "duration": 0.006482,
-     "end_time": "2026-06-13T02:35:05.778915+00:00",
+     "duration": 0.006101,
+     "end_time": "2026-07-18T20:21:11.199397+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.772433+00:00",
+     "start_time": "2026-07-18T20:21:11.193296+00:00",
      "status": "completed"
     }
    },
@@ -1014,19 +1014,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "9647e018",
+   "id": "ed786405",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:53.731196Z",
-     "iopub.status.busy": "2026-06-16T02:33:53.731137Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.014639Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.014318Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.206752Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.206667Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.483544Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.483137Z"
     },
     "papermill": {
-     "duration": 0.294252,
-     "end_time": "2026-06-13T02:35:06.076792+00:00",
+     "duration": 0.281166,
+     "end_time": "2026-07-18T20:21:11.484005+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:05.782540+00:00",
+     "start_time": "2026-07-18T20:21:11.202839+00:00",
      "status": "completed"
     }
    },
@@ -1035,7 +1035,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ewm_span_20: pandas=0.0010s, polars=0.0023s, speedup=0.4x\n"
+      "  ewm_span_20: pandas=0.0011s, polars=0.0011s, speedup=1.0x\n"
      ]
     }
    ],
@@ -1057,13 +1057,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d698e698",
+   "id": "2292ce1b",
    "metadata": {
     "papermill": {
-     "duration": 0.004378,
-     "end_time": "2026-06-13T02:35:06.086356+00:00",
+     "duration": 0.003387,
+     "end_time": "2026-07-18T20:21:11.494013+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.081978+00:00",
+     "start_time": "2026-07-18T20:21:11.490626+00:00",
      "status": "completed"
     }
    },
@@ -1076,19 +1076,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "bb95f69f",
+   "id": "2a550acc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.015711Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.015632Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.017272Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.017038Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.501674Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.501512Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.503991Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.503623Z"
     },
     "papermill": {
-     "duration": 0.007447,
-     "end_time": "2026-06-13T02:35:06.098667+00:00",
+     "duration": 0.006887,
+     "end_time": "2026-07-18T20:21:11.504302+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.091220+00:00",
+     "start_time": "2026-07-18T20:21:11.497415+00:00",
      "status": "completed"
     }
    },
@@ -1114,14 +1114,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47e5fb58",
+   "id": "0efa9708",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003628,
-     "end_time": "2026-06-13T02:35:06.106899+00:00",
+     "duration": 0.003375,
+     "end_time": "2026-07-18T20:21:11.511230+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.103271+00:00",
+     "start_time": "2026-07-18T20:21:11.507855+00:00",
      "status": "completed"
     }
    },
@@ -1134,19 +1134,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "99f6a036",
+   "id": "8cf554c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.018090Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.018029Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.019802Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.019576Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.518900Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.518757Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.521043Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.520764Z"
     },
     "papermill": {
-     "duration": 0.006598,
-     "end_time": "2026-06-13T02:35:06.117115+00:00",
+     "duration": 0.006713,
+     "end_time": "2026-07-18T20:21:11.521287+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.110517+00:00",
+     "start_time": "2026-07-18T20:21:11.514574+00:00",
      "status": "completed"
     }
    },
@@ -1173,19 +1173,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "aa33b112",
+   "id": "c4e72e76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.020812Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.020751Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.315902Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.315500Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.547758Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.547651Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.826373Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.825852Z"
     },
     "papermill": {
-     "duration": 0.44013,
-     "end_time": "2026-06-13T02:35:06.560922+00:00",
+     "duration": 0.283235,
+     "end_time": "2026-07-18T20:21:11.826714+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.120792+00:00",
+     "start_time": "2026-07-18T20:21:11.543479+00:00",
      "status": "completed"
     }
    },
@@ -1194,7 +1194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ohlcv_resample_daily: pandas=0.0034s, polars=0.0013s, speedup=2.7x\n"
+      "  ohlcv_resample_daily: pandas=0.0037s, polars=0.0014s, speedup=2.7x\n"
      ]
     }
    ],
@@ -1220,14 +1220,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "686f11fa",
+   "id": "4181ac05",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003724,
-     "end_time": "2026-06-13T02:35:06.568589+00:00",
+     "duration": 0.004079,
+     "end_time": "2026-07-18T20:21:11.834831+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.564865+00:00",
+     "start_time": "2026-07-18T20:21:11.830752+00:00",
      "status": "completed"
     }
    },
@@ -1240,19 +1240,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "44bf2657",
+   "id": "56098abc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.317164Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.317085Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.318963Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.318712Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.842531Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.842436Z",
+     "iopub.status.idle": "2026-07-18T20:21:11.844482Z",
+     "shell.execute_reply": "2026-07-18T20:21:11.844124Z"
     },
     "papermill": {
-     "duration": 0.006707,
-     "end_time": "2026-06-13T02:35:06.578981+00:00",
+     "duration": 0.006449,
+     "end_time": "2026-07-18T20:21:11.844698+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.572274+00:00",
+     "start_time": "2026-07-18T20:21:11.838249+00:00",
      "status": "completed"
     }
    },
@@ -1272,19 +1272,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "5b96ab5a",
+   "id": "f4027a16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.320000Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.319941Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.604962Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.604632Z"
+     "iopub.execute_input": "2026-07-18T20:21:11.852343Z",
+     "iopub.status.busy": "2026-07-18T20:21:11.852248Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.134637Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.134258Z"
     },
     "papermill": {
-     "duration": 0.29499,
-     "end_time": "2026-06-13T02:35:06.877683+00:00",
+     "duration": 0.286858,
+     "end_time": "2026-07-18T20:21:12.135046+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.582693+00:00",
+     "start_time": "2026-07-18T20:21:11.848188+00:00",
      "status": "completed"
     }
    },
@@ -1293,7 +1293,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  cross_sectional_stats: pandas=0.0015s, polars=0.0012s, speedup=1.2x\n"
+      "  cross_sectional_stats: pandas=0.0016s, polars=0.0015s, speedup=1.1x\n"
      ]
     }
    ],
@@ -1322,14 +1322,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12e9f363",
+   "id": "a64e3ddb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006646,
-     "end_time": "2026-06-13T02:35:06.891811+00:00",
+     "duration": 0.003483,
+     "end_time": "2026-07-18T20:21:12.142359+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.885165+00:00",
+     "start_time": "2026-07-18T20:21:12.138876+00:00",
      "status": "completed"
     }
    },
@@ -1342,19 +1342,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "ab9f91a4",
+   "id": "861d7201",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.606171Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.606097Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.607938Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.607670Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.150131Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.150020Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.152160Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.151765Z"
     },
     "papermill": {
-     "duration": 0.007045,
-     "end_time": "2026-06-13T02:35:06.902566+00:00",
+     "duration": 0.006805,
+     "end_time": "2026-07-18T20:21:12.152630+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.895521+00:00",
+     "start_time": "2026-07-18T20:21:12.145825+00:00",
      "status": "completed"
     }
    },
@@ -1376,19 +1376,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "74737fa2",
+   "id": "ad7d802f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.608873Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.608813Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.895408Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.894969Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.161958Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.161873Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.432691Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.432273Z"
     },
     "papermill": {
-     "duration": 0.299648,
-     "end_time": "2026-06-13T02:35:07.205926+00:00",
+     "duration": 0.276284,
+     "end_time": "2026-07-18T20:21:12.433162+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:06.906278+00:00",
+     "start_time": "2026-07-18T20:21:12.156878+00:00",
      "status": "completed"
     }
    },
@@ -1397,7 +1397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  symbol_stats: pandas=0.0019s, polars=0.0012s, speedup=1.5x\n"
+      "  symbol_stats: pandas=0.0019s, polars=0.0011s, speedup=1.7x\n"
      ]
     }
    ],
@@ -1429,13 +1429,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85b9a011",
+   "id": "1e882888",
    "metadata": {
     "papermill": {
-     "duration": 0.003776,
-     "end_time": "2026-06-13T02:35:07.213689+00:00",
+     "duration": 0.003704,
+     "end_time": "2026-07-18T20:21:12.440646+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.209913+00:00",
+     "start_time": "2026-07-18T20:21:12.436942+00:00",
      "status": "completed"
     }
    },
@@ -1449,19 +1449,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "371777dd",
+   "id": "35b167d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.896646Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.896529Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.898718Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.898381Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.448438Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.448344Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.450262Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.449935Z"
     },
     "papermill": {
-     "duration": 0.006898,
-     "end_time": "2026-06-13T02:35:07.224292+00:00",
+     "duration": 0.006474,
+     "end_time": "2026-07-18T20:21:12.450599+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.217394+00:00",
+     "start_time": "2026-07-18T20:21:12.444125+00:00",
      "status": "completed"
     }
    },
@@ -1487,14 +1487,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7de19c7",
+   "id": "39140511",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005006,
-     "end_time": "2026-06-13T02:35:07.233114+00:00",
+     "duration": 0.003597,
+     "end_time": "2026-07-18T20:21:12.457866+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.228108+00:00",
+     "start_time": "2026-07-18T20:21:12.454269+00:00",
      "status": "completed"
     }
    },
@@ -1507,19 +1507,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "5b49e0c8",
+   "id": "e8f04e97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.899735Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.899631Z",
-     "iopub.status.idle": "2026-06-16T02:33:54.901839Z",
-     "shell.execute_reply": "2026-06-16T02:33:54.901490Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.465749Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.465642Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.467869Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.467416Z"
     },
     "papermill": {
-     "duration": 0.006731,
-     "end_time": "2026-06-13T02:35:07.243650+00:00",
+     "duration": 0.007065,
+     "end_time": "2026-07-18T20:21:12.468426+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.236919+00:00",
+     "start_time": "2026-07-18T20:21:12.461361+00:00",
      "status": "completed"
     }
    },
@@ -1537,19 +1537,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "ecacce0c",
+   "id": "b0818e35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:54.902613Z",
-     "iopub.status.busy": "2026-06-16T02:33:54.902512Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.230050Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.229719Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.480761Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.480606Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.777463Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.776936Z"
     },
     "papermill": {
-     "duration": 0.323698,
-     "end_time": "2026-06-13T02:35:07.571293+00:00",
+     "duration": 0.302144,
+     "end_time": "2026-07-18T20:21:12.777860+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.247595+00:00",
+     "start_time": "2026-07-18T20:21:12.475716+00:00",
      "status": "completed"
     }
    },
@@ -1558,7 +1558,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  cross_sectional_zscore: pandas=0.0037s, polars=0.0033s, speedup=1.1x\n"
+      "  cross_sectional_zscore: pandas=0.0043s, polars=0.0037s, speedup=1.2x\n"
      ]
     }
    ],
@@ -1583,14 +1583,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64993488",
+   "id": "fd2e9a78",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004048,
-     "end_time": "2026-06-13T02:35:07.579417+00:00",
+     "duration": 0.003582,
+     "end_time": "2026-07-18T20:21:12.785397+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.575369+00:00",
+     "start_time": "2026-07-18T20:21:12.781815+00:00",
      "status": "completed"
     }
    },
@@ -1603,19 +1603,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "bfec01f8",
+   "id": "e0273235",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.231047Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.230970Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.232784Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.232450Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.793581Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.793474Z",
+     "iopub.status.idle": "2026-07-18T20:21:12.795781Z",
+     "shell.execute_reply": "2026-07-18T20:21:12.795359Z"
     },
     "papermill": {
-     "duration": 0.006868,
-     "end_time": "2026-06-13T02:35:07.590018+00:00",
+     "duration": 0.00718,
+     "end_time": "2026-07-18T20:21:12.796126+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.583150+00:00",
+     "start_time": "2026-07-18T20:21:12.788946+00:00",
      "status": "completed"
     }
    },
@@ -1632,19 +1632,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "27bbd5b5",
+   "id": "8ed2a0a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.233369Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.233308Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.576081Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.575713Z"
+     "iopub.execute_input": "2026-07-18T20:21:12.804105Z",
+     "iopub.status.busy": "2026-07-18T20:21:12.804013Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.134252Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.133745Z"
     },
     "papermill": {
-     "duration": 0.346866,
-     "end_time": "2026-06-13T02:35:07.940639+00:00",
+     "duration": 0.334792,
+     "end_time": "2026-07-18T20:21:13.134554+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.593773+00:00",
+     "start_time": "2026-07-18T20:21:12.799762+00:00",
      "status": "completed"
     }
    },
@@ -1653,7 +1653,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  percentile_rank: pandas=0.0045s, polars=0.0127s, speedup=0.4x\n"
+      "  percentile_rank: pandas=0.0047s, polars=0.0110s, speedup=0.4x\n"
      ]
     }
    ],
@@ -1677,13 +1677,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fcc6757",
+   "id": "7dcdc3be",
    "metadata": {
     "papermill": {
-     "duration": 0.00434,
-     "end_time": "2026-06-13T02:35:07.949070+00:00",
+     "duration": 0.003696,
+     "end_time": "2026-07-18T20:21:13.142228+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.944730+00:00",
+     "start_time": "2026-07-18T20:21:13.138532+00:00",
      "status": "completed"
     }
    },
@@ -1696,19 +1696,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "e9992f4e",
+   "id": "806c744b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.577098Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.577027Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.578787Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.578547Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.150286Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.150177Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.152740Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.152239Z"
     },
     "papermill": {
-     "duration": 0.010242,
-     "end_time": "2026-06-13T02:35:07.963538+00:00",
+     "duration": 0.007305,
+     "end_time": "2026-07-18T20:21:13.153120+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.953296+00:00",
+     "start_time": "2026-07-18T20:21:13.145815+00:00",
      "status": "completed"
     }
    },
@@ -1728,19 +1728,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "35c58403",
+   "id": "e8e00231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.579465Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.579399Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.910238Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.909921Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.161557Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.161408Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.444842Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.444312Z"
     },
     "papermill": {
-     "duration": 0.350209,
-     "end_time": "2026-06-13T02:35:08.318116+00:00",
+     "duration": 0.28812,
+     "end_time": "2026-07-18T20:21:13.445151+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:07.967907+00:00",
+     "start_time": "2026-07-18T20:21:13.157031+00:00",
      "status": "completed"
     }
    },
@@ -1749,7 +1749,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  lagged_values: pandas=0.0051s, polars=0.0013s, speedup=4.0x\n"
+      "  lagged_values: pandas=0.0035s, polars=0.0017s, speedup=2.0x\n"
      ]
     }
    ],
@@ -1771,13 +1771,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1c20fda",
+   "id": "80070d7e",
    "metadata": {
     "papermill": {
-     "duration": 0.003846,
-     "end_time": "2026-06-13T02:35:08.329121+00:00",
+     "duration": 0.003667,
+     "end_time": "2026-07-18T20:21:13.452748+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.325275+00:00",
+     "start_time": "2026-07-18T20:21:13.449081+00:00",
      "status": "completed"
     }
    },
@@ -1791,19 +1791,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "7188b118",
+   "id": "71f39962",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.911290Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.911213Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.914031Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.912659Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.460771Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.460671Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.462748Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.462466Z"
     },
     "papermill": {
-     "duration": 0.006671,
-     "end_time": "2026-06-13T02:35:08.339567+00:00",
+     "duration": 0.006772,
+     "end_time": "2026-07-18T20:21:13.463137+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.332896+00:00",
+     "start_time": "2026-07-18T20:21:13.456365+00:00",
      "status": "completed"
     }
    },
@@ -1829,13 +1829,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6406a601",
+   "id": "51298379",
    "metadata": {
     "papermill": {
-     "duration": 0.003798,
-     "end_time": "2026-06-13T02:35:08.347174+00:00",
+     "duration": 0.003627,
+     "end_time": "2026-07-18T20:21:13.471834+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.343376+00:00",
+     "start_time": "2026-07-18T20:21:13.468207+00:00",
      "status": "completed"
     }
    },
@@ -1846,19 +1846,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "c5708569",
+   "id": "e793db33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.914763Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.914704Z",
-     "iopub.status.idle": "2026-06-16T02:33:55.916836Z",
-     "shell.execute_reply": "2026-06-16T02:33:55.916610Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.480033Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.479911Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.482768Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.482361Z"
     },
     "papermill": {
-     "duration": 0.007022,
-     "end_time": "2026-06-13T02:35:08.357968+00:00",
+     "duration": 0.007593,
+     "end_time": "2026-07-18T20:21:13.483044+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.350946+00:00",
+     "start_time": "2026-07-18T20:21:13.475451+00:00",
      "status": "completed"
     }
    },
@@ -1877,19 +1877,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "94e48f35",
+   "id": "c9be2dbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:55.917643Z",
-     "iopub.status.busy": "2026-06-16T02:33:55.917582Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.254066Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.253593Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.491143Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.491037Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.752686Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.752192Z"
     },
     "papermill": {
-     "duration": 0.292651,
-     "end_time": "2026-06-13T02:35:08.654730+00:00",
+     "duration": 0.266575,
+     "end_time": "2026-07-18T20:21:13.753341+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.362079+00:00",
+     "start_time": "2026-07-18T20:21:13.486766+00:00",
      "status": "completed"
     }
    },
@@ -1898,7 +1898,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  simple_filter: pandas=0.0014s, polars=0.0008s, speedup=1.7x\n"
+      "  simple_filter: pandas=0.0014s, polars=0.0005s, speedup=2.9x\n"
      ]
     }
    ],
@@ -1916,13 +1916,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79afefed",
+   "id": "c0cb992a",
    "metadata": {
     "papermill": {
-     "duration": 0.004272,
-     "end_time": "2026-06-13T02:35:08.666663+00:00",
+     "duration": 0.00371,
+     "end_time": "2026-07-18T20:21:13.761090+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.662391+00:00",
+     "start_time": "2026-07-18T20:21:13.757380+00:00",
      "status": "completed"
     }
    },
@@ -1935,19 +1935,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "4686ca06",
+   "id": "2a8ec250",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.255244Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.255135Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.259036Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.258723Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.769521Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.769423Z",
+     "iopub.status.idle": "2026-07-18T20:21:13.773664Z",
+     "shell.execute_reply": "2026-07-18T20:21:13.773256Z"
     },
     "papermill": {
-     "duration": 0.008381,
-     "end_time": "2026-06-13T02:35:08.678848+00:00",
+     "duration": 0.009167,
+     "end_time": "2026-07-18T20:21:13.774194+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.670467+00:00",
+     "start_time": "2026-07-18T20:21:13.765027+00:00",
      "status": "completed"
     }
    },
@@ -1971,19 +1971,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "cfc87a04",
+   "id": "216d2467",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.259923Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.259857Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.581476Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.581102Z"
+     "iopub.execute_input": "2026-07-18T20:21:13.783730Z",
+     "iopub.status.busy": "2026-07-18T20:21:13.783644Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.049619Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.049182Z"
     },
     "papermill": {
-     "duration": 0.290899,
-     "end_time": "2026-06-13T02:35:08.973647+00:00",
+     "duration": 0.271148,
+     "end_time": "2026-07-18T20:21:14.050236+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.682748+00:00",
+     "start_time": "2026-07-18T20:21:13.779088+00:00",
      "status": "completed"
     }
    },
@@ -2014,14 +2014,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87e83fa2",
+   "id": "c76e7ed9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003882,
-     "end_time": "2026-06-13T02:35:08.981643+00:00",
+     "duration": 0.003685,
+     "end_time": "2026-07-18T20:21:14.060954+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.977761+00:00",
+     "start_time": "2026-07-18T20:21:14.057269+00:00",
      "status": "completed"
     }
    },
@@ -2034,19 +2034,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "8ea7bfb4",
+   "id": "cddbdcdb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.582502Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.582416Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.584274Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.584001Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.072625Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.072527Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.074671Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.074290Z"
     },
     "papermill": {
-     "duration": 0.006922,
-     "end_time": "2026-06-13T02:35:08.992372+00:00",
+     "duration": 0.007171,
+     "end_time": "2026-07-18T20:21:14.075139+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.985450+00:00",
+     "start_time": "2026-07-18T20:21:14.067968+00:00",
      "status": "completed"
     }
    },
@@ -2068,19 +2068,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "d0af5681",
+   "id": "df7dcde0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.585221Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.585150Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.918757Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.918385Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.085784Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.085694Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.363834Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.363454Z"
     },
     "papermill": {
-     "duration": 0.294434,
-     "end_time": "2026-06-13T02:35:09.290655+00:00",
+     "duration": 0.283191,
+     "end_time": "2026-07-18T20:21:14.364505+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:08.996221+00:00",
+     "start_time": "2026-07-18T20:21:14.081314+00:00",
      "status": "completed"
     }
    },
@@ -2089,7 +2089,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  range_filter: pandas=0.0015s, polars=0.0009s, speedup=1.6x\n"
+      "  range_filter: pandas=0.0015s, polars=0.0006s, speedup=2.6x\n"
      ]
     }
    ],
@@ -2113,13 +2113,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0994934a",
+   "id": "5ad394e6",
    "metadata": {
     "papermill": {
-     "duration": 0.003983,
-     "end_time": "2026-06-13T02:35:09.298808+00:00",
+     "duration": 0.003825,
+     "end_time": "2026-07-18T20:21:14.390461+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.294825+00:00",
+     "start_time": "2026-07-18T20:21:14.386636+00:00",
      "status": "completed"
     }
    },
@@ -2133,19 +2133,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "b76367d4",
+   "id": "a2b14c19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.920067Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.919971Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.921857Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.921573Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.399021Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.398918Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.401018Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.400556Z"
     },
     "papermill": {
-     "duration": 0.006748,
-     "end_time": "2026-06-13T02:35:09.309434+00:00",
+     "duration": 0.007136,
+     "end_time": "2026-07-18T20:21:14.401391+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.302686+00:00",
+     "start_time": "2026-07-18T20:21:14.394255+00:00",
      "status": "completed"
     }
    },
@@ -2171,13 +2171,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d29d631",
+   "id": "febd81f2",
    "metadata": {
     "papermill": {
-     "duration": 0.003794,
-     "end_time": "2026-06-13T02:35:09.317083+00:00",
+     "duration": 0.003712,
+     "end_time": "2026-07-18T20:21:14.408975+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.313289+00:00",
+     "start_time": "2026-07-18T20:21:14.405263+00:00",
      "status": "completed"
     }
    },
@@ -2190,19 +2190,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "83c8e7c6",
+   "id": "2822283e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.923186Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.923103Z",
-     "iopub.status.idle": "2026-06-16T02:33:56.929752Z",
-     "shell.execute_reply": "2026-06-16T02:33:56.929453Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.417229Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.417127Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.423889Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.423521Z"
     },
     "papermill": {
-     "duration": 0.010929,
-     "end_time": "2026-06-13T02:35:09.331849+00:00",
+     "duration": 0.011918,
+     "end_time": "2026-07-18T20:21:14.424607+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.320920+00:00",
+     "start_time": "2026-07-18T20:21:14.412689+00:00",
      "status": "completed"
     }
    },
@@ -2232,19 +2232,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "0e97a37a",
+   "id": "0c60fbc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:56.930885Z",
-     "iopub.status.busy": "2026-06-16T02:33:56.930816Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.259495Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.259103Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.435421Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.435323Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.725080Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.724419Z"
     },
     "papermill": {
-     "duration": 0.307252,
-     "end_time": "2026-06-13T02:35:09.643147+00:00",
+     "duration": 0.294723,
+     "end_time": "2026-07-18T20:21:14.725508+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.335895+00:00",
+     "start_time": "2026-07-18T20:21:14.430785+00:00",
      "status": "completed"
     }
    },
@@ -2253,7 +2253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  asof_join: pandas=0.0032s, polars=0.0010s, speedup=3.2x\n"
+      "  asof_join: pandas=0.0032s, polars=0.0009s, speedup=3.5x\n"
      ]
     }
    ],
@@ -2276,14 +2276,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e589b0b3",
+   "id": "ea337353",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003929,
-     "end_time": "2026-06-13T02:35:09.651763+00:00",
+     "duration": 0.003816,
+     "end_time": "2026-07-18T20:21:14.733504+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.647834+00:00",
+     "start_time": "2026-07-18T20:21:14.729688+00:00",
      "status": "completed"
     }
    },
@@ -2297,19 +2297,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "d073e39c",
+   "id": "ad098b05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.260790Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.260721Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.263013Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.262769Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.745823Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.745643Z",
+     "iopub.status.idle": "2026-07-18T20:21:14.749505Z",
+     "shell.execute_reply": "2026-07-18T20:21:14.749038Z"
     },
     "papermill": {
-     "duration": 0.010368,
-     "end_time": "2026-06-13T02:35:09.666358+00:00",
+     "duration": 0.008943,
+     "end_time": "2026-07-18T20:21:14.749842+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.655990+00:00",
+     "start_time": "2026-07-18T20:21:14.740899+00:00",
      "status": "completed"
     }
    },
@@ -2354,19 +2354,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "c595e973",
+   "id": "98ce3ca4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.264007Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.263938Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.605365Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.604800Z"
+     "iopub.execute_input": "2026-07-18T20:21:14.758492Z",
+     "iopub.status.busy": "2026-07-18T20:21:14.758385Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.079698Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.079198Z"
     },
     "papermill": {
-     "duration": 0.320877,
-     "end_time": "2026-06-13T02:35:09.994976+00:00",
+     "duration": 0.326223,
+     "end_time": "2026-07-18T20:21:15.080130+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.674099+00:00",
+     "start_time": "2026-07-18T20:21:14.753907+00:00",
      "status": "completed"
     }
    },
@@ -2375,7 +2375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  anti_join: pandas=0.0065s, polars=0.0021s, speedup=3.0x\n"
+      "  anti_join: pandas=0.0071s, polars=0.0021s, speedup=3.4x\n"
      ]
     }
    ],
@@ -2397,13 +2397,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c149b6f",
+   "id": "2a581340",
    "metadata": {
     "papermill": {
-     "duration": 0.003928,
-     "end_time": "2026-06-13T02:35:10.003056+00:00",
+     "duration": 0.003807,
+     "end_time": "2026-07-18T20:21:15.088080+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:09.999128+00:00",
+     "start_time": "2026-07-18T20:21:15.084273+00:00",
      "status": "completed"
     }
    },
@@ -2416,19 +2416,19 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "9f22fdcf",
+   "id": "01b8503e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.606673Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.606550Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.611753Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.611268Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.096803Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.096693Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.100703Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.100346Z"
     },
     "papermill": {
-     "duration": 0.008914,
-     "end_time": "2026-06-13T02:35:10.015873+00:00",
+     "duration": 0.008992,
+     "end_time": "2026-07-18T20:21:15.100973+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.006959+00:00",
+     "start_time": "2026-07-18T20:21:15.091981+00:00",
      "status": "completed"
     }
    },
@@ -2458,19 +2458,19 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "b7f658d3",
+   "id": "0b93ea83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.612972Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.612850Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.973165Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.972849Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.110102Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.110010Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.402928Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.402427Z"
     },
     "papermill": {
-     "duration": 0.311365,
-     "end_time": "2026-06-13T02:35:10.331270+00:00",
+     "duration": 0.298252,
+     "end_time": "2026-07-18T20:21:15.403256+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.019905+00:00",
+     "start_time": "2026-07-18T20:21:15.105004+00:00",
      "status": "completed"
     }
    },
@@ -2479,7 +2479,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  inner_join: pandas=0.0046s, polars=0.0010s, speedup=4.6x\n"
+      "  inner_join: pandas=0.0046s, polars=0.0009s, speedup=4.9x\n"
      ]
     }
    ],
@@ -2499,13 +2499,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49e43b8f",
+   "id": "7210b78c",
    "metadata": {
     "papermill": {
-     "duration": 0.004014,
-     "end_time": "2026-06-13T02:35:10.339535+00:00",
+     "duration": 0.003826,
+     "end_time": "2026-07-18T20:21:15.411240+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.335521+00:00",
+     "start_time": "2026-07-18T20:21:15.407414+00:00",
      "status": "completed"
     }
    },
@@ -2519,19 +2519,19 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "74729d73",
+   "id": "c238c04a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.974536Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.974456Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.979121Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.978817Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.419698Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.419589Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.424616Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.424253Z"
     },
     "papermill": {
-     "duration": 0.010956,
-     "end_time": "2026-06-13T02:35:10.354502+00:00",
+     "duration": 0.010039,
+     "end_time": "2026-07-18T20:21:15.425091+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.343546+00:00",
+     "start_time": "2026-07-18T20:21:15.415052+00:00",
      "status": "completed"
     }
    },
@@ -2563,14 +2563,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57b08fad",
+   "id": "7265e5a8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003995,
-     "end_time": "2026-06-13T02:35:10.362683+00:00",
+     "duration": 0.003832,
+     "end_time": "2026-07-18T20:21:15.435230+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.358688+00:00",
+     "start_time": "2026-07-18T20:21:15.431398+00:00",
      "status": "completed"
     }
    },
@@ -2583,19 +2583,19 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "df987539",
+   "id": "f3f38960",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.980306Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.980233Z",
-     "iopub.status.idle": "2026-06-16T02:33:57.981955Z",
-     "shell.execute_reply": "2026-06-16T02:33:57.981686Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.443869Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.443764Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.445645Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.445331Z"
     },
     "papermill": {
-     "duration": 0.007391,
-     "end_time": "2026-06-13T02:35:10.374138+00:00",
+     "duration": 0.00688,
+     "end_time": "2026-07-18T20:21:15.445950+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.366747+00:00",
+     "start_time": "2026-07-18T20:21:15.439070+00:00",
      "status": "completed"
     }
    },
@@ -2612,19 +2612,19 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "76a716f1",
+   "id": "9258b3d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:57.983007Z",
-     "iopub.status.busy": "2026-06-16T02:33:57.982931Z",
-     "iopub.status.idle": "2026-06-16T02:33:58.315412Z",
-     "shell.execute_reply": "2026-06-16T02:33:58.314975Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.455058Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.454915Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.767699Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.767341Z"
     },
     "papermill": {
-     "duration": 0.332005,
-     "end_time": "2026-06-13T02:35:10.710128+00:00",
+     "duration": 0.318152,
+     "end_time": "2026-07-18T20:21:15.768077+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.378123+00:00",
+     "start_time": "2026-07-18T20:21:15.449925+00:00",
      "status": "completed"
     }
    },
@@ -2633,7 +2633,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  lazy_filter: pandas=0.0030s, polars=0.0012s, speedup=2.4x\n"
+      "  lazy_filter: pandas=0.0031s, polars=0.0013s, speedup=2.4x\n"
      ]
     }
    ],
@@ -2652,14 +2652,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "929166e2",
+   "id": "30529b96",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004045,
-     "end_time": "2026-06-13T02:35:10.718430+00:00",
+     "duration": 0.003894,
+     "end_time": "2026-07-18T20:21:15.776218+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.714385+00:00",
+     "start_time": "2026-07-18T20:21:15.772324+00:00",
      "status": "completed"
     }
    },
@@ -2672,19 +2672,19 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "18d31d33",
+   "id": "31fc465c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:58.316851Z",
-     "iopub.status.busy": "2026-06-16T02:33:58.316777Z",
-     "iopub.status.idle": "2026-06-16T02:33:58.318801Z",
-     "shell.execute_reply": "2026-06-16T02:33:58.318392Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.784955Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.784842Z",
+     "iopub.status.idle": "2026-07-18T20:21:15.786656Z",
+     "shell.execute_reply": "2026-07-18T20:21:15.786352Z"
     },
     "papermill": {
-     "duration": 0.00677,
-     "end_time": "2026-06-13T02:35:10.729131+00:00",
+     "duration": 0.00693,
+     "end_time": "2026-07-18T20:21:15.787064+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.722361+00:00",
+     "start_time": "2026-07-18T20:21:15.780134+00:00",
      "status": "completed"
     }
    },
@@ -2699,19 +2699,19 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "945768c6",
+   "id": "573cb15c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:58.319543Z",
-     "iopub.status.busy": "2026-06-16T02:33:58.319482Z",
-     "iopub.status.idle": "2026-06-16T02:33:58.616005Z",
-     "shell.execute_reply": "2026-06-16T02:33:58.615694Z"
+     "iopub.execute_input": "2026-07-18T20:21:15.795640Z",
+     "iopub.status.busy": "2026-07-18T20:21:15.795541Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.100168Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.099845Z"
     },
     "papermill": {
-     "duration": 0.312039,
-     "end_time": "2026-06-13T02:35:11.045108+00:00",
+     "duration": 0.30966,
+     "end_time": "2026-07-18T20:21:16.100745+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:10.733069+00:00",
+     "start_time": "2026-07-18T20:21:15.791085+00:00",
      "status": "completed"
     }
    },
@@ -2738,14 +2738,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "057a7f86",
+   "id": "6a86287e",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004152,
-     "end_time": "2026-06-13T02:35:11.053608+00:00",
+     "duration": 0.007452,
+     "end_time": "2026-07-18T20:21:16.115985+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.049456+00:00",
+     "start_time": "2026-07-18T20:21:16.108533+00:00",
      "status": "completed"
     }
    },
@@ -2758,19 +2758,19 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "030127e5",
+   "id": "b6da5791",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:58.617051Z",
-     "iopub.status.busy": "2026-06-16T02:33:58.616980Z",
-     "iopub.status.idle": "2026-06-16T02:33:58.618722Z",
-     "shell.execute_reply": "2026-06-16T02:33:58.618447Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.131467Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.131271Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.134059Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.133629Z"
     },
     "papermill": {
-     "duration": 0.006893,
-     "end_time": "2026-06-13T02:35:11.064488+00:00",
+     "duration": 0.011134,
+     "end_time": "2026-07-18T20:21:16.134423+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.057595+00:00",
+     "start_time": "2026-07-18T20:21:16.123289+00:00",
      "status": "completed"
     }
    },
@@ -2791,19 +2791,19 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "b0b5939e",
+   "id": "a1c5a7ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:58.619366Z",
-     "iopub.status.busy": "2026-06-16T02:33:58.619304Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.031784Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.031457Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.143379Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.143224Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.440512Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.440081Z"
     },
     "papermill": {
-     "duration": 0.321045,
-     "end_time": "2026-06-13T02:35:11.389601+00:00",
+     "duration": 0.302483,
+     "end_time": "2026-07-18T20:21:16.440955+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.068556+00:00",
+     "start_time": "2026-07-18T20:21:16.138472+00:00",
      "status": "completed"
     }
    },
@@ -2812,7 +2812,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  combined_query: pandas=0.0052s, polars=0.0016s, speedup=3.3x\n"
+      "  combined_query: pandas=0.0033s, polars=0.0017s, speedup=2.0x\n"
      ]
     }
    ],
@@ -2843,13 +2843,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc88614a",
+   "id": "6b55af36",
    "metadata": {
     "papermill": {
-     "duration": 0.004003,
-     "end_time": "2026-06-13T02:35:11.397841+00:00",
+     "duration": 0.004005,
+     "end_time": "2026-07-18T20:21:16.449292+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.393838+00:00",
+     "start_time": "2026-07-18T20:21:16.445287+00:00",
      "status": "completed"
     }
    },
@@ -2863,19 +2863,19 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "39afcfb0",
+   "id": "02d60d24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.032797Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.032725Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.034336Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.034100Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.458026Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.457917Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.460209Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.459812Z"
     },
     "papermill": {
-     "duration": 0.007275,
-     "end_time": "2026-06-13T02:35:11.409073+00:00",
+     "duration": 0.007342,
+     "end_time": "2026-07-18T20:21:16.460535+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.401798+00:00",
+     "start_time": "2026-07-18T20:21:16.453193+00:00",
      "status": "completed"
     }
    },
@@ -2901,13 +2901,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d59f661c",
+   "id": "afe2a1f1",
    "metadata": {
     "papermill": {
-     "duration": 0.003983,
-     "end_time": "2026-06-13T02:35:11.417242+00:00",
+     "duration": 0.003965,
+     "end_time": "2026-07-18T20:21:16.468578+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.413259+00:00",
+     "start_time": "2026-07-18T20:21:16.464613+00:00",
      "status": "completed"
     }
    },
@@ -2918,19 +2918,19 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "76799ca0",
+   "id": "21b67500",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.035215Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.035155Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.320025Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.319697Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.477311Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.477189Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.749264Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.748820Z"
     },
     "papermill": {
-     "duration": 0.296087,
-     "end_time": "2026-06-13T02:35:11.717314+00:00",
+     "duration": 0.277447,
+     "end_time": "2026-07-18T20:21:16.749950+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.421227+00:00",
+     "start_time": "2026-07-18T20:21:16.472503+00:00",
      "status": "completed"
     }
    },
@@ -2993,13 +2993,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcb43ca0",
+   "id": "a48a8ede",
    "metadata": {
     "papermill": {
-     "duration": 0.004016,
-     "end_time": "2026-06-13T02:35:11.725660+00:00",
+     "duration": 0.004061,
+     "end_time": "2026-07-18T20:21:16.759954+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.721644+00:00",
+     "start_time": "2026-07-18T20:21:16.755893+00:00",
      "status": "completed"
     }
    },
@@ -3013,19 +3013,19 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "4e693b2a",
+   "id": "e383da12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.321203Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.321125Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.322871Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.322569Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.769088Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.768983Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.771039Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.770686Z"
     },
     "papermill": {
-     "duration": 0.007131,
-     "end_time": "2026-06-13T02:35:11.736770+00:00",
+     "duration": 0.007066,
+     "end_time": "2026-07-18T20:21:16.771298+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.729639+00:00",
+     "start_time": "2026-07-18T20:21:16.764232+00:00",
      "status": "completed"
     }
    },
@@ -3051,14 +3051,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04d1a755",
+   "id": "fdface0a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004007,
-     "end_time": "2026-06-13T02:35:11.744828+00:00",
+     "duration": 0.003952,
+     "end_time": "2026-07-18T20:21:16.779526+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.740821+00:00",
+     "start_time": "2026-07-18T20:21:16.775574+00:00",
      "status": "completed"
     }
    },
@@ -3069,19 +3069,19 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "d7eee0d0",
+   "id": "7b5cac51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.323696Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.323628Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.325257Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.324951Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.788059Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.787958Z",
+     "iopub.status.idle": "2026-07-18T20:21:16.789859Z",
+     "shell.execute_reply": "2026-07-18T20:21:16.789542Z"
     },
     "papermill": {
-     "duration": 0.007407,
-     "end_time": "2026-06-13T02:35:11.756236+00:00",
+     "duration": 0.006799,
+     "end_time": "2026-07-18T20:21:16.790248+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.748829+00:00",
+     "start_time": "2026-07-18T20:21:16.783449+00:00",
      "status": "completed"
     }
    },
@@ -3096,19 +3096,19 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "d76c2bb6",
+   "id": "3d950b43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.326013Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.325953Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.616068Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.615738Z"
+     "iopub.execute_input": "2026-07-18T20:21:16.799157Z",
+     "iopub.status.busy": "2026-07-18T20:21:16.799057Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.097176Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.096732Z"
     },
     "papermill": {
-     "duration": 0.311098,
-     "end_time": "2026-06-13T02:35:12.071344+00:00",
+     "duration": 0.303171,
+     "end_time": "2026-07-18T20:21:17.097525+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:11.760246+00:00",
+     "start_time": "2026-07-18T20:21:16.794354+00:00",
      "status": "completed"
     }
    },
@@ -3117,7 +3117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_contains: pandas=0.0027s, polars=0.0009s, speedup=3.1x\n"
+      "  str_contains: pandas=0.0026s, polars=0.0010s, speedup=2.6x\n"
      ]
     }
    ],
@@ -3135,14 +3135,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4f71527",
+   "id": "88ac1161",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004114,
-     "end_time": "2026-06-13T02:35:12.079798+00:00",
+     "duration": 0.004537,
+     "end_time": "2026-07-18T20:21:17.106605+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.075684+00:00",
+     "start_time": "2026-07-18T20:21:17.102068+00:00",
      "status": "completed"
     }
    },
@@ -3153,19 +3153,19 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "3771c38a",
+   "id": "f34e9464",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.617057Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.616988Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.618626Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.618388Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.116138Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.115982Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.118035Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.117711Z"
     },
     "papermill": {
-     "duration": 0.007032,
-     "end_time": "2026-06-13T02:35:12.090840+00:00",
+     "duration": 0.007585,
+     "end_time": "2026-07-18T20:21:17.118464+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.083808+00:00",
+     "start_time": "2026-07-18T20:21:17.110879+00:00",
      "status": "completed"
     }
    },
@@ -3181,19 +3181,19 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "148a1693",
+   "id": "f08e03af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.619379Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.619317Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.916325Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.916006Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.127456Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.127367Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.442890Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.442577Z"
     },
     "papermill": {
-     "duration": 0.317142,
-     "end_time": "2026-06-13T02:35:12.412039+00:00",
+     "duration": 0.320769,
+     "end_time": "2026-07-18T20:21:17.443413+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.094897+00:00",
+     "start_time": "2026-07-18T20:21:17.122644+00:00",
      "status": "completed"
     }
    },
@@ -3202,7 +3202,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_replace: pandas=0.0047s, polars=0.0007s, speedup=7.2x\n"
+      "  str_replace: pandas=0.0049s, polars=0.0007s, speedup=7.1x\n"
      ]
     }
    ],
@@ -3222,14 +3222,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cee5025",
+   "id": "cc979da1",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004071,
-     "end_time": "2026-06-13T02:35:12.420434+00:00",
+     "duration": 0.004144,
+     "end_time": "2026-07-18T20:21:17.452037+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.416363+00:00",
+     "start_time": "2026-07-18T20:21:17.447893+00:00",
      "status": "completed"
     }
    },
@@ -3240,19 +3240,19 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "d266f2c1",
+   "id": "872bb824",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.917346Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.917272Z",
-     "iopub.status.idle": "2026-06-16T02:33:59.918907Z",
-     "shell.execute_reply": "2026-06-16T02:33:59.918674Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.460960Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.460859Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.462732Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.462362Z"
     },
     "papermill": {
-     "duration": 0.007646,
-     "end_time": "2026-06-13T02:35:12.432103+00:00",
+     "duration": 0.007029,
+     "end_time": "2026-07-18T20:21:17.463158+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.424457+00:00",
+     "start_time": "2026-07-18T20:21:17.456129+00:00",
      "status": "completed"
     }
    },
@@ -3268,19 +3268,19 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "b2752038",
+   "id": "905b2ab5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:33:59.919623Z",
-     "iopub.status.busy": "2026-06-16T02:33:59.919563Z",
-     "iopub.status.idle": "2026-06-16T02:34:00.231905Z",
-     "shell.execute_reply": "2026-06-16T02:34:00.231563Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.472098Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.471999Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.767107Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.766694Z"
     },
     "papermill": {
-     "duration": 0.325503,
-     "end_time": "2026-06-13T02:35:12.761728+00:00",
+     "duration": 0.30031,
+     "end_time": "2026-07-18T20:21:17.767650+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.436225+00:00",
+     "start_time": "2026-07-18T20:21:17.467340+00:00",
      "status": "completed"
     }
    },
@@ -3289,7 +3289,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_extract: pandas=0.0052s, polars=0.0006s, speedup=8.1x\n"
+      "  str_extract: pandas=0.0054s, polars=0.0008s, speedup=6.6x\n"
      ]
     }
    ],
@@ -3311,13 +3311,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7171d5c",
+   "id": "9537039a",
    "metadata": {
     "papermill": {
-     "duration": 0.004421,
-     "end_time": "2026-06-13T02:35:12.772247+00:00",
+     "duration": 0.004129,
+     "end_time": "2026-07-18T20:21:17.776203+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.767826+00:00",
+     "start_time": "2026-07-18T20:21:17.772074+00:00",
      "status": "completed"
     }
    },
@@ -3328,19 +3328,19 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "e74a9a3d",
+   "id": "4dc787a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:34:00.232871Z",
-     "iopub.status.busy": "2026-06-16T02:34:00.232797Z",
-     "iopub.status.idle": "2026-06-16T02:34:00.240363Z",
-     "shell.execute_reply": "2026-06-16T02:34:00.240077Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.785075Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.784981Z",
+     "iopub.status.idle": "2026-07-18T20:21:17.795054Z",
+     "shell.execute_reply": "2026-07-18T20:21:17.794777Z"
     },
     "papermill": {
-     "duration": 0.016315,
-     "end_time": "2026-06-13T02:35:12.792776+00:00",
+     "duration": 0.015155,
+     "end_time": "2026-07-18T20:21:17.795436+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.776461+00:00",
+     "start_time": "2026-07-18T20:21:17.780281+00:00",
      "status": "completed"
     }
    },
@@ -3367,7 +3367,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (8, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>mean_speedup</th><th>min_speedup</th><th>max_speedup</th><th>n_ops</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>6.142819</td><td>3.076095</td><td>8.118097</td><td>3</td></tr><tr><td>&quot;E_join&quot;</td><td>3.625185</td><td>3.040387</td><td>4.59511</td><td>3</td></tr><tr><td>&quot;F_lazy&quot;</td><td>2.851385</td><td>2.448117</td><td>3.310183</td><td>3</td></tr><tr><td>&quot;C_window&quot;</td><td>1.839027</td><td>0.357715</td><td>4.031803</td><td>3</td></tr><tr><td>&quot;G_memory&quot;</td><td>1.815652</td><td>1.815652</td><td>1.815652</td><td>1</td></tr><tr><td>&quot;B_groupby&quot;</td><td>1.811912</td><td>1.213148</td><td>2.698723</td><td>3</td></tr><tr><td>&quot;A_rolling&quot;</td><td>1.80977</td><td>0.435263</td><td>5.119252</td><td>5</td></tr><tr><td>&quot;D_filter&quot;</td><td>1.509915</td><td>1.26291</td><td>1.698636</td><td>3</td></tr></tbody></table></div>"
+       "<small>shape: (8, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>mean_speedup</th><th>min_speedup</th><th>max_speedup</th><th>n_ops</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>5.449681</td><td>2.63587</td><td>7.075123</td><td>3</td></tr><tr><td>&quot;E_join&quot;</td><td>3.961029</td><td>3.43296</td><td>4.922292</td><td>3</td></tr><tr><td>&quot;F_lazy&quot;</td><td>2.382538</td><td>1.999468</td><td>2.776322</td><td>3</td></tr><tr><td>&quot;D_filter&quot;</td><td>2.25142</td><td>1.274596</td><td>2.908793</td><td>3</td></tr><tr><td>&quot;B_groupby&quot;</td><td>1.823755</td><td>1.058339</td><td>2.672985</td><td>3</td></tr><tr><td>&quot;G_memory&quot;</td><td>1.815652</td><td>1.815652</td><td>1.815652</td><td>1</td></tr><tr><td>&quot;A_rolling&quot;</td><td>1.663839</td><td>0.866258</td><td>3.936437</td><td>5</td></tr><tr><td>&quot;C_window&quot;</td><td>1.219659</td><td>0.424272</td><td>2.047402</td><td>3</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (8, 5)\n",
@@ -3376,14 +3376,14 @@
        "│ ---       ┆ ---          ┆ ---         ┆ ---         ┆ ---   │\n",
        "│ str       ┆ f64          ┆ f64         ┆ f64         ┆ u32   │\n",
        "╞═══════════╪══════════════╪═════════════╪═════════════╪═══════╡\n",
-       "│ H_string  ┆ 6.142819     ┆ 3.076095    ┆ 8.118097    ┆ 3     │\n",
-       "│ E_join    ┆ 3.625185     ┆ 3.040387    ┆ 4.59511     ┆ 3     │\n",
-       "│ F_lazy    ┆ 2.851385     ┆ 2.448117    ┆ 3.310183    ┆ 3     │\n",
-       "│ C_window  ┆ 1.839027     ┆ 0.357715    ┆ 4.031803    ┆ 3     │\n",
+       "│ H_string  ┆ 5.449681     ┆ 2.63587     ┆ 7.075123    ┆ 3     │\n",
+       "│ E_join    ┆ 3.961029     ┆ 3.43296     ┆ 4.922292    ┆ 3     │\n",
+       "│ F_lazy    ┆ 2.382538     ┆ 1.999468    ┆ 2.776322    ┆ 3     │\n",
+       "│ D_filter  ┆ 2.25142      ┆ 1.274596    ┆ 2.908793    ┆ 3     │\n",
+       "│ B_groupby ┆ 1.823755     ┆ 1.058339    ┆ 2.672985    ┆ 3     │\n",
        "│ G_memory  ┆ 1.815652     ┆ 1.815652    ┆ 1.815652    ┆ 1     │\n",
-       "│ B_groupby ┆ 1.811912     ┆ 1.213148    ┆ 2.698723    ┆ 3     │\n",
-       "│ A_rolling ┆ 1.80977      ┆ 0.435263    ┆ 5.119252    ┆ 5     │\n",
-       "│ D_filter  ┆ 1.509915     ┆ 1.26291     ┆ 1.698636    ┆ 3     │\n",
+       "│ A_rolling ┆ 1.663839     ┆ 0.866258    ┆ 3.936437    ┆ 5     │\n",
+       "│ C_window  ┆ 1.219659     ┆ 0.424272    ┆ 2.047402    ┆ 3     │\n",
        "└───────────┴──────────────┴─────────────┴─────────────┴───────┘"
       ]
      },
@@ -3396,7 +3396,7 @@
      "text": [
       "\n",
       "### Overall Statistics\n",
-      "Mean speedup (Polars vs pandas): 2.7x\n",
+      "Mean speedup (Polars vs pandas): 2.6x\n",
       "Operations where Polars is faster: 20/24\n",
       "Operations where pandas is faster: 4/24\n",
       "Detailed Results (sorted by speedup):\n"
@@ -3412,27 +3412,27 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (24, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>operation</th><th>pandas_time</th><th>polars_time</th><th>speedup</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>&quot;str_extract&quot;</td><td>0.005235</td><td>0.000645</td><td>8.118097</td></tr><tr><td>&quot;H_string&quot;</td><td>&quot;str_replace&quot;</td><td>0.004721</td><td>0.000653</td><td>7.234265</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;multi_horizon_returns&quot;</td><td>0.008509</td><td>0.001662</td><td>5.119252</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;inner_join&quot;</td><td>0.004623</td><td>0.001006</td><td>4.59511</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;lagged_values&quot;</td><td>0.005093</td><td>0.001263</td><td>4.031803</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;cross_sectional_zscore&quot;</td><td>0.003698</td><td>0.00328</td><td>1.127562</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_mean_20&quot;</td><td>0.001155</td><td>0.001163</td><td>0.992635</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_std_20&quot;</td><td>0.001185</td><td>0.001282</td><td>0.924274</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;ewm_span_20&quot;</td><td>0.000996</td><td>0.002288</td><td>0.435263</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;percentile_rank&quot;</td><td>0.004538</td><td>0.012687</td><td>0.357715</td></tr></tbody></table></div>"
+       "<small>shape: (24, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>operation</th><th>pandas_time</th><th>polars_time</th><th>speedup</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>&quot;str_replace&quot;</td><td>0.004859</td><td>0.000687</td><td>7.075123</td></tr><tr><td>&quot;H_string&quot;</td><td>&quot;str_extract&quot;</td><td>0.005437</td><td>0.000819</td><td>6.63805</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;inner_join&quot;</td><td>0.004568</td><td>0.000928</td><td>4.922292</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;multi_horizon_returns&quot;</td><td>0.008527</td><td>0.002166</td><td>3.936437</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;asof_join&quot;</td><td>0.003224</td><td>0.000914</td><td>3.527835</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;B_groupby&quot;</td><td>&quot;cross_sectional_stats&quot;</td><td>0.001585</td><td>0.001498</td><td>1.058339</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;ewm_span_20&quot;</td><td>0.001101</td><td>0.00113</td><td>0.974853</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_std_20&quot;</td><td>0.001196</td><td>0.001277</td><td>0.936005</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_mean_20&quot;</td><td>0.001209</td><td>0.001396</td><td>0.866258</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;percentile_rank&quot;</td><td>0.004666</td><td>0.010998</td><td>0.424272</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (24, 5)\n",
-       "┌───────────┬────────────────────────┬─────────────┬─────────────┬──────────┐\n",
-       "│ category  ┆ operation              ┆ pandas_time ┆ polars_time ┆ speedup  │\n",
-       "│ ---       ┆ ---                    ┆ ---         ┆ ---         ┆ ---      │\n",
-       "│ str       ┆ str                    ┆ f64         ┆ f64         ┆ f64      │\n",
-       "╞═══════════╪════════════════════════╪═════════════╪═════════════╪══════════╡\n",
-       "│ H_string  ┆ str_extract            ┆ 0.005235    ┆ 0.000645    ┆ 8.118097 │\n",
-       "│ H_string  ┆ str_replace            ┆ 0.004721    ┆ 0.000653    ┆ 7.234265 │\n",
-       "│ A_rolling ┆ multi_horizon_returns  ┆ 0.008509    ┆ 0.001662    ┆ 5.119252 │\n",
-       "│ E_join    ┆ inner_join             ┆ 0.004623    ┆ 0.001006    ┆ 4.59511  │\n",
-       "│ C_window  ┆ lagged_values          ┆ 0.005093    ┆ 0.001263    ┆ 4.031803 │\n",
-       "│ …         ┆ …                      ┆ …           ┆ …           ┆ …        │\n",
-       "│ C_window  ┆ cross_sectional_zscore ┆ 0.003698    ┆ 0.00328     ┆ 1.127562 │\n",
-       "│ A_rolling ┆ rolling_mean_20        ┆ 0.001155    ┆ 0.001163    ┆ 0.992635 │\n",
-       "│ A_rolling ┆ rolling_std_20         ┆ 0.001185    ┆ 0.001282    ┆ 0.924274 │\n",
-       "│ A_rolling ┆ ewm_span_20            ┆ 0.000996    ┆ 0.002288    ┆ 0.435263 │\n",
-       "│ C_window  ┆ percentile_rank        ┆ 0.004538    ┆ 0.012687    ┆ 0.357715 │\n",
-       "└───────────┴────────────────────────┴─────────────┴─────────────┴──────────┘"
+       "┌───────────┬───────────────────────┬─────────────┬─────────────┬──────────┐\n",
+       "│ category  ┆ operation             ┆ pandas_time ┆ polars_time ┆ speedup  │\n",
+       "│ ---       ┆ ---                   ┆ ---         ┆ ---         ┆ ---      │\n",
+       "│ str       ┆ str                   ┆ f64         ┆ f64         ┆ f64      │\n",
+       "╞═══════════╪═══════════════════════╪═════════════╪═════════════╪══════════╡\n",
+       "│ H_string  ┆ str_replace           ┆ 0.004859    ┆ 0.000687    ┆ 7.075123 │\n",
+       "│ H_string  ┆ str_extract           ┆ 0.005437    ┆ 0.000819    ┆ 6.63805  │\n",
+       "│ E_join    ┆ inner_join            ┆ 0.004568    ┆ 0.000928    ┆ 4.922292 │\n",
+       "│ A_rolling ┆ multi_horizon_returns ┆ 0.008527    ┆ 0.002166    ┆ 3.936437 │\n",
+       "│ E_join    ┆ asof_join             ┆ 0.003224    ┆ 0.000914    ┆ 3.527835 │\n",
+       "│ …         ┆ …                     ┆ …           ┆ …           ┆ …        │\n",
+       "│ B_groupby ┆ cross_sectional_stats ┆ 0.001585    ┆ 0.001498    ┆ 1.058339 │\n",
+       "│ A_rolling ┆ ewm_span_20           ┆ 0.001101    ┆ 0.00113     ┆ 0.974853 │\n",
+       "│ A_rolling ┆ rolling_std_20        ┆ 0.001196    ┆ 0.001277    ┆ 0.936005 │\n",
+       "│ A_rolling ┆ rolling_mean_20       ┆ 0.001209    ┆ 0.001396    ┆ 0.866258 │\n",
+       "│ C_window  ┆ percentile_rank       ┆ 0.004666    ┆ 0.010998    ┆ 0.424272 │\n",
+       "└───────────┴───────────────────────┴─────────────┴─────────────┴──────────┘"
       ]
      },
      "metadata": {},
@@ -3485,13 +3485,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fa82c42",
+   "id": "437743d5",
    "metadata": {
     "papermill": {
-     "duration": 0.004252,
-     "end_time": "2026-06-13T02:35:12.801464+00:00",
+     "duration": 0.005623,
+     "end_time": "2026-07-18T20:21:17.805556+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.797212+00:00",
+     "start_time": "2026-07-18T20:21:17.799933+00:00",
      "status": "completed"
     }
    },
@@ -3502,43 +3502,40 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "9ae9b446",
+   "id": "ba2111ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:34:00.241250Z",
-     "iopub.status.busy": "2026-06-16T02:34:00.241188Z",
-     "iopub.status.idle": "2026-06-16T02:34:01.086245Z",
-     "shell.execute_reply": "2026-06-16T02:34:01.085895Z"
+     "iopub.execute_input": "2026-07-18T20:21:17.815274Z",
+     "iopub.status.busy": "2026-07-18T20:21:17.815157Z",
+     "iopub.status.idle": "2026-07-18T20:21:18.840460Z",
+     "shell.execute_reply": "2026-07-18T20:21:18.840077Z"
     },
     "papermill": {
-     "duration": 0.780356,
-     "end_time": "2026-06-13T02:35:13.586098+00:00",
+     "duration": 1.030943,
+     "end_time": "2026-07-18T20:21:18.840819+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:12.805742+00:00",
+     "start_time": "2026-07-18T20:21:17.809876+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
+      "application/json": {
        "data": [
         {
          "marker": {
           "color": "#0a1628"
          },
          "text": [
-          "6.1x",
-          "3.6x",
-          "2.9x",
+          "5.4x",
+          "4.0x",
+          "2.4x",
+          "2.3x",
           "1.8x",
           "1.8x",
-          "1.8x",
-          "1.8x",
-          "1.5x"
+          "1.7x",
+          "1.2x"
          ],
          "textposition": "outside",
          "type": "bar",
@@ -3546,22 +3543,22 @@
           "H_string",
           "E_join",
           "F_lazy",
-          "C_window",
-          "G_memory",
+          "D_filter",
           "B_groupby",
+          "G_memory",
           "A_rolling",
-          "D_filter"
+          "C_window"
          ],
          "xaxis": "x",
          "y": [
-          6.142818866392337,
-          3.6251846399585865,
-          2.8513850056630505,
-          1.8390267632998034,
+          5.449681095152066,
+          3.961028829004577,
+          2.382538043697235,
+          2.2514197633808095,
+          1.8237554301804766,
           1.8156516000477612,
-          1.8119117661475752,
-          1.809769875077452,
-          1.5099150178790801
+          1.663838617525201,
+          1.21965850107043
          ],
          "yaxis": "y"
         },
@@ -3572,39 +3569,39 @@
          "name": "pandas",
          "type": "bar",
          "x": [
-          "str_extract",
           "str_replace",
-          "multi_horizon_returns",
+          "str_extract",
           "inner_join",
-          "lagged_values",
-          "combined_query",
+          "multi_horizon_returns",
           "asof_join",
-          "str_contains",
           "anti_join",
+          "simple_filter",
           "column_projection",
           "ohlcv_resample_daily",
+          "str_contains",
+          "range_filter",
           "lazy_filter",
-          "df_estimated_size",
-          "simple_filter",
-          "rolling_sharpe_63"
+          "lagged_values",
+          "combined_query",
+          "df_estimated_size"
          ],
          "xaxis": "x2",
          "y": [
-          0.00523503334261477,
-          0.004720971027078728,
-          0.008508812674942115,
-          0.0046233390069877105,
-          0.005093083639318745,
-          0.005239242299770315,
-          0.003153546635682384,
-          0.0026527563265214362,
-          0.006475454002308349,
-          0.0029728690084690848,
-          0.0033826963820805154,
-          0.0030245720020805797,
-          1.160132,
-          0.0014223999654253323,
-          0.0033867479457209506
+          0.004858862007192026,
+          0.0054367133270716295,
+          0.004567878330514456,
+          0.008527270333919054,
+          0.0032239340022594356,
+          0.007143460670098041,
+          0.0014075903309276327,
+          0.002963986994776254,
+          0.0037004113304040707,
+          0.0026326826628064737,
+          0.0014634369969523202,
+          0.0031393423366049924,
+          0.0034671739946740368,
+          0.003347966330087123,
+          1.160132
          ],
          "yaxis": "y2"
         },
@@ -3615,39 +3612,39 @@
          "name": "Polars",
          "type": "bar",
          "x": [
-          "str_extract",
           "str_replace",
-          "multi_horizon_returns",
+          "str_extract",
           "inner_join",
-          "lagged_values",
-          "combined_query",
+          "multi_horizon_returns",
           "asof_join",
-          "str_contains",
           "anti_join",
+          "simple_filter",
           "column_projection",
           "ohlcv_resample_daily",
+          "str_contains",
+          "range_filter",
           "lazy_filter",
-          "df_estimated_size",
-          "simple_filter",
-          "rolling_sharpe_63"
+          "lagged_values",
+          "combined_query",
+          "df_estimated_size"
          ],
          "xaxis": "x2",
          "y": [
-          0.0006448597026367983,
-          0.0006525847129523754,
-          0.0016621203006555636,
-          0.0010061432840302587,
-          0.0012632272749518354,
-          0.001582765292065839,
-          0.0009732996501649419,
-          0.0008623780061801275,
-          0.00212981264727811,
-          0.0010633127142985661,
-          0.0012534433044493198,
-          0.0012354689727847774,
-          0.6389617919921875,
-          0.0008373776605973641,
-          0.0021470096350337067
+          0.0006867529979596535,
+          0.0008190226702330013,
+          0.000927998330250072,
+          0.0021662410047914213,
+          0.0009138563376230499,
+          0.002080845665962746,
+          0.00048390866625898826,
+          0.0010675946638608973,
+          0.0013843739967948447,
+          0.0009987906669266522,
+          0.0005692379976001879,
+          0.0013235986649912472,
+          0.0016934506614537288,
+          0.00167442832995827,
+          0.6389617919921875
          ],
          "yaxis": "y2"
         },
@@ -3659,29 +3656,29 @@
          "opacity": 0.7,
          "type": "histogram",
          "x": [
-          0.9926349257307949,
-          0.9242736226908009,
-          5.11925200094489,
-          1.5774255925347913,
-          0.4352632334859833,
-          2.6987230854981896,
-          1.2131475006679757,
-          1.52386471227656,
-          1.1275618520257977,
-          0.357715340910768,
-          4.031803096962845,
-          1.6986361499190559,
-          1.2629098210396872,
-          1.5681990826784973,
-          3.2400572990527254,
-          3.040386679356021,
-          4.595109941467014,
-          2.4481165198856596,
-          2.7958557896396385,
-          3.310182707463853,
-          3.076094598320898,
-          7.234265426967268,
-          8.118096573888844,
+          0.8662581605161599,
+          0.9360053023393924,
+          3.936436580721133,
+          1.6056404454088407,
+          0.97485259864048,
+          2.6729852908039327,
+          1.0583388959630784,
+          1.7399421037744192,
+          1.1873019785924916,
+          0.424271687887594,
+          2.047401836731204,
+          2.9087933923760096,
+          1.2745957114437818,
+          2.5708701863226375,
+          3.527834594488804,
+          3.432960352104236,
+          4.922291540420692,
+          2.371823438357542,
+          2.7763224144050684,
+          1.9994682783290942,
+          2.6358703079469294,
+          7.075123110678407,
+          6.638049866830859,
           1.8156516000477612
          ],
          "xaxis": "x3",
@@ -3722,56 +3719,56 @@
          ],
          "type": "scatter",
          "x": [
-          0.0011547150012726586,
-          0.0011851769716789324,
-          0.008508812674942115,
-          0.0033867479457209506,
-          0.0009960913642620046,
-          0.0033826963820805154,
-          0.0015036069865648944,
-          0.0018995426362380385,
-          0.0036981713492423296,
-          0.004538198001682758,
-          0.005093083639318745,
-          0.0014223999654253323,
-          0.0012230730305115383,
-          0.0014801012972990673,
-          0.003153546635682384,
-          0.006475454002308349,
-          0.0046233390069877105,
-          0.0030245720020805797,
-          0.0029728690084690848,
-          0.005239242299770315,
-          0.0026527563265214362,
-          0.004720971027078728,
-          0.00523503334261477,
+          0.0012091909932981555,
+          0.0011957336634319897,
+          0.008527270333919054,
+          0.0036096713301958516,
+          0.001101251337483215,
+          0.0037004113304040707,
+          0.0015854400019937505,
+          0.0019399113322530563,
+          0.004345616665280734,
+          0.004666128001796703,
+          0.0034671739946740368,
+          0.0014075903309276327,
+          0.0012334079947322607,
+          0.0014634369969523202,
+          0.0032239340022594356,
+          0.007143460670098041,
+          0.004567878330514456,
+          0.0031393423366049924,
+          0.002963986994776254,
+          0.003347966330087123,
+          0.0026326826628064737,
+          0.004858862007192026,
+          0.0054367133270716295,
           1.160132
          ],
          "xaxis": "x4",
          "y": [
-          0.0011632826644927263,
-          0.0012822793408607442,
-          0.0016621203006555636,
-          0.0021470096350337067,
-          0.0022884803668906293,
-          0.0012534433044493198,
-          0.001239426356429855,
-          0.0012465297089268763,
-          0.003279794667226573,
-          0.012686618332130214,
-          0.0012632272749518354,
-          0.0008373776605973641,
-          0.0009684563459207615,
-          0.0009438223205506802,
-          0.0009732996501649419,
-          0.00212981264727811,
-          0.0010061432840302587,
-          0.0012354689727847774,
-          0.0010633127142985661,
-          0.001582765292065839,
-          0.0008623780061801275,
-          0.0006525847129523754,
-          0.0006448597026367983,
+          0.0013958783286701266,
+          0.0012774859933415428,
+          0.0021662410047914213,
+          0.0022481193348842985,
+          0.0011296593341588352,
+          0.0013843739967948447,
+          0.0014980456714207928,
+          0.0011149286680544417,
+          0.003660077001162184,
+          0.010997971665346995,
+          0.0016934506614537288,
+          0.00048390866625898826,
+          0.0009676856619383519,
+          0.0005692379976001879,
+          0.0009138563376230499,
+          0.002080845665962746,
+          0.000927998330250072,
+          0.0013235986649912472,
+          0.0010675946638608973,
+          0.00167442832995827,
+          0.0009987906669266522,
+          0.0006867529979596535,
+          0.0008190226702330013,
           0.6389617919921875
          ],
          "yaxis": "y4"
@@ -3883,778 +3880,72 @@
         ],
         "showlegend": true,
         "template": {
-         "data": {
-          "bar": [
-           {
-            "error_x": {
-             "color": "#2a3f5f"
-            },
-            "error_y": {
-             "color": "#2a3f5f"
-            },
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "bar"
-           }
-          ],
-          "barpolar": [
-           {
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "barpolar"
-           }
-          ],
-          "carpet": [
-           {
-            "aaxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-           }
-          ],
-          "choropleth": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "choropleth"
-           }
-          ],
-          "contour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "contour"
-           }
-          ],
-          "contourcarpet": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "contourcarpet"
-           }
-          ],
-          "heatmap": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmap"
-           }
-          ],
-          "histogram": [
-           {
-            "marker": {
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "histogram"
-           }
-          ],
-          "histogram2d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2d"
-           }
-          ],
-          "histogram2dcontour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2dcontour"
-           }
-          ],
-          "mesh3d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "mesh3d"
-           }
-          ],
-          "parcoords": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "parcoords"
-           }
-          ],
-          "pie": [
-           {
-            "automargin": true,
-            "type": "pie"
-           }
-          ],
-          "scatter": [
-           {
-            "fillpattern": {
-             "fillmode": "overlay",
-             "size": 10,
-             "solidity": 0.2
-            },
-            "type": "scatter"
-           }
-          ],
-          "scatter3d": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatter3d"
-           }
-          ],
-          "scattercarpet": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattercarpet"
-           }
-          ],
-          "scattergeo": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergeo"
-           }
-          ],
-          "scattergl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergl"
-           }
-          ],
-          "scattermap": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermap"
-           }
-          ],
-          "scattermapbox": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermapbox"
-           }
-          ],
-          "scatterpolar": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolar"
-           }
-          ],
-          "scatterpolargl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolargl"
-           }
-          ],
-          "scatterternary": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterternary"
-           }
-          ],
-          "surface": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0.0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1.0,
-              "#f0f921"
-             ]
-            ],
-            "type": "surface"
-           }
-          ],
-          "table": [
-           {
-            "cells": {
-             "fill": {
-              "color": "#EBF0F8"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "header": {
-             "fill": {
-              "color": "#C8D4E3"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "type": "table"
-           }
-          ]
-         },
          "layout": {
-          "annotationdefaults": {
-           "arrowcolor": "#2a3f5f",
-           "arrowhead": 0,
-           "arrowwidth": 1
-          },
-          "autotypenumbers": "strict",
-          "coloraxis": {
-           "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-           }
-          },
-          "colorscale": {
-           "diverging": [
-            [
-             0,
-             "#8e0152"
-            ],
-            [
-             0.1,
-             "#c51b7d"
-            ],
-            [
-             0.2,
-             "#de77ae"
-            ],
-            [
-             0.3,
-             "#f1b6da"
-            ],
-            [
-             0.4,
-             "#fde0ef"
-            ],
-            [
-             0.5,
-             "#f7f7f7"
-            ],
-            [
-             0.6,
-             "#e6f5d0"
-            ],
-            [
-             0.7,
-             "#b8e186"
-            ],
-            [
-             0.8,
-             "#7fbc41"
-            ],
-            [
-             0.9,
-             "#4d9221"
-            ],
-            [
-             1,
-             "#276419"
-            ]
-           ],
-           "sequential": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ],
-           "sequentialminus": [
-            [
-             0.0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1.0,
-             "#f0f921"
-            ]
-           ]
-          },
           "colorway": [
-           "#636efa",
-           "#EF553B",
-           "#00cc96",
-           "#ab63fa",
-           "#FFA15A",
-           "#19d3f3",
-           "#FF6692",
-           "#B6E880",
-           "#FF97FF",
-           "#FECB52"
+           "#0a1628",
+           "#D4A84B",
+           "#1a2d4a",
+           "#C87533",
+           "#10b981",
+           "#ef4444"
           ],
           "font": {
-           "color": "#2a3f5f"
-          },
-          "geo": {
-           "bgcolor": "white",
-           "lakecolor": "white",
-           "landcolor": "#E5ECF6",
-           "showlakes": true,
-           "showland": true,
-           "subunitcolor": "white"
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
           },
           "hoverlabel": {
-           "align": "left"
-          },
-          "hovermode": "closest",
-          "mapbox": {
-           "style": "light"
-          },
-          "paper_bgcolor": "white",
-          "plot_bgcolor": "#E5ECF6",
-          "polar": {
-           "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
            }
           },
-          "scene": {
-           "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
            }
           },
-          "shapedefaults": {
-           "line": {
-            "color": "#2a3f5f"
-           }
-          },
-          "ternary": {
-           "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
           "title": {
-           "x": 0.05
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
           },
           "xaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           },
           "yaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
            },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
           }
          }
         },
@@ -4744,8 +4035,7 @@
          }
         }
        }
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAMgCAYAAADBabHPAAAgAElEQVR4XuydBXQbudfFb5syMzPjFrawZWZutwwpQ8qMKTMzMzMzM3O7ZWbmJoWk+c5Vv/HfdpzEiR3Hdp/O2XO2sUYj/aTRXD09vQnl4+PjA0lCQAgIASEgBISAEBACQsBJCYQSweukPSvNEgJCQAgIASEgBISAEFAERPDKQBACQkAICAEhIASEgBBwagIieJ26e6VxQkAICAEhIASEgBAQAiJ4ZQwIASEgBISAEBACQkAIODUBEbxO3b3SOCEgBISAEBACQkAICAERvDIGhIAQEAJCQAgIASEgBJyagAhep+5eaZwQEAJCQAgIASEgBISACF4ZA0JACAgBISAEhIAQEAJOTUAEr1N3rzROCAgBISAEhIAQEAJCQASvjAEhIASEgBAQAkJACAgBpyYggtepu1caJwSEgBAQAkJACAgBISCCV8aAEBACQkAICAEhIASEgFMTEMHr1N0rjRMCQkAICAEhIASEgBAQwStjQAgIASEgBISAEBACQsCpCYjgderulcYJASEgBISAEBACQkAIiOCVMSAEhIAQEAJCQAgIASHg1ARE8Dp190rjhIAQEAJCQAgIASEgBETwyhgQAkJACAgBISAEhIAQcGoCInidunulcUJACAgBISAEhIAQEAIieGUMCAEhIASEgBAQAkJACDg1ARG8Tt290jghIASEgBAQAkJACAgBEbwyBoSAEBACQkAICAEhIAScmoAIXqfuXmmcEBACQkAICAEhIASEgAheGQNCQAgIASEgBISAEBACTk1ABK9Td680TggIASEgBISAEBACQkAEr4wBISAEhIAQEAJCQAgIAacmIILXqbtXGicEhIAQEAJCQAgIASEgglfGgBAQAkJACAgBISAEhIBTExDB69TdK40TAkJACAgBISAEhIAQEMErY0AICAEhIASEgBAQAkLAqQmI4HXq7pXGCQEhIASEgBAQAkJACIjglTEgBISAEBACQkAICAEh4NQERPA6dfdK44SAEBACQkAICAEhIARE8MoYEAJCQAgIASEgBISAEHBqAiJ4nbp7pXFCQAgIASEgBISAEBACInjNHAOZizZGgxql0Lt9fTOvkGyOTmDByh0YO3MV9q0ZjwRxYzl6c6T+wUxgzrKtmDhnLQ6tn4Q4saIH892sU3zPobNw4tx/OLxhskUFvv/4GZVd+yBa1MhYNXMAokSOaFF5ll589eZ91G41CCP7tESl0vktLc7q19++/wT13IYiV7b0mDGys9XLlwKFgBDwTUAEr5mjIiQE708vb6zYsBeHTlzCg8cvwJdKogRxUKpwLrSoXwGRIkYwq/Zrtx7CvqPncfXGPXz67IGYMaIiZ9a0aFa3AjKnT2GzMsy6kQWZBo1biNVbDupKiBA+HFImS4halYqieoXCCOPiEqjS7V3w+vj4oGiNTmoh1qJ+xUC1TT8zx1nTziNx/sptbFk8AqmSJTRZ1r1Hz1GpUW8sn+6ObJlSB+l+QS2jQsNe6hnQUujQoRAlUkQlGBrXLoe//0oXpPpY86I/WfB2GTgNR05dwZrZA5EiaQIDrKcv3MCCVTtw6+5jvHn3EZEjR0CqZImQJ0cGVC1bEMkSx7dmN6iyQkrwPnr6ErOXbsW5y7fw/NVbhA0TBkkTxUWOLGlRvsQ/BuN0/9HzaN9vMob2bIZq5QpZnYEUKASEgCEBEbxmjoiQELwvXr9DiZpdkCxxPOTNkQlRo0TCpWt31GSaNUNKLJvmDheX0AG2gHVPmiieEikJ4sXCs5dvsPfIeXXd+rmDlSgMKFmjjIDuYenvmuBt3aiyetF88fDEoeMXQZFVukguTBjULlC3sFfB6+XtjVev32PO8m1YvfkAOrX41yLBO2DsAnBRxGRK8H77/gMPn7zEkAmLceHq7SAJXkvLoOD18PyGetVKqnp+//4TT168xp5DZ+H96xe2LBquxnhIpj9V8F66dhf13IagR9u6cK1ZxqALpi/ahGkLNiB+3Jgolj8HokeLrETvmYs3QXFYsWQ+jOrXyurdFhKC9/jZq3DrPRFhXEKjZOFcSBQ/Nr589cTl6/dw5fo9xIsTAwfWTjRoa6f+U9UztWflWIQLF9bqHKRAISAE/kdABK+ZoyEkBO/Hz19x9uJNlCiU06CW7qPnY/32w2orrPA/2QJswZFTl1EwT1aEChVKl3frnhPoOWyW2WLJGmUEWFELM2iC98yOmTrr969fPmjdcxyOnbmKhRN7IXf2DGbfxV4Fb/u+k7D/2AVdOywRvMvW78GY6StRvGBO7Dp4xqTgzVuhjXpxaykoFl5Ly6Dg5Y4GLYj6acXGfRg6cQkGd2+KGhUKm923wZHxTxW8tFJS0O1eMcZAtD1/+Ral6nRDjixpMG9cD1+Cjpbfy9fvonm9ClbvjpAQvOXq98CnLx5YM2ug2onTTxT3S9buRt+ODQ3+TteGqk36YUDXxmonSpIQEALBR8DuBK/20lg/bwj4MuZWvKfnd/zzdya4d3ZFwnj/86WcMHsNDhy/iFdv3ivrT+yY0VC2WF60blhZWRK01LL7WDx98QbjBrhh2sKNOHnuGiJFDK9cA7q1qQ1ufeunDTuOYMGqncoCET9OTJQs/DcWrtpp4MP7/cdPdBs8A7fvPcHrtx+UlSlZonj4t2IRNPy3tIG4PHD8Auav2I4795+qvydLEh9F8mVDy/qVzLLQGne/thXWv3Mj1K5SPEij4+jpK2jVYxxG9W2FiqXyBWsZe4+cQ0f3KSa37k6ev4ZmXUbr6sHt9eUb9mLD9iN4/OyVsmqnSZlYbflVKPGPv/U0JXh5wZ7DZ0FLSvc2ddC4dllVBq0x0xduwvXbDxEmjIvaGu/SsiZSp0isu4cpwbtt30ksXr1LWcm5IOG2Osemm2tVVU8taeN45/LRynq6adcxvP/wGZOGtEfR/NlhyZh48vy1EqAc9216TTB70WIMj+z5bAzq1gSfv3hg1LQVJgXvrXtP8OvXLyWyaa0LiuC1tAy/BO+6bYfRf8x8zBnbDflzZdE1keOIz9ymXUfx7MUb5VtarEAOdG1dG9GiRFL5NMvkiD4tlNWR/fTy9XukSp4IPdvWVWNCPzHP1PkbcPDERdX3SRLEQaG8fymXClrvtD7fvGg41mw5iB37T4GW7ZxZ06F/F8O5S5uTxvZvg0lz1yqLZ+RIEVCnagm0aVRZ1W3KvPW4+N8d5YJEMUS3FW3RGpj5J3up5qhWtqDyZaWPMS2OGdIkw8oZ/WHKh5dzJS22fPaWTOmDmNGj+vnckUOByu1Qv3pJX+cb6OLAxWavdvXUnGhOCojxzbuPMWrqcjx48gLv3n9Sz27GtCmUaOacqiW/BO+1Ww8wdcEGtUv246cX0qZMjNaNqqB4gRwG1SOD0nW6qV0DPsMBJfZHztIt1MJxytAOAWU3+J2Cl32/bFq/QF0nmYWAEAgcAbsVvBEjhEPCeLHx91/p8fj5KyVSUydPhHXzhiBsmN++mLR0hQ8fDkkSxlUTxvNX77Bl9zHlLzV7TDcdCb5cOMF5e3sjY7oUSJ8qKa7cuIcbdx6plwgtZFqat2I7xs9are6VL1dm9aI/deEG7j54aiB4KTgadRiOLBlSIkG82HAJHRo37jzE7kNnDQSIJrZYVtF82dULkIdE2B59S2Rgum3lpv1qe3n6iM4Gk3xAZdD6wK3wa7cfYNKcdUifJimmDO0YKNEdlDIoPorW6Ih0qZJgwYReBtXsN2oedh86ow7NcOExfPIyJXhprUufOhnevv+IPYfPIXy4sL6se8bt9Uvwai/ebq1ro0mdcth35Dw69p+C1CkSoWyxPGp7nIsc9g3FHPueyZTg5Rbt5Wt3lbiNHjWy8oneefA0fv70wsb5QxEjehR1rSZ+aOn59u27sizTFaF+9VL49PmrEuCWjgntpRwUC++jp69Qp/UgVC5TQAmSxWt2+Sl4Nc5kxP4KiuC1tAwKXrqpTBvRSRXl5eWtnt8RU5YpYTrGvbVODNK3uV3fSTh2+gpqViqKtKmS4uGTF1ixYZ8SehQWFI6a4KWwYyryTza1cD1w7AJChw6ttpm1/nz7/hNqtxqItx8+o2qZAkiaOB4o4mkV79uhgVroan1OgcgFNRdCFNBcXNKdiNy0pD8n/ZUpNdKkTIKzl26qeYYLosMnLymhzAXYmQvXlVsOXXLomsNk7vzDvBS8sWNEw+t3H1Q9OK9y3hzSo6kvwctzAvXbDsWPHz+xdFq/AA9raotZU7snmr82hag584w5jPksz166GRnTJlcHA/nccfeG8/miSb0VMyZTgpfvgObdxqjnm4vnsGHDqEUJFxXGu2WBFby8Z+FqHdRcunH+MAODS0DzMhdRs5dtwYkt09V7TJIQEALBQ8BuBW+fDvWVv55m0aBlgi8UWmkpUvxKtApTNHFVrvn08eVCP6kRfVqiZKG/f78wvb1Rp/VgfPj4GXtXj1d/e/XmA0rX6apENidAfZ8qc1wauH3Owxvc3uPJfqbWPcfj7sNnartP36WAooniWxPv5nYv71Gz5QDQv3ff6vG+rNP+lTNp7jrMXrpFZalVuRj6dGgQ6PsHtQz2ibLY60U8oFWEL4kyRXOrLWm2LW+F1sryPrx3C11TKGAuXL2jDtr5l/wSvNrfKTiypE+JUnW6IjK3x+cM0vEjz4oNeyFXtgyYOaqLuo25Lg20OlVv5q4ERPXyv7fVNfFDzj3c6oILOC1Za0wEVfB+9fiGum0GI17cmJg1qqt6STuC4NU/tKax5CKpbZOqaFijtBIwTLTC9xgyU/UjLbBaorjhrszcsd3VYkMTvLTuDe7RVGfJNLUjQaFPwU+xnD1zGl2ZXGRzUcZxpfV528ZV0aJBJd2zpY39XSvGqMU5kzYnjXZvrXxbmdgvRap3UMJ+ZN9WusUsre9FqndU//bPD93U/MNyNcFLX1ljq7W+hdfD8zuadBqpdi+WTu2H5EkCPkw2ZsZKLN+wD2d3zDK5cNbcbzgX0/0qY9pkatGRNlUSX4dIzWFs6vmnOKfrBPuUURmYjAUv55BKrn3UInXR5N66e3t7/0K1Zu7K6r90al9d8WS+bP1eJVzrVi1h1vSsPUO8BxctPBDMRXumdCnUAsivdObiDTTuNBLzxvfAPzkzmXUvySQEhEDgCdit4DUO7UO3AZ5I5+TTr9NvPyhaOZas262iGDx68hKfv3oo0cTEyYuWXu3lQnGwbclIA0L0/Vu1eT8u7pmnJmtO3MMmLcHiyX18nfo2JXjp8rB4zW6cvngDL169VS8sJkYDuLRvnvp/t94TcOr8dSyY0BO05FiaNOEflJO9FN48KX3/8Qus2rQf8eLEVH6tgbEqBLUMbiXWbDkQnVvW1Pns7Tp4Gl0GTseSKX2VmOVLKU/5NkicII6y0HObODBJE7Z0h6EQorVq086jKnID/aAnD+mgFiN12gxW26+MbqCf+o6ciy17juPUtplKoJoSvBxf3CanqKI7y8dPX0ALNlPH5jXQskEl9f/++XNaa0wERfCy/u37TcK9h8+xcmZ/JQCYHEHwUpzQLYXpl88v5YbBZ2/L7uNKDHLHg4kii2N83dzBBv1L16gCVdrp+kkTvGPc26B8iby6vBw3Bau0h5trFbRtUk3NKfkquSlf1Jmjuvo5JP3qc1qBuRDm7gYjE/g3JzGU1o+fP7Fh/lCD+9Ro3l8JerohaMmc+Yd5NZcG+okaJ03w7lszAW17T1CLAFpKKUrNSTwHcPPOY2xcYFhf7VrNtYSLBbooaYlCslalYooxDQvmMub19P3lvM1nmVZh7swwUfByMcNkLHi5G0CGdOEq9f9Wcq0unFMZDefCnrkGRglz2m+ch4uqxWt3q10gLbHfaGjhwtfUnEY3Di5ouCDhIT5JQkAIBA8BhxG8bH6O0i1QOO9fyg+SvmO00HLSL1M0D3JnT4+4sWMoQUc/Xfqeadtbmr+cseDVxOP53XPUlvnwyUvVqv7E1uk6Pz8Nu7HgvXLjPhp3HKF+rlGhiLJcRI8WRQms/cfO48r+Beo3blPSj83z2w9l3fkrUyrk+zuzClFj7DscUBezbqxjvWolfB1+COha49+1F0KzuuXRpVWtwF5u8FIxtwz6qv3y8cHmhcPU9RQmdx48w45lo3T3p680rUa0hqdPnRR/ZUylfC/NOZxnHJZMK5RiZmDXJkrYb993Ct2HzDB54I/Wb1qwty4eoSJXmBK8nQdMVW4r3BqmJTpRgthq+5suCu2bVgcjRDD5J3itNSaCInjpYtNj6Cxl2U2V/H/ROdZsPaj8U/ncMEyUqTiyIe3SYOrQGllrz7G2rc7QadxO9yvRrYXuLX4JXoq07CWbQRvXmiBpXKssurv9Ftymkl99Tn/xFt3GKrFcKG9Wdalfc1LTzqPw5v0n3TOi3YfuU1zgczHHZO78w7wBCV7WL3/uLOBBVs6t2i6YOZMC57Zv33+qhXNAie4dFJ4Mj7jr0FnlvlGueF7Qj9lcxtocmDB+bOWXnDxpAjVX04rOhTKtpEzGgnfngdPoOmi6v1U8u3O2wU5MQO3x73e6fvFdxHrQpeXE2f9U/ejfbTzv0y2DfWRqEW5JHeRaISAEDAk4jOClBSBHqebqABndGjRhZOziQP/MDu6TzRK82va8JngHT1isLJ9ndszytQVlLHhppeNBE1qRGDZMS/QppA+qJnj5d7pK0HJ47vJN9ZL98PEL0qZMoixs5opezQLHwys8AKPvHhHUQf1PRTclKmnRCWoKTBlan5EZ/Qi5fdvGtSpaNfxtFdUSX4rb951UvnVXb9wHXR/o00u3B/+SJni5rUkfxSiRIyBdqqQG4k0TvMbb3Sx31pItmDxvndoJYCxRY8H7380HqNVqoNpl6Nuxga4P+HLLV9HNbMFrrTERFMFLa2iv4bP95cgYt/rjV8tsr4KX/vDNuo7WHY6iv6+Li4tyMTGV4sWOAQomvwQv3Z2ylTAheGuX1VmYTZXrl+Cl2KHvqDmClwc4X7/76EvwunYcoSzamuANzPwTkODduveEekY4jtOlTKK2/M2dlyh4f/zwwvwJPQM1hSh/drehShBSaH718FRWTh4q1az4xgXyGlrekyeOjwUTexrEIadLEX2n/RK82nPPw4jZ9FxS9O+RNUMqcOwHR+KBUM7hpuYdumTQmEM3Pvr4SxICQiB4CDiM4GUc0PINeqJNoypo17SaOpnNE9qX98038B2zRPDOXLwZU+avV9tzFKT6yVjwMgQNLcp0f9BPpgSv/u8U7nwxUlhNHNxOWQkDSrS8zVi8SR24omXKGokW51xlWyqLk3/btP7dK7Bl0IpTvGZnNKheSglKLjD2rBpnEHnD+H68R9dB05TbyvHN0/w9DOKXD69+mdxqrOs2RJ3Cb2QUM7T38DnYtu+Eny4NWig3vtzz5sioKzYogtfSMcHrgyJ46Rp0485jX926/+g55frBiA0UgwVy/y/igb0LXkaP4G6Be+dGqFOluIo+wn4+smmKvx8bMVfw0pWCvuX6/t0hLXgDM/8EJHhp9ecilAtN+jjT/WfioPZmiT8unhh9Zu2cQb6Q0HKp+VWb4qX57B5cNxGxYkQLkDEtxJw/tHeAfpkBCV7tudeP1GKNeVQrg2I8dKjQfjJjlJY+I+aAPtvG0WY067ap36xZRylLCPzpBBxC8NK3s/eIOcpXj75tPO1PYUqBqv2bHUnh0W/UXHUK3xyXBmML7/krt9Cw/XAVAkjf300LA6b/aWHmo0+afuxJbqN27DdZhczRLGSc6EoXyW2wVaZtcXIrj1t6fiVOooPGLVIxd7u2roWmdcr7O15pQeDBE1pJNAsNX+qMCqB/eIeFaNvAxsLPGmX4V0lapmgppXtHhAjhVHxOLdGCdfjUZZQvntfAgq3VNaBPtpojeMm0VO2uyjq0ds5gXb8wdFXFRr2Vj6W2ADC28Goh1PQtMVzA0BWC49FclwZLxoQ+24AEL3cSGNEjVsxoAcb4tIYPL/20D5+8rCKXMO6zqRRUK7FfYcnofuDWawJOXbiGLYtGqINWdM8YOHahci9hn+gniiaOM0bZMFfw8nr6mjOayIrp7siaMZWuSFOH1ozHaXBYeM2df1jRgASv/qeFtUU/PyDBD0kElPjpbX785PT2mb6y0iBBP1u3xlV9+a7yeaMvPX3I+bETcxgzus7fZVuqQ350vdDSweMX0X3ITOX+5JeFl8992brdVSgyinsaK7TE9wsZ6Ie1C+yhNbrWUcDTLYERJPQTLbgtuo/Fxat3sHvlWPURDv0kh9YCGmXyuxCwDgG7Fby0ANJvk8KNEwKjLOgLzvuPnqNa037Kb5ahehimiDF7GY+XVsGgCF4ibdJ5pDoUwU+VcjucW270xeK2uv79tRc3D3fQ2vfq7Qd1f5fQoVReTfDyRc3DbBRxDGX0/uMXrNt6CD6gL+twf785T6HLj0zwtG/xAoYfn2BdaT2hn6GWGPGAhziObpqiO3GubWHzBZ87Wwblq0zXCvoAcmLm4T797UtrlOHf0NQO8DCPcQxgzdJBpiUK5lTxRxk+i6KtQK4smDq8o7+j3hzBywLog8tDRPyEbrkSeVVYMrLmuKGg0eLpGgtevriqNu2HZy/fqv7k2OPi5enz1+pacwWvJWOC9aerB4UbD1cxPB0PujD+JxMjXmhJCwvF0Faa37RfAP0TvLSg0lrH55AfemAYNPr5xooR1eBDHnQHotVe/2Cpdj9zy/CrfsZfWqPV9d2HT2BEBbLQPzBIcUMrL10d6Mf/T86M6mAU3WMOnbyEId2bqpi0gRG8XNzWbj0I3779QJWyBdXnYm/fe6pEMEWOflgyWwhec+cf8gyM4GV+Wm05b5gT51vbUVs1a4CKVKGftBjJPMSb86+0yJQ2heqHJ89fYf9Rhn4LhVmju+mir5jDmFZSLhi5gGdYQVqlT1+4jjBhwiBnlrR+Cl7Wi+HLeDCP7k4VSuZD0oRxle8wY2Jz4aofbzewYck4T9HqzsT5i5E8GNLu7btPqnzex9SuEvNzQT9/5Xac3Drd7M/FW+f1L6UIgT+LgN0KXvoyHTl1ScXWTRA3FupULa4+W6nvu0qxwa9EPXjyUuWpXCa/ehEzJFFQBS8Pw9EtgVZdrvwZJqa7W101mekLXg6That3Yuna3UrEpkmRWAVXZzxIfR9eWh/WbTukwmp9+eqBuHFiKvHW2rVygDEuNQHh15BkJAH6v/kneDnRsj58+XMSp9WPnxemLzTDJ9HSqZ9MCd7AluHfI0ThRF89ihIt9q6Wn39btekAeMCELzLGTeZBj4ql8sO1VpkA/QrNFby8H+N5zlxs+OGJTi1qqt0DLZk6tMYX2+AJi3Dx6m1EjhRRRQdo9G8ZVGnS12zBa8mYYN2Mv7Smz/u/gwutLniNv5Km3YAhrvT9v/0TvOaW4Z/gNQ5LxkOIXJTWrVbC1zYxLb9L1u5SB7EYsSFc2DDK+stYu/xYC31WAyN4WS8KMroXcd75/NVT7VIw/BTnJVoMbenDa+78ExTBy2e0aZfRuPjfbRX5wnh3SL+PuKtWoHJbtfvECCz6ic/z8TNXVR9wkUajgM8vH8SNHR2F82VXH9jQt7Saw5gGDfrD8pPSPABLYclIDwPHLfTXh1erFz80w37i4o1WXEaqoUGhatlCBjHNAyt4WT53rjbvPoYT567h2YvXyvDBD55QiLdxraLCk5lKXMzR/1g/LNqfJUOktULANgTsVvAGtH1tGzxyFyEgBISAEPCPAA8JX7v1EDuWjQ50XO8/nSwXAvzQx8BujVGzonxa+E8fD9L+4CUggjd4+UrpQkAICAGnJqAdCJOwWoHvZopdfiqcX/XT/9BR4EuSK4SAEAiIgAjegAjJ70JACAgBIeAvAca45cEvnkswFcNZ8PkmoEVuCMpHhISnEBACgScggjfwzOQKISAEhIAQ0CPAA5SVXfuocINzx/VQh2Ml+U2Ah6H54aKAQt0JQyEgBKxHwO4Er/WaJiUJASEgBISAEBACQkAICAFABK+MAiEgBISAEBACQkAICAGnJiCC16m7VxonBISAEBACQkAICAEhIIJXxoAQEAJCQAgIASEgBISAUxMQwevU3SuNEwJCQAgIASEgBISAEBDBK2NACAgBISAEhIAQEAJCwKkJiOB16u6VxgkBISAEhIAQEAJCQAiI4JUxIASEgBAQAkJACAgBIeDUBETwOnX3SuOEgBAQAkJACAgBISAERPDKGBACQkAICAEhIASEgBBwagIieJ26e6VxQkAICAEhIASEgBAQAiJ4ZQwIASEgBISAEBACQkAIODUBEbxO3b3SOCEgBISAEBACQkAICAERvDIGhIAQEAJCQAgIASEgBJyagAhep+5eaZwQEAJCQAgIASEgBISACF4ZA0JACAgBISAEhIAQEAJOTUAEr1N3rzROCAgBISAEhIAQEAJCQASvjAEhIASEgBAQAkJACAgBpyYggtepu1caJwSEgBAQAkJACAgBISCCV8aAEBACQkAICAEhIASEgFMTEMHr1N0rjRMCQkAICAEhIASEgBAQwStjQAgIASEgBISAEBACQsCpCYjgderulcYJASEgBISAEBACQkAIiOCVMSAEhIAQEAJCQAgIASHg1ARE8Dp190rjhIAQEAJCQAgIASEgBETwyhgQAkJACAgBISAEhIAQcGoCInidunulcUJACAgBISAEhIAQEAIieGUMCAEhIASEgBAQAkJACDg1ARG8Tt290jghIASEgBAQAkJACAgBEbwOOgYePnmJ2Uu34Oylm3j55j1iRo+C+HFj4Z+cmVC1bEGkSJrA7lqWt0Ib1K5cDF1a1bJp3Wq2HIjECeJg4uB2wX7fXQfPYO3WQ/jv5n14fv+BBHFjIn3qZKhQ8h+UKPg3QocOZVYdfv3ywYxFG5E/dxbkyJLWrGsk059D4MipK1i2fjcuX7sHD89viKaZcD4AACAASURBVBcnJgr/kw3N61dAgrix7BbE42evsHnXMdSsVAzx4sTQ1fPpizcoXacbmtUtb7P5YdqCDZi+aFOArEb2aQkvb2/0GzUPM0d1RaG8WQO8xl4yHDh+Ae36TEKnFv+iRf2KqlrjZ63Gqs0HcGrbDHupplXrEdT2rd9+GO6j56v3RKnCuaxaJynMPgiI4LWPfghULS5cvY1mXUarl1z18oWU0P3w6QvOX76FQycuon71UujuVidQZdoiszMLXgrUnsNmYvu+U8ifKwtKFMqJKJEi4vHzV9h14Axu33+C6SM6o0i+bGah5gs2W4lm6Na6NprUKWfWNZLpzyAwfeFGTFu4EVkzpES5Ev8getTIuPvgGdZsPQgXl9CYN64HMqRJZpcwTpz9D827jcGqWQOQJX1KXR0/fv6Kecu3IXf2jDYTlDfuPML12w91dbh8/R5Wbz4AN9cqSJQgju7vubKlx6fPHth18DSqly9sl8YEU5398vV7VG3SF2WK5sHAbo11WYIqCO1yQJmolCXtmzhnLVZs3IcN84YYjAFHabvU038CIngdcIRQ7N669xjblo5CtCiRDFrw+u0HcCIvlPcvu2uZMwve+Su3Y9zM1Wqh0bhWWQP2Pj4+2LjzKJImige+PM1JInjNofTn5Tl14Tqadh6lhNfg7k0QKtT/dgyevXiDum5DECliBGxdPEKJX3tLfglee6gnF6vdh8zwJcbtoW5BqUP/MfNx5NRlbFk0AlEiRxTBawbE7z9+omqTfsiWOTVo2ZfkXARE8Dpgf1Z27YMIEcJh9ayBAdZ+zPSV4FZNz3b1sGz9XmVppEWodpXiypKhn67evI8p89bj/JXb6mWZNmVitG1cDf/8nUmX7aeXN+Ys3YLNu4/jxet3iB8nJooXzIm2jasaTKrnr9zChNlrwTJ5vwK5s2DH/lNoUKOUbsuS20dnLt7AzuWjDepRp81gxI0VHVOGdVR/D0wbTAHRXBqK5s+urEjcVk2SKB66tq6FYvlzqEtqNO+PsGHDYOWM/gZFnDx/TVnTZ47q4uciwtv7F4pU74jkSeJj2bR+AfbJwlU7sW7bIbx6+wE/f3opS32Zornh1rgqwocLq7ZPad01Tu2bVkfrRpXVn/lypsi++/CZWvTQ7aFLq5pIlji+7rKPn75i1LTl2HvkHFhHiu13Hz6rvtVv56OnLzF25iqcOn9d1Sdz+hRo37QG8uTIoCuLfbBh5xEsntQHtIKcOPef2pIuki+7soodWDdR9bOWvnp8Q9EaHVGnSgnFWZJ1CLTtMxHnLt/CgbUTETFCOF+FbthxRG29TxnaQT2XdHfIXa41GtUsgy9fPXHw+AV8/uqJrBlSYWBXV6ROkThQz7Zf42DHstEIaFxrYte40kum9EHm9CmRs3QL9GxbV9VVS8fPXsXU+Rtw/c4j9Wzkz5VZzR9JEsbV5eHzHTtmNPXbmi0H8fj5ayRNGBedW9ZUDMxN/gleupC07jkO6+YO1lnPtfvyOeF9n798i8QJ46JLy1pIlCC2cjk7ce4auCShAaJ/F1eDOfLNu4/qWeKuHJ+XpInjoU6V4uo/bSFz5/5TTJm/Hhf/u6P6MnGCuMiTI6N6psjDr0TDR4laXdC9TR00/Le0QTZTFlCWzbrQJevjpy9qcc65mu8J/cT3x/DJS3Hxv7uIGD6c4sv5pValogG6opjTlivX7+naSwZpUiRG5dL5VT3Ypm6DZ4DufB8+fkbkyBGRIXUytHGtYmBIMNU+c1hr7aRL2sBxC7F7xRix8pr78DhIPhG8DtJR+tXsO3KushjSmkhLj7GVVz8vX1ALV+9Uk3SrhpWVL+uBYxcwY/Emtc1Vs2JRlZ0TKoXdvxWLoGCev0DDESe/jTuPYMWM/rrtx/Z9J+HB4xdoWre8mnyfPH+FaQs2IlP6FOolq5Xl2mEEUiZLqFwuIoQPh0vX7mLz7mNoUrtckASvOW3wqyv5Yrp59xESxouNSqXyI3z4sMqP8OHTl9i8cLjaouR28MCxC7F2ziBkTJtcV1Sn/lPVtduXjjKwpunfi9ui/7YY4Otl7Vd9uCXt8e27mswjR4qgtqPnLNuKymUKYEAXV3UZFwKNO41E3aolUL5EXvW3hPHjIGG8WFi0ZhdmLtqEFg0qIlO6FErILFq9E89evMWmhcPUS/Xb9x+o1rSfepHyhRc/bkzcvPsYG7YfQbIk8XWCl9ueFPuxYkRVrhPsK4omCv05Y7sjb46M6t4cR0vX7UG4cGHAhUO6VElBN46yxfKgfIOe6NG2Llz1hAoXVyOmLJOXhpXnF4rXgnmyYMIg0/7odA3IX6mt6vNe7erpBC8Xcw1rlEbpIrnw4dNXjJm+Qo1BCtWwYVxULc15tv0aB60aVkJA4/rzFw81tkZNW4HB3ZsiZbLf5ww4llg/Y8FLkenWe7zyTeZzy7E8d/k21ab184YokcvE5/varQdqYd64VjlEixoJi1bvwv5j57F9yUizRUtQBC/vS59e3jdKlIjqObl49Q7ChnVRcx0F4eNnr8E5m3MrBT0TF6M1Ww5AquQJ8W/FoogaJRIuX7urXFW6tqql+u/Dxy+o2Kg30qVKgrrVSiiBy3mUC8wN84ciTqzofo4uzmdDJixWCyONk5bZWBByMcy5hmK2VYNKSnifPHdNbe23a1oNbRr9NozcuvcEtVsPUvNWtXKc18PizMWb2LLnOJrW+d+8bqpS5rSFc16LbmOQJUMq1KxUVM2Nh09ewtHTV7B/zQTQz5t8//4rnXLj4zjYtOsoKJLXzxuKZInjqVsbt88c1vp15jgtXL2jcierX72klZ9gKS4kCYjgDUn6Qbz3qzcf0KbXeOW6wMQHnQejOBGUL/GPwQSnWUePbZ5mcGCK1oqnz99gy+IRqgxaVWkB5EOunyjk6Cs4oGtj8AXU0X0y9q0Zj5jRo+qyaQcjDq2fpCbhhu2HKWvHlsUjDaxQxi4NgbXwBtQGv3DyhUghN398D/ViZXr/8TNK1OyiJm73zo3g+e0Hiv3bSVlaB3VrovKQc8napq0k+vfaf+yCEgvThndSYjAoiSJg444jOLF1urrcL5cGTt6sJw9WUAho6dMXDxSo3Baj+rZWApmHcWYu3qQT9Fo+1vP1u486wUtrDXcAdq8cp0QvE4VstWb9ECFcOLW9y8RxtHzjPiye3EeNB/1En0xup29bMlK3KOAuRPKkCXSLoKAwkWsMCfBF/E9FNzSuXVZZ7vxKfM5o7aQo1iy8xgsSigQ+8+MGuKlFi7nPtn/jwFR9jMe1Xy4N3Eo2FrzcWuZOlv5uBHeVytbroayP2lzF55uHdmeP6aarAvPx+eazTKFpTgqK4DW+r2YJHj+wrZpLtETL5M07j3TzLUXZ6Ys3sHyau8G8PHraChw6eUk9SxR7bXpNwMqZv+dgLXGuoqAO4/J7oWIq9Rw6SwnEpVP7+vrZWBDuOXwWXNgb72INnbgE67YfxsG1ExE9WmQ06TwSL169U3OKNo+ycHNc1cxpCxfe3GFaP3+IQds4t+j7VOs3SHsmerevr8YEk3H7zGFtDKlZ19GIGjmSTQ46mzM2JY91CIjgtQ5Hm5dCQXT6wnUcO3NVCd+bdx4rEcdVMcUQD04xaVuQxzdPM6gjLYqT5q7DhT1z4eHxDfkrt1WTTCijKAJeXt7ImzOjOggzfPIyLFu/x2CyU4X6+ICuDkum9FXWCE6AtPh0aFbD4J6WCF5up/vXBs1KZaoj/IrSQF/In15eqt5MtEjS1YBWEVpcuJW6cPUO3b/96uT9R8+jfb/JZgteWmRpAeV2LV9KX7964ouHpxKLl/fNV7fxS/By+7Cj+xTffQColwWZkz3bzLGwcGIvg2obC14KU75M+LLTTxTMPMV+evtMVY5f44jX7DtyHh3cJ6sxQiub5meq/dvmD4eT3pCLmnxmCl66EFF0aYK3T4cGvqxV2Us1V5Y5jhlznu2cWdP6Ow7MGdfmCl663hSq2l5t3TetU96gRym8aO3VXLpMPd/0m/+rRFO0ca3qy3XLr+ERFMFrHP2FczGFm/EBVQpZWre1BS13X+48eAoXI9H669cvVT3OA9y6r9CwF/7KmAr1a5RCtkypDVw5/BvmZJQkYTwM6dHUVzZjQUhLMC2lZ3fONsjLCECuHUeottCYwvmbrmt0vdJP5gjegNrCd1fBKu0NokmYah/nFi7Qr99+pFwvvnp4KmOFNu/xGuP2mcPa+F4U+9y5M8dFzUmnG6dslgheJ+pWTlAd+k1WFl7NcuuXUKHgonXv4LqJakucW2ecNEoV8R2Ohb5aCePHVv5T3HZaYCSiNIR0GXjz7oOywHDLskaFwsEqePXbEDf2/0IcGXepX4K38wC6KzxW7gpMdNXgC6ZPh/rKZ4wWohKF/kb/zo38HSX0U67dapBZLg0ent9Rq9VAJXQZoi1n1nSIEyua8sldtXk/ruxf4K/g5XbmoPGLMGdsNySIF9tXvWhxovWddc+VPT1G9W3lr+AtXK2D8i8c1qu5Qb5Vm/Zj8ITF2LNyrBLE/glebokypFSWDCkxaUh7kCv99bQx6ESPWIg2hSIuT3m6NGT106VBE8X0g+X2uX+Cl4vc0oVzK9cmc55t+gz7NQ7MHdfmCt57j56jUqPealwyzKJ+6jpoOhhRgWOTya/nm4K+Rb0KaNukmln9Zg3BS7cAWqaNd3uMRRh9/ulH3cUP//ZUyRKqOnMxOX3RRt1uHv3m6Sqh7+dsqnEU3bmzZ1BuLcbJuC7GPLX8+n1AwWvuvO4XbP/acv/Rc/UOMtXfWnnrth0GD+LRjYvvFu5sRosaGXXbDFZnTbTzDUFlrV9vlkHXP5nDzHp0HCaTCF6H6SrzKtpz2Czs3H8al/bNUxf49YJiRIHFa3bhzI6Z+OLxTVlTaEnx74ARLQGM33h6+wx1EtxU4osvd7lWJsWfsSVgwNgFykK9d9U4g6JMHVozZeHVb0M4fw5w+PVCbNBumPJV1iy8rAS3sl6/+aCsGHwRbF44zOBgj6k20xpL6wR9gY0PvRnn58E9igtuv9IKp6WZizdj2sINOsFLEUkLlXFYMoZG6jJwur+H6FgmXVHot8sXr34ybeGNreKL6ict9JU5Fl5eN2vJFlX/ZdPcUb/tENCiyMM3kqxLoHXP8crf3q9Da/Ttp7/o1OEd1YFMvwQvrWK5yrZUIoGHIc15tv2bT8wd1/QN5TNmHJbM2KVBs/DygBpj8+on+pvSwrtm9u9Du44oeLmzEilieOWuYE6iK9OVG/dUjG+6IHDnhoLWr0QLLw+wau5Z+vlMWXg5bs7tMrTwaucIOIfwYB79x01FoTHHwqt/f1Nt4eFJvoP04wUbt42CmAdj6aahH50ka/Em/grewLLmffk80FovFl5zRqfj5BHB6zh9pavpsElLlCDT96PljzyoRKHDww08TezXC4ovl/L1eyJl8oSYO7a7ysdtH/pnbV0y0sAHmP6ctFqkT51UncbldnrLBpXQsbmhuwJX6LQC01e2XP2eyrWB1j4tsRxOjHWrFtcdWuOW+bwV23Fy63RogpX5qjdzR9JEcQ2iNBgLXlNt8KsrTb0QGZmAE6iba1WdZYDXa22kxZhWlvkTepo1QrQg9uRCPsZp276T6oMAvC9P0e9eOVYdINQST0jPW7FNJ3j5d75galcpZuBXzdPGJWt1wV+ZUmPhxN4G/n+01HNrkCesKXr2HT2vDnvwxcpEtk27jFLjRBPmHEu0nLA+2iEYim2Oh4gRwhv48JpadGj1f/v+E0rU7IwY0aMqkcWdA78WRWYBlUwmCdANpkW3scr3nNvV+i9++s3/DksWXoWiYjQOvwTv8g37wL6neGCED3Ofbb8W0Fp0iIDG9X83H6gdjhkjOxv4oJvy4a3SpC/ChQ2L1bMG6NpJf04ekmzwb2kDH15TH5axZwuv5kLC+TdfrswGfc2tdB6cff7qnfJN5pyqJf6Nz79/llDmpQ8vP0hk7NLE34wF7+5DZ9WuDKPiFC/wO2oNEw/xbtx1FIfWTVI+vKXqdFORaLR3BvNw4VGkegfUq1bS3ygN5rSlcuPfrmWMgasfUo/+2Jw7S9buijzZM2B47xa6OnIuo4HFPwuvOayNHzYuGKJHjSI+vE42D4vgdcAOpWWG4qVYgRzqZUV/05ev32HL7uN48uINZo3qqgspxRfUknW7Ub1cYWTPkga0wNJPleGs+LLTgr/TN6pV97GIHTM6XGuVUREYKM427DyqJpl+nRqqe/KwG62ylUrn14Xp4jbl1j3HVWgqinAKKFpv2zapisJ5s6nt+1lLNqsVs/6XlK7cuI86rQepE8l8gTPf7CWbwb9z4tUPS2ZOG/wTvM9evsG/FYqoE8YMB0brtrYwID8tadvznGQnD+mgPiBhTqIPM91JeDiDlpeShf5W/cL7ciuPLzG+5Hl/Cm2W27xeReVDvHHHUazctF9ZmzWXBt6Th8F4CpwHlLggiBsrhupXhjui/zX7ntu9fBldvXFfcecBPB6WoUsBD55lSpsClcvkx+cvnth96Ixy4aBYXjHdXTWL7eQCI0a0KCpKQ8Tw4bFu+yH1Bb85Y7rrQtL559Kg8WEMU24L8/AID5FICh4Ck+etUxZ1HmTiIdXo0aLg7oOnKjRWaKMPT2iClxa06uUKqcXsf7ceYPmGvcoCrC1KzX22/RoHFKLmjGvOP1wYMRJAs7oVoA4d/Z0JXGAaH1o7dOISGIaNOyGcb+jrPnfFdnz//kNFadAWaI5o4eXClW5QXKDSPYGhAPnxoD2HziqhumnBMGXNnbpgg4rUkild8t8HurYfwbnLN7FxwTC1g+NXYpSGYZOW4vCGyb6i+JiK0kBfXcZ259fYaBnmwor31/fZ1dycOL8wesuT52+U7y8Xu83rVVBh4PxK5rRF6+/smdMolwUuuPleYixh7gLSxWrb3hMY3quFim7B9wmfhUdPX6ldCr9cGsxhrV9vWqAp4ru71ZUoDcEzhYVYqSJ4Qwx90G/M8DW0GFJoUiT++PkTsWJEU759jEmoH6OSLyj6htIX9djpq+pwFH3H6LrAiUU/0foyc8lmNaHyIFvcODGRM0taJWCyZkylsnLSZYiwLXtOKEFM6wO38ksUzInGtcvpQhzxUBzDWPFQQerkiVVYHfoMc5tb/9PCPIAwe+lWvH3/EamSJcK/lYpg9eaD6pO8+oLX3DaYosoXYpgwLkrUXfrvjuJVIHdW9O5Q3+RnWLsMnKZ8BHctHxOo4P0UDXwBcHuQwtLT87t6KdP/rWKpfGqBQIscw+yMnbEKD568QJyY0dTCxcv7F9ZuPWggeHnQgwsHnqgPFzYMurWpo/OLpmsD+XLS531p4eJniOnfp70IeZhuwuw16oXAejDUD7/Sx/z0AdYSfZfHzVqNU+evqcOHmdImVy8Q/fjL5ghehjHiYQ/6RNMSJCn4CHBhxf7n2KCIjBsnhhpfPLCo/2lhTfBSNPLFz77mQqxKmQJo16SabmfF3Gfbv3Fg7rimgOEhLsbD5o7ArNFd1RxiKg4vy2SoLi4YuUDN93dmNXdxF0NLjih4WXf2B9t25OQlvH77ETGiR1E7aVz8lyueVz23NBTwmeXuGw+Pcs5u17S6yudf0uLw9uvYELUqFzPIaipOLXeHJs1dC1p7GUIsSaK46oud9aqV0F1LH3IutPicMw/DTvJ9wx2rlg0q6j5dbKpe5raFLi8MmcmFPudKhqwjDwpgjuWRU5erRQHdyGgF52Kgx9CZ/lp4zWGtX2fufvBdJXF4g2/+CqmSRfCGFHkb3dccoWKjqgT5NrZsg3IZqN1ViQFaLZwp8SVBV5bSRXP7Cj9njXbyoAyFNQWMJPsg4N+hNfuoodQiuAjwgNfpCzewccFQA7cIa96PQrZc/R6+XFSseQ9blsXnpVKjPsidI4N8ac2W4G10LxG8NgIdUrexpVgMrjbasg38qtH8lTtwYM0EZXFx5NRjyExkSJtMuUL8+OmlAsRfvWEYpN1a7dO+SGfsm2mt8qWcoBEQwRs0bs5wFT8qU7VJX9SoWMQqC1x+eGL5+r1IkzKx2lHkrhwj5fBDPjwz4l9cYEfhycNqW/eeUH7EfsX+dZS2SD19ExDB6+SjwpZiMbhQ2qoNPDjDcF78eMTQnr4/7Rtc7Quuclt2H6u2gvn1LfrD5ciSRn0ymP6C1k5uvSfg3sPn2LHM7y/SWfueUl7ABETwBszImXNoH8VhaEXjzwQHtt08mNx7+Gw8ePJSuRfwvAbdaOi7a/w1t8CWbQ/56arHdw3j2Jcq7Ds8pz3UUepgGQERvJbxk6uFgBAQAkJACAgBISAE7JyACF477yCpnhAQAkJACAgBISAEhIBlBETwWsYPz956WliCXC4EhIA1CSSMFVGFeHP05OMDPH8n84uj96PU37kIJIod0bka9Ae1RgSvhZ0tgtdCgHK5ELAyARG8VgYqxQkBIaAjIILXcQeDCF4L+04Er4UA5XIhYGUCInitDFSKEwJCQASvE4wBEbwWdqIIXgsByuVCwMoERPBaGagUJwSEgAheJxgDIngt7EQRvBYClMuFgJUJiOC1MlApTggIARG8TjAGRPBa2IkieC0EKJcLASsTEMFrZaBSnBAQAiJ4nWAMiOC1sBNF8FoIUC4XAlYmIILXykClOCEgBETwOsEYEMFrYSeK4LUQoFwuBKxMQASvlYFKcUJACIjgdYIxIILXwk4UwWshQLlcCFiZgAheKwOV4oSAELCJ4P3lAxw5eRFfPTzMIu4SJgyyZU6LBHFimpX/T88kgtfCESCC10KAcrkQsDIBEbxWBirFCQEhYBPB6+Xtgx7uozBr3iKziKdOlRJrl81GulRJzMr/p2cSwWvhCBDBayFAuVwIWJmACF4rA5XihIAQcErB23PoLGRIkwxN6pQL8R6+evM+Bo5diDv3nyBRgjjo3b4+CuX9y6r1EsFrIU4RvBYClMuFgJUJOKLg3bTrGOat2I7NC4fpaMinha08MKQ4uyPg4+WJX16fAQ52vRQqlAtCR4hjd/VlhYLzS2u2tvDai+D9+dMLZep1R92qJVC7SnEcOn4Rgycsxq4VYxArRlSrjQMRvBaiFMFrIUC5XAhYmYAjCd5Xbz7AteNwvP/4BfHixBTBa+WxIMXZNwHvr4/x5fI4+Px4b1DR8EnKIELqugiFUHbXAGcRvBt3HkX/MfMROlQohAnjgjw5MmL6iM7IX7kt3FyrYtu+k7h+6wGWTnNH/9Hz8PjZa/j4/ELGtCkwoIsr0qRMrPrm2Ys3GD55Gc5evomIEcKhTNE86NWuHn78+ImJc9Zi18Ez+OnlhbLF8qB7mzoIGzaMrz49feEGOrpPxrHN0xA69O8+r9VqIOpUKY7q5QtbbQyI4LUQpQheCwHK5ULAygQcSfBqTT94/CLGz14jgtfKY0GKs28C3l8e4fOFYfD5/s5Q8CavhIhpG4rgDaD7LPXhNWXhpeBNmTQh3BpXRcL4sREnVgzcvvcYaVIkRrhwYbFmywEcOH4BCyb0gpe3N6o3649i+bOjWb0KePPuI9ZtPYTubnUwYsoyPH/1FiN6t4SPjw/cek9A6SK50aBGKV+tWr35ANZtO4xVswbofusxZCbix42Frq1rWW0Qi+C1EKUIXgsByuVCwMoERPBaGagUJwSCiYAIXkOw9uDSQME7f3xP5durpa17TmD7/pO4ff8pPDy/wSV0aBzeMBnnLt9Cp/5TcHDdJLi4hNblp8DNVbYVtiwarvxxmXYeOI2NO49g5qiuvkbTojW7sO/IOSye3Ef3G63PYcOEgXvnRlYbfSJ4LUQpgtdCgHK5ELAyAWcSvD+8vK1MR4oTAvZD4NOb+3h9arAvC2/EFJUQP1tThNETUfZS6/BhXYKtKvYoeLfuPYEx01dicPemyu3hyfNXcO04Asc3TwN/W7xmF1bPGmjA5O37TyhcrYOyEGvJ29sbSRPFMxC12m+08G7YeRQrprvr8tPCGy9uTHRrXdtqvEXwWohSBK+FAOVyIWBlAs4keN99/mFlOlKcELAfAt8/PsSHc0N8Cd4IySshWsbGyr/U3lLsaOGCrUq2Fry9h89RvrjN6pbXtcnYwktLa/SoUXSuBbfvP9EJ3rOXbqLLwGnKwqv53rKgX7988HfZlti9Ygzixo4RIK9TF66jc/+pOLZ5KkL9f5//22IAalcphpoViwZ4vbkZRPCaS8qPfMaCl6b8lRt2Yeuuw/D0/I6hfdsiU/pUJq+mU3fHvmPRu1MTJEucwMKayOVCQAiQgDMJ3ufvPKVThYDTEhCXBsOutbXgnTR3Ha7ffogx7q3h+e0H4sWJoQ6t6bs0zFm2VbkbjB3ghq8e3zBu5iowhBgtvNQwVZr0UwfSmtYph89fPLB22yF0aFZDhRh7/e6DOsAWO2Z0UCg/fPIClUsX8DWeWU6pOt3QqGYZ1KpUFIdPXUb/0fOxc/loswSzuQ+ICF5zSZkpeOcv24SnL16hc+v6iBwpIhhug47exuni1VuYs3gdHjx+jhlj+4jgtbAf5HIhoBEQwStjQQg4BgERvCEreF+8fodO7lNw484jdaBstHtrX4KXIrf7kBk4ee4akiSKh9KFc2H5xr1K8DI9ePwCI6cuw4WrdxAhfDiUK55XiVwK6KkL1qsoDe/ef0LSxPHQuFZZVCtXyOTgvHTtLgaPX4Q7958iUYLY6O5WF8UL5LDqQBbBayFOfQvvVw9PNO0wCPMnD1Bi15zk1n0EeulZeKfNW41v33+gq1sD5Rzeruco9O3cFKlTJjWnOMkjBP54Ao4keJ+/eocazd3h5eUNz2/fETVKJGUB4QtD4vD+8UPZ6QGI4A1Zwev0A8yogSJ4LexxfcF78+5DDBw1EymTJcbLV28RJ05MdGhRF4kTxvXzLsaCl6b99r1GwbVOJRw9dREZ06VEpTLWi0NnxDDsrwAAIABJREFUYXPlciFg9wQcSfD6B1MEr90PNamghQRE8BoC/OUDHD55AR4e5rkyuYQJg2yZ0yJBnJgW9sSfcbkIXgv7WV/wnjp3BUtXb8PIAR2VhXfzzkM4cPQsJgz1HYZDu62x4FVbBI+eoduAiciWJS3cu7awsIZyuRD4swiI4P2z+lta67gERPA6bt85Ys1F8FrYa/qC9/qt+5i9eB0mDO2mSn3/4ROadx6CdQvGmG3hZcaHT56j58BJSJUiCYb1bas7tWhhVeVyIfBHEBDB+0d0szTSCQiI4HWCTnSgJojgtbCz9AUvD6g1btcf7t1aIkPaFNi575hySxjapy1evXmPfYdPoW71sgZ3NLbwfv/xE536jkXHlnWxbO12ZMuSHv9WKmFhLeVyIfDnEBDB++f0tbTUsQmI4HXs/nO02ovgtbDHjMOSXbt5D1PnrlIHzxLGj4PObRogTqzouHr9DnoMmoTtK6eoO54+fxULV2zBo6cvkCBeHOTOngmtGtfApNkrEDN6VDSqXVFZiN16jMCQXm2QJtX/vnpiYZXlciHg1ARE8Dp190rjnIiACF4n6kwHaIoIXgs7ST48YSFAuVwIWJmACF4rA5XihEAwERDBG0xgpViTBETwWjgwRPBaCFAuFwJWJiCC18pApTghEEwERPAGE1gpVgRvcIwBEbzBQVXKFAJBJyCCN+js5EohYEsCfgreFFUQMU19hIL9fVo4UWzzYuwHhSPDkr15dh2/vL6ZdblPKBdEj5MckSJFNyv/n57JIS28b99/wr2Hz/Duw2cAPogVIxpSp0iMWDGi2rw/RfDaHLncUAj4S0AErwwQIeAYBPwSvJ4JG+Hgle/48vWrQUPix4uDKpUqhGjjglPw8tPCT87Nxdf7m8xqo0vkxEhUYBCixUxgVv4/PZPDCN6fXt7YvOsYVm7aj2u3HiBSxPDqMBijGrx++wG/fvkgc/oUqFu1BCqVzo8wLi426Vt9wRsqmBajDEAvSQgIAfMIiOA1j5PkEgIhTcAvwfsxnita912Au3fvG1SxbNnSmDx+ZIjafUXwBn7UXL15H+37TsKBtRMDf7EVr3AIwUtYPYbMVJEPqpYtiLLF8iJtysS6+LTe3r9w+/4TbN93Eht2HEH0aFEwqm8rJYCtkV6+fo9Jc9fiyKnL+Pj5K0b3a42yxfKoojXB++HDB2zbuQcfP36yxi0NysiQLh2KFzP9/Wmr30wKFAIOTkAEr4N3oFT/jyEggtewq53VwiuCNxCPdPZSzdG4Vlm0algZESOE8/fKz188MGX+eqzefAAX984LxF1MZ6XArdG8P8oUzY2aFYsiWtTIoCWXocP0Be+r16/RtEVb3Lx1x+J7GhfQsX0btG3dQt1XkhAQAv4TEMErI0QIOAYBEbwhK3g79Z+KKJEj4sXrd7h87S7Sp06qjIWJEsSBh+d3NGg3FI+fvYaPzy9kTJsCA7q4Ik3KxMrAWL/tULg1rorl6/eCuqtRrTJo06iKrkGL1+zCotW78PmrB9KnToYnz1/pLLy9hs/G4ZOX1D2SJoyLDs1roFThXOrak+evYcz0lXjw+AVix4yG2lWKo1nd8lYZ0A5h4d175BxKFvo7UA2mpbdaOcutopPnrcPTF2/UIDCVNAuvCN5AdY9kFgLBRsARBW/PobPUSyRSxAiKS9fWtZA9c1o8f+cZbJykYCEQ0gRE8Ia84H309CU6t6yJ5EkSYOKcNfD89gMzRnYG3UgpgtOkSIxw4cJizZYDOHD8AhZM6KXmqqpN+sG1ZhnUqFAYz16+g1vv8di2ZBSSJY4Harbhk5dibP82SJE0IXYdPI3ZS7foBO+la3eRMF5sRI8WGddvP0SLbmNwbNNUuLi4oFDV9hjWuzkK5s6K+49f4Oylm6hXzTof33IIwRuSDyWtu3FjR8fDJy/x4vV7ZEyTDAO7NUG6VElUtUTwhmTvyL2FgG8Cjip4G9YsjSzpU+oaRN99Ebwywp2ZgAjekBe8ObOmRaOaZVRF7tx/qna0L+yZi9ChQ2HrnhPYvv8kbt9/Cg/Pb3AJHRqHN0xWgrdBu2E4tW2GrgHlG/REr3b1UPifbGjbZyLy/Z0ZDWqUUr8buzRc/O8OVm06gEvX7uCrxze8efcRWxaPQNJE8fBPhTZo37Q6/q1YRFmfrZkcTvBeuXEfdx88Vb68TNv3ncKew2fwV8bUcK1VVnWSNVP+Sm1Rr1pJ1K9REuHChsXUBRuw++AZ7Fg2Sq16vn7zUrd78uwl6rq2DhaXhs4d3NCjc2u4WLlt1uQkZQkBeyEQKXwYh3P/6T9mPu4/eq7OJfCF0bxeBVDwfvT4aS9YpR5CwOoEPD88wPszQ+Dz/Z1B2Z/iuaKViUNr5cqVxqwpY0L0XRgjclirc9AKtLUPL10a9AXvh49fUKBKOyVkD564qFwLBndvijw5MiqXBNeOI3B88zSTgrdmy4Fo3bAyShTKiSpN+qJrq1pqLjMWvI+fvUK1pv2UVbliyfzKypu/clssmtQbaVMmwf5jFzBz8SbcvPMYqVMkQsfm/6JIvt/lWJocTvA27jQS2TOnQacW/+Lm3cdqNVIsf3Zcv/NImdb1fUgshcPr2RETBrVD3hwZVXE09+cu1wqrZw1ApnQp8PHr7xfSs+cvUb9Jm2ATvF07tLK6mLcGHylDCNgbgWiRwjqc4NUYchuxVfexyqctW6Y08Pz+e0EtSQg4I4Ev7x7gzenBvgVvfFe06uM7SkP5cqUxb9pYhHGxrmErMGwjRQgTmOyByhvSgpcGRc4/x7dMAxfh0aNGUe5VTLTqmit4qdMql86P6uUL+xK8tBovXbcbK2cO0LHRF7zaH+nfu2LjPsxdthUntk4PFEe/Mjuc4M1X0Q0zRnVRonfm4s3Yf+w8Vs8aiNMXbsB99DzsWjHGKmC0Quq0HqTCnNWv/ts0z06g4N2zcqxy7BaXBqvilsKEgMUEHNGlgVt6DLPo4+OD5t3GoEvLWmpBLS4NFg8HKcCOCYhLg2HnhITgjRY1krKi0mXBffR8ZM2QSoncOcu2Yt+Rcxg7wE25HYybuUq5Jphj4V2wcgc27TqGEX1awMvLG3OWb8WV6/eUDy/dGVr1GId543sgVvSoWLpuDxat2YWNC4aqYAA87FarcjEkThAH2/aeVLvqO5ePtsoodjjBS7G5Yf5QJEkYF269JyhH655t64Jm8sqN++LC7jlWAaMVsnrLQUxbsAGzRndFssTxVXiya7ceYsmUPiqLCF6r4pbChIDFBBxR8LbrMwlvP3yCt7c3iubPATfXKsqlQQSvxcNBCrBjAiJ4Q17wUjvxWwY/f3qhXIl/lJ4KT3dNj2/oPmQGTp67hiSJ4qF04VxYvnGvWYL3x4+fGDxhMfYcPov4cWOhRMGc2LjziO7Q2vhZq7Fi435EiRxBRb9avHa30lQUuf1GzVMH1Ty/fVcuDn07NrRaiFmHE7wN2w9D7uwZUDRfdtBszlOAxQvmVCEuhk5cgt0rx1r98Z6/crtahXAAFMidBX06NFDWGBG8VkctBQoBiwk4ouA11WgRvBYPBSnAzgmI4A15wavvw2vnw8Xi6jmc4GU4i5bdx+LLV0/kyJIWCyf1Ul9Va9J5pApzMbx3C4uhBKYAsfAGhpbkFQLBT0AEb/AzljsIAWsQEMFrSPGXD/D62XX4eH0zC69PKBdEj5MckSL9NsAFNhkfWgvs9Y6W3+EELwHT0vrs5RukSpYILi6h4eXtjfOXbyNlsgSIGzuGTftABK9NccvNhECABETwBohIMggBuyAggjdku0EEb8jyd7i7i+B1uC6TCjs5ARG8Tt7B0jynISCC12m60iEa4nAW3l+/fLBi416cv3JbRUwwTvxCiC2TCF5b0pZ7CYGACYjgDZiR5BAC9kBABK899MKfUweHE7y/T/ftQ/ECObHr0BmULZYHUSJFBD8lXKpILozs09KmvSeC16a45WZCIEACIngDRCQZhIBdEBDBaxfd8MdUwuEEb7F/O6Fr69qoWDIf+P9zx3ZH6hSJMWbGStD6y5AatkwieG1JW+4lBAImIII3YEaSQwjYAwERvPbQC39OHRxO8GYr0Qxr5gxCulRJUNm1D/p3cUWubOlVWLIBYxfo4rzZqgtF8NqKtNxHCJhHQASveZwklxAIaQIieEO6B/6s+zuc4OUn6Mb1d0O+XJnBE4ZpUyZG2ybVsPfIOfQaNgtnd862aQ+K4LUpbrmZEAiQgAjeABFJBiFgFwRE8Bp2A8OSHTl5EV89PMzqH5cwYZAtc1okiBPTrPx/eiaHE7z13IYgW+Y0ynVh18Ez6DtyDiqXKYgjpy4jY9pkmDykg037VASvTXHLzYRAgARE8AaISDIIAbsgIILXsBv4aeEe7qMwa94is/ondaqUWLtsttrxlhQwAYcTvB8/fcUvn1/qm8tMC1ftxKGTF5EyWSJ0bFYD0aNFDrjVVswhgteKMKUoIWAFAiJ4rQBRihACNiAggjdkBS+/TssgAEzUTnmyZ0Tfjg0C/J7Bqk37cfDEJdg6KpalQ9LhBK+lDbb29SJ4rU1UyhMClhEQwWsZP7laCNiKgAjekBe83r9+qR3z128/YNTUFfj4+QuWTOnr7xAQwRuMT8jVm/fNLj1L+pRm57VGRhG81qAoZQgB6xEQwWs9llKSEAhOAiJ4Q17wsgb9OjVUFbn78JkKBnB00xRwN33w+EW4cuM+EsaPjU4t/kXxAjlUPn3By+8hNGg3FI+fvYaPzy9kTJsCA7q4Ik3KxCovz125uVbFtn0ncf3WA6ybNwQnz/2HRat34d2HT0iWOD46t6yJQnn/Cs6hpsp2CAtv5qKNzQbx38GFZue1RkYRvNagKGUIAesREMFrPZZSkhAITgIieO1L8N65/xRVm/bDia3TUavlQNSsVAR1q5bE1Rv30KHfZCyb7o5UyRIaCN6fXt64fO0u0qRIjHDhwmLNlgM4cPwCFkzopRO8KZMmhFvjqko4U0h36DdJWZETxIuFi1fvwMPzG4oXzBmcQ81xBO/7j591IPqPWQBacWtVLqr7G+PvNuowHG1cq6j4vLZMInhtSVvuJQQCJiCCN2BGkkMI2AMBEbz2I3i/fPVE7xFz8POnF1o2qIguA6fjwNoJCBUqlKqk++j5iBs7Ojo0q2EgePnb1j0nsH3/Sdy+/1SJV5fQoXF4w2Sd4J0/vicypEmm/s2v5DbrOhrTh3dCruwZEDaMi82GokNYePVp5K/UFlOHd0LOrGkNIC3fsA/rth3CurmDbQaPNxLBa1PccjMhECABEbwBIpIMQsAuCIjgDXnBu277YUQMHw5fPb6hYN6sGNy9KU5fuK4CAqyaNUBXwekLN+LZy7cY2rOZgeDduvcExkxfqa7LkyMjnjx/BdeOI3B88zSTgpd/nLNsK9ZuPYRXbz8oLde/syuSJ4kf7GPS4QRvrrItMdq9jc6XRCO078h5dB00DRf3zgt2aPo3EMFrU9xyMyEQIAERvAEikgxCwC4IiOANecHr+e27stpGjRIJkSKG/38r7C10HjANB9dNDNDC23/MfESPGgVdW9dS196+/yRAwau1+s27jxg+eSm8vL1tElLW4QRvr+GzcfPOI0we2gFJE8VT3N59+KzELn1D1s8bYtMHWQSvTXHLzYRAgARE8AaISDIIAbsgIII35AUva6AdWtNqQ79cHl6rUaEw6lcvpXx42/ebjOUmfHhprd135BzGDnBTVuJxM1eBgQb8svAeP3sVT56/QanCfyNKpIgYMXW5cqMY0qNpsI9JhxO8n754KOfps5duKodn+n88e/EWMaJHUSI4W6bUwQ5NLLw2RSw3EwKBIiCCN1C4JLMQCDECInjtU/CyVvcfPcfgCYtwlVEa4sVGp5Y1TUZpoMjtPmQGTp67hiSJ4qF04VxYvnGvn4L31r0nGDZpCW7efQx6B+fNmQkDurrqvq0QnIPR4QSvBoNwr9y4h9ChQytLb5F82RA+XNjgZGWybLHw2hy53FAI+EtABK8MECHgGARE8Ias4HWMUWK9Wjqs4LUeAstKEsFrGT+5WghYm4AjCl66aj19/hqMaclYl22bVIOPD/D8nae18Uh5QsBuCIjgNeyKXz7A4ZMX4OFh3nPvEiYMsmVOiwRxYtpNn9pzRRxO8NK5mSEwGLvt81cPX2zHDXCzKW8RvDbFLTcTAgEScETBy8MbcWJFB0Mslm/QE2vnDELkSBFF8AbY25LBkQmI4HXk3nO8ujuc4B00fhHWbzuMnH+lVS+I0KFCG1Af1a+VTXtBBK9NccvNhECABBxR8GqNev7qnTqjsFqFAwoFL+9fAbZXMggBRyXw8c09vDo5GD7f3xk04VN8V7TqswB37xp+ZbV8udJYNGscwroYvvdt2f6wYULu3rZspzPey+EEb76KbuoDE41qlrGL/hDBaxfdIJUQAjoCjip4Hz19hUHjFsK9cyOkSJpAuTS8+fRdelYIOC2BH58e4eO5Ib4FbzxXtOrrW/CWK1sa0yaNQuj//xhCSICJG/136C5JjkfA4QRvgSrtMLxXC3VIzR6SCF576AWpgxD4HwFHFLz8FCd3rgZ2a4LYMaOpxogPr4xqZycgLg3O3sP21T6HE7xjZqxU8Xb5tQ97SCJ47aEXpA5CwHEFr+e3H8hdrhVyZEmjos4wNa1THoX/ySY+vDKwnZqACF6n7l67a5zDCV768K7ZchB1qxZHuLC+w5B1d6tjU8gieG2KW24mBAIk4IgWXlONEgtvgF0tGRycgAheB+9AB6u+wwneZl1G+4t43vgeNu0CEbw2xS03EwIBEhDBGyAiySAE7IKACF7f3bB732F8+PTZ7P4pU7wwokePanb+Pzmjwwlee+ssEbz21iNSnz+dgAjeP30ESPsdhYAIXt891a3vUDx49NTsLhw33B3JkyYyO/+fnFEEr4W9L4LXQoByuRCwMgERvFYGKsUJgWAiIII3ZAVvz6GzkCFNMjSpUy6Yeti8Yn18fNBnxFycu3wTr95+QOwY0VCrcjG0bFARoawYkcPhBC8Ds6/YuBfnr9xWXyUyTjNGdjaPsJVyieC1EkgpRghYiYAIXiuBlGKEQDATEMErgpcEqOsWr92FQnn/QpyY0XH99kO06jEOS6f1Q9YMKa02Ch1O8I6ftRorNu5D8QI5sevQGZQtlgdRIkXEhh1HUKpILozs09JqcMwpSASvOZQkjxCwHQERvLZjLXcSApYQEMEbcoJ3486j6D9mvoppHCaMC/LkyIjpIzojf+W2cHOtim37TuL6rQdYOs0d/UfPw+Nnr+Hj8wsZ06bAgC6uSJMysar8sxdvMHzyMpy9fBMRI4RDmaJ50KtdPfz48RMT56zFroNn8NPLS2m17m3qIGzYMP4OGV536sJ1DBi7AGvnDEasGNbzT3Y4wVvs307o2ro2KpbMB/7/3LHdkTpFYjBcGVcJPdvWteT5C/S1IngDjUwuEALBSkAEb7DilcKFgNUIiOANOcHLO5tyaaDgTZk0IdwaV0XC+LERJ1YM3L73GGlSJEa4cGGxZssBMG74ggm94OXtjerN+qNY/uxoVq8C+In0dVsPgdGyRkxZhuev3mJE75agy4Jb7wkoXSQ3GtQo5ef4OX3hBpp0Hqm+ojt1WEdkzZjKamONBTmc4M1WohnWzBmEdKmSoLJrH/Tv4opc2dLj8MlLakVwYO1EqwIKqDARvAERkt+FgG0JiOC1LW+5mxAIKgERvPYpeOeP76l8e7W0dc8JbN9/ErfvP4WH5ze4hA6Nwxsm49zlW+jUfwoOrpsEF73PPVPg5irbClsWDUeiBHFUMTsPnMbGnUcwc1TXAC28x85eRZ/hc7Bu7mDd9UEdY/rXOZzg5epjXH835MuVGZ36T0XalInRtkk17D1yDr2GzcLZnbOtwcXsMkTwmo1KMgoBmxAQwWsTzHITIWAxARG89i94t+49gTHTV2Jw96bK7eHJ81dw7TgCxzdPA39bvGYXVs8aaNCQt+8/oXC1DspCrCVvb28kTRQPiyf3MWvc1GkzGFXLFkSdKsXNym9OJocTvPXchiBb5jTKdYG+IX1HzkHlMgVx5NRlZEybDJOHdDCn3VbLI4LXaiilICFgFQIieK2CUQoRAsFOQARvyAre3sPnKF/cZnXL6ypCo6K+hZd+vtGjRkHX1rVUntv3n+gE79lLN9Fl4DRl4Q0dOpSuDLqX/l22JXavGIO4sWMEaRxVatQbTeuWR7VyhYJ0vamLHE7w8rPCv3x+Ieb/B1peuGonDp28iJTJEqFjsxqIHi2y1eCYU5AIXnMoSR4hYDsCInhtx1ruJAQsISCCN2QF76S561REhDHurcFPnMeLE0MdWtMXvHOWbcW+I+cwdoAbvnp8w7iZq3D15n1l4eUBsypN+qkDaU3rlMPnLx5Yu+0QOjSrgYFjF+L1uw/qAFvsmNGVUH745AUqly7gq9Hnr9zC3sPnULFUPiWQ+TXdRWt2YduS3/681koOJ3it1XBrlSOC11okpRwhYB0CISl4adkYO2OlihrDk8klCv2NQd2aIEL4cP42btOuY5i3Yjs2LxymyyefFrbOeJBS7JeACN6QFbwvXr9DJ/cpuHHnkTpQNtq9tS/BS5HbfcgMnDx3DUkSxUPpwrmwfONeJXiZHjx+gZFTl+HC1TtqnitXPK8SuRTQUxesVzvx795/QtLE8dC4VlmTFtunL95gxORluHLjHr56eCJj2uTo4VZXDq3xVODKjfvBkBpPn7/GLx8f/JUxNdo1rYZsmVLb/MkWwWtz5HJDIeAvgZAUvCs37cei1TsxbURnRIoYHt0Hz1AuWN1a1zZZ51dvPsC143C8//gF8eLEFMErY/uPIiCCN2QF7x812BwxSsOg8YuU9aRG+cJqFUABTD+SXQdPqxhyDFxsyySC15a05V5CIGACISl4eZijRMGcaFSzjKrooROXMHj8IuxbM97fih88fhHjZ68RwRtw90oOJyIggtd3Z+7edxgfPn02u5fLFC+M6P/v4mn2RX9oRodzachdrjXcXKv4+hQeAxzvOXxW+XzYMongtSVtuZcQCJhASAreItU7YkiPpij8TzZV0YdPXqJ8g54qegyDsvuVRPAG3K+Sw/kIiOB1vj615xY5nODNV9ENQ3s2R4lCOQ248lPDzbqOxoXdc2zKWwSvTXHLzYRAgARCUvDmKd8aU4Z1RN4cGVU9X75+j+I1O+PIxin+fjHIL8H72fNngO2VDELAUQl4vH+Ad2eGwOf7O4MmfIrvilZ9FuDu3fsGfy9XrjTmTB0DF72IALZue7RIYW19S7mflQg4nOAdMmExQoUKhX6dGhog2H/0PKYu2ID184ZYCY15xYjgNY+T5BICtiIQkoKXFt5hvZqjYJ6sqrmWWni/fvOyFTa5jxCwOYGv7x7g7ZnBZgve8hS808YiTAgK3igR/f80rs0hyg3NJuBwgrffqHnYsvs46lUvqb4BraVzl2+qA2y5s2XQ/Y2ftwvuJII3uAlL+UIgcARCUvA26jAcpQrnQsN/S6tK8xOcg8YtwsF1/n8BUlwaAtfHkts5CIhLg3P0o6O0wuEEb7Muo81mO298D7PzBjWjCN6gkpPrhEDwEAhJwbts/R4sXbcXM0YySkMEdB00HZnSJUfv9vVVY3ng9tiZqxjbv41B40XwBs9YkFLtm4AIXvvuH2erncMJXnvrABG89tYjUp8/nUBICl5v718YNW0FNu8+Bi8vLxQrkEPF4aX4ZWKgd35P/sDa3xbf56/eoUZzd3h5ecPz23dEjRJJBWZnHEuJw/unj2Tnb78IXufvY3tqoUMIXgZFzpAmmT1x09VFBK9ddotU6g8mEJKC15rYRfBak6aUZY8ERPDaY684b50cQvD+XaYlUiRNgKplC6pPz2mfFbaHbhHBaw+9IHUQAv8jIIJXRoMQcAwCIngD7qdLV6/jyn838fHjJ/yVJSMK5c8d8EWSwyQBhxC8X756YseBU9i44yj+u3kfhfNlQ9WyhVD4n78QxsUlRLtWBG+I4pebCwFfBETwyqAQAo5BQASv3/304eMn9HQfiaWrNhhk+itzBsycPBzZsvwOfWhJ6jl0lto9b1KnnCXFWPXaJ89fo37boahVqSjaNqlm1bIdQvDqt5hhfnjwg5Ea+K36iiXzoWq5QkiXKolVwZhb2P+xd95hUVxdGH9ZeldAQLH3jmAvsfcYTWKNvSLYC9iQKti7oKIRu7F3jSb62btiVOwiNkQBkd5hv2cGQcaF3WV3WBg480eeuHvre85efnv33HMJeOVVisqRAsopkJEhRmxcHBvbamRoAFEeqYkIeJXTmWqTAqpSgIA3b6W7/zYCV67fzrWAsZEhbpw/gkoVrZQyVVED3i9fY8AkJmAScHX+qTEBb5Z1mT9+NwMes7u+567cQ7XKVpkhD51bwthIXyknyE9lAt78qEVlSYH8KfAh5DNO/XsVd/57gncfQiFmaJe5E11NDZUqlEWTRnXRq+tPsCprnt0wAW/+NKbSpEBhKUDAm7vyO/cegf3UeVLN8nP3jti/3Vdh0x09cxWuy/zZ9K4aGupoZlMH6xdNR6veEzFhxK84df4mnr54g12+LnBdugXvP4ZDLM5AnRqV4TZjBKpXyYTtj58isHDtbtx9+Jy9TbJb+2bsoduUlFQwN+CevXiH3Zzs3qEZnBwGQVMz9zzG8QlJGD19CcYP741zl+/CytKMgDc363JCHl68QYdWjbDKY5LCjpCfigS8+VGLypIC8ikQF5+AjdsO4dylm6hTswratWqMOrWqwqSUMbuQhn/5iqDg97h47S5evn6HLu1bwn5kX+jr6YKAVz6NqRQpUNgKEPDmbgG7yXOxe/9RmeaJ//xUZhlpBXLb4WWAt0qFspgw8leUtTCFmUkpvHz9HtUrW0FLSxMHTlxg84tvXTUHaenp+H3NByhhAAAgAElEQVSMK8tcYwb/jIjIaBw6eQnMHQiL1u1GaNgXLJprx25UTJi7Cl3bNcXQvl0khsSs6fazV7JntH7v2RbzFm0m4JXHslkhD9PG9ZOnuNJlCHiVlpAaIAUkFBhi7wxzs9KYOGYgqlepIFWhx8+C4LNlP2Lj4rFrgxcBL/kTKSAQBQh4czdUt1+H4+qNOzKt+OTOOaXCGvICXv+VszmZsU7+ewOn/3cTL4NDkJCYBHWRCJePrMW9hy8wzXUdLh5aA3V1UfZ4GcBt0n08TmxfiHKWZuzrZy7cZlMyblwyU2JezIViTGKCsYN/Zt8j4P0mEZPf8vmr9+w3COZhrho+c/E2GtaphoVzx6o8gwMBr8zPJBUgBfKtwIatB2A/sh8buiDPk5qWjlUbdmHW5BEEvPIIRmVIgSKgAAFv7kYo7B3enMB78twNLFu/F55Oo9mwhw+hYRgxdRGuH/cF896OA2ex38+dMxEmFrftb1PYHeKsJz09HRXKmWPHWslQjUEOnmDSz2Y9TF5yZulnuG6373zePFVwh9Z+H+OCfr3aY/BvnXDl1iNMnLcKjvYD2f+3KFMaXrPH8CaOPA0R8MqjEpUhBVSnAIU0qE5r6okUUEYBAt7c1VNFDC/T89yFm9lY3DF/9MweCBPSkBN4mThfY0MDzLQfwJZ5GfwhG3jvPniOGe6+7A5vzkPEzBmrxt3t8M9fy1DGtFS+XYR2eL9J1qS7Hfasd2WzMizfuA8vgt5j0zJHPH35lo0BuXR4Tb7FVaYCAa8y6lFdUkC2AjExcfgaE4tK5cuyhT98DMO9B09Rs1pFNr73x4eAV7amVIIUKAoKEPDmbQVpYQ1Mlpqb/zuqVDgD0zNz8yPDTstc7JGYlAJzs1LsobWcwLt590mcv3IPy90mgDlYtmLjPgQ+D2Z3eJnY2z6j5rMH0kYP6oHYuAQcPHUJU8b0hfvybQiPjGIPsJmWNmZB+e2HT+xNkrIeAt5vCrXuM4ndEq9WqRyGTvJGC9u6mDT6NzCxu8zu772zm2Rpyev7BLy8ykmNkQISCixYsRkaInXMnT4aXyKjMGaqJzQ0NJCQkIA508agbUsbTh0CXnIiUkAYChDw5m0nJg+v9zIfrN+8k1OoQd1a8Fu3iJc8vJ/CIzHNZR0bTsAcKFvqYi8BvAzkOi3YgJv3nqB8OXN0bdsEe46eY4GXed68/4TFPrtxP/AVdLS10KNjcxZyGYD22XqYzdIQ+TUGFazMMXJAd/zW4yeZzknA+02iGe7rkZScDNsGNbFq0wE2vqNRvepsbt6te//G8e0LZYrJZwECXj7VpLZIAUkFBo6dg1mTh6OxdV0cOXUBh06ex9Z1Hrh8/R4OHD+Hjcu5MWEEvORFpIAwFCDglW0n5qa1h4HPsm9aa9u6mexKVCJXBQQXwxsWEYXZ3hvxPOg9+v3cDjPGD2BTY/wyfC66tG3C/rugnhUb98N/72k8vrgtuwsC3oJSm9olBTIV+PmPKdiyxg2W5qZYvHortLQ1McNhKD5+CofdDC+c3MMNYyLgJc8hBYShAAGvMOxUXEYpOOBlttUrlbfgnP5ThTG27T/DptV49PQ1Aa8qBKc+SIFvCoyZ4oHhg35BM5t6GD7RBaMH90GPzq3BpCPzXLYJ+7Ys4WglROBl0gMxMW56ujrsXJgDIo3q1UBoZCL5ASlQbBUg4C22pi2SExMc8Fp3GsPGmXRr31RlgjKp0A6dugy3mSPZnWTa4VWZ9NQRKYB/LtzA6o27oaOrAw11dWxZ6wZDfT2s3LCLjen1duZeMiNU4B3Wvyvq1/p+CI+5VO5zVBJ5AClQbBVIi32HmAAviJMjOXOMNh8Be+etCAoK5rzeo3tXrFu1WO50hQUhnGXpzC+l9AhPAcEB76+j5mPEgG5yBT7zYY7LNx9gnf8R+K+chZi4BHQd5EjAy4ew1AYpkA8FHj5+iddvQ9CySQNYmJuyYUz7Dp+FjXUd1P0hU4MQgZdJ/RP8LpT9Q962hTWbgJ0B3qyrlPMhFRUlBQSjwNew1/h800MCeGMsRmD8PEng7dmjK3ZuWgktje+XHKh6sjnTb6m6b+pPOQUEB7zMjR9b9/2NfX5u7G5PQT6v34VimqsPtqxwYnPJhXyKkADepJR0dgjvQz5j4PDxeP7iFe9Dmj51AuZOd4C6umQS/tsBT7Fq0z58+RoNbW0tjBzQA317tc91DMxpy2Xr9+D6nUdITU3DhcPreB8rNUgKFLYC2prqbNJyIT7MBRrjnZZjyti+sK5bnUIahGhEGrPcClBIg9xSUUEeFBAc8Pa3c8fzoHeoaGUBXR1tCQkObOLe+KGMRszu7mTntVATffvrKRaD+YOkqamBdV5T8FPzhoiMTWG7CP0UhmGjHQoEeKdNnoDpk+04iZ2z5vX05Rvo6+myeoQwN6BM8sCpv1ZDW0tTYuoTZi3FTy0aoX+fTmBuMmFSiNBDChRFBXYe+BvD+vfI19AOn7qA33/ugNIGWoIDXuYOejMTY3ZHd6zjMsywG4C6NSsT8ObLA6iw0BQg4BWaxYQ9XsEB78Ydx6Uqbj+8d4FZJLcd3qKUpeHJi2D2etVNK+dLxDgFPHqGXftPYeUC7j3Wn8K+YOrcpVjhOQPlrSzYtE+Pnwdh/oyxBaYjNUwKyFKgz9DpaNKoDsaP7A9zs9JSi0d+jcafu47i2q3/cGzXKkFeLTxp3hp8iYoBc/1m+1Y2mDCiDxvSQIfWZHkKvS9kBQh4hWw94Y1dcMBbmBIXZeC1m+6FyKgYuM8aj/p1qknufB/7F5dvBEAkEiE6Jg71alfDFLs/2J3g/125g8MnzmPGxGFs2qfVCx2zT4sXpt7Ud8lVIPRzBJau244XQW/xU3MbtG/dGNWqVoRJKSP2y9zXqGi8ef8RF68F4NK1e6hRrQKcJo1gU5cJMYY3N0sT8JZc/y8pMyfgLSmWLhrzJODNhx2KMvAy0/gQ8hlO7quwabUre4o957Npx2GkpKTAYdQAZIjFWOGzA5aWZhg56Be22JK123ArIBBLXCajRrVK+VCFipICBafA7YDHOHn2Mv4LfI7EpGQ2rEekJmIPrenq6MCmQU380r0dmjSqmz0IAt6Cswe1TArwqQABL59qUluyFBAc8DKxbgtW7cD9wJdISJRM2XP3TMm+Wnj8TG/MmDAUtX6A1r1HzrLAMOqPzJAPZlfs8o17cHG0Y/+9zGcHbtx9CM/Z9qhfp7osv6H3SQGVKsDEzoeFf0FUdCy7w2tsZADzMqbQ1JA8uErAq1LTUGekgMIKEPAqLB1VVEABwQEvc7Xwq+APGN6/G5b4/oXpdv1hWtoIS3z3YFCfjrAbmrljqaqnsGN4r995iBpVK7JZJJ6+CMb8Reuxc/0CNiTh/OXb7E+8TPhC0JsPbJL+dYtnw9BAjwXcqhWt0K9PZ5y/chsXr97F4L49sGi1P3yXzZXYIVaVntQPKaCsAgS8yipI9UkB1ShAwKsanamXTAUEB7ytek/EclcHtGpSH50HzMD6xTNQs2p5bN37Nx4+DcIqD24S+oI2dGED78l/ruDg8X/BpBwrZWwI+5F90dg68+fdWe5rYNOwFv74vTv779P/XsXBE+fZk+C2DWvDYXR/fA6LxDyvdVjt7YjSpYywfe9JvAsJhcvMcQUtHbVPChSIAgS8BSIrNUoK8K4AAS/vklKDUhQQHPAyN60xOXhrV6+IvmNd2R3eNs0agLlyeLqbD26cXK9Sgxc28Kp0stQZKSAABQh4BWAkGiIpAICAl9xAlQoIDnjb950G56lD0aVtE7gs9UdGRga854zF/hMXsXrTAVw/4atK/UDAq1K5qTNSQKYCBLwyJaICpECRUICAt0iYocQMQnDAO2fhJliYlWZ3dgOfB2PwhAWoZGWB9x/D2LjeGeMHqNR4BLwqlZs6IwVkKkDAK1MiKkAKFAkFCHiLhBlKzCAEB7w/WubhkyBcvROIqhXLolv7phIXLhS0JQl4C1phap8UyJ8CBLz504tKkwKFpQABb2EpXzL7FTzwFrbZCh141b5de8y3EGKmQfY/9JAChaoAk3P36OmLuHTtLsIjvmLvn4uRnp6BRWv80bJJQ3Rq24wzPgLeQjUXdU4KyK0AAa/cUlFBHhQQBPAuWrdb7qnOnTxE7rJ8FCxM4H3y/AXOnD3PxzQ4bWhqaqBnty6oVrUy721Tg6RAfhXYse8kzl64gX6/dMZ6//3499AGtok9h/7GnfuPscrLkYA3v6JSeVKgCChAwFsEjFCChiAI4LVzWi63STYt4/7xk7uiggULE3iv37yDEaPHKzjyvKvp6+nB/88NsG3UgPe2qUFSIL8KDLF3huOk4bCpXwtd+jpkA++zl28wd8E6HNmxgoA3v6JSeVKgCChAwFsEjFCChiAI4C3K9iDgLcrWobEVBwV6DpyEbb4LYG5WmgO8j568wlyvdTi5Zw0Bb3EwNM2hxClAwFviTF6oExYs8DLXCr/98JkVr1J5C/ZmscJ4CHgLQ3XqsyQpwFyX/cdv3dC+TRMO8K7bvBcvX7/D2kWzCHhLkkPQXIuNAgS8xcaUgpiI4IA3NTUNKzcdwJ7D58AcZmEeTQ11DPm9C6bZ9Wf/X5UPAa8q1aa+SqICV27ex6oNuzFswM9sDO/sKSNxOyAQF67ehcccB7Rq2pCAtyQ6Bs1Z8AoQ8ArehIKagOCAd6nvX/jn0h3MnjQYDetUY8X+7/ErLPHdgx4dm8PJYZBKDUDAq1K5qbMSqsD1Ow+x58BpvAx+B7EYqFLJCkP69UTbljYSilCWhhLqJDRtwSlAwCs4kwl6wIID3p9+nYwFs8agfatGHOH/d+0+3JdvxeUja1VqEAJelcpNnZVwBcRiMQu8IlHe6fgIeEu4k9D0BaMAAa9gTFUsBio44G3UeQz2bnRD7eoVOQZ49uodBjl44r9//1SpYQh4VSo3dUYKyFSAgFemRFSAFCgSChDwFgkzlJhBCA54GahtVK865kwazDGS1+qdePziDf5a76JS4xHwqlRu6qwEKvA57Av8dx/Ds6C3SExMklBg/5YlnNcIeEugk9CUBakAAa8gzSbYQQsOeO8+eA4mL2/lCpZoUKcqK/yDx0F4/zEMm5c7wbZBDZUag4BXpXJTZyVQgenzV+BrVDR6dG6DUkYGEgp069hK8MA7Z+EmhISGIyExGR1b22DiqN/Y0I3QyMQSaHGacklRgIC3pFi6aMxTcMDLyPYpPBI7D/6DoDchrIrVq5THsL5dYVGmtMpVJeBVueTUYQlT4Oc/pmDO1FH4qYXkAbXcpBDiDm9EZDTMTIyRkSFGz6GzcXCzB/T1dAl4S5ivl7TpEvCWNIsX7nwFBbyv34Xi3OW7MNDXQ4fWNihrblK46gEg4C10E9AAirkCY6Z4YHC/HujUtplcMxUi8GZNLDQsElPmr8V+PzcAaohLTJVrzlSIFBCiAvFf3yDyzgKIkyM5w4+xGIHx87YiKCiY83qPHl2x2WcZNKQcWi1oHQz1NAu6C2q/gBQQDPAGPHqJ0TOWQE1NDeoiNaipibDOewpa2NYtIGnka7YkAu/uA6dx+vw1MDmRK1hZwGnSCFiam0oIFvk1Gqs37sGH0DBoa2vBfkRfWNevKZ+wVIoU+KbA+Su3se/wP/BdNleuPNtCBd53IWHwWLENLtOHsyFbTEhDXFIa+QEpUGwViI9kgNczf8Dru7xwgVdXo9jao7hPTDDAy8TtqqurY43nJKiJRHBd6o8HT17h9C7ugRVVG6wkAi9zEYB1vZowMtTHtr0n8OHjZ8yfMVZC+gXLN6FB3Zr4tWd7vH4bArfFG7B5tSt0tLVUbSbqT8AKfAj5jClzlyIpJQUZGRlgUpPlfM4eWM/5txCB98L1+zh86jLcHUfBtLQROx+K4RWw09LQ5VKAQhrkkokK8aSAYIC3aY/xWOc1FS0aZ+7ofg7/io79p+PiodUoY1qKJzny30xJBN6cKt0OeIz9R//Bcs/pEuL9MW4O1iycBfMymaEnczzXYdDv3RAXn4Dte0/AZ8kcaGtpwmOpH2yt6+CXbm3zbwCqUewVmOC0COnp6ejdox2MjQyhBm4O3tbNrQUNvIlJKWDWN5v61SESidi5jB7UE21bWFMMb7H37pI9QQLekm1/Vc9eMMBbr/1IHPH3Qs2q5bM1qt9hFI5t9UK1ylaq1i27v5IOvAtXbUG1KhUw8NeuEjaY5bEGzW3ro+8vndh0Us4LffHbzx3Zw0erN+yGto4Wqlaywu37T+AyU3KHuNCMSh0XKQV6DpwEt1nj0bxxA7nGJcQd3twmRju8cpmbCglYAQJeARtPgEMXFPAumT8eFcqZZ8s8dJIXFs2z47xmXTfzumFVPSUZeI+evoDLNwKwxG1arrGVTP7U1X578Dk8EmXMSuNjaBh72r5e7WpISkrBxFmLoKGhjpVeM9kT6fSQArkp4OC0CH26t0X3Tq3lEoiAVy6ZqBApUOgKEPAWuglK1AAEBbzyWObxxW3yFOOtTEkF3hNnL+P85dvwdp4oF6wmp6Ri5EQX+K10YWN/k5JTwORXjY9PgM/i2TDKJb8qb0aihgStwM07D7Fh20GsWzQLmpqSB0Z0dXU48yPgFbS5afAlSAEC3hJk7CIwVcEAb8inCLnksrI0k6scX4VKIvDuOfQ3Hj15BVfHcfgRNpj3urRvycZVM1kcmIOGyckp8NmyDwb6unAY1Z+VfuWGXahoZQmIgYdPXsJzrgNfJqF2ipkCXfpK941/D20g4C1mNqfplAwFCHhLhp2LyiwFA7xFRbAfx1ESgffXYTOgpaXJpofLenyXzoVJaWN06z8Bq7ydULdmFQS9+QAn11XQ1tZkb8ka2v9niERquHTtHk7+cxlL3aex1We5r0abFrbo06NdUTUzjasQFQh8+kpq7/XrVCfgLUT7UNekgKIKEPAqqhzVU0QBQQBv1i1E+ZlgdEw8jI3081NFobIlEXgVEooqkQIqUoBCGlQkNHVDCiipAAGvkgJS9XwpIAjg7TxwJny8p6J29YpyTS74XSgmOa/BqZ2L5SqvTCECXmXUo7qkQN4KnP73Kqzr18Kbdx+lyiT0tGR5TY6yNNCno7grQMBb3C1ctOYnCOD1XrMT+45fwIBfOmB4/66oaGWRq4qhn79gz5Hz2HnoH/Tv1Q7OU4cVuNoEvAUuMXVQQhVgYndnTxnJxntLe07vXcd5m3Z4S6jD0LQFpwABr+BMJugBCwJ4GYVv3nuCNVsO4eGTINStWRl1alSEZRkTNlH7p7BIvAz+gP8ev0KjetUxZWxfNLepoxLDEPCqRGbqpAQqwORu1tTShIa6er5mT8CbL7moMClQaAoQ8Baa9CWyY8EAb5Z1nr58i6u3H+FVcAi+RMWwty6ZlDJE9SpW+Kl5Q7nDHviyNgEvX0pSO6QAV4Gl67ZjSL+esCpbJl/SEPDmSy4qTAoUmgIEvIUmfYnsWHDAW9SsVJKAVwzgXsB/SEhM4N0MmpqaaNm0CaDGvTaW946oQcEowIQ0rFk0i834kZ+HgDc/alFZUqDwFCDgLTztS2LPBLxKWr2kAe+ChUtx+OgJJVWTrG7TqCE2+a7J9WIB3jujBgWhAAEvEBqZKAhb0SBJAUUUIOBVRDWqo6gCBLyKKvetXkkDXhd3L+zbf1hJ1SSrN2lsgx3+fgS8vCsr3AaLKvAGPg+G+/JteBX8AeUszTB38hA2nCqvR57yx85ew5a/TuP4Nu/sZihLg3B9l0YunwIEvPLpRKX4UYCAV0kdCXiVFPBbdQJefnQsTq0wwMtcVCLrOXtgPadIQYY0MLcHdhvshD9+7YSBfTri0vX/4LlqB87+tYw9S/DjI6t8WEQURkxdiK/RcTA3K03AK8vY9H6xUoCAt1iZs8hPhoBXSRMR8CopIAEvPwIWw1YY4B0+4GeUtZR+aK1zu+YqA97b959hqstaXDvumw3jA8a7Y1Cfjvi9Z1sJK8hb/uL1/7By0wEC3mLoxzSlvBUg4CXvUKUCBLxKqk3Aq6SABLz8CFgMWymKIQ37j1/AoVOXsc/PLVvxWQs2wqKMCWbaD5Cwgrzl8wLeiOjkYmhZmhIpkKlASsw7RAcsgDg5kiNJjPkIjHfeiqCgYM7rPbp3he/qJRAV4uHmMqW0yXwCVUCQwJuSkoprdwMREhqBjIwMNKxbjc2/WxgPAS8/qlNIAz86FqdWiiLwbj9wFuev3MOOtfOypXZd5g9NDQ24TB8uIb+85fMC3rSMjOJkUpoLKcBRIDr8NcJuekoCr8UIjJ8nCbw9e3TFdr8V0NQQFZqSmuqF13ehTbqYdCw44A149ALT3XwRGRUDMxNjpKWlIzIqFm2aNcBK94nQ19NRqWkIePmRm4CXHx2LUytFEXiZHdsjZ67ir/UunB1e8zKl4Wg/MNcdXnnKU0hDcfJcmou8ClBIg7xKUTk+FBAc8PYe6cweDlnu6sACL/O8fheKaS7r2J1er9lj+NBF7jYIeOWWSmpBAl5+dKRWgII8tHbr/lNMd/XBteM+UPv2s2q/cW4Y2KcD+vdqLyG/vOUJeMlzS6ICBLwl0eqFN2fBAW+jzmPYndyObWw5qp2/EoA5C/1w528/lapJwMuP3AS8/OhIrRQs8DLhVF0GOWJ4/24Y8Et7XL71EK5L/XFmz1KUMS0F5ibI5Rv2YdE8O5iblYKs8ln2IuAlzy2JChDwlkSrF96cBQe8fce6sn9omJRAOZ/7gS8xyXkNrh3zUamaBLz8yE3Ay4+O1ErBAi+j74MnQfBcuZ293rycpSmcJvyBjq1tWOlv3H2MsY7L8PfuJahoZcG+Jq18aFgk+o51YUOzEpOSYWigh95dW2POpMEo7Dy8zM2K4oQQiJmBcB41qOtZAbIzxpE7kgJSFSDgJQdRpQKCA94zF25j/fZj2OM7n5Ojc/fhc+zuSs6QBj3dgo/nJeDlx10JePnRkVopeOBVlcaFDbzMPBOebURa1AvOlEX65aFXexxEmpJ5h1WlDfVTPBQg4C0edhTKLAQHvPXaj5Rb28cXt8ldVtGCBLyKKsetR8DLj47UCgEvnz4Qd38BUr885DSpblgFBrYuBLx8Cl1C2yLgLaGGL6RpCw54mSwN8j62DWrKW1ThcgS8CkvHqUjAy4+O1AoBL58+QMDLp5rU1o8KEPCST6hSAcEBryrFkacvAl55VJJdhoBXtkZUQj4FCjJLg3wj4KdUUQhpIODlx5bUSu4KEPCSZ6hSAcEBb0RktFR9slKVqUpEAl5+lCbg5UdHaoV2ePn0AQJePtWktmiHl3ygMBUQHPDKiuFVRdxuToMR8PLjvgS8/OhIrRDw8ukDBLx8qkltEfCSDxSmAoID3mev3knoxeS6tJ+zEvOmDEWvzi1VqicBLz9yE/DyoyO1QsDLpw8Q8PKpJrVFwEs+UJgKCA548xLLf+9p3L7/FBuXzFSpngS8/MhNwMuPjtQKAS+fPkDAy6ea0ttKT/oCceInibzHIk19MJkxiuNDMbzF0apFd07FBngv33yAaa4+CPhns0rVJuDlR24CXn50pFYIePn0AQJePtWU3lZqzCvEBSwA0hI4BXVrDINOpd6qG4gKeyLgVaHY1BUED7zMLUBfvsZg4drdePryDf7evVSlZiXg5UdueYD30vV7uHLzPubPGJtnp/+7cgdHTp6HuoYG9PV0MMNhKExNSvEzSGpFEApQlgb+zETAy5+Wsloi4P2uULT5CNg7b0VQUDBHtu7du2LtysWFeslfOVNdWaak94uoAoID3rwOrTG3qi1xtkPHNrYqlZqAlx+5ZQHvkrXb8V/gM9SrXS1P4I2OiYXddC9s9fEA4w8HT5zH2/ehmDlhqMKDXLd5LypXLIdfurXNtQ3mC9eWXUfxIPA5exVszeqVMHHMQKirixTqMyziK2a4rMCuDV551n/1+h3Wbz3A/vSZnp4Bu+F9Ub9ONYX6YyoVty8SBLwKu4JERQJe/rSU1RIBLwGvLB+h95VTQHDAe/H6fxIzNjLUQ/Uq5WFkoKecGgrUJuBVQLRcqsgCXqbKzTsPce7K7TyB90tkFEZN9oDfSmeUtTDDyX+u4PWbD3AYPQDT5i3Fbz93ROd2zfEy6C0YgF67eBYLxrk9MTFxcFu6EW/ff8Kowb3zBN7rtx/g1L9X4O08iW3GbfEG/NTSlu0nv8/hk//D6XPXEBMbh/1bluRZ3d5xIaba/YE6NauAgd8FK/7Edl/P/HbHli+sLxIKDVbOSgS8cgolRzECXjlE4qkIAS8BL0+uRM3koYDggLeoWZKAlx+L8AG8zEiOn7mEP3ceQdtWjREWHon5M8fCyFAfHz6GwcltJZa6T4P3Kn84ThiK6lUryhy837ZDKFe2TJ7Ae/HqXRw4/i9WeM6Ejo4WFq7agtbNG6FW9cqYOncpVnjOQHkrCxw5dQGPnwdJDcdgBpOYmIQRk9ykAu/oKR4YMbAX2rVujA8hn+G+1A9/rnGF75b9SEpOYXe0ExKTMGn2EjhPH41qVSpInacqv0jIFJyHAkIE3tlefngZ/CH7C9hM+wFoVK8GQiMTATGAXH4wUBNnvlWQj1CBVy2XH70ztSpoxRS3BgEvAa/i3kM15VFAEMAb+JwbxyNtYvVr8Xua9ezF29i8+xTefvgEHW0tdP6pMeZMHgJtLU12GAS88riZ7DJ8AG9cfALmeKzFNPvB+BQeiW1/nUCPTq3Q95dO7ADOnL+G9f4HMHbYb+jdvZ3sQQGQBbxMSMHitVsR+PQVGlvXZcMMHCcOg5qaGph44sMnzmPGxGFYvHorVi90zHNHOWsw8gDvs1dvMcttNazr10BSUgrGDfuNDaVg0vNNnrMEIwb9gqu3/mN3gPMKxcg5eVnAWxBfJOQSX8FCQgXeYf27Iuf6lXXTWnriJ2QkfpZQQ13HDCI9KwVVkq9a4QGvWh4DlA2sGSNE52kAACAASURBVGnxyIh9A2SkctpQ09CDyKgm1PJqWj5JCqwUAS8Bb4E5FzXMKiAI4JV12UROW/J98cRfR8/DpJQhu9sSFRMHR4/16Nq+KSaP/p2Al8cPER/Ay+y2Xrl1Hy4zx7Eje/oiGF4r/8Tujd7sv/+5cIMF3oG/dcUfv3eXa/SygPd50Fv4bTuI2ZNH4sbdh9h39B92F5eJNWaeJWu34VZAIJa4TEaNapVk9ikP8C5YsRmtmlqjrGUZ7Dl4Ghoa6nCfZc+2/ebdRzh+g+EsHWR1Kgt4C+KLhKwxKfO+EIHXdZk/gt+Fsl+U2rawxtjBP7Mx4WnpGQh/dw9f73hISFLKZhbKVGlTYACXmp6BD1dckfrlIadvJkVW2dYe0NMvuMOgX8ODkfTpJiDO4PStYVIXZlY2UuccF/0Zn264IyM+hFNXy6IFrFrOgaaC8fXK+KQ8dSM/PUPELXeJLA0GtYfDok5fqIuKKKnLM7k8ykRHvEbYTU+IkyM5JWIsRmD8PMlDaz17dMV2vxWFakNNDcXOZyghE1XlSQFBAO/X6Njs6bou28ruggzo3T77tYwMMYZPWQiHEX0K/OKJdf6H8fzVe/gsnErAy5MTMs0oCrzMzipz0KvjT03x4tVbeK7YjA3L58FQXw//XLyJS9cD4D1vAvvTv9uSjfCePwmz3Fdj3vQxqF2jsswZyALe1X57ULWSVfaO8d4jZ/HuwyfMmjyCbXuZzw4WhD1n26N+neoy+5MFvJFfo2E3wxsHt2ZmI0lLT8fvw2di0yoXWJqb4u2HUMx2X4OqlcvD23kiC1CyHlnAWxBfJGSNSZn3hQi8WfNNTUvHeKflmDK2L6zrVkdETDISwx4gNkAyRtvA2gm6li2kAy+zIZqrCzAvSt8tZX6tiLrrmSvwGjdxgYa2sTJmklo36ctTxNx1B8RpnHL6dR2gV6GTVL9OTQhH9L0FEsCrad4CxjaOEMnxmSiwiUlpOOnrS8Tc85QAXr2aw6BfpY9cn+XCGLcyfabEvGNtJQG85iMwPpcsDT26d4XvmiWFasMyxtrKTJnqFqICggDenPq0+mUifBZOg22DGhzZ9hw5j0OnLuHQn4od3pHXBuNnrUDdmpUxdWxfAl55RZOjnCzgZWD17fuPiImJh6WFGeZNG83Gxu4+cBqBz4KwyGUy2wsTw8sc/GLCTwwN9DDFbjCMDfUx1Xk5xg3/DbYNaiPg0TOs9duD9cvmyQwxyA14z1++zcIls4t78Ng5NjbXxdEOIpEalvvuRKXylujfpwvOX7kNBhYH9+2BRav94btsLgvi0p7cgJcB+vOXb7G70gzgDhgzO3vHOCQ0HNOcl2GP30JkiMWY5rycPdC2++BpWNevhX7fwjmk9Zkb8Bb0Fwk5XELhIkIE3ojIaJiZGLMhMWMdl2GG3QB2nWFieJkdVia04MdHv6EjtMo0zwNoM0uLk8OQEvEfkJ7Mra5jBq0yLWXuDhdESIMYYuQWY5tzgKlRzxB3z0MCePXq2kO7bEdIG3h6UgTi7nvlCrz6DWcWakoraU5NIQ3f1aG0ZAovf1RRigKCA94m3e2w1MUBHVvbcKZ1/koAZnr44r9zWwrM4Ef+voI1fx7C4S0L2DAH5knPyNwlYWJ8+w2xw/MXr3jvf+bUCXB2mggNde5WDQN2g4Zl/nzP56Ovp4c9O/zQoXVjTrOp6WJMmumKv/Yd4rM7ti0GeE8c2Ap9XS3e21akQSa388S5q/A5PBJamhqwKmcO/5Wz2abGOS5Dc9s6GDu4F1JT07B43W4wceZMaAHz64PTxD/w8dMXOMxegR3rnGFa2gjrtx7F63cfsdxtQp7D8dt5HOev3GMPL9WqVhHDB3RDz44tEPDoBdvnvbOZl6rcuf8Mqzfvh4aGBvt3f8rY/uwXQK/VO2FayhAOI39lc1MPsnfHWq+pqFMj71CKqa7rEBT8AVHRcShfzhyLncejcgVLMGO5H/gy++bCvcfO4/Cpy9DV0YaRkT7mTx2O0sYGGDbZGzPGD0Bz27q4FfAEC1Ztxz4/DzYHcmE9zA5eEd3Ey1OSSfPW4EtUDNLT09G+lQ0mjOjDhjQoC7xp8SGIu+8NcVI4p2/t8l2hW2uszF1DRYGXWRXTPl1E4ttTnH7VRNrQrTUaGkZVpboHAe93eejiie9aUB7ewlpVi0e/ggPeOQs34fmrd1jrNQUVypmzVoiMimVhNzomnoXRgnjOXryDBat24M8VTqhd/fvp/s9RSWx3n8PCMXLMhAIB3qmTHTBlop3EH/Gr129j+KjxvE+XAd6tWzagiW1DTtvMH7F5Lguwb/9h3vtkgHfXdj9oaWYeBqSHFFBUAXNjHcEBb25zFTrwprw/jYTnW7nAq64LA9v50DCuScD7gwK0w/tdENrhVXT1o3rSFBAc8MbEJWDK/LW4++A5LM1NoKmhzu6mlTI2YCHYuq7iCfjzEmr/8QvYuPM4u9tVs2p5TjHK0sDPB0xWSAM/vVArJUEBIYY0EPByFaAd3u960A7vdy1oh7ckrOAFN0fBAW+WFDfvPcGjZ68hEonYnd52La2zU4XxKdf6bUdx8twNrPOagrIWptlNMz/tMgeCCHj5UZuAlx8dhdAKkz6NiameO20UKlpZ5jpkJoaYOVxoYKCf/b6bk1129gtp8yTg/a5OYYY00A5v/j6NtMNLO7z58xgqnV8FBAu8TIL9z+FfUam8RX7nnK/yv49xwfOg9xJ1Lh1ewx4yIeDNl5x5Fibg5UfHot7Kf4EvsHnHIbx5H8pm05AGvLsP/p19GDE/8yLgJeClQ2v5+cQUXtn0uHeIZWLMf0hLRiENhWeT4tyz4ICXSVHmssQfF67fZ+3C5N1lkv/3t3NDu5aNsrMnqMpoBLz8KJ0X8DKnucWyM2spPggmUJIelSswwWkR5sjY4c0NeJkLNbbvPQGfJXPYX3Q8lvrB1roO54INAl4CXgJelX+kFeqQgFch2aiSggoIDnhne/uBSeEza8IfYHZfsy6aOHTqMnYe/AdHt3opKIVi1Qh4FdPtx1p5AW/w27dYumIdIsK5p8z56HXM6GHo3rmTRIqjT58jkJCYwEcXP7ShhjKmpWFoaCDR9uvXb5D+Q5J9PgagLlJH1Sq5ZGlgr6stmG8S4gyxzENj8gDvPC8flC5lBH09XQz6vTvatszMzLJ6w25o62ix+Y9v338Cl5ljOVIR8BLwEvDysXoUfBsEvAWvMfXwXQHBAW+bPpPhv2o2e3iMuYEtC3ifvnyLoZO8ce/sJpXal4CXH7nzAt7XwW8watwkfPz4kZ+OcrSyyMsN/X7rLQG8Z/49jwXemRc78PmYmZli6UJP1KopeQHFXBcP3P+Pe6MVH323+6kN5syaLpF79PGzF1i8ZAXi4uP56IbThuOMKWjVvJlU6JUFvMwFDEx6MXV1EYKC38PJYw02rXRhw4iY65QnzlrEpoFb6TWTBeKcDwEvAS8BL+8f6wJpkIC3QGSlRvNQQHDAa9t1HI5t82YPquUE3iu3HmHWgg24cXK9So1NwMuP3EUJeE+ePovpjnP5mViOVszNy2DLJh/Ursm9NIUpMnKsA65dv8V7n7169cDKpd4SwPsw8AlGj5uA6OgY3vv027AWHdpKv/JWFvD+OKjp85dj5KDesK5fE0z8/vT5KxAfnwCfxbNhZMTdMSfgJeAl4M3fxzot+gXEaYncSmoiqOtbQaRtkr/G8lG6MIE3LSYI4rQfvvAzX7J1LCHSLZPnLMqZcr9g52O6VLSQFRAc8I5zXI4m1rUwftgv2cCbnJIKh9kr2WT367wzr/xV1UPAy4/SBLwEvHsO/Y0u7VuijGkpPAh8gbIWZjAvY4KXQW8xz9sXW1a7snC7csOuzMNuYuDhk5fwnOtAO7x5fAwpS8N3YZirhemmtdwdJTHoLyS/O815U03bBAYNHaFuUIGfRT6XVgoTeBPfHEfS633cOWvow6DRbGgY5Z3elIC3wNyhwBsWHPAyGRNGTl2Epja1wdyu9nvPtrh9/ymYw2y7feejRhVuntyCVpCAlx+FCXhLBvDeDgjEtr9O4F3IJ1iam6Fpo7oYPzLzmu5u/SdglbcT6tasgnOXbrGH0xKTUlDK2BDjhv2K5o0b4NK1ezj5z2UsdZ/G1mFSl7VpYYs+PdplOyLt8H7/TBLw5g94maud02NeQvzDVcxqaurQYMBPM/OGzYJ4CjMtWeLLnUh6e/wH4DWFoc08qBt8v2iJ73kXLvAeRdKr3T8ArwEMbJ2hYSQZdpZVkICXby9QXXuCA15GmtDPX7D7yDk8ef4GGWIxalWrgKF9u2TfvKY6+UBpyXgSm4C3ZAAvT+4itRkCXgJehUMaxGIkPF2P5NCrHB8T6VmyO3/qurnnjebDr5UG3rzOoMqRiEYZ4M1IiQJ+DIcAIFbXhrqMcAgCXj48h9qQVwFBAq+8k1NFOdrh5UdlAl4CXn48CSDgJeBVCnif+CA59PIPwFsWBsxuZxEF3ozUJKSGXYY4NZa7Y6lpDG2rzjI/WsoAb9qXh4h/Knl2RreOPTRNGkk9vErAK9M0VIBHBQQHvGnp6dh9+Bz+/t8tfAqLxMVDq9k8vLO8NqJDKxv06tKSR3lkN0XAK1sjeUoQ8BLwyuMn8pQh4CXgLXnAG4fYgAXIiH3N+YholKoDw8ZugJq61I+OMsCbGhGAuP8WSbSv32guNE1tCXjlWbSojEoUEBzw+m49giNnrmLkgO5YtG53dlqyTbtO4Mqth9i5zlklwmV1QsDLj9wEvAS8/HgS7fDm1JFieL+rIdehNSakQZkdXjVALZebcsTMCUsZjzIhDRmpBLyy9P3x/cQ3FMObX82EXl5wwNt54Ex4zxmL5jZ1OGnJHj19jXFOy3GT0pIp7ZP6enrw/3MDbBs14LTFLNku7l7Yt/+w0n382AABLwEvX05FO7y0w1tYO7wZ8SHISJK8JEekawkmDljaQ8D7XR1VXC1MwMvXiiucdgQHvI06j8Hfe5ahrLkJB3jvPXwBO6fldPEED75HwEt5eJVxo7zy8IaEfkJSYpIyTedal7l+umw5C+jq6LDvE/AS8BYW8KaEXkH847VcP1UTwcDWDZql6xLw/qAAxfDyvhxSg1IUEBzwMtcJjxvSCz06NucAr9fqnXjy4g32rHdRqcEppIEfuWmHt/jv8O7dfxib/tzGj8PkaKVCeSssXOAKK6uyBLw/qEshDd8FUUVIAwHvd70phpf3pY4aVFIBwQHvv5fvwm3ZVkwY+Ssbw7t4nh0u33qA0+dvsZdOdGxto6Qk+atOwJs/vfIqTcBb/IHXf9suLFq6kh+HydFKlcqV4L/ZF+WtyhHwEvAiPSkCtMOb6Qh0aC3v5YZCGnhfiot8g4IDXkbR/127D78dx/Hk5RuIxUDNquVhP7wPurZronLBCXj5kZyAl4BXUU8i4M1bOdrhpR1eytKQ++eDgFfRFVe49QQJvFlyM7fiMMArEuWVcbvgDUPAy4/GBLwEvIp6UnEA3jkLNyEkNBwJicnsr1QTR/3Grm2hkYlI/fIQcfcXSMij39ARWmWaA1KWPwJeAl4C3vwBr2FjV6gbVslzOaKb1hRdqQu/niCBNyUlFdfuBiIkNAIZGRloWLcaGtXL+yrAgpSZgJcfdQl4CXgV9aTiALwRkdEwMzFGRoYYPYfOxsHNHtDX0yXgFadx3EKvrj20y3aEtOSuxS2kIbH8eITEmyI9PZ2jha6uDqzr12O1oLRk+V89ctvhFWmZ4pnWUDx8ws1nzHynbNWqJerWrgEC3vxrXVRqCA54Ax69wHQ3X0RGxbB/INLS0hEZFYs2zRpgpftE6OtlntRW1UPAy4/SBLwEvIp6UnEA3qy5h4ZFYsr8tdjv5wZm6/ZLbDISPj9AbICnhDyG1k7QLdtCamL/lJgPiLrnBfEPqbK0y3eFUT07qb+OMb+gfb3jye4w53yY3a9STV2goW2cp8mYunHBp5DwfCunjJq6Lowau0DHtJZUcydGPEXMXXfgB+DVr+sA/YqdoKaW97Z2akI4ou4uAJMiLOejadECpWwcIZJSV5whRvTDdUgOvcSpK9Iri1JNnKGpn3kwMtdHDMR/uIS4QMksDUZN3KBrVl/qnJO+vkT0XU8gLYFT7rOpHexnrUFo6CfO60MHD4CH62x2Pmkpcfh62yPXiydKN/eASJT3xRPMLwmxT7cj8e1xrq20TWHcZD60jSpKHXfC57uIDZC8eMLQZi50LZpI9c/k6HeIvrcA4uRITh8x5iMw3nkrgoKCOa/36N4V69cukWpDedYR1j+DjiDh5W6unXUscCG8E5ycub+oiEQi7Nq+Ca1bNIGZkbY8XVCZIqiA4IC390hnmJQyxHJXBxZ4mef1u1BMc1nH7vR6zR6jUpkJePmRm4CXgFdRTyouwPsuJAweK7bBZfpwVK5gyYY0pKZlIPz9PUTd8ZCQp5TNLJhVbiMVKGIi3yLspqcE8OpW7AZLGwdoqIvylD01PQMhV11zBV7LVh7Q0y+VZ930DDHCnx9D7FN/CeA1ae4GE0vpKbq+fHyEyFtuEsBrVN8BZap3lwrq8TGf8emGuwTwalm0QLkWc6ApZc5p6RkIvbMKSR8lgdeihSsMSlnlzbtiIDzoPKIfruGWURPBpJkHTK2spbr418/PEHHLXQJ4w8zsMG7mKgngHTFsEJZ7O0NDJEJiYgw+XnXNFXjLt/WCpoZm3rZKF+PTA38kvDkmAbxlmrvC2Czvn/eZChHvbuLr3YWS/tl4HswqSv9CFh3xGuG3PCWB12IExs+TBN6ePbpi28YVUm0ozzrC+GfYk4OIe7FTAngvRnSC4zxJ4N27czO6tGsBLc28PzPy9E1lCk8BwQEvk4eX2cnt2MaWo9r5KwGYs9APd/72U6maBLz8yE3AS8CrqCcVB+C9cP0+Dp+6DHfHUTAtbcRKQTG8HhLAWxJDGj6b2MHOSRJ4hw0ZCBfnWWDyUFNIQ/5Xj1xDGtgd3o5wcvbigrBIhB3b/NC8SWMKaci/1EWmhuCAt+9YVwz4pT0G9unIEfF+4EtMcl6Da8d8VCouAS8/chPwEvAq6klCB97EpBQ07TEeNvWrg/nplHlGD+qJti2sKYaXYnhBwPt9ZejevSvWrlws7Zym3MsIAa/cUhWbgoID3jMXbmP99mPY4zuf87PW7sPn8PTlW05Ig55uwcfzEvDy81kg4CXgVdSThA68ec2bdnhph5fxDQJeAl5F10aqx1VAcMBbr/1IuW34+CL/tzr92DkBr9zmkFqQgJeAV1FPIuDNW7mCSkvGpG4SaRpIdMxAOhuOASDl/elcD60Z2M6HhnFNqeZOjXqGuHsEvAS83ENrtMOr6CpJ9RgFBAe8TJYGeR/bBtIXVXnbkVaOgJcPFQECXgJeRT2JgFe1wKthYo0gUS8kJCVzOtbQ0EC1qlVgamJCwJtTGTURDGzdoFla+kG91JhXiAtYIJmlgWJ4s9Uk4FV0laR6ggTeomY2Al5+LELAS8CrqCcR8KoWeDUt28BrbxQOHeae6q9YoTy2bPJB5UoViyTwapdtj1DdXoA4gyOYmpoIVatW+rY1LUbCEx8kh17mlGHSkhnYzIO6rqVUN00JvYL4x5JpyQh4c5ctPe4dYu97S2RpiDYfAftc0pIR8Cq6SlI9QQFvckoqvkbHwrSUETQ1NVjrxSck4cS/15GUnIJfurTKPt2sStMS8PKjNgEvAa+inkTAS8CbU4G8Lp7IsOoHj8338OwZ91fCenVrY4m3B7S0tdnUGAS8mWqqaZvCkIF8A+l5eFMjAhD3n2QeXv1Gc6Fpais1bR4Br6KrHtVTRAHBhDT47TyBPUfO4e/dS8AcRmNuJBo8wRNPXr6FpoYGjI30sdtnPspamCqig8J1CHgVlo5TkYCXgFdRTyLgJeCVD3j7Yrzn33jw4BFHMFsba+z030jAm8vFEwS8ma7CZE+htGSKrtBFp55ggHfIRC80t62DKWP6surduv8U42etwLGt3ihrboKxjstQpWJZeDiOUqm6J8+cz9xtjo/HseOnEPGFe2MM8961O4Eyx9S6ad638LRo3hTNmjSGbbNWnHau37yDEaPHc16T1k5WQVnj0dfTg7fbTJS1tJAY9/8uXELg46fs67LaYcrIOx5ZwFvFykSmhvkdT+dO7VG3di2Ja0o/hsdiuuNcqf3JO6+cjZibl2F/8q1ds0b2ywF3rrP/f/TYSbx7/yHXPvM7r5yN1KxZA927dmJfsm363X8eBj7B6HETEB0dw7v/+G1Yi1K6IuaiMM5z/7+HuHI1c758+g9jL//NvihvVY5tt6yJrtRdJZmOVEQKFNUsDUINaciwIuDNy7UTX+5EksCAVwwxMuKZ2+e4ISrMwqNhUI7NYy3tobRkRWShU+EwBAO87X6fioVzx2UDlI//Edx//BJbVsxi5fr38l14rd6JS4d/uOWmgMX08JC8AenHLpeu3ytzFLMmDJJZZtykzLlmPbkBrzztyBoPA7wTR/aWOR5Z7TANyDseWcA79Ne2KhtP2arWMoFX3nnlHHRuwLvZZ6nK5pXTf/ICXkXm9eMEGOANevQdbPOaIF/+c+D0DQLePEQuiCwNBLx5f2Qphve7NgUd0sBcDxwfuBbpMa84BlHXrwD9ehOglksWkZwFCXhl/ukpdgUEA7yNuozFznXOaFA785rDyfPXolJ5CzjaD2T//ejpawyd5I0H57eo1EgnTv/L9hefkIBjJ07jSwHs8DZv1gRNm9iiSfM2MoFXkZ3HHwVjgNfLZQbKWppz3mK+MF+4dAWPi8kOb6cO7VC3Ti0Jfwn9Ei8TeBXROTfgvXfrKtv/0ROn8P59SK6+q9wOb3V07dyR3WxtnMN/CnqH10hHYoMXzA7v1es3s+eozLxyCkU7vHkveQS837WhHd68/USQO7xiMWLvuSE9KvMXx6xH3bAqDG1dCHhVSkLC6EwwwNt1kCOmjeuPnp2as8p27D8d08b1Q++urdl/X7rxAG7Lt+LiodUqVZ5iePmRW9YO78ePH/npKEcri7zc0O+33hIhDSdPn5UJvIoMJjfgzWpn5FiK4VVEU6YOxfCWHODVrz8ZWhY/SXxmcyqQ96E1CmnIy1PyBF7b+VA3qCBRTQ3i7JCBwjq0xuzwEvAqumqWzHqCAd7FPntw/U4ge5PavYcvsGrzAVw4uDo7M8NS37/w6NlrdhdYlQ8BLz9qE/AS8CrqSQS8JQd4Q0wmYsues+wvajmfDu3b4o8Bmec7CHi/K6NRqg4MG7sBaupSP165Aa9IvyIepPTCqzfczQZ1DXW0atYUNWpUY9vMC3hTazgjLsNEIp5eV1cHlhaZvx4qk6WBgFfRFbPk1hMM8EZGxWL4lIUIfhcKNTU1zBw/AKMG9WAtFxOXgO6DnTBucK/s11RlUgJefpQm4CXgVdSTCHhLDvC+L2WPsVO88DUqmjPpqZMdMNF+HAtXBLw8Aa9RdRwMrIHFy304WhsaGGDLZl/YWDeQCryvjadi5rwlSE9P49R3mjEZvX/uwe7SE/AquupRPUUUEAzwst8kU9Pw+MUbWJiV5qQfC/kUgcBnwWhuUweljCWvu1REGHnrEPDKq5T0cgS8BLyKehLfwMvk+3ZZ4o/rdwNhoK+LYf26YtyQXnkOT1b5wOfBcF++Da+CP6CcpRnmTh6Cn5o35LR37Ow1bPnrNI5v885+nbI0SF4tTMD73W2GDRkIF+dZUIMaMlLjEBuwABmxrzl+pdQOr5LA+9JgEkbYzUJaWipnTDlDyQh4FV31qJ4iCggKeBWZYEHXIeDlR2ECXgJeRT2Jb+Cd4b4e6enpcJk+HKFhkXCYvRIL545F2xbWuQ5RWnnmS3q3wU7449dOGNinIy5d/w+eq3bg7F/LYFLKEGERURgxdSG+RsfB3Kw0Ae83hVOjniHuHgEvI8fnQrpaWETAm/15pzy8iq7ORaseAa+S9iDgVVLAb9UJeAl4FfUkPoE3JSUVzX52wN4NrqhdPfOGqWUb9uLL1xgsnmcnMURZ5W/ff4apLmtx7bgvRKLMxMQDxrtjUJ+O+L3n91R7F6//h5WbDhDwEvACadz4ZKWAt3Q9GNq6MTcnSPiuOEOcHV+bawwvAS8Br6KLchGtR8CrpGEIeJUUkICXVYCyNCjuR3wCL3NGoNfwubh7ZhN0dbTYQR04eRGHTl7C3o1uEoOUVX7/8Qs4dOoy9vl9rztrwUZYlDHBTPsB2e2VLOB1gabx98tXskTIeU8A7fB+dzVlgFe7Qncs2R+Gh48ec3y3SpXKmD/HESalS7GvE/BmyiPSscCF8I5wcvbi6EU7vIqvz0WpJgGvktYg4FVSQAJeAl4lXYhP4H368i36jXND4IWt7OFY5jn57w1s2nUCx7cvlBiprPLbD5zF+Sv3sGPtvOy6rsv82evQmZCJrCcv4M0QixH29i4ib0tecFPadhbMq/4k9Va56Ii3+HTDA+KkcM7Y9Sp2Q9nGE6CpIbnzl1UwJS0D7y+7IPXLQ05d5uIJ731ROHjoGOf1ihXKY++OjahfuyrSM8T49PQoYp/4c8qoaRgistw0fI1JkdCyQgWr7Dzr4R8e4stNN0DMPfAUUtoBoycvkDi0NnPqBDg7TYSGuhpioz4h9Lo7MuK5ea3F5fvCziP3q4VPHPCHob4uUtMyEHJrJZI+XuICj15ZWLZyg2EpK4lxf3MTNk3X55fnEPXgh8uP1EQwae4B8wqNpHr6l9CnCL/pLrHDG2Zmh3EzVyE0lLlV7PszYtggrFw0H5rqIiQkxODDZReJGF4GeCcsu4tr129x6tatUxsH92xCeUszpKWLEXp/C+KDufZkQhoOP66JhcvWceoyh9Z2b9+I9q1s2dfD3txE5J3vsedZhYMMJ2HYOMkY3uWLPDB2eD/2F4+osNf4fNMD4mTuDaUxFiMwft5WBAUF6iCvqAAAIABJREFUc/ru2aMrdmxaCS0NEVJS0/H24txc8/CWb+sJXT3jPPVm/DM08ADinu/k2lnHAhcjOsFx3gLu6yIR9u3ajG4dWkL92y81Si5bVL0QFCDgVVJ0Al4lBfxWnUIaKKRBUU/iE3izdmzv/7MZWlqa7JCYHd6DJy5xdmmzxiqrPLPDe+TMVfy13iV7eswOr3mZ0tmX5jBv5AW8YdFJSAp/gLgA7h9gpo5BQydoWzaXCrypsSGICfCSAF7t8l1hUJfJavDD/c85jMDsuMbc9cwVeL32RuHQYUng9d/sg6pVKoFJGZX49jQSnm/lgoNWaVyN7Y1pTq4S5t61fTNatWjCvp4c+RSxd/MXwztloh2rRVpCODvnH4FX2sUTu7b7QUdbmx133CMfJIf+ALzGNfFOpz+iYhI549ZQV0f16lVhaVGGfT0p5DLiAtdy56YmYlODaZvWk+riyVGvEHvPUzKkwdQOdo6SwDts6EC4z5/N2jA9NQ7RdzzzBbzbtqyHmWlpFtTjn++QuFo4M4a3JhYvlwTerX+uh61NZpaG5PB7iA1YJDG3VwaTMDyXQ2uLvd3Qv28fdtypMe8y/fMH4I02HwF7Z0ng7dG9K3xWL2brijMyEHUn94snjJu6QKRpmKfejG8nBB1B4qvdEsB7IbwTnJwlgXfntk1o2bwxLErpKLpUUb1CVoCAV0kDEPAqKSABL6sAhTQo7kd8Ai8bk9vTng1fyIrhZXJ8R0RGY6mLvcQgZZW/df8pprv64Npxn2y4ZHaQB/bpgP692me3V1JCGkQs8P6CaU6S4SE7t29Gi6aNWU2KWkiDhmlDbL5kjA2btnF8wNzMDH9u8kGd2jXZ14va1cLSdnj9N/vC1KQ0O24Kacg0K4U0KL4OC6EmAa+SViLgVVJAAl4CXiVdiE/gZYYy1WUd+3Pr/GnDERbxFXZOy+E+cxQ6/ZT5Ey5zCY5paaPsVGXSyjNA3GWQI4b374YBv7TH5VsP4brUH2f2LEUZ08z4SeYh4AUIeF9l7uTzeGiNgDfvxSXxzVEk5brDSzG8Si7JRbY6Aa+SpiHgVVJAAl4CXiVdiG/gZXZzXZb642bAE+jr6mBI385wGN4ne5RDJ3nDytIMS+aPZ1+TVf7BkyB4rtyOV8EhKGdpCqcJf6Bjaxu2LpP2rO9YF6SlpSMxKRmGBnrsdelzJg1mf2oOjUxkQwri7kuGNOg3dIRWmeZA3lEJSIsPQdx971xDGnRrjZUa0sCMj+k3txjevEIatmzyQeVKFcH8ZJzyPq+QhpK3w5tSwwVxaZI/sRsY6MLCPPPWsdQYAt6sD1leIQ3du3fF2pWLWZenm9aUXDhLYHUCXiWNTsCrpIAEvAS8SroQ38Cr5HB4q07Am78Y3oK8aU2pkAaRBp7pOGCu61IJ33B3mYP2bduwX1oIeL/Lowzwapg0xHPxz0hO5h6M1FDXQM2aNVC6dOZhNtrh5W2pEkxDBLxKmoqAV0kBCXgJeJV0IQLevAWkHd7v2kg7tLbTfyO0tLWZbUMkPGEOrV3miKos8AZqjMNoe0cJQ61fuwJdOnUg4JXz0Jo8O7xaFj/Be99XnDx9lqM388uD79oVYLKBEPAquegKtDoBr5KGI+BVUkACXgJeJV2IgJeAd+pkBxTlHV4C3u8+WtBXCzPA674rDEdPnOZ8MJh1YoufDwGvkuutkKsT8CppPQJeJQUk4CXgVdKFCHgJeAl44xAbsCBfacmKa5YGAl4lF9RiXJ2AV0njEvAqKSABLwGvki5EwEvAS8BLwJv1KSDgVXJBLcbVCXiVNC4Br5ICEvAS8CrpQgS8BLwEvAS8BLxKLqQloDoBr5JGJuBVUkACXgJeJV2IgJeAl4CXgJeAV8mFtARUJ+BV0sgEvEoKSMBLwKukC5VU4DWwdYVm6QaSeXiZJLjfcvPmlaUhrWxfvEmqhbS0NI762tpasGlknZ3al/LwZspDWRq+u4mhgQG2bPaFjXXm1cKpEQGI+0/yauGXBpMwIperhenQmpILHlVXWAECXoWly6xIwKukgAS8BLxKulBJBd53pafBa9kmJKdw842OHjUMfXr1YC+VyAt4EyyGYIL7Prx4+Yqjfvt2P2HD2pXZwEzAS8C7eLkPx0cIeHWVXLGoemEpQMCrpPIEvEoKSMBLwKukC5VU4H1tOBEjHeYhKSmJo6C761wMHthPJvCOd9mD5y+4wNuhQ1ts8llNwEt5eCEyqo6DgTVAwAuIRCLs2OaH5k0ao5wpAa+SS3ahVSfgVVJ6Al4lBSTgJeBV0oUIeAl4KYaXYnizlhHK0qDkglqMqxPwKmlcAl4lBSTgJeBV0oUIeAl4CXgJeAl4lVxIS0B1Al4ljUzAq6SABLwEvEq6UHEA3tlefngZ/AF6ujqsGjPtB6BRvRoIjUxE6peHYGJpf3wopOG7IgS8BLwEvEoupCWgOgGvkkYm4FVSQAJeAl4lXai4AO+w/l1Rv1aVbDXEYhDwirlZJN6XssfYKV74GhXN8RoCXgJeAl4lF9ISUJ2AV0kjE/AqKSABLwGvki5UHIDXdZk/gt+FsgfN2rawxtjBP4MB3rikVER/vI/ou54SKgUbTsIIh7kSh9YWuM3DmBEDIRKpISHqPb7cXgBxUjinfoLlEIyfL3lorWOHttj55zqoq6shPUOMsBvu7A5zzkfTsg2890bh4OFjnNcrViiPnVvXo1b1ysgQi/H11UnEP/XnlBFplca1uN6Y6ugqMZ+/dv6JDj81Y1+P+fwYUbfdgR+AN6SUA0ZPWSABvNOnTIDjtPFQF6khKTYMEbc9kREfwulDXL4v7Dz+xoMHjziv29pY4+Cezezuenq6GF8C1iAp9BKnDJOW7M8rxli/cRvndXMzM2z394VNwzqsvaLfXkDMw7XcuYk08FhjHEbZO0rM2c9nFXr/3AlqakBs+At8veMBpCVwyoWZ2mGc4yqEhn7ivD586CAs8pzLzjk5KRbhN9zzdbXwnh0bYFnGFBkZYnwJ3IbEN8e5tjKqjkOPa2LRsnWc15ksDTv8N6BlM2v29eiQO4i+t1Bibq8MJmF4LmnJli50x7BBv0FNpIb4yDeIvLMA4uRITv0YixEYP28rgoKCOa/36NEVm32XQUOkhrS0DHy+Ph/pUU85ZdgY3t3hOHr8FOd1Zp3YuXUDqlcpn+mfzw8j/sUu7px1LHAxohMc53F/UWEOre3ZsQnt2zSDoa6mkisWVS8sBQh4ZSjPLAbLN+zFkb+vIDUtDZ1+agwPx1HQ0dZiaxLw8uO6TRrbYIe/HzQ1NTgNvg5+g1HjJuHjx4/8dJSjlZz5IHM2fvL0WUx3nMt7f+bmZbBlkw9q16wh0fbIsQ64dv0W73326tUDK5d6Z+dVzergYeATjB43AdHRMbz36bdhLTq0bcP+Ec/5+G/bhUVLV/LeX3EA3ixRUtPSMd5pOaaM7QvrutURl5iG6I8BiL6XX+AdBJHaN+C945k/4N3s8x14b7rlH3irVfkGvCcQ/yyfwNumOSsFC7x33PIHvFPtM4E37nP+gXf3n5nAm5GRN/BeNsZ6v1yAd8t6LvA+WsP1cVnA27NzJvBGPM8/8HowwCtCcjIDvG75A97tG7nA+5b7BYbJ0iAVeJs2ygTej7fzD7wDf88E3q8M8HrmD3h9lmcCb3q6YsBbuUKmf744lE/g3Yz2rZvBUI/7N4r3BY0aLDAFCHhlSLv32P+wff8Z+C6aDj1dbTh5boB1vepwtB9IwMujWxLwEvAq6k7FAXgjIqNhZmIMsViMsY7LMMNuAOrWrEwhDRTSgM8mdrBzktzhHTZkIFycZ0ENashIpZCGrPWDsjQoupIW/3oEvDJsPGLqInRqY4vh/buxJS/deADPldtx/kDmThXt8PLzISHgJeBV1JOKA/BOmrcGX6JikJ6ejvatbDBhRB/2J3I6tEYxvAS831eG7t27Yu3KxewvVsyXw9h7brmHNOwKw9ETpzlLCrNObPHzQYUKVuzriW+OIunVbk4ZkY4FLoR3hJOzF/d1ysOr6PJcpOoR8MowR7vfp2LBrNFsXB3zvP3wGT2HzsbdM5ugq6OF2IRU9vWQ0M8YPNJBIpE7H9Zm49OmZsan5XzOX76JISPs+OiC04a+nh52bt2IVs0yf7LKetLFwMy5Hti77xDvfTLAe3D3n9DR5sZHPX3xGkNGTSiQkAY2lmxgZixZ1sNAxoGjpzFlxhze58iENOz0Xw/rerW4umaIMWCYXYGENPzSqwc2rFnM/gSY87kdEIhho+0LJKRhi9869OzSjhPSwPyE6Ou3Hd5LCiakYff2jahaMfMPmYGupkQ4Be/GVEGDBLweEiENdGjtu+PRDi8BrwqWoWLVBQGvDHM262mPdd5T0dymDlvyc/hXdOw/HVeOroNJKcPs2nHxSXj2Kpj52sm7g+jp6aJuze+nt7M6ePP+EyK+cIP9+eq8nKU5ylmacZpjpvboyQukpHJ3XfjoU01NBNuGtSVAhdn1Cn7zgY8uJNowMjJAjaoVJeJbg958wNco/mNbmQFUqlAOZUxLSega8PA5xOJ03uepoa4O6/o12cNQOZ/Q8EiEhHAPwfDVualJKVSpWE6iuWev3iIuLp6vbr63o6aGWtUqwdBAj/+2C7lF5gt1wpeXSIm4KzGSN7EVcO56IMQZGZz3bBpZo1O71uxnKSU+AvEfL0Atg/uZjRVb4MjFt0hOSuTUNTExwahhA9n4X+ZLSszrk0BaHNdfNYxx6nYcQj9HcF7X1tZC/996o6ylOVs3/tM9pMe85JTJgAYCP5ni1v1nEvPp0qkDGjXIXGcTo94g+fNNZh+PU+5jYnmcvfwUaT/Mp06tmujZvRM77tTkaMS/OwdkcK9cTlE3x4H/fUBCAtcHDQwMMHr4H9DW0swc99t/kZ78hTs+kT7OB4rx+i33IBxz5oC5xrlKpQrs0p8Q/gipXwMlfT/SClduSb7epnVLtGhqw65BSbEfkfjxChOgwKkfnloOJy+9QFpq5uZK1lOpUkX07/Mz+4U9LTURcW/PAOncnMzQNsXec2GIjeOuZ7p6uhg2qB+MjQwhzhAj9uNVZMRz19kMkQ5uvNTGkxdvOP2qi9TRs2cX1K5elX09/stzpEYESMw5KKYCLlx/xO7E5nyaNrZFuzYtWP9Mig9DYsglqP0QuhIttsTxC8FISubOp0yZMhg+uB9r5/T0DMS+OSFxyA+axjh+Mxafw7g21NHWxoB+fWBRxoy1c8KnO0iLCfph3FoI+GiMew9ecF5n7NO1Syc0rFcLhnp0aK2Ql0WFuyfglSEds8PrPWcs2jRrwJb8cYdXYeWpIilACpACpAApQAqQAqSAShQg4JUh8/ApC9GlbRMM69eVLXnh+n14rNiOi4dWq8RA1AkpQAqQAqQAKUAKkAKkgHIKEPDK0G/34X+x69A5bFjMZGnQwUyP9ahbsxLmTh6inPJUmxQgBUgBUoAUIAVIAVJAJQoQ8MqQmYkTWuL7F47/cw1paWno0NqGzcObdQWoSqxEnZACpAApQAqQAqQAKUAKKKwAAa/C0vFTMS4+EQb6uvw0Jmcrqu4zKTkFGhrqYA5Q0cOfAiVFV1X7K38WopZIAVKAFCAFiooCBLyFaAnm9OofDp7o16s9+vVqp5KRMAnue4+Yh15dWmHiqF9hbKhf4P0u27AXl288wJzJQ9C6af0C74/pgLkhL+zLVxgZ6KlsN575NSA5JZW9oEQVT2HomjWvlJRUaGkV/GllJu/13IWbMHHUbxjUpyPU1UWqkJb6UIEC70I+I+DRS/zavU2+e0tNTYPb8q0YNagHalQpn+/6VEF1CnwKj8RS37/gNXuMytZi1c2OehKSAgS8hWito2euYtWmAzi9awn09XRUMhLnxX/iU1gkLM1N2Es0GOgd8EuHAgMJ5o9a75HOcBjeBwdOXkStahUwe+IfqGhlUWDzZa6BXr35IGLiMu+kZ1LKMTHXlcoXTJ/Ml4jFPntw7vJdMFfDMnMb2rcz/vi1M0Q/5L/la9JZuk63648DJy6iaqWycJsxEqaljfjqItd2mC9pa/48hIMnL2Hh3LHZ+akLolNGy19HObN9BL/7iIjIGCx3dUDlCpYF0R21mU8FmC94in4BYeree/gC+09cwDIXe4m0edKGwsDudDdfRHyNxuZljsUyHV0+TVFkizOwO2raYrRsUh8u04bly86FOSllfLswx019S1eAgLeQPCQhMQk9hszGtHH98FuPnzijuB/4EtZ1q/MOS4+fv8GQSV446u/FQkPg82AsXrcHsfEJWL9oOqx+yLvLhzQT562GkYE+Fs0bB+YneP+9f2PngbNwdBiEvj+35aMLTht/HT2P5Rv2sXHWPTu1QFxCIvYePY+te//GWq8paNqoNq99xsYlYMB4D5SzNMW8yUNQtVI5PHnxFss37mX7WbNgCrvLzPfD6MrknV08zw4MAKzw248b9x7jgJ97ge28JialsLutH0LDoaEuwi9dW2PI7535nlp2e9v2n8G+YxdwfJs3mHynzBcm5ovMX+tdCvQLU4FNiOeGj529huev3qFbh2awrlstX60HPHqBsxfvwKZ+DXTv0CxfdZnCNwOesGvH/v+zdx7QVVXbGp5X7ICIvaGoKFhQUSw06b333jsJEEqAEAKEFmrovffemyAiKEUBBRUUUGwoKIqI2K/ljW/y1rk7O3ufkpxAgL3GeOM+yTm7zL3O2v/65z//OblPyPMNENS62wjdvITKzqYG7AJiDh35TDJkyCCPPfJAyOvr8ROnpP/IOdI9sp48/EByn2l/QUzNs+K4zPvrr7tWWjesGBJoTO09f/TxF+o9nyf3IyFnA1MDdnlXHDz8mdyUOaM8+lBoDP7Jb0/L/JVbtFV37UrFtEFUKCM18zOU83ifvfAR8ADvhY+5npEFbNqC9TKkV2spX/wl31Uc+/xrqd6ityye3FfZ0HCOBpEDhcVg9ID28mTO/zWyePWNfdrO9Jqrw6ux3bn3oLSKHi6RzapK6waVfC+Yk6d+kP/+979hBy0ct2z9bjIktrWULvJ8ktBteO1tGTRmnraExmA+XGPg6LmalgWEWVP8SCq6D5wkp77/UWYkdk8xE+Z0nSauHVtUlxb1Kmhcf/jxnBSq0l6WTukrjz+aPVy35zsO9wHIvvvOW2RIbBup1KSnDOrRIuwbCHNC7odnOTi2lRTNn8d3HcQbRn1kfGTY7/FSOuBrb74rvYfPkNYNKgoZDeQetSsXC+oWiF/JOl2lZf0KCgAz3nC9rkP25iRuBwPsto8dI5kz3SAvPfu4NKtTTnI8eL7LXaCRGhCUGrB79NOvJKr3WPnl1981rc4mdHxClIKiYAe/6RUb3pCxM1bI6P7t5ZkncgT11dQ8K3MCNpl9R8xS8mBEn7ZBPavU3DPZsa7xE+SDjz6VnDnuF95Lw/u08zVgCnTjqXnOm7btkfjE2ZLpxhvkt9//kPzPPymDerTUhkc9E6ZIZNOq8nB29/lWrXmcPPLQfXLLzTfJW+8cklmjY4IG6+a6We+a1SmrZJS9AVOge/f+nn4j4AHei/BsWLwqNu4p7ZtVlRUb3pSsWTJLzw71lXVo3mWo3HPnbdrOOJxj3Zbdysi0qFdepsxfqyACdtne9Stc5/zr77+lWrM4ZQZYeP/440+VFYSbYbVeL6n2Pfs/kvnjeznexvwVW8LKSP762x9SoHKkjOnfXgq9+FSyc1Js1bXfBJk4uHNQL6hgYm/iShyPfXFCfjr3iy7Kb7z1vnz/w4+ydGp82IsD6bQE2K1QIr90bl1TQcOL5dvKrjXjJctNaaMBR5/59Tffy7Th0UnCwuYiMnaUnvtKHrjGzF6ySZZP66cbADbJMxK7+QUCJl5sekvV7So7Vo3TLEGTqATV9NeqWCRgSA3Y7dO5sZQp9oKs3/KWbiQXT+oTUGriBIJmLNogOR++P6C23wnsfvrlSdn33pGA1018qjbrJVXKFBIkQGwQp8xbK2/v/0imj+jm957J4ODSw5pdoUQ+zUrtPXBEN7ObF40IiiRI6bMCKM9Ztknuu/t2adu4stx9x63SqttwKVHoOalbpbjf607NPSNbahI1WLMqI/tG6Bx578Nj0qHXGNm8aHhAwsDpOQf7rJhf7XqMlH7RzaRCyXxaE9G573h5NvejsnPPB3rP4xM6+WVtS9eNVtlcsYLPypjpywVmflhcW1+8WLed6iys181mcM2mnTJz8UaZNiI6CUEU8EfifSDdRsADvBfh0XSIG6OLBj9CdIoLVm6RyXPWyJO5HpQDhz5RTW8ozEOgWyAVXb5hd2nTqLK+HH48+7OMm7lSAMEsLKUK5w10iJD/Pm/5qzJn6SZZNydBF861r+6SxMlLZdKQzpIrx/0hHy+YL7BZeO6pnNKuceVgPp7qz8B+1IvoL/tfnaYgkxfFxq17lF022kaebziZc+I6d9lmWTt7kDLK6197S+JHzFKNdJ0qxUNO3wUKAux/ryHTdb5iydeheXWhpTV+1GnVfOXwJ19KnTbxsmxqv2TM4bZdB/R6dqweG+jSL8u/oxXnGcDGVmzUQ7q0qS1li70oE2atkmefelTyPp1Tf98w4fy2re2WmSusK2jao3qPk6w3ZxaAKxkD0sfN65XTmPUdPks3hmzArcMKdgEjZtRr118Lz2pVKuoacycQNHX+Os10ASSb1S3nmtFyY3aRaPUfOVuy3XuHDO7Z2jWLkjh5iXz82dfqpW4GbG2ZetEyc1QPv1Iu5tqJb76XetVKKJPO75zOmyVrd5F543v5lTak5ll9+fUpBenIJ37//Q+Zs2yzyrQ+/uwref/DTyWxbzu/8zs19/zm2+/rHFgze1CS2pIy9brpeU0GieeybP12zS6Y7IAbsxvss6rcNFZqlC/sa/TETRILsj3MWzew+8lnX6ukiwZREBvL1m2TJVPiheLa6P4TVbLHQFqC7I2MnDWj4XbdxCLv07nCvq5elovTJXBTHuC9wA8JVoEd7Lq5g+XuO27xnR2dVJn63aRDs2paeRzOQQru9Z37FUBYi6hYJK677hrJds8d4TydvnBZoPp1a6Zd6sxgtx6snIB48LIOxfGgTfdEeSJndmnfrFpY78ftYMSPBXrvxsl6ndx3x95j5exPvyjDkC/vE2G9DhPXAd1bSPFCz/qOve7V3Vr8M2dMz7CeD3DNxmhEn3aavp08d42+9B99KJuCiynDuob1fOZgdDfkHL2iGiY7vnWzmCYnT+cHbdh+oDKVMI1vvPWegv/XliSq7R8vcJg5GFwyAGSJrC912C5YcyQ/MIDlGnTXOYN0is8BkthQsEGdMbJ7kjQw2YrS9aIlJrK+Mm9mbN25Xzc/d92eVXI8eJ90aF7NUZfbvPNQeSDbXb7CJcAuDHVi3wj56uQpBezN65V3ZC4nzVkj23Yf0AI15t2SNdv09IDsjBlvkC7x4+Wh++/RjJXT4Pqezf2I1K9WMsmfaRMfqJCVjVeT2mV9OueJc1YLv4tbs2ZRdt3fZjY1zwqghbPB2jkJes2Avsieo+TU6R/1d8EmwV9hVWrumftDuwuwN4O1rkbL3rJ9xRjN6lg3IWQWjC+99TkjRwjlWXHMZ0q20I20yTxC1kTEjNTLAOz+ePac/Pevv3SjhM6XzR8EylvvfCjxibNk9cyBcvXVVysRgVQQAAwRwfzeuPVtzcRR8GuXfdnnp7lv1jv+j2OgB7bO/XS+VHiX5xABD/Be4GlBeuv0Dz8lA7XTF27QyndToBPOyyLlCLvTrnEVqV25aIpT3hS5WbW/btdICpxFc1BMyxTfRkrYWvR1E2av1kXvQrhesAhWbRYnlUsXSPI8WYxhYbcsGaFylXAN4goz92Suh6Rrm1o+bRkFecyrlTMGhOtUepzTZ35SycSD99/tOy7pwcjY0VLwhdwS3bZOWM/HwUghI59ANtG5da0kqe4la15XNwxkG6EWDYX9Qi/SAQEeLaOHKVBEowhoRZd+1+23KIht3DFBQe3YAR2SyWxI5dZt109BZeXSBZVBjGhSRSqWyi9IZbrGT5Rtu/ZLo5qlNfb2wXywuoDs2POBdOozTgb2aKlp9vVbdsvAMfNkyeS+cv+9STfRaLKzZsmkwMOAXUC1KUjas/+wPvc9GyYmk/+wUQYM4VcOMAHoPJz9Htn9zoeqI6ewiSI4t4wDbjisDTNH9kjCAlO4N2PhRvn2+zNS+KWnpXWjSskALIWS0xdskOF92soTj2aX/qPmyu59B5UZzpI5k8xbvll1pjUrFJG777w1SchS+6wAmMULPqfSt8+/+laadRoijWuVVu21AZxF8j/jaGnpds9shsbPWqWAFgafOgC7rI11BvkCBMnNWTIJG4M23UcoecG88Keltj7nlDwr6kxyP8b6Vls1u1awS/EZMUBewebonjtvldHTlsmsUTG6ccGBCOa+T5fG0mfYTM2AGWmgmXPI3Zw2OdbrNg8RHfHWHe+qDIZ5P2LSEmX6g5H+XKTlwTttgAh4gDcdTBHDtlA4Yi3QCeelsYgljF0gZ8/9Ij0i60r+vMH74fIyVE1Y016yZErfsDPC9vtkkaFAY+P8oSEBVwBoTMJUdUmAYX0hz2Pyn/+IZLjqqrBpaO3XyksNcF67UlFpXKuMMubVmvdWRigtpBWk6GYufkVmL3lFQeett2SRxau3+jRv4Zwzbseq3Tpe6lcvIZVKFUiz01G4MmrqcgUgvJjRUH76xQkZGtdWCr2YO6jzwojve/+IPPXYw3LHbTcH9Z1L4UP8luNHzJZPvzyhrCXMJr9P2F2Y+Ca1ykjbmJHq4PHcU48muSVe7P0SZ6uM4bmnHpGR8e3lmmsySHS/icoijhvYUaL7T5JiBfNoMZrbMGCXbIO1QLRmq75St0oxqVbO2YFl0eqtMm7GSmWQrdX3yJ/4G3IutwFgf75sa3lj5Rgqo6G9AAAgAElEQVQFIPz2ovqMU5nGVf/5jx7TbQCG0JHWq1JcypfIJxu2viW9h86Qlg0qSN6ncmoanDhYtZ7mWFvefEfT4JyPTA5glw1Gwtj5cuDgJ1KqyPP6GyQTAlizjtQ+q0lzVsubb3+gz7dVgwpJwO6eAx9Jjuz3qv6a9cduEWe/Z34/jaMSdN1A948efu3mXcpU2zNpaKth4NlYIrPDK75HZD35+++/1RLu9V37lV2tVq6QYx1ISp/Vd6d/1PcUNoR///Ov3Jb1Jp+MAZDOWstGo0KJl9SbGw33U489pOCW99TY6StUZnHrzTfJyH6Rev32DRbnwH/en484Ui5+Y4sn9/FJXpBasdnfsnhEkmd8oTzJL4W1Kb1fowd408ETIi1JCn/q8LRJEVtvkbTOiEmLJa5TYymc7+mAd//B4c9059ytXR3Vx4Zq8RLwBLYPwB7gAACL4fbSDHRMtMmwnkc/Pa72bnPH9gwIeGF7rrnmGsmd63/uFYHOY/7Os0ucskQAARSWkHZDsoKNUFoNgMuG197SFyHSCfRtF2LAoOQt00oWTIgLSosNO0SFNwUkoQ7OxQvt8+MnJVPGG+Xll54KqishDCAvNdgiwPKRY1+qm0VaWqiFem/h/Dyb2PoRAxTsGhkDcb/l5sy6waXoyW2wSezab6Lqso2MActE5jSMqhMwoIIfyVLvTo2TgF1szljLyFLZ2U5zfthnjm+1I0MW0X3AZJk8tLMWJ7EGnDn7s+MmpUbLPjoPjGwpbugMeef9I8ry3Xl7Vr9hZRP199//6iaAmoZhvdv6CAbOWbRGpyQAx3owtLNd4ifKlGFdFOwyuFdiBBDcte+g6l7Xzz1f7OU2UvKsiA0uGFZm13gQ//jTz0IMsJS0ShDM+c09lyv+ojL6BV7IreypGe1jR+tv02qNSZExmxFS/4c/OS65cmRTRx0rs9u7UyPZtvs9BfpkE55ysMUL9KyQ2mGLBwC3DwqQ3zv0STKwC8iuVCq/gu6+XZq4zjNzPDvYNVrdBtVLJpO4WK+B3wSMvlVeCOAFcO9cPc73UY6/98DhNJN3hXOd8I4l4gHedDALkBugQwomTcsLasFK2IavlMEsXeSFkP0kAQTXXH110FZZVDTjh7px/pCQPTdDDS9Wbbw4qfpGb8zLEDCXEokCL1ZAUzCtm3l5wRS56QCDuQ+AwIdHPleNm73gx+373O9D99+dIkAYzDVZP4N+HHbt1Pdn1Oqnc6uaIZv2oxucPG+ttKhbLqi50LbHSPn9jz+kYfVSyn6llSuI9T5feX2P9Bg4WWNK6h9NNZsftHhRLWteVmwv9w3gAfiM7tc+yVrAy3jRqq1+f7cwfAAPZAikr80wwICsBUVJ9nHmLBKF/8l1zoPWScqQkmZHe0lBWYcW1X0A0Wm+8j2eFc8J4GNAFZrkUf2SW89hF9V72HS1+0NHi/7XMK4UJNH85e9//lGds1sxLtKY13cdSFLExrx+uVoHmT0qxtVijc+wdo6fuVK6RdQVABB6cxhS6iA6952gbjv+Co5T8qyMVtdf8R7+6vs3T3Xd2H8Gu92uv7yxamwS2Ub7XmMk33NPSL2q510fmDPIsWDareum27mJxaGjn/uKwjgGTDiSk+9On3V9VnwOQN0qeoRqku2gFxkL7zpIA8PsAnad5qLbOugGdmm6dPrMOZU2xEU1clwPeB+wySBbwqD4uFX0MMmejQY/jX2xggW3ZytCXZe9z1+4CHiA98LFOixnWrIWTdl6ZThgMv/4808ZNzDKBwh37zskeZ/J5beYAh3mVye+C6qoigW+QsMe0rl1bYElAEB+8dU3+nIMVp/KiwEQC0PhrwjNSDsmDemiRSa8dGMTpsnhY19Ky3oVVFsYSucyU6wQTOCL1+wsifERauAPI0kasUnt84tdWg21OmoUI9nvu0sXXVwQKIwI5R7Ruv753/8GfBZ0tcITuUf7epLniUdk1aYd8u77R6VdkyqODIu/e+a5ADYCuU/AeHfrP0kqlyko35w6rdZpuHSkpTUd1815YWjYSGS5KZOM7hep9kZT5q3T+yVLAaN5uXRsQ78K62ktyuJlT10A4IsufOj3ndxR2HDhNoKvrB3s8lu/+aZMUrJwXpXruD1vA3aH9GojxQrkUbBr1146zSd+YxSc2cEuv4sb/r89d0xkPUf2cDYSCBrKWOQFWKShd2VtGjtjpVowOrUtRu/OejR+UJTvsijoe3X7PnUmMAVOxQs+m2xTh8YcD+NFE3vr/Bk+abFqXGE5g1lvUvOsrMV7VvcNQPSJb79XizXS+gy70wYe5dVbxMn25aN9DDSyFrS6OL7gNeukrTYBwhrsxLenk3W2AzAjH+jbtYl+1Dh5wITD3jLsz8o6F/yBXj6HDKVB5ACVT4QCdvkusoyCLzylbLXdheHff0VozQ6YnjWqR7LpeeTYcdWFd2ldS27OklkLdtFq81li7wSmvfbJafWmDN9xPcAbvlim6kgUGTAogPJnAD957lqtzp47Nlb1qexEMdmmaIKXeOOOg2T1rEF+rXaouJ40d42c+Oa0Mpr2AhPrjVA9vWvfIZk3LlYXdqp/T585qwCiaplCaotkBWi8JJ0AG9c8a/ErUqVsQalYMr/jPXIvAGw6MFkHizXsEQxhKIVSLFojpyzRxdJfMwYW1cYdBmkF8nsffqKm+vfdc7u+1OyDgolrr7naL4NL0RrtcAHt/kbHuLG6ePIMPv70K8F7FlBPui3YYbo/wZDUrVrCFZSQ8oZ5Y9NhBqDw2+9+0LkUygBQzli4QUGQmyyGFy+ab67JsEcwP7Aq6PtO//iTAv1gwT06OQqi2jSs5DeNac5bs2IRjSXFUDlzZFPdKkWUuISgXWzbI1HdDYJh/0OJzcX4LC/tdjHnvUupQre+jB958F7VNNLC/NVFI5JlSlgLkH7AhrIZsAMD2pCj6SUj4KRJhz0v26CboOUNBewSJ+QNx78+JS8997hjIRSgtO/wmbJh/pBkGzrWH8AngB5HAzZW6C1Ny3LWjOadh0ifLk2SyX0A5DQnYK1l8wXz/9qb7yh4ZlNg7NKw4Cr58vPJ5ihrNSwo/trb3zqgRW2vLBiqQB8yguvB8g2NqV0ilZpnZS3eM/OM50qGcP64Xirp8Oe0QYz4fTSoXkplIBNnr5a4To1UzuAP7HIuNswARyvQ5lwbX9+j3fYgP9xs66zPiv+fOUXxHCCd/+XY+w99osexd97j88hFUlPb4mY5xvyicx7zy6kb5vsfHtON0w8//qTFs60bVtLfjxtzfKm1T74Ya9XFPqcHeC/2E/j/87MQLVz5mrJgEU2rOHbxgUEALJBGe+C+u2RIbCutZOXfKazoPWyGlCnyggyNaxPUXbG7ZsEkHWd+zNYvslBUbBSj+jha5tZs1UdBE7teFiKqqq0m6DC0pM0w6jYvHuvxSAvNX/Gq7Np7UBlqa4EHPo0Y4K+ZnaAFKD0Tpmqh0jNP5pAG1UrqfXYfONlXMBBsr3OuCfaGAfB1SjdyTR99/KXey8ipS6VYgWf1ZUqqjdQtxvPd2tVVTSTtbk99d0ZTmm4DEDBu5gpB4kAK3Wo/Z74DEGvfa7SmDk3l+4BRc2Xn3g/U3inb3bdr56xAtkkcj+e/ZvMuWf3KDtWc2ZtgcD35K0XI2+sn+gAeKeHyDXvI7NE9dDPAS+Xd9z/WrnjBDObhtAXr1N8UwG6X4wAIlq7bLiun908inUEeA/PIC5IN26h+7ZP4r6K9BZDaO+VxTTTaYDPBixdNrpOenPMuXvO6rJo5wOdGgiftyW9/kHGDOmqGonabeClb7AUtymKDxQYzWLu8YGJzMT4DcAC8U/jllGYFADrNQ64VoEbTErSnTaMGi/3FTfHfdddd66rfZ36ZBiQwfjh7kKUxz4f5ycbZ2rXKpL2JvVu6nH9n3tKp0F4MZo0xbGbGjNcn2QyzttVrN0BdaZxsCpn/6O4BoIBcunexDhowQzEbm3TWATJo9qJHrABZV2D9endurICoadQQndP4nSMxYa46+Y6n5llZ79uA3TmjY5ShDeS0QTxxsdm++4Cug3gf0ynPCexyLDyH3Yb93G5g1/p91rela7fptTIX0XkjL6DuAQ3yc0/n1CLAF/KEt/07jkGQGnFRDX1EC5stmGPsD3nP8OzZMAYqbg0G7CKlMzZtF2Mt8M7pHgEP8Kaz2QHAQmfJQtqxRQ1fIcb+gx9rqpbFGyDVptsI/bGaVBJVpSwoFKhg04M1iymuCHSLpLZg7PAYJAVoGGYYASpZB3RvrkAV27Tl0/r7GA+YBdgR0w0LQEsrR9hGfyw1BVdjpy9XXZSxxYEtQK8Fy0SRBkCkS5taAhBGs4xWL8+Tj6rxOUUVsJMU0jkVPDjdL8cZO2O56p7Rk1oLSwDu/5H/CIUgpDlhPmgCAutlKt97dmggyEVwRQi2tzsvdV56jz/6gL5cTBEboAvLIVwOjGyCRZIOQdw/+l/SqzBzFMEE24SEY5C2R6+HlY5J2fPSLlS1g6yZNcjH5hNjYsCzNd3brr/+Wi0ayvNkDkdmyymumPKzSUDiwLXDlBi/4BF92yVxA2GuqGXb2J66IWLexQ2dLpsWDvcx02x02MzgWOI2qBCnqr96+cLqR2qGOa/VyQF5Sq3W8bJyRn895/L1byhQJxbaSWrKUmU18aa91AdsbbPOQ5RtDXaOWu/ZCRiEEhMcCRq2HyRbl470AWDALlZedEAkHcxctqe9kVSQXua3Z2UQcUHge27dA42EgKzX3vcOa7qddQewy++WTBK/g2CHE/DrMWiKgheKtPwNrB8Bz8gKTPU/cxQ5l5M9Y2qfFb8l7MWsYNfNaYP3Brp2uy8z9+N0z/wmsKBjbXAaAH022ObcwYBdjgPIbNFlqHRqVctRX801qte3zV6RDRkbiXAVAbNmNeqYoAQHBYesx8w/1mt/hePBgF2z0WK9uRD1CsHObe9z5yPgAd50OhNIx+MxiKUSrB1V0xiZw8AhXyAdM2zCQtmyJFG7yaAFBXAAWDe89rbky/u4msjDyNq1tk6yA0DP/GWvyv4PP5ahsW30pURVMoVqvKQoyAC4oYszA5CKhyVggR102+6JqoELli3jZYAG1VgnmevipYle2LTPZCGq1bqvsnaGOcYTOGHMfAX3WJAFq8dE97x8/XZp36y6Sg44Z76K5xsrjIyPVI1xnbb9tDBh+MTFapbPy850q4PpxXIslEGL0HkrNkutikW1KxbPh0Ihq+cyQJBNzezRMb5DF6zcXobFtQlKa229HhgLXloUNJrCHfR/WCvVqFBYrr3mGpm+cL2vox+bGYqbOrWupelGWFI2TLA/wQ4qlZHJUDnNQg9gx9/VDEBskeodpVdUoyTsLT6yVJej98MRpFmnwWq2z2aNTQr2UU4yFtiqucs3KyCKbFZN/aF5aR37/ISyama07DpcJQ1UpjPXcBfo27Wpal5h5A4d+UwWTeqTIoAYbGyulM/xskcqAGCBMfMHdvl9+TPxtzOIADA2cnhCm4wIPqkVS+aTxx7JrkAKWy42kRNmr/KBXdY11sGjx46r9AuQ47QZd0vpw1iTJSKLgX2Z3frLPNvC1TrK+ISoJD7l/I5wf2FdMYO1jOwYDXJSMzgGGzxkDP6cNtjUUQD4xu73knXCcwO7dMVkc+KUpeOa2fiTeYKptYNdyBjcYyA18Da236c/0MsmBd00zSKsgw0RDT/QeqcW9NrBrjkP7wUK8LDCdBr2DYqTTII1EKb6ux/Oai2IN9JfBDzAm/6eSZIr2rx9n4IxUi0sFug8vz75ndoNRTSpqlZLMByv73xXFk7s7VvMAQ912/bTNA4LPfZcLNYUmNDGGFsp++INqwrjtm3Xe/LPP//IoBg8Ns+DO8AEfrbGkJ5r4eU2ZkAH1cgh8McTMrpdHU0D/vLb70EzzPZHwAsKZqVa2ULyeM7san3z9BM5ktjp8B0Y4phBUxRcIaMgNWlliNweLeCVtKuxMYIFBNiSwuMF+XKVDpL3mZy6UQDA8YKEdcflAHaSEaq7ApsSWBE6ZFEwQREXLwwGALVyk1jBFN0UFmHHhcMBZvroxkjn4wCBtCTYlyUgExs6YoLWlk0CHsUjJy+RFvUrSPO65dTBABCIRRNpWYZhVDZv36sbAorpsKcKNNz023yP66/duq/s2TDZlyHg3EVrRMmqmQMl2z23q7VWoZee0jbJDDZ4VJCzkXM7NmCEWLEJ4aWE1MKkJWGC8VrlJUa6nwIjw8JxfDrzwUpSUd4jsr5ra9tA9+39/X8RIBsDS4c+lir9Dw5/mozZtYJdY4FljaEV7JL2xqIKZwWsr5hHaNwb1yyt2lU2irSJpQkHQI0MAZtymF0yHi26DFO2EscO/GRJnzu15bUWOJlr4TdP4wnkXjTkwCqN9sROGReyMyPjI3y1AhAUbNJhENnkUtDEmojHOBZ7ZFFg4oPVsPubY25OGwaMsq44Mf72eybugcCu9TrsYBeShsJYNjvIpNBFt6ifvHueAb1ICEwBK4RJrVZ9ZOuyUY56Ws4FY+4P9LJGvLbjHZVZ5Xwom3pJ2zc3HIPiO56LGWzU0LHThAUZGcOfZM4J7JpYsHl3cwfx1omLHwEP8F78ZxDyFbB7RudKNTIgtWj1KBk7sKPkfTqnHosdP+Dhpsw3yv333qX6TMDd1GHR+vn3Pzrml70DRGBbZnR5HJMFHI1tiUJ5FZwA+DBchznbvvs99eqFDQZc0Q3rwMGPpUf7+lqEkBJLMYqxOC7XfvDwZ0lscvgbqWnSejA+FCihXSadi+TDxCHkwIpoCrJ6i96qNzQpQDR3FRvHaBtWFnLjrvBgtrvkzttvkaL5n1H2xJ+Mw9+1wJ5nyXyjFtiY50caHjaqdcOKqhVc++puPc/+g58oQOvfrXlAlwSORcvNzvHjpXq5wlK+xEsaM5gIbN9gf9C38gIyveb5Dv8N23L/PXcom/buwY+1Cj1YqzWnewXclqrbVV5dPML3Qhs0Zr4c/uQLjSuayFHTlqmEgwwBYCZx0hJZP++8nzHacIrknLS9brGl7TPyFVhtXmp0xeO+sRti80LRIHMW7TJgCAmNN1IfATbjkT1Hq/7dLmMwYJfnfer0GV1HNs4b6ltrYHEx90eewIYQ0AmTnz/vEzKiT4SCWLrJxbSvr79z9OAwqWy6KRZrWLOUb8OEbOfkqdPK+CNLABC16jZc1wrmhL+B5hgtOIVsuH0wOB5rIvImM0zTAYDxghVbdMP/w5lzMmLyYinwfG6VBbAeA7wBRRTWsant1HucStaYi6kdTk4bwcoMzLkBzdQqLJjQKwmzy3Ni40hTDfvAZePsuZ9VVsRGk3oPWHsjI+E9AilC1srarZHjABpvyZLZJ/9gLcC+EBDMhpuufUi6YNZNpskf6IVkoXDzzz//ktJFn9dNMO8wrO38rctO8heY708+/9pV5mRvQ+wUa94R/vyvU/vMve+nLAIe4E1Z3NLNtyhGKVGrs+xaO97HwrFIKUvy/2CB3So/YFJDFEVZU2yh3AgpNNLf7JBh/QBksKxVmsaqFhWpBTv1mi37KLiCWQFc4XVoTW+Hck6t5D5xShc92O7Fa7ZqerJS6QIqEbAWdRWpHqWFScG0P3a7BjYEMJsVSuT3sS84U/DCNG0qjbsCRXAY0g8YNUevxzCTodwfn4W1oiDOSE8ApRSXrJuTIDvRbfcao1pt4stLGysh2ItgG3OwWaFj054DhxUs8zyQHTB3sJzDR9RIQrRnfJt4lRgAKhjIZ+jsRlYgNYOCNY6FVIVNDIWWWuF9803aCABpChkFnkH5Bj3UAQRpC6w7RYW0ErW2tg10LcwdGD1YNHTafD+2Y0Nlb9jU0CUKJwczmK9IJJDJMN/c0teBznux/05BJBvFlHhKk5KOGzJdNdTBpI/dulYBAsj4WDW7VmYX0AoogX0kg2UdpmAKEFWgcqRmVTZv26ub7oSerdRuCnkK+n8GLPH+D45KntyP+phMNliFqraXTQuGJXH1oKMaUjBkF3YQZq7BCezyN9rrPnT/Pb6CVUAbrW6NJAcfYGRDAKyqZQrqRpyBbRjzHbeSmYs36gbP6DsBV4De1LgQ2J02QgW7XCMNFSh2Nb6z/Bvvkf6j5iirjbbf32CDyu971YwBSQDmsAmLlMUlK+WmaQXgkumhkQkuOcQx58PZlEQo9XLeJPUWbqCXluv83hlYorGWsm6yQbbq/K334AZ2qYNg3kIw0G7ant2ytiF2ijXPlHm2eeGwoLzKL/Z6cSWd3wO8l8HTpmCC3Tam53mfzqXgoWubOgoWzGBRJHUNM4iuFxDJAhTMS81fiHAtWLNpp/ZdB1jwUsBB4n9gaY+2aASQp2Zoa+NmveSO27KqfMGuS0bT+UzJFtoFxxjoUwRBqjM1Vb9o8Eh946bAIujkrsACx8t78tAurrdoN+p3+yAMVtn63ZVFYrHGkYMKdVwG6OAGa465Pho+mJTUdDLjGpgHpCDNMIwwhUdmbgBqitfqLO+/NkM/hib5/vvuSGYhFMzzhYVj45I1SyZlbAGwMNjEDyDAQEvHiwS7NBg0OjYNjm3l11rO37m5fuK4aGIfZehgs9AEojc3lehIfeJHzFI7uTM/nlNtOkVUgaq2g7nni/EZ5iSg0B/odUsBB5M+5p4CNafgM06AgLQymnIAFm4GZA8o9AL4MB9N+p3MSpl63WT/q9N0baFmAI05m+pWDSpq6tgt9Qxwz18xQrYsGeGTVtn9gt2eC/aJL+d72sfs8rkRk5bIxq1vyZIp8bo5dbO6sh6TzaMBuzQn4Hs4kDz1+EO+ece6he1b5TIF/ILeQNpY47QB6MNWMZBG2n7vSEPIcvAsyNLZwS73ixSOdcmpkxybdDawVm9jzsE69d6hYzJ80iJtbmIf/H3qvHX6e2TdRoNdq2IR182ImVNWeQNrK/UO21eMlvfR+85eraCXZkl4lENMOA3eXfzWDSNt1TRj1Zk4eamvaNLJg9oN7OKSQr0LxBA2kMh7vJE+IuAB3vTxHFJ9FRT4ACKWb3hD3n73I/XNtQ40uEePfaVVqLzo0JcBpGAJH3vkfr8WNP4urm67/tqxi108YAbrMDSTZldMa8uh4xfJa0sTU32PgHYWxk2v7/n/Ar1CPhYW4Idt2p4NkxQkDR6/UHXNw3u38xXFpeQCWOiPfHJcNbBO7gq81Gq26qssAiw37OTudw7pNeTP+6S+PNiMwAITl0CaPRhzGObyxV/Sy6UhBmCP+OJXOWT8Avny61OaYkRzi873qxOnpHyJfPo8jQ43JffKd9BgvvXuIRnTv4PvEMhHSBtTNGicEIb///lTeh7zPYpIaCU9b9x5/TKsc6XGMZoGRT7CSwgHEqQIMGcw6navzmCuwaoBjhk0VW6/NYtPj27s92CXAQq80AE9NDwZ3LNVMIdPl5/xB3oDpYADgV4D+AI1p7CmvQmSAbvTE7upRAZtK8CX9tgUDgEWYP151vy2KjbuKZ1a1pTihc63pgb0fv7VNzo/uQZqB/DtNnMC8MOGBuYekLr9rfekZ/v68vOvv6ne39ocAz03G65A1n92bau5d1qtOzkfcJ1OYNdtkgQCvcFqYzl+pz7jpHjB5/wWBDpdB9cA6EW+AIuN64Vhds39wpp3bUvW5aVkRAl/o7EFDLy9sQwZMTJLVuAJ0IX9RbqADWNt2NzCeYNmRCEesDQDmEKGsE7u2ThJ5VBsbGDp2ehSYxJMAZlTAR9z+6UKbVWWY3zciRNSC5pg7Nhz0CfpIKb2Y7Axa9R+UIoKj9PlgnIZXJQHeC+Dh2i9BRoj3HD9dUmKFIx+kRfJw9nvVf3r+Fkr9UVDwwN0bpioO3ViChQeAyQAajCwFJSYjjgGIALGKJAK1wDcAvwefuBen+6SFC4vODpG0Wcd8E9aNthucMFcm5O7Al2beCFumDdUG3Kg7wLkwuYAzsYM6Kgv2qa1y2rBWqgjuv9EvQejGySmAEBeDth6YR3Xs2MD+eHMT4KtFAUyoVgx2a+HjRNdlVZM76/aa/xK2UigTQTU9xs5R5tVWJkcWCvAdqDOa073DquEbAOTfgbyEeYv2kfTeQ/mHIkFBT+wYWgyqSA3RYehxpTjcB8dmleTiqUKKHOFrv2JnA/K1p3vSsfm1fUZJk5ZqgVR5iVHitqfN2mo13EhPu8GeoNJAbuB3lCbU5j7hNnHK3xGYrckbD3xTRi3QFrWK68MvNXDlPWsfexoadu4stSoUETnGJIH5gaewczPZnXK+jx+ATlVmvWS4XFtFUTDOlLU+/GnxyUxPlKbY7AJ5/mz3nEcGGWAmtOzdQO79959u3x/+qzcdmsWnat2C0hqAbhX/IhZCwINN9AbqjY20HkC/R1wTQHX5KGdVcZgfdZVShcQOn3iJoO8yZ7qp1C6Y9wY/R31i26q6xYb2PINusumhcOSSRoApkipjEY60LX5+zvFcs88+YivOQrH/vz4Se0+SHMJngcZzya1yiYjHUyjEaR+1oIzvoNjD93pmJdWv2jmsHWeurl8tOg6TAtvw/n+S02crvTveoD3CpgB6BexSwE0GWumPp2b+FgTFgQWfmt70VDDot+ftlxdDYz20bRBpnWl8aYM9bj+Pm8KRvgMRSO82PAvpoKbVFJKi8jczgnYtLor8DJCPtKldW1lVGC7eYliY8a5YWRpLnHPnbdpOi8Qu+t0XuJKwQsSAgrpaPAA2HPqZAag6D9ytrRtXEXBapF8zyQpPAw29qSbV2x4Q2Cw0Hyjv8YaDK1knTZ42g7wsWKkoKs07eUrBgv2HE6fs8tHKITkJUMjFf4XJhhdKIB4576DWnxEp6iUDPTsvBTRgeIIQoEebhCkhGGe9hz4SDXiSAJmLtqoulGKCukOF45Co5Rcc0q/Ywe9oaSA7aDXLZUfqDkF196002D1dzad9/g3t6YT1nvFRVPNHiAAACAASURBVGXA6LmSO9dDyspbr4HfOZIqtLFIndDvU5DYpe8EaVyrtBZTUXcwtFcblXJhqdUhbowWxMHc0Tq597CZuj62aVQpWYhJewOS+c05tadl4019BP679hFMq2Hrd5xAbyBtLPdkHSnxrOU60c0iJ2CNQkqCO4bbs67dOl71yU6Ff8T76KfHfbpsu881ABjXHWQLxqUmpfPa+j3WSXTIrI94nps6Drzj+e3i7oDXfIYMGSShZ0vfVw1QxfoTdyDmECwxWTRANJt8rED9zVM3T2WICdYw5H7+upmG4/69YwQXAQ/wBhenS/ZTdv0i1kzYW6EpMwPAi2VOONO3pEzRolJsRXFbWg7YZUzXYQtJb6bGpSGU60R7uvudD2XB+F6qzSN1h2bQaF8BFsRgQkJUwKIPf+cF2K/atFNtfmALkE44dTIzTAbpXwAdL/45o3umCKABMtDDAeCNOwNuErdmzayFX2YAHm675WYF+RRzIN1gHqVkg2OVj5jOe8aTl2p8/D2XTonXlzIFTKXrdlVNZUqaLFjjzcZs2bpt2p7V6BNJmT70wN26ccErGNszgMHWHfvVJxT3jEtpUMmPPplYBZMCpvjK+GADegFBbLjcmlPQhpW/0TIaWQ2SAjtjiuPCwSOfanc9fiPBgF17jN1AGHIq6hdMdzfmL9fDIOtEZouB1R2dFLEhNFpP2hsPnbAomQzMem638yKLaNppiLy1boLv45yXot2UZJeIycCx86VnZD39DfnTxgLMAJjXXnu1L9aheNZiWYgrRr2qJQQmEs9vU8gHMUJzHHvXPdrX8++k+Eu+nFeBr1sdCLKFYjU7yZShXeVf+VcLXwGVfA/G0zwTEzgaZATbSIj5SLEvGxIKU+n+Sbz4byQqvHOID93yaCtu/HUpVo1uV1cKvZhb5WfUnPTs0FB/FzDy/O5px/3Wux9JlTIFlCT666+/NWtIYyLcQ4KxvmQz3WPgZAXa3BPvAjyYiW+wjYQupfXlUrlWD/BeKk8qFddpZAfsWpEd4NfrKwz5/0r9mSO7q88lu++Fq7aqD2+VsgUdU0DBXApMCnZCVrurYL4X6meQN9B1DQnD4NjWQaUPQz2H2+d5WVA0A+PHQvv+h58m8fik5em5X35VvS2gfNGq19SIHgBJP3uaXKRkOHUy40XEYm5kKxyXKmUWb7eijVDPjU4utmMD9TRlAKij1NprqBaccL+rNu1QJu7B++9SP1SreT3sE4V3sEeBhrXznpE2ILsxTUr4N1w5sBWzFt0FOq7T3/l9dBswSYghvtakZGGKyFTwEmTzZpxN0Cr+8utvYWWnUnLNqf2OWwqYdssAlWdLtVQQF8zLHe0tsp3IptXUPgw7L8AEm0/rICuB7IgGDjT+CBVEcCy7JVSocShVp6vKF5hHgBJAL78RMiLWjZz9uIDYUVOXypbFib6iWD5D84vvT/+otpAMNqcxCVN1Hn325TeqZw2G3WM+890bbrhOLfiY66T73bSx6EP7Dp+p8gJS68hzSN8zAumvzb1RIFupcU9di2DD7RkxbCF5TubfTdMGimnLFH1RvZE5/6KJvX0ty61xI0tE8x7WR76Lxy2ssNtGIJhCS45PAR8WaGwOerSvp79bgPTiyX19sio2Nvxm0WhTsEqHTSwrAfnGx5yYR/ebpPItY8HJ/fCexCeZtSslmzIr2GXzN2LyEt18saawcWrXuLLvWYU6f73Ppy4CHuBNXfwuqW/zY2YxtNpnoRGlrS5pYxYcOm7RiQoAg/CfhaBF3fIpYgkvRHCwf1GD+Xrlwy5hCOX6cS4YPH6Baj7ZwaP/YtGlhS3OEvh//vHHf6VOlWJq1aYtk8f3ShETCpiwdzKjeA3gh1MHAyBevmEPad+8mq8ALpT7cfosbiAwHyzYFIwAcNElw3hyv3g/s5mCZVu48jU1scd31zBAdJeDhXdK/7oBUdjcXkOmK5NlbRiAfzByCjSSPP/xM1cpgGHjQ1MN0tChDtggmoPgcc3vAfYOPSNuDqS8L6fhlgLmHgFTzF0cTwINMkg4KQDwyHZQHY9MAGcN7Lrc6gLQiVPFHixjZq7DagkV6Nqc/o4TB0ygcZFhzrC5wh4NRhD7MGzpnLIGSFvwpEYecc01GXR9ZL2k9THzw+7fCrjpMXCKessGAr2Ay8Hj5utv4/Cx49qlzEjD7NrYcz//JnXaxms3ucimVXVD1qbHSAW9JpsWDOh1s19ziptbhzI22TDosP/2QY0BxZ+1KxdVB4pgbP6CAb2w3hQ7Zsx4g0roYFCp4ch04w1K2jCQKd1+y81a4wHbX6NVX3lz5RgfMOd3TSMeilSdrp1j2MEu2R8ya8T21ptvUumEfX5DbGDLSXEf18X9kC1hA4PVGr87LPkgQVJSM5OSOe99538R8ADvFTwbAMAtuw6TdXMHK0tQrEaUTBvRzae/gpGBEalcuqDP8/IKDpffW4clRM+HnpDOdrwgqpQppPovFn0qe0nHm5QrumqYEnRzqR2kAmEore4Yi1Zv1Yp3wBqFPvw3L+x//v1X9XMp2SCQ0seuCG0ywJX5gXMDqWsaVVANbS2Yy1ehnUwY3EkLzkzzjtmjewbdKY64cE4KjChoMpo/8wJbNjVeWRPYyj+xd2pbR2UVAAe1N6pUJEVpZfM8YIbQMRu/19Q+p/T2fTYRJgVsXEG4RpwV8G0GBOJNfOr7M65NRyjaxP6JzxrGlCJDngnZAJ6902AOASqDYZDDGTeyIw3aD1Sf5Q4tqmsTFEDK1h3vKFsLaKIOIP/zT8qgHi11XvVMgL2uKtmz3S2xQ6bJ6zv366aI+TgopqUCGbeipWBBL+sFNQDIC5zkMlZtLE092FQjFzNj1Ss7ZPvuA0k81v2B3lDALoC6avM4BdPWDmX8DmmQM3tMTKq8z+3P1x/oNWCXOQbgBfgCJr86eUrqtRsgK2f01+I4WGBALa2niRUbndeXj9L1wNQK8LlyxV70FcxCJNB23dRaWDdlgHU8l3/+9XfdwHx3+oxmK3CBsANX4yPN8QpWjpQpw7omkbRxD8jPYJaN/3k457h3LPcIeID3Cp4dFHkBKCjWQGDPfwMizDDV7HjQpjT9fqWFlxcTFf/4b8LuAnArNYmVVvUrJLEKwr6NAiyKbmCY0Iga65tQY0YlO5pWU2HMYo/n8sDuLbRQB1BDSm1IbGtd/BPGztdFOiWNCcy14VhxS9bMvoYgMK7IC0zlMtXzJWp3ls2LhmsFO/pf0sbWosZQ79N8vmXX4aqFg82G2YFFY9MGeGHAUJLynDY8Wiv1UzooGIKZutznPnMHcHTi2+/lxDen5dCRz5Q9ZyNDip3nh0sH4BWwQAcrXDkYbLZIW7PxYRg/Yxw0qOT/V11F3kniCZ7S58E1siZZO52l5Fj8PgBKgEyA0zsfHJV2PUYqkKH4FEkHYAeXAhxEGOMTOvk2q0Z+YDZgTmCX1Hnxgs8qmxwI9Lqxp273hr8wsbWCJdYQNiew6tZBzNDOkt43mRY72OWZzli4Ub2nYZZptmB3XLHra03ThurlXvYBRus9p+S5WL/jBHqtYNcwuXyHorScD9+vMgTWH5hZOp2x1k2au0aOfX5CnYNYCw3YheGHcGgVPULXYGwnySQBiE3HReumjDWTtuzEhe8hzyCrt+qVN31yFvs9k/1AdvXOpim+2Ds1u0htrLzvBx8BD/AGH6vL+pMUfZCyBqSRukFPBlBr16RyWFjIyzp4DjeHXtWwuYWqtFfmHCaIQevVkrW7aDqeLlMFq0QqOEsp4LWfntbOLPJ4LrPolqzTVSvSTUcrXgaknE2hDQxXSizFOC/zpEKjGMl27x16D0bv1zNhqt4n9mW8OMgkAFLRx6HzhBlLSctpwAbeqxRdYovEnAWYdYuo6wsD9//1ye9cX0RX2lwMdL8AvDHTlitjRrtsAOp9d9+mrW9NGpqizNWbdqgGEsBZpUxBPSzSGaybAHcwkzx/1hLTZQ2dLp6u+IJb/ZND7TBmNfmnKQT6UbIUwQwkLwAhvMhx9jBg3XyXFtQ1yhdWaY4ZzFM2jbQstoJd+/mcwK6xuaKtLawoMXEDvU5gFykNm5A8uR9JZv3F+fFQx6bNdGejXqJdz1Eye1QPTekbAGg8uSlIA5hiWUihLbaUpmUy+uveQ2dIywYVVFuNRAy5xrC4pPpr6327dSjDx9d6z+Y7wTbdcYotBAIZFjbYONCwQbGCXXv8jQzhr7//0vXVOnCZaRA5QOUsRsYACwtbv+XNd+XZpx5ReZ+T3WHputHSp0tjyfPkoxIRM1JB7+23ZZUFK7foumcd/CbIgKETZ3OOLDC+a1O1rSQThhQlNdaRwcx57zPOEfAArzczNAKkYWA5YAmoMAYwUQWLJjXc9l5XWshJXxFfLLTo9Y7XLC8VzPPRkeEz+vqyUcq2A9Yo6rK2+Aw1Xrx4SOVRBQ0rsnTttiRtgdEPYxFFkw4WfPrdU02cEk0Z7URhOijE+/TLE6oX3vf+Ea12RsIBy4KPL2b1VGYDPugEhezDmh4N9R7N50krfvfDjz6HEdjdWq36aLrQWjCX0uNfid8jZV6ycN4kHaIAsXQcRBttCrRMbNhU8R3cAqJa1tQXvVX/yJxgDgJUTKOGQM0WrHF362gVqJMcxwCcte6WKNNHRMvmN/bJs08+kgQwmQ6N25aP8vnEslkF1DD8gV02AbT5ZvNlNL8GgLWoX14lBr//8V8Z07+9HhvQGxk7WmYldpdMmW5UCzz0nEYqAPPcNX6COqzkzHG/ak9p8ALotg5YSjYSgLYffvxJ1r66W+KiGmoTIQO2sdNCY8ommy6GNKTIlPFGLUaeOKSzet8CqrFVHNa7rQ88E4+iNTrJ4sl9fLp1a6qfTSyFz1bQ5u+euW68wssWfzGo9smc/8zZn30dDikMZqNMrJAr5c71oC8UbmDXzU2hXcxI3XRZwaZ1ns4ZHeNaU4HcBL9nHCbM/KAxTf/o5j57T3NhPLeGHQapFSV69jHTV6i9I17ptEv2wO7FW1U9wHvxYp9uzox/brVyheTeu26XHXve19QNBUaAXetuOt1c8CV2IbwwaK/8xtvvqcUN+kFSj5ky3qAvKFgeWDMKLeiSZ7W9snYIS8lto7HEzsvKduBqQVoaP8oJs1drK1/YZSQBVFHDBAUzYG5K1YnWQiXS3UgAKPy649asUr96CU2F44M5feF6X+aA41LEQZEODSTo7MTnTeV0MOe1fgZtMKABAA1zvHHrHr0Wk5YM9Xje50XlIBSuGkcMkwaG8YXhzffc4740tokXGzoKKSnUIXVud2AgE0BDCCrlzfwCbHSJnyhVyxV0BUMG7GbKeL0UeD63bpqMdVYwBU5cH/IE/F9Zz5wGWk9Y365taqtmNxiwa44DQYATAMOJ7SVNDsgko8HoNXS6nDv3qwKnxClLpFTh53Xjx2YX9o/s2si+EaptRqoEoEYWREGddbCxW7XxTSUjAJ84IZjzs3lF04p0oXm98movR2aEJkNPP0Ha/7w7DCz567sOaEc1M2AnX67WQWaPivEVKttT/TDKRioUzD0Hu7kx4BMZiLVA1emZBQN2uWcyFMYVgg6LNAFBnsNwcmBg80bmyG6rSAOTEZMWy9Th0XLf3bcr6H31jb2u2U9kZGzyWOd/++0P6Tl4qn7WA7sXd4X1AO/FjX+6ODsep6TB6DDFwj9k/EJ56IF71FvVG+GLAAUzAAOrDyNMa80KRWX5hu3y/NO51O0A0AlwwCJu07a9QhvWlLLspASrNI2VxrXKqE6NdCZ2Qcun9dN0dIVGPWT8oE6SM0c2efOt99Vm6L9//SWNapQOypkD/1W3TRGG7KSF46ObJXFNoGDv0YeyaaoS9puXe6h6YtOdi0I1AAXAGZ3hrr0HBc05mwlvpCwCMGG9OzfWDQvzAQmJSQPD0C9dt12buzgNH4j44UcFB9aiNIp+8Ii22mfFJkyTxx59QN0+TIreHNfK7JYp9oIWhLI2oV+lWNGATH9MbzDFWYCchLEL5LMvT8jf//wrt2W9yS+zGwwAM59BKww7aZr6APzHzlipcUUvbLpSwqDjekKRqVXqgwMG4M/InZjnt2XNkkyW4QQ8ybLwW9uzYaLj+sFmmPXF2jURyQMbF66DzTnyFrdUv1uhnv2eDbikS2LlMgUcNzdm3hw6+plkznij5H0mlxYKOnWpowAXT2fDrNuBK0V2uGnQQIfMEq4yDDbobbolqo85rLp9U2a8lnGdMHPU+qw5L9IfvIe5NuPZ7fYro5CQGDGQ37i5QaTsV+p9KyUR8ABvSqJ2GX4H4MKPExkDHbo6ta6VYl3nZRieNLklWIJ8FdupbhJAii6yRO0usmxKvLy9/0MZNGa+tmG1G7SHejEUkCGVeP/DT+SxR7Mrk4U5O6nGqzJclazhCHo1GCnD8IV6PvN5Coxwj+gV1cin+UT+EJMwRV+oACrS5Lx8rF2bgtEUAxwo/Dv2xUnp3KqmFldh9N49op4WAHoj5RFA00sGAA/p8g16qJsBzh7WYdeJGlADiKClNqnjcYPOe9My2IxE9R4ra+cMlrvvuEWL5JC2YAuFHtIOhpxkDBwHMA6DT6GRGW5Mrx3sAjxpnYv8AJbOPsh0vXfok5DBLschHgVfeCqJnRnznzk6e3RMQH0+RaVod61FZzQqoMnD9hVjVAfKBhXm8OqrMyTZcNgBoLmvOUs3qTsLG0Az6KiGty6sJ+sPcqbKpQuoXzDyJ5rboO9lQ2EAoVuqP9R7dmN67YCVbmjorWkNPHNkj2TPiefIxos55sTS4g/O5grSgCySlSyAcPjn73+0iNYqfTBgF7vF02fO6foYF9XIJ60wF4G2m4JOo49O+a/M++bFiIAHeC9G1L1zehEQ0c47pDEHx7bydeOp06afOhmQAsPOxlroE86gUVRBIdn6uUOSLOpIKPKUbKFpVFO8wSKP3AFv5lAHrDb3eNcdWSVL5kzy2o53ZGhcWx/ji/F9z44NVOYBU0ejh5/O/arFKcG0YqboBiYc/SOsNEyhN8ITAfyiccB4bWlikgManSgMPUyYYSS7D5gsX3z9rXrrspEhW8TzIAUOmIyPbqqtWp3ArGHse0TUVVlB6XrREhNZP4mzCWl82tpOHto5WedCGkjccOP10uT/mWcr2GVDmTh5qcxb8araZ33x1TfStHZZoZ2sdQD0kRa4dQ4LJar2Tlv83pAr4WxSvni+ZM4fHx79XOULtKHld0ZDHbqAIX2gnTIxGzx2gTaWsafbrQDQXCPn53mYWOEfS13G5u17lRk1en02w0grANv8G8wlG1E7+wnYDuSja79np3jZQa9bYweeA9fmVEBmjuv0XWQMrDdsavAvZkNl796mRZrTl0ubhpU0A+HUMhrATUwo9g3HmDx3jTz6cLagdMzhOJ93DOcIeIDXmxleBC5iBIxnI5dAWhMmlgV53MCOKSoiC/ZWWNBvypQxmecnWkdkCPs3T1VmBM0m/qSAG9NqNthzmM+hYaYl77mff9FWpVYT/rxlWsnqWYMU7MIA5srxgPSLbupJEkINchp8HhYdBwbsnNo1qaJuGCaNjbE+aXk6XNGkg8IqAALMKSCCjc7QCQtl73tHNIMBwET36cbc2i/fqo3lb8YZoHalYo4+tTCk+947LH26NBEkWms37/I5EVCPQEMR2D6YS66tRqs+6igAADYDxvM//5FUA1478MNJZPP2ffr7wdN4Dy2/x/ZM5hENY4p3NtcIQK5RoYjqe/cc+MjHhiODCDScgCfFnRy/e0RdbfvsNpxApPk35oE1E2M9RjBg1wpUN2x9W5llCvRYi5BVWOUvrIVcM2A+2z23S6+ohsk2OXbgasAubjQUR7JBoiGNPz2wW8topB7IrTbMH+KzO+T6kYQF2z2P3web99HTlmkB4l133CbdImpL8YLPucYf9pjz4gXdtE65FDXQCTQ/ruS/e4D3Sn763r2nqwiQrpw8Z40yMLgepPVwKojDQgyWddWMAQpYKNYY3rtdquUNTvdC1XWR6h2ld6fGWhBC6jyloDqtY3WlHp+qfIoe0ZpOW7BeAZnVlQCGHYY333NPBASKTmAXoLRx61s6B9yaUBiwi3UYwJtCxfGzVinA5nfCZuzmLJklbuh0bYwCU0knK9LSMP8vV+2gBWvW3xQ+2Q9nv8fnhgLYRYKw/rXd6lgSiOWl5e+Sta8nkVaYOcKmgHPBLGLzNWPhBrV8G9i9ubLesK2ffP61WlXZB/d6+JPjkitHNnUZcYoZzDud3YwPsPUYNA3pEj9e78Ewm0gb0LMiLRo5dakj68kx/IFdQDdWcxVK5pfalYomY3ut95za3wqe8DDMSLwGdG+uTjad+4xXa0e3jnVce72IAdomGllIsDUPbJQAxrhcmO8AsrEvo84AC0c6WOLRfMdt5502gu2eZzIh2PU1r1teuvWfKCdPnZH2zau6Mr2w8pAguPT0HTHLtYtdamN8pX7fA7xX6pP37jvdRQAAeur0GU0pXqxBIQsd2eg4hG5wSK/WqepW5u8+SDnWaROvLzFe0BcC5F+suF7q53XTiXJfpN8BCN3a1ZWKpfI73qobswuzP27mStnx9vsyd2xsMtkMem5cIyqVyq9gFxlQ46gEBXMUAWENBptLESbuAwAfazERml2swF5dNNx3XYDbSk16auMSUygHcAfMd25dUwFpINALi0yBJAWl/gYev60bVJInc2WXyNgxCnopCh05Zaner7/hFDP+LSJmlLYop8jYSd5w/OtT8tJzj+uhAXTIO7hOfl/UaHzy2VdSukhynbudMbUD4B9/+lkb6gC27Q0uwjW/AXvFanTSIlY2L6bJA4CdLpGmAM1+PqzXsHtEfkMmgvH58W9k4Oh58t6Hn2jGqE2jysm06Pbj2H2RWZNhoJl3+JozggG9bMaadxkqxQo8K++8f0RbRme5KZO88dYBWbJ2uzSqWSoJ6CX2OHEMn7RYN3Rs2JCS0UJ6/dzBugbzPOjYyeYzWEAfrudyuRzHA7yXy5P07sOLQBgiQBpx1pKNah9FYVBaLawUNmFJlSP7PcqeeK4KYXh4aXgIJ50opzOSHFgyNKiky+0FbnwOH1hSuaTkSe+OmLxErxapAyliQBmsJ0DTPmA9jacyHrAFXsithZdm4GNdrOCzjlXwyDJovEILWFpfA7Cx5Tv7088KOHH4SBi3QFtXs8GjQYW/lrycEz0rGmOKmnA+8TcA67EdGyoA5T4AvQCbssVekGZ1yrl+FYcTu47ZAOAmtUrL8ZPfyb4Dh1VOQkc4p0G2hiK/GYndk9j+qR1cvwna+hxfZafhpq3Fw7t+5ACf5Ml8F3DGcGNgg52aMKoUSu5/dZpKu0yTh137DmkM3TJAODBUadpLrRbz533SBxZvvfkm3QzB9LfvNUaL/dyKWt063rEZwrqR1u1m+AO9Bux2aF5dwSlylttvzSJPPfawFh0im3n/w099jhW4hFBEN3dsT7WPYzOW2CdC73f20k1Sq2JRuTrDVT5dNYXMpqNlsHH1Pnc+Ah7g9WaCFwEvAtoxbfikJeotSZelvE/nTLOo4MFL9TovhHpVi6fZebwDp10EAK0RPUcrGwWAwEf619//0KYEFDyaNs9OV4ALCHrQ3Lkekinz12mTFEAKRVpvrhrretE0IajXrr+8sWpsEgcZgAySCre5BFCM7jdRi4aw/aMQdFR8pEox7MVZ5uT+QC8yH1r5wryZDSEA1WnTRlobe7AJgzvpNQN6p8xbp3IGCtXe3POBZMl8o1QrV9jXmdF0abTqmJ3YXrIxNDXYsniEY8zYRHx54lQyFxY+DBiOHTxNPb/rVyuR7Pswqtt2H9ACRKvUBIaXFtQwltYRDOtpBYtIt5gzdmsvgHbhah1l1ugYLTwjFu1iEuX702dl8eS+ynLC5j6eM7u6fVgH0geyU4NjW2sDDyzNuHYabCT0bCUHDn2s/vJOzg8cB+nHiW9PJ2mIw/PCpzmiSRVtJxzonu1g1zqfrEWHv/76u7TukSjThnWVDFdnkHL1u2tjokIvPqU+5WQtsN9juG0+0u7Xffke2QO8l++z9e7Mi0DQEYDZPXLsS31ZOHlfBn2gID5ImvDkqdO+Tk5BfMX7SDqLAN68D9x3l0Q0rSIrN7wpy9dvl/7dm0uLLkNlxfQBrkwfAIZCxTdWjtGGDfhER/efqEVa2NM56VrNrVNQWb1FnGxfPtoHlHbuPajM8trZg1TT6qZvpVANkHfbrVmU6XUCEYA20uA4hjDcQC/e2TSMgG2E2Z6zZJOs27JL2emXX0rK+MIGs7kDrKM1zv/8k5pyx3IQGzBS9rCTnHfB+Dg5e+5ntdQa1b+9r6DOTQ6CJy+gdefqcY6ZGI7ZqMMg9VSm9TNAm2IwNrOtGlRUay+6IE4e2jWJnRr3DrtKjKwgHhkGzWXmj+vl6J4QDOg1RWLo97u0qa2Fa/amGviEIxkhrY8emzlDXCiyrdQ4RucdGQc6n9G5zGmUqNVZhvRqo7UHbE4AvTS3YZ45ZRGcjuHUQtmuOed+eAYTEzqp5ALf5DaNKvn8lc08MhZ8ZDisc8+wtYD1qN7jpHOrWrL/4FGV6sBMm8/yrCEIaBBF1z5vpCwCHuBNWdy8b3kR8CLgReCKjQDWTzC7pnEC/sod4sYogAsEKPB/Rg+K1zNgp2X0cG2mMDI+QoEsllRuUhq+i4yiQfVSqo3EjgxmDD2v0bfGdmygbXbdhhvYbRo1WMHEuEFRPoYadhZvVpOqR8vZsP1AZQwpWgNAVS1TSOpWLa4OFXRHA1DbB/63ANAOzatpIRvML5ZXpmsczCNaaLraWdv2chwK0QB8WLqZARhr2H6QtG1cOQm4sp+X6+W4P//6mzZN6B5ZT901du07qM4ICWPnK6toniPfd2omY8AunrxOxXLmvP5Ar9URAdkL+mJ8jxdN6pOk2QbH/Jfb8gAAIABJREFUIl4UzdarUtzX1Y+sAt363t00VbMJNVr20aI2e+tlvo+UA69c00AC0EvcF03qrQw/cwWHCKufszV2TmCXvztpzq2+4QBrq5WafbPij61l8zR13jr5488/JbJZNcl29+2+DARNoLbtfk8tGMcO6OB1QE3hyusB3hQGzvuaFwEvAl4ErtQIwEBhI4cG9+V8TyvLZUDrb3/8qc4OsHiFX3o6WdtoACsFYnwGEJTniUcU7OK/CwDj3/F8RbsY1apmEvkCgIF22Nt3H9COhc3qllNG1gCLUoXzKpC5+85b1feXAlD0pZkz3eArvqTVMKlrk643QIyGFrdkvUnTyW5AklQ/RXak2wG5FUrk90kRAEkw32iS4zo1dmzcQ3ajaI0otc2yssFHP/1K5SB05ArUftbuWhHMHCSD88tvv/u6Z8L0xo+YJWfP/SrLpsarowWDY9drN0BWzujvYxJhonHFCAR2/YFeN/sv5ALWjnPWe0EmwsYHNpf5gF1b9Ra91b0BKQbPiQ0CVnT2QTzJNqCfZhPGYMORPdtdvo0RDTjYADgVCaO1PfPjOX0WoWrOzbUEA3bR7PI562aG77sBY7TEh45+LhMS/tcOOpjn733mfAQ8wOvNBC8CXgS8CHgRCDkC6HcXrHxN/V1xOwC0wlK1ih6uVk60w6VzV4v65R2LjZat264+vnwPVrdRxwRlfGGzMmfKKANGz5G7br9V3RT8DTuwQEYAcM527x1apNRn+EzJeMP10i2irh4GaQOA1anpAAAL0Fe5aS9ZM2ug3od1kOpHp4nXqxl4p35z6gf9t7//+Udtq26+KZP07ZociAH2nynRQjYtHOaT9LixiU73nBKwy3Fwq4DBjo1qKOWLv6QOCPhrjx3YwSfhMN3z8jyZI0lRFPeMJMRfEwj7tRqmFzcHwCrnfuyR7DKiT9sk7D0Alla+/tru8vyQv5DSp2iO7AL6aaMtvuH6a1WCYZdGIBOI7jdJwTysKNkDM1dwe0DSsXDVVmnZoIJrq2zuK1jNOXUQxjXDXnRoB7DMURwZyBCw0WIDZB32TZn5G3p1CvGc5lbIP+Ar8Ase4L0CH7p3y14EvAh4EQhHBAC9FJ71bF9fjIUYjJ1hKWGwaF9Le12TvrcCA9PBi4Kh5RvekMWT+vg8cAENpep2leVT+ylj6zTc9K3G4o/iqOh2dbRVsr1Ayo11hJkuVrOTLJncN5m21X4NePfSFhnJAw1WhsS21uI4Cq9WzxqYhD00903hlzYY6NZMgT4Azi5jcHs2SBE++Ogzx+YbgZ4nBXvoeD84/KkCWCvYNQ1FrB7LgY4X6O90Svvlt1+lXY9RqsWFYUW+YIApTD163dUzB6qkgSY3aI3tVms4N9SPGCATB3fSTRRMuGnFzjXA9MK600jEbm3I/EIjTTbAaa5g00aTCTe7s2A052xCmOeA6xXT+6vbB8MUHTqxtTgzVGgUo3OdzY/d99m6KTNxRpax8fU92m0PmzIAO+x3WnXjDPR8L8W/e4D3Unxq3jV7EfAi4EUgnUWAgqYp89Zq0xKrBnfYhEWa5n/ogXtk2679QuGPvWUrtkxPP/FwMqZt07Y9WiDmpul10rcSFjcwaw0ZYIGCOwrvzPEBOK27Ddd0PkVTgQauEZVKF1ANLFKKbgMma2EREgDcEwBaDAAlBXW0CweMo/8F7B355Lg0qV0moIwh0HUE+3dAd83WfSWmfX0fs2sHu/bivWCP7fQ5LONuvy2rNnbolzhbDh87fr699DuH5N2DH6vbA2CYa0AusnBib8dNBkwozHnWmzML9mEA5ztvy6qnpAU5cwqJBt30nPy8DTNMq+FgutVZ7yWQ5hxZBmwyx3Ziqu1srbUjHECfjQAMtB3oW6/BSUONbh72G124W/Feap7d5fhdD/Bejk/VuycvAl4EvAhc4Aig9cSyi2Io6yDdDBtVsVFP+fvvvx07CcL2fX3yu2QNDSgCmr5wveDbTOer1g0rBXQRsYNdmMbhkxbJwO4t/IIKwC6+r1dfnUFbe/sDIOb+ADNoQI1cAtcIJB34BDetU9YHdu0d6viDVSd6IR+VYdUNELdem4mdvXgvpdd37udf1emBDQVs9qpXdqitGFpaCguRKhjAjVXd7n2HpGiBPNoC2cmyDJaaTMHOvR9oEwwGcW5Vv6LQoQ3fWrrq2Qdz8N33j2p761CHm+ac60ND3KZ7om6QyhV70VdgZz2Hla2F9W3cMUHlLzD8xIVGJwBlNy/yMdOXa2tso6EGvDNwnSDDwnxr3ahSMh1wqPd5JXzeA7xXwlP27tGLgBcBLwJpHAHa7WIbhoMBjK51mPa2tNiFCTNtb81nkAOQtsZsv0G1kiphwGGAdD82Ws3rlddGC4BqKu3djPfdmF3SwehY3Zi0lIBdrh1AjiMA+laK0MbNWCmNa5X2Vf+nhVQgXI/R3j0vlOK9cF2DPT40iIjsOUo3DE85uF1wXgBovgoR6tAAcBw1dZm6flDMNmT8Atm6dGS4Li/JcayacyvYhS2nMK5V9Ah97v6akdB9jeLOwbGtkmQtcNIADMNOo0m2DjYB6JBxx0D3u2L9GyqbuPuOW7XxCEWZFI1unD8kTe77cjqoB3gvp6fp3YsXAS8CXgQuYgRoF90xbow8kfNB6RfdVLWGBuzS3hbWlNa488f3UnbPOmADAS/4mVK4hu0Umk2svmjJm/uxh7QYjda2dHSzDyyjarTsLfnyPqkpdLsMwh/oxeOXRg18Lxhm13puJAqrN+2QXkOma0tcY3VlB3NW+yq+D8im65Zdv3mhHp+1e57TRsFf8V44rtFtM0A8z8fnj2R2Zfw7sowXyrdVn1qcGxjMC2zOcGUwDUjQ/mIVF85h2HFcIGinDdg1MgY2beiT3eQ3APVnS7XUgjtTDAnA7zFwsnA8uk4e++KkZiJeyJN0w8g9cPy8ZVqrNpz7ZvM3bcF6beKCtIciS2/4j4AHeL0Z4kXAi4AXAS8CYYsAzSSOfnpc2Tdeymh4AbtGW2k6ifk7IQC0VJ0usu+VKfLtdz9oS15A74atb0vWLJm0cYLToIsfdlOADhgzGpyQ9sWGjP9dvv4NKVYwjxaXhXOQMn99535f21o7mDMMcuUyBbXZAgPN78Q5q9W3+GKBXq4jHMV7KYklrhAFX3gqiWYX2QMgjsYTv/z6mzoY0EDC3lUNGcCcZZula5tacsdtWYXGDnZmHd/dzQuHhbyBCeZeYPUpFrNayOFfDOg+/eNP6gHMpowmI9aBzvgbOr/FtFSWlgwGMg1aueNWQVaDYy+dGi9ZMp8vfjODjUCR6h3Vbg9XFAYbRGKBNpwmGxTInTn7s9xxm9ecwuk5eoA3mNntfcaLgBcBLwJeBEKKAGxY/koRWvxllzAEOhBsbYHKkZqepvMfbGNkz9Hq7UuVur/mBzCXVZr2kmuuyaAMH40jSP/yf/z/NIZwc30IdF3B/N0N7PLd8QmdkqSs/bUwNudCNjFn2SZtRfzwA/dKuyZVAuqYg7lO85lwFO+Fcj5/n4WpxcoOkAvY5b5xYVg6JV6L06wDgEmsKVhzYtbRuJLub9Wggl/bs5Rce8ygqfoMcABhrNuyW2IGTZHIptUkf94nZPGa15WRHd67bTLQunjNVtXbosWlCx9MNYVxyCJoX4yXc5NaZRz1xhQ+du03UbsSIqOZOn+9z23DuEGQoUjsG7jgMiX3fal/xwO8l/oT9K7fi4AXAS8C6TQCJWp3kV4dG2raNdQB+Pn65PeqU7zxhusU9J745rTqfAMNDPrfevcjmTy0czK9L9ICio3+/edfee7pnI4NIgId3+3vWKk16zxEBnRvocwloKddj/OaUjvYNcfwB3ppSUxHNXTMlcsUkP0ffKwdt5ZO6ZvMdzal12z/nl3P/O33Z6T/yDkqMWhap5wUK3CeXQz3wN+4UYcEvTeK2swoWaertu7N8eC9yU5JkeBRPIZdCgTRxtaL6C+j4iOT6cpTc/1YnbXplqgOGzwbWgrXr1ZCdr/zoUwZ1kV9mJHk4EOMC4XToJvc6ld2aBGnifmzuR+VBau2qFUbhXDWAkNzDDIoaHn57viEKHXbMGD30NHPJHPGGyXvM7kksmnVsG6MUhOv9PJdD/CmlyfhXYcXAS8CXgQuswiQtu8SP0ElDfYmDoFuFWBKCnjP/o+kTaNKftsFOx3LCfSilURjTHoYaQTgYerw6JCaKgS6buvfcRL49IsTev9GtkDavv+ouZIj+70+vakT6OVzVZvFyYvPPqZaUTMGjJqrjRZSojcOdO1OxXvdB0zWQjFYx74jZgVsFBHoHG5/n7/iVW3EMCzuf6zo2XO/SNHqUbJuToLccXtW+efvf3wd+bq2re3rnscx3TTBlZvGKqParE45bYIRrkFMMlx1lax9dZcsXv266tJhm2l3PXloF3VPoM01TLXTQGJTvWVvWT6tv0o2iH27mEQpVuBZ7STHnBg8doFmNOy6clh5vg/Ytvv8ZsiQQYZNXCSfHz8pM0f2CNftXhbH8QDvZfEYvZvwIuBFwItA+oyAvVgr1KvExgrGzInhC3QsQO/+Q5/ItOHR2hyApgXYYZECR+c7c9FG2fve4TRp1QqofrZ0S1kwvpcW3zEM2AXE40VsfHr5mx304u3aNGqI7Fg9NgmbO2T8QsGfeN7YWL/SjkCxcQRhluI9SscowoJNBFwhTUEiUKdtvBZeUZAYzoH+evysldp8hGcDqGdz8p//XKVNJ7A0ozkF14HPMcWByAoYdmbdXBca1zWbd6ql3ZFj57WyPP9wjh17PpDhExfLqpkD9LDGExjJwYIJccl0vNZzozOeveQVie/aVCUM5rfCXKC4Ey1u/Wol9ZrJctiHWwti5hl2fOtf2y05H75fNcXe8FoLe3PAi4AXAS8CXgQu4wgA0uiENmLSEvn8q/Mm/2ZQsIU/8N6Nk9IkAlitUbzXuXUt1aDC7DqBXXPyPfsPq86Y68V7uG7bfrJlcaLcnCWTfoQGBDCKgOX7771TmzAAmkN1lgh0s3QCoxnI3LE9daNQqUlPSewToXISvG5rVSyazD4r0DED/R2Q1qHXGPntjz+1AGvj1j1y/XXXyNRh0VrgBQAu36C7lC/xv05+/o6J6wZa2pmjeshD99+tkpi67fqrx7Ib6xroGp3+juygTtt+2iWudcOKCtbffPt9ZfBhW/GR/vDoFypxiWxW1bdRYEPzZM4HhW59iVOWqhUb0h/TES6uU0N5/JHs2syF7njLpvZL5lpBBgU2F+9r02rZXCOMN4C/5Mt5VcdsNl0pucfL5Tsew3u5PEnvPrwIeBHwIuBFwDUCHeLGaLoYv1YzFq56TZ0blk2N139y0kymJqSwbANGzxG0pLCR350+62N26Uy3fstuPTzWVgAT++g3co7s3f+RNhb46OgXsvH1t31gFwBHlT+spVOHr9RcN+n6cvW7S1ynRlLoxaeEOFE8BmOZloPzrtm0U9Dz5srxgHaxu+bqDGpFFhk7WnXEyAXcfJjNtdnBLv8OoKadb9tGlUPuthbontkgUFR57bVXS1TLmgrYP/3ypDRqP0jyPJlDz/fuBx/Lrr0H1YEB2QPPfu2cwcmKGHGcsHeE27x9n5QqnHx+uF2XkXeMGdBBnUpGTl4irRpWkloViwS6lcv67x7gvawfr3dzXgS8CHgR8CJABGAm9+4/LKP7t1ctJyn0LvHj1RaMphH+NJOpjSD61IWrtvrALkBWLdvi2qhcA9lAtbKFHFvEUmCHxy8FcIbZNWC3Ysn8adaWGAYyqvc46dyqluw/eFQBG44CF3qECnbxtkU/OyimpTK7ZmCPt3Xnuz6mNNybG8D6q9v3qSNJxhtvkCrNeqljQ4/Ier5riE+cLR8d/VxOnf7R9yzNH5FllK4XLTGR9VMFyJ20zLv2HRS02G+uGnuhH1+6Op8HeNPV4/AuxouAFwEvAl4E0iICABJaAR/7/ISmf499/rX0imqkvrgmjZwp4/VS4Pnc0rxuOW1hG65BOh5AQ7ON1958V3oPnyFliryg/0ZnurPnflb2cceqsckaFzjJGBq0Hyh2sMuxrr3m6rDKG2App85bJ3/8+adENquWBECGKzb248CW4lDAsIPdG66/TmiFPHvpK1pwiDQB/St6WX/DHkOkLNh/YRuGn264x/6DH6s38OvLRyVxATH6a7NxsZ8X72h7Q5ZQrg2wSyti5A85H87m+ypzLmHcfNmyeEQoh7vsPusB3svukV76N0Ql9dT5awU929mffpbbbr1ZHstxv6btihV8NqgbbNtjpHZk6hXVMKjPex/yIuBF4MqIAE4AP5z5SbCAQhtrwC5p5DLFXtCUOsCE9L3p5BXOyMDWorulcI7ub/jsdouoK+UadJcdq8clAUg0FZi5eGMSNrBRh0Hy0P33SN+uTXyXRZe6ltHD1Z+1Rb3y4bzcC34spCd5nnhEyhV/SXoOnqqg18gYTEc12NtKpfIL1l7EaNHE3kK7X6fhBHabRg3WzQZevXWrlPDbDjglAUBb26ZHory6aISv2Mx+HSk5rr/vGGb34ez3SM2KRdSZggG4bxAxQJrULqsOG1fy8ADvlfz00+G9k3qJ6Dlacud6UKtTMY5nx//ajndV8/Tu5qlBXbUHeIMKk/chLwJXdASsYBedpRl0u4I9NG2CwxkkgA9a1J4dGuhhAb3L1m+XSqUKaPr7199+V5aWLl002qDjmLF0w/khT8kWsmxavI+ZNGAXa6thvdv6dQUI532k1bEAaFFxY+Xgkc+lVOHnZUD3ZqrZhQipH9FfEvtGaqGWaTfdvPNQadu4slp02cfZn36RiJ6jZFBMCy3ys3eVA5hG9RknXdrUlvLFXwrrLdFM4vjJ77Rg7J33j8qG195KJmMI1wnRPCPjmJ7YXTdMbIogiJBWzFu+WYoWyCP9optJMLrxcF1TejyOB3jT41O5Qq+JnXyZ+t3kmScekRF92iZL7bHgUelqFrEvvvpGzv3ym7IlLFYdW9TQSmh8KimysA6qjWF0OAZaLnRxGW88n77sHlHXVwXNrn/wuAVq+0OF7eOPPCBv7/9IFk/uoxW1DLRsLLgsMjdlulEqlsqvhQosNAwW4Iez3yuZM90gS9du0+vFj3HohIWyfcWYJJW27XuNkaszXCUj4yOv0Kfu3bYXgYsTATfNJGn82q3jtWkFa0a4BxZfNVv1laFxrSV/3vN2Ueh5YeRmLXlFJs1ZIzdlvlHXM2uBnbmO2MHT5MS332tzC9YfmN3LBexaY43llpW1JUYUztGoQTvvxY7RdbXnoKna7IE1199wa6E8a/Erak2H04EZtPiFKcVxITXjrXc+lD7DZ8p///orzcCuuT60y8wHBj69C1ZskV9//0OK5n9GNeqh6MZTc8/p+bse4E3PT+cKuza65rBLpcuMP89NutzwUqAPOz6F2Pf0HT5TizdghWlLSlqMVqKkDRlZbsqk9jrVmvWSxrXKSPkSL6kGDBB64/XXydiBHX1gFR0Vx8IKZ+eeD2TC7NU+wEv6kdRj9fKFpVq5QnLi29MyYNQcKVv0RV+bSQAvCyj9zssWe1H++utvKZI/jxSrGSVd29bxVcpyPcVqdpIpQ7sG1T3qCpsO3u16EUjzCNg1k6YYrHalYmoxlVaDTXOnPuO0SxZrlGl1TCvmIbGt1UKqaach2i3LXp1PsRUbetg6mlpQGAWzSxOElOhb0+oew31cWvFGxo6SVxYMU39g86xeyPOYDO7ZSk8HA25vQcy/G7ALc75qxoAkQBbSARu46Lbn2wQb1h8QHQ77MjYxdKeDYb5YI1Td+MW6zrQ+rwd40zrC3vGDjsC85a/K8ImL5MCW6UF/x3zQdAPClJzhJGmgEhp7IKsP55Fjx6Va8zh5Z9MU7fLTossw2TBvsG9xAlwXrNzeB3g5BtYyK6b3910jljHd+k+UXWvHa+oNwHvPXbdJ/27NktwHO+yDhz+VJZP76r/jr7hy4w49X2qZhJAD5n3Bi4AXgSQRMACqRvnC0q5JlTSPDowcfq1li74gX538Ttec9rGjJXu2u6VLm1q6HsUMmiIb5w91vJZl67bLzr0f+GQMKdG3pvlNhvkEMYOmaoEfLXtpfIEPMUVe81ZskVmLNwqd2V5+8WnVN5umHlZm98Mjn0mbRpV9ra6VzFi9VW3pKJRzk7iE+TYu+OFC0Y1f8Iu7gCf0AO8FDLZ3Kv8RCAXwAjLRRJF+/PmXX+XM2Z+VLaEjjxvgbdZpiMoTnMaGeUNk8/a9uvhtWZLo+4gd8LbpPkLuvP0WrQw2A9YXppZF87FHHlDAS//06HbnGQMzkEDQXx1rHypo6b9et0px7cfuDS8CXgQuXgTocFWxUYwWQl0IsGu903Vbdp9vPtA3QllL5A6zR8foGoL2E09Xt2EYzZToWy9etFN+Zp4TmufVm3ZIQkwrLTYD6G954x3p372ZPJHzQVm0aqtsefMdLTpEZkantQOHjmkr5sOffCltuicqg/7tdz+o3GzswA7632kFdvF5fv6ZXMoiX6wRSDd+sa7rQp/XA7wXOuLe+VwjANvBYgR7arVUsX8BP82x05dL09plhXQWhu5TF6zXxcsf4MWknUUH8b7TmLZgvZrQb5w/JCTAC4NQvGbngICXg9Zq3Vdy53pIihd6VtrFjJJty0b59MPe1PAi4EXg4kUAsHkx0s4/nv1ZPVtH9YvUrmz9R86Rf/79V5sPBDtSq28N9jzp5XOQDMjZALAN2w9UG67s2e7yXR7kBu14KUREOgaYNa4FxHvXvkNaY8H7A3lEWoFdLoj3Q4+BU/S94w/0YptH9hBmOtxd0fzpxt3cLdLLsw7ndXiAN5zR9I6VqghgrF6qTld59OFsMnVYV9eitaadBsuD998jvTs18p2PQjWE+gbwoo/Da9MKbmECtu06IGtmD0rSm94YkL/y+h7pMWiKvLlyjK9No53hpViNRWnljPN90xmbtu0VKnJ3r/ufpMGJ4eWzS9ZukxGTFmsxDIUp6PW84UXAi8CVHQF8WwFFaP7XvbpLGtQoJU1qBZ/5CaRvBXRNnrNGnSEuJ4CzaPVW2fH2BzJu0PkaDDNw+8HhZ8q8dSoNQYtrl5iZz9rBLvISGGNG6SLP+/TVqZmhwYDejnFjVXLH84Hw4d3lpEdO6XW46cZTerxL8Xse4L0Un9plfM1bd+6XqN5j1RGhYY1S6qX7/Zmf5PWd+1XCgNYWLSxscI+IetrKkQWLNBa7dQN4x89cqeByZHyERgvmBiug6i16S+7HHpIWdctL1pszq9MCUgpkBr/9DuDuIk8/nkP9CrEEwtLlvQ+P+TS8LFy03KxRgaK1l7VtI4xM6SIvqNsDw03SwN+wHCpcraMWzM0dGyvP5n7kMn6a3q15Ebh0ItB94GSJaFI1qNQzDgLIqGAZwzVoQ4w7DMdkPQl1OOlbYQt/OHtO8J296qqrhBoHNuOXy9j33hHpPWyGFjrbgTx2ljTzuP66a2XTwmH6v/ZhB7vIS/olztaiZAiTFRvekKG92oRlnQ4EeqkVGd6nrbzwzGPSMW6MPPZodmnXuHJYH5XRjZcr9uIVWTfiAd6wTifvYOGIwAeHP5Np89epdRhFCBQnAAxZhGjbSEoKEf7udw6pxRcG5TCxP5371Qd4kTd0HzhJ9h44InTnmTYiWhd6HB1GT10u+94/oobmAOEi+Z/xuTlwzn6Jc+SzL0/KPXfdKo1qllabs1UzB/h8L1lkKV47/PEXuiiajkdmwfUHeIlPl/gJ8snnX+si7Q0vAl4E0kcEAgESc5WA3U59xqtXbmLf80Wy6WE46VtNwRYa0lw5HtAmDU/myq7d3fD5vRwGtl/ocbFxy/nw/cqKImNAwoZEhHfE58e/0WJlnhkEBy49vFfefPuD813uSuRT8qN+xAC1vsTDtnblYiqZ4FlbZW6piZl9juGhDKHCe40MJK4/XCcSBByL1s5J0NPt2POBkIGEpfYKnFP+BDzAm/LYed+8AiIA+K7btp+8vX5iEv/clN46Oq2StbtIy/oVpV7V4ik9jPc9LwJeBNIgAoFArwG7h45+Jpkz3ih5n8ml1mHUEaSXYfSt335/RpndfHmf1IItgBKZpZFTlmhDAthDAOClPv7991+hrmP3vkMyNK6N2kA27phwXg/9/wARoA+IpfVyTMJUqV+tRDKP5YGj5+p3u0XUk4iYkSpnqFa+sOSr0FZ2r50QNikIcwwv5YkJnWTzG/u0UJpsH77QlZvEqrcwHUUhcQDlSCyuvjqDvLH7PalVqWiqHhfyDo6LZWawA/KHa8vx4H1yw/XJWfJgj5MePucB3vTwFLxrSDcRWLLmdcmU8UZld2GSx89apV2OwsXksEvvNWSabFs+WjJlvCHd3Ld3IV4EvAicj4Ab6DVg9/szZ7XGgMY0aPo/P35SZo7ska7Chxd5jZa9k4Bdc4HnC70Gybblo8KyiU9XN46krMtQuS1rFhkc2yoJG0rrXTJrbnUTSOVuvimjdGheXeVtgF4Gm4JJQzqH9TZh43GQYE41iBwoVcoWVMeeQWPma2c9bNcYRnIxf3wvZZ5TOzhfdP9JUrlMgYCgl2wncr3jJ07J7bdmlR/PntOOdmQ9L9XhAd5L9cl5150mEcDyhopn5BF33p5Vd9odmldTf91wDF40D95/l6tTRDjO4R3Di4AXgdRFwA567WAXKRMDdhHtLWtFehvbd78nL7/0VLIUeN/hsyRDhqskzlL0m96uPaXXQwbt2VItZf3cwb52zBwLsEtTDrq0uQFH2E+KnfFJx5MX0IueF09k4+mb0uvy9z20xlG9x+lc+vizr2VYXBuV2dn1xUgusL1M7QgG9NLRLnbINClR6DndICDXQxbSIW6sVCyZL01abqf2voL5vgd4g4mS9xkvAl4EvAh4EbiiIgDoXbjyNe26+MFHnyqbS/tZA3YJBvLSwoBYAAAgAElEQVSB6QvXa23Aow9lk9YNK6UreYP9gZGaLlojShZO6O3rZvnHn/8VGuheDvIG7jd+xCz55rsz/8feWYBHdbRt+IGQkODuDkVbChSnuDvF3Vu8FIprcXenuLs7xQsUKVAoFIq0uGuAhAj5rnf4dpuEkOzmzG52k+dc1399f8mZ98y5Z/bsvXPemcGovt+qJR8tkV0TJ8nvlfO7tK6NCqUKmLfqtUfHl5F3SWGQH0/BZVdkWDZFkrksnVp9Y7g6oUmvjOy27j4WP7Stq1a4kMne4wd1UP3++s17ePPGC7lzZjZch4gIQOGNCOq8JgmQAAmQgFMTuPbPXTUxKv+X2dCmcVWcPndZvR1aNXuQtjdCugGt2LhPrQQhG1tIbujqzQewfsch1K9e2jxxV/c17R1PNuNYvWW/mogmy5YFHtmVyWCSpmYaLe3ato4azQ18yPJdW3YfVSO7gX/c2Os+PrUmsIw4d+w7EflzZ7Op9DbuOAwli+Qxb609ZsZKPHn2AuMGdrAXAptdh8JrM7QMTAIkQAIkEFkJyBKHskGAzLIf0buNWu5QZtrLUoqOmudYs1V/5M6RGfIaXUbyZN1fkd1c2TJEumYScf1+wFRzGoP8QGnxwyi1IoJMYJO/y6t7WZIylkdMh7l/Saso+/VXatOM4IfMK5F7qFAiv1bp7dSqlnkVojzl2qjdRk1pHJLKIJPpTu+eq/KO5ZAtnWct2YI2jaoE2fDDYSB+oiIUXkdvIdaPBEiABEjAoQjcf/RMrdl9etdctSRW5/5TlfTu2H8CCePHwXdNq0M2tFm+Ya9aEaFO1RIRWn/ZlGflpn1YuGqnWp6xQY3SqFquSKSctBYY9NPnr5A4YTz1T9+0HoBiBb9Aj/YNzKd06T9FzdMQATYd4VnJwBaNu2PfCZz/67paokzWe5f/9XzjheRJEiJblrQYP7CDljQUyXsOvERdg3ZDIAJcovCX6rak38xeskVNcjQtiSb9ae3Wg1iz9YB5i2dbMNAdk8KrmyjjkQAJkAAJRGoCsgpCsZqdsX/tJJWzK9sSd+43RW1Ws2bOYNy4dR9j1avgl5g/sZeWyUbhBSqjzht2HEGl0gXVslZfZM8Y3lBOW06W1pJX9Yc3TTOPUsrNdBkwFUW+yhVkiUhLJnUFBmHaqVMnHInZoc9E3Lr7CN3b1Ve7vaVMlkjJu63X4T1/6bpae7h2leJ49PQFtu09ribSyQ+D4If8OOjYZ5IaJZc6OvpB4XX0FmL9SIAESIAEHI6AiOTd+0/U2q/ySlyk996Dpyj8VU61LuykOWvwZa4sagmziJwQJpv3uESPHqWXQZQR+TptB+LQ+inm9XSPnvpTpTxsXTwSqVIkwc79J1D263yqrSyRXtkMQlb1uXL9NjKnT4UhPVupLYwl11ZGPpvXrWBITmUyoYxAZ86Q2ryLp+lDIFIqE+yevniFYgU+Vyk0OjcSkRFcSffw9/dHpTKF1P0FPmSypmllElkGrkyxvGhSu7zDfUaDV4jC6/BNxAqSAAmQAAk4GgFZS1VWBDh59i+0b15DbTUux5K1u9UrYNndcfPuo2qUzrTluaPdQ1SqT69hsyGv75vWqYDfz1/BrMWb1dJsks4gKzNM/nkdJg/trJbiklHU0KR3/9Gz6DFkpproV618UZy9cBVDJy3Gsun9MXjcQoV11pjuiGlwY4+QpFe2P+47ci46t6qNovlzYfWWA/B+56NWUrDVISxMO4nKaHnTLiPQvlkNtSGGTGqTTTSK5M9lq8tri0vh1YaSgUiABEiABKIaAdlqPEG8OGqZL1kVYOq89UHSGP688g8yp0+ttrBNkTRRVMPjMPcr0jZz8WYcOn5OTchq3agKCufLaV62rG2Tqupv3u98MXVYF7V6Q0jSKyO4Zer+gP4/NFMrQZiORWt2qR86OT9LjxmjumnblUykV7a3/7Fdffj6+aFS415qp7jjv1/C3HE/qr5X99vBarMKyc/Wfcj2ywePnQ2ybrPkgp+9eFX1569yZ0XFUgV1X9Ym8Si8NsHKoCRAAiRAAlGJgLwGrt68r1ryS1ZsMB2mXbtSJEuEkX2/jUpIHP5eQ1qjd8CY+Xj//r25rUzSa1rJQLYwHjR+IfauGv9RG8s/6JTd4AC37DmqlpKTnddklFlGqeeM/RHf9RyvtiSWlArdh4zoNuo4TOWmp0udXIU/cOysqofuHeh01z14PAqvrQkzPgmQAAmQQKQnIHmVMglKRMiUsxt4i1pbilCkh2uDG/zUhhQy2VB+vEwZ1sV81cArGdy881CNqMpErXSpkwXZhtjUxpLPLWv4ykYSOg/JGx4/azU2LRyuwor0SlqN5NOumDlQax5v4Hov3/CLWnGkb5cmiB49utqBrmKpAmpCnTMdFF5nai3WlQRIgARIwGEJ9Bv1Mx4/fYmZo7vJvsNo12uCqmtg2ZVds56/fO3QO7I5LGCNFVuwage+Lpg7yFbD+389g94j5qhRellj+VPH6s37VXpE1bKFcfHvf9WkwMBtPHX+erUJyaQhnZEnVxZttZbVGxp2GKom17VrVl3lGh85cR5ZMqS2+SoJkjss6Tqy81r18kVV/nJETsYMD1QKb3iosQwJkAAJkAAJBCMgMnvt37tqEf/pCzaqV79Lp/U3b2wgfx82eSnu3n+sXkXzcBwCMlraZ8QcTPypk9qcIqzjrZc3GrYfqvKBRXZlApdMXkuVIjHSpEyKE2f/Qu/hc9TGF5nSpQwrnMV/l01DZAk8N7cY+OHbeiqHlodlBCi8lnHiWSRAAiRAAiRgMYE23ceqtUtlgpEcJtmVVR0WTe5j3snK4oA80WYErJVdU0XO/nkV2bOkV7LbsusotYOdrJggax737NgIC1buwL2HTzCkRytz3UWUY3m4G7oXSbHYe+i0EvOI2P7YUOUjsDCFNwLh89IkQAIkQAKRk4C80p6xcKNap1cmE8nIbmDZffD4GeYs2YJ+3zc1L/kUOUk4/l1JPm+Oz9JbNLIb0t3Imr6Dxy3AjmVjEC16dIydsQI3bt5HrFjuame0AT80U8Ukt7dxx+HYuGCYWgWCh30JUHjty5tXIwESIAESiCIEDh47h/U7DuP0uctInCi+eWRXZLfVD6PVBKAJgzvaZDmpKILYIW7z2j931dq0MplMluqS0fxmXUbi6fOXKqVF0h5OnbuM1CmS4PGzl/gyZ2aHqHdUqwSFN6q1OO+XBEiABEjAbgSu/nMHfUbMVTm7Ij4m2S2QJ7t6Hb503R58nj0DRvX7zmaz7O12s1H4QrLhyPyVO9CwVhm1A59sbrFwch8lwL+duYQu/aeqtXIrlMyvKMm/ySQ5GeHnYR8CFF77cOZVSIAESIAEoiiB9+8DED16NLPsFsn/OQb+0EzNsn/r9Q6T5q7B923qqCWukiXhq25n7SZPnr1E536TIds5B5fdwd1boFr5DxtVmAQ48L856z07U70pvM7UWqwrCZAACZCAUxJ489Ybdb8dhMCya7oR2dyg2+AZavKTbG/Lw3kJ/Pb7JWRIlyLIyC5l1zHak8LrGO3AWpAACZAACURyAoeO/4EShXOrkd3gsnvn/mN4eMRU/9y3c2PkZp6nU/eGkEZxg/+bjAhLmgsP+xCg8NqHM69CAiRAAiRAAkEImEZ2nzx/iZ/H9VBLTO0+eAo/jV+IHcvHaN+pi/jtR+DIiQt46fka1cqFnMZw5sLfGDVtBdbO/cl+lYriV6LwRvEOwNsnARIgARKwP4GQZFdqIf9etEYnLJjYG1/kyGT/ivGK2gmENNrba9hsJEuaED3aN9B+PQYMmQCFlz2DBEiABEiABOxM4MJfNzBu1irMGPlDkM0DRk1brtbrXfvzEK7aYOc2scXlXr/xQsXGPdG3cxPzpLVnLzxRrn53bF40AmlTJbPFZRkzBAIUXnYLEiABEiABEnAAApPmrsX2fb9hyZS+SJUiCc5dvAZvbx/kz5ON8usA7RPeKjx9/gqJE8YzF5+3YjtO/3EZs8d82F765p2HWL/9EBrWLKPanYdtCFB4bcOVUUmABEiABEjAYgLBZXf5hr2YtXiLWqP3xas3mD6iKyc4WUzTcU+UJeoqNe6JPl2aIOB9AFZu3ofzl66jSpnCaFavAjKnT+W4lXfymlF4nbwBWX0SIAESIAHnJvDPrfvo3H+KmrhmGuHr/tMMZEyXEl1a18aiNbtw6Pg5LJzUx7lvlLXHgWNn0bnfFLXecuKE8VG/eimV6hDLw510bEyAwmtjwAxPAiRAAiRAAmER8PP3h0v06Nhz6BQqliqIfUfOYMTUpdi2ZBQ83GOiZsv+are2lMkThxWKf3cwAr5+/th35Hds3HkEZ/+8ikqlC6J+jdL4PFtGB6tp5K4OhTdyty/vjgRIgARIwEkIyLbD1Zv3w/61E9VEti79pyB1yqTo07kxnr/05DJlTtKOwavp7/8eE+esQdrUyVC9fFHEjsXR3IhoSgpvRFDnNUmABEiABEggBAKySoNMcho7oD32Hz2DMTNWYu+q8WRFAiRgkACF1yBAFicBEiABEiABXQTk9fewSYtx7uJ1vHjpidpVSuCHb+vqCs84JBBlCVB4o2zT88ZJgARIgAQclYBsNfzunQ8yZ0jtqFVkvUjAqQhQeJ2quVhZEiABEiABEiABEiABawlQeK0lxvNJgARIgARIgARIgAScigCF16mai5UlARIgARIgARIgARKwlgCF11piPJ8ESIAESIAESIAESMCpCFB4naq5WFkSIAESIAESIAESIAFrCVB4rSXG80mABEiABEiABEiABJyKAIXXqZqLlSUBEiABEiABEiABErCWAIXXWmI8nwRIgARIgARIgARIwKkIUHidqrlYWRIgARIgARIgARIgAWsJUHitJcbzSYAESIAESIAESIAEnIoAhdepmouVJQESIAESIAESIAESsJYAhddaYjyfBEiABEiABEiABEjAqQhQeJ2quVhZEiABEiABEiABEiABawlQeK0lxvNJgARIgARIgARIgAScigCF16mai5UlARIgARIgARIgARKwlgCF11piPJ8ESIAESIAESIAESMCpCFB4naq5WFkSIAESIAESIAESIAFrCVB4rSXG80mABEiABJyKwP2HTzF76RYcOXEeT5+9QsIEcfF1wS/QoUVNpE6RxCHuZeGqndi461dsWTTCXJ+3Xt4oULk9hvRohbrVSjpEPVkJEnBWAhReZ2051psESIAESCBMArfuPkKjjkORIF4ctG1cFenTpMDte48wb/k2PHn2EitmDkTGdCnDjGPrE0ISXj9/f+zcdwJf5sqCdKmT2boKjE8CkZoAhTdSNy9vjgRIgASiNoGOfSfh6j93sXnhCMTyiGmG4eXtg1qt+iNd6uT4eXwP9e9tuo9FyuSJ4R7TDTv2/QZfP3/UrFgMfbo0RgwXF3XOy1dvMG7WKuw/egZ+fv74PFtG9OnSBFkzpTHHyJwhNeLG8cDarQfV+ad2zsbg8Ytw8uxfePriFeLG9kChfDnRp3NjJEkUH7sPnkL3n2YEaagurWujffMayFO+LSYM6oiyxfOpv5+5cFVd/6+rNxEvTixUr1AUP3xbD64xPtRP7iFdmuTqbxt2HIa//3tUKVsYfbs0gYtL9KjdGXj3UZoAhTdKNz9vngRIgAQiL4E3b71RuFoH9OncBE1ql/voRldt3o/hk5fi2NYZShBFFk//cUWlDxTN/zlu3n2AqfM3oGeHBmhSu7ySx8YdhyF1yiRo37wmPNzdsHLjPuw8cALbl45GLA93FePUH5dRumheVC5TSEmx/O/kn9fh8+wZ1Ajz0+evMGb6CjWyPGVYF/j4+GLusm0qzuIpfVU9JZYIemDhffj4Oao07Y06VUuidpXiuPfwKYZPXoLKpQuhZ8eGZuE9cfYv1Kr0NcqXyI+bdx5gwuw1GNKzlfo3HiQQVQlQeKNqy/O+SYAESCCSE7h87RbqtB2EBZN6o1DeHB/drchti66jsHbuT8iZNYOS1ayZ06J3p0bmc4dOWoLzl65j3c9DcPi3P9Bv1DwcWD/ZPKIaEBCAYjU7Y0z/9ihe6AsVI1WKJBjWq3WodNdtO4Sp89fj8Map6ryQUhrk3wML7/jZq3Hs1J/YMH+YOfaeQ6fRa9gsJe0m4c6UPiX6d21mPqdVt9FInzoFfurRMpK3OG+PBD5NgMLL3kECJEACJBApCVgqvCKzOT5Lr2Q1e5Z05tFSgSJiOmH2ahzfNhOzlmzG9AUbQ2QlMlmvWqkQY0iBP6/8g9WbD+DS3//ipecbleoQEPAep3fNtVh42/eegORJE6lJbKZDRn3L1OumhPxT99Bz2Cy8fx+ACYM7Rsp25k2RgCUEKLyWUOI5JEACJEACTkfg9RsvFKneMcyUhuNbZyDu/1MagguvpD1MmrsWJ7bPwsxFm7B17zHsXD72kyxCkuYLf91A084jUK18EVQqXQjJkiRQqROT5q4xLLwPHj9D2XrdQxXe3sPnQCbAUXidrguzwhoJUHg1wmQoEiABEiABxyLQvvdEXL9575OT1jKkTYE5Y39UlQ5JVmV09NkLT8yf0Av7jpxB10HTsGXxSGQKtrKD5PfKpLCQYsxcvBk79/2GrUtGmeHIRLX+o382C++KjfuwdN3uj2Q6cEqDTFaTlIaNC4YHidNr2Gwc3/ZfSkNwaafwOlafZG0ihgCFN2K486okQAIkQAJ2IHDr7kM06jgM8ePGxrdNqgVZlkxWTFgxYyBEek3C+8bLGx2a10S8uLFw+LfzmLdiG5ZO6488ubKoUdIG7YZAJsP98G1dVU4mjm3ceQTN61ZAgTzZQxTeXQdOos+IOejXtZlaXuzy1VtYsm43Xnm+MQvvybOXIbm2Ywe2R8a0KeDm6oosGVMHyeGV0dwqTXqrSXW1q5TA/UdPMWzSElQsVdCcdxyScFN47dDReAmHJ0DhdfgmYgVJgARIgASMEJCNJ2Ys2oRfT17AsxevkDB+XLUKQ+fW3wTZeEJk0fPNW7zz8cXNOw+RMllitXRYySJfmi8vubeT563DgaNn8eKlJ5IlSaiWGOvato5aYiwk4ZSJbTLhbOOOI2qps6L5c+Hz7BkxZ+kWs/DKBUZNW44tu4/Cz/+9yiOuX73UR8uSSSqExLp89aZKw6hevii6fVcPrq4xPjlKTeE10ntYNrIQoPBGlpbkfZAACZAACRgiEJKsGgrIwiRAAg5DgMLrME3BipAACZAACUQkAQpvRNLntUnAtgQovLbly+gkQAIkQAJOQoDC6yQNxWqSQDgIUHjDAY1FSIAESIAESIAESIAEnIcAhdd52oo1JQESIAESIAESIAESCAcBCm84oLEICZAACZAACZAACZCA8xCg8DpPW4VYU1k6Z+6yrWrXnodPniNh/Dhq68nC+XKiVqWvzetLOtJtFqraAQ1qlEb3dvXtWq0u/adg/9Gz6prRo0dT+86nTZUMhfLmQKNvyiJNyqRB6tNv1M/YvPsozuz5GTHdXC2q64Ydh+Hm5opq5YpYdL6cVK7Bj2o5o1WzBqkyB4+dQ6d+k7Fp4XB8ljGNxXE+deLte4/UUkf1qpdWOzwFPoJf2/DFGIAErCBg2vp39pgfUbzQF1aUdMxTAz9jpIaybFjezz9Dm0ZVkP/LbFZVumGHoUiaKD6mjehqVTmdJ89YuBGyaUZYx+h+36k1igeMmY/I0pZh3TP/7nwEKLzO12bmGp/986pa81HWgaxdpbgS3RevXuPM+b9x6Pg5NKldPsie8I5yqxEpvOf/uoF+3zeFrIspi76f+fMq9h46jWjRgLEDO6BMsbxmTLsPnsTFK//i+7Z1EMPFxSJ8sn2ofMnNGt3NovPlpHkrtiN2LHc0qlXWJsJ7/PRFtO0xDqvnDMbn2TIGqVfwa1tcaZ5IAhoIREbhNT1jZOe1h4+fqU0pbty6j0lDOqF8ifwWU3ME4ZX2+evqTXOd5d7WbDmAji1qIlWKJOZ/F5l/5fkW8syUDTFMG3lYfLM8kQTsQIDCawfItrqEyO7fN25j+7IxiBcnVpDLPH76AvKwKl4ot60uH+64ESm8V/+5i10rxgapu2wb2nXgVPx55V+sm/sTMmdIHe57C4/wBr+Y7hHe0IQ33DfKgiSggUBkFN7gz5iXnm9QpWlv9TbJ9BbHEnSOILzB67lj3wnIVssh/Xi25J54DglEJAEKb0TSN3jtGi36wd3dDWvm/BRmpHEzV0Fet/fu3BjLN/yCq//cUVttNqhZRv1aD3z8eeUfTJu/AWcuXFV7w3+WMTU6tfwGhb/KaT5Ndgv6edlWbNlzDLLdZfIkCVHm63zo1LIW4sT2MJ935sLfmDR3HSSmXK9Ygc+xc/8JNK1T3pzSMHDsApw6d/kjEQ3+wLfmHkICIq8bQxJeOffJs5eo3KQXShbJg/GDOqjiE+esweotB3Bi+yxzOJHR+Su3qziSFpE+TQpULVtY3Y/Iroy6Bz4ktWT+xF6Qum/cdQRLpvTD5J/X4fjvF1V6wc7lYxH8Pk3CO2fsjyoV4dBvf+D9+wCUK/4VBvzQTI0Gy7F1zzH0GTkX+9ZORIqkicyXDVxvk+wG57F0Wj/k+yLrR9eW846d/hPTF2zEX9duqVQO2RVK0k8Cp3zU++4nJE4YT/1t7daDuH3/MdKmTKp2fJJ+wMNxCVj6OZK+M3HuWsguZa/fvEXCBHFRMG8OdG1Txzy699bLGwUqt1db9nq/81EjfDLSlytbBgzu3uKjH4/rtx/GwtU7cef+Y7WL2RfZM2L7vt+CvAZftHoX1m8/hEdPX8DX10+9wapYqgA6tqxlTi2Sz4NszSujp3fuPVbbAEv6T4v6ldQzJqRDPuNl6nVD28ZV8X2bOkFOmb1kC2Yv2YwD6yerXdiu/XMX0xZswLmL1yD3mDpFUnXvP7avH2p606eeMTI4cf3mPRxcP1ld15LPWPDngiXtIbHls5k6RRKV0jZz8SZcuXYbNSoWw7BerVW61KeeX5b02NCE98iJC2jfewLWzxuK7FnSqXCm50TBvNnVc0L6UuqUSdH9u/pIlSKxSsc7/vslRAPU4Myg7i2CfH9Im8nzUt5YynbOaVMnQ8OaZdT/RZPXckC428qS++U5kYsAhdeJ27P/6HnYtOtXlbYgr5GCj/IGvjX5klu0Zpd6ELVrVkM9EGVrzFlLNuOnHi1Rr1opdbo84OXhLHu1f10wt3rVv/vgKWzadQQrZw0yvxKXB/u/tx+gdaMq6svgzv1HmLFwE3Jmy4Bpw783x2rx/ShkTJdSpVy4x3TDH5euY8ueo2jVoHK4hNeSe/hUk4YmvFKm+08z1YP19K456mEaXHhFylt1G4P6NUqjdNE88PL2wdFTF3DhrxvYMH8Y/r5xB72GzVZCKl+Mckh6g3wRC/9l6/fCzS0GShXNg6yZ0iqJbdes+ieFV7YKLft1PnyZM7P6sly37RCqVygKyZezVHg9X79VUjBmxkoM7dkaGdOlUGXl+vLDJPiXqnxpdew7ESUKf6m2LJUvGUl7kC99uUeRXNMX2aW//1U/glrWr6yEY/Ga3dh/9Ax2LB0d5HWnE3/EImXVLX0W7D18GkdOnMfn2TMhUYK4ePTkBRav2YWYMd2wcf4w9WPYJLzyealXvRRqViwGb28fjJq+HAHvA7Bp4Qj1w1AOEdlxs1apbXpLFc2Ld+98lID9duZSEOGduWgT3nq/Q5YMqdVn6fq/9/Dz8m1K2kSi5ZDn1s/LtqFL69rImjkt5I3WrgMnkTJ5YvM5ITVelwFTcenKv9i7eoK5XnJe5Sa9keOz9Jj4U0e8ePka1Zr3RdZMaVRuv/zok+eWvMrfuGC4yre35hnj4+OLio17qufksun9YelnLPhn05L2MH025dkcwyU6qpUvon4wyA/iFMkShfr8sqSzh0d45Tkh+dnynIgTx0M9C8/9eQ2uri7qe0B+IN++9xjyfSbfO707NVJVkS2c6303GJnSp0TdaqXUs/T8petqi+gf29VHs7oVDLWVJffLcyIXAQqvE7enfAF16DNRpS7IkS51MmTLnA5f5c6KKmULm+VE/mYa1Tm6ZUaQB738Ir97/wm2LhmlYshDVvKxerRvEIRM3W8Hq9GYwT+2VA9sSQGQkUUZDTEdB46dRed+U3BowxT1pdCsywj1i37rktHwcHcznxc8pcHaEd6w7sGaL6PA506dvx5zlm7F4Y1TFbvgwiv716/cuA+/754b5BKv33iZRyU+ldIg/Fds2oclU/spjoGPT43wzh7TPUhKisjCkrW7sX/tJCRNnMCiEV65TmgpDcGvXavVAPXWIPCrVxnBr9S4lxrFNvULGbmRCZJzx/Uw34qcV7Zedwzp0Up9cfFwTAKWPgtCqr1M+pQfjvLjJ1vmtGbh/eHbumqU13SY3j7sXD4G6VInh/zwktHVYgW+wOShnc3nWZrSID/YNu08guPbZqqyDdoNUSPO8hkJfAT+LIZU/0PH/0DHvpPw8/geKJr/w0iwvMmSZ9W88T1RJH8uHP7tD3ToMwmrZn945pkO+YErkhZaPr+wuXL9NtbNGwp/f3/cvvtITfqSHw6m+JZ+xixJaQjeHlJX+Wz6+Pqq68lzwnRY8vwKq8eGR3iDPydMI8ETf+qkRu5NR4+hs3Dl2i3zd5E8f0+eu4wVMwYG+c4aO2Oleuu1feloQ20V1r3y75GPAIXXydtUZsaePPsXjp76U4mvvL56/tJTjYzIF4vpoW56pX5sy4wgdywjJ1PmrcfZvfPw9q03itbopB7o0f4/KmM62c/PH4Xy5cD8Cb0wcupyLN+wFzICGeQICICkOiyd1l+NjojYyghm8NeHRoRX0gJCuwfXGJ+eXBbWCG9YwispISLnMmoiqzB8nj1jEOEXFqEJb0h1lzKfEt7gqzT8fv5vNP9+pGoDGVm1JKVB4lsqvJLLXLxWFzU63bphlfNOCVkAACAASURBVCBN26rbaDXaa0qfMb02DSwvMhEwd9nW6NCi1kdpMk7+MYtU1bfkWSCfI3kDsXn3r5CRxX9u3Yfnay+8fuul0gzkM57vi8/MwisTQZvULmfmJKvGtOg6Coun9FU/oE1pOqa+azoxJOEVaZW0K3ntf/fBE7x58+G6Mop8ft8CVVRSeXbtP4E2jauqFIYcn2UI8qP6Uw0mE8nKNeiu6jRu4IfUpUHjFuC33y9h98px6hqy8k3VZn2QO0cmNKlTXr1hCb6Cy6fiB1+lQc6TH/89OzRUzw1rPmPBnwuWtIdJeOUNXuDPpvy7Jc+vsDp6eIQ3eF1MbT5zVDc12m86RGTlbZTpR803rQfg2r934RJswvD79+9VEekLRtoqrHvl3yMfAQpv5GtTtUTZ9wM+jFKaRm4/9SUnXywjpy5TuWXyRSOv8kRQy5f8eDaxR0w39cpQfonL6/2Fk/uESE9y8548e6FGBeU1ep2qJYKcp1t4A99D4BGN4JULS3jlvmQE6OSOWSGmNMgXjuS/rd68H/cfPVPhRex7dWykRoZsLbySV1izVX+MHdhe5Q3rFl6ZSV69eV+M6NNW5f8FPn4cMhMyQ3vvqvHqn0MSXvn3POXb4tvGVdGp1TeR8JMVOW7JkmeBfI56j5iDbXuPo0LJ/ChdLK/KuZUl7uRHnykH3JTSEFx4JQWgccdhWDipDyR/0yRbkrMub6JMR3Dhfev1DvXb/aREV5YulDzzJIniQURr9Zb9uLB/oSoqE8EmzF6t0hjkh5ikVxT5KhcGdmseppzKD3xJzZA3UfKjvcQ336NNo6rqx7np2HfkjMp/Nb09k3x7ef3evF7FUDuBPGMuXP4HYwe0V3VKED8OMqZNaR6htOYzFlx4LWmP0D6bljy/wurhOoRX5o/IKPeMkT+o9C7TEfyNWsnaXfFF9kzo/v/0sOB1y5Qupfqn8LZVWPfKv0c+AhTeyNem6o7k4bhr/0n8sW+++u9PfclNmL1GvSY/tXM2Xr/1ViN8MrpnykENCc+wSUvUZC4RQ1nLNqRDvrgKVG6n8rGCf0kEF97B4xeqEepfVk8IEiqkSWshjZIGvgdZA/dTR2jCKyMvlRr3VBPDRvb9VoUIadKaKfa9B09UXp+MkEv+2aENkxULeTUaJ/bHy5J9ir/Es3SE1zRSaxol2/bLcfQePgd7Vo1XOdmf+uKQ0as2P44NcWZ14GubRp9kgpqsGxr4aPnDhxHetXM/TJCk8Drvg8OSZ8Gr128hwiFpCpKuYDpkEmqzLiOtFl5TKkHgCU0SM7jwyoRW+eEpqTKBJ5/JpLIZizaahddUHxmxvXHrHk6du4LpCzeo3PRFn/ghbioj0i4/xiUfOFYsd/SViZ9rJn20RrWcL3mkFy7fUPnzMtItsQvkyR6uZ4wUsuYzFvizKZO3LGmP0D6bgSv9qedXWL3ansIrk7JjecRUqSWWHNa2lSUxeU7kIkDhdeL2HDFlqZq5HDiPVm5HZktLzq1MtpAvGDlC+pJ75+OLKk16I2P6lCrfSw55jfTg0TNsWzo6SA6wjA7IL3PJ2/vlyO/oOnAavmtaHV3bBp3tLK8+ZRRYJqjJRBAZAZ0yrIuZssQR4W1Uq4x50posbj5/5Q78tm2m2rRBDjmvdpuBSJsqqXnhdUvv4VNN+inhlS93GRGXyWcbFwxTOYdyBBdeeX2WPs2Hv5kOmYDXd+TPauRT1qWU/MCnz14puQx86BBemdQhX7qHNkxVr29PnpVJdKNVXrDkbZuO4ZOXYuveY+bVJWQtYRk1k7WBZTJa4CO4bMsIspurK9bMGWyeBS1fjrKsUtO6FYLk8Ib02pQjvI7/QLHkcyQjrBUa9sDw3m3wTeXi5puSH6bf9RxvtfDKG5EKDX9En86N1frgpkNGQxu2H2KetCavtGXzguA/4mSmvrxdMY3wyqSs4Gu9SrkTZ/8yv4UIrSVadxujJsbJxE15Tspoo+mQukreqTzDAv9bufrdQ3z7Efg6Yb1FknMt/YwF/mxa2h4S/1M/Ri15foXVe+0pvKbUOVPuc+C6ydrAMsnQSFuFda/8e+QjQOF14jbNX+k7JYbyulF285FZrLLQubzqvvPgCeaM+VG9TpRDvuSWrt+D2pVLIM/nWSAjsLL0j8z+l5nDpg0J5AujXc/xSJwwPlrUr6hmFt+6+xAbd/2Kgnmyq2Wx5Joy2U2+/GTVANNavzICuW3vMfPSPrIEkYzedmpVCyUKfaleU85ZukWN6sgIommnNdOXnsy6lS9XOW/u0i3q1aBsBGHaacjSe/hUk8qXUeCNJzzfvMXf12+rZZF8ff0xYXCHIEIYXHhlNFVeSUqKhryWffbcE3OXb0MsmeT1/1EIWWZn6vwNava4rE4hk0ck3zc8wiv512W+zqu+eIW1jH717dJETR6TQ9pQRqUzZ0iFHu0bwsv7nZpJLvcjX+Sm5dTkvLL1uqklfeTVrUwgkhxgyUsMLrwyEie7vMnomrSt5E/OW7lDzaiXiUqmGeoc4XXeB4clnyPJx67ZagAkl7d/12aIHzeWmqwqr/llpN/alAahJW+dDh//Q238kiVjapz985paCuzp81dm4ZUfV5JWVbZ4PrRtXA2+fn7YtPNXrNq8X60YYxJemRwpOfSykUOihHHxz60HkBz8+tVLh/p2ytRqprcjkrM7dfj3QTackdHc6Qs3qo1gcmZNr3KWN+w4gt/PX1GrTiRPmvCTjW+J8Fr6GQv82bS0PUITXkueX2H1ansKr4xqy+REmZMibwllqTvZWEk2CpJdRTcvHKFG3sPbVmHdK/8e+QhQeJ24TWWJFpEbEU2RRJGrRAni4euCX6BDi5pBctnkS05y4MoW/wpHT/6pJoFIfpSkLuTJlSUIBRkRnL10i3rAy0S2pEkSIt/nnynR+iJHJnWufAnIEmFb9x5XQixSJiMusoxWywaV1RelHPLKX5bjevPWC5nTp1bL/EjOsKyjGHhrYcnxm7tsG54+f4lM6VKhbvWSWLPlIFIkTRhEeC29h5CaNfCEEvmi83CPqdaCFLFsXreCGpkOfAQXXlk+SdI/RJKfPH+FJAnjqXV7JV9Vlm0ySejQSYtx6Ng5+Pj6oWq5wiqPOTzCK1+4Irr3Hz1FymSJlKwGX/1A0ipGTlmmJndI/UUAnr14pXIbA68fLLPEZVKIvM5NED8uZI1fGa0PaSb4rycvqKV/ZBRFRr8kN1L6iSycbzoovM774LD0WSCf66GTluDshauIGdNVbcGd5/PPVD8Kj/CKKMtnX95SxIjhop4/8sZB/i3wdrTS/8bPWo1/7zxQnzH5Qe/n/x7rth00C6/k0Yu0ykivxJW3Dd9UKY4W9Sqp3NmwDlkqrFSdH1QOr6x6ErjMrbuP1A9zWVNb3nbJBGB5RnZuXVt9ZkI7LBFeKW/JZyz4Z9OS9ghNeC15foXFzZ7CK3UR6ZVn0ZHf/sDjpy9VTrS0gQyMVC5TCEbaKqx75d8jHwEKb+Rr0xDvKDThchYEkeEenIU16xl5CfBzFHnblndGAiTwaQIU3ijSOyLDl1xkuIco0t14mw5MgJ8jB24cVo0ESMBmBCi8NkPrWIEjw5dcZLgHx+oVrE1UJMDPUVRsdd4zCZAAhZd9gARIgARIgARIgARIIFIToPAabF7Pt74GI7A4CZCATgJxY316LWad1wkt1ubdR9VSe1sWjQj1krsPnsTPy7fj5p0HauKnrAPdp0sTNVlQDqPPlxgu0eESPRr83r+Hv3+AvW4/0l5HWMrh/54sdTSym2t0+Ph+2DnNWQ5HeL44CytHqyeF12CL3HvqZTACi5MACegkkDKRh1rCKiKOR09eoEXXkXj+8jWSJUkYpvCu3LRPrfCRJ9dnasmlHkNmokKpAmpZu4AA4P4zY88X+XKO6xFDibOnl19EIIlU14zjEUOtT230h0ikgmLgZuSz+uCZF5zp50OqxB4G7phFI5IAhdcgfQqvQYAsTgKaCUSk8Jpu5eCxc5g4d22Ywhv81qct2IAr125j+siuFF7N/UJHOAqvDor/xaDw6uXJaKEToPAa7CEUXoMAWZwENBNwZuFt12sCcmbNoHYw5Aiv5o6hIRyFVwPEQCEovHp5MhqF16Z9gMJrU7wMTgJWE3BW4ZVtdafMW692tJM0BxHel2+MzRFwd3OBu1t0ePv4w9vHuXIlrW54OxSI6RZdpTR4v/O3w9Ui/yUSxHHFi9fG+ri9KUmdeTgnAY7wGmw3Cq9BgCxOApoJOKPw7j54CsMmLcG8CT2RPUs6RUSE18vHWN6ta4zocHWJDl+/9/D1p/Aa7WrCUg6yNEryQ3kPtxjw9vFzqhzeWDFj6Ll5RrE7AQqvQeQUXoMAWZwENBNwNuFds+WA2spbttfNmimNmQZTGjR3DA3hmNKgAWKgEExp0MuT0UInQOENo4ccOXEB7XtPCHKW7L9+bu889W8UXn7ESMCxCDiy8ErawtFTf2L8oA4K2sxFm7Dtl+OYNvx7pEye2AzSwz0mgGhcpcGxuhYovHobhMKrlyejUXgN9QER3mGTFmPdvKHmOLLiUdw4sewmvNFeeyJlhuQIiB0H928+MnQ/LEwCkZ1ARArv/UfPUKftQPj5+cPL+516TtSoUAx9OjdW2CVHd9OuIziwbrL679ptBuLK9dsfNcmhDVOQOGF8Cq+DdVYKr94GofDq5cloFF5DfUCEd8SUpdi1YmyIcewxwkvhNdSELBzFCESk8OpEzZQGnTT1xKLw6uFoikLh1cuT0Si8hvqACG+nfpOQMH5cxIsTCwXz5kDXb+uq/18OCq8hvCxMAtoJUHj/Q8qNJ/R2LwqvXp4UXr08GY3Ca6gPPH/piYePnyN+vDh48OgpJsxeg6SJ42PSkM4qrl2WVPH0RIJUiYE4cfDi/jND98PCJBDZCcSP7RphO63pZMsRXp009cSi8OrhyBFevRwZzTICnLRmGSfzWWf/vIoWXUfhj1/mq/UY374ztmyQRZf39ESspImU8L598tyiIoFPun3nHhavWGtRucIF8qFc6eIWncuTSMARCchSRxG1tbBOHhRenTT1xKLw6uFoT+H1efcObjFlEqieg1sL6+EYEVEovFZSlxnWvYfPwa+bp6mSzpDScO36DYydMMWiO61QrjTq1q5l0bk8iQQckQBTGv5rFaY06O2hFF69PG2d0nDj2mUc3rcLFavVQcrUabVUnsKrBWOEBKHwhoF9/sodSJMyCb7MlQUvXr7GgDHz8VXurOjbpQmFN0K6LC9KAqEToPBSeG31GaHw6iVrS+H998ZV7N2xUVW4bKUayJQlu5bKU3i1YIyQIBTeMLDLupmL1uzCnXuP1RJDFUoWQLfv6sHD3Y3CGyFdlhclAQqvpX2AI7yWkrLsPAqvZZwsPctWwnv39k3s2LxaVaN0+WrIki2npVUK8zwKb5iIHPYECq/BpmFKg0GALE4CmglwhJcjvJq7lDkchVcvWVsI74N7t7Fj81r4+/uhaIlyyJU7n9ZKU3i14rRrMAqvQdz2EF6DVQRzeI0SZHlnIkDhpfDaqr9SePWS1S28Tx4/xNb1K+Dn54tCxUojd94CeisMgMKrHandAlJ4DaKm8BoEyOIkoJkAhZfCq7lLcYTXRkB1Cu+zp4+xZf1y+Pr4IG/+Ishf2DarDVF4bdQZ7BCWwmsQMoXXIEAWJwHNBCi8FF7NXYrCayOgOoX3j99P4OTxQ/j8y/woUryMjWrMEV6bgbVDYAqvQcgUXoMAWZwENBOg8FJ4NXcpCq+NgOoUXqmiTFZLnTa9jWr7ISxHeG2K16bBKbwG8VJ4DQJkcRLQTIDCS+HV3KUovDYCqlt4bVTNIGEpvPagbJtrUHgNcqXwGgTI4iSgmQCFl8KruUtReG0ElMJrI7AMGyIBCq/BjkHhNQiQxUlAMwEKL4VXc5ei8NoIKIXXRmAZlsJriz5A4bUFVcYkgfAToPBSeMPfe0IvyWXJ9JKl8OrlyWihE+AIr8EeQuE1CJDFSUAzAQovhVdzl+IIr42AWiu8vr4+cHX9sMtpRB3M4Y0o8savS+E1yNAewhvttSdSZkiOgNhxcP/mI6trzI0nrEbGAk5MgMJL4bVV9+UIr16y1giv7JwmO6ghIACVqteFq1vEiC+FV28fsGc0Cq9B2hRegwBZnAQ0E6DwUng1dymO8NoIqDXCu2PzarXsWLz4CVGrXjPEdHe3Ua1CD0vhjRDsWi5K4TWIkcJrECCLk4BmAhReCq/mLkXhtRFQS4V3746N+PfGVcSNGx816zWFR6zYNqpR2GEpvGEzctQzKLwGW4bCaxAgi5OAZgIUXgqv5i5F4bURUEuEd9+uLbhx7TJix4mLmnWbqv+NyIPCG5H0jV2bwmuMHyi8BgGyOAloJkDhpfBq7lIUXhsBDUt4D+/fhSuXzsPd3QO1GjRXI7wRfVB4I7oFwn99Cm/42amSFF6DAFmcBDQToPBSeDV3KQqvjYCGJrzHDv+Ci+fPqFzdGnWaIkHCRDaqhXVhKbzW8XKksym8BluDwmsQIIuTgGYCFF4Kr+YuReG1EdBPCa+vjw82rlkMr7dvUK12YyROksxGNbA+LIXXemaOUoLCa7AlKLwGAbI4CWgmQOGl8GruUhReGwENbYTX5907vHr1AkmSJrfR1cMXlsIbPm6OUIrCa7AVKLwGAbI4CWgmQOGl8GruUhReGwENK4fXRpc1FJbCawhfhBam8BrEbw/hNVhFcOMJowRZ3pkIOKPwbt59FPNX7sCWRSPMqAMCgPvPvAyhjxvLFXE9YsDzrS88vfwMxWJhgBtP6O0FFF69PBktdAIUXoM9hMJrECCLk4BmAs4kvI+evECLriPx/OVrJEuSkMKruS/oDkfh1UuUwquXJ6NReG3aByi8NsXL4CRgNQFnEl7TzR08dg4T566l8Frd2vYtQOHVy5vCq5cno1F4bdoHKLw2xcvgJGA1AQrvf8iY0mB19wm1AIVXL89EsaPj+Zv3CNAb1qbRmMNrU7w2Dc6UBoN4KbwGAbI4CWgmEJmE98UbH0N0PNxc4O7mAi8ff3j7+BuKxcJQLKMhGrx8mA9ttD88uH8Pm9evQvVa9ZAqTVqj4exWPmEcN7tdixfSS4DCa5AnhdcgQBYnAc0EIpPwGpVU1xjREcMlGnz93sPP35nG0TR3Ck3hhCWiAX5+ZGkE6YMH97FyxVLIervZs+dEjVq1jYSza1mPmC52vR4vpo8AhdcgSwqvQYAsTgKaCUQm4eUqDZo7h8FwTGkwCBDAi+fPsGntEiW76dOnR8XqDZjSYBwrI1hAgMJrAaTQTqHwGgTI4iSgmQCF9z+gzOHV27kovMZ4vnr5HJvXLoO3txeSpUiFNq1a4qmnH4XXGFaWtpAAhddCUJ86jcJrECCLk4BmAs4kvPcfPUOdtgPh5+cPL+93iBsnFmpUKIY+nRuD6/Bq7hgawlF4ww/R0/Olkl3ZLjhR4qSoUbcJ0iWPjwfPvCi84cfKklYQoPBaASukU+0hvNFeeyJlhuQIiB0H928+srrG3HjCamQs4MQEnEl4Q8NM4XW8TkjhDV+biORuXLMEb157IkHCRKhRpyliuruDy5KFjydLhY8AhTd83MylKLwGAbI4CWgmQOH9DyhTGvR2Lgpv+Hhe+esCDu/bifgJEqF6ncbw8IilAlF4w8eTpcJHgMIbPm4UXoPcWJwEbEWAwkvhtVXfovCGn+zFC2eQIeNniB0nrjkIhTf8PFnSegIUXuuZBSnBEV6DAFmcBDQToPBSeDV3KXM4Cq9eshRevTwZLXQCFF6DPYTCaxAgi5OAZgIUXgqv5i5F4bURUAqvjcAybIgEKLwGOwaF1yBAFicBzQQovBRezV2KwmsjoBReG4FlWAqvLfoAhdcWVBmTBMJPgMJL4Q1/7wm9JFMa9JKl8OrlyWihE+AIr8EeQuE1CJDFSUAzAQovhVdzl+IIr4VAfX194erqauHZXKXBYlA8UQsBCq8VGCfMXoMFq3bg4sFF5lIUXisA8lQSsAMBCi+F11bdjCO8nyZ7YO82vHr5AlVrNUCMGJZJL0d4bdVTGTckAhReC/vFojW7sOvASVz464bdhdfCKn7yNG48YZQgyzsTAQovhddW/ZXCGzLZXw/uwV9/nlN/rF67EVKkSmtRE1B4LcLEkzQRoPBaAHLLnqNYv/0wBv/YEtWb96XwWsCMp5BARBGg8FJ4bdX3KLwfkz1x9ADOnz2l/lC2Ug1kypLdYvwUXotR8UQNBCi8YUA8/NsfmLZgIxZM7IVXr9+iQsMeQYT38ct3GprBtiGuXruB0eMnW3SRiuXLoH6dWhady5NIwBEJJIkXE9GiOWLNrKsTtxa2jpc9zqbwBqV89vRxnP7tiPrH0uWrIUu2nFY1A4XXKlw82SABCm8oAG/cuo8fBk3H/Ak9kTRxAtx98OQj4fX1e2+wCWxf/PLf1/HTyIkWXahapbJo2rC2RefqPGnuwuV48PBxmCFjuMRAv56dwzyPJ0RdAjFcolN4/9/83FpY7+eAwvsfz4vnz+DY4V/UPxQtUQ65cuezGjaF12pkLGCAAIU3FHgyutul/1REi/7/4aKAAPj6+cPVNQamDf8exQvlhj0mrRloX1XUGXJ4h48ch1t37oR5q26urpg+ZXyY5/GEqEuAKQ3/tT2FV+/ngML7geeVS+dxeP8u9f8XKlYaufMWCBdoCm+4sLFQOAlQeK0AF9IIL4XXCoChnErh1cORUT4sdcSUhg89gcKr9xNB4f3Ac/3KhXj29DHy5i+C/IWLhxsyhTfc6FgwHAQovFZAo/BaAcvKUym8VgLj6Z8kQOH9Dw2FV+8HhcL7gae3txf+vnQBufMVNASYwmsIHwtbSYDCawUwCq8VsKw8lcJrJTCeTuG1oA9QeC2AZMUpFF4rYFlwKoXXAkg8RRsBCq9BlExpMAjw/8UpvHo4MgpTGgL3AQqv3k8EhVcvTwqvXp6MFjoBCq/BHmIP4Y322hMpMyRHQOw4uH/zkdU15qQ1q5GxgBMTYErDf41H4dXbkSm8enlSePXyZDQKr037AIVXD16O8OrhyCgc4eUIr+0+BRRevWwpvHp5MhqF16Z9gMKrBy+FVw9HRqHwUnht9ymISsLr6+MDVzc328HEh8/qg2deCLDpVfQGT5XYQ29ARrMbAaY0GERN4TUI8P/FKbx6ODIKhZfCa7tPQVQRXk/Pl9i0egmKFC9r9e5p1tCn8FpDi+caJUDhNUiQwmsQIIVXD0BGMRMInMMr24EfP30R1/+9i2cvPBEQEIDECeMhS8Y0KPxVTsSLE8thyXFrYcdrmqggvK89X2HL+uV489oTSZImxzcNWtisISi8NkPLwCEQoPAa7BYUXoMAKbx6ADJKEOG9eecBZi3ZjB37fkP8uHHwRY5MSJo4Pt75+OLBo2e49u9deL5+i6pli6BDixpIlzq5wxGk8DpckyCyC6/X2zfYvHYZZIQ3XvyEqFWvGWK6u9usISi8NkPLwBRe/X2AwquHKVMa9HBkFOCX/Ucw6ee1KF7oCzSuVQ4F8mSHi0v0IGj8/P1x/PQlLFm7G6fPX0GP9vXRpHZ5h8JH4XWo5lCViczC+87bG5vWLsWrl88RN2581KzXFB6xYtu0ESi8NsXL4MEIcITXYJeg8BoEyBFePQAZxUygfuteGDewPYrkz2URlb2HT6P/6Hk4uWO2Refb6yQKr71IW36dyCq8MkFN0hhku+DYceKiZt2m6n9tfVB4bU2Y8QMToPAa7A8UXoMAKbx6ADKKmYCv1yukT2NdisKV67eRLXNawxTfvw/A+FmrsHHnEfj6+aFs8a8wpEcruMcMebb7Wy9vjJq2AkdPXYC//3vkypYBA7o2Q6oUSUDhNdwc2gNERuH18/PF1vUr8OTxQ7i7e6BWg+ZqhNceB4XXHpR5DRMBCq/BvmAP4TVYRXDjCaMEWd6ZCETkxhOrNu/H4jW7MGNUN8TyiImeQ2fhy1xZ0KN9gxARDp+8FE+fv8To/u0Qw8UF42atwpXrt7BwUh8KrwN2usgovPfv3sa2jSvhFjMmatZthgQJE9mNPIXXbqh5IQAUXoPdgMJrECBHePUAZBQzgcDCu2XPUVy5dhs9OzZUfx82aQl2HTyJ3DkyY2TftkgYX+9r2xZdR6Hs1/nQvF5Fdb1Dx//A0ImLsW/txBBbSM4vmCc7OrX6Rv394LFzGDF1GfauGk/hdcA+HRmFVzBfv/oXEiRMjMRJktmVOoXXrrij/MUovAa7AIXXIEAKrx6AjBKi8NZuMxB1q5VC42/K4siJC+jUb5IabZX/P3nShBjeu41WciVrd8WwXq1RovCXKu7NOw9RpWlvnN41Fx7uH6c1/HLkd/QZMQeNvymHmpW+xtgZK1G+RH7UrVaSwqu1ZfQEi6zCq4eO9VEovNYzY4nwE6Dwhp+dKknhNQiQwqsHIKOEKLz5K32HFTMHIWumNBg/ezX+vn4bc8f1wF9Xb6J974k4tGGKVnIFq7THtBFdUShvDhX34ePnKFOvG45smoZECT4eTX7w+Bl+/GkmMqVPhSMnzqt1gaW85CBLDu+L1z6G6ucR0wXubi7weucPbx9/Q7FYGHCP6YJoiAavd37EoYFAwrhueO5prI9rqIZVIaTOPJyTAIXXYLtReA0CpPDqAcgoIQpvsZqdsWRqP2ROnwpNO49A4Xw50bn1N2rkVUZ/f989Vys5GeEd0actvi74hYob1ghvo47DUL96KXxTuThkqbRp8zdg8+6j2LNyHFxdXeHta0xSXV2iI4ZLNPj6v4efvzNt4Kq1WbQFixE9GhANZKmJqLurC975+jvV1sIebi6a7p5h7E2AwmuQOIXXIEAKrx6AjBKi8Hb/aSa8371Dvi+yYtLctVg+YwDy5MqiVlFYuGontiweqZVc8+9HqpSEZnUrqLgHjp3FkAmLOwD0jgAAIABJREFUcXD95I+uI7u+5SnXFstnDsDn2TKqv5tGhH9ZPQEpkiXG/WdehuoXN5Yr4nrEgOdbX3h6cVTSEMxIvg6vUTbhKc+UhvBQY5nwEqDwhpfc/8tReA0CpPDqAcgoIQrvoycv0HvEbMiyY3WrlkT3dvXVSGr15n2VmMp/6zyWb9iLZet/wazRskqDO34cMhM5s6ZH3y5N1GVEtI+e+hPjB3VQ/92m+1jEjxdHjQrHdHPFnGVbsHPfCSXiXJZMZ8voieXMObyy1q6rm2O9jqfw6umXjGIZAQqvZZw+eRaF1yBACq8egIwSovDaG4uspTtmxkrI6hB+fn4oXSyvWodX5FeOKfPWY9OuIziw7sOI7+OnLzB6+gqc/uMKokWLhtw5M6FPp8Zch9feDWfh9ZxVeM+fPYVL58/YZfc0C1Gq0yi81tDiuUYJUHgNEqTwGgRI4dUDkFHMBFzhg6SJrVs4/+WrN4gfz7bbqFrbRBzhtZaY7c93RuG9eP4Mjh3+RcEpWa4Ksmb/3PagLLwChddCUDxNCwEKr0GM9hDeaK89kTJDcgTEjoP7Nx9ZXWNuPGE1MhZwYgLNOw7A9BFdkT1LOovu4p9b99G5/xRsXzraovPtdRKF116kLb+OswnvtSuXcGDvNnWD+QsXR978RSy/WTucSeG1A2RewkyAwmuwM1B4DQL8f/HhI8fh1p07YQZzc3XF9CnjwzyPJ0RdAguXrcPqLQdQv3ppNK9XAelSh7zN8P2HT7Fi4z4sXb8H9aqVRP+uzRwKGoXXoZpDVcaZhPfGtcvYt2uLqnfuvAVQqFhphwNK4XW4JonUFaLwGmxeCq9BgBRePQAZxUxAvkRPnLmEKfPX4/yl68iZNQNyfJYOKZImQvTo0fHg0TNc/ecOzl28plZs+L5tHfO6uY6EkcLrSK3xoS7OIry3b97Arq3rVJ2z5cyNEmUqOR5M5vA6ZJtE5kpReA22LoXXIEAKrx6AjBJEeKNF+/CfssHErycv4No/d/H0xSu1aYBsAJElY2oUL5Tb4rSHiMBL4Y0I6qFf0xmE9+7tm9ixebW6kSzZcqJ0+WqOB/L/NeIIr8M2TaSsGIXXYLNSeA0CpPDqAcgoIQqvM2Oh8Dpe6zmD8P6yczP+uX4FmT/LgTIVqzsexEA1ovA6dPNEuspReA02KYXXIEAKrx6AjELhDaEPcOMJvR8MZxBef38//HHmJPIVKKr35m0QjcJrA6gM+UkCFF6DnYPCaxAghVcPQEah8FJ4bf4pcAbhtTkEjReg8GqEyVBhEqDwhoko9BMovAYBUnj1AGQUCi+F1+afAgqvXsQUXr08GS10AhRegz2EwmsQIIVXD0BGofBSeG3+KaDw6kVM4dXLk9EovDbtA/YQXqM3wI0njBJkeWciIF+iplUanKnewevKSWuO13oUXr1tQuHVy5PRKLw27QMUXj14ufGEHo6MAoQkvN7vfPDw8XOkTxPyJhSOyI3C63it4ijC6/PuHdxixnQ8QFbWiMJrJTCebogAUxoM4QMovAYB/r84hVcPR0YJKrzPX3pi4JgFOHDsrEJz8eAi+Pu/R73vBqNkkTzo2raOwyKj8Dpe0ziC8L7z9saW9cuQLkNmh9w9zZpWo/BaQ4vnGiVA4TVIkMJrECCFVw9ARjETCDzC23vEHDx59hK9OjZC7TYDlfDKsX77YSxdtwebFg53WHIUXsdrmogWXl9fH2zbsBJPHj+ER6zYqN+krVOP9FJ4Ha+PR+YaUXgNti6F1yBACq8egIwSovB+XbMLFkzqjayZ0iBXqZZm4ZUd2Jp2HoHfd891WHIUXsdrmogUXj8/X2zftBqPHtyDu7sHatZrinjxEzoeJCtqROG1AhZPNUyAwmsQIYXXIEAKrx6AjBKi8Oar8C02LxqBtKmSBRHeIycuoNewWTi+babDkqPwOl7TRJTwymYSOzavxYN7t+Hq5oZa9ZojQcJEjgfIyhpReK0ExtMNEaDwGsLHHF6D+MzFmcOriyTjBE5p+LbHeOT/MhvaNatuFt53Pr7o0HsiYsdyx7QRXR0WGIXX8ZomooR3x+bVuHv7Jlxd3VCtdiMkSeo8ky9Da0UKr+P18chcI6cT3jbdx2LikE6IHzd2kHY5c+Eq1m07iJF9v9XaXr+evICZizbh+s17eP/+PXJly4hB3VsgU7qU6joc4dWDm8KrhyOjBJ20duX6bbTsOgoF8mbHviNnULtKCZw8+xdkMtvyGQPwWcY0DouMwut4TRMRwrt3x0b8e+MqYsRwRdVaDZAsRSrHAxPOGlF4wwmOxcJFwOmEV/LwDm2YgiSJ4ge5Yflia9B+CM7tnRcuEJ8qJMIbLVo0ZMucFn7+/hg7YxXeenlj9pjuFF6NpCm8GmFG8VDBlyW7//Aplm/8BZeu/Iv3AQHqs9y0TnmV5uDIB4XX8VrH3sL78sUzbFi1GJK/W7VWQ6RKk87xoBioEYXXADwWtZqA0wivjMjIIZNQtiwagUQJ45lv1sfHD0vW7sauAyexb+1EqyFYUiAgIACPn77E0ImL8Xn2jGjfvIbdhDfaa0+kzJAcAbHj4P7NR5ZUN8g53HjCamQs4MQEuPHEf40XN5Yr4nrEgOdbX3h6+TlxqzpG1e0tvHLXDx/chSxFJsuQRbbDHsJ76fIV7Nt/SKGLFzcOypYphTSpwz9KniqxR2RrhihzP04jvDKyG9rh4e6Gn3q0QrVyRWzSeC26jsLpP66gbrWSGNy9JaJHj6auc/+Zl02uFzhoNE9PpBDhjRMHD2wsvOXLlUa92rVsfk/BLzBsxDjcvnsnzOu6xnDFjKnjwzyPJ0RdAikSBt1p7Z9b93Hx73/x5s3Hn9UGNcs4LCiO8Dpe00SE8DoeBX01sqXwvnrlid79B+OXfQeDVDhu3Djo37cn6tSqHq4bofCGC5tDFHIa4f3zyj8KWIN2QzBn7I9IED+OGaC7mxtSpUiCWB623Xnm0ZMXGDx+IdKkTIL+XZup68uXks0PT09Eix8PiBMHh3fuw/2Hlo3yflO9IlxdXXH57+sYONwySaxeuRyaN7L/Yvy9BozEP7duh4nSzdUVy+dPDfM8nhC1CZi2Fl60ehfGzVqlng0q7z/YnsO/rJ7gsKAovI7XNBRevW1iS+Ht0KX7R7IbuPbLFv2MQgW/svqGKLxWI3OYAk4jvCZiktqQIF4clVcbEYcsZ9Rv1Fwc2TRNXd4ek9YCpzT06zUMFy5esujWJ48bhVixY4EpDRbh4kmRhEDglIYS33yPGhWLoft39c1vZZzlNim8jtdSFF69bWIr4T1x8nc0bRn6BHYZ6T1z4rDVN0ThtRqZwxRwOuEVcrfuPsKFyzfw+vXbj0Da+hWl5AmPn70appEhCq+evsxJa3o4MkrQVRoKVG6PiT91QvFCXzgdGgqv4zUZhVdvm9hKeKdOn41pM8PeVObA3m1W5/NSePX2AXtGczrhXbP1IIZNWgwXFxf1itKUS2uCdmDdZK38hk9eigJ5suHLXFnw6PFz9B31M8p+nQ/d29XnCK9G0hRejTCjeKjgWwsnThAPvTo1cjoqFF7HazJbCa+vj4/aUCKqHbYS3vadu5knqoXGNDxpDRRe5+2lTie8Zep1Q8kiedCvSxO4usawOfml6/Zg3fZDuHPvsUqlqFa+CDq1rAU3N1cKr0b6FF6NMKN4qMDC++TZS9RqNQCNa5eDS/TokNVWAh+m1VYcERmF1/FaxRbCK2vsHtq3AzXrNosUu6dZ02q2El5LR3h//+0Q4sWLa02VQeG1CpdDnex0wvtVxe8weWhnFC+U2yFAMqVBTzNQePVwZJSgKQ0zFm7EzMWbkTRxAiSM/3Hu/4b5w7Qie/8+AONnrcLGnUfg6+eHssW/wpAereAe89Ojdw8fP8eUeetw5MR5vPR8g7ED2qNS6YJqQqzRVWC4LJnW5oVu4b3173Xs3rZeVfLLrwqhYJGSeivs4NFsJbx37t5D6fLVQr37Avm/woolP1tNiMJrNTKHKeB0wvvDoOnImikNOra0/9JZIbUahVdPX6bw6uHIKEGFt3C1jmjdsDK+axq+JYis5blq834sXrMLM0Z1UytD9Bw6S6VD9WjfIMRQIrh12g5CxVIFUK9aKcSLG1stJJEwflwKr7Xw7XC+TuGVrYJly2A5MmXJjrKVPqztHpUOWwmvMAxtlDdOnNjYunG11fm7EpfC67w91OmEd8XGfZg0dw1G9PkWbiGkNJQqmseurWEP4Q18Q9NmzOEqDVMsW2LNrh2BF3MYAoFTGopU64ixAzvYbdKarNctOf7N61VUPA4d/0NtVvOpDXGmzl+Puw+eYEz/dh/x4wivw3Qpc0V0Ce+jB/ewbeMq+Pv7IUOmz1C+yjeOd7N2qJEthVeqv2jJckyZPhuvX78x3032rJ9hzOihyJk9W7jukMIbLmwOUcjphPeLMq1CBXdh/0K7gqXw6sHNEV49HBkl6AjvqGnL4f3OR6UV2OMoWbsrhvVqjRKFv1SXu3nnIao07Y3Tu+ZCNscJfsjobtLE8dV5Dx4/R44s6dQGOvIWi8Jrjxaz7ho6hPfJ44fYtmElfH19kDZ9JlSqXte6SkSis20tvCZUskyZHKlTpwzXqG5g5BRe5+2ATie8joaawqunRSi8ejgySlDhHTJhEdZuO4RGtcpANi0JfvTs2FArsoJV2mPaiK4olDeHiiv5uTLRVtbtTpTg48kxRat3QuNvyqFJnXKqftMXbsSeg6ewc/kYtWnM89c+hurnEdMFHm4u8HrnDy8ff0OxWBiKpeSceL0L3zbNz589xZoVi+Hj8w6p0qRFnfpNozTWRHHd8NzTB/bYv0kXaKkzD+ckQOE12G4UXoMA/1+cwquHI6MEFd423ceGimT+xF5akckI74g+bfF1wQ/r/oY1wlu0RidMGtLZLMhe3j4oULkd1swZjByfZcA7X2OSGsMlOmK4RIOf/3v4+TuTVmhtFm3BXFyiQbY8Ci/LQwf347fjx5AqVWo0bNxU/aiJykdMVxfDfdze/NzlRw8PpyTgdMK7Y9+JUEFXKVvIrg1B4dWDm8KrhyOjBBVee/No/v1IlC+RH83qVlCXPnDsLIZMWIyD60NeH7xh+yGoXqEomtQur85/6/VOCe/eVeORMnkSrtJg7wYM43o6UhrO/f4bcn6RD25RcN3d4HjtldKgsxsxpUEnTfvGcjrhLVS1w0eEZCmgt17eiBPbAye2z7IrQQqvHtwUXj0cGSVihXf5hr1Ytv4XzBotqzS448chM5Eza3r07dJENY0sV3b01J8YP+jDc0w20pGl0+aM/RHpUidXy5Nd+vsmlk7rxxxeB+zMOoTXAW8rwqpE4Y0w9FHywk4nvCG1kp+/P2q3GYQf29VHySIfJovY66Dw6iFN4dXDkVE+CG+Zej+gf9dmmLloU6hIdK/D6+//HmNmrMSWPUfh5+eH0sXyqglzIr9yTJm3Hpt2HUHgHSEXrNqBZev34s1bbxQr8Dn6fd8USRLFp/A6YGem8OptFAqvXp6MFjqBSCG8coubdv2KJWt3Q/cXWFgdiMIbFiHL/k7htYwTzwqbgHyJyuYPVcsVVqOpoR3fNgl9cfqwr2a7M7hKg+3YhjcyhTe85EIuR+HVy5PRoojw7jtyBj2HzcKZPdbvnGKkk1B4jdD7ryyFVw9HRonYlAad/Cm8OmnqiUXh1cPRFIXCq5cno0Uy4T159nKQOwpAAJ49f4W5y7bCwz0mVswcaNc2t4fwRnvtiZQZkiMgdhz06zWMG09w4wm79nFnu1jgjSdk3W5JH5AUgcDHkRMXMGLKUuxaEfoqDhF57xTeiKQf8rUpvHrbhMKrlyejRTLhzVWq5Ud3FMPFBblzZsKQnq2RKV1Ku7Y5hVcPbo7w6uHIKEFHeOV5cWjDlI+E9/K1W2jYYSjO7Z3nsMgovI7XNJYI76njh/E+4D0KFS3leDfgYDWi8DpYg0Ty6jhdDq+sxhD8cI8ZE9Gjy+qI9j8ovHqYU3j1cGSUD8K759AphaL7TzPUpLG4cWKZ0fj6+mHDjsN46fkG6+cNdVhkFF7Ha5qwhPf8mZM4cewgXFxioG7jVogXP6Hj3YQD1YjC60CNEQWq4nTC62htQuHV0yIUXj0cGeWD8Bao/J1CIRs5uMd0k82xzEfMmG74LGMa9OncGNmzpHNYZBRex2ua0IT34vkzOHb4FyW7VWrWQ4pUaR3vBhysRhReB2uQSF4dpxTe/UfPYt7ybbj2713VPFkypMZ3TaujVNE8dm8uCq8e5BRePRwZJWhKQ42W/bFkSl8kiB/H6dBQeB2vyT4lvNeuXMKBvdtUhavUbIDUadM7XuUdsEYUXgdslEhcJacT3nXbDmH4lKWoX70UcufIrJrm3MVrWLf9EAZ3b4FvKhe3a3NRePXgpvDq4cgoXKUhcB+IG8sVcT1iwPOtLzy9/Ng9DBIISXhvXLuMfbu2qMiVqtdF2vSZDF4l6hSn8EadtnaEO3U64a3cpBda1K+EhjXLBOG3YuM+LF23BzuXj7ErVwqvHtwUXj0cGYXCS+G13acguPDevnkDu7auUxcsW6kGMmXJbruLR8LIFN5I2KgOfEtOJ7xflm2DdfOGqBy8wMffN+6g3reD8ce++XbFTeHVg5vCq4cjo1B4Kby2+xQEFl4fHx+sWDQTvj4+KFG2MrLl+MJ2F46kkSm8kbRhHfS2nE54KzXuhdYNK6N+jdJBkC7f8AuWrZcRXvuuq0nh1dOzKbx6ODIKhZfCa7tPQfAR3qdPHuHxw/vInsu+W9rb7g7tG5nCa1/eUf1qTie8a7YcwKjpK1QO7xc5PuRK/XHxGtZuO4QBXZuhbrWSdm1Tewhv4BuaNmMON57gxhN27ePOdrHAG084W90D15eT1hyv9cJalszxauzYNaLwOnb7RLbaOZ3wSgPsPXwaPy/fhuv/3lPtYVqloWzxfHZvHwqvHuQc4dXDkVFCH+H19fPHzdsPkCZVUrVcmSMfFF7Hax0Kr942ofDq5clooRNwSuF1pEal8OppDQqvHo6MElR4x89ejX9u3ceMkT+oNXmbdBqGK9dvq2XK5k/oxXV42WGsIkDhtQpXmCdTeMNExBM0EnAa4f3r6k2Mn7UavTs3RtZMH09YGzNjBfp2boIsGVNrxBN2KApv2IwsOYPCawklnmMJgcApDRUb9UT3dvVQsVRBbN1zDCOmLsOiyX2w7ZfjuHLtNn4e38OSkBFyDkd4IwR7qBel8OptEwqvXp6MFklGeAeMmY8Hj59h3vieId7Rdz3HI22qZBjYrbld25zCqwc3hVcPR0YJOsKbp3xbbFk0AulSJ8eQiYvx8tUbTPypI/69/QANOwzFb9tmOiwyCq/jNQ2FV2+bUHj18mS0SCK8sv5up1bfoFq5IiHekYzezFy8KVKu0hD4hjlpzRXTOWmNz7VQCAQe4S1Trxsm/tQJeXJlQbXmfVG3akm0bFBJpTW07DoKxym87EuhEPD29sLubetRvHRFJEqcFBRevd2FwquXJ6NFEuHNW+FbLJvWH7myZQjxjs5fuo7m34/EuV8i3zq8FN7/CLi5Unj5UAudQGDhnTB7DfYcOoWM6VLg+OlL2L5sNNKkTIrZS7bg0G9/YOXMgQ6LkyO8Eds077y9sXXDCjx/9gQZMmdF+cq1KLyam4TCqxkow4VKwGlyeAtX64hxA9ujeKHcId7Q/l/PoM/IuTi5Y7Zdm5wpDXpwM6VBD0dGCZrSIKsyyIouf1+/jZqViqF00bzw8/dHt0HTUb5kftSoUMxhkVF4I65pfH19sGXdcjx7+hgpUqVFlZr14OISg8KruUkovJqBMlzkEN42P45F6hRJMLRn6xBvqPfwOSrHd/GUvnZtcgqvHtwUXj0cGSWo8E5bsAGliubFF9kzOh0aCm/ENJmfny+2b1qNRw/uIUnS5KhepzFixHBVlWFKg942ofDq5clooRNwmhHeA8fOonO/KRjwQzPUr14aLi7R1Z3JaM2y9XsxbuYqjB/UAZXLFLJrm9tDeKO99kTKDMkREDsO+vUaxo0nmMNr1z7ubBcLnNKQr8K3GDewAyJijW6j3Ci8RgmGr/zWDSvx4N5tlbNbo04TuLr9t14zhTd8TD9VisKrlyejRRLhlduYtWQzpi/YiMQJ4yFb5nQIQAAuX72F5y890bphFfzYvr7d25vCqwc5R3j1cGSUoCO8rbqNRskiedCyfiWnQ0PhtX+T7dq6Drdv3kC8+AlRq14zxHR3D1IJCq/eNqHw6uXJaJFIeOVWrv5zB9t/+Q03bn3YZS196hSoXKYgcmYNeTKbrTsAhVcPYQqvHo6MElR4T5z9C31GzMHKWYMQL06sj/DE8ggqNI7Ej8Jr39b4689z+PXgHsSNlwA16zaBR6zYH1WAwqu3TSi8enkyWiQTXkdrUAqvnhah8OrhyChBhTdXqZahIrl4cJHDIqPw2r9pzv3+G7JkzYk4ceOFeHEKr942ofDq5cloFF6b9gEKrx68FF49HBklqPCeufB3qEjyfZHVYZFReB2vaSi8etuEwquXJ6NReG3aByi8evBSePVwZJSgwuvMPCi8jtd6FF69bULh1cuT0Si8hvrA7oMn8fPy7bh55wHcY7qhXPGv0KdLE8R0+7BMDYXXEF5zYQqvHo6M8rHw+vu/x827D/HWy/sjPJ9n07tc2fv3ARg/axU27jwCXz8/lC3+FYb0aKWeHWEdsknGglU7YEqzoPCGRcz+f6fw6mVO4dXLk9EovIb6wMpN+5AoQVzkyfUZXrx6jR5DZqJCqQLo0ro2hdcQ2aCFKbwaYUbxUIGXJbvw1w107DsJz154hkhFdw7vqs37sXjNLswY1Q2xPGKi59BZ+DJXFvRo3yDUVlm0Zhd2HTgJqS+F13E7MIVXb9tQePXyZDQKr9Y+IAvZX7l2G9NHdqXwaiRL4dUIM4qHCiy8zbqMQKIE8dSShY06DsPs0d2RJlVSdOg9EU3rVkC1ckW00mrRdRTKfp0PzetVVHEPHf8DQycuxr61Ez95nS17jmL99sMY/GNLVG/el8KrtUX0BqPw6uVJ4dXLk9EovFr7QLteE9QSaF3b1rGb8Aa+gWkz5nDjCW48obVPR7ZggYW3QOX2mDehJ77MmRkVG/XEpCGd1Od3w47D2LDjCJZN76/19kvW7ophvVqjROEvVdybdx6iStPeOL1rLjzcP05rOPzbH5i2YCMWTOyFV6/fokLDHhRerS0SNNi1K5fwz42/Ub5yrXBdhcIbLmyfLETh1cuT0Si82vqA5OVNmbceG+YPU2kOcvj5B+D23ft49SrkV6bBL541S0a4urrC2/sdrv9z06K6JUyYAKlSJFPnjp4wA2fPX7So3IKZ4xE7dixc/vs6Bo+YYFGZapXLolnDDzIfnuP16ze4efuuRUWTJU2CpEkSqXN7DxyFf2/dDrOcm6srls6bEuZ5PCHqEnCJHg3Ron24/7wVvsWyaf2RK1sGNOk0HM3rVUDFUgUh6/N27DMJv++eqxVUwSrtMW1EVxTKm0PFffj4OcrU64Yjm6aZnxmmC964dR8/DJqO+RN6ImniBLj74MlHwvv8tY+h+nnEdIGHmwu83vnDy8ffUCxnL3zt6mXs3LpR3Ubt+k2QOk06q2/J3c1F9S3hycM4gURx3fDc0wcBxkPZLYLUmYdzEnCarYUjGu/ug6cwbNISNVqUPct/D8pHL7wxd94SnDj9u0VVHD1sIJImTYJbd+5iyPCxFpUpWaIomjf+kAM4ZfocnP/zkkXlpk4YpYT36rUbGD3eMkmsWL406tcJ3+iHVOrCxUuYPG2ORfWrWa0KalT78Op3yPBxuHXnTpjlRHhnTRsf5nk8IeoSSBrf3Sy8Mqr7XdPqqFO1BGRS2LmLVzF5aBfMW7Edvxz5HXtX6e1LMsI7ok9bfF3wC9UAoY3wyuhul/5TES36/+08IAC+fv5wdY2BacO/x9cFc+OdrzGxiuESHTFcosHP/736cR5VjxvXr2HtmlXq9mvWqo3sOXKGC4WwBD7w5GGcQExXF8N93HgtrIsgP3p4OCcBCq8F7bZmywHMXroFs8f8iKyZ0gQpIas0zFuwBCctFN4RQz4I7+07dzFspGXCW6J4MTRt9GHbZEdPafjz4iVMnWGZ8NaoWgXVqn4QXubwWtAReYpFBAKnNCxbvxdurjFQv0ZpNdpav91PePK/9s47vsbrj+OfiCzEXjVaapaiZrWImtXQql0rfkZtIkaoTQSxidh71J41a+8qahSlpbV3rcRMIr/XOWkuich97r3nuSP5PP/095Nzvuec9/neJ++ce57z3H+E5M7OGNG3LbyrfKopptZCPl2Ho5pXKTSvX11W2XXwOIaMnY/dqyYYDRHfCu/N+8+M1kuogGcKF3h6JEfo03CEPouwKJajVr514yp+Wr1Edt+rcg0UKFTU7KFwS4PZ6OKtyC0NankyWsIEKLxGMmTKvLXYsP2QXHF5L0sGQ2kPdzc4OTnJY8kovK8hUnh5y7E1gTeFN25fxNFkZ/+8jJzZMiNLpnTKu7p49TYsWrUdU0eKUxrc0WPIFBTK/wF+6NJUtiW2RR04chpjBnZ4q20Kr/LpwJ1bN7Bx7TJERITjc6+qKFy0hEWNUHgtwvdWZQqvWp6MRuG1KAfqth6A8xff3lu6Z/VEZEyfhsIbhy6F16J0Y2UFBBISXgXhEwwhzvwNClkCcfJCREQEKpUrLs/hFfIrLvEMwNot+7Br5dsrvhRetbNz7+5tbFi9BOHhL1GqbAUUL2X5iRwUXrVzROFVy5PRKLy65gBXeGPjpfDqmm4MroFAZ//hGkpFFxEPoNrrxRdPWDYzyxbOxONHD1Dkk9IoW76SZcH+q03hVYLREITCq5Yno1F4dc0BCi+FV9cEY3CTCWzYvMPw0Jqxyt83rWWsiM1+TuG1DP2TsFCQCJ/HAAAgAElEQVT8df4MPilZ1rJAb9Sm8CpDKQNReNXyZDQKr645QOGl8OqaYAxuMgFbbmkwubMJVKDwqqSpJhaFVw3HmCgUXrU8GY3Cq2sOWEN4q5YugW69OiAqZSr09Q+w6xdPcEuDrunG4BoIxBXeqKgoHDx6BhcuRZ8PnTdXdnxeqrB86NSeLwqv/c0OhVftnFB41fJkNAqvrjlA4eUKr64JxuAmE3hTeMVRZJ37TcSfF68iW9boU1Zu3PoXBfLmRMjwbvKFD/Z6UXjtb2YovGrnhMKrliejUXh1zQEKL4VX1wRjcJMJvCm8vgOC8Sj0iTwGTJyqIq67/z6Ux4VlSJca44d0Njm+tSpQeK1FWns7FF7trLSUpPBqocQyqgjwHF4LSVJ4KbwWphCrKybwpvCW/qodZo7phU8K543VyokzF/B9zzE4snma4tbVhaPwqmOpKhKFVxXJ6DgUXrU8GS1hAhReCzOEwkvhtTCFWF0xgbjCO2usP4oVyhOrleOn/0LbXmMpvIrZWzNcZGQEtvy0EsVKlkWOnLms0jSFVy1mCq9anoxG4dU1Byi8FF5dE4zBTSbwpvB26T8JT58+x6gB7eUWBnGJVwt3HxyCdGk8MTGgi8nxrVWBK7wJk960bhmuX72M9BkyoV7jllaZFgqvWswUXrU8GY3Cq2sOUHgpvLomGIObTOBN4b155z46/TAef1++gfeyZJSxbty6h7y5syNkRDdkzZTe5PjWqkDhfTdpsbJ79fLfSJ0mHWo3aAZ3dw+rTAuFVy1mCq9anoxG4dU1Byi8FF5dE4zBTSYQ91iyV6+isO/wKcOxZPlyZ0f5MkWRLBmPJTMZrh1U2LFlPf6+cA6enmmk7HqkSGm1XlF41aKm8KrlyWgUXl1zgMJL4dU1wRjcZAIxwvv3lZvYvvcoUqVMgUrliuO9zPa7mhvfILnC+zaVXds24ML5s1Jy6zT0QcpUnibnhyUVKLyW0Hu7LoVXLU9Go/DqmgPWEF6vCuXQrHFDOY7gkOl88cTEMbrOKYM7NgHxS1Q8lNaqe5B8uYRzMic4OSVDcGBXlC1RyGEGR+GNPVV7d27B+bOn5PYFsbIrtjNY+6LwqiVO4VXLk9EovLrmAIWXK7y6JhiDm0xA/BJt5z8Gzs7OmDi0M5ySJcPAUXNw8uwFbFoUZHI8W1Wg8L4mf+PaFWxcuxSurq74pn4zpEsfvR/b2heFVy1xCq9anoxG4dU1Byi8FF5dE4zBTSYgfomW8W6H4GG+KFsyekVXvHGtcgM/7F41wa7frvbmYCm8saderO5myJQFGTNlMTknVFWg8KoiGR2HwquWJ6NReHXNAQovhVfXBGNwkwmIX6IfV/of1swZhvwf5jDU/7hSS6ybOwx5cmU3OaYtKlB4bUE94TYpvGrnhMKrliejUXh1zQEKL4VX1wRjcJMJxAhvUP92yJkts6F+s87DMKJv21j/FveFFCY3pmMFCq+OcM0MTeE1E9w7qlF41fJkNAqvrjlA4aXw6ppgDG4ygRjh1VLxzO55WorZpAyF1ybYE2yUwqt2Tii8ankyGoVX1xyg8FJ4dU0wBjeZgPgleuP2PU31sme1zcNPWjpH4dVCybplKLxqeVN41fJkNAqvrjlA4aXw6ppgDG4ygbgvnjA5gJ1UoPDayUS80Q0Kr9o5ofCq5cloFF5dc4DCS+HVNcEY3GQCFN7XyDxTuMDTIzlCn4Yj9FmEySytWeHWjas48st+fFmzLlzd3KzZtOa2KLyaUWkqSOHVhImFFBFwiooS6wi8zCVgDeGtWroEuvXqgKiUqdDXP4AvnuCLJ8xN1yRRj8LreMJ759YNbFy7DBER4ahY1Rv5C35sl7lK4VU7LRRetTwZjSu8uuYAhZcrvLomGIObTIDC61jCe//fu1i/ajHCX75EidKfo+Sn5U2ec2tVoPCqJU3hVcuT0Si8uuYAhZfCq2uCMbjJBCi8jiO8Dx/cx/pVi/Di+XMULloCn3tVNXm+rVmBwquWNoVXLU9Go/DqmgMUXgqvrgnG4CYToPA6hvCGhj7C2mUL8Pz5MxQoVBRelWuYPNfWrkDhVUucwquWJ6NReHXNAQovhVfXBGNwkwlQeO1feJ+EhWLdykUQ//0wb0FUqfGNyfNsiwoUXrXUKbxqeTIahVfXHKDwUnh1TTAGN5mALYX31asojJm6FGs270N4RASqVCiJIT1bwt3NNd5xbN39K2Yu3ojL127JMlUrlESfLk3h5uqCxHws2c8bV+PyPxeQK09+VPvqW5Pn2FYVKLxqyVN41fJkNAqvrjlA4aXw6ppgDG4yAVsK79J1OzF/+RaEjPBDCg839Bo6FcUK50XP9o3iHceStTuQPq0nPimcDw8fh6HnkCmo/kVpdGlVN1ELr3hA7cSxX1D6My+T59eWFSi8aulTeNXyZDQKr645QOGl8OqaYAxuMgFbCm8L3xGoUr4EfBp8Kfu959BJDB03HztWjNM0juA5q3H+wlVMHu6bqIVXEww7LEThVTspFF61PBmNwqtrDlB4Kby6JhiDm0zAlsJbsa4vAvxbwatsMdnvy9duw7tZbxzdMgMe7vFva3hzgO38x6JQ/lzwbVOPwmvyzOtfgcKrljGFVy1PRqPw6poD1hBerwrl0KxxQzmO4JDpfPEEXzyha047enBbCm8Z7/YIDvTFp8U/khhv332Ayg38sG9tsNy6kNAl9v1OnLUKq2cHyLJiD+/9sJcWTUcKN2d4uDrj6YtIPHsZaVEsVoZk6eQEyZOX5QQyeLrifuhLONLbr0SfeTkmAb5pzcJ5o/ByhdfCFGJ1xQRsKbxihTewTxuUL1PEpBXerbuPIGD8Aswa2wsF874v6wrhfRlumVgld04GZ2cnRES+QmSkI2mF4qRQFE6wBJwQGflKUcSkHcbVxdniHLc2QTdXZ2s3yfYUEaDwWgiSwkvhtTCFWF0xAVsKr0/X4ajmVQrN61eXo9p18DiGjJ2P3asmvHOUy9fvwrSF6zEtqAfyf5jDUC4xn9KgeMqtFo5bGtSi5pYGtTwZLWECFF4LM4TCS+G1MIVYXTEBWwrv4tXbsGjVdkwdKU5pcEePIVNQKP8H+KFLUzlKsW3hwJHTGDOwg/z/U+atxYbthxA8rCvey5LBQMLD3U2uJN68/8wiOp4pXODpkRyhT8MR+izColimVt659Sdkz/mBfKlEYrkovGpnksKrliejUXh1zQEKL4VX1wRjcJMJ2FJ4xVfdQSFLsP7nA4iIiEClcsXlObxCfsUl9uiu3bIPu1ZGr/jWbT0A5y9efWuMe1ZPRIZ0aRxWePfu3ILzZ0/B3d0DjZq3haubEHjHvyi8aueQwquWJ6NReJXkwLqtBzB7ySasnxcYKx6Fl8KrJMEYRBkBWwqvskH8t4fXEVd4D+7djjOnfoOLiwu+beCDtOlfr1yr5GOLWBRetdQpvGp5MhqF16IcuHPvIVr4DseDR2HInDEdhdcIzdNnzmJSyHRNzL+p6Y1aNaPPKx02fDSuXLtmtJ6riwsm85QGo5yScgEK7+vZt/aWhqO/7MPxo4fg7JwcNes0Qpas2RNVKlJ41U4nhVctT0aj8CrJgd0HT2DcjBUUXgqvknxiEP0IUHhtI7ynjh/B4QO7ZONffdMQOd7Ppd8k2ygyhVcteAqvWp6MRuFVkgMUXm0YucKrjRNL6UeAwmt94RVbGMRWBnFV/vJr5MkXfQ5xYrsovGpnlMKrliejUXiV5MC7hPfZi0hMnjYXB389qqmd8SOHIEvmjLh89Rp+GDRCU50aZUuiXde2QKpUGNJvOE78fkZTvZnBo5EyZQqc/+sihozQ9mrTmjWqoGnDujL+nbv/4sWLF5raypkjmywn+jZq/BRNderXroW6tb+SZfsOGolLV99+eCduILGlYd70dx/xpKXhm7fvICLc+BPrzs7OyPZeFhnyyZOnuP/goZbwSJ8ureQurhs3byMy0vhZqsldkuO9LJk1xbeHQlev3dDUDTc3N2TOZNkeTq1teXi4I2OG9HD/7+UAmjpox4Uc5Viyx48eYNnCmZLk515VULhoSTumalnXKLyW8Ytbm8KrliejJUyAx5JpzJB3Ce+DsJeYNmM+fjmqTXhHBQ5C5kwZceXqNQwMCNLUerUyJdDZr70U3gE/BOLUaW3CGzI+SIrXnxf+xvBR4zW1VaNaZXzXoI4sO2L0RJz/64KmevNmBMtyp06fxbhJUzXVqfN1TdT+uoYsO2hoEC5r2cOb3AUzpmiT93d1wr/vUNy5d9doH9N4psbEsdEPKe7ZdxBzFy4xWkcUaNm8MSpW+FyW7dq9Lx6HhRqtlzljJowaPtBoOXsp8L+2XTR1pUC+vPihl6+msvEVCg19gi49+miq/0nRj9GtczukTekq34bl6JejCK/gLE5kePzoIUp/5uXo2BPsP4VX7fRSeNXyZLSECVB4NWaILbc0VC1dAt16dUBUylTo6x9gtVcLjxkfjD81Cu+MKRMlSUfY0tB/YADu3LtndOaF8I4OCpDl9h84hAWLlxqtIwr4NP0O5ct9Jsv29O+vUXgzYtjQAZri20Ohth21SWz+fHnR00+bHMc3rrCwJ+ju31fTkIsVKYxOHdqCWxpe47L2Q2uaJsqBC1F41U4ehVctT0aj8CrJAQpvwhgpvK/5UHhfs6Dwmn/7caQVXvNH6Vg1Kbxq54vCq5Yno1F4LcqBm3fuo16bAYiIiMSz5y/gmSoFvqleDn06N5FxrXEOL1d4X0+himPJuMJr0UdCVuYKr+UMjUWg8BojZP2fU3jVMqfwquXJaBReXXOAwhuNlyu8XOGN74PGFV7zbz8UXvPZ6VWTwquWLIVXLU9Go/DqmgMUXgpv3ATjlobXRCi85t9+KLzms9OrJoVXLVkKr1qejEbh1TUHKLwUXgrvuz9iFF7zbz/2JLzi6LG9O7fiy5p14eLqav6gHLwmhVftBFJ41fJkNAqvrjlA4aXwUngpvHrcZOxFeEMfP8S6lYvx7OkTFChUFF6Vo48STIoXhVftrFN41fJkNAqvrjlgDeH1qlAOzRo3lOMIDpnOY8kmjrFoTvnQmkX4ZGU+tGY5Q2MR7EF4heSuWb4AT8JCkTZdenzbwIcrvE5OCH0abmz6+HMNBCi8GiCxiDICPIfXQpQUXq7wcoWXK7wW3kbirW5r4X3+/BnWrVgEsZ0hdZp0qN2gGdzdPfQYqsPE5Aqv2qmi8KrlyWhc4dU1Byi8FF4KL4VXj5uMLYX3xfPnWL9qER4+uI+UqTxRp6EPPFKk1GOYDhWTwqt2uii8ankyGoVX1xyg8FJ4KbwUXj1uMrYS3vDwl1i/cjHu/3tXSq5Y2fX0TKPHEB0uJoVX7ZRReNXyZDQKr645QOGl8FJ4Kbx63GRsJbwH9+7AmVPH5PaFb+o3Q5q06fQYnkPGpPCqnTYKr1qejEbh1TUHKLwUXgovhVePm4ythFes8P68cTXKVawuH1Tj9ZoAhVdtNlB41fJkNAqvrjlA4aXwUngpvHrcZGwlvHqMJbHEpPCqnUkKr1qejEbh1TUHKLwUXgovhVePmwyFVw+qlsWk8FrGL25tCq9anoxG4dU1Byi8FF4KL4VXj5sMhVcPqpbFpPBaxo/Cq5Yfo5lGgOfwmsbrrdLWEN6qpUugW68OiEqZCn39A/jiCb54wsKstbw6XzxhOUNjESi8xghZ/+cUXrXMucKrliejcYVX1xyg8HKFlyu8XOHV4yZD4dWDqmUxKbyW8eMKr1p+jGYaAa7wmsaLK7zv4DVjykT5k9NnzmJSyHRNVL+p6Y1aNb+UZYcNH40r164Zrefq4oLJXOE1yknvAlzh1ZswYKnwXrt+A0Gjx+LG9Zu4dOU6ChYsgHp1vkHdb2vh2OH9cPdIgcJFS+g/kETUAoVX7WRyhVctT0bjCq+uOcAVXq7wcoWXK7x63GQsEd5t23ehd79BCA0Ne6trrZrVRcbUrvLf6zdpjXTpM+jR/UQZk8KrdlopvGp5MhqFV9ccoPBSeCm8FF5zbzKvXkVhzNSlWLN5H8IjIlClQkkM6dkS7m6uZq/wPn4ciopVa+Lx4zA4OQFO/3Uuygko9lEe1KhUWv7Lp+UqoWjx6P/NSxsBCq82TlpLUXi1kmI5FQS4pcFCihReCi+Fl8Jr7m1k6bqdmL98C0JG+CGFhxt6DZ2KYoXzomf7RmYL77ARozF3wZJYsiv6V7hALtSsUlZ29cDRM5g3b7653U6y9Si8aqeewquWJ6MlTIDCa2GGUHgpvBReCq+5t5EWviNQpXwJ+DSI3su+59BJDB03HztWjDNbePMUKo5kYjk3ZmkXQL7cOVDnq/Kyjd9+/wvb9h7DpPEj4V2jurldT5L1KLxqp53Cq5Yno1F4dc0BCi+Fl8JL4TX3JlOxri8C/FvBq2wxGeLytdvwbtYbR7fMkNsabt5/ZlJo8aDaF1VqwSnZ62offvAe6tesKP/h5NmL2Lr7iPzfxYsVxfIl80yKn9QLU3jVZgCFVy1PRqPw6poDFF4KL4WXwmvuTaaMd3sEB/ri0+IfyRC37z5A5QZ+2Lc2GOnSeOJlxCuTQpes4I1//r5sWN11dUmOjv/7FuK/Z/+8hA3bfzHEc3Vxxa1/jpsUP6kXdk7mJLeKRERGJXUUSsbv5pIML8NfwZFoij7zckwC3NJg4bxZQ3i9KpRDs8YNZU+DQ6bzxRM8lszCrLW8Oo8ls5yhiCBWeAP7tEH5MkVkwLgrvEKuTLkKl6mOfy5fgdMb+xnECm+Rgh9i3dYDsUK5u7vj38sUXlP4siwJkIDjEqDwWjh3FN5ogDyH93Ui+TT9DuXLfSb/oad/fzwOCzWaZZkzZsSwoQOMlrOXAhReNTPh03U4qnmVQvP60Xtpdx08jiFj52P3qglyD+/90JcmN5Qzb1E4aTDlMqVKYOWSuSbHT8oVPNyc5Qrv0+eRSRmDsrFnSO2K+49fOtQKr+gzL8ckQOG1cN4ovBTeuClE4X1NJH++vOjp18XsT1lY2BN09++rqX6xIoXRqUNbiH2BGnxPU0y9Cy1evQ2LVm3H1JHilAZ39BgyBYXyf4AfujQ1/6G1gsWRTKwMJwAhKioKu7dvRI7s2fQeYqKKzz28aqeTe3jV8mS0hAlQeC3MEAovhZfC++4PEYU34RtMZOQrBIUswfqfDyAiIgKVyhWX5/AK+TX3xRN79h1A67adozc1xCO9Yr9kyxZN0a93DwvvfkmvOoVX7ZxTeNXyZDQKr645QOGl8FJ4Kbx63GTMFd6YvuQpWAJOTlGG7Q3RDwZF4ceFs1GmJF8pbM6cUXjNofbuOhRetTwZjcKraw5QeCm8FF4Krx43GUuFV/TJM4ULPD2SI/RpOEKfRejRzSQVk8KrdropvGp5MhqFV9ccoPBSeCm8FF49bjIUXj2oWhaTwmsZv7i1KbxqeTIahVfXHKDwUngpvBRePW4yFF49qFoWk8JrGT8Kr1p+jGYaAT60Zhqvt0pTeCm8FF4Kr4W3kXirU3j1oGpZTAqvZfwovGr5MZppBCi8pvGyifBWLV0C3Xp1QFTKVOjrH8AXT/DFExZmreXVeQ6v5QyNRaDwGiNk/Z9TeNUy55YGtTwZLWECFF4LM8QaK7wU3teT5OrigskUXguz1vLqFF7LGRqLQOE1Rsj6P6fwqmVO4VXLk9EovLrmAIU3Gi/ftPY6zfjiidcseA6v+bcfCq/57PSqSeFVS5bCq5Yno1F4dc0BCi+FN26CUXgpvCpuOhReFRTVxqDwquVJ4VXLk9EovBblwKtXURgzdSnWbN6H8IgIVKlQUr4Jyd0t+n3aFF4KL4X33R8xrvCaf/uh8JrPTq+aFF61ZCm8ankyGoXXohxYum4n5i/fgpAR4l33bug1dCqKFc6Lnu0bUXjfIMstDa9hcIWXK7wW3XT+q0zhVUFRbQwKr1qeFF61PBmNwmtRDrTwHYEq5UvAp8GXMs6eQycxdNx87FgxjsJL4Y03tyi8FF6LbjoUXhX4dIlB4VWLlcKrliejUXgtyoGKdX0R4N8KXmWLyTiXr92Gd7PeOLplBjzcXbml4T+6XOHlCm98HzRuaTD/9sMVXvPZ6VWTwquWLIVXLU9Go/BalANlvNsjONAXnxb/SMa5ffcBKjfww761wUif1lP+24SQOdj/yxFN7YSMDUCWzBlx6co19OwXqKmO92el0KpTGyBVKgwfNBK/nTytqd78aWORMmUKnPvzIvoHjNFU5xvvqvBpXE+WHRg4DmfP/aWp3sqFU2W546fOIHD0ZE11GtX9Gg3qeMuyvfoNxz9XrhqtJ44l+3HOJKPlEirQucdA3Lpz12iMtKlTY1ZIkCy3Y/cBTJ29yGgdUaBD62ao8kU5WbZ1R388Cg01Wi9r5kyYPHao0XL2UqB+8w6aulKoYD4M7dddU9n4CoWGPkHLjj011S9VvAj6dO8IIYpOTpqq2HUhJcLrkRyeKVwQ+iwCoU/D7Xq8jtA5Cq/aWaLwquXJaAkT4Dm8RjJErPAG9mmD8mWKyJJxV3iZYCRAAiRAAiRAAiRAAvZNgMJrZH58ug5HNa9SaF6/uiy56+BxDBk7H7tXTbDvmWXvSIAESIAESIAESIAEJAEKr5FEWLx6Gxat2o6pI8UpDe7oMWQKCuX/AD90acoUIgESIAESIAESIAEScAACFF4jkxQZ+QpBIUuw/ucDiIiIQKVyxeU5vEJ+eZEACZAACZAACZAACdg/AQqvGXNk7GUUZoS0iyrBc1Zj047DuHX3PjKlTyOPYmtWr5pd9E1FJ168DEfbXtEP782f+IOKkDaPsW7rASxc+TMuXr6B97Nnxrq52h6EtHnHE+jAvsOnMGHmSty7/0iefS3ysPG3Vey5y3bZt9Pn/8HgMfNw4Z9ryJY1o/xWqsKnRe2yr/bSKVPv7fsO/472vcfG6r6LS3Kc2DbLXoZkt/14HPYUrfyC8H3TWvjyi9J22092LPEQoPCaMZfGXkZhRki7qDJm2jJ4fVoMeXJlw9k/L8F3QDCmjPRD2RKF7KJ/lnRCrNT7DZ6MO3cfwM3NNVEI77zlW7B8/S4pMoXy58LTZ8+RM1tmSzDZvK44BaVm896YM643ihbKg0tXb6FJpwBMHNoFpT8paPP+OUoHwsMj8GWTXvIPhUa1K2PPwRMYOn4Bti4ZbThdxlHGYs1+mnpvF8IbMH4+Vs56fcKKOCDEM1UKa3bb4dqaOGsV1m7Zh38fPMboAR0ovA43g47ZYQqvGfNm7GUUZoS0yyrNuwxHVa+SaPHfSzfsspMaOzVw9Byk9kyJPB9kw9ot+x1eeMOePEOl+t2wYsYQ5MqZVSMF+y/26/Fz6NBnHPavmyzPuRZXg7aD0bRuVXxbo7z9D8BOeig4+g6YhAPrQ5AsWfQZbQ3bDcZ3tSujrreXnfTS/rph6r1dCG/gxIXY8uMo+xuMA/RIfLbbNKlJ4XWAuUoMXaTwmjGLxl5GYUZIu6vy7PlLVGnoh7EDO+KzUoXtrn+mdEh8PX7n3gN5vJyQ3cQgvDsPHMfAUXNQtNCHOHryPMTXqEJmurSqawoauysrViZb+gXh2fMX6NSyDpyTJcP4GSuwOKQ/UqbgvnmtEyZW/ldt3Itl0wcZqvgHTEOWTOnRo31DrWGSXDlT7+1CeDv1HY90aTyROlUKlCn+EXy/ry//Ny/jBCi8xhmxhDoCFF4zWGp5GYUZYe2qSr+Rs3Dn3kPMGN0DTg58ir/Y47p196+YNKwrkjs7Y83mfYlCeMXpIQtXbsOYQR2QL3cOXLx0HR36jEeHFrWl+Dry9eOaHdiy6zDc3Vxx8OgZ+LapJ/f58dJOYP6Krdix7xgWTOprqCS+5XBJnhwD/Hy0B0piJU29tz94FCpfRpQmdSrcuvMvxk5bjkwZ0mD8kM5JjJx5w6XwmseNtcwjQOE1g1tifxmFOJXi1+N/YN6EPg6/F038Alq4cqvh1VuvXr2C2M8rVkQPrg+RD0U54rV49XYp8m8KjVgJvXDpOkKGd3PEIck+7/9VfEW8COvnBco5Eg/jfd9zNFo3rim3NfDSRkCs8K7Zsh9LpgwwVBArvJkzpUPP9o20BUmCpSy9tx8//RfEtoiT22c79EKBtaaewmst0mxHEKDwmpEHifVlFBGRkRg0ei6uXL+NKSP8HF5245vaxLLCK04yEKvwO1aMh0tyZznU0VOX4uGjMLl1w1GvaQvW4+TZi/Lc65hLrEyKp+eH9W7tqMOyer8PH/8DfgMn48D6yQbxqv/9IDSqXQkNan1h9f44SoOW3tsPHDmN3sOmY/+6YEcZsk37SeG1Kf4k1ziF14wpT4wvoxCy2773OLi5ukixEP+VfxE5JTM8PGQGKrurkliEV+x19W7eB1UrlETX1vVw6epNtPMfi6B+7Rx6z/WxU3/Ko+NmjO6JkkXz48ate2jRbSR6tGuIGpXK2F0+2WuHXr4MR7Xvesoj3Rp+/QX2Hj4l93yLh6syZUhrr922eb+M3dtHTv4RGdKlNmyxmb1kE3K8lxHFCueVf2z2D5ot85YvJtI2lRRebZxYSg0BCq8ZHBPjyyjEmYif1er4Fg1xAsDGhSPNoGSfVRKL8Aq6l6/dxpCx8/D7ub+lxHTwqY2vq39un+BN6JV4ycusxRvx8HGY/JbBp351ebQWL9MIiJXyoePm48I/15Etawb06tgYlcsVNy1IEitt7N7erHMgsmfNiKD+7SQZcT8RxwNeu3FX5mr1iqXh17ZBolok0CMFxMkWG3f8AnHajJurK1xcnOUZ4vxjTA/ajBlDgMLLXCABEiABEiABEiABEkjUBCi8iXp6OTgSIAESIAESIAESIAEKL3OABEiABEiABEiABEggUROg8Cbq6eXgSIAESIAESIAESIAEKLzMARIgARIgARIgARIggURNgMKbqKeXgyMBEiABEiABEiABEqDwMgdIgF/rYGsAABA2SURBVARIgARIgARIgAQSNQEKb6KeXg6OBEiABEiABEiABEiAwsscIAESIAESIAESIAESSNQEKLyJeno5OBIgARIgARIgARIgAQovc4AESIAESIAESIAESCBRE6DwJurp5eBIgARIgARIgARIgAQovMwBEiABEiABEiABEiCBRE2Awpuop5eDIwESIAESIAESIAESoPAyB0iABEiABEiABEiABBI1AQpvop5eDo4ESIAESIAESIAESIDCyxwgARMIPHgUivK1u2DZ9EH4uEBuE2qyKAmQgL0SSMqf65/3HIV/wFTMGN0LZYoXNDpFI4IXY+eB41g9ayg8U6UwWp4FSMBeCFB47WUm2A8DgYjISPy4ejtWb9qHqzfuwM3VBVkypUPZkoXRvF41ZMua0Wa0kvIvRptBZ8MkoDMBa3yuO/QZj+xZM6J/t+aG0ew+eAKd+k7A5sVBeD97Fp1H+XZ4Me6azfqgU8tv0bRuNU3tv3oVBZ+uw5ErZ1YM691aUx0WIgF7IEDhtYdZYB9iEegfNBvb9h5F19Z1UbhAboSHR+DM+UtYt3U/Wn3nja+rf24zYtb4xWizwbFhEkiiBKzxuY5PeG/ffYBfj/+BKhVKIIWHu9Xpj5u+HPsOn8LKmUPh7JxMc/vnLlxBw3aDsX5etPjyIgFHIEDhdYRZSmJ9/KRqa3RuVRdtmtSMNfKoqCg8DnuKNJ4p8dvvf6J5l+EYO6gjZi7egIuXruODnFkxuMf/UPzjfIZ62/cdw5R5a/H3lZvInCEt6nhXQNumXxtu7n/+fQ2jpyyV8VKmcEe50kXQu1NjpE2TSsYQ7Y2YtBjb9h6Bq6sLShYtgJ37fzNsaYhZoTmze56hTfHLoF6bgdizeiIypk+jua9JbJo5XBJ4i0CRyi3h17YBjp48j1+OnUVqz5To+L9v0fDrL2TZR4+fyBXRy9duIfTJM/n5qlmlLHzb1EeyZE6yjIjRt2szGWPPoRNI45kKHVrURv1aFQ3tGftca2ln/c8HMGfJZly5flveL0oUyY/+vs0N9443BzdswkIsWbsj1ngXBveFs7MzmnQMwKENU5A6VQrDvWLKCD953zr/91UU+DAnRg1oj9/P/Y0ZC3/CtZt3UeSjDzGyXzu8lzm9jClWXcV9cMWG3fj3wWPkypFFcqvmVeqdWRYZ+QoVvu2C7u0axmIjvmGbPGcNNmw/hPsPHiNr5vSoWqGkLPfm1axzIIoVyoNeHb9jJpOAQxCg8DrENCWtTtZo4o/8eXJg7MCOcHFJHu/gY4Q3T67saFqnCjKmT4v5K7bg8rXb2LZ0jJRTsc+s/8hZ6N/NB8U/zosrN+6g38hZ8KlfHT4NvsTNO/dRt1V/tGhYAzWrlsXTZy8wasoSpHB3Q3Cgr2y3pd9I3H8YCt/W9ZA2jadcjQmes9os4U2or0lrhjlaEoifgJBVsS/Up/6XKJA3J/YcPCklbvXsABTIkxNiJXbagvUoX6YoMmdMi7/+uYbBY+ZKSY75Sl7EcHdzRctGX0kxFPeBlRt2Y+NCsW0gs6bPtbF2jp36E627B0np/Lhgbim9azbvQ3uf2sjzQba3Bvfk6XN0HTAJ72XOgG7f15c/T5M6Fc7+eSle4c2ZLTO+b1pLCv34GStw++59ZMqYDm2aeMPN1VX+m5DNoP7tZKxRIUtw6NgZKfo53suEIyfPYeDouVg8uT8KF8gVL+yTZy+ieZdA7FsbLBcRYq6pC9ZhzaZ9cmwZ0qXGH39dxk/bDiJkeLfYwr7yZ6zYsAfr5wUynUnAIQhQeB1impJWJ8XKTvchIRArEOKmXiDP+/KXSsXPislfZOKKEd7DG6ciVUoP+W93/32Iyg38MGlYV1T6vDgatRuCWtU+Q/P61Q0AF63aJlculk4diDHTlklBDh7W1fDz8xevom7rATi2dQZOnLmANj1GY9Oi178o4371acoKb0J9TVozzNGSwLuFd2JAV1QuV9xQ4JsWfVG+TBH4d2ocb6Xew6ZDrEqKb3vEJYR37KBOqF4xenVTbIkq7d0egX3ayNXgX347a/RzHV9Db7azePV2hMxbg+3LxiGFh5um6YxvS4OQzvhWeA+sm2xYKRbCHzhxEY5smmZYAJi9ZBNWbtgj9/6K1eoK/z1IWzDv+4a+CMHOlSPrWyuzMQVE/dlLNmLz4lGx+t9t4GQ8f/EC04J6JDiu38/9g8YdhuLUjjmG1XVNIFiIBGxEgMJrI/BsNmECz56/lCsW5/66jHMXr+DoifPyZj99VA+Im3qM8B7ZPC3W3rdK9buhdeOaaFq3KopVbS2lOe6VKUNa7F41Aa38gnD4+B/xdkRI7s97jmDZ+l3YvmysoYwlwvuuvjarp+1hEeYMCSR2AkJWg4f54ovPPzEMVYjmsxcvMCkg+g9TcarAph2/yG1KYU+e4sGjMJQtUQhTR/oZhDdujIp1fdGxRW00ql1ZfvVv7HNtrJ3rt+7hu/ZDZHufl/oYRQt9iOoVS0PcW951mSK8b94rxLas7oNDpFjGXGI1Wazy7l0zCWK1WTxEFt8lBF9sh4jvEhwOHDmNeRP6xPqxWBHvNjBYPkRXpvhHKF44L6p6lYKHe/RiQ8wl9h+LBQaxQpw+rWdiT02OLxEQoPAmgklMCkMQ2w3EL5i8uXNg3OCO7xResSdNfBXYrF51FK3SCiP7tpWrvPFd/+s2Un7FObRXq3h/Hr2KsjvWCsi7hPf0rrlwcoreQ/iuPbxxhTemr2J7BS8SIIHo1dm4stp98BSEh4fLbUbzV2xF8OxVcruCkDEhWjN/3Cj39iYkvOIP4fbNv5HCq+VzraUdsbK6bc9RnDx7AYeOncXj0CdYMWPwO09bMFd4d+z7Dd0GBeP3nXPjFd4jJ85B3Mt2rhgvT7PRes1Y9BMO//YHZo/zf6uKOB1n+95jEKu4B4+eRrYsGbBs+mC4JHc2lL1y/Q6+auqP/euCkS4NhVcrd5azHQEKr+3Ys+V4CLx4GQ6xevLh+++99VOxIuvh4Sb3ksW3wvvPlZuo5fMDFgb3Q4ki+eTWhDy5smH0gA6xYolVX/FEsjhPUmxJWD9/uDz6LOaK+blYSeo1dCp2r55guKGLB0K86nQ17OGN6UfMA2oixqmzF9G4Y8BbD629Kbxx+8pkIAESeFt4wyMi8VWTXmjwdSW0a/613FOf+/1sGOjnY8AlHggT9wytwqvlc22sHbGFIrnza/kT/axUr5t8UKxJnSrxTqXfoMlyf/Kbf2C/a0vDm/cKY8Ir/ggX96QBfi0MD/fFvZfF1yGxpWHO0k1yy9abV9yxxfwBv25uIPLmzm4o+uvxc2jVPYhbGvjBdRgCFF6Hmaqk0VFx8xa/OL78ooz8WlM8gBH65Cl+3n0Uqzfvxeyx/ij9SUGD8Ionh0sVKyCfTJ44ayWyZEyHGaN7Slhbdx+RXwWKh1m8q3wqn4g+/NtZuQI7ZmAHecavOE1BPNjSpnFNpEvrKR/QEPt8V80aCiHf1b/rKR9CEdsOxB5h8TPxVWrMiyfEKk+VBt1R4dOiqPNVefkQzaz/VpzintKQUF+TxuxylCSQMAGxwluz6meo5+2FyFevsGTNDvlZF/tMxV79oeMXyGO0+nRqAlfX5HI/7tK1O+Vqr1bh1fK5NtaOeHDu5p1/8W2N8nIbgxDXfiNmYsGkvihaKE+8gwyZuwbLf9qN8UM6yZ+LLQNC1OPbw2uK8IpYgRMXYu2W/ejauh5KFs2PsCfPsWP/MfnQm/jGK75L9LmF7wgcXD851rawLv0m4uOCH8r7r3hmYtXGPVi5cY9cQY55hkLEW7BiK1Zt2gshwrxIwBEIUHgdYZaSUB/F6qo47mfLrl/lUWP37j+SJy58UjivPFoo5sixmJVVceyOkNjwiAhU8yqNfr7NDA+xCWziCDEhoEJyRZy8ubLju9qVDdschKBOnLkKR0+dx8uX4fKXkLjRxzxJLX4piKfAxcNt+XLnkOLbZ/iMWG9aE22MmrIUt+89QKmiBVD7y3LoHTj9rRVeY31NQtPMoZJAvASE8H5WsjAuXLouj8Qq8lEeBPi3Mpz1+vBRGMQ53WJ/vzhG0LtKWXlyw+PQp5qFVzRs7HNtrB1Rf+r8tfjjrysIDXsq+yfE8qvKn75zZsW2i96B03DkxHl4uLth1the8o9qFcIr7pvzlm/B6k17ce3GXfnAW5GCH6Jts1rvFHBxlFn52p3xQ5emsc42F/ffH9fswKWrtyCOghQPDPdo1xCF8sc+7eG7DkOlXPfqwGPJ+HF2DAIUXseYJ/YyDoF3PbRmj6Acqa/2yI99SjoE4tvDm3RGb/2RTpi5Uq6SL5kywPAMgpZeiBNsxINyGxaMsMkb4rT0kWVIIC4BCi9zwiEJOJJEOlJfHTIZ2OlEQ4DCa92pFCvZ3s16o3fnJvKbKS2X2OMrVqXFcZFi9Z0XCTgKAQqvo8wU+xmLgCNJpCP1lWlGArYkQOG1Pn3xGve+I2Zizvg+KFIwt9EOiC0l4jjHNbMDYm0fM1qRBUjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgLwEKr758GZ0ESIAESIAESIAESMDGBCi8Np4ANk8CJEACJEACJEACJKAvAQqvvnwZnQRIgARIgARIgARIwMYEKLw2ngA2TwIkQAIkQAIkQAIkoC8BCq++fBmdBEiABEiABEiABEjAxgQovDaeADZPAiRAAiRAAiRAAiSgL4H/AyMPbI9PBEmXAAAAAElFTkSuQmCC"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -4871,13 +4161,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b502aa6d",
+   "id": "f9500a99",
    "metadata": {
     "papermill": {
-     "duration": 0.005355,
-     "end_time": "2026-06-13T02:35:13.597170+00:00",
+     "duration": 0.005006,
+     "end_time": "2026-07-18T20:21:18.850827+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.591815+00:00",
+     "start_time": "2026-07-18T20:21:18.845821+00:00",
      "status": "completed"
     }
    },
@@ -4888,19 +4178,19 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "c9823f9a",
+   "id": "764e99e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:34:01.087124Z",
-     "iopub.status.busy": "2026-06-16T02:34:01.087055Z",
-     "iopub.status.idle": "2026-06-16T02:34:01.090832Z",
-     "shell.execute_reply": "2026-06-16T02:34:01.090545Z"
+     "iopub.execute_input": "2026-07-18T20:21:18.861050Z",
+     "iopub.status.busy": "2026-07-18T20:21:18.860926Z",
+     "iopub.status.idle": "2026-07-18T20:21:18.865215Z",
+     "shell.execute_reply": "2026-07-18T20:21:18.864920Z"
     },
     "papermill": {
-     "duration": 0.010968,
-     "end_time": "2026-06-13T02:35:13.613455+00:00",
+     "duration": 0.00999,
+     "end_time": "2026-07-18T20:21:18.865588+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.602487+00:00",
+     "start_time": "2026-07-18T20:21:18.855598+00:00",
      "status": "completed"
     }
    },
@@ -4909,8 +4199,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Results saved to: 02_financial_data_universe/output/benchmark/pandas_polars_s.csv\n",
-      "Summary saved to: 02_financial_data_universe/output/benchmark/pandas_polars_summary_s.csv\n"
+      "Results saved to: /home/stefan/ml4t/code/02_financial_data_universe/output/benchmark/pandas_polars_s.csv\n",
+      "Summary saved to: /home/stefan/ml4t/code/02_financial_data_universe/output/benchmark/pandas_polars_summary_s.csv\n"
      ]
     }
    ],
@@ -4956,13 +4246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcb04864",
+   "id": "aa9b3d88",
    "metadata": {
     "papermill": {
-     "duration": 0.005458,
-     "end_time": "2026-06-13T02:35:13.624538+00:00",
+     "duration": 0.004717,
+     "end_time": "2026-07-18T20:21:18.875079+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.619080+00:00",
+     "start_time": "2026-07-18T20:21:18.870362+00:00",
      "status": "completed"
     }
    },
@@ -4973,19 +4263,19 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "e7c9e819",
+   "id": "a9c464ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:34:01.091773Z",
-     "iopub.status.busy": "2026-06-16T02:34:01.091712Z",
-     "iopub.status.idle": "2026-06-16T02:34:01.093870Z",
-     "shell.execute_reply": "2026-06-16T02:34:01.093547Z"
+     "iopub.execute_input": "2026-07-18T20:21:18.885329Z",
+     "iopub.status.busy": "2026-07-18T20:21:18.885208Z",
+     "iopub.status.idle": "2026-07-18T20:21:18.887688Z",
+     "shell.execute_reply": "2026-07-18T20:21:18.887405Z"
     },
     "papermill": {
-     "duration": 0.00911,
-     "end_time": "2026-06-13T02:35:13.639030+00:00",
+     "duration": 0.008259,
+     "end_time": "2026-07-18T20:21:18.888119+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.629920+00:00",
+     "start_time": "2026-07-18T20:21:18.879860+00:00",
      "status": "completed"
     }
    },
@@ -4996,7 +4286,7 @@
      "text": [
       "Scale: S (10,000 rows)\n",
       "Fastest-on-Polars categories at this scale: H_string, E_join\n",
-      "Smallest-gap (or pandas-faster) categories at this scale: A_rolling, D_filter\n"
+      "Smallest-gap (or pandas-faster) categories at this scale: A_rolling, C_window\n"
      ]
     }
    ],
@@ -5014,13 +4304,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54deabb8",
+   "id": "fa1b0770",
    "metadata": {
     "papermill": {
-     "duration": 0.005531,
-     "end_time": "2026-06-13T02:35:13.650087+00:00",
+     "duration": 0.00463,
+     "end_time": "2026-07-18T20:21:18.897630+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.644556+00:00",
+     "start_time": "2026-07-18T20:21:18.893000+00:00",
      "status": "completed"
     }
    },
@@ -5032,13 +4322,13 @@
     "scale* and the takeaways printed above name this run's top-2 / bottom-2\n",
     "categories so the prose stays in sync with the actual numbers:\n",
     "\n",
-    "- At **S (10K rows)** fixed Python overhead compresses the gap but does not\n",
-    "  erase it: Polars still leads every category on average and is faster on the\n",
-    "  large majority of individual operations. The margins are widest on strings\n",
-    "  and joins and narrowest on the simpler rolling/window/groupby/filter\n",
-    "  operations, where a handful of individual ops dip below parity — those are\n",
-    "  the only places pandas wins. The cell above prints this run's top-2 and\n",
-    "  bottom-2 categories so the prose tracks the actual numbers.\n",
+    "- At **S (10K rows)** fixed Python overhead compresses the gap. Polars keeps a\n",
+    "  large, reliable lead on the string, join, and lazy categories, where there is\n",
+    "  enough work to amortize its setup cost. On the lighter groupby, window, filter,\n",
+    "  and rolling operations that overhead is a bigger share of the runtime, so\n",
+    "  Polars' margin is smallest and least stable there and individual categories can\n",
+    "  land on either side of parity from run to run. The cell above prints this run's\n",
+    "  top-2 and bottom-2 categories so the prose tracks the actual numbers.\n",
     "- At **L / XL (≥1M rows)** Polars' parallelization widens the gap on string,\n",
     "  groupby, join, and lazy operations; the narrow-margin categories at S pull\n",
     "  further ahead as parallelization amortizes the Python overhead.\n",
@@ -5071,19 +4361,19 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "cb6b4dfe",
+   "id": "05ef7f3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:34:01.094529Z",
-     "iopub.status.busy": "2026-06-16T02:34:01.094469Z",
-     "iopub.status.idle": "2026-06-16T02:34:01.096121Z",
-     "shell.execute_reply": "2026-06-16T02:34:01.095913Z"
+     "iopub.execute_input": "2026-07-18T20:21:18.907786Z",
+     "iopub.status.busy": "2026-07-18T20:21:18.907676Z",
+     "iopub.status.idle": "2026-07-18T20:21:18.909691Z",
+     "shell.execute_reply": "2026-07-18T20:21:18.909391Z"
     },
     "papermill": {
-     "duration": 0.009398,
-     "end_time": "2026-06-13T02:35:13.664862+00:00",
+     "duration": 0.007725,
+     "end_time": "2026-07-18T20:21:18.909965+00:00",
      "exception": false,
-     "start_time": "2026-06-13T02:35:13.655464+00:00",
+     "start_time": "2026-07-18T20:21:18.902240+00:00",
      "status": "completed"
     }
    },
@@ -5096,7 +4386,7 @@
       "BENCHMARK COMPLETE\n",
       "======================================================================\n",
       "pandas 2.3.3 vs Polars 1.41.1, scale S\n",
-      "Results: 02_financial_data_universe/output/benchmark/pandas_polars_s.csv\n"
+      "Results: /home/stefan/ml4t/code/02_financial_data_universe/output/benchmark/pandas_polars_s.csv\n"
      ]
     }
    ],
@@ -5130,25 +4420,25 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
-  "ml4t_provenance": {
-   "source_py_blob": "98d8828939df991c809ba471ecd530d00c60529c",
-   "executed_at": "2026-06-16T02:34:57.422690+00:00",
-   "executor": "cpu-local",
-   "production": true,
-   "parameters": {},
-   "notes": "perf benchmark; timings non-deterministic, prose is qualitative"
-  },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.052071,
-   "end_time": "2026-06-13T02:35:16.290729+00:00",
+   "duration": 12.093783,
+   "end_time": "2026-07-18T20:21:19.931467+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "02_financial_data_universe/22_pandas_polars_benchmark.ipynb",
    "output_path": "02_financial_data_universe/22_pandas_polars_benchmark.ipynb",
    "parameters": {},
-   "start_time": "2026-06-13T02:35:01.238658+00:00",
+   "start_time": "2026-07-18T20:21:07.837684+00:00",
    "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "b544fc9c77a52c8115c416511494f1074f3d84f2",
+   "executed_at": "2026-07-18T20:21:20.358245+00:00",
+   "executor": "cpu-local",
+   "production": true,
+   "parameters": {},
+   "notes": "Ch02 re-verification: S-scale prose describes the stable pattern (Polars leads string/join/lazy; lighter ops noisy near parity)"
   }
  },
  "nbformat": 4,

--- a/02_financial_data_universe/22_pandas_polars_benchmark.py
+++ b/02_financial_data_universe/22_pandas_polars_benchmark.py
@@ -1433,13 +1433,13 @@ print(f"Smallest-gap (or pandas-faster) categories at this scale: {', '.join(_bo
 # scale* and the takeaways printed above name this run's top-2 / bottom-2
 # categories so the prose stays in sync with the actual numbers:
 #
-# - At **S (10K rows)** fixed Python overhead compresses the gap but does not
-#   erase it: Polars still leads every category on average and is faster on the
-#   large majority of individual operations. The margins are widest on strings
-#   and joins and narrowest on the simpler rolling/window/groupby/filter
-#   operations, where a handful of individual ops dip below parity — those are
-#   the only places pandas wins. The cell above prints this run's top-2 and
-#   bottom-2 categories so the prose tracks the actual numbers.
+# - At **S (10K rows)** fixed Python overhead compresses the gap. Polars keeps a
+#   large, reliable lead on the string, join, and lazy categories, where there is
+#   enough work to amortize its setup cost. On the lighter groupby, window, filter,
+#   and rolling operations that overhead is a bigger share of the runtime, so
+#   Polars' margin is smallest and least stable there and individual categories can
+#   land on either side of parity from run to run. The cell above prints this run's
+#   top-2 and bottom-2 categories so the prose tracks the actual numbers.
 # - At **L / XL (≥1M rows)** Polars' parallelization widens the gap on string,
 #   groupby, join, and lazy operations; the narrow-margin categories at S pull
 #   further ahead as parallelization amortizes the Python overhead.


### PR DESCRIPTION
## What

Fresh Ch02 re-verification under the current sign-off gates surfaced one prose defect in `22_pandas_polars_benchmark`.

The S-scale (10K rows) takeaway claimed **"Polars still leads every category on average and is faster on the large majority of individual operations ... those are the only places pandas wins."** At S scale the benchmark is timing-noisy: across repeated runs the lighter **groupby / window / filter / rolling** categories land on *either* side of parity (observed category means from 0.27× to 1.8× for the same category across runs). So the absolute claim is not reliably true and can directly contradict the notebook's own "Speedup by Category" chart in a given run.

## Fix

Reword the S-scale paragraph to the **stable** pattern only:
- Polars keeps a large, reliable lead on **string / join / lazy** (always top, >1.7×).
- The lighter **groupby / window / filter / rolling** ops are the smallest, least-stable margins and can land on either side of parity run-to-run.
- Per-run specifics are deferred to the existing dynamic top-2 / bottom-2 print (the notebook already computes these), so prose and numbers stay in sync.

Prose-only change; notebook re-executed (CPU, S scale) and re-stamped. Benchmark wall-clock timings are volatile and Gate-3 exempt. **No printed book number changes** (no erratum).

## Verification

- Re-executed clean end-to-end (111 cells), provenance stamped (`production=True`, `executor=cpu-local`).
- Committed figure and `category_summary` table agree (both derive from the same run); dynamic print bottom-2 matches the chart's smallest-margin categories.
- Pair-sync + provenance pre-commit gates pass.

Mirrored identically into `ml4t/third-edition` (`~/ml4t/code`) to preserve the one-home invariant.