### PR TITLE
Ch02 22_pandas_polars_benchmark: fix figure so it renders on GitHub (image/png)

### DIFF
--- a/02_financial_data_universe/22_pandas_polars_benchmark.ipynb
+++ b/02_financial_data_universe/22_pandas_polars_benchmark.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7c32a2a6",
+   "id": "7920dd68",
    "metadata": {
     "papermill": {
-     "duration": 0.003652,
-     "end_time": "2026-07-18T20:21:08.488582+00:00",
+     "duration": 0.004104,
+     "end_time": "2026-07-19T03:42:54.482391+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:08.484930+00:00",
+     "start_time": "2026-07-19T03:42:54.478287+00:00",
      "status": "completed"
     }
    },
@@ -63,13 +63,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4a91e04",
+   "id": "5cb85426",
    "metadata": {
     "papermill": {
-     "duration": 0.00309,
-     "end_time": "2026-07-18T20:21:08.495128+00:00",
+     "duration": 0.003045,
+     "end_time": "2026-07-19T03:42:54.488974+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:08.492038+00:00",
+     "start_time": "2026-07-19T03:42:54.485929+00:00",
      "status": "completed"
     }
    },
@@ -80,20 +80,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "794a92e6",
+   "id": "acf00d9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:08.502606Z",
-     "iopub.status.busy": "2026-07-18T20:21:08.502498Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.652448Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.651860Z"
+     "iopub.execute_input": "2026-07-19T03:42:54.495944Z",
+     "iopub.status.busy": "2026-07-19T03:42:54.495834Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.146886Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.146285Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 1.154646,
-     "end_time": "2026-07-18T20:21:09.653176+00:00",
+     "duration": 2.655699,
+     "end_time": "2026-07-19T03:42:57.147653+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:08.498530+00:00",
+     "start_time": "2026-07-19T03:42:54.491954+00:00",
      "status": "completed"
     }
    },
@@ -134,19 +134,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "346f4acf",
+   "id": "ed45ae1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.664050Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.663850Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.665810Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.665443Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.154612Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.154452Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.156127Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.155832Z"
     },
     "papermill": {
-     "duration": 0.00647,
-     "end_time": "2026-07-18T20:21:09.666043+00:00",
+     "duration": 0.005829,
+     "end_time": "2026-07-19T03:42:57.156720+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.659573+00:00",
+     "start_time": "2026-07-19T03:42:57.150891+00:00",
      "status": "completed"
     },
     "tags": [
@@ -162,19 +162,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "42d4e1db",
+   "id": "13337e27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.672894Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.672810Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.703396Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.703001Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.166876Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.166802Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.223965Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.223235Z"
     },
     "papermill": {
-     "duration": 0.034838,
-     "end_time": "2026-07-18T20:21:09.704000+00:00",
+     "duration": 0.062094,
+     "end_time": "2026-07-19T03:42:57.224331+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.669162+00:00",
+     "start_time": "2026-07-19T03:42:57.162237+00:00",
      "status": "completed"
     }
    },
@@ -185,13 +185,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5237453",
+   "id": "ea0830cf",
    "metadata": {
     "papermill": {
-     "duration": 0.003171,
-     "end_time": "2026-07-18T20:21:09.710472+00:00",
+     "duration": 0.003074,
+     "end_time": "2026-07-19T03:42:57.230684+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.707301+00:00",
+     "start_time": "2026-07-19T03:42:57.227610+00:00",
      "status": "completed"
     }
    },
@@ -209,19 +209,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3c7064ca",
+   "id": "cf0375aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.717369Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.717260Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.720653Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.720375Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.237409Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.237318Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.241446Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.240705Z"
     },
     "papermill": {
-     "duration": 0.007431,
-     "end_time": "2026-07-18T20:21:09.721007+00:00",
+     "duration": 0.008062,
+     "end_time": "2026-07-19T03:42:57.241778+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.713576+00:00",
+     "start_time": "2026-07-19T03:42:57.233716+00:00",
      "status": "completed"
     }
    },
@@ -289,13 +289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8206ab3e",
+   "id": "0c92b09a",
    "metadata": {
     "papermill": {
-     "duration": 0.0032,
-     "end_time": "2026-07-18T20:21:09.727449+00:00",
+     "duration": 0.002997,
+     "end_time": "2026-07-19T03:42:57.247964+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.724249+00:00",
+     "start_time": "2026-07-19T03:42:57.244967+00:00",
      "status": "completed"
     }
    },
@@ -309,20 +309,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "640e985c",
+   "id": "0c9f59af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.734475Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.734383Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.762060Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.761682Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.254683Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.254591Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.282249Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.281755Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.032201,
-     "end_time": "2026-07-18T20:21:09.762788+00:00",
+     "duration": 0.031662,
+     "end_time": "2026-07-19T03:42:57.282723+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.730587+00:00",
+     "start_time": "2026-07-19T03:42:57.251061+00:00",
      "status": "completed"
     }
    },
@@ -380,14 +380,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cd71a62",
+   "id": "6d1583ba",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003171,
-     "end_time": "2026-07-18T20:21:09.771290+00:00",
+     "duration": 0.003865,
+     "end_time": "2026-07-19T03:42:57.292713+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.768119+00:00",
+     "start_time": "2026-07-19T03:42:57.288848+00:00",
      "status": "completed"
     }
    },
@@ -401,19 +401,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "f440d7c7",
+   "id": "23d1cade",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.778598Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.778486Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.780843Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.780559Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.302251Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.302089Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.305139Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.304808Z"
     },
     "papermill": {
-     "duration": 0.006626,
-     "end_time": "2026-07-18T20:21:09.781218+00:00",
+     "duration": 0.007802,
+     "end_time": "2026-07-19T03:42:57.305457+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.774592+00:00",
+     "start_time": "2026-07-19T03:42:57.297655+00:00",
      "status": "completed"
     }
    },
@@ -438,20 +438,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3cd80913",
+   "id": "47de3204",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.794318Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.794182Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.796435Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.796150Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.312591Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.312500Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.314924Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.314510Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009555,
-     "end_time": "2026-07-18T20:21:09.796932+00:00",
+     "duration": 0.006564,
+     "end_time": "2026-07-19T03:42:57.315161+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.787377+00:00",
+     "start_time": "2026-07-19T03:42:57.308597+00:00",
      "status": "completed"
     }
    },
@@ -470,14 +470,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d200906e",
+   "id": "95eb43b3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003179,
-     "end_time": "2026-07-18T20:21:09.803653+00:00",
+     "duration": 0.003103,
+     "end_time": "2026-07-19T03:42:57.321418+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.800474+00:00",
+     "start_time": "2026-07-19T03:42:57.318315+00:00",
      "status": "completed"
     }
    },
@@ -489,19 +489,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "6f59a0ce",
+   "id": "aa883137",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.810781Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.810668Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.813143Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.812866Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.328078Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.328016Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.330589Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.330090Z"
     },
     "papermill": {
-     "duration": 0.006845,
-     "end_time": "2026-07-18T20:21:09.813654+00:00",
+     "duration": 0.006375,
+     "end_time": "2026-07-19T03:42:57.330869+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.806809+00:00",
+     "start_time": "2026-07-19T03:42:57.324494+00:00",
      "status": "completed"
     }
    },
@@ -544,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62654446",
+   "id": "fbfe12f3",
    "metadata": {
     "papermill": {
-     "duration": 0.003203,
-     "end_time": "2026-07-18T20:21:09.820578+00:00",
+     "duration": 0.003098,
+     "end_time": "2026-07-19T03:42:57.337123+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.817375+00:00",
+     "start_time": "2026-07-19T03:42:57.334025+00:00",
      "status": "completed"
     }
    },
@@ -564,19 +564,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8b7a2426",
+   "id": "cfdb84c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.827796Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.827689Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.829538Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.829295Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.343893Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.343824Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.345834Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.345457Z"
     },
     "papermill": {
-     "duration": 0.006186,
-     "end_time": "2026-07-18T20:21:09.830036+00:00",
+     "duration": 0.005864,
+     "end_time": "2026-07-19T03:42:57.346074+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.823850+00:00",
+     "start_time": "2026-07-19T03:42:57.340210+00:00",
      "status": "completed"
     }
    },
@@ -602,14 +602,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "561ab074",
+   "id": "3b6b4d3c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003217,
-     "end_time": "2026-07-18T20:21:09.836501+00:00",
+     "duration": 0.003085,
+     "end_time": "2026-07-19T03:42:57.352289+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.833284+00:00",
+     "start_time": "2026-07-19T03:42:57.349204+00:00",
      "status": "completed"
     }
    },
@@ -622,19 +622,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "25f68cfe",
+   "id": "f307fa70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.843627Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.843530Z",
-     "iopub.status.idle": "2026-07-18T20:21:09.845278Z",
-     "shell.execute_reply": "2026-07-18T20:21:09.845005Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.359095Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.359031Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.360782Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.360458Z"
     },
     "papermill": {
-     "duration": 0.006008,
-     "end_time": "2026-07-18T20:21:09.845689+00:00",
+     "duration": 0.00571,
+     "end_time": "2026-07-19T03:42:57.361165+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.839681+00:00",
+     "start_time": "2026-07-19T03:42:57.355455+00:00",
      "status": "completed"
     }
    },
@@ -649,19 +649,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "8b685b43",
+   "id": "239a1d1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:09.852900Z",
-     "iopub.status.busy": "2026-07-18T20:21:09.852806Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.112395Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.112063Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.367901Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.367838Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.661539Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.661073Z"
     },
     "papermill": {
-     "duration": 0.263745,
-     "end_time": "2026-07-18T20:21:10.112783+00:00",
+     "duration": 0.297597,
+     "end_time": "2026-07-19T03:42:57.661866+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:09.849038+00:00",
+     "start_time": "2026-07-19T03:42:57.364269+00:00",
      "status": "completed"
     }
    },
@@ -670,7 +670,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  rolling_mean_20: pandas=0.0012s, polars=0.0014s, speedup=0.9x\n"
+      "  rolling_mean_20: pandas=0.0012s, polars=0.0012s, speedup=1.0x\n"
      ]
     }
    ],
@@ -688,14 +688,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f672eee",
+   "id": "22bb6661",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003291,
-     "end_time": "2026-07-18T20:21:10.119622+00:00",
+     "duration": 0.003243,
+     "end_time": "2026-07-19T03:42:57.668535+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.116331+00:00",
+     "start_time": "2026-07-19T03:42:57.665292+00:00",
      "status": "completed"
     }
    },
@@ -708,19 +708,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ae1d00e4",
+   "id": "c649b602",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.126955Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.126853Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.128755Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.128490Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.675712Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.675615Z",
+     "iopub.status.idle": "2026-07-19T03:42:57.677545Z",
+     "shell.execute_reply": "2026-07-19T03:42:57.677196Z"
     },
     "papermill": {
-     "duration": 0.006247,
-     "end_time": "2026-07-18T20:21:10.129104+00:00",
+     "duration": 0.00613,
+     "end_time": "2026-07-19T03:42:57.677845+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.122857+00:00",
+     "start_time": "2026-07-19T03:42:57.671715+00:00",
      "status": "completed"
     }
    },
@@ -735,19 +735,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "744576bb",
+   "id": "33108e5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.137615Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.137529Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.411873Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.411448Z"
+     "iopub.execute_input": "2026-07-19T03:42:57.685293Z",
+     "iopub.status.busy": "2026-07-19T03:42:57.685189Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.005767Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.005314Z"
     },
     "papermill": {
-     "duration": 0.279814,
-     "end_time": "2026-07-18T20:21:10.412194+00:00",
+     "duration": 0.325161,
+     "end_time": "2026-07-19T03:42:58.006280+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.132380+00:00",
+     "start_time": "2026-07-19T03:42:57.681119+00:00",
      "status": "completed"
     }
    },
@@ -756,7 +756,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  rolling_std_20: pandas=0.0012s, polars=0.0013s, speedup=0.9x\n"
+      "  rolling_std_20: pandas=0.0012s, polars=0.0012s, speedup=1.0x\n"
      ]
     }
    ],
@@ -774,13 +774,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3aeba11b",
+   "id": "e719e432",
    "metadata": {
     "papermill": {
-     "duration": 0.003314,
-     "end_time": "2026-07-18T20:21:10.419156+00:00",
+     "duration": 0.003356,
+     "end_time": "2026-07-19T03:42:58.013500+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.415842+00:00",
+     "start_time": "2026-07-19T03:42:58.010144+00:00",
      "status": "completed"
     }
    },
@@ -794,19 +794,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "5af7bd4c",
+   "id": "f88b2a64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.426525Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.426421Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.428416Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.428127Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.020570Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.020467Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.022768Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.022366Z"
     },
     "papermill": {
-     "duration": 0.006375,
-     "end_time": "2026-07-18T20:21:10.428840+00:00",
+     "duration": 0.00651,
+     "end_time": "2026-07-19T03:42:58.023231+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.422465+00:00",
+     "start_time": "2026-07-19T03:42:58.016721+00:00",
      "status": "completed"
     }
    },
@@ -826,19 +826,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "42f9bbe1",
+   "id": "9fb9ef49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.436391Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.436286Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.734804Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.734392Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.030434Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.030340Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.386203Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.385779Z"
     },
     "papermill": {
-     "duration": 0.302896,
-     "end_time": "2026-07-18T20:21:10.735148+00:00",
+     "duration": 0.360238,
+     "end_time": "2026-07-19T03:42:58.386704+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.432252+00:00",
+     "start_time": "2026-07-19T03:42:58.026466+00:00",
      "status": "completed"
     }
    },
@@ -847,7 +847,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  multi_horizon_returns: pandas=0.0085s, polars=0.0022s, speedup=3.9x\n"
+      "  multi_horizon_returns: pandas=0.0083s, polars=0.0019s, speedup=4.3x\n"
      ]
     }
    ],
@@ -868,14 +868,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbfddf02",
+   "id": "cb883fec",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003345,
-     "end_time": "2026-07-18T20:21:10.742084+00:00",
+     "duration": 0.003279,
+     "end_time": "2026-07-19T03:42:58.395456+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.738739+00:00",
+     "start_time": "2026-07-19T03:42:58.392177+00:00",
      "status": "completed"
     }
    },
@@ -888,19 +888,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "434c8519",
+   "id": "71e18258",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.749573Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.749415Z",
-     "iopub.status.idle": "2026-07-18T20:21:10.751976Z",
-     "shell.execute_reply": "2026-07-18T20:21:10.751578Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.402980Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.402880Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.404895Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.404500Z"
     },
     "papermill": {
-     "duration": 0.006911,
-     "end_time": "2026-07-18T20:21:10.752248+00:00",
+     "duration": 0.006368,
+     "end_time": "2026-07-19T03:42:58.405158+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.745337+00:00",
+     "start_time": "2026-07-19T03:42:58.398790+00:00",
      "status": "completed"
     }
    },
@@ -917,19 +917,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "fb1d4dd1",
+   "id": "06ff5375",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:10.759646Z",
-     "iopub.status.busy": "2026-07-18T20:21:10.759517Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.182580Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.182087Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.412622Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.412534Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.753541Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.753228Z"
     },
     "papermill": {
-     "duration": 0.42724,
-     "end_time": "2026-07-18T20:21:11.182849+00:00",
+     "duration": 0.345491,
+     "end_time": "2026-07-19T03:42:58.754045+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:10.755609+00:00",
+     "start_time": "2026-07-19T03:42:58.408554+00:00",
      "status": "completed"
     }
    },
@@ -938,7 +938,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  rolling_sharpe_63: pandas=0.0036s, polars=0.0022s, speedup=1.6x\n"
+      "  rolling_sharpe_63: pandas=0.0033s, polars=0.0021s, speedup=1.5x\n"
      ]
     }
    ],
@@ -965,14 +965,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90cd0055",
+   "id": "f004c91a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003462,
-     "end_time": "2026-07-18T20:21:11.189958+00:00",
+     "duration": 0.003299,
+     "end_time": "2026-07-19T03:42:58.760888+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.186496+00:00",
+     "start_time": "2026-07-19T03:42:58.757589+00:00",
      "status": "completed"
     }
    },
@@ -985,19 +985,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "2fbdf335",
+   "id": "8456c479",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.197313Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.197201Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.199105Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.198783Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.768244Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.768140Z",
+     "iopub.status.idle": "2026-07-19T03:42:58.770112Z",
+     "shell.execute_reply": "2026-07-19T03:42:58.769758Z"
     },
     "papermill": {
-     "duration": 0.006101,
-     "end_time": "2026-07-18T20:21:11.199397+00:00",
+     "duration": 0.00617,
+     "end_time": "2026-07-19T03:42:58.770400+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.193296+00:00",
+     "start_time": "2026-07-19T03:42:58.764230+00:00",
      "status": "completed"
     }
    },
@@ -1014,19 +1014,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "ed786405",
+   "id": "e67c880f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.206752Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.206667Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.483544Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.483137Z"
+     "iopub.execute_input": "2026-07-19T03:42:58.777897Z",
+     "iopub.status.busy": "2026-07-19T03:42:58.777803Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.099510Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.099200Z"
     },
     "papermill": {
-     "duration": 0.281166,
-     "end_time": "2026-07-18T20:21:11.484005+00:00",
+     "duration": 0.326069,
+     "end_time": "2026-07-19T03:42:59.099919+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.202839+00:00",
+     "start_time": "2026-07-19T03:42:58.773850+00:00",
      "status": "completed"
     }
    },
@@ -1035,7 +1035,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ewm_span_20: pandas=0.0011s, polars=0.0011s, speedup=1.0x\n"
+      "  ewm_span_20: pandas=0.0011s, polars=0.0010s, speedup=1.1x\n"
      ]
     }
    ],
@@ -1057,13 +1057,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2292ce1b",
+   "id": "4f17e8c7",
    "metadata": {
     "papermill": {
-     "duration": 0.003387,
-     "end_time": "2026-07-18T20:21:11.494013+00:00",
+     "duration": 0.003373,
+     "end_time": "2026-07-19T03:42:59.106927+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.490626+00:00",
+     "start_time": "2026-07-19T03:42:59.103554+00:00",
      "status": "completed"
     }
    },
@@ -1076,19 +1076,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "2a550acc",
+   "id": "424aa2bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.501674Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.501512Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.503991Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.503623Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.114147Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.114064Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.115816Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.115551Z"
     },
     "papermill": {
-     "duration": 0.006887,
-     "end_time": "2026-07-18T20:21:11.504302+00:00",
+     "duration": 0.005945,
+     "end_time": "2026-07-19T03:42:59.116183+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.497415+00:00",
+     "start_time": "2026-07-19T03:42:59.110238+00:00",
      "status": "completed"
     }
    },
@@ -1114,14 +1114,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0efa9708",
+   "id": "4ce50ef5",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003375,
-     "end_time": "2026-07-18T20:21:11.511230+00:00",
+     "duration": 0.003271,
+     "end_time": "2026-07-19T03:42:59.122781+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.507855+00:00",
+     "start_time": "2026-07-19T03:42:59.119510+00:00",
      "status": "completed"
     }
    },
@@ -1134,19 +1134,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "8cf554c8",
+   "id": "6679bc93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.518900Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.518757Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.521043Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.520764Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.129876Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.129801Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.131545Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.131320Z"
     },
     "papermill": {
-     "duration": 0.006713,
-     "end_time": "2026-07-18T20:21:11.521287+00:00",
+     "duration": 0.006019,
+     "end_time": "2026-07-19T03:42:59.132098+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.514574+00:00",
+     "start_time": "2026-07-19T03:42:59.126079+00:00",
      "status": "completed"
     }
    },
@@ -1173,19 +1173,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "c4e72e76",
+   "id": "b53b3ac7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.547758Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.547651Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.826373Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.825852Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.155122Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.155016Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.498655Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.498314Z"
     },
     "papermill": {
-     "duration": 0.283235,
-     "end_time": "2026-07-18T20:21:11.826714+00:00",
+     "duration": 0.348254,
+     "end_time": "2026-07-19T03:42:59.498973+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.543479+00:00",
+     "start_time": "2026-07-19T03:42:59.150719+00:00",
      "status": "completed"
     }
    },
@@ -1194,7 +1194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ohlcv_resample_daily: pandas=0.0037s, polars=0.0014s, speedup=2.7x\n"
+      "  ohlcv_resample_daily: pandas=0.0035s, polars=0.0014s, speedup=2.6x\n"
      ]
     }
    ],
@@ -1220,14 +1220,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4181ac05",
+   "id": "d6eed7f3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004079,
-     "end_time": "2026-07-18T20:21:11.834831+00:00",
+     "duration": 0.003435,
+     "end_time": "2026-07-19T03:42:59.506096+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.830752+00:00",
+     "start_time": "2026-07-19T03:42:59.502661+00:00",
      "status": "completed"
     }
    },
@@ -1240,19 +1240,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "56098abc",
+   "id": "e7f4828a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.842531Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.842436Z",
-     "iopub.status.idle": "2026-07-18T20:21:11.844482Z",
-     "shell.execute_reply": "2026-07-18T20:21:11.844124Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.513921Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.513805Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.515984Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.515600Z"
     },
     "papermill": {
-     "duration": 0.006449,
-     "end_time": "2026-07-18T20:21:11.844698+00:00",
+     "duration": 0.007513,
+     "end_time": "2026-07-19T03:42:59.517058+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.838249+00:00",
+     "start_time": "2026-07-19T03:42:59.509545+00:00",
      "status": "completed"
     }
    },
@@ -1272,19 +1272,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "f4027a16",
+   "id": "735c08cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:11.852343Z",
-     "iopub.status.busy": "2026-07-18T20:21:11.852248Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.134637Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.134258Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.525343Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.525236Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.866691Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.866229Z"
     },
     "papermill": {
-     "duration": 0.286858,
-     "end_time": "2026-07-18T20:21:12.135046+00:00",
+     "duration": 0.346033,
+     "end_time": "2026-07-19T03:42:59.867016+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:11.848188+00:00",
+     "start_time": "2026-07-19T03:42:59.520983+00:00",
      "status": "completed"
     }
    },
@@ -1293,7 +1293,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  cross_sectional_stats: pandas=0.0016s, polars=0.0015s, speedup=1.1x\n"
+      "  cross_sectional_stats: pandas=0.0016s, polars=0.0013s, speedup=1.3x\n"
      ]
     }
    ],
@@ -1322,14 +1322,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a64e3ddb",
+   "id": "070d515f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003483,
-     "end_time": "2026-07-18T20:21:12.142359+00:00",
+     "duration": 0.003557,
+     "end_time": "2026-07-19T03:42:59.874367+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.138876+00:00",
+     "start_time": "2026-07-19T03:42:59.870810+00:00",
      "status": "completed"
     }
    },
@@ -1342,19 +1342,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "861d7201",
+   "id": "2b6dc4db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.150131Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.150020Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.152160Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.151765Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.882355Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.882251Z",
+     "iopub.status.idle": "2026-07-19T03:42:59.884540Z",
+     "shell.execute_reply": "2026-07-19T03:42:59.884097Z"
     },
     "papermill": {
-     "duration": 0.006805,
-     "end_time": "2026-07-18T20:21:12.152630+00:00",
+     "duration": 0.00676,
+     "end_time": "2026-07-19T03:42:59.884770+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.145825+00:00",
+     "start_time": "2026-07-19T03:42:59.878010+00:00",
      "status": "completed"
     }
    },
@@ -1376,19 +1376,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "ad7d802f",
+   "id": "596a38db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.161958Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.161873Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.432691Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.432273Z"
+     "iopub.execute_input": "2026-07-19T03:42:59.892540Z",
+     "iopub.status.busy": "2026-07-19T03:42:59.892433Z",
+     "iopub.status.idle": "2026-07-19T03:43:00.214549Z",
+     "shell.execute_reply": "2026-07-19T03:43:00.214184Z"
     },
     "papermill": {
-     "duration": 0.276284,
-     "end_time": "2026-07-18T20:21:12.433162+00:00",
+     "duration": 0.326522,
+     "end_time": "2026-07-19T03:43:00.214864+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.156878+00:00",
+     "start_time": "2026-07-19T03:42:59.888342+00:00",
      "status": "completed"
     }
    },
@@ -1397,7 +1397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  symbol_stats: pandas=0.0019s, polars=0.0011s, speedup=1.7x\n"
+      "  symbol_stats: pandas=0.0020s, polars=0.0014s, speedup=1.4x\n"
      ]
     }
    ],
@@ -1429,13 +1429,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e882888",
+   "id": "cb5e91e7",
    "metadata": {
     "papermill": {
-     "duration": 0.003704,
-     "end_time": "2026-07-18T20:21:12.440646+00:00",
+     "duration": 0.003492,
+     "end_time": "2026-07-19T03:43:00.222150+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.436942+00:00",
+     "start_time": "2026-07-19T03:43:00.218658+00:00",
      "status": "completed"
     }
    },
@@ -1449,19 +1449,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "35b167d5",
+   "id": "6ea6905e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.448438Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.448344Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.450262Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.449935Z"
+     "iopub.execute_input": "2026-07-19T03:43:00.229716Z",
+     "iopub.status.busy": "2026-07-19T03:43:00.229627Z",
+     "iopub.status.idle": "2026-07-19T03:43:00.231441Z",
+     "shell.execute_reply": "2026-07-19T03:43:00.231140Z"
     },
     "papermill": {
-     "duration": 0.006474,
-     "end_time": "2026-07-18T20:21:12.450599+00:00",
+     "duration": 0.006245,
+     "end_time": "2026-07-19T03:43:00.231811+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.444125+00:00",
+     "start_time": "2026-07-19T03:43:00.225566+00:00",
      "status": "completed"
     }
    },
@@ -1487,14 +1487,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39140511",
+   "id": "e34a50f6",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003597,
-     "end_time": "2026-07-18T20:21:12.457866+00:00",
+     "duration": 0.003437,
+     "end_time": "2026-07-19T03:43:00.238788+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.454269+00:00",
+     "start_time": "2026-07-19T03:43:00.235351+00:00",
      "status": "completed"
     }
    },
@@ -1507,19 +1507,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "e8f04e97",
+   "id": "e1e4a635",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.465749Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.465642Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.467869Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.467416Z"
+     "iopub.execute_input": "2026-07-19T03:43:00.247567Z",
+     "iopub.status.busy": "2026-07-19T03:43:00.247486Z",
+     "iopub.status.idle": "2026-07-19T03:43:00.249466Z",
+     "shell.execute_reply": "2026-07-19T03:43:00.249042Z"
     },
     "papermill": {
-     "duration": 0.007065,
-     "end_time": "2026-07-18T20:21:12.468426+00:00",
+     "duration": 0.007868,
+     "end_time": "2026-07-19T03:43:00.250118+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.461361+00:00",
+     "start_time": "2026-07-19T03:43:00.242250+00:00",
      "status": "completed"
     }
    },
@@ -1537,19 +1537,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "b0818e35",
+   "id": "268e63c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.480761Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.480606Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.777463Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.776936Z"
+     "iopub.execute_input": "2026-07-19T03:43:00.262743Z",
+     "iopub.status.busy": "2026-07-19T03:43:00.262626Z",
+     "iopub.status.idle": "2026-07-19T03:43:00.607632Z",
+     "shell.execute_reply": "2026-07-19T03:43:00.607140Z"
     },
     "papermill": {
-     "duration": 0.302144,
-     "end_time": "2026-07-18T20:21:12.777860+00:00",
+     "duration": 0.351057,
+     "end_time": "2026-07-19T03:43:00.608086+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.475716+00:00",
+     "start_time": "2026-07-19T03:43:00.257029+00:00",
      "status": "completed"
     }
    },
@@ -1558,7 +1558,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  cross_sectional_zscore: pandas=0.0043s, polars=0.0037s, speedup=1.2x\n"
+      "  cross_sectional_zscore: pandas=0.0039s, polars=0.0036s, speedup=1.1x\n"
      ]
     }
    ],
@@ -1583,14 +1583,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd2e9a78",
+   "id": "ffecb25d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003582,
-     "end_time": "2026-07-18T20:21:12.785397+00:00",
+     "duration": 0.003581,
+     "end_time": "2026-07-19T03:43:00.615552+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.781815+00:00",
+     "start_time": "2026-07-19T03:43:00.611971+00:00",
      "status": "completed"
     }
    },
@@ -1603,19 +1603,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "e0273235",
+   "id": "54b38de7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.793581Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.793474Z",
-     "iopub.status.idle": "2026-07-18T20:21:12.795781Z",
-     "shell.execute_reply": "2026-07-18T20:21:12.795359Z"
+     "iopub.execute_input": "2026-07-19T03:43:00.623211Z",
+     "iopub.status.busy": "2026-07-19T03:43:00.623103Z",
+     "iopub.status.idle": "2026-07-19T03:43:00.625421Z",
+     "shell.execute_reply": "2026-07-19T03:43:00.625027Z"
     },
     "papermill": {
-     "duration": 0.00718,
-     "end_time": "2026-07-18T20:21:12.796126+00:00",
+     "duration": 0.006647,
+     "end_time": "2026-07-19T03:43:00.625715+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.788946+00:00",
+     "start_time": "2026-07-19T03:43:00.619068+00:00",
      "status": "completed"
     }
    },
@@ -1632,19 +1632,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "8ed2a0a9",
+   "id": "71d827d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:12.804105Z",
-     "iopub.status.busy": "2026-07-18T20:21:12.804013Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.134252Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.133745Z"
+     "iopub.execute_input": "2026-07-19T03:43:00.633845Z",
+     "iopub.status.busy": "2026-07-19T03:43:00.633751Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.029753Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.029324Z"
     },
     "papermill": {
-     "duration": 0.334792,
-     "end_time": "2026-07-18T20:21:13.134554+00:00",
+     "duration": 0.400454,
+     "end_time": "2026-07-19T03:43:01.030172+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:12.799762+00:00",
+     "start_time": "2026-07-19T03:43:00.629718+00:00",
      "status": "completed"
     }
    },
@@ -1653,7 +1653,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  percentile_rank: pandas=0.0047s, polars=0.0110s, speedup=0.4x\n"
+      "  percentile_rank: pandas=0.0046s, polars=0.0109s, speedup=0.4x\n"
      ]
     }
    ],
@@ -1677,13 +1677,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dcdc3be",
+   "id": "74c123cd",
    "metadata": {
     "papermill": {
-     "duration": 0.003696,
-     "end_time": "2026-07-18T20:21:13.142228+00:00",
+     "duration": 0.004656,
+     "end_time": "2026-07-19T03:43:01.042311+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.138532+00:00",
+     "start_time": "2026-07-19T03:43:01.037655+00:00",
      "status": "completed"
     }
    },
@@ -1696,19 +1696,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "806c744b",
+   "id": "58a95152",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.150286Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.150177Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.152740Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.152239Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.052724Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.052606Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.054658Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.054373Z"
     },
     "papermill": {
-     "duration": 0.007305,
-     "end_time": "2026-07-18T20:21:13.153120+00:00",
+     "duration": 0.007716,
+     "end_time": "2026-07-19T03:43:01.055071+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.145815+00:00",
+     "start_time": "2026-07-19T03:43:01.047355+00:00",
      "status": "completed"
     }
    },
@@ -1728,19 +1728,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "e8e00231",
+   "id": "ff6a26ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.161557Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.161408Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.444842Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.444312Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.062648Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.062582Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.393428Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.393103Z"
     },
     "papermill": {
-     "duration": 0.28812,
-     "end_time": "2026-07-18T20:21:13.445151+00:00",
+     "duration": 0.335238,
+     "end_time": "2026-07-19T03:43:01.393928+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.157031+00:00",
+     "start_time": "2026-07-19T03:43:01.058690+00:00",
      "status": "completed"
     }
    },
@@ -1749,7 +1749,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  lagged_values: pandas=0.0035s, polars=0.0017s, speedup=2.0x\n"
+      "  lagged_values: pandas=0.0034s, polars=0.0011s, speedup=3.1x\n"
      ]
     }
    ],
@@ -1771,13 +1771,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80070d7e",
+   "id": "d86f1a87",
    "metadata": {
     "papermill": {
-     "duration": 0.003667,
-     "end_time": "2026-07-18T20:21:13.452748+00:00",
+     "duration": 0.003676,
+     "end_time": "2026-07-19T03:43:01.401566+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.449081+00:00",
+     "start_time": "2026-07-19T03:43:01.397890+00:00",
      "status": "completed"
     }
    },
@@ -1791,19 +1791,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "71f39962",
+   "id": "696a87aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.460771Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.460671Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.462748Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.462466Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.409159Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.409076Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.410830Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.410567Z"
     },
     "papermill": {
-     "duration": 0.006772,
-     "end_time": "2026-07-18T20:21:13.463137+00:00",
+     "duration": 0.00609,
+     "end_time": "2026-07-19T03:43:01.411189+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.456365+00:00",
+     "start_time": "2026-07-19T03:43:01.405099+00:00",
      "status": "completed"
     }
    },
@@ -1829,13 +1829,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51298379",
+   "id": "aed95401",
    "metadata": {
     "papermill": {
-     "duration": 0.003627,
-     "end_time": "2026-07-18T20:21:13.471834+00:00",
+     "duration": 0.003761,
+     "end_time": "2026-07-19T03:43:01.419661+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.468207+00:00",
+     "start_time": "2026-07-19T03:43:01.415900+00:00",
      "status": "completed"
     }
    },
@@ -1846,19 +1846,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "e793db33",
+   "id": "117973b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.480033Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.479911Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.482768Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.482361Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.427837Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.427709Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.430285Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.429984Z"
     },
     "papermill": {
-     "duration": 0.007593,
-     "end_time": "2026-07-18T20:21:13.483044+00:00",
+     "duration": 0.007309,
+     "end_time": "2026-07-19T03:43:01.430645+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.475451+00:00",
+     "start_time": "2026-07-19T03:43:01.423336+00:00",
      "status": "completed"
     }
    },
@@ -1877,19 +1877,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "c9be2dbe",
+   "id": "8c99f554",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.491143Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.491037Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.752686Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.752192Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.438836Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.438730Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.758520Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.758206Z"
     },
     "papermill": {
-     "duration": 0.266575,
-     "end_time": "2026-07-18T20:21:13.753341+00:00",
+     "duration": 0.324729,
+     "end_time": "2026-07-19T03:43:01.759046+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.486766+00:00",
+     "start_time": "2026-07-19T03:43:01.434317+00:00",
      "status": "completed"
     }
    },
@@ -1916,13 +1916,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0cb992a",
+   "id": "d0b67f35",
    "metadata": {
     "papermill": {
-     "duration": 0.00371,
-     "end_time": "2026-07-18T20:21:13.761090+00:00",
+     "duration": 0.003681,
+     "end_time": "2026-07-19T03:43:01.766723+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.757380+00:00",
+     "start_time": "2026-07-19T03:43:01.763042+00:00",
      "status": "completed"
     }
    },
@@ -1935,19 +1935,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "2a8ec250",
+   "id": "96b88718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.769521Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.769423Z",
-     "iopub.status.idle": "2026-07-18T20:21:13.773664Z",
-     "shell.execute_reply": "2026-07-18T20:21:13.773256Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.774858Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.774754Z",
+     "iopub.status.idle": "2026-07-19T03:43:01.778892Z",
+     "shell.execute_reply": "2026-07-19T03:43:01.778551Z"
     },
     "papermill": {
-     "duration": 0.009167,
-     "end_time": "2026-07-18T20:21:13.774194+00:00",
+     "duration": 0.008884,
+     "end_time": "2026-07-19T03:43:01.779476+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.765027+00:00",
+     "start_time": "2026-07-19T03:43:01.770592+00:00",
      "status": "completed"
     }
    },
@@ -1971,19 +1971,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "216d2467",
+   "id": "233fc674",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:13.783730Z",
-     "iopub.status.busy": "2026-07-18T20:21:13.783644Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.049619Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.049182Z"
+     "iopub.execute_input": "2026-07-19T03:43:01.788556Z",
+     "iopub.status.busy": "2026-07-19T03:43:01.788456Z",
+     "iopub.status.idle": "2026-07-19T03:43:02.257143Z",
+     "shell.execute_reply": "2026-07-19T03:43:02.256450Z"
     },
     "papermill": {
-     "duration": 0.271148,
-     "end_time": "2026-07-18T20:21:14.050236+00:00",
+     "duration": 0.473243,
+     "end_time": "2026-07-19T03:43:02.257555+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:13.779088+00:00",
+     "start_time": "2026-07-19T03:43:01.784312+00:00",
      "status": "completed"
     }
    },
@@ -1992,7 +1992,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  multi_condition_filter: pandas=0.0012s, polars=0.0010s, speedup=1.3x\n"
+      "  multi_condition_filter: pandas=0.0012s, polars=0.0011s, speedup=1.1x\n"
      ]
     }
    ],
@@ -2014,14 +2014,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c76e7ed9",
+   "id": "4f80a955",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003685,
-     "end_time": "2026-07-18T20:21:14.060954+00:00",
+     "duration": 0.00367,
+     "end_time": "2026-07-19T03:43:02.265782+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.057269+00:00",
+     "start_time": "2026-07-19T03:43:02.262112+00:00",
      "status": "completed"
     }
    },
@@ -2034,19 +2034,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "cddbdcdb",
+   "id": "04a620e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.072625Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.072527Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.074671Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.074290Z"
+     "iopub.execute_input": "2026-07-19T03:43:02.279017Z",
+     "iopub.status.busy": "2026-07-19T03:43:02.278856Z",
+     "iopub.status.idle": "2026-07-19T03:43:02.281526Z",
+     "shell.execute_reply": "2026-07-19T03:43:02.281037Z"
     },
     "papermill": {
-     "duration": 0.007171,
-     "end_time": "2026-07-18T20:21:14.075139+00:00",
+     "duration": 0.009808,
+     "end_time": "2026-07-19T03:43:02.281787+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.067968+00:00",
+     "start_time": "2026-07-19T03:43:02.271979+00:00",
      "status": "completed"
     }
    },
@@ -2068,19 +2068,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "df7dcde0",
+   "id": "aa067c04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.085784Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.085694Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.363834Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.363454Z"
+     "iopub.execute_input": "2026-07-19T03:43:02.290554Z",
+     "iopub.status.busy": "2026-07-19T03:43:02.290420Z",
+     "iopub.status.idle": "2026-07-19T03:43:02.650805Z",
+     "shell.execute_reply": "2026-07-19T03:43:02.650205Z"
     },
     "papermill": {
-     "duration": 0.283191,
-     "end_time": "2026-07-18T20:21:14.364505+00:00",
+     "duration": 0.365575,
+     "end_time": "2026-07-19T03:43:02.651446+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.081314+00:00",
+     "start_time": "2026-07-19T03:43:02.285871+00:00",
      "status": "completed"
     }
    },
@@ -2089,7 +2089,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  range_filter: pandas=0.0015s, polars=0.0006s, speedup=2.6x\n"
+      "  range_filter: pandas=0.0016s, polars=0.0009s, speedup=1.9x\n"
      ]
     }
    ],
@@ -2113,13 +2113,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ad394e6",
+   "id": "68d9cfd3",
    "metadata": {
     "papermill": {
-     "duration": 0.003825,
-     "end_time": "2026-07-18T20:21:14.390461+00:00",
+     "duration": 0.003777,
+     "end_time": "2026-07-19T03:43:02.672489+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.386636+00:00",
+     "start_time": "2026-07-19T03:43:02.668712+00:00",
      "status": "completed"
     }
    },
@@ -2133,19 +2133,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "a2b14c19",
+   "id": "0c78f577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.399021Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.398918Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.401018Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.400556Z"
+     "iopub.execute_input": "2026-07-19T03:43:02.681242Z",
+     "iopub.status.busy": "2026-07-19T03:43:02.681084Z",
+     "iopub.status.idle": "2026-07-19T03:43:02.683431Z",
+     "shell.execute_reply": "2026-07-19T03:43:02.683021Z"
     },
     "papermill": {
-     "duration": 0.007136,
-     "end_time": "2026-07-18T20:21:14.401391+00:00",
+     "duration": 0.007887,
+     "end_time": "2026-07-19T03:43:02.684037+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.394255+00:00",
+     "start_time": "2026-07-19T03:43:02.676150+00:00",
      "status": "completed"
     }
    },
@@ -2171,13 +2171,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "febd81f2",
+   "id": "4914c979",
    "metadata": {
     "papermill": {
-     "duration": 0.003712,
-     "end_time": "2026-07-18T20:21:14.408975+00:00",
+     "duration": 0.003796,
+     "end_time": "2026-07-19T03:43:02.691751+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.405263+00:00",
+     "start_time": "2026-07-19T03:43:02.687955+00:00",
      "status": "completed"
     }
    },
@@ -2190,19 +2190,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "2822283e",
+   "id": "e6101ec5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.417229Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.417127Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.423889Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.423521Z"
+     "iopub.execute_input": "2026-07-19T03:43:02.700091Z",
+     "iopub.status.busy": "2026-07-19T03:43:02.699940Z",
+     "iopub.status.idle": "2026-07-19T03:43:02.708115Z",
+     "shell.execute_reply": "2026-07-19T03:43:02.707668Z"
     },
     "papermill": {
-     "duration": 0.011918,
-     "end_time": "2026-07-18T20:21:14.424607+00:00",
+     "duration": 0.013008,
+     "end_time": "2026-07-19T03:43:02.708460+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.412689+00:00",
+     "start_time": "2026-07-19T03:43:02.695452+00:00",
      "status": "completed"
     }
    },
@@ -2232,19 +2232,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "0c60fbc9",
+   "id": "4daa2a3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.435421Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.435323Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.725080Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.724419Z"
+     "iopub.execute_input": "2026-07-19T03:43:02.716891Z",
+     "iopub.status.busy": "2026-07-19T03:43:02.716807Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.065869Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.065398Z"
     },
     "papermill": {
-     "duration": 0.294723,
-     "end_time": "2026-07-18T20:21:14.725508+00:00",
+     "duration": 0.353755,
+     "end_time": "2026-07-19T03:43:03.066143+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.430785+00:00",
+     "start_time": "2026-07-19T03:43:02.712388+00:00",
      "status": "completed"
     }
    },
@@ -2253,7 +2253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  asof_join: pandas=0.0032s, polars=0.0009s, speedup=3.5x\n"
+      "  asof_join: pandas=0.0032s, polars=0.0011s, speedup=3.0x\n"
      ]
     }
    ],
@@ -2276,14 +2276,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea337353",
+   "id": "3c8bb97c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-07-18T20:21:14.733504+00:00",
+     "duration": 0.004192,
+     "end_time": "2026-07-19T03:43:03.074657+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.729688+00:00",
+     "start_time": "2026-07-19T03:43:03.070465+00:00",
      "status": "completed"
     }
    },
@@ -2297,19 +2297,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "ad098b05",
+   "id": "a672bf96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.745823Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.745643Z",
-     "iopub.status.idle": "2026-07-18T20:21:14.749505Z",
-     "shell.execute_reply": "2026-07-18T20:21:14.749038Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.084235Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.084071Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.087156Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.086769Z"
     },
     "papermill": {
-     "duration": 0.008943,
-     "end_time": "2026-07-18T20:21:14.749842+00:00",
+     "duration": 0.008641,
+     "end_time": "2026-07-19T03:43:03.087409+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.740899+00:00",
+     "start_time": "2026-07-19T03:43:03.078768+00:00",
      "status": "completed"
     }
    },
@@ -2354,19 +2354,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "98ce3ca4",
+   "id": "72330dcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:14.758492Z",
-     "iopub.status.busy": "2026-07-18T20:21:14.758385Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.079698Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.079198Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.096562Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.096441Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.435995Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.435551Z"
     },
     "papermill": {
-     "duration": 0.326223,
-     "end_time": "2026-07-18T20:21:15.080130+00:00",
+     "duration": 0.344741,
+     "end_time": "2026-07-19T03:43:03.436271+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:14.753907+00:00",
+     "start_time": "2026-07-19T03:43:03.091530+00:00",
      "status": "completed"
     }
    },
@@ -2375,7 +2375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  anti_join: pandas=0.0071s, polars=0.0021s, speedup=3.4x\n"
+      "  anti_join: pandas=0.0063s, polars=0.0019s, speedup=3.3x\n"
      ]
     }
    ],
@@ -2397,13 +2397,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a581340",
+   "id": "6081e0c3",
    "metadata": {
     "papermill": {
-     "duration": 0.003807,
-     "end_time": "2026-07-18T20:21:15.088080+00:00",
+     "duration": 0.003814,
+     "end_time": "2026-07-19T03:43:03.444347+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.084273+00:00",
+     "start_time": "2026-07-19T03:43:03.440533+00:00",
      "status": "completed"
     }
    },
@@ -2416,19 +2416,19 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "01b8503e",
+   "id": "06135619",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.096803Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.096693Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.100703Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.100346Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.452438Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.452345Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.456600Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.456112Z"
     },
     "papermill": {
-     "duration": 0.008992,
-     "end_time": "2026-07-18T20:21:15.100973+00:00",
+     "duration": 0.008767,
+     "end_time": "2026-07-19T03:43:03.456882+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.091981+00:00",
+     "start_time": "2026-07-19T03:43:03.448115+00:00",
      "status": "completed"
     }
    },
@@ -2458,19 +2458,19 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "0b93ea83",
+   "id": "4cec6be1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.110102Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.110010Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.402928Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.402427Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.465062Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.464920Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.815106Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.814695Z"
     },
     "papermill": {
-     "duration": 0.298252,
-     "end_time": "2026-07-18T20:21:15.403256+00:00",
+     "duration": 0.35474,
+     "end_time": "2026-07-19T03:43:03.815450+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.105004+00:00",
+     "start_time": "2026-07-19T03:43:03.460710+00:00",
      "status": "completed"
     }
    },
@@ -2479,7 +2479,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  inner_join: pandas=0.0046s, polars=0.0009s, speedup=4.9x\n"
+      "  inner_join: pandas=0.0045s, polars=0.0010s, speedup=4.7x\n"
      ]
     }
    ],
@@ -2499,13 +2499,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7210b78c",
+   "id": "999cfbdd",
    "metadata": {
     "papermill": {
-     "duration": 0.003826,
-     "end_time": "2026-07-18T20:21:15.411240+00:00",
+     "duration": 0.00441,
+     "end_time": "2026-07-19T03:43:03.824784+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.407414+00:00",
+     "start_time": "2026-07-19T03:43:03.820374+00:00",
      "status": "completed"
     }
    },
@@ -2519,19 +2519,19 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "c238c04a",
+   "id": "ab65efe1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.419698Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.419589Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.424616Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.424253Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.834744Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.834626Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.840366Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.840041Z"
     },
     "papermill": {
-     "duration": 0.010039,
-     "end_time": "2026-07-18T20:21:15.425091+00:00",
+     "duration": 0.011288,
+     "end_time": "2026-07-19T03:43:03.840753+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.415052+00:00",
+     "start_time": "2026-07-19T03:43:03.829465+00:00",
      "status": "completed"
     }
    },
@@ -2563,14 +2563,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7265e5a8",
+   "id": "1b4f4aa2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003832,
-     "end_time": "2026-07-18T20:21:15.435230+00:00",
+     "duration": 0.003808,
+     "end_time": "2026-07-19T03:43:03.848675+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.431398+00:00",
+     "start_time": "2026-07-19T03:43:03.844867+00:00",
      "status": "completed"
     }
    },
@@ -2583,19 +2583,19 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "f3f38960",
+   "id": "8d4ba328",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.443869Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.443764Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.445645Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.445331Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.856814Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.856722Z",
+     "iopub.status.idle": "2026-07-19T03:43:03.858508Z",
+     "shell.execute_reply": "2026-07-19T03:43:03.858226Z"
     },
     "papermill": {
-     "duration": 0.00688,
-     "end_time": "2026-07-18T20:21:15.445950+00:00",
+     "duration": 0.006462,
+     "end_time": "2026-07-19T03:43:03.858889+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.439070+00:00",
+     "start_time": "2026-07-19T03:43:03.852427+00:00",
      "status": "completed"
     }
    },
@@ -2612,19 +2612,19 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "9258b3d0",
+   "id": "c6ab59cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.455058Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.454915Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.767699Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.767341Z"
+     "iopub.execute_input": "2026-07-19T03:43:03.867181Z",
+     "iopub.status.busy": "2026-07-19T03:43:03.867099Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.210749Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.210370Z"
     },
     "papermill": {
-     "duration": 0.318152,
-     "end_time": "2026-07-18T20:21:15.768077+00:00",
+     "duration": 0.348274,
+     "end_time": "2026-07-19T03:43:04.211097+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.449925+00:00",
+     "start_time": "2026-07-19T03:43:03.862823+00:00",
      "status": "completed"
     }
    },
@@ -2633,7 +2633,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  lazy_filter: pandas=0.0031s, polars=0.0013s, speedup=2.4x\n"
+      "  lazy_filter: pandas=0.0029s, polars=0.0011s, speedup=2.6x\n"
      ]
     }
    ],
@@ -2652,14 +2652,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30529b96",
+   "id": "69ccbda0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003894,
-     "end_time": "2026-07-18T20:21:15.776218+00:00",
+     "duration": 0.003897,
+     "end_time": "2026-07-19T03:43:04.219227+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.772324+00:00",
+     "start_time": "2026-07-19T03:43:04.215330+00:00",
      "status": "completed"
     }
    },
@@ -2672,19 +2672,19 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "31fc465c",
+   "id": "3cb4c6fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.784955Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.784842Z",
-     "iopub.status.idle": "2026-07-18T20:21:15.786656Z",
-     "shell.execute_reply": "2026-07-18T20:21:15.786352Z"
+     "iopub.execute_input": "2026-07-19T03:43:04.227582Z",
+     "iopub.status.busy": "2026-07-19T03:43:04.227493Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.229290Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.229016Z"
     },
     "papermill": {
-     "duration": 0.00693,
-     "end_time": "2026-07-18T20:21:15.787064+00:00",
+     "duration": 0.006683,
+     "end_time": "2026-07-19T03:43:04.229777+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.780134+00:00",
+     "start_time": "2026-07-19T03:43:04.223094+00:00",
      "status": "completed"
     }
    },
@@ -2699,19 +2699,19 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "573cb15c",
+   "id": "f3979644",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:15.795640Z",
-     "iopub.status.busy": "2026-07-18T20:21:15.795541Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.100168Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.099845Z"
+     "iopub.execute_input": "2026-07-19T03:43:04.238457Z",
+     "iopub.status.busy": "2026-07-19T03:43:04.238368Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.570893Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.570400Z"
     },
     "papermill": {
-     "duration": 0.30966,
-     "end_time": "2026-07-18T20:21:16.100745+00:00",
+     "duration": 0.337308,
+     "end_time": "2026-07-19T03:43:04.571175+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:15.791085+00:00",
+     "start_time": "2026-07-19T03:43:04.233867+00:00",
      "status": "completed"
     }
    },
@@ -2720,7 +2720,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  column_projection: pandas=0.0030s, polars=0.0011s, speedup=2.8x\n"
+      "  column_projection: pandas=0.0029s, polars=0.0010s, speedup=2.8x\n"
      ]
     }
    ],
@@ -2738,14 +2738,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a86287e",
+   "id": "01d17f60",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007452,
-     "end_time": "2026-07-18T20:21:16.115985+00:00",
+     "duration": 0.003984,
+     "end_time": "2026-07-19T03:43:04.579506+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.108533+00:00",
+     "start_time": "2026-07-19T03:43:04.575522+00:00",
      "status": "completed"
     }
    },
@@ -2758,19 +2758,19 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "b6da5791",
+   "id": "06f0e667",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.131467Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.131271Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.134059Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.133629Z"
+     "iopub.execute_input": "2026-07-19T03:43:04.588077Z",
+     "iopub.status.busy": "2026-07-19T03:43:04.587933Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.590370Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.589998Z"
     },
     "papermill": {
-     "duration": 0.011134,
-     "end_time": "2026-07-18T20:21:16.134423+00:00",
+     "duration": 0.007245,
+     "end_time": "2026-07-19T03:43:04.590664+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.123289+00:00",
+     "start_time": "2026-07-19T03:43:04.583419+00:00",
      "status": "completed"
     }
    },
@@ -2791,19 +2791,19 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "a1c5a7ac",
+   "id": "fb1f790c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.143379Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.143224Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.440512Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.440081Z"
+     "iopub.execute_input": "2026-07-19T03:43:04.599733Z",
+     "iopub.status.busy": "2026-07-19T03:43:04.599647Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.964007Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.963615Z"
     },
     "papermill": {
-     "duration": 0.302483,
-     "end_time": "2026-07-18T20:21:16.440955+00:00",
+     "duration": 0.369974,
+     "end_time": "2026-07-19T03:43:04.964594+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.138472+00:00",
+     "start_time": "2026-07-19T03:43:04.594620+00:00",
      "status": "completed"
     }
    },
@@ -2812,7 +2812,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  combined_query: pandas=0.0033s, polars=0.0017s, speedup=2.0x\n"
+      "  combined_query: pandas=0.0031s, polars=0.0019s, speedup=1.7x\n"
      ]
     }
    ],
@@ -2843,13 +2843,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b55af36",
+   "id": "ea60d917",
    "metadata": {
     "papermill": {
-     "duration": 0.004005,
-     "end_time": "2026-07-18T20:21:16.449292+00:00",
+     "duration": 0.00402,
+     "end_time": "2026-07-19T03:43:04.973006+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.445287+00:00",
+     "start_time": "2026-07-19T03:43:04.968986+00:00",
      "status": "completed"
     }
    },
@@ -2863,19 +2863,19 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "02d60d24",
+   "id": "512b8a47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.458026Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.457917Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.460209Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.459812Z"
+     "iopub.execute_input": "2026-07-19T03:43:04.983098Z",
+     "iopub.status.busy": "2026-07-19T03:43:04.982910Z",
+     "iopub.status.idle": "2026-07-19T03:43:04.985832Z",
+     "shell.execute_reply": "2026-07-19T03:43:04.985326Z"
     },
     "papermill": {
-     "duration": 0.007342,
-     "end_time": "2026-07-18T20:21:16.460535+00:00",
+     "duration": 0.009144,
+     "end_time": "2026-07-19T03:43:04.986099+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.453193+00:00",
+     "start_time": "2026-07-19T03:43:04.976955+00:00",
      "status": "completed"
     }
    },
@@ -2901,13 +2901,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afe2a1f1",
+   "id": "2896f687",
    "metadata": {
     "papermill": {
-     "duration": 0.003965,
-     "end_time": "2026-07-18T20:21:16.468578+00:00",
+     "duration": 0.003935,
+     "end_time": "2026-07-19T03:43:04.994346+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.464613+00:00",
+     "start_time": "2026-07-19T03:43:04.990411+00:00",
      "status": "completed"
     }
    },
@@ -2918,19 +2918,19 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "21b67500",
+   "id": "42e8a408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.477311Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.477189Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.749264Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.748820Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.003017Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.002918Z",
+     "iopub.status.idle": "2026-07-19T03:43:05.330919Z",
+     "shell.execute_reply": "2026-07-19T03:43:05.330345Z"
     },
     "papermill": {
-     "duration": 0.277447,
-     "end_time": "2026-07-18T20:21:16.749950+00:00",
+     "duration": 0.332955,
+     "end_time": "2026-07-19T03:43:05.331247+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.472503+00:00",
+     "start_time": "2026-07-19T03:43:04.998292+00:00",
      "status": "completed"
     }
    },
@@ -2993,13 +2993,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a48a8ede",
+   "id": "55c2ab9c",
    "metadata": {
     "papermill": {
-     "duration": 0.004061,
-     "end_time": "2026-07-18T20:21:16.759954+00:00",
+     "duration": 0.005685,
+     "end_time": "2026-07-19T03:43:05.342999+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.755893+00:00",
+     "start_time": "2026-07-19T03:43:05.337314+00:00",
      "status": "completed"
     }
    },
@@ -3013,19 +3013,19 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "e383da12",
+   "id": "d8a674b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.769088Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.768983Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.771039Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.770686Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.351732Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.351629Z",
+     "iopub.status.idle": "2026-07-19T03:43:05.353824Z",
+     "shell.execute_reply": "2026-07-19T03:43:05.353396Z"
     },
     "papermill": {
-     "duration": 0.007066,
-     "end_time": "2026-07-18T20:21:16.771298+00:00",
+     "duration": 0.007292,
+     "end_time": "2026-07-19T03:43:05.354189+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.764232+00:00",
+     "start_time": "2026-07-19T03:43:05.346897+00:00",
      "status": "completed"
     }
    },
@@ -3051,14 +3051,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fdface0a",
+   "id": "e046f090",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003952,
-     "end_time": "2026-07-18T20:21:16.779526+00:00",
+     "duration": 0.00396,
+     "end_time": "2026-07-19T03:43:05.362438+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.775574+00:00",
+     "start_time": "2026-07-19T03:43:05.358478+00:00",
      "status": "completed"
     }
    },
@@ -3069,19 +3069,19 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "7b5cac51",
+   "id": "e6954d86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.788059Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.787958Z",
-     "iopub.status.idle": "2026-07-18T20:21:16.789859Z",
-     "shell.execute_reply": "2026-07-18T20:21:16.789542Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.371331Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.371215Z",
+     "iopub.status.idle": "2026-07-19T03:43:05.373110Z",
+     "shell.execute_reply": "2026-07-19T03:43:05.372766Z"
     },
     "papermill": {
-     "duration": 0.006799,
-     "end_time": "2026-07-18T20:21:16.790248+00:00",
+     "duration": 0.007037,
+     "end_time": "2026-07-19T03:43:05.373411+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.783449+00:00",
+     "start_time": "2026-07-19T03:43:05.366374+00:00",
      "status": "completed"
     }
    },
@@ -3096,19 +3096,19 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "3d950b43",
+   "id": "7a89f7d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:16.799157Z",
-     "iopub.status.busy": "2026-07-18T20:21:16.799057Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.097176Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.096732Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.381871Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.381793Z",
+     "iopub.status.idle": "2026-07-19T03:43:05.706230Z",
+     "shell.execute_reply": "2026-07-19T03:43:05.705836Z"
     },
     "papermill": {
-     "duration": 0.303171,
-     "end_time": "2026-07-18T20:21:17.097525+00:00",
+     "duration": 0.329516,
+     "end_time": "2026-07-19T03:43:05.706884+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:16.794354+00:00",
+     "start_time": "2026-07-19T03:43:05.377368+00:00",
      "status": "completed"
     }
    },
@@ -3117,7 +3117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_contains: pandas=0.0026s, polars=0.0010s, speedup=2.6x\n"
+      "  str_contains: pandas=0.0025s, polars=0.0005s, speedup=5.3x\n"
      ]
     }
    ],
@@ -3135,14 +3135,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88ac1161",
+   "id": "a2a3e378",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004537,
-     "end_time": "2026-07-18T20:21:17.106605+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-07-19T03:43:05.715492+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.102068+00:00",
+     "start_time": "2026-07-19T03:43:05.711491+00:00",
      "status": "completed"
     }
    },
@@ -3153,19 +3153,19 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "f34e9464",
+   "id": "5458301c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.116138Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.115982Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.118035Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.117711Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.724038Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.723957Z",
+     "iopub.status.idle": "2026-07-19T03:43:05.725735Z",
+     "shell.execute_reply": "2026-07-19T03:43:05.725416Z"
     },
     "papermill": {
-     "duration": 0.007585,
-     "end_time": "2026-07-18T20:21:17.118464+00:00",
+     "duration": 0.006761,
+     "end_time": "2026-07-19T03:43:05.726195+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.110879+00:00",
+     "start_time": "2026-07-19T03:43:05.719434+00:00",
      "status": "completed"
     }
    },
@@ -3181,19 +3181,19 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "f08e03af",
+   "id": "919d24f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.127456Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.127367Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.442890Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.442577Z"
+     "iopub.execute_input": "2026-07-19T03:43:05.736967Z",
+     "iopub.status.busy": "2026-07-19T03:43:05.736897Z",
+     "iopub.status.idle": "2026-07-19T03:43:06.069914Z",
+     "shell.execute_reply": "2026-07-19T03:43:06.069477Z"
     },
     "papermill": {
-     "duration": 0.320769,
-     "end_time": "2026-07-18T20:21:17.443413+00:00",
+     "duration": 0.337871,
+     "end_time": "2026-07-19T03:43:06.070273+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.122644+00:00",
+     "start_time": "2026-07-19T03:43:05.732402+00:00",
      "status": "completed"
     }
    },
@@ -3202,7 +3202,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_replace: pandas=0.0049s, polars=0.0007s, speedup=7.1x\n"
+      "  str_replace: pandas=0.0047s, polars=0.0008s, speedup=6.1x\n"
      ]
     }
    ],
@@ -3222,14 +3222,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc979da1",
+   "id": "91a3e347",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004144,
-     "end_time": "2026-07-18T20:21:17.452037+00:00",
+     "duration": 0.004044,
+     "end_time": "2026-07-19T03:43:06.078772+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.447893+00:00",
+     "start_time": "2026-07-19T03:43:06.074728+00:00",
      "status": "completed"
     }
    },
@@ -3240,19 +3240,19 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "872bb824",
+   "id": "28fca11b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.460960Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.460859Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.462732Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.462362Z"
+     "iopub.execute_input": "2026-07-19T03:43:06.090169Z",
+     "iopub.status.busy": "2026-07-19T03:43:06.090051Z",
+     "iopub.status.idle": "2026-07-19T03:43:06.091989Z",
+     "shell.execute_reply": "2026-07-19T03:43:06.091699Z"
     },
     "papermill": {
-     "duration": 0.007029,
-     "end_time": "2026-07-18T20:21:17.463158+00:00",
+     "duration": 0.007157,
+     "end_time": "2026-07-19T03:43:06.092344+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.456129+00:00",
+     "start_time": "2026-07-19T03:43:06.085187+00:00",
      "status": "completed"
     }
    },
@@ -3268,19 +3268,19 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "905b2ab5",
+   "id": "fa0d884b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.472098Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.471999Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.767107Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.766694Z"
+     "iopub.execute_input": "2026-07-19T03:43:06.101182Z",
+     "iopub.status.busy": "2026-07-19T03:43:06.101095Z",
+     "iopub.status.idle": "2026-07-19T03:43:06.462245Z",
+     "shell.execute_reply": "2026-07-19T03:43:06.461812Z"
     },
     "papermill": {
-     "duration": 0.30031,
-     "end_time": "2026-07-18T20:21:17.767650+00:00",
+     "duration": 0.366096,
+     "end_time": "2026-07-19T03:43:06.462594+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.467340+00:00",
+     "start_time": "2026-07-19T03:43:06.096498+00:00",
      "status": "completed"
     }
    },
@@ -3289,7 +3289,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  str_extract: pandas=0.0054s, polars=0.0008s, speedup=6.6x\n"
+      "  str_extract: pandas=0.0053s, polars=0.0009s, speedup=6.2x\n"
      ]
     }
    ],
@@ -3311,13 +3311,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9537039a",
+   "id": "66bc3a61",
    "metadata": {
     "papermill": {
-     "duration": 0.004129,
-     "end_time": "2026-07-18T20:21:17.776203+00:00",
+     "duration": 0.004236,
+     "end_time": "2026-07-19T03:43:06.471342+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.772074+00:00",
+     "start_time": "2026-07-19T03:43:06.467106+00:00",
      "status": "completed"
     }
    },
@@ -3328,19 +3328,19 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "4dc787a0",
+   "id": "eb810d86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.785075Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.784981Z",
-     "iopub.status.idle": "2026-07-18T20:21:17.795054Z",
-     "shell.execute_reply": "2026-07-18T20:21:17.794777Z"
+     "iopub.execute_input": "2026-07-19T03:43:06.480735Z",
+     "iopub.status.busy": "2026-07-19T03:43:06.480622Z",
+     "iopub.status.idle": "2026-07-19T03:43:06.489565Z",
+     "shell.execute_reply": "2026-07-19T03:43:06.489158Z"
     },
     "papermill": {
-     "duration": 0.015155,
-     "end_time": "2026-07-18T20:21:17.795436+00:00",
+     "duration": 0.014222,
+     "end_time": "2026-07-19T03:43:06.489889+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.780281+00:00",
+     "start_time": "2026-07-19T03:43:06.475667+00:00",
      "status": "completed"
     }
    },
@@ -3367,7 +3367,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (8, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>mean_speedup</th><th>min_speedup</th><th>max_speedup</th><th>n_ops</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>5.449681</td><td>2.63587</td><td>7.075123</td><td>3</td></tr><tr><td>&quot;E_join&quot;</td><td>3.961029</td><td>3.43296</td><td>4.922292</td><td>3</td></tr><tr><td>&quot;F_lazy&quot;</td><td>2.382538</td><td>1.999468</td><td>2.776322</td><td>3</td></tr><tr><td>&quot;D_filter&quot;</td><td>2.25142</td><td>1.274596</td><td>2.908793</td><td>3</td></tr><tr><td>&quot;B_groupby&quot;</td><td>1.823755</td><td>1.058339</td><td>2.672985</td><td>3</td></tr><tr><td>&quot;G_memory&quot;</td><td>1.815652</td><td>1.815652</td><td>1.815652</td><td>1</td></tr><tr><td>&quot;A_rolling&quot;</td><td>1.663839</td><td>0.866258</td><td>3.936437</td><td>5</td></tr><tr><td>&quot;C_window&quot;</td><td>1.219659</td><td>0.424272</td><td>2.047402</td><td>3</td></tr></tbody></table></div>"
+       "<small>shape: (8, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>mean_speedup</th><th>min_speedup</th><th>max_speedup</th><th>n_ops</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>5.872602</td><td>5.30789</td><td>6.206668</td><td>3</td></tr><tr><td>&quot;E_join&quot;</td><td>3.63847</td><td>2.95285</td><td>4.678021</td><td>3</td></tr><tr><td>&quot;F_lazy&quot;</td><td>2.379486</td><td>1.677788</td><td>2.816734</td><td>3</td></tr><tr><td>&quot;D_filter&quot;</td><td>1.926734</td><td>1.05555</td><td>2.868141</td><td>3</td></tr><tr><td>&quot;G_memory&quot;</td><td>1.815652</td><td>1.815652</td><td>1.815652</td><td>1</td></tr><tr><td>&quot;A_rolling&quot;</td><td>1.78242</td><td>0.970304</td><td>4.287955</td><td>5</td></tr><tr><td>&quot;B_groupby&quot;</td><td>1.758083</td><td>1.272597</td><td>2.575381</td><td>3</td></tr><tr><td>&quot;C_window&quot;</td><td>1.531532</td><td>0.42252</td><td>3.098696</td><td>3</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (8, 5)\n",
@@ -3376,14 +3376,14 @@
        "│ ---       ┆ ---          ┆ ---         ┆ ---         ┆ ---   │\n",
        "│ str       ┆ f64          ┆ f64         ┆ f64         ┆ u32   │\n",
        "╞═══════════╪══════════════╪═════════════╪═════════════╪═══════╡\n",
-       "│ H_string  ┆ 5.449681     ┆ 2.63587     ┆ 7.075123    ┆ 3     │\n",
-       "│ E_join    ┆ 3.961029     ┆ 3.43296     ┆ 4.922292    ┆ 3     │\n",
-       "│ F_lazy    ┆ 2.382538     ┆ 1.999468    ┆ 2.776322    ┆ 3     │\n",
-       "│ D_filter  ┆ 2.25142      ┆ 1.274596    ┆ 2.908793    ┆ 3     │\n",
-       "│ B_groupby ┆ 1.823755     ┆ 1.058339    ┆ 2.672985    ┆ 3     │\n",
+       "│ H_string  ┆ 5.872602     ┆ 5.30789     ┆ 6.206668    ┆ 3     │\n",
+       "│ E_join    ┆ 3.63847      ┆ 2.95285     ┆ 4.678021    ┆ 3     │\n",
+       "│ F_lazy    ┆ 2.379486     ┆ 1.677788    ┆ 2.816734    ┆ 3     │\n",
+       "│ D_filter  ┆ 1.926734     ┆ 1.05555     ┆ 2.868141    ┆ 3     │\n",
        "│ G_memory  ┆ 1.815652     ┆ 1.815652    ┆ 1.815652    ┆ 1     │\n",
-       "│ A_rolling ┆ 1.663839     ┆ 0.866258    ┆ 3.936437    ┆ 5     │\n",
-       "│ C_window  ┆ 1.219659     ┆ 0.424272    ┆ 2.047402    ┆ 3     │\n",
+       "│ A_rolling ┆ 1.78242      ┆ 0.970304    ┆ 4.287955    ┆ 5     │\n",
+       "│ B_groupby ┆ 1.758083     ┆ 1.272597    ┆ 2.575381    ┆ 3     │\n",
+       "│ C_window  ┆ 1.531532     ┆ 0.42252     ┆ 3.098696    ┆ 3     │\n",
        "└───────────┴──────────────┴─────────────┴─────────────┴───────┘"
       ]
      },
@@ -3397,8 +3397,8 @@
       "\n",
       "### Overall Statistics\n",
       "Mean speedup (Polars vs pandas): 2.6x\n",
-      "Operations where Polars is faster: 20/24\n",
-      "Operations where pandas is faster: 4/24\n",
+      "Operations where Polars is faster: 21/24\n",
+      "Operations where pandas is faster: 3/24\n",
       "Detailed Results (sorted by speedup):\n"
      ]
     },
@@ -3412,27 +3412,27 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (24, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>operation</th><th>pandas_time</th><th>polars_time</th><th>speedup</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>&quot;str_replace&quot;</td><td>0.004859</td><td>0.000687</td><td>7.075123</td></tr><tr><td>&quot;H_string&quot;</td><td>&quot;str_extract&quot;</td><td>0.005437</td><td>0.000819</td><td>6.63805</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;inner_join&quot;</td><td>0.004568</td><td>0.000928</td><td>4.922292</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;multi_horizon_returns&quot;</td><td>0.008527</td><td>0.002166</td><td>3.936437</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;asof_join&quot;</td><td>0.003224</td><td>0.000914</td><td>3.527835</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;B_groupby&quot;</td><td>&quot;cross_sectional_stats&quot;</td><td>0.001585</td><td>0.001498</td><td>1.058339</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;ewm_span_20&quot;</td><td>0.001101</td><td>0.00113</td><td>0.974853</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_std_20&quot;</td><td>0.001196</td><td>0.001277</td><td>0.936005</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_mean_20&quot;</td><td>0.001209</td><td>0.001396</td><td>0.866258</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;percentile_rank&quot;</td><td>0.004666</td><td>0.010998</td><td>0.424272</td></tr></tbody></table></div>"
+       "<small>shape: (24, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>operation</th><th>pandas_time</th><th>polars_time</th><th>speedup</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;H_string&quot;</td><td>&quot;str_extract&quot;</td><td>0.005289</td><td>0.000852</td><td>6.206668</td></tr><tr><td>&quot;H_string&quot;</td><td>&quot;str_replace&quot;</td><td>0.004747</td><td>0.000778</td><td>6.103249</td></tr><tr><td>&quot;H_string&quot;</td><td>&quot;str_contains&quot;</td><td>0.002528</td><td>0.000476</td><td>5.30789</td></tr><tr><td>&quot;E_join&quot;</td><td>&quot;inner_join&quot;</td><td>0.004472</td><td>0.000956</td><td>4.678021</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;multi_horizon_returns&quot;</td><td>0.008313</td><td>0.001939</td><td>4.287955</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;cross_sectional_zscore&quot;</td><td>0.003852</td><td>0.003588</td><td>1.073382</td></tr><tr><td>&quot;D_filter&quot;</td><td>&quot;multi_condition_filter&quot;</td><td>0.001201</td><td>0.001138</td><td>1.05555</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_std_20&quot;</td><td>0.001183</td><td>0.001193</td><td>0.9918</td></tr><tr><td>&quot;A_rolling&quot;</td><td>&quot;rolling_mean_20&quot;</td><td>0.001155</td><td>0.00119</td><td>0.970304</td></tr><tr><td>&quot;C_window&quot;</td><td>&quot;percentile_rank&quot;</td><td>0.00461</td><td>0.01091</td><td>0.42252</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (24, 5)\n",
-       "┌───────────┬───────────────────────┬─────────────┬─────────────┬──────────┐\n",
-       "│ category  ┆ operation             ┆ pandas_time ┆ polars_time ┆ speedup  │\n",
-       "│ ---       ┆ ---                   ┆ ---         ┆ ---         ┆ ---      │\n",
-       "│ str       ┆ str                   ┆ f64         ┆ f64         ┆ f64      │\n",
-       "╞═══════════╪═══════════════════════╪═════════════╪═════════════╪══════════╡\n",
-       "│ H_string  ┆ str_replace           ┆ 0.004859    ┆ 0.000687    ┆ 7.075123 │\n",
-       "│ H_string  ┆ str_extract           ┆ 0.005437    ┆ 0.000819    ┆ 6.63805  │\n",
-       "│ E_join    ┆ inner_join            ┆ 0.004568    ┆ 0.000928    ┆ 4.922292 │\n",
-       "│ A_rolling ┆ multi_horizon_returns ┆ 0.008527    ┆ 0.002166    ┆ 3.936437 │\n",
-       "│ E_join    ┆ asof_join             ┆ 0.003224    ┆ 0.000914    ┆ 3.527835 │\n",
-       "│ …         ┆ …                     ┆ …           ┆ …           ┆ …        │\n",
-       "│ B_groupby ┆ cross_sectional_stats ┆ 0.001585    ┆ 0.001498    ┆ 1.058339 │\n",
-       "│ A_rolling ┆ ewm_span_20           ┆ 0.001101    ┆ 0.00113     ┆ 0.974853 │\n",
-       "│ A_rolling ┆ rolling_std_20        ┆ 0.001196    ┆ 0.001277    ┆ 0.936005 │\n",
-       "│ A_rolling ┆ rolling_mean_20       ┆ 0.001209    ┆ 0.001396    ┆ 0.866258 │\n",
-       "│ C_window  ┆ percentile_rank       ┆ 0.004666    ┆ 0.010998    ┆ 0.424272 │\n",
-       "└───────────┴───────────────────────┴─────────────┴─────────────┴──────────┘"
+       "┌───────────┬────────────────────────┬─────────────┬─────────────┬──────────┐\n",
+       "│ category  ┆ operation              ┆ pandas_time ┆ polars_time ┆ speedup  │\n",
+       "│ ---       ┆ ---                    ┆ ---         ┆ ---         ┆ ---      │\n",
+       "│ str       ┆ str                    ┆ f64         ┆ f64         ┆ f64      │\n",
+       "╞═══════════╪════════════════════════╪═════════════╪═════════════╪══════════╡\n",
+       "│ H_string  ┆ str_extract            ┆ 0.005289    ┆ 0.000852    ┆ 6.206668 │\n",
+       "│ H_string  ┆ str_replace            ┆ 0.004747    ┆ 0.000778    ┆ 6.103249 │\n",
+       "│ H_string  ┆ str_contains           ┆ 0.002528    ┆ 0.000476    ┆ 5.30789  │\n",
+       "│ E_join    ┆ inner_join             ┆ 0.004472    ┆ 0.000956    ┆ 4.678021 │\n",
+       "│ A_rolling ┆ multi_horizon_returns  ┆ 0.008313    ┆ 0.001939    ┆ 4.287955 │\n",
+       "│ …         ┆ …                      ┆ …           ┆ …           ┆ …        │\n",
+       "│ C_window  ┆ cross_sectional_zscore ┆ 0.003852    ┆ 0.003588    ┆ 1.073382 │\n",
+       "│ D_filter  ┆ multi_condition_filter ┆ 0.001201    ┆ 0.001138    ┆ 1.05555  │\n",
+       "│ A_rolling ┆ rolling_std_20         ┆ 0.001183    ┆ 0.001193    ┆ 0.9918   │\n",
+       "│ A_rolling ┆ rolling_mean_20        ┆ 0.001155    ┆ 0.00119     ┆ 0.970304 │\n",
+       "│ C_window  ┆ percentile_rank        ┆ 0.00461     ┆ 0.01091     ┆ 0.42252  │\n",
+       "└───────────┴────────────────────────┴─────────────┴─────────────┴──────────┘"
       ]
      },
      "metadata": {},
@@ -3485,13 +3485,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "437743d5",
+   "id": "cf402b09",
    "metadata": {
     "papermill": {
-     "duration": 0.005623,
-     "end_time": "2026-07-18T20:21:17.805556+00:00",
+     "duration": 0.004261,
+     "end_time": "2026-07-19T03:43:06.498974+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.799933+00:00",
+     "start_time": "2026-07-19T03:43:06.494713+00:00",
      "status": "completed"
     }
    },
@@ -3502,40 +3502,43 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "ba2111ed",
+   "id": "38ef4076",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:17.815274Z",
-     "iopub.status.busy": "2026-07-18T20:21:17.815157Z",
-     "iopub.status.idle": "2026-07-18T20:21:18.840460Z",
-     "shell.execute_reply": "2026-07-18T20:21:18.840077Z"
+     "iopub.execute_input": "2026-07-19T03:43:06.508334Z",
+     "iopub.status.busy": "2026-07-19T03:43:06.508228Z",
+     "iopub.status.idle": "2026-07-19T03:43:07.882709Z",
+     "shell.execute_reply": "2026-07-19T03:43:07.881778Z"
     },
     "papermill": {
-     "duration": 1.030943,
-     "end_time": "2026-07-18T20:21:18.840819+00:00",
+     "duration": 1.38128,
+     "end_time": "2026-07-19T03:43:07.884682+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:17.809876+00:00",
+     "start_time": "2026-07-19T03:43:06.503402+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "application/json": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
        "data": [
         {
          "marker": {
           "color": "#0a1628"
          },
          "text": [
-          "5.4x",
-          "4.0x",
+          "5.9x",
+          "3.6x",
           "2.4x",
-          "2.3x",
+          "1.9x",
           "1.8x",
           "1.8x",
-          "1.7x",
-          "1.2x"
+          "1.8x",
+          "1.5x"
          ],
          "textposition": "outside",
          "type": "bar",
@@ -3544,21 +3547,21 @@
           "E_join",
           "F_lazy",
           "D_filter",
-          "B_groupby",
           "G_memory",
           "A_rolling",
+          "B_groupby",
           "C_window"
          ],
          "xaxis": "x",
          "y": [
-          5.449681095152066,
-          3.961028829004577,
-          2.382538043697235,
-          2.2514197633808095,
-          1.8237554301804766,
+          5.872602497379094,
+          3.6384704671122647,
+          2.379486135992597,
+          1.9267344032590799,
           1.8156516000477612,
-          1.663838617525201,
-          1.21965850107043
+          1.7824201775476556,
+          1.758083166987667,
+          1.5315324806675736
          ],
          "yaxis": "y"
         },
@@ -3569,39 +3572,39 @@
          "name": "pandas",
          "type": "bar",
          "x": [
-          "str_replace",
           "str_extract",
+          "str_replace",
+          "str_contains",
           "inner_join",
           "multi_horizon_returns",
-          "asof_join",
           "anti_join",
+          "lagged_values",
+          "asof_join",
           "simple_filter",
           "column_projection",
-          "ohlcv_resample_daily",
-          "str_contains",
-          "range_filter",
           "lazy_filter",
-          "lagged_values",
-          "combined_query",
-          "df_estimated_size"
+          "ohlcv_resample_daily",
+          "range_filter",
+          "df_estimated_size",
+          "combined_query"
          ],
          "xaxis": "x2",
          "y": [
-          0.004858862007192026,
-          0.0054367133270716295,
-          0.004567878330514456,
-          0.008527270333919054,
-          0.0032239340022594356,
-          0.007143460670098041,
-          0.0014075903309276327,
-          0.002963986994776254,
-          0.0037004113304040707,
-          0.0026326826628064737,
-          0.0014634369969523202,
-          0.0031393423366049924,
-          0.0034671739946740368,
-          0.003347966330087123,
-          1.160132
+          0.005288811662467197,
+          0.004747272003442049,
+          0.002528268339422842,
+          0.004472488673248638,
+          0.008312871320716416,
+          0.006268140345734234,
+          0.003382073996666198,
+          0.0031788766791578382,
+          0.0014185253336715202,
+          0.002922961003302286,
+          0.0028880273457616568,
+          0.0035300380065261074,
+          0.0016027223318815231,
+          1.160132,
+          0.003147957322653383
          ],
          "yaxis": "y2"
         },
@@ -3612,39 +3615,39 @@
          "name": "Polars",
          "type": "bar",
          "x": [
-          "str_replace",
           "str_extract",
+          "str_replace",
+          "str_contains",
           "inner_join",
           "multi_horizon_returns",
-          "asof_join",
           "anti_join",
+          "lagged_values",
+          "asof_join",
           "simple_filter",
           "column_projection",
-          "ohlcv_resample_daily",
-          "str_contains",
-          "range_filter",
           "lazy_filter",
-          "lagged_values",
-          "combined_query",
-          "df_estimated_size"
+          "ohlcv_resample_daily",
+          "range_filter",
+          "df_estimated_size",
+          "combined_query"
          ],
          "xaxis": "x2",
          "y": [
-          0.0006867529979596535,
-          0.0008190226702330013,
-          0.000927998330250072,
-          0.0021662410047914213,
-          0.0009138563376230499,
-          0.002080845665962746,
-          0.00048390866625898826,
-          0.0010675946638608973,
-          0.0013843739967948447,
-          0.0009987906669266522,
-          0.0005692379976001879,
-          0.0013235986649912472,
-          0.0016934506614537288,
-          0.00167442832995827,
-          0.6389617919921875
+          0.0008521176544794192,
+          0.0007778270034274707,
+          0.0004763226703895877,
+          0.0009560643423659106,
+          0.0019386563314280163,
+          0.0019083763375723113,
+          0.0010914506662326555,
+          0.0010765453334897757,
+          0.0004945800077014914,
+          0.0010377129947301,
+          0.0010923206670364987,
+          0.0013706856601250668,
+          0.0008632976581187298,
+          0.6389617919921875,
+          0.0018762550025712699
          ],
          "yaxis": "y2"
         },
@@ -3656,29 +3659,29 @@
          "opacity": 0.7,
          "type": "histogram",
          "x": [
-          0.8662581605161599,
-          0.9360053023393924,
-          3.936436580721133,
-          1.6056404454088407,
-          0.97485259864048,
-          2.6729852908039327,
-          1.0583388959630784,
-          1.7399421037744192,
-          1.1873019785924916,
-          0.424271687887594,
-          2.047401836731204,
-          2.9087933923760096,
-          1.2745957114437818,
-          2.5708701863226375,
-          3.527834594488804,
-          3.432960352104236,
-          4.922291540420692,
-          2.371823438357542,
-          2.7763224144050684,
-          1.9994682783290942,
-          2.6358703079469294,
-          7.075123110678407,
-          6.638049866830859,
+          0.9703037110201372,
+          0.9917997321105113,
+          4.28795510888366,
+          1.5482608687550825,
+          1.1137814669688875,
+          2.5753811462534837,
+          1.2725968875393627,
+          1.4262714671701544,
+          1.0733817597657194,
+          0.4225195145576562,
+          3.0986961676793454,
+          2.8681412745815744,
+          1.055550085766902,
+          1.8565118494287631,
+          2.952849806011471,
+          3.2845410112913456,
+          4.678020584033978,
+          2.643937291415504,
+          2.816733545928585,
+          1.6777875706337029,
+          5.307890001025887,
+          6.103249157619035,
+          6.206668333492361,
           1.8156516000477612
          ],
          "xaxis": "x3",
@@ -3719,56 +3722,56 @@
          ],
          "type": "scatter",
          "x": [
-          0.0012091909932981555,
-          0.0011957336634319897,
-          0.008527270333919054,
-          0.0036096713301958516,
-          0.001101251337483215,
-          0.0037004113304040707,
-          0.0015854400019937505,
-          0.0019399113322530563,
-          0.004345616665280734,
-          0.004666128001796703,
-          0.0034671739946740368,
-          0.0014075903309276327,
-          0.0012334079947322607,
-          0.0014634369969523202,
-          0.0032239340022594356,
-          0.007143460670098041,
-          0.004567878330514456,
-          0.0031393423366049924,
-          0.002963986994776254,
-          0.003347966330087123,
-          0.0026326826628064737,
-          0.004858862007192026,
-          0.0054367133270716295,
+          0.0011548923406129081,
+          0.0011834286657782893,
+          0.008312871320716416,
+          0.003321124337768803,
+          0.0010645330088057865,
+          0.0035300380065261074,
+          0.0016223196677553158,
+          0.0019610443462928138,
+          0.0038517216647354266,
+          0.004609557344034935,
+          0.003382073996666198,
+          0.0014185253336715202,
+          0.0012007666809950024,
+          0.0016027223318815231,
+          0.0031788766791578382,
+          0.006268140345734234,
+          0.004472488673248638,
+          0.0028880273457616568,
+          0.002922961003302286,
+          0.003147957322653383,
+          0.002528268339422842,
+          0.004747272003442049,
+          0.005288811662467197,
           1.160132
          ],
          "xaxis": "x4",
          "y": [
-          0.0013958783286701266,
-          0.0012774859933415428,
-          0.0021662410047914213,
-          0.0022481193348842985,
-          0.0011296593341588352,
-          0.0013843739967948447,
-          0.0014980456714207928,
-          0.0011149286680544417,
-          0.003660077001162184,
-          0.010997971665346995,
-          0.0016934506614537288,
-          0.00048390866625898826,
-          0.0009676856619383519,
-          0.0005692379976001879,
-          0.0009138563376230499,
-          0.002080845665962746,
-          0.000927998330250072,
-          0.0013235986649912472,
-          0.0010675946638608973,
-          0.00167442832995827,
-          0.0009987906669266522,
-          0.0006867529979596535,
-          0.0008190226702330013,
+          0.001190237991977483,
+          0.0011932133347727358,
+          0.0019386563314280163,
+          0.0021450676722452044,
+          0.0009557826560921967,
+          0.0013706856601250668,
+          0.0012748103375391413,
+          0.0013749446661677212,
+          0.0035883986565750092,
+          0.01090969099702003,
+          0.0010914506662326555,
+          0.0004945800077014914,
+          0.0011375743294289957,
+          0.0008632976581187298,
+          0.0010765453334897757,
+          0.0019083763375723113,
+          0.0009560643423659106,
+          0.0010923206670364987,
+          0.0010377129947301,
+          0.0018762550025712699,
+          0.0004763226703895877,
+          0.0007778270034274707,
+          0.0008521176544794192,
           0.6389617919921875
          ],
          "yaxis": "y4"
@@ -4035,7 +4038,8 @@
          }
         }
        }
-      }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAMgCAYAAADBabHPAAAQAElEQVR4AeydA2AjzxfHv6nbs23b/p9t27Zt9Gzbtv0727Ztq27/86a3uTRN0jQpkvb1bnZnZ94bfGbxdmZ2YuPp6eHHjhnwOcDnAJ8DfA7wOcDnAJ8DfA5E1HPABvzHBJgAE2ACABgCE2ACTIAJRFQCbPBG1JblejEBJsAEmAATYAJMwBQCEVCHDd4I2KhcJSbABJgAE2ACTIAJMIF/BNjg/ceCfUyACRhPgCWZABNgAkyACVgNATZ4raapuKBMgAkwASbABJiA5RHgElkDATZ4raGVuIxMgAkwASbABJgAE2ACJhNgg9dkdKzIBIwnwJJMgAkwASbABJhA+BFggzf82HPOTIAJMAEmwAQiGwGuLxMIFwJs8IYLds6UCTABJsAEmAATYAJMIKwIsMEbVqQ5H+MJsCQTYAJMgAkwASbABEKQABu8IQiTk2ICTIAJMAEmEJIEOC0mwARChgAbvCHDkVNhAkyACTABJsAEmAATsFACbPBaaMMYXyyWZAJMgAkwASbABJgAEzBEgA1eQ3Q4jgkwASbABKyHAJeUCTABJqCHABu8esBwMBNgAkyACTABJsAEmEDEIBDZDN6I0WpcCybABJgAE2ACTIAJMAGjCbDBazQqFmQCTIAJRCQCXBcmwASYQOQhwAZv5GlrrikTYAJMgAkwASbABCIlAYMGb6QkwpVmAkyACTABJsAEmAATiFAE2OCNUM3JlWECTCCUCHCyTIAJMAEmYMUE2OC14sbjojMBJsAEmAATYAJMIGwJWGdubPBaZ7txqZkAE2ACTIAJMAEmwASMJMAGr5GgWIwJMAHjCbAkE2ACTIAJMAFLIsAGryW1BpeFCTABJsAEmAATiEgEuC4WQoANXgtpCC4GE2ACTIAJMAEmwASYQOgQYIM3dLhyqkzAeAIsyQSYABNgAkyACYQqATZ4QxUvJ84EmAATYAJMgAkYS4DlmEBoEWCDN7TIcrpMgAkwASbABJgAE2ACFkGADV6LaAYuhPEEWJIJMAEmwASYABNgAsEjwAZv8HixNBNgAkyACTAByyDApWACTMBoAmzwGo2KBZkAE2ACTIAJMAEmwASskQAbvNbYasaXmSWZABNgAkyACTABJhDpCbDBG+lPAQbABJgAE4gMBLiOTIAJRGYCbPBG5tbnujMBJsAEmAATYAJMIBIQYINXo5HZywSYABNgAkyACTABJhDxCLDBG/HalGvEBJgAEzCXAOszASbABCIUATZ4I1RzcmWYABNgAkyACTABJsAEtAmYbvBqp8THTIAJMAEmwASYABNgAkzAAgmwwWuBjcJFsiwCq9ZvQ4GSNSyrUJG8NPOXrEXxCg0shgIXxDQCdZp0guuEmaYph5JW3JR5cOjY6WCl7ufnh3I1mmHXvsPB0jNXuHn7Phg4YqK5yQRb/+nzl8iYuwy+fvsebF1WYALhRYAN3vAiz/kygb8Enr94jVHjZ6J01SZIkr4QSlVpjOlzl8HLy+uvhO7dus07kft/VRAzaQ6kzFIUdZt2wtETZ3UL/w29cu0WylZvJnUSps0vH9LLVm0CPbD/ioTJLk/RqrIMVPZkGQujUu1WWL9lV5jkbU4mr16/Rfvug1GwVC1Z/h4DXIOV3LfvP5CzSGWpe+feowC6g0ZOQplqTZEgTT6jX7CWr96MGg3bg9qfWL5+8y5AmroOuvYZIfMneXLZC1VCh+5DQOehLnkOC5oAnbvC5kXViqXVwg8fP0fnXsPkNZo8UxF5jpNxbw2c6T7SoGVXZMhVWrr6zbtg/NT56rqlSpEMFcoVx8TpC9Rh7GECfwlY7I4NXottGi5YZCFw8uxF3Ln/ELWrVcCiWeOQJ2c2jJk0B1NmLTGIwN3NA/17dsCujYsxa/IIZMyQBrUad8T5S9f06v389Rs1KpeVOisXTkG1imUwfOx0zJy/Qq9OaEU0bVBTlmP2lFGIFze2NLr2HzoRWtmFSLq/frvBxcUZ7Vo2QM7smYOdZqdeQ1EoX26pp1LJnXrz9esPVK9UFjWqlFOHBeX5+PkrCubLhS7tmwclGiA+V44skj2dOwN7d8C7Dx/FudMBvr6+AeT4wDgCazbsRON61dTCX75+Q+U6LfHl2zf06toGqxZNFddqe9jbO+Dn799qOUv0nDxzUZwLHZE6ZXKMHdEHi+eMR6tm9fH5y7cAxW1ctxrWbtwJd3ePAOF8wAQslQAbvJbaMlyuAARo6LNHf1c0at0d6XKWRLaCFTFCGGre3t5qOTKW2nUbhMz5ysleCfJ/EgaBInD2whXZs3XkxBmUrNwI1LNYtV4bXL56UxGR+9kLViJvsWqy14zy+/79pwxXNtQz12/oONELVxPUc1O9QTtcv3VXiZb7STMWyd5T6q2jXrSWHfvJcF2bJvVrYP2yWejUtgkqlS+BSaMHoEPrhti4dbcucXVYy6Z1Ub92FRQtnE/2LLkO6Y0UyZPg5JlLahltT/H/FUDndk2lTrlSRYWh1AxVKpTGiVPntUXVx9SjqV1+6hGmnsq5i1ZLuZ17D6FWo45Ikfl/oPqWqNQQb96+l3GBNn8DkiZJJMtRvXIZrFgwGZkzpsW+g8dkLLVJDdFzSelRL/YQ1ylwc3OXcbo2QbU96cQVQ9Ur1m6R5aQe0QnTFuDX7z+g86pwmdqy3NTDbsj4z5g+NaaNG4JWTeshZozolKzRbsnKDfjzx10ay7qU5k13RdcOzaShoSteV1jf7m0xoFcHFMibQ1e03rAY0aNJ9nTuNKxTDb26tMbjpy/w7MUrtQ4NV/cZPE72UNK1Qu176+4DdTy9kFWs1RILl61DvuLVkDpbcbTpMkAaz2oh4Tl8/AzoOqNrhaYGUU/2nz9uIsb/v4+PL3oOHI1MecvK65pGOzSv67ii3WhaEeVP5wPdC66IkQq6tkmPeiFp1OLM+cv+CYottevoibPkNUhlp/Nx6879Iubff0pn8KjJshc2S/7yoPPtX+w/3+SZi2XZbt99+C9Qw0fn+Snx0krXkxJ849Y9fPj4GRNHDQBd38XFdUeO2iprpvSKGH78/IUBwydIfsSHelIPHjkp4425z0hBjU1QbaYhqtdLdUmbWhi7w/uidvWK8jwpX7qovC9pKuXLkwPOTk44dlL/vUNTnv1MILwJ2IR3ATh/JmAsgTUbdyB/npy4eHwHpk8Yig1b94AeRor+t+/fRe9lOZw6uBEbVs6Co4MDmrXrHWi4fuXabZgyZhAuHNuOZEkSo0OPwWoZGpok46p7p5a4eno3CuXLg1lavZ/ff/xAtiwZsXHFbJz+bxNKFS8sjCj/XjIqCxnUi5avg+uQXnh68wROHNggyh08g8TO1g5Ro0Sh5Ix2x4XR+vHjF/GAymu0zouXb3Dh8jWULFZIr07t6hWw9+BRaRwqQqfOXsKr1+9Qp0ZFUK9x684D0KBOFVw/uxfXTu9Bi0a1oVJpdWEqynr2KpVKtgMNy1er3w4J48fD5ZO7MHvKSKzbtBN9Bo/VowkY2/Zk5LZsWgf3Lh9CxzaNMWPuUmnkLZ49Aa8fnMW6ZTOQJFF8vfmYGnH3/iNMmr4I86ePVidBQ+Dqg3D0eIuXxv2HjiNDutRImjiRuiRN2/YWbftLjjpcO7MXVSqWlOc5tY8idO3mHflis2nlXGxfvwBPnr3E+Cn/hr7pnCTDsmyporh0YifWLp2BOLFjw0vkqaSxfstueHt5Y6LrANQV5xO9cGzZEdA4nb1gBfLlyYaZk0bA28cHrTr3R9e+w5EgXlxMHD0Q9nZ26NRrmLqH2tPTE46OTuLlZKg8Jzu3bYpBIycHmpu7dNUmpEmdAicPbACNeChloj291NH82DUbtmP/1uXIkikdBQdyZ85fQeJECaRTIuPFjSO9x09fkHt9m8ate+Dq9TtihGYk7lz6D21bNsT3vy/YQd1ndKVpTJsVKFlDGtm69CksbpxYok0/4t6DJ3Ro0OXMnglnL1w2KMORhglwbNgRsAm7rDgnJmAegby5sqGHMESpZ620MDLpIbZ8zWZ1og1qV5U9pLFjxUTObJkxddxgObyvfeMe1KczcufMikQJ48seNZpr9/7jJ5nOijVbUataBTQVw+2xYsaQ8ZkyppVxyqZQ/twynnpTkyVNjO4dWyBr5gzYe+CoFHn77iOoDPlFDwgNf2cXxjEZVzLSiA31JNGDuIMwyIISp14g6lElV4/m2Y3qJ3r7cgalJnvASSd7oYooUjCv7OnVp0Sso0eLiu27D6pFtu06iFLFCiJ+vDj4LHrRab7x/wrllb2eKVMkRYsmdSRftUIQnk3b9oLqTYb3ynVbhbHvgmnjh4AevoUL5MHQ/l1BLzwfP33RmZKxbd+oblXZG+7k5AiqE7VVqpTJZO9yFBcXFCuSX/ZqIQT/qDezpejhdx3aCwkTxAvBlE1P6tjJc6D2JxdX9KBu2b4fc8SLhYODvUz0hDDUrl6/LcPyiOsuTuyYslc7d84s2LLzgJShDV0jIwb1ALU5nec0rE8vUBRHbtqcpWgoepC7dWguz5U0qVKgd9fWoB5miieXPUsGYfCNkO0ybEA3lClRWLyE3aAotWsg0hjYuxNoNGCi60A8e/4KxQoXkL3bFDZ2eB8ZRr2tpETXH/V+ZxFGKvnr1qyEFo3rYP3mgPPEc2XPAurdJhk6HyD+VCqVfPGikQ3isG/rMjlyIqJ0/n8uXhrjxo4VII7ypd5cGj3IUbgSajbqIOfAar4s0NQBcnOnjZLTUqJGcRF1LwIqKyUW1H2GZDQdldWYNsuVPStoDq6mrqa/Sf2aKFokLwqWqokSFRuCep1prvjvP380xaQ/bpzYeCraQh7whglYOAEbCy8fF48JqAlky5Je7SdPjmyZ8O79R5BBQccvX72Rw9M0HYEe5PFS5YWP6A16+foNRatd0sQJ1H6lJ0YxpJ6IYd3i/8uvjidPiaIFaad2lB99wEEPA8qD8qKerJev3kqZsiX/h4+fPqNkpUagYVXqNaahSxkZxOb0uUty+Ld1s3poVJfmBBpWSJE8sZyLSXN4y5b6H/oNHQ/qdTOsBaxYOFnOK2zdrD42b98HGm7Xp2Nra4s6oudt219Dh4zbLTv2oZbo+SUdMnaKCKOZhpVpuJp6t435MGfclLlqo6tDjyFo1rAWalYtJ4fWixbJB2dnJ0peOmJKnifPXtAukHtpZNvnzJYlgG7NauWxcu1W+VCnaSj7Dh6Xxk4AITMPhrhOFSMCGdSGjJnJhYi65hze5fMno17tSmgqRkOUF7/HT56DDJy4whim81tx+/87ATI2lUIkS/KvR5jC4saJI4fyyU/u/sMnyJ8nO3n1ukwZ0gaIS5E8CT59DvhioymTKkUSKZ8pQxq5pw3p0P6TePmiPTn6qLNyndZy2hGVf/zUeXj59xqleHI5RQ8l7TUd9ewOHjkJt+7cx+5NS4J8SfH09ICjeIHSTIP8A3p1xPM7JzF36ijJYN/BY8hbvDr2/52nwH5OWQAAEABJREFU/ujxM9krTC8BJK/t/vxxk0ayvvuMtryxbTZ/xmi0b9VIW119TNcdTbF6dP2YeKHoCHohnDJ7CfKXqCn4vVHLkcfR0VF9/6VjdkzAkgmwwWvJrcNlM4qAp5eXNFJqNe6AeHFjYc2SGXj/+CK+vLgKe3t7eHl6B0jHxibwaU8POUWIDDzFT3s7YfDRXnE0NHrt5m3MmjICD64exrdX10G9oFQOkqFez5MHNqJRvWrCaHDDuCnzUKJigwCGAMlpu7v3H4OGJDu3a4ZhoqdLO17XMfVK0jxM6pFevWgaiope1lnzV+oSDRBWMF8u2aM2Zewg9O7WBhOnLQwQr31Qq2p5HDlxVtbh4OFT8Pb2QZUKpdViW1bPxdD+XeAkHoDrNu9GAdE7RNMe1AI6PFTmXRsX48juNXh597QYrh6ultJuA1s7W3Wctofazti2d3J2DKBO7XZkzxoUKpAHj548Q/vug+Q88QBCZh5cvXEb1INNRhc5mj9OSdK8YVoxgfxh7aiHlc4bcjWqlIXrkN5yCsrq9TtkUVQqleyRpXNb29HIiRQSm6CuJSECqGDwz06rbVUqUvALoKMpo1JRPKB5jqhUKilP5wJ5NmzZDZq+MmxAVzl1ieowpF9XKNcoyZBz1mGoqlQqeW6/ev0OJ05fJDGDjnqHv379plOGrk96GaTe6eP71yN3jqxYuHSdWlal8i+3OkDDE9R9RkNUelUq49pMChuxodGVCmWLYfzI/nLq1s+fv7B+y54Amp+/fBX33DgBwkL1gBNnAmYQCPzkNyMxVmUCoUng5u0HAZK/fvOunMNHUxzevvuAh4+fCyOzOjKkSwVHRwfcvvcQ1BsZQCmIg9SpksueHU2xG7fvaR6CPn4jYy9b5gyIFTMGPDw8ZV6aQjSnr13Lhhg3oh/OHtqCF6Jn6dKVm5oiAfxUdjLahvbrIod8A0QG48DX108a/8FQMUqUPlBJlyYFaG7ltt0HUKViKTntQFF2EoYDTSsgQ50M2Dw5s4merONKtM590iSJQAZX7pxZ5coHilAa0Qb00Y9yTPur1+7QDqlTJpd7zY25bZ8jayY5VWbBjDFYvmAS9ole3u8/fmpmYZZ/6tjBsheejHtyNP+cEpwjev6Cu7oC6YWG8/X1Bc17/fHjh0w+Q/rU8uWGhshlgIkbmhd88XLA6QkmJhUstXOXrqGIeIkpkDcnEv6dRnJT6zo2lGAR8eJIKyt07jUUO/YcMiSK7Fkzipel50b1dCZPmhi//viv0pA2TUrQFIwnekYtjLnPaBYspNpMM03FT9M9okaNgt9aK0w8ePQEOcRImyLHeyZgyQTY4LXk1uGyBSBAQ/Uz5i0HrWV6+PgZzFm0Ci2b1pUyCeLHRZLECXH42Gl5fOfeIzm9QbMXSEYEsWneuBbWbNiBPfv95+PSsOjBwyeh+ZctSwbR83NB9HJ6g4ZQO/YcCk0DiR6Q9FX5r9/+c96ol8jb21sMDSbVTEbtv3bjDqrWbY0iBfOAHoI0r09xaiHhoXmAlLbwyv9jJs0GzcU8cfqCnJJA62YeEvWnlRukgNjQB3g0lCu88j9NXaBhaUp/49Y96DHAVfZAN6xbVcYb2tSpUVl+PEYGoTLPkOTv3n+EKbOWgNaopWMa8qbh1VQpdNeXZAw56vmlj+noa33ie+HSdbhOnInG9aqL3qTYgVTNafs5C1fhgGhfmvpC7sSpC9JAogd8oIxEAPUgEjty1OYfPn4C+S9d+WfUrd20E03a9hTS/v9z5cgiDXsy7smRgU0xubJnAb2ckZ8crfRBaRFHN3dPmS4d0wsVxdOLV7X6bfH46XM6lI5YkwzNf6aAi+Klio6VqQkUpstR2UlOcXSeEOuiRfyn8xTKn1uOWnTuPUz07J+Bu7sHaOkyWsHk3MWrupLUGdazcysQj5nzV0gDmspO5wrlr1MhhAKzZU6Py9dugZYH8xIjQFPFkPzBIwGv46CyKv6/AuIFaLL8qFXzutPWo28LEgqjmvJT4miKEzGl61NhTD+WsnXXfsG1iBSjc4HmvXfsMRTElO4XdP3SaAAJBHWfIRlNZ2ybdeg+BAuWrtVUDeCfI66JWWKUSCk31aX/sPGgF0uaY68I0334waNnKF+mqBLEeyZg0QTY4LXo5uHCaRJoJYxb6qVJmaUoevR3RYPaVdS9oWTYrlk8TfbGFCpdGw1adkO/Hu0RxcVZM4kg/Q1qVwWtbTt87DTQslsbt+5Fzy6tA+iNHd5Xfg1OQ9LFKtQH9WKVKl5ILRM1qgvooZE0QyE5R7VDj8FySR/NeYhqYeE5duq8NCZoLi0t36TpRLT6Py0GTw8dJeD9h89o3LonyAiaPne5DF6zeDpoCSF5IDZkCN29/1j4/P+TwdZr0GhQHv2Gjscj0SvuOqQXhvbv6i9gYFu3ZkWQ0RU9elSU1JjX7OLsjOOnziFrgQqyvnmKVRMPwWKgj4QMJKc3inp+d29ajEtXb8olsYhf6RKFMXnMIJ065rS9j+jZ7CKMujgpcoPcngNH5KoEKpXuoWYyiokdOer93HvgmGRJhqFSOJoneu6C8Uahojdk1BSZFr0svXj5Wvopn09/57P++PFLvmj90ViejV7ISIaWtqJ0WnToI/WOB7FUFJWd9Mi16tQPDx89xcaVs+VHU5QOuRULp4CW2ho0YjLSZC+Bhi27i/zPI6ro6aN4YxwZjZTuvoPHQHPr8xStJs8VWlXBGH1TZejcq1y+BEpXaYL8JWqKUZsH6Nk54HWsL226RshRfJkSRbB0zkQ51WWf6PmnMG1H06Yov+27/1NHZcmUXn64Om3OUrTs2BdtOg+QIx50Dvfr0U4tRytDZBcjDJ17DQPdL0iOettJIKj7DMlou4BtprvNrt64BfqlNG1d5ZiM2k+fP2PEuBmizbuB7rV0r9mxfiGoPRW57bsOolzp/yFVimRKEO+ZgEUTYIPXopuHC6dJwMnRAYtnj5dzZm+e24fhA7vLObqKDP0QAA0Znz28BTfO7pWG34u7p1G5QkkpUkj0WtFcPicnR3lMG5qnRmH0hTkdk+vSvplcQomW19q2dr5cheH80e0UJR3N0aVyXDi2A3cuHhQGcnuQoTlmWB8ZX7p4YZw7slWWk9J+dvsk2rZoKON0bXp0aqmWJXlNpylP4R1a//vYZOak4XIpLQonHvShiVJXRY/KT2vcKsdtmjeQZSYdKhcZlpQmGY2KjL49PdhI7+6l/wLMn6QPhnZuWKSuw+fnVzBj4rAAMtpp0nJj/Xu21w5WH1OvKKVJ7Xfl1G45x5Q+plEEqMw0J1I5DqrtSe7Ts8sBDDoKo9UDHl47qi77xeM7ZW8sxelydnZ2allioTjN84PqRR/86NKnMKob6WXOmJYO1Y7OXQrXdkkSJ5Qy1BtIcdkyZ5DHtKG5oRSm7erVqkzROh194KgpT/XftGouyLjVVKBVA2gFBjqXXz84i6N71gqjeA6yCmOO5Gi1BVrBgPyKoxUTHt8IOJWFPjgkOWpLypfa1eXvi+hmOfe7m6Iu9zRndMWCKdJPG+12U9qAekgpnhxNa6K0iS0d09ziof27yaUFaXnBpXMngAxNqgPFk9OVN4Vr51exXHG8e3QBtKd4XY5WYdm977B8caV4uq/0Ei/KZCTSuXD/6mFsX7dAru6iUv17maIpUbTuNl0PVH66JpURmqDuM5TPigWT5bQp8pMLqs1Ihs5VYkx+XY7Oy5GDe+LwrtV4df+sZLh8/iTQCiaKPBnlC5evQ+8ubZQg3jMBiyfABq/FN1HoFZBTZgJMgAkwAfMJ0EeAU8cNgTGrk5ifW/inQB/00YhbnlzZwr8wXAImYCQBNniNBMViTIAJMAEmEGEJmF0xGl2hj+TMTsgKEkieLDFotMgKispFZAJqAmzwqlGwx5IJ6Bt+tOQyc9mYABNgAkyACTAByyDABq+x7cByTIAJMAEmwASYABNgAlZJgA1eq2w2LjQTYAJMIPwIcM5MgAkwAWsjwAavtbUYl5cJMAEmwASYABNgAkwgWARCyeANVhlYmAkwASbABJgAE2ACTIAJhBoBNnhDDS0nzASYABMAwBCYABNgAkwg3AmwwRvuTcAFYAJMgAkwASbABJhAxCcQnjVkgzc86XPeTIAJMAEmwASYABNgAqFOgA3eUEfMGTABJmA8AZZkAkyACTABJhDyBNjgDXmmnCITYAJMgAkwASbABMwjwNohSoAN3hDFyYkxASbABJgAE2ACTIAJWBoBNngtrUW4PEzAeAIsyQSYABNgAkyACRhBgA1eIyCxCBNgAkyACTABJmDJBLhsTMAwATZ4DfPhWCbABJgAE2ACTIAJMAErJ8AGr5U3IBffeAIsyQSYABNgAkyACUROAmzwRs5251ozASbABJhA5CXANWcCkY4AG7yRrsm5wkyACTABJsAEmAATiFwE2OCNXO1tfG1ZkgkwASbABJgAE2ACEYQAG7wRpCG5GkyACTABJhA6BDhVJsAErJ8AG7zW34ZcAybABJgAE2ACTIAJMAEDBNjgNQDH+CiWZAJMgAkwASbABJgAE7BUAmzwWmrLcLmYABNgAtZIgMvMBJgAE7BAAmzwWmCjcJGYABNgAkyACTABJsAEQo5AeBi8IVd6TokJMAEmwASYABNgAkyACQRBgA3eIABxNBNgAkwg9AhwykyACTABJhAWBNjgDQvKnAcTYAJMgAkwASbABJiAfgKhHMMGbygD5uSZABNgAkyACTABJsAEwpcAG7zhy59zZwJMwHgCLMkEmAATYAJMwCQCbPCahI2VmAATYAJMgAkwASYQXgQ43+ASYIM3uMQsSP7O/cfoMWgCKtXvhJLVWqFll6GYOncFTp+/ZkGlDFiULv3GoufgSQEDQ/no9x83FCrfBJt3HgzlnIA/bu5YtnYHug+cgLK12qFC3Q6yXWYtWgtPL69g5f/y9TssXLEJnz5/DZYeC0dOAq/evMf4GUvRqF1/lK7RBnStrdq4Gz6+vhYP5Pzlm/K60S7o1Rt35bV7+95j7ahQOT5+5rLMj+4XhtzEmcuweNVWlKzeOlTKEVqJHjp+DuVqt5f3KSWP/1VshpUbdimHEW5vajvduvsQ9Fz9+OlLhGMSWSvEBq+VtvzZi9fRuttwYUR5o0m9qhg1sAvKFC+IF6/e4fzl61ZaK+su9oUrN1G7eS9s3LYfObNlxOBe7dCmaS0kiB8HG7bux6KVm4NVwddv30sj4POXb8HSU4R5H3kIHDl5Ac07DcZrYfTWr1EeI/p3Qv482bBaGLwdernik4WfQ1eu38GaTbsDNVjUqC7IkTUDXJydAsWFRkCOLOkwc/wAtRvcq63Mpmbl0uowiq9XswISJYiL7JnTy3hr2NAL94wFa9CyUY0w42kNXPSVMWumdMiTIzNmLVqnT4TDrYyAjZWVl4v7l8CS1VuRIW1KzJ00GI1qV0TRQrnRuG5lTB/bH+2a1/0rxXPdSesAABAASURBVLuwIkAPk/HTl8oHyYp5Y8RDpTpK/C8v6lQrh/HDemDtoomivVKFVXE4n0hEgIzZURPno2De7Jgxrj+qVyol7wfN6lfFkpkjxUvwW0yft9oqiaRLnQLzpwxFqhRJwqT8MWNER75cWdUuc4a0Mt+kiROowyg+ZbJEqFyumOQtBaxgc+TEeXz5+h1VKxS3gtKGeBFNSrBimaI4LLh9/vrNJH1WsiwCNpZVHC6NsQQ+fvqKeHFj6RSPGsVFHa4M0R0+cQEderuiVPU2cgrEuGmL4e3trZYjj5u7O8ZOXYyazXqgeJWWaNi2Hw4ePUNRAZyxcsdPX5LDq5Rnn6GTceP2gwDp0MG2PYflECJNO6BjxdFQfpma/r0rFBacepC8Prdpx0E5xaCkGIrsNmA8PmoMV02btxLl63SAt49PAHUyZkuLIeLp81cFCNc82LH3KN6+/yheNmojftzYmlHSnzxpQlAPvDwQm9Ub96DXkImo3KAzqCzteo7EuUv/euapx06Z+tGiy1DJiIZYn798K7T9/9NwdYM2fVGiaivZZrMXr4Ov1vD1sxdvQGlTHm17jMSegyd0DsVSnWk6TK1mPWXb12/dBxu2HfDP6O9WaQPad+k/DjRdg84Rc7j9TZp3ZhBYunobfP180bNjU9jYBLylk6HWoFZF8dA+hwePn8tc6Fqjc2nFup0YPGYWqjbsIs/BblrXgxQWGxpNoulSdA5VrNcJA0ZNx/cfv0SM/38lPTqnh4+fi+qNu8nz9eu3H/j24yfmLlmP9r1GyTzofO83Yipevn7nryy2U+aslEPqSjpUtqqNuooYQN+Uhp37jqKhcu437YEJM5bCy+vf/UxJa+3mvRg1aT4ovVLi3td76KQQ6+3WHipX8qSpU3RfoxG4inU7ynvqj5+/5P3BdfJCyZvusSQjK6mxoWkpPQZNlPfokuIe1ab7CHW7KWLUjtQGNJWNpk117jsG67bsU6L17ulenkuMPGk+H/QJ3773CJQ3lYHqQPcizXulokejVjWadAfJUN1IpogRUyTI8KZpITQiRvevFp2HYNbCNSCGStoenp6yXeu06CXvSU07DpIyFE4yxpxbJKfPGXP//F+hXLC1tcHBI2f1JcPhVkQg4N3Rigoe2YuaOWNqnL1wHWOmLsLjZy+DxDF6ygLRI1EUO9fOlEPtZFCNnrJIrUfz/Np2H4kjJ8+jctliGDGgE7JlSg96gB0+fj7Ycldu3JUPRhr2o2HB3DmzYKTohSIDTJ2YCZ6g6mEoyTWb9uLUuatoUq8y2jWrgxev3qKTeFiQsQehWKtKWdCDiR4M4lD9f+9/J+WctxqVy6jDtD13HzyRQWVKFJL7oDZ37j8C9V716tQcHVvWQxQXFzm3+c59/7mK9GDq1LqBTKZft5bq4VSaHkGBk2Yvx7ylG5AzWyYM69dBtFlRbNn5H6bMXUnR0lFdOoqXnO/C6OjapiHqVCuDnfuPgeojBTQ2w8fNwa4DJ1CxTBGMGtgZubNnxowFq8WQ+B4NKX/v5FnLULpYfmxcOhnD+naAOdz8U+StOQQuXr2FLBnTIm4c3S/AxQvnlcnTPFnp+btZsmYrYokezVXzx2LB1GH4+v1HgOuBxA6fOCdezCYherSoGNC9FVo3qYH7D5+hYx9XaL9crdm8R45wLJ09SvYsR4vqAg8PT9x/9ByF8+WU0yxqVy2LN+8+gl6+3cQLNuVRp1pZlBXXjZOTo/o8Hz24C0XpdFt3HcK46UuQLXMGDO/fEVXKFwfNTR0walog+dWbdiNJogRYPscVcyYNAhmU1BseSDAEA9Zt2Y/jpy+joRh5q1O9nLynklHfc/BExIgeBT07NZNTIcjgU653yp7K1qzjYMHnPVo0rI5BPdvAwcFevizQyzTJfBNtRAYudVZ0FveHsUO7oZEY2fv15w9F63V0j7t87S5yZMugV0aJuP/oGWgajJOjAwb2aI2WjWvIMrXqOkzeBxU5etGi7xWKFsqDAUIubuwY6NxvTKDzQpHX3A90nYGrN++hUZ2KmDCiBzq1rg87ezt4/e2EoedR+16uOCY6TcqXLgLXwV1RvmQRXBedJnROUVq0vx/EuUVyupwx90/Sc3RwQKb0qUVnxA06ZGflBNjgtdIG7N+9NXKKt/XdB46jSfuBoJ62WYvW4tGTFzprVK1CCVQtXwL0dl+kQE706NAEB46chmKAkrFEhvOU0X3kvNOS/8uHQb3aoJIY0lm4chOUP2PllqzaKh7CaTDFtS9KFy8gp11MGtkb5g4NBVUPpZy69tGiRpFDkKWLFZQPo7mTB+OtePgSQ5JPIYYp8wrDfPueI3SodnScO3smpBTx6kAtz8vX75EgXhzY2hh3SY0d2h0dW9UHGY71apTHtDF9USBPNnVPTayY0YVBnAz0l1nccGkYlRw9hB4+eQ566LdpWlsaIaWK5hdtVht9urTATtHT/O7DJ1LDxu0H4C56SRZOG4FaVcugfKki4qE/GH5+fjJe2ZCxTi9AQ3q3R1vxIlC8SF70F8YNPbCXr9uOX7//KKJyX0oYuzSnkYwgehiYw00myBuTCVCv5uu3H5Awfly9aSROFE/GPX3+Su6VTcpkScQ50xw0jJ8+TQpMGN4jwPVAaU+buxp5xTVBUyXo/KlTrZw4hwbhhRhpICNTSYv28YTBTedNnFgxkTlDGtjZ2clrgnSbN6yG4oXzoFXjGlg6axQ8Pb2w//BpUgOdP/RibGtjo542kCOLbsPMXRjQC1duBhnOdH+i+1TrJjWlMX1GdABQj7BM9O8mY7qUwkivCSoTnavtmtUFvSBQT+RfkRDfRY3ijOlj+8kRHSpb9YolQC/R1NPerV1j0PU6QhjqdL+ge7BSgDlL1gkD107wcQXdE+glYPaEgYgbOyaWi954krv38Km8Hru3byI6MIpJXkXy50RbcS+geH3unnghp5GqDGlT6RNRh9PoWvKkiTB74iCUK1lYlmX+lGH49ccNa8VLDQnSPWHtlr1oIozt3p2bge4ZdD9rVKcyRRt0ZKzTaF+DmuVlOxbIkx35c2cTL/71ETN6NKkrnzPiWUYvYlS3YoVyy46KxTNGypcvEiJ+QZ1bJKftjL1/KnoZ0qbAzTsPlUPeWzEBGysue6QuOt0Y6Ia0eMYIeSNwcXaWxhIN+9DQtjacwuKmqBn2v4K55eG1W/fk/vzlG0iTMhm0HzSlihUQPaHv1EP/xspdu3UfBfPmkGkrm9Qpk4CGWJVjU/ZB1cNQmoUL5AgQnThhfPGwTYwr1++qw8kwpJubMnXg8dOXoofqGWpULqWWCQkP5UHDkjS0WbhCUzkEfP7yTdkDFVT65y/dgkqlEkZs6QCipYQhSj0j10TPCUXcuP0QWTOmFb1KUelQOjtbW/mQlAd/Nxev3Ja+4kXyyL2yKSYMFBpivK31hbxy7ihytA8rbpQXu38E/CD+iRcY7ZeYfxL/fL6+fv8OhC+o6+HR0xfyBbVmlYDnGV036dOmxKWrd0Qq//7/r2DOfwcaPjLqqFeShuBpugJNlyKD6ZXGtAYNcYPex6JMNJ2iqDCANAUL588hXzbPX7mpGSx7gTUDyLim45dv3tMuVFyxvz3qSuKJE8WX3oLCsJMesVGpVEiUMB5ev/kgjvz/n7t0U/R0F5adEv4hkFNU6Dq8esOfNb2k0EvvyInzQNM6fv76rYga3H/49FXGx4kVXe4NbS5evY2ihf2fD4pcLPECni1TOvGy4H+voM4RujcUKZBLEZF7Mr6lx8CGXoRoTjYZ8bQ6xKs3/6a3KGrnxfMonXgJS540oRKkc2/KuWXs/VPJMHasmKDRCDpnlTDeWycBNnits93Upc4iDJrOrRvKIcQDm+fL3pg1m/bg67cfahny0A2L9oqLEd3fCPr4d8mr9x++gG5i9EDSdH2GTZYq1ItEHn+5l9JA0ydHDyRfX1/E1nFzjR0rBiVjsguqHoYSjhEtWqDoWKI89NGPEkG9UFTGjTsOyKD12/bLHoWSohdVBujZJEuSAO8/fgYNHeoRUQe/FA/6bgPGwVYYn43rVML44T3lUG6hfNlhzAOM8iEDh+bNabZBqeptZO/t67cfZV6fvnxF9L/tLAP+bmLHjv7X5797/+mzfMiSMewf4r+NFcO/rd7/7TH2DwXiiB4nxa/sTeWm6PPeNAIO9vayd/edVhtppvbm7/mQXPTaaYbruh7o3Feuh7fv/UcKBo+eGeh6p1GBN+8/aiaHWDH9zxfNQOrZHDVpAWgKVocWdcWITx95rseLGxvffhhnrGmm9+79Z3kYSxhg0vN3o1KpEFucl2/f+Zf5bzCiRXVWvHJvY2Mr925uHnIfGhuatqCZrr1oIzp2cXGindpR21GPNQXQ9CN3dw9s3nkwEGuah6y0YcIEcbFE9JBTh8e46UtQrXE30NzZy9f8DVFKS5fz+rskIg3R64pXwmheLPXs6zo3YsaIhvcf/Pl/+uT/EVeMvz2yir6ue4MSp7mfN3koCuXLARoJrNeqL2jeMn1foMi8F8+jOLEDn09KPO1NPbeMvX9SHuScHB1pB2of6eGN1RJgg9dqmy5wwWnIXul9e6XVg6FtAJNRSinQMCTtEyWMi7Spk8uHES27o+1Sp0xKYjBGLnq0KLC1scHvP+5SR3OjbdA5OjrIaDKQpefvhuZn/fUG2AVVjwDCWgdkAGoF4cPHT1AYUJyNKHftKmWw/9Ap+WHOoWNnQUOS2sYgyWo6ZZ4kfQmtGa7Lf/LsFdBDZeSATqAhYhquo+kKfn4qXeKBwhKJniFbGxs5PUO7nei4fKnCUidu7Fj4ofFxkQwUmy9fAr4M0XAv9V4oH4MIEfn/vWBDnjhiqJr2aqejnKZyU6fJHpMJUC/bvQdP1aMw2gkdP3NJBtFQuvT83Xz/+fOv79+OPiaKKwxHCknyt2eShuHpvNJ2Xds0IDG1Ezan2q94yCjJljkd6KW8WsWSoBEaOtd1nZeKjqF93LgxZfTHvz2W8kBsaJiclu/T9yGvEAm9/yGQMk0PoulmFcv8T+c9eNrYfupcUqdIismufXB630rMnzwEVPcegyfhw6cvahltDz0bKOz7j8BtTuGKixEtKuhep/NeKdJXDFqlHbTTozZQ0jK0jyFexOnbhOO7l2Hj0knIkzMzRk9ZKD+uJL0E8WPjy9eA9ykK13SmnlvG3j+VvJQ6KnVXwnlvfQRsrK/IXGIioG04Uhi5+4+e0k4M1SeSe2Vz9uI1xSv3p89fkftc2TLJPT2IXr56J3plY4AeSNqObsgkaIycSqUCrZ158cotUlG7d6LH6OXrgEOJykNV20C/9/CZWk/TE1Q9NGW1/SfOXA4Q9OT5K1B5cmXPGCC8euWSco5hvxFTQT0wxkxnoDls9CBasHyzzh+KoPlzyg+C0LQDGtajB4uSMc1tvvZ3eokSRg9A8nt4etFO7QrmzQZfPz+8E70t2u1Ex8q0kexQvnlzAAAQAElEQVRZ0uHWvUegXhtFmXqgL14N2C4Z0qWU0YePn5N7ZXP05EU5pJpevAgpYYb2pnAzlB7HGUeA5lHSxz7T56+G9osjXVfrt+5DkQI5kTJ54gAJnjn/b1UQiiDZ5y/fIHcO/3tCGvGSS3ODad4onVfaLkO6oOeDUnmcnQL2bNKHox6enpSl2tGULLpG1AF6PDSkTz2jNOdcU4Q+bqK8MqUPukyaepbkL5g3O+7ef4xsmdPrvAdrl5VeMqkNalUtLY3ep89fa4uoj6kzgw60e+UpTNOpVCrQdJXjp/1fkpQ4+vGb67fuI+PfNk+TMhmcnBxx5oLWc0XrWNE3tE+aOKGcC0z3xIdPXkhRmtf74NEzPHvxRh7r2lB7G3Nuaesae/9U9Oi6SJ40oZxGpoTx3joJsMEb+u0WKjm07jZMrqBAc5jIgCFHc3f3HTqFCqX/J4fhNTM+dOw8aBkckqMlyqbOXSU/YlLmtNWoVErezGilBloehm54dDOjL/VbdxuuTspYudZNa4HyIn3qTb7/8Cl6DpkEG3FDVScmPLRwO5Vh8uwVeP7yrZzDSstc3br7SMQG/h9UPQJr/Av59esPKB8q14UrNyU/Mg7pK+9/UpAfuBQrklcuo0YfU9CcRc14ff5u7RvLqSRNOwySPxhx7NQl0MdlA12no3L9zrh594FUzZ87K+iBv2rjbjkF4f6jZ+g9ZDJ8fXxlvLJJmiQh7O3tsOvAcVCZyZEBToZ1swZVMV4MadIqGtTmFLd83Q7QEmZPnvk/+OrVKA8yDga7zlTru4rhZUrD1sZGyQY07+5/BXNh1sJ1oDJTWjS0SnMEWzeuiXhxY6tlDXmop9gUbobS5LigCdAwN608QkZgt4ETsGPvEdAoAs2PpC/ryTCgjxG1U/ooeuw0r4eBrjPECE48ueoByZIB0rdrC7kCQofertiy6z/QdUPp0y880p7kDLn8ubPjyvU7oHnlNKpBxi6ttELnpaZeKmFcU/zG7QfkuXr99n3NaLWfegbp46j9h0/JjzLpXD0hRkxoneE8ObOAPkhVC1uZp3v7xvjy7Scate2PFet2SmOS7tUjJsyTq1JQdfYeOil/xXHr7kOgutM9ml6y6cNDQ8Z+fHEN071O30fNlLbienZsIqcu0JQJyoPcQHEPoekubZvVkmL0Mt60bhXQ9Dla+YVkDh8/j9XinkYCmi/zdKzpyIBs1nEwlqzeJs8n0qUVK3x8fFAgdzYpWrtaWaRMkUSuEHJcdFTQnN7VG/egTffh+PHzl5TJb+S5JYU1NsbePxWVR09fIk+OLMoh762YwL+nnhVXIjIWvX2L+nBwsMe8pRtB62eSW79lH8ggpa9mtZn06dJCPAiPStkpc5aLB0MBDOndVi2mUqkwa8JA+SHUyXNXMGTsbAwcNQO0dFftamWCLUerGkwY0QvnL9+Ua0rS8l9VyhUTvRfp1GmRR6VSYeKI3rIuTTsOlOv2+vj4oX7N8hQdyAVVj0AKGgG0fM+nz1/kA6P/yOmgeXD0wx26bs6liuaTmrQagfQYsaFVFlbOG4NMGVJhz8HjwqCeA1r+5sXLd+jZqSna//1BkAxpU8rlvGhIjtas7Nh7NAqIXttKZYsGyIXKN25oDzx59gq9h06WbafMoevQoh4G9mwN6qWeOGuZjCNjomSRfMJoiSPToV75hdOGy6V++g6bip6DJsrhylJF8wsjNpaUUTbjhvVAuVKFMXPhGvQZOgWbdhwEGfCtmtRURIzam8LNqIRZyCCBji3rY/Tgbvj9+w/mi1GGQaNnglYXyZE1PVYvGAc657QTMOZ6oBGdhdOGAX7A4pVb5bWzetMepBYGKhmY2mlqH9epXlZeyyMnzUexKi0wefZy9OvWCon/rhyhyNO0HvrBHHop7y6M9iFjZitRgfYNalWQq4hsE0YfndfT5q6UqwRMG903kKw1BdCycmtEW5HhShz6DJuCiTOXilEWFSqWLiKrkiJpItmLv2PvUfQbPhX0wpIoQTzQagZ0vUshPRvqCLkg7sd6otXBWTOlw/ypw/BYGHr9RkzDsLFzEMXFGctmu4IMa0Wwlbg30OobtDwZPX/mLFmPru0ay+j48fS/JNOUN5qycPbidQwePQvDxs0FTZ+iFRdyZfcfXbC1sQGdd3nFS8z0+atEXaeB7pd0T1SmwRl7bskCaW2MuX+SCk0TefbiNWiqCR2zs24CNtZd/MhbelrOita33b56Bs4eWC3dqX0r5YOA3r61ySQXN8rlc0ZLub0b5gpjqY1cNkhTjnoTu7RpiI1Lp+DknuWg+VW0rBgtTWaKHD3E1i6cIOeaHd6+WP4SHK0sQUtwaaaXXAwXzZs8BCd2L5euT5fm6NS6AQ5tW6QpJv3JjaiHFNTY0M2aGDWtV0V+IHZm/yoc3bFEGvj6ei9p+gHFaX+trJGsTi/1okwd3Q+bl0+V/CjfNQvHy+XdVKp/c3TpBrpq3lhQWY7sWCyX5KElnUhPM2EaiqZfyyI2lBb1hivxtMwcpUF1oThasYMeQJrDfCS/UBi9x3YtBZ0fQ/u2x3UxNEm9HEo6tCejv2fHpti6cpos94Ylk+VyRBSnOPowjfJJnTKJEhRobyq3QAlxQLAJ0D2BjJJ9G+fK65fakpYCpOWbdCXm7ORg1PVAH8bOnzoU+zbNk/ePTcumgOb10rlO6SrXV51q5egwgKPziq7lbSunS126X9EL17pFEzG0T7sAsi0bVQeF0zWxa+0sGUcGEJ1zWTKmkcfKhpYnXLd4Eui83rZqOvqKnmi6fynx+spE5y6lR9eVImtor8g3qlMpkFgbMYpF154SoS9PKivlqW2QkoFH90NFn/Zk9I4Z0g3EiTjQh8i01jUtQUnx1BbUMbFi7hgc3blUXq/EMbm4h1K8IVezcim8efcJt+89CiBG94Vm9asGCCPedD+h+lG70zJr1EscQEgc0MgBlZXqR+cbjSaIYLniD+11OeJA5yWl/9/WhaDzle6ZNGVGU57uY7T0HJ079CxaKToTaO6yo4ODFDP23NJuJ6ksNsbcP3cfOAGaNkLz0IUK/7dyAhZn8Fo5Ty6+lRO4dO02toshYZom0LxBVfnxnTVXiYYNqeeXhg3JjZ26WK7G0ciI9TKDU++Ixi04dWdZJmANBGhKQs0qpbBszfYQKe6N2w/krzHSfYUc9cDOmL8aBfPmQKoU+l+KQyTzMEiEpp3R/Pc2TWqFQW6cRVgQYIM3LChzHlZDgIZTaU4cTamoVaWM1ZRbX0H/uLlh6NhZcsrDEDFMTFNUqIedenD06ZgSHtG4mcIgFHQ4SSYQogSaN6iO9GlTyG8IzE3YxdkJNM+fpjP0GjwJi1ZuQdFCeeA6qLO5SVuE/qvX79GkbhXQ9w0WUSAuhNkE2OA1G6FlJ2DMMLRl18C/dGFVD1rqh4bYenRoGiG+yu3atpEc+qQhRxoepaFp6oHxpxpy24jGLeTIWF5K+obeLa+kXKKQJhArZnTQXGllWoA56dPKDzRdi+4tJ/euAE11oe9HdE2pMyef8NJNkyoZmolRvvDKn/PVJmD+MRu85jPkFJgAE2ACTIAJMAEmwAQsmAAbvBbcOFw0JsAEjCfAkkyACTABJsAE9BFgg1cfGSPD7e0dYIqjn3o0Rc9UHTs7e7k4uan6pujZ2tqC1lY0RddUHVqMnb4UNlXfFD2VSiXX0zVF11Qd5fQ0Vd8UPT8/P5mtKbqm6vj4+EKlsjHpGiM9RJA/qos+hnRtm3M/MYexudc4rb1ra2tnUvsC5l13np6eJuVL7WDOtWBnZ2fWvZjuqXSfo3IE15GeOfdHOs/sxLMkuPmSPP7+kd8UR3mbokc6VGeVSmVSe9P5ScwpHX3ub9WC3H358hlh5CJFPkEC1xJgg1cLCB8yASbABJgAE2ACTCA0CMSPnxDszGdgStuwwWsKNdZhAtZOgMvPBJgAE2ACTCASEWCDNxI1NleVCTABJsAEmAATCEiAjyIHATZ4I0c7cy2ZABNgAkyACTABJhBpCbDBG2mbnituPAGWZAJMgAkwASbABKyZABu81tx6XHYmwASYABNgAmFJgPNiAlZKgA1eK204LjYTYAJMgAkwASbABJiAcQTY4DWOE0sZT4AlmQATYAJMgAkwASZgUQTY4LWo5uDCMAEmwASYQMQhwDVhAiFDYN2mnRg7eY7R7smzFyGTcQRKhQ3eCNSYXBUmwASYABNgAkwg4hHYsGWX0cYuGcaPn7LBq30WsMGrTSSMjzk7JsAEmIBCYPveI2jYpi8KlW+Cr99+KMG8ZwJMwAgCPp4/8PvDzUDO/csDI7RZRCGwfus+uLm7K4dhsv/0+Ss69h6F5p0Gof+IqaGSPxu8YdKUnAkTYAJMIGgCCeLFwahBXRA3TqyghSOeBNeICZhF4M+nu3h2dGAg9+7SDLPSjWzKW3b9B3d3zzCt9rR5K1EoX06smDsWMWJEw6oNu0I8fzZ4QxwpJ8gEmAATMI1AoXw5kC51CtOUWYsJMAEmYCaBXfuP4d37j+g1ZCK6DRgnU6vVrDumzFmOjn1cceTkecxZvA4V63VA7eY9sHDFJilDmy9fv2Og63Q0bNsXpaq3wrFTFygY+w6dRKN2/WQ4pePj6yvDNTcnz15B1QolZFCVcsVx8twV6Q/JjU1IJhbqaXEGTIAJMAEmwASYABNgAqFCgIzOhAniYerofpg5fqA6j2RJEmLe5KEoVbQAKpYpin0b52PNwom4eechLl29JeVmLFiNWDGiY92iSdi5djayZkqH5y/fYNna7Zg9YTDWLJgAD08v7Nh7RMorm99/3KBSAbFiRpdByZMmxIePn6U/JDds8IYkTZFWlQadkLdUPbWjxhbBgf4vXrUVdVv2Qh3xhrRz39FA8RzABJgAE1AI+Ph448+f3wGc5rGnp6feOE05XX4PD3cxfOlmkr6b2x94eHiYpEtl8fT0AKVB/uA6d3c3kbe7yXl7eZnLzNS8/4DqHdz6KvLE283N1PZyM4uZOeeZuzudZ6Yy+y2YBd1eHuJcVq4Zzb2fn1+onuOaeUVUf6liBdVVcxfXPPXUdh84Dq/evMPDJ/4fyJHh2655HSkXNYqLnJp19cZd/Pr9B/1HTkX7XiNx7eY93Ln3GNp/Njb/zFGV6p9fW86c49BJ1ZwSRQDdIzuW4tKRjdKlSJY4UI32HDyBuw+eiLejCVg2ZwxWbdwlT5pAghzABJgAExAEbG3t4OzsotfZ29vrjTOkR3EODo5wdHQySd/JyRkODg4m6VLe9vYOoDTIH1xHZXYQZQ+uniJvZ2cuM0cT6+0MqrdSjuDuHQRvJydT28tJtJep5XYR5TadmaMjnWehm7eDOB+g40+lUsExFM9xHVlGuCAHeztZJy8vbwxynY4yxQvJHmDq7f3j5i7jaGNn5y9HfukE++JF8mLR9JHSbVw6BUP6tJdRyiaKizN8fHzh6eUlgz59+Yr48eJIAMq6YgAAEABJREFUv5Ebo8RsjJJioRAlcO/hE+TMlgEO4iEVLWoUZMmYFkdOXJB50LwZ+kKSDujNiObI0AlGx+yYABOIvARUKhVUKnYqFTNQqZiBSqWbgb47hEqlW16lMj9cX57WGu7i7ITvP37qLP637z/ES5MDcmT1t2HOXLimlsuTMwuWrNqiPqae3fy5swr75jwe/e0FptVnHulYMu1/BXPj4JHTUveA2BcVx/IgBDds8IYgTCWpyvU7oXL9jpizZB18dUzOpo9Srt18AG9vb9nVf+vuQ7z78EmqjxrYBRu378fT568wYsIcjB3aQ7xVa70xSUneMAEmYDQBKxGct3SDXJKMluipJO4jfYZNtpKSczGZABOIKAQa162C6fNXqT9a06xXvLixZScdfZjWa/BE0NxeJb57hybSlqEP1IpVbo6zF68hccL46NetFVwnz5cfrlHcNx1LLvbq1Aw79x8DLUv2/MUbNK1fVUk2xPZs8IYYSv+Els4ejZN7V2L+1OF4+Pg5lN5a/1j/LU0KT5s6GcrWaovazXoEOGFo3suwfh3RtONAVC1fAhnSpvRX4i0TYAIRnkDHVvVx9sBqtZs8qk+ErzNXkAkwgbAlEFRu5UoWxvSxA+SUBZLdunIGokeLSl7phgsbhT5Mmza2P1wHdUXrJrVkeJxYMTFuWE+sXTgRJ/asQNkShWV46WIF5XJjFL5v43zkzZVVhmtuaCnGhdNGSLkJI3rB2clJMzpE/GzwGonx9r1HaNFlKP5XsRmo50XXshqUVHzx9kP7ZEkSosT/8uPO/cd0GMCpVCp0bFkPR3cuw4EtC0XDOgYwes+cvyblvXX0DssI3jABJsAEmAATYAJMgAkYTYANXiNQ0ZIZPQdPQrXyxXFo+2K5NIeNMFq1VWnitrePjwx29/DE8dMXkS1zenn88dMX9RwWmphN83Lpl0w2bNsPWn+ucrliUu7ew6fYuvsQNi2bir0HT+DGbf6FGAmGN2FIgLNiAkyACTABSyJQv3ZVDOrT2WiXJlVySyq+RZSFDV4jmuH4mUvIlD41alUtAydHB6RIlkh+PKKt+vb9RxQp31guSVa/VS+pU69GeSl24uxlzF++Ufp//fqD8nU6oGTVlth94BjmTRkqhwvICB4yegZGD+6KRAniYaLo1h86dqac5ysVecMEmAATYAJMgAmEHQELyalh3WpGG7tkGKdOyQavdtOxwatNRMfxm7cfZWjDNn3ldIaVen7yLk3KZDh/aL1cjmzHmtlo17yu2jCuXbUslPl4sWPFwJEdi3Huv3VYNX+8XJyZMrC3t8PmFdNRMG8OOkTG9KlB6dC8XhnAGybABJgAE2ACTIAJMIFgE2CD1whkfn6+ePv+A8YP74WVc8fg+OlLuHztttT8/fsXTHG08LgpeuboeHh4mFRWU/OkhdI9PNzDOM8/oAXOTS2zCXpwc6M83cK0nm5ubiLfsM2TFvqnfE1hZKoOnT9ugq8p+j5/pxfJC5U3TIAJMAEmEKkJsMFrRPPHiR0TmdKnkVMZ6EvCbJnT4v5j/18WiRIlKkxxtEC2KXrm6NDC3+boB1fXxSUKHB2dTOIT3LwUeRcXF9Ci7MpxWOxp4XgnJ+cwraezszPIhUX9lDyojmGdJ50/xFcpQ3D2tra2RlzdLMIEmEDIEeCUmIDlEmCD14i2oQWQHzx+JufSenh64uadR8iYjpcLMwIdizABJsAEmAATYAJMINwJsMFrRBPQQstN61VB2x4j0ab7CJQuXhC5s2cyQpNFtAnwMRNgAkyACTCBsCTg4emDk2cu4sTpC4FcWJaD8wpfAmzwGsm/UtliWLdoAlbNG4tGtSsaqcViTIAJMAEmwAR0EuDAMCLw8bsnqtRtjYq1mgdyf/64hVEpzMvm+/Oj+Hh7rdHO89db8zKMgNps8IZQo756/RZREmQy2sVLlddoWUrXy8srhErKyTABJsAEmAATYALWROD782PC2F1ntGODN3DrssEbmInlhHBJmAATYAJMgAkwASYQAQgsX7cdqzfuCreasMEbbug5YybABJhAYAKfPn/FwhWbpNv734nAApE0hKvNBJgAEzCHABu85tBjXSbABJhACBP4/OUb3n/4glzZMyFt6hQhnDonxwSYABMwTKBWs+6YNGsZWnUdihadB4NWqSKN5y/foGbT7mjQug/adh+OJ89eUTD2HTqJnoMmoHPf0WjZZTDWbdkrw2lDvbqk07H3KNx/+JSCpDt84hzK12mHui17YciYf78oe+TkeXTpNwb1WvVG/da9pWxIbSKQwRtSSDgdJsAEmED4Enj74RPevP2ARAniyoL4+fmBfkhDn/P19TUYr0+Pws3RNVffWvP2L3f4MPfP2ydc2tu8vIkXOdPKbkzeJCMvmGBs6BwOylG6hmSCkZ3ViKZIlghLZ7mie/smmDBjiSx3rJjRsWj6CKxfMhltm9fBhJn+4RT59v1HTBjRC8tmj8Gh42fx7cdPPH72Epu2H8CyOaMxcWRv3Lr7iESly5A2FXaunY2NS6cgedJEWLN5jwyfMX81Jo3qLcNnTxgsw0JqwwZvSJHkdJgAE2ACIUAgmbj5TxvTF3lyZsGAkdNBD1ty3t5e0OcCxRuQ1U7D15cMEG+9aWvLax77+HiL8vmYpEvpmJO3ObqUt5+fr8nl9q+3acy8vb3DjRmV28fHx+R6m3eeeYt6m8rMS+gG3V4+4nwM7iVI54IhR2nSuWZIJrh5WoN88SL5ZDFppIl6dv3ES7eTkyMOHj2D3kMnYdHKzXj24rWUoU3ObBkRNYoLeUE/1vXi5Vtcu3lPLuMaM3o0RIsaBWVLFpbxtHFwsMfytdvRtf9YnDx7GY8eP6dg5MiaARNnLMWyNdvgK/KUgSG0YYM3hEByMkyACTCBkCDg4uwERwcHJE2cAE5ODvjj5g761ThHRxGux9nZ2cFRT1xQ4XZ29qBffgxKTlc86ZG+rjhjwkiX0jBGVlvG3t4B5LTDjT22tTWdGeVLzti8Aso5guodMEx/22rLka6DgyMcTWhv0rO3t4ejCbqkY2fGeUa8yFE6pjhj8qb0g3sNBlUWYmYnrhFDcsHN0xrkycBVyqmCSnrXb9mHl2/eoW+XllgwdTjc3DxkOG3oHkV7cjYqG/FS5U1eaIbb2f379cuxUxeKEax4GDu0O3p2bAY3d/+0Rg3sgga1K8FP/OvQaxTcPTxlOuZsFF02eBUSvGcCTIAJWACBi1dvyQ/Wps1bidixYqp7TSygaFwEJsAEIgmBLbv+kzXdf/gUkidLBJVKhRev3iJP9sxImCAuzly4Bu8getSzZ06PS+J+RiMDZEBfuHxTpkkbSqtYkbyIHi0qTp67QkHS/fz1GxnSpkSrxrVgZ2uDdx8+yfCQ2LDBGxIUOQ0mwASsmIBlFT1frqxo17yu7PUY3KutZRWOS8MEmECkIPDr9x/54dj6rfvQv3trWee6Ncpj9uK1aN9rJC5fv4MY0aPJcH2bdGlSoHSxgujUxxXdB44HGb2KbKvGNdG84yA5pYGm+Sjh9LFa1YadMWDkNJQvVQQpkyVWoszes8FrNkJOgAkwASbABJgAE2ACEYDA3yp0bFlffji2fM4YpE+TUoZSz+v21bPkdAb6mG3fxvkyvGKZoujbtaX002b88J7InSMzedGiUQ3MnzocM8cPxIq5Y9GkXlUZXqV8CexYMwuzJgxC784tMHui/wdqlOaudXNAabRpVkfKhtTGJqQS4nSYABNgAkyACTABJsAEmIAlEmCD1xJbhcvEBCyXAJeMCTABJsAEwphAjBQlEC9LQ6OdQ9REJpdw68oZcm6tyQlYqCIbvBbaMFwsJsAEmAATYAJMwJIJhF3ZYqQoKYzdRkY7cwzesKtV2ObEBm/Y8ubcmAATYAJMgAkwASbABMKYABu8YQycs4tcBLi2TIAJMAEmwASYQPgTYIM3/NuAS8AEmAATYAJMIKIT4PoxgXAlwAZvuOLnzJkAE2ACTIAJMAEmwARCmwAbvKFNmNM3ngBLMgEmwASYABNgAkwgFAiwwRsKUDlJJsAEmAATYALmEGBdJqBJYN2mnRg7eY7R7smzF5rq7BcErMLgpZ+ju3bzHnYfOI6la7Zjw7YDOHziAj5++iKqwP+ZABNgAkyACTABJhBxCWzYsstoY5cM48dP2eDVPhss3uA9duoS6rfug3nLNuLi1dtwc3fDsxevsf/wSbTrOQqjpyzEtx8/tesVCY65ikyACTABJsAEmAATCFkCrboORaN2/dC0wwB07T8Gb9590JvBj5+/ULt5D73xlhRh8Qbv7oPHMHV0XyyYOgwjB3RC59YN0b97K0wa2RubV0xF9izpsfe/U5bElMvCBJgAE2ACYUmA82ICTCBECfTv1hqr5o9HscJ5MW7aohBNO7wSs3iDd/KoPkiaOKFOPrY2NqhWoQQa1a6oM54DmQATYAJMgAkwASbABEwjUChfTjx68kIqb95xEE07DkTDtqITcvlGGaa5ef7yDWo27Y4GYlS+bffhePLslYz+9Pmr7AXuP2Iq2vcaiSfPX2HkxHlo030YSlVvJUbsw6bT0uINXklLbB48fg43d3fhA/YcPIEhY2bj1Zt38tiIDYswASbABJgAE2ACTIAJBIPAhSs3kSZVcpDxumjVZswYOwBLZ7ni0PFzOHPhWoCUYsWMjkXTR2D9kslo27wOJsxcoo5/8eot2rWoK0brh+P23Ucg2cUzRuHg1kXInzubWi40PVZj8I6aNB/29va4fe+x/GgtU/pUGD0lYnSzh2YDc9pMgAkwgYAE+IgJMAEmYJgA9b4WKt8YR0+ex4AebXD15l2UKlYAsWPFgLOTE6qUL47rt+4HSMTJyREHj55B76GTsGjlZtD3VopA8qSJkCZlMnmYIV1KnD5/BfOXbcCJM5dkmjIilDdWY/Da29nBztYWF67cQtUKxdG4bmX8+v0nlPFw8kyACTABJsAEmAATiFwEqPf17IE1mDVhMJImTiArT3aY9IgN2WN+8BO+f//Xb9mHl2LkvW+XlrIn183NQx3pIDoslYP0aVJiyUxXZMqQBuu37sPazXuUqFDd6zR4QzVHExMnrM9evMHZi9eQLXM6mYqPj4/ch/aG5q8UKt8Eius5eFJoZ8npMwEmEEkJ0BfRS1Zvw5pNe0Bz3SIpBq42E2ACFkQgV7ZMOHrqAr58/S6nl+757wRyZ88UoIQ0bSFP9sxImCCunO7g7eMdIF45+P7jF6JGcUHxwnlRu2pZ3Lr7SIkK1b3VGLwtG1bH+BlLQG8GGdOlAs3pjRcndqjC0Uw8T47MOHtgtXTTxvTVjGI/E2ACEZdAmNfs67efyJE1PUqL4cNx0/7NgQvzgnCGTIAJMIG/BFKnTIrm9auj+6DxoGXLyFgtmDfH31j/Xd0a5TF78Vr5Ydrl63cQI3o0/wit7eET50QHYmMpd/z0JbRqUlNLInQOrcbgLV4kL6clOsYAABAASURBVOZPGYo+XZpLEunTpMDM8QOknzdMgAkwgYhCIEvGNMibMwuiR48Kb2/dPSQRpa5cDybABCyPAH2UliNrhkAFq1O9HFbNG4d1iyahfYt6Mj56tKjYsmK69GdImxLbV8+S0xm6t2+CfRvny/C4cWJh3eJ/I+O1qpQRnYdrpNzYod2RNlVyKRfaG6sxeAkEfbC2Yt1OLFyxSe0oPCzc7fuP8b+KzdCm+wjcuP1AnSU9kBSnDgwFj5KHOXuaAmKOvim6kSNPH4R1PSk/cqa0iak6lB85U/VN0TMnP/qFxlC4FMMkSSr7mKmL0KNDE5mfr68v3N3d9DovLy+9cYb0KM7LyxMeHu4m6ZMe6VM6pjjSpTRM0fX09AA5U3RJx9vbdGaULzlKJ/jOHVTv4Ov5tz/pmsqM9Dw9PU1qayqvlxnnGfEiR+mY4ozJm+omL5hgbIIqCzHzEteIIblgZMei4UjAagxe+knhiTOXYvveI/j85bvYH8XL1+/DBF3iRPGxc81M7Ns0T36l2GfYFPxx818izcfHG/7OJ1TL4p+Hkpdpez8/379lNU0/+GXwAT2og6/nbXI5fX19RJ5kgHqbnEZwy+vr6x3mefr4+Ij6kQvLelJ+5PTn6aO+HkJGxteM9vTz8wvVazI0E5+3dAMqlSkKpZdFpVLBzs5er7OxsdEbZ0iP4mxsbGFra2eSPumRPqVjiiNdSiOsdSk/lcp0ZlRmGxvTmNnZ2YHqbWegPQ3FkS7lb0hGXxzp2draQl98UOE2Zp1nVG9TmdkLZkG3F9UNwfwLqs7EzMbGMLNgZmmSeP3aVTGoT2ejHS0lZlJGEVjJxlrqtv/wSSyZORIJ4sXBwJ5tsHXldLh7/PsCMDTr4eLshGhRo0hHP3KRMH5cYWz7rwHs6OgER+kcQ7MIcJR5KHmZtqcLOyTSMT4NR7mUnPHyptVLM30HB8rTAY4hwMvYNMInTwc4ODjAMQzraW/vEE55OsLRhHraiIdzqF6UoZQ4zW87ff4abt97KEey6KVRpSKDl4wF3c5WGjG64+yEgWXImaNL6Zqjb45ueObtX24ygsKeuX/epuUbnszs7IgXOdPKbky9SSa4lyUxCcpRuoZk9OQZosEN61Yz2tglwzh1yrCZJhCilQzlxKzG4HVxcRFvpXbwFEMqPmJ4z8nRATbiIRDKfGTymsuf0YoNX7//QLIkun/9TSrwhgkwASZgIoHSxQpizcLxaNe8rnTWaribWH1WYwJMgAmECgGrMXijiF5WLy9vpEqRFKMnL8SshWvg4ekdKlC0E93730nQkmRFK7fAlLkrMXZIN1Cvr7YcHzOBYBFgYSbABJgAE2ACTCBMCFiNwdu7cwvZu9uzYxMkS5wAjqKHd3CvNmECqV6N8qAlyU7uWY55k4eo1wEOk8w5EybABJgAE2ACEZwAV48JhDYBqzF4U6dMgiguznKxYlqzjYb74sUNu3V4Q7shOH0mwASYABNgAkyACTCB0CFg8QZvh96uMORCBwunankEuERMgAkwASbABJgAEzCNgMUbvK2b1AS55EkSyUXYSxTJh0pli8LJ0RFxY8cyrdasxQSYABNgAkzAWglwuSMdgROnL2DTtj1Gu3cfPkY6RkFV2OIN3ny5soLc/UdPsWDacDSoVQHVKpTA9LH94O7hvxZuUJXkeCbABJgAE2ACTIAJWCuBE6fPY8OW3Ua7t+/Y4NVua4s3eJUCu+tYc9czjFZpUMpgRXsuKhNgAkyACTABJsAEgk1g/dZ9cHMP2w7FoWNnIV/p+ihVvRUGjpqGn79+B7vcQSlYjcGbP3d2dOztis07D2LfoVPoM2wyUqVIElT9OJ4JMAEmwAQiNQGuPBNgAsEhsGXXf3B39wyOitmytBDBhUPrsXn5NLk4weqNu81OUzsBqzF4e3VqihqVS+HqjXs4de4KyhQviB4dmoD/mAATYAJMgAkwASbABMwnsGv/Mbx7/xG9hkxEtwHjZIK1mnXHlDnL0bGPK46cPI85i9ehYr0OqN28h/w1SCkkNl++fsdA1+lo2Lav7Kk9duqCCIXopDyJRu36yXBKh348TEZobOjHvFQqFWLGiCZ/RtoPIf/T8FZj8KpUKtBvy48Z0g3kKpT+H1QqlQYu072syQSYABNgAkyACTCByE6gaoUSSJggHqaO7oeZ4weqcZBBOm/yUJQqWgAVyxTFvo3zsWbhRNy88xCXrt6ScjMWrEasGNGxbtEk7Fw7G1kzpcPzl2+wbO12zJ4wGGsWTICHpxd27D0i5bU3HXuPQoGyDfHuwye0a1ZHO9rsY6sxeF++fod5Szega/9xAZYpM5sAJ8AEmAATYAIKAd4zASbABAIRKFWsoDqMvqmintruA8fh1Zt3ePjkhYwjw7ddc39DNWoUF8SNE0uMyt/Fr99/0H/kVLTvNRLXbt7DnXuPoetv3pRh+G/bYqROkRSLV23RJWJWmNUYvKOnLEQM8ebQpF5luUwZLVVGzqzaszITYAJMIIwIbNx+AE06DESzjoNx4uwVnbluFz0fDdv0RaHyTfD12w+dMhzIBJgAEwhrAg72djJLLy9vDHKdjjLFC8keYOrt/eP27wM3Ozt/OSlMGzESX7xIXiyaPlK6jUunYEif9hSj08WMHg2lihXA+cs3dcabExh8g9ec3MzQjR4tChrVrogCebLLZcpoqTJyZiTJqkyACTCBMCHw/OVbrFy/CwumDsPEET0xRrzAu3t4Bso7Qbw4GDWoi+wZCRTJAUyACTCBMCDg4uyE7z9+6szp2/cfcHBwQI6sGeBgb48zF66p5fLkzIIlGj2z1LObP3dWHDlxHo/+9gLTi/yjp/49wmpF4blx+4HYAjS/9+ipi8iYPpU8DsmN1Ri8BPbZizchWXdOiwkwASZgFgFjlelDW+rliOLijIQJ4iJjulS4eMV/3hs0/grly4F0qVNohLCXCTABJhC2BBrXrYLp81epP1rTzD1e3NjIkjGt/ACt1+CJoLm9Snz3Dk3k/Fv6QK1Y5eY4e/EaEieMj37dWsF18nz54RrFfdMxejVv2Qa5LFnBsg2lXstGNZVkQ2xvNQbvk+evBeB+aNpxEDr0dlW7ECPBCTEBJsAEQonAx89fxI0/njr1pIkT4MOnz+pjYzx+fn5gxwz4HDB8DhhzLWnKhARPzfQigr9cycKYPnaAnLJA9dm6cgaiR4tKXumG9+soP0ybNrY/XAd1ResmtSgccWLFxLhhPbF24USc2LMCZUsUluGlixXEirljZTh97JY3V1YZrrmhD+IuHt4AcvTRW3xhWGvGh4TfagxeWpZs5vgB6NaukYBbU+1CAgKnwQSYABMIbQIqm3+3W5UqeCvM+Pj4wM3tj17n5eWlN86QHsV5enrAw8PdJH13dzd4enqapEt5e3l5gtIgf3AdlZnKHlw9Rd7b21xmHibW2w1Ub6Ucwd0Tb3d3U9vLXbSXqeX+I8ptOjMPDw9xnoVu3nQ+6LqOxbuirmAZFhR/Oj+JuSE5mRBvLJ7AvzuwhReV5uvqchZebC4eE2ACCoFIvI8XJza+ffuuJvDl6zfEjxtHfRyUx9bWFi4uUfQ6mlNnKN5QnKOjE5ycnPWmbUjX2dkFjo6OJulSug4OjqA0yB9cR2V2FGUPrp4ib2/vYHK5KV8nJycT9V3gIOqtlCO4e+Lt7GxqeznD0QxmDg6mMyNe5IJbX0XemLypbrquJUPvl0r6+vZ0fhJzffEUrivPkA4rVqQA6teuYrRLlPDfiFJIl8Va07OxloJ7iF6EFet2osegCerpDDS1wVrKz+VkAkwg8hL4X8HcOHnuCug+9uXrd9y5/wQF8maTQOhjjs/CAJYHvGECTCBSEAhuJYsVyY+6NSsb7RLGZ4NXm7HVGLyjJs7Hx89f8enzN9SsXApRXZyRMV1K7frwMRNgAkzA4gikSJZI3LdKo3W34eKlfSJ6dmomv3Cmgi5YsQmXrt4mr1xrnJYk+yTudZXqd0KfYZNlOG+YABNgAkzAPAJWY/A+efYSfbo0R5Qozihfqggmu/bBqzfvzas9azMBiyXABYtoBOrVKI/V88dh5bwxKF44j7p6k0b2lvc0CujYqj7OHlitdpNH9aFgdkyACTABJmAmAasxeKNEcZFV9fb2gbLIsZeXjwzjDRNgAkyACTABJhBBCXC1mEAIELAagzdqlCj49uMniuTPiZZdhgg3FAnjG//RB/iPCTABJsAEmAATYAJMIFISsBqDd/rYfqCfnGvVpCYG9WyLTq3ro1/3VpGy0bjSgQhwABNgAkyACTABJsAE9BKwGoOXakALRD959hrRokYFLVFma2NVxacqsGMCTIAJMAEmEIoEOGkmwAR0EbAai3HvfydQtWFXjJgwFwNdp6Fyg87Yd+iUrjpxGBNgAkyACTABJsAEIiyBC5euYfGK9Zg6ezE2b9+LDx8/R9i6hlTFrMbg3bHvGLasnCq/cN6wZDJWzB2DZWu3hRSHSJUOV5YJMAEmwASYABOwPgKenl7oM3gMSlVphB79R2HY6Klo0aEPCpWqiZNnLoZIhdZv3Qc3d/cQSSu4icyYvwr5SteHt0/IL0pgNQZvrBjR4OjgoGYXN3ZM2NraqY/ZwwSYABNgAkwgmARYnAlYFYGufYZj/pI1gcr8/uMnVKvfBhcvXw8UF9yALbv+g7u7Z3DVzJZ/+vwV7j96JtcoV6lUZqennYDVGLwxYkTHmk178OHTFzx+9hIzF65B4fw5tOsTqsdfv/1Aqept5OLwoZoRJ84EmAATYAJMgAkwAQ0C+w4ew5qN2zVCAnq9vLzQrtvAgIHBPNq1/xjevf+IXkMmotuAcVK7VrPumDJnOTr2ccWRk+cxZ/E6VKzXAbWb98DCFZukDG3oVyQHuk5Hw7Z9ha3UCsdOXaBg7Dt0Eo3a9ZPhlI6Pr68M196Mn7EEg3q1hR/98/PTjjb72MbsFMIogZ37jmK2gFy9cTc0aT8Q67bsw9rNe0G/SkQu1IqhkfCUOSuRO0dGIORfPMB/TIAJMAEmwASYABPQR+DshSv6otThDx8/w7sPH9XHwfVUrVACCRPEw9TR/TBz/D/jOVmShJg3eShKFS2AimWKYt/G+VizcCJu3nmIS1dvyWxmLFiNWKJzct2iSdi5djayZkqH5y/fYNna7Zg9YTDWLJgAD08v7Nh7RMprbnYfPI58ObMgaeKEmsEh6rcag1fz14d0+UOUio7Ert+6D2dnR2TJmA7i5UOHBAcxASbABCI2Aa4dE2AC4Ufgxq27RmV+49Y9o+SCI1SqWEG1uLuHh+zx7T5wHF69eYeHT17IODJ82zWvI/1Ro7ggbpxYuHrjLn79/oP+I6eifa+RuHbzHu7cewzNP4rfuusQWjSuqRkc4n6LN3jrteotpy8QNF893eAhTkUrQW9vb8xatA5d2zbUiuFDJsAEmAATYAJMgAmEPoHsWTMZlUn2rGIk2ihJ44VyknlkAAAQAElEQVQc7P2/mfLy8sYg1+koU7yQ7AGm3l7l128pNTs7fznyS6dSoXiRvFg0faR0G5dOwZA+7WWUsrl554HoKX6AQuUayQ/WKA/y//7jpoiEyD6EDd4QKVOARCaN7IPo0aJizpINqNKwC0ZNmo8jJy9AE3AAhVA4WLNpL2pVLS3LoZ28u7s7yHmINx7tuJA8pjx0uRu376NktZbIW6oe6rToiflL18vy6JK9++AxWnQehELlG+F/lZri7v3HemV16Qc/zAP0RWnw9dxNLhe1g6enp8n6ppQ1fPL0hIeHZ5jWk7iGT54eJtXT1zfkv/INyWtaX1qfPn+V8+Jobhwtx6hPjsOZABOIXAQK5c8dZIXTpUmJhPHjBSlnSMDF2Qnff/zUKfLt+w84ODggR9YM8uOyMxeuqeXy5MyCJau2qI+p5zZ/7qw4cuI8Hv3tBaZvoR499e8RVgQL5cuJi4c3qJ29MK7PHlyLKC7OikiI7C3e4E2RLBFaNKyOxTNGYM2C8cidPRMOHjmNGk26o8egCdi253CIgDCUyKnzV+E6aYEwFJvIB9HKDbswff4qqUJvM+RsbW3lcWhtKA9dLnnSRNi0fCrOHliDUQM748DRM7j/6Dm0ZWmSeN9h01C0YB4592bzsqlIlDBeIDltPfOObWFraxPKedgFSN9WtAM588odMM2g0qL8yAUlF5LxlB+5kEwzqLQoP3JByYVkPOVHzpQ0VSobhOufiZl//vIN7z98QS5xr0ubOoWJqbAaE2ACEY1AxXIl0LheDb3Vovvk4tkT9MYbG9G4bhWQjaN8tKapFy9ubGTJmFZ+gNZr8ETQ3F4lvnuHJnj34ZP8QK1Y5eY4e/EaEieMj37dWsF18nwZTh+vffv2Q1EJ071VPRFixYyOKuWLY/zwntizfg5qVy2Lew+ehjqwRdOHC4NytXTtmtdFs/pV0aNDU5kvnWCKkwGhtFHy0N7HjBEdcWPHgr29PRIliC9zt7OzDWAEks7Js1eQOFF8tG5aG6STMEE8uffy9pY9w4+evpQ6S1Zvxfjpi6Wf9Mx1phor5uQbOfKkNiYXPOPcfK7hkadpdVSpVPJ6MHZDU6aoR7VL/3Go1awnilZugfJ1OqBxuwEYO3UxXr5+Z2xSZsu9FQ+NN28/iGs6rkzLz88XXl6eep2Pj7feOEN6FEe63t5eZulTOqY4ytsUPdKhMpMjvynOx8fH5DpTvuRMyZd0fMxsLy8vU9vLCzRFz8vAuWQozpxyEy9yhtI3FGdM3lQ3ecEEY2MoTyUuqLyDkZ3ZonOmjsLoYX3gotX7mTNbZhzduw55cmUzO49yJQtj+tgBcsoCJbZ15YwAI9zD+3UEfZg2bWx/uA7qitZNapEY4sSKiXHDemLtwok4sWcFypYoLMNLFyuIFXPHyvB9G+cjb66sMlzf5sz+NbATnVf64k0NtxqD98Hj53Bz918Iec/BExg5cT5SpUiMgT3bmFr3CKP35NkrOaWhbK02aNmopnz70q7ca/HwdBbDFA3a9EHxKs0xbtoieIqbprOTE8aLE3TE+Dl48PgZiG2vzi201fmYCUR4Aq26DcfFq3fQtF4VzBjXH0e2LxY39QkY1q8DMqRLgX4jpuHw8fOhziGZGLWZNqYv8ojhwQEjp4MM8VBYoSfU68EZMAEmEPIEqNOiR6dWeHLzJDYsn43JYwbj3JHtOPXfZjEqlCXkM4xAKVqNwUtzd6kX8/a9x9iw7QAypU+F0VMWhXlTtGxUHR1b1Q/zfA1lmDplUjn3ZfPyaThw5DToq0lteT9fXzx78QqjB3fDjrWz5VeTazbulmIZ06dGmRKF0KrrUIzo3wk0fwf8xwTClED4Z9a/W0sMF8ZtgTzZ5DCdvb0dYseKgQxpU8rRpJVzxyBpkgShXlC6/uhHdpImTgAnJwfQ9wo2NjZiFMdBr7O1tdMbZ2+vX4/iSNfOzt4sfUrHFEd5m6JHOlRmcuQ3xdFIkCl6pEP5kiO/Kc6cevvrmtpe9nL0zpQyk45/3obPJ5LT5YgXOV1xxoQZk7ed9gdTCPovJPIOOpeQl6BVECpXKIUOrRsja+b0IZ9BBEzRagxee3EiUxf3hSu3ULVCcTSuW1kabRGwTUyqkkqlQsrkSZA2dXL8d/RsoDTix4uDtKmSCZccMaNHQ6F8OXD/kf90ED/RfXTu4nWpExo/5ycT5g0TsHACmcSLn3YRae77s5dvZTAZwGT8yoNQ3Fy8ekt+KzBt3kphcMcEPdhCMTtOmgkwAUsjwOUJFQJWY/DSb248e/FGToLOljmdhOHjY51fYcvCh9CGvnykLyEpua/ffuD8pRvIlCENHeLjpy/qLyOLFc6D56/e4auQoYf4+cs3kTlDWim3dvMe+Pr5Ytms0Rg5YS6+//glw3nDBCIjgfEzlsqX6R8/f6FR237o2m8M6EPVsGKRL1dWtGteFz07NsPgXm3DKlvOhwkwASYQoQlYjcHbsmF10M/OpU+TEhnTpcKDx88RL07sCN04xlSOfmq5euMu6jm8WTOlRcG82aXqibOXMX/5RumnD9U6t26Adj1HoLF4iMeMEQ2N6lTCi1dvsXrTbkwc0Rvp0qRA0/rVMGTMTKnDG4slwAULRQK0KDr1qp4Vox40ErJ+ySTs++9EKObISTMBJsAEmEBoE7AKg5eG2WmpnvlThqJPl+aSSXphnM0cP0D6I/OmcP6cOLx9KS4d2SjdkD4d1DhoFYvJo/qoj0v+Lx82LZuK9Usmo3fnFnIuFy1rRl9Nxo0TS8o1qFURsyYMAv8xgchKwMbW/7Z45fpdZM+SQa4FaWtnF1lxcL2ZgIUT4OIxAeMI+N/ZjZMNNymau3v8zOVwy58zZgJMIPIQSJooAQaPmQWa9pMvVxY5vQE0pyryIOCaMgEmwAQiHAGrMHiJOn2xvHbzXnz5+p0O2TEBowmwIBMIDoFBvdqgRqWSmDt5MKJFjQL6ZaHmDasFJwmWZQJMgAkwAQsjYDUG79bdhzBr0VpUbtBZ/uJZofJN5N7CeHJxmAATsFICv/+4yZLTsmD04Rj9QhAFJE2cEGVLFCKvNH6lhzdMwDoJcKmZQKQlYDUG79kDq+UvnWnvI23LccWZABMIUQKtuw2TP7zi5eUdKN1rN++hUbv+2HWAP14LBIcDmAATYAJWQMBqDF4rYBnmRXzw6Ckq1GxulKtYqwWqN2gftOzf9Oo07Rjm9eEMmUB4EpgxbgDoQ7VK9TuhTffh6NDbVbpazXpi7LRFaFK3MprWqxKeReS8mQATsHICHz68AzvzGZhyGliNwfvi1Tv0GDQBJaq2klMZeEoD8OvXb5w8c8Fod/rcJaNlz124asr5xDpMwGoJJIgXB0P7tseeDXPQtV0jtG5SU7qZ4/tj49IpqFS2mNXWjQtuGgHWYgIhSSB27DhgF3IMgts2VmPwjpo0H1UrlETG9Kmwa+0sdGnTUD6MglthlmcCTIAJGCLgYG+PHFkygObxkqM5vIbkOY4JMAEmwAQsn4DVGLzu7h4oXSw/fH19QWvG0k8LP3n2KpwJc/ZMgAkwASbABJgAE2AClk7AagxeFxcnyVKlUuHl63dw9/DEl68/ZBhvmAATYAJMIJwJcPZMgAkwAQsmYDUGb86sGfDtx080rFUJjdr2R8lqrVC2ZEELRstFYwJMgAkwASbABJgAE7AEAmFp8JpV306tGyBm9Ggo8b+8OLl3hVyirHbVsmalycpMgAkwAW0Cnl5eWLpmO4aPnyujnjx7jcPHz0s/b5gAE2ACTMA6CVi8wXv6wjUYctaJnUvNBJiApRIYOXE+3r3/hBev3soiJk4UDys37JT+kNtwSkyACTABJhCWBCze4N247QAMubCExXkxASYQ8Qk8e/4a9PPCjo4OsrJOYu/lHfjHKGQkb5gAE2ACTMA8AmGkbfEG74xx/WHIhREnzoYJMIFIQsDOzjZATb3Z2A3Agw+YABNgAtZIwOINXgWqn58f7j18is07D0p3/9EzUJgSz3smwAQiLIEwrVj2LBmwauNu/Pr1Bxeu3ESfYVNQsmj+MC0DZ8YEmAATYAIhS8BqDN4JM5ehU58xuHrjnnQde4/G5NkrQpYGp8YEmECkJ9CrU1PEiR0D9vZ2mDZvNUoVK4DWjWuGGZc37z5gyeptWLNpD54857XGwww8Z8QErIIAF9JUAlZj8F66egsbl03GmCHdpNu4dBLOXbphar1ZjwkwASagk4BKpUKlMkWxbLYr1i2agGoVSsDGJuxulV+//USOrOlRWhja46Yt0VlGDmQCTIAJMIHgEQi7u3jwyhVI2sHBHnFjx1SH06+t2dsHnGunjmQPE4jEBLjq5hHw9vHB+cs3sFT0si5csQmKMy9V47WzZEyDvDmzIHr0qOD5w8ZzY0kmwASYgCECVmPwxokVE3OXrMdF0dNLbtbCNUgQL66hunEcE2ACTCDYBLoPGI+V63fBzcM92LohpUDfJ4yZugg9OjSRSfoII/z379/Q5zw9PfXG6dNRwj08PODm5maS/p8/f0D6SlrB3VO5KY3g6pE8ldnd3d2kcpM+5U17Uxzl6+Zmat7EzLz2+vPH1PZyg7u7R7gwI17kTOFNOsa0l7s4H+QF828jfX5+cqdzQ2kbcn+MOMd1JsyBFkfAagzekQM64dOXb3IxeFoQ/tv3Xxjer4PFAeUCMQEmYN0E3n34jDmTBqNz64Zo17yu2oVlreYt3SCnVeTImkFma2trCxcXF73O3t5eb5whPYpzcHCAk5OTSfrOzs4gfUrHFEflpjRM0aUyOzo6mlRuyo/ypr0pjvJ1cjI1b2JmXns5O5vaXk5wdHQIF2bEi5wpvEnHmPZyFOcDdPypVDoC/wZR2oacsxHn+N+keGfhBGwsvHyyeFdv3MXugydQu2oZ7N0wV7qhfdsjdqwYMp43TMBkAqzIBLQIJEoQFz9+/tIKDbvDwyfO4fT5a7h976GcTuHr6yszV6lUUKnYqVTMQKViBiqVbgbyYgnGRqXSnY5KZXx4MLJj0XAkYPEGL82f6zV0Mo6cOI/Ofcdi3ZZ94YiLs2YCTCCiE2jTtBaadRyMDr1dA7iwqnfpYgWxZuF4dc9yWH4wF1Z15HwskwCXiglEZAIWb/DuP3wGO9fMxPI5o7Fp2WRs33s4zNvj9r3HKFurHQqVb4LmnQZj36FTYV4GzpAJMIGwITB78TqkS5McDWtXQusmNdUubHLnXJgAE2ACTCA0CFi8wWtjo0K0qFFk3ePFjQ1PT2/pD8tNsiQJsHXlNJzatxJ9urTAjAWr4aZncnxYlivs8+IcmUDEJ/D9xy9MGtkbxQvnQb5cWdUu4teca8gEmAATiLgELN7gpYcPTWtQ3M9fv+W8NuU4LJomerSo0ui2tbFBjOjRoFLZwNfXLyyy5jyYABMIYwKpUyTBzTsPwzhXzs7qCHCBmQATsCoCFm/wpkmVDFdu3FO7tKmTq/0UHla0FUE7owAAEABJREFU6cM5mtLQsG0/jBnSFVFcnMMqa86HCTCBMCTw/uMXtOs5Eo3a9Q+XObxhWFXOigkwASYQaQhYvME7f8pQGHJh1VK5smeSUxqWzByJSTOX4svX7zLr379/gdyfP7/lscYmRL2Uh7Zzc/sTonloJ6adX3CPiYmHB61V6c8ouPqmyNOaibQWoym6pupQO7i7u8nzwNQ0gqvn5ub2d+3UsGNLdaR8g1tWc+Tp/HET57kpadDatdrntDHHnds0wMzxA9CzY1P1/F2ay2uMLsswASbABJiAZRKweIP37oMnBsl9+vwVd+4/NigTUpG2NjbImC4VEsSPi/uPnslko0SJCnIuLv7zjGVgKGwoD23n7OwSCjn9S1I7v+AeExNHRyfJJ7i6psq7uLjINUVN1TdFj9rByck5TOtJa0OSM6W8pupQHcM6Tzp/iK8pZaa1a/+dzcb7NOftavqNT4ElAxPgECbABJhA+BKweIN3wsxlcJ20AFdu3IWX178P1t6+/4glq7ehXqu+IH9oYnz05AX+uPn/6tKrN+/w5PlrpEudPDSz5LSZABMIYwK0DNnjZy8DTGOgMMWFcXE4OybABJgAEwhBAhZj8Oqr09KZI5E7RyYsWrkFpWq0kUuD0Vzajr1H4/2Hz3K5Mlq3Up9+SIS/fvcR1Rt3k3k3ajcADWpVRNw4sUIiaU6DCTABCyFQ4n/5kCBenADTGGgqg+IspJhcDCbABJgAEzCBgMUbvLToeuVyxTBv8hCc3LMcZw+slm776hkY1KsNkidNaEK1g6dCyxP9t3WhzPfE7uVoVLti8BJgaSbABCyewJpNexA1iot6GTLN6QzkD8MKcFZMgAkwASYQwgQs3uAN4fpyckyACTABJsAEmAATYAJWQSDkCskGb8ix5JSYABOwYgK/f7sFWONbWetb2Vtx1bjoTIAJMIFIT4AN3kh/CjAAJmDdBEKq9F7e3qC1vfU5Y/Lx9vHBmKmL0KLzELmWL33kqkvv+q37aNFlKJp2HITFq7aoRbbvPYKGbfrK7wW+fvuhDmcPE2ACTIAJmEeADV7z+EVKbXpYDxg5FSWqtkCT9v1x/vINgxzcPTxRtWFn9Bg03qAcRzKB8CQQM0Y0s9f83rX/GL58/SY/pq1TrSzGT18aqEp+fn4YNm4O+nVtgWWzXXHk5AXQD9uQIH00N2pQF/4olmCwYwJMILgEWN4AAasxeL//+IW1W/Zh8OiZ0q3fuh8UZqBuHBVKBBwdHdCzU3Mc2bEUA3q0xfBxs/Hj5y/o+5u/dD0ypEsFlUqlT4TDmUCEIHD63FVUKltU1qVUsQK4ff8xfv9xk8fK5v6jZ3BxcUbmDGlgZ2uLciUL4+S5KzK6UL4cSJc6hfTzhgkwASbABEKOgNUYvCMmzMOvX7/kw6F4kbx49eY9KCzkUHBKxhKQP74RLw5oBY2smdIidqyYePL8lU71x09f4uGTFyhfqrA63s3dHTWadMW9h09l2ILlGzF68nzp500oE+Dk9RKoX6OC3jhjIz5+/ookiRJIcTJmE8aPiw8fv8hjZfNeHCdJGE85RLIkCeQSi+oAHR7qFfbx8YY+5+vrozdOn44Sbo4upWGOvjm64Zm3f7nDh7l/3vrPBeJiyJmjb46ujw/xImda2Y3Jm2R0XD4Gg3wMXFdKHKWr+HXtDWbAkRZDwGoMXnt7W7RrXhdk7FKPSJ8uzfH2/QeLARlZC3Lx6i3xQP+MDGlTBkJAD+kpc1ZiWL+OEKO4wvlJGWcnJ4wf1hMjxs/Bg8fPsOfgCfTq3ELG8YYJhBeBJvUqh0jWKpVKnY6Nhl8dKDwqm38yQNC3YbqWvL29oc/5+vrpjdOno4T7+voKY9nHJH0fYcSQvpJWcPekS2kEV4/kzdEl/aCYkow+R2UmI0hfvOFwH1DZDct4620P0qX8TdEnPR8fX71pB5Wmr1nnmY+ot2nnGZXLmLypfuLyMvo/CVLahhyl6SuuEUMylA47yycQ9J3WQurg6ekNmguqFOeT6EmJ4uKiHPI+HAg8Fb26IyfMxYSRvUFGrHYR1m7Zi5JF88vF/LXjMqZPjTIlCqFV16EY0b8TXJydwH9MwNoJxIsTC1++fldX48u3H4gfL7b6mDwJxPHXbz/JK92Xr9+QIH4c6de3odEUR0cnOOpxdnZ2cNQTF1S4nZ09HBwc4WiCPumRvim6pEO6lAb5g+vs7R1ALrh6irytrenMKF9ySlrB2zuC6h08nX9tT7oOZrSXvb09HE1oa9KxM+M8I17kKB1TnDF5U/r6riF94UGVhVjbiWvEkJy+tDncsghYjcFLb1i1mvWQX0APdJ0uf1I4XtxY6mWELAtrxC8NzZ8eNWk+Jo/qgzw5Muus8PHTlzBjwWrkLVUPg0SbnTp3BS27DJGy1Lty7uJ16ff28ZF7y9twiZhA8AgULpATh46fl0rnL99E6hRJEMXFWc7jvXX3oQyn0RB6YX/5+h18RM/RYSH/v4K5ZRxvmAATYAJMIHQIWI3BmzVTGtSoVBLx4sREquRJ0KBWefkwAf+FOYGvoteqz7BJ6N25BainVrMAj5+9xPuPn2XQwmnDcWrvClw6shFjh/YAPdSXzR4t49Zu3gNfP18smzUa1EtMBrSM4A0TsGIC1SqWhI2NSi5LtmT1VvTv3lrW5pUwbl0nL5B+lUqFkQM6YejY2VIuT67MyJ09k4ybt3SDXJKMDOJK9Tuhz7DJMpw3TCDcCXABmICVE7Aag5fm7xpyVt4OVlX8TTsOyGWUWnQeJHtvqQf38Ilzsg5LxUP+yAn/Hi4ZoGPz4tVbrN60GxNH9Ea6NCnQtH41DBkzU4ckBzEB6yJgZ2uLwb3aYvmc0aAXvuRJE8oK0ColG5b8M15zZM0gZVbNG4u2TWtLGdp0bFUfZw+sVjsaQaFwdkyACTABJmAeAasxeJVfO9Lem1d91jaFAL14UK+tpitdrKBMasyQ7mhYu5L0a27oQ8PpYwfIoORJE2HfxvnqtUYb1KqIWRMGgf+YABNgAtoEfL1+4dnRgYHcq5ND4eOpfzlE7XT4mAkwgchNwGoMXs1m+v3HHbsPnsSLV+81g9nPBJgAE2ACEYyAn68Pfn+4Gcj9+XgLfr7eFlpbLhYTYAKWRsBqDF7qVVRcz45NsXn5FPkhiKUB5fIwASbABJgAE2ACTIAJWBYBqzF4tbE52NvDy8tLO9hqjrmgTIAJMAEmwASYABNgAmFDwGoMXu25u2OnLpZL+oQNJs6FCTABJsAEQokAJ8sEmAATCHUCVmPwapNIljQhprj20Q7mYybABJgAE2ACTIAJMAEmEICAdRi8osjK/F1l37ReFf51LsElrP8fPHISURJkMspFS5QVcVLkNkqW0sxZuGJYV4fzYwJMgAkwASbABCIBAYs3eLWnMmgfR4I24ioyASbABNQE2BM8Ah4/XgRa4YFWffD+8yF4CbE0E2ACVk3A4g1ehe6jpy+xbut+PBb7N+8+Ycuuw7h974kSzfsITuDX7z/oM3QSSlRtgc59R+ut7Y+fvzB8/Bw0aN0HTdr3x70HfI7ohcURTCASEPhwa12gNXxpXd9fr45HgtpzFZlAhCYQrMpZvMGrTGH48vUHtiyfigkjemFE/47YsWYmbG1VwaosC1s3gQql/4c+XVsarMTMhWuRLGkirF8yGSMGdMZA1+nw8/MzqMORTIAJMAEmwASYQMQmYPEGr4Lfzc0dsWPFUA7h5OgAezs79TF7IjaBqFFcUKZEIdDeUE0fPHqGArmzS5G0qZLD19cXd0Uvr5u7O2o06Yp7D5/KuAXLN2L05PnSz5sITMAKq/bp81coU7f2/nfCCmvARWYCTIAJWB4BqzF448aJhXlLN+DJs9f48OkL1m7eCx8fX8sjyiUKVwJpUiXDxau3ZBmePHuF9x8+4+37j3B2csL4YT0xYvwcPHj8DHsOnkCvzi2kHG+YgCUR+PzlmzhvvyBX9kxImzqFJRWNy8IEmIAVE4jsRbcag3fkwE74/PU7uvQfgxadh+DZizcY0rd9ZG8/rr8Wge7tG8t53oXLN8aQMTOFwZBcLZExfWrZS9yq61CM6N8pyFU+qGe4fc8RKFiuEZas3gp9f99//BJ5zUK9Vr3QqG0/rFi/Q58ohzMBowi8/fAJb95+QKIEcQPIv72yADT/VNM9PzYIf95dCiDHB0yACTABJhCQgNUYvDGjR8OQ3u2wd8Nc6Qb1agMKC1gdPorsBGLGiI4xQ7rizIE1WLVgPL5++4HkSRJJLDSX99zF69Lv7eMj94Y2NGWmZeOaqFG5lCExrN+6D46ODli7aBKmju6HlcLgff7yjUEdfZHBMbIHj54Zwka2vlJxeFgSoDno08b0RZ6cWTBg5HQ5LYem5ri7u+HP50c6Vxzw+P0RFG+K8/LyhIeHu0n6pEf6puRLOqRLaZDfkNPHn/QN6VGcj55rXWFKMsF1np4eIBdcPX95dxhTbn9Zt0DtQrrGMNOlT3qenp6B0tQlqyvMy8vLZF3iRU5XusaEGZM31U3fuaIvPKi8iZmXuEYMyelLm8Mti4DVGLyv3rxDtwHjUbdlb0nw/sOnmL98o/TzJnITePzsJd5//Cwh0GoO5PkiRgPGTV2IeHFjI10a/2HhtZv3wNfPF8tmjcbICXNBPbMw8Jc2dXIUzJsjyLniPj6+UIl/NiqxtVHBwcEBcWLHxKMnL1CjSTf8cXOXuVBv8b5DJ6Vf38ZYI3vDtrA3su/cfyxGWMbJFTBadxuKk2cv66sGh5tBwMXZCY7iHEqaOAGcnBzk+aNSqWBvbw8bcX7pStrGxkbGk0xwna2tLezs7EzSJz3SD26eijzpUhrKsb499PzZ2NgGWW4bwUaXukrlz1RfnobCbW3tYCu4GZLRH2eOrr3M1xhmuvInPTu7oJnp0qUwW1ubIHmTnC5nK3iR0xVnTJitEXlT3RDMP715i+uN4oiZrSg7+fW5YGbJ4uFEwCac8g12tiMnLkClsv9DnFgxpW76tClx6uxV6Q/tzdUbdzFg1HSUqdkWbbqPwPEz/KAPbea60i9UvpFcmuz85RvIW6oetuz6D/S3dPVWHDlxnry4fO02ilRshmqNu+Dj56+YPMr/1/hevHqL1Zt2Y+KI3tIAblq/GmjKg1Qyc1OzSilcEedI/jINULl+R7RvUU9+XEcGc8PalTB93kps3L4fzsKQqVimqMHcSMdSjexZi9ahTPECcgWMlo1qYox4oTBYGY40iQDNQaeP1qaJ8ya2uN/Rh5oqlUoYOnaAeLGCjj+VSiXjbaUhRgZVYOf+6TZenhgayH26Ph+2BvSCirOxsYWtifrG6kLPn60wRILKW6VS6dRWqVSwNbHcxuRrKG1j660rDXN0KT1z9M3RpbzNccbkTTII5p8xZaJ0DckFM0sWDycCNuGUb7CzpaEKWpZKud+rVCrZWxfshExQoB6XPl1a4MCWBWjeoBrGTFloQlwio4cAABAASURBVCqsYi6BswfW4tKRjWpXu2pZmeSYId1BhiUdFC+SD6f3rcSpvaswY9xA0MeOFJ48aSLs2zhffdygVkXMmjAIZvypVa/dvI//FcyFY7uWY/3iyVi1YSfIwCaB+jUr4OXrd1gjjO2RA7pQUIg4mmYRHka2ra3/LUOlUiFh/DiyLqb0ZEtF3ugkkC9XVtByjD07NsPgXm11ypgS6O3xXfd0iG+PTUkuWDpev9/rzNvzx4tgpcPCTIAJMAFTCfg/vUzVDkM9WkrV29tbnSMt3UPDv+qAUPRkSJcKccUQta2NjTRsvLy8QMtchWKWnLQVEdi+5wiKFMit7tWl5dBu33ska0BziB8+fg5vbx/om0soBYO5uX7rPooWClsju1n9Kpg6d5XsXR84ahr6d28jS0290vTCEZyebKnIm0hD4OvTQ4E+tqMP77493BJpGETsinLtmIDlE7Aag7d+zfIYNm4OaJmpBcs3oW3PkWgmhqXDGvG23YeRNnUK0DJXlLe3MMIVR8eh5ZQ8NPchaUDpKrdmXoo/PPJU8jZ2T2U0VtYYOfq4hZym7P1HT/H67XthyHrL9aHPX74OehH69PkLbt9/hNQpk8q4IWNmoHa1smJkoLr8EQzNNAz5KT9y+mS27T6CQvlyyvWoUyZPjDQpk+HG7fsyz4+fvkAxsj08PGSYvnQ0wyk/cpphmn6as9unc3Mc3bkUowd3E9fjbHh4esr0a1ctI3u1qSd7aJ8OMkxT11S/OW1JHymC/5gAE2ACTIAJCAJWY/BWLlcMXdo2RKmi+fDj52/MGDsApYsXEFUIu/83bj/Ams17MUxjOTQfH2/Rc0cu6K/+zSnpv3wor3/OnDSD0tWVp6+vafUMKi+KJwNFV57BCaPykQuOjj5ZmrtNS5Jt2LYfC5ZvlMuTPX3+Urb38rXbcOTEOelv1bg6Tp69gprNuqHbgHFo27Q2UiZLhF37j+KPmxtaNKyG6pVKiJckRzmPWF9+muHEgoxPzbArN+7g569fMs/YsaLj/OWbwrD0wucvX3DnwSOkSZVUxg0fPxu1qpZG03pVMGTsLBmmmY4+v648FVlPL0/sOnACpYvlh4O9HQrkyYpv33/g06fPMn0y9GlqAxm29CW2omfuntqSnCnpUH3ovGLHBJgAE2ACTMBqDF5qKvrynX5tq2/XFkieNCEFhZmjXrPZi9dh9sSBSJbkX96Ojk5wlM4xVMvin4eSl//ewSHs87S3dwi1eqpUKjhKlv71M8XvIJhQGU3R1dbJlzuber6wMnc4XZpUcBRlHDesF5rWrw5H4U+XJiU2LZuC3evmyaXJqlcqDUcRXrNKWSybPRbOzi5wFMfTxUtai4Y14Cj8+ty9h8/lR3cbtx/AopWbpf/dhy9wFDrDx8/Fp8/f4Sj87VvUw+nzV1GnZW/0GjIZnVo1RKb0aXHw6Dm4e3iiQ8sGaFC7spxmsWnnITgKnaCcra2t/FpfU+7uw2fw8QVcRB1oybfL1+/BUaT18Mkr0JSiRAkTwFEcj56yEHVrlEfLRrUwctICOIqwkHDUltSmpqRlY2MTaucqJ8wEzCDAqkyACYQDAat5Ipy5cA01GnfH8PFzJKZ7D5+ix6AJ0h/am0+fv2LwmFkY1LMtEiWIF9rZcfpaBN59+IgTpy8Y5U6euYhTZy8ZJUtpXr91Vyu38D3MkTVDICM7RbLEslD7Ns6XK0zQAU1j2CSN7LlYs3AiKpUtRsGoWqEEls4aDcXYo3WBm9StIuP0bWg+MK16sW7LXsxbul7O0VXWER44ajpev3kvVft1ayGnMdRv1Rs0X3fSqD4yn137j4GWXmvbrA7qVC8njGMn2ZMtlXjDBJgAE2ACTMACCFiNwTtb9K4umjECtEwPccuYLhU+fvpK3lB3m3YcxM07D9GwbT8UKt9EuncfPoVevpxyAAKHjp5GxVrNjXKV67RCtfptjZKlNPsOHhsgr8h4YKyRXaJIPhzevhgblk7B4pmjkCVjWonLFCN7738n0KBNH2lck8EtE9KxGTVpvpxKQgY5OWUpOh2iHMQEmAATYAJMQC8BqzF4afiUFmLXrIkf/DQPQ83fsVV9nD2wOoBLGD9uqOXHCTOBiE4gdqwYoI/b0qdJGWRVxw7tru71rl21bJDyLBCxCHBtrIuAt9tnPDs6MJB7dXKYdVWESxvhCFiPwWtvB/r1LKUFrty4q+7tVcJ4zwSYgHUQoB/XoB5ilcq08m4Woy49B0+Qyt9+/JQ/+KGsfSwDecMEQoCA+7engQw3MubenB0XAqlHzCR8fTx0rrn85+Mt+Pl6RcxKc62sgoDVGLz0ww80vElfgnfo5Yrx0xejW7tGAKyCMxfSygicvXAFYybNNsqNmzIP46fON0qW0ty6c7+V0Qjf4rpOWoASVVtg8OgZoHWNqTQ0V1ilUuHAkdMYN3URmtavhuRJE1EUOyYQYgR8vX7rNN7cv9wLsTw4ISbABMKGgNUYvDRnd+rovhjRvxPq1iiLdYsnIX2aFGFDiXOJdATI4B07eQ6MceOnzsOEafONkqX09Bm8T569MPpjO/o4jxx9eGeMe/TkmVW2YYeW9XBkxxJsXzNLGrSjJ89X12PUwC6YuWA1fvz8BfrlPHVEZPZw3S2KwKP9XXB7Q5UA7s7Gavj1+pRFlZML40/g5ZnxgXr0XxwfDPcvD/0FeGvVBKzG4CXKKpUKiRPGR6rkyWBrY1VFp+KzYwIGCSxavt7oj+2q1msDcvThnTFu7qLVOvPeufc/o3umqRebjPsxRvZ8kyGuM9NgBMaPGxsqlQoxo0dD5XLFcffBE7U2/Zrdd2Hs0nrFvOauGgt7mAATMJGA2+f7Onv0fb1+mJgiq4UnAe28rcZqpK+6qzbsihET5mKg6zRUbtAZ+w7xW7J2g/IxEwgOgV17DxvdM0292GT0Ui+1Me7kmQvBKYpa9tqte/jj5i6Pf/3+I/dk0NL0hayZ0sljiqclCmeOG4goUVywfO12Gc4bJsAE/Ak8OzZYR2/lEHj9fusvYGD76+1lfLi1JpD78+6SAS2OYgKWTcBqDN4d+45hy8qpWDlvDDYsmYwVc8dg2dptlk2XS8cEmIBOAktWb5VLkt1/9Aytuw1Fhbrt1XKaa/827ThILktWpmZrvHj1BoN6t5NyE2cskWsO586RGTS1Yce+IwF6f6VQkBsWYAIRl8DvD7cC9Vb++XgLvt7+L5OGav7r3RV8vL0ukPvz/rIhNY5jAhZNwGoM3lgxosHRwUENM27smLC1tVMfs4cJMAHrIdC6SS31UmP0K3b7Ny1QF17zBza2rZyOcwfX4vD2pRg5oIuc2kCCIwZ0RufWDckrf01u++pZyJQ+tTzmDRNgAkyACQSTQCQQtxqDN0aM6FizaQ8+fPqCx89eYubCNSicP0ckaCKuIhNgAkyACTABJsAEmIA5BKzG4N257yjo19aqN+6GJu0HYt2WfVi7ea/81TP69TNzILAuE2ACQRJggUhO4N62RgFWG6DVB+5uqg63T7cjORmuPhNgAtZAwGoMXu1fOtM+tgbYXEYmwASYABNgAkzA2glw+a2RgNUYvJpw6ccnfv76rRnEfibABJgAE2ACTIAJMAEmoJOAxRu8bXuMxO17j2Xhf/9xQ8O2/dBj0ERUa9wNh4+fl+G8YQKWRoDLo5/Auk07jV77l5ZCGzdlrtHyV67d0p+xlcS8efcBS1Zvk98sPHn+ykpKzcVkAkyACVg2AYs3eD9++oIsGdNIivsOnUQUFxe5PNmy2aOxetNuGc4bJsAErIfA+s07jV77d+L0BaAfuzBm3V+SuXLd+g3er99+IkfW9ChdrADGTVtiPQ3LJWUCuglwKBOwCAIWb/DaaPyi2s07j1CtQnG5PFnKZInw+4//ovQWQZILwQSYABMIAQL0gp83ZxZEjx4V3t7eMkX64Q1y8kDHxs8PoPignA5VGRSUHsVLQR0bigvK6VCTQUHpKfFSWMdGiTe016Emg8KXmXHtZaheQcXJSurYBKVH8TrU/gb5hfp5Rvmb4/4W1OidZl76lII6V/TpcbhlEbB4g1elUuH5y7egnw+9fuu+6PnIqCbo6en/MFAHsMc6CXCpmQATCECAHsJjpi5Cjw5NZLivrw/c3d3kfVAGaG2UeJLR57y8PLW0/A8pL09PD5m+Pl0K95cOvPX29i8byehz3t5egRVFCOXt4eFuct5eXl5B6vr4+IicAv/38/MNUpe4BNb0N1YpTl99lXDKQ5e+r693kHkraWjvqc4eHua0V9B5e/990dIuu6+vX5Dl9hDtqa2nHBvDTLu+yjGVSfHr23vpOceV/HXtNdPyI8tWh5CPj2FmOlQ4yAIJWLzB26FlXbTuNgxNOwxC2lTJkEL07BLHew+fImH8uORlxwSYABOIUATmLd2ASmWKihf8DLJe9CM7zs4u0BzxkhF/N7a2tqB4Q87BwfGvdMCdSqWCo6NTkPoBtf4d2dvbBalrZ2cPXX9UHycn5yD1delSWNuerqjZqGMgR7/gp7AgNiSr7d5+/ImLV24Fck+fv1aXh7ho69GxSmUcM5XKhsQDOaU9lTJq7oPyOzg4wMnJnPayV9dPX152drp/1InaS5+OEu4k2jNQhf8GEE9FLrh7e/ugy+2g5xz/m73OnWY5VCqVThnioSmn7depxIEWR8DG4kqkVaCyJQph68pp6NmpKcYN66GOjRrFBYN6tVUfs4cJMAEmEBEIHD5xDqfPX8Ptew+xcMUmvb26EaGu5taBDNaTZy5A23379iPIpLf+dwsVazUP5FwnzApSlwUiF4HmPWYiSoJMgdy0OTzH3prOBIs3eAlm9GhRQXPa7EVPAh2TS5o4AZInTUjeSOa4ukyACURkAqWLFcSahePRrnld6ahXLSLXl+vGBJgAEwgLAlZh8IYFCM6DCTABJsAErIwAF5cJMAEmYCQBNniNBMViTIAJMAEmwASYABNgAtZJIKIbvNbZKlxqJsAEmAATYAKRkMD760vx7OjAQO73m7ORkAZXOSQJsMEbkjQ5LSbABJiAxRLggjEByyfg/u0Zfn+4Gch5u32y/MJzCS2aABu8Ft08XDgmwASYABNgAkyACTABcwkEMHjNTYz1mQATYAJMgAkwAfMJuH99hA+31gRyP54fMT9xToEJREICbPBGwkbnKjMBJhAkARZgAuFKwO3LQ3y8vS6Q+/nCeg3eSTMWY8yk2YHcu/cfw5U1Zx45CLDBa0Q7f/32A32GTkbJ6q0xceYyIzRYhAkwASbABJgAE9AkMHnWEoydPCeQe/vug6YY+y2OQMQoEBu8RrZjpXLF0LZpbSOlWYwJMAEmwASYABNgAkzAUgiwwWtES8SKGR2liuaHs7OjEdIswgQiHwGuMRNgAkyACTABSybABq+ZrfPs2TM8E+7t2zdIlji+TmdMFvp0lfDnz58bk4zO/JU0lL0xCSWKH1vWi+qm6b5/+6qm+1kJAAAQAElEQVTOw5h0lDwN7cMznehRnQPVMyzLo8nWBj5qtpq8QqI8tjZ+xiSjM3/NspDfmIRIzs/HKxBbqm9UF0eZj7HpUFqGnDHphLTM9Vv30aLLUDTtOAiLV23Rmby3jw/GTF2EFp2HoF3PkXj15p1aTp/+9r1H0LBNXxQq3wQ0lUqtwB4mwASshQCX00IJsMFrZsOsWLEC5Pbu2Y2GNUrpdMZkoU9XCV+zZg3c3d0DOA8Pj0BJK/KG9oGUdARUKVNA1ovqpunu3LyqrqMOtUBBhsqhxClKfn5+Aeqn1NfLy0udp6Kja6+kY2ivrZctfZJA9aR8vb29DSVjVnl8hCFEeZDTZOug8tSZrsGC/I3Urpf2cVQHX51sqSx/k5A7bT1dx1IwiA3p+Xj8CMSW6ps+ZXxZzyCSkNGUTlBOCv7d0LlCXMn5+vr8DQ3ZHZ2nw8bNQb+uLbBstiuOnLyAqzfuBspk1/5j+PL1G5bPGY061cpi/PSlUsaQfoJ4cTBqUBfEjRNLyvKGCTABJsAEQoYAG7xmckyePDnIJUiYEC9ef9DpjMlCn64SnixZMtjZ2QVy2mkr8ob22jq6jt+8/yzrRXXTdNGix1DXUZeedpihcihxio5KpQpUP6qzjY2NOk9FR9deScfQXlvv+88/geqp5BmcdLTTpWN9+jaiPpQHOU22Pn4qnfXUl45mOOVnyHkJ24/y03bENjjpUB6a8vr8Us7GLhBbqu/P3+6ynvp0NcMpnaCcprytrS2UOqpUoXN7u//oGVxcnJE5QxrYifzKlSyMk+euaBZD+k+fu4pKZYtKf6liBXD7/mP8/uMGQ/qF8uVAutQppA5vLJvAyTMXceL0hUDOskttXuluP/4oPzjTXmlh+ZrN5iXM2kwgDAiEzhMhDApuKVm0bNkS5KpUqYb1O47odMaUVZ+uEt60aVP1g1x5oNPDXTttRd7QXltH1/Gewxdkvahumi5rjjzqOurS0w4zVA4lTlNHqZvmnuqpyBraa6ajz6+tf+vhm0D1pLy1DUHt9LTT0XWsraMcq1T/DHtNtl5wUrPVTE/RM7TXlNfl/+P1zxCk+ilOpVIFSFaXrnZYAAU9B6Rj5xQjEFuq78PnH2U99agGCKZ0gnKaCtRu+uqmKWeO//3HL0iSMJ46iWRJEuD9h8/qY8Xz8fNXJEmUQB6SYZwwflx8ELrG6ktF3lgkgW+/vFC1XhtUrNU8kDNmia1uw1ciSoJMgdzIcdMtsr5Koe48/iQNXu2VFlas3aKIBHvPCkwgrAiwwWsEaZqLR3PqaEmybXsOy/l19x8+NUKTRZgAE4iIBFQ2mi8K+m+jKtU/ORsNv7H6CjtfX194enqCpkMoYZp7X18/GU8y+py+aTqUJk0F0aenhGvmp+mnaTGKjL49yWjqKH7fv/XSp6eEK/LG7jXrQ3no0qN66woneSVfSkeXjKEwRZf2+vLQF06cSI9caLVXmTq9AhnaZHyvWrdVfQ5ROXTV0U9XoAij+lCZFSeCgvWfOCu6lJYuZc12UWS19/qY6UpPCdNMQwnT3usrE3EifW15PrZMAvrv1JZZ3nApFfXOnD2wGpouQ7pU4VKWyJcp15gJWBaBBPFi4+u3n+pC0TzdBPHjqI8VT7w4sfDl63flEF++/UB8oWusvlpReFSqf4azONTxX58pokOUg6yegJ85zW2OLsxStnruXAHrJsAGr3W3H5eeCTCBMCaQIW1KfPr8FS9fv4OP6KE8fPw8/lcwtyzFuw+f8OzFG+kvXCAnDok4Ojh/+SZSp0iCKC7OMKRPsrqcSqWCg4MDVCrdhi9N5aB4Q46meuhL297eXqZvSF+XLoXRlCNDehRHMiSr7S7d+YgaDdujWv22AVznXsMClEdbL6hjzfoQG13yKlXQLCkdXbqGwqi+ilOpdOehUukOJ06Krs72EhmrVHQumN5eQl2kEvg/5afkTeUILAGoxD/o+FOpqEwO6jbTIWIwiDgreatUKp2y1I6KjL491UGnsoFAzbT0ialUustEnEhfnx6HWxYBG8sqDpeGCTABJmDZBFQqFUYO6IShY2fLJcfy5MqM3NkzyUIfOXEB67buk/5qFUvCxkYlZZas3or+3VvLcJVKv/68pRvklCkyqCvV74Q+wyZLnYi6+fLDHSfPXAjkLl+7GVGrzPViAkwgnAiwwRtO4EMpW06WCTCBMCCQI2sGudzYqnljofkLjI3qVMLAHv6GLU2FGtyrrZRbOG04kidNqC6ZPv2OreoHmDo1eVQftQ57mAATYAJMwHQCbPCazo41mQATYAIWQWDJxpOoULN5IDdn4UqLKF/4FIJzjUgExi04qPNju449BkekanJdQpEAG7yhCJeTZgJMgAmEBYGnrz8HmhZAUwUeP30RFtlzHkyACTABiycQqQ1ei28dLiATYAJMIJQJ/PHwFsZy5PsRhVDGyskzASZgYQTY4LWwBuHiMAEmwATCksDrD+6oUrdVoB9QoB9VCMtycF5MgAkwgdAkwAZvaNLltJkAE2ACTIAJMAEmwATCnYDxBm+4F5ULwASYABNgAkyACTABJsAEgk+ADd7gM2MNJsAEIjkBrj4TYAJMgAlYFwE2eK2rvbi0TIAJMAEmwASYABOwFAJWUw42eK2mqbigTIAJMAEmwASYABNgAqYQYIPXFGqswwSYgPEEWJIJMAEmwASYQDgTYIM3nBuAs2cCTIAJMAEmwAQiBwGuZfgRYIM3/NhzzkyACTCBQAQ+ff6KhSs2Sbf3vxOB4jmACTABJsAEgk+ADd7gM2MNJhCKBDjpyE7g85dveP/hC3Jlz4S0qVNEdhxcfybABJhAiBBggzdEMHIiTIAJMIGQI/D2wye8efsBiRLEDblEOSUmYG0EuLxMIAQJsMEbgjA5KSbABJiAuQSSJU2EaWP6Ik/OLBgwcjp8fX3h7e2N379/Cb+PzuT9hIyuCC8vL6lHuh4e7rpE4OenM1gGkp7iAN2CXl6e6jwUWe09ycgEtTZ+fr5aIf6HFP4vjd/+gbq2uosEd3c3dZmInU5VPXn7+Pizpvzd3Nx0qQpmejIW0n/+/FbnTW0nggL999WTN3GifMl5eHgE0qOAH7898N+Rkzh4+HgAd/jYKXW+pE+yupyvngb3EOcH6ZHzEudNcHSpnqRHjuqvS9dQmJvbH3XZfXx0n+OUh640vL3/nePU7rpk9FRZilKZFeenR9BXT3t5enrIcsuEeGPxBNjgtfgm4gIaIMBRTCDCEXBxdoKjgwOSJk4AJycH/HFzh52dHVxcosDGxlZnfVUq3bdye3t7qUe6Dg6O0PWnUukK9Q8jPcUBugXt7OzVeSiy2nt7ewfo+lPpSVMl6vMvDRddqv5hKv+d9tbR0UldJjvBTjuejikP2ms7W1s7ta6Tk5N2tDxWqVRyr2vj7Oyi1rex0d0u+vImTkq9HcQ5oCv9x69/o3aTTqjZqEMA17RtL3W+lIYuXQpTqXSX3UGcH6RHjs4bktV2Nnp0qZ6kR47qr60X1LGTk7O67La2us9xykNXOnYa5x+1uy4ZPcWWolRmxalUutnYiPNRCmttlPbSCuZDCyWg+2q00MJysZgAE2ACEZ3Axau35Adr0+atROxYMRE1ir/Bp1LpfhhLHoaihJ5KpYJKpZKiwdmoVCqpp1Kp9KrVaz8OURNmDuQWLlsbpK4Q0JuuSqUS0f5Or5CeCJXKX0+lUumRMBysUqlCNW+VgexVKpWJeUOtp1KpoO9PX4xKpVLr69M1FK5Sma6vUpmuS2VSqUzXV6nM16UysLN8AmzwWn4bcQmZABOIRATy5cqKds3romfHZhjcq20kqjlXlQkwASYQegTY4A09thaXMheICTABJsAEmAATYAKRkQAbvJGx1bnOTIAJMIHITYBrzwSYQCQjwAZvJGtwri4TYAJMgAkwASbABCIbATZ49bU4hzMBJsAEmAATYAJMgAlECAJs8EaIZuRKMAEmwARCjwCnzASYABOwdgJs8BrZghu3H0CTDgPRrONgnDh7xUgtFmMCTIAJMAEmwASYABMIbwIhZPCGdzVCN//nL99i5fpdWDB1GCaO6IkxUxbC3cMzdDPl1JkAE2ACTIAJMAEmwARChAAbvEZgPHXuCooXyYsoLs5ImCAuMqZLhYtXboH/mAATYAKBCHAAE2ACTIAJWBwBNniNaJKPn78gccJ4akn6yc8Pnz6rj9nDBJgAE2ACTIAJMAEmEJCAJR2xwWtka6hs/qFSqVRqrbJly4Jc82ZNkSV1vFBzlSpVAuWj6Xr36h5q+SWJ4xAoP8p7rOvwUMvTCb915rlw3oxQy/PHp+c689y+aU2o5fnk3lWdeZ48sjfU8rxw+pDOPO9cPxdqee7ftUVnnh9ePwy1PFctW6jO8/z584gof35+fvD19UHMVKUQN3ODQK5CmVIY2LtTIFemZBGpR7oO0ZIG0qO0UmQthwG9OgbSpfRIT3FxMtbQoV8fDWpX0qmbK3tmdd7OcbPq0G2A7LmLCd2OwgUse7uWDdS6fio7nbpxMtVHl7aNA+lSuZMnTaTWj5akkE794sWK69StVa2cWtfWOY5O3YSZagpmHXTqOzs7qvVjpamgQ78+qlUurVO3aOH8al2HGKl06DZA2mxlRN6BmfXs0kqtS20WL3M9Hfr10bxxDZ15Z86UVq3vEj+nDt0GyFOAmAXOu1nDmmpdlZ2LTt04meqhT7c2OvOOHy+2Wj9GiuI69UuVLKFTt2LZEmpd+ygJdeomy1JRJzM6V2xtVWr92Omq6tCvj9rVK+jMO3+e7FIX/GcVBGysopThXMh4cWLj27fv6lJ8+foN8ePGkcd79+4Buf379+L0iUOh5igPbXfwwL5Qy+/U8UOyXtp5/ndwf6jleVJPnof/OxB6eR7TXc/Dh0Ivz+NH/9PJ9ujhg6FWT0pbuy3p+NiR0MvzyOEDOut5QtT/37USstfMof/2q/PMnz+fvEYjxsYPPj4+iJqsJGJnrBfIVa/VEP17tg/kygqDl/TI2UVNGkiP0kqfrx4G9OoQSJfSIz3FxUxbQ4d+fTRv1kynbq4cWWSZSd8pTiYduvWQr0Q9oRs479bN6qt1/VT2OnXjCIO3e+e2Qj9wvZMJg5fyJRclcUGd+mUq1depW6NKOXXeNo5xdOomyUHMOurUd3F2UutHT1lOh3591KnbWKdu0cJ51boOMVLr0K2HLIXq6myvHp1aqXWp3rEy1NWhXx9tW7XUmXfmDGnV+s7xc+jQrYcipXW3V5P6NdS6sHXRqRsnUwP06xG4rek8ix8vjlo/SpKiOvUrV2sAktV2FcsVV+vauiTSqZsqd32dzCgtG9GZRbzIxUhTRYd+fTRu3ERn3vnz5JB5R4x7TMSvBRu8RrTx/wrmxslzV+Dh6YkvX7/jzv0nKJA3mxGaLMIEmAATYAJMgAkwASMIsEioEmCD1wi8KZIlQk0xBNW623D0GDQRPTs1k9BwWAAAEABJREFUg4O9vRGaLMIEmAATYAJMgAkwASYQ3gTY4DWyBerVKI/V88dh5bwxKF44j5FaLMYEQpQAJ8YEmAATYAJMgAmYQIANXhOghaRK1/7j8OrNu5BM0mBaNCWjRZehCMsfz5B5dh6Co6cuGixbSEbKPEU9T5+/FpLJBpkWrdlMeQcpGMICX7/9COEU9Sd38uwVdB84Ac9evtUvFMIx9NHWvYdP4ebuHsIpc3KWQODt+4/YtOOgJRQlWGXw9vHB0tXb4O3tHSw9axe+cOUmyIVvPTh3JhA8AmzwBo9XiErv3H9M/oBF0sQJQzRdQ4nNXLgWaVMlw679R0HG9uOnLw2Jh0iczDN1cuz97wQ69HLF7XuPQyRdQ4lQnuVLFgatoTxg5DR8+/HTkLjZcWTkUj4jJsyVv8Y3yHVGqOepFPrwiXOo2bQHtu4+pASF2t7LyxszF65Bw9oVxIN+q/T7+PqGWn6U8J37j9G0wyBMn7caLcSL07xlG9jwJTARxP36/Qdubp5wdHQIdo3ou4rwMjbJ2B0yZhaev3oLaKzcgwj+d/XGXYyZsgiODsFvL3PR0LlibhqsH3kJsMEbTm3/+48bFizfhAHdWwUoAT3Mv30Pnd662/ce4fqt++jbtQUmjeyNJvUqY8zURfj563eAMoTkgXae7VvUwdUb90Iyi0Bp3RYG9f1HT1GvZnn0F3xLFy+InoMmIrT+6IHbb8Q0FCmYC8tmu2LXulkoK4zt9j1H4tGTF6GVrUx34YpNmLN4A8qUKAgPDy8ZFpqbdVv3IWe2jCiYNwdGDeyMN28/YM/BE6GW5Zt3HzBg1AyMHtwV86cOxYYlk5E/V1aQoRFqmVpZwh8/fcHw8XMxbNwcvP/4Odil3ylevHsMmoAtu/4Ltq65eZN+SzESQxlXq1CCdkY7Mjj7i+tu76FTRutoCtJ1223AeNALo2a4MX7Km85BMvpG9O8IO1tbY9TUMjQ60k7cH+4/eqYOM9ZjTnt5ennhwJHT2LzzIH78/GVslmo5MnZHTJgnf3E0R9YM6nBjPNTW67bsE7wvwNeEl+Tzl2+idbdhMOUFm16al63dgYtXb8HPzw/0Z+xzz1xmlBc7yyDABm84tcPiVVvkciYr1u/EB/HAomLQNIOjJy8gahQXOgxxN2n2CnmzWLNxD+giLpAnO5bOGoVoUaOEeF5KgkqedKOjh0Su7Jmkoa3Eh8Z+0qxl6NGhCWxt/E/vsiUKwVY8kK7dDB1De9eB43ASvVNVy/s/sFUqFUr+Lx/GDumOg0fPhEYVZQ9nn2GTxbDibWlku7t7gj6uDJXM/ib66fNXrNu8Fzdu38cRcZ7SOUQPn58/f/+VCPndguWbQYZQyuSJ1YnnyZkFKZMlBvf2+COhqULOzk5o2agGRk2cH2yjd9GKzRjYsw1+/3GXPfb+qRq3NSdvGnXp3G8MmjeohtQpkwSrPem8GyxGUf64uYN+9bJDb1d8/2G8AUdTj74Lg2/iyF7479g5aQQaV2NIY03T2FWp/q3LbkwaNDUnQbxYIEN53LTFePbijTFqahkT20vybdV1mDB2D+HBoxdoL0bbiIM64SA8dx88gWLsZkiXKgjpgNGk267nKDg7O+L1m/fy42+6fwSU0n9E9+5Rk+Yjb86saCZGe7buOqRfWCtm+94jcJ28UN4f9x86jWVrtktjv32vUbh196GWdMBDuseYwyxganwU3gT8LYLwLkUky59ucPsPn8H6JZNQOH8OdBE3feqpmz5vFXp2bAY7O7sQJ0K9As5OjqKHbCI8vDzRrOMg0E0kxDPSSHDnvqNwsLeTef4UDxcajlberjXEQtRLecaOFR1kzGsmTD0w7h4emkEh5j984gLqVi8n06Oei0vXbkt/mlTJ0KZZbekPyc2795/QtsdI3LzzCOOGdkOM6FHx9PkrYTQkDclsAqU1a9E61KpWBnMmDcG+QydRu1lP2IiHffVKJQPJhkQAsTx++hJqVy0TKLmu7RqH2othoMwsNICMFTL8CufPKR/cqVIkQXfxokfMqMg0zebmHf0P9CfPXpMYCubLIc6lh2hWvyp+/XIDvZhSxKlzV0FTWMiv7czNm3rXaEpV6ya1UKV8cQSn947Oi+Hj5iJDutRYOG04XAd1QeYMqY02WsdNXwIynsjYPH76Irq0aWi0LuVNw/lxYsWUBqtKpcJk0ZGwaOVmNTdtVsoxGedNOgzEqg270Hf4NPGC4YZa4tymJS8VGUP7oNprrXgZJeNOXxozF6xFzqwZsWj6cAzq1QZTXHtjxoJV+sQDhJPBOnLiPNmzS8ZucHrH6Z4/ZMxs9OrUDDUqlUKzBlWRNHEC8aLif5+kjOg8pXOZ/NruthiZHDttEWZNGAganVwyaxRixIiuLabz+OXrd1i8ciumjemLUkXzY2jf9njw5Dl6DZkky5I1UzqdekqgOcyUNHhvOQTY4A2HtpgmDNsWDasjZvRoqFD6f1g1f5x44DxCmlRJUUg8fBDCf/SWSr0CdLNwdnJCx5b1MXlUH0QXhpI6Kx0e6p3UdxPSIR4giPJcIHqOlDzJQJkzcTBUKv29IWs27QEN9QVIKBgHlOfCFVvQrV2TAFp0w3wobnJ5Rc9ggIgQOqCHYKKE8WRqNFVl/rKNcqoIlcchhJevo4972vYYgbrVyqJf15agHrKFKzbho+h9TRg/rixDaGyoJ4QeSs1Fb1zc2DExfnhPYXA6Y8SATmLvEhpZyjTt7GwRK6ZxDzepEIk2O/cfxeHj56TxUDBvdvkhavo0KVCvRnmQMdde9GCR0asLCU2bGjVpnuyt7Ny6PjZuPyDFyBB68OgZOvUdg+XrdsDXT/f8bHPyJgOo5+BJ0sAuX6oIromRF9dJC5AjS0Y0FQYhvZzLwujZzFq0FsmTJkCrxjWkhJu7O85duoFL4kVzrRgyJ2NaRujZnDhzGfOnDJXTuq7evI+xopc1U4Y0eqQDBi8Q1xr1ptN9jXqIyQjt06W5eLF3wIQZSwMKax09f/kGsYShNmZINzH60xWzFq4D9VRmTp9KSzLwoaH2opd5mqqWP3dWMbKUP7Dy35DL1++gS9uGf4+AxAnji5eFrupjfZ7PX79hlDB2xw3tIV4yUuH5y7eguhvbO/70+RvEixsLRQvlVmdBU5WiRnGWx/SyM2DUdDk9SgZobGiKzujJC0Rb9UHqFP4v9DSalkZ0JrTrORJBTQk5e/E66KVCuTfSPZlGBCqULoJKZYvKnOg5d/ue7u9KTGUmE+aNxRGwsbgSRfACUY9JWmHY1qleVl3Tn7/+gAyy7u2bqMNC0kMPAPrloSWrtuKVGE6itOkNW7mB0LG2+yOGCmnozdbGtFOE5oc1rlMZ6VKnUCdNPZHqAy3PE9FDuf/IaSRLkkArxvhDyjNxoniYu3S9eu4s1Xfw6FnSCDDUc075K1NLjM/RX7JcyUKyx5OOaHoIGYOHjp0FPaQoLCRdogTxsGzOaFQXPSWlixfAirlj8PnLdyRJFD8kswmUFg13Ozray+FAemh8/fodn0S+Pj66DaJACZgQQL+ARL2XZy6E7UobJhQ1XFTaNa+DHXuPgnr1XMSL7N37/g9tMlCu3LgrjDB7ZM+SXmfZYgrDq2Htiug9dAq+/fiNl6/fy2lOJHxNGIEPHz9H0YK59X6YZE7eKpUKk0XvYtkShWTPNPWQLp45QvY60hz4Bcs3UTH0Onrpate8roz39vHBgJEzQMZe3y4tYGdrg4GuM2Wcvk2xwnmwRQyJ03kcO2Y0ObxNvdt0b+4/YipevHoHfboNa1cCGbi7DhxDy85DsX7rPkybt1L2Wl6/dU+fmgwnI408x4XB7enpJUbybJAxfWrkES/iDwTvFet24vGzlyQSyBlqL+oomDhzGWjaj6F7bLo0yUXHyoMAaf/54waabkajVPTiHiDy7wH1Zs+bOgypxAiCKb3jCRPEESMHf/D12w9xz/gm55vTNFqaA0xzgsfPWIKZ4weIe3/Cvzn+2yWIFwdzJw+V0xGUUHouGTslhJ5zxJQ6builvX3PUejarhHqVCsnXjYOo0NvV5y9eANrN++RH1UreSh7Xczs7e2w+8Bx+ZJIzxxFlveWT8A0a8by62WxJaSLpasYjrW1+Yd+zuL1cp4iXZyhUXAykuZOGoyyJQqLobQpcggOBv7o5rBk1RbRU9rYgJThKOo9aFSnkmEhjdgZ89egQ4t6sLX5x0Uj2igv5UlDnOVLFUb/kdPRtOMguRJFmRIF0U4YB7oS+fTlG+hDhgEjp2Gi6KGhoUldcobCqlcsCRtR7naix4GW7Bo/fTFqix7Y0Fp9g3pYlfJQj33eXFlEj1ciJUjnnsqlM8LIwAJ5smHVvLFyvjdxrduyN9o2qx2qvbtUNDIuVm3cjZET5+P0hWugj08oXJe7//ApLly5qSsqQobRB1MzxvXH+w+f8fnbd9D1Rg/g7gMmoGm9KnAd3AU02qCv8uVF72qHFnUwe9EaDOndThrIO/YekcP7W1ZMlaMG+nrQzM2bRrfeffgkR0LGD+8BpQfus7geaeoV9QLrKzcZfxRHBtrwcXOQLXM69OjQVPQixhb3uELCYH1L0Xpdv24txfWqQrseI+RSibPFUDm9DA8eM1P0GD6Xw/z0YZeuBKjcFH7s1EXQHFzqEU+fJiW6DhiPuHFiU5ReR6M9roM64+HjZ6jXqi+iuLiIUZoWUr7/iGmIHy+2/JD5P/GyLAO1Nrrai1Zm2Xf4lDAKhwgD2k5+lKylpj7sITpU5i/bJK8jCqRpCsbOq1Xqbah3nM49Slfb0U8tD+7dFkNFW9FUOj9h7Y4d2g03bj9An2FTRM9tEqxcvwv0oqatS8ex/o7wUCdMcKeE0Atz1fLF0F7cm9v2GIn6tSqAplVQGaiTw9bGBnFixwD1upMs5afptJlR51HrbsPx9MVrce9zBo1UvArDZUU1y8b+4BMw3boIfl4RSCPkquLu4Slv0C0b+w/P6UqZ1nms16q3fDM25+Iq8b+8cvoEDX/qykcJ27B1v3jYfVMOQ32vrJVbpEBOedPbd+gUaLkhUzMuXawg6IFNBtq2VdNBc/RUKpXO5O7efwL6UrtcycKi16kPalUtAzJcg/NBhUqlQte2jTCgexvce/gE3t6+oA+IdGYoAmmYmXoWhDdE/nt7+4jenSR60zp26pIcbl25YReod0mvYBARZBSQUbVt5XQc3blU9prrU6GHdpP2A+XQuClfwSvpRo8WFbMnDgKdG7fvPkTsmDGUqED7E+euiJ7KdzKcvgiXngi+oTZp36IuqHczioszBo6ageYNq6GaeAlLLYaAB/ZsI3oh98veNV0oaD4mTW8ivucv38Au0XM1R7wcE3d62Ygh+JNRpUvX3LzJyJ07aQiUF/33Hz9LA2h4v45y6hP17F+7eU9X1jLsw8cvSJcmBdo0rSWP6Z7Rb8Q00AsoBdD0Inp5J7+ms7WxkedutYqlQFFHeQEAABAASURBVNOsqK7Dxs6WaW1ZOU0Ysp2wSrxkGZpeRcbnjn1HZY8lLaf2XBhA1AaUDw3XP9PzIRoZ6zSdrUndynI6kKeXN6nIF9bkSRNiwvCe2LzzP1DPtYzQ2mi2F62Osmv/cTk9g3p2l6/bgQHiRZ8MSS01eZgwQVzQC1Jq0VPrJ4zOIUHMq70jRgy8vf3LJxMQG3294yIKY6cuwrlL18kbyGVKnxr0YrF3w1y5ugvxmThrGZbMcsUU177IkyMTaL5sIEWNgOcv35g0JaRg3hzihaiJnL9LH8DSixJ9dBg9mgvmiHOdRgcoG2ob2ms6TWYUPm3eKuTNmVne7yuVLQYaJdm25whFsbMCAmzwhnMj0XykJTNHgnrq9BVlnRg2WzJzFGpVLS16aKeplxFbvGor6AMmfXq6wu1sbfG/grl0RckwMsZWb9otLuiGoDdqyoPm19GUCykQwhsyLGcvXodu7RvJlP18/URPhS2oJ4BWApCBobihXgn62egE8eNgqHjo/f7tjpEDOsneLnrg0lfoxmafOmUS0etZB9PH9hO9N/7z03TpLlixGTRUN2fJOtBPVZtrnFUs8z80qFVeV1byoyOa89isQVVUEnLP9TyIdSqbGEjDo4tWbsbkUb0xY2x/7D98GovEiAEZJKYkaWtjgzLFC4pe+rqgB5C+NC5cvoV8ubLJXuD6rfuJfE1brkpf+pYefvfBUzg7O8peTqWsqzfuAbU/GUNP/n6kpsRp79dvPQAy2pRVYmhVji79x2KnMKqo51efEQaRkKl5K713ZCR27jtGvpxSjy1NyaB5nRu279drRNG5QMajyF6uPtN32FQkT5JQzu2l6QrdB47HwSNnKFqnI2OF8qcv+Gk6QNumteUIE01LomF8+tCWFMlo1h4hoRfk4oXzYvTkhepe6lTCkJw6dwWGjZsrP0yjF2ldzOhFoVWTmqD06QWF8ujStoE0slUqFaaO7gu6T1O4PkfTr+i6opdBaq/1opOCyti9Q2PxgrMP48VolS5dkqURv6dBzKulqQZUtucvA/aW6+odp95+ymv04K5ymJ/mzdKxPkfTN8g4njyyN1Im8x+ZSpk8Cb59/6lWofypXdQBwpMmVTKxhXxp154SEtR0FPo4rVKZoiADvt+IqXBxcUavTs1levlzZ5N7fRuFGcVfuX4XnVo1IK90b95+RBRnZ+nnjeUTYIPX8tsIJf6XD5NmLUeOLBmweMYIaUyNm74Ex05fNGgA6Ksa9fLpuhGT/JwlG2TvR6xYMeR0AE9PT1QoUwTL1+4I8IMR98TwMS1RQzpBObp50QOT3qy1Zdds2ovsYkgyTcpkuCCGo8lYogfevMlDsXDFJm3xED2mhyIZAu2a1wYtKVa3ejl07jtaDC3GkfMZ5y7dgAxp/81BDonMaV3eazfvYli/DujcuiGyZkqL3QdPSrZUHlPy+Pb9B/S9MNHLUq7sGWWbxo0TC9UqlZDTAyrW7Yjp81fJBwA0/t69/6RxpN9L8/H0xa7dvAfD+3WS5yZN4UkYPx7OX7op54PS0lHUu6RP11A41VNfPLGj4XAPTw/QF/iZ0qdCpvRpQHlRDzOde/RxU1sxrEkGjL50rDmcViqg+tIUHarHxu0HQHVfu3ACihXKjdFTFlCwXteoTkXMXrxeMqMX364Dxsu5jtOEAfbg8Qvs/e+kXl1z86a0O7SsBxpWvnnnIabOWYlJI3uhQ4v6WLJ6O4IyouhHSdKmTiZ78WjYuX3PUeLaTQV6GdRbaBGhUqlQulgB+aIqDuV/Gl6PGtVFTpWgnl76sZzL12/LOM1N8SJ5QSuIzBw3AFkypgV9gObm7inv0UP7thejErmwfc9hvaNV1KNIH98tWb0NqURvPPXMUgcAXTNBzRGNHze2XLWAevWpB/7cpRuyp5c+gh45oDNoeUvNsmr7g5pXS/f2iSN6QjEyFX1bGxt5L1F6x52cnMQI5Ts5leLY6UvInT2LXCOb5ssqOtp7J0dHjBvWQ94fKI569mkOcqfW9ekQ9Lyg/OtpfOdCEfqmhND1bMx0FEqDXsxiRIuGQWLkg46D61IkS4y7D57INqWXyW2ifakjiqbn0AsOlSW4abJ82BEIC4M37GpjpTnRDYt6xGh6g2YVaHkhMhAG9GgtDRN6gNENjmRu3L6PRGKIinoUgttz5uhgB1rD8pzW8NP9R89A6dJw2679x8TwUTR0at1A9JplRaVyxeTbO+VND1Uynrq2a0iHQbpc2TOBbu6DRs8M0FtD9SVDmIZknzx/hWnzViOaGGaavWg9VqzfKXqYPWTa9GtwG8XDm/KVAcHYUM/iy9fvdGosWL5ZGrpUNhKgB0+LRtVlLw8Z4jRvleYFHz5+HtTbSzLGOEN5Tp6zQvRiNZJ5UFoPHz+Du4c73n34LJfKuX3vEQUHy125cQ/UG0bGtKYiGS2bBLdOrfwfJBQ3VAxjJhS92fs2zUM+0bMxYeYyCpbuwJHTWLZ2u/QHtaGPfsaJly7KQ1v2569fSJIongymUQJ6+Pbq1FQeT5ixRPRA7ZcfacqAYGz01ZOSOC96d+l6GDVpgTCUessePxoipi/wqSfMVwzhenh6wXVgZzV70otITqVSYcKIXsiYLhXoQ7bDJ87LIVtanzlPzixynqeh+ubLlRU0x5ReHmjkgea9N6hVQa6SQSMwVcQ9QJ++SmVe3m1E7yr14pMxQUtQ0UdttLQglZ0+CiVjUF/eFE4rNnRr1xj0YkNLTuXPkxV9u7agKHkuLF2zXe4pwEO8xJMjPznNEa/Fq7bgrLgvjujXUcrfEPfZF6/egspGsuR+avxQD608QC/oFL5p50Fxbf+7J9JHngtXbBEG4VuK1uloGcpowrhu3nEwqlcsCQ8PTwRnjui7D59A82onjOgBMpQpk+kLVoO+KSCjke5FxITCNZ2+ebXEn/TI2M0gziNNHU0/9Y7TyjBla7YVL0lrxWjKadA0hShRnMQIWWckFM8m6ljR1FH8dF2So2OlZ5+M3QxpU0pj0lD+dK+mXn16RtEKMZRGcKajUFvRy4hKpXuKG6VnyA0XHRUbtu1Hwzb95a94zhAvO97ePrJzyM3dA/2GT5EjTIbS4LjwI8AGb/ixV+dcq0oZ0bORC7T0y64Dx+RNmyLt7O1Ej+MYvH33AfVrVgANWVH47oMnRO9VavlgL5Qvp+w5U+Ionhw9tDRvzBSmOJrTRG/Yr968F2/js2XP6vnLNzBiwlz07NgUdnZ2uHbzvlwJQNGhxcLjxI4hD2nu2jzRE0zDfjLAiA31htCQ1xMxlEY/u/v12w/5Yw30VXZs0Zt8S/TqUC8UDTuNHtwF1ANdqmg+mXKSxAnkV76d+42VN0QZaOSmtmC7WTyIZi1aC3p5UNRoSPDU+StyDhaFUQ8SDeFSW5ARRz0sNA+X5r3OXrIO6dMY39OrL0/qeaMHET0kKU8ybt9//CKXiStdLL98qJ4+f5WiguVKFc0vPzoiA4dGAqhulMDX7z/QrkUdEF86vnzttvwinV4w6LhQ3uxQ8qOepeXrdkKJmyCGRA31VrRpWkt+GEUfwZAxQS8vlCa5CqX+h+Hj58mPAQe5zkSenJmROUMa2XNz7dZ98WC2BS0FtFO8VJG8sU5fPUn/3sPHeCnO5wnDe8DHx1cMbSfCiAnz8PXbd9mb9PLVO7TtPkI+iEk+/Fzo5kxD4TQE+1IYadPH9gMZNkqOTo4OilfvngyKO/efoGXjGigpRpYUQRq2pnNXOda1NzdvSpPuO9Szm/DvEns03Wf7niMoX/p/FK3Xxfr7YdOTZ6/E/dMPyoo3ZOzRmr2Pn76QPdfePj4YLF68t+w8FCgt+iiSekqnju4j7oG24n48H9GjRsXWldPkFAUykuke0rzTEHh7e6v16V5LB/HixMarvx8w3b73WH75P21MP6TTWKmG5LRdvRrlsWbheHntBXeOKHGaPra/fAZQunQtvhejNJuWTcaQPu3wVPA4evIiRQVymdKnDjCvlgx7zbV2/zt2VnRCrAqkpwSQgdq0fhVxb0wJ+kVLuifQ9DB6gThw+Axu3X2giOrd0/2Blsmknn0ytjXz16dEzyeaEkJrgNO0h5TJE0PfdBR9aZgaTvfSMUO6yXOCfvkxmnhZ6TlkknzRWTR9uGjDeuK+M9fU5FkvlAnYhHL6nLyRBLJkTIOxQ7vLGxc9qEmtSP6cmC4eWgeOnJU33O7tG8uh9jWbdssLjGQK5csBXR8l0UR6WjieZHQ5enjR0iwDerSSN+m1m/ehdZNawvDOKcWpl+i66N2gA7qJr960B5VFDw/d3Jes2oo2zWqBDMMOvV1JxChHD8RGtStigOixjhYtitSJ9fdBVa5UEVGO96ChrSliOJN6VNuIXh8Sogd1qyY1xc2kjvzAjIwlKgfFBeXoBkW9KFXLlxBpLwV9EEc68ePGxoo5o4XxZScfhDMXrkFP0QupUqkwc+FaYQhXABkOb959ROIE8TBt/mpZPtINyunLk3rQxg7tJtWpt5qMU3rBkAFiQz019AJDdaMPFYePnytePO6JmKD/U1nJWKUH0KYdB6QCTROhessDsXnz/iOo50t45f/zl2/KhxUdLBc9uzQvkcpOhigZCrY2Nnj28q3eHgv62Ii+Us+XKwtoRIDqtHbzXn9jSbysHBI943QOdWnTQDKm5aeGi56zOtXKgaZzJBMvMgNdp8uRAzJEqBxBOV31JB16aC6f7Qrqkad6US/d7z9/MH54TzkfcurclbJcJDtv2Qb1yyMdRzSnUqlAK8Hom+YSVH1pZEPT2A1KXjNepTIvb+o5TJrYf3kqGuqm9YB7dGwCmutJv0S5auNuPDEwFzmmuJ/Qy5ubuzvonKLVPezsbDFqUBdZTPpYKYqLi7i+K8pjzY3//ba/nB60cMVmOXWMegNpVI16zq+Ll7UHYkRmxdzRwiC2U6tu3X0YNBpH18K6LfvRZ9hk4aZg9OBuoPv6RjHKQj/dvFj0HpPBrFbU4TE0R5TuC8SEpk5QHbXVKZzKSJ0ZdJ3Q/dbdw0M+M7RltY+JKRmbylq7/wljl1bOoRUNtGU1j9s1ryteKn9gwzb/e44St2PfEdFJE5ixEq/saQ5y6eIFoBi7Sv7EjFZAIGb6XrxVKsPTUZQ8NPfU6WBoqtzuA8dBK9C0ES/H9I0FnUOa+pp++v6DjN2OLeuBOnQoju6bP37+BuWjr8OJ5Nj9JRDGOzZ4wxh4UNmR0TFKDLsqcnHjxBKGaE1Mdu2DtKmT49Dxc3JuGBkmJEOT9an3slmDquqPkh4/fYkKpQoHOX+N9OnGWKtKWdDXu2WKF6Qg6epWL4tPn7+hRZehaNllGNo1qw0yoJau2YZyIu1EwghcIB4KZDjSjaH/iKliWN64+Z/Ro0WVRojM6O+GjFp6c64j8qWbNA3DU9mo15Uecu17jcL2PUfFQ6QLqJxtuw+Hvhvh3yQD7KgXgNIvKHo1lQgqB/mXR+PIAAAQAElEQVQfid4fWloorxj2vXX3Ie4/fIKaomeYPti4dvOuZNNGvAw4OtiTuNFOV57K8j7URjQfjNaipATpYe7i4iR67lOhi+jJ9vXzBc3dpnnE9DAlGWMc9fiQMalLtlDeHDh19opspwtXbmLKnBVoUq8y6Mcs6LxqXLcS6KG6cv2/nt479x6KHjNfXcmpw2iYsG71cvLLeprCQD3xHz5+Fsb6XWHY1pfLRdEQe9LE8UHGFCnScOeYqYtQuWxxxIwRDcPHzaFgo512PekFTrkmfEQvXvo0yUEPT3ro0+jH7z9u4vooijditGTvwZOyzrQUHRnoRmfKggEI0LkSICAED8gwpLmzypSqwWNmYeX6HXIa19yl6+R8WV3Z0ZJ9E0f0BBmejdv1ly+0w8UwtEoIk7FLPdX0QxtXrt9B2x4j5fkuotT/6Z5DB2T49OnSnLzS0ZQKMp6pxzxaVP+XdRkhNvQSTwbe3QdPxQtkCvliTKs/pBejQvQiTdc63dPpw1i6noWK3v90T7j74EmgOaJ0XfUeOhk9Bo6Hu6cXug+cAM1RFUowGa3yIOquTG2gFzsyvuh+SZ0Wm8VIF8npcs7ODhg7pAfowzu6F9BL/+xJg+UxydOKDbqMbIqjqSO/f/+B0utNxl7qlMlAbUHxNCeXPkIkv7ZTeM9bulGdP90X9h46BZpC4+bmjr7DJkse2rp0TL3JtCdHxjG96NJ0FKovtRedN/QCTPHkqNOB9svW7qBdAHfk5AVMES/G1SuWkvOwY0aPLjqadgeQ0TywtbVFt3aN1J1EdG+hD5+rVyopz4HW3YaJve7pdJrpsD/sCLDBG3asQySnnFkzCEPiPm7/neup/VESGb50w7j38JnMjx4c0hPMDQ0b0TqT1Gv239aFoJ//JMPov6Nn0UYMZ9OqDVdv3MGwvu2FUdMQBUVP85Zd/wUzl8DiqVMkxeBebeWX5rNEryvNJUwQL7ZcmJweXAXyZJdKnl4+6rmYZPQb+zat9CjLRP5uaMhx5IBO8mjhii3o1r6JTHv+8g3o1q6x7M1JlSIJvnz7IedqVW/cDdQDSz2aUimIja486eVFyZMeJNPmrUSn1g2xc98xaTg+ff4aqZInAf1s6qad5nOF+KOXpwE92mD89CWg6QsdRM9EXmHkz160TrxU1ZIrUyxbu1305BeX0yBohYokohc2a6Z0Qtu4/3RujOzfEbFixhAvJ13lR0+kef7SDdnrSH7qNaGf0R49uKtcMYRe8t59+KxeUkzjnCXxYDtaOo2WOqIHP70UkdHRv1tLmc5M0XvfsVU91BPDyNT7u2HbflBvoIyMQJtXb96Lh+17vTUiA4p68v/P3lkAWFF9Yfx7u8BSIiktJYKigIhICX9BRUQQkO6W7u7u7pJuUJAUERRQESQERLq7Q5pd9j/fhbe8LdjmvX3fwp24c/M382bOnHvumUWW9pEjNQETUmgJGOe4T1OD2tbLcFD28RQOOfzvmN5xmy+x879bA2oRqRFzPGbfppst3ls+LvgB6H7rzp171iGb+QDB4J6tsXT1Bms/6P/U8pf9soi5h/Bewt9pv2FTQBMs3tPoe7tphwHW8bxmFCeoUuhH+1vr5Z7HKOxRkBluKR04OY1xjoH3yt6dmpovvV28chWTR/RAxvSpcejoSezZdxh0DceX65LF/oer166j95CJjtn9bfMex2vS0UaUZiYnT5/DrVv/IaH1u+Lw/8DuLY1JmGNmCnNUHDBunsV3+65/rRHCDuYFt1Gbvli5dhNWrH1mMsd09kAFBtvM/THWb4Qji9Sqc5+TCNv1GA6aBXE/qMAROHLgsWWrNpi5EXwe1GrS1dRL9jwWXBg9sKNhtu/AUYvZQUwa3g1FLc0vRyroDePg0+dZcPkdzVE4ebVd92Gg7XezepUxxxoVcJyMS6307Tt3EPBll+Zrk0d0x+59B8xIYN4PsoPKkODqpOY/V/a3zGH+htp1H462TWsZEzWadnxcMA/4UQuTwFqQI+9H1qb+vyQCEnhfEviwVsubOQWla9dvgT+yxdYDi9pQe3mrf95shuJoJ0qhlG+Z1BhQw2VPE9Y1NWX82ACHSml20LT+E2GQ5R0/ecZ6oCTiZoSFjz/KYyZfUOtKodZe8IVLV2D/shidlTdo1csIivbj4VmTLc1EWMf5i1f93t6vW8IuhW8Ouc6ZNADXb/5nJtaFpy573lu3bqNSmeLgA4YTB2tV/goURkdMmA26hLNrSqipoDbfni8sa2qUR/bvAH6I5BNLo//n9t3WA/Eq6FeUEwc3b9kBanqfCOGzQS0H67lptZHrkIRkSRODGl++SNjTU7hMYwnP3D9/4TJetbS6WZ9OiqEATCGImt5de/ajTbchTBYh4YClLcv5blZkseqilokPPvrPZOE3LAHCx+cxYsV6YtvKYzzvPMbASYyRqcVkHZEZ+OJLwTdgHTyXdZv3wI6//wW9EXToNRK8Rzim43mYHIyXFP7m+Elrnr+B1ssTr1HHvPxyJLWpQQm9rKfqN52sF/ajRuBt021YsC8cnOzKcvfuP4LypT+zNPbN0W/4VGyxXp4oxPJYcIFCYr3qXxtTGgq7sWN7mUlsN61zToGTAhq9CrAvLGP3voOwayi5z99g+VKfGqG1uzX6MLxvO3MN8VhQgZpKunRjoHDLNLwn0tyH2ww0G6AA/DwzAY5ScCSKdsO0EeXkrj37DhmXiQN6tDaTLn0fPwZfCFhmUIHX8Z9/7TYTFq9euwnet+rXLGeUBlSETJy+KKhsfnEcLUlmjSwygsI++0+teaYMaRGc0PbHtr+N6QSvN5pmceIhbYJpj93NUopw8iHLe1E4eeYc6OuXmnh72q++KIK3s2Yy90J7XMC1oznKcEt50KJhNfA+niJ5UpQuURSd+owCPQvZ8zWrX8W6710GX/rscbQJ5j2KJiHrfv0DdDmXK3tW++Hnrmk73ahORb8RrJOnz5tnUq4cTwRi3rs5sfjc+UvPLUcHI5fACwTeyK1cpYeNQNrUKUCB9vpN/5OS7t2/j4nTF5u3TJZMrwclPiuMs9aPrK31xsubFePDGqgVK1X8Y2OfxJsiJ5mxLN5gf/19h6UFLsTdCAvULM4Y1wdpUqVAnWbdYH848aZKBryBcdizVpXSlpBWIkLqTZQwgSmHQmaC+PGwet0ms7/E0l7nt7TY1JxwchhdOPEmxoPU5Njbxv3QBmpeK5YpZrLRPdEa66WF/aOZyRefFjSuj6gZGDVpjrEv5EQN2nm/6KFvCnzB4sGDR6CNLZPRZq9utSeaXtr08hrjgyqiX5xSWg+he/fugVpC9mvSjEXInu1N4xtz8JgZ+KZWeTbHBDIOTgtoErxgQY0ctXxMNnnGErS0HoTcZphk/VbKfFnUaPNpO84HEhnTRIcmHzQloRaHaV0t8MHNftMOnC8Tju0fPWku6ArwoqVVL5TvfbRtUgOLf/jJMQmoBXtgDZ1PDzD0S9dw/JIbj3P0YZw17P1+zrf85eVHLEp/YQkZvUfC28fH37EeA8eZCU59uzQFNbWlreHf2QtX+EsTcCeHdW0cPHTcmMYM7NYCQ8fMMBp6pqOfcLtdPvcDhmvWi2qqlK8ZYZf3Rwp/NSt9BU5yamdp4x5bLzzMM2Pecpw5f5mbfoFC887d+83kYAp7fgeC2KDAx2uVh/hyzvsGNbGMozZ7kaWYaN9zmBE6ea3zHnb0xGkmf27gSxq1y4N7tQZfiHmv4GjT8zJRyKPGlPflhm36mPsHP7hAQbxy2c+x59/Dftl5bbBtfhHWBv1nUys6/tsFoC/eAd1bgL+jHX/vM6YUa9ZthuPLgZXF3JupRW7ddTDqWPeQhd8OQatGNcw54/GQhg+sEact2/aAIxCOeTZs2gpej45xAbf50sG4E6fOIm/uHNw04ZfN28BrgKNqJuLpgn54/1cg99M9oEbFUhgw4ls8tK77QdbLRe733jbCMoVi2mBTY+2XOMBG26Y1zWgVozlpuHXXIaBPZJoB8uVx4KhvzbnnfZ1pFF4OAY+XU61qjQgC/DGVLPY/v6JmLlgODv9QSKE9Eu0Xa1f5yti80h/lzxu3+KUNzwaHzuyTr1gO36jrVi0d7PAg04Q1ULCmoD3ZGia0D4tRgD9pDfFRgzXYGt4snP/9sBYfbD4Oz7GP3k8fiNSU5P8wB0b2awdu12/Ry9jbUuikJoDCFJ2/0+wj2EJDcKCMNRTLT4zS9myeNSxZuMAHxh/od8vXGU8H9aqXRbe2DcAH1bad/xhNWcCHTwiq8UtS2LrhU5NGDRcfMtT0UhD9Yc2vaFCjnEkX0S9OZNuuWW207jYUZaq3xD/7jxqBhH3MmD6NcYPHimn7SEGUQhO1kmTN+LCGQT1bgdpe5ufLEoftOcmPDzQKclNH97K0iC1x8dI1Y9/cpmkNY17C9Ca42OKJ0NsA3SwNJa8Xe/P37j+E1paQW79GWbS1NKwcVYjt5WUOO9qFUgt2/cYNv6Ff8m/ZZYgl0JQx9xRmoCnR4WOn0NoSdCgQ8AWG8RR6qUmnbTbPH+MuWCMzcePEAb1tcJ+B11+Vcs9/WeW9ix44+HuPGSsGpo/tDQpwcxevwtwlq7Bpy3aMnTo/kBDG8vniWrdaGW5aaRZYAkwRv7kNFByphRwwYipGWL9rCpQmocOCbtmYziEq0CZHARjsWlea0mz+c6d1HV3FhGFdwWuLLw6DerQyNr7UMNNEgIJw0/b9wZG6QIU+jeBvYrB13WZMl+ZpTPArngv70WMnzqJZh/5IlyalP+GPk5mzZk5vkvGaaGql8fU1u34LCveN61bCwSMnMaxPW+PmjlrmIWNnoHHdCtaLwUXUatrNH28+h761fj+Lpg0Dnzl24dOv0GA2eE3wvmM/zNGhxnUrorV1nXEExh7Pe2uNSiXtu0GuaXt867/bxoyK1yMnc3O0iF/C69u5KWgPTI21/RplIXwJ4JrhfwVzm6+oVbNGIHg+ORfC08MDU2YuMWYpd+7ex+jJc5k02MD6W3QcgKb1K4M+kcmtfc8RoEeLOYtWgSOFwWbWgUgnIIE30hFHXQVesbzAhxgFoHFTF4BeHey1/7F1l3lL5z79JfLHd/Dwce6GKdgnX/FmTS0hh53CVFAIM1Hbwhsgh9q3WkOanOA1aXh3ZEiXOoQlhD4Zb9p8sDJnnlzvgEPcFID5AB0/tKsZtqd3As4Cr1imODj8eOpM+CYpeFnD69Q8UOvK8xg3TmzwJsqHO80c2BbG03by+o2bOHT0BDijmDdoHgtryJEtCwb1aGmyj5w4BzUrlTLDppH14pTb0uTw08/L547GBIslHzwr125CQwftLu1tG1sPWDqcp//e8dMWgHbFppFhWNgFEmblR1uogWLZi5auRRtLQ8MXRB6z2WzInDG9+dAL9105ZEyfGu2a1saO3f/6dSPHO1lxwNKYvm+dg1pVSoEeSMqV+swc79hrhFnbF7wWqVl7Jr926wAAEABJREFU8PChEf5H9m/vJ7BSY1qvRQ+cOHXeeglrCAoEg0dNs2c1QjHNkk6cPGviKMwwD69nE/F08UQoGA568aB27Gm0v1U36yUvc8bXcevWHfBesGT5T9j4x3YsnTUC/bo0B0cBOMnWX6YAOx42D39u2lhvz8ETUdbS8gdIanbZZ6YxO8EsOBJAAalIoQ+NYGhP1rFFPUs4modvWvcBX0ynj+mNTBnSgoIvX+TefSuzmatQtXwJE2fPF3BN8waa4wSMD7hPt4r9hk/xi+7SdySaNagCnt8F36/B1h170H/4VFAIrGtpYO3CbrXyX8I+uuSX+ekGR5ioFaWQyBfPkf07GGGyYa0KhuOxp+f1afJQrWYtWIEps5aAgv83rXtb53KHX35qxicO7wb7M2bfgSPWyJaXeVmgsLp2w+8YMWGWX3r7RqoUyawX1VlG+1/felnn5MYUryVD1zb18f3Kn1GlQUdjT1yveQ/wBd+ez3FdyhrBpDlJImukjy8NPJbXGtnj6GiNiiVx+/Y93Ld+C3y5GGMJvwHvu1TQtGtex7j023fgKAaMnIopo3phYPeW+PD9d8B7K8uMDsEV+yCB1xXPWjBt5ps1BQf+0PJZP1LeYJmUrmpOWoJY0cJ5QS1MG0uzljTJq+BX1Xbu2Q8OwTFdWAJtznhjDEve0OThA61Ln9Go0agzslvCGTW7FAZDU0Z40hb5KA94E+1gva236zEMiRMlAG1OKQT37tTYTLjgjfrD998NTzV+eVMmT2YNsZU0QgYfWLwRU1vFBNT8FimUx2gQODkiZYqkoG0kj4UnJE70qsnOWcactEPBOrgXJ19LLUTPC9SgsD0mYzgX1MRwOJFlU6Pz4MFDFC2UFzusodTfrBe2JIkSYe+/h+AolDHtIEvI4vURmur50KYWknnu3X8A+8x7PsD4m+CHFviCxZnewX2VjnldIVDopebe3tZmlvZp/LSF4EtvrhxvY+nskeb6Zd9v/XfHnsxvzfsKX8QYYRdCuL3QelEo8OF74AcWODueAsF+S5DmMXv4xLrnUGjivqeHB+gft2PvUZaQfI5RWP3zZksImI2m9apYmtcC4O+LL9EI8EdBokLpYuYFl5PY1m7YYg0Rd7J+gwnAY5xcmiJ50gC5/O82qWdpLa2XfF4zFOJ6DBqPkf3a43kC5exFK/D71r/9F/R0j0PVtA+muYH9ZenpIfOyONJ6OejUsi6mWcJuiqdt4yjbSEtwfN3SvA6whs9pMkPhyZ4v4PqWpbEMGBdwf9GytcjyRnojQNuPTR7ZE5wMyqH9ooU/NK7/qHmeOqonKDRSs0thl5OR7XmCWpPVpBlLMLBHS6R46huZX8P8Z/8RU2bfYZMR8HzxJSE4ZvY6+FtftOwn1K5SGuMGdzYT8PZZgq39uOOa95fSJYpg9qKVqN2kG/iyT6HdMQ236eubNtM1G3ex7hEjUbrEJ2jXrBb+3nsAC5f+CJoTNKpTwbpuOoLmW8wTXKBWvveQCeZFil49yJhp6Xru2PHTKFujFe7eexBoVJNKklzZ3wJHkGgGUa96OWOKwryZrBcevmhwm4Gc+jm8pDBOIXIJSOCNXL4vpXROTKJNESvnzY0TCDhLna6iZlpv1pwBy+EWCmqcXPIiGzqW87IDH2q0F1wwdQiqlPvipTTn44IfmKHPWpVLmxvd1Fnf4ZP/5TU2xpHZIEcbZZobLF25HnWqPhmm5WTEI8dOG3MHusXpb2lxJljCTMCHUGjalyfXu8audZ+loQjuxYk2xBt/34GOLerihqVpXmQ9dOmz91k9od/q0f4bcKb00HEzQVtaDrvzgTt03CyM6NsOHF6mYHPq7AW/j4iQhYenhxF6Ql/jkxx1q5cBbUupOWrSrh/KfvkJXkuaGN2e81W6Jzldc8mX4kHWMLm3j7exV7QLsTQTihs3Dn5c/5s5DxcvX31uB2nakyfXO8YbB20saVZgfwml8BxUZr4UUlubNElCUINKe+LBvdqa0RHaiWbPltnSvh0KKqtfHE1+Rg/sYIQkv8gQbMT2ioVmDaqCJhg9LWF3eJ92RusaXFYK+X27NAM94VC4dUy399/D6D10EkYN7GQ0j5u37DTMKIzZ03lYAj4FUZuNTtGexKawNI6PvL2NO0C6KWvVZTA+/Tjfk4NBLPkyRw8EQRwyUfOWrMYPq3+xrn+b30sbD9hf4LjNl/BhVl8p/Nk8bGjVeTDswu7+Q8cwc/5ySwu9l0kDBZvNBio0aB7DgzQDmjp7CXgf7tqmATKlTwu7NwseZ8iSOT2WrV5vPjTD/YCBSpcNm7fiu5nD8ZOlrT124owRLH9c/0fApGbSIVl/O+d748py8sgeqFf9a/AaDpTYiqAAz499TLEEe7qLs6Lw88atZl5AvepljX9kjhLyJZfHggscReAE5TbdhuGGNapw+uxFMB9frGctWG7OOV9GuM8yqDGmgoDbDHGfmu68niY5d+Ht44NxUxfio3xPzO84Efv1NCksjfmn5rgWUUNAAm/UcH5ptVB7UOLTwqDt4u5/Dhob36RPZ+Cev3jF3Gg4A/qlNdDFKuZDjM7k2ew41k3NLnhyP7ICh935sGb5HLrkjdj+QJs6+zsjoPHm+02r3ng32xvgzODuA8eD5555whqCe3GiKQyHZYf0bm0mpdSs/BXGTJ5naWL/CWtVJh8nJ9JLBrU+TetVNg8VPhxjxogBDr8zEUcjOKxNMxL2efbilfi8SAEeCnPg1/3qWQ9Rnlt6GKha/gurL/vA8r95amKRL3d2S9O3y9TBD5+E11bbFPQSFxRy6Yngr137jFeMOs26gx8euHL1miWoHDAjC1ev38R2S7veqc9I8N4RsLmfWJrDlWs3m+gB3Vri2InTaFy3otHAVbWGj09bLybmYIAFRy+oCTt3/rIxA7Dbzt69dx90pcWJmwGy+NvlHAJ6ivEXGcxO+57DcezkGX9H48bxwqAerY222N+BADtbd+zFyAlzrLQtQTd+NAvjCxiFlf7DJ2PMwI5Ge0ebXAp41CBy6J9mAwGK8tvl59ipZKCGmaZRFKg5gZBD9PSty+uddTADNYDd2zcEbX0DCtw8zomGfEmbNKK7mfC5z9KQOtpgM03A0L7HcCNsUzBk/vY9RyBx4gTm2ubkuIDpHffZ5uHjZ1svn+3NCwqPUeDjqAy37cH+okBmAds977s1WPXTZtDrBYXWHh0aWS+b45E6ZXK0aVLDCIb7rBdte1k2m81oyOdMGmg+FmK/D9qPB7XmSBVfWO3HUlja9YcPvUHNa52qpVG9YWcU+DCn/XCwa46KNKxVDmOnzAWFe96HqdFO8Mor4AczOMp21LrmWUDASY8UZiuW/Rzjv10E+kOu/k1HxIjhgQqlP7N+X/vRoddIUJDmCxHzK0QNAQm8UcP5pdXCB1uNp8b+dDXDN3oKDXwb5bBOnapl/GkGXlpDXbDiepbGgEOSUdl0mjZUsIZ2WeexE2fNF8P4kZDx3y60HghfGP+X9FXMiSnUujFdREz4ovBsf3E6cfocOIPZPoz71859SJM6BUqXKMrqwh1oulG1fAkjcM5auNLYC9o1huOnLUDBfLmM670ps76Hzfq38qdNaGxpZjkBJqyVU1P16f/yYfrYPsYf8fO+SrfM0qjdv//QVHX1+g2zdtUFNbTN6lcFJxwVKfSh8cdMv7HVK3xpae/SgLP06cmALz8B+8g4XgfVrIc5PXkM79veGsp/Bc06DAAnQtImlwJgwHz2fX4o4fade+AXITdZGtLaTbuCHxKgALx1xx48L6+9jODWvMdRMK1Utjjoz9oxHV+sMrzA9p+CGoWbcl99aq41TmBdt2kr+Fnh6fOWYeSAjmA5K9duBCe+DerZ2tht9u7UxNL0Lneszt+LZ8Z0adCmcQ1MnrnETGAipwbWiyrNdfp1bQZq2X9c/ztYbj9LqPb1hZ/AzTbZC6aw+vPGPzFhWDdTP18wqCHlCMXz7NxpfkEzIc41oCD9zluZwA8o0J793v375oMs9joCruPFjWu1pRUoQPIYzRY4aZAmL9ynGdL1G7e4CQq9ZOYo9LL9P/78m9EY877J0Ud6EcmdMxvSpk5uhF2+DPxg/b5MIU8XvB/Y7zVPo0K1Kv/VZ/hhzS/Gty7vjf27Nkf9Gl+HqIwsmTNgaO+2RkBm/8iKZg02m82YW926dRsDgpn0yHPdpU19vBIvPupZ9Q3p1caYOvQcNAHD+7Q1L0ss084sRA1SonARkMAbLnyuk5lD3+9bNxZqJ6t+0wGcZXvzv/9AW03X6UW0bWmYOnbz1i1jExnD0oBSG1TmyyJ+5Zw9fxGJEyU0+5zwxRsrhRITEYaF44vTW5kzWoL2LtC10gVrlGDkxNlo3qAKPD0i9nYyacYSS4AvZF2jn6B+y17mmj187LSp66ilWdm6Yzc4uYV2knQy//2Kn8PQM/9Z7BPb8uXOEeRX6aiFpB/hDJbAxPpKVm6G8Aja/muP+j0KHvwioM1mw+kzF/C69eLCVlBz19Ma9qcJwj1LuN+97yCjA4XSXxQxk8bI48Spc2javp9xi8gPPHAo/OLlK9hnaR7x9O+Wg00qhRh6R9i97wBomlL56y/QqE5FowGjne+FS5eN9i/gSwWvdQpbT4sMtOLwcafeI40mkVo9m83mL01PS+Dgtesv0mGH5VPzSQ0svRzwEDn1aNcQFOIGW4JL8mRJGA2OuHxjjQKwL4ygWRHTcpuBx/sFsNOkEEU73kQJExjt7TtvvQEqJaj15mgJzYPmLlkNToylRpPlsV6aHtCmeNaCFVa9fxtbVAr21BbSXIEaUpqrTbBeCilMsv6Agb9jxh04fAxFCuVBn87NwBdjulG7cOmqEVR5PKhA7z/UXPIYNf5DxkzHmEGdQN/wtAenj/AZ83/AidPnmcTvRcHu55rC/bghnY2ChddXt35jkOjVBOjatoGxK6awS0G5U6u6Jn9oFrwPcWJaUHnIcHDPVuAkR9rnc7ST9QSV9nlxf/9zwHgHsafhdfK8SY9MR2GdX7PkS8bhY6dAn8bUbvMaCIoZ8yhEHoGIfUJFXjtVcjgJ0HcsJ+DwzXb80G64f/8BWjasHuFCSjibqeyhIMAHyEeWtpNZ3nwjnd+w88Y/dliahBNGK0Gtyt//HETMmJ7gUPyiH34ydnHME5Zw0nqYJUuayBq6rgQ+yBu17WsmPNHWNyzlPS9P/PhxLEGgFD61NK/D+rRB19b1MdZ6wMaNExvDx81CzUpfGVtblhErZgzjJYDbHS1hJ7gHPo+HJNDsp2MQX6Xb/ve/Zmh09c+bwd8UhyRTvJYUt+/ctYSQ3SEp2qnTpE2T0rRv4MhplrY2ASi4DuzREvRwwD6agwEWnIxz/sJVS9jtb10LaY2W1p6EJiI2m83sXrl6HfzgBYfGTYS1eCV+PPOlRgq+FJ6plR1mndvpY/taw97t8X6OtzB60jwr5bP/WTKnx7JgbER53iqyvTAAABAASURBVDtaw/SvJngF7Z9+Xe9ZzidbHJnhtcv2PIl5tmT9A0ZMwTfWUPaFS1dQz3rRou2mPQVtWT09nj0238iYzrjV87VUsTRlsAvKTE/BldcH/SFzP6jw78Ej/uw412+kv9mHZiJXkkRPXliZj0LvyAEd8OiRD3dBm1wKbRt//wsf5c2FPLneNfF8+fXx8bXSeZt9ju5w9IMjeibi6YITvGj77+nhAZqjrN2wBW9keN16SX71aYrgV+wrNdTUcmdKn9ZMXvtr1z+YPWGA+VBP+x5D/Saysd1UsthL4/lmfj6LEiV81bj74r5d2KXwu2P3v3A0o2HZwX0EheXyPHIS3vIfN+KH1RuMppjxjiHBK/FBTwl8AXKMd9zm+WagXXT/4VOtF/oLjofNizY/MMH2/nvwKBwnPb7IHzTzjJu6AIN7tgF/L4uWrTX+7INi5q9S7UQogWe/3AgtVoU5GwG61yqYNydadx2CRm36oIqlTeFkBmdrp9oTNgL8pCVvxpXrd7AEhLngsJ3NZgOHlXu0b2Q9VD8zgkX8eHHAYcaw1QLrIXARLTsPMi9KZUoUMRM5WjasEdbinpuvUe2KfhonapHeyPi6Sb/97304xokuvo/NPgUSTrz8rEg+s//vwWOmfWYnHAsO2VMTZ/8qHYvatmOv+TLYmnW/oV2z2shoDVFTa0l/qkeOn2YSlw20F+XLBIUuDm93bFEHNpvNmJRQs123eXejiUOAP9rINu84ALRPjRUrht9RXo/e3j54682Mxm80hZKalUqZCZZ+iRw2Dh09if7W8DA/fECzBh5K/3pq3Lj5HzdNoLb4v//umIlyvI75QmcOWAsKu136jkaqlMnQrd034CgH7Wv5AkSNpJXE/KfQSiE0oH9imnsNHDUNI/p3ML+XhrUqIFXypJbG+YDJF9SiZqWSuHvvLqrUbw+6wepsvZRRg7hw6VosXbXe8KOQF1RexnEi7HfLf8ZW67pi3SvWbjSaXdqh8njAUKdqaeslsKQpl8fixYtnbEO57e3tbcxAKGBSq8kJrnfv3QN9pMewRoGYxh7IoMhHH6BJ+/44fuosBlka0M6t6yEkfzabDeOGdDFD8hQwqW3nOcuYPjX4TKHgfOT4KQT3Z7PZ8EnhvNbvpxao6aWnCwr3fLnifqfeo+BoRkObbZY1fd4PXPkLnJzbrONAc75G9G2HQ0dPYfW6zf7ScOfBw4egRpbbwYVHj7xRo1EXS1lwHMWse8mE6Yv9JeU9iC9m1NT2tEY/hvdpZ4RXuoycu3il0SDTXpfXob+M1o7N9mTyHxmFhZlVhP5HAAGPCChDRbgIAQ6r8AMOi6cPQ9mSn7hIqwM3UzGBCXCIled2/pRBZvYzhYxllrYjTarXzEPInuPc+UugSzr7fsDhYnt8cGtO9qCd4v7DRy0NxT7wQWcf5gwuT0TH0+Zv0ogeZjiYmp/mHQYi7wc5jN/cK9dugCxYJx+ew8fPBCf2cT8iAoeCqTUbammcd+7+F29lyYCG1gtkkUIfonqFLyOiipdWhlesWKZuer1wnBT2994DoOCYO+c7qNGwM2jKYRI+XTx6+AgtG1WzhIQCxo61bvMeKFerNeiCi0PxN/+7DQq7ds8AT7MFWsX28sLA7s9sRC9evmoEOE6Eo8DCSV1d+o6xXjgemBchlk2hd9HSH41Wr+fA8eCwO30HHztxFg1b9zV2li0bVgOFb74o2StNkyo56J+YQi/LpgZu0ozFVv0tQY0909EnMIX5LNboCfeDCpzoyA8UzJ86BPzoQoE8OY3P1xVrf8XEYd2RKGEC0JwoODtNfpyj+CcFMH3uMuy3tIb0SW03OwiqvoBxFFofWlrfjr1G4KtqLSwh/xI6WC8qFASbtO9naZ+P+E34DJiX8wEqlvkcl69eNx4vYsWMGTDJc/fJjB8EGdyrlTWC9ORFh4zPXbwCCv3Py2wfmaKwGzu2F9o1q2VGnihIBmVG06BmeWsU5Y7fR1BYNucV8Mt5DWqWQ6WynxvWdCf43rtZcfRE4JfP2c9xMcd7Ba+RT/+XD7yHpEubythaUzseUIB1nPRIW+odu/dhxfyx5iWMZkFrN/zO5gUZwsMsyAIVGSoCEnhDhUuJRcB1CGzdvsfSulX11+Cz5y/j9afD1rR5o7Y/uIexv4wOO9R0UPtKLRkFa4dDUbb5epoU1vBgK3h6xkDD2uWNLTMrP3vuopkAw+H35p0GWRokgG7deCwiAjW+wyxNEoVDfnRg5oIV+OKTQsZnckSU7wxlUOtIgZB2kdSo0q3hmEGdjFDy7ZjeePXVBP6amSVzBqOxYyQFuGF926JXxyaYPXEAKMy0cnCDxResjb9vZ9JAgeeUgQdoC8sJWBR2aRZw4PBxUGuYKUMapE75GpP42Yjeun0XZSxhr1D+99HIGhXgQb7oNKpTwZj1UIAtU6IoNv3xrF562aCgwo+t8FzabDbw3LLfzE9hu4WltW7XtJbxgLDS0rwusoahqc3n8eDCqp82YYU1tD5xWDe8miA+QmKnSdMktpUz/2nHG1zZQcXbbDZQE9/CEupHD+xoJoTR7VmTdn2ta7KUMQeivTKH/YPKX9hiRiE9qGOM49A9TaTadh+KBq16ge7XGM9gs9lAbyrkx32aHtCNGu1lQyo8Fy74gbmumD8oMxrG20Oz+lVAu+7lP/5qov61RnJqVy1tXrIYQaGV9dOsZP53a8BRFwr+PMY20iNGUC7mvH180KXfaPNxCwre3a3RgT5DJ4MvfpyQ5+nhYSbQshwGTlbMkC41lq/5xXi3GNSjtXFTGcPT04x4HbZGKg4eOcGkgYLNFjwzb28fsG+8zuztDlSAIsJFQAJvuPApswg4L4GBPVrB/gC3t5ITrhjHGfAbf9+BaWP6GM2I/bgrrfng4cQiR23S2QuXYLP+NWzdB19+9hHaOnxBLSL6RoEkttcTTehjX1+U/fIT4+YpIsp2pjJqVLKGzT1s6Dt0Eob0amtMN9g+9j1ThrRG+AnuoU4NJYfV/7t954nP1wolQTdYzE9B6E/rRYyTdyigMC6o0LnPaCO8UttHYbfnwAlmNKH4Jx+B5gL2PLQRpU0uNWzUztnjeR2U+KyQfdcS1HbA7u6ML0P37j0EP35A206/RE83KGw3btsPDetUwptvpDd2xxz2pzlQqy5DcObchacp/a+ovaNG2C64UnChEBgSO02azzzP9OGYpbHmhDD/NT7bo6u3TOnTGo8Q9JLBlzwyp1lD844DzSeYrz/1oGDPRc32i4b5acveqfdI85I8yLqfHDxy3NRhL8O+5ihAX0tIpG3xa0kT26NfuC70dA5CUGY012/+Zz42wb7bC6L2/n8Fcptdmk98bAnMZsda0OSB7hLffSuz+QgHPb0wzjpk/lPoHdSjpTHpspvCeHt7g9rxBPHj+9l8e3p4gNfAjl3/guYUTFurSTcEdPmWynrx4j2WH/RgBRNnLALNb/iCNnP+D+arb4wPLjgyY9s4MrLj738RP35c47aMJjbB5VV82AhI4A0bN9fJpZaKgAMBath6DBhvCbmvYGT/9kYz4XDY5Tf5wNu194CZbMWPq0Rmhwb3bA1qgCKzjpdZNk1DOMGVZgL2dlD4TJ4skeFLd0wnTp2zHwq0Pn7iDCh0FC2UB3SV1bbbUKP95JB70iQJzSTKQJmeRlBoLFr4Q2P7S//AFKTeejMjPimcFxXKFDN5qZlDMH95389uPqhAn9H8GiAF4JKf/w8UAGs37WZycV6D2QiwoIlAg5pfg9rPERNmI3fOt0HtIrXX9IG9dNWGADme7NpsNpOOQnho7DSpNeZEqSelBL1cuOxHJHglXtAHHWL5gYZalUsZ8xJqCVtbzD/9OK8RWBu37YPjJ886pIYlUK6wtJR/+4uz71BAbtd9GPp0bmIJ+Rdx4tRZ8AWPwl/AYX6+GAzr09aqJ4U9e6jWHp4eloY1tl+eLv3GYNaCH5AyeVJjG+1oRhPUSwoz0oRmZP8OVhtSYkAwX7HjuaEpzN79R5jF2KRnzZwRHVvWNftkRvObWpW/QlHr+qOw23PQBAzo1tyYfZhETxe5c2bzi6PZysHDJzFhaDfwvsMRjvWb/nyaMuiVIzN+gIX+mC9euopC+d5H2yY1QHOJoHMqNqwEJPCGlZzyiYCLEOADldo0Dk/zIUa7PX4m2WazuUgPnt9M9q1Ju37g5KSTp89hxrg+sE9we35OHX0RgUQJn5gv3L13H9UadgInB7brMQJ0c1i25CfY/OfOYIvgUP0nloB64vR5UHBsUq8yYseOZeyBX7E0ajdu3g42LzXpPLj6599Qstj/kDF9au6awKuWmrTGbfsaX7YmMsCCQ9Nx48bGhOmL8Gam9OBwPzW7tGutWamUKY/7AbKZXU6YK1akgNneuXs/GluaXrNjLc6dv4x4ceJYW8H/p6Y3NLatFOBu37kDR22kY+lsJ81nyMExPqjtlg2rg3M1btz6D7RvpckBzTxo0lG25KdY+8sz+1JqFYMb5qcJRON2fVG9YklTXr8uzY0dNE09+Pvy9PDwNwmMkx1f9JubvWhlsOeLmlqOPNGMhmYhd+7cs7pnMzbZfLFcujrolwwrkd//FMF8xY429zTNsCek0FvD6hf3yYAjBDabDWTWpH1/NKhZARwdoIaVwi5NNKjN5cRH2mYzn2Ngm//cvtuYWNm1vbzec1sCsWO6gNuOzPbuPwR+WbJ+jbJo220YDh45YQnTXgGzaD+cBCTwhhOgsouAsxPYtfegEVYmTFtkCYN9YZ8w4uztDmn7PKyHbz9LA0NBhk7iKUCENK/ShYwAXyToM7Vf1+bo37UZxkyeD2rd3n4zwwsLiBXTE6lSJAPtHqkhpOb4+xXrLKHioxfm/fKzQuAHFjiBjH6ku/UfC37ti8P11SuUBK/poArhNcEPDlDj902t8njw4KH5IEbdamWNeQW9ItQNxuuEY3mcvETBh8P/tMel54WyJYsat1/fzlkKvmw5pue2zWYLtW1rgyAmZbEsBnpxKPFpITMxjMIvP79N+1EeCy5Mn7vUEtzK+U1YpTb819/+Mi71HPNQ4As4zM86GlkvE9UrfGk06ky/d/9hnLBeJrn9Svx4mPfdGgweM91vmJ+C4ZlzF3k4yDDu2/nWuVoImmXwoxdBJapRqST4UQtqX8uX/sxoVfsNn4ot2/eALxFB5XGMo5cQujejcEtTp75dmoHmBZXqtsMPq39B666D/dniOubl9rQ536Ne9a8tAT8PeM45skBhlzbqnLTJst99OwuT+gspLC00r7OYMZ9M3JtmXRfM3/6pWzxev99Z1/vz+pDjnaw4cOi4mWBYq0opjJg4x3ie8FeRdsJNQAKvP4TaEYHoR4BDs/MmDwKHialFiX49BGg3yiHv6Ng3Z+hTpgxpTTM4genhw0fGFVbWNzOaBzTtIPcdOApqgU2iAAtOcixWJD/qtehhDTVPxbJVGzCoZytOQN8nAAAQAElEQVTwq1UUhGhyQB/RAbKZ3cSJXsXwvm3Br0S27jrUCGCfF82P9j1HwNdKwY+vWCvzn5q8xpamn+0xEU8Xvr6+oO0ttXrFLM0tbSf7DJmEHNmyorqlteZEoadJA616tG+IhUt/ROV6HfCbpc0eNaAj4lsCH+1al/zwEyh8UjPIjJwIx8Bte2BdIbVtpdkEJ2U5mjdQoF7500Z8lPc9S9CfaYT2RAlfwRefFTLmGfZ6Aq5bNarh5w+ZPNp1Hw766mUImJYaT8dhfmrX+bU9mnAw7d5/D6OXNaxPkwX+xti+1es2YdzgLpYWMhaTWIJiWeOXm5phE+GwGD15LvYfPI5F04ZawuSH1rkbBppWOSTxt5kj25s4aAl/yZImxsBuLTB0zAxUKF3MvGR06DkcwQnMGdOlMZ4VJs9cYjTJ9A1uvXsY38I0WahVuTT4dVF/lTns0D64aKFnwu6Abi1BYXfPvkPg9U0f1bcszblDlkCbvJZ+3/Y36LaNHJmgcP7cuHrtBigwcz+o0Kx+ZYyfttBMcsyV420snT3SmJ217TYUdZp1N+f9yLFTJusPlrY74HVmDmjxQgISeF+ISAlEQAREwA0JOHSZk836dG6Cw0dPoEKddogXNy7aN6tlBIEy1Vtaws5kfF2zNTi065DNb5ND6hQC+OGOwb1aI2P6tEYA5gcrviz2P2z8fTvow9Qvg8NGwlcTwGazIX7c2Mjz/jt4563MqFHxS1D4qWZpeZmUtrnB+Zy12WygG7lP/5cP/LAEfVNPHd0T9Ds7fWwfTJqxmEUEGShwU6v9/awR5qt+qVO9hu6WljlhwgSYP3WQ8cQwxtJ2MzM9Ofzz1DaU+wyOdprcf1Gg0JU50+t+yahVpfnGoNHTkfPdtzBtTG9j4hHD0xMrf9psBKGghEx7AfRRTWGfL7o1K5eyRwdaU+it8XSYnwftH2igb+Q+QyeCGsw3M6WzNKUbsPrnzaCwe+zEacxdvMqYOrB8em3pNmCcsbtmGQwc2l/3yxYM6d3aTKDNbgmzWd7IYPxo83hQofgnBUGTkH7DpyBmrBiYPra3NRpQCF36jcaR42cwevIcrPppU1BZjYDKtp46cx5rfv4N9O9LAZI25Ky7gqU5DjKjQyQF/P5dW5oRiSf9nwT6+B1iXbd/W6NlDkkDbaZ4LQl4nXNEwS6sTp3znaVtLw++eBy1mAXKZEVwVGqQ9RLo7eMNvlBSWG5jCbs0C+I5b9esNmbMX44f1/8GepqIGcCvslWE/oeAgATeEEBSEhEQARFwdwIUPDmZp1r5EujZsTE49E276ZYNq4MjCAu/HYwF368FJ4oFxYrD5zPH98W7b2c2X+fKmjkD+nZpatxKUai8ffse+MGLoPIyrmvbhmjQqrfRdPJLXe2tIWOWxYlGtM2lsPl+MHaTHAG4cOmKJZhPwcAeLZHitaQs0mje4sT2CtGQOTXF1HRS89i1TQOQBwV5Tlxs2r4/alcpbdyAmYKfLhztNJ9GvXBFzwD2RNRazp7Y3wi6RT7KY6KpZV+y/CdwAh2H7mlOYA4EsfDx8QGFJn52OIjDL4za/ve/GNyrrRH+qFlcte6JsEuXaxTAllhD9fSBy4Io9LZrWhsUemkCwi/mUTua+713/CakUTjf/vc+0K6aeXgNcR0wdGvbAJkzvo5bt+6AwiBfMpImToRF04eiZ4fG2LnnQMAs/vZTp0qO71euB22Oy5X6FN8//ew4NbYnntqU0w7dX6anOxUsbXLG9KmNnTrP96AerY0gzZeCSl9/bl6aghvNoAadnkxWW5ySJE5ozlvaVCks7e5YnL941XzEhSMC5DBxxqKnNT5Z8Rrl74vC7qY/diCx9VLFSZ88Snd91OpyRGHC0G5ImiQRoxVCSSA8Am8oq1JyERABERABVyYQw9Is1alWBp4eHpY2dw/y5c6BooU/NF2iYNK+eS3EihkDOyyhpn7LXkYoNgefLvgw5yY1cJ8UzstNv9DO0hg7fvDC78DTDbo6mz2hP06fvQQKBhQ2KTw0adfX0viWMsIm7UgpTDzN4m9FIXf8kK5G08gDFIbadh+GHu0bGQ0y454XaEecPm0qtGpU3S8ZhW3ahn5etAC8fR6DWjy/gxG0wXbbixozZR4WL1sLcuzUexTSv57KEqSu2A+bNYVMs2EtyJNfZ7M2w/S/ytfFwUl8tEOlsDuiX3uj1aYHAQ7T57GEWWq27YVTUKRNMDX2tGOl/+b//ruNDZu3YfW6TajfqhdqViplyuCHHoaMmWHP6m9NG2wKnuwfX274ctHeesHx9PAwfadA7C9DgJ2klrDZwUrfpe9ojJk817xk2ZOwP++89Qb4ksIJvfb4gOsLF68YwZJ94rHd/xxEuVpt8N2K9eBHUL5f+TOjgwxvvpHOenl7YMwwPiuSH5euXDWjEymTJwNNeirX74BM1ihHkJmtyEuXrxmNvrVp/tNmm0I2v/qYyBKETaQWoSYggTfUyJRBBERABAIScL/9VxO8Yj3U7/vrOO117z14iKYdBlgCaF4jnPhL8HSnUP7cWLl249O9Jyv67R01aY6ZXPSdpTkM6PrqSSoYN1mckMb0IfU5a89rFxboZ7VJu35mchm1xPbjz1tzsh2FfXsaI2xbmt26TyfCHT560ngKiQyh114nP6zCj3HQ9RU/VlGnWQ/kfDer/XCgyWR+B8K5kSTRq6CwSy0nvyTGMH5oF9DWl0KpY/F88eHLzKgBHcz57925KfbtP4x1v25F4zoVjT3uvO/WYMXaX8Hyqn3TyZ/HB8eybDab9UKV1+/jFI7HXrRNrxH8AEjjepVQv8bXZmSAdVEIpn0v7bl/XP97sMVkypDWEpTfMC71eK57DBxvjQwkQZVyxTFlZA9LgP8NN27eCjI/tfT0E9xz0HiUqd7SypfU9J3pV1uCf5Y30lt5/wsyLyM/L5of+w8dNWY+LTsPwuLl68C+UPDncYWwEfAIWzblEgEREAERcGcCfKDfvnMPy59++Yos+EDnjPY6lhb419+3I7jJSYXy5QLtW3sOmmA8HdCUgZPaTpw6j25tG1rDyfcxeNQ0FhkoULvJyG/nfG9pekuF2Ocs89jDamvIuWHtCuCHLexxoVlT2G7eYSA4q5+CE/NScKbLv/Y9h4O2s4yL6FCnahmMnjTP+CGmppDmGC0bVjXVzFuy2hLC/E8mMwciYEGzCAqnNAuZs3gVRg/sZEwNWDS9Nsycvxx0ncZ9BmpomZ7bNOto1qCqJTC3s16C8lka0nXY+PtfoLaeWtseHRoidmwvJg0y8FoJ8kAIIjkikTFdGtAWl95qvh3TCzUrf4V2PYbj34NHET9+3OeWwvNLl2kcsSjw4Xvo37U56OOXE8jYP17/wRVA12Z068YXkh4dGlnX9D007zgINSt9ZSYQMy9NP4LKT8GWphtxY8fBteu3MG5wZ6MVDyqtU8Y5aaMk8DrpiVGzREAERMDZCXAy0r17D4wPUwqt9P3KB3r96l+jXdNaeGwN8wfXB5ol9LQEAQpHC5euBQUKL6+Y2LJ9NziBav+h48FlNfG0HQ6pz1mTwWFBQeaTACYVDodfuEkPE3SDVeSjD4xQf/DICXB2/nlrGNzX12a+3vXCQsKQgDaovTo1toTLf7Bzz79GcKLASfta+2SyVxPED0PJIctis9lAW+wYMTxNBpo2tO85AokTJ8DvW3eBbuPMgWAWNHX46ZctlvDb3mh/mezyleuYOvs7cDIhzUYYF9GBpgRs992798HJdwznLlzG50UKGLODb+csBT1iBFcv81M4pe0sPVr0HDzBfHGOdsvPM6PJmjkD+nVpZkyA+gydhKrlvzAT8FhPrcqlcOLUOXP9cD9giBkzBqpWKIFxQzr7vVwETKP90BHwCF1ypRaBl0uA7mGadxyImo27gJ+P5aQZzqp9UaumWDfU593QXpRfxyOUgAqLJgToLaBimWLghJuxUxegdIki4Cx7di9DutTgBC9uvyhcvXYTeXK9g76WcLBh01aMnTrfTPB5UT4eD6nPWaaNqECtJYet2/UYhqbtB4Da1Z27/8Xt23fB4ejm31SPqKoClUPTiuoVSmL8kK5IlDABKOzSvnbc4C5GCzhk7AxjMxsoYwREsO46VUvjz+17jXuw+d+twTtvZQJfAOgKjS89nFwVXFX58uQwwi75MQ2F9JETZ6NpvSrWdVMAHSzhmXbRiOA/vgTQ9rrvsEngl/b+2vUPhvZujce+vujUeyToYm72wpUIzqb37SyZjJ33pBmLDfOB3VtY12pT4xqOz6O5S1YZV2jPaza/cle4wAcmCe3M6zTrjgnTFmGQNZLRf/jUICdO8vfFFxqTSYtwE5DAG26EKiCqCPCG0bRDf9B5/czx/YyboI4t6jzXFsrethnzfjA3N/u+1iIgAhFLwMPmEWIhNWDNnxT+ECvXbjbR9H967MRp0FbVRLxgQUGrYN73TCraz7brPtwSnt8Fh5I52WfZ6g3w9vExxyN60bZJLWOH2rReJdCPbpVyXxgTi3hxvEBhcP2mbYiMF21+7pku0xwnk/HTw/QvfPDwCb8PTkR0f1kezUBoZnDg8DEUKZQHfTo3A19SVq/bhAuXrhoNMNMFFWLFjOl3jVBjOnrSXOMFgl4IsmV9A9mzZcbufYdg/9u97yB4Tu374Vlz0mP/bi2MZnnsoM545ZX4oG9cenSYNaEf4ljnjKYOwdVBt2ts89KVG5AmVQrE9vJC844DULRwHmR4PTW+ad0LZ85dCC67mew4ZdYSc7zn4IlGwP2sSD4M7tkaCV+Nb2yFzUGHBU1+zgTzQY/rN26hbbehgfz0OmTXZgACEngDANGu8xKYPm8ZihctiP8VzO3XSNo62b8ctuD7H1G8QmNUadABNPQ/ffbJzYfaIj50mrbrj4Zt+pivA/FYx14jwEkM1Rt1Nj4b7YXSf2Pleu1M2gnTFqJA8Rr2Q+CQHG0NazXtZmbqUgjnQWoMGMcym3YYgO9X/gyWwWP2wH3ewO37WotAdCLQxBL66JLM19KahbZfOd7JgtzvvW39HjuCX1Qb3re9Jfy8GapiaDfr6HOWvlo3bN4GH0vYpWDA46EqMASJUyRPip4dGqJTn9Gwayb3Hzpm3KdRgOIkM5p5REbdbJ7jZLLBo6fj7IVLGD2woxHCeTwy7zfUeh45dhqeHh7gS8raDVvwRobXQUH8wsUr5h7INgQX+JlmDvnTawLT3L13H9t3/YsM6dJw14Tpc3/AmfOXzXZELGjWMGZQJ6Ol7W0JnW9kSGsEUY5EfPq/fDh3/tJzq2neoCroho2T2Fp0HoQGtSqgSd3KKFX8YyO4p06ZPNj8fFHgSxHt3K9eu46po3uBX7+jljtu3Di4feduoLz1qpc1rvSoEXY8yBe4oPz0BlWGYz5335bA6+5XgAv1n/ZO72XPGmyL8+R6FyvmjTY+QekKZsDIb03apvUqg3aCY4d0NjNdY3vFifuB5wAAEABJREFUAmfcFiqQG3MmDcAY6wExY/4y0A7vwqUrZoipb5fmJq3jTHHedGi71bpxDcwY28dokDhBx1RiLThLu2Htihhr3VCphY4dOza2/73POgLs3LMfMSztRo5sgT9NaRI8Z6FDIuAKBPi74uQkm80WpuaW/qII+lm/O5pCIAx/FGzfy/4W6L2A2TOlT2sNQ3vg65Kf4iurbL4QMz6iA7V9nVrWxa69+43Wrmu/seA9gv2pUamkpQ1Mjr927ovoak157C8nT1ELuG3nPxjet52fBpX2tQNGTI20CXS0Xy3y0Qdo0r4/jp86C344gR/z4H2yqTUSt/zHjcbcgsIZgvhLmyaFJeTdw29/7sKmLTtRu2lX83U4CsCcAMe2j+zfHtwPInu4omgrzOusXvWvTTnU3HawFCApUyQzdshNLaXF84THaXO+R52qZYwPaVOAtWA7bbYXX/vULMeMERMeVlpe7+t++RNLfliHgh8+GaWwivL7T8bULNO3MbnaDwTlp/fs+Yvo0neMPYnWQRCQwBsEFEW5JgEPTw9MtW5ELToNwvI1v+LQkRNBdoR2WtTCMA01vh17j8KdO/eNaxw6r8+VIyvokoaZ6dyda4bd+w4jmzXsRs0G9zkBgUKy3YH5m5nSwdFFT/mvPjUzkpn2u+XrUL7Up9xUEAERCIYAf3f0HRvM4edGM1+dqqUxeeZi81vml7Vix45pNMacac8PEDy3gHAcZLs5ge74yXNIljQR7KNOLPKcpXWNHy8ONyMteHv7WEP08fyEXZpx/LDmF0wY2g2xrBftyKq4lKXZpGeKy1evW0P8sUAb5mYdB6Jcqc8wwhK+Dx09hdXrNgdZPe1TR/Rrh937DmDpyvWo/PUX1stKRezasx80zfg66PtlkGWFNpK2yLUqf2WyUanRxdLQUwM7eUQP9OncFJkzpgXNRUyCIBatG9f0J+wGkSTYKE8PD1T6+nN07jMK1PYO7NHCqrMJOEltxIRZZuSQbvnsIyUcOWjn8EEPFhy0n9576Na2AQ8Ha4tsDrrxQgKvG598V+s6hclde4L/wk7rLoPBL/j07NAIg3u2wr37D4LsIidY0F0NnXjTtyHDygVjQd+ezMBjXDPEjBGDqyfBGqqNYQnVT3YAHuNbun3fy9Ic27e5/qxIAfy995D58hS/DPT5JwUZrSACIhCJBCqVKY4xU+bjyLFTeD/H28aFF6w/+0QpazPS/qdInsQIfddv3MKVazfMSJJ12wBNNjh6xAlOFLAiugG8N9aoWBITZyxCn6GT8f2K9eAkthgxPBES38bhaU/h/O+jQJ6cxmsBzTca1CwHDvsnSpgAzb+pgi8/KxRs8ZyQRZMACr7UiHMCcu+hkzByQAfrXp4O1FwfPXE62PwRcWDkhDnghyLsAjBNK/7cvgcpXksSEcUHWcYXn3wETmAbP22RsXl+K0smYwaTJFEi9OvaDCdPn8OP638HfVX3Gz4ZqVImAz/oQZMMFsiJkY5+evm54fFDu4Jfd+MkOF7/TKfgn4CH/13tiYDzEqhVuTTWrP8N/Lwib0psKd+QN1vDYffu38f1m7dQMO97xj4r4Ns5h/1u3PyPWYx9G23HRk+e6zeh5Ojx0+CQEX1p7j94zPhMZOLf/tzJlQk53nkT9BJx4PATd0nzv1tj3SjTm/JMggCLGJ6eKFW8MNr2GI4vPikQqZqWAFVrVwTclgDtanu0b2iE3l9/247iRYMXuCIaEoXqLm3qg0PQNRp1BrV0/bs1N/cWfiTjnvUS3q77UOMDNqLrLvJRHlQq8zkuXroCfhQiVqwY4HyDEyHwbRwRbfnXum/Wrlran+bTK1YsY04WkvIp7PYZOtGYmHESGM3FOImM99mm7fuDms6QlBPaNHWrlUaDmuVNNppftO85Au+9+xby5s5hzEEiy8NPcUsBwuuUFbOP/PpbjUolzaS6mpb2edGytZi7ZLV1Lrsa7Tk/6MG0DJy7Qj+93KZ5Bl9uEid8Fd0HjLNGNE6hZcNqPKQQgIAE3gBAtOu8BPiJR86upa1a1W86olHbvhg0ehoSJ0oADmdWLVcClet1MENCVy3timNPGtT8Gv2tN+WGTyet9erYyHoI3UT1hp1RvnYb6wE1FtS8cKircd1K6NR7FGjHRQ0DXdqwLPpg7NqmAYaMmYHaTbth64691hDSNzwUbKD9IAXpyByeC7ZyHRABNyVA20d+6Wvs4M7gfSMqMbz1ZkZjx7964Xj07tQEDx8+AicYcS7BlJE90Kx+VXTrPy5SmkRBiH3mxzno2zi0vo3D0yh+iISmI6EtY4yleJgwbSHGW2H0gE6gTfT0eT+ASoh338oM2rBWLV8CjAtt2SFJT2ZMx4nNXfuOtupPjvbNa5vJza06D8biZT+BLsv4sRGmi4zw78EjcDS5Wb9xK2hXPM66fpMkShhklZwfsmXbHmO2kjjRqyBDmpaMGfRs0uL3K37GBesFKMgC3DBSAq8bnnRX7jJdy3BS2NJZI60felczO5h2texTvepl8d3M4eCDrn6Ncvh9zSxGm1Cu1GcY3re9mYjGyTX8BGrfLk0xd/JALJ4+zEx0o7DLxLS/40xn1pMieTJ/s8ULF8iNb0f3wvSxfUw9nPjAPPTJSdMIbjuGvfsOo0ihD8H6HOO1LQIiEP0JcL5ASzObv7w1hJ3bdJgTox48eGhesE1EJC2uhsO3cSQ1Kchi61Qri+SvJcHoAR2RInlSk+bnjVswsn8HvJ4mpfmyGUfoIlPgZKW0i33zjQzo2KIO7lkjhjxvb2R8HUtmDEMiS6lCDyBMFxmBLwrfLf/ZKFEGjpqGFWs3Gs0uBdng6qOt85hBnYzvZab5Yc2vGNKrtVH+cH/J8p+w6Ie1oG0w9xUAD0FwZwLqe1AEho+fBbo3q1y/A2jSENbhoS6WtoBmE03rVQqqGsWJgAhEcwKcL9DCGl6mjSu76u3tja79RqNu9TLGnRfjIisE59t4+Y+/gsLcdyvWRVbVoSqXwiy92jgKZileS4ZHFqtqFUoYYbhVl8H49ON8oSo3tIkpbHPSI83laIscN46XcVlGU4JSn/8PFy9fNSYqLJejdouWreVmhIQvPi1kPrwxfe4y7D941Chz+DGX5xXOkUj76CPT8eWA5g3c5rmlADxxeHcEpyFmOncLEnjd7Yyrvy8k0L1dQ6xZNB7zpwzC4J6tkeK1J1qHF2YMkKBf1+b4Ye5o8LOUAQ5pVwREwNkIREJ7KMzlyv6WKZm+eFt1GYLMGdOhTImiJi4yFzmC8W08ZeYSdGpVD3fu3gdfyCOzDWEtu1mDytaLwRhj61y3Whn07dIMSRMnNDbJRb6qh/7Dp+LRI++wFh9sPnrcoa0151/Qa4M94e9b/0bihAlgs9lAYbdph/6W8Gs/GjFrupijSz27SUpoSx09sAN2/P2v9TIzGMstbS/N/+iqr023Iahcvz3YL85BCW250Sm9BN7odDbVFxEQAREQAackMNkSNKmF+6bWkwlSUdFIej7o99S38bETZ02VeT/IAU4Qo1eH27fvgRO1zAEnWmRMlwZtGtcAmV2/cQucxNbK0vJ+8elHlhJhFLJkTod2PYZZQqdvhLZ69OR5yPpmBvTv1gKb/tiJrTv2YJqlde01eIKx67ULu9XKfwl+UjtCK7cK40sKPVdYm6H+z3ksFUoXwxsZ02LckC6IFze2mc/CjyxNsjS9vTo2xuDR04y5RqgLjyYZJPCG/EQqpQiIgAiIgAiEiQDdXrVtWjNMecOTiT6CaTPce8gEcGJWk7oVYR+O54ciqM0MT/mRlTdL5gygHW8iS7O6+Ie1oDBH0wcKhJwMXKxIAZw9f8nSau5D/Za98LwPRYS0jWTTrmktYxfbvnktrPppM44eP2Xma6ROlRzU7FLY/bJY4ZAWGeJ0tPeet2R1sOlpV8zJ0rWadMXU2d+bcxlU4qb1KhtPD1v+2oO0qZOjU8t6aN9jBGLFigm6N7t46VpQ2dwizsMteqlOioAIiIAIRCABFRUaApxxTxtVm80WbDYO0X87Z2mwgkywGUNwgJ4I+BGdNt2G4catOzh99iJoYhGCrE6R5P7DR0iXNpW/ttCtF4XEph0G4NP/5TVCnr8EYdihva49W5pUKYyXDZqmpUyRDK06D4Zd2OWHi2bOX45tO/fak4d7zbpv37kTrDeKy1duGBdvM8b1Rdy4cYx7Tnulu/cdBO3D7ftce3p6IFXyZKCpRJ1qpdGy8yAcPnoK/MIdvQ9RW8107hQk8LrT2VZfRUAEREAEopzAwcMnjE0qBd+gKqdZQafeI7Hkh5+MIHPj1hOf4UGlDWscNaINa5XD2ClzQfeKkfkFtrC2Mbh8ZUsUxeyFK8zHLexpbty8BfrqrVOtDH79fTuuXr9hDgUl/JkD4Vi07zEcnEBHze5i6xy17zkCiRMnwO9bd6Fb/7HhKNl/VvoDptDrqOmlcMo+vZ4mhRHqKWxX+bq40ULbc8+Ytxxnzl+275p1nvffxUFLwKVQnifXu6Af+3bNauPatRvgB1DmLlkFmouYxG6yiDSB1034qZsiIAIiIAIi8FwC2bO9idJfFAWFWgq3jonp/7u7JTQltIbu508dZASZMZPnOyaJsG2aCQzt3RYFPswZYWVGRUE0y6C5waQZS0CzDA7v05NCzUpfoX71r0EzhMc+j01TghL+zIFwLAb3ao2ihfLi1JkLePKRiEzw9PREq0Y1jE3s+Yv+hc1wVIVm9avgwqXLsAu9NNWg9wb2u0m9SpizaKUpnhMfd/y9DwNGTAW/VJc+bUoTb1/QVKVfl2YYP20RZi1YgYJ530PmjK9bwu4AFC2cx9hFf9O6F86cu2DPEu3XEnij/SlWB0VABF4yAVUvAkbIpPupHgPGwS70+vr6otegCUiWNLHRutL0gIJMlXJf4OiJ06LmQOD9nNlAG2gPDw+MnboApUsUAc0amCRDutSWMHo+WOGPacIT7C7CDhw+hiKF8qBP52bYsGkrVq/bZAmnV+EVK1Z4ig+Ut3Xjmsic6XUTnzVzBnxWJD/40aTNW3aCnhd4YM++Q+g5eCLKflnUfCQjoEkD09Bt2YyxfVCjUklw1KBF50FoUKsCmtStjFLFP8bgXm3x3Yr1uHnrNpNH++AR7XuoDoqACIiACIiAExD4pHBefPxRHvAjA2wO/aamT5vK0hRW567RXnKYvmu/MUaT2DQSP6lrKnTRhYfNA/yMs735jsKfPS4y1m9nyYQjx07D08MDA7q1xNoNW/BGhtfxvA9EhLUd/JiRPe8Xn3yE7u2+QYJX4qFnxybGXVuPQeMxsl97UGt/+OhJdOw9EkEJvXj6N23O96hTtQw+LvjB0xggaeJX8cvmbYgXL45fXORvvLwaPF5e1apZBERABERABNyLAIVeu0srft2RNqh2Avx87tHjpxEVn9S11+mKaw7tHzx8HNSQ/3vwKOzCX4b0abBy7UbjhYIT2iK6bweJADAAABAASURBVGlSJUeRjz5AE+tF5PipsxjUsxXo6QJR8MdJdOW/+sxosntawu7wPu1AUw9W/e7bmVGxzOdo33N4sJMRqTV2FHaZb+mqDfiyWCHQ/IH70T1I4I3uZ1j9EwEXI6DmioC7Evh54xbjiuv1NCmt4flvES9uHDNRiyYQ/92+gzGT50aI+y1X5xvbKxaaNaiKw8dOwS78vZYsMeo27wEKovEtjWWrLkMixT6VpgAULi9fvQ62I6on//ELcIN6tEb611OZiXoHj5zA79v+xvmLV6wXABs69hoR4tO7+qeNoKs3vjhs+Ws3egwcH62vLwm8Ib40lFAEREAEREAEIo9AimA+qXvIEmrK1miFu/cemJn6kdcC1yrZLvzRhnfEhNnInfNtM+mLttJ0w0YNZmT0qHD+92H/XHRklO9QZqBNanrZX354o2n7AWZy287d/+L27bv4vGh+NP/miXlMoIwBIrbu2ItUKV/D6nW/oUqDjvj1t79Qr3rZaH19SeANcBFoVwREQAREQAReBoGgPqmbL3d2zFqwHG9mSgcO03O2/stomzPWaRf+2Ladu/ejcZ1K3DTh3PnLiBcncmxTaXoSnIs5akvnLl5lvnI2eeZivwlhBw4fR3B5TINDuWjbpJYZAWhar5IR8jnRka7n7t27h+B8BJ88fd66llbg2vWboOeHXXsO4vrNmxgzqBP4uem0qVOEshWulVwCr2udL7VWBPwT0J4IiEC0IZAxXRq0aVwDk2cuwfUbt5DvgxzoO2wyErzyCsYO7mw8BByV94Ygzzc/TEEftRQq5yxahaWr1qNsyaKIjA968OWDEwtpahKwMf2GT8G+A0fQp3MTpE6ZHOO/XYDDx06iXY/hoMAZMH1Y91MkT4qeHRqiU5/RRoBlOS/yEZwmdXI88vZG9wHj8FG+XFgxf4wRlpMmTsjs0T5I4I32p1gdFAEREAERcBUCnHVv/6Tugu9/BP29cmKUzWYDfcGeOHUOHL53lf5EVTt7tG+IhUt/ROV6HfDbnzsxakBHxI8fD/R9vOSHnzB74UqjIY+I9tCPMf0qO7qYY7n0FrHvwFH06NDIekmJjxKfFcLlq9fQ2RJK+3dtbrT0TBdRgRruTi3rYtfe/QiJj2BPDw/UrVbGvDxVLV/CaIgjqi2uUI4EXlc4S2qjCIiACIiA2xH4+58DKPX5//z6ve7XLRg1cS5Kf1HEL04bTwjQNRg/A/z9rBGYOLwbUqd6DfygR+pUyTFrQj+88kpctO465EniCFhS6KWLOUeh9x9L2C1pnS+7X95DR09i779HLE1sI9CTQgRUG6gIemrgi9CBKPIRHKgBLhQhgdeFTpaaGl4Cyi8CIiACrkOgeYMqmDZ3GWgX+vPGPzF68jyMHdIFGdKlNp2gS66Hjx6ZbS2eESCvngPHg27KWjWqbj7sQW8EZ89fNiyfpQzfFl3MlSv1qV8hed7Lhr92/oOtO/YYO9p23Ydh9MCOyJb1DZw4fd5o5u/cveeXPiI3otJHcES2OyrLksAblbRVlwiIgAiIgAiEkECqFK+Zz8babDaMsYTdkf3bw/4J2b3/HjZ2oafPXAhhaQGSReNdftCDms/61b/26yVfHArlfx82m80vLiI23sv+lp8f2zcyvo5Orepi7YY/MGfxSgzu2QpvvZnRVMPz9s5bb6Bp+/4RZlphCn66eJk+gp82welXEnid/hSpgSIgAiIgAu5OgJ/UTZYkkcFAzS4nHlGgomC31xJ+fR4/Nse0APhBj1qVv/JDMWvhCvy99wDaNavlFxdZG68lTYwGNcth/NAuyJwpHYaPn4lq33RCl76jzSREelL4cf3vftXz62j3Hzz02w/Pxsv2ERyetkdFXgm8UUHZNetQq0VABERABJyEwNDebTBn0Uoz679T71EY0L2FGSrf8fc+4wJrzbrNxiOBkzTXaZoxZ9EqbPpjOwb3au2niY3sxqV4LSkyZ0wH2vDu2nsQ347phZqWAE5PDXxZiR8/rl8TJkxfhOVrfvHbD+/Gy/QRHN62R3Z+CbyRTVjli4AIiIAIuDiBl998anIb162Eg0dOYliftsiaOQPoFaD3kEmg/97zl66gdrNuL7+hTtaCfHmym6/X8atoUd20lMmTgRPY7t69bzw00J3ZuQuX8XmRAqBLs6mzv0ONiqVQ/qvPjI9eulSL6ja6U30SeN3pbKuvIiACIiACLk1g1IAOoK0oNYV9hk4y7rfKlCgK2qv2bN8Y385ZCn2c4tkpzpQ+7Uv7etirCeKjVaPq6DtsEmo37Ya/dv2Dob1bw9dqXqfeI3H85FlQ20tzFJo8fLf8Z+uI/kcWAQm8EURWxYiACIiACIhAVBCgF4Lx3y7EkN5tkf71VKZKagwnTl+IiPY5awrXIswEsmXNhP7dWhihe+ygzsY/L92lxY0TB327NDNeI/gRi3hx46Ly18XDXI8yvpiABN4XM1IKERABERCBkBNQykgmYLPZwC+vceY/q6KGkEJUZPmcZR0KYSdAs4YxgzohUcIE6DV4IuLGjWN88/LFhcIuj/fs0Aj37j8IeyXK+UICEnhfiEgJREAEREAERMA5CVBoigqfs87Ze9dq1ZWr15E2dQp0aV3faHb7DZuCJIkSGuF35+5/Qa29a/XItVr7cgRe12Kk1oqACIiACIiAUxKISp+zTgnAhRqVLGli1Kte1thYU9iNHdvLuEqz2WxYuuoXvJ/zbRfqjes1VQKv650ztVgERCAaEVBXRCA8BJ7nc5a+Z9t2G4qxU+cbLwDhqUd5I47AtRu3kCrla0bYZak3bt4CJyHSpRj3FSKHgATeyOGqUkVABERABEQgSgkE9Dm7cNmPKFa0APg1sA49R4C2vlHaIFUWJIGkiROibrUyfseW/7gRpb8oYrw3rN/0J5p3HBihvnn9KnL+jUhtoQTeSMWrwkVABERABEQgagjYfc5euHjFVFgoX27s2nMABfLkRL4PcuLI0ZMmXgvnIeDr64sVP/6Kq9dvoELttti6/R90bFkHpYp/7DyNjCYtkcAbTU6kuiECbkFAnRQBEQiWQKanPmf7j5gCCr3FPymIYyfP4Nr1m6hYphiyZM4QbF4diFoC/YZPwYq1v2LQ6Om4cfM/xInjhSkje6Bz63pIleK1qG2Mm9QmgddNTrS6KQIiIAIi4B4EOrasi24DxoE2vDE8PXHk+Cn36LgL9ZIfpPjv9j28lTk9ls8bjYa1KiBxoldD1QMlDh0BCbyh46XUIiACIiACIuDUBDKmS4NBPVpi6aoNyPdBDuTJ9a5Tt9cdGxc3TmxU+bo4vvqiCOLEju2OCKK8zxJ4oxy5KhSBqCKgekRABNyVALWFvTo2RtXyJdwVgfotAv4ISOD1h0M7IiACIiACIiAC0Y6AOuT2BCTwuv0lIAAiIAIiIAIiIAIiEL0JSOCN3udXvQs5AaUUAREQAREQARGIpgQk8EbTE6tuiYAIiIAIiEDYCCiXCEQ/AhJ4o985VY9EQAREQAREQAREQAQcCEjgdYChzZATUEoREAEREAEREAERcBUCEnhd5UypnSIgAiIgApFK4O69+xg5cTaqfdMJ9Vv2Qq2m3fDTL3+8qM4IPX7+4mX8sHqDvzILfVkLDx4+9BenHREQgdARkMAbOl5KLQIiIAIiEE0J9B4yESdPX8C0sb3NZ167t/sGI8bPxvpNf0ZZj/lJ4JU/bfZX34i+7RAzRgx/cdoRAREIHQEJvKHjFbbUyiUCIiACIuDUBE6ePo/f/9yFLq3rIVbMmKat/GJZ7aqlMXP+CvDvr13/GK1vux7DULd5D6MFPnjkBA/h3v37GDZuFirX74CqDTpi7NT5ePz4sTk2eeZidOozEk3b90e9Fj3h7eODrv3GomTlpqhUrx36DZ9i8jPxuG8X4NiJ02jYpg/6D5/KKLTqOgSPvL3N9sbft1tl9DDtaNFpEI6fPGvi7W3r3GcUvmndG626DMGlK9fMMS1EQAQACby6CkRABERABKKMgLNWdOLUWaRJ9RqSJknkr4nvZc+KE6efCJU8cPTYKTSuUwnfju6FmpVKoc/QSYzG1Nnfw8cSZGeN74cZ4/ri4qWrWLTsJ3OMixOnzmFQz1aYOqonYnh6okalklgxfyzmTBpo9ucsXsVkaFK3EjKmT4uJw7qhsyV8m8iniytXr6Pn4Alo3bgGZoztg5zvZgW10k8PW9rpc2hQqwImDe+O4p8UwLS5y+yHtBYBtycggdftLwEBEAEREAERCCmB9OlSI4MVmL5g3vdw5uxF3H/wEFu378U/+4+gWccBJhw+dhJ79h1kMhPyf5AD8eLGMdtc3PrvNoaPn4kWHQdi77+HcfDwcUY/N+zedxjZsr6Bt7NkMumqlv8C1DDfuXvP7L+R4XWkT5vSbKdMnsxois2OFiIgAs6o4dVZEQEREAEREIGoJZD+9dQ4c+4SqEV1rHnXngOWEJnaMSrQtjfNDWxAmyY1jGaW2tkFU4egf7cWfmm9vGL5bZ88fR59h05GsSIFMKxvO9SpVgb374dgUpqvr6UNfqanol2vh82q+GnJnp7Pjnl4eMDb2+fpEa1EQASe/TrEQgREQAREwLkIqDVRRiCdpRkt8GFO9B02GQ8fPTL1Hj1+GtPnLkPNyiXNPheMo70st79f+TPSpkmB+PHiokCenJg0cwn+u32Hh3D1+g2jfTU7ARanz15AmtQpjLY2tiUIr9+01S9F/Phxceu///z2HTdyvPMm9h04igNPtcHzv1uDN99I709z7Jhe2yIgAs8ISOB9xkJbIiACIiACbkyge/tGSP96KtRp2t1MSKPw26pxdRQtlNePCgXMOYtWmYlpa37+HV3bNDDHalctg6yZ06Nh6z6o1rATajXuius3bppjARd53n8Hnh4eqNGoC1p3HYxErybwS0L73ZzvZDXx9klr9oO0L2Z9Q8bMQO2m3bB1x150a/uN/bDWIhCtCYS3cxJ4w0tQ+UVABERABKIFgbhxYqNlw+qYM2mAcUs2fWwffPZxfn99o0Z21IAOmDt5oEmTxdKwMgHjmzeoauLnTBxgJqTlzZ2Dh9CgZnkTzI61oBcIljFrQj8M79sebZvWxNjBna0jMIJwp1b1TLx90tqmlTPgFeuJSUThArnNhDm2jWVkeGpP/MF77xhzClOItciWNROmjeltbem/CIgACUjgJQUFERCBaEBAXRABERABERCBoAlI4A2ai2JFQAREQAREwB+BgFpUfwe1IwLOREBtCURAAm8gJIoQAREQAREQAREQARGITgQk8Eans6m+iEDICSilCIiACIiACLgNAQm8bnOq1VEREAEREAEREIHABBTjDgQk8LrDWVYfRUAEREAEREAERMCNCUjgdeOTr66HnIBSioAIiIAIiIAIuC4BCbyue+7UchEQAREQARGIagKqTwRckoAEXpc8bWq0CIiACIiACIiACIhASAlI4A0pKaULOQGlFAEREAGBgV5oAAAQAElEQVQREAEREAEnIiCB14lOhpoiAiIgAiIQvQioNyIgAs5BQAKvc5wHtUIEREAEREAEREAERCCSCEjgjSSwIS9WKUVABERABERABERABCKTgATeyKSrskVABERABEJOQClFQAREIJIISOCNJLAqVgREQAREQAREQAREwDkIuJrA6xzU1AoREAEREAEREAEREAGXISCB12VOlRoqAiIgAo4EtC0CIiACIhBSAhJ4Q0pK6URABERABERABERABJyPQAhaJIE3BJCURAREQAREQAREQAREwHUJSOB13XOnlouACIScgFKKgAiIgAi4MQEJvG588tV1ERABERABERABdyPgnv2VwOue5129FgEREAEREAEREAG3ISCB121OtToqAiEnoJQiIAIiIAIiEJ0ISOCNTmdTfREBERABERABEYhIAiormhCQwBtNTqS6IQIiIAIiIAIiIAIiEDQBCbxBc1GsCIScgFKKgAiIgAiIgAg4NQEJvE59etQ4ERABERABEXAdAmqpCDgrAQm8znpm1C4REAEREAEREAEREIEIISCBN0IwqpCQE1BKERABERABERABEYhaAhJ4o5a3ahMBERABERCBJwS0FAERiDICEnijDLUqEgEREAEREAEREAEReBkEJPC+DOohr1MpRUAEREAEREAEREAEwklAAm84ASq7CIiACIhAVBBQHSIgAiIQdgISeMPOTjlFQAREQAREQAREQARcgEC0EnhdgLeaKAIiIAIiIAIiIAIiEMUEJPBGMXBVJwIiIAJRQEBViIAIiIAIOBCQwOsAw1U3/z14FC07D8IXFRvj41J1ULtpNwwfPxO/b/3babvUtH1/tOoyJMrbV6xcQ+QrVs2EgsVroESlJqjaoCMGj56O23fuBmpPWNr5w+oNWLvh90BlPS+igNWWWQtX+CUZOXG2OZ9+EeHcOH32AibPXIwrV68HKilg3YESKEIEophAWH53UdzEEFfneM/hvadM9ZboMXB8kL/F5xX6994D5r7F+/3z0kXmMd6X2IcXhZ83/onodA4jk6nKjgoCT+qQwPuEg8sut/y1G3Wb98DDR96oVqEkendqik8K58WpMxewdcdul+1XZDb8vexvYfTAjhjWtx0a16mIgnnfw+p1m1G+dlvs3LPfX9WZMqRFpgxp/MW9aGflT5ux7tctL0rm73jOd7IgxWtJ/MVF5M7Z8xcxfd4PuHrtRqBiI7vuQBUqQgTcjID9njOyf3t8XrQAfvltG75p3ce6bz9yKRJlv/zU3Dt5/2SoUPoz0/72zWv7i89l3WMzheHeaQrTQgQiiYBHJJWrYqOIwLdzvkeWN9Jj/JAuqPJ1cXyULxeqli+Bkf07oEHN8lHUCteqJtGrr+CD997Bh++/ixKfFUIjS+idPbE/YsWMgR4DxvnT9LZqVB1N61WO9A6Os87fZx/nj/R6gqrgZdYdVHteRpzqFIHIJPDsnpMd39Qqj7ZNauLchUsI7UhQZLYxJGW/niaFuXfy/smQNnUKk+3tNzP6i0+c6FW0iqJ7p2mAFiIQAgIeIUijJE5M4PKV60iWNFGQLYwfL65f/MY/dpjhsPWbtqFhmz4o8lU9M2Q+YMRUeHt7+6Xjxr3799F/+FSUqdEShb+sjcr12+OnX/7gIX8hpOk2/r4dVRp0MHW27TYUe/Yd8lcOd5auWm/ad+fuPe76BQ7Df1Kmvt9+aPrhlykEG7xxN6lXCVcsDeiC73/0y9E0gOmFz+PHoOlBtYadDJsKddqADI8cO2XyVPumE/7Zf9iYk9iH/br1H2uOjXxqprB5y07UaNTFmJ/QlIIHgzMrOHPughn+/LRsA3xdszUWLl3L5H6BZdds3MVv377Bc9y2+1Czu2HzNj/zkVpNuxnObNvJ0+fN8aDq3nfgCOq16ImPv6qL4uUbmfyXr1wz6e0L1tul72jMXrTS0o63wf9K1kGtJl1N/+1ptHYNAvZr85ff/kL1Rp1R6MtaQV5vN279h/HfLrC0k73NtUGToPY9h4MmM449tZf35/bd4HXC+0j52m2wbPUGx2RmOyT3h5DWe+36TWOexN+K/XocM3kuAt5XTMVPF5XqtQP78HTXb8XfMX8nvGcyMixlM19QIY/1ss34o8dPcwVvHx9jhla2RitzX6lYt22g37pJGGCxfuNW9Bw0AeVqtTbnjPeled+tga+vr19K9p39mLNolbmXfFW1ubkHXL9xCxHZJ78Kn24EvHfa790HDh/HhGkLzfVVuX4HM/L02Lqv7vh7H3jP4r2O98e9/x5+WtKzFUc0abJn7ksVGqNj75G4eev2swTW1qGjJ008TfxYVpN2/TDfYmId0v+QEYi2qSTwuvipfTtrRmzZthv9hk/B0RNPbp7P61LfYZMsreZHWD5vNLq0bgAKQ32HTfHLQoGufoteVvxWlPi0EHp2bIx333rT3Ch5c7UnDGk6mgjwppQyeVKrvvrIlTMbeg2eiBOnztmLCtP6Rf0IS6FFC+eFh4cHjp88E2z2KbOWYMa8H/DZ//Kjf7cWaNesNt7I+Dpu3b5j8nRqVQ/pX0+Nd97K7DfEV7tqaXOMi3v37mP4hFloWr8Sls4eiQplPmd0kIFpW3YejHRpUqJz6/rI+W5WUJBY/uOvQaYPLvI9K1/jupXM4fYOQ4/JgzGhOHjkBBq27oPYXrHQqWVdsP3nLlxEnWbdcddqvyno6WLX3gOgcDywe0ssnDYEyZMlNsJxwHRPk2vlxARuWYLDsLEz0fKbqli1YBzKlfo00PX24MFDHDxyEvk/yImeHRrj65KfWprKy+ALFl+AHbvH63fq7KVo1qAKVswfYw3lF8SgUdOwe99Bv2QhvT+EtN5OfUaB12SVcsUxqGdLNK5bETGskZtHAV7q/RpgbRQrUtDcQ2/9519wWvPz76DSoHD+XFYqICxlm4xBLChoMvrVBAm4MiNLK9ZuQvFPCqB3pybIlf1tjJo0BxRSTYJgFidOn0Ps2F6oVfkrdGv7DbJlyYRJ0xdh7uLVgXLMXbIKcePExrSxvfHt6F54JX7cCO1ToAqDieBL+m1LsdG0fmXw3kSlxmTrvtp7yCTkfOct655aC17Wvaddj2G4b11v9mLWb/oTrbsOQYJX4qNjizqoW600Dh4+gUZt+4ACM9PduHkLTSwBl0qcJtY9r3+35qhijXjevnuXhxXcnIAEXhe/ADq0qAsKQivXbgS1i5UtbeyYKfNg1zgG7F6pz/+HksX+Z27kBT7MiZYNq4HDanYB9Lvl64zgPKxvW9SrXhYfF/zAErbq4YtPPsLkWYth/wtpum9nf49sWTNhWJ92KFr4Q2N2MaRXG1y9HtiW1F52SNYv6kdIygiYxtPDA6lSJMPpsxcDHvLb3/H3fmM2UqNSSZAfh/XKf/WZ9YB6y6RhX/mQfDVBPPAYQ8Z0z2yAeQNv0aAa8uR6FwlfTYD0aVOafEEtmLZZ/SqoU62MOQ/d2jYw52HanKXgC0dQeYKKS5QwATJnTGsOOQ49UqA1kQEWfAC9bgnZYwd3Bs0sKpQuhonDuuO29ZCaZz004ZCeD5pe1ktRpgxpLWE3CSjwc/Lfpj+2O6TSpisQ4DXVrlktvG+9lL4SPx4qf1080PWWPFkSjBrQATUrl0Lh/O+jTtXSmDamNx4+fIQf1/ufqMnrt3Xj6shtlUchpa51HfNlcNXazX44Qnp/CEm9FHI4elSpTDEjiH/4fnbzO2tUuyISJnjFr86AG198WtBoWNdueDaKRRYc1eJLcIwYMRDWsgPWxXK37dxrFAixYsbE/wrkxv5DxywFwzZ0bfMN6tcoh8JWXAdLoCP/GfOX+TOxClgemVL4+7JYYXz6v3zm91enahksXPZjwKRIliQRWG6SRAnxtiUYM0FYeDFfeALvm+2a1jL3NL6AZ82cAbMXrsTI/h1QrUIJc8/p0f4bo7n98689pqpHj7wxYvwccy3x+itWpID1QvYZxg3pjFPWSBUnyTEhtce8/7T4ppql2Clk7sEF8uRE/epf87CCmxPwcPP+u3z3eSOnYDJ1VE9zs4gbJ44ZvuGw5Nip8wP1L7/143eMLJj3ifbi738OmOitO/YgU/q0yJEti9m3L4oU+tBMhLMPa4c03d//HETe3DnsxZh1xvSpkSZVcrMd1sWL+hHWcm02gAHB/L35Rjps2rIDZLs3iCG3YLL5RXt6eKBgvvf89l+0USCv/7T5P3wPFy9fxdlzl16UNczH/9q1Dx891WrZC0lkCc3vvpUZPGaP4zrLGxngFSsWN02gEE/h5sy54F8aTEItnJJASK43viA3sbRoHDLmUDnNFShknDl7wV+fKNC99WZGf3Hp0qQAJ1DaI0Nzf3hRvRRMM6RLjRnzlxuzozPn/LfHXmfANYXpXNnfMi/+9mOb/9hpBM3ilsaVcWEtm3kZOJJGVvQM06LTIEuA9gE10GzvXzv3MYkl6L5v1vZFIeuFguYI+w4ctUcFWl+4eAUDLa05zTI+KlHLmCpMnLHIeIAIqHEvmDenv/zh7ZO/wkKx878CH/hLTSVDiteSgizsB1KleM1s2q+VI8dPGSVJmS+Lmnj7gunefCM9tu/610SlT5vajEz1GjwBy9f8gv+ejryZg5G0ULGuQ0ACr+ucq+e2NFvWN9CkbmUzVLV2yUTzJjx38Spcv3HLX75EluDiGPFqgvhm9/JTd1UXL10zGl7enB0DbauY8Oz5J4JWSNLRtooawMSJEjCrv5A40av+9kO786J+hLY8e/qz5y8jbergta6tG9ewtFplsNbSZjVo1cvYO5JzSG+sr7wSHzE8Pe3VPXdNTXHAtEmesrx85epz84b1IG0lqU159ZVXAhWR8NVXcPGS/3rjx4sTKJ2npwfu3X8QKF4Rzk0gqOstaeInv1P79UatJ4eeaUrVsFZ5a+SmrTHdSZY0MW7cuuOvg/Gsa8Nms94gHWI9rWvffm2E5v4Q0nonDO2GfB/kADXHFeq0A02CVv20yaEFQW8WK1oAFCztQvKPG35DyuTJ/L34h7Vs1mj30jB2UCcsnj4M388a4acIuGj9loNin+jVJ+wvXrrCIgIF2v226joYh46cQKniRdCjfUNzLjj6xMTky7U9JEr4pDz7Ptfh6RPzhyUkCHBviWlpuuPE9vJXlIelGIgZM4bffeS8JdgzAecMOD6XuE0N+bmLl3kYKZInxbfWiAMVQQNGfotSVZujz9DJ2PH3k5cKk0gLtyXg4bY9j8Yd53CkXXN7JoCmLaAAbL8pcriLSFKmSGpsUkcP7GhungHXGdOnYTKEJF2CV+LB08MDd+7eN3kcFwEFRNps8TgFZK7tgbZ79m3H9Yv64Zg2pNvrft1ibMHSpX0y8ziofJ4eHqhe4UusmD8WPy6eaLZnL1qBidOfmXv4z+d/L8Dz3//BAHvUmj14+NBf7EVLu8uI16yhZa7JjcOk3HYMwXFzTBPU9qtPBfIr164HOnzpbKOiTwAAEABJREFUyjUkSZwwULwiogcBXm+Ok53YqyvXbnKFZEmTmDUFz3ffzmxerksV/xgcaaHZDu1/TYJQLEJzfwhpvXyB5zD5xpXTsWjaELyf8230HTYZtP98XtOKWiNY1Eiv+mmzdb+6h9//3IXinxb0lyWsZbOQRNbLIjm9nzMbOLplsz17EaCJAdkH/q0/EXSTJEnEIgKFo8dO4cSpc2hUp4IxFfukcF4zhB8vbtxAaRnhUCV3TQhPn0wBUbRInfI1U1PzBlWDfC41q1fJHOciY7o0GNqnLX5fMwsTh3a1tOneaNllCHj/4nEF9yXg4b5djx49Dyg42nt18Mhxs5kugI3olr/8f4zi9607Tbr33n1ig8oH2OkzF0ANLG/QAUOCV55ohEOSzmazIcc7WfDXzn9MHfYFh+EC2snab2gBBfQDh0/Ys/lbv6gf/hKHYIe2X+OmLkC8uHGMjXMIsoAPi88+zo83M6UHh9zseeLFjY1Hj3zsu+Fa/7J5m7/8nNHOIdhUTx8AHNK7aGldaWNoT3j33n2cOnPevmvW1CBx48HD5/v9tNls4BAh62F6e+AHK3b/cxC0t7PHaR39CGza8uR+YO/ZH9v+NrbZqVO9ZqL4QhondmyzbV/8ZgmHDwK8mNmPPW9ts9lCfH8IS71pUqVAtfIlwKH7w5Zw+Ly2xLN+9zQhWLvhD2PaQO1pcUvrG1ye0JQdXBn2+CyZ05vN9Rv/NGv74pfNf5lJtG9mfN0e5W9tf9GlGZvjgQ2btjruhng7IvsUbKVhPJDJUrSkeC0peJ8O+EzifpbMGQKVTC0x48uWLGqE3uMnzwZKowj3IiCB18XPd93m3c0ECNq3/bXrHzDQvnTNz7+ZWdF2AdXezZ9/3Qq6AGM6utsZPn42OAHALhiX/qKIEWroqYHufCj48KHHGcN1m/ewF4OQpqtbvaxpE/NTm3zw8HG06joEHtbDzq8wayP722+CbRg6diboLouC74gJs/DP/iPW0cD/X9SPwDmexVy/+Z9p05a/doMTwGiPSFc3vEEO6N7CDIs9S+1/q2HrPjBfsdv2tylj0bK12Ln7XzjaKWdIlxr8GhKFB3I+9hyvD/5L97/HSWWTZi6BvZx5S1aDbqM4ic3T48lP98tihXD//gMMsbhxhjKH99r3GG7d4P0L3GlSpwCHCFes3WjazXZxUpH/Gp/stWpUzZguDLCGBJmOoVOf0eYlqH6Nsk8SaRntCPB6Gzlxtr/rbfW6TWbSpKfHk+stT67s5nrnV78ePfIGhV16TKF2NCxAQnp/CEm9vGfUaNQF385ZCk4M43VLt38+Pj74MNe7L2xe8U8K4rw1ND519vfInu1NUAC0Zwpv2fZyglpzUlXBvO9hzOT5+PW37eb3uWT5T8YGtW7VMpZ2PXFQ2cCJokkTJ8SsBT9YL9jeRoPZZ8gkhFSwi8w+BdngcETypYUTKjk5jR5BvluxzpxjftWSXxnlmsWv/nkzaCP9/cqfDUc+uybNWIKErybAW28GFoqZR8F9CDy5i7lPf6NdT7+pVRGxYsXEhGmL0LzjQBMWfLfGCKRtmtQI1N+2TWvhh9W/mHTDxs0Ah/K6tqnvl85ms2HMoE7gW/HmP3eia/+x6NR7lNEYfl3qk1Cn42SQQT1bY+uOvcbvb+N2/fDlZ4XAYVG/wqwNm82GwT3bmL5Ub9TJ+O318fFFxTLFrKOB/7+oH4FzPIvZtWe/6T/7tfGP7UhqDRl2bl0Pi2cMM0OCz1IG3sqSOR0OHTll3Cu17zkC6379E22b1ULtKl/5Ja5TtQw403rY2Bmmnulzl/kdC81GnDix0bJhdQwZPc2U892Kn80+PVTYy3ktaWIM7NEK+/Yfsfg2AW0WP/lfXryVJaM9iVkbm7ZuLXHsxBm06TbUlEfNsDkYYEGXahOHdwd9hLKP3fuPM5rv6WP7mAdHgOTajSYEQnK9lfvqU/Ob7DVkIgp9WQtDrWu8ffM6SJUyWZgo5Mr+FgaF4P4QknppIpH8tcTgi2yXvmPQfcB4XLx8xXiVoA3tixr4Ye7s4O/k+o1bKGaN3DimD2/ZjmUFtT2ge0t8ViQ/Rk+ei7bdhmHxDz+h+TdVzctGUOkZ5xUrlvXbbwmajNFXednqLXHv/n20tF5YefxFIbL79KL6Q3uco4qTR3QHfIGps743gu2cxauQ0dL+vp8zmykuXZqU4GgAn3F88R9qKQJoiz3Jup8FVP6YDFq4FQEJvC5+uosWymP82y6bMwpb1s4x4bc1s4z7GfswtmMX6W5qxri+Jt3qheONGxu+PTumoSaQXxdbNG0YNq+aAdrD0a3YF5985JjMaAxDkq5QvlyYN3mQsalav2yq+RIcPUuM6NfOX3mvp0mBCUO7YtPKGSa0bVoTjetWws9Lp/hLx53XrRvbi/rBdAEDJ/TZOf26Yhpmju8HutUqWex/xt44YPqA7WzVqAYmDu+G5XNH45cfvsWUkT3My4VjPtpQd23TAD9YaVhXn85NzWEKr2RudgIsaG9Wo2JJv1h7Wrp+or0wy/lu5nAjbPglerpBNz9zJg3AHz/OBvtH7fvEYd0wtHfbpymerJiO/jfJl+VRo84jAetmHN2r0fMH+7hm8QSM7N8eFK55zB7Irl/X5vZdvzX7SHdqfhHacBkCL7reOImSv8mls0aaewjvO0U+yoP5UwajW9sGfv20X79+EU83eL3QjdnTXbMKyf0hJPVSoKHLQ163676fjDWLxmN43/YvfIk1jbAWnh4e4LXO30bZkp9YMc/+h6ds/ibZ72elBd5i/1o1qm4ms/F+u/DboahQupi/hHQ/ybbZXYrxICcr8x7FPLzv9+/WAmVKFDXnhiYATENzDeYrV+oz7vqF8PTJXgjLZNk0HbDH2ddsl+M9ntcW02ZMn9qexKx7dmgE3r/MjsOC9ym6xnSIAvvL+6/9PHECIO16aRfNdDxOhQ3vTb8sn2Z48rp83Xq28LiCexOQwOve51+9FwEREAEREAEREIFoT0ACrwufYjVdBERABERABERABETgxQQk8L6YUbRIEdxwkqt1Lrr0w9W4q73Rm0BwJggu1Gs1VQREQASeS0AC73Px6KAIiIAIiIAIiIAIiICrE3AfgTeSzhS/HKTgiYAMbDYbfH19A8UHTOeO+3R/xpnE7tj3kPT58WOfCLlugGfO/eHyf7ZwM/nvv/+wevXqcJcTknPoLml4j/PwCP+5cRdeL+qnzeaazw3ozyUIeLhEK524kR4enlAIzACWsPHkYRD4mLvzstk8jOscd+cQXP+9vX0Q3LHQxNtsziPw0tVV225D8fFXdUHfsAjmb/y3C1CpXjt8Wakpeg+ZCPsHHWw2W7iZ3Lr1H1asWGnKCQ1HpQ3+Hubj8xiAh5hG0HMQoMBrEY2g8qLq2oX+XIKAh0u0Uo0UAREQARcn8MVnhVC/+tfP7UWOd7NiwdQhmDWhH65dv4mlKzc8N70OioAIiIAIhIxAMAJvyDIrlQiIgAiIwIsJJEqYAPRXGyeO13MT86tbTJA40aug39VLV65yV0EEREAERCCcBCTwhhOgsouACERzAi+he/fu38fKtRuRJ9c7pnaaB3l7eyO8gYWFtwzlf3YefHx8wn1OxPMZT7JwRab8XSk4PwEJvM5/jtRCERABNyJA4bZrvzFGI5w3dw7Tc8ZREAhP4ETJiCgnPG2IbnnJk1yjW79eVn/IkuFl1R/Wes2P1E0WrtxNCbyufPbUdhEQgWhHYOrs75A1cwY0rlvJr28eHh7w8vIKV4gVKxZsNlu4yghvG6Jb/hgxYoBco1u/XlZ/yDJmzJgud436/VC14dQEPJy6dWqcCIiAixFQc0NL4MixU7h6/YbJtnDpWly5egP1a5Qz+1qIgAiIgAhEDAEJvCHgyAdSvmLVYA+tugwJQa4oTjJuHCz1DdCsGfQnAiLgXAS8fXzM/YMuyZauWm+2Dx4+bho5aeZibN+1D0wzcuJsLP/xV3Oc95s+QyebNFqIgAi4IAE12akISOAN4el4P8fb2LJ2jgkj+rULYS4lEwEREAEghqenuXfY7yFcZ8mcwaAZ0qsNihUpEGSabm0bmDRaiIAIiIAIhI+AR/iyK7cIiEA4CCirCIiACIiACIhAFBCQwBtCyPsOHkXB4jVQr0VP7Nl3yC8X3ag4Q+DMVjaKa2doD9vAGa9cK/h3u0MePj6PwbVCYDYRdQ1zBj1/EwoiIAKuQEBtFIHIJSCBNwR8U6V8DcvnjsaaxRNQpNCHaNt9GO7eu29yUqhzhkAhgQ3iQ37xstXo0X9kqMMPq35CRPWF7WGIqPIOHz0e6v6QQZ9BYyKsTxHVF5bj6/vYKdvFtr3s8Pixb4Sw8fX15U9CQQREQAREQAQggTcEF0HcOLHxSvx4JlT5ujhSvJYUp89eMDlflvuWgPXSPQ4b5OnpicuXr+LgoaOhDleu3YgwdzAR7V7m0SMfhKVPh44ci7A+BWQenn2er/Dkj855Y8TwjJBzRlde0J8IiIAIOBC4f/+JssohSptuQkACbwhO9O07d/1S0WPD9Zu3kDZ1Cr84bYiACIiACIhAFBJQVWEgsG3bNowaNQpnz54NQ25lcXUCEnhDcAZXr9ts3AR9VKIWho2fhf5dm4Na3xBkVRIREAEREAEREIGXTGDPnj1Ys2YNqOF98ODBS26Nqn8ZBCTwhoB6hdLFjEuhzatmYMLQrnj37cwhyPWSk6h6ERABERABERAB7Nu3D0uXLjUkqlSpgowZM5ptLdyLgATe6HK+mzQBOElnzJjo0iP1QwREQAQihIAKcV8CBw4cwJIlSwyAihUrInNmKawMDDdcSOB1w5OuLouACIiACIhAdCdw+PBhLFy40HSzTJkyyJo1q9nWwj0JSOA1510LERABERABERCB6ELg5MmTmDdvnulOyZIlkT17drOthfsSkMDrvudePRcBERCBwAQUIwLRgMDevXtNL4oVK4ZcuXKZbS3cm4AEXvc+/+q9CIiACIiACEQ7Al9++SWqV6+OvHnzRru+qUNhIxAWgTdsNSmXCIiACIiACIiACEQRAXljiCLQLlKNBF4XOVFqpgiIgDMSUJtEQAREQARcgYAEXlc4S2qjCIiACIiACIiACDgzASdvmwReJz9Bap4IiIAIiIAIiIAIiED4CEjgDR8/58k9bhxgswHNmkF/IuCkBNQsERABEYgwAvfu3YuwslRQ9CcggTf6n2P1UAREQAREQASiFQEKu1OnTsV3333nov1Ss6OagATeqCau+kRABERABERABMJM4MGDB5g5cyauXbuGu3fvhrkcZXQvAhJ43et8q7cuREBNFQEREAER8E/g4cOHRti9ePEi0qRJg8qVK/tPoD0RCIaABN5gwChaBERABERABETAKQiYRjx69AizZ8/G+fPnkTJlSvNhiRgxYphjWojAiwhI4H0RIR0XAREQAREQARF4qQS8vb0xd+5cnDlzBkSsVzEAABAASURBVMmTJ0fNmjURK1asl9omVe5aBCTwutb5UmuDI6B4ERABERCBaEtg/vz5OHnyJJImTWqEXS8vr2jbV3UscghI4I0cripVBERABERABF4KgehW6eXLl3Hu3DkkTpwYtWrVQpw4caJbF9WfKCAggTcKIKsKERABERABERCBsBFIliwZ6tWrZzS78eLFC1shyuX2BCTwRpdLoEkTwNcXGDMmBD1SEhEQAREQARFwHQJJkiRBggQJXKfBaqnTEZDA63SnRA0SARFwVwLLVm9A5XrtkK9YNVy/cctdMURtv1WbCIiAWxCQwOsWp1mdFAERcAUCyZMlQe/OTZE0SSJXaK7aKAIiIAIuQ0AC74tPlVKIgAiIQJQQyPdBDmTOmC5K6lIlIiACIuBOBCTwutPZVl9FQARckoCvry/ohzS8gZ0PXxneEdKO6NIGHx8f8fCOuGvixIkTcEWm/F0pOD8BCbzOf47UQhEQATcn4Ov72BIEvMMVHj/2ga8lOPv4eIerHOV/xs/XOi/kKibPmISVxffff2c+LHH8+DGXuz7d/PbkMt2PcIHXZXquhoqACIiAixDw8PCEl1dseIUjxIrlBZvNBq9wlKG8/s9BjBgxQa7i4p9LaHmsXr0G+/cfAP/INLT5X3Z6tlvB+Ql4OH8T1UIREAERcEkCarQIiMALCKxYsQJ79uwxqSpWrIj06dObbS1EIKIJSOCNaKIqTwREQATCSGDCtIXGJdmVq9fxRcXGaNt9aBhLUjYRcH4C69atw86dO01Dy5UrhzfeeMNsaxEdCbz8PkngffnnIGJaMG4crPFKoFkz6E8ERMA1CTSqUxFb1s7xC0N7t3XNjqjVIvACAhs3bsQff/xhUpUpUwbZsmUz21qIQGQRkMAbWWRVrgiIQKgIKLEIiIB7EKCg++uvv5rOlixZEtmzZzfbWohAZBKQwBuZdFW2CIiACIiACIhAkASKFy+OXLlyBXnMzSPV/UggIIE3EqCqSBEQAREQAREQgaAJ5M+fH7Vr10aePHmCTqBYEYgEAhJ4IwGqihSBSCegCkRABETAhQm8/vrrLtx6Nd0VCUjgdcWzpjaLgAiIgAiIgAgYAlqIQEgISOANCSWlEQEREAEREAEREAERcFkCEnhd9tSp4SEnoJQiIAIiIAIiIALuTEACbyjO/vUbt1Dkq3qgc/hQZFNSERABERABEXAOAlHUinPnzuHRo0dRVJuqEYEXE5DA+2JGfimGjZuFXDmyAjY431+TJoCvLzBmjPO1TS0SAREQARFwGwLnz5/HzJkzMXfuXLfpszrq/AQk8IbwHO3+5yDixPFCtqyZLcEyhJlcM5laLQIiIAIiIAJhInDx4kUj7D58+DBM+ZVJBCKLgATeEJD19vbGmCnz0ax+5UCpHz9+DGcLvtT0BmrpiyOYz9n64tieF/cg6BSOZTjPtq/TXTfOwiairsOgrwbFikBoCChtaAhcu3bNCLsPHjxAmjRpULVq1dBkV1oRiFQCEnhDgHfu4tUoW7IoErwSP1Bq/rCdLVBA9/HxQWgD8zn2ZeS4b9G1z7BQhz//2gm+3Qcsz7Hs0G6zPJ8w9Il5QltXZKdnXyKSTWS3N6rL9/b2QUTUyXMf6AerCBEQgUghcOPGDUyfPh337t1DypQpUb16dcSMGTNS6lKhIhAWAhJ4Q0Dtt6270GfIJOQrVg2TZy7GrIUrMHLibJMzTpw4cLbAm4ynpydCG5jPsS8nTp3FocPHQh3u3XuA2LFjI1asWBHGhuWFtj/29I59coZt9iVWrJgRxsYZ+hSRbYgZM0aEsOH5h/5EQAQincCtW7eMsHv79m0kT54cNWvWNPf/SK9YFYhAKAh4hCKt2yadMrIHtqydY0KDmuVRo2JJtGxY3W15qOMiIAIiEAQBRbkhAQq51OxS6E2cOLERdr28vNyQhLrs7AQk8Dr7GVL7REAEREAERMDJCSRMmBC1a9c2ozNO3lQ1z00JRK3AGw0g167yFRrVqRgNeqIuiIAIiIAIiED4CMSPHx+1atUywi63w1eacotA5BGQwBt5bFWyCIiACARLQAdEILoQePXVV5EgQYLo0h31I5oSkMAbXU7suHGAzQY0awb9iYAIiIAIiIAIiICLEIiSZkrgjRLMqkQEREAEREAEREAEROBlEZDA+7LIq14REIGQE1BKERABERABEQgHAQm84YCnrCIgAiIgAiLgDgROnz7tDt10iT6qkWEjIIE3bNyUSwREQAREQATcgsCSJUswbdo0HDt2zC36q05GTwISeKPneVWv3JqAOi8CIiACEUNg6dKl2LdvnynMx8fHrLUQAVckIIHXFc+a2iwCIiACIiACkUxgzZo12LNnj6mlYsWKyJw5s9l2qYUaKwJPCUjgfQpCKxEQAREQAREQgScE1q1bh23btpmdcuXKIWvWrGZbCxFwVQISeF31zKndEUVA5YiACIiACDgQ2LRpE/744w8TU6ZMGWTLls1sayECrkxAAq8rnz3HtjdpAvj6AmPGOMZqWwREwEkILFq2FtUadkKNRl2wacvOIFv1994D+KZ1b1T7phNadh6Eg0dOBJlOkSIQOQRgtLq//PKLKb548eLInj272dZCBFydgAReVz+Dar8IiIDTEzh5+jxmLViBScO7Y3DPVug3bDLuP3gYqN2jJs1FlXIlMGfSALyfMxumzFwSKI0iRCAqCHz66afIkydPVFSlOkQgSghI4I0SzNGnEvVEBEQg9AR++3MnChfIjXhx4yBF8qTImjkD/tr5DwL+PX78GB42m4m2wYbkVlqzo4UIRBEBCrm1a9dG/vz5o6hGVSMCUUNAAm/UcFYtIiACbkzg8tVrSJUimR+BNKmS49KVq3779o0alb5C135jkK9YNSxdtR51q5Yxh3x9feHt7R3uwMIiohyVYc4F6KYrOrJIlSpVuK+1sHJxRab8XSk4PwEJvM5/jtRCERCBaEDA5vHsdmuz2YLs0aY/tqN/9xb4eekUVCxTDCMmzAb/fH0fW8KVd7jC48c+8LUEZx8f73CVo/zP+Pla54VcxeQZk/CwIEuG8JTxMvLyN6rg/ASe3YGdv62u10K1WAREQAQsAsmSJMaNGzetrSf/r12/gdeSJnmy83T54OFDbN6yEwXy5DSmD0U+yoN/9h8xRz08POHlFRte4QixYnnBZrPBKxxlKK//cxAjRkyQq7j45xJWHmQZM2YseLnYNQr9uQQBD5dopRopAiIgAi5MoGDeXNj8505QqL12/Sb+PXgMH+Z+1/ToyLFTuGoJwLFixoSnpwf2/nvYxP+5fQ8ypU9jtqPDQn0QAREQgZdJQALvy6SvukVABJyKwLkLl/DtnKXoPWQimncciI69RmDo2Jn4cf1v8A7HZ1XTpU2JMiWKom7zHmjZeTBaNa4BCrjs/KSZi7F91z6jfW3VuLpV7wBUb9QZv/72F9o2rcUkCiIQoQTOnTuHBw8eRGiZKkwEnJ2AEwm8zo5K7RMBEYjOBEZMmIUWnQbhkfcj5Mj2JiqV/RxFC+dFqpSvGVODGpYQuv/QsTAjqFC6GOZMHIBZE/qhcP73/coZ0qsNihUpYPa/+OQj/LJ8GmZP6I+hfdoajw7mgBYiEEEEzp8/j1mzZmHKlCkSeiOIqYpxDQISeF3jPL24lePGwVIRAc2aQX8iIAKhJ5A8WVIs/HYIGtaqgK++KIL8eXLi0//lQ5Wvi6Nf1+bo360lLlwK7Fkh9DWFIIeSiEAkELhy5QpmzpxpBN0sWbLAy8srEmpRkSLgnAQk8DrneVGrREAEophAlXJfwMPBk0LA6tOnTYmPC34QMFr7IuASBK5du4bp06cbYTdXrlzghyVcouFqpNsTiCgAEngjiqTKEQERiBYElv/4K27fuWtsdvsMmYSSlZvi921/R4u+qRPuSeDGjRtG2L179675VHDJkiXdE4R67dYEJPC69elX50UgOhCI2D4sWroW8ePFxdbtey3B9w6G9G6DCdMWRmwlKk0EoojArVu3jLB7+/ZtZMuWDWXKPPmYSRRVr2pEwGkISOB1mlOhhoiACDgDAS+vWKYZO/f8i0L5c5vPANtsQX8owiTUQgSclAA1ujRjoNCbNWtWlCtXzklbqmZFGAEVFCwBj2CP6IAIiIAIuCGBmDFj4PsVP2PTHzuQK8dbxrSBn0l1QxTqsosToE16vHjxkDlzZlSsWNHFe6Pmi0D4CEjgDR8/5RYBVyOg9r6AQMcWdXHl2nXjrSFl8mQ4efocPsqb6wW5dFgEnI9A7NixUa9ePVSoUMH5GqcWiUAUE5DAG8XAVZ0IiIBzE0j/eio0qFkeRQt/aBqaKX1aNK5byWxrIQKuSCBGjBiu2OwoaLOqcCcCEnjd6WyrryIgAsESaNt9KPiltaAS3Lx123xxbfailUEdVpwIiIAIiICTE5DA6+QnKMTNa9IE8PUFxowJcRYlfDEBpXAfAl9+9j/zpbUm7fph3LfzMXnmYhN6D5mIqg064t79ByhZrJD7AFFPRUAERCAaEZDAG41OproiAiIQdgL/K5gbi6YNRe2qpREndhy/gnK+kwXTx/ZGt7YNkPDVBH7x2hABNyOg7oqASxOQwOvSp0+NFwERiEgCNpsNuXNmQx1L6KUdL0Op4h8jWdLEEVmNyhKBCCVw/PjxCC1PhYlAdCQggTc6ntWX1SfVKwIiIAIiEKUEli1bhlmzZmHHjh1RWq8qEwFXIyCB19XOmNorAiIgAiLg9ASiooErVqzA7t27ET9+fGTKlCkqqlQdIuCyBCTwuuypU8NFQAREQATclcCaNWuwc+dOxIkTB7Vr10bChAndFYX6LQIhIiCBN0SYIiORyhQBEXBWAnv2HcKiZWtN865cvY4Tp86ZbS1EwBkIrFu3Dtu2bYOXlxdq1qyJxIllY+4M50VtcG4CEnhDcH72HTiKT8s2QL5i1VCzcRes+fm3EORSEhEQAVckMHP+cgwY+S1+WP2Lab6vry/6DZ9itrWIJAIqNsQENm/ejD/++AOxYsUywm7y5MlDnFcJRcCdCUjgDcHZT5s6Ob6fNQK/rZmFtk1rYdSkObh3/34IciqJCIiAqxH4cf1mzBrfD6+8Es80nR4a7ty9a7a1EIGXSYBa3Q0bNiBmzJioXr06UqZM+TKbo7pFwKUIuIrA+1KhJnglPl6JHw+eHh54NcErsNk88Pix70ttU6DKx40DbDagWTPoTwREIOwEvGLHtgSKGP4KsMHmb187IvAyCMSNG9e6NmOiatWqSJMmzctogsvX+d/tO+g9cBSq1WuJslW+QauOfbBt+98u3y914MUEJPC+mJFJsWvPfmPSULl+e/Tr2gzx4j5zTG8SaCECIhAtCCR6NQH+PXjU9IXmDN/OWYo3Mr5u9p1joVa4K4F33nkHrVu3Rrp06dwVQbj6/c+/h1Dgk68xaMRELF2xFmvXb8Lk6fPwWekaZh2uwpXZ6Qm4jMB78PAGnsMjAAAQAElEQVTxQDBpWxsoMpIi3sv+ljFp+HZ0LwwZPQ3Xrt80Nd25cxvOEB4+fGDa8+jRI3Dbx8cHoQ0PHjzw1xdv70ehLoN13r9/D/fu3cX9+/f9lRceTiyPZYc+eEdYG8LTfse8d+/eQUDWjsfdffvhw4cRcs54rZgfRSgXPTo0xPcr14P3l0IlauH02Qto1ahaKEtRchGIHAKxrRGIyCk5epd69+49lK/RGEePnwzUUT43W3fqiw0b/wh0TBFOTiAUzXMZgXfExDmBujVgxNRAcZEZ4enhgayZMyD5a0lx8MgJU1W8ePHhDCFWLC/THtp2cdvT0xOhDZzx69iXGDFihroM1hk7dhzEiRMXsa0bs2N54dlmeSw79CGGU5wfx77HjRvPzK52jNP2s99RrFixIuSc8VoxP4pQLhImeAVd2zTA6oXjsHTOKPTs0AgJLa1vKItRchEQASciMMnS5J46fTbYFnE0p13X/sEe1wHXJ+Dh7F04c+4i/tr1D27fvmvW3GbY+McOPLA0QVHR/iPHTuHuvSeT1M6cu4BjJ88is4Y4owK96hCB8BIIU/77Dx7i2IkzOH7yjN99J0wFKZMIiIBTENi1e98L23Hw8DFoguoLMblsAqcXeHfu2Q/a0F24dMWsuc3w629/GS1MVJA/e+Eyvqra3NjwVmnQEZXKFkfSJImiomrVIQIiEMUExkyZh1JVmoFr3mvsIYqboepEQAQikMCef/a/sDRqeff9e+iF6Vw3gXu33OkF3lKf/w8Th3VD82+qmjW3GXq0b4gc72SJkrNXOP/7WPf9ZGxZOwebVs5Ala+LR0m9qkQERCDqCaz79U8snT0SU0f18nfPifqWqEZ3JHDu3Dlj4++OfY/MPn9UIM8Li48TJzZy58r+wnRK4JoEnF7gtWOl4Mthxt3/HARNGuzBflxrERCB8BNQCUDiRK8iTmwvoRCBKCdw9uxZzJw5E5MnT5bQG8H0S33x6QtLLFGsCDw8XEYsemF/lMA/AZc5s9PmLEWZ6i0x7tsF/kwb/HdHeyIgAiIQPgL1qpVFh14jMHnmYn8hfKXCfKq4WsNOqNGoCzZt2Rlkcd4+Phg2bhaKl2+E/J9Xx4LvfwwynSKjHwFqdmfNmgV6KXnjjTfMxNbo18uX16NPPy6IEp8XCbYBiRMlxICe7R2PazuaEXAZgXfL9j1m1vTkET00zBjURdikCeDrC4wZE9RRxYmACISQwE+//IEDh477TVQNYbbnJjt5+jxmLViBScO7Y3DPVug3bDI4YhUwE9PsO3AE44Z0xaaV01Ew73sBk2g/GhKgsEvNLoXdXLlyoXjx4tGwly+/SzMmDEXrpvWM9yHH1nz4QU789MNspEqZ3DFa29GMgMsIvIkSvgKbzRbN8Ks7Lk1AjY+WBPiRmcUzhqNlw+poULO8XwhPZ3/7cycKF8iNeHHjIEXypMa94V87/0HAvzU/b0arRtWRMX1qxIgRA2lSJQ+YRPvRjICjsJs9e3aULFkymvXQeboT1/r99enWBhePbseOzSuxcc1CnNj3OzasnI+3srzhPA1VSyKFgMsIvLG9vNC131j8+tt22fBGyqWgQkVABEggTeoUZliZ2xEVLl+9hlQpkvkVR0H20pWrfvvcePz4MS5dvoalq9ajaOl6aNphAE6ducBD1uCNL3x8vMMdWFhElKMynpyLx499wnVOTp8+bWx2qdl9++23UapUyXCV9zLPS0TVHV6mIWlHrFgxkDlTOryX420kTpQg3Mz5u1JwfgIuI/BeunINV65dx4Kla2TD6/zXlVooAi5L4NUE8VG5fgcMGTsjQm14bQ6TYWy2oEerHj56hEzp02L5vDH4vEh+DBg51XCkuyRvb2+EJ/j4+BjBOTxlKK+3v3PAlxRyDQuXS5cuYc6cOebl6s033zTCbljKiU55yJLB1fpkfqRaOD0BlxF46YosqOD0hNXApwS0EgHXIJAxXWp8Vfx/ePWVeBHW4GRJEuPGjZt+5V27fgOvJU3it88Nzg5PmjghCuV/35g+fPxRHvCjN/ZjXl6x4RWOECuWlzELC08Zyuv/HMSIERPkGhYuKVOmQrp06ZAxY0ZUrlwZXuE4t9ElL1nGjBkLXi7Ggr9RBecn4DICr90NWcC18yNWC0VABFyJgKPdruN2ePpQMG8ubP5zp/k65LXrN/HvwWP4MPe7pkgKtVctAZg7Bax0vMdxe9vOf8ywK7cVohmBp92pUqWKEXaf7molAiIQiQRcRuC1f+2I6zGT56N5x4EYO2V+JKJR0SIgAu5EgG7I+EVHroMK4WGRLm1KlClRFHWb90DLzoPRqnENxIoZ0xQ5aeZibN/15LOnjWpXwKY/dqJW025YtmoDOreqZ9JoEX0JxIgRI/p2Tj0TASci4DICr6M5w6wJ/TBn0gBkSJfGiVBGaFNUmAiIQDQjUKF0McyZOAC8f/HrjfbuDenVBsWKFDC7tB8e2b89Zoztg1EDOshLg6GihQiIgAiEn4DLCLwBu5opfVrcuPlfwGjti4AIiECYCNB8IcVrSVE4f24/V2SMYyjwYa4wlalMEUFAZYiACIhA+Am4jMBLuzbH8OP633Dx8pXwE4guJYwbB3Dmd7Nm0J8IiEDYCYyYOCdQ5gEjnnhLCHRAESIgAiIgAi5BwGUEXtruOgZ+DalvlyfCnUuQViNFQAScmsCZcxeNj+/bt++atf0Fe+MfO8xkM6duvBrnlATu3buHzZs3O2Xb1CgRcDcCLiPwOtrwcnt43/bGX6W7nTD1VwREIHII7Nyz3/j45sQ1x5frX3/7C13bNIicSiO+VJXoJAQePHhgPiqxYcMG/P77707SKjVDBNyXgMsIvHS8fuDwcSxZ/pMJB4+cME7U3ffUqeciIAIRSaDU5/8DX6abf1PVrLnN0KN9Q+R4J0tEVqWyojmBR48eGWH34sWLiBs3Lt56661o3mN1TwSckYD/NrmMwDto9HQ0btsPu/YcMKFRm74YOnam/95oTwREQATCSYCCbziLUHY3JsCvhM2dOxfnz59HnDhxULt2bSROnNiNiajrIuAcBFxG4N2+6x8smj4U/bo2N2HRtCH4c/se56CoVoiACLgkATVaBCKawPz583Hy5El4eXmhZs2aSJo0aURXofJEQATCQMBlBN5YsWKCn9209zFpkkSIGdPTvqu1CIiACIiACLxUAvPmzcOxY8cQK1YsI+wmT578pbZHlYtAKAhE+6QuI/AmSZQQ479dAPvM6TGT5yJ5Mr05R/srVB0UgZdIwOfxY5w4ff4ltkBVuwqB5cuX4/Dhw+CX06pWrYqUKVO6StPVThFwCwIuI/D26tgYV67dQI+B4024cfM2OJnELc6SOikCzkDATdowcNQ03L5zF7f+u40q9dujWft+mLVwhZv0Xt0MK4FcuXIhduzYqFy5Ml5//fWwFqN8IiACkUTAZQTexIleRfd2DbF64XgTurX7BoyLJC6uV2yTJoCvLzBmjOu1XS0WASci8O+Bo4gfLy62/LUb+T7IgQXfDsGadZucqIVqijMSSJMmDVq2bImMGTM6Y/PUpggmoOJcj4DTC7z0xDBvyepAZGcvWmlMHAIdUIQIiIAIhIOAh+eT2+LO3fuRPVsWxIsbB54xYoSjRGV1FwKcqOYufVU/RcDVCDy5sztxq//Y9jcqlP4sUAsrl/0cm7fsCBSvCBFwDgJqhasSSJMyObr0G4OtO/big/eyGfMG+Lpqb9RuERABERABEnB6gdfT0rZwEgAb6xgY9+Cht2OUtkVABEQg3AQ6t66H0l98jPFDu+CV+PFw4+Yt1KxcKtzlqgARcFsC6rgIOAEBpxd4vWLFwr379wOh4qSSOLG9AsUrQgREQATCSsDbxwetuw6xNLvvIFWK10wxaVKlwKf/y2e2tRABERABEXBNAk4v8JYu8TE69R6Ny1eu+RG+ePkqulpDjqVLFPGL04ZLE1DjRcApCMTw9DRupYJ6yXaKBqoRL5XArl27cOXKlZfaBlUuAiIQNgJOL/CWK/UZ3s6SAeVqtUGVBh1QoU4bVKzTzorLiHKlPg1br5VLBERABIIhQKG3fK22GDRqGibPXOwXgkmuaDchsHv3btDX7syZM3Hv3r1I7LWKFgERiAwCTi/wstMNapbHygVjUfnr4qhdpYzZZpzNZuNhBREQARGIMAJ8wS5VvDASJXwlwspUQa5N4MCBA1i2bJnpxNtvv404ceKYbS1EQARch4BLCLzEyckjJYv9D8U/KWh8ZDLOXYP6LQIiEHkE+DIdVIi8GlWyMxPg19MWLlxomsiPSxQvXtxsayECIuBaBFxG4HUtrC+htePGAdR4N2sG/YmACISPwL4DRzFz/nI/cwaaNoSvROWOJAKRWuyxY8cwb948U0f27NlRsmRJs62FCIiA6xGQwOt650wtFgERiEQC0+Yuw+DR07Bs9QZcvXbTWv+C02cvRmKNKtoZCZw8eRLz5883TcuaNSvKlCkD/YmACLgugegv8LruuVHLRUAEXgKBH9dvxrejeyF5siTo1Koevp81EvcfPHgJLVGVL4vA1atXMXfuXHh7eyNLliyoWLHiy2qK6hUBEYggAhJ4IwikihEBEYgeBOLGjWtckz189Ag+jx8jtlcseNBcKBp0T10IGYEkSZIgU6ZMyJgxIypVqhSyTEolAiLg1AQ8nLp1apwIiIAIRDGBeHFi49Ejb2RIlwZ9h07GmMlzoa86RvFJcILqqNWVsOsEJ0JNEIEIIhBA4I2gUlWMCIiACLgogTZNaoHa3VaNqiFtquTwsjS8XVrXc9HeqNnhIRAzZszwZFdeERABJyIggTcEJ2PXnv3o2HskPilTH/Va9MTGP3aEIJeSiIAIuCKBjOlTI17cOIgfLy7qVCsDuihLljSxK3ZFbRYBERABEXhKQALvUxDPW8W1hjjbNq2Ftd9NQs1KpdBv2OTnJdcxERABFyQwdup8PC+Et0uLlq1FtYadUKNRF2zasvO5xdGMIl+xavD28XluOh0UAREQgaggEB3qkMAbgrOYJXMGJE2cEJ4eHiiY9z08evQI9+7fD0FOJREBEXAVAvEtje7zQnj6cfL0ecxasAKThnfH4J6tzEvz/QcPgyzy+MmzOHT0FGJZw+k2m74mGSQkRYqACIhAKAlI4A0lsKUr1+ONjOkQJ3bsUOaM5ORNmgC+vsCYMZFckYoXgaAIuH5crcpf4XkhPD387c+dKFwgtzGVSJE8KbJaL9F/7fwHQf0NGTsDHVrUhi//8TcdVCLFhZvAvXv38Ntvv4W7HBUgAiLgGgQk8IbiPO3Zdwhzl6xG93bf+OW6e/cOIiqcPnMGf+3YHerwz779/trw8OFD+FhDoaENDx8+8FcOfVCGtgymv29pv+/fv4cHD+77Ky88nFgeyw5LcKz35KlToebLc7Jv/4EI68u9e3cRkLVjG919+9Gjh4b1gUOHw3Sujp84ZfLzWvH7pmuLGgAAEABJREFUoYZiY9+BI2jbbSi+qNjYhHY9hmHfgaOhKCFw0stXryFVimR+B9KkSo5LV6767ds3Vv+8GblzvI00qVLYo8za1xJ8fXy8rd91+AILi4hyXL0M/sZmz56N9evXY+PGjWHm+vixT5jzujrDyGq/KzLl78pf0I5TEpDAG8LTcvnKtSf2fYM7IW3qZw+j2LHjIKICJ8cNGjERoQ0z5n7vrw2cWezp6YnQhpgxY/krJ7T57eljxYqFWLG8ELC88HBiefbyQ7t2rHebpVULLV+mn7tohT82jmWGdtvLKzZixIgZYeWFtn5nT+/pGcOwWbLsx1D/FniutmzbZfJ7eHggLH/9hk9BurQpMW5wFxP4ex8wcmpYivKXx+bQHpvN5u8Yd27fuYulKzegRuVS3PUXKPDyBTQ8wcd6CY6IcsLTBmfIe8/S7M6bNw/nz59HvHjxkDVrFoS1XY8fP7YEXp8w5w9rvdE1H69RBlfrn78fq3aclkDYnghO253IadiVq9fRpd8YdG5VHymTP9PSsDY+VCMysMzQBpvNBsc22GyBH6YIwZ/NZouQchzbEpHbCONfwDaEpRibzeaPTcAyQ7mvsizh70XMbLbwXcc2W9jyUyhs1qAqMqRLbUJza5ujJgjHX7IkiXHjxk2/Eq5dv4HXkibx2+fGP/sPg+GjL2qCE9boC5jbd+7eM9cLX5TCE/jSaLPZ4GW9cLlr4MvUkiXf4ezZc0bYrVu3LpInTwGvMDLhiyu5hjW/8sWGlwN7sqSixDHOFbb5+1VwfgIezt/El9/CxT/8hL3/Hkbl+u3Ng4gPowuXrrz8hqkFIiACEU6AWrvrN275lcsXXr+dMG4UzJsLm//ciQcPH+La9Zv49+AxfJj7XVPakWOncNUSgPPmzoEta+f4hZgxY2Dz6pmgizSTUItwE5g/fz5OnjwJanYp7CZKlCjcZaqA8BJQfhGIGgISeEPAuVGdin4PIfsDKcVrSUOQU0lEQARcjUDlr79Axbrt0LBNHxOqNOiIauW/DFc3aCJRpkRR1G3eAy07D0arxjWMFwYWOmnmYmzftY+bCpFIgGYMx44dk7AbiYxVtAg4MwEJvM58dtQ2Q0ALEYhKAqW/KIJpY3rhk8IfmjBtTG+UKv5xuJtQoXQxzJk4ALMm9EPh/O/7lTekVxsUK1LAb9++sWnlDMTw9LTvah0OAitXrsThw4cRP358SLMbDpDKKgIuTEACrwufPDVdBEQg4ggcO3EWjdv1w8df1cXQsTORP09OlCv1GehRIeJqUUkvg0C+fPmQMmVK1KlTBy5uxvAy8KlOEYgWBCTwRovTqE6IgAiEl0DfYZPw7ttvoFfHJng9TQoMHj0jvEUqv5MQSJIkCRo0aCBh10nOh5ohAi+DgATel0E9MuocNw6w2YBmzaA/ERCB0BO49d9tNKpdEYXy5UKrRjVw/OSZ0BeiHCIgAiIgAk5JQAKvU54WNUoEROBlErDZbMYVGPTn0gTUeBEQARGwE5DAayehtQiIgFsTOHv+kp/bQbvrQa7twa3hqPMiIAIi4OIE3FzgdfGzp+aLgAhEGIHRAzvieSHCKlJBIiACIiACUU5AAm+UI1eFIiACzkjgg/fewfOCM7Y5Qtvk4oXt2rULZ8+edfFeqPkiIAKRRUACb2SRVbkiIAIiIAJRQmDv3r1Yvnw5Zs6ciXv37kVJnapEBETAtQiERuB1rZ6ptSIgAiIgAtGewIEDB/D999+bfpYtWxZx4sQx21qIgAiIgCMBCbyONLQtAiIgAiEioETOQIBfT1u4cKFpSrly5ZA1a1azrYUIiIAIBCQggTcgEe2LgAiIgAg4PYFjx45h3rx5pp0lS5ZEtmzZzLYWIiACUUzARaqTwOsiJ+qFzWzSBPD1BcaMeWFSJRABERABVyZw5swZzJ8/33ShePHiyJUrl9nWQgREQASCIyCBNzgyihcBEYgoAipHBCKMwPXr1zF79mx4e3ujaNGiyJMnT4SVrYJEQASiLwEJvNH33KpnIiACIhDtCCRKlAgffPABPvroIxQsWDDa9U8diu4E1L+XRUAC78sir3pFQAREQATCROCTTz5BkSJFwpRXmURABNyTgARe9zzv6rUTE1DTREAEREAEREAEIpaABN6I5anSREAEREAEREAEIoaAShGBCCMggTfCUKogERABERABERABERABZyQggdcZz4raFHICSikCIiACIiACIiACLyAggfcFgHRYBERABEQgagk8ePAAv/zyS9RWGg1qUxdEQASCJyCBN3g2rnVk3DjAZgOaNYP+REAERMBVCTx8+BAzZ87Epk2bsH79elfthtotAiLgZAQk8DrZCYnc5qh0ERABEXBeAo8ePTIflTh//jxSpkyJQoUKOW9j1TIREAGXIiCB16VOlxorAiIgAtGTAL+cNnfuXPCzwcmTJ0fNmjURM2bMyOusShYBEXArAhJ43ep0q7MiIAIi4JwE5s+fj5MnTyJp0qRG2PXy8nLOhqpVIiACLklAAm/wp01HREAEREAEooDAwoULcezYMSROnBi1a9dGnDhxoqBWVSECIuBOBCTwutPZVl9FQAREIEwEIi/TqlWrcODAASRMmNBoduPGjRt5lalkERABtyUggddtT706LgIiEJUEFi1bi2oNO6FGoy7YtGVnkFWP/3YBKtVrhy8rNUXvIRPx4OHDINNFp8i8efMiderURthNkCBBdOqa+iICIuBEBCJM4HWiPqkpIiACIuBUBE6ePo9ZC1Zg0vDuGNyzFfoNm4z7DwILsznezYoFU4dg1oR+uHb9Jpau3OBU/YiMxiRJkgT16tUzGt7IKF9lioAIiAAJSOAlBQUREAERiDgCgUr67c+dKFwgN+LFjYMUyZMia+YM+GvnPwj4VyBPThOVONGryGkJv5euXDX7WoiACIiACISPgATe8PFzntxNmgC+vsCYMc7TJrVEBETAELh89RpSpUhmtrlIkyo5nifM3rt/HyvXbkSeXO8wufXT9oWPj3e4AwuLiHJUxpNz8fixT7jPiVg+YWnn4IpM+btSCI6A88RL4HWec6GWiIAIRGMCNo9nt1ubzRZsT32tF9eu/cagyEd5kDd3DpOOcfRTG57g4+NjBOfwlKG83nBk8PjxY0vg9fEX53hc2/55vYgHr1GGF6VztuPmR6qF0xN4dgd2+qaqgSIgAtGRgDv0KVmSxLhx46ZfV69dv4HXkibx23fcmDr7O2Py0LhuJb9oD0tY9vKKDa9whFixvGCz2eAVjjKU1/85iBEjJshVXPxzCSsPsowZMxa8XOwa9fuhasOpCXg4devUOBEQARGIBgQK5s2FzX/uNF4Xrl2/iX8PHsOHud81PTty7BSuWgIwdxYuXYsrV2+gfo1y3I02YdmyZdi3b1+06Y86IgKRREDFRiIBCbyRCFdFi4AIiAAJpEubEmVKFEXd5j3QsvNgtGpcA7FixuQhTJq5GNt37YO3jw9GTpyN5T/+inzFqpnQZ+hkk8aVF/Szu3v3bixZsgR379515a6o7SIgAi5MQAJvCE7e9Ru30LbbUHz8VV0MHj09BDmURAQiiYCKdVkCFUoXw5yJA4zLscL53/frx5BebVCsSAHE8PTElrVz/IVubRv4pXPFjTVr1mD79u2m6eXKlUNcfVTCsNBCBEQg6glI4A0h8y8+K4T61b8OYWolEwEREAH3JvDrr79i27ZtBkKZMmWQLVs2s62FCEQUAZUjAqEhIIE3BLQSJUxgZkzHieMVgtRKIgIiIALuTeCPP/7Axo0bDYSSJUsie/bsZlsLERABEXhZBCTwvizyqjcKCKgKERCBqCZAre66detMtcWLF0euXLnMthYiIAIi8DIJSOANJ/379+/j1q1bOHz0eJgC89vDw4cPQb+OoQ30W/ho5EjAZoNP48agj8LQlsH0jx49gr0tXLNcxoc2sB8PHjwA1ywnIgLLC2077Okd62eb7PGhWZOpYznh3bazPnbiVJium2vXrvs7VxFx/V2/fiNMbTly7IS/toSfjbcpj8xDc47sae1s6cAe+otSAteuXQPtdlnpxx9/jDx58nBTwRkIqA0i4OYEJPCG8wKIESMGzpy9gI7dB4UpML89eHp6WjKrLUyBedkVm80G+uy02UJfDsuwt4Vrmy30ZdhsNrAce2A5ERFYns0WtvY41h/WcsjUsZzwbtvLGzRiYpium737DsLehjt37oWpDF6zVyzB2V7O4aMnwlROrwGj/NpiLys8azsbrm220J9z5mP9Nptub4jiv8SJE4Na3fz586NQoUJRXLuqEwEREIHgCeiJEDybEB3hg5XBZgv9g9lms/kTFMIjjPEhzwZzzWCzhbo9YD72xR64b7OFvhz2g2XY19yOiGCzhb4tNlvEMY6IPtjLsLOx2cLWJ3t+e3k2W9jKsefnmmXabOEvh2WFJ3h6epjfhYeHB2y20LfH03pxZP02mw36i3oC1Op++umnUV+xahQBERCB5xDweM4xHXpKgP4x6ReTLsmWrlpv/GMePHz86VGtREAEREAEohcB9UYERCC6EZDAG4IzGpR/zCyZM4Qgp5KIgAiIgAiIgAiIgAi8bAISeMN4BpRNBERABERABERABETANQhI4HWN86RWioAIiICzElC7REAERMDpCUjgdfpTpAaKgAiIgPMQuHjxImbNmmXcDjpPq9QSERABEXg+gagReJ/fBh0VAREQARFwAQJXrlzBjBkzcPz4cfzyyy8u0GI1UQREQASeEJDA+4SD6y+bNAF8fYExY1y/L+qBCERjAq7atRs3bmD69OnmoyApU6YEPyzhqn1Ru0VABNyPgARe9zvn6rEIiIAIhIoAvyZJYffu3btInjw5atasiVixYoWqDCUWAREQgQAEonRXAm+U4lZlIiACIuBaBG7fvm00uxR6kyZNaoRdLy8v1+qEWisCIuD2BCTwuv0lIAAi4MQE1LSXSoAaXWp2ac6QMGFC1K5dG3HixHmpbVLlIiACIhAWAhJ4w0JNeURABETADQj8+OOPuHbtGl599VUj7MaNG9cNeq0uioBzElCrwkdAAm/4+Cm3CIiACERbAp9//jnSpUuHWrVqIUGCBNG2n+qYCIhA9CcggTf6n2P10G0IqKMiELEEqNGlsEtzhogtWaWJgAiIQNQSkMAbtbxVmwiIgAiIgAiIQGQTUPkiEICABN4AQLQrAiIgAiIgAiIgAiIQvQhI4I0u53PcOMBmA5o1g/5CRECJREAEREAEREAE3ISABF43OdHqpgiIgAiIgAgETUCxIhD9CUjgjf7nWD0UARFwcwLXrt/AiHHTsfmvA/i6akO069of+/YfNlSWLVuGffv2mW0tREAERCC6EpDAG13PbAT3S8WJgAi4JoHtO/cgX9GymDprEU6fv4I1637FuMmzUOjz8hg7fiJ2796NJUuWgB+ZcM0eqtUiIAIi8GICEnhfzEgpREAERMAlCVAMt1IAABAASURBVFy8fAVflK2NU6fOwtfX118fPnwvC65evmjiypUrB7ogMztavIiAjouACLggAQm8LnjS1GQREIHoSeDK1eto2r4/6jTrjs59RuHe/fvh6uhb7xfF7bt3YPOwwWZ7Fgp88A4+fO9tU/ZPm7Yjc+Y3zbYWIiACIhBdCUjgjYwzqzJFQAREIAwERk2ai7y5c2DamN5IkOAVzF28OgylPMly3xKW7919IjDbbLYnkdbyg5xZUDDPu9YWsPbXv7BzzyHs/feA2ddCBERABKIrAQm80fXMql8iIAIuR+D3rX+jxGcfmXaX+PQj/LZ1l9kOy+KLsjUBS8612awFnvzleDsTPs7/ntn55Y9d2P3vUdhsNgwdNcXERcZCZYqACIiAMxCQwOsMZ0FtEAERcHsCd+7es4RPIFHCBIZF2tTJcfnKNbN9/fp1bN26NVTh92278EzUBRImiI9i//vAlPfbtr346++DZttms2HHrt2hKju0bYmu6f/66y9s27ZN7EJ5bQZ3PZAlmQZ33FnjzQ9JC6cn4AQCr9Mzco0GNmkCcFLKmDGu0V61UgREIBABD49nt2Sb7dn2xYsXsWLFilAF2HwBS5jF078bt24bE4Ztfx/AH9v9uyF77PMoVGWHti3RNf2PP/6IlStXil0or83grodVq1Zh9erVLsfz6U9MKycn8OyO6uQNVfNEQAREIDoTiBc3Dnx8HuPho0emm1ev30CypInNdtasWdG3b99QhYL585i8jguaMPz6x9+OUdZ7si9aNf8mVGWHti3RNX23bt3Qu3dvsQvltRnc9dCrVy/06NHD5Xj6+0Fpx2kJSOB12lOjhomACLgbgfx5cuLnX7eYbv/0yx8o+GFOsx2WxaqF3+Kxjy8CuiMLWBYHhurXrBIwWvsiIAIi8FIJRHTlEngjmqjKEwEREIEwEmjZsCpWrN1k3JKdOn0eVcuXCGNJQOzYsdG4cXX4PqcECsNL509CrFgxn5NKh0RABETA9Ql4uH4X1AMREAH3JBD9ep00SSJMGNrVuCXr360F4lhCa3h6ObxPV+zb9hO8fXzw+PETbS+FXG57ecXEhaPb8fknhcNThfKKgAiIgEsQkMDrEqdJjRQBERCBsBHImP51PLhyCPv/+hFVShXE3UsHcO/yAVw7tQcJXokftkKVSwREwLkIqDUvJCCB94WIlEAEREAEREAEREAERMCVCUjgdeWzp7aLQMgJKKUIiIAIiIAIuC0BCbxue+rVcREQAREQARFwRwLqszsSkMAbXc76uHEwTuabNYP+REAEREAEREAEREAEnhGQwPuMhbZEwI+ANkRABERABERABKIPAQm80edcqiciIAIiIAIiENEEVJ4IRAsCEnijxWlUJ0RABERABERABERABIIjIIE3ODKKDzkBpRQBERABERABERABJyYggTeEJ2fRsrWo1rATajTqgk1bdoYwl5KJgAiIgAi4EwH1VQREwDkJSOANwXk5efo8Zi1YgUnDu2Nwz1boN2wy7j94GIKcSiICIiACIiACIiACIvCyCUjgDcEZ+O3PnShcIDfixY2DFMmTImvmDPhr5z8I259yiYAIiIAIiIAIiIAIRCUBCbwhoH356jWkSpHML2WaVMlx6cpVsz979mz88MMPOHPmTJgC89vDL7/8EqYy9u/fj23btpn2HDhwANu3bw9TOVu3boW9LVwfOnQoTOX8/PPPmDt3LubNm++vPJYZ1rBy5cowteXUqVP+2rBp06YwlbNv3z5/5YS1H8w3Z84czJ+/wJR35MiRMLVn7dq1Jj/LW7BgQZjK4DW7ePFiv3JWr14dpnJOnDjhVwbbE96wYMFCU97u3bvD1J7ffvvN5D979qz5TWjhxATUNBEQARGIIgISeEMI2ubxDJXNZvPL5ePjjWRJE6JhrbJhCsxvD+++lSlMZZQrVQT/fvw/zJg+DX9WrYIiH+UOUzmF8uaEvS1cVyrzaZjKyfLG6/D1fWy+g8FyIiKkSpEkTG2pX720vz69907mMJVTunghf+WEp0+PH/vAw8NmyqtW7vMwtSdThtQmP9vh5RUjTGU0tK7ZV+LF8SsnberXwlROnSol/cpge8IbPD09THlffJI/TO354L23TP7Hjx8juvzx9/To0UOEJ6ROnQoTJowPVxnhqT865o0RwxP8PUfHvr2MPvE6573xZdQdnjqjy30muvfjmRTnnD11ilYlS5IYN27c9GvLtes38FrSJGa/atWqUBADXQPOdw2kSZPa/Ea1EAEREAEREAEJvCG4BgrmzYXNf+7Eg4cPce36Tfx78Bg+zP1uCHIqiQiIgAhEFAGVIwIiIAIiEFYCEnhDQC5d2pQoU6Io6jbvgZadB6NV4xpYtmqD3JQFwe7CpSsYMGIqipdvhEr12mHm/OVBpFLUmMlzka9YNXj7+AjGUwJkMWzcLHPt5P+8OhZ8/+PTI1qFl8CVq9fRtH1/1GnWHZ37jMK9+/fDW6Rb5V8UAreUHXuNML9p/q4Z9h046laMwtvZoWNnokSlJqhcv314i1J+dyAQhj5K4A0htAqli2HOxAGYNaEf0qdNJTdlwXDz8PBAua8+xZrFE9Cva3Ms/uEnHD1+OpjU7hl9/ORZHDp6CrFixoTN9swe3D1pPOs1Xf/tO3AE44Z0xaaV01Ew73vPDmorXARGTZqLvLlzYNqY3kiQ4BXMXbw6XOW5U+bQuKUcP6QLtqydY0K2rJncCVO4+5o9W2b06dw03OWoABEIjoAE3uDIPCdebsqCh/Na0sTInDEd+JcpfVpkypAW5y5c5q7CUwJDxs5Ahxa14ct/vr5PY7Va8/NmtGpUHRnTp0aMGDFAbyjhoKKsDgR+3/o3Snz2kYkp8elH+G3rLrOtxYsJ6H7/YkYRkeKzj/MjSaKEEVGUyhCBIAlI4A0Sy/Mjn+em7Pk53esoNbv7Dx3Du9abu3v1PPjerraEutw53raEuRTBJ3LDI/SocOnyNSxdtR5FS9dD0w4DcOrMBTckEfFdvnP3njWSACRKmMAUnjZ1cly+cs1sa/FiAqG537fpNsyY5HB4/tEj7xcXrhQiECUEVAkJSOAlhTCE4NyUhaGoaJnlxq3/0KnPSHRt+w0SWkOo0bKToezU7Tt3sXTlBtSoXCqUOd0j+cNHj8BRgeXzxuDzIvkxYORU9+h4FPSSpkb2amw23fbtLEK6Dsn9vnWTmtjww1QM6tkKBw4fx+xFK6E/ERAB5yGgO18YzsXz3JSFobhol8Xn8WP0HjzBGp6ugUL5ckW7/oW1Q//sPwyGj76oaSa3UAPEbWrgwlpmROV72eVQIEuaOCEK5X8f8eLGwccf5cGRY6dedrOiRf3k6ePzGHyhYIeuXr+BZEkTc1MhBARCer+nOReLy57tTVSv8CX2H9KkNfJQEAFnISCBNwxnQm7KgodGIa7HgPH44tNCyPdBjuATuuERThqyT2jhOmbMGNi8eqYR8NwQR6AuF8ibC3/t+sfEb9v5DzJnemILbiK0CBeB/Hly4udft5gyfvrlDxT8MKfZ1uLFBJ53v+dLGV8gWApHcLj29vY2bizfelOT1sjDBYOaHE0JSOANw4kNyk0ZZ9yHoahol2XH7n1Yv+lPdOs/1mgx6Z5n9bpN0a6f6lDEE2hUuwI2/bETtZp2M27/OreqF/GVuGmJLRtWxYq1m4xbslOnz6Nq+RJuSiL03X7e/X7SzMXYvmufKfTrmq3NPY/rVxPER41KJU28FiEjUL9lL+PK8sSpc4bjvCXyJBIyckoVUgIeIU2odP4JOLopK2wNw/o/6r57AbWY1GRS2xutiERQZzatnIEYnp4RVJrrF0MhYWT/9pgxtg9GDegAeWmIuHOaNEkiTBja1bgl69+tBeLEjh1xhbtBScHd74f0aoNiRQoYAmuXTDTuyH6YOxrN6lfRb9tQCfliysgehh+fGQxVyn0R8sxKKQIhICCBNwSQlEQEREAEREAERCAwAcWIgKsQkMDrKmdK7RQBERABERABERABEQgTAQm8YcKmTCEnoJQiIAIiIAIiIAIi8HIJSOB9ufxVuwiIgAiIgLsQUD9FQAReGgEJvC8NvSoWAREQAREQAREQARGICgISeKOCcsjrUEoREAEREAEREAEREIEIJiCBN4KBqjgREAEREIGIIKAyREAERCDiCEjgjTiWKkkEREAEREAEREAERMAJCbi0wOuEPNUkERABERABERABERABJyMggdfJToiaIwIiIAJhIKAsIiACIiACzyEggfc5cHRIBERABERABERABETAlQgE3VYJvEFzUawIiIAIiIAIiIAIiEA0ISCBN5qcSHVDBEQg5ASUUgREQAREwL0ISOB1r/Ot3oqACIiACIiACIiAnYDbrCXwus2pVkdFQAREQAREQAREwD0JSOB1z/OuXotAyAkopQiIgAiIgAi4OAEJvC5+AtV8ERABERABERCBqCGgWlyXgARe1z13arkIiIAIiIAIiIAIiEAICEjgDQEkJRGBkBNQShEQAREQAREQAWcjIIHX2c6I2iMCIiACIiAC0YGA+iACTkRAAq8TnQw1RQREQAREQAREQAREIOIJSOCNeKYqMeQElFIEREAEREAEREAEIp2ABN5IR6wKREAEREAEROBFBHRcBEQgMglI4I1Muio7wglcuHQFnfqMRIU6bVC5fnt8XbM1du87GOH1BFdggeI1gjukeBEQATcgEFH3gPMXL+OH1Rv8EWvRaRB+3/q3v7iI3pk6+zssWf7Tc4vtMXA8tu3c+9w0OigCrkZAAq8LnTE1FZg8cwk8PDwxa8IAzJ8yGCP7t0f8uHGFRgREQARcisCFi1ew8qfN/trcpF4lZHsrk7+4iNy5fecuVvy4EV8VL/LcYmtUKomJ0xc/N40OioCrEZDA62pnzM3be+XqDeR5Lxtie8UyJNKmToFMGdKa7ckzF6Nj75Fo2r6/pf3tgM59RuHGrf/MsXv372PYuFkmvmqDjhg7dT4eP35sjp0+ewEde41AtW86oXqjzljz828mnou1G3638rTHN617Y8L0hYwy4dZ/t1GsXEOzzYW3jw8KfVmLmybkK1YNYybPRYNWvVC5Xjus+3WLiddCBEQgQggEWUjDNn0waNQ0NOswAOVqtcb4bxf4pVvw/Y8oXqExqjTogJadB4G/e/tB/l4nzViMhq37oH7LXvh77wH7IQR3D7h2/aa5X7C8inXbYs6iVX55/tr1D9p0G4I6zbrjkzL1sfGPHX7H7BvjrLYdO3EabHP/4VNN9LipC7Bv/1GzzfghY2egqdWXLys1xbzv1mDl2o1gG9m3HX/vM+m4oDaW96iajbuYe9W/B5+UwWOOYf3GP5H7vXcQM2YMEx1cOzOlT4t79+7hxKlzJp0WIhAdCEjgjQ5n0Y36ULvKV5g6Zykate1rHmb/7D/sr/cnT5/DwB4tLe3vIKRMnhTT5nxvjk+d/T18fHwwa3w/zBjq6/24AAAJ9ElEQVTXFxcvXcWiZT+ZYxy+K1QgN+ZMGoAxAztixvxlOHjkBK5cvY6B1sOzd6cmmDS8O7y9fRCav3RpU2HyiB4YPbAThlvC9tXrN0KTXWlFQATCQOD+g4cYNaAD5k0ZhD37DuOX3/4ypeTJ9S5WzBuNeZMH4bMi+TFg5Lcm3r7IkC41Jg7vZt0/Wli/+yfHnncPiBPHC/27NjflTR3VCxs2b8XOPftNcWOnzEfD2hUwbUxvrFwwDjmyZTbxjosmdSshoyVYThzWDZ1b13M89GzbFxht9WXi8K6YMmsJrly7YdrYs0MjUBhmQt5X+g6bgnZNa2GmdX9r3bgGOvUeBb6E87hj2LnngL+2PK+d776dRWYNjvC07fIEoq/A6/KnRh0IisB72d/CdzOHo1blUrh6/RaatOuP71f87Jc0T653ED/eExOHIoXyYtfeJ/a9W7fvxT/7j6BZxwEmHD520noYHgQ1tfsPHcPyNb+CGpWO1oPizp371rFD2G09LN97NwsyZ0xnyq9S7guzDumiSKEPTdJkSRMj65sZsXffEbOvhQiIQOQRKJw/Nzw8PBArZkzk/zCnpa19IoR6eHpYL8vfo0WnQeb3fujICX+NKFo4r9lPkighzl+4YgTG590DYnt5WfeXA+g1eCLa9RiO6zdu4cCh46aMXDnewoRpCzFl9nfY++8hJHw1gYkP7YLt97D6kiZVCquMV/BR3lymiHfeyozTZy8+aeM/h3D//gMMHTfT3MNGTJiNm7du49SZ8yat4+Lchcvg/cge97x2pngtCc6ev2hPqrUIuDwBCbwufwrdrwN8kH34fnZ0a9sALb6piqUBJn4EScQGtGlSA9SmMCyYOgT9u7WAp6cnYsSIgfFDuvgdW7lgLMp/9Rng62uO2cuLaaWzbzOf3SSCcaHV/jKPgghEFQHVA7TuMhhvZkoPakcH92yFe5aQ6MjF0+PZ49DD08OMCD3vHrDyp43YsGkrqlcoibGDO6OgJYzevXffFNnim2qgpjVNyuTW6M5MLP/xVxMf2kWsp6YHzOfp4eHvfuT5tI02mw1Z3kjvd//i/e3XFdOQMV0aBPxjeY8cRqqe186H3o8Q03ppCFiG9kXAVQk8+4W7ag/UbrcisOWv3eDEC3b64aNH2GtpbV9Lmoi7Jvz623ZcunLNek75YuHSH5Ere1YTXyBPTkyauQT/3b5j9jkMSLOFeHHjIGvmDBg9eS7sAuzR46eNOcO71jDkvgNH/er77c+dJi8XzBfbKxZox8f9zVsC2+jRZpDHDh4+Dmp53s32BncVREAEIpHA0lXr4e3tbUZv1vy8Ge+9+7Yl3N7H9Zu3LKH0PSRKmAA/b/wzRC149zn3gBMnz+Ldt99ExvSprfp8sOWvv/3KpIaVWtninxTE50U/wu5/Dvkds2/Ejx/XauN/9t0wr3O+k8WYYK3fuNWvjC3WfdJvx2HjjYxpcebcM63t89p5+swFI0g7ZNemCLg0gacCr0v3QY13IwL7Dx5DhTptzcSMz8s1wpHjp9C8QTU/Am9lyYg23YaCLsv40KtdtYw5xnXWzOnBCR/VGnZCrcZdcf3GTXOsV8dGloB7E9Ubdkb52m3QbcBY+Dx+jNeSJjYa5C59x5iJI1t3/GPS2xfVK5Y0k9I4RHrKejjY4+3ru/fumQkyPQeNR4cWdcChUvsxrUVABCKHQKoUyVCjcRczYYwmAP8rmBtxYsdG1XIlULleB2PScPVayOzpn3cPKPPlJ/hx/W/mnsLf+JuZ0vl16JvWvfBp2QZoa92LDh07aUyw/A4+3ciYPi1yvpMVrbsORv/hTyatPT0UqlUiS4DnvIXvV/6MWk274fPyDUGhP6hCihUp4GfiwePBtdPXGt2i2ddH+d5nMgURiBYEJPBGi9PoPp2oU60MVi8cj0nDu2PDD1Mxe0J/pEub0g9AxnSpTZzdZCFhglfMMWpjmzeoirmTB2LOxAFYMX8s8ubOYY6lSvEa+nZpao4tnj7MTEJJniyJOfbZx/nBCTBjB3VCr46N8fuaWSaeiwqli2HJjOHmeF2rXZtWzmC0X2B9nCAzf+oQfPq/fH7x2nByAmqeSxMoUiiP+Q3zt9m4biW/vtSrXtbY//P3XL9GOX+/5S1r5/il48YvP3wLr1ixuIng7gFpUiUH7xcTOdGte0v079YCrIOZeP9Z9/1kDO3TFv26NAO9yTDeMXh6eKBTq3oY3re936Q1tq3AhzlNMpomfPDeO2abC/bH8V7H+429jbmyv4VxQ7pgxtg++HHxRAzu2ZpZAoW3s2SyRrnumslvPBhcO//YttvYC/O+yXQKIhAdCEjgjQ5nUX0QAREQAREQgRAQaNO4Bk6cOvvclDdu3gJHxZ6bSAfdgkB06qQE3uh0Nt28Lw1qlgeDM2AIqDFyhjapDSIQ3QkE1IpG9/6GpX9vZHwduXNme27WEp8V8vN289yEOigCLkRAAq8LnSw1VQScj4BaJAIiIAIiIALOT0ACr/OfI7VQBERABERABETA2QmofU5NQAKvU58eNU4EREAEREAEREAERCC8BCTwhpeg8otAyAkopQiIgAiIgAiIwEsgIIH3JUBXlSIgAiIgAiLg3gTUexGIWgISeKOWt2oTAREQAREQAREQARGIYgISeKMYuKoLOQGlFAEREAEREAEREIGIICCBNyIoqgwREAEREAERiDwCKlkERCCcBCTwhhOgsouACIiACIiACIiACDg3AQm8zn1+Qt46pRQBERABERABERABEQiSgATeILEoUgREQAREwFUJqN0iIAIiEJCABN6ARLQvAiIgAiIgAiIgAiIQrQi4qcAbrc6hOiMCIiACIiACIiACIvAcAhJ4nwNHh0RABEQg2hNQB0VABETADQhI4HWDk6wuioAIiIAIiIAIiIA7EwiJwOvOfNR3ERABERABERABERABFycggdfFT6CaLwIiEJUEVJcIiMD/2a1zFAaCGAiA//+1c4PZNqxAR4UDYpCqkyZAYKKAwjsxNTsTIECAAAECBAjEAgpvTGUwFzBJgAABAgQIEOgjoPD2ycImBAgQILBNwD0ECLQQUHhbxGAJAgQIECBAgACBKgGFt0o2/9ckAQIECBAgQIBAoYDCW4jrawIECBD4R8AsAQIEagQU3hpXvxIgQIAAAQIECDQRGFd4m7hZgwABAgQIECBAYIiAwjskKGsSIEDgS8CTAAECBEIBhTeEMkaAAAECBAgQINBR4HknhffZyAQBAgQIECBAgMBgAYV3cHhWJ0AgFzBJgAABAncFFN672bucAAECBAgQuCdw8mKF92TsjiZAgAABAgQI3BFQeO9k7VICuYBJAgQIECCwSEDhXRSmUwgQIECAAIF3Bfy2Q0Dh3ZGjKwgQIECAAAECBH4IfAAAAP//vA2MaQAAAAZJREFUAwC8FppFdHWSAQAAAABJRU5ErkJggg=="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -4161,13 +4165,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9500a99",
+   "id": "ecb96ccf",
    "metadata": {
     "papermill": {
-     "duration": 0.005006,
-     "end_time": "2026-07-18T20:21:18.850827+00:00",
+     "duration": 0.00492,
+     "end_time": "2026-07-19T03:43:07.898909+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.845821+00:00",
+     "start_time": "2026-07-19T03:43:07.893989+00:00",
      "status": "completed"
     }
    },
@@ -4178,19 +4182,19 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "764e99e9",
+   "id": "94d0c120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:18.861050Z",
-     "iopub.status.busy": "2026-07-18T20:21:18.860926Z",
-     "iopub.status.idle": "2026-07-18T20:21:18.865215Z",
-     "shell.execute_reply": "2026-07-18T20:21:18.864920Z"
+     "iopub.execute_input": "2026-07-19T03:43:07.909775Z",
+     "iopub.status.busy": "2026-07-19T03:43:07.909611Z",
+     "iopub.status.idle": "2026-07-19T03:43:07.914567Z",
+     "shell.execute_reply": "2026-07-19T03:43:07.914196Z"
     },
     "papermill": {
-     "duration": 0.00999,
-     "end_time": "2026-07-18T20:21:18.865588+00:00",
+     "duration": 0.010949,
+     "end_time": "2026-07-19T03:43:07.914812+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.855598+00:00",
+     "start_time": "2026-07-19T03:43:07.903863+00:00",
      "status": "completed"
     }
    },
@@ -4246,13 +4250,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa9b3d88",
+   "id": "a8933455",
    "metadata": {
     "papermill": {
-     "duration": 0.004717,
-     "end_time": "2026-07-18T20:21:18.875079+00:00",
+     "duration": 0.004854,
+     "end_time": "2026-07-19T03:43:07.925085+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.870362+00:00",
+     "start_time": "2026-07-19T03:43:07.920231+00:00",
      "status": "completed"
     }
    },
@@ -4263,19 +4267,19 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "a9c464ab",
+   "id": "3111bd03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:18.885329Z",
-     "iopub.status.busy": "2026-07-18T20:21:18.885208Z",
-     "iopub.status.idle": "2026-07-18T20:21:18.887688Z",
-     "shell.execute_reply": "2026-07-18T20:21:18.887405Z"
+     "iopub.execute_input": "2026-07-19T03:43:07.935336Z",
+     "iopub.status.busy": "2026-07-19T03:43:07.935229Z",
+     "iopub.status.idle": "2026-07-19T03:43:07.937832Z",
+     "shell.execute_reply": "2026-07-19T03:43:07.937532Z"
     },
     "papermill": {
-     "duration": 0.008259,
-     "end_time": "2026-07-18T20:21:18.888119+00:00",
+     "duration": 0.008441,
+     "end_time": "2026-07-19T03:43:07.938327+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.879860+00:00",
+     "start_time": "2026-07-19T03:43:07.929886+00:00",
      "status": "completed"
     }
    },
@@ -4286,7 +4290,7 @@
      "text": [
       "Scale: S (10,000 rows)\n",
       "Fastest-on-Polars categories at this scale: H_string, E_join\n",
-      "Smallest-gap (or pandas-faster) categories at this scale: A_rolling, C_window\n"
+      "Smallest-gap (or pandas-faster) categories at this scale: B_groupby, C_window\n"
      ]
     }
    ],
@@ -4304,13 +4308,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa1b0770",
+   "id": "2e634a8a",
    "metadata": {
     "papermill": {
-     "duration": 0.00463,
-     "end_time": "2026-07-18T20:21:18.897630+00:00",
+     "duration": 0.004866,
+     "end_time": "2026-07-19T03:43:07.948235+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.893000+00:00",
+     "start_time": "2026-07-19T03:43:07.943369+00:00",
      "status": "completed"
     }
    },
@@ -4361,19 +4365,19 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "05ef7f3d",
+   "id": "029a9d1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-18T20:21:18.907786Z",
-     "iopub.status.busy": "2026-07-18T20:21:18.907676Z",
-     "iopub.status.idle": "2026-07-18T20:21:18.909691Z",
-     "shell.execute_reply": "2026-07-18T20:21:18.909391Z"
+     "iopub.execute_input": "2026-07-19T03:43:07.958843Z",
+     "iopub.status.busy": "2026-07-19T03:43:07.958744Z",
+     "iopub.status.idle": "2026-07-19T03:43:07.960635Z",
+     "shell.execute_reply": "2026-07-19T03:43:07.960391Z"
     },
     "papermill": {
-     "duration": 0.007725,
-     "end_time": "2026-07-18T20:21:18.909965+00:00",
+     "duration": 0.007868,
+     "end_time": "2026-07-19T03:43:07.961029+00:00",
      "exception": false,
-     "start_time": "2026-07-18T20:21:18.902240+00:00",
+     "start_time": "2026-07-19T03:43:07.953161+00:00",
      "status": "completed"
     }
    },
@@ -4422,23 +4426,23 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.093783,
-   "end_time": "2026-07-18T20:21:19.931467+00:00",
+   "duration": 15.047147,
+   "end_time": "2026-07-19T03:43:08.880617+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "02_financial_data_universe/22_pandas_polars_benchmark.ipynb",
    "output_path": "02_financial_data_universe/22_pandas_polars_benchmark.ipynb",
    "parameters": {},
-   "start_time": "2026-07-18T20:21:07.837684+00:00",
+   "start_time": "2026-07-19T03:42:53.833470+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
    "source_py_blob": "b544fc9c77a52c8115c416511494f1074f3d84f2",
-   "executed_at": "2026-07-18T20:21:20.358245+00:00",
+   "executed_at": "2026-07-19T03:43:20.991138+00:00",
    "executor": "cpu-local",
    "production": true,
    "parameters": {},
-   "notes": "Ch02 re-verification: S-scale prose describes the stable pattern (Polars leads string/join/lazy; lighter ops noisy near parity)"
+   "notes": "Ch02 re-verification: S-scale prose fix; re-executed with default renderer so figure embeds image/png (renders on GitHub)"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Follow-up to #382. That PR re-executed the notebook with `PLOTLY_RENDERER=json`, which embeds the "Speedup by Category" figure as **`application/json` only** (no `image/png`). GitHub's notebook renderer shows `application/json` as a collapsed JSON tree, not a chart — a regression from the figure's prior `image/png` + plotly-mimebundle state.

Re-executed with the default `plotly_mimetype+png` renderer (kaleido present) so the figure embeds `image/png` and renders for readers. **Notebook-only** change; the `.py` (the #382 prose fix) is unchanged. No book number changes.

Verified: committed `.ipynb` figure output now carries both `image/png` and `application/vnd.plotly.v1+json`; embedded png reviewed (all 4 panels render, labels legible, no clipping). Mirrored to `~/ml4t/code`.

Part of the corpus-wide `application/json`-only-figure class the supervisor catalogued in `notebooks/changes/ch02.md`; this closes the `22_pandas_polars_benchmark` entry.