### PR TITLE
Ch04/03_sec_form4: fix off-by-one in grant-vs-others commentary (95 -> 96)

### DIFF
--- a/04_fundamental_alternative_data/03_sec_form4_insider_transactions.ipynb
+++ b/04_fundamental_alternative_data/03_sec_form4_insider_transactions.ipynb
@@ -51,10 +51,10 @@
    "id": "1456460a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:14.754162Z",
-     "iopub.status.busy": "2026-07-17T13:00:14.753795Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.366724Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.366074Z"
+     "iopub.execute_input": "2026-07-19T15:26:21.206258Z",
+     "iopub.status.busy": "2026-07-19T15:26:21.205849Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.872139Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.871469Z"
     },
     "papermill": {
      "duration": 1.56839,
@@ -90,10 +90,10 @@
    "id": "221b587d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.367920Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.367723Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.369955Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.369594Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.873816Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.873659Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.875382Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.875125Z"
     },
     "papermill": {
      "duration": 0.004957,
@@ -141,10 +141,10 @@
    "id": "2e1366ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.371065Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.370967Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.374475Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.374064Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.876402Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.876333Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.878759Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.878493Z"
     },
     "papermill": {
      "duration": 0.004474,
@@ -186,10 +186,10 @@
    "id": "e3117a92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.375250Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.375151Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.377869Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.377545Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.879592Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.879524Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.881680Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.881467Z"
     },
     "papermill": {
      "duration": 0.027884,
@@ -265,10 +265,10 @@
    "id": "2903a499",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.378626Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.378531Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.380840Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.380522Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.882564Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.882501Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.884150Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.883921Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
@@ -314,10 +314,10 @@
    "id": "fff1b160",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.381584Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.381490Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.384688Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.384416Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.884985Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.884922Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.887408Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.887129Z"
     },
     "papermill": {
      "duration": 0.008265,
@@ -374,10 +374,10 @@
    "id": "9ad52be7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.385856Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.385747Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.389137Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.388803Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.888053Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.887992Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.890386Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.890124Z"
     },
     "papermill": {
      "duration": 0.007231,
@@ -446,10 +446,10 @@
    "id": "9279e36f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.390237Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.390093Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.392701Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.392159Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.891003Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.890938Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.892425Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.892195Z"
     },
     "papermill": {
      "duration": 0.007077,
@@ -501,10 +501,10 @@
    "id": "0b7a1177",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.393529Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.393443Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.410327Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.409646Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.893233Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.893174Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.898649Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.898409Z"
     },
     "papermill": {
      "duration": 0.016473,
@@ -547,10 +547,10 @@
    "id": "559fe049",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.411811Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.411657Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.426293Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.425696Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.899385Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.899323Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.906520Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.906071Z"
     },
     "papermill": {
      "duration": 0.04675,
@@ -629,10 +629,10 @@
    "id": "f7f2abff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.427954Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.427817Z",
-     "iopub.status.idle": "2026-07-17T13:00:16.431845Z",
-     "shell.execute_reply": "2026-07-17T13:00:16.431180Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.907649Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.907547Z",
+     "iopub.status.idle": "2026-07-19T15:26:22.911741Z",
+     "shell.execute_reply": "2026-07-19T15:26:22.911362Z"
     },
     "papermill": {
      "duration": 0.018156,
@@ -669,7 +669,7 @@
    },
    "source": [
     "The two panels below tell different stories. By *filing count*, sales are the most common\n",
-    "insider event; by *share volume*, two equity grants outweigh all 95 other transactions put\n",
+    "insider event; by *share volume*, two equity grants outweigh all 96 other transactions put\n",
     "together — the first sign that trade frequency and economic weight are not the same thing.\n",
     "Note what the volume panel does *not* mean: a grant is compensation, not a conviction\n",
     "trade. It is the largest bar here and the least informative one, which is exactly why the\n",
@@ -682,10 +682,10 @@
    "id": "2b8f44cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:16.433459Z",
-     "iopub.status.busy": "2026-07-17T13:00:16.433296Z",
-     "iopub.status.idle": "2026-07-17T13:00:17.827627Z",
-     "shell.execute_reply": "2026-07-17T13:00:17.826733Z"
+     "iopub.execute_input": "2026-07-19T15:26:22.912790Z",
+     "iopub.status.busy": "2026-07-19T15:26:22.912706Z",
+     "iopub.status.idle": "2026-07-19T15:26:24.302943Z",
+     "shell.execute_reply": "2026-07-19T15:26:24.301196Z"
     },
     "papermill": {
      "duration": 0.01033,
@@ -977,10 +977,10 @@
    "id": "6671667a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:17.830813Z",
-     "iopub.status.busy": "2026-07-17T13:00:17.830449Z",
-     "iopub.status.idle": "2026-07-17T13:00:17.848883Z",
-     "shell.execute_reply": "2026-07-17T13:00:17.847065Z"
+     "iopub.execute_input": "2026-07-19T15:26:24.307815Z",
+     "iopub.status.busy": "2026-07-19T15:26:24.307435Z",
+     "iopub.status.idle": "2026-07-19T15:26:24.326357Z",
+     "shell.execute_reply": "2026-07-19T15:26:24.324841Z"
     }
    },
    "outputs": [
@@ -1059,10 +1059,10 @@
    "id": "ee17748a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:17.852804Z",
-     "iopub.status.busy": "2026-07-17T13:00:17.852424Z",
-     "iopub.status.idle": "2026-07-17T13:00:19.186173Z",
-     "shell.execute_reply": "2026-07-17T13:00:19.184235Z"
+     "iopub.execute_input": "2026-07-19T15:26:24.330823Z",
+     "iopub.status.busy": "2026-07-19T15:26:24.330480Z",
+     "iopub.status.idle": "2026-07-19T15:26:25.700940Z",
+     "shell.execute_reply": "2026-07-19T15:26:25.700231Z"
     }
    },
    "outputs": [
@@ -1257,11 +1257,11 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "10d7d10d44f981d6a798a7d837ae3f99721d8772",
-   "executed_at": "2026-07-17T13:02:14.021535+00:00",
-   "executor": "local-uv",
+   "executed_at": "2026-07-19T15:26:26.765826+00:00",
+   "executor": "nbconvert",
+   "parameters": {},
    "production": true,
-   "parameters": {}
+   "source_py_blob": "c39c887aaab5e3feaa6fca9bb77cee81c5f85473"
   },
   "papermill": {
    "default_parameters": {},

--- a/04_fundamental_alternative_data/03_sec_form4_insider_transactions.py
+++ b/04_fundamental_alternative_data/03_sec_form4_insider_transactions.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.19.3
+#       jupytext_version: 1.18.1
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -266,7 +266,7 @@ summary = (
 
 # %% [markdown]
 # The two panels below tell different stories. By *filing count*, sales are the most common
-# insider event; by *share volume*, two equity grants outweigh all 95 other transactions put
+# insider event; by *share volume*, two equity grants outweigh all 96 other transactions put
 # together — the first sign that trade frequency and economic weight are not the same thing.
 # Note what the volume panel does *not* mean: a grant is compensation, not a conviction
 # trade. It is the largest bar here and the least informative one, which is exactly why the


### PR DESCRIPTION
## Gate-0 re-verification — #375 parser fix confirmed held, one small numeric fix

This notebook was re-signed after reader **#375** (Form 4 date/code misalignment from a document-wide regex). This pass re-verifies the fix under the current Gate-0 oracle.

### #375 fix HELD (independent oracle)
An independent oracle parses each `<nonDerivativeTransaction>` block a **different way** (regex over each block's own serialized XML) and compares field alignment against `parse_form4`'s ElementTree walk: **all 98 transactions across 20 filings match with ZERO mismatches**. Every field (code/date/shares/price) is correctly anchored to its own block — no cross-block interleaving. Headline claims re-derived from raw XML and confirmed: Musk 25 purchases = **$1.0B** vs all sales **$151.7M** (~a sixth); Sale is the most frequent event (58); two grants (519.7M shares) dominate volume; all 83 P/S rows are priced (0 placeholders).

### Sole defect fixed
Commentary said *"two equity grants outweigh all **95** other transactions"*. Total is 98, minus 2 grants = **96** others. Corrected 95 → 96.

### Notes
- No book-facing number changed (Ch04 prose references the notebook only as a one-line pointer).
- Re-executed clean end-to-end under `uv run` (0 error outputs, 2 figures), provenance stamped.
- `jupytext_version` header re-stamped by the local jupytext (1.18.1); cosmetic.