### PR TITLE
Ch04/04_sec_xbrl: assets coverage counts filled cells, not filings (92.3% -> 90.0%)

### DIFF
--- a/04_fundamental_alternative_data/04_sec_xbrl_fundamentals.ipynb
+++ b/04_fundamental_alternative_data/04_sec_xbrl_fundamentals.ipynb
@@ -99,10 +99,10 @@
    "id": "fd3b265a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:26.702510Z",
-     "iopub.status.busy": "2026-07-17T13:00:26.702044Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.049938Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.049343Z"
+     "iopub.execute_input": "2026-07-19T15:39:14.872251Z",
+     "iopub.status.busy": "2026-07-19T15:39:14.871725Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.318554Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.318121Z"
     },
     "papermill": {
      "duration": 1.510552,
@@ -131,10 +131,10 @@
    "id": "0e6bba02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.051768Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.051643Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.053873Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.053382Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.320085Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.319952Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.321478Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.321188Z"
     },
     "papermill": {
      "duration": 0.00363,
@@ -179,10 +179,10 @@
    "id": "7caf492a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.055170Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.055112Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.063658Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.063370Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.322524Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.322460Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.330842Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.330453Z"
     },
     "papermill": {
      "duration": 0.020393,
@@ -237,10 +237,10 @@
    "id": "2757b13a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.064680Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.064619Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.069357Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.069000Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.331669Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.331603Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.335072Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.334773Z"
     },
     "papermill": {
      "duration": 0.006725,
@@ -329,10 +329,10 @@
    "id": "c2d15fcf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.070322Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.070206Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.073732Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.073301Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.336178Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.336118Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.338549Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.338210Z"
     },
     "papermill": {
      "duration": 0.004543,
@@ -423,10 +423,10 @@
    "id": "09cf3a0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.074899Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.074782Z",
-     "iopub.status.idle": "2026-07-17T13:00:28.087602Z",
-     "shell.execute_reply": "2026-07-17T13:00:28.086976Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.339643Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.339580Z",
+     "iopub.status.idle": "2026-07-19T15:39:16.349523Z",
+     "shell.execute_reply": "2026-07-19T15:39:16.349101Z"
     },
     "papermill": {
      "duration": 0.010206,
@@ -472,10 +472,10 @@
    "id": "590d559e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:28.089314Z",
-     "iopub.status.busy": "2026-07-17T13:00:28.089180Z",
-     "iopub.status.idle": "2026-07-17T13:00:29.432088Z",
-     "shell.execute_reply": "2026-07-17T13:00:29.430371Z"
+     "iopub.execute_input": "2026-07-19T15:39:16.350530Z",
+     "iopub.status.busy": "2026-07-19T15:39:16.350453Z",
+     "iopub.status.idle": "2026-07-19T15:39:17.624411Z",
+     "shell.execute_reply": "2026-07-19T15:39:17.622357Z"
     },
     "papermill": {
      "duration": 0.888696,
@@ -567,9 +567,9 @@
            ""
           ],
           [
+           "",
            "1",
-           "1",
-           "1",
+           "2",
            "1",
            "1",
            "1",
@@ -590,6 +590,111 @@
            "1",
            "2",
            "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "",
+           "1",
+           "2",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           "1",
+           ""
+          ],
+          [
+           "",
+           "1",
+           "1",
+           "2",
+           "",
+           "1",
+           "1",
+           "2",
            "1",
            "1",
            "1",
@@ -627,111 +732,6 @@
            "1"
           ],
           [
-           "",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "2",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "",
-           "1",
-           "2",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "1",
-           "1",
-           "1",
-           "1",
-           "",
-           "1",
-           "2",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           "1",
-           ""
-          ],
-          [
            "1",
            "1",
            "1",
@@ -795,8 +795,8 @@
            "",
            "1",
            "1",
-           "2",
-           "",
+           "1",
+           "1",
            "1",
            "1",
            "2",
@@ -828,26 +828,26 @@
           "2025Q1"
          ],
          "y": [
-          "XOM",
+          "IBM",
           "MSFT",
           "ABT",
-          "BAC",
-          "COST",
-          "AAPL",
-          "META",
-          "NVDA",
-          "JNJ",
-          "TSLA",
+          "V",
           "KO",
           "AMD",
-          "CVX",
-          "GOOGL",
-          "IBM",
+          "AAPL",
           "AMZN",
-          "V",
-          "GS",
+          "TSLA",
+          "META",
+          "XOM",
+          "GOOGL",
+          "PFE",
+          "BAC",
+          "NVDA",
+          "CVX",
           "JPM",
-          "PFE"
+          "COST",
+          "GS",
+          "JNJ"
          ],
          "z": [
           [
@@ -911,9 +911,9 @@
            0
           ],
           [
+           0,
            1,
-           1,
-           1,
+           2,
            1,
            1,
            1,
@@ -934,6 +934,111 @@
            1,
            2,
            1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           0,
+           1,
+           2,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           1,
+           0
+          ],
+          [
+           0,
+           1,
+           1,
+           2,
+           0,
+           1,
+           1,
+           2,
            1,
            1,
            1,
@@ -971,111 +1076,6 @@
            1
           ],
           [
-           0,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           2,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           0,
-           1,
-           2,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           1,
-           1,
-           1,
-           1,
-           0,
-           1,
-           2,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           1,
-           0
-          ],
-          [
            1,
            1,
            1,
@@ -1139,8 +1139,8 @@
            0,
            1,
            1,
-           2,
-           0,
+           1,
+           1,
            1,
            1,
            2,
@@ -1241,7 +1241,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAJYCAYAAACadoJwAAAQAElEQVR4AezdCaBMZRvA8WfulVvJUslS9kilpM2S7EpIEi12CdmSpCQkISVUUhJliVS052YN2aNFCNlCSl/K2mK7vvO8zJg77syduXfunJkz/+/znjnre97n98y5d547Z6aEI0cOn6BhwHOA5wDPAZ4DPAd4DvAc4DnAc4DnQCSeAwnC/xBAwCYBTosAAggggAACCMSfAAVI/OWciBFAAAEEEEAAAQQQsE2AAsQ2ek6MAAIIIIAAAgjEnwARI0ABwnMAAQQQQAABBBBAAAEEIiZAARIxat8TsYwAAggggAACCCCAQPwJUIDEX86JGAEEEEAAAQQQQAAB2wQoQGyj58QIIIAAAgjEnwARI4AAAhQgPAcQQAABBBBAAAEEEHC+QNRESAESNalgIAgggAACCCCAAAIIOF+AAsT5OSZCXwGWEUAAAQQQQAABBGwToACxjZ4TI4AAAvEnQMQIIIAAAghQgPAcQAABBBBAAAEEnC9AhAhEjQAFSNSkgoEggAACCCCAAAIIIOB8gfgrQJyfUyJEAAEEEEAAAQQQQCBqBShAojY1DAwB5wkQEQIIIIAAAgggQAHCcwABBBBAAAHnCxAhAgggEDUCFCBRkwoGggACCCCAAAIIIOA8ASLyFaAA8RVhGQEEEEAAAQQQQAABBLJMgAIky2jp2FeAZQQQQAABBBBAAAEEKEB4DiCAAALOFyBCBBBAAAEEokaAAiRqUsFAEEAAAQQQQMB5AkSEAAK+AhQgviIsI4AAAggggAACCCCAQJYJRKwAybII6BgBBBBAAAEEEEAAAQRiRoACJGZSxUARyLAAByKAAAIIIIAAAlEjQAESNalgIAgggAACzhMgIgQQQAABXwEKEF8RlhFAAAEEEEAAAQRiX4AIolaAAiRqU8PAEEAAAQQQQAABBBBwngAFiPNy6hsRywgggAACCCCAAAIIRI0ABUjUpIKBIICA8wSICAEEEEAAAQR8BShAfEVYRgABBBBAAIHYFyACBBCIWgEKkKhNDQNDAAEEEEAAAQQQQCD2BNIbMQVIekJsRwABBBBAAAEEEEAAgbAJUICEjZKOEPAVYBkBBBBAAAEEEEDAV4ACxFeEZQQQQACB2BcgAgQQQACBqBWgAIna1DAwBBBAAAEEEEAg9gQYMQLpCVCApCfEdgQQQAABBBBAAAEEEAibAAVI2Ch9O2IZAQQQQAABBBBAAAEEfAUoQHxFWEYAgdgXIAIEEEAAAQQQiFoBCpCoTQ0DQwCBQAKvv/mOVK1zb6Bd2BYmgZLXVJdPZswNU290owLLvv5W8hS6Rv7777AuOqqFM5hwObV+sKf0fnpoOIeWZX3pz7Zqt92XZf3TMQLRIEABEg1ZYAxZLqA/0PNfeqMMGf5alp/L+wTfrV5nXmTs23/AezXzYRAoWCCflCt7ZRh6ootwC4waM0lq1G8W7m5jtr/m7bpLn2eGRWT823fskmeeGym1GrSQSy6rJDVvby4vvTZejh49mur8a37cKHXubC2FSleSG6reISNGvZlqOwsIIBCTAjEzaAqQmEkVA82MwMR3PpCnenWTd6Z9JikpKZnpimOjRKBh/doy8oX+UTIahoFAdAgsWrZSfty4SRrfcZuMfWWIXF/uahn8wqsy/JXTBcaff+2Thvd2kBuuu1rWrJgpLwzqLS9aBchbb78fHUEwCgQQcLwABYjjUxyHAfqEvOrbH0TfgejcvoWcc3Z2mTN/Sao91q7/SfTt+StvvFX0logy5evIgkXLPfu88PJYufXOVqLvoOj2+zs97tl2/PhxeeX1SXLzLXebvzbqX30/TZ5rtutfInVZF4qVqWL67tDtSV0U3eeuZp2k6JU3m/XV6zWVX3/73WxLa3Lg4CF5ov/zcmO1O6TIFZXl3tZdZfaXizy7fvPdGrmz6YOmv+tuvl36Dhwu//77n9muxdcVN9wix62xmhWnJh0f7ist2/c4tSSmv9satTF96F9EnxvxeqpjmrTobP6K26XHU6JGej49eOyEqaLbNEY9bvALo+TYsWO6ybQTJ07Iy6MnyPVVGoju0+yBh0X/Ql6hxp1mu3ui8QQ6v3s/96O+q+V9C1Z6eXQf537UMfcbNFwe6T1I1OfqinXNX469x753337p2WeIqGnhy28SzZmex93Hob//kUFDXzHPD92uefzw05nuzeZRz6N//fZ1Mxu9JpnJsXajLzDr3nW/jB43xfxFW+PRd/w07x99NlvqN3lASpWrIb2eek6OHDmqh5iWt9j18vyLY8x2jUGfy+9/OMNs8zfZ8NNWadH+Ebn8utqmz07d+5lrTPd/Z9qn5vnnfvdPr5kJk6frJknP0+zkM0nv+aW7z1u4VBrc085cG/q8enLAC/LPP//qJvPcTMs/0DWjBwa6RvU5EOhnhh7vbg/1fFpmzJwvr77xtrnW1WPjpm3uzbJ85Xfm3SK11xh0XJ6N1kwga2vzGf9a3HunvDv+FdGfd/XqVLeKiyek4wNN5f0PP/fsqz8TsmVLlGf6PCLn58ktNapWkgfbNpXXxk727JPWjL+49RrX61uvSe/jftr8s4lZj9P1ei08NWiEdHtsgJS+tpbobUbTPko2P2eGjRwnFayfCdrP+Len6e6p2ldLv5bqdZuad2zqNW4r+vzy3kHd7vTzM9B7P3/z7uvn8X5DPD+r2nbuJXv+3Os55McNm0W3V6jRyDzXGt7XQVavXe/ZrjN6Pb397kdyd8vOZh+9nt774LS97pOR60CPoyHgJAEKECdlk1jSFJj8/idyT6N64nK55L4md8g773+car9e/Z6XQpcUkFkfTZBta7+SQf0elXPOOdvs8+VXS2Ws9QJ7YN8esm3NV/LVrPek/PXXmG06GfrSGPn0i7kyoO8j8uOq2dKre0d5+tmXZObcr6RokUtk/ox3dDf5ed0i2ffLanlj5LNy8NDf8kCXJ6yx3C6rlyXL90tmSJtmjc34zM5pTJo/0N36hfujvDJsgHWeOdL+/qayf/9Bs+euX3fLHdZfMwvku0i+WfSZjBo+QKZaLwJ79nnWbL+jXm35a+8+WbB4hVnWid53/tkX8+Qu66+kurzQ2tat5wBp06Kx6WP0iwPl61WrZcCQl3Wzp71lvTC4tERRWWQ5THpjuFl/4OA/8mi3dvLD8i9k6KAnZMnyb1Pd6jbF8h/28hvS9/Gu8v3SGVLv1hryxoR3zbHuSbDnd++f1mOgPKa1v66b8t6ncuN1ZWXJnGkyYkgf0fg++OR0AdGy/aNWvg6ZvyR/vzRZbq9bwypCOoqa6/FHjhyRpKSz5cUh/Uwuu7RvKU8OGCZzF6QucrVfXzc93rtlJsfufrZs2y5zvlwsjz3cQdo0b2IVem9Lx+595b0PPpN2re+12n0yYcoH8p7Xi1E9Vl/wdW7XQtZ+PUvatrpbtFDWnOg23/a/P/60/nreXq656kr5bNqbMvuTSZI793lyj1UU67uLze6+w1xD115TRvQ5r61Niyamm/Q8zU4+k/SeXzpOfWF7S80qsuqrT+Wdt16WCy+4QI56FcG+/pq/QNdMetdoKM+1V4Y9LfVvqyFdOrT0eJQuVdwT5dCX3pC7GtwmLz7XT/7977CVrz6iL+h1h/SsdZ9gWrbEbHJejhyeXdes2yg3V7pREhMTPesqVbheNm/dLvruiGelz4y/uF0ulzS/906ZNPWDVEdMnfaJlL/hGrnqiss869/7YIYkWsXPC4N7y7Xlykj7h3pbz7c+8vv/9ki/x7tZP1/Lif5RYNOW7Z5jdEYLa71Gv7N+Xl5RuqQ0atbRFLS6Lb186j7BtFXWH3L+/Gu/fDx1jHw+/U3zR6G2nU//wWn/gQNydZnL5f2Jo8zPjJrV9I8SHWX3//5I1f3Y8e9KR+t60p/vze5paOW0r/y8/RfPPhm5DjwHM4OAQwQSHBIHYSCQpsDf//wjH34yU+5qeJvZfl/j2+Vz66+R3n/V+m3371Lu6iulcKGLzV8DGzW4VSrcUM7s/9vuP+SC8/NYvxSvkXPPPUfKWr98OrVrbrYdPnzE3Fs90Co+alm/iHLnyim33VJVWlsv/Ca+c/IvvmZHn8mf1l/U9H7smyvdIHly55JiRQtZL/ybiH6mwWdXs7ho6UrR9tqLz0jFG6+1XkicK7WrV5a7raJKd5g09UOz7sXn+kreC8+Xm6wXEv16PST6wv+PPX+ZmG6rXc046P7aPp/5pehfQOveUk0X5cVX3zJFzX2NG5g+brSKrCd7djIvyM0OpybXli0jPbo+YExy5TzPrH30oQekUvnrRJdrVr1Jej3yoHXuT802nbw99SPrxUlDadSgjolX/0Jb2RqjbnO3YM/v3j+tx0B5TGt/XVe7RmXRF8ya41tq3Cy1LNeV367RTfLVkq+tom+dvGoVdNdfe7X1ojaPtG15j1xnvWj64NNZZh897rGH20uZK0oZE82JvvB/d/pnZrt7kpabe5s+an61ZTTH2oe2Y8eOy9TxL8u91vNc86IvfL9a/LW8PXaE5X+ryc0tNW+Wb75bq7t7WvN77zAvkvU5rDHqcfpXXM8OXjP6Yr7sVaVF4y51aVEpXrSwDHn6cVn34ybj5bVrqtlgPFMdcGpB4wj0/NLnTlPrDwvdOraWfBddKJcWLyp6jMZyqgvx9U/vmknvGs3Ic809Ft/H/r27yUMdW0mTO+vKkP49RV9464tx3S+j1nqsu61bv8lcxx1P/dzS9dr/+dY7HzrvbhdekMfM/vb7/8xjWpNAcbdqepfoOzvudya0GJ067TNpav1M8e6rXNkrrIK9r+gfRl4c0lcuLpjffD7lBeuPF7fXrSmjhj9trrVvvz95HbqP1QLuunJXyUV5L7Ceb4/JWWdlk48+O3kdppdPdx/pPSYmJpg/ROjvAi2ahjz9mPk5sH7jFnOoPg9b3tfI/HFJ93m4Uxu56srSkjxrvtnunmgRr78T1FjficqX90L5dvXJay6j14G773Qe2YxAzAgkxMxIGSgCGRD40HqhWLTwJdZfa68wR+svO33hry/OzQpror/4u/caKHqLjN4q9O33J39RWJtEX5T+sedPqVGvmeitNu9af0nWW2V02zbrL1pahNzWqI3obRXu1n/wi7Lt59N/7dJ9vZsWHJUr3iC3NGxl/bX8BfMOi96u5b2P9/zmLT+bX9L6wsp7vXt+y7YdUqXyjZ53bXS9jlsft/68Qx+ksVWAadHxn/UXVl3x4Wcz5c7bb5Wzz07SRdm4aasMfH5kqjhq39FS9Baj33affkGiLx7MAV4TvYWk2QMPy+XX1zbH620Ju3//Q9y3wGzbvtP8kvY6xPorYmnvxaDPn+ogn4VAefTZ1bN4ifXix7NgzVyU93zRfFuzssX6a7AWsHmLXW/icud35pyvxPuvmVOnf2puX9Jb43Sf50aMlp2//KZdeJq321ODRqTqb8fOXyUcOdaT6bssSUnZdda0Yta7cJeVKm69WDvLLOukc+BDYAAAEABJREFUiFVo7/nrL531tKuuvNwzrzNly1whW3/eqbNnNPMuy/wlqWI4v3A5USu9Js444NSKYD1P7e55SO/5pc/d8teX9eyf1oy3v25P75pJ7xptYhUL/n5maP+htDJe7w4Us4o5PfaPP0/mJ6PW2oe2JctXmVvTHmh1jym0dZ02l8ulD2k2l7hk/4GDqfLb/YmBZt9AcesfPxrUrSV6PejOs+Yust49/FvuaVxfFz3t8ssu9cy7XC4pUayIXFH69LpE610ZfXHv/UciPaCs9ccffdSWPftZVtF/mec5ml4+9ZhgWkmrePUuXK8uU1pcLpf18/zktaA/0/TW1Op1m8pFxa0/IBW6RvQdON/rXX/PeJ8vf7681s+VUzkN8ueK9/HMI+BEAecVIE7MEjFlWED/Aqff9qIvDN1Nf2G8bb1r4O70yZ5d5K3RQ6WIVagstX5h67fH6Oc6dLv+RXXRrPel2T13WC+w/pUhw0dL9br3id4a4XK5dBdZNu8Dz60VeruJtuVffmi2+Zt8MPk16derq5ydlGT9wv5cKtRsJIuXrfK3u/kl6HejtUF/aVsPnn+J2U7fWqEr3e90fDFngbltYfa8xXLXHXV0k2kul0uGP/vkGXFoLN7vzJxzqmAxB1kTfYF0d8sucu9dDWTWRxPlz+3fSvIHb1lbRI74fOuOWeln4nIFd34/h5vVgfJodkhjkpBwMoepN50wiy6Xy/xFXQ18m94Koju998Hn5vMTTz3xkHy94GPj1/fxh86I3dut64OtrX0/8bQihS/WrjKdY+0km/XiTR/dzeVypbrNRqz/uVwuzy0+1qLff+7bgHx3cLlc0rhhXROrr4u+QPXd373scqXv6d7X/Rj08yutNLo7sR69/a1F8y+9aybQNZqR55o5aRoT75y5XCcDcdu7XBmz1tPoX+31Vp8uHVrJU09001WeViD/RebngGeFNfPnX/usqcglF+cXfRH+9YLTz9EnenQ029KLu2XTRqK3MOofOt794FNpWP8WyXHuueZY9ySbz88mK0RJSEj988rlCv05mujz3Pf9Geg+f6iP2bJl81wvTw4YJt+vWSevWO/S/PTdPHMN6Dsdvj/rEhISzjjNiZM/Vsx1rr9XfK8dXXb/XDnjYFYg4ECBM68SBwZJSPEpoB/eXLriGxk/+gX57P1xnjbdevGvf6nVbW6ZOrWqiN469N7EUdKzWzv56POTb+3rdv1rVof7m1pv+z8uy+Z+IDusv26v+naNXFq8sHnXYd6Cpbpbmi3JKjB0g96OoI/upu886O1O+sLgy8+nmG+qmTl3oXtzqseSlxYz9yJvPfVuRqqN1sKlxYvID2s3WHOn/333/Y9moYT110WdOeuss0RvQ/vos9nmtgX9zEvVyuV1k2lXli4pX361zMyHMvn2+3WS98ILrBcatc1tCfoiYM26jam60Ft01v6Yep3vPhk9f6oTWQuB8mhtDulf6ctKmELTfUtJWgcvX/W96O1kesuevqjTfdasS50LXefd9MXHZSWLibvptnDkWPvJaFv7Y+ox/7BuvWje0uqvdKlLRf+y7v6Sg7T2Ofvs7HIi5dQrrlM7BON5alfPQzDPr9KlSsjKb37wHBPMTDDXzNlWsR3oGg3luZaUPUncRUUw43PvUzoIa/e+3o96G9ddzTtKv8e7mtvRvLfpfMUbr5El1h88vMekf3zRdxn0tlDdx/381McC+S7SVaYFirtm1Uqix7/97ofmVlf9w405KAyTH7yuqyNHjsq69T9Zz9FCpudg8ml2TGeyedt28+6Pe7c11s8yvV22eLHCZpX+N0luv62WXH1laXNrq74Dvm7DJrMt2ElGroNg+2Y/BGJJgAIklrLFWEMSmPL+R6Kf7WjU4FapctONnqafn6hVrZJMee8T059+Y9S3p2670g+f6mcA3C++9D++9va7H5lbkXTnr5asNN/wVLxYIdG/jPXs1sF8f/470z41H/TWF2XTP/5CJr938oPuhQsVlKSk7LL2x5/0cNPWb9wsw195U37ZdfI2Hb2dZ4v1tnzxoid/mZqdvCY6dr1trFP3fuYbc/S2qLkLloh+e4zupvck6208+t3/etuCfnh84NCR0vyehuZ+ad1HW+M7bpNZ876St9/9WBpb7364XCf/2qrb9EPk+k09Q4a/JjoeLZj0nSL9diTd7q/p7SO/7v5d9F0m3Uf7GPn6RJ31NP2rqFrr/dr6bWRqpePw7GDNZPT81qGef4Hy6NkphBm931v/utnl0aes4myp6F919cOm+g1eeluQdnX1lZfJN9ZzRz/kry9U9L+lMPvLRboppBauHId0Uq+dp07/3HxTk95689bb75v5Ns0be+1xerZtyyZmoX233qIvCvW5os9pff7p8bqxuFX47vjlV9F867K2YDx1P+8WzPPrkS5tRZ9T+rzTdyb1XRO9vtxj8e7PPZ/eNaPxaB/+rtFQn2slrJ8X6zduCfkrwIOxdsckImb2+x9+lAZ3PyCVK14vWtjqZ4vczexgTe5uVN98SL/PM8PMOyH6rX/jJr4vD7S+x9rq/196cbtcLuvd4jvlqcEvSckSRUR/bkmY/jf0pTGiP6f1c21P9B8qR48ekyZ31jO9p5dPs1MQE5fLJT16D5ad1nNXv7mr99MviP6h5srLS5qj9Zasr5Z8bX4H6M/aTo/0S1WwmJ3SmWTkOkinSzYjEJMCFCAxmTYGnZ6Avhh85/1PpUG92mnuqus//nyO6H3r+oHMek3amnue9asw9QXVM326m+POO+9c8/WZ+h/r0lu4OnbvY77WUr+FRXfo0bWt6O03b709Ta6uUFeq1LnHFB85zj1HN0vO83KIvkC64972pn/9dqFzzzlHFi5eLldVuM2su77qHVKndlXRDy+bg9KY6DdOlb3qCvM5FR1Luy5PeF7MFLqkoHw+bZzoN7hcd/PtomOsVf0mGTb4yVQ96QsSvZ1K/6LfyCpGvDfqL0V9l+hr6y/JNW9vLldcf4tVJI2TI0cOe+92xvyV1i/mV4c/I52t4ki/mnL4qHHitnPvrIVQz4c7yKCho6RYmSqmcHqwbTPJlSuXexfJ6Pk9HVgzgfJobc7Qv4lvDJdba1aRJ58eJpeWrS5N739YvlqyQs6z8irW/zRn9etUl1q3t5Dy1RuZQvORLg9YW0L/F44ch37Wk0c83r2DDHtlrPkK5rcmTRP9tjZ94XVya+rp+Xlym9vt9Hncsn0Pk9Me1ou2Ldt2yFnZspmda1SpKGWvutxs0+vG/TW86Xmag70mwTy/qt1cQd6fNEq+mL1A9Gugr69yh7m+3GPx6s4zm941o7EFukZDfa7pN0Rt3/GLXFDkWlGPjV5fw+sZVBozwVj7HqbfdqeF8nTrDyH6tb7ezb2vvkuh17t+GcHV1s8h/ca8hzvfL62bNXbvkuZjMHG3vO9O0T/E3Ovz4fM0OwxhZY8u7aR5u0esn5t1ZMNPW+Sjd14XjUO7SC+fuk8wrdzVV8pV1h8VKtZsLPUbtxV9V3PsqCGeQ5/t/5j5uXtT7cZS9bZ7pbT17ltN649Znh2CnAn1OgiyW3azVYCThypAARKqGPvHhIDecrTlh4Vp3n6gAbS8r5Hs+mmZuT9Z/2Nduzd/be7n1ftwP31vrFxycQHdTWpVu0n08xy6Xpt+nW77Nk3NNp24XC5TOMz99G3Tn34NqH6FY6MGdXSzaU/06OTpW1/Y6dfz6jm0P236uYmXhz51xr365uBTE30hot8So1+zq8foOO5tfPuprSL6lafa5471S+TbxZ/LwL6PmtvDPDtYMy6XS/Qrf/X4q664zFqT+p/+FV5/qW9ds1A2fjdPtL9+vbp5dtJb17yX3Rua3FlXFs1+X1bM/0j0djL35wPcLw5cLpc83KmN+XpfPbeeQ79px/cdn/TO7z6f+7HjA83M1yK7lwPl0b2P92Na8Tw3oJdMHDPcs9t5Oc6Vp5/sbp4D+nzRr1V+f9Kr4vbTe73V5Lsln4u2t157XvTFvO7n7iSt87i3eT9mNsePPvSAfPHheO8upfejnUWfj94rBz/VU6aMe8l7legLOB2z5mfxnGlyz131U23fvHqBuc3OvVKfw/pcXr00WfQ5p+edOGaY+aY43Udd9Lzanzb31/Cm56nH+rb0nl+6v37pgo5Bx6Ln0+fuuaf+CODPP9A1o/FpH9qXNt9rNNTnWvGihc11qX1pK12quCm6df7ss5M0BNP0g9y6Tm+FMiusiY4lkLW1S6p/3a1CQvtIq3nvWOaKUjLr44nyy8Zl5uuLe3RNv3AOJm59B0rfHb7P6+eT+7xp5UILIb391b2PPupzseuDrXTW43TbLVVl/ao58vuWleZzZpo/s8OpiS5rzvQ5kNbPQH1+Dnn68VN7+394pEtb87N8+4+LZcLrL0j+i/J6dtbbJ8eNes58fuvHlbNFx63Xkl5T7p32/PyN+ZZC97I+fjXrPdGfVzqvLb3rQPddOPNd3ZWGgGMFKEAcm9rIB8YZEUhLQP8aOvSlN8zXi+oHXfX7/N+e+pHc36JJWruzDgEEYlRA/6OXL456UxrUrSX62bkYDYNhI4BABAQoQCKAzCkQiGcB/WC6fnhT/yvuV1WoI9M+Tpa3Xhtq/rIZzy5hjp3uELBVQD8rV6BkBetdsHPluWfSf6fB1sFycgQQsF2AAsT2FDAABJwtkD37WeZ+bb0l5LdNK8xtWg3r13Z20DEUXVq3jMTQ8BlqlAjoba1/bFt1xm1LUTK8dIeR1i2M6R7k2YEZBBAIVYACJFQx9kcAAQQQQAABBBBAAIEMC4StAMnwCDgQAQQQQAABBBBAAAEE4kaAAiRuUk2gDhYgNAQQQAABBBBAIGYEKEBiJlUMFAEEEEAg+gQYEQIIIIBAqAIUIKGKsT8CCCCAAAIIIICA/QKMIGYFKEBiNnUMHAEEEEAAAQQQQACB2BOgAIm9nPmOmGUEEEAAAQQQQAABBGJGgAIkZlLFQBFAIPoEGBECCCCAAAIIhCpAARKqGPsjgAACCCCAgP0CjAABBGJWgAIkZlPHwBFAAAEEEEAAAQQQiLxAZs9IAZJZQY5HAAEEEEAAAQQQQACBoAUoQIKmYkcEfAVYRgABBBBAAAEEEAhVgAIkVDH2RwABBBCwX4ARIIAAAgjErAAFSMymjoEjgAACCCCAAAKRF+CMCGRWgAIks4IcjwACCCCAAAIIIIAAAkELUIAETeW7I8sIIIAAAggggAACCCAQqgAFSKhi7I8AAvYLMAIEEEAAAQQQiFkBCpCYTR0DRwABBBBAIPICnBEBBBDIrAAFSGYFOR4BBBBAAAEEEEAAgawXcMwZKEAck0oCQQABBBBAAAEEEEAg+gUoQKI/R4zQV4BlBBBAAAEEEEAAgZgVoACJ2dQxcAQQQCDyApwRAQQQQACBzApQgGRWkOMRQAABBBBAAIGsF+AMCDhGgALEMakkEAQQQAABBBBAAIgX0rEAABAASURBVAEEol8g9gqQ6DdlhAgggAACCCCAAAIIIOBHgALEDwyrEUDgTAHWIIAAAggggAACmRWgAMmsIMcjgAACCCCQ9QKcAQEEEHCMAAWIY1JJIAgggAACCCCAAALhF6DHcAtQgIRblP4QQAABBBBAAAEEEEDArwAFiF8aNvgKsIwAAggggAACCCCAQGYFKEAyK8jxCCCAQNYLcAYEEEAAAQQcI0AB4phUEggCCCCAAAIIhF+AHhFAINwCFCDhFqU/BBBAAAEEEEAAAQQQ8CsQdAHitwc2IIAAAggggAACCCCAAAJBClCABAnFbgjYKMCpEUAAAQQQQAABxwhQgDgmlQSCAAIIIBB+AXpEAAEEEAi3AAVIuEXpDwEEEEAAAQQQQCDzAvTgWAEKEMemlsAQQAABBBBAAAEEEIg+AQqQ6MuJ74hYRgABBBBAAAEEEEDAMQIUII5JJYEggED4BegRAQQQQAABBMItQAESblH6QwABBBBAAIHMC9ADAgg4VoACxLGpJTAEEEAAAQQQQAABBEIXyOojKECyWpj+EUAAAQQQQAABBBBAwCNAAeKhYAYBXwGWEUAAAQQQQAABBMItQAESblH6QwABBBDIvAA9IIAAAgg4VoACxLGpJTAEEEAAAQQQQCB0AY5AIKsFKEAyKZySclxivQ0Z/prQosMgT6FrJNZbrF8POn6uh+i4HjQPsX496Pg1Dlr0PKfIhf250J+zsd4y+fIx7g+nAPH7FGADAggggAACCCCAAAIIhFuAAiTcovSHAAKZF6AHBBBAAAEEEHCsAAWIY1NLYAgggAACCIQuwBEIIIBAVgtQgGS1MP0jgAACCCCAAAIIIJC+QNzsQQESN6kmUAQQQAABBBBAAAEE7BdwbAFy7PhxqVSnhXR8dKA07/CEPDtinBw+ckTc63Wbu23eukOWr1pt9nev08dZXy6xP0PxOAJiRgABBBBAAAEEEHCsgGMLEM3YWWdlk9eH95NJrz8r/x0+LO9+MFNXi65fNmuyuFvJEkXM+vLXXe1Zp9vq1Kxs1jPJmMARy3zd6pWydMFM2bRhTcY6sfkoJ8RwW+1q8uE7Y2T3llWyeM50ua9JA5tV4/f0sfB8Si87TojBCdeEE/KgzzUnxEEMmkkaAqEJOLoAcVMkJiTIDdeWkU3WOx3udTxGRiB/wUJSpHipyJwsi84S6zEcPPS39Og9UApfXklGjh4vI4b0yyIpug1GINafTxpjrMfglGsi1vOgzyVtTogjTDEoh23NCTHYhseJQxaIiwIkJSVFvvn+R7m0eGEDdPToMc/tVk3a9DDrdPL1t2s86/UWrI2btulqWgYFsiclSd58BSUxMVsGe7D/MCfEsGT5Kvl5+y9y9OhRmfZRsiRlzy55cueyHzcOR+CE55MTYnDCNeGEPOiPACfEQQyaSRoCoQlEXwES2vgD7u0uNOo06WhedDVtXNfs730L1vQJI8w6nfjeglW6VHFdbVq9evXFt5kNTBCIIYHundvK+o2bZd/+AzE0aoaKQNYJcE1knS09I4AAAv4EHF2AuAuNOR++IU/2aCdnJ2X355Du+uTkGeLb0j2IHRCIIoHa1StLxweaS6fuffyOig0IxJMA10Q8ZZtYEUAgmgQcXYBEEzRjQcBOgRLFikj/3t2l4X3tZc2PG+0cCudGICoEovCaiAoXBoEAAghEQoACxEvZ9zMg7300y2srswjEpkDxooVl4pjh0u2xp2XDT1tiMwhGjUAYBbgmwohJVwg4QoAgIi3g2AIkW2KifPX5hDM8/a2veMM1qb6CV7+G995Gdc44nhXBC+iH/xfNmyGbN66V3bt2iM4fPLA/+A6iYE8nxNClQyu5rtxV5it4//59vWi7rGTxKNCNvyE44fnkhBiccE04IQ/6E8AJcRCDZpKGQGgCji1AQmNgbxUId0tISJAqteqnajlz5Q73abK0PyfE0LPPYMmR/4pU7afNfMNblj5x/HTuhOeTE2JwwjXhhDzoZeKEOIhBM0lDIDQBCpDQvNgbAQQQyAoB+kQAAQQQQCBuBChA4ibVBIoAAggggAACZwqwBgEEIi1AARJpcc6HAAIIIIAAAggggEAcC3gKkDg2IHQEEEAAAQQQQAABBBCIkAAFSISgOQ0CAQTYhAACCCCAAAIIxI0ABUgmU/38i2Mk1lsmCTg8jAK9HnlQYr3F+vWg4w9jSukqkwJZfz1k/TWXSQIORwABBBwnQAHiuJQSEAIIIIAAAgggEAMCDDFuBShA4jb1BI4AAggggAACCCCAQOQFKEAib+57RpYRQAABBBBAAAEEEIgbAQqQuEk1gSKAwJkCrEEAAQQQQACBSAtQgERanPMhgAACCCCAgAgGCCAQtwKOLkBGv/WejH/nE5Pc9t0HSMtOT0qbLn2l+5PPy6+7/+dZ37B5NzPvnnTtNUTq3dvZvcgjAggggAACCCCAAAKOEbA7EEcXIL64j3VtIxNeHSRVKl0nQ0eON5tdLpEcOc6RdRu2mOX9Bw7J3r37xeWyNpg19kyOHD4s61avlKULZsqmDWvsGUQmz0oMmQQM0+FOyINSOCEOYtBM2t/Ig/05cI+AXLgl7H10Qh7sFeTsoQrEVQHixqlwfVnZsm2ne1FqVa0ocxcuM8uz5y+VmlUrmHm7J/kLFpIixUvZPYxMnT+6YwguNGIIzikSe5GLSCinfw7ykL5RJPZwQh7UyQlxEINmkoZA8AJxWYCs+n6dlChW2KNU8YaysnzlarM8b+EKqyCxvwDJnpQkefMVlMTEbGZcsTghhujImhPyoJJOiIMYNJOnmo0P5MFGfJ9TkwsfEJsWnZAHm+g4bQYF4qoAebDHM1KlfhtZsHilPPZQG3H/L1u2RLmydEmZb61PSEyQC87PJSdOnHBvNo/16tUX32Y2MEEAAQQQQAABBGJIgKEiYLdAXBUgY0Y8JYtmTJCXnu0lhS7Ob+xNnWFNalWrIC+8Ml5q+7n9Kjl5hvg20wETBBBAAAEEEEAAAQQQCFogrgqQ1CqplyrcUFburFdDalqFSOotLCGAAAIIIIAAAggggEC4BBxdgBw9dkySsp8VlFViQoJ0aH235MmVM6j92QkBBDIhwKEIIIAAAgggELcCji1AUlJS5McNW6VIoYImuWNf6i9ly1xm5r0nur50qeLeqyRXzvMk+b3XUq2L9IKOf9G8GbJ541rZvWuH6PzBA/sjPYxMnY8YMsUXtoOdkAfFcEIcxKCZtL/Fex7sz8DpEZCL0xZ2zjkhD3b6ce7QBRxZgBw7flxqNWovxYteIpUrlAtdJQqOSLDekalSq754t5y5ckfByIIfAjEEb5WVezohD+rjhDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXMOizs+MpAUcWINkSE2X+J29Kr4fb2v4fFDzlzAMCCCCAAAIIIIAAAghYAo4sQKy4+BfNAowNAQQQQAABBBBAIG4FKEDiNvUEjgAC8ShAzAgggAACCNgtQAFidwY4PwIIIIAAAgjEgwAxIoDAKQEKkFMQPCCAAAIIIIAAAggggEDWC0S+AMn6mDgDAggggAACCCCAAAIIRKkABUiUJoZhIZAVAvSJAAIIIIAAAgjYLUABYncGOD8CCCCAQDwIECMCCCCAwCkBCpBTEDwggAACCCCAAAIIOFGAmKJNgAIk2jLCeBBAAAEEEEAAAQQQcLAABYiDk+sbGssIIIAAAggggAACCNgtEFcFyL4DB2XgsDekxYO9pWWnJ6Xr48/KwiWrTA7+/udf6f/ca3JP20fl7vsflbYPPSWH/v7HbGOCAAIIZFKAwxFAAAEEEEDglEBcFSA9+w2XHOcmyeQxQ+Tt0c9K+9aNZcOmbYbig8/myoGDf8uk0UNk2vjh0qNzS7PersmRw4dl3eqVsnTBTNm0YY1dw8jUeYkhU3xhO9gJeVAMJ8RBDJpJ+xt5sD8H7hFEJhfus2XNIzFkjSu9OlsgbgqQH9b9JL//8ad069Dck9FrypSWB9vcbZb37tsvZctcJmcnZTfLV11RSs7Lca6Zt2uSv2AhKVK8lF2nD8t5iSEsjJnuxAl5UAQnxEEMmkn7G3mwPwfuEZALt4S9j07Ig72CnD1NAT8r46YA2fHLb1KmdAnJli1bmhQN69aUz2YukE49B8m4tz+UHb/sTnO/SK3MnpQkefMVlMTEtMcbqXFk5jzEkBm98B3rhDyohhPiIAbNpP2NPNifA/cIyIVbwt5HJ+TBXkHOHqpA3BQgCpOQcDrcPoNGSqU6LaROk466SYoVuVjefXOotLq3gWz9eae06vSkbNu+y2zTSb169cW36XoaAkEIsAsCCCCAAAIIIIDAKYHTr8hPrXDqQ5FCBWXbjl1y4sQJE+Lgvt1k7kdjzbx7kv2ss6TSjdfIs/0ellrVKsqXi752b5Lk5BlnNM9GZhBAAAEEolSAYSGAAAIIRJtA3BQg+vmOHOeeK08NeVX+2POXycO//x02jzrRz4js3XdAZ823X23b/ovkvSC3WWaCAAIIIIAAAgggEKIAuyPgRyBuChCNf9jARyV79uzyYI+B0rT949KjzwvyeLc2ukl++/0Pad2lr3R4ZIDUu7ezXHRhHql/a1WzjQkCCCCAAAIIIIAAAgiERyCuCpA8uXJKv54d5MNJL8rUsUNl0ujBUqtqRSNZp2Zl+XTKSHnjxf7y1ecT5Pmne/j9wLo5IPhJhvZMSUmRRfNmyOaNa2X3rh1m/uCB/Rnqy66DiMEu+dTndUIeNCInxEEMmkn7G3mwPwfuEZALt4S9j07Ig72CnD1UgbgqQELFsXN//cB8lVr1xbvlzBVbt4QRg53PoNPndkIeNJqMxaFHRk8jhujIBXmIjjzoKMiFKtjfnJAH+xUZQSgCFCChaLEvAggggAACCAQnwF4IIICAHwEKED8wrEYAAQQQQAABBBBAIBYFon3MFCDRniHGhwACCCCAAAIIIICAgwQoQByUTELxFWAZAQQQQAABBBBAINoEKECiLSOMBwEEEHCCADEggAACCCDgR4ACxA8MqxFAAAEEEEAAgVgUYMwIRLsABUi0Z4jxIYAAAggggAACCCDgIAEHFyAOyhKhIIAAAggggAACCCDgEAEKEIckkjAQiCoBBoMAAggggAACCPgRoADxA8NqBBBAAAEEYlGAMSOAAALRLkABEu0ZYnwIIIAAAggggAACsSDAGIMUoACxoMZOmi6jxk215k7/27j5Z2nSpsfpFcwhgAACCCCAAAIIIIBApgUoQCzCOjVvljnzl1lzp//NWbBM6tSqfHpFhOeOHD4s61avlKULZsqmDWsifPZMnu7U4cRwCsLmByfkQQmdEAcxaCbtb+TB/hy4R0Au3BL2PjohD/YKcvZQBShALLEihQpI7lw5Zc2Pm6ylk/+0IKlTw74CREeRv2AhKVK8lM7GbCOG6EidE/Kgkk6II6tjUKesbsSQ1cLB9e+EPGikToiDGDQfSPmQAAAQAElEQVSTNASCF6AAOWVVu3pFmbvw5Lsga9dvkjy5c4oWJqc2R/whe1KS5M1XUBITs0X83OE6ITGESzJz/TghDyrghDiIQTNpfyMP9ufAPQKH5cIdVsw9OiEPMYce5wNOiPP4PeHfWr2SVYCskBMnTojeflXbWvZstGbq1asvvs1azT8EEEAAAQQQQAABBBAIQSD8BUgIJ4+mXQvkzyuFLy4g367+0RQidWvfnGp4yckzxLel2oEFBBBAAAEEEEAAAQQQSFeAAsSLqHb1CjLyjXek8CUFJO8Feby2MItAbAgwSgQQQAABBBBAINoFKEC8MnRL9Ztk87adUrtaBa+1zCKAAAIIIJCuADsggAACCAQpQAHiBZU713my5ItJ0uSOW73W2jObkpIii+bNkM0b18ruXTvM/MED++0ZTAbPSgwZhAvzYU7Ig5I4IQ5i0Eza38iD/Tlwj4BcuCXsfYz9PNjrx9lDF6AACd0sIkckJCRIlVr1U7WcuXJH5NzhOgkxhEsyc/04IQ8q4IQ4iEEzaX8jD/bnwD0CcuGWsPfRCXmwV5CzhypAARKqWBTvz9AQQAABBBBAAAEEEIh2AQqQaM8Q40MAgVgQYIwIIIAAAgggEKQABUiQUOyGAAIIIIAAAtEowJgQQCDWBChAYi1jjBcBBBBAAAEEEEAAgWgQyOAYKEAyCMdhCCCAAAIIIIAAAgggELoABUjoZhyBgK8AywgggAACCCCAAAJBClCABAnFbggggAAC0SjAmBBAAAEEYk2AAiTWMsZ4EUAAAQQQQACBaBBgDAhkUIACJINwHIYAAggggAACCCCAAAKhC1CAhG7mewTLCCCAAAIIIIAAAgggEKQABUiQUOyGAALRKMCYEEAAAQQQQCDWBGKuANl/4JBUrttKpn8622N97PhxqVSnhQwY+vrpdceOSc2G7aTPoJFmXc+nhpl9dD/v9t/hIzL6rfekeoO2snffAbOvTmo0fEAfaAgggAACCCCQlgDrEEAAgQwKxFwBMmfBUilZvLDMXbjCE7LL5ZIc554ja9dvkmNW4aEbFi79Vgrkv1BnTRv2TE9ZNmuyp91z563StkUjOTspu9l+4QV5ZMr0GWY+GiZHDh+WdatXytIFM2XThjXRMKSQx0AMIZNlyQFOyIPCOCEOYtBM2t/Ig/05cI+AXLgl7H10Qh7sFYz82WP9jDFXgMxdsEIe7dJaftv9h+z5a5/H3+VyyU3ly8mSr1ebdfMWLpNaVSuaed/JomXfyvqftskDzRud3OQSub1ONZk9f5n8/c+/J9dFwTR/wUJSpHipKBhJxodADBm3C+eRTsiDejghDmLQTNrfyIP9OXCPgFy4Jex9dEIe7BXk7KEIxFQBsvv3PVbRsVfKlrlM6tS8Sb6YuzhVrLfWqCRffrVC9Laqn3f+KiWKFUq1XRf2/LlXRr4xRZ7t200SEk6Hn2S9E3LHbdVl6gfJupvtLXtSkuTNV1ASE7PZPpaMDiDrY8joyII/jhiCt8rqPclFVgsH1z95CM4pq/dyQh7UyAlxEINmkoZAaAKnX4GHdpwte89esExuqV7JnLuBVSzMsd6xMAunJmUuLyk/bd5mFSHLpWaV8nLixIlTW04+pKSkyJODRkrPrq0l74Xnn1zpNW3auK58OnOhKWC8VpvZevXqi28zG5gggAAC8ShAzAgggAACCGRQIKYKkLkLlsuEqZ+YD5Pf07anbNq6XXb8stsUGu5i4+ZK18moce/KrTUqn0EydtIHUubyS6XC9WVTb9M6xSpW9HMkt9W8ST74dE7q7dZScvIM8W3Wav4hgAACCCCAAAIRFeBkCMS6QMwUIFpoHDh4yPMhcv1Aect7bpdZ85ekysEdt9WQZo3rS5FCBVKt/+6H9bJkxffSpV3TVOt9F5o2ricfJ38pKcdTfDexjAACCCCAAAIIIIAAApkUiJkCZNaXi6Vm1fJe4YrUqlZRZs1LXYAUvqSAtLinfqr9dOHVN98175hUqdfavIPi/irerT/v0s2edn6eXOYdkiNHj3rWMYMAAggggAACCCCAAALhEYiZAqR9qybSrUPzVFGXLllMpk8YIdkSE2XuR2NTbdOFmlXKy+C+3XRWxr08INW7J/oOirYSxS6RTm3vlWZN6pn9dKKfEdFtOm9X08+rLJo3QzZvXCu7d+0QnT94YL9dw8nQeYkhQ2xhPyhL8hD2UabfoRPiIIb08xyJPchDJJSDOwe5CM4pq/dyQh6y2oj+wysQMwVIeMOO/t70G7qq1Kov3i1nrtzRP3CvERKDF4aNs07Ig/I5IQ5i0Eza32I9DyrohBicEocTcuGEGPT5RIsdAQqQ2MkVI0UAAQQQQAABBBCwT4Azh0mAAiRMkHSDAAIIIIAAAggggAAC6QtQgKRvxB6+AiwjgAACCCCAAAIIIJBBAQqQDMJxGAIIIGCHAOdEAAEEEEAg1gUoQGI9g4wfAQQQQAABBCIhwDkQQCBMAhQgYYKkGwQQQAABBBBAAAEEEEhfIPQCJP0+2QMBBBBAAAEEEEAAAQQQSFOAAiRNFlYiEJ0CjAoBBBBAAAEEEIh1AQqQWM8g40cAAQQQiIQA50AAAQQQCJMABUiYIOkGAQQQQAABBBBAICsE6NNpAhQgTsso8SCAAAIIIIAAAgggEMUCji1ARo9/T8a/84mhH/3We3JXq0ek46MDpVmHXvLK2Hfk2PHjZlv77gOkYfNuZt496dpriNS7t7N7MWoeGQgCCCCAAAIIIIAAArEu4NgCxDcxDW6rLq8P7yejh/WTr79dKyutpvu4XCI5cpwj6zZs0UXZf+CQ7N27X1wua4NZY8/kyOHDsm71Slm6YKZs2rDGnkFk8qzEkEnAMB3uhDwohc1x6BAy3Ygh04Rh6YA8hIUxLJ2Qi7AwZroTJ+Qh0wh0EFGBuClA3KqJiSdDznthHvcqqVW1osxduMwsz56/VGpWrWDm7Z7kL1hIihQvZfcwMnV+YsgUX9gOdkIeFMMJcRCDZtL+Rh7sz4F7BOnnwr1n9D4SQ/TmhpFFp8DJV+PRObawjuqNidOkUp0WcstdHaRooYulVIminv4r3lBWlq9cbZbnLVxhFST2FyDZk5Ikb76CkpiYzYwrFifEEB1Zc0IeVNIJcRCDZtL+Rh7sz4F7BOTCLWHvoxPyYK+gg8+eRaHFTQHSofXdsmzWZJnx7qty+MhhmffVcg9ptmyJcmXpkjJ/8UpJsN4hueD8XHLixAnPdp2pV6+++DZdT0MAAQQQQAABBBBAAIHgBeKmAHGTXHB+brmh3FWyfNXJz1WYOsOa1KpWQV54ZbzU9nP7VXLyDPFt7j55dLwAASKAAAIIIIAAAgiESSDuChD99qtvV6+TvBec/gyIWla4oazcWa+G1LQKEV2mIYAAAghEgwBjQAABBBBwmkDcFCCfzVxgvoZXv3L39z17pWnjuqlymZiQIHqbVp5cOVOtZwEBBBBAAAEEEIhLAYJGIIsEHFuAdLr/Xrm/WUPD1qntvfLhpBfN1/DqZ0AmjBoouXKeJ/q/sS/1l9Kliuusp+m25Pde8yzbMZOSkiKL5s2QzRvXyu5dO8z8wQP77RhKhs9JDBmmC+uBTsiDgjghDmLQTNrfyIP9OXCPgFy4Jex9dEIe7BXk7KEKOLYACRUiwP62bEqw3pGpUqu+eLecuXLbMpaMnpQYMioX3uOckAcVcUIcxKCZtL+RB/tz4B4BuXBL2PvohDzYK8jZQxWgAAlVjP0RQCCCApwKAQQQQAABBJwmQAHitIwSDwIIIIAAAuEQoA8EEEAgiwQoQLIIlm4RQAABBBBAAAEEEMiIgNOPoQBxeoaJDwEEEEAAAQQQQACBKBKgAImiZDAUXwGWEUAAAQQQQAABBJwmQAHitIwSDwIIIBAOAfpAAAEEEEAgiwQoQLIIlm4RQAABBBBAAIGMCHAMAk4XoABxeoaJDwEEEEAAAQQQQACBKBKI4gIkipQYCgIIIIAAAggggAACCIRFgAIkLIx0goDDBAgHAQQQQAABBBDIIgEKkCyCpVsEEEAAAQQyIsAxCCCAgNMFoq4AOZ6SIm9N/khadOwtD3TrL2269pO33//ck4c9f+2TJ555Sdp06SstOz0pQ14cJ4f+/sez/ceNW6Rjj4HmWO1jyrQZcuLECc/2Ldt2ysO9n5fWnfuYc/QZNFJ0ne4w+q33ZPw7n+gsDQEEEEAAAQQQQCC+BIg2QgJRV4C8MWGaLP/mB3l9eD95c+QAGfRkV9nxy28ejp79hsmlxQvLhFcHyaTXBsuRo8fk2RFjzXYtTrS4uL/5nebY117oI8lzFsn0T+eY7X/t3S8P9nhG7qhbQyZax2ofNaqUlzXrN5nt0TQ5cviwrFu9UpYumCmbNqyJpqEFPRZiCJoqS3d0Qh4UyAlxEINm0v5GHuzPgXsE5MItYe+jE/JgryBnD1UgqgqQFOvdj6kffiG9u7eT83Kca2IpdHF+6dOjvZn/7of1sm//QWnbvJFZdrlc0qNzS1n69WrZ8+de+XjGl1LxhrJS4fqrzfZcOc+Thzo0lWmfzDLLn3yxwGyrVbW8Wc6WmCi1q1WUO+vVNMvRNslfsJAUKV4q8sMK4xmJIYyYmejKCXnQ8J0QBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpy9lAEoqoA+f2PP+Wcs8+W4kUvSTOGnb/+LpeXKiaJCaeHnfO8HFK0cEHZvvNX+cXaftUVpVIde81VpeXX3/4wt2Ht3PWblC1TOtX2aF3InpQkefMVlMTEbNE6xHTHRQzpEkVkByfkQaGcEEcwMWis0dyIITqy44Q8qKQT4iAGzSQNgdAETr+SD+24LNs7wau4mP7pbKlUp4Vpm7fuOHlO612PkzNpT303u1wJop8ASTn1OZCEBJfnwHr3djZ9PzHgRc86fzP16tUX3+ZvX9YjgAACCCCAQMwJMGAEEIiQQFQVIAXy5ZX//vtP/ty7z4Tf5I5bZdmsyXLZpUXNcuGL88vGzT+L3qplVliTg4f+tt79+M16F+Ri0du11m3YYq09/e/7NevlkoIXSWJCghS+pKBs277LszH5vdfkuf6PeJYDzSQnzxDfFmh/tiGAAAIIIIAAAggggMCZAmcWIGfuE7E1LpdL7rmzjjzad5hs2LTNnFeLjcNHjpj5a8teIblznidvTfnILOu3Ww1/dZJUrlBO8l54vtxZv6YsWfGdrPjm5Ie2tTgZNfZd06cecGe9GjJnwTKZOPVT+e/wyT4PHz6sm2gIIIAAAggggAACCCAQAYGoKkA03g5t7paqla6Xp4aMkuYdnpC77+8ptatVkhLFCulmGTawp2zetlP063lbde4jSdnPkt6PtDPb8l6QR0Y+94SMn/KxtHu4v3TqOUhuq3WzNG5wi9l+fp5c5tu1vv1hvTRt/7g0bt1DZsxeJPef+lC77vTGxGnmtiz3rV/Hjh/X1TQEIiLASRBAAAEECp6d7wAAEABJREFUEEAAAacLRF0BkpiQIG1bNJL33xouU954Tj6YOELatbxL3J8N0SLjuae6y4RRA+Xt0c+a4sP9jVmarCtLXyqvj+gn414eIJNfHyIt7qkvLtfpz31cWrywvDykl3w06SXTt86XLllMD5VObe81t3zpbV/upt+UZTZGeKLv/CyaN0M2b1wru3ftEJ0/eGB/hEeRudMRQ+b8wnW0E/KgFk6Igxg0k/Y3P3mwf2AhjMAJMWi4ToiDGDSTNARCE4i6AiS04Tt3by24qtSqL94tZ67cMRUwMURHupyQB5V0QhzEoJm0v5EH+3PgHgG5cEvY+2h/HuyNn7NHXoACJPLmnBEBBBBAAAEEEEAAgbgVoACJotQzFAQQQAABBBBAAAEEnC5AAeL0DBMfAggEI8A+CCCAAAIIIBAhAQqQCEFzGgQQQAABBBBIS4B1CCAQbwIUIPGWceJFAAEEEEAAAQQQQEAFbGoUIDbBc1oEEEAAAQQQQAABBOJRgAIkHrNOzL4CLCOAAAIIIIAAAghESIACJELQnAYBBBBAIC0B1iGAAAIIxJsABUi8ZZx4EUAAAQQQQAABFaAhYJMABYhN8JwWAQQQQAABBBBAAIF4FKAAEYnHvBMzAggggAACCCCAAAK2CDiuADl2/LiMe/sDadGxt3R8dKA83Pt5WbLiexk7abqMGjc1FfLGzT9LkzY95HhKijTr0EtWr93o2d75scHy5aKvPcvMIIBAVgjQJwIIIIAAAgjEm4DjCpCxE6fLim/WypgRT8nrw/vJC8/0EC1K6tS8WebMX5Yqv3MWLJM6tSpLYkKC9OnRQQaPeMMUI7PnL5Vzz0mSmlXKp9o/kgtHDh+WdatXytIFM2XThjWRPHXYzkUMYaPMVEdOyIMCOCEOYtBM2t/Iw6kcRMEDuYiCJFhDcEIerDD4F0MCjipAUqx3MqZ++IU8+Ug7yXHuOSYN2c86S6rddL0UKVRAcufKKWt+3GTW60QLkjo1KuuslLn8Uil31RXy1pSPrHdLPpCeXduY9XZO8hcsJEWKl7JzCJk+NzFkmjAsHTghDwrhhDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXMLSzx/vejipAfv/jTznn7LOleNFL0sxr7eoVZe7Ck++CrF2/SfLkzmkKE/fOXdrdJ5Pf+1zq1q4iBfLlda+25TF7UpLkzVdQEhOz2XL+cJyUGMKhmPk+nJAHVXBCHMSgmbS/kQf7c+AeAblwS9j76IQ82CvI2UMVSAj1gGjf3+XyP8Jbq1eyCpAVcuLECdHbr2pby957/7DuJ8l30QXy7eofvVeb+Xr16otvMxuYZEKAQxFAAAEEEEAAAQTiTcBRBUj+iy6Uf/89LD/v/C3NPBbIn1cKX1zAFBhzF66w3um42bPff4ePyMg3psjI556QI0ePyoLFqzzbdCY5eYb4Nl1PQwABBGJSgEEjgAACCCBgk4CjCpCEhAS5767bpP+QUbJp63ZDqsXEwqXfmHmd1K5ewSo03pHClxSQvBfk0VWm6bdk3VrzJimY/yJ5ovsD1j5TTCFiNjJBAAEEEEAAAQTCJEA3CMS7gKMKEE1m+9ZNpEql6+TJgSPlgW79pdfTL0m2xETdZNot1W+Szdt2Su1qFcyyTrZt3yULl6yS1vfdoYtSomghubliOZn07mdmmQkCCCCAAAIIIIAAAgiERyAhPN1kpJesOUaLjXYtG8u08cPlzZED5MXBj0nlCuU8J8ud6zxZ8sUkaXLHrZ51xYteItMnjBD9xiz3yh6dW0u7lne5FyP+qN/otWjeDNm8ca3s3rVDdP7ggf0RH0dmTkgMmdEL37FOyINqOCEOYtBM2t/Ig/05cI+AXLgl7H10Qh7sFeTsoQo4rgAJFSBa99fbyarUqi/eLWeu3NE63DTHRQxpskR8ZZp5iLHnkqI5IQ5i0Eza38iD/Tlwj4BcuCXsfXRCHuwV5OyhClCAhCrG/ggggAACCGRCgEMRQACBeBegAIn3ZwDxI4AAAggggAAC8SFAlFEiQAESJYlgGAgggAACCCCAAAIIxIMABUg8ZNk3RpYRQAABBBBAAAEEELBJgALEJnhOiwAC8SlA1AgggAACCMS7AAVIvD8DiB+BMAv0euRBifUWZhJbunv+xTHihGYLHid1qgBxIYBAlAhQgERJIhgGAggggAACCCCAAALOFEgdFQVIag+WEEAAAQQQQAABBBBAIAsFKECyEJeuEfAVYBkBBBBAAAEEEIh3AQqQeH8GED8CCCAQHwJEiQACCCAQJQIUIFGSCIaBAAIIIIAAAgg4U4CoEEgt4KgCZPirk6TevZ3lxIkTniiXr1otleq0kM9mLfCs+37NBrNu+qezzbr23QdIy05PSqeeg6RN134yZsI0OXzkiNnGBAEEEEAAAQQQQAABBMIn4JgCRIuOBYu/lgsvyCOrvl/nEXK5XFKsyCUyb+EKz7q51nzxopeIy+XyrHusaxsZPayvjBnRT7Zt/0WeGfq6Z1u4ZkLp58jhw7Ju9UpZumCmbNqwJpRDo2ZfYoiOVDghD9EhmflROCEXt9WuJh++M0Z2b1kli+dMl/uaNMg8TIR7cEIenBCDpt0JcRCDZpKGQGgCjilAVn63VkoUKyx333GLzJ6/LJVCoYvzyb79B+XQ3/+Yd0dWfrdGri17Rap93AtJ2bNLn0c7yNKVq+XX3f9zr7blMX/BQlKkeClbzh2ukxJDuCQz148T8pA5AYmaw2M9FwcP/S09eg+UwpdXkpGjx8uIIf2ixjaUgcR6HjRWJ8TglDickAsnxKDPJ1psCDimANGi49YalaRWtYqy7OvVcuzYsVQZqFmlgvUuyHLRQuW6sldKgivBFCOpdjq1kPO8HFKqRBHZ+vOuU2si/5A9KUny5isoiYnZIn/yMJ2RGMIEmclunJCHTBJEzeFOyMWS5avkZ+td4qNHj8q0j5JF/2iTJ3euqDEOZiBOyENsxeA/K06Igxj855ctCPgTcEQBosXG8pU/SO3qFSXHuedI2TKlZIlVhHgHrcWJ3nqlt2LVrlbBe1Oa8wkJqWnq1asvvi3NA1mJAAIIxIlA985tZf3GzdY7zAfiJGLCRAABBGJMIEqHm/pVdpQOMr1hLVnxvfy5d59Ub9DWfLh8/uKVMufUbVj62RBtBfLnlSPWX+zWrt8s111zZcAujx0/Ltt3/ibFilzs2S85eYb4Ns9GZhBAAIE4E6hdvbJ0fKC5dOreJ84iJ1wEEEAAgcwKOKIAmb1gmfTp0V6WzZps2pwP35ClX39/xjdZtW3eSLS5XKc/fO4LqO+mvPbmu3Jd2cul0MX5fTezHJsCjBoBBMIoUKJYEenfu7s0vK+9rPlxYxh7pisEEEAAgXgQiPkCRL8ud/nK1VL95hs9+Tovx7lyfbkrZOGSVZ51OlPh+qullp/br14YNcF8DW+77gMke/az5KnHO+ohNAQQQAABL4HiRQvLxDHDpdtjT8uGn7Z4bfE3y3oEEEAAAQRSC8R8AZKUPbvM+3icaNHhHdoLAx6VW2vcJBVvuEaGPdPTe5OZf7RLK2lyx61mfuxL/eXt0c+ar+GdMGqgdGxzj/lgpdlo0yQlJUUWzZshmzeuld27dpj5gwf22zSajJ2WGDLmFu6jnJCHcJvY1Z8TctGlQyu5rtxV5it4//59vWi7rGRxu0gzdF4n5MEJMWjynBBHVMegyEE0J8QQRJjsEkUCMV+ARJFlWIeiH4KvUqu+eLecuXKH9RxZ3RkxZLVwcP07IQ/BRRr9ezkhFz37DJYc+a9I1X7avC368b1G6IQ8OCEGTYkT4iAGzSQNgdAE4qEACU2EvRFAAAEEEEAAAQQQQCDLBChAsoyWjhFAQAQDBBBAAAEEEEAgtQAFSGoPlhBAAAEEEHCGAFEggAACUSpAARKliWFYCCCAAAIIIIAAArEpwKgDC1CABPZhKwIIIIAAAggggAACCIRRgAIkk5i9HnlQYr1lkiDA4ZHb9PyLY8QJLXJiWXcm8pB1tqH0HOs/l9zjDyVm9kUAAQQQiA2BqChARo2bKoFabFAySgQQQCCKBBgKAggggAACUSoQFQWI/kcEA7UotWNYCCCAAAIIIIDAGQKsQACBwAJRUYC0adpQArXAIbAVAQQQQAABBBBAAAEEYkUgCwuQ0An27jsgU6bNkD6DRpr2zgdfiK4LvSeOQAABBBBAAAEEEEAAgWgUiKoCpP9zr8mCJavkumuuMO3Lr1bIgKGvR6MbY0IgugUYHQIIIIAAAgggEKUCUVWA7P7fH/L6iH7SuMEtpr0+vK/88uvusNAdO35cqt7extPXyu/WSqOW3U3/e/7aJ08885K06dJXWnZ6Uoa8OE4O/f2PZ19mEEAAAQQQCFaA/RBAAAEEAgskBN4c2a0JCWcOJyHBFfZBrNuwWZ4dMU5efLaXFLq4gPTsN0wuLV5YJrw6SCa9NliOHD1mbR8b9vPGW4dHDh+WdatXytIFM2XThjUxGf5ttavJh++Mkd1bVsniOdPlviYNYi4OJ+RB0Z0QBzFoJu1v5MH+HLhHQC7cEvY+OiEPpwR5iBGBM1/x2zjwcldfIZ17DpI3Jk4zrVPPwXLjtVeHZUQul0v0/1u27ZSnhrwmwwf1lGKFC8p3P6yXffsPStvmjcx5XC6X9OjcUpZ+vVr2/LnXrGOScYH8BQtJkeKlMt6BzUcePPS39Og9UApfXklGjh4vI4b0s3lEGTt9rOfBHbUT4iAGdzbtfSQP9vp7n51ceGvYN++EPNinx5lDFYiqAuTxh9pIgzrVZPvO30y7s14NebRLq1BjSnP/EydOiN6G1f3J52VQn65Somghs9/OX3+Xy0sVk8SE0xQ5z8shRa3iZPvOX80+MTeJkgFnT0qSvPkKSmJitigZUejDWLJ8lfy8/Rc5evSoTPsoWZKyZ5c8uXOF3pGNRzghD8rnhDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXkLOHKnD6VXeoR2bB/noL1u1WATK4bzfRVv/WqqLrwnWqBOvdjQL5L5LPZi5M3aW1PvWKM5fq1asvvu3MvVjjZIHundvK+o2bZd/+A04Ok9gyKcDhCCCAAAIIIBBYIKoKkI2btslj/YdLvXs7m9br6RGycfPPgSMIcqvL5TLFzIuDH5Mf1v0k497+UPR/hS/Ob86RkpKii6bpbTfbrXdhiha+2CzrJDl5hvg2XU+LD4Ha1StLxweaS6fufeIjYKJEAAEEYk+AESOAQIwIRFUBMmjEWKl/SzV5d9xQ026rXUUGDw/vh8HPy3GujBraW2bPXyIfJ38p15a9QnLnPE/emvKRSZneqjX81UlSuUI5yXvh+WYdk/gWKFGsiPTv3V0a3tde1vy4Mb4xiB4BBBBAAAEEEDhDILQVUVWApBxPkeo33yC5rIJAW42bb5SjR4+EFpGfvbWwOCEnzFa9h3/U0D5W0fGxLFi8SoYN7Cmbt+2UNmNyIyIAABAASURBVF37SavOfSQp+1nS+5F2Zl8m8S1QvGhhmThmuHR77GnZ8NOW+MYgegQQQAABBBBAIAwCUVWA5M93gSxbudoT1tKvv5eLC+bzLGdmJltionz1+QRPF/nyXiCfThlpCp68F+SR557qLhNGDZS3Rz9rig99p8SzMzMZEtDb2hbNmyGbN66V3bt2iM4fPLA/Q33ZdVCXDq3kunJXma/g/fv39aLtspLF/Q4nGjc4IQ/q6oQ4iEEzaX8jD/bnwD0CcuGWsPfRCXmwV5CzhyoQFQVIx0cHirY9f+6XHn1fkIbNu8kdVnu03zD586/YesEaagKcvL9+gUCVWvXFu+XMlTumQu7ZZ7DkyH9FqvbT5m0xFYMT8qDgToiDGDSTWdaC7pg8BE2V5TuSiywnDuoETshDUIGyU9QIREUB8kCLRqLtoQ5NZeRzT0jfnh2kn9V0vku7+6IGi4EggAACCCCAAAII+AqwjEBoAlFRgNx47VUSqIUWEnsjgAACCCCAAAIIIIBAtApERQHixtm5a7eMHv+ePNRriLklS2/L0ubeHu2PjA8BBBBAAAEEEEAAAQQCC0RVAaKf/9APizdtXNfckqW3ZWkLHAJbEUAAAYEAAQQQQAABBGJEIKoKkGyJCdK+VRO5qXy5VLdkxYglw0QAAQQQQCAOBQgZAQQQCE0gqgoQ/XrTNT9uCi0Cm/d+/sUxEuvNZsKwnL7XIw+KE1pYMOgEAQQQQAABBOJDIEajjKoCpE7Nm6Rzz0FSqU6LVC1GbRk2AggggAACCCCAAAII+AhEVQEydOR46fzAfTL3o7GybNZkT/MZM4sI+AqwjAACCCCAAAIIIBAjAlFVgOTKeZ7oB9BznHtOjPAxTAQQQCDeBYgfAQQQQACB0ASiqgApf/1VMmHqJ7LvwMHQomBvBBBAAAEEEEAg3gSIF4EYFYiqAmTKtBkyZsI0qXt3Jz4DEqNPKIaNAAIIIIAAAggggEAggagqQLw/9+E9n1YAh48ccRcpZzxu3/mbvDn5I2nxYG/TGrXqLus2bDHdtO8+QH5Y95OZ953sP3BIKtdtJdM/ne27iWUEEEAAAQQQQAABBBAIg0BUFSAj35gi/9vzV1BhJWXP7vmQ+kPtm8m9jep4lg/9/Y98PGOejBj8mEweM0RGv9BXzjn77HT7nbNgqZQsXljmLlyR7r5ZvcORw4dl3eqVsnTBTNm0YU1Wny5L+ieGLGENudOszUPIw8nwAU6IgxgynP6wHkgewsqZqc7IRab4wnawE/IQNgw6iohAVBUguXPmlHYPPy1PDnxZvl+zIcMAf+7dLyWKFZZ8eS8wfRTIn9davsTMB5rMXbBCHu3SWn7b/Yfs+WtfoF0jsi1/wUJSpHipiJwrq05CDFklG1q/TsiDRuyEOIhBM2l/c0QeHPA7Qp8J5EIV7G9OyIP9iowgWIGoKkBaN71DPpz0otxc6Tp5cfTb0qZLX0me85UcO3Ys2HjMfuWvu0r+s95BaPvQU/LCKxOCKmZ2/77HKjr2Stkyl4n+90i+mLvY9GXXJHtSkuTNV1ASE7PZNYRMn5cYMk0Ylg6ckAeFcEIcxKCZtL+RB/tz4B4BuXBL2PvohDxEWpDzZU4gqgoQDSVbYqLUrXWz3N+skeg7GWMnfSj3PvC4LFr2rW4Oqp2dlF1eH95PHu92vyQmuqRH32GmkAl08OwFy+SW6pXMLg1uqy5z5i8z8+5JvXr1xbe5t/GIAAIIIIAAAggggAACwQlEVQHy3+EjMu2T2VbB0VM+Tv5SnnyknXz09kvybN+HZMRrk4KL6NReLpdLLi9VXHp0bi09u7aS5LlLTm1J+2HuguXmK4D1v8J+T9uesmnrdtnxy27PzsnJM8S3eTbG7QyBI4AAAggggAACCCAQmkBUFSB33/+obPn5Fxn69KPy0rOPS6UbrzHRlLYKieuuudLMBzPRwmHrz7vMrsdTUmTt+i1y4fm5zXJaE93/wMFDng+x6zdwtbzndpk1P3DRklZfrEMAAQQiIsBJEEAAAQQQiFGBqCpA3n79WXni4bZSrMjFZ3D269nhjHX+Vhw+clieHPSS3N+1nzRo2lW+W7NBHmzTxLP7gz2e8Xx1b/vuA2TWl4ulZtXynu06U6taRZk1jwJELWgIIIAAAgggcFqAOQQQyJxAVBQg+oHvn3f8Knly5TTRzF24XJ4Y8KK88sYUOXjob7Mu0KRZk3rSvWNLzy6lShSVd8e9IONHDZTk916TqWOfl4sL5DPbx77UP9U7HbrcvlUT6dahudnunpQuWUymTxjhXoz4Y4r1zs2ieTNk88a1snvXDtH5gwf2R3wcmTkhMWRGL3zHOiEPquGEOIhBM2l/Iw/258A9AnLhlrD30Ql5sFeQs4cqkIkCJNRT+d//zckfSt4L85gd1vy4SQYPf0Ouuepy2bv/oAx/NbTPfphOHDBJSEiQKrXqp2o5c+WOqciIITrS5YQ8qKQT4iAGzaT9jTzYnwP3CMiFW8LeRyfkwV5Bzh6qQFQUICdOiJyX41wz9gWLv5bGd9wiTRvXlX49H5T1P20x65kggICXALMIIIAAAggggECMCkRFAXLk6FHRD4ur4cbN2+X6Ux84d7lccvx4iq6mIYAAAgggEBUCDAIBBBBAIHMCUVGAXF6qmAx9+S2Z99Vy2br9F7m27BUmqkN//yMul8vMM0EAAQQQQAABBBCIawGCd4hAVBQgTz3WUc7LcY5M/3Su9O7eTvQ/JKi+a9dvkjo1K+ssDQEEEEAAAQQQQAABBBwgEBUFSM7zcshDHZrL6GF9pUql6zysFW+4Rtq1vMuzzMwpAR4QQAABBBBAAAEEEIhRgagoQGLUzgy71yMPSqw3EwgTBBAISoCdIivw/ItjJNZbZMU4GwIIIBD9AhQg0Z8jRogAAggggAACIhgggIBDBChAHJJIwkAAAQQQQAABBBBAIGsEwtsrBUh4PekNAQQQQAABBBBAAAEEAghQgATAYRMCvgIsI4AAAggggAACCGROgAIkc34cjQACCCAQGQHOggACCCDgEIG4KkBGv/WejH/nE5M6na/eoK3s3XfALOukRsMH9EGOHT8uVW9vY+aZIIAAAggggAAC8S1A9AiEVyCuChBfugsvyCNTps/wXc1ymASOHD4s61avlKULZsqmDWvC1GtkuyGGyHoHOhu5CKQTuW1OyMNttavJh++Mkd1bVsniOdPlviYNIgcYpjM5IQ9K4YQ4iEEzSUMgNIH4LUBcIrfXqSaz5y+Tv//5Nyg1dgpdIH/BQlKkeKnQD4yiI4ghepJBLqIjF7Geh4OH/pYevQdK4csrycjR42XEkH7RARviKGI9D+5wnRAHMbizySMCwQnEbwFi+SQlZZc7bqsuUz9Itpb4F26B7ElJkjdfQUlMzBburiPWHzFEjDq9Ewm5SJcoIjs4IQ9Llq+Sn7f/IkePHpVpHyVLUvbskid3roj4heskTsiDWjghDmLQTNIQCE0grgsQpWrauK58OnOh/Hf4iC76bfXq1Rff5ndnNiCAAAIIxIRA985tZf3GzbJv/+nPA8bEwCM6SE6GAAIIhFcgfguQExbkiROS49xz5LaaN8kHn86xVvj/l5w8Q3yb/73ZggACCCAQ7QK1q1eWjg80l07d+0T7UBkfAgjEq4BD447fAsQroU0b15OPk7+UlOMpXmuZRQABBBBwqkCJYkWkf+/u0vC+9rLmx41ODZO4EEAAgagUiKsC5OixY5KU/awzEnF+nlxS4fqycuToUbNN7wvOftaZ+5mNTOwQ4JwIIIBA2ASKFy0sE8cMl26PPS0bftoStn7pCAEEEEAgOIG4KUBSUlLkxw1bpUihgkamU9t7pVmTemZeJz27tpZlsybrrPywbpMUvqSAmWeScQE1XzRvhmzeuFZ279ohOn/wwP6Md2jDkcRgA7qfU5ILPzBZvjr1CZyQhy4dWsl15a4yX8H79+/rRdtlJYunDjTKl5yQByV2QhzEoJmkIRCaQFwUIPofFqzVqL0UL3qJVK5QLqCQ/gcKXx4zWR7t0irgfmxMXyAhIUGq1KqfquXMlTv9A6NoD2KInmSQi+jIhRPy0LPPYMmR/4pU7afN26IDOMhROCEPGqoT4sjSGBQpAs0JMUSAiVOEUSAuCpBsiYky/5M3pdfDbcXlcgXk03dG3nnjebnqitj+b1cEDJKNCCCAAAIIIIAAAgjYJBALBYhNNJwWAQQQQAABBBBAAAEEwi1AARJuUfpDwFECBIMAAggggAACCIRXgAIkvJ70hgACCCCAQHgE6AUBBBBwqAAFiEMTS1gIIIAAAggggAACGRPgqKwVoADJWl96RwABBBDIhECvRx6UWG+ZCJ9DEXCkwPMvjpFYb45MTASDogCJIHbsnYoRI4AAAggggAACCCAQXgEKkPB60hsCCCAQHgF6QQABBBBAwKECFCAOTSxhIYAAAggggEDGBDgKAQSyVoACJGt96R0BBBBAAAEEEEAAAQS8BAIUIF57MYsAAggggAACCCCAAAIIhEEg5gqQ9t0HSKtOfTyhr9uwRTo+OlAOHzkiNRu2k0N//+PZpjOP9R8us+cvleWrVsstd3Uw+7Z7+Gl5uPfzsm7DZt3F0/YfOCSV67aS6Z/O9qxjBgFbBDgpAggggAACCCDgUIGYK0A0D3//868s+fp7nfW0pOzZpVL5a2T+4q8967QY+eb79VKt8g1m3ZWlL5XXh/eTcS8/LS3vvV26PfGcbN66w2zTyZwFS6Vk8cIyd+EKXaRlUuDI4cOybvVKWbpgpmzasCaTvdlzODHY457WWclFWiqRXxcPeYi8auhndEIeNGonxEEMmkn7mxPyYL9i5EYQcwWIyyXS+r4GMnHqJ2co3Vq9ksxdcLp40GLkpvLlRIsT351vKFdG7r7zVpk8bYZnkx77aJfW8tvuP2TPX/s865nJuED+goWkSPFSGe8gCo4khihIwqkhkItTEDY/kAebE3Dq9E7Ig4bihDiIQTMZlpapTpyQh0wBxNDBMVeAqG3pUsXlrGzZZPXajbroaZUrlJONm7eJ3kqlK+dZ72TcUqOSzqbZrr36ctm+81ezbffve6yiY6+ULXOZ1Kl5k3wxd7FZzyTjAtmTkiRvvoKSmJgt453YfCQx2JwAr9OTCy8MG2fJg434Xqd2Qh40HCfEQQyaSfubE/Jgv2LkRhCTBYjytGnWUMa/87F4/y+bVZTcXPE6mbdwuSlCNmzaJpXLX+O9S6r5hITT4c9esExusd5B0R0a3FZd5sxfprOeVq9effFtno3hnqE/BBBAAAEEEEAAAQQcKnD6FXiMBHjihDVQa3LjtVfJX3sPyLbtv4jL5bJWnvx3q/WOx7yvVpgipEql60WLkpNbzpxu/XmXFClU0GyYu2C5TJj6iVSq00LuadtTNm3dLjt+2W226SQ5eYb4Nl1PQwABZwkQDQIIIIAAAghkrUDMFSDeHO1bNTZP7y+/AAAQAElEQVRFwwmrIHGv18Jkxy+/yYcz5okWI+71vo9brcLlvY9mSst7bjeFxoGDh2TZrMmeputnzV/iexjLCCCAAAIIIJA1AvSKAAJxIhDTBUiVStfJWWel/nyBy+WS6jeXt94d2S83lCuTKo0/btzi+Rrel0ZPlmd6d5aSJYrIrC8XS82q5VPtW6taRZk1jwIkFQoLCCCAAAIIIIAAAg4UiGxIMVeAjH2pv+iH0N1MU8cONV+t617Wx0e7tJLk915LdWtWxRuukTkfvmH21a/hHfncE3LVFSe/nal9qybSrUNzPdTTSpcsJtMnjPAsMxO6QEpKiiyaN0M2b1wru3ftMPMHD+wPvSMbjyAGG/F9Tk0ufEBsWiQPNsH7nNYJedCQnBAHMWgm7W9OyIP9ipEbQcwVIJGj4UyZFdAP+VepVV+8W85cuTPbbZYe79s5MfiK2LdMLuyz9z4zefDWsG/eCXlQPSfEQQyaSfubE/Jgv2LkRkABEjlrzoQAAggg4F+ALQgggAACcSJAARIniSZMBBBAAAEEEEAgbQHWIhBZAQqQyHpzNgQQQAABBBBAAAEE4lqAAsQr/cwigAACCCCAAAIIIIBA1gpQgGStL70jgEBwAuyFAAIIIIAAAnEiQAGSyUQ//+IYifWWSQIORwABBBCIaQEGj0BkBXo98qDEeousmPPORgHivJwSEQIIIIAAAggggEAsCMTpGClA4jTxhI0AAggggAACCCCAgB0CFCB2qHNOXwGWEUAAAQQQQAABBOJEgAIkThJNmAgggEDaAqxFAAEEEEAgsgIUIJH15mwIIIAAAggggMBJAaYIxKlATBYgx44fl0p1WsiAoa970nbs2DGp2bCd9Bk00qwb/dZ7Zh/dz92+mLv4jHW6rUGzh8wx+w8cksp1W8n0T2ebZSYIIIAAAggggAACCCAQXoFoKEBCjsjlckmOc8+Rtes3iRYe2sHCpd9KgfwX6qyndWh9tyybNdnT6ta+2TNfuUI5ea7/I2b5s3deMcfMWbBUShYvLHMXrjDLdk6OHD4s61avlKULZsqmDWvsHEqGz00MGaYL64FOyIOCOCEOYtBM2t/Ig/05cI+AXLgl7H10Qh7sFeTsoQrEZAGiQbpcLrmpfDlZ8vVqXZR5C5dJraoVzXxGJ3MXrJBHu7SW33b/IXv+2pfRbsJ2XP6ChaRI8VJh68+OjojBDvUzz+k/D2fuG81rnBAHMUTHM4w8REcedBTkQhXsb07Ig/2KjCBYgZgtQDTAW2tUki+/WiH/HT4iP+/8VUoUK6SrPe2NidM8t1zVbtTesz6tmd2/77GKjr1StsxlUqfmTaK3a6W1X6TWZU9Kkrz5CkpiYrZInTLs5yGGsJNmqEMn5EEDd0IcxKCZtL9FTR4yQeGEGDR8J8RBDJpJGgKhCcR0AVLm8pLy0+ZtVhGyXGpWKS8nTpxIFb33LVhzPxqbapvvwuwFy+SW6pXM6ga3VZc585eZefekXr364tvc23hEAAEEEEAAAQQQiB0BRmqvQEwWIFpoaFO6mytdJ6PGvSu31qisixlucxcslwlTPzHvmNzTtqds2rpddvyy29NfcvIM8W2ejcwggAACCCCAAAIIIIBAUAIxWYB4R3bHbTWkWeP6UqRQAe/VIc1roXHg4CHzgXT3h9Zb3nO7zJq/JKR+Ym9nRowAAggggAACCCCAQGQFYr4AKXxJAWlxT/001bw/A6Jft7t5644095v15WKpWbV8qm21qlWUWfMoQFKhsIAAAuEToCcEEEAAAQTiVCAmC5BsiYmS1mc69HMgg/t2M6ns1PbeVO9o6DsbJUsUMdt0MuyZnlLtput1Vtq3aiLdOjQ38+5J6ZLFZPqEEe7FiD+mpKTIonkzZPPGtbJ71w4zf/DA/oiPIzMnJIbM6IXvWCfkQTWcEAcxaCbtb+TB/hy4R2BXLtznD8cjMYRDkT7iTSAmC5B4SFJCQoJUqVU/VcuZK3dMhU4M0ZEuJ+RBJZ0QBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpy9hAEzK4UIIaBCQIIIIAAAggggAACCERCgAIkEsqcAwFfAZYRQAABBBBAAIE4FaAAidPEEzYCCCAQrwLEjQACCCBgrwAFiL3+nB0BBBBAAAEEEIgXAeJEwAhQgBgGJggggAACCCCAAAIIIBAJAQqQSCj7noNlBBws0OuRByXWmxPS8/yLY8QJzQm5IAYEEEAAgdQCFCCpPVhCAAGHCxAeAggggAACCNgrQAFirz9nRwABBBBAIF4EiBMBBBAwAhQghoEJAggggAACCCCAAAJOFYiuuChAoisfjAYBBBBAAAEEEEAAAUcLUIA4Or0E5yvAMgIIIIAAAggggIC9Ao4oQFo82Fv6DBqZpmRa20a/9Z7c1eoRebDHM9K6cx/5+ts15lhdP/6dT8w8EwQQQACBsArQGQIIIIAAAkYg5guQbdt3yZGjR+Tb1evln3//M0G5J4G2NbituowZ8ZQ89VhH6T/kNTl85Ij7sKh4PHL4sKxbvVKWLpgpmzacLJCiYmAhDIIYQsDKwl2dkIcs5Ilo107IxW21q8mH74yR3VtWyeI50+W+Jg0iahiOkzkhD06IQXPphDhiIwbV9t+cEIP/6NgSjQIxX4DMnr9U6tauKuWvv1oWLlmVyjjQNveOlxYvLGefnSS//f6ne1XUPOYvWEiKFC8VNePJyECIISNq4T/GCXkIv4o9PcZ6Lg4e+lt69B4ohS+vJCNHj5cRQ/rZA5nJs8Z6HjR8J8TglDickAsnxKDPJ1psCMR8ATJ34XKrAKkst9WqLHMWLE2l7rst1cZTC1t/3iX//vefFMx/4ak10fGQPSlJ8uYrKImJ2aJjQBkYBTFkAC0LDnFCHrKAxZYunZCLJctXyc/bf5GjR4/KtI+SJSl7dsmTO5ctnhk9qRPy4IQYNH9OiIMYNJM0BEITiOkCZN2GLXLh+XmkQL68UvGGsrJp607Zf+CQEQi0TXd4Y+I0qVSnhfR//lUZ8EQX80tU1/tr9erVF9/mb1/WI4DAGQKscKBA985tZf3GzbJv/wEHRkdICCCAAAJZJRDTBYjeYrV63UZTSNx0W0vZ8+demffVcmMVaJvu0KH13bJs1mR5e/SzUuH6q3VVwJacPEN8W8AD2IgAAgg4WKB29crS8YHm0ql7HwdH6ZTQiAMBBBCILoGYLUBOnDghcxYskw8nvWgKCS0mRgx6TOYuXCGBtkUXP6NBAAEEYk+gRLEi0r93d2l4X3tZ8+PG2AuAESOAAAKREuA8aQrEbAHyzeofJd9FF0rB/Bd5AtMPom/ZtlO+XPy13217/trn2T+tGfetWXp7lrZjx4+ntRvrEEAAgbgUKF60sEwcM1y6Pfa0bPhpS1waEDQCCCCAQOYEYrYAuaFcGZkwamCq6BMTEmTW9NelVpUKfrflvSCPdGp7r9zfrGGqY3VB1+s7Kd4tW2Kibop4S0lJkUXzZsjmjWtl964dZv7ggf0RH0dmTugVAzFkBjKTxzohD5kkiJrDnZCLLh1ayXXlrjJfwfv37+tF22Uli0eNcTADcUIenBCD5soJcRCDZpKGQGgCMVuAhBZm7O2dYBVTVWrVF++WM1fumAqEGKIjXU7IQ3RIZn4U9uQi8+P27qFnn8GSI/8VqdpPm7d57xL1807IgxNi0CeKE+IgBs0kDYHQBChAQvNibwQQQAABBBBAIDgB9kIAgTQFKEDSZGElAggggAACCCCAAAIIZIVAJAqQrBg3fSKAAAIIIIAAAggggEAMClCAxGDSGDICwQuwJwIIIIAAAgggEF0CFCDRlQ9GgwACCCDgFAHiQAABBBBIU4ACJE0WViKAQEYFnn9xjMR6y2js0XRcr0ceFCe0aDJlLAggEDsCjDS6BShAojs/jA4BBBBAAAEEEEAAAUcJUIA4Kp2+wbCMAAIIIIAAAggggEB0CVCARFc+GA0CCDhFgDgQQAABBBBAIE0BCpA0WViJAAIIIIAAArEqwLgRQCC6BShAojs/jA4BBBBAAAEEEEAAgVgRCGqcMVuAbN66Qx7qNUTu79pPOvUcJMNGTZRDf/9jgv5x4xbp2GOgPNCtv7To2FumTJshJ06cMNu2bNsp3Z8cKk3b95Lb7u4oQ14cJ4ePHJFKdVqk2bbv/M0cxwQBBBBAAAEEEEAAAQQyLxCTBcjefQek46MDpdHttWT8qIEyelhfqX9rFdm3/6Ds+WufPNz7ebm/+Z3y5sgB8toLfSR5ziKZ/ukcozVq3LtS5opL5Z03npPk916TmlXLS1L27LJs1mTTHmrfTO5tVMfM67qihQua4yI9OXL4sKxbvVKWLpgpmzasifTpw3K+uI4hLILh6cQJeVAJJ8RBDJpJ+xt5sD8H7hGQC7eEvY9OyIO9gpw9VIGYLEA+Tp4vFa6/WmpWKe+J94rLSkihi/PLxzO+lIo3lDXbdWOunOfJQx2ayrRPZumi7N23Xypcd7W4XC5JSEiQCteXlWj9X/6ChaRI8VLROrygxkUMQTFl+U5OyIMiOSEOYtBMZm0LpnfyEIxSZPYhF5FxTu8sTshDejGyPXoEYrIA2bnrNylbpnSair/8+rtcdUXqF+3XXFVafv3tD3MbVst7Gki/Z0eZd0ne/3iWHDh4KM1+7F6ZPSlJ8uYrKImJ2eweSobPTwwZpgvrgU7Ig4I4IQ5i0Eza38iD/Tlwj4BcuCXsfQxjHuwNhLPHjEBMFiCqa72BoQ9pNt9tLleCnLD2TDlxQmpVqyBvv/6s1KlZSWbPXyrtHu4vx44ds7YG/levXn3xbYGPYCsCCCCAAAIIIIAAAgj4CsRkAVL4koKy5sdNvrGYZb0Na92GLWbePfl+zXq5pOBFkphwMly9LaveLVVl7EtPy/HjJ2Tt+s3uXf0+JifPEN/md2c2IIAAAggggAACCCCAQJoCJ1+Rp7kpelfeWa+GLFu5Wia9+5kcOXrUDHT9T1tFb7+6s35NWbLiO1nxzckPbh889LeMGvuu3HNnHbOfHnf06Ml3PPQbrv7at18uvCCP2cYEAQRiX4AIEEAAAQQQQCC6BWKyADk/Ty55fXg/WfndWmnWvpd0ffxZmTF7keTJnVPyWsXEyOeekPFTPja3V+lX9N5W62Zp3OAWk4lV1jFN2vSQNl37ScuOvaX1fXdI4UsKmG1MEEAAAQQQQCDDAhyIAAIIBCUQkwWIRlayRBF55fneMn3CCBk19Enp2bW1nJfjXN0kV5a+VF4f0U/GvTxAJr8+RFrcU19cLpfZ9lCH5vLJlJEyYdRAWZQ8Udo0bWjWuyfNmtST7h1buhdte0xJSZFF82bI5o1rZfeuHWb+4IH9to0nIycmhoyohf8YJ+RBVZwQBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpGw9ljawwxW4DEFnPoo9WvCK5Sq754t5y5cofekY1HEION+F6ndkIeNBwnxEEMmkn7G3mwLv1OggAAEABJREFUPwfuEZALt4S9j07Ig72CnD1UAQqQUMXYP6oFGBwCCCCAAAIIIIBAdAtQgER3fhgdAgggECsCjBMBBBBAAIGgBChAgmJiJwQQQAABBBBAIFoFGBcCsSVAARJb+WK0CCCAAAIIIIAAAgjEtICjCpCYzgSDRwABBBBAAAEEEEAgDgQoQOIgyYSIQAQEOAUCCCCAAAIIIBCUAAVIUEzshAACCCCAQLQKMC4EEEAgtgQoQGIrX4wWAQQQQAABBBBAIFoEGEeGBChAMsTGQQgggAACCCCAAAIIIJARAQqQjKhxjK8AywgggAACCCCAAAIIBCVAARIUEzshgAAC0SrAuBBAAAEEEIgtAccVIKPfek/uavWIdHx0oDTr0EteGfuOHDt+3JOV/QcOSeW6rWT6p7M963Rm3/4D8vTzo6XFg72ly2ODpc+gkbJt+y7dREMAAQQQQAABBM4UYA0CCGRIwHEFiCo0uK26vD68n4we1k++/natrLSartc2Z8FSKVm8sMxduEIXPa3nUyMkd67zZPKYIfLqC32kR5dWstcqSjw7RHjmyOHDsm71Slm6YKZs2rAmwmcPz+mIITyOme3FCXlQAyfEQQyaSfsbebA/B+4RkAu3hL2PTsiDvYKcPVSBcBQgoZ4zYvsnJp4ML++FeTznnLtghTzapbX8tvsP2fPXPrP+h3U/ye9//CkPtW9qlnVy4fl55LqyV+isbS1/wUJSpHgp284fjhMTQzgUM9+HE/KgCk6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5eygCJ1+hh3JEDOz7xsRpUqlOC7nlrg5StNDFUqpEUTPq3b/vsYqOvVK2zGVSp+ZN8sXcxWb9jl9+kzKlS0i2bNnMcjRMsiclSd58BSUxMXrGFKoLMYQqlpH90z/GCXnQKJ0QBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpy9lAFHFmAdGh9tyybNVlmvPuqHD5yWOZ9tdy4zF6wTG6pXsnM621ac+YvM/Nm4nKZB3+TevXqi2/zty/rEUAAAQTiQIAQEUAAAQQyJODIAsQtccH5ueWGclfJ8lUnP0Mxd8FymTD1E/PuyD1te8qmrdtlxy+7pUihgvLjxq2pPqzu7sP9mJw8Q3ybexuPCCCAAAIIIIAAApET4EyxLeDoAkS//erb1esk7wV5TKFx4OAh886IvjuireU9t8us+UvMLVn58l4gTz83Wv7ce/JzIfr47Q/rYzu7jB4BBBBAAAEEEEAAgSgTcGQB8tnMBeZreBs27ya/79krTRvXlVlfLpaaVcun4q9VraLMmrfErBv2TA/Jli1R2nV7Wjr1HCQjXp0k5+fOZbZF74SRIYAAAggggAACCCAQWwKOK0A6tb1XPpz0ovkaXv0MyIRRAyVXzvOkfasm0q1Dc/H+X+mSxWT6hBFmVR6r2Hi6Vyf56O2XZPSwvjK4bzcpXvQSs82OSUpKiiyaN0M2b1wru3ftMPMHD+y3YygZPicxZJgurAc6IQ8KEnVx6KBCbMQQIlgW7U4esgg2A92SiwygZcEhTshDFrDQZRYKOK4AyUKriHadkJAgVWrVT9Vy5sod0TFk9mTEkFnB8BzvhDyohBPiIAbNpP2NPNifA/cIMpoL9/HR8EgM0ZAFxhBrAhQgsZYxxosAAggggAACCCCAgD0CYTkrBUhYGOkEAQQQQAABBBBAAAEEghGgAAlGiX0Q8BVgGQEEEEAAAQQQQCBDAhQgGWLjIAQQQAABuwQ4LwIIIIBAbAtQgMR2/hg9AggggAACCCAQKQHOg0BYBChAwsJIJwgggAACCCCAAAIIIBCMAAVIMEq++7CMAAIIIIAAAggggAACGRKgAMkQGwchgIBdApwXAQQQQAABBGJbgAIktvPH6BFAAAEEEIiUAOdBAAEEwiJAARIWRjpBAAEEEEAAAQQQQCCrBJzVLwWIs/JJNAgggAACCCCAAAIIRLWAYwuQ/QcOSeW6rWT6p7M9CTh2/LhUqtNCOj46UNp07ScP935evl+zQQ4fOWLW6zbftn3nb57jmbFfgBEggAACCCCAAAIIxLaAYwuQOQuWSsnihWXuwhWpMnTWWdnk9eH9ZMKogVKrWgUZNe5dScqeXZbNmmzaQ+2byb2N6ph5XVe0cMFUx0dq4cjhw7Ju9UpZumCmbNqwJlKnDet5iCGsnBnuzAl50OCdEEeMx6BpEGIwDLZPnJAHRXRCHMSgmaQhEJqAYwuQuQtWyKNdWstvu/+QPX/tS1MlW2KCXHh+rjS3RcPK/AULSZHipaJhKBkeAzFkmC6sBzohDwrihDiIQTNpfyMP9ufAPQJy4ZYI9Jj125yQh6xX4gzhEnBkAbL79z1W0bFXypa5TOrUvEm+mLvY43X06DHP7VbDRk2Sts0bebZF00z2pCTJm6+gJCZmi6ZhhTQWYgiJK8t2dkIeFMcJcRCDZtL+Rh7sz4F7BOTCLWHvoxPyYK8gZw9VIKYKkGCDm71gmdxSvZLZvcFt1WXO/GVmXid6C5beWrUoeaIM6tNVnh76uq5Ot9WrV198W7oHsQMCCCCAAAIIIIAAAgikEnBkATJ3wXKZMPUT807HPW17yqat22XHL7tTBZ4tMVFuKl9O/tq7X/63569U29JaSE6eIb4trf1Yh4BDBQgLAQQQQAABBBAIi4DjChAtNA4cPOT5ELm+29Hynttl1vwlZ4D9uHGL/PPvf5Ind84ztrECAQQQQACB6BBgFAgggICzBBxXgMz6crHUrFo+VZZqVasos+adLED0MyD6NbxtH3pKOj06SHp2aSXZzzor1f4sIIAAAggggAACCCAgEGSJgOMKkPatmki3Ds1TYZUuWUymTxghetuVviOiX8P71ivPyMLPx0vDejVT7dusST3p3rFlqnV2LKSkpMiieTNk88a1snvXDjN/8MB+O4aS4XMSQ4bpwnqgE/KgIE6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5e6gCjitAQgWI1v0TEhKkSq36qVrOXLntGm6GzksMGWIL+0FOyIOiOCEOYtBM2t/Ig/05cI+AXLgl7H10Qh7sFeTsoQpQgIQqxv4IIIBARAU4GQIIIIAAAs4SoABxVj6JBgEEEEAAAQTCJUA/CCCQJQIUIFnCSqcIIIAAAggggAACCCCQlkAwBUhax7EOAQQQQAABBBBAAAEEEAhZgAIkZDIOQCCSApwLAQQQQAABBBBwlgAFiLPySTQIIIAAAuESoB8EEEAAgSwRoADJElY6RQABBBBAAAEEEMioAMc5W4ACxNn5JToEEEAAAQQQQAABBKJKgAIkqtLhOxiWEUAAAQQQQAABBBBwlgAFiLPySTQIIBAuAfpBAAEEEEAAgSwRoADJElY6RQABBBBAAIGMCnAcAgg4WyBmC5D23QdIw+bdUmWna68hUu/ezp51b07+SFo82Nu0Rq26y7oNW8w2PbZSnRbibpOnzfDMu9e5H7fv/M0cwwQBBBBAAAEEEEAAAYcLRCS8mC1AXC6RHDnO8RQV+w8ckr1794vLZW2w6LTY+HjGPBkx+DGZPGaIjH6hr5xz9tnWlpP/xox4SpbNmmxai7vrm0ddfqh9M7m3UR3PctHCBU8eEOHpkcOHZd3qlbJ0wUzZtGFNhM8entMRQ3gcM9uLE/KgBk6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5e6gCMVuAaKC1qlaUuQuX6azMnr9UalatYOZ18qdVjJQoVljy5b1AF6VA/rxSotglZj5WJvkLFpIixUvFynDTHGfMxuAVDTF4Ydg8Sy5sTsCp05OHUxA2PzghD0rohDiIQTNJQyB4gZguQCreUFaWr1xtop23cIXU8ipAyl93lfxnvYvQ9qGn5IVXJsj3azaY/dyTB3s847ntavf/9rhXR81j9qQkyZuvoCQmZouaMYU6EGIIVSxr9ndCHlTGCXEQg2Yy/ZbVe5CHrBYOvn9yEbxVVu7phDxkpQ99h18gpguQbNkS5crSJWX+4pWSkJggF5yfS06cOGGUzk7KLq8P7yePd7tfEhNd0qPvMEme85XZphPvW7AK5MurqwK2evXqi28LeAAbEUAAAQQQQACB2BJgtAhERCBmCxBTZ1iTWtUqWO9wjJfaXu9+uOVcLpdcXqq49OjcWnp2bSXJc5e4N4X8mJw8Q3xbyJ1wAAIIIIAAAggggAACcS4QswWIO28Vbigrd9arITWtQsS9Th93/LJbtv68S2fleEqKrF2/RS48P7dZTnfCDggggAACCCCAAAIIIJAlAjFfgCQmJEiH1ndLnlw5UwEdPnJYnhz0ktzftZ80aNpVvluzQR5s0yTVPiwggED0CTAiBBBAAAEEEHC2QMwWIGNf6i+lSxVPlZ1cOc+T5PdeM+tKlSgq7457QcaPGmjWTR37vFxcIJ/ZpseWLXOZmfedNGtST7p3bOm7OuLLKda7NovmzZDNG9fK7l07ROcPHtgf8XFk5oTEkBm98B3rhDyohhPiIAbNpP2NPPjNQcQ3kIuIk6d5QifkIc3AWBm1AjFbgEStaJgGlmC9s1OlVn3xbjlzxdYtZMQQpidDJrtxQh6UwAlxEINm0v5GHuzPgXsE5MItYe+jE/Jgr2A4zh5ffVCAxFe+iRYBBBBAAAEEEEAAAVsFKEBs5efkvgIsI4AAAggggAACCDhbgALE2fklOgQQQCBYAfZDAAEEEEAgIgIUIBFh5iQIIIAAAggggIA/AdYjEF8CFCDxlW+iRQABBBBAAAEEEEDAVoGoKkBsleDkCCCAAAIIIIAAAgggkOUCFCBZTswJEIgJAQaJAAIIIIAAAghERIACJCLMnAQBBBBAAAF/AqxHAAEE4kuAAiS+8k20CCCAAAIIIIAAAm4BHm0RoACxhZ2TIoAAAggggAACCCAQnwIUIPGZd9+oWUYAAQQQQAABBBBAICICjihAjqekSLMOvWT12o0etM6PDZYvF31tlmfM/kraPvSUPNCtv7R7uL+s+OYHs14n7bsPkIbNu+msp3XtNUTq3dvZs8wMAgggkHUC9IwAAggggEB8CTiiAElMSJA+PTrI4BFviBYjs+cvlXPPSZKaVcrLV8u+lTETp8uz/brJmyMHyOPd2krfwaNk89YdJtMul0iOHOfIug1bzPL+A4dk79794nJZG8waeyZHDh+WdatXytIFM2XThjX2DCKTZyWGTAKG6XAn5EEpnBAHMWgm7W/kwf4cuEdgey7cA8nEIzFkAo9D41bAEQWIZq/M5ZdKuauukLemfCRjJ30gPbu20dXy/kcz5f5mDaVAvrxm+bJLi8pdt9eSaZ/MNss6qVW1osxduExnRYuXmlUrmHm7J/kLFpIixUvZPYxMnZ8YMsUXtoOdkAfFcEIcxKCZtL+RB/tz4B4BuXBL2PvohDzYK8jZQxHQAiSU/aN63y7t7pPJ730udWtX8RQcu377n1x9ReoX8VdeXlJ2/vq7J8hpo6cAABAASURBVJaKN5SV5StXm+V5C1dIrSgoQLInJUnefAUlMTGbGVcsToghOrLmhDyopBPiIAbNpP2NPNifA/cIyIVbwt5HJ+TBXkHOHqqAowqQH9b9JPkuukC+Xf1jKgeXK/DtVNmyJcqVpUvK/MUrJSExQS44P5ecOHEiVR/16tUX35ZqBxYQyJAAByGAAAIIIIAAAvEl4JgC5L/DR2TkG1Nk5HNPyJGjR2XB4lUmk5cUzCdr128y8+7Jjxs2S+GL85tFU2dYk1rVKsgLr4yX2n7e/UhOniG+zXTABAEEEEAgNgUYNQIIIICALQKOKUDGTpout9a8SQrmv0ie6P6AKUa0ELmn0W0y/p1P5I89fxngjZt/lg8+myv3NKpjlt2TCjeUlTvr1ZCaViHiXscjAggggAACCCCAQPgF6DG+BRxRgGzbvksWLlklre+7w2SzRNFCcnPFcjLp3c+kaqXrpH2rxtJrwEvmK3j1XY6BT3aVS4sVFu//JSYkSIfWd0ueXDm9VzOPAAIIIIAAAggggAACYRRICGNftnVVvOglMn3CCMl+1lmeMfTo3FratbzLLNe/taq89cozMu7lAaZVuvEas14nY1/qL6VLFddZT8uV8zxJfu81z3LWzfjvOSUlRRbNmyGbN66V3bt2mPmDB/b7PyAKtxBDdCTFCXlQSSfEQQyaSfsbebA/B+4RkAu3hL2PTsiDvYKcPVQBRxQgoQYdC/snWO/IVKlVX7xbzly5Y2HonjESg4fC1hkn5EEBwx6HdhrhRgwRBvdzOvLgB8aG1eTCBvQ0TumEPKQRFquiWIACJIqTw9AQQAABBBBwogAxIYBAfAtQgMR3/okeAQQQQAABBBBAIH4EoiJSCpCoSAODQAABBBBAAAEEEEAgPgQoQOIjz0TpK8AyAggggAACCCCAgC0CFCC2sHNSBBBAIH4FiBwBBBBAIL4FKEAymf/ej3YWGgY8B3gO8BzgOcBzgOdADDwHouI1S0JCosR6y+TLx7g/PCHuBaIcoFWr1vLHH39E+SgDD++5556XhQsXBt4pyrd+9tln8tpro6N8lIGHt2nTJunW7eHAO8XA1oYN75QjR47EwEj9D/HJJ/vId99953+HGNgyZco7MmXKlBgYqf8hfvPNN9Kv31P+d4iBLf/995/cdVfjGBhp4CF27fqQbN26NfBOUb511KhXZcaMGVE+ysDDmz9/vgwd+kLgnaJ86++//y5t2twf5aNkeAlxSUDQCCCAAAIIIIAAAgggYIsABYgt7JwUgfgVIHIEEEAAAQQQiG8BCpD4zj/RI4AAAgjEjwCRIoAAAlEhQAESFWlgEAgggAACCCCAAALOFSAybwEKEG+NKJyfNGmiXHTRRVE4suCH9MQTvaRatWrBHxCFezZo0EA6d+4UhSMLfkilSpWSkSNfDv6AKN3zk08+luzZs0fp6IIb1rPPDpZrr702uJ2jdK/mzZtJ8+bNo3R0wQ3r+uuvl4EDnwlu5yjd6+yzz5YPP/wgSkcX/LBGjXpFSpQoEfwBUbhn165dpH79+lE4suCHVKNGDXn88ceCPyAK98yfP79MmDA+CkfGkLwFKEC8NZjPcgFOgAACCCCAAAIIIBDfAhQg8Z1/okcAgfgRIFIEEEAAAQSiQoACJCrSwCAQQAABBBBAwLkCRIYAAt4CFCDeGmGa/+6H9fLEMy9J7Ubtpd3DT8vCpd94et7z517p+viz0vahp+TJgS/Lv//9Z7bNmP2VtO8+wBzzaL8XZNv2XWZ9oL6OHTsmo8ZNlZadnpT7u/aT7k8+Lzt37TbH6WTYqIlS/74u0rT947oYUtv9vz0y5MVxUvfuTnJfu8dk4tRPPcf7i8HfWAP1pZ1q7OrxQLf+lld/WfHND7ratNfefNec//b7usozL7wuh0P8D9D5O/7Y8eMyeMRYadOlr3R4ZID88utJt0Bj9deXDvTHjVukY4+BojG06NhbpkybISdOnNBN8v7Hs6RK/TZS7fb7pWuvIaL7mg1BTtSnfRrPDT1c+9bzterUR75a9q2uMs3fWAP1teevfeZ5qyb6nNL8H/r7H9Ofe7J33wGp2bCdjH7rPfeqoB79PTf04NVrN0ob6/mr5xz39ul72f2Ndd2GLXLLXR2kUp0W0rpzH/li7mLtxrRYuSaOp6RIo5bdTQxN2vSQV8a+Y8bvnmjssXBN9H/uNRPDrY0flD6DRsrBQ3+7Q5BAMbwf4Wsi0HUdaCx6rfq7rt2BZvSaUB9/17W/a8LfdR1oLOld15n5PRHouvb3eyJQ3O449GeQ2riX07uu03Nx95PWY6Dnhr/fE4Hidp/jlTemmGtD+3Cv09j9XdeBnofu4wM9BjLQvn1/TwSK232er79dY2JYvmq1e5X5/RUL18R7H80yY9ffE9omvfeZJ4ZA14Rezz37DZMaDR+QoSP5HIkHLQtmIlqAZMH4o7LLc885W3p2bSOzPhgjre+7QwYPf8MzzpfHTJGKN1wjb73yjOTKldN6oZpstuXPd6GMGtpbPpv6ipS6tKi8Pv7kC7xAfb1qvTjftGWHvDXyGRk/aqDUqlZBtLg5cvSo6bNsmVIy8MmuZj7USUJCgjRpeIt8MW20DO7bTaZ9Mlu2bNtpuvEXg7+xBupLXzSPmThdnu3XTd4cOUAe79ZW+g4eJZu37jDnuubqy+XdcS/IpNGD5a+9++Wjz78064Od+Dv+s5kLrP72yYRXB0mTO26R5156y3QZaKz++tIfZg/3fl7ub36nieG1F/pI8pxFMv3TOabP6jffKPM+Hiszp4+WW6wcjRzzjlkf7MTfc2P7zt9k0rufyZgRT8nQpx8xz7P/Dh8x3fobq7++9CD9oXtp8cLGZNJrg+XI0WPyrFWk6TZ3G/7qJLnumstFXBLS//w9N7RIe2rIq/L4Q23Mc/jLRV+L/nLXzv2NtfAl+eXDSS/K4i8mmevs5TGTPYV8zFwTLpeMHt5Xls2aLMMHPibfrl4v+ste446la6Jdy7tk6cy3rWt0qJyX41x5Z3qyhmCK4UDXdaSviUDXtb+xpHddm0CtSUavCX/P70DXhL/r2hqG+ZfWWNK7rjPze8Lfda2DeTnE33V6jLaPk7+UfBddINYlooumpXddp+diOvEzCfTc8Pd7IlDcehr9A+JPW3ZI9rPOsuI4+cMyveva3/NQ+wum+TPw93siUNx6Pn0d8dpb78uVpS/1xBBr18QDLe4yP2P152yrextoWKald03Uu7WqtG/Z2OzLJOsEKECywLZ0qeKS94I8kpiQIDdXvFaOWgXBv6fe6Viy4nupf2sVc9b6t1SRxSu+M/M3lCsjSdmzyzlnny2Vy18rv+/Za9b760v/qvLBZ3OlR+dWctZZ2cy+DepUt35wXyjzrRdxuuLWGjfJhefn0dmQW768F0ipEkVF/3dpscKiL0x/3f2HLoq/GPyNNVBf7380U+5v1lAK5Mtr+r7MKr7uur2WKXh0ReXy5fRBLjg/t5SzipH/7fnTLAc78Xf8kuXfST3LX/upWbWCrLPewfj7n38l0Fj99fXxjC+torKsVLj+au1OcuU8Tx7q0NSKYZZZ1j71F5Hm9hyrOD0hJ8z6YCf+nhuLl38r1SrfIDnOPUcK5M8rl1vPu5XfrhX9Xxpj1dXiry990b9v/0Fp27yR2c/lclnPrZay9OvVon/J1JX6V9lzzkmSMpeXkhBDEH/PjY2bf5Zzzz3H/JLLlpgot1rP2UVWXHo+f2NV35zn5TDXV26riHe5EiQl5YTE0jXhcrnE/Zy/8ILcGq71jpl5kFi6JgpfUkBcLpfkyZ1T9AWN+7mdXgyRvib0fP5+num2tK7P9K5rzVZmrgl/z+9A14S/69rfWIK5rvWay+jvCX/XtY7H3+8Jf3HrMQcOHpJPv1ggzRrX00XTgrmuA7mYTgJMNP/+nhv+fk8EiltP9cKoCdLr4futH5PWFeF+Jzyd33U6jrSeh9pfMM2fgb/fE3o+f3Hr+SZO/UTua1TH/GFBi2JdF2vXhI7Zt6V3TZyfJ5fUrFJezrF+1/key3J4BRLC2x29+Qp89Pk8KWm9kNcXn/oC1/pdLfoE1/30L7l/7PlLZ1O1qR8kS4Xrrkq1The8+9r9+x7RPosWLqibPK3M5SVkh9dtWJ4NmZjRdz7W/7RVrrbeUQk2Bu+xep/auy9dv+u3/8nVV1gvaHXhVLvy8pKy89ffTy2dfNAC7vNZC6V8Gi4n9wg89T3+jz/3yiUF85uD9IWvvhj83x+pc+E7VrOzNfHt6xdrrFf5xHDNVaXl19/+sF5Uniw2xr39oXk7+NVx75p3lKxuMvTP+7nxx59/ycUFLvL0U+ji/PI/nwLNd6yena0Z777U+/JSxcyLemuT+acv8vX5tX3nr6K3QLwydqo81L6p2ZaZifdz43fL/BKvGPSa+P1/f57RvfdYdaP+EtG31fX2wsF9HzJFWCxeE5XrthK9naxKxevEXcDG2jWh77pqHL//sUfaWX9x1PwEE4Nd10Ra13VaY0nvug7tmlAV/837+R3MNeF7XfsbS3rXtf8Rhb7F+7oO9veEd9x6xpetd4cf7tj8ZDF78kenhHJd+7pon6E03+fGH0H8nvCOW8+VPHeR3HDNlVLo4gK66GmRuiZ8Df4I4veEb9w7rdcQa9dvkdtq3ewZv87E0jWh49V3ZPVWqsefHmH9bjz5+z2S14SOgeZfgALEv02mt/yw7ieZMj1ZnnrsQU9f+ldC94LLdSa/fnZg34FD0rbFyb9Eu/dNqy8tZtzbvR9Tjqd4L2Zqft+Bg9J74EvSt+eDksf6a7N2ll4MaY1Vj0urL13vcp18i1rn3c07Bv3rS9/Br5i/Sujta+59gn30d7zLdfq8CV7z2q+/sfrvS4863TS3ep+/Nl2rt6rM//Qt6fZgM9FYdF2oLa3nhst6l83dj8t1Oh5d52+sui2tvsTneN1Pm8YwZVqy3NWglnl3R9dltKX13HAleI87uGvi2rJXmFuw3hw5QF4Y+Zbo7Xk6Jj8hiPfzSffLTEvruZHRa2LJF5Nk2vhh8sOPP1nvNn3vGZbL5W1ycrV3DIFye3LvwFN/x7tcp8+b4DWvvaUVt64fNfRJc6tm8SKXyFtTPtJVprlcp/syK6yJdwx2XBP+YvA3Ft8QXK4E0etBW7iuibSuRVeCt13qayKt3AUci28QVh70n8agj+FoaV3X6V0TvnHrZ7t0LNeUKa0PqZqfEFJd12m5pOoknQV/zw2X63QuErzmtTvfuPUzc3qbcKumd+jmM5rLdbov98ZwXhP+DAL9nkgrbv1c0GMPtXYPMdWjbwjRek3cUr2izP7gdXl79LOS87zzZNCw07fCi28QpyIM5zVxqkseAgik/skWYEc2hSbwh/XOhn5AXD/Xobcp6NF6q8xxqzjQeyt1+c+9++SivBforGlff7tGvlm9Tl569nFzO5ZZaU3S6qtA/rzy9z//yY5fdlsfNqF4AAAQAElEQVR7nP63bsNWuaxksdMrMjGnF+MzQ0fLI51aSdVK15me0oshrbHqgWn1pesvKZhP1q7fpLOe9uOGzVYMRTzL+sHky0sVl84P3OdZF8pMWsdfdOH5nhet2tdf+w6I3nes8/7GqtvS6kvfeXD/8tR9tH2/Zr25bU3fXdFlbWcnZZdaVSvK2h83SUpKaEViWs+Niy68QPbt269dm/aX9XzKl/dCM6+TtMaq69Pqq7D17one+uE9Lv1Asf7FS2+L01sFB74wxryL88bEaaIf6Hvp9be1u6BbWs+N/BddIHv3HfT0oTHovfHuFWmN1b0tMSHB3HaWP19e0bHH2jXhjkP/Unrt1VfI92s2mFWxdk3ooPWPEzWqlJevv12ni9a7i+lf17pjJK+JQNd1WmNJ77oOxzWR1vM7vWsireva31jSu6417sy2tK7r9H5PpBX3V0tXSfKcr8zPmAd7PCP6e0G/ZCLY6zotl2Bj8/fcCPR7Iq24dczaqtRrbeI4evSY6Ly+IxTMda3jzcw1kZZBoN8TacV97Phx6zpeI3ff39PEoLl6pM8L5st0Yuma0Nu2s2XLZr0Tld96DdNC9C4O9Y3ENaHnoaUvQAGSvlHIe+g9832sv9g/+Uh7KZj/9C0y2tFN5cvJ3AXLdFZmz18qN1c4+RmH1es2yvh3PpFn+3U3H1wzO1gTf33pC9smd9SWYaMmiP7AsHaVz2YtkMOHj0iVitfqoncLeV5/cPYf8prUu6WqVLrxmlTH+4vB31gD9XVPo9tM3PrDXE+iLyS/mLdE7rmzji6KfpPFnj/3SftWTcxyqBN/x99kuc9duMJ0t+KbNVKi6CXmNp5AY/XX1531a8qSFd+J9qMd6gv3UWPflQdO3Y6iv5D0L1O6bdGyb6VI4YLi/ddBXR+orfbz3Li54nWin5fQbwb7a+9++XHjVqlww8nPofgbq7++9B2F3DnP8/wFW8erH2itW7uK5MmdS8a+1N/zYb4Ore8W/UBf944tAw071TZ/z43SVrGs2/Qtf/1lOM/KicalB/sbq35BwT///qe7mG8v27p9l5QqUURi6Zr4/Y8/za0lGoT+1VR/yZcuWVwXJZauiTVWMa2D1twtWLJKSpcqpovpxhDpayLQde1vLOld15m9Jvw9v0sHuCb8Xdf+xpLedW2SlYmJXrvh+l3Xqe29np8x+sUaelvrxNcGB3Vd+3MJJrRAzw1/vyf8xa3v0OsHnt1NP5+5KHmi+d2S3nXt73kYTAy6jz8D/Xma1u8Jf3Hrz1H3+PWx/HVXy4uDH5NqN10vsXRN6M9VddH25Vcr5IrLSuisZPU1YU7CJCiBhKD2YqeQBPQbo/QXs96frvepa9v9vz2mj+4dm1uFwlfma3h37PxNmt9d36zXF6z6F9Aad7Q1f3Vo0qaHWR+ory7WOwKXlSwq+hW8Tds9Jm+/95m8PqKfaNWvB7fvPsB8he3PO341fer9kLo+mKbvxMz7arn0e3aUOVZj0L9O6bH+YvA31kB96Tsr7Vs1ll4DXhL9a1f77k+LvgOkfxXWwkr/yv7pzAWeMQz0fhtVBxOgBTr+jro1rCLAJfp1j29O/lB6PfyA6cnfWAP1pV848PKQJ2T8lI9NXu9o3k30G8Rq3Hyj6XPp19/Lzaf+Ivbcy29af40J/oW7duDvuaGfz2hUv5b56t/uTw6VRzq3MsVroLH660vPM2xgT9Fvb9GvxNWvb9Yi5NEurXRTppu/54bL5ZIBT3Q2zzPNxfXXXinXlb3CnM/fWHft/kMaWsb6nGzW4Qm57666ktd6R0sPis5rYpP5Kmwdrzb9WaBfTPHQE0PM81o/A5JHP/hYtbyGYN5tjIVrQgc7ZuJ0E8PNdVvJ8lU/mG/90/WBrmvdHulrwt91HWgs6V3Xemxmmr/nt8uV9jUR6LoONI70ruv2mfg94e+61vH4+z3hL249xl8LdF1n1MV9rkDPDX+/JwLF7e7X9zErr4lABv5+TwSK23fs7uVYuiYGDTv5jn2tO9uZPw7269lB3P8LdE2opf6c1q/g/WjGPPPzbeOmbe5DeQyjQEIY+6KrUwLef8nRvyBoK5Avr9mqL5RGD+srb73yjDzb72HzQXLdMNbrL8y6//QJI3S1BOpLC42u7ZqK3uM4eng/668s54p+IM4caE18+2zW5PQ3i1ibA/7z/UuOjknfDdGD/MXgb6yB+tL+6t9a1XjoVwnXqVlZRo19x3x42/cvMToG7x8iemygFuh43danR3vRr+F948X+UqRQAdOVv7Hq/np+7+Y9ljKXX2qKP81rj84tRe9v3n/gkOlT3zHQe/312Bnvvio3XnvmFwyYHf1MfPPofm7o7vpO0eTXh8ik0YPNX6h0XaCxBupLf7noVy5PGDVQRgx6TLQg1ndVtE/vpt9aprn2XpfevO6v8Xs39zWhH9jXPLw9+lnx/upDf2PVv8TN+fAN89fSrz6fIM0a1/WcPlauCS2wp40fbmJQk8F9HhKX6/T94bFwTSj6qOd7e2LQ52E+r1tK/cWgx0X6mvB3Xac3lkDXtR7rbhm5Jvw9v7XPtK6JQNe1HuNuvmNJ77r2HUcovycCXdf+fk/4ns/755k7hrJlLjPvurqXA13X6bq4O/HzGOi5oX2n9XsiUNzep9GfT9qHe11WXRN6Dv054t28fz+l9XsiUNzu8erjy0N6ie6r89pi5Zp4rv8j5mfTvI/HmS9+8b7dPdA1kZZl6VIn353W+GnhE6AACZ+lrT3pbTL6At79joqtg8ngyfW2JP1hP2LQ46lejGWwO9sOa1CnuuiLy9y5zrNtDJk9sX7m5pMpI0V/2WS2L7uO55qwSz71ebmuU3vYucR1baf+6XNzTZy2sHvOCdeE3YaBzh9oGwVIIB22IYAAAggggAACCCCAQFgFKEDCyklnCPgKsIwAAggggAACCCDgLUAB4q3BPAIIIICAcwSIBAEEEEAgKgUoQKIyLQwKAQQQQAABBBCIXQFGjkAgAQqQQDpsQwABBBBAAAEEEEAAgbAKUICEldO3M5YRQAABBBBAAAEEEEDAW4ACxFuDeQQQcI4AkSCAAAIIIIBAVApQgERlWhgUAggggAACsSvAyBFAAIFAAhQggXTYhgACCCCAAAIIIIBA7AjExEgpQGIiTQwSAQQQQAABBBBAAAFnCFCAOCOPROErwDICCCCAAAIIIIBAVApQgERlWhgUAgggELsCjBwBBBBAAIFAAhQggXTYhgACCCCAAAIIxI4AI0UgJgQoQGIiTQwSAQQQQAABBBBAAAFnCDizAHFGbogCAQQQQAABBBBAAAHHCVCAOC6lBISAvQKcPXSBI0ePyhsTp0mLjr3lwR7PSNfHnzXLx44dC9jZ+Hc+kVHjpgbcJ9SNHR8dKN/9sD7Uw2zZ//NZC2Xnrt22nJuTIoAAAghkXIACJON2HIkAAgiERWDgC2Pk2x82yOvD+8mYEU/JqKFPymWXFpd//zsclv6d2snMeUtk12+/OzW8jMTFMQgggEBMCFCAxESaGCQCCDhVYPvO32TB4pUysHcXOS/HuZ4wq998g+Q8L4f8tXe/tOz0pDTr0EvufaCnTH5/hmcf75l///tPhr86SZq27yXNOzxh3hlJSUkxu+i7GsNGTZQujw2WVp36yLRPZpv1OtmwaZu0e7i/1Z6WXk+PkP8OH9HVpr374Uype09nc+7uTz6f6t2GSnVayGtvvivdnnhOpn7whdnfezLryyXWWB437+iMHv+eVK7bymw+cPCQ1GnS0czr5Njx41L19jY6a1rfwaOkQdOucl+7x2TwiLFWEfafWb/yu7XSpms/eWLAi9K11xB5ffz7snHzz/LKG1NF41u9bqPZN5DB0JHjRd9d0oLPdMoEAQQQCJsAHYUiQAESihb7IoAAAmEW+HnHLil0cT65KO8FafZ8zjlJ8mzfbvLOG8/LuJcHyJeLVljvlqw/Y99xb38ox60X85NeGywTXh0kv//vT3n/49OFhhYjI5/vLZNGD5YPP5sj/9vzl+ljwNDRUq92Favvp+WOujVlo1WQmA3WpPx1V8tn74w057615k0y5KU3rbWn/xW6OL+MfO4Jadq47umV1tyeP/fKcy+/Jc9YRZW+o3Ps2HFrbXD/Wt3XQD6bOkomj3lOsiUmyuRppwuuTVu2S8f775VRVhwd779HSpcsJg91aGreObqmTGlJz+Bf6x0lHW+/xx4MbjDshQACCCCQJQIUIFnCGr+dEjkCCIRX4OykJPluzQYZMPR1eaz/CNm774Bs+GnbGSdZsWqNrF2/WR56Yohpm7Zulx+sdwXcO1a96TpJTDj5Iz/fRXll2/ZfZP+BQ/K/P/6SO+vXNLtVrlBOihYuaOZ1kpCYIOMmfygP935ePv1igfxkveOg692tTq3K7tlUj6vXbZJrry4tpUoUNeubNalnHoOZ6DskI16bKA8/8Zys+XFTqoLoskuLSrEiF/vtJj2DWlUrSMIpA7+dsAEBBBBAIMsFTv42yvLTcAIEEEAAgbQEihW5RH759X/yx6l3JHz3+Xz2QvnyqxXS8p4G5rMhN1e8Tv759+RtSan2dYk82qWVeTdAP0vy7rgX5Nl+D3t2SUxM9Mzri/Bjx1LkhPV/ndfm3pgtMZt7Vnr0GSqXXVpMnu7VSYY+/YjoOwiejdZMUvbs1jSNfydOSLZsp/s5y2tex6HvxriP8n53RG9HGzTsDalTs7IMH/SYtG3RSP777/QtYUlJfs7n7swlAQ2Sks5y78kjAggggICNAhQgNuJzagQQQEDfcah+843y+NMvyroNWzwgCxavkoOH/paft++Sq6+8TEoUu0T0xfqyld979vGeqVy+nIyZON0co+v/3LvPfEZC5/21PLlySt4L88jqtRvNLr/u/p/oLWG68O9//8ne/Qfk5orXyvl5csnchct1dVDtmqsuk+/XbJTNW3eY/ad6fUYkx7nnyNlWIaGfbdGNi5Z9ow+m7dy1WwpdUkDKXF7S7DPPKrzMBj+THOeeLQcO/u3ZmhEDz8HMIJApAQ5GAIFQBChAQtFiXwQQQCALBPQzCZVuLCsDhr5mPiSuHxbftG27nHN2kjS6vbbMnLdYOvYYKE8//5r1jsTJ25p8h3F/80ZyealiZj/9Ot82nfvK3n37fXc7Y/npxzvJhKmfmg+oj3h1khQscJHZ55yzz5bmTepL03a9RG/B+vOvfWZ9MJO8F55v3onoN2SUdfxj5rMp3se1vLeBdHhkgOl3xy+nv0a3/PVXmdvE9IPyPfoOlfNz5/I+7Iz5e+6sI7O/XCqdHxss+iH0jBqc0TErEEAAAQSyVCCsBUiWjpTOEUAAAYcKZD/rLOnQ+m55/63hoh8Sf/WFPtK+ZWNzG5N+0Hva+OHy+oh+8txT3c1tVe1a3iX6v/ubNZSu7ZrqrHnHoFuH5jLljedk8utDzAe5K95wjdmmt2TdeO1VZl4nLw5+TPTzQ9rkMwAAA6lJREFUHjpfulRx0WU957CBPUXPdW3ZK3ST6Hk+mDhCXh7SS9q3aiJLvphk1utk2azJ+uC36W1UU8cOlanjXpDOD9yXaj8tHKZPONnvAy0ayVefTzDb1UHPpQYjBj0uPbu2Nred6UYdv8ah8+52fbkyomN+zfLSD6HrOyvBGrj74BEBBBBAIPICFCCRN+eMCGSFAH0igAACCCCAAAIxIUABEhNpYpAIIIBAbAt4v3sS25GkNXrWIYAAAgiEIkABEooW+yKAAAIIIIAAAghEjwAjiUkBCpCYTBuDRgABBBBAAAEEEEAgNgUoQGIzb76jZhkBBBBAAAEEEEAAgZgQoACJiTQxSAQQiF4BRoYAAggggAACoQhQgISixb4IIIAAAgggED0CjAQBBGJSgAIkJtPGoBFAAAEEEEAAAQQQsE8gM2emAMmMHscigAACCCCAAAIIIIBASAIUICFxsTMCvgIsI4AAAggggAACCIQiQAESihb7IoAAAghEjwAjQQABBBCISQEKkJhMG4NGAAEEEEAAAQTsE+DMCGRGgAIkM3ociwACCCCAAAIIIIAAAiEJUICExOW7M8sIIIAAAggggAACCCAQigAFSCha7IsAAtEjwEgQQAABBBBAICYFKEBiMm0MGgEEEEAAAfsEODMCCCCQGQEKkMzocSwCCCCAAAIIIIAAApETcMSZKEAckUaCQAABBBBAAAEEEEAgNgQoQGIjT4zSV4BlBBBAAAEEEEAAgZgUoACJybQxaAQQQMA+Ac6MAAIIIIBAZgQoQDKjx7EIIIAAAggggEDkBDgTAo4QoABxRBoJAgEEEEAAAQQQQACB2BCIzQIkNmwZJQIIIIAAAggggAACCPgIUID4gLCIAAKBBdiKAAIIIIAAAghkRoACJDN6HIsAAggggEDkBDgTAggg4AgBChBHpJEgEEAAAQQQQAABBLJOgJ7DKUABEk5N+kIAAQQQQAABBBBAAIGAAhQgAXnY6CvAMgIIIIAAAggggAACmRGgAMmMHscigAACkRPgTAgggAACCDhCgALEEWkkCAQQQAABBBDIOgF6RgCBcApQgIRTk74QQAABBBBAAAEEEEAgoEBIBUjAntiIAAIIIIAAAggggAACCKQjQAGSDhCbEYgSAYaBAAIIIIAAAgg4QoACxBFpJAgEEEAAgawToGcEEEAAgXAKUICEU5O+EEAAAQQQQAABBMInQE+OFKAAcWRaCQoBBBBAAAEEEEAAgegU+D8AAAD//w2n+lwAAAAGSURBVAMAQsYAWHftyOwAAAAASUVORK5CYII="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAJYCAYAAACadoJwAAAQAElEQVR4AezdCaBMZRvA8WfulVvJUslS9kilpM2S7EpIJVrsErIlSUlIQkqopCTKEqloz80askeLELKFFF/K2mK7vvO8zJg77syduXfunJkz/+/znjnre97n98y5d547Z6aEI0cOn6BhwHOA5wDPAZ4DPAd4DvAc4DnAc4DnQCSeAwnC/xBAwCYBTosAAggggAACCMSfAAVI/OWciBFAAAEEEEAAAQQQsE2AAsQ2ek6MAAIIIIAAAgjEnwARI0ABwnMAAQQQQAABBBBAAAEEIiZAARIxat8TsYwAAggggAACCCCAQPwJUIDEX86JGAEEEEAAAQQQQAAB2wQoQGyj58QIIIAAAgjEnwARI4AAAhQgPAcQQAABBBBAAAEEEHC+QNRESAESNalgIAgggAACCCCAAAIIOF+AAsT5OSZCXwGWEUAAAQQQQAABBGwToACxjZ4TI4AAAvEnQMQIIIAAAghQgPAcQAABBBBAAAEEnC9AhAhEjQAFSNSkgoEggAACCCCAAAIIIOB8gfgrQJyfUyJEAAEEEEAAAQQQQCBqBShAojY1DAwB5wkQEQIIIIAAAgggQAHCcwABBBBAAAHnCxAhAgggEDUCFCBRkwoGggACCCCAAAIIIOA8ASLyFaAA8RVhGQEEEEAAAQQQQAABBLJMgAIky2jp2FeAZQQQQAABBBBAAAEEKEB4DiCAAALOFyBCBBBAAAEEokaAAiRqUsFAEEAAAQQQQMB5AkSEAAK+AhQgviIsI4AAAggggAACCCCAQJYJRKwAybII6BgBBBBAAAEEEEAAAQRiRoACJGZSxUARyLAAByKAAAIIIIAAAlEjQAESNalgIAgggAACzhMgIgQQQAABXwEKEF8RlhFAAAEEEEAAAQRiX4AIolaAAiRqU8PAEEAAAQQQQAABBBBwngAFiPNy6hsRywgggAACCCCAAAIIRI0ABUjUpIKBIICA8wSICAEEEEAAAQR8BShAfEVYRgABBBBAAIHYFyACBBCIWgEKkKhNDQNDAAEEEEAAAQQQQCD2BNIbMQVIekJsRwABBBBAAAEEEEAAgbAJUICEjZKOEPAVYBkBBBBAAAEEEEDAV4ACxFeEZQQQQACB2BcgAgQQQACBqBWgAIna1DAwBBBAAAEEEEAg9gQYMQLpCVCApCfEdgQQQAABBBBAAAEEEAibAAVI2Ch9O2IZAQQQQAABBBBAAAEEfAUoQHxFWEYAgdgXIAIEEEAAAQQQiFoBCpCoTQ0DQwCBQAJvvPWuVK1zX6Bd2BYmgZLXVJdPp88JU290owJLv/lO8hS6Rv7777AuOqqFM5hwObV6qIf0emZIOIeWZX3pz7Zqt92fZf3TMQLRIEABEg1ZYAxZLqA/0PNfeqMMHvZ6lp/L+wTfr1prXmTs23/AezXzYRAoWCCflCt7ZRh6ootwC4wcPVFq1G8a7m5jtr9mbbtJ72eHRmT827bvlGefHyG1GjSXSy6rJDVvbyYvvz5Ojh49mur8q3/aIHXuaiWFSleSG6reIcNHvpVqOwsIIBCTAjEzaAqQmEkVA82MwIR3P5Sne3aVd6d+LikpKZnpimOjRODO+rVlxIv9omQ0DAOB6BBYuHSF/LRhozS64zYZ8+pgub7c1TLoxddk2KunC4w//9ond97XXm647mpZvXyGvDiwl7xkFSBvv/NBdATBKBBAwPECFCCOT3EcBugT8srvfhR9B6JTu+ZyztnZZfa8xan2WLPuZ9G356+88VbRWyLKlK8j8xcu8+zz4itj5Na7Woq+g6LbH+j4hGfb8ePH5dU3JsrNt9xj/tqof/X9LHmO2a5/idRlXShWporpu33Xp3RRdJ+7m3aUolfebNZXr9dEfvt9t9mW1uTAwUPyZL8X5MZqd0iRKyrLfa26yKyvFnp2/fb71XJXk4dMf9fdfLv0GTBM/v33P7Ndi68rbrhFjltjNStOTTo80kdatOt+aklMf7c1bG360L+IPj/8jVTHNG7eyfwVt3P3p0WN9Hx68JjxU0S3aYx63KAXR8qxY8d0k2knTpyQV0aNl+urNBDdp+mDj4j+hbxCjbvMdvdE4wl0fvd+7kd9V8v7Fqz08ug+zv2oY+47cJg82mugqM/VFeuavxx7j33vvv3So/dgUdPCl98kmjM9j7uPQ3//IwOHvGqeH7pd8/jRZzPcm82jnkf/+u3rZjZ6TTKTY+1GX2DWvfsBGTV2svmLtsaj7/hp3j/+fJbUb/yglCpXQ3o+/bwcOXJUDzEtb7Hr5YWXRpvtGoM+lz/4aLrZ5m+y/uct0rzdo3L5dbVNnx279TXXmO7/7tTPzPPP/e6fXjPjJ03TTZKep9nJZ5Le80t3n7tgiTS4t625NvR59VT/F+Wff/7VTea5mZZ/oGtGDwx0jepzINDPDD3e3R7u8YxMnzFPXnvzHXOtq8eGjVvdm2XZiu/Nu0VqrzHouDwbrZlA1tbmM/41v+8ueW/cq6I/7+rVqW4VF09KhwebyAcffeHZV38mZMuWKM/2flTOz5NbalStJA+1aSKvj5nk2SetGX9x6zWu17dek97H/bzpFxOzHqfr9Vp4euBw6fp4fyl9bS3R24ymfpxsfs4MHTFWKlg/E7Sfce9M1d1Tta+XfCPV6zYx79jUa9RG9PnlvYO63eXnZ6D3fv7m3dfPE30He35WtenUU/b8uddzyE/rN4lur1CjoXmu3Xl/e1m1Zp1nu87o9fTOex/LPS06mX30enr/w9P2uk9GrgM9joaAkwQoQJyUTWJJU2DSB5/KvQ3ricvlkvsb3yHvfvBJqv169n1BCl1SQGZ+PF62rvlaBvZ9TM4552yzz1dfL5Ex1gvsAX26y9bVX8vXM9+X8tdfY7bpZMjLo+WzL+dI/z6Pyk8rZ0nPbh3kmedelhlzvpaiRS6RedPf1d3kl7ULZd+vq+TNEc/JwUN/y4Odn7TGcrusWposPyyeLq2bNjLjMzunMWn2YDfrF+5P8urQ/tZ5Zku7B5rI/v0HzZ47f9sld1h/zSyQ7yL5duHnMnJYf5livQjs0fs5s/2OerXlr737ZP6i5WZZJ3rf+edfzpW7rb+S6vICa1vXHv2ldfNGpo9RLw2Qb1aukv6DX9HNnva29cLg0hJFZaHlMPHNYWb9gYP/yGNd28qPy76UIQOflMXLvkt1q9tky3/oK29Knye6yA9Lpku9W2vIm+PfM8e6J8Ge371/Wo+B8pjW/rpu8vufyY3XlZXFs6fK8MG9ReP78NPTBUSLdo9Z+Tpk/pL8w5Jkub1uDasI6SBqrscfOXJEkpLOlpcG9zW57NyuhTzVf6jMmZ+6yNV+fd30eO+WmRy7+9m8dZvM/mqRPP5Ie2ndrLFV6L0jHbr1kfc//FzatrrPavfL+MkfyvteL0b1WH3B16ltc1nzzUxp0/Ie0UJZc6LbfNv//vjT+ut5O7nmqivl86lvyaxPJ0ru3OfJvVZRrO8uNr3nDnMNXXtNGdHnvLbWzRubbtLzNDv5TNJ7fuk49YXtLTWryMqvP5N3335FLrzgAjnqVQT7+mv+Al0z6V2joTzXXh36jNS/rYZ0bt/C41G6VHFPlENeflPubnCbvPR8X/n3v8NWvnqLvqDXHdKz1n2CadkSs8l5OXJ4dl29doPcXOlGSUxM9KyrVOF62bRlm+i7I56VPjP+4na5XNLsvrtk4pQPUx0xZeqnUv6Ga+SqKy7zrH//w+mSaBU/Lw7qJdeWKyPtHu5lPd96y+7/7ZG+T3S1fr6WE/2jwMbN2zzH6IwW1nqNfm/9vLyidElp2LSDKWh1W3r51H2CaSutP+T8+dd++WTKaPli2lvmj0JtOp3+g9P+Awfk6jKXywcTRpqfGTWr6R8lOsiu//2Rqvsx496TDtb1pD/fm957p5XTPvLLtl89+2TkOvAczAwCDhFIcEgchIFAmgJ///OPfPTpDLn7ztvM9vsb3S5fWH+N9P6r1u+7dku5q6+UwoUuNn8NbNjgVqlwQzmz/++7/pALzs9j/VK8Rs499xwpa/3y6di2mdl2+PARc2/1AKv4qGX9IsqdK6fcdktVaWW98Jvw7sm/+JodfSZ/Wn9R0/uxb650g+TJnUuKFS1kvfBvLPqZBp9dzeLCJStE2+svPSsVb7zWeiFxrtSuXlnusYoq3WHilI/Mupee7yN5LzxfbrJeSPTt+bDoC/8/9vxlYrqtdjXjoPtr+2LGV6J/Aa17SzVdlJdee9sUNfc3amD6uNEqsp7q0dG8IDc7nJpcW7aMdO/yoDHJlfM8s/axhx+USuWvE12uWfUm6fnoQ9a5PzPbdPLOlI+tFyd3SsMGdUy8+hfaytYYdZu7BXt+9/5pPQbKY1r767raNSqLvmDWHN9S42apZbmu+G61bpKvF39jFX1r5TWroLv+2qutF7V5pE2Le+U660XTh5/NNPvocY8/0k7KXFHKmGhO9IX/e9M+N9vdk7Tc3Nv0UfOrLaM51j60HTt2XKaMe0Xus57nmhd94fv1om/knTHDLf9bTW5uqXmzfPv9Gt3d05rdd4d5kazPYY1Rj9O/4np28JrRF/NlryotGnepS4tK8aKFZfAzT8janzYaL69dU80G45nqgFMLGkeg55c+d5pYf1jo2qGV5LvoQrm0eFHRYzSWU12Ir39610x612hGnmvusfg+9uvVVR7u0FIa31VXBvfrIfrCW1+M634ZtdZj3W3tuo3mOu5w6ueWrtf+z7fe+dB5d7vwgjxm9vfd/zOPaU0Cxd2yyd2i7+y435nQYnTK1M+lifUzxbuvcmWvsAr2PqJ/GHlpcB+5uGB+8/mUF60/Xtxet6aMHPaMuda+++Hkdeg+Vgu468pdJRflvcB6vj0uZ52VTT7+/OR1mF4+3X2k95iYmGD+EKG/C7RoGvzM4+bnwLoNm82h+jxscX9D88cl3eeRjq3lqitLS/LMeWa7e6JFvP5OUGN9Jypf3gvlu1Unr7mMXgfuvtN5ZDMCMSOQEDMjZaAIZEDgI+uFYtHCl1h/rb3CHK2/7PSFv744Nyusif7i79ZzgOgtMnqr0Hc/nPxFYW0SfVH6x54/pUa9pqK32rxn/SVZb5XRbVutv2hpEXJbw9ait1W4W79BL8nWX07/tUv39W5acFSueIPccmdL66/lL5p3WPR2Le99vOc3bf7F/JLWF1be693zm7dulyqVb/S8a6Prddz6uOWX7fogjawCTIuO/6y/sOqKjz6fIXfdfqucfXaSLsqGjVtkwAsjUsVR+44WorcY/b7r9AsSffFgDvCa6C0kTR98RC6/vrY5Xm9L2LX7D3HfArN12w7zS9rrEOuviKW9F4M+f6qDfBYC5dFnV8/iJdaLH8+CNXNR3vNF823Nymbrr8FawOYtdr2Jy53fGbO/Fu+/Zk6Z9pm5fUlvjdN9nh8+Snb8+rt24Wnebk8PHJ6qv+07fpNw5FhPpu+yJCVl11nTilnvwl1Wqrj1Yu0ss6yT8qH4QAAAEABJREFUIlahveevv3TW06668nLPvM6ULXOFbPllh86e0cy7LPMWp4rh/MLlRK30mjjjgFMrgvU8tbvnIb3nlz53y19f1rN/WjPe/ro9vWsmvWu0sVUs+PuZof2H0sp4vTtQzCrm9Ng//jyZn4xaax/aFi9baW5Ne7DlvabQ1nXaXC6XPqTZXOKS/QcOpspvtycHmH0Dxa1//GhQt5bo9aA7z5yz0Hr38G+5t1F9XfS0yy+71DPvcrmkRLEickXp0+sSrXdl9MW99x+J9ICy1h9/9FFb9uxnWUX/ZZ7naHr51GOCaSWt4tW7cL26TGlxuVzWz/OT14L+TNNbU6vXbSIXFbf+gFToGtF34Hyvd/09432+/PnyWj9XTuU0yJ8r3sczj4ATBZxXgDgxS8SUYQH9C5x+24u+MHQ3/YXxjvWugbvTp3p0lrdHDZEiVqGyxPqFrd8eo5/r0O36F9WFMz+QpvfeYb3A+lcGDxsl1eveL3prhMvl0l1k6dwPPbdW6O0m2pZ99ZHZ5m/y4aTXpW/PLnJ2UpL1C/sLqVCzoSxautLf7uaXoN+N1gb9pW09eP4lZjt9a4WudL/T8eXs+ea2hVlzF8ndd9TRTaa5XC4Z9txTZ8ShsXi/M3POqYLFHGRN9AXSPS06y313N5CZH0+QP7d9J8kfvm1tETni8607ZqWficsV3Pn9HG5WB8qj2SGNSULCyRym3nTCLLpcLvMXdTXwbXoriO70/odfmM9PPP3kw/LN/E+MX58nHj4jdm+3Lg+1svb91NOKFL5Yu8p0jrWTbNaLN310N5fLleo2G7H+53K5PLf4WIt+/7lvA/LdweVySaM765pYfV30Barv/u5llyt9T/e+7segn19ppdHdifXo7W8tmn/pXTOBrtGMPNfMSdOYeOfM5ToZiNve5cqYtZ5G/2qvt/p0bt9Snn6yq67ytAL5LzI/BzwrrJk//9pnTUUuuTi/6Ivwb+affo4+2b2D2ZZe3C2aNBS9hVH/0PHeh5/JnfVvkRznnmuOdU+y+fxsskKUhITUP69crtCfo4k+z33fn4Hu84f6mC1bNs/18lT/ofLD6rXyqvUuzc/fzzXXgL7T4fuzLiEh4YzTnDj5Y8Vc5/p7xffa0WX3z5UzDmYFAg4UOPMqcWCQhBSfAvrhzSXLv5Vxo16Uzz8Y62nTrBf/+pda3eaWqVOriuitQ+9PGCk9uraVj784+da+bte/ZrV/oIn1tv8TsnTOh7Ld+uv2yu9Wy6XFC5t3HebOX6K7pdmSrAJDN+jtCProbvrOg97upC8MvvpisvmmmhlzFrg3p3oseWkxcy/yllPvZqTaaC1cWryI/LhmvTV3+t/3P/xkFkpYf13UmbPOOkv0NrSPP59lblvQz7xUrVxeN5l2ZemS8tXXS818KJPvflgreS+8wHqhUdvclqAvAlav3ZCqC71FZ81Pqdf57pPR86c6kbUQKI/W5pD+lb6shCk03beUpHXwspU/iN5Oprfs6Ys63Wf12tS50HXeTV98XFaymLibbgtHjrWfjLY1P6Ue849r14nmLa3+Spe6VPQv6+4vOUhrn7PPzi4nUk694jq1QzCep3b1PATz/CpdqoSs+PZHzzHBzARzzZxtFduBrtFQnmtJ2ZPEXVQEMz73PqWDsHbv6/2ot3Hd3ayD9H2ii7kdzXubzle88RpZbP3Bw3tM+scXfZdBbwvVfdzPT30skO8iXWVaoLhrVq0kevw7731kbnXVP9yYg8Iw+dHrujpy5KisXfez9RwtZHoOJp9mx3Qmm7ZuM+/+uHdbbf0s09tlixcrbFbpf5Pk9ttqydVXlja3tuo74GvXbzTbgp1k5DoItm/2QyCWBChAYilbjDUkgckffCz62Y6GDW6VKjfd6Gn6+Yla1SrJ5Pc/Nf3pN0Z9d+q2K/3wqX4GwP3iS//ja++897G5FUl3/nrxCvMNT8WLFRL9y1iPru3N9+e/O/Uz80FvfVE27ZMvZdL7Jz/oXrhQQUlKyi5rfvpZDzdt3YZNMuzVt+TXnSdv09HbeTZbb8sXL3ryl6nZyWuiY9fbxjp262u+MUdvi5ozf7Hot8fobnpPst7Go9/9r7ct6IfHBwwZIc3uvdPcL637aGt0x20yc+7X8s57n0gj690Pl+vkX1t1m36IXL+pZ/Cw10XHowWTvlOk346k2/01vX3kt127Rd9l0n20jxFvTNBZT9O/iqq13q+t30amVjoOzw7WTEbPbx3q+Rcoj56dQpjR+731r5udH3vaKs6WiP5VVz9sqt/gpbcFaVdXX3mZfGs9d/RD/vpCRf9bCrO+WqibQmrhynFIJ/Xaecq0L8w3NemtN2+/84GZb92skdcep2fbtGhsFtp17SX6olCfK/qc1uefHq8bi1uF7/ZffxPNty5rC8ZT9/NuwTy/Hu3cRvQ5pc87fWdS3zXR68s9Fu/+3PPpXTMaj/bh7xoN9blWwvp5sW7D5pC/AjwYa3dMImJmf/jxJ2lwz4NSueL1ooWtfrbI3cwO1uSehvXNh/R7PzvUvBOi3/o3dsIH8mCre62t/v+lF7fL5bLeLb5Lnh70spQsUUT055aE6X9DXh4t+nNaP9f2ZL8hcvToMWl8Vz3Te3r5NDsFMXG5XNK91yDZYT139Zu7ej3zougfaq68vKQ5Wm/J+nrxN+Z3gP6s7fho31QFi9kpnUlGroN0umQzAjEpQAESk2lj0OkJ6IvBdz/4TBrUq53mrrr+ky9mi963rh/IrNe4jbnnWb8KU19QPdu7mznuvPPONV+fqf+xLr2Fq0O33uZrLfVbWHSH7l3aiN5+8/Y7U+XqCnWlSp17TfGR49xzdLPkPC+H6AukO+5rZ/rXbxc695xzZMGiZXJVhdvMuuur3iF1alcV/fCyOSiNiX7jVNmrrjCfU9GxtO38pOfFTKFLCsoXU8eKfoPLdTffLjrGWtVvkqGDnkrVk74g0dup9C/6Da1ixHuj/lLUd4m+sf6SXPP2ZnLF9bdYRdJYOXLksPduZ8xfaf1ifm3Ys9LJKo70qymHjRwrbjv3zloI9XikvQwcMlKKlaliCqeH2jSVXLlyuXeRjJ7f04E1EyiP1uYM/Zvw5jC5tWYVeeqZoXJp2erS5IFH5OvFy+U8K69i/U9zVr9Odal1e3MpX72hKTQf7fygtSX0f+HIcehnPXnEE93ay9BXx5ivYH574lTRb2vTF14nt6aenp8nt7ndTp/HLdp1Nzntbr1o27x1u5yVLZvZuUaVilL2qsvNNr1u3F/Dm56nOdhrEszzq9rNFeSDiSPly1nzRb8G+voqd5jryz0Wr+48s+ldMxpboGs01OeafkPUtu2/ygVFrhX12OD1NbyeQaUxE4y172H6bXdaKE+z/hCiX+vr3dz76rsUer3rlxFcbf0c0m/Me6TTA9KqaSP3Lmk+BhN3i/vvEv1DzH0+Hz5Ps8MQVnbv3FaatX3U+rlZR9b/vFk+fvcN0Ti0i/TyqfsE08pdfaVcZf1RoWLNRlK/URvRdzXHjBzsOfS5fo+bn7s31W4kVW+7T0pb777VtP6Y5dkhyJlQr4Mgu2U3WwU4eagCFCChirF/TAjoLUebf1yQ5u0HGkCL+xvKzp+XmvuT9T/WtWvTN+Z+Xr0P97P3x8glFxfQ3aRWtZtEP8+h67Xp1+m2a93EbNOJy+UyhcOcz94x/enXgOpXODZsUEc3m/Zk946evvWFnX49r55D+9Omn5t4ZcjTZ9yrbw4+NdEXIvotMfo1u3qMjuO+Rref2iqiX3mqfW5ft1i+W/SFDOjzmLk9zLODNeNyuUS/8lePv+qKy6w1qf/pX+H1l/qW1Qtkw/dzRfvr27OrZye9dc172b2h8V11ZeGsD2T5vI9Fbydzfz7A/eLA5XLJIx1bm6/31XPrOfSbdnzf8Unv/O7zuR87PNjUfC2yezlQHt37eD+mFc/z/XvKhNHDPLudl+NceeapbuY5oM8X/VrlDya+Jm4/vddbTb5f/IVoe/v1F0RfzOt+7k7SOo97m/djZnP82MMPypcfjfPuUno91kn0+ei9ctDTPWTy2Je9V4m+gNMxa34WzZ4q995dP9X2Tavmm9vs3Cv1OazP5VVLkkWfc3reCaOHmm+K033URc+r/Wlzfw1vep56rG9L7/ml++uXLugYdCx6Pn3unnvqjwD+/ANdMxqf9qF9afO9RkN9rhUvWthcl9qXttKlipuiW+fPPjtJQzBNP8it6/RWKLPCmuhYAllbu6T6180qJLSPtJr3jmWuKCUzP5kgv25Yar6+uHuX9AvnYOLWd6D03eH7vX4+uc+bVi60ENLbX9376KM+F7s81FJnPU633VJV1q2cLbs3rzCfM9P8mR1OTXRZc6bPgbR+Burzc/AzT5za2//Do53bmJ/l235aJOPfeFHyX5TXs7PePjl25PPm81s/rZglOm69lvSacu+055dvzbcUupf18euZ74v+vNJ5beldB7rvghnv6a40BBwrQAHi2NRGPjDOiEBaAvrX0CEvv2m+XlQ/6Krf5//OlI/lgeaN09qddQggEKMC+h+9fGnkW9Kgbi3Rz87FaBgMGwEEIiBAARIBZE6BQDwL6AfT9cOb+l9xv6pCHZn6SbK8/foQ85fNeHYJc+x0h4CtAvpZuQIlK1jvgp0rzz+b/jsNtg6WkyOAgO0CFCC2p4ABIOBsgezZzzL3a+stIb9vXG5u07qzfm1nBx1D0aV1y0gMDZ+hRomA3tb6x9aVZ9y2FCXDS3cYad3CmO5Bnh2YQQCBUAUoQEIVY38EEEAAAQQQQAABBBDIsEDYCpAMj4ADEUAAAQQQQAABBBBAIG4EKEDiJtUE6mABQkMAAQQQQAABBGJGgAIkZlLFQBFAAAEEok+AESGAAAIIhCpAARKqGPsjgAACCCCAAAII2C/ACGJWgAIkZlPHwBFAAAEEEEAAAQQQiD0BCpDYy5nviFlGAAEEEEAAAQQQQCBmBChAYiZVDBQBBKJPgBEhgAACCCCAQKgCFCChirE/AggggAACCNgvwAgQQCBmBShAYjZ1DBwBBBBAAAEEEEAAgcgLZPaMFCCZFeR4BBBAAAEEEEAAAQQQCFqAAiRoKnZEwFeAZQQQQAABBBBAAIFQBShAQhVjfwQQQAAB+wUYAQIIIIBAzApQgMRs6hg4AggggAACCCAQeQHOiEBmBShAMivI8QgggAACCCCAAAIIIBC0AAVI0FS+O7KMAAIIIIAAAggggAACoQpQgIQqxv4IIGC/ACNAAAEEEEAAgZgVoACJ2dQxcAQQQAABBCIvwBkRQACBzApQgGRWkOMRQAABBBBAAAEEEMh6AcecgQLEMakkEAQQQAABBBBAAAEEol+AAiT6c8QIfQVYRgABBBBAAAEEEIhZAQqQmE0dA0cAAQQiL8AZEUAAAQQQyKwABUhmBTkeAQQQQAABBBDIegHOgIBjBChAHJNKAkEAAQQQQAABBMNvcVQAABAASURBVBBAIPoFYq8AiX5TRogAAggggAACCCCAAAJ+BChA/MCwGgEEzhRgDQIIIIAAAgggkFkBCpDMCnI8AggggAACWS/AGRBAAAHHCFCAOCaVBIIAAggggAACCCAQfgF6DLcABUi4RekPAQQQQAABBBBAAAEE/ApQgPilYYOvAMsIIIAAAggggAACCGRWgAIks4IcjwACCGS9AGdAAAEEEEDAMQIUII5JJYEggAACCCCAQPgF6BEBBMItQAESblH6QwABBBBAAAEEEEAAAb8CQRcgfntgAwIIIIAAAggggAACCCAQpAAFSJBQ7IaAjQKcGgEEEEAAAQQQcIwABYhjUkkgCCCAAALhF6BHBBBAAIFwC1CAhFuU/hBAAAEEEEAAAQQyL0APjhWgAHFsagkMAQQQQAABBBBAAIHoE6AAib6c+I6IZQQQQAABBBBAAAEEHCNAAeKYVBIIAgiEX4AeEUAAAQQQQCDcAhQg4RalPwQQQAABBBDIvAA9IICAYwUoQBybWgJDAAEEEEAAAQQQQCB0gaw+ggIkq4XpHwEEEEAAAQQQQAABBDwCFCAeCmYQ8BVgGQEEEEAAAQQQQCDcAhQg4RalPwQQQACBzAvQAwIIIICAYwUoQBybWgJDAAEEEEAAAQRCF+AIBLJagAIkk8IpKccl1tvgYa8LDQOeAzwHovE5kKfQNRLrLRpdGRPXu53PgVh/3aTjz+TLx7g/nALE71OADQgggAACCCCAAAIIIBBuAQqQcIvSHwIIZF6AHhBAAAEEEEDAsQIUII5NLYEhgAACCCAQugBHIIAAAlktQAGS1cL0jwACCCCAAAIIIIBA+gJxswcFSNykmkARQAABBBBAAAEEELBfIK4KkFFvvy/j3v3UqOt89QZtZO++A2ZZJzXufFAf5Njx41L19tZmnokNApwSAQQQQAABBBBAwLECcVWA+GbxwgvyyORp031XsxwmgSOHD8vaVStkyfwZsnH96jD1GtluiCGy3oHORi4C6YRvW3o9OSEPt9WuJh+9O1p2bV4pi2ZPk/sbN0gv7Kjb7oQ8KKoT4iAGzSQNgdAE4rcAcYncXqeazJq3VP7+59/Q1Ng7aIH8BQtJkeKlgt4/GnckhujJCrmIjlzEeh4OHvpbuvcaIIUvryQjRo2T4YP7RgdsiKOI9Ty4w3VCHGGKwU1iy6MTYrAFjpNmSCB+CxCLKykpu9xxW3WZ8mGytcS/cAtkT0qSvPkKSmJitnB3HbH+iCFi1OmeiFykSxSRHZyQh8XLVsov236Vo0ePytSPkyUpe3bJkztXRPzCdRIn5EEtnBAHMWgmaQiEJhB9BUho48/03k0a1ZXPZiyQ/w4fCdhXvXr1xbcFPICNCCCAAAJRL9CtUxtZt2GT7Nt/+vOAUT9oBogAAgjEuED8FiAnrMydOCE5zj1Hbqt5k3z42Wxrhf9/ycnTxbf535stCMSmAKNGIJ4EalevLB0ebCYdu/WOp7CJFQEEELBdIH4LEC/6Jo3qySfJX0nK8RSvtcwigAACCDhVoESxItKvVze58/52svqnDdEQJmNAAAEE4kYgrgqQo8eOSVL2s85I7vl5ckmF68vKkaNHzTa9Lzj7WWfuZzYyQQABBBCIaYHiRQvLhNHDpOvjz8j6nzfHdCwMHgEEwiFAH5EWiJsCJCUlRX5av0WKFCpojDu2uU+aNq5n5nXSo0srWTpzks7Kj2s3SuFLCph5JhkXUPOFc6fLpg1rZNfO7aLzBw/sz3iHNhxJDDag+zklufADE+HVTshD5/Yt5bpyV5mv4P179zrRdlnJ4hGWzNzpnJAHFXBCHMSgmaQhEJpAXBQg+h8WrNWwnRQveolUrlAuoJD+BwpfGT1JHuvcMuB+TtwY7pgSEhKkSq36qVrOXLnDfZos7Y8YspQ3pM7JRUhcWbazE/LQo/cgyZH/ilTt501bs8wsKzp2Qh7UxQlxEINmkoZAaAJxUYBkS0yUeZ++JT0faSMulyugkL4z8u6bL8hVV8T2f7siYJBsRACBaBNgPAgggAACCMSNQFwUIHGTTQJFAAEEEEAAgRAF2B0BBCItQAESaXHOhwACCCCAAAIIIIBAHAt4CpA4NiB0BBBAAAEEEEAAAQQQiJAABUiEoDkNAgEE2IQAAggggAACCMSNAAVIJlP9wkujJdZbJgk4HAEEEMgygZ6PPiRZ27K+/yzDoWMEEEAgRgUoQGI0cQwbAQQQQAABBBCIaQEGH7cCFCBxm3oCRwABBBBAAAEEEEAg8gIUIJE39z0jywgggAACCCCAAAIIxI0ABUjcpJpAEUDgTAHWIIAAAggggECkBShAIi3O+RBAAAEEEEBABAMEEIhbgbgqQPYdOCgDhr4pzR/qJS06PiVdnnhOFixeaZL/9z//Sr/nX5d72zwm9zzwmLR5+Gk59Pc/ZhsTBBBAAAEEEEAAAQScImB3HHFVgPToO0xynJskk0YPlndGPSftWjWS9Ru3mhx8+PkcOXDwb5k4arBMHTdMundqYdbbNTly+LCsXbVClsyfIRvXr7ZrGJk6LzFkii9sBzshD4rhhDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXkLOHKhA3BciPa3+W3X/8KV3bN/MYXVOmtDzU+h6zvHfffilb5jI5Oym7Wb7qilJyXo5zzbxdk/wFC0mR4qXsOn1YzhvdMQQXIjEE5xSJvchFJJTTPwd5SN8oEns4IQ/q5IQ4iEEzSUMgeIG4KUC2//q7lCldQrJly5amzp11a8rnM+ZLxx4DZew7H8n2X3eluV+kVmZPSpK8+QpKYmLa443UODJzHmLIjF74jnVCHlTDCXEQg2byVLPxgTzYiO9zanLhA2LTohPyYBMdp82gQNwUIOqTkHA63N4DR0ilOs2lTuMOukmKFblY3ntriLS8r4Fs+WWHtOz4lGzdttNs00m9evXFt+l6GgIIIIAAAgggEEsCjBUBuwVOvyK3eyRZfP4ihQrK1u075cSJE+ZMg/p0lTkfjzHz7kn2s86SSjdeI8/1fURqVasoXy38xr1JkpOnn9E8G5lBAAEEEEAAAQQQQACBoATipgDRz3fkOPdceXrwa/LHnr9EROTf/w57kPQzInv3HTDL+u1XW7f9KnkvyG2WmSCAAAIIIIAAAggggEB4BOKmAFGuoQMek+zZs8tD3QdIk3ZPSPfeL8oTXVvrJvl99x/SqnMfaf9of6l3Xye56MI8Uv/WqmYbEwQQCLMA3SGAAAIIIIBA3ArEVQGSJ1dO6dujvXw08SWZMmaITBw1SGpVrWiSX6dmZfls8gh586V+8vUX4+WFZ7r7/cC6OSCLJykpKbJw7nTZtGGN7Nq53cwfPLA/i88a3u6JIbyeGe3NCXnQ2J0QBzFoJu1v8Z4H+zNwegTk4rSFnXNOyIOdfpw7dIG4KkBC57HvCP3AfJVa9cW75cwVW7eEEYN9zx/vMzshDxqPE+IgBs2k/Y082J8D9wjIhVvC3kcn5MFewaDPzo6nBChATkHwgAACCCCAAAIIIIAAAlkvQAGS9cacwVeAZQQQQAABBBBAAIG4FaAAidvUEzgCCMSjADEjgAACCCBgtwAFiN0Z4PwIIIAAAgggEA8CxIgAAqcEKEBOQfCAAAIIIIAAAggggAACWS8Q+QIk62PiDAgggAACCCCAAAIIIBClAhQgUZoYhoVAVgjQJwIIIIAAAgggYLcABYjdGeD8CCCAAALxIECMCCCAAAKnBChATkHwgAACCCCAAAIIIOBEAWKKNgEKkGjLCONBAAEEEEAAAQQQQMDBAhQgDk6ub2gsI4AAAggggAACCCBgt0DMFiCbtmyXh3sOlge69JWOPQbK0JET5NDf/xjPnzZslg7dB8iDXftJ8w69ZPLU6XLixAmzbfPWHdLtqSHSpF1Pue2eDjL4pbFy+MgRqVSneZpt247fzXFMEEAAgUwIcCgCCCCAAAIInBKIyQJk774D0uGxAdLw9loybuQAGTW0j9S/tYrs239Q9vy1Tx7p9YI80OwueWtEf3n9xd6SPHuhTPtstgl55Nj3pMwVl8q7bz4vye+/LjWrlpek7Nll6cxJpj3crqnc17COmdd1RQsXNMdFenLk8GFZu2qFLJk/QzauXx3p04flfMQQFsZMd+KEPCiCE+IgBs2k/Y082J8D9wgikwv32bLmkRiyxpVenS0QkwXIJ8nzpML1V0vNKuU92bnishJS6OL88sn0r6TiDWXNdt2YK+d58nD7JjL105m6KHv37ZcK110tLpdLEhISpML1ZSVa/5e/YCEpUrxUtA4vqHERQ1BMWb6TE/KgSE6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5e5oCflbGZAGyY+fvUrZM6TRD+vW33XLVFalftF9zVWn57fc/zG1YLe5tIH2fG2neJfngk5ly4OChNPuxe2X2pCTJm6+gJCZms3soGT4/MWSYLqwHOiEPCuKEOIhBM2l/Iw/258A9AnLhlrD30Ql5sFeQs4cqEJMFiAZpvYGhD2k2320uV4KcsPZMOXFCalWrIO+88ZzUqVlJZs1bIm0f6SfHjh2ztgb+V69effFtgY9gKwIeAWYQQAABBBBAAAEETgnEZAFS+JKCsvqnjadCSP2gt2GtXb851cofVq+TSwpeJIkJJ8PV27Lq3VJVxrz8jBw/fkLWrNuUav+0FpKTp4tvS2s/1iGAAAIIRJMAY0EAAQQQiDaBk6/Io21U6Yznrno1ZOmKVTLxvc/lyNGjZu91P28Rvf3qrvo1ZfHy72X5tyc/uH3w0N8ycsx7cu9ddcx+etzRoyff8dBvuPpr33658II8ZhsTBBBAAAEEEEAAgTAJ0A0CfgRisgA5P08ueWNYX1nx/Rpp2q6ndHniOZk+a6HkyZ1T8lrFxIjnn5Rxkz8xt1fpV/TeVutmadTgFkOw0jqmcevu0rpLX2nRoZe0uv8OKXxJAbONCQIIIIAAAggggAACCGStQEwWIEpSskQRefWFXjJt/HAZOeQp6dGllZyX41zdJFeWvlTeGN5Xxr7SXya9MVia31tfXC6X2fZw+2by6eQRMn7kAFmYPEFaN7nTrHdPmjauJ906tHAvhuMxQ32kpKTIwrnTZdOGNbJr53Yzf/DA/gz1ZddBxGCXfOrzOiEPGpET4iAGzaT9jTzYnwP3CMiFW8LeRyfkwV5Bzh6qQMwWIKEGGmv761cEV6lVX7xbzly5YyoMYoiOdDkhDyqZsTj0yOhpxBAduSAP0ZEHHQW5UAX7mxPyYL8iIwhFgAIkFC32RQABBBBAAIHgBNgLAQQQ8CNAAeIHhtUIIIAAAggggAACCMSiQLSPmQIk2jPE+BBAAAEEEEAAAQQQcJAABYiDkkkovgIsI4AAAggggAACCESbAAVItGWE8SCAAAJOECAGBBBAAAEE/AhQgPiBYTUCCCCAAAIIIBCLAowZgWgXoACJ9gwxPgQQQAABBBBAAAEJnm0WAAAQAElEQVQEHCTg4ALEQVkiFAQQQAABBBBAAAEEHCJAAeKQRBIGAlElwGAQQAABBBBAAAE/AhQgfmBYjQACCCCAQCwKMGYEEEAg2gUoQKI9Q4wPAQQQQAABBBBAIBYEGGOQAo4uQEa9/b6Me/dTQ9GuW39p0fEpad25j3R76gX5bdf/POvvbNbVzLsnXXoOlnr3dXIv8ogAAggggAACCCCAAAJhEnB0AeJr9HiX1jL+tYFSpdJ1MmTEOLPZ5RLJkeMcWbt+s1nef+CQ7N27X1wua4NZY8/kyOHDsnbVClkyf4ZsXL/ankFk9KynjiOGUxA2PzghD0rohDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXkLOHKhBXBYgbp8L1ZWXz1h3uRalVtaLMWbDULM+at0RqVq1g5u2e5C9YSIoUL2X3MDJ1fmLIFF/YDnZCHhTDCXFkdQzqlNWNGLJaOLj+nZAHjdQJcRCDZpKGQPACcVmArPxhrZQoVtijVPGGsrJsxSqzPHfBcqsgsb8AyZ6UJHnzFZTExGxmXLE4IYboyJoT8qCSToiDGDST9jfyYH8O3CNwWC7cYcXcoxPyEHPocT7guCpAHur+rFSp31rmL1ohjz/cWtz/y5YtUa4sXVLmWesTEhPkgvNzyYkTJ9ybzWO9evXFt5kNTBBAAAEEEEAAAQQQQCBogfAXIEGfOvI7jh7+tCycPl5efq6nFLo4vxmAqTOsSa1qFeTFV8dJbT+3XyUnTxffZjpgggACCCCAAAIIIIAAAkELxFUBEkilwg1l5a56NaSmVYgE2o9tCESzAGNDAAEEEEAAAQSiXcDRBcjRY8ckKftZQeUgMSFB2re6R/LkyhnU/uyEAAIIIICAlwCzCCCAAAJBCji2AElJSZGf1m+RIoUKGooxL/eTsmUuM/PeE11fulRx71WSK+d5kvz+66nWRXpBx79w7nTZtGGN7Nq5XXT+4IH9kR5Gps5HDJniC9vBTsiDYjghDmLQTNrfyIP9OXCPgFy4Jex9jP082OvH2UMXcGQBcuz4canVsJ0UL3qJVK5QLnSVKDgiwXpHpkqt+uLdcubKHQUjC34IxBC8VVbu6YQ8qI8T4iAGzaT9jTzYnwP3CMiFW8LeRyfkwV5Bzh6qgCMLkGyJiTLv07ek5yNtbP8PCoaakMzsz7EIIIAAAggggAACCES7gCMLkGhHZ3wIIOA4AQJCAAEEEEAAgSAFKECChGI3BBBAAAEEEIhGAcaEAAKxJkABEmsZY7wIIIAAAggggAACCESDQAbHQAGSQTgOQwABBBBAAAEEEEAAgdAFKEBCN+MIBHwFWEYAAQQQQAABBBAIUoACJEgodkMAAQQQiEYBxoQAAgggEGsCFCCxljHGiwACCCCAAAIIRIMAY0AggwIUIBmE4zAEEEAAAQQQQAABBBAIXYACJHQz3yNYRgABBBBAAAEEEEAAgSAFKECChGI3BBCIRgHGhAACCCCAAAKxJuC4AuTY8eMy9p0PpXmHXtLhsQHySK8XZPHyH2TMxGkycuyUVPnZsOkXady6uxxPSZGm7XvKqjUbPNs7PT5Ivlr4jWeZGQQQQAABBBDwEmAWAQQQyKCA4wqQMROmyfJv18jo4U/LG8P6yovPdhctSurUvFlmz1uaimn2/KVSp1ZlSUxIkN7d28ug4W+aYmTWvCVy7jlJUrNK+VT7R3LhyOHDsnbVClkyf4ZsXL86kqcO27mIIWyUmerICXlQACfEQQyaSfsbebA/B+4RkAu3hL2PTsiDvYKRP3usn9FRBUiK9U7GlI++lKcebSs5zj3H5Cb7WWdJtZuulyKFCkjuXDll9U8bzXqdaEFSp0ZlnZUyl18q5a66Qt6e/LH1bsmH0qNLa7Pezkn+goWkSPFSdg4h0+cmhkwThqUDJ+RBIZwQBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpy9lAEHFWA7P7jTznn7LOleNFL0jSoXb2izFlw8l2QNes2Sp7cOU1h4t65c9v7ZdL7X0jd2lWkQL687tW2PGZPSpK8+QpKYmI2W84fjpNmfQzhGGXgPoghsE8kt5KLSGr7Pxd58G8TyS1OyIN6OSEOYtBM0hAITSAhtN2jf2+Xy/8Yb61eySpAlsuJEydEb7+qbS177/3j2p8l30UXyHerfvJebebr1asvvs1sYIIAAgjEowAxI4AAAgggkEEBRxUg+S+6UP7997D8suP3NDkK5M8rhS8uYAqMOQuWW+903OzZ77/DR2TEm5NlxPNPypGjR2X+opWebTqTnDxdfJuupyGAAAIIIIAAApEU4FwIxLqAowqQhIQEuf/u26Tf4JGyccs2kxstJhYs+dbM66R29QpWofGuFL6kgOS9II+uMk2/JevWmjdJwfwXyZPdHrT2mWwKEbORCQIIIIAAAggggAACCIRFIIYLkLTjb9eqsVSpdJ08NWCEPNi1n/R85mXJlpjo2fmW6jfJpq07pHa1Cp51W7ftlAWLV0qr++8w60oULSQ3VywnE9/73CwzQQABBBBAAAEEEEAAgfAIJISnm+jpRYuNti0aydRxw+StEf3lpUGPS+UK5TwDzJ3rPFn85URpfMetnnXFi14i08YPF/3GLPfK7p1aSdsWd7sXI/6o3+i1cO502bRhjezauV10/uCB/REfR2ZOSAyZ0QvfsVmSh/ANL+ienBAHMQSd7izdkTxkKW9InZOLkLiybGcn5CHLcOg4SwQcV4BkiZINnertZFVq1RfvljNXbhtGkvFTEkPG7cJ5pBPyoB5OiIMYNJP2t1jPgwo6IQanxOGEXDghBn0+0WJHgAIkdnLFSBFAAAEEEEAAAQTsE+DMYRKgAAkTJN0ggAACCCCAAAIIIIBA+gIUIOkbsYevAMsIIIAAAggggAACCGRQgAIkg3AchgACCNghwDkRQAABBBCIdQEKkFjPIONHAAEEEEAAgUgIcA4EEAiTAAVIJiF7PvqQxHrLJAGHI4AAAggggAACQQu88NJoifUWdLDsmKZA6AVImt2wEgEEEEAAAQQQQAABBBBIX4ACJH0j9kAgagQYCAIIIIAAAgggEOsCFCCxnkHGjwACCCAQCQHOgQACCCAQJgEKkDBB0g0CCCCAAAIIIIBAVgjQp9MEKECcllHiQQABBBBAAAEEEEAgigVirgBp162/tOzY20O6dv1m6fDYADl85IjUvLOtHPr7H882nXm83zCZNW+JLFu5Sm65u73Zt+0jz8gjvV6Qtes36S6etv/AIalct6VM+2yWZ100zTAWBBBAAAEEEEAAAQRiXSDmChAF//uff2XxNz/orKclZc8ulcpfI/MWfeNZp8XItz+sk2qVbzDrrix9qbwxrK+MfeUZaXHf7dL1yedl05btZptOZs9fIiWLF5Y5C5brIi2TAkcOH5a1q1bIkvkzZOP61ZnszZ7DicEe97TOanMu0hpSyOuIIWSyLDmAPGQJa4Y6JRcZYgv7QeQh7KR0mI5AzBUgLpdIq/sbyIQpn54R2q3VK8mc+aeLBy1GbipfTrQ48d35hnJl5J67bpVJU6d7Numxj3VuJb/v+kP2/LXPs56ZjAvkL1hIihQvlfEOouBIYoiCJJwaArk4BWHzA3mwOQGnTu+EPGgo6cehe0V3I4boyI8T8hAdklk/ipgrQJSkdKnicla2bLJqzQZd9LTKFcrJhk1bRW+l0pVzrXcybqlRSWfTbNdefbls2/Gb2bZr9x6r6NgrZctcJnVq3iRfzllk1jPJuED2pCTJm6+gJCZmy3gnNh9JDDYnwOv05MILw8ZZ8mAjvtepnZAHDccJcRCDZtL+5oQ82K+YxgiyaFVMFiBq0brpnTLu3U/E+3/ZrKLk5orXydwFy0wRsn7jVqlc/hrvXVLNJyScDn/W/KVyi/UOiu7Q4LbqMnveUp31tHr16otv82xkBgEEEEAAAQQQQAABBIISOP0KPKjd7d/pxAlrDNbkxmuvkr/2HpCt234Vl8tlrTz571brHY+5Xy83RUiVSteLFiUnt5w53fLLTilSqKDZMGf+Mhk/5VOpVKe53Numh2zcsk22/7rLbNNJcvJ08W26nhYXAgSJAAIIIIAAAgggECaBmCtAvONu17KRKRpOWAWJe70WJtt//V0+mj5XtBhxr/d93GIVLu9/PENa3Hu7KTQOHDwkS2dO8jRdP3PeYt/DWEYAAQQQiKgAJ0MAAQQQcJpATBcgVSpdJ2edlfrzBS6XS6rfXN56d2S/3FCuTKp8/bRhs+dreF8eNUme7dVJSpYoIjO/WiQ1q5ZPtW+tahVl5lwKkFQoLCCAAAIIIIBA/AgQKQJZJBBzBciYl/uJfgjd7TFlzBDz1bruZX18rHNLSX7/9VS3ZlW84RqZ/dGbZl/9Gt4Rzz8pV11x8tuZ2rVsLF3bN9NDPa10yWIybfxwzzIzoQukpKTIwrnTZdOGNbJr53Yzf/DA/tA7svEIYrAR3+fU5MIHxKZF8mATvM9pnZAHDckJcRCDZtL+5oQ82K8YuRHEXAESORrPmZjJoIB+yL9Krfri3XLmyp3B3uw5jBjscU/rrOQiLZXIryMPkTdP64xOyIPG5YQ4iEEzaX9zQh7sV4zcCChAImfNmRBAIGQBDkAAAQQQQAABpwlQgDgto8SDAAIIIIBAOAToAwEEEMgiAQqQLIKlWwQQQAABBBBAAAEEMiLg9GMoQJyeYeJDAAEEEEAAAQQQQCCKBChAoigZDMVXgGUEEEAAAQQQQAABpwlQgGQyoy+8NFpivWWSgMMRQMCJAsSEAAIIZJFAz0cfklhvWUQTN91SgMRNqgkUAQQQQAABBGJBgDEi4HQBChCnZ5j4EEAAAQQQQAABBBCIIoEoLkCiSImhIIAAAggggAACCCCAQFgEKEDCwkgnCDhMgHAQQAABBBBAAIEsEqAAySJYukUAAQQQQCAjAhyDAAIIOF3AcQXIqLffl7tbPiodHhsgTdv3lFfHvCvHjh/35HH/gUNSuW5LmfbZLM86ndm3/4A888Ioaf5QL+n8+CDpPXCEbN22UzfREEAAAQQQQAABBJwvQIQREnBcAaJuDW6rLm8M6yujhvaVb75bIyuspuu1zZ6/REoWLyxzFizXRU/r8fRwyZ3rPJk0erC89mJv6d65pey1ihLPDhGeOXL4sKxdtUKWzJ8hG9evjvDZw3M6YgiPY2Z7cUIe1MAJcRCDZtL+Rh7sz4F7BOTCLWHvoxPyYK8gZw9VwJEFiBshMfFkeHkvzONeJXPmL5fHOreS33f9IXv+2mfW/7j2Z9n9x5/ycLsmZlknF56fR64re4XO2tbyFywkRYqXivz5w3hGYggjZia6ckIeNHwnxEEMmkn7G3mwPwfuEZALt4S9j07Ig72CnD0UgZOv0EM5Igb2fXPCVKlUp7nccnd7KVroYilVoqgZ9a7de6yiY6+ULXOZ1Kl5k3w5Z5FZv/3X36VM6RKSLVs2sxwNk+xJSZI35sV7sgAAEABJREFUX0FJTIyeMYXqQgyhimXN/k7Ig8o4IY5gYtBYo7kRQ3Rkxwl5UEknxEEMmkkaAqEJOLIAad/qHlk6c5JMf+81OXzksMz9eplRmTV/qdxSvZKZ19u0Zs9baubNxOUyD/4m9erVF9/mb1/WI4AAAggggEDMCTBgBBCIkIAjCxC33QXn55Ybyl0ly1ae/AzFnPnLZPyUT827I/e26SEbt2yT7b/ukiKFCspPG7ak+rC6uw/3Y3LydPFt7m08IoAAAggggAACCCCAQHACZxYgwR0XE3vpt199t2qt5L0gjyk0Dhw8ZN4Z0XdHtLW493aZOW+xuSUrX94L5JnnR8mfe09+LkQfv/txXUzEySARQAABBBBAAAEEEIgVAUcWIJ/PmG++hvfOZl1l95690qRRXZn51SKpWbV8qrzUqlZRZs5dbNYNfba7ZMuWKG27PiMdewyU4a9NlPNz5zLbmCAQKQHOgwACCCCAAAIIOF3AcQVIxzb3yUcTXzJfw6ufARk/coDkynmetGvZWLq2bybe/ytdsphMGz/crMpjFRvP9OwoH7/zsowa2kcG9ekqxYteYrbZMUlJSZGFc6fLpg1rZNfO7Wb+4IH9dgwlw+ckhgzThfVAJ+RBQZwQBzFoJu1vfvJg/8BCGIETYtBwnRAHMWgmaQiEJuC4AiS08KN374SEBKlSq36qljNX7ugdcBojI4Y0UGxY5YQ8KJsT4iAGzaT9jTzYnwP3CMiFW8LeR/vzYG/8nD3yAhQgkTfnjAgggAACCCCAAAIIxK0ABUgUpZ6hIIAAAggggAACCCDgdAEKEKdnmPgQQCAYAfZBAAEEEEAAgQgJUIBECJrTIIAAAggggEBaAqxDAIF4E6AAibeMEy8CCCCAAAIIIIAAAipgU6MAySR8z0cfklhvmSTg8DAKvPDSaIn1FuvXg44/jCmlq0wKxPr1oOPPJAGHI4AAAo4ToABxXEoJKAMCHIIAAggggAACCCAQIQEKkAhBcxoEEEAAgbQEWIcAAgggEG8CFCDxlnHiRQABBBBAAAEEVICGgE0CFCA2wXNaBBBAAAEEEEAAAQTiUYACRCQe807MCCCAAAIIIIAAAgjYIuDYAuTY8eNSqU5z6fDYAGnW/kl5bvhYOXzkiLjX6zZ327Rluyxbucrs716njzO/WmxLUjgpAvEjQKQIIIAAAgggEG8Cji1ANJFnnZVN3hjWVya+8Zz8d/iwvPfhDF0tun7pzEnibiVLFDHry193tWedbqtTs7JZzyRjAkcs87WrVsiS+TNk4/rVGevE5qOcEMNttavJR++Oll2bV8qi2dPk/sYNbFaN39M74fnkhBiccE2EJQ9RcCk6IQ5iiIInEkOIOQFHFyDubCQmJMgN15aRjdY7He51PEZGIH/BQlKkeKnInCyLzhLrMRw89Ld07zVACl9eSUaMGifDB/fNIim6DUYg1p9PGmOsx+CUayLW86DPJW1OiIMYNJO0UATifd+4KEBSUlLk2x9+kkuLFzb5Pnr0mOd2q8atu5t1Ovnmu9We9XoL1oaNW3U1LYMC2ZOSJG++gpKYmC2DPdh/mBNiWLxspfyy7Vc5evSoTP04WZKyZ5c8uXPZjxuHI3DC88kJMTjhmnBCHvRHgBPiIAbNJA2B0AQcXYC4C406jTuYF11NGtU1Ot63YE0bP9ys04nvLVilSxXX1abVq1dffJvZwCQTAhwaaYFundrIug2bZN/+A5E+NedDICoFuCaiMi0MCgEEHC7g6ALEXWjM/uhNeap7Wzk7KXuG05mcPF18W4Y740AEbBCoXb2ydHiwmXTs1tuGs3PKqBNgQMI1wZMAAQQQsEfA0QWIPaScFYHoEyhRrIj069VN7ry/naz+aUP0DZARIRBhAa6JCINzulQCLCAQ7wIUIF7PAN/PgLz/8UyvrcwiEJsCxYsWlgmjh0nXx5+R9T9vjs0gGDUCYRTgmggjJl0hgAACGRCwsQDJwGhDOCRbYqJ8/cX4M47wt77iDdek+gpe/Rre+xrWOeN4VgQvoB/+Xzh3umzasEZ27dwuOn/wwP7gO4iCPZ0QQ+f2LeW6cleZr+D9e/c60XZZyeJRoBt/Q3DC88kJMTjhmnBCHvQngBPiIAbNJA2B0AQcW4CExsDeWSGQkJAgVWrVT9Vy5sqdFafKsj6dEEOP3oMkR/4rUrWfN/ENb1n2pAnQsROeT06IwQnXhBPyoJeKE+IgBs0kDYHQBChAQvNibwQQQAABBDIlwMEIIIBAvAtQgMT7M4D4EUAAAQQQQACB+BAgyigRoACJkkQwDAQQQAABBBBAAAEE4kGAAiQesuwbI8sIIIAAAggggAACCNgkQAFiEzynRQCB+BQgagQQQAABBOJdgAIkk8+AF14aLbHeMknA4WEU6PnoQxLrLdavBx1/GFNKV5kUiPXrQcefSQIOD58APSGAQJQIUIBESSIYBgIIIIAAAggggAACzhRIHRUFSGoPlhBAAAEEEEAAAQQQQCALBShAshCXrhHwFWAZAQQQQAABBBCIdwEKkHh/BhA/AgggEB8CRIkAAgggECUCFCBRkgiGgQACCCCAAAIIOFOAqBBILRB1BcjxlBR5e9LH0rxDL3mwaz9p3aWvvPPBF55R7/lrnzz57MvSunMfadHxKRn80lg59Pc/nu0/bdgsHboPMMdqH5OnTpcTJ054tm/eukMe6fWCtOrU25yj98ARout0h1Fvvy/j3v1UZ2kIIIAAAggggAACCCCQBQJRV4C8OX6qLPv2R3ljWF95a0R/GfhUF9n+6++e0Hv0HSqXFi8s418bKBNfHyRHjh6T54aPMdu1ONHi4oFmd5ljX3+xtyTPXijTPptttv+1d7881P1ZuaNuDZlgHat91KhSXlav22i2Z/UklP6PHD4sa1etkCXzZ8jG9atDOTRq9iWG6EiFE/Kgkk6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5e6gCUVWApFjvfkz56Evp1a2tnJfjXBNLoYvzS+/u7cz89z+uk337D0qbZg3Nssvlku6dWsiSb1bJnj/3yifTv5KKN5SVCtdfbbbnynmePNy+iUz9dKZZ/vTL+WZbrarlzXK2xESpXa2i3FWvplmOtkn+goWkSPFS0TaskMZDDCFxZdnOTsiD4mQiDj08KhoxREUahDxERx50FORCFexvTsiD/YqMIFiBqCpAdv/xp5xz9tlSvOglaY5/x2+75fJSxSQx4fSwc56XQ4oWLijbdvwmv1rbr7qiVKpjr7mqtPz2+x/mNqwdO3+XsmVKp9oerQvZk5Ikb76CkpiYLVqHmO64iCFdoojs4IQ8KJQT4iAGzaT9jTxEOgf+z0cu/NtEcosT8hBJL86VeYHTr+Qz31dYekjwKi6mfTZLKtVpbtqmLdtP9m+963FyJu2p72aXK0H0EyAppz4HkpDg8hxY775Opu8n+7/kWedvpl69+uLb/O3LegQQQAABBBBAAAEEbBeI0gFEVQFSIF9e+e+//+TPvfsMV+M7bpWlMyfJZZcWNcuFL84vGzb9InqrlllhTQ4e+tt69+N3612Qi0Vv11q7frO19vS/H1avk0sKXiSJCQlS+JKCsnXbTs/G5Pdfl+f7PepZDjSTnDxdfFug/dmGAAIIIIAAAggggAACZwpEVQHicrnk3rvqyGN9hsr6jVvNaLXYOHzkiJm/tuwVkjvnefL25I/Nsn671bDXJkrlCuUk74Xny131a8ri5d/L8m9Pfmhbi5ORY94zfeoBd9WrIbPnL5UJUz6T/w6f7PPw4cO6ieZsAaJDAAEEEEAAAQQQiBKBqCpA1KR963ukaqXr5enBI6VZ+yflngd6SO1qlaREsUK6WYYO6CGbtu4Q/Xrelp16S1L2s6TXo23NtrwX5JERzz8p4yZ/Im0f6ScdewyU22rdLI0a3GK2n58nl/l2re9+XCdN2j0hjVp1l+mzFsoDpz7Urju9OWGquS3LfevXsePHdTUNAQQQQCBDAhyEAAIIIIBAaoGoK0ASExKkTfOG8sHbw2Tym8/LhxOGS9sWd4v7syFaZDz/dDcZP3KAvDPqOVN8uL8xS0O7svSl8sbwvjL2lf4y6Y3B0vze+uJynf7cx6XFC8srg3vKxxNfNn3rfOmSxfRQ6djmPnPLl9725W76TVlmY4Qn+s7PwrnTZdOGNbJr53bR+YMH9kd4FJk7HTFkzi9cRzshD2rhhDiIQTNpfyMP9ufAPQJy4ZbIoscgu3VCHoIMld2iRCDqCpAocbF9GFpwValVX7xbzly5bR9XKAMghlC0sm5fJ+RBdZwQBzFoJu1v5MH+HLhHQC7cEvY+OiEP9gpy9lAF4qEACdWE/RFAAAEEEEAAAQQQQCCLBChAsgiWbhFAQAVoCCCAAAIIIIBAagEKkNQeLCGAAAIIIOAMAaJAAAEEolSAAiRKE8OwEEAAAQQQQAABBGJTgFEHFqAACezDVgQQQAABBBBAAAEEEAijAAVIGDHpyleAZQQQQAABBBBAAAEEUgvYXoCMHDtFArXUw2UJAQQQQCAoAXZCAAEEEEAgSgVsL0D0PyIYqEWpG8NCAAEEEEAAAQTSFGAlAggEFrC9AGnd5E4J1AIPn60IIIAAAggggAACCCAQSwJZWICExrB33wGZPHW69B44wrR3P/xSdF1ovbA3AggggAACCCCAAAIIRLNA1BQg/Z5/XeYvXinXXXOFaV99vVz6D3kjmu0YGwLRK8DIEEAAAQQQQACBKBWImgJk1//+kDeG95VGDW4x7Y1hfeTX33YFxXY8JUWatu8pq9Zs8Ozf6fFB8tXCb8zy9FlfS5uHn5YHu/aTto/0k+Xf/mjW66Rdt/5yZ7OuOutpXXoOlnr3dfIsM4MAAggggECwAuyHAAIIIBBYIGoKkISEM4eSkOAKPPpTWxMTEqR39/YyaPibosXIrHlL5NxzkqRmlfLy9dLvZPSEafJc367y1oj+8kTXNtJn0EjZtGW7OdplnSJHjnNk7frNZnn/gUOyd+9+cbmsDWaNPZMjhw/L2lUrZMn8GbJx/Wp7BpHJsxJDJgHDdLgT8qAUToiDGDST9jfyYH8O3CMgF24Jex+dkIdTgjzEiMCZr/ptGni5q6+QTj0GypsTpprWsccgufHaq4MeTZnLL5VyV10hb0/+WMZM/FB6dGltjv3g4xnyQNM7pUC+vGb5skuLyt2315Kpn84yyzqpVbWizFmwVGdFi5eaVSuYebsn+QsWkiLFS9k9jEydnxgyxRe2g52QB8VwQhzEoJm0v5EH+3PgHgG5cEvY++iEPNgryNlDEYiaAuSJh1tLgzrVZNuO3027q14Neaxzy1Bikc5t75dJ738hdWtX8RQcO3//n1x9ReoX8VdeXlJ2/Lbb03fFG8rKshWrzPLcBculVhQUINmTkiRvvoKSmJjNjCukSZTsTAzRkQgn5EElnRAHMWgm7W/kwf4cuEdALtwS9j46IZmKm70AABAASURBVA/2CnL2UAWipgDRW7ButwqQQX26irb6t1YVXRdKQD+u/VnyXXSBfLfqp1SHuVyBb6fKli1RrixdUuYtWiEJiQlywfm55MSJE6n6qFevvvi2VDuwgAACCIgICAgggAACCCAQWCBqCpANG7fK4/2GmQ9/6wfAez4zXDZs+iXw6L22/nf4iIx4c7KMeP5JOXL0qMxftNJsvaRgPlmzbqOZd09+Wr9JCl+c3yyaOsOa1KpWQV58dZzU9vPuR3LydPFtpgMmCCCAAAIIIBANAowBAQRiRCBqCpCBw8dI/VuqyXtjh5h2W+0qMmjYmKAZx0ycJrfWvEkK5r9Inuz2oClGtBC5t+FtMu7dT+WPPX+ZvrSo+fDzOXJvwzpm2T2pcENZ0du+alqFiHsdjwgggAACCCCAAAIIIJCeQGjbo6YASTmeItVvvkFy5TzPtBo33yhHjx4JKpqt23bKgsUrpdX9d5j9SxQtJDdXLCcT3/tcqla6Ttq1bCQ9+79svoJX3+UY8FQXubRYYfH+X2JCgrRvdY/kyZXTezXzCCCAAAIIIIAAAgggEEaBhDD2lamu8ue7QJae+iC4drTkmx/k4oL5dDbdVrzoJTJt/HDJftZZnn27d2olbVvcbZb18yRvv/qsjH2lv2mVbrzGrNfJmJf7SelSxXXW07QISn7/dc+yHTMpKSmycO502bRhjezaud3MHzyw346hZPic8RhDhrGy8EAn5EF5nBAHMWgm7W/kwf4cuEdALtwS9j46IQ/2CnL2UAVsL0A6PDZAtO35c7907/Oi+Y8C3tGsqzzWd6j8+VdsveAOFT/Q/gnWOzJVatUX75YzV+5Ah0TdNmKIjpQ4IQ8q6YQ4iEEzmWUt6I7JQ9BUWb4juchy4qBO4IQ8BBUoO0WNgO0FyIPNG4q2h9s3MR8g79OjvfS1mn6YXL9WN2qkGAgCCCCAAAIIIIBAGgKsQiA0AdsLkBuvvUoCtdDCYW8EEEAAAQQQQAABBBCIZgHbCxA3zo6du2TUuPfl4Z6DzS1ZeluWNvf2WHhkjAgggAACCCCAAAIIIBBYIGoKEP38R7bERGnSqK65JUtvy9IWePhsRQABBIwAEwQQQAABBBCIEYGoKUCyJSZIu5aN5aby5VLdkhUjjgwTAQQQQACBOBUgbAQQQCA0gagpQC4rWVxW/7QxtNGzNwIIIIAAAggggAAC8SoQo3FHTQFSp+ZN0qnHQKlUp3mqFqOuDBsBBBBAAAEEEEAAAQTSEIiaAmTIiHHS6cH7Zc7HY2TpzEmelsaYWYWArwDLCCCAAAIIIIAAAjEiEDUFSK6c55kPoOc495wYoWOYCCCAAAIiGCCAAAIIIBCaQNQUIOWvv0rGT/lU9h04GFoE7I0AAggggAACCMSjADEjEKMCUVOATJ46XUaPnyp17+nIZ0Bi9MnEsBFAAAEEEEAAAQQQSE8gagoQ7899eM+nFcCx48dNkdJ/yBu62bRjx45JzTvbSu+BI8zyqLffN/t4f6j9yzmLzlin2xs0fdgcs//AIalct6VM+2yWWWaCAAIIIIAAAggggAAC4RWImgJkxJuT5X97/goqOpfLJfpZkTXrNooWHnrQgiXfSYH8F+qsp7VvdY/nw+xa1NStfbNnuXKFcvJ8v0fN8ufvvmqOmT1/iZQsXljmLFhulu2cHDl8WNauWiFL5s+QjetX2zmUDJ+bGDJMF9YDszYPYR1qwM6cEAcxBExxxDaSh4hRp3sicpEuUUR2cEIeIgLFScImEDUFSO6cOaXtI8/IUwNekR9Wr083QJfLZf6jhYu/WWX2nbtgqdSqWtHMZ3QyZ/5yeaxzK/l91x+y5699Ge0mbMflL1hIihQvFbb+7OiIGOxQP/OcTsiDRuWEOIhBM2l/c0QeHPA7Qp8J5EIV7G9OyIP9iowgWIGoKUBaNblDPpr4ktxc6Tp5adQ70rpzH0me/bXnHY60Arq1RiX56uvl8t/hI/LLjt+kRLFCqXZ7c8JUzy1XtRu2S7XNd2HX7j1W0bFXypa5TPS/SaK3a/nuE8nl7ElJkjdfQUlMzBbJ04b1XMQQVs4Md+aEPGjwToiDGDST9jfyYH8O3CMgF24Jex+dkIdIC3K+zAlETQGiYWRLTJS6tW6WB5o2lD/37pcxEz+S+x58QhYu/U43n9HKXF5Sft601SpClknNKuXlxIkTqfbxvgVL//siqTb6LMyav1RuqV7JrG1wW3WZPW+pmXdP6tWrL77NvY1HBBBAAAEEEEAAAQQQCE4gagoQfRdj6qezrIKjh3yS/JU89Whb+fidl+W5Pg/L8NcnpopGCw1tulLfMRk59j25tUZlXcxwmzN/mfkaYP1Q+r1tesjGLdtk+6+7PP0lJ08X3+bZGLczBI4AAggggAACCCCAQGgCUVOA3PPAY7L5l19lyDOPycvPPSGVbrzGRFK6VHG57porzXxakztuqyFNG9WXIoUKpLU5qHVaaBw4eMh8IF0/rK6txb23y8x5i4M6np0QQACBiAtwQgQQQAABBGJUIGoKkHfeeE6efKSNFCty8RmUfXu0P2Ode0XhSwpI83vruxdTPXp/BkTf2di0ZXuq7e6FmV8tkppVy7sXzWOtahVl5lwKEIPBBAEEEEAAAQQ8AswggEDmBGwvQPTD3r9s/03y5MppIpmzYJk82f8lefXNyXLw0N9mne9EPyuS1mc69HMgg/p0Nbt3bHNfqnc09F2NkiWKmG06GfpsD6l20/U6K+1aNpau7ZuZefekdMliMm38cPdixB9TUlJk4dzpsmnDGtm1c7uZP3hgf8THkZkTEkNm9MJ3rBPyoBpOiIMYNJP2N/Jgfw7cIyAXbgl7H52QB3sFOXuoApkoQEI9Vdr7vzXpI8l7YR6zcfVPG2XQsDflmqsul737D8qw11J/9sPsFCeThIQEqVKrfqqWM1fumIqeGKIjXU7Ig0o6IQ5i0Eza38iD/Tlwj4BcuCXsfXRCHuwV5OyhCthegOgXV52X41wz7vmLvpFGd9wiTRrVlb49HpJ1P28265kggICPAIsIIIAAAggggECMCthegBw5elSOp6QYvg2btsn1pz5w7nK55Pjxk+vNRiYIIIAAAghEgQBDQAABBBDInIDtBcjlpYrJkFfelrlfL5Mt236Va8teYSI69Pc/4nK5zDwTBBBAAAEEEEAAgbgXAMAhArYXIE8/3kHOy3GOTPtsjvTq1lbOTspuaNes2yh1alY280wQQAABBBBAAAEEEEDAGQK2FyA5z8shD7dvJqOG9pEqla7zqFa84Rpp2+JuzzIzXgLMIoAAAggggAACCCAQowK2FyAx6sawEUAgTgUIGwEEEEAAAQQyJ0ABkjk/jkYAAQQQQACByAhwFgQQcIgABYhDEkkYCCCAAAIIIIAAAghkjUB4e6UACa8nvSGAAAIIIIAAAggggEAAAQqQADhsQsBXgGUEEEAAAQQQQACBzAlQgGTOj6MRQAABBCIjwFkQQAABBBwiELMFyOEjR6RSneZptm07fpe3Jn0szR/qZVrDlt1k7frNJmXtuvWXH9f+bOZ9J/sPHJLKdVvKtM9m+W5iGQEEEEAAAQQQiFMBwkYgvAIxW4AkZc8uS2dOMu3hdk3lvoZ1zLyuO/T3P/LJ9LkyfNDjMmn0YBn1Yh855+yz05WbPX+JlCxeWOYsWJ7uvlm9w5HDh2XtqhWyZP4M2bh+dVafLkv6J4YsYQ25UyfkQYN2QhzEoJm0v5EH+3PgHgG5cEvY++iEPNgryNlDFYjZAiRQoH/u3S8lihWWfHkvMLsVyJ/XWr7EzAeazJm/XB7r3Ep+3/WH7Plr3xm7RnpF/oKFpEjxUpE+bVjPRwxh5cxwZ07IgwbvhDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXkLOHIuDIAqT8dVfJf9Y7CG0eflpefHW8/LB6fbomu3bvsYqOvVK2zGVSp+ZN8uWcRekek5U7ZE9Kkrz5CkpiYrasPE2W9k0MWcobdOdOyIOIiBPiIIagn7ZZuiN5yFLekDonFyFxZdnOTshDluHQcZYIOLIAOTspu7wxrK880fUBSUx0Sfc+QyV59tcBAWfNXyq3VK9k9mlwW3WZPW+pmXdP6tWrL77NvY1HBBBAAAEEnCtAZAgggEB4BRxZgCiRy+WSy0sVl+6dWkmPLi0lec5iXe23zZm/TMZP+dR8qP3eNj1k45Ztsv3XXZ79k5Oni2/zbGQGAQQQQAABBBBAAIFwCzi0P0cWIFo4bPllp0nZ8ZQUWbNus1x4fm6znNZE9z9w8JDnQ+z6QfYW994uM+cFLlrS6ot1CCCAAAIIIIAAAggg4F/AkQXI4SOH5amBL8sDXfpKgyZd5PvV6+Wh1o09Cg91f9a806Ff49uuW3+Z+dUiqVm1vGe7ztSqVlFmzqUAUYsoaAwBAQQQQAABBBBAwCECjihAmjauJ906tPCkpFSJovLe2Bdl3MgBkvz+6zJlzAtycYF8ZvuYl/uleqdDl9u1bCxd2zcz292T0iWLybTxw92LEX9Msd65WTh3umzasEZ27dwuOn/wwP6IjyMzJySGzOiF71gn5EE1nBBHbMag+qcbMZy2sHPOCXlQPyfEQQyaSRoCoQk4ogAJLeTY2DshIUGq1KqfquXM5f82smiMihiiIytOyINKOiEOYtBM2t/Ig/05cI+AXLgl/DxGaLUT8hAhKk4TJgEKkDBB0g0CCCCAAAIIIIAAAgikLxALBUj6UbAHAggggAACCCCAAAIIxIQABUhMpIlBImCXAOdFAAEEEEAAAQTCK0ABEl5PekMAAQQQQCA8AvSCAAIIOFSAAsShiSUsBBBAAAEEEEAAgYwJcFTWClCAZK0vvSOAAAIIIIAAAggggICXAAWIFwazvgIsI4AAAggggAACCCAQXgEKkPB60hsCCCAQHgF6QQABBBBAwKECFCAOTSxhIYAAAggggEDGBDgKAQSyVoACJGt96R0BBBBAAAEEEEAAAQS8BAIUIF57MYsAAggggAACCCCAAAIIhEEg5gqQ/QcOSeW6LWXaZ7M84R87flwq1Wku/Ye8cXrdsWNS88620nvgCLOux9NDzT66n3f77/ARGfX2+1K9QRvZu++A2VcnNe58UB9oCNgjwFkRQAABBBBAAAGHCsRcATJ7/hIpWbywzFmw3JMSl8slOc49R9as2yjHrMJDNyxY8p0UyH+hzpo29NkesnTmJE+7965bpU3zhnJ2Unaz/cIL8sjkadPNfDRMjhw+LGtXrZAl82fIxvWro2FIIY+BGEImy5IDnJAHhXFCHMSgmbS/pZcH+0eY/gicEING6YQ4iEEzSUMgNIGYK0DmzF8uj3VuJb/v+kP2/LXPE63L5ZKbypeTxd+sMuvmLlgqtapWNPO+k4VLv5N1P2+VB5s1PLnJJXJ7nWoya95S+fuff0+ui4Jp/oKFpEjxUlEwkowPgRgybhfOI52QB/VwQhy30Af9AAAQAElEQVTEoJm0v5EH+3PgHgG5cEvY+xglebAXgbNHTCCmCpBdu/dYRcdeKVvmMqlT8yb5cs6iVFC31qgkX329XPS2ql92/CYlihVKtV0X9vy5V0a8OVme69NVEhJOh59kvRNyx23VZcqHybqb7S17UpLkzVdQEhOz2T6WjA6AGDIqF97jnJAHFXFCHMSgmbS/kQf7c+AeAblwS9j76IQ82CvI2UMVOP0KPNQjbdh/1vylckv1SubMDaxiYbb1joVZODUpc3lJ+XnTVqsIWSY1q5SXEydOnNpy8iElJUWeGjhCenRpJXkvPP/kSq9pk0Z15bMZC0wB47XazNarV198m9mQFRP6RAABBBBAAAEEEEDAoQIxVYDMmb9Mxk/51HyY/N42PWTjlm2y/dddptBwFxs3V7pORo59T26tUfmMlI2Z+KGUufxSqXB92dTbtE6xihX9HMltNW+SDz+bnXq7tZScPF18m7Wafwgg4DABwkEAAQQQQACBrBWImQJEC40DBw95PkSuHyhvce/tMnPe4lRCd9xWQ5o2qi9FChVItf77H9fJ4uU/SOe2TVKt911o0qiefJL8laQcT/HdxDICCCCAAAIIZJ0APSOAQJwIxEwBMvOrRVKzavlUaalVraLMnJu6ACl8SQFpfm/9VPvpwmtvvWfeMalSr5V5B8X9Vbxbftmpmz3t/Dy5zDskR44e9axjBgEEEEAAAQQQQAAB5wpENrKYKUDatWwsXds3S6VTumQxmTZ+uGRLTJQ5H49JtU0XalYpL4P6dNVZGftK/1Tvnug7KNpKFLtEOra5T5o2rmf204l+RkS36bxdTT+vsnDudNm0YY3s2rlddP7ggf12DSdD5yWGDLGF/SAn5EFRnBAHMWgm7W/kwf4cuEdALtwS9j46IQ/2CnL2UAVipgAJNbBY31+/oatKrfri3XLmyh1TYcViDL7AxOArYt8yubDP3vvM5MFbw755J+RB9ZwQBzFoJmkIhCZAARKaF3sjgAACCGSNAL0igAACCMSJAAVInCSaMBFAAAEEEEAAgbQFWItAZAUoQCLrzdkQQAABBBBAAAEEEIhrAQoQr/QziwACCCCAAAIIIIAAAlkrQAGStb70jgACwQmwFwIIIIAAAgjEiQAFSJwkmjARiJRAz0cfklhvkbLKyvO88NJocULLSiP6dgvwiAACCERWgAIkst6cDQEEEEAAAQQQQACBkwJxOqUAidPEEzYCCCCAAAIIIIAAAnYIUIDYoc45fQVYRgABBBBAAAEEEIgTAQqQOEk0YSKAAAJpC7AWAQQQQACByApQgETWm7MhgAACCCCAAAInBZgiEKcCjihAmj/US3oPHJFmCtPaNurt9+Xulo/KQ92flVadess33602x+r6ce9+auaZIIAAAggggAACCCCAQPgFoqEAyVRUW7ftlCNHj8h3q9bJP//+l6qvQNsa3FZdRg9/Wp5+vIP0G/y6HD5yJNWxdi8cOXxY1q5aIUvmz5CN608WSHaPKdTzE0OoYlmzvxPykDUyke/VCbm4rXY1+ejd0bJr80pZNHua3N+4QeQhM3lGJ+TBCTFoGp0QBzFoJmkIhCYQ8wXIrHlLpG7tqlL++qtlweKVqaIPtM2946XFC8vZZyfJ77v/dK+Kmsf8BQtJkeKlomY8GRkIMWRELfzH+M9D+M9Fj4EFYj0XBw/9Ld17DZDCl1eSEaPGyfDBfQMHHKVbYz0PyuqEGJwShxNy4YQY9PlEiw2BmC9A5ixYZhUgleW2WpVl9vwlqdQDbXPvuOWXnfLvf/9JwfwXuldFxWP2pCTJm6+gJCZmi4rxZGQQxJARtfAf44Q8hF/Fnh6dkIvFy1bKL9t+laNHj8rUj5MlKXt2yZM7lz2gGTxr1OQhg+PXw5wQg1PicEIunBCDPp9osSMQ0wXI2vWb5cLz80iBfHml4g1lZeOWHbL/wCGjH2ib7vDmhKlSqU5z6ffCa9L/yc7ml6iu99fq1asvvs3fvqxHAAEE4kGgW6c2sm7DJtm3/0A8hEuMCCDgIAFCsVcgpgsQvcVq1doNppC46bYWsufPvTL362VGNNA23aF9q3tk6cxJ8s6o56TC9VfrqoAtOXm6+LaAB7ARAQQQcLBA7eqVpcODzaRjt94OjpLQEEAAAQSyQiBmC5ATJ07I7PlL5aOJL5lCQouJ4QMflzkLlkugbVmBGLt9MnIEEEAgdIESxYpIv17d5M7728nqnzaE3gFHIIAAAgjEtUDMFiDfrvpJ8l10oRTMf5EngfpB9M1bd8hXi77xu23PX/s8+6c14741S2/P0nbs+PG0dmMdAgggkDmBGD26eNHCMmH0MOn6+DOy/ufNMRoFw0YAAQQQsFMgZguQG8qVkfEjB6SyS0xIkJnT3pBaVSr43Zb3gjzSsc198kDTO1Mdqwu6Xt9J8W7ZEhN1U8RbSkqKLJw7XTZtWCO7dm438wcP7I/4ODJzQmLIjF74jnVCHsKnYW9PTshF5/Yt5bpyV5mv4P179zrRdlnJ4vbChnh2J+TBCTFo2uyKQ88drkYM4ZKkn3gSiNkCxOlJSrCKqSq16ot3y5krd0yFTQzRkS4n5CE6JDM/CifkokfvQZIj/xWp2s+btmYeJ4I9OCEPTohBU+6EOIhBM0lDIGgBsyMFiGFgggACCCCAAAIIIIAAApEQoACJhDLnQMBXgGUEEEAAAQQQQCBOBShA4jTxhI0AAgjEqwBxI4AAAgjYK0ABYq8/Z0cAAQQQQAABBOJFgDgRMAIUIIaBCQIIIIAAAggggAACCERCgAIkEsq+52AZAQQQQAABBBBAAIE4FaAAidPEEzYC8SpA3AgggAACCCBgrwAFiL3+nB0BBBBAAIF4ESBOBBBAwAhQgBgGJggggAACCCCAAAIIOFUguuKiAImufDAaBBBAAAEEEEAAAQQcLUAB4uj0EpyvAMsIIIAAAggggAAC9go4qgAZ9tpEqXdfJzlx4oRHddnKVVKpTnP5fOZ8z7ofVq8366Z9Nsusa9etv7To+JR07DFQWnfpK6PHT5XDR46YbUwQQAABBMIiQCcIIIAAAggYAccUIFp0zF/0jVx4QR5Z+cNaE5xOXC6XFCtyicxdsFwXTZtjzRcveom4XC6zrJPHu7SWUUP7yOjhfWXrtl/l2SFv6Grb2pHDh2XtqhWyZP4M2bh+tW3jyMyJiSEzeuE71gl5CJ+GvT05IRe31a4mH707WnZtXimLZk+T+xs3sBc1A2d3Qh6cEIOmzglxxEYMqu2/OSEG/9GxJRoFHFOArPh+jZQoVljuueMWmTVvaSrrQhfnk337D8qhv/8x746s+H61XFv2ilT7uBeSsmeX3o+1lyUrVslvu/7nXm3LY/6ChaRI8VK2nDtcJyWGcElmrh8n5CFzAtFzdKzn4uChv6V7rwFS+PJKMmLUOBk+uG/04IYwkljPg4bqhBicEocTcuGEGPT5RIsNAccUIFp03FqjktSqVlGWfrNKjh07lioDNatUkLkLlokWKteVvVISXAmmGEm106mFnOflkFIlisiWX3aeWhP5h+xJSZI3X0FJTMwW+ZOH6YzEECbITHbjhDxkkiBqDndCLhYvWym/WO8SHz16VKZ+nCz6R5s8uXNFjXEwA3FCHpwQg+bKCXEQg2aShkBoAo4oQLTYWLbiR6ldvaLkOPccKVumlCy2ihBvCi1O9NaruQuWS+1qFbw3pTmfkJCapl69+uLb0jyQlQggkJYA6xwo0K1TG1m3YZP1DvMBB0ZHSAgggAACWSWQ+lV2Vp0li/tdvPwH+XPvPqneoI35cPm8RStk9qnbsPSzIdoK5M8rR6y/2K1Zt0muu+bKgCM6dvy4bNvxuxQrcrFnv+Tk6eLbPBuZQQABBOJMoHb1ytLhwWbSsVvvOIs8FsNlzAgggEB0CTiiAJk1f6n07t5Ols6cZNrsj96UJd/8cMY3WbVp1lC0uVynP3zumw59N+X1t96T68peLoUuzu+7mWUEEEAg7gVKFCsi/Xp1kzvvbyerf9oQ9x4AIIAAAn4F2JCmQMwXIPp1uctWrJLqN9/oCfC8HOfK9eWukAWLV3rW6UyF66+WWn5uv3px5HjzNbxtu/WX7NnPkqef6KCH0BBAAAEEvASKFy0sE0YPk66PPyPrf97stYVZBBBAAAEEghOI+QIkKXt2mfvJWNGiwzvkF/s/JrfWuEkq3nCNDH22h/cmM/9Y55bS+I5bzfyYl/vJO6OeM1/DO37kAOnQ+l7zwUqz0aZJSkqKLJw7XTZtWCO7dm438wcP7LdpNBk7rVcMxJAxwrAc5YQ8hAUiCjpxQi46t28p15W7ynwF79+714m2y0oWjwLd4IfghDw4IQbNmBPiIAbNJA2B0ARivgAJLdzY2Vs/BF+lVn3xbjlz5Y6dAKyREoOFEAX/nJCHKGAMyxDsyUVYhu7ppEfvQZIj/xWp2s+btnq2x8KME/LghBj0ueKEOIhBM0lDIDQBCpDQvNgbAQQQQAABBBAIToC9EEAgTQEKkDRZWIkAAggggAACCCCAAAJZIRCJAiQrxk2fCCCAAAIIIIAAAgggEIMCFCAxmDSGjEDwAuyJAAIIIIAAAghElwAFSHTlg9EggAACCDhFgDgQQAABBNIUoABJkyX4lT0ffUhivQUfbfTu+cJLo8UJLXqFgx8ZeQjeKiv3jPWfS+7xZ6URfSOAgHMFiCy6BShAojs/jA4BBBBAAAEEEEAAAUcJUIA4Kp2+wbCMAAIIIIAAAggggEB0CVCARFc+GA0CCDhFgDgQQAABBBBAIE0BCpA0WViJAAIIIIAAArEqwLgRQCC6BShAojs/jA4BBBBAAAEEEEAAgVgRCGqccVOAHDt+XKre3tqDsuL7NdKwRTf59bddsuevffLksy9L6859pEXHp2TwS2Pl0N//ePZlBgEEEEAAAQQQQAABBMIjkBCebmKrl7XrN8lzw8fKS8/1lEIXF5AefYfKpcULy/jXBsrE1wfJkaPHrO1jYiuoKBztkcOHZe2qFbJk/gzZuH51FI4w/SHdVruafPTuaNm1eaUsmj1N7m/cIP2DdI8oak7Ig3I6IQ5i0Eza38iD/Tlwj4BcuCXsfXRCHuwV5OyhCsRNAeJyuUT/v3nrDnl68OsybGAPKVa4oHz/4zrZt/+gtGnW0Ni5XC7p3qmFLPlmlez5c69ZxyTjAvkLFpIixUtlvAObjzx46G/p3muAFL68kowYNU6GD+5r84gydvpYz4M7aifEQQzubGbdYzA9k4dglCKzD7mIjHN6Z3FCHtKLke3RIxA3BciJEydEb8Pq9tQLMrB3FylRtJDJwo7fdsvlpYpJYsJpipzn5ZCiVnGybcdvZh8mGRPInpQkefMVlMTEbBnrIAqOWrxspfyy7Vc5evSoTP04WZKyZ5c8uXNFwciCH4IT8qDROiEOYtBM2t/Ig/05cI+AXLgl7H0MYx7sDYSzx4zA6VfdMTPkQNynPQAAEABJREFUjA80wXp3o0D+i+TzGQtSd2KtT73izKV69eqLbztzL9Y4WaBbpzaybsMm6x2zA04Ok9gQQAABBBBAAIEsFYibAsTlckmC9S7HS4Melx/X/ixj3/lI9H+FL84vGzb9IikpKbpomt52s23H79a7IBebZZ0kJ08X36br02ysdJxA7eqVpcODzaRjt96Oi42AEEAAAQQQQACBSArETQHiRj0vx7kyckgvmTVvsXyS/JVcW/YKyZ3zPHl78sdmF71Va9hrE6VyhXKS98LzzTom8S1QolgR6derm9x5fztZ/dOG+MaIgegZIgIIIIAAAghEt0DcFCBaWJyQEyYbeg//yCG9raLjE5m/aKUMHdBDNm3dIa279JWWnXpLUvazpNejbc2+TOJboHjRwjJh9DDp+vgzsv7nzfGNQfQIIIBAYAG2IoAAAkEJxE0Bki0xUb7+YrwHJV/eC+SzySOk+s03SN4L8sjzT3eT8SMHyDujnjPFh75T4tmZmQwJ6G1tC+dOl00b1siundtF5w8e2J+hvuw6qHP7lnJduavMV/D+vXudaLusZHG7hpOh8zohDxq4E+IgBs2k/Y082J8D9wjIhVvC3kcn5MFewWg4e2yNIW4KkNhKizNGq5+5qVKrvni3nLlyx1RwPXoPkhz5r0jVft60NaZicEIeFNwJcRCDZtL+Rh7sz4F7BOTCLWHvoxPyYK8gZw9VgAIkVDH2j2oBBocAAggggAACCCAQ3QIUINGdH0aHAAIIxIoA40QAAQQQQCAoAQqQoJjYCQEEEEAAAQQQiFYBxoVAbAlQgMRWvhgtAggggAACCCCAAAIxLeCoAiSmM8HgEUAAAQQQQAABBBCIAwEKkEwm+YWXRkust0wSRMXhPR99SJzQogIzY4PgKAQQQAABBBBAICgBCpCgmNgJAQQQQACBaBVgXAgggEBsCVCAxFa+GC0CCCCAAAIIIIBAtAgwjgwJUIBkiI2DEEAAAQQQQAABBBBAICMCFCAZUeMYXwGWEUAAAQQQQAABBBAISoACJCgmdkIAAQSiVYBxIYAAAgggEFsCFCBWvsZMnCYjx06x5k7/27DpF2ncuvvpFcwhgAACCCCAAALeAswjgECGBChALLY6NW+W2fOWWnOn/82ev1Tq1Kp8ekWE544cPixrV62QJfNnyMb1qyN89vCcjhjC45jZXpyQBzVwQhzEoJm0v5EH+3PgHgG5cEvY++iEPNgryNlDFQhHARLqOaNu/yKFCkjuXDll9U8bPWPTgqRODfsKEB1I/oKFpEjxUjobs40YoiN1TsiDSjohDmLQTNrfyIP9OXCPgFy4Jex9dEIe7BXk7KEIUICc0qpdvaLMWXDyXZA16zZKntw5RQuTU5sj/pA9KUny5isoiYnZIn7ucJ2QGMIlGaif9Lc5IQ8apRPiIAbNpP2NPNifA/cIyIVbwt5HJ+TBXkHOHqpAQqgHOHX/W6tXsgqQ5XLixAnR269qW8vesdarV198m/d25hFAAAEE4kyAcBFAAAEEMiRAAXKKrUD+vFL44gLy3aqfTCFSt/bNp7acfEhOni6+7eQWpggggAACCCCAAAKRFOBcsS1AAeKVv9rVK8iIN9+VwpcUkLwX5PHawiwCCCCAAAIIIIAAAgiEQ4ACxEvxluo3yaatO6R2tQpea6N5lrEhgAACCCCAAAIIIBBbAhQgXvnKnes8WfzlRGl8x61ea+2ZTUlJkYVzp8umDWtk187tZv7ggf32DCaDZyWGDMKF+TAn5EFJoi4OHVSIjRhCBMui3clDFsFmoFtykQG0LDjECXnIAha6zEIBCpAsxM1M1wkJCVKlVv1ULWeu3JnpMuLHEkPEydM8oRPyoIE5IQ5i0Eza38iD/TlwjyCjuXAfHw2PxBANWWAMsSZAARJrGWO8CCCAAAIIIIAAAgjYIxCWs1KAhIWRThBAAAEEEEAAAQQQQCAYAQqQYJTYBwFfAZYRQAABBBBAAAEEMiRAAZIhNg5CAAEEELBLgPMigAACCMS2AAVIbOeP0SOAAAIIIIAAApES4DwIhEWAAiQsjHSCAAIIIIAAAggggAACwQhQgASj5LsPywgggAACCCCAAAIIIJAhAQqQDLFxEAII2CXAeRFAAAEEEEAgtgUoQGI7f4weAQQQQACBSAlwHgQQQCAsAhQgYWGkEwQQQAABBBBAAAEEskrAWf1SgDgrn0SDAAIIIIAAAggggEBUCzi2ANl/4JBUrttSpn02y5OAY8ePS6U6zaXDYwOkdZe+8kivF+SH1evl8JEjZr1u823bdvzuOZ4Z+wUYAQIIIIAAAggggEBsCzi2AJk9f4mULF5Y5ixYnipDZ52VTd4Y1lfGjxwgtapVkJFj35Ok7Nll6cxJpj3crqnc17COmdd1RQsXTHV8pBaOHD4sa1etkCXzZ8jG9asjddqwnocYwsqZ4c6ckAcN3glxxHgMmgYhBsNg+8QJeVBEJ8RBDJpJGgKhCTi2AJkzf7k81rmV/L7rD9nz1740VbIlJsiF5+dKc1s0rMxfsJAUKV4qGoaS4TEQQ4bpwnqgE/KgIE6Igxg0k/Y38mB/DtwjIBduiUCPWb/NCXnIeiXOEC4BRxYgu3bvsYqOvVK2zGVSp+ZN8uWcRR6vo0ePeW63GjpyorRp1tCzLZpmsiclSd58BSUxMVs0DSuksRBDSFxZtrMT8qA4ToiDGDST9jfyYH8O3CMgF24Jex+dkAd7BTl7qAIxVYAEG9ys+UvlluqVzO4Nbqsus+ctNfM60Vuw9NaqhckTZGDvLvLMkDd0dbqtXr364tvSPYgdEEAAAQQQQAABBBBAIJWAIwuQOfOXyfgpn5p3Ou5t00M2btkm23/dlSrwbImJclP5cvLX3v3yvz1/pdqW1kJy8nTxbWntxzoEHCpAWAgggAACCCCAQFgEHFeAaKFx4OAhz4fI9d2OFvfeLjPnLT4D7KcNm+Wff/+TPLlznrGNFQgggAACCESHAKNAAAEEnCXguAJk5leLpGbV8qmyVKtaRZk592QBop8B0a/hbfPw09LxsYHSo3NLyX7WWan2ZwEBBBBAAAEEEEAAAYEgSwQcV4C0a9lYurZvlgqrdMliMm38cNHbrvQdEf0a3rdffVYWfDFO7qxXM9W+TRvXk24dWqRaZ8dCSkqKLJw7XTZtWCO7dm438wcP7LdjKBk+JzFkmC6sBzohDwrihDiIQTNpfyMP9ufAPQJy4Zaw99EJebBXkLOHKuC4AiRUgGjdPyEhQarUqp+q5cyV267hZui8xJAhtrAf5IQ8KIoT4iAGzaT9jTzYnwP3CMiFW8LeRyfkwV5Bzh6qAAVIqGLsjwACCERUgJMhgAACCCDgLAEKEGflk2gQQAABBBBAIFwC9IMAAlkiQAGSJax0igACCCCAAAIIIIAAAmkJBFOApHUc6xBAAAEEEEAAAQQQQACBkAUoQEIm4wAEIinAuRBAAAEEEEAAAWcJUIA4K59EgwACCCAQLgH6QQABBBDIEgEKkCxhpVMEEEAAAQQQQACBjApwnLMFKECcnV+iQwABBBBAAAEEEEAgqgQoQKIqHb6DYRkBBBBAAAEEEEAAAWcJUIA4K59EgwAC4RKgHwQQQAABBBDIEgEKkCxhpVMEEEAAAQQQyKgAxyGAgLMFYrYAadetv9zZrGuq7HTpOVjq3dfJs+6tSR9L84d6mdawZTdZu36z2abHVqrTXNxt0tTpnnn3Ovfjth2/m2OYIIAAAggggAACCCDgcIGIhBezBYjLJZIjxzmeomL/gUOyd+9+cbmsDRadFhufTJ8rwwc9LpNGD5ZRL/aRc84+29py8t/o4U/L0pmTTGt+T33zqMsPt2sq9zWs41kuWrjgyQMiPD1y+LCsXbVClsyfIRvXr47w2cNzOmIIj2Nme3FCHtTACXEQg2bS/kYe7M+BewTkwi1h76MT8mCvIGcPVSBmCxANtFbVijJnwVKdlVnzlkjNqhXMvE7+tIqREsUKS768F+iiFMifV0oUu8TMx8okf8FCUqR4qVgZbprjjNkYvKIhBi8Mm2fJhc0JOHV68nAKwuYHJ+RBCZ0QBzFoJmkIBC8Q0wVIxRvKyrIVq0y0cxcsl1peBUj5666S/6x3Edo8/LS8+Op4+WH1erOfe/JQ92c9t13t+t8e9+qoecyelCR58xWUxMRsUTOmUAdCDKGKZc3+TsiDyjghDmLQTKbfsnoP8pDVwsH3Ty6Ct8rKPZ2Qh6z0oe/wC8R0AZItW6JcWbqkzFu0QhISE+SC83PJiRMnjNLZSdnljWF95YmuD0hioku69xkqybO/Ntt04n0LVoF8eXVVwFavXn3xbQEPYCMCCCCAAAIIIBBbAowWgYgIxGwBYuoMa1KrWgXrHY5xUtvr3Q+3nMvlkstLFZfunVpJjy4tJXnOYvemkB+Tk6eLbwu5Ew5AAAEEEEAAAQQQQCDOBWK2AHHnrcINZeWuejWkplWIuNfp4/Zfd8mWX3bqrBxPSZE16zbLhefnNsvpTtgBAQQQQAABBBBAAAEEskQg5guQxIQEad/qHsmTK2cqoMNHDstTA1+WB7r0lQZNusj3q9fLQ60bp9qHBQQQiD4BRoQAAggggAACzhaI2QJkzMv9pHSp4qmykyvneZL8/utmXakSReW9sS/KuJEDzLopY16QiwvkM9v02LJlLjPzvpOmjetJtw4tfFdHfDnFetdm4dzpsmnDGtm1c7vo/MED+yM+jsyckBgyoxe+Y52QB9VwQhzEoJm0v5EHvzmI+AZyEXHyNE/ohDykGRgro1YgZguQqBUN08ASrHd2qtSqL94tZ67YuoWMGML0ZMhkN07IgxI4IQ5i0Eza38iD/Tlwj4BcuCXsfXRCHuwVDMfZ46sPCpD4yjfRIoAAAggggAACCCBgqwAFiK38nNxXgGUEEEAAAQQQQAABZwtQgDg7v0SHAAIIBCvAfggggAACCEREgAIkIsycBAEEEEAAAQQQ8CfAegTiS4ACJL7yTbQIIIAAAggggAACCNgqEFUFiK0SnBwBBBBAAAEEEEAAAQSyXIACJMuJOQECMSHAIBFAAAEEEEAAgYgIUIBEhJmTIIAAAggg4E+A9QgggEB8CVCAxFe+iRYBBBBAAAEEEEDALcCjLQIUILawc1IEEEAAAQQQQAABBOJTgAIkPvPuGzXLCCCAAAIIIIAAAghERMCxBcioce/LuHc/NYij3n5f7m75qHR4bIA0bd9TXh3zrhw7ftxsa9etv9zZrKuZd0+69Bws9e7r5F7kEQEEEMhCAbpGAAEEEEAgvgQcW4D4prHBbdXljWF9ZdTQvvLNd2tkhdV0H5dLJEeOc2Tt+s26KPsPHJK9e/eLy2VtMGvsmRw5fFjWrlohS+bPkI3rV9sziEyelRgyCRimw52QB6VwQhzEoJm0v5EH+3PgHoHtuXAPJBOPxJAJPA6NW4G4KUDcGU5MPBly3gvzuFdJraoVZc3tsaYAABAASURBVM6CpWZ51rwlUrNqBTNv9yR/wUJSpHgpu4eRqfMTQ6b4wnawE/KgGE6Igxg0k/Y38mB/DtwjIBduCXsfnZAHewU5eygC+mo8lP1jdt83J0yVSnWayy13t5eihS6WUiWKemKpeENZWbZilVmeu2C5VZDYX4BkT0qSvPkKSmJiNjOuWJwQQ3RkzQl5UEknxEEMmkn7G3mwPwfuEZALt4S9j07Ig72CnD1UgbgpQNq3ukeWzpwk0997TQ4fOSxzv17mscqWLVGuLF1S5i1aIQnWOyQXnJ9LTpw44dmuM/Xq1RffputpCGROgKMRQAABBBBAAIH4EoibAsSd1gvOzy03lLtKlq08+bkKU2dYk1rVKsiLr46T2n5uv0pOni6+zd0njwgggAACMSjAkBFAAAEEbBGIuwJEv/3qu1VrJe8Fpz8DovIVbigrd9WrITWtQkSXaQgggAACCCCAAAJZI0Cv8S0QNwXI5zPmm6/h1a/c3b1nrzRpVDdV5hMTEkRv08qTK2eq9SwggAACCCCAAAIIIIBA+AQcW4B0fOA+eaDpnUaqY5v75KOJL5mv4dXPgIwfOUBy5TxP9H9jXu4npUsV11lP023J77/uWc66Gf89p6SkyMK502XThjWya+d2M3/wwH7/B0ThFmKIjqQ4IQ8q6YQ4iEEzaX8jD/bnwD0CcuGWsPfRCXmwV5Czhyrg2AIkVIho2z/BekemSq364t1y5sodbcMMOB5iCMgTsY1OyINihT0O7TTCjRgiDO7ndOTBD4wNq8mFDehpnNIJeUgjLFZFsQAFSBQnh6EhgAACCCDgRAFiQgCB+BagAInv/BM9AggggAACCCCAQPwIREWkFCBRkQYGgQACCCCAAAIIIIBAfAhQgMRHnonSV4BlBBBAAAEEEEAAAVsEKEBsYeekCCCAQPwKEDkCCCCAQHwLUIBkMv+9HuskNAx4DvAc4DnAc4DnAM+BGHgORMVrloSERIn1lsmXj3F/eELcC0Q5QMuWreSPP/6I8lEGHt7zz78gCxYsCLxTlG/9/PPP5fXXR0X5KAMPb+PGjdK16yOBd4qBrXfeeZccOXIkBkbqf4hPPdVbvv/+e/87xMCWyZPflcmTJ8fASP0P8dtvv5W+fZ/2v0MMbPnvv//k7rsbxcBIAw+xS5eHZcuWLYF3ivKtI0e+JtOnT4/yUQYe3rx582TIkBcD7xTlW3fv3i2tWz8Q5aNkeAlxSUDQCCCAAAIIIIAAAgggYIsABYgt7JwUgfgVIHIEEEAAAQQQiG8BCpD4zj/RI4AAAgjEjwCRIoAAAlEhQAESFWlgEAgggAACCCCAAALOFSAybwEKEG+NKJyfOHGCXHTRRVE4suCH9OSTPaVatWrBHxCFezZo0EA6deoYhSMLfkilSpWSESNeCf6AKN3z008/kezZs0fp6IIb1nPPDZJrr702uJ2jdK9mzZpKs2bNonR0wQ3r+uuvlwEDng1u5yjd6+yzz5aPPvowSkcX/LBGjnxVSpQoEfwBUbhnly6dpX79+lE4suCHVKNGDXniiceDPyAK98yfP7+MHz8uCkfGkLwFKEC8NZjPcgFOgAACCCCAAAIIIBDfAhQg8Z1/okcAgfgRIFIEEEAAAQSiQoACJCrSwCAQQAABBBBAwLkCRIYAAt4CFCDeGmGa//7HdfLksy9L7YbtpO0jz8iCJd96et7z517p8sRz0ubhp+WpAa/Iv//9Z7ZNn/W1tOvW3xzzWN8XZeu2nWZ9oL6OHTsmI8dOkRYdn5IHuvSVbk+9IDt27jLH6WToyAlS//7O0qTdE7oYUtv1vz0y+KWxUveejnJ/28dlwpTPPMf7i8HfWAP1pZ1q7OrxYNd+llc/Wf7tj7ratNffes+c//b7u8izL74hh0P8D9D5O/7Y8eMyaPgYad25j7R/tL/8+ttJt0Bj9deXDvSnDZulQ/cBojE079BLJk+dLidOnNBN8sEnM6VK/dZS7fYHpEvPwaL7mg1BTtSnXRrPDT1c+9bztezYW75e+p2uMs3fWAP1teevfeZ5qyb6nNL8H/r7H9Ofe7J33wGpeWdbGfX2++5VQT36e27owavWbJDW1vNXzzn2ndP3svsb69r1m+WWu9tLpTrNpVWn3vLlnEXajWmxck0cT0mRhi26mRgat+4ur45514zfPdHYY+Ga6Pf86yaGWxs9JL0HjpCDh/52hyCBYvggwtdEoOs60Fj0WvV3XbsDzeg1oT7+rmt/14S/6zrQWNK7rjPzeyLQde3v90SguN1x6M8gtXEvp3ddp+fi7ietx0DPDX+/JwLF7T7Hq29ONteG9uFep7H7u64DPQ/dxwd6DGSgffv+nggUt/s833y32sSwbOUq9yrz+ysWron3P55pxq6/J7RNfP9zTwyBrgm9nnv0HSo17nxQhozgcyQetCyYiWgBkgXjj8ouzz3nbOnRpbXM/HC0tLr/Dhk07E3POF8ZPVkq3nCNvP3qs5IrV07rhWqy2ZY/34Uyckgv+XzKq1Lq0qLyxriTL/AC9fWa9eJ84+bt8vaIZ2XcyAFSq1oF0eLmyNGjps+yZUrJgKe6mPlQJwkJCdL4zlvky6mjZFCfrjL101myeesO042/GPyNNVBf+qJ59IRp8lzfrvLWiP7yRNc20mfQSNm0Zbs51zVXXy7vjX1RJo4aJH/t3S8ff/GVWR/sxN/xn8+Yb/W3T8a/NlAa33GLPP/y26bLQGP115f+MHuk1wvyQLO7TAyvv9hbkmcvlGmfzTZ9Vr/5Rpn7yRiZMW2U3GLlaMTod836YCf+nhvbdvwuE9/7XEYPf1qGPPOoeZ79d/iI6dbfWP31pQfpD91Lixc2JhNfHyRHjh6T56wiTbe527DXJsp111wu4pKQ/ufvuaFF2tODX5MnHm5tnsNfLfxG9Je7du5vrIUvyS8fTXxJFn050Vxnr4ye5CnkY+aacLlk1LA+snTmJBk24HH5btU60V/2GncsXRNtW9wtS2a8Y12jQ+S8HOfKu9OSNQRTDAe6riN9TQS6rv2NJb3r2gRqTTJ6Tfh7fge6Jvxd19YwzL+0xpLedZ2Z3xP+rmsdzCsh/q7TY7R9kvyV5LvoArEuEV00Lb3rOj0X04mfSaDnhr/fE4Hi1tPoHxB/3rxdsp91lhXHyR+W6V3X/p6H2l8wzZ+Bv98TgeLW8+nriNff/kCuLH2pJ4ZYuyYebH63+RmrP2db3tdAwzItvWui3q1VpV2LRmZfJlknQAGSBbalSxWXvBfkkcSEBLm54rVy1CoI/j31Tsfi5T9I/VurmLPWv6WKLFr+vZm/oVwZScqeXc45+2ypXP5a2b1nr1nvry/9q8qHn8+R7p1ayllnZTP7NqhT3frBfaHMs17E6Ypba9wkF56fR2dDbvnyXiClShQV/d+lxQqLvjD9bdcfuij+YvA31kB9ffDxDHmg6Z1SIF9e0/dlVvF19+21TMGjKyqXL6cPcsH5uaWcVYz8b8+fZjnYib/jFy/7XupZ/tpPzaoVZK31Dsbf//wrgcbqr69Ppn9lFZVlpcL1V2t3kivnefJw+yZWDDPNsvapv4g0t+dYxekJOWHWBzvx99xYtOw7qVb5Bslx7jlSIH9eudx63q34bo3o/9IYq64Wf33pi/59+w9Km2YNzX4ul8t6brWQJd+sEv1Lpq7Uv8qec06SlLm8lIQYgvh7bmzY9Iuce+455pdctsREudV6zi604tLz+Rur+uY8L4e5vnJbRbzLlSApKScklq4Jl8sl7uf8hRfk1nCtd8zMg8TSNVH4kgLicrkkT+6coi9o3M/t9GKI9DWh5/P380y3pXV9pndda7Yyc034e34Huib8Xdf+xhLMda3XXEZ/T/i7rnU8/n5P+Itbjzlw8JB89uV8adqoni6aFsx1HcjFdBJgovn399zw93siUNx6qhdHjpeejzxg/Zi0rgj3O+Hp/K7TcaT1PNT+gmn+DPz9ntDz+Ytbzzdhyqdyf8M65g8LWhTruli7JnTMvi29a+L8PLmkZpXyco71u873WJbDK5AQ3u7ozVfg4y/mSknrhby++NQXuNbvatEnuO6nf8n9Y89fOpuqTfkwWSpcd1Wqdbrg3deu3XtE+yxauKBu8rQyl5eQ7V63YXk2ZGJG3/lY9/MWudp6RyXYGLzH6n1q7750/c7f/ydXX2G9oNWFU+3Ky0vKjt92n1o6+aAF3BczF0j5NFxO7hF46nv8H3/ulUsK5jcH6QtffTH4vz9S58J3rGZna+Lb16/WWK/yieGaq0rLb7//Yb2oPFlsjH3nI/N28Gtj3zPvKFndZOif93Pjjz//kosLXOTpp9DF+eV/PgWa71g9O1sz3n2p9+WlipkX9dYm809f5Ovza9uO30RvgXh1zBR5uF0Tsy0zE+/nxm7L/BKvGPSa2P2/P8/o3nusulF/iejb6np74aA+D5siLBavicp1W4reTlal4nXiLmBj7ZrQd101jt1/7JG21l8cNT/BxGDXNZHWdZ3WWNK7rkO7JlTFf/N+fgdzTfhe1/7Gkt517X9EoW/xvq6D/T3hHbee8RXr3eFHOjQ7Wcye/NEpoVzXvi7aZyjN97nxRxC/J7zj1nMlz1koN1xzpRS6uIAuelqkrglfgz+C+D3hG/cO6zXEmnWb5bZaN3vGrzOxdE3oePUdWb2V6olnhlu/G0/+fo/kNaFjoPkXoADxb5PpLT+u/VkmT0uWpx9/yNOX/pXQveByncmvnx3Yd+CQtGl+8i/R7n3T6kuLGfd278eU4ynei5ma33fgoPQa8LL06fGQ5LH+2qydpRdDWmPV49LqS9e7XCffotZ5d/OOQf/60mfQq+avEnr7mnufYB/9He9ynT5vgte89utvrP770qNON82t3uevTdfqrSrzPntbuj7UVDQWXRdqS+u54bLeZXP343KdjkfX+RurbkurL/E5XvfTpjFMnposdzeoZd7d0XUZbWk9N1wJ3uMO7pq4tuwV5hast0b0lxdHvC16e56OyU8I4v180v0y09J6bmT0mlj85USZOm6o/PjTz9a7TT94huVyeZucXO0dQ6Dcntw78NTf8S7X6fMmeM1rb2nFretHDnnK3KpZvMgl8vbkj3WVaS7X6b7MCmviHYMd14S/GPyNxTcElytB9HrQFq5rIq1r0ZXgbZf6mkgrdwHH4huElQf9pzHoYzhaWtd1eteEb9z62S4dyzVlSutDquYnhFTXdVouqTpJZ8Hfc8PlOp2LBK957c43bv3MnN4m3LLJHbr5jOZyne7LvTGc14Q/g0C/J9KKWz8X9PjDrdxDTPXoG0K0XhO3VK8osz58Q94Z9ZzkPO88GTj09K3w4hvEqQjDeU2c6pKHAAKpf7IF2JFNoQn8Yb2zoR8Q18916G0KerTeKnPcKg703kpd/nPvPrko7wU6a9o3362Wb1etlZefe8LcjmVWWpO0+iqQP6/8/c9/sv3XXdYep/+tXb9FLitF+smWAAAQAElEQVRZ7PSKTMzpxfjskFHyaMeWUrXSdaan9GJIa6x6YFp96fpLCuaTNes26qyn/bR+kxVDEc+yfjD58lLFpdOD93vWhTKT1vEXXXi+50Wr9vXXvgOi9x3rvL+x6ra0+tJ3Hty/PHUfbT+sXmduW9N3V3RZ29lJ2aVW1Yqy5qeNkpISWpGY1nPjogsvkH379mvXpv1lPZ/y5b3QzOskrbHq+rT6Kmy9e6K3fniPSz9QrH/x0tvi9FbBAS+ONu/ivDlhqugH+l5+4x3tLuiW1nMj/0UXyN59Bz19aAx6b7x7RVpjdW9LTEgwt53lz5dXdOyxdk2449C/lF579RXyw+r1ZlWsXRM6aP3jRI0q5eWb79bqovXuYvrXte4YyWsi0HWd1ljSu67DcU2k9fxO75pI67r2N5b0rmuNO7Mtres6vd8TacX99ZKVkjz7a/Mz5qHuz4r+XtAvmQj2uk7LJdjY/D03Av2eSCtuHbO2KvVamTiOHj0mOq/vCAVzXet4M3NNpGUQ6PdEWnEfO37cuo5Xyz0P9DAxaK4e7f2i+TKdWLom9LbtbNmyWe9E5bdewzQXvYtDfSNxTeh5aOkLUICkbxTyHnrPfG/rL/ZPPdpOCuY/fYuMdnRT+XIyZ/5SnZVZ85bIzRVOfsZh1doNMu7dT+W5vt3MB9fMDtbEX1/6wrbxHbVl6Mjxoj8wrF3l85nz5fDhI1Kl4rW66N1CntcfnP0Gvy71bqkqlW68JtXx/mLwN9ZAfd3b8DYTt/4w15PoC8kv5y6We++qo4ui32Sx58990q5lY7Mc6sTf8TdZ7nMWLDfdLf92tZQoeom5jSfQWP31dVf9mrJ4+fei/WiH+sJ95Jj35MFTt6PoLyT9y5RuW7j0OylSuKB4/3VQ1wdqq/w8N26ueJ3o5yX0m8H+2rtfftqwRSrccPJzKP7G6q8vfUchd87zPH/B1vHqB1rr1q4ieXLnkjEv9/N8mK99q3tEP9DXrUOLQMNOtc3fc6O0VSzrNn3LX38ZzrVyonHpwf7Gql9Q8M+//+ku5tvLtmzbKaVKFJFYuiZ2//GnubVEg9C/muov+dIli+uixNI1sdoqpnXQmrv5i1dK6VLFdDHdGCJ9TQS6rv2NJb3rOrPXhL/nd+kA14S/69rfWNK7rk2yMjHRazdcv+s6trnP8zNGv1hDb2ud8PqgoK5rfy7BhBboueHv94S/uPUdev3As7vp5zMXJk8wv1vSu679PQ+DiUH38WegP0/T+j3hL279Oeoevz6Wv+5qeWnQ41Ltpusllq4J/bmqLtq++nq5XHFZCZ2VrL4mzEmYBCWQENRe7BSSgH5jlP5i1vvT9T51bbv+t8f00a1DM6tQ+Np8De/2Hb9Ls3vqm/X6glX/Alrjjjbmrw6NW3c36wP11dl6R+CykkVFv4K3SdvH5Z33P5c3hvcVrfr14Hbd+puvsP1l+2+mT70fUtcH0/SdmLlfL5O+z400x2oM+tcpPdZfDP7GGqgvfWelXctG0rP/y6J/7WrX7RnRd4D0r8JaWOlf2T+bMd8zhgHeb6PqYAK0QMffUbeGVQS4RL/u8a1JH0nPRx40Pfkba6C+9AsHXhn8pIyb/InJ6x3Nuop+g1iNm280fS755ge5+dRfxJ5/5S3rrzHBv3DXDvw9N/TzGQ3r1zJf/dvtqSHyaKeWpngNNFZ/fel5hg7oIfrtLfqVuPr1zVqEPNa5pW7KdPP33HC5XNL/yU7meaa5uP7aK+W6sleY8/kb685df8idlrE+J5u2f1Luv7uu5LXe0dKDovOa2Gi+ClvHq01/FugXUzz85GDzvNbPgOTRDz5WLa8hmHcbY+Ga0MGOnjDNxHBz3ZaybOWP5lv/dH2g61q3R/qa8HddBxpLete1HpuZ5u/57XKlfU0Euq4DjSO967pdJn5P+LuudTz+fk/4i1uP8dcCXdcZdXGfK9Bzw9/viUBxu/v1fczKayKQgb/fE4Hi9h27ezmWromBQ0++Y1/rrrbmj4N9e7QX9/8CXRNqqT+n9St4P54+1/x827Bxq/tQHsMokBDGvujqlID3X3L0LwjaCuTLa7bqC6VRQ/vI268+K8/1fcR8kFw3jPH6C7PuP238cF0tgfrSQqNL2yai9ziOGtbX+ivLuaIfiDMHWhPfPps2Pv3NItbmgP98/5KjY9J3Q/QgfzH4G2ugvrS/+rdWNR76VcJ1alaWkWPeNR/e9v1LjI7B+4eIHhuoBTpet/Xu3k70a3jffKmfFClUwHTlb6y6v57fu3mPpczll5riT/PavVML0fub9x84ZPrUdwz0Xn89dvp7r8mN1575BQNmRz8T3zy6nxu6u75TNOmNwTJx1CDzFypdF2isgfrSXy76lcvjRw6Q4QMfFy2I9V0V7dO76beWaa6916U3r/tr/N7NfU3oB/Y1D++Mek68v/rQ31j1L3GzP3rT/LX06y/GS9NGdT2nj5VrQgvsqeOGmRjUZFDvh8XlOn1/eCxcE4o+8oVenhj0eZjP65ZSfzHocZG+Jvxd1+mNJdB1rce6W0auCX/Pb+0zrWsi0HWtx7ib71jSu659xxHK74lA17W/3xO+5/P+eeaOoWyZy8y7ru7lQNd1ui7uTvw8BnpuaN9p/Z4IFLf3afTnk/bhXpdV14SeQ3+OeDfv309p/Z4IFLd7vPr4yuCeovvqvLZYuSae7/eo+dk095Ox5otfvG93D3RNpGVZutTJd6c1flr4BChAwmdpa096m4y+gHe/o2LrYDJ4cr0tSX/YDx/4RKoXYxnszrbDGtSpLvriMneu82wbQ2ZPrJ+5+XTyCNFfNpnty67juSbskk99Xq7r1B52LnFd26l/+txcE6ct7J5zwjVht2Gg8wfaRgESSIdtCCCAAAIIIIAAAgggEFYBCpCwctIZAr4CLCOAAAIIIIAAAgh4C1CAeGswjwACCCDgHAEiQQABBBCISgEKkKhMC4NCAAEEEEAAAQRiV4CRIxBIgAIkkA7bEEAAAQQQQAABBBBAIKwCFCBh5fTtjGUEEEAAAQQQQAABBBDwFqAA8dZgHgEEnCNAJAgggAACCCAQlQIUIFGZFgaFAAIIIIBA7AowcgQQQCCQAAVIIB22IYAAAggggAACCCAQOwIxMVIKkJhIE4NEAAEEEEAAAQQQQMAZAhQgzsgjUfgKsIwAAggggAACCCAQlQIUIFGZFgaFAAIIxK4AI0cAAQQQQCCQAAVIIB22IYAAAggggAACsSPASBGICQEKkJhIE4NEAAEEEEAAAQQQQMAZAs4sQJyRG6JAAAEEEEAAAQQQQMBxAhQgjkspASFgrwBnD13gyNGj8uaEqdK8Qy95qPuz0uWJ58zysWPHAnY27t1PZeTYKQH3CXVjh8cGyPc/rgv1MFv2/2LmAtmxc5ct5+akCCCAAAIZF6AAybgdRyKAAAJhERjw4mj57sf18sawvjJ6+NMycshTctmlxeXf/w6HpX+ndjJj7mLZ+ftup4aXkbg4BgEEEIgJAQqQmEgTg0QAAacKbNvxu8xftEIG9Oos5+U41xNm9ZtvkJzn5ZC/9u6XFh2fkqbte8p9D/aQSR9M9+zjPfPvf//JsNcmSpN2PaVZ+yfNOyMpKSlmF31XY+jICdL58UHSsmNvmfrpLLNeJ+s3bpW2j/Sz2jPS85nh8t/hI7ratPc+miF17+1kzt3tqRdSvdtQqU5zef2t96Trk8/LlA+/NPt7T2Z+tdgayxPmHZ1R496XynVbms0HDh6SOo07mHmdHDt+XKre3lpnTeszaKQ0aNJF7m/7uAwaPsYqwv4z61d8v0Zad+krT/Z/Sbr0HCxvjPtANmz6RV59c4pofKvWbjD7BjIYMmKc6LtLWvCZTpkggAACYROgo1AEKEBC0WJfBBBAIMwCv2zfKYUuzicX5b0gzZ7POSdJnuvTVd598wUZ+0p/+WrhcuvdknVn7Dv2nY/kuPVifuLrg2T8awNl9//+lA8+OV1oaDEy4oVeMnHUIPno89nyvz1/mT76Dxkl9WpXsfp+Ru6oW1M2WAWJ2WBNyl93tXz+7ghz7ltr3iSDX37LWnv6X6GL88uI55+UJo3qnl5pze35c688/8rb8qxVVOk7OseOHbfWBvev5f0N5PMpI2XS6OclW2KiTJp6uuDauHmbdHjgPhlpxdHhgXuldMli8nD7Juado2vKlJb0DP613lHS8fZ9/KHgBsNeCCCAAAJZIkABkiWs8dspkSOAQHgFzk5Kku9Xr5f+Q96Qx/sNl737Dsj6n7eecZLlK1fLmnWb5OEnB5u2ccs2+dF6V8C9Y9WbrpPEhJM/8vNdlFe2bvtV9h84JP/74y+5q35Ns1vlCuWkaOGCZl4nCYkJMnbSR/JIrxfksy/ny8/WOw663t3q1Krsnk31uGrtRrn26tJSqkRRs75p43rmMZiJvkMy/PUJ8siTz8vqnzamKoguu7SoFCtysd9u0jOoVbWCJJwy8NsJGxBAAAEEslzg5G+jLD8NJ0AAAQQQSEugWJFL5Nff/id/nHpHwnefL2YtkK++Xi4t7m1gPhtyc8Xr5J9/T96WlGpfl8hjnVuadwP0syTvjX1Rnuv7iGeXxMREz7y+CD92LEVOWP/XeW3ujdkSs7lnpXvvIXLZpcXkmZ4dZcgzj4q+g+DZaM0kZc9uTdP4d+KEZMt2up+zvOZ1HPpujPso73dH9Ha0gUPflDo1K8uwgY9Lm+YN5b//Tt8SlpTk53zuzlwS0CAp6Sz3njwigAACCNgoQAFiIz6nRgABBPQdh+o33yhPPPOSrF2/2QMyf9FKOXjob/ll2065+srLpESxS0RfrC9d8YNnH++ZyuXLyegJ08wxuv7PvfvMZyR03l/Lkyun5L0wj6xas8Hs8tuu/4neEqYL//73n+zdf0BurnitnJ8nl8xZsExXB9Wuueoy+WH1Btm0ZbvZf4rXZ0RynHuOnG0VEvrZFt24cOm3+mDajp27pNAlBaTM5SXNPnOtwsts8DPJce7ZcuDg356tGTHwHMwMApkS4GAEEAhFgAIkFC32RQABBLJAQD+TUOnGstJ/yOvmQ+L6YfGNW7fJOWcnScPba8uMuYukQ/cB8swLr1vvSJy8rcl3GA80ayiXlypm9tOv823dqY/s3bffd7czlp95oqOMn/KZ+YD68NcmSsECF5l9zjn7bGnWuL40adtT9BasP//aZ9YHM8l74fnmnYi+g0daxz9uPpvifVyL+xpI+0f7m363/3r6a3TLX3+VuU1MPyjfvc8QOT93Lu/Dzpi/9646MuurJdLp8UGiH0LPqMEZHbMCAQQQQCBLBcJagGTpSOkcAQQQcKhA9rPOkvat7pEP3h4m+iHx117sLe1aNDK3MekHvaeOGyZvDO8rzz/dzdxW1bbF3aL/e6DpndKlbROdNe8YdG3fTCa/+bxMemOw+SB3xRuuMdv0lqwbr73KzOvkpUGPi37eQ+dLlyouuqznTfPx2QAAA59JREFUHDqgh+i5ri17hW4SPc+HE4bLK4N7SruWjWXxlxPNep0snTlJH/w2vY1qypghMmXsi9LpwftT7aeFw7TxJ/t9sHlD+fqL8Wa7Oui51GD4wCekR5dW5rYz3ajj1zh03t2uL1dGdMyvW176IXR9ZyVYA3cfPCKAAAIIRF6AAiTy5pwRgawQoE8EEEAAAQQQQCAmBChAYiJNDBIBBBCIbQHvd09iO5K0Rs86BBBAAIFQBChAQtFiXwQQQAABBBBAAIHoEWAkMSlAARKTaWPQCCCAAAIIIIAAAgjEpgAFSGzmzXfULCOAAAIIIIAAAgggEBMCFCAxkSYGiQAC0SvAyBBAAAEEEEAgFAEKkFC02BcBBBBAAAEEokeAkSCAQEwKUIDEZNoYNAIIIIAAAggggAAC9glk5swUIJnR41gEEEAAAQQQQAABBBAISYACJCQudkbAV4BlBBBAAAEEEEAAgVAEKEBC0WJfBBBAAIHoEWAkCCCAAAIxKUABEpNpY9AIIIAAAggggIB9ApwZgcwIUIBkRo9jEUAAAQQQQAABBBBAICQBCpCQuHx3ZhkBBBBAAAEEEEAAAQRCEaAACUWLfRFAIHoEGAkCCCCAAAIIxKQABUhMpo1BI4AAAgggYJ8AZ0YAAQQyI0ABkhk9jkUAAQQQQAABBBBAIHICjjgTBYgj0kgQCCCAAAIIIIAAAgjEhgAFSGzkiVH6CrCMAAIIIIAAAgggEJMCFCAxmTYGjQACCNgnwJkRQAABBBDIjAAFSGb0OBYBBBBAAAEEEIicAGdCwBECFCCOSCNBIIAAAggggAACCCAQGwKxWYDEhi2jRAABBBBAAAEEEEAAAR8BChAfEBYRQCCwAFsRQAABBBBAAIHMCFCAZEaPYxFAAAEEEIicAGdCAAEEHCFAAeKINBIEAggggAACCCCAQNYJ0HM4BShAwqlJXwgggAACCCCAAAIIIBBQgAIkIA8bfQVYRgABBBBAAAEEEEAgMwIUIJnR41gEEEAgcgKcCQEEEEAAAUcIUIA4Io0EgQACCCCAAAJZJ0DPCCAQTgEKkHBq0hcCCCCAAAIIIIAAAggEFAipAAnYExsRQAABBBBAAAEEEEAAgXQEKEDSAWIzAlEiwDAQQAABBBBAAAFHCFCAOCKNBIEAAgggkHUC9IwAAgggEE4BCpBwatIXAggggAACCCCAQPgE6MmRAhQgjkwrQSGAAAIIIIAAAgggEJ0C/wcAAP//WPA3wwAAAAZJREFUAwDXMf1JhloDLQAAAABJRU5ErkJggg=="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1250,7 +1250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`assets` coverage: 240/260 (92.3%)\n"
+      "`assets` coverage: 234/260 (90.0%)\n"
      ]
     }
    ],
@@ -1277,7 +1277,11 @@
     "fig.show()\n",
     "\n",
     "total_cells = len(symbols) * len(quarters)\n",
-    "filled_cells = sum(sum(row) for row in matrix)\n",
+    "# Count symbol-quarter CELLS that carry at least one assets value, not the number of\n",
+    "# filings: six cells hold two rows (an original plus an amended/restated filing that maps\n",
+    "# to the same calendar quarter, the \"2\" cells above), and summing the counts would credit\n",
+    "# those as extra coverage.\n",
+    "filled_cells = sum(1 for row in matrix for v in row if v > 0)\n",
     "print(f\"`assets` coverage: {filled_cells}/{total_cells} ({100 * filled_cells / total_cells:.1f}%)\")"
    ]
   },
@@ -1307,10 +1311,10 @@
    "id": "20b24c3c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:29.437527Z",
-     "iopub.status.busy": "2026-07-17T13:00:29.437178Z",
-     "iopub.status.idle": "2026-07-17T13:00:29.452437Z",
-     "shell.execute_reply": "2026-07-17T13:00:29.450840Z"
+     "iopub.execute_input": "2026-07-19T15:39:17.628706Z",
+     "iopub.status.busy": "2026-07-19T15:39:17.628351Z",
+     "iopub.status.idle": "2026-07-19T15:39:17.641779Z",
+     "shell.execute_reply": "2026-07-19T15:39:17.640495Z"
     },
     "papermill": {
      "duration": 0.008947,
@@ -1399,10 +1403,10 @@
    "id": "fe2ffaae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:29.456949Z",
-     "iopub.status.busy": "2026-07-17T13:00:29.456594Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.710006Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.708349Z"
+     "iopub.execute_input": "2026-07-19T15:39:17.644418Z",
+     "iopub.status.busy": "2026-07-19T15:39:17.644176Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.892610Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.890592Z"
     }
    },
    "outputs": [
@@ -1825,10 +1829,10 @@
    "id": "9f191c87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.714918Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.714369Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.723626Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.721757Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.897460Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.897058Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.904112Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.902650Z"
     },
     "papermill": {
      "duration": 0.005809,
@@ -1879,10 +1883,10 @@
    "id": "94f99f49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.727858Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.727360Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.735282Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.733576Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.908935Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.908628Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.914250Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.913519Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
@@ -1929,10 +1933,10 @@
    "id": "306dcfc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.739137Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.738768Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.746201Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.744804Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.916709Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.916497Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.922231Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.920962Z"
     }
    },
    "outputs": [
@@ -1972,10 +1976,10 @@
    "id": "4c49b822",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.750451Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.750101Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.763949Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.762545Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.926042Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.925588Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.937815Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.936752Z"
     },
     "papermill": {
      "duration": 0.012669,
@@ -2051,10 +2055,10 @@
    "id": "dc14f3c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.770461Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.770064Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.782726Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.781455Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.942117Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.941753Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.951236Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.950476Z"
     },
     "papermill": {
      "duration": 0.014184,
@@ -2131,10 +2135,10 @@
    "id": "f12dbf27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T13:00:30.787573Z",
-     "iopub.status.busy": "2026-07-17T13:00:30.787007Z",
-     "iopub.status.idle": "2026-07-17T13:00:30.803325Z",
-     "shell.execute_reply": "2026-07-17T13:00:30.802079Z"
+     "iopub.execute_input": "2026-07-19T15:39:18.953329Z",
+     "iopub.status.busy": "2026-07-19T15:39:18.953178Z",
+     "iopub.status.idle": "2026-07-19T15:39:18.961914Z",
+     "shell.execute_reply": "2026-07-19T15:39:18.960976Z"
     },
     "papermill": {
      "duration": 0.011317,
@@ -2220,7 +2224,7 @@
     "## Key Takeaways\n",
     "\n",
     "1. The SEC XBRL Frames API is sufficient to assemble a cross-sectional fundamentals panel without a vendor subscription. The default downloader output covers 20 large-cap US equities × 49 quarters × 11 us-gaap concepts (240 rows in this snapshot).\n",
-    "2. Coverage is concept-dependent. `assets` is reported by 92.3% of company × quarter cells in this universe; `revenues` is sparse for AAPL/MSFT/banks because they file under post-ASC-606 concepts.\n",
+    "2. Coverage is concept-dependent. `assets` fills 90.0% of company × quarter cells in this universe (234 of 260); `revenues` is sparse for AAPL/MSFT/banks because they file under post-ASC-606 concepts.\n",
     "3. Filing-lag stats expose two regimes: the median filing lands ~33 days after fiscal-quarter end (typical 10-Q timing), but the upper quartile starts at 395 days and the max reaches 781 days — that long tail is dominated by amended/restated filings returned by the XBRL Frames API.\n",
     "4. Always filter on `announcement_date` for backtesting, and sort by `fiscal_quarter_end` to pick the winner. Filtering on the wrong column injects lookahead bias: querying as of 2023-06-30 by `fiscal_quarter_end` picks a fresher quarter than was available for 11 of the 16 symbols with admissible data — Q2 2023 fundamentals that were not filed until August 2023. Sorting on the wrong column is the subtler error: `announcement_date` selects the most-recently-announced row, which walks *backwards* in fiscal time whenever a restatement or a late-attributed Q4 fact lands, so the \"PIT-correct\" query would return a stale quarter right after every 10-K.\n",
     "5. Knowledge time can be missing: 36 of 240 rows (15%) carry no `announcement_date` and are therefore never admissible to a PIT query. Report that coverage gap rather than letting the filter drop it silently.\n",
@@ -2250,11 +2254,11 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "ff5c353b3ecb35f0a41c6bd2897458e324e28207",
-   "executed_at": "2026-07-17T13:02:14.092911+00:00",
-   "executor": "local-uv",
+   "executed_at": "2026-07-19T15:39:20.040224+00:00",
+   "executor": "nbconvert",
+   "parameters": {},
    "production": true,
-   "parameters": {}
+   "source_py_blob": "6268769192cd2502abe09ec9feedffb3e44d0670"
   },
   "papermill": {
    "default_parameters": {},

--- a/04_fundamental_alternative_data/04_sec_xbrl_fundamentals.py
+++ b/04_fundamental_alternative_data/04_sec_xbrl_fundamentals.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.19.3
+#       jupytext_version: 1.18.1
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -224,7 +224,11 @@ fig.update_layout(
 fig.show()
 
 total_cells = len(symbols) * len(quarters)
-filled_cells = sum(sum(row) for row in matrix)
+# Count symbol-quarter CELLS that carry at least one assets value, not the number of
+# filings: six cells hold two rows (an original plus an amended/restated filing that maps
+# to the same calendar quarter, the "2" cells above), and summing the counts would credit
+# those as extra coverage.
+filled_cells = sum(1 for row in matrix for v in row if v > 0)
 print(f"`assets` coverage: {filled_cells}/{total_cells} ({100 * filled_cells / total_cells:.1f}%)")
 
 # %% [markdown]
@@ -395,7 +399,7 @@ mismatches
 # ## Key Takeaways
 #
 # 1. The SEC XBRL Frames API is sufficient to assemble a cross-sectional fundamentals panel without a vendor subscription. The default downloader output covers 20 large-cap US equities × 49 quarters × 11 us-gaap concepts (240 rows in this snapshot).
-# 2. Coverage is concept-dependent. `assets` is reported by 92.3% of company × quarter cells in this universe; `revenues` is sparse for AAPL/MSFT/banks because they file under post-ASC-606 concepts.
+# 2. Coverage is concept-dependent. `assets` fills 90.0% of company × quarter cells in this universe (234 of 260); `revenues` is sparse for AAPL/MSFT/banks because they file under post-ASC-606 concepts.
 # 3. Filing-lag stats expose two regimes: the median filing lands ~33 days after fiscal-quarter end (typical 10-Q timing), but the upper quartile starts at 395 days and the max reaches 781 days — that long tail is dominated by amended/restated filings returned by the XBRL Frames API.
 # 4. Always filter on `announcement_date` for backtesting, and sort by `fiscal_quarter_end` to pick the winner. Filtering on the wrong column injects lookahead bias: querying as of 2023-06-30 by `fiscal_quarter_end` picks a fresher quarter than was available for 11 of the 16 symbols with admissible data — Q2 2023 fundamentals that were not filed until August 2023. Sorting on the wrong column is the subtler error: `announcement_date` selects the most-recently-announced row, which walks *backwards* in fiscal time whenever a restatement or a late-attributed Q4 fact lands, so the "PIT-correct" query would return a stale quarter right after every 10-K.
 # 5. Knowledge time can be missing: 36 of 240 rows (15%) carry no `announcement_date` and are therefore never admissible to a PIT query. Report that coverage gap rather than letting the filter drop it silently.


### PR DESCRIPTION
## Gate-0 re-verification — #376 as-of fix confirmed held, one coverage-metric fix

This notebook was re-signed after reader **#376** (`query_fundamentals_as_of` sorted by `announcement_date` instead of `fiscal_quarter_end`). This pass re-verifies under the Gate-0 oracle.

### #376 fix HELD
An independent oracle recomputes the PIT as-of pick a **different way** — a pure-python per-symbol argmax of `fiscal_quarter_end` over admissible rows (`announcement_date <= as_of`) — and it **matches `query_fundamentals_as_of` exactly** (16 admissible symbols; 11 lookahead mismatches vs the `fiscal_quarter_end`-filter variant). The function correctly filters on `announcement_date` and sorts by `fiscal_quarter_end`. Lag stats (median 33 / p75 395 / max 781 days), null-announcement (36/240 = 15%), and row/symbol counts all re-derived from raw and confirmed.

### Defect fixed — coverage double-counted amended filings
`assets` coverage was `filled_cells = sum(sum(row))` — the sum of per-cell **filing counts**. Six (symbol, calendar-quarter) cells hold two rows (an original plus an amended/restated filing that maps to the same calendar quarter — the "2" cells in the heatmap), so they were credited as extra coverage: 240/260 = 92.3%. The honest **% of cells that carry an assets value** is **234/260 = 90.0%**. Fixed to count filled cells; Takeaway 2 updated to "90.0% ... (234 of 260)". The heatmap (a filing-count view) is unchanged.

### Notes
- No book-facing number changed (Ch04 prose discusses PIT/as-of conceptually; it prints no coverage figure).
- Re-executed clean end-to-end under `uv run` (0 error outputs, 2 figures), provenance stamped.
- `jupytext_version` header re-stamped by local jupytext (1.18.1); cosmetic.