### PR TITLE
fix(ci): repair both weekly-external jobs (AQR drift false alarm + chapters shell)

### DIFF
--- a/.github/workflows/weekly-external.yml
+++ b/.github/workflows/weekly-external.yml
@@ -79,16 +79,18 @@ jobs:
           EDGAR_IDENTITY: ${{ secrets.EDGAR_IDENTITY }}
         run: |
           set +e
-          # Build -k as an array so a multi-word filter (e.g. "foo or bar")
-          # stays a single pytest argument instead of being word-split.
-          FILTER_ARGS=()
+          # Build -k via positional params so a multi-word filter (e.g.
+          # "foo or bar") stays a single pytest argument instead of being
+          # word-split. POSIX sh has no arrays and this container's default
+          # shell is dash, so "$@" is the portable stand-in for an array.
+          set --
           if [ -n "${TEST_FILTER_INPUT:-}" ]; then
-            FILTER_ARGS=(-k "${TEST_FILTER_INPUT}")
+            set -- -k "${TEST_FILTER_INPUT}"
           fi
           # Public repo: chapter notebooks only. Case-study pipeline tests need
           # gated results/registries that aren't shipped, so they're excluded.
           python -m pytest tests/test_chapter_notebooks.py \
-            -v --tb=short -m weekly "${FILTER_ARGS[@]}" \
+            -v --tb=short -m weekly "$@" \
             --junitxml=junit-weekly.xml
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
         continue-on-error: true

--- a/tests/test_external_drift.py
+++ b/tests/test_external_drift.py
@@ -106,15 +106,25 @@ def test_fama_french_reachable():
     _assert_schema(df, {"timestamp", "Mkt-RF", "SMB", "HML", "RF"}, "fama_french")
 
 
-def test_aqr_reachable():
-    """AQR factor source — quality-minus-junk panel reachable (wide country panel)."""
+def test_aqr_reachable(tmp_path):
+    """AQR factor source — live download of the monthly QMJ workbook still parses.
+
+    Unlike the other providers, ``AQRFactorProvider`` splits the live pull from
+    the local read: ``download()`` fetches the Excel workbook from aqr.com, and
+    ``__init__``/``fetch`` only read a pre-populated data directory. Mirror
+    ``data/factors/aqr_download.py`` — a tiny one-dataset download into a temp
+    dir, then read it back — so this smoke actually exercises AQR's website. A
+    moved/renamed workbook or layout change surfaces here; a bare ``fetch`` would
+    only read an ambient local cache and never touch the network.
+    """
     from ml4t.data.providers.aqr import AQRFactorProvider
 
-    provider = AQRFactorProvider()
+    # No date filter: the monthly QMJ panel is already small, and the provider's
+    # date-string filter path is brittle. We only need reachability + that the
+    # Excel workbook still parses to a timestamped frame.
+    AQRFactorProvider.download(output_path=tmp_path, datasets=["qmj_factors"])
+    provider = AQRFactorProvider(data_path=tmp_path)
     try:
-        # No date filter: the provider's date-string filter path is brittle and
-        # the monthly QMJ panel is already small. We only need reachability +
-        # that the Excel workbook still parses to a timestamped frame.
         df = provider.fetch("qmj_factors")
     finally:
         provider.close()


### PR DESCRIPTION
Repairs both jobs of the weekly `Weekly External` workflow, which failed together in [run 29723874288](https://github.com/stefan-jansen/machine-learning-for-trading/actions/runs/29723874288).

## 1. `weekly-drift` — AQR smoke was a false-positive drift alarm (Closes #390)

The drift smoke opened #390 claiming an AQR source "moved, renamed a file, or changed its payload schema." It hasn't — a HEAD request to the QMJ workbook returns `HTTP 200`, 2.2 MB, correct content-type.

`test_aqr_reachable` instantiated `AQRFactorProvider()` and called `fetch()`. But unlike every other provider in this module (Yahoo, Binance, Ken French all fetch live), `AQRFactorProvider` **splits the live pull from the local read**: `download()` fetches from aqr.com, while `__init__`/`fetch()` only read a pre-populated local data directory. In CI, with no AQR data on disk, the test failed at construction with `FileNotFoundError` — before ever touching the network — so it could never detect drift and failed every weekly run.

**Fix:** rewrite `test_aqr_reachable` to mirror `data/factors/aqr_download.py` — `download()` one dataset (`qmj_factors`) into a temp dir, then read it back. The smoke now genuinely exercises AQR's website.

Validated against an empty (CI-like) data dir: before `1 failed, 7 passed, 1 skipped`; after **`8 passed, 1 skipped`**, with the AQR test doing a real live pull.

## 2. `weekly-chapters` — bash array under dash (silent every week)

The step built its optional pytest `-k` filter with a bash array (`FILTER_ARGS=(...)`), but the `ml4t/ml4t:latest` container runs `run:` steps under **dash**, which has no arrays. It died at parse time (`Syntax error: "(" unexpected`, exit 2) before pytest ran — and produced no junit, so no failure issue was ever filed.

**Fix:** rewrite with positional params (`set --` / `"$@"`), the POSIX stand-in for an array. Preserves intent: a multi-word filter like `"foo or bar"` stays a single `-k` argument; an empty filter adds no `-k`. Verified in dash both ways.

---
Both fixes are network/CI-only; ruff, YAML, and pre-commit hooks pass.
