### PR TITLE
Ch09/14_panel_features: correct GLD/SLV cross-asset stats (ml4t-engineer 0.1.0b10)

### DIFF
--- a/09_model_based_features/14_panel_features.ipynb
+++ b/09_model_based_features/14_panel_features.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "230f27b8",
+   "id": "daf1163f",
    "metadata": {},
    "source": [
     "# Panel Features: Pairwise and Cross-Sectional Transforms\n",
@@ -16,7 +16,7 @@
     "\n",
     "Panel features matter because temporal features computed in isolation\n",
     "(volatility, momentum, regime probabilities) gain signal when placed\n",
-    "in cross-sectional context — a 25% conditional volatility means\n",
+    "in cross-sectional context - a 25% conditional volatility means\n",
     "different things for a utility stock and a biotech.\n",
     "\n",
     "**Learning Objectives**:\n",
@@ -35,27 +35,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "3fbf0542",
+   "id": "350e0fc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:05.911911Z",
-     "iopub.status.busy": "2026-07-13T03:46:05.911754Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.295238Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.294680Z"
+     "iopub.execute_input": "2026-07-20T17:03:22.305086Z",
+     "iopub.status.busy": "2026-07-20T17:03:22.304674Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.722936Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.722465Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/stefan/ml4t/code/.venv/lib/python3.14/site-packages/ml4t/engineer/features/ml/__init__.py:9: UserWarning: Feature 'cyclical_encode': lookback=0 but has period/window parameter. Consider using lookback='period' or specifying the actual lookback.\n",
-      "  from ml4t.engineer.features.ml.cyclical_encode import *  # noqa: F403\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\"\"\"Panel Features — pairwise and cross-sectional transforms for multi-asset temporal features.\"\"\"\n",
+    "\"\"\"Panel Features - pairwise and cross-sectional transforms for multi-asset temporal features.\"\"\"\n",
     "\n",
     "import warnings\n",
     "\n",
@@ -88,13 +79,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7580dafd",
+   "id": "39b97b2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.300353Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.300216Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.302503Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.302121Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.724205Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.724125Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.726012Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.725681Z"
     },
     "tags": [
      "parameters"
@@ -102,7 +93,7 @@
    },
    "outputs": [],
    "source": [
-    "# Production defaults — Papermill injects overrides for CI\n",
+    "# Production defaults - Papermill injects overrides for CI\n",
     "MAX_SYMBOLS = 0  # 0 = all symbols\n",
     "START_DATE = \"2015-01-01\"\n",
     "END_DATE = \"2024-12-31\""
@@ -110,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67f4f357",
+   "id": "232390f4",
    "metadata": {},
    "source": [
     "## Load Data\n",
@@ -125,13 +116,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "23d63e69",
+   "id": "73cd96e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.310303Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.310188Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.340573Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.339848Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.727282Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.727221Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.753740Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.753214Z"
     },
     "lines_to_next_cell": 0
    },
@@ -167,13 +158,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e34ff493",
+   "id": "e8ff719f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.348937Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.348812Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.363195Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.362538Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.755437Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.755344Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.772859Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.772327Z"
     }
    },
    "outputs": [
@@ -218,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6acbabff",
+   "id": "d844efed",
    "metadata": {},
    "source": [
     "## Cointegration Testing\n",
@@ -233,13 +224,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "018f807c",
+   "id": "e3f07a58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.374740Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.374623Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.424103Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.423527Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.774690Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.774595Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.820148Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.819771Z"
     }
    },
    "outputs": [
@@ -267,13 +258,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a1a9827c",
+   "id": "88bcf3cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.430362Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.430273Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.436944Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.436228Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.821173Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.821093Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.827064Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.826551Z"
     }
    },
    "outputs": [
@@ -313,19 +304,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5ef5284",
+   "id": "2f0519b8",
    "metadata": {},
    "source": [
     "When both tests agree on cointegration, we have stronger evidence of a\n",
     "long-run equilibrium relationship. When they disagree, treat the pair\n",
-    "with caution — the relationship may be fragile or sensitive to the\n",
+    "with caution - the relationship may be fragile or sensitive to the\n",
     "sample period. The Johansen-implied hedge ratio often differs from OLS\n",
     "because the two methods weight observations differently."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "097f815f",
+   "id": "58aa9340",
    "metadata": {},
    "source": [
     "## Spread Construction\n",
@@ -339,13 +330,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "774c7e18",
+   "id": "92af34fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.451213Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.451053Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.506853Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.506244Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.828063Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.827936Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.863651Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.863217Z"
     }
    },
    "outputs": [
@@ -382,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8927c617",
+   "id": "e35354ae",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -398,13 +389,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2d1090cb",
+   "id": "86f4649e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.516149Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.515991Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.554200Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.553635Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.864763Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.864678Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.900490Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.900093Z"
     }
    },
    "outputs": [
@@ -477,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3c0de8a",
+   "id": "f8436a7b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -492,13 +483,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "306a7b6c",
+   "id": "c615d7d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.570137Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.570031Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.575393Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.574615Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.901715Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.901625Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.906376Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.906120Z"
     }
    },
    "outputs": [
@@ -546,10 +537,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "952f754b",
+   "id": "23b12e9c",
    "metadata": {},
    "source": [
-    "The half-life estimate uses full-sample OLS on the spread — in a\n",
+    "The half-life estimate uses full-sample OLS on the spread - in a\n",
     "walk-forward context, only past data should be used. The Kalman spread\n",
     "typically yields shorter half-lives because the adaptive hedge ratio\n",
     "removes low-frequency drift from the spread, leaving a faster-reverting residual."
@@ -557,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f29b54b2",
+   "id": "c9523fc8",
    "metadata": {},
    "source": [
     "## Trading Signals: Z-Score and Bollinger Bands\n",
@@ -571,13 +562,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "1c31c074",
+   "id": "70d52d82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.592694Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.592519Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.598261Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.597750Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.907487Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.907426Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.910356Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.910120Z"
     }
    },
    "outputs": [
@@ -607,11 +598,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9d514d5",
+   "id": "2830e263",
    "metadata": {},
    "source": [
     "The z-score normalizes the spread by its rolling mean and standard\n",
-    "deviation — it is the natural signal for mean-reverting spreads because\n",
+    "deviation - it is the natural signal for mean-reverting spreads because\n",
     "cointegration implies the spread is stationary around a fixed level.\n",
     "Entry at $\\pm 2\\sigma$ captures significant deviations while filtering noise."
    ]
@@ -619,13 +610,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "372e8748",
+   "id": "4da39f1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.606953Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.606821Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.614226Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.613809Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.911450Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.911386Z",
+     "iopub.status.idle": "2026-07-20T17:03:24.915811Z",
+     "shell.execute_reply": "2026-07-20T17:03:24.915546Z"
     }
    },
    "outputs": [
@@ -666,7 +657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "259bdc62",
+   "id": "828d8873",
    "metadata": {},
    "source": [
     "## Visualize Trading System"
@@ -675,13 +666,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "b7059f23",
+   "id": "04a1c119",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:08.623834Z",
-     "iopub.status.busy": "2026-07-13T03:46:08.623675Z",
-     "iopub.status.idle": "2026-07-13T03:46:08.994461Z",
-     "shell.execute_reply": "2026-07-13T03:46:08.994121Z"
+     "iopub.execute_input": "2026-07-20T17:03:24.916914Z",
+     "iopub.status.busy": "2026-07-20T17:03:24.916846Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.347871Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.347380Z"
     }
    },
    "outputs": [
@@ -743,26 +734,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbde6d1c",
+   "id": "dbf21dfd",
    "metadata": {},
    "source": [
     "## Illustrative Backtest\n",
     "\n",
     "A compact backtest demonstrates how cointegration features translate into\n",
-    "tradable signals. This ignores transaction costs and slippage — see\n",
+    "tradable signals. This ignores transaction costs and slippage - see\n",
     "Chapters 18–19 for proper strategy evaluation with realistic cost models."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b58b33dd",
+   "id": "08be4246",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.007190Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.007099Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.015320Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.015016Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.349256Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.349175Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.356193Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.355920Z"
     }
    },
    "outputs": [
@@ -845,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5511e67a",
+   "id": "b9328d2a",
    "metadata": {},
    "source": [
     "## Summary: Primary Pair Analysis"
@@ -854,13 +845,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "0ec8c7b7",
+   "id": "77958837",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.029162Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.029009Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.033003Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.032669Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.356950Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.356884Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.359854Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.359617Z"
     }
    },
    "outputs": [
@@ -964,7 +955,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b04eb27",
+   "id": "195e8291",
    "metadata": {},
    "source": [
     "## Cointegration Screening: Multiple ETF Pairs\n",
@@ -976,13 +967,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "915cfc03",
+   "id": "fa148a96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.046436Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.046321Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.048299Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.047996Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.360596Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.360535Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.362110Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.361848Z"
     }
    },
    "outputs": [],
@@ -1003,13 +994,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f2d0fa9c",
+   "id": "8807af06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.056477Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.056349Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.356077Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.355527Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.362827Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.362768Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.685960Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.685396Z"
     }
    },
    "outputs": [],
@@ -1061,13 +1052,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "1b15cd48",
+   "id": "4c04181f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.367373Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.367257Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.373861Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.373417Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.687507Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.687435Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.692767Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.692291Z"
     }
    },
    "outputs": [
@@ -1197,10 +1188,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5ac4fa8",
+   "id": "60ec0c7b",
    "metadata": {},
    "source": [
-    "Economic relatedness does not guarantee cointegration — several\n",
+    "Economic relatedness does not guarantee cointegration - several\n",
     "apparently related pairs fail the Engle-Granger test, and the two\n",
     "tests sometimes disagree. Half-lives range from days to months,\n",
     "reflecting the speed at which different pair relationships mean-revert.\n",
@@ -1210,7 +1201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc9ba61b",
+   "id": "03f9389e",
    "metadata": {},
    "source": [
     "## Save Pairs Trading Features for Downstream Chapters\n",
@@ -1223,13 +1214,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "996778db",
+   "id": "bb29f1ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.410490Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.410368Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.412785Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.412250Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.695422Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.695345Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.697804Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.697172Z"
     }
    },
    "outputs": [],
@@ -1241,7 +1232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b5b85dd",
+   "id": "c560587b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1258,13 +1249,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "d5574aaa",
+   "id": "24f48a47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.435259Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.435159Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.438935Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.438451Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.699329Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.699256Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.702753Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.702345Z"
     }
    },
    "outputs": [],
@@ -1321,13 +1312,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "3b02281c",
+   "id": "f56d8648",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.445077Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.445014Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.484357Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.483674Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.703774Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.703711Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.743404Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.743032Z"
     }
    },
    "outputs": [
@@ -1363,13 +1354,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "96e47023",
+   "id": "df19850e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.491087Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.491012Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.496746Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.496208Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.744670Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.744598Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.752411Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.749108Z"
     }
    },
    "outputs": [
@@ -1378,7 +1369,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[OK] Saved pairs trading signals to /home/stefan/ml4t/code/case_studies/etfs/models/time_series/pairs_trading_signals.parquet\n",
+      "[OK] Saved pairs trading signals to /tmp/claude-1000/-home-stefan-ml4t-agents/ac2f3c8d-9d11-48e0-a687-e7d29eb8b83b/scratchpad/ch09-out/etfs/models/time_series/pairs_trading_signals.parquet\n",
       "  Shape: (2516, 8)\n",
       "  Pairs: ['GLD/SLV']\n",
       "  Date range: 2015-01-02 00:00:00 to 2024-12-31 00:00:00\n",
@@ -1413,7 +1404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10f44f81",
+   "id": "06e26d7a",
    "metadata": {},
    "source": [
     "## ml4t-engineer: Cross-Asset Features as Polars Expressions\n",
@@ -1427,13 +1418,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "8690f953",
+   "id": "0d0bcc8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.509716Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.509554Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.518035Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.517068Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.753654Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.753533Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.760275Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.759906Z"
     }
    },
    "outputs": [
@@ -1442,8 +1433,8 @@
      "output_type": "stream",
      "text": [
       "=== ml4t-engineer: Cross-Asset Features (GLD/SLV) ===\n",
-      "  corr          : mean=0.7799, std=0.0622\n",
-      "  beta          : mean=1.4323, std=0.3169\n",
+      "  corr          : mean=0.7937, std=0.0599\n",
+      "  beta          : mean=1.4570, std=0.3212\n",
       "  coint_score   : mean=0.0697, std=0.0570\n"
      ]
     }
@@ -1487,39 +1478,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ba98875",
+   "id": "d3d2c8f0",
    "metadata": {},
    "source": [
     "The library expressions compose naturally in `with_columns()`, making it\n",
     "straightforward to compute cross-asset features across many pairs in a\n",
     "single Polars pipeline. `correlation_regime_indicator()` adds binary\n",
-    "regime flags based on rolling correlation levels — useful for\n",
+    "regime flags based on rolling correlation levels - useful for\n",
     "conditional feature engineering."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3beaca11",
+   "id": "bd271531",
    "metadata": {},
    "source": [
     "## Cross-Sectional Ranking of Temporal Features\n",
     "\n",
     "Raw temporal features (momentum, conditional volatility, regime\n",
     "probabilities) vary in scale across assets. Cross-sectional ranking\n",
-    "converts them to universe-relative signals — essential for panel models\n",
+    "converts them to universe-relative signals - essential for panel models\n",
     "that predict cross-sectional returns."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "7c848555",
+   "id": "90541f5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.536808Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.536643Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.544524Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.544037Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.761496Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.761385Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.769876Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.769335Z"
     }
    },
    "outputs": [
@@ -1560,13 +1551,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "8298ae7b",
+   "id": "d41e447c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.552310Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.552141Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.563730Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.563172Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.770828Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.770712Z",
+     "iopub.status.idle": "2026-07-20T17:03:25.783116Z",
+     "shell.execute_reply": "2026-07-20T17:03:25.782707Z"
     }
    },
    "outputs": [
@@ -1736,13 +1727,13 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "8812d1a9",
+   "id": "736059c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.570749Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.570670Z",
-     "iopub.status.idle": "2026-07-13T03:46:09.805365Z",
-     "shell.execute_reply": "2026-07-13T03:46:09.804907Z"
+     "iopub.execute_input": "2026-07-20T17:03:25.784388Z",
+     "iopub.status.busy": "2026-07-20T17:03:25.784260Z",
+     "iopub.status.idle": "2026-07-20T17:03:26.033845Z",
+     "shell.execute_reply": "2026-07-20T17:03:26.033302Z"
     }
    },
    "outputs": [
@@ -1782,24 +1773,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ae20829",
+   "id": "728a15e3",
    "metadata": {},
    "source": [
     "Ranks are bounded, stationary, and immune to outliers. A high\n",
     "momentum rank (top of universe) followed by rank decay signals\n",
-    "momentum exhaustion — a feature that absolute momentum values\n",
+    "momentum exhaustion - a feature that absolute momentum values\n",
     "cannot express because their scale drifts with market conditions."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0b641ef7",
+   "id": "1d52719a",
    "metadata": {},
    "source": [
     "## Relative Temporal Features\n",
     "\n",
     "Many temporal features gain signal when expressed relative to a\n",
-    "benchmark — isolating idiosyncratic dynamics from systematic exposure.\n",
+    "benchmark - isolating idiosyncratic dynamics from systematic exposure.\n",
     "We demonstrate market-relative features (vs SPY). Sector-relative\n",
     "features follow the same pattern with a sector ETF as benchmark\n",
     "(e.g., XLE momentum minus XLF momentum isolates energy-specific signal)."
@@ -1808,13 +1799,13 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "0268da70",
+   "id": "f8b1bab1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:09.830462Z",
-     "iopub.status.busy": "2026-07-13T03:46:09.830344Z",
-     "iopub.status.idle": "2026-07-13T03:46:10.041928Z",
-     "shell.execute_reply": "2026-07-13T03:46:10.041446Z"
+     "iopub.execute_input": "2026-07-20T17:03:26.034993Z",
+     "iopub.status.busy": "2026-07-20T17:03:26.034877Z",
+     "iopub.status.idle": "2026-07-20T17:03:26.248817Z",
+     "shell.execute_reply": "2026-07-20T17:03:26.248274Z"
     }
    },
    "outputs": [
@@ -1886,10 +1877,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75f1a07d",
+   "id": "0a862ece",
    "metadata": {},
    "source": [
-    "Relative momentum removes the market component — XLE's energy-sector\n",
+    "Relative momentum removes the market component - XLE's energy-sector\n",
     "bets become visible only after subtracting the broad equity trend.\n",
     "Relative volatility (vol / market vol) distinguishes periods where an\n",
     "asset is genuinely more volatile from periods where the entire market\n",
@@ -1899,7 +1890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8e3d168",
+   "id": "52bd612a",
    "metadata": {},
    "source": [
     "## Multi-Asset Regime Aggregation (Illustrative)\n",
@@ -1907,7 +1898,7 @@
     "Individual regime classifications (from `11_hmm_regimes`) gain\n",
     "power when aggregated across the universe. We approximate per-asset\n",
     "regime probabilities from realized volatility percentiles to\n",
-    "demonstrate the aggregation mechanics. This is exploratory — the\n",
+    "demonstrate the aggregation mechanics. This is exploratory - the\n",
     "full-history ranking introduces look-ahead. In production, use\n",
     "HMM-filtered regime probabilities estimated within walk-forward folds."
    ]
@@ -1915,19 +1906,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "08df2f57",
+   "id": "5f40f1b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:10.070149Z",
-     "iopub.status.busy": "2026-07-13T03:46:10.070039Z",
-     "iopub.status.idle": "2026-07-13T03:46:10.077239Z",
-     "shell.execute_reply": "2026-07-13T03:46:10.076797Z"
+     "iopub.execute_input": "2026-07-20T17:03:26.249921Z",
+     "iopub.status.busy": "2026-07-20T17:03:26.249838Z",
+     "iopub.status.idle": "2026-07-20T17:03:26.256815Z",
+     "shell.execute_reply": "2026-07-20T17:03:26.256300Z"
     }
    },
    "outputs": [],
    "source": [
     "# Illustrative regime probabilities from rolling volatility (proxy for HMM crisis probs).\n",
-    "# WARNING: This ranks each asset's volatility over its FULL history — a look-ahead\n",
+    "# WARNING: This ranks each asset's volatility over its FULL history - a look-ahead\n",
     "# shortcut for demonstrating the aggregation mechanics. In production, use per-asset\n",
     "# HMM filtered probabilities estimated inside walk-forward folds (see 11_hmm_regimes).\n",
     "vol_panel = panel.select([\"timestamp\", \"symbol\", \"vol_60d\"]).with_columns(\n",
@@ -1963,13 +1954,13 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "659da433",
+   "id": "cd542865",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T03:46:10.087873Z",
-     "iopub.status.busy": "2026-07-13T03:46:10.087714Z",
-     "iopub.status.idle": "2026-07-13T03:46:10.323853Z",
-     "shell.execute_reply": "2026-07-13T03:46:10.323388Z"
+     "iopub.execute_input": "2026-07-20T17:03:26.258194Z",
+     "iopub.status.busy": "2026-07-20T17:03:26.258114Z",
+     "iopub.status.idle": "2026-07-20T17:03:26.493869Z",
+     "shell.execute_reply": "2026-07-20T17:03:26.493397Z"
     }
    },
    "outputs": [
@@ -2006,36 +1997,36 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a8e3de4",
+   "id": "86a6a173",
    "metadata": {},
    "source": [
     "Crisis breadth spikes during market selloffs (visible as SPY drawdowns),\n",
     "confirming that aggregating individual regime indicators produces\n",
     "a useful system-wide stress signal. Regime dispersion is low during\n",
     "broad crises (all assets move together) and high during sector\n",
-    "rotations (differentiated behavior) — making it a complement to\n",
+    "rotations (differentiated behavior) - making it a complement to\n",
     "crisis breadth rather than a substitute."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "39fb18bb",
+   "id": "fa05ebb2",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
     "\n",
-    "1. **Cross-sectional ranking normalizes temporal features** — ranks are\n",
+    "1. **Cross-sectional ranking normalizes temporal features** - ranks are\n",
     "   scale-invariant, outlier-robust, and stationary, making heterogeneous\n",
     "   assets comparable for panel models\n",
-    "2. **Relative features decompose alpha from beta** — asset momentum minus\n",
+    "2. **Relative features decompose alpha from beta** - asset momentum minus\n",
     "   sector momentum isolates idiosyncratic signal from systematic exposure\n",
-    "3. **Two cointegration tests for robustness** — Engle-Granger and Johansen\n",
+    "3. **Two cointegration tests for robustness** - Engle-Granger and Johansen\n",
     "   may disagree; treat pairs with caution when they do\n",
-    "4. **Kalman filter adapts** — dynamic hedge ratios track structural shifts\n",
+    "4. **Kalman filter adapts** - dynamic hedge ratios track structural shifts\n",
     "   that a static OLS estimate misses\n",
-    "5. **Half-life guides lookback** — use 2x half-life for rolling z-score\n",
+    "5. **Half-life guides lookback** - use 2x half-life for rolling z-score\n",
     "   windows; short half-lives are more practical for trading\n",
-    "6. **Screen multiple pairs** — economic relatedness does not guarantee\n",
+    "6. **Screen multiple pairs** - economic relatedness does not guarantee\n",
     "   cointegration; the `ml4t-engineer` library scales this analysis\n",
     "   with Polars-native expressions\n",
     "\n",
@@ -2066,17 +2057,12 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 6.446345,
-   "end_time": "2026-07-13T03:46:11.674454+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "09_model_based_features/14_panel_features.ipynb",
-   "output_path": "09_model_based_features/14_panel_features.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-13T03:46:05.228109+00:00",
-   "version": "2.7.0"
+  "ml4t_provenance": {
+   "source_py_blob": "3d7ed368d47e129f86d5de16f696c2bdcb54d50b",
+   "executed_at": "2026-07-20T17:04:59.483960+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/09_model_based_features/14_panel_features.ipynb
+++ b/09_model_based_features/14_panel_features.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "daf1163f",
+   "id": "d7dee47b",
    "metadata": {},
    "source": [
     "# Panel Features: Pairwise and Cross-Sectional Transforms\n",
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "350e0fc5",
+   "id": "4cc675e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:22.305086Z",
-     "iopub.status.busy": "2026-07-20T17:03:22.304674Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.722936Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.722465Z"
+     "iopub.execute_input": "2026-07-20T17:49:09.934637Z",
+     "iopub.status.busy": "2026-07-20T17:49:09.934521Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.861229Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.860579Z"
     }
    },
    "outputs": [],
@@ -79,13 +79,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "39b97b2a",
+   "id": "539bb434",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.724205Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.724125Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.726012Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.725681Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.863415Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.863289Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.865401Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.864870Z"
     },
     "tags": [
      "parameters"
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "232390f4",
+   "id": "be836b16",
    "metadata": {},
    "source": [
     "## Load Data\n",
@@ -116,13 +116,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "73cd96e1",
+   "id": "d3dfdd2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.727282Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.727221Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.753740Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.753214Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.866632Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.866560Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.897255Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.896531Z"
     },
     "lines_to_next_cell": 0
    },
@@ -158,13 +158,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e8ff719f",
+   "id": "51b8f78c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.755437Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.755344Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.772859Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.772327Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.898651Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.898561Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.908974Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.908492Z"
     }
    },
    "outputs": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d844efed",
+   "id": "9c7ca28a",
    "metadata": {},
    "source": [
     "## Cointegration Testing\n",
@@ -224,13 +224,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e3f07a58",
+   "id": "555c07ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.774690Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.774595Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.820148Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.819771Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.910271Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.910182Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.982999Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.982676Z"
     }
    },
    "outputs": [
@@ -258,13 +258,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "88bcf3cb",
+   "id": "8902c3ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.821173Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.821093Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.827064Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.826551Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.984594Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.984446Z",
+     "iopub.status.idle": "2026-07-20T17:49:12.990967Z",
+     "shell.execute_reply": "2026-07-20T17:49:12.990626Z"
     }
    },
    "outputs": [
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f0519b8",
+   "id": "01adcf67",
    "metadata": {},
    "source": [
     "When both tests agree on cointegration, we have stronger evidence of a\n",
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58aa9340",
+   "id": "13d8ebb1",
    "metadata": {},
    "source": [
     "## Spread Construction\n",
@@ -330,13 +330,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "92af34fb",
+   "id": "634f2e02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.828063Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.827936Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.863651Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.863217Z"
+     "iopub.execute_input": "2026-07-20T17:49:12.992523Z",
+     "iopub.status.busy": "2026-07-20T17:49:12.992436Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.047640Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.046713Z"
     }
    },
    "outputs": [
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e35354ae",
+   "id": "dd6b7368",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -389,13 +389,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "86f4649e",
+   "id": "0952adc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.864763Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.864678Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.900490Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.900093Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.049102Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.048946Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.094830Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.094412Z"
     }
    },
    "outputs": [
@@ -468,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8436a7b",
+   "id": "9f6d9b99",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -483,13 +483,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c615d7d9",
+   "id": "946331d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.901715Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.901625Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.906376Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.906120Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.096513Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.096272Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.102941Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.102445Z"
     }
    },
    "outputs": [
@@ -537,7 +537,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23b12e9c",
+   "id": "c9a51c8f",
    "metadata": {},
    "source": [
     "The half-life estimate uses full-sample OLS on the spread - in a\n",
@@ -548,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9523fc8",
+   "id": "7dba4041",
    "metadata": {},
    "source": [
     "## Trading Signals: Z-Score and Bollinger Bands\n",
@@ -562,13 +562,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "70d52d82",
+   "id": "7a70c6a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.907487Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.907426Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.910356Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.910120Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.103832Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.103754Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.107671Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.107323Z"
     }
    },
    "outputs": [
@@ -598,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2830e263",
+   "id": "75ff2967",
    "metadata": {},
    "source": [
     "The z-score normalizes the spread by its rolling mean and standard\n",
@@ -610,13 +610,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "4da39f1d",
+   "id": "690df2b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.911450Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.911386Z",
-     "iopub.status.idle": "2026-07-20T17:03:24.915811Z",
-     "shell.execute_reply": "2026-07-20T17:03:24.915546Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.109257Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.109089Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.115727Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.115406Z"
     }
    },
    "outputs": [
@@ -657,7 +657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "828d8873",
+   "id": "78d70d57",
    "metadata": {},
    "source": [
     "## Visualize Trading System"
@@ -666,13 +666,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "04a1c119",
+   "id": "706da2d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:24.916914Z",
-     "iopub.status.busy": "2026-07-20T17:03:24.916846Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.347871Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.347380Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.116811Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.116717Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.560792Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.559960Z"
     }
    },
    "outputs": [
@@ -734,7 +734,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbf21dfd",
+   "id": "30caac05",
    "metadata": {},
    "source": [
     "## Illustrative Backtest\n",
@@ -747,13 +747,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "08be4246",
+   "id": "babb9499",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.349256Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.349175Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.356193Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.355920Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.562139Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.561984Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.572963Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.572460Z"
     }
    },
    "outputs": [
@@ -836,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9328d2a",
+   "id": "2e7b291c",
    "metadata": {},
    "source": [
     "## Summary: Primary Pair Analysis"
@@ -845,13 +845,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "77958837",
+   "id": "24dfe55a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.356950Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.356884Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.359854Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.359617Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.574501Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.574416Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.578293Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.577919Z"
     }
    },
    "outputs": [
@@ -955,7 +955,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "195e8291",
+   "id": "8d0ba6a5",
    "metadata": {},
    "source": [
     "## Cointegration Screening: Multiple ETF Pairs\n",
@@ -967,13 +967,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "fa148a96",
+   "id": "cb296578",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.360596Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.360535Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.362110Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.361848Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.579757Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.579651Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.581716Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.581287Z"
     }
    },
    "outputs": [],
@@ -994,13 +994,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "8807af06",
+   "id": "c1f0c971",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.362827Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.362768Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.685960Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.685396Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.582909Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.582826Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.978108Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.977681Z"
     }
    },
    "outputs": [],
@@ -1052,13 +1052,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "4c04181f",
+   "id": "ec01f130",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.687507Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.687435Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.692767Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.692291Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.979364Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.979262Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.985383Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.984968Z"
     }
    },
    "outputs": [
@@ -1188,7 +1188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60ec0c7b",
+   "id": "eeb25cd4",
    "metadata": {},
    "source": [
     "Economic relatedness does not guarantee cointegration - several\n",
@@ -1201,7 +1201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03f9389e",
+   "id": "cb83d2fc",
    "metadata": {},
    "source": [
     "## Save Pairs Trading Features for Downstream Chapters\n",
@@ -1214,13 +1214,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "bb29f1ca",
+   "id": "c621de45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.695422Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.695345Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.697804Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.697172Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.986473Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.986378Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.988522Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.988183Z"
     }
    },
    "outputs": [],
@@ -1232,7 +1232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c560587b",
+   "id": "eb49147e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1249,13 +1249,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "24f48a47",
+   "id": "59943fe1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.699329Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.699256Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.702753Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.702345Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.989255Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.989186Z",
+     "iopub.status.idle": "2026-07-20T17:49:13.992621Z",
+     "shell.execute_reply": "2026-07-20T17:49:13.992292Z"
     }
    },
    "outputs": [],
@@ -1312,13 +1312,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "f56d8648",
+   "id": "395137d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.703774Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.703711Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.743404Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.743032Z"
+     "iopub.execute_input": "2026-07-20T17:49:13.993591Z",
+     "iopub.status.busy": "2026-07-20T17:49:13.993514Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.034989Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.034628Z"
     }
    },
    "outputs": [
@@ -1354,13 +1354,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "df19850e",
+   "id": "ecd94fa7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.744670Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.744598Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.752411Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.749108Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.035984Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.035903Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.041636Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.041291Z"
     }
    },
    "outputs": [
@@ -1369,7 +1369,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[OK] Saved pairs trading signals to /tmp/claude-1000/-home-stefan-ml4t-agents/ac2f3c8d-9d11-48e0-a687-e7d29eb8b83b/scratchpad/ch09-out/etfs/models/time_series/pairs_trading_signals.parquet\n",
+      "[OK] Saved pairs trading signals to case_studies/etfs/models/time_series/pairs_trading_signals.parquet\n",
       "  Shape: (2516, 8)\n",
       "  Pairs: ['GLD/SLV']\n",
       "  Date range: 2015-01-02 00:00:00 to 2024-12-31 00:00:00\n",
@@ -1386,7 +1386,9 @@
     "    output_path = MODEL_DIR / \"pairs_trading_signals.parquet\"\n",
     "    combined_signals.write_parquet(output_path)\n",
     "\n",
-    "    print(f\"\\n[OK] Saved pairs trading signals to {output_path}\")\n",
+    "    # Show a repo-root-relative path so the output carries no machine-specific prefix.\n",
+    "    display_path = output_path.relative_to(get_case_study_dir(\"etfs\").parents[1])\n",
+    "    print(f\"\\n[OK] Saved pairs trading signals to {display_path}\")\n",
     "    print(f\"  Shape: {combined_signals.shape}\")\n",
     "    print(f\"  Pairs: {combined_signals['pair'].unique().to_list()}\")\n",
     "    print(\n",
@@ -1404,7 +1406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06e26d7a",
+   "id": "ab23a4e8",
    "metadata": {},
    "source": [
     "## ml4t-engineer: Cross-Asset Features as Polars Expressions\n",
@@ -1418,13 +1420,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "0d0bcc8a",
+   "id": "938a4f75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.753654Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.753533Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.760275Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.759906Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.042586Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.042506Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.050027Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.049613Z"
     }
    },
    "outputs": [
@@ -1478,7 +1480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3d2c8f0",
+   "id": "8c91db63",
    "metadata": {},
    "source": [
     "The library expressions compose naturally in `with_columns()`, making it\n",
@@ -1490,7 +1492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd271531",
+   "id": "8ed3e920",
    "metadata": {},
    "source": [
     "## Cross-Sectional Ranking of Temporal Features\n",
@@ -1504,13 +1506,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "90541f5a",
+   "id": "8367313c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.761496Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.761385Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.769876Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.769335Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.051483Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.051261Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.061816Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.061157Z"
     }
    },
    "outputs": [
@@ -1551,13 +1553,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "d41e447c",
+   "id": "82c85fed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.770828Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.770712Z",
-     "iopub.status.idle": "2026-07-20T17:03:25.783116Z",
-     "shell.execute_reply": "2026-07-20T17:03:25.782707Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.063420Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.063272Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.076569Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.076242Z"
     }
    },
    "outputs": [
@@ -1727,13 +1729,13 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "736059c6",
+   "id": "1a39b89b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:25.784388Z",
-     "iopub.status.busy": "2026-07-20T17:03:25.784260Z",
-     "iopub.status.idle": "2026-07-20T17:03:26.033845Z",
-     "shell.execute_reply": "2026-07-20T17:03:26.033302Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.077998Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.077893Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.389676Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.388995Z"
     }
    },
    "outputs": [
@@ -1773,7 +1775,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "728a15e3",
+   "id": "d97c25f2",
    "metadata": {},
    "source": [
     "Ranks are bounded, stationary, and immune to outliers. A high\n",
@@ -1784,7 +1786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d52719a",
+   "id": "2d89b49a",
    "metadata": {},
    "source": [
     "## Relative Temporal Features\n",
@@ -1799,13 +1801,13 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "f8b1bab1",
+   "id": "7ad1cdbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:26.034993Z",
-     "iopub.status.busy": "2026-07-20T17:03:26.034877Z",
-     "iopub.status.idle": "2026-07-20T17:03:26.248817Z",
-     "shell.execute_reply": "2026-07-20T17:03:26.248274Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.391614Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.391455Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.631366Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.630644Z"
     }
    },
    "outputs": [
@@ -1877,7 +1879,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a862ece",
+   "id": "9823c0af",
    "metadata": {},
    "source": [
     "Relative momentum removes the market component - XLE's energy-sector\n",
@@ -1890,7 +1892,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52bd612a",
+   "id": "e09873bb",
    "metadata": {},
    "source": [
     "## Multi-Asset Regime Aggregation (Illustrative)\n",
@@ -1906,13 +1908,13 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "5f40f1b4",
+   "id": "9d9a5bcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:26.249921Z",
-     "iopub.status.busy": "2026-07-20T17:03:26.249838Z",
-     "iopub.status.idle": "2026-07-20T17:03:26.256815Z",
-     "shell.execute_reply": "2026-07-20T17:03:26.256300Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.633341Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.633159Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.643568Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.642954Z"
     }
    },
    "outputs": [],
@@ -1954,13 +1956,13 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "cd542865",
+   "id": "b140d6a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T17:03:26.258194Z",
-     "iopub.status.busy": "2026-07-20T17:03:26.258114Z",
-     "iopub.status.idle": "2026-07-20T17:03:26.493869Z",
-     "shell.execute_reply": "2026-07-20T17:03:26.493397Z"
+     "iopub.execute_input": "2026-07-20T17:49:14.644924Z",
+     "iopub.status.busy": "2026-07-20T17:49:14.644761Z",
+     "iopub.status.idle": "2026-07-20T17:49:14.938495Z",
+     "shell.execute_reply": "2026-07-20T17:49:14.937853Z"
     }
    },
    "outputs": [
@@ -1997,7 +1999,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86a6a173",
+   "id": "11f06b17",
    "metadata": {},
    "source": [
     "Crisis breadth spikes during market selloffs (visible as SPY drawdowns),\n",
@@ -2010,7 +2012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa05ebb2",
+   "id": "5c7c884e",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -2058,11 +2060,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "3d7ed368d47e129f86d5de16f696c2bdcb54d50b",
-   "executed_at": "2026-07-20T17:04:59.483960+00:00",
+   "source_py_blob": "db310dc1f007c162d751659c74934372dce56c50",
+   "executed_at": "2026-07-20T17:49:38.509105+00:00",
    "executor": "local-uv",
    "production": true,
-   "parameters": {}
+   "parameters": {},
+   "notes": "ch09/14 re-exec: repo-relative save path (matches 07); GLD/SLV stats under ml4t-engineer 0.1.0b10"
   }
  },
  "nbformat": 4,

--- a/09_model_based_features/14_panel_features.py
+++ b/09_model_based_features/14_panel_features.py
@@ -662,7 +662,9 @@ if all_signals:
     output_path = MODEL_DIR / "pairs_trading_signals.parquet"
     combined_signals.write_parquet(output_path)
 
-    print(f"\n[OK] Saved pairs trading signals to {output_path}")
+    # Show a repo-root-relative path so the output carries no machine-specific prefix.
+    display_path = output_path.relative_to(get_case_study_dir("etfs").parents[1])
+    print(f"\n[OK] Saved pairs trading signals to {display_path}")
     print(f"  Shape: {combined_signals.shape}")
     print(f"  Pairs: {combined_signals['pair'].unique().to_list()}")
     print(

--- a/09_model_based_features/14_panel_features.py
+++ b/09_model_based_features/14_panel_features.py
@@ -25,7 +25,7 @@
 #
 # Panel features matter because temporal features computed in isolation
 # (volatility, momentum, regime probabilities) gain signal when placed
-# in cross-sectional context — a 25% conditional volatility means
+# in cross-sectional context - a 25% conditional volatility means
 # different things for a utility stock and a biotech.
 #
 # **Learning Objectives**:
@@ -41,7 +41,7 @@
 # `11_hmm_regimes` for regime features used in universe aggregation.
 
 # %%
-"""Panel Features — pairwise and cross-sectional transforms for multi-asset temporal features."""
+"""Panel Features - pairwise and cross-sectional transforms for multi-asset temporal features."""
 
 import warnings
 
@@ -71,7 +71,7 @@ from data import load_etfs
 from utils.paths import get_case_study_dir
 
 # %% tags=["parameters"]
-# Production defaults — Papermill injects overrides for CI
+# Production defaults - Papermill injects overrides for CI
 MAX_SYMBOLS = 0  # 0 = all symbols
 START_DATE = "2015-01-01"
 END_DATE = "2024-12-31"
@@ -178,7 +178,7 @@ print(f"\nImplied hedge ratio from Johansen: {hedge_ratio_joh:.4f}")
 # %% [markdown]
 # When both tests agree on cointegration, we have stronger evidence of a
 # long-run equilibrium relationship. When they disagree, treat the pair
-# with caution — the relationship may be fragile or sensitive to the
+# with caution - the relationship may be fragile or sensitive to the
 # sample period. The Johansen-implied hedge ratio often differs from OLS
 # because the two methods weight observations differently.
 
@@ -315,7 +315,7 @@ print(f"Half-life (OLS spread): {half_life_ols:.1f} days")
 print(f"Half-life (Kalman spread): {half_life_kf:.1f} days")
 
 # %% [markdown]
-# The half-life estimate uses full-sample OLS on the spread — in a
+# The half-life estimate uses full-sample OLS on the spread - in a
 # walk-forward context, only past data should be used. The Kalman spread
 # typically yields shorter half-lives because the adaptive hedge ratio
 # removes low-frequency drift from the spread, leaving a faster-reverting residual.
@@ -345,7 +345,7 @@ print(f"Lookback window: {lookback} days (2x half-life)")
 
 # %% [markdown]
 # The z-score normalizes the spread by its rolling mean and standard
-# deviation — it is the natural signal for mean-reverting spreads because
+# deviation - it is the natural signal for mean-reverting spreads because
 # cointegration implies the spread is stationary around a fixed level.
 # Entry at $\pm 2\sigma$ captures significant deviations while filtering noise.
 
@@ -425,7 +425,7 @@ plt.show()
 # ## Illustrative Backtest
 #
 # A compact backtest demonstrates how cointegration features translate into
-# tradable signals. This ignores transaction costs and slippage — see
+# tradable signals. This ignores transaction costs and slippage - see
 # Chapters 18–19 for proper strategy evaluation with realistic cost models.
 
 # %%
@@ -557,7 +557,7 @@ display_df["Half-life (d)"] = display_df["Half-life (d)"].map(
 display(display_df)
 
 # %% [markdown]
-# Economic relatedness does not guarantee cointegration — several
+# Economic relatedness does not guarantee cointegration - several
 # apparently related pairs fail the Engle-Granger test, and the two
 # tests sometimes disagree. Half-lives range from days to months,
 # reflecting the speed at which different pair relationships mean-revert.
@@ -725,7 +725,7 @@ for col in ["corr", "beta", "coint_score"]:
 # The library expressions compose naturally in `with_columns()`, making it
 # straightforward to compute cross-asset features across many pairs in a
 # single Polars pipeline. `correlation_regime_indicator()` adds binary
-# regime flags based on rolling correlation levels — useful for
+# regime flags based on rolling correlation levels - useful for
 # conditional feature engineering.
 
 # %% [markdown]
@@ -733,7 +733,7 @@ for col in ["corr", "beta", "coint_score"]:
 #
 # Raw temporal features (momentum, conditional volatility, regime
 # probabilities) vary in scale across assets. Cross-sectional ranking
-# converts them to universe-relative signals — essential for panel models
+# converts them to universe-relative signals - essential for panel models
 # that predict cross-sectional returns.
 
 # %%
@@ -809,14 +809,14 @@ plt.show()
 # %% [markdown]
 # Ranks are bounded, stationary, and immune to outliers. A high
 # momentum rank (top of universe) followed by rank decay signals
-# momentum exhaustion — a feature that absolute momentum values
+# momentum exhaustion - a feature that absolute momentum values
 # cannot express because their scale drifts with market conditions.
 
 # %% [markdown]
 # ## Relative Temporal Features
 #
 # Many temporal features gain signal when expressed relative to a
-# benchmark — isolating idiosyncratic dynamics from systematic exposure.
+# benchmark - isolating idiosyncratic dynamics from systematic exposure.
 # We demonstrate market-relative features (vs SPY). Sector-relative
 # features follow the same pattern with a sector ETF as benchmark
 # (e.g., XLE momentum minus XLF momentum isolates energy-specific signal).
@@ -876,7 +876,7 @@ plt.tight_layout()
 plt.show()
 
 # %% [markdown]
-# Relative momentum removes the market component — XLE's energy-sector
+# Relative momentum removes the market component - XLE's energy-sector
 # bets become visible only after subtracting the broad equity trend.
 # Relative volatility (vol / market vol) distinguishes periods where an
 # asset is genuinely more volatile from periods where the entire market
@@ -889,13 +889,13 @@ plt.show()
 # Individual regime classifications (from `11_hmm_regimes`) gain
 # power when aggregated across the universe. We approximate per-asset
 # regime probabilities from realized volatility percentiles to
-# demonstrate the aggregation mechanics. This is exploratory — the
+# demonstrate the aggregation mechanics. This is exploratory - the
 # full-history ranking introduces look-ahead. In production, use
 # HMM-filtered regime probabilities estimated within walk-forward folds.
 
 # %%
 # Illustrative regime probabilities from rolling volatility (proxy for HMM crisis probs).
-# WARNING: This ranks each asset's volatility over its FULL history — a look-ahead
+# WARNING: This ranks each asset's volatility over its FULL history - a look-ahead
 # shortcut for demonstrating the aggregation mechanics. In production, use per-asset
 # HMM filtered probabilities estimated inside walk-forward folds (see 11_hmm_regimes).
 vol_panel = panel.select(["timestamp", "symbol", "vol_60d"]).with_columns(
@@ -951,24 +951,24 @@ plt.show()
 # confirming that aggregating individual regime indicators produces
 # a useful system-wide stress signal. Regime dispersion is low during
 # broad crises (all assets move together) and high during sector
-# rotations (differentiated behavior) — making it a complement to
+# rotations (differentiated behavior) - making it a complement to
 # crisis breadth rather than a substitute.
 
 # %% [markdown]
 # ## Key Takeaways
 #
-# 1. **Cross-sectional ranking normalizes temporal features** — ranks are
+# 1. **Cross-sectional ranking normalizes temporal features** - ranks are
 #    scale-invariant, outlier-robust, and stationary, making heterogeneous
 #    assets comparable for panel models
-# 2. **Relative features decompose alpha from beta** — asset momentum minus
+# 2. **Relative features decompose alpha from beta** - asset momentum minus
 #    sector momentum isolates idiosyncratic signal from systematic exposure
-# 3. **Two cointegration tests for robustness** — Engle-Granger and Johansen
+# 3. **Two cointegration tests for robustness** - Engle-Granger and Johansen
 #    may disagree; treat pairs with caution when they do
-# 4. **Kalman filter adapts** — dynamic hedge ratios track structural shifts
+# 4. **Kalman filter adapts** - dynamic hedge ratios track structural shifts
 #    that a static OLS estimate misses
-# 5. **Half-life guides lookback** — use 2x half-life for rolling z-score
+# 5. **Half-life guides lookback** - use 2x half-life for rolling z-score
 #    windows; short half-lives are more practical for trading
-# 6. **Screen multiple pairs** — economic relatedness does not guarantee
+# 6. **Screen multiple pairs** - economic relatedness does not guarantee
 #    cointegration; the `ml4t-engineer` library scales this analysis
 #    with Polars-native expressions
 #


### PR DESCRIPTION
`09/14_panel_features` calls `rolling_correlation` and `beta_to_market`, whose estimators were fixed in `ml4t-engineer 0.1.0b10` (they did not compute Cov/Var — see the Ch08 PR #394). Re-executed under b10:

- corr 0.7799 → 0.7937 (was biased low)
- beta 1.4323 → 1.4570 (was biased low ~1.7%)
- coint_score 0.0697 unchanged (`co_integration_score` uses `rolling_std`, not the fixed functions)

Both move up slightly as the downward bias is removed; the interpretation is unchanged (GLD/SLV ~0.79 correlated, silver ~1.46 beta to gold). The book does not quote these numbers, so no erratum. Em-dash sweep applied.

Deferred to the Ch09 sign-off track (out of scope for this targeted correctness fix): the figures use the default matplotlib colorway rather than the ML4T palette — a pre-existing gap, not introduced here.
