### PR TITLE
Fix the experiment workflow: create_experiment must copy config

### DIFF
--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -154,9 +154,13 @@ def load_sweep(case_study: str) -> dict:
 
 
 def _setup_path(case_study: str):
-    from utils import CASE_STUDIES_DIR
+    # Resolve through get_case_study_dir so setup.yaml is read from the same place
+    # the model stages read it: the source tree in production, or ML4T_OUTPUT_DIR
+    # when set (tests, and the create_experiment workflow where the reader edits
+    # backtest.sweep/costs/execution in their isolated experiment copy).
+    from utils.paths import get_case_study_dir
 
-    return CASE_STUDIES_DIR / case_study / "config" / "setup.yaml"
+    return get_case_study_dir(case_study) / "config" / "setup.yaml"
 
 
 def _load_setup(case_study: str) -> dict:

--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -160,7 +160,10 @@ def _setup_path(case_study: str):
     # backtest.sweep/costs/execution in their isolated experiment copy).
     from utils.paths import get_case_study_dir
 
-    return get_case_study_dir(case_study) / "config" / "setup.yaml"
+    # create=False: reading config must never materialize the case-study dir. A
+    # side-effect mkdir under ML4T_OUTPUT_DIR would make create_experiment think
+    # the experiment already exists.
+    return get_case_study_dir(case_study, create=False) / "config" / "setup.yaml"
 
 
 def _load_setup(case_study: str) -> dict:

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -280,13 +280,23 @@ worth reporting as an issue.
 ## Experimenting Without Changing the Release Baseline
 
 Create a writable copy of the installed artifacts before changing a configuration or running a
-training or backtest stage:
+training or backtest stage. The artifact bundle installs the registry (`run_log/`) only, so first
+produce the modeling dataset (`features/`, `labels/`) that the model stages consume, then create the
+experiment and run your edited stage against it:
 
 ```bash
+# 1. Produce the modeling dataset the model notebooks need (writes features/ and
+#    labels/ into the case study directory; skip any that already exist).
+uv run python case_studies/etfs/02_labels.py
+uv run python case_studies/etfs/03_financial_features.py
+uv run python case_studies/etfs/04_model_based_features.py
+
+# 2. Snapshot the installed artifacts + config into a writable experiment.
 uv run python scripts/create_experiment.py \
   --cs etfs \
   --output /tmp/ml4t-etf-experiment
 
+# 3. Edit config in the experiment (see below), then run the stage against it.
 ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment \
   uv run python case_studies/etfs/07_gbm.py
 ```
@@ -297,12 +307,6 @@ writable. `ML4T_OUTPUT_DIR` routes both config reads and new registry rows into
 `/tmp/ml4t-etf-experiment/`, so you change a configuration **inside the experiment** and the
 downloaded release stays untouched. You edit config there, not in the model notebook - the notebooks
 have no hyperparameter grids inline; they read the config system described below.
-
-> **Prerequisite for training stages.** The artifact bundle installs the registry (`run_log/`) only.
-> `07_gbm.py` and the other model notebooks also need the modeling dataset (`features/`, `labels/`),
-> which you produce by running `02_labels.py`, `03_financial_features.py`, and
-> `04_model_based_features.py` first. `create_experiment.py` copies whatever of those already exist in
-> the case study directory.
 
 ### Try Different Model Hyperparameters
 

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -473,14 +473,7 @@ case_studies/etfs/07_gbm:
 
 ### Output Isolation
 
-When the environment variable `ML4T_OUTPUT_DIR` is set (which `pytest` does automatically), notebook outputs **and config reads** are redirected to that directory. This prevents test runs from overwriting production artifacts like trained models or backtest results. Because config is redirected too, the target must contain the case study's config; `pytest` seeds it automatically, and for a manual run `create_experiment.py` builds a self-contained copy:
-
-```bash
-# Manual output isolation: create a self-contained experiment (copies config +
-# artifacts) so the redirected config reads resolve, then run against it.
-uv run python scripts/create_experiment.py --cs etfs --output /tmp/ml4t-etf-experiment
-ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment uv run python case_studies/etfs/07_gbm.py
-```
+When the environment variable `ML4T_OUTPUT_DIR` is set (which `pytest` does automatically), notebook outputs **and the model/sweep config reads** are redirected to that directory. This prevents test runs from overwriting production artifacts like trained models or backtest results. Because that config is redirected too, the target must contain the case study's config: `pytest` seeds it automatically, and for a manual run `create_experiment.py` builds the isolated copy. To actually run a stage against the isolated directory - including generating the `features/`/`labels/` a model stage needs first - follow the runnable sequence in [Experimenting Without Changing the Release Baseline](#experimenting-without-changing-the-release-baseline) above; setting `ML4T_OUTPUT_DIR` by hand at an empty path will fail because the redirected config (and modeling dataset) are absent.
 
 ---
 

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -342,8 +342,11 @@ Cadence, transaction costs, and selection breadth live in the experiment's
 - `costs.*` - the transaction-cost model (per-share fees, spreads).
 - `backtest.sweep.top_n_predictions` - how many model configs advance at each stage.
 
-The `14_backtest.py` parameter cell exposes run-scoping knobs only - `SPLIT`, `TOP_K`, `MAX_SYMBOLS`,
-`TOP_N_PREDICTIONS`, `FORCE_REBACKTEST` - which select what to backtest, not the strategy economics.
+The `14_backtest.py` parameter cell exposes run-scoping knobs - `TOP_K`, `MAX_SYMBOLS`,
+`TOP_N_PREDICTIONS`, `FORCE_REBACKTEST` - which scope what to backtest, not the strategy economics.
+This notebook always backtests on the **validation** split (the split the sweep selects on); the
+held-out test set is evaluated once on the selected winner in the analysis stage, not from here, so
+do not repurpose the `SPLIT` variable to backtest holdout.
 
 ```bash
 $EDITOR /tmp/ml4t-etf-experiment/etfs/config/setup.yaml   # edit decision / costs / backtest.sweep
@@ -470,11 +473,13 @@ case_studies/etfs/07_gbm:
 
 ### Output Isolation
 
-When the environment variable `ML4T_OUTPUT_DIR` is set (which `pytest` does automatically), all notebook outputs are redirected to a temporary directory. This prevents test runs from overwriting production artifacts like trained models or backtest results.
+When the environment variable `ML4T_OUTPUT_DIR` is set (which `pytest` does automatically), notebook outputs **and config reads** are redirected to that directory. This prevents test runs from overwriting production artifacts like trained models or backtest results. Because config is redirected too, the target must contain the case study's config; `pytest` seeds it automatically, and for a manual run `create_experiment.py` builds a self-contained copy:
 
 ```bash
-# Manual output isolation
-ML4T_OUTPUT_DIR=/tmp/ml4t-test uv run python case_studies/etfs/07_gbm.py
+# Manual output isolation: create a self-contained experiment (copies config +
+# artifacts) so the redirected config reads resolve, then run against it.
+uv run python scripts/create_experiment.py --cs etfs --output /tmp/ml4t-etf-experiment
+ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment uv run python case_studies/etfs/07_gbm.py
 ```
 
 ---

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -291,33 +291,61 @@ ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment \
   uv run python case_studies/etfs/07_gbm.py
 ```
 
-The setup command copies every available generated prerequisite, changes the release marker to a
-baseline marker, and makes only the copy writable. `ML4T_OUTPUT_DIR` routes new registry rows and
-artifacts into `/tmp/ml4t-etf-experiment/etfs/`. The downloaded release remains unchanged.
+The setup command copies every available generated prerequisite **and the case study's `config/`
+tree** into the experiment, changes the release marker to a baseline marker, and makes only the copy
+writable. `ML4T_OUTPUT_DIR` routes both config reads and new registry rows into
+`/tmp/ml4t-etf-experiment/`, so you change a configuration **inside the experiment** and the
+downloaded release stays untouched. You edit config there, not in the model notebook - the notebooks
+have no hyperparameter grids inline; they read the config system described below.
+
+> **Prerequisite for training stages.** The artifact bundle installs the registry (`run_log/`) only.
+> `07_gbm.py` and the other model notebooks also need the modeling dataset (`features/`, `labels/`),
+> which you produce by running `02_labels.py`, `03_financial_features.py`, and
+> `04_model_based_features.py` first. `create_experiment.py` copies whatever of those already exist in
+> the case study directory.
 
 ### Try Different Model Hyperparameters
 
-Open a model notebook such as `07_gbm.py`, modify the configuration, and run it with the experiment's
-`ML4T_OUTPUT_DIR`. The new run receives a unique hash in the copied registry.
+The GBM grid is not a `PARAM_GRID` inside `07_gbm.py`. It is the list of preset names in
+`config/training/{label}.yaml` under the `gbm:` key; each name resolves to a preset file in
+`case_studies/config/lgb/{name}.yaml` that holds the actual LightGBM parameters. To change the grid,
+edit these files **in the experiment**:
 
-```python
-# In 07_gbm.py, change the parameter grid:
-PARAM_GRID = {
-    "num_leaves": [31, 63, 127],      # Try more complex trees
-    "learning_rate": [0.01, 0.05],     # Different learning rates
-    "min_child_samples": [20, 50],
-}
+```bash
+# Add or remove configs from the grid (one preset name per line under `gbm:`):
+$EDITOR /tmp/ml4t-etf-experiment/etfs/config/training/fwd_ret_21d.yaml
+
+# Change the hyperparameters of a preset, or add a new preset file:
+$EDITOR /tmp/ml4t-etf-experiment/config/lgb/leaves_63_mse.yaml
+
+# Run on CPU if you do not have a CUDA-enabled LightGBM build
+# (set modeling.gbm.device: cpu in the experiment's setup.yaml):
+$EDITOR /tmp/ml4t-etf-experiment/etfs/config/setup.yaml
+
+ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment \
+  uv run python case_studies/etfs/07_gbm.py
 ```
+
+Each config that is not already in the copied registry trains and receives a unique hash there; the
+analysis notebooks pick up every registry hash automatically.
 
 ### Try a Different Backtest Configuration
 
-Modify the signal-to-position mapping, change cost assumptions, or adjust position sizing:
+Cadence, transaction costs, and selection breadth live in the experiment's
+`etfs/config/setup.yaml`, not as variables in `14_backtest.py`:
 
-```python
-# In 14_backtest.py, change the strategy:
-TOP_N = 10              # Hold top 10 instead of top 20
-COST_BPS = 15           # Higher transaction costs
-REBALANCE_FREQ = "W"    # Weekly instead of monthly
+- `decision.cadence` - rebalance cadence (e.g. `monthly_month_end`).
+- `costs.*` - the transaction-cost model (per-share fees, spreads).
+- `backtest.sweep.top_n_predictions` - how many model configs advance at each stage.
+
+The `14_backtest.py` parameter cell exposes run-scoping knobs only - `SPLIT`, `TOP_K`, `MAX_SYMBOLS`,
+`TOP_N_PREDICTIONS`, `FORCE_REBACKTEST` - which select what to backtest, not the strategy economics.
+
+```bash
+$EDITOR /tmp/ml4t-etf-experiment/etfs/config/setup.yaml   # edit decision / costs / backtest.sweep
+
+ML4T_OUTPUT_DIR=/tmp/ml4t-etf-experiment \
+  uv run python case_studies/etfs/14_backtest.py
 ```
 
 ### Compare Your Experiments

--- a/scripts/create_experiment.py
+++ b/scripts/create_experiment.py
@@ -18,6 +18,23 @@ def _make_writable(root: Path) -> None:
         path.chmod(path.stat().st_mode | stat.S_IWUSR)
 
 
+def _seed_shared_presets(repo_root: Path, output_root: Path) -> None:
+    """Copy the shared model presets into the experiment's ML4T_OUTPUT_DIR.
+
+    ``load_configs`` resolves preset files at ``{ML4T_OUTPUT_DIR}/config/{model_type}/``
+    (it reads ``case_dir.parent / "config"``), so the shared ``case_studies/config/``
+    tree must be present there for a preset lookup to succeed under the experiment
+    dir. Mirrors ``tests/conftest.py::seeded_output_dir``. Shared across every case
+    study in one output root, so seed it once and leave an existing copy in place.
+    """
+    src = repo_root / "case_studies" / "config"
+    dst = output_root / "config"
+    if not src.is_dir() or dst.exists():
+        return
+    shutil.copytree(src, dst)
+    _make_writable(dst)
+
+
 def create_experiment(
     case_study: str,
     output_root: Path,
@@ -29,6 +46,9 @@ def create_experiment(
     source_run_log = source / "run_log"
     if not source.is_dir() or not source_run_log.is_dir() or source_run_log.is_symlink():
         raise ValueError(f"Install the {case_study} artifact bundle before creating an experiment")
+    source_config = source / "config"
+    if not source_config.is_dir():
+        raise ValueError(f"Case study {case_study} has no config/ tree; cannot create experiment")
 
     output_root = output_root.resolve()
     target = output_root / case_study
@@ -44,6 +64,12 @@ def create_experiment(
             if candidate.is_dir():
                 shutil.copytree(candidate, staging / name)
 
+        # config/ is a version-controlled input, not a generated artifact, but the
+        # reader edits it to define the experiment and get_case_study_dir() redirects
+        # config reads to ML4T_OUTPUT_DIR, so the experiment must carry its own copy
+        # (else notebooks crash on config/setup.yaml before any reader edit is reached).
+        shutil.copytree(source_config, staging / "config")
+
         _make_writable(staging)
         release_metadata = staging / "run_log/.release"
         if release_metadata.exists():
@@ -52,6 +78,8 @@ def create_experiment(
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
+
+    _seed_shared_presets(repo_root, output_root)
     return target
 
 
@@ -69,8 +97,10 @@ def main() -> None:
     args = parser.parse_args()
 
     experiment = create_experiment(args.cs, args.output)
+    output_root = args.output.resolve()
     print(f"Experiment ready: {experiment}")
-    print(f"Set ML4T_OUTPUT_DIR={args.output.resolve()} when running case-study notebooks.")
+    print(f"Edit the config in {experiment / 'config'} to change the experiment,")
+    print(f"then set ML4T_OUTPUT_DIR={output_root} when running case-study notebooks.")
 
 
 if __name__ == "__main__":

--- a/scripts/create_experiment.py
+++ b/scripts/create_experiment.py
@@ -18,23 +18,6 @@ def _make_writable(root: Path) -> None:
         path.chmod(path.stat().st_mode | stat.S_IWUSR)
 
 
-def _seed_shared_presets(repo_root: Path, output_root: Path) -> None:
-    """Copy the shared model presets into the experiment's ML4T_OUTPUT_DIR.
-
-    ``load_configs`` resolves preset files at ``{ML4T_OUTPUT_DIR}/config/{model_type}/``
-    (it reads ``case_dir.parent / "config"``), so the shared ``case_studies/config/``
-    tree must be present there for a preset lookup to succeed under the experiment
-    dir. Mirrors ``tests/conftest.py::seeded_output_dir``. Shared across every case
-    study in one output root, so seed it once and leave an existing copy in place.
-    """
-    src = repo_root / "case_studies" / "config"
-    dst = output_root / "config"
-    if not src.is_dir() or dst.exists():
-        return
-    shutil.copytree(src, dst)
-    _make_writable(dst)
-
-
 def create_experiment(
     case_study: str,
     output_root: Path,
@@ -55,8 +38,16 @@ def create_experiment(
     if target.exists():
         raise FileExistsError(f"Experiment already exists: {target}")
 
+    # Shared model presets (case_studies/config/) resolve at {ML4T_OUTPUT_DIR}/config/
+    # (load_configs reads case_dir.parent / "config"). Seed them once per output root;
+    # leave an existing copy in place so a second case-study experiment reuses it.
+    presets_src = repo_root / "case_studies" / "config"
+    presets_dst = output_root / "config"
+    seed_presets = presets_src.is_dir() and not presets_dst.exists()
+
     output_root.mkdir(parents=True, exist_ok=True)
     staging = output_root / f".{case_study}-staging-{uuid.uuid4().hex}"
+    presets_staging = output_root / f".config-staging-{uuid.uuid4().hex}" if seed_presets else None
     try:
         staging.mkdir()
         for name in GENERATED_DIRS:
@@ -74,12 +65,22 @@ def create_experiment(
         release_metadata = staging / "run_log/.release"
         if release_metadata.exists():
             release_metadata.rename(staging / "run_log/.baseline")
+
+        if presets_staging is not None:
+            shutil.copytree(presets_src, presets_staging)
+            _make_writable(presets_staging)
+
+        # All expensive copies are done; finalize with atomic renames only. Order:
+        # presets first so a completed case-study dir never implies missing presets.
+        if presets_staging is not None:
+            presets_staging.rename(presets_dst)
         staging.rename(target)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
+        if presets_staging is not None:
+            shutil.rmtree(presets_staging, ignore_errors=True)
         raise
 
-    _seed_shared_presets(repo_root, output_root)
     return target
 
 

--- a/tests/test_create_experiment.py
+++ b/tests/test_create_experiment.py
@@ -17,8 +17,8 @@ def _load_module():
     return module
 
 
-def test_create_experiment_copies_baseline_without_mutating_source(tmp_path: Path) -> None:
-    module = _load_module()
+def _seed_source(tmp_path: Path) -> Path:
+    """Build a minimal etfs source tree (registry + features + config)."""
     source = tmp_path / "repo/case_studies/etfs"
     registry = source / "run_log/registry.db"
     registry.parent.mkdir(parents=True)
@@ -29,6 +29,23 @@ def test_create_experiment_copies_baseline_without_mutating_source(tmp_path: Pat
     features = source / "features/features.parquet"
     features.parent.mkdir()
     features.write_bytes(b"features")
+    # Per-case-study config (input the reader edits to define the experiment).
+    config = source / "config"
+    (config / "training").mkdir(parents=True)
+    (config / "setup.yaml").write_text("modeling:\n  gbm:\n    device: cpu\n")
+    (config / "training/fwd_ret_21d.yaml").write_text("gbm:\n- default_mse\n")
+    # Shared model presets resolved at {ML4T_OUTPUT_DIR}/config/{model_type}/.
+    shared = tmp_path / "repo/case_studies/config/lgb"
+    shared.mkdir(parents=True)
+    (shared / "default_mse.yaml").write_text("params: {objective: regression}\n")
+    return source
+
+
+def test_create_experiment_copies_baseline_without_mutating_source(tmp_path: Path) -> None:
+    module = _load_module()
+    source = _seed_source(tmp_path)
+    registry = source / "run_log/registry.db"
+    release = source / "run_log/.release"
     registry.chmod(registry.stat().st_mode & ~stat.S_IWUSR)
     release.chmod(release.stat().st_mode & ~stat.S_IWUSR)
     registry.parent.chmod(registry.parent.stat().st_mode & ~stat.S_IWUSR)
@@ -45,3 +62,43 @@ def test_create_experiment_copies_baseline_without_mutating_source(tmp_path: Pat
     assert not registry.stat().st_mode & stat.S_IWUSR
     registry.parent.chmod(registry.parent.stat().st_mode | stat.S_IWUSR)
     release.chmod(release.stat().st_mode | stat.S_IWUSR)
+
+
+def test_create_experiment_seeds_editable_config_and_shared_presets(tmp_path: Path) -> None:
+    """The documented workflow reads config through ML4T_OUTPUT_DIR, so the
+    experiment must carry its own per-CS config and the shared preset tree, both
+    writable so the reader can edit them (regression for the D7 config crash)."""
+    module = _load_module()
+    _seed_source(tmp_path)
+
+    output_root = tmp_path / "experiments/etf-test"
+    result = module.create_experiment("etfs", output_root, repo_root=tmp_path / "repo")
+
+    # Per-CS config copied under the experiment's case-study dir.
+    setup = result / "config/setup.yaml"
+    training = result / "config/training/fwd_ret_21d.yaml"
+    assert setup.exists() and training.exists()
+    # Shared presets seeded at the output root so load_configs() resolves them at
+    # {case_dir.parent}/config/{model_type}/.
+    preset = output_root / "config/lgb/default_mse.yaml"
+    assert preset.exists()
+    # All copied config is writable (the reader edits it in place).
+    assert setup.stat().st_mode & stat.S_IWUSR
+    assert preset.stat().st_mode & stat.S_IWUSR
+    # Source config is untouched by the experiment run.
+    assert (tmp_path / "repo/case_studies/etfs/config/setup.yaml").exists()
+
+
+def test_create_experiment_requires_config_tree(tmp_path: Path) -> None:
+    """A case study with artifacts but no config/ cannot form a runnable experiment."""
+    module = _load_module()
+    source = tmp_path / "repo/case_studies/etfs"
+    (source / "run_log").mkdir(parents=True)
+    (source / "run_log/registry.db").write_bytes(b"registry")
+
+    try:
+        module.create_experiment("etfs", tmp_path / "out", repo_root=tmp_path / "repo")
+    except ValueError as exc:
+        assert "config" in str(exc)
+    else:  # pragma: no cover - guard must raise
+        raise AssertionError("expected ValueError for missing config/ tree")

--- a/tests/test_sweep_config_seam.py
+++ b/tests/test_sweep_config_seam.py
@@ -272,3 +272,15 @@ def test_sweep_reads_redirected_setup_under_output_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
     assert load_sweep(cs)["top_n_predictions"]["allocation"] == sentinel
     assert get_top_n_predictions(cs, "allocation") == sentinel
+
+
+def test_sweep_read_does_not_create_case_study_dir(tmp_path, monkeypatch):
+    """Reading sweep config must not materialize the case-study dir under
+    ML4T_OUTPUT_DIR: a side-effect mkdir would make create_experiment believe
+    the experiment already exists."""
+    from case_studies.utils.sweep_config import load_sweep
+
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    with pytest.raises((FileNotFoundError, KeyError)):
+        load_sweep("etfs")  # no config seeded under tmp_path
+    assert not (tmp_path / "etfs").exists()

--- a/tests/test_sweep_config_seam.py
+++ b/tests/test_sweep_config_seam.py
@@ -245,3 +245,30 @@ class TestRegistryReconciliation:
                         f"unrecognized by the seam test - extend the test or "
                         f"the loader."
                     )
+
+
+# ---------------------------------------------------------------------------
+# ML4T_OUTPUT_DIR redirection - the create_experiment workflow
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_reads_redirected_setup_under_output_dir(tmp_path, monkeypatch):
+    """When ML4T_OUTPUT_DIR is set, the sweep loader must read setup.yaml from
+    the redirected dir, so a reader's experiment-local edit to
+    ``backtest.sweep.top_n_predictions`` is honored (regression for the
+    create_experiment workflow: model stages redirect config reads, and the
+    Ch16-19 sweep must too)."""
+    from case_studies.utils.sweep_config import get_top_n_predictions, load_sweep
+
+    cs = "etfs"
+    exp_config = tmp_path / cs / "config"
+    exp_config.mkdir(parents=True)
+    # A deliberately non-default allocation breadth the source setup.yaml never uses.
+    sentinel = 3
+    (exp_config / "setup.yaml").write_text(
+        f"backtest:\n  sweep:\n    top_n_predictions:\n      allocation: {sentinel}\n"
+    )
+
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    assert load_sweep(cs)["top_n_predictions"]["allocation"] == sentinel
+    assert get_top_n_predictions(cs, "allocation") == sentinel


### PR DESCRIPTION
## Problem

The documented **Experimenting Without Changing the Release Baseline** workflow crashed for every
reader. `create_experiment.py` copied the generated artifacts (`run_log/labels/features/evaluation/
benchmark`) but **not** `config/`, and `get_case_study_dir()` redirects config reads to
`ML4T_OUTPUT_DIR`, so `07_gbm.py` died with `FileNotFoundError` on `config/setup.yaml` before any
reader edit was reached.

## Fix

- `create_experiment.py` now copies the per-CS `config/` tree and seeds the shared
  `case_studies/config/` presets at the output root (where `load_configs` resolves them), mirroring
  `tests/conftest.py::seeded_output_dir`. All copies are staged first and finalized with atomic
  renames only. The experiment is self-contained for the documented workflow: the reader edits config
  in the experiment dir, trains into the isolated registry, and the release artifacts stay untouched.
- `sweep_config._setup_path` resolves `setup.yaml` through `get_case_study_dir(..., create=False)` so
  the Ch16-19 backtest sweep honors experiment-local edits like the model stages already do (and a
  config read no longer has a filesystem side effect).
- Rewrote the docs **Experimenting** section against the real config system: the GBM grid is
  `config/training/{label}.yaml` + `config/lgb` presets (there is no `PARAM_GRID` in the notebook);
  cadence/costs/sweep live in `setup.yaml` (no `TOP_N`/`COST_BPS`/`REBALANCE_FREQ`). Added the
  features/labels prerequisite and CPU device note; the isolation example now points at the runnable
  sequence rather than a command that fails on a clean install.

## Verification

End to end on etfs: `create_experiment` builds a complete experiment; `07_gbm` reads config from it
and trains one edited config on CPU into the **isolated** registry (new hash) while the **source**
registry stays byte-identical. `load_configs`, `load_sweep`, and `get_top_n_predictions` all resolve
under the experiment dir. New tests in `tests/test_create_experiment.py` and
`tests/test_sweep_config_seam.py`.

## Deferred (tracked follow-up, v3.1)

`setup.yaml` is still read source-bound in `backtest_runner`, `backtest_loaders`, and
`modeling.py:310`; the backtest preset (`config/backtest/base.yaml`) is deliberately source-only.
Unifying those reads touches signed, hash-feeding infra (no-op in production) and is scoped out of
this launch-time change per maintainer decision. Tracked in the agents workspace under
`work/2026-07-24-reader-experience-remediation/FOLLOWUP_config_read_unification.md`.