### PR TITLE
Refresh the README landing copy and require ml4t-diagnostic 0.1.0b25

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ strategy you can actually run, and keep running, in a live market.
 - **Generative AI** and **autonomous agents** are new to this edition and cut across that workflow, bringing
   retrieval-augmented generation, knowledge graphs, and multi-agent systems to financial research.
 - The [companion website](https://ml4trading.io) features [112 primers](https://ml4trading.io/primer/),
-  [56 agent skills](https://ml4trading.io/skills/),
+  [61 agent skills](https://ml4trading.io/skills/),
   and [six production Python libraries](https://ml4trading.io/libraries/)
   that facilitate substantial parts of the workflow.
 
@@ -106,7 +106,7 @@ range:
 - [Cross-cutting concepts](https://ml4trading.io/primer/): 24 building blocks referenced across chapters, for example
   momentum and mean reversion, the bias-variance tradeoff, and walk-forward validation.
 
-### 56 Agent Skills
+### 61 Agent Skills
 
 Reusable, guard-railed tasks for coding agents, each with built-in defenses against lookahead bias, data leakage, and
 multiple-testing errors. Each category links to its full set; a few skills show the range:
@@ -127,6 +127,8 @@ multiple-testing errors. Each category links to its full set; a few skills show 
 - [Workflows](https://ml4trading.io/skills/): 5 skills covering factor research, model validation, and production
   readiness.
 - [Production](https://ml4trading.io/skills/): 2 skills, live trading and monitoring & alerting.
+- [Advanced AI](https://ml4trading.io/skills/): 5 skills covering research operators, agent memory, forecasting,
+  governance, and RAG evaluation.
 
 ### Courses
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ strategy you can actually run, and keep running, in a live market.
 > material with direct feedback. See [Courses](#courses) below.
 
 <p align="center">
-  <a href="https://amzn.to/4eigy2F"><img src="assets/cover.jpeg" width="45%" alt="Machine Learning for Trading, 3rd Edition"></a>
+  <a href="https://amzn.to/4eigy2F"><img src="assets/cover.png" width="45%" alt="Machine Learning for Trading, 3rd Edition"></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ strategy you can actually run, and keep running, in a live market.
   and [six production Python libraries](https://ml4trading.io/libraries/)
   that facilitate substantial parts of the workflow.
 
-> For the first time, we are offering [live cohort courses](https://ml4trading.io/courses/) that work through this
-> material with direct feedback. See [Courses](#courses) below.
+> **Free reader's guide:** Join [Navigate ML for Trading, 3rd Edition](https://maven.com/p/c6e0e7/navigate-ml-for-trading-3rd-edition)
+> on **July 30, 2026 at 11:00 AM ET** for a 30-minute map of the book, case studies, code, and companion resources.
+> See all current [courses and workshops](https://maven.com/stefan-jansen); the cohort courses are listed under
+> [Courses](#courses) below.
 
 <p align="center">
   <a href="https://amzn.to/4eigy2F"><img src="assets/cover.png" width="45%" alt="Machine Learning for Trading, 3rd Edition"></a>
@@ -142,7 +144,7 @@ the material live, with direct feedback:
 
 Each course runs as a scheduled cohort; the links above always point to the next one, where you can enroll or join the
 waitlist. *Stay current between cohorts with the
-twice-weekly [**Insights** newsletter](https://insights.ml4trading.io/).*
+[**Insights** newsletter](https://insights.ml4trading.io/).*
 
 ---
 

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -67,7 +67,7 @@ RUN /opt/ml4t/bin/pip freeze | grep -E '^(torch|torchaudio|torchvision)==' > /tm
 # step below, so this only needs the lower bounds (--pre allows the pre-only builds).
 RUN /opt/ml4t/bin/pip install --no-cache-dir --pre \
     "ml4t-data>=0.1.0b15" \
-    "ml4t-diagnostic>=0.1.0b19" \
+    "ml4t-diagnostic>=0.1.0b25" \
     "ml4t-engineer>=0.1.0b8" \
     "ml4t-live>=0.1.0b3" \
     "ml4t-backtest>=0.1.0b16" \

--- a/envs/py312/pyproject.toml
+++ b/envs/py312/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "shap>=0.45",
     "opacus>=1.4",
     "pfhedge>=0.23",
-    "ml4t-diagnostic>=0.1.0b22",
+    "ml4t-diagnostic>=0.1.0b25",
     # Bayesian (arviz/pymc for uncertainty features, pycausalimpact for ARIMA event studies)
     "arviz>=0.18,<1.0",
     "pymc>=5.14",

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir \
     "psutil>=5.9" \
     "jupyterlab>=4.1" \
     "ml4t-data>=0.1.0b15" \
-    "ml4t-diagnostic>=0.1.0b7" \
+    "ml4t-diagnostic>=0.1.0b25" \
     "ml4t-engineer>=0.1.0b2" \
     "pytest>=8.0" \
     "pyyaml>=6.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # ML4T Libraries (PyPI, pre-release)
     # ===================
     "ml4t-data>=0.1.0b15",
-    "ml4t-diagnostic>=0.1.0b23",
+    "ml4t-diagnostic>=0.1.0b25",
     "ml4t-engineer>=0.1.0b10",
     "ml4t-backtest>=0.1.0b20",
     "ml4t-live>=0.1.0b3",

--- a/uv.lock
+++ b/uv.lock
@@ -4365,7 +4365,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "ml4t-backtest", specifier = ">=0.1.0b20" },
     { name = "ml4t-data", specifier = ">=0.1.0b15" },
-    { name = "ml4t-diagnostic", specifier = ">=0.1.0b23" },
+    { name = "ml4t-diagnostic", specifier = ">=0.1.0b25" },
     { name = "ml4t-engineer", specifier = ">=0.1.0b10" },
     { name = "ml4t-live", specifier = ">=0.1.0b3" },
     { name = "ml4t-models", specifier = ">=0.1.0a6" },
@@ -4496,7 +4496,7 @@ wheels = [
 
 [[package]]
 name = "ml4t-diagnostic"
-version = "0.1.0b23"
+version = "0.1.0b25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arch" },
@@ -4518,9 +4518,9 @@ dependencies = [
     { name = "statsmodels" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/80/3b78ca08a3a37445199ce2c941c74c9c6452bc31eca8df76849261017659/ml4t_diagnostic-0.1.0b23.tar.gz", hash = "sha256:e46f755575430ef41beed2f03e2a657a0de68ee7b9964575a4b3e6b2a0a35408", size = 1387039, upload-time = "2026-07-20T16:37:13.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/17/3aaa0b955dc5358e3c4b0fb0eed8c7c8f2bcfcb67ca16df4c695f183b423/ml4t_diagnostic-0.1.0b25.tar.gz", hash = "sha256:6e3c12fd51e67be1841d213bf7e30555bf9f0be284a2f1b129602e15169914f9", size = 1388197, upload-time = "2026-07-23T02:07:15.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/29/ecf53275ba73dd2545fdf3de0d115564e83a777f58831ffa2bf602e2c7ff/ml4t_diagnostic-0.1.0b23-py3-none-any.whl", hash = "sha256:ea776c8a9024dcbc840044be99c8942408898669fb3ed2b9de85df78bd75b2ef", size = 941148, upload-time = "2026-07-20T16:37:11.327Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3f/0cc42bdab3d97ece8727234c24356397906600a721281560e4600b94a22a/ml4t_diagnostic-0.1.0b25-py3-none-any.whl", hash = "sha256:ffb284a15f7f7ff48a16eaf07d18269e0ffa3f749aadb2ba34c7e58f12bdc8a0", size = 941470, upload-time = "2026-07-23T02:07:13.558Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Four commits that have been sitting unpushed on `signoff/env-b25` since 2026-07-22, cherry-picked onto current `main` rather than merged, because that branch predates the release squash and would revert `.github/scripts/`, the Ch21 RL modules, and the `scripts/` prune.

## README

The landing copy is what a visitor reads first and three things in it were stale:

- **Skill count.** "56 agent skills" in the summary and in the section heading. The per-category list now includes Advanced AI (research operators, agent memory, forecasting, governance, RAG evaluation) and the ten categories sum to exactly 61.
- **Cover asset.** `assets/cover.jpeg` -> `assets/cover.png`. Both are committed; `.png` is the current artwork.
- **Reader guide.** The generic cohort-courses note is replaced by the free 30-minute *Navigate ML for Trading, 3rd Edition* session on July 30, 2026 at 11:00 AM ET. Verified against the Maven page: the event exists, the time matches (15:00 UTC), it is free, and registration is open.

The "twice-weekly" qualifier on the Insights newsletter is dropped.

`signoff/env-b25` also carried a rename of the multi-agent course and its URL. `main` already has both, so nothing was taken from that hunk.

## Dependency

`ml4t-diagnostic` 0.1.0b23 -> 0.1.0b25 in `pyproject.toml`, `envs/py312/pyproject.toml`, `envs/ml4t/Dockerfile`, `envs/rapids/Dockerfile`, and `uv.lock`. b25 is the current PyPI release; `uv lock --check` resolves 547 packages clean.

## Context

Found while auditing the 22 branches on this repo. Six were deleted as provably redundant; ten more carry library and test code `main` does not have, and are being triaged separately.