### PR TITLE
Give subplot figures a way to put panel labels under the figure title

### DIFF
--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,127 @@
+"""Tests for the shared figure style module.
+
+These pin the one invariant the Plotly template cannot enforce on its own: a
+subplot figure's panel labels must read as subordinate to its figure title.
+Plotly writes ``subplot_titles`` as annotations with an explicit 16pt, and an
+explicit value beats anything the template sets in ``annotationdefaults``, so a
+template edit that lowers ``title.font.size`` silently inverts the hierarchy on
+every subplot figure in the repo.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import plotly.io as pio  # noqa: E402
+from plotly.subplots import make_subplots  # noqa: E402
+
+from utils.style import (  # noqa: E402
+    _PLOTLY_SUBPLOT_TITLE_SIZE,
+    SUBPLOT_TITLE_SIZE,
+    style_subplot_titles,
+)
+
+
+def _template_title_size() -> int:
+    return pio.templates["ml4t"].layout.title.font.size
+
+
+def test_panel_labels_stay_below_the_figure_title():
+    """The hierarchy this helper exists to enforce."""
+    assert _template_title_size() > SUBPLOT_TITLE_SIZE
+
+
+def test_style_subplot_titles_restyles_panel_labels():
+    fig = make_subplots(rows=2, cols=2, subplot_titles=["A", "B", "C", "D"])
+
+    # Plotly's hardcoded default, which the template cannot override. It is also
+    # part of the selector's signature, so this failing means the helper has
+    # gone blind rather than merely that a number moved.
+    assert {a.font.size for a in fig.layout.annotations} == {_PLOTLY_SUBPLOT_TITLE_SIZE}
+
+    style_subplot_titles(fig)
+
+    assert [a.font.size for a in fig.layout.annotations] == [SUBPLOT_TITLE_SIZE] * 4
+    for annotation in fig.layout.annotations:
+        assert annotation.font.size < _template_title_size()
+
+
+def test_style_subplot_titles_leaves_other_annotations_alone():
+    """A bare update_annotations() would restyle these too - it must not."""
+    fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
+    fig.add_annotation(
+        text="callout",
+        x=0.5,
+        y=0.5,
+        xref="x",
+        yref="y",
+        showarrow=True,
+        font={"size": 22, "color": "#ff0000"},
+    )
+    # A paper-referenced, arrowless note - the case a naive xref check would miss.
+    fig.add_annotation(
+        text="source",
+        x=0,
+        y=-0.1,
+        xref="paper",
+        yref="paper",
+        showarrow=False,
+        font={"size": 9},
+    )
+
+    style_subplot_titles(fig)
+
+    by_text = {a.text: a for a in fig.layout.annotations}
+    assert by_text["A"].font.size == SUBPLOT_TITLE_SIZE
+    assert by_text["B"].font.size == SUBPLOT_TITLE_SIZE
+    assert by_text["callout"].font.size == 22
+    assert by_text["callout"].font.color == "#ff0000"
+    assert by_text["source"].font.size == 9
+
+
+def test_style_subplot_titles_spares_a_note_sharing_the_paper_signature():
+    """The near-miss: paper-referenced, arrowless, bottom-anchored, centered.
+
+    Everything a subplot title has except Plotly's 16pt. A selector built on the
+    reference frame and anchors alone would restyle this.
+    """
+    fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
+    fig.add_annotation(
+        text="source",
+        x=0.5,
+        y=-0.12,
+        xref="paper",
+        yref="paper",
+        showarrow=False,
+        xanchor="center",
+        yanchor="bottom",
+        font={"size": 9, "color": "#333333"},
+    )
+
+    style_subplot_titles(fig)
+
+    by_text = {a.text: a for a in fig.layout.annotations}
+    assert by_text["source"].font.size == 9
+    assert by_text["source"].font.color == "#333333"
+    assert by_text["A"].font.size == SUBPLOT_TITLE_SIZE
+
+
+def test_style_subplot_titles_applies_once():
+    """A restyled label loses the 16pt signature, so a second call does nothing."""
+    fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
+    style_subplot_titles(fig)
+    style_subplot_titles(fig, size=30)
+    assert {a.font.size for a in fig.layout.annotations} == {SUBPLOT_TITLE_SIZE}
+
+
+def test_style_subplot_titles_is_chainable():
+    fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
+    assert style_subplot_titles(fig) is fig
+
+
+def test_style_subplot_titles_accepts_an_explicit_size():
+    fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
+    style_subplot_titles(fig, size=11)
+    assert {a.font.size for a in fig.layout.annotations} == {11}

--- a/utils/style.py
+++ b/utils/style.py
@@ -353,6 +353,72 @@ def upper_triangle_mask(corr: object) -> np.ndarray:
     return np.triu(np.ones_like(np.asarray(corr), dtype=bool), k=1)
 
 
+# Canonical panel-label size for Plotly subplot figures. Plotly writes
+# subplot_titles as annotations carrying an explicit size of 16, and an explicit
+# value beats the template's annotationdefaults, so the template cannot lower
+# them from here. That leaves a subplot figure with 16pt panel labels above a
+# 14pt figure title. style_subplot_titles() is the opt-in helper that restores
+# the order: title 14 > panel label 13 > body 11.
+SUBPLOT_TITLE_SIZE = 13
+
+
+# The size Plotly stamps on every subplot-title annotation it creates. Part of
+# the signature below, so a change to this default makes the helper match
+# nothing rather than match the wrong thing;
+# test_style_subplot_titles_restyles_panel_labels fails first if it moves.
+_PLOTLY_SUBPLOT_TITLE_SIZE = 16
+
+
+def _is_subplot_title(annotation: object) -> bool:
+    """Match the annotations ``make_subplots`` creates for ``subplot_titles``.
+
+    Plotly stamps all six of these properties on a subplot title and on nothing
+    else it creates: arrowless, referenced to the paper in both axes, centered
+    horizontally, anchored at the bottom, and sized 16. A caption or source note
+    added with ``add_annotation`` normally differs in at least one - most often
+    the size, since 16 is not a size hand-written annotations pick.
+
+    An ``add_annotation`` call that happens to set all six identically is
+    indistinguishable from a panel label and will be restyled. Nothing in the
+    figure records which annotations Plotly authored, so that case cannot be
+    separated; it just needs a different size or anchor to opt out.
+    """
+    return (
+        getattr(annotation, "showarrow", None) is False
+        and getattr(annotation, "xref", None) == "paper"
+        and getattr(annotation, "yref", None) == "paper"
+        and getattr(annotation, "xanchor", None) == "center"
+        and getattr(annotation, "yanchor", None) == "bottom"
+        and getattr(getattr(annotation, "font", None), "size", None) == _PLOTLY_SUBPLOT_TITLE_SIZE
+    )
+
+
+def style_subplot_titles(fig: object, size: int = SUBPLOT_TITLE_SIZE) -> object:
+    """Bring ``make_subplots`` panel labels under the figure title.
+
+    Plotly hardcodes 16pt on subplot-title annotations, which outranks both the
+    body text and the 14pt figure title the template sets. Call this after
+    building a subplot figure::
+
+        fig = make_subplots(rows=2, cols=2, subplot_titles=[...])
+        ...
+        style_subplot_titles(fig)
+
+    Only the panel labels are restyled - ``add_annotation`` callouts keep their
+    own font, so the call is safe at any point in figure construction. It also
+    applies once: a restyled label no longer carries Plotly's 16pt and so falls
+    out of the selector, which makes a second call at a different ``size`` a
+    no-op rather than a second restyle.
+
+    Returns the figure so it can be chained.
+    """
+    fig.update_annotations(  # type: ignore[attr-defined]
+        font={"size": size, "color": COLORS["slate"]},
+        selector=_is_subplot_title,
+    )
+    return fig
+
+
 # =============================================================================
 # PLOTLY TEMPLATE (optional — only used if Plotly is installed)
 # =============================================================================
@@ -879,6 +945,8 @@ __all__ = [
     "label_line_ends",
     "zero_line",
     "upper_triangle_mask",
+    "style_subplot_titles",
+    "SUBPLOT_TITLE_SIZE",
     # Book-specific
     "ML4T_STYLE",
     "HAS_PLOTLY",


### PR DESCRIPTION
Recovered from `release/readme-refresh-and-ch08-figure-fix`, one of ten branches found to hold code `main` does not have. `tests/test_style.py` exists on no version of `main`.

## The defect it addresses

Plotly writes `make_subplots`' `subplot_titles` as annotations with an explicit size of 16, and an explicit value beats the template's `annotationdefaults`. The `ml4t` template sets the figure title to 14. So every subplot figure in the repo currently renders its panel labels larger than the title of the figure they label.

`style_subplot_titles(fig)` is opt-in and restores the order: title 14 > panel label 13 > body 11.

**No figure changes appearance in this PR.** Nothing calls the helper yet; adopting it in a notebook means re-executing that notebook, which is separate work.

## The selector

It matches the six properties Plotly stamps on a subplot title and on nothing else it creates: arrowless, paper-referenced in both axes, centered, bottom-anchored, sized 16. A bare `update_annotations()` would restyle a figure's own callouts, which is the mistake this exists to avoid.

An `add_annotation` call setting all six identically is indistinguishable from a panel label and will be restyled. Nothing in the figure records which annotations Plotly authored, so that case cannot be separated; the docstring says so.

## Tests

Seven, including a source note that shares the paper/arrowless/bottom/centered signature and differs only in size. Checked that the narrower selector was needed: the first version of this selector, built on reference frame and anchors alone, did restyle that note.

The hierarchy test reads the template's title size rather than hardcoding it, so lowering the title in the template again fails the test instead of silently re-inverting the order. The 16pt default is asserted too, so a Plotly change makes the helper match nothing and fail loudly rather than match the wrong thing.

## Not taken from the branch

That branch also raised the template title from 14 to 19. `main` set it to 14 deliberately after the branch was written, so only the helper and its tests are here. The branch's `08_financial_features/03` adoption needs a notebook re-execution and is left for later.