### PR TITLE
Guard the Crypto GBM and TabM lineage contracts, not just the sequence one

### DIFF
--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -337,6 +337,38 @@ def _train_tabm_fold(
 from case_studies.utils.registry.store import flush_fold_predictions
 
 
+def _decision_time_checkpoint_metrics(
+    frame: pl.DataFrame,
+    *,
+    date_col: str,
+    entity_col: str,
+    pred_col: str = "y_score",
+    ret_col: str = "y_true",
+) -> dict[str, float | int]:
+    """Score one pooled checkpoint with equal weight per decision timestamp.
+
+    The counterpart of ``deep_learning._decision_time_checkpoint_metrics``, and
+    the same contract: a decision time with 200 names counts once, exactly as a
+    decision time with 20 does. Pooling the rows instead would weight the wide
+    days, and averaging per-fold ICs would weight the folds.
+    """
+    stats = cross_sectional_ic(
+        frame,
+        frame,
+        pred_col=pred_col,
+        ret_col=ret_col,
+        date_col=date_col,
+        entity_col=entity_col,
+        method="spearman",
+        min_obs=5,
+    )
+    return {
+        "ic_mean": float(stats["ic_mean"]),
+        "ic_std": float(stats["ic_std"]),
+        "ic_n_days": int(stats["n_periods"]),
+    }
+
+
 def _load_incremental_preds_for_config(incr_dir: Path, config_name: str) -> pl.DataFrame:
     """Reassemble one config's predictions from its per-fold incremental saves."""
     parquet_files = sorted(incr_dir.glob(f"{config_name}_fold*.parquet"))
@@ -1123,15 +1155,11 @@ def run_tabm_cv(
             actual_col = eval_col if eval_col else "y_true"
             for epoch in sorted(cfg_all_preds["epoch"].unique().to_list()):
                 epoch_predictions = cfg_all_preds.filter(pl.col("epoch") == epoch)
-                checkpoint_metrics[int(epoch)] = cross_sectional_ic(
+                checkpoint_metrics[int(epoch)] = _decision_time_checkpoint_metrics(
                     epoch_predictions,
-                    epoch_predictions,
-                    pred_col="y_score",
-                    ret_col=actual_col,
                     date_col=date_col,
                     entity_col=entity_col,
-                    method="spearman",
-                    min_obs=5,
+                    ret_col=actual_col,
                 )
         elif fold_checkpoint_ics:
             checkpoint_metrics = {

--- a/tests/test_crypto_modeling_lineage.py
+++ b/tests/test_crypto_modeling_lineage.py
@@ -7,7 +7,8 @@ from datetime import UTC, datetime
 import polars as pl
 import pytest
 
-from case_studies.utils import deep_learning
+from case_studies.utils import deep_learning, gbm, tabular_dl
+from case_studies.utils import registry as registry_api
 from case_studies.utils.registry import (
     build_training_spec,
     modeling_input_fingerprint,
@@ -151,3 +152,121 @@ def test_crypto_dl_checkpoint_metric_equal_weights_decision_times() -> None:
 
     assert metrics["ic_n_days"] == 2
     assert metrics["ic_mean"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_crypto_lightgbm_cuda_request_fails_closed(monkeypatch) -> None:
+    """A CUDA-requested Crypto grid must never continue on CPU."""
+    monkeypatch.setattr(gbm, "_best_gpu_device", lambda _library: None)
+    config = {
+        "config_name": "cuda_required",
+        "params": {"objective": "regression"},
+        "max_iterations": 2,
+        "checkpoint_interval": 1,
+    }
+
+    with pytest.raises(RuntimeError, match="CUDA"):
+        gbm.train_gbm_config(config, [], feature_names=[], device="cuda")
+
+
+def test_crypto_gbm_registration_keeps_current_lineage(tmp_path, monkeypatch) -> None:
+    """The per-config checkpoint must retain the notebook's current input identity."""
+    captured = {}
+    preset = tmp_path / "config/lgb/default_mse.yaml"
+    preset.parent.mkdir(parents=True)
+    preset.write_text(
+        "library: lightgbm\nmax_iterations: 2\ncheckpoint_interval: 1\n"
+        "params:\n  objective: regression\n"
+    )
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+
+    def capture_training_run(_case_study_id, *, spec, **_kwargs):
+        captured["spec"] = spec
+        return training_hash_from_spec(spec)
+
+    monkeypatch.setattr(registry_api, "register_training_run", capture_training_run)
+    monkeypatch.setattr(registry_api, "get_training_dir", lambda *_args, **_kwargs: tmp_path)
+    result = {
+        "best_iter": 1,
+        "best_ic": 0.0,
+        "best_ic_std": 0.0,
+        "elapsed_s": 0.1,
+        "predictions": [],
+        "learning_curves": [],
+        "fold_metrics": [],
+    }
+    cfg = {"family": "gbm", "config_name": "default_mse", "checkpoint_interval": 50}
+
+    gbm.register_gbm_result(
+        "crypto_perps_funding",
+        result,
+        cfg,
+        "fwd_ret_8h",
+        n_folds=2,
+        max_bin=63,
+        extra_params={"device": "cuda", "input_fingerprint": "current-lineage"},
+    )
+
+    assert captured["spec"]["params"]["device"] == "cuda"
+    assert captured["spec"]["params"]["input_fingerprint"] == "current-lineage"
+
+
+def test_crypto_tabm_cuda_request_fails_closed(monkeypatch) -> None:
+    """A CUDA-requested TabM grid must never continue on CPU."""
+    monkeypatch.setattr(tabular_dl.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA"):
+        tabular_dl.run_tabm_cv(
+            None,
+            [],
+            configs=[],
+            n_features=0,
+            feature_names=[],
+            label_col="fwd_ret_8h",
+            date_col="timestamp",
+            device="cuda",
+        )
+
+
+def test_crypto_tabm_checkpoint_metric_equal_weights_decision_times() -> None:
+    """Unequal cross-section sizes must not turn checkpoint IC into row weighting."""
+    first = datetime(2023, 1, 1, tzinfo=UTC)
+    second = datetime(2023, 1, 2, tzinfo=UTC)
+    frame = pl.DataFrame(
+        {
+            "timestamp": [first] * 5 + [second] * 10,
+            "symbol": [f"a{i}" for i in range(5)] + [f"b{i}" for i in range(10)],
+            "y_score": [float(i) for i in range(5)] + [float(i) for i in range(10)],
+            "y_true": [float(i) for i in range(5)] + [float(9 - i) for i in range(10)],
+        }
+    )
+
+    metrics = tabular_dl._decision_time_checkpoint_metrics(
+        frame,
+        date_col="timestamp",
+        entity_col="symbol",
+    )
+
+    assert metrics["ic_n_days"] == 2
+    assert metrics["ic_mean"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_crypto_tabm_rejects_two_sources_of_training_identity() -> None:
+    """A TabM run must not be handed both identity spellings at once.
+
+    `input_data_spec` and the legacy `identity_params` both feed the training
+    spec, and whichever won would silently decide the training hash. Refusing
+    the pair is what keeps a Crypto re-run from registering under an identity
+    the notebook did not intend.
+    """
+    with pytest.raises(ValueError, match="not both"):
+        tabular_dl.run_tabm_cv(
+            dataset_pd=None,
+            splits=[],
+            configs=[],
+            n_features=1,
+            feature_names=["f0"],
+            label_col="fwd_ret_8h",
+            date_col="timestamp",
+            input_data_spec={"input_fingerprint": "from-spec"},
+            identity_params={"input_fingerprint": "legacy"},
+        )


### PR DESCRIPTION
Recovered from `signoff/crypto-fixture`, one of the branches found to hold code `main` does not have.

`tests/test_crypto_modeling_lineage.py` on `main` has five tests, all deep-learning. The branch had ten, covering three families. The GBM and TabM halves were dropped when the case study was integrated - the same shape as notebooks shipping without the library contract they were certified against.

## What is restored

Five tests, each rewritten against `main`'s code rather than the branch's:

- a CUDA request that cannot be served fails closed, for LightGBM and for TabM, instead of quietly training a different model on CPU
- `register_gbm_result` keeps the notebook's declared device and input fingerprint in the training spec
- a TabM checkpoint scores each decision timestamp once, so a day with 200 names does not outvote a day with 20
- `run_tabm_cv` refuses `input_data_spec` and `identity_params` together

## The one code change

The checkpoint-metric test needed a seam. `main` computes that metric inline in `run_tabm_cv`, while `deep_learning.py` has it as `_decision_time_checkpoint_metrics`. `tabular_dl.py` now has the same helper and calls it.

**No metric moves.** The inline call already passed `date_col` and `entity_col` to `cross_sectional_ic`; the helper passes the same arguments. Verified against `main`'s code before writing the test: on an unequal-cross-section fixture (5 names on day one, 10 on day two, ICs +1 and -1) it returns `ic_mean` 0.0 over `n_periods` 2. Downstream reads only `ic_mean` and `ic_std`, both of which the helper returns.

## Found, not fixed here

`run_tabm_cv` has a second path: when `save_dir` is None there are no incremental predictions, and checkpoint selection falls back to `np.nanmean` over per-fold ICs. That is a mean of fold ICs, which weights a short fold like a long one and can select a different epoch.

It is pre-existing and this PR does not touch it. It is also off the registered path - `register=True` already refuses `save_dir=None` - but it is on the path a reader takes. Filed in the agents workspace as `issues/2026-07-26-tabm-checkpoint-selection-falls-back-to-mean-of-fold-ics.md` for whoever owns published numbers, since fixing it changes what such a run reports.

## Not carried over

The branch's `tests/test_conformal.py`: `main`'s `test_conformal_calibration.py` already covers both properties, one verbatim.

Its sixth lineage test asserted `register_epoch_checkpoint` took `identity_params`. `main` routes that through `run_tabm_cv` into `build_training_spec`, so it is replaced by a test of the guard `main` actually has there.

## Verification

`tests/test_crypto_modeling_lineage.py` 10 passed, `tests/test_gbm_runtime.py` 20 passed, ruff clean.