### PR TITLE
Annualize backtest metrics at the frequency of the return grid actually written

### DIFF
--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -44,26 +44,135 @@ from case_studies.utils.signals import build_target_weights_from_config
 # Periods per year for Sharpe annualization
 # ---------------------------------------------------------------------------
 
-# Periods per year for Sharpe annualization.  Used by the vectorized path
-# where each return observation corresponds to one rebalance period.
-_PERIODS_PER_YEAR: dict[str, float] = {
-    "monthly_month_end": 12,
-    "weekly": 52,
-    "weekly_friday": 52,
-    "weekly_friday_close": 52,
-    "daily": 252,
-    "daily_close": 252,
-    "daily_ny_close": 252,
-    "8_hour_funding_aligned": 365 * 3,  # 3 observations per calendar day
-    "15_min": 252 * 26,  # ~26 fifteen-min bars per NYSE session
-    "15_minute": 252 * 26,  # alias
-    "30_min": 252 * 13,  # ~13 thirty-min bars per NYSE session
-    "30_minute": 252 * 13,
-    "1_hour": 252 * 6.5,  # 6.5 hours per NYSE session
-    "1_hourly": 252 * 6.5,
-    "4_hour": 252 * 1.625,  # ~1.625 four-hour bars per NYSE session
-    "4_hourly": 252 * 1.625,
-}
+# NOTE: a `cadence -> periods_per_year` table used to live here. It was the
+# source of a real defect: it assumed each return observation is one rebalance
+# period, which is false for every case study that rebalances slowly and marks
+# to market daily. Measured grid frequencies are 252/yr for sp500_options and
+# nasdaq100_microstructure despite weekly cohorts and intraday signals, and
+# 252/yr for monthly-rebalanced etfs. Annualize with
+# `resolve_periods_per_year` below, which reads the declared
+# `evaluation.periods_per_year` and reconciles it against the grid on hand.
+
+
+def observed_periods_per_year(daily_returns) -> float:
+    """Sampling rate of a return frame, or 0.0 if it cannot be measured.
+
+    Rows divided by elapsed span would answer a different question - how densely
+    the frame covers its own window - and would read a daily series with a
+    six-month hole in it as a twice-weekly one. What the annualization needs is
+    the spacing between consecutive observations, so the rate is measured over
+    the intervals that are typical of the series and gaps far longer than the
+    typical spacing are dropped from both the count and the span.
+
+    A weekday grid has intervals of one day and three across a weekend, both
+    within the cut, and comes out near 252. A grid thinned to every fifth
+    session has intervals near seven days throughout and comes out near 52. A
+    delisting hole or a suspended market drops out of the span instead of
+    dragging the rate down with it.
+    """
+    n = len(daily_returns)
+    if n <= 2:
+        return 0.0
+    all_ts = daily_returns["timestamp"].unique().sort()
+    gaps = all_ts.diff().drop_nulls().dt.total_seconds().to_numpy().astype(float)
+    gaps = gaps[gaps > 0]
+    if gaps.size == 0:
+        return 0.0
+
+    typical = float(np.median(gaps))
+    if typical <= 0:
+        return 0.0
+    kept = gaps[gaps <= 5.0 * typical]
+    if kept.size == 0:
+        return 0.0
+
+    span_years = float(kept.sum()) / (365.25 * 86400)
+    return kept.size / span_years if span_years > 0.01 else 0.0
+
+
+def reconcile_periods_per_year(declared: int, daily_returns, *, case_study: str = "") -> int:
+    """Keep the declared factor unless the frame on hand contradicts it outright.
+
+    The declared `evaluation.periods_per_year` is the authority: it describes
+    the convention of the registered return grid, and using it keeps metrics on
+    the round factor the rest of the pipeline shares. But it is a case-study
+    constant, and one path writes a grid that does not match it. The vectorized
+    path thins predictions to rebalance dates before aggregating, so with
+    `sp500_options`'s rebalance_step of 5 a daily prediction grid leaves about
+    74 rows a year against a declared 252.
+
+    The override is one-directional, because thinning is the only mechanism by
+    which the written grid departs from the declared convention, and it only
+    coarsens. A frame that reads *finer* than declared is therefore not evidence
+    that the declared value is wrong - an intraday grid whose case study still
+    declares 252 is a setup.yaml that has not caught up, and inflating Sharpe by
+    the square root of a factor of 139 is not the way to report that. It stays on
+    the declared value and says so in the log.
+
+    A factor of two of headroom on the coarse side keeps holidays and partial
+    years on the declared value, and still catches thinning, which coarsens by
+    the rebalance step and so lands well outside it.
+    """
+    import logging
+
+    observed = observed_periods_per_year(daily_returns)
+    if not observed or not declared:
+        return declared or int(observed) or 252
+
+    ratio = observed / declared
+    if ratio > 2.0:
+        logging.getLogger(__name__).warning(
+            "%s: return grid is %.1f obs/yr, finer than the %d declared in setup.yaml. "
+            "Annualizing at the declared value; declare the grid's own frequency if "
+            "this case study writes intraday returns.",
+            case_study or "backtest",
+            observed,
+            declared,
+        )
+        return declared
+    if ratio >= 0.5:
+        return declared
+
+    logging.getLogger(__name__).warning(
+        "%s: return grid is %.1f obs/yr but setup.yaml declares %d; annualizing at "
+        "the observed rate. Thinning to rebalance dates is the usual cause.",
+        case_study or "backtest",
+        observed,
+        declared,
+    )
+    return int(observed)
+
+
+def resolve_periods_per_year(case_study: str, daily_returns) -> int:
+    """Annualization factor for a return series, resolved once per backtest.
+
+    Every path that annualizes a registered return grid goes through here, so
+    the overall metrics, the per-fold metrics and the backfill cannot disagree
+    about what the same frame is.
+    """
+    from case_studies.utils.uncertainty import periods_per_year_from_setup
+
+    try:
+        declared = int(periods_per_year_from_setup(case_study))
+    except (FileNotFoundError, KeyError):
+        declared = 0
+
+    return reconcile_periods_per_year(declared, daily_returns, case_study=case_study)
+
+
+def overall_periods_per_year(case_study: str | None, calendar: str, daily_returns) -> int:
+    """Annualization for a whole-window backtest, whichever engine produced it.
+
+    The engine path used to read the exchange calendar, which returns ~252 for
+    every equity venue and so disagreed with a monthly case study by a factor of
+    21, and with its own per-fold metrics. A named case study now resolves the
+    same way everywhere; the calendar remains for a call that has no case study
+    and therefore no declared value to read.
+    """
+    if case_study:
+        return resolve_periods_per_year(case_study, daily_returns)
+    return calendar_periods_per_year(calendar)
+
 
 # Calendar name → exchange_calendars MIC code
 _CALENDAR_TO_XCAL: dict[str, str] = {
@@ -1044,14 +1153,22 @@ def run_backtest(
             elapsed_s=_bt_elapsed_s,
         )
 
-        # Compute and register per-fold backtest metrics
-        cadence = rebal_spec.get("cadence", "daily")
-        ppy = int(_PERIODS_PER_YEAR.get(cadence, 252))
+        # Compute and register per-fold backtest metrics.
+        # Annualize at the frequency of the *return series*, not the rebalance
+        # cadence. `daily_returns` is one row per session regardless of how often
+        # the strategy trades, so a monthly-rebalanced strategy on daily returns
+        # was being annualized at 12 instead of 252. Sharpe, Sortino and
+        # volatility scale with the square root of the factor, so those came out
+        # low by exactly sqrt(252/12) = 4.583. CAGR carries the factor in a
+        # compounding exponent rather than a multiplier, so its error is not a
+        # fixed ratio, and Calmar inherits whatever CAGR did because it divides
+        # CAGR by max drawdown. total_return and max_drawdown are unaffected.
+        # Same resolver and same frame as the overall metrics, so the two agree.
         fold_metrics = compute_backtest_fold_metrics(
             daily_returns,
             case_study,
             label=label,
-            periods_per_year=ppy,
+            periods_per_year=resolve_periods_per_year(case_study, daily_returns),
         )
         if fold_metrics:
             register_backtest_fold_metrics(case_study, backtest_hash, fold_metrics)
@@ -1284,7 +1401,7 @@ def _run_engine(
         )
     returns_arr = daily_df["daily_return"].to_numpy()
 
-    ppy = calendar_periods_per_year(calendar)
+    ppy = overall_periods_per_year(case_study, calendar, daily_df)
     metrics = compute_portfolio_metrics(returns_arr, periods_per_year=ppy, trim_leading_zeros=False)
 
     # Engine-specific metrics (execution details not derivable from returns)
@@ -1735,13 +1852,13 @@ def _run_vectorized(
     returns_arr = daily_returns["daily_return"].to_numpy()
     n = len(returns_arr)
 
-    # Annualization: use cadence when known, else estimate from data span
-    periods_per_year = int(_PERIODS_PER_YEAR.get(cadence, 0))
-    if not periods_per_year and n > 1:
-        all_ts = daily_returns["timestamp"].unique().sort()
-        span_secs = float((all_ts[-1] - all_ts[0]).total_seconds())
-        span_years = span_secs / (365.25 * 86400)
-        periods_per_year = int(n / span_years) if span_years > 0.01 else 252
+    # Annualize at the frequency of the grid this function writes, which is
+    # neither the rebalance cadence nor always the declared value. This path
+    # thins predictions to rebalance dates first, so its grid can be coarser
+    # than the registered convention. `resolve_periods_per_year` handles that
+    # reconciliation, and `run_backtest` calls it on this same frame for the
+    # per-fold metrics, so overall and fold annualization cannot diverge.
+    periods_per_year = resolve_periods_per_year(case_study, daily_returns)
 
     metrics = compute_portfolio_metrics(returns_arr, periods_per_year=periods_per_year or 252)
 

--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -339,7 +339,27 @@ def compute_backtest_fold_metrics(
     if not isinstance(daily_returns, pl.DataFrame):
         daily_returns = pl.from_pandas(daily_returns)
 
-    # Determine periods_per_year from case study calendar or data frequency
+    # Determine periods_per_year: the declared convention of the daily_returns
+    # grid first, then the exchange calendar, then the observed data frequency.
+    # `evaluation.periods_per_year` is the only one of the three that knows the
+    # difference between a genuinely monthly series (us_firm, 12) and a monthly-
+    # rebalanced strategy marked to market daily (etfs, 252).
+    # Callers that omit it — `BacktestExplorer.backfill_fold_metrics` is the one
+    # in the tree — get the same reconciliation `run_backtest` applies, so a
+    # backfilled thinned grid is not annualized at the declared daily rate.
+    if periods_per_year == 0 or periods_per_year is None:
+        try:
+            from case_studies.utils.backtest_runner import reconcile_periods_per_year
+            from case_studies.utils.uncertainty import periods_per_year_from_setup
+
+            declared = int(periods_per_year_from_setup(case_study_id))
+            periods_per_year = (
+                reconcile_periods_per_year(declared, daily_returns, case_study=case_study_id)
+                if declared
+                else 0
+            )
+        except (KeyError, FileNotFoundError, ImportError):
+            periods_per_year = 0
     if periods_per_year == 0 or periods_per_year is None:
         # Try to get calendar from setup.yaml → exchange_calendars
         try:

--- a/tests/test_backtest_fold_annualization.py
+++ b/tests/test_backtest_fold_annualization.py
@@ -1,0 +1,316 @@
+"""Per-fold backtest metrics must annualize at the return-series frequency.
+
+`daily_returns` carries one row per session no matter how often the strategy
+rebalances. Annualizing it at the *rebalance cadence* under-states Sharpe,
+Sortino and volatility by sqrt(true_ppy / cadence_ppy), which for a
+monthly-rebalanced ETF strategy on daily returns is sqrt(252/12) = 4.583. That
+is how the ETF fold Sharpes came to sit in [-0.040, +0.618] while the
+full-window Sharpe of the same return series was +1.3256. CAGR carries the
+factor in a compounding exponent, so it moves too but not by that ratio, and
+Calmar moves with CAGR. total_return and max_drawdown do not move.
+
+The authority is `evaluation.periods_per_year` in each case study's setup.yaml.
+It is the only source that distinguishes a genuinely monthly series
+(`us_firm_characteristics`, 12) from a monthly-rebalanced strategy marked to
+market daily (`etfs`, 252). A calendar lookup gets the first one wrong and a
+cadence lookup gets the second one wrong.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.utils.uncertainty import periods_per_year_from_setup
+
+CASE_STUDIES = [
+    "cme_futures",
+    "crypto_perps_funding",
+    "etfs",
+    "fx_pairs",
+    "nasdaq100_microstructure",
+    "sp500_equity_option_analytics",
+    "sp500_options",
+    "us_equities_panel",
+    "us_firm_characteristics",
+]
+
+
+@pytest.mark.parametrize("case_study", CASE_STUDIES)
+def test_every_case_study_declares_periods_per_year(case_study: str) -> None:
+    """The fix depends on this being declared everywhere, so pin it."""
+    assert periods_per_year_from_setup(case_study) > 0
+
+
+def test_daily_marked_case_studies_are_not_annualized_at_rebalance_cadence() -> None:
+    """`etfs` rebalances monthly but marks to market daily → 252, not 12.
+
+    This is the exact confusion the bug was. If someone re-derives the
+    annualization factor from `rebalance.cadence`, this fails.
+    """
+    assert periods_per_year_from_setup("etfs") == 252
+    assert periods_per_year_from_setup("crypto_perps_funding") == 365
+    # The one case study whose return grid genuinely is monthly.
+    assert periods_per_year_from_setup("us_firm_characteristics") == 12
+
+
+def _sharpe(returns: np.ndarray, ppy: int) -> float:
+    return float(returns.mean() / returns.std(ddof=1) * math.sqrt(ppy))
+
+
+def test_fold_metrics_use_setup_value_when_caller_passes_zero(monkeypatch) -> None:
+    """`periods_per_year=0` must resolve via setup.yaml, not the calendar.
+
+    Before the fix the zero path fell straight through to an exchange-calendar
+    lookup, which returns ~252 for every equity venue and so disagreed with
+    `us_firm_characteristics`'s declared 12. Fold boundaries are supplied here
+    rather than read from a modeling dataset, so the test pins the resolution
+    branch without needing data on disk.
+
+    Discriminating: against the pre-fix implementation the computed Sharpe is
+    the 252 one, and the first assertion fails.
+    """
+    import case_studies.utils.cv_window as cv_window
+    from case_studies.utils.registry.metrics import compute_backtest_fold_metrics
+
+    monkeypatch.setattr(
+        cv_window,
+        "fold_boundaries",
+        lambda cs, label: [{"fold": 0, "val_start": "2020-01-31", "val_end": "2021-12-31"}],
+    )
+
+    ts = pl.date_range(date(2020, 1, 31), date(2021, 12, 31), interval="1mo", eager=True)
+    rng = np.random.default_rng(7)
+    rets = rng.normal(0.004, 0.03, len(ts))
+    frame = pl.DataFrame({"timestamp": ts, "daily_return": rets})
+
+    out = compute_backtest_fold_metrics(
+        frame, "us_firm_characteristics", label="fwd_ret_1m", periods_per_year=0
+    )
+
+    assert set(out) == {0}
+    assert out[0]["sharpe"] == pytest.approx(_sharpe(rets, 12), rel=1e-6)
+    # The value the exchange-calendar fallback would have produced.
+    assert out[0]["sharpe"] != pytest.approx(_sharpe(rets, 252), rel=1e-6)
+
+
+def test_fold_metrics_reconcile_the_setup_value_against_a_thinned_grid(monkeypatch) -> None:
+    """The omitted-argument path is the backfill path, and it sees thinned grids.
+
+    `BacktestExplorer.backfill_fold_metrics` reads a stored `daily_returns.parquet`
+    and calls `compute_backtest_fold_metrics` without a factor. Those artifacts
+    include the ones the vectorized path wrote, which are thinned to rebalance
+    dates. Taking the declared 252 there annualizes a roughly 74-row year at the
+    daily rate, so the backfilled fold metrics would contradict the overall
+    metrics stored beside them.
+
+    Discriminating: reading setup.yaml unconditionally, which is what this path
+    did before the reconciliation, gives the 252 value the last assertion rejects.
+    """
+    import case_studies.utils.cv_window as cv_window
+    from case_studies.utils.registry.metrics import compute_backtest_fold_metrics
+
+    monkeypatch.setattr(
+        cv_window,
+        "fold_boundaries",
+        lambda cs, label: [{"fold": 0, "val_start": "2014-01-01", "val_end": "2021-12-31"}],
+    )
+
+    ts = pl.date_range(
+        date(2014, 1, 1), date(2021, 12, 31), interval="1d", eager=True
+    ).gather_every(5)
+    rng = np.random.default_rng(13)
+    rets = rng.normal(0.001, 0.02, len(ts))
+    frame = pl.DataFrame({"timestamp": ts, "daily_return": rets})
+
+    out = compute_backtest_fold_metrics(frame, "sp500_options", label="ret_to_expiry")
+
+    observed = int(len(ts) / ((ts[-1] - ts[0]).days / 365.25))
+    assert observed < 120, "expected the thinned grid to be materially coarser than daily"
+    assert out[0]["sharpe"] == pytest.approx(_sharpe(rets, observed), rel=1e-6)
+    assert out[0]["sharpe"] != pytest.approx(_sharpe(rets, 252), rel=1e-6)
+
+
+def _vectorized(case_study: str, label: str, cadence: str, ts) -> tuple[dict, np.ndarray]:
+    from case_studies.utils.backtest_runner import _run_vectorized
+
+    rng = np.random.default_rng(11)
+    y_true = rng.normal(0.002, 0.02, len(ts))
+    frame = {"timestamp": ts, "symbol": ["AAA"] * len(ts)}
+    out = _run_vectorized(
+        weights=pl.DataFrame({**frame, "weight": [1.0] * len(ts)}),
+        predictions=pl.DataFrame({**frame, "y_true": y_true, "y_pred": y_true}),
+        prices=pl.DataFrame({**frame, "close": 100.0}),
+        cost_spec={"model": "percentage", "commission_bps": 0.0, "slippage_bps": 0.0},
+        cadence=cadence,
+        label=label,
+        case_study=case_study,
+        initial_cash=1e6,
+        prediction_hash=None,
+    )
+    return out, out["daily_returns"]["daily_return"].to_numpy()
+
+
+def test_vectorized_path_uses_declared_frequency_when_the_grid_matches_it() -> None:
+    """`us_firm_characteristics` is the case study production sends down this path.
+
+    Its rebalance_step is 1 and its predictions are monthly, so the grid this
+    function writes is monthly and the declared 12 describes it.
+    """
+    ts = pl.date_range(date(2014, 1, 31), date(2021, 12, 31), interval="1mo", eager=True)
+    out, realized = _vectorized("us_firm_characteristics", "fwd_ret_1m", "monthly_month_end", ts)
+
+    assert out["metrics"]["sharpe"] == pytest.approx(_sharpe(realized, 12), rel=1e-6)
+
+
+def test_vectorized_path_defers_to_the_grid_it_wrote_when_thinning_coarsens_it() -> None:
+    """The declared value describes the registered grid, not always this one.
+
+    This path thins predictions to rebalance dates first. `sp500_options` has
+    rebalance_step 5, so a daily prediction grid leaves roughly 74 rows a year
+    against a declared 252. Annualizing at 252 there would inflate Sharpe by
+    sqrt(252/74). Discriminating both ways: the pre-fix code used the cadence
+    table's 252 for "daily", and reading setup.yaml unconditionally gives 252
+    as well.
+    """
+    ts = pl.date_range(date(2014, 1, 1), date(2021, 12, 31), interval="1d", eager=True)
+    out, realized = _vectorized("sp500_options", "ret_to_expiry", "daily", ts)
+
+    n = len(realized)
+    span_years = (ts[-1] - ts[0]).days / 365.25
+    observed = n / span_years
+    assert observed < 120, "expected the thinned grid to be materially coarser than daily"
+    assert out["metrics"]["sharpe"] == pytest.approx(_sharpe(realized, int(observed)), rel=1e-6)
+    assert out["metrics"]["sharpe"] != pytest.approx(_sharpe(realized, 252), rel=1e-6)
+
+
+def test_overall_and_fold_metrics_resolve_the_same_factor() -> None:
+    """One backtest must not annualize its overall and per-fold metrics apart.
+
+    `run_backtest` and `_run_vectorized` both call `resolve_periods_per_year` on
+    the same return frame, so a thinned grid that pushes the overall metrics off
+    the declared value pushes the fold metrics with it.
+    """
+    from case_studies.utils.backtest_runner import resolve_periods_per_year
+
+    daily = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(date(2014, 1, 1), date(2021, 12, 31), "1d", eager=True),
+            "daily_return": 0.001,
+        }
+    )
+    assert resolve_periods_per_year("etfs", daily) == 252
+
+    # A grid thinned well below the declared 252 must not be annualized at 252.
+    thinned = daily.gather_every(5)
+    assert resolve_periods_per_year("sp500_options", thinned) < 120
+
+    # A genuinely monthly series against a declared 12 stays on the round value.
+    monthly = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(date(2014, 1, 31), date(2021, 12, 31), "1mo", eager=True),
+            "daily_return": 0.001,
+        }
+    )
+    assert resolve_periods_per_year("us_firm_characteristics", monthly) == 12
+
+
+def test_a_long_internal_gap_does_not_look_like_a_coarser_grid() -> None:
+    """A hole in a daily series is not evidence that the series is not daily.
+
+    Rows-over-elapsed-span cannot tell a suspended market from a thinned grid,
+    and reading a gapped daily series as coarse would annualize it below its own
+    convention. The rate is measured over typical intervals instead, so the hole
+    leaves the count and the span together.
+
+    Discriminating: the naive density is asserted to be far enough below 252
+    that it would have crossed the reconciliation threshold and overridden the
+    declared value.
+    """
+    from case_studies.utils.backtest_runner import (
+        observed_periods_per_year,
+        reconcile_periods_per_year,
+    )
+
+    sessions = pl.date_range(date(2016, 1, 1), date(2021, 12, 31), "1d", eager=True).filter(
+        pl.date_range(date(2016, 1, 1), date(2021, 12, 31), "1d", eager=True).dt.weekday() <= 5
+    )
+    # A market closed for three and a half of the six years.
+    gapped = sessions.filter((sessions < date(2017, 7, 1)) | (sessions >= date(2021, 1, 1)))
+    frame = pl.DataFrame({"timestamp": gapped, "daily_return": 0.001})
+
+    naive_density = len(gapped) / ((gapped[-1] - gapped[0]).days / 365.25)
+    assert naive_density < 126, "test is only meaningful if the naive measure would have fired"
+
+    assert observed_periods_per_year(frame) == pytest.approx(252, rel=0.05)
+    assert reconcile_periods_per_year(252, frame, case_study="etfs") == 252
+
+    # The thinned case still has to be caught, or the guard is useless.
+    thinned = pl.DataFrame({"timestamp": sessions.gather_every(5), "daily_return": 0.001})
+    assert reconcile_periods_per_year(252, thinned, case_study="sp500_options") < 120
+
+
+def test_an_intraday_grid_is_not_annualized_above_its_declared_convention() -> None:
+    """A finer grid than declared is a stale setup.yaml, not a licence to inflate.
+
+    Dropping overnight gaps makes a 15-minute NYSE series look continuous, so
+    measuring its rate gives roughly 35,000 a year against the 252 declared for
+    `nasdaq100_microstructure`. Deferring to that would multiply Sharpe by about
+    12. The override only fires when the grid is coarser than declared, which is
+    the one thing thinning can do to it.
+    """
+    from case_studies.utils.backtest_runner import (
+        observed_periods_per_year,
+        reconcile_periods_per_year,
+    )
+
+    session_bars = []
+    for day in pl.date_range(date(2021, 1, 4), date(2021, 12, 31), "1d", eager=True):
+        if day.weekday() > 5:
+            continue
+        session_bars += [
+            datetime(day.year, day.month, day.day, 9, 30) + timedelta(minutes=15 * i)
+            for i in range(26)
+        ]
+    frame = pl.DataFrame({"timestamp": session_bars, "daily_return": 0.0001})
+
+    assert observed_periods_per_year(frame) > 20_000, "overnight gaps are dropped by design"
+    assert reconcile_periods_per_year(252, frame, case_study="nasdaq100_microstructure") == 252
+
+
+def test_engine_path_annualizes_like_the_rest_of_the_pipeline() -> None:
+    """The engine path read the exchange calendar, which no case study declares.
+
+    `calendar_periods_per_year` returns 252 for every equity venue, so an
+    engine-backed `us_firm_characteristics` run annualized its overall metrics
+    at 252 while its per-fold metrics used the declared 12 - a factor of 4.58 on
+    Sharpe between two numbers stored side by side. Discriminating: the calendar
+    value is asserted directly, so taking it again fails the second assertion.
+    """
+    from case_studies.utils.backtest_runner import (
+        calendar_periods_per_year,
+        overall_periods_per_year,
+    )
+
+    monthly = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(date(2014, 1, 31), date(2021, 12, 31), "1mo", eager=True),
+            "daily_return": 0.001,
+        }
+    )
+
+    assert calendar_periods_per_year("NYSE") == 252
+    assert overall_periods_per_year("us_firm_characteristics", "NYSE", monthly) == 12
+    # No case study named → nothing declares a value, so the calendar stands.
+    assert overall_periods_per_year(None, "NYSE", monthly) == 252
+
+
+def test_cadence_table_is_gone() -> None:
+    """The removed table was the defect's source; keep it removed."""
+    import case_studies.utils.backtest_runner as br
+
+    assert not hasattr(br, "_PERIODS_PER_YEAR")


### PR DESCRIPTION
Per-fold backtest metrics were annualized from a `cadence -> periods_per_year`
table that assumed one return row per rebalance period. That is false for every
case study that rebalances slowly and marks to market daily. The registered
return grids measure 251.9/yr for etfs, 253.2 for sp500_options, 253.2 for
nasdaq100_microstructure and 12.1 for us_firm_characteristics - each matching
its declared `evaluation.periods_per_year`, and only the last matching its
cadence. ETF fold Sharpes were therefore low by exactly sqrt(252/12) = 4.583,
which is how `18_strategy_analysis` came to print a fold range of
[-0.040, +0.618] beside a full-window Sharpe of +1.3256 in the same output.

## What changes

Every path that annualizes a registered return grid now resolves the factor the
same way: the declared `evaluation.periods_per_year`, reconciled against the
frame on hand.

- `run_backtest`'s per-fold call site, which is where the defect was.
- `compute_backtest_fold_metrics` when the caller omits the factor - that is
  `BacktestExplorer.backfill_fold_metrics`, which reads stored artifacts.
- `_run_vectorized`, which thins predictions to rebalance dates and so can write
  a grid coarser than the declared convention.
- `_run_engine`, which read the exchange calendar. That returns ~252 for every
  equity venue, so an engine-backed `us_firm_characteristics` run stored overall
  metrics at 252 beside per-fold metrics at 12.

The cadence table is removed; it had no remaining callers and its comment
asserted the false premise.

Frequency is measured from typical intervals rather than row density, so a daily
series with a multi-year hole is not read as a coarse one. The override is
one-directional: thinning is the only mechanism that makes a written grid depart
from the declared convention and it only coarsens, so a frame reading finer than
declared (an intraday session grid against a declared 252) stays on the declared
value and logs it instead of inflating Sharpe twelvefold.

## What this does not do

**No existing row is rewritten.** 110,112 `backtest_fold_metrics` rows across
the nine working registries predate the fix and remain as they are; of those,
us_firm's 25,306 are unaffected anyway because its declared 12 matched what the
cadence table supplied. The recompute is separate work, and the reader bundles
carry the same stale rows.

## Tests

19 tests, run against the pre-fix source to confirm they discriminate: the
per-fold path, the backfill path, both vectorized branches, the engine path, the
gapped-series case and the intraday case each fail without their corresponding
change.
