### PR TITLE
Restore the test-data regeneration path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -436,6 +436,19 @@ jobs:
             tests/test_ch21_rl_environments.py \
             tests/test_import_resolution.py \
             -v --tb=short
+      # The harness that decides which notebooks run, and the subsampler that
+      # builds the fixtures they run against. Both were ungated: the fixture
+      # regeneration path had not been runnable for months without anything
+      # going red, and a notebook could be marked skip on a credential the
+      # weekly workflow supplies without anything noticing.
+      - name: Run test-harness and fixture-generator tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_pm_helpers.py \
+            tests/test_create_test_data.py \
+            -v --tb=short
 
   # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -449,6 +449,15 @@ jobs:
       - name: Run test-harness and fixture-generator tests
         env:
           PYTHONPATH: ${{ github.workspace }}
+          # Same override as the download-logic step above, and for the same
+          # reason: create_test_data imports the production producers, which
+          # pulls in utils.config, which hard-fails at import when
+          # ML4T_DATA_PATH does not exist. This job checks out no test-data, so
+          # the workflow-level default points at a directory that is not there.
+          # The tests build their own synthetic sources under tmp_path and read
+          # nothing from this path.
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
         run: |
           .venv/bin/python -m pytest \
             tests/test_pm_helpers.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -453,6 +453,7 @@ jobs:
           .venv/bin/python -m pytest \
             tests/test_pm_helpers.py \
             tests/test_create_test_data.py \
+            tests/test_sample_registry_for_tests.py \
             -v --tb=short
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -400,9 +400,14 @@ jobs:
         # data/download_all + firm-char extract_zip, plus gymnasium for the
         # Chapter 21 environments). Intentionally NOT the full project env (no
         # torch/ml4t-*) so this stays a fast per-commit gate.
+        #
+        # requests is here for the fixture-generator tests: create_test_data
+        # validates the 13F artifacts by rebuilding them with the producer's own
+        # build_features_and_matrix, and 13f_download.py imports requests at
+        # module scope. Nothing in this job makes a network call.
         run: |
           uv venv --python 3.14
-          uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium
+          uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium requests
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -57,9 +57,11 @@ class Dataset:
         build: Callable invoked as ``build(source, output)``; returns the list of
             files it wrote. Receives the roots, not per-file paths, because some
             datasets fan out to several outputs.
-        subdir: Path under the output root that this dataset owns, relative to it.
-            ``--clean`` removes exactly this directory, so it must not be shared
-            with another dataset.
+        owns: Paths under the output root, files or directories, that this dataset
+            is solely responsible for. ``--clean`` removes exactly these and
+            nothing else, so a dataset that shares a directory with an artifact it
+            does not generate must name the individual files rather than the
+            directory.
         budget: Manifest ``subsets`` entry describing the reduction (e.g.
             ``{"max_entities": 200}``). Recorded verbatim in the manifest.
     """
@@ -67,7 +69,7 @@ class Dataset:
     name: str
     description: str
     build: Callable[[Path, Path], list[Path]]
-    subdir: Path
+    owns: tuple[Path, ...]
     budget: dict[str, object] = field(default_factory=dict)
 
 
@@ -161,6 +163,58 @@ def build_firm_characteristics(source: Path, output: Path) -> list[Path]:
     return written
 
 
+# --- institutional holdings (13F) ---------------------------------------------
+
+# Columns 22_rag_financial_research/07_institutional_holdings_graph refuses to run
+# without. report_date is the SEC period-of-report, distinct from filing_date, and
+# put_call marks option positions the notebook separates out from share holdings.
+# A fixture missing them is not a smaller fixture, it is a different schema.
+_13F_REQUIRED_PROVENANCE = ("report_date", "put_call")
+_13F_DIR = Path("equities") / "positioning" / "13f"
+# The three artifacts load_institutional_holdings_13f, load_13f_edges and
+# load_13f_stock_features read. The co-ownership matrix is deliberately absent:
+# the notebook computes it from the holdings, and the production .npy is 255MB.
+_13F_FILES = (
+    "institutional_holdings.parquet",
+    "institution_stock_edges.parquet",
+    "stock_features.parquet",
+)
+
+
+def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
+    """Copy the production 13F artifacts into the fixture set verbatim.
+
+    No reduction is applied. Together these are about three megabytes, and the
+    notebook filters to a hardcoded CIK list, so any subsample keyed on
+    institution risks dropping a CIK the notebook asks for and turning a schema
+    fixture into a silent coverage gap.
+    """
+    written: list[Path] = []
+    for filename in _13F_FILES:
+        src = source / _13F_DIR / filename
+        if not src.exists():
+            raise FileNotFoundError(
+                f"13F artifact not found at {src}. Fetch it with "
+                "data/equities/positioning/13f_download.py."
+            )
+
+        if filename == "institutional_holdings.parquet":
+            names = set(pl.scan_parquet(src).collect_schema().names())
+            if missing := sorted(set(_13F_REQUIRED_PROVENANCE) - names):
+                raise ValueError(
+                    f"Source 13F artifact at {src} lacks SEC provenance {missing}. It predates "
+                    "the canonical downloader; regenerate it before building the fixture."
+                )
+
+        dst = output / _13F_DIR / filename
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        rows = pl.scan_parquet(dst).select(pl.len()).collect().item()
+        print(f"    {filename}: {rows:,} rows ({dst.stat().st_size / 1e6:.1f} MB), copied verbatim")
+        written.append(dst)
+    return written
+
+
 DATASETS: tuple[Dataset, ...] = (
     Dataset(
         name="firm_characteristics",
@@ -169,8 +223,20 @@ DATASETS: tuple[Dataset, ...] = (
             "split, built from the char/*.npz tensors so symbol identity survives"
         ),
         build=build_firm_characteristics,
-        subdir=Path("equities") / "firm_characteristics",
+        owns=(Path("equities") / "firm_characteristics",),
         budget={"max_entities": FIRM_CHAR_MAX_ENTITIES},
+    ),
+    Dataset(
+        name="institutional_holdings_13f",
+        description=(
+            "the whole production 13F artifacts, already small enough to ship "
+            "intact and carrying the SEC provenance columns readers filter on"
+        ),
+        build=build_institutional_holdings_13f,
+        # Named individually, not as the 13f/ directory: bulk/ sits beside them and
+        # is produced elsewhere, so --clean must not take it.
+        owns=tuple(Path("equities") / "positioning" / "13f" / name for name in _13F_FILES),
+        budget={"subsample": "none"},
     ),
 )
 
@@ -257,9 +323,12 @@ def main() -> int:
     for dataset in selected:
         print(f"  {dataset.name}: {dataset.description}")
         if args.clean:
-            target = output / dataset.subdir
-            if target.exists():
-                shutil.rmtree(target)
+            for owned in dataset.owns:
+                target = output / owned
+                if target.is_dir():
+                    shutil.rmtree(target)
+                elif target.exists():
+                    target.unlink()
         built[dataset.name] = dataset.build(source, output)
         print()
 

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -260,14 +260,25 @@ def _require_derived_13f_matches_holdings(source_dir: Path) -> None:
     same comparison belongs here - before the stale copy enters the fixture set,
     rather than after a chapter job goes red against it.
 
-    The rebuild is keyed on the CIK set the holdings themselves carry, which is
-    the producer's own rule: it steps back to the newest quarter every requested
-    institution filed for, so a quarter that is still filling in cannot enter
-    either side of the ownership-change comparison.
+    The rebuild is keyed on the producer's configured institution set, not on
+    whichever CIKs the holdings happen to carry. Keyed on the holdings, a file
+    missing one of the ten institutions is internally consistent and would pass,
+    which is the silent coverage gap this builder exists to prevent: the notebook
+    asks for all ten by CIK. Passing the configured set also reproduces the
+    producer's own step-back rule, so a quarter that is still filling in cannot
+    enter either side of the ownership-change comparison.
     """
-    build = _load_13f_producer().build_features_and_matrix
+    producer = _load_13f_producer()
+    required_ciks = [cik for _, cik in producer.INSTITUTIONS]
     holdings = pl.read_parquet(source_dir / "institutional_holdings.parquet")
-    features, edges, *_ = build(holdings, expected_ciks=holdings["cik"].unique().to_list())
+    if absent := sorted(set(required_ciks) - set(holdings["cik"].unique().to_list())):
+        raise ValueError(
+            f"Source 13F holdings at {source_dir} cover none of the filings of {absent}, "
+            "which data/equities/positioning/13f_download.py requests by CIK. The fixture "
+            "would be internally consistent and still miss an institution the notebook asks "
+            "for; regenerate all three artifacts."
+        )
+    features, edges, *_ = producer.build_features_and_matrix(holdings, expected_ciks=required_ciks)
     for filename, rebuilt, keys in (
         ("institution_stock_edges.parquet", edges, ["institution_id", "stock_id"]),
         ("stock_features.parquet", features, ["cusip"]),

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -402,6 +402,23 @@ def write_manifest(output: Path, built: dict[str, list[Path]]) -> Path:
     return manifest_path
 
 
+def roots_overlap(source: Path, output: Path) -> str | None:
+    """Return why these roots cannot be used together, or None.
+
+    The fixture root and the production root have to be separate trees. With
+    ``--clean`` the same path on both sides deletes the production tensors and 13F
+    artifacts before the build reads them; without it, the copy would be a file
+    onto itself. Nesting either way is the same hazard one level down.
+    """
+    if source == output:
+        return f"--source and --output are the same directory: {source}"
+    if output in source.parents:
+        return f"--output {output} contains --source {source}"
+    if source in output.parents:
+        return f"--output {output} is inside --source {source}"
+    return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -436,6 +453,8 @@ def main() -> int:
     output = args.output.expanduser().resolve()
     if not source.is_dir():
         parser.error(f"--source is not a directory: {source}")
+    if overlap := roots_overlap(source, output):
+        parser.error(overlap)
 
     selected = [DATASETS_BY_NAME[name] for name in (args.dataset or sorted(DATASETS_BY_NAME))]
 

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Subsample production data into the CI fixture set in ml4t/third-edition-test-data.
+
+This is step 1 of the two-step regeneration path; step 2 is
+``tests/generate_intermediates.py``, which runs the case-study pipelines against
+whatever this script produces. ``tests/generate_test_data.sh`` chains both.
+
+Each dataset is declared once, in DATASETS, as a spec that names its source under
+``--source``, its destination under ``--output``, and how it is reduced. The
+subsample budgets are the ones recorded in ``data/manifest.json`` in the test-data
+repo, which is rewritten from DATASETS on every run so the manifest cannot drift
+from what was actually generated.
+
+Usage:
+    # Everything (from the repo root)
+    uv run python tests/create_test_data.py \
+        --source ~/ml4t/code/data --output ~/ml4t/test-data/data
+
+    # One dataset, which is the common case when a schema gate goes red
+    uv run python tests/create_test_data.py \
+        --source ~/ml4t/code/data --output ~/ml4t/test-data/data \
+        --dataset firm_characteristics
+
+    # Show what would be written, touching nothing
+    uv run python tests/create_test_data.py --source ... --output ... --dry-run
+
+Never set PLOTLY_RENDERER=json here or in any wrapper: notebooks executed with the
+JSON renderer emit no image/png, and the resulting figures do not render on GitHub.
+This script writes no notebooks, but the shell wrapper used to, which is how that
+debt was created.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import polars as pl
+
+REPO_ROOT = Path(__file__).parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """One fixture-generation unit.
+
+    Attributes:
+        name: Selector for ``--dataset``.
+        description: What the reduction keeps, mirrored into the manifest.
+        build: Callable invoked as ``build(source, output)``; returns the list of
+            files it wrote. Receives the roots, not per-file paths, because some
+            datasets fan out to several outputs.
+        subdir: Path under the output root that this dataset owns, relative to it.
+            ``--clean`` removes exactly this directory, so it must not be shared
+            with another dataset.
+        budget: Manifest ``subsets`` entry describing the reduction (e.g.
+            ``{"max_entities": 200}``). Recorded verbatim in the manifest.
+    """
+
+    name: str
+    description: str
+    build: Callable[[Path, Path], list[Path]]
+    subdir: Path
+    budget: dict[str, object] = field(default_factory=dict)
+
+
+# --- firm characteristics -----------------------------------------------------
+#
+# The published Chen-Pelger-Zhu archive ships one dense (date, firm, variable)
+# tensor per split. The firm axis is positional and persistent *within* a split,
+# which is the only place anonymous firm identity survives -- the RetChar.csv in
+# the same archive drops it. So the fixture is built from the tensors via the
+# canonical converter in data/equities/firm_characteristics/download.py, not from
+# the CSV and not from the full-size parquets (which predate the symbol schema:
+# they carry `date` and no `symbol`, and the loader rejects them).
+
+FIRM_CHAR_SPLITS = (
+    # (split, tensor filename, symbol namespace offset) -- offsets match
+    # convert_to_parquet: the archive publishes no cross-split firm mapping, so
+    # the namespaces are kept disjoint rather than implying an identity join.
+    ("train", "Char_train.npz", 0),
+    ("valid", "Char_valid.npz", 1_000_000),
+    ("test", "Char_test.npz", 2_000_000),
+)
+FIRM_CHAR_MAX_ENTITIES = 200
+
+
+def _firm_char_tensor_dir(source: Path) -> Path:
+    """Locate the characteristic tensors under a production data root.
+
+    Two layouts exist in the wild: the one download.py's extractor produces (it
+    strips a redundant ``datasets/`` wrapper) and the one a manual ``unzip``
+    leaves behind (it does not). Both are read here because the manual path is
+    what the archive's own instructions tell readers to do.
+    """
+    base = source / "equities" / "firm_characteristics" / "dl_asset_pricing"
+    for candidate in (base / "char", base / "datasets" / "char"):
+        if all((candidate / filename).exists() for _, filename, _ in FIRM_CHAR_SPLITS):
+            return candidate
+    raise FileNotFoundError(
+        f"Characteristic tensors not found under {base} (looked in char/ and "
+        "datasets/char/). Fetch them with "
+        "data/equities/firm_characteristics/download.py."
+    )
+
+
+def build_firm_characteristics(source: Path, output: Path) -> list[Path]:
+    """Write the four canonical firm-characteristics parquets, subsampled by firm.
+
+    Keeps the ``FIRM_CHAR_MAX_ENTITIES`` most-observed firms per split, so each
+    retained firm carries its full time series. Subsampling per date instead would
+    shred the panel: a firm would appear and vanish across adjacent months, and
+    every downstream fold, lag and cross-sectional rank would be computed over a
+    different, unstable cross-section.
+    """
+    from data.equities.firm_characteristics.download import _characteristic_frame
+
+    tensor_dir = _firm_char_tensor_dir(source)
+    out_dir = output / "equities" / "firm_characteristics"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    split_frames: list[pl.DataFrame] = []
+    for split, filename, offset in FIRM_CHAR_SPLITS:
+        frame = _characteristic_frame(tensor_dir / filename, split, offset)
+        keep = (
+            frame.group_by("symbol")
+            .len()
+            # Ties broken by symbol so the fixture is reproducible bit for bit.
+            .sort(["len", "symbol"], descending=[True, False])
+            .head(FIRM_CHAR_MAX_ENTITIES)
+            .get_column("symbol")
+        )
+        subsampled = frame.filter(pl.col("symbol").is_in(keep.implode()))
+        path = out_dir / f"firm_characteristics_{split}.parquet"
+        subsampled.write_parquet(path)
+        split_frames.append(subsampled)
+        written.append(path)
+        print(
+            f"    {split}: {len(subsampled):,} rows, "
+            f"{subsampled['symbol'].n_unique()} firms, "
+            f"{subsampled['timestamp'].n_unique()} dates "
+            f"({path.stat().st_size / 1e6:.1f} MB)"
+        )
+
+    # load_firm_characteristics(split="all") reads this file rather than
+    # concatenating the splits, so it has to be materialized.
+    all_path = out_dir / "firm_characteristics_all.parquet"
+    pl.concat(split_frames).write_parquet(all_path)
+    written.append(all_path)
+    print(
+        f"    all: {sum(len(f) for f in split_frames):,} rows ({all_path.stat().st_size / 1e6:.1f} MB)"
+    )
+    return written
+
+
+DATASETS: tuple[Dataset, ...] = (
+    Dataset(
+        name="firm_characteristics",
+        description=(
+            f"{FIRM_CHAR_MAX_ENTITIES} most-observed anonymous firms per published "
+            "split, built from the char/*.npz tensors so symbol identity survives"
+        ),
+        build=build_firm_characteristics,
+        subdir=Path("equities") / "firm_characteristics",
+        budget={"max_entities": FIRM_CHAR_MAX_ENTITIES},
+    ),
+)
+
+DATASETS_BY_NAME = {dataset.name: dataset for dataset in DATASETS}
+
+
+def write_manifest(output: Path, built: dict[str, list[Path]]) -> Path:
+    """Rewrite data/manifest.json from what this run actually produced.
+
+    Only the datasets built in this run are refreshed; entries for datasets not
+    selected are carried over, so a single ``--dataset`` run does not blank the
+    rest of the manifest.
+    """
+    manifest_path = output / "manifest.json"
+    manifest: dict = {"version": "1", "subsets": {}, "files": {}}
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        manifest.setdefault("subsets", {})
+        manifest.setdefault("files", {})
+
+    for name, paths in built.items():
+        dataset = DATASETS_BY_NAME[name]
+        manifest["subsets"][name] = {**dataset.budget, "description": dataset.description}
+        for path in paths:
+            rel = path.relative_to(output).as_posix()
+            size = path.stat().st_size
+            manifest["files"][rel] = {"size_bytes": size, "size_mb": round(size / 1e6, 2)}
+
+    manifest["files"] = dict(sorted(manifest["files"].items()))
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        required=True,
+        help="Production data root to subsample from (e.g. ~/ml4t/code/data)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Fixture data root to write (the test-data repo's data/ directory)",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        choices=sorted(DATASETS_BY_NAME),
+        help="Build only this dataset; repeatable. Default: all.",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove each selected dataset's output directory before writing it",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report the plan, write nothing")
+    args = parser.parse_args()
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    if not source.is_dir():
+        parser.error(f"--source is not a directory: {source}")
+
+    selected = [DATASETS_BY_NAME[name] for name in (args.dataset or sorted(DATASETS_BY_NAME))]
+
+    print("=== ML4T test-data subsampler ===")
+    print(f"Source: {source}")
+    print(f"Output: {output}")
+    print(f"Datasets: {', '.join(d.name for d in selected)}")
+    print()
+
+    if args.dry_run:
+        for dataset in selected:
+            print(f"  [dry-run] {dataset.name}: {dataset.description}")
+        return 0
+
+    output.mkdir(parents=True, exist_ok=True)
+    built: dict[str, list[Path]] = {}
+    for dataset in selected:
+        print(f"  {dataset.name}: {dataset.description}")
+        if args.clean:
+            target = output / dataset.subdir
+            if target.exists():
+                shutil.rmtree(target)
+        built[dataset.name] = dataset.build(source, output)
+        print()
+
+    manifest_path = write_manifest(output, built)
+    print(f"Manifest: {manifest_path}")
+    total = sum(path.stat().st_size for paths in built.values() for path in paths)
+    print(f"Wrote {sum(len(p) for p in built.values())} files, {total / 1e6:.1f} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -11,8 +11,16 @@ subsample budgets are the ones recorded in ``data/manifest.json`` in the test-da
 repo, which is rewritten from DATASETS on every run so the manifest cannot drift
 from what was actually generated.
 
+DATASETS covers the fixtures whose absence or staleness has taken a CI job red,
+not every fixture the test-data repo carries. The rest - equities bars, crypto,
+futures, FX, the nasdaq minute set, options - were produced before this script
+existed and have no spec here yet, so this is not a from-empty rebuild of the
+fixture repo: it operates on a checkout of ml4t/third-edition-test-data and
+replaces the datasets it knows. Reconstructing the remaining specs is tracked in
+``agents/issues`` (test-data regeneration coverage).
+
 Usage:
-    # Everything (from the repo root)
+    # Every dataset declared below, over an existing test-data checkout
     uv run python tests/create_test_data.py \
         --source ~/ml4t/code/data --output ~/ml4t/test-data/data
 
@@ -33,6 +41,7 @@ debt was created.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import shutil
 import sys
@@ -41,6 +50,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 REPO_ROOT = Path(__file__).parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -226,6 +236,53 @@ _13F_REQUIRED_COLUMNS: dict[str, tuple[str, ...]] = {
 _13F_FILES = tuple(_13F_REQUIRED_COLUMNS)
 
 
+def _load_13f_producer():
+    """Import data/equities/positioning/13f_download.py by path.
+
+    Its filename starts with a digit, so it cannot be reached by an import
+    statement.
+    """
+    path = REPO_ROOT / "data" / "equities" / "positioning" / "13f_download.py"
+    spec = importlib.util.spec_from_file_location("ml4t_13f_download", path)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(f"13F producer not found at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _require_derived_13f_matches_holdings(source_dir: Path) -> None:
+    """Rebuild edges and stock features from the holdings and require equality.
+
+    A column-name check passes an artifact whose dtypes, column order or values
+    are those of an older producer generation. 22_rag/07 rebuilds both frames and
+    compares them with ``assert_frame_equal``, which checks all of that, so the
+    same comparison belongs here - before the stale copy enters the fixture set,
+    rather than after a chapter job goes red against it.
+
+    The rebuild is keyed on the CIK set the holdings themselves carry, which is
+    the producer's own rule: it steps back to the newest quarter every requested
+    institution filed for, so a quarter that is still filling in cannot enter
+    either side of the ownership-change comparison.
+    """
+    build = _load_13f_producer().build_features_and_matrix
+    holdings = pl.read_parquet(source_dir / "institutional_holdings.parquet")
+    features, edges, *_ = build(holdings, expected_ciks=holdings["cik"].unique().to_list())
+    for filename, rebuilt, keys in (
+        ("institution_stock_edges.parquet", edges, ["institution_id", "stock_id"]),
+        ("stock_features.parquet", features, ["cusip"]),
+    ):
+        stored = pl.read_parquet(source_dir / filename)
+        try:
+            assert_frame_equal(rebuilt.sort(keys), stored.sort(keys), check_row_order=True)
+        except AssertionError as exc:
+            raise ValueError(
+                f"Source 13F artifact at {source_dir / filename} is not what the current "
+                f"producer builds from institutional_holdings.parquet: {exc}. Regenerate "
+                "all three artifacts with data/equities/positioning/13f_download.py."
+            ) from exc
+
+
 def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
     """Copy the production 13F artifacts into the fixture set verbatim.
 
@@ -234,9 +291,9 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
     institution risks dropping a CIK the notebook asks for and turning a schema
     fixture into a silent coverage gap.
     """
-    written: list[Path] = []
+    source_dir = source / _13F_DIR
     for filename in _13F_FILES:
-        src = source / _13F_DIR / filename
+        src = source_dir / filename
         if not src.exists():
             raise FileNotFoundError(
                 f"13F artifact not found at {src}. Fetch it with "
@@ -251,9 +308,13 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
                 "data/equities/positioning/13f_download.py before building the fixture."
             )
 
+    _require_derived_13f_matches_holdings(source_dir)
+
+    written: list[Path] = []
+    for filename in _13F_FILES:
         dst = output / _13F_DIR / filename
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src, dst)
+        shutil.copyfile(source_dir / filename, dst)
         rows = pl.scan_parquet(dst).select(pl.len()).collect().item()
         print(f"    {filename}: {rows:,} rows ({dst.stat().st_size / 1e6:.1f} MB), copied verbatim")
         written.append(dst)

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -165,20 +165,53 @@ def build_firm_characteristics(source: Path, output: Path) -> list[Path]:
 
 # --- institutional holdings (13F) ---------------------------------------------
 
-# Columns 22_rag_financial_research/07_institutional_holdings_graph refuses to run
-# without. report_date is the SEC period-of-report, distinct from filing_date, and
-# put_call marks option positions the notebook separates out from share holdings.
-# A fixture missing them is not a smaller fixture, it is a different schema.
-_13F_REQUIRED_PROVENANCE = ("report_date", "put_call")
 _13F_DIR = Path("equities") / "positioning" / "13f"
-# The three artifacts load_institutional_holdings_13f, load_13f_edges and
-# load_13f_stock_features read. The co-ownership matrix is deliberately absent:
-# the notebook computes it from the holdings, and the production .npy is 255MB.
-_13F_FILES = (
-    "institutional_holdings.parquet",
-    "institution_stock_edges.parquet",
-    "stock_features.parquet",
-)
+
+# The canonical columns of each artifact data/equities/positioning/13f_download.py
+# emits, as required by their consumers. Validating one artifact is not enough:
+# the three are generated together and a stale copy of any of them is a different
+# schema, not a smaller fixture. Concretely, 22_rag/07 refuses to run without
+# holdings.put_call and holdings.report_date (report_date is the SEC
+# period-of-report, distinct from filing_date, and put_call marks the option
+# positions the notebook separates from share holdings), and
+# 10_text_feature_engineering/02 reads stock_features.issuer_name, which an older
+# generation of the producer spelled `issuer`.
+#
+# Listed per file rather than as one set so the error names the artifact that is
+# stale. The co-ownership matrix is deliberately absent from the fixture: the
+# notebook computes it from the holdings, and the production .npy is 255MB.
+_13F_REQUIRED_COLUMNS: dict[str, tuple[str, ...]] = {
+    "institutional_holdings.parquet": (
+        "cik",
+        "accession_no",
+        "cusip",
+        "issuer",
+        "shares",
+        "value_thousands",
+        "put_call",
+        "report_date",
+        "filing_date",
+        "company_name",
+    ),
+    "institution_stock_edges.parquet": (
+        "institution_id",
+        "stock_id",
+        "institution_name",
+        "stock_name",
+        "weight_value",
+        "weight_shares",
+        "report_date",
+        "timestamp",
+    ),
+    "stock_features.parquet": (
+        "cusip",
+        "issuer_name",
+        "n_inst_holders",
+        "total_inst_value_usd",
+        "timestamp",
+    ),
+}
+_13F_FILES = tuple(_13F_REQUIRED_COLUMNS)
 
 
 def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
@@ -198,13 +231,13 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
                 "data/equities/positioning/13f_download.py."
             )
 
-        if filename == "institutional_holdings.parquet":
-            names = set(pl.scan_parquet(src).collect_schema().names())
-            if missing := sorted(set(_13F_REQUIRED_PROVENANCE) - names):
-                raise ValueError(
-                    f"Source 13F artifact at {src} lacks SEC provenance {missing}. It predates "
-                    "the canonical downloader; regenerate it before building the fixture."
-                )
+        names = set(pl.scan_parquet(src).collect_schema().names())
+        if missing := sorted(set(_13F_REQUIRED_COLUMNS[filename]) - names):
+            raise ValueError(
+                f"Source 13F artifact at {src} is missing {missing}. It predates the "
+                "canonical downloader; regenerate all three artifacts with "
+                "data/equities/positioning/13f_download.py before building the fixture."
+            )
 
         dst = output / _13F_DIR / filename
         dst.parent.mkdir(parents=True, exist_ok=True)
@@ -243,12 +276,24 @@ DATASETS: tuple[Dataset, ...] = (
 DATASETS_BY_NAME = {dataset.name: dataset for dataset in DATASETS}
 
 
+def _owned_by(dataset: Dataset, rel: str) -> bool:
+    """Whether ``rel`` (manifest key, POSIX-relative) falls under the dataset."""
+    return any(
+        rel == owned.as_posix() or rel.startswith(f"{owned.as_posix()}/") for owned in dataset.owns
+    )
+
+
 def write_manifest(output: Path, built: dict[str, list[Path]]) -> Path:
     """Rewrite data/manifest.json from what this run actually produced.
 
     Only the datasets built in this run are refreshed; entries for datasets not
     selected are carried over, so a single ``--dataset`` run does not blank the
     rest of the manifest.
+
+    A rebuilt dataset's old entries are dropped before the new ones are recorded,
+    keyed on its ``owns`` paths. Merging instead would leave an artifact that has
+    been renamed or discontinued listed forever, and the manifest is the only
+    record of what the fixture set is supposed to contain.
     """
     manifest_path = output / "manifest.json"
     manifest: dict = {"version": "1", "subsets": {}, "files": {}}
@@ -260,6 +305,9 @@ def write_manifest(output: Path, built: dict[str, list[Path]]) -> Path:
     for name, paths in built.items():
         dataset = DATASETS_BY_NAME[name]
         manifest["subsets"][name] = {**dataset.budget, "description": dataset.description}
+        manifest["files"] = {
+            rel: entry for rel, entry in manifest["files"].items() if not _owned_by(dataset, rel)
+        }
         for path in paths:
             rel = path.relative_to(output).as_posix()
             size = path.stat().st_size

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -203,12 +203,24 @@ _13F_REQUIRED_COLUMNS: dict[str, tuple[str, ...]] = {
         "report_date",
         "timestamp",
     ),
+    # Every column build_features_and_matrix emits, not just the ones a consumer
+    # names: 22_rag/07 rebuilds this frame and compares it with
+    # assert_frame_equal, which checks the whole schema, so a source missing a
+    # derived column passes a partial check here and fails the notebook's parity
+    # assertion instead.
     "stock_features.parquet": (
         "cusip",
         "issuer_name",
         "n_inst_holders",
         "total_inst_value_usd",
+        "avg_position_size_usd",
+        "position_size_std_usd",
         "timestamp",
+        "ownership_hhi",
+        "inst_coverage_pct",
+        "position_cv",
+        "inst_value_change_usd",
+        "inst_pct_change",
     ),
 }
 _13F_FILES = tuple(_13F_REQUIRED_COLUMNS)

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -30,6 +30,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -322,6 +323,12 @@ def main():
         json.dump(metadata, f, indent=2)
     print(f"Metadata: {metadata_path}")
 
+    # A failed stage leaves whatever the previous run wrote in place, so exiting 0
+    # reports success while the fixture set still holds the stale artifact. That
+    # is how the sp500_options temporal artifact shipped without a `fold` column:
+    # the stage timed out, the wrapper ran under `set -e` and saw nothing.
+    return 1 if failed else 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/generate_test_data.sh
+++ b/tests/generate_test_data.sh
@@ -69,9 +69,14 @@ export MPLBACKEND=Agg
 
 if [[ ",$STEPS," == *",1,"* ]]; then
   echo "=== Step 1: subsample raw data ==="
+  # --clean so a rebuild leaves no file the current spec does not produce. The
+  # manifest is rewritten from the specs either way, so without it a discontinued
+  # or renamed artifact loses its manifest entry and stays on disk, where the
+  # "git add -A" below would commit it back into the fixture set.
   uv run python tests/create_test_data.py \
       --source "$SOURCE_DATA" \
-      --output "$TEST_DATA_DIR/data"
+      --output "$TEST_DATA_DIR/data" \
+      --clean
   echo ""
 fi
 

--- a/tests/generate_test_data.sh
+++ b/tests/generate_test_data.sh
@@ -37,7 +37,10 @@ TEST_DATA_DIR="${1:-$HOME/ml4t/test-data}"
 SOURCE_DATA="${ML4T_SOURCE_DATA:-$HOME/ml4t/code/data}"
 STEPS="${STEPS:-1,2,3}"
 
-if [[ ! -d "$SOURCE_DATA" ]]; then
+# Only step 1 reads production data; steps 2 and 3 run off the fixture set and
+# the case-study registries, so requiring it would block the common single-step
+# re-run.
+if [[ ",$STEPS," == *",1,"* && ! -d "$SOURCE_DATA" ]]; then
   echo "ERROR: production data root not found: $SOURCE_DATA" >&2
   echo "Set ML4T_SOURCE_DATA to the directory holding the full datasets." >&2
   exit 1
@@ -52,11 +55,16 @@ echo ""
 
 cd "$REPO_ROOT"
 
-# MPLBACKEND=Agg is needed for headless execution. PLOTLY_RENDERER is deliberately
-# NOT set: this script used to export PLOTLY_RENDERER=json, which makes Plotly emit
-# a JSON blob instead of image/png, so every notebook it touched renders as raw
-# JSON on GitHub. That is the origin of the unrenderable-figure debt the `guards`
-# job reports. Do not reintroduce it.
+# MPLBACKEND=Agg is needed for headless execution.
+#
+# PLOTLY_RENDERER is not exported here, but note that it is not thereby unset:
+# step 2 runs notebooks through run_notebook(), which sets PLOTLY_RENDERER=json
+# itself. That is safe in this script because it writes only parquet
+# intermediates -- the executed notebook goes to a gitignored _executed_*.ipynb
+# and is discarded. The rule the JSON renderer breaks applies to re-executing a
+# *committed* notebook: it emits a JSON blob instead of image/png, so the figures
+# render as raw JSON on GitHub. Never use this script's step 2 to refresh a
+# committed notebook.
 export MPLBACKEND=Agg
 
 if [[ ",$STEPS," == *",1,"* ]]; then
@@ -85,7 +93,8 @@ if [[ ",$STEPS," == *",3,"* ]]; then
   echo "=== Step 3: sample production registries ==="
   # Reads each case study's production run_log/registry.db and copies a subset in.
   # Read-only with respect to the production registries; it never writes them.
-  uv run python tests/sample_registry_for_tests.py
+  uv run python tests/sample_registry_for_tests.py \
+      --output "$TEST_DATA_DIR/intermediates"
   echo ""
 fi
 

--- a/tests/generate_test_data.sh
+++ b/tests/generate_test_data.sh
@@ -1,59 +1,96 @@
-#!/bin/bash
-# Regenerate all test data (raw + intermediates) for CI.
+#!/usr/bin/env bash
+# Regenerate the CI fixture set in ml4t/third-edition-test-data.
 #
-# Run from the review repo root. Requires:
-# - ML4T_DATA_PATH to point to full production data (default: ~/Dropbox/ml4t/data)
-# - The working repo at ~/ml4t/third-edition
-# - The review repo at ~/ml4t/technical_review
+# Run from the root of this repo (~/ml4t/public). The three steps are separable
+# and each is individually re-runnable; the whole chain is rarely what you want.
+# The usual trigger is a single dataset going red on a schema gate, in which case
+# step 1 with --dataset plus step 2 for the affected case studies is enough.
+#
+#   Step 1  create_test_data.py          subsample production data -> data/
+#   Step 2  generate_intermediates.py    run pipeline stages       -> intermediates/
+#   Step 3  sample_registry_for_tests.py copy production registry rows into
+#                                        intermediates/<cs>/run_log/registry.db
+#
+# Step 3 is not optional, and it was missing from both this script and the
+# test-data README. Several late-stage notebooks (us_firm_characteristics/08a_ipca
+# and 08_latent_factors, and the model_analysis and strategy_analysis stages
+# across case studies) are replay-only: they refuse to fit and read registered
+# results instead. Without step 3 they fail on a cache miss that reads like a
+# code bug rather than a missing fixture.
+#
+# The previous version of this script referenced ~/ml4t/third-edition and
+# ~/ml4t/technical_review (neither exists) and called scripts/deploy_to_review.py
+# (which does not exist either). The generator now lives in the public repo and
+# there is no separate review repo to deploy to.
 #
 # Usage:
-#   cd ~/ml4t/technical_review
 #   bash tests/generate_test_data.sh [TEST_DATA_DIR]
-
+#
+# Env:
+#   ML4T_SOURCE_DATA   production data root to subsample (default ~/ml4t/code/data)
+#   STEPS              comma-separated subset of 1,2,3 (default all)
+#   CASE_STUDIES       space-separated list for step 2 (default: all nine)
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DATA_DIR="${1:-$HOME/ml4t/test-data}"
-WORKING_REPO="$HOME/ml4t/third-edition"
-REVIEW_REPO="$HOME/ml4t/technical_review"
+SOURCE_DATA="${ML4T_SOURCE_DATA:-$HOME/ml4t/code/data}"
+STEPS="${STEPS:-1,2,3}"
 
-echo "=== ML4T Test Data Generator ==="
-echo "Output:       $TEST_DATA_DIR"
-echo "Working repo: $WORKING_REPO"
-echo "Review repo:  $REVIEW_REPO"
+if [[ ! -d "$SOURCE_DATA" ]]; then
+  echo "ERROR: production data root not found: $SOURCE_DATA" >&2
+  echo "Set ML4T_SOURCE_DATA to the directory holding the full datasets." >&2
+  exit 1
+fi
+
+echo "=== ML4T test-data regeneration ==="
+echo "Repo:        $REPO_ROOT"
+echo "Source data: $SOURCE_DATA"
+echo "Output:      $TEST_DATA_DIR"
+echo "Steps:       $STEPS"
 echo ""
 
-# Step 1: Generate subsampled raw data
-echo "=== Step 1: Generating subsampled data ==="
-cd "$WORKING_REPO"
-uv run python tests/create_test_data.py \
-    --source "${ML4T_DATA_PATH:-$HOME/Dropbox/ml4t/data}" \
-    --output "$TEST_DATA_DIR/data" \
-    --clean
-echo ""
+cd "$REPO_ROOT"
 
-# Step 2: Deploy latest notebooks from third-edition -> review repo
-echo "=== Step 2: Deploying latest notebooks ==="
-cd "$WORKING_REPO"
-uv run python scripts/deploy_to_review.py --all
-echo ""
+# MPLBACKEND=Agg is needed for headless execution. PLOTLY_RENDERER is deliberately
+# NOT set: this script used to export PLOTLY_RENDERER=json, which makes Plotly emit
+# a JSON blob instead of image/png, so every notebook it touched renders as raw
+# JSON on GitHub. That is the origin of the unrenderable-figure debt the `guards`
+# job reports. Do not reintroduce it.
+export MPLBACKEND=Agg
 
-# Step 3: Generate intermediates (runs pipeline notebooks via Papermill)
-echo "=== Step 3: Generating intermediates ==="
-cd "$REVIEW_REPO"
-ML4T_DATA_PATH="$TEST_DATA_DIR/data" \
-MPLBACKEND=Agg \
-PLOTLY_RENDERER=json \
-uv run python tests/generate_intermediates.py \
-    --output "$TEST_DATA_DIR/intermediates"
-echo ""
+if [[ ",$STEPS," == *",1,"* ]]; then
+  echo "=== Step 1: subsample raw data ==="
+  uv run python tests/create_test_data.py \
+      --source "$SOURCE_DATA" \
+      --output "$TEST_DATA_DIR/data"
+  echo ""
+fi
 
-# Summary
+if [[ ",$STEPS," == *",2,"* ]]; then
+  echo "=== Step 2: generate pipeline intermediates ==="
+  cs_args=()
+  if [[ -n "${CASE_STUDIES:-}" ]]; then
+    # shellcheck disable=SC2206
+    cs_args=(--case-studies ${CASE_STUDIES})
+  fi
+  ML4T_DATA_PATH="$TEST_DATA_DIR/data" \
+  uv run python tests/generate_intermediates.py \
+      --output "$TEST_DATA_DIR/intermediates" \
+      "${cs_args[@]}"
+  echo ""
+fi
+
+if [[ ",$STEPS," == *",3,"* ]]; then
+  echo "=== Step 3: sample production registries ==="
+  # Reads each case study's production run_log/registry.db and copies a subset in.
+  # Read-only with respect to the production registries; it never writes them.
+  uv run python tests/sample_registry_for_tests.py
+  echo ""
+fi
+
 echo "=== Done ==="
-echo "Test data directory: $TEST_DATA_DIR"
 du -sh "$TEST_DATA_DIR/data" "$TEST_DATA_DIR/intermediates" 2>/dev/null || true
 echo ""
-echo "Next steps:"
-echo "  cd $TEST_DATA_DIR"
-echo "  git add -A"
-echo "  git commit -m 'update: regenerate test data'"
-echo "  git push"
+echo "Review and commit in the test-data repo:"
+echo "  cd $TEST_DATA_DIR && git status && git add -A && git commit"

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1609,13 +1609,33 @@ case_studies/etfs/09_dl_lstm:
     N_EPOCHS: 1
   timeout: 180
 case_studies/etfs/10_dl_tsmixer:
+  # LOOKBACK becomes the Darts input_chunk_length, which must exceed
+  # output_chunk_length, and output_chunk_length is the label horizon: etfs is
+  # primary fwd_ret_21d, so 21. LOOKBACK was 5, which _resolve_chunk_lengths
+  # rejects outright on any data size. 24 is the smallest value that keeps the
+  # window valid without paying for the notebook default of 60.
   parameters:
     BATCH_SIZE: 32
-    LOOKBACK: 5
+    LOOKBACK: 24
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 1
   timeout: 180
+case_studies/etfs/11a_pca:
+  # MAX_SYMBOLS must match 04_model_based_features, which builds the temporal
+  # artifact these notebooks validate against. With no override they ran on the
+  # full fixture universe while the artifact covered 5 symbols, so the CV splits
+  # spanned dates the artifact never saw and fold 0 validation came out at 93.5%,
+  # just under the 95% floor in MIN_TEMPORAL_DATE_COVERAGE.
+  parameters:
+    MAX_FOLDS: 2
+    MAX_SYMBOLS: 5
+  timeout: 300
+case_studies/etfs/11b_ipca:
+  parameters:
+    MAX_FOLDS: 2
+    MAX_SYMBOLS: 5
+  timeout: 300
 case_studies/etfs/11_latent_factors:
   gpu: true
   parameters:
@@ -1983,12 +2003,17 @@ case_studies/sp500_options/03_financial_features:
     N_RESTARTS: 1
   timeout: 120
 case_studies/sp500_options/04_model_based_features:
+  # Skipped in CI (gpu: true), so this timeout bounds only fixture generation via
+  # tests/generate_intermediates.py, where 300s was not enough to finish even on a
+  # GPU. The stage silently failed there, which is why the committed temporal
+  # artifact had no `fold` column and 05_evaluation, 07_gbm and 09_deep_learning
+  # failed on missing fold-specific features.
   gpu: true
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 2
-  timeout: 300
+  timeout: 1800
 case_studies/sp500_options/05_evaluation:
   parameters:
     MAX_SYMBOLS: 5

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2008,11 +2008,21 @@ case_studies/sp500_options/04_model_based_features:
   # GPU. The stage silently failed there, which is why the committed temporal
   # artifact had no `fold` column and 05_evaluation, 07_gbm and 09_deep_learning
   # failed on missing fold-specific features.
+  #
+  # The parameters below are the ones this notebook's parameters cell actually
+  # declares. It was previously given MAX_FOLDS / MAX_SYMBOLS / N_EPOCHS, none of
+  # which it defines, so Papermill logged "Passed unknown parameter" and the full
+  # production MCMC workload (10 calibration symbols x 2000 draws x 4 chains) ran
+  # anyway. Raising the timeout hid that rather than fixing it.
   gpu: true
   parameters:
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 2
+    SV_CHAINS: 2
+    SV_DRAWS: 100
+    SV_N_PARTICLES: 100
+    SV_POOL_SIZE: 2
+    SV_RETRY_DRAWS: 200
+    SV_RETRY_TUNE: 200
+    SV_TUNE: 100
   timeout: 1800
 case_studies/sp500_options/05_evaluation:
   parameters:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1615,11 +1615,12 @@ case_studies/etfs/10_dl_tsmixer:
   # LOOKBACK becomes the Darts input_chunk_length, which must exceed
   # output_chunk_length, and output_chunk_length is the label horizon: etfs is
   # primary fwd_ret_21d, so 21. LOOKBACK was 5, which _resolve_chunk_lengths
-  # rejects outright on any data size. 24 is the smallest value that keeps the
-  # window valid without paying for the notebook default of 60.
+  # rejects outright on any data size. 22 is the smallest value it accepts - the
+  # check is input > output and nothing more - so the window is valid without
+  # paying for the notebook default of 60.
   parameters:
     BATCH_SIZE: 32
-    LOOKBACK: 24
+    LOOKBACK: 22
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 1

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1071,8 +1071,11 @@
     COHORT_SAMPLE: 10
   timeout: 300
 22_rag_financial_research/01_sec_filing_pipeline:
+  # SYMBOLS, not TICKERS: the notebook's parameters cell declares SYMBOLS, so the
+  # old key was dropped by Papermill and the weekly job fetched all five default
+  # symbols across both default years from EDGAR instead of one.
   parameters:
-    TICKERS:
+    SYMBOLS:
     - AAPL
     YEARS:
     - 2024

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1778,12 +1778,16 @@ case_studies/nasdaq100_microstructure/03_financial_features:
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/04_model_based_features:
+  # MAX_SYMBOLS and START_DATE must match the consumers of this notebook's
+  # temporal artifact (05_evaluation and 06-12, all MAX_SYMBOLS 5 from
+  # 2000-01-01). This stage used to run on 3 symbols over 2021-06..2021-12 while
+  # the consumers built CV folds over the full two-year window, so the artifact
+  # covered none of fold 0 and validate_temporal_fold_coverage failed at 0.0%.
   long_running: true
   parameters:
-    END_DATE: '2021-12-31'
-    MAX_SYMBOLS: 3
-    START_DATE: '2021-06-01'
-  timeout: 600
+    MAX_SYMBOLS: 5
+    START_DATE: '2000-01-01'
+  timeout: 900
 case_studies/nasdaq100_microstructure/05_evaluation:
   parameters:
     MAX_SYMBOLS: 5

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2014,15 +2014,19 @@ case_studies/sp500_options/04_model_based_features:
   # which it defines, so Papermill logged "Passed unknown parameter" and the full
   # production MCMC workload (10 calibration symbols x 2000 draws x 4 chains) ran
   # anyway. Raising the timeout hid that rather than fixing it.
+  #
+  # The sampler settings are deliberately NOT reduced. sv_diagnostics_pass()
+  # requires bulk and tail ESS of at least 400 and raises after one retry, so any
+  # draw count whose total posterior sample count approaches 400 fails closed by
+  # construction: 2 chains x 100 draws is 200 samples, and the retry's 2 x 200 is
+  # exactly 400, which correlated NUTS draws never reach in effective terms.
+  # What is safe to reduce is how many times that sampler runs and how finely the
+  # filter resolves: the pool is the per-fold MCMC fit count (10 -> 2) and the
+  # particle count is the filter's resolution over every segment (1000 -> 100).
   gpu: true
   parameters:
-    SV_CHAINS: 2
-    SV_DRAWS: 100
     SV_N_PARTICLES: 100
     SV_POOL_SIZE: 2
-    SV_RETRY_DRAWS: 200
-    SV_RETRY_TUNE: 200
-    SV_TUNE: 100
   timeout: 1800
 case_studies/sp500_options/05_evaluation:
   parameters:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -109,8 +109,7 @@
 04_fundamental_alternative_data/01_academic_characteristics:
   timeout: 300
 04_fundamental_alternative_data/02_sec_filing_explorer:
-  skip: true
-  skip_reason: Requires EDGAR_IDENTITY env var for SEC EDGAR network calls; CI does not provide.
+  requires_env: EDGAR_IDENTITY
   tier: weekly
   timeout: 300
 04_fundamental_alternative_data/03_sec_form4_insider_transactions:
@@ -136,8 +135,7 @@
 04_fundamental_alternative_data/13_polymarket_prediction_markets:
   timeout: 120
 04_fundamental_alternative_data/14_text_data_extraction:
-  skip: true
-  skip_reason: Requires EDGAR_IDENTITY env var for SEC EDGAR network calls; CI does not provide.
+  requires_env: EDGAR_IDENTITY
   tier: weekly
   timeout: 300
 05_synthetic_data/00_classical_simulation:
@@ -1078,6 +1076,8 @@
     - AAPL
     YEARS:
     - 2024
+  requires_env: EDGAR_IDENTITY
+  tier: weekly
   timeout: 300
 22_rag_financial_research/02_domain_embeddings_comparison:
   parameters:

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -16,6 +16,11 @@ overrides.yaml schema (per-notebook, all optional):
     skip: bool — hard skip in uv-native run (Docker tests ignore)
     skip_reason: str
     requires_import: str | list[str]
+    requires_env: str | list[str] — environment variables the notebook cannot run
+        without (API keys, SEC identity). Skipped when any is unset or blank,
+        executed when they are all present. Prefer this over `skip: true` for a
+        missing capability: `skip` is unconditional, so a notebook marked that
+        way stays unexecuted even in the workflow that supplies the credential.
     gpu: bool
     long_running: bool
     docker_env: str — informational (e.g., "benchmark")
@@ -81,6 +86,21 @@ def current_test_tier() -> str:
     if tier not in VALID_TIERS:
         raise ValueError(f"Invalid ML4T_TEST_TIER={tier!r} — must be one of {sorted(VALID_TIERS)}")
     return tier
+
+
+def missing_required_env(overrides: dict) -> list[str]:
+    """Return the ``requires_env`` variables that are unset or blank.
+
+    An empty list means the notebook's credentials are all present and it must
+    execute. This is what keeps a credential-gated notebook honest in both
+    directions: it does not fail the per-commit run that has no secret, and it
+    does not silently stay skipped in the weekly run that does.
+    """
+    declared = overrides.get("requires_env")
+    if not declared:
+        return []
+    names = [declared] if isinstance(declared, str) else list(declared)
+    return [name for name in names if not (os.environ.get(name) or "").strip()]
 
 
 def get_reruns(overrides: dict) -> int:

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -56,11 +56,42 @@ def _copy_rows(src, dst, table: str, rows: list) -> int:
     return len(rows)
 
 
+def rejected_output_root(intermediates_dir: Path) -> str | None:
+    """Return why this output root must not be written to, or None.
+
+    Each destination is unlinked before its source is opened, and a production
+    registry.db is 43-180 MB and gitignored, so a run pointed at a case-study tree
+    destroys the results SSOT with nothing to restore it from.
+
+    Two rules. The root may not be, or sit inside, any directory named
+    ``case_studies``: in a worktree ``CODE_CS_DIR`` is the worktree's own tree while
+    the canonical registries are the ones in ~/ml4t/code, so path equality alone
+    would let a run write over them. And no destination may resolve onto its own
+    source. Both are checked before anything is created or removed.
+    """
+    resolved = intermediates_dir.resolve()
+    if any(part.name == "case_studies" for part in (resolved, *resolved.parents)):
+        return (
+            f"{resolved} is inside a case_studies tree, where each destination is a "
+            "production registry.db that this script unlinks before reading"
+        )
+    for cs_id in CASE_STUDY_IDS:
+        src_db = (CODE_CS_DIR / cs_id / "run_log" / "registry.db").resolve()
+        if (resolved / cs_id / "run_log" / "registry.db") == src_db:
+            return f"{resolved} resolves onto the source registry at {src_db}"
+    return None
+
+
 def sample_registry(cs_id: str, intermediates_dir: Path = DEFAULT_INTERMEDIATES_DIR) -> dict:
     """Sample from production registry into test intermediates. Returns stats."""
     src_db = CODE_CS_DIR / cs_id / "run_log" / "registry.db"
     if not src_db.exists():
         return {"status": "SKIP", "reason": "no source registry.db"}
+    if reason := rejected_output_root(intermediates_dir):
+        raise ValueError(
+            f"Refusing to sample {cs_id}: {reason}. Point --output at the test-data "
+            "repo's intermediates/ directory."
+        )
 
     dst_dir = intermediates_dir / cs_id / "run_log"
     dst_dir.mkdir(parents=True, exist_ok=True)
@@ -181,6 +212,12 @@ def main() -> int:
     )
     args = parser.parse_args()
     intermediates_dir = args.output.expanduser().resolve()
+
+    if reason := rejected_output_root(intermediates_dir):
+        parser.error(
+            f"--output is not usable: {reason}. Point it at the test-data repo's "
+            "intermediates/ directory."
+        )
 
     print(f"Sampling registries from {CODE_CS_DIR}")
     print(f"Writing to {intermediates_dir}")

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -20,6 +20,7 @@ Writes to: <--output>/{cs}/run_log/registry.db
 import argparse
 import contextlib
 import sqlite3
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -167,7 +168,7 @@ def _populate_sample_db(src, dst, dst_db) -> dict:
     return stats
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--output",
@@ -186,11 +187,13 @@ def main():
     print(f"Top {TOP_N_PER_GROUP} backtests per (family × stage) + all holdout\n")
 
     total_size = 0
+    not_refreshed: list[str] = []
     for cs_id in CASE_STUDY_IDS:
         print(f"--- {cs_id} ---")
         stats = sample_registry(cs_id, intermediates_dir)
         if stats["status"] != "OK":
             print(f"  {stats['status']}: {stats.get('reason', '')}")
+            not_refreshed.append(cs_id)
             continue
         for table in [
             "training_runs",
@@ -207,6 +210,18 @@ def main():
 
     print(f"\nTotal registry size: {total_size} KB ({total_size / 1024:.1f} MB)")
 
+    if not_refreshed:
+        # A skipped case study leaves whatever registry the destination already
+        # held, so exiting 0 here reports a refresh that did not happen and the
+        # replay-only notebooks then read the previous vintage.
+        print(
+            f"\nERROR: {len(not_refreshed)} of {len(CASE_STUDY_IDS)} registries were not "
+            f"refreshed: {', '.join(not_refreshed)}. Their production registry.db is missing "
+            f"under {CODE_CS_DIR}; the fixture keeps whatever it held before this run."
+        )
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -66,8 +66,12 @@ def rejected_output_root(intermediates_dir: Path) -> str | None:
     Two rules. The root may not be, or sit inside, any directory named
     ``case_studies``: in a worktree ``CODE_CS_DIR`` is the worktree's own tree while
     the canonical registries are the ones in ~/ml4t/code, so path equality alone
-    would let a run write over them. And no destination may resolve onto its own
-    source. Both are checked before anything is created or removed.
+    would let a run write over them. And no destination may land on a production
+    registry once every symlink along it is followed - the per-agent worktree setup
+    symlinks each case study's ``run_log`` to the canonical one precisely so the
+    results source of truth is shared, which makes a symlinked destination the
+    normal case here rather than an exotic one. Both are checked before anything is
+    created or removed.
     """
     resolved = intermediates_dir.resolve()
     if any(part.name == "case_studies" for part in (resolved, *resolved.parents)):
@@ -77,8 +81,14 @@ def rejected_output_root(intermediates_dir: Path) -> str | None:
         )
     for cs_id in CASE_STUDY_IDS:
         src_db = (CODE_CS_DIR / cs_id / "run_log" / "registry.db").resolve()
-        if (resolved / cs_id / "run_log" / "registry.db") == src_db:
+        dst_db = (resolved / cs_id / "run_log" / "registry.db").resolve()
+        if dst_db == src_db:
             return f"{resolved} resolves onto the source registry at {src_db}"
+        if any(part.name == "case_studies" for part in dst_db.parents):
+            return (
+                f"{resolved}/{cs_id}/run_log resolves into a case_studies tree "
+                f"({dst_db}), whose registry this script unlinks before reading"
+            )
     return None
 
 

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -12,10 +12,12 @@ Sampling strategy:
 
 Usage:
     uv run python tests/sample_registry_for_tests.py
+    uv run python tests/sample_registry_for_tests.py --output ~/ml4t/test-data/intermediates
 
-Writes to: ~/ml4t/test-data/intermediates/{cs}/run_log/registry.db
+Writes to: <--output>/{cs}/run_log/registry.db
 """
 
+import argparse
 import contextlib
 import sqlite3
 from pathlib import Path
@@ -24,7 +26,7 @@ REPO_ROOT = Path(__file__).parent.parent
 CODE_CS_DIR = REPO_ROOT / "case_studies"
 
 TEST_DATA_ROOT = Path.home() / "ml4t" / "test-data"
-INTERMEDIATES_DIR = TEST_DATA_ROOT / "intermediates"
+DEFAULT_INTERMEDIATES_DIR = TEST_DATA_ROOT / "intermediates"
 
 CASE_STUDY_IDS = [
     "etfs",
@@ -53,13 +55,13 @@ def _copy_rows(src, dst, table: str, rows: list) -> int:
     return len(rows)
 
 
-def sample_registry(cs_id: str) -> dict:
+def sample_registry(cs_id: str, intermediates_dir: Path = DEFAULT_INTERMEDIATES_DIR) -> dict:
     """Sample from production registry into test intermediates. Returns stats."""
     src_db = CODE_CS_DIR / cs_id / "run_log" / "registry.db"
     if not src_db.exists():
         return {"status": "SKIP", "reason": "no source registry.db"}
 
-    dst_dir = INTERMEDIATES_DIR / cs_id / "run_log"
+    dst_dir = intermediates_dir / cs_id / "run_log"
     dst_dir.mkdir(parents=True, exist_ok=True)
     dst_db = dst_dir / "registry.db"
 
@@ -166,14 +168,27 @@ def _populate_sample_db(src, dst, dst_db) -> dict:
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_INTERMEDIATES_DIR,
+        help=(
+            "Fixture intermediates root to write (the test-data repo's "
+            "intermediates/ directory). Default: ~/ml4t/test-data/intermediates"
+        ),
+    )
+    args = parser.parse_args()
+    intermediates_dir = args.output.expanduser().resolve()
+
     print(f"Sampling registries from {CODE_CS_DIR}")
-    print(f"Writing to {INTERMEDIATES_DIR}")
+    print(f"Writing to {intermediates_dir}")
     print(f"Top {TOP_N_PER_GROUP} backtests per (family × stage) + all holdout\n")
 
     total_size = 0
     for cs_id in CASE_STUDY_IDS:
         print(f"--- {cs_id} ---")
-        stats = sample_registry(cs_id)
+        stats = sample_registry(cs_id, intermediates_dir)
         if stats["status"] != "OK":
             print(f"  {stats['status']}: {stats.get('reason', '')}")
             continue

--- a/tests/test_case_studies.py
+++ b/tests/test_case_studies.py
@@ -23,7 +23,13 @@ from pathlib import Path
 
 import pytest
 
-from tests.pm_helpers import current_test_tier, get_overrides, get_tier, run_notebook
+from tests.pm_helpers import (
+    current_test_tier,
+    get_overrides,
+    get_tier,
+    missing_required_env,
+    run_notebook,
+)
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -105,6 +111,10 @@ def test_case_study_pipeline(
     if overrides.get("skip"):
         reason = overrides.get("skip_reason", "marked skip in overrides")
         pytest.skip(f"Skipped: {reason}")
+
+    # Credentials the notebook cannot run without.
+    if absent := missing_required_env(overrides):
+        pytest.skip(f"Requires {', '.join(absent)} (unset in this environment)")
 
     # Check required imports (e.g., gensim, signatory, duckdb)
     requires = overrides.get("requires_import")

--- a/tests/test_chapter_notebooks.py
+++ b/tests/test_chapter_notebooks.py
@@ -29,6 +29,7 @@ from tests.pm_helpers import (
     current_test_tier,
     get_overrides,
     get_tier,
+    missing_required_env,
     run_notebook,
 )
 
@@ -77,6 +78,10 @@ def test_chapter_notebook(notebook_path, populated_data_dir, seeded_output_dir):
     # Skip if overrides say so (e.g., missing test data)
     if overrides.get("skip"):
         pytest.skip(f"Skipped: {overrides.get('skip_reason', 'marked skip in overrides')}")
+
+    # Credentials the notebook cannot run without (e.g. EDGAR_IDENTITY).
+    if absent := missing_required_env(overrides):
+        pytest.skip(f"Requires {', '.join(absent)} (unset in this environment)")
 
     # Check required imports (e.g., gensim, signatory, duckdb)
     requires = overrides.get("requires_import")

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -342,21 +342,26 @@ def test_13f_builder_rejects_a_source_missing_a_derived_feature(tmp_path: Path) 
         build_institutional_holdings_13f(source, tmp_path / "out")
 
 
-def _write_13f_source(holdings_dir: Path) -> pl.DataFrame:
+def _write_13f_source(holdings_dir: Path, drop_cik: str | None = None) -> pl.DataFrame:
     """Write a consistent three-artifact 13F source and return the holdings.
 
-    Two institutions filing two post-2023 quarters for three issuers: enough for
-    the producer to find a quarter both filed for, and a prior one to measure
+    Every institution the producer requests, filing two post-2023 quarters for
+    three issuers: one quarter to build the graph from and a prior one to measure
     ownership change against. The derived artifacts come from the producer itself,
-    so this source is consistent by construction and any test that perturbs it is
+    so the source is consistent by construction and a test that perturbs it is
     testing the check rather than the fixture.
+
+    ``drop_cik`` omits one institution from all three artifacts, which is the case
+    a rebuild keyed on the holdings' own CIKs cannot see.
     """
+    producer = _load_13f_producer()
+    ciks = [cik for _, cik in producer.INSTITUTIONS if cik != drop_cik]
     rows = []
     for report_date, filing_date in (
         (date(2024, 6, 30), date(2024, 8, 14)),
         (date(2024, 9, 30), date(2024, 11, 14)),
     ):
-        for cik, company in (("0001067983", "BERKSHIRE"), ("0001350694", "BRIDGEWATER")):
+        for cik in ciks:
             for index, (cusip, issuer) in enumerate(
                 (("037833100", "APPLE INC"), ("594918104", "MICROSOFT"), ("67066G104", "NVIDIA"))
             ):
@@ -366,22 +371,39 @@ def _write_13f_source(holdings_dir: Path) -> pl.DataFrame:
                         "accession_no": f"{cik}-{report_date:%Y%m%d}-{index}",
                         "issuer": issuer,
                         "cusip": cusip,
-                        "value_thousands": 1_000_000 * (index + 1) + int(cik[-1]),
+                        "value_thousands": 1_000_000 * (index + 1) + int(cik[-4:]),
                         "shares": 10_000 * (index + 1),
                         "put_call": "",
                         "report_date": report_date,
                         "filing_date": filing_date,
-                        "company_name": company,
+                        "company_name": f"INSTITUTION {cik}",
                     }
                 )
     holdings = pl.DataFrame(rows)
     holdings.write_parquet(holdings_dir / "institutional_holdings.parquet")
 
-    build = _load_13f_producer().build_features_and_matrix
-    features, edges, *_ = build(holdings, expected_ciks=holdings["cik"].unique().to_list())
+    features, edges, *_ = producer.build_features_and_matrix(holdings, expected_ciks=ciks)
     edges.write_parquet(holdings_dir / "institution_stock_edges.parquet")
     features.write_parquet(holdings_dir / "stock_features.parquet")
     return holdings
+
+
+def test_13f_builder_rejects_a_source_missing_a_requested_institution(tmp_path: Path) -> None:
+    """A consistent artifact set can still be short one institution.
+
+    22_rag/07 asks for all ten by CIK, so a holdings file that simply lacks one is
+    a coverage gap the graph reads as an absent manager rather than as a broken
+    fixture. Keyed on the holdings' own CIKs the rebuild would agree with itself
+    and pass.
+    """
+    source = tmp_path / "source"
+    holdings_dir = source / "equities" / "positioning" / "13f"
+    holdings_dir.mkdir(parents=True)
+    missing = _load_13f_producer().INSTITUTIONS[0][1]
+    _write_13f_source(holdings_dir, drop_cik=missing)
+
+    with pytest.raises(ValueError, match=rf"cover none of the filings of \['{missing}'\]"):
+        build_institutional_holdings_13f(source, tmp_path / "out")
 
 
 def test_13f_builder_rejects_derived_artifacts_the_holdings_do_not_produce(tmp_path: Path) -> None:

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -24,10 +24,66 @@ from tests.create_test_data import (
     write_manifest,
 )
 
+# The columns data/equities/positioning/13f_download.py writes, transcribed from
+# its select() and agg() calls rather than imported from create_test_data. Reading
+# them from _13F_REQUIRED_COLUMNS would make every test below agree with whatever
+# that constant happens to say, including an incomplete version of it.
+_PRODUCER_13F_SCHEMAS: dict[str, tuple[str, ...]] = {
+    "institutional_holdings.parquet": (
+        "cik",
+        "accession_no",
+        "issuer",
+        "cusip",
+        "value_thousands",
+        "shares",
+        "put_call",
+        "report_date",
+        "filing_date",
+        "company_name",
+    ),
+    "institution_stock_edges.parquet": (
+        "institution_id",
+        "stock_id",
+        "institution_name",
+        "stock_name",
+        "weight_value",
+        "weight_shares",
+        "report_date",
+        "timestamp",
+    ),
+    "stock_features.parquet": (
+        "cusip",
+        "issuer_name",
+        "n_inst_holders",
+        "total_inst_value_usd",
+        "avg_position_size_usd",
+        "position_size_std_usd",
+        "timestamp",
+        "ownership_hhi",
+        "inst_coverage_pct",
+        "position_cv",
+        "inst_value_change_usd",
+        "inst_pct_change",
+    ),
+}
+
 
 def ctd_13f_required_columns() -> dict[str, tuple[str, ...]]:
     """The canonical 13F schemas, so a test frame is built from one source."""
-    return _13F_REQUIRED_COLUMNS
+    return _PRODUCER_13F_SCHEMAS
+
+
+def test_13f_required_columns_cover_the_producer_schemas() -> None:
+    """A column the producer emits but the check omits is invisible until ch22 runs.
+
+    22_rag/07 rebuilds ``stock_features`` and compares it with ``assert_frame_equal``,
+    which checks the whole schema. A source artifact from an older producer
+    generation therefore has to be rejected on any missing column, not only on the
+    few a loader reads by name.
+    """
+    assert {name: set(columns) for name, columns in _13F_REQUIRED_COLUMNS.items()} == {
+        name: set(columns) for name, columns in _PRODUCER_13F_SCHEMAS.items()
+    }
 
 
 def _write_tensor(path: Path, dates: list[int], n_firms: int, seed: int) -> None:
@@ -265,6 +321,22 @@ def test_13f_builder_rejects_a_stale_derived_artifact(tmp_path: Path) -> None:
         frame.write_parquet(holdings_dir / filename)
 
     with pytest.raises(ValueError, match=r"stock_features\.parquet.*\['issuer_name'\]"):
+        build_institutional_holdings_13f(source, tmp_path / "out")
+
+
+def test_13f_builder_rejects_a_source_missing_a_derived_feature(tmp_path: Path) -> None:
+    """No consumer loads ``ownership_hhi`` by name, and ch22's parity check still needs it."""
+    source = tmp_path / "source"
+    holdings_dir = source / "equities" / "positioning" / "13f"
+    holdings_dir.mkdir(parents=True)
+
+    for filename, columns in ctd_13f_required_columns().items():
+        frame = pl.DataFrame({column: [0] for column in columns})
+        if filename == "stock_features.parquet":
+            frame = frame.drop("ownership_hhi")
+        frame.write_parquet(holdings_dir / filename)
+
+    with pytest.raises(ValueError, match=r"stock_features\.parquet.*\['ownership_hhi'\]"):
         build_institutional_holdings_13f(source, tmp_path / "out")
 
 

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -169,7 +169,7 @@ def test_manifest_records_sizes_and_preserves_unselected_entries(tmp_path: Path)
         name="firm_characteristics",
         description="test",
         build=lambda source, output: [],
-        subdir=Path("equities") / "firm_characteristics",
+        owns=(Path("equities") / "firm_characteristics",),
         budget={"max_entities": 200},
     )
     import tests.create_test_data as ctd

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -1,0 +1,192 @@
+"""Tests for the CI fixture subsampler in tests/create_test_data.py.
+
+The subsampler is the only thing standing between a schema change in production
+data and a CI fixture set that silently predates it, so the properties asserted
+here are the ones whose violation is invisible until a job goes red: that the
+canonical schema survives the reduction, that firm identity is preserved rather
+than re-derived per date, and that the manifest describes what was written.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+from tests.create_test_data import (
+    FIRM_CHAR_SPLITS,
+    Dataset,
+    _firm_char_tensor_dir,
+    build_firm_characteristics,
+    write_manifest,
+)
+
+
+def _write_tensor(path: Path, dates: list[int], n_firms: int, seed: int) -> None:
+    """Write a Char_*.npz in the published (date, firm, variable) layout.
+
+    -99.99 is the archive's missing marker; the converter drops those cells,
+    which is what makes firm observation counts differ.
+    """
+    rng = np.random.default_rng(seed)
+    variables = ["ret", "BEME", "AT"]
+    data = rng.normal(size=(len(dates), n_firms, len(variables)))
+    # Firm f is missing from the first f dates, so coverage strictly decreases
+    # with firm index and "most observed" has a deterministic answer.
+    for firm in range(n_firms):
+        data[:firm, firm, 0] = -99.99
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        path,
+        date=np.asarray(dates),
+        variable=np.asarray(variables),
+        data=data,
+    )
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> Path:
+    """A minimal production data root carrying the three characteristic tensors."""
+    char_dir = tmp_path / "equities" / "firm_characteristics" / "dl_asset_pricing" / "char"
+    _write_tensor(char_dir / "Char_train.npz", [19670131, 19670228, 19670331], 6, seed=0)
+    _write_tensor(char_dir / "Char_valid.npz", [19870130, 19870227], 5, seed=1)
+    _write_tensor(char_dir / "Char_test.npz", [19920131, 19920228], 5, seed=2)
+    return tmp_path
+
+
+def test_tensor_dir_accepts_the_manually_unzipped_layout(tmp_path: Path) -> None:
+    """A manual unzip leaves datasets/char/; download.py's extractor strips it."""
+    nested = (
+        tmp_path / "equities" / "firm_characteristics" / "dl_asset_pricing" / "datasets" / "char"
+    )
+    for _, filename, _ in FIRM_CHAR_SPLITS:
+        _write_tensor(nested / filename, [19670131], 2, seed=3)
+    assert _firm_char_tensor_dir(tmp_path) == nested
+
+
+def test_tensor_dir_reports_where_it_looked(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="datasets/char/"):
+        _firm_char_tensor_dir(tmp_path)
+
+
+def test_fixture_carries_the_canonical_schema(source: Path, tmp_path: Path) -> None:
+    """The loader rejects anything lacking symbol/timestamp/split - the exact gate
+    that took ch04, ch11-12 and cs-us_firm_characteristics red."""
+    output = tmp_path / "out"
+    build_firm_characteristics(source, output)
+
+    for split in ("all", "train", "valid", "test"):
+        path = (
+            output / "equities" / "firm_characteristics" / f"firm_characteristics_{split}.parquet"
+        )
+        assert path.exists(), f"{split} fixture missing"
+        frame = pl.read_parquet(path)
+        assert {"symbol", "timestamp", "split"}.issubset(frame.columns)
+        assert frame["timestamp"].dtype == pl.Date
+        assert frame["symbol"].dtype == pl.UInt32
+        # Legacy column names must not reappear alongside the canonical ones.
+        assert "date" not in frame.columns
+
+
+def test_all_is_the_concatenation_of_the_splits(source: Path, tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    build_firm_characteristics(source, output)
+    out_dir = output / "equities" / "firm_characteristics"
+
+    all_frame = pl.read_parquet(out_dir / "firm_characteristics_all.parquet")
+    parts = sum(
+        len(pl.read_parquet(out_dir / f"firm_characteristics_{split}.parquet"))
+        for split, _, _ in FIRM_CHAR_SPLITS
+    )
+    assert len(all_frame) == parts
+    assert set(all_frame["split"].unique()) == {"train", "valid", "test"}
+
+
+def test_symbol_namespaces_stay_disjoint_across_splits(source: Path, tmp_path: Path) -> None:
+    """The archive publishes no cross-split firm mapping, so a symbol that appears
+    in two splits would assert an identity the data does not support."""
+    output = tmp_path / "out"
+    build_firm_characteristics(source, output)
+    all_frame = pl.read_parquet(
+        output / "equities" / "firm_characteristics" / "firm_characteristics_all.parquet"
+    )
+
+    per_split = {
+        split: set(all_frame.filter(pl.col("split") == split)["symbol"].to_list())
+        for split in ("train", "valid", "test")
+    }
+    assert not per_split["train"] & per_split["valid"]
+    assert not per_split["train"] & per_split["test"]
+    assert not per_split["valid"] & per_split["test"]
+
+
+def test_subsampling_keeps_whole_firm_histories(source: Path, tmp_path: Path, monkeypatch) -> None:
+    """Keeping the N most-observed firms must not truncate their time series.
+
+    Subsampling per date instead would leave each retained firm with holes, and
+    every downstream lag, fold and cross-sectional rank would then be computed
+    over a cross-section that changes shape month to month.
+    """
+    monkeypatch.setattr("tests.create_test_data.FIRM_CHAR_MAX_ENTITIES", 2)
+    output = tmp_path / "out"
+    build_firm_characteristics(source, output)
+
+    train = pl.read_parquet(
+        output / "equities" / "firm_characteristics" / "firm_characteristics_train.parquet"
+    )
+    assert train["symbol"].n_unique() == 2
+    # Firms 0 and 1 are the most observed by construction (3 and 2 dates).
+    per_firm = train.group_by("symbol").len().sort("symbol")
+    assert per_firm["len"].to_list() == [3, 2]
+
+
+def test_subsampling_is_deterministic(source: Path, tmp_path: Path) -> None:
+    """Ties are broken by symbol, so a regenerated fixture is byte-comparable."""
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    build_firm_characteristics(source, first)
+    build_firm_characteristics(source, second)
+
+    for split in ("all", "train", "valid", "test"):
+        rel = Path("equities") / "firm_characteristics" / f"firm_characteristics_{split}.parquet"
+        assert pl.read_parquet(first / rel).equals(pl.read_parquet(second / rel))
+
+
+def test_manifest_records_sizes_and_preserves_unselected_entries(tmp_path: Path) -> None:
+    """A single --dataset run must not blank the rest of the manifest."""
+    output = tmp_path / "out"
+    output.mkdir()
+    (output / "manifest.json").write_text(
+        '{"version": "1", "subsets": {"etfs": {"max_symbols": 15}}, '
+        '"files": {"etfs/etf_universe.parquet": {"size_bytes": 1, "size_mb": 0.0}}}'
+    )
+    target = output / "equities" / "firm_characteristics"
+    target.mkdir(parents=True)
+    written = target / "firm_characteristics_all.parquet"
+    pl.DataFrame({"symbol": [1]}).write_parquet(written)
+
+    dataset = Dataset(
+        name="firm_characteristics",
+        description="test",
+        build=lambda source, output: [],
+        subdir=Path("equities") / "firm_characteristics",
+        budget={"max_entities": 200},
+    )
+    import tests.create_test_data as ctd
+
+    monkeypatched = dict(ctd.DATASETS_BY_NAME, firm_characteristics=dataset)
+    original = ctd.DATASETS_BY_NAME
+    ctd.DATASETS_BY_NAME = monkeypatched
+    try:
+        manifest_path = write_manifest(output, {"firm_characteristics": [written]})
+    finally:
+        ctd.DATASETS_BY_NAME = original
+
+    import json
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["subsets"]["etfs"] == {"max_symbols": 15}, "unselected subset was dropped"
+    assert manifest["files"]["etfs/etf_universe.parquet"]["size_bytes"] == 1
+    entry = manifest["files"]["equities/firm_characteristics/firm_characteristics_all.parquet"]
+    assert entry["size_bytes"] == written.stat().st_size
+    assert manifest["subsets"]["firm_characteristics"]["max_entities"] == 200

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -8,6 +8,7 @@ than re-derived per date, and that the manifest describes what was written.
 """
 
 import json
+from datetime import date
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +20,7 @@ from tests.create_test_data import (
     FIRM_CHAR_SPLITS,
     Dataset,
     _firm_char_tensor_dir,
+    _load_13f_producer,
     build_firm_characteristics,
     build_institutional_holdings_13f,
     write_manifest,
@@ -340,15 +342,79 @@ def test_13f_builder_rejects_a_source_missing_a_derived_feature(tmp_path: Path) 
         build_institutional_holdings_13f(source, tmp_path / "out")
 
 
+def _write_13f_source(holdings_dir: Path) -> pl.DataFrame:
+    """Write a consistent three-artifact 13F source and return the holdings.
+
+    Two institutions filing two post-2023 quarters for three issuers: enough for
+    the producer to find a quarter both filed for, and a prior one to measure
+    ownership change against. The derived artifacts come from the producer itself,
+    so this source is consistent by construction and any test that perturbs it is
+    testing the check rather than the fixture.
+    """
+    rows = []
+    for report_date, filing_date in (
+        (date(2024, 6, 30), date(2024, 8, 14)),
+        (date(2024, 9, 30), date(2024, 11, 14)),
+    ):
+        for cik, company in (("0001067983", "BERKSHIRE"), ("0001350694", "BRIDGEWATER")):
+            for index, (cusip, issuer) in enumerate(
+                (("037833100", "APPLE INC"), ("594918104", "MICROSOFT"), ("67066G104", "NVIDIA"))
+            ):
+                rows.append(
+                    {
+                        "cik": cik,
+                        "accession_no": f"{cik}-{report_date:%Y%m%d}-{index}",
+                        "issuer": issuer,
+                        "cusip": cusip,
+                        "value_thousands": 1_000_000 * (index + 1) + int(cik[-1]),
+                        "shares": 10_000 * (index + 1),
+                        "put_call": "",
+                        "report_date": report_date,
+                        "filing_date": filing_date,
+                        "company_name": company,
+                    }
+                )
+    holdings = pl.DataFrame(rows)
+    holdings.write_parquet(holdings_dir / "institutional_holdings.parquet")
+
+    build = _load_13f_producer().build_features_and_matrix
+    features, edges, *_ = build(holdings, expected_ciks=holdings["cik"].unique().to_list())
+    edges.write_parquet(holdings_dir / "institution_stock_edges.parquet")
+    features.write_parquet(holdings_dir / "stock_features.parquet")
+    return holdings
+
+
+def test_13f_builder_rejects_derived_artifacts_the_holdings_do_not_produce(tmp_path: Path) -> None:
+    """A complete column set is not the same artifact as the current producer's.
+
+    22_rag/07 rebuilds edges and features and compares whole frames, so a source
+    whose derived files carry stale values passes every name check here and fails
+    the notebook instead.
+    """
+    source = tmp_path / "source"
+    holdings_dir = source / "equities" / "positioning" / "13f"
+    holdings_dir.mkdir(parents=True)
+    _write_13f_source(holdings_dir)
+
+    features_path = holdings_dir / "stock_features.parquet"
+    pl.read_parquet(features_path).with_columns(
+        pl.col("total_inst_value_usd") * 1000
+    ).write_parquet(features_path)
+
+    with pytest.raises(ValueError, match=r"stock_features\.parquet is not what the current"):
+        build_institutional_holdings_13f(source, tmp_path / "out")
+
+
 def test_13f_builder_copies_a_complete_artifact_set(tmp_path: Path) -> None:
     source = tmp_path / "source"
     holdings_dir = source / "equities" / "positioning" / "13f"
     holdings_dir.mkdir(parents=True)
-    for filename, columns in ctd_13f_required_columns().items():
-        pl.DataFrame({column: [0] for column in columns}).write_parquet(holdings_dir / filename)
+    _write_13f_source(holdings_dir)
 
     output = tmp_path / "out"
     written = build_institutional_holdings_13f(source, output)
 
     assert {path.name for path in written} == set(ctd_13f_required_columns())
     assert all(path.exists() for path in written)
+    for path in written:
+        assert set(ctd_13f_required_columns()[path.name]).issubset(pl.read_parquet(path).columns)

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -7,6 +7,7 @@ canonical schema survives the reduction, that firm identity is preserved rather
 than re-derived per date, and that the manifest describes what was written.
 """
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -14,12 +15,19 @@ import polars as pl
 import pytest
 
 from tests.create_test_data import (
+    _13F_REQUIRED_COLUMNS,
     FIRM_CHAR_SPLITS,
     Dataset,
     _firm_char_tensor_dir,
     build_firm_characteristics,
+    build_institutional_holdings_13f,
     write_manifest,
 )
+
+
+def ctd_13f_required_columns() -> dict[str, tuple[str, ...]]:
+    """The canonical 13F schemas, so a test frame is built from one source."""
+    return _13F_REQUIRED_COLUMNS
 
 
 def _write_tensor(path: Path, dates: list[int], n_firms: int, seed: int) -> None:
@@ -182,11 +190,93 @@ def test_manifest_records_sizes_and_preserves_unselected_entries(tmp_path: Path)
     finally:
         ctd.DATASETS_BY_NAME = original
 
-    import json
-
     manifest = json.loads(manifest_path.read_text())
     assert manifest["subsets"]["etfs"] == {"max_symbols": 15}, "unselected subset was dropped"
     assert manifest["files"]["etfs/etf_universe.parquet"]["size_bytes"] == 1
     entry = manifest["files"]["equities/firm_characteristics/firm_characteristics_all.parquet"]
     assert entry["size_bytes"] == written.stat().st_size
     assert manifest["subsets"]["firm_characteristics"]["max_entities"] == 200
+
+
+def test_manifest_drops_entries_the_rebuild_no_longer_produces(tmp_path: Path) -> None:
+    """A renamed or discontinued artifact must not stay listed forever."""
+    output = tmp_path / "out"
+    target = output / "equities" / "firm_characteristics"
+    target.mkdir(parents=True)
+    (output / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1",
+                "subsets": {},
+                "files": {
+                    # Under the dataset's owns path, but not produced this run.
+                    "equities/firm_characteristics/firm_characteristics_46.parquet": {
+                        "size_bytes": 9,
+                        "size_mb": 0.0,
+                    },
+                    # Outside it — belongs to another dataset, must survive.
+                    "equities/positioning/13f/stock_features.parquet": {
+                        "size_bytes": 7,
+                        "size_mb": 0.0,
+                    },
+                },
+            }
+        )
+    )
+    written = target / "firm_characteristics_all.parquet"
+    pl.DataFrame({"symbol": [1]}).write_parquet(written)
+
+    dataset = Dataset(
+        name="firm_characteristics",
+        description="test",
+        build=lambda source, output: [],
+        owns=(Path("equities") / "firm_characteristics",),
+    )
+    import tests.create_test_data as ctd
+
+    original = ctd.DATASETS_BY_NAME
+    ctd.DATASETS_BY_NAME = dict(original, firm_characteristics=dataset)
+    try:
+        manifest_path = write_manifest(output, {"firm_characteristics": [written]})
+    finally:
+        ctd.DATASETS_BY_NAME = original
+
+    files = json.loads(manifest_path.read_text())["files"]
+    assert "equities/firm_characteristics/firm_characteristics_46.parquet" not in files
+    assert "equities/firm_characteristics/firm_characteristics_all.parquet" in files
+    assert files["equities/positioning/13f/stock_features.parquet"]["size_bytes"] == 7
+
+
+def test_13f_builder_rejects_a_stale_derived_artifact(tmp_path: Path) -> None:
+    """Validating the holdings alone lets a stale edges or features file through.
+
+    ``stock_features`` is the case that reached readers: an older producer spelled
+    its issuer column ``issuer``, and 10_text_feature_engineering/02 reads
+    ``issuer_name``.
+    """
+    source = tmp_path / "source"
+    holdings_dir = source / "equities" / "positioning" / "13f"
+    holdings_dir.mkdir(parents=True)
+
+    for filename, columns in ctd_13f_required_columns().items():
+        frame = pl.DataFrame({column: [0] for column in columns})
+        if filename == "stock_features.parquet":
+            frame = frame.drop("issuer_name").with_columns(pl.lit("ACME").alias("issuer"))
+        frame.write_parquet(holdings_dir / filename)
+
+    with pytest.raises(ValueError, match=r"stock_features\.parquet.*\['issuer_name'\]"):
+        build_institutional_holdings_13f(source, tmp_path / "out")
+
+
+def test_13f_builder_copies_a_complete_artifact_set(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    holdings_dir = source / "equities" / "positioning" / "13f"
+    holdings_dir.mkdir(parents=True)
+    for filename, columns in ctd_13f_required_columns().items():
+        pl.DataFrame({column: [0] for column in columns}).write_parquet(holdings_dir / filename)
+
+    output = tmp_path / "out"
+    written = build_institutional_holdings_13f(source, output)
+
+    assert {path.name for path in written} == set(ctd_13f_required_columns())
+    assert all(path.exists() for path in written)

--- a/tests/test_create_test_data.py
+++ b/tests/test_create_test_data.py
@@ -23,6 +23,7 @@ from tests.create_test_data import (
     _load_13f_producer,
     build_firm_characteristics,
     build_institutional_holdings_13f,
+    roots_overlap,
     write_manifest,
 )
 
@@ -425,6 +426,16 @@ def test_13f_builder_rejects_derived_artifacts_the_holdings_do_not_produce(tmp_p
 
     with pytest.raises(ValueError, match=r"stock_features\.parquet is not what the current"):
         build_institutional_holdings_13f(source, tmp_path / "out")
+
+
+def test_overlapping_roots_are_rejected(tmp_path: Path) -> None:
+    """--clean plus one root would delete the production data it then reads."""
+    root = tmp_path / "data"
+    nested = root / "fixtures"
+    assert roots_overlap(root, root) is not None
+    assert roots_overlap(root, nested) is not None
+    assert roots_overlap(nested, root) is not None
+    assert roots_overlap(root, tmp_path / "elsewhere") is None
 
 
 def test_13f_builder_copies_a_complete_artifact_set(tmp_path: Path) -> None:

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -149,15 +149,17 @@ def test_credential_gated_notebooks_declare_requires_env_not_skip() -> None:
     ``skip: true`` is unconditional and is checked after tier routing, so a
     notebook marked that way stays unexecuted even in weekly-external.yml, which
     exists to supply exactly these credentials.
+
+    Selection is by ``requires_env`` rather than by what ``skip_reason`` happens to
+    say: an entry carrying both keys is hard-skipped whatever reason it gives, and
+    matching on the reason text would let it through under any other wording.
     """
     overrides = yaml.safe_load((Path(__file__).parent / "overrides.yaml").read_text())
 
-    hard_skipped_on_a_credential = {
+    hard_skipped_despite_a_gate = {
         key
         for key, value in overrides.items()
-        if isinstance(value, dict)
-        and value.get("skip")
-        and "EDGAR_IDENTITY" in str(value.get("skip_reason", ""))
+        if isinstance(value, dict) and value.get("requires_env") and value.get("skip")
     }
 
-    assert hard_skipped_on_a_credential == set()
+    assert hard_skipped_despite_a_gate == set()

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tests.pm_helpers import (
     RECORD_REPLAY,
@@ -13,22 +14,26 @@ from tests.pm_helpers import (
     get_record_mode,
     get_reruns,
     get_tier,
+    missing_required_env,
 )
 
 
 def test_collect_chapter_notebooks_keeps_real_notebooks_and_skips_helpers() -> None:
     notebooks = {path.as_posix() for path in collect_chapter_notebooks(Path("."), range(1, 28))}
 
-    assert "06_strategy_definition/02_case_study_overview.py" in notebooks
+    assert "06_strategy_definition/03_case_study_overview.py" in notebooks
     assert "08_financial_features/case_study_feature_summary.py" in notebooks
     assert "11_ml_pipeline/08_ml_backtest_intro.py" in notebooks
     assert "16_strategy_simulation/01_backtest_first_principles.py" in notebooks
     assert "21_rl_execution_hedging/07_backtest_with_impact.py" in notebooks
 
-    assert "03_market_microstructure/filter_itch_symbol.py" not in notebooks
-    assert "03_market_microstructure/lob_utils.py" not in notebooks
-    assert "03_market_microstructure/lob_generator.py" not in notebooks
-    assert "13_dl_time_series/dl_utils.py" not in notebooks
+    # Helper modules that live beside the notebooks. Each is a file that exists
+    # today, so the exclusion is actually exercised: asserting a deleted path is
+    # absent proves nothing.
+    assert "03_market_microstructure/limit_orderbook.py" not in notebooks
+    assert "13_dl_time_series/dl_sequences.py" not in notebooks
+    assert "21_rl_execution_hedging/rl_environments.py" not in notebooks
+    assert "16_strategy_simulation/_etf_baseline.py" not in notebooks
 
 
 # ---------------------------------------------------------------------------
@@ -96,3 +101,63 @@ def test_get_record_mode_accepts_rewrite() -> None:
 def test_get_record_mode_rejects_invalid() -> None:
     with pytest.raises(ValueError, match="Invalid record_mode"):
         get_record_mode({"record_mode": "none"})
+
+
+# ---------------------------------------------------------------------------
+# requires_env — credential gating
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_env_empty_without_declaration() -> None:
+    assert missing_required_env({}) == []
+
+
+def test_missing_required_env_reports_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ML4T_FAKE_KEY", raising=False)
+
+    assert missing_required_env({"requires_env": "ML4T_FAKE_KEY"}) == ["ML4T_FAKE_KEY"]
+
+
+def test_missing_required_env_treats_blank_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset GitHub secret interpolates to the empty string, not to nothing."""
+    monkeypatch.setenv("ML4T_FAKE_KEY", "   ")
+
+    assert missing_required_env({"requires_env": "ML4T_FAKE_KEY"}) == ["ML4T_FAKE_KEY"]
+
+
+def test_missing_required_env_empty_when_all_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ML4T_FAKE_KEY", "Jane Doe jane@example.org")
+    monkeypatch.setenv("ML4T_OTHER_KEY", "token")
+
+    assert missing_required_env({"requires_env": ["ML4T_FAKE_KEY", "ML4T_OTHER_KEY"]}) == []
+
+
+def test_missing_required_env_reports_only_the_absent_ones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ML4T_FAKE_KEY", "present")
+    monkeypatch.delenv("ML4T_OTHER_KEY", raising=False)
+
+    assert missing_required_env({"requires_env": ["ML4T_FAKE_KEY", "ML4T_OTHER_KEY"]}) == [
+        "ML4T_OTHER_KEY"
+    ]
+
+
+def test_credential_gated_notebooks_declare_requires_env_not_skip() -> None:
+    """A notebook blocked only on a credential must be gated, never hard-skipped.
+
+    ``skip: true`` is unconditional and is checked after tier routing, so a
+    notebook marked that way stays unexecuted even in weekly-external.yml, which
+    exists to supply exactly these credentials.
+    """
+    overrides = yaml.safe_load((Path(__file__).parent / "overrides.yaml").read_text())
+
+    hard_skipped_on_a_credential = {
+        key
+        for key, value in overrides.items()
+        if isinstance(value, dict)
+        and value.get("skip")
+        and "EDGAR_IDENTITY" in str(value.get("skip_reason", ""))
+    }
+
+    assert hard_skipped_on_a_credential == set()

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -34,6 +34,24 @@ def test_a_root_resolving_onto_a_source_registry_is_rejected() -> None:
     assert rejected_output_root(CODE_CS_DIR.parent / "case_studies") is not None
 
 
+def test_a_symlinked_destination_is_rejected(tmp_path: Path) -> None:
+    """The worktree setup symlinks each case study's run_log to the canonical one, so
+    a destination that only looks separate is the normal case, not an exotic one."""
+    root = tmp_path / "intermediates"
+    (root / "etfs").mkdir(parents=True)
+    (root / "etfs" / "run_log").symlink_to(CODE_CS_DIR / "etfs" / "run_log")
+
+    assert rejected_output_root(root) is not None
+
+
+def test_a_symlinked_case_study_directory_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "intermediates"
+    root.mkdir(parents=True)
+    (root / "etfs").symlink_to(CODE_CS_DIR / "etfs")
+
+    assert rejected_output_root(root) is not None
+
+
 def test_every_case_study_is_covered_by_the_check(tmp_path: Path) -> None:
     """The guard iterates CASE_STUDY_IDS; an empty list would make it vacuous."""
     assert len(CASE_STUDY_IDS) == 9

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -1,0 +1,40 @@
+"""Tests for the registry sampler's output-root guard.
+
+Step 3 of the regeneration path unlinks each destination registry before opening
+its source, and a production registry.db is 43-180 MB and gitignored. A wrong
+--output therefore destroys the results source of truth with nothing to restore it
+from, which is the one failure in this path that cannot be undone by re-running it.
+"""
+
+from pathlib import Path
+
+from tests.sample_registry_for_tests import (
+    CASE_STUDY_IDS,
+    CODE_CS_DIR,
+    DEFAULT_INTERMEDIATES_DIR,
+    rejected_output_root,
+)
+
+
+def test_the_intended_output_root_is_accepted() -> None:
+    assert rejected_output_root(DEFAULT_INTERMEDIATES_DIR) is None
+
+
+def test_a_case_studies_tree_is_rejected() -> None:
+    """Named-directory rule, not path equality: in a worktree CODE_CS_DIR is the
+    worktree's own tree while the canonical registries live in ~/ml4t/code."""
+    assert rejected_output_root(CODE_CS_DIR) is not None
+    assert rejected_output_root(Path.home() / "ml4t" / "code" / "case_studies") is not None
+    assert rejected_output_root(CODE_CS_DIR / "etfs") is not None
+
+
+def test_a_root_resolving_onto_a_source_registry_is_rejected() -> None:
+    """The destination for cs_id is <root>/<cs_id>/run_log/registry.db, so a root one
+    level above a case-study tree collides with the source even under another name."""
+    assert rejected_output_root(CODE_CS_DIR.parent / "case_studies") is not None
+
+
+def test_every_case_study_is_covered_by_the_check(tmp_path: Path) -> None:
+    """The guard iterates CASE_STUDY_IDS; an empty list would make it vacuous."""
+    assert len(CASE_STUDY_IDS) == 9
+    assert rejected_output_root(tmp_path) is None


### PR DESCRIPTION
Restores the three-step path that regenerates the CI test fixtures. `tests/create_test_data.py`
was missing from the repo, so the path had been unrunnable; the fixtures in CI could be consumed
but not rebuilt.

## What is here

- `tests/create_test_data.py` (new) builds the fixture datasets, including the 13F holdings
  fixture, which it validates by importing the production producer
  (`data/equities/positioning/13f_download.py`) and rebuilding edges (24,672 rows) and stock
  features (7,998 rows) byte-equal under `assert_frame_equal`, keyed on the producer's
  `INSTITUTIONS` CIK set. A producer change that breaks that equality fails the builder before it
  copies anything.
- `tests/sample_registry_for_tests.py` gains `--output` and refuses a destination that resolves
  (through symlinks) inside a case-studies tree, where it would unlink a gitignored production
  registry. It also exits 1 rather than 0 when the registry it was asked to refresh was not
  refreshed.
- `tests/generate_test_data.sh` passes `--clean` at step 1 and fails step 3 on an unrefreshed
  registry.
- `tests/overrides.yaml` corrections: the stochastic-volatility sampler is no longer reduced to
  2x100 draws against an ESS>=400 gate, `SYMBOLS` replaces the nonexistent `TICKERS` key, and the
  TSMixer lookback is 22 (the model floor) rather than 24.
- Credential-dependent notebooks gate on `requires_env` rather than a blanket `skip: true`, so the
  three EDGAR notebooks execute in `weekly-external.yml` now that `EDGAR_IDENTITY` is set.
- `requests` added to the minimal `test-unit` dependency set. `create_test_data.py` imports the
  13F producer, which imports `requests` at module scope. No network call is made; dropping it
  takes the job red.

## Tests

`tests/test_create_test_data.py` (new, schemas transcribed from the producers),
`tests/test_sample_registry_for_tests.py` (new, 6 guard tests including the destructive
invocations run for real against a live registry), and additions to `tests/test_pm_helpers.py`.
41 tests pass; `ruff check` and `ruff format` clean.

## Known gaps, filed rather than fixed

The path declares 2 of the fixture repo's datasets; it copies registry rows without the artifact
directories their hashes address; `causal_runs`, `cohort_metrics` and `backtest_paired_metrics`
stay schema-only; a CI time-budget skip can silence cme_futures stages 04-08 during generation
with exit 0; and the nasdaq/etfs fixture universe is selected differently by producer and
consumer with no tie break. All are fixture-path only and move no published number.
