### PR TITLE
Keep the local review-agent config out of the reader-facing repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,5 +197,6 @@ case_studies/*/catalog/*.json
 !24_autonomous_agents/forecast_traces/01_react_reasoning_20260615T191047Z_04eb6e7c603d.json
 !24_autonomous_agents/forecast_traces/09_evaluation_and_governance_20260615T191431Z_d5030378899c.json
 
-# roborev snapshots
+# roborev snapshots and the local review-agent config
 /.roborev/
+/.roborev.toml

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,4 +1,0 @@
-agent = "codex"
-review_min_severity = "low"
-post_commit_review = "commit"
-auto_close_passing_reviews = true


### PR DESCRIPTION
`.roborev.toml` configures roborev, the code-review agent used while maintaining this
book. It arrived in the Chapters 11-27 release commit rather than by decision, and it
means nothing to someone who clones the repository: it names a review agent, a severity
floor, and a post-commit trigger for a tool they do not run.

Untracked and added to `.gitignore` beside the existing `/.roborev/` rule. The file
stays on disk where it is used, and is linked into each working copy from the
maintenance workspace.

No functional change to anything in the repository.