### PR TITLE
Pin tsmixer test symbols that exist in the folds they are scored on

### DIFF
--- a/case_studies/utils/cv_results.py
+++ b/case_studies/utils/cv_results.py
@@ -72,7 +72,7 @@ def assemble_cv_result(
 
     eligible = curve_df.filter(pl.col("ic_mean").is_finite())
     full_coverage_days: float | None = None
-    if require_full_coverage:
+    if require_full_coverage and not eligible.is_empty():
         finite_days = eligible.filter(pl.col("ic_n_days").is_finite())
         if finite_days.height == eligible.height:
             full_coverage_days = float(cast(int | float, finite_days["ic_n_days"].max()))
@@ -84,7 +84,14 @@ def assemble_cv_result(
             )
 
     if eligible.is_empty():
-        raise ValueError("No finite, full-coverage checkpoint is available for selection.")
+        # Report the scored-day counts: ic_n_days == 0 for every checkpoint means no
+        # decision date reached the cross-sectional IC min_obs threshold, which is a
+        # universe-too-small problem rather than a training failure.
+        scored = curve_df.select("config", "epoch", "ic_mean", "ic_n_days").to_dicts()
+        raise ValueError(
+            "No finite, full-coverage checkpoint is available for selection. "
+            f"Considered {len(scored)} checkpoint(s): {scored}"
+        )
 
     metadata = metadata or {}
     grid: list[dict[str, Any]] = []

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2176,11 +2176,19 @@ case_studies/us_equities_panel/11_dl_tsmixer:
   # The default MAX_SYMBOLS top-by-history selection picks production symbols
   # absent from the sampled raw panel; SYMBOLS overrides it. Sibling lstm/nlinear
   # use a non-Darts path and don't need this.
+  #
+  # Every pinned symbol must additionally be gap-free across the whole MAX_FOLDS
+  # span and cover both validation windows: cross_sectional_ic uses min_obs=5, so
+  # a symbol missing from a date drops that date, and a whitelist of exactly five
+  # scores zero days as soon as one drops out. AMD was pinned here and has no rows
+  # at all in 2014 or 2015 - both test validation windows - which left four symbols
+  # per date, ic_n_days=0 and a NaN IC for every checkpoint. Eight symbols keeps
+  # three spare above min_obs.
   parameters:
     BATCH_SIZE: 32
     LOOKBACK: 5
     MAX_FOLDS: 2
-    SYMBOLS: [AAPL, AMD, AIG, AMAT, BAC]
+    SYMBOLS: [AIG, AMAT, C, CSCO, GE, INTC, JPM, MSFT]
     N_EPOCHS: 1
   timeout: 600
 case_studies/us_equities_panel/12_dl_weekly:


### PR DESCRIPTION
`cs-us_equities_panel` had exactly one failing notebook, `11_dl_tsmixer`, so this turns the job green.

## What it was

The failure surfaced as `TypeError: float() argument must be a string or a real number, not 'NoneType'` at cell 11, naming neither the cause nor the file.

The test whitelist pinned **AMD**, which has no rows at all in 2014 or 2015 - exactly the two validation windows the test uses (`MAX_FOLDS: 2` selects folds with val 2015 and val 2014). AMD traded below $5 for most of 2012-2016 and drops out of the universe there, so this pin never worked; it is not a new regression.

The chain: four of the five pinned symbols reached each date -> `cross_sectional_ic` uses `min_obs=5` -> every one of the 503 dates was dropped -> `ic_n_days=0`, `ic_mean=NaN` for the only checkpoint -> the eligible-checkpoint set was empty -> `finite_days["ic_n_days"].max()` returned `None` -> `float(None)` raised.

## What changed

**`tests/overrides.yaml`** - replaces the five pinned symbols with eight verified gap-free across the whole `MAX_FOLDS` span and full-coverage in both validation windows, chosen from the 24 that qualify. The whitelist itself is still needed (Darts joins a horizon-aware base target from the reduced raw panel, which the default `MAX_SYMBOLS` selection misses); only its membership changes. Eight leaves three spare above `min_obs`, so a single dropout no longer zeroes the metric.

**`case_studies/utils/cv_results.py`** - `assemble_cv_result` already had the correct error for this state ("No finite, full-coverage checkpoint is available for selection") and never reached it, because the coverage narrowing ran on an empty candidate set first. Guards that narrowing and reports the per-checkpoint scored-day counts, so `ic_n_days=0` is visible in the message.

## Verification

Run in `ml4t/ml4t:latest` against the CI fixtures, same invocation as the workflow:

| Job | Before | After |
|---|---|---|
| `cs-us_equities_panel` | 1 failed, 19 passed, 2 skipped | **20 passed, 2 skipped** |
| `cs-cme_futures` | 17 passed, 2 skipped | 17 passed, 2 skipped |

`cs-cme_futures` is included because `cv_results.py` is shared by every DL notebook in every case study; it is the one case-study job green on `main`, so it is the regression guard.

`tests/overrides.yaml` is also touched by #410 (merged) and `fix/py312-bsts-kernel`, on different notebook keys.