### PR TITLE
Mark the us_firm GPU notebooks GPU-only and skip the cache-only IPCA replay

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2260,6 +2260,12 @@ case_studies/us_firm_characteristics/06_gbm:
     NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/us_firm_characteristics/07_tabular_dl:
+  # setup.yaml pins modeling.tabular_dl.device: cuda, and resolve_torch_device
+  # refuses to silently downgrade an explicit device. So this notebook cannot run
+  # on the CPU runner, and running it there is what the GPU-first rule forbids.
+  # Sibling us_equities_panel/08_tabular_dl passes on CPU only because that case
+  # study pins no tabular_dl device.
+  gpu: true
   parameters:
     BATCH_SIZE: 32
     MAX_FOLDS: 2
@@ -2272,6 +2278,38 @@ case_studies/us_firm_characteristics/08_latent_factors:
     FORCE_RETRAIN: true
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
+    N_EPOCHS: 2
+    N_FACTORS: 2
+  timeout: 300
+# 08a and 08b are the split successors of 08_latent_factors above, and the entry
+# never followed the split: neither had one, so both ran unreduced and unmarked and
+# died on the latent-factor CUDA guard. They need different treatment.
+#
+# 08a_ipca is NOT a GPU notebook. Its own preamble records that IPCA has no GPU
+# implementation and the production fit used four bounded CPU workers; the notebook
+# imports no Torch. It only demanded CUDA because load_case_study_context builds one
+# runtime for the whole latent-factor family, takes no device argument, and the
+# family is configured cuda for the Torch models (cae/sdf/sae).
+#
+# It cannot pass here on either device: it is a publication-replay notebook that
+# patches a fitting sentinel over the model runner and asserts zero fit calls, so it
+# needs the production registry's cached IPCA predictions. The trimmed fixture has
+# none, and reduced MAX_SYMBOLS/MAX_FOLDS would miss the cache key anyway. Verified
+# both ways - forced to CPU and on a 3090 it fails identically at cell 6 with "IPCA
+# fitting is forbidden during sign-off". So it skips for the same reason as 08c/08d.
+case_studies/us_firm_characteristics/08a_ipca:
+  skip: true
+  skip_reason: 'Cache-only publication replay: patches a fitting sentinel and asserts zero fit calls, so it requires the production registry IPCA predictions absent from the trimmed test-data. Not GPU-related - IPCA has no GPU implementation. Needs a full fixture rebuild.'
+# 08b is genuinely GPU: a Torch conditional autoencoder that trains, and its chapter
+# counterpart 14_latent_factors/06_conditional_autoencoder is already gpu: true.
+# Verified passing on a 3090 with these parameters.
+case_studies/us_firm_characteristics/08b_conditional_autoencoder:
+  gpu: true
+  parameters:
+    FORCE_RETRAIN: true
+    MAX_FOLDS: 2
+    MAX_SYMBOLS: 5
+    MAX_VARIANT_LABELS: 0
     N_EPOCHS: 2
     N_FACTORS: 2
   timeout: 300


### PR DESCRIPTION
Turns `cs-us_firm_characteristics` green. All three of its failures were one cause.

## What it was

`07_tabular_dl`, `08a_ipca` and `08b_conditional_autoencoder` all died on a CUDA guard. Their production device is declared cuda in `setup.yaml` (`modeling.tabular_dl.device`, `modeling.latent_factors.device`), and `resolve_torch_device` / the latent-factor bridge deliberately refuse to silently downgrade an explicit device. The CI runner has no GPU.

Running them on CPU is what the GPU-first rule forbids, and the repo already has the right mechanism: `gpu: true`, which the harness (`tests/test_case_studies.py:129`) turns into a skip when no CUDA device is visible. 43 notebooks already carry it, including `14_latent_factors/06_conditional_autoencoder`, the chapter counterpart of 08b. The defect is that the override table never got the marker.

`08a_ipca` and `08b_conditional_autoencoder` are the split successors of `08_latent_factors` and had **no override entry at all**, so they ran unreduced as well.

## What changed

They need different treatment, which is the substance of this PR:

**`07_tabular_dl`** and **`08b_conditional_autoencoder`** are genuinely GPU (TabM; a Torch conditional autoencoder that trains). Both get `gpu: true`; 08b also gets the reduced parameters it never had.

**`08a_ipca` is not a GPU notebook**, and marking it one would have been wrong. Its own preamble records that *IPCA has no GPU implementation* and the production fit used four bounded CPU workers; it imports no Torch. It demanded CUDA only because `load_case_study_context` builds one runtime for the whole latent-factor family and takes no device argument, so the family's cuda setting (there for cae/sdf/sae) applied to it.

It also cannot pass on **either** device: it patches a fitting sentinel over the model runner and asserts zero fit calls, so it needs the production registry's cached IPCA predictions, which the trimmed fixture does not carry. Forced to CPU and run on a 3090 it fails identically at cell 6 with `RuntimeError: IPCA fitting is forbidden during sign-off`. So it skips for the same reason as siblings `08c`/`08d`, with that reason recorded rather than inherited.

## Verification

In `ml4t/ml4t:latest` against the CI fixtures.

| Run | Result |
|---|---|
| `cs-us_firm_characteristics`, CPU, as CI runs it | **12 passed, 7 skipped, exit 0** (was 3 failed, 12 passed, 4 skipped) |
| `07_tabular_dl` + `08b_conditional_autoencoder`, `--gpus all` on an RTX 3090 | **2 passed** |

The GPU run is the point of the second row: it shows the two new `gpu: true` markers are not hiding a broken notebook, and that the parameters set here actually work.

## What this does not fix

Three notebooks move from failing to **skipped**, not to passing. CI has no GPU runner, so these and the other 43 GPU-marked notebooks never execute there. That gap is real and this change cannot close it - filed as `issues/2026-07-27-no-gpu-runner-leaves-46-notebooks-unexercised-in-ci.md` in the agents repo, which also notes that `08_latent_factors`'s existing override passes five parameters its notebook does not declare, invisible for exactly this reason.

Touches only `tests/overrides.yaml`, on us_firm keys. #410 (merged), #414 and `fix/py312-bsts-kernel` touch other keys in the same file.