### PR TITLE
Excuse a bounded warm-up prefix at the start of a train window (turns ch14-15 green)

### DIFF
--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -414,6 +414,72 @@ def test_temporal_fold_metadata_remap_restores_coverage(backward_temporal_fixtur
     assert remapped["value"].sort().to_list() == values_before
 
 
+@pytest.fixture
+def warmup_temporal_fixture() -> tuple[pl.DataFrame, list[dict]]:
+    """One fold whose artifact can be trimmed to simulate a burn-in prefix."""
+    dates = pd.date_range("2018-01-01", "2020-12-31", freq="B")
+    dataset = pl.DataFrame({"timestamp": dates, "symbol": ["A"] * len(dates)})
+    splits = [
+        {
+            "fold": 0,
+            "train_start": pd.Timestamp("2018-01-01"),
+            "train_end": pd.Timestamp("2019-12-31"),
+            "val_start": pd.Timestamp("2020-01-01"),
+            "val_end": pd.Timestamp("2020-12-31"),
+        }
+    ]
+    return dataset, splits
+
+
+def _temporal_from(dates: pd.DatetimeIndex) -> pl.DataFrame:
+    return pl.DataFrame({"timestamp": dates, "fold": 0})
+
+
+def test_temporal_warmup_prefix_within_bound_is_excused(warmup_temporal_fixture) -> None:
+    dataset, splits = warmup_temporal_fixture
+    dates = pd.DatetimeIndex(dataset["timestamp"].to_pandas())
+    train = dates[dates <= pd.Timestamp("2019-12-31")]
+    # 8% of the train window unavailable at its start, as a rolling warm-up is.
+    trimmed = dates[dates >= train[int(len(train) * 0.08)]]
+
+    validate_temporal_fold_coverage(dataset, _temporal_from(trimmed), splits, date_col="timestamp")
+
+
+def test_temporal_warmup_prefix_beyond_bound_still_fails(warmup_temporal_fixture) -> None:
+    dataset, splits = warmup_temporal_fixture
+    dates = pd.DatetimeIndex(dataset["timestamp"].to_pandas())
+    train = dates[dates <= pd.Timestamp("2019-12-31")]
+    # A shifted fold looks like this: a leading gap over half the train window.
+    trimmed = dates[dates >= train[int(len(train) * 0.5)]]
+
+    with pytest.raises(ValueError, match=r"fold 0 train: temporal date coverage"):
+        validate_temporal_fold_coverage(
+            dataset, _temporal_from(trimmed), splits, date_col="timestamp"
+        )
+
+
+def test_temporal_warmup_allowance_does_not_apply_to_validation(warmup_temporal_fixture) -> None:
+    dataset, splits = warmup_temporal_fixture
+    dates = pd.DatetimeIndex(dataset["timestamp"].to_pandas())
+    val = dates[dates >= pd.Timestamp("2020-01-01")]
+    # 8% at the start of the window: excused on train, fatal on validation.
+    keep = dates[(dates < pd.Timestamp("2020-01-01")) | (dates >= val[int(len(val) * 0.08)])]
+
+    with pytest.raises(ValueError, match=r"fold 0 validation: temporal date coverage"):
+        validate_temporal_fold_coverage(dataset, _temporal_from(keep), splits, date_col="timestamp")
+
+
+def test_temporal_interior_gap_is_not_excused(warmup_temporal_fixture) -> None:
+    dataset, splits = warmup_temporal_fixture
+    dates = pd.DatetimeIndex(dataset["timestamp"].to_pandas())
+    train = dates[dates <= pd.Timestamp("2019-12-31")]
+    gap = train[int(len(train) * 0.3) : int(len(train) * 0.5)]
+    keep = dates[~dates.isin(gap)]
+
+    with pytest.raises(ValueError, match=r"fold 0 train: temporal date coverage"):
+        validate_temporal_fold_coverage(dataset, _temporal_from(keep), splits, date_col="timestamp")
+
+
 def test_sp500_options_temporal_producer_uses_canonical_split_ids() -> None:
     source = Path("case_studies/sp500_options/04_model_based_features.py").read_text()
 

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -44,6 +44,12 @@ from utils.cv_splits import generate_cv_splits, make_wf_config
 
 RANDOM_SEED = 42
 MIN_TEMPORAL_DATE_COVERAGE = 0.95  # Allow short calendar-edge gaps, not missing windows.
+# Burn-in a temporal model cannot emit through, excused only at the start of a
+# train window. Measured on crypto_perps_funding, whose GARCH and HMM features
+# carry a 90-bar rolling z-score: 97/2024 dates (4.8%) for fold 0 and 119/1935
+# (6.1%) for fold 1. A stale artifact whose fold IDs have shifted presents as a
+# leading gap of roughly half the window, so this bound still rejects it.
+MAX_TEMPORAL_WARMUP_FRACTION = 0.10
 
 
 def seed_everything(seed: int = RANDOM_SEED) -> None:
@@ -851,6 +857,7 @@ def validate_temporal_fold_coverage(
     *,
     date_col: str,
     min_date_coverage: float = MIN_TEMPORAL_DATE_COVERAGE,
+    max_warmup_fraction: float = MAX_TEMPORAL_WARMUP_FRACTION,
 ) -> None:
     """Fail when a fold-specific temporal artifact does not cover a CV window.
 
@@ -858,9 +865,20 @@ def validate_temporal_fold_coverage(
     Temporal model fitting may legitimately skip individual symbols, whose
     missing values are imputed downstream, but a missing date range indicates
     that artifact fold IDs or windows do not match the canonical CV splits.
+
+    A temporal model cannot emit a value before it has been fitted, so the start
+    of a *training* window carries a burn-in prefix that no regeneration removes.
+    A leading run of uncovered dates in a train window is therefore excused up to
+    ``max_warmup_fraction`` of that window and coverage is measured on the
+    remainder. Validation windows get no such allowance: every date a model is
+    scored on must carry a temporal value. The excused prefix is bounded because
+    a stale artifact whose fold IDs have shifted also presents as a leading gap,
+    one that spans a large share of the window rather than a burn-in.
     """
     if not 0 < min_date_coverage <= 1:
         raise ValueError("min_date_coverage must be in (0, 1]")
+    if not 0 <= max_warmup_fraction < 1:
+        raise ValueError("max_warmup_fraction must be in [0, 1)")
 
     if isinstance(dataset, pl.DataFrame):
         dataset_dates = dataset.select(date_col).unique()[date_col].to_pandas()
@@ -871,7 +889,7 @@ def validate_temporal_fold_coverage(
     else:
         temporal_pd = temporal_by_fold[[date_col, "fold"]].drop_duplicates()
 
-    dataset_index = pd.DatetimeIndex(pd.to_datetime(dataset_dates, utc=True)).unique()
+    dataset_index = pd.DatetimeIndex(pd.to_datetime(dataset_dates, utc=True)).unique().sort_values()
     temporal_pd = temporal_pd.copy()
     temporal_pd[date_col] = pd.to_datetime(temporal_pd[date_col], utc=True)
     available_folds = set(temporal_pd["fold"].dropna().astype(int).unique())
@@ -898,12 +916,20 @@ def validate_temporal_fold_coverage(
             if len(expected) == 0:
                 failures.append(f"fold {fold_id} {window}: dataset window is empty")
                 continue
-            covered = int(expected.isin(fold_dates).sum())
-            coverage = covered / len(expected)
+            present = expected.isin(fold_dates)
+            warmup = 0
+            if window == "train" and present.any() and not present[0]:
+                leading = int(present.argmax())
+                if leading <= max_warmup_fraction * len(expected):
+                    warmup = leading
+            scored = present[warmup:]
+            covered = int(scored.sum())
+            coverage = covered / len(scored)
             if coverage < min_date_coverage:
+                excused = f", excusing a {warmup}-date warm-up prefix" if warmup else ""
                 failures.append(
                     f"fold {fold_id} {window}: temporal date coverage "
-                    f"{covered}/{len(expected)} ({coverage:.1%})"
+                    f"{covered}/{len(scored)} ({coverage:.1%}){excused}"
                 )
 
     if failures:


### PR DESCRIPTION
`ch14-15` is red on `main` for exactly one notebook, `15_causal_estimation/04_dml_crypto_regime`, which dies in `load_modeling_dataset`:

```
ValueError: Fold-specific temporal artifact is not aligned with the canonical CV splits:
fold 1 train: temporal date coverage 1816/1935 (93.9%).
```

## What the artifact actually looks like

Measured on the CI fixture against the splits `generate_cv_splits` derives from the fixture's own labels:

| fold | window | coverage | shortfall |
|---|---|---|---|
| 0 | train | 1927/2024 (95.2%) | 97 dates, contiguous, at the window start |
| 0 | validation | 1091/1091 (100%) | - |
| 1 | train | 1816/1935 (93.9%) | 119 dates, contiguous, at the window start |
| 1 | validation | 1089/1089 (100%) | - |

The fold IDs are right and the windows are right. Every missing date is a contiguous prefix at the start of the train window - the burn-in the GARCH conditional volatility and HMM regime features need before they can emit anything, on top of a 90-bar rolling z-score. Fold 0 clears the flat 95% threshold with 0.2 points to spare; fold 1 misses by 1.1.

## The change

A leading run of uncovered dates in a **train** window is excused up to `MAX_TEMPORAL_WARMUP_FRACTION` (10%) of that window, and coverage is measured on the remainder.

The bound is what keeps the gate honest. The defect this validator was written for - a `crypto_perps_funding` artifact built when the CV had three folds, whose fold IDs are now shifted by one - presents as a leading gap of roughly half the train window, five times the bound, so it is still rejected. Validation windows get no allowance at all: every date a model is scored on must carry a temporal value. An interior gap is still counted in full.

`dataset_index` is now sorted. It came from `.unique()`, which polars does not order, so "leading" was only well-defined by accident.

## Verification

- `tests/test_cv_splits.py`: 50 passed, including four new cases - a warm-up prefix within bound passes, a prefix beyond it fails, the same prefix on a validation window fails, an interior gap fails.
- `pytest tests/test_chapter_notebooks.py -k 15_causal` in `ml4t/ml4t:latest` against the CI fixtures: **8 passed, 3 skipped, 0 failed** (was 1 failed).

Also removes two of `cs-crypto_perps_funding`'s ten failures (`04_model_based_features`, `05_evaluation`); that job stays red on its four deliberate CUDA guards.