### PR TITLE
deps: bump ml4t-models to 0.1.0b0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ dependencies = [
     "llama-index-embeddings-huggingface>=0.7.0",
     "chromadb>=1.5.5",
     "pfhedge>=0.22.0",
-    "ml4t-models>=0.1.0a6",
+    "ml4t-models>=0.1.0b0",
     "llama-index-vector-stores-chroma>=0.5.5",
     "llama-index-llms-openai>=0.7.7",
     # Ch24 Autonomous Agents (required at notebook runtime; Docker installs

--- a/uv.lock
+++ b/uv.lock
@@ -4368,7 +4368,7 @@ requires-dist = [
     { name = "ml4t-diagnostic", specifier = ">=0.1.0b25" },
     { name = "ml4t-engineer", specifier = ">=0.1.0b10" },
     { name = "ml4t-live", specifier = ">=0.1.0b3" },
-    { name = "ml4t-models", specifier = ">=0.1.0a6" },
+    { name = "ml4t-models", specifier = ">=0.1.0b0" },
     { name = "mlflow", specifier = ">=3.10.1" },
     { name = "mlflow", marker = "extra == 'mlops'", specifier = ">=2.16" },
     { name = "nbconvert", specifier = ">=7.16" },
@@ -4566,14 +4566,14 @@ wheels = [
 
 [[package]]
 name = "ml4t-models"
-version = "0.1.0a6"
+version = "0.1.0b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/bc/2881ba099d50a3b7ce12bb083b203f8ddd5417e509f737e087b0c5ce9be0/ml4t_models-0.1.0a6.tar.gz", hash = "sha256:c70374f7c5313004a0c56c6b04fd2960ca5f8dd5a371fb95b642fb7283169a5f", size = 64335, upload-time = "2026-07-21T09:39:41.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/9b/ec8265362880b0514b6d78069812daf6123e42b744c758a5b4d6b44f09eb/ml4t_models-0.1.0b0.tar.gz", hash = "sha256:621f13436c25500a7799a3a5814e1a2763f218f3f65ff14f108772c95ad47b33", size = 66541, upload-time = "2026-07-23T01:57:18.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/8a/efdd016fb760b1b8d4d34179b1115ea4f333ea4bb83ec8ba8a8b39fe794e/ml4t_models-0.1.0a6-py3-none-any.whl", hash = "sha256:2b40392096fa95a113e347f1c0c282b6876ca6df25877aafd1b65bb9f2bcd8ba", size = 79392, upload-time = "2026-07-21T09:39:40.073Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b9/5d169af60f2d1fa3e919bdc7bd5f50cd39ea6113e698424fb1bb701c9920/ml4t_models-0.1.0b0-py3-none-any.whl", hash = "sha256:d94356d06b073ccab5d1ef4d619c8f6cbe6392c16916fb204f065b0a66324016", size = 79458, upload-time = "2026-07-23T01:57:16.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `ml4t-models` from `>=0.1.0a6` to `>=0.1.0b0`.
- The existing `a6` pin already fixed the multi-factor (K>1) IPCA solver (ml4t/models#12 - corrected `_estimate_gamma` einsum ordering + a rotation-invariant convergence check), but `ml4t/ml4t:latest` was never rebuilt after that pin landed, so CI has been running the pre-fix `a4` solver.
- `0.1.0b0` is the current PyPI release beyond `a6` - docs/examples/CI additions and one additive export (`PipelineFitResult`), no core solver changes since `a6`.
- Follow-up once merged: rebuild/republish `ml4t/ml4t:latest` (`gh workflow run docker-publish.yml --ref main -f images=ml4t`) so the image picks this up - that's the actual fix for the `sp500_equity_option_analytics::11b_ipca` CI failure (folds 0/1 never converging under the stale `a4` solver).

## Test plan
- [x] `uv lock` - only `ml4t-models` moved, no ripple.
- [x] `uv sync --frozen && uv run python -c "import ml4t.models"` - imports clean.
- [x] Verified inside the actual `ml4t/ml4t:latest` image: pip-installing `ml4t-models==0.1.0a6` over the stale baked-in `a4` turns `cs-sp500_equity_option_analytics::11b_ipca` from FAIL to PASS with no other changes (confirms the fix is the dependency version, not notebook/preset code).
- [ ] Required checks (guards/lint/test-unit) on this PR.