### PR TITLE
Pin the image's lightgbm to uv.lock instead of a floating >=4.6

### DIFF
--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -103,10 +103,20 @@ COPY pyproject.toml uv.lock /build/
 # held to the lock's torch-2.10.0-consistent versions. torch/torchvision/torchaudio +
 # lightgbm (CUDA-built separately) are excluded too. Everything else is pinned to the
 # lock. Generated BEFORE the strip so uv.lock still matches pyproject.toml for --frozen.
+#
+# lightgbm is excluded from the constraint but still has to match the lock, so its exact
+# version is written to /tmp/lightgbm-pin.txt for the two build steps below to install.
+# A floating "lightgbm>=4.6" there silently drifted 4.6.0 -> 4.7.0 on 2026-07-27, and 4.7
+# device-links the CUDA-13-built libnccl_static.a, which nvcc 12.6's nvlink cannot read
+# ("nvlink error: Uncompress failed (target: sm_80)"). Reading the version from the lock
+# means the image cannot drift off the version readers get from `uv sync`.
 RUN cd /build && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
-      | grep -iE '^[a-z0-9._-]+==' \
-      | grep -viE '^(torch|torchvision|torchaudio|lightgbm|triton|setuptools)==|^nvidia-' \
-      > /tmp/locked-constraints.txt
+      | grep -iE '^[a-z0-9._-]+==' > /tmp/locked-all.txt && \
+    grep -viE '^(torch|torchvision|torchaudio|lightgbm|triton|setuptools)==|^nvidia-' \
+      /tmp/locked-all.txt > /tmp/locked-constraints.txt && \
+    grep -iE '^lightgbm==' /tmp/locked-all.txt | head -1 | cut -d';' -f1 | tr -d '[:space:]' \
+      > /tmp/lightgbm-pin.txt && \
+    test -s /tmp/lightgbm-pin.txt && cat /tmp/lightgbm-pin.txt
 
 # Remove packages that need special handling from pyproject copy:
 # - lightgbm: installed separately with CUDA build on amd64
@@ -148,7 +158,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       CUDACXX=/usr/local/cuda/bin/nvcc CUDAHOSTCXX=/usr/bin/g++-12 \
       /opt/ml4t/bin/pip install --no-cache-dir --force-reinstall --no-deps \
         --no-binary lightgbm \
-        --config-settings=cmake.define.USE_CUDA=ON "lightgbm>=4.6" && \
+        --config-settings=cmake.define.USE_CUDA=ON "$(cat /tmp/lightgbm-pin.txt)" && \
       /opt/ml4t/bin/python -c "\
 import lightgbm as lgb; \
 print(f'LightGBM {lgb.__version__}'); \
@@ -156,7 +166,7 @@ print('CUDA build: OK (runtime verification requires GPU)')"; \
     fi
 # arm64: standard pip wheel (no GPU on macOS)
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      /opt/ml4t/bin/pip install --no-cache-dir "lightgbm>=4.6"; \
+      /opt/ml4t/bin/pip install --no-cache-dir "$(cat /tmp/lightgbm-pin.txt)"; \
     fi
 
 # Install optional dependency groups (bayesian, advanced, mlops)


### PR DESCRIPTION
The amd64 image rebuild dispatched on 2026-07-27 (`30307626522`) failed after 17 minutes at LightGBM's CUDA device link:

```
nvlink error   : Uncompress failed (target: sm_80)
nvlink fatal   : elfLink fatbinary error (target: sm_80)
```

## Cause

`envs/ml4t/Dockerfile` derives a fully-pinned constraint from `uv.lock`, but carves `lightgbm` out of it (it is built separately with CUDA) and then installs a floating `"lightgbm>=4.6"`. LightGBM **4.7.0** released after the last green build and the rebuild picked it up.

4.7 added NCCL-based multi-GPU GBDT, so the device-link step now pulls in `libnccl_static.a`. The Ubuntu CUDA repo ships `libnccl-dev 2.30.7-1+cuda13.3`, whose fatbins nvcc **12.6.85**'s nvlink cannot decompress.

Comparison against the last green amd64 build (`ml4t/third-edition` run `29531427990`, 07-16):

| | 07-16 green | 07-27 failed |
|---|---|---|
| lightgbm | 4.6.0 | **4.7.0** |
| `nccl_gbdt.cpp` compiled | no | yes |
| `libnccl_static.a` device-linked | no | yes |
| libnccl package | `2.30.7-1+cuda13.3` | `2.30.7-1+cuda13.3` |
| nvcc | `12.6.85-1` | `12.6.85-1` |

NCCL and nvcc are identical across both. The only thing that moved is LightGBM, so this is deterministic, not a transient runner resource failure.

## Fix

Both LightGBM install steps (amd64 CUDA source build, arm64 wheel) now install the exact version `uv.lock` pins, extracted from the same `uv export` that produces the constraint file — `lightgbm==4.6.0` today. That is the combination the last green build used, and the image can no longer drift off the version readers get from `uv sync`.

Verified the extraction against the real `uv.lock`: yields `lightgbm==4.6.0`.

Context: `issues/2026-07-27-ci-image-lags-the-lock-with-no-freshness-check.md` in the agents repo. The torch stack remains deliberately unpinned and is the remaining drift surface.