### PR TITLE
Gate notebook provenance at the merge, over the change's own notebooks

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -94,15 +94,24 @@ def iter_notebooks() -> list[Path]:
     return sorted(out)
 
 
-def notebooks_changed_since(ref: str) -> list[Path]:
-    """Notebooks this branch is answerable for, relative to ``ref``.
+def notebooks_changed_since(ref: str, merge_base: bool = True) -> list[Path]:
+    """Notebooks this change is answerable for, relative to ``ref``.
 
-    A branch owns a notebook if it edited the notebook OR edited the paired
+    A change owns a notebook if it edited the notebook OR edited the paired
     ``.py``, since changing the ``.py`` is exactly what makes the rendered
-    notebook stale. Notebooks nobody on this branch touched are somebody else's.
+    notebook stale. Notebooks nobody touched are somebody else's.
+
+    ``merge_base`` picks which question is being asked. For a pull request it is
+    "what does this branch add on top of the base", so the diff runs from the
+    merge base (``ref...HEAD``) and commits that landed on the base meanwhile are
+    not this branch's problem. For a push it is "what does the published tree
+    become", so the diff must run against the previous tip itself
+    (``ref..HEAD``) — a force-push can revert a notebook relative to that tip
+    without the merge base ever seeing it.
     """
+    spec = f"{ref}...HEAD" if merge_base else f"{ref}..HEAD"
     diff = subprocess.run(
-        ["git", "diff", "--name-only", f"{ref}...HEAD"],
+        ["git", "diff", "--name-only", spec],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -199,7 +208,7 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 def _cmd_check(args: argparse.Namespace) -> int:
     scope = None
     if args.since:
-        scope = notebooks_changed_since(args.since)
+        scope = notebooks_changed_since(args.since, merge_base=not args.no_merge_base)
         if not scope:
             print(f"notebook sync OK: no notebook is changed relative to {args.since}")
             return 0
@@ -257,6 +266,12 @@ def main() -> int:
         metavar="REF",
         help="check only notebooks this branch changed relative to REF (e.g. origin/main), "
         "counting a notebook as changed when its paired .py changed",
+    )
+    cp.add_argument(
+        "--no-merge-base",
+        action="store_true",
+        help="diff REF..HEAD instead of REF...HEAD — use for a push, where the question is what "
+        "the published tree becomes relative to the previous tip, not what a branch adds",
     )
     cp.set_defaults(func=_cmd_check)
 

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -27,12 +27,19 @@ Notebooks WITHOUT a stamp are reported as "unverified" but do not fail unless
 as they are re-run through the canonical path, and the gate enforces only where
 provenance exists. Flip to ``--strict`` once the backfill is complete.
 
+**Where this gate runs.** It gates the *merge*, not the commit. Run on every local commit over every
+notebook in the repo, one stale notebook anywhere blocked every commit by every agent — including
+commits touching no notebook at all — so work could not be checkpointed. A stale render only reaches
+a reader through a merge, so the gate runs in CI on the pull request, over the notebooks that pull
+request changes. Run it locally against your branch whenever you want the same answer early.
+
 Usage::
 
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --notes "..."
-    uv run python .github/scripts/notebook_provenance.py check          # gate (stamped-only)
-    uv run python .github/scripts/notebook_provenance.py check --strict  # also fail on unverified
+    uv run python .github/scripts/notebook_provenance.py check              # whole repo
+    uv run python .github/scripts/notebook_provenance.py check --strict     # also fail on unverified
+    uv run python .github/scripts/notebook_provenance.py check --since origin/main   # this branch only
 """
 
 from __future__ import annotations
@@ -87,6 +94,32 @@ def iter_notebooks() -> list[Path]:
     return sorted(out)
 
 
+def notebooks_changed_since(ref: str) -> list[Path]:
+    """Notebooks this branch is answerable for, relative to ``ref``.
+
+    A branch owns a notebook if it edited the notebook OR edited the paired
+    ``.py``, since changing the ``.py`` is exactly what makes the rendered
+    notebook stale. Notebooks nobody on this branch touched are somebody else's.
+    """
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{ref}...HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    owned: set[Path] = set()
+    for name in diff:
+        path = REPO_ROOT / name
+        if path.suffix == ".ipynb":
+            owned.add(path)
+        elif path.suffix == ".py":
+            nb = path.with_suffix(".ipynb")
+            if nb.exists():
+                owned.add(nb)
+    return sorted(p for p in owned if p.exists() and not (SKIP_PARTS & set(p.parts)))
+
+
 def paired_py(nb_path: Path) -> Path | None:
     """The .py jupytext-paired to this notebook (same dir + stem). None if absent."""
     cand = nb_path.with_suffix(".py")
@@ -124,12 +157,17 @@ def stamp_notebook(nb_path: Path, executor: str, notes: str | None = None) -> di
     return stamp
 
 
-def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str]]:
-    """Return (stale, testmode, unverified) lists of repo-relative offenders."""
+def check_all(
+    strict: bool = False, notebooks: list[Path] | None = None
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (stale, testmode, unverified) lists of repo-relative offenders.
+
+    ``notebooks`` restricts the scan; None means every tracked notebook.
+    """
     stale: list[str] = []
     testmode: list[str] = []
     unverified: list[str] = []
-    for nb_path in iter_notebooks():
+    for nb_path in iter_notebooks() if notebooks is None else notebooks:
         rel = str(nb_path.relative_to(REPO_ROOT))
         py = paired_py(nb_path)
         if py is None:
@@ -159,7 +197,17 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
-    stale, testmode, unverified = check_all(strict=args.strict)
+    scope = None
+    if args.since:
+        scope = notebooks_changed_since(args.since)
+        if not scope:
+            print(f"notebook sync OK: no notebook is changed relative to {args.since}")
+            return 0
+        print(f"checking {len(scope)} notebook(s) changed relative to {args.since}:")
+        for nb in scope:
+            print(f"  {nb.relative_to(REPO_ROOT)}")
+        print()
+    stale, testmode, unverified = check_all(strict=args.strict, notebooks=scope)
     fail = bool(stale or testmode) or (args.strict and bool(unverified))
     if stale:
         print(
@@ -203,6 +251,13 @@ def main() -> int:
 
     cp = sub.add_parser("check", help="gate: fail on stale or test-mode stamped notebooks")
     cp.add_argument("--strict", action="store_true", help="also fail on unstamped notebooks")
+    cp.add_argument(
+        "--since",
+        default=None,
+        metavar="REF",
+        help="check only notebooks this branch changed relative to REF (e.g. origin/main), "
+        "counting a notebook as changed when its paired .py changed",
+    )
     cp.set_defaults(func=_cmd_check)
 
     args = ap.parse_args()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,12 +383,28 @@ jobs:
       # stale render one commit earlier, and a stale render only reaches a reader
       # through a merge, so the gate lives here and covers what this PR changed:
       # a notebook it edited, or one whose paired .py it edited.
-      - name: Notebooks this PR changed were executed from their current .py
-        if: github.event_name == 'pull_request'
+      #
+      # It runs on push to main as well as on the PR. Branch protection means
+      # everything should arrive via a PR, but this workflow's own history is
+      # that exports used to land on main as pushes and nothing CI ran had seen
+      # them — a gate that only fires on the path we believe is the only path is
+      # how that happened. On push the base is the previous main tip, so the
+      # scope is exactly what the push introduced.
+      - name: Notebooks this change touched were executed from their current .py
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         run: |
           source .venv/bin/activate
-          python .github/scripts/notebook_provenance.py check \
-            --since "origin/${{ github.base_ref }}"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="origin/${{ github.base_ref }}"
+          else
+            base="${{ github.event.before }}"
+            # All-zero on a branch's first push, and absent after a force-push
+            # that dropped the old tip; fall back to the parent of HEAD.
+            if [[ "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+              base="HEAD~1"
+            fi
+          fi
+          python .github/scripts/notebook_provenance.py check --since "$base"
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -395,16 +395,22 @@ jobs:
         run: |
           source .venv/bin/activate
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base="origin/${{ github.base_ref }}"
-          else
-            base="${{ github.event.before }}"
-            # All-zero on a branch's first push, and absent after a force-push
-            # that dropped the old tip; fall back to the parent of HEAD.
-            if [[ "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
-              base="HEAD~1"
-            fi
+            # What does this branch add on top of the base: merge-base diff.
+            python .github/scripts/notebook_provenance.py check \
+              --since "origin/${{ github.base_ref }}"
+            exit $?
           fi
-          python .github/scripts/notebook_provenance.py check --since "$base"
+          # What does the published tree become: diff the previous tip directly,
+          # so a force-push that reverts a notebook relative to it is still seen.
+          base="${{ github.event.before }}"
+          if [[ "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            # First push, or a force-push that dropped the old tip. There is no
+            # honest scope, so check everything rather than guess a narrower one.
+            echo "previous tip unavailable ($base) — checking every notebook"
+            python .github/scripts/notebook_provenance.py check
+            exit $?
+          fi
+          python .github/scripts/notebook_provenance.py check --since "$base" --no-merge-base
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,6 +338,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # notebook_provenance.py --since needs the merge base, not a shallow tip.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
@@ -373,6 +376,19 @@ jobs:
           source .venv/bin/activate
           python -m pytest tests/test_notebook_output_hygiene.py -q \
             --deselect tests/test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks
+      # A committed .ipynb must be its CURRENT .py, executed for real. This used
+      # to be a pre-commit hook scanning every notebook in the repo, so one stale
+      # notebook anywhere blocked every commit by every agent — including commits
+      # touching no notebook. Checkpointing work matters more than catching a
+      # stale render one commit earlier, and a stale render only reaches a reader
+      # through a merge, so the gate lives here and covers what this PR changed:
+      # a notebook it edited, or one whose paired .py it edited.
+      - name: Notebooks this PR changed were executed from their current .py
+        if: github.event_name == 'pull_request'
+        run: |
+          source .venv/bin/activate
+          python .github/scripts/notebook_provenance.py check \
+            --since "origin/${{ github.base_ref }}"
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,14 +48,13 @@ repos:
         entry: python3 .github/scripts/check_notebook_pair_sync.py
         files: \.(ipynb|py)$
 
-      # Sync gate: a stamped notebook must be its CURRENT .py executed in a
-      # production run. Fails if any provenance-stamped .ipynb is stale (its
-      # paired .py changed since execution) or was committed from a TEST-mode
-      # run. Unstamped notebooks are advisory only (gradual adoption). See
-      # .github/scripts/notebook_provenance.py.
-      - id: notebook-sync
-        name: notebook provenance sync gate
-        language: system
-        entry: python3 .github/scripts/notebook_provenance.py check
-        pass_filenames: false
-        always_run: true
+      # The provenance sync gate — a stamped notebook must be its CURRENT .py
+      # executed in a production run — deliberately does NOT run here. It ran on
+      # every commit over every notebook in the repo, so one stale notebook
+      # anywhere blocked every commit by every agent, including commits that
+      # touched no notebook. That stops work being checkpointed, which is how
+      # work gets lost. It gates the merge instead: the `guards` job in
+      # .github/workflows/test.yml runs
+      #   notebook_provenance.py check --since <base>
+      # on the pull request, over the notebooks that pull request changes. Run it
+      # locally against your branch whenever you want the same answer early.


### PR DESCRIPTION
## What

The notebook provenance check moves from a pre-commit hook into the `guards` CI job, scoped to the notebooks the change actually touches.

## Why

The hook ran with `always_run: true` and `pass_filenames: false`, so **every local commit scanned every notebook in the repo**. One stale notebook anywhere blocked every commit by every agent, including commits that touched no notebook at all.

Four agents are currently working four case studies against a red CI gate, and a verified fix (`etfs::08_tabular_dl`) sat uncommitted for a day because of this. Uncommitted work is how work gets lost — a reboot on 2026-07-27 destroyed nine hours of it in another worktree.

## What does not change

The invariant. A committed `.ipynb` must still be its current `.py`, executed in a production run. Only *where* it is enforced changes: a stale render reaches a reader through a merge, not through a local commit.

## Scope

A change owns a notebook if it edited the notebook, or edited the paired `.py` — changing the `.py` is exactly what makes the render stale.

The diff form differs by event, because the question differs:

- **pull request** — "what does this branch add on top of the base": merge-base diff, `origin/<base>...HEAD`. Commits that landed on the base meanwhile are not this branch's problem.
- **push to main** — "what does the published tree become": two-dot diff against the previous tip, `<before>..HEAD`. A merge-base diff here would let a force-push revert a notebook relative to the published tip without the gate seeing it.
- **previous tip unavailable** (first push, or a force-push that dropped it) — no honest narrow scope exists, so every notebook is checked. `main` is currently 0 stale and 0 test-mode, so this passes rather than wedging.

The gate runs on push as well as on the PR. Branch protection means everything should arrive via a PR, but this workflow's own header records exports landing on `main` as pushes with nothing CI ran having seen them — a gate covering only the path we believe is the only path is how that happened.

## Verification

Adding one line to `case_studies/etfs/03_financial_features.py` scopes the check to that single notebook and exits 1:

```
checking 1 notebook(s) changed relative to origin/main:
  case_studies/etfs/03_financial_features.ipynb

STALE (paired .py changed since the notebook was executed — re-run in the canonical env):
  case_studies/etfs/03_financial_features.ipynb
```

`--since` with no changed notebooks exits 0. Both diff forms were exercised against a real range. The whole-repo `check` and `check --strict` behave exactly as before.

`guards` gains `fetch-depth: 0` because the diff needs history, not a shallow tip.

## Review history

Roborev blocked the first two pushes, both on real defects in this change: the gate firing only on `pull_request`, and the triple-dot diff on pushes. Both are fixed here (jobs 9509, 9512).