### PR TITLE
Add utils.style.show_with_alt so a notebook figure can carry alt text

### DIFF
--- a/utils/style.py
+++ b/utils/style.py
@@ -307,6 +307,19 @@ def add_message_title(
         )
 
 
+def show_with_alt(fig: object, alt: str) -> None:
+    """Render *fig* carrying alt text for screen readers, then close it.
+
+    `plt.show()` emits an `<img>` with no alternative text, which nbconvert warns
+    about and a screen reader cannot describe. The alt text is a sentence saying
+    what the chart shows, not a repeat of the title.
+    """
+    from IPython.display import display
+
+    display(fig, metadata={"image/png": {"alt": alt}})
+    plt.close(fig)
+
+
 def label_line_ends(ax: Axes, xpad_points: int = 4, expand_right: float = 0.10) -> None:
     """Direct-label each labeled line at its last finite point; use instead of a legend.
 
@@ -942,6 +955,7 @@ __all__ = [
     "add_regime_shading",
     "format_pct_axis",
     "add_message_title",
+    "show_with_alt",
     "label_line_ends",
     "zero_line",
     "upper_triangle_mask",


### PR DESCRIPTION
Adds one shared helper, `utils.style.show_with_alt(fig, alt)`, so a notebook figure can carry
alternative text for a screen reader.

`plt.show()` emits an `<img>` with no `alt` attribute. nbconvert warns on it, and a reader using a
screen reader gets nothing at all for the chart. Three case-study notebooks already answer this -
`etfs/11c_conditional_autoencoder`, `11d_stochastic_discount_factor`, `11e_supervised_autoencoder` -
and each spells the same pair out by hand:

```python
display(fig, metadata={"image/png": {"alt": "..."}})
plt.close(fig)
```

The helper is that pair, so the next notebook does not have to rediscover the metadata key. The alt
text is a sentence saying what the chart shows, not a repeat of the title.

**Verified**, against the executed `crypto_perps_funding/02_labels` notebook that uses it for all
five of its figures: every figure output carries an `image/png.alt` sentence in its cell metadata.

```
$ python -c "... read 02_labels.ipynb, print outputs' metadata['image/png']['alt'] ..."
1. Non-null label rate by position from the end of each series.
2. Histograms of both labels on identical bins and a log count axis.
3. Class shares of the three-class label, year by year.
4. Panel autocorrelation of both labels against lag in periods.
5. Rolling mean of the per-settlement rank IC over the window.
figures with alt text: 5
```

One caveat worth stating: **nbconvert still warns.** Its HTML template does not read output metadata
into the `alt` attribute, which is why `etfs/11c` warns too despite carrying alt text. The metadata
is correct in the `.ipynb`; the warning is the template's, and is not fixable from a notebook.

Split out of the `crypto_perps_funding/02_labels` branch, which is where the helper was written.
Neither lane edits shared infrastructure inside a notebook branch, so this goes first and that branch
rebases onto it.
