### PR TITLE
Count label overlap on the grid the label was built on, not on surviving rows

### DIFF
--- a/case_studies/etfs/02_labels.ipynb
+++ b/case_studies/etfs/02_labels.ipynb
@@ -5,10 +5,10 @@
    "id": "60c3e02e",
    "metadata": {
     "papermill": {
-     "duration": 0.009633,
-     "end_time": "2026-07-29T05:40:38.097973+00:00",
+     "duration": 0.003732,
+     "end_time": "2026-07-30T03:46:10.592376+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:38.088340+00:00",
+     "start_time": "2026-07-30T03:46:10.588644+00:00",
      "status": "completed"
     }
    },
@@ -46,16 +46,16 @@
    "id": "945e5a70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:38.113170Z",
-     "iopub.status.busy": "2026-07-29T05:40:38.112876Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.158052Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.157522Z"
+     "iopub.execute_input": "2026-07-30T03:46:10.605383Z",
+     "iopub.status.busy": "2026-07-30T03:46:10.605153Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.634190Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.633852Z"
     },
     "papermill": {
-     "duration": 2.053186,
-     "end_time": "2026-07-29T05:40:40.158665+00:00",
+     "duration": 2.035162,
+     "end_time": "2026-07-30T03:46:12.634886+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:38.105479+00:00",
+     "start_time": "2026-07-30T03:46:10.599724+00:00",
      "status": "completed"
     }
    },
@@ -92,16 +92,16 @@
    "id": "2d65c645",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.162238Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.162145Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.163860Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.163578Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.638474Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.638377Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.640084Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.639822Z"
     },
     "papermill": {
-     "duration": 0.004387,
-     "end_time": "2026-07-29T05:40:40.164347+00:00",
+     "duration": 0.00409,
+     "end_time": "2026-07-30T03:46:12.640508+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.159960+00:00",
+     "start_time": "2026-07-30T03:46:12.636418+00:00",
      "status": "completed"
     },
     "tags": [
@@ -124,10 +124,10 @@
    "id": "7e6e10bb",
    "metadata": {
     "papermill": {
-     "duration": 0.000959,
-     "end_time": "2026-07-29T05:40:40.166344+00:00",
+     "duration": 0.001087,
+     "end_time": "2026-07-30T03:46:12.642760+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.165385+00:00",
+     "start_time": "2026-07-30T03:46:12.641673+00:00",
      "status": "completed"
     }
    },
@@ -148,16 +148,16 @@
    "id": "4cf499a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.169010Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.168948Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.177714Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.177420Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.645419Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.645345Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.654360Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.654046Z"
     },
     "papermill": {
-     "duration": 0.010837,
-     "end_time": "2026-07-29T05:40:40.178170+00:00",
+     "duration": 0.010752,
+     "end_time": "2026-07-30T03:46:12.654638+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.167333+00:00",
+     "start_time": "2026-07-30T03:46:12.643886+00:00",
      "status": "completed"
     }
    },
@@ -192,10 +192,10 @@
    "id": "65a5d78d",
    "metadata": {
     "papermill": {
-     "duration": 0.000999,
-     "end_time": "2026-07-29T05:40:40.180264+00:00",
+     "duration": 0.001098,
+     "end_time": "2026-07-30T03:46:12.656947+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.179265+00:00",
+     "start_time": "2026-07-30T03:46:12.655849+00:00",
      "status": "completed"
     }
    },
@@ -218,10 +218,10 @@
    "id": "22e190ab",
    "metadata": {
     "papermill": {
-     "duration": 0.000973,
-     "end_time": "2026-07-29T05:40:40.182264+00:00",
+     "duration": 0.001075,
+     "end_time": "2026-07-30T03:46:12.659166+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.181291+00:00",
+     "start_time": "2026-07-30T03:46:12.658091+00:00",
      "status": "completed"
     }
    },
@@ -243,16 +243,16 @@
    "id": "5559c251",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.184977Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.184916Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.235791Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.235321Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.662014Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.661935Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.710131Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.709667Z"
     },
     "papermill": {
-     "duration": 0.052919,
-     "end_time": "2026-07-29T05:40:40.236176+00:00",
+     "duration": 0.050098,
+     "end_time": "2026-07-30T03:46:12.710393+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.183257+00:00",
+     "start_time": "2026-07-30T03:46:12.660295+00:00",
      "status": "completed"
     }
    },
@@ -292,10 +292,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001715,
-     "end_time": "2026-07-29T05:40:40.239435+00:00",
+     "duration": 0.001177,
+     "end_time": "2026-07-30T03:46:12.713062+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.237720+00:00",
+     "start_time": "2026-07-30T03:46:12.711885+00:00",
      "status": "completed"
     }
    },
@@ -316,7 +316,13 @@
     "\n",
     "The arithmetic stays local rather than calling `fixed_time_horizon_labels`, which computes\n",
     "the identical $(P_{t+h}-P_t)/P_t$ but agrees only to a rounding step - enough to change the\n",
-    "digest and everything derived from it. Adopting it is one deliberate change across all nine."
+    "digest and everything derived from it. Adopting it is one deliberate change across all nine.\n",
+    "\n",
+    "Two bookkeeping columns are numbered here, on the complete price series, because both mean\n",
+    "something only before a row is dropped: `from_end` counts back from each symbol's last\n",
+    "session for Section D's boundary profile, and `session` numbers its bars forward so\n",
+    "Section F's overlap statistics keep counting trading sessions once the null tail and the\n",
+    "holdout are filtered out. Neither reaches the label parquet, which selects three columns."
    ]
   },
   {
@@ -325,16 +331,16 @@
    "id": "b0a89140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.242859Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.242710Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.289335Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.288803Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.715957Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.715882Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.752049Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.751598Z"
     },
     "papermill": {
-     "duration": 0.048798,
-     "end_time": "2026-07-29T05:40:40.289665+00:00",
+     "duration": 0.038117,
+     "end_time": "2026-07-30T03:46:12.752342+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.240867+00:00",
+     "start_time": "2026-07-30T03:46:12.714225+00:00",
      "status": "completed"
     }
    },
@@ -356,7 +362,8 @@
     "\n",
     "\n",
     "labels_df = prices.with_columns(\n",
-    "    (pl.len().over(\"symbol\") - 1 - pl.int_range(pl.len()).over(\"symbol\")).alias(\"from_end\")\n",
+    "    (pl.len().over(\"symbol\") - 1 - pl.int_range(pl.len()).over(\"symbol\")).alias(\"from_end\"),\n",
+    "    pl.int_range(pl.len()).over(\"symbol\").alias(\"session\"),\n",
     ")\n",
     "for label_name, horizon in HORIZONS.items():\n",
     "    labels_df = forward_return(labels_df, horizon, label_name)\n",
@@ -369,10 +376,10 @@
    "id": "8ee04045",
    "metadata": {
     "papermill": {
-     "duration": 0.001579,
-     "end_time": "2026-07-29T05:40:40.292788+00:00",
+     "duration": 0.001255,
+     "end_time": "2026-07-30T03:46:12.755080+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.291209+00:00",
+     "start_time": "2026-07-30T03:46:12.753825+00:00",
      "status": "completed"
     }
    },
@@ -396,16 +403,16 @@
    "id": "6ea6f9de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.297940Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.297729Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.347154Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.346638Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.758064Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.757982Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.805918Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.805544Z"
     },
     "papermill": {
-     "duration": 0.052972,
-     "end_time": "2026-07-29T05:40:40.347649+00:00",
+     "duration": 0.050138,
+     "end_time": "2026-07-30T03:46:12.806377+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.294677+00:00",
+     "start_time": "2026-07-30T03:46:12.756239+00:00",
      "status": "completed"
     }
    },
@@ -458,16 +465,16 @@
    "id": "d9228bef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.355491Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.355354Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.454967Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.454532Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.812826Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.812710Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.903757Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.903393Z"
     },
     "papermill": {
-     "duration": 0.104546,
-     "end_time": "2026-07-29T05:40:40.455504+00:00",
+     "duration": 0.095079,
+     "end_time": "2026-07-30T03:46:12.904082+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.350958+00:00",
+     "start_time": "2026-07-30T03:46:12.809003+00:00",
      "status": "completed"
     }
    },
@@ -525,10 +532,10 @@
    "id": "c691f19f",
    "metadata": {
     "papermill": {
-     "duration": 0.001251,
-     "end_time": "2026-07-29T05:40:40.458214+00:00",
+     "duration": 0.001317,
+     "end_time": "2026-07-30T03:46:12.906889+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.456963+00:00",
+     "start_time": "2026-07-30T03:46:12.905572+00:00",
      "status": "completed"
     }
    },
@@ -548,16 +555,16 @@
    "id": "69eff7af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.462231Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.462139Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.487631Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.487001Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.910192Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.910117Z",
+     "iopub.status.idle": "2026-07-30T03:46:12.939543Z",
+     "shell.execute_reply": "2026-07-30T03:46:12.939061Z"
     },
     "papermill": {
-     "duration": 0.028389,
-     "end_time": "2026-07-29T05:40:40.487928+00:00",
+     "duration": 0.031583,
+     "end_time": "2026-07-30T03:46:12.939843+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.459539+00:00",
+     "start_time": "2026-07-30T03:46:12.908260+00:00",
      "status": "completed"
     }
    },
@@ -590,16 +597,16 @@
    "id": "fda2b919",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.491235Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.491153Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.586248Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.585811Z"
+     "iopub.execute_input": "2026-07-30T03:46:12.943623Z",
+     "iopub.status.busy": "2026-07-30T03:46:12.943544Z",
+     "iopub.status.idle": "2026-07-30T03:46:13.046906Z",
+     "shell.execute_reply": "2026-07-30T03:46:13.046502Z"
     },
     "papermill": {
-     "duration": 0.097153,
-     "end_time": "2026-07-29T05:40:40.586562+00:00",
+     "duration": 0.105792,
+     "end_time": "2026-07-30T03:46:13.047374+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.489409+00:00",
+     "start_time": "2026-07-30T03:46:12.941582+00:00",
      "status": "completed"
     }
    },
@@ -653,16 +660,16 @@
    "id": "1f0cdb50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.590139Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.590057Z",
-     "iopub.status.idle": "2026-07-29T05:40:40.676355Z",
-     "shell.execute_reply": "2026-07-29T05:40:40.675830Z"
+     "iopub.execute_input": "2026-07-30T03:46:13.051158Z",
+     "iopub.status.busy": "2026-07-30T03:46:13.051085Z",
+     "iopub.status.idle": "2026-07-30T03:46:13.129499Z",
+     "shell.execute_reply": "2026-07-30T03:46:13.129009Z"
     },
     "papermill": {
-     "duration": 0.088587,
-     "end_time": "2026-07-29T05:40:40.676723+00:00",
+     "duration": 0.080823,
+     "end_time": "2026-07-30T03:46:13.129842+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.588136+00:00",
+     "start_time": "2026-07-30T03:46:13.049019+00:00",
      "status": "completed"
     }
    },
@@ -737,10 +744,10 @@
    "id": "390c579b",
    "metadata": {
     "papermill": {
-     "duration": 0.001478,
-     "end_time": "2026-07-29T05:40:40.679894+00:00",
+     "duration": 0.001595,
+     "end_time": "2026-07-30T03:46:13.133256+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.678416+00:00",
+     "start_time": "2026-07-30T03:46:13.131661+00:00",
      "status": "completed"
     },
     "tags": [
@@ -759,10 +766,10 @@
    "id": "afd112be",
    "metadata": {
     "papermill": {
-     "duration": 0.001375,
-     "end_time": "2026-07-29T05:40:40.682737+00:00",
+     "duration": 0.00144,
+     "end_time": "2026-07-30T03:46:13.136200+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.681362+00:00",
+     "start_time": "2026-07-30T03:46:13.134760+00:00",
      "status": "completed"
     }
    },
@@ -773,7 +780,14 @@
     "window, so the row count overstates the information carried. Two measurements: how fast the\n",
     "overlap decays, and what the row count is worth once it is priced in. `effective_sample_size`\n",
     "applies Ch7.2's average-uniqueness weighting per symbol - concurrency is a property of one\n",
-    "entity's windows."
+    "entity's windows.\n",
+    "\n",
+    "Both are counted on `session`, the grid the label was built on, not on position among the\n",
+    "rows that survive to `dev`. The distinction is vacuous here - property 3 above proves the\n",
+    "only null labels are each symbol's last $h$ sessions, and the holdout filter cuts a prefix,\n",
+    "so `dev` holds an unbroken run per symbol - and it is not vacuous on a case study whose\n",
+    "bars can go missing mid-series, where closing over a hole would pair windows that share\n",
+    "nothing and report the overlap as larger than it is."
    ]
   },
   {
@@ -782,16 +796,16 @@
    "id": "dd9bc40f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:40.686279Z",
-     "iopub.status.busy": "2026-07-29T05:40:40.686185Z",
-     "iopub.status.idle": "2026-07-29T05:40:42.279473Z",
-     "shell.execute_reply": "2026-07-29T05:40:42.278892Z"
+     "iopub.execute_input": "2026-07-30T03:46:13.139820Z",
+     "iopub.status.busy": "2026-07-30T03:46:13.139731Z",
+     "iopub.status.idle": "2026-07-30T03:46:15.077955Z",
+     "shell.execute_reply": "2026-07-30T03:46:15.077448Z"
     },
     "papermill": {
-     "duration": 1.5956,
-     "end_time": "2026-07-29T05:40:42.279745+00:00",
+     "duration": 1.94076,
+     "end_time": "2026-07-30T03:46:15.078466+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:40.684145+00:00",
+     "start_time": "2026-07-30T03:46:13.137706+00:00",
      "status": "completed"
     }
    },
@@ -819,8 +833,10 @@
     "# F3. Overlap decay across the panel. Computed on one asset this would be a claim about\n",
     "# that asset: pooled and single-symbol estimates disagree most at the lag that matters.\n",
     "max_lag = PRIMARY_HORIZON + 4\n",
-    "acf = panel_autocorrelation(dev[PRIMARY_LABEL], PRIMARY_LABEL, max_lag=max_lag)\n",
-    "n_rows, n_eff = effective_sample_size(dev[PRIMARY_LABEL], horizon=PRIMARY_HORIZON)\n",
+    "acf = panel_autocorrelation(dev[PRIMARY_LABEL], PRIMARY_LABEL, max_lag=max_lag, bar_col=\"session\")\n",
+    "n_rows, n_eff = effective_sample_size(\n",
+    "    dev[PRIMARY_LABEL], horizon=PRIMARY_HORIZON, bar_col=\"session\"\n",
+    ")\n",
     "\n",
     "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
     "ax.bar(np.arange(1, max_lag + 1), acf, color=COLORS[\"blue\"], width=0.7)\n",
@@ -858,10 +874,10 @@
    "id": "3ef89e80",
    "metadata": {
     "papermill": {
-     "duration": 0.001856,
-     "end_time": "2026-07-29T05:40:42.283442+00:00",
+     "duration": 0.001704,
+     "end_time": "2026-07-30T03:46:15.082138+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.281586+00:00",
+     "start_time": "2026-07-30T03:46:15.080434+00:00",
      "status": "completed"
     },
     "tags": [
@@ -881,10 +897,10 @@
    "id": "f8ce0560",
    "metadata": {
     "papermill": {
-     "duration": 0.002284,
-     "end_time": "2026-07-29T05:40:42.287887+00:00",
+     "duration": 0.001574,
+     "end_time": "2026-07-30T03:46:15.085342+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.285603+00:00",
+     "start_time": "2026-07-30T03:46:15.083768+00:00",
      "status": "completed"
     }
    },
@@ -907,16 +923,16 @@
    "id": "348479e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:42.292599Z",
-     "iopub.status.busy": "2026-07-29T05:40:42.292503Z",
-     "iopub.status.idle": "2026-07-29T05:40:42.375304Z",
-     "shell.execute_reply": "2026-07-29T05:40:42.374815Z"
+     "iopub.execute_input": "2026-07-30T03:46:15.089254Z",
+     "iopub.status.busy": "2026-07-30T03:46:15.089178Z",
+     "iopub.status.idle": "2026-07-30T03:46:15.160506Z",
+     "shell.execute_reply": "2026-07-30T03:46:15.160073Z"
     },
     "papermill": {
-     "duration": 0.085659,
-     "end_time": "2026-07-29T05:40:42.375770+00:00",
+     "duration": 0.073771,
+     "end_time": "2026-07-30T03:46:15.160753+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.290111+00:00",
+     "start_time": "2026-07-30T03:46:15.086982+00:00",
      "status": "completed"
     }
    },
@@ -979,10 +995,10 @@
    "id": "62cd1c2a",
    "metadata": {
     "papermill": {
-     "duration": 0.001711,
-     "end_time": "2026-07-29T05:40:42.379523+00:00",
+     "duration": 0.001708,
+     "end_time": "2026-07-30T03:46:15.164350+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.377812+00:00",
+     "start_time": "2026-07-30T03:46:15.162642+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1001,10 +1017,10 @@
    "id": "0a5dbfcf",
    "metadata": {
     "papermill": {
-     "duration": 0.001521,
-     "end_time": "2026-07-29T05:40:42.382640+00:00",
+     "duration": 0.001609,
+     "end_time": "2026-07-30T03:46:15.167606+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.381119+00:00",
+     "start_time": "2026-07-30T03:46:15.165997+00:00",
      "status": "completed"
     }
    },
@@ -1034,16 +1050,16 @@
    "id": "4eebcfda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:42.386655Z",
-     "iopub.status.busy": "2026-07-29T05:40:42.386568Z",
-     "iopub.status.idle": "2026-07-29T05:40:42.447740Z",
-     "shell.execute_reply": "2026-07-29T05:40:42.446663Z"
+     "iopub.execute_input": "2026-07-30T03:46:15.171503Z",
+     "iopub.status.busy": "2026-07-30T03:46:15.171424Z",
+     "iopub.status.idle": "2026-07-30T03:46:15.236935Z",
+     "shell.execute_reply": "2026-07-30T03:46:15.236343Z"
     },
     "papermill": {
-     "duration": 0.064324,
-     "end_time": "2026-07-29T05:40:42.448586+00:00",
+     "duration": 0.068207,
+     "end_time": "2026-07-30T03:46:15.237415+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.384262+00:00",
+     "start_time": "2026-07-30T03:46:15.169208+00:00",
      "status": "completed"
     }
    },
@@ -1075,16 +1091,16 @@
    "id": "57a575c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-29T05:40:42.455889Z",
-     "iopub.status.busy": "2026-07-29T05:40:42.455800Z",
-     "iopub.status.idle": "2026-07-29T05:40:42.459710Z",
-     "shell.execute_reply": "2026-07-29T05:40:42.459148Z"
+     "iopub.execute_input": "2026-07-30T03:46:15.245659Z",
+     "iopub.status.busy": "2026-07-30T03:46:15.245545Z",
+     "iopub.status.idle": "2026-07-30T03:46:15.249107Z",
+     "shell.execute_reply": "2026-07-30T03:46:15.248624Z"
     },
     "papermill": {
-     "duration": 0.007563,
-     "end_time": "2026-07-29T05:40:42.460121+00:00",
+     "duration": 0.007852,
+     "end_time": "2026-07-30T03:46:15.249519+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.452558+00:00",
+     "start_time": "2026-07-30T03:46:15.241667+00:00",
      "status": "completed"
     }
    },
@@ -1140,10 +1156,10 @@
    "id": "ce6c0655",
    "metadata": {
     "papermill": {
-     "duration": 0.001821,
-     "end_time": "2026-07-29T05:40:42.464402+00:00",
+     "duration": 0.001738,
+     "end_time": "2026-07-30T03:46:15.253101+00:00",
      "exception": false,
-     "start_time": "2026-07-29T05:40:42.462581+00:00",
+     "start_time": "2026-07-30T03:46:15.251363+00:00",
      "status": "completed"
     }
    },
@@ -1195,24 +1211,24 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "source_py_blob": "9b1a7dfcb0deb5e8a0547e6367a2840bfafd850e",
+   "executed_at": "2026-07-30T03:46:17.649252+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
+  },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.143501,
-   "end_time": "2026-07-29T05:40:43.583852+00:00",
+   "duration": 6.533984,
+   "end_time": "2026-07-30T03:46:16.474502+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/etfs/02_labels.ipynb",
    "output_path": "case_studies/etfs/02_labels.ipynb",
    "parameters": {},
-   "start_time": "2026-07-29T05:40:37.440351+00:00",
+   "start_time": "2026-07-30T03:46:09.940518+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "e10b87083a46f2812366c4bbc773bc0199811100",
-   "executed_at": "2026-07-29T05:40:50.727835+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/02_labels.py
+++ b/case_studies/etfs/02_labels.py
@@ -158,6 +158,12 @@ print(f"market_data digest: {MARKET_DATA_DIGEST}")
 # The arithmetic stays local rather than calling `fixed_time_horizon_labels`, which computes
 # the identical $(P_{t+h}-P_t)/P_t$ but agrees only to a rounding step - enough to change the
 # digest and everything derived from it. Adopting it is one deliberate change across all nine.
+#
+# Two bookkeeping columns are numbered here, on the complete price series, because both mean
+# something only before a row is dropped: `from_end` counts back from each symbol's last
+# session for Section D's boundary profile, and `session` numbers its bars forward so
+# Section F's overlap statistics keep counting trading sessions once the null tail and the
+# holdout are filtered out. Neither reaches the label parquet, which selects three columns.
 
 
 # %%
@@ -169,7 +175,8 @@ def forward_return(df: pl.DataFrame, horizon: int, name: str) -> pl.DataFrame:
 
 
 labels_df = prices.with_columns(
-    (pl.len().over("symbol") - 1 - pl.int_range(pl.len()).over("symbol")).alias("from_end")
+    (pl.len().over("symbol") - 1 - pl.int_range(pl.len()).over("symbol")).alias("from_end"),
+    pl.int_range(pl.len()).over("symbol").alias("session"),
 )
 for label_name, horizon in HORIZONS.items():
     labels_df = forward_return(labels_df, horizon, label_name)
@@ -369,13 +376,22 @@ print(
 # overlap decays, and what the row count is worth once it is priced in. `effective_sample_size`
 # applies Ch7.2's average-uniqueness weighting per symbol - concurrency is a property of one
 # entity's windows.
+#
+# Both are counted on `session`, the grid the label was built on, not on position among the
+# rows that survive to `dev`. The distinction is vacuous here - property 3 above proves the
+# only null labels are each symbol's last $h$ sessions, and the holdout filter cuts a prefix,
+# so `dev` holds an unbroken run per symbol - and it is not vacuous on a case study whose
+# bars can go missing mid-series, where closing over a hole would pair windows that share
+# nothing and report the overlap as larger than it is.
 
 # %%
 # F3. Overlap decay across the panel. Computed on one asset this would be a claim about
 # that asset: pooled and single-symbol estimates disagree most at the lag that matters.
 max_lag = PRIMARY_HORIZON + 4
-acf = panel_autocorrelation(dev[PRIMARY_LABEL], PRIMARY_LABEL, max_lag=max_lag)
-n_rows, n_eff = effective_sample_size(dev[PRIMARY_LABEL], horizon=PRIMARY_HORIZON)
+acf = panel_autocorrelation(dev[PRIMARY_LABEL], PRIMARY_LABEL, max_lag=max_lag, bar_col="session")
+n_rows, n_eff = effective_sample_size(
+    dev[PRIMARY_LABEL], horizon=PRIMARY_HORIZON, bar_col="session"
+)
 
 fig, ax = plt.subplots(figsize=FIGSIZE["single"])
 ax.bar(np.arange(1, max_lag + 1), acf, color=COLORS["blue"], width=0.7)

--- a/case_studies/utils/label_diagnostics.py
+++ b/case_studies/utils/label_diagnostics.py
@@ -2,8 +2,19 @@
 
 Both statistics here answer the same question - how much independent information a
 per-bar label with a multi-bar horizon actually carries - and both are wrong in the
-same way when computed carelessly: on one entity rather than the panel, or with the
-concurrency of overlapping windows ignored.
+same three ways when computed carelessly: on one entity rather than the panel, with
+the concurrency of overlapping windows ignored, or with the frame's row order
+mistaken for the grid the horizon is counted in.
+
+The third is why both take `bar_col`. A diagnostics frame usually holds only rows
+with a non-null label, and where a bar is missing - an outage, a settlement an
+exchange skipped, a symbol that had not listed - the surviving rows close over the
+hole. Counting positions among survivors then makes the two rows either side of a
+hole adjacent, so windows that share nothing appear to overlap and windows `lag`
+apart on the grid are pooled with windows further apart. `bar_col` names each row's
+position on the grid the label's horizon is measured in, which the caller builds
+from the frame the label was built on, before any row was dropped. Only differences
+within an entity are read, so any affine origin will do.
 """
 
 from __future__ import annotations
@@ -18,45 +29,56 @@ def panel_autocorrelation(
     column: str,
     *,
     max_lag: int,
+    bar_col: str,
     entity_col: str = "symbol",
 ) -> np.ndarray:
     """Autocorrelation of *column* at lags 1..max_lag, pooled across entities.
 
-    The lag is taken within an entity, so no pair spans two entities, and the
-    column is demeaned within its entity before pooling. Without the demeaning a
-    panel whose entities sit at different levels reports that level dispersion as
-    persistence: a series that is constant inside every entity, and so has no
-    autocorrelation to speak of, would come back at 1.0.
+    A pair is kept only if both rows belong to the same entity and their `bar_col`
+    positions differ by exactly the lag, so no pair spans two entities and none
+    spans a hole in the grid. The column is demeaned within its entity before
+    pooling: without the demeaning a panel whose entities sit at different levels
+    reports that level dispersion as persistence, and a series that is constant
+    inside every entity - so with no autocorrelation to speak of - would come back
+    at 1.0.
 
     A single-entity estimate is a claim about that entity, and the two disagree
-    most at the lag that matters - the label horizon.
+    most at the lag that matters - the label horizon. A lag with no surviving pair
+    is reported as NaN rather than dropped, so the returned array always has
+    `max_lag` entries and the lag axis of a figure drawn from it stays honest.
     """
-    centred = frame.with_columns(
-        (pl.col(column) - pl.col(column).mean().over(entity_col)).alias("_centred")
+    centred = frame.select(
+        entity_col,
+        pl.col(bar_col).alias("_bar"),
+        (pl.col(column) - pl.col(column).mean().over(entity_col)).alias("_centred"),
     )
-    return np.array(
-        [
-            centred.with_columns(pl.col("_centred").shift(-lag).over(entity_col).alias("_lagged"))
-            .select(pl.corr("_centred", "_lagged"))
-            .item()
-            for lag in range(1, max_lag + 1)
-        ]
-    )
+    out = []
+    for lag in range(1, max_lag + 1):
+        lagged = centred.select(
+            entity_col,
+            (pl.col("_bar") - lag).alias("_bar"),
+            pl.col("_centred").alias("_lagged"),
+        )
+        pairs = centred.join(lagged, on=[entity_col, "_bar"], how="inner")
+        value = pairs.select(pl.corr("_centred", "_lagged")).item() if pairs.height else None
+        out.append(np.nan if value is None else value)
+    return np.array(out, dtype=float)
 
 
 def effective_sample_size(
     frame: pl.DataFrame,
     *,
     horizon: int,
+    bar_col: str,
     entity_col: str = "symbol",
-    timestamp_col: str = "timestamp",
 ) -> tuple[int, float]:
     """Return (rows, N_eff) for a label sampled every bar over *horizon* bars.
 
     ``N_eff`` is Chapter 7.2's average-uniqueness sum: each row is weighted by the
     share of its forward window no concurrent label also spans. Concurrency is a
     property of one entity's overlapping windows, so the weights are computed per
-    entity and summed.
+    entity and summed, over the entity's own grid positions - a window that starts
+    on the far side of a hole is concurrent with nothing on the near side.
 
     **What a label occupies is ``horizon`` return intervals, not ``horizon + 1``
     bars.** The label at bar *i* is $P_{i+h}/P_i - 1$, so it consumes the returns
@@ -69,20 +91,25 @@ def effective_sample_size(
     The one-session horizon is the case that settles it: consecutive one-day
     forward returns are built from disjoint returns and are fully independent, so
     every weight must be 1 and ``N_eff`` must equal ``N``. The closed-bar form
-    returns ``N/2`` there. Average uniqueness converges to ``1/h``, so ``N_eff``
-    tends to ``N/h`` - which is the reference value the stage standard cites.
+    returns ``N/2`` there. On a gapless grid average uniqueness converges to
+    ``1/h``, so ``N_eff`` tends to ``N/h`` - the reference value the stage standard
+    cites - and a grid with holes sits above it, because a hole ends an overlap
+    early.
 
     *frame* is expected to hold only rows with a non-null label, so every row has a
     complete forward window even though the bars closing the last few are not
     themselves rows of *frame*; the endpoints are left uncapped and the concurrency
-    array extended to ``n + horizon - 1`` rather than truncated, which would shorten
-    exactly those windows.
+    array extended past the last window's end rather than truncated, which would
+    shorten exactly those windows.
     """
     rows, weight = 0, 0.0
-    for _, group in frame.sort(timestamp_col).group_by([entity_col], maintain_order=True):
-        n = group.height
-        events = np.arange(n)
-        weights = calculate_label_uniqueness(events, events + horizon - 1, n_bars=n + horizon - 1)
-        rows += n
+    for _, group in frame.group_by([entity_col]):
+        bars = group[bar_col].to_numpy()
+        bars = bars - bars.min()
+        events = np.sort(bars)
+        weights = calculate_label_uniqueness(
+            events, events + horizon - 1, n_bars=int(events[-1]) + horizon
+        )
+        rows += group.height
         weight += float(weights.sum())
     return rows, weight

--- a/tests/test_label_diagnostics.py
+++ b/tests/test_label_diagnostics.py
@@ -2,8 +2,9 @@
 
 Both statistics are cheap to compute wrongly in a way that looks plausible: an
 autocorrelation that silently pairs one entity's last row with the next entity's
-first, and an effective sample size that returns the row count when the windows
-do not in fact overlap.
+first, an effective sample size that returns the row count when the windows do not
+in fact overlap, and either one closing over a hole in the grid so that windows
+sharing nothing are counted as adjacent.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ def _panel(n_per_symbol: int = 60, symbols: tuple[str, ...] = ("A", "B")) -> pl.
         {
             "symbol": [s for s in symbols for _ in range(n_per_symbol)],
             "timestamp": list(range(n_per_symbol)) * len(symbols),
+            "bar": list(range(n_per_symbol)) * len(symbols),
             "x": rng.normal(size=n_per_symbol * len(symbols)),
         }
     )
@@ -33,10 +35,11 @@ def test_autocorrelation_of_a_repeating_series_is_one_at_the_period() -> None:
         {
             "symbol": ["A"] * 40,
             "timestamp": list(range(40)),
+            "bar": list(range(40)),
             "x": [float(i % period) for i in range(40)],
         }
     )
-    acf = panel_autocorrelation(frame, "x", max_lag=period)
+    acf = panel_autocorrelation(frame, "x", max_lag=period, bar_col="bar")
     assert acf[period - 1] == 1.0
     assert acf[0] < 0
 
@@ -49,10 +52,11 @@ def test_level_differences_between_entities_are_not_persistence() -> None:
         {
             "symbol": ["A"] * 10 + ["B"] * 10,
             "timestamp": list(range(10)) * 2,
+            "bar": list(range(10)) * 2,
             "x": [1.0] * 10 + [5.0] * 10,
         }
     )
-    acf = panel_autocorrelation(frame, "x", max_lag=3)
+    acf = panel_autocorrelation(frame, "x", max_lag=3, bar_col="bar")
     assert np.all(np.isnan(acf)), acf
 
 
@@ -66,7 +70,7 @@ def test_a_one_session_horizon_loses_no_information() -> None:
     labels appear to share one even here, and this returns N/2.
     """
     frame = _panel(n_per_symbol=50)
-    rows, n_eff = effective_sample_size(frame, horizon=1)
+    rows, n_eff = effective_sample_size(frame, horizon=1, bar_col="bar")
     assert rows == 100
     assert n_eff == pytest.approx(rows)
 
@@ -74,7 +78,7 @@ def test_a_one_session_horizon_loses_no_information() -> None:
 def test_overlapping_windows_shrink_the_effective_count_toward_n_over_h() -> None:
     horizon = 10
     frame = _panel(n_per_symbol=1000)
-    rows, n_eff = effective_sample_size(frame, horizon=horizon)
+    rows, n_eff = effective_sample_size(frame, horizon=horizon, bar_col="bar")
     assert rows == 2000
     assert n_eff < rows
     # A label spans h return intervals and its neighbour shares h-1 of them, so
@@ -101,7 +105,7 @@ def test_effective_sample_size_matches_uniqueness_computed_by_hand(
     """Pins both conventions at once: h intervals per label, and complete windows
     at the boundary rather than endpoints truncated at the row count."""
     frame = _panel(n_per_symbol=n, symbols=("A",))
-    rows, n_eff = effective_sample_size(frame, horizon=horizon)
+    rows, n_eff = effective_sample_size(frame, horizon=horizon, bar_col="bar")
     assert rows == n
     assert n_eff == pytest.approx(expected)
 
@@ -121,15 +125,81 @@ def test_the_anchor_bar_is_not_counted_as_consumed() -> None:
     assert with_anchor / n == pytest.approx(1 / (horizon + 1), abs=0.005)
 
 
+def _gapped_alternating(blocks: tuple[tuple[int, int], ...]) -> pl.DataFrame:
+    """One entity sampled on a grid with holes, valued +1/-1 by grid parity.
+
+    *blocks* is a sequence of (first bar, length) runs, so the bars between two
+    runs are absent from the grid rather than absent from the data.
+    """
+    bars = [b for start, length in blocks for b in range(start, start + length)]
+    return pl.DataFrame(
+        {
+            "symbol": ["A"] * len(bars),
+            "bar": bars,
+            "x": [1.0 if b % 2 == 0 else -1.0 for b in bars],
+        }
+    )
+
+
+def test_a_hole_in_the_grid_is_not_read_as_adjacency() -> None:
+    """The defect this argument exists to stop.
+
+    The series alternates with grid parity, so its true lag-1 autocorrelation is
+    exactly -1. Every run here starts on an even bar, so pairing rows by their
+    position among the surviving rows joins the last row of one run to the first of
+    the next - two rows of the same parity - and reports persistence where the grid
+    says there is none.
+    """
+    frame = _gapped_alternating(((0, 3), (4, 3), (8, 3), (12, 3)))
+    acf = panel_autocorrelation(frame, "x", max_lag=1, bar_col="bar")
+    assert acf[0] == pytest.approx(-1.0)
+
+    positional = frame.with_columns(pl.int_range(pl.len()).over("symbol").alias("row"))
+    spurious = panel_autocorrelation(positional, "x", max_lag=1, bar_col="row")[0]
+    assert spurious == pytest.approx(-4 / 7)  # three of the eleven pairs span a hole
+
+
+def test_labels_either_side_of_a_hole_do_not_overlap() -> None:
+    """Two runs far enough apart share no forward window, so the effective count is
+    twice one run's - not the smaller number that treating the six rows as six
+    consecutive bars returns."""
+    horizon = 3
+    two_runs = _gapped_alternating(((0, 3), (10, 3)))
+    one_run = _gapped_alternating(((0, 3),))
+
+    rows, n_eff = effective_sample_size(two_runs, horizon=horizon, bar_col="bar")
+    assert rows == 6
+    assert n_eff == pytest.approx(
+        2 * effective_sample_size(one_run, horizon=horizon, bar_col="bar")[1]
+    )
+    assert n_eff == pytest.approx(10 / 3)  # 5/3 per run, computed by hand as above
+
+    positional = two_runs.with_columns(pl.int_range(pl.len()).over("symbol").alias("row"))
+    contiguous = effective_sample_size(positional, horizon=horizon, bar_col="row")[1]
+    assert contiguous == pytest.approx(8 / 3)  # six consecutive bars, overlap overstated
+
+
+def test_bars_are_taken_from_the_grid_regardless_of_row_order() -> None:
+    """The grid column, not the frame's order, decides what is adjacent."""
+    frame = _gapped_alternating(((0, 8),))
+    shuffled = frame.sample(fraction=1.0, shuffle=True, seed=0)
+    assert panel_autocorrelation(shuffled, "x", max_lag=2, bar_col="bar") == pytest.approx(
+        panel_autocorrelation(frame, "x", max_lag=2, bar_col="bar")
+    )
+    assert effective_sample_size(shuffled, horizon=3, bar_col="bar") == pytest.approx(
+        effective_sample_size(frame, horizon=3, bar_col="bar")
+    )
+
+
 def test_effective_sample_size_is_computed_per_entity() -> None:
     """One symbol of 2n rows carries less independent information than two of n:
     concurrency stops at an entity boundary."""
     horizon = 10
     one = _panel(n_per_symbol=200, symbols=("A",))
     two = _panel(n_per_symbol=100, symbols=("A", "B"))
-    assert effective_sample_size(one, horizon=horizon)[0] == 200
-    assert effective_sample_size(two, horizon=horizon)[0] == 200
+    assert effective_sample_size(one, horizon=horizon, bar_col="bar")[0] == 200
+    assert effective_sample_size(two, horizon=horizon, bar_col="bar")[0] == 200
     assert (
-        effective_sample_size(two, horizon=horizon)[1]
-        > effective_sample_size(one, horizon=horizon)[1]
+        effective_sample_size(two, horizon=horizon, bar_col="bar")[1]
+        > effective_sample_size(one, horizon=horizon, bar_col="bar")[1]
     )


### PR DESCRIPTION
`panel_autocorrelation` paired rows by position among the rows handed to it, and `effective_sample_size` numbered its events with `arange`. A diagnostics frame holds only rows with a non-null label, so where a bar is missing the surviving rows close over the hole: two windows that share nothing are counted as adjacent, windows `lag` apart on the grid are pooled with windows further apart, and the reported overlap comes out larger than it is.

## The fix

Both functions now take `bar_col`, the row's position on the grid the horizon is counted in, built by the caller from the frame the label was built on - before any row is dropped. A pair enters the autocorrelation only if the two positions differ by exactly the lag; uniqueness is weighted over the entity's own grid positions, so a hole ends an overlap instead of hiding it. It is a required keyword rather than an optional one: the default that made this silent is the defect.

## What moves, measured on production data

| | grid | positional (shipped) |
|---|---|---|
| `etfs` `fwd_ret_21d` N_eff | 20,017.238095 | 20,017.238095 |
| crypto `fwd_ret_24h` N_eff | 22,072 | 22,026 |
| crypto `fwd_ret_24h` N_eff / N | 0.334222 | 0.333525 |
| crypto `fwd_ret_8h` acf lag 1 | 0.029775 | 0.030319 |

`etfs` has no absent sessions - property 3 in `02_labels` proves the only null labels are each symbol's last *h* - so every statistic is identical to six decimals and its re-executed notebook differs only in source, prose and provenance. No published `etfs` number changes and no artifact digest moves (the label parquet selects its three columns explicitly).

Crypto's numbers do move, and the four-decimal agreement with 1/*h* that its earlier reading suggested was an artifact of the positional index: with the holes counted, uniqueness sits slightly *above* 1/*h*, which is what a hole ending an overlap early should do. That notebook is on its own branch and picks this up there.

## Tests

Three new regression tests pin the difference with values computed by hand rather than recorded from a run: `-1.0` against `-4/7` for the lag-1 autocorrelation of a parity-alternating series sampled with holes, `10/3` against `8/3` for the effective count of two runs either side of a gap, and one that the grid column rather than row order decides adjacency. The existing seven still pass unchanged apart from naming the grid.
