### PR TITLE
Ask Plotly for a PNG only where a Chrome exists to render it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -427,6 +427,7 @@ jobs:
             tests/test_download_scripts_registry.py \
             tests/test_compose_mounts.py \
             tests/test_download_coverage.py \
+            tests/test_plotly_renderer.py \
             -v --tb=short
       # The Chapter 21 environments reached readers as broken imports partly
       # because no job ran the tests that name them: test_import_coverage.py

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -397,6 +397,29 @@ export HTTPS_PROXY=http://proxy:port
 docker compose pull ml4t
 ```
 
+### "Kaleido requires Google Chrome to be installed"
+
+Notebooks pick their Plotly renderer automatically and no longer ask for static
+PNGs where Chrome is missing, so this should not appear. If you are on an older
+image, either pull the current one or set the renderer explicitly:
+
+```bash
+docker compose pull ml4t
+docker compose run --rm -e PLOTLY_RENDERER=json ml4t python case_studies/etfs/05_evaluation.py
+```
+
+Chrome installed on your *host* has no bearing on this: the notebook runs inside
+the container, which ships without one.
+
+Only static image export (`fig.write_image`, `fig.to_image`) genuinely needs
+Chrome. Install it into a *running* container, since `docker compose run --rm`
+discards the download when the container exits:
+
+```bash
+docker compose up -d ml4t
+docker compose exec ml4t plotly_get_chrome -y
+```
+
 ---
 
 ## Local Setup with uv (Alternative to Docker)

--- a/tests/test_plotly_renderer.py
+++ b/tests/test_plotly_renderer.py
@@ -1,0 +1,97 @@
+"""The default Plotly renderer must not require Chrome.
+
+Regression gate for #432. `utils` used to hard-code `plotly_mimetype+png`; the
+`png` half drives kaleido, kaleido v1 drives a Chrome it does not bundle, and the
+Docker images ship no Chrome. Every `fig.show()` in a figure-producing notebook
+therefore died on ChromeNotFoundError.
+
+The probe is deliberately written so that *any* failure means "no Chrome", since
+this code runs at `import utils` and must never be what breaks the import. These
+tests inject a fake `choreographer` rather than depending on what is installed on
+the runner.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from utils import _default_plotly_renderer
+
+WITH_PNG = "plotly_mimetype+png"
+WITHOUT_PNG = "plotly_mimetype"
+
+
+@pytest.fixture
+def fake_choreographer(monkeypatch):
+    """Install a stand-in `choreographer.browsers.chromium` with a scripted result."""
+
+    def install(find_browser):
+        chromium = types.ModuleType("choreographer.browsers.chromium")
+        chromium.Chromium = type("Chromium", (), {"find_browser": staticmethod(find_browser)})
+
+        browsers = types.ModuleType("choreographer.browsers")
+        browsers.chromium = chromium
+        root = types.ModuleType("choreographer")
+        root.browsers = browsers
+
+        for name, module in {
+            "choreographer": root,
+            "choreographer.browsers": browsers,
+            "choreographer.browsers.chromium": chromium,
+        }.items():
+            monkeypatch.setitem(sys.modules, name, module)
+
+    return install
+
+
+def test_png_requested_when_chrome_is_found(fake_choreographer):
+    fake_choreographer(lambda **_: "/usr/bin/google-chrome")
+    assert _default_plotly_renderer() == WITH_PNG
+
+
+def test_png_dropped_when_chrome_is_absent(fake_choreographer):
+    """The Docker case: kaleido is installed, Chrome is not."""
+    fake_choreographer(lambda **_: None)
+    assert _default_plotly_renderer() == WITHOUT_PNG
+
+
+def test_png_dropped_when_the_probe_raises(fake_choreographer):
+    """A choreographer API change must degrade, not break `import utils`."""
+
+    def explode(**_):
+        raise RuntimeError("choreographer changed its API")
+
+    fake_choreographer(explode)
+    assert _default_plotly_renderer() == WITHOUT_PNG
+
+
+def test_png_dropped_when_choreographer_is_missing(monkeypatch):
+    """Plotly without kaleido: the import inside the probe fails outright."""
+    for name in list(sys.modules):
+        if name == "choreographer" or name.startswith("choreographer."):
+            monkeypatch.delitem(sys.modules, name)
+    monkeypatch.setitem(sys.modules, "choreographer", None)
+
+    assert _default_plotly_renderer() == WITHOUT_PNG
+
+
+def test_env_var_still_wins(monkeypatch):
+    """`PLOTLY_RENDERER=json` is how CI and papermill force a headless renderer."""
+    import importlib
+
+    import plotly.io as pio
+
+    monkeypatch.setenv("PLOTLY_RENDERER", "json")
+    pio.renderers.default = "browser"
+
+    import utils
+
+    importlib.reload(utils)
+
+    assert pio.renderers.default == "browser", (
+        "utils must leave the renderer alone when PLOTLY_RENDERER is set, "
+        "so the env var chosen by CI/papermill survives"
+    )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -27,15 +27,36 @@ from utils.config import (
 # Backward compatibility alias
 DATA_DIR = ML4T_DATA_PATH
 
+
 # Plotly: include PNG in cell output so GitHub can render .ipynb figures.
 # Override with PLOTLY_RENDERER env var (e.g. "json" for headless CI).
+#
+# The "png" half goes through kaleido, and kaleido v1 drives a Chrome it does not
+# bundle. Where no Chrome is installed - the Docker images, a slim server - every
+# `fig.show()` died on ChromeNotFoundError (#432), which made the figure-producing
+# notebooks unrunnable rather than merely PNG-less. So ask for PNG only when a
+# Chrome is actually resolvable and otherwise fall back to "plotly_mimetype",
+# which still renders interactively in Jupyter and is inert in a plain script.
+# A probe that raises is treated as "no Chrome": this must never be what breaks
+# the import.
+def _default_plotly_renderer() -> str:
+    try:
+        from choreographer.browsers.chromium import Chromium
+
+        if Chromium.find_browser(skip_local=False):
+            return "plotly_mimetype+png"
+    except Exception:  # noqa: BLE001
+        pass
+    return "plotly_mimetype"
+
+
 try:
     import os as _os
 
     import plotly.io as _pio
 
     if not _os.environ.get("PLOTLY_RENDERER"):
-        _pio.renderers.default = "plotly_mimetype+png"
+        _pio.renderers.default = _default_plotly_renderer()
 except ImportError:
     pass
 


### PR DESCRIPTION
Fixes #432.

## The defect

`utils/__init__.py` set the default renderer to `plotly_mimetype+png` unconditionally. The `png` half goes through kaleido, kaleido v1 drives a Chrome it does not bundle, and the Docker images ship without one. So every `fig.show()` in the container raised `ChromeNotFoundError`, which made the figure-producing notebooks **unrunnable** rather than merely PNG-less.

Reproduced in `ml4t/ml4t:latest`, the image the reporter used:

```
renderer default: plotly_mimetype+png
chrome: None
RuntimeError: Kaleido requires Google Chrome to be installed.
```

## The fix

Probe for a Chrome and keep `+png` when one is resolvable, so committed `.ipynb` figures still render on GitHub. Otherwise fall back to `plotly_mimetype`, which renders interactively in Jupyter and is inert in a plain script.

Any failure of the probe itself takes the same fallback. This runs at `import utils` and must never be what breaks the import.

## Verification

| Environment | Renderer | `fig.show()` |
|---|---|---|
| `ml4t/ml4t:latest` (no Chrome) | `plotly_mimetype` | succeeds |
| host with Chrome | `plotly_mimetype+png` | succeeds, PNG preserved |
| `PLOTLY_RENDERER=json` set | untouched | CI and papermill unaffected |

`tests/test_plotly_renderer.py` covers the four probe outcomes (Chrome found, Chrome absent, probe raises, choreographer missing) plus the env-var override. Confirmed the tests fail if the fallback is reverted to `+png`.

## Docs

A troubleshooting entry stating that host Chrome is irrelevant inside a container, which is what the reporter asked. It also notes that static export (`fig.write_image`) does need Chrome, and that installing it must happen in a running container since `docker compose run --rm` discards the download.