### PR TITLE
Run the leakage and holdout-boundary detectors in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -490,6 +490,24 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/test_pvalue_tail_precision.py -v --tb=short
 
+      # The methodology ratchet. Both files are static AST/source scans over the
+      # notebook tree, so they need no data and no model deps, and both were
+      # ungated: nothing invoked either one. The cost of that showed up the first
+      # time they were run from CI's perspective — the random-split bucket still
+      # listed an occurrence that no longer exists in the source, which is the
+      # ratchet's own staleness check firing after the drift, not before it.
+      # A leak-shaped call added to any notebook now fails the PR that adds it.
+      - name: Run leakage and holdout-boundary detectors
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_leakage_detectors.py \
+            tests/test_holdout_boundary.py \
+            -v --tb=short
+
   # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)
   #

--- a/tests/test_leakage_detectors.py
+++ b/tests/test_leakage_detectors.py
@@ -269,10 +269,6 @@ RANDOM_SPLIT_ALLOWLIST: dict[str, str] = {
 
 # Backlog: known, UN-AUDITED occurrences awaiting that chapter's Gate-0 pass. NOT approvals.
 RANDOM_SPLIT_PENDING: dict[str, str] = {
-    "21_rl_execution_hedging/06_inverse_reinforcement_learning.py": "Ch21, UN-AUDITED: "
-    "behavior-cloning split of (state, action) expert pairs. ⚠ trajectory (state,action) "
-    "pairs are NOT automatically i.i.d. — adjacent states from one episode can straddle the "
-    "split; resolve at the Ch21 pass with a trajectory/episode-grouped split. NOT approved.",
     "23_knowledge_graphs/06_gnn_feature_engineering.py": "Ch23, UN-AUDITED: KFold(shuffle="
     "True) in GNN feature engineering. Resolve at the Ch23 Gate-0 pass. NOT approved.",
 }


### PR DESCRIPTION
Two static scanners already lived in `tests/` but nothing ran them, so they were
enforcing nothing.

`tests/test_leakage_detectors.py` and `tests/test_holdout_boundary.py` are AST and
source scans over the notebook tree. They need no data, no model dependencies and
no GPU, so they belong in `test-unit` alongside the other cheap checks.

The first thing running them surfaced was a failure that predates this branch: the
random-split ratchet listed `21_rl_execution_hedging/06_inverse_reinforcement_learning.py`
as a pending occurrence, and that split call is no longer in the source. The
ratchet's own staleness check was red, unobserved, because nothing invoked it. The
stale entry is removed here.

Verified against a faithful reproduction of the `test-unit` job environment
(`uv venv --python 3.14` plus the job's exact install list): **28 passed, 2 skipped**.

Effect going forward: a leak-shaped call added to any notebook fails the pull
request that adds it, rather than being found later by reading.
