### PR TITLE
Stop storing t = 0 for an IC that was never aggregated

### DIFF
--- a/case_studies/RUN_LOG.md
+++ b/case_studies/RUN_LOG.md
@@ -380,11 +380,12 @@ Headline metrics aggregated across walk-forward folds, one row per prediction se
 |----------------------|------|------------------------------------------------------------|
 | `prediction_hash`    | TEXT | Primary key, foreign to `prediction_sets`                  |
 | `computed_at`        | TEXT | ISO 8601 UTC timestamp                                     |
-| `ic_mean`            | REAL | Mean cross-sectional Spearman IC across folds              |
-| `ic_std`             | REAL | Std-dev of fold-level IC                                   |
-| `ic_t`               | REAL | `ic_mean / (ic_std / √n_folds)`                            |
-| `n_folds`            | REAL | Number of folds aggregated                                 |
-| `pct_positive`       | REAL | Fraction of folds with IC > 0                              |
+| `ic_mean`            | REAL | Mean cross-sectional Spearman IC over the folds with a defined IC |
+| `ic_std`             | REAL | Std-dev of fold-level IC (0.0 when fewer than two folds define one) |
+| `ic_t`               | REAL | Diagnostic fold-level t, `ic_mean / (ic_std / √n_folds_ic)`. **NULL when undefined** — fewer than two folds with an IC, or no dispersion across them. Read `ic_t_hac` for inference: it is the HAC t on the daily IC series and comes with `ic_ci_lo` / `ic_ci_hi` |
+| `n_folds`            | REAL | Number of folds present in the prediction set              |
+| `n_folds_ic`         | REAL | Number of those folds that produced a defined IC. Below `n_folds` means partial coverage: some fold scored constant and contributes to no IC statistic |
+| `pct_positive`       | REAL | Fraction of the folds with a defined IC whose IC > 0       |
 | `task_type`          | TEXT | `'regression'` or `'classification'`                       |
 | `accuracy`           | REAL | Classification: accuracy at threshold (NULL for regression) |
 | `balanced_accuracy`  | REAL | Classification: balanced accuracy                          |

--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -35,6 +35,14 @@ def compute_prediction_fold_metrics(
     - headline_metrics: aggregated across all folds
     - fold_metrics: per-fold breakdown keyed by fold_id
 
+    Folds whose scores are constant produce no cross-sectional IC. Headline
+    ``ic_mean`` / ``ic_std`` / ``ic_t`` / ``pct_positive`` are computed over the
+    folds that did produce one, and ``n_folds_ic`` reports how many that was
+    against ``n_folds``. ``ic_t`` is None when fewer than two folds have a defined
+    IC or the folds show no dispersion. The fold-based ``ic_t`` is a diagnostic:
+    the inferential statistic is ``ic_t_hac``, computed below on the daily IC
+    series with its confidence interval.
+
     Regression metrics: ic, ic_std, rmse, mae, n_entities
     Classification metrics: ic, ic_std, auc_roc, log_loss, brier_score,
         accuracy, balanced_accuracy, auc_pr, n_entities
@@ -137,16 +145,34 @@ def compute_prediction_fold_metrics(
 
         fold_results[fold_id] = fold_m
 
-    # Headline aggregates — IC always computed
+    # Headline aggregates over the folds that produced a *defined* IC.
+    #
+    # A fold whose scores are constant has no cross-sectional rank correlation, so
+    # `cross_sectional_ic` returns NaN for it — an L1 config that zeroes every
+    # coefficient on one fold is the case that surfaced this. Aggregating with plain
+    # `np.mean`/`np.std` propagates that NaN into every headline value, and because
+    # `np.nan > 0` is False the `ic_t` guard fell through to a sentinel `0.0`. A
+    # stored `ic_t = 0.0` reads as "this IC is indistinguishable from zero", which is
+    # a claim; "not computable" is not. Aggregate over the defined folds, count them
+    # in `n_folds_ic` so partial coverage is visible next to `n_folds`, and return
+    # None (SQL NULL) for a t statistic that does not exist.
+    #
+    # `ic_std` keeps its 0.0-when-undefined convention: `_verify_cached_config` in
+    # `case_studies/utils/gbm.py` reads the stored value through `float()`, which a
+    # NULL would raise on.
     fold_ics = [fm["ic"] for fm in fold_results.values()]
-    headline: dict[str, float | str] = {
-        "ic_mean": float(np.mean(fold_ics)) if fold_ics else 0.0,
-        "ic_std": float(np.std(fold_ics)) if len(fold_ics) > 1 else 0.0,
-        "ic_t": float(np.mean(fold_ics) / (np.std(fold_ics) / np.sqrt(len(fold_ics))))
-        if len(fold_ics) > 1 and np.std(fold_ics) > 0
-        else 0.0,
+    defined_ics = [float(ic) for ic in fold_ics if ic is not None and np.isfinite(ic)]
+    n_ic = len(defined_ics)
+    ic_dispersion = float(np.std(defined_ics)) if n_ic > 1 else 0.0
+    headline: dict[str, float | str | None] = {
+        "ic_mean": float(np.mean(defined_ics)) if n_ic else None,
+        "ic_std": ic_dispersion,
+        "ic_t": float(np.mean(defined_ics) / (ic_dispersion / np.sqrt(n_ic)))
+        if n_ic > 1 and ic_dispersion > 0
+        else None,
         "n_folds": len(folds),
-        "pct_positive": float(np.mean([ic > 0 for ic in fold_ics])) if fold_ics else 0.0,
+        "n_folds_ic": n_ic,
+        "pct_positive": float(np.mean([ic > 0 for ic in defined_ics])) if n_ic else None,
         "task_type": "classification" if task_type == "classification" else "regression",
     }
 

--- a/tests/test_registry_metrics.py
+++ b/tests/test_registry_metrics.py
@@ -21,6 +21,9 @@ These tests lock in:
 - Headline aggregation: ``ic_mean`` = mean across folds, ``ic_t`` =
   Newey-West-free pooled t, ``pct_positive`` = fraction of folds with
   IC > 0, ``n_folds`` = count, ``task_type`` = 'classification' for classification.
+- Folds with an undefined IC (constant scores ⇒ no rank correlation) are
+  excluded from every headline aggregate instead of poisoning it with NaN,
+  and ``ic_t`` is None rather than 0.0 when it cannot be computed.
 
 All fixtures are hermetic — no real data, no setup.yaml.
 """
@@ -267,13 +270,140 @@ def test_classification_auc_is_computed_on_binary_label(classification_predictio
 # -----------------------------------------------------------------------------
 
 
-def test_single_fold_returns_zero_ic_std_and_zero_t(regression_predictions) -> None:
-    """With only one fold, cross-fold stddev is undefined; the function reports 0."""
+def test_single_fold_reports_zero_ic_std_and_null_t(regression_predictions) -> None:
+    """One fold gives no cross-fold dispersion, so there is no t to report."""
     fold0_only = regression_predictions.filter(pl.col("fold_id") == 0)
     headline, _ = compute_prediction_fold_metrics(fold0_only, task_type="regression")
     assert headline["n_folds"] == 1
+    assert headline["n_folds_ic"] == 1
     assert headline["ic_std"] == 0.0
-    assert headline["ic_t"] == 0.0
+    assert headline["ic_t"] is None
+
+
+# -----------------------------------------------------------------------------
+# Folds with an undefined IC
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def fourfold_predictions() -> pl.DataFrame:
+    """4 folds × 10 dates × 10 entities with y_score ≈ y_true."""
+    rng = np.random.default_rng(7)
+    rows = []
+    for fold in range(4):
+        for d in range(10):
+            for e in range(10):
+                y_true = float(rng.normal())
+                rows.append(
+                    {
+                        "timestamp": f"2024-{fold + 1:02d}-{d + 1:02d}",
+                        "symbol": f"S{e}",
+                        "fold_id": fold,
+                        "y_true": y_true,
+                        "y_score": 0.8 * y_true + 0.2 * float(rng.normal()),
+                    }
+                )
+    return pl.DataFrame(rows).with_columns(pl.col("timestamp").str.to_date())
+
+
+@pytest.fixture(scope="module")
+def predictions_with_one_constant_fold(fourfold_predictions) -> pl.DataFrame:
+    """Fold 3 scores every entity identically, so it has no cross-sectional IC.
+
+    This is what an L1 config does when its penalty zeroes every coefficient on
+    one fold: the predictions become constant, the per-date rank correlation is
+    undefined, and ``cross_sectional_ic`` returns NaN for that fold.
+    """
+    return fourfold_predictions.with_columns(
+        y_score=pl.when(pl.col("fold_id") == 3).then(1.0).otherwise(pl.col("y_score"))
+    )
+
+
+def test_constant_fold_yields_nan_fold_ic(predictions_with_one_constant_fold) -> None:
+    """Precondition for the tests below: the constant fold really does produce NaN."""
+    _, folds = compute_prediction_fold_metrics(
+        predictions_with_one_constant_fold, task_type="regression"
+    )
+    assert all(np.isfinite(folds[f]["ic"]) for f in (0, 1, 2))
+    assert not np.isfinite(folds[3]["ic"])
+
+
+def test_undefined_fold_ic_does_not_zero_the_headline_t(
+    predictions_with_one_constant_fold,
+) -> None:
+    """A NaN fold must not send ``ic_t`` to a sentinel 0.0.
+
+    Regression test. Aggregating with plain ``np.mean``/``np.std`` propagated the
+    NaN, and because ``np.nan > 0`` is False the dispersion guard fell through to
+    ``0.0`` — storing "t = 0", i.e. "this IC is indistinguishable from zero", for
+    configurations whose IC was simply never aggregated. Six rows in the shipped
+    ETF registry carried ``ic_t = 0.0`` alongside a mean IC of +0.054 over 8 folds.
+    """
+    headline, folds = compute_prediction_fold_metrics(
+        predictions_with_one_constant_fold, task_type="regression"
+    )
+    defined = np.array([folds[f]["ic"] for f in (0, 1, 2)])
+    expected_t = float(np.mean(defined) / (np.std(defined) / np.sqrt(len(defined))))
+    assert headline["ic_t"] is not None
+    assert headline["ic_t"] != 0.0
+    assert math.isclose(headline["ic_t"], expected_t, rel_tol=1e-12)
+
+
+def test_headline_aggregates_over_the_folds_with_a_defined_ic(
+    predictions_with_one_constant_fold,
+) -> None:
+    """``ic_mean`` / ``ic_std`` come from the folds that produced an IC."""
+    headline, folds = compute_prediction_fold_metrics(
+        predictions_with_one_constant_fold, task_type="regression"
+    )
+    defined = [folds[f]["ic"] for f in (0, 1, 2)]
+    assert math.isclose(headline["ic_mean"], float(np.mean(defined)), rel_tol=1e-12)
+    assert math.isclose(headline["ic_std"], float(np.std(defined)), rel_tol=1e-12)
+
+
+def test_n_folds_ic_counts_only_folds_with_an_ic(predictions_with_one_constant_fold) -> None:
+    """``n_folds`` stays the fold count; ``n_folds_ic`` exposes partial coverage."""
+    headline, _ = compute_prediction_fold_metrics(
+        predictions_with_one_constant_fold, task_type="regression"
+    )
+    assert headline["n_folds"] == 4
+    assert headline["n_folds_ic"] == 3
+
+
+def test_pct_positive_ignores_folds_without_an_ic(predictions_with_one_constant_fold) -> None:
+    """A NaN fold must not be counted as a non-positive one.
+
+    ``np.nan > 0`` is False, so the old expression silently scored every
+    undefined fold against the signal.
+    """
+    headline, folds = compute_prediction_fold_metrics(
+        predictions_with_one_constant_fold, task_type="regression"
+    )
+    assert all(folds[f]["ic"] > 0 for f in (0, 1, 2))
+    assert headline["pct_positive"] == 1.0
+
+
+def test_single_defined_fold_reports_null_t(fourfold_predictions) -> None:
+    """Three of four folds constant ⇒ one IC ⇒ no dispersion ⇒ no t."""
+    one_left = fourfold_predictions.with_columns(
+        y_score=pl.when(pl.col("fold_id") == 0).then(pl.col("y_score")).otherwise(1.0)
+    )
+    headline, _ = compute_prediction_fold_metrics(one_left, task_type="regression")
+    assert headline["n_folds"] == 4
+    assert headline["n_folds_ic"] == 1
+    assert headline["ic_mean"] is not None
+    assert headline["ic_t"] is None
+
+
+def test_headline_ic_is_null_when_no_fold_defines_one(fourfold_predictions) -> None:
+    """Every fold constant ⇒ nothing to average, and NULL rather than 0.0."""
+    all_constant = fourfold_predictions.with_columns(y_score=pl.lit(1.0))
+    headline, _ = compute_prediction_fold_metrics(all_constant, task_type="regression")
+    assert headline["n_folds"] == 4
+    assert headline["n_folds_ic"] == 0
+    assert headline["ic_mean"] is None
+    assert headline["ic_t"] is None
+    assert headline["pct_positive"] is None
 
 
 def test_accepts_pandas_dataframe(regression_predictions) -> None:


### PR DESCRIPTION
## The defect

`prediction_metrics.ic_t` is stored as `0.0` for configurations whose t statistic was never computed, which reads as "this IC is indistinguishable from zero".

A fold whose scores are constant has no cross-sectional rank correlation, so `cross_sectional_ic` returns NaN for that fold. An L1 config whose penalty zeroes every coefficient on one fold produces exactly that. The headline aggregation in `compute_prediction_fold_metrics` used plain `np.mean`/`np.std` over the fold ICs, so a single NaN fold poisoned every headline value, and because `np.nan > 0` is False the dispersion guard fell through to the sentinel:

```python
"ic_t": float(np.mean(fold_ics) / (np.std(fold_ics) / np.sqrt(len(fold_ics))))
if len(fold_ics) > 1 and np.std(fold_ics) > 0
else 0.0,
```

`pct_positive` had the same defect in the same expression: `np.nan > 0` is False, so an undefined fold was silently counted against the signal.

## What changed

- Headline `ic_mean` / `ic_std` / `ic_t` / `pct_positive` aggregate over the folds that produced a **defined** IC instead of propagating NaN.
- New `n_folds_ic` records how many folds that was, against `n_folds`, so partial coverage is visible in the row rather than hidden behind a mean that silently averages a subset.
- `ic_t` is `None` (SQL NULL) when it cannot be computed — fewer than two defined folds, or no dispersion across them. A zero t is a claim; a null is not.
- `ic_std` keeps its 0.0-when-undefined convention: `_verify_cached_config` in `case_studies/utils/gbm.py` reads the stored value through `float()`.
- `case_studies/RUN_LOG.md` documents the columns and points at `ic_t_hac` as the inferential statistic.

This changes what a re-run writes. It does not modify any existing registry.

## Tests

`tests/test_registry_metrics.py` gains a 4-fold fixture whose fourth fold scores every entity identically, reproducing the NaN fold:

```
7 failed, 16 passed   # against the unfixed metrics.py
23 passed             # after
```

The new cases pin: the constant fold really does yield NaN; `ic_t` is neither 0.0 nor None and equals the naive t over the three surviving folds; `ic_mean`/`ic_std` match the surviving folds; `n_folds_ic` is 3 of 4; `pct_positive` ignores the undefined fold; one defined fold gives a NULL t; no defined fold gives NULL throughout.

Verified end to end against the committed prediction sets: recomputing an affected configuration reproduces the stored `ic_mean` (0.054352), `ic_std` (0.036777) and `ic_t_hac` (1.8732) exactly, confirming this is the code path that wrote those rows, and the only value that moves is `ic_t`, from `0.0` to `3.6200` over the 6 of 8 folds that define an IC.