### PR TITLE
Compute the DML tail p-value with sf, and detect the ones that are not

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,6 +378,18 @@ jobs:
           source .venv/bin/activate
           python -m pytest tests/test_notebook_output_hygiene.py -q \
             --deselect tests/test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks
+      # A two-tailed p-value written as `2 * (1 - dist.cdf(abs(t)))` returns
+      # exactly 0.0 above |t| ~8.35, so a notebook teaching inference printed
+      # `p=0` for a number no computation produced. `dist.sf` is the correct
+      # call. The pattern is grep-visible, and the scan is unfiltered for the
+      # same reason as the pair-sync check: it is reintroduced by copying an
+      # expression from one chapter into another, not by editing one file.
+      # The scan is stdlib-only; the numeric tests in the same file skip here
+      # for want of scipy and the modelling stack.
+      - name: No tail probability computed as 1 - cdf
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/test_pvalue_tail_precision.py -q
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,18 +378,6 @@ jobs:
           source .venv/bin/activate
           python -m pytest tests/test_notebook_output_hygiene.py -q \
             --deselect tests/test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks
-      # A two-tailed p-value written as `2 * (1 - dist.cdf(abs(t)))` returns
-      # exactly 0.0 above |t| ~8.35, so a notebook teaching inference printed
-      # `p=0` for a number no computation produced. `dist.sf` is the correct
-      # call. The pattern is grep-visible, and the scan is unfiltered for the
-      # same reason as the pair-sync check: it is reintroduced by copying an
-      # expression from one chapter into another, not by editing one file.
-      # The scan is stdlib-only; the numeric tests in the same file skip here
-      # for want of scipy and the modelling stack.
-      - name: No tail probability computed as 1 - cdf
-        run: |
-          source .venv/bin/activate
-          python -m pytest tests/test_pvalue_tail_precision.py -q
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,
@@ -422,9 +410,14 @@ jobs:
         # validates the 13F artifacts by rebuilding them with the producer's own
         # build_features_and_matrix, and 13f_download.py imports requests at
         # module scope. Nothing in this job makes a network call.
+        #
+        # scipy/statsmodels/scikit-learn are the import surface of
+        # case_studies/utils/causal.py, so the p-value tail test can actually
+        # run its numeric case rather than skipping past the behavior it pins.
         run: |
           uv venv --python 3.14
-          uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium requests
+          uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium requests \
+            scipy statsmodels scikit-learn
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -482,6 +475,20 @@ jobs:
             tests/test_create_test_data.py \
             tests/test_sample_registry_for_tests.py \
             -v --tb=short
+      # A two-tailed p-value written as `2 * (1 - dist.cdf(abs(t)))` returns
+      # exactly 0.0 above |t| ~8.35, so a notebook teaching inference printed
+      # `p=0` for a number no computation produced. `dist.sf` is the correct
+      # call. Two halves, both needed: the numeric case pins the behavior of
+      # the DML HAC p-value that reaches the registry, and the static scan
+      # catches the expression coming back — it is reintroduced by copying it
+      # from one chapter into another, so the scan is unfiltered by path.
+      - name: No tail probability computed as 1 - cdf
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
+        run: |
+          .venv/bin/python -m pytest tests/test_pvalue_tail_precision.py -v --tb=short
 
   # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -352,7 +352,7 @@ def manual_dml_timeseries(
 
     t_stat_hac = theta / se_hac if se_hac > 0 else np.nan
     p_value_hac = (
-        2 * (1 - stats.t.cdf(abs(t_stat_hac), df=max(n_periods - 2, 1)))
+        2 * stats.t.sf(abs(t_stat_hac), df=max(n_periods - 2, 1))
         if not np.isnan(t_stat_hac)
         else np.nan
     )

--- a/tests/test_pvalue_tail_precision.py
+++ b/tests/test_pvalue_tail_precision.py
@@ -22,7 +22,7 @@ path, and a skip there would mean the modelling stack went missing.
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 import pytest
@@ -32,13 +32,6 @@ REPO_ROOT = Path(__file__).parent.parent
 # Chapter notebooks, case studies, and shared helpers. Tests are excluded: the
 # baseline assertion below deliberately writes the broken form.
 SCANNED_GLOBS = ("[0-9][0-9]_*/*.py", "case_studies/**/*.py", "utils/**/*.py")
-
-# `1 - norm.cdf(x)` written out in one expression.
-DIRECT = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
-# `probability = norm.cdf(x)` - a name bound to a CDF value. The two-line
-# spelling that follows it, `p_value = 1 - probability`, cancels exactly as hard
-# and reads as arithmetic rather than as a tail, which is how it hides.
-CDF_BINDING = re.compile(r"^\s*([A-Za-z_]\w*)\s*=.*[A-Za-z_][\w.]*\.cdf\(")
 
 # PENDING, not approved. Each of these is the same defect, and the one-token fix
 # is known. It is not applied here because every one of them sits in a paired
@@ -67,23 +60,67 @@ PENDING = {
 }
 
 
+def _is_cdf_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "cdf"
+    )
+
+
+def _is_literal_one(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and not isinstance(node.value, bool) and node.value == 1
+
+
+def _cdf_bound_names(tree: ast.AST) -> set[str]:
+    """Names assigned an expression that calls ``.cdf`` anywhere inside it."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            value, targets = node.value, node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            value, targets = node.value, [node.target]
+        else:
+            continue
+        if any(_is_cdf_call(n) for n in ast.walk(value)):
+            names.update(t.id for t in targets if isinstance(t, ast.Name))
+    return names
+
+
 def _hits(path: Path, rel: str) -> list[str]:
     """Both spellings of the cancellation, in one file.
 
-    Names bound to a CDF value are collected first, then every ``1 - <that
-    name>`` is flagged wherever it appears in the same file. Comments are
-    stripped: prose that names the pattern - including a comment explaining why
-    a nearby line uses ``sf`` - is not the pattern.
-    """
-    code = [line.split("#", 1)[0] for line in path.read_text().splitlines()]
-    bound = {m.group(1) for line in code if (m := CDF_BINDING.match(line))}
-    indirect = [re.compile(rf"1(\.0)?\s*-\s*{re.escape(n)}\b") for n in sorted(bound)]
+    Parsed rather than grepped, for two reasons. Comments and docstrings are
+    invisible to ``ast``, so prose naming the pattern - including a comment
+    explaining why a nearby line uses ``sf`` - does not trip it. And an
+    assignment spread over several lines is one node, so
+    ``probability = float(`` with the ``norm.cdf(...)`` on the next line is
+    still a CDF binding.
 
-    return [
-        f"{rel}:{lineno}: {line.strip()}"
-        for lineno, line in enumerate(code, start=1)
-        if DIRECT.search(line) or any(p.search(line) for p in indirect)
-    ]
+    Known limit: a CDF value reached through a subscript or attribute rather
+    than a bare name (``1 - result["psr"]``) is not tracked.
+    """
+    source = path.read_text()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    bound = _cdf_bound_names(tree)
+    lines = source.splitlines()
+
+    hits = {
+        node.lineno: f"{rel}:{node.lineno}: {lines[node.lineno - 1].strip()}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Sub)
+        and _is_literal_one(node.left)
+        and (
+            _is_cdf_call(node.right)
+            or (isinstance(node.right, ast.Name) and node.right.id in bound)
+        )
+    }
+    return [hits[line] for line in sorted(hits)]
 
 
 def _occurrences() -> dict[str, list[str]]:
@@ -94,6 +131,48 @@ def _occurrences() -> dict[str, list[str]]:
             if hits := _hits(path, rel):
                 found[rel] = hits
     return found
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("inline", "p = 2 * (1 - stats.t.cdf(abs(t), df=n))\n"),
+        ("bound name", "probability = norm.cdf(z)\np_value = 1 - probability\n"),
+        (
+            "binding wrapped over lines",
+            "probability = float(\n    stats.norm.cdf(z_score)\n)\np_value = float(1.0 - probability)\n",
+        ),
+        (
+            "subtraction wrapped over lines",
+            "probability = stats.norm.cdf(z)\np_value = (\n    1\n    - probability\n)\n",
+        ),
+    ],
+)
+def test_detector_finds_every_layout(tmp_path: Path, label: str, source: str):
+    """Every way of writing it, including the ones no regex sees."""
+    path = tmp_path / "sample.py"
+    path.write_text(source)
+
+    assert _hits(path, "sample.py"), f"missed the {label} layout"
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("sf", "p_value = 2 * stats.t.sf(abs(t), df=n)\n"),
+        (
+            "a comment naming the pattern",
+            "# sf, not 1 - norm.cdf(z), which cancels\np = norm.sf(z)\n",
+        ),
+        ("a CDF used as a probability", "psr = float(norm.cdf(z))\nis_significant = psr >= 0.95\n"),
+        ("an unrelated subtraction", "share = 1 - weight\n"),
+    ],
+)
+def test_detector_does_not_fire_on_correct_code(tmp_path: Path, label: str, source: str):
+    path = tmp_path / "sample.py"
+    path.write_text(source)
+
+    assert not _hits(path, "sample.py"), f"false positive on {label}"
 
 
 def test_no_new_tail_probability_is_written_as_one_minus_cdf():

--- a/tests/test_pvalue_tail_precision.py
+++ b/tests/test_pvalue_tail_precision.py
@@ -1,0 +1,127 @@
+"""Tail p-values must stay positive and finite for extreme test statistics.
+
+A two-tailed p-value written as ``2 * (1 - dist.cdf(abs(stat)))`` returns exactly
+``0.0`` once ``abs(stat)`` passes roughly 8.35, because ``cdf`` rounds to ``1.0``
+long before the tail mass underflows: the subtraction cancels every remaining
+significant digit. It is already wrong by 60% at 8.3. The survival function
+``dist.sf`` evaluates the tail directly and stays accurate to the smallest normal
+double::
+
+    |t| = 6.00   2 * (1 - cdf) = 2.138e-09   2 * sf = 2.138e-09
+    |t| = 8.30   2 * (1 - cdf) = 2.220e-16   2 * sf = 1.385e-16
+    |t| = 8.94   2 * (1 - cdf) = 0           2 * sf = 5.702e-19
+
+A notebook that teaches inference must not print ``p=0`` for a value no
+computation produced, and ``p_value_hac`` must not be stored as ``0.0``.
+
+The static scan below is stdlib-only so it runs in the always-on ``guards`` job.
+The numeric tests need scipy and the modelling stack and skip without them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# Chapter notebooks, case studies, and shared helpers. Tests are excluded: the
+# baseline assertion below deliberately writes the broken form.
+SCANNED_GLOBS = ("[0-9][0-9]_*/*.py", "case_studies/**/*.py", "utils/**/*.py")
+
+ONE_MINUS_CDF = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
+
+# PENDING, not approved. Each of these is the same defect, and the one-token fix
+# is known. It is not applied here because every one of them sits in a paired
+# notebook: editing the `.py` makes the committed `.ipynb` stale, and the
+# provenance gate (`.github/scripts/notebook_provenance.py`) then requires a
+# production re-run in the canonical environment. That re-run is the owning
+# chapter's or case study's work, in its own worktree and its own PR, so the fix
+# ships with the run that renders it rather than leaving output the source no
+# longer produces.
+#
+# A worker touching one of these files must apply `sf`, re-run, and delete the
+# row. The list only shrinks: it is a baseline so a *new* occurrence fails
+# immediately, not permission to add one.
+PENDING = {
+    "07_defining_the_learning_task/06_ic_inference.py": 2,
+    "07_defining_the_learning_task/07_multiple_testing.py": 1,
+    "09_model_based_features/02_structural_breaks.py": 2,
+    "15_causal_estimation/09_adia_causal_benchmark.py": 1,
+    "15_causal_estimation/11_factor_zoo_validation.py": 1,
+    "16_strategy_simulation/11_sharpe_ratio_inference.py": 1,
+    "17_portfolio_construction/05_factor_allocation_evidence.py": 1,
+    "19_risk_management/01_var_cvar.py": 2,
+    "case_studies/sp500_equity_option_analytics/03_financial_features.py": 1,
+}
+
+
+def _occurrences() -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for glob in SCANNED_GLOBS:
+        for path in sorted(REPO_ROOT.glob(glob)):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            hits = [
+                f"{rel}:{lineno}: {line.strip()}"
+                for lineno, line in enumerate(path.read_text().splitlines(), start=1)
+                if ONE_MINUS_CDF.search(line)
+            ]
+            if hits:
+                found[rel] = hits
+    return found
+
+
+def test_no_new_tail_probability_is_written_as_one_minus_cdf():
+    """Static guard: the cancellation cannot appear in a file that is clean today."""
+    violations = [
+        hit for rel, hits in _occurrences().items() for hit in hits[PENDING.get(rel, 0) :]
+    ]
+
+    assert not violations, "use dist.sf(x), not 1 - dist.cdf(x):\n" + "\n".join(violations)
+
+
+def test_pending_baseline_has_no_stale_rows():
+    """A row that no longer matches must be deleted, so the baseline only shrinks."""
+    found = _occurrences()
+    stale = [
+        f"{rel}: baseline expects {count}, found {len(found.get(rel, []))}"
+        for rel, count in PENDING.items()
+        if len(found.get(rel, [])) != count
+    ]
+
+    assert not stale, "PENDING is out of date - fix the file and drop the row:\n" + "\n".join(stale)
+
+
+def test_scipy_baseline_confirms_the_cancellation():
+    """The premise: `1 - cdf` is exactly zero where `sf` is not."""
+    stats = pytest.importorskip("scipy.stats")
+
+    assert 2 * (1 - stats.t.cdf(8.94, df=4231)) == 0.0
+    assert 2 * stats.t.sf(8.94, df=4231) > 0.0
+
+
+def test_dml_hac_pvalue_survives_extreme_t():
+    """`manual_dml_timeseries` writes `p_value_hac` into the registry.
+
+    The treatment effect here is estimated almost without noise, so the HAC
+    t-statistic lands around 20 - past the point where `1 - cdf` cancels, well
+    short of where the true tail mass underflows.
+    """
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("statsmodels")
+    pytest.importorskip("sklearn")
+    from case_studies.utils.causal import manual_dml_timeseries
+
+    rng = np.random.default_rng(7)
+    n = 600
+    x = rng.normal(size=(n, 2))
+    t = x[:, 0] * 0.5 + rng.normal(scale=0.5, size=n)
+    y = x[:, 1] * 0.3 + 0.12 * t + rng.normal(scale=1e-4, size=n)
+
+    result = manual_dml_timeseries(y, t, x, n_folds=5, embargo=5)
+
+    assert abs(result["t_stat_hac"]) > 8.35, "fixture must reach the underflow zone"
+    assert result["p_value_hac"] > 0.0, "p-value underflowed to exactly zero"
+    assert np.isfinite(result["p_value_hac"])

--- a/tests/test_pvalue_tail_precision.py
+++ b/tests/test_pvalue_tail_precision.py
@@ -33,7 +33,12 @@ REPO_ROOT = Path(__file__).parent.parent
 # baseline assertion below deliberately writes the broken form.
 SCANNED_GLOBS = ("[0-9][0-9]_*/*.py", "case_studies/**/*.py", "utils/**/*.py")
 
-ONE_MINUS_CDF = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
+# `1 - norm.cdf(x)` written out in one expression.
+DIRECT = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
+# `probability = norm.cdf(x)` - a name bound to a CDF value. The two-line
+# spelling that follows it, `p_value = 1 - probability`, cancels exactly as hard
+# and reads as arithmetic rather than as a tail, which is how it hides.
+CDF_BINDING = re.compile(r"^\s*([A-Za-z_]\w*)\s*=.*[A-Za-z_][\w.]*\.cdf\(")
 
 # PENDING, not approved. Each of these is the same defect, and the one-token fix
 # is known. It is not applied here because every one of them sits in a paired
@@ -54,10 +59,31 @@ PENDING = {
     "15_causal_estimation/09_adia_causal_benchmark.py": 1,
     "15_causal_estimation/11_factor_zoo_validation.py": 1,
     "16_strategy_simulation/11_sharpe_ratio_inference.py": 1,
+    "16_strategy_simulation/12_dsr_validation.py": 1,
+    "16_strategy_simulation/13_ras_protocol.py": 1,
     "17_portfolio_construction/05_factor_allocation_evidence.py": 1,
     "19_risk_management/01_var_cvar.py": 2,
     "case_studies/sp500_equity_option_analytics/03_financial_features.py": 1,
 }
+
+
+def _hits(path: Path, rel: str) -> list[str]:
+    """Both spellings of the cancellation, in one file.
+
+    Names bound to a CDF value are collected first, then every ``1 - <that
+    name>`` is flagged wherever it appears in the same file. Comments are
+    stripped: prose that names the pattern - including a comment explaining why
+    a nearby line uses ``sf`` - is not the pattern.
+    """
+    code = [line.split("#", 1)[0] for line in path.read_text().splitlines()]
+    bound = {m.group(1) for line in code if (m := CDF_BINDING.match(line))}
+    indirect = [re.compile(rf"1(\.0)?\s*-\s*{re.escape(n)}\b") for n in sorted(bound)]
+
+    return [
+        f"{rel}:{lineno}: {line.strip()}"
+        for lineno, line in enumerate(code, start=1)
+        if DIRECT.search(line) or any(p.search(line) for p in indirect)
+    ]
 
 
 def _occurrences() -> dict[str, list[str]]:
@@ -65,12 +91,7 @@ def _occurrences() -> dict[str, list[str]]:
     for glob in SCANNED_GLOBS:
         for path in sorted(REPO_ROOT.glob(glob)):
             rel = path.relative_to(REPO_ROOT).as_posix()
-            hits = [
-                f"{rel}:{lineno}: {line.strip()}"
-                for lineno, line in enumerate(path.read_text().splitlines(), start=1)
-                if ONE_MINUS_CDF.search(line)
-            ]
-            if hits:
+            if hits := _hits(path, rel):
                 found[rel] = hits
     return found
 

--- a/tests/test_pvalue_tail_precision.py
+++ b/tests/test_pvalue_tail_precision.py
@@ -14,8 +14,10 @@ double::
 A notebook that teaches inference must not print ``p=0`` for a value no
 computation produced, and ``p_value_hac`` must not be stored as ``0.0``.
 
-The static scan below is stdlib-only so it runs in the always-on ``guards`` job.
-The numeric tests need scipy and the modelling stack and skip without them.
+Both halves run in the always-on ``test-unit`` job, which installs scipy,
+statsmodels and scikit-learn for the numeric case. The ``importorskip`` calls
+keep the static scan usable from a stdlib-only environment; they are not the CI
+path, and a skip there would mean the modelling stack went missing.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## The defect

A tail probability written as `1 - dist.cdf(x)` returns **exactly `0.0`** once `x` passes
roughly 8.35, and is already wrong by 60% at 8.3: `cdf` rounds to `1.0` long before the
tail mass underflows, so the subtraction cancels every remaining significant digit.
`dist.sf` evaluates the tail directly.

Measured on `stats.t` with `df=4231`:

| \|t\| | `2 * (1 - cdf)` | `2 * sf` |
|---|---|---|
| 6.00 | 2.138e-09 | 2.138e-09 |
| 8.30 | 2.220e-16 | 1.385e-16 |
| 8.94 | **0** | 5.702e-19 |
| 9.50 | **0** | 3.409e-21 |

It changes no decision - any statistic in the underflow zone is significant under any
threshold. What it does is show a p-value of exactly zero, a number no computation
produced, and store `0.0` in a `p_value` column.

It appears in two spellings. The inline one is grep-visible. The other is not:

```python
probability = float(stats.norm.cdf(z_score))
p_value = float(1.0 - probability)
```

That cancels exactly as hard and reads as arithmetic rather than as a tail.

## What this PR changes

**`case_studies/utils/causal.py`** - the HAC p-value from `manual_dml_timeseries`. This is
where the defect reached stored output: `p_value_hac` goes into the registry, so the zeros
were durable rather than only rendered. The helper has no paired notebook, so the fix
stands alone.

**`tests/test_pvalue_tail_precision.py`** - two numeric tests and a static scan covering
both spellings. The scan collects the names each file binds to a CDF value, then flags
`1 - <that name>` wherever it appears. It reads code only, so a comment explaining why a
nearby line uses `sf` is prose, not the pattern.

The same expression appears in eleven paired notebooks across Ch07, Ch09, Ch15-17, Ch19
and one case study. They are **not** edited here: changing one of those `.py` files makes
its committed `.ipynb` stale, and `.github/scripts/notebook_provenance.py` then requires a
production re-run in the canonical environment. That re-run belongs to the chapter or case
study that owns the notebook. Editing without it would ship a notebook whose displayed
output the source no longer produces.

So the eleven are recorded as a `PENDING` baseline with a per-file occurrence count, the
same shape `tests/test_leakage_detectors.py` already uses:

- a **new** occurrence anywhere fails immediately, which is the point - the expression
  comes back by being copied from one chapter into another, not by editing one file;
- a `PENDING` row can only be removed by fixing the file, because
  `test_pending_baseline_has_no_stale_rows` fails when a count no longer matches.

Both halves run in `test-unit`, which now also installs scipy, statsmodels and
scikit-learn - the import surface of `case_studies/utils/causal.py`. Without them the
numeric tests would skip and the changed behavior would be pinned by a test that never
runs.

## Verification

```
$ python -m pytest tests/test_pvalue_tail_precision.py -q
4 passed
```

Verified in a venv built from the `test-unit` dependency list alone: 4 passed, 0 skipped.
Reverting the `causal.py` change fails `test_dml_hac_pvalue_survives_extreme_t` (`0.0 > 0.0`)
and the static scan; rewriting it in the two-line form fails the scan too. Applying `sf`
to a `PENDING` file without deleting its row fails
`test_pending_baseline_has_no_stale_rows`.

`ruff check` / `ruff format --check` clean on `utils/ data/ tests/`; the notebook pair-sync
and provenance gates pass unchanged.

## Upstream

`ml4t-diagnostic` carried the same defect at 18 sites, including `compute_ic_hac_stats`,
which is what rendered `HAC t(3 lags): -8.94 (p=0)` in the crypto funding case study.
Fixed there in ml4t/diagnostic#28.