### PR TITLE
Derive the provenance production flag from a declaration, not a fossil

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -205,9 +205,31 @@ def injected_parameters(nb: dict) -> dict[str, object] | None:
             continue
         try:
             params[target.id] = ast.literal_eval(node.value)
-        except ValueError:
-            params[target.id] = ast.unparse(node.value)
+        except (ValueError, TypeError):
+            params[target.id] = _non_literal_value(node.value)
     return params
+
+
+def _non_literal_value(node: ast.expr) -> object:
+    """Value for an injected assignment that ``literal_eval`` will not take.
+
+    Papermill spells a non-finite float as a call, ``float('nan')``, so that form
+    has to come back as the number to compare against a declared ``float("nan")``.
+    Anything else compares as its own source text.
+    """
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"float", "int"}
+        and len(node.args) == 1
+        and not node.keywords
+    ):
+        constructor = float if node.func.id == "float" else int
+        try:
+            return constructor(ast.literal_eval(node.args[0]))
+        except (ValueError, TypeError):
+            pass
+    return ast.unparse(node)
 
 
 def iter_notebooks() -> list[Path]:

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -126,22 +126,23 @@ def _normalize_value(value: object) -> tuple[str, object]:
 
     Numbers compare as ``Decimal`` rather than ``float``, so two integers that differ
     above 2**53 stay different. Floats route through ``str`` first, so the literal
-    ``0.1`` matches the string ``"0.1"`` instead of its binary expansion.
+    ``0.1`` matches the string ``"0.1"`` instead of its binary expansion. NaN and the
+    infinities compare as lowercased text, because a Decimal NaN does not equal
+    itself and every form of a non-finite value has to reach the same normal form.
     """
     if isinstance(value, bool):
         return ("bool", value)
-    if isinstance(value, int):
-        return ("num", Decimal(value))
-    if isinstance(value, float):
-        return ("num", Decimal(str(value)))
-    if isinstance(value, str):
-        text = value.strip()
+    if isinstance(value, (int, float, str)):
+        text = str(value).strip()
         try:
-            number = Decimal(text)
-        except InvalidOperation:
-            return ("str", text)
-        # NaN never equals itself, so a literal "nan" would never match itself.
-        return ("num", number) if number.is_finite() else ("str", text)
+            number = Decimal(value if isinstance(value, int) else text)
+        except (InvalidOperation, ValueError):
+            return ("str", text)  # not a number at all
+        if number.is_finite():
+            return ("num", number)
+        # Decimal's own spelling is the normal form that makes `inf`, `Infinity`
+        # and `float("inf")` agree, and NaN compare equal to itself at all.
+        return ("str", str(number).lower())
     return ("str", str(value))
 
 

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -116,18 +116,46 @@ def production_parameters(parameters: dict[str, object]) -> bool:
     )
 
 
+def _normalize_value(value: object) -> tuple[str, object]:
+    """Tagged scalar form: ``("bool", …)``, ``("num", …)`` or ``("str", …)``.
+
+    The tag is what keeps ``True`` distinct from the number 1. Python treats them as
+    equal — ``bool`` subclasses ``int`` — so an untagged form would let a numeric
+    override match a boolean one.
+    """
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, (int, float)):
+        return ("num", float(value))
+    if isinstance(value, str):
+        text = value.strip()
+        try:
+            return ("num", float(text))
+        except ValueError:
+            return ("str", text)
+    return ("str", str(value))
+
+
 def _normalize_parameters(parameters: dict[str, object]) -> dict[str, object]:
     """Comparable form of a parameter set.
 
-    Papermill's ``-p`` passes every value as a string, so the same override reaches
-    ``metadata`` as ``True`` through one entry point and ``"true"`` through another.
-    Bool-like values collapse to the bool; everything else compares as its repr, so
-    ``5`` and ``"5"`` are the same override.
+    Papermill's ``-p`` stringifies every value, so one override arrives as ``True``
+    through a YAML file and ``"true"`` through the CLI. Normalizing lets the two
+    compare equal, so a declaration is not reported as contradicting the injected
+    cell that recorded the same run.
+
+    Only the parameters in ``PRODUCTION_SAFE_PARAMETERS`` are read as booleans.
+    Every other name keeps its type, so ``MAX_SYMBOLS = 1`` still contradicts a
+    declared ``{"MAX_SYMBOLS": true}`` while matching ``{"MAX_SYMBOLS": "1"}``.
     """
     out: dict[str, object] = {}
     for name, value in parameters.items():
-        coerced = _coerce_bool(value)
-        out[name] = coerced if coerced is not None else str(value)
+        if name in PRODUCTION_SAFE_PARAMETERS:
+            coerced = _coerce_bool(value)
+            if coerced is not None:
+                out[name] = ("bool", coerced)
+                continue
+        out[name] = _normalize_value(value)
     return out
 
 

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -85,9 +85,19 @@ PRODUCTION_SAFE_PARAMETERS = {
 
 
 def _coerce_bool(value: object) -> bool | None:
-    """Return a boolean for Papermill's bool-like CLI values."""
+    """Return a boolean for Papermill's bool-like CLI values.
+
+    The same override reaches this module as ``True`` through a YAML parameter file,
+    ``"true"`` through ``papermill -p`` (which stringifies everything), and ``1``
+    through a JSON declaration. All three name the same run, so ``1`` and ``"1"``
+    have to coerce alike — otherwise one form is read as a boolean and the other as
+    the string ``"1"``, and comparing the two reports a contradiction that is not
+    there.
+    """
     if isinstance(value, bool):
         return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in {"true", "1", "yes", "on"}:

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -13,14 +13,41 @@ The stamp lives in ``nb.metadata["ml4t_provenance"]``::
     executed_at    : ISO-8601 timestamp
     executor       : environment label (e.g. "ml4t-gpu", "local-uv")
     production     : bool — True iff overrides preserve the full production surface
-    parameters     : the papermill parameter overrides
+    parameters     : the papermill parameter overrides, as declared by the executor
     notes          : optional free text (e.g. "GPU libs: xgboost,lightgbm,catboost")
+
+Where ``parameters`` comes from, and why it is not read out of the notebook
+----------------------------------------------------------------------------
+
+``metadata.papermill.parameters`` cannot answer "was *this* run parameterized".
+Two mechanisms make it a fossil, both reproducible:
+
+1. Papermill does not clear it. Re-executing with no overrides leaves the previous
+   run's dict in place next to a freshly written ``start_time``, so the timestamps
+   describe the new run and the parameters describe an older one.
+2. ``jupytext --sync`` rebuilds the cell list from the ``.py`` and so removes the
+   ``injected-parameters`` cell, but notebook-level ``metadata`` survives
+   untouched. The marker that belongs to the run is deleted and the stale one is
+   kept.
+
+So the executor states the parameters and the stamp records that statement:
+``--production`` for an unparameterized run, or ``--parameters '<json>'``. One of
+the two is required; this tool never infers.
+
+Where the notebook *does* carry evidence of its own execution — papermill's
+``injected-parameters`` cell, which lives in the cell list and is rewritten by
+every parameterized run — ``stamp`` cross-checks the declaration against it and
+refuses to write a stamp that contradicts it. Stamping also rewrites
+``metadata.papermill.parameters`` to the declared set, so the fossil cannot
+outlive the stamp and disagree with it later.
 
 Gate (``check``): for every tracked ``.ipynb`` that HAS a stamp,
 
 * ``source_py_blob`` must equal ``git hash-object`` of the current paired ``.py``
-  (else the ``.py`` changed since the notebook was executed — STALE), and
-* ``production`` must be True (else a TEST-mode run was committed).
+  (else the ``.py`` changed since the notebook was executed — STALE),
+* ``production`` must be True (else a TEST-mode run was committed), and
+* the stamp must not contradict a committed ``injected-parameters`` cell (else the
+  notebook was re-executed with overrides after it was stamped).
 
 Notebooks WITHOUT a stamp are reported as "unverified" but do not fail unless
 ``--strict`` is passed. This is deliberate: adoption is gradual — stamp notebooks
@@ -29,8 +56,9 @@ provenance exists. Flip to ``--strict`` once the backfill is complete.
 
 Usage::
 
-    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu
-    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --notes "..."
+    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --production
+    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --parameters '{"MAX_SYMBOLS": 5}'
+    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --production --notes "..."
     uv run python .github/scripts/notebook_provenance.py check          # gate (stamped-only)
     uv run python .github/scripts/notebook_provenance.py check --strict  # also fail on unverified
 """
@@ -38,6 +66,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import subprocess
 import sys
@@ -47,6 +76,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKIP_PARTS = {"_reference", ".venv", ".git", ".ipynb_checkpoints"}
 STAMP_KEY = "ml4t_provenance"
+INJECTED_TAG = "injected-parameters"
 PRODUCTION_SAFE_PARAMETERS = {
     "FORCE_REBACKTEST": True,
     "FORCE_RETRAIN": True,
@@ -74,6 +104,62 @@ def production_parameters(parameters: dict[str, object]) -> bool:
         and _coerce_bool(value) is PRODUCTION_SAFE_PARAMETERS[name]
         for name, value in parameters.items()
     )
+
+
+def _normalize_parameters(parameters: dict[str, object]) -> dict[str, object]:
+    """Comparable form of a parameter set.
+
+    Papermill's ``-p`` passes every value as a string, so the same override reaches
+    ``metadata`` as ``True`` through one entry point and ``"true"`` through another.
+    Bool-like values collapse to the bool; everything else compares as its repr, so
+    ``5`` and ``"5"`` are the same override.
+    """
+    out: dict[str, object] = {}
+    for name, value in parameters.items():
+        coerced = _coerce_bool(value)
+        out[name] = coerced if coerced is not None else str(value)
+    return out
+
+
+def injected_parameters(nb: dict) -> dict[str, object] | None:
+    """Parameters papermill injected into *this* execution, or None if it did not.
+
+    Papermill writes an ``injected-parameters``-tagged cell holding one literal
+    assignment per override. Unlike ``metadata.papermill.parameters`` this lives in
+    the cell list, so it cannot outlive the run it belongs to: a parameterized run
+    rewrites it, and ``jupytext --sync`` drops it with every other cell that is not
+    in the paired ``.py``. A cell that is merely left over from an earlier run was
+    still executed by the later one — its values were in force either way — so it
+    is evidence about the committed outputs, which the metadata block is not.
+
+    Returns None when there is no such cell, which is the ordinary shape of an
+    unparameterized run *and* of any notebook synced since. Absence is therefore
+    not proof of a production run; that is why the executor must declare.
+    """
+    cells = [
+        c for c in nb.get("cells", []) if INJECTED_TAG in (c.get("metadata", {}).get("tags") or [])
+    ]
+    if not cells:
+        return None
+    source = cells[-1].get("source", "")
+    if isinstance(source, list):
+        source = "".join(source)
+    params: dict[str, object] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return params
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            params[target.id] = ast.literal_eval(node.value)
+        except ValueError:
+            params[target.id] = ast.unparse(node.value)
+    return params
 
 
 def iter_notebooks() -> list[Path]:
@@ -104,30 +190,68 @@ def git_blob(path: Path) -> str:
     ).stdout.strip()
 
 
-def stamp_notebook(nb_path: Path, executor: str, notes: str | None = None) -> dict:
+def contradicts_injected_cell(nb: dict, parameters: dict[str, object]) -> str | None:
+    """Why ``parameters`` disagrees with the notebook's injected cell, or None.
+
+    Only meaningful when the notebook still carries an ``injected-parameters``
+    cell. No cell means no evidence either way, not agreement.
+    """
+    injected = injected_parameters(nb)
+    if injected is None:
+        return None
+    declared_n = _normalize_parameters(parameters)
+    injected_n = _normalize_parameters(injected)
+    if declared_n == injected_n:
+        return None
+    return (
+        f"declared parameters {parameters!r} do not match the injected-parameters "
+        f"cell this notebook was executed with, {injected!r}"
+    )
+
+
+def stamp_notebook(
+    nb_path: Path,
+    executor: str,
+    notes: str | None = None,
+    *,
+    parameters: dict[str, object],
+) -> dict:
+    """Record how this notebook was executed.
+
+    ``parameters`` is the executor's statement of the overrides the run used —
+    ``{}`` for a production run. It is never read back out of the notebook: see the
+    module docstring for why ``metadata.papermill.parameters`` cannot answer that
+    question. Stamping overwrites that metadata with the declared set, so the
+    fossil cannot survive to contradict the stamp.
+    """
     py = paired_py(nb_path)
     if py is None:
         raise SystemExit(f"no paired .py for {nb_path.relative_to(REPO_ROOT)} — cannot stamp")
     nb = json.loads(nb_path.read_text(encoding="utf-8"))
-    params = nb.get("metadata", {}).get("papermill", {}).get("parameters", {}) or {}
+    conflict = contradicts_injected_cell(nb, parameters)
+    if conflict:
+        raise SystemExit(f"refusing to stamp {nb_path.relative_to(REPO_ROOT)}: {conflict}")
     stamp = {
         "source_py_blob": git_blob(py),
         "executed_at": datetime.now(UTC).isoformat(),
         "executor": executor,
-        "production": production_parameters(params),
-        "parameters": params,
+        "production": production_parameters(parameters),
+        "parameters": parameters,
     }
     if notes:
         stamp["notes"] = notes
-    nb.setdefault("metadata", {})[STAMP_KEY] = stamp
+    metadata = nb.setdefault("metadata", {})
+    metadata[STAMP_KEY] = stamp
+    metadata.setdefault("papermill", {})["parameters"] = parameters
     nb_path.write_text(json.dumps(nb, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
     return stamp
 
 
-def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str]]:
-    """Return (stale, testmode, unverified) lists of repo-relative offenders."""
+def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Return (stale, testmode, contradicted, unverified) repo-relative offenders."""
     stale: list[str] = []
     testmode: list[str] = []
+    contradicted: list[str] = []
     unverified: list[str] = []
     for nb_path in iter_notebooks():
         rel = str(nb_path.relative_to(REPO_ROOT))
@@ -146,11 +270,25 @@ def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str]]:
             stale.append(rel)
         if not stamp.get("production", False):
             testmode.append(f"{rel} (params={stamp.get('parameters')})")
-    return stale, testmode, unverified
+        conflict = contradicts_injected_cell(nb, stamp.get("parameters") or {})
+        if conflict:
+            contradicted.append(f"{rel} ({conflict})")
+    return stale, testmode, contradicted, unverified
 
 
 def _cmd_stamp(args: argparse.Namespace) -> int:
-    s = stamp_notebook(Path(args.notebook).resolve(), args.executor, args.notes)
+    if args.production:
+        parameters: dict[str, object] = {}
+    else:
+        try:
+            parameters = json.loads(args.parameters)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--parameters is not valid JSON: {exc}") from exc
+        if not isinstance(parameters, dict):
+            raise SystemExit("--parameters must be a JSON object of override name to value")
+    s = stamp_notebook(
+        Path(args.notebook).resolve(), args.executor, args.notes, parameters=parameters
+    )
     print(
         f"stamped {args.notebook}: source_py_blob={s['source_py_blob'][:12]} "
         f"executor={s['executor']} production={s['production']}"
@@ -159,8 +297,8 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
-    stale, testmode, unverified = check_all(strict=args.strict)
-    fail = bool(stale or testmode) or (args.strict and bool(unverified))
+    stale, testmode, contradicted, unverified = check_all(strict=args.strict)
+    fail = bool(stale or testmode or contradicted) or (args.strict and bool(unverified))
     if stale:
         print(
             "STALE (paired .py changed since the notebook was executed — re-run in the canonical env):"
@@ -173,6 +311,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
         )
         for r in testmode:
             print(f"  {r}")
+    if contradicted:
+        print(
+            "CONTRADICTED (the stamp disagrees with the injected-parameters cell in the "
+            "committed notebook — re-stamp the run that produced these outputs):"
+        )
+        for r in contradicted:
+            print(f"  {r}")
     if unverified:
         verb = "UNVERIFIED (no provenance stamp"
         verb += (
@@ -184,7 +329,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
     if not fail:
         print(
             f"notebook sync OK: {len(stale)} stale, {len(testmode)} test-mode, "
-            f"{len(unverified)} unverified (advisory)"
+            f"{len(contradicted)} contradicted, {len(unverified)} unverified (advisory)"
         )
     return 1 if fail else 0
 
@@ -199,6 +344,16 @@ def main() -> int:
     sp.add_argument("notebook")
     sp.add_argument("--executor", required=True, help="environment label, e.g. ml4t-gpu / local-uv")
     sp.add_argument("--notes", default=None)
+    # The executor states the parameters; the tool does not infer them from
+    # notebook metadata written by a different process. See the module docstring.
+    params = sp.add_mutually_exclusive_group(required=True)
+    params.add_argument(
+        "--production", action="store_true", help="this run used no parameter overrides"
+    )
+    params.add_argument(
+        "--parameters",
+        help="JSON object of the overrides this run used, e.g. '{\"MAX_SYMBOLS\": 5}'",
+    )
     sp.set_defaults(func=_cmd_stamp)
 
     cp = sub.add_parser("check", help="gate: fail on stale or test-mode stamped notebooks")

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -71,6 +71,7 @@ import json
 import subprocess
 import sys
 from datetime import UTC, datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -122,17 +123,25 @@ def _normalize_value(value: object) -> tuple[str, object]:
     The tag is what keeps ``True`` distinct from the number 1. Python treats them as
     equal — ``bool`` subclasses ``int`` — so an untagged form would let a numeric
     override match a boolean one.
+
+    Numbers compare as ``Decimal`` rather than ``float``, so two integers that differ
+    above 2**53 stay different. Floats route through ``str`` first, so the literal
+    ``0.1`` matches the string ``"0.1"`` instead of its binary expansion.
     """
     if isinstance(value, bool):
         return ("bool", value)
-    if isinstance(value, (int, float)):
-        return ("num", float(value))
+    if isinstance(value, int):
+        return ("num", Decimal(value))
+    if isinstance(value, float):
+        return ("num", Decimal(str(value)))
     if isinstance(value, str):
         text = value.strip()
         try:
-            return ("num", float(text))
-        except ValueError:
+            number = Decimal(text)
+        except InvalidOperation:
             return ("str", text)
+        # NaN never equals itself, so a literal "nan" would never match itself.
+        return ("num", number) if number.is_finite() else ("str", text)
     return ("str", str(value))
 
 

--- a/.github/scripts/strip_papermill_cell_metadata.py
+++ b/.github/scripts/strip_papermill_cell_metadata.py
@@ -16,9 +16,11 @@ This is the same class as the empty ``tags: []`` fossil handled by
 being tracked. Timing of a past run carries no information for a reader, so
 removing it is lossless.
 
-**Notebook-level** ``metadata.papermill`` is NOT touched: ``notebook_provenance.py``
-reads ``metadata.papermill.parameters`` to decide whether a run was production or
-TEST-mode. Only per-cell blocks are removed.
+**Notebook-level** ``metadata.papermill`` is NOT touched; only per-cell blocks are
+removed. ``notebook_provenance.py`` no longer decides production-vs-TEST from
+``metadata.papermill.parameters`` — that key is a fossil, and the executor now
+declares the parameters instead — but it does rewrite the key when it stamps, and
+rewriting it here as well would mean two tools racing over one value.
 
 Unlike ``strip_empty_cell_tags.py`` this reserializes the JSON rather than
 editing raw text, because the block is nested and regex-matching nested objects

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,11 +18,15 @@ reader runs. The checks CI enforces and the tools that repair committed notebook
 live in [`.github/scripts/`](../.github/scripts). Reading the book needs none of
 them; opening a pull request can, and the failure tells you which:
 
-- `notebook_provenance.py stamp <nb.ipynb> --executor <env>` — re-stamps a
-  notebook. The pre-commit gate fails a stamped notebook whose `.py` source has
-  moved on since, and any notebook committed from a test-mode run. An unstamped
-  notebook is reported but does not fail, until the backfill is complete and the
-  gate moves to `--strict`.
+- `notebook_provenance.py stamp <nb.ipynb> --executor <env> --production` — re-stamps
+  a notebook. Pass `--parameters '{"MAX_SYMBOLS": 5}'` instead of `--production` when
+  the run did use overrides; one of the two is required, because the notebook's own
+  `metadata.papermill.parameters` can outlive the run it describes. The pre-commit
+  gate fails a stamped notebook whose `.py` source has moved on since, any notebook
+  committed from a test-mode run, and any stamp that contradicts the
+  `injected-parameters` cell in the committed notebook. An unstamped notebook is
+  reported but does not fail, until the backfill is complete and the gate moves to
+  `--strict`.
 - `strip_empty_cell_tags.py` — run when the pair-sync gate reports a notebook
   whose `.ipynb` carries empty `tags: []` its `.py` does not.
 - `sanitize_notebook_paths.py` — strips machine-specific absolute paths out of

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -110,14 +110,21 @@ def test_float_matches_its_decimal_string() -> None:
 def test_non_finite_values_reach_one_normal_form() -> None:
     """A Decimal NaN does not equal itself, so these have to compare as text.
 
-    Papermill spells a non-finite override ``float('nan')``, which is not a literal
-    and so reaches the comparison as that source text on the injected side. Every
-    form that *is* a number normalizes together; the call form compares as itself.
+    The cell source is what papermill 2.7's ``PythonTranslator`` actually emits for
+    a non-finite float: a ``float(...)`` call rather than a literal.
     """
-    nb = _notebook([_injected_cell("# Parameters\nCAP = inf\n")])
-    assert contradicts_injected_cell(nb, {"CAP": float("inf")}) is None
-    assert contradicts_injected_cell(nb, {"CAP": "Infinity"}) is None
-    assert contradicts_injected_cell(nb, {"CAP": 5}) is not None
+    nb = _notebook([_injected_cell("# Parameters\nCLIP = float('nan')\nCAP = float('inf')\n")])
+    assert contradicts_injected_cell(nb, {"CLIP": float("nan"), "CAP": float("inf")}) is None
+    assert contradicts_injected_cell(nb, {"CLIP": "NaN", "CAP": "Infinity"}) is None
+    assert contradicts_injected_cell(nb, {"CLIP": float("nan"), "CAP": 5}) is not None
+
+
+def test_papermill_translator_still_spells_non_finite_floats_as_a_call() -> None:
+    """Pins the assumption the test above encodes, so it fails if papermill changes."""
+    papermill_translators = pytest.importorskip("papermill.translators")
+
+    assert papermill_translators.PythonTranslator.translate(float("nan")) == "float('nan')"
+    assert papermill_translators.PythonTranslator.translate(float("inf")) == "float('inf')"
 
 
 def test_string_parameters_compare_by_value() -> None:

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -93,6 +93,20 @@ def test_bool_coercion_does_not_reach_ordinary_numeric_parameters() -> None:
     assert contradicts_injected_cell(nb, {"MAX_SYMBOLS": 2}) is not None
 
 
+def test_large_integers_do_not_collapse_onto_each_other() -> None:
+    """Above 2**53 a float round-trip would make two distinct values compare equal."""
+    nb = _notebook([_injected_cell("# Parameters\nSEED = 9007199254740993\n")])
+    assert contradicts_injected_cell(nb, {"SEED": 9007199254740993}) is None
+    assert contradicts_injected_cell(nb, {"SEED": "9007199254740993"}) is None
+    assert contradicts_injected_cell(nb, {"SEED": 9007199254740992}) is not None
+
+
+def test_float_matches_its_decimal_string() -> None:
+    nb = _notebook([_injected_cell("# Parameters\nTRAIN_SAMPLE_FRAC = 0.1\n")])
+    assert contradicts_injected_cell(nb, {"TRAIN_SAMPLE_FRAC": "0.1"}) is None
+    assert contradicts_injected_cell(nb, {"TRAIN_SAMPLE_FRAC": 0.2}) is not None
+
+
 def test_string_parameters_compare_by_value() -> None:
     nb = _notebook([_injected_cell('# Parameters\nSTART_DATE = "2024-06-01"\n')])
     assert contradicts_injected_cell(nb, {"START_DATE": "2024-06-01"}) is None

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -85,6 +85,20 @@ def test_numeric_and_string_bools_are_the_same_override() -> None:
     assert contradicts_injected_cell(nb, {"FORCE_RETRAIN": 0}) is not None
 
 
+def test_bool_coercion_does_not_reach_ordinary_numeric_parameters() -> None:
+    """``MAX_SYMBOLS = 1`` is a count, not a flag, so it must not match ``true``."""
+    nb = _notebook([_injected_cell("# Parameters\nMAX_SYMBOLS = 1\n")])
+    assert contradicts_injected_cell(nb, {"MAX_SYMBOLS": "1"}) is None
+    assert contradicts_injected_cell(nb, {"MAX_SYMBOLS": True}) is not None
+    assert contradicts_injected_cell(nb, {"MAX_SYMBOLS": 2}) is not None
+
+
+def test_string_parameters_compare_by_value() -> None:
+    nb = _notebook([_injected_cell('# Parameters\nSTART_DATE = "2024-06-01"\n')])
+    assert contradicts_injected_cell(nb, {"START_DATE": "2024-06-01"}) is None
+    assert contradicts_injected_cell(nb, {"START_DATE": "2020-01-01"}) is not None
+
+
 # -----------------------------------------------------------------------------
 # The injected-parameters cell — the record that belongs to the execution
 # -----------------------------------------------------------------------------

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -107,6 +107,19 @@ def test_float_matches_its_decimal_string() -> None:
     assert contradicts_injected_cell(nb, {"TRAIN_SAMPLE_FRAC": 0.2}) is not None
 
 
+def test_non_finite_values_reach_one_normal_form() -> None:
+    """A Decimal NaN does not equal itself, so these have to compare as text.
+
+    Papermill spells a non-finite override ``float('nan')``, which is not a literal
+    and so reaches the comparison as that source text on the injected side. Every
+    form that *is* a number normalizes together; the call form compares as itself.
+    """
+    nb = _notebook([_injected_cell("# Parameters\nCAP = inf\n")])
+    assert contradicts_injected_cell(nb, {"CAP": float("inf")}) is None
+    assert contradicts_injected_cell(nb, {"CAP": "Infinity"}) is None
+    assert contradicts_injected_cell(nb, {"CAP": 5}) is not None
+
+
 def test_string_parameters_compare_by_value() -> None:
     nb = _notebook([_injected_cell('# Parameters\nSTART_DATE = "2024-06-01"\n')])
     assert contradicts_injected_cell(nb, {"START_DATE": "2024-06-01"}) is None

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -73,6 +73,18 @@ def test_production_parameters_allow_only_full_run_cache_bypasses():
     assert not production_parameters({"USE_CACHE": True})
 
 
+def test_numeric_and_string_bools_are_the_same_override() -> None:
+    """``1`` from a JSON declaration and ``"1"`` from ``papermill -p`` are one run."""
+    assert production_parameters({"FORCE_REBACKTEST": 1})
+    assert production_parameters({"USE_CACHE": 0})
+    assert not production_parameters({"USE_CACHE": 1})
+
+    nb = _notebook([_injected_cell("# Parameters\nFORCE_RETRAIN = 1\n")])
+    assert contradicts_injected_cell(nb, {"FORCE_RETRAIN": "1"}) is None
+    assert contradicts_injected_cell(nb, {"FORCE_RETRAIN": True}) is None
+    assert contradicts_injected_cell(nb, {"FORCE_RETRAIN": 0}) is not None
+
+
 # -----------------------------------------------------------------------------
 # The injected-parameters cell — the record that belongs to the execution
 # -----------------------------------------------------------------------------

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -3,24 +3,62 @@
 Stamped notebooks carry ``metadata.ml4t_provenance`` recording the git blob of the
 paired ``.py`` they were executed from and whether the run used production
 parameters. This test fails if any *stamped* notebook is stale (its ``.py`` changed
-since execution) or was committed from a TEST-mode run.
+since execution), was committed from a TEST-mode run, or carries a stamp that
+contradicts the ``injected-parameters`` cell in the committed notebook.
 
 Unstamped notebooks are not failed here (adoption is gradual — stamp notebooks as
 they are re-run through the canonical path). See
 ``.github/scripts/notebook_provenance.py`` for the stamp/check tool. To stamp::
 
-    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor <env>
+    uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> \
+        --executor <env> --production
+
+The executor declares the parameters (``--production`` or ``--parameters '<json>'``)
+because ``metadata.papermill.parameters`` is a fossil: papermill does not clear it
+on an unparameterized re-run, and ``jupytext --sync`` deletes the
+``injected-parameters`` cell while leaving that metadata behind. The tests below pin
+both halves of the replacement — the declaration is what gets recorded, and a
+committed injected cell can veto it.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / ".github" / "scripts"))
 
-from notebook_provenance import check_all, production_parameters  # noqa: E402
+import notebook_provenance  # noqa: E402
+from notebook_provenance import (  # noqa: E402
+    check_all,
+    contradicts_injected_cell,
+    injected_parameters,
+    production_parameters,
+    stamp_notebook,
+)
+
+
+def _notebook(cells: list[dict], metadata: dict | None = None) -> dict:
+    return {
+        "cells": cells,
+        "metadata": metadata or {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _injected_cell(source: str) -> dict:
+    return {
+        "cell_type": "code",
+        "metadata": {"tags": ["injected-parameters"]},
+        "source": source,
+        "outputs": [],
+        "execution_count": 1,
+    }
 
 
 def test_production_parameters_allow_only_full_run_cache_bypasses():
@@ -35,9 +73,109 @@ def test_production_parameters_allow_only_full_run_cache_bypasses():
     assert not production_parameters({"USE_CACHE": True})
 
 
+# -----------------------------------------------------------------------------
+# The injected-parameters cell — the record that belongs to the execution
+# -----------------------------------------------------------------------------
+
+
+def test_injected_parameters_reads_the_cell_papermill_wrote() -> None:
+    nb = _notebook([_injected_cell('# Parameters\nMAX_SYMBOLS = 5\nSTART_DATE = "2024-06-01"\n')])
+    assert injected_parameters(nb) == {"MAX_SYMBOLS": 5, "START_DATE": "2024-06-01"}
+
+
+def test_injected_parameters_is_none_without_the_cell() -> None:
+    """No cell is no evidence — not evidence of a production run."""
+    assert injected_parameters(_notebook([])) is None
+
+
+def test_injected_parameters_accepts_a_source_list() -> None:
+    """nbformat stores cell source as a list of lines as often as a string."""
+    nb = _notebook([_injected_cell(["# Parameters\n", "MAX_SYMBOLS = 5\n"])])
+    assert injected_parameters(nb) == {"MAX_SYMBOLS": 5}
+
+
+# -----------------------------------------------------------------------------
+# The stamp declares; the injected cell can veto
+# -----------------------------------------------------------------------------
+
+
+def test_no_injected_cell_never_contradicts() -> None:
+    assert contradicts_injected_cell(_notebook([]), {"MAX_SYMBOLS": 5}) is None
+
+
+def test_declaration_matching_the_injected_cell_does_not_contradict() -> None:
+    nb = _notebook([_injected_cell("# Parameters\nMAX_SYMBOLS = 5\n")])
+    assert contradicts_injected_cell(nb, {"MAX_SYMBOLS": 5}) is None
+
+
+def test_papermill_string_coercion_does_not_look_like_a_contradiction() -> None:
+    """``-p FORCE_RETRAIN true`` reaches the cell as a string and the CLI as a bool."""
+    nb = _notebook([_injected_cell('# Parameters\nFORCE_RETRAIN = "true"\n')])
+    assert contradicts_injected_cell(nb, {"FORCE_RETRAIN": True}) is None
+
+
+def test_claiming_production_over_an_injected_cell_contradicts() -> None:
+    """The false positive the fossil allowed: a TEST run stamped as production."""
+    nb = _notebook([_injected_cell("# Parameters\nMAX_SYMBOLS = 5\n")])
+    conflict = contradicts_injected_cell(nb, {})
+    assert conflict is not None
+    assert "MAX_SYMBOLS" in conflict
+
+
+def test_stamp_refuses_to_contradict_the_injected_cell(tmp_path, monkeypatch) -> None:
+    nb_path = tmp_path / "demo.ipynb"
+    nb_path.write_text(json.dumps(_notebook([_injected_cell("# Parameters\nMAX_SYMBOLS = 5\n")])))
+    (tmp_path / "demo.py").write_text("# %%\nMAX_SYMBOLS = 0\n")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+
+    with pytest.raises(SystemExit, match="refusing to stamp"):
+        stamp_notebook(nb_path, executor="local-uv", parameters={})
+
+
+def test_stamp_records_the_declaration_not_the_papermill_fossil(tmp_path, monkeypatch) -> None:
+    """The defect this replaced.
+
+    Papermill leaves ``metadata.papermill.parameters`` in place across an
+    unparameterized re-run, and ``jupytext --sync`` keeps that metadata while
+    deleting the ``injected-parameters`` cell. A notebook in exactly that state —
+    stale TEST parameters in metadata, no injected cell — used to be stamped
+    ``production=False`` from the fossil, failing a genuine production run.
+    """
+    nb_path = tmp_path / "demo.ipynb"
+    fossil = {"papermill": {"parameters": {"MAX_SYMBOLS": 5, "START_DATE": "2024-06-01"}}}
+    nb_path.write_text(json.dumps(_notebook([], metadata=fossil)))
+    (tmp_path / "demo.py").write_text("# %%\nMAX_SYMBOLS = 0\n")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+
+    stamp = stamp_notebook(nb_path, executor="local-uv", parameters={})
+
+    assert stamp["production"] is True
+    assert stamp["parameters"] == {}
+    # The fossil is overwritten, so it cannot outlive the stamp and disagree.
+    written = json.loads(nb_path.read_text())
+    assert written["metadata"]["papermill"]["parameters"] == {}
+
+
+def test_stamp_records_declared_overrides_as_test_mode(tmp_path, monkeypatch) -> None:
+    nb_path = tmp_path / "demo.ipynb"
+    nb_path.write_text(json.dumps(_notebook([])))
+    (tmp_path / "demo.py").write_text("# %%\nMAX_SYMBOLS = 0\n")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+
+    stamp = stamp_notebook(nb_path, executor="local-uv", parameters={"MAX_SYMBOLS": 5})
+
+    assert stamp["production"] is False
+    assert stamp["parameters"] == {"MAX_SYMBOLS": 5}
+
+
+# -----------------------------------------------------------------------------
+# The gate over the committed tree
+# -----------------------------------------------------------------------------
+
+
 def test_stamped_notebooks_are_current_and_production() -> None:
-    stale, testmode, _unverified = check_all(strict=False)
-    assert not stale and not testmode, (
+    stale, testmode, contradicted, _unverified = check_all(strict=False)
+    assert not stale and not testmode and not contradicted, (
         "Committed notebooks are out of sync with their source .py:\n"
         + (
             "  STALE (re-run in the canonical env):\n    " + "\n    ".join(stale) + "\n"
@@ -45,8 +183,14 @@ def test_stamped_notebooks_are_current_and_production() -> None:
             else ""
         )
         + (
-            "  TEST-MODE (must be a production run):\n    " + "\n    ".join(testmode)
+            "  TEST-MODE (must be a production run):\n    " + "\n    ".join(testmode) + "\n"
             if testmode
+            else ""
+        )
+        + (
+            "  CONTRADICTED (stamp disagrees with the injected-parameters cell):\n    "
+            + "\n    ".join(contradicted)
+            if contradicted
             else ""
         )
     )


### PR DESCRIPTION
## The defect

`notebook_provenance.py stamp` decided whether a committed notebook came from a production run by reading the notebook's own `metadata.papermill.parameters`:

```python
params = nb["metadata"]["papermill"]["parameters"]
"production": production_parameters(params),
```

That key is not a record of the run being stamped. Both mechanisms reproduce:

1. **Papermill does not clear it.** Executing with `-p MAX_SYMBOLS 5 -p START_DATE 2024-06-01`, then re-executing the same file with no overrides, leaves the old dict in place next to a freshly-written `start_time`. Verified: after the second run the metadata still read `{'MAX_SYMBOLS': 5, 'START_DATE': '2024-06-01'}`.
2. **`jupytext --sync` preserves it.** Syncing rebuilds the cell list from the `.py`, which removes the `injected-parameters` cell, while notebook-level `metadata` survives untouched. Verified: after a sync from a clean `.py`, the injected cell was gone and the parameters dict was unchanged.

So the marker that belongs to the run is deleted and the misleading one is kept, and the flag can be wrong in both directions — a genuine production run stamped `production=False` from a weeks-old TEST dict, or a reduced run stamped `production=True` once its overrides aged out of the allowlist check.

## What changed

**The executor declares.** `stamp` now requires `--production` or `--parameters '{"MAX_SYMBOLS": 5}'`. Nothing is inferred from metadata another process wrote.

**The notebook can veto.** Papermill's `injected-parameters` cell lives in the cell list, so a parameterized run rewrites it, and a cell left over from an earlier run was still executed by the later one — its values were in force either way. `stamp` reads that cell and refuses to write a declaration that contradicts it; `check` reports the same contradiction over the committed tree, catching a notebook re-executed with overrides after it was stamped.

```
$ notebook_provenance.py stamp case_studies/etfs/11a_pca.ipynb --executor local-uv --production
refusing to stamp case_studies/etfs/11a_pca.ipynb: declared parameters {} do not match the
injected-parameters cell this notebook was executed with, {'USE_CACHE': False, 'FORCE_RETRAIN': True}
```

Absence of the cell still proves nothing — `jupytext --sync` deletes it — which is why the declaration, not the cell, is the primary evidence. Stamping also overwrites `metadata.papermill.parameters` with the declared set, so the fossil cannot outlive the stamp.

Parameter comparison normalizes the forms of one override that papermill's several entry points produce: `-p` stringifies everything, a YAML file keeps real types, and a JSON declaration gives numbers. Booleans are read as booleans only for the names in `PRODUCTION_SAFE_PARAMETERS`, so `MAX_SYMBOLS = 1` still contradicts a declared `true`; numbers compare as `Decimal`, so integers differing above 2**53 stay apart; and papermill's `float('nan')` call spelling is read back as the number.

## Verification

`tests/test_notebook_sync.py` goes from 2 tests to 19, covering: reading the injected cell; absence being no evidence; the declaration being recorded rather than the fossil (the false negative); a declaration contradicting the cell (the false positive); `-p` string coercion not looking like a contradiction; boolean coercion not reaching ordinary numeric parameters; large integers; non-finite values; and papermill's spelling of them, pinned so the assumption fails loudly if the translator changes.

The gate is unchanged over the current tree:

```
notebook sync OK: 0 stale, 0 test-mode, 0 contradicted, 65 unverified (advisory)
```

The last four commits are fixes for findings the pre-push review raised on the ones before them.