### PR TITLE
Give the two config-trim copies one home, and fix the dead one

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests.preset_patches import _patch_presets_for_testing
+from tests.preset_patches import _patch_presets_for_testing, _trim_label_configs
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -271,10 +271,12 @@ def seeded_output_dir(tmp_path_factory):
     return output_dir
 
 
-# _patch_presets_for_testing (imported above) and the _TEST_PRESET_PATCHES
-# table it reads live in tests/preset_patches.py, which
-# tests/generate_intermediates.py also imports - that script runs standalone
-# without pytest installed, so the table can't live in this module.
+# _patch_presets_for_testing and _trim_label_configs (imported above), and the
+# _TEST_PRESET_PATCHES table the first reads, live in tests/preset_patches.py,
+# which tests/generate_intermediates.py also imports - that script runs
+# standalone without pytest installed, so they can't live in this module.
+# _trim_label_configs was duplicated here until 2026-07-30; the copy in
+# generate_intermediates.py globbed the wrong directory and trimmed nothing.
 
 _PREDICTION_COL_RENAMES = {
     "y_score": "prediction",
@@ -301,36 +303,6 @@ def _migrate_predictions_schema(preds_root: Path) -> None:
             continue
         df = pl.read_parquet(parquet).rename(renames)
         df.write_parquet(parquet)
-
-
-# Max configs per family in label config files (keep tests fast but comprehensive).
-# Only applied to families with homogeneous sweep configs (linear, gbm).
-# DL/TabDL/latent/causal families are NOT trimmed because each config often
-# maps to a dedicated notebook (e.g., 09_dl_lstm, 10_dl_tsmixer).
-_MAX_CONFIGS_PER_FAMILY = 2
-_TRIM_FAMILIES = {"linear", "gbm"}
-
-
-def _trim_label_configs(cs_config_dir: Path) -> None:
-    """Trim training menu YAMLs to at most _MAX_CONFIGS_PER_FAMILY for sweep families."""
-    training_dir = cs_config_dir / "training"
-    label_root = training_dir if training_dir.exists() else cs_config_dir
-    for label_yaml in label_root.glob("fwd_*.yaml"):
-        data = yaml.safe_load(label_yaml.read_text())
-        if data is None or not isinstance(data, dict):
-            continue
-        trimmed = False
-        for family, configs in data.items():
-            if (
-                family in _TRIM_FAMILIES
-                and isinstance(configs, list)
-                and len(configs) > _MAX_CONFIGS_PER_FAMILY
-            ):
-                data[family] = configs[:_MAX_CONFIGS_PER_FAMILY]
-                trimmed = True
-        if trimmed:
-            with open(label_yaml, "w") as f:
-                yaml.dump(data, f, default_flow_style=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -35,14 +35,12 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-import yaml
-
 try:
     from tests.pm_helpers import get_overrides, run_notebook
-    from tests.preset_patches import _patch_presets_for_testing
+    from tests.preset_patches import _patch_presets_for_testing, _trim_label_configs
 except ModuleNotFoundError:
     from pm_helpers import get_overrides, run_notebook
-    from preset_patches import _patch_presets_for_testing
+    from preset_patches import _patch_presets_for_testing, _trim_label_configs
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -76,29 +74,6 @@ DL_STAGE_PATTERNS = re.compile(
 # copies of the same workload-reduction table drift the moment one gets a
 # fix the other doesn't (e.g. IPCA's factor_ridge/gamma_ridge
 # regularization), silently regenerating fixtures against the stale values.
-
-_MAX_CONFIGS_PER_FAMILY = 2
-_TRIM_FAMILIES = {"linear", "gbm"}
-
-
-def _trim_label_configs(cs_config_dir: Path) -> None:
-    """Trim label config YAMLs to at most _MAX_CONFIGS_PER_FAMILY for sweep families."""
-    for label_yaml in cs_config_dir.glob("fwd_*.yaml"):
-        data = yaml.safe_load(label_yaml.read_text())
-        if data is None or not isinstance(data, dict):
-            continue
-        trimmed = False
-        for family, configs in data.items():
-            if (
-                family in _TRIM_FAMILIES
-                and isinstance(configs, list)
-                and len(configs) > _MAX_CONFIGS_PER_FAMILY
-            ):
-                data[family] = configs[:_MAX_CONFIGS_PER_FAMILY]
-                trimmed = True
-        if trimmed:
-            with open(label_yaml, "w") as f:
-                yaml.dump(data, f, default_flow_style=False)
 
 
 def seed_configs(output_dir: Path) -> None:

--- a/tests/preset_patches.py
+++ b/tests/preset_patches.py
@@ -55,3 +55,38 @@ def _patch_presets_for_testing(config_dir: Path) -> None:
             preset.update(overrides)
             with open(preset_path, "w") as f:
                 yaml.dump(preset, f, default_flow_style=False)
+
+
+# Max configs per family in training menu YAMLs (keep tests fast but comprehensive).
+# Only applied to families with homogeneous sweep configs (linear, gbm).
+# DL/TabDL/latent/causal families are NOT trimmed because each config often
+# maps to a dedicated notebook (e.g., 09_dl_lstm, 10_dl_tsmixer).
+_MAX_CONFIGS_PER_FAMILY = 2
+_TRIM_FAMILIES = {"linear", "gbm"}
+
+
+def _trim_label_configs(cs_config_dir: Path) -> None:
+    """Trim training menu YAMLs to at most _MAX_CONFIGS_PER_FAMILY for sweep families.
+
+    The menus live at ``config/training/fwd_*.yaml``. An earlier copy of this
+    function globbed ``config/fwd_*.yaml``, matched nothing, and silently left
+    every sweep family at full width.
+    """
+    training_dir = cs_config_dir / "training"
+    label_root = training_dir if training_dir.exists() else cs_config_dir
+    for label_yaml in label_root.glob("fwd_*.yaml"):
+        data = yaml.safe_load(label_yaml.read_text())
+        if data is None or not isinstance(data, dict):
+            continue
+        trimmed = False
+        for family, configs in data.items():
+            if (
+                family in _TRIM_FAMILIES
+                and isinstance(configs, list)
+                and len(configs) > _MAX_CONFIGS_PER_FAMILY
+            ):
+                data[family] = configs[:_MAX_CONFIGS_PER_FAMILY]
+                trimmed = True
+        if trimmed:
+            with open(label_yaml, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)


### PR DESCRIPTION
`tests/generate_intermediates.py` and `tests/conftest.py` each carried their own
`_trim_label_configs`. They had drifted:

- the `conftest.py` copy globs `config/training/fwd_*.yaml` and works;
- the `generate_intermediates.py` copy globbed `config/fwd_*.yaml`, where no
  training menu has ever lived, so it matched nothing and every fixture
  regeneration ran the full sweep for every case study.

Measured on `fx_pairs`, before and after, per training menu:

| family | before | after |
|---|---|---|
| `linear` | 28 | 2 |
| `gbm` | 15 | 2 |
| `deep_learning` | 3 | 3 |
| `tabular_dl` | 3 | 3 |
| `causal_dml` | 1 | 1 |

`tests/preset_patches.py` exists for exactly this situation - it holds the
workload-reduction table both modules import, because two copies of *that* had
previously drifted onto different values with no error to signal it. The trim
moves there for the same reason and both call sites import it.

**No CI behaviour changes.** `conftest.py` keeps the function it already had,
now by import rather than by copy; the moved body is its version, unmodified.
Only fixture regeneration - which is not run in CI, and which was running
unreduced - is affected.

## Verification

```
pytest tests/test_pm_helpers.py tests/test_create_test_data.py \
       tests/test_sample_registry_for_tests.py
51 passed
```

`ruff check` and `ruff format --check` clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)