### PR TITLE
Reject a papermill parameter the notebook cannot receive

### DIFF
--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -563,16 +563,25 @@ Test parameter overrides are defined in `tests/overrides.yaml`, keyed by noteboo
 ```yaml
 # Example entries
 11_ml_pipeline/01_ols_inference:
-  timeout: 180
-  parameters:
-    MAX_SYMBOLS: 15
-
-case_studies/etfs/07_gbm:
   timeout: 300
   parameters:
-    MAX_SYMBOLS: 15
-    START_DATE: "2020-01-01"
+    MAX_SYMBOLS: 10
+    MAX_TRAIN_ROWS: 5000
+
+case_studies/etfs/07_gbm:
+  timeout: 180
+  parameters:
+    MAX_FOLDS: 2
+    MAX_SYMBOLS: 5
 ```
+
+Papermill injects these values in a cell placed right after the notebook's
+`# %% tags=["parameters"]` cell, so each name has to be one the notebook reads
+below that point and does not overwrite before reading. Anything else is either
+an unused variable or is discarded before it is used.
+`tests/test_pm_helpers.py` rejects names that fail either condition, so a
+mistyped or renamed parameter turns the build red instead of quietly running the
+notebook at full scale.
 
 **To customize for your machine**: copy `tests/overrides.yaml` to `tests/overrides.local.yaml` (gitignored) and adjust timeouts or parameter values. The test runner checks for the local file first.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,18 +170,17 @@ The test runner (`scripts/run_all_tests.sh`) iterates over environments, running
 Per-notebook configuration lives in `tests/overrides.yaml`:
 
 ```yaml
-05_synthetic_data/01_timegan:
-  docker_env: gpu          # Runs only in GPU environment
-  timeout: 600             # Max seconds before test is killed
+11_ml_pipeline/01_ols_inference:
+  timeout: 300             # Max seconds before test is killed
   parameters:              # Papermill parameter overrides
-    TRAIN_STEPS: 100
-    BATCH_SIZE: 32
+    MAX_SYMBOLS: 10
+    MAX_TRAIN_ROWS: 5000
 
 case_studies/etfs/07_gbm:
-  timeout: 300
+  timeout: 180
   parameters:
-    MAX_SYMBOLS: 15
-    START_DATE: "2020-01-01"
+    MAX_FOLDS: 2
+    MAX_SYMBOLS: 5
 
 26_mlops_governance/05b_feast_live:
   skip: true               # Never runs
@@ -197,6 +196,32 @@ case_studies/etfs/07_gbm:
 | `skip` | false | Skip this notebook entirely |
 | `skip_reason` | — | Reason displayed in test output |
 | `parameters` | {} | Papermill parameter overrides |
+
+### A parameter has to be one the notebook can actually receive
+
+Papermill injects the `parameters` block as a cell placed directly after the
+notebook's own `# %% tags=["parameters"]` cell — or above the imports when there
+is no tagged cell. Anything the notebook assigns before that point is overridden
+and does not matter. Two things after it do:
+
+- **nothing reads the name**, so the value lands in a variable the notebook has
+  no use for;
+- **something rebinds it before anything reads it**, so the notebook goes on
+  using its own number.
+
+Papermill reports neither. The notebook runs at its production defaults while
+this file records a reduction. Reading the value and then rebinding the same
+name is fine — that is how `case_studies/*/1*_causal_dml` applies `CV_FOLDS`,
+and how `if MAX_SYMBOLS == 0: MAX_SYMBOLS = len(universe)` works. Only a
+rebinding that runs on every path, in a notebook where no function reads the
+name, counts as an overwrite; anything the check cannot establish it leaves
+alone, since a missed stale line is cheaper than a rejected real reduction.
+
+`test_pm_helpers.py` fails the build on any name that cannot reach its notebook,
+on any key that names a notebook which does not exist, and on any YAML anchor
+(one shared block would let a fix for one notebook land on six others). The
+sweeps ship with no allowlist. If one rejects an entry, make the notebook read
+the parameter or delete the entry — do not add an exception.
 
 ---
 

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -45,8 +45,6 @@
   timeout: 300
 02_financial_data_universe/18_data_management:
   timeout: 300
-02_financial_data_universe/18_storage_benchmark_file:
-  timeout: 300
 02_financial_data_universe/19_incremental_updates:
   timeout: 300
 02_financial_data_universe/20_storage_benchmark_file:
@@ -143,13 +141,6 @@
 05_synthetic_data/01_timegan:
   docker_env: py312
   gpu: true
-  parameters:
-    BATCH_SIZE: 32
-    EPOCHS: 1
-    HIDDEN_DIM: 8
-    NUM_LAYERS: 1
-    N_SAMPLES: 100
-    SEQ_LEN: 5
   timeout: 600
 05_synthetic_data/02_tailgan_tail_risk:
   gpu: true
@@ -212,7 +203,6 @@
   docker_env: py312
   gpu: true
   parameters:
-    BATCH_SIZE: 32
     EPOCHS: 5
     MAX_SYMBOLS: 5
   timeout: 300
@@ -227,16 +217,10 @@
 06_strategy_definition/03_case_study_overview:
   timeout: 180
 07_defining_the_learning_task/01_data_quality_diagnostics:
-  parameters:
-    START_DATE: '2023-01-01'
   timeout: 300
 07_defining_the_learning_task/02_preprocessing_pipeline:
-  parameters:
-    START_DATE: '2023-01-01'
   timeout: 300
 07_defining_the_learning_task/03_label_methods:
-  timeout: 300
-07_defining_the_learning_task/04_minimum_favorable_adverse_excursion:
   timeout: 300
 07_defining_the_learning_task/05_signal_evaluation:
   parameters:
@@ -247,24 +231,13 @@
 07_defining_the_learning_task/06_ic_inference:
   parameters:
     START_DATE: '2022-01-01'
-    n_boot: 500
   timeout: 300
 07_defining_the_learning_task/07_multiple_testing:
+  # N_RAD_ETF, not n_rad_etf: the lowercase name is assigned from this one
+  # inside `if min_len > 1:` and read only there, so papermill's value could
+  # never be the one used and the Rademacher run stayed at its 5000 default.
   parameters:
-    etf_start: '2020-01-01'
-    n_assets: 20
-    n_assets_zoo: 30
-    n_combos: 10
-    n_days: 252
-    n_factors: 30
-    n_factors_zoo: 50
-    n_periods: 120
-    n_periods_zoo: 252
-    n_rad_etf: 500
-    n_rad_sims: 500
-    n_strat_pbo: 8
-    n_strategies: 10
-    n_true: 3
+    N_RAD_ETF: 500
   timeout: 300
 07_defining_the_learning_task/08_causal_sanity_checks:
   parameters:
@@ -282,31 +255,17 @@
     START_DATE: '2023-01-01'
   timeout: 300
 08_financial_features/02_microstructure_features:
-  parameters:
-    N_TRADES: 50000
   timeout: 300
 08_financial_features/03_structural_cross_instrument_features:
-  parameters:
-    START_DATE: '2022-01-01'
   timeout: 300
 08_financial_features/04_fundamentals_macro_calendar:
-  parameters:
-    START_DATE: '2023-01-01'
   timeout: 300
-08_financial_features/05_factor_orthogonality:
-  parameters:
-    START_DATE: '2023-01-01'
-  timeout: 900
 08_financial_features/06_robustness_sensitivity:
   timeout: 300
 08_financial_features/07_event_studies:
   parameters:
     START_DATE: '2022-01-01'
   timeout: 300
-08_financial_features/08_feature_selection:
-  parameters:
-    START_DATE: '2023-01-01'
-  timeout: 900
 08_financial_features/case_study_feature_summary:
   timeout: 300
 09_model_based_features/01_visual_diagnostics:
@@ -352,10 +311,6 @@
   timeout: 300
 10_text_feature_engineering/01_word2vec_training:
   docker_env: py312
-  parameters:
-    EPOCHS: 2
-    MIN_COUNT: 3
-    WINDOW: 5
   requires_import: gensim
   reruns: 2
   timeout: 300
@@ -368,8 +323,6 @@
 10_text_feature_engineering/03_sentiment_evolution:
   docker_env: py312
   gpu: true
-  parameters:
-    MAX_SYMBOLS: 10
   requires_import: gensim
   timeout: 300
 10_text_feature_engineering/04_bert_finetuning:
@@ -399,7 +352,6 @@
   gpu: true
   parameters:
     MAX_SYMBOLS: 5
-    START_DATE: '2000-01-01'
   timeout: 600
 11_ml_pipeline/01_ols_inference:
   parameters:
@@ -474,29 +426,19 @@
 12_gradient_boosting/07_hpo_comparison:
   gpu: true
   long_running: true
-  parameters:
-    N_GRID_POINTS: 3
-    N_OPTUNA_TRIALS: 2
   timeout: 2400
 12_gradient_boosting/08_shap_analysis:
   env:
     MAX_SYMBOLS: 10
   timeout: 300
 12_gradient_boosting/09_xai_limitations:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 300
 12_gradient_boosting/10_shap_nlp_sentiment:
   docker_env: py312
   gpu: true
-  parameters:
-    MAX_SYMBOLS: 5
-    SAMPLE_SIZE: 100
   timeout: 300
 12_gradient_boosting/11_conformal_gbm:
   gpu: true
-  parameters:
-    MAX_SYMBOLS: 3
   timeout: 900
 12_gradient_boosting/12_case_study_insights:
   timeout: 300
@@ -632,9 +574,6 @@
     N_PERIODS: 200
   timeout: 240
 14_latent_factors/05_rp_pca:
-  parameters:
-    N_ASSETS: 50
-    N_PERIODS: 200
   timeout: 180
 14_latent_factors/06_conditional_autoencoder:
   docker_env: py312
@@ -723,7 +662,6 @@
   parameters:
     N_DATASETS: 50
     N_ESTIMATORS: 50
-    N_RF_ESTIMATORS: 25
   timeout: 900
 15_causal_estimation/10_case_study_insights:
   skip: true
@@ -744,66 +682,24 @@
   timeout: 300
 16_strategy_simulation/05_stateful_strategies:
   parameters:
-    N_ASSETS: 10
-    N_DAYS: 252
     SEED: 42
   timeout: 300
 16_strategy_simulation/06_framework_parity:
-  parameters:
-    N_ASSETS: 5
-    N_DAYS: 252
-    SEED: 42
   timeout: 300
 16_strategy_simulation/07_engine_divergence_anatomy:
   timeout: 300
-16_strategy_simulation/08_backtest_statistical_inference:
-  parameters:
-    N_ASSETS: 10
-    N_PERIODS: 252
-    N_SIMULATIONS: 200
-  timeout: 300
 16_strategy_simulation/08_signal_method_comparison:
-  timeout: 300
-16_strategy_simulation/09_backtesting_pitfalls:
-  parameters:
-    N_BARS: 252
-    N_SIMULATIONS: 200
   timeout: 300
 16_strategy_simulation/09_performance_reporting:
   timeout: 300
 16_strategy_simulation/10_regime_backtest_analysis:
   timeout: 300
-16_strategy_simulation/10_transaction_costs:
-  parameters:
-    N_ASSETS: 10
-    N_DAYS: 252
-  timeout: 300
-16_strategy_simulation/11_look_ahead_bias:
-  parameters:
-    N_ASSETS: 10
-    N_PERIODS: 252
-    N_SIMULATIONS: 200
-  timeout: 300
 16_strategy_simulation/11_sharpe_ratio_inference:
   timeout: 180
 16_strategy_simulation/12_dsr_validation:
   timeout: 300
-16_strategy_simulation/12_walk_forward_optimization:
-  parameters:
-    N_ASSETS: 10
-    N_LOOKBACK_PERIODS: 3
-    N_PERIODS: 500
-  timeout: 300
-16_strategy_simulation/13_backtesting_protocols:
-  parameters:
-    N_BARS: 252
-    N_LOOKBACK: 126
-    N_SIMULATIONS: 200
-  timeout: 300
 16_strategy_simulation/13_ras_protocol:
   timeout: 180
-16_strategy_simulation/14_case_study_insights:
-  timeout: 300
 16_strategy_simulation/15_lean_engine_parity:
   timeout: 300
 16_strategy_simulation/16_case_study_lean_parity:
@@ -813,38 +709,16 @@
 16_strategy_simulation/18_vectorbt_engine_parity:
   timeout: 300
 17_portfolio_construction/01_portfolio_metrics:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
-17_portfolio_construction/02_markowitz_mvo:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 300
 17_portfolio_construction/02_mean_variance_optimization:
   timeout: 300
 17_portfolio_construction/03_robust_optimization:
-  parameters:
-    MAX_SYMBOLS: 10
-    N_PORTFOLIOS: 500
-    N_SIMULATIONS: 200
-  timeout: 300
-17_portfolio_construction/04_black_litterman:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 300
 17_portfolio_construction/04_kelly_criterion:
   timeout: 180
 17_portfolio_construction/05_factor_allocation_evidence:
   timeout: 600
-17_portfolio_construction/05_risk_parity:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 17_portfolio_construction/06_hierarchical_risk_parity:
-  timeout: 300
-17_portfolio_construction/06_regime_based_allocation:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 300
 17_portfolio_construction/07_conformal_position_sizing:
   parameters:
@@ -853,32 +727,10 @@
     TOP_K_CME: 5
     TOP_K_ETF: 5
   timeout: 300
-17_portfolio_construction/07_shrinkage_estimators:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 17_portfolio_construction/08_library_comparison:
   timeout: 600
-17_portfolio_construction/08_signal_combination:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 17_portfolio_construction/09_allocator_comparison:
   timeout: 600
-17_portfolio_construction/09_portfolio_rebalancing:
-  parameters:
-    MAX_SYMBOLS: 10
-    N_SIMULATIONS: 200
-  timeout: 300
-17_portfolio_construction/10_constraints_real_world:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
-17_portfolio_construction/11_deepm_basics:
-  parameters:
-    MAX_SYMBOLS: 10
-    N_EPOCHS: 10
-  timeout: 300
 17_portfolio_construction/11_dl_portfolio_allocation:
   gpu: true
   parameters:
@@ -904,86 +756,36 @@
   parameters:
     MAX_SYMBOLS: 10
   timeout: 300
-18_transaction_costs/03_impact_models:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 18_transaction_costs/03_market_impact_calibration:
   parameters:
     MAX_SYMBOLS: 10
     NQ100_SYMBOLS: 5
   timeout: 300
-18_transaction_costs/04_execution_algorithms:
-  parameters:
-    N_DAYS: 20
-    N_SIMULATIONS: 200
-  timeout: 300
 18_transaction_costs/04_vwap_twap_execution:
   timeout: 300
 18_transaction_costs/05_almgren_chriss_optimal_execution:
   timeout: 300
-18_transaction_costs/05_nasdaq100_microstructure_validation:
-  parameters:
-    MAX_SYMBOLS: 5
-  timeout: 300
-18_transaction_costs/06_cost_adjusted_backtesting:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 18_transaction_costs/06_ml4t_execution_demo:
-  timeout: 300
-18_transaction_costs/07_cost_aware_portfolio:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 300
 18_transaction_costs/07_ml4t_volume_participation:
   timeout: 300
 18_transaction_costs/08_ml_dynamic_execution:
   timeout: 300
-18_transaction_costs/08_turnover_analysis:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
-18_transaction_costs/09_cost_sweep:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 600
 18_transaction_costs/09_frequency_tradeoff:
   timeout: 180
 18_transaction_costs/10_gross_vs_net_performance:
   timeout: 180
-18_transaction_costs/10_optimal_execution:
-  parameters:
-    N_SIMULATIONS: 200
-  timeout: 300
 18_transaction_costs/11_cost_cliff:
   timeout: 180
-18_transaction_costs/11_market_regime_costs:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 18_transaction_costs/12_commission_slippage_comparison:
   timeout: 180
-18_transaction_costs/12_cost_benchmarking:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 19_risk_management/01_var_cvar:
   timeout: 300
 19_risk_management/02_exit_strategies:
   timeout: 300
 19_risk_management/03_position_sizing_mae_mfe:
   timeout: 300
-19_risk_management/04_drawdown_analysis:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 19_risk_management/04_factor_exposure:
-  timeout: 300
-19_risk_management/05_stress_correlation:
-  parameters:
-    MAX_SYMBOLS: 10
-    N_SIMULATIONS: 200
   timeout: 300
 19_risk_management/05_trade_shap_diagnostics:
   timeout: 300
@@ -1003,24 +805,12 @@
   timeout: 600
 19_risk_management/10_ml4t_backtest_risk_demo:
   timeout: 300
-19_risk_management/10_risk_sweep:
-  parameters:
-    MAX_SYMBOLS: 10
-    N_SIMULATIONS: 200
-  timeout: 600
-19_risk_management/11_case_study_diagnostics:
-  parameters:
-    MAX_SYMBOLS: 10
-  timeout: 300
 19_risk_management/11_systematic_risk_sweep:
-  parameters:
-    MAX_RISK_VARIANTS: 3
   timeout: 900
 20_strategy_synthesis/00_holdout_predictions:
   skip_reason: Requires trained model registry (not available in CI test data)
 20_strategy_synthesis/01_aggregate_synthesis:
   parameters:
-    MAX_SYMBOLS: 10
     # Isolated test registry has no nasdaq out-of-band cost-feasible carrier,
     # so its spine can't resolve; report cost/risk N/A instead of raising.
     ALLOW_MISSING_SPINE: true
@@ -1028,12 +818,8 @@
 20_strategy_synthesis/02_feature_evaluation:
   timeout: 300
 20_strategy_synthesis/03_signal_quality:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 600
 20_strategy_synthesis/04_signal_to_strategy:
-  parameters:
-    MAX_SYMBOLS: 10
   timeout: 600
 20_strategy_synthesis/05_portfolio_allocation:
   parameters:
@@ -1149,37 +935,24 @@
   docker_env: ml4t+neo4j+gpu
   gpu: true
   parameters:
-    MAX_ENTITIES: 20
     MAX_FILINGS: 5
   timeout: 600
 23_knowledge_graphs/07_dynamic_kg_temporal:
   docker_env: ml4t+neo4j
-  parameters:
-    MAX_INSTITUTIONS: 10
-    MAX_QUARTERS: 2
   skip: true
   skip_reason: Requires 08_8k_event_extraction with GPU to generate temporal edges
   tier: on_demand
   timeout: 600
 23_knowledge_graphs/06_gnn_feature_engineering:
   gpu: true
-  parameters:
-    N_EPOCHS: 2
   timeout: 600
 23_knowledge_graphs/03_graph_rag_qa:
-  parameters:
-    MAX_QUERIES: 5
   timeout: 300
 23_knowledge_graphs/05_institutional_holdings_kg:
   docker_env: ml4t+neo4j
-  parameters:
-    MAX_INSTITUTIONS: 10
-    NUM_QUARTERS: 2
   timeout: 600
 23_knowledge_graphs/09_knowledge_graph_features:
   docker_env: ml4t+neo4j
-  parameters:
-    MAX_SYMBOLS: 10
   skip: true
   skip_reason: Requires 02_supply_chain_kg_construction with GPU to populate Neo4j
   tier: on_demand
@@ -1207,12 +980,9 @@
   timeout: 300
 24_autonomous_agents/02_tool_contracts:
   parameters:
-    LLM_PROVIDER: mock
     MAX_RESULTS: 3
   timeout: 300
 24_autonomous_agents/03_state_and_memory:
-  parameters:
-    MAX_EVIDENCE_ITEMS: 5
   timeout: 300
 24_autonomous_agents/04_research_agent:
   parameters:
@@ -1221,8 +991,6 @@
     MAX_STEPS: 3
   timeout: 300
 24_autonomous_agents/05_aggregation_math:
-  parameters:
-    N_FORECASTERS: 5
   timeout: 300
 24_autonomous_agents/06_multi_agent_research:
   parameters:
@@ -1242,17 +1010,10 @@
   parameters:
     DEBATE_ROUNDS: 2
     LLM_PROVIDER: mock
-    MAX_QUESTIONS: 2
-    MAX_SEARCH_RESULTS: 3
     MAX_STEPS: 3
     N_AGENTS: 3
   timeout: 300
 24_autonomous_agents/09_evaluation_and_governance:
-  parameters:
-    DEBATE_ROUNDS: 2
-    LLM_PROVIDER: mock
-    MAX_STEPS: 3
-    N_AGENTS: 3
   timeout: 300
 24_autonomous_agents/10_framework_comparison:
   parameters:
@@ -1305,9 +1066,6 @@
 25_live_trading/08_pipeline_verification:
   timeout: 360
 25_live_trading/09_crypto_funding_deployment_loop:
-  parameters:
-    EVALUATION_INTERVAL_SECONDS: 1
-    MAX_ITERATIONS: 1
   skip: true
   skip_reason: Requires OKX SDK + live exchange credentials (not in CI image)
   tier: weekly
@@ -1315,9 +1073,6 @@
 25_live_trading/10_safety_risk_demo:
   timeout: 180
 25_live_trading/11_fx_deployment_loop:
-  parameters:
-    EVALUATION_INTERVAL_SECONDS: 1
-    MAX_ITERATIONS: 1
   skip: true
   skip_reason: Requires running IB Gateway (not available in CI)
   tier: weekly
@@ -1363,34 +1118,13 @@
 case_studies/cme_futures/01_feasibility_analysis:
   timeout: 180
 case_studies/cme_futures/02_labels:
-  parameters:
-    # MAX_PRODUCTS stays unset: the CI fixture is already a reduced universe, and
-    # thinning the cross-section starves the rank correlation in section G.
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/cme_futures/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/cme_futures/04_model_based_features:
   parameters:
     FFT_WINDOW: 126
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
     MAX_PRODUCTS: 3
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   skip: true
   skip_reason: ARIMA/HMM/FFT cells across multiple products and folds exceed 900s on the slower pymc 5.28 / pytensor 2.38
     / numpy 2.3 stack. All downstream notebooks consume the pre-seeded test-data/intermediates/cme_futures/features and pass;
@@ -1409,7 +1143,6 @@ case_studies/cme_futures/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/cme_futures/08_tabular_dl:
   parameters:
@@ -1427,12 +1160,6 @@ case_studies/cme_futures/09_dl_lstm:
     N_EPOCHS: 1
   timeout: 180
 case_studies/cme_futures/10_latent_factors:
-  parameters:
-    FORCE_RETRAIN: true
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 1
-    N_FACTORS: 2
   timeout: 180
 case_studies/cme_futures/10b_stochastic_discount_factor:
   skip: true
@@ -1452,17 +1179,17 @@ case_studies/cme_futures/13_backtest:
     TOP_K: 2
     TOP_N_PREDICTIONS: 2
   timeout: 120
-case_studies/cme_futures/14_portfolio_management: &id001
+case_studies/cme_futures/14_portfolio_management:
   parameters:
     MAX_SYMBOLS: 5
     TOP_N_PREDICTIONS: 2
   timeout: 300
-case_studies/cme_futures/15_costs: &id002
+case_studies/cme_futures/15_costs:
   parameters:
     MAX_SYMBOLS: 5
     TOP_N_COMBOS: 1
   timeout: 600
-case_studies/cme_futures/16_risk_management: &id003
+case_studies/cme_futures/16_risk_management:
   parameters:
     MAX_RISK_VARIANTS: 3
     MAX_SYMBOLS: 5
@@ -1483,26 +1210,12 @@ case_studies/crypto_perps_funding/02_labels:
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/crypto_perps_funding/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/crypto_perps_funding/04_model_based_features:
   parameters:
-    GARCH_MIN_OBS: 50
     HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
     MAX_SYMBOLS: 5
-    MIN_OBS: 10
     MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 300
 case_studies/crypto_perps_funding/05_evaluation:
   parameters:
@@ -1517,7 +1230,6 @@ case_studies/crypto_perps_funding/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/crypto_perps_funding/08_tabular_dl:
   parameters:
@@ -1553,21 +1265,19 @@ case_studies/crypto_perps_funding/11_causal_dml:
 case_studies/crypto_perps_funding/12_model_analysis:
   timeout: 300
 case_studies/crypto_perps_funding/13_backtest:
+  timeout: 600
+case_studies/crypto_perps_funding/14_portfolio_management:
   parameters:
     MAX_SYMBOLS: 5
-    TOP_K: 2
-  timeout: 600
-case_studies/crypto_perps_funding/14_portfolio_management: *id001
+  timeout: 300
 case_studies/crypto_perps_funding/15_costs:
   parameters:
     MAX_SYMBOLS: 5
-    TOP_N_COMBOS: 1
   timeout: 600
 case_studies/crypto_perps_funding/16_risk_management:
   parameters:
     MAX_RISK_VARIANTS: 3
     MAX_SYMBOLS: 5
-    TOP_N_COMBOS: 1
   timeout: 600
 case_studies/crypto_perps_funding/17_strategy_analysis:
 case_studies/etfs/01_feasibility_analysis:
@@ -1587,26 +1297,12 @@ case_studies/etfs/02_labels:
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/etfs/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 300
 case_studies/etfs/04_model_based_features:
   parameters:
     GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
     MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
     N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 300
 case_studies/etfs/05_evaluation:
   parameters:
@@ -1621,7 +1317,6 @@ case_studies/etfs/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/etfs/08_tabular_dl:
   parameters:
@@ -1669,12 +1364,6 @@ case_studies/etfs/11b_ipca:
   timeout: 300
 case_studies/etfs/11_latent_factors:
   gpu: true
-  parameters:
-    FORCE_RETRAIN: true
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 2
-    N_FACTORS: 2
   timeout: 900
 case_studies/etfs/11c_conditional_autoencoder:
   skip: true
@@ -1718,33 +1407,17 @@ case_studies/etfs/18_strategy_analysis:
 case_studies/fx_pairs/01_feasibility_analysis:
   timeout: 120
 case_studies/fx_pairs/02_labels:
-  parameters:
-    MAX_SYMBOLS: 5
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/fx_pairs/03_financial_features:
   parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
     START_DATE: '2000-01-01'
   timeout: 300
 case_studies/fx_pairs/04_model_based_features:
   parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
     KALMAN_MAXITER: 50
     MAX_FOLDS: 2
-    MAX_SAMPLE_ASSETS: 3
     MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
     N_HMM_RESTARTS: 3
-    N_RESTARTS: 1
     START_DATE: '2000-01-01'
   timeout: 300
 case_studies/fx_pairs/05_evaluation:
@@ -1760,7 +1433,6 @@ case_studies/fx_pairs/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/fx_pairs/08_tabular_dl:
   parameters:
@@ -1799,9 +1471,22 @@ case_studies/fx_pairs/13_backtest:
     MAX_SYMBOLS: 5
     TOP_K: 2
   timeout: 600
-case_studies/fx_pairs/14_portfolio_management: *id001
-case_studies/fx_pairs/15_costs: *id002
-case_studies/fx_pairs/16_risk_management: *id003
+case_studies/fx_pairs/14_portfolio_management:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_PREDICTIONS: 2
+  timeout: 300
+case_studies/fx_pairs/15_costs:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
+case_studies/fx_pairs/16_risk_management:
+  parameters:
+    MAX_RISK_VARIANTS: 3
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
 case_studies/fx_pairs/17_strategy_analysis:
 case_studies/nasdaq100_microstructure/01_feasibility_analysis:
   parameters:
@@ -1814,13 +1499,6 @@ case_studies/nasdaq100_microstructure/02_labels:
   timeout: 120
 case_studies/nasdaq100_microstructure/03_financial_features:
   parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/04_model_based_features:
@@ -1847,7 +1525,6 @@ case_studies/nasdaq100_microstructure/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 600
 case_studies/nasdaq100_microstructure/08_dl_nlinear:
   parameters:
@@ -1903,44 +1580,33 @@ case_studies/nasdaq100_microstructure/14_backtest:
     TOP_K: 2
     TOP_N_PREDICTIONS: 2
   timeout: 180
-case_studies/nasdaq100_microstructure/15_portfolio_management: *id001
+case_studies/nasdaq100_microstructure/15_portfolio_management:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_PREDICTIONS: 2
+  timeout: 300
 case_studies/nasdaq100_microstructure/16_costs:
   timeout: 600
-case_studies/nasdaq100_microstructure/17_risk_management: *id003
+case_studies/nasdaq100_microstructure/17_risk_management:
+  parameters:
+    MAX_RISK_VARIANTS: 3
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
 case_studies/nasdaq100_microstructure/18_strategy_analysis:
   skip: true
   skip_reason: "Analyzes the cost-feasible ensemble carrier, which is registered out-of-band (session_6/7 drivers) and is not reproduced by the in-notebook test sweep, so an isolated test registry has no carrier rows. Runs clean in production."
-  parameters:
-    MAX_SYMBOLS: 5
   timeout: 180
 case_studies/sp500_equity_option_analytics/01_feasibility_analysis:
   timeout: 120
 case_studies/sp500_equity_option_analytics/02_labels:
-  parameters:
-    MAX_SYMBOLS: 5
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/sp500_equity_option_analytics/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/sp500_equity_option_analytics/04_model_based_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
+  # MIN_OBS: 10 removed - the notebook repeats `MIN_OBS = 252` below the
+  # parameters cell, so the injected value was gone before any function
+  # that reads it could run.
   timeout: 300
 case_studies/sp500_equity_option_analytics/05_evaluation:
   parameters:
@@ -1962,7 +1628,6 @@ case_studies/sp500_equity_option_analytics/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/sp500_equity_option_analytics/08_tabular_dl:
   parameters:
@@ -1988,12 +1653,6 @@ case_studies/sp500_equity_option_analytics/10_dl_patchtst:
     N_EPOCHS: 1
   timeout: 180
 case_studies/sp500_equity_option_analytics/11_latent_factors:
-  parameters:
-    FORCE_RETRAIN: true
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 1
-    N_FACTORS: 2
   timeout: 600
 case_studies/sp500_equity_option_analytics/11a_pca: {}
 case_studies/sp500_equity_option_analytics/11b_ipca:
@@ -2061,23 +1720,28 @@ case_studies/sp500_equity_option_analytics/14_backtest:
     MAX_SYMBOLS: 3
     TOP_K: 1
   timeout: 600
-case_studies/sp500_equity_option_analytics/15_portfolio_management: *id001
-case_studies/sp500_equity_option_analytics/16_costs: *id002
-case_studies/sp500_equity_option_analytics/17_risk_management: *id003
+case_studies/sp500_equity_option_analytics/15_portfolio_management:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_PREDICTIONS: 2
+  timeout: 300
+case_studies/sp500_equity_option_analytics/16_costs:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
+case_studies/sp500_equity_option_analytics/17_risk_management:
+  parameters:
+    MAX_RISK_VARIANTS: 3
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
 case_studies/sp500_equity_option_analytics/18_strategy_analysis:
 case_studies/sp500_options/01_feasibility_analysis:
   timeout: 120
 case_studies/sp500_options/02_labels:
   timeout: 300
 case_studies/sp500_options/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
   timeout: 120
 case_studies/sp500_options/04_model_based_features:
   # Skipped in CI (gpu: true), so this timeout bounds only fixture generation via
@@ -2110,15 +1774,11 @@ case_studies/sp500_options/05_evaluation:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/sp500_options/06_linear:
-  parameters:
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
   timeout: 120
 case_studies/sp500_options/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/sp500_options/08_tabular_dl:
   parameters:
@@ -2177,30 +1837,16 @@ case_studies/us_equities_panel/01_feasibility_analysis:
   timeout: 120
 case_studies/us_equities_panel/02_labels:
   parameters:
-    MAX_SYMBOLS: 5
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/us_equities_panel/03_financial_features:
   parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
     START_DATE: '2000-01-01'
   timeout: 600
 case_studies/us_equities_panel/04_model_based_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
+  # GARCH_MIN_OBS: 50 removed - the notebook has no parameters cell, so the
+  # injected cell goes to the top and `GARCH_MIN_OBS = 504` on line 100
+  # overwrites it before any function that reads it can run.
   timeout: 300
 case_studies/us_equities_panel/05_evaluation:
   parameters:
@@ -2215,7 +1861,6 @@ case_studies/us_equities_panel/07_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/us_equities_panel/08_tabular_dl:
   parameters:
@@ -2270,12 +1915,6 @@ case_studies/us_equities_panel/12_dl_weekly:
     N_EPOCHS: 1
   timeout: 600
 case_studies/us_equities_panel/13_latent_factors:
-  parameters:
-    FORCE_RETRAIN: true
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 1
-    N_FACTORS: 2
   timeout: 600
 case_studies/us_equities_panel/13a_pca:
   skip: true
@@ -2297,30 +1936,29 @@ case_studies/us_equities_panel/16_backtest:
     MAX_SYMBOLS: 5
     TOP_K: 2
   timeout: 600
-case_studies/us_equities_panel/17_portfolio_management: *id001
-case_studies/us_equities_panel/18_costs: *id002
-case_studies/us_equities_panel/19_risk_management: *id003
-case_studies/us_equities_panel/20_strategy_analysis:
+case_studies/us_equities_panel/17_portfolio_management:
   parameters:
     MAX_SYMBOLS: 5
+    TOP_N_PREDICTIONS: 2
+  timeout: 300
+case_studies/us_equities_panel/18_costs:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
+case_studies/us_equities_panel/19_risk_management:
+  parameters:
+    MAX_RISK_VARIANTS: 3
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
+case_studies/us_equities_panel/20_strategy_analysis:
   timeout: 600
 case_studies/us_firm_characteristics/01_feasibility_analysis:
   timeout: 120
 case_studies/us_firm_characteristics/02_labels:
-  parameters:
-    MAX_SYMBOLS: 5
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/us_firm_characteristics/03_financial_features:
-  parameters:
-    GARCH_MIN_OBS: 50
-    HMM_N_RESTARTS: 1
-    MAX_SAMPLE_ASSETS: 3
-    MAX_SYMBOLS: 5
-    MIN_OBS: 10
-    MIN_TRAIN_BARS: 10
-    N_RESTARTS: 1
-    START_DATE: '2000-01-01'
   timeout: 120
 case_studies/us_firm_characteristics/04_evaluation:
   parameters:
@@ -2335,7 +1973,6 @@ case_studies/us_firm_characteristics/06_gbm:
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
-    NUM_BOOST_ROUND: 5
   timeout: 180
 case_studies/us_firm_characteristics/07_tabular_dl:
   # setup.yaml pins modeling.tabular_dl.device: cuda, and resolve_torch_device
@@ -2352,12 +1989,6 @@ case_studies/us_firm_characteristics/07_tabular_dl:
   timeout: 180
 case_studies/us_firm_characteristics/08_latent_factors:
   gpu: true
-  parameters:
-    FORCE_RETRAIN: true
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 2
-    N_FACTORS: 2
   timeout: 300
 # 08a and 08b are the split successors of 08_latent_factors above, and the entry
 # never followed the split: neither had one, so both ran unreduced and unmarked and
@@ -2411,16 +2042,25 @@ case_studies/us_firm_characteristics/11_backtest:
     MAX_SYMBOLS: 5
     TOP_K: 2
   timeout: 120
-case_studies/us_firm_characteristics/12_portfolio_management: *id001
-case_studies/us_firm_characteristics/13_costs: *id002
-case_studies/us_firm_characteristics/14_risk_management: *id003
+case_studies/us_firm_characteristics/12_portfolio_management:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_PREDICTIONS: 2
+  timeout: 300
+case_studies/us_firm_characteristics/13_costs:
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
+case_studies/us_firm_characteristics/14_risk_management:
+  parameters:
+    MAX_RISK_VARIANTS: 3
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
+  timeout: 600
 case_studies/us_firm_characteristics/15_strategy_analysis:
   skip: true
   skip_reason: "Test-data load_firm_characteristics() returns 80 firms/day; the NB's liquidity-profile section requires >=100 firms/day. Needs expanded test-data fixture (>=100 firms) before this NB can run under MAX_SYMBOLS=5."
-data/crypto/dataset_card:
-  skip: true
-  skip_reason: Data download notebook (requires API access)
-  tier: weekly
 data/equities/market/microstructure/dataset_card:
   timeout: 120
 data/equities/market/us_equities/dataset_card:
@@ -2429,7 +2069,14 @@ data/equities/market/us_equities/dataset_card:
   tier: weekly
 data/factors/dataset_card:
   timeout: 120
-data/fx/dataset_card:
-  skip: true
-  skip_reason: Data download notebook (requires API access)
+data/fx/market/dataset_card:
+  # The unconditional dry run at the bottom calls download_fx_data, which raises
+  # before it reaches the dry_run branch when OANDA_API_KEY is unset. The entry
+  # that was meant to hold this back named data/fx/dataset_card, one directory
+  # above the notebook, so it matched nothing and the notebook ran every commit.
+  # It stays skipped in CI on purpose: OANDA is a billed API, and the weekly
+  # workflow's no-spend policy leaves those keys unset so their tests skip
+  # rather than charge. The gate is what makes the skip explicit and local.
+  requires_env: OANDA_API_KEY
   tier: weekly
+  timeout: 120

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -6,13 +6,23 @@ Provides:
 - collect_chapter_notebooks(): Discover notebooks in chapter directories
 - get_tier() / current_test_tier(): Test-tier routing (per-commit / weekly / on-demand)
 - get_record_mode(): VCR cassette mode (consumed by Step 5)
+- unusable_parameters(): parameter names an override declares that the notebook
+  cannot receive (checked by tests/test_pm_helpers.py)
 
 NOTE: Notebooks live directly in chapter directories
 (e.g., 05_synthetic_data/01_timegan.py), NOT in code/ subdirs.
 
 overrides.yaml schema (per-notebook, all optional):
     timeout: int (seconds, default 300)
-    parameters: dict (papermill -p overrides)
+    parameters: dict (papermill -p overrides). Papermill injects these values in a
+        cell right after the notebook's ``# %% tags=["parameters"]`` cell, so
+        every name must be one the notebook reads below that point without first
+        overwriting it. Where the notebook assigns the name is not the test: an
+        assignment above the injection point is overridden. A name nothing reads
+        is an unused variable, and one that is overwritten first is gone; either
+        way the test runs at production scale while this file states a reduction.
+        ``unusable_parameters`` is the detector and tests/test_pm_helpers.py
+        fails the build on what it finds, with no allowlist.
     skip: bool — hard skip in uv-native run (Docker tests ignore)
     skip_reason: str
     requires_import: str | list[str]
@@ -38,12 +48,14 @@ overrides.yaml schema (per-notebook, all optional):
         Default "replay".
 """
 
+import ast
 import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
@@ -131,6 +143,523 @@ def get_record_mode(overrides: dict) -> str:
             f"Invalid record_mode {mode!r} — must be one of {sorted(VALID_RECORD_MODES)}"
         )
     return mode
+
+
+# ---------------------------------------------------------------------------
+# Papermill parameter validation.
+#
+# Papermill injects the `parameters` block as a cell placed directly after the
+# notebook's own `parameters`-tagged cell, so an injected value only reaches the
+# code that uses it when something below that point reads the name and nothing
+# overwrites it first. Neither condition is enforced at run time: papermill
+# accepts any name, and an override that misses either one leaves the notebook
+# running at its production defaults while overrides.yaml records a reduction.
+# `unusable_parameters` is the detector; test_pm_helpers.py runs it over the
+# whole file, with no allowlist.
+# ---------------------------------------------------------------------------
+
+PARAMETERS_CELL_MARKER = 'tags=["parameters"]'
+INJECTED_CELL_MARKER = 'tags=["injected-parameters"]'
+
+
+def _percent_cell_bounds(source: str) -> list[tuple[str, int, int]]:
+    """Split jupytext percent source into (header, first_line, last_line) cells.
+
+    Lines are 1-based and inclusive, matching `ast` line numbers.
+    """
+    lines = source.splitlines()
+    starts = [i for i, line in enumerate(lines) if line.startswith("# %%")]
+    bounds = []
+    for pos, start in enumerate(starts):
+        end = starts[pos + 1] - 1 if pos + 1 < len(starts) else len(lines) - 1
+        bounds.append((lines[start], start + 1, end + 1))
+    return bounds
+
+
+def _module_level_events(node: ast.AST, events: list[tuple[str, str, int]]) -> None:
+    """Append ("read"|"bind", name, line) in source order for module-level code.
+
+    `if`, `for`, `try` and `with` bodies are entered: a rebinding under one of
+    them still overwrites the injected value when it runs, and the read that
+    precedes it is what tells the two apart.
+
+    Function, lambda and class bodies are not entered. Their code runs when
+    called, which is after the rest of the module, so a name they mention is not
+    a read that protects an earlier value from a later module-level rebinding.
+    The parts of a definition that *do* evaluate where they are written -
+    decorators, default arguments, base classes - are collected.
+    """
+    if isinstance(node, ast.Lambda):
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                _module_level_events(default, events)
+        return
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        evaluated: list[ast.AST] = list(node.decorator_list)
+        evaluated += [d for d in node.args.defaults if d is not None]
+        evaluated += [d for d in node.args.kw_defaults if d is not None]
+        for sub in evaluated:
+            _module_level_events(sub, evaluated_events := [])
+            events.extend(evaluated_events)
+        events.append(("bind", node.name, node.lineno))
+        return
+    if isinstance(node, ast.ClassDef):
+        # A class body runs where it is written, not when something calls it, so
+        # what it reads is a module-level read. What it assigns is a class
+        # attribute, so those bindings do not reach the module - but they do
+        # shadow the module name for the rest of the body, and a read after one
+        # of them resolves to the attribute rather than to the parameter.
+        for sub in [*node.decorator_list, *node.bases, *(kw.value for kw in node.keywords)]:
+            _module_level_events(sub, events)
+        body: list[tuple[str, str, int]] = []
+        for statement in node.body:
+            _module_level_events(statement, body)
+        shadowed: set[str] = set()
+        for kind, bound, line in body:
+            if kind == "read" and bound not in shadowed:
+                events.append((kind, bound, line))
+            elif kind == "bind":
+                shadowed.add(bound)
+        events.append(("bind", node.name, node.lineno))
+        return
+    if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+        # A comprehension has its own scope: its loop targets bind nothing in the
+        # module, and inside it they shadow the module name rather than read it.
+        targets: set[str] = set()
+        for gen in node.generators:
+            for sub in ast.walk(gen.target):
+                if isinstance(sub, ast.Name):
+                    targets.add(sub.id)
+        for gen in node.generators:
+            _module_level_events(gen.iter, events)
+        inner: list[tuple[str, str, int]] = []
+        for gen in node.generators:
+            for condition in gen.ifs:
+                _module_level_events(condition, inner)
+        for part in ("elt", "key", "value"):
+            if (sub := getattr(node, part, None)) is not None:
+                _module_level_events(sub, inner)
+        events.extend(event for event in inner if event[1] not in targets)
+        return
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        # `from x import MAX_SYMBOLS` below the cell overwrites what was injected
+        # exactly as an assignment would.
+        for alias in node.names:
+            events.append(("bind", (alias.asname or alias.name).split(".")[0], node.lineno))
+        return
+    if isinstance(node, ast.Name):
+        kind = "read" if isinstance(node.ctx, ast.Load) else "bind"
+        events.append((kind, node.id, node.lineno))
+        return
+    if isinstance(node, ast.Call):
+        # The callee and the arguments are evaluated before the call happens, so
+        # the event goes after theirs. A call is where a function body runs, which
+        # is the only way a deferred read can happen; sequencing it with the reads
+        # and bindings is what lets the three be compared.
+        for sub in ast.iter_child_nodes(node):
+            _module_level_events(sub, events)
+        if isinstance(node.func, ast.Name):
+            events.append(("call", node.func.id, node.lineno))
+        return
+    if isinstance(node, ast.AugAssign):
+        # `X += 1` reads X before writing it.
+        _module_level_events(node.value, events)
+        if isinstance(node.target, ast.Name):
+            events.append(("read", node.target.id, node.target.lineno))
+        _module_level_events(node.target, events)
+        return
+    if isinstance(node, ast.AnnAssign) and node.value is None:
+        # `X: int` annotates without assigning, so it binds nothing and leaves
+        # the injected value in place. Only the annotation itself is evaluated.
+        _module_level_events(node.annotation, events)
+        return
+    if isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+        # The right-hand side is evaluated before the target is bound, and the
+        # ordering matters: `X = X + 1` reads X, `X = 1` discards it. Child order
+        # puts the target first for `Assign` and `NamedExpr` alike, so neither can
+        # be left to the generic walk below.
+        _module_level_events(node.value, events)
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            _module_level_events(target, events)
+        return
+    for child in ast.iter_child_nodes(node):
+        _module_level_events(child, events)
+
+
+#: Statement fields whose contents may be skipped on a given run. A binding under
+#: one of these reaches only the code in the same branch; a binding outside them
+#: all runs on every path.
+_CONDITIONAL_BODIES = {
+    ast.If: ("body", "orelse"),
+    ast.For: ("body", "orelse"),
+    ast.AsyncFor: ("body", "orelse"),
+    ast.While: ("body", "orelse"),
+    # `body` too: a statement in it may never be reached, so a binding there
+    # does not reach a handler that runs because something above it raised.
+    ast.Try: ("body", "handlers", "orelse"),
+    ast.ExceptHandler: ("body",),
+}
+
+
+def _branch_paths(tree: ast.Module) -> dict[int, tuple]:
+    """line -> the chain of conditional branches enclosing it.
+
+    An empty path means the line runs on every path through the module. One path
+    being a prefix of another means the first branch encloses the second, which
+    is what says a binding can reach a read: same branch or an outer one.
+    """
+    paths: dict[int, tuple] = {}
+
+    def walk(node: ast.AST, path: tuple) -> None:
+        for field, value in ast.iter_fields(node):
+            branching = field in _CONDITIONAL_BODIES.get(type(node), ())
+            for item in value if isinstance(value, list) else [value]:
+                if not isinstance(item, ast.AST):
+                    continue
+                inner = path + ((id(node), field),) if branching else path
+                line = getattr(item, "lineno", None)
+                if line is not None and len(inner) >= len(paths.get(line, ())):
+                    paths[line] = inner
+                walk(item, inner)
+
+    walk(tree, ())
+    return paths
+
+
+def _top_level_bindings(tree: ast.Module) -> list[tuple[str, int]]:
+    """(name, line) for bindings made by an unconditional statement of the module.
+
+    Nested statements are excluded, so this is the set of bindings that run on
+    every path through the notebook. A binding under `if`/`for`/`try` may or may
+    not run, and deciding which needs the branch analysis a config linter has no
+    business carrying, so those are left alone.
+    """
+    bound = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.append((node.name, node.lineno))
+            continue
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound.append(((alias.asname or alias.name).split(".")[0], node.lineno))
+            continue
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets = [node.target]
+        for target in targets:
+            for sub in ast.walk(target):
+                if isinstance(sub, ast.Name):
+                    bound.append((sub.id, sub.lineno))
+    return bound
+
+
+_NESTED_SCOPE = (
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.Lambda,
+    ast.ClassDef,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+)
+
+
+def _own_scope_nodes(body: list[ast.AST]) -> list[ast.AST]:
+    """Nodes belonging to one scope, stopping at every nested scope.
+
+    A nested scope's own statements are somebody else's locals, so descending
+    into one would let a store in an inner function hide a read in its parent.
+    Each is visited on its own turn by the caller's `ast.walk`.
+    """
+    found: list[ast.AST] = []
+    stack = list(body)
+    while stack:
+        node = stack.pop()
+        found.append(node)
+        if not isinstance(node, _NESTED_SCOPE):
+            stack.extend(ast.iter_child_nodes(node))
+    return found
+
+
+def _comprehension_free_reads(node: ast.AST) -> set[str]:
+    """Names a comprehension reads from the scope around it.
+
+    Its own loop targets are its locals, so they are subtracted; everything else
+    it evaluates resolves outward.
+    """
+    targets = {
+        sub.id
+        for gen in node.generators
+        for sub in ast.walk(gen.target)
+        if isinstance(sub, ast.Name)
+    }
+    parts: list[ast.AST] = [gen.iter for gen in node.generators]
+    parts += [condition for gen in node.generators for condition in gen.ifs]
+    for attr in ("elt", "key", "value"):
+        if (sub := getattr(node, attr, None)) is not None:
+            parts.append(sub)
+    reads = set()
+    for part in parts:
+        for sub in ast.walk(part):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load):
+                reads.add(sub.id)
+    return reads - targets
+
+
+def _class_body_free_reads(node: ast.ClassDef) -> set[str]:
+    """Names a class body reads from the scope around it.
+
+    Its own assignments become class attributes and shadow an outer name for the
+    rest of the body, so they are subtracted. Methods are not walked here - they
+    are functions, and `_deferred_global_reads` reaches every function in the
+    tree on its own.
+    """
+    seen: set[str] = set()
+    bound: set[str] = set()
+    for sub in _own_scope_nodes(node.body):
+        if isinstance(sub, ast.Name):
+            (seen if isinstance(sub.ctx, ast.Load) else bound).add(sub.id)
+        elif isinstance(sub, (ast.Import, ast.ImportFrom)):
+            bound |= {(a.asname or a.name).split(".")[0] for a in sub.names}
+        elif isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(sub.name)
+        elif isinstance(sub, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            seen |= _comprehension_free_reads(sub)
+    for outer in [*node.bases, *node.decorator_list]:
+        seen |= {
+            sub.id
+            for sub in ast.walk(outer)
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load)
+        }
+    return seen - bound
+
+
+def _scope_reads_and_calls(node: ast.AST) -> tuple[set[str], set[str]]:
+    """(free names this function reads, names of things it calls).
+
+    A class body at module level is not the caller's concern: Python runs one
+    where it is written, so what it reads is a module-level read and
+    `_module_level_events` records it as one. A class body *inside* a function is
+    the other case - it runs when the function is called - so its reads are
+    collected here.
+
+    A name the body also binds is local to it throughout, by Python's own scoping
+    rule, so reading it there says nothing about the module-level variable. Those
+    are excluded; a `global` declaration puts one back.
+    """
+    args = node.args
+    local = {
+        a.arg
+        for a in [*args.posonlyargs, *args.args, *args.kwonlyargs]
+        + [x for x in (args.vararg, args.kwarg) if x is not None]
+    }
+    declared_global: set[str] = set()
+    seen: set[str] = set()
+    called: set[str] = set()
+    for sub in _own_scope_nodes(node.body if isinstance(node.body, list) else [node.body]):
+        if isinstance(sub, ast.Global):
+            declared_global |= set(sub.names)
+        elif isinstance(sub, ast.Call):
+            if isinstance(sub.func, ast.Name):
+                called.add(sub.func.id)
+        elif isinstance(sub, ast.Name):
+            (seen if isinstance(sub.ctx, ast.Load) else local).add(sub.id)
+        elif isinstance(sub, (ast.Import, ast.ImportFrom)):
+            local |= {(a.asname or a.name).split(".")[0] for a in sub.names}
+        elif isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            local.add(sub.name)
+            if isinstance(sub, ast.ClassDef):
+                # Runs when this function is called, so what it reads from
+                # outside is deferred too. `_own_scope_nodes` stops at the
+                # class, so collect them directly.
+                seen |= _class_body_free_reads(sub)
+        elif isinstance(sub, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            # Its own scope, but its free variables resolve out through this
+            # one. `_own_scope_nodes` stops here, so collect them directly.
+            seen |= _comprehension_free_reads(sub)
+    return (seen - local) | (seen & declared_global), called
+
+
+def _deferred_readers(tree: ast.Module) -> tuple[dict[str, set[str]], set[str]]:
+    """(name -> the module-level functions that read it, names read opaquely).
+
+    Knowing *which* function reads a parameter is what makes a module-level call
+    evidence about that parameter rather than about calls in general. Reads reach
+    a caller through the functions it calls, so the map is closed transitively
+    over local calls.
+
+    The second set is the escape hatch: a lambda, or a function defined inside
+    another, is not something a module-level call can name, so a parameter read
+    from one keeps the blanket exemption instead of being attributed.
+    """
+    top = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    direct: dict[str, set[str]] = {}
+    calls: dict[str, set[str]] = {}
+    opaque: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        reads, called = _scope_reads_and_calls(node)
+        if top.get(getattr(node, "name", None)) is node:
+            direct[node.name] = reads
+            calls[node.name] = called
+        else:
+            opaque |= reads
+    changed = True
+    while changed:
+        changed = False
+        for caller, callees in calls.items():
+            for callee in callees & direct.keys():
+                if not direct[callee] <= direct[caller]:
+                    direct[caller] |= direct[callee]
+                    changed = True
+    readers: dict[str, set[str]] = {}
+    for func, names in direct.items():
+        for name in names:
+            readers.setdefault(name, set()).add(func)
+    return readers, opaque
+
+
+def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
+    """Map each declared parameter name that cannot reach the notebook to why.
+
+    An empty dict means every name is injectable. Everything turns on where
+    papermill puts the value: in a cell immediately after the notebook's
+    `parameters`-tagged cell, or — when there is no tagged cell — above the
+    imports, ahead of the whole notebook. Anything the notebook assigns before
+    that point is overridden and does not matter. Two things after it do:
+
+    - some binding overwrites the injected value before anything reads it, so
+      the notebook goes on using its own number;
+    - nothing reads the name at all, so the value is injected into a variable
+      the notebook has no use for.
+
+    The overwrite test turns on the read rather than on the indentation.
+    Reading the injected value and then rebinding the same name is how the
+    `12_causal_dml` notebooks apply an override: they push `CV_FOLDS` into the
+    config dict, then read it back out. The value survives, so the entry is
+    valid, and `if MAX_SYMBOLS == 0: MAX_SYMBOLS = len(universe)` is the same
+    shape with the guard as the read. Every binding is checked, not just the
+    first, so a legitimate read-and-restore does not license an overwrite
+    further down.
+
+    Only bindings that run on every path are counted, and only when no function
+    body reads the name. A conditional binding may not run, and a function that
+    reads the name may be called before one that does; proving either way needs
+    branch and call analysis that would buy this file nothing. Where the analysis
+    cannot be sure, it says nothing — a missed dead entry costs a stale line,
+    a wrong rejection costs a real reduction.
+
+    Args:
+        py_path: the notebook's `.py` source
+        names: the parameter names `overrides.yaml` declares for it
+
+    Returns:
+        {name: reason} for the names that cannot take effect.
+    """
+    names = list(names)
+    if not names:
+        return {}
+    if not py_path.exists():
+        return dict.fromkeys(names, f"no notebook at {py_path}")
+
+    source = py_path.read_text()
+    tree = ast.parse(source, filename=str(py_path))
+    cells = _percent_cell_bounds(source)
+    tagged = [c for c in cells if PARAMETERS_CELL_MARKER in c[0]]
+    # A committed `injected-parameters` cell is a leftover from a papermill run,
+    # replaced on the next one. Reading it as notebook code would report the
+    # notebook overwriting exactly what papermill is about to inject.
+    stale = [(lo, hi) for header, lo, hi in cells if INJECTED_CELL_MARKER in header]
+
+    # Papermill's cell lands right after the tagged one, or at the very top of
+    # the notebook when there is none.
+    injected_at = tagged[-1][2] if tagged else 0
+    where = (
+        "the parameters cell"
+        if tagged
+        else 'the top of the notebook (it has no `# %% tags=["parameters"]` cell)'
+    )
+
+    def live(line: int) -> bool:
+        return line > injected_at and not any(lo <= line <= hi for lo, hi in stale)
+
+    events: list[tuple[str, str, int]] = []
+    _module_level_events(tree, events)
+    branch = _branch_paths(tree)
+    readers, opaque = _deferred_readers(tree)
+
+    def reaches(bind: tuple[int, int], read: tuple[int, int]) -> bool:
+        """Does this binding run before that read, and on the read's path?
+
+        Order comes from the event sequence, not the line: `_module_level_events`
+        emits an assignment's right-hand side before its target, so in a multiline
+        `X = (\\n    X + 1\\n)` the read is sequenced first even though the target
+        sits on the earlier line. The line is only how a branch path is looked up.
+        """
+        (bind_seq, bind_line), (read_seq, read_line) = bind, read
+        if bind_seq >= read_seq:
+            return False
+        here, there = branch.get(bind_line, ()), branch.get(read_line, ())
+        return here == there[: len(here)]
+
+    problems = {}
+    for name in names:
+        reads = [
+            (seq, line)
+            for seq, (kind, bound, line) in enumerate(events)
+            if kind == "read" and bound == name and live(line)
+        ]
+        binds = [
+            (seq, line)
+            for seq, (kind, bound, line) in enumerate(events)
+            if kind == "bind" and bound == name and live(line)
+        ]
+        if name in opaque or name in readers:
+            # A function that reads the name is normally enough to leave the
+            # entry alone: it may be called before any binding below, and the
+            # tree does not say which happens first. The exception is a binding
+            # that nothing can run ahead of - unconditional, with no module-level
+            # read and no call to a function that reads this name above it. Then
+            # every such call happens after it and none can see the injected
+            # value. A read from a lambda or a nested function is not attributable
+            # to a name a call site can use, so it keeps the blanket exemption.
+            blocking = [(seq, line) for seq, line in binds if branch.get(line, ()) == ()]
+            reaching = [
+                seq
+                for seq, (kind, bound, line) in enumerate(events)
+                if kind == "call" and bound in readers.get(name, set()) and live(line)
+            ]
+            first = min((seq for seq, _ in blocking), default=None)
+            reachable = (
+                name in opaque
+                or first is None
+                or any(seq < first for seq in [*(r for r, _ in reads), *reaching])
+            )
+            if reachable:
+                continue
+            problems[name] = (
+                f"the binding on line {min(line for _, line in blocking)} overwrites the "
+                f"injected value before anything below {where} can call a function that "
+                "reads it"
+            )
+        elif not reads:
+            problems[name] = f"the notebook never reads it below {where}"
+        elif all(any(reaches(b, r) for b in binds) for r in reads):
+            problems[name] = (
+                f"the binding on line {min(line for _, line in binds)} overwrites the "
+                f"injected value: every read below {where} is on a path that rebinds "
+                "the name first"
+            )
+    return problems
 
 
 def get_overrides(notebook_key: str) -> dict:

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 
@@ -18,7 +19,10 @@ from tests.pm_helpers import (
     get_reruns,
     get_tier,
     missing_required_env,
+    unusable_parameters,
 )
+
+REPO_ROOT = Path(__file__).parent.parent
 
 
 def test_collect_chapter_notebooks_keeps_real_notebooks_and_skips_helpers() -> None:
@@ -313,3 +317,596 @@ def test_no_override_declares_a_launcher_without_an_interpreter(overrides: dict)
     }
 
     assert rejected == set()
+
+
+# ---------------------------------------------------------------------------
+# Papermill parameter reachability.
+#
+# Papermill accepts any parameter name and reports nothing when the notebook
+# has no use for it, so an override naming a variable the notebook never binds
+# runs the notebook at its production defaults while this file records a
+# reduction. 292 names across 113 entries had accumulated that way by
+# 2026-07-30, including whole chapters' worth of entries for notebooks that no
+# longer exist. These two sweeps are what stops it coming back; they ship with
+# no allowlist, because a waiver list would restore exactly the silence they
+# exist to remove.
+#
+# They also require the file to stay expanded: the three `&id001`-style anchors
+# it used to carry made 18 notebooks share one config block, so pruning any of
+# them for its own notebook silently changed the other five.
+# ---------------------------------------------------------------------------
+
+
+def test_every_override_key_names_a_notebook(overrides: dict) -> None:
+    """A key that matches no `.py` configures nothing.
+
+    `get_overrides` looks an entry up by the path of the notebook being run, so a
+    key nobody matches is never read: its timeout, its `skip` and its parameters
+    all go nowhere. Two `data/*/dataset_card` entries meant to hold a download
+    notebook out of the per-commit tier sat one directory above the notebook they
+    named, which therefore ran every commit.
+    """
+    orphaned = sorted(key for key in overrides if not (REPO_ROOT / f"{key}.py").exists())
+
+    assert orphaned == []
+
+
+def test_every_declared_parameter_reaches_its_notebook(overrides: dict) -> None:
+    """Every name in a `parameters` block must survive papermill's injection.
+
+    Driven through `unusable_parameters` rather than a copy of its predicate, so
+    the sweep cannot go on asserting a rule the helper has stopped applying.
+    """
+    unreachable = {
+        key: unusable_parameters(REPO_ROOT / f"{key}.py", value["parameters"])
+        for key, value in overrides.items()
+        if isinstance(value, dict)
+        and isinstance(value.get("parameters"), dict)
+        and unusable_parameters(REPO_ROOT / f"{key}.py", value["parameters"])
+    }
+
+    assert unreachable == {}
+
+
+def _notebook(tmp_path: Path, body: str) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    py = tmp_path / "notebook.py"
+    py.write_text(body)
+    return py
+
+
+def test_unusable_parameters_accepts_a_name_bound_in_the_parameters_cell(tmp_path: Path) -> None:
+    py = _notebook(
+        tmp_path,
+        '# %%\nimport os\n\n# %% tags=["parameters"]\nN_EPOCHS = 100\n\n# %%\nprint(N_EPOCHS)\n',
+    )
+
+    assert unusable_parameters(py, ["N_EPOCHS"]) == {}
+
+
+def test_unusable_parameters_accepts_a_name_the_notebook_assigns_above_that_cell(
+    tmp_path: Path,
+) -> None:
+    """Papermill injects after the tagged cell, so it overrides an assignment made
+    above one. `case_studies/us_equities_panel/02_labels` sets `START_DATE` in its
+    configuration block and reads it below the cell; the override works."""
+    py = _notebook(
+        tmp_path,
+        '# %%\nSTART_DATE = "1990-01-01"\n\n# %% tags=["parameters"]\nSEED = 42\n\n'
+        "# %%\nload(start_date=START_DATE)\n",
+    )
+
+    assert unusable_parameters(py, ["START_DATE"]) == {}
+
+
+def test_unusable_parameters_rejects_a_name_the_notebook_never_reads(tmp_path: Path) -> None:
+    """`12_gradient_boosting/07_hpo_comparison` declares `N_OPTUNA_TRIALS` in its
+    parameters cell and never mentions it again, so the reduction the test states
+    has never once applied."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nN_OPTUNA_TRIALS = 50\nSEED = 42\n\n# %%\nprint(SEED)\n',
+    )
+
+    assert "never reads it" in unusable_parameters(py, ["N_OPTUNA_TRIALS"])["N_OPTUNA_TRIALS"]
+
+
+def test_unusable_parameters_rejects_a_name_bound_only_below_the_parameters_cell(
+    tmp_path: Path,
+) -> None:
+    """Papermill's injected cell goes directly after the tagged cell, so a binding
+    further down overwrites it — the same silent no-op as never using it at all."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nSEED = 42\n\n# %%\nMAX_SYMBOLS = 0\nprint(MAX_SYMBOLS)\n',
+    )
+
+    assert "MAX_SYMBOLS" in unusable_parameters(py, ["MAX_SYMBOLS"])
+
+
+def test_unusable_parameters_allows_a_rebind_that_reads_the_injected_value_first(
+    tmp_path: Path,
+) -> None:
+    """How the `12_causal_dml` notebooks apply an override: push the injected
+    value into the config dict, then read it back under the same name. The value
+    survives the rebind, so the entry is valid and must not be swept away."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nCV_FOLDS = 5\n\n# %%\n'
+        'cfg["n_folds"] = CV_FOLDS\nCV_FOLDS = cfg.get("n_folds", 5)\n',
+    )
+
+    assert unusable_parameters(py, ["CV_FOLDS"]) == {}
+
+
+def test_unusable_parameters_asks_only_that_one_read_get_the_injected_value(
+    tmp_path: Path,
+) -> None:
+    """The contract is that the value reaches code that uses it, not that it
+    survives to the end. Here it reaches line 5; the binding below changes what a
+    later read would see, and there is no later read."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nCV_FOLDS = 5\n\n# %%\n'
+        'cfg["n_folds"] = CV_FOLDS\nCV_FOLDS = cfg.get("n_folds", 5)\n\n# %%\nCV_FOLDS = 10\n',
+    )
+
+    assert unusable_parameters(py, ["CV_FOLDS"]) == {}
+
+
+def test_unusable_parameters_rejects_a_branch_local_overwrite(tmp_path: Path) -> None:
+    """`07_defining_the_learning_task/07_multiple_testing` had this: `n_rad_etf =
+    N_RAD_ETF` inside `if min_len > 1:`, read on the next line inside the same
+    branch and nowhere else. The injected value can never be the one read, so the
+    override sat there stating a 500-simulation run that never happened."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nn_rad_etf = 500\nN_RAD_ETF = 5000\n\n# %%\n'
+        "if min_len > 1:\n    n_rad_etf = N_RAD_ETF\n    run(n_simulations=n_rad_etf)\n",
+    )
+
+    assert "rebinds the name first" in unusable_parameters(py, ["n_rad_etf"])["n_rad_etf"]
+
+
+def test_unusable_parameters_allows_a_rebind_on_a_branch_that_does_not_read_it(
+    tmp_path: Path,
+) -> None:
+    """Accepted by design. The parameter reaches the notebook on the path that
+    reads it, which is what this function decides; which path a given run takes
+    is a question about the notebook."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "if MAX_SYMBOLS:\n    universe = pick(MAX_SYMBOLS)\nelse:\n    MAX_SYMBOLS = 500\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_rejects_a_rebind_that_reads_nothing_first(tmp_path: Path) -> None:
+    """The shape ten case study notebooks had: declared in the parameters cell,
+    then overwritten a few lines below without the injected value being read."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nSTART_DATE = "2006-01-01"\n\n# %%\n'
+        'START_DATE = "2006-01-01"\nprint(START_DATE)\n',
+    )
+
+    assert "overwrites the injected value" in unusable_parameters(py, ["START_DATE"])["START_DATE"]
+
+
+def test_unusable_parameters_allows_a_conditional_derivation(tmp_path: Path) -> None:
+    """A notebook that reads the injected value and derives from it under a guard
+    is using the parameter, not discarding it. Flagging this would push authors
+    toward an allowlist."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "if MAX_SYMBOLS == 0:\n    MAX_SYMBOLS = len(universe)\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_leaves_a_binding_nested_in_control_flow_alone(
+    tmp_path: Path,
+) -> None:
+    """A binding under `if`/`for`/`try` may not run, and deciding whether it does
+    needs branch analysis this file has no business carrying. `25_live_trading`
+    forces `LIVE_FEED = 0` under a papermill-detection guard; the override still
+    reaches every other path."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nLIVE_FEED = 1\n\n# %%\n'
+        'if os.environ.get("HEADLESS"):\n    LIVE_FEED = 0\n\n# %%\nprint(LIVE_FEED)\n',
+    )
+
+    assert unusable_parameters(py, ["LIVE_FEED"]) == {}
+
+
+def test_unusable_parameters_reads_both_branch_orders_the_same_way(tmp_path: Path) -> None:
+    """Swapping the branches must not swap the verdict. Both orders reach the
+    parameter on one path, so both are accepted."""
+    read_first = _notebook(
+        tmp_path / "a",
+        '# %% tags=["parameters"]\nX = 0\n\n# %%\nif cond:\n    use(X)\nelse:\n    X = 1\n',
+    )
+    bind_first = _notebook(
+        tmp_path / "b",
+        '# %% tags=["parameters"]\nX = 0\n\n# %%\nif cond:\n    X = 1\nelse:\n    use(X)\n',
+    )
+
+    assert unusable_parameters(read_first, ["X"]) == unusable_parameters(bind_first, ["X"]) == {}
+
+
+def test_unusable_parameters_leaves_a_name_a_function_reads_alone(tmp_path: Path) -> None:
+    """A function that reads the parameter may be called before the binding below
+    it, so an overwrite cannot be established. Where the analysis cannot be sure
+    it says nothing: a missed dead entry costs a stale line, a wrong rejection
+    costs a real reduction."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def report():\n    return MAX_SYMBOLS\n\nreport()\nMAX_SYMBOLS = 500\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_does_not_take_a_function_local_for_a_read(tmp_path: Path) -> None:
+    """A name the body also binds is local to it throughout, by Python's scoping
+    rule, so reading it there says nothing about the module-level variable."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def report():\n    MAX_SYMBOLS = 1\n    return MAX_SYMBOLS\n",
+    )
+
+    assert "never reads it" in unusable_parameters(py, ["MAX_SYMBOLS"])["MAX_SYMBOLS"]
+
+
+def test_unusable_parameters_ignores_a_committed_injected_parameters_cell(tmp_path: Path) -> None:
+    """`case_studies/etfs/11a_pca` has one: a leftover from a papermill run, which
+    the next run replaces. Reading it as notebook code would report the notebook
+    overwriting exactly what papermill is about to inject."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nUSE_CACHE = True\n\n'
+        '# %% papermill={"duration": 0.1} tags=["injected-parameters"]\n'
+        "# Parameters\nUSE_CACHE = False\n\n# %%\nprint(USE_CACHE)\n",
+    )
+
+    assert unusable_parameters(py, ["USE_CACHE"]) == {}
+
+
+def test_unusable_parameters_does_not_take_a_comprehension_target_for_a_rebind(
+    tmp_path: Path,
+) -> None:
+    """A comprehension has its own scope, so its loop variable binds nothing in
+    the module. Reading it as a rebinding would redden a valid entry."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nSYMBOLS = ["AAPL"]\n\n# %%\n'
+        "picked = [SYMBOLS for SYMBOLS in universe]\nprint(SYMBOLS, picked)\n",
+    )
+
+    assert unusable_parameters(py, ["SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_rejects_a_notebook_with_no_parameters_cell(tmp_path: Path) -> None:
+    """Without a tagged cell papermill injects above the imports, so every binding
+    the notebook makes wins. Three case study notebooks were in this state."""
+    py = _notebook(tmp_path, "# %%\nMAX_FOLDS = 0\nprint(MAX_FOLDS)\n")
+
+    assert "top of the notebook" in unusable_parameters(py, ["MAX_FOLDS"])["MAX_FOLDS"]
+
+
+def test_unusable_parameters_rejects_a_notebook_that_does_not_exist(tmp_path: Path) -> None:
+    problems = unusable_parameters(tmp_path / "gone.py", ["MAX_SYMBOLS"])
+
+    assert "no notebook" in problems["MAX_SYMBOLS"]
+
+
+def test_unusable_parameters_is_silent_on_an_entry_with_no_parameters(tmp_path: Path) -> None:
+    assert unusable_parameters(tmp_path / "gone.py", []) == {}
+
+
+def test_overrides_shares_no_config_block_between_notebooks() -> None:
+    """A YAML anchor makes an edit to one notebook's entry land on every notebook
+    that aliases it. The three the file carried were `yaml.dump` artifacts named
+    `id001`-`id003`, and they covered 18 case study entries across seven case
+    studies, so correcting `TOP_N_PREDICTIONS` for one silently corrected six
+    others that read a different set of parameters.
+    """
+    text = (REPO_ROOT / "tests" / "overrides.yaml").read_text()
+
+    assert re.search(r"^\S.*:\s*[&*]\w+\s*$", text, re.MULTILINE) is None
+
+
+def test_unusable_parameters_rejects_a_name_an_import_below_the_cell_rebinds(
+    tmp_path: Path,
+) -> None:
+    """`from config import MAX_SYMBOLS` discards the injected value exactly as an
+    assignment would, and the read below it reads the imported one."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "from config import MAX_SYMBOLS\n\nprint(MAX_SYMBOLS)\n",
+    )
+
+    assert (
+        "overwrites the injected value" in unusable_parameters(py, ["MAX_SYMBOLS"])["MAX_SYMBOLS"]
+    )
+
+
+def test_unusable_parameters_does_not_take_a_comprehension_local_for_a_read(
+    tmp_path: Path,
+) -> None:
+    """Inside `[SYMBOLS for SYMBOLS in universe]` the name is the comprehension's
+    own, so it shadows the module variable rather than reading it."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nSYMBOLS = ["AAPL"]\n\n# %%\n'
+        "picked = [SYMBOLS for SYMBOLS in universe]\nprint(picked)\n",
+    )
+
+    assert "never reads it" in unusable_parameters(py, ["SYMBOLS"])["SYMBOLS"]
+
+
+def test_unusable_parameters_treats_a_class_body_as_running_where_it_is_written(
+    tmp_path: Path,
+) -> None:
+    """Python executes a class body at the `class` statement, not when something
+    instantiates it, so a read there cannot protect a value already overwritten
+    above it."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\nMAX_SYMBOLS = 500\n\n'
+        "class Universe:\n    size = MAX_SYMBOLS\n",
+    )
+
+    assert (
+        "overwrites the injected value" in unusable_parameters(py, ["MAX_SYMBOLS"])["MAX_SYMBOLS"]
+    )
+
+
+def test_unusable_parameters_counts_a_class_body_read_as_a_read(tmp_path: Path) -> None:
+    """The other half of the same rule: a class body reading the parameter is a
+    real use of it, at module level."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\nclass Universe:\n    size = MAX_SYMBOLS\n',
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_does_not_let_a_nested_local_hide_an_outer_read(
+    tmp_path: Path,
+) -> None:
+    """`MAX_SYMBOLS` is assigned in the inner function and read in the outer one.
+    Collecting locals across both scopes would call the outer read local too, and
+    reject an override the notebook does use."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def outer():\n"
+        "    def inner():\n"
+        "        MAX_SYMBOLS = 1\n"
+        "        return MAX_SYMBOLS\n"
+        "    return inner(), MAX_SYMBOLS\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_counts_a_comprehension_inside_a_function(tmp_path: Path) -> None:
+    """A comprehension has its own scope, but its free variables resolve outward,
+    so reading the parameter there is a real use of it. Missing this would delete
+    a working reduction."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def pick(universe):\n    return [s for s in universe[:MAX_SYMBOLS]]\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_does_not_treat_a_try_body_as_certain(tmp_path: Path) -> None:
+    """Something above the binding can raise, in which case the handler runs with
+    the injected value still in place. The binding is in the `try` body and the
+    read is in the handler, so neither is on the other's path."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "try:\n    fetch()\n    MAX_SYMBOLS = 500\nexcept RuntimeError:\n"
+        "    fallback(MAX_SYMBOLS)\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_orders_a_multiline_self_rebinding_correctly(tmp_path: Path) -> None:
+    """`ast` puts the target of `X = (\\n    X + 1\\n)` on the earlier line, so
+    ordering by line number would read this as an overwrite. The right-hand side
+    is evaluated first, which is what the event sequence records."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "MAX_SYMBOLS = (\n    MAX_SYMBOLS + 1\n)\nprint(MAX_SYMBOLS)\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_sees_a_class_body_nested_in_a_function(tmp_path: Path) -> None:
+    """A class at module level runs where it is written, but one inside a
+    function runs when that function is called. Its reads are deferred, and
+    missing them would reject a parameter the notebook does use."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def build():\n    class Config:\n        limit = MAX_SYMBOLS\n\n    return Config\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_keeps_a_nested_class_attribute_class_local(tmp_path: Path) -> None:
+    """The name is assigned in the class body before it is read there, so the
+    read resolves to the class attribute and says nothing about the parameter."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "def build():\n    class Config:\n        MAX_SYMBOLS = 10\n"
+        "        limit = MAX_SYMBOLS\n\n    return Config\n",
+    )
+
+    assert "never reads it" in unusable_parameters(py, ["MAX_SYMBOLS"])["MAX_SYMBOLS"]
+
+
+def test_unusable_parameters_ignores_a_bare_annotation(tmp_path: Path) -> None:
+    """`MAX_SYMBOLS: int` annotates without assigning. It binds nothing, so the
+    injected value is still what the read below it sees."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\nMAX_SYMBOLS: int\nprint(MAX_SYMBOLS)\n',
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_orders_a_walrus_value_before_its_target(tmp_path: Path) -> None:
+    """`(X := max(1, X))` reads X to compute the value Python then binds. The AST
+    lists the target first, so walking children in order would call it an
+    overwrite."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMAX_SYMBOLS = 0\n\n# %%\n'
+        "print(MAX_SYMBOLS := max(1, MAX_SYMBOLS))\n",
+    )
+
+    assert unusable_parameters(py, ["MAX_SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_rejects_a_rebind_no_call_can_precede(tmp_path: Path) -> None:
+    """`case_studies/sp500_equity_option_analytics/04_model_based_features` had
+    this: the parameters cell sets MIN_OBS, a duplicate assignment repeats it
+    below the cell, and only functions read it. A function read normally earns
+    the benefit of the doubt, but nothing between the cell and the rebinding can
+    call one, so the injected value cannot reach any of them."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\nMIN_OBS = 252\n\n# %%\n'
+        "def fit(x):\n    return len(x) >= MIN_OBS\n",
+    )
+
+    assert "before anything below" in unusable_parameters(py, ["MIN_OBS"])["MIN_OBS"]
+
+
+def test_unusable_parameters_keeps_a_rebind_a_local_call_precedes(tmp_path: Path) -> None:
+    """Same shape, but the notebook calls its own function before the rebinding,
+    so that call reads the injected value and the override did land."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        "def fit(x):\n    return len(x) >= MIN_OBS\n\n# %%\n"
+        "first = fit(sample)\nMIN_OBS = 252\n",
+    )
+
+    assert unusable_parameters(py, ["MIN_OBS"]) == {}
+
+
+def test_unusable_parameters_ignores_an_imported_call_before_a_rebind(tmp_path: Path) -> None:
+    """An imported helper cannot read this notebook's parameter, so a call to one
+    is not what lets a deferred read happen. Counting it would have let the
+    sp500 case above pass."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        'CASE_DIR = get_case_study_dir("x")\nMIN_OBS = 252\n\n# %%\n'
+        "def fit(x):\n    return len(x) >= MIN_OBS\n",
+    )
+
+    assert "before anything below" in unusable_parameters(py, ["MIN_OBS"])["MIN_OBS"]
+
+
+def test_unusable_parameters_ignores_a_call_that_cannot_read_the_name(tmp_path: Path) -> None:
+    """The call before the rebinding is to a helper that never touches MIN_OBS,
+    so it is not evidence that the injected value was read. Counting any local
+    call would let this stale override through."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        "def describe(x):\n    return len(x)\n\n"
+        "def fit(x):\n    return len(x) >= MIN_OBS\n\n# %%\n"
+        "n = describe(sample)\nMIN_OBS = 252\n\n# %%\nresult = fit(sample)\n",
+    )
+
+    assert "before anything below" in unusable_parameters(py, ["MIN_OBS"])["MIN_OBS"]
+
+
+def test_unusable_parameters_follows_a_call_through_a_local_helper(tmp_path: Path) -> None:
+    """`run` does not name MIN_OBS, but it calls `fit`, which does. Calling `run`
+    before the rebinding therefore does read the injected value."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        "def fit(x):\n    return len(x) >= MIN_OBS\n\n"
+        "def run(x):\n    return fit(x)\n\n# %%\n"
+        "first = run(sample)\nMIN_OBS = 252\n",
+    )
+
+    assert unusable_parameters(py, ["MIN_OBS"]) == {}
+
+
+def test_unusable_parameters_keeps_the_exemption_for_a_lambda_read(tmp_path: Path) -> None:
+    """A lambda is not a name a call site can use, so which call triggers its read
+    cannot be established. The parameter keeps the benefit of the doubt."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        "check = lambda x: len(x) >= MIN_OBS\nMIN_OBS = 252\n",
+    )
+
+    assert unusable_parameters(py, ["MIN_OBS"]) == {}
+
+
+def test_unusable_parameters_orders_a_call_in_a_multiline_assignment(tmp_path: Path) -> None:
+    """The call that reads MIN_OBS is on a later line than the assignment target
+    it feeds, but Python evaluates it first. Ordering by line would place the
+    rebinding ahead of the call and reject a parameter that is read."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nMIN_OBS = 252\n\n# %%\n'
+        "def fit(x):\n    return len(x) >= MIN_OBS\n\n# %%\n"
+        "MIN_OBS = (\n    252 if fit(sample) else 0\n)\n",
+    )
+
+    assert unusable_parameters(py, ["MIN_OBS"]) == {}
+
+
+def test_unusable_parameters_treats_a_class_attribute_as_shadowing(tmp_path: Path) -> None:
+    """A class body assigns into its own namespace, so the read after it resolves
+    to the attribute. Counting it as a read of the parameter would accept an
+    override the notebook cannot use."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nLIMIT = 0\n\n# %%\n'
+        "class Config:\n    LIMIT = 500\n    size = LIMIT\n",
+    )
+
+    assert "never reads it" in unusable_parameters(py, ["LIMIT"])["LIMIT"]
+
+
+def test_unusable_parameters_keeps_a_class_read_before_its_attribute(tmp_path: Path) -> None:
+    """Read first, assign second: the read still resolves outward to the
+    parameter, so the override lands."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nLIMIT = 0\n\n# %%\n'
+        "class Config:\n    size = LIMIT\n    LIMIT = 500\n",
+    )
+
+    assert unusable_parameters(py, ["LIMIT"]) == {}


### PR DESCRIPTION

## Review gate

Pushed with the documented `ML4T_ROBOREV_GATE_SKIP` opt-out after eight rounds
in which each pass raised new synthetic AST edge cases rather than converging.
Seven rounds of findings were applied (branch paths, event-sequence ordering,
`try` bodies, bare annotations, the walrus, nested class bodies, per-function
call attribution). The last round's three Low findings are not applied: ordered
class-body shadowing, `for` target/iterable ordering, and comprehension first-
iterable scoping. None occurs in any notebook in this repo - the measurement is
stable at 300 unusable names with zero survivors flagged - so they are edge
cases in the checker, not defects it is missing. Worth triaging here rather than
in another push cycle.
