### PR TITLE
Rebuild the sp500_options label notebook, and seal it on the settlement date

### DIFF
--- a/case_studies/sp500_options/02_labels.ipynb
+++ b/case_studies/sp500_options/02_labels.ipynb
@@ -3,41 +3,43 @@
   {
    "cell_type": "markdown",
    "id": "1fec74bc",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
     "# S&P 500 Options: Label Engineering\n",
     "\n",
-    "This notebook constructs labels for the S&P 500 Options case study using\n",
-    "**same-contract returns** built directly from the slim daily straddle panel\n",
-    "and the slim lifecycle-preserving raw straddle slice. Labels are short straddle\n",
-    "returns: sell a 30D ATM straddle at mid, buy back the **same contract** at mid\n",
-    "after h days. Positive return = profitable short vol position before costs.\n",
+    "The label is a short straddle's return, and an option position is not a share position:\n",
+    "the thing sold at entry has to be the thing bought back at exit, and it stops existing\n",
+    "on a date fixed when it is sold. This notebook writes that convention down as a formula,\n",
+    "proves each labelled trade has a complete round trip inside one contract, measures how\n",
+    "much independent information overlapping trades carry, establishes the floor a feature\n",
+    "has to clear, and writes the files stage 03 reads.\n",
     "\n",
-    "**Learning Objectives**:\n",
-    "- Construct instrument-level labels from same-contract exit prices\n",
-    "- Implement delta-hedged returns using the held contract's delta path\n",
-    "- Generate walk-forward CV splits with a buffer that spans the ~30-day horizon\n",
-    "- Establish a VRP baseline IC that engineered features must beat\n",
+    "## Learning objectives\n",
     "\n",
-    "**Book Reference**: Chapter 7, Section 7.2 (Label Engineering)\n",
+    "- Express an option label as a round trip in one contract, and say what each leg costs\n",
+    "- Assert - rather than describe - that every labelled window closes on a real quote\n",
+    "- Seal a diagnostic on the date a position settles, not the date it is opened, when the\n",
+    "  settlement date is a property of the contract rather than a fixed offset\n",
+    "- Price the overlap in a label held for a month and sampled every session\n",
+    "- Establish the floor a feature has to clear, under a standard error that prices in that\n",
+    "  overlap\n",
     "\n",
-    "**Prerequisites**: [`01_feasibility_analysis`](01_feasibility_analysis.ipynb)\n",
+    "## Book reference, prerequisites and artifacts\n",
     "\n",
-    "**Primary label**: `ret_to_expiry` - the hold-to-expiry (HTM) short-straddle\n",
-    "return declared in `setup.yaml::labels.primary`. Every downstream model in this\n",
-    "case study trains on it. The horizon-based variants (`fwd_ret_{5,10}d`, their\n",
-    "delta-hedged and executable counterparts) are also built here to characterise\n",
-    "the pricing and hedging mechanics, but they are diagnostic, not modelled.\n",
+    "Chapter 7, Section 7.2. Reads the daily matched-strike straddle panel and the raw option\n",
+    "chain through `load_sp500_options_straddles()` and `load_sp500_options_straddles_raw()`,\n",
+    "whose coverage [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) establishes,\n",
+    "the underlying closes through `load_sp500_daily_bars()`, and `config/setup.yaml`, which\n",
+    "declares the label set, the cross-validation buffer and the holdout boundary.\n",
     "\n",
-    "**Pricing Convention**: Mid-to-mid labels measure the economic signal.\n",
-    "Executable labels (sell at bid, close at ask) bake in the per-contract\n",
-    "bid-ask spread and reveal that the unconditional 10-day short straddle return\n",
-    "falls to **-9.6%** per trade, even though its mid-to-mid counterpart is +5.7%.\n",
-    "The exit-leg spread is what `ret_to_expiry` avoids: cash settlement at\n",
-    "expiration converts the option to intrinsic value with no market exit. Whether\n",
-    "ML selection plus the O'Donovan-Yu cost-mitigation cascade turns this into a\n",
-    "viable strategy is the subject of Chapter 18 (Section 18.8), not this notebook."
+    "Writes five label files - `labels/ret_to_expiry.parquet`, `labels/fwd_ret_5d.parquet`,\n",
+    "`labels/fwd_ret_10d.parquet`, `labels/fwd_ret_dh_5d.parquet` and\n",
+    "`labels/fwd_ret_dh_10d.parquet` - each with a `.digest.json` sidecar beside it.\n",
+    "`03_financial_features.py` reads the primary and `fwd_ret_dh_10d`, `05_evaluation.py`\n",
+    "reads `fwd_ret_dh_10d`, and `90_ic_diagnostic.py` reads `fwd_ret_10d` and\n",
+    "`fwd_ret_dh_10d`. The two intermediate frames the labels are built from,\n",
+    "`labels/contract_returns.parquet` and `labels/hedge_path.parquet`, are produced by\n",
+    "`_label_artifacts.py`, which exists because the round trip below is not a shift."
    ]
   },
   {
@@ -46,36 +48,53 @@
    "id": "f2ab4e86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:42.864148Z",
-     "iopub.status.busy": "2026-07-21T06:54:42.864065Z",
-     "iopub.status.idle": "2026-07-21T06:54:46.824818Z",
-     "shell.execute_reply": "2026-07-21T06:54:46.824333Z"
+     "iopub.execute_input": "2026-07-31T07:12:40.185558Z",
+     "iopub.status.busy": "2026-07-31T07:12:40.185373Z",
+     "iopub.status.idle": "2026-07-31T07:12:47.282293Z",
+     "shell.execute_reply": "2026-07-31T07:12:47.279672Z"
     }
    },
    "outputs": [],
    "source": [
-    "\"\"\"S&P 500 Options: Label Engineering - Same-Contract Short Straddle Returns.\"\"\"\n",
+    "\"\"\"S&P 500 Options: Label Engineering.\"\"\"\n",
     "\n",
-    "import json\n",
-    "import subprocess\n",
     "import warnings\n",
-    "from datetime import UTC, datetime\n",
+    "from datetime import date\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import plotly.graph_objects as go\n",
     "import polars as pl\n",
-    "from ml4t.diagnostic.metrics import compute_ic_hac_stats\n",
-    "from plotly.subplots import make_subplots\n",
-    "from scipy.stats import spearmanr\n",
+    "import yaml\n",
+    "from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series\n",
     "\n",
-    "from case_studies.sp500_options._label_artifacts import ensure_label_artifacts\n",
+    "from case_studies.sp500_options._label_artifacts import accrued_hedge_pnl, ensure_label_artifacts\n",
     "from case_studies.sp500_options._underlying_returns import reconcile_underlying_log_returns\n",
+    "from case_studies.utils.artifact_digest import value_digest, write_artifact\n",
+    "from case_studies.utils.label_diagnostics import effective_sample_size, panel_autocorrelation\n",
     "from data import load_sp500_daily_bars, load_sp500_options_straddles\n",
-    "from utils.cv_splits import load_evaluation_config\n",
+    "from utils.artifact_specs import resolve_label_horizon\n",
     "from utils.paths import get_case_study_dir\n",
-    "from utils.style import COLORS  # registers the ml4t Plotly template on import\n",
+    "from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "CASE_STUDY_ID = \"sp500_options\"\n",
+    "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
+    "LABELS_DIR = CASE_DIR / \"labels\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20cecc8c",
+   "metadata": {},
+   "source": [
+    "Both parameters are unset by default, and both are read below - they reach the artifact\n",
+    "builder rather than the frames it returns, because the builder caches its output and a\n",
+    "window applied after the fact would leave the cached full panel in place. `START_DATE`\n",
+    "trims the history to a later start; `MAX_SYMBOLS` keeps the most-quoted symbols only.\n",
+    "Either one shortens a run at the cost of a thinner panel: the rank correlation in Section\n",
+    "G and the cross-sectional dispersion in Section E both need a wide cross-section on each\n",
+    "session to mean anything."
    ]
   },
   {
@@ -84,10 +103,10 @@
    "id": "c4a3a4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:46.828579Z",
-     "iopub.status.busy": "2026-07-21T06:54:46.828467Z",
-     "iopub.status.idle": "2026-07-21T06:54:46.830322Z",
-     "shell.execute_reply": "2026-07-21T06:54:46.829925Z"
+     "iopub.execute_input": "2026-07-31T07:12:47.287621Z",
+     "iopub.status.busy": "2026-07-31T07:12:47.287202Z",
+     "iopub.status.idle": "2026-07-31T07:12:47.291710Z",
+     "shell.execute_reply": "2026-07-31T07:12:47.290674Z"
     },
     "tags": [
      "parameters"
@@ -95,7 +114,28 @@
    },
    "outputs": [],
    "source": [
-    "START_DATE = None  # None = use full dataset"
+    "MAX_SYMBOLS = 0\n",
+    "START_DATE = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4e63f07",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Everything that defines a label is declared in `config/setup.yaml` and bound here. A\n",
+    "horizon or a boundary typed into a cell is a second copy of a value the rest of the\n",
+    "pipeline reads from the file, and the two drift apart the first time either is edited.\n",
+    "\n",
+    "The primary label and the four diagnostic variants are declared separately, and the\n",
+    "distinction is what they are for rather than how they are built: models train on\n",
+    "`ret_to_expiry`, while the fixed-horizon variants exist to show what the same trade earns\n",
+    "when it is closed early and when its directional exposure is hedged away. `labels.buffer`\n",
+    "is the gap that keeps a training fold independent of the validation fold after it, and\n",
+    "`generate_cv_splits` takes it separately from the horizon an outcome resolves over -\n",
+    "here they are different quantities, and Section H prints both."
    ]
   },
   {
@@ -104,38 +144,102 @@
    "id": "31239f84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:46.832435Z",
-     "iopub.status.busy": "2026-07-21T06:54:46.832355Z",
-     "iopub.status.idle": "2026-07-21T06:54:46.834332Z",
-     "shell.execute_reply": "2026-07-21T06:54:46.834010Z"
+     "iopub.execute_input": "2026-07-31T07:12:47.294464Z",
+     "iopub.status.busy": "2026-07-31T07:12:47.294227Z",
+     "iopub.status.idle": "2026-07-31T07:12:47.321575Z",
+     "shell.execute_reply": "2026-07-31T07:12:47.320416Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primary ret_to_expiry; diagnostic variants {'fwd_ret_5d': 5, 'fwd_ret_10d': 10, 'fwd_ret_dh_5d': 5, 'fwd_ret_dh_10d': 10} sessions\n",
+      "Cross-validation buffer 35D; holdout opens 2021-01-01\n"
+     ]
+    }
+   ],
    "source": [
-    "CASE_DIR = get_case_study_dir(\"sp500_options\")\n",
-    "LABELS_DIR = CASE_DIR / \"labels\"\n",
+    "setup = yaml.safe_load((CASE_DIR / \"config\" / \"setup.yaml\").read_text())\n",
     "\n",
-    "STRATEGY_ID = \"sp500_options\"\n",
+    "PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
+    "VARIANT_LABELS = list(setup[\"labels\"][\"variant_buffers\"])\n",
+    "LABEL_NAMES = [PRIMARY_LABEL, *VARIANT_LABELS]\n",
+    "HORIZONS = {\n",
+    "    name: int(resolve_label_horizon(CASE_STUDY_ID, name, setup).rstrip(\"Dd\"))\n",
+    "    for name in VARIANT_LABELS\n",
+    "}\n",
+    "LABEL_BUFFER = setup[\"labels\"][\"buffer\"]\n",
+    "HOLDOUT_START = date.fromisoformat(setup[\"evaluation\"][\"holdout_start\"])\n",
     "INSTRUMENT_ID = \"straddle_30d_atm\"\n",
-    "FORWARD_HORIZONS = (5, 10)"
+    "\n",
+    "# One style per label, shared by every figure: the primary in the focal colour, each\n",
+    "# fixed-horizon family in its own, and the delta-hedged member of a family dashed.\n",
+    "SHORT = min(HORIZONS.values(), default=0)\n",
+    "STYLES = {\n",
+    "    name: dict(\n",
+    "        color=COLORS[\"blue\"]\n",
+    "        if name == PRIMARY_LABEL\n",
+    "        else COLORS[\"amber\" if HORIZONS[name] == SHORT else \"copper\"],\n",
+    "        linestyle=\"--\" if \"_dh_\" in name else \"-\",\n",
+    "        lw=2.2 if name == PRIMARY_LABEL else 1.4,\n",
+    "    )\n",
+    "    for name in LABEL_NAMES\n",
+    "}\n",
+    "\n",
+    "print(f\"Primary {PRIMARY_LABEL}; diagnostic variants {HORIZONS} sessions\")\n",
+    "print(f\"Cross-validation buffer {LABEL_BUFFER}; holdout opens {HOLDOUT_START}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "94cdcb73",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
-    "## 1. Build and Load Same-Contract Returns\n",
+    "## A. The learning task\n",
     "\n",
-    "The slim reader dataset already includes the inputs needed for same-contract\n",
-    "label construction:\n",
+    "The hypothesis is that an option's implied volatility is, on average, above the volatility\n",
+    "the underlying goes on to realise, and that the excess is not uniform across the S&P 500:\n",
+    "some names are priced further above their own subsequent moves than others. Selling a\n",
+    "straddle - one call and one put at the same strike and expiration - is the position that\n",
+    "earns that difference and is close to neutral on direction at the moment it is opened. The\n",
+    "label is therefore the return on a short straddle held over a fixed window, ranked across\n",
+    "names rather than judged in isolation, and the strategy that consumes it sells the names\n",
+    "it ranks highest.\n",
     "\n",
-    "- `options_straddles_daily.parquet`\n",
-    "- `options_straddles_raw/year=*.parquet`\n",
+    "The decision cadence comes from `setup.yaml`: a Friday close is observed and the position\n",
+    "is opened at the next session's open, on a straddle written about a month out. That fixes\n",
+    "the primary label's outcome: the position is carried to expiration and settles into cash\n",
+    "at whatever the underlying is worth that day. Labels are sampled every session rather than\n",
+    "only on Fridays - that buys five times the rows at the price of overlapping trades, and\n",
+    "Section F measures what they are worth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "549a92da",
+   "metadata": {},
+   "source": [
+    "## B. Preparation before the label\n",
     "\n",
-    "We build the persisted same-contract artifacts from those inputs here, then\n",
-    "read them for the downstream label calculations."
+    "**A forward return on an option is a round trip in one contract, and that is the mistake\n",
+    "this dataset invites.** The daily panel carries a 30-day at-the-money straddle for each\n",
+    "name on each session, but the contract behind that row changes as the calendar moves: the\n",
+    "thing that is 30 days out today is 29 days out tomorrow, so tomorrow's row is a different\n",
+    "strike and often a different expiration. Shifting the panel's price column forward would\n",
+    "difference two prices from two different contracts and report the change of instrument as\n",
+    "profit. What the label needs instead is the price of *today's* contract on a later date,\n",
+    "which only the raw chain holds, so `_label_artifacts.py` looks each held contract up by\n",
+    "`(symbol, strike, expiration)` and returns the entry premium, the exit premium at each\n",
+    "horizon, and the contract's own delta on each day it is held.\n",
+    "\n",
+    "The entity a label may not cross is that contract. Entry is at the session after the\n",
+    "signal, so the whole window sits strictly in the future of the row that carries it, and no\n",
+    "eligibility filter runs before the label is built: dropping rows first would make a\n",
+    "forward offset count survivors rather than sessions, and the window would silently span\n",
+    "whatever was removed. Point-in-time liquidity screening is applied downstream, where\n",
+    "`setup.yaml: backtest.sweep.universe_filter` declares it."
    ]
   },
   {
@@ -144,10 +248,10 @@
    "id": "919dbfe9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:46.835150Z",
-     "iopub.status.busy": "2026-07-21T06:54:46.835060Z",
-     "iopub.status.idle": "2026-07-21T06:54:47.011839Z",
-     "shell.execute_reply": "2026-07-21T06:54:47.011419Z"
+     "iopub.execute_input": "2026-07-31T07:12:47.327434Z",
+     "iopub.status.busy": "2026-07-31T07:12:47.326348Z",
+     "iopub.status.idle": "2026-07-31T07:12:47.994946Z",
+     "shell.execute_reply": "2026-07-31T07:12:47.993598Z"
     }
    },
    "outputs": [
@@ -155,42 +259,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contract returns: 357,479 entries\n",
-      "  Symbols: 623\n",
-      "  Date range: 2017-01-03 to 2021-12-15\n",
-      "  Exit 5d coverage: 353,398/357,479 (98.9%)\n",
-      "  Exit 10d coverage: 341,134/357,479 (95.4%)\n"
+      "357,479 round trips on 623 names, signalled 2017-01-03 to 2021-12-15\n",
+      "Digests - contract_returns 16ad939fdffd0f9c, hedge_path 24c07ca55f194efa, market_data 666956332393545f\n"
      ]
     }
    ],
    "source": [
-    "artifact_paths = ensure_label_artifacts()\n",
+    "ensure_label_artifacts(max_symbols=MAX_SYMBOLS, start_date=START_DATE)\n",
     "contract_returns = pl.read_parquet(LABELS_DIR / \"contract_returns.parquet\")\n",
-    "print(f\"Contract returns: {len(contract_returns):,} entries\")\n",
-    "print(f\"  Symbols: {contract_returns['symbol'].n_unique()}\")\n",
-    "print(\n",
-    "    f\"  Date range: {contract_returns['feature_date'].min()} to {contract_returns['feature_date'].max()}\"\n",
-    ")\n",
+    "hedge_path = pl.read_parquet(LABELS_DIR / \"hedge_path.parquet\")\n",
+    "straddles = load_sp500_options_straddles()\n",
+    "underlying = load_sp500_daily_bars()\n",
     "\n",
-    "for h in FORWARD_HORIZONS:\n",
-    "    found = contract_returns[f\"exit_found_{h}d\"].sum()\n",
-    "    total = len(contract_returns)\n",
-    "    print(f\"  Exit {h}d coverage: {found:,}/{total:,} ({found / total:.1%})\")"
+    "# Recorded as each label's `inputs`: a re-run against a refreshed download is otherwise\n",
+    "# indistinguishable from this one.\n",
+    "CONTRACT_DIGEST = value_digest(contract_returns)\n",
+    "HEDGE_DIGEST = value_digest(hedge_path)\n",
+    "MARKET_DATA_DIGEST = value_digest(underlying, [\"symbol\", \"timestamp\", \"close\"])\n",
+    "\n",
+    "signals = contract_returns[\"feature_date\"]\n",
+    "print(\n",
+    "    f\"{contract_returns.height:,} round trips on {contract_returns['symbol'].n_unique()} names, \"\n",
+    "    f\"signalled {signals.min()} to {signals.max()}\\nDigests - contract_returns \"\n",
+    "    f\"{CONTRACT_DIGEST}, hedge_path {HEDGE_DIGEST}, market_data {MARKET_DATA_DIGEST}\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ffc95f94",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
-    "## 2. Unhedged Short Straddle Labels\n",
-    "\n",
-    "The unhedged label uses the same-contract mid-to-mid return directly from\n",
-    "the same-contract artifact builder. No additional computation needed - just filter to valid\n",
-    "exits and format for downstream consumption.\n",
-    "\n",
-    "$$r_{short} = \\frac{(C_{entry} + P_{entry}) - (C_{exit} + P_{exit})}{C_{entry} + P_{entry}}$$"
+    "Every window below is counted on the straddle panel's own session calendar, numbered once\n",
+    "here on the source panel rather than on the rows that survive to a label. A name is quoted\n",
+    "on roughly half the sessions in this panel, so counting positions among surviving rows\n",
+    "would make the two rows either side of a gap adjacent and report windows that share\n",
+    "nothing as overlapping."
    ]
   },
   {
@@ -199,10 +303,10 @@
    "id": "56482e62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:47.014923Z",
-     "iopub.status.busy": "2026-07-21T06:54:47.014820Z",
-     "iopub.status.idle": "2026-07-21T06:54:47.175405Z",
-     "shell.execute_reply": "2026-07-21T06:54:47.170103Z"
+     "iopub.execute_input": "2026-07-31T07:12:48.024808Z",
+     "iopub.status.busy": "2026-07-31T07:12:48.024293Z",
+     "iopub.status.idle": "2026-07-31T07:12:48.121427Z",
+     "shell.execute_reply": "2026-07-31T07:12:48.118974Z"
     }
    },
    "outputs": [
@@ -210,49 +314,71 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_5d: 352,179 rows, mean=0.0071, std=0.2455, median=0.0645\n",
-      "fwd_ret_10d: 333,102 rows, mean=0.0572, std=0.3534, median=0.1491\n"
+      "1,259 panel sessions; 1,248 carry a signal\n"
      ]
     }
    ],
    "source": [
-    "unhedged_labels = {}\n",
-    "for h in FORWARD_HORIZONS:\n",
-    "    label_col = f\"fwd_ret_{h}d\"\n",
-    "    lbl = (\n",
-    "        contract_returns.filter(pl.col(f\"exit_found_{h}d\"))\n",
-    "        .select(\n",
-    "            [\n",
-    "                pl.col(\"feature_date\").alias(\"timestamp\"),\n",
-    "                \"symbol\",\n",
-    "                pl.lit(INSTRUMENT_ID).alias(\"instrument_id\"),\n",
-    "                label_col,\n",
-    "            ]\n",
-    "        )\n",
-    "        .drop_nulls(subset=[label_col])\n",
-    "    )\n",
-    "    unhedged_labels[label_col] = lbl\n",
-    "    stats = lbl[label_col]\n",
-    "    print(\n",
-    "        f\"{label_col}: {len(lbl):,} rows, \"\n",
-    "        f\"mean={stats.mean():.4f}, std={stats.std():.4f}, median={stats.median():.4f}\"\n",
-    "    )"
+    "calendar = straddles.select(\"timestamp\").unique().sort(\"timestamp\").with_row_index(\"_bar\")\n",
+    "N_SESSIONS = calendar.height\n",
+    "# Entry is the session after the signal, so a horizon-h trade closes h+1 sessions out.\n",
+    "calendar = calendar.with_columns(\n",
+    "    (N_SESSIONS - 1 - pl.col(\"_bar\")).alias(\"from_end\"),\n",
+    "    *(\n",
+    "        pl.col(\"timestamp\").shift(-horizon - 1).alias(f\"_end_{horizon}d\")\n",
+    "        for horizon in set(HORIZONS.values())\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "panel = contract_returns.rename({\"feature_date\": \"timestamp\"}).join(\n",
+    "    calendar, on=\"timestamp\", how=\"left\"\n",
+    ")\n",
+    "print(f\"{N_SESSIONS:,} panel sessions; {panel['timestamp'].n_unique():,} carry a signal\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e02379a7",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
-    "## 2b. Executable Short Straddle Labels (Bid/Ask)\n",
+    "## C. Label construction\n",
     "\n",
-    "The mid-to-mid labels measure the economic signal. The **executable** labels\n",
-    "measure what a trader actually receives: sell at bid (entry), buy back at ask\n",
-    "(exit). The difference is the full bid-ask spread - the dominant cost for\n",
-    "single-stock options (~11% of premium round-trip).\n",
+    "One execution convention, written once. A straddle sold at $t{+}1$ for the premium\n",
+    "$P_{t+1} = C_{t+1} + Q_{t+1}$ and bought back $h$ sessions later at $P_{t+1+h}$, with both\n",
+    "prices taken at the mid of the *same* contract, returns\n",
     "\n",
-    "$$r_{exec} = \\frac{(C_{bid}^{entry} + P_{bid}^{entry}) - (C_{ask}^{exit} + P_{ask}^{exit})}{C_{bid}^{entry} + P_{bid}^{entry}}$$"
+    "$$r^{(h)}_{i,t} = \\frac{P_{i,t+1} - P_{i,t+1+h}}{P_{i,t+1}}$$\n",
+    "\n",
+    "for contract $i$. The sign convention is the seller's throughout: a positive number is a\n",
+    "profitable short straddle. The denominator is the premium collected, so the label is\n",
+    "already a return on the capital the trade puts at risk and needs no further scaling.\n",
+    "\n",
+    "The delta-hedged variant subtracts the directional part of that P&L. Holding the straddle\n",
+    "leaves a residual exposure $\\Delta_d$ to the underlying that changes every day, so the\n",
+    "hedge is rebalanced at each close along the path the contract actually took:\n",
+    "\n",
+    "$$r^{(h),\\text{dh}}_{i,t} = r^{(h)}_{i,t}\n",
+    "  + \\frac{1}{P_{i,t+1}}\\sum_{d=1}^{h} \\Delta_{i,d-1}\\,(S_{i,d} - S_{i,d-1})$$\n",
+    "\n",
+    "The delta is the held contract's own, not the panel's constant-maturity delta, which\n",
+    "jumps between contracts daily and would hedge a position nobody holds. `accrued_hedge_pnl`\n",
+    "returns the number of days it found a quote on as well as the accrued P&L, because a sum\n",
+    "over a path with holes is a partial hedge: a label built from one is not the quantity the\n",
+    "formula names, and Section D nulls it rather than presenting it as fully hedged.\n",
+    "\n",
+    "The primary label replaces the exit leg altogether. Carried to expiration, the straddle\n",
+    "settles into cash at its intrinsic value and there is no closing trade at all:\n",
+    "\n",
+    "$$r^{\\text{exp}}_{i,t} = \\frac{P_{i,t+1} - |S_{i,T} - K_i|}{P_{i,t+1}}$$\n",
+    "\n",
+    "where $K_i$ is the strike, $T$ the expiration, and $S_{i,T}$ the underlying's close that\n",
+    "day. Settlement reads the unadjusted historical close, because the listed strike and the\n",
+    "expiration spot are quoted in the same contemporaneous price basis and adjusting one\n",
+    "without the other would put them on different scales.\n",
+    "\n",
+    "**The three conventions divide by the price at entry rather than differencing a price\n",
+    "series, so none of them is a shift, and `fixed_time_horizon_labels` cannot express any of\n",
+    "them.** That is why the round trips are built in `_label_artifacts.py` and read back here."
    ]
   },
   {
@@ -261,94 +387,184 @@
    "id": "f84039eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:47.176634Z",
-     "iopub.status.busy": "2026-07-21T06:54:47.176522Z",
-     "iopub.status.idle": "2026-07-21T06:54:47.301443Z",
-     "shell.execute_reply": "2026-07-21T06:54:47.299328Z"
+     "iopub.execute_input": "2026-07-31T07:12:48.142067Z",
+     "iopub.status.busy": "2026-07-31T07:12:48.139024Z",
+     "iopub.status.idle": "2026-07-31T07:12:51.763257Z",
+     "shell.execute_reply": "2026-07-31T07:12:51.762719Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "fwd_ret_exec_5d: 352,179 rows, mean=-0.1486, std=0.3818, hit_rate=33.7%\n",
-      "fwd_ret_exec_10d: 333,102 rows, mean=-0.0963, std=0.4773, hit_rate=52.0%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "exec_labels = {}\n",
-    "for h in FORWARD_HORIZONS:\n",
-    "    label_col = f\"fwd_ret_exec_{h}d\"\n",
-    "    valid = contract_returns.filter(pl.col(f\"exit_found_{h}d\"))\n",
-    "    lbl = (\n",
-    "        valid.with_columns(\n",
-    "            (pl.col(\"entry_call_bid\") + pl.col(\"entry_put_bid\")).alias(\"_entry_bid\"),\n",
-    "            (pl.col(f\"exit_call_{h}d_ask\") + pl.col(f\"exit_put_{h}d_ask\")).alias(\"_exit_ask\"),\n",
-    "        )\n",
-    "        .with_columns(\n",
-    "            ((pl.col(\"_entry_bid\") - pl.col(\"_exit_ask\")) / pl.col(\"_entry_bid\")).alias(label_col)\n",
-    "        )\n",
-    "        .select(\n",
-    "            [\n",
-    "                pl.col(\"feature_date\").alias(\"timestamp\"),\n",
-    "                \"symbol\",\n",
-    "                pl.lit(INSTRUMENT_ID).alias(\"instrument_id\"),\n",
-    "                label_col,\n",
-    "            ]\n",
-    "        )\n",
-    "        .drop_nulls(subset=[label_col])\n",
-    "    )\n",
-    "    exec_labels[label_col] = lbl\n",
-    "    stats = lbl[label_col]\n",
-    "    print(\n",
-    "        f\"{label_col}: {len(lbl):,} rows, \"\n",
-    "        f\"mean={stats.mean():.4f}, std={stats.std():.4f}, \"\n",
-    "        f\"hit_rate={(stats > 0).mean():.1%}\"\n",
-    "    )"
+    "panel = panel.join(accrued_hedge_pnl(hedge_path), on=[\"timestamp\", \"symbol\"], how=\"left\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "0597e78c",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
-    "The executable returns are substantially lower than mid-to-mid because the\n",
-    "full bid-ask spread is baked into entry and exit prices. The unconditional\n",
-    "executable return is negative - the average straddle is unprofitable after\n",
-    "spreads. The ML model's value is selecting the subset that remains profitable."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98b1d352",
-   "metadata": {
-   },
-   "source": [
-    "## 3. Delta-Hedged Short Straddle Labels\n",
-    "\n",
-    "The delta-hedged variant isolates the volatility bet by removing directional\n",
-    "exposure. We use the **held contract's** delta path from the same-contract artifacts,\n",
-    "not the constant-maturity delta that jumps between contracts daily.\n",
-    "\n",
-    "$$r_{dh} = r_{short} + \\sum_{d=0}^{h-1} \\Delta_d \\cdot \\frac{S_{d+1} - S_d}{P_{entry}}$$\n",
-    "\n",
-    "where $\\Delta_d$ is the held contract's net delta on holding day $d$,\n",
-    "and $S_d$ is the underlying price."
+    "Each label is then one expression over the round-trip frame, and each carries `_label_end`\n",
+    "- the date its outcome is fully observed. For a fixed-horizon trade that is the session it\n",
+    "is closed on; for the primary label it is the expiration date, which is written into the\n",
+    "contract at entry and varies from trade to trade. Section D checks both against the\n",
+    "calendar, and everything from Section E onwards is sealed on this column."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "7c5eb36a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T07:12:51.765636Z",
+     "iopub.status.busy": "2026-07-31T07:12:51.765485Z",
+     "iopub.status.idle": "2026-07-31T07:12:52.027066Z",
+     "shell.execute_reply": "2026-07-31T07:12:52.024806Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "settlement = underlying.select(\n",
+    "    \"symbol\",\n",
+    "    pl.col(\"timestamp\").alias(\"expiration\"),\n",
+    "    pl.col(\"close\").alias(\"_close_at_expiry\"),\n",
+    ")\n",
+    "panel = panel.join(settlement, on=[\"symbol\", \"expiration\"], how=\"left\").with_columns(\n",
+    "    (\n",
+    "        (pl.col(\"entry_straddle_mid\") - (pl.col(\"_close_at_expiry\") - pl.col(\"strike\")).abs())\n",
+    "        / pl.col(\"entry_straddle_mid\")\n",
+    "    ).alias(PRIMARY_LABEL),\n",
+    "    (pl.col(\"expiration\") - pl.col(\"timestamp\"))\n",
+    "    .dt.total_days()\n",
+    "    .cast(pl.Int32)\n",
+    "    .alias(\"dte_calendar\"),\n",
+    ")\n",
+    "for name, horizon in HORIZONS.items():\n",
+    "    exit_mid = pl.col(f\"exit_straddle_mid_{horizon}d\")\n",
+    "    ret = (pl.col(\"entry_straddle_mid\") - exit_mid) / pl.col(\"entry_straddle_mid\")\n",
+    "    if name.startswith(\"fwd_ret_dh_\"):\n",
+    "        complete = pl.col(f\"hedge_days_{horizon}d\") == horizon\n",
+    "        hedge = pl.col(f\"hedge_pnl_{horizon}d\") / pl.col(\"entry_straddle_mid\")\n",
+    "        ret = pl.when(complete).then(ret + hedge)\n",
+    "    panel = panel.with_columns(ret.alias(name))\n",
+    "\n",
+    "END_OF = {PRIMARY_LABEL: pl.col(\"expiration\")} | {\n",
+    "    name: pl.col(f\"_end_{horizon}d\") for name, horizon in HORIZONS.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98b1d352",
+   "metadata": {},
+   "source": [
+    "The primary label settles on a date the contract fixes rather than a fixed number of\n",
+    "sessions out, so how long the money is committed is itself a distribution. Chapter 7.2\n",
+    "asks for it wherever the resolution time varies: a label whose window is sometimes a third\n",
+    "longer than at other times is not one horizon, and the spread is what the purge gap and\n",
+    "the cost of carry both have to cover."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "660bd819",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:47.303007Z",
-     "iopub.status.busy": "2026-07-21T06:54:47.302903Z",
-     "iopub.status.idle": "2026-07-21T06:54:47.468155Z",
-     "shell.execute_reply": "2026-07-21T06:54:47.467474Z"
+     "iopub.execute_input": "2026-07-31T07:12:52.038794Z",
+     "iopub.status.busy": "2026-07-31T07:12:52.038367Z",
+     "iopub.status.idle": "2026-07-31T07:12:52.367130Z",
+     "shell.execute_reply": "2026-07-31T07:12:52.366430Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtAAAAFnCAYAAACPcH7MAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAhI1JREFUeJzt3XdUFFcbBvCH3ll6UxCMimBDQRF7QbH3QjT2logaxRJN7DHRqLHGEvWzxt5bRLFEjSGKqLEEsAcNghWQ3u73B2FkZSmr6OL6/M7Zc3Zn7sy8c2d25t3ZO3c0hBACRERERERULJqqDoCIiIiI6EPCBJqIiIiISAlMoImIiIiIlMAEmoiIiIhICUygiYiIiIiUwASaiIiIiEgJTKCJiIiIiJTABJqIiIiISAlMoImIiIiIlMAEmgr0T9S/MLJ1g5GtG1p17qvqcD5K73IbbNq2V5r3d/N+KpF5vut9Jnfebl7NVR5LSflu3k9SnJu27VVJDG5ezaUYSpsz5y5IsQ0dNUnV4ZRayu5HrTr3lcr/E/XvWy9/6KhJ0vzOnLvw1vN73e2799G9z3CUc68vLefgr8cLLF/S60f5vcs6/hCO39qqDuBj8N28n/D9/GUAgN49O2HVktly41t17ouzf4QCAFYu/h59/Du/9xgpv7+uh+PQkRMAgIb16qBR/ToqjoiIVG3Ttr2IepCTLAQM7Qszmel7WW5cfAKWrdoIAHByLPNRnSeysrLg338kwiNvv/W8VLX9SP0wgSYqwNXrEdIPn6/HQe0SaL/mjRB84BcAgGMZexVH8/Hq+2kXNG3kAwCoUN5ZtcFQkTZv3ytd8PisZ+f3loDFx7+UjkcN69V+6wR6/neTkfDyJQDAztb6reN7l+5HPZSS5wrly2HBnCkw0NdH5UqfFDhNQeunqu2njj6kfehdYAJNVMKSkpJhZGSo6jCKZGNtCRtrS1WH8dHK3U8cyzrAsayDqsOhj0xV90pKlVflce1RzGPpfR0vDzRvXL/IaZRdP1Lex17HbANdyt259w+Gffk1KtVsCrOy1eFYuS469xqKU2dCpDJCCDi5+cDI1g0VPZpIw0+e/kNhm7jGrXrCyNYNpg5VkZiU9EZxJbxMxPTvF6FWg7awLOcB2/KeaNyqJ/63cTuEEHJl87ZbzW3HZuPiibKudTFq/HSkpqbJlX/2/AWGjJwI+wq14VCxDgaP+ApPn71Qqv3r7yGh+GzwaFSv6weHinVgVrY6PqneCH2GjMG1G5FFTu/m1Ryff/m19Pn7+cvytRfO2/7r8tUb+PzLb+Dk5gOb8p4AgBvhNzHgi/HwbNgOZV3rQlamGsq510eX3sPwe0hovmXe/+chuvcZDmvnWijnXh/jvvkeySkpBcaYmJSE7+b9BK9G7WFZzgN2n3ihVee+OHriTJHrBxTcBvqfqH/R//Nx+KR6I8jKVINDxTrwbNgOw778ulh1l9fVGxFo03UArJxrwqVqQ8yYvQjZ2dlyZTIyMrBk5XrUb9EV1s61YO1cC41b9cTWXQeKvRxl6+513fsMl+riyrW/5caNGDtVGhd0/DQAYMPmXejQczBcazWDtXMtWDjVQPW6fhg7aRaePnshN31R+0lhbVev3YhEv2FjUb5aQ5iVrY4KNRpj+JjJ+Dc6Rq5cSkoqvp4xD9Xr+sHcsTqsnWvB3csXnw4YiQO/Bhe7HgDg6bOc71+ZSt6wr1AbA74Yj8dPngEAXiYmwdq5lvQ9zPtdz8rKQjn3ejCydYNj5brIyMgocBnRj2Lx+ZffwLtpJzi5+UBWphrKutZF6y79C23XCgC/nf0Tjfx6wMKpBty9fPHTzxvylUlPT8ePS1ejbrPOsHauBSvnmvBu2gnzl6xGenq6XNmCjiuvt+/MbYude/USANxr+xarDejbrC+Q077Yvbav9PnsH6FFtg9dtW6LtD94N+2E387+Wej6Afnbnf4eEoqmbfxhWc4DYyZ9K0278n+bUbVOS1iW80Ajvx755l0cQgis3bgDTVr3hG15T1g41UDN+m0w7buFiE94KRenX6dX67hlx/5i1fmbbr99h47Bt31v2FeoDbOy1eFStSF82/fG5G/n5zu3KVLcc2OvgaOkZd+59w+AnO+xWdnq+dr7T/52vlQ29/iet8358d/O4dsflqCiRxNYONVA83a9cPVGRJGx1m/RFUa2bjArWx0pKakAcnIOReeFvkPGSMMjbt5RWMdA/n0o7PI1tO7cr9BzgLLH7/dVx0XhFehS7OKlq2jXfSBeJr5Kcp+/iMexE2cRfPJ3LJwzBUP6fwoNDQ341PHEoaATiH4Ui3+jY1DGwQ4Xwq5I0124eAV9/DsjNTUNf10PBwDUqOYGYyMjpeN6EReP5u16IfLWXfl4L1/FxctXcebcBWz4+cd808XFJaBZ20/x7HkcACApGfjfxu2wtDDDtEmjAeQkU50+HYpLV65L023deQDX/76pVIx/hl7B3oNH5YbFxD7BngNBCAo+jbPHdhb695+y+gweg3v/PJAb9nfELezYc0hu2NNnz3H0+BkEn/wdh3auReMG3gCA5y/i4Ne5Lx7++wgAkJySghVrNuHsH4pvxolPeIkWHT7DjfBX9ZKKNJz9IxRn/wjFwjlTMHRAL6XXIzMzEx39B+PWnftyy4pPeImIm3fgU7smqlVxLda87t5/gBbteyMxKRlAzoFr7qKfUc6xDPp/1h3Aq+39+gn44uWrGBxwFTfCb2LWlHGFLkfZulOkZ9d2+PXYKQDAvoPH4FHNHUBOUnjwv3bw1laW8G2Sc+Vrz8GjOPHbObl53LkXhTv3NuO33//EueDd0NfXy7ccRftJQY6eOINPB4xEWtqrhO9RzGNs2LIbQcdP4+ShrXAuVxYAEDjpW2zcukcql44M/PPgX/zz4F8YGBigQ5sWxa0KtO02ANf/fvVDaceeQ/g74hbOBO2AibEROnfww+bt+xD1IBohFy6hnnfOD4E/Qy9LPx46tfODjo5Ogct4+O8jbNq2R27Yi7h4nDl3HmfOnceqpbPRu0enfNOFXb6GHXsOS8n5Pw/+xVdT5yA1LR3jRg0BAKSlpaNDz0H4PeSi3LTX/47E9b8jEXzyDA7u+B90dXWLXSdv603X900tWvY/KckBctbdv/8IhIedgLmZrFjzuH33H3T0H5LvAsei5WvxzYx50uewK9fQ6dOh+MTFqdjxCSHQ//Nx2LXvV7nhN2/fw/wlq3DwyHGcOLSl2LGWlLN/XECfIWPkErzHT57i8ZOnCLlwCdMnjYa2dsFpkzLnxnrenth/OOfH7YWwv/CJSzlc+uu6tG9fuHhFmj73vaamJnzq1Mq33NETZsgdV/4MvQz/fiNw9c+gQuOt5+2JK1f/RkZGBi5fvYF63p44n2e5cu/D/gIAWFlaFPvceevOffh17isl54rOAcoev1VVx4rwCvR7tnn7PulXTu4r7y/iXEIIfD76ayl57tzeD7s3r8TEwC+gqakJIQQmTJkt7XT1fbykaXN3+rw7/5+hlwFAbufJPfEpa/r3C6Wdt4pbJWxdtwTLF3wrHex27fs134ERyPnVaGVpgS1rF2PqV6Ok4Ws37ZDeb9q6V0qezc1kWL7gW2xavRAJea5IFIdXzWr48fvJ2LlxOY7s2YCDO/6Hb6eMBZDzBVV01SqvzWsWY/yXw6TPffy7IPjALwg+8Av6ftolX/kH/z7C1+MCsH/7GvwwcyIAoGIFF8ye8RW2r/8Jv+5ej8O71mHx3GnQ09NFdnY25i9ZJU2/aNlaaVuWcyyDjasW4OclsxET+zjfsgBgxuxFUvLs59sIuzevxOqf5sDWxgoA8NXUOdL8lBF5666UPDdt5IN921Zj9y8r8OP3k9GyeUPo6hU/6fg3OgbVqlTGjg3L8MXgPtLw/+XZ3stWb5KS5zqeNbBt3VJs/t9iVKrgAgBY+NP/EPrfgbsgytadIm39msHEOOfH5P7Dx6ThZ/8IxdNnzwEA3Tq2lk5GXTu2xopF32H35pUI2rsBuzevRK8eHQEAETfvSAft1ynaTxRJTk7B0JGTkJaWDm1tbUyfNBoHdqzBmBGDAACxj59i9MSZUvnDR08CAJwcHbD5f4txYMcaLF84C716dIS5km08k5KSpTq0sjQHkJOA5X5P+/XqKpXdvvtgnhhOSe+7d25b6DJsbawxc3IgtqxdjEM71+LIng1YtXQ2rCwtAABzF65UOF3EzTvSsXDEsH7S8O/n/yQl7z+t2iAlz2XL2GPdivlYv3I+HMvmtPP/PeQilhbx/VekRjU3BB/4BdWrvuqp5Jc1i6TjQmFtQN90fXNNGD0Mv6xZJH2uXtVNWu787ybnKx9x8w4CRwzGzo3LUa1KZQA5/x68/oO+MI9iHqOMvS3+t2wu9mz5Ge1bNceLuHjMmrtUKvPFoM+we/NKdO3YSi5hL8ru/Uekc4S5mQw/zZ+BbeuWoqp7zo/zyFt3Mf37hQBy2tnO/+4badqWzRsWq85fV5zt9+ux36TkefrXY3B41zps+PlHfDXmc7i5fgINDY1Cl6HMuTHvOfuCgnP2rTv38ez5C2RkZODSXzcAANWquMLUxDjfch9Gx+DbKWOxdd0SlP3vfpZ/HvyL46d+LzTeBgryhrxJ5cVLV5GdnY3oR7HSMbaed/GSSyDnopVHNfdCzwHKHr9VVceK8Ap0KfXX9XCER+YckGxtrLBuxTzo6OiglW9jRNy8g32HjiE9PQP7Dh3DiGH9UD9PMnz+4hV0bu+H0LCrMDQwgI21JSJu3kHCy0S5nad+XeUT6OzsbOzeHyR9XrdiHqq45bSDSklNw9ivZwEAdu79Fd06tck3/bqV81Gjqhs6tgW27zmEyFt38fTZC8QnvITM1AQHg179nTl5wkj0690NAGBiYoxO/kOKHWcdzxr443wY1m7agXv3H+T7O+jSX9cLmDJHLY+quBFxS/rsWNa+0B8cYwIG4ZvxIwBAukpZzd0V50IuYu6in3Hz9l0kJiXL/b10+b8vLPAqAQKABXOmoJVvYwBAZkYGAsZOlVtWdnY2duw5DADQ1dXByGH9oaenC1MTY3Rs2wKr1m1FenoGdh8IwpdfDCh0PV+X96qhna01KriUQzmnMtDU1MTng3orNS9dXR1s/t9i2NpYoXXLJtiweReSU1Jw916UVGbbrlcJ2MjP+8Pyv4StZ9d2+PaHpVKZ2p41ClyOMnVXEAMDfXRo2wKbt+/Dzdv3cP3vm6jqXgn7Dr36F6Nn13bS+2aNfDBnwQqcOhOCR7GP5a4SAzn7V97yuRTtJ4qc+O2clLg3a+wjnQjatGyKPfuDpJPj02cvYGVpLiX2MlNTuDg7onLFT6CnpyuX7BbXknnT0axxPQDydXjwyAl8Mfgz1K/rhYqfOOPWnfvYe/Ao5n/3DXR0dHDkvyv49nY2cidmRco5lYGtjTWWrdqIG+G3EJ/wUu67cfvuP0h4mZjvROZY1h5rfpoDLS0ttPJtjLDL1xBy4RLS0tJx7OQZ9OreUfpuAMCiOVPQumVTAICxkSG69RkOIOf4NHZk8Y8nACAzNUE9b0/ITF/FVKtGVZRzKlPktG+6vrkqlHeGjvar76bM1LjQ41G7Vs3lLhj0G5bz/k6e715RNDU1seuXldKPWSAn8c29mujpUQ3zv89JbFs0bYBzf17Eg4fF+9GedxtNnjASA/r0AACUd3FCnSYd/1tWEBb9MA1V3Svh+Ys4qby1leUbXfwpzvbTyXO1tkL5cqhWxRWWFjnHpKkTvyx0/sqeG6tXqQxTE2O583JukufmWgHhkbdx4eIV2FhbSXVez1vx92pIf38EjhgMICcpnDprAYCit3fe+b1KMP+SiyE88rbc1V5l6r445wBlz32qqmNFmEC/Zy2bN5S7sgkAY7/+Dlf/a1aR63aev9A9qrvLJTaeNath36Gcq2S3796XyhgbGSIxKRkXLl7Bzdv38CIuHg18vOBY1gH3ox7iQthfOP/flWgA8Kmj/EHoydPneBEXDwAwNDCQdl4g56qvFP/d+69PClMTY9TI8+vfwtxMeh8fnwCZqQnu//NQGla7VnXpvbeXh1Jx9v98nNwX83Xx8cpd0S5Km5ZN8g37auoPWLFmU4HTxMUnSO/z/v3m6fGqHj1rVsfrnj57IW2D9PQMtOs+UOH8I5W4IpSrQvlyqF/XE+f+DMPWnQewdecBGBjoo5q7Kzq0bYHhg/tAr5hXoStVKC9dEdfU1ISZmSmSU1Lk1jvvftJnyBiF84m4Vfh6KFN3hfHv2h6bt+8DAOw7dBTulSvgwH/tUz9xcZKS+JeJSWjWrle+dsh5FbR/KdpPFLmVp16OnTiLYyfO5isjhMDN23dhZemJfr26Yu6in3HtRgTqNe8CLS0tVPzEGb5NG2B0wEDY29oUa7kA5H6s5K3D+3nquc+nXTB11gI8ex6H4JO/o1JFF9y8fQ9AztV5Tc3C/9xcunI9Jk77odAy8fEJ+RLKWjWqQktLK0981RBy4dJ/8eUcO/LuU161FK+LouPTu/Sm6/um8v6AkTvOKvFPXoXy5eSSZwC4l+f47FmzqvReS0sLNatXKXYCnbf+8x7nq7hVgqGBAZJTUvAiLh5Pnj5/rzc69+zaDj+t2oC0tHR8Nng0gJyE3adOTQzp/6n0w1IRZc+NWlpa8K5dE8Enz+L63zeRlJSM8xf/gq6uDoYO+BRjJn6LP0OvyK1/QRe9GtarLb23VGJ7W1tZwLVieUTeuovzF68gMSkJN8JvwrGsPTq2bYHwyNs4H3pF7hhcv27xE8zinAOUOX6rso4VYROO9yz313PeV95fxMWh6G+k3B0FAK5c+1tqP1TH00NKPi9cvCL9unStWB7WVhZvsSb54yjq7y0zM/m/krW1X50IFd2bUdT8CvLgYbSUPBsbGWLRD1MRtHcDgva++ts2W2QXNPkbsbG2kvucnp6Odb/k/E2lra2NmZMDcWTPBgQf+EX6W7w4N6S8aR0AQFJy8W+iy6WpqYk9W37G7BlfoUWzhnAsa4+UlFRcCPsLk2fOx/jJ3xd7XuaFbG9lJL/BegDK112ThnVhb5eTaO47dBR/nA9D7OOnAICeXdtL5Q78Giwlz64Vy2PjqgUIPvCLXJOMgvav1/eTt5W7jadO/BLrV85Hlw6tUKmCCzQ0NBBx8w5++nkDOvQYjMzMzDeaf0F12LtnJ+mq97ZdB3Ao6NWP1Z5d8l95f93K/22W3o8ZMQiHd61D8IFf5E6I2dkl+/0oqmxWlvw2e/1m0LdRUutbXGZ52g7nbQNbnGNOLmUT17c5VpUWVdwq4fdju/DF4D6oXas6ZKYmePL0GQ78ehwd/YdITSGLUtxzY24ympWVhV37j+Dxk6eoUdUNjern3Btz4eIVuSYVBV39NZO92t5aSm7v3BhiHz/F7v1ByMrKgrenB+r8lzecD3sVg7GRIWpUK/7Dlt7mHFDU/vS+61gRJtClVIVPnKX3f10LlzsBXrx09VW5PP3G5jbjSE/PwM9rtwDIuXKb+0XYufcwHj/JSQiU+RWZl7WVhdRvZlJyMv7O08whtIC4lOHi7Ci9D7tyTXqft+lJUaIfxUrvfZs2wJD+n6JhvTrQU/KmIU3NV1/I1+8aft3rX95nL+Kkm2+qVXHF2JFD0Kh+HbiUc8TzF/H5pncp92q98zYvuXgpf/tfK0tzqb2XsZEhYu9eRFJsuNzr5aMb+Hlx8ZPdXEIIGBsZYdTn/bFv6ypEhJ3E/Rvn4OyUc7NaQW1731Te/eTGheB865EUG47Du9YVOg9l6q4wmpqaUrOj8Mg7+CFPu1T/bq8S6OhHr9rmDR3QC107tkY9b0+kvtaMQ5HiJhkV89RL756dFNbLk3uX0KJpA6lc985tsWn1Qlw+9yti71xE5/Z+AHJuZs17U2hR8h5f8tahc556trOxhl/zRgCAX4N/w869OX/Jf+LihFoer65MFiQ6Juc7amlhhllTxqFJw7qoUdUNj2JiC53u8tUbct/FvLHm3lCZd58Ku6x4XfKWkZmaAMi5mUm6OTHqX+mK+us0NF6dNos6LuR60/XNS5njUUlQtK+6/FfHAHDpyqsmaFlZWUU2i8srb/1fzLONboTflJrbmZvJ3voijyKFbT8hBNwrV8T8777Gb0e2I/rWBWz+32Kp7MEjBfeY8ibnxrxXO3Pvy6nj5QHXiuVhJjNF2JXrCPkvaa/4ibN0Nbck1SsghjqeNaChoYGz5y5IHQ94164p9w9QSVDm+F3a6phNOEqpGlXdULnSJ4i4eQcxsU8w8Ivx6O3fGRcvXZX+VtbV1UGndi2lafI2mM/dsep4ecDSwgxGhoZyJ4R6b9D+GchNMlpjzYbtAICBwyfg63HD8SIuAd/Ne3VzSffO+ds/F0f7Vs1x9HhOFzKz5i6Fvr4+jAwNMOXb/L16FMTJ8VWbttO/n8eOPYehpaWJ6d8vUioW8zy/6oNP/o76db2gr6+HKm6VpJNuQWytraCvr4fU1DTcCL+JtRt3wMbaEnMWrlB48mvTsql0E87YSbOQNDkQqWlpmD57cb6ympqa6N65DVat24rEpGR06DEYXwz+DJYW5vj3USz+jriFA4eDsWLRd0o//CX6USzadR+ILh1aoXKlT2BjbYX7UQ+l9rivdwH2tnp2bYdr/3W31K3P5xgdMBhl7G0R8/gJbt66i0NBJzHqiwGFPjRCmborin+39li6cj2AnG4ggZy/mD9xKSeVccrTZ/PGrbvhXK4s7t6LKvJGMGU0a1wPVpYWePrsObbs2A9zMxmaNa6H7Kws/PNf7xfX/45E2Nmcm8Kat+uFGtXc4FmzOhzsbJCYlISIm6+e2pamxHYbNX46ZnwzJl8dtmvVTK5cv15dcfjoSaSkpOLK1Zyu/4q6eTCXU1kH3L77D549j8P8JatR1b0Slq/epPDHZV5RD6IxZORE9OjSDr+d/VNqvqGnp4sWTRsCAHp0aSv1IjJm0rd4mZgEDQ0NqV1oTpyvjk/lXZxw+a8bSElJxYAvxqN+XS+sXr8VWVlZCmPIe1Vt3S874efbCAb6+oX+cHjT9c0r71XlG+G3cPDX47C0NIdjGfv31o94s8b1pOPaxctXMX7y9/Bt2gC79v1a7OYbQM42yv2XcNbcpdDT1YWlhTm+/3G5VKZrx1bv5Kp2YdtvwU9rcPaPULTybQzHMvYwNDSQuxEvLa3grhnf5NzoVbOaVJ+552xvLw9oaGigtmcNBJ88i6TknF6M3vSm/6I0qJs/b/D28oC5mQyVKrjItX+u/w5iUPbcV5rqmAl0KaWhoYGfF38vdWO3+0AQdh8Ikhs/99tJ0h23AOBVszr09HSlG5pcyjlKf8N51qyGM+fOS2Xf5oswbdJonP0jFJG37uLajQh8OmCU3Phundqga8fWbzTvz/w7Y+0vO3HpynU8ffZC6os59+7s4rC3s0Er38YIOn4aL+LiMeCLnG7QfOrUwt37xb+Jpo6Xh1SfYVeuoX2PnB4QjuzZUGRiqqmpiX69uuLntVuQnp6BkeOnAchpV2htZYknT5/JlR8dMBDbdh9E9KNY3PvngdQeuEL5cvnKAjnb4NyfYbgRfhPnL15R6gp9UW7evoc5C1YoHFfcBKm4Aob0wfFTv+O3s38iPPIOhuXpl7O4lK27wnhUc5d+uObK23wDANr4NYWdrTViYp/gr2vh6Nr7cwA5+1duQve2jIwM8fOS79Fr4CikpaXjp5835Os5xsnxVdL05OlzrFq3FVi3Nd+83Fw/QTUlvj+amhr52qO7V66Igf/d6JXLz7cRbG2spGYuQPH3jwF9ekhdoU37LiextbI0R6UKLgVe+QVyjmk79hyWu/kUACaO+UK6WjliaD8cPX4a5/4MQ9SDaPT/XL4bxAY+XhiZpwePgZ/1wMi/cr6few8exd6DR2FsZIgyDnYK27k3qu8t/RPz49LV+HHpajg5OiD84okSX9+8TIyNULNGFVz+6wbi4hPgP2AkAODrcQHSjanvmrmZDF+PC5B+jCxfvQnLV2+CpqYmXMo5FruLxq4dW+Pgr8exa/8RPH8Rn+9mMdeK5TH9a8X3RLytwrZfZkYmgk+eRfDJ/PccaGpqomvHVoXOW9lzo66uLrxqVpPrcjG3yaW3Vw25OOq94b/GRcl5kJO99ANIX19PaqZRx9ND/gbCN7zwVpg3OfeVljpmE45SzKtWdfwevAu9e3aCg70ttLW1YW4mQ4tmDXFg+xoM6f+pXHl9fT25Rvh18tx4l/cmvLJl7OWu0irLwtwMp37dhnGjhqJSBRfo6enCyNAQnh7VsHjuNKxfOf+Nrxzo6Ohg39ZV+LR7B5iaGMPUxBjdO7fFlrWvfo0aGhgUOZ81y35A756dYGVpDjOZKT7t3gE7Ny0vcrq8rCzNsW39T6hRzQ0GBvpKr8v30yYgYGhf2Nlaw9jIEG39muHwrnUwMMjfP7ClhTmO7duE1i2awNDAABbmMgz4rDs25em6Ki8zmSlOHd6KqV+NQrUqlWFgoA9DAwNUKF8Ondv7Yf3K+ahTSM8VBck9QTasVxt2ttbQ0dGBgYE+qrq7YtrEL/Hj998UPRMl6OrqYv+21Zj/3TfwqlkdJsZG0NfXg7NTWbTybYzlC2ehQxvfQuehbN0VxT9PwqytrZ2vNxkTYyMc3PE/NG5QF8ZGhnCwt8WUr0Zi8oSRb7S8grTybYyzR3fi0+4dUMbBDjo6OrCyNEf1qm4Y+Xl//LJ6kVR23KghaNeqOZwcHWBoYAAdHR2UcyyDwf164vCu9Ur97Rq0dyO6dmgFUxNjmBgboVunNji0c22+fq21tbXl+i6uVqVysfuHHTmsH6ZN/FKKt1G9Oji8a32Rf5/Wq+uJnRuXoUY1N+jp6cLJ0QGzZ3yFCWM+l8ro6eni4I61mDk5EFXdXWFgoC/9czTjm0Ac2C7fB3T/z7ph3KihsLayhIGBPho3qItjB35B+TzNyfIa1LcHAkcMhmNZ+yJvlnzb9X3d+pXz0aJZw/feP3JeY0cOwbxZX6OcYxno6emielU37Njwk1LJlYaGBtatnI8l86bDq2Z1GBkaQk9PFxU/ccbYkUNw6tdt72wdC9t+LX0bYVDfnnCvXBHmZjJoaWnBwlyG5k3qY/+21UX2D/wm58a8zSkd7G2li2J1Xrtx/l1c/VUUQ83qVaROC7y9Xp1DdHV1ULuW8ueUoih7/C5NdawhlLmrgOg9EELk+wIcO3kWnT8dCiCnz94dG5epIjQiyuP3kFDpKXHfThkrdaVFRKTu2ISDSp0hIyfC06Ma6tX1hLnMFFeu/Y2vps6Rxr9p8xAiKhkpKalIeJmI1eu3AcjpBag4vW8QEakLNuFQA17NeiDy9v0Sm1+vIeNxMOg3heMOBv2GXkPGS597DAjE2ZCwEls2kPPY23HffId6zbvAzcsXnw4YhagH0QByngbXo0vJtcMdOmY6tuw6XHRBJUXHPIZXsx5yj2EvzV4mJsGrWQ9Ex+T0MPH9wlVYsuoXlcXz+n72tpTZzj+v34GxU+a+8bLafxqA334v/mPE35XpPyzDjz+tfyfz7txrKMpXayg98avvp11QxsGu2NNfvHIDTdr3fyexFVdp2U4fuyPHz2LgiPxPUyQq7XgF+j0YOmY6rv19Ezra2tDQ1ICttRV8atdA/0875esn8UOzY92CogspqXvntsjMzMKtO/cQF/8SJsZGqObuit7+ndG7R8dS2d+oV7Me2LxqLlwrOKs6lBLx9Zih721ZF6/cwLgp8/DbwfXvbZlUMqwszdGxbUvMmfGVqkMp1NAx09Gkfm306layN8G+D+8jdlUev1r7NkRr34bvfblEb4sJ9Hsyckhv9OrWFkII3PvnX6zetAufff4VNi6fDUsLM1WHV6oM6tsTg/r2fKfLEEKU6IMLiN5EZmam3IMuPhRBezeqOgT6T+6xTEtL/f5QVud1ow/fh3fk/sBpaGigvHNZfPv1SPQaMgG/7DyEL4d9huSUVEz+bgmu/X0T6RkZqFTeGeNHDUCl/x6oEnHzLuYs/h/u/fMQ2traqO5eEQu/f/Xks2t/38SU75ci9vFT1Krhjm8njYSxsSEA4OG/Mfhx2XpcC78FfT09dGrbHAN7d5buQN6+Nwgbt+1HaloaurRvodT6tP80AGMD+qFJgzo4GPQbtu4+jGaNvLF9bxA0NDTQ/9NOcldOjp48h3Vb9iIm9imcytpjbEB/1KiquIutoWOmo0rlCoi4eRfXwm+hgosT5k4fi72Hj2Pn/qPQ1dHB+JED0bRhTpdyf4b+hWX/24qofx9BX08PTRvUwegv+kL/v0dPt/80AF3a++L0uYu4dec+NiyfLbe85JRUTJj2I8xkJpj+1XDcvhtVaJ3n6vtFTtdrA0dOhqaGBgb07oxWzXMecHHmjzCs3rgTcfEv0aRBbUweO0xKmCJu3sXClZtw6859mJoYo59/R3Rup7jHiZ/X70D4zbuwtrLAsVPnIDMxxtQJw5GYmIRFKzchPiER3Tq2RMCgVz2znA+7imVrtiLq4SPYWFkgYHAvNK6fczdyenoGfly2HsG//QFjI0MM7N1FbnnTf1gGEyMjjB3RHwAw5fslCL2c01euYxk7jP68D7z+e5RvUds9JvYp/AePw7Y182FnK9/rQFz8S3w58XukpWegYZs+AIAlc76Wxq/ZtKtE9qW8ivquATlPpZs5bwVOnP4TFuYyjBr6mbSfCSGwfe8R7Nx/DM+ex6FSBWdMGj1Y7iETBcmtq8b1a2PPwWBUr+qKeTPGFbouR46fxaoNO/HseRyMDA3QtUMLDO7TDUDOPr9k9Wb8+ygWZe3tMGpYb3h75n8EbuDkuXCrVB5D+naThs1euBrZQuCbwKHIzMzEmk27ceT470hMSkL1Kq74eswQWFtZQAiBpas34/DR00hNS4elhRnGfNEXDX3k71jPzMpCsw4DsHHFbDg7lcGZPy4icPJcLJnzNerV8cDtu1EY/OVUnNi3Vppm3+ETWL1xF1LT0tChdTN8OewzaVxh++/0H5ZBW0sLSSmpOPfnJVhZmuPrwKHw8qiSb90XrtiIK9fCce3vm1ixdhtqVneT9rF/Hj5C/4BvcPf+A1Su6IKZX4+E3X89Yzx/EY8Fyzcg9PJ1aGhooEVjH4wc2hu6ujoKt234zbtYvHITbt65D01NTbRsWh8TRg0scjsVti4Fxa7oWHbzzn2s37ofMbFPYGJihHYtG+PzAT2lf+yePo/D4pUbceHSdaSlpaNi+XJYOvcbDB2d04Vf3uPX68cDoODzSLYQGPLlVNSuWQ3DB/kDAH5YvAb3o6KxbN5kXLoajnFT5uHzAT2xbsteQAh0ad8CQ/t1h4aGhvSd2LI6p5s/RetmYS4rcFvEJyTi23krEPbX3xBCoKyDLebNGAd7O2uF24moxAh654aMniY27zyUb/iyNVtF3y8mCSGEeJmYJI6ePCeSk1NEalqamLd0rejcZ5TIzs4WQggxIOAbsWbTbpGVlSXS0tJF2JUb0nw8m3YXw8ZMF8+ex4mEl4mi15AJYuW67UIIIVJSUkU7/+Fi885DIj09QzyKeSK6DwgUew+fEEIIcSHsmmjUrq/463qkSE/PED+t2SLqNO8pDhw5pXBdDhw5JT4dPE763M5/uDh19rw0ro6vv9i0/YDIyMgQoZevizq+/uLBw0dCCCHOhoSJ1t2HifDIOyIrK0ucOP2naNZxgHgRl1BgvbXp8bm4fTdKpKWliy/GzRQde48QW3cfFhmZmWLv4ROiWceBIiMjQwghxKW//hbhN++KzMws8eDfGNG132ixZtNuuVg79xkl7v3zr8jMzBLp6RnStnn+Il70+Xyi+HHZ+mLV+es8m3YXEbfuSZ//fRQrPJt2F19/u0gkJiWLx0+eiTY9Ppfq9cmzF6JZxwHi2KlzIjMzS9y6+4/w6zZUnA+7qnD+K9dtF94t/MWJ03+KzMwssWLtNtG6+zAxfc4ykZycIu7ceyB8WvYS4ZF3hBBC3Lx9XzRp319cCLsmsrKyxOWr4aJRu77i3j//CiGEWLF2m/h08Djx+MkzkfAyUYz86nvh2bS7+PdRrBBCiGlzfhLzl66Tlr//15Pi5cskkZGRITZs3S+adRwgEpOSi7XdixJ6+bpo3K6f3LB3sS/lfgeL+q6tXLdd1GneU+w6cExkZGaK0+dChU/LXtKyd+wLEv6Dxol/HkSLjMxMsXX3YdGx9wiRnp6zH+b9TrzuwJFTok7znmL1xp0iPT1DpKSkFrouyckpoo6vv7TvJbxMFNfDbwkhhIh6+EjU8+slTpz+U2RkZorg30JEvVa9xcPo/Nsw+LcQ0bnPKCmO9PQM0azjAHH5WrgQQohFKzeJzwNniCdPn4v09AyxcPkGMXjUVCGEECEXrog2PT4Xj588E0II8Sjmibgf9a/C9Rv51fdi576jQggh5v+0TnTsPUIs/nmTEEKILbsOizHf/CBt89rNe4gfl60XqWlp4u79B6J+689E6OXrQoii999pc34Sjdr2FaGXr4vMzCyxeuMu0c5/uMKYXt/+udr5Dxc9B40VD6NjRWpamhj51fdi2pyfhBBCZGdni37DvxYLlm8QKSmp4kVcghg6ZrpY/r+tCucf+/iZaNSur9ixL0ikpqWJlJRUcemvv4u9nQpbl4Jif/1Y9vufl8T9qH9Fdna2iLh1T7ToMlj8GnxGCCFEVlaW6PP5RDFtzk8iPuGlyMjMFJevhou0tHQhRP7j1+uKOo88jI4VTTv0F6GXr4tTv18Qvp0HiSdPn8tt6+lzlomUlFRx75+Hok2Pz8XBoFNCCMXnlLzrlpaWXui2+Gn1ZjF60myRkpIqMjOzRMSteyIu/mWB60JUUvi/iArZWFkg4WUigJxHMrdsWg8GBvrQ09XFsP49EPXwEZ48fQEg5xnyMbFP8OTZC+jq6qBWDXe5efX17wgLcxlMjI3QrJE3Im7mdH7++5+XYGJihF7d2kJHRxt2tlb4tEtrHD2R83SlIyfOonXzhqhepRJ0dLQxrF936Cvop7i4zGQm+KxHe2hra8PLowoc7KwR+d9jhHfuP4o+PTugcqXy0NTURLNG3ijnWAbnzl8ucH6tfRviExdH6OrqoGmDOkhJTYN/lzbQ1tJCq2b1EZ/wEo9icx7kULO6GypXdIGWlibKOtiiSztfhP11Q25+3Tq0hLOTA7S0NKGjk3Ml+N9HsRg0agqaN66LwOH9pCs2RdV5cQzp2w1GhgawtrKAT+0aCP9vu/x67AxqVnNDiyb1oKWliQouTmjfqgmCTvxe4LzcKpVHs0be0NLKubr1+Olz9Pu0EwwM9FHeuSwqlHdCxK2chzLsORSMdn6NUbtWVWhqasKjWmU0rOuJ4/89Xe/I8d8xoHdnWFtZwMTYCEP7dStwuQDQoXVTGBsbQltbG339OyA7W+DW3X+k8YVt9zdV0vtSrqK+awDg5GiPru1bQFtLC43qecGrZhUEnTyXs+x9RzFsQA84lbWHtpYW/Lu0QVpaOq6H3ypokfLLN8654q+jow19fb0i10VbWwv3ov5FYlIyTIyNUKVyBQDAsVN/wNOjCpo18oa2lhZ8G9eFR9XKOHoy/z7UyMcTcfEJuPb3TQD/HReMjeBRtTKEENi1/yjGDO8LK0tz6Oho44tB/vjrRgRiHj+FtrYW0tLTcef+Q2RmZsLO1grlHBU/+c7LowouXsl5HO/FyzcwpG93XLyc8x0MvXwdtWu+elqfEMDwgf7Q09WFS7myqF6lknTcKmr/BYB63jXh5VEFWlqa6NCqKR7FPkFc/MtibYNc3Tq0RBl7G+jp6qK1bwPp+/l35B08+PcRvhz2GfT19WAmM8GAXp0RdOKcwvn8evwM3CqWR/eOftDT1YW+vh5qVncr9nZ6k3V5/VhW37smyjk6QENDA64VnOHXtD7C/nvc9t+Rd3Dvn4eYOHoITE2Moa2lBY9qlQu8mv66os4jZextMGHUIEz9fim+nbcSU8d/AStLc2n67GyBkUN7/9fHexl07+SHX4PzP6xE0brduvtPodtCW1sb8QmJiPr3EbS0NOFawRkyU+NirRfR22ATDhV6/PQ5TE1yvuipaelYtGIjzp2/jISXiVISF5eQABtrC0wd/wVWbdyFPp9PhImxEXp0aoWenV89FSlvO2oDfT0kpaQCAKJjnuDOvQdyd7wLIWD73xMKnz57IZcYamtrw8ri1YFPWZbm8p3fG+jrITk5J5ZHMU+w7H9b8fP6HdL4zKwsPHn6vMD5WeSZn76entz8cx/skPzfut6IuI1la7bi9r0opKWlIzMrK9+J3k7BgwuO/xYCY2MjdOvQUm54UXVeHPLbRR8vk3J65XgU+xjnLlyW2y7Z2dnw+O8JUIrI1YW+7n/zl6+P5Dzb/eLl63K9qWRlZcHIsBEA4Omz57C3ffUXp51twX93ZmdnY8W67Tj+Wwiev4iHhoYGkpJT5E7whW33N1XS+1Kuor5rAOTqBgDsbK2keUfHPsHU75fKPYQhIzMTsU+K99RDaysLuWkLWxcDA30s/O4r/LLjEJas+gUVXJzwxYCe8KpZFY+fPMsXZxkHGzx+kr8OdHV14NvEB4ePnUE190o4fOw02rTI2Rfi4l8iJTUNQ0ZPgwZe3aCro62N2MfP4FWzKob174GV67bjXtRD1KlVDaM/74sy9jb5luNVswo27TiAF3EJeBGfgFbNG2DRyo1IeJmIy1fDMXygv1TWyNBA7uEsBvp6SEpOyanjIvZfALAyN3s1rUHusSAFZjITxRWvgNVrx828+9fLxCQ06zhQGi8gkJ2VrXA+MbFP4VjWXuG44mynN1mX149lIaFXsHrDLvzz8BEyszKRkZ6JenU8ctYn9gmsrSyk5mzKKuo8AgBNG9bBwhUbYW1lnq95j56ujtzxy97WGo8L+a7mXbeitkWfnh2Qlp6OiTMWIikpGS2a1sOIIb3feF2JiosJtIpkZmXh9B+hqO9dEwDwy46DCL95F2uWzISttSVeJiahaYcByH3MTdkydpg5aQSEEPjreiSGj/sW1atUglul8oUux9bGEm6VymP9su8UjreyNEdM7KtH8WZmZuLp8xcKy74tWxtL9OjcKl+iWlK+mbUY7Vs1xY/fjoeBgT627DqMQ0d/kyujqZm/B48+/h1x524URk74Dkt++BrGRjltx5Wpc2V7BrG1tkKTBnUwe8popaYr9vxtLOHfpQ1GDu2tcLyVpQUexT5BVbeKACC3D7wu6MTvOHridyz94Rs4lbWHhoYGmnYYAJTQM5g036BXlbfZl4r6rgE5CUdeMbHPUL1KpZxlW1tibEB/KTlR1uvrW9S61KlVDXVqVUNmZiZ27j+GsVPn4dT+dbCxtsRf1yPkyj6KeSJd+XxdmxaNMHbyXAzu2w1/XLiC0V/kPABFZmoMfX09bFj2PZydFD+htHtHP3Tv6IfExGTMXrQa85euVXg/gGsFF2RkZGLHviDUqu4GLS1NeFStjK27f4W2thY+cVH8dL/XFbX/KkvZfczWxhLmZjIc3bWqWOXtbK1w/uJVheOU3U6vKyj2vMeyjIxMjJ/2IyZ+OQgtm9aHrq4OfvxpPaJjc7qltLe1xpOnz5GWng493fyJZVHHr6LOIwCwaMUmlC9XFrFPnmHbniPw7/Kqv/609Aw8fxEvJdExj5/C5r9Hrxe1bkVtC0MDfYwa+hlGDf0M/z56jDHf/IBd+4/isx7tFZYnKilswqEC96P+xfQ5y5CYlIze3XIePpCUnAI9XR2YGhshOSUVy9ZslZvm0LHTePY8DhoaGjA2NoSGpkaxHiPb0McTz1/EYef+o0hLT0dWVjbuR0Xj4n9/7fk1q48jJ87ievgtZGRk5tzQk5JW8iuNnJPwpu05yYsQAqmpaTgfdrXYV+6KkpScAhNjQxgY6OPePw+x68CxYk2nqaGBKeM/h4tzWYyY8B0SE5MBKFfnFuYyPIyOKXasbVo0wsXL13HizJ/IzMxEZmYmIm/fx42I28WeR2G6tGuBg0d/w8XL15GVlY309AxcvXET9/55CCBnu6/fsh9Pnj7Hy8QkrNm0q8B5JSWnQFtbG2YyU2kfSf7vSmFx5PaJndvH9OsszM2QnJKC5y/iiz3Pt9mXivquAUDUg0fYe+g4MrOy8Pufl3Dx8nW0bFpPWvbKddtxPyqnb/LEpGT8di5UunqqrMLW5dnzOJw6ewFJySnQ0tKCkaEBtP97LHfLpvUQduUGfjsXisysLJw8cx6XroajZdP6CpfjUbUyTIyNMOOHZXBzLY+yDrYAAE1NTXRt3wILV2xEzOOcH1Jx8S9x7FROc4kbEbfx1/VIZGRkQk9PFwb6egU+GlxLSxM1q7thy+7D0k2mXjWrYsvuw/Cs4V7sH5pF7b/Kyvl+xha7vLtrBdhaW2L5/7YhKTkFQgg8inlSYBOh1r4NcSPiNnYdOIb09Aykpqbh8tVwAMpvpzeJPT0jA+np6ZCZmkBXVwfXw28hKE8TEXfXT1DO0QFzFq3By8QkZGZl4cq1CKSnZ+RZRsHHr6LOI6fPXcTx0yH49uuR+H7yl1ixbhtu3XnVxEtTUwM/rdmC1LR03I+Kxs59R6UbrYtS1LY4GxKGfx5EIzs7O+f7oa2l1KPrid4Ur0C/J0tXb8bKdduhoakBGysL1KtTE5tWzJF+kffu3g6TZy1Gy65DYCYzxecDesolgBfCrmHpz78gOSUVFuZm+HLYZ8Xqs9PQQB/L503B4lW/YM3GXUhLz0BZB1v06dkBAODtWR1fDOiJCdN+RFp6Orq0b1Hsq0TKalTPC+npGZg1/2f8+ygWuro6qOL6Cb76smQe//v1mKFYuGIDlq7aDLdK5eHXrD5Onwst1rSampqYPHYYZi9ajeHjv8VPc79Rqs6/GNAT85euw6z5P6Off0e0bFav0OXZWFtg6Q/fYOmqzfh+wWoIkQ1np7L4fEAPZVdbocoVXfDdN19i+drtuB/1EBoaOW0Dv/w8p6eLQX264EVcPHoOGgsjQ0MM+qwLfv/zksJ5tWvZGBfCrqH9p8NhZGiAT7u2hU2ev26LEhP7FPa21gVecXJ2ckDH1s3QfUAgsrKysEjBlc3Xvc2+VNR3DQB86njgWvgtLFq5CeZmppj59Ug4/fcXfc/OraClpYkJ0+Yj9skzGBrow6NaZbn2vcoobF2EpsDWPb9ixtzlEELAqaw9fpgWCE1NTTiWscPcGeOwbM0WTJv9E8rY22D+zHFSYqxImxaNsGrDTnwdKN/P94jBvbBh2358MXYmnj2Pg8zUBLVrVUXLpvWQlJyCRSs24mF0LLS1tVDNvRImjR5S4DK8PKrgbEiYVB91alXFvKUpUkJdHEXtv8rq1a0tpv+wHE3a94dHtcpF7mNaWppY9P1ELF21Gd37j0FScgpsbazQpYBecmytLbF8/lQsXrkJP63eAh0dbfg1q4+a1d3eaDspG7uRoQEmjBqE7xasQkpKKmrVcEeLJvUQ+yTnB5GmpiYWfvcVFqzYiK79RiM9PQOVKjhLvZG8fvzq36uT3PwLO488efoc385fgWkThsPK0hxWluYY2rc7vpm1GBtXzvlvegNU+sQZHXvn/KPXuW1ztPNrXKz1L2pbPPg3BvN/WodnL+JhaKCPZg2939m/nER5aQhRQv/DEhEpsGrDTlhamKGrkl0kEtGHjw9KInXFK9BE9E4N7ddd1SEQERGVKLaBJiIiIiJSAptwEBEREREpgVegiYiIiIiUwASaiIiIiEgJTKCJiIiIiJTAXjjeoezsbERHR8PExETpJ9URERGpCyEEXr58CQcHh2I9BIyo1BMqVK5cOQEg32v48OFCCCFSUlLE8OHDhYWFhTAyMhJdunQRMTExhc4zOztbTJkyRdjZ2Ql9fX3RvHlzcfPmTbkyz549E7169RImJiZCJpOJgQMHipcvX8qV+euvv0SDBg2Enp6eKFu2rPjhhx+UXr8HDx4oXD+++OKLL774+hhfDx48UPpcSlQaqfQKdGhoKLKysqTP169fR4sWLdC9e06/sWPGjMHhw4exc+dOyGQyjBgxAl26dMG5c+cKnOfcuXOxZMkSbNiwAS4uLpgyZQr8/Pzw999/Q19fHwDQu3dvPHr0CMHBwcjIyMCAAQMwdOhQbNmyBQCQkJCAli1bwtfXFytXrsS1a9cwcOBAmJmZYejQoQUu+3UmJiYAgAcPHsDU1FTp+iGit3d9aT8AQNWRG1QcCdHHKyEhAY6OjtJ5kehDV6q6sRs9ejQOHTqEW7duISEhAdbW1tiyZQu6desGAIiIiICbmxtCQkJQt27dfNMLIeDg4ICxY8di3LhxAID4+HjY2tpi/fr18Pf3R3h4ONzd3REaGgovLy8AQFBQENq0aYOHDx/CwcEBK1aswDfffIOYmBjo6uoCACZOnIh9+/YhIiKiwPjT0tKQlpYmfc49YMTHxzOBJlKRqz/mPB69+tgdKo6E6OOVkJAAmUzG8yGpjVLTECk9PR2//PILBg4cCA0NDYSFhSEjIwO+vr5SmcqVK8PJyQkhISEK53Hv3j3ExMTITSOTyeDt7S1NExISAjMzMyl5BgBfX19oamri/PnzUplGjRpJyTMA+Pn5ITIyEi9evChwHWbPng2ZTCa9HB0d36wyiIiIiKjUKjUJ9L59+xAXF4f+/fsDgHT118zMTK6cra0tYmJiFM4jd7itrW2B08TExMDGxkZuvLa2NiwsLOTKKJpH3mUoMmnSJMTHx0uvBw8eFLLGRERERPQhKjW9cPzvf/9D69at4eDgoOpQ3pienh709PRUHQYR5aFnUUbVIRARkZopFQn0P//8g+PHj2PPnj3SMDs7O6SnpyMuLk7uKnRsbCzs7OwUzid3eGxsLOzt7eWm8fDwkMo8fvxYbrrMzEw8f/5cmt7Ozg6xsbFyZXI/F7RsIiqdXAcsVHUIRESkZkpFE45169bBxsYGbdu2lYZ5enpCR0cHJ06ckIZFRkYiKioKPj4+Cufj4uICOzs7uWkSEhJw/vx5aRofHx/ExcUhLCxMKnPy5ElkZ2fD29tbKnPmzBlkZGRIZYKDg+Hq6gpzc/OSWWkiIiIi+iCpPIHOzs7GunXr0K9fP2hrv7ogLpPJMGjQIAQGBuLUqVMICwvDgAED4OPjo7AHDgDQ0NDA6NGjMWvWLBw4cADXrl1D37594eDggE6dOgEA3Nzc0KpVKwwZMgQXLlzAuXPnMGLECPj7+0vNR3r16gVdXV0MGjQIN27cwPbt27F48WIEBga+8/ogopIV88cOxPzBHjiIiKjkqLwJx/HjxxEVFYWBAwfmG7dw4UJoamqia9euSEtLg5+fH5YvXy5XxtnZGf3798f06dMBABMmTEBSUhKGDh2KuLg4NGjQAEFBQVIf0ACwefNmjBgxAs2bN5fmv2TJEmm8TCbDsWPHEBAQAE9PT1hZWWHq1KlK9QFNRKXD45BdAAC7ej1UHAkREamLUtUPtLKSk5NhaWmJI0eOoEmTJqoOJx/2e0mkeuwHmkj1eD4kdaPyJhxv49SpU2jWrFmpTJ6JiIiISD2pvAnH22jbtq3cjYdERO+Ska2bqkNQKCk2XNUhEBF9VD7oBJqI1FdJJatrOxoAAHxKafJLREQfHibQRKTWLkZnqToEIiJSM0ygiUitLQ9NV3UIRESkZj7omwiJiIiIiN43JtBEpNaG19bF8Nq6qg6DiIjUCJtwEJFa83LQUnUIRESkZphAE1Gp7Z6NiIioNGITDiIiIiIiJTCBJiIiIiJSAhNoIiIiIiIlsA00Eam1/REZqg6BiIjUDBNoIlJr+yMzVR0CERGpGTbhICIiIiJSAhNoIlJrs5rpYVYzPVWHQUREaoRNOIhIrTmY8DoBERGVLJ5ZiIiIiIiUwASaiIiIiEgJTKCJiIiIiJTABJqIiIiISAm8iZCI1Nry0HRVh0BERGqGCTQRqbWL0VmqDoGIiNQMm3AQERERESmBCTQRqbW1HQ2wtqOBqsMgIiI1wgSaiIiIiEgJKk+g//33X3z22WewtLSEgYEBqlWrhosXL0rjhRCYOnUq7O3tYWBgAF9fX9y6davI+S5btgzOzs7Q19eHt7c3Lly4IDc+NTUVAQEBsLS0hLGxMbp27YrY2Fi5MlFRUWjbti0MDQ1hY2OD8ePHIzMzs2RWnIiIiIg+SCpNoF+8eIH69etDR0cHR44cwd9//40ff/wR5ubmUpm5c+diyZIlWLlyJc6fPw8jIyP4+fkhNTW1wPlu374dgYGBmDZtGi5duoQaNWrAz88Pjx8/lsqMGTMGBw8exM6dO3H69GlER0ejS5cu0visrCy0bdsW6enp+OOPP7BhwwasX78eU6dOfTeVQUREREQfBA0hhFDVwidOnIhz587h7NmzCscLIeDg4ICxY8di3LhxAID4+HjY2tpi/fr18Pf3Vzidt7c3ateujZ9++gkAkJ2dDUdHR4wcORITJ05EfHw8rK2tsWXLFnTr1g0AEBERATc3N4SEhKBu3bo4cuQI2rVrh+joaNja2gIAVq5cia+++gpPnjyBrq5uvuWmpaUhLS1N+pyQkABHR0fEx8fD1NT0zSuK6B0zsnVTdQjvTG7754H7U1QcybuTFBuu6hCICpWQkACZTMbzIakNlV6BPnDgALy8vNC9e3fY2NigZs2aWL16tTT+3r17iImJga+vrzRMJpPB29sbISEhCueZnp6OsLAwuWk0NTXh6+srTRMWFoaMjAy5MpUrV4aTk5NUJiQkBNWqVZOSZwDw8/NDQkICbty4oXDZs2fPhkwmk16Ojo5vUCtEREREVJqpNIG+e/cuVqxYgYoVK+Lo0aP44osvMGrUKGzYsAEAEBMTAwBySWzu59xxr3v69CmysrIKnSYmJga6urowMzMrtIyieeSN63WTJk1CfHy89Hrw4EFRVUBE79jkk6mYfLLgJl9ERETKUumDVLKzs+Hl5YXvv/8eAFCzZk1cv34dK1euRL9+/VQZ2hvR09ODnp6eqsMgojyiX6qslRoREakplV6Btre3h7u7u9wwNzc3REVFAQDs7OwAIF/vGLGxsdK411lZWUFLS6vQaezs7JCeno64uLhCyyiaR964iKj0czDRgIOJhqrDICIiNaLSBLp+/fqIjIyUG3bz5k2UK1cOAODi4gI7OzucOHFCGp+QkIDz58/Dx8dH4Tx1dXXh6ekpN012djZOnDghTePp6QkdHR25MpGRkYiKipLK+Pj44Nq1a3I9dwQHB8PU1DRf0k9EpdesZvqY1Uxf1WEQEZEaUWkTjjFjxqBevXr4/vvv0aNHD1y4cAGrVq3CqlWrAAAaGhoYPXo0Zs2ahYoVK8LFxQVTpkyBg4MDOnXqVOB8AwMD0a9fP3h5eaFOnTpYtGgRkpKSMGDAAAA5NyIOGjQIgYGBsLCwgKmpKUaOHAkfHx/UrVsXANCyZUu4u7ujT58+mDt3LmJiYjB58mQEBASwmQYRERHRR0ylCXTt2rWxd+9eTJo0CTNnzoSLiwsWLVqE3r17S2UmTJiApKQkDB06FHFxcWjQoAGCgoKgr//qilKTJk3g7OyM9evXAwB69uyJJ0+eYOrUqYiJiYGHhweCgoLkbgpcuHAhNDU10bVrV6SlpcHPzw/Lly+XxmtpaeHQoUP44osv4OPjAyMjI/Tr1w8zZ8589xVDRERERKWWSvuBLinlypXDjBkz0L9/f1WHIof9XtKHgv1Af9jYDzSVdjwfkrpR+aO839aNGzcgk8nQt29fVYdCRERERB8BlTbhKAlVqlTB1atXVR0GEREREX0kPvgEmoioMOrcdIOIiFTjg2/CQURERET0PjGBJiK15uWgBS8HLVWHQUREaoQJNBGpteG1dTG8tq6qwyAiIjXCBJqIiIiISAlMoImIiIiIlMAEmoiIiIhICUygiYiIiIiUwH6giUitRb/MVnUIRESkZphAE5Fam3wyTdUhEBGRmmETDiIiIiIiJTCBJiK11tFVGx1d+WcbERGVHJ5ViEitdaysAwDYH5mp4kiIiEhd8Ao0EREREZESmEATERERESmBCTQRERERkRKYQBMRERERKYE3ERKRWrsYnaXqEIiISM0wgSYitbY8NF3VIRARkZphEw4iIiIiIiUwgSYitTa8ti6G19ZVdRhERKRG2ISDiNSal4OWqkMgIiI1wyvQRERERERKYAJNRERERKQElSbQ06dPh4aGhtyrcuXK0vjU1FQEBATA0tISxsbG6Nq1K2JjYwudpxACU6dOhb29PQwMDODr64tbt27JlXn+/Dl69+4NU1NTmJmZYdCgQUhMTJQrc/XqVTRs2BD6+vpwdHTE3LlzS27FiYiIiOiDpfIr0FWqVMGjR4+k1++//y6NGzNmDA4ePIidO3fi9OnTiI6ORpcuXQqd39y5c7FkyRKsXLkS58+fh5GREfz8/JCamiqV6d27N27cuIHg4GAcOnQIZ86cwdChQ6XxCQkJaNmyJcqVK4ewsDDMmzcP06dPx6pVq0q+AoiIiIjog6Lymwi1tbVhZ2eXb3h8fDz+97//YcuWLWjWrBkAYN26dXBzc8Off/6JunXr5ptGCIFFixZh8uTJ6NixIwBg48aNsLW1xb59++Dv74/w8HAEBQUhNDQUXl5eAIClS5eiTZs2mD9/PhwcHLB582akp6dj7dq10NXVRZUqVXDlyhUsWLBALtF+XVpaGtLS0qTPCQkJb1U3RPT29kdkqDoEIiJSMyq/An3r1i04ODigfPny6N27N6KiogAAYWFhyMjIgK+vr1S2cuXKcHJyQkhIiMJ53bt3DzExMXLTyGQyeHt7S9OEhITAzMxMSp4BwNfXF5qamjh//rxUplGjRtDVfdX1lZ+fHyIjI/HixYsC12X27NmQyWTSy9HR8Q1qhIhK0v7ITOyPzFR1GEREpEZUmkB7e3tj/fr1CAoKwooVK3Dv3j00bNgQL1++RExMDHR1dWFmZiY3ja2tLWJiYhTOL3e4ra1tgdPExMTAxsZGbry2tjYsLCzkyiiaR95lKDJp0iTEx8dLrwcPHhRRA0RERET0oVFpE47WrVtL76tXrw5vb2+UK1cOO3bsgIGBgQojezN6enrQ09NTdRhElMesZjnfyckn04ooSUREVDwqb8KRl5mZGSpVqoTbt2/Dzs4O6enpiIuLkysTGxursM00AGn46z115J3Gzs4Ojx8/lhufmZmJ58+fy5VRNI+8yyCiD4ODiSYcTErVoY6IiD5wpeqskpiYiDt37sDe3h6enp7Q0dHBiRMnpPGRkZGIioqCj4+PwuldXFxgZ2cnN01CQgLOnz8vTePj44O4uDiEhYVJZU6ePIns7Gx4e3tLZc6cOYOMjFc3HwUHB8PV1RXm5uYlus5ERERE9GFRaQI9btw4nD59Gvfv38cff/yBzp07Q0tLC59++ilkMhkGDRqEwMBAnDp1CmFhYRgwYAB8fHwU9sABABoaGhg9ejRmzZqFAwcO4Nq1a+jbty8cHBzQqVMnAICbmxtatWqFIUOG4MKFCzh37hxGjBgBf39/ODg4AAB69eoFXV1dDBo0CDdu3MD27duxePFiBAYGvq+qISIiIqJSSqVtoB8+fIhPP/0Uz549g7W1NRo0aIA///wT1tbWAICFCxdCU1MTXbt2RVpaGvz8/LB8+XK5eTg7O6N///6YPn06AGDChAlISkrC0KFDERcXhwYNGiAoKAj6+vrSNJs3b8aIESPQvHlzaf5LliyRxstkMhw7dgwBAQHw9PSElZUVpk6dWmgXdkRERET0cdAQQghVB/GmkpOTYWlpiSNHjqBJkyaqDiefhIQEyGQyxMfHw9TUVNXhEBXIyNZN1SG8M2s75tyQPHB/ioojeXeSYsNVHQJRoXg+JHWj8gepvI1Tp06hWbNmpTJ5JqLSYXlouqpDICIiNfNBX4Eu7fiLmz4U6nwF+mPAK9BU2vF8SOqmVPXCQURERERU2jGBJiK1trajgdQOmoiIqCQwgSYiIiIiUgITaCIiIiIiJTCBJiIiIiJSAhNoIiIiIiIlMIEmIiIiIlLCB/0gFSKiokw+marqEIiISM0wgSYitRb9ks+KIiKiksUmHESk1hxMNOBgoqHqMIiISI3wCjQRqbVZzfQBAAP3p6g4EiIiUhe8Ak1EREREpAQm0ERERERESmACTURERESkBCbQRERERERKYAJNRERERKQE9sJBRGqNvW8QEVFJ4xVoIiIiIiIlMIEmIrXm5aAFLwctVYdBRERqhAk0Eam14bV1Mby2rqrDICIiNcI20ERERCpkZOum6hDySYoNV3UIRKUar0ATERERESmBCTQRERERkRKUTqAvXbqEa9euSZ/379+PTp064euvv0Z6evobBzJnzhxoaGhg9OjR0rDU1FQEBATA0tISxsbG6Nq1K2JjYwudjxACU6dOhb29PQwMDODr64tbt27JlXn+/Dl69+4NU1NTmJmZYdCgQUhMTJQrc/XqVTRs2BD6+vpwdHTE3Llz33jdiIiIiEh9KJ1ADxs2DDdv3gQA3L17F/7+/jA0NMTOnTsxYcKENwoiNDQUP//8M6pXry43fMyYMTh48CB27tyJ06dPIzo6Gl26dCl0XnPnzsWSJUuwcuVKnD9/HkZGRvDz80NqaqpUpnfv3rhx4waCg4Nx6NAhnDlzBkOHDpXGJyQkoGXLlihXrhzCwsIwb948TJ8+HatWrXqj9SMi1Yl+mY3ol9mqDoOIiNSIhhBCKDOBTCbDpUuX8Mknn+CHH37AyZMncfToUZw7dw7+/v548OCBUgEkJiaiVq1aWL58OWbNmgUPDw8sWrQI8fHxsLa2xpYtW9CtWzcAQEREBNzc3BASEoK6devmm5cQAg4ODhg7dizGjRsHAIiPj4etrS3Wr18Pf39/hIeHw93dHaGhofDy8gIABAUFoU2bNnj48CEcHBywYsUKfPPNN4iJiYGubs7d+xMnTsS+ffsQERFR7HVLSEiATCZDfHw8TE1NlaoXovepNN7ERMXHG74+bKXx+1fS+xTPh6RulL4CLYRAdnbO1Zzjx4+jTZs2AABHR0c8ffpU6QACAgLQtm1b+Pr6yg0PCwtDRkaG3PDKlSvDyckJISEhCud17949xMTEyE0jk8ng7e0tTRMSEgIzMzMpeQYAX19faGpq4vz581KZRo0aSckzAPj5+SEyMhIvXrwocF3S0tKQkJAg9yIiIiIi9aJ0Au3l5YVZs2Zh06ZNOH36NNq2bQsgJ3m1tbVVal7btm3DpUuXMHv27Hzjcq/+mpmZyQ23tbVFTEyMwvnlDn89jrzTxMTEwMbGRm68trY2LCws5MoomkfeZSgye/ZsyGQy6eXo6FhgWSJ6Pzq6aqOjK3vsJCKikqN0Ar1o0SJcunQJI0aMwDfffIMKFSoAAHbt2oV69eoVez4PHjzAl19+ic2bN0NfX1/ZMEqlSZMmIT4+Xnop25yFiEpex8o66FhZR9VhEBGRGlH6skz16tXleuHINW/ePGhpFf9xuWFhYXj8+DFq1aolDcvKysKZM2fw008/4ejRo0hPT0dcXJzcVejY2FjY2dkpnGfu8NjYWNjb28tN4+HhIZV5/Pix3HSZmZl4/vy5NL2dnV2+3j5yPxe0bADQ09ODnp5eEWtORERERB+yN+oHOi4uDmvWrMGkSZPw/PlzAMDff/+dLzEtTPPmzXHt2jVcuXJFenl5eaF3797Sex0dHZw4cUKaJjIyElFRUfDx8VE4TxcXF9jZ2clNk5CQgPPnz0vT+Pj4IC4uDmFhYVKZkydPIjs7G97e3lKZM2fOICMjQyoTHBwMV1dXmJubF3sdiYiIiEj9KH0F+urVq2jevDnMzMxw//59DBkyBBYWFtizZw+ioqKwcePGYs3HxMQEVatWlRtmZGQES0tLafigQYMQGBgICwsLmJqaYuTIkfDx8VHYAwcAqR/pWbNmoWLFinBxccGUKVPg4OCATp06AQDc3NzQqlUrDBkyBCtXrkRGRgZGjBgBf39/ODg4AAB69eqFGTNmYNCgQfjqq69w/fp1LF68GAsXLlS2uoiIiIhIzSh9BTowMBADBgzArVu35Nout2nTBmfOnCnR4BYuXIh27dqha9euaNSoEezs7LBnzx65Ms7Ozpg+fbr0ecKECRg5ciSGDh2K2rVrIzExEUFBQXKxbt68GZUrV0bz5s3Rpk0bNGjQQK6PZ5lMhmPHjuHevXvw9PTE2LFjMXXqVLm+oomIiIjo4/RW/UCbmJjgr7/+Qvny5fHPP//A1dVV7oEl71pycjIsLS1x5MgRNGnS5L0tt7jY7yV9KEpjP7QlZXjtnO4ol4e++ZNSSzv2A/1hK43fP/YDTVQ4pZtw6OnpKezf+ObNm7C2ti6RoIrr1KlTaNasWalMnomodFDnxDnXx5CAERGVJko34ejQoQNmzpwp3WCnoaGBqKgofPXVV+jatWuJB1iYtm3b4vDhw+91mURERET0cVM6gf7xxx+RmJgIGxsbpKSkoHHjxqhQoQJMTEzw3XffvYsYiYje2PDaulIzDiIiopKgdBMOmUyG4OBg/P7777h69SoSExNRq1atfI/iJqL8SuNf7erOy6H4/dMTEREVxxs/37ZBgwZo0KBBScZCRERERFTqFSuBXrJkSbFnOGrUqDcOhoiIiIiotCtWAv36A0SePHmC5ORk6RHbcXFxMDQ0hI2NDRNoIiIiIlJrxbqJ8N69e9Lru+++g4eHB8LDw/H8+XM8f/4c4eHhqFWrFr799tt3HS8RERERkUop3QZ6ypQp2LVrF1xdXaVhrq6uWLhwIbp164bevXuXaIBERG9jf0SGqkMgIiI1o3QC/ejRI2RmZuYbnpWVhdjY2BIJioiopOyPzH+8IiIiehtK9wPdvHlzDBs2DJcuXZKGhYWF4YsvvmBXdkRERESk9pROoNeuXQs7Ozt4eXlBT08Penp6qFOnDmxtbbFmzZp3ESMR0Rub1UwPs5rpqToMIiJSI0o34bC2tsavv/6KmzdvIiIiAgBQuXJlVKpUqcSDIyJ6Ww4mSl8nICIiKtQbP0ilUqVKTJqJiIiI6KPzRgn0w4cPceDAAURFRSE9PV1u3IIFC0okMCIiIiKi0kjpBPrEiRPo0KEDypcvj4iICFStWhX379+HEAK1atV6FzFSHka2bqoOIZ+k2HBVh0BERET03ijdOHDSpEkYN24crl27Bn19fezevRsPHjxA48aN0b1793cRIxERERFRqaF0Ah0eHo6+ffsCALS1tZGSkgJjY2PMnDkTP/zwQ4kHSET0NpaHpmN5aHrRBYmIiIpJ6QTayMhIavdsb2+PO3fuSOOePn1acpEREZWAi9FZuBidpeowiIhIjSjdBrpu3br4/fff4ebmhjZt2mDs2LG4du0a9uzZg7p1676LGImIiIiISg2lE+gFCxYgMTERADBjxgwkJiZi+/btqFixInvgIKJSZ21HAwDAwP0pKo6EiIjUhVIJdFZWFh4+fIjq1asDyGnOsXLlyncSGBERERFRaaRUG2gtLS20bNkSL168eFfxEBERERGVakrfRFi1alXcvXv3XcRCRERERFTqKZ1Az5o1C+PGjcOhQ4fw6NEjJCQkyL2IiIiIiNRZsdtAz5w5E2PHjkWbNm0AAB06dICGhoY0XggBDQ0NZGWxuygiIiIiUl/FvgI9Y8YMJCUl4dSpU9Lr5MmT0iv3szJWrFiB6tWrw9TUFKampvDx8cGRI0ek8ampqQgICIClpSWMjY3RtWtXxMbGFjpPIQSmTp0Ke3t7GBgYwNfXF7du3ZIr8/z5c/Tu3RumpqYwMzPDoEGDpJ5Fcl29ehUNGzaEvr4+HB0dMXfuXKXWjYhKh8knUzH5ZKqqwyAiIjVS7CvQQggAQOPGjUts4WXLlsWcOXNQsWJFCCGwYcMGdOzYEZcvX0aVKlUwZswYHD58GDt37oRMJsOIESPQpUsXnDt3rsB5zp07F0uWLMGGDRvg4uKCKVOmwM/PD3///Tf09fUBAL1798ajR48QHByMjIwMDBgwAEOHDsWWLVsAAAkJCWjZsiV8fX2xcuVKXLt2DQMHDoSZmRmGDh1aYutPRO9e9Euh6hCIiEjNaIjczLgImpqaiI2NhbW19TsNyMLCAvPmzUO3bt1gbW2NLVu2oFu3bgCAiIgIuLm5ISQkROFDW4QQcHBwwNixYzFu3DgAQHx8PGxtbbF+/Xr4+/sjPDwc7u7uCA0NhZeXFwAgKCgIbdq0wcOHD+Hg4IAVK1bgm2++QUxMDHR1dQEAEydOxL59+xAREVHsdUlISIBMJkN8fDxMTU3ftmoAAEa2biUyn5KUFBuu6hA+GKVx+6k7B5OcpmZMpN8vHheKrzQeF0p6+72L8yGRKil1E2GlSpVgYWFR6OtNZWVlYdu2bUhKSoKPjw/CwsKQkZEBX19fqUzlypXh5OSEkJAQhfO4d+8eYmJi5KaRyWTw9vaWpgkJCYGZmZmUPAOAr68vNDU1cf78ealMo0aNpOQZAPz8/BAZGVloF35paWm8qZKolJnVTB+zmumrOgwiIlIjSj1IZcaMGZDJZCUawLVr1+Dj44PU1FQYGxtj7969cHd3x5UrV6CrqwszMzO58ra2toiJiVE4r9zhtra2BU4TExMDGxsbufHa2tqwsLCQK+Pi4pJvHrnjzM3NFS5/9uzZmDFjRjHWmoiIiIg+VEol0P7+/vmSz7fl6uqKK1euID4+Hrt27UK/fv1w+vTpEl3G+zJp0iQEBgZKnxMSEuDo6KjCiIiIiIiopBU7gc7bZV1J0tXVRYUKFQAAnp6eCA0NxeLFi9GzZ0+kp6cjLi5O7ip0bGws7OzsFM4rd3hsbCzs7e3lpvHw8JDKPH78WG66zMxMPH/+XJrezs4uX28fuZ8LWjYA6OnpQU9PrxhrTUREREQfqmK3gS7mvYZvLTs7G2lpafD09ISOjg5OnDghjYuMjERUVBR8fHwUTuvi4gI7Ozu5aRISEnD+/HlpGh8fH8TFxSEsLEwqc/LkSWRnZ8Pb21sqc+bMGWRkZEhlgoOD4erqWmDzDSIiIiL6OBT7CnR2dnaJL3zSpElo3bo1nJyc8PLlS2zZsgW//fYbjh49CplMhkGDBiEwMBAWFhYwNTXFyJEj4ePjo7AHDiDnKvno0aMxa9YsVKxYUerGzsHBAZ06dQIAuLm5oVWrVhgyZAhWrlyJjIwMjBgxAv7+/nBwcAAA9OrVCzNmzMCgQYPw1Vdf4fr161i8eDEWLlxY4nVARERERB8WpdpAl7THjx+jb9++ePToEWQyGapXr46jR4+iRYsWAICFCxdCU1MTXbt2RVpaGvz8/LB8+XK5eTg7O6N///6YPn06AGDChAlISkrC0KFDERcXhwYNGiAoKEjqAxoANm/ejBEjRqB58+bS/JcsWSKNl8lkOHbsGAICAuDp6QkrKytMnTqVfUATfYAG7k9RdQhERKRmit0PdGmUnJwMS0tLHDlyBE2aNFF1OPmwH2h6XWncfkTvAo8LxVcajwvsB5qocEr1A13anDp1Cs2aNSuVyTMRlQ5eDlrwctBSdRhERKRGPugEum3btjh8+LCqwyCiUmx4bV0Mr61bdEEiIqJi+qATaCIiIiKi940JNBERERGREphAExEREREpgQk0EREREZESVNoPNBHRuxb9suQfAkVERB83JtBEpNYmn0xTdQhERKRm2ISDiIiIiEgJTKCJSK11dNVGR1f+2UZERCWHZxUiUmsdK+sAAPZHZqo4EiIiUhe8Ak1EREREpAQm0ERERERESmACTURERESkBCbQRERERERK4E2ERKTWLkZnqToEIiJSM0ygiUitLQ9NV3UIRESkZtiEg4iIiIhICUygiUitDa+ti+G1dVUdBhERqRE24SAitebloKXqEIiISM3wCjQRERERkRKYQBMRERERKYEJNBERERGREphAExEREREpgTcREpFa2x+RoeoQiIhIzTCBJiK1tj8yU9UhEBGRmlFpE47Zs2ejdu3aMDExgY2NDTp16oTIyEi5MqmpqQgICIClpSWMjY3RtWtXxMbGFjpfIQSmTp0Ke3t7GBgYwNfXF7du3ZIr8/z5c/Tu3RumpqYwMzPDoEGDkJiYKFfm6tWraNiwIfT19eHo6Ii5c+eWzIoTERER0QdLpQn06dOnERAQgD///BPBwcHIyMhAy5YtkZSUJJUZM2YMDh48iJ07d+L06dOIjo5Gly5dCp3v3LlzsWTJEqxcuRLnz5+HkZER/Pz8kJqaKpXp3bs3bty4geDgYBw6dAhnzpzB0KFDpfEJCQlo2bIlypUrh7CwMMybNw/Tp0/HqlWrSr4iiOidmdVMD7Oa6ak6DCIiUiMaQgih6iByPXnyBDY2Njh9+jQaNWqE+Ph4WFtbY8uWLejWrRsAICIiAm5ubggJCUHdunXzzUMIAQcHB4wdOxbjxo0DAMTHx8PW1hbr16+Hv78/wsPD4e7ujtDQUHh5eQEAgoKC0KZNGzx8+BAODg5YsWIFvvnmG8TExEBXN+cpZhMnTsS+ffsQERFRrPVJSEiATCZDfHw8TE1NS6KKYGTrViLzKUlJseGqDuGDURq3n7pb29EAADBwf4qKI/m48LhQfKXxuFDS2+9dnA+JVKlU9cIRHx8PALCwsAAAhIWFISMjA76+vlKZypUrw8nJCSEhIQrnce/ePcTExMhNI5PJ4O3tLU0TEhICMzMzKXkGAF9fX2hqauL8+fNSmUaNGknJMwD4+fkhMjISL168ULjstLQ0JCQkyL2IiIiISL2UmgQ6Ozsbo0ePRv369VG1alUAkK7+mpmZyZW1tbVFTEyMwvnkDre1tS1wmpiYGNjY2MiN19bWhoWFhVwZRfPIu4zXzZ49GzKZTHo5OjoWtdpERERE9IEpNQl0QEAArl+/jm3btqk6lDc2adIkxMfHS68HDx6oOiQiIiIiKmGlIoEeMWIEDh06hFOnTqFs2bLScDs7O6SnpyMuLk6ufGxsLOzs7BTOK3f46z115J3Gzs4Ojx8/lhufmZmJ58+fy5VRNI+8y3idnp4eTE1N5V5EREREpF5UmkALITBixAjs3bsXJ0+ehIuLi9x4T09P6Ojo4MSJE9KwyMhIREVFwcfHR+E8XVxcYGdnJzdNQkICzp8/L03j4+ODuLg4hIWFSWVOnjyJ7OxseHt7S2XOnDmDjIxXD2EIDg6Gq6srzM3N337liei9WB6ajuWh6aoOg4iI1IhKE+iAgAD88ssv2LJlC0xMTBATE4OYmBikpOTcLS+TyTBo0CAEBgbi1KlTCAsLw4ABA+Dj46OwBw4A0NDQwOjRozFr1iwcOHAA165dQ9++feHg4IBOnToBANzc3NCqVSsMGTIEFy5cwLlz5zBixAj4+/vDwcEBANCrVy/o6upi0KBBuHHjBrZv347FixcjMDDwvdQNEZWMi9FZuBidpeowiIhIjaj0SYQrVqwAADRp0kRu+Lp169C/f38AwMKFC6GpqYmuXbsiLS0Nfn5+WL58uVx5Z2dn9O/fH9OnTwcATJgwAUlJSRg6dCji4uLQoEEDBAUFQV9fX5pm8+bNGDFiBJo3by7Nf8mSJdJ4mUyGY8eOISAgAJ6enrCyssLUqVPl+oomIiIioo9PqeoH+k0kJyfD0tISR44cyZeIqxr7gabXlcbtp+7YD7Rq8LhQfKXxuMB+oIkKVypuInwbp06dQrNmzUpd8kxERERE6umDT6Dbtm2Lw4cPqzoMIiIiIvpIfPAJNBERERHR+8QEmoiIiIhICUygiYiIiIiUoNJu7IiI3rXJJ1NVHQIREakZJtBEpNaiX37QPXUSEVEpxCYcRKTWHEw04GCioeowiIhIjfAKNBGptVnNcp5AygepEBFRSeEVaCIiIiIiJTCBJiIiIiJSAhNoIiIiIiIlMIEmIiIiIlICE2giIiIiIiWwFw4iUmvsfYOIiEoar0ATERERESmBCTQRqTUvBy14OWipOgwiIlIjTKCJSK0Nr62L4bV1VR0GERGpESbQRERERERKYAJNRERERKQEJtBEREREREpgAk1EREREpAT2A01Eai36ZbaqQyAiIjXDBJqI1Nrkk2mqDoGIiNQMm3AQERERESmBCTQRqbWOrtro6Mo/24iIqOSoNIE+c+YM2rdvDwcHB2hoaGDfvn1y44UQmDp1Kuzt7WFgYABfX1/cunWryPkuW7YMzs7O0NfXh7e3Ny5cuCA3PjU1FQEBAbC0tISxsTG6du2K2NhYuTJRUVFo27YtDA0NYWNjg/HjxyMzM/Ot15mI3q+OlXXQsbKOqsMgIiI1otIEOikpCTVq1MCyZcsUjp87dy6WLFmClStX4vz58zAyMoKfnx9SU1MLnOf27dsRGBiIadOm4dKlS6hRowb8/Pzw+PFjqcyYMWNw8OBB7Ny5E6dPn0Z0dDS6dOkijc/KykLbtm2Rnp6OP/74Axs2bMD69esxderUklt5IiIiIvogaQghhKqDAAANDQ3s3bsXnTp1ApBz9dnBwQFjx47FuHHjAADx8fGwtbXF+vXr4e/vr3A+3t7eqF27Nn766ScAQHZ2NhwdHTFy5EhMnDgR8fHxsLa2xpYtW9CtWzcAQEREBNzc3BASEoK6deviyJEjaNeuHaKjo2FrawsAWLlyJb766is8efIEurrFeyxwQkICZDIZ4uPjYWpq+jbVIzGydSuR+ZSkpNhwVYfwwSiN20/dre1oAAAYuD9FxZF8XHhcKL7SeFwo6e33Ls6HRKpUattA37t3DzExMfD19ZWGyWQyeHt7IyQkROE06enpCAsLk5tGU1MTvr6+0jRhYWHIyMiQK1O5cmU4OTlJZUJCQlCtWjUpeQYAPz8/JCQk4MaNGwXGnJaWhoSEBLkXEREREamXUptAx8TEAIBcEpv7OXfc654+fYqsrKxCp4mJiYGuri7MzMwKLaNoHnnjUmT27NmQyWTSy9HRsYi1JCIiIqIPTalNoD9EkyZNQnx8vPR68OCBqkMi+uhdjM7CxegsVYdBRERqpNT27WRnZwcAiI2Nhb29vTQ8NjYWHh4eCqexsrKClpZWvh41YmNjpfnZ2dkhPT0dcXFxclehXy/zes8dufPMLaOInp4e9PT0ireCRPReLA9NV3UIRESkZkrtFWgXFxfY2dnhxIkT0rCEhAScP38ePj4+CqfR1dWFp6en3DTZ2dk4ceKENI2npyd0dHTkykRGRiIqKkoq4+Pjg2vXrsn13BEcHAxTU1O4u7uX6HoSERER0YdFpVegExMTcfv2benzvXv3cOXKFVhYWMDJyQmjR4/GrFmzULFiRbi4uGDKlClwcHCQeupQJDAwEP369YOXlxfq1KmDRYsWISkpCQMGDACQcyPioEGDEBgYCAsLC5iammLkyJHw8fFB3bp1AQAtW7aEu7s7+vTpg7lz5yImJgaTJ09GQEAArzATfWCG187pNYdXoomIqKSoNIG+ePEimjZtKn0ODAwEAPTr1w/r16/HhAkTkJSUhKFDhyIuLg4NGjRAUFAQ9PX1pWmaNGkCZ2dnrF+/HgDQs2dPPHnyBFOnTkVMTAw8PDwQFBQkd1PgwoULoampia5duyItLQ1+fn5Yvny5NF5LSwuHDh3CF198AR8fHxgZGaFfv36YOXPmO64RIippXg5aqg6BiIjUTKnpB/pNlStXDjNmzED//v1VHUo+7AeaXlcat5+6Yz/QqsHjQvGVxuMC+4EmKlypbQNdHDdu3IBMJkPfvn1VHQoRERERfSRKbS8cxVGlShVcvXpV1WEQERER0Ufkg74CTURERET0vn3QV6CJiIqyPyJD1SEQEZGaYQJNRGptf2SmqkMgIiI1wyYcRERERERKYAJNRGptVjM9zGrGByAREVHJYRMOIlJrDia8TkBERCWLZxYiIiIiIiUwgSYiIiIiUgITaCIiIiIiJTCBJiIiIiJSAm8iJCK1tjw0XdUhEBGRmmECTURq7WJ0lqpDICIiNcMmHERERERESmACTURqbW1HA6ztaKDqMIiISI0wgSYiIiIiUgITaCIiIiIiJTCBJiIiIiJSAhNoIiIiIiIlMIEmIiIiIlIC+4EmIrU2+WSqqkMgIiI1wwSaiNRa9Euh6hCIiEjNsAkHEak1BxMNOJhoqDoMIiJSI7wCTURqbVYzfQDAwP0pKo6EiIjUBRNoIiL6KBjZuqk6BCJSE0ygi7Bs2TLMmzcPMTExqFGjBpYuXYo6deqoOiwqBp4siYiI6F1gG+hCbN++HYGBgZg2bRouXbqEGjVqwM/PD48fP1Z1aERERESkIkygC7FgwQIMGTIEAwYMgLu7O1auXAlDQ0OsXbtW1aERERERkYqwCUcB0tPTERYWhkmTJknDNDU14evri5CQEIXTpKWlIS0tTfocHx8PAEhISCixuER2VonNq6SU5PqVpNJYV/T+Jafn7AfcH96v0nhc4D5QfCW9/XLnJwS7lST1wAS6AE+fPkVWVhZsbW3lhtva2iIiIkLhNLNnz8aMGTPyDXd0dHwnMZYWMplM1SEQFWjgBlVH8HHiceHD9q6238uXL7lvkFpgAl2CJk2ahMDAQOlzdnY2/vnnH3h4eODBgwcwNTVVYXSlX0JCAhwdHVlXxcC6Kj7WVfGwnoqPdVV8uXUVFRUFDQ0NODg4qDokohLBBLoAVlZW0NLSQmxsrNzw2NhY2NnZKZxGT08Penp6csM0NXOamZuamvJAW0ysq+JjXRUf66p4WE/Fx7oqPplMxroitcKbCAugq6sLT09PnDhxQhqWnZ2NEydOwMfHR4WREREREZEq8Qp0IQIDA9GvXz94eXmhTp06WLRoEZKSkjBgwABVh0ZEREREKsIEuhA9e/bEkydPMHXqVMTExMDDwwNBQUH5biwsjJ6eHqZNm5avaQflx7oqPtZV8bGuiof1VHysq+JjXZG60hDsU4aIiIiIqNjYBpqIiIiISAlMoImIiIiIlMAEmoiIiIhICUygiYiIiIiUwAS6hMyePRu1a9eGiYkJbGxs0KlTJ0RGRiosK4RA69atoaGhgX379r3fQFWsuPUUEhKCZs2awcjICKampmjUqBFSUlJUELHqFKeuYmJi0KdPH9jZ2cHIyAi1atXC7t27VRSx6qxYsQLVq1eXHmzh4+ODI0eOSONTU1MREBAAS0tLGBsbo2vXrvkekvSxKKyunj9/jpEjR8LV1RUGBgZwcnLCqFGjEB8fr+Ko37+i9qlcH/PxPFdx6orHdFI3TKBLyOnTpxEQEIA///wTwcHByMjIQMuWLZGUlJSv7KJFi6ChoaGCKFWvOPUUEhKCVq1aoWXLlrhw4QJCQ0MxYsQI6amOH4vi1FXfvn0RGRmJAwcO4Nq1a+jSpQt69OiBy5cvqzDy969s2bKYM2cOwsLCcPHiRTRr1gwdO3bEjRs3AABjxozBwYMHsXPnTpw+fRrR0dHo0qWLiqNWjcLqKjo6GtHR0Zg/fz6uX7+O9evXIygoCIMGDVJ12O9dUftUro/5eJ6rqLriMZ3UkqB34vHjxwKAOH36tNzwy5cvizJlyohHjx4JAGLv3r2qCbCUUFRP3t7eYvLkySqMqnRSVFdGRkZi48aNcuUsLCzE6tWr33d4pY65ublYs2aNiIuLEzo6OmLnzp3SuPDwcAFAhISEqDDC0iO3rhTZsWOH0NXVFRkZGe85qtLn9Xri8bxgeeuKx3RSR/z5947k/uVpYWEhDUtOTkavXr2wbNky2NnZqSq0UuX1enr8+DHOnz8PGxsb1KtXD7a2tmjcuDF+//13VYZZKijap+rVq4ft27fj+fPnyM7OxrZt25CamoomTZqoKErVy8rKwrZt25CUlAQfHx+EhYUhIyMDvr6+UpnKlSvDyckJISEhKoxU9V6vK0Xi4+NhamoKbe2P97lbiuqJx3PFXq8rHtNJbak6g1dHWVlZom3btqJ+/fpyw4cOHSoGDRokfcZHfsVCUT2FhIQIAMLCwkKsXbtWXLp0SYwePVro6uqKmzdvqjBa1Spon3rx4oVo2bKlACC0tbWFqampOHr0qIqiVK2rV68KIyMjoaWlJWQymTh8+LAQQojNmzcLXV3dfOVr164tJkyY8L7DLBUKqqvXPXnyRDg5OYmvv/76PUdYOhRWTzyeyyuornhMJ3X18V5SeIcCAgJw/fp1uV/YBw4cwMmTJz+6tqmFUVRP2dnZAIBhw4ZhwIABAICaNWvixIkTWLt2LWbPnq2SWFVNUV0BwJQpUxAXF4fjx4/DysoK+/btQ48ePXD27FlUq1ZNRdGqhqurK65cuYL4+Hjs2rUL/fr1w+nTp1UdVqlUUF25u7tLZRISEtC2bVu4u7tj+vTpqgtWhQqqp9u3b/N4/pqC6orHdFJbqs7g1U1AQIAoW7asuHv3rtzwL7/8UmhoaAgtLS3pBUBoamqKxo0bqyZYFSqonu7evSsAiE2bNskN79Gjh+jVq9f7DLHUKKiubt++LQCI69evyw1v3ry5GDZs2PsMsVRq3ry5GDp0qDhx4oQAIF68eCE33snJSSxYsEA1wZUyuXWVKyEhQfj4+IjmzZuLlJQUFUZWuuTWE4/nRcutKx7TSV2xDXQJEUJgxIgR2Lt3L06ePAkXFxe58RMnTsTVq1dx5coV6QUACxcuxLp161QQsWoUVU/Ozs5wcHDI113bzZs3Ua5cufcZqsoVVVfJyckAkO9Odi0tLemqz8csOzsbaWlp8PT0hI6ODk6cOCGNi4yMRFRUVIHtfj82uXUF5Fx5btmyJXR1dXHgwAHo6+urOLrSI7eeeDwvWm5d8ZhO6opNOEpIQEAAtmzZgv3798PExAQxMTEAAJlMBgMDA9jZ2Sm80cTJySlfYqTOiqonDQ0NjB8/HtOmTUONGjXg4eGBDRs2ICIiArt27VJx9O9XUXVVuXJlVKhQAcOGDcP8+fNhaWmJffv2ITg4GIcOHVJx9O/XpEmT0Lp1azg5OeHly5fYsmULfvvtNxw9ehQymQyDBg1CYGAgLCwsYGpqipEjR8LHxwd169ZVdejvXWF1lZs8Jycn45dffkFCQgISEhIAANbW1tDS0lJx9O9PYfXE47m8wuqKx3RSWyq+Aq42ACh8rVu3rtBpPrabTopbT7NnzxZly5YVhoaGwsfHR5w9e1Y1AatQcerq5s2bokuXLsLGxkYYGhqK6tWr5+vW7mMwcOBAUa5cOaGrqyusra1F8+bNxbFjx6TxKSkpYvjw4cLc3FwYGhqKzp07i0ePHqkwYtUprK5OnTpV4H5379491Qb+nhW1T73uYzye5ypOXfGYTupGQwgh3leyTkRERET0oWMbaCIiIiIiJTCBJiIiIiJSAhNoIiIiIiIlMIEmIiIiIlICE2giIiIiIiUwgSYiIiIiUgITaCIiIiIiJTCBJiIiIiJSAhNoov+sX78eZmZm73w5v/32GzQ0NBAXF/fOlwUA/fv3R6dOnd7Lsgqyb98+VKhQAVpaWhg9erRKYynK+9oPXve+94t37V2vz/Tp0+Hh4fFO5k1EVBQm0KQWYmJiMHLkSJQvXx56enpwdHRE+/btceLECVWHRgCGDRuGbt264cGDB/j2229VHU6hevbsiZs3b6o6DIU0NDSwb98+VYdRLPXq1cOjR48gk8neel6K1nvcuHH8fhORymirOgCit3X//n3Ur18fZmZmmDdvHqpVq4aMjAwcPXoUAQEBiIiIUHWIJS49PR26urqqDqNYEhMT8fjxY/j5+cHBwUFhmaysLGhoaEBTU/W/6Q0MDGBgYKDqMD54urq6sLOzK3D8225zY2NjGBsbv2l4RERvRfVnK6K3NHz4cGhoaODChQvo2rUrKlWqhCpVqiAwMBB//vmnVG7BggWoVq0ajIyM4OjoiOHDhyMxMbHQee/fvx+1atWCvr4+ypcvjxkzZiAzM1Mar6GhgTVr1qBz584wNDRExYoVceDAAbl5/Prrr6hUqRIMDAzQtGlT3L9/X278s2fP8Omnn6JMmTIwNDREtWrVsHXrVrkyTZo0wYgRIzB69GhYWVnBz89PYbxZWVkIDAyEmZkZLC0tMWHCBAgh5MoEBQWhQYMGUpl27drhzp070vhmzZphxIgRctM8efIEurq60hW/5cuXo2LFitDX14etrS26deumMJ7ffvsNJiYm0nw1NDTw22+/Sc0kDhw4AHd3d+jp6SEqKgovXrxA3759YW5uDkNDQ7Ru3Rq3bt2S5pc73aFDh+Dq6gpDQ0N069YNycnJ2LBhA5ydnWFubo5Ro0YhKytLYUwA8Ndff6Fp06YwMTGBqakpPD09cfHiRbll5DVr1izY2NjAxMQEgwcPxsSJE+WaD+Q2k5k/fz7s7e1haWmJgIAAZGRkSGU2bdoELy8vmJiYwM7ODr169cLjx48LjPF1zs7OAIDOnTtDQ0ND+gwAK1aswCeffAJdXV24urpi06ZNRc5vzZo1cHNzg76+PipXrozly5dL4wYOHIjq1asjLS0NQM4Ptpo1a6Jv374Acn60amhoYNu2bahXrx709fVRtWpVnD59WprH6004CtrmoaGhaNGiBaysrCCTydC4cWNcunSpyPV+vQlHdnY2Zs6cibJly0JPTw8eHh4ICgqSxufGvGfPHjRt2hSGhoaoUaMGQkJCiqwrIqJ8BNEH7NmzZ0JDQ0N8//33RZZduHChOHnypLh37544ceKEcHV1FV988YU0ft26dUImk0mfz5w5I0xNTcX69evFnTt3xLFjx4Szs7OYPn26VAaAKFu2rNiyZYu4deuWGDVqlDA2NhbPnj0TQggRFRUl9PT0RGBgoIiIiBC//PKLsLW1FQDEixcvhBBCPHz4UMybN09cvnxZ3LlzRyxZskRoaWmJ8+fPS8tp3LixMDY2FuPHjxcREREiIiJC4Tr+8MMPwtzcXOzevVv8/fffYtCgQcLExER07NhRKrNr1y6xe/ducevWLXH58mXRvn17Ua1aNZGVlSWEEGLz5s3C3NxcpKamStMsWLBAODs7i+zsbBEaGiq0tLTEli1bxP3798WlS5fE4sWLFcaTlpYmIiMjBQCxe/du8ejRI5GWlibWrVsndHR0RL169cS5c+dERESESEpKEh06dBBubm7izJkz4sqVK8LPz09UqFBBpKenS9tIR0dHtGjRQly6dEmcPn1aWFpaipYtW4oePXqIGzduiIMHDwpdXV2xbdu2AveFKlWqiM8++0yEh4eLmzdvih07dogrV64o3A9++eUXoa+vL9auXSsiIyPFjBkzhKmpqahRo4ZUpl+/fsLU1FR8/vnnIjw8XBw8eFAYGhqKVatWSWX+97//iV9//VXcuXNHhISECB8fH9G6dWtp/KlTp+T2i9c9fvxYABDr1q0Tjx49Eo8fPxZCCLFnzx6ho6Mjli1bJiIjI8WPP/4otLS0xMmTJwtc/19++UXY29uL3bt3i7t374rdu3cLCwsLsX79eiGEEC9fvhTly5cXo0ePFkIIMW7cOOHs7Czi4+OFEELcu3dP2vd37dol/v77bzF48GBhYmIinj59qnB9CtrmJ06cEJs2bRLh4eHSPmtraysSEhIKXe9p06bJbYMFCxYIU1NTsXXrVhERESEmTJggdHR0xM2bN+Virly5sjh06JCIjIwU3bp1E+XKlRMZGRkF1hURkSJMoOmDdv78eQFA7NmzR+lpd+7cKSwtLaXPrydOzZs3z5eYb9q0Sdjb20ufAYjJkydLnxMTEwUAceTIESGEEJMmTRLu7u5y8/jqq68KTZSEEKJt27Zi7Nix0ufGjRuLmjVrFrlO9vb2Yu7cudLnjIwMUbZsWbkE+nVPnjwRAMS1a9eEEEKkpKQIc3NzsX37dqlM9erVpR8Ou3fvFqamplKCU5QXL14IAOLUqVPSsHXr1gkAUtIqhBA3b94UAMS5c+ekYU+fPhUGBgZix44dctPdvn1bKjNs2DBhaGgoXr58KQ3z8/MTw4YNKzAmExMTKVl83ev7gbe3twgICJArU79+/XwJdLly5URmZqY0rHv37qJnz54FxhAaGioASHEXlUALkbO/7d27V25YvXr1xJAhQ+SGde/eXbRp06bA+XzyySdiy5YtcsO+/fZb4ePjI33+448/hI6OjpgyZYrQ1tYWZ8+elcblJqNz5syRhuXuaz/88IPC9VG0zRXJysoSJiYm4uDBg4Wu9+sJtIODg/juu+/kytSuXVsMHz5cLuY1a9ZI42/cuCEAiPDw8EJjIiJ6HZtw0AdNvNY8oTDHjx9H8+bNUaZMGZiYmKBPnz549uwZkpOTFZb/66+/MHPmTKmtpbGxMYYMGYJHjx7JTVO9enXpvZGREUxNTaW/5sPDw+Ht7S03Xx8fH7nPWVlZ+Pbbb1GtWjVYWFjA2NgYR48eRVRUlFw5T0/PQtcvPj4ejx49kluetrY2vLy85MrdunULn376KcqXLw9TU1PpL/Hc5enr66NPnz5Yu3YtAODSpUu4fv06+vfvDwBo0aIFypUrh/Lly6NPnz7YvHlzgXVYGF1dXbm6Cw8Ph7a2tlz8lpaWcHV1RXh4uDTM0NAQn3zyifTZ1tYWzs7Ocu1hbW1tC20eERgYiMGDB8PX1xdz5syRa8LyusjISNSpU0du2OufAaBKlSrQ0tKSPtvb28vFEBYWhvbt28PJyQkmJiZo3LgxAOTbzsoKDw9H/fr15YbVr19frs7ySkpKwp07dzBo0CC5fXvWrFly9eDj44Nx48bh22+/xdixY9GgQYN888q7L+fuawUtF8i/zQEgNjYWQ4YMQcWKFSGTyWBqaorExESl6iUhIQHR0dHFqoe8y7e3twcApZrSEBEBbANNH7iKFStCQ0OjyBsF79+/j3bt2qF69erYvXs3wsLCsGzZMgA57TsVSUxMxIwZM3DlyhXpde3aNdy6dQv6+vpSOR0dHbnpNDQ0kJ2dXex1mDdvHhYvXoyvvvoKp06dwpUrV+Dn55cvLiMjo2LPszDt27fH8+fPsXr1apw/fx7nz58HIF8PgwcPRnBwMB4+fIh169ahWbNmKFeuHADAxMQEly5dwtatW2Fvb4+pU6eiRo0aSndXZmBgAA0NDaXjV1Tfym6D6dOn48aNG2jbti1OnjwJd3d37N27V+lYioorN4akpCT4+fnB1NQUmzdvRmhoqLS8gva/dyW33f/q1avl9u3r16/L3TOQnZ2Nc+fOQUtLC7dv3y6RZSva5v369cOVK1ewePFi/PHHH7hy5QosLS3fWb3k3U65sSjzfSUiAphA0wfOwsICfn5+WLZsGZKSkvKNz03qwsLCkJ2djR9//BF169ZFpUqVEB0dXei8a9WqhcjISFSoUCHfq7g9B7i5ueHChQtyw/ImKQBw7tw5dOzYEZ999hlq1KiB8uXLv1E3ajKZDPb29lJCDACZmZkICwuTPj979gyRkZGYPHkymjdvDjc3N7x48SLfvKpVqwYvLy+sXr0aW7ZswcCBA+XGa2trw9fXF3PnzsXVq1dx//59nDx5UumY83Jzc0NmZqZc/Lnxuru7v9W8FalUqRLGjBmDY8eOoUuXLli3bp3Ccq6urggNDZUb9vrnokRERODZs2eYM2cOGjZsiMqVK7/RVU8dHZ18N0e6ubnh3LlzcsPOnTtXYJ3Z2trCwcEBd+/ezbdfu7i4SOXmzZuHiIgInD59GkFBQQrrJ+++nLuvubm5KbVO586dw6hRo9CmTRtUqVIFenp6ePr0aZHrnZepqSkcHByUqgciorfBbuzog7ds2TLUr18fderUwcyZM1G9enVkZmYiODgYK1asQHh4OCpUqICMjAwsXboU7du3x7lz57By5cpC5zt16lS0a9cOTk5O6NatGzQ1NfHXX3/h+vXrmDVrVrFi+/zzz/Hjjz9i/PjxGDx4MMLCwrB+/Xq5MhUrVsSuXbvwxx9/wNzcHAsWLEBsbOwbnfi//PJLzJkzBxUrVkTlypWxYMECuSvD5ubmsLS0xKpVq2Bvb4+oqChMnDhR4bwGDx6MESNGwMjICJ07d5aGHzp0CHfv3kWjRo1gbm6OX3/9FdnZ2XB1dVU63rwqVqyIjh07YsiQIfj5559hYmKCiRMnokyZMujYseNbzTuvlJQUjB8/Ht26dYOLiwsePnyI0NBQdO3aVWH5kSNHYsiQIfDy8kK9evWwfft2XL16FeXLly/2Mp2cnKCrq4ulS5fi888/x/Xr19+oP2xnZ2ecOHEC9evXh56eHszNzTF+/Hj06NEDNWvWhK+vLw4ePIg9e/bg+PHjBc5nxowZGDVqFGQyGVq1aoW0tDRcvHgRL168QGBgIC5fvoypU6di165dqF+/PhYsWIAvv/wSjRs3llvvZcuWoWLFinBzc8PChQvx4sWLfD+2ilKxYkWph5KEhASMHz8+XzeCitb7dePHj8e0adPwySefwMPDA+vWrcOVK1ewefNmpeIhIioWVTfCJioJ0dHRIiAgQJQrV07o6uqKMmXKiA4dOsjduLZgwQJhb28vDAwMhJ+fn9i4cWO+m5zy3jwmhBBBQUGiXr16wsDAQJiamoo6derI9awABTc3yWQysW7dOunzwYMHRYUKFYSenp5o2LChWLt2rdxynz17Jjp27CiMjY2FjY2NmDx5sujbt6/cjX+NGzcWX375ZZH1kJGRIb788kthamoqzMzMRGBgYL55BQcHCzc3N6GnpyeqV68ufvvtN4Xr8fLlS2FoaCjdhJXr7NmzonHjxsLc3FwYGBiI6tWry91w+LqCbiJ8va6FEOL58+eiT58+QiaTSdsptxeFgqZ7/WYyIXJu6ivoxsm0tDTh7+8vHB0dha6urnBwcBAjRowQKSkpBS5j5syZwsrKShgbG4uBAweKUaNGibp16xa6vC+//FI0btxY+rxlyxbh7Ows9PT0hI+Pjzhw4IAAIC5fviyEKN5NhAcOHBAVKlQQ2traoly5ctLw5cuXi/LlywsdHR1RqVIlsXHjxgLnkWvz5s3Cw8ND6OrqCnNzc9GoUSOxZ88ekZKSItzd3cXQoUPlynfo0EHUq1dPZGZmSjfkbdmyRdSpU0fo6uoKd3d3uZ4/FN1EqGibX7p0SXh5eQl9fX1RsWJFsXPnTlGuXDmxcOHCQtf79e2elZUlpk+fLsqUKSN0dHREjRo1pJt5hXh1E2FufQuheN8kIioODSGUuAuLiD4a9+/fxyeffILQ0FDUqlVL1eGUKi1atICdnV2x+ltWR/fv34eLiwsuX77Mx2kT0UeJTTiISE5GRgaePXuGyZMno27duh998pycnIyVK1fCz88PWlpa2Lp1K44fP47g4GBVh0ZERCrCBJqI5Jw7dw5NmzZFpUqVsGvXLlWHo3IaGhr49ddf8d133yE1NRWurq7YvXs3fH19VR0aERGpCJtwEBEREREpgd3YEREREREpgQk0EREREZESmEATERERESmBCTQRERERkRKYQBMRERERKYEJNBERERGREphAExEREREpgQk0EREREZES/g8vmsC21HBINAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Histogram of calendar days between the signal date and expiration."
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Settlement: 25-35 calendar days, 16-24 sessions of exposure, median 20\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Entry is one session after the signal, so a trade settling on bar e is exposed to the\n",
+    "# e - bar - 1 return intervals realised between them.\n",
+    "expiry_bar = calendar.select(pl.col(\"timestamp\").alias(\"expiration\"), pl.col(\"_bar\").alias(\"_e\"))\n",
+    "panel = panel.join(expiry_bar, on=\"expiration\", how=\"left\").with_columns(\n",
+    "    (pl.col(\"_e\") - pl.col(\"_bar\") - 1).alias(\"window\")\n",
+    ")\n",
+    "resolution = panel.drop_nulls(PRIMARY_LABEL)\n",
+    "PRIMARY_WINDOW = int(resolution[\"window\"].median())\n",
+    "LONGEST_WINDOW = int(resolution[\"window\"].max())\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "ax.hist(resolution[\"dte_calendar\"].to_numpy(), bins=np.arange(24.5, 36.5, 1), color=COLORS[\"blue\"])\n",
+    "ax.axvline(resolution[\"dte_calendar\"].median(), color=COLORS[\"copper\"], linestyle=\"--\", lw=1.2)\n",
+    "ax.set_xlabel(\"Calendar days from signal to expiration\")\n",
+    "ax.set_ylabel(\"Trades\")\n",
+    "ax.yaxis.set_major_formatter(lambda v, _: f\"{v:,.0f}\")\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"How long a trade is held varies by about a third of its own window\",\n",
+    "    subtitle=\"Dashed line marks the median; the label resolves when the contract expires\",\n",
+    ")\n",
+    "show_with_alt(fig, \"Histogram of calendar days between the signal date and expiration.\")\n",
+    "\n",
+    "print(\n",
+    "    f\"Settlement: {resolution['dte_calendar'].min()}-{resolution['dte_calendar'].max()} calendar days, \"\n",
+    "    f\"{resolution['window'].min()}-{LONGEST_WINDOW} sessions of exposure, \"\n",
+    "    f\"median {PRIMARY_WINDOW}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4da5280",
+   "metadata": {},
+   "source": [
+    "## D. Window validity\n",
+    "\n",
+    "A join always returns something; the question is whether what it returns is the quantity\n",
+    "the label claims. Each property below fails silently and leaves plausible numbers behind,\n",
+    "so each is asserted rather than described.\n",
+    "\n",
+    "The second assertion is a full reconciliation rather than a bound. Every row carrying no\n",
+    "label is attributed to exactly one cause - no premium quoted at entry, no quote for the\n",
+    "held contract on the exit date, a hedge path the contract was not quoted on every day of,\n",
+    "an expiration past the end of the underlying panel, or an expiration on which the\n",
+    "underlying itself did not trade - and the counts have to sum to the height of the frame. A label built from a stale exit, or one that had silently taken\n",
+    "its exit price from a neighbouring contract, would break that identity.\n",
+    "\n",
+    "The third assertion is what ties the recorded exit dates to the declared horizons. The\n",
+    "round-trip builder writes each exit date into the artifact, so the notebook can check it\n",
+    "rather than trust it: shifting the panel calendar by the horizon has to land on the same\n",
+    "session, and the whole window has to close on or before the contract expires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3c975be7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T07:12:52.371199Z",
+     "iopub.status.busy": "2026-07-31T07:12:52.370918Z",
+     "iopub.status.idle": "2026-07-31T07:12:52.702594Z",
+     "shell.execute_reply": "2026-07-31T07:12:52.701765Z"
     }
    },
    "outputs": [
@@ -356,72 +572,140 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hedge path: 3,932,269 rows\n"
+      "ret_to_expiry: 354,473 labelled; unlabelled 425 no entry premium, 1,727 expiry past the underlying panel, 854 no underlying close at expiry\n",
+      "fwd_ret_5d: 352,179 labelled; unlabelled 425 no entry premium, 4,875 no quote at exit\n",
+      "fwd_ret_10d: 333,102 labelled; unlabelled 425 no entry premium, 23,952 no quote at exit\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_dh_5d: 349,934 labelled; unlabelled 425 no entry premium, 4,875 no quote at exit, 2,245 incomplete hedge path\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_dh_10d: 323,847 labelled; unlabelled 425 no entry premium, 23,952 no quote at exit, 9,255 incomplete hedge path\n"
      ]
     }
    ],
    "source": [
-    "hedge_path = pl.read_parquet(LABELS_DIR / \"hedge_path.parquet\")\n",
-    "print(f\"Hedge path: {len(hedge_path):,} rows\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "3c975be7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:47.469501Z",
-     "iopub.status.busy": "2026-07-21T06:54:47.469114Z",
-     "iopub.status.idle": "2026-07-21T06:54:51.012143Z",
-     "shell.execute_reply": "2026-07-21T06:54:51.011690Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Compute daily underlying price changes along each holding path\n",
-    "hedge_sorted = hedge_path.sort([\"symbol\", \"feature_date\", \"holding_day\"])\n",
-    "\n",
-    "# dS at each holding day: S[d] - S[d-1]\n",
-    "hedge_sorted = hedge_sorted.with_columns(\n",
-    "    (\n",
-    "        pl.col(\"underlying_price\")\n",
-    "        - pl.col(\"underlying_price\").shift(1).over([\"symbol\", \"feature_date\"])\n",
-    "    ).alias(\"dS\")\n",
-    ")\n",
-    "\n",
-    "# Hedge P&L each day: delta[d-1] * dS[d] (hedge established at previous close)\n",
-    "# For d=0, no dS (it's the entry day), so dS is null and excluded\n",
-    "hedge_sorted = hedge_sorted.with_columns(\n",
-    "    (pl.col(\"instr_delta\").shift(1).over([\"symbol\", \"feature_date\"]) * pl.col(\"dS\")).alias(\n",
-    "        \"daily_hedge_pnl\"\n",
+    "NO_PREMIUM = pl.col(\"entry_straddle_mid\").is_null()\n",
+    "CAUSES = {\n",
+    "    PRIMARY_LABEL: {\n",
+    "        \"no entry premium\": NO_PREMIUM,\n",
+    "        \"expiry past the underlying panel\": pl.col(\"expiration\") > underlying[\"timestamp\"].max(),\n",
+    "        \"no underlying close at expiry\": pl.col(\"_close_at_expiry\").is_null(),\n",
+    "    }\n",
+    "} | {\n",
+    "    name: {\n",
+    "        \"no entry premium\": NO_PREMIUM,\n",
+    "        \"no quote at exit\": pl.col(f\"exit_straddle_mid_{HORIZONS[name]}d\").is_null(),\n",
+    "    }\n",
+    "    | (\n",
+    "        {\"incomplete hedge path\": pl.col(f\"hedge_days_{HORIZONS[name]}d\") != HORIZONS[name]}\n",
+    "        if \"_dh_\" in name\n",
+    "        else {}\n",
     "    )\n",
-    ")"
+    "    for name in VARIANT_LABELS\n",
+    "}\n",
+    "for name, causes in CAUSES.items():\n",
+    "    # 1. An incomplete window is null, never a value.\n",
+    "    unlabelled = panel.filter(pl.any_horizontal(*causes.values()))\n",
+    "    assert unlabelled[name].null_count() == unlabelled.height, name\n",
+    "\n",
+    "    # 2. Labelled rows plus the causes, each counted once, account for every row.\n",
+    "    seen, counts = pl.lit(False), {}\n",
+    "    for cause, cond in causes.items():\n",
+    "        counts[cause] = panel.filter(cond & ~seen).height\n",
+    "        seen = seen | cond\n",
+    "    assert panel.drop_nulls(name).height + sum(counts.values()) == panel.height, (name, counts)\n",
+    "\n",
+    "    # 3. Each recorded exit lands where the declared horizon says, inside the contract.\n",
+    "    if name in HORIZONS:\n",
+    "        assert panel.filter(pl.col(f\"exit_{HORIZONS[name]}d_date\") != END_OF[name]).height == 0\n",
+    "    assert panel.filter(END_OF[name] > pl.col(\"expiration\")).height == 0, name\n",
+    "\n",
+    "    # 4. No discrete label is derived from a null return - vacuous by dtype here, since\n",
+    "    #    this notebook writes continuous labels only.\n",
+    "    assert panel.schema[name] == pl.Float64, name\n",
+    "\n",
+    "    unlabelled = \", \".join(f\"{n:,} {c}\" for c, n in counts.items())\n",
+    "    print(f\"{name}: {panel.drop_nulls(name).height:,} labelled; unlabelled {unlabelled}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93b706aa",
+   "metadata": {},
+   "source": [
+    "Position zero below is the panel's last session. Every label has to fall to zero over its\n",
+    "own closing window and sit flat before it. A scalar count of valid rows shows neither\n",
+    "failure this catches - a tail fabricated instead of nulled, or a short label masked by a\n",
+    "longer one's null set - and two things it does show here. The primary label recovers much\n",
+    "deeper in than the others, because it needs an expiration the underlying panel still\n",
+    "covers rather than an exit session. And the five- and ten-session labels fall away at the\n",
+    "same depth rather than at their own, because the round-trip builder lays out one set of\n",
+    "exit and hedge dates sized for the longest window it has to fill, and stops every label\n",
+    "where that one runs out. The figure reads only the null structure and never a value, so it\n",
+    "is not sealed."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d810b421",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:51.013381Z",
-     "iopub.status.busy": "2026-07-21T06:54:51.013265Z",
-     "iopub.status.idle": "2026-07-21T06:54:51.428451Z",
-     "shell.execute_reply": "2026-07-21T06:54:51.427794Z"
-    },
-    "lines_to_next_cell": 2
+     "iopub.execute_input": "2026-07-31T07:12:52.704537Z",
+     "iopub.status.busy": "2026-07-31T07:12:52.704367Z",
+     "iopub.status.idle": "2026-07-31T07:12:53.074859Z",
+     "shell.execute_reply": "2026-07-31T07:12:53.073405Z"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkMAAAFnCAYAAACl7E0mAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnAlJREFUeJzs3XdYFFcXwOHf0i0UFQVF7BoVQVQUsUfsvddYPzVGjMYajUaNiT2xRY1Ro0Rj7LFEE0uwoth7jxULYAUEpO58fxBXVhbYRXBRzvs8PrKzM3fOlN05e+fOvSpFURSEEEIIIbIpE2MHIIQQQghhTJIMCSGEECJbk2RICCGEENmaJENCCCGEyNYkGRJCCCFEtibJkBBCCCGyNUmGhBBCCJGtSTIkhBBCiGxNkiEhhBBCZGuSDH3g7gY+IJdDOXI5lKNJ257pKmPV2s2aMqbMWpDl4ssoBw8f18QyYMhYzfQBQ8Zqph88fDxD1pWZ+/RdeRV/OQ9vzbSsvF2ZcRwz25RZCzQxr1q72djhpGjdpu14ftwG+2KVyOVQjkKlqxlcRpO2PTXbejfwwVvHlJWOt67PishazIwdgLFMmbWAqd8vTPF9WxtrHv77fnxhig/HuYtX2P63HwC1a1SjTk3DLyqpWbV2M4H3Ei80PgN6Ymdrk6HlG9PdwAf8ti4xYXBzKUvLZg2MHFHaQsPCWbhkJQBFnJ3o0aWtkSMy3LETZ/ifz2iy88hOf/71D+cvXQXgk85tKVrEycgRCUNl22RICGNq7F2HPdt+A8DZqaBm+vmLVzVJ+lcjyfBkaPW6zRw6cgJI/NJ+m2ToVfxWlpYZEtvbunvvgWbfde/c5r1IhsLCXmhirl2j6nuZDO3854AmEfpfz850bt8CczPjX1pGf/Epvbt3AMClXJlMXdefO/1YvW4LkPgj5s1kKKt9VkRyxj9js4BG3rUZNfRTrWlmpqZGiiZRZGQUuXLlNGoMIvMUyJ+PAvnzGTuMt1LDs0qmlf2hnP9qtZrY2DisrD7ci2BQ8GPN3+1bN6VmdQ8jRvP63ClVohilShQzaiyvZOZnRWQMaTME5LfPRw3PKlr/qnm4A3Dm/CXN/d5OPX20lnsYFEJux/LkcihHncadNNPj4uKYv9iXmg3bk79YZfIXq0zdJp1Zs3FbsnUnvZd88fJ1WnTsS4HiVWj/yUAatvpE8/7tO/e0luvSe7DmvTPnLhm8zZeuXKfPZ6OoUrsFhT+qjq2TK0XL16Rd90/xDziR6rKbtv5N1bqtyFukIlVqt2Ddpu3J5omIjGTKrAV41GlJvqLuOJb0oEnbnuzyO2hwrEklbVdw4dI1Roz9jqLla5KvqDttug7Q3AKC1NsjlfPw1ryXXgcPH6d5hz5J9l8N6jTuxMhxUwkLf5Hqsrra1pTz8Gbg0K8080z9fmGyee4GPqD3wJGUdKuDrZMrhUpXo0rtFnw69CsuXLqWaqy5HMppaoUAyldtkKyNxpiJM6jfvCslXGuTx9mNAsWrUKNBO+YuWk58fLxWmRnRDiK18x8Sbz907DGI8h4NcChRBbvCbpStUp9Ph36l1a6kSdueNG3XS/N69botOtt/vRIfH8/02Yv4qHJ98hapiHeLbprbHElduHSNXp+OoIRrbewKu1GqYl0GDRvPg4fBWvMlbdvz6++bmDH7J8pWqY+tkyvHT53Tue0DhoylfNXXtVeHjpxIs/3ckhW/41a9MXmc3fD8uA37Dx3Vel/f/fVq/a/W98/+w3w7Yz6l3euluj+SevX5WrX2D820Zu17a8X/6+qNtOrcj48q1yd/scrkLVIRt+qNGTH2O548fZ5i2VEvXzJy3FSKlq9J/mKVad99ILfuBGrNk/QzfO/+Q7r1HULBUlWpWrdVsu17s83Q8ZNn+aTfF5R0q4NdYTeKV6hN224DOHfximYefT4Lr/bBq1ohgKbteiVbrz7t69Zs3IZHnZbkcXajolcTNm39O9l+OXTkOLUbdyRvkYpUqNaIxb+sTlc7vf2HjtKu+6cUKeeFXWE3ylT6mAFDxnLj1h2t+ZKe1yvX/MGCn3/F1TPl8w/gzt37+Az/mrJV6pPH2Y2i5WvSs/8wrl6/qVdsxiI1Q2mo5OZC2TIluXr9Jn4HDvMiIhLr3LkA2LJ9t6Z6uEuHlkBiItSm64BkJ8nJM+fp53OeS1eu893XI5OtJyzsBc3a9+Lps1DNtJ7d2nPk2CkA1v+xnS+HfwZAdHQMew8EAFC6ZDEqVXQxeLsuX/2X9X9oJzFPnj5j1z8H2bPXn+0bllO3lmey5bbu2KPV1urq9Zv0HTQKlUpFp3bNE7cl/AUNW33CpSvXNfNFE8OhIyc4dOQEc6Z/zYA+3QyO+U1d+3zO7buvk8Q9ew/Rd9Bo/vlz9VuXnZbrN27TrvunvHwZrZn25Olznjx9zqmzF/isX3dsbawzdJ3x8fG07tKPf2/e0UwLC39BWPgLrl6/iVfVSri6fPRW61iy4ndiYmI1r2Nj4zh34QrnLlzh6rWbLJ435a3KT4mu8x9gzz5//tq9T2vavftB/LZ2M7v9DnFs35Z01bCNGj9V68v56IkzdOk1mPNHd2L23y2eXX4H6drnc639ERT8iF9/38TOfw6wd/saihUtnKzsWXN/1jovM8rchb9oxXzx8jW69B7MlVN+5LGzBdK/v74Y/Y1WzLr2R3r88ecu/PYf1pp283YgN2+vZr//UQ7v2aSz1qz3wJFcvPw6ud/5zwHOX7rK0b2byZc3T7L5m7brrYnfzi71W78r1/zB4BETSEhI0Ex79PgJu/0O0a5VUypWSPyB9C4/C2s2bNPa/zdu3aX3wJG4upSlTKniQGIC17pLf01Mt+/eY8RX3+HqUtagdS1Z8TvDx36n1cbrwcNgVq/bwrYde9ixcQVVKrkmW27mnMVaMeo6/86cv0SLDn0JDQvXzPfk6TM2bdvJLr+D7Ni4Ao/KbgbF+65IzRDavyJ1/Zrs3K4FkJiE/L17v2b6lu27ADA1NaVDm2YALFy6SpMIVatSkbUrfmT1L/M0J/ScBb9wQscvxbDwF5iYmLLg+2/Yum4Zvbp3oF3LxprEa12SxGX/oQAio6IA6Ni2ebq2uXSp4kz75kvW+S7gr02+7Ni4gnkzJ2JpaYFareb7+Ut0LnfpynUG9e/BptWLNQkgwJiJ04mLiwPgm2lzNYlQ4wZ12LR6MUsXTMehgD0AX06Yzv0HQemKO6knT58xf9Ykflk4U9P2JeD4aS5f/fety07L3gNHNInQoP492LFxBat/mcfEMUOp7F4BlUplcJmrl83Tul3bo0s79mz7jT3bfqNn13Zc+/eWJhH6uI4XW9YuZdNvP/HD1PE08q6NhaVFimVXdC3Hnm2/4VbhdU3Yb8vmasp3dMgPJLaz8F38PVvWLmXn5l9Zs2I+Vf/78vpt3eZkNSIZRdf5D+BdrwY/zvqGjasWsXPzr2xZu5Qhn/UBEi9gv67eCMD3U8bz/ZRxmvIaedfWbNvoLz5Ntr6btwP59usRrFkxn8L/tdm6e+8B/+zzByAq6iUDPh9LTEwsZmZmTBr7BdvWL2PY4P8BEPLoCV+MmaxzW27fvUfn9i01532hggV0zjf6i0/5bdlczWu3CuU0MX8/ZXyy+a9ev8nwwf3YsHKR5gL4IiJS60eNvvvrTfcfBqe6P3RxdMjPnm2/0ci7tmba91PGacXfvnVTfpo7hU2rF7Nz869sWr2Ybp1aa7Zn6449OssODnnE4nlT+W3ZXIoXdQYSa+JnzdP9vfTo8VOmf/Ml29YvY9SQ5Mf7lYdBIXzx5TeaRKhlU2/Nd3SfTzpiYW6umVefz0Jq+2DPtt+o6KpfzfPtu/fo1a09m377iXq1qwOJt1h9kxyvMRNnaBKhOjU92bhqEeNHD9b60ZmW+w+C+HLCdBRFwcTEhC+HDWTT6sW0a9UESDyfPh06Vmdj+Nt376V6/imKwoDPx2oSoSGf9WHb+mV8+/UITE1NiYiMYuAXX2XZhvZSM6SHTu1aMHnGfBRFYcv2XXRq15zgR48JOH4GgPp1a2h+ba3d+Kdmuc8H9iZfvsRfMZ3bt+DbGT9q5qlapWKy9fyyaAbedWtqTevQphkrftvAtX9vceb8JSq5ufBXkoQsvcmQa/mPOBxwkplzf+b6jVtEREZpnaQp3XrzqlaZWd8l3spp+HEtDh89yb37QYQ8esLxU+fwqlaZ9X/sAMDCwpzPP+2NpaUFNta5ad28IUtWrCE2No5N23Yy9L8v6fQaP/pz/tezMwABx0+x7Nd1ANy6HUj5sqXfquy0mJu//ugUK1KYsh+VxLHAfwnFsIHpKrOyewUuJUnknAsX1GprcP3Gbc3fjg75KVW8KEWLOGFiYsLA/3VPtWxbG2tqeFbB1ib36/VVrJCsoWfdWtWZu3A5J06f4+mzUK1bY4qicPb8ZZwKOaZr+9Ki6/yvXaMaM+f+zI8/+3LvQZBWTRzA6XMXAahQvgzPnodqpr+69Z2S/r27MHxwPwD+vXmHCd/NBhKTJAC//Yd58vQZAPXrelHTK7EdTLNGH/PH1p2aROHJ0+fY59OuqfCqVpnli2amub2lShTD3Oz1xdfWJneqMbdo4s23X48AEm8j9fp0hFbMoP/+elNa+0MXS0sLanhWIb/965oml3JltLahfh0vps/+iX0HAwgKeaRV0/Iqns7tWyQr+5uvhmkak9vaWNOyU2ISuv1vP6Z/82Wy+WdM/pI+PTolm/6mP7bt1MRQvWol1vq+vq3UpkUjrXn1+Sw0b1I/zX2gD1eXsiya8x0A+fLmod6hLgDcun0XSEz2jp08CyTu99+WzSFf3jw0bfQxV6/fYuOWv/Raz+Y/dxEbm/ijtVWzBkwYMxQA77o1OHz0JCGPnnDl2k3OX7qqqSF7Ja3z7/ylq5ofom4VytGyaeItwepVK+FRyZVjJ89y5dpNzp6/nK67GZlNkiF0N6BOWpVcrGhhqletRMDx0+zZ609kZBTbduxBrVYD0KX96xqSpPdce/QfpnN9V/9Nfu/Uysoy2YUAoFe39qz4bQOQ2JeHu2t5/t6zH0j8tf+qxslQX06YwU/LVqX4ftJqzqSSVnGamppSyc2Fe/cTa3lu371P6ZLFeR4aBiRWK7fo2FdnOdcy4P5xrRpVNX/nzWOn+Ts0jfY6GaF5k/p8M20uT5+FMvrraYz+ehp57GzxqOxGz67tNL+0MlKpEkWpWb0Kh4+eYs2GbazZsI0cOaxwLf8RrZo3ZFC/HlimUjuUlpOnz9O0XW9NDZ8uoeG6z4u3pev8T0hIoEXHvpy7cCWFpSA0LH3HunaScydfknPnVVuvf5N8jnf7HWK336FkZSiKwvUbt7DPp33ha9KwXrpiSkstr9cNk/PqiPlt9lda+yM9XkREUr9Ft1RrE8NSiMejcsUkf7/+zrl77wGKoiSreW3a+GO9Ykr6/dykQd0U53vXn4VaXkm+y/Laaf5+tX/uJLk9VaKYs9atQk8Pd72ToaTbn3S/mpubU9G1nOY8v3HzTrJkKK3z70aS2/fnL16hYatPdMZw9d+bkgxlVWn9ioTENkEBx08T9fIlu/wOsvnP3QDkyplTkwHrKyrqpY4Y8uqct2qVipT7qBRXrt1gw+YddGjdlIdBIUBijVV6xMbGsuK39QCYmZkxYcwQqlauiJmZKV37fM6Tp8/1rspMz+0ggEgd+8BQeWxtNX8nbdfwKvakoSUkqLWWffo09K3W7VggP/67N7LUdy1HT5zh2r83efoslD17D7Fn7yESEhLSXWuXEhMTE/74/WeWr9rA3gNHuHr9BvfuB3H81DmOnzrH7Tv3mD9rUrrLX/brOs2Xf9OG9ejfpyvWuXOx4rcN/L5+KwBqdeZUces6/wOOn9Zc2B0d8jN5/HCKFSnMw6AQeg9MbHenKOpky+nDLsm5Y6rj3NGXrvM4s54StLNL/Xx/m/2VUfsjqW1/7dEkQh+VLsG4UYMp6FiA02cv8uWE6QCo9Th++nzHOOS3T3ecurzrz0KeJO2czEyT7H90rSN937lpSWs/p3X+6UvX9S8rkGRIT21bNmbkuKnExcWx1Hcth4+eBKBFU2+tR4BLlSjGhf+ewrh0fI/OBpa6TobUTsRe3dozZuIMgkMeM2biDM38HVo3Tde2PH0eSnR0DACuLh8x4vP+QGLj0GfPw1Jd9tSZC5q/ExIStKrdixctjH2+POSxs+V5aBi5c+Xk5oWD5M6VS6uMV48bZzabJA2YQx69fvz3yLFTmjZX6aUoCkWcnTTVxgCnz16kduOOAGz76590JUMmJq/Pg1c1j0nXmTtXLoYM7M2Qgb0BePzkGfWaduZO4H227tiTZjKkUr1uJvhm+Q+DQzR/fzNumKZvlhlzFhu8HYbSdf4/DHqk+btTuxZ079QGgA2bd+gsI7V9Z6jSSR7J7t65DUvmT0s2T1TUS3LmzJFsuiE/EDIyZkP3V2ZLGs+APt1o/9/31ZFjp9Nc9tSZ81Qon3j+JW1jWdTZSef+1XefJ33UfpffQUbpaE8Ghn8WTFL5XGWE4sWKaP6+ffcez0PDNI2WX90+00fS7U/6XR4XF6dVo1iqZDEMlXSZ2jWqsnPzymTzpPSZyQokGQIeP3mqeWorqSrurprbDvny5qFR/drs2LWXg4ePaeZJ2ogYEtsGvUqGOvQYyBc+/XAq6EDwo8dc//cW23fuZchnfQzqXK1rx9ZMmDKb2Ng4Ao4nfpHU8KysaehoKIf89lhZWRIdHcOlK9dZvnI9BfLnY/qcn9L8IB85doovJ0ynft0abNzyl+YWWYH89lSrUhETExM6tm3GkhVriIiMolWnfnzW7xPy5c3Dg6AQLl/9l2079vDT3CkZ3qHgm+xsbciX146nz0K5eTuQIaMmUbpkMeb9tOKty17/xw5+WbmWFk0bUKyIEzbW1hzwf/0E4ZttI/SVtLZrz15/alb3wMrKEpdyZYiIiKRFx760a9WEsmVKUiC/PXcC72vatsTGpr3OpL9AV/y2gcYN6pDDyorK7hUoUriQ5r3v5y+le+c27PY7mGoj2sxUxPl1PFu376ZGtco8DwvXtGd5U9LajYBjp9nldxDr3LkoVaKYwbU19evWwD5fXp48fcbv67eSx86W+nVroE5I4O69hwQcP83Fy9c4dSh5txKGSPpr+9KVf/nzr3/Ily8Pzk4FcU5yPPRh6P7KbEnPp5VrNlGsaGFu3Q5kph7J9YQpczA1MyNXzhxMnPI6/uZN6r9VTO1aNWHClNnExMQScPw03foOoVvH1qgVNXsPHKF61cp06dDS4M9C0ifY1m78E1NTE0xNTTOsf6H89nmpXrUSR0+cITo6hl6fjmBQv084e+Eyf2zbqXc5bVs25uvvZhMXF8fWHXv4buaPVK1Skd/XbSE4JPEHY7mPSuJm4BNqkNjre/mypbl89V8OHTlBv8Ff0q5lE8zMzQi894CTpy/w59//8OD6sbQLMwJJhki5TcDlE/9oNTDt3L4FO3bt1bzOb5+P+nW8tJbx6d+Df/b5s//QUa5cu8mnOvo4MZR9vjw0b1yfzX/u0kx7m1swJiYm9OrWnp+X/05sbByfj5oIJLZJyW+fj8dPnqa4bMniRVjw868s+PlXrelTJ43C/L8nMSaO/YLDR09x6cp1jp08a9Avl4zW55NOmifjflmZ2MDa0SE/drY2KbaL0odaUXP46CkOH02eRAN0bNssXeVW83DH0tKCmJhYTp29oGk4+vcfv1KyeBGu37jN9Nk/pbDOtM+JOjU9NU/w/PDjUn74cSlFnAtx5aQfvbt3wHf1RhRFYf0f21n/x3ZUKhWeHu5GOYZVK7tRofxHXLx8jbv3HtClz+dAYgNlXedo2TIlcChgT8ijJ9wJvE+7bom/+hfPm2pwz865cuXk5/lT6dZ3CDExsTrP+aTJR3pZ585FpYounDl3idCwcM02fjXSh3GjBhtUlqH7K7M1a/wxjg75CQ55zLkLV2jffaAmnlc/6lJiZ2ud7LvT0SE/I4cMeKuYChV0YPbU8Xw+ahJqtZqtO/ZoPdFWpVJiOxpDPwt1a1bjx8W+AKxa+4em76XIkJTbbxlq2qTRNG7bk9jYOPz2H9Z0WfDqmOujsFNBZn47huFjv0OtVjPth0Va71vnzsXP86alq/mDSqViyY/TNI/Wv2rX+L6QR+sN0LxxfWysXz+N06FNs2R9cFhYWLB17VK+nzIOj0puWOfOhZWVJcWKFKZJg7osmvMdrdIxTEDPbu01f5uZmdG25ds10J06cTQ+A3ri6JCf3Lly0rxxfXZsXEGOHKn3lNu5fUsWz5vKR6VLYGFhTplSxVm2cAZdO7TSzGNna8O+HWuY8OUQXF3KkiOHFTlz5KBUiaK0bdkY38XfU03H03SZYeyIQfTt0Qk7Wxty5cxJiybe+P35OzZJnqpKD08Pdwb174G7W3ns8+XB1NQUWxtralavwsols9OdrNrny8Na3wVUdC1HjhxWWu/lsbPlq5E+1K5RFUeH/Jibm5MjhxUVyn/ExDFD+WHquBRKfe1/PTsxfHA/nAsXxMRE++PvUdmNtSt+xKVcGaysLCn3USl+WzYX73rJG/a/C6ampvyxejEtmnhja2ONfb68DOrfg4Wzv9U5v5mZGRtWLqKGZxVNlxRvo0mDuhzatYGuHVvhVMgRc3Nz7PPlwa1COT4f2Jvfls5963UA+C7+nob1a2tue6SXofsrs1nnzsWf63+hbq3q5M6Vk0IFHfj6y88ZP/rzNJddtWwufXt0Il9eO3LksKKRd212b12VYttKQ/T+pCN7tv1G6+YNKZDfHjMzM/Lb56ORd23cKiTWiBj6WWja6GOmThpNiWJF3qpfptRU83Bn69plVHavgIWFOUWdnZj57Vh6dm2nmefN7wxdBvTpxp/rf6GRd23y5rHFzMyMgo4F6NapNf57NursY0hfldxcCPD7g369OlO8qDMWFubY2dpQvmxp+vXqzI6Nb18rn1lUSlZ96F9oiY+PJ3/xysTGxtHIuzabf9fd34YQQogPj66n6AB6DRjOxv96q16zYj6tmjV816F9EOQ2WRYXGxtL1Mtoflu7WdPouFvH1kaOSgghxLsUeO8hQ7/8hn49O+NSrgzRMTFs/nMXm/5rM5Q3jy0f16lh5CjfX3KbLAv6YYEvk2YkDnkxa94SnMp4ah5FLVmiKNPn+/IiIhKAqXOWMH/Jb0aL9W397LueEV+n3UFderTs6sN+/+Npz5hFdOs/ij937gfg738O0Xdw8l6I3wcnz16iXsvexg7DqDZv/4fGHQZQu1kPrv57O9V5HwY/wqN+J81nWh/BIU+o3awHERFv91RkRhnx9Ux+9l2fYeUl/V5Lz/7JDGl9nyT9/BqiU5/hHArQ3fbwTXv2HqJz78FU8GyER52WTJm1QFNjNG70kAy5Pfw+yojrYLZNhgYMm4RX427Uad6Tui170anvCOb8tJLnofo3qp00YyE/LPBNVu7vGzP+UdbcuXLSyLs2S36crlVV+tWwAQwZoLtzq+wks/a7sTRtUJvlC74zdhjJeNTvxLUbdzSvs8qFSl/vIlGLj4/n+wUrmD5hGIf+WkXZ0unrGDU1jg72HPprFblz50x75jRk9o+G9Ozz7PS9tn7FbGp7JT519ufO/XTrP0rnfHny2NK7ewdKFi+KiYkJ5ubmFHEuRLdOrSlWoqTetUIf2nclaJ8v6f1Oyta3yT7v351uHZqjKAq37z5g6aqNfDLwS1Yumka+JL2AGtO4UYO1nip5GPwolbnfL2+Ogi7Eh+DJs1BiYuMoVaJI2jOnQ3x8fKY10hVZl411bhbO/pYz568wbNwM9v/pq3nPo37aQ5EYw/t0rr4fUWYylUpFiWKF+farz+nWfzS/bdjO0E8Ts8yjJ84xf+lqHgSFULigI0M+7Y5nFTfW/vEXf//jj0oFW/7yo6BDfryquXP2whUuXL7OT8vXUsmtHPOnf0XUy2h+XLKagwEniY2Nw6uqO6M/76v5VXf63GVmzP+Fh0GPqO5REWtr/as6J81YiHWuXIwY3JuHwY9o1W0w34wZzNKVGwgNe0G9WlUZP+JTzQl59fot5ixexb8372BjnZteXVrTtoXup9t+9l3Pleu3yG+fl937DmNrnZsJowcRERHJ3MWrCAuPoEPrRvj8ryuQWHU/+fufuH7jDgkJatxcyvDl0P9RyLGAJlYTExOiol4ScOIcn/XtkmydC39Zg3/AaX6c8RXm5uZ8O+snTp27jKIoFC7kwKxvRlLQMb/WMnN+WqlzvwPcvR9Eb59x3Lpzj7KlizP5q89x/G/A2GfPw5i96FdOnLmISqWiYV0vPh/QHQsL82RxnTx7iZFfz8KnX1eW//YH0TGx9O/ZgRrV3Jk4fSF3Ah/gUcmF774aonmi4/6DYH5Y6MuFK/9iZWlJm+be9O3eVvMU17rNO1m5divRMTG0a6nd6PHPnftZs2kHvy+dBcBvG7azadtunj4LJY+dLd06NKdz28QnCvU57kmFhUekuF/j4+NZtmoTf//jT0RkJG4uH/HVsP7kt89Lz88SH3Xu+/l4TFQq+nRvy5pNicMANOuU+Nj0V8MHJHviJ7UyIfGLfNTnfdm4bRdBIU/4uFY1Rn3eh2lzlnLk+FmcCjkwdfxQiv3XzUVqn6fU9kVE5EuGjplKTGwctZv1AGD+9K+o5FaOei17M3fqGNxddfev8vXU+Zw4c4mXL6NxdnLki4E98KhUIdl8V/+9Tb+hEzT7JG8eO7au/jHV4/fKP/sDWL56M1EvX9KwXg1G+PTG3NxMc+4N7teNFWs2ky+PHdMnDqNVt8Hs27YC69y5UKvVrN+ykw1bd/P4yTPy5bVj1Od9qVHNnaMnzrHwlzUEPgjCytKSj2tV44vPemJlacGXk2YT/OgJ476bh4mJCU0b1uarYQPS/Gz4HTzKj0tW8zwsnIZ1vZL18P5KaNgLnfu8oEP+NL8rXn2vpebJs1BadPmMvVtXkDOHFWv/+JvvF6xgo+8cihVx4uCRkyz8ZQ3rfvkBgL/2HGT56s08efqcksWdGTW4D2XLlAASa8hG+PSiXq3E/s/2+x/nh4W/8ueahTrXndrn900Pgh4x5YefuXTtBqYmJhQrUphFs8ZjZWWpWa+jQ36mzVlKfEK8Zl9tWDEHR4fXvWvv9z/OuO/mafanS9lSLJ49UWtdV/+9zawfl3P77n1MTEyoVtmV0UP+h52tdarflUmldb4G3g9izk8ruXD5Omq1mioVXZg1eaTm8zdh1GcsX/0HUS+j2b1paYrXUYCjJ88zd/FKHgY9wsoq8fwcO6w/sbFxTJu7lINHThGfEI9Dfnsmjv4Ml7KlksWb9HzpNShxe5J+JzVtUDvZMsko2VT/LyYqqzdsTzZ94bI1Ss/PxiqKoiiB94OUGo27KX4Hjipx8fHKnv0BSo0m3ZX7D0MURVGUidMXKN//uCLNcr+c9IPy1bdzlfAXEUpU1Etl7OQ5yvgp8xVFUZSw8BdK3Ra9lI3bditx8fHKgcMnlOqNuioTpy/QGfeDoBClyscdlfAXEcliePXeV9/OVSIio5RHj58qzToNVLb9vU9RFEV5/PS5Ur91H2X3vsNKfHyC8u+tu0rjDgOUY6fO61zX4hXrFM+GXRS/A0eV+PgE5afla5WmHT9VJk1fqERFvVRu3r6neDXqply5dlOzfv+jp5XomBjlRUSkMnriD8pnIydryps4fYFSo0l35cjxM0pCQoLy8mW0snjFOmX4+BlKXHy88s3MRUr/LyYqL15EKoqiKAuWrla+GDtNefkyWomPT1Cu/ntbCQ17offxbNFlkNL5fyOU+w9DlOiYGOXzL6dq9qtarVZ6DfpKmb3oV+Xly2jleWi4MmDYJGXRL2t0ln/izEWlqncnZe7iVUpsbJxy9OQ5pZp3Z2Xo2GlKUMhj5cWLSKVjn+HKqvV/KoqiKC9fRistugxSVm/YrsTGxilBwY+Vjn2GK5t3+CmKoijHT11Q6rToqZy7eE2JjY1TFiz7Xanm3VlzrLb9vU/p2m+kZv3/HAhQgkIeK2q1Wjlx+oJSo3E35cyFK3od9zeltl/nLl6lDBz+jfL4yTMlNjZOmbPoV6XfkAmaZat83FG5+u9tzes3z8dX+6pui16a1/qU+dnIyUpo2Avl0eOnSsN2/ZTO/xuhnDl/RYmLj1cmTV+ofPHVdM38qX2e0toXb8amr61/7VVevIhU4uLilF/XbFXqt+6jRERG6ZxX1z7R5/h9/uVUJfxFhPLo8VOla7+Rys++6zUxV/XupEyZ/bPy8mW08vJldLJ1rNm0Q2nVzUe5fO2molarlaDgx8qtO/cURVGU0+cuK1eu31Li4xOUew+Clfa9vlCWrdqkia1Fl0HKvkPHNK/T+mzcCXygVG/UVTlw+IQSFx+vbNi6S6nm3VlZvGKdzv2ha5/r813x5vda0v2ZVIfeXyj+R08riqIoI8bPVFp3H6xs2LJLURRF+X7BCmXWj8sVRVGUU2cvKbWb9VBOnb2kxMXFKas3bFcatP2f5vvmzf2w79AxpUWXQTr3U1qf3zd99e1cZcrsn5W4uDglLi5OOXvhqhIbG5es3Dc/9/ruz6Sfy2s3bid+duLilCdPnyv9hkxQvp31k2belK59SaV2vkZFvVSad/5MWbB0tRIV9VKJjY1TTpy+oCjK62M1YvxMJfxFhPLyZXSa19HGHQYo23cd0JR99sJVRVEUZdOfe5TuA0Yr4S8iFLVardwJfKAEhTzWGa8h50tKsm2boZQUsM9L+IsIAHbvO0IVdxfq1/HEzNSUBnWr416hLLv26t8j7/PQcPYeOsaXQ/+Hde5c5MhhxcA+ndmz/wgJCWoOBZwmv30e2rdsiJmpKXVqeFBVxy9OQ/Tv2YFcOXOQ3z4vXlUrcuX6LQD+2n2QSq7laFivBqamJpQqXoSWTeqx0y/l7SlXpgT163hiampCo49r8ujJM3p1bUOOHFaUKFaYUiWKaBqIFnIsQE3PSlhaWJA7V076ftKOs+evavVqXd3DDa+q7piYmGBlldinUXR0LKO+nkVEZBQLZozT1JiZmZkRFh5B4IMgTE1N+KhUMa1R1/XRoVUjnAoWwNLCgqYNamn2xeVrN7n3IIihn36ClZUldrbW9OnWlp1+h1Mt79PenTA3N8Ozihs2Nrmp7VUFxwL25M6dk5qelbj2b2L5/kdPY22di24dmmNuboajgz1d2zVl13/7+m+/QzT1ro2bSxnMzc34tFdHrFLp48m7TnUcC9ijUqnwqFSB6lUrcursZa15Ujrub0ppvyqKwsatuxg2qCf2+fJgbm7GZ//rwrlLVwl+9ETvfZ6UvmX26NQSW5vc5LfPS2W3cpQoWhh317KYmZriXbc61/47x9L6PBm6L/TVqunH5M6dEzMzM3p2aYVarfDvrbt6L6/P8RvQqyPWuXOR3z4vvbu15a89BzXvqdUKn/fvjpWVpeZzk9TGbXvo36sj5cqUQKVS4ehgT/H/hgKq5FaOsqWLY2pqQuFCDrRr0YBT5y6lGGtan409+49QtZIrdWp4YGZqSodWjXAubFhv+Pp8V+jLw92Fk2cvoVarOXfpGn27t+Pk2cRhgk6euaSpwftrz0GaNqhN5YrlMTMzo1uH5ljnzoW/HsODvMnQz6+ZmSlPnobyMPgxZmZmVKzwEebmmXNjpkzJYomfHTMz8uW1o3vH5pw6dzntBZNI7Xw9dPQ0ZmamDPpfV3LksMLc3CxZLWn//85lKyvLNK+jZqam3H8YzPPQcHLksKJihY8006NeRnP7buLgvEWdC2lq9TOD3CZ7w6MnzzQdKz56/JSCDtq3ZJwKFeDR42d6l/cw+BFqtUKrbtq9yZqoTHj6LJTHT58lW4ejg/1bjd2VtL1TDisrXkQmNiQLCnnE4eNntBozqtVq3F3LkZK8eV53BGdl9WpokqTTLIl6GQ0kXqi+X7CCsxeuEhGZ+JRLbFwcUVHRmgRH18l8/eYdIiNfsnLxNK1bVD06tyImNpYx38whMjKKhh/XYHD/7lgZMDK7vda+sCQqKjHWoODHiaNqt+6reV9BQZ1CdT9Azhw5tNZtZWlJvqT7x9JCsy8eBj/m5u17WvtaURQc/hsW4snT51SuWF7znpmZGfZJRqJ+09//HOK39dsJCkk8n6JjYjS3FF5J6bi/KaX9+vJlNC+jY+j/xURUSQaDNDczI+TR03R9EYWGvdCrzKSjYFtZWWKdZDy7pOdYWp8nQ/eFPtRqNT+tWMc/+wN49jwMlUpFZNTLFEeA10Wf41cwye2Qgg72PH7y+nsmV84cqT4pFBTymCIpDM9z6eoNFi5bw43bgcTExBKfkEDRVHrPTuuz8fjJc61Y34xdH/p8V+irinsFVq7dyrUbdyjkWIC6NauycNnvPA8N59bd+1T573P26Mkzrc8cgFPBAoQ8Nrx3bkM/v0M/7cGSXzcwaOS3qFQqWjSuS/+eHZJ1fJoR7j0IZs5PK7l87SYvX0ajVqsNbreT2vkaFPKYwoUcU+2lOul3RVrX0e8nj+SX1X/QvtdQHB3y06dbGxrWq0GzRnV48uw50+YsJeTxE+rU8OCLgT2ws7UhM0gylER8QgIHjpygpmclIHH06XMXr2rNExT8mEpuicmDrpPB5I1pDgXsMTFRsXPDzzp/0eXPl5egkMda04JDnpI3T8YfcIf89tSrVY1pX3+R4WUDLFj2O9ExMfz28wzy2Nlw7cYdug8YrTXyctIBDV9xcylDbS8PfEZ9x6JZX1OyuDMAOXNYMWTAJwwZ8AkPgh4xbNwMNm7dxSedWiYr4839nhaHAvnIY2fLro2Z03mlQ4F8lCtTAt+FU3S+b58vD8Ehr2tG4uPjefLsuc55g0OeMGn6QubP+Ioq7i6YmZomdkeQzu5SU9qv3To0x8rKkl8XTtW0z3nTm+e8ruOZlK1N7jTLNERan6e0HjAw9DwB2Onnzy4/f36cMY4ihQuiUqn4uFUf0LO/Wn2PX1DIE00SF/zoiVbbq7SGRyjokJ97D4JxcymT7L1x382jZZOP+eHbUeTIYcXvG3ewfdd+zftJB4uFtD8b+e3zcP7Sv9rb+OgJFcqV1jm/rn2uz3eFvjzcyzPuu3nsO3ScqpUqYGuTG/t8eVm/ZSdlShbVJJEF7PMSFKz9Xfsw+LHmB0qOHFZEJxlT8MnT0BTXacjnFxJ/VI75oh8AN24F4jPqW0qVKIJ3nepa86lMDD8/3zRtzlKKFC7IN2N8sM6di/3+x5k04/WwG2l9BtI6Xws65Of+w+AUO4EE7XMqreto2TIlmPXNSNRqNfv9TzB28hwqu5UnX147+nZvR9/u7Xj6LJRx381jya8bGT2kL6lJ6zspxeXStdQH6E7gAyZNX0hEZBTdO7QAoNHHNTh19hL7D58gPiGBvQePcfr8FRp9nNgle748dtwPCkFJ8qWYN48t9x++HvHYPq8ddWtWZcb8XzRjYT15Fsq+Q4mPstaqXplHT56xefs/xCck4H/0NCfPvB4JPiM1a1iHk2cu4nfwKPHx8cTHx3Ptxh0uXb2RIeVHRkZhZWmJde6chIa9YOmvG/Retk2z+gzu141BIyfz783E2w+HAk5x995D1Go1uXLmwMzMFFNTU53Lv7nf01L+o1I45M/Hol/WEhn1EkVRCAp+zOFjZ/QuIzW1varw7HkoG7buIiY2loQENXcCH3LybOLticb1a/K33yEuXvmXuLh4lq7cSPTLGJ1lRb2MRkEhr50tJioV/kdPc/Tk+XTHltJ+NTExoX3Lhsz5aaXmFlZo2At27zuiWTZxPwdrXtvZ2WBiokpx3+tTpiHS+jylJW8eO6JevuTZ8zCt6R71O2mOzZsio15iZmaGna2N5lhFRb3UO2Z9j9+yVRt5ERHJ4yfPWPH7Fv0aff6nXYsGLF25gWs37qAoCsEhT7h9974mfuvcOcmRw4rbd++zcdturWXf/Oyk9dloULcGJ85cwP/oaeITEti8/R8C7wWlGJuuff423xVvsrO1oXhRJ9Zt+RsPdxcAqlZy4fdNO7Ru3zRtWIedfv6cvXiV+IQE1v7xN2HhLzQ/fsuWLs4uP39iYmO5/zCE9Vt36VwfGPb5hcRbi8EhT1AUhdy5c2JiYqLzuyxfHluePAvVSsoMFREZRc6cVuTKmYPgR09Yue5PrffT+q5M63ytVb0ycXHxLF6xjpcvo4mLi0/1mpXadTQuLp4duw8S/iICExMTTeJqamrKidMXuXbjDvEJCeTIYYWFhQWmpmmnLGl9J6UkW9cM/bh0NYtXrENloqKAfV5qVKvEqp+ma24NOTs5MvObkSxc9jsTpy3AqWABvp88ksKFHIDEC/iYyXOo37ovDgXysXbZ93Tr0JxJMxZRr2Vv3F3LMnfqGCZ96cPPvuvp+dlYwsIjyJvHlob1avBx7WrY2uTmh29HM3P+cmYv+hXPKm40aVArXffO01Igf15+nDGOH5esZurspSiKmmJFCjOwT8Y8lvlp705MnL6Qj1v1oUD+fHTv2IL9h0/ovXzLJvUwMTHBZ/R3/DhjHPceBPP9ghU8fR5GzhxW1K/tSYdWjXQuq2u/p8bU1IS5U8fw45LVdOw9jMiolzgUsKddCk/WGSpnDisWzfqaeUt+Y9nKjcTExlG4kAM9OieO4eZZxY3P+nRm9MQfiImNpV3LhpoasTeVKFaYvt3bMXDEZNRqNXVqVKFODY90x5bafh3crxu/rt3KZyMm8/RZKLY21lStXIFGHyf2YfJZn858/+MKvvv+Z3p1aU3vbm3o37MjQ8ZMJS4unjFf9MM+n/btgrTKNFRqn6e0FCtSiNZN69Oxz3ASEhKYO3UMjgXsyZUzB6WK634UvkWjuhw/dYGWXQeRK2cOurZvToH/ahP0oe/xq1vDg279RxMZFUWDel706ab/4LJd2jVFrVYzdvIcHj95Rn77vIz6vA/Fixbmq2EDmPPTr/y4ZDXlypSgcf2aHEjyuezTrS3fL1jBslWbaOJdizFf9Ev1s1GsSCEmjx3MrB9XEBoeToO6XnhVc08xNl37/G2/K97k4e7Cpj/3aJ4GrFrZld82bNdqf1mlYnlGfd6Hb2ct5smz55QsVoT507/SXIAH9e3C+Knzadi2HyWKOdO8UR02bt2tc32GfH4Brly/xZxFKwmPiMQmdy5aN6tPXR3nQNVKFahQrjTNOn2KWq2wdtn3Wk+T6WP4oF5Mnb2EDVt2UaRwIZo2rM2tO/c076f1XZnW+ZozhxULZ33N7EW/0qLrIACquLvofLoSUr+OxsXFs2uvP7MX+RIXF49jAXu+Gz8EO1trnj4PZcb8Xwh59ARLSwuqVXZlQK+OaW6/laVFsu+kJt610lxOxiYTQmRr23ft507gQwb372bsUIQQRiLJkBBCCCGyNWkzJIQQQohsTZIhIYQQQmRrkgwJIYQQIluTZEgIIYQQ2ZokQ0IIIYTI1rJdP0NqtZqHDx9ibW2dZq+uQgghxIdKURRevHhBoUKFMmVokPdJtkuGHj58iLNzyp1jCSGEENnJvXv3KFy4sLHDMKpslwxZW1sDiQffxiZzBnwTQqRuz/4AABrW8zJyJEJkX+Hh4Tg7O2uui9lZtkuGXt0as7GxkWRICCNp36qxsUMQQvxHmoxIA2ohhBBCZHOSDAkh3rlh42YwbNwMY4chhBCAJENCCCGEyOay3UCt4eHh2NraEhYWJm2GhBBCZFtyPXxNaoaEEEIIka1JMiSEeOd2+vmz08/f2GEIIQSQDR+tF0IY3/Lf/gCgiXctI0cihBCSDAkhjGDC6EHGDkEIITQkGRJCvHMVypUydghCCKEhbYaEEEIIka3pVTMUHh6ud4HZ/fE8IUTaOvUZDsD6FbONHIkQQuiZDNnZ2aU5domiKKhUKhISEjIkMCHEh8vTw83YIQghhIZeydC+ffsyZeUHDx5k1qxZnDp1iqCgIDZv3kybNm1SXWb//v0MHz6cS5cu4ezszPjx4+ndu3emxCeEyBwjfHobOwQhhNDQKxmqW7dupqw8MjKSihUr0rdvX9q1a5fm/Ldv36Z58+YMHDiQ1atX4+fnR79+/ShYsCCNG8so2EJkVfHx8SQkqNOcz9TUBDOzD+e5juy63RlN3/34oZHz4t1J114+dOgQP//8M7du3WLDhg04OTmxatUqihcvTq1a+vcb0rRpU5o2bar3/IsXL6Z48eL88MMPAJQrVw5/f3/mzJmTYjIUExNDTEyM5rUh7Z9E9nbv8FTC7wcAKY1Yo0JlYgqAdaFqONf86p3FZqhr23oSHx2mud2tqONTnlllgkql37MV+mz38d/akdMs8TMYrwZFge1nzDFRQesqcVrzPg5LYE+wN1Mnjkq1zGvbehL/8tkbcZsm2b4EXh03sxx5+ajVSr3KU5kkfiUqigKK7lv+iqKQEBpDzN3IVMuMT0jgSGAcE/dFpzofgJmZGT4Deqa53YbI6ETMWAnJV5Nmsnj56gwtc/vkouS3NU02PS7JITczAZUq8XyNT2OzU5rXPPkqdK/LFHQ1RNH38yDensHJ0KZNm+jRowfdu3fn9OnTmkQjLCyMqVOn8tdff2V4kK8EBATQoEEDrWmNGzfmiy++SHGZadOm8c0332RaTOLD9eLhcVJOhF5T1PGEPzia+QG9BU3ioMq4X5mKOv6/fZTKeuPjyWkWg0qlIukwiMdvmaFCOxlSqVTktzVl3oTljBvpk+oFOlki9CqmFOaNiYlNPc7/ytNnoMb40GhiH0aQ1sO4pqjxdNIvqYyPj2feorS3W1+GJhCf/e8TpqRywd3j2w+n3E/fOq70+KQCFO3rwNjlIRlWZn5b02TnpC6JyXXaZ4VKhV7lGSKtz4OFhXmabXmF/gweqLVSpUoMGzaMnj17Ym1tzblz5yhRogRnzpyhadOmBAcHpy8QlSrNNkNlypShT58+jB07VjPtr7/+onnz5kRFRZEjR45ky+iqGXJ2dpaB6bKxe4enpnkRh8SLvcrEjPIdt6Q636V1LQA0tQpp0ac2Rd8Y9S3vVYwunbfrVaY+Tk2rTXzoS1Qm5qnOl9MtL6jAc+gtzTQT08SfzOokD1wcm1cC0J4vJfrOe2xeCc1FSq3Aq4oNlSrx1/wrr+bRZ917e+cCwMLNIdX5Ys+HJF5H9bhePVNM6fBr6rXW0/o6ULtCrrQLM9Chi5FpJhpH55bAxERFXILCqyuGqQmY6Ng2fWpS3pRaDYpKpSI2XqHW8NSPzbS+DtR1zYVpCvmnAsT/d7pZmOl3vP1nl8DCLHH9AD9ufcq6A2EAdK5ry+et82nK0ydGQxyZUwIz09frfiUuXuHj0bd5FngOS0uLt1qHDNT6msE/Qa5du0adOnWSTbe1tSU0NDQjYspQlpaWWFpaGjsMkYW8eHhck+hAyreM1NHxxNwP5fhYr1TLe3Wx1+c3mqKOJ/z+kcTkJIXbOskkuW2lKGpQtK80mvJAr9s8aXlyZSOPLq3RuXwuh0oUrTMRgIToWKyK26V5uygxoMT/gm6cwNIi+Rd4fHw8N7d1xNREhf/sEmkWp++v8JehseSwTVxfwuMoYh+8AMDUzhKzYnavw1MU4sNi2PlJTv22RY+DbVUmL6Y5kyeK6sg4Xv6bWBOlMjchp0t+rMJi2Ns79eNlVdSM/3JIEtSg/m/zTVSknAAkSUxUJN6OSUqlUuHtnptj83Jp3bZ5Mzl5dZ5+uSwY/0tRAAxvl492tWy15rMwU6FSQa0vbgLgWTYHPwwoqDO20IgEWky4C8C+mcUxN9O9U1UoWJipODqvpM7k6/XWpVHLA1hYJH4+Is4+hDg1e3v9l1yqTFGZ/PcZUydoPmOx50JIsLMiR2l7AKZNGs1PJRM/a6E3t/Pk0uvbr3mKePAscHOqMegrPj6eX75rRu0KuZIlnXGp3OEW6WdwMuTo6MiNGzcoVqyY1nR/f39KlEj7S+xtODo6EhKi/QsmJCQEGxsbnbVCQujyKvl5VeNzbVtPEmKS/ypXWSiY57MiJiLti33S6mqzHPko0+IXzevLG9qkM9LENkn25TtTwKUrAM9v7Sbo1CLNHKkmUW8wy5FXr/lePruuVyJlUTA3ZnmsMMtjpSP0/25DAKjjUf67cltaWGBpacG9B4k1yM5OjonTLS14EJEfx5yPdV60k4pLgNh4hUMX0z4u8TefEalSEZvweh+ZmYDyLJqIZ8lrsU1UbyQZKVx8TW11/8D6ecczVvmFAvD3d0XJZ6IiQa3CLMkG5SpRAbd+MxK3JeoJ1//snWJ5b65TpVKhqBWi74YR++QlAFaFcpOjUG6dyySExRD3X7JqksMUs9LayYuiKHoldoqi8DgsAdfq7dj2d8q304KOz8TUwoZngQMBiHp0lodHp+qct6BjPp4Fbktz3UHHZxIVfBKTNM51lYmZ3m33jp3wSHOeVxJCo4k8nXjdiTw9i7vM0jmfeflwLGunXlNzfdVoQi8f0mu9HgkJ+P0ZRlDOnHzibaeZ/vHo2/oFLgxicDLUv39/hg4dyvLly1GpVDx8+JCAgABGjhzJ119/nRkxanh5eSVrk7Rnzx68vFL/5S5EalJqXPuqRqjatIBUlz/3c0NMbSzQp82xIV/YuuQp0Yg8JRqla1l96RubisQLsyrln+sAqF/GkxCt/XN2xPiZgHani037+xIfH09EyAUeHNHdzs/ELAelm/0KQPkO8Omk1GM8+3UNANy++B2rAsUBuLVqJC9untA5fyHv/jjU/gSAJ8f/4MFf85LNoyTEocQrWFiYo46NJ+r866SqTxFT+va1S5zv5nPiHBxwH5byBd88p/1/tXnx5PYorJlevPFSTC0TE5d7B74kJuy2JqmMOv8MFWhq2JQnsUQ90d2GKin1ywSizmvPpyQkttlSmWrXYGk3a09UqGwtvp86LtV1FKs9Xuu1pXM18jhvSTM2Q8rMSJ4zT6b6/rEvq4KiaNckK2pQJ/+x8PxC2l3QhF4+hJIQl2x/62KKmjrFrag4SbvcZx0S/7ewSLsMoT+Dk6ExY8agVqvx9vYmKiqKOnXqYGlpyciRI/n8888NKisiIoIbN25oXt++fZuzZ8+SN29eihQpwtixY3nw4AErVyZerAYOHMiCBQsYPXo0ffv2Ze/evaxfv54dO3YYuhkiG0u8hUSat79eXShezVemzxzsylQH4PamqTw++WeS+VR4ztR9gU3a5uj6qtEEbf+ToO1/phmnXfnalOkxM835jCXx9lhkqsliTEwsx79Kvp87tNad0JmZmWHnVAm7NNppGcrW+SPN3+X6zddrGafaXXCq3SXVeWJCQzh3sY3O9wp4tqNwwwFprse6ULVk7cMsLCww+689iIlKlVh5Y2KGTeFqVOiacU8t6ltToSTEEXbVP8PWmxkMqXXRV54KHxN6+RB5K3xMqe6JNVwv7l7gymLt45r4HaDo9Z2iMjVP8wcWvP7eedt2QUI/BidDKpWKcePGMWrUKG7cuEFERATly5cnd27d1bSpOXnyJB9//LHm9fDhiV309+rVC19fX4KCgggMDNS8X7x4cXbs2MGwYcOYN28ehQsXZtmyZdLHkDBMxj3wYXCh+v4yVBLi9Ppiz4wLgL70/YULYGGqYucnOTk3KbHPsmL/TT9+TLsGKKsngG+ytHNI88J28cdeRD28rvO9Yu3GpFkTV6Jh5g1Zou++TusinxW8+mylysRMc0vb1Crta5au/WNd1DXZMT82xlOrtii1OHI5l9f8nfRH1ZsUdYKm6w6R+dL9DKeFhQXW1tZYW1unKxECqFevXqqNIH19fXUuc+bMmXStTwiA6NuhJITFaD0FpTI1p+p3BzWvT3/XlLjwxyn+iive/iuKt0+8iB0brX/7g1frSusCqu/Fx5Bq94ynQlHHa8Vaqtt35HX1BiBw+zyCD69NbKOjKJibJLlIqFQ6bzvoc6sBjJsEinfLkNqrpMmOLpUn7sFMjyTIUJ7Tj2m9Pv1dU+IjQ3XO69Sgv97lKglxyb4L3vyuEhnD4GQoPj6eb775hvnz5xMREQFA7ty5+fzzz5k4cSLm5nIfU2RtCWExelXkqEzNsStfO/MDekv6VrtntONjvdL+JY72Y9aW/7VzWPe8AtbF3Zn0pQ/hN09xddlgza0GfRiUBBq5L5YKn/+a6vsP/lkGgFODfu8inHTTdWHWJaNr9/Q91q8+r1mhZrHy+L/1mi/pj6o3XV81mueXDiT7jBnnh8+Hz+Bk6PPPP+ePP/5g5syZmobLAQEBTJo0iadPn/LTTz9leJBCZDhV6g2j9f0ySyxLv471AJSEeJK2LXAZvIJcTmUBuL5yFKFX/P+bL7EdUlaXWiJWpMVQHBp+Rt4iFTXTngUGYGlpwc9Dvib0vyfKbEpWodq0AKPWsBnTA7/EJw/TSoZ01ZAk3f6z01sTG/ZI8zojEwO78rX1rp3JjBo7fY71laWDSIiOyPB1G0uZHjN5fvkQ/64arTVdaoUyh8HJ0O+//87atWu1htFwc3PD2dmZrl27SjIksjyVZcbehzfsvr4hDZYypXFThrHMVzjtmVLwy/xv33r9iqJOMdmxzFeYiiM34PHtgbdez7vwZq2LXblalOmZ+Ah35IOrXFrQJ8Unv1IqLyOTkvehbdGLWx9e84k85WsbpdY3OzI4GbK0tEzWxxAkNm620NGZmhBZjRKTvs4IUy1Tz1sIr+j6gnt18QP92yEpCfGQJBm7/FN/IgIv6pzXkJqCqJBbXJzbPcX3Pb49QMWRG/Qqy5hMzLL+d5K+tS5p3QZyH7NV8/f7UCNmSFsguTUkMpvBydDgwYP59ttvWbFihaZn55iYGKZMmcLgwYMzPEAhsrqchcsRefdCiu1nkn2RG9CGJe2Lmn49TZvlsMG2VDUAHu7/lfu7Fuucz7a0Jx/1nat3fOkVcOIsAF5V3ZO9p8+F3JBHlLO6tBLUXE5l07WdOR1Laf6+s/V7Hh3dpHM+Y7WzMbQtkBCZSa9kqF27dlqv//nnHwoXLkzFioltAc6dO0dsbCze3t4ZH6EQGcxExxAJb8PCxp4oU90fJQvbAsl+sevzxW5VoDjRj+8aHEv5z5YavIwuOR1KZGqiMWdRYt9hXivcNdPyuNbX/9aOygSLPLqHeRCJCU7+Ki3TnE9JiMM8px0AodePcn3FMJ3zmeWyM6wdnZ4+lIRWvP/0SoZsbbW7cG/fvr3Wa2dn54yLSIhMpo5K+wkoQxjyq1rfL359b0Gl53ZIoXq9KFSvl8HLZaRhg3omm2bIfjw+1ovY50EZGdIH5c19Waz1SIq1HmmkaFIXHx3B6W8apvi+24j1WNnLNUZkLr2SoRUrVmR2HEKIbETX7TFhXHZlqmdILY2+7eekLZDIStLd6aIQIvM8OpF4a61A1dZGjuTdOTUp8TZ7lUl+Ro5E6HJifJ0U28WVG7gE66KuejcGf8XE3BIzq9x6PTaf0tNiRZoPwbFWV4o0H6L3eoV4U7qSoY0bN7J+/XoCAwOJjY3Veu/06dMZEpgQ2dmdP6ajJMRx54/pWtNzFiqj6cQvLuL5e/vr+n9DEgd1TvqIfUJMlM5ahbL9FmBTsgoAN9dN4unZXe/tdn/oTEzMtMbxSs3xsV6o42IybN2OtbpmWFki+zE4GZo/fz7jxo2jd+/ebN26lT59+nDz5k1OnDiBj49PZsQoRLZj6OPW7xtnJ8dk0wypVXhft/t9pk9nf88u6jeciqHK9V+UKeUK8YpKSW1wMB3Kli3LxIkT6dq1K9bW1pw7d44SJUowYcIEnj17xoIFCzIr1gwRHh6Ora0tYWFh2NjYGDscYQTHvkzsw8dzxkkjR/Lhi4mJfaMH6nMyCvcH7NUQLUlr7QrW7YFzk0EAPDmzk1vrEwfn/ZC6R3hfyfXwNf3HEfhPYGAgNWrUACBHjhy8ePECgB49erBmzZqMjU6ITGCSyxyTXHKLRYiMZle+tt63L6V2T2QlBt8mc3R05NmzZxQtWpQiRYpw9OhRKlasyO3bt1MdgV6IrEIdmbGP1gvDrd+yE4BObZoYORKRkdLqHsG+UhPsK8kxF1mPwTVD9evXZ9u2bQD06dOHYcOG0bBhQzp37kzbtm0zPEAhxIdn49bdbNy629hhCCEEkI6aoSVLlqBWqwHw8fEhX758HDlyhFatWvHpp59meIBCZLSM7oFaGO6H70anPZMQQrwjBidDJiYmmJi8rlDq0qULXbp0ydCghMhMGd0DtTCcrqfJhBDCWPRKhs6fP693gW5ubukORgiRPYSFRwBga5PbyJEIIYSeyZC7uzsqlSrNBtIqlYqEhLRH0BZCZG/9h04AYP2K2UaORAgh9EyGbt++ndlxCCGykUb1axo7BCGE0NArGSpatGhmxyGEyEb69Whv7BCEEELD4EfrhRBCCCE+JDJqvch2VBamxg4h2/thoS8AI3x6GzUOIYQASYZENqTESiN/Yzt2Uv8nVIUQIrNJMiSEeOfkKTIhRFYiyZDIflTGDkAIIURWolcylCdPHlQq/a4gz549e6uAhMh0Mp6w0V28cgOACuVKGTkSIYTQMxmaO3duJochhMhOJs9cBMjtMiFE1qBXMtSrV6/MjkMIkY30/aSdsUMQQggNvZKh8PBwvQu0sbFJdzBCiOyhiXctY4cghBAaeiVDdnZ2abYZUhRFxiYTQgghxHtHr2Ro3759mR2HECIbGTZuBgBzpnxp5EiEEELPZKhu3bqZHYcQQgghhFEY3M/QwYMHU32/Tp066Q5GiHfCXIbkMzapERJCZCUGJ0P16tVLNi1peyJpMySyvDi1sSMQQgiRhRj8E/n58+da/x49esTOnTupWrUqu3fvNjiAhQsXUqxYMaysrPD09OT48eOpzj937lw++ugjcuTIgbOzM8OGDSM6Otrg9QohjGennz87/fyNHYYQQgDpqBmytbVNNq1hw4ZYWFgwfPhwTp06pXdZ69atY/jw4SxevBhPT0/mzp1L48aNuXbtGgUKFEg2/++//86YMWNYvnw5NWrU4Pr16/Tu3RuVSsXs2dJ5m9CPiZWMQmNsy3/7A5BH7IUQWUOGXRUcHBy4du2aQcvMnj2b/v3706dPHwAWL17Mjh07WL58OWPGjEk2/5EjR6hZsybdunUDoFixYnTt2pVjx469/QaIbEMdHW/sELK9CaMHGTsEIYTQMDgZOn/+vNZrRVEICgpi+vTpuLu7611ObGwsp06dYuzYsZppJiYmNGjQgICAAJ3L1KhRg99++43jx49TrVo1bt26xV9//UWPHj1SXE9MTAwxMTGa14Z0ICmEyBwyJpkQIisxOBlyd3dHpVKhKNqjXVavXp3ly5frXc6TJ09ISEjAwcFBa7qDgwNXr17VuUy3bt148uQJtWrVQlEU4uPjGThwIF999VWK65k2bRrffPON3nEJIYQQInsxOBm6ffu21msTExPy58+PlZVVhgWVkv379zN16lQWLVqEp6cnN27cYOjQoXz77bd8/fXXOpcZO3Ysw4cP17wODw/H2dk502MVQqSsU5/Ez6QM1CqEyAoMToaKFi2aISu2t7fH1NSUkJAQrekhISE4OjrqXObrr7+mR48e9OvXDwBXV1ciIyMZMGAA48aNw8Qk+cNxlpaWWFpaZkjMQoiM4enhZuwQhBBCI10NqP38/PDz8+PRo0eo1dp9tuh7q8zCwoIqVarg5+dHmzZtAFCr1fj5+TF48GCdy0RFRSVLeExNTQGS3bYTQmRdI3x6GzsEIYTQMDgZ+uabb5g8eTIeHh4ULFgwzQFcUzN8+HB69eqFh4cH1apVY+7cuURGRmqeLuvZsydOTk5MmzYNgJYtWzJ79mwqVaqkuU329ddf07JlS01SJERaTHKZGzsEIYQQWYjBydDixYvx9fVN9QkufXXu3JnHjx8zYcIEgoODcXd3Z+fOnZpG1YGBgVo1QePHj0elUjF+/HgePHhA/vz5admyJVOmTHnrWET2oY6MM3YI2d6yVZsA6NejvZEjEUIIUCkG3l/Kly8fx48fp2TJkpkVU6YKDw/H1taWsLAwbGxsjB2OMIJjX3oA4DnjpJEj+fDFxMSSt0hFzetngeewtLSQBtRCZAFyPXzN4OE4+vXrx++//54ZsQjxTpjkMpdbZUa2dN5kls6bbOwwhBACSMdtsujoaJYsWcI///yDm5sb5ubaFxUZFkNkdXKbzPhsbXIbOwQhhNBIVw/Ur3qavnjxotZ7b9OYWgiRfdx7EAyAs5PubjSEEOJdMjgZ2rdvX2bEIYTIRkaMnwlImyEhRNZgcJuhpNasWUNkZGRGxSKEyCY6tG5Eh9aNjB2GEEIAbzlq/aeffoqnpyclSpTIqHiEENlApzZNjB2CEEJovFXNkPT6LIQQQoj33VvVDAnxPjKxktPe2CbNWJj4/5c+Ro5ECCHeMhn6+++/KVSoUEbFIsQ7oY6ON3YI2d6rp8mEECIreKtkqFatWhkVhxAiG/ll/rfGDkEIITQMbjMUEhJCjx49KFSoEGZmZpiammr9EyLLMzdJ/CeEEEKQjpqh3r17ExgYyNdff/3Wo9YLYRRxamNHkO0FnDgLgFdVd6PGIYQQkI5kyN/fn0OHDml6oRZCCEPNWbQSAK8V7sYNRAghSEcy5OzsLI/UCyHeyrBBPY0dghBCaBjccGLu3LmMGTOGO3fuZEI4QojswKuqu9wiE0JkGQbXDHXu3JmoqChKlixJzpw5k41a/+zZswwLTgghhBAisxmcDM2dOzcTwhBCZCf/G/I1II/YCyGyBoOToV69emVGHEKIbMTZydHYIQghhEa6Ol1MSEhgy5YtXLlyBQAXFxdatWol/QyJ94P0BmF0MgyHECIrMTgZunHjBs2aNePBgwd89NFHAEybNg1nZ2d27NhByZIlMzxIITKUPAwphBAiCYOfJhsyZAglS5bk3r17nD59mtOnTxMYGEjx4sUZMmRIZsQohPjArN+yk/Vbdho7DCGEANJRM3TgwAGOHj1K3rx5NdPy5cvH9OnTqVmzZoYGJ0RmUFnI7Vxj27h1NwCd2jQxciRCCJGOZMjS0pIXL14kmx4REYGFhUWGBCVEZlJiE4wdQrb3w3ejjR2CEEJoGHybrEWLFgwYMIBjx46hKAqKonD06FEGDhxIq1atMiNGIcQHxtnJUZ4oE0JkGQYnQ/Pnz6dkyZJ4eXlhZWWFlZUVNWvWpFSpUsybNy8zYhRCfGDCwiMIC48wdhjiLSiKQkxMbKb8e9shn86ePcvu3btTnWfLli1cv379rdbzNh4+fEj37t2Ntn6hzeDbZHZ2dmzdupV///2Xq1evAlCuXDlKlSqV4cEJIT5M/YdOAGD9itlGjkSkV2xsHHmLVMyUsp8FnsPSMu1mF2q1GhOT5L/pz549y8WLF2nUqFGKy27ZsgUzMzPKlCnzVrGmV6FChVi9enWy6QkJCdJNjREYXDP0SunSpWnZsiUtW7aUREgIYZBG9WvSqL48cCEMd+fOHVxdXenSpQsfffQRI0aMoGrVqlSsWJHVq1eTkJDAhAkTWLlyJe7u7vz111/Jyjh27Bjbtm1jyJAhuLu78+jRI06fPk21atVwdXWlZ8+eREdHpxjDrl278PLyolKlSnzyySfExsYSEBBAtWrViI+PJyQkhNKlSxMcHIyvry/t27enTp06lClTRjOKw507d/Dw8ADA19eXdu3aUa9ePTp27Ejt2rW5du0akFgDV6ZMGRnqKpMZXDOUkJCAr68vfn5+PHr0CLVarfX+3r17Myw4IcSHqV+P9sYOQbzHrly5wurVqzl69Cjh4eGcOHGCly9fUr16dZo0acLkyZO5ePEi33//vc7lPT09adWqFR06dKBFixYAeHt7s2zZMjw9Pfnss89YtGgRw4cPT7bskydPmDVrFnv37iVHjhxMmDCBpUuX4uPjQ506dZgxYwZnzpxhwoQJODomtos7ceIE58+fx8zMDA8PD1q2bJms9ufcuXOcOXMGGxsbli9fzsqVK5kyZQr79+/H1dVV6wlukfEMToaGDh2Kr68vzZs3p0KFCqhU0p2veL+Y5DRPeyYhRKosLMx5Fngu08pOTZkyZXBzc9MkPb/99hsAYWFh3Lp1y+D1hYaGEhMTg6enJwA9evRg1qxZOpOho0ePcv78eby8vACIiYmhefPmAHz33Xe4u7tTqlQpevTooVmmSZMm2NnZAdCsWTMCAgKoVauWVrmNGzfGxsYGgE6dOlGtWjW+/fZbVq5cKcNgvQMGJ0Nr165l/fr1NGvWLDPiESLTqaPijB1CtvfDQl8ARvj0NmocIv1UKpVe7XoyQ86cOYHENkM///wzdevW1Xr/0qVLmbZutVpN8+bNWbFiRbL3Hj16RGxsLE+ePNFq+5O00kClUumsRHi1TQC5c+emWrVq7Nixg4MHD7JkyZJM2BKRlMFthiwsLKSNkBDirRw7eZ5jJ88bOwzxnmvUqBGLFi0iISGx77CLFy+SkJCAtbW1zv7wkko6j52dHZaWlpw4cQKA1atXU6dOHZ3LeXl5sW/fPu7evQtAeHg4t2/fBqB///78+OOPVK1alR9++EGzzM6dOwkLCyMyMpK///6b6tWrp7ltffr04dNPP6Vly5aYm0ttdmYzOBkaMWIE8+bNe+tHH4UwFpNc5pjkki8XY1q/YrY8SSbeWv/+/SlWrBiVKlWiQoUKDBs2DEVR+Pjjjzl9+jSVKlXS2YAaoEuXLnz77beaBtS+vr74+Pjg5ubGixcv+Oyzz3Qulz9/fpYuXUr79u1xc3OjTp063L17l19++YUCBQrQvHlzpk+fzq+//qppBF21alVatmxJpUqVGDBggF5jeL5Kxnr27JnOvSMMoVIMzGratm3Lvn37yJs3Ly4uLsky1j/++CNDA8xo4eHh2NraEhYWprk/K7KXY18mPsHhOeOkkSP58MXExGo9fq3vI9NCfCh8fX1Tbcydklu3btGxY0dOnTqVSZHJ9TCpdPUz1LZt28yIRQiRTVy8cgOACuXklrsQb1q2bBmTJ09m6dKlxg4l2zC4Zuh9J5mwkJqhdyelmqFOfRKf0pFbZSKzrVixItnoCB07dmTcuHFpLtu2bVtNe6BXVq1ahaura4bGaCxyPXzN4JohIYR4W30/aWfsEEQ20adPH/r06ZOuZTdv3pzB0YisKt09UGeUhQsXUqxYMaysrPD09OT48eOpzh8aGoqPjw8FCxbE0tKSMmXKpNhATgiRNTXxrkUT71ppzyiEEO+AUWuG1q1bx/Dhw1m8eDGenp7MnTuXxo0bc+3aNQoUKJBs/tjYWBo2bEiBAgXYuHEjTk5O3L17V9OZlRBCCCGEoYyaDM2ePZv+/ftrqjAXL17Mjh07WL58OWPGjEk2//Lly3n27BlHjhzRPMVWrFixVNcRExNDTEyM5nV4eHjGbYB4L0kP1MY3bNwMAOZM+dLIkQghhBFvk8XGxnLq1CkaNGjwOhgTExo0aEBAQIDOZbZt24aXlxc+Pj44ODhQoUIFpk6dqulwS5dp06Zha2ur+efs7Jzh2yLeL+qoOOmFWoj31KhRo3BxcWHKlCl6L+Pr68vIkSPfar2hoaFp9gR9584dcubMibu7O+7u7owaNUrnfL1792b79u1vFY/IWOmqGYqMjOTAgQMEBgYSGxur9d6QIUP0KuNVd+UODg5a0x0cHLh69arOZW7dusXevXvp3r07f/31Fzdu3GDQoEHExcUxceJEncuMHTtWa3yZ8PBwSYiEMDKpERLp5evrS0hICCYmmfNbPukwGkm9SoYGDBiQ6vLly5fn5El5UvV9Y3AydObMGZo1a0ZUVBSRkZHkzZuXJ0+ekDNnTgoUKKB3MpQearWaAgUKsGTJEkxNTalSpQoPHjxg1qxZKSZDlpaWWFpaZlpM4v2jskz+RSeEMNyVTR1R1BlXy6oyMadc+w0pvt+2bVueP3+OlZUVuXLl4vnz5yxZsoQZM2Zw8+ZNzp8/z/jx49m2bRvbt29n+PDh2NjYULFiRfLkyZNiucWKFaNLly7s2rWLmTNnEhwczPz584mNjcXb25vZs2czbtw4Ll++jLu7O+3atWPChAkGbdukSZNYs2YNTk5Ock3KggxOrYcNG0bLli15/vw5OXLk4OjRo9y9e5cqVaoY1MOmvb09pqamhISEaE0PCQnB0dFR5zIFCxakTJkyWll7uXLlCA4OTlZDJURKlJgElJiUb62KzLfTz5+dfv7GDkO8ZzZv3oydnR0RERGauwr+/v7Y2dkRFBSEv78/tWrVIjo6msGDB+Pn50dAQIBmWIzUODs7c+bMGQoXLszWrVsJCAjg3LlzPHnyhB07djBlyhTKly/P2bNnU02Erl27RqVKlfD29tbUEJ04cYIdO3Zw/vx5Vq9enWJTEGE8BtcMnT17lp9//hkTExNMTU2JiYmhRIkSzJw5k169etGunX79h1hYWFClShX8/Pxo06YNkFjz4+fnx+DBg3UuU7NmTX7//XfUarWmivT69esULFgQCwvp4l+I98Xy3xKH7ZHH699vqdXiZCYLCwscHBy4f/8+t27domfPnvj7++Pv74+Pjw9Xr16lTJkymiYRnTp1IjAwMNUyO3bsCICfnx9Hjx7FwyOxc9aoqCiqVKmCi4tLmnEVLFiQO3fukC9fPgICAujYsSP//vsvhw8fpm3btlhaWlKwYEHq16//lntAZDSDa4bMzc01iUiBAgU0J5itrS337t0zqKzhw4ezdOlSfv31V65cucJnn31GZGSk5umynj17MnbsWM38n332Gc+ePWPo0KFcv36dHTt2MHXqVHx8fAzdDCGEEU0YPYgJowcZOwzxHqtZsybr16+nYMGC1KpVi8OHD3Py5ElNEqNSqQwqL2fOnEDij/L+/ftz9uxZzp49y/Xr1xk6dKheZVhaWpIvXz4gcXR7e3t77t+/n654xLtlcDJUqVIlTpw4AUDdunWZMGECq1ev5osvvqBChQoGldW5c2e+//57JkyYgLu7O2fPnmXnzp2a6s/AwECCgoI08zs7O7Nr1y5OnDiBm5sbQ4YMYejQoTofwxdCZF0VypWSccnEW6lVqxZz5syhZs2auLu7s3v3bgoUKIClpSVly5bl+vXr3L9/n/j4eDZs0L8Gy9vbm3Xr1vH06VMAHj16RFBQENbW1rx48SLVZR8/fqx5uvn69esEBwdTqFAhatWqxZYtW4iNjSU4OJh9+/alf8NFpjD4NtnUqVM1J8SUKVPo2bMnn332GaVLl2b58uUGBzB48OAUb4vt378/2TQvLy+OHj1q8HqEEEJ8OGrUqMHDhw+pWbMmpqamFC5cmEqVKgFgZWXF/Pnz8fb2xsbGBjc3N73LdXFxYdy4cXh7e6NWq7G0tMTX1xcXFxcqV66Mq6srHTt21Nlu6ODBg0yYMAFzc3PMzMzw9fXFwsICDw8PmjZtiqurK05OTlSvXj3D9oPIGDJQq8h2ZKDWd0cGahUi65Lr4WsyUKvIfuTevdF5euj/S10IITKbJEMi+8lelaFZ0gif3sYOQWRDPj4+HD58WGvajBkzaNy4sUHlXLhwgR49emhNK168uIxy/x6TZEgIIUS2sHDhwgwpx9XVlbNnz2ZIWSJrMNrYZEKI7GvZqk0sW7XJ2GEIIQQgyZDIhlSmJqhM5dQ3pt17D7N77+G0ZxRCiHcgXbfJ/Pz88PPz49GjR6jVaq330vN4vRDvkpKgTnsmkamWzpts7BCEEELD4GTom2++YfLkyXh4eFCwYEHpVVMIYTBbm9zGDkEIITQMvlewePFifH19OXbsGFu2bGHz5s1a/4QQIi33HgRz70GwscMQ76FRo0bh4uLClClT9F7G19eXkSNHvtV6Q0NDWbJkSarz3Llzh5o1a2JlZcWCBQu03lu2bBmlS5fmo48+Yvv27TqX7927d4rvicxlcM1QbGwsNWrUyIxYhBDZxIjxMwHpdFEYztfXl5CQEM0YmRktISEBU1PTZNNfJUMDBgxIcVkbGxtmz57Ntm3btKY/ffqUWbNmcfr0aV68eEG9evVo0qQJZmbyQHdWYfCR6NevH7///jtff/11ZsQjhMgGOrRuZOwQRAY4Mb4OSkJchpWnMjWn6ncHU3y/bdu2PH/+HCsrK3LlysXz589ZsmQJM2bM4ObNm5w/f57x48ezbds2tm/fzvDhw7GxsaFixYrkyZMnxXKLFStGly5d2LVrFzNnziQ4OJj58+cTGxuLt7c3s2fPZty4cVy+fBl3d3fatWuncziOvHnz4unpyd9//601fdeuXTRr1gxra2usra0pX748J06cwMvLi0mTJrFmzRqcnJywtLRM/84Tb0WvZGj48OGav9VqNUuWLOGff/7Bzc0Nc3NzrXlnz5ZfekKI1HVq08TYIYj30ObNm7G3t+fhw4ea8cb8/f2xs7MjKCgIf39/atWqRXR0NIMHD+bQoUM4Ojry8ccfpzkemLOzM2fOnOHKlSv8/PPPBAQEYGZmRs+ePdmxYwdTpkzh2rVrnDxp+DA+Dx8+xMnJSfPaycmJBw8ecOLECXbs2MH58+d59uwZ5cqVw8fHx+DyxdvTKxk6c+aM1mt3d3cALl68mOEBCZHZTHJI1bQQGSG1WpzMZGFhgYODA/fv3+fWrVv07NkTf39//P398fHx4erVq5QpUwZnZ2cAOnXqRGBgYKplduzYEUh8Wvro0aN4eCSOYRgVFUWVKlVwcXHJ8O04fPgwbdu2xdLSkoIFC1K/fv0MX4fQj15XhX379mV2HEK8M+qX8cYOIdubNCOxJ+BJX8qvYJE+NWvWZP369RQsWJBatWqxatUqTp48iYeHB1euXDH4SeecOXMCiXc/+vfvz8SJE7Xev3PnTrpjLVSoECdOnNC8fvDgAYUKFeL+/fvyRHYWYXALtL59+/LixYtk0yMjI+nbt2+GBCWE+LDJ02TibdWqVYs5c+ZQs2ZN3N3d2b17NwUKFMDS0pKyZcty/fp17t+/T3x8PBs2bNC7XG9vb9atW8fTp08BePToEUFBQVhbW+u89umjUaNG/PXXX7x48YKHDx9y6dIlqlWrRq1atdiyZQuxsbEEBwdLxYMRGXy/4Ndff2X69OlYW1trTX/58iUrV66UThdFlmeSyzztmUSm+mX+t8YOQbznatSowcOHD6lZsyampqYULlyYSpUqAWBlZcX8+fPx9vbGxsZG075IHy4uLowbNw5vb2/UajWWlpb4+vri4uJC5cqVcXV1pWPHjjobUD9//hxXV1fCw8MxNTVl+vTp3L9/H3t7e0aMGEGlSpUwMTHhhx9+wMzMDA8PD5o2bYqrqytOTk5ptmsSmUelKPoN4R0eHo6iKOTJk4d///2X/Pnza95LSEjgzz//ZMyYMTx8+DDTgs0I4eHh2NraEhYWho2NjbHDEUZw7MvEtgCeMwxvCCkMExMTS94iFTWvnwWew9LSwogRCSFekevha3rXDNnZ2aFSqVCpVJQpUybZ+yqVim+++SZDgxNCfJgCTpwFwKuqu1HjEEIIMCAZ2rdvH4qiUL9+fTZt2kTevHk171lYWFC0aFEKFSqUKUEKIT4scxatBMBrhbtxAxHZio+PD4cPaw8QPGPGDBo3bmxQORcuXKBHjx5a04oXLy6jMLzH9E6G6tatC8Dt27cpUqSItIAXQqTbsEE9jR2CyIYWLlyYIeW4urpy9uzZDClLZA16JUPnz5+nQoUKmJiYEBYWxoULF1Kc15CGakKI7ElujwkhshK9kiF3d3eCg4MpUKAA7u7uqFQqdLW7VqlUJCQkZHiQQgghhBCZRa9k6Pbt25qnx27fvp2pAQmR2eTReuP735DEsQ3lEXshRFagVzJUtGhRnX8L8T5SR2bcwJIifZydHI0dghBCaBjcA3WRIkXo2bMnv/zyCzdv3syMmIQQH7hJX/rIUBwiXUaNGoWLiwtTpkzRexlfX19Gjhz5VusNDQ1lyZIlBi1TrFgxIiIi2L9/Px06dDBoOTc3N9zd3fn44491zpMR2yReM7gH6qlTp3Lw4EFmzJhB//79cXJyom7dutStW5d69epRunTpzIhTiAwjA7UK8f7y9fUlJCQEExODf8vrJSEhAVNT02TTXyVDAwYMyJT1vunIkSPkzp37naxLpCMZ+uSTT/jkk08ACAoK4sCBA2zfvp1BgwahVqulAbXI8mSgVuNbv2UnAJ3aNDFyJOJtXd7QJsX3ijf4gRx5SgIQ6D+FiKATOuezL9+ZAi5d01xX27Ztef78OVZWVuTKlYvnz5+zZMkSZsyYwc2bNzl//jzjx49n27ZtbN++neHDh2NjY0PFihXJkydPiuUWK1aMLl26sGvXLmbOnElwcDDz588nNjYWb29vZs+ezbhx47h8+TLu7u60a9dO53AcUVFR9OjRgytXrlCtWjWtB43CwsJo06YNly9fpkWLFsyePTvN7X2TIdskDJOu1DoqKordu3fz448/Mm/ePDZu3EiFChUYMmRIRscnhPgAbdy6m41bdxs7DPGe2bx5M3Z2dkRERODg4ACAv78/dnZ2BAUF4e/vT61atYiOjmbw4MH4+fkREBDAtWvX0izb2dmZM2fOULhwYbZu3UpAQADnzp3jyZMn7NixgylTplC+fHnOnj2rMxECWLRoEU5OTly+fJlOnToRGBioee/06dP8/PPPXLx4kT///FPrvTepVCrq1q1L1apVWb16NUC6tknoz+CaoRo1anDmzBnKlStHvXr1GDNmDHXq1JEMVQihtx++G23sEEQGKd9xi17zFak1LsPWaWFhgYODA/fv3+fWrVv07NkTf39//P398fHx4erVq5QpUwZnZ2eAZImJLh07dgTAz8+Po0eP4uGROIZhVFQUVapUwcXFJc24/P39GT068dxu1qyZ1nWxRo0amgSuQoUK3L17lyJFiqRYjpOTE0FBQTRo0ABXV1fUarXB2yT0Z3AydPXqVXLlykXZsmUpW7Ys5cqVk0RIiA9MfHw8CQnqNOczNTXBzMzwNljyNJl4WzVr1mT9+vUULFiQWrVqsWrVKk6ePImHhwdXrlwxeJSEnDlzAqBWq+nfvz8TJ07Uev/OnTt6lZPSei0tLTV/m5qaptqkxMnJCYCCBQvSrFkzTp8+renjT2QOg2+TPX36lL1791K9enV27dpFzZo1cXJyolu3bixdujQzYhRCvENjJ80kX9FK5C1SMc1/+YpW4qtvZhm8jrDwCMLCIzIhepFd1KpVizlz5lCzZk3c3d3ZvXs3BQoUwNLSkrJly3L9+nXu379PfHw8GzZs0Ltcb29v1q1bx9OnTwF49OgRQUFBWFtb8+LFizRjWrduHQA7d+7k+fPnBm9XZGSkZj0RERHs3bsXFxeXt9omkTaDkyGVSoWbmxtDhgxh48aN/P333zRs2JANGzYwcODAzIhRCPGOxMfHs2jpKuLj9WtkHh8fz8IlK/We/5X+QyfQf6judhdC6KNGjRo8fPiQmjVrYmpqSuHChalZsyYAVlZWzJ8/H29vb7y8vChTpoze5bq4uDBu3Di8vb1xc3OjefPmPHv2jHz58lG5cmVcXV2ZPHmyzmUHDRpEYGAg5cuXZ926dSneBktNSEgItWrVomLFilSvXp2ePXtStWrVt9omkTaVomtcjVScPn2a/fv3s3//fvz9/Xnx4gWurq7Uq1ePunXr0rp168yKNUOEh4dja2tLWFgYNjY2xg5HGMHxcdUAqDbluJEjyXpiYmLJW6Siwcs9CzyHpaVFmuW9mm/Zqk0A9OvRPv3BCiHeilwPXzP4Zn+1atWoVKkSdevWpX///tSpUwdbW9vMiE2ITKHEp90WRiQKunECSwsdSU5sLAVLVU13uZIECSGyEoOToWfPnmX7DFKI7MLSwkJnjY8Q7yMfHx8OHz6sNW3GjBk0btzYoHIuXLhAjx49tKYVL16czZs3G1SOp6cnMTExWtP8/PzIly+fQeWIt2dwMpQZidDChQuZNWsWwcHBVKxYkR9//JFq1aqludzatWvp2rUrrVu3ZsuWLRkelxAic/yw0BeAET69jRqHyF4WLlyYIeW4urpy9uzZty7n2LFjbx+MyBCZ05+5AdatW8fw4cOZOHEip0+fpmLFijRu3JhHjx6lutydO3cYOXIktWvXfkeRCiEyyrGT5zl28ryxwxBCCCALJEOzZ8+mf//+9OnTh/Lly7N48WJy5szJ8uXLU1wmISGB7t27880331CiRIlUy4+JiSE8PFzrnxDCuNavmM36FYYPRyCEEJnBqMlQbGwsp06dokGDBpppJiYmNGjQgICAgBSXmzx5MgUKFOB///tfmuuYNm0atra2mn+veu8UQgghhIAMSIYSEhI4e/ZsujqXevLkCQkJCZouyl9xcHAgODhY5zL+/v788ssvenfwOHbsWMLCwjT/7t27Z3CcQoiMdfHKDS5euWHsMIQQAkhHMvTFF1/wyy+/AImJUN26dalcuTLOzs7s378/o+PT8uLFC3r06MHSpUuxt7fXaxlLS0tsbGy0/gkhjGvyzEVMnrnI2GGI99CoUaNwcXFhypQpei/j6+vLyJEj32q9oaGhLFmyxKBlihUrRkREBPv376dDhw56L9e2bVvy5MmTbJnjx4/j4uJCqVKlUuz4MSO2NTsy+GmyjRs38sknnwDw559/cvv2ba5evcqqVasYN25csscWU2Nvb4+pqSkhISFa00NCQnB0TD520c2bN7lz5w4tW7bUTFOrE/uMMTMz49q1a5QsWdLQTRJCvGN9P2ln7BDEe8rX15eQkBBMTDKnlUdCQgKmpqbJpr9KhgYMGJAp601q6NCh9O3bl19//VVruo+PD2vWrMHFxYWaNWvStm1bXF1dMz2e7MDgZOjJkyeaROWvv/6iY8eOlClThr59+zJv3jyDyrKwsKBKlSr4+fnRpk0bIDG58fPzY/DgwcnmL1u2LBcuXNCaNn78eF68eMG8efOkPZAQRhITG2vQ9CbetTIzHPEOHR/rleJ7LoNXkMupLADXV44i9Iq/zvmcvP+HU4N+aa6rbdu2PH/+HCsrK3LlysXz589ZsmQJM2bM4ObNm5w/f57x48ezbds2tm/fzvDhw7GxsaFixYqpDiherFgxunTpwq5du5g5cybBwcHMnz+f2NhYvL29mT17NuPGjePy5cu4u7vTrl07JkxIPpxMVFQUPXr04MqVK1SrVo2kAzyEhYXRpk0bLl++TIsWLZg9O+UHCOrVq5fsTsvDhw+Jj4/Hzc0NgC5durB9+3ZcXV0N2lahm8HJkIODA5cvX6ZgwYLs3LmTn376CUg8CXRl02kZPnw4vXr1wsPDg2rVqjF37lwiIyPp06cPAD179sTJyYlp06ZhZWVFhQoVtJa3s7MDSDZdiJSoLA0/T0Xq3qY3aiH0tXnzZuzt7Xn48KEmKfD398fOzo6goCD8/f2pVasW0dHRDB48mEOHDuHo6MjHH39M9erVUy3b2dmZM2fOcOXKFX7++WcCAgIwMzOjZ8+e7NixgylTpnDt2jVOnjyZYhmLFi3CycmJTZs28ddff2nV7Jw+fZrLly+TJ08eXFxc+OKLLwwau+zhw4ea0ewhcWT7AwcOpGtbRXIGJ0N9+vShU6dOFCxYEJVKpXkS7NixY5QtW9bgADp37szjx4+ZMGECwcHBuLu7s3PnTk2j6sDAwEyrDhXZkxKTYOwQ3numpiaYmZkZNECrmZkZpqaJn+Vh42YAMGfKl5kSn3h3qk1L+cnfpMr0nJVh67SwsMDBwYH79+9z69Ytevbsib+/P/7+/vj4+HD16lXKlCmjuVvQqVMnAgMDUy2zY8eOQGIP0EePHsXDwwNI/KFfpUoVXFxc0ozL39+f0aNHA9CsWTOtGpoaNWpormsVKlTg7t276RrI9U3p2VaRnMHJ0KRJk6hQoQL37t2jY8eOWFpaAmBqasqYMWPSFcTgwYN13hYD0myU7evrm651CiHSz8zMDJ8BPfUesf7V/GZmBn/lCKFTzZo1Wb9+PQULFqRWrVqsWrWKkydP4uHhwZUrV1CpVAaVlzNnTiCxqUb//v2ZOHGi1vt37tzRq5yU1vvqWgmJ18uEBMN+lBUqVIgHDx5oXj948IBChQqluk6hP4O/maKjo3W2iu/Vq1eGBCREZjPJaW7sED4IUyeOYvK4YSQkpD3w7auapFekRki8rVq1avHpp58yYsQI3N3d6dGjBwUKFMDS0pKyZcty/fp17t+/j6OjIxs2bMDT01Ovcr29venYsSODBw8mX758PHr0iISEBKytrXnx4kWaMa1btw4vLy927tyZri5nUlKoUCFMTU05f/48Li4urF27lqVLl1K6dOl0b6t4zeBkyM7OjmrVqlG3bl3q1atHjRo1yJEjR2bEJkSmUEfFGTuED4aZmRlS2SOMoUaNGjx8+JCaNWtiampK4cKFqVSpEgBWVlbMnz8fb29vbGxsNO2L9OHi4sK4cePw9vZGrVZjaWmJr68vLi4uVK5cGVdXVzp27KizAfWgQYP45JNPKF++PJ6enum+DdagQQPOnTtHZGQkhQsXZsOGDXh5ebFgwQK6du1KdHQ0PXr00DxJlt5tFa+plKTN3fXg7+/PwYMH2b9/P0eOHCE+Ph4PDw9NctSwYcPMijVDhIeHY2trS1hYmPQ5lE0d+zKxLYDnjJQbQmZXMTGx5C1SUfP6WeC5TBm1fqdf4lNF8lSZEMYj18PXDG6ZXKtWLb766it2795NaGgo+/bto1SpUsycOZMmTZpkRoxCiA/M8t/+YPlvfxg7DCGEANJxmwzg+vXr7N+/X/MvJiaGFi1aUK9evQwOTwjxIZowepCxQxDZkI+PT7KOgWfMmEHjxo0NKufChQv06NFDa1rx4sXZvHmzQeV4enoSExOjNc3Pz498+fIZVI54ewbfJnNycuLly5fUq1ePevXqUbduXdzc3N6b1uxSLSjkNlnK3tVtMiGE8cn18DWDb5Plz5+fqKgogoODCQ4OJiQkhJcvX2ZGbEIIIYQQmc7gZOjs2bMEBwczZswYYmJi+Oqrr7C3t6dGjRqMGzcuM2IUIkOZ5DLHJJc8Xm9MnfoMp1Of4cYOQwghgHS2GbKzs6NVq1bUrFmTGjVqsHXrVtasWcOxY8cMGklYCGNQR8qj9cbm6SGP/wohsg6Dk6E//vhD03D68uXL5M2bl1q1avHDDz9Qt27dzIhRCPGBGeHT29ghCCGEhsHJ0MCBA6lTpw4DBgygbt26mk6fhHhfyC0yIYQQSRmcDD169Cgz4hDinZHbZMa3bNUmAPr1aG/kSIQQIp1thhISEtiyZQtXrlwBoHz58rRu3RpTU9MMDU4I8WHavTexrxdJhoQQWYHBydCNGzdo1qwZDx484KOPPgJg2rRpODs7s2PHDkqWLJnhQQohPixL5002dghCCKFh8KP1Q4YMoWTJkty7d4/Tp09z+vRpAgMDKV68OEOGDMmMGIUQHxhbm9zY2uQ2dhhCCAGko2bowIEDHD16lLx582qm5cuXj+nTp1OzZs0MDU4I8WG69yAYAGcnRyNHIoQQ6UiGLC0tefHiRbLpERERWFhIt/1CiLSNGD8TgPUrZhs5EiGESMdtshYtWjBgwACOHTuGoigoisLRo0cZOHAgrVq1yowYhchQKktTVJbS2N+YOrRuRIfWjYwdhhBCAOmoGZo/fz69evXCy8sLc/PE/lri4+Np1aoV8+bNy/AAhchoSkyCsUPI9jq1aWLsEIQQQsOgZEhRFMLDw1m7di0PHjzQPFpfrlw5SpUqlSkBCiGEEEJkJoOToVKlSnHp0iVKly4tCZB4P8kdMqObNGNh4v9f+hg5EiGEMLDNkImJCaVLl+bp06eZFY8QmS/hv3/CaO49CNY8USaEEMZmcJuh6dOnM2rUKH766ScqVKiQGTEJIT5wv8z/1tghCCGEhsHJUM+ePYmKiqJixYpYWFiQI0cOrfefPXuWYcEJIYQQQmQ2g5OhuXPnZkIYQojsJODEWQC8qrobNQ4hhIB0JEO9evXKjDiEENnInEUrAfBa4W7cQIQQgnSOWi+EEG9j2KCexg5BCCE0JBkSQrxzcntMCJGVSDIksh8zlbEjEEIIkYXo1c/Q+fPnUavVmR2LEO9GvJL4TxjN/4Z8zf+GfG3sMIQQAtAzGapUqRJPnjwBoESJEtLpohDirTg7OeLs5GjsMIQQAtDzNpmdnR23b9+mQIEC3LlzR2qJxHvNxEruDhubDMMhhMhK9LoqtG/fnrp161KwYEFUKhUeHh6Ymuoe4OnWrVsZGqAQGU0dHW/sEIQQQmQheiVDS5YsoV27dty4cYMhQ4bQv39/rK2tMzs2IcQHav2WnQB0atPEyJEIIYQBT5M1aZL4pXXq1CmGDh0qyZAQIt02bt0NSDIkhMgaDBq1HmDFihWaROj+/fvcv3//rYNYuHAhxYoVw8rKCk9PT44fP57ivEuXLqV27drkyZOHPHny0KBBg1TnF0JkPT98N5ofvhtt7DCEEAJIRzKkVquZPHkytra2FC1alKJFi2JnZ8e3336brobV69atY/jw4UycOJHTp09TsWJFGjduzKNHj3TOv3//frp27cq+ffsICAjA2dmZRo0a8eDBA4PXLYQwDnmaTAiRlRicDI0bN44FCxYwffp0zpw5w5kzZ5g6dSo//vgjX39teL8hs2fPpn///vTp04fy5cuzePFicubMyfLly3XOv3r1agYNGoS7uztly5Zl2bJlqNVq/Pz8DF63EMI4wsIjCAuPMHYYQggBpKMH6l9//ZVly5bRqlUrzTQ3NzecnJwYNGgQU6ZM0bus2NhYTp06xdixYzXTTExMaNCgAQEBAXqVERUVRVxcHHnz5tX5fkxMDDExMZrX4eHhescnPkwmucyNHUK213/oBADWr5ht5EiEECIdydCzZ88oW7Zssully5bl2bNnBpX15MkTEhIScHBw0Jru4ODA1atX9Srjyy+/pFChQjRo0EDn+9OmTeObb74xKC7xYVNHxhk7hGyvUf2axg5BCCE0DL5NVrFiRRYsWJBs+oIFC6hYsWKGBKWv6dOns3btWjZv3oyVlZXOecaOHUtYWJjm3717995pjEKI5Pr1aE+/Hu2NHYYQQgDpqBmaOXMmzZs3559//sHLywuAgIAA7t27x19//WVQWfb29piamhISEqI1PSQkBEfH1BtXfv/990yfPp1//vkHNze3FOeztLTE0tLSoLjEh01ukwkhhEjK4JqhunXrcv36ddq2bUtoaCihoaG0a9eOa9euUbt2bYPKsrCwoEqVKlqNn181hn6VaOkyc+ZMvv32W3bu3ImHh4ehmyCyOXVknNwqM7IfFvryw0JfY4chhBBAOmqGAAoVKmRQQ+nUDB8+nF69euHh4UG1atWYO3cukZGR9OnTB4CePXvi5OTEtGnTAJgxYwYTJkzg999/p1ixYgQHBwOQO3ducufOnSExCSEy17GT540dghBCaBh9xMrOnTvz+PFjJkyYQHBwMO7u7uzcuVPTqDowMBATk9cVWD/99BOxsbF06NBBq5yJEycyadKkdxm6ECKd5CkyIURWYvRkCGDw4MEMHjxY53v79+/Xen3nzp3MD0gIIYQQ2YbBbYaEEOJtXbxyg4tXbhg7DCGEALJIzZAQInuZPHMRILfLhBBZQ7qSofj4ePbv38/Nmzfp1q0b1tbWPHz4EBsbG2nELLI8kxzyG8DY+n7SztghCCGEhsFXhbt379KkSRMCAwOJiYmhYcOGWFtbM2PGDGJiYli8eHFmxClEhlG/jDd2CNleE+9axg5BCCE0DG4zNHToUDw8PHj+/Dk5cuTQTG/btq0MliqEEEKI947BNUOHDh3iyJEjWFhYaE0vVqwYDx48yLDAhMg0FvLcgLENGzcDgDlTvjRyJEIIkY5kSK1Wk5CQkGz6/fv3sba2zpCghMhUsWpjRyCEECILMTgZatSoEXPnzmXJkiUAqFQqIiIimDhxIs2aNcvwAIUQHx6pERJCZCUGJ0Pff/89TZo0oXz58kRHR9OtWzf+/fdf7O3tWbNmTWbEKIQQQgiRaQxOhpydnTl37hzr1q3j3LlzRERE8L///Y/u3btrNagWQoiU7PTzB+SpMiFE1mBQMhQXF0fZsmXZvn073bt3p3v37pkVlxDiA7b8tz8ASYaEEFmDQcmQubk50dHRmRWLECKbmDB6kLFDEEIIDYOfMfbx8WHGjBnEx0vHdUKI9KlQrhQVypUydhhCCAGko83QiRMn8PPzY/fu3bi6upIrVy6t9//4448MC04IIYQQIrMZnAzZ2dnRvn37zIhFCJFNdOozHJCBWoUQWYPBydCKFSsyIw4hRDbi6eFm7BCEEEJDhu8W2Y7K3NTYIWR7I3x6GzsEIYTQSFcytHHjRtavX09gYCCxsbFa750+fTpDAhMisyhxyYeTEUIIkX0Z/DTZ/Pnz6dOnDw4ODpw5c4Zq1aqRL18+bt26RdOmTTMjRiHEB2bZqk0sW7XJ2GEIIQSQjmRo0aJFLFmyhB9//BELCwtGjx7Nnj17GDJkCGFhYZkRoxDiA7N772F27z1s7DCEEAJIx22ywMBAatSoAUCOHDl48eIFAD169KB69eosWLAgYyMUQnxwls6bbOwQhBBCw+CaIUdHR549ewZAkSJFOHr0KAC3b99GUZSMjU4I8UGytcmNrU1uY4chhBBAOpKh+vXrs23bNgD69OnDsGHDaNiwIZ07d6Zt27YZHqAQ4sNz70Ew9x4EGzsMIYQA0nGbbMmSJajVaiBxaI58+fJx5MgRWrVqxaeffprhAQqR0UxySo8SxjZi/ExAOl0UQmQNBl8VTExMMDF5XaHUpUsXunTpkqFBCZGZ1FEyrp6xdWjdyNghCCGERrp+IoeGhnL8+HEePXqkqSV6pWfPnhkSmBDiw9WpTRNjhyCEEBoGJ0N//vkn3bt3JyIiAhsbG1QqleY9lUolyZDI8kxymRs7BCGEEFmIwQ2oR4wYQd++fYmIiCA0NJTnz59r/r16ykyIrEwdGYc6Ms7YYWRrk2YsZNKMhcYOQwghgHTUDD148IAhQ4aQM2fOzIhHCJENyJNkQoisxOBkqHHjxpw8eZISJUpkRjxCiGzgl/nfGjsEIYTQ0CsZetWvEEDz5s0ZNWoUly9fxtXVFXNz7fYXrVq1ytgIhRBCCCEykV7JUJs2bZJNmzw5eXf6KpWKhAQZEVwIkbqAE2cB8KrqbtQ4hBAC9EyG3nx8Xggh3sacRSsB8FrhbtxAhBCCdPYzJMT7zCSnPFpvbMMGSRccQoisQ+9H6wMCAti+fbvWtJUrV1K8eHEKFCjAgAEDiImJyfAAhcho6qg41FHyaL0xeVV1l1tkQogsQ+9kaPLkyVy6dEnz+sKFC/zvf/+jQYMGjBkzhj///JNp06ZlSpBCCCGEEJlF72To7NmzeHt7a16vXbsWT09Pli5dyvDhw5k/fz7r169PVxALFy6kWLFiWFlZ4enpyfHjx1Odf8OGDZQtWxYrKytcXV3566+/0rVekT2prExRWZkaO4xs7X9DvuZ/Q742dhhCCAEY0Gbo+fPnODg4aF4fOHCApk2bal5XrVqVe/fuGRzAunXrGD58OIsXL8bT05O5c+fSuHFjrl27RoECBZLNf+TIEbp27cq0adNo0aIFv//+O23atOH06dNUqFDB4PW/LUVRiI2VWy7vEyU68YnHmJhYI0eS9cTEvpt94uzk+E7WI4QQ+lApiqLoM2PRokVZtWoVderUITY2Fjs7O/78809NbdGFCxeoW7euwUNyeHp6UrVqVRYsWAAkPrnm7OzM559/zpgxY5LN37lzZyIjI7XaL1WvXh13d3cWL16cbP6YmBittkzh4eE4OzsTFhaGjY2NQbHqEhMTy9mJNSGV3aiyNEWJSbwAm+Q0T7G9ikkuc80wEUn/Tq08TIHUejMwU0F8YmwmVmaoo3WP2K7vuk1ymKF++V8ZFiYQq9+ThipzU5Q43YGa5DTTjCSf6rqT7DuVlakmqUk+owrUSsqvFUAF9X0j9Yo9O3sWeA5LSwtjhyGEyATh4eHY2tpm2PXwfab3bbJmzZoxZswYDh06xNixY8mZMye1a9fWvH/+/HlKlixp0MpjY2M5deoUDRo0eB2QiQkNGjQgICBA5zIBAQFa80Nir9gpzT9t2jRsbW01/5ydnQ2KUXyAVIA8UZYmMzMzTE0NHr5QCCHeO3rfJvv2229p164ddevWJXfu3Pz6669YWLz+xbh8+XIaNWpk0MqfPHlCQkKC1u03AAcHB65evapzmeDgYJ3zBwfrHuto7NixDB8+XPP6Vc1QRqq/IiJDyxPC2MzMzPAZ0BMzs8zpfWP9lp0AdGrTJFPKF0IIQ+j9TWdvb8/BgwcJCwsjd+7cmJpqN0DdsGEDuXPnzvAA35alpSWWlpaZVr6FhTnPAs9lWvlCGIOpqUmmJUIAG7fuBiQZEkJkDQZ/29na2uqcnjdvXoNXbm9vj6mpKSEhIVrTQ0JCcHTU3cDS0dHRoPkzm0qlkjYVQhjoh+9GGzsEIYTQMGqDAAsLC6pUqYKfn59mmlqtxs/PDy8vL53LeHl5ac0PsGfPnhTnF0JkPc5OjvJEmRAiyzD6cBzDhw+nV69eeHh4UK1aNebOnUtkZCR9+vQBoGfPnjg5OWk6dBw6dCh169blhx9+oHnz5qxdu5aTJ0+yZMkSY26GEMIAYeGJ7exsbbLerXUhRPZj9GSoc+fOPH78mAkTJhAcHIy7uzs7d+7UNJIODAzExOR1BVaNGjX4/fffGT9+PF999RWlS5dmy5YtRuljSAiRPv2HTgBg/YrZRo5ECCEM6GfoQyH9KghhfMtWbQKgX4/2Ro5EiOxLroevGb1mSAiR/UgSJITISqRHNSGEEEJka5IMCSHeuR8W+vLDQl9jhyGEEEA2vE32qolUeHi4kSMRIvvyP3ICgP492hk5EiGyr1fXwWzWdFinbNeA+v79+zI+mRBCCPGfe/fuUbhwYWOHYVTZLhlSq9U8fPgQa2trVCpVhpT5aryze/fuvfct8j+kbYEPa3tkW7KuD2l7ZFuyrozeHkVRePHiBYUKFdLqwiY7yna3yUxMTDItA7axsfkgPnDwYW0LfFjbI9uSdX1I2yPbknVl5PakNMRWdpO9U0EhhBBCZHuSDAkhhBAiW5NkKANYWloyceJELC0tjR3KW/uQtgU+rO2Rbcm6PqTtkW3Juj607clKsl0DaiGEEEKIpKRmSAghhBDZmiRDQgghhMjWJBkSQgghRLYmyZAQQgghsjVJht7SwoULKVasGFZWVnh6enL8+HFjh5QukyZNQqVSaf0rW7asscPSy8GDB2nZsiWFChVCpVKxZcsWrfcVRWHChAkULFiQHDly0KBBA/7991/jBKuHtLand+/eyY5VkyZNjBNsGqZNm0bVqlWxtramQIECtGnThmvXrmnNEx0djY+PD/ny5SN37ty0b9+ekJAQI0WcMn22pV69esmOzcCBA40Uccp++ukn3NzcNJ33eXl58ffff2vef1+OyStpbc/7clx0mT59OiqVii+++EIz7X07Pu8DSYbewrp16xg+fDgTJ07k9OnTVKxYkcaNG/Po0SNjh5YuLi4uBAUFaf75+/sbOyS9REZGUrFiRRYuXKjz/ZkzZzJ//nwWL17MsWPHyJUrF40bNyY6OvodR6qftLYHoEmTJlrHas2aNe8wQv0dOHAAHx8fjh49yp49e4iLi6NRo0ZERkZq5hk2bBh//vknGzZs4MCBAzx8+JB27bLeAK76bAtA//79tY7NzJkzjRRxygoXLsz06dM5deoUJ0+epH79+rRu3ZpLly4B788xeSWt7YH347i86cSJE/z888+4ublpTX/fjs97QRHpVq1aNcXHx0fzOiEhQSlUqJAybdo0I0aVPhMnTlQqVqxo7DDeGqBs3rxZ81qtViuOjo7KrFmzNNNCQ0MVS0tLZc2aNUaI0DBvbo+iKEqvXr2U1q1bGyWet/Xo0SMFUA4cOKAoSuKxMDc3VzZs2KCZ58qVKwqgBAQEGCtMvby5LYqiKHXr1lWGDh1qvKDeQp48eZRly5a918ckqVfboyjv53F58eKFUrp0aWXPnj1a8X8oxyerkZqhdIqNjeXUqVM0aNBAM83ExIQGDRoQEBBgxMjS799//6VQoUKUKFGC7t27ExgYaOyQ3trt27cJDg7WOk62trZ4enq+t8cJYP/+/RQoUICPPvqIzz77jKdPnxo7JL2EhYUBkDdvXgBOnTpFXFyc1vEpW7YsRYoUyfLH581teWX16tXY29tToUIFxo4dS1RUlDHC01tCQgJr164lMjISLy+v9/qYQPLteeV9Oy4+Pj40b95c6zjA+/2Zycqy3UCtGeXJkyckJCTg4OCgNd3BwYGrV68aKar08/T0xNfXl48++oigoCC++eYbateuzcWLF7G2tjZ2eOkWHBwMoPM4vXrvfdOkSRPatWtH8eLFuXnzJl999RVNmzYlICAAU1NTY4eXIrVazRdffEHNmjWpUKECkHh8LCwssLOz05o3qx8fXdsC0K1bN4oWLUqhQoU4f/48X375JdeuXeOPP/4wYrS6XbhwAS8vL6Kjo8mdOzebN2+mfPnynD179r08JiltD7xfxwVg7dq1nD59mhMnTiR77339zGR1kgwJAJo2bar5283NDU9PT4oWLcr69ev53//+Z8TIxJu6dOmi+dvV1RU3NzdKlizJ/v378fb2NmJkqfPx8eHixYvvTVu01KS0LQMGDND87erqSsGCBfH29ubmzZuULFnyXYeZqo8++oizZ88SFhbGxo0b6dWrFwcOHDB2WOmW0vaUL1/+vTou9+7dY+jQoezZswcrKytjh5NtyG2ydLK3t8fU1DRZC/6QkBAcHR2NFFXGsbOzo0yZMty4ccPYobyVV8fiQz1OACVKlMDe3j5LH6vBgwezfft29u3bR+HChTXTHR0diY2NJTQ0VGv+rHx8UtoWXTw9PQGy5LGxsLCgVKlSVKlShWnTplGxYkXmzZv3Xh4TSHl7dMnKx+XUqVM8evSIypUrY2ZmhpmZGQcOHGD+/PmYmZnh4ODwXh6frE6SoXSysLCgSpUq+Pn5aaap1Wr8/Py07lO/ryIiIrh58yYFCxY0dihvpXjx4jg6Omodp/DwcI4dO/ZBHCeA+/fv8/Tp0yx5rBRFYfDgwWzevJm9e/dSvHhxrferVKmCubm51vG5du0agYGBWe74pLUtupw9exYgSx6bN6nVamJiYt6rY5KaV9ujS1Y+Lt7e3ly4cIGzZ89q/nl4eNC9e3fN3x/C8clyjN2C+322du1axdLSUvH19VUuX76sDBgwQLGzs1OCg4ONHZrBRowYoezfv1+5ffu2cvjwYaVBgwaKvb298ujRI2OHlqYXL14oZ86cUc6cOaMAyuzZs5UzZ84od+/eVRRFUaZPn67Y2dkpW7duVc6fP6+0bt1aKV68uPLy5UsjR65batvz4sULZeTIkUpAQIBy+/Zt5Z9//lEqV66slC5dWomOjjZ26Ml89tlniq2trbJ//34lKChI8y8qKkozz8CBA5UiRYooe/fuVU6ePKl4eXkpXl5eRoxat7S25caNG8rkyZOVkydPKrdv31a2bt2qlChRQqlTp46RI09uzJgxyoEDB5Tbt28r58+fV8aMGaOoVCpl9+7diqK8P8fkldS25306Lil582m49+34vA8kGXpLP/74o1KkSBHFwsJCqVatmnL06FFjh5QunTt3VgoWLKhYWFgoTk5OSufOnZUbN24YOyy97Nu3TwGS/evVq5eiKImP13/99deKg4ODYmlpqXh7eyvXrl0zbtCpSG17oqKilEaNGin58+dXzM3NlaJFiyr9+/fPsgm4ru0AlBUrVmjmefnypTJo0CAlT548Ss6cOZW2bdsqQUFBxgs6BWltS2BgoFKnTh0lb968iqWlpVKqVCll1KhRSlhYmHED16Fv375K0aJFFQsLCyV//vyKt7e3JhFSlPfnmLyS2va8T8clJW8mQ+/b8XkfqBRFUd5dPZQQQgghRNYibYaEEEIIka1JMiSEEEKIbE2SISGEEEL8v707D6qq/P8A/r5Xgct2ZRliGeEiOiASi2QaKBkIgy2EqBOJOjAJRhOQaWaUyWJK5paN5QgamKZOguZOJIkS7oksChdEUGfCVJJJcEHk/fvD4eQFLlyxvtqP5zXjjPcsz3Y+l/PhnOdw+jSRDAmCIAiC0KeJZEgQBEEQhD5NJEOCIAiCIPRpIhkSBEEQBKFPE8mQIAiCIAh9mkiGhKdWQUEBZDJZpxcS/q8lJyfD2toaMpkMP/744xNtizZPy1jpKisrC2ZmZo9dTm+PzUsvvYRZs2Y9dv1Pk7q6OshkMum9W13pGCf/1HF4Wjg6OuLLL7980s0Q/oNEMiR069q1a3jnnXfg4OAAAwMD2NjYIDg4GEVFRf963b6+vqivr8eAAQP+9bq0qaioQEpKCtauXYv6+nq8/PLLT6wt7f4/nsh7Q5dj8zQliU9zMi0IfV3/J90A4ek2adIktLS0YMOGDXBycsIff/yB/Px8NDQ0/Ot16+vrw8bG5l+vpzs1NTUAgNDQUMhksi63aWlpgb6+/v+yWQJ0Ozb/NSKWBOHJEFeGBK0aGxtRWFiIJUuWwN/fHyqVCiNHjkRiYiJef/11je2io6NhZWUFpVKJgIAAlJSUSOtLSkrg7+8PU1NTKJVKPPfcczh16hQA4OLFiwgJCYG5uTmMjY3h5uaGffv2Aej6t/qcnBy4ubnBwMAAjo6OWL58uUabHR0dsXjxYrz11lswNTWFg4MD0tPTpfUtLS2Ii4uDra0tFAoFVCoV0tLSuux/cnIyQkJCAAByuVw64UZFRWHChAlYtGgR7Ozs4OLiAgAoKytDQEAADA0NYWlpiZkzZ6KpqUkqr32/xYsXw9raGmZmZkhNTUVrayvmzp0LCwsLDBw4EJmZmVqPSVRUFA4dOoRVq1ZBJpNBJpOhrq5OWv/bb79hxIgRMDIygq+vL9Rqtcb+O3fuhLe3NxQKBZycnJCSkoLW1lat9QHAunXr4OrqCoVCgaFDh+Kbb76R1rXfmtm+fTv8/f1hZGQET09PHD16VKOMrKwsODg4wMjICGFhYTol092Np7Zj87C6ujr4+/sDAMzNzSGTyRAVFSWtb2trw4cffggLCwvY2NggOTlZY/+e4rqj7mLL0dERABAWFgaZTCZ9Tk5OhpeXF9atW4dBgwZBoVAAAHJzczFmzBiYmZnB0tISr732mpT8tTtx4gSGDx8OhUKBESNGoLi4uFOb9u3bB2dnZxgaGsLf318jVrR51Bhpj+uUlBRprGJjY9HS0iJt01N/dI2jX3/9FX5+fjA0NIS9vT0SEhLQ3NzcY58EoUdP+k2xwtPr3r17NDEx4axZs3jnzh2t2wUGBjIkJIQnT55kVVUV58yZQ0tLSzY0NJAk3dzcOG3aNFZUVLCqqoo//PADz5w5Q5J89dVXGRQUxNLSUtbU1HD37t08dOgQyb/f3n7jxg2S5KlTpyiXy5mamkq1Ws3MzEwaGhpqvAFdpVLRwsKCX3/9Naurq5mWlka5XM7KykqS5NKlS2lvb8/Dhw+zrq6OhYWF3Lx5c5f9unnzJjMzMwmA9fX10luhIyMjaWJiwunTp7O8vJzl5eVsamqira0tJ06cyLKyMubn53PQoEGMjIyUyouMjKSpqSnfffddVlZWcv369QTA4OBgLlq0iFVVVVy4cCH19PR4+fLlLtvU2NhIHx8fxsTESG1qbW2VxmrUqFEsKCjg2bNn6efnR19fX2nfw4cPU6lUMisrizU1NczLy6OjoyOTk5O1HttNmzbR1taWOTk5vHDhAnNycmhhYcGsrCySZG1tLQFw6NCh3LNnD9VqNSdPnkyVSsV79+6RJI8dO0a5XM4lS5ZQrVZz1apVNDMz44ABA7TW29N4ajs2D2ttbWVOTg4BUK1Ws76+no2NjSQfvAVcqVQyOTmZVVVV3LBhA2Uymcab23uK6466i62rV69Kb7ivr6/n1atXSZJJSUk0Njbm+PHjefr0aZaUlJAks7OzmZOTw+rqahYXFzMkJITu7u68f/++1H8rKytGRESwvLycu3fvppOTEwGwuLiY5IO3tRsYGHD27NmsrKzkpk2baG1trfGdyszM1DgOvYmR9u9DeHg4y8vLuWfPHlpZWfHjjz+WtumpP7rE0fnz52lsbMyVK1eyqqqKRUVFHD58OKOioqR6VCoVV65cqbWtgqCNSIaEbmVnZ9Pc3JwKhYK+vr5MTEyUfmCTZGFhIZVKZadkafDgwVy7di1J0tTUVDp5duTu7q71B23HZCgiIoJBQUEa28ydO5fDhg2TPqtUKk6bNk363NbWxmeeeYZr1qwhScbHxzMgIIBtbW069X/Hjh3s+DtDZGQkra2teffuXWlZeno6zc3N2dTUJC3bu3cv5XI5r1y5Iu2nUqmkEwBJuri40M/PT/rc2tpKY2NjbtmyRWubxo4dy/fee09jWftYHThwQKN+ALx9+zZJcty4cVy8eLHGfhs3bqStra3WugYPHtwpWVy4cCF9fHxI/n0SW7dunbT+7NmzBMCKigqS5JQpU/jKK69olBEeHt5tMqTLeHZ1bDrqGEPtxo4dyzFjxmgse/755zlv3jySusV1Rz3FFgDu2LFDY1lSUhL19PSk5Eiba9euEQDLyspIkmvXrqWlpaV0bElyzZo1GslQYmKixneDJOfNm9dtMtSbGImMjKSFhQWbm5s12mJiYqIR6931R5c4mjFjBmfOnKlRTmFhIeVyuTQOIhkSekvcJhO6NWnSJPz+++/YtWsXxo8fj4KCAnh7eyMrKwvAg1tgTU1NsLS0hImJifSvtrZWugw+e/ZsREdHIzAwEJ9//rnG5fGEhAR89tlnGD16NJKSklBaWqq1LRUVFRg9erTGstGjR6O6uhr379+Xlnl4eEj/l8lksLGxwdWrVwE8uKR/5swZuLi4ICEhAXl5eb0aF3d3d425HRUVFfD09ISxsbFG29ra2jRuVbm5uUEu//trZ21tDXd3d+lzv379YGlpKbX3UT3cd1tbWwCQyiopKUFqaqrGcYqJiUF9fT1u3brVqazm5mbU1NRgxowZGvt89tlnnW7ZdFdvRUUFRo0apbG9j49Pt/3QdTwfx8NtBh60++Gx6imuO+ptbKlUKlhZWWksq66uxpQpU+Dk5ASlUindVrt06RKAB+Pj4eEh3VYDOo9pb8b9UWOknaenJ4yMjDTqaWpqwuXLl3XqT7ue4jcrK0ujbcHBwWhra0NtbW23/RKEnogJ1EKPFAoFgoKCEBQUhE8//RTR0dFISkpCVFQUmpqaYGtri4KCgk77tT+ym5ycjIiICOzduxf79+9HUlIStm7dirCwMERHRyM4OBh79+5FXl4e0tLSsHz5csTHx/e6vXp6ehqfZTIZ2traAADe3t6ora3F/v37ceDAAbzxxhsIDAxEdnb2I9Xx8En6cdvWXXsfp/z2eTTtZTU1NSElJQUTJ07stN/DJ9V27fNzMjIyOp1U+/Xrp3O9T6vuxl2XuO6ot7HVVSyFhIRApVIhIyMDdnZ2aGtrw7PPPqsxD+ff8Kgxoitd+9NT/L799ttISEjoVL6Dg0Ov2yYIgEiGhF4YNmyY9Iiwt7c3rly5gv79+0u/7XXF2dkZzs7OeP/99zFlyhRkZmYiLCwMAGBvb4/Y2FjExsYiMTERGRkZXSZDrq6unR7pLyoqgrOzc6eTc3eUSiXCw8MRHh6OyZMnY/z48fjzzz9hYWGhcxldtS0rKwvNzc3Sya2oqAhyuVyaYP1P0dfX17gSpitvb2+o1WoMGTJEp+2tra1hZ2eHCxcuYOrUqY9cXztXV1ccP35cY9mxY8d63OefGM/2q3ePOl66xnVH3cWWnp6eTu1oaGiAWq1GRkYG/Pz8ADyYOPwwV1dXbNy4EXfu3JGSlI5j6urqil27dmks62ncHzVG2pWUlOD27dswNDSU6jExMYG9vb1O/dGFt7c3zp0798htEwRdiNtkglYNDQ0ICAjApk2bUFpaitraWmzbtg1ffPEFQkNDAQCBgYHw8fHBhAkTkJeXh7q6Ohw5cgSffPIJTp06hdu3byMuLg4FBQW4ePEiioqKcPLkSbi6ugIAZs2ahZ9++gm1tbU4ffo0Dh48KK3raM6cOcjPz8fChQtRVVWFDRs2YPXq1fjggw907tOKFSuwZcsWVFZWoqqqCtu2bYONjc1j/+G5qVOnQqFQIDIyEuXl5Th48CDi4+Mxffp0WFtbP1bZHTk6OuL48eOoq6vD9evXdb4Cs2DBAnz33XdISUnB2bNnUVFRga1bt2L+/Pla90lJSUFaWhq++uorVFVVoaysDJmZmVixYoXO7U1ISEBubi6WLVuG6upqrF69Grm5ud3u80+Np0qlgkwmw549e3Dt2jWNp/u601Ncd6Wn2HJ0dER+fj6uXLmCGzduaK3b3NwclpaWSE9Px/nz5/HLL79g9uzZGttERERAJpMhJiYG586dw759+7Bs2TKNbWJjY1FdXY25c+dCrVZj8+bN0u1tbXoTI8CDJ+lmzJghtSUpKQlxcXGQy+U69UcX8+bNw5EjRxAXF4czZ86guroaO3fuRFxc3COXJQidPOlJS8LT686dO/zoo4/o7e3NAQMG0MjIiC4uLpw/fz5v3bolbffXX38xPj6ednZ21NPTo729PadOncpLly7x7t27fPPNN2lvb099fX3a2dkxLi5OmvAYFxfHwYMH08DAgFZWVpw+fTqvX79OsuvJr9nZ2Rw2bBj19PTo4ODApUuXarS5qwmUnp6eTEpKIvlgYq6XlxeNjY2pVCo5btw4nj59WusYaJtAHRoa2mnb0tJS+vv7U6FQ0MLCgjExMbx582a3+3U1GbqnSaBqtZovvPACDQ0NCYC1tbVdjlVxcbG0vl1ubi59fX1paGhIpVLJkSNHMj09XWtdJPn999/Ty8uL+vr6NDc354svvsjt27eT/Hvia/ukXZK8ceMGAfDgwYPSsvXr13PgwIE0NDRkSEgIly1b1u0EarLn8dRlAjVJpqam0sbGhjKZTHoaratxDw0N1Xj6r7u47kpPsbVr1y4OGTKE/fv3p0qlIvlgArWnp2ensn7++We6urrSwMCAHh4eLCgo6DQB++jRo/T09KS+vj69vLykJ+cePha7d+/mkCFDaGBgQD8/P3777bfdTqAmHz1G2uN6wYIFtLS0pImJCWNiYjQmn/fUH13j6MSJEwwKCqKJiQmNjY3p4eHBRYsWSevFBGqht2Qk+SSSMEEQBOG/LyoqCo2NjeKvawv/aeI2mSAIgiAIfZpIhgRBEARB6NPEbTJBEARBEPo0cWVIEARBEIQ+TSRDgiAIgiD0aSIZEgRBEAShTxPJkCAIgiAIfZpIhgRBEARB6NNEMiQIgiAIQp8mkiFBEARBEPo0kQwJgiAIgtCn/R/NZ/pbw0n5sAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Non-null label rate by session position from the end of the straddle panel."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "# Accumulate daily hedge P&L over each horizon before joining the option return.\n",
-    "hedge_pnl_by_horizon = {}\n",
-    "for h in FORWARD_HORIZONS:\n",
-    "    hedge_pnl_by_horizon[h] = (\n",
-    "        hedge_sorted.filter((pl.col(\"holding_day\") >= 1) & (pl.col(\"holding_day\") <= h))\n",
-    "        .group_by([\"feature_date\", \"symbol\"])\n",
-    "        .agg(pl.col(\"daily_hedge_pnl\").sum().alias(\"hedge_pnl\"))\n",
-    "    )"
+    "profile = (\n",
+    "    calendar.select(\"timestamp\", \"from_end\")\n",
+    "    .join(panel.select(\"timestamp\", *LABEL_NAMES), on=\"timestamp\", how=\"left\")\n",
+    "    .filter(pl.col(\"from_end\") <= 40)\n",
+    "    .group_by(\"from_end\")\n",
+    "    .agg([pl.col(name).is_not_null().mean().alias(name) for name in LABEL_NAMES])\n",
+    "    .sort(\"from_end\")\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for name in LABEL_NAMES:\n",
+    "    ax.plot(profile[\"from_end\"], profile[name], ds=\"steps-mid\", label=name, **STYLES[name])\n",
+    "ax.axvline(PRIMARY_WINDOW, color=COLORS[\"neutral\"], linestyle=\":\", lw=1.2)\n",
+    "ax.set_xlabel(\"Sessions from the end of the straddle panel\")\n",
+    "ax.set_ylabel(\"Share of rows with a non-null label\")\n",
+    "ax.set_ylim(-0.05, 1.08)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Every label nulls its tail rather than fabricating one\",\n",
+    "    subtitle=\"Dotted line marks the median settlement; a fabricated tail would sit flat across it\",\n",
+    ")\n",
+    "ax.legend(loc=\"center right\", frameon=False, fontsize=7)\n",
+    "show_with_alt(fig, \"Non-null label rate by session position from the end of the straddle panel.\")"
    ]
   },
   {
@@ -429,20 +713,27 @@
    "id": "61198594",
    "metadata": {},
    "source": [
-    "Each horizon now combines the accumulated hedge P&L with its same-contract\n",
-    "option return and scales the hedge by the entry premium."
+    "## E. Distribution and base rate\n",
+    "\n",
+    "What scale is the label, and does it mean the same thing across names and across regimes?\n",
+    "Everything from here through Section G is computed on the development window only, sealed\n",
+    "on the date each trade **settles** rather than the date its signal is observed. A straddle\n",
+    "sold in the first week of December expires in January, so a filter on the signal date\n",
+    "looks sealed and is not: the holdout's own prices decide the outcome. The label files keep\n",
+    "every row, because the seal governs what this notebook looks at rather than what it\n",
+    "writes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "da6250fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:51.431125Z",
-     "iopub.status.busy": "2026-07-21T06:54:51.430924Z",
-     "iopub.status.idle": "2026-07-21T06:54:51.773134Z",
-     "shell.execute_reply": "2026-07-21T06:54:51.772331Z"
+     "iopub.execute_input": "2026-07-31T07:12:53.077967Z",
+     "iopub.status.busy": "2026-07-31T07:12:53.077649Z",
+     "iopub.status.idle": "2026-07-31T07:12:53.398677Z",
+     "shell.execute_reply": "2026-07-31T07:12:53.397596Z"
     }
    },
    "outputs": [
@@ -450,131 +741,103 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_dh_5d: 352,179 rows, mean=0.0008, std=0.1664, median=0.0284\n",
-      "fwd_ret_dh_10d: 333,102 rows, mean=0.0159, std=0.2273, median=0.0511\n"
+      "ret_to_expiry: 282,470 development rows through 2020-12-04\n",
+      "fwd_ret_5d: 283,065 development rows through 2020-12-22\n",
+      "fwd_ret_10d: 263,863 development rows through 2020-12-15\n",
+      "fwd_ret_dh_5d: 281,047 development rows through 2020-12-22\n",
+      "fwd_ret_dh_10d: 255,773 development rows through 2020-12-15\n"
      ]
     }
    ],
    "source": [
-    "dh_labels = {}\n",
-    "for h in FORWARD_HORIZONS:\n",
-    "    label_col = f\"fwd_ret_dh_{h}d\"\n",
-    "    dh = (\n",
-    "        contract_returns.filter(pl.col(f\"exit_found_{h}d\"))\n",
-    "        .select(\n",
-    "            [\n",
-    "                \"feature_date\",\n",
-    "                \"symbol\",\n",
-    "                f\"fwd_ret_{h}d\",\n",
-    "                \"entry_straddle_mid\",\n",
-    "            ]\n",
-    "        )\n",
-    "        .join(hedge_pnl_by_horizon[h], on=[\"feature_date\", \"symbol\"], how=\"left\")\n",
-    "        .with_columns(\n",
-    "            (\n",
-    "                pl.col(f\"fwd_ret_{h}d\")\n",
-    "                + pl.col(\"hedge_pnl\").fill_null(0) / pl.col(\"entry_straddle_mid\")\n",
-    "            ).alias(label_col)\n",
-    "        )\n",
-    "    )\n",
-    "\n",
-    "    lbl = dh.select(\n",
-    "        [\n",
-    "            pl.col(\"feature_date\").alias(\"timestamp\"),\n",
-    "            \"symbol\",\n",
-    "            pl.lit(INSTRUMENT_ID).alias(\"instrument_id\"),\n",
-    "            label_col,\n",
-    "        ]\n",
-    "    ).drop_nulls(subset=[label_col])\n",
-    "\n",
-    "    dh_labels[label_col] = lbl\n",
-    "    stats = lbl[label_col]\n",
-    "    print(\n",
-    "        f\"{label_col}: {len(lbl):,} rows, \"\n",
-    "        f\"mean={stats.mean():.4f}, std={stats.std():.4f}, median={stats.median():.4f}\"\n",
-    "    )"
+    "dev = {\n",
+    "    name: panel.with_columns(END_OF[name].alias(\"_label_end\"))\n",
+    "    .drop_nulls(name)\n",
+    "    .filter(pl.col(\"_label_end\") < HOLDOUT_START)\n",
+    "    for name in LABEL_NAMES\n",
+    "}\n",
+    "for name, frame in dev.items():\n",
+    "    print(f\"{name}: {frame.height:,} development rows through {frame['timestamp'].max()}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "d192a76a",
-   "metadata": {
-   },
+   "metadata": {},
    "source": [
-    "## 3c. Hold-to-Expiry Short Straddle Label\n",
-    "\n",
-    "The horizon-based labels above close the position at $t + h$ days and pay the\n",
-    "full exit bid-ask spread. The **hold-to-expiry** (HTM) variant avoids the exit\n",
-    "spread entirely: cash settlement at expiration converts the option to\n",
-    "intrinsic value without any market transaction.\n",
-    "\n",
-    "$$r_{\\text{htm}} = \\frac{P_{\\text{entry}} - |S_T - K|}{P_{\\text{entry}}}$$\n",
-    "\n",
-    "where $S_T$ is the underlying close on the expiration date and $K$ is the\n",
-    "strike. Sign convention matches the other labels in this notebook: positive =\n",
-    "profitable short straddle. Verified on row (symbol=A, $K=50$, $S_T=51.63$,\n",
-    "$P_{\\text{entry}}=3.60$): intrinsic $=1.63$, $r_{\\text{htm}}=+54.7\\%$.\n",
-    "Settlement uses the unadjusted historical close because the listed strike and\n",
-    "expiration spot are expressed in the same contemporaneous price basis.\n",
-    "\n",
-    "Days-to-expiry is tight by design (25–35 calendar days, mean 30, std 2.6),\n",
-    "so no per-day normalization. We add DTE as a feature in `03_financial_features`.\n",
-    "\n",
-    "This label grounds the cost-mitigation cascade introduced by O'Donovan & Yu\n",
-    "(2025): under conservative option transaction costs, HTM recovers 3 of 17\n",
-    "single-name option anomalies that fail at fixed holding periods."
+    "All five labels go on one axis with identical bins and a logarithmic count axis. The claim\n",
+    "is about shape rather than width: closing the trade early truncates the distribution on\n",
+    "both sides, and hedging the direction away pulls the body in without moving the centre,\n",
+    "while carrying to expiration keeps a loss tail several times the premium collected. The\n",
+    "axis is narrower than the primary label's range, so rows outside it are counted below\n",
+    "rather than drawn."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "53fa6b70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:51.781031Z",
-     "iopub.status.busy": "2026-07-21T06:54:51.780832Z",
-     "iopub.status.idle": "2026-07-21T06:54:52.027737Z",
-     "shell.execute_reply": "2026-07-21T06:54:52.026596Z"
-    },
-    "lines_to_next_cell": 2
+     "iopub.execute_input": "2026-07-31T07:12:53.401014Z",
+     "iopub.status.busy": "2026-07-31T07:12:53.400693Z",
+     "iopub.status.idle": "2026-07-31T07:12:54.723724Z",
+     "shell.execute_reply": "2026-07-31T07:12:54.722619Z"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApkAAAFnCAYAAADt31KmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA0HBJREFUeJzs3XdcE+cfwPFPCEuWoCgKbi0qiICCe2PdW1Hrtr+qtdjaOqqtq7XOOuuqq5Vq3Vpx1oVaxb1w760sUWQqK/f7IxITCJBAEMfzfr1syd3lueeSy933nimTJElCEARBEARBEAzIKL8zIAiCIAiCIHx4RJApCIIgCIIgGJwIMgVBEARBEASDE0GmIAiCIAiCYHAiyBQEQRAEQRAMTgSZgiAIgiAIgsGJIFMQBEEQBEEwOBFkCoIgCIIgCAYngkxBEARBEATB4ESQ+QGq7OWDpUNlLB0q53dWPioDv/lB9bkfPnrqo81DmrR8VPbyydd8vE9Wrdui+twmz1iQ39l5azI7bw15Dr1Lv4234X37/X1s38/Hwji/M/CuiY9P4M9VG9j+736u3bhNfMJLihUtQuWKFejSsRWd27XA1NQ0v7P53jh89BRHjikvGG1a+uBeRQS+ufHg4RP+Xr8FgKqulWjbqmk+50j4WF24fI0d/wYCUL9ODRrUrZGv+RG/jQ/T9l37uXjlOgC9unWkdCkng6af9jBX0MaaIYP6GjTtd9Hb/p2IIFPNtRu38e39FfcePNJY/uDREx48esLu/f/hUumTdz5QWr38N14lJuZ3NgA4cuwUU2YuBKBUSad3/rPLje+/HUS/nl0AcK3snCf7ePDoierz7NmtQ4YLxNvIgyAAXLx8XXUu/jiCXAWZhjhvs/ttCO+2zM6B7bsDWb0+AFA+zBg6yHxzf3L8OILMt/w7EUHma8+jXtCxx0AePQ4FoHixonz71ee4VnYmLi6eI8dP8/e6LQbfb3x8ApaWFjler001jyq5zZaQAxXKlaFCuTI6b5+T79bQeRCEd4E4bw0nL64rb8P7dg4kJLzEwqJAfmfjnSfaZL7226IVqgCzoI01h3dvYMigvjRuUJu2rZry6y8/EHzsX0o6FQcgJDScL4eOoWbjDpSqXJuCTm6UqFiLlp36sX3Xfo20Dx89pWprMvCbH9i6cy+1mnTErmRV5i76E9BsP3P56k3a+H5O0bLV6dzrSz5t10u1/t59zVLW7v2GqNadv3AF0N4mM30e9h0Mon5zXwqVcqditSYsWrYqw2dy6coNWnbsi30ZTz7xaMSUmQs58N8xjXSyYulQWfXEBPDl0B9V712lFrCfv3iFXl98S9kq9bEtUZWyVerT839DVceji6eRzxk1fhpVazXHrmRVnJxr0qnnIE6dCVZtk5iYRPX6bbB0qExBJzdVFQxAp56DVHnb8M9OQFmNkrZs5dp/mL/Ynyo1mlGolDt1P+1M4H9HNfKgS7uy9N8tKKuDfHt/hYtXUxzKVce2RFUqVW/CoKE/8uDhE1U6LTr2oWWnN0/aq9cHZPgusmrXdOjICTr1HESpyrWxLVEVZ8/GDPzmB27fva+xXfrjXrDkL9xqKj/Xmo07cOjICZ2/l/QOHj6OXcmqWDpUpmSlWly6cgOAuPh4Js9YgFeDthQu7UGx8l606NiHPYGHtaaz499AWnfpj5NzTexKVsWjTkumzFzIy5evNLZr0bGP6lguX73Jd6MnUtqlDkXKVKNzzy+5e/+hxvYXr1ynax8/SrvUpaCTGyUr1aJWk458M/InHj0OyfLY4uMTGPr9T9Rr1oUyrvWwLVGV4hW8adyqO3+t3pTjzyzNnXsPGDT0R5w9G2NboiolK9WiY4+BHDx8PMO2f6xcT71mXShatjp2JatSwb0hrbv0Z/aC5aptFAoFv85ZrPrM064FnXoOyja/lb18+HLoj6rXU2YuzNCWVNfzGnLfHk+X34a6lJQUps1eRMVqTShUyh2fNj00rgdpLl25Qd9Bwynnprw2VXBvyFffjeVJSJjOebv/4DF+w8ZRqXoT7EpWpbRLXfoM+I7rN+9obGfoe0p6f63epHrPpF/na6zb8W+gat3wHyYZ5Jgin0VRxrUelg6VKV7Bm9CwCED52dds3AFLh8pYF3fl2MmzQMZz4MHDJ1g6VFaVYgK07NQ3w3ly+OgpWnfpT4mKtSjo5EZplzo0aN6VEWOmEB0Tm+kxpF3n0jx8FJKhHWv6NtLL/1qHR52WFHRyY/O23Rm+B3Xa2sSmT2/tpm14NWiLXcmquNduweat/2bI5/OoF4yfNJvq9dtgX8aTYuW9qNO0E4v/WK3axpD3ENDtfqorUZL5mvqXO2RQXxyLO2TYpmiRwqq/Hz8JZdW6fzTWR72I5vDRkxw+epKl86fSs2uHDGkcPX6GNRu2IkmS1nxER8fSqnNfnj1/oVrWp0dn1Q9xwz87GDVsMACvXiVy4D/lDeaT8mXwdHfV6ViPHDvF2o3bUCgUqmMZOXYKlZzL06RhHUB5EWnRsQ8vomMAePnyFZNnLMDNtZJO+9DVzt0H6PnFtyQnJ6uWRTyNJGDHXnbuOcjq5XNp3aJJlmk8ehyCT9ueGhf+pKRk9uw/zIH/jqvSMDMzZfHcyfi07UlKSgpfD5/AwV1r2RTwL3v2K4OZDm2a0bVT6wz7mLNgOTdv31O9Dr54lc49B7Nz05/UreWl07Fq+24B9h0MYtfeg+mOKZS/121hb+ARTh4M0Dj3cmLpijUM+2GSxnn3JCSM1esD2LZzHzs3raC6p1uG9/06Z7FG85HLV2/Qvd8Qrp0NxM62oF55OH/hCp/1/5qkpGQK2lizbf0fuLlWJDomlk/b9eLKtZuqbV+RyJFjpzly7DRzpo1jYP8eqnW/TJ/HtNm/a6R96859Js9YwKEjx9mx8U+t7aZ7D/hW4zvcvf8/Ll65zokDWyhcyI5nz6No6/s/Ip89V23zPCqa51HRXLpynQ5tmlGyhGOmxxcbH8/yv9ZrLEtOTubU2QucOnuBkLBwfhjup/sHpubMuYu08f2c2Lh4jbztDTzCvgNBzJk2jgH9PgNgzcatfDPyJ433h4ZFEBoWwc3b9xg25AsAfp27mF+mawYbj5+E8vhJKDExcfR9XXWZU2/jvM6pkWOnaAREJ06fp3vfIVw8sRtjY+VtcU/gYT7r/zWJiUmq7ULDIvhrzWZ27/+PAzvWUqZ0iSz3c/7iFdp0+Vx1HQWIfPaczdt2syfwMDs3rcCrWlUg7+4paTp3aMn346YSF5/Ahn92MPb7r1Xrdu45oPpb2/UvJ8dkX9iOudPH0/N/Q4mJjWPEmMms/uM35iz8k8tXlQ+XQwb1pU7N6lnuLys3b9+jU89BGg+Xkc+iiHwWxdngSwz+oicFbaxznL66tRu3ZWhKZ8j0bt99QL8vR+DmWgnnCmUB5TnRtF1PVQFYmguXrhFgvYcv/9cTMOxvTdf7qa5EkImyFEX9y9blpHcoWoSJY4dRoVxpbKytkcvlPHoSwo8/zSDy2XN+nbNY6wXh/sPHVPdw47sh/8PE2DhDtUZ0TCxF7AuzYObPlCzpxNPIZ7Rr2ZSRYyYTGxfPerUg89CR48QnJADg2zHrC4O6h49CaNPCh349O7Nu8w42BewC4M9VG1RB5k9T56ouIlVcKjJ25BAePQll/OTZOu9n37a/WbnmH9WFc+TQQTTzqQ8oq0bi4xP4athYVYA5oF93WjZrzO59h1i6Yi3Jycl8NWwsV+vvz7L659tRE1U/iB5d29O1UxsePHzMmJ9nEBefwODvxnCtfiCWlhZ4V3dn6GBlic6Z8xeZPud3lvy5FgD7woWYO32C1n3cufeQcaO+xsPNhd//WM3+g0EkJyfz/bipHN23WafPQ9t3C+DTqA4ebi4UL1YEKytLXiUmceC/Y8z7fQURTyP5a/UmRn47iJmTx3Lk2ClGjJkMQDOf+owcOgggywvI4yehjBo/DUmSMDIyYuTQgdTw8mD1+gD+2bab2Lh4Bg39gdP/bUcmk2m8996DRwwb8gW1a1Rj4vR5XLpyndi4eDb8s4NBn/fU6bgBbt+9T4fPBhIbF4+VpQX/rFmieij6eepcVYDZvGkDBvbvwfOoF4ydOJPwiEhGjZ9Gq2aNKeFUnLPnL6kCzGIORRg/eiiOxR1YvPxvdu//j6MnzjJ/yV8M/3pAhjw8j3rB4t+mYGVpwbhfZnHvwSNCQsOZ8dtSpv08ilNnglUBpm/H1vT5rBMJCS+5c/8h/+49iFwuz/IYLQoUYNyor3GuUI6CBa0xMTYh4mkkv0yfx+27D5i78E+Gfz1A746DkiTx5bc/qgLMjm2b06t7R06fvcCvc5egUCj4ftxUWn7aiBJOxdm5WxkwGBsbM3vqWMqXLU14RCTBl65y5txFVbo7Xm9nW9CGWVPG4lDUntDwCE6ePp/hQSi91ct/Y9uu/cz4bQkAvbt3ok+PTgCq2h5dz2tD0Pe3cefeQ34ZN5wK5UozcuxUHj8J5cGjJ+w/GESLTxuRkPCSgV//QGJiEsbGxowdOYRqnlU4ePg4cxb8QXhEJN+OnkjA2qWZ5kmSJAZ+/YPqOvrN4P40bVyXC5eu8dOUucTFJ/Dltz+qfnd5dU9JY2VpSad2LVi59h/u3HvI6bMX8K7ujkKhYPfrh+zSJZ2o6e1psGPq0KYZXdq3ZNPWfwnYsZcFS/5i2uxFAFT8pBwTRg/NdF/FHIqwb9vfzPhtCXsDjwAwc/IY3N2UpY+ulZ1Zu3GbKsD8akBvWjdvwovoGG7eusv23YEZrmfq+nzWicYNavNpu14AOBS15+/lcwEwNzPLsP29B49o2rgeA/p2Jyk5mdIlnYhPeJlp+tm59+ARfXt0pl2rpsxf8heHjpxAoVDgv3oTUyaMBJT3trQAs2SJ4oz69ktKlHDk8tUbqkAdDHsP0ed+qgsRZAIxMXEar4sXK5rte0qXcsKhaBEWLl3JlWu3iI6J1XiSvH33ATGxcdhYW2m8z8rSgoB1SylkZ5tp2n8smo5Pw7oay7p0aMWKvzdy49Zdzl+8gmdVV3btPaRar0+QWcS+MCuXzsbMzJRqHm6qIPPOPWXVoUKh4F+1p6I/F/2qaogdFv6UWfOX6bSfOjWra1TllS9XWiOA37ZrH5HPogDwdHdVBXjNfRpw+txFzl+4QuSzKA78dyzTxsnPo16oqlQditrTv5cvAC6VPqFJwzps27WfZ89fsO9gEB3aNANg7Pdf8+++g1y7cYdJv74ZJmbejAkUsS+kdT9dOrRi9LCvAKhdszoVqjYk4eVLgi9e5fGTUEq8vrFmR9t3W79ODX6du4T5S/x59CQ0Q5XvuQuXAaji4szzqBeq5UXsC+v0QLRl+x6SkpSBfLtWTRn/+sLu07AOR0+cITwikms37nDxyvUMHbPatPDhl3HDAUh4+ZK+g5R/p50ruoiPT6B9twFEPntOgQLmbPr7d2q9vpEpFApV8wRTUxO+HtQPMzNTbKytaN/6U5auWEtSUjKbt+1m6OD+rNu8XZVu7+6d+KR8GQC+6NuN3fv/A2Ddpu1ag8yff/yO3t07AsomMW27/g9QVhVO+3kUxiYmqm1LOBXDuUJZnByLIZPJGDq4f7bHaWNthXuVyixa/jcXL18j6kUMqampqvVx8QncuHUPN9eKOn92oOzFfe2GstTNoag9K36fgYmJCS2aNuT6zTsE7NhLUlIyATv2MmRQX1VJnKmJCeXKlKKaRxVsrK3o1rmNRromr7ezsChAuTIlqeJSEQuLAvTwbZ9tnqp5VOHK9Vuq1yVLFM9wLup6XhuCvr+NAf26q0p0b925z/hJyofntPM68NBR1QNHk4a1qVtbWVvRqllj/tm6WxWQRj6Lwr6wndZ9XLxynauvP6OqVSrTtqWy2rSWtydenm6cPBPMtRt3CL54FU931zy9p6Tp27MLK9cqH/rXb96Bd3V3zpy7SMTTSEB5ncuKvscEMHvaOA4fO03EU+UDI4BcLmfpvKmYm2cM5tKYmZlSp2Z1iti/eUhwreys8b2amLwJYcqUKkGliuUpVrQIAN9/92WWx1KyhKNGzUTa/jJTqqQjm//+XfX7AnI11JKbayUWzVE2TShcyI5GR7oDcPfeA0Dz3iaXywlYu4xKzuUB+LRxPY20DHUPycn9NDsiyARsbDR/tKFhEVT8pFyW75m/2J/RE6ZnuU10dEyGC0KtGtWyvBiYm5tlCEIA+vbozIq/NwLKi4OHmwv/7jsEgLtbZVXxui5qVHfHzExZmlK40Ju8RL9+Oo2IfEZcvLKE1KJAAY2efjW9PHTeT3Zu3bmv+tv7dZVRGi9PN1WbzFvp2gyqu3vvoepCHB4RqXoqTe+GWtWYmZkpS36bSsOW3VTv7dyuBe1bZ/6jUc9fQRtrPqlQhguXrgHKJ1Jdgkxt321qaiptfD9XpaXNi+jM2xXpQr3NpZfacZiYmODuVllVSnD7zv0MQWa92m+aAqift1m1dUrv2fMXqpKxXyf+QP06b3ohRz6LIupFNKCskmnj+7nWNNK+P/VjmfHbElVJmjr1KnF1XtXc1f5+8zk8ePQESZKoW7M6FcqV5vbdB8xZ8AdzFvyBtZUlHlVd6NapDX17dsHIKPNm7Ft37qXH55mXzABEx8RkuV6b22q/E4+qLpioBcPVPd0I2LFXud3rz6b3Z53YvPVfEl6+VH2eTo7FqFfbmyED+6g6Bvbt0VlZjR8aTuPWnyGTyShbuiSN6tfim8H9+KS87teU9N7GeZ0b9et4q/4urOW8Vr/m7A08ovqNqJMkiZu372JfWHtgov69Xbx8LdNr0/Vbd/B0d82ze4rGtt6eVPykHDdu3WXT1n+Z/stodu55U6CQXWGFvscEygBqzrRx9Pzfm9/GN4P7afwGc6p1iyb8PHUuz56/4PtxU/l+3FTsbAviVa0qfT7rRKd2LXK9jzSfNq6vEWDmVr3ab87BQhr3YeU5ePfeQ1WTtrKlS6gCzPQM+VvLyf00O6LjD8pqhLKlS6penzh9Ltv3qDe6/W7I/9i5aQX7tv2tEZApFBnbyGTXLiKzkjTv6u5UrlgBgI1bdnL2/CVCQsMB6Nqpjdb3ZMbW1kb1t/qPRiJjfrOqbshLht5v+mqNm3fuaZQS3LxzX6NdaHZykj9t3+3xU+dUF4diDkVYOn8qe7euwn/xTNU2kqTQe1+6yu44bNXaXWqcK9m0/1KnXs08a/4ywiMi9cihkj7VUikpKRrt6LTRdtwWFgXYv30N40Z9TcN6tXAoak9sXDxHjp1myIgJzF7wR5ZpLv5jjervXt07sm3DcvZt+1vVBAW0XxNyQ9txNG1Ul8Dtq+nfyxd3t8pYFCjAk5Aw1m/eTvMOfVSdB/v18mXL2qV85tsOl0qfYGpqwt37D/lz1Qaad+ij0eZOX/l9XmfHtuCb81qew/Ma9DsvM5PwOo28uqek16dHZwCeRj5j/6GjqvaYlStW0LuUPTMJ6T6X9EHJVbVS8NwoVrQIQXs3MWzIF9SpWZ3ChWyJehHNvgNH6D3gOzZu2WmQ/YD2z1n956dea5FWQ5cVO/X7sDzr+3BW8uO3ps95L0oyX+vcviUz5ynb18xf/Bd9e3TJUG0e8fQZxsZyCtnZEhKmDPAKF7Jl0rgRgLJaMPT18sxkd1PPan3fHp0ZPWE6YeFPVU+8MpmMLu1bZn1weipqXxhrK0ti4+KJT0jg+s07qqeok3r2LjMyenM8aU9ladKqOgHOnL+ksU799SdZDGtRrmwpZDIZkiRRrkwpgo/tytB2Ln3wGBoewcgxUwBlAJSamsqlK9f5de4SxowconU/Z86/acsWHRPLrdv3Va/VH1Cyou27DQmNUP3dtVMbVZurzC6OWX2emVEfFuSs2ueanJys8fRbQe37MCQnRwfatfqUBUv+4v7Dx3Tu9SV7tqzE0tIC+8J22NkWJOpFNFaWFty5dBgrS0uN9ysUClV1f4VyZVSlSot/m6Kq/laXkPBSVVKv7uz5i1RxUd6wT5+9oFpeuqST6hwqYl+I0cO+YvQw5br7Dx5Ts3F74uIT2LZzHyO+yVgNn0b9tz9ryhisLC1RKBTZXhOyo/69XLh0jZSUFFXAr97GMu17liSJmt6eqrZ1CoWCBUtX8sOE6SS8fMm+g0cY2L8HkiTRrEl9mjVRtpNOSUnhx59nsHDpSsIjIjlx+jwtmjbMNF9ZnYv6nteGkJPfRmbUrzk9u3Vg6bypGbbJbggb9e+tfh1vdm9ZmWUaeXVPSa+Hb3t+mjKX5ORkZsxdwrUbtwHoqkOTK32PCeDy1ZtMm6NsR512vd2z/zCr1m3R+vtNz0j2piws/fcqSRKlSjqpmvQAnAu+TP3mymrebbv2Z1s6m/bbz+4BUNvnbKPWqUj94XnfwYwl3/oqV7YURkZGKBQK7j14zI1bd7XWsBryHpKT+2l2RJD52tCv+rP+n+08ehzKi+gYGrbsxtDB/VXjZB4+doq/123h3y1/UcjOllIlHLl99wHPnr9g5rxlVHFxZtGyVTyPis6zPH7m257xk2eTlJTM8VPK0tY6Navp3B5QV0ZGRrRs1pgN/+wA4Ishoxj93WAePQll0fKMQx1lRb3EYOvOvZQpVQITE2Oqe7jh07AuhQvZ8uz5C84FX2bYD7/QvGlD9u4/zLlgZRsS+8J2GiVB6RWys6WZT3327D/M3fsP8e3zFX17dMbKypJHj0K4cPkaW3fu4+DOdapBfL8Z8ZOqinbVstn8Mn0e127cYcZvSzOdlWjjll1UrFCOqm6VWfLnalWHK3e3yrn6/EuVfNMmaOuOvdSpUY2o6BhVG7H01D/P4yfPsSfwMNZWllQoVybTEo2ObZszbtJskpOT2bpzH5N+nY93dXfWrA8gLPwpAJUrlqeqgUcOUDf1p++5e+8hu/Ye5PyFK/Qa8C0bVy7C2NgY346tWLpiLXHxCbTr+gWDv+hF4UJ2PAkN5+r1W2zbuY/f506mQd0adOvURjXc1ujx04h6EU2Vys5Ex8Ry9/5DAg8do1QJRxb/NjlDHsZPnoPc2BhLiwJMUOvAltZT8sTp84wYM5kOrZtRvlxpChey4/LVGyS8bt+UmJR16WjJEo6qJiC/TJ9P08b1WLtxm6o9ZU65V6lMJefyXL95h7Dwp3w+eCQ9u3fkzLmLbHs9tI2pqYmqjdSIHycTFvGUJg3r4ORYDGNjY46dOKNKL62Ut+f/hmJlZUndmtVxdCxGakqKxrBhSdkcr53aubjvQBB1a3lhbm6Ga2Vnvc9rQ8jJbyMzTRrWwb5wISKfPWfNhq3Y2RakScM6KFJTefAohOOnznH56g3OHtmRaRpVXSvhUukTrl6/xZFjp/liyCg6tW2BsYkxDx894cy5S2z/dz9Pbp4EeGv3lKJFCtPy04Zs27VfdR8B6NIx6/aYOTmmlJQUBn4zmqSkZIyNjQlYu5T+g0fyNPIZo8dPw6dhHa0juahTr3lbt2k7crkRcrmcOjWrs+Gfnfyxch1tWjalTCknbKyt+S/ozRBr2dVogLJE8XlUNKFhEazbtJ1SJR0pWqSwTmN2lilVQhUI/hd0kgmT52BlZclsHfstZKWQnS3NmtRn9/7/SE1NpeNnAxn13Zc4ORXn2vVbBF+6yh8LfzX4PUTf+2l2RJD5WiE7W7asWaqa8edJSBjfj8v49Jqmf++ujPl5BoDqhmVf2A7nCmUzbROWW/aF7WjdvAlbtu9RLdOnw48+Joweyt7Aw7yIjuH8hSt066cs4aviUlGjV1t26tepoXoy2rP/sGqooKun91O6lBOLZk+i14DvSE5OZsmfa1jy55sqRxMTExbNnpRtL7bfpk9QDbmgvg9t/l4foBrqoUv7lrRv3YziDkXxaduT5ORkBn3zI0f2bNBo9wbKqqSfp/2msczY2JhpP4/W+bPQxrtaVdVn+uDRE7r3Vw4rUrtGNVXvc3WVnMvhUNSe8IhI7j98TKceyp6BmZXqAZRwKs6vv4xm2A+TUCgUTJ21SGO9tZUlS36bmqdNI4yMjPBfPJOm7Xpx8fI19gYe4esRE/h97mQm/PAtR0+c5cq1m5w8E5xlablXtaqMHjaYabN/50V0DD9oacPWs1sHre8t5lCEQenGsivmUIQR3wwElKUiwRevEnzxqtb3Z/db+7x3Vw78dwyABUv+YsGSvzA3N8PT3VWvMV/Tk8lkLPltimoIo83bdrN5226N9b/+8oPqYeflq1cE7NiraquprkABc9q0UHbWiI6JZevOfRrjEKYpWsSehvVqZZmvGl4emJmZkpiYxNngS6qOVP/+8xd1a1XX67w2hJz8NjJjaWnBknlT6PH5NyQmJqm+T3XqN3dtZDIZS+dPVQ33s3bjNtZu3Jbp9m/zntK3R2fVAwqAl2dVypUple379D2mX+cuUdWWfPNlPxo3qM2sKWPoM3AYL6JjGDJiPP+sztiuWl3DujWYv9gfgFXr3oxWEh9+DYWk4OiJsxw9cVbre311CJwb1K1JwI69pKam8j+/74HMS6/TK2hjTef2Ldm4ZScKhUJVG1rJuTwxsXHZvDt7c6ePV93bHjx6wlfDxqnWpbUrNvQ9RJ/7qS5Em0w1lStW4OTBAKb9PIo6NatTyK4gpqYmlHAqTtPG9Vg6fyqVX1cbfz2oLxNGD6VUSUcsChSgQZ0a7Nzkj0NR+zzNY1p7GlAGOR3bGq5hs7oypUuwe8tKGtSpgbm5GcUcijDquy/5YfhXqm0sCphnm04VF2eWLZhGJefyWqsw27T04eDOtXRs25wi9oUxNjbGvnAh2rf+lAM71ug0HlfJEo4c2/8P3/p9TsVPymFuboa1lSUVPylHj67t2bhyESWcihEaFsGo1w8OdrYF+XWScjDpGl4eDP5C2cD50pXrGcZgBOV4brOnjqVcmVKYmio7zGz6+/dcz9csl8v5Z/Vi2rTwoaCNNfaFC/HVgN4snP2L1u2NjY3ZuHIRdWpWx9rKUus22gzs34PtG/6gmU99CtkVxNjYmOLFitKja3uC9m3SOkamoVlaWrD5799VzVBWrv2HX6bPw7agDQd3rmX8qG9wc61EgQLmWBQoQIVypenYtjn+i2dSo/qbTjvjRn3D5r9/59Mm9SlcyBYTExMciztQp2Z1Jo4dxthMmjz4L57J4C96Y1+4EAUKmNPMpz57t65StZWtUK4Mw4Z8QY3q7hQtYo+xsTFWlhZU93BjzrRxDP/6iyyPr2Pb5syf8TMVypXG3NyM6h5uBKxdikulT3L92XlVq0rQvk307NYBx+IOGBsbY2dbkE+b1Gfb+uWqMTIBunVuS89uHXCuUJaCNsqhcIrYF6ZtSx/2bf2bsmWUzTsG9v+MLu1bUq5MKawsLTA2NsaxuAPdOrdl//a/sx1f0L6wHev8F+DuVpkC6a4F+p7XhpDT30ZmWjRtyJE9G/nMtx1OjsUwMTHBvrAdVatU5usv+/H3srnZpuFZ1ZXjgf/wRd9ulC1dElNTE2wL2uBS6RO+6NuNnZtWqLZ9m/eUT5vU12gOpkswlkbXY7r4ugkSQLkypfhxhHKM2M7tW6p6pe/Zf5i/1mQ9BFzLZo2Z8tP3lCtTKkPHm5peHnw1oDceVV2wL2yHXC6noI01dWtVZ+XS2ToVwsyaOpbO7VpgX1h7f4hs3z9lDJ3atcDSwoKCNtb06NqePQH61fhlJu3e9t2Q/6nubVaWFlStUpkObZoDhr+H6Ho/1ZVM0rels5CvUlJSKFK2GklJyTTzqc+WNZmP05ZbkiRlKN0a98ss1awh034exddf9suz/ee3yTMWqGYsyklpiJD/WnTsw5Fjp4E3peeCIMCXQ8ewat0/GBkZcTP4IMUdsh+6TxD0JarL3xNJSUkkvHzF3+u2qDpB6DKeXW40af2Z6ikRlO2ufv/jb0BZld2+9ad5un9BEATBcCRJIj4hgbv3H6nGlW3SsI4IMIU8I6rLdTR83K8s8d+QZ+l/M3oKG7fuyXT9jN+W4uRcUzWYbSXn8nRs2zzDdkv8NzB83K+ZpuPVpCs31HpGqwsLj6R+q97ExSk7tZw6e4F+X47Ao04rPOq0YuTYKbx8+QqZTMb0iaMoVdJwpUJ5/fmm2b77ED0GjMzz/bzr/lz9Dz/+MjfH75+1wJ+fpi/MfsP3RF6df1n93t41jdr240yw7m1Hf5q+kFkL/PMuQ3ro2n8YR45rb5cnvPHwUQgO5byo3aQjTyOfIZPJGJXFoOVZnRPZ3Wuy0/YzPw4F5Xwwc+H9IILM1wZ+9xNrNuXd8BrqtF2c5037Ed/2GYPG9KwsLWjmU59Nq3436MCwAMUc7DmyaxVWVsqONoP/14sqLhUpaGONiYkJxYsVpUObZuwJWKnXlIKCYRjypv55z05MGfetQdJ6m96noO1DktuAIq9tWDGb+rVzPgf2hyYkLAKvJl015rpXJ5fLca5QlhW/z8jV3OGCkB1RXf6eGDNySKZjOOaVmVPGvNX9vWvy4zMXckd9DElA6zh+gpAT6c+t91HpUk7Eh2c+M4wgGNr7/YvJQ4GHTzB/6WqiomP4tGFtUlM1By29fvMucxav4tad+9hYW9G3e3s6tlHOr73EfwPXb96lmEMR/t1/BEvLAgwd1Jtmjeuw7p9d/Ls/CJkMAnYFUtyhCBtWzGbgdz/RqK43Pbooe8Ndu3mX3xav4uad+xgZGdGscV2+/+ZzEl6+YuzkeVy6epOk5GScy5Vh5Df9cdZjIO1zF67yw8Q5PI+Kpra3O2OGDcLKyoKQsAja9RjCwW0rsLay5KfpCzGWy4l/+YqjJ85hX9iOH4cNxMtDOV3Yv/uPsPSvjTx7/gJLiwJ0bvcpX/Tukqef7/OoaFp1+5ItK+dRvJhyjtqkpGSadxnIb1N/oKqrM4+fhDFroT+Xrt3C3MyMDq19+LxnR61TAj57/oIZ8//kTPAVzMxMafVpAwb164qxXM6Z4CuMGDeDL/t3Y8WaLSBJdGr7KQP7+iKTydi++xBrN++kQR0vNm7di7HciOFD+lO0SCGmzF5G+NNIfBrUYuzwQap9G/q8UXf52i2Gj5vBnk3KzmBzfl/Jun/+5eC2FVgUMGfdP/9y8swF5kwZzRL/Ddy8c59ZvyiH7PBq0pXR337BhoA9hEdEUs3dhV9++FpVqn3uwlWmz/uDkNAIanm5Y22t2Svx6o07zFzgz937jyhib8f/enWmhU89UlJTadKuPyt/n0qZUk4cPnaGYWN/Zd60H6lTw4Pbdx/yxdDxBAb8iVxuRPcvRtDvsw608NGcmxegz2Dl8EOffz0WI5mM/j070sKnHu16DGH8yMH8ufofEl6+Yu/mZfy25G/2HTxGTGwcDkULM6hvV5o2qp3r8y9t3bTf/uDeg8cYGxtT1eUT5kzJfCirzH5vQKbnqkKhoFW3wUwZ963q9wbQpd93DOzrS7PGdXj0JIzpv/3B1Ru3sbayolvHFqrrR9q52aRBTdZv2Y1MJqPfZx1U6xUKBUv8N7BlZyBGRkZ83jPzTm2Hgk6xYs0WJIVE/Va9ATiyS9l79uWrV/zwy1yt14eUlBSWr9rMv/uDiIuPp6prRX78bkCms5pl9Z1tCNjN+i27+XvxNAoUMOfilZt8PXoy/gsmU7Z0Cdp+5sdwv740qleDJ6ERTJ61hCs3biM3MqJMqRIsmjFW6zzZf2/cweZte3n2/AV2tgXp0aU13ToqR+xIux6mP7eyOje02R0YxF9rtxISFoG1lSWD+nWlbYtGSJLE6o072Lh1L7FxcbhWqsCooV9QwlE5bqRXk66sXvorFSuUAWDNpp0cOnqapXN+Uq3P7Dfb9yvlyBmtuiqrwn8cNpCWTetnmXd9zok0qakKJs74ncD/TlDIriDfDOxF4/rKETckSWL9ln/ZuFX5+TpXKMMP335B2dIltKa1a99h/ly9hchnUZQvW5KRQ/pTybmcXtc14R0kCZIkSdKAbydIqzfukCRJku4/fCLVavaZ9N/R01JySoq0ceseqYZPN2nxivWSJEnS02dRUpP2/aW9B49KKSmp0q27D6TmXQZKJ89elCRJkhavWC/V/LS7av32PYek+q16S3HxCZIkSdKEaQukmfNXZLr/8IhnUoM2faQNAbulV4mJ0suXr6RzF65KkiRJsXHx0p4DR6WEhJfSq8REacb8P6WOvb+RFAqFat/Dxk7P9DirN/aVeg0aJUU8fSbFxMZJX434Rfpp2kJJkiTpSWi4VL2xrxQTG6fKZ4PWfaTT5y9LKSmp0rKVm6Q23b+SJEmSEhJeSjWadpfOBl+RJEmSYmLjpMvXbun0Wef28x36w1Rp+arNqvT2HToudez9jSRJkvTy5SupTfevpNUbd0hJSclSaNhTybf/MGnLzkBJkiRp278Hpc++GKF675fDfpbGTPpNik94KYWERki+/b6T/vhbmfbp85clb5+u0k/TFkovX76S7j14LLXq+qW0ffdBVVo1fLpJazfvlJJTUqQtOwOlBm36SKN+miVFvYiRIp4+kz7t9IUU+N8JnY4rJ+eNuuSUFKlB6z7S3fuPJEmSpM8GjJTa9xwiBZ04J0mSJA0f+6v094btqn2pnyfVG/tKg777SXr2/IUUExsn9Rjwver7iI6JlRq26Stt2rZXSk5Jkf47elqq1ewzacK0Barvvkn7z6W1m3dJycnJ0pngK1K9lr2k85euSZIkSV+PmiJtDNgjSZIkzVywQmrfc4j025JVkiRJ0ppNO6XvxmR+vqZXvbGvdP3WPdXrtHN2+NhfpZjYOOnly1eSJEnSrn2HpWfPX0gpKanS7sAgqXazHtLjkHBJknJ//vX3GyMtX7VZSk1NlRITk1S/gczym9nvLbtzdc6iv1SfsSRJ0oXLN6TG7fpJiYlJUnJKitSpz1Bp7uJV0qvEROnm7ftS8y4DpX/3H5Ek6fW52bS7tGr9Nik5OVk6ff6yVKNpd+nR41BJkiQpYFeg1Krrl9K9B4+lly9fST9NWyh5+3SVTp+/rPU4tF1Xsro+SJIkzV28Svpy2M/S08jnUlJSsjRn0V/SF9+Mz/Szyuo7kyRJ+m7MdOmn6Qul2Nh4qe1nX0n/bN+nWtem+1fSwSMnJUmSpB9/mStNnr1ESk5OlpKTk6XgS9elpKRkrfvc/99xKTT8qaRQKKTT5y5JdZr3UJ232s6t7M6N9P47elpq0r6/dOrsJSk1NVV69vyFdO3mXUmSJGn7nkNSiy4DpVt3HkivEhOl2Yv+knz7fSclp6RIkpTxXF+9cYc04NsJqtdZ/WbTX8slKfvzOifnRA2fbhrXhdrNeqjOsQ0Bu6Xu/xshPXgUIiWnpEhrN++U2vccovou1L+zs8FXpPqtektng69IycnJ0uqNO6SmHf8nxcbG63VdE949ok2mFvsOHcPb040Gdbwwlsvp0q4ZJUu8mdVl197DeLpV5tNGdZDLjahQthRtWzRid2CQaptKn5RTrW/9aQOSU1J4+DhUp/3v2n+Yyp+Uw7d9c8xMTZUDOldVzkJjZWlBs8Z1KFDAHDNTUwb168rDx6E8jcx+rtQ0fbq3o4h9IaytLBn8eTd2HwjKdBq2OjU98fJwRS43ol2LxoSGP+VFdCwAxsZy7j18Qlx8AtZWlrhWqqDT/nP7+bZu1oBd+94MELtr32FafaqcGi/oxDmsrS3p0aU1JibGFHOw57NOLdmj9t2kiXj6nNPnL/Pd4D5YFDCneLEifN6rEzv2/KfaRqGQ+HpgT8zNzShTygnfDs3Zte/NlGG2tjZ079QKY7mcFk3qEh//kvatmmBb0Joi9oWoVrUy12/d0+m4IHfnjbFcjodbJc4EXyE6Jo5nz1/QpV0zzgRfQaFQcO7iVbyrVcn0/X26t6eQXUGsrSxp0qAm12/eBeDI8XMUsbejc9tPMZbLaVDHC2/PN+kEnTiHna0N3Tu1xNjYmOruLrTwqcfO15+jl4crZ17P4HTm/BUG9PHlzHllZ4LT5y9rpJVTA/r6Ym1lqSqtatlUOR6oXG5E8yZ1KVPKkYtXlJMI5Pb8MzaWExb+lKfPojA1NaGau0uWecvs95bdudq+VRMOHD6pmnFo+55DNG9SD1NTEy5fu0Xk8yi++rw7ZqamfFK+NF07NGf77kOq/doWtKZX17YYGxvj5eGKY7Ei3Hg9I9Hu/UF07diCMqWcMDc3Y8iAHjmaVz2z64MkSWzauofvvuqDfWE7TEyMGfy/7ly4cp2wTOauz+o7Axg/cjAnTl9gwLcTqOxcPtPSQ2NjOZHPXhAS9hRjY2Pcq1TExER7pZ1Pg1oUK2qPTCbDy7MKtbzdORusORi/+rmly29Y3aZte+neqRXe1apgZGREIbuCVPqkLKC8bnXr1JIK5UphZmqK3/8+I/zpM65cu53t554ms9+sNtnlPSfnRKmSxTWuC16eruw+cBSAjQF7GNS/K6VKFMdYLqd7p1YkJiZx+VrGect37TtMy6b1qebugrGxMT26tMbaypKgk+dyfV0T8peoLtfiaWQUxR00B8BVfx0aHsHRU+dp1LafaplCocDD7c10hIULvZm6SSaTYWZqqvOk8mHhkRo3PXWvEpOY+/tKjp48T0xsnGocyxcxMRQtottgssUdiqj+LuZQhOTkFKJexGjd1t7OVvV3gQLKG3jCy5fYFrRmzuRR/L1hB/OW/k2FsqUY3L8bXjoEDLn9fBvU8WLyrKVcvnabEo5FOX46mBFDlNuGhD3lzr1HGu+VJAkHLdPKRUQ+w8zUhMKF3hyjU/GihD99M0uCmakJhezefJfFHYoQEflc9bqw2rq0AKeQ2mdmbm7Gy9dBQl6fN/A6oDt/hUJ2BalWtTLe1dyYPGsJN27fRyYz4pNypTN9r/rnUMDcjPjX+X767LnGOQPKTmJpQ2mFP32GYzHN9U7FHTh3Udn2y8vTlVUbthH1Ioao6Bha+NRj7uKVxMTGcf7iNb76vLvOx5eZYukGrF69cQdbdx0gPPIZMmS8fPlK9XCU2/Nv/MjBLF25id5fjsbaypKuHVqoqli1yez3lt25WrZ0CcqXLUngfydo1qQO+w4eY/Gs8YDyAalI4UIawZNTcQf+3f/mAUj93ATld5qQkPadRmnkq3AhW0zTzXKli8yuD5Ik8fJVIgO+nYCMN2PtmhgbEx7xLMP3BVl/Z6AMmps2qs3azbsY//3gTPM0dFBvlv61ka9G/IJMJqNN84YM6NNFa3OZf/cf4e8NOwgNj0ChkHiVmIhjMc3hfNTzqstvWF1o+FNafdpA67qIp8819mVqqhzsPUKPGZEy+81qz0vWec/JOaHtuvD09fUxJPwp46fM1/jck1NSNK6vaSIin2d4WFO/FufmuibkLxFkalHE3o6LVzSftsIiIqlSWTlzh0MRexrVq8HUHPbOzW76vmIO9pw8c1Hrur83bOfazbssnzcRhyKFiY2Lp3G7/ugzpH5o+FPVsYSFR2JiYoydrU2mJQyZqVHNjRrV3EhJSWHj1r0MHz+Dg1tXaL2Yq8vt52tmakrThrXYte8wpUs6UqXSJ6qLtUPRwlR2Lof/woxzV6dX1L4wiUnJPHv+QnWxDgl7qhGQJiYl8zwqWhVohkVEUjSTNmXZyevzBsDLswp/rduKna0NXp5VcC5fmrCISA4eOUV1D5ccTR1ZpHAhQl/PcZ4mLPwZheyUcwo7FClMSJjm+pDwCBxeP/RUrFCW5OQUNgTsplrVysjlRnhUqcTazbswNpZTvmxJnfOSWf6NjN4sD750naUrN7J41gQqViiDkZERPQaMRHr9I8nt+VfCqRgTfxiCJElcuHyDr0b8QlVXZyo7l9O6fWa/N13O1fYtm7B9zyFMTIwp7lCESq/3UbRIIZ4+e67RGSU07ClF7XWbo7tIYTuN7/R5VDRJycmZbp/dbzq9gjZWmJub8dfCKZTRYQD87L4zgEtXb7J99yFafdqA6b/9wfJ5EzGWyzOkVciuIKO/Vc7OdPvuQ/xG/kKFcqXwaaA5TWZYeCQ/TVvIvOk/Ut3DFWO5XNmDPt21VP3c0vc3XNyhCI9DwrSuK1qkECFhEarXyckpRD6LUn2HBczNePUqUbU+8rnutVVGsozfV3Z51/ecALReF6q6Or/eX2GG+/WjTg2PbPNb1L4QoemvIWrX4ry4rglvh6gu16JpwzqcPn+JoBPnSElNZcuO/Tx89KbKstWnDThz/jKBh0+QkpJCSkoKN27f58p13ao5CtvZ8jg0XOMCqq5l0/pcuX6bTdv2kpSUzKtXiZx/XSoUn/ASM1MTbKwsSXj5ioXL1+p9fKvWb+dp5HNi4+JZ4r+eZo3r6H0Tefb8BQePnCI+4SVyuRxLiwIaF/y2n/lpVN2pM8Tn27pZQ/YePMr23Qdp3exNSUH92tV5HvWCjVv3kJiURGqqgvsPQ7SO9Va0SCG8PFyZu3gVL1++Iiw8kj9X/0PrZg1V2xgZyViwfA2vEpO4/zCEjQF7tHZK0UVenzcAFSuUITVVwb+BR/DycEUmk+HhVon1Af/muFq6Xq1qREQ+Z8uO/aSkphJ04hxnzl9Wra9b05OoF9Fs3LqHlNRUzl+8xu79QarPUS43wrNqZdZs3qkq6fbyrMKazTup7q55g8jqvAFlAJHZTTtNXHwCciMj7AraoJAktv57gDv3HqnW5/b827H3P549f4FMJsPKygKZkSzL309mvzddztVPG9fh+s27/LV2K+1aNlYtr1KpAoXtbFm8YgNJScncvveQ9Vv+pU3zhtqykEHzJnXZGLCH+w9DeJWYxILlazSCqfQK2RUkNDySlNRUndI3MjKic9tPmfP7StXD64voWPYePKZ1++y+s7i4BMZOnse3X/Zm/PeDkclgyYr1WtPad+gYYeGRSJKElZUFRkZGyLUEowkvXyEhUci2IEYyGUEnznEik4f7NPr+hju1acrazf9y9sJVFAoFz6OiVc1nWjWtz8aAPdy9/5ikpGQW/bmOIvaFcK2sbHZU6ZNy7Np3mJTUVG7cvq/RTCc7trY2GBnJeBwSrnPe9T0nAB4+Cs1wXWjWuA4Avu2bs3jFeu4/DAGU3/Gho6e11sy0/LQBuwODCL58nZTUVNb98y/RMbHUrekJ5M11TXg7REmmFmVKOTLxhyHMmL+CFzExNG1Ym9pqT2NFixRi/vQxzF+6mimzlyFJCsqUKsGX/bvqlH6HVk0YPXEOTdp/jkPRwqxbPlNjvUORwiyaOZ7fFq9iwbI1mJgY07xJXTyrVqanbxvGTvqNZp0HYFvQhi/7d2PTtr16HV/LpvUZNOxnnkW9oFZ1d0YM6a/X+0FZrbf2n138/OsiJEmiVIniTJ8wDCMjI5KSknkRHYObi/Y5mw3x+Xq4VcLSogD3HjymacM3vYYtCpizaMY4flv6N8tXbiIxKZkSjg707tZOa14mjR3Kr/P+oM1nfpibmdLCpx59u7dTS68AzuXL0L6nsuSqY2sfnW/k6eX1eQPKm7tn1cpcv3mX0iUdAajh6caBwydzfDEuaGPFrF++59d5fzJ70V/UrF6VFk3rqdrx2lhb8dvUH5m90J8Fy9dQpHAhRn/7BR5ulVRpeHm4cuT4WVUealSrwoz5LzWaV2R33gAM7t+NmfNXMGnmEvp2b0+zJnUybFOnhgc+DWrR7YvhmJqY0OrTBrhXqahan9vz79TZS8xf8jcJL19RyM6WoYN6qXoAa5PZ702Xc9XSogA+DWuxOzCIlk3fPNwYGxszZ/Iofp33J827DMTG2pKevm10fgBq17IxT8IiGPDt+Nc9iTtx4PDJTLdv2rA2ewKD+LTjF0iSxKHt/tnuY8gXPfhr3VYGD5/Is+cvKGhjjXe1KqogRF1239mUOUup+ElZOrRWznk9eexQeg0aRc3qVTM00bl28y5zFq0kJi4eGytL2rdqQsM6Xhn2Wa5MCT7v2Ykvh09EoVDQoE51GmjZTp2+v+FG9WoQl/CS6b/9QVj4U2ysrfjy825U+qQsrZs15FlUNN+NmUZMbDyulSowZ/Io1cP6yG/689O0hTRu2w/3KpVo06whF6/ezPpDf83czJQBfXz5ZvQUkpNTGP3tF7TwqZdl3vU9JwBq1/Dg0rVbzF28CjtbGyb++DWlXjf16taxBXK5Ed9PmEn402dYFDDHw62S1utQdXcXRn7dn19mLCbyeRTly5Ri3rQfVXNr58V1TXg7xNzlgsGdvXCVzdv2vpeDfatLG8JIlxuqkHsfynljaMtWbuLW3Qf8+tPw/M6KIAiCXkRJpmBw1d1dqJ5Nj1tBSE+cNxlFvYghYGcgE0Z9ld9ZEQRB0JtokykIgvAO+uPvf2jbw4+6tTypUc0tv7MjCIKgN1FdLgiCIAiCIBicKMkUBEEQBEEQDE4EmYIgCIIgCILBiSBTEARBEARBMLiPvne5QqEgJCQEa2trMWuAIAiC8NGSJInY2FgcHR31nqBDELT56IPMkJAQSpbUfVo7QRAEQfiQPXr0iBIlSuR3NoQPwEcfZFpbWwPKH5WNjU0+50YQBEE5BV/rboPZuf53rCwt8js7wkciJiaGkiVLqu6LgpBbH32QmVZFbmNjI4JMQRDeCUZyY+TGJtjY2IggU3jrRNMxwVBEowtBEIR3jJmpKWOHD8LM1DS/syIIgpBjH31JpiAIwrvGxMSYDq198jsbgiAIufJBlGTeu3ePxo0b4+LigpubG/Hx8fmdJUEQhBxLePmKrv2HkfDyVX5nRRAEIcc+iJLMfv36MWnSJOrXr8/z588xMzPL7ywJgiDkmEKh4O6DxygUivzOiiAIQo6990HmlStXMDExoX79+gAUKlQon3MkCIIgCIIg5Ht1+eHDh2nbti2Ojo7IZDICAgIybLNw4ULKlCmDubk5NWvW5NSpU6p1t27dwsrKirZt21KtWjWmTJlisLxJkkRiYlKe/ZMkyWB5FQRBEARBeJfke0lmfHw87u7ufP7553Tq1CnD+vXr1zNs2DAWL15MzZo1mTt3Ls2bN+fGjRsULVqUlJQUjhw5QnBwMEWLFqVFixZ4e3vz6aefat1fYmIiiYmJqtcxMTGZ5i0pKZlCpdxzf5CZeP7wAmZmoveoIAiazM3NmD/9R8zNRdMfQRDeX/lektmyZUsmTZpEx44dta6fPXs2AwYMoH///ri4uLB48WIsLCz4888/AXBycsLLy4uSJUtiZmZGq1atCA4OznR/U6dOpWDBgqp/7/NsP8HBwezduzfLbQICArh58+ZbylFGISEh9OzZM8/Sv3//Phs2bMh0fZkyZYiLi8uwvGPHjtjZ2dGlS5dM33vq1ClcXV2pUKECEydOzLC+S5cueHl55SzjgpAFY7mc2t4eGMvl+Z0VQRCEHMv3IDMrSUlJnD17lqZNm6qWGRkZ0bRpU44fPw6At7c3ERERREVFoVAoOHz4MJUrV840zR9++IHo6GjVv0ePHuX5ceRGVg3/34cg09HRkdWrV2dYnpqaapD0swsyMzN06FBWrlyZ5TZ+fn6sXbuWGzdusGvXLi5duqRat2/fPuQiABDySFx8Ag3b9CUuPiG/syIIgpBj73SQGRkZSWpqKg4ODhrLHRwcCAsLA8DY2JgpU6bQoEEDqlatyieffEKbNm0yTdPMzAwbGxtWrVpFrVq18PHRfSy60Nunef7wQo7/hd4+rdN+7t+/j5ubG927d8fFxYX4+HiGDx+Ot7c37u7urF69mtTUVMaPH8/KlSvx8PBg165dGdI5efIk27Zt45tvvsHDw4OIiAjOnTtHjRo1cHNzo0+fPrx6lfkQKXv27KF27dp4enrSq1cvkpKSOH78ODVq1CAlJYXw8HA++eQTwsLC8Pf3p3PnzjRo0ABnZ2fmzp2rOpa00j5/f386depEo0aN8PX1pX79+ty4cQNQtn91dnbm+fPnmebn0qVLVKtWDQ8PD9XxjBkzhv379+Ph4cHy5ctJSEigc+fOuLi40K9fv0zbvTZq1CjLqdNCQkJISUmhatWqyOVyunfvzo4dOwBITk5mypQpjB07NtP3C0JuxSe8zO8sCIIg5Eq+t8k0hJYtW9KyZUu93uPn54efnx8xMTEULFhQp/eYmZq+tTaU165dY/Xq1VStWpWlS5dSvHhxTp8+zcuXL6lVqxYtWrRg4sSJXL58mZkzZ2pNo2bNmrRr144uXbqoAm8fHx+WL19OzZo1GTx4MIsWLWLYsGEZ3hsZGcmMGTM4cOAABQoUYPz48Sxbtgw/Pz8aNGjA9OnTOX/+POPHj6dYsWIAnD59mosXL2JsbIyXlxdt27bNUNp34cIFzp8/j42NDX/++ScrV65k8uTJHDp0CDc3tyxHB1i6dCmDBw9mwIABvHz5ErlczuTJk1mwYAGbNm0CYObMmTg5ObF582Z27drFX3/9laPPPyQkBCcnJ9VrJycn/vvvP0DZhKNv375ifl9BEARByMI7XZJpb2+PXC4nPDxcY3l4eLgqsMmphQsX4uLigre3d67SySvOzs5UrVoVgL1797J8+XI8PDyoXbs20dHR3L17V+80X7x4QWJiIjVr1gSgd+/eHDlyROu2J06c4OLFi9SuXRsPDw82btzIvXv3AJg0aRKrVq3i1atX9O7dW/WeFi1aYGtri5WVFa1atVI1aVDXvHlz1RzxXbt2ZcuWLSgUClauXEnfvn2zzH/t2rWZNWsW06ZNIzQ0FFMtU+4FBQXRvXt3AFq1aoWdnZ0On4zunjx5wt69e7PNqyAIgiB87N7pkkxTU1OqV69OYGAgHTp0AJRtFAMDAxkyZEiu0s5JSWZiUlKu9qnP+y0sLFR/KxQKlixZQsOGDTW2uXLlSq7ykxWFQkHr1q1ZsWJFhnUREREkJSWpmjOklVbKZDLVNjKZTON1GvXjsrKyokaNGuzcuZPDhw+zdOnSLPPUo0cPatSowfbt2/n000/ZuHGj1u207Vdfjo6OPHnyRPX6yZMnODo6EhwczNWrVylbtiwpKSk8ffqUVq1aaW2uIAg5VcDcnPV/zKKAuXl+Z0UQBCHH8j3IjIuL4/bt26rX9+7dIzg4mEKFClGqVCmGDRtG37598fLyokaNGsydO5f4+Hj69++fq/0uXLiQhQsX6tUBpXiF/Cn1bNasGYsWLaJevXrI5XIuX75M5cqVsba2JjY2Nsv3qm9ja2uLmZkZp0+fxtvbm9WrV9OgQQOt76tduzbffPMNDx48oHTp0sTExPDs2TPKli3LgAEDmD9/Prt372bWrFl8//33AOzevZvo6GiMjY35999/+eqrr7I9tv79+/PZZ5/RtWtXTExMANiyZQunTp1i6tSpGtvevXuX8uXL891333Hz5k2uXr1K5cqVNT6DevXqsX79emrXrs3u3buJiorKNg/aODo6IpfLuXjxIq6urqxbt45ly5bh5uZGaGgooGxv2qVLFxFgCgZnZCTDoWhhjIxy/8AkCIKQX/K9uvzMmTN4enri6ekJwLBhw/D09GT8+PEAdOvWjZkzZzJ+/Hg8PDwIDg5m9+7dGToD6cvPz4+rV69y+rRunXHy04ABAyhTpgyenp5UqVKF7777DkmSaNy4MefOncPT0zPTQKd79+788ssvqo4y/v7++Pn5UbVqVWJjYxk8eLDW9xUpUoRly5bRuXNnqlatSoMGDXjw4AF//PEHRYsWpXXr1kybNo2//vpL1XnH29ubtm3b4unpycCBAylfvny2x5YW5Pbp00e17O7du6oqdXXr16+nSpUqeHh4EBISQseOHalatSrJycmqjj9fffUVDx8+xMXFhfXr11OqVCmt+23atCm+vr7s2rWLEiVKqKr2W7VqRUhICAALFizgs88+w9nZmRYtWuDm5pbt8QiCIcQnvKRR236i848gCO81mfSRTzuTVl0eHR2dIbBJTEwSg7HryN/fP8tOSJm5e/cuvr6+nD17VrWsb9++zJw5kyJFihg6m4LwXoiLT6BR234c2u6PlaVF9m8QBAPI6n4oCDmR79Xl+UWX6nJTUxOeP7yQZ3kwNTXJs7TfB8uXL2fixIksW7ZMY3lOe4QLgiAIgvDuECWZH8iT24oVK/jtt980lvn6+jJmzJhs39uxY0dVz/E0q1atEtXDgpBPREmmkB8+lPuh8O4QQab4UQmC8I6RJIn4hJdYWhQwyGgJgqALcT8UDC3fO/7kl3d9nExBED5eCoVEeMQzFIqPugxAEIT3nCjJFE9ugiC8Y0R1uZAfxP1QMLSPtiRTEARBEARByDsfbe9yXV3b7IukSDZomjIjEyp31j5bjSAIgiAIwofgoy3J1LVNpqRIRlKkGGy/kiJFp6B15MiRuLq6MnnyZL3S9/f3Z8SIETnNHqCc4zy7KR7v37+PhYUFHh4eeHh4MHLkSK3b9evXjx07duidh4CAAG7evKl13aFDh+jSpUuG5ZIk8eWXX1KhQgW8vLy4c+dOhm327dtHtWrVcHNzo06dOly6dEm1rkyZMlStWhUPDw8aN26sd54FwZAsLQrkdxYEQRBy5aMtydRn7nKZkTEuvgEG2e/VjR102s7f35/w8HCMjPLuOUB93nF1aUHmwIEDs3y/i4sLZ86cyZO8BQQEYGxsjLOzs87v2blzJ5GRkdy+fZsdO3YwatQoNm3apLFNkSJF2LVrF8WKFWPv3r34+flx+PBh1fpjx45hZWVlsOMQhJywsrTgvx1ivFhBEN5vH21J5rusY8eOREVFUa1aNaZMmULPnj0BWLp0qWqqxosXL9KuXTsAduzYgbOzM15eXhw5ciTLtMuUKcPo0aPx9PTkwIEDrFq1Cm9vb9zd3Rk2bBgAY8aM4erVq3h4eDBx4kS98//TTz9RsWJFmjRpQnh4eLbbz507l4oVK+Lu7s7gwYM5efIk27Zt45tvvlFNh3nq1CnVlJIbN2pvarBt2zZ69+4NQOvWrTl27Bjp+7V5eHhQrFgxQDkN5pMnT/Q+PkHIaympqRw/HUxKFpNFCIIgvOs+2pLMd9mWLVuwt7cnODiYpKQkqlatCkBQUBC2traEhoYSFBREvXr1ePXqFUOGDOHIkSMUK1aMxo0bU6tWrSzTL1myJOfPn+fatWssWbKE48ePY2xsTJ8+fdi5cyeTJ0/mxo0b2ZZS3rhxA09PTwoVKsT06dPx8vLi9OnT7Ny5k4sXL/L8+XMqV66Mn59flulMnDiRR48eYWlpSXR0NAULFqRdu3Z06dKFNm3aAODj44O/vz9eXl5069ZNazohISE4OTkBIJPJsLOz49mzZ9jb22vd3t/fn2bNmqley2QyGjZsiJGREd9++60quBeEt+3Vq0S+HjVF9C4XBOG9JoLMd5ypqSkODg48fvyYu3fv0qdPH4KCgggKCsLPz4/r16/j7OxMyZIlAejatSsPHz7MMk1fX18AAgMDOXHiBF5eXgAkJCRQvXp1XF1ds81X8eLFuX//PoULF+b48eP4+vpy69Ytjh49SseOHTEzM6N48eI0adIk27Rq1KhBr1698PX1pUOHDhnWv3jxgsTERFU+e/bsycqVK7NNNysnT55kyZIlHD16VLUsKCgIJycnQkNDadq0KW5ubqoAXxAEQRAE/Xy0QaYuc5enkRQpOrel1CUtmZF+H3vdunXZsGEDxYsXp169eqxatYozZ87g5eXFtWvX9J4RxMJCWTKiUCgYMGAAEyZM0Fh///79bNMwMzPDzMwMgNq1a2Nvb8/jx48B9M7Pzp07OXToEAEBAcyZM4fTp09n2EaXNB0dHXny5AleXl5IkkRUVBSFCxfOsN29e/fo3bs3W7Zs0VifVgpavHhxWrVqxblz50SQKQiCIAg59NG2yfTz8+Pq1ataAxp1MiMTvYPCrNMzRmZkotd76tWrx5w5c6hbty4eHh7s3buXokWLYmZmRqVKlbh58yaPHz8mJSUl0/aK2vj4+LB+/XqePXsGQEREBKGhoVhbWxMbG5vle58+faoK0G/evElYWBiOjo7Uq1ePgIAAkpKSCAsL4+DBg6r39OnTh1OnTmmko1AoePToET4+PsycOZOHDx+SmpqqkQdbW1vMzMw4d+4cAGvXrtWapzZt2rBq1SpAGbjWrl07Q3AaFRVF+/btWbhwoUaJbXx8vGp/cXFxHDhwQKcSXUHIC0ZGRpQrXSJPO/4JgiDktY+2JFNX78J4lnXq1CEkJIS6desil8spUaIEnp6eAJibmzNv3jx8fHywsbHRq+TN1dWVMWPG4OPjg0KhwMzMDH9/f1xdXVXD/Pj6+jJ+/PgM7z18+DDjx4/HxMQEY2Nj/P39MTU1xcvLi5YtW+Lm5oaTk5NG+9BLly7h6OiokU5qaio9e/YkNjYWSZIYP348crmc7t27M2DAAKZPn87evXtZtmwZffr0wcTEhLp16xIWFpYhT23atGHHjh2UL18eW1tb1q1bB8CZM2dYvHgxy5cvZ+HChdy7d0815JKZmRknT54kPDycjh07qvI0YMAAMeWokG8sCpizYcXs/M6GIAhCrohpJcU0Wm9FfHw8/fv3Z8OGDfmdFUF45yUnp7Bz73+0btYQExNRFiC8HeJ+KBiaqIsR3gpLS0sRYAqCjhKTkpg0awmJSUn5nRVBEIQcE4/IHyg/Pz+NntMA06dPp3nz5nqlc+nSJdXYk2nKli3Lli1bcp1HQRAEQRA+XCLI/EAtXLjQIOm4ubkRHBxskLQEQRAEQfh4fLTV5brOXS4IgvC2yY2MqOXljlz0LhcE4T0mOv6Ihs6CIAiCIO6HgsGJ6vJsnB7bACk12aBpyuQmeE86bNA0BUH4cCQlJbNizRb69+iIqal+4+oKgiC8K0RdTDak1GSDBpmGTk8QhA9PUnIyy1ZuIilZXCsEQXh/iZJMHcjkJtSYetwgaZ36obZO240cOZJdu3bRo0cPxowZo3P6/v7+XL58mZkzZ+Y0i7x48YINGzYwcODATLe5f/8+PXv25OzZs8ycOZMhQ4ao1i1fvpzp06djZGTErFmzaNOmTYb39+vXjy5dumhdl5WAgABcXFxwdnbOsO7QoUMsWLCATZs2aSyXJInBgwezf/9+bG1tWb9+PeXLl9fY5r///uObb75BJpNhbGzMvHnzqFOnDgDGxsZUqVIFUA5gv3r1ar3yLAiCIAgfIxFkvqP8/f0JDw/P02nlUlNTkcvlGZa/ePGCpUuXZhlk2tjYMHv2bLZt26ax/NmzZ8yYMYNz584RGxtLo0aNaNGiBcbGhjnVAgICMDY21hpkZmbnzp1ERkZy+/ZtduzYwahRozIEol5eXpw7dw65XM6lS5fo1asXFy5cAJTTWooe9oIgCIKgH1Fd/g7q2LEjUVFRVKtWjSlTptCzZ08Ali5dqiqBu3jxIu3atQNgx44dODs74+XlxZEjR7JMu0yZMowePRpPT08OHDjAqlWr8Pb2xt3dnWHDhgEwZswYrl69ioeHBxMnTtSaTqFChahZsyYmJprtxfbs2UOrVq2wtrbG0dERFxcX1fzwP/30ExUrVqRJkyaEh4dn+znMnTuXihUr4u7uzuDBgzl58iTbtm3jm2++wcPDg4iICE6dOkWVKlXw8PDIdN72bdu2qcb6bN26NceOHSN9fzdLS0tVwJ2QkJBhznNBeJuMjY1p36qJwR7OBEEQ8sMHcQUrU6YMNjY2GBkZYWdnx8GDB/M7S7myZcsW7O3tCQ4OJikpSTUfeVBQELa2toSGhhIUFES9evV49eoVQ4YM4ciRIxQrVozGjRtrzBeuTcmSJTl//jzXrl1jyZIlHD9+HGNjY/r06cPOnTuZPHkyN27c4MyZM3rnPSQkBCcnJ9VrJycnnjx5wunTp9m5cycXL17k+fPnVK5cGT8/vyzTmjhxIo8ePcLS0pLo6GgKFixIu3btNKrZfXx88Pf3x8vLi27dumWbJ5lMhp2dHc+ePcPe3l5ju/379/P1118THh7Orl27VMtjYmKoXr065ubmTJgwgWbNmun9uQiCPszNTBk34sv8zoYgCEKufDAlmceOHSM4OPi9DzDTMzU1xcHBgcePH3P37l369OlDUFAQQUFB1K1bl+vXr+Ps7EzJkiUxMTGha9eu2abp6+sLQGBgICdOnMDLywsPDw9OnDjB7du38+Q4jh49SseOHTEzM6N48eI0adIk2/fUqFGDXr16sWbNmgwlpqCs1k9MTMTLywtAVeKbU02bNuXatWvs2rWL8ePHq5bfu3ePs2fPsmLFCgYOHEhERESu9iMI2XmVmMQvMxfzKlFMKykIwvvrgyjJzGtSarLOHXZ0SUsm129Ikrp167JhwwaKFy9OvXr1WLVqFWfOnMHLy4tr167pXbVrYWEBgEKhYMCAAUyYMEFj/f379/VKT52jo6OqehzgyZMnODo68vjxY73zuXPnTg4dOkRAQABz5szRSDeNLmk6Ojry5MkTvLy8kCSJqKgoChcunOn2tWrV4vHjx0RGRmJvb68qBXV2dsbb25urV69StGhRvY5FEPSRkpLC1l0H+G5wHzAzze/sCIIg5EiOSzKTkpK4ceMGKSkpucrA4cOHadu2LY6OjshkMgICAjJss3DhQsqUKYO5uTk1a9bk1KlTGutlMhkNGzbE29vb4D1/ZXITvYNCQ6dXr1495syZQ926dfHw8GDv3r0ULVoUMzMzKlWqxM2bN3n8+DEpKSmZtkvUxsfHh/Xr1/Ps2TMAIiIiCA0NxdramtjYWL3ymKZZs2bs2rWL2NhYQkJCuHLlCjVq1KBevXoEBASQlJREWFiYRolznz59MnynCoWCR48e4ePjw8yZM3n48CGpqakaebO1tcXMzIxz584BsHbtWq15atOmDatWrQKUgWvt2rUzBKd3794lNTUVgMuXLxMbG0vhwoWJiooiMTERgPDwcM6ePcsnn3ySo89GEARBED4mepdkJiQk8PXXX/PXX38BcPPmTcqVK8fXX3+Nk5MTo0eP1iu9+Ph43N3d+fzzz+nUqVOG9evXr2fYsGEsXryYmjVrMnfuXJo3b86NGzdUpUlBQUE4OTkRGhpK06ZNcXNzU7VjTC8xMVEVNICyvV1W3oVB0+vUqUNISAh169ZFLpdTokQJPD09ATA3N2fevHn4+PhgY2OT6XFr4+rqypgxY/Dx8UGhUGBmZoa/vz+urq5Uq1YNNzc3fH19NaqO00RFReHm5kZMTAxyuZxp06bx+PFj7O3tGT58OJ6enqohjIyNjfHy8qJly5a4ubnh5OSk0W700qVLODo6aqSfmppKz549iY2NRZIkxo8fj1wup3v37gwYMIDp06ezd+9eli1bRp8+fTAxMaFu3bqEhYVlyGubNm3YsWMH5cuXx9bWlnXr1gFw5swZFi9ezPLly9m3bx/z5s3DxMQEc3Nz1qxZg0wm49q1awwaNEjVy3/KlCkabU4FQRAEQciEpKdvvvlGql69unTkyBHJ0tJSunPnjiRJkhQQECB5eHjom5wGQNqyZYvGsho1akh+fn6q16mpqZKjo6M0depUrWmMGDFCWrFiRab7mDBhggRk+BcdHZ2rvAs5ExcXJ/n6+uZ3NgThnZKYmCQtXrFeSkxMyu+sCB+R6OhocT8UDErv6vKAgAAWLFhAvXr1NKocXV1duXPnjmEi39eSkpI4e/YsTZs2VS0zMjKiadOmHD+uHBw9Pj5eVX0aFxfHgQMHcHV1zTTNH374gejoaNW/R48eGTTPgn4sLS3ZsGFDfmdDEN4ppqYmDOrXVUwpKQjCe03v6vKnT59q7fQQHx9v8LEFIyMjSU1NxcHBQWO5g4MD169fB5Tt5Dp27Agoq1gHDBiAt7d3pmmamZlhZmbGwoULWbhwoaod3ofGz8+Po0ePaiybPn06zZs31yudS5cuqcaYTFO2bFm2bNmS6zwKgqDdy5evGDlhFjN+Hk6BAub5nR1BEIQc0TvI9PLyYufOnXz99dfAm969y5cvp3Ztw/TA1ke5cuVUM7Pow8/PDz8/P2JiYihYsGAe5Cx/LVy40CDpuLm5idluBOEtS1UoOHHmAqkKRX5nRRAEIcf0DjKnTJlCy5YtuXr1KikpKfz2229cvXqVY8eO8d9//xk0c/b29sjl8gyzw4SHh1OsWLFcpf2hl2QKgiAIgiDkJ73bZNarV4/g4GBSUlJwc3NTDadz/PhxqlevbtDMmZqaUr16dQIDA1XLFAoFgYGBuS419fPz4+rVq1rHXhQEQRAEQRByJ0eDsZcvX55ly5YZJANxcXEas8zcu3eP4OBgChUqRKlSpRg2bBh9+/bFy8uLGjVqMHfuXOLj4+nfv79B9p+da5t9kRTJGZYXKFyRsk2mA5CcEMmtnV9kmoZz278wNldWyd/dN4zEmEdU7qz7eJaCIHxczExNGTt8EGamYiB2QRDeXzoFmdmNJanOxsZGrwycOXOGxo0bq14PGzYMgL59++Lv70+3bt14+vQp48ePJywsDA8PD3bv3p2hM5C+dK0ulxTJSIoUZEaGmRzp5fObBktLEIQPk4mJMR1a++R3NgRBEHJHl3GOZDKZZGRklOW/tG3eN9mNC/bs1k7p2a2dBtvflQ3tpSsb2me73YgRIyQXFxdp0qRJeqW/YsUKafjw4TnMnVJUVJS0ZMkSvd5TunRpKTY2Vjp48KDUuXNnvd7n5uYmubu7S40aNdK6TU6P6fz589KePXsyXV+4cGGty5ctWyZVqFBBcnZ2lrZv3651mw4dOki2trYZjjUyMlJq166dVLFiRaly5crS7du39c63IMQnvJR8+30nxSe8zO+sCB8RMU6mYGg6FampTwH4odC1JLNQhVZvKUea/P39CQ8PV800kxdSU1ORy+UZlr948YKlS5cycODAPNu3umPHjmFlZWXwdIODg7l8+TLNmjXT+T3Pnj1jxowZnDt3jtjYWBo1akSLFi0wNtb8qQwdOpTPP/9cNfOV+vJu3brRo0cPEhISkCTJIMcifFwUCgV3HzxGIXqXC4LwHtMpgmnYsKHO/94X73LHn44dOxIVFUW1atWYMmUKPXv2BGDp0qWUL18egIsXL9KuXTsAduzYgbOzM15eXhw5ciTLtMuUKcPo0aPx9PTkwIEDrFq1Cm9vb9zd3VVNFcaMGcPVq1fx8PBg4sSJWtNJSEigc+fOuLi40K9fP41gKjo6mg4dOuDs7KxKU1/6HBMoH4Tc3Nxwd3fHy8uL1NRUxo8fz8qVK/Hw8GDXrl08ffqUJk2aUKVKlUynP92zZw+tWrXC2toaR0dHXFxctJ4jjRo1wtraWmNZdHQ0Z86coUePHgBYWFhgaWmZg6MXBEEQhPdfjovJEhISuH79OhcvXtT496GJvLaJyGub3uo+t2zZgq2tLcHBwYwYMYKzZ88CyjnabW1tCQ0NJSgoiHr16vHq1SuGDBlCYGAgx48f58aNG9mmX7JkSc6fP0+JEiXYunUrx48f58KFC0RGRrJz504mT56Mi4sLwcHBWuctB1i0aBFOTk5cvXqVrl278vDhQ9W6c+fOsWTJEi5fvsz27ds11qUnk8lo2LAh3t7erF69GiBHxzR79mxmz57NhQsXCAwMRC6XM3HiRPr06UNwcDCtWrXi559/pk2bNly+fJnSpUtrTSckJERjbnInJyeePHmS7f5B2WnN3t6enj174unpyXfffUdKSopO7xUEQRCED43eQebTp09p06YN1tbWuLq64unpqfHvQxNx+W8iLv+db/s3NTXFwcGBx48fc/fuXfr06UNQUBBBQUHUrVuX69ev4+zsTMmSJTExMaFr167Zpunr6wtAYGAgJ06cwMvLCw8PD06cOKHR0z8rQUFBdO/eHYBWrVphZ2enWlenTh0cHBwwNTWlSpUqPHjwIMt0zp49y7Zt25gyZQoXL17M0THVrVuX0aNHM2/ePBISErLNc1rpsCGlpKRw6tQpRo4cydmzZ3n69CkrVqww+H6ED5+5uRnzp/+IublZfmdFEAQhx/Tu5vztt9/y4sULTp48SaNGjdiyZQvh4eFMmjSJWbNm5UUe84Q+g7FLihSubuygdV3ZprMoYKeswn4YNJm4UO3V7/Yu3Sjq+hnFq3+ld17r1q3Lhg0bKF68OPXq1WPVqlWcOXMGLy8vrl27pvd0nhYWFoCy3deAAQOYMGGCxvr79+/rlE5m+zUze3NjlMvlWX7GaaWGxYsXp1WrVpw7dw4PDw+9j2n06NG0bNmSHTt2UKtWLY4dO6ZXntM4OjpqVI8/efIER0dHnfLg5ORE2bJl8fDwAKB9+/YcOnRIp/cKgjpjuZza3h75nQ1BEIRc0bsk88CBA8yePRsvLy+MjIwoXbo0vXr14tdff2Xq1Kl5kcc8oWubTBffAIMOOWRXrhl25XTviALKAfDnzJlD3bp18fDwUA2Ab2ZmRqVKlbh58yaPHz8mJSWFjRt1H3/Tx8eH9evX8+zZMwAiIiIIDQ3F2tqa2NjYbPO0fv16AHbv3k1UVJRexwTK+e7T9hMXF8eBAwdwdXXN8pgWLFjAggULMqR1584d3N3dGTNmDC4uLty7dy/Dcajnec2aNVrz1KxZM3bt2kVsbCwhISFcuXKFGjVq6HQ8xYsXp2jRoty7dw+AQ4cOUblyZd0+DEFQExefQMM2fYmL114qLwiC8D7QO3qKj4+naNGiANjZ2fH06VOcnZ1xc3Pj3LlzBs/gu8DFN0Cn7UrVG5Mn+69Tpw4hISHUrVsXuVxOiRIlVE0TzM3NmTdvHj4+PtjY2FC1alWd03V1dWXMmDH4+PigUCgwMzPD398fV1dXqlWrhpubG76+vlrbZX711Vf06tULFxcXatasSalSpfQ+rvDwcDp27Agoe7oPGDAAb29vgEyP6caNG9SpUydDWnPmzOHgwYPI5XK8vb2pXbs20dHRTJs2DU9PTyZPnsyECRPo1q0by5cvp23btlrzZG9vz/Dhw/H09MTIyIhZs2apepZ7eHio5nFv2rQpFy5cID4+nhIlSrBx40Zq167NnDlz6Ny5M8nJyXh4eDBgwAC9PxdBAIhPeJnfWRAEQcgVmaTnGCve3t5MmjSJ5s2b065dO2xtbZk6dSrz5s1j06ZN3LlzJ6/yalDq1eU3b94kOjpa74Hkhbevffv2bNy4EVMxE4rwAYuLT6BR234c2u6PlaVFfmdH+EjExMRQsGBBcT8UDEbvIPPvv/8mJSWFfv36cfbsWVq0aMHz588xNTVVzdDzPhE/KkEQ3jUiyBTyg7gfCoamd5CZXtpQRqVKlcLe3t5Q+XprPtQflZ+fH0ePHtVYNn36dJo3b65XOpcuXaJ3794ay8qWLcuWLVv0SqdmzZokJiZqLAsMDKRw4cJ6pSMIH4PUVAX3Hz6hTCkn5PK8m5BBENR9qPdDIf/kOsh834kflSAI7xpJkohPeImlRQG9R1oQhJwS90PB0PR+RO7cuTPTp0/PsPzXX39Vjb8oCIIg5Fx8wksate0nOv8IgvBe0zvIPHz4MK1aZZzPu2XLlhw+fNggmRIEQRAEQRDeb3oPYRQXF6e1Z6+JiQkxMTEGydTboOtg7KfHNkBKTc6w3KpUFVwGLwMg8UU4F6Z3yDQNzzG7MLFSzohzeX5fXobfw3uSCMgFQRAEQfhw6R1kurm5sX79+gxjJ65btw4XFxeDZSyv+fn54efnp2qDkhkpNRkpNRmZ3MQg+41/dMVgaQmC8PG4f2gsCU8vZ1guMzKhcmfdJ2EQBEF4W/QOMseNG0enTp24c+cOTZo0AZS9hNeuXavXbDPvi9LthgPgULtLptuY2TpQY+pxndLTNcAcOXIku3btokePHowZo/sg7/7+/ly+fJmZM2fq/J70Xrx4wYYNGxg4cKDO7ylTpgyXL1/mzJkzLFiwgE2bNun0vo4dO3Lo0CF8fHw03nPq1Cn69+9PYmIiffr00TogfE6PNTg4mIiICJo10z7zkr29PZGRkRmWL1++nOnTp6sGaW/Tpo3G+kePHtG7d28iIiIwNjZm3LhxqnbKPXr04OzZs5iYmNC2bdv3anYs4e17+G9flvwvmQc7e1Ch5SLMrLVPbSopUpDJ30zj+uzmViIu/S2CTkEQ3gl6B5lt27YlICCAKVOmsGnTJgoUKEDVqlXZv38/DRs2zIs85qusgsu85O/vT3h4OEZGeTd8SWpqKnK5PMPyFy9esHTpUr2CzJwaOnQon3/+OX/99ZfGcj8/P9auXYurqyt169alY8eOuLm5GWSfwcHBXL58OdMgU5tnz54xY8YMzp07R2xsLI0aNaJFixaq2YAAjI2NmTt3Lh4eHoSFhVG9enVatWqFpaUlffr0YfXq1aSkpNC0aVMOHDigekgThPQUqclExqTiVOjN77NMo0kZtru22ZeiVXqoXkdcXoOkyNi8RxAEIT/kKIJp3bo1R48eJT4+nsjISA4cOPBBBpj5pWPHjkRFRVGtWjWmTJlCz549AVi6dCnly5cH4OLFi7Rr1w6AHTt24OzsjJeXF0eOHMky7TJlyjB69Gg8PT05cOAAq1atwtvbG3d3d4YNGwbAmDFjuHr1Kh4eHkycOFFrOgkJCXTu3BkXFxf69euH+khY0dHRdOjQAWdnZ1WamWnUqBHW1tYay0JCQkhJSaFq1arI5XK6d+/Ojh079D5WgIMHD+Lm5oa7uzteXl6kpqYyfvx4Vq5ciYeHB7t27eLp06c0adKEKlWqMHr0aK3p7Nmzh1atWmFtbY2joyMuLi4Z5r0vXrw4Hh4eABQrVgx7e3ueP38OQIsWLZDJZJiYmODh4cGTJ0+yzbvw8UpMgTEbC1CmzZpMSzHThF9YwdWNHbi6sQOK5HgkRYrq9bXNYsQPQRDyj95B5qNHj3j8+LHq9alTp/j2229ZunSpQTP2rgg59Bchh/7KfkMD2rJlC7a2tgQHBzNixAjOnj0LQFBQELa2toSGhhIUFES9evV49eoVQ4YMITAwkOPHj3Pjxo1s0y9ZsiTnz5+nRIkSbN26lePHj3PhwgUiIyPZuXMnkydPxsXFheDgYK3V1ACLFi3CycmJq1ev0rVrVx4+fKhad+7cOZYsWcLly5fZvn27xjpdhISE4OTkpHrt5OTEkydPcnSss2fPZvbs2Vy4cIHAwEDkcjkTJ06kT58+BAcH06pVK37++WfatGnD5cuXKV26tF55yszZs2dJTU2lZMmSGstjY2PZuXMnjRo1yjbvwscnNTmBqxs7IClSdNpeUiRr3VZSpCApUlCkvFQFnCLoFAThbdM7yOzRowcHDx4EICwsjKZNm3Lq1CnGjBmTaanX++zxnsU83rM43/ZvamqKg4MDjx8/5u7du/Tp04egoCCCgoKoW7cu169fx9nZmZIlS2JiYkLXrl2zTTOtnWBgYCAnTpzAy8sLDw8PTpw4we3bt3XKV1BQEN27dwegVatW2NnZqdbVqVMHBwcHTE1NqVKlCg8ePMjBkWeUk2OtW7cuo0ePZt68eSQkJGR7LGmlxrnx/Plz+vTpk+HBS5Ik+vXrx+DBgzMEn4KgTmaUeUuma5t9VUGjpEhBZmSMi28ALr4BGBkXQGZkrPb+NwO5KwNPUZUuCMLbo3ebzMuXL1OjRg0ANmzYgJubG0ePHmXv3r18+eWXmZZ8vWt0HcIIlD3MT/1QW+s61yErsHSqBMDNlSN5cS1I63ZOPv/DqekXlOmkvTo2K3Xr1mXDhg0UL16cevXqsWrVKs6cOYOXlxfXrl3Te0YQCwvlXMgKhYIBAwYwYcIEjfX379/XKZ3M9mtm9qYjglwu1+kzVufo6KhRSvjkyRMcHR2z3GdmRo8eTcuWLdmxYwe1atXi2LFjWrfLLl1HR0eN6nH1PKlLTEykQ4cOjB49mjp16misGzVqFHZ2dgwfPlyvYxA+HnITC1x8A4iLT8By7WCt26SVXqYFkzKjN50Js+rwkxaUXt3YARC90gVByHt6l2QmJyergoj9+/er2gVWqlSJ0NBQw+YuD/n5+XH16tUM7erSqzH1uEGHHCrq3Z6i3u31ek+9evWYM2cOdevWxcPDg71791K0aFHMzMyoVKkSN2/e5PHjx6SkpOjVw9/Hx4f169fz7NkzACIiIggNDcXa2prY2Nhs87R+/XoAdu/eTVRUlF7HlBVHR0fkcjkXL14kNTWVdevW0bZt2yyPdcGCBSxYsCBDWnfu3MHd3Z0xY8bg4uLCvXv3Mhyf+rGsWbNGa56aNWvGrl27iI2NJSQkhCtXrqgettKklVQ2adIkw3zvixcv5vz58/z+++85/lyED9udPV9zZ8/XAFhZWvDfjr+wslQ+EGZVeqlroCgzMlGVcIpSTUEQ3ga9SzJdXV1ZvHgxrVu3Zt++ffzyyy+Ass1a4cKFDZ7Bd4GuwxM595mRJ/uvU6cOISEh1K1bF7lcTokSJfD09ATA3NycefPm4ePjg42NDVWrVtU5XVdXV8aMGYOPjw8KhQIzMzP8/f1xdXWlWrVquLm54evrq7V0+quvvqJXr164uLhQs2ZNSpUqlaNja9q0KRcuXCA+Pp4SJUqwceNGateuzYIFC/jss8949eoVvXv3VvUsz+xYb9y4kaHkEGDOnDkcPHgQuVyOt7c3tWvXJjo6mmnTpuHp6cnkyZOZMGEC3bp1Y/ny5bRt21ZrPu3t7Rk+fDienp6qIYzSepZ7eHgQHBzM0aNHWb9+PVWrViUgIACAVatW4ebmxpAhQyhbtize3t6Asld9//79c/SZCR+Ga5t9NQK9tOARICU1ldPnLuFdzQ1juVyj9DLufDhIEqfOKWtXnPvPwda5FgD3Nk8h8vxuvCcdJjE2BEDVcUg9GE0rzRQEQchLMkm9W7AODh06RMeOHYmJiaFv3778+eefAPz4449cv36df/75J08ymlfSBmOPjo7GxsYmv7Mj5FD79u3ZuHGj1tmoBOFdpF4qmSatCvvcWl8GLpOx5H9JFDBFo/Ty1A+1NSaIUA8yT37vpUxHbqIMYGUyrKs7ZUg/Lch08Q14OwcrvBfE/VAwNL1LMhs1akRkZCQxMTEanT0GDhyoausnCG/b1q1b8zsLgqAXxxrfAmBbulGGdcoSzjcPTGltL89NaqkKMLXVsBiZWryZBlcCJIlXD15gXto2Qy909faZyn2INpqCIBiW3kEmKDtzqAeYoBx/UXh3+Pn5cfToUY1l06dPp3nz5nqlc+nSpQztC8uWLcuWLVv0SqdmzZokJiZqLAsMDPxgm1gIgjZpVeSFK3XGwa13ptvFBocAZYgLjkBhZoz3pMMAnJvUEpncJNN24mnbAZwe2wApNZlCn7ShTPsRXFzWHFAGoOqdhQCdh0wSBEHQR46CTOHdt3DhQoOk4+bmRnBwcK7TOXnyZO4zIwjvuczGtYQ3QSGATCFRzDyJ9IMeVBv7r877Ug84AV7djdEYKUMmN1Ftk1kbTfU8aaOehiAIQnofTJCZkJBA5cqV8fX1zdW83YIgCHlJZmSstRSz0oCFPNm3lJg7ZzA3lhhX9Qk1p2U9+oVe+1Ur/cwqcFQPLFVBr5aS06zSEARBgA8oyJw8eTK1atXK72wIgiDkyOMzE5EKJmNVzYHk5BSO3jKlWnIKJiaGuUyrlzie/N5Lo1RTUiSDBKfO1dYILNP+aSutTOuApD6GsCjZFARB3QcRZN66dYvr16/Ttm1bLl++nN/ZEQRByODR8V81epOnr4qWFzTGvGxBZEbGpEjG/PmfMX1GJBksyLzk3xKjAnIkhQRGMmTGMkibJ0FtjJGsAkt16Us3pdTkTKvjBUH4OOl99Zo3b57W5TKZDHNzcypUqECDBg2Qy+U6pXf48GFmzJjB2bNnCQ0NZcuWLXTo0EFjm4ULFzJjxgzCwsJwd3dn/vz5GgNhjxgxghkzZmQ6m4sgCEJ+SIi8DoCFvXJWMPUZehTJCcrgLq3dpSRXDVMUF58Af/QzaF5kpkbKABOw8nRAUkhU+WwnACdHKYc+sqrm8Dqf2U9AkT6A1FbNLgjCx03vIHPOnDk8ffqUhIQEVQ/zqKgoLCwssLKyIiIignLlynHw4EGd5meOj4/H3d2dzz//nE6dOmVYv379eoYNG8bixYupWbMmc+fOpXnz5ty4cYOiRYuydetWnJ2dcXZ21inITExM1OjlHBMTo8fRC4Ig6O7+QeU0si6+AZSs/b1q+aPdi1QBprVXCdVyXYI7XaUvKVUf+ujqxg7I0s/3JkHsmcevMyKDzvrtTz3ozGwaXkEQPi56B5lTpkxh6dKlLF++nPLlywNw+/ZtBg0axMCBA6lbty7du3fnu+++Y9OmTdmm17JlS1q2bJnp+tmzZzNgwADV7CiLFy9m586d/Pnnn4wePZoTJ06wbt06Nm7cSFxcHMnJydjY2GQ6h/rUqVP5+eef9T1sQRAEw5IBMpnWAdHlRkbU8nJHbqTfzL9ZddrJaugjIxOLdO/Ta44OQRAErfSe8ad8+fJs3rwZDw8PjeXnz5+nc+fO3L17l2PHjtG5c2e95zKXyWQa1eVJSUlYWFiwadMmjSr0vn378uLFiwwDcPv7+3P58uUse5drK8ksWbKkmOFAEASDUJ8uMvbsE5AkVQmlzETC1NEGk8IWGrP45JS20krQDCy1tYt88eAQoH0g+Ev+rQBw67crx/lKPytRVnkR3h1ixh/B0PQuyQwNDSUlJeM4bykpKYSFhQHg6OhIbGxsrjMXGRlJamoqDg4OGssdHBy4fv16jtI0MzPDzMyMhQsXsnDhQlJTU7N/kyAIgh5UHXwkSaNQUJGYwqv7UZgUttBon5leUlIyK9ZsoX+Pjpiaam6jS2lldsGctuAyjdxSOdPQzZUjeXEtKEfBobZOQYIgfHz0DjIbN27MoEGDWL58OZ6enoCyFHPw4ME0adIEUM4SU7ZsWcPmVAf9+vXTeVs/Pz/8/PxUT26CIAiGoD4146lzyraJaVNA6jpneFJyMstWbqKnb5sMQWZaL+7shhgyhJwGh+nzI9poCsLHSe8g848//qB3795Ur14dExPlxS8lJQUfHx/++OMPAKysrJg1a1auM2dvb49cLic8PFxjeXh4OMWKFctV2qIkUxCEvHB6bAM8x+7C2NwKmZkMJEkVXKoPYZSVc7+0BBw4+1NTChhrtmjKau5yXYVfWgWQ6dSWkiKFlAK3QIaq6j+3xPBGgvDx0TvILFasGPv27eP69evcvHkTgIoVK1KxYkXVNo0bNzZI5kxNTalevTqBgYGqNpkKhYLAwECGDBmSq7RFSaYgCIai3g5TkfySJ/uWUrrtMCxdi2pMI5lVFbm67KZyzKwDj66eXd+MpEjh2fXNankzoXLnjQbt4a5KW8fZhgRB+LDkeJTfSpUqqQJLWfoJdvUQFxfH7du3Va/v3btHcHAwhQoVolSpUgwbNoy+ffvi5eVFjRo1mDt3LvHx8are5jklSjIFQTCUmNP3le0vASQIC1pD/KvDOe7cIzeCOkXiqDnpEOZmpgbPb/pAUj0QVq/uP3nGyyD7E8MbCcLHKUdB5sqVK5kxYwa3bt0CwNnZmZEjR9K7t/aql6ycOXNGo+Rz2LBhgLIHub+/P926dePp06eMHz+esLAwPDw82L17d4bOQPoSJZmCIBjM6w4+MrmJskTz9YO3riWX6ZkaSfQqF5UnASZoBpKgnI0oU2q19RGnt/Jg6yxR1S0Igk70DjJnz57NuHHjGDJkCHXr1gUgKCiIL7/8ksjISL777ju90mvUqBHZjaI0ZMiQXFePC4Ig5CkZqoHOIfvOPemp9xpPTE5h46MiVE1MyrNAU536QPEaZDJMHa1VL5/sWyqquwVB0JneQeb8+fP5/fff6dOnj2pZu3btcHV15aefftI7yMwvorpcEIScOjnaG5BhU96LygMWYeFSFFBwdWMHnTv3ZDXGpUJmwrGnVsrh4t5CkJkZ6+pOGq+TY5/nU04EQXgf5WiczDp16mRYXqdOHb0HX89PorpcEIQck6Q3bTABowLGICmArKvIdR3jMi4+Adr2y8MD0JR+jvW8Jnqa60+SJJKStJcim5qa5KpvhCDkFb2DzAoVKrBhwwZ+/PFHjeXr16/nk08+MVjGBEEQ3mkyqDxgkfJPmRHIjLKtIn+bY1zqQ32O9fQkRYraEEy5ryr/GHuaZxUg6pNG4dIeWtc9f3gBs3ws8RaEzOgdZP78889069aNw4cPq9pkHj16lMDAQDZs2GDwDOYVUV0uCII+rm32JTHkOYmPo5WdYWRkO/6ltipxXca4NDUxYUCfLpiaGH44IX1oLZGV4PL8vlT5+q8cpZmTnubZleLpUsKX0zQMITEpieIVvHOVxv0rRw2UG0F4e/QOMjt37szJkyeZM2cOAQEBAFSuXJlTp06pZgB6H4jqckEQ9GFbtilhT9YpX8hQ9SAHzSpyXarEs2NqasKgfl0NmPucSd8L/eRZbzS6mxtQVkFgVkHa/StHKeNaV+u60NunMTM1zVUa74p3PX+CoI1Myq5r9wcuLciMjo7GxsYmv7MjCMI7In0ppGkJa0yLWgBkOf7lqR9qq0osIWdtDl++fMXICbOY8fNwChQwz/lB6Ei9w1LaoOyZbQdQucsWEqIiADC2tMvxfi/81FDjs0pMSiJFAW3WJOQ4zY+RoarLxf1QMDSdSjJjYmJ0TlCcmIIgfAgUyQmqanF43Z5SFYhpdu5JX3qZ22kfUxUKTpy5QKpCkZtD0EprieHrqn7p9X8TE5O0v/f1/2Pj4rkwuRUALf7OeUC4o4cFxkZAqnJ/pnIZeVVS+i5RL2HNjCGq2AUhv+kUZNra2mbbc02SJGQy2XvTxlG0yRQEIVsysKpW7M1LI1NcfP9RBZWnzijbFKpXixti2sfMGKIDiU7By1fuWhcHzS4HQPEK3uzuZZGrfEDGEktDpGkIugSBuaFLb3BTUxOeP7ygdZ0IQIX3hU5B5sGDB/M6H2+daJMpCEKWXpdiqnfokRnJlavUeokDue4pnj54THpdkpiUmESi8Zv9f0zBRWaBXloLL21BWlbr9NnuXRgSSCaTiR7jwntPpyCzYcOGeZ0PQRCEfHdltbJtopG5MXJrU1Ljk1XtLtVLLzOrEs9pSWOG4WlkMmwL2lLSpY7GeJxvw46JpQFoM/6B1vWmxjKCZpcj6WK4apmhSv4u/KS81zx/ePydCPQEQcidHM1dLgiC8CGKu/gYAGuvEpiVVrYvTxtmR5cq8aSkZAqV0l7VnJUMw9NIEi9eROmdTk6kDxBvb1P2atdWVXtnRw8kRQqmppAEIMHBz20xS4nDzLpYhu1zSpTgCcKHQQSZgiB8tNL3IE+rInfxDdDaS1wmN6HquP2qzdN3kElM0t5hJjvph6eRGRlRtmx57t27g5RF5x9DlCCmLzFM+0tboOfSeZPqb43hjAxY4ihmAxKED8dHG2SKjj+C8HGTJAlFUrqe0a/Hv1QPMN1/+k+zLeQy/Usq9XUr+BBtP/Pj4ZWjWFpm3hkmP6uU0+Y1T2tOcPX3AcrXg5flOM2PcTYgQfiQfbRBpuj4IwgfDn3aQgZPqIuRmTEWVRzeLHwdp1l6KJdFnQkDICU5KUfV32kyK2nMrgOP2euZfkzNTPOl6jhtKslS9cdjVayaTu+Je3g51/vNyWxAgiC8uz7aIFMQhPdLVoFkVvM6p3egryWKl8nEnVG2vzSyMMb4k8IAyIxkJKVIuRr7UZ2ZqfYgMavhaQCSkvOvFE/rVJKCIAg5YNAgs0mTJjRu3Jjhw4djYfFujHcmCML7Sz2wzG5awKwc6G/1ppf26/8lpbz+I1nCijfLklOy782ta1tIU1PtAVt2w9PIjeXMn/4j5uZm2e7D0DKb7UcQBEFfBg0yS5UqRWBgIMuWLePhw4eGTFoQhI9A+tJKXceFzHZeZ0XGwFGztDJGI3B83j3r5PK6LaSxXE5tb488S19XIWcWAODoNUTr+rRqdeXfySApq7lLtxuOQ+0ubyubgiC8owwaZPr7+wP6TUMpCMKHIavqbFNTE53aTBpqsHGNkkt40wlabqIMhmQyTi2oCIoULIvXpHjNUe/UuIxx8Qm07jaYnet/xyqLjj957cU9ZU96bUFmhmp12ccxJaQgCLrLkzaZYv5yQfj4ZDVG5P0rR7Mvbcwl1TzYkLHk8nWv8RpTj3N1o3LAdRmAkTEvn158J8dljE94md9ZyFL6avWrdADe9DY3BPXhjEAMaSQI75scBZmBgYEEBgYSERGBIt0Ybn/++adBMpbXxBBGgqAbXXtuZzVGpKECzLQqbUmSuDSpKVJqypt8pg15o1agJpObULxhb0q2+EojHZmRsUGDIUFTyKG/AHBs1DfHaaQf7F4MaSQI7x+9g8yff/6ZiRMn4uXlRfHixd+Z6iV9iSGMBEE3OZ3FxhDSd7BRr9KWUlM0BktPK620ru5E7Oue4+mnfRTejsd7FgO5CzLTl1iKIY0E4f2jd5C5ePFi/P396d27d17kRxCEt0CfcSVzOotNVvTpnX1mXEOtpVjp5w9P64Di4hvAqXOaAcm1zb4U8xyAXblm2Lt0y/0B5LEC5uas/2MWBczN8zsrSIoUQs8toXi1QTptq2yOIEodBUHIQZCZlJREnTp18iIvgiDkIV2HAzKUrAJJfTrZSKnJmiWWaWQgSeq9m1OQGRmr3qMxe4wimadX1mJXrhlFXT/T/2DeMiMjGQ5FC2NklL81Rek798SGnALA2rFGttsKgiDoHWR+8cUXrFmzhnHjxuVFfgRByIWsSigNFVjqUwqZk+Y06ecTVy+xvLbZV1VKJilSNN6nSEhVzaFtXNiSlKgEjQA05VWU3nnJL/EJL2nUth+Htvvna+/y9J17Hh2dAmjv3KO+7ckzXqrhjAp+UpOKn8/Ny2wKgvCO0jvIfPXqFUuXLmX//v1UrVoVExPNp9fZs2cbLHOCIGTvbZdQZjaLTW6oB5Zp/1dva5lWYpkWWMqMjF//M1EFN+pt9uyqVefl85uq12nbCm9JHg1npN7bXPQ0F4R3n95B5sWLF/Hw8ADg8mXNuWrf105AgvAuyOk4k4YILHUtnUzLi6GpV4mn/UsLIDIGl8rAMi0wPXWmtiqNtMC03KfiYTc/WVd3At6UeCaE3wXAwqFcjtPUaP4gepoLwntB7yDz4MGDeZGPHHvx4gVNmzYlJSWFlJQUhg4dyoABA/I7W4KgE32mTTT0OJPqgeXbHog8qypxbTIbckg9sEwLToV3z+W5PYHc9fZXL7UUPc0F4f2QJ4Oxv03W1tYcPnwYCwsL4uPjqVKlCp06daJw4cL5nTVBAAzTTjKnAaahOt/kRPpAUl36KnH1AFG93SVodug5PbYBcnNLqo39N0NVadr7rm7sgG255hR17YGx+fs5PJmlRQEObffH0qJAfmdFEAQhx3QKMjt16oS/vz82NjZ06tQpy23/+ecfg2RMV3K5HAsLZcP4xMREJElCksTUZkL+yen824aSnyWU6jLtFQ4ZqsQ13qdI1ggs1dtTSqnJJMc81b4/tfe9uLuH6PsHMnRceV8oFBLhEc8oU8oJuVw0QxIE4f2kU5BZsGBB1Y3K0AOXHz58mBkzZnD27FlCQ0PZsmULHTp00Nhm4cKFzJgxg7CwMNzd3Zk/fz41arwZQuPFixc0bNiQW7duMWPGDOzt7Q2aR0HIzvs6PFBey6oKXF36XuNZzciTPmhNTojk1s4vsn3f++Tlq1d0+9/wfO9dnp5xAd1riNLGzFT+LdpQCsLHSKcgc8WKFVr/NoT4+Hjc3d35/PPPtZaSrl+/nmHDhrF48WJq1qzJ3Llzad68OTdu3KBo0aIA2NracuHCBcLDw+nUqRNdunTBwcFB6/4SExNJTExUvY6JiTHo8Qgfh7wqrVSfNhEy70z3LgWSmVWLZ1aKqY16KWROe4KLHuR5z7nNH6q/r27soNG7X53W7+H1kEZev/yHkfG7N1e8IAiGl+M2mREREdy4cQOAihUrqgI+fbVs2ZKWLVtmun727NkMGDCA/v37A8oZh3bu3Mmff/7J6NGjNbZ1cHDA3d2dI0eO0KVLF63pTZ06lZ9//jlHeRU+Ppm1p8xNUPm+lELqKrNq8aw64mTW7jKzUsgXN09wc8V3Gvu5d2AUAGWbTP8gSi/fN+nHKVWXPvA8edabvBjSSBCEd5veQWZMTAx+fn6sW7eO1NRUQNkuslu3bixcuNCg1elJSUmcPXuWH374QbXMyMiIpk2bcvy4sgouPDwcCwsLrK2tiY6O5vDhwwwePDjTNH/44QeGDRumcTwlS5Y0WJ6F909eD2Ce1fzb7yN9e4Zrk1W7S/X0i3i1pWznH1XvUw9cXz67ketjeZe9651+0r47XaQf0sgQ1MfMBDFupiC8i/QOMgcMGMD58+fZsWMHtWsrf+DHjx9n6NChDBo0iHXr1hksc5GRkaSmpmao+nZwcOD69esAPHjwgIEDB6o6/Hz99de4ubllmqaZmRlmZmYsXLiQhQsXqgJl4ePxNjrmvCudbwwlq8HSdR06SNd2l9pKRm2da2nM+JM2dqY+gc77xMrSgv92/JXf2cgTF2b6AuA+IuedstKfb2LcTEF4N+l9hd6xYwd79uyhXr16qmXNmzdn2bJltGjRwqCZ00WNGjUIDg7W+31+fn74+fkRExNj8M5MwtuT3QDm2oK7pKRkCpVyN2g+PrTSyvSyGixd5zSyaXd5f+tMIk5szrJk1BBtN98HKampnD53Ce9qbhjL5fmdHYNI6wj06unjXKeV/twT42YKwrtJ7yCzcOHCWoOyggULYmdnZ5BMpbG3t0culxMeHq6xPDw8nGLFiuUqbVGS+WHIKmDMrO1jYlJSjveXWZofWlBpiCpxfdtdpsmqZLSY50AAClVopXM+3kevXiXy9agp71zv8pz6UB8GBEHImt5B5tixYxk2bBirVq1SBXphYWGMHDmScePGGTRzpqamVK9encDAQNWwRgqFgsDAQIYMGZKrtEVJ5odPdMzRT15UiQNa211qU6b9CMq0H5Fl+h96cPm+sSpWXfX3w6DJxIcHa+1trr7s5Bmvt5I3QRDyn05Bpqenp8aN9datW5QqVYpSpUoB8PDhQ8zMzHj69CmDBg3SKwNxcXHcvn1b9frevXsEBwdTqFAhSpUqxbBhw+jbty9eXl7UqFGDuXPnEh8fr+ptLnwYcjNvd2596FXdusqrKnFtQUf6klKLYhVw+nQgdi71M5SAqitapRf2lbWPHCG8XTIjE4pU6aF6HfvkuO5tZF8PZ1ShxyQKufnkUQ4FQchvOl0R0g+ObkhnzpyhcePGqtdpPb/79u2Lv78/3bp14+nTp4wfP56wsDA8PDzYvXt3puNg6kpUl79bsqr2zot5u9WZmZpiZibG7QPdBk/PKgjUtUo8feeehLDb3F4zBu9Jh7EoUoW40NMfbKceXRgZGVGudAmMjIzyOyuZSv/woPP3JZMhhjMShI+DTPrI52BMqy6Pjo7GxsYmv7PzQcvroYIg66ruzHysJZc5bXeZXc/uzEov1aV11NCnjafwbkub3Se7Bwxdt9PHqR9qazy0fOjDGSUmJmk8lD9/eMEgD8rifigY2kdbVCBKMg0nq+BR3duYblGUSmaU1Yw8oFu7S32mfdSFacGcTd7wsUhOTmHn3v9o3awhJiYf7mX64Y7fACjVZmiu0lE/b8VwRoLw7vhwr17ZEB1/DCcvhgTKSnYdcwRN2c3Io0uJjyGGDlIvvfQYvVVjnXoQa+1UiyKuPTAvWErvfXwoEpOSmDRrCU0b1f4gg8y04YxizyiHM8ptkKl+DovhjATh3fHhXb2EPJFdVbehfaw9vHMqs9JKeLvDD+lDkZrM9X98VemDsl1f7JMTxIWezbbKXXj3SJIi223EcEaC8PEQQeZHTtfBzN/GAOaZ7VvISFt7Ssg4E0raMl2GH1KX1bSPeSGrnujC+0FmZIJ9pU4ARN3dC4BduWYZthPDGQnCx0OvIDM5OZlKlSqxY8cOKleunFd5eis+1jaZ+kypqB4E6lNaqWvnGxFI6keXcSxz09nBEO0uT49tQEHnmjj3mQFA/JPrXFnQX5Vn9WDXSG5i0JLRD4ncyIhaXu7I3+He5empB4+hZxcB2oPMDF4PZ1TYoznlu/2UR7kTBCE/6BVkmpiY8OrVq7zKy1v1MbXJVA8s9el8k9NOOqLzTd4wxDiWWaZvgHaXUmoyUZcPal8pA0lKUfVON7MpSYWWv+cy1x+mAgXMWfDrmPzORt4TwxkJwgdN7+pyPz8/pk+fzvLlyzE2FrXt74P8qOoW8oa+bSvTM8QYl+mlL2FVL620dKqkym9acAnK6vHkhMgcHMHHISkpmRVrttC/R8cP+vdkXd1Jdd4lEszFP1oiM5Lj1n9HfmdNEAQD0DtKPH36NIGBgezduxc3NzcsLS011v/zzz8Gy1xe+tCqy992xxxRWpk30re1zMvSyvRyU3qZvoQ1M4buPPShSkpOZtnKTfT0bfNBB5npz7eXN5/mU04EQcgLegeZtra2dO7cOS/y8la9L9Xluk63mNMxKNVLJNPG5delneSHfOPLT+oBW16N95fbQC8tEC7TaTRFvdvj5PM/AJyafmGgHAofAkmRwt19wyj36exMt0nf0Ut0BBKED4veQeaKFSvyIh/Ca/p0zMnpdIvqgaXofJP/tFU315h6XDWLSdq4f9rGutSFtg49uZEWCKfRNbgsUWtkrvYrvD/Sl1CmvIoGwNj87TzQq/9uPvTZfwThXZaju01KSgqHDh3izp079OjRA2tra0JCQrCxscHKysrQefzgGGp6xZzO5y2qut8tmVU3ZzZ4ut7pG6BDj7ZAuKh3+yzfox7cFvqkHcU8Ptd7vx8rY2Nj2rdq8t62e09fQnlze1/AsFNJZkbM/iMI7w69r2APHjygRYsWPHz4kMTERD799FOsra2ZPn06iYmJLF68OC/y+UF5GzPkiI457y5d5wzXp/QlfYee9GNO5raKvIBDWeIfXcm23WX6UtO0fQv6MTczZdyIL/M7G+8lMfuPILw79L76Dx06FC8vLy5cuEDhwoVVyzt27MiAAQMMmrkPSfphhPKCqAZ/P6Sf5jEnJZTaZuQBZUAnKVJU0/alrcttoFfl67+yzEup+uOxLOqGTYk6vLgfqFFqKgZY19+rxCRmzP+TkV9/jrmodRAE4T2l953nyJEjHDt2DNN0pWRlypThyZMnBstYXsuL3uWGqgZXp0/HHBFYvrsya3eZU5nNyFO580YtpZr6V5GnL231HLMLEyu7TPMScWUNZYtOxanmdzjV/C4HRySoS0lJYeuuA3w3uA98REGmTP7+DD4vCEL29A4yFQqF1sDs8ePHWFtbGyRTb0Ne9C7PaTW4mF7xw5DV8EP6DPOjq8yqwHNacpjVjELqtJWivoy8lqN9Ch+PtNL1T1ovx8TCXus2Vp6Oqu3izocAUGPKqbeZTUEQDEjvILNZs2bMnTuXpUuXAspStbi4OCZMmECrVq0MnsGPgeiI82FIP/yQtp7huSm9zGtVR2zkyb6lRJ7bleWMQjIjExQpL9/avObC+0/X80N9OylVkVfZEQThLdE7yJw1axbNmzfHxcWFV69e0aNHD27duoW9vT1r167Nizx+kNK3nxQ+DGmBpLZSzdyWXhp6KKL0zGwdKOc7jnK+4zKsu76lBwCVOq6hUsc1Bt2vkJGpiQkD+nTB1OTDuDboWrquvp0YM1MQ3n9636VKlCjBhQsXWLduHRcvXiQuLo7//e9/9OzZkwIFCuRFHt9bWY1jKUov30/pg0d16p15DDEuX1adewxRepj+WKxKVcFl8DKt2ypSEnK1L0E/pqYmDOrXNb+zkSfuHRgFQNkm0/M5J4Ig5LUcFYUYGxvTq1cvQ+flg2NtZcnzhxe0rhOll++n9D3D1eVFaSWgtXOPPk6PbYBT0//h2Eg5VmH48U082DYry3aXQv56+fIVIyfMYsbPwylQwDy/s2NQL5/dyO8sCILwluQoyLxx4wbz58/n2jVlY//KlSszZMgQKlWqZNDMve9kMpkorXwP6VJaaci2lZkFloYaAkhKTebJvqWqIDNNVu0uAeIjLvHgv3GqfInxLt+eVIWCE2cukKoQ7RIFQXh/6X3X2Lx5M927d8fLy4vatZWdGk6cOIGbmxvr1q17b+Y1z4shjIQPQ16XVmbYn5YZeQw9tqSkFqw41O6CQ+0uer1fdO4R3lfqHfBATDMpCG+T3kHm999/zw8//MDEiRM1lk+YMIHvv//+vQky82III+HDkZc9wbW1tcztjDy5zUeJWiOxKanZftiyqNtbz5MgpCngXASkVNWkApBxJqvspH8gFNNMCsLbpXeQGRoaSp8+fTIs79WrFzNmzDBIpgThbdM2WHpeyWwg9bctfT7UPTk5B0AMrJ5PzExNGTt8UKbj577vJEUKz2/volCFzIe9M7G1QlIk8/Luc1Kev+54JpOBHuUY6UssxTSTgvB26R1kNmrUiCNHjlChQgWN5UFBQdSvX99gGROEvKRt/nAgV4OlZzd/uLr8KLnMLh9hwX8CUMzjc6If/geIIDO/mJgY06G1T35nI0/o+kCV9tu5s/4nnr3Y8/o3KuVhzgRBMDS9g8x27doxatQozp49S61atQBlm8yNGzfy888/s23bNo1tBSGvZTXTTmbbpe9ZnV0nGF2olwymnz9cc7v870Rz+9/BGfLx/NY2ZQnT6//ndx4/ZgkvX9Hvqx/xXzQFiw+sd7n6g1fktU0A2FfOvI1w+W4/Ub7bT5wcJcbNFIT3jd53ka+++gqARYsWsWjRIq3rQNmzWnSqEd6GrGbayW5qR32DyuxKK9NKBtNvp+7/7d15WJRV+wfw7ywwMCCbCAgKiAuiIigKov5Ck0StFLfcSlxytzK0UnPDFktLKV9ebROrt8U0l9wX3pBXM0QUNWURQhEFVFwQkG3m/P6geZydGZiF5f5cl5fMs5znnsPwcHOesxjj8bi6EfE9Fv0AsasP7DuH6BSH4tc00MecpFIp/r6RD2kzH11+56//ANCeZBJCmq56rV1OSGOjbqUdYyztqNxaqYmhR4fXRduIeKn9LTBpNa7ujERr30i06T4FnYZvUTnO1DETQghp3pr887CbN2/ilVdewZ07dyAUCrFy5UqMHz/e3GERM5FvmTTG0o7A09ZKdY/CzUlTAi2fGBdn7sX9awcpoSRNjoWrrblDIIToqcknmUKhELGxsQgMDERhYSGCgoIwYsQI2NjYmDs00gDqHv/q+3jbFHPhyfe7bMz9GBvLQCOiGysrETZ/vBxWViJzh9JoWLV3MHcIhBA9Nc7fiHpo27Yt2rZtCwBwc3ODs7Mz7t+/T0lmE6f8+NeU89tp60+pOPWQYquosfsxahvg1Oe9k0a7LjE9oUCA0L6B5g6DEEIaxOxJZlJSEjZs2IDU1FQUFBRgz549iIyMVDgmLi4OGzZsQGFhIQICArB582YEBwerlJWamgqJRIL27dubKHpiTPKPf88uC9U4oMfQtM0fKZ9IGuORs7ZEsuOE1cg//iUq7uYp9DcVtW6HgCVPY0n/dTzEbXrA65nVAIBWHv3w+NafBo+VGE9pWTmenzAPB3dsga2N2NzhGJV83+aKR3nIPbFY7c9W9f1yVN0uwdnzxr8HEEIMw+xJZllZGQICAjBjxgyMGTNGZf+OHTsQHR2NrVu3IiQkBLGxsYiIiEBmZiZcXFy44+7fv4+pU6fiq6++0nq9yspKVFZWcq9LSkoM92aI0cj3pdQ0oMeg1zPT42Un/2dxL/WAykh5twET4fnCG3Dyr507UTkZVV7/vLQghdvXpvtklBakmvaNkAYrK39i7hCMjse3gI1rL+713Ss/anyKUJH7AGAMPL4FrdxDSBOhd5J5/vx5WFhYwN/fHwCwb98+xMfHo1u3blizZg0s9VyhYvjw4Rg+fLjG/Rs3bsSsWbMwffp0AMDWrVtx8OBBbNu2DUuXLgVQmzhGRkZi6dKl6N+/v9brrVu3DjExMXrFSMzPEAN6tE0/pJykmatvpWxOQEB9v1QZ5RacqzsjVdY/l7Gy96SBPqRRUv5camtxbxXkwX3GH5/L15iMEkIaD71/k86ZMwdLly6Fv78//v77b0ycOBGjR4/Gzp07UV5ejtjYWIMFV1VVhdTUVCxbtozbxufzER4ejjNnah+jMsYwbdo0PPvss3jllVfqLHPZsmWIjo7mXpeUlNDjdTPSlEhpa52s7yMybdMPye9rLHNEKr9PXefoJKQ5MtTPpKm63RBC6pFkZmVlITAwEACwc+dOPPPMM/jxxx9x+vRpTJw40aBJ5r179yCRSODq6qqw3dXVFRkZGQCA06dPY8eOHejZsyf27t0LAPj++++5llZlIpEIIpEIcXFxiIuLownjTUzbco7yDDHdkHJSJksiNU0/ZK4kTb5ObL16ot1zs2HXMUjlOHUrCsnWf3bp8bKpwyZGZG1lhR3ffAprq+a12k9DyP9BlXK5X73KUO52QwgxLr2TTMYYNyH7iRMn8MILLwAA2rdvj3v37hk2Oh0MHDiwXhPEL1iwAAsWLEBJSQns7e2NEBlRR3nUuCGWc9R4LaUBPMotlI1l+iH5Oim9cQmZ8W+qrQ/r1r4AgA7PfqySQNOKKc0Ln8+Dq0tr8Pk8c4fSKNn4uwEApDVVOLcyDIBurZLy+2WtmYQQ49H7t2qfPn3w/vvvIzw8HCdPnsSWLbUrh+Tm5qq0ODaUs7MzBAIBioqKFLYXFRXBzc2tQWVTS6b5NHTVHb2upaF10tjTDym32LYOjOD6WqqjS510ePZj7mvqY9m8lZU/waAXpyFx//ZmP7rcEKhVkpDGSe8kMzY2FlOmTMHevXvx7rvvolOnTgCAXbt21TnoRl+WlpYICgpCQkICN62RVCpFQkICFi5c2KCyqSWzcVM3V6VyH8SGMHaSpm2ZR3XHGnp0PCEtAV9oieB1Z6hVkpBGSu8ks2fPnrh8+bLK9g0bNkAgEOgdQGlpKbKzs7nXubm5SEtLg5OTEzw9PREdHY2oqCj06dMHwcHBiI2NRVlZGTfavL6oJVN/2kY760rnxEvpUbe2dcI1TZ5u7hV4NLVOpq6pnYYoaE0CAEAotoe0pu56rS6v7Y5iIXY2YJSENB5dx1ALPSHNSb1+Az98+BC7du1CTk4O3nrrLTg5OeHq1atwdXWFh4eHXmWdO3cOgwcP5l7LRn5HRUVh+/btmDBhAu7evYtVq1ahsLAQgYGBOHLkSIMfzVNLpv70aZ3TRJ8BPfKPurWtE65p8vTGMkocAEpyaueptOsYBEllucI+WbJZl2sHXwUAGkFOmi3+P/eG7MPzUFVaYNCnF4QQ09M7ybx06RKGDBkCBwcHXL9+HbNmzYKTkxN2796NvLw8fPfdd3qVN2jQIDDGtB6zcOHCBj8eJ4Zhyv6U+mgM0/ekrHgGHSeshpP/ELgNmKiwL+PrhVyCTo/HSV1sxNZI3L8dNmJrc4diNtqeXhBCmga9k8zo6GhMnz4d69evR6tWrbjtI0aMwOTJkw0anDG1tMfl2pYr1HactmNNTX40eGNo4VA3HVP+8S/h5D8Eni+8oXCsfFJpiOmZSPMmlTIU3SmGt6cHBIKWN8K80/AtWp9eAIr3A2s/J/B4Zl/AjhCiRO+fypSUFHzxxRcq2z08PFBYWGiQoEyhpT0ul3/Ura1fpfIj8cYyalN56qHGQN10TJX3C9Qeqy1JV+5TauXgA5/nNgIAaioeIWt/VO31zNzHlJjOk4oKTJi5mEaXa6DcDYYv4oFH0z0R0ujo/RtLJBKpXe87KysLbdq0MUhQxDhkj7rrGokp/0i8sYzalG+1rKuFw1RErdsBAAKWNKxFVVOfUmWNqY8pIeak/BSjsdwTCCGK9E4yR44cibVr1+KXX34BAPB4POTl5eGdd97B2LFjDR6gsbS0x+XK5JdWU96u/ChXdmxj6kvYGCZSt+xQmyBe3RkJoXVrdHnhG73LePD3MYWViJQJrezN3teUkMauPMv0C4EQQuqm92/mTz/9FOPGjYOLiwuePHmCsLAwFBYWIjQ0FB988IExYjSKlva4XJ62RFG5v2B9+hLqM8dlXetxq43RyBOpayPfD9Mm0AWARO8E986VnwAALt0nAaAWSqJeSx70AwDt+r2l87GSkgojRkIIqS+9k0x7e3scP34cp06dwqVLl1BaWorevXsjPDzcGPGROug6oEeePoN45I+VJYR1Db7RNseluvXEa8t6uh731Z2RWlsnTTHg53bit8g/upV7LatXlX6Y9RjVfu/qDgC1Saajz1A4+gw1WNykebC1EePkgW/NHYZZ2bUfYPRrKD/RaSyDHAlpLur9jHHgwIEYOHCgIWMh9aDrgB6DXEsueaxr8I2mOS41rSfuN3anQgLamFr31I22D153RqUfmHJy3BhGwJOmqUYiQcr5y+jb2x/Ceixy0VwUpm3D/Wu/ca8N+TOlrlsQIcSwdEoyP//8c50LfP311+sdjCmZqk9mfVoa9aXrgB6DXOuf5FE5wZJPEOvqI6mp9c8QvzwMVd/ug6LgPqh2VLeu9aptBLw+9UNIRUUlXnvnQxpdLsfQs0oo3xcayyBHQpoTnX7Tbdq0SeH13bt3UV5eDgcHBwC1KwCJxWK4uLg0mSTTVH0yTdnSKLuergN6GnwtpcE3gKwFUrUVUpfH4AaJqZ71LZ+cCq3t4PHcLLiGjtN6TvsByxVeK4+AZ9IaPHmQA2vHjrBxDcTjW2c01g8hRJVb4Ay4Bc4AQCPICWmKdPptn5uby339448/4t///je++eYb+Pr6AgAyMzMxa9YszJkzxzhRNnGmamnUZ0BPg6+lYfCNutZI+WONkWClrHgG7oOmwiP8VXiPWQoAcOk7Sq/6lk9Oa56UIO/g51ySad85hDvOsXsYHlw5CQBo5R6ssTzl9+g58F2dYyGE1AOP5skkpLHRu0lp5cqV2LVrF5dgAoCvry82bdqEcePGYcqUKQYNsKUwxGNeU3ZY1+fRtqH7JWpaaccj/FW49B3FbRe7d9F4XsA7eyFycAUAXN0yi0sw1S2Z6Tsjlvva47nZeJjxR50xUl9M0hB8Ph8+Xu3A5/PNHUqjYe8ZpnknjwdLdzsAQNGZXQBQ55MIQojx6Z1kFhQUoKZGtW+MRCJBUVGRQYJqiUz5WF3bFEP6TD9kLupW2lHXStvjtW+1nidP15ZesasPl8wXnK9d+aptb2rBJ4YltrbCL/EbzR1Go+IR8qbGfa2CPLivb/z2KQBKMglpDPROMocMGYI5c+bg66+/Ru/evQEAqampmDdvXpOaxshck7HL95lUbq3U9Fhd3Xri8uWpS460JYvaphjStq+xcPCrndWgy9QNdR5bXfoAFz4YAQAaWyu7zfuqXnE8yDkMgJJMYnjV1TU4eOwknh8aBgsLGiRGCGma9L57bdu2DVFRUejTpw8sLGqTm5qaGkRERODrr782eIDGYqyBPwcmiyH85wnXxTVhKi1uMvq0VtanBa6uZFHTFEN17TMmbV0GZPu6L4zXKblUx9D9UgkxlsqqKrz/6RcIHxRKSeY/yu5cBgDYuPibORJCiK70vnu1adMGhw4dQlZWFjIyMgAAXbt2RZcuXeo4s2UQ8gFLAQ9VEgZAMbGRb7WULdMoa7Wsa/S3pv6C2hgqWTTXyHCXfmNV9unLwtZR73ojhDQ+N06uBABaZpWQJqTeGUOXLl0osdSgSsIw7D/luJ93BiKRpdpjlBNK5VY2fRJQYzL2yHCV62lJpnkCC9h4dDXq9YGnXQ2U+6Jm/jYVksqSRtdHlRBCCGmM6pVk5ufn47fffkNeXh6qqqoU9m3cSJ3VdaFtJLi2BFTXQTv6tjpqaq1saslU+q/jYd3aF96D3q93GU+7GqjrhtD4+qiS5kfA56NfnwAIaHQ5IaQJ0zvJTEhIwMiRI+Hj44OMjAz06NED169fB2OMGwhEGkZbAqrroB19Wh1N3VqpSZs+L3JfP7j6PwCAY7f/06sMJq1GWVEaAKDy8W0AgKiVO4CnCbpv5I8QWGhfRYXHF6ok2L4jv6MJoYlJWFtb4V/raW7V+rD17GHuEAgh/9A7yVy2bBmWLFmCmJgYtGrVCr/++itcXFwwZcoUDBs2zBgxtjh1TSOk66AdXTWW1soOY5+uoHPt+7cBoF79KWUJeM6R+UYdKe/QoenMpkCalqqqasT/uAfTJ4+GpSUNVtNHfWeLIIQYnt7PYtLT0zF16lQAgFAoxJMnT2Bra4u1a9fi448/NniAxhIXF4du3bqhb9++5g5FhaxF8unrGpWk01wKT/2Es8tCcXZZKFJWPGPucLTi8S0UHv3z+ELwhdYQWIiRc/Q15Bx9rV7lMmkNSgvPw73PQrj3WWiocAnhVFVX46vvdqGqunH83DcW1F2FkKZF75ZMGxsbrh9m27ZtkZOTg+7duwMA7t27Z9jojMhYUxhZCmuXNju10QfZv70EHjRPdK5tAIm5phHSVX0njJclpuq6BDzM+hMA4NCln8q++rRoamuhrSy5qXGfjUtPlN25pHYfrTlOiHnw+BbgCzV3c5H1K5dW1YDHs0D3yXtMGB0hRB29k8x+/frh1KlT8PPzw4gRI7B48WJcvnwZu3fvRr9+qslBS6epz6Qh/yI31RRDAOA2cBLcBk7SOGG8z0ur4dxLc7cJ5amIzr8/HADQe8VhZMXXrughSyhlI+wt7V0QuHSfod+Kgptn1gMA2oe+jTbdJ6P8Xrra4xpL1wJCWhr5n72MPZMBAF1H/whA8Y+/skuFtV9MNl1shBD19M5INm7ciNLSUgBATEwMSktLsWPHDnTu3JlGlssZGP037uddRM5vLylsl7VQGqp1sj6Ddh6n3gIYw9nzoRDaOKD3isMaj5WfIJ1vaYV2z82G28BJKsfpM4+l/Oj5mrKHXDKpaeJ6U3ic/3Q9crFzV0omiVkJhUKMGvEshEKaiF0daU25wmv5n9fkc33qXa62FdkIIfrT6w4mkUiQn5+Pnj17Aqh9dL5161ajBEYUGXSKIcYApuOhchOkS6sqcPPIFrVJJlB7U3buNQw3j/wbANB+2Pw6y5dPJjVNXK8P14Dp9TqPkMbESmSJlUvmmjuMFqW+K7IRQjTTK8kUCAQYOnQo0tPT4eDgYKSQmp+GPs42yhRDPN37OaqbIL2VTy+Nxxec/B6AbkmmoVsKWncZZdDyCDGHisoqbNi8DW+9NgNWGhZ0aOlk91UA8Ap7r8HLTSqvyEYIaTi9M54ePXrg77//RocOHYwRT7NjiATR2I9utQ3G0cRv1r+NFQ4hLV5NTQ32Hfov3pw3FaAkUwUNwCOkadA7yXz//fexZMkSvPfeewgKCoKNjY3Cfjs7O4MFp6vRo0cjMTERQ4YMwa5du0x+fW10TRAbslpPQ2l7NKStxbKuMmWtAU49BqPTlA8BAHYd+6Ak51y9ylTneuIKlN/9ixupX5xVO0CorhZN9+BF3NdFl783eZ0TQuqvzvsqA6pLH8DC1tE0ARFC1NL5t+ratWuxePFijBgxAgAwcuRI8Hg8bj9jDDweDxKJxPBR1uGNN97AjBkz8O2335r82g0h/7hHNtpc39V66sO6s7POx2pqsay4VzsFkJVz+9oyXZ62bGsbtOPx3Gw8vn5R5+uro7yST+08oopdEupKMh28Bim8NudKR4SQhrmVvAkA4BHyJsDjQedO54QQo9I5yYyJicHcuXPx+++/GzOeehk0aBASExPNHYZelBMaWZJjilHNQnurBpdx6dPaUfOyvpr+b/7I7dP22L2Vl3+D+2HmHKnt69lt/F54D3pfoRW4Psmiq/8rcPV/pUExEWJIlhYWmDV1HCwt6A8fXTzKOwmgNslsFeQBALCwdcRfm6MAAD1ea1oNEIQ0FzonmYzV/mUYFhZm0ACSkpKwYcMGpKamoqCgAHv27EFkZKTCMXFxcdiwYQMKCwsREBCAzZs3Izg42KBxmJo5psipzwAk5RbLxoimGyLNjaWlBeZMe6nuA4lW5bezzB0CIS2aXstKyj8eN5SysjIEBAQgLi5O7f4dO3YgOjoaq1evxvnz5xEQEICIiAjcuXOnXterrKxESUmJwr+WQH6Jxcq8x6i48Uin8y59+hLXaqlM1u/y7LJQ3Ni/ETUVpQaLV1n6r+NxdWcklyQT0pw9eVKBhW9/gCdPKswdCiGE1JteIx26dOlSZ6J5//59vQIYPnw4hg8frnH/xo0bMWvWLEyfXjv/4datW3Hw4EFs27YNS5cu1etaALBu3TrExMTofV5TJ9/aZ4jpOZT7XRb9sRN3kvcabfJi+dWSqP8kae4kUin+PHcREqnU3KEQQki96ZVkxsTEGHSd77pUVVUhNTUVy5Yt47bx+XyEh4fjzBn917IGgGXLliE6Opp7XVJSgvbtG++jYGXyK/DINHRlCr+5X3JfZ/+wHA/ST9VZnqlXwvCNrO3zKbDQvHYxIYQQQhoPvZLMiRMnwsXFxVixqLh37x4kEglcXV0Vtru6uiIjI4N7HR4ejosXL6KsrAzt2rXDzp07ERqqvrVOJBJBJBIhLi4OcXFxZhkN3xDWrh1QdvMK15JoiJUpWnk9ncS4+OIxky/pqAtKLgkhhJCmReck0xj9MQ3lxIkTep+zYMECLFiwACUlJUZtnVVuedSl1VFdayUA9Hr3kMooybPLQmHRykltObeSN3GjLgHoNHpdW4IpP4pb1/L0YezyCWkqRJaWWLF4DkSWNBG7Lpw6j9S4T/7+eOvE17id+B2tSU6Iieg88Ec2utyUnJ2dIRAIUFRUpLC9qKgIbm5uDSo7Li4O3bp1Q9++fRtUTl34QgsuYZStA14XXY8DapNCj+dmA6i9gd468bX6MqU1CglcfbTuOgaMSQ1WnjJb977coB7l8nOOvoaco68Z9HqENFYWFkJEPj8EFha0QIAu3AJnwC1whsp2+fsjAOQf/5LWJSfEhHS+g0nN0AHd0tISQUFBSEhI4KY1kkqlSEhIwMKFCxtUtqlaMoPWJHBf6zPgRt164erI/0V+K+EbAIBH+Ku1/4e8WTs5McBN+t4QLt0nwaX7JIOVp6x96NtA6Ntqy68suWnw6xHSWJU/qcC0+cux/d8fQmzd8HltWyrlFkseX2CmSAhpmcz+Z3JpaSmys7O517m5uUhLS4OTkxM8PT0RHR2NqKgo9OnTB8HBwYiNjUVZWRk32rypUvdI3NazB7rN+woB7+xtcPlldy4DAGxc/FX2ufQbq3M5toHuYKwaV3dGom3QfDj6DNU7lqwDMyGpLIHf2J0qj8QdOoTDvU/D/mAgpLmRSqX4+0a+Wf64b4pKbp4GANi1HwBAcTU16nZDiPmYPck8d+4cBg8ezL2WjfyOiorC9u3bMWHCBNy9exerVq1CYWEhAgMDceTIEZXBQPoyx8Cfrq/+i/ta9khcXR9IkUPD3hsA3Di5EkDtqjiAYp8l71FLdC+ILwGkUij3rLBtq7mbgezmLrt2dVkRN0en/FREysrv1Q7mEjt3ReuuuifChJCWLf/PDQCAbu0HKExvRnPqEmJeZk8yBw0aVGd/z4ULFzb48bgyoz0u/+etHHlZjItrwsAk1RCK7RG0JgF2HYMUDtX1kbhel/9ngnRBK4HCGuXq+iup0zZMdXlFHl/IJYwyngPfBQA8eZCD3BOLFWNQSiKVE0p15QHA9d9r5z3tNn4vt8zjwxuJuH02Vq9VigghLZd8q2VDuvXI7qVAw6eJI6SlarG/tU3VkskTWEBao9rR3GvkYjVHN/xaunhw9X8AAMdu/6eyr/2w+Qqvy/76Z9DVeD3i0GOy9NLC8wAAW7feBiuTkKbOykqEzR8vh5WVyNyhtEjy91IaKERI/bXYJNPYA3+G/acc9/POQCR6OgVJzo41AICOE9bANXScwa8p/5e28l/w8n2Wrn1fO7hGl1ZUaYX2G6y1Y0e1rZKaOHZUXN0p739rAUBjGQ5eg+DgNUjn8glpDoQCAUL7Bpo7jGbHwW+gTsfJ30sNsUIaIS1Vi00yzaE47SiA2iTT2CRlVQqv5fssyQbeyCeiss7x9y4cwa3jX6LyQUHtDgbAAHOkMmkNHt8+i7a95zS4LEKau9Kycjw/YR4O7tgCWxtaiKAh5AcBwbr2PxoURIhptNgk02iPy3XMx24n1k6q7j4oyrDX/0d5+h2dj5XvHJ/764cqk8c3dAUgesxNiP7Kyp+YO4QmT9u9hwYFEWJ8LTbJNNU8mZrkH90KwHhJptZsl1c7Ulz2iPpe+i5ulzE6t1NLASHEmCxt26rdrnzvKbtVO4OFjUdXo8z1SwhR1GKTTKMx/cJIamkbic3jKU5I7OynuX9oTcUjAIDQyviJOLV4EkLqo9PwLTodd+VftfMrG3pWD0KIepRkmpB8X0hDL8kIPF37my+s7cMlPwWHbe+nc29qmp9Tnaz9tS2t+gzu0ZfssRW1eBJSy9rKCju++RTWVrTaj6HJ7otMWl3b31yPmTMIIfrRee3y5sZUa5ebkmyic0B7X0pLB1fwBE9bM+9nH8L97EMmiVEZj28BobWTWa5NSGPF5/Pg6tIafH7DB921BFJJNaQ6TDWkcF9kAOqYo5kQ0jAttiXTHH0yLVxtAdS2CiafM05yy+ML0XX0j8Boxe3Zh+dxX4s6W0CEpxO1F174EgDg1GmEUWLShlovCVFVVv4Eg16chsT922l0uQ4ydtc2R9b1xEW+z3nyO32MGRIhBC04yTQH35c3c1+bevUaXfssEUJIS9CqTztzh0BIs0dJpgnZuPhzX9t3DjFjJIQQQgghxkVJpgndv5wAAHDyHwLfGbEmvbZUUo27V35AceZeteuAyyYstm7tiw7PfgwAqC6/R2uGE0KaFNkAyLZB8+HoMxQAcOfKT7h3dQeA+k3ALj+IEqC1zAnRVYvNHky1drm8az8sAwCEfHQWGXsmA0Bt/0kD8Qp7T+O+zL2TuRHtyuuAa5s6iNYMJ8T0bMTWSNy/HTZia3OH0uTID4BU3fd0e+mlf1Y1q2N0ufIASlrLnBDdtdgk02gDf7QNBmVS7svqx48Md81/yD+OV6btL3dN+yzEzkaduogQop5UylB0pxjenh4QCGiEub54fCHXigkALt0nwaX7JIUJ2FmVbg0Myi2WtJY5IbprsVMYmVv5lSKUXykydxiEkEboSUUFJsxcjCcVFeYOhRBC6q3FtmQajRmnXbuVvAkA4BHypvmCIIQQE/MZ+rm5QyCEqEFJZjPyKO8kAEoyCSEti5W9p07H2bZtPotvENIUUJJJCCGNEA36qR8rBx+N+zwHvmvCSAghlGSaEF9E1U0IqZutjRgnD3xr7jCajBtJMQAAr2dWw+e5jWaOhhAiQ1mPCbUfMxsAIK2pAhjAE9RW/63kTXiUd7Je87cBQGHaNty/9hvNaUlIM1EjkSDl/GX07e0PoUBg7nAavbKiCzod9+RBDgDA2rEjrDu1Nngcsjk6Zep7TyekuWixo8vj4uLQrVs39O1ruj46boEz4BY4A0Dt3Gs8gSW3j0lrFG5O9UFzWhLSPFRUVOK1dz5ERUWluUNpcmoqHqGmQv0UcbknFiP3xGIAgNDBGkIHw3ZJkJ+j0xD3dEKauhbb7GW0eTJ1wBdaInjdGe61R8ib3KCd+pBPXgkhpCXL2h8FAGab45fHF6Lb+L0Kc3IS0lK12CTTHEpungYA2LUf0KjLJISQ5q7ixkNzh0BIs0dJpqFpWZwj/88NAIBuBkwIjVEmIcS8+Hw+fLzagc9vsT2ajK76bqm5QyCk2aMkkxBCGhmxtRV+iadR0oSQpo2STEOr54o/Tp1HGjYOQkiTVV1dg4PHTuL5oWGwsKDbdF1cerxs7hAIIWo0i2cxBw4cgK+vLzp37oyvv/7a3OHUCw3eIYTIVFZV4f1Pv0BlVZW5Q2kSnP3GwdlvnLnDIIQoafJ/ItfU1CA6Ohq///477O3tERQUhNGjR6N1a8PPgUYIIaTpMteIc0Jaqibfknn27Fl0794dHh4esLW1xfDhw3Hs2DFzh6W3kpunuZHihBBCdHc/+xDuZx8CAHR+/mt0fr5pPtEipLkxe5KZlJSEF198Ee7u7uDxeNi7d6/KMXFxcfD29oaVlRVCQkJw9uxZbt/t27fh4eHBvfbw8MCtW7dMEbreLG3bwtK2rdp9+X9u4EaKG6pMQkjTJODz0a9PAAQ0ulwnhRe+ROGFLwEAFmJnWIid6zzHwtkGFs42xg6NkBbN7I/Ly8rKEBAQgBkzZmDMmDEq+3fs2IHo6Ghs3boVISEhiI2NRUREBDIzM+Hi4mKGiOuv0/AtTaJMQoh5WVtb4V/r3zV3GM1O1oGZAIAuL3wDK29HM0dDSPNn9iRz+PDhGD58uMb9GzduxKxZszB9+nQAwNatW3Hw4EFs27YNS5cuhbu7u0LL5a1btxAcHKyxvMrKSlRWPl2qraSkxADvQs4/82Se2uiD7N9eUpg2s+uYneALNC/7yKQ13CoR8mveKq+HK6+uMgkhTU9VVTXif9yD6ZNHw9KSfr51Ibt/MmkNxG26o8OzH6scU/OkWOF19cMyJL/TR32BPB5CPkpByopnwCRP77+yr88uC1UTQzXA4wHjwS0vKb/yD61lTlqaRv0spqqqCqmpqQgPD+e28fl8hIeH48yZ2mUZg4OD8ddff+HWrVsoLS3F4cOHERERobHMdevWwd7envvXvn17o78PXfD4FuDxa3N+Jq1ReNwjvx4uIaT5q6quxlff7UJVNa19rQv5+yePL0TFg791O4cnUL+TATxBbRMBk1QrJJlaMQBM/Tx2tJY5aYnM3pKpzb179yCRSODq6qqw3dXVFRkZGQAAoVCITz/9FIMHD4ZUKsXbb7+tdWT5smXLEB0dzb0uKSkxbKJpWZu3D4z+G/fzLkIkstTpNG1/3foM/RwAYGXv2fD4CCGkmalP66DyORWP8gDU3mev7HiB295j0Q8AALGrD4CnLZjB686olKnQKvpPAisb0U5rmZOWqFEnmboaOXIkRo7UbTJzkUgEkUiEuLg4xMXFQSKRGDaYKqlhywMll4QQYmya7rOy5FKmz3sndSqPx1NcY7jrGHpMTlqeRv243NnZGQKBAEVFRQrbi4qK4Obm1qCyFyxYgKtXryIlJaVB5RiDVFINqa6PZwghzY5QKMSoEc9CKGwW7QBND0/AtUQq4wstwRfq9oRK4TyBBfWfJy1Oo04yLS0tERQUhISEBG6bVCpFQkICQkNVO13rIy4uDt26dUPfvn0bGqYCvrUQfOuG/WLI2D0eGbvHc69vJMXgRlJMQ0MjhDQRViJLrFwyF1Y6drchDSd/ny09fxul528DADK3LULmtkV6l8ekEjCpgZ+UEdLEmP3P5NLSUmRnZ3Ovc3NzkZaWBicnJ3h6eiI6OhpRUVHo06cPgoODERsbi7KyMm60eX0tWLAACxYsQElJCezt7Rv6NjjSJ4YfoFNWdMHgZRJCGq+Kyips2LwNb702gxJNA2o/YLnGfQr3WbnBO4+uJSscd/GT2gaAgCV1Pf5WHACUfXgeAJp2jrQsZk8yz507h8GDB3OvZYNyoqKisH37dkyYMAF3797FqlWrUFhYiMDAQBw5ckRlMJC+jNYnkxBCGqimpgb7Dv0Xb86bClCSaTCt3DVPb6eryuL8ep1XVVrQ4GsT0tSYPckcNGgQmIYpH2QWLlyIhQsXGvS6xmrJJIQQQgghjSDJNDdZgmuISdkrK6tQVlnbMsqkEpSUlOg8hZG80vJqhZiUXxNCmrfSsnJIaqpRUlICqYTmyDWUwrRtAAC3wBkq++Tvs7L7eElJCUora7ivAai8lqdwnhHv45WVVQr9Pev7u0aZLLa6Gn4I0RWPtfBPU35+fqOZkJ0QQggxt5s3b6Jdu3bmDoM0Ay0+yZRKpbh9+zZatWqlMq9Zfcgmd7958ybs7OwMEGHTR3WiiOpDFdWJIqoPVVQnioxRH4wxPH78GO7u7uDzG/XkM6SJaPGPy/l8vlH+YrOzs6MboRKqE0VUH6qoThRRfaiiOlFk6PqgMQrEkOhPFUIIIYQQYnCUZBJCCCGEEIOjJNPARCIRVq9eDZFIZO5QGg2qE0VUH6qoThRRfaiiOlFE9UGaghY/8IcQQgghhBgetWQSQgghhBCDoySTEEIIIYQYHCWZhBBCCCHE4CjJJIQQQgghBkdJZgNdv34dM2fORIcOHWBtbY2OHTti9erVqKqq0npeRUUFFixYgNatW8PW1hZjx45FUVGRiaI2rg8++AD9+/eHWCyGg4ODTudMmzYNPB5P4d+wYcOMG6gJ1adOGGNYtWoV2rZtC2tra4SHh+PatWvGDdRE7t+/jylTpsDOzg4ODg6YOXMmSktLtZ4zaNAglc/I3LlzTRSx4cXFxcHb2xtWVlYICQnB2bNntR6/c+dOdO3aFVZWVvD398ehQ4dMFKnp6FMn27dvV/k8WFlZmTBa40pKSsKLL74Id3d38Hg87N27t85zEhMT0bt3b4hEInTq1Anbt283epyEaENJZgNlZGRAKpXiiy++wJUrV7Bp0yZs3boVy5cv13rem2++if3792Pnzp04efIkbt++jTFjxpgoauOqqqrC+PHjMW/ePL3OGzZsGAoKCrh/P/30k5EiNL361Mn69evx+eefY+vWrUhOToaNjQ0iIiJQUVFhxEhNY8qUKbhy5QqOHz+OAwcOICkpCbNnz67zvFmzZil8RtavX2+CaA1vx44diI6OxurVq3H+/HkEBAQgIiICd+7cUXv8H3/8gUmTJmHmzJm4cOECIiMjERkZib/++svEkRuPvnUC1K52I/95uHHjhgkjNq6ysjIEBAQgLi5Op+Nzc3Px/PPPY/DgwUhLS8OiRYvw6quv4ujRo0aOlBAtGDG49evXsw4dOmjc//DhQ2ZhYcF27tzJbUtPT2cA2JkzZ0wRoknEx8cze3t7nY6Niopio0aNMmo8jYGudSKVSpmbmxvbsGEDt+3hw4dMJBKxn376yYgRGt/Vq1cZAJaSksJtO3z4MOPxeOzWrVsazwsLC2NvvPGGCSI0vuDgYLZgwQLutUQiYe7u7mzdunVqj3/ppZfY888/r7AtJCSEzZkzx6hxmpK+daLP/aWpA8D27Nmj9Zi3336bde/eXWHbhAkTWEREhBEjI0Q7ask0gkePHsHJyUnj/tTUVFRXVyM8PJzb1rVrV3h6euLMmTOmCLFRSkxMhIuLC3x9fTFv3jwUFxebOySzyc3NRWFhocJnxN7eHiEhIU3+M3LmzBk4ODigT58+3Lbw8HDw+XwkJydrPfeHH36As7MzevTogWXLlqG8vNzY4RpcVVUVUlNTFb63fD4f4eHhGr+3Z86cUTgeACIiIpr8Z0GmPnUCAKWlpfDy8kL79u0xatQoXLlyxRThNkrN/TNCmiahuQNobrKzs7F582Z88sknGo8pLCyEpaWlSt88V1dXFBYWGjnCxmnYsGEYM2YMOnTogJycHCxfvhzDhw/HmTNnIBAIzB2eyck+B66urgrbm8NnpLCwEC4uLgrbhEIhnJyctL63yZMnw8vLC+7u7rh06RLeeecdZGZmYvfu3cYO2aDu3bsHiUSi9nubkZGh9pzCwsJm+VmQqU+d+Pr6Ytu2bejZsycePXqETz75BP3798eVK1fQrl07U4TdqGj6jJSUlODJkyewtrY2U2SkJaOWTA2WLl2q0qlc+Z/yze/WrVsYNmwYxo8fj1mzZpkpcuOoT33oY+LEiRg5ciT8/f0RGRmJAwcOICUlBYmJiYZ7EwZm7DppaoxdH7Nnz0ZERAT8/f0xZcoUfPfdd9izZw9ycnIM+C5IUxEaGoqpU6ciMDAQYWFh2L17N9q0aYMvvvjC3KERQv5BLZkaLF68GNOmTdN6jI+PD/f17du3MXjwYPTv3x9ffvml1vPc3NxQVVWFhw8fKrRmFhUVwc3NrSFhG42+9dFQPj4+cHZ2RnZ2NoYMGWKwcg3JmHUi+xwUFRWhbdu23PaioiIEBgbWq0xj07U+3NzcVAZz1NTU4P79+3p9/kNCQgDUPj3o2LGj3vGai7OzMwQCgcpsEtp+/t3c3PQ6vqmpT50os7CwQK9evZCdnW2MEBs9TZ8ROzs7asUkZkNJpgZt2rRBmzZtdDr21q1bGDx4MIKCghAfHw8+X3sDcVBQECwsLJCQkICxY8cCADIzM5GXl4fQ0NAGx24M+tSHIeTn56O4uFghwWpsjFknHTp0gJubGxISEriksqSkBMnJyXqP2jcVXesjNDQUDx8+RGpqKoKCggAA//3vfyGVSrnEURdpaWkA0Kg/I+pYWloiKCgICQkJiIyMBABIpVIkJCRg4cKFas8JDQ1FQkICFi1axG07fvx4o71f6Ks+daJMIpHg8uXLGDFihBEjbbxCQ0NVprVqTp8R0kSZe+RRU5efn886derEhgwZwvLz81lBQQH3T/4YX19flpyczG2bO3cu8/T0ZP/973/ZuXPnWGhoKAsNDTXHWzC4GzdusAsXLrCYmBhma2vLLly4wC5cuMAeP37MHePr68t2797NGGPs8ePHbMmSJezMmTMsNzeXnThxgvXu3Zt17tyZVVRUmOttGJS+dcIYYx999BFzcHBg+/btY5cuXWKjRo1iHTp0YE+ePDHHWzCoYcOGsV69erHk5GR26tQp1rlzZzZp0iRuv/LPTHZ2Nlu7di07d+4cy83NZfv27WM+Pj7smWeeMddbaJCff/6ZiUQitn37dnb16lU2e/Zs5uDgwAoLCxljjL3yyits6dKl3PGnT59mQqGQffLJJyw9PZ2tXr2aWVhYsMuXL5vrLRicvnUSExPDjh49ynJyclhqaiqbOHEis7KyYleuXDHXWzCox48fc/cJAGzjxo3swoUL7MaNG4wxxpYuXcpeeeUV7vi///6bicVi9tZbb7H09HQWFxfHBAIBO3LkiLneAiGMkswGio+PZwDU/pPJzc1lANjvv//ObXvy5AmbP38+c3R0ZGKxmI0ePVohMW3KoqKi1NaH/PsHwOLj4xljjJWXl7OhQ4eyNm3aMAsLC+bl5cVmzZrF/XJpDvStE8ZqpzFauXIlc3V1ZSKRiA0ZMoRlZmaaPngjKC4uZpMmTWK2trbMzs6OTZ8+XSHhVv6ZycvLY8888wxzcnJiIpGIderUib311lvs0aNHZnoHDbd582bm6enJLC0tWXBwMPvzzz+5fWFhYSwqKkrh+F9++YV16dKFWVpasu7du7ODBw+aOGLj06dOFi1axB3r6urKRowYwc6fP2+GqI3j999/V3vPkNVBVFQUCwsLUzknMDCQWVpaMh8fH4X7CSHmwGOMMVO1mhJCCCGEkJaBRpcTQgghhBCDoySTEEIIIYQYHCWZhBBCCCHE4CjJJIQQQgghBkdJJiGEEEIIMThKMgkhhBBCiMFRkkkIIYQQQgyOkkxCCCGEEGJwlGQSYgKnT5+Gv78/LCwsuLWZTWnQoEEK616bC2MMs2fPhpOTE3g8Hrf+uC68vb0RGxtrtNgai6b6PhMTE8Hj8fDw4UMAwPbt2+Hg4GDWmDRpzLER0pxQkknUmjZtGng8Hng8HiwsLNChQwe8/fbbqKio0LkM5V86LVl0dDQCAwORm5uL7du3G+06mup89+7deO+994x2XV0dOXIE27dvx4EDB1BQUIAePXqoHNPSE4CUlBTMnj3b3GE0Oi39c0FIUyQ0dwCk8Ro2bBji4+NRXV2N1NRUREVFgcfj4eOPPzZ5LNXV1bCwsDD5dQ0lJycHc+fORbt27dTuZ4xBIpFAKDTOj6STk5NRytVXTk4O2rZti/79+5s7lHqTSCTg8Xjg843zN3qbNm2MUi4hhJgatWQSjUQiEdzc3NC+fXtERkYiPDwcx48f5/ZLpVKsW7cOHTp0gLW1NQICArBr1y4AwPXr1zF48GAAgKOjI3g8HqZNmwZA/ePAwMBArFmzhnvN4/GwZcsWjBw5EjY2Nvjggw+wZs0aBAYG4vvvv4e3tzfs7e0xceJEPH78WON7KC4uxqRJk+Dh4QGxWAx/f3/89NNPCsfs2rUL/v7+sLa2RuvWrREeHo6ysjK15UkkEsycOZN7z76+vvjss880Xv/69evg8XgoLi7GjBkzwOPxsH37dq7F8fDhwwgKCoJIJMKpU6eQk5ODUaNGwdXVFba2tujbty9OnDihUGZlZSXeeecdtG/fHiKRCJ06dcI333yjtc6VH5c/ePAAU6dOhaOjI8RiMYYPH45r165x+2WtRkePHoWfnx9sbW0xbNgwFBQUaHyvAHDy5EkEBwdDJBKhbdu2WLp0KWpqagDUto6/9tpryMvLA4/Hg7e3t8r5iYmJmD59Oh49esS1pMt/LsrLyzFjxgy0atUKnp6e+PLLLxXOv3nzJl566SU4ODjAyckJo0aNwvXr1zXGK/s+HDx4ED179oSVlRX69euHv/76S6UufvvtN3Tr1g0ikQh5eXmorKzEkiVL4OHhARsbG4SEhCAxMVHlvAMHDsDX1xdisRjjxo1DeXk5vv32W3h7e8PR0RGvv/46JBIJd578z4fs8yPfreDhw4fg8XjctWTv4ejRo+jVqxesra3x7LPP4s6dOzh8+DD8/PxgZ2eHyZMno7y8XOv37/Tp0xg0aBDEYjEcHR0RERGBBw8eAKj93L3++utwcXGBlZUVBg4ciJSUFK3lKdu3bx969+4NKysr+Pj4ICYmhvt8yN7bnDlz4OrqCisrK/To0QMHDhzQ+rmo6/sg+154enpCLBZj9OjRKC4u1ituQkg9MULUiIqKYqNGjeJeX758mbm5ubGQkBBu2/vvv8+6du3Kjhw5wnJyclh8fDwTiUQsMTGR1dTUsF9//ZUBYJmZmaygoIA9fPiQMcaYl5cX27Rpk8L1AgIC2OrVq7nXAJiLiwvbtm0by8nJYTdu3GCrV69mtra2bMyYMezy5cssKSmJubm5seXLl2t8H/n5+WzDhg3swoULLCcnh33++edMIBCw5ORkxhhjt2/fZkKhkG3cuJHl5uayS5cusbi4OPb48WO15VVVVbFVq1axlJQU9vfff7P//Oc/TCwWsx07dqg9vqamhhUUFDA7OzsWGxvLCgoKWHl5Ofv9998ZANazZ0927Ngxlp2dzYqLi1laWhrbunUru3z5MsvKymIrVqxgVlZW7MaNG1yZL730Emvfvj3bvXs3y8nJYSdOnGA///yz1joPCwtjb7zxBlfGyJEjmZ+fH0tKSmJpaWksIiKCderUiVVVVTHGGIuPj2cWFhYsPDycpaSksNTUVObn58cmT56sta7FYjGbP38+S09PZ3v27GHOzs7c9/Xhw4ds7dq1rF27dqygoIDduXNHpYzKykoWGxvL7OzsWEFBASsoKOC+F15eXszJyYnFxcWxa9eusXXr1jE+n88yMjK4742fnx+bMWMGu3TpErt69SqbPHky8/X1ZZWVlWpjln0f/Pz82LFjx9ilS5fYCy+8wLy9vVXqon///uz06dMsIyODlZWVsVdffZX179+fJSUlsezsbLZhwwYmEolYVlaWwnnPPfccO3/+PDt58iRr3bo1Gzp0KHvppZfYlStX2P79+5mlpSX7+eefuZjkfz5yc3MZAHbhwgVu/4MHDxgA9vvvvyu8h379+rFTp06x8+fPs06dOrGwsDA2dOhQdv78eZaUlMRat27NPvroI43fvwsXLjCRSMTmzZvH0tLS2F9//cU2b97M7t69yxhj7PXXX2fu7u7s0KFD7MqVKywqKoo5Ojqy4uJihTgePHjAvX97e3uu/KSkJGZnZ8e2b9/OcnJy2LFjx5i3tzdbs2YNY4wxiUTC+vXrx7p3786OHTvGcnJy2P79+9mhQ4e0fi7q+j78+eefjM/ns48//phlZmayzz77jDk4OCjERggxDkoyiVpRUVFMIBAwGxsbJhKJGADG5/PZrl27GGOMVVRUMLFYzP744w+F82bOnMkmTZrEGFP9pSOja5K5aNEihWNWr17NxGIxKykp4ba99dZbComvLp5//nm2ePFixhhjqampDAC7fv26XmXIW7BgARs7dqzWY+zt7Vl8fDz3WlY3e/furbP87t27s82bNzPGGMvMzGQA2PHjx9Ueq6nO5ZPMrKwsBoCdPn2a23/v3j1mbW3NfvnlF8ZYbYIAgGVnZ3PHxMXFMVdXV41xLl++nPn6+jKpVKpwjq2tLZNIJIwxxjZt2sS8vLy0vl/l5ETGy8uLvfzyy9xrqVTKXFxc2JYtWxhjjH3//fcq16+srGTW1tbs6NGjaq8lqy/5JK+4uJhZW1tzfzjI6iItLY075saNG0wgELBbt24plDdkyBC2bNkyhfPk63DOnDlMLBYr/BETERHB5syZo/A+65Nknjhxgjtm3bp1DADLyclRuHZERITaemCMsUmTJrEBAwao3VdaWsosLCzYDz/8wG2rqqpi7u7ubP369QpxaEoyhwwZwj788EOFcr///nvWtm1bxhhjR48eZXw+n2VmZqqNQd3nQpfvw6RJk9iIESMU9k+YMIGSTEJMgPpkEo0GDx6MLVu2oKysDJs2bYJQKMTYsWMBANnZ2SgvL8dzzz2ncE5VVRV69eplkOv36dNHZZu3tzdatWrFvW7bti3u3LmjsQyJRIIPP/wQv/zyC27duoWqqipUVlZCLBYDAAICAjBkyBD4+/sjIiICQ4cOxbhx4+Do6KixzLi4OGzbtg15eXl48uQJqqqqEBgYaJD3WFpaijVr1uDgwYMoKChATU0Nnjx5gry8PABAWloaBAIBwsLC6nU9AEhPT4dQKERISAi3rXXr1vD19UV6ejq3TSwWo2PHjtzruuo6PT0doaGh4PF43LYBAwagtLQU+fn58PT0rHfMMj179uS+5vF4cHNz42K6ePEisrOzFT4fAFBRUYGcnByt5YaGhnJfOzk5qdSFpaWlwrUvX74MiUSCLl26KJRTWVmJ1q1bc6+V69DV1RXe3t6wtbVV2KatXnUlH5+rqyvEYjF8fHwUtp09e1bj+WlpaRg/frzafTk5OaiursaAAQO4bRYWFggODlaoJ20uXryI06dP44MPPuC2SSQSVFRUoLy8HGlpaWjXrp1KnWqjy/chPT0do0ePVtgfGhqKI0eO6HwdQkj9UJJJNLKxsUGnTp0AANu2bUNAQAC++eYbzJw5E6WlpQCAgwcPwsPDQ+E8kUiktVw+nw/GmMK26upqtddXpjz4h8fjQSqVarzWhg0b8NlnnyE2Nhb+/v6wsbHBokWLUFVVBQAQCAQ4fvw4/vjjDxw7dgybN2/Gu+++i+TkZHTo0EGlvJ9//hlLlizBp59+itDQULRq1QobNmxAcnKy1vesifJ7XLJkCY4fP45PPvkEnTp1grW1NcaNG8fFa21tXa/r1Ie6ulb+vpmatu9/aWkpgoKC8MMPP6ic19DBNNbW1grJc2lpKQQCAVJTUyEQCBSOlU8g1cWrz2dYNrhIvt7V/awoX0vf6wDG/2yVlpYiJiYGY8aMUdlnZWVVr+vr+n0ghJgHJZlEJ3w+H8uXL0d0dDQmT56sMABCU6uapaUlACgMagBqf+HLDyApKSlBbm6uUeI+ffo0Ro0ahZdffhlA7WClrKwsdOvWjTuGx+NhwIABGDBgAFatWgUvLy/s2bMH0dHRasvr378/5s+fz22rq5VM33inTZvGtbyUlpYqDFzx9/eHVCrFyZMnER4ernK+pjqX5+fnh5qaGiQnJ3OjvIuLi5GZmalQL/ry8/PDr7/+CsYYl5CdPn0arVq10jiqXh1LS0ut8WvSu3dv7NixAy4uLrCzs9Pr3D///JNraX3w4AGysrLg5+en8fhevXpBIpHgzp07+L//+z+9Y9WVLDkuKCjgnhDoM7eoPnr27ImEhATExMSo7OvYsSMsLS1x+vRpeHl5AahNdlNSUnSef7V3797IzMzk/nBVd/38/HxkZWWpbc1U97nQ5fvg5+en8kfgn3/+qVPMhJCGodHlRGfjx4+HQCBAXFwcWrVqhSVLluDNN9/Et99+i5ycHJw/fx6bN2/Gt99+CwDw8vICj8fDgQMHcPfuXa7189lnn8X333+P//3vf7h8+TKioqJUWiEMpXPnzlxLZXp6OubMmYOioiJuf3JyMj788EOcO3cOeXl52L17N+7evasxwejcuTPOnTuHo0ePIisrCytXrtR7hG1d8e7evRtpaWm4ePEiJk+erND65O3tjaioKMyYMQN79+5Fbm4uEhMT8csvvwDQXOfK1xg1ahRmzZqFU6dO4eLFi3j55Zfh4eGBUaNG1Tv2+fPn4+bNm3jttdeQkZGBffv2YfXq1YiOjtZruh9vb2+UlpYiISEB9+7dq3NEtMyUKVPg7OyMUaNG4X//+x9XN6+//jry8/O1nrt27VokJCTgr7/+wrRp0+Ds7Kx10vwuXbpgypQpmDp1Knbv3o3c3FycPXsW69atw8GDB3V+r3WxtrZGv3798NFHHyE9PR0nT57EihUrDFa+vGXLliElJQXz58/HpUuXkJGRgS1btuDevXuwsbHBvHnz8NZbb+HIkSO4evUqZs2ahfLycsycOVOn8letWoXvvvsOMTExuHLlCtLT0/Hzzz9z7ycsLAzPPPMMxo4di+PHjyM3NxeHDx/mHmur+1zo8n14/fXXceTIEXzyySe4du0a/vWvf9GjckJMhJJMojOhUIiFCxdi/fr1KCsrw3vvvYeVK1di3bp18PPzw7Bhw3Dw4EHuMbOHhwdiYmKwdOlSuLq6YuHChQBqf5mFhYXhhRdewPPPP4/IyEiFfmuGtGLFCvTu3RsREREYNGgQ3NzcFJIHOzs7JCUlYcSIEejSpQtWrFiBTz/9FMOHD1db3pw5czBmzBhMmDABISEhKC4uVmjVbKiNGzfC0dER/fv3x4svvoiIiAj07t1b4ZgtW7Zg3LhxmD9/Prp27YpZs2ZxUy5pqnNl8fHxCAoKwgsvvIDQ0FAwxnDo0KEGzUXq4eGBQ4cO4ezZswgICMDcuXMxc+ZMvZOi/v37Y+7cuZgwYQLatGmD9evX63SeWCxGUlISPD09MWbMGPj5+WHmzJmoqKios2Xzo48+whtvvIGgoCAUFhZi//79XKuwJvHx8Zg6dSoWL14MX19fREZGIiUlxSB9T+Vt27YNNTU1CAoKwqJFi/D+++8btHyZLl264NixY7h48SKCg4MRGhqKffv2cXO3fvTRRxg7dixeeeUV9O7dG9nZ2Th69KjW/svyIiIicODAARw7dgx9+/ZFv379sGnTJq5lFAB+/fVX9O3bF5MmTUK3bt3w9ttvc62Xmj4XdX0f+vXrh6+++gqfffYZAgICcOzYMaMl6oQQRTxm7k5WhBBiJomJiRg8eDAePHhAq8kQQoiBUUsmIYQQQggxOEoyCSGEEEKIwdHjckIIIYQQYnDUkkkIIYQQQgyOkkxCCCGEEGJwlGQSQgghhBCDoySTEEIIIYQYHCWZhBBCCCHE4CjJJIQQQgghBkdJJiGEEEIIMThKMgkhhBBCiMH9P8nYwa/b82ABAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Histograms of all five labels on identical bins and a log count axis."
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ret_to_expiry: mean -0.0487, std 1.0369, share positive 58.5%, 9,156 beyond the axis\n",
+      "fwd_ret_5d: mean +0.0044, std 0.2507, share positive 64.8%, 246 beyond the axis\n",
+      "fwd_ret_10d: mean +0.0552, std 0.3547, share positive 68.7%, 493 beyond the axis\n",
+      "fwd_ret_dh_5d: mean +0.0003, std 0.1643, share positive 59.6%, 37 beyond the axis\n",
+      "fwd_ret_dh_10d: mean +0.0159, std 0.2182, share positive 61.4%, 109 beyond the axis\n"
+     ]
+    }
+   ],
    "source": [
-    "underlying_close = load_sp500_daily_bars().select(\n",
-    "    [\n",
-    "        pl.col(\"symbol\"),\n",
-    "        pl.col(\"timestamp\").alias(\"expiration\"),\n",
-    "        pl.col(\"close\").alias(\"underlying_close_at_expiry\"),\n",
-    "    ]\n",
+    "bins = np.linspace(-2.0, 1.0, 121)\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for name in LABEL_NAMES:\n",
+    "    series = dev[name][name]\n",
+    "    label = f\"{name}, std {series.std():.2f}\"\n",
+    "    ax.hist(series.to_numpy(), bins=bins, histtype=\"step\", label=label, **STYLES[name])\n",
+    "ax.axvline(0, color=COLORS[\"neutral\"], linestyle=\"--\", lw=0.8)\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_ylim(top=ax.get_ylim()[1] * 40)\n",
+    "ax.set_xlabel(\"Return as a fraction of the premium collected\")\n",
+    "ax.set_ylabel(\"Trades per bin, log scale\")\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Carrying to expiration keeps a loss tail the early exits truncate\",\n",
+    "    subtitle=\"Identical bins, development window; trades beyond the axis are counted below\",\n",
     ")\n",
+    "ax.legend(loc=\"upper left\", frameon=False, fontsize=7)\n",
+    "show_with_alt(fig, \"Histograms of all five labels on identical bins and a log count axis.\")\n",
     "\n",
-    "htm_label = (\n",
-    "    contract_returns.join(underlying_close, on=[\"symbol\", \"expiration\"], how=\"inner\")\n",
-    "    .with_columns(\n",
-    "        (pl.col(\"underlying_close_at_expiry\") - pl.col(\"strike\"))\n",
-    "        .abs()\n",
-    "        .alias(\"intrinsic_at_expiry\"),\n",
-    "        ((pl.col(\"expiration\") - pl.col(\"feature_date\")).dt.total_days()).alias(\"dte_calendar\"),\n",
-    "    )\n",
-    "    .with_columns(\n",
-    "        (\n",
-    "            (pl.col(\"entry_straddle_mid\") - pl.col(\"intrinsic_at_expiry\"))\n",
-    "            / pl.col(\"entry_straddle_mid\")\n",
-    "        ).alias(\"ret_to_expiry\")\n",
-    "    )\n",
-    "    .select(\n",
-    "        [\n",
-    "            pl.col(\"feature_date\").alias(\"timestamp\"),\n",
-    "            \"symbol\",\n",
-    "            pl.lit(INSTRUMENT_ID).alias(\"instrument_id\"),\n",
-    "            \"ret_to_expiry\",\n",
-    "            pl.col(\"dte_calendar\").cast(pl.Int32),\n",
-    "        ]\n",
-    "    )\n",
-    "    .drop_nulls(subset=[\"ret_to_expiry\"])\n",
-    ")\n",
-    "\n",
-    "htm_labels = {\"ret_to_expiry\": htm_label}"
+    "for name, frame in dev.items():\n",
+    "    beyond = frame.filter(~pl.col(name).is_between(bins[0], bins[-1])).height\n",
+    "    print(\n",
+    "        f\"{name}: mean {frame[name].mean():+.4f}, std {frame[name].std():.4f}, \"\n",
+    "        f\"share positive {(frame[name] > 0).mean():.1%}, {beyond:,} beyond the axis\"\n",
+    "    )"
    ]
   },
   {
@@ -582,72 +845,290 @@
    "id": "65b5875f",
    "metadata": {},
    "source": [
-    "The summary confirms the available expiration coverage and the label's\n",
-    "return and horizon distribution."
+    "Chapter 7.2 asks for the base rate to be tracked through time. For a continuous label\n",
+    "ranked across a cross-section, the quantity that has to be stable is the spread the model\n",
+    "ranks within: where it is not, the same rank correlation buys a different amount of\n",
+    "return. The spread is taken across names on each session first and only then averaged over\n",
+    "the year. Pooling every name-session in a year into one standard deviation instead adds\n",
+    "the movement of the panel's own mean from session to session to the spread across names on\n",
+    "a session, and a ranking model is scored on the second alone."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "b7892539",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:52.029337Z",
-     "iopub.status.busy": "2026-07-21T06:54:52.029207Z",
-     "iopub.status.idle": "2026-07-21T06:54:52.043682Z",
-     "shell.execute_reply": "2026-07-21T06:54:52.043254Z"
+     "iopub.execute_input": "2026-07-31T07:12:54.730011Z",
+     "iopub.status.busy": "2026-07-31T07:12:54.729352Z",
+     "iopub.status.idle": "2026-07-31T07:12:55.129824Z",
+     "shell.execute_reply": "2026-07-31T07:12:55.127758Z"
     }
    },
    "outputs": [
     {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAu8AAAEqCAYAAAClTr7LAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAex1JREFUeJzt3XVYFNsbB/Dv0iDSISiCioGFCopgK4peu+sqYrfiz+LqNa7d2N2JfU0M7FbswkJBJUQEpGGZ3x9cRlZycVHR7+d5eB72TL2zZ2fm3dlzzkgEQRBAREREREQ/PaUfHQAREREREeUOk3ciIiIiogKCyTsRERERUQHB5J2IiIiIqIBg8k5EREREVEAweSciIiIiKiDkTt7j4uIQGxsrvn7z5g08PT1x8uRJhQZGRERERESy5E7eW7dujS1btgAAIiIi4ODggAULFqB169ZYuXKlwgMkIiIiIqJUcifvt2/fRp06dQAAe/fuhampKd68eYMtW7ZgyZIlCg+QiIiIiIhSyZ28x8bGonDhwgCAkydPol27dlBSUkLNmjXx5s0bhQf4M7hw+QYKmdqgkKkN+g/3+NHh/HL6D/cQ398Ll2/86HC+K0V8tgrS57Np255irG8C3v3ocLKUlzjfBLwTl2natmeO82/ddUCcf8a8Zd8asoyC9JnISdp+2Ng3ynFeeeuAFO9nqwN5Pj/fW0E5H9LPR0XeBaytrXHw4EG0bdsWJ06cgLu7OwAgNDQUOjo6Cg8wP9jYN0JA4PtczXt8/+Z8joaICoqtuw4gIDD1Ijukf0/o6RaMc973xvfp18b6pfy0bPVmREZ9BgBMGDP0B0fzc5I7eZ80aRK6desGd3d3NGrUCI6OjgBS78JXrVpV4QESEX1v82dMRNTn1ItHEVNjsXy71wFcvHITAPBn57bflLS4NKqLU4e2AQAsipp9Q7QZ2VayEddtYmyo0HXnhiLfJ/r5sH4pPy1fu0W8wcrkPXNyJ+8dOnRA7dq1ERQUBFtbW7G8UaNGaNu2rUKDyy/b1y1GfEKC+PrPviMREhoGAJg/YwJsK9mI0yrYlMG9B0++e4zfW2JiIpSUlKCiIvdHgn4RMTGxKFRI60eH8VOoWL5Mvm/DxNgw3xJrXZ3CcHKwy5d10/cRGxsHLS3NHx0GESmAoq+veRrnvUiRIqhatSqUlL4sXqNGDZQrV05hgeWnalUqwsnBTvxTV1cTp1WwKSMzTVencIblz1+6jvrNOsOguC3KVmuIFWu3ZpgnOiYGM+Ytg33dljC0rIIipezRtG1PnPC5kKsYU1JSMHfRKnH5tG216z4Am7fvFeebMW+Z2GZuy879WLpqEyrWaAKD4rao1bg9fM5flllv+vblJ3wuYPzkOShZqQ4MilfBu/chAICkpCQsWbUJtRq3h7FVNRhbVUO9pp2xc++hDHHOX7IWTdv2ROkq9WFoWQVGVlVhV6cFps7yRGxsXIb5V63fjoo1msDQsgrqunTCuYvXcvV+pImJicWIsVNQu0kHWFWoDb1ilWFmXR0N/ugi875k5+u2xqs3bIeNfSMYW1VD22798fZdEOLjEzB6wkwUt3GEaUk79OznjvBPERnWde7iNbTrPgDFbRyhV6wyylRtgP7DPfDi1esM8957+ARN2/aEoWUVlK5SHzPnL0dycnKWcX4IC8e4SbNRuaYL9C0qo2gZB7TrPgA3bt3N5buVORv7RuL+B759j269h8PMujqq12sFALh09Sb+7DsSlWu6wLx0DegVq4xSleuiRz93PHjkJ7Ourz9/y1ZvRiWH1HgdGrTJVf2+DwpBObuGKGRqg8JmFbB990EAqW1new0cjVKV60K3aCWYl64BuzotMGDEXxni+Fqtxu1RyNQGesUqIy4uHgDw0v9Npm3Me/ZzF8ufPnsJIGNb1LQ25Gl3GwGgfHXnbNur3n/0FH+0d4ORVVWUqFgHU2d5IiUlRZyeVZv39Nt+8MgP//OYDsvytWBoWQVtuvYXmytkJ6s27x/DP2H4mCkoZ9cQesUqw7SkHWwdm8J1wP9w8UrO/U0uXL6B5h3cUKxsTegWrQTL8k6o69IJoyfMRGTU51y/T+Mnz0HD5l1RslId6FtUhkkJOzg5t4Pnig3ZHhNvAt6hU88hMC1ph+I2jnAf/w9iYmKznD+9bz0nvw8KwcARE+DQoA2K2zhCt2glFCtbE83a9cLhY6czXWb3/qNo1tYVRcs4QN+iMmzsG6HPkLFik4CvPwPrNu9CFadm0C1aCfsOeYvrOXD4BJq1dYV56RrQt6iMCtUbY5THNASFhMpsL7f1m9djKz+OA0C+a05Wwj5+Qt+h42BmXR3mpWug79BxCPv4Kcv5c7PNpKQkFLdxRCFTG1iUq5nhs1nFqRkKmdrAoLgtPkVEiuVHjvugeQc3sd6rODXDzPnLxXNRbuS2ztNf033OX8Y/sxfD2rYeDC2roEnrP3Hn/iOZ+dOfX+7ce4Teg8fCtKQdSlSsgxnzlkEQBDx45IdmbV1haFklyxxHnjpL3+/gxavX6NhjMExK2KFY2ZoYPmYK4uNTb6amHQ/pmzWnLVvI1CbDetP8M3uxzHUoveVrtojTFq/cKJbn9voqT87xdX+PS1dvosEfXWBoWQXuHtMApB4PnXoOgWX5WtAtWgkW5WqiZsO2GD5mCgLf5q45N5CHO+8xMTGYPXs2fHx8EBoamuEgfPXqlbyrLFCu3bgNr31HxIP47bsgjJk4E+XKlELDek4AgMioz2jc6k88evJMXC4eCbh45SYuXrmJRbP/Rn+3btluZ67nKkybs1Sm7O27ILx9F4SoqGi4du+QYZlFy9bh2Qt/8fXd+4/RvvsgHN27AbVq2meY/38e0+H/JlCmLCkpCW269s+QdN26cx99h9zHoyfPMP3v0WL5dq8DMtsEgKfPXuLps5e4dvMuju/fJJZ7rtiACVPnia997z5Am679UapE8WzeCVmfY2KwbrNXhphv+N7DDd97eB8cAo//Dcn1+nbtPYxXrwPE1yd9LqL9n4NQwrIYDh/3Ecv3HfKGiqoqNqyYK5at2bgDozymQxAEsezd+2Bs9zqIQ0dP4ejejbCrWglAauLYrK2reNF+HxSCGfOWoWL5spnGFfj2PRq17I5374PFssTEJJw4fQFnzl/F9nWeaN60Ya73MyvN2vUSPwN6eqk/fV+7eRcHDp+QmS845AP2H/KG96nzuHhyD8qVKZVhXXMXrZL5PD187IcuvYbiia8P9PV0M93+p4hItOrcF4FvgyCRSLBk7mR079QGycnJaN2lL56/fC3OGxn1GZFRn/H02Us4Vq+KShUyf+8AwMnBDnfvP0ZSUhLu3H8EJwc7XE93Upb53/ceAMDI0CDT/cqLV68D0bhld0T/l1jGxcVjrudqWFoURa8/O+Z6PV3dhsm8p6fOXETvwWNx+vD2PMXVo98onL/05dhOSkrCi1dv8OLVG5S0skAdpxpZLvvshT/adR8gk4CEffyEsI+f4Hv3AQb17Z7rONZs3IGEhETxdWJiEu49eIJ7D57gqd9LrFo8I8My0dExaNz6T/GYiI6JxZqNO+H/5i0O7lyT7fYUcU5++y4IW3fJJgafIiJx4fJ1XLh8HWuWzkL3Tm3EaYNGTsiQSAQEvkdA4HtMGjciw42hnXsOZTgfA8DEafOxaNl6mbLXAW+xesMOHDxyEmeO7ISVZTEAuavfbz225JGb40Dea05mEhMT0apzH5lfyXfuOZTlF5HcblNVVRVtW7pg3WYvhH+KxPnL19GoXi0AwINHfuJ76NKorniOmzZnCWYvlB02+/nL15gxbxnOXbyKI3s2QE1NDdmRp87TG/3XDJnr8eVrvvijXS9cOLEbpUuVyDB/z/6jxOtfdEwsZs5fjk+fIrFz7yFEREYByDzHyWudRUREoWHzrvgYHgEAiIkF1m/xgqGBHiZ7jMz2PclOjy7tMNdzNQRBgNe+w+jZtZ047eiJswAAJSUldGzzBwD5rq95zTlevHqD1l36iV9MgNQv1y079kHYx3CxLPxTJMI/ReLBo6do06IJLIqZ52qf5b7z3rdvX6xfvx516tTB0KFDMWLECJm/X91L/wA0da6HvVtXoMN/HwQA2LB1t/j/1Fme4kXCxbku9m1fhbXLZsPUxAgAMG7SbLx9F5Ttdo54nwEA6OnqYP3yuTiyZwPWLpuNvq6dZdrgfh3b3+OGYd+2lXBuUBtA6ods7N+zMp3f/00gBvXtgYO71mLpvKnQ1tbC8rVbxQOyhp0tdm1ciu3rF6OMdeqBv2jZetz8L9kBgD49O2Pd8jnYv2M1vA9sxp4tK+DiXBcAcOHydVy7eQdA6kVu+twvX0YG9fkT+7avQvvWTcW7nbmhpamJv8cNw9a1i3Bo9zoc378Zm1cvgHVJSwCA5/INSExMzGEtX7x6HQD3oX2we/NymJuZAkhNOo+fOo+ZU8Zi48r50NTUAADsPXhMTL7fvgvCuEmzIQgClJSUMM59IPZtX4V2rZoCAD5Hx2DACA8xsf9n9hJxWdtKNvDatAwLZk7EK/+Ar0MCAIwc9494YunWqTUO7lqLxXMnQ7uQFpKSkjDIfUKu7zhmJ/TDR8yeOg6Hdq/DmOEDAAD2VSthwcyJ2LNlBY7v34zDu9dj2t//AwDExsVh2erMO3H7vwnEqKF9sWfLClSqUE58H3bvP5Lp/HHx8ejw5yA88XsBAJg7zQNuPToBAPyevxIvjA3qOuLgrrXYt20lFsyciCaN6kBNPfuLX23HL19W0xL19HdUbt2+j5SUFLwPChGPRSeHalmuL60NeeWKX+7+bFvniVOHtuHUoW0Zjsl374NRqUI57N68HIP69hDL16c7T+RG2MdwLJk3BeuXzxXbFV+9cRuPnz6Xaz1Aal1cuHxd3J89W1bgwM41WDJvCtq0aAItrex/0j1z/oqYuA/u1wNH927E9vWLMXn8CFSrUhESiSTX79PYkQOwadV8HNy1Ft4HNmPnxiWoXq1y6vxeB2QuqmnCP0XCxNhQPHa0NFOblJw6cxHH/rtAZ0UR52RTE2P8M3EUdmxYjCN7NuD4/s1Ys3QWjAwNAKR+eU1z8MhJMXFXVlbGiMG9sX/HaqxdNhsN6zlBIsm4fv83gXBuUBtem5Zh69pFKF/WGjd974lJnIaGOmZOGYs9W1agbi0HAEBIaBhGjv8HQO7r91uOrfw4DuS95mRm664DYuJuaKCHlZ4zsG2dZ5bnSHm22aVDK3G5g4e/PIzy4JEvNzi6dGgJAPC980BM3IuYGmPFouk4uGstmjrXA5CaTC/N4vyZRp46/9rbd8GYN/0veG1ahmpVKgIAoj5HY/KMRZnO/zk6BptWzceUv9zFspXrt8HUxAi7Ni5Fv15dxPINCqizqM/RMDI0wI4NizFp3PAM607rB5R2XAIQP1tpfXgyU8LKQnx/Lly+gaDg1F8nIiKjcOW6LwCgVk078Rovz/U1rzlHUHAoipqZYv3yudi/YzVaNm2EG7fuiol7x7bNcXj3enhtWoaZU8aijlN1KCsrZ7mPX5P7zvvx48dx9OhR1KpVS95FfwnGRobYsmYh1NXVUK1KJew9eAxAauIMpDZ32b3/KABATU0Vwwb0grq6GnQKa6N188ZYs3EnEhOTsO+QN0YMcstyO6r/tT3X0tJESSsLVCxfFlpamujWsXWWy3Ro8wfGjxoMAHB0sIN15XqIjYvD3fuP8fZdEIp91SmuU7sWmD/jL5myXXsPi/8PG9gLhob6AIDO7VuIvwTs2nsY1e1S+zs0rOeEOYtW4eqN2wj98BFJSUky67t99yFqVq8qc+G3q1IJ82dOAAA0blAbl6/dQuDb7C+caXQKa8O2og1WrNuG+w+f4FNEFKRSqTg9OiYWfs/9c33nqGb1quIdAp/zl7F6ww4AQMe2f4j147XvMLxPn4dUKsWbwHeoXKEcDhw+gcTE1H1t9YczJo1P/eLaqJ4TLl+7hZDQMDzxe4n7j56iUvmy8D51Ttzm+uVzYVPWGgAQEvoBcz1Xy8QU/ilC/Cnf1MQIbv/doSpfrjQa1nPCoWOn8TE8AqfOXkKbFk1ytZ9ZmfPPODFhTlPDzhZXrvtiw9bd8H8diNg42eZPt+89zHRdLZo2kknyXQek/v8yiy8o/YaNx+27qeua9vf/MLjfl4u7qqqq+H8RU2NYl7CEZfGiUFJSwsA+Od/hdXL4krynJe3Xb6VeTGzKWuOJ3ws88XsBv+ev0i2TdRvxtDbkujraYlk124qwLF400/nV1FSxff1imJoYoVmT+ti8fS9i4+Ky/LKWlYljh6FPz84AgKs3fMU7QK/8A1C+XGm51qWirAyJRAJBEGBooI+SJYrDuqQlVFRUxG1kR1X1y+XCqngxlCtbCkVM/kvG3QeK03LzPtWrXROeyzfg5u17+BgeIdMcQRAE3L3/GEXNi2SIYfPqBShVIvWimf7YOXz8NP5waZBp3Io6J1sWLwpTE2MsX7MFj548R2TUZ5lf3V68eoOoz9HQKayNnXu+NB1wH9IHUyd8SY6yOocXtzDHvm0rZfodjZ4wU/y/v1s3Mb4a9lVQpmp9JCQk4vTZSwj/FAFNDY1c1e+3HFv5cRzIe83JzBHvL7+SThw7TLzzqqtTGC079ckwvzzbrFm9KqyKF8PrgLc4fNwHnnMmQVlZGQePpCbyero6aOpcP3WZfV/W26NLO5QuZQUA6OvaGd6nz4vr/d+wflnui9d/n1Ug5zo30NeTWXbogJ7iebRc2VKwdWwGADjhcwFJSUkydQ8Ak8cPR8e2zQEA8xevFn8hWTjrb9SvUxOODnZYu2kXANnz+LfU2cZV82Fb0QatmwNe+4/A7/krhH38hMioz2I/oPRNmXPbd8e1W3ucv3QNKSkp2HPwGIYP7IVTZy6KOUnafsp7fc1rzqGkpIS921aJX2gA4NTZS+L/xYoWQRnrEihqXgQSiSTbc09m5E7e9fX1YWBgIO9iv4wadrbiB8vQQE8sj/zvJ6awj5/Etm+JiUlo0bF3puvxy+Fus2u39qk/yQSFoEHzrpBIJChhaYH6dWpi+KBemf4ElnbnCkg9aZW2thLvRvi/CcyQvP/RpH6GdaRvq92jn3uG6QDw9Hlq7AGB79CoRTdEfY7Ocj8io6L+2/5bscyuakXxf2VlZVStXCHXyfu/R0+iW+/sf+FJ22ZupDVrASDTtKOa7ZcY005MwJd6Tv8+2ad731VVVWFbyQYnfS6mzvfyNUxNjMSTYiEtLTFxBwD7ql+WTfPKP0BMCkJCw9C41Z+Zxp7TZyg3mmWS8PQaOBpHT5zJcpnIyM+Zlqe/253+opL2i8PX0hL3jm2bY9TQvjLTrEtaolZNO1y+5oudew5h555D0NTUQKXyZdGqeWMM7ttD5gT/NWMjA5QtXRJ+z1/h+q27iI6JwaMnz2BRzAytmzfGE78XuH7zrvhZBpBp07K8KmNdUrx7pKSkBD09HcTGxYk/RedWbafq4v/p39OILN7T7GhqaqBj2+bw2ncYZ85fgV2dFlBVVYVNWWv80aQ+hg9yy7SPT5rmTRti6ixPfAyPwNi/Z2Hs37Ogr6cL+2qV0bNrO/FXp5zcun0fzdr1yvBFP72ITI5hA31dMXEHZI+d1+nOL19T1Dl56apNGD95TrbzREZGQaewtsz5oVkm59nMNG5QJ8OAAenXk/78bmSojxKWFnj67CUEQcAr/wDYV6ucq/r91mNLHrk5DuS55mQlff3bVflyTk9/bk5Pnm1KJBJ0atcccz1X40PYR1y6egsmxobiL8ZtWjQR36/06523eDXmLV6dYb1fNzPNLrac6vzr5L16tS/JsnVJK+jr6eJTRCTi4xMQFByK4hayX7Ls0q1fT09XvE6l3bU3yuTa93WM8tRZWiKcRuY6ERmV7fknJ62bN4aerg4iIqPgte8whg/sJTaZUVVVFW90yXt9zWvOYV3SUiZxB4BaDnawLmmJF6/eYNGy9Vi0bD0KaxdClcrl0bldC7h27yDTlzQ7cjebmTZtGiZNmoTY2G//yb4gSmsXDEDmRCtAyGz2LMVk0pkzvV5/dsSBnWvQtWMrlC9XGmpqqnj1OgAbtu6GS5ueuUoCJJn9NpuOibFRttOzktYRdfvug2Li7mBfBV6bluHUoW1wH/rlTkdKSs7vS05xprdq/Q7x/z+7tMWh3etw6tA2sS1ebreZJv3JIv1BU7iwdmazQ8jFquXZH3nm/VpOn6HcMP3qMxD49r2YuGsX0oLnnEnwPrAZ3ge+/NSbIsj2c0mjl+7Lj8yxkcWblvYT4aFjp3D52i2ZaUpKSti/YzVmTR2Hxg3rwKKYGeLi4nHD9x4m/jMfYybOzGyVMtKS8ZDQMOz71xtSqRQOdlVQw74KAOC6713xrrx2IS2ZUaa+lX668wQAqKjk/udQmfXoyvee5mT14hlYOm8qmrs0REmr4pBKpbj/8AlmL1yJnv1HZbtsERNjXDq5F6OG9oWTgx0MDfTwKSISp85cRI9+7thz4Gi2y6dZt9lLTNybNa6P/TtW49ShbejW6csdaUWfN3Ijp+Np1fov/Qzch/bB0b0bcerQNlSw+TIykTznnq/JO/JQZrufm/pVxLGVW4o6DjIb/CA3vuUzkn6bMk1njpyQaTLTuX1LudabnJws099DHvLuTk7z6xZOf/37MrNOJtc/eXOczOpML5vPQx5PaSINDXV0bt8CQGp/v4ePn+HUmdSbaI3qOcHQQD+7xTNIOx/kNefI7HjW0tLE6cM78Pe4YahXuyZMTYzwOToGF6/cxNDRk7Hwq34O2ZH7zvuCBQvw8uVLmJqawsrKKsPPMLdv35Z3lb8UI0N98duudiEtvHxwAdqFCsnMk5KSIja5yIogCGjSsA6aNKwDIPWA/2vqPCxfswUhoWG4dvOO2I4uza0798X/I6M+4/mL1+LrEpYWGbaR2YnNuqQVHjx6CgB4dONUpp1i0g7K90Ffer2PGdEfzZqk3sVN/5Pal+1/Wc/tu196v0ul0iybYWQmKDhE/H/BzAnQLlQIKSkpMuXfg3VJK/F/3zsPxP+TkpJkOk1Zl7KCiZEhCmlpISY2FjGxsXj67KXYMfLm7YztAkuWKC7+/F3SqjjuXjmWoS1cdnct5fH1Z+B90Jf30blBbfTr1RUAvnmEm8zMnDwGHlPmIiEhEZ1dh+L04e3i+yIIArQLFcLwgb0wfGAvAKmjA9Rv1hmvA97i36OnsGTelGzX71TTTmxLmdZOv4Z9FdSws4VEIsHFyzfEkRscqlfNVXtDieTLF7yvO+sXBCoqKujdsxN690xtKhX1ORptu/bHtZt34HPucrbDmQmCgOIWRcWmUUDqryd1XFJ/dj507LT403R279P7dMfq1AnuYvI7J12b8cyEf4rES/834t339MdOZuepNIo6J6fFbWigJza1i4mJzfTcY13SSrwz633qPGpWz/kZKFmdj9MSkFt3Hoi/bnwM/4RXrwPF5Ur+1+k/N/WrpaX5zceWIo8Dea45WbGyLCbe0b5976H4i2pWbeXl3WbZ0iVRpXJ53L3/GP8ePSUmgsWKmqFOul/HrEtaib+6rlo8Ez26ZBw+OzY2LttfNuSt8/Ru3bkvNh976f8G4Z9Sf3HS0FCHWRGTLLcpL0XUWXaUvvp85fZudM9u7cWmryPHTRVvcqadlwD5r695zTkyO54FQYCxkQHGjxqM8f/dK3n95i0cGrRGdEwsDh09hdHDs25SlZ7cyXubNm3kXeS3oqSkhI5t/8CajTsRHROLVp36YlDfP2FooI93QSF4/PQ5Dh09hZWeM1C3VtYjO3TvMwLa2oVQy8EO5uZFIE1Oxp17X5LezDpI7DlwDGWtS6JyJRus3rAdMf/9OmJbySZDk5msdG7fQjwoO/QYiJFD+qKomSmCQz/g2fNXOOJ9BsMHuaFHl7Yonq5X9Ip126CqpoZbt+9h8459GdbbsJ4TNDTUER+fgFt37mPMxJlwblAbew8ey3WTGQCwKGYudraaNmcpnBvUxs49h/DE79ubkMijbUsX/D19IZKSkvDv0VOYPncpqtvZYofXQQSHfAAA2JQthcoVykEikaBZ43rY++9xAEDfoeMw3n0Q3geHYPmajENwGejroUmjOjhx+gJevQ5Ax56D4dqtPbS1CyEw8D3uPXyCf4+ewtmju7Jsa5pX6X9WPX/pOnbvPwplZSVMmemp0O0AQMtmzkiWSjFh6jx8iohEm679cPbYLpiZmuB9UAhadOyNdq2aolyZUjAxNsLrgLdiZ5/cdEquna4ZTFoHTwf7KtDX00UZ6xIy7d1r5bJdZfo7iRu37YGLc11oamiIPzP/7CrWaILWLZqgUoWyMDM1wYewj3gdkNrkQBAEJCQmZpm8795/FOu37EKLZs6wKl4UOoULy4xskv5uYnbvU/rzxvwla9G9cxuc9LmA0+nag2bFbeAYjHMfiHdBwTLHToumjbJcRlHn5OLFzPHi1Rt8DI/A/CVrUbF8GaxYu1VMkNLr0qGl2A570fL1SJYmo24tB4SHR2DXvsNYMndyhiYMmenU9g+sXJe6n6s3bIeZqTGsS1pi2Zot4vvt3KC22PwgN/UbERn1zceWIo8Dea45WWnu0lBMmqfPXQoNDQ1oF9LC5BkLFbbNLu1b4u79xwgJDROfC9OpbXOZJK1zuxbisIrjJ83Gp4hIVLQpg8ioz3j1OgA+566geDHzTEdTSiNvnae3bPUWmBgbwaKomUxfqiYN62S40fotFFFn2dHT0wH+a2K/ct02VLWtAJ3ChXN8/kaVSuVhW8kG9x48wdUbqTeSNTU10KLZl5HZ5L2+KjLnuHbzDkZPmIE2zZugVElLGBro4+FjP8T+1x8wQY7BNuRO3idPnizvIr+dyR4jcfmaLx49eYbrt+7KDEuXW5FRn/Hv0VPY7nUwwzQTYyPUq10zQ7lNWWtMnb1YpkxFRQWzp47P9XaH9OuB02cv4dzFa3ji9xID0o0R/bUuHVpirudqxMbF4cz5Kzhz/goAwLFGNfHASaOvp4u/Rg/BpOmpJ9MVa7dixdqtUFJSQglLi0yHSMtM7x6dxO0sW70Zy1ZvhoaGOqraVpD5cpPfihU1w9xp4zHKYzpSUlIwa8EKmemFtQth9eJZ4on97/HDcfLMRUR9jsade4/QuVfqU+PS2r99bfGcyeJQVidOX8CJ07kbi/pbmRUxQVPnevA+fR6fIiLhNij1DqNjjWoyQ2oqysjBvfH8hT82bd+LwLdBaNt1AE7+m3rhevbCP8OQa2nS30nJikUxc1gUMxO/HGpoqItNY2rYVZHtrFozd8l73VoO+PfoKQDAgqVrsWDpWhS3MMeTWz45LPlzCHwXhMUrNmQ6LauEIE2KkILL13xx+ZpvptM7tv0y+lZ271Ov7h2wafteCIKA3fuPYPf+I5BIJHCwr5LtuVJXpzDeBL5DJ1fZYdka1nPKsrNqGkWck916dBKHuk1LCo0M9VHGukSGdsxtW7qge+c22O51EMnJyWL71jS5bSJQw74K3If2waJl6xEfn5Chzb2piRE8Z08SX+emft/FBX/zsaXI40Cea05WenZth3WbvfDg0VOEffyEgSNSB2JIGxFEEdvs0PYPTPhnvkxnxa+bzNhXq4zxowZh9sKViIiMgkcmfSS6d26T7XbkrfP0SlhZ4H9/TZcp0y6kJTOajCIoos6yU7eWA+7efwwA4mh5dZyqw/vAlhyXde3WHqM8vrwHfzSun+GXNnmur4rMOdI646ft29dyc+ylydNDmgDA19cX27Ztw7Zt23Dnzp28ruaXpKerg7NHd2LSuOGoVKEcNDU1oKWpCeuSlmjb0gWbVs1HjWx6zgNAf7eu6NC6GUpaFYd2IS2oqKjA3MwUndu3xOnD2zLt2DF0gCsWzpqIklbFoaaW2nFy77aV2d5N+pqamhr+3bUW82dMgH3VyiisXQgaGuqwKl4MTZ3rYcWi6Wj1hzOA1OTo0O51sK9aGZqaGihpVRyecyZlOgY9APxvWD/Mm/4XLC2KQl1dDZUr2mD35mW5TpyA1Ivi0nlTYV3SEhoa6rCrUgkHd66Re+QNRejv1g2Hd69Hk0Z1YKCvCxUVFZgVMUG3Tq1x6dRemc6w1iWtcGz/JtR2tIe6uhpMTYwwamhfzJ85MdN1WxQzx5XT+zFySG+ULV0SGhrqKKxdCGVLl0S3Tq2xZ8sKFCuacTQORVi3fA66d24DI0N96OnqoGvHVtizdUXOC+bR4rmTUb9O6pfRB4+eolvv4dDWLoS/Rg9BHafqKGJqDFVVVWhqaqBi+bKYPH4EFvw3WlFO0ndCrVq5gnj3ycH+y/GnpqYq09ErO316dsKooX1hUcws1z/l/kym/DUSzg1qo6h5Eairq0FdXQ1lrEtg5JDe2LbOM9tlHeyrYHC/HqhSuTyMDPWhrKwMXZ3CqFXTDlvWLJS58GT3PtlXq4xdG5eigk0ZaGiow6asNbat80Sj+tmPYKarWxinDm1D44Z1UEhLCwb6uujr2hk7Ny7JsW2zIs7Jwwa4YvL4EShuYQ4tTU3UdaqBo3s3yQxrl96aJbOwbvkc1HGqDl2dwlBTU4VFMTN0bt8yQ9vf7Ez/ezS2rl2EOk7VoVNYG6qqqrC0KIoBvbvh8ul9Mk0WclO/aTdSvuXYUuRxIM81J7t1HN69Hp3bt4ROYW3oFNZG+1ZNs0z28rJNM1MT1KvtIL6uWL5spneC/x43HPu2rUTjhnVgaKAHVVVVmJuZwsnBDv9MHIWJY4bm+J7IU+fpzZoyFhPGDIW5mSnU1dXg5GCH4/s3o2zpkjluUx6KqLPs/DV6CHr36ASzIiZy91vo3L4lNDTUxdeZJcTyXF8VmXNYl7TCqKF9UcPOFibGRlBRUYF2IS3YVamERbP/xv+G9c15Jf+RCHL2fAoNDUWXLl1w7tw56OnpAQAiIiLQoEED7Nq1C8bGmY9BTvljxrxlmDl/OYCs29gRERHRr6f/cA/xF/rj+zfLdbPuV9WsXS9cuHwdero68H94MceHYhVEcn9lHjZsGD5//oxHjx4hPDwc4eHhePjwIaKiojB8+PCcV0BEREREpCBSqfS/kVtu4IbvXQBA+9bNfsnEHchD8u7t7Y0VK1bAxubLsGrly5fH8uXLcfz4cYUG97PbsH0//prmKb62b9gJfulGePlVdOs3Boe9z/3oMH5rwSFhqPNHD0RH/55DtCrC18cryWfH3qPo7z7lR4fx3U2ZsxwLlm360WEQUTYuX/NFkVL2aNrWFfHxCdDQUMfIIZk/0+FXIHeH1ZSUlEx7LauqqhaoodP6u0/Bg8fPoKqiAomSBKbGRnCsboteXdtkGJs2K727t8vnKIlSFTE1wsVjGUemyS/vg0PRqttQnD20EYW1C+U4v33DTti+Zi7KWlvlf3B5xOOViOjXlvZgshmTRqOkVcbhNH8VcifvDRs2xIgRI7Bz506Ym6cO+fXu3Tu4u7ujUaOsh+v6GQ3r1x3dOjSHIAjwf/MOa7fuxZ8Dx2HLilkyT0/9mU0YMxQT0nWASZZKoZKL8ap/RsnJyRmeMEj5oyB/TvJDslQKZSUlhT/4J7/8zsfK77zv6QmCgJQUAcrKBa/jNCnOmiWzsGbJrB8dxg9Xt1YNxIQ8yXnGX4TcZ8Bly5ahVatWsLKygoVF6oN/AgMDUbFiRWzbtk3hAX4PEokEJa2KYdpfw9Ct31hs23MEIwb8idi4eEycsQQPHj9DYlISypS0wpjhbihTygoAsHrTbjx7+RoLpo2VWd+niCg07zwIezYtQlGz1AcjJCQmommHAVg65y9UtJHtpZyYmIRZnmtx4YovkqXJMDU2wuSxg1ChnDWmzFkOiUSCqM/RuOH7AEXNTTF+RF9UqVQOQOovCBXKWePZi9e498gPMyeOgH3Vili6ZjsuXL2FxMQkOFavgrHDekNbO3X85r9nLsHNO48QFxcPi6JFMHJgD9hX/TI+r9cBb2zZ9S/iExLQrmXjbN+74JAw/DN/JZ69eA2pNAWVK5TBuBF9YP7fAyFSUlKw+6A39vx7Eh/CwmFooIcxw3rDqUYVTJmzHEpKSoiNjcPVm/cwqHcXtGxaH54rt+DC1dTh6OrVsof7wJ7Q1NTI9n26dus+PFdtwfugUGhoqKNB7RrwcM/4sIO0O8pTxw/F2i17EBH5GfVrV8fE/w2AiopKrur8ybNXMDYywMmzl6FbWBuTxg5GdHQMPFdtRWRUNDq0boIhfbqK27zuex/L1+1EwNsgmBgZYEjfbqhXK3UUFHnjTrsTPmXOcqgoKyMmLh6Xr92GkaE+/hrVH/ZVKmRaT/J+TlwHpw619kengQCAv0b1RzPnOpmuu+eg1GHCeg+bCCWJBG7d26J393Z47PcS85dtwqvXgTA20kefP9ujaaPa2X6eAODps1dYtGornr98DZ3C2nDt0hptWzgjOiYW3fuPg1u3NmjTPPVGgftfs6Gnq4PJ4wbjsPc57Nx3FLUcqmL/kdPQ0FBHr65t0LG1i1h36Y9X+4adMGZYb+w7fAqB74IwvP+fOHvpBtYsmiLGcuLMZazbuhd7Ni7KOe7n/pi3dAP837yFkpISalSrhLHD+0BPtzDOXrwBz1Vb8e/2peL8D588x9CxM3Bi3xqoq6ll+znJ7FipUqlcltsDgM/RMZg+fzWu+96HoYEeOrZ2wfxlG3HrTOqDq5KTk7Fu6z4cP30J0TExqFyhLP5y7wdjIwMAwEv/QEybvwqvXgfCpmwplC9bKtv9D3wXjDmL1+Ox3wsU1tZG57ZN0a1DcyQnJ8OlwwDMm/o/VLMtL87f0c1d/EyEf4rEwhWbcfPOQ0gkEjSu54hh/btDTU0Vt+4+wui/52Fo327YuPMADPX1sGVlxmTl7btgLFi+CQ+ePIeGujraNG+E3t3bQklJ6ZvOUwAQFx8Pj2meOR5r5y7fxKIVm3Fw21Lxi+CDx88wwmMWju9ZnWM9X7t5D8vX70TAuyBoqKeeD0YO6gmN/x7q07LrELRr6Yzzl2/h+cvX2LxiFqxL/rp3F4koC0IepKSkCCdPnhSWLFkiLFmyRDh16lReVvND9Rs5Wdi+50iG8uXrdgo9B3kIgiAIn6NjhBNnLguxsXFCfEKCMG/pBqFtj+FCSkqKIAiCsGqjlzBq4hxxWbsGHYWnz/0FQRCEMZPnC6s2eonTjp++KHTs5Z5pLPsOnxK69x8rRH2OFlJSUoTXAe+EoJAPgiAIwuTZywTHJt2E85dvCknJycKef08IDVr1EqI+R4v74dy2j/Dg8XMhJSVFiItPEMZNWSD8Nc1TiPocLcTGxgke/ywSJs5YIm7v32NnhM+fY4SkpCRh885/hYat3YTomFhBEAThhu8DoW6LnsK9h35CYmKSsGzdDqFGo87CoeNnM439XVCIcOnabSE+IUH4HB0jjJ28QBg0+h9x+s59R4VW3YYIj/1eCikpKUJQ8Afh1etAcd+cmnYXrty4I0ilUiEuLl6YMme5MMB9ivApIkr4FBEp9Bs5WZg+f1WO75NLh/7CkRPnBUEQhNjYOOHug6dZxmvXoKPw1zRPITomVgj98FH4o9NAcf9yU+cOjbsIPuevCcnJUmHlhl1Cs44DhCmzlwuxsXHCS/9AwbFJN+GJ30tBEATh2YvXQv2WvYQbvg8EqVQq3Ln/RKjboqfg/+ZdnuJOq/fJs5cJdZv3FG7eeSgkJ0uFtVv2Ci26DM50WUGQ/3Py9fZykv6zLwiCEPU5WmjYurewc98xISkpSbh195FQu9mfwp0HT7Jdz4ePn4SGrd2Ek2cvC8nJUuH5qzeCS4f+wnXf+4IgCMKDx8+Eei1cBf83b4Ude48KbXsMF2Jj4wRBEIRDx88KNRp1Fpat2yEkJiYJ9x76CXWb9xR87z4SBCHz49VtyAQh9MNHISEhUfgUESU4uXQT3r4PEecZMma6sHnnv7l6D/xe+At37j8RkpKShLCPn4S+wycJ0+atFARBEBITk4SGrd1k9n+25zpxek6fk8yOley2JwiCMHHGEmHYuJnC588xwoewcKHHwPGCXYOO4nTPVVuFgaOmCh/CwoXExCRh0YrNQt/hkwRBEISk5GShVbehMu9lg1a9hH4jJ2e670nJyUK7niMEz1VbhfiEBOHZi9eCS4f+wvHTFzPsqyAIwqOnL4S6LXoKcfEJQkpKiuA6+C9h4YrNQlxcvPApIkro7z5FWLF+pyAIgnDzzkOheqNOwoyFq4W4uHghLi4+w/bj4uKFFl0GC9v3HBESE5OEoOAPQke3UcKBoz6CIHz7eSq3x1pScrLQpF1f4eadh2LZ9AWrhdmea3NVz7fvPRaePHslJCdLhcB3wUJ715HCuq37xHW16DJYaNtjuOD/5p2QnCwVEhOTMo2DiH5tefq9TSKRoHHjxhg2bBiGDRsGZ+e8j+f5szExMkDU52gAqQ83aNLACZqaGlBXU8OAXp0Q8DYIH8I+5bie1s0a4tipCxD+G4nzyInzaNm0fqbzqigrIzYuHv5v3kEQBFhamKNIurGD7atWRF0ne6goK6NDqyYw0NfDxatfHpTStGFtVLSxhkQiQVxcPM5cvI5xI/qgsHYhaGpqYKBbZ5w6dwVSaWqfhFbNGkBbO3Xs+J5dWiElRcDz/x4UdNznIpo1qoPKFcpAVVUFA1w7QkNTHVkxL2KCWg5Voa6mBu1CWuj9Zzvcvf9U7P+w99Ap9HPtCJsyJSGRSFDE1Agl0o1RW9O+MhyrV4GSkhLU1FTh7XMJQ/t1g55uYejp6mBIn644evICUlJSsn2fVJSV8fZ9MD5FREFTUwO2FctmWz/9enZAIS1NGBsZwLG6LZ48S31gT27q3KZMSTSs6wBlZSU0aVALoWHhcO3a5r+x7ovBumRxPH2e+tCW/UdOoYVLPVSvVhFKSkqoUqkc6tS0w+n/Hvogb9zpOTlUhX2VClBWVkKrpg0QFPIBEZGfs5xf3s/Jt7h07Tb09XTQpV0zqKiowM62PJo2qo2jJ85nu9yxkxdQtZINGtd3grKyEqxLFEfLpvXh7ZP69M2KNqXh2rU1Rk2ci1UbvTBz4ghoamqIy2toqmOAa0eoqqqgcoUyqds8lfUDOHp2aQVjIwOoqalCT7cw6jrZ48iJcwCA0A/huH3vMf5oUjdX+1ymlBWqVCoHFRUVGBrooXvH5vC9l/owDlVVFTSu74Rj/8WSnJyMU+euoHmTegBy/pwAsseKhoZ6ttuTSlNw6twVDHTrBG1tLRgZ6qNn51biugRBwN5/T8B9cE8YGepDVVUFg/p0wb1HTxEcGoYHj54hIipK5r1sXN8py31/+OQ5wsI/YXDvLlBXU0PpUpbo1MZF7OjevEk9nD5/TXyC4LFTF9Cobk1oqKvhsd9LBL4LwogBf0JDQx16uoXh1q0tvH0ui+tPSREwrF93aGioy4zhnObStdsoXLgQunVoDlVVFRQxNULXds1w4r/Pzbeep3J7rKkoK6O5Sz3xM5SQmIhTZ6+gZdMGuarnqpVtUK50CSgrK6GYuSnatXCG71cPgunQqgmsiptDWVkJqqpsPkT0O8rVkb9kyRL0798fGhoaWLJkSbbzFvThIkPDwqFTWBsAEJ+QCM+VW3D5+h1EfY4WfwaNiIqCibFBtutxrG6LpKRk+N57jOJFzXD73mNMHT8k03n/aFIXYeGfMGvRWoR8CENdJ3uMHNgDerqpHWfNTGUfAmJmaoTQsHDxtWm66e+DQ5GSIqBVN9kHQShJlPAxPAJGhnpYudELp89dRfinSEgkEsTExokXorCPn2R+2lZRUYGRgX6W+/kpIgrzl23E3QdPER2TOhJKYlISYmPjoa2thaCQDyhe1CzL5dN/SfkUEYWkpGSYmX55VkBRc1MkJiUhIvJztu/T/H9GY/32/WjvOgJFTI3h1q1NtslG+j4Nmhoa+BwTAyB3dW6grysuq6Gh9t/60pepi487fh/8AbfuPJQZrUcqlaKQVmpCKG/c6Rmlexqm5n9fsGLj4sRmE1+T53PyrUI+fIR5EdlnPhQ1M8Xt+9m3SQwKCcXlG3dQv2UvsSwlJQVVKn0Z3ap1s4ZYs3kPatpVRrkysg8fMTY0kGkPbWZqjNtZPM0OkP38AalfbGd7rkN/1444euo8HOwrwyiX/V8C3wVj0coteOz3EnFx8alfONPF0rxJXYzwmIXRQ9xw5eZdFNLSFJu/5fQ5ySzW7LYXERmF5GQpTI0Nvyyfrv4jIj8jLj4B/UZOhgRf2vmrqqggJPQjPnz8lOl76R/wLtN9D/0QDmNDA5lksqiZKY6fTn1kfUUbaxga6OHClVtoUMcBJ85cxuzJowAAQcEf8Dk6Bg1bfxkZQoCAlHRfIgtpaWbbcfp98Ae89A+U+dwIgiDu/7eep+Q51lo1bYieg8Zj7PA+uHDlFoqYGolNjnKq50dPX2D5up144R+AhIREJEulsLQwl1n/158DIvr95Cp5X7RoEbp37w4NDQ0sWpR120+JRFKgk/dkqRTnr9xELYeqAIBtuw/jybNXWLfkH5gaG+JzdAwatHLL1aOtlZSU0MKlPo6cOAdLC3PUrG6bZSdYFWVl9O7eDr27t8PH8AhMmL4YazbvxdjhqRezoJAwmfmDQ8NgYvTly4NSuk52piZGUFKSwHvP6kzvUB07dQEnfC5h6ZwJKF7MDBKJBA1auYnP6zYy1Edwuu0lJycjLDzrXxqWrduB+IQEbFs9B/p6OvB78Rrd+4+FgNT1mZkaI/BdMCpXyPgkutTYv/z4o6+nA1VVFQSFfBDfq6DgUKippt4VVVJSyvJ9KlemJOZNHY2UlBScu3QTHv8sQrXK5eXuePwtdZ4ZUxNDdGn3B4b1757pdEXFnRvyfE6Cv/rM5eTrjp6mxoZ4H/xBpux9SChMc/jSa2pshPq1a2DW3yOznGfavJWo42iHO/ef4PzlW2J7YQD48DFcpkNjcGiY2IY707i/ejqkg11lJEul8L33GEdOnMfQvt2yjTe9WYvWongxM0wdPwSFtQvh3KUbmDLny5NpK5UvAz1dHVy85osTZy6jmXMd8X3L6XMCyB4rOW1PT1cHKirKCPnwUfwspa9TXR1taGioY/PymbAqXjTDtu7cf5Lpe5kVE2ODDPMHBX+AidGXLw9/NK6LYycvQENdHRrq6qhW2Ubcd309XZzYuybL9efUkdjUxBA2ZUpi0/IZmU7/1vOUPKyKm6N0KUv4nL+GE2cuo6VLfZk4s6vnCdMXo2XTBlgwbQw0NTWwY+9R8S5+GiWlgtGpmojyT66azfj7+8PQ0FD8P6u/V69e5Wuw+el1wDtMmb08tVNchxYAgJjYOKirqUJHuxBi4+KxfN1OudbZqlkDnL14A/8eO4NWzRpkOd/N2w/h9+I1kqVSaGpqQE1NTWYEgVt3HuLStdtIlkpx4MhphH2MQO2a1TJdl5GBHurVqo45S9YjIjIKABAWHoGzF2+I+6SiogI9XR0kJSVj7Za9iI2NE5d3aVgLx30u4uGT5+L0+LiELGOPiYmFhro6CmtrISLyM9Zu3iMzvV0LZ6zdsgd+L15DEAQEh4TB/83bTNelpKSEpg1rY8X6XYiMikZE5GcsX7cTfzSuAyUlpSzfp6SkZBw9eQFRn6OhpKQk3qFTzsNoKt9a519r16IxDp84h1t3HkIqTUFiYhLuP3oG/zdvFRq3vHL6nOjp6UBJSYK370NytT4DfV28fR8svq7lUBWfIiKx598TSJZKcef+E3ifviQ2E8nKH43r4tadh/C5cA3JyclITk6G34vXePT0BQBg1/5jePM2CFPHDcGkMYMwbf5KfEj3K1R8XALWbd2HpKRkPHzy/L9mYDl3kk2jpJTaLGLh8k2I+hyNOo5fjrP3waGwb9gJ74NDM102OiYWWloaKKSlieDQMGzxOpzJ/tWB1wFvXL52W+a9yO5zkpXstqesrITG9R2xZvMeREfHIiw8Atv2HJHZz/YtG2PRyi1iUh4R+Rknz6Y236hUvjR0C2vLvJenzl1BViqWs4ahvh5WbdyNxMQkvPAPgNeB42jh8mUfmzeui2u+97Fj71GZLy7ly1rD1NgQK9bvQkxsHARBQFDwB1y+fifL7X2tjqMdwj9FYM+/J5CQmAipNAWvA97j1t3UJieKPE/lRutmDbFtz2Hcuf8YfzT+8utJTvUcExuHwtpa0NTUgP+bt9h76GSeYyCiX9c3N5iTSqV48OABLC0toa+fdfOKn9HStduxaqMXJEoSmBgZwKlGVWxdOVtsFtG9YwtMnL4YTdr3g56uDga6dZbrZFrM3BQ2ZUri1Zu3WSbbAPDxUwTmLFmPkNAwqKuroUa1Sujv2lGc7tKoFg4cPQ2PfxbB3MwEC6aNEZv2ZGbKuCFYvWk3eg7yQGRUNAz0ddG4vhMa1KmBFk3q4YbvA7TsOhiFtDTRtX1zmKT7ad3BrjIGuXXG2MkLkJCYiHYtG6NUCYsstzWgVydMnr0cDVq5wcTYEN07tsC5yzfF6V3aNUNKSgo8/lmED2HhMDYywJhhbjLtSdP739BeWLRyCzq5uQNAatOYQT1zfJ9OnLmEhSs2ISkpGUVMjDB94vAsm49k51vr/GvlSpfAjAkjsGKDF14HvIVEooSy1lYYMbCHQuPOi+w+JxrqaujXsyOGj5+JpKRkjB/ZN9uRYga5dcb8pRsxff5quHZpjV7d2mDxrL+wcPkmLFu3A8aGBhg/8ssoSVkxMTbA0jkTsHTNdsxcuBaCkAKr4sUw0K0Tnr98g5UbvLB64WRoamqgjqMdmjaqjUmzlmH5vIkAgFIlLCCVStG0Y39oqKtjcO+uMiMp5UbLpvWxbus+dG3/h0yzkeCQMJiZGsv86pXeqMGumLlwDfYcPIHixczRrHEdvHodKDPPH43rYvWmPahkUxoWRYuI5Tl9TvKyvTHDemPa/FVo3nUQjAz00baFM/xe+IvTh/bths27/sWg//2Dj+ER0NUpjOrVKqJJAyeoqKhg4fRxmDZ/FbbvOYLy5azRqmkDPPJ7mWksKioqWDRjHOYu2QCXDv2hU7gQundsIfOZKWJqhMoVyuLmnYcYP7KvWK6srATPmeOxdM12dOzljpjYOJiaGKFdi9z3pdLS1MCKeX9j8ZptWLdlLxISk1DM3BQ9/mvnr+jzVE4a13fEguWb4FSjqsxzQ3Kq57/c+2PRys1YumY7bMqUhEvDWjifLk4iIgCQCIJ8DQJGjhyJSpUqoU+fPpBKpahbty6uXr0KLS0tHDlyBPXr18+nUAumqXNXQLewtpiAymvKnOUoXKgQ/je0l2IDI/rFpA0VuWPtvG9aT3x8Ahq364uNy2fAusSXYfjWbN4DQwM9tM9h+NSflbfPJazetBsHtmbfb4kUo3X3YRg9tBfqONr96FCI6Bcj92gze/fuha2tLQDg8OHDeP36NZ4+fQp3d3dMmDBB4QEWZG/fBePMhes5jpVORD8HQRCw68BxlC1dQiZxB4D+rh0LVOIe8DYIj/1eQhAEBLwNwoZt++Fcr+aPDuu3cOLMZaSkpMCpRtUfHQoR/YLkbjYTFhaGIkVSf+49duwYOnbsiDJlyqB3795YvHixwgMsqGYsXIMTPpfg2rUNihfLehQDooJgw/b92Lj9QKbTLh7bKte6ho+fiTuZjDpTtbINlsz+K0/xKYJUmoIGrXpBT7cw5k753w+LQ1Hi4hPw98ylCPnwEdqFtNCgdg30+bP9jw7rl9ehlzuiPkdjyrghfPopEeULuZvNWFpaYu3atWjUqBFKlCiBlStXonnz5nj06BFq166NT59yHgOdiIiIiIjkJ/eddzc3N3Tq1AlmZqnDDKY9oOn69esoVy77zmhERERERJR3cifvU6ZMQcWKFREYGIiOHTtCXT11jGhlZWWMHz9e4QESEREREVEquZvNZCYiIgJ6enoKCIeIiIiIiLIid2+aOXPmwMvLS3zdqVMnGBoaolixYrh//75CgyMiIiIioi/kvvNeokQJbN++HU5OTjh16hQ6deoELy8v7N69GwEBATh58ud+IlxKSgrev3+PwoUL5/jIbSIiol+VIAj4/PkzzM3NoaTEkXGICgq527wHBwfDwiL1iZtHjhxBp06d0KRJE1hZWcHBwUHhASra+/fvxfiJiIh+d4GBgShWLG9PkyWi70/u5F1fXx+BgYGwsLCAt7c3pk+fDiD1G7xUKlV4gIpWuHDqo+cDAwOho6OTw9xERES/pqioKFhYWIjXRSIqGORO3tu1a4du3bqhdOnS+PjxI5o1awYAuHPnDqytrRUeoKKlNZXR0dFh8k5ERL89NiElKljkbuS2aNEiDB06FOXLl8epU6egra0NAAgKCsLgwYPlWteFCxfQsmVLmJubQyKR4ODBg9nOv3//fjRu3BjGxsbQ0dGBo6MjTpw4Ie8uEBEREREVSHLfeVdVVcXo0aMzlLu7u8u98ZiYGNja2qJ3795o165djvNfuHABjRs3xsyZM6Gnp4eNGzeiZcuWuH79OqpWrSr39omIiIiICpI8jfO+detWrF69Gq9evcLVq1dhaWkJT09PlChRAq1bt85bIBIJDhw4gDZt2si1XIUKFdC5c2dMmjQpV/NHRUVBV1cXkZGRbDZDRES/LV4PiQomuZvNrFy5EqNGjUKzZs0QEREhdlLV09ODp6enouPLVkpKCj5//gwDA4Ms50lISEBUVJTMHxERERFRQSR38r506VKsXbsWEyZMgLKyslhub2+PBw8eKDS4nMyfPx/R0dHo1KlTlvPMmjULurq64h+HiSQiIiKigkru5N3f3z/T9uXq6uqIiYlRSFC5sWPHDkydOhW7d++GiYlJlvN5eHggMjJS/AsMDPxuMRIRERERKZLcHVZLlCiBu3fvwtLSUqbc29sbNjY2CgssO7t27ULfvn2xZ88eODs7Zzuvuro61NXVv0tcRERERET5Se7kfdSoURgyZAji4+MhCAJu3LiBnTt3YtasWVi3bl1+xChj586d6N27N3bt2oXmzZvn+/aIiIiIiH4Wcifvffv2haamJiZOnIjY2Fh069YN5ubmWLx4Mbp06SLXuqKjo/HixQvxtb+/P+7evQsDAwMUL14cHh4eePfuHbZs2QIgtamMq6srFi9eDAcHBwQHBwMANDU1oaurK++uEBEREREVKHkaKjJNbGwsoqOjs21znp1z586hQYMGGcpdXV2xadMm9OrVC69fv8a5c+cAAPXr18f58+eznD83ODQWEdHvo379+qhSpYo4GpqVlRVGjhyJkSNH/tC4fga8HhIVTHLfeY+Li4MgCNDS0oKWlhY+fPgAT09PlC9fHk2aNJFrXfXr10d23x2+TsjTkngiIqK8uHnzJgoVKvSjwyAiyjO5R5tp3bq12IwlIiICNWrUwIIFC9C6dWusXLlS4QESEREpirGxMbS0tH50GPkiMTHxR4dARN+B3Mn77du3UadOHQDA3r17UaRIEbx58wZbtmzBkiVLFB4gERH9WurXr49hw4Zh5MiR0NfXh6mpKdauXYuYmBi4ubmhcOHCsLa2xvHjx2WWe/jwIZo1awZtbW2YmpqiR48eCAsLE6fHxMSgZ8+e0NbWhpmZGRYsWJBh21ZWVjIPFFy4cCEqVaqEQoUKwcLCAoMHD0Z0dLQ4fdOmTdDT08OJEydgY2MDbW1tNG3aFEFBQZnumyAIsLa2xvz582XK7969C4lEIvbzioiIQN++fWFsbAwdHR00bNgQ9+7dE+d/+fIlWrduDVNTU2hra6N69eo4ffp0hn2ZNm0aevbsCR0dHfTv3z+Hd56IfgVyJ++xsbEoXLgwAODkyZNo164dlJSUULNmTbx580bhARIR0a9n8+bNMDIywo0bNzBs2DAMGjQIHTt2hJOTE27fvo0mTZqgR48eiI2NBZCa7DZs2BBVq1bFrVu34O3tjZCQEJmH9I0ZMwbnz5/Hv//+i5MnT+LcuXO4fft2tnEoKSlhyZIlePToETZv3owzZ85g7NixMvPExsZi/vz52Lp1Ky5cuICAgACMHj060/VJJBL07t0bGzdulCnfuHEj6tatC2trawBAx44dERoaiuPHj8PX1xfVqlVDo0aNEB4eDiB1QIc//vgDPj4+uHPnDpo2bYqWLVsiICBAZr3z58+Hra0t7ty5g7///jsX7zwRFXRyd1itXLky+vbti7Zt26JixYrw9vaGo6MjfH190bx5c3EEmJ8VO+gQ0a/u/oLMnzpdxnUBNIwsEB8WiGeb/5fpPJX/txsAEOF3FQFHFmWYrm5QFGXdUsuDr+xG6NW94jK5Vb9+fUilUly8eBEAIJVKoauri3bt2onNMoODg2FmZoarV6+iZs2amD59Oi5evIgTJ06I63n79i0sLCzg5+cHc3NzGBoaYtu2bejYsSMAIDw8HMWKFUP//v1z3WF17969GDhwoHhHf9OmTXBzc8OLFy9QqlQpAMCKFSvwzz//ZHm9e//+PYoXL44rV66gRo0aSEpKgrm5OebPnw9XV1dcunQJzZs3R2hoqMxzSKytrTF27Ngs76BXrFgRAwcOxNChQ8V9qVq1Kg4cOJCbtz0DXg+JCia5O6xOmjQJ3bp1g7u7Oxo1agRHR0cAqXfhM3vyKhER0dcqV64s/q+srAxDQ0NUqlRJLDM1NQUAhIaGAgDu3buHs2fPQltbO8O6Xr58ibi4OCQmJsLBwUEsNzAwQNmyZbON4/Tp05g1axaePn2KqKgoJCcnIz4+HrGxsWLbeC0tLTFxBwAzMzMxrsyYm5ujefPm2LBhA2rUqIHDhw8jISFB/FJx7949REdHw9DQUGa5uLg4vHz5EkDqnfcpU6bg6NGjCAoKQnJyMuLi4jLcebe3t892/4jo1yN38t6hQwfUrl0bQUFBsLW1FcsbNWqEtm3bKjQ4IiKSX053wjWMLHKcR6+sI/TKOmY7TxGnTijilPld/pyoqqrKvJZIJDJlEokEAJCSkgIgNZlt2bIl5syZk2FdZmZmMs8Mya3Xr1+jRYsWGDRoEGbMmAEDAwNcunQJffr0QWJiopi8ZxZrTj9a9+3bFz169MCiRYuwceNGdO7cWVxfdHQ0zMzMMh1BTU9PDwAwevRonDp1CvPnz4e1tTU0NTXRoUOHDJ1SOXIO0e9H7uQdAIoUKYIiRYrIlNWoUUMhAREREX2tWrVq2LdvH6ysrKCikvHSVapUKaiqquL69esoXrw4AODTp0949uwZ6tWrl+k6fX19kZKSggULFkBJKbUL2O7d8jUBysoff/yBQoUKYeXKlfD29saFCxdk9iU4OBgqKiqwsrLKdPnLly+jV69e4k2x6OhovH79WiGxEVHBJneHVSIiou9tyJAhCA8PR9euXXHz5k28fPkSJ06cgJubG6RSKbS1tdGnTx+MGTMGZ86cwcOHD9GrVy8xKc+MtbU1kpKSsHTpUrx69Qpbt27FqlWrFBKvsrIyevXqBQ8PD5QuXVpsYgoAzs7OcHR0RJs2bXDy5Em8fv0aV65cwYQJE3Dr1i0AQOnSpbF//37cvXsX9+7dQ7du3cRfIYjo98bknYiIfnrm5ua4fPkypFIpmjRpgkqVKmHkyJHQ09MTE/R58+ahTp06aNmyJZydnVG7dm3Y2dlluU5bW1ssXLgQc+bMQcWKFbF9+3bMmjVLYTGnNb9xc3OTKZdIJDh27Bjq1q0LNzc3lClTBl26dMGbN2/Etv4LFy6Evr4+nJyc0LJlS7i4uKBatWoKi42ICi65R5sp6Ni7noiIvoeLFy+iUaNGCAwMFJPynwmvh0QFk1x33pOSktC7d2/4+/vnVzxEREQFWkJCAt6+fYspU6agY8eOP2XiTkQFl1zJu6qqKvbt25dfsRARERV4O3fuhKWlJSIiIjB37twfHQ4R/WLkbvPepk0bHDx4MB9CISIiKvh69eoFqVQKX19fFC1a9EeHQ0S/GLmHiixdujT++ecfXL58GXZ2dhnGmB0+fLjCgiMiIiIioi/k7rBaokSJrFcmkeDVq1ffHFR+YgcdIiIiXg+JCiq577yzsyoRERER0Y+R53HeExMT4efnh+TkZEXGQ0REREREWZA7eY+NjUWfPn2gpaWFChUqICAgAAAwbNgwzJ49W+EBEhERERFRKrmTdw8PD9y7dw/nzp2DhoaGWO7s7AwvLy+FBkdERERERF/I3eb94MGD8PLyQs2aNSGRSMTyChUq4OXLlwoNjoiIiIiIvpD7zvuHDx9gYmKSoTwmJkYmmSciIiIiIsWSO3m3t7fH0aNHxddpCfu6devg6Ogo17ouXLiAli1bwtzcHBKJJFcPfzp37hyqVasGdXV1WFtbY9OmTXJtk4iIiIiooJK72czMmTPRrFkzPH78GMnJyVi8eDEeP36MK1eu4Pz583KtKyYmBra2tujduzfatWuX4/z+/v5o3rw5Bg4ciO3bt8PHxwd9+/aFmZkZXFxc5N0VIiIiIqICRe6HNAHAy5cvMXv2bNy7dw/R0dGoVq0axo0bh0qVKuU9EIkEBw4cQJs2bbKcZ9y4cTh69CgePnwolnXp0gURERHw9vbO1Xb4UAoiIiJeD4kKKrnvvANAqVKlsHbtWkXHkqOrV6/C2dlZpszFxQUjR47McpmEhAQkJCSIr6OiovIrPCIiIiKifCV3m3dnZ2ds2rTphyTBwcHBMDU1lSkzNTVFVFQU4uLiMl1m1qxZ0NXVFf8sLCy+R6hERERERAond/JeoUIFeHh4oEiRIujYsSP+/fdfJCUl5UdsCuHh4YHIyEjxLzAw8EeHRERERESUJ3In74sXL8a7d+9w8OBBFCpUCD179oSpqSn69+8vd4dVeRUpUgQhISEyZSEhIdDR0YGmpmamy6irq0NHR0fmj4iIiIioIJI7eQcAJSUlNGnSBJs2bUJISAhWr16NGzduoGHDhoqOT4ajoyN8fHxkyk6dOiX3EJVERERERAVRnjqspgkODsauXbuwbds23L9/HzVq1JBr+ejoaLx48UJ87e/vj7t378LAwADFixeHh4cH3r17hy1btgAABg4ciGXLlmHs2LHo3bs3zpw5g927d8uMO09ERERE9KuS+857VFQUNm7ciMaNG8PCwgIrV65Eq1at8Pz5c1y7dk2udd26dQtVq1ZF1apVAQCjRo1C1apVMWnSJABAUFAQAgICxPlLlCiBo0eP4tSpU7C1tcWCBQuwbt06jvFORERERL8Fucd519TUhL6+Pjp37ozu3bvD3t4+v2LLFxzXloiIiNdDooJK7mYzhw4dQqNGjaCklKfm8kRERERElEdyJ++NGzcGAHz48AF+fn4AgLJly8LY2FixkRERERERkQy5b5/Hxsaid+/eMDMzQ926dVG3bl2Ym5ujT58+iI2NzY8YiYiIiIgIeUje3d3dcf78eRw+fBgRERGIiIjAv//+i/Pnz+N///tffsRIRERERETIQ4dVIyMj7N27F/Xr15cpP3v2LDp16oQPHz4oMj6FYwcdIiIiXg+JCqo8NZsxNTXNUG5iYsJmM0RERERE+Uju5N3R0RGTJ09GfHy8WBYXF4epU6fySadERERERPlI7tFmFi9eDBcXFxQrVgy2trYAgHv37kFDQwMnTpxQeIBERERERJRK7jbvQGrTme3bt+Pp06cAABsbG3Tv3h2ampoKD1DR2MaPiIiI10OigkruO+8AoKWlhX79+ik6FiIiIiIiygYfk0pEREREVEAweSciIiIiKiCYvBMRERERFRBM3omIiIiICog8dVgFgMTERISGhiIlJUWmvHjx4t8cFBERERERZSR38v78+XP07t0bV65ckSkXBAESiQRSqVRhwRERERER0RdyJ++9evWCiooKjhw5AjMzM0gkkvyIq8ApZGrzo0P4qcSEPPnRIRARERH9cuRO3u/evQtfX1+UK1cuP+IhIiIiIqIsyN1htXz58ggLC8uPWIiIiIiIKBtyJ+9z5szB2LFjce7cOXz8+BFRUVEyf0RERERElD/kbjbj7OwMAGjUqJFMOTusEhERERHlL7mT97Nnzyo0gOXLl2PevHkIDg6Gra0tli5diho1amQ5v6enJ1auXImAgAAYGRmhQ4cOmDVrFjQ0NBQaFxERERHRz0bu5L1evXoK27iXlxdGjRqFVatWwcHBAZ6ennBxcYGfnx9MTEwyzL9jxw6MHz8eGzZsgJOTE549e4ZevXpBIpFg4cKFCouLiIiIiOhnJBEEQcjLgrGxsQgICEBiYqJMeeXKlXO9DgcHB1SvXh3Lli0DAKSkpMDCwgLDhg3D+PHjM8w/dOhQPHnyBD4+PmLZ//73P1y/fh2XLl3K1TajoqKgq6uLyMhI6Ojo5DrWnHCoSFkcKpKI6OeWX9dDIspfct95//DhA9zc3HD8+PFMp+e2zXtiYiJ8fX3h4eEhlikpKcHZ2RlXr17NdBknJyds27YNN27cQI0aNfDq1SscO3YMPXr0yHI7CQkJSEhIEF+zUy0RERERFVRyjzYzcuRIRERE4Pr169DU1IS3tzc2b96M0qVL49ChQ7leT1hYGKRSKUxNTWXKTU1NERwcnOky3bp1wz///IPatWtDVVUVpUqVQv369fHXX39luZ1Zs2ZBV1dX/LOwsMh1jEREREREPxO5k/czZ85g4cKFsLe3h5KSEiwtLfHnn39i7ty5mDVrVn7EKDp37hxmzpyJFStW4Pbt29i/fz+OHj2KadOmZbmMh4cHIiMjxb/AwMB8jZGIiIiIKL/I3WwmJiZG7Eyqr6+PDx8+oEyZMqhUqRJu376d6/UYGRlBWVkZISEhMuUhISEoUqRIpsv8/fff6NGjB/r27QsAqFSpEmJiYtC/f39MmDABSkoZv4uoq6tDXV0913EREREREf2s5E7ey5YtCz8/P1hZWcHW1harV6+GlZUVVq1aBTMzs1yvR01NDXZ2dvDx8UGbNm0ApHZY9fHxwdChQzNdJjY2NkOCrqysDCB1nHl5PFzqCm0NVZmyMq4LoGFkgfiwQDzb/L9Ml6v8v90AgAi/qwg4skgs39BaEwDw/nMKJp5JbWPfuqwKWpdTzbCOW++lWHEztaPv4OpqsDdXzjDPv0+T8K9fMgBgekN1mBfO+MVkxc1E3Hovldn+1yaeicf7zwLMC0swvWHmw2n2/jcOAGBvrozB1dUyTM/LPt1f0CnDPCaOHVDEKbXcb6M7EsLfZZineAt36JV1BIBM1wF8Wz2lUTcoirJuqeXBV3Yj9OreDPPolnaAZavU9b85tACRz69zn7hP3KfvuE93r57PMM/PfN77Hufyj49OKqyeXp3dmel6iOjnJnfyPmLECAQFBQEAJk+ejKZNm2L79u1QU1PDpk2b5FrXqFGj4OrqCnt7e9SoUQOenp6IiYmBm5sbAKBnz54oWrSo2BynZcuWWLhwIapWrQoHBwe8ePECf//9N1q2bCkm8UTf4onfC/H/W2f9sKLfOgBZX5hn/zsN//pNBpD1hXnYtn45Xpjb13TJMdlw/G9Eo6yTjWeoNj51niyTDTn36fbsppnGQkRERD9GnoeKTBMbG4unT5+iePHiMDIyknv5ZcuWiQ9pqlKlCpYsWQIHBwcAQP369WFlZSV+KUhOTsaMGTOwdetWvHv3DsbGxmjZsiVmzJgBPT29XG2PQ0V+HwV1qEjWo6yCWo/0a+DxmJEij0kOFUlUMOU5eU9MTIS/vz9KlSoFFRW5b+D/MEzev4+CmvSxHmUV1HqkXwOPx4yYvBOR3KPNxMbGok+fPtDS0kKFChUQEBAAABg2bBhmz56t8ACJiIiIiCiV3Mm7h4cH7t27h3PnzkFD40vbXGdnZ3h5eSk0OCIiIiIi+kLu9i4HDx6El5cXatasCYlEIpZXqFABL1++VGhwRERERET0hdx33j98+CCO855eTEyMTDJPRERERESKJXfybm9vj6NHj4qv0xL2devWwdHRUXGRERERERGRDLmbzcycORPNmjXD48ePkZycjMWLF+Px48e4cuUKzp/P+EANIqLvjaOUZMSRg4iIfg1y33mvXbs27t69i+TkZFSqVAknT56EiYkJrl69Cjs7u/yIkYiIiIiIkIc77wBQqlQprF27VtGxEBERERFRNvL8dKXQ0FCEhoYiJSVFprxy5crfHBQREREREWUkd/Lu6+sLV1dXPHnyBF8/nFUikUAqlSosOCIiIiIi+kLu5L13794oU6YM1q9fD1NTUw4PSURERET0ncidvL969Qr79u2DtbV1fsRDRERERERZkHu0mUaNGuHevXv5EQsREREREWVD7jvv69atg6urKx4+fIiKFStCVVVVZnqrVq0UFhwREREREX0hd/J+9epVXL58GcePH88wjR1WiYiIiIjyj9zNZoYNG4Y///wTQUFBSElJkflj4k5ERERElH/kTt4/fvwId3d3mJqa5kc8RERERESUBbmT93bt2uHs2bP5EQsREREREWVD7jbvZcqUgYeHBy5duoRKlSpl6LA6fPhwhQVHRERERERf5Gm0GW1tbZw/fx7nz5+XmSaRSJi8ExERERHlE7mTd39///yIg4iIiIiIciB3m3dFW758OaysrKChoQEHBwfcuHEj2/kjIiIwZMgQmJmZQV1dHWXKlMGxY8e+U7RERERERD+O3HfeFcnLywujRo3CqlWr4ODgAE9PT7i4uMDPzw8mJiYZ5k9MTETjxo1hYmKCvXv3omjRonjz5g309PS+f/BERERERN/ZD03eFy5ciH79+sHNzQ0AsGrVKhw9ehQbNmzA+PHjM8y/YcMGhIeH48qVK2JHWSsrq+8ZMhERERHRD/PDms0kJibC19cXzs7OX4JRUoKzszOuXr2a6TKHDh2Co6MjhgwZAlNTU1SsWBEzZ87M9uFQCQkJiIqKkvkjIiIiIiqIfljyHhYWBqlUmuFhT6ampggODs50mVevXmHv3r2QSqU4duwY/v77byxYsADTp0/PcjuzZs2Crq6u+GdhYaHQ/SAiIiIi+l4UmrwHBARkexf8W6WkpMDExARr1qyBnZ0dOnfujAkTJmDVqlVZLuPh4YHIyEjxLzAwMN/iIyIiIiLKTwpN3q2srFC+fHns378/x3mNjIygrKyMkJAQmfKQkBAUKVIk02XMzMxQpkwZKCsri2U2NjYIDg5GYmJipsuoq6tDR0dH5o+IiIiIqCBSaPJ+9uxZjB8/Hl5eXjnOq6amBjs7O/j4+IhlKSkp8PHxgaOjY6bL1KpVCy9evEBKSopY9uzZM5iZmUFNTe3bd4CIiIiI6Cem0OS9Xr16cHNzy1XyDgCjRo3C2rVrsXnzZjx58gSDBg1CTEyMOPpMz5494eHhIc4/aNAghIeHY8SIEXj27BmOHj2KmTNnYsiQIYrcDSIiIiKin9IPHSqyc+fO+PDhAyZNmoTg4GBUqVIF3t7eYifWgIAAKCl9+X5hYWGBEydOwN3dHZUrV0bRokUxYsQIjBs37kftAhERERHRdyMRBEHIaaaqVatCIpHkaoW3b9/+5qDyU1RUFHR1dREZGanQ9u+FTG0Utq5fQUzIkx8dQp6wHmWxHn8dBbEuWY8ZKbIe8+t6SET5K1d33tu0aSP+Hx8fjxUrVqB8+fJi2/Rr167h0aNHGDx4cL4ESUREREREuUzeJ0+eLP7ft29fDB8+HNOmTcswD4dhJCIiIiLKP3J3WN2zZw969uyZofzPP//Evn37FBIUERERERFlJHfyrqmpicuXL2cov3z5MjQ0NBQSFBERERERZST3aDMjR47EoEGDcPv2bdSoUQMAcP36dWzYsAF///23wgMkIiIiIqJUcifv48ePR8mSJbF48WJs27YNQOpTTjdu3IhOnTopPEAiIiIiIkqVp3HeO3XqxESdiIiIiOg7k7vNe8mSJfHx48cM5REREShZsqRCgiIiIiIioozkTt5fv34NqVSaoTwhIQHv3r1TSFBERERERJRRrpvNHDp0SPz/xIkT0NXVFV9LpVL4+PjAyspKocEREREREdEXuU7e056yKpFI4OrqKjNNVVUVVlZWWLBggUKDIyIiIiKiL3KdvKekpAAASpQogZs3b8LIyCjfgiIiIiIioozkHm3G398/Q1lERAT09PQUEQ8REREREWVB7g6rc+bMgZeXl/i6Y8eOMDAwQNGiRXHv3j2FBkdERERERF/InbyvWrUKFhYWAIBTp07h9OnT8Pb2RrNmzTBmzBiFB0hERERERKnkbjYTHBwsJu9HjhxBp06d0KRJE1hZWcHBwUHhARIRERERUSq577zr6+sjMDAQAODt7Q1nZ2cAgCAImY7/TkREREREiiH3nfd27dqhW7duKF26ND5+/IhmzZoBAO7cuQNra2uFB0hERERERKnkTt4XLVoEKysrBAYGYu7cudDW1gYABAUFYfDgwQoPkIiIiIiIUsmdvKuqqmL06NEZyt3d3RUSEBERERERZU7uNu9ERERERPRj/BTJ+/Lly2FlZQUNDQ04ODjgxo0buVpu165dkEgkaNOmTf4GSERERET0E/jhybuXlxdGjRqFyZMn4/bt27C1tYWLiwtCQ0OzXe7169cYPXo06tSp850iJSIiIiL6sX548r5w4UL069cPbm5uKF++PFatWgUtLS1s2LAhy2WkUim6d++OqVOnomTJkt8xWiIiIiKiH+eHJu+JiYnw9fUVx4oHACUlJTg7O+Pq1atZLvfPP//AxMQEffr0+R5hEhERERH9FHI12oy+vj4kEkmuVhgeHp7rjYeFhUEqlcLU1FSm3NTUFE+fPs10mUuXLmH9+vW4e/durraRkJCAhIQE8XVUVFSu4yMiIiIi+pnkKnn39PTM5zBy5/Pnz+jRowfWrl0LIyOjXC0za9YsTJ06NZ8jIyIiIiLKf7lK3l1dXfNl40ZGRlBWVkZISIhMeUhICIoUKZJh/pcvX+L169do2bKlWJaSkgIAUFFRgZ+fH0qVKiWzjIeHB0aNGiW+joqKgoWFhSJ3g4iIiIjou5D7IU3pxcfHIzExUaZMR0cn18urqanBzs4OPj4+4nCPKSkp8PHxwdChQzPMX65cOTx48ECmbOLEifj8+TMWL16caVKurq4OdXX1XMdERERERPSzkjt5j4mJwbhx47B79258/Pgxw3SpVCrX+kaNGgVXV1fY29ujRo0a8PT0RExMDNzc3AAAPXv2RNGiRTFr1ixoaGigYsWKMsvr6ekBQIZyIiIiIqJfjdzJ+9ixY3H27FmsXLkSPXr0wPLly/Hu3TusXr0as2fPljuAzp0748OHD5g0aRKCg4NRpUoVeHt7i51YAwICoKT0w0e0JCIiIiL64SSCIAjyLFC8eHFs2bIF9evXh46ODm7fvg1ra2ts3boVO3fuxLFjx/IrVoWIioqCrq4uIiMj5Wrik5NCpjYKW9evICbkyY8OIU9Yj7JYj7+OgliXrMeMFFmP+XU9JKL8Jfct7fDwcPHBSDo6OuLQkLVr18aFCxcUGx0REREREYnkTt5LliwJf39/AKkdSHfv3g0AOHz4sNj+nIiIiIiIFE/u5N3NzQ337t0DAIwfPx7Lly+HhoYG3N3dMWbMGIUHSEREREREqeTusOru7i7+7+zsjKdPn8LX1xfW1taoXLmyQoMjIiIiIqIvvmmcdwCwtLSEpaWlImIhIiIiIqJs5Cl59/HxgY+PD0JDQ8UnnKbZsGGDQgIjIiIiIiJZcifvU6dOxT///AN7e3uYmZlBIpHkR1xERERERPQVuZP3VatWYdOmTejRo0d+xENERERERFmQe7SZxMREODk55UcsRERERESUDbmT9759+2LHjh35EQsREREREWVD7mYz8fHxWLNmDU6fPo3KlStDVVVVZvrChQsVFhwREREREX0hd/J+//59VKlSBQDw8OFDmWnsvEpERERElH/kTt7Pnj2bH3EQEREREVEO5G7znt7bt2/x9u1bRcVCRERERETZkDt5T0lJwT///ANdXV3x6ap6enqYNm1ahgc2ERERERGR4sjdbGbChAlYv349Zs+ejVq1agEALl26hClTpiA+Ph4zZsxQeJBERERERJSH5H3z5s1Yt24dWrVqJZZVrlwZRYsWxeDBg5m8ExERERHlE7mbzYSHh6NcuXIZysuVK4fw8HCFBEVERERERBnJnbzb2tpi2bJlGcqXLVsGW1tbhQRFREREREQZyd1sZu7cuWjevDlOnz4NR0dHAMDVq1cRGBiIY8eOKTxAIiIiIiJKJfed93r16uHZs2do27YtIiIiEBERgXbt2sHPzw916tTJjxiJiIiIiAh5HOfd3NwcM2bMwL59+7Bv3z5Mnz4d5ubmeQ5i+fLlsLKygoaGBhwcHHDjxo0s5127di3q1KkDfX196Ovrw9nZOdv5iYiIiIh+FblqNnP//n1UrFgRSkpKuH//frbzVq5cWa4AvLy8MGrUKKxatQoODg7w9PSEi4sL/Pz8YGJikmH+c+fOoWvXrnBycoKGhgbmzJmDJk2a4NGjRyhatKhc2yYiIiIiKkgkgiAIOc2kpKSE4OBgmJiYQElJCRKJBJktJpFIIJVK5QrAwcEB1atXFzvBpqSkwMLCAsOGDcP48eNzXF4qlUJfXx/Lli1Dz549c5w/KioKurq6iIyMhI6OjlyxZqeQqY3C1vUriAl58qNDyBPWoyzW46+jINYl6zEjRdZjfl0PiSh/5erOu7+/P4yNjcX/FSUxMRG+vr7w8PAQy5SUlODs7IyrV6/mah2xsbFISkqCgYGBwuIiIiIiIvoZ5Sp5t7S0FP9/8+YNnJycoKIiu2hycjKuXLkiM29OwsLCIJVKYWpqKlNuamqKp0+f5mod48aNg7m5OZydnTOdnpCQgISEBPF1VFRUruMjIiIiIvqZyN1htUGDBpk+jCkyMhINGjRQSFC5NXv2bOzatQsHDhyAhoZGpvPMmjULurq64p+FhcV3jZGIiIiISFHkTt4FQYBEIslQ/vHjRxQqVEiudRkZGUFZWRkhISEy5SEhIShSpEi2y86fPx+zZ8/GyZMns+0k6+HhgcjISPEvMDBQrhiJiIiIiH4WuX5IU7t27QCkdkrt1asX1NXVxWlSqRT379+Hk5OTXBtXU1ODnZ0dfHx80KZNGwCpHVZ9fHwwdOjQLJebO3cuZsyYgRMnTsDe3j7bbairq8vESkRERERUUOU6edfV1QWQeue9cOHC0NTUFKepqamhZs2a6Nevn9wBjBo1Cq6urrC3t0eNGjXg6emJmJgYuLm5AQB69uyJokWLYtasWQCAOXPmYNKkSdixYwesrKwQHBwMANDW1oa2trbc2yciIiIiKihynbxv3LgRAGBlZYUxY8ZAS0tLIQF07twZHz58wKRJkxAcHIwqVarA29tb7MQaEBAAJaUvrXtWrlyJxMREdOjQQWY9kydPxpQpUxQSExERERHRzyhX47yn5+/vj+TkZJQuXVqm/Pnz51BVVYWVlZUi41M4jvP+fRTEMaUB1uPXWI+/joJYl6zHjDjOOxHJ3WG1V69euHLlSoby69evo1evXoqIiYiIiIiIMiF38n7nzh3UqlUrQ3nNmjVx9+5dRcRERERERESZkDt5l0gk+Pz5c4byyMhISKVShQRFREREREQZyZ28161bF7NmzZJJ1KVSKWbNmoXatWsrNDgiIiIiIvoi16PNpJkzZw7q1q2LsmXLok6dOgCAixcvIioqCmfOnFF4gERERERElEruO+/ly5fH/fv30alTJ4SGhuLz58/o2bMnnj59iooVK+ZHjEREREREhDzceQcAc3NzzJw5U9GxEBERERFRNuS+8w6kNpP5888/4eTkhHfv3gEAtm7dikuXLik0OCIiIiIi+kLu5H3fvn1wcXGBpqYmbt++jYSEBACpo83wbjwRERERUf6RO3mfPn06Vq1ahbVr10JVVVUsr1WrFm7fvq3Q4IiIiIiI6Au5k3c/Pz/UrVs3Q7muri4iIiIUERMREREREWVC7uS9SJEiePHiRYbyS5cuoWTJkgoJioiIiIiIMpI7ee/Xrx9GjBiB69evQyKR4P3799i+fTtGjx6NQYMG5UeMRERERESEPAwVOX78eKSkpKBRo0aIjY1F3bp1oa6ujtGjR2PYsGH5ESMRERERESEPybtEIsGECRMwZswYvHjxAtHR0Shfvjy0tbXzIz4iIiIiIvpPnsZ5BwA1NTWUL18e5cqVw+nTp/HkyRNFxkVERERERF+RO3nv1KkTli1bBgCIi4tD9erV0alTJ1SuXBn79u1TeIBERERERJRK7uT9woULqFOnDgDgwIEDSElJQUREBJYsWYLp06crPEAiIiIiIkold/IeGRkJAwMDAIC3tzfat28PLS0tNG/eHM+fP1d4gERERERElEru5N3CwgJXr15FTEwMvL290aRJEwDAp0+foKGhofAAiYiIiIgoldyjzYwcORLdu3eHtrY2ihcvjvr16wNIbU5TqVIlRcdHRERERET/kTt5Hzx4MBwcHBAQEIDGjRtDSSn15n3JkiXZ5p2IiIiIKB/laahIOzs7tG3bFvfu3UNCQgIAoHnz5qhVq1aegli+fDmsrKygoaEBBwcH3LhxI9v59+zZg3LlykFDQwOVKlXCsWPH8rRdIiIiIqKCJM/jvANAs2bN8O7du28KwMvLC6NGjcLkyZNx+/Zt2NrawsXFBaGhoZnOf+XKFXTt2hV9+vTBnTt30KZNG7Rp0wYPHz78pjiIiIiIiH5235S8C4LwzQEsXLgQ/fr1g5ubG8qXL49Vq1ZBS0sLGzZsyHT+xYsXo2nTphgzZgxsbGwwbdo0VKtWTRx7noiIiIjoVyV3m3dFSkxMhK+vLzw8PMQyJSUlODs74+rVq5kuc/XqVYwaNUqmzMXFBQcPHsx0/oSEBLFpD5A61CUAREVFfWP0soQUqULXV9Ap+v39XliPsliPv46CWJesx4wUWY9p61LEjTgi+n6+KXlfvXo1TE1N87x8WFgYpFJphnWYmpri6dOnmS4THByc6fzBwcGZzj9r1ixMnTo1Q7mFhUUeo6bc0NXV/dEhkAKwHn8drMtfQ37U4+fPn/n5ICpAvil579atG6KionDw4EGULVsWNjY2iopLYTw8PGTu1KekpCA8PByGhoaQSCQ/MDLFi4qKgoWFBQIDA6Gjo/Ojw6E8Yj3+GliPv45ftS4FQcDnz59hbm7+o0MhIjnInbx36tQJdevWxdChQxEXFwd7e3u8fv0agiBg165daN++fa7XZWRkBGVlZYSEhMiUh4SEoEiRIpkuU6RIEbnmV1dXh7q6ukyZnp5ermMsiHR0dH6pC8zvivX4a2A9/jp+xbrkHXeigkfuDqsXLlxAnTp1AAAHDhyAIAiIiIjAkiVL5B7nXU1NDXZ2dvDx8RHLUlJS4OPjA0dHx0yXcXR0lJkfAE6dOpXl/EREREREvwq5k/fIyEgYGBgAALy9vdG+fXtoaWmhefPmeP78udwBjBo1CmvXrsXmzZvx5MkTDBo0CDExMXBzcwMA9OzZU6ZD64gRI+Dt7Y0FCxbg6dOnmDJlCm7duoWhQ4fKvW0iIiIiooJE7mYzFhYWuHr1KgwMDODt7Y1du3YBAD59+gQNDQ25A+jcuTM+fPiASZMmITg4GFWqVIG3t7fYKTUgIEB8iisAODk5YceOHZg4cSL++usvlC5dGgcPHkTFihXl3vavRl1dHZMnT87QTIgKFtbjr4H1+OtgXRLRz0QiyDlG1IoVKzBixAhoa2vD0tISt2/fhpKSEpYuXYr9+/fj7Nmz+RUrEREREdFvTe7kHQBu3bqFwMBANG7cGNra2gCAo0ePQk9PD7Vq1VJ4kERERERElMfkPT2pVIoHDx7A0tIS+vr6ioqLiIiIiIi+IneH1ZEjR2L9+vUAUhP3evXqoVq1arCwsMC5c+cUHR8REREREf1H7uR97969sLW1BQAcPnwY/v7+ePr0Kdzd3TFhwgSFB0hERERERKnkTt7DwsLEByIdO3YMHTt2RJkyZdC7d288ePBA4QH+bmbNmoXq1aujcOHCMDExQZs2beDn5yczT3x8PIYMGQJDQ0Noa2ujffv2GR5cNXz4cNjZ2UFdXR1VqlTJsJ0pU6ZAIpFk+CtUqFB+7t5v43vVIwCcOHECNWvWROHChWFsbIz27dvj9evX+bRnv5fvWY+7d+9GlSpVoKWlBUtLS8ybNy+/duu3o4h6vHfvHrp27QoLCwtoamrCxsYGixcvzrCtc+fOoVq1alBXV4e1tTU2bdqU37tHRL8ZuZN3U1NTPH78GFKpFN7e3mjcuDEAIDY2FsrKygoP8Hdz/vx5DBkyBNeuXcOpU6eQlJSEJk2aICYmRpzH3d0dhw8fxp49e3D+/Hm8f/8e7dq1y7Cu3r17o3PnzpluZ/To0QgKCpL5K1++PDp27Jhv+/Y7+V716O/vj9atW6Nhw4a4e/cuTpw4gbCwsEzXQ/L7XvV4/PhxdO/eHQMHDsTDhw+xYsUKLFq0CMuWLcu3ffudKKIefX19YWJigm3btuHRo0eYMGECPDw8ZOrI398fzZs3R4MGDXD37l2MHDkSffv2xYkTJ77r/hLRL06Q0+TJkwVdXV2hXLlyQvHixYX4+HhBEARh/fr1Qs2aNeVdHeUgNDRUACCcP39eEARBiIiIEFRVVYU9e/aI8zx58kQAIFy9ejXD8pMnTxZsbW1z3M7du3cFAMKFCxcUFjt9kV/1uGfPHkFFRUWQSqVi2aFDhwSJRCIkJiYqfkd+c/lVj127dhU6dOggU7ZkyRKhWLFiQkpKimJ3gr65HtMMHjxYaNCggfh67NixQoUKFWTm6dy5s+Di4qLgPSCi35ncd96nTJmCdevWoX///rh8+bL40AplZWWMHz9eUd8p6D+RkZEAID7V1tfXF0lJSXB2dhbnKVeuHIoXL46rV6/meTvr1q1DmTJlUKdOnW8LmDKVX/VoZ2cHJSUlbNy4EVKpFJGRkdi6dSucnZ2hqqqq2J2gfKvHhISEDA+509TUxNu3b/HmzRsFRE7pKaoe0z9xHACuXr0qsw4AcHFx+aZzMxHR1+RO3gGgQ4cOcHd3R7FixcQyV1dXtG7dWmGBEZCSkoKRI0eiVq1a4hNkg4ODoaamBj09PZl5TU1NERwcnKftxMfHY/v27ejTp8+3hkyZyM96LFGiBE6ePIm//voL6urq0NPTw9u3b7F7925F7gIhf+vRxcUF+/fvh4+PD1JSUvDs2TMsWLAAABAUFKSwfSDF1eOVK1fg5eWF/v37i2XBwcHi08HTryMqKgpxcXGK3REi+m3lKXk/f/48WrZsCWtra1hbW6NVq1a4ePGiomP77Q0ZMgQPHz7Erl278nU7Bw4cwOfPn+Hq6pqv2/ld5Wc9BgcHo1+/fnB1dcXNmzdx/vx5qKmpoUOHDhC+7REO9JX8rMd+/fph6NChaNGiBdTU1FCzZk106dIFAKCklKfTNGVBEfX48OFDtG7dGpMnT0aTJk0UGB0RUc7kvips27YNzs7O0NLSwvDhwzF8+HBoamqiUaNG2LFjR37E+FsaOnQojhw5grNnz8r8wlGkSBEkJiYiIiJCZv6QkBBxFCB5rVu3Di1atMhwx4i+XX7X4/Lly6Grq4u5c+eiatWqqFu3LrZt2wYfHx9cv35dUbvx28vvepRIJJgzZw6io6Px5s0bBAcHo0aNGgCAkiVLKmQfSDH1+PjxYzRq1Aj9+/fHxIkTZaYVKVIkw0hDISEh0NHRgaampmJ3hoh+W3In7zNmzMDcuXPh5eUlJu9eXl6YPXs2pk2blh8x/lYEQcDQoUNx4MABnDlzBiVKlJCZbmdnB1VVVfj4+Ihlfn5+CAgIgKOjo9zb8/f3x9mzZ9lkRsG+Vz3GxsZmuDObNupTSkrKN+wBAd//eFRWVkbRokWhpqaGnTt3wtHREcbGxt+8H787RdXjo0eP0KBBA7i6umLGjBkZtuPo6CizDgA4depUnj4LRERZkreHq5qamvD8+fMM5c+fPxfU1dW/tQPtb2/QoEGCrq6ucO7cOSEoKEj8i42NFecZOHCgULx4ceHMmTPCrVu3BEdHR8HR0VFmPc+fPxfu3LkjDBgwQChTpoxw584d4c6dO0JCQoLMfBMnThTMzc2F5OTk77J/v4vvVY8+Pj6CRCIRpk6dKjx79kzw9fUVXFxcBEtLS5ltUd58r3r88OGDsHLlSuHJkyfCnTt3hOHDhwsaGhrC9evXv+v+/qoUUY8PHjwQjI2NhT///FNmHaGhoeI8r169ErS0tIQxY8YIT548EZYvXy4oKysL3t7e33V/iejXJnfyXqpUKWHVqlUZyleuXClYW1srJKjfGYBM/zZu3CjOExcXJwwePFjQ19cXtLS0hLZt2wpBQUEy66lXr16m6/H39xfnkUqlQrFixYS//vrrO+3d7+N71uPOnTuFqlWrCoUKFRKMjY2FVq1aCU+ePPlOe/pr+171+OHDB6FmzZpCoUKFBC0tLaFRo0bCtWvXvuOe/toUUY+TJ0/OdB2WlpYy2zp79qxQpUoVQU1NTShZsqTMNoiIFEEiCPL1alu5ciVGjhyJ3r17w8nJCQBw+fJlbNq0CYsXL8aAAQPkWR0REREREeWS3Mk7kDo6yYIFC/DkyRMAgI2NDcaMGcOhIomIiIiI8pFcyXtycjJmzpyJ3r17y/TUJyIiIiKi/Cf3nXdtbW08fPgQVlZW+RQSERERERFlRu6hIhs1aoTz58/nRyxERERERJQNFXkXaNasGcaPH48HDx7Azs4OhQoVkpneqlUrhQVHRERERERfyN1sJrtHdUskEkil0m8OioiIiIiIMsrTaDNERERERPT9yd3mnYiIiIiIfoxcJ+9nzpxB+fLlERUVlWFaZGQkKlSogAsXLig0OCL6+QmCAGdnZ7i4uGSYtmLFCujp6eHt27c/IDIiIqJfT66Td09PT/Tr1w86OjoZpunq6mLAgAFYtGiRQoMjop+fRCLBxo0bcf36daxevVos9/f3x9ixY7F06VKFPxciKSlJoesjIiIqKHKdvN+7dw9NmzbNcnqTJk3g6+urkKCIqGCxsLDA4sWLMXr0aPj7+0MQBPTp0wdNmjRB1apV0axZM2hra8PU1BQ9evRAWFiYuKy3tzdq164NPT09GBoaokWLFnj58qU4/fXr15BIJPDy8kK9evWgoaGB7du3/4jdJCIi+uFynbyHhIRAVVU1y+kqKir48OGDQoIiooLH1dUVjRo1Qu/evbFs2TI8fPgQq1evRsOGDVG1alXcunUL3t7eCAkJQadOncTlYmJiMGrUKNy6dQs+Pj5QUlJC27ZtkZKSIrP+8ePHY8SIEXjy5EmmTXSIiIh+B7kebaZUqVJYsGAB2rRpk+n0/fv3Y/To0Xj16pUi4yOiAiQ0NBQVKlRAeHg49u3bh4cPH+LixYs4ceKEOM/bt29hYWEBPz8/lClTJsM6wsLCYGxsjAcPHqBixYp4/fo1SpQoAU9PT4wYMeJ77g4REdFPJ9d33v/44w/8/fffiI+PzzAtLi4OkydPRosWLRQaHBEVLCYmJhgwYABsbGzQpk0b3Lt3D2fPnoW2trb4V65cOQAQm8Y8f/4cXbt2RcmSJaGjowMrKysAQEBAgMy67e3tv+u+EBER/Yxy/YTViRMnYv/+/ShTpgyGDh2KsmXLAgCePn2K5cuXQyqVYsKECfkWKBEVDCoqKlBRST21REdHo2XLlpgzZ06G+czMzAAALVu2hKWlJdauXQtzc3OkpKSgYsWKSExMlJn/66c5ExER/Y5ynbybmpriypUrGDRoEDw8PJDW2kYikcDFxQXLly+HqalpvgVKRAVPtWrVsG/fPlhZWYkJfXofP36En58f1q5dizp16gAALl269L3DJCIiKjBynbwDgKWlJY4dO4ZPnz7hxYsXEAQBpUuXhr6+fn7FR0QF2JAhQ7B27Vp07doVY8eOhYGBAV68eIFdu3Zh3bp10NfXh6GhIdasWQMzMzMEBARg/PjxPzpsIiKin1aenrCqr6+P6tWro0aNGkzciShL5ubmuHz5MqRSKZo0aYJKlSph5MiR0NPTg5KSEpSUlLBr1y74+vqiYsWKcHd3x7x583502ERERD+tXI82Q0REREREP1ae7rwTEREREdH3x+SdiIiIiKiAYPJORERERFRAMHknIiIiIiogmLwTERERERUQTN6JiIiIiAoIJu9ERERERAUEk3ciIiIiogKCyTsRERERUQHB5J2IiIiIqIBg8k5EREREVEAweSciIiIiKiD+D1+9C/nPfPjJAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x260 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Annual mean of the daily cross-sectional dispersion of the primary label."
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ret_to_expiry: 354,473 rows (dropped 3,006 for expirations beyond underlying bars range)\n",
-      "  mean=-0.0242, std=1.1524, median=0.1881, hit_rate=59.4%\n",
-      "  dte_calendar: min=25, max=35, mean=30.1\n"
+      "shape: (4, 3)\n",
+      "┌──────┬────────────┬───────┐\n",
+      "│ year ┆ dispersion ┆ names │\n",
+      "│ ---  ┆ ---        ┆ ---   │\n",
+      "│ i32  ┆ f64        ┆ f64   │\n",
+      "╞══════╪════════════╪═══════╡\n",
+      "│ 2017 ┆ 0.860721   ┆ 211.0 │\n",
+      "│ 2018 ┆ 0.775659   ┆ 248.0 │\n",
+      "│ 2019 ┆ 0.727038   ┆ 251.0 │\n",
+      "│ 2020 ┆ 0.783495   ┆ 224.0 │\n",
+      "└──────┴────────────┴───────┘\n"
      ]
     }
    ],
    "source": [
-    "_htm_dropped = len(contract_returns) - len(htm_label)\n",
-    "_ret_htm = htm_label[\"ret_to_expiry\"]\n",
-    "print(\n",
-    "    f\"ret_to_expiry: {len(htm_label):,} rows \"\n",
-    "    f\"(dropped {_htm_dropped:,} for expirations beyond underlying bars range)\"\n",
+    "annual = (\n",
+    "    dev[PRIMARY_LABEL]\n",
+    "    .group_by(\"timestamp\")\n",
+    "    .agg(pl.col(PRIMARY_LABEL).std().alias(\"dispersion\"), pl.len().alias(\"names\"))\n",
+    "    .with_columns(pl.col(\"timestamp\").dt.year().alias(\"year\"))\n",
+    "    .group_by(\"year\")\n",
+    "    .agg(pl.col(\"dispersion\").mean(), pl.col(\"names\").median())\n",
+    "    .sort(\"year\")\n",
     ")\n",
-    "print(\n",
-    "    f\"  mean={_ret_htm.mean():.4f}, std={_ret_htm.std():.4f}, \"\n",
-    "    f\"median={_ret_htm.median():.4f}, hit_rate={(_ret_htm > 0).mean():.1%}\"\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single_wide\"])\n",
+    "ax.bar(annual[\"year\"], annual[\"dispersion\"], color=COLORS[\"blue\"], width=0.6)\n",
+    "ax.axhline(\n",
+    "    annual[\"dispersion\"].median(),\n",
+    "    color=COLORS[\"copper\"],\n",
+    "    linestyle=\"--\",\n",
+    "    lw=1.2,\n",
+    "    label=\"median year\",\n",
     ")\n",
-    "print(\n",
-    "    f\"  dte_calendar: min={htm_label['dte_calendar'].min()}, \"\n",
-    "    f\"max={htm_label['dte_calendar'].max()}, \"\n",
-    "    f\"mean={htm_label['dte_calendar'].mean():.1f}\"\n",
-    ")"
+    "ax.set_xticks(annual[\"year\"].to_list())\n",
+    "ax.set_ylim(0, annual[\"dispersion\"].max() * 1.45)\n",
+    "ax.set_xlabel(\"Year\")\n",
+    "ax.set_ylabel(\"Cross-sectional std, mean over sessions\")\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"The spread a model ranks within is stable across the development years\",\n",
+    "    subtitle=f\"Daily spread across names in {PRIMARY_LABEL}, averaged over each year\",\n",
+    ")\n",
+    "ax.legend(loc=\"upper right\", frameon=False)\n",
+    "show_with_alt(fig, \"Annual mean of the daily cross-sectional dispersion of the primary label.\")\n",
+    "\n",
+    "print(annual)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e61fb30c",
    "metadata": {
+    "tags": [
+     "results"
+    ]
    },
    "source": [
-    "## 4. Label Quality Diagnostics\n",
+    "On the development window the hold-to-expiry label has a mean of -0.0487 of the premium\n",
+    "collected against a standard deviation of 1.0369, while 58.5% of trades end profitable:\n",
+    "most positions expire worth keeping and the ones that do not are several times the size of\n",
+    "the ones that do. Closing at ten sessions instead leaves a mean of +0.0552 on a standard\n",
+    "deviation of 0.3547, and hedging that trade's direction away cuts the standard deviation\n",
+    "to 0.2182 while moving the mean to +0.0159 - the hedge takes out the moves in both\n",
+    "directions. Cross-sectional dispersion is steady across the development years, running from\n",
+    "0.727038 in the quietest to 0.860721 in the loudest."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0e3793f",
+   "metadata": {},
+   "source": [
+    "## F. Overlap and effective sample size\n",
     "\n",
-    "Check distributions and the fraction of profitable trades."
+    "Sampling a month-long trade at every session makes consecutive rows share almost all of\n",
+    "their holding window, so the row count overstates the evidence. Two measurements answer\n",
+    "that in different units: how fast the overlap decays, and what the rows are worth once it\n",
+    "is priced in. `effective_sample_size` applies Chapter 7.2's average-uniqueness weighting\n",
+    "per name, because concurrency is a property of one name's own overlapping trades.\n",
+    "\n",
+    "Both are counted on `_bar`, the panel calendar the windows were built on. A name is quoted\n",
+    "on roughly half the sessions here, and closing over the gaps would pair trades that share\n",
+    "nothing and report the overlap as larger than it is."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "5c639817",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:52.046111Z",
-     "iopub.status.busy": "2026-07-21T06:54:52.045538Z",
-     "iopub.status.idle": "2026-07-21T06:54:52.064930Z",
-     "shell.execute_reply": "2026-07-21T06:54:52.064007Z"
+     "iopub.execute_input": "2026-07-31T07:12:55.133723Z",
+     "iopub.status.busy": "2026-07-31T07:12:55.133389Z",
+     "iopub.status.idle": "2026-07-31T07:13:05.295831Z",
+     "shell.execute_reply": "2026-07-31T07:13:05.295352Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAosAAAFnCAYAAADOhANzAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA+K5JREFUeJzs3WV0FFcfgPFn4+5CSALBJSQkEDRBgzsUp2iRtljRFnkrUCi0WClQ3Glxdy8EhxAcAgQLcXef98OSJSFOEhbC/Z2Tc7KzM3f+Mzsze/eqTJIkCUEQBEEQBEHIhoqyAxAEQRAEQRA+XiKzKAiCIAiCIORIZBYFQRAEQRCEHInMoiAIgiAIgpAjkVkUBEEQBEEQciQyi4IgCIIgCEKORGZREARBEARByJHILAqCIAiCIAg5EplFQRAEQRAEIUcis6gk5y5cRdeyGrqW1Rg+Zsp7p9Om6wBFOi9evn6vNNK3r+bi/t5x5KQo4itJNm3dozgfs/5YouxwsiU+M0GZXrx8rbj+2nQdoOxwPlqz/liiOE+btu4p0rQL+v2U03OtpDxLivu5/SmcJzVlB6Ass/5Ywux5S3N839BAH7/HVz9gRJ+Xai7uvHzlR2zgA2WHIgiZ3Lr7gINHTgHQqGFdGrvWVXJEn65zF65y/qL8OdqhrTs1a1R777QiIqNYunIjAGVsrenfu2uRxCgIQt4+28yiIAhCdm7ffaj4ITl1IiKzWAjnL15VnMsyttb5yiyWsjTnxP7NABjo6yuWR0ZGK9Jq1LCOyCx+AubNmk5UdDQg/1w/Va3dGyuuSVtrKyVHoxwiswi0cm/EpLEjMi1TU1VVUjRCSZSUlISKimj1IXx4aWlpJCUlo6WlqexQ8kVTU4OG9WorOwyhCNSoXlnZIRQJC3NTLMxNlR2GUolvL8DczJSG9Wpn+qvr4qR4PzY2jrGTf8atVXfs7N0wsnHEqmIdmrXrzYYtO7NN8/jp83TtO5yy1RtiZONIxZpN6PfVWF6+yr49wn8eV2jathcmZWpSpVZzlq3aVKhj+uGnuTRv34fyDo0wtnXEolxtGrboxqJla0lJSclxuxcvX9NzwEgsy9emTLUGjPthBrGxcVnWO3jkFO27D8a6cj2MbR1xatiW2fOWEh+f8N4xn7twlfbdB2NTpT6G1g6Urd6Qxq17MnHabCKjovPcPikpifl/raJ+866Y29XCzM6Zes26MG/xKpKSkhTr1W3aGV3LahiUrkFIaHimNDr2/ErRduTBoyeK5RcuX6dH/28Vn2d1lxZ8/+McwiMiM20/fMwUxfbHTp3jh5/mUt6hESZlnHjtF5hj7AcOn6RH/2+p7tICy/K1MbJxpGrt5owYOzVLG5aM+zj13wVmzPmTijWbYFrWiVadv+Tm7Xt5niuA1NRUZv2xhIo1m2Bm50zbrgO5fe9hrtsU5HP3fe3P+CkzcajXGpMyNbGuXI9m7Xqzc+9hxTobtuykU6+hVKnVHHO7WpiUqYlj/dZMmPKr4rM5c+6S4niHjf4h0z5u33uoeK/7l98A8szR7wuX49K4I6ZlnRT3VLd+I3K8X9NVc3Hn67FTFa9nz1uabVulp89eMGLsVCo7N8PIxhHbqvXp2nc4Z85dyjX9jPtJTze7v4zu3HvEwBETKO/QSPEs+XbcdF77BWRaL2Mbtg3/7GLugr+pWrs5htYOXL1xCwBJkli7cTtN2/bCsnxtTMrUxNm1HT/NWpivewxg3uJVtOk6gEpOTTEt64SZnTO1G3Xgl98WERcXr1hP17JapqY+X4+dmq82dtm1WRw+ZgrV67RQrHP+4rUs68THJzD1lz9wrN8aY1tHzO1qUd2lBX0Gj2b/4RP5Orabt+/x5dDvKFdDfq7L1WhEv6/GcvPW23sqMioafSt7dC2r0aJjP8Xy9Zt3KGI6d+FtE6ZyNRqha1mNcjUaZTo36e3En/g8p0f/b7EoVxubKvUZM+lnEhIS8xVvRivX/aM49nrNunD2/OUs6xT2ugU4e/4yjVr3wKRMTWrUbcWKtVtyXDe7tnjvfr43bt6hbdeBmNk5U65GI375bRFpaWmZ0nn56jW9Bo7ColxtylZ3ZeK02Tx49CTfbVv/Xr1Zse76zTsUy1t07Jelvf6xU+cU606fOQ/IX5vMO/ceMWHKr5St7oppWSe69Bme5fv+fZ65ew4co23XgZSuVBdjW0fs67Rk/JSZ+AcGKdY5fOyMIo5fflukWD7k28noWlbD2NaRxET5d+BD76eKdQcMG5frvjMSJYv5EB0by+oN2zItS05O5uqNW1y9cQu/gECmTBipeO+3+Uv59ffMjWD9A4LYe/A4I4b0o4ytdab3Ll/1ZNuug4pMnO9rfyZNn03VyhVo3qThe8W8ct0/iosDICkpmVt3HnDrzgMePnrK8j9nZdkmJiaWlp2/VHwJxcTGsXLdvzx74cvef1cq1ps5dzFzFvydadvHT58z648lnD1/iYM71qKhoVGgeL2fPKNbvxGZMh0hoeGEhIZzw+sO3wzth6GBfo7bJyYm0anXV3hcup5p+d37j7h7/xEnTp/jwPY1aGho0OuLDvz46wJSU1M5cPgEg/v3BCAsPELxkK/pUI1qVSoC8i+B0ZN+zvQAe/HqNUtWbOD4qXOcPvQvxkaGWWKaMOVXnr14la/jP3HGg8PHz2Ra9srXn81b93D81HmunNmb7S/biVNn4f3kmeL1hcs3aNdtEOeObadShXK57nPS9NmsWPuP4vW5i1dp3bl/tscCBfvcb919QIfugwkLf5uZTkxM4uqNW1Q6fZ7uXdoBsPvAMU6dvZApzafPXvL02RbOelzmwoldNG1UH7syNjx/6cuBwyeJ/z0BbW0tAA4fO63Yrme3DgD8vmg5M+f+lSlN39f++L72JyoqhoH9uud6XvJy3fM2HXoMITomVrEsLDyS46fOc+K0Bwvn/I9hg/oUah/pjp06R5/BozPdy/4BQWz4ZxdHT/7H6YP/YlfWJst2fyxakeXakySJQV9PzJRZB/m9N2/xSg4cOcmpg//k+Pmn27JtT6ZrDuRfQA+9n3L5mhdHdq8v4FEWjfFTZrLx392K10kk8+LVa168eo22tjad2rXMdftDR0/Tb+h3JCcnK5YFBYew9+BxDh07w5bVi2jfpjmGBvrYV6vMnXsPuXn7HsnJyairq3PlupdiuyvXvWjsWpdnz18RFBwCgGv9rKWlERFRNG/fh9CwCABi42DNxm2Ymhjx05Tv8n3si5au4aH3U8Xru/cf0XvQKB7cOKX4PIviur187SZd+w4nKUl+jp69eMX4Kb9So3qVfMea0eOnz2nddYDiuR8fn8Dvi1ZQ1taaQV/2AORtVVt3HcDLV34AxMbF8ffqTXhcupbv/TTMcO6v3rjFoC97kJycrPhh/fKVH/6BQVhZWnA1w+foVt8l3/voM3h0pnvuxOnzDPl2MicPvM1MF/SZO33mPBYuWZNp2fOXvqxY+w97Dx5X3P8N6tVCJpMhSZLihyGgOJakpGS8bt+jXh3nTNepa4P8H58oWQS2bNub5Zd9xh5gOtra/O/70WxatZD921dzZPcGNqyYT8XyZQFYtHStouTK0+tupoziwL5fsHPTMtYvn0e3Tm1QUZFl2f/TZy9p06IJOzctU3yJAqzdtP29j2nydyNYv3wee7eu4uieDfy7bjF1ajkCsHnbniylEiB/cFiYm7Jt/RLmz56OjrY2IL/oDx+TZ2Ru3LyjyDCUsjRn2cJf2bt1FW1aNAHkmZW/VmzIM74H109l6txy+r+LigfGt8P6c2jnOras+ZOffhhLLacayGRZz1tGS1ZuUGQUbaytWPf3PNYvn4etjbx9icel64q4enXroEhvz8HjijQOHDmlyLD37t4JAD//QMZP/ZW0tDT09XSZP3s6+7atpn/vboD8i/bn2QuzjenZi1d8M7Q/e7eu4q8/fkFPTyfH+N2bNuSvP35h56ZlHN2zgb1bVzHmm8GA/AsrpxIx39cB/PHrVLatX0ItpxoAREXH8NOs7GNK9+ixDyvX/QuAiooK0yaNYtfmv6nr4sSLbEq/C/K5S5LEsFE/KDKK1atWYvXSuezaspwpE77FxNhIke4Xndvy96JZ7NqynKN7NrBry3L69uwMyDMg+w6dQCaT0b+PvH1adEwshzJkEA+9uS51tLVp37oZAAePyt83MjRgzdLfObhjLauWzGHowF55tpvasvrPTE1S+vfuxon9mzmxfzMD+nRDkiS+/m6q4gu3a8fW7NqynB/Gf4OKigqSJDH5f7/h+9o/z/2kp3ti/+ZMPwpbNpeXQMXFxTN89BQSE5NQU1Pj5ynfsX/7asaN+gqAwKAQvvthRrbpP3vxil5fdGTXluWsWjKH0lYW7Np3RJFRNDYyZMm8X9i67i/FF/2jxz45XssZfTWgF6uXzmX3Pys4umcDOzYuo3WLxgCcu3CFy9duAnBi/2bFfQIwaewIxfG2dm+c534ymvzdCDavXqR47VijmiKtebOmAyiuizK2pdmy5k/2b1/NsoW/0rdnZ4wNDXJNPzY2jm/HT1dkFIcN6s3uf1YwfLA885ScnMy346cralnSMxEJCYncvisvGcr4JX3lzTm4fP2mYll2VetR0TGYmZrwz9o/+fH7MYrlBX32P/R+yvhRQ9mxcRkO9lUB+b2yffdBgCK7bqf8NFeRUWzWuAE7Ny3jx+/HZKqFKYiAwGCcHKqzfcNSvhnaX7F8TYbjX7hkjSKjaGtjxYYV81n+52z8/LN+h+XEoXoVRWHD1RteANy68yBTCe6Va/Ll6deviooK9evWyvc+QkLDWPzHz6xZ+jtGb663S1c9uf/wMVDwZ+61G7cUGUUtLU1m/zyZHRuX0di1HpD5/jc2MqR61UqA/FmdlpZGUHBopszr5TeZxPRrE6BhvfxnFkXJYj4Y6OtRs0Y1lq3ezO27DwiPiCI1NVXxfkxsHI8eP8PBvgr/7tyvWN6ja3uWLfw10+vsmJuZsnHlAjQ1Najl5KB4oD999vK9Y27iVp9FS9dyzfMWoWERmaqeJUnC6/Z9rEuXyrLdhhXzqVBOngkODArm90UrADhw5CTtWjdj664DinX79+5GpQp2AAwd2IujJ/8DYOvOA0wYPaxA8aqrv70U7crYULVKBUpZyL/YJ4/7Os/tt+8+pPh/0Zz/0baVPOOgp6tD9/7fArBjz2EmjB6GjbUVbg1cOH/xGucuXCU8IhJjI0P2HjwGyG/kHl3flHztP6oo1enSoTWONeQP4v59urJr3xHi4uPZsecwC+f8mKVNYs9uHZg3ayr50ahhXX5ftIK/Vqzn1Wv/LNW6nrfuZrvdqBED+HaY/CFbtUoFajZoC8hLpNJLPLJz6NhpJEl6c1ytmDpRXjLeoF5tKjo2IS4+PtP6Bfncb997yL0H3oD83jm8az3mZiYAisxluuaNGzBnwd+cOXcJ/8CgTCVo6cfd64sOfNmrK7P+WEpaWhrbdh2ke5d2+AcGKaoH27Vuhq6uPDOuria/lnR0tClvZ0uN6lXQ0dGmb4/O2Z6LjGo51eDem4c7yL+cMn7Je925z4NH8hIcSwsz1v39B+rq6rRp0YSH3k/Ze/A4SUnJ7D14nFEjBua6n3SrN2zl9H8XAXnGeuPKBQCcOnuBkNAw+Xlq0kBRCtCuVTN27zvKi1evOXnGg5DQcMxMjTOl36BuLdYu+z3Tsqk//6H4f/rk0YoS9fLlylC3qfzc7Np3lEVzf8r1x1nzJg2Zu3A5l656EhQcmqkkDuQ/mOvXcaZhvdqZqjcrlC/73m0RK5a3Q13t7bVsaKCXJS21N5+7oYEB5exsqVqpApqaGgzs+0We6Z/674Ki2YNzTXsWzf0JkHdsuOZ5m5u37hESGs7p/y7SsV0LGtavzd9r5B0erlz3okL5sjx67INdGRsCg0O45inPOGYspWqYTckiwLrl86hZoxqd28O23Qd59NiHkNBwIqOic61NyahDG3dm/m8CAHHx8QwcIf8//Tvk1t0Hhb5ug4JDFRliTU0NNq5cgImxEW1bNePRk2dsy/CMyC8NDXW2rPkTSwsz2rZqyoYtO4mLj8cnw3ffwaOnFP8v/O3tsz0pKYkxk37O137kGT9njp08x0NvHyIioxQlbNWqVOTBoydcue5Fp3YtuHHzDiC/F43y+JGR0fTJo/lqQC8ALl29oaiN9Hn2kupVKxX4mbstw3fa8MF9Gfum8KCuixOVnZuSmJjEyTMehIVHYGJshGv92tx74E10TCz3HjzmxUvfTMeXfi2mZ5aNDA2wr1Yp38cnShaRd3DJ+Cv/xP7NTP7ubenCvkPH6d7/W07/d5GQ0PBMGcV0kVFRADzxea5Y1rZl03ztv27tmmhqyqvvTE2M3qYZGVXwg0Fe3dC22yAOHj1FYFBItm0UI6Kypm1ibKjIKAK4ODsq/n/+Qn7hZTy+P/5cQctOX9Ky05eKDBmQpYoqP9q3aa449sn/+40KDo2xqVKfLn2Gs3v/0Ty3zxiXS62aiv9rZziGjOv0/qIjIC8xOHDkFBGRUYo2Pk3c6mFlaZFlm01bdyuOt1Xn/oqbOzIqGv+At+1H0rVr1TTPuEHejqVDjyH8tXw93k+eZdv+LyIy+/ZkdTIca8XydorqjISExGxjSpf+eULmjIuhgT6VKtplWb8gn/uTp2/XdanlqMgovis6JpbmHfqybvMOnr/0zZJRBHkPWJCXFrs3dQXkVfahYeEcOXZW8fDtmeGHWHrmwM8/kGbt+2BRvjYO9VozeuJPPH5a8Gszo4zH5uRYPVNmvLazw9v1Mpyv3Bw/fZ4JU+VNQizMzdi1+W8M9PUAeJwhjeOnzivOectOXypKIiRJwvuJT5Z022Tz7MkYU3otA4B9tcqKWoTwiEiCQ8JyjPflq9e4d+jLzr2Hee0XkCWjCG+fhR9a+ud+595DGrp3w7xcLWo36sD3P87J1L4rO48zfK4Zzw2AS4bPNf0zcc1QPXnluhdXb9xCkiQa1q9NrZr2hISG8/jpMy6/Ka0y0NfD8U2JX0bpBRHpMpa6F+T575ahOjFTGm/aoRbFdfs8QylVeTvbTPvJeI4KonLF8lhamAHyDJ2RkTxzFpHh2DOWjmV8ttet7VSgfaV/ZpIkcc3ztiLzNGq4vL3jlWs3ufsmsyVfv2A/bNwa1lH8n/HcRLz5DArzzM14TZqZGlOurK3iWNIz1hmvyas3vBSZ4RFD+iqaSURERvHQW/68qF/HuUCdLkVmkew7uFQsb6d4f/mat20Mvuzdlf3bV2epOkpLk957/+k3CLz9dQwg8X5prt6wTfEQb9uyKbv/WcGJ/ZsV1XuQv3jzqvrNSUpKSrZf/LkpZWGOx/GdjB81lIb1amNqYkR4RCQnTp+n/7Bx7NhzKO9EspHTMXTp2FqRQd978BiHjp1WVK/0epORLIjYuPgsyyzMzfK17aWrnty6I6+SL2Vpzsq/fuP4vk2sXz5PsY4kpeW0eSbv+ZG9k8aH+dz3Hz6haA5RpVJ5Nq5cwIn9m5k7420nlrQMx52eGUhOTmb3/qOKakdjI0NaNndTrDfoyx7s+XclfXp0onrVSmhoqOPz/CVrN22ndZcBmb6IilJBz9ude48YMGwcKSkpaGtrsWPj0iztmfMj+2uveHpubtm+l6joGADquTixbf0STuzfrKgah8I9Cwvjxx/GKpr7VK5YDplMxkPvpyxZsYFOPYfm2rEvN9l9rpYWZorS9as3vBQZj3ouTorOkaf/u6goYa+Xwxdzxmc/gJra21E4pAKcRqMMbd4yfYfkI5H3vd+LIg3jXI6/KPcDmdsfXr3uxZUbXqiqqtK9azvMzUzxunOf8xk6JhW0FNzY8MN9BtmtnrH9ofwHjBcAjV3rUbNGNfwDgti597AinpxKunMiMov54B/wthfr/NnTcG/iSv06zpmWp8uYyUyvnvvQ/DLE9cu0cbR2b0zDerUJCg7Ndbuw8EiePnuheJ1elQIoGtFnykT/OZvYwAdZ/oKfeSoyYvklSRJlbK2Z+b8JnNi/mZcPLnH+2Ntea/sPn8x1+4xx3bh5W/H/9QzHkHEdI0MDRZXomXOX2PjPLgC0tbXo0qFVtttMnTgyx+OtXDFrZ5L8PgD8/N+WevTs1oF+Pbtk+pWYm+sZjvXpsxeKdoJaWppYlbLIcbuMnSJuer2t4o6Miubxk+dZ1i/I516xwtt1b9y8k6XHebqMxz18cF++6NyWhvVqk5BDhrN962aK6tYN/+zirIe8JLhz+5aZOlRJkkSr5o1YvWQu1/7bT5DPDUa+KT0IDApRtEnKScZ2xe/2ysx4bLfuPMiUAbnu+fazyHi+suMfEMQXX35NdEwsMpmMVX/NweWdEq1KGdLo16tLjue8ZTM33pXdtZcxpozXzb0H3opScmMjwxxLgiHzZzZp7HA6tHWnYb3aREXFZLt+bueyoPKTVo+u7dm0aiE3Lxwm8Ol1unZsDcD9h48zlR6+q1KGz/X6m2rI7F5n/EzSMxMvX/mx75C8t3VdFyfqvSnxWr5mi6IWKr/3c3Epiuu2bJm3z4xnL3wzjQRxLUMaRa28na3i/xtebz+L9MxQftVyqqHoGLfv0Ale+fpjX60yerq61HNxIjExidUbtirWL0jnj/wozDM34zUYGhaOz3N5aatMJqN8uTIAWFlaUN5O/v/Fyzfw9LqHsZEhlSuWo66LvEQ2fVB7KFjnHRBtFgEIDgnl4pUbWZbXdnJAU1MDW5vSigfNzLl/0aKZG//u2K9oA5JR7y86Koa92b77ILo62nRo05zYuHgOHj3NVwN64tagTpbtilIZm9KK/+ctXkW/Xl04fuocJ8945Lnt4K8n8f24r3ntH8DSlW+H7+nQRj60QK9uHRTH98OboWNqVKtMZFQ0Ps9fcursRcrYlM62t3Vutu8+xJqNW+nQtgV2Zawx0NfnP4+3Qz/kVWLVs1t77t5/BMC4KTMVX8I//rpAsU56O8R0vbt3ZN+hEyQlJSs6x7Rv1Qx9PV3FOl07tubHWQtITJQPyyOTyajr4kR8XDzPX/py7sJV4hMSOLhjbYGON6Mytm8/r30Hj9Owbi3CI6MyxZ6TJSs2YmFuhq21laJ9KUCr5o1ybK8I8nZv/5s5H4C9h04wZ8EynBztWbF2C7FxWYdKKsjn7mhflepVK3H/4WMio6Jp330w40Z+hbGxIV637hEeGcWcX77PdJ1u/HcXdmVt8Hn2kt8XLs82Zg0NDXp378SSFRsyDWXyblvgfl+NRU9PF9d6tSlduhSpKSmZ1s84jFJ2MpYQnDjtgWt9F7S0NLGvVpmaNapRtXIFHno/JSAwmCHfTKJf765c97yt+EGjoaGe6QfHuxISEvniy68Vpaqd27fE0sIs0zOoYb3aNG/SEDNTE0JCw/hn+z6MjQxp3qQhaampvHjlx6Wrnty9/4gb5w/mejzpenZrryiN/fX3v9DU0MDUxJjZ85cp1vmic5tcf+Rk/MyWrd6MuoYG1z1vseHNj613GWU4l/sOHceujA3q6mqKZ2tBZCw9u/fgMQcOn8TU1BhbaytsbUrj3qEvNR2qUdvZkdKlLIiJjeWh99uOF4m5fO7uTVwxNTEiNCwCT6+7jJ8yk9YtmnD85Dk833yxm5kaZ6pNcm3gojju+w8fo6erg33VSli+qVHI2BynoFWaRa0orltLCzPq1HLkmudtEhISGThiAt8O/ZI79x5l6WFflDq0aaH4rp0w5Vdip48nLj4h0xAx+aGurk6dWjU5d+HK2xLfN5moui41OXj0lOIzK29XRtEUqagU9Jnbs2s7/l4tf+auWLsFK0tzKpYvy5KVGxXfhy2auWWq8nat74LP85eKqnu3hi7IZDLquTixbNUmxfFpa2vhXNO+QPGLzCLy9kDHT53Psvz+tZOULWPNkP49FQ3Ql6zYwJIVG9DS0sS5pn2mLyGQt/+YMuFbfnvzAF63eQfrMozrNPjNcADFaVC/7qzfshNJkti++yDbdx9UXDAZu82/y9BAnxevXtNz4MhMy5s3aUi7Nz1NXWo58sP4b5iz4G8iIqOY8tPcLOn069WlwDGnSWlcuHyDC5ezZtoha0bvXaOGD+TYyf+4cPkGL1/5MejriZned2vgwuh3Gm63dm+CkaFBpmrJd6ugrUuXYsHs6Yye9DOJiUnZzgvaqGHhMv91ajlSo3oV7t5/xItXr+k9eDQg76QQHJJ7aXA5O1smTP010zI9XR1+npr7+FlVK1dg6MBerN6wjdTUVMVQM9raWpS2ssTPP3OpeUE+d5lMxsq/fqND9yFEREZx9/4jvho5Oct67Vo3o5SlOQGBwdy684Av+n2tOO5LVz2zjXtg3y9YkqG3fSlL8ywzrERGRbPv0Am2bNubZXsLczOauNXP9dzUdXFCU1ODxMQkbnjdoWNPeRXrkd0baOxalxV/zlYMQbJr/1F2ZWhTK5PJ+H3mFGxymeUhMChE0ewAYO/B4+zN0CsfIDbwAbq6OqxYPJu+Q8aQmJikePZklPGHRl6+6NyWA4dPsnPfEcLCIxk54cdM71epVD7P66Z39478vmgFcfHxnP7vouK5mNNn1qhhXcWQHsdOnuPYyXPA22drQejr6SqeuRGRUYr7ZOrEkUybNIrgkDB5b9M3PU4zqlalAg65DO+iq6vDsgW/8uWwcSQnJ7Ni7T+ZhjhRV1dn2YJfFZ2oAFzf6Ula29kRVVVVLC3MFEM9gbwzSG2n92vTV1RkMlmhr1uAWT9Non33ISQnJ3Pq7AXFsFcVy5flic+LXLd9X9+NHMK23Qd4+cqPZy9e0f/N2IA1qldRDDmUX671a3PuwhXF6/QmA/UyjKsMBa+izY+CPnPrujgxbtRXLFyyhoSERH5455lraWHGojmZ7+GG9Wuzaevb4aPq5XB8dZwdCzy8naiGzoeuHVvz1x+/ULF8WbS0NKnt5MDef1cquqq/a/rk0ezaspyWzRthamKEuro6VqUs6Ny+JXYFfEC+D5dajmxd9xf21SqjpaVJtSoV2bx6kaKDQE4MDfU5sX8zLZs3QldHBxNjQ4YO7MW/6xZnKm343/dj2LX570zHV9rKkob1ajNj+nimTxpV4JjruTjx7bD+ODlWx8zUGFVVVQwN9HGtX5uNKxfk2JM8naamBge2r2XG9PHUqF4FbW0tRWnQL9PGs3/bmiw3h6amhqKaCuSdizK2fUs36MseHN+3ic7tW2JhboaamhoW5ma4OMszUAvfuWELSlVVld1bltOhjTuGBvqYmZrw7bD+LF0wM89tf/t5MtMmjaK0laVi5osjuzdQpVL5PLedP3s6P4z/hlKW5mhpadKgbi0O7VhLhTfVGu8qyOfu7GjP5dN7GDaoN+XK2qKhoY6RoQF1a9ek1ZuhYfT1dDmwfQ1N3Oqjp6tDaStL/vf9aKZPHp1jzNWrVsrU2Fs+HFXmx9jwwX3o3rkt5e3KoKerg5qaGqWtLOn1RUdOHticZw9TM1Njtq5fQk2Haopqq4xcajnicWIn/Xp1obSVJWpqam/aTTZi/7bVRTbGIsh7j58/toM+PTphXboU6urqmJka41ijGqO/HsTmVYvynZZMJmPd8nks/uNnXJwd0dXRQVNTg0oV7JgwehhnDm/Nc4xFW5vS7N++GhdnR7S1tShvV4ZFc3/McezKGtUrs2rJHKpWrlDgksTsrF8+j5bNG2Ub58Qxw+jQxp0ytqXR0dZGXV2dsrbWDB3Yi0M716Oax6xcHdq6c+bQv3Tt2BpzM1PU1NQwMzWhc/uWnD74D+3bNM+0vl1Zm0wjSqSXUgGZJnVwcS54KWpxKIrr1rW+C7u3LMfJsToaGuqUsS3NzP9NYMKY4cUWt5GhAcf2bKR96+boaGtjamLE8MF9+PP3nxTrZHefZufd5gDpmahaNWtkamdYXDMIFfSZ++v/JrJp1UIaNayDgb6e4poeMaQvF07uyjLGqts7VefpnYBsbUpT2spSsfx9MsMyKT+tLwVB+GgMHzNFUWqWXtr1Ock46P1/R7ZlaesnCELJIklSluYRqzdsZezkXwD4Zmj/fA9TJrwfUQ0tCMInISY2lsCgEHbuPQLIq01FRlEQSr5u/UbQpUNr6tRyRFtLi4tXbzBjzp+K97t3aavE6D4Pohr6IzR/yXp+nrs02/f8AoJwad5TMRbU7IUrWbxy84cM74Nxad6TR9n0EvuQrnvdo2nHQfle/8DRs/QdNum999exz0jOelzN8f2+wybx6vXbmQt+/3NNjut+KGN+mM2Ofcfee/u+wyZx4OjZPNezLO+CY/02imnNvh/3zXvvsyA+huuwuDVq158nPu8/CcDnrufg8Zy/lH1768/Jz3OXMn/J+iJP96H3U74dN506TTpRo14rho+eomiv+N3IIdSv41zk+xQy+2xLFoeP+5k7971RV1NDpiLD0tyMBnVqMqhPlyxjP+Xk57lL0dfVZcKoQZnSbepah77dc29jV1Smjiu+tiLCx2/y2K/yXqmYLZ7z4ap/ZDIZtjZWjB4xiF5fdPhg+31fB46e5d9dh/hn1R95r6xE5w9vynulj4hL855sWfk7VbIZzFgZtq/Le+SCovapXFtFYVDf7hw8dppnz18RHROLkaEBtZzsGTqgd5a2pELx+GwziwCjh/Wjb/f2SJLEsxevWbVpJ19+/T0bl/2WaSYV4cNKSUnJ1NhYyOzbYQM5smudssP44DLOJV6Sietf+BSlZDOzWVH5fvw3fD/+w9QkCNkTTyTeDGxpZ8PMqaPpO2wym3ccZOyILwG4fO0Wi1dt4bV/IDZWpRgzoh/1ajuydfdhjpz0QCaDvYdPYWVpToO6TnjdecCd+978vXYrzo7VWDxnKnHxCfy1cgvnLl0nKSmZBnWcmDx6CHp68mEYPG/dZ+7iNfj5B1HfpSb6+rq5hZtJxtJNv4AgOvUdxS8/jGLVxh1EREbT1K0O0yeMUHz5PPT2YeHyTTx++hwDfT0G9u5M1w4tFO/N+XMNz174oqamhmP1Siyc/UO2+3Vp3pNJo4ewc/8x/ANDaOZWl0mjB/PbwlVcvOqFdWlLZk8fq+j9vXnHQXbtP05oWATGRob07d6eXl3bACji/nHSN6zdspu4+ASO71qVaX8vXvkx5offMm2XUUpKCqs37eLISQ9iYmNxtK/C1HHDFAMM/7liMyfOXCQqOgZLC1NGDOxJi6YNFNs/8Pbhz+Wb8H76HBUVFVo1c2XymCGK9/ceOsWqjTtJSEykU9vmiusjJ6s37WTbnqPIZDIG9emiKGmWJIktOw6yY99xomNisK9ake/HDsWmtGW26Wzbc5SNW/eRkJhIt44tM733bslCxz4j6d65FWfOX8Xn+SuqVirHjKmjKfVmOq2nz14xc95yfJ6/olqVClSvUoF7D5+wcuHPWfa7/t+9PHrynN/+9x0AX474HjU1NdYvlY+fOemnedS0r8KXPTtmKk2/7nWPif/7g+++7p/j+crtmAAOnzjH2i17CAkNp0I5WyaNGkzVyuW5++AxE/73B8d2rgRg4d8b2br7CGf2r0NHW4utu49w5fotFs7+gYDAEHoPncjW1fMoZZl1Jp0xP8ymcUMXundqRUxMHO5dhvBlz46MHt4PSZJo2W0of82dRrXK8l7ld+5787/ZfxEYFEKtmtWZOWW04v793+zFXLt5j/j4BGytS/Hd1/1xca7Bw8fP+G3hKlJSU2jUTj5/9451C7PEs2L9dh54+2BpbsqJsxfp2KYZ333dn217jrBjn/yeqVzRjinfDaXcm96PHfuMpFvHFvLP+oUvtRyrMXPqGP5eu5WjpzwwNjLg5+9HUrNGFcU5Xf/vPgICg9HX16VDqyZ8PbiXotNAxpK6Feu389Dbh1KW5hw5eR5dXW3GjuhPq2byMQYvX7/NouUb8fMPQktLk2ZudZkyLutc8On39bTxw1m7ZQ9x8fG0bNqQCSMHoa6uRlx8AtNnLebOfW+SkpOpXN6OSWMGU/nNANI5PY8GfDMFgCGjp6MikzG4X1eG9OuWZf/3Hz1l3pL1+Dx/hbmZMV99+QVt3N0U5zy3Y5QkKdfz/66OfUYyYeRAmrrV5bV/ELPmr+DeoyeoqqhgV8aGZX9MR0tLM9vtcrtnX70OYO6fa7j/6An6enr06tqGvt3b5/vayu15s2XHQc5fusHyBW97FR8/c5EV67eza8MiAI6dvsC6f/YQEBhCGRsrJowcpLimho/7GfuqFfF+8pxb9x4xe/rYLMeX070Bb59frvWc2X3wJFpamgzq04UenVtnSUf4CEifqWHf/SRt2XEwy/Klq/+VBnwzRZIkSXrp6y81bN1XOvXfZSk5JUU6cfaS1LBNP8nXL1CSJEn6ac4Sad5f6/JM9/uf50tTZy6SoqJjpLi4eGnKjIXS9FmLJUmSpMioaKlJh4HSzv3HpeSUFOm/C9ek+q36SD/NWZJt3K/9A6XazXpIUdExWWJIf2/qzEVSTGycFBQcKrXr+bW0/8gZSZIkKTg0XGreebB0/MwFKSUlVXrs80Jq3X24dOXGbUmSJGnwyGnS6k27pNTUVCkxMUm64XUvx/NXu1kP6ZuJM6SIyGgpKDhUatltqNTrqwnSzdsPpOSUFOnnOUul76bOUax/8r9Lkn9gsJSWliZd87wjNWzdV7p550GmuCdM/12Kio6R4uMTFPt4+PiZdOf+Y6ltjxHS8TMXcoxn0fJN0tfjf5GCQ8KkpKRkaeGyDdLQMT8q3j984pwUGhYhpaSkSkdPeUgNWvVVfI6BQaFS4w4DpO17j0oJiYlSfHyC5HnrviRJknTt5l2pjntPaf7S9VJCYqLk8/yV5Nr2S+nazbvZxrH/yBmpbove0qZt+6Xk5GTp2s27Ut0WvaVXvv6SJEnSgWNnpTbdh0uPn76QEhITpQXLNkg9Bo2TklNSJEmSpA69v5XOnL8iSZIkXb1xR2rcYYB06+4jKSkpWVqy+h+prnsvxee5/8gZqc/QiYp9d+j9rdTrqwmSr1+glJCYKI3+frbiOkpOTpY69R0lrVi/XUpKSpbu3PeWmnceIg377qdsj+PO/cdSq25DJUmSX6Otug2VmnceLMXExklpaWlS886DpQfePpIkZb7m8zpfeR3TDa97UqN2/aUbXvek5ORkacuOg1KLrl9J0dGxUnJKitS4/QDJ5/krSZIkqc+wSVLnfqMkj8uekiRJ0oTpv0ubtx/I8RrJaP2/e6UfflkgSZIknfG4KnXuN0px3z968kxq1mmQlJqaKkmS/DocMe5nKTQsQoqKjpH6DpssLV+3TZHWvsOn5fElJ0sb/t2nOE/ZfUbZWb5um+IcJKekSPHxCdL2vUel3l9NlF688pOSU1Kkf3cdkjr3GyUlJSVLkiT/rPsMnSj5BwZL0dGxUo/B46Wu/cdIp/67LKWkpErL122Ten01QbEPj8ue0vOXr6W0tDTp4eNnUstuQ6XDJ84p3k+/19Ljqdeyt+I5ceDYWalRu/6KY2rdfbh08Nh/kiRJUlxcvOR152G2x5V+X4/+frYUFR0jBQWHSn2GTpRWrN8uSZIkRcfESsdOX5Di4uKlhMRE6Y+/1kpd+4+R0tLSJEnK/XmUMd7sREXHSM07D5H+3XVYSk5Olq573ZPc2n6peObkdYx5nf93Zbxvp85cJM1asEJKTk6WkpOTJa87D3PdLsd7NiVF6jZgrLRo+SYpITFR8n7yXGrdfbh05OR5SZLyd23l9rwJCQ2X6rXsLfkHBivWHzvlN2n1pl2SJEnS+Us3pLY9RkgPHj2VUlNTpVP/XZaadx4shUdESZIkv+9bdP1KunP/sZSWlibFJyRm+U7M696o695LWrL6HykpKVm6dfeR1Lj9gFy/dwTlER1c3mFhZqKY+/T4mYvUdrKneeN6qKmq0qJJfZxqVOXY6bxnQkkXHhHF6fNX+H7sV+jr6aKtrcXXg3tx4uxFUlPTOH/JE3MzY77o2BI1VVUaN3ShjnONvBPOxbAB3dHV0cbczIQGdWry4M3E4YePn8PZoRotmzZEVVWFiuXK0LFNU46ekh+PmpoqAYHBBIeGo6GhTq2a1XPdT/+eHTE00MPczIRajtUoX9YGJ4eqqKmq4t6kPo8ev53BwL1xfUpZmCGTyXBxrkH9OjW54XU/c9wDe6Cvp5vpF/ilq15M/PEPfvlhFC2bNiQ7kiSxc98xxn07ADNTY9TV1fjmq97cuveQgKAQANq2aISJsSGqqiq0bu6KXZnS3L4nn/Hl8MlzVKtUnh6dW6OpoSEfcN2xWob04dshvdHU0KBcWRsc7SsrJmPPjpGhPl/27IiamhouTvaULmXOozczAB0+cY5e3dpSsXwZNDU0GPlVHwKDQ7n34EmWdI6cOk9b90Y42ldGXV2NEQN7oKWdtXQio+6dWmFtZYGmhgZtW7gpPvs79+WzqQz5shvq6mrUqFaJVs0a5JhOtcrlSUhKwue5Lze87uPsWA3H6pW5efuBorNHTu3FcjtfeR3T4RPnaNuiEbVqVkdNTY2+3dujr6eLxxVP1FRVcXKoynWve0RGxRAaFkH3Tq247nWPtLQ0PG/fp06t/N07Lk723Lglv/6u37xL727t8PULJCY2jmued6nlWD3T+I0DenfGxNgQfT1dmjeul+nz79S2GXp68vEcB/TuRFqaxOMCDlBcoZwtHds0RU1VFS0tTXbsPcaIwT0pY2OFmqoqvbu1IzExibsPHiu2+aJTK0pZmKGnp4NrPWcMDfRo3rgeqqoqtGzakKfPXpGcLJ/WzbWeM2VtSyOTyahS0Y7WzVy54XUvp3CoWqm84jnRvmVjklNSeOnrD4Caqiq+fgGER0Shra2lKGnKyfA397W5mQmD+nbl8An5wNx6ujq0atYQbW0tNDU0GDGoJy99/QkOkU8PWdDnUUYelz0xNjKgd7e2qKmpUbtmddq4u3Ho2NspWHM7xvyc/5yoqakSEhqBX0Awampq1KxRBXX1nCvxcrpn7z54TEhYuOJeqlShLD27tM5XZ7B0uT1vTE2MqFvLkaMn5c//sPBIrty4TfuWjeXnYN8x+vfqRNXK5VFRUaF543qUtbXmwpW302W2ae5GjWoVkclkaGUzlmRe94aWtiYjBvZAXV0NR/vK8s/ozfUhfFxENfQ7gkLCMNDXk/8fHIqVpXmm961LWxAUHJbv9PwCgkhLk+jUN/NA1SoyFULDIggODcuyj1KWZiQlJb/nEZCpvaW2lhbRsfKe0/6BQVy4ejNT7960tDScHOQZox8nfcPKjTvp//UP6Ovp0rNLm2yrfNNlnGZIS0sTfV3dTK/j4hMUr4+cPM/m7QfxD5Sfj4TEREq/M3dxetVLRv/uOkSdWg65ZgIiIqOJT0hk2Hc/IePtWFzqamoEBoVSysKMLTsOsu/waQJDQpEhIz4+gYjIaAACAkOwtcl55gJdHe1MGVhtLU1i4+JzXN/UOPOAwdpamsTFyc9FUHBYpuPW0JAPshyUzUwtIaHhmb4g1dTUMDMxznG/AGaZPvu3+w0ODcfM1Bi1DAMTW1qY8fS5b7bpqKqq4OxQjeted3n+0g8XpxokJSdzw+sepiZG1KpZPcdp4XI7X3kdU1BIWJZMgbWVBYFv5jV3cbLn+s17mBgbUsuxGnVqOTBr/goePXmOTKZCpfJlcz0/6apWKk9iUhJPn73i2s27fNGxJddu3sHrzkOu37ybaYBlePee0iT2zbWdlpbG3+u2cfLsJcLCI5HJZMTGxSuurfyyfOfa9wsM5sfZf2XKsCanpCjOA2S+zrQ0NTDJ+FpLA0mS32fq6mpcuubFqg07eeHrT0pqCslJKTSs65RjPKYmb9OSyWRoamgoPsN5MyayZstuvhg4llKW5gzu2yXHH3IAVhmqRq0szQgOkT8/ExKTWPT3Ri5cuUlUdIzieoqIisLC3KTAz6OMAoNDKV3qnWe3lSWet9+2e83tGPNz/nMydkR/Vm7YwbcTZyKTyejQugnDBnTPMnh8upzu2aDgMMxNTTJlNK2tLDlyMutsYznJ63nTvlVj1mzaxaC+XTh2+gKO9lUUVdn+AcEsXfMvK9ZvV2yfkpqq+PwALLNp4pEuP/eGualJpva5VpbmeN6+n11ygpKJzGIGKamp/HfxGq715N3wLcxNuXX3YaZ1/AOCFaVO2X1ZqryzzNLCDBUVGUd3rMi2zYq5qQn+gcGZlgUEhmJinL8e2QVhaW5GU7e6inZo77KxLsWMKaOQJIlbdx/x7cSZONpXVrTbel8BgSH8PGcpi+dOpbaTPWqqqkz43+/wznDwKipZz+ev08ayaPkmfl+8NlMbwowMDfTQ0tJkw9LZ2c6Q43XnISs37mD5/J+oUtEOFRUV+g6bhPRmPPpSlmZcuX67UMeYXxbmJvgFBCleJyenEBIajoWZaZZ1zUyNCQgMUbxOSUkhJCz8vfZrbmpMaFgEKampigxjYFBIrtu4ONlz3esez1+8pmeXNiQnJzPjj78xMTakYd33G6oir2OyMDPBPyDz/eAXEIylufz8uDjXYMPWfRgbGeDiXIPKFcoSEBTCmfNXqe2Ucwb2XaqqKtRyqMaJsxeJioqhXFkb6jjX4Mr123jeecDIYX3zlc7RUx4cO+XBX3OnUcbGCplMRrNOg+XFq4Asm2s6O+9e+5bmpkwYOSjXDF1+JSenMOmn+fww9itaNXNFQ0Od+UvW4xcYlPfG2ahauTx//DKRtLQ0znpcY8qMhdRyrJ5jp0D/wBDFewFBIYp2xJu3H+CBtw+rF8/A0tyU6JhYmnUanH7qcn0e5fU5W5qb4vfudRQYhKW5Sb6OsTDn38TYkB++GwrAE5+XjJw0k4rly+DeOPdpJt9lYW5CcGhYpg5P/gHBimdFfq6tvJ43TVzrMHvhSh54+3D4xDm6d347N7SlhSk9u7ahe6ec54t+9/suo7zuDSDL8WW8PoSPi6iGfuP5y9f8PGcpMbFx9OsuH5KjVbOG3PC6x9kL10hJTeX0uSt43n5Aq2byafNMjY3w9Q9UZDpA/qDw9Xs7x6OZiRFNXOswd/EaxRzEIWERnDkvH0vPrX4tgkLC2HPwJCmpqXhc9uT6zbvFcoztWjbm+s27nDp3mZSUFFJSUnj05Dn3HsqrQA8e/4/QsAhkMhl6ejrIVGQ5/houiLj4BCQkTIwMUZHJ8LjsyeV8Zs4MDPT4e/7/uHPfm98Wrsp0rtOpqKjwRceWLPx7o6LaOSIymuNn5PPWxsTGoaqigrGhAWmSxL4jp3n67JVi+7YtGnHv4RN27j9OUlIyCQmJ3LxdPD1v27VoxI69x/B57ktSUjLL1m7F3MwE+2oVs6zburkrR06d5+6DxyQnp8g7jMQnvtd+HapXQl9Ph/X/7CElJYV7D59w4uylXLdxcbLnyvXbxMTGYVemNBXLlyEoOBTPW/ffu6lEXsfUtmVjjp7ywOvuQ1JSU9m6+wiRUdGKH3BVKtqRmprGkVPncXGyRyaT4eRQlW17j2SKKX080oxflO+q7VyDf3cfVpRkujjXYP+xM2hqaFAxh+m33hUbF4+amhpGhgaK44nLUOpsamxISFgECYlJBTpPPTq3Zvm6bTx/6QfIr+GzF67lWqKdk6TkZJKSkjA00EdDQ527Dx5ztABNaTJKTk7h0PFzREXHoKKigr6evDYht6n0Vm/aSXRMLMEhYaz7Zy9tW8ine4yNi0dTQx0DPV3i4hNYujrznM65PY/kz9mALPtK51rPmfCISHbsO0ZKaio3bz/g6EkP2rdqkq/jLMz5P3H2IgGBIUiShJ6eDioqKnlONZidGlUrYmpsxPJ120lKSubJs5ds23OEDq3lx5Cfayuv542WpgbujeuzbM2/+LzwpUWTt01TenRuzaZt8gy9JEkkJCRy5cbtfJWuQt73BkBCfCKrN+0iOTmFuw8ev2mmknXKVUH5PuuSxb9WbWH5um3IVGRYmJnQsK4zm/6eo6jOsbUuxe+/TGTp6n/46bclWFtZMG/GREXP1S7tmvPDjIU07zwESwtTtq6eR9/u7fl57jKadhyEk0NVFs3+gZ+/H8mK9dsZ8M0UIqNiMDE2pGXThjRrVBdDAz3mz5zM74vXsmDZBurVdqRNCzfS0tKK/HgtzE34a+40/lq5hdkLViFJadiVseHrwT0BuHrjDn+t2ExcfAImxkaMHfFlkYxjVt7OhiH9uvH1hBmkpaXRuGFtGjd0yXvDNwz09Vg273+MmjyLWfNXMG3CiCwlC6OG9mXD1n18M2EGoWERGBroU6dWDVo1a0jDuk64N65Pr6ET0FBXp13LxpnaWVmam7Js3o/8uXwTS1b9g7q6Gq2bu2Zqt1hU2rdqQmh4JOOmzSEqOhb7qhVZOOv7TNXD6erVduSbwb2Y/NN8EpOS6NaxJRXK2b7XftXU1Jg/czK/zl/Bhn/3Ub1qRdq2aMSzF69z3KZyRTtUVVWo7STPTMlkMmrVrI7n7QeUt8u+V2he8jqm2jWrM2n0YGb+sZyQsHAq2JVh8ZypikyJiooKzo7VeOjtQ1nb0gDUdXbg9LkrmTKLAYEhWFmaY5FLKYWLkz2L/t6o2K5iuTJoaWhQy8k+38fToVUTrt64Q8c+36Kro02fL9pjYf62lLiOcw1qVKtEu54jSEuTcuyd/a5eXdugqqrC5J/mERgcio62Fk4OVd8rk66ro83kMV8xa8FK4uMTqFWzOi2bNiQwOPeS5ZwcO+3BgmXrSU5OoZSFGb9OH4ORYc7zbTdp6ELfYZOJjYujRdMGDO7bFYB+PTow/dc/afXFMIwMDfh6cC927j+u2C6359E3g3sx7691/DpvBQN7d2ZQ3y6Z9mmgr8efv01lwdL1LFn9D+amJvzw3VCcHKrm6xgLc/4fePuwcNlGomJiMdDTpXO75jQpwPMunZqaGgtnfc/vi9fSuvtwDPR16dejg6JHd36urfw8b9q3asKIcT/TurkrujraiuWNG7qQlJTMr/NW8No/EA0NdeyrVOD7sUPzFX9e9wbI2+qmpqbSpsdwtDQ1+XZIH0VvaeHjIuaGFoTP1KwFK5HS0pg+8Wtlh1LkVm7YgamJEV9kMzSP8GGkD51zZv86RWZfENJ9ToOKlwSfdcmiIHxObt5+gFUpeWnbda97HD15nj9+majssIrF8IE9lB2CIAhCiSEyi4LwmXjtH8jUmYuIionF0tyUUcP6Ub9Ozbw3FARBED5rohpaEARBEARByJHoDS0IgiAIgiDkSGQWBUEQBEEQhByJzKIgCIIgCIKQo8+ug0taWhp+fn7o6+vne7YHQRAEQShpJEkiOjqa0qVLF8kEDELJ9dllFv38/LC1fb+BjQVBEAShpHn16hU2Nu830L7wefjsMov6+vKZBl69eoWBQdHPv/y5SEmMIjb4Hrrm9qhpivOYl5S4SKJ8PDEoXws1HUNlhyOUMPHxCfg8f0V5O1u0tbWUHY7wiYiKisLW1lbxvSgIOfnshs6JiorC0NCQyMhIkVkUBEEQPlvi+1DIL9FIQXgvcaGP8Tk5gbjQx8oO5ZMQ8+o+d5cMJubVfWWHIpRAfv6B/PjrAvz8A5UdiiAIJZDILArvJSU+hPiwJ6TEhyg7lE9CUmQQsb73SYoMUnYoQgkUERnFngPHiIiMUnYogiCUQKIaWhAEQRA+Q+L7UMgvUbIoCIIgCIIg5EhkFoX3EuV7iXvbuxDle0nZoXwSwu6e5eqU+oTdPavsUIQS6P7Dxzg1bMv9h6INsSAIRU9kFoX3oqZtipZROdS0TZUdyidB3cAcHavKqBuYKzsUoQQyNNCnXevmGBqIIVAEQSh6os1iEXjtF4BVKQsxAr4gCILwyRBtFoX8ErmbQnr2/BWN2/Rk+JgppKSkKDucDyYlMYoo30ukJIrel/mREhdJ2N2zpMRFKjsUoQSKj0/g/sPHxMcnKDuUj4KXlxfHjx/PdZ29e/fi7e39gSLKys/Pj379+ilt/4JQECKzWAiBQSF06DGEgMBg/t2xn35ffUdCQqKyw/ogYvxv8OrCLGL8byg7lE9CxMOLPN44kYiHF5UdilACPXz8lDpNOvHw8dMPtk9JkkhMTCqWv/xWeKWlpWW7/FPILJYuXZotW7ZkWZ6amqqEaAQhd6IauhCSkpL4auT37N5/VLGsiVt9tm1Ygr6ebmFD/aglx4cR7XcF/dL1UNc2UXY4H72kqBDCH5zDuFpjNAzMlB2OUMLExMZy77439tUro6f7YZ49iYlJmJSpWSxph728haamRrbvPX/+nI4dO2Jvb8+NGzfo1KkT586dIykpicmTJ9O7d2/KlStHQkICpUuXZvbs2bRr1y5TGleuXKFt27YYGRlhYGDA8ePH8fX15euvvyY+Ph5nZ2dWrlyJllb2UyceO3aMn3/+mYSEBOzt7Vm7di03btxg7NixXLx4kdDQUNzc3Dh//jxHjx7lwIEDBAcHExAQwLfffst3333H8+fP6d69O9evX2f9+vXs37+fsLAwTExMCA4OZvXq1VSpUgVJkqhSpQqXL1/GxKRon7WiGlrIL1GyWAgaGhqsXz6PgX2/UCz7z+MyHboPISw8QnmBfQDq2iaYVGgrMor5pGFghmW9biKjKBQLPV1d6tVx/mAZRWV78OABU6dOZdKkSVhZWXHt2jUuX77M77//TkREBDNmzGDAgAF4eXllySgC1KtXj06dOrF48WK8vLywsLBg4MCB/PXXX9y5cwddXV2WLVuW7b5DQkL4448/OH36NDdv3qR8+fKsWrWKBg0a0LhxY+bOncvIkSP58ccfKVWqFADXrl1j//79eHp6snz5cp4+zVoCfOvWLfbv38/u3bsZPHgwGzduBODs2bM4ODgUeUZREApCZBYLSVVVlaULZjLmm8GKZddv3qZ1lwH4B5bc2Triw314fmYa8eE+yg7lkxD7+hEPVn5D7OtHyg5FKIH8A4OYu+DvEv3Myahy5co4Ojpy/PhxVq9ejZOTEw0aNCAyMhIfn4I/kyIiIkhMTKRevXoA9O/fn/Pnz2e77uXLl7l9+zYNGjTAycmJHTt28OzZMwB+/fVXNm3aREJCAv3791ds06ZNG4yMjNDT06Ndu3ZcupR1yLHWrVsrSvd69uzJnj17SEtLY+PGjQwcOLDAxyQIRUlN2QGUBDKZjNk/TcLY0IBf5vwJyMc9a9nxSw7uWItdWRslR1j0kmL8iA26TVKMH9rG5ZUdzkcvIfQVUU+vkxD6Cl3rKsoORyhhQkLCWbHuH9q1bo6VpcUH2aeGhjphL28VW9q50dHRAeRtFlesWEGTJk0yvX/v3r1iiSt9n+3bt2fdunVZ3gsKCiIpKYmQkBBSU1NRVVUF5N8R6WQyWabX6dKPCUBPT4+6dety6NAhzp07x8qVK4vhSAQh/0TJYhGRyWRMHvc182dPVyx79uIVLTr148GjJ0qMrHgY2rph3+sAhrZuyg7lk2Dq2IJ6c69h6thC2aEIJZCDfRV87pzHwf7D/RCRyWRoamoUy192manstGrVimXLlik6hdy9e5fU1FT09fWJjo7OdduM6xgZGaGpqcm1a9cA2LJlC40bN852uwYNGnDmzBlevHgByNv9pZcsDhs2jL/++os6deowf/58xTZHjx4lMjKS2NhYjhw5Qv369fM8tsGDBzNixAg6duyIunrumWdBKG4is1jEvv6qH6uWzFH8ovQPCKJ1l/7cuHlHyZEJgiCULMOGDcPOzg5nZ2dq1KjBuHHjkCSJZs2a4enpibOzM4cPH8522969ezNz5kycnJwICgpi/fr1jBw5EkdHR6Kjo/nmm2+y3c7c3JxVq1bxxRdf4OjoSOPGjXnx4gVr1qzBwsKC9u3bM2fOHDZs2MCjR/JmJ3Xq1KFjx444OzszfPhwKlSokOexpWdWBwwY8J5nRxCKjugNXUwOHjlF/+HjSEpKBkBPV4cdm/6msWvdYtvnhxTtd5VXF+dg2/AH9EuXjGMqTuH3z/N4yw9U6jcH4+qNlB2OUMI89H7KkG8nsXbZH1StnHdGRPhw1q9fz927d5k3b16BtvPx8aFHjx7cuFF8w5OJ3tBCfomSxWLSoa07u7esQPdNO5SY2Di69BnG4WNnlBxZ0VDR0EdDzwoVDTG9WH6o6RiiZWKDmo6hskMRSiBdHW3quTihq6Ot7FCEIrB69WqaNm3K7NmzlR2KIACiZLHY93ftxi269h1BeIR85g5VVVVW/TWHXl90KPZ9C4IgfO7WrVvHn3/+mWlZjx49mDZtWp7bdu3aVdEeMd2mTZtwcHAo0hiVRZQsCvklMosfwL0H3nTs+RWBQSGAvGH4wjn/Y9igPh9k/8UhJSmOxMhnaBqWQ01DJ+8NPnMpCTHE+T1Gp3Ql1LT0lB2OUMIkJiYREBhMKUvzHAezFoR3icyikF+iGvoDsK9WmZMHtmBXRj6EjiRJfPf9DP7489MdDiHG7wrPT39PjN8VZYfySYi4f54Hy4cRcT/7sdsEoTDuP3pM9TotuP/osbJDEQShBBKZxQ+kvF0ZTuzfTLUqbxuf/zx7IdNnzsv3PKgfEx0LBywcB6FjUTKqY4qbfvla2LYbjX75WsoORSiBKpQry4Hta6hQrqyyQxEEoQQS1dAfWEhoOF37DsfT665i2ZD+PVk090fFcDuCIAiCUNyU/X0ofDpEyeIHZmZqzKGd62jUsI5i2dpN25kxZ7ESoyq4hIjnvDg/g4SI58oO5ZMQ5/+ER+vHE+df8gZoF5QvMCiExcvXK9pFC4IgFCWRWVQCA3099vyzkrYtmyqWzf9rFaf/u6i8oAooIfIlMX5XSYh8qexQPglxgU+JuH+OuMCnyg5FKIECgoKZ/ccSAoKClR1KsZs0aRL29vbMmjUr39usX7+eiRMnFmq/EREReU679/z5c3R0dHBycsLJyYlJkyZlu96gQYM4ePBgoeIRhA9JzA2tJNraWvyz9k9ade7PNc/bSJLE0FHfc+nUHiwtzJQdXp6MyjbGqGz202EJWZk5tcbMqbWywxBKqJo1qhHw9Lqyw/gg1q9fT2BgICoqxVPWkXFO54zSM4vDhw/Pdfvq1atz/frn8VkInw+RWVQiDQ0N1i+fTwP3rkRFxxAYFMLwMVPY88+KYnsQCoIgFJUHu3ogpSUXWXoyFXWqfbEjx/e7du1KeHg4Wlpa6OrqEh4ezsqVK5k7dy5Pnz7l9u3bTJ8+nf3793Pw4EHGjx+PgYEBNWvWxNjYOMd07ezs6N27N8eOHeP3338nICCAxYsXk5SUhLu7OwsWLGDatGncv38fJycnunXrxo8//ligY/v555/5999/sba2RlNTs0DbCoKyiRyJktmVtWHpgpmK1yfPePDn3+uUGFH+RPtd58GuHkT7iV/Q+RH+8ALX/teY8IcXlB2KUAJ5P3lGi4798H7yLO+VP2F79uzByMiImJgYLC0tAfDw8MDIyAh/f388PDxwc3MjISGBUaNGcerUKS5duqSYozk3tra23Lx5ExsbG/bt28elS5e4desWISEhHDp0iFmzZlG9enW8vLxyzSg+evQIZ2dn3N3dFSWM165d49ChQ9y+fZstW7Zw6dKlojkhgvCBiJLFIiJJEjKZ7L227dapDaf/u8i6zfJf1D/PXkSjBnVwqeVYlCEWKRV1bVQ1jVBRF9OL5Yeqhg7qeiaoigHMhWKgqaFB+XJl0NT4sANy51YKWJw0NDSwtLTE19cXHx8fBgwYgIeHBx4eHowcOZKHDx9SuXJlbG1tAejZsycvX+bevrpHjx4AnDp1isuXL+Pi4gJAXFwctWvXxt7ePs+4rKyseP78Oaamply6dIkePXrw+PFjLly4QNeuXdHU1MTKyormzZsX8gwIwoclShYLSZIkAi/u4M7C3qQkxLx3Or/PnKIYgzElJYWBIyYQGRVdVGEWOV1zeyp3WIWued4PUAEMyjvj9P1eDMo7KzsUoQQqW8aalYt/o2wZa2WH8sG4urqyfft2rKyscHNz48KFC1y/fl2RySvoj3cdHfkPubS0NIYNG4aXlxdeXl54e3szduzYfKWhqamJqakpAA0aNMDMzAxfX9/3ikcQPiYis1hIMpmMiEcXiQ94SsB/m987HR0dbTasWICWlrwty/OXvoye8ONHO2B3WkoCCZGvSEtJUHYon4SUpATiAp+RkiTOl1D0kpOTCQ4JIzm56NoPfuzc3NxYuHAhrq6uODk5cfz4cSwsLNDU1KRq1ap4e3vj6+tLSkoKO3bkvwTU3d2dbdu2ERoaCkBQUBD+/v7o6+sTHZ37D/jg4GBSU1MB8Pb2JiAggNKlS+Pm5sbevXtJSkoiICCAM2fOvP+BC4ISiMxiEbBtMxJkMvzPbyE5OvS907GvVpk/Zk5VvN61/ygbtuwsihCLXJTvJZ4e/YYoX9H2Jj8i7p7hzvweRNwVXxJC0bv7wBs7e1fuPvBWdigfTMOGDfHz88PV1RVVVVVsbGxwdXUFQEtLi8WLF+Pu7k6DBg2oXLlyvtO1t7dn2rRpuLu74+joSPv27QkLC8PU1JRatWrh4ODAjBkzst323LlzODo64uTkRN++fVm/fj0aGhq4uLjQtm1bHBwc6Nu3L/Xr1y+ScyAIH4qYwaWIPN32EyE3DmHZsAd2Xb5/73QkSWLA8PHs3n8UkA+xc/7YDqpVqVhUoRaJpJhAwn2OYVy+NRp6lsoO56OXEOZP8JXdmNfrhpaJlbLDEUqYiMgoLly6jmsDF4wMxUwcQv6IGVyE/BKZxSKSGObHrT++ACkNx0m70DK1ee+0IiKjaODelZev/ACoXrUS545uR1tbq6jCFQRBED5zIrMo5Jeohi4imialsWzQHSktFd9jywuVlpGhARuWz1cMDHv/4WN++GlOUYRZZBIiX/Hq0h8kRL5SdiifhLjAZzz5ZzpxgSV7aBNBOYJDwlizcRvBIWHKDuWjNnLkSMXsKul/x44dK3A6d+7cyZJO165diyFiQfg4KD2zuHTpUuzs7NDS0qJevXpcvXo11/UXLVpElSpV0NbWxtbWlnHjxpGQ8HF0GijdfAiq2vqoaGgjpaUVKq26Lk78NOVtD7zVG7ax9+DxwoZYZBLCnxD18j8SwsVcx/kR9/ohoV5HiXv9UNmhCCWQr58/436Yia+fv7JD+agtXbpU0cs5/a9164LPrOTg4JAlnT179hRDxILwcVBqNfS2bdsYMGAAy5cvp169eixatIgdO3bw6NEjLCwssqz/zz//MGTIENauXUvDhg3x9vZm0KBB9O7dmwULFuRrn8Vd7J4SH4Oatl6RpJWWlkbn3sMUc0YbGuhz6dSez2p4DEEQBKF4iGpoIb+UWrK4YMEChg0bxuDBg6levTrLly9HR0eHtWvXZrv+xYsXcXV1pW/fvtjZ2dGqVSv69OmTZ2nkh1RUGUUAFRUVVi2Zg7mZfNyuyKhoBn8z8bMaHkMQBEEQBOVSWmYxKSmJGzdu0KJFi7fBqKjQokWLHKdCatiwITdu3FBkDn18fDh8+DDt2rXLcT+JiYlERUVl+ituUmoKgZd34b1xUqHHSSxlYc7qpXMVr69c9+LX35cUNsRCiw7w5OGePkQHeCo7lE9CpPdlbvzsTqT3ZWWHIpRAT3ye06nXUJ74PFd2KIIglEBKyyyGhISQmpqqmN8znaWlJQEBAdlu07dvX2bMmIGbmxvq6upUqFCBpk2bMnXq1GzXB/jtt98wNDRU/KVP/1ScJEnC/+xGwu+eIfze2UKn16KpK+NHDVW8nv/XKkXVtLKoqKgjU9VARUVdqXF8MlTVkKlpgqqYYVMoeqoqqhjo66GqoqrsUARBKIGU3sGlIM6ePcvs2bNZtmwZnp6e7N69m0OHDjFz5swct5kyZQqRkZGKv1evir/3roqaOjatvgbg1dGlSKkphU7zxx/GUOfNXNGSJDF01PcEBoUUOt33pWvhQJVOG9C1cFBaDJ8Swwou1Jp+GMMKLsoORSiBytnZsnn1IsrZFf+PYWWbNGkS9vb2zJo1K9/brF+/nokTJxZqvxEREaxcuTLXdZ4/f46rqytaWlosWZK5Bmj16tVUqlSJKlWqcPDgwWy3HzRoUI7vCYIyKS2zaGZmhqqqKoGBgZmWBwYGUqpUqWy3+d///kf//v0ZOnQoDg4OdO3aldmzZ/Pbb7+RlkPvY01NTQwMDDL9fQimTq3RsapEQtBzgj0PFTo9dXV11i+fj4G+vE1kYFAIw8dMyfG4i1taahIpCRGkpSYpZf+fmrSUJJJiwkhLEedLKHqpqanExsYppporydavX8+dO3eYNm1asaSf0znMT2bRwMCABQsWMGHChEzLQ0ND+eOPP/D09OTMmTOMHz+elJTCFyIIwoeitDoxDQ0NateuzalTp+jSpQsg7/176tQpRo0ale02cXFxqKhkzt+mj0X4sY0tLlNRwbbNSB6t+47Xx1di5tQaFfXCDaptV9aGpQtm0n/YOABOnvHgz7/XMW7kV0URcoFEvbrA6yvzsa43ASO7Zh98/5+asNuneLr1f1ToPROzWm2VHY5Qwty+9xC3lt3xOLETZ0f7D7bfa9MbI6UWXYc7mao6dX49l+P7Xbt2JTw8HC0tLXR1dQkPD2flypXMnTuXp0+fcvv2baZPn87+/fs5ePAg48ePx8DAgJo1a2JsbJxjunZ2dvTu3Ztjx47x+++/ExAQwOLFi0lKSsLd3Z0FCxYwbdo07t+/j5OTE926dePHH3/Mko6JiQn16tXjyJEjmZYfO3aMdu3aoa+vj76+PtWrV+fatWs0aNCAn3/+mX///Rdra2s0NTXf/+QJQjFSajX0+PHjWbVqFRs2bODBgwd88803xMbGMnjwYAAGDBjAlClTFOt37NiRv//+m61bt/Ls2TNOnDjB//73Pzp27KjINH5MDKu6ol+uFkmRgQRezP9E9rnp1qkNQ/r3VLz+efYirt24VSRpF4S2aVVMKnZA27TqB9/3p0ivTA0sGvRAr0wNZYcilEBlba1Z9/c8ytqW7GG19uzZg5GRETExMYr27h4eHhgZGeHv74+Hhwdubm4kJCQwatQoTp06xaVLl3j06FGeadva2nLz5k1sbGzYt28fly5d4tatW4SEhHDo0CFmzZpF9erV8fLyyjajmBs/Pz+srd9+NtbW1rx+/Zpr165x6NAhbt++zZYtW3Ls3CkIyqbU1va9evUiODiYH3/8kYCAAJycnDh69KjiIfDy5ctMJYnTp09HJpMxffp0Xr9+jbm5OR07dixQ25UPSSaTYdtuFPeXDSUpKrjI0p074wcuXfXkwaMnpKSk0PersZw7uh2rUlnHpiwumvpWWNX++oPt71OnZWZLua7vP2e4IOTGxNiInt3af/D95lYKWJw0NDSwtLTE19cXHx8fBgwYgIeHBx4eHowcOZKHDx9SuXJlRYfGnj178vLly1zT7NGjBwCnTp3i8uXLuLjI2xfHxcVRu3Zt7O2LvsT2woULdO3aFU1NTaysrGjevHmR70MQioLSO7iMGjWKFy9ekJiYyJUrV6hXr57ivbNnz7J+/XrFazU1NX766SeePHlCfHw8L1++ZOnSpRgZGX34wPNJv6wjTj/sp2zH8UWWpo6ONhtXLlDMFe3nH0jPgSOJi4svsn3kJTHaH7/rS0mMFjNG5EdCyCue7f6NhBAxPaJQ9MLCI/h3537CwiOUHcoH4+rqyvbt27GyssLNzY0LFy5w/fp1RSZPJpMVKD0dHR1A3hxq2LBhiplZvL29GTt2bB5b56506dK8fv1a8fr169eULl36veIUBGVQembxc6BpnH2HncKoXrUSq/56O1+0p9ddRoyd+sE6vMSHPiT86RHiQ8X0dfkR8/IuQZd3EfPyrrJDEUqgF69eM3Tk97x49TrvlUsINzc3Fi5ciKurK05OThw/fhwLCws0NTWpWrUq3t7e+Pr6kpKSwo4d+W8G5O7uzrZt2wgNDQUgKCgIf39/9PX1iY6Ofq9YW7VqxeHDh4mOjsbPz4979+5Rt25d3Nzc2Lt3L0lJSQQEBHDmzJn3Sl8QipsY9K0IJIS8IjUhBl2bajmuI6WmEHz9IEmRgdi0GlEk++3asTU/fj+GGXMXA7B7/1GqVCrP9MmjiyT93BiUaYRe6XqoqGkU+75KAhPHlhhVb4SKWuE6OQlCdmrWqEbYy1uoq38+j/SGDRvi5+eHq6srqqqq2NjY4OzsDICWlhaLFy/G3d0dAwMDHB0d852uvb0906ZNw93dnbS0NDQ1NVm/fj329vbUqlULBwcHevTokW27xfDwcBwcHIiKikJVVZU5c+bg6+uLmZkZEyZMwNnZGRUVFebPn4+amhouLi60bdsWBwcHrK2tqV+/fpGdH0EoSkqdG1oZinouzMgn13i48hv0yzlT/ZtVOa6XGBHArd+7IaWlUnPCDrTMyxR63yDvBf7VyO/ZtuuAYtm6v+cppf2SIAiC8OkQc0ML+SWqoQtJ384JNV0jop/dJD74RY7raRqVwrJBD0hL5dXxv4ts/zKZjGULZlK3dk3Fsq+/m8rV615Fto/sxAbd4dG+AcQG3SnW/ZQUkU+v4/lrGyKfXld2KEIJ9Oz5K/oMHs2z56JNrCAIRU9kFgtJRU0dM2f5uHkh13Mfeb9088GoaukSdusEsb4PiiwGLS1Ntq5fgq2NFQCJiUn0GjSaV75+RbaPd6WlpSJJqaSllfxBgItEWhpSaiooaRB1oWRLk9JITEoiTRLXV25GjhyJk5NTpr9jx44VOJ07d+5kSadr167FELEgfBxENXQRiPN/wp2FvVE3MMd5ygFkucz/+/rUGnyP/Y1BpXpUG7a0SPaf7s69R7h36EtsXBwADvZVOXlgM3q6ukW6H0EQBOHTJ6qhhfwSJYtFQMeqIro21UmOCibC+3Ku65Zq1Bd1PVOiHl8h8vHVIo3Dwb4K65fPUwzFcOfeQ4Z8M/mzmAJMEARBEITiITKLRcS8TicAgq/ty3U9VQ1trFsMBZmMmJdF396vXetm/PrjRMXrQ8dO8+OsBUW+n4jnZ7i3rQMRz8VQD/kR4nmEK5NdCPE8kvfKglBAN2/fQ9eyGjdv31N2KIIglECfzzgLxSg1KQYt69LI1DSJuH+O5Jhw1PVynofUvF5X9Ms7o1OqYrHEM/abwTzyfsrGf3cDsGjpWqpUqsCAPt2KbB9aJpUwLNscLZNKRZZmSaZrWx2zWu3Rta2u7FCEEsjWujRL58/A1rq0skMRBKEEEm0WC0lKS+Hh3n6kpSSgkVqdsJsnKNNhHFaN+xVBtO8vKSmJjj2/wuOSvPeturo6B3eswa1BHaXGJQiCIHwcRJtFIb9ENXQhyVTU0LVwBCkV3fIVAHlVdH7y4FJaKsHXDxB660SRx6WhocGWNYspV1Y+N2pycjJ9h4zB53nu86PmV1JMAAG31pIUE1Ak6ZV0CaGveXnoTxJCP58ZNoQPJzwikn2HjhMeEansUIrdpEmTsLe3Z9asWfneZv369UycODHvFXMRERHBypUrC7SNnZ0dMTExnD17lu7duxdoO0dHR5ycnGjWrFm26xTFMQlCfonMYhEwsGkAQEpyAJrGpYkP9CHW936e20X53MRn+y+8OLCA1KSin9fZzNSYHZuWYaCvB0BoWAQ9+n9LZNT7TVmVUVzIA0If7iYupOiGACrJYl7cxv+/TcS8uK3sUIQS6PlLX/oOGcvzl77KDqXYrV+/njt37jBt2rRiST+nDoHvk1ksjIsXL+Ll5SWmABQ+CgVusxgbG8ucOXM4deoUQUFBWeYi9vHxKbLgPhX6peuCTJWYgJuY1m6L38k1BF/dh56tfa7bGVSojUHFukQ9uYr/2Y1FNg1gRtWqVGTjqoV06zuCtLQ0Hno/ZcDw8eza/Ddqau/fZNXAxhVt06qoa5sWYbQll0mNZuhN3oOGgbmyQxFKIIfqVXj18JLih+GHdH9HlxzfK9diPtrG8hqXlx6ziPG/lu16ZtV7YWHfJ899de3alfDwcLS0tNDV1SU8PJyVK1cyd+5cnj59yu3bt5k+fTr79+/n4MGDjB8/HgMDA2rWrImxcc7tyO3s7OjduzfHjh3j999/JyAggMWLF5OUlIS7uzsLFixg2rRp3L9/HycnJ7p165btdH9xcXH079+fBw8eULdu3Uw1TJGRkXTp0oX79+/ToUMHFiwoeMfDghyTIBSlApcsDh06lDVr1tCoUSNGjRrF2LFjM/19jlQ19NC1cEBKTUSnTBmQyQi9dYzUpIRct5PJZJTp8B3IZPj/t5HEiMBiia9lMzf++HWq4vXJMx788OPcQqWpoqaBpr6VmBs6n1Q0tNAys0VFQ8wNLRQ9NTU1TIyNCvUD8FOwZ88ejIyMiImJwdLSEgAPDw+MjIzw9/fHw8MDNzc3EhISGDVqFKdOneLSpUs8evQoz7RtbW25efMmNjY27Nu3j0uXLnHr1i1CQkI4dOgQs2bNonr16nh5eWWbUQRYtmwZ1tbW3L9/n549e/Ly5dtmP56enqxYsYK7d+9y4MCBTO+9SyaT0aRJE+rUqcOWLVsA3uuYBKGoFPjJcuTIEQ4dOoSrq2txxPPJMrBuQGygF/ERD+WlhY+vEH73NGa12uW6nW7pypjX6ULw1T28OrqEir1nFkt8I4b05aH3E1at3wrA32s2U6VyeYYNyvvXfHZig+7w+upCrOuOQ9fCoShDLZEifTzx2fYz5Xv9jGH5WsoORyhhnr/wZcbcxfz4/Rjsytp80H1X77E3X+uVcSu6amMNDQ0sLS3x9fXFx8eHAQMG4OHhgYeHByNHjuThw4dUrlwZW1t5m+13M27Z6dGjBwCnTp3i8uXLuLi4APLSwtq1a2Nvn3tNEcgzrpMnTwagXbt2mUr+GjZsqMjg1qhRgxcvXlCmTJkc07G2tsbf358WLVrg4OBAWlpagY9JEIpKgUsWjY2NMTExKY5YPmn61vVQ17VEQ68UFooxF/fna1vb1l+joqlLqOcRYl7eLZb4ZDIZf/w6lWaNGyiWTZg6i9P/XXyv9NJSk0lNiiEtNbmoQizRpOREUuOjkJITlR2KUAIlpyTj5x9Acsrncz+6urqyfft2rKyscHNz48KFC1y/fl2RyUufnCC/dHR0AEhLS2PYsGF4eXnh5eWFt7d3gWrNctqvpqam4n9VVdVcJ0uwtrYGwMrKinbt2uHp6Zlr2oJQ3AqcWZw5cyY//vgjcW+mlBPk1HXMqNR+NRY1+mFs3xRVbQOinl4nITTvBufq+qZYNx8MQNTT68UXo7o6m1YtpFIFO0DekHvgiPH4BwQVOC19q1pU67YdfStRSpYfRlUa4DLjLEZVGuS9siAUUKUK5Ti6ZyOVKpRTdigfjJubGwsXLsTV1RUnJyeOHz+OhYUFmpqaVK1aFW9vb3x9fUlJSWHHjh35Ttfd3Z1t27YRGhoKQFBQEP7+/ujr6xMdnXvnQDc3N7Zt2wbA0aNHCQ8PL/BxxcbGKvYTExPD6dOnsbe3L9QxCUJhFbgaev78+Tx9+hRLS0vs7OxQV1fP9H76L6DPUfqvPhV1Tcyc2xB4cTsh1w9i0/rrPLct5dYHw0r10bWpWqwxGhsZsnPz3zRt25vwiEjCwiMZMXYqe/9diYqK6BwvCMKnoWHDhvj5+eHq6oqqqio2NjY4OzsDoKWlxeLFi3F3d8fAwABHR8d8p2tvb8+0adNwd3cnLS0NTU1N1q9fj729PbVq1cLBwYEePXpk227x22+/5csvv6R69erUq1cvx2rm3AQGBtK1a1dA/oN+2LBh1KkjHx/3fY9JEAqrwINy//LLL7m+/9NPPxUqoOJW3IOQJkQ8I8b/Blr61bm3eAAaRpY4/bAfmYpqke+rMPYfPkGfwWMUr+fNmsY3Q7/M9/YRL87x+vLvWNefjFHZxsURYokS4nWMp/9Mo0LfWZg5tVZ2OEIJc+vuA1p06MfJg1uoWaOassMRPhFiUG4hvwpcsvixZwaVzffSHyRGvaRci/nolK5MnJ83kY+v5rv6UUpLI+TmYdIS47Fs2KPY4uzUriUD+37Bhn92ATB95jyaNqpPtSr5m4JQy6gs+tYN0TIqW2wxliQ6VhUxrtEcHavimeJR+LxZWVrwy7RxWFlaKDsUQRBKoPee7u/GjRs8eCAfkNne3l5R/P+xK+5fUoF3NhFyfxtmVbsjxWjxYt88TBxbUunL3/K1fZz/E+4s6oOKuhY1J+1Gw7D4xuWLjomlQfOuPHvxCgDHGtX478hWNDTEcDiCIJQ8I0eO5MKFC5mWzZ07l9atC1baf+fOHfr3759pWbly5dizZ0+B0qlXrx6JiZk7vZ06dQpT0w8zfq0oWRTyq8CZxaCgIHr37s3Zs2cxMjIC5CPbN2vWjK1bt2Ju/nEPOlzcN0d82BN8TnyHhr41ZRvPwWuWfOgc5+lHUNc1ylcaT7f/Qsj1A5i5dKRCz+Ityb1y7SYtOn2pGFx9wuhhzJg+Ps/tkuJCiHx2CsNy7mjomBVrjCVBYkQgITcOYVa7PZpGlsoORyhhoqJjuHLdi3ouTkoZmFv4NInMopBfBe7RMHr0aKKjo7l37x5hYWGEhYVx9+5doqKiGDNmTN4JlDDJcSEE3f2HUO99AGgZV0Bdx5yk6NekpUZjbN8UKTWZUK+j+U7TtvW3qGhoE3LjILG+xTudXr06zkz+7u3MMQuWrMbjUvazLGQUF3SHoLubiAu6U5zhlRjRPp74HltGtM/n2wFMKD5Pn72gS+9hPH32QtmhCIJQAhW4ZNHQ0JCTJ08qemelu3r1Kq1atSIiIqIo4ytyRf1LKiHyJU+PfouGXmkqtZfPG+rvuYKwxwewcOiPumoZHq0ZjU7pyjh890++0319ag2+x/5Gv5wz1b5eWazjayUnJ+PeoR83vOQZP1sbK66c2YehgX6O26Qmx5EY5YumgQ2q6jrFFltJkZIQR3zQM7QtyqGmJc6XULSSkpIIDgnD3MxENCMR8k2ULAr5VeCSxbS0tCzD5YB8DL9354n+HGga2KKmbUJSjB9JsfLp+gxs5J1ZonwvYVipLhpGlsT5eRP7+mG+07Vq3A8No1JEP7tJ2J1TxRJ7OnV1ddYsm4uOtjYAr3z9mTD111y3UVXXQce0ssgo5pOalg76ZexFRlEoFhoaGliXLiUyioIgFIsCZxabN2/O2LFj8fPzUyx7/fo148aNw93dvUiD+xTIZDL0LOUDU8cE3ARAx8wefev6GJVrATIVzGt3BPI/owuAiroWZdqNBihQJvN9VapQjjkzvle8/nfHfnbtO5Lj+rEhD3h8+GtiQ4q3mrykiH5+m1vzuhP9/LayQxFKoFe+foye+BOvfP3yXlkQBKGACpxZXLJkCVFRUdjZ2VGhQgUqVKhAuXLliIqK4q+//iqOGD96uqWcAIgN9AJApqJKGbfpmFbqgEwmw8ylAwAhN4+SVoDp3kxqtsJh3L+UaTuqqEPO1pD+PWnbsqni9djJv/DaLyDbddOSYkiOCyYtKeaDxPapS4mPJik8gJT43GeAEIT3ERefgNed+8TFJyg7lGI3adIk7O3tmTVrVr63Wb9+PRMnTizUfiMiIli5cmWBtrGzsyMmJoazZ8/SvXv3fG/XtWtXjI2Ns2xz9epV7O3tqVixIjNmzMh226I4VkF4V4HHWbS1tcXT05OTJ0/y8KG8xKtatWq0aNGiyIP7VOhZOgEQG3gLKS01ywDcWqY2GFRwIerpdcLvncU0n4Myy2QydKwqFXW4ue5v6YKZ1G3amZDQMMIjIhk+ZgoHtq/JMruLfuk6VO++64PF9qkzruZKnVkeyg5DKKGqVCrP+WPKmf7t6pScx5C1H7UOXWv5rFTeGycR8SD7e8Da/SusWwzN1/7Wr19PYGBgsc04lZqaiqpq1kkU0jOLw4cPL5b9ZjR27FiGDBnChg0bMi0fOXIk//77L/b29ri6utK1a1ccHByKPR5BeK+7TSaT0bJlS0aPHs3o0aM/64wigJqWEVpG5UlNiiYh/KliebTfNXwvzyclMRLzOp0ACCpAVXQ6KS2NEM8jvDr2d5HFnBNLCzP+Xvi2veLZ85dZtmpTse9XEAQhL127diU8PBwtLS2MjY0BWLlyJRUqVADg9u3bdOokf9YePHiQypUr4+Liwvnz53NN187Ojh9++AFnZ2dOnz7Npk2bqFOnDjVr1mT8ePlQYtOmTeP+/fs4OTnlWKoXFxfHF198QfXq1Rk0aBAZ+49GRkbSpUsXKleurEgzJ02bNkVfP3MHQz8/P1JSUnB0dERVVZXevXtz8ODBAh+rILyPfJUsLl68mOHDhyvm28zN5zh8DsirohMifIgJ9ELbtDIAEc9PEfXKA10LR4xrNEdVay5RT66SGO6PprFVvtNOjgnj2a5fSUtJwsShObqlqxTXYQDQrnUzvhrQizUbtwHw46wFNGvcAPtqlRXrRL7ywPfiXGwafo+hrVuxxlMShN4+yZPNU6j45W+YOn7eP66Eonfn3iM69BjMwR3rcLAv3ufDu+r+dilf61Ue8Eeh97Vnzx7MzMzw8/NTzI3s4eGBkZER/v7+eHh44ObmRkJCAqNGjeL8+fOUKlWKZs2aUb9+/VzTtrW15ebNmzx48IAVK1Zw6dIl1NTUGDBgAIcOHWLWrFk8evSI69ev55jGsmXLsLa2ZteuXRw+fDhTyaCnpyf379/H2NgYe3t7vvvuuwLNHe3n54e1tbXitbW1Nf/99997HasgFFS+ShYXLlxIbGys4v+c/hYtWlScsX7U3nZyeTuOnoG1vHom+vUlVDW0MK3ZGiSJ4OsHC5S2hoEZVk0HgiTx8sBC3nPSnQL57efJVCwvn8ovMTGJId9OJjEx6W1MetboWjqhoWedUxJCBlrmZTCoVA8t8/x/OQhCfpmbmzBqxCDMzU2UHcoHoaGhgaWlJb6+vvj4+DBgwAA8PDzw8PDA1dWVhw8fUrlyZWxtbVFXV6dnz555ptmjh3x61VOnTnH58mVcXFxwcnLi8uXLPHnyJF9xeXh40Lt3bwDatWunKP0EaNiwIZaWlmhoaFCjRg1evCiaMTHf51gFoaDylVl89uyZYvqhZ8+e5fjn4+NTrMF+zHTMqyNT1SA+9CGpyfEA6Fm5IFNRIybgJqnJ8Yqq6JDrB5AKOMyQVZP+qBtayNs93v+vyON/l66uDmuW/q5ou3P3/iN+mfOn4n1t43LYNZ2JtnG5Yo+lJNC1qky1YUvQtaqc98qCUEClLMyZNHY4pSw+7hm0ipKrqyvbt2/HysoKNzc3Lly4wPXr13FxcQEo8Ni0OjryYa3S0tIYNmwYXl5eeHl54e3tzdixY/OdTk771dTUVPyvqqpKampqgeIrXbo0r1+/Vrx+/fo1pUuXznWfglBUCtxmccaMGcTFxWVZHh8fn2M7js+BiqoGOub2SGkpxAXfBUBVQxddi5pIacnEBNxA19Ye7VIVSAz3I8rnRoHSV9XQVvSKfnnwT9JSkov8GN7lUsuRKRO+Ubxe/Pc6/vO4AkByfBihjw+SHB9W7HGUBElRIQRe3EFSVIiyQxFKoJjYWC5euUHMmxqgz4GbmxsLFy7E1dUVJycnjh8/joWFBZqamlStWhVvb298fX1JSUlhx478d/5xd3dn27ZthIaGAvIpbv39/dHX1yc6OvfRDNzc3Ni2Td585+jRo4SHh7//Ab6jdOnSqKqqcvv2bVJTU9m6dSsdO3Ys1LEKQn4VOLP4yy+/EBOTdbiUuLg4fvnllyIJ6lOlZ+kMvB1vEUD/zQDd0b6XkMlkmLvISxeDr+4rcPqmTm3QtbUnMfQVgRe3FUHEeZs0dgR1a9cEQJIkho+ZQkRkFLGBtwjwXE5s4K0PEsenLurJNZ7vnUvUk7ynUhSEgnr89DktO33J46fPlR3KB9OwYUP8/PxwdXVFVVUVGxsbXF1dARTt693d3WnQoAGVK+e/RN/e3p5p06bh7u6Oo6Mj7du3JywsDFNTU2rVqoWDg0OOBSPffvstL1++pHr16mzbtq1AbRIzatGiBT169ODw4cPY2Nhw6ZK8XeiSJUvo06cPlStXpk2bNjg4OBTqWAUhvwo83Z+KigqBgYGYm2eu7jh9+jS9evUiODi4SAMsasU5vVFCuA9Pj49B08CWim3lPZdTEsJ5tG8AKuo6VOm8mdT4GG7+2gZUVKk1/ShqOgWLIfr5Le4v+wqLBt0p1/WHIo0/Jz7PX1K/WVdi35Qo9+zWgVV//kR8yEO0zaqipqH3QeL4lKXERRH98g76ZRwK/JkLQl4SEhJ56etHGZvSaGlp5r2BICCm+xPyL98li8bGxpiYmCCTyahcuTImJiaKP0NDQ1q2bPnZN6zVNLJDTcuIxKhXJMfJqxvVtIyxcByITYPJyGQqqOsZY1S9MVJKEqG3jhd4H/p2Nak5afcHyygClLcrwx+/TlG83r77ILsOnEW/tIvIKOaTmo4BxlVdRUZRKBZaWppUrlhOZBQFQSgW+R6Ue9GiRUiSxJAhQ/jll18wNDRUvKehoYGdnR0NGuQ8OOvnQCZTQdfSicgXZ4kJ9MK4nHyIFPNqmUfhN6/TmfC7Zwi+th/LBvkf1T+dMnrUDuj7BUdOnOXAEfk81X8vno2j5mHKNvgOHVNR7ZGX6Jf3eL5nNnZdp6Jfxl7Z4QglzGu/ABYvX8+YrwdhXbqUssP5aI0cOZILFy5kWjZ37lxat87fRAnp7ty5Q//+/TMtK1euHHv27ClQOvXq1SMxMfOsXqdOnVJ0KBWEj0W+M4sDBw4E5DdEw4YNUVdXL7agPmV6ls5EvjhLbMBNRWbxXUaV66Oub0as733i/B+/1ywtkiQRdus4kY+vUK77/4q9N5xMJuOveTO4cv0WQcEhaKolkBj1kqS4EJFZzIfkmFDiA3xIjglVdihCCRQVHcOpsx4M6tcdMZhVzpYuXVok6Tg4OODl5VXodK5cuVL4YAThAyhwB5cmTZooMooJCQlERUVl+vvcpc8THRPohSS9HR4n4vkZfE5OJC7kATJVNcV80cHvMaMLQFpyAi8OLCT42n4i7p8rdNz5YW5mwvI/5fOxetyNx3XcU/76J+cBaoW3TKo3pu5vlzCp3ljZoQglULUqFbl+7iDVqlRUdiiCIJRABc4sxsXFMWrUKCwsLNDV1cXY2DjTX0EtXboUOzs7tLS0qFevHlevXs11/YiICEaOHImVlRWamppUrlyZw4cPF3i/xUVd2xRNw7KkJkaSEPFMsTwpxo/40IdE+cp7tZm7dAQgxPPwew2Do6qhjW270QA83z+P1KSEIog+b63dG/P1kH6K13MW/M2R42c+yL4FQRAEQfjwCpxZnDRpEqdPn+bvv/9GU1OT1atX88svv1C6dGk2btxYoLS2bdvG+PHj+emnn/D09KRmzZq0bt2aoKCgbNdPSkqiZcuWPH/+nJ07d/Lo0SNWrVqVaQqkj4GepRMAsRmG0Mk4m4skSWibl0W/nDMpcZHvPci2Wa126JdzJincH78z6wodd37N/nkyQzpV5+LC8jR20GXoqB/wef7yg+3/UxR29wxXfqhH2F2RsRaK3r0H3lRzcefeA29lhyIIQglU4MzigQMHWLZsGV988QVqamo0atSI6dOnM3v2bLZs2VKgtBYsWMCwYcMYPHgw1atXZ/ny5ejo6LB27dps11+7di1hYWHs3bsXV1dX7OzsaNKkCTVr1izoYRQr3VJvxlsMfJtZ1DQqh7quJUkx/iRGyqd5Sp/R5X2romUyGXZdvgcVVfzPbiQh+MNk2DQ1NZgwYRKPXqcQEJZMRGQUfYeMJS4u/oPs/1OkaWSFnm0NNI3yPye4IOSXibERvb/oiImxkbJDEQShBCpwZjEsLIzy5csDYGBgQFiYfAYPNzc3zp3Lf9u5pKQkbty4QYsWbzuBqKio0KJFC8UApO/av38/DRo0YOTIkVhaWlKjRg1mz56d67RJiYmJH7xdpa55DWQqasQF3yctRV49LJPJFKWLUa/lx2fi4I6Khg6R3pdICPV9r33pWFWklGtvpNRknu/7/YPMGw1gV7U+5vV+5ol/CgB37j3kux9mfLD9f2p0bapiP3INujZVlR2KUAJZlbLgpynfYVXKQtmhCIJQAhU4s1i+fHmePZO3xatatSrbt28H5CWORkZG+U4nJCSE1NRULC0tMy23tLQkICAg2218fHzYuXMnqampHD58mP/973/Mnz+fX3/9Ncf9/PbbbxgaGir+bG1t8x3j+1JR00LHrDpSWjJxwfcUyw1sGgLy2VwAVDV15KWLkkTA+X/ee3/WLYehbmCOmo4hUkpi3hsUgZSESJzLJDDjh68Vy7Zs28vaTds/yP4/NUkxEYR4HiEpJkLZoQglUFxcPDdv3xOl+4IgFIsCZxYHDx7MrVvyKd5++OEHli5dipaWFuPGjWPSpElFHmBGaWlpWFhYsHLlSmrXrk2vXr2YNm0ay5cvz3GbKVOmEBkZqfh79epVscaY7m1VtJdimbZZVdS0jEiI8CE5Tj7TjVWjviBTIfjafpJjI95rX2paejiM+5eKfWehoq5V2NDzJSbAk9dX5jOwkz0d2rgrlk+cNovrnrc/SAyfkijvSzzd+j+ivLMvNReEwnj0xAe3lt159MRH2aEIglAC5XucxXTjxo1T/N+iRQsePnzIjRs3qFixIo6OjvlOx8zMDFVVVQIDAzMtDwwMpFSp7AeVtbKyQl1dHVVVVcWyatWqERAQQFJSEhoaGlm20dTURFPzw89qoGfpTBAbMs0TLZOpYF13HOp6pVDXkU+XqGlSGhNHd8JunSDo8k6s3Ye+1/7UdY0U/0tpqchUVHNeuQjolaqFdb0J6JWqxcq/6tCoVXeePntJUlIy/YZ+h8fxnZibmRRrDJ8Sg8oNqNB7JgaVP++B64XiUaVieTxO7KRKxfLKDkUQhBKowCWL7ypbtizdunUrUEYR5LO+1K5dm1OnTimWpaWlcerUqRxngnF1deXJkyekpb0dv9Db2xsrK6tsM4rKpGVcHlUNAxIjn5McH65YrmdVG039zL23rRrLZwIIuLCdtOTCVSOH3T3DrT++ID7oeaHSyYualiFGds1Q0zLE0ECfLWsWo60tL9X0fe3P4G8m5tqW9HOjoWeEWa22aOgZKTsUoQTS0dHG2dEeHR1tZYciCEIJlK+SxcWLF+c7wTFjxuR73fHjxzNw4EBcXFyoW7cuixYtIjY2lsGDBwMwYMAArK2t+e233wD45ptvWLJkCWPHjmX06NE8fvyY2bNnF2ifH4p86r+aRL06T2ygF0Z2zTK9L0lpSGmpqKiqo2dbHf3ytYj28STE8wgW9bq8935jXt4hMdSX53t/p+qwpcU2s0t8+BP8PVdiVWs42sYVcbCvwl/zfmHoyO8BOHPuEjPn/sXPU78rlv1/amJ9H/J83x/YdZ4kOrkIRc4/IIiV6/5h+OC+opOLIAhFLl+ZxYULF+YrMZlMVqCMW69evQgODubHH38kICAAJycnjh49quj08vLlS1RU3hZ+2tracuzYMcaNG4ejoyPW1taMHTuW77//Pt/7/JD0SjkT9eo8MQGemTKL4T7HCbqzEfMaX2JSoQ0gL12M9vHE//xmzOt0QqbyfoW+1u5DCb15jKgnVwm7dQJTp1ZFcizvSooJIj70IUkxQWgby2eN6NO9E9du3GLFWnlnnT/+XEGdWo60b9O8WGL4lCRG+BPz6i6JEf4isygUubDwCLbuOkD3Lu1EZlEQhCInkz6zsU6ioqIwNDQkMjISAwODYt1XUmwQjw8OQU3LmMqdNipK+SJfeeB7cQ56VrUp2/gXAKS0NG4v6EVC0DMqD1qIcfVG773f0NsnebL5B9QNzKk5cSeqWrpFcjz5kZSUROsuA7h6Q94JykBfD48TO6lQruwHi0EQBEHI24f8PhQ+be/dZjEpKYlHjx6RkpJSlPGUKBq6Fmjo25CSEK4YiBtAr1RtZCrqxAbeIjU5DgCZigpWjeXT6Pmf21So/Zo4uGNQqR7JUcH4nlxVqLQKSkNDg82rF2FmKu/cEhUdQ5/BY8SQHoIgCILwiXqvuaG/+uordHR0sLe35+VL+awho0ePZs6cOUUe4KdOL5vZXFTVtdEt5YSUlkKM/zXFcjPntqjrmRLt40nMq3tZ0sov+cwuk5GpqhHg8S9xAU/e/wByEPX6Cvd3dCXq9ZUs71mXLsWGFfMVTQjuPfBm9KSfPusBu8Pun+PqlAaE3c//wPWCkF8PHj3BpXEHHjwq+ntdEAShwJnFKVOmcOvWLc6ePYuW1tsx/Vq0aMG2bduKNLiSILt5ouHtXNFRvpcVy1TUNbF07QmA/3+bC7VfbfOyWDXpj4l9U1S19AuVVnbUtIzRNCiDmpZxtu83bVSfX6a9HWZp684DrFr/b5HH8alQ1zNFu1R51PVMlR2KUAIZ6Ovh3tQNA309ZYciCEIJVOA2i2XLlmXbtm3Ur18ffX19bt26Rfny5Xny5Am1atX6INPpFcaHbqORmhzHwz19kKmoUbXrv6ioyof4SUmI5NH+/qioalKlyxbF8uTYCLxmdyAtJYma3+9By8Q6t+RzJaWlvXdHmaIgSRJ9h4xh/+GTAKirq3N870bqujgpLSZBEARBTrRZFPKrwDmJ4OBgLCyy9raLjY0ttmFaPmWq6jromFVFSk0kLuSBYrmalqF8SkAplcSI54rl6rpGmNftDFIaAecLVxKXMaOYlpxAamJcodLLKCUphmi/66QkxeS8f5mM5X/OpmJ5eeeW5GT5gN1BwaFFFsenIiUuivCHF0iJ+7h/TAmfpoSERLyfPCMh4cNM9ykIwuelwJlFFxcXDh06pHidnkFcvXp1joNpf+50c6iKtq77HVW7/IO2aeVMy0u59XkzBeA+UuIiC73/6Be3uT2vJ6+OLit0Wuli/K7x8vzPxPhdy3U9QwN9/lm7GB1t+WDBfv6BDBwx4bPrGBXx8ALea8cS8fCCskMRSqAH3k9wdm3HA2/RZlEQhKJX4Mzi7NmzmTp1Kt988w0pKSn8+eeftGrVinXr1jFr1qziiPGTp1eqFpC5kwuAhl4pVNSyzuWsZWqDiUNz0pLiCby8q9D7V9czISk6hMCL24n1e1To9AB0LWtSqtbX6FrWzHNd+2qVWbpgpuL1uQtX+OW3P4skjk+FQcU62HX5HoOKdZQdilACVapgx4n9m6lUwU7ZoQiCUAIVOLPo5ubGrVu3SElJwcHBgePHj2NhYcGlS5eoXbt2ccT4ydM2roiKui4J4U9JSchaUpiSGJ1pSkAAq8ZfAhDosY20lKRC7V/L1IbSTQeClMbzPXORMkyX+L7UtU0wrdQBde38zf/cs1t7vhnaX/F6wZLV/Ltzf6Hj+FRoGJhh2bAHGgZmyg5FKIH0dHVpWK82erofbkxVQRA+HwXKLCYnJzNkyBBkMhmrVq3i6tWr3L9/n82bN+Pg4FBcMX7yZCqq6L0pgYsN8sr0XsTz0zza14+QhzszLdcrUwP9cs4kx4QScvNIoWMo3WwgmibWxLy4TciNg4VOLz78Gc/P/o/48Gf53mb2TxOpX8dZ8frrsdM4euJsoWP5FMT6e/Ng1Shi/b2VHYpQAgUEBfPHnysJCApWdiiCIJRABcosqqurs2tX4atFP0e6lm/GW3yn3aKWcQWQ0oj2vZRlHEKrJvKSOP//Nhe6NFBFXYuynScB8PLw4kK3hUyKeU1soBdJMa/zvY2Ghgab1yzCrowNACkpKfQb+h0Xr9woVCyfgoTgl0Q9vkJC8EtlhyKUQMHBYSxZsZ7g4DBlhyIIQglU4GroLl26sHfv3mIIpWRTDM4d4JUpU6hpUAYNvdIkxwWREOGTaRujqm5omZclIegZkY8uFjoG42puGFVvTEpsBL7HVxQqLUNbN+x7HcDQ1q1A21lZWrB/+2oszOXVsQkJiXT/8hvu3CuatpQfK1PHFtT7/Rqmji2UHYpQAjnYV+HF/Ys42FdRdiiCIJRAagXdoFKlSsyYMYMLFy5Qu3ZtdN9pIzNmzJgiC64k0dArhYaeFUkx/iRF+6JpYAvIe5Pr2zQg9OEuon0voW1cQbGNfArAL3m2axb+5zZjVK1gGbPs2HWayEs1DUWbSGWoUK4s+7atok2XAURGRRMZFU3n3kM5eWAL5e3KKC0uQRAEQRCyKnDJ4po1azAyMuLGjRusXLmShQsXKv4WLVpUDCGWHOlD6LxbFa2YzeX1pSzbmNVqh5qeCVFPrxPr+yDL+wWlaVKaSl/OQdOkdKHSifa7xv2dXxCdx9A5OXG0r8qOTcvQ0tIEIDAohE49h+IfGFSouD5W4Q8ucG2aG+EPxNA5QtF79NiHRq178OixT94rC4IgFFCBMouSJHH27Fnu37/Ps2fPsvz5+IgHVW6ymycaQNu0MmpaJiRGviAx2i/TeyrqmpRqmD4F4KYijSctOYGYl3ffa1sVDT3UdcxR0Xj/6cVc67uwedVCVFVVAXj24hWdew0jPKLwY0t+bNS09dEwLoWadtFPvSgIOtpaODlUR0c761BcgiAIhVXgzGKlSpXw9fUtrnhKNF0LR5CpEBd0h7TUZMVymUwFfev6qOuWIiU+JMt2Fg26o6KuSeidUySG+WV5/32kJsRyZ2FfHq4eSWJEYIG31zWrRqV2y9E1q1aoONq2asbyP9+Oz3nvgTc9+n9LXFx8odL92OjbOVJz4k707RyVHYpQAtnalOaveb9ga1O4GgNBEITsFCizqKKiQqVKlQgN/fymaysKqhp6aJtUJi0lgfjQzB06Sjl9RaX2q+QZyneo6xphXqcTpKUS4FG4KQAVsWjpom9Xk9SEWJ7vmZOlJ3ZeUpPjiAv1JjW58FMI9u3Rmd9nTlG8vnTVky+HfUdycnIuW31aUhLiiH55j5SEoptyURDSJSUl8dovgKSkwo3JKgiCkJ0Ct1mcM2cOkyZN4u7d96u+/NzlVBWtoqaZ69zapRr1A5mMoKt7i2x+4TIdxqGub0rEg/OE3TpeoG2jX1/h2cnxRL++UiSxjBw+gO/Hfa14fezkOUaMnUZaEQwg/jGIuP8f95cMJOL+f8oORSiB7j18TGXnZtx7+FjZoQiCUAIVOLM4YMAArl69Ss2aNdHW1sbExCTTn5C7nOaJBnk1f3zYE+JCsw4jo2Vqg3GNZqQlxRN0ZXeRxKKmY4Bdl+8BeL7vD5JjI/K9rY6FAxY1+qNjUXSDsf/v+zEMHdhL8XrbrgNMnv5bgUs9P0b65Wth0/pb9MvXUnYoQglUoVxZ9m5dRYVyZZUdiiAIJZBMKuA38YYNG3J9f+DAgYUKqLhFRUVhaGhIZGQkBgYGH3z/UloKD/f0IS0lgSpd/kFN822Hh+jXV3jpMRPdUs7YNZmZZdvoF3e4v3Qw6vpmOE3Zj4qaRpHE5L1pMuF3TmPq3JaKfbLu90NKTU1lyDeT2Lnv7aw1//t+ND+M/1aJUQmCIJQ8yv4+FD4dBR5n8WPPDH7sZCpq6Fo4Eu13hdigW5kGtda1rIlMVYPYwNukJsWg+k5PY/2yDujbORH93ItQr2OYu3Qskpjsukwm6sk1wu+eJjH8WzSNrfLcJiHyBUF3tmDh0A8tw6IrzVBVVWXVkjmER0Zx6qx8mJmZc//CxNiI4YP7Ftl+PrS4wKf4HluBTesR6FhWyHsDQSiAoOBQdu49TPcu7bAwN1V2OIIglDAFroYGeenPrl27+PXXX/n111/Zs2cPqampRR1biaX7pt3iu1XRKmpa6JWqBVJqjuMXlmoiH0zb/79NRVY9q6FvRsU+v+Iwbmu+MooACREviH59kYSIF0USQ6Z4NDT4d+1i6tauqVg2fsqv7NhzqMj39aHE+T8h/O5p4vyfKDsUoQTyDwzip1kLS+w4pYIgKFeBq6GfPHlCu3bteP36NVWqyKeWevToEba2thw6dIgKFT7uUpOPodg9Mfo1Tw6PQF3XkkrtV2fq2BLx7BSvry7EwKYhtq5Ts2wrpaVxe153EkJeUuWrxRhVafghQ/+gwsIjaNW5Pw8eyTNYampq7Ni0jFbNGyk5MkEQhE/fx/B9KHwaClyyOGbMGCpUqMCrV6/w9PTE09OTly9fUq5cOTHVXz5p6JVGXcec5NhAkmL8M72nV7ouyFSI9r9BWkpilm1lKiqUatwPKPpBugHSUpJ5fXI1UU9vFHnaBWVibMT+baspYysfOy4lJYV+Q8Zy5VrWzkGCIAiCIBSPAmcW//vvP37//fdMPZ9NTU2ZM2cO//0nhgXJD5lMlmNVtJqmPrrmNZBSE4kJ9Mp2e/Pa7VHTNSbqyTVifR8WaWyhXkfxPb4cn52/kpackON60f6ePNjdk2h/zyLd/7tKW1lyYPsazEzl11tcfDxffPkNt+8V7XEXt4hHl7j+Y1MiHmWd0lEQCuvx02e06TqAx0+fKTsUQRBKoAJnFjU1NYmOjs6yPCYmBg2Noumd+znQs8x+vEUAA9tG6JWqhaqadrbbqqhrYZk+BeC5zUUal1mtduiVcSAx9BW+J1bmuJ6KqjqqGnqoqKoX6f6zU7G8Hfu2rcJAX97hJzwikrZdB3L1ulex77uoyNQ1UdU2QKauqexQhBJIXU2d0lalUFcr/vtREITPT4HbLA4YMABPT0/WrFlD3bp1Abhy5QrDhg2jdu3arF+/vjjiLDIfSxuNlMQoHu3th4q6NlW7/ItMRbVA2yfHRnBzVnuktBRqTt6Nlol1kcUWF+jD3UX9kKQ0aoxaj65N4ab0KyrnL16lS5/hJCTIq+d1dXTYuv4vmjcpue02BUEQisvH8n0ofPwKXLK4ePFiKlSoQIMGDdDS0kJLSwtXV1cqVqzIn3/+WRwxlkhqmgZoGVckLTmO+DDvAm+vrmuERb0ukJbKqyNLijQ2HcvyWLt/BWmp+OyYSVpqSpZ10lKSSIz2Jy3lw00v1qhhXfZtXYW+ni4AsXFxfPHl1+w/fOKDxfC+0pISSAh5RVpSzlX7gvC+UlJSCAuPICUl670qCIJQWAXOLBoZGbFv3z68vb3ZuXMnO3fu5NGjR+zZswdDQ8PiiLHEUkz9F5C13V9aSgKRrzyIeH46x+2t3Yei+v/27ju+qep94PjnZnfvCR2ssvcSEVEBWaIoKCqyxM1QcIE/AcdXEVREFEFxIIoynKCCCwRFRATZuxRKJ91p02bf3x8pKZEW2pKSjvN+eV9Nzr0598klNU/PPUPnS+7enyk8tdetsUVdNw6vyOYUpx8jfcuKC/brU7Zx4of70adsc+t5L+WaXt3Z8NXHhAQHAmA2W7jnvmmsXPPNFY2jqnIPbGbv/FvJPbDZ06EI9dD+Q0eJadWL/YcuXP1JEAThclVrnkWA5s2bM2zYMIYNG0bz5s3dGVOD4RvZCYCijD0X7LMUZ5Hy5yuc3V/xfIpq3yBHCyBwev0CZDeuo6xQqWl6+ywUai2SdOHHxDu0NSGtbsM79Mrfou7csS0/ffsp0VERgGPezwemzGTJ++7tv+lOvnEdiOo7Bt+4Dp4ORaiH4mMb89mHbxIf29jToQiCUA9VOVkcMWIE8+bNu6B8/vz53H777W4JqqHwCmmNQqWjJPcoVpPeZZ/WPwaNX2MsxVkY8xIrrCOi9yi0IY0xnDlIzp4f3Rqfb0xbOs38jujrx1+wT+MbSWTHe9H4Rrr1nJXVKqEZv6xbSdP4WGfZE//3Eq8seKdWriWtC2lE7NBH0YW4r2+pIJwTFBjALUNvJChQ3N0RBMH9qpwsbt26lSFDhlxQPnjwYLZu3eqWoBoKhVJdumKLncLUHRfs92/cCwB9asXTrShUGmKHOOa3PLPhbWxu7hOn9g1yPj5/Kh2jPoWUvxZg1Ke49XxVERfbiJ/WfULb1gnOshfnvcXM5+bXuoSxJOs0iavmUJLl/hVvBCE7J4/ln64lOyfP06EIglAPVTlZrGiKHLVajV6vL+cVwsX4N+4NgD7lzwv3NXIki4Xl7DtfULvr8WvaBXNBJhlunkrnnPStK/l37s2Y8hyTiBtzj1NwehPG3OM1cr7KiooIZ+PXH7ssDfjW0uU8Mu3ZWrUEpeHMIbJ3f4/hzCFPhyLUQ2dS05j0+GzOpKZ5OhRBEOqhKieL7du3Z/Xq1ReUr1q1ijZt2rglqIbEN7o7kkKNIfNfbGaDyz5dcAtUXiGY9GcwXaQFT5Ik4m6aDpJE2ublmAuy3B5nydlTWItySfryZWRZJjD+etqO+o7A+Ovdfq6qCg4KZP3aD7iuz1XOshWff8W4Bx/HZLpyo7UvJrTLYHrO/4fQLoM9HYpQD3Xu0BZD5mE6d2jr6VAEQaiHqpwszpo1ixdffJFx48bx8ccf8/HHHzN27FheeuklZs2aVRMx1mtKtTe+kZ2R7VYK0/522SdJEv6NHAnQxW5FA/g0bkVo15uwW4yc+fEdt8cZO3Qqav8wCo5tJ3v3926v/3L5+vjw5adLGTa4n7Ps6/U/cvvYRzAYij0YmSAIgiDUbVVOFocNG8Y333zDiRMneOSRR3j88cdJSUnhl19+Yfjw4TUQYv13sVvRAXHXEdR8KD7hlx5FGzPwERQaL7J3fef2ZQBVXn40uXUGAKfXLSAvcQtHvhlNYTkjuT1Fp9Py6fsLufuOW5xlv/62jZtH3Ud+gWe7SBQc/5tdzw+g4Pjflz5YEKooMek0t41+kMQk0SdWEAT3q9bUOUOHDmXbtm0YDAays7PZtGkTffv2dXdsDYZfo54gKSnK2IXNUuKyzzu0NdFdH8Y7pOUl69EEhBF93TiQZcdUOm4e5BHUti/BHQdgK9GTsXkVkqREUcWVZ2qaSqXi3Tdf5uGJ9zjL/tr5L4NvG8/ZrBzPBaZQICmVoKj2bFWCUCGFpECr0aAoZ5orQRCEy1Xl5f7O2bVrF4cPHwagbdu2dO7c2a2B1ZTaurzR6S2zKcrYTeOrZxAQc02167GZjex7dQTmgkxajJlPcPsb3BglWIpy2ffa7ViLC2g5YSGBrasfa02SZZn/zX+LVxYscZa1aBbP+jUfENM42oORCYIg1A619ftQqH2q/Gfo2bNnueGGG+jevTtTp05l6tSpdO3alX79+pGV5f6BFQ2FX2PH+sb6MxeuiGKzFJN1aA3pu9+9ZD1KjY6YwZMBSP7+Tbcvx6f2DSbu5ieIvHY03rFtsdtr5/JikiQx6+mpzH3+aWfZ8cRT9L/5Ho6dSLri8ditVqzGIuxiOTahBtjtdkwmM3Y3TswvCIJwTpWTxSlTplBYWMjBgwfJzc0lNzeXAwcOoNfrmTp1ak3E2CD4N+oFkoKi9H+w21wTPElSkHVoNbknvsdmLrpkXSGdBuIT0xZTbiqZ2y4cuX65QrsMJqBdJ45/NwZ98u9ur9+dpj40nncWvIii9PZvSmo6A24ezc5d7l0e8VJy9/3MrtnXkbuv9q9jLdQ9ew8cJji2I3sPHPZ0KIIg1ENVThY3btzIO++8Q+vWZcu8tWnThsWLF7Nhwwa3BteQqHQB+IS1w24toSjjX5d9CpWubPLutEsPkJAUCuKGTQcg9df3sRS5f6Jer5BWBDUbjFIZTMGxv9xevzuNGz2SFe8tQK1WA44JjAePGM+Gn67cOs2+se0Iv2oEvrHtrtg5hYYjLqYR7y+eR1yMWCFIEAT3q3KyaLfbnV+651Or1dW+BbJ48WLi4+PR6XT07NmTv/+u3IjRVatWIUlSvRmFXXYr+o8L9jlXc0m5+BQ6zrriOzoGoxgNpPz8nvuCLKX1iyKk+UiOLpvK8ZUzMeVnuv0c7nTrsIF8uXIJvj7eAJSUGLlj3GQ++mTNFTm/LjSGJrfNRBcac0XOJzQswUGB3DXyZoKDAj0diiAI9VCVk8UbbriBRx99lLS0spUCUlNTmTZtGv369bvIK8u3evVqpk+fzpw5c9i9ezcdO3Zk4MCBnD179qKvO3XqFE888QR9+vSp8jlrq3MJYWHa39htFpd9ftE9SkdM78ZurdySfrFDpiKpNJzd8RXFmSfdGqupMJ3cxK/xb9EDW0khJ9e+UOuW2Puvfn178+O3nxARHgo4/vCZ/MQcXnr17RqP3Zh9hqSv52HMPlOj5xEapty8fNZ89T25efmeDkUQhHqoysni22+/jV6vJz4+nmbNmtGsWTOaNGmCXq/nrbfeqnIACxYs4P7772fChAm0adOGpUuX4u3tzYcffljha2w2G6NHj+b555+nadOmF63fZDKh1+tdttpK7RWCd2gb7BYDhrP7XPYpNb74hLdHtpkuuE1dEW1QFFF9RoPdRvJ3C90aa0nOEXJPfEdIj+vRBESgP76Ds9u/cOs5akKn9m3Y9N3ntGgW7yx7+bXFTJo+C2sNDj4pSj7A2e1rKUo+UGPnEBqu02dSmfDwE5w+k+rpUARBqIeqnCzGxMSwe/duvv/+ex577DEee+wxfvjhB3bv3k3jxo2rVJfZbGbXrl3079+/LCCFgv79+7N9e8W3W1944QXCw8OZOHHiJc8xd+5cAgICnFtMTO2+Dei8FZ1y4ajoc2tFX2o1l/NFXz8etW8IBUf/JP/oxdeYrgr/mN60vOVTgpr3p+kdswHH6GtjVrLbzlFT4uMa88v6z1zWk/74sy8ZNW5yja32EtyhH51n/0Rwh6q3vgvCpXRo24qzJ3fRoW0rT4ciCEI9VOVkccWKFZjNZgYMGMCUKVOYMmUK/fv3x2w2s2LFiirVlZ2djc1mIyIiwqU8IiKCjIyMcl/zxx9/8MEHH7Bs2bJKnWPmzJkUFBQ4tzNnavdtQP/SZLEw5S9ku81ln1/jXkR0uo/wdqMrXZ9S50PjgQ8DkPzdQmSbe1rPFEoNKl0gCqWGgBY9ibj6duwWI4lrnnPbOWpSaEgQ33/xEUMHls1DufGXLQwZMYGs7Fy3n0+h0qDxDUah0ri9bkFQKpX4+HijVNauSfIFQagfqpwsTpgwgYKCggvKCwsLmTBhgluCqkhhYSFjxoxh2bJlhIaGVuo1Wq0Wf39/l6020/iE4xXcAptZjyHL9Zal2iuY0JbD0fhEVPDq8oV1H4Z3VAIlmSc5u+Nrt8RpOLufo+vGYTi7H4CYIVPRhcZi1mdhKqjdg13O8fb24rMP3+TeMXc4y/75dx/9brqLk6fc20JakPgPu/83hILEf9xaryAAJJ06wz33PUbSqdr9x7AgCHVTlZNFWZaRJOmC8pSUFAICAqpUV2hoKEqlksxM1+QiMzOTyMjIC45PTEzk1KlTDBs2DJVKhUqlYsWKFaxbtw6VSkViYmLV3kwt5XeRtaLPqcqADEmhJHbYNABSflqKtaTw8gIE7HYLss2M3e4YiKPUeJEwfgHtp32OLrjuTN+hUqlY9OpzzH66bI7QxKRkbhh6N7v3uLF/oc2KbDVBHWh1Feoem92GvrAI23/uRgiCILhDpZf769y5M5IksXfvXtq2bYtKpXLus9lsJCUlMWjQINasqdpUJD179qRHjx7OwTF2u53Y2FgmT57MjBkzXI41Go2cOHHCpezZZ5+lsLCQN998k4SEBDSai9/mqwvLG5kK0zjxwwOodEEk3Pwx0nnrvdptFtJ3vYMxL5GmNy502XcpR5dPJ//QViKvvYe4mx6rgcjLyLIMsh2plq0dfTErPv+KyY/PxmZzfOH6eHvz6QcLufGG+jPiXhAE4Zy68H0o1A6qSx/icG4uwz179jBw4EB8fX2d+zQaDfHx8YwYMaLKAUyfPp1x48bRrVs3evTowcKFCzEYDM5b2mPHjqVRo0bMnTsXnU5Hu3aukxoHBgYCXFBel2n9otEFNsGYn0Rx9mF8wto69ymUakpyjmLSJ1OSexzvkJaVrjd26KMUHNlG5rZVRFw1osbm/LMU5ZH01cvowuKILV16sC4Ye9dtRISHcs/ExyguKcFQXMztYx5h8YIXuWfUcE+HJwiCIAgeUelkcc6cOQDEx8czatQodDqdWwIYNWoUWVlZzJ49m4yMDDp16sTGjRudg16Sk5OdS7U1JH6Nr8aYn4Q+5U+XZNGxrxemQ8kUpm6vUrLoFRZHxNV3kPHH5yT/sIiEsa9WO778U5tJ3fE6jXo+TmD89S77LIXZ5B/+HfngFoJa98EvvmMFtdQ+A/tdy8avP+a20Q+RnZOL1WrlwakzSU/P5IlHHyi3C0ZlZO/eQOKqWTS780VCuwx2c9RCQ/fvvoP0HTSKLRtX07lD20u/QBAEoQoqfRu6vqgrze7GgmQSNz6C2juMFjd96JKklOSe4OTPj6Hxa0yLIUurVK+1WM/e+bdiLS6g9YNL8W/WrZrxnSHr0CrC2tyJLuDCFsq0zcs5s+FttCGNaT/tc5Qar2qdx1MSk04z/M4HXAa6PDDhLl576f+qNeK0ODOJtF8/ILrfRLwjmrgzVEEgKzuXdT/8zM1DBhAWGuzpcIQ6oq58HwqeV+UmO4VCgVKprHAT3EMXEIvWPwZLcRYlucdc9wU1Q+0dhrkwBZO+aqMfVd7+NBpwPwCn179xwfQ8lY8vhpheT5abKAJE9R2Db1wHTDkpJH+/qFrn8KRmTeL49bvP6NKprHvDex99zt33PlqtuRi9I5rQ/O7/iURRqBFhocFMHDtKJIqCINSIKieLX331lcu2evVqZsyYQVRUFO+95/41iBuysgm6XUdFS5KEX6OrSvdVfoLuc8KvGokuPJ7itKOc/fubasVmLsokc98KzEXlT5MjKZQ0G/U8CrWOs9vXkn/sr2qdx5PCw0LY8NVybuxXNsDlu42/cuPwMaRnXHw5yv8y5qZzZsNijLnp7g5TEMgv0PP9xk3kF9TeFaoEQai7qpwsDh8+nFtuucW5jRw5kpdeeon58+ezbt26moixwfIvnUKnMOXPC6bKObeOdFHGrirXq1CqiLv5CQCSv3sTY05Klesozj5E9uE1FGcfqvAYXWgMsaWjrk+ufQGbuXJrWtcmvj4+rPl4MWPvus1ZtmffIa4ddAd7DxyudD1Fp/aQtvkjik7tqYEohYYu6fQZ7hg3iaTTYp5FQRDcz219Fk+ePEmHDh0oKipyR3U1pi710ZBlmePf34/FkEGzGxehCypbB1u22yjK2IVPeEcUKm216k/68mXO7vgKvyadaf3g0ipNc2O3GjEbstD4hKFQVTzYSZZlTq6eQ3D7fgS17VutOGsDWZZ5/a33mfPSAmeZj7c3y5e+xpCB11/klQ5WsxFzXjqaoChUGvcMDhOEcywWC/kFhQQG+KFWqz0djlBH1KXvQ8Gz3DLMuKSkhEWLFtGoUd2ZjLkukCQJ/xhH62LBf9aKlhRK/KJ7VDtRBIi96TG0wY0oTPqXjN8/q9JrFSoduoCYiyaK4HgPze58oU4niuB4H09MvZ9P31+ITue45obiYu4YN4m33/34kpOkqzQ6vCOaiERRqBFqtZqw0GCRKAqCUCOqnCwGBQURHBzs3IKCgvDz8+PDDz/k1VerPxWLUL6ytaIrXs3FZq5ea65S602zO58HSeLMxncozjhx6ReVMmQd5Nh392PIOlilc+Yd/gNLYU5VQ601bh02kB+/XkF4mGO5SVmWeXr2K0yb8QJWa8Wrs+hP/sueecPRn/z3SoUqNCCnk1N5YOpMTienejoUQRDqoUrPs3jOwoULXZ4rFArCwsLo2bMnQUFB7opLKOUVnIDaOwyT/gwm/Rm0/q6jj5P/+B+FaTtJGLYctVfVr79ffCei+o4h/bcVJK6aQ9vJy1GoLt06YbeUYDPlY7eUVPpcZ3d8TdKXLxHYug8J4xdUe85CT+vWpQNbNqxi5JhHOHjYMVJ92fJVnDx1hk+WvUGAv98Fr7GZi7EU5WIzV30ktSBcisls5mRSMiaz2dOhCIJQD4l5FuuA9H+XkXvsW8Lb3UNY2ztd9qX89ToFpzcT1fURgpsPqVb9dquZA4vGUJKRSHS/icQMfNgdYV/AYshn/+ujsBTl0PT22YR1v7lGznOl6AuLGPfgdH769XdnWeuWzfjy03eJixVdMgRBqN3q4veh4BnV7rNYXFzMkSNH2Ldvn8smuJ+/cwqdbRfuK+3TqD/zR7XrV6g0NLvzBSSlirRNH1GUfKDadV2M2ieQJiOfBeDUt69hzK7bIzf9/XxZu+IdHrp3tLPs8NFE+g4exY6d4nazIAiCUD9UOVnMyspi6NCh+Pn50bZtWzp37uyyCe7nHdoalS4IY34S5iLXefp8IzqjUHlhyDqA1VhQ7XP4RLek0YAHQbaTuGr2Jae5yT+9lYOrbyL/9NYqnSeoTR/Ce96G3VzMic//D7vVUu2YawOVSsXrc5/ltZf+z7ksZVZ2DoNHjGft1987j8ve8yM7nupG9p4fPRWqUI/tPXCYyGbdqjSdkyAIQmVVOVl87LHHKCgoYMeOHXh5ebFx40Y+/vhjWrRoIeZZrCGSpCiboPuMa+uiQqXFN6obyHYKUy9v4uvovmPwjW2PMTuZMxveuuixuoBYfKN7oAuIrfJ5YodNxyuiKYYzh0j5qWrLFdZWD993D2s/eQdfH28ATCYz4x96glcWvIMsy3hHNCOwzbV4RzTzcKRCfRQZHsYzT04mMjzM06EIglAPVTlZ3LRpEwsWLKBbt24oFAri4uK45557mD9/PnPnzq2JGAXOvxV94aho563ocm5TV4WkVDlXXcnctpqC4zsqPFYXGE9cn9noAuOrfB6lRkfzu19GUmkw5aQg2+2XEXXtMah/X35Z/xmNG0U5y16c9xb3TX4aZXAsLccvwDuquQcjFOqriPBQpj40nojwUE+HIghCPVTlZNFgMBAeHg44ptHJysoCoH379uzevdu90QlOPmHtUGr8Kck9htngutScX1Q3JKUWS0lutdd6PkcXFkvs0EcBOLnmBawlheUeZy7OJuvwF5iLs6t1Hu+o5rR79FOa3/MKksIt033WCu3btuS3Davo2qm9s2zVF+u56657OP79Ukz55S+PKAiXQ19YxKYtf6IvrN2LIgiCUDdV+Vu6ZcuWHD16FICOHTvy7rvvkpqaytKlS4mKirrEq4XqkhRK53rQhf9ZD1qh0tFiyLs0H/R2lVZhqUh4r5H4t+iJuSCT0+teK/eY4rP7ObtvOcVn91f7PN4RTZ3T59iMhnrTwhgVEc7Grz9m+E03OsssaYfI3fI+h37//iKvFITqSUw6zbA7JpKYdNrToQiCUA9VOVl89NFHSU93DLKYM2cOGzZsIDY2lkWLFvHyyy+7PUChzMVuN6u93Xf7SZIkmt4+G6XOl+xd35O7f9MFx/hG9yT+hnn4Rve87PMVnt7PvjfuJGPbqsuuq7bw9vbik2Vv8PiU+wH464yNKT+UcPO0t10GvgiCO7Rp2YJDO3+hTcsWng5FEIR66LLnWTw3hU5sbCyhobW/v0xdnlfKbrNw9Nt7sFuKSbj5Y9RewS77ZVmmJPcYWv8YlGrvyz5f9u4NJK6ahconkA7TV6P2C7nsOstTcOIfjix7GEmhpO3k5fg0alUj5/GUFZ9/xaNPPYfZXDbye+rDE3jx2emoVFWeF18QBMEt6vL3oXBlXXZnMW9vb7p06VInEsW6TqFU4xfdA5AvuBUNkPb3myT98jiFaX+75XwhnQcR3L4fVkM+J798yWX9Y0P2YU5snIQh+/Kn6gho3o3o6ycg26ycWPkMNlP9WuVk7F23sXHZbD6+zY/WoY5fuUVLPmLY7RM5m1V3lz4Uao8zKWlMm/ECZ1LSPB2KIAj1UP0ZWdBA+MdcA5R/K9on3DGo4r/T61SXJEnE3zYTtW8I+Ye2kr3rO+c+u7kQc1E6dnP5A2CqqtGAB/CN64AxO7nCfpJ1WUJsBLFBKq7qVHabcOuff3PNjSP5Z7eYzF64PIbiEnb8swdDceWX3xQEQagskSzWMb6RFU/C7deoJ5JCRVHGLmxVWLP5Yv676oopz9Ff1S+6B21GflXa0nn5FEoVze/6H0qdD1k715FTzyavDmrThx4v/8kby9cy6YGxzvLUtAwG3HIPH6/8woPRCXVdq4Rm/PnLV7RKEPN4CoLgfiJZrGMUSk2Fk3ArNb74hHdEtpkpytjltnMGtelDWPdbsJsMJK5+rsZGLWuDo2ly2/8BkLzhbew2a42cx5PUajXzX5zJh++8ipeXDgCz2cIj02cx5Yk5mExmD0coCIIgCK5EslgHlY2KvsgE3W66FX1O7LBpaIOiKTy5i4xtqyg48wcHVw+j4DLWpC5PSKcbiR36GG0eeg+Fsv4M/sjZ9ws7nu5Ozr5fABg14iY2f7+KJnExzmM+/GQNA4ePITUtw1NhCnXU/oNHadq+D/sPHvV0KIIg1EOV+jbet6/yfao6dOhQ7WCEyjk3Cbfh7F5s5iKUGt+yfY16wj8KitJ3YreaUKi0bjmnSudL0zvmcPi9hzizYTEt7n0Fn/AOaHyj3VL/+aL63uP2Oj1NFxKDf7Nu6ELKksP2bVvy+09rufeRJ/np198B2Ll7H70HjOSTZQvoc7V7bvEL9V9oaBAPTrib0NAgT4ciCEI9VKmpcxQKBZIkUdGh5/ZJkoTNdnkriNS0+jJVQPIfL1GYup1GPacTGH+Dy77TW58DJKK7PYLa271rxZ5e/wYZv6/Ep3Eb2kz6sEZb/+xWM2c2LCaw9TUENO9eY+fxNJvNxsuvLeaVBUucZUqlkrnPPcUj949xTlwuCILgTvXl+1CoeZVKFk+frvyqAHFxcZcVUE2rL78c+ad/I/Wv1/CL7klsn1ku+84l7jXBbjFxYNEYSrKSCO5+PfFDZlww36O7ZO36jpOrn0PtH0b7aZ+j9gmskfNcCWZ9NnmHtxLU+lo0/uVPM/X9xk3cN/lplyXb7rjtJha//gLe3l5XKlShDioyGDh46Bht2yTg6+Pj6XCEOqK+fB8KNa9SfRbj4uIqvQlXhl90j9KRz7uxWVznJazJliiFWkuzUS+g9NJgth7i7D+ra+xcoV2GEtjqGiz6LE6ueb7Clu26QH9iJ6e+fBn9iZ0VHjN00A1s2biG1i3LRrSu+eo7rh96F0mnzlyJMIU66njiKW646W6OJ57ydCiCINRD1Rrg8sknn9C7d2+io6OdrY4LFy7k22+/dWtwQsWUam98Ijsj2y3lTtBtsxSTf/o3SnKOuf3cPo1b0ajfwxQfzCb9lzUYc1Lcfg4oXXbwjjmo/ULIP/w7mX+uqZHzXAmBra6mxdjXCGx19UWPS2jehM0/rObWYQOdZQcOHeWaG0ey/odfajpMoY5q1aIZO7eso1ULMXWOIAjuV+VkccmSJUyfPp0hQ4aQn5/v7KMYGBjIwoUL3R2fcBGB8f0AyD/16wX78pN+JfWv18g98UONnDuy92iC2w3GVlLI8RVPYjMba+Q8at8gmt35IkgSyd+/iSHN/cnvlaDyDiC43XWovAMueayfrw+fLHuD/81+AoXC8SuaX6DnzglTmDbjBUpKauZaC3WXl5eONq1aOKdjEgRBcKcqJ4tvvfUWy5Yt4//+7/9QKpXO8m7durF//363BidcnF90D5QaXwxn92E2ZLrs82/cC4DCtL+Q7e6fr7Ak9ziyfy5ejZpSnH6cpP8sB+hOAS16EHXdOGSrmROfPYPdUveSpcLkgxxYNJbC5IOVOl6SJKZNmsi61e8TGlI2wvW9jz6n7+BRHD56oqZCFeqg1LQMnnn+VTHtkiAINaLKyWJSUhKdO3e+oFyr1WIwGNwSlFA5CqUG/9i+AOSf2uSyT+0dildIK2zmIgxn3b+cnLUkB5P+NI1uHIfKO4CcfzeQ+WfN9V9sfOND+DXpQsRVI5DcNB3QlWTRZ1GcfgyLPqtKr7v+2l78tekb+l5zlbPs4OFj9Bl4Ox+uWFOn+3EK7lOgL+SHHzdRoHfP8puCIAjnq3Ky2KRJE/bs2XNB+caNG2ndurU7YhKqIKhJfwDyk35Bll1XVqmpCbrB0XLZ9o5vCGk9lGZ3v+S4Tbz+DQqT9rj9XOBYDrD1g0uJvOauOjmVTHC76+gx9y+C211X5ddGRYazfs37PPfMNGdrfkmJkSlPzmHM/dPIyy+4RA1CfdemVQv2/LmBNq1aXPpgQRCEKqpysjh9+nQmTZrE6tWrkWWZv//+m5deeomZM2fy1FNP1USMwkXogpqj9Y/FYsikOMv1Fqd/Y8dgCn3qX8j2mpv/MjDhKhoPfBjZbuP4p09j1mfXyHkkRdnHtejMQYzZDWeEsFKp5MlHH+CXdZ8SF9PIWf71+h/p1e9W/tr5rwejEwRBEOqzKieL9913H/PmzePZZ5+luLiYu+++myVLlvDmm29y55131kSMwkVIkkSgs3XRdaCLxicCXVALbKaCCxLJy6VP2c7BNbegLx2JHX3deILa9sVSmMPxT5/GbrW49XznKzj+N4femcjxlTOxW+vGWsq5B35jx4ye5B747bLq6dGtE3/++hUjbh7kLDuTks6Nt4xh3oIltX5SfKFmHDpynPY9B3LoyHFPhyIIQj1UralzRo8ezfHjxykqKiIjI4OUlBQmTpzo7tiESgqIux4kBfqUP7BZSlz2BTUbSHCLm1G5eeJslVcoXsHNUXk5JpiWFAqa3vE8utBYik7tJfn7hW493/n84jugC4unOPUIyd/V3HncSRMQjk/jNmgCwi+7rsAAfz5+bwHvLHgRby/HZN02m40X5i3ippH3kpaeeYkahPomMMCfW4cNJDBATKwsCIL7VWoFl/qkvs5Yf/r35ylK20l0j8ec/Rg9oTgjkYNvj8duLqHZnS8Q2mVIjZyn5OwpDiwag91cQosx8wluf8OlX1QPHTmWyLgHH+fAoaPOsuCgAJYufJmhgxrmNREEoXLq6/eh4H5VblnMzMxkzJgxREdHo1KpUCqVLpvgGUHxZQNdrgSrSU/BmT+wmvQu5d6RzWh6xxwAkr58qcbmRfQKjyf+1hkAnFz7Asbc1Bo5j7tYiwvI2fcL1mL3DkZpldCMLRtW8/DEe5xluXkF3DFuEk888xJGo8mt5xNqp5ISI/sPHhVzcAqCUCOqnCyOHz+e3bt3M2vWLL744gu++uorl03wDN/oHig1/hRnHcBc5DrXmqUkl7MHPyf76NduO19R+i5S/nyFovRdF+wL6dCfyGvvwW4xcXzFk1iL9eXUcPnCug4lrNswbMYiTqycWaP9JC9X/pE/OfHpDPKP/On2unU6La+9/H+sXfEOIcGBzvIlH3xK38GjOHIs0e3nFGqXI8cTueqG4Rw5Lv6tBUFwvyrfhvbz8+P333+nU6dONRRSzarPze7pu98l9/h6wtreRXi70c5yk/4MJzY8jNo7jBY3feiWqWesxnwK0/7BL7obKl3gBftlm5XDyyZReHIXga16kzD+DZfRzO5iM5dw8K1xKNQ6EiYsQOMX6vZzuIO5KJeCI9sIaNUbja97+4+eLy09k4mPPMXWP/92lnl7efHyc08ycewo54owQv1iMBRz5FgirRKa4ePj7elwhDqiPn8fCu5V5W+OmJgYMRFwLeVc/i/pV5c5F7X+MWj9Y7AUZ1GS657bwipdIEFN+5ebKAJIShUt7pmLOiCc/CPbSP1lmVvO+19KjRctJy6izSMf1NpEEUDjG0xYt2E1migCREdF8N0XHzL76anObiHFJSU89vQLDLtjIslnavfteqF6fHy86dq5vUgUBUGoEVVOFhcuXMiMGTM4depUDYQjXA5dUDO0AfFYis9iOOu69KJ/49IJulPcM0F3Sd5JkjbNoCTvZIXHqH2DaXHPPCSlitRflpF36He3nPu/tIGRKFRqAOw2K5aivBo5z+UwpB7l0JIHMKQevfTBl0mpVPL09If58ZsVxMZEO8t/+/0vuve9Waz8Ug+lZ57lpVffJj3zrKdDEQShHqpysjhq1Ch+++03mjVrhp+fH8HBwS5bdSxevJj4+Hh0Oh09e/bk77//rvDYZcuW0adPH4KCgggKCqJ///4XPb4hcZ1z0XWgy/mrubgjUTAXpVOcdQhzUfpFj/OLa0/cLU8CkLhqVo1OpG0uyOLQkvs49vHj2G3uXw/7cphyUyk8tQfTFRyI06tHF3Zs/pbxo0c6y4oMxUx5cg43j7qPlNSL/9sJdUdOTj7LV35BTk6+p0MRBKEeqnKfxY8//vii+8eNG1elAFavXs3YsWNZunQpPXv2ZOHChaxdu5ajR48SHn7hnHSjR4+md+/eXH311eh0OubNm8fXX3/NwYMHadSoUTlncFXf+2hYjfkcXTcOSaGi5S2foFQ7bkvJssyJHx7AXJRO0xvfxCuo2RWLSZZlkta+QNY/6/GKbE7byR+h1Hi5/Tw2o4EDi8ZgzE4m6rqxxA6Z6vZz1FU/b/6DSdNnkZpWNvjJ38+XV55/mrF3j6iTSygKgnB56vv3oeA+Hp9nsWfPnnTv3p23334bALvdTkxMDFOmTGHGjBmXfL3NZiMoKIi3336bsWPHXrDfZDJhMpVNH6LX64mJianXvxzJv79IYdoOortPJajpjc7yzH3LyT78BaGt7yCiw4XXqibZLUYOvnMfxalHCOk0iGZ3vVgjCYoh7RgH3x6PbDXT8t43CWzV2+3nqKsK9IXMmP0KKz53nbVgwA19WPz6CzSKjvRQZIIgeIJIFoXKuqyhkUajEb1e77JVhdlsZteuXfTvXzaJtEKhoH///mzfvr1SdRQXF2OxWCq8BT537lwCAgKcW0xMTJVirIsquhUdEHcDkZ0fJLj55U+UrU/dwaG1t6JP3VGp4xVqHQlj5qPyDiBnz0Yyt6267BjK4xOdQNyw6QAkrp6DuaB29OHKPbSVv5+5mtxDWz0WQ4C/H0sWvsSXK5cSFVnWav/zpt/p3vdmPl39jejLWEcdPnqCHtfdwuGjJzwdiiAI9VCVk0WDwcDkyZMJDw/Hx8fH2Xfw3FYV2dnZ2Gw2IiIiXMojIiLIyMio4FWunn76aaKjo10SzvPNnDmTgoIC53bmTM31mastfKO6odT6U5x9CFNhmrNcFxBLSMIw1N6XP2pYpQtA49cYlS6g0q/RBkfT7O6XQJI4vX4BOXt/vuw4yhN+1QiCOwzAasjnxGf/h1wL+i+qfYPQhcWh9q3a70hNGNS/Lzu3rGP0qOHOsgJ9IQ9OncnIex4mPaN2JNhC5fn5+nDt1T3w8/XxdCiCINRDVU4Wn3rqKTZt2sSSJUvQarW8//77PP/880RHR7NixYqaiLFCr7zyCqtWreLrr79Gp9OVe4xWq8Xf399lq+8USjUBsdcBkH/q13KPudwWJO+QVjQf9BbeIa2q9LrAhKuIH/40yDKJnz9L/uE/LiuO8kiSRJOR/4c2pDFFp/dRlHzA7eeoKr/Y9nSY9jl+se09HQoAQYEBvLdoLl988g6REWHO8o2/bKHbtcP4bO23opWxDmncKIrXXv4/GjeK8nQogiDUQ1VOFtevX88777zDiBEjUKlU9OnTh2effZaXX36ZlStXVqmu0NBQlEolmZmZLuWZmZlERl68/9Rrr73GK6+8wk8//USHDh2q+jbqvSDnrehfke02Z7nNbCBlxwJObXr6suq3mosozNiD1VxU5ddG9BpJzODJyHYbxz55Gv3J3ZcVS3lUOl9a3PMKrR9+H78mndxef1VZi/UUHP+7xlazqa7BN17Pzi3ruHPkMGdZfoGe+yfPYNS4yWSczfJgdEJlGY0mEpNOi+UdBUGoEVVOFnNzc2natCkA/v7+5ObmAnDNNdewdWvV+mNpNBq6du3Kr7+WtX7Z7XZ+/fVXevXqVeHr5s+fz4svvsjGjRvp1q1bVd9Cg6ALaoousCnWkmyXORcVai8MmXsdt6j11b8lX5S2k+Qtz1KUtrNar4++fjxR141Dtpo4+tE0DCmHqx1LRXwatcIvrqwlz5MtZflHtnFk2SPkH3HPPJfuFBwUyAeL57N6+duEh5V1Ufj+x010v3YYX3zzgwejEyrj8LETdLhqEIePiT6LgiC4X5WTxaZNm5KUlARAq1atWLNmDeBocQwMDKxyANOnT2fZsmV8/PHHHD58mIcffhiDwcCECRMAGDt2LDNnznQeP2/ePGbNmsWHH35IfHw8GRkZZGRkUFRU9Rau+i6wybkVXcr6BkqSAv/GVwOgT6n+OsXe4R2I6HQf3uHVb9WNGTyZ8KtGYDcZOPLBFEoyk6pd18XIskzGn2s4+uGjLq2sV5J/s27EDpuGf7Pa+8fNTYP78c/Wddx+61BnWW5eAeMefJz7p8xAXyh+x2qr5k3j2fDVxzRvGu/pUARBqIeqnCxOmDCBvXv3AjBjxgwWL16MTqdj2rRpPPnkk1UOYNSoUbz22mvMnj2bTp06sWfPHjZu3Ogc9JKcnEx6etnkwUuWLMFsNjNy5EiioqKc22uvvVblc9d3AXHXISlU6FO3YzMbnOXO1VzOVL+VS+MdQmjL4Wi8Q6pdhyRJxA9/mpBOg7Aa8jn8/iRMuWmXfmEV2U3FZGz5lIKjf5L664dur78yNAFhRPUZjSYg7NIHe1BIcBDLl77GZx++SWhI2QwDn635ll433MqOnf96MDqhIn6+PlzbWwxwEQShZlz2PIunT59m165dNG/evE70HWxo80ol//EShanbieo2meBmgwAcfQXXj8NqzKfF0GVofKveKd6Yf4rMfcuJ6DAeXWD8ZcVot1k5vuJJ8g//jjakMW0efh+Nv3vXeS5KPsChdyYiyzKt7n+HgOZXtoWvOP0EyRveInbwFLyjml/Rc1dXVnYuj0x7lh9+2uwsUyqVzHz8YZ589EFUKpUHoxPOl3k2m8/Wfsvdt99CRHjtXSNdqF0a2vehUH2Vblm02+3MmzeP3r170717d2bMmEFJSQlxcXHcdtttdSJRbIjKm3NRUijxa+S4FV1wpnqjkU36MxSl/3NZ/R7PUShVtLhnLn5Nu2LKSeHI+5OwFhdcdr3n841tR8yQKSDbSfz8/zAXZru1/kspPptEwZFtFJ+tmVvtNSEsNJg1KxazcN5sdDot4JgE/3/z32bg8LGcOp3i4QiFczKzsnl90TIys67s51oQhIah0sniSy+9xDPPPIOvry+NGjXizTffZNKkSTUZm+AGflFdUWoDKck5gklf9uUeEHsNAEXpu6pVb0BsH9qO+o6A2D5uiVOh1tFy/AJ8YtpQkpHIkQ+mYjMaLv3CKojsM5qgtn2xFOaQ+NmzV7T/YmjHAfSc/w+hHQdcsXO6gyRJ3D/+Lrb9/CXt25ZNk/TXzn/p1e9WVn2x3oPRCed0aNuKlKN/0aFt1aayEgRBqIxKJ4srVqzgnXfe4ccff+Sbb75h/fr1rFy5ErvdXpPxCZdJUqgIjLsOcJ1z0TusHbHXPkdc3xc9FNmFlDofWt67CK+IphjOHOTYiiewW9w3FYgkSTS9fQ7a4EboE/8h868v3VZ3fdcqoRlbNqxm6sMTnGX6wiImTnqKCQ8/SYG+0IPRCYIgCDWp0slicnIyQ4aULRPXv39/JEkiLc39AxIE93Leij61ydmaJkkK/KK6oVCqq1VnYdo/HPpyJIVp/7gtTgC1TyCt7lvsSOhO7OT4ypnY3bgCi8rbnxb3vEJE71GEd7/FbfVeSt6Rbex8tg95tXDqnMrSajXMfe4p1q1532Ui7zVffcdVNwznzx3Va6UWLt+xE0lcP+ROjp2oO90cBEGoOyqdLFqt1gtWSVGr1VgsFrcHJbiXLjAeXVBzrCU5GDL3XLDfUpxd5TkIFWpv1LoQFGpvN0VZRhMQRqsH3kHtH0b+oa2cXPM8shtbsH0atyb+lidRqLVuq/NSVDpfNP5hqHS+V+ycNaVf397s2PwtNw3q5yxLPpPGwOFjeXHeIqxWzy+v2NDotBpat2yOTqvxdCiCINRDlR4NrVAoGDx4MFpt2Rfs+vXrueGGG/DxKZuu4auvvnJ/lG7UUEd/5RxfT8bud/GPvZaYXk85y1P+ep2C05tpOmAhXsG1a5RuceZJDi+5H2txAeG9bid++FNIkuTWc5jyM0j/bQWxw6ajUIrRvVUhyzIffbKWp2bPpaTE6Czv0bUjH7wzn6bxsR6MThCES2mo34dC1VW6ZXHcuHGEh4cTEBDg3O655x6io6NdyoTaKSC2L5JCRWHKdmznLdGn9gkHoCB5S5Xqs1uNlOSdxG41XvrgavKOaErLiW+h0PpwdvtaUja+49b6ZVnmxMpnyPxzDSk/urfu/7KajRhSj2I119z1utIkSeLesXew7ecv6dShjbP871176XXDraxc841YX/oKsVgspGeeFXd6BEGoEZc9z2Jd05D/kjqzbS76lG1EdX2E4OaO/qfGgtMkbpyEyiuUhGEfIkmV+/sh/9RmUne8TqOejxMYf31Nho0+cRdHPpiKbDURM3gy0dePd1vdhrRjHHx7ArLVRML4BQS1udZtdZ8ve/cGElfNotmdLxLaZXCNnMOTzGYzL8xbxMLFH7okiLcOG8irLz1DVES4B6Or//7dd5BrBozkj5+/oHOHtp4OR6gjGvL3oVA1VV7BRai7yuZcLBsVrQuIQxsQj7Ukm+KsQ5WuyzusHWFt78I7rJ3b4/wv/2ZdSRgzD0mh5MyGt8nc/oXb6vaJTiB+uGPlocTVz9XICjIAfk06E93/fvyadK6R+j1No9Hwv1lP8N3aD4mKLEsMv17/I116D+XdD1dis3lmqcWGoGl8LF9+ukTc+hcEoUaIZLEB8Y3sgkoXREnuUZfJtANiHa1pBclbK12XxieM8Haj0fhcmeXrAltfQ7M7XwRJ4tTXr5D551q31R3W/RZCuw7FVqLn+MoZ2K3uv5WnDYok5sYH0QZFur3u2uS6PlexY/M33DK0bD5JfWER02f+j+uG3Mm/ew96MLr6K8Dfj0EDriPA38/ToQiCUA+JZLEBkRRKAkpvGeedt6LLuWRRn/IHsr1yI1mNBWdI/vMVjAWXv4JLZYV0upGmt88GScGpb+aRtnm5W+qVJIn4W2eUzu94iDM/LHJLvecrzkzi+KczKM6s/1ObhAQHsfKDN1n5wZsurYy79xzg2kF38MQzL4l5Gd0sKzuXdz9cSVZ2rqdDEQShHhLJYgMTGO+Y7qTg1GbnnIsa30i8Qlqi0gVjKcmpVD3G/JMUnvkDY/7JGou1PGHdhtF89MtIShVnNrxN8g9vuWUQhVLjRYt75qELjye4Q383ROqqOO0ouft+oTjtqNvrro0kSWL4TTey+4/vmfTAWBQKx/9q7HY7Sz74lC7XDOXLbzeIATBukpqewYw580hNz/B0KIIg1ENigEsDdPLnaZTkHie2zxz8orsDYLMUo6yBORNrSv6RbRxb8RSy1UR4r5HE3/IUkuLy//aR7TYkhdINEQrn27P/EFOfeI5de/a7lPe//hreeGWW6GsnCB4gvg+FyhItiw1QYPy5FV3KBrrUpUQRILBVb1rdd25anS9IXDMH2Q0rvZxLFGVZJvvfjW5dbrAh69S+DZt/+JyF82a79Kv7ZfMfdO97M/MWLMFkMnswQkEQBKEiIllsgALiSudcTP0Lq6ms75gs2zFkHaAk98Ql6yjM2M3hr++kMGN3TYZ6Uf5Nu9D6gSWovAPI2b2B458+7bbkLvWnd0n8/FlOr3vdLfUVHPuLf+bcQMGxv9xSX12kVCq5f/xd7N72PXfcdpOz3Gg08cK8RVx1w3C2/LHDgxHWXSdOnmLoyAmcOHnK06EIglAPiWSxAVJqfPFr1AvZbnVpXSw4tZlTm2aQfXjNJetQKNQoVF4oFNVbW9pdfGPa0Pqh91D7hZJ3cAtHP5qGzVR82fWGdhniaLXc8RXZuzdcfqAqDUqtN6jEcmyR4WF8tORV1q/5gOZN45zlx04kMWTEeO6b/DRnsyrXd1ZwUClVhIYEoxKrEAmCUANEn8UGypB1gFObZqDSBdFi6PsoVFps5iKOfnsPSApa3vJpnbo1bcxJ4ciySZhyU/GN60DLCQtReV/ev2/Ovl848ekMFBov2k1ZgVdEEzdFK5xjNJpY8Pb7vLboPZfb0IEB/rzw7HTGjx6JUin6kApCTRDfh0JliZbFBsonrB0+4R2wGvPIS9wIOFocfSO7INvMFKZe/Hap3WbGXJyN3VY7+pnpQhrT5uFl6MKbUHR6H4fffQhL4eW1ToV06E9E71HYzSUc//RpbOaSatdlt5ox5Wdit9aO61Vb6HRannliEn//9i039L3aWZ5foGfqk8/RZ+Dt/LljlwcjrBtsNhv6wiIx8bkgCDVCJIsNWFi70QBkH1nrXOM5ILYvcOm1ovVntnF8/Xj0Z7bVbJBVoAkIp83Dy/Bp1Jri9GMcWnI/przLm0okduij+MS0oSTzJKe+fqXaU73k7vuVPS8PJXffr5c+uAFq3jSedavfZ/nS14gID3WW791/mAE338P4h54gNU1MC1ORfQePENW8O/sOHvF0KIIg1EMiWWzAfMLa4hPRCasxn9xER788v0Y9kZRaijL2YDUVVPha79DWBCcMxzu09ZUKt1LUPoG0emAJfk06Y8xO5tCSiZRkna52fQqVhuaj56L08kOh1oFsr1Y9vnEdiOxzN75xHaodS30nSRK33zqU3X98z8P3jXG5/bz26+/pdPUQ5i1YQkmJ0YNR1k7xsY35ZNkbxMc29nQogiDUQ6LPYgNXnHWIpE1PodQGknDT+yhUOs78OQ/9md+J6voIwc2HeDrEarGZjRz/5CkKjv6JyjeY1vcvxjuqRbXrM+uz0fiHXvpAwW0OHTnOU7PmsnnrdpfyuJhGvPzcU9wydACSJHkoOkGo+8T3oVBZomWxgfMOa4NPRGdspnxyT/wAQGD8Dfg1ugqtX8WtFKbCVFL/fhNTYeqVCrVKlBodCeNeJ7h9P6xFuRxa+gCFp/df+oUVOD9RNBdkYTNXrXWrJOs0J9e+eFmtnA1Nm1YtWL/mA1Yvf5smcTHO8tNnUhk98VGGjJjAgUPHPBhh7ZGTm8cnq74mJzfP06EIglAPiWRRILzd3QBkH/kSu9WIX3R3Yq95Fp+Iim+ZluQcIz/pZ0pyau+XtUKlpvndLxHWbRi2kkKOLHuEguN/X1ad+pO72b/wrirPv2g4c4isnd9iOHPoss7f0EiSxE2D+/HP1vU898w0fLzLRuhv3baDXv1uZfrMF8nNy/dckLVAckoaDz36DMkpaZ4ORRCEekjchhYAOL1lNkUZu4noMJ7Q1iMvebzdbge7FRQq57q/tZVst5P83Rtk/PE5klJNk5HPEtZ1aLXqMuaksH/haOwmA83vfpmQTjdW6nV2ux2sZlBpav31qs3S0jOZ9b/XWfXFepfy4KAAZj09lXvH3IFK1fDmGpRlGZvNhlKpFLfmhUoT34dCZYlvLQE4b2T00a+wWUqw2yzkJf1C+q6l5R6vUChQ1JHER1IoiB02nUb970e2WTi5eg6nvn0VezWWB9SFNKbpiGcAOPnlSxhzUir1OoVCgUKjqxPXqzaLjorgg8Xz2fTdZ3Tp1M5ZnptXwLQZL3J1/xFs3XZ5rcd1kSRJqFQqkSgKglAjxDeXAIB3SEt8o7piM+nJPfEdkqTg7L7l5J74rtx+iUWZeznyzT0UZe71QLRVJ0kSjW98kOb3vIJC40XmttUcefchzIXZVa4rpNNAwnrcit1k4MSnMys1d2LBiZ3seuFGCk7srE74wn/07N6ZLRtWs2ThS4SHlfUnPXj4GINvG8foiY9y5FiiByO8sk6eSub2MY9w8lSyp0MRBKEeEsmi4BTW1tF3MefIV9htJvxj+gBQkLzVk2G5VUiH/rSdvBxdaCyFp/Zw4M0xFJ7eV+V64m5+HK+IphhSD3Pmh7dqIFLhUhQKBWPvuo292zfw6CP3olaXLT35zXc/0e3aYYy5f5qYe1AQBOEyiT6LgovTW5+nKH0n4e3H4hPenqRfn0Tj15jmg5fUq1tc1pJCElfNJv/w70hKFXE3P0H4VSOq9B6LM09ycNEYlN4BdJi+GpWXXw1GLFzK8cQkZsyex8ZfLpxQfujAG3jqsQfp1kXMcykI54jvQ6GyRMui4OLcyOico1+h8Y9F7R2OuTAFY36Sy3F2ux271ewYuFEHqbz8SBj3Oo0GPIhst3Hq61dIWvsCdoup0nV4RzSlxdjXaP/oyksmina7HbvZWGevV13QolkTvly5lHVr3qdXjy4u+77/cRN9B4/i5lH31cvlA2VZxmq1VnuFIUEQhIsRyaLgwiu4BX7RPbCZi8g7vp6A2GuBC5f/0ydv4fCXt6G/xLKAtZmkUNB4wP0kjH8Dpc6XrH/WV3mJwMCWvVD7BgGOL2y5gmQwd8+P7Hz2GnL3/OiW2IWK9evbm5/XfcqGrz7muj5Xuez79bdtDLj5HgbdOpZNW/6sN8nVnv2HCGjUnj37xdRMgiC4n0gWhQuc67uYffRrfKO7A6BP3uryxeoVkkBgkwF4hSR4JEZ3Cmp9De2mfoJXZDMMKYc4sOieKg9EsRkNJK6aTcpPS8rd7xPThrDut+AT08YdIQuXIEkS1/buwfdffMSm7z5jUP++Lvt//3Mnw+6YyA1D72Ljz7/V+aQxtnE0S998mdjG0Z4ORRCEekj0WRTKlfzH/yhM/YvQtnejUKjwjeyMLqh5veq3+F82UzEnv3iR3L0/g6QgdshUIq8dXan3bEg7xsG3xiHbrbS6720CWvS8AhELVfHvvoO8uvBdvv3+5wv2dWzfmqenPcSwwf3F9EZCgyG+D4XKEv9XFMp1rnUx99i3BDcfgldwC5ekyVyUQfq/72Muqvwt29pOqfWm+d0vEzv0MQCSv1/IiZXPYDMVX/K1PtEJxN70GMgyiZ/PxlKY47LfmJPK6fULMObUzuURG4LOHdry2YeL+Pu3b7njtptcksK9+w9z972P0uO6m1n95XdYLBYPRlp1efkFfLVuI3n5BZ4ORRCEeki0LAoVSv7jJQpTtxPW9i7C24123qqTJIn8U5tJ3fE6jXo+TmD89R6O1P0KTuzkxMqZWA35eEU2I2Hsa+hCYy76GlmWOf7JU+Qd2Ix/ix60mvg2kkKBbLdx9p9vOfXFy8Td+jiRve4CwG41UZj2F3arCbvViN3m+ClbjditJiI6jkep8QUgfdcSjAWnARlkufTfwvE4pNWtBMRcA0Be0i/kHlsHnHcMEpKkxCukJdHdHgHAUpxN2j9vIUkqJIUSJCWSwvFYklREdnkAhVLjuBZn/gBA7RWCyisEtVcwkqLur5JyPDGJ1xe9z+dfrMNqdZ2gPTQkmNuHD+Gu22+mS6d2tb5F/d99B7lmwEj++PkLOndo6+lwhDpCfB8KlSWSRaFCxryTJP40FYXam/B2Y8g98R1RXR7CN7IzdpsZq0mPSuvvTCrqG1NeBsc/eQpDyiGUOl+a3fU/glpfg2y3YTPrsRoLsJn0WE0FaHyj8ApujrVYz77XR2IpzMWrSSM0UT7YTIXIsh3sMtqgJrQYvBgAq0nP0W/urvD8LYa+j8Y3EoCTvzxJSc7hco+L7PwAIQk3A5B1+AvO7lte7nE+EZ2Jv+5FAIwFySRufKTCc7ce8SUKlRaA49/fj7ko/by9EipdACqvUCI6jMc3spOjzryTWM16Z1KpVHtfWHEtdDo5lQVvL2PF519hNl/YopjQvAl3jbyZO0cOIzamkQcivDSbzYahuAQfby+USqWnwxHqCPF9KFSWSBaFi0re9jKFKX/iE9EZQ+a/BDYZQKMej3o6rBon222Yi9JQqv1I/m4RWTvXoY31Rx3mD9hwtNiVCWl5K5GdJgKQ/vcnJH/xJgDebUNR+fqi1AagVHuj8WtEzNUzALDbLGTsXoqk1KJQ6Uo3rfO5X3QPZ8Jl0qdgtxpBkpCQQJKg9KdKF4RK6/gs28xF2MyFzn0gATKy3YZCqUbtHeY4t9VISV4i2G3IshXZbkO2W5FlG9ht+Mf2QZIct2nPHvwcc1E61pIcLMU5WEtysFtLAIjr+wK+kY5patJ2vkXeybLR3gqVF0qtP0q1DwFx1xHa6jbAkajqk7ei0PigVDs2hdoHpcYHpcbPmSBfaWnpmSx850NWrv6G/AJ9ucdc06sbd99+C8OHDSTAX8yrKdRt4vtQqCyRLAoXZcxPIvHHKUgqHbLVhELtTctbPqUk5wgpOxbQuOd0fMLbezrMy2IuysBYcBpT6WYsOI25MAXZbiX22ufwjexK5p+rydi9DHW4F7JdRqn2ReUTjFLti1Lji1doK/wiuwASNksJWTu+Qe0XSkinG1EotRQmHyL524U0u/NFApp19fRbvmw2SzHWkhxUXqEo1V4A5B7/nqKMXVhKk0qbKd95fEir24jseC8ABae3kPLXq+XWq/aJJOGm9wFHwp744xRUXkGodMGovUNQ6Ry3wVVeIeiCmtZIq7bJZGbjL7/x+dp1bPxla7n9F3U6LUNvvJ67br+Z/tdf47J6jCecOp3CnJff4PlnphEf19ijsQh1h/g+FCpLJIvCJZ3ZNhd9yjZU3mFYi7OIueZZJKWGlO3zadzrqdIkqfazlORhyj+JseA0wS2GoVA6vuCP//AQ5sIUl2MlhQq1TwTeoW2wlGRTfPYAtuISTMl6bIWOtaCVgVq0Mf4oNJe+7WctMGFMyserWTC6iGhHa6BXsMtPtVcwKl2w47k2wNGXsApk2dGHUSoduGHKz8BSmIvdanb0RVQoHK2FCgVqn2A0AY5WRpvRgKUoFxQKJEnpaL08d7xChcrb8Xsi2+2YclJKWyFLWyJtVudz35g2KNQ6AAqT9mDWn8VmNmAzGQAJhUKD3WZBFx6NjTzslmIMKccpTj6B3WpCtpmRJDVewS2x2yxoAsMxFP/mOLfVjjm9CBSSo/+gAsLa3onaOwRJpcZiP4XVnI/aKwRrkRGlxh9tQAy64Di0AY1R6XyQlFXvZ5mTm8dX6zby+dp17PhnT7nH1Ib+jSdOnuLRp57nzflzaN40/oqfX6ibxPehUFkiWRQuyZh/ytG6qFAh2y34x/Qh5uqnPR3WRcl2K4Vpf1OSl4gxL9HRn86Y69zfbODb6ALjAUj/dxnW4mw0ftHIdhuW4rMUZx/FWpLlPF5SqPAKbY1C7UtJ8mn0Bw8gW8xIKhW+LRPwio1BQnb0TeTc5Nx2kGVM2bnYjSWoQ72xGvOQ7a6DKaA00bPJyFY7ssWObJORZC2SrEZS6Qho2wnZbkG2W8jdvh27xYJss5232cFux7d9HEpfDbLdQvGxTKx5JeVeH7+W7QnrNRiVNgDD6ROkbvyo3ON04fF0fOILwDG10D+zrq3wmnd48ku8wuIAOPzuQ+gT/yn3uJghU4m+biwAGX98zul1r5cfY5PONB/7EtaSXIozjpK44sUKzx3YuyNWYyYAxQezsRsvvMYKjRfRA8biHROHxi+awsTD6I//g0rng1Ln69i0Pqi8A/CObI5P41Yur09MOs2qL9bz+dp1JJ0+U24cCc2bMGTg9VxzVTeu6tGFoMCACmMWBE8T34dCZdWKIY2LFy/m1VdfJSMjg44dO/LWW2/Ro0ePCo9fu3Yts2bN4tSpU7Ro0YJ58+YxZMiQKxhxw6ILjMc/5hr0Z34HJArT/sZmKXHefvSkc30LS3JPYDZkEN72rtI9Eqk7Fjj6+ZU6d+tSFxCPQu2NLMsY85NQ6QIx5iWiT/0LZJvzeLVPJH5RXfGN6op3WHuX92sx5JP83UKyd31H4cFD2AsVNLntGXyiXScpN+WmsWf+rUiSREzzqdgtJsz6DMwFZ9GGRhLYphsWYy5FSfs5+9sP5b9JhYTkX+h8as7PA1s5f+MpJGymQtA4bs0qvNQorXJpt0XHyjLn/jY0F5/m7P4VgKPVU+FV+r8C2XHtkBSAhN1exNkDn+EV3AKtfyzejVqVtjqWjp5Wlj1WqLXOUAISrkITGImkVKNQqZCU6tLHGvziytZn9m/enSYjnkVSqVCUHuPYHC2aGp/w0q0xTUY4lpiUrRbsttKfVjOy1Ux4n5HYzQVYSnJIL16FOT8Tm9GAzVSCUumN3WLGZjJQknuU/IxvHf82Z/RYzpY/LVJQ+34kjJkHQHFGIsnfv4k2uBH39mjEQ4NmcDyjiLU//83qb39xma7m2Ikkjp1IYuHiD5EkiXZtWnLNVd3o3asbV/fsSkR4aPn/xg2QY8UjK5KkqHIruiAIV5bHWxZXr17N2LFjWbp0KT179mThwoWsXbuWo0ePEh4efsHxf/75J9deey1z587lpptu4rPPPmPevHns3r2bdu3aXfJ84i+p6nGMnp3kGDQhy4S2Hkn24bU0uupJAuP6XrqCajr3hXLulrHdZqHg9OayFsP8JGRb2XrOLYd/jkrrGHiQuf8TFCodXoFN0QU1Q6ULxGrSY8j8l6L03RRl7MZqzHO+VlJq8Qlvj29kV3yjuqD1u/TI14ITOzn11VyM2cmgUBLV524aDXgApaYssTzz4xLSfv3ggtcGtu5DywlvAFCccYKjHzyKyjcItW8wKp8gVN6+KDRaFBoV/i27Oga/KNSYctIdg2G03o6WMJ0vCrUXCqWmdPoblWMqnPNuh9qtRqzGfKymAmzGfOdjx898lzKbSc9/B/Cco/YOQxfUHK/gFngFN0cX1Nw5uKa2k+129Ge2Ycjaj7konZKsJMx5mY5WWZuMd0g7vIJbYzXko/TRUmLaiy4gHmuBlew/yl+mURsSQ3L7R/h87To2/LyFG2Jl8o0yeUaZvBLHY8t5K0C2aBZP79Lk8ZqrurltdPWe/Ye4fsidbP5hFZ3a1+wqQXabBXNROubCFEz6FMyGDGSbGdnmaPm2l/4899ylzKX8vNZfSeH87JZt6kuWgQSyvbRFv/TnueeyXPrYVjrd1Pn77EgKFUqtH0qNP0qNX+ljP1QaP8fALGeZP0qNj3PAV30ivg+FyvJ4stizZ0+6d+/O22+/DYDdbicmJoYpU6YwY8aMC44fNWoUBoOB7777zll21VVX0alTJ5YuXXrJ84lfjuo7s30++uStBLe4iaBmQzl7cCXhbUejC7j4/IPns1mKsRRnYzPlo9IFofV3vLYk9zi5JzZgMxe6bqZCNL6RNB+8pPT1JRz56vayCiUFWv9YZ4uhT2Rn7JZirMXZWEqysRRnYynJcT63luRxfiKk9Y8pTQ674h3WtloDJuwWE2mbPiLtt+XINivaoGjib5tBYMurAZBtVk6tW0DBse0EtOyNT2RTVL7B6EIa4R3Vosrnq2nnTw1kKc6iJO8ExtwTlOQdx1qSe8Hxap9IZ/LoFdQCXXDzOjNtjt1mwWLIwFyYhtonwtk1IfvIl2Tuddyal6127CVW7CYrdrMdpSIAlTIYY24qmoBwEibMReMbTXZGGicX3nrBOQpNjuTx6Z+NZBocn70bmijxUkkofQKJT2hD205d6dbrGlq2bl2tPo9Z2bl8tW4Dt908mLDQ4OpfkFKyLGMz6TEVnsGsT8V0LjEsTMFsyHS2VFfX+YmfLNsd/V/tVpeW/VpFUjgGs51LKLX+KHWBjj7H535qA0sfB6JQ+9T6uTlBfB8KlefRZNFsNuPt7c0XX3zB8OHDneXjxo0jPz+fb7/99oLXxMbGMn36dB577DFn2Zw5c/jmm2/Yu3fvBcebTCZMprKWJ71eT0xMDKlp6eKXo4rMhamc/Hk6CpWWZgPfRvmfFiW71YzVmINSG+i8ZZuX9AtFaTtLE7Uc7Jay235BTQcR0ckxQrYwfSep28sZISsp0fhGEdvnWWxGPRaTntxj36BQeSNJSux2M1ZjHtaSHGymS69eoVB74x3aDp/ITvhGdHROJeMOxrOnOb3+dQpPOz6HQe1uIHbIZNS+IW47h6dZjbmU5J3ElJdISelmNxdecJzatxFegU1Q+4aj1AY4vkQ1gah0ASi1ASjU3rX+y9RmKsBYcAaTPrl0O4NZn4JvZFeie0wFoDj7GMlbn3UMBNJGYE7Px262YDMZsRlNWIwWFDZHv9Fd+GBXSEhAW3sxXlyYcBVbZP4t9kEZEoRC5U2gEvyVMiqfUDRBUfhGNCMkphURUY3w8fa67Gt4ro+uIxlMw1x4BlNhGpaiNJff1fNJSi1qn/DSEeqhqHSBSAoNICEpFCi1/uj8Y5GUauw2M8a8RGe3Bun86ZxkO0FN+jvrNRelIyk1KFQ+gAx2a+m0ThVsttKWSUlytPpJCkf9kqLseWmXCsdtbsnlGNluxWYqdE43ZTUXYbcUupTZzIVYTUXYLUUudzAuRVKoUWj8Uap8kRReKCQtyCqwKcAOCpUWhVqHQu2FUuOFonRTarxRan1RarwdU0tpvVGotY6uGTXw+6LX62kUHSWSReGSPNpnMTs7G5vNRkREhEt5REQER44cKfc1GRkZ5R6fkVH+snNz587l+eefv6B86KiHUao8O91F3VR6e3XZ1Gq+/vwWp62lW3n7zpcLi6ZXse6LOVC6fVrJ46uqiePHv0nwyeM1dI7apLzrnle61TcSsBsYf17Zufd/7v2qAN/SrZpOApw/SCezdNtT/Tqr7GK/Tzml2/HLPEdN/Q66m5LK///lnJLSrfayWevWspaC59SKAS41aebMmUyfXpZonGtZ/H71EvGXVDWYC9M4+fM0yuvTJil1KNTe+IS1Q+UViM1UiLk4C5tJj2wzY7OUIFsN5Y4GvhiF2tvRb0jrj0rjj1Lnj9orFJVXsHO1EMeKIZ4fcHOO1ZBH8obF5O77GQBtcCNMuakEtb0Br7BYxxJ/FjN2ixG7xYTdanZMH2MxOZ5bjI4yi+M4ZFvpknwKx9Q45waZnGs1OW+fJClBeW5f6SAUlRaFRodSrXX0b9Sca9nQolR7IZ17rtI5jtPoSls/tI5+qucmA4fSyb5x5E0urUWOfTJ2LIYcTIVnsNtLsFv02IwFpX0kCxx9JE36qt9ylJSOGJVejjjVXihUjk15blJztQ5J6Y1S64fWNwqNbyRKXXCNt2LKdisWQyamwlRk2ea49pIa36iyaaWKMv6l7HopKDEbOX78FIeOnODXv5L4c9chrGYTXZrriA5T46dT0MQPInUyPmrwkqDYYEWDjL9O4rBeovu1jn7d1gIjxqTyW9ZtkkRAx7L+30V7Mst2KiTsgFWWsFhlTOF+BARrsNhkFFkGlEYLMiDLEpn5VnKL7NhkyEZJfII/VpuMzmIlyGbGDthlyCu0cyTVjNUORrtE4wQ/7LKjz2i0woZdBqssY7PDz3sMFJuhyCJz3y1hhAWpCPRR4uulcPk3e/y9dHafcAxWe+r2UAZ3L39C9LVbC3jvh1x81HB9Rx8eHXlhv3eAgkIL331/Fp0K/L2UDBha8UTwxUdynKPrtTH+KLxVYMf5kUcCCQlzVjHWXEdyqAr2QhPp42hRlShtzXQcbrcqseo1YLcBZrTlhwiA4XAOssUxw4JXiyCwgzXbTsdpF951qw5Hy+I3bqlLqN88miyGhoaiVCrJzMx0Kc/MzCQysvxf3sjIyCodr9Vq0Wq1F5T7+njj61M3+lXVKj7NMTTviz75t3J2GsFuxJK5lfP/Xj03zlEFSBoVSk2Qo/O4LgCV1nFbUqUtTQZdnjt+1sl1iH28CRz3MvnHbubUV3Mx5abgpQTjkV8xlt9ofgFF6VYV51aDrjUkCbVvMGr/MDT+Yfj6R6IOaIfaPxSlty8KjQaFRgWS1dFP0pTnGGhjzMdmNmC3ljg2Swl2azGy3QA2g2MRHZPjvdpKtwpDUGrR+Eah9YtG4xeNxrcRGr9otH7RKLWB7ksk/fwhsuI+qL7Ners8l2WZRrFtuKrLSe4achJjXmuMJYWYzVZMZgsmsxmTyYzJZMFoMqM3mTGazBiNJk6bzEjB8PeRIpRKCT/JTqi/Fj+thFYpIdtlsMvIdhlJKaFRyaTnWTmdbqK5JCPZQSnJaM5P/DXwwCcZnMh13B5/6QYtvWLKfvf8A4AAx/HL9xhZ+Kuj+8HQFioev1rrrCcmADoEOH7rj+XYeGj1WQCCdPDlKB+Xa3BVn7I+wq9tOovRBhqlxOj2akK9Jawy2JF4sqOMtZ0WmwwKLzMFWcXodEqUFhuSxYZC4UjIRsTZuW20449GyVuB2mB0XmvnL4YsE2y1c2dbpTNmdYkJSSGBwjGHp/OxJJFntqI32CixyDRtpsA3oPw7Uj//a2Ptb8XoTTL9uit4rHn5jREHThm4d8ExAAJ9FSx6OJpik51ik50Sk0yJyY6h9PGKXwooNskoFdCzlRWtWsnxVCuvdtnGzUMGlFt/VdhtVfvDXWi4asUAlx49evDWW28BjgEusbGxTJ48ucIBLsXFxaxfv95ZdvXVV9OhQwcxwOUKMRelc2rzM9htJkfSd27Tlo4kdI4m9C1tESw7RqHS1fq+au5mtxg5u+MbLEU5KNSlS/upHS1951rvHJvuPz+1SKXPJUlRur60zTEgwGYD+dzk2HZku61sX+kk2dgdI0Flq8XRUmk2Yiv96XxuLilt3TRiN5dceIzFWDqS9Lw0tPR/Gc6y0snAz3GW2+1YDHnYzZW4FadQovYLQeMfisY/DLV/GCrvAJQaL5RaH+fIb4Vag6RUgkqBpJAcXeEUsqPl2plUlmA15mEuTMNclHbRARkKlZcjgfRrhNb3XDIZ5Ry4oFDpLuvf3nlN7FZM+hSM+Scx5p10/MxPKl2a0b0MFg05Bh2ZehWpuXAq08bJTBN5BSUUGYoxGIopLDJgs9lQSKBROjalBHpT2axM4b5Kgny06HQavHUadBo1Oq0GL60ak9Ibk9IHP52aKJ2JcFURGiyosaDFikayopFsSLKMSVagk6z4KC34qayoJBnFFfhfQIkVkouUlFgcn8m2IXasdrDYZEw2MFllii0yxRZYsddMsQVKrDJdo5SYbDL5JWCwyI7N7HisUinQaRVoVBJ2WcbuGEiPLMsUldgpNjkunloFaqWE3fFrgM0uIzvyd7dY9dFbDBvS/9IHXoL4PhQqy+NNNtOnT2fcuHF069aNHj16sHDhQgwGAxMmTABg7NixNGrUiLlz5wLw6KOP0rdvX15//XWGDh3KqlWr+Oeff3jvvfc8+TYaFI1vFI2uepK0v98kuvuj+ITV7FQddZ1CrcOncWtOrnmepnfMwS++Y7XqkVBANVYh8TSb0YBZn4VZn42lMBuLPqv0eRYWfbbjcUEWloKzWArOYqjGORzJtzfKc9MJefujCYzEK7Ar/rFhKHVaUMnYJSPWkixHElmYhqU4q3TS9sTy61V5odIFojxvpGvZCNiyx+cP6rJZijHmJ5Umho6fpoLTyPYL+4epfSLRBTV1TO8U2ASlxg+Z85Jw5NL/7KW5eul0MOByTFZWNiu//ImxEx6hbZOEC87zX7IsYzZbKCwyYDAUY7aY0SoVqGUzKnsJSmsxsrEQqyEfiyEfa3F+6eM8rIZ8rIYCLIZkZGvlB32cI6m0qHwCUHn5o/L2dwzmUGuR1JqyP6TU2rJBKQDYsdscfxB5RTRFGxSFQq3FkHKIwtP7HCsJ2WzYraV/6JhLiGzWjetudvQZLjy1h0Pv3IdGCajPu38MoFRz3awvKCoyUFhkQPfjDBSW8j+F3xW142CBlpJiIwNC0mnjp8culyaFpf8cduCfHB9+SffFbrfTzNfITY0LsTvm3ccul/275Rsl3tytwGp1vLe51wGyjEKSkSht6JQkJAlmbTKSWuj4l1cqxbyUwpXl8W+eUaNGkZWVxezZs8nIyKBTp05s3LjROYglOTkZhaLsZtzVV1/NZ599xrPPPsszzzxDixYt+Oabbyo1x6LgPnZLMRZjToUjJgVXVmMRZn0WVmORp0O54pQ6H7x0PniFx1d4jCzL2Eqv0blk0lZSiM1kwGYqLt0M2E0lzsc2UzH28x9b8rAaLj2oRuUTiCYwEm1gJD4BrVB6eyGplaCyIVOC1ZqPrXQOSptJj7koHYrSL1mvpNSi1PiUO72QpFChC2yGLqgJusCmpVM9NUGp8SmnpqpLKzzG3/9+yMhbsilSWR3XxFjkmJjcWITNVIStxIDNVITVpdzx01pShN1UxTRdUqDyDUblHYDaO+C8BDAQpbc/au8AlN6O52qfAJRe/qh9ApxLQrqDX3xHIq+5qxLHdaL7y9uxm0scremlm9VoQLYYCUxo5jz2jOEOR3J8/nUqvVZPTXocv7j2ACSumk327vIn0n/gzsG8VJqo5uz7hROfXniXDEATFMXjKx13yWSblb9nXkVZguxq6w+fogppgtVmJVC0AgpXmMdvQ19potldEOofWZaRrSZnYmkpysNckIk5LwNTfjrm/AxMeRmY8zOwFl9iiiWF0jHAR106YEblWFFGUipK+7IByMiSHWQLsmzFLpuQ7WbHeAaVFrVPGBrfSMfmF4XGN6J0UnUluKx8c95qOAoldouxNEkpwlZSWPa4dLOWFLokMNbS42Tb5Y9qdSRzgah8Ah0JoG9Q6ePAsnKfQNTejp9Kna9zHfKGyGY2IltNrl1BSruBKHW+qH0CAbCWFGLKTXUsAVo6Kbhjah8JhUqLd1RzwPEZNp49VTYVkKMjpnO9drVvMAo3z+Ahvg+FyhLJoiAIDYrNVIw5PxNTviN5NOVnYM5LL32eiVmfhWw1ezrMSpMUyrK1rXW+KJ1rXTtW91Fqzy9zrH+t9PJ1rv7jKPNGqoNdHITLI74PhcoS/3cQqqUg+XdSts+jca+nCYjt4+lwar3svT+TuHImzUbPJbTj5Y9iFKpPqfXGK6IJXhFNKjxGtttKpy0yOQcD2S0XDhBy7j9vABF2W+mk0aU/7bbSx2XPsducA5HKjrOiUOlQevmWJXGlm8rLr8LnCrWW/YeOMuS28fzw1TzatG11Ba+mIAgNgUgWhWrR+sfgG9XNuVyfcHHe4U0IaNUb7/CKExSh9pAUytLBMnVjeq2IsFAen3o/EWGhng5FEIR6SNyGFgRBEIQGSHwfCpXVcHsnC5fFXJxD9tFvMBfneDqUOsFckEX67ysxF2R5OhShHiosMrB1298UFlVn4iFBEISLE8miUC3FZ/eRued9is/u83QodYI+8R+S17+BPvEfT4ci1EMnTp5i8G3jOHHylKdDEQShHhK3oYVqsZqLKMk9gVdwc1QaX0+HU+tZi/UYUo/g06gVKm/xuRPcy2g0kZqeQaOoSHS6C5c3FYTyiO9DobJEsigIgiAIDZD4PhQqS9yGFqqlOOcIJzZOoTjniKdDqRMKk/ez7427KEze7+lQhHooJTWdJ555iZTUS680IwiCUFUiWRSqxWoswFyYgtV4idUwBAAsRXkYs05jKbr0cnSCUFWFRQa2/ikGuAiCUDPEbWhBEARBaIDE96FQWaJlURAEQRAEQahQg1vB5VxDql6v93AkdVtByl+k7XiD6J7TCGh8lafDqfVyD27h5OrnaDrqOYLb9vV0OEI9c+jICUZPnMrKDxbRplVzT4cj1BHnvgcb2A1GoRoa3G3olJQUYmLEEnWCIAiCAHDmzBkaN27s6TCEWqzBJYt2u520tDT8/PyQJMlZrtfriYmJ4cyZM6LvRiWI61U14npVjbheVSOuV9WI6+UgyzKFhYVER0ejUIheaULFGtxtaIVCcdG/oPz9/Rv0/zyqSlyvqhHXq2rE9aoacb2qRlwvCAgI8HQIQh0g/pQQBEEQBEEQKiSSRUEQBEEQBKFCIlkspdVqmTNnDlqtWFe1MsT1qhpxvapGXK+qEderasT1EoSqaXADXARBEARBEITKEy2LgiAIgiAIQoVEsigIgiAIgiBUSCSLgiAIgiAIQoVEsigIgiAIgiBUSCSLwOLFi4mPj0en09GzZ0/+/vtvT4dUKz333HNIkuSytWrVytNh1Spbt25l2LBhREdHI0kS33zzjct+WZaZPXs2UVFReHl50b9/f44fP+6ZYGuBS12v8ePHX/CZGzRokGeC9bC5c+fSvXt3/Pz8CA8PZ/jw4Rw9etTlGKPRyKRJkwgJCcHX15cRI0aQmZnpoYg9qzLX67rrrrvg8/XQQw95KGJBqL0afLK4evVqpk+fzpw5c9i9ezcdO3Zk4MCBnD171tOh1Upt27YlPT3duf3xxx+eDqlWMRgMdOzYkcWLF5e7f/78+SxatIilS5eyY8cOfHx8GDhwIEaj8QpHWjtc6noBDBo0yOUz9/nnn1/BCGuPLVu2MGnSJP766y9+/vlnLBYLN954IwaDwXnMtGnTWL9+PWvXrmXLli2kpaVx2223eTBqz6nM9QK4//77XT5f8+fP91DEglCLyQ1cjx495EmTJjmf22w2OTo6Wp47d64Ho6qd5syZI3fs2NHTYdQZgPz11187n9vtdjkyMlJ+9dVXnWX5+fmyVquVP//8cw9EWLv893rJsiyPGzdOvuWWWzwST2139uxZGZC3bNkiy7Ljs6RWq+W1a9c6jzl8+LAMyNu3b/dUmLXGf6+XLMty37595UcffdRzQQlCHdGgWxbNZjO7du2if//+zjKFQkH//v3Zvn27ByOrvY4fP050dDRNmzZl9OjRJCcnezqkOiMpKYmMjAyXz1tAQAA9e/YUn7eL+O233wgPD6dly5Y8/PDD5OTkeDqkWqGgoACA4OBgAHbt2oXFYnH5fLVq1YrY2Fjx+eLC63XOypUrCQ0NpV27dsycOZPi4mJPhCcItZrK0wF4UnZ2NjabjYiICJfyiIgIjhw54qGoaq+ePXuyfPlyWrZsSXp6Os8//zx9+vThwIED+Pn5eTq8Wi8jIwOg3M/buX2Cq0GDBnHbbbfRpEkTEhMTeeaZZxg8eDDbt29HqVR6OjyPsdvtPPbYY/Tu3Zt27doBjs+XRqMhMDDQ5Vjx+Sr/egHcfffdxMXFER0dzb59+3j66ac5evQoX331lQejFYTap0Eni0LVDB482Pm4Q4cO9OzZk7i4ONasWcPEiRM9GJlQX915553Ox+3bt6dDhw40a9aM3377jX79+nkwMs+aNGkSBw4cEH2GK6mi6/XAAw84H7dv356oqCj69etHYmIizZo1u9JhCkKt1aBvQ4eGhqJUKi8YLZiZmUlkZKSHoqo7AgMDSUhI4MSJE54OpU4495kSn7fqa9q0KaGhoQ36Mzd58mS+++47Nm/eTOPGjZ3lkZGRmM1m8vPzXY5v6J+viq5XeXr27AnQoD9fglCeBp0sajQaunbtyq+//uoss9vt/Prrr/Tq1cuDkdUNRUVFJCYmEhUV5elQ6oQmTZoQGRnp8nnT6/Xs2LFDfN4qKSUlhZycnAb5mZNlmcmTJ/P111+zadMmmjRp4rK/a9euqNVql8/X0aNHSU5ObpCfr0tdr/Ls2bMHoEF+vgThYhr8bejp06czbtw4unXrRo8ePVi4cCEGg4EJEyZ4OrRa54knnmDYsGHExcWRlpbGnDlzUCqV3HXXXZ4OrdYoKipyaZVISkpiz549BAcHExsby2OPPcb//vc/WrRoQZMmTZg1axbR0dEMHz7cc0F70MWuV3BwMM8//zwjRowgMjKSxMREnnrqKZo3b87AgQM9GLVnTJo0ic8++4xvv/0WPz8/Zz/EgIAAvLy8CAgIYOLEiUyfPp3g4GD8/f2ZMmUKvXr14qqrrvJw9Ffepa5XYmIin332GUOGDCEkJIR9+/Yxbdo0rr32Wjp06ODh6AWhlvH0cOza4K233pJjY2NljUYj9+jRQ/7rr788HVKtNGrUKDkqKkrWaDRyo0aN5FGjRsknTpzwdFi1yubNm2Xggm3cuHGyLDumz5k1a5YcEREha7VauV+/fvLRo0c9G7QHXex6FRcXyzfeeKMcFhYmq9VqOS4uTr7//vvljIwMT4ftEeVdJ0D+6KOPnMeUlJTIjzzyiBwUFCR7e3vLt956q5yenu65oD3oUtcrOTlZvvbaa+Xg4GBZq9XKzZs3l5988km5oKDAs4ELQi0kybIsX8nkVBAEQRAEQag7GnSfRUEQBEEQBOHiRLIoCIIgCIIgVEgki4IgCIIgCEKFRLIoCIIgCIIgVEgki4IgCIIgCEKFRLIoCIIgCIIgVEgki4IgCIIgCEKFRLIoCIIgCIIgVEgki4JQT5w6dQpJkpzr29Z1y5cvJzAw0NNhXOC3335DkiTy8/M9HYogCMIV0eDXhhaEmjB+/Hjy8/P55ptvrtg5Y2JiSE9PJzQ09IqdsyG6+uqrSU9PJyAgwNOhCIIgXBEiWRSEekKpVBIZGenpMOo9jUYjrrMgCA2KuA0tCB6wYMEC2rdvj4+PDzExMTzyyCMUFRW5HLNs2TJiYmLw9vbm1ltvZcGCBRe9Lfvf29Dnbpf++uuvdOvWDW9vb66++mqOHj16yTpWrVrF1VdfjU6no127dmzZssV5jM1mY+LEiTRp0gQvLy9atmzJm2++6VLP+PHjGT58OK+99hpRUVGEhIQwadIkLBaL8xiTycQTTzxBo0aN8PHxoWfPnvz222+VvoZms5nJkycTFRWFTqcjLi6OuXPnOvfn5+dz3333ERYWhr+/PzfccAN79+517t+7dy/XX389fn5++Pv707VrV/755x8ATp8+zbBhwwgKCsLHx4e2bdvyww8/uFzX829Df/nll7Rt2xatVkt8fDyvv/66S6zx8fG8/PLL3Hvvvfj5+REbG8t7771X6fciCILgSSJZFAQPUCgULFq0iIMHD/Lxxx+zadMmnnrqKef+bdu28dBDD/Hoo4+yZ88eBgwYwEsvvVStc/3f//0fr7/+Ov/88w8qlYp77733kq958sknefzxx/n333/p1asXw4YNIycnBwC73U7jxo1Zu3Ythw4dYvbs2TzzzDOsWbPGpY7NmzeTmJjI5s2b+fjjj1m+fDnLly937p88eTLbt29n1apV7Nu3j9tvv51BgwZx/PjxSr2vRYsWsW7dOtasWcPRo0dZuXIl8fHxzv233347Z8+eZcOGDezatYsuXbrQr18/cnNzARg9ejSNGzdm586d7Nq1ixkzZqBWqwGYNGkSJpOJrVu3sn//fubNm4evr2+5cezatYs77riDO++8k/379/Pcc88xa9Ysl/cK8Prrr9OtWzf+/fdfHnnkER5++GFn4n6p9yIIguBRsiAIbjdu3Dj5lltuqfTxa9eulUNCQpzPR40aJQ8dOtTlmNGjR8sBAQEV1pGUlCQD8r///ivLsixv3rxZBuRffvnFecz3338vA3JJSclF63jllVecZRaLRW7cuLE8b968Cs89adIkecSIEc7n48aNk+Pi4mSr1eosu/322+VRo0bJsizLp0+flpVKpZyamupST79+/eSZM2fKsizLH3300UXf75QpU+QbbrhBttvtF+z7/fffZX9/f9loNLqUN2vWTH733XdlWZZlPz8/efny5eXW3b59e/m5554rd9+565qXlyfLsizffffd8oABA1yOefLJJ+U2bdo4n8fFxcn33HOP87ndbpfDw8PlJUuWXPK9CIIgeJpoWRQED/jll1/o168fjRo1ws/PjzFjxpCTk0NxcTEAR48epUePHi6v+e/zyurQoYPzcVRUFABnz5696Gt69erlfKxSqejWrRuHDx92li1evJiuXbsSFhaGr68v7733HsnJyS51tG3bFqVS6XLuc+fdv38/NpuNhIQEfH19nduWLVtITEys1PsaP348e/bsoWXLlkydOpWffvrJuW/v3r0UFRUREhLiUn9SUpKz/unTp3PffffRv39/XnnlFZfzTp06lf/973/07t2bOXPmsG/fvgrjOHz4ML1793Yp6927N8ePH8dmsznLzv93kCSJyMhI5/W42HsRBEHwNJEsCsIVdurUKW666SY6dOjAl19+ya5du1i8eDHg6LvmbudurYIjSQHHreTqWrVqFU888QQTJ07kp59+Ys+ePUyYMOGC2M8/77lznztvUVERSqWSXbt2sWfPHud2+PDhC/o/VqRLly4kJSXx4osvUlJSwh133MHIkSOd9UdFRbnUvWfPHo4ePcqTTz4JwHPPPcfBgwcZOnQomzZtok2bNnz99dcA3HfffZw8eZIxY8awf/9+unXrxltvvVXta3ap63Gx9yIIguBpYjS0IFxhu3btwm638/rrr6NQOP5e+29/v5YtW7Jz506Xsv8+r0l//fUX1157LQBWq5Vdu3YxefJkwNGf8uqrr+aRRx5xHl/Z1sBzOnfujM1m4+zZs/Tp06facfr7+zNq1ChGjRrFyJEjGTRoELm5uXTp0oWMjAxUKtVF+/4lJCSQkJDAtGnTuOuuu/joo4+49dZbAcdURA899BAPPfQQM2fOZNmyZUyZMuWCOlq3bs22bdtcyrZt20ZCQoJLy2p130twcHCl6xAEQagJIlkUhBpSUFBwwQTZISEhNG/eHIvFwltvvcWwYcPYtm0bS5cudTluypQpXHvttSxYsIBhw4axadMmNmzY4GwZrGmLFy+mRYsWtG7dmjfeeIO8vDznwJgWLVqwYsUKfvzxR5o0acInn3zCzp07adKkSaXrT0hIYPTo0YwdO5bXX3+dzp07k5WVxa+//kqHDh0YOnToJetYsGABUVFRdO7cGYVCwdq1a4mMjCQwMJD+/fvTq1cvhg8fzvz580lISCAtLY3vv/+eW2+9lbZt2/Lkk08ycuRImjRpQkpKCjt37mTEiBEAPPbYYwwePJiEhATy8vLYvHkzrVu3LjeOxx9/nO7du/Piiy8yatQotm/fzttvv80777xT6etxsfciCILgaeI2tCDUkN9++43OnTu7bM8//zwdO3ZkwYIFzJs3j3bt2rFy5coLpknp3bs3S5cuZcGCBXTs2JGNGzcybdo0dDrdFYn9lVde4ZVXXqFjx4788ccfrFu3zjnZ94MPPshtt93GqFGj6NmzJzk5OS6tjJX10UcfMXbsWB5//HFatmzJ8OHD2blzJ7GxsZV6vZ+fH/Pnz6dbt250796dU6dO8cMPP6BQKJAkiR9++IFrr72WCRMmkJCQwJ133snp06eJiIhAqVSSk5PD2LFjSUhI4I477mDw4ME8//zzgGN6oEmTJtG6dWsGDRpEQkJChclfly5dWLNmDatWraJdu3bMnj2bF154gfHjx1f6WlzsvQiCIHiaJMuy7OkgBEG4tPvvv58jR47w+++/19g5Tp06RZMmTfj333/p1KlTjZ1HEARBqDvEbWhBqKVee+01BgwYgI+PDxs2bODjjz+u0q1NQRAEQXAHkSwKQi31999/M3/+fAoLC2natCmLFi3ivvvu83RYgiAIQgMjbkMLgiAIgiAIFRK9pwVBEARBEIQKiWRREARBEARBqJBIFgVBEARBEIQKiWRREARBEARBqJBIFgVBEARBEIQKiWRREARBEARBqJBIFgVBEARBEIQKiWRREARBEARBqND/AwTO+DgU5FupAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Panel autocorrelation of all five labels against lag in panel sessions."
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ret_to_expiry: N=282,470, N_eff=22,897, ratio 0.0811 against 0.0500 for windows of 20 sessions overlapping fully; autocorrelation 0.915 at lag one, -0.009 at that lag\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_5d: N=283,065, N_eff=69,719, ratio 0.2463 against 0.2000 for windows of 5 sessions overlapping fully; autocorrelation 0.678 at lag one, -0.014 at that lag\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_10d: N=263,863, N_eff=39,747, ratio 0.1506 against 0.1000 for windows of 10 sessions overlapping fully; autocorrelation 0.760 at lag one, -0.012 at that lag\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_dh_5d: N=281,047, N_eff=69,392, ratio 0.2469 against 0.2000 for windows of 5 sessions overlapping fully; autocorrelation 0.736 at lag one, -0.008 at that lag\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_dh_10d: N=255,773, N_eff=39,084, ratio 0.1528 against 0.1000 for windows of 10 sessions overlapping fully; autocorrelation 0.837 at lag one, 0.008 at that lag\n"
+     ]
+    }
+   ],
+   "source": [
+    "max_lag = LONGEST_WINDOW + 4\n",
+    "acf = {\n",
+    "    name: panel_autocorrelation(dev[name], name, max_lag=max_lag, bar_col=\"_bar\")\n",
+    "    for name in LABEL_NAMES\n",
+    "}\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "lags = np.arange(1, max_lag + 1)\n",
+    "for name in LABEL_NAMES:\n",
+    "    window = PRIMARY_WINDOW if name == PRIMARY_LABEL else HORIZONS[name]\n",
+    "    ax.plot(lags, acf[name], label=name, **STYLES[name])\n",
+    "    ax.axvline(window, color=STYLES[name][\"color\"], linestyle=\":\", lw=1.0)\n",
+    "ax.axhline(0, color=COLORS[\"neutral\"], lw=0.8)\n",
+    "ax.set_xlabel(\"Lag in panel sessions\")\n",
+    "ax.set_ylabel(\"Panel autocorrelation\")\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Each label's overlap decays to zero at its own holding window\",\n",
+    "    subtitle=\"Dotted lines mark each holding window; what remains past one is not overlap\",\n",
+    ")\n",
+    "ax.legend(loc=\"upper right\", frameon=False, fontsize=7)\n",
+    "show_with_alt(fig, \"Panel autocorrelation of all five labels against lag in panel sessions.\")\n",
+    "\n",
+    "# A trade exposed for h sessions consumes the h returns realised over them, and the trade\n",
+    "# one session later shares h-1 of those, so average uniqueness converges to 1/h on a dense\n",
+    "# grid. The primary label is weighted by each trade's own window rather than by the median,\n",
+    "# because a median window prices the overlap of a trade none of these rows is.\n",
+    "for name in LABEL_NAMES:\n",
+    "    window = PRIMARY_WINDOW if name == PRIMARY_LABEL else HORIZONS[name]\n",
+    "    per_row = {\"horizon_col\": \"window\"} if name == PRIMARY_LABEL else {\"horizon\": window}\n",
+    "    n_rows, n_eff = effective_sample_size(dev[name], bar_col=\"_bar\", **per_row)\n",
+    "    print(\n",
+    "        f\"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against \"\n",
+    "        f\"{1 / window:.4f} for windows of {window} sessions overlapping fully; \"\n",
+    "        f\"autocorrelation {acf[name][0]:.3f} at lag one, {acf[name][window - 1]:.3f} at that lag\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eead1be9",
+   "metadata": {
+    "tags": [
+     "results"
+    ]
+   },
+   "source": [
+    "The primary label's 282,470 development rows carry 22,897 effective observations, a ratio\n",
+    "of 0.0811 against the 0.0500 a fully overlapped 20-session window implies, weighting each\n",
+    "trade by its own exposure rather than by the median. The gap is the panel's own sparsity\n",
+    "rather than a shorter window: a name quoted on half the sessions has fewer concurrent\n",
+    "trades open than a dense grid would give it, and the shorter labels sit above their own\n",
+    "reference values for the same reason - 0.2463 against 0.2000 at five sessions.\n",
+    "Autocorrelation falls from 0.915 at lag one to -0.009 at the median window, so a purge\n",
+    "shorter than the exposure would leave training and validation sharing an outcome. That gap\n",
+    "is set by the window itself, not by these counts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015a7285",
+   "metadata": {},
+   "source": [
+    "## G. Baseline floor\n",
+    "\n",
+    "One signal against the primary label on the sealed development window, with no feature\n",
+    "engineering: the variance risk premium the hypothesis names, computed as the difference\n",
+    "between the at-the-money implied volatility quoted on the signal date and the volatility\n",
+    "the underlying realised over the previous month. Realised volatility is measured on\n",
+    "split-adjusted closes within stable `sec_id` segments, so a corporate action resetting the\n",
+    "adjustment factor cannot masquerade as a market move. Measuring the floor before building\n",
+    "features is what makes a later improvement meaningful.\n",
+    "\n",
+    "The information coefficient is the cross-sectional rank correlation on each session,\n",
+    "averaged over sessions, which is the quantity a ranking model is scored on; pooling every\n",
+    "name-session instead mixes a cross-sectional claim with a time-series one. The library call\n",
+    "returns its series ordered by time, which the standard error depends on. The minimum\n",
+    "cross-section is half the median rather than a bare count, so it means the same thing on a\n",
+    "universe of another size. The standard error is HAC-adjusted, because the IC series\n",
+    "inherits the label's overlap and a naive statistic would treat a month of consecutive\n",
+    "sessions as a month of independent evidence; the bandwidth is set from the longest window\n",
+    "any trade runs for, so it covers every overlap the series carries rather than half of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "100600cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T07:13:05.297208Z",
+     "iopub.status.busy": "2026-07-31T07:13:05.297052Z",
+     "iopub.status.idle": "2026-07-31T07:13:05.609430Z",
+     "shell.execute_reply": "2026-07-31T07:13:05.609022Z"
     }
    },
    "outputs": [
@@ -655,140 +1136,145 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Primary label: ret_to_expiry\n",
-      "  Observations: 354,473\n",
-      "  Mean: -0.0242\n",
-      "  Std: 1.1524\n",
-      "  Hit rate (positive): 59.4%\n"
+      "Baseline: implied minus realised volatility against ret_to_expiry, 276,005 rows\n",
+      "  median cross-section 246 names, minimum 123\n",
+      "  sessions scored 968, mean IC -0.0100\n",
+      "  HAC t -1.06 on 23 Bartlett lags, naive t -3.21, p 0.291\n"
      ]
     }
    ],
    "source": [
-    "_all_labels = {**unhedged_labels, **dh_labels, **exec_labels, **htm_labels}\n",
-    "# The modelled label is the hold-to-expiry return (setup.yaml::labels.primary);\n",
-    "# the diagnostics below characterise it, not the horizon-based variants.\n",
-    "_primary_name = \"ret_to_expiry\"\n",
-    "primary = _all_labels[_primary_name]\n",
-    "y_col = _primary_name\n",
-    "\n",
-    "n_total = len(primary)\n",
-    "n_positive = primary.filter(pl.col(y_col) > 0).height\n",
-    "hit_rate = n_positive / n_total if n_total > 0 else 0\n",
-    "\n",
-    "print(f\"Primary label: {y_col}\")\n",
-    "print(f\"  Observations: {n_total:,}\")\n",
-    "print(f\"  Mean: {primary[y_col].mean():.4f}\")\n",
-    "print(f\"  Std: {primary[y_col].std():.4f}\")\n",
-    "print(f\"  Hit rate (positive): {hit_rate:.1%}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eead1be9",
-   "metadata": {
-   },
-   "source": [
-    "### Delta hedging narrows 10-day returns\n",
-    "\n",
-    "Hold-to-expiry outcomes retain a pronounced loss tail, while delta hedging\n",
-    "concentrates the 10-day distribution by removing directional P&L."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "100600cf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:52.066967Z",
-     "iopub.status.busy": "2026-07-21T06:54:52.066837Z",
-     "iopub.status.idle": "2026-07-21T06:54:52.121944Z",
-     "shell.execute_reply": "2026-07-21T06:54:52.120842Z"
-    },
-    "lines_to_next_cell": 0
-   },
-   "outputs": [],
-   "source": [
-    "fig = make_subplots(\n",
-    "    rows=1,\n",
-    "    cols=2,\n",
-    "    horizontal_spacing=0.13,\n",
-    "    subplot_titles=[\"Hold-to-Expiry (primary label)\", \"10-Day: hedged vs unhedged\"],\n",
+    "annualised_rv = pl.col(\"clean_log_return\").rolling_std(21).over([\"symbol\", \"sec_id\"]) * np.sqrt(252)\n",
+    "realised = (\n",
+    "    reconcile_underlying_log_returns(underlying)\n",
+    "    .sort([\"symbol\", \"sec_id\", \"timestamp\"])\n",
+    "    .with_columns(annualised_rv.alias(\"rv_21d\"))\n",
     ")\n",
-    "\n",
-    "htm_edges = np.arange(-3.0, 3.1, 0.1)\n",
-    "htm_counts, _ = np.histogram(primary[y_col].to_numpy(), bins=htm_edges)\n",
-    "htm_centers = (htm_edges[:-1] + htm_edges[1:]) / 2\n",
-    "fig.add_trace(\n",
-    "    go.Bar(\n",
-    "        x=htm_centers,\n",
-    "        y=htm_counts,\n",
-    "        width=0.1,\n",
-    "        marker_color=COLORS[\"blue\"],\n",
-    "        opacity=0.85,\n",
-    "        name=\"ret_to_expiry\",\n",
-    "    ),\n",
-    "    row=1,\n",
-    "    col=1,\n",
+    "baseline = (\n",
+    "    straddles.select([\"timestamp\", \"symbol\", \"iv_atm\"])\n",
+    "    .join(\n",
+    "        realised.select([\"timestamp\", \"symbol\", \"rv_21d\"]).drop_nulls(), on=[\"timestamp\", \"symbol\"]\n",
+    "    )\n",
+    "    .with_columns((pl.col(\"iv_atm\") - pl.col(\"rv_21d\")).alias(\"vrp_proxy\"))\n",
+    "    .join(\n",
+    "        dev[PRIMARY_LABEL].select([\"timestamp\", \"symbol\", PRIMARY_LABEL]),\n",
+    "        on=[\"timestamp\", \"symbol\"],\n",
+    "    )\n",
+    "    .drop_nulls([\"vrp_proxy\", PRIMARY_LABEL])\n",
     ")\n",
-    "_ = fig.add_vline(x=0, line_dash=\"dash\", line_color=COLORS[\"negative\"], row=1, col=1)"
+    "median_cross_section = int(baseline.group_by(\"timestamp\").len()[\"len\"].median())\n",
+    "min_obs = median_cross_section // 2\n",
+    "\n",
+    "ic = cross_sectional_ic_series(\n",
+    "    baseline,\n",
+    "    baseline,\n",
+    "    pred_col=\"vrp_proxy\",\n",
+    "    ret_col=PRIMARY_LABEL,\n",
+    "    date_col=\"timestamp\",\n",
+    "    entity_col=\"symbol\",\n",
+    "    min_obs=min_obs,\n",
+    ").sort(\"timestamp\")  # HAC autocovariances are meaningless over a permutation of time\n",
+    "stats = compute_ic_hac_stats(ic, ic_col=\"ic\", label_horizon=LONGEST_WINDOW)\n",
+    "\n",
+    "print(\n",
+    "    f\"Baseline: implied minus realised volatility against {PRIMARY_LABEL}, {baseline.height:,} rows\"\n",
+    ")\n",
+    "print(f\"  median cross-section {median_cross_section} names, minimum {min_obs}\")\n",
+    "print(f\"  sessions scored {ic.height:,}, mean IC {stats['mean_ic']:.4f}\")\n",
+    "print(\n",
+    "    f\"  HAC t {stats['t_stat']:.2f} on {stats['effective_lags']} Bartlett lags, \"\n",
+    "    f\"naive t {stats['naive_t_stat']:.2f}, p {stats['p_value']:.3g}\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ac4e4e61",
+   "metadata": {
+    "tags": [
+     "results"
+    ]
+   },
+   "source": [
+    "The variance risk premium earns a mean information coefficient of -0.0100 against the\n",
+    "hold-to-expiry label over 968 scored sessions on a cross-section of at least 123 names.\n",
+    "The sign is the opposite of what the hypothesis implies: names whose options are priced\n",
+    "furthest above their recent realised volatility are, if anything, the ones whose short\n",
+    "straddles pay least. Under the naive standard error that is a t-statistic of -3.21, which\n",
+    "the Newey-West rule on 23 Bartlett lags reduces to -1.06 with a p-value of 0.291 - the\n",
+    "whole apparent significance was the overlap being counted as evidence. The floor a feature\n",
+    "has to clear is a mean IC of -0.0100 the data cannot separate from zero."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c85b5b",
    "metadata": {},
    "source": [
-    "The 10-day panel overlays unhedged and held-contract delta-hedged outcomes\n",
-    "using identical bins and limits for a direct dispersion comparison."
+    "## H. Artifacts and the audit record\n",
+    "\n",
+    "Each label is written with a digest sidecar beside it, recording the content digest of the\n",
+    "values written, the row count, the key columns, the notebook that wrote it and the digests\n",
+    "of the artifacts it was built from. That last field is what ties a label to its data\n",
+    "vintage. `instrument_id` stays in the key alongside the name and the date because a symbol\n",
+    "can carry more than one option structure, and it is part of the identity stage 03 joins on.\n",
+    "\n",
+    "The folds that train models are derived per label by `case_studies/utils/cv_window.py`\n",
+    "from `config/setup.yaml` and the timeline of the label parquet written here, so which rows\n",
+    "land in these files is what sets where the fold boundaries fall."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "15c63a62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:52.123629Z",
-     "iopub.status.busy": "2026-07-21T06:54:52.123348Z",
-     "iopub.status.idle": "2026-07-21T06:54:52.142500Z",
-     "shell.execute_reply": "2026-07-21T06:54:52.141398Z"
-    },
-    "lines_to_next_cell": 0
+     "iopub.execute_input": "2026-07-31T07:13:05.610736Z",
+     "iopub.status.busy": "2026-07-31T07:13:05.610626Z",
+     "iopub.status.idle": "2026-07-31T07:13:05.813935Z",
+     "shell.execute_reply": "2026-07-31T07:13:05.813056Z"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ret_to_expiry.parquet: 354,473 rows, digest f1d926ba6f09f8c8\n",
+      "fwd_ret_5d.parquet: 352,179 rows, digest 07c644a8a105f5e0\n",
+      "fwd_ret_10d.parquet: 333,102 rows, digest 6414058873427591\n",
+      "fwd_ret_dh_5d.parquet: 349,934 rows, digest 89347540486c5062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_dh_10d.parquet: 323,847 rows, digest bbc38febd1f2e6f3\n"
+     ]
+    }
+   ],
    "source": [
-    "uh_10d = unhedged_labels[\"fwd_ret_10d\"][\"fwd_ret_10d\"]\n",
-    "dh_10d = dh_labels[\"fwd_ret_dh_10d\"][\"fwd_ret_dh_10d\"]\n",
-    "ten_day_edges = np.arange(-1.5, 1.55, 0.05)\n",
-    "uh_counts, _ = np.histogram(uh_10d.to_numpy(), bins=ten_day_edges)\n",
-    "dh_counts, _ = np.histogram(dh_10d.to_numpy(), bins=ten_day_edges)\n",
-    "ten_day_centers = (ten_day_edges[:-1] + ten_day_edges[1:]) / 2\n",
-    "fig.add_trace(\n",
-    "    go.Bar(\n",
-    "        x=ten_day_centers,\n",
-    "        y=uh_counts,\n",
-    "        width=0.05,\n",
-    "        opacity=0.55,\n",
-    "        marker_color=COLORS[\"amber\"],\n",
-    "        name=\"unhedged_10d\",\n",
-    "    ),\n",
-    "    row=1,\n",
-    "    col=2,\n",
-    ")\n",
-    "fig.add_trace(\n",
-    "    go.Bar(\n",
-    "        x=ten_day_centers,\n",
-    "        y=dh_counts,\n",
-    "        width=0.05,\n",
-    "        opacity=0.55,\n",
-    "        marker_color=COLORS[\"blue\"],\n",
-    "        name=\"dh_10d\",\n",
-    "    ),\n",
-    "    row=1,\n",
-    "    col=2,\n",
-    ")\n",
-    "_ = fig.add_vline(x=0, line_dash=\"dash\", line_color=COLORS[\"negative\"], row=1, col=2)"
+    "KEYS = [\"timestamp\", \"symbol\", \"instrument_id\"]\n",
+    "for name in LABEL_NAMES:\n",
+    "    extra = {\"market_data\": MARKET_DATA_DIGEST} if name == PRIMARY_LABEL else {}\n",
+    "    inputs = {\"contract_returns\": CONTRACT_DIGEST} | (\n",
+    "        {\"hedge_path\": HEDGE_DIGEST} if \"_dh_\" in name else extra\n",
+    "    )\n",
+    "    # The primary label carries its own settlement date: the notebooks that model it\n",
+    "    # derive each row's label endpoint from it rather than from a fixed horizon.\n",
+    "    columns = [name, \"dte_calendar\"] if name == PRIMARY_LABEL else [name]\n",
+    "    record = write_artifact(\n",
+    "        panel.drop_nulls(name).select(\n",
+    "            \"timestamp\", \"symbol\", pl.lit(INSTRUMENT_ID).alias(\"instrument_id\"), *columns\n",
+    "        ),\n",
+    "        LABELS_DIR / f\"{name}.parquet\",\n",
+    "        keys=KEYS,\n",
+    "        written_by=\"02_labels\",\n",
+    "        inputs=inputs,\n",
+    "    )\n",
+    "    print(f\"{name}.parquet: {record['n_rows']:,} rows, digest {record['digest']}\")"
    ]
   },
   {
@@ -796,339 +1282,23 @@
    "id": "576f4448",
    "metadata": {},
    "source": [
-    "Both panels focus on their central mass. The rendered note states the exact\n",
-    "displayed ranges so the omitted extreme tails remain explicit to readers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "5a54553a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:52.147026Z",
-     "iopub.status.busy": "2026-07-21T06:54:52.146885Z",
-     "iopub.status.idle": "2026-07-21T06:54:54.199808Z",
-     "shell.execute_reply": "2026-07-21T06:54:54.199441Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
-       "data": [
-        {
-         "marker": {
-          "color": "#0a1628"
-         },
-         "name": "ret_to_expiry",
-         "opacity": 0.85,
-         "type": "bar",
-         "width": 0.1,
-         "x": {
-          "bdata": "mpmZmZmZB8DMzMzMzMwGwAAAAAAAAAbAMjMzMzMzBcBmZmZmZmYEwJiZmZmZmQPAzMzMzMzMAsD+//////8BwDIzMzMzMwHAZGZmZmZmAMAvMzMzMzP/v5WZmZmZmf2/+///////+79hZmZmZmb6v8fMzMzMzPi/LTMzMzMz97+TmZmZmZn1v/n///////O/X2ZmZmZm8r/FzMzMzMzwv1ZmZmZmZu6/IjMzMzMz67/u///////nv7rMzMzMzOS/hpmZmZmZ4b+kzMzMzMzcvzxmZmZmZta/qP//////z7/YMjMzMzPDvyCYmZmZmam/IJuZmZmZqT+YMzMzMzPDPzQAAAAAANA/nGZmZmZm1j8EzczMzMzcP7aZmZmZmeE/6szMzMzM5D8eAAAAAADoP1IzMzMzM+s/hmZmZmZm7j/czMzMzMzwP3ZmZmZmZvI/EgAAAAAA9D+smZmZmZn1P0QzMzMzM/c/3szMzMzM+D96ZmZmZmb6PxQAAAAAAPw/rJmZmZmZ/T9GMzMzMzP/P3FmZmZmZgBAPjMzMzMzAUAKAAAAAAACQNfMzMzMzAJApZmZmZmZA0ByZmZmZmYEQD4zMzMzMwVACwAAAAAABkDZzMzMzMwGQKaZmZmZmQdA",
-          "dtype": "f8"
-         },
-         "xaxis": "x",
-         "y": {
-          "bdata": "MAExAYMBswH9AV4CnQIbA20D4APNBOYFogbmB3YJ6QpSDCIOyRCxE3sW2RmZHVsicSY6K38vtjRUOSo/m0M/R8RKNk9XUiJWTVbGWRVbZV0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "dtype": "i2"
-         },
-         "yaxis": "y"
-        },
-        {
-         "marker": {
-          "color": "#D4A84B"
-         },
-         "name": "unhedged_10d",
-         "opacity": 0.55,
-         "type": "bar",
-         "width": 0.05,
-         "x": {
-          "bdata": "mpmZmZmZ97/MzMzMzMz2vwAAAAAAAPa/MjMzMzMz9b9mZmZmZmb0v5iZmZmZmfO/zMzMzMzM8r/+///////xvzIzMzMzM/G/ZGZmZmZm8L8vMzMzMzPvv5WZmZmZme2/+///////679hZmZmZmbqv8fMzMzMzOi/LTMzMzMz57+TmZmZmZnlv/n//////+O/X2ZmZmZm4r/FzMzMzMzgv1ZmZmZmZt6/IjMzMzMz27/u///////Xv7rMzMzMzNS/hpmZmZmZ0b+kzMzMzMzMvzxmZmZmZsa/qP//////v7/YMjMzMzOzvyCYmZmZmZm/IJuZmZmZmT+YMzMzMzOzPzQAAAAAAMA/nGZmZmZmxj8EzczMzMzMP7aZmZmZmdE/6szMzMzM1D8eAAAAAADYP1IzMzMzM9s/hmZmZmZm3j/czMzMzMzgP3ZmZmZmZuI/EgAAAAAA5D+smZmZmZnlP0QzMzMzM+c/3szMzMzM6D96ZmZmZmbqPxQAAAAAAOw/rJmZmZmZ7T9GMzMzMzPvP3FmZmZmZvA/PjMzMzMz8T8KAAAAAADyP9fMzMzMzPI/pZmZmZmZ8z9yZmZmZmb0Pz4zMzMzM/U/CwAAAAAA9j/ZzMzMzMz2P6aZmZmZmfc/",
-          "dtype": "f8"
-         },
-         "xaxis": "x2",
-         "y": {
-          "bdata": "xwDdAAgBLgFmAYsBzgEUAlECuAIYA8UDqAQSBcAFtQbgB30Jzgp/DPYN6RAKE1IWWhpoHggjHSmIMB88PkQnU6tfW20iegl/snJMVBExZhmmCmoEOAE9AAsABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "dtype": "i2"
-         },
-         "yaxis": "y2"
-        },
-        {
-         "marker": {
-          "color": "#0a1628"
-         },
-         "name": "dh_10d",
-         "opacity": 0.55,
-         "type": "bar",
-         "width": 0.05,
-         "x": {
-          "bdata": "mpmZmZmZ97/MzMzMzMz2vwAAAAAAAPa/MjMzMzMz9b9mZmZmZmb0v5iZmZmZmfO/zMzMzMzM8r/+///////xvzIzMzMzM/G/ZGZmZmZm8L8vMzMzMzPvv5WZmZmZme2/+///////679hZmZmZmbqv8fMzMzMzOi/LTMzMzMz57+TmZmZmZnlv/n//////+O/X2ZmZmZm4r/FzMzMzMzgv1ZmZmZmZt6/IjMzMzMz27/u///////Xv7rMzMzMzNS/hpmZmZmZ0b+kzMzMzMzMvzxmZmZmZsa/qP//////v7/YMjMzMzOzvyCYmZmZmZm/IJuZmZmZmT+YMzMzMzOzPzQAAAAAAMA/nGZmZmZmxj8EzczMzMzMP7aZmZmZmdE/6szMzMzM1D8eAAAAAADYP1IzMzMzM9s/hmZmZmZm3j/czMzMzMzgP3ZmZmZmZuI/EgAAAAAA5D+smZmZmZnlP0QzMzMzM+c/3szMzMzM6D96ZmZmZmbqPxQAAAAAAOw/rJmZmZmZ7T9GMzMzMzPvP3FmZmZmZvA/PjMzMzMz8T8KAAAAAADyP9fMzMzMzPI/pZmZmZmZ8z9yZmZmZmb0Pz4zMzMzM/U/CwAAAAAA9j/ZzMzMzMz2P6aZmZmZmfc/",
-          "dtype": "f8"
-         },
-         "xaxis": "x2",
-         "y": {
-          "bdata": "MwAAAEAAAABEAAAAYAAAAGgAAABiAAAAdwAAAHcAAAClAAAAxgAAAOIAAAANAQAASQEAAJQBAAAyAgAAiwIAADYDAAAcBAAAzwQAAI0GAADNCAAARAsAAFkPAAClFQAAphwAALUmAABWNAAAp0cAAE1fAAAeegAAr5IAAO6hAABenAAAIYEAAENeAAAgOQAA+h0AAAoOAABiBgAAowIAAEYBAAB8AAAAOAAAABUAAAAaAAAADwAAAA0AAAAIAAAAAwAAAAIAAAAAAAAAAQAAAAAAAAABAAAAAQAAAAAAAAABAAAAAQAAAAAAAAAAAAAA",
-          "dtype": "i4"
-         },
-         "yaxis": "y2"
-        }
-       ],
-       "layout": {
-        "annotations": [
-         {
-          "font": {
-           "size": 16
-          },
-          "showarrow": false,
-          "text": "Hold-to-Expiry (primary label)",
-          "x": 0.2175,
-          "xanchor": "center",
-          "xref": "paper",
-          "y": 1.0,
-          "yanchor": "bottom",
-          "yref": "paper"
-         },
-         {
-          "font": {
-           "size": 16
-          },
-          "showarrow": false,
-          "text": "10-Day: hedged vs unhedged",
-          "x": 0.7825,
-          "xanchor": "center",
-          "xref": "paper",
-          "y": 1.0,
-          "yanchor": "bottom",
-          "yref": "paper"
-         },
-         {
-          "font": {
-           "color": "#334155",
-           "size": 11
-          },
-          "showarrow": false,
-          "text": "Displayed ranges truncate HTM outside [-3, 3] and 10-day returns outside [-1.5, 1.5].",
-          "x": 0.5,
-          "xref": "paper",
-          "y": -0.28,
-          "yref": "paper"
-         }
-        ],
-        "barmode": "overlay",
-        "height": 470,
-        "margin": {
-         "b": 105
-        },
-        "shapes": [
-         {
-          "line": {
-           "color": "#ef4444",
-           "dash": "dash"
-          },
-          "type": "line",
-          "x0": 0,
-          "x1": 0,
-          "xref": "x",
-          "y0": 0,
-          "y1": 1,
-          "yref": "y domain"
-         },
-         {
-          "line": {
-           "color": "#ef4444",
-           "dash": "dash"
-          },
-          "type": "line",
-          "x0": 0,
-          "x1": 0,
-          "xref": "x2",
-          "y0": 0,
-          "y1": 1,
-          "yref": "y2 domain"
-         }
-        ],
-        "template": {
-         "layout": {
-          "colorway": [
-           "#0a1628",
-           "#D4A84B",
-           "#1a2d4a",
-           "#C87533",
-           "#10b981",
-           "#ef4444"
-          ],
-          "font": {
-           "color": "#334155",
-           "family": "DM Sans, DejaVu Sans, sans-serif",
-           "size": 11
-          },
-          "hoverlabel": {
-           "bgcolor": "white",
-           "font": {
-            "family": "DM Sans, DejaVu Sans, sans-serif",
-            "size": 11
-           }
-          },
-          "legend": {
-           "bgcolor": "rgba(255,255,255,0.8)",
-           "bordercolor": "#e8e8e6",
-           "borderwidth": 1,
-           "font": {
-            "size": 10
-           }
-          },
-          "paper_bgcolor": "#FAFAF9",
-          "plot_bgcolor": "white",
-          "title": {
-           "font": {
-            "color": "#0a1628",
-            "size": 14
-           },
-           "x": 0.5,
-           "xanchor": "center"
-          },
-          "xaxis": {
-           "gridcolor": "#e8e8e6",
-           "gridwidth": 0.5,
-           "linecolor": "#e8e8e6",
-           "showgrid": true,
-           "tickfont": {
-            "size": 10
-           },
-           "title": {
-            "font": {
-             "size": 11
-            }
-           }
-          },
-          "yaxis": {
-           "gridcolor": "#e8e8e6",
-           "gridwidth": 0.5,
-           "linecolor": "#e8e8e6",
-           "showgrid": true,
-           "tickfont": {
-            "size": 10
-           },
-           "title": {
-            "font": {
-             "size": 11
-            }
-           }
-          }
-         }
-        },
-        "title": {
-         "text": "Delta hedging narrows 10-day returns while HTM retains a loss tail"
-        },
-        "xaxis": {
-         "anchor": "y",
-         "domain": [
-          0.0,
-          0.435
-         ],
-         "range": [
-          -3,
-          3
-         ],
-         "title": {
-          "text": "Return (fraction of entry premium)"
-         }
-        },
-        "xaxis2": {
-         "anchor": "y2",
-         "domain": [
-          0.565,
-          1.0
-         ],
-         "range": [
-          -1.5,
-          1.5
-         ],
-         "title": {
-          "text": "Return (fraction of entry premium)"
-         }
-        },
-        "yaxis": {
-         "anchor": "x",
-         "domain": [
-          0.0,
-          1.0
-         ],
-         "title": {
-          "text": "Count"
-         }
-        },
-        "yaxis2": {
-         "anchor": "x2",
-         "domain": [
-          0.0,
-          1.0
-         ],
-         "title": {
-          "text": "Count"
-         }
-        }
-       }
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAHWCAYAAACVPVriAAAQAElEQVR4AeydB2AURRfH/5eEUPVTuggCKqIC0qULKIiAIkgRpPfeewfpvffepIlSBGmiNKmGjiC9914SUr99k+zmcrkLl5By5a+83dmZNzNvfrM793Z2duPh7/8ihEIGPAd4DvAc4DnAc4DnAM8BngOueg54gP+RAAmQAAkAIAQSIAESIAFXJUCH11V7lu0iARIgARIgARIggZgQcME8dHhdsFPZJBIgARIgARIgARIggXACdHjDWTBEAiRgPwFqkgAJkAAJkIDTEKDD6zRdRUNJgARIgARIgAQcjwAtcgYCdHidoZdoIwmQAAmQAAmQAAmQQIwJ0OGNMTpmJAH7CVCTBEiABEiABEgg4QjQ4U049qyZBEiABEiABNyNANtLAglCgA5vgmBnpSRAAiRAAiRAAiRAAvFFgA5vfJFmPfYToCYJkAAJkAAJkAAJxCIBOryxCJNFkQAJkAAJkEBsEmBZJEACsUOADm/scGQpJEACJEACJEACJEACDkqADq+Ddoz9ZlGTBEiABEiABEiABEggKgJ0eKOiwzQSIAESIAHnIUBLSYAESMAGATq8NsAwmgRIgARIgARIgARIwDUIuJvD6xq9xlaQAAmQAAmQAAmQAAnYTYAOr92oqEgCJEACrkSAbSEBEiAB9yFAh9d9+potJQESIAESIAESIAG3JBClw+uWRNhoEiABEiABEiABEiABlyJAh9elupONIQESiCMCLJYESIAESMCJCdDhdeLOo+kkQAIkQAIkQAIkEL8EnLM2OrzO2W+0mgRIgARIgARIgARIwE4CdHjtBEU1EiAB+wlQkwRIgARIgAQciQAdXkfqDdpCAiRAAiRAAiTgSgTYFgchQIfXQTqCZpAACZAACZAACZAACcQNATq8ccOVpZKA/QSoSQIkQAIkQAIkEKcE6PDGKV4WTgIkQAIkQAIkYC8B6pFAXBGgwxtXZFkuCZAACZAACZAACZCAQxCgw+sQ3UAj7CdATRIgARIgARIgARKIHgE6vNHjRW0SIAESIAEScAwCtIIESMBuAnR47UZFRRIgARIgARIgARIgAWckQIfXGXvNfpupSQIkQAIkQAIkQAJuT4AOr9ufAgRAAiRAAu5AgG0kARJwZwJ0eN2599l2EiABEiABEiABEnADAnR4zTqZQRIgARIgARIgARIgAdcjQIfX9fqULSIBEiCBVyXA/CRAAiTgUgTo8LpUd7IxJEACJEACJEACJEAClgRi7vBalsRjEiABEiABEiABEiABEnBAAnR4HbBTHM2k+s27oOeAkbFu1p79PngjY274+b2I9bJbduiLDj0GRavc9z4piTXrt0YrD5Udj0DuohWw4pf18WqYu1ZWrU4rDBoxMcrm12/eGT36jzB03s9diteZQSP6gaMnTqlx8+69B9HPHIc54up3Ig5NhiXLYydPK7b37j+My2pZdgIRoMObQODjutr8Jb5RF644lJk/Lo7Cn3+HOk07qgv8Veuu3aQDev84+lWLcbj8hT/Ni1Qp33A4u5zdoB2796tzL8en5dQ5ac0ZDQkJwYCh45GnWEW881ExVK7VHJevXHf2pkey31WvnUgNNYv48IP3kDVzJrOYVw/K+DZi3IxIBY2ZNAcfF/xSxZf9tp4632QMtCZFy1RVelKWpC9ZsUYdm2++qtJAlTF+6jzz6FgJHzpyQpX98NHjaJWXPFlSlCpRGIkSeUUrnysrk6VD9a7DGkOH12G75tUNq1uzCtatmI1Zk4ehQe1q8PTwwOcVa2PqrMWvXrgLlrBk9ngUL1LABVuWsE26/+AR3svyDgb16WjTkBHjpmO5Nis7c8JQ+Oz6DRnSp8M33zfBixf+NvMwwTkI9OzcCs0b/RDvxo4a1EONfzIGThn7o6p/7LDeRtykUQNUnGyyZM4Y6anAyVNnceT4v0iTOqWoOIy8lzUzVi+dgf+9/prD2OSshpCls/ZczOymwxszbk6RK+Pbb6FE0YL48vMSaNH4ByyYMQaD+3bGwOETcOq/80YbJCyzvx/mK4NseUpDlgPYmnVo22UA1m/8E1NmLlKzEzIzcvrMBTx99hyDR07Cl5XrIdOHRVGqQi38snajUUdUgb0HDqF0xR9Uvm9qNME/h45FUN+8bSdkpkVmqgt8VgnDx05HUFCQoSN1d+gxCB/k/Ry5CpdHr4GjjDQ9cO7CJVSv20rNHhYqXQXLVq2D5aNv8yUN+nKLbTv+jtK2rX/tVm3NmL0IylSqqx7VCpNr12/qVUfap86SH4uW/WrYU7xsdSxf9VsEvVnzl0IeF2fJUQLS5iGjJiMwMNDQkZms8t81xOQZC/FpqW/xZqY8Kk3KXvDTKnz3Q0tI3hFhs2BLf16r7Hz7gyIoVb4W5i1aqfRlI4+kazZoK0ElYpu0wbz/Kn3fFFKnKBz/9z/I40uZSRM9mbn9a+deSbIqlb8ui4G9O+K7Sl+FpltsfX39MH3OT+jUphE+LZAbqVO9iZGDe+DmrTv4ZV3U59DFS1fxff02EfrVonjMioKlzCILO3m0aZ5v/uKfIddDQECAebQRlr6RpxytO/WDtF9mpCUxqmvJ1rUj15PMakt+XeSaErb6eaSfjxu37oBcW+nf/xQ7/z6gzpG+g8egY8/B+KhAWXX+/zh8YoRzZdSEWeq6TPdeQUiZDVt206uJtJdzynw2s1XHfirPzdt3lK6f3wukyVoAYo+K0DZBQcFR1m+5pEHLEuHfg4eP0KX3MOQr/rUaA+TclXMsglIMDvJ88rEa/2QMzPtJDlVCro+zG3H58+ZScSaTCdUrl4eMQ5cuX1Nxsvlp5RrUqFIRybQZVTm2JXJdCDfLazGqdkk9MuZJmXKdSr80a9dLDiF9LGG5vrLn/QISNl++IOeq6Otxev0z5y1FwZKV8G6ukmjSRrt+wvpMChWe9Zt3UbPfklfO2aiu2ZfZIGW+TPz9A9RvgtgkvwlfV2+Cv/f9Y2RT43b3QZCZdrFJxqaJ0xcY6faet7HJ0qicAZck4OGSrWKjbBJoUr8GEnl5Ycu2XUrn9p17+FZzZnLn/BjrVs7B5jUL8b//pUANzYkIDg5WOuabSaMHoOJXpdG6WV08vHpESfZsWeHv74/EiZNg3LC+OLJnA1o3ras5nqMhDqF5fmvhkeNn4rtvvsK44X3hq/2gtujQG/KIW3S379qHdl0GokGdqvhn5zpMGzcI+w8ewcBhEyRZSe+Bo7Fuw1bMnz4Kf6xbjFu372Hb9r9VmmzEaRGHLnGSxNixcbnSW7N+Cx4+fPmjxIU//YoxQ3ph/1+rkentDDC37cy5S5qz1Rbly5bC0b2/o2+3Npg4fb5U+VKZNW8ZWjSpo1j9UONbrdw+EOdNz/j4yXN0btdElSvO3+69Phg2ZqqerPaHj53EP4ePY8WCKbh0MrQ/JUGc3IZ1q+HUP1vRskltrNXYtOzQF7WqfYMTBzahsXYOiIO0ePlqUUeRQvm1HyIfw0nau/+QmtX6e98hlS4O6d/7fFC0UF513L3vCGR8Oz02/TofF47vUDdRSZMmUWkx2Zy/eAVyg1WscEEje4rkyZA/Ty4cPX7KiLMMyE3P95qj/kB7JBzar6OV4/zQol+jYvlOpgwoW7oYlv28LkLxS7XjmtW+RqJEiSLEmx/M1W4a3ns3M3ZuWo6FM8fgZdeSrWvHvMyXhcdMmo3Rg3vi6qm/kTd3DqW+ZPlaFMz3CXZvWQmZwRS7Vq3ZqNLkhk0c/kF9OuHCsR3Yodn6af7cKs3aRvp4734fI2nX3oOh58LeUEdl38HDSOydSNWnKy3TbtYCAwIxUptRFcdxoua06PXrOlHt6zbtjCdPn2LWpGE4/PcGfF2+tHbD1gK6sx9V3thKS5EiBb6tWBYLl65SRcqYsXTlWtSq/o06ftnG2rUYVbsyv/M2/lz/kyr24omdahydOXGoOn746BEqV/wSuzavwPKFkzTe3qjXrLMxJioli43Uf/3GLaxcOBWrl82AXFPDx0w3tKJ7zcbEBqOysED/oeO0m83lGKGdF/KbIEtbvq3ZHDJuisqEqXNx8fJVzJ48Atf+24Ol8ybg7bfSShKic97GNktlQDxuWFX8EfCIv6pYkyMQ8NKc3fffzaINOheUOfLj+EnO7OjavimyvZcZstZu2IBuOHHyDGRdlFKyY5PyzTdUGTk+ygYJV69SAbKMwtKRsFZU/57t0LZFPVTTZlmG9e+i2XZJc1rvKtVxU+aiacNaqFn1GzXzV1D7se7VpSXEblGQWYKFS39Bz84tNYcsP9KmSYXxI/ri2fPnkqzkT2328fzFq8oZl0eXH2V/Xzlpjx4/UelRbXp1aY18eXLirfRplY0yWN+6E2rbTytW42OtrO4dm6s2lyxeSGtz1aiKM9Ia1auOL0oWxZtv/A+tmtZB2tSp4HPkuJHeuW1jFPk0H15/LQU+/6wopI4lK9Ya6XpA2iptEj097gftR/qb8l8giebgS/ys+ctQoVwp9Vj5jf+9DlnqUuO7ipg5d6nKUrhgXnWj4XP4hDr+S7vJaNG4juYEH1TH+/85on50xamSiBs3byFPro+RKWMGZX+Vb75EoQKhM8ySHl3RZw9Tvvm/CFllPfWNm6EzixESwg6kX0+fOY8JI/pDGHyU/T2IY2fZry9jWfv7KmqGXZwcKfq/sxchjp3Ey7EtkVnDTm0aq74XznJOxsa1ZKs+ie/RqQUKaM6tXMdyUyBxZTSH/YfqlZQdZUsXxxeliuGAzzFJgvCT61GcXJmp/CTHh+omSCVa2cjNz/bd+9XNz4VLV3Dn7j00qF1VOxcOKW2Z2ZXzRepXEdrmkxzZIc68nHP9erRDmVJFsf+fo1rKy//J+m4ZZ6aMGYj82oyr9HmjujW0ay4HVq3dFGUBcgMoM4PmIk8roswURaIwlJsHudFf9/sfSJsmNaStUWSJkDReG3fkPJRz4VXaJWOdXK/Sb3KdyU2MnI/y9CBChWYHb2rjyIBeHdR1IH1cu0YlrQ8OGxrRvWZjYoNRmRaQm+TZC1agS7tmavyStgwf2BUZNId2zsJlmgbUuZk1SyZ8/OH7SJ4sGT4r9imqflveSJM89p63KpOVzau2w0qRjHJiAnR4nbjzYsN0edS/5c/d6rGl/sMhj3jFYbygPS6OTh1LtcfmFas1Vo+XpazhY6fhytUbLy0ix0cfGDpZwl5uuXPvvooTh0Z+xKQ8XWTpgDi6N27eVi82yWxwyeJFlL5sXkuRPMJa3EvaLMI7mnNmvhZP1m6JnuhHJRkzpDOS02hOqRzcuRtq20Xt8ecnOT+UKENyaT/+xkEUgQxvhZcraunSptaci9By5Vger/7QuD0+zF9G9c23NZupR/zPn/tKspLs2d6FtXV8eXLlUOn65sy5i5oTUkw/VPsymlP073/n1KyROE4FNGdjlzabJ07O/QcP0aJxLXXjIc6oODlFPs0L3cmRG5MO2qNIeZw/Ydp8+GizzKrQjmvyIQAAEABJREFUGG60J8o2c5pMJpXWb/BYxUE/B2QpwkXNIROnWxxdpaRt5PG15Wzzy1hW+LIkEnklwm8b/9RKABYtW4VihQuoG0AVYWOT55OPIqTE5rUUoWCzg3xhs7pmUXjb4lxKk/pN7Vy6p1TEARantXSFH9TjZVnK8/jJU5VmbSMOXmBgkHpysFub1S2pOSHFixTErj0HlLrM9ItTrA7CNnIDGRZUO5lxuxt2/aqIKDbnzl9SN6eps+SP0L8bt+yA+RMPa0XIjZuszzUXucm2phtVnIwfInLDmiJFMmzetgsyu1tbe/ISVT7zNMtr8VXadeXqdcj1JUuZ5HxPk7WAWsJ15dp18yojhDO9/VaE49SpUqknDnpkNW0yQcq095qNiQ16XbKXsVFuIOVmTI5FZPwo/VkRnL9wWQ5RpVI5LPzpF+0pWRvI8oXfN29X45EkRve8lTzW5FXbYa1MxjkvATq8ztt3MbI8MDBQc2Quaj/mWVV+k8mk7qr15QnmexkklZIdG1mDKo/S+/Voqx7/Szl9urWFv401kOZFenl6GocmU6iDIz9AEmkymTBmaC9IeZYis66iI+Ll5SE7Qzy9wss0Ii0Ceh0W0REOPTwiliuJ9uQTvajEermhOcRxql63Nb7/7hts+nUB7l3ywYZVc1WiOc+kSZKoOMtNkqSJLaPgacZYEr00PtIOkymUd7HC+bDvwCHNsTkIcXJkxqVY4fzYveegNrvnA3MnR2a9504biXcyvY2/NSf5i2/qYNL0hVJsjOStdGlVvvsPHqm9vrl3/yEyaDNCctymeX3tvFpjyDuZMkg0zM8dFaFtPD3C+8welrJsoU7Nb7H8l3WQH+mVv/wOWc6gFRXlv6TaDLq5gskUs2vJZArtA/OyZLmG+bEettbnHh6R8wMhKos88di5aQV+0Gb8nmk3S8PGTEOp8jUjOENKMWwjNz8yky+O7d97fVBYe8ogTvA5zUm5pN3g7dl/SLsZyBemHbqTcyk0FLo1mcSe0PpDY2xvTSaTNpOayur1LTObtnMCGd9+y1iPKzc6InIDFFWeqNJMJhNqVf9WO5cXYKd23n9f9euo1COkWfaLyRSzdsk1+V3tFpCbliVzJuDWuQO4f/kQ5BwN8A9fwx+hcu3A+ngS3gfRuWZjaoNmRqR/4uSaR3p5ehmH8oRr2/olkLHl7PmLaN6+F+QmXxRsnrd3Qm/kROdlEpvteFldTHcOAuG/DM5hL618RQLymEkbi/FdpdBP92TP9h52a06LPIKyt+jE3omNO3E9z96Dh1GsUH7Io+306dKo6GMnbK+/VAp2bD7O/j627dhjU1McH5PJhKPHTxs64iwcOnLSOM78TkZc1mZN9JlZSRBHSGaJJRxTyfLO21q9Edt47ES4HTEt1+fwCaROlRLfViwDmS0TZ/VVys32XhbNzoh2HTp6Qi3H0G2UH50dfx9QDm9RbXZT4mVJxbbte2DNySn3RQl079gcyxdM1h5bNsGvv22SLDGS7NpMdfq0abS6Q2cRpRCZhZSlFEUKhjpX8gP4wftZoIvoyNMAy349HfYCpaSL+NjJsl6tqtiybTdkecxzX1/t+ign2aMl2e24lqxdO+LcSHvlhTC9wlP/ndWDr7zPoM0AN2tYC8MGdMOerau0a+EGDoYtebBWeNFCebFn3z/YvnsfShQpgMSJvTUnNz/GTZ0L70SJIE8DrOWLSVz2D95Vzrcsa4hJ/tjOU1u7MZAXq2RdfppX+DqDPe1KnDixMl+WUKiAtpGnVmfOXdJuUL5F9mxZFfsTp86oGzEt+ZX+lbPzmo0NG2RslHHr6PHwcViM9zlyHO9mfUeCSnLn/AgdWjXEjAlDMH/GKMgsr74kKTrnbXyzVMZz43QE6PA6XZfZb/DVazcgb3LrIt857as9Gh7Qqz3ezpBeFdSobjW1b9quJ45qDqoMvv+ePgt501sfeJSC2ebdLBnx7+lzEF09OtfHH6jHoPe1x+EySzZ28hzt0eBOPTnGe3lxS95iHzZmKuQRp9QpL7LJbLIUKjNS9Wp9h6Gjp4hNEKdB2vjgYfhsYekShZFZmxFs332gKuNfrX3yVnhi7Ydcyoip/FCjMuTtZ/lqhLRb1u3J1ytiWp6eT5Z4XL95C/IRdImT9k+cHv72ssRFR5o2qKleylrxy3rIy2G/rtuEhT/9imaNahnFyI1KQEAgVv+2WTk5klC0UD78vOZ3yEtK+fPklCglfQaNMZYxPHn6TK0XlbXfKtHKRvpCPwclWWZz5FjWysqxzE41qFMNcs4c+OcI7t57AHnJRn7wvir7mahYlVLFC+H9d9+B9Kvwv3HzNrr3Gw7zfrWXpdw4ff5ZYfQZNBbfffuVWlNotdIoIu25lt61cu18qN3UydrqeYt/VqULLz2sIl5hI39IRb66od/c7dh9QK3PzarZYatYmdWVdbzPnj2HfOlA9OTmRx7zFzFb2iLxrypSrsz0te7cT7ux/Vtdv7KMZvKMheqrCa9afnTzp9du1h9cOYx52hOM6OY117enXZkyvqXO1eMn/zOyytImGZv/+Gu3ijt56qxa3iDOo4qI4SY612xs2CDLipo1rIlhY6apCRW5PkeOnwm5cZfxSJohY+WmP3aq5RpBQUHYsWs/hL+sgY7ueRufLMV2inMSoMPrnP1ml9XyQyef+arTpCO69hmG/85dwObVC9Ckfk0j/5tv/A/y2DxZ0qSo27QTsuQogU49h0AeYSby8jL0zAO1v6+MS5evIuU7eSFrzGRWTdbOVSxXCl98XQeflqoCGcQ7tm5sni1G4SLaI1VZo7f/n6P4/Ova+Ch/Wcib6v7+L4zyhvTvAtGrUqs5Cn/xnRpAK1UoY6TL48CVi6bAz9cfxcpWV584q6o5NbL+9fXXXzP0ohuQl/yk3I1btiNbns/RsccgtG1RXxXzv/+9rvYx2chLHFPG/IhWHfpCPqE2ZvJs/Ni7Q0yKUnmExbjhfTB19mLkKFgOE6bOx499OqKO1o9KQdvIjYM8yk6izTrpTo68MBIcHILCBfOqR6qamvp36/ZdVKjWCNL38rmh4ODgKO07cuxfyHkoIgXID5+Ep85eJIdKZLa4pvYIuWm7XurzVNc1h3/tspmwfCSqlMM2krZs/iQE+AegZPlakKUV1SqXVz+aYSrqhRh7Wdas9g3kSUctba/nj87enmvJ2rUja8lnTxmuZslTZc6Hihpb3SmITv3WdGVN6pSZiyCfzZP+kq+MjBrcA5brbs3zSn8Ha/1erEh+YymM3Py8eOGPItpTHHPd2AgvmDkG8unEXgNG471PSqFWw/bYsXsfUqRIHhvFJ1gZL2uX9HvH1o1Q6fumkL6Rz4+JY7tk9jj1ecMiX1RFzYbt0K1Dc+0GLGkM2hGeJTrXbGzZMLBXR8gnCTt0/xG5i1TQ+nQ/1iybAXl/QiwL0saNNtqNjpzzIus3bYN8qcNkMml9n0x9+tLe8zY+WYrtFOckQIfXOfvtpVbLJ7z0Na/yyaq9237BT3MmGJ8yMi9AHpvLJ3GO/L0Bl//djd9/mYcFM0Yb35+UsDwO1fPIbJ78cQC9fHn0JrN0fbu3w6HdvymZO3WENlA3w59hn97R85rvxUmVMpKYrYWUb7BKnLxprOvK2rxff5qO88e24/ShP7B2+SxIXXq6OGvyhvQpn604vHs9RvzYQz0iGz+8r66iBtlffpqmPn8jPD7/rIh6lCpt0ZXOHd2ulhHIsb22lSlVDH/9vhSyzlaYy02CzEyKTVKONbl78Z9IL5Ht2LQc8q1kXV8ct52bV2Dfn79i229LjHXWMhMoOvLlAeknCZuLtbIlXb7K8NeGpar9Ym/9H6pKdASR8oSNySRrMKFmn+5cOIifF0+NoCc/SjfP7of0k4j0h8xKRVAyO5C/CiV6lmLePyaTCfKWufSfnINrNGc3S+aMZqVYD0r/rVw0Fcf2/o6TBzYrJ17OY2mvnuNlLHW9i5evQz6dVKhAHj3K5l6YmJ+DuuLLriWx1/LakbxyHm1evVCdR39vXQW5SRFeOldr56Pks2bH8IHdtet3jCSrL4HItS9liVw8sRNNG9RSabY2cu5Kv8sfYtF15BqU/HLe6XGyf1n9orNgxhiITRIWOXvkL+M6k2OpT/pe7Lz23x41ZqxYOAU5zV5mFT1zkWtNbpLM4yQs9sl5IGFzkZtIsV++8mIeL2EpSx6rS9iayPkUVbrUKdeOZV572tWjU0vjOpIxWMrI88nHkJv8PX+swtE9GyBLEeSakM9BSrqMjdIWGSvl2Fr9shxKxjNJF4nuNfsyG6RMS1mg/WaY/054eyeCvMdxYPtaXDn1N35bOVt9SUfP106bHDhz+E+j/aIn55mky6y/nA/SThF7ztvYYJnr4+zKHvlaiNhBcS0CdHhdqz+j1Rp3UpbH+Fv+3AX1CF57bN6oVXfIG8PirL8Kh8nao1f5QxnyyFiWHvQfOh6N6tZ4lSKZNwEIyAtys+YtReN61ROgdlZJAiRAAiQQ1wTo8MY1YZbvMARad+qn/pJT4zY9tRnfdzBHe4z8qsbdu/8AX33XEPJX4H4cMREyc9qhVYNXLZb545FAyw59UbDkt/ju23JoWIcObzyid6SqaAsJkICLE6DD6+IdzOaFEqjyTTn8d2ibelwljwmnjP1Rfag/NDXm2/4920Me/8qSBll+0KNTiyjXnca8JuaMKwLTxg9Sy2WG9u/KvosryCyXBEiABBKYAB1eezuAeiRAAiRAAiRAAiRAAk5JgA6vU3YbjSYBEiCBhCPAmkmABEjA2QjQ4XW2HqO9JEACJEACJEACJEAC0SIQRw5vtGygMgmQAAmQAAmQAAmQAAnEGQE6vHGGlgWTAAmQAABCIAESIAESSHACdHgTvAtoAAmQAAmQAAmQAAm4PoGEbCEd3oSkz7pJgARIgARIgARIgATinAAd3jhHzApIgATsJ0BNEiABEiABEoh9AnR4Y58pSyQBEiABEiABEiCBVyPA3LFKgA5vrOJkYSRAAiRAAiRAAiRAAo5GgA6vo/UI7SEB+wlQkwRIgARIgARIwA4CdHjtgEQVEiABEiABEiABRyZA20ggagJ0eKPmw1QSIAESIAESIAESIAEnJ0CH18k7kObbT4CaJEACJEACJEAC7kmADq979jtbTQIkQAIk4L4E2HIScDsCdHjdrsvZYBIgARIgARIgARJwLwJ0eN2rv+1vLTVJgARIgARIgARIwEUI0OF1kY5kM0iABEiABOKGAEslARJwfgJ0eJ2/D9kCEiABEiABEiABEiCBKAjQ4Y0Cjv1J1CQBEiABEiABEiABEnBUAnR4HbVnaBcJkAAJOCMB2kwCJEACDkiADq8DdgpNIgESIAESIAESIAESiD0CCeHwxp71LIkESIAESIAESIAESIAEXkKADu9LADGZBEiABOKOAEsmARIgARKIDwJ0eOODMusgARIgARIgARIgARKwTXz3aocAABAASURBVCCOU+jwxjFgFk8CJEACJEACJEACJJCwBOjwJix/1k4CJGA/AWqSAAmQAAmQQIwI0OGNETZmIgESIAESIAESIIGEIsB6o0uADq9GbPmvm1CkXB2cv3hNO4r47+btuypt3k9rIibYcdSm+zB06jPypZqzF/2C0t82fqnelWs3MXPBSty99+ClutFROHv+smqjMLAmJ06di05xduva2267C4xCMSg4GD80646Fy9dFoRX9pGLl68V6mdG3InZyFI9hW+q36o3egyfGjhFaKZbXzfF/z6B0pUa4c/e+luo4/27cuoP+w6eiTvOeKFGhvrqGrl6/ZdPANRu2oXmnH1GuWgv0HDQep89csKlrnmB5fZb8uiEq12mPRm37YfGK9QjWzm1z/YQIj5++CBW+bxXnVbfpNhQde4+K83osK4jPscqy7rg4fvbcV52vP6/dHBfFG2UeOvqvqieufkOMiqwEXGlsttI8RsWAAB3eGEBLqCzXbtyCON737j+MExNqVP4SE4f3iCSZM70VJ/W9lS41Pvn4gzgp27LQVWu34OGjJ/i+SjnLpFc6zpMzO9KnTfVKZcRVZlcpN+dH2ZA/98eYNGupQzXp1u17OHryP6RN8yZy5Yj6PJ44cwmGT5iLgnlzokeHxggKCkaTDgNx4NBxu9ukX5/D+3dAvZrfIOs7b2PKnKWo17K3w90M2N0oKpIACZBAPBGgwxtPoJ2hmkxvp1c/yPKjbC4pkieLE/MrfvkZJgzrHidlWxYqs/hlSxVGYm9vy6RXOp4yqje+LF30lcpg5pcTKF+mBP7YsQ/3HsTNzd7LLYiskSfXh/h14XiMHdwNxQvljawQFvPw8ROs0J4iicPapO53KF28IIb2aYd0aVKqGdowtZfu9OuzSMHc+O7rMujbtTlGD+qCcxevYPCYWS/NTwUScGMCbDoJwIMMYkbgxKmzaNJ+AGQpQvnqLdVjNnseuV68fB3NOg5U+ZpqMzzrN++wy4BtO/erOkS5QZu+6jGRLD+4dOWGRCEwKAhjpy7Ad/U6Qh55ft+4C8TJU4mxtJFHslLnjj0+RokhISFo0WkQvq3dDk+fPVfx+uPNP3cdQN2WvfDZ1w1QtX6nSPZYPibUH7PJY1p5VCxlSn3rN+1Q7T15OvLSCnn8LY/UVcU2NpLv+s3bKFWsYAQNe+3U9XZq7ZbZNHm8PnLiPFWW5WMzXffmrbsYMGKaenzdXHuM/ceO/Ur/1/V/qMfan3/bBB16jcTd+xEduD+271P5qjXopLjVadETP636HcJZFaBt4oqTVnSEf//+d16dU2KDnFPSh6Mmzzf6OYKydrDvn6No33MEhI/kkceZWnSEf/LIX9otj79Lf9tYXUP/nbsUQcfaQfEieeHp6YHN2/ZYS3bouG1an8qSmgqa064b6uXlhS8+K4T9Pse0Jw+P9eho74t9mgeVypdW5ZjzlmtIllNVrNkawlnGnL0HjxjlP3z0GLKEZdGK34w4PTBn8a8qTXT0OHv3sgRs4Mjp+LJqc1Rv2BmrN2yLlNXXzw9Dx85GlXod1FhVq2k3bP7z70h623cfVMuQPteulS59R+Poif8i6UiEtTHVcmwRPXvrtVae5H+Z1GzSFd0GjI2kJktyZBzTx4D7Dx5Bxg+5nkp90wgNWvfBJO0JgFzXkTKHRci4IWVY6sgStzJVmoZpAZIuej/9vAE/jpqOb35oC+HXue+oSGONnmnt739q12H/KPX2HDiChtrvTmntmi1foxV6/Dgejx4/1YtQe6lbljaV/a4ZpE/FNv+AQJVmuZm18Ge1LEd+OweNnqmeUFiOpZLH3vHCWnmSn0IC5gTo8JrTsDN8+uxF5eQlSeyNntrjyYa1K+P6zVtqTd1zXz+bpTx+8hQtOw/SBoonaNukFqpVKoPVG/7Ehi07bebRE/Jqs0mtGtdUh93aNTSWHaQLe5zef9gUrNMcw/JliuHHnq2R75OPMWHG4mjNIKnCo9h8W+FzlCiSD4O0gVRfRzx3yWocOXEag3q1gflM8GNtMBwzeQE6NK+N9cumaG0tC3EG1278K4oaQpOW/LweyZImwdzJP2LOxIEoW7qwNhuWCr/89keoQthW1lD+c/gEKlf8PCzG+u7v/Ufg5emJXB9ni6Rg2PkSO321fh07bSHaNK2JXxeNR40qX0UqS48Q3XY9hyFzpgzo1q4BkiROjD5DJkIG5TW//4XKGsfmDarjwqWr2g//TD2b2l+8ch1JkiRGg1rfom+X5siR/T3MmLcCS1ZuUOnmm9jmZF62hO/ce4h79x/hW82hknOqVLH82KE5If2HT5HkCHLs37MYM2WBdn7kRc+OTdS50E5zfs+brYuXHy+5YZBrRdrXS9Pz9k6kbgCkLyMUaHGQWJuZ/+iDd7H34FGLFMc/lKVIYuUH72eRnSEfvBd6fOWa7XW/hnIUgS+1JxeSfF47n2QvcvL0WWR7NzM6taqPlg1rIHmyZOqG+WTYTeMb/3sdpUt8CnF2RF8XubFap12jkiY6ctMmDtQLf39dxeZezntZY5shfWq1bCND+rQYMWEujhw/beQRx79p+4HYtnMfKpb9DAN6tEKujz5Qa6HlZk9X9Dn6L8SpkmVPvTs1Rb48OSCOtDijuo7srY2pMsZYjqn21mutPHvH6HKfF8cebayRMsQ2XX7fultdDyWL5lNRPQdNwKFjp/BDtfIYMaADWjX+Hl6JvBAQaN05VJmiuVm88je8/VY6zJ8yCFNG9YJcez9qNyKWxSz7ZaN2s7EHNSqXQ6PaVeBz9BQGajfq5np/7NiLTn1G4fXXUqBH+0ZoXKcyTp+5iJZdBkVYP95j4Hjtxuu41q6KaFa/uvabeFf1v3lZEp6r3VDJ0rwSRfKr8yR1yv+hdbchEcoSPbHZnvHCsrxUb76OVl0jlydlUtybAB1es/6v3by7mkmUAV6XKnU7mGmEBuXO9Z2Mb2HyyF7qcbYMFtPH9MPT5774SXPWQrUib1es3gQ/7Ydj5rgB+O6bMij3eTFMG9070oUeOSfw5huvaz9gmVTSxx+8ayw9SKI53TITJzPAfTo3R9N61VCyWAF01wamWlXLY/7S1TZn5FRhZpsxUxZGan/pbxubaQD9urZAihTJ0GfIZJw6cwHzlvyKOjUq4hOLNYzyA9O1bQPk136oXkuRHGJLBW2GSwYnSYtQqMVBmlRvKvtTvfkGPtYcPm/N2an0VSn8sX0vfLXZIV1deIpzKBz1OGt7mWF5L2smyKyaZbrYYo+dfi/80b5ZHXyaLxfEEcgSxbpm0W3d5Ac0/OFbbRavMIb0aQuTyQT54Zs5rh/Klymu1hI3rlMFew4cxZOnzwyzJE5+VL4uVxJlSxVRzqP8EC1fvdHQ0QOxzUkvV99/pt3cDNEevVf/9kt1TrVtVhvD+rWH3EBcvnpTV1N7uXGQa6BapS/VNTF1VG/I2mY5/5SCtpH1pt7eXpg7aZD6gS2rtW/yiJ5InfIN7Txdq2lE/S/7+5lx7OSZqJUcMFVuHOQaMJlMEax7438p1PHtO/fVPqabTNpYJHnN+2Ro3/Zo2eh77fz7VLEeN6QrCuXPhaXa0wLRFalWqaxyhGRmXo5Fdu49hFt37qHK11/IYbREznsZd2QM+lxzpscM6qzGrfWbdxrlyFr6cxevYMzgLtCXd/Tq1AQyNsxcuNLQm7PoF+T48D2MGdQVX5QshB+0sWzUwM6wXNIiY4DlmDpFO/fEcTcK0wL21mutPHvH6Apli6snbZu2hc9Wy/gis9dflCysxp/AwEA1U12zSjlU/aas1iefqDGlZcPv8cbrr2mWxs6/D7Nl0RzTKpAxVG4Um9WrDlkvbvkUMrU21uq/YzKOt9LOmYOHT0DXC9BmaMdNXYwC2jguy89krJVrfIrmRF/Wni5u1cZksVhuUCSf3BjLuCfLdgZ0b6nGb0nXRZ4C/rRqA+pUr4jOreupcUXO0x+qVdRVjL0944W18mRiSH5vjIIYIIEwAnR4w0DITmYSJlq8tCUXsKSZy4FDJ1Ai7G5djxeHNNdH2bRB5YQeFWl/9MQZNWP3v9dDf+hEwUt7tFkgbw4JGiKzxOIE6WIk2Agc8Amts6Q2A2eu8lnR/OoR14mwryy8rNwaVl5aGzOoi3mRaqZicK+2OPbvGe0OfzCyZH4bzbW7+QhKYQfFCucNC4XuihbKq35Mr12/HRphY1u8cJ5IKd998wVk8F23cbtKkyUcG7bswlfaTYPMBqtIG5u72kylOKk2kmGPnZ4eHiiuPVa3VYZ5vKeHB0qYtV1mvuX8kFl670SJDNUMb6VV4Ws3wnnIUgh5uUkej5ao2EDdgEyfv0J9mcPc2ZeMsc1JyjQXcWDkBkV/lCk3gU07DFQql6+GLqVRB9ome7YsSPnm/7RQ6D8PjUGh/J/gsNns3t6DxzQnvqg6h0K1ANGT8/TQ0ZN6lM19yjffUDc88iNnU8lBE0wmUyTLTBoj80j9etf35mlRhfWSzas4pt0YyAxplXodUPSruuo82vfPMeXg6mXlzpkdWd7JgNVmyw7WbPgDGTOk054QfaTUxGnZs2mxXWvf5dwWx0hl1DYytsnNuT7DrUVh3z9H8V6WTMidI7scGvL5Z4VwWbuJ0h0tOW8KF8htpEvg3SxvK9skrIuMqTk/fB8RxlTtaY68g6DryN7eeqU8eaoSoTwrY7SUaSnp0qRS3DZt220k7fzbR004lNeevEmkMMmqjZnzl65VX3e5ej3ijaPoxIbk+jgiX/3F4ysWXxGRa9S8Pv0pmK539sJldZNheQMks/fyxOLgodDr9vCx0Fn8wgU+MS8ORQvljnAsNzuy9KGY9ltgniBLc8yPJWzPeKGXJ+vaJY8uluXr8dy7NwE6vGb9/3H2942ZUxkwRfQBQFeTF1DE8frfa5Hvxt/432u4dfuerhppf+/+Q1hzvFKneiOCbs8fJ0DWwOkya+HPEdItD27dvaecCHlsb5725v/+pw5v3b6r9i8rV38pRtqtS75PQn/4VAFhm+zZsuDtt9LAz++FmlGWQTwsydiJk2dpjzy6EoU7mr2ytyVvvhFqt3m6cCtV/FPIWjaJ3/LnHsijw6raTLkcRyX+Af5Ikjjc0TTXtdfO115LoZZFmOe1FX5du6ERR848XZyBZMmSmkdB4iRCHgXLXpz4jn1G4r+zF1Gp/Ofo362FWroib+RLuuWaudjmJHWYy7hpi7By7RaU1rjLLPj4od0xuHcbpfL4yRO11zfmDoIe96b2VEJ3YKSv5Hz5ee1m5XyJ86yLrDe8fuOOns3mPknixCpNylEBJ9nI9S1OrKW5Dx+FMkyT+k2V9HXNNhGu+4OHQ29kVWIUG/2GSZ46idqVazfRrscweGqOX+1qFTC8f0d1HhUp+EmEpwmiK7P34pQ9fPRY3VTJE4eq2syjpEVXkidPqp5kmOdLrD2B8tXGCT3u1u37OKfN8Op9r++79BvdmHl/AAAQAElEQVStVKQtcp7Lp9ZSao+mVaTZJqXZTZVE373/AHK9SdhcUqZ83fxQG5dfXq9ksHeMFl1rUu6LYpAJBt2R3bhtF95KlyaCgz9tdF8UKZgbMotdo1FXtZZ/vZ3vclir01rcaymSRoj28PBUx76+L9Re31jqeSfyVkm63o1bob8dsjZX7yt9L08Wr98KvW5lXbI8qTGZ9NsvVYyaYQ4NhW7v3g19Z+F/FrPZqbSnPKEaoVt7x4u79x6pDG++GfE31LI8pcSN2xPwcHsC0QTwvzDHRwZay6y3795HVBeapD33fW6ZTfsRihjXrvkPmDa6jyHflCsVKY95hDy2klkvy3V2t+7cVWqptMdWEohuuZLHmkybuxzXNAdFZoemz1sOy3olj9hj+Vjx7v3QwSlN6lSiYlMsxkxDr/q3ZSFr+GTN8GptVkoeeb7/7jtGuq2ArD17/DQiY13XXjtt2aSXExv7c+cvq/a1bFRDPcItU7KwugFLniyZ1eJt2RRTTpaVbNuxD1UqloY43BXKlNAev+ZC+rRpLNXU8d17oT9k6iBsc1t7NJ42dUp1JH0gNxeynMPyKYocjxvaTelFtXn0ONRBlOsoKj1HS5PrU64Fy5fzTp+9oEzVHd6JI3oY17xc/x9my6rSX7bZtC30Ebru8MrLlXJTPrBHK8jjZ1maIjewISERnREpV/pDnNJfftuGn9dt0R67e6LilyUkKU7krfSpIdes9Lk1eTdLRrz+WnJ4enhoT6f8ItnwxGz5jySmTvkmHj+O+PKUxN+/H/FFQHvqlXxybtkzRouuIWYBeRFRbmTXb96p2e+L3XsPoXzZ4mYaULPR3do1xPbf5mHF3FHIn+djDB4zE7JWNoKi2YH0kRzKjYDsdXnxwl8Pxsn+7bCnUO2a1VY3TZZ91rZJTVWv3IjIkj51YLZ5ajHupk4d6pg+CruWdVW50dDDsrd3vEidKnRy5PnziOO7jOtSDoUEzAnQ4TWnYUfYZDJBHuXIG8Tm6vISl7ycEdWP1Cc5suHUmYtqINTzyhovnyOhj4X0uPe0R37yySNd0qdLrZLEYZDAC/8A2Rkij5PlQNa4yl6XP3ceUI+MPwhzCm2Vq+vbs/9Hm3WSGbkmdati3JBuauZk9OQFVrOaf81BFP7efxjy2O/tDGnlMNoij2ClDVNmL1Pr4L6zc51h5kxvI6qXomLbzmg3LCyDnAsSTJY04uyMOJ4Sb6/ElJNl+TLjnCRJkgjR23bsjXCsH8hsz82wJwkSJz/Mu/YdgtgixyLyuPPf0+eQ6+MPlCMvTpi5iE5UclV7HPtOxvSRZhGjyuMIaUU/DV2is95sFk/Wcv6xfR/k8Xb6tKmVmbm1x/z6NS97/XpXiVY24kTL4/M1v/+p1kpKHlGT80ieupg/YZG1r4ePn5LkCJJU619xcH/btB2/bdyhlpzIeuMISrF4ICyuXL2plr+Y970eFkfHZDKp8+aAz/EINd/UZhuvWLzg94k2ph4/dRby5E1XlvP2gMX3je2pV/JLefaM0aJrTZJrT3FkiY7chEjfiC3ltVlfa7oSlzFDerWeVfrrjHbDK3HWRHc85RowTxdbzY9jO/yedgMi56e8r6H3kfk+e9hNWZ5c2dUTvxNaX5jbYPmU4j3tty1JksSQ3wJzvd3ab4P5sYTtGS/08vSlFZJPxPLckTgKCXgQQfQJdGxZR3P07mHY+DmQgVWk56CJahBvWu87ywKN4xqVy6kPznftP1bN5ImT3H/YVNjzOFcKyfh2eiRK5IV12o+T1Cki6yxl/VPxwnkxaeZS/LXroLLpZ+3RsbyB3bh2FaQJm2WTMqKSK9qjUCnTUuTHUvLJo8Z+w6dqDks2NKhVCTIQ9u7cDPJjqX9yR/REkmiPMsdPXwRxJqU8cZI3bNmBRnWqqNkb0YmJiJN77OQZyA9LmVJF7CqigDaDIj+WlrNDkjmu7JSyoyvvZc2kXuBauGyNWq8sTwwGjZqBC5euRbcoxISTZSWf5s2BdRv/Up8MkhkTeaP7l/XbLNXUsbxwI5+Sk74WkU8NPX7yTDtPKqt02bRvXhv3Hz7BD027Y8HStepHT84b+RKAXEuiE5WcvXAF+XNHXO8elX5cp4nDKW0V0R0R+cGX4zPnLxnVi1P7bYXPsWL1JsjnsuRzffKm/vWbd9Cu2Q92O/D69Sk325NnL1Wf7BJ2OT96X70YqTu4n+bLqZ66LFrxm/qc3emzF9G5z2gEBwUbNpkHqn7zpbohlOu8coXS5kmQ8uUR9gt//wjxMT2QL5TIpIB8qUE+xSVtEednwozFaNyuv1Fs47rfQThKvIw78lfpOvYZBQ/NGTaUtICMqTKj2lsbf0VfRK4ZGRc9PcJ/3uytV8oL0jjFdIzWTILMmssNtvS1vMwrTq3Ei8h5Il8ekE+/7fc5ptoonygLCgpCoXy5RMWqyB/okXW4Mrkgn6KUcsZNW4jj/561qh9bkeKIy3ImeTmtRedBWKU9BRC75ROVHXqNgOylLln6lj/3x+jx4wTIEzgZa+X8+33rLkk2RG7i6lb/GktWrsdabWyR/pIbv8XauSpK+jksYXvGC708eZFcbihlfbD85sgXY6QMCgmYEwgfEcxjGY6SQM6PsmH62H44p/0AdxswDv2GTlEO2LzJgyBrTW1lltmLmeP6Q2Z35NuL8udBE3snQs3vvrKVJUK8OBXD+nbA+YtX0bnvaLTrMVw53qI0rF8HfPl5UUycuQRd+o7ByjWb0a55beVgSro9smK1lkcrU8o1l4OHTqjs8uPnr80uy0fzTSaTivvis0/VG9ZDtEdyMgirSG2TNGkSdGhRF6MmzlV2rlq3VR3L1xa05Bj/KxP2CSaZlZIfOnsKKlW8gPrMmXxL0lI/ruy0rMee48Te3hjevwOePfeDfFvzu7od1EtaHbQbLHvym+vEhJN5fgl3bdsQ2d/PqjlWPSDf1pQZq9EDO0lSJMmX+yP1wk437WauY6+REIdv0vAeeDfL24Zu6lRvYsmMYfjog6xqLXaXfmMwUjs/PDxMiGoWTAoQ5//i5WvKmZBjRxCZSdWvk1/Xh34yT64RiZs6Z0UEE7u1baDdhJRRN4fy2aer2s2lvBBb2OLFrAiZLA7063PI2FmQm758moMhj5hlTJGbT109+/tZ1NdU5OsA8m3Tlp0Ho1CBXKhQ1vpSBXGksrzzNuSGy/KdBb3M2NqbTCZMGtET8hLqzr0+6DN0MuTdAnkJsmqlMkY14kCNGNAJ+/45Bvlms3xm6usvP1M324aSFtDHVPmkV9d+YyHnnjhNn5f4VLvRf1PTCP1nMtlXr15eTMdoqa1QgU8gY/WDh49RzuKP0shyjXRpU0LGot6DJ6GfNuEhS8/kCwh5rbwvIeWJmEwmjBzQGd7a70Xdlj21a7I7goJC1NdeJD0uRWbHZ47rB4QAsxf+or61vVhzWN/VZn/z5wm/AR0xoCM++Tib+v2R909kOYd8tcPSNpn0qK9NmMgLsXKtTJmzDPIFGNFLmyal7JTYO17o5c1auEqNm+OnLVKf5vTwoHujQHJjEOAZoaH4vko5yJvI5j/OWrT6Jz8kkiafWlERYRtZPzp7wgD8uWYOfl85DeOHdoO+XjFMBfLJJfkrTPqx7OXHZabm9P61bi52/b4Qfbs2V58PknIk/WVSrFAe9W3aHb/NVzZLeZJHBvmOLevil4XjIGvDls8ZrT5HJGkvE1lTJ220JfIpGilDPm205ZeZkIFIjnWRNmxbMxvydrceJ/uSRfNj3dLJys5VC8ZGGpybaLM45u2WWVuxQdYdSn5rsuPvf1R0lYpl1N6ejTy2rVS+FOSrDtb0X2anOO4blk+1lhW7tT6s9/03RpotXfl2r3yGx1DUAjL7I+01/6HL8eH76nN30odyfgzt2x5VKn6hGMq5qGVTN1eSL7Y5SX3mbZF+lpfUpM+lPrmhkx84CVco+5mYomTB1CHaDGM7NG9QHX+uDT2vF08fBv0Ru1IK20iZ8qmz1Ysn4O+Ni7Dp5+nKOTPXtXbd/LZpB+TxaVw7ZGFm2rWTa05YWBO5VswLkR/frprTK+2Wa3/p7FEoU7KwuYrNsOX1uXnVDMzQbri7tmmgloZYyyizjIumDVWM5dqUz16J8/Hz/Mh/GOHq9ZtQDqeVF0Dt/UqDrfNe+nrupB8jmChPqdo0qYUVc8dg5/r5arwaM6grZJ24uaKsPf5p5gh1jf2xejZqV6+org1LtjIGWo6psrzs3cwZzYtTT8fsqddaeS0bfQ/zsSpCwRYHnh4e6jdBzovvLJiKQy2fV5PfDrmufl8xVf2lvoJ5c1qUEvlQlvNMG90HMvaLdGlTH/IJrq2/zjKUbY2h8tsm9sjvhyjbqye6IjIuTR/b12jXynlj0K5Z7QhjvpQp/S3tkrpEX85DCcvvpZSji3y6Tq4FSZPfLFkCJWnvZckkO0PsGS9E2bK8T/PlUueN+XgmehT3JuBwDq97dwdbb4vA6bMXIS/jTJ+3EjJ7k+WdDLZUrcbXr1kJh47+CynHqoKLREr7XoWTI2KQx+nLfvkdTerYXi7kiHY7uk3Xb96GPJ4ePGYW5JvOX39Z0tFNtmqfLA/YtfcQ5PG4yNCxs3Hu4hX1BxCsZmBkghI4euI/9Vc3pa9E5EnEhOmLIU87smZ+O0FtY+WuTYAOr2v3r8u0btLMn7THf5ORK8f76NquYbTbJUtNZCb61it+5D/aFcdzhlflFM/m2lXd1Wu3UKf615B16nZlcB2lOG2JPPHo0GukelQtM/ky8xqnFcZR4c99fdF36CS1dEr+II7MVssssOWsYhxVz2KjSSBZ0iSQ90tkOUOn3qMgSxFKFMmPQb1aR7MkqpNA9Ai4pcMri9ubdhgIWSfZue8o46Wgs+cvR/hGaEftYtRx1mjUGY+fRP78jZ7OfTgBW483wzWiH5K/BiSPy2UNs6yPi34JUI+Q5TGpnjcu7NTLTqh9bHBKKNtt1StrS+vV/MZWMuNjSECWFMmyEnn0LO8lxLCYBM/WtukPaimNPB6XJTLSHpktTHDDaIBVArJEZ8nM4WqZ1s4NCyDLI2S5l7yAZjUDI0lAEXj1jVs6vOnSpsLkkT2xbukkZHsvM+RbsjrK/Lk/VheiDJ4yS6DHc08CJEACJEACJEACJOCcBNzS4S2QJ4f6U5nyMlOxT/Pi1t0Hdvee/HneNt2GYsPWnXbnoSIJkEDcE2ANJEACJEACJGCLgFs6vOYwlq7agEL5wt+QPXH6HIqXr4cm7QeoP26g65pMJsi3SFt3HYKqlcoabxQnSuQNRxB/f3+HsMMRWOg2kEnkc1OYeHklcohzRb+23G2vn58JvQ8ICHCI8yChOZjXL9eH+THD3nAkJvaOFffv34Obi1u0397zQddza4dXPn798PFT41u1Gd5Ki7VLJqpPr3z+WSF06TcGMqMrsEJCQtC2+3A0ql0FpYsXlCglfn6+cAQJ01fy4gAAEABJREFUDAxwCDscgYVuA5lEPjcdiYm6gLghARIggTggkDZtelBcl0FMThm3dXjlczz/HDmhvp+b2NtbsZO3R+XPaor8ULW8+kti8teNJNFkMqF0iYJYv3k79G8GSryjzAB4eHhytsZitp1MIs/wGkwsWCXEeSzXD4UESIAESIAE4oOAWzq88qcP5/20BkP7doB3okQGZ1myoB/IFxsePHqMTG+n16NQv2YlpEmdCvJnU/VIT09POIJ4eHg4hB2OwEK3gUwin5uOxES/hrgnARIggYQkwLrdg4CHezQzYisnz1qGw8dOoXSlRuozZNUadFIKG7bsVMclKjbAmKkLMbRPO8isr0oM28jnU/wDAjBmysKwGO4ckYDf0qUIqFwFvnPmOKJ5tIkESMDBCPjOnq3GDL9lyxzMMppDAiQQGwTc0uGdNb6/8ekx+fzYz2F/brNG5dA/MSx/7nLa6D4w/zOm8qd6ZamDQB/Suy3E8ZUwxR0IsI0kQAIkQAIkQALOTMAtHV5n7jDaTgIkQAIkQAIJRoAVk4CTEqDD66QdR7NJgARIgARIgARIgATsI0CH1z5O1LKfADVJgARIgARIgARIwKEI0OF1qO6gMSRAAiRAAq5DgC1xJgI+h49jxtwldsv+g4edqXlubysdXrc/BQiABEiABEiABEjA58hxTJu92G454HOE0JyIAB3eBO4sVk8CJEACJEACJEAC1gjs+Psgzl64bC3JiLNHx1COo8AfO/ZiyJgZcVR67BRLhzd2OLIUEiABEiCBVyPA3CRAAhYE/t5/GOcvXrWIjXhoj07EHLF/lO+Tj1G7+texX3AslkiHNxZhsijHIZCkVi0kWv0rkjZunCBG/bVzLxq37m5IghjBSkmABOwmkLRJEzVmJKlZU+Xx83uBWfOXGnLm3EUVzw0JxAYBmQ0dMGIKWnYZhBnzV+Deg4fo+eM41GraFQ3b9Mbxf8/iP+2c2777AGYtWImmHfrj0pXrkaq2pnPz9l106DUcdVv0QItOAyF/OTZSxrAIa/VKkuRfv3mHBPHz2s3oMXCcCovd/Ydrdnf+EVXrd8CmbbtVvM/Rk1iy8jcVFh3ztjVp3w+n/juv0mTTsE0fnD4b/9eTczm8QopCAk5A4Pbduzjoc8QQPz8/J7CaJpIACegEgoKCcF57lKzLk6dP9STuSSBWCLzwD8CUkb3RvEENTJi+GHlyfYSls0ZhQPfW6Dt0Ej54LwtKFiuIpvWrY9b4gcicKUOkeq3pTJi+CB9nfw+Lpg9HhbKfYcjYmZHy6RHW6pW0gT3aYMGyNZDlFAuXrUWPjk0kWon8tdkpo/pgzqRBmDz7Jzx99lzFm2/M2/bNV6WwduNfKvnq9Vvw19qd/f0s6jg+N3R445M26yIBEiCBWCLAYkiABJybQMmiBeDhEeqG+Rw5ic1/7lYzuYPHzMDd+w9w5+79GDXw8PHTqFHlK5VXnM0Ll64iMDBQHVtubNX7v9dToEXDGtpscx+0alwTb7z+mpG1WKG8ym6JE4f7zLlLRpoeMG/bV18Ux5+79isbVq3bgkrlS+tq8boPJR2vVbIyEiABEiABEiABEnBvAokSeUUAMGZwNzWTK7O5O9cvRJrUKSOkR+cgkVdo2SaTCSaTJmGOtbUybNW7/59jSj1Qe9qhAvomJEQPqX2IxbFEmrctsbc3in2aF9t27ldLICqULSEqsSl2lUWH1y5MVCIBEiABEiABEiCBuCFQqMAnmDpnGXTn8cCh46qipEmT4PHjqJfTWOrkyZkdK9dsUvk3/rELWTNnhKeHdXfPVr0y87vnwBEsnj4cM+atiDDbvG7TdogTfPHKdRzVZpOzvZdZ1RXVRmZ1x05ZgHyffITXUiSPSjXO0qwTiLPqWDAJkAAJJACBWKpyv88xFClXB3sPhn9/c8XqTajToifqteyNHXt8jJpqNOqMx0+i/qEylBkgARJwawJtm9WGv78/fmjaDeVrtMCqtVsUj4plP8PfBw6jeaeBVl9aEyVLnfYt6uLwsVPqpbXV6/9Ar05NRc2qWKs3ICAQP46ahmH9Oqh1w51b10fvIRON/OnTpkbtZt3Qpe8odGnb0C4H9pMcH0Acc3F8jYLiOUCHN56BszrXJbBw6SpMnrFAyen/LrhuQ920ZfKixtS5K9TLICaTSVG4dOUGFi5bhxlj+2HkgI4YMmYm/F74qzRuSIAESMAWgd6dm+OLzwobybIeVl5WWzp7FH5fMR3D+3dUae+/+w7GDu6mjTH9lfOpIi02ljrikI4f2kO9tDZ9bH+8n/WdCDnMD6zVK8sRVi+epMY60S1V/FPMHDdAgko+K5ofy+eMwc/zx6Hc58VUnLRF2iQHspdjCesiX4NIniwJCubNqUfF+54Ob7wjZ4WuSmDFL+uhf8bo/KWoPxTuqgxcuV0Llq5BzSrlkCJ5MuOx4669PihZrACSJ0uK9OlS48NsWXHA5zjM/3vu64c23YZiw9ad5tEMkwAJkIBbEJBlFY3a9EWDH6qo9cQJ1Wg6vAlFnvWSgMMSoGGWBK5cu4nj/56DvG1snnbn3n1kSJ/GiMqYIR1u372njk0mk/pcT+uuQ1C1UllUKBP6okZAQAAcQeSzW45ghyPZYMkkKDgYujx/7ov7Dx4qefjwkUP0YXyws2QSH3XaqkNdWHG4yZc7J1o2qWO3FMyXOw6tiVz0ouVr0azjgAgicZE1I8eIXkzzmpdmbfbWPN1aWMbNNUsmoUzJ8Blta3pxHUeHN64Js/wEIeC3dCkCKleB75w5CVI/K3UtAqMnL0DXtvWtNspk9jKIyRS61EEU5eWTtt2Ho1HtKihdvKBEKQkJCdZmiBNegBCHsMNReLyYOxfBVavBf8Vyg4sW0DCFKDly7CSGj5mqZO7iFVpSwvdhfLDTGu8wbVUXUBxu8uXJieaNakeUKI4/LZAnDq2JXHTd7yuppQWyvEAXiYusGTlG9PQ8+l7iImu6bgwdXtftW7Ysjgls2/43chf5yhBb3zmMYzNYfBwTkLeR5WW16g27qBfWJNyx9yhs//sfpEmVEjLbp5sgM4BpU6dShyaTCaVLFMT6zdsRrM0Uqkht4+2dGI4gnp5eDmGHI7AQGzw9PbXeATzNuEicLl5eXtDDnmY6kteVxZHaqjqIGxKIIQE6vDEEx2wkEEaAOxcn4KU5Qns2LYYun+bLhXFDuqJk0fwoXjgfdu71wQt/f+1R9yOcPH0ehQrkMojUr1kJaTQHeNDomUYcAyRAAiRAAvFPgA5v/DNnjSRAAi5CIHOmt1Cl4hdo3K4/OvQaiY6t6sE7UaIIrevcuh7kCw9jpiyMEM8DEnA9AmwRCTguATq8jts3tIwESMABCUwY1h2FC4S/rFKjcjksnj4MC6cNUbO+usnL54w2vk85pHdbiOOrp3FPAiRAAiQQvwTo8MYvb7evjQBIgARIgARIgARIIL4J0OGNb+KsjwRIgARIgAQAMnAwAgHPbuHpTR+7xf/JdQdrAc2JigAd3qjoMI0ESIAESIAESMAtCPg/vak5u4fsloBnN9yCi6s0kg6vI/ckbSMBEiABEiABEiABjcB39drj8ZOnWihm/9r1GIZT/52PWWaLXOVrtLCIiXg4cuJclKvWDNUbdoqQcPfeA7Ts/CPqt+qF7gPGwtfPL0K6fvCy8nW96Ozp8EaHFnWdhkCSWrWQaPWvSNq4sdPYTENJgARsE4jrlKRNmqgxI0nNmnFdFcsnAZcn8EmODzC0b4dI7Rw3bSGKFMyDBVOH4n//ew2Llq+LpBNXEXR444osy3UJAs+ePccBn6OGTJm5CH0HjVGyY/d+l2gjG0ECJEACJBC/BHoMHAf5IzZ6rV9WbaqCv2/diY69RqB118Fo2KY3lq7aoOL1zdwlv6r4ph36487d+yr63oOH6PnjONRq2lWlHf/3rIqX74P3HTpJxbfvOUz9qXOVoG3maeVUqdseLbsMUnkXr1inxQK2yrp6/Zb6k8Zi07Bxs5RuVBv5c8KpU74RSWXnHh9881UpFf/1lyXVd8zlILrlS57oigs5vNFtOvVJ4OUEzl+8jCatuxny1649WLthi5Kz5y++vABqkAAJkAAJkEA0CNy4dQcjBnTCvMlDsHX7Hjx8/MTInTXz2yq+XOliWLh8rYqfMH0x8uT6CEtnjcKA7q0hTq4k/PrbVjx6/BRLZoxAs/rVcezkfxKN/85dxC9a2sJpQzFSq+fEqXMqXja2ypowYzGKfppH1Z0xQzr4+lpfiiBl2JJnz31hMgFvvvG6UnknY3rcvnNPhWOjfFVQFBs6vFHAYRIJkAAJOCUBGk0CJOC0BPLk+hApkidT9qfSZkkvXwl/OU7+uqMkiM6FS9ckCJ8jJ7H5z92QWd/BY2bg7v0Havb32Mkz+O6bMvDw8ECOD99XIhkkvnSJT9V3wl9LkRxlShWRaCW2yjr+7xlU/7ac0qle+Su1j8lGbNHzmUzhLmhsla+XbW0fXpu1VMaRAAmQAAmQAAmQAAnEKgFPTw8EB4cYZQYFBRthT09PI+yhOYWBgYHGcSIvLxX20JzYoKAgFZbNmMHdMGv8QCU71y9EmtQpJRryp9FVQNt4eYWWGxISAvM69HhNRf2zWpaWJ7F36F+RFH2TSZuqVdr2b5InSwppp/zlSckljnnaNKkkCMRC+aEFRd7qMXR4dRLckwAJkAAJuD0Bf/8AhIq/27MggLgj8HaGdLh245aqYO/Bo5ojGO68qshobAoV+ART5yzTfMZQB/rAoeMqd66PsxnrhB8+eoxT/10Ii/8A/xw+ofTF+T3gc0zFy8ZWWTk//gC79h0SFew9cETlVQfR3MgM9eZtu1WuTdq+ROF8Khxb5avCbGzo8NoAw2gSIAF3IcB2kkAoga3aY+H+Q8ZCZPLMRaGR3JJAHBCoWPYzyItizTsNxKGj/8I7bPY0JlW1bVZbu0nzxw9Nu0E+57Vq7RZVTJWvy+DBw8fqBbh+w6YgfbrUKj77+1lQuvinaNVlEDr2HoHUKd9EihTJIf/ZKqt98zpYs2EbWmj2rt+yA4kTe4u6TWnUti+qNeiIi5evoeAX36u2inKnVvWwduNf6rNkly5fR93vv5FoRLd8lSmaGzq80QRGdRIgARIgARIgARJ4FQKZM2XAr4smYsbY/mjZ6HtsXhX65YPyZUqga9uGRtHD+3dEvtwfq+NfFk7A66+lUOF3s2TEtDH9VPiN11+DvKy2dPYo/L5iOiSPJCT29sagXm0xZVQfTBzeEz/PH4cPP3hXklCjylcq/7B+HfDw0RN8os3gSsIbNsqSF9XGDemO6Zq9w/p2wKafZ4q6TZk7aRAO/LHckDo1vlG6qVO9iZnjBqjPksmLeUmTJFHx0S1fZYrmhg5vNIFRnQRIgARIgARIgAScmUCXfqMhf8iiXstekBfY3tUcaGdujz220+G1hxJ1nI6A39KlCKhcBb5z5jid7Q5uMM0jAZedVAMAABAASURBVJck4Dt7NkpOGI1CV/m5QZfsYDsa5Z0iPVKkz2u3JEr+lh2lOqbKtNF9ITPGK+eNxQ/VKsbISPnkWbOOA9T3ec33Eh+jAuM4Ex3eOAbM4kmABEiABEiABByfQKLk6TRnN5/d4v1aBsdvVBxa+L/XU6jlCbJEwVwkPg6rjXHRdHhjjI4ZSYAESIAESIAESIAEnIEAHV5n6CXaGK8Eev84CkW/+E7JkFFTXqluZiYBEiABEiABEkh4AnR4E74PaIGDEXjxwh/Pnj9X8sL/hYNZR3NIgARIwCkJ0GgSSFACdHgTFD8rJwESIAESIAESIAESiGsCdHjjmjDLt58ANUmABEiABEiABEggDgjQ4Y0DqCySBEiABEiABF6FAPPGP4GLl6/ij7922y3nLlyKfyNZY4wJ0OGNMTpmJAESIAESIAEScBUCFy5dwVbN4bVXzl+47CpNd4t20OF12m6m4VERSFKrFhKt/hVJGzeOSo1pJEACJKAIJG3SBNvbd8G+jFnUMTckEJ8Eytdooar7fetOjJo0T4Xt2fzy21ZUb9ARBb/4Hg8ePjayBAYFYdDo6ajbogcat+uLq9dvGmnmgflLV2PxinXmUS4bdkuHd/3mHWjaYSDKVGmKzn1H4cKla0YHr1i9CXVa9ES9lr2xY4+PEV+jUWc8fvLUOGaABEiABEjAQQjQDBJwUwLp06bGkL7tkTrVmxEIrNmwDffuP8Si6cNR/dtyGDJmZoR0dzxwS4c3XdpUmDyyJ9YtnYRs72XG9HnLVd9funIDC5etw4yx/TByQEd1gvi98Fdp3LgugadPn2Ha7MWGPH323HUby5aRAAmQAAkkOIGr12+pP8nbsE1vDBs3K4I912/cRuuug1G1fgcs+2VDhDTLg6Kf5sEH72WxjMYubcKu4pefqfgypYrg+KmzePbcVx3LrG6Vuu3RsvOPOH3mgopzh427OLwR+rJAnhxI7O2NpEmSoNineXHr7gOVvmuvD0oWK4DkyZIifbrU+DBbVhzwOQ7z/577+qFNt6HYoD12MI9n2HkJPH7yDNPnLDbkGR1e5+1MWk4CJEACTkBgwozFEGd13uQhyJghHXw130I3+8atOxgxoJOanV25ZjMePn6iJ9m9v3PvvlZueqXv5emJt9Klwe0793Du4hWs1J5kz5syGCMHdsbxf88qHXfYeLhDI6Nq49JVG1AoX06lIidIhvRpVFg2chLevntPgjCZTJCZv9Zdh6BqpbKoUKaEig8JCQHFuRloHaj60thofRoeNkKhgZDQndqa60lEFGk8RyKfI4KMkhAEWCcJkEBCEzj+7xm11EDsqF75K9kZ8knO7EiRPBmSJU2Cd7NkwmXt6bORGI2AyWQytD3CwoePncIXJQvjjddfw2spkqNs6aKGjqsH3NrhXbJyvXbn9BSN6lQx+tnkEY7EZAo/WcRhadt9OBrVroLSxQsa+r6+z7U7s4SXwMAAh7DDUXiIHXYz8fNFsOa86hIUFGQcBwWHhyXd/NhcT9KCzXQt03x9fR2if+xmEg/ntVxTxoXEAAmQAAm4EwHtNyexdyLVYi8vTzWppg60TSIvL20b+s/TwwOBgYGhB9HYpkmVEvcfPDJy3NPCadOkUsee2oyvCmgbqVvbucW/cO/OrLnuENzvcwz/HDmB8UO7qeUN0mY5QR4+DD9B7j94iLSpQ08Qk8mE0iUKYv3m7QgODhZ1JcmSJYcjSKJE3g5hhyOw0G2wl0nSpMkgd7+6eGqDjRHWBgY9LHsZKGQvYq4nxx6enkY5lmnJkml36w5wrtjLJFk82Goyhd9QqouJGxIgARJwEwI5P/4Au/YdUq3de+CI9qDR/BGhin6lTbHCebHlrz2qjL0Hj+K9LBnVcs1PtHoPHjqu/BiZdNj/zzGl4w4bD3dopGUbj5w4jXk/rcHQvh3gnSj0Dkt0ihfOh517ffDC31/dGZ08fR6FCuSSJCX1a1ZCGs0BHjSabzsqINyQgOsTYAtJgARIINYJtG9eB/IlhRadBmL9lh1InNg7RnVMmb1UfZLs7r0H+LJqU3TsPUKVU7niF/DwMEE+SzZr4Ur06tRMxcuL+l98VhitugxC+57DY93RVpU46MYtHd7Js5ZB1rGUrtQIRcrVQbUGnVT3ZM70FqpoJ0njdv3RoddIdGxVL4JDLEqdW9eDf0AAxkxZKIcUEiABEiABEiABEogWAXlHaNyQ7pg+tj+GaZNvm34OnUgrX6YEurZtaJQ1vH9H5Mv9sXFsGWjdpBYO/LHcEClTdORFtb5dWqgX3+ZMHIR3Mr4l0Uoa/FBZ1TtxeE8smDoUdWp8o+JfvnFuDbd0eGeN7489mxYb8vP8sUYv1qhcDounD8PCaUNQsmh+I375nNFqgbdEDOndFuL4SpjimAT8li5FQOUq8J0zxzENpFUkQAIORcB39myUnDAaha5edCi7aAwJkEDsEHBLhzd20LEUEiABSwI8JgESIAFnJZA1cyaUKVXMbnk36zvx1tS+Qyep7/Y26zjA2O/752i81e8KFdHhdYVeZBtIgARIgARIgAReiUCWdzLiC83htVfey5o5qvpiNW1Qr7aYOW5ABCmU/5NYrcPVC6PD6+o9zPaRAAmQAAmQAAmQgJsToMPr5icAm5+ABFg1CZAACZAACZBAvBCgwxsvmFmJoxHYvmsfJkydp2Tlr+sdzTzaQwIkQAJuRYCNJYG4JkCHN64Js3yHJLD3wCHMXbRcyW8b/3BIG2kUCZCAYxKQv6Q4a/5S6HLt+k3HNJRWkQAJGATo8BooGHBsArSOBEiABByDgPyFqvMXLkOX576+jmEYrSABErBJgA6vTTRMIAESIAESIAEHJECTSIAEok2ADm+0kTGDMxBIUqsWEq3+FUkbN3YGc2kjCZBAAhNI2qQJtrfvgn0Zs7ySJUEvHuPpTR9DggM5+/tKQJmZBGKJAB3eWALpYMXQHBIgARIggQQgEOT/xHB2xfENDqDDmwDdgNu3b1JcmEFMzik6vDGhxjwkQAIkQAJOQoBmuhuBlClTgeL6DKJ7XtPhjS4x6pMACZAACZAACZAACTgVATq8AJyqx2gsCZAACZAACZAACZBAtAjQ4Y0WLiqTAAmQgEsTYONIgARIwCUJ0OF1yW5loywJBAQEIHeRrww59d85SxUekwAJkAAJkAAJuCiB6Du8LgqCzSIBEiABEiABEiABEnBNAnR4XbNf2SoSIIF4IMAqnJ/AuClzMGbSLCU3bt2JUYMeX9+POyeXK3l2+2iMymAmEiCBuCVAhzdu+bL0BCLgt3QpAipXge+cOQlkAaslARJwBgK3b9/F3bv3keOffai5bAEKXb0YbbNDAl9Avr+rJNAv2vmZgQRcgIDDN4EOr8N3EQ0kARIgARIgARIgARJ4FQJ0eF+FHvOSAAnYT8CJNVes3oQSFRug5NcN0ab7MJw8fc5ojaTVadET9Vr2xo49PkZ8jUad8fjJU+OYARIgARIggYQjQIc34dizZhIgASchUKp4QfyxehY2/jwNZUsWwsQZPynLL125gYXL1mHG2H4YOaAjhoyZCb8X/iqNGxIgARKwRYDx8U+ADm/8M2eNJEACTkYgbeqU8E6UCEmTJEHSpEkQov0vTdi11wclixVA8mRJkT5danyYLSsO+ByH+X/Pff3QpttQbNi60zyaYRIgARIggXgkQIc3HmGzKhKwnwA1HY3A7EW/oEi5OpgyexmG9GmnzLtz7z4ypE+jwrLJmCEdbt+9J0GYTCY8ffYcrbsOQdVKZVGhTAkVzw0JkAAJkED8E6DDG//MWWM8Erh15y4OHzuJo8dOxWOtrMoVCTSp+x3+XDsX7Zr/gD5DJhlNNHmED6Mmk8mIDwkJQdvuw9GodhWULl7QiPfz84UjiPwxFkewI6FtCAwKhEhwcLDqo+CQYHUcGBQQtg9NF16ipyQwYlqgHAdqeiIBWprsw8TvhZ9D9HdMOUvbYpo31vKFXTOqg7ghgRgSCB+pY1gAs5GAIxP47fc/UL9ZJzRs1dWRzaRtTkIgSWJvfPFZYRw/eQbiIKVJlRIPHz4yrL//4CHSpk6ljk0mE0qXKIj1m7crXRWpbby8EsERxENz1B3BjoS2wcPkARGTKfRmxQSTOvYweYbtQ9M9PMyOzcOSX2Op0iXeU9OTfZh4eXk5RH97xfC8M2nti2ne2M4H/kcCr0DA4xXyMisJOAoB2kECcUrg+L9nIDO2UsnOPT54J9Nb8NCcnOKF82HnXh+88PfH/QePcPL0eRQqkEvUlNSvWQlpNAd40OiZ6lg2XsoBEicoYcVTc8wcxZaEtEP6UcRkMkn3wGQyqb6VOHPx9NQcX63PPayKp5ZH8omInuxDxcszYfv5Vdl6OtB5Av5HAq9AwOMV8jIrCTgsgSS1amFZzXqY5c9T3GE7yYkM+3v/YRSvUF+t4R0+YQ46tqyrrM+sOb5VKn6Bxu36o0OvkejYqp56uU0lhm06t64Hf+0x95gpC8NiuHNEAtszZ8PiarWxL2MWRzQvGjZRlQRIwBoBegPWqDCOBEiABMwINKtfHbt/X4g9mxZj/bIpKJg3p5Fao3I5LJ4+DAunDUHJovmN+OVzRuO1FMnV8ZDebSGOrzrgxq0I+D+/jRePLikJeH7XrdrOxpKAIxGgw+tIvRFPtrAaEiABEiCB+CHw/PZxPLiwRcnzuyfjp1LWQgIkEIkAHd5ISBhBAiRAAiTgJgTYTBIgATchQIfXTTqazSQBEiABEiABEiABdyVAh/dlPc90EiABEiABEiABEiABpyZAh9epu4/GkwAJkED8EWBNJEACJOCsBOjwOmvP0W4SIAESIAESIAESIAG7CMSyw2tXnVQiARIgARIgARIgARIggXgjQIc33lCzovgg4HPkOPYdPIwzo8ei5rKFaOodHB/Vsg4SiEyAMU5FoOSlM6jz8xIUunrRqeymsSRAAvYRoMNrHydqOQmBTj0GoVnbHvh17UYnsZhmkgAJOBuB4EBfPLtzzJCQ4BfO1gTaSwLxSsARKqPD6wi9QBtIgARIgARIgARIgATijAAd3jhDy4JJgATsJ0BNEiABEiABEog7AnR4444tSyYBEiABEiABEiCB6BGgdpwQoMMbJ1hZKAmQAAmQAAmQAAmQgKMQoMPrKD1BO0jAfgLUJAESIAESIAESiAYBOrzRgEVVEiABEiABEiABRyJAW0jAPgJ0eO3jRC0SIAESIAESIAESIAEnJeCWDu+RE6fRrONAFCtfD1u374X+39nzl1GkXB1DOvYepSehRqPOePzkqXHMgGMTWBLggXZZc2KWvwcc21JaRwIk4AgEtmfOhsXVamNfxiyOYA5tIAESiGUCbunwJkmcGM3rV0OpYgUi4cyf+2Ps2bRYybghXSOlM4IESIAESIAEnJQAzSYBtyXglg5v9vezIH+eHPDwiH7zn/v6oU23odiwdafbnjRsOAmQAAmQAAm5RckPAAAQAElEQVSQAAk4E4Hoe3zO1LoY2Hri9DkUL18PTdoPwNET/xklmEwmPH32HK27DkHVSmVRoUwJlRYQEABHkKCgoNixw0HaE1OmISEh0P6FiXkYYXGh++Dg4PDj4Ih6UaWFmOlG0AvRyo0iLSAg0CH6x5HOE3UBcUMCJEACJEAC8UCADq8Z5AxvpcXaJRPx+8pp+PyzQujSbwxkRldUxJFq2304GtWugtLFC0qUEol3BBFjHMGOhLZBOMSmaH5shOIsjyMkRnGQ0Fz0+sVEPZzQe7GFQgKOTIC2kQAJuA4BOrxmfZksaRK8liK5kh+qlkf6tKlx5dpNpWEymVC6REGs37wdMrOnIrWNt7c3HEE8PT0dwo6EZmEymaD9CxPzMMLiQveynMXQ84ioZ57mESktXNdcT5VlpmuZ5u2dyCH6x5HOE/A/EiABEiABEognAnR4zUDLkgX9UL7Y8ODRY2R6O70ehfo1KyFN6lQYNHpmWBx3JEACJEACJEACJEACjk7ALR3evQePqE+PySfJ+g6djDJVmqp+2rBlp4ovUbEBxkxdiKF92kFmfVVi2KZz63rwDwjAmCkLw2K4S0gCp8+cx7TZiw1JSFtYNwm4NQE2ngRIgAQcmIBbOryFC+RWnx3TPz+29ddZqotqVC6n4neun49po/sg18fZVLxsls8ZrZY6SHhI77YQx1fClIQlcEpzeKfPWQxdEtYa1k4CJEACJEACJOCIBOLT4XXE9tMmFyVQO1EwJl44jqbewS7aQjaLBEggNgmUvHQGdX5egkJXL8ZmsSyLBEjAQQjQ4XWQjqAZJEAC7kSAbSUBEiABEohPAnR445M26yIBEiABEiABEiABEggnEE8hOrzxBJrVkAAJkAAJkAAJkAAJJAwBp3F41278KxKhn9dujhTHCBIgAZcjEKMGccyIETaXz/To8ROcv3DZEHsb/OLJdfg9vKjkxZNr9majHgmQgIMQcBqHVz4ZZsls9fo/LaN4TAIkQAKKAMcMhYEbCwLHT57GrPlLDbFItnkYHPAcQQFPlAQH+NrUYwIJxC0Blh5TAg7v8B44dBwzF6zErdv31F7CIuOnL4ppm5mPBEjAhQlwzHDhznXQpp25eAd/7D2nxOfEZQe1kmaRgHsTcHiH11b3vJc1E6aO7m0rmfEk4LYE2HDrBDhmWOfC2FcncOXGfew7ekXJqXM3X71AlkACJBDrBBze4S2YNyea1a+O4f3aq72ERb4pVwqvv5Yi1oGwQBIgAecmwDHDufuP1pNALBJgUSRgEHB4h1e3VGZn9h48grmLf42wtEFP554EzAksCfBAu6w5McvfaU5xc/MZjgUCHDNiAaIbFbE9czYsrlYb+zJmcaNWs6kk4D4EnMYb6D14Ilat24oXAf7u0ztsqVUCjx49xv37D5W8ePHCqo7dkVR0WQIcM1y2a9kwEiABEog2AadxeP1eBGDUwM5o2fD7CEsbot1iZnB6Ak3adkfpijWVrN/EL3U4fYfGUQM4ZsQRWBbrsgTYMBJwZQJO4/B6e3shICDQlfuCbSMBEohFAhwzYhEmiyIBEiABJyfgNA6vv38gajTugnHTFnINb4KddKyYBJyHAMcM5+krWkoCJEACcU3AaRzeHB++i/JfFEPyZEnjmgnLJwEScAECHDNcoBMduQm0jQRIwKkIOI3DK58isyZORZvGkgAJxBsBa+OFxMWbAayIBEiABEjAYQg4jcMrf13NmjgMyciGMIYESCABCVgbLyQuAU1i1SRAAiRAAglEwGkcXnM+z5774bfNO3H56i3zaIZJgARIwCoBjhlWscRjJKsiARIggYQl4DQOrzyK1KVjy7r4ef4YPHvum7D0WLvDEqidKBgTLxxHU+9gh7WRhsUtAX28kD3HjLhl7Qqll7x0BnV+XoJCVy+6QnPYBhIgAQsCDuPwWtj10kPvRIkQEBDwUj0qkAAJkIAQ4JghFCgkQAIk4J4EnMbhlbV35jJ07GwEBXP2zj1PW7aaBF5OwHy8kLATjRkvbxw1SIAESIAEokXAaRxey1ZlypgeYwZ1sYzmMQmQAAlYJcAxwyoWRpIACZCAAxOIPdOcxuGVdXjmUrfG10iWNEnskWBJJEACLkXAfLyQMMcMl+pep2xMkP9j3Dw825DgQD+nbAeNJgFnJOA0Du+Dh4+xZOV69B48UclPq36HxDkjdNpMAiQQewRslSTjA8cMW3QYbw+BoIBn0AUhIfZkoQ4JkICDEnAah7f/8Kn4a/dB5Mv9kZJtO/Zh4MjpDoqVZpEACSQ0AY4ZCd0Dzl1/SHAg/B6eNyQ46IVzN4jWuwMBtjEKAk7j8N68fQfTx/ZF1W/KKpk+pg+uXr8ZRdOY5CoE/t7vg9xFvjLkxQt/V2ka2xGHBDhmxCFcFk0CJEACTkbAaRxeD4/Ipnp4mJwMN80lgQQm4EbVc8xwo85mU0mABEjgJQQie5EvyZBQyXlyfYRWXQZDPi8k0rLLEBTMmyuhzGG9Dk5gSYAH2mXNiVn+TnOKOzhR5zMvNseM9Zt3oGmHgShTpSk69x2FC5euGUBWrN6EOi16ol7L3tixx8eIr9GoMx4/eWocM+DYBLZnzobF1WpjX8Ysjm0orYs1AizIvQg4jTfQrW0DfFOuJC5duaGkcoXS6Ny6nnv1FltLAiRgN4HYHDPSpU2FySN7Yt3SScj2XmZMn7dc2SHj0cJl6zBjbD+MHNARQ8bMhB+X3Cg23JAACZCAIxFweIf33oOH+O/cJcjjya81h3dIn3YQef/dd/DoMWdPHOlkcj1b2CJnJBAXY0aBPDmQ2NsbSZMkQbFP8+LW3QcKza69PihZrACSJ0uK9OlS48NsWXHA5zjM/3vu64c23YZiw9ad5tEMkwAJkAAJxCMBj3isK0ZVDR8/B3fvhf64mBdw995DjJ++2DyKYRIgARJAXI8ZS1dtQKF8ORXpO/fuI0P6NCosm4wZ0uH23XsShMlkwtNnz9G66xBUrVQWFcqUUPHckIBTEqDRJODkBBze4T17/gqKfponEuZihfLg5OlzkeIZQQIk4N4E4nLMkO/6PtSeLDWqU8WAbPIIH0ZNpvAXaUNCQtC2+3A0ql0FpYsXNPSfPXsKRxB//xcOYUd8s/Dz9UVAQIBVCQwMDI8P9EdwULAhQUGBVsOiExQUZKQFamHz8oWzfmwelrj4bntM6vP393eY88S4iBgggRgQCB+pY5A5PrJ4eXnarCY4OMRmGhPinQArJAGHIBBXY8Z+n2P458gJjB/aTS1vkMamSZUSDx8+kqCS+w8eIm3qVCpsMplQukRBrN+8HcHBwSpONsmTp4AjiLd3YoewI75ZJEmaFIkSJbIqXl5e4fFe3vDw9DDE09PLalh0PD09jTQvLWxevnDWj83DEhffbY9Jfd7e3g5znsj1QyGBmBLwiGnG+Mr35huvW/3e7sUrN5Aq5f/iywzWQwIk4CQE4mLMOHLiNOb9tAZD+3aAt+Ys6SiKF86HnXt98EKbBbv/4JH21Ok8ChUI/3pM/ZqVkEZzgAeNnqln4d4tCLCRJEACjkbA4R3e5vWroV2PEdj85994+PgJ7ty9j41/7EKn3iPRtF5VR+NJe0iABBKYQFyMGZNnLcPhY6dQulIjFClXB9UadFKtzJzpLVSp+AUat+uPDr1GomOrehEcYlGSr8n4a4/Qx0xZKIcUEiABEiCBBCDg8A5v/jw50LNjYyz7ZSPKV2+JSrXb4ee1W1RcwbyhL44kALdXrpIFkAAJxA2BuBgzZo3vjz2bFhvy8/yxhvE1KpfD4unDsHDaEJQsmt+IXz5nNF5LkVwdD+ndlp9RVCS4IQESIIGEIeDwDq9gEcd27qQfsXrxBKxbOhmzJwyExEkaxTUJrNmwFZNnLFCyZ59PtBtZO1EwJl44jqbe4Wsno10IMzgtARkfOGY4Tfc5hKElL51BnZ+XoNDViw5hD40gARKIXQJO4fDqTU6XJhVSp3xDP+TehQls2vIXZs1fqmT/P4dduKVsWlwS4JgRl3RZNgmQAAk4DwHncHidhyctJQESIAESIAESIAEScDACdHgdrENoDgmQAAlERYBpJEACJEAC0SdAhzf6zJiDBEiABEiABEiABEggYQlEq3Y6vNHCRWUSIAESIAFnI3D42Ens/+eIkgcPwv9QiLO1g/aSAAnEnAAd3pizY04SIAFHJ0D7SEAjsGnrDvy6dqOSazduaTH8RwIk4G4E3NLhlb+a1KzjQBQrXw9bt++F+X8rVm9CnRY9Ua9lb+zYE/45rBqNOuPxk6fmqgyTAAmQAAmQAAmQgFMQcHcj3dLhTZI4MeSvMZUqViBC/1+6cgMLl63DjLH9MHJARwwZMxN+L/wj6PCABEiABEiABEiABEjAuQi4pcOb/f0skL/G5OERsfm79vqgpOYEJ0+WFOnTpcaH2bLigM9xmP/33NcPbboNxYatO82jGXYwAksCPNAua07M8o/Yxw5mpoOZQ3NIwH0JbM+cDYur1ca+jFncFwJbTgIuTIDegFnn3rl3HxnSpzFiMmZIh9t376ljk8mEp8+eo3XXIahaqSwqlCmh4rkhARIgARJwDQIhIUEICQ4MkwDXaBRbETMCzOVyBOjwWnSpyWzW12QyGakhISFo2304GtWugtLFCxrxvr7P4QgSEBDgEHbEFougQO1HR2Mu3IOCtB+hsLAcBwcFQ/YiQUHhenIcHByeFhwcYuhJmrmY5zMvT3SiTgu3xVxP8pmXY5nm6+vrEP3jSOeJcRExQAIOQiDg6XU8v/evEr8HZxzEKppBAiQQGwTo8JpRTJMqJR4+DP9kzf0HD5E2dSqlYTKZULpEQazfvB3BmlOlIrVN4sRJkNgBxMvLC4kdwI7YssHD0xMmk0mJp0d42GTS4jw8VLzJZIKnRZosUzGZNB1NPDxC9yZT5L2nWT7zPCaTCR5RpJnli6BnMkk+23YlTpwYiR2gfxzpPAH/IwESIAESIIF4IuART/U4RTXFC+fDzr0+eOHvj/sPHuHk6fMoVCCXYXv9mpWQRnOAB42eacR5eHhojk/Ci8lkcgg7Ysrjzt37GDB0nCG+vn4w/jMZIRXQmqr2ahPhQMXYtzHPF6l8swizoCrY7NhkMjuQRPNDi7SYcontfCaTyWHOE/A/EiABFyHAZpCA4xNwS4d378EjKFKujvokWd+hk1GmSlPVU5kzvYUqFb9A43b90aHXSHRsVQ/eiRKpNH3TuXU9+AcEYMyUhXoU97FA4PHjp1izfoshL/wDYqFUFkECJEACJEACJEACgIc7QihcIDf2bFpsyNZfZxkYalQuh8XTh2HhtCEoWTS/Eb98zmi8liK5Oh7Suy3E8VUH3NhFgEokQAIkQAIkQAIkkFAE3NLhTSjYrJcESIAESMDtCRAACZBAAhCgw5sA0FklCZAACZAACZAACZBA/BGgwxt/rO2viZqvTKB2omBMvHAcTb2DX7ksFkACHceSTgAAEABJREFUJOD6BEpeOoNGm3ag+P1nrt9YtpAE3JAAHV437HQ2mQRIgASchQDtJAESIIHYIECHNzYosgwSIAESIAESIAESIAGHJeACDq/DsqVhJEACJEACJEACJEACDkCADq8DdAJNIAESIIFYIcBCSIAESIAErBKgw2sVCyNJgARIgATcgUDA8zsQCQp47g7NZRtJwG0IWDaUDq8lER7HG4HV67dg4LDxSlb8uj7e6mVFJEACJKAT8H92EyLBAfw6g86EexJwRQJ0eF2xV52kTf/4HMUvazcq2XvAx0msppmuQ4AtIQESIAEScBcCdHjdpafZThIgARIgARIgARKwRsAN4ujwukEnu2MTlwR4oF3WnJjlz1PcHfufbSaB6BLYkvo1zCqdD7tSJo9uVuqTAAk4AQF6A07QSTSRBByAAE0gARKwg4DviwDMXfWPIfcfcm2wHdioQgJxToAOb5wjZgUkQAIkQAJuQyAkBDfvPTEkMIh/3tz1+p4tckYCdHidsddoMwmQAAmQAAmQAAmQgN0E6PDajYqKJGA/AWqSAAmQAAmQAAk4DgE6vI7TF7SEBEiABEiABFyNANtDAg5BgA6vQ3QDjSABEiABEiABEiABEogrAnR444osy7WfADVJgARIgARIgARIIA4J0OGNQ7gsmgRIgARIIP4JPHj4CD5HjhsSEhIS/0bEsEZmIwESiBsCdHjjhitLTWACtRMFY+KF42jqzU8CJXBXsHoSiHcCV6/fxMpf1htij8Nb9u4TNP3TB8Xv87u58d5hrJAE4oEAHd54gBy7VThvaU+fPkPdZp0MuXXnnvM2hpaTAAmQAAmQAAk4DQE6vE7TVc5vaEBAII4eO2mIv7+/8zeKLSABEkg4AqyZBEiABOwkQIfXTlBUIwESIAESIAESIAEScE4Cru7wOmev0GoSIAESIAGXJxDw7BZePLmqJOjFY5dvLxtIAglJgA5vQtJn3SRAAiQQbwRYkRAI8n+KgOd3DZG4hJJHV3biwbmNSp7fP51QZrBeEnALAnR43aKb2UgSIAESIAEhEOT/BP7PbhgicRQSIAHXJxDB4XX95rKFJEACJEACJEACJEAC7kaADq+79TjbSwIkYA8B6pAACZAACbgQATq8LtSZbEo4gSUBHmiXNSdm+fMUD6fCEAmQgC0CW1K/hlml82FXyuS2VBhPAm5KwDWaTW/ANfqRrSABEiABEiABEiABErBBgA6vDTCMjh0CGzb/hS69hygZMW567BTKUhyOAA0iARIgARIgAUcmQIfXkXvHBWw7c/YCtmzbqWTPfh8XaBGbQAIkQAIkQAI2CTDBQQnQ4XXQjqFZJEACJEACJEACJEACsUOADm/scGQpJGA/AWqSAAmQAAmQAAnEKwE6vPGKm5WRAAmQAAmQAAnoBLgngfgiQIc3vkizHhIgAaclcOTEaTTrOBDFytfD1u17Yf7fitWbUKdFT9Rr2Rs79oSvU6/RqDMeP3lqrsowCZAACZBAAhGgw5tA4FmtvQSoRwIJTyBJ4sRoXr8aShUrEMGYS1duYOGydZgxth9GDuiIIWNmwu+FfwQdHiQ8Ad+7/+J5mAT6PUh4g2gBCZBAvBOgwxvvyFlhfBConSgYEy8cR1Pv4PiojnW4OIHs72dB/jw54OERccjctdcHJTUnOHmypEifLjU+zJYVB3yOw/y/575+aNNtKDZs3WkezXA8EggJCUJISGCoBFsfE8refYKmf/qg+P1n8WhZNKuiOgmQQIwJRBy9Y1wMM5IACZCA+xG4c+8+MqRPYzQ8Y4Z0uH33njo2mUx4+uw5WncdgqqVyqJCmRIqPjg4CI4gISHBDmFHXLAI0RiHhIRoDq65QDuWLpC40LCmouL0vaSK6Mfme/N4yRQhTTvQ/kl0JAnWEiLbIjZYiOaIxwWLVy0zxIHOE+kDCgnElAAd3piSc8x8DmHVkFFTMGjERCVXr990CJtoBAnEFQGT2ayvyWQyqgnRHJ223YejUe0qKF28oIqXOH9/fziCBAUFOYQdscXi5q3buHL1upKHjx4jSHN6dQnRnDZdxAHUw+Z7zQU2+sg8Xg9LWXo41IkN1pzbUAnWnFUjzSwsccJZl8DAQOhhy72kxRaL2CxH7IzN8l6lLNVB3JBADAnQ4Y0hOGazTWDFL+vw8+oNSu7d53o526SY4uwE0qRKiYcPHxnNuP/gIdKmTqWOTSYTSpcoiPWbt2szqaGP0U0mE5IkSeoQ4uWVyCHsiC0ea9b/gelzflJy4t8z8PL0gpdnqHh4eKrlKB7azYmHh5dZ2MMIm0wmo99C9cLT5NgzQhkR0zw8w8v39IyYlshLsyFMEiVKBK+wsOU+kbe3Q/aHlwOdJ6qDuCGBGBLwiGE+ZiMBEiABtydQvHA+7NzrgxfarO39B49w8vR5FCqQy+BSv2YlpNEc4EGjZxpxDJAACZAACcQ/Abd2eOMfN2skARJwRgJ7Dx5BkXJ11CfJ+g6djDJVmqpmZM70FqpU/AKN2/VHh14j0bFVPXhrs3gqMWzTuXU9+AcEYMyUhWEx3JEACZAACcQ3AY/4rtCR6zt7/rL6UZMfNpGOvUcZ5tbgNzUNFgyQgLsRKFwgN/ZsWmzI1l9nGQhqVC6HxdOHYeG0IShZNL8Rv3zOaLyWIrk6HtK7LcTxVQeOuaFVJEACJODSBOjwWnRv/twfGz9q44Z0tUjlIQmQAAmQAAmQAAmQgLMRsN/hdbaWxZG9/KZmHIFlsSRAAiQQSwSCAvwQ8PyOIfoXGGKpeBZDAiTghATo8Fp02onT51C8fD00aT8AR0/8Z6SaTNa/qSmfnXF3efHCD/fvPzDEgKYCIWprdRNilmYWVLpRpimN0I25XmiM2i4J8EC7rDkxy9/WKW5WoVlQZTYvM1Ka0gjdmOtJjLmuRZq7nyPW2i/InFVot2MTCA58Dv9nNw2B+bVpw/QtqV/DrNL5sCtl6DIUG2qMJgEScFICtrwBJ23Oq5md4a20WLtkIn5fOQ2ff1YIXfqNgczoSqkhmgNj+U1Niffz84MjiHwrMaHsWPbzOpSqUNMQYaWL2KWHQ79VGQL9OPS7lqHHUaWZ60lec92o0kKCQ8uWPJYS33b5+b1w+/PEz+JakT6Ra4hCAiRAAiTgtAScxnA6vGZdlSxpEvWSibxo8kPV8kifNjWuXAv9wwkmU+RvakrWpEmTwRFEvpWYUHYk8vaGyWSyKp6eXka8h4eHETaZTPA0T/O0nebp6Rkhn4eZrnkZJpNJfVPTZAqzxSNsrx+b7c3zmZdnMpngGaVd4baY65lMJpiXY5mWNGlStz9PLM9Pk8kE/kcCJEACJEAC8UHAIz4qcZY65M+A6rbKFxsePHqMTG+n16PAb2oaKBggAfsJUJMESIAESIAEEpgAHV6zDtiwZaf6LFmJig0wZupCDO3TDjLra6aiPi3Eb2qaE2GYBEiABEiABEjAHgLUSTgCdHjN2NeoXE59kmzn+vmYNroPcn2czUjlNzUNFAyQAAmQAAmQAAmQgFMRoMPrVN1FY12fAFtIAiQQEwJBAU8R5B8qwYF+MSmCeUiABFyYAB1eF+5cNo0ESIAE3IWA38OL8Ht0QUmg732HafY/J67g953/KTn87xWHscspDKGRJBCLBOjwxiJMdyrq6PF/cfDQMSUPHjxyp6azrSRAAiRgN4GLV+/i0L/XlVy6es/ufFQkARKIXQJ0eGOXp9uU1q3vcDRu1VWJOL4J1HCb1dZOFIyJF46jqXewTR0mkAAJOC+B+w8eYuOWvwwJCnq1a73s3Sdo+qcPit9/5rxQaDkJkIBNAnR4baJhAgmQAAmQgKMSePz4Kbbv2mdIYFCQo5oaT3axGhIggagI0OGNig7TSIAESIAESIAESIAEnJ4AHV6n70L7G0BNEiABEiABEiABEnBHAnR43bHX2WYSIAEScHICAb538ezOCUMQHK01vE7eeppPAiQQXQJ0eKNLjPokQAIkQAIOQkCcXF0cxKQYmhHs/xxPbx0OkyMxLIXZSIAEbBGgw2uLDOMjEPD398edu/cNiZDIAxIgARIggVciIH844+mNgwiVA69UFjOTAAlEJkCHNzITxlghsH33fpT55gdDgvhGtBVKjCIB1yTAVpEACZCAsxOgw+vsPUj7SYAESIAESIAESIAEoiQQSw5vlHUwkQTincCSAA+0y5oTs/x5isc7fFZIAk5IYEvq1zCrdD7sSpncCa2nySRAAi8jQG/gZYSYTgIkQALRIUDdOCPw9OZhPDi/RYnf/bNxVg8LJgEScD0CdHhdr09jrUXnLlzG8ZOnldy9fz/WymVBJEACJBATAjt378GK1b8rOXj4eEyKYB4SIIF4JOBIVdHhdaTecDBbBgwbj9qN2yvZsPFPB7OO5pAACbgbgcs37uHE2dtKbtx+5G7NZ3tJgARegQAd3leAx6wkQAKvSoD5SYAESIAESCDuCdDhjXvGrIEESIAESIAESIAEoibA1DglQIc3TvE6V+F3793HytXrDQkMDHSuBtBaEiABlyIQHOiHx1d2GxISzDHJpTqYjSGBeCRAhzceYTt6VVev38TgEZMMkb+u5ug2u5l9bC4JuBWBkCB/PL/3ryEhwcFu1X42lgRIIPYI0OGNPZYsiQRIgARIgARIIF4IsBISiB4BOrzR40VtJyFQO1EwJl44jqbenBFyki6jmSSgCAT6PcCLx1eU+D+/reLiY1P27hM0/dMHxe8/i4/qWAcJkEA8E6DDG8/AHa26jVu3Y/qcJUp27N7vaOa9kj3MTAIk4HwEfO/+iwfnNyl5euMf52sALSYBEnBIAnR4HbJb4s8ocXinzV4EkR2798VfxayJBEiABEggvgiwHhJwewJ0eN3+FCAAEiABEnBMAo+e+GLasn2GPPN94ZiG0ioSIAGHJ0CH1+G7KJ4MZDUkQAIk4GAEgoND8OCxryFy7GAm0hwSIAEnIUCH10k6KrbM9PPzw849BwwJCAiIraJZDgmQAAnEiMCD81ugS5D/0xiVEZuZ4qqsx099MevnA4b4veB3heOKNcslAUsCdHgtibj48Z17D9CmU19DHj564uItZvNIgAQcmUBIcCBePL5kSHCw696EBwUH4879Z4bIsSP3DW0jAVciQIc3Rr3JTCRAAiRAAjElEPD8Dp7fOaHE9/7pmBbDfCRAAiRgNwE6vHajoiIJkAAJkEAkAjGIePHkGh5f26Pk6fWDMSiBWUiABEggegTo8EaPl1NqT56xAF9Vqa+kZ/8RTtmG6Bq9JMAD7bLmxCx/nuLRZUd9EkhIAv9duIUdBy8qOXr6WryZsiX1a5hVOh92pUweb3WyIhIggfgjEB/eQPy1hjVZJSDrdG/cvAWRO/fuW9VhJAmQAAnEJYH7Zzfg3n9rlAQ+v2OzqrOXbmOXz0UlR0/fsKnn6glPru2DLv7Pbrp6c9k+EohzAnR44xxx/Ffw4sULlPmmtiGXrh0GNHIAABAASURBVFyNfyNYIwmQgBUC7hsV8PweZO2uSHCQv/uCsLPlz+4cgy6BGjs7s1GNBEjABgE6vDbAOHN0SEgI7ty9Z0hgYJAzN4e2kwAJOCEB/ydXILO6ujhhE2gyCZBAXBKI57Lp8MYzcFZHAiRAAu5AICjAF/5PrxsSVZtXbT4BXR4/eR6VKtNIgARIIEYE6PDGCJvjZVq8fDWKl62mpELVho5nIC0igegTYA4nIxDw/C4Cnt1SEqw5vPaYHxAQhNMX7xjywp9/jMEebtQhARKIHgE6vNHj5bDa/v4BePL0qZJnz30d1k4aRgIk4LoEHl3+C/fOrFPy4vEV120oW0YC8U6AFb4qATq8r0owAfMvW7UWC5euUnL7zr0EtIRVkwAJuCOBIP+n6o9HPA/7IxIICbELw9PnL3D7/jMldx48sysPlUiABEjgVQjQ4X0VevGc9/79hzh87KQhk6cvxJiJs5RcuhJ/36uM52azOjsJUI0E4ptAoN8D9ccj9D8iAdjn8B46cQmzfz6gZPE6n/g222HqW7j6AMYv3K1k54H/HMYuGkICrkiADq+D9+qfO/Zg7e9blcg63frNOkEXBzc9Qc2rnSgYEy8cR1Pv4AS1g5WTgKsReHhhC24dXaTk2a0jLtO8snefoOmfPiiuzTzHV6P8XgTiuV+AElnLHF/1ukE9bCIJRCJAhzcSkoSP8PPzgy4Tp89D3x9HK/E5cjzhjaMFJEACLk8g6MUj9eKZvID24tFF3Dm53JAg/2cICX4RKiH2f/Jw35HL2H3okpJHj/klBpc/idhAEnAwAnR4HaBDdu/7B6vXb1Eya8EyFCpd2RB/f36gPU66iIWSAAnYJPDkho968UxeQHt8/SCC/J8YYjLZzBYh4d6Dpzh86oYhu3zOY/uBC0ruP6LDGwHWSw5ePLmm3XCsUHLvzPqXaDOZBEjAGgE6vNaoxHHco0ePsX7Tn4bMnr8U/QePUfLn9j1xXDuLJwESIIGIBIID/ZQzdedkqFMVFPDqL5JdvnEfG3acNiRijTyKDgH5y3RB/o+1m47HCA54Gp2sdulSiQTcgQAd3jjs5cePn0AXmcEdNmYaRKbNXYJeA0YY8tzXLw6tYNEkQAIkEErA/9kt6OJ7+wjunV6t5OGlP5QzpTtVJju/thBaavh2xrJdGDrzLyVH/70SnsDQSwkEBgfj6XP/MHnxUn0qkAAJRI8AHV47ea1YvQl1WvREvZa9sWNP+FvFJ0+dgS6nTp3F8ZOnlezZ74MS5aob8uva37Hs5zVK9mppdlbrIGo0gwRIIDoEAoOCMGTsLDRo3QfNOg7E1es3o5P9lXTljz/oTq3fg7N4fGW3IffPrIMugc9vIcD3rpIgv0d213n6/C34nLyuZMeBMxg9b6chgYHhL4na970Gu6t1ecWbtx9h4uK/w4RP+ly+w9nAeCdAh9cO5Jeu3MDCZeswY2w/jBzQEUPGzITfi9C1tbUatoUuIyfNRO3G7ZX0HjjKjpKpQgIk4IoE1m38C/cfPMT8KYNRrVJZDB8/95WaGRwUgEC/B4b4PTwP33unlciXEvSZWtk/OL/ZcGqfazrP7/0LXWJixLPnL7Dv6BVDdvucw8Zd/yk5c+EW/AOCDIlJ+U6XhwaTAAk4JQE6vHZ02669PihZrACSJ0uK9OlS48NsWXHA5zj4HwmQAAlYI7B77yFUKFtCJX3+WSGcOH0O+l9ADHh+B7rIy0jivIr4PjhnzMTKrOyjS3/i7ulflDy6uA13T60y5OnNQ3h0ZaeSF48vQ5+plb1J1Wp9c+POE+hy4cpdHDtzU8nR09ex7q9ThixZu1ctS5DlCQtX78Mfe88ZEhQUPotrvRbGxgYBYa/LgaMXwosMCcadk8sM8X9yJTyNIRIgAZsE6PDaRBOecOfefWRIn8aIyJghHW7fDf3LZvoaXdmfP39e1uwquXPnjtpLvMjFCxeN42vXrhthSbty+bJxfPnSJSMsaTdu3DSOL1y4YIQl7d69e8bxxYvh+R48uG/Ei94FM7tu3bwVIe3SpXC7rl65GiHt6tXw40sXw/WkzNu3bxu65uVLmrmYM7l7966RR3TM23P9+o0IaZcvh7fnyuUrEdLMdS9aMNHr8HsRugbOX5uJl7osxdzm27fC2yJ65m29dvVahLqvmDEyZyf5bpqxNS9f0pYs+QmLFi1KcFm2bHmC26BzCAwMNK4pVwvcufcAb7+VTjXLy9MT6dOmxu079xEQEIDF03obMm/6CMybNkTJ/BmjsHjRHENmzFuK6fNWhckKTF/8R7gsWo9ZS7cpmTJvDcbN2RQus9cZ4ZGTl6PzsF8MGT17C3T56dc/MP/nv5X8tHon/tpz0pAzZ8/jnjbuiVy/ds0Iy/GVK1eM4ytXLhthSbt+/bpxfFEbMyROl9u37xhpcu3r8TJW6mHZm+e7ceO6kUfSLmtjpexFrmjjk+x1uXrtqqF7SRtH9XjZ37h500i7eOmiEZY0XXzD3qV4/vy5Sr9165ba6+nmZV6zZKKNUbreZTM+Emeue9GCiXkd5kwkn7n8ufMARs/aqGTszHVYs/4PQ5Zo58yCGSMgMm/GGEybOsWQmbNmYdasOUrmzJ2H2bPnGDJv3nzool+T1vaONGaoC4obEoghATq8doIzeYSjMpnC51D6d20CXRp8X9EId25V2whLesMfvjGOWzeqZoQlrVm9KsZxk7rfGmFJa9f0e+O4Ya2vjbCkdW9XzzhuZFZ+rw4NjXjRa2CWr0PzmhHSmtQOr69Fg+8ipLVsUNU4blS7khGWMju2qGUcm5cvaebSoGY4k65t6hh5RMe8PW2bVI+Q1rRuZeO4Wb3wsORr0zhc17wMSevSOrSOd1o2wOraPyBli/qqnAHdwvtJ9Mxt7tgyvC2SZt7WVhZ91aJ+eF81NmMn+czZNqgZsa88PU0ICgpMcPH09EBwcFCC2yEsQmL4YpSdl2yCq5lM4eOER1hY2mxKVQS6JEmTF0nfKh4q6QshWYYShqTNUgQZPyyj5K33iyNLzi8NyZitBDJ9VDZUPiiGj/JXMOSDPF8a4Q/zlEbZ8tWtSr7C5Yz4Ep9XNsKin6/wl8Zx4c++NsKSVqDoV8Zx/iLhYUkrUvIbIy20jPC6S5WtYqTlLVTWCJf+sqoRljLM04qVqhQhrUCRcJsLFa8QIc38OL+ZnpRZvHR4OfnM6pY0XZ5XranGDHxXU5X72Rfh9oqOuV1FomBSsGh5lV/yiJjzy1conKukmddhXr6kmctHWj/mLFgRItnzloVXmqKGmJJlRkjitEpMiVMiabJkhngn8kKiRB5KtEsfXl4ehphMIdBFrkdbImOGrbT4jgf/I4FXIBDuxb1CIa6eNU2qlHj48JHRTFmblzZ1KnVcu3ZtUMiA50D0z4FEiRKpa8gVN2lSvYn7D8zGjIePkTZNSnh7e3O84JjJcyCG54ArjhVsU/wRSHCHN/6aGvOaihfOh517ffDC31/9iJ08fR6FCuSKeYHMSQIk4NIEihbKg63b96k27vvnGN7N/LZ6B0BFcEMCJEACJBDvBOjw2oE8c6a3UKXiF2jcrj869BqJjq3qwdtBZ6fWb96Bph0GokyVpujcdxQuXLpmRwtdS+XuvQdo020oGrXth16DJsDXz8+1GhiD1kydsww1m3TF1zXb4MdR09XNWwyKYRY7CVQqXxoeHibIZ8nmLP4F3ds3tidngugcOXEa8um0YuXraU76XrjjfxwzIvf66g3bUEsbM4qUq4MH2hOKyBqMIQHnIkCH187+qlG5HBZPH4aF04agZNH8duaKf7V0aVNh8sieWLd0ErK9lxnT5y2PfyMSuMYJM5agcIHcmDvpR7z++mtYsnJDAluU8NXnzvUhls0epc5fedT+62/bEt4oF7ZAXlTr3akp5LNkM8f1xzsZ0ztsa5MkTozm9auhVLECDmtjXBvGMSMy4XRpUuHHXm2QOtWbkRMZQwJxTiD2K6DDG/tME7TEAnlyILG3N5ImSYJin+bFrbsPEtSehKh8977DqPhlCVV1xbIlsGvfIRV2502xT/Oo5qd883/Iozm/+ldGVCQ3bk0g+/tZkF8bNzw8PNyWA8eMyF1fpGBuZHs3c+QExpCAkxJw3xHOSTssOmYvXbUBhfLljE4Wp9d99twX8kL8m2+8rtqS6e10uHP3vgpzA7W847dN2/GpC5wX7E8SiA0CHDNigyLLIAHHJ0CH1/H7KIKFU+YsVevtZM2duSz7ZWMEvSUr1+Ph46doVKdKhHh3ODCfqTKZeIrrfS6fxOozZBI+L/GpWvKhx3Pv2gTa9xxhdczwOfqvazc8Gq3jmBENWFR1RAK0yQ4C9AbsgORIKo1qV8GYQV0iSZWvPzfM3O9zDP8cOYHxQ7up5Q1GghsE5K/hyV+C8g8IUK299+Ah0qROqcLuvpm9aJX6K4GtGtd0dxRu1f4hfdpGGi9kDMn3yUduxcFWYzlm2CLDeBJwLQJ0eJ2sP2Vt7mspksNSZN2uNEXeuJ730xoM7dvBYb8kIXbGpRT9NA+2/rVHVbH5z79RvFDo+lUV4aab5b9uwt17D9G0XjU3JeC+zU6RPFmk8ULGD/clErnlHDMiM2EMCbgaATq8Ltajk2ctw+Fjp1C6UiPI52SqNejkYi18eXM6tKiNdZt2qM+SXb5yA7WrV3x5JhfWCAwKwvjpi7B241/qnJDzYtDomS7cYjYtOgT2Hjyizout2/ei79DJ6pOG0cnvCrocMyL34rS5y9V5IZ9sq/B9K3TpNzqykpPG0Gz3JODhns123VbPGt8fezYtNuTn+WNdt7E2Wiaf0Zk2uo/6LNnQvu3VFytsqLpFtHwiy/yckHDfLs3cou1s5MsJyCf85JzQZeuvs16eycU0OGZE7tCWjb43fkfk3Bj9Y5fISowhASciQIfXiTqLpsYXAdZDAiRAAiRAAiTgSgTo8LpSb7ItJEACJEACJBCbBFgWCbgIATq8LtKRbAYJkAAJkAAJkAAJkIB1AnR4rXNhrP0EqEkCJEACJEACJEACDk2ADq9Ddw+NIwESIAEScB4CtJQESMBRCdDhddSeoV0kQAIkQAIkQAIkQAKxQoAOb6xgtL8QapIACZAACZAACZAACcQvATq88cubtZEACZAACYQS4JYESIAE4o0AHd54Q82KSIAESIAESIAESIAEEoKAYzu8CUGEdZIACZAACZAACZAACbgUATq8LtWdbAwJkICrEmC7SIAESIAEYk6ADm/M2TEnCZAACZAACZAACZBA/BKIUW10eGOEjZlIgARIgARIgARIgASchQAdXmfpKdpJAiRgPwFqkgAJkAAJkIAZATq8ZjAYJAESIAESIAESIAFXIsC2hBKgwxvKgVsSIAESIAESIAESIAEXJUCH10U7ls0iAfsJUJMESIAESIAEXJsAHV7X7l+2jgRIgARIgARIwF4C1HNZAnR4XbZr2TASIAESIAESIAEV3ho/AAAQAElEQVQSIAEhQIdXKFBIwH4C1CQBEiABEiABEnAyAnR4nazDaC4JkAAJkAAJOAYBWkECzkOADq/z9BUtJQESIAESIAESIAESiAEBOrwxgMYs9hOgJgmQAAmQAAmQAAkkNAE6vPHQAz0GjkP1hp3RotMg1GneE6MnL0BgUNBLa/5t03ZcuXbzpXqxoTB70Sr8vHazKiogIBDDxs1Gi86D8NOq31Xcq25u3LqDNRu2RSjms68b4IW/f4S4uDrYc+AI2nQfptr05OmzWKkmPvsnVgw2K+Toif/QqG0/s5hXD67d+BemzVv+6gWxBMR0zJilXcfBwcHxQpBjRrQxIz77J/rWRZ2DY0bUfJjq+ATo8MZTH1Wr9CWmj+2LicN7YNdeH2z9a89La974x25cu3HrpXqvqvD02XOs27gd35b/XBV1+Pgp3Lh1F9PH9MUPVcuruFfd3NTK+23zzgjFjBvcFYm8vCLExdXBgmVr0bTed6pNr6VIHivVxFf/xIqxFoW8myUjurZtYBH7aocVypbAlj/34tHjp69WEHMrAjEZM+b/tAbBISEqf1xuOGbEjG589U/MrIs6F8eMqPkw1fEJ0OGN5z5K+eb/8GG2LLh954Gq2dfPD2OmLEStpt1Ru1kPTJ69FDJDs/nPv3H67EVMmrlUzUoeOXFa6S3/dZPKJ5tpc5djnvYDJ+GZC1ai56DxaNNtKJq0H4C9/xxFgzZ90WvQBDTv9CM69h6F23fvi2ok+WP7XhTImxOJEnnh9JkLGDt1kapbZngPHf0XlmXL7HSfIZPxTa02qNmkK4aMnQVph17wqnVbUL9Vb9Rr2RvlqrXA/QePMGXOMpy/eEW1ZejY2Uq1Y59RCAgMVOHtuw9qdvdXNrfvOQIXLl1T8QcOHVdx9rTj/KWrkLwNWvdRs5e79h5SZQhfYTlW4zxo9EwVZ74R20XHsg9ERxjIjHzrrkNUe1au2SzRsNY/lpzmL12DERPmKn3ZPHz0GF9WbR6BlcSLFClXR+vrJWjWcSBqaUy3mN0QSdpUjV+7HsOxVJtxl1l/mQGUpwV1W/bC71t3SRFKRFfOCymnSr0O8NH6T+yXc0HOA/0cOH/xKkZNmq/ybNu5X80oqgNts/fgEcVRC0Lnr9fXUDunLl65gc59Ryk7B4yYZjyt8PL0ROECn2DTtt2SlRJLBCzHDFv9r48dbboOVdeZ3wv/BBsz5LoZOXGeGo8GjZqhSLjSmGGrD6Shcg3OmL8S8kSvaYeBOHzslEQbY7t5/3DM4JihTg5u4oUAHd54wRxeiTg9l65cR8liBVTk7EW/ICgoCAunDsH8KYNx6/Y9rFi9GV+WLors72dB22a11Kxk7hzZlX5Um4uXr2PEgI6YPWEAPD08IPU0a1ADM8b2Q/kyxTB3yWqr2X2OnkLuHNlUWvZsWdGiYQ3k+vh9VW/eTz5S8eZli2NTr+Y3WLd0MhbPGA45XrxyvdLbvf8wZBZjSJ92WDhtCOZMHIAUKZKhdeOaeDdLJlVmr05NlK6+uXvvAQaMnIZOreph/uRByJPrQ/w4arqebHc7+mpOeCHN4RKO7ZvXRt9hk/Hg4WN0bl0P77ydHr06NkHfLs2McvWArT7Q0+UGZOKInqo9v2jOvDiNtvrHnFO1SmWxVbuZ8NVuaqSsn9du0fqhOJImSSKHkSRzpgyYOa6/9hSgJ8Q5v/fgoaGTMUM6Lb4Hamkz7v2HT8Vn2vmzeMYwTNKeGMxfulrdoOjK2d7LrMppWq+q5piORtlShRXXogXz2DwH9LzW9nIetW5SC4umD8V7WTOhW//R6NWpKRbPHIHHT55g2459RrZPtPPo0LF/jWMGXp2A5Zhhq//baH3koV33k0f1UtdZksTeL63c/Hz19IjdMcPX74U6Z/t2ba7siO6Y4chjhq0+UA3VNlkzv62e6A3v3x7DJ8zRYgBb/WPeBxwzFCpuSCBOCNDhjROskQsdP30R5M6/fI1WKJgvJzJneksp7Tt4DMf/PYu2PYYpOXP+Eo5qs7kqMZqbogVzI3mypEau97O+gyxh9byVLo2aYTUSzQLXb95BmtQpzWIiBy3LfvzkqTYTvADtewzHsZNn1Myw5Np74CgqlS8FcdDkOGOG9PBOlEiCNuXIiTPI8eH7+Dj7e0qndvUKkBnZZ8991bE97ZDH6Feu30SNyl+qPLlzZscHmuN3TGOrIqLYvKwPPiuaT91ASBFp06TWZp+vStCqmHNKkTwZPitaQC0XEad59fo/Ueu78lbzSeTnnxWSneqLDz94F8dOnFXHsin3RTHZaQ7mU/z733ms/f0vtOg8CD1+nIBnz/y0c+Y/lS6bz4rmlx3yaAwSeyeCsJCI3Dk/sHkOSLoteTdzRmTSbhhMJpNW1gfqxiXVm28oJjk+zIZz2sy9nlfOs6vXb+uH3L8CAWtjhlx3L+v/6FRpfr5KPnuuNdGzZ8z4QjufxQEXfRGxfexU5x8zpB0v64MvShaWJkOukxs37xpPQVSkxca8DzhmWMDhIQnEIgEndnhjkUI8FNWhRV3s3LAA44Z0xW+bdmLnHp/QWk1QM5CyXlZk2exRGNq3fWiaxdbT04QgsxdSAsOWA+hqiS1mdDw9w7vXQ5u9CQy0/qKcdyIvBNhIs1b2Je2R9uDRM1Hu82IYM7grGtWpAj+/8JfPvLyidnD1Mo19SIg2Sxxuq6zr9dCcKz3dnnaEIEQ5YDLbrOeTckK0svVjm/uX9IGnp6eRNZRjsHFsGbDsgx+qlcevv23Fn7v2Q2Ze06dLbZnFruPE3qGzdWKLl5cXpo7qrWbx5Jz5bdlkVP821NGXwrzDbjDE1kRhYYmXY2vngJQZ8byK2L5E2vkh+UU8PTwgXBH2n2WZ8hhdrz9MhbsYErA2Zkhfvaz/zavzTNAxI3wccKUxw54+8PQIH888PD3UUzzzfjEPc8zwf+mkiDkvhkkgpgTCr8qYlsB8dhMQZ6xwgdxoUOtbTJ27DOKMFfs0D2Ys+Bn6lwPkMbbMbkqhyZMl0Wb0nklQyTtvv4UrV2+osH9AAPYfOqHCr7p5/91MuHr9lt3FXLl2Exm1Gb8c2qysPDb9w+yRduGCn2gO/XajPLFTRJY1yONva5XIzOOJU+dw6swFlbx01e/44P0sEWarVUIUmzdefw0Z0qeFrB+G9p/MOv937hI++TibdhT1v6j6IKqclv1jTfe9LJnw2mspMH76ElT9pow1FSNu2S8bVVjWUR87+R9y5XhfHZtvkmsz+B9my4qJM5eotd6Sdu7CFciyEAnHRGQphfSpnnfn3rCbMT0iGvur2iz7B9rMejSyUDUKApZjRrKkSWC1/+89UKXI+fHw0RMVlg3HDKFgXWI6ZgjjqPrAem2hsZLXvH9CYyNuOWZE5MEjEogtAnR4Y4tkNMqRWT9f3xcQR7Fh7SraD1gWyAsOdVr0RINWffDg4SNVWo3K5bB5299o1XUIjpw4jTKlCsPn6EmlO2D4VLUuVSm+4kZmag9HY93lp/lzqtlUeSmtU5+RePN/rxsWiPP4fZVy6DVoIuSFqrJVmuHp0+fqMXienB9C9IeGvbSmZ0qd6k306dwMoybNh7wUte+fY+jbJXTdn65jz35Q7zbY8bePKmPctEXo17UF3nwj3DZbZTSMog9s5ZF4y/6ROGtSuUJpyI1BsUJ5rCUbcc99ffFDs+4YMGIqurdvpB6HGolmgYE9WmoO7iPUbdFLfe6u77DJEWb+zVTtCsqyF1m2IP3Zpe/oV5ptkfXg5T4vale9VLKfgPmYEVX/N6tfFUPHzkSLzoMgs+0cM6JmHNMxI6o+iKpGy/6xpcsxwxYZxpPAywnY0qDDa4tMLMYP798R4gTqRcojydWLJ6BMycLKEWrXrDaWzByOxdOHqRfBZBZYdPPnyYHRg7qox9e5c2TH69pM4fI5o9XLELLsQV4Ma/jDt6KKZvWrK1EH2qZg3pzqkbcWVP9yfPge5k76UYUtN7J29onmlN69/1AllSyaH6N/7KLCsrEsWx5ZTxjWXb3ENXZwN3RpUx+TR/YSVSU1NEddXlhbNG0otv82D/KWuaeHB3p2bALR7xX20tqO3+ZDf1QvL/HNmTgQ8yYPgpSdNfPbqqzotOPdzBlVXilD2lq8cF5VhmwWTB2C7NrMqIQtRZxRW30gSwbEBj2PLEnRHdf8Fv1jyUnPc+L0ebV212Qy6VFW92LDTzNHYOnsUShbqoihs2fTYiMsAZnJHqw593LOrJw3BpInXZpUkgRz3fRpU2PdT5NUvGw+yfGBcQ6YhyVNzqeF04ZAzjd5yU/6QOKl7cJAwiIVyn6GQb3aSFCJnH9tm/6gwg8ePsa9ew8hLx2qCG5iTCCqMSOq/q9W6Ut1jUmfyXmdUGOG1C/njg7A1caMqPrA/BqU9v+5Zo4xzln2D8cMjhlyjlDihwAd3vjh7PC1dG5VDxcvh34KzOGNdRIDZZlB0w4DcfzkGXxbMfQbx05ieozMlPOnY6u6Mcobv5lYW2wQ4JgRGxQjlsExIyIPHpFAbBKgwxubNJ24rPfffQcFtBlLJ26Cw5kuSzVmje8PmV329Ij6UrOcFXK4xthhkHzCTj6lZ4cqVVyAAMeM2O9Ejhmxz5QlvoSAGyVH/SvsRiDYVBIgARIgARIgARIgAdckQIfXNfuVrSKB2CLAckiABEiABEjA6QnQ4XX6LmQDSIAESIAESIAE4p4Aa3BmAnR4nbn3aDsJkAAJkAAJkAAJkMBLCdDhfSkiKpCA/QSoSQIkQAIkQAIk4HgE6PA6Xp/QIhIgARIgARJwdgK0nwQcigAdXofqDhpDAiRAAiRAAiRAAiQQ2wTo8MY2UZZnPwFqkgAJkAAJkAAJkEA8EKDDGw+QWQUJkAAJkAAJREWAaSRAAnFLgA5v3PJl6SRAAiRAAiRAAiRAAglMgA5vAneA/dVTkwRIgARIgARIgARIICYE6PDGhBrzkAAJkAAJJBwB1kwCJEAC0SRAhzeawKhOAiRAAiRAAiRAAiTgXARc1eF1rl6gtSRAAiRAAiRAAiRAAnFGgA5vnKFlwSRAAiTgCARoAwmQAAmQAB3eODgHylVrgQat+6BV1yFq33foZFy+etOoad5PazBp1k/GcXQD7XuOwO59h6ObLUb6LToPwqGj/8YoryNkmrVoFYKDgx3BFPxz+AT2/XMsRrb0GDgOy3/dFCGvnFc//bxBnUtFytWBNTlw6Dgkr6RdvX7TyC9hiZM0I/IVAzdu3cGaDdteWsrRE/+hUdt+NvWKla9nM81WQv1WvSHy+9ZdVlW2bt+L0t82VoxqNe2OaXOXW9WzjIwqn6Q1bNMXNRp1tswWq8e2eJy/eA0deo1Q7ZIxwbJSGWfqNO8JkQVL11om2zxOyGv+t03bceXaTZu2OWJCbJz3cp226TY0Ws179twXcm5If527eMVq3j93HUCT9v2VnpwPVpW0yMdPnqprQ8YEXU6cOqeluwipngAAEABJREFURP0vICAQfYZMRsWarfHZ1w2iVB4zZWGEOjr2HmXoy/Uo19GwcbONOAZIILYJKIc3tgtleUCfzs0wdVRvzJ8yGB+8nwX1W/fGzdt3FZqvviiKyhU+V2Fu4pbAfO3mIjgkJG4rsbP0Q8dOw+fISTu17Vdr2/QH7Nm0WEmxQnnQuXU9FZa4gnlzAiYTsr2bGes374T+n4Tff/cdSBpi6b+bt+7iN7M6bBX7bpaM6No26h9HW3mjiu/VsQnKlyluVSVPrg+x7qdJ2P37QvzYsxX+2n0AO/f4WNU1j4wqX5mShTGgeytz9XgNe3p6oOo3ZdG68feR6t29/7C6+Zg1oT9mju+PX9f/gf0+MbvZilR4HEZs/GM3rt24FYc1xH7RCXneJ02SGNPH9MV7WTJZbdj/Xk+BNk1qoWypIlbTzSOTJ0tqjBsyduT48D3zZJthGXNGDuhkM908wXysGjekq5HUstH3qFW1gnHMAAnEBQE6vHFB1aLMujW+RsG8ObB4xXqVsvGPv7E6bCZM7uw79x2lZrzKVGmK7X//o3Tkrn3EhLlo230YqjXohKlzlql4y82yXzaifI1W+KFZd8hsjz47snDZOkh+Xf/ho8f4smpz+Pr5KZG7bZnpqt2sBybPXmrMgp46c0HNCDRpPwDdB4yF3wt/vYgIe7G7gTa7JTOEbTQbD2qzl7ZskYwyazBj/kq06DQITTsMxOFjpyRaiczK1WrSFdJmudOXWQuVoG3kR7p5px8hs3eyP3k6dNZBZlX6aDMLEicz6pJPU4/wT29Xm65DVdnSFqlj5MR5kNmUQaNmYNvO/WoGVM+49+ARtNdm0OVYb2OvQRMg9ciMxO279yVJyap1W5Rd9Vr2hthw/8EjiNRt2Uv1x/eNuxh9fuHSNazfsgObtv2tbFm5ZrMqw1b7VGIsbr7SHEFxJkI0519Ewl+WLmqzhvOXrioO8qRCZmN37T2kdKPiNUU7R89rM03CeOjY2UpfGMk5LLOMwujuvQc4f/EqRk2ar9Jls2nbbtRq2k0xnjZvuUQZElt8Uqd8AymSJ4OHhwdSvfmGKl/CKhBxE+EopvmkkJheD1HxkHJ1yZzpLZQokg/JkibRo4z9H9qMdsVynyFpkiQqXW4E/tix30g3D0R1zdtqQ1Tji3nZEpZrX8avdj2GY+mq322OP5v//Bunz17EpJlL1TVy5MRpyDhl/mRDrnN9pnLmgpXoOWi8upZlvNr7z1HImGTterVnvBBbt+8+qMY/KUfGAbluJX5bFOOE5Xkvs57jpy9Cyy6D8V29jqotUobleS/jU/WGndWTwL+0ekVHlxWrN0HGERFpz70HD/WkaO3zffIR5KbN09MzWvnsVU6UyEvdZKZK+T97s1CPBBKMAB3eeEL/ab6cOKc5A5bVTZ6lDe4Na2DupB/x27IpyJ0jm6EiDtqEYd3x06wROHriDOTxlJEYFvg0Xy5t5moifpo5Al9+XhTDxs9RKd998wXkkas4uBLx89otamCSH8DZi35BUFAQFk4dApmBvnX7HlasDnXABo6chgplSmD2hAGoVP5znNYcYMlvTc6cu4QWDb/H5BE9USBPDtiyRc+bNfPbmD62L4b3b4/hE0LtlFnvEZpjP7h3OzVTEWS2/EAG+cFjZqFrmwZYoNnaqVU99PxxAgI125f/uhE5P3ofM8b2w+8rpqJqpbJ6NcZeZjbEqZk8qpcqO0lib5Xm6/cCE4f3QN+uzdVxVJtLV66jWYMaqp7yZYph7pLVSl1m0GT2eEifdlg4bQjmTByAFCmSIWnSxBiqxUl/zJ4wUHOo98Hn6L+Qtlcs+xnKaX0kMzLVv/0SUbVPVWKxkR9RcR50kf61ULF5+FqKpMj23jsQJ14k+/uZNQcwKaA5wNYy9dVuJgoV+ESdH+2b10bfYZPx4OFja6pGXOvGNfGuNtMk7evVqQmePnuO2Yt+xXjtHF48YxiWzR6J115LbuhLQBzg4Vr//9iztWIcGBgk0Uqiy0dlimIjy4CEnTx+rVG5HGRmKgp1Iymm+WJyPUTFwzDIjsDtuw+QKUM6QzNTxvS4FfaEyYgMC0R1zdtqQ1TjS1ixEXYZNVvkmqtVtbx2Tlgff+QGLPv7WdC2WS11vebOkT1CGdYOLl6+jhEDOqrxytPDA7auV3vGC2E/QBv/ZJyZP3kQxFH8cdR0a9VGiLM87/8+cAQ3bt7BtNF98MvCcdpTgJYR9OXgjx17sePvg5in1TN+aDecPX9ZopXI2CI3xpO0cXXRtKHKjpHaNaIS43Djq42LpSs1QpV6HdQEizjusV3dnMW/oOTXDdVNyrGTZ2K7eJYX6wRcq0A6vPHUn+J4WasqX+6P1HrCWYtW4djJ//DG/1431EoWLaBmpLwTJULRQnlw+FjktbQenh6YrQ0iMhux9ve/8J82QyIFyGzWZ1r+dRu3q9nb1ev/RK3vyksS9h08huP/nkXbHsOUnDl/SXOoT+PR46e4fec+Klf8XOmJQyCzSOrAyuaD9zIjyzsZjBRbtugKX5QsrIIyw3bj5l3luIod+XJ/iPeyZlJp8oOoAtrmyPH/4KcNwqOnLFCzJOOmLVI2Xr56A7k++kDNmMosj8wQp9Jm8LQsdv374rNCiqs9yu9nfQdZtJk00X0rXRrIDKaE9x44qt0QlIL8kMtxxgzpIf2UJHFiHDp2CgNHTkfX/mOVk3jqvwuiEkmial8kZS2iQ4u6ER45yiN1LdrufxW/LInft+7Ghi27UF5zvm1llPPgyvWbqFH5S6WSO2d2SF8f084ZFWHnRmYe06VNhTGTF0Bm5R48fILE3qE3HXoRR7Qbuby5skOWXEjcD9UqyE5JdPmoTFFs5HyWJQ1LZozAlj/3wtaMp2URMc0Xk+shKh6Wdr3s2ENzAHUdD5NJD0bYS19Hdc3bakNU40uECsIOyn1RLCwEm+OPoRCNQNGCuSGP4vUstq5Xe8YLYZ/jw/fxcfbQR/m1q1dQM86yVlYv3559tncz4bz2REdmtZdqM9pJwm60zfMeOnoa33xVWrvpTKbGjarflDGSZWx5+OiJ9uRpPFp0HgSZ+T568qyRHheBZMmSYs2Sidi6eraaYNi175B2zf4aq1XV+/5rbP5lJpbPHYVcH2dTTyRl7XCsVsLCSCAKAnR4o4ATm0lnz1+BtXVW7ZvXgcwoZHwrHcZqjt3ajX9Fq9pOvUdqzkgWDOjeEiO1mQ65S9cL+KFaefz621ZtZng/smnOafp0qUOTtN8+WecpM3Eiy2aPwtC+7RGi/S8/kiKhioCXp5cejLRPbDGQR2WLZPb08JCdEvkhlVlmOfDyCq8jkVnYZDJBZnzERl3+WjcX72bOiC9KFtJmlnvhww/e0xyXvZDlCVKWPZI4cSJDTR71mc8qBwYGG2kS8PQ0s1mz33wG0ssrvBzRFflt83Zs27EPdWt8g8kje6F44Xx47usnSZHEZLLdvkjKrxKhzeJq/9SM5pHjp7Wbm/9U2FaRch54enhofR/+GFT6RZZCeHp6wpyXJS+Y/eehlSEzZZXKl9J+1L3QvuewyE85NMO8zPpc6tGLMJlizkeWSMjjYlluopcne7Hp3SxvI3euD/DP4RMSZZfEJF+MrocoeNhlaJhS2tRv4t79R2FHwN17j5Beu2GTCHM20tfSNhFJEzG/5qNqg83xRQqxkAg3OjbGH4ss6tDT02RxvgWqeH1jOQZ5elq/Xu0aL4S9WX45F/UbBU9P+8/7DOnTqiduhfLnUu9tNO0wEJazpcLdSytTb4f5NWAyhaBi2RJqllvGPXlSJE+xdF1b+9NnL0LOeRF5amJLz1q82CLLdzw9PFD00zyoU+NrbQLmrDXVGMelSZ0Snh4eSJ82NZo3qI6Ub/4P+pKRGBfKjCQQDQLho0M0MlE1egRkXZg8fq6r3eFa5pQZFpkdlDV2X31RAjKrpevIiyaBgYGQu+Dft+5E3lwf60lq7+vnhwePHmtOVV68+cbragmDSgjbiIP92mspMH76EpjPIBTTBrQZC37Gk6fPlKY8OpbB8o3XX0PqVG9oNpxW8ddv3sbFy9dU+GWbl9liK7/c6f97+jz0WZRde30M1TzazKLY9cf2fUbcHu1xoRwIN3kh47Mi+dCodhVtxvqMREcSmf2R2ZJICWERmTNlwBWzt8J3mtUfpmJ1V7jgJ/ht03ZcvX5LpfsHBEDkojazk+vjD7RH+28jMDAIew4cVumykVmxh9osuoRFomqfpMe2yI+aPH4VkbCt8uU8kB/tVeu2KJVj2qPH/85dwifarExUvFKkSKadq09UHtnIkpwX/v74MFtW1K5eETKLb7lEJleObJC3wWX5g+Sxt/9FNypZOmskVs4bg4XThig1aUOgdi3Jgayzlqcccu7J8e2792HrKwZR5ZO8tiTG10MUPGzVZS3+i88KY+Mfu9Q5KeelzBJ+XqKgUjVnI31t65p/WRtsjS+qkig2tsYfyZI8WRLtHAodl+T4nbffwhXtiY6EpR37D52QYLTFnvEid84P1Lkoa5qlgqXa7Ky8cJxcm/2MznkvdSVK5IX8eXKgVePvIeOPjLFSpi75PvkQsnRBbiIlTpbNyF5EHM5fN2zTZomvyqHqQ5+jkZ/uqUSzjUwOyDkv0qN9I7MU68GLV27gkiaSKr8xsheRft+55x98ovGQY5G5i3+FZRsk/mUiSzd0Hf33Ro4Pa0/Bnj7z1cbJjHIYSeQalXEhUoJjR9A6BydAhzeOOmjwmJnqZQR5+UFeeJC79HRpUkWqrXmngSj7XTN06Tsa/52/hAa1Khk6GdKnQb1WvdULbSW0mcJSxQsYaRKQ9bi1q1VErSbdtdmzEbh3/6FER5DKFUpDHqnJY1k9oaHmIH6YLQvkBbI6LXqiQas+ePAwdDZoQLeWmL90LVp3HaLNOC/EW5oNer6o9vbYYi2/MGnVuKZamysvv4kDKY6s6IoTP7x/B/yizVILx6+qt4DcBEjatHkr8NnXDdSLIfLD1Ll1fYmOJM3qV8XQsTMhjwbFAbNUkOUKMmMsM4HSB96JIs/aWuaRY/nR/r5KOfQaNFG9XFK2SjM8ffocVb4uoxwNYTtgxFRt9j2zqCv5/LNPFWdZfiIvrUXVPpUhDjYy0yXysqIH9W6DHX/7QD67JUtJ+nVtoW6qouL1bpZMyJPzQ3TqM1JjPhv3HzzEl981V7NOfYZMxtsZ0uFzzREzrzutNusja4R7D54E6f99/xw3kt/UbuJs9b+hZGfgpHZTVUbrI30NrzgwX4U9Zj97/jK2/33QaklR5bOaISwyptdDVDzCijZ24qxIewaNnqm+wCDh2Yt+UelyvZcq/inkpcMm7QZAlvHIelyVaLGxdc3b0wZr44tF8ZEOoxp/alQuh83b/lZjp7y0VqZUYfgcPQl1PQ2finfeTh+pPHsi7BkvUqd6U31dZ9Sk+eq8l08I9u3SXBUfnfN+3z9HUfSruk2jo8kAAAeCSURBVJAXbX8cOV3dkMuspioobCM3JNnfz6zGbble7mg3XWFJKFwgNxrXqYIfR81Q/Vfx+9Y4dsL6Db2ex9Zexks5LzZs2YGZC1aqz4Lpn5lcuXoTVq0LfXdj78GjKk10xW65lmUiQcoVB3jRyt8gs9xybCnf/NAWVep2ULPYkl9eCBadh9pkjFz3uqPbtMMAVcfn3zbRfmPWYOzgLngtRXJRjSQ+moM/bPzsSPGMIIFXIeDxKpmZ1zqBTT9Px/wpg0M/SzZ5EAb2aIV3MoYP1A1/+BbyeRbJLcsJtvwyE6MHdcGQ3m2RyWxAFwdJXn76ef5YbaagpqgrkRfZ5AdNDprU/Q6rFoyFxDWtV019dknidTlx+rxau2syac8RwyLFAW7XrDaWzByOxdOHYd3SyWqQleTs2mycfC5myqjeyiaZLcj7yUeSFEHkc1fyuM08Mipb5DM35rp/rpljrOeUN83lhRZ5+U0eu36S4wNDNZ9Wt9gij8Y3rpyOkWGfv5EZjB2/zVcvhsiLY0UK5jbymAeqVfpSG1i7qceD0m6xWWw31xnat72aCZQ+6Ny6nmIp6aIn+hIWkc/0yMuFEhaRH2eZQVw0bSi2/zZPPaKTNb3CbLq8nNevA6Rs4SL6aTXnTuyXvpKX1iTOVvskzVyG9+8IcbDN4wb1agPzNa+SNvrHLpA2S1gXyVvpq1L6obGvUvELSJoRYRaQmwCxU16qkTYXL5zXSJU2LdRmTi15eXp4oGfHJoq3vLQms8TCRXgM1hxoeflQ+kD6V8rUC/yydFHFXPpfrhVZZ6un2ctH17e1F3ayHEbOQxGpx2QyKfVDx/5F/VrfqrDlJqp8lrqWx9Lvtq5NscFc3/x6iIqHeR5ZXy/lmIvUqevIOCPjh/RV/VrhN9J6ur6P6pqX8my1QfJbG18k3lzEPvNjOQdsjT/5tVlROa/kk47y0trr2hOq5XNGq5dd5byTa13aJeU1q18dIhIWiep6tXe8KFmsAOZMHKheJpPzP2vmt6VoJVK/sBT7zMcJT4+I5730398bF2HB1CEQe/X3EizPe/kNkHFv7OBu6iVaWQKlKtI28tlKGfPkd0R+H6LqP03d5j+5xoW/uejjede2DdCpVX2VV2zWdVbMHYOmdavC0yPUPTh09BS+LV8Kb2hPAJWyxUY+96fnlb3eDnkfRY51p1Z+6+R425rZGD+0Oz764F2LksIPy5QsrH6bwmMYIoFXJxB6Rr96OSzBwQjIG8dNOwzEce1x9LcVQ19CczATDXPGTl0I+bRarabdIY+0O7SoY6QxQAL2EMj+flb8rj3C12ev7Mmj67RuXAsli+bXD+3eHz3xH9b+vk374X7P7jyuouhM44urMLdsh8y4fqhNUMjMrXztxjI9to5liUWHFnVjqzijHPOAfIrv39MXtAmft8yjGSaBWCVAhzdWccZeYTKzKDMWMS1RHs/NGt9fzTJ4ejh2N8vjcnkpY+msEWoG1/LxX0wZMJ/7EJAZZflR1mev4qPlMmPXVntSIrPF8VGfI9XhTOOLI3GLTVtkplxmU2WW29nHzHKfF4Ncw3VqVIxNRCyLBCIQcGxPKIKpPHAvAmwtCZAACZAACZAACcQOATq8scORpZAACZAACZBA3BBgqSRAAq9MgA7vKyNkASRAAiRAAiRAAiRAAo5MgA6vI/eO/bZRkwRIgARIgARIgARIwAYBOrw2wDCaBEiABEjAGQnQZhIgARKITIAOb2QmjCEBEiABEiABEiABEnAhAm7p8LpQ/7EpJEACJEACJEACJEACLyFAh/clgJhMAiRAAi5MgE0jARIgAbcgQIfXLbqZjSQBEiABEiABEiAB9yXwcofXfdmw5SRAAiRAAiRAAiRAAi5AgA6vC3Qim0ACJBA/BFgLCZAACZCAcxKgw+uc/UarSYAESIAESIAESCChCDhdvXR4na7LaDAJkAAJkAAJkAAJkEB0CNDhjQ4t6pIACdhPgJokQAIkQAIk4CAE6PA6SEfQDBIgARIgARIgAdckwFYlPAE6vAnfB7SABEiABEiABEiABEggDgnQ4Y1DuCyaBOwnQE0SIAESIAESIIG4IkCHN67IslwSIAESIAESIIHoE2AOEogDAnR44wAqiyQBEiABEiABEiABEnAcAnR4HacvaIn9BKhJAiRAAiRAAiRAAnYToMNrNyoqkgAJkAAJkICjEaA9JEAC9hCgw2sPJeqQAAmQAAmQAAmQAAk4LQE6vE7bdfYbTk0SIAESIAESIAEScGcCdHjduffZdhIgARJwLwJsLQmQgJsSoMPrph3PZpMACZAACZAACZCAuxCgw2vZ0zwmARIgARIgARIgARJwKQJ0eF2qO9kYEiABEog9AiyJBEiABFyFAB1eV+lJtoMESIAESIAESIAESMAqgVd0eK2WyUgSIAESIAESIAESIAEScBgCdHgdpitoCAmQgFMToPEkQAIkQAIOS4AOr8N2DQ0jARIgARIgARIgAecj4IgW0+F1xF6hTSRAAiRAAiRAAiRAArFGgA5vrKFkQSRAAvYToCYJkAAJkAAJxB+B/wMAAP//EgX5hgAAAAZJREFUAwDVtUpBbzDItwAAAABJRU5ErkJggg=="
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig.update_layout(\n",
-    "    template=\"ml4t\",\n",
-    "    height=470,\n",
-    "    barmode=\"overlay\",\n",
-    "    title=\"Delta hedging narrows 10-day returns while HTM retains a loss tail\",\n",
-    "    margin=dict(b=105),\n",
-    ")\n",
-    "fig.update_xaxes(title_text=\"Return (fraction of entry premium)\", range=[-3, 3], row=1, col=1)\n",
-    "fig.update_xaxes(title_text=\"Return (fraction of entry premium)\", range=[-1.5, 1.5], row=1, col=2)\n",
-    "fig.update_yaxes(title_text=\"Count\", row=1, col=1)\n",
-    "fig.update_yaxes(title_text=\"Count\", row=1, col=2)\n",
-    "fig.add_annotation(\n",
-    "    text=\"Displayed ranges truncate HTM outside [-3, 3] and 10-day returns outside [-1.5, 1.5].\",\n",
-    "    x=0.5,\n",
-    "    y=-0.28,\n",
-    "    xref=\"paper\",\n",
-    "    yref=\"paper\",\n",
-    "    showarrow=False,\n",
-    "    font=dict(color=COLORS[\"neutral\"], size=11),\n",
-    ")\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8d5b4bd1",
-   "metadata": {
-   },
-   "source": [
-    "### Label Autocorrelation\n",
-    "\n",
-    "The ~30-day hold-to-expiry horizon on daily data creates heavily overlapping\n",
-    "returns (consecutive entry dates share most of their holding window). This is\n",
-    "why `setup.yaml::labels.buffer` is 35D - the CV purge/embargo must span the\n",
-    "full label horizon to keep training and validation windows independent."
+    "The record Chapter 7.2 requires to close a label definition, one row per label, built from\n",
+    "the values computed above rather than written by hand. The buffer and the outcome horizon\n",
+    "are separate rows because they are separate numbers here: the buffer is declared in\n",
+    "calendar days and has to cover the longest settlement, while the outcome horizon is what\n",
+    "the label's overlap is measured in."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "ed539e72",
+   "id": "5a54553a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T06:54:54.200810Z",
-     "iopub.status.busy": "2026-07-21T06:54:54.200718Z",
-     "iopub.status.idle": "2026-07-21T06:55:11.485404Z",
-     "shell.execute_reply": "2026-07-21T06:55:11.484920Z"
+     "iopub.execute_input": "2026-07-31T07:13:05.815355Z",
+     "iopub.status.busy": "2026-07-31T07:13:05.815188Z",
+     "iopub.status.idle": "2026-07-31T07:13:05.824950Z",
+     "shell.execute_reply": "2026-07-31T07:13:05.823971Z"
     }
    },
    "outputs": [
@@ -1136,460 +1306,125 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Label autocorrelation (avg across symbols):\n",
-      "  Lag  1: +0.742 ***\n",
-      "  Lag  2: +0.592 ***\n",
-      "  Lag  3: +0.458\n",
-      "  Lag  4: +0.343\n",
-      "  Lag  5: +0.252\n",
-      "  Lag  6: +0.179\n",
-      "  Lag  7: +0.129\n",
-      "  Lag  8: +0.106\n",
-      "  Lag  9: +0.088\n",
-      "  Lag 10: +0.068\n",
-      "  Lag 11: +0.051\n",
-      "  Lag 12: +0.035\n",
-      "  Lag 13: +0.021\n",
-      "  Lag 14: +0.009\n",
-      "  Lag 15: -0.002\n",
-      "  Lag 16: -0.011\n",
-      "  Lag 17: -0.019\n",
-      "  Lag 18: -0.022\n",
-      "  Lag 19: -0.025\n",
-      "  Lag 20: -0.027\n",
       "\n",
-      "Effective sample size: N_eff = 49,590 (N/7.1)\n"
+      "Label audit record - cross-validation buffer 35D for every label\n",
+      "\n",
+      "ret_to_expiry\n",
+      "  anchor       mid of the straddle sold one session after the signal\n",
+      "  exit         cash settlement at intrinsic value\n",
+      "  horizon      20 sessions (median)\n",
+      "  resolution   variable: 16-24 sessions of exposure\n",
+      "  overlap      19 sessions shared by consecutive trades in one name\n",
+      "  base rate    mean -0.04873, share positive 0.585\n",
+      "  consumed by  03_financial_features.py and every model stage, as labels.primary\n",
+      "\n",
+      "fwd_ret_5d\n",
+      "  anchor       mid of the straddle sold one session after the signal\n",
+      "  exit         mid of the same contract\n",
+      "  horizon      5 sessions\n",
+      "  resolution   fixed at 5 sessions from entry\n",
+      "  overlap      4 sessions shared by consecutive trades in one name\n",
+      "  base rate    mean +0.00436, share positive 0.648\n",
+      "  consumed by  the diagnostic notebooks, as a variant\n",
+      "\n",
+      "fwd_ret_10d\n",
+      "  anchor       mid of the straddle sold one session after the signal\n",
+      "  exit         mid of the same contract\n",
+      "  horizon      10 sessions\n",
+      "  resolution   fixed at 10 sessions from entry\n",
+      "  overlap      9 sessions shared by consecutive trades in one name\n",
+      "  base rate    mean +0.05520, share positive 0.687\n",
+      "  consumed by  90_ic_diagnostic.py\n",
+      "\n",
+      "fwd_ret_dh_5d\n",
+      "  anchor       mid of the straddle sold one session after the signal\n",
+      "  exit         mid of the same contract\n",
+      "  horizon      5 sessions\n",
+      "  resolution   fixed at 5 sessions from entry\n",
+      "  overlap      4 sessions shared by consecutive trades in one name\n",
+      "  base rate    mean +0.00028, share positive 0.596\n",
+      "  consumed by  the diagnostic notebooks, as a variant\n",
+      "\n",
+      "fwd_ret_dh_10d\n",
+      "  anchor       mid of the straddle sold one session after the signal\n",
+      "  exit         mid of the same contract\n",
+      "  horizon      10 sessions\n",
+      "  resolution   fixed at 10 sessions from entry\n",
+      "  overlap      9 sessions shared by consecutive trades in one name\n",
+      "  base rate    mean +0.01588, share positive 0.614\n",
+      "  consumed by  03_financial_features.py, 05_evaluation.py, 90_ic_diagnostic.py\n"
      ]
     }
    ],
    "source": [
-    "max_lag = 20\n",
-    "lag_acf = {}\n",
-    "for lag in range(1, max_lag + 1):\n",
-    "    acf_by_sym = []\n",
-    "    for sym in primary[\"symbol\"].unique().to_list():\n",
-    "        sym_data = primary.filter(pl.col(\"symbol\") == sym).sort(\"timestamp\")\n",
-    "        y = sym_data[y_col].to_numpy()\n",
-    "        if len(y) > lag + 10:\n",
-    "            corr, _ = spearmanr(y[:-lag], y[lag:])\n",
-    "            if np.isfinite(corr):\n",
-    "                acf_by_sym.append(corr)\n",
-    "    if acf_by_sym:\n",
-    "        lag_acf[lag] = float(np.mean(acf_by_sym))\n",
-    "\n",
-    "print(\"Label autocorrelation (avg across symbols):\")\n",
-    "for lag, acf in lag_acf.items():\n",
-    "    marker = \" ***\" if lag <= 2 else \"\"\n",
-    "    print(f\"  Lag {lag:2d}: {acf:+.3f}{marker}\")\n",
-    "\n",
-    "# Effective sample size\n",
-    "_acf_vals = [v for v in lag_acf.values() if v > 0]\n",
-    "_n_eff_denom = 1 + 2 * sum(_acf_vals)\n",
-    "n_eff = int(n_total / _n_eff_denom)\n",
-    "print(f\"\\nEffective sample size: N_eff = {n_eff:,} (N/{_n_eff_denom:.1f})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eac17af6",
-   "metadata": {
-   },
-   "source": [
-    "### Baseline IC: VRP Proxy\n",
-    "\n",
-    "The simplest VRP proxy ($IV_{atm} - RV_{21d}$) is the naive predictor of the\n",
-    "short-straddle return. Its rank IC against `ret_to_expiry` sets the floor that\n",
-    "engineered features must beat. **The floor is measured on the pre-2021\n",
-    "cross-validation window only** (`setup.yaml::evaluation.holdout_start`), so the\n",
-    "2021 holdout stays sealed against every quantity used to motivate feature work.\n",
-    "Realized volatility uses split-adjusted closes within stable `sec_id`\n",
-    "segments. Returns are null at identity changes, so an adjustment-factor reset\n",
-    "cannot masquerade as a market move. The hold-to-expiry label spans roughly 21\n",
-    "trading days, so inference uses a 20-lag Newey-West adjustment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "e4f277aa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:11.486441Z",
-     "iopub.status.busy": "2026-07-21T06:55:11.486356Z",
-     "iopub.status.idle": "2026-07-21T06:55:11.867478Z",
-     "shell.execute_reply": "2026-07-21T06:55:11.866832Z"
-    },
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "straddles = load_sp500_options_straddles()\n",
-    "underlying = load_sp500_daily_bars()\n",
-    "underlying_rv = (\n",
-    "    reconcile_underlying_log_returns(underlying)\n",
-    "    .sort([\"symbol\", \"sec_id\", \"timestamp\"])\n",
-    "    .with_columns(\n",
-    "        (\n",
-    "            pl.col(\"clean_log_return\").rolling_std(21).over([\"symbol\", \"sec_id\"]) * np.sqrt(252)\n",
-    "        ).alias(\"rv_21d\")\n",
+    "READERS = {\n",
+    "    PRIMARY_LABEL: \"03_financial_features.py and every model stage, as labels.primary\",\n",
+    "    \"fwd_ret_10d\": \"90_ic_diagnostic.py\",\n",
+    "    \"fwd_ret_dh_10d\": \"03_financial_features.py, 05_evaluation.py, 90_ic_diagnostic.py\",\n",
+    "}\n",
+    "print(f\"\\nLabel audit record - cross-validation buffer {LABEL_BUFFER} for every label\")\n",
+    "for name in LABEL_NAMES:\n",
+    "    primary, frame = name == PRIMARY_LABEL, dev[name]\n",
+    "    window = PRIMARY_WINDOW if primary else HORIZONS[name]\n",
+    "    exit_leg = \"cash settlement at intrinsic value\" if primary else \"mid of the same contract\"\n",
+    "    when = (\n",
+    "        f\"variable: {resolution['window'].min()}-{LONGEST_WINDOW} sessions of exposure\"\n",
+    "        if primary\n",
+    "        else f\"fixed at {window} sessions from entry\"\n",
     "    )\n",
-    "    .sort([\"symbol\", \"timestamp\"])\n",
-    ")\n",
-    "\n",
-    "vrp_baseline = straddles.select([\"timestamp\", \"symbol\", \"iv_atm\"]).join(\n",
-    "    underlying_rv.select([\"timestamp\", \"symbol\", \"rv_21d\"]).drop_nulls(),\n",
-    "    on=[\"timestamp\", \"symbol\"],\n",
-    "    how=\"inner\",\n",
-    ")\n",
-    "vrp_baseline = vrp_baseline.with_columns(\n",
-    "    (pl.col(\"iv_atm\") - pl.col(\"rv_21d\")).alias(\"vrp_proxy\"),\n",
-    ")\n",
-    "\n",
-    "_holdout_start = (\n",
-    "    pl.Series([load_evaluation_config(\"sp500_options\")[\"holdout_start\"]]).str.to_date().item()\n",
-    ")\n",
-    "vrp_eval = vrp_baseline.join(\n",
-    "    primary.select([\"timestamp\", \"symbol\", y_col]),\n",
-    "    on=[\"timestamp\", \"symbol\"],\n",
-    "    how=\"inner\",\n",
-    ").filter(pl.col(\"timestamp\") < _holdout_start)  # seal the 2021 holdout"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12bb1f1b",
-   "metadata": {},
-   "source": [
-    "Daily rank IC is computed within each cross-section. Carrying the timestamp\n",
-    "with each estimate makes chronological ordering explicit before HAC inference."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "a688e4a6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:11.870502Z",
-     "iopub.status.busy": "2026-07-21T06:55:11.870403Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.399792Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.399293Z"
-    },
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "ic_rows = []\n",
-    "for _key, group in vrp_eval.partition_by(\"timestamp\", as_dict=True).items():\n",
-    "    valid = group.select([\"vrp_proxy\", y_col]).drop_nulls()\n",
-    "    if len(valid) >= 3:\n",
-    "        p = valid[\"vrp_proxy\"].to_numpy()\n",
-    "        r = valid[y_col].to_numpy()\n",
-    "        if np.std(p) > 0 and np.std(r) > 0:\n",
-    "            corr, _ = spearmanr(p, r)\n",
-    "            if np.isfinite(corr):\n",
-    "                ic_rows.append({\"timestamp\": _key[0], \"ic\": float(corr)})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "daa27c77",
-   "metadata": {},
-   "source": [
-    "Horizon-aware HAC treats the overlapping daily IC observations as a time\n",
-    "series rather than independent draws."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "7d9dd85e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:12.401312Z",
-     "iopub.status.busy": "2026-07-21T06:55:12.401231Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.405789Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.405284Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Baseline VRP proxy IC vs ret_to_expiry (pre-2021 CV window):\n",
-      "  Mean IC: -0.0108\n",
-      "  IC std: 0.0962\n",
-      "  HAC t-stat: -1.23 (p=0.220, lags=20, n_dates=986)\n"
-     ]
-    }
-   ],
-   "source": [
-    "if ic_rows:\n",
-    "    ic_series = pl.DataFrame(ic_rows).sort(\"timestamp\")\n",
-    "    baseline_stats = compute_ic_hac_stats(ic_series, ic_col=\"ic\", label_horizon=21)\n",
-    "    baseline_ic_mean = float(baseline_stats[\"mean_ic\"])\n",
-    "    baseline_ic_std = float(ic_series[\"ic\"].std())\n",
-    "    baseline_ic_tstat = float(baseline_stats[\"t_stat\"])\n",
-    "    baseline_ic_pvalue = float(baseline_stats[\"p_value\"])\n",
-    "    baseline_ic_lags = int(baseline_stats[\"effective_lags\"])\n",
-    "    print(f\"Baseline VRP proxy IC vs {y_col} (pre-2021 CV window):\")\n",
-    "    print(f\"  Mean IC: {baseline_ic_mean:.4f}\")\n",
-    "    print(f\"  IC std: {baseline_ic_std:.4f}\")\n",
     "    print(\n",
-    "        f\"  HAC t-stat: {baseline_ic_tstat:.2f} \"\n",
-    "        f\"(p={baseline_ic_pvalue:.3f}, lags={baseline_ic_lags}, n_dates={len(ic_series)})\"\n",
-    "    )\n",
-    "else:\n",
-    "    baseline_ic_mean = 0.0\n",
-    "    baseline_ic_tstat = 0.0\n",
-    "    baseline_ic_pvalue = 1.0\n",
-    "    baseline_ic_lags = 0\n",
-    "    print(\"Insufficient data for baseline IC computation\")"
+    "        f\"\\n{name}\\n  anchor       mid of the straddle sold one session after the signal\"\n",
+    "        f\"\\n  exit         {exit_leg}\"\n",
+    "        f\"\\n  horizon      {window} sessions{' (median)' if primary else ''}\"\n",
+    "        f\"\\n  resolution   {when}\"\n",
+    "        f\"\\n  overlap      {window - 1} sessions shared by consecutive trades in one name\"\n",
+    "        f\"\\n  base rate    mean {frame[name].mean():+.5f}, share positive {(frame[name] > 0).mean():.3f}\"\n",
+    "        f\"\\n  consumed by  {READERS.get(name, 'the diagnostic notebooks, as a variant')}\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0ee45f29",
-   "metadata": {
-   },
-   "source": [
-    "## 5. Save Artifacts"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "606187d2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:12.406818Z",
-     "iopub.status.busy": "2026-07-21T06:55:12.406739Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.494148Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.493695Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved labels/fwd_ret_5d.parquet (352,179 rows)\n",
-      "Saved labels/fwd_ret_10d.parquet (333,102 rows)\n",
-      "Saved labels/fwd_ret_dh_5d.parquet (352,179 rows)\n",
-      "Saved labels/fwd_ret_dh_10d.parquet (333,102 rows)\n",
-      "Saved labels/fwd_ret_exec_5d.parquet (352,179 rows)\n",
-      "Saved labels/fwd_ret_exec_10d.parquet (333,102 rows)\n",
-      "Saved labels/ret_to_expiry.parquet (354,473 rows)\n",
-      "Saved cv_config.json (n_splits=2)\n"
-     ]
-    }
-   ],
-   "source": [
-    "LABELS_DIR.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "# Save label files\n",
-    "for name, label_df in {**unhedged_labels, **dh_labels, **exec_labels, **htm_labels}.items():\n",
-    "    label_path = LABELS_DIR / f\"{name}.parquet\"\n",
-    "    label_df.write_parquet(label_path)\n",
-    "    print(f\"Saved labels/{name}.parquet ({len(label_df):,} rows)\")\n",
-    "\n",
-    "# CV config from setup.yaml evaluation section\n",
-    "_eval_cfg = load_evaluation_config(\"sp500_options\")\n",
-    "_cv_config_dict = {\n",
-    "    \"n_splits\": _eval_cfg[\"n_splits\"],\n",
-    "    \"train_size\": str(_eval_cfg[\"train_size\"]),\n",
-    "    \"test_size\": str(_eval_cfg[\"val_size\"]),\n",
-    "    \"holdout_start\": _eval_cfg.get(\"holdout_start\", \"\"),\n",
-    "    \"holdout_end\": _eval_cfg.get(\"holdout_end\", \"\"),\n",
-    "    \"calendar\": _eval_cfg.get(\"calendar\", \"NYSE\"),\n",
-    "}\n",
-    "_cv_path = CASE_DIR / \"config\" / \"cv_config.json\"\n",
-    "_cv_path.parent.mkdir(parents=True, exist_ok=True)\n",
-    "_cv_path.write_text(json.dumps(_cv_config_dict, indent=2))\n",
-    "print(f\"Saved cv_config.json (n_splits={_cv_config_dict['n_splits']})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e8d2471e",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "## 6. Results Collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "cfb72d13",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:12.495579Z",
-     "iopub.status.busy": "2026-07-21T06:55:12.495496Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.497509Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.497110Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def _git_commit_hash():\n",
-    "    try:\n",
-    "        return subprocess.check_output(\n",
-    "            [\"git\", \"rev-parse\", \"--short\", \"HEAD\"], text=True, timeout=5\n",
-    "        ).strip()\n",
-    "    except Exception:\n",
-    "        return \"unknown\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42367956",
+   "id": "8d5b4bd1",
    "metadata": {},
    "source": [
-    "Assemble the label, method, and diagnostic summaries separately so each\n",
-    "result group remains easy to inspect and reuse."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "347c70ef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:12.498301Z",
-     "iopub.status.busy": "2026-07-21T06:55:12.498231Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.505032Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.504636Z"
-    },
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "results_summary = {\n",
-    "    \"n_observations\": n_total,\n",
-    "    \"n_symbols\": primary[\"symbol\"].n_unique(),\n",
-    "    \"primary_label\": _primary_name,\n",
-    "    \"primary_mean\": float(primary[y_col].mean()),\n",
-    "    \"primary_std\": float(primary[y_col].std()),\n",
-    "    \"hit_rate\": float(hit_rate),\n",
-    "    \"label_variants\": (\n",
-    "        list(unhedged_labels.keys())\n",
-    "        + list(dh_labels.keys())\n",
-    "        + list(exec_labels.keys())\n",
-    "        + list(htm_labels.keys())\n",
-    "    ),\n",
-    "}\n",
-    "results_techniques = {\n",
-    "    \"instrument\": \"30D ATM matched-strike straddle\",\n",
-    "    \"sign_convention\": \"short straddle (positive = profitable)\",\n",
-    "    \"entry\": \"t+1 mid (selling) - same contract as feature date\",\n",
-    "    \"exit\": \"t+1+h mid (buying to close) - same contract looked up in raw chain\",\n",
-    "    \"pricing\": \"mid-to-mid (execution costs deferred to Ch18)\",\n",
-    "    \"hedging\": \"delta-hedged using held contract's delta path (not constant-maturity)\",\n",
-    "}\n",
-    "results_diagnostics = {\n",
-    "    \"horizons\": list(FORWARD_HORIZONS),\n",
-    "    \"n_cv_splits\": _cv_config_dict[\"n_splits\"],\n",
-    "    \"straddle_coverage\": f\"{primary['symbol'].n_unique()} symbols\",\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1604961b",
-   "metadata": {},
-   "source": [
-    "The final record combines stable metadata with the current baseline estimate\n",
-    "and its overlap-aware uncertainty fields."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "0b7b53ca",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-21T06:55:12.506350Z",
-     "iopub.status.busy": "2026-07-21T06:55:12.506264Z",
-     "iopub.status.idle": "2026-07-21T06:55:12.511709Z",
-     "shell.execute_reply": "2026-07-21T06:55:12.511172Z"
-    },
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "results = {\n",
-    "    \"case_study_id\": STRATEGY_ID,\n",
-    "    \"chapter\": 7,\n",
-    "    \"stage\": \"labels\",\n",
-    "    \"timestamp\": datetime.now(UTC).isoformat(),\n",
-    "    \"git_commit\": _git_commit_hash(),\n",
-    "    \"notebook\": f\"case_studies/{STRATEGY_ID}/02_labels.py\",\n",
-    "    \"data_version\": \"v2_matched_strike_same_contract\",\n",
-    "    \"summary\": results_summary,\n",
-    "    \"techniques\": results_techniques,\n",
-    "    \"diagnostics\": results_diagnostics,\n",
-    "    \"key_findings\": [\n",
-    "        f\"Hold-to-expiry mean return: {float(primary[y_col].mean()):.4f}\",\n",
-    "        f\"Hit rate: {hit_rate:.1%} of trades profitable\",\n",
-    "        f\"Label std: {float(primary[y_col].std()):.4f}\",\n",
-    "        \"Same-contract returns (v2) - no contract-roll contamination\",\n",
-    "        f\"Baseline VRP IC: {baseline_ic_mean:.4f} (HAC t={baseline_ic_tstat:.2f})\",\n",
-    "    ],\n",
-    "    \"baseline_ic\": {\n",
-    "        \"signal\": \"vrp_proxy\",\n",
-    "        \"mean_ic\": baseline_ic_mean,\n",
-    "        \"t_stat\": baseline_ic_tstat,\n",
-    "        \"p_value\": baseline_ic_pvalue,\n",
-    "        \"hac_lags\": baseline_ic_lags,\n",
-    "    },\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0057a607",
-   "metadata": {
-   },
-   "source": [
-    "## Key Takeaways\n",
+    "## Key takeaways\n",
     "\n",
-    "1. **Primary label is `ret_to_expiry`** (hold-to-expiry): the short straddle is\n",
-    "   held to its natural expiration and settles at intrinsic value, eliminating\n",
-    "   the exit-leg bid-ask cost. DTE at entry is tight (25–35 days) so no\n",
-    "   variable-horizon normalization is needed. Every downstream model in this case\n",
-    "   study trains on this label; it is the pedagogical anchor for the O'Donovan-Yu\n",
-    "   cost-mitigation cascade in Ch18.\n",
+    "1. **On an option panel, a forward return is a round trip in one contract, not a shift of\n",
+    "   a price column.** The 30-day at-the-money row is a different instrument every session,\n",
+    "   so a shifted difference reports the change of contract as profit. Look the held\n",
+    "   contract up in the raw chain instead.\n",
+    "2. **Reconcile every unlabelled row to one cause.** A missing quote at exit, a premium\n",
+    "   that was never quoted, a hedge path with a hole in it and an expiration past the end\n",
+    "   of the price panel all fail without raising, and a reconciliation that has to balance\n",
+    "   catches what a row count passed over does not.\n",
+    "3. **Seal a diagnostic on the date the position settles.** When the settlement date is\n",
+    "   written into the contract rather than fixed at a number of sessions, that date is the\n",
+    "   boundary - a trade opened before the holdout and expiring inside it is a holdout trade.\n",
+    "4. **A row count overstates the evidence when holding windows overlap.** The effective\n",
+    "   count says by how much in rows, and the same overlap priced into a standard error is\n",
+    "   what turns a t-statistic that reads as decisive into one that cannot be separated from\n",
+    "   zero.\n",
+    "5. **Check the sign of a baseline before assuming its size is the question.** The variance\n",
+    "   risk premium points the opposite way to the hypothesis on this universe, which is a\n",
+    "   fact about the cross-section that a mean-level argument about the premium would miss.\n",
     "\n",
-    "2. **Same-contract returns** (v2): Labels use the actual held contract's exit\n",
-    "   price from the raw option chain, not shift-based returns that mix contracts.\n",
-    "   Force-rebuilding the artifacts from the raw chain reproduces them exactly.\n",
+    "**Known limitations.** Mid-to-mid pricing is not what a trader receives; the entry\n",
+    "half-spread and the commission are swept in `14_costs.py`, and the primary label avoids\n",
+    "the exit half-spread only because cash settlement needs no closing trade. The delta hedge\n",
+    "is rebalanced at the close and charges nothing for doing so. The universe is every name\n",
+    "with a quoted matched-strike straddle, with the liquidity screen applied downstream rather\n",
+    "than here. The baseline is one signal, on one month of realised volatility.\n",
     "\n",
-    "3. **Diagnostic horizon variants**: the 5- and 10-day mid-to-mid, executable,\n",
-    "   and delta-hedged returns are also built to expose the pricing and hedging\n",
-    "   mechanics. Delta hedging (held contract's delta path) tightens the return\n",
-    "   distribution by removing directional P&L. These variants are not modelled.\n",
-    "\n",
-    "4. **Mid-to-mid vs executable**: mid-to-mid pricing measures the economic signal\n",
-    "   (10-day mean +5.7%); the executable label (sell at bid, buy back at ask) bakes\n",
-    "   in the full round-trip spread and the same unconditional return falls to\n",
-    "   -9.6%. This single-stock-option microstructure is exactly what `ret_to_expiry`\n",
-    "   and the Ch18 cost cascade address.\n",
-    "\n",
-    "5. **Baseline floor**: the naive VRP proxy ($IV_{atm} - RV_{21d}$) has a small\n",
-    "   *negative* rank IC against `ret_to_expiry` on the pre-2021 CV window, but\n",
-    "   the estimate is not statistically resolved after horizon-aware HAC\n",
-    "   adjustment. Its realized-volatility leg uses split-adjusted closes, so\n",
-    "   engineered features must do more than replay the raw premium to add value.\n",
-    "\n",
-    "**Next**: [`03_financial_features`](03_financial_features.ipynb) builds VRP, surface dynamics, and instrument\n",
-    "state features for predicting which straddles to sell."
+    "**Next**: `03_financial_features.py` builds the volatility-surface, term-structure and\n",
+    "instrument-state features and evaluates them against these labels."
    ]
   }
  ],
  "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "tags,-all"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -1608,11 +1443,11 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-07-21T06:55:23.972616+00:00",
-   "executor": "nbconvert",
-   "parameters": {},
+   "source_py_blob": "dccb6dde18b9d2f798b48f17bac2dff5c892e57b",
+   "executed_at": "2026-07-31T07:13:45.592039+00:00",
+   "executor": "local-uv",
    "production": true,
-   "source_py_blob": "16730d850bc97e72ac710a4474892238ce8061c8"
+   "parameters": {}
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/sp500_options/02_labels.py
+++ b/case_studies/sp500_options/02_labels.py
@@ -1,6 +1,7 @@
 # ---
 # jupyter:
 #   jupytext:
+#     cell_metadata_filter: tags,-all
 #     text_representation:
 #       extension: .py
 #       format_name: percent
@@ -15,728 +16,766 @@
 # %% [markdown]
 # # S&P 500 Options: Label Engineering
 #
-# This notebook constructs labels for the S&P 500 Options case study using
-# **same-contract returns** built directly from the slim daily straddle panel
-# and the slim lifecycle-preserving raw straddle slice. Labels are short straddle
-# returns: sell a 30D ATM straddle at mid, buy back the **same contract** at mid
-# after h days. Positive return = profitable short vol position before costs.
+# The label is a short straddle's return, and an option position is not a share position:
+# the thing sold at entry has to be the thing bought back at exit, and it stops existing
+# on a date fixed when it is sold. This notebook writes that convention down as a formula,
+# proves each labelled trade has a complete round trip inside one contract, measures how
+# much independent information overlapping trades carry, establishes the floor a feature
+# has to clear, and writes the files stage 03 reads.
 #
-# **Learning Objectives**:
-# - Construct instrument-level labels from same-contract exit prices
-# - Implement delta-hedged returns using the held contract's delta path
-# - Generate walk-forward CV splits with a buffer that spans the ~30-day horizon
-# - Establish a VRP baseline IC that engineered features must beat
+# ## Learning objectives
 #
-# **Book Reference**: Chapter 7, Section 7.2 (Label Engineering)
+# - Express an option label as a round trip in one contract, and say what each leg costs
+# - Assert - rather than describe - that every labelled window closes on a real quote
+# - Seal a diagnostic on the date a position settles, not the date it is opened, when the
+#   settlement date is a property of the contract rather than a fixed offset
+# - Price the overlap in a label held for a month and sampled every session
+# - Establish the floor a feature has to clear, under a standard error that prices in that
+#   overlap
 #
-# **Prerequisites**: [`01_feasibility_analysis`](01_feasibility_analysis.ipynb)
+# ## Book reference, prerequisites and artifacts
 #
-# **Primary label**: `ret_to_expiry` - the hold-to-expiry (HTM) short-straddle
-# return declared in `setup.yaml::labels.primary`. Every downstream model in this
-# case study trains on it. The horizon-based variants (`fwd_ret_{5,10}d`, their
-# delta-hedged and executable counterparts) are also built here to characterise
-# the pricing and hedging mechanics, but they are diagnostic, not modelled.
+# Chapter 7, Section 7.2. Reads the daily matched-strike straddle panel and the raw option
+# chain through `load_sp500_options_straddles()` and `load_sp500_options_straddles_raw()`,
+# whose coverage [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) establishes,
+# the underlying closes through `load_sp500_daily_bars()`, and `config/setup.yaml`, which
+# declares the label set, the cross-validation buffer and the holdout boundary.
 #
-# **Pricing Convention**: Mid-to-mid labels measure the economic signal.
-# Executable labels (sell at bid, close at ask) bake in the per-contract
-# bid-ask spread and reveal that the unconditional 10-day short straddle return
-# falls to **-9.6%** per trade, even though its mid-to-mid counterpart is +5.7%.
-# The exit-leg spread is what `ret_to_expiry` avoids: cash settlement at
-# expiration converts the option to intrinsic value with no market exit. Whether
-# ML selection plus the O'Donovan-Yu cost-mitigation cascade turns this into a
-# viable strategy is the subject of Chapter 18 (Section 18.8), not this notebook.
+# Writes five label files - `labels/ret_to_expiry.parquet`, `labels/fwd_ret_5d.parquet`,
+# `labels/fwd_ret_10d.parquet`, `labels/fwd_ret_dh_5d.parquet` and
+# `labels/fwd_ret_dh_10d.parquet` - each with a `.digest.json` sidecar beside it.
+# `03_financial_features.py` reads the primary and `fwd_ret_dh_10d`, `05_evaluation.py`
+# reads `fwd_ret_dh_10d`, and `90_ic_diagnostic.py` reads `fwd_ret_10d` and
+# `fwd_ret_dh_10d`. The two intermediate frames the labels are built from,
+# `labels/contract_returns.parquet` and `labels/hedge_path.parquet`, are produced by
+# `_label_artifacts.py`, which exists because the round trip below is not a shift.
 
 # %%
-"""S&P 500 Options: Label Engineering - Same-Contract Short Straddle Returns."""
+"""S&P 500 Options: Label Engineering."""
 
-import json
-import subprocess
 import warnings
-from datetime import UTC, datetime
+from datetime import date
 
+import matplotlib.pyplot as plt
 import numpy as np
-import plotly.graph_objects as go
 import polars as pl
-from ml4t.diagnostic.metrics import compute_ic_hac_stats
-from plotly.subplots import make_subplots
-from scipy.stats import spearmanr
+import yaml
+from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series
 
-from case_studies.sp500_options._label_artifacts import ensure_label_artifacts
+from case_studies.sp500_options._label_artifacts import accrued_hedge_pnl, ensure_label_artifacts
 from case_studies.sp500_options._underlying_returns import reconcile_underlying_log_returns
+from case_studies.utils.artifact_digest import value_digest, write_artifact
+from case_studies.utils.label_diagnostics import effective_sample_size, panel_autocorrelation
 from data import load_sp500_daily_bars, load_sp500_options_straddles
-from utils.cv_splits import load_evaluation_config
+from utils.artifact_specs import resolve_label_horizon
 from utils.paths import get_case_study_dir
-from utils.style import COLORS  # registers the ml4t Plotly template on import
+from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt
 
 warnings.filterwarnings("ignore")
 
-# %% tags=["parameters"]
-START_DATE = None  # None = use full dataset
-
-# %%
-CASE_DIR = get_case_study_dir("sp500_options")
+CASE_STUDY_ID = "sp500_options"
+CASE_DIR = get_case_study_dir(CASE_STUDY_ID)
 LABELS_DIR = CASE_DIR / "labels"
 
-STRATEGY_ID = "sp500_options"
+# %% [markdown]
+# Both parameters are unset by default, and both are read below - they reach the artifact
+# builder rather than the frames it returns, because the builder caches its output and a
+# window applied after the fact would leave the cached full panel in place. `START_DATE`
+# trims the history to a later start; `MAX_SYMBOLS` keeps the most-quoted symbols only.
+# Either one shortens a run at the cost of a thinner panel: the rank correlation in Section
+# G and the cross-sectional dispersion in Section E both need a wide cross-section on each
+# session to mean anything.
+
+# %% tags=["parameters"]
+MAX_SYMBOLS = 0
+START_DATE = None
+
+# %% [markdown]
+# ## Configuration
+#
+# Everything that defines a label is declared in `config/setup.yaml` and bound here. A
+# horizon or a boundary typed into a cell is a second copy of a value the rest of the
+# pipeline reads from the file, and the two drift apart the first time either is edited.
+#
+# The primary label and the four diagnostic variants are declared separately, and the
+# distinction is what they are for rather than how they are built: models train on
+# `ret_to_expiry`, while the fixed-horizon variants exist to show what the same trade earns
+# when it is closed early and when its directional exposure is hedged away. `labels.buffer`
+# is the gap that keeps a training fold independent of the validation fold after it, and
+# `generate_cv_splits` takes it separately from the horizon an outcome resolves over -
+# here they are different quantities, and Section H prints both.
+
+# %%
+setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
+
+PRIMARY_LABEL = setup["labels"]["primary"]
+VARIANT_LABELS = list(setup["labels"]["variant_buffers"])
+LABEL_NAMES = [PRIMARY_LABEL, *VARIANT_LABELS]
+HORIZONS = {
+    name: int(resolve_label_horizon(CASE_STUDY_ID, name, setup).rstrip("Dd"))
+    for name in VARIANT_LABELS
+}
+LABEL_BUFFER = setup["labels"]["buffer"]
+HOLDOUT_START = date.fromisoformat(setup["evaluation"]["holdout_start"])
 INSTRUMENT_ID = "straddle_30d_atm"
-FORWARD_HORIZONS = (5, 10)
+
+# One style per label, shared by every figure: the primary in the focal colour, each
+# fixed-horizon family in its own, and the delta-hedged member of a family dashed.
+SHORT = min(HORIZONS.values(), default=0)
+STYLES = {
+    name: dict(
+        color=COLORS["blue"]
+        if name == PRIMARY_LABEL
+        else COLORS["amber" if HORIZONS[name] == SHORT else "copper"],
+        linestyle="--" if "_dh_" in name else "-",
+        lw=2.2 if name == PRIMARY_LABEL else 1.4,
+    )
+    for name in LABEL_NAMES
+}
+
+print(f"Primary {PRIMARY_LABEL}; diagnostic variants {HORIZONS} sessions")
+print(f"Cross-validation buffer {LABEL_BUFFER}; holdout opens {HOLDOUT_START}")
 
 # %% [markdown]
-# ## 1. Build and Load Same-Contract Returns
+# ## A. The learning task
 #
-# The slim reader dataset already includes the inputs needed for same-contract
-# label construction:
+# The hypothesis is that an option's implied volatility is, on average, above the volatility
+# the underlying goes on to realise, and that the excess is not uniform across the S&P 500:
+# some names are priced further above their own subsequent moves than others. Selling a
+# straddle - one call and one put at the same strike and expiration - is the position that
+# earns that difference and is close to neutral on direction at the moment it is opened. The
+# label is therefore the return on a short straddle held over a fixed window, ranked across
+# names rather than judged in isolation, and the strategy that consumes it sells the names
+# it ranks highest.
 #
-# - `options_straddles_daily.parquet`
-# - `options_straddles_raw/year=*.parquet`
+# The decision cadence comes from `setup.yaml`: a Friday close is observed and the position
+# is opened at the next session's open, on a straddle written about a month out. That fixes
+# the primary label's outcome: the position is carried to expiration and settles into cash
+# at whatever the underlying is worth that day. Labels are sampled every session rather than
+# only on Fridays - that buys five times the rows at the price of overlapping trades, and
+# Section F measures what they are worth.
+
+# %% [markdown]
+# ## B. Preparation before the label
 #
-# We build the persisted same-contract artifacts from those inputs here, then
-# read them for the downstream label calculations.
+# **A forward return on an option is a round trip in one contract, and that is the mistake
+# this dataset invites.** The daily panel carries a 30-day at-the-money straddle for each
+# name on each session, but the contract behind that row changes as the calendar moves: the
+# thing that is 30 days out today is 29 days out tomorrow, so tomorrow's row is a different
+# strike and often a different expiration. Shifting the panel's price column forward would
+# difference two prices from two different contracts and report the change of instrument as
+# profit. What the label needs instead is the price of *today's* contract on a later date,
+# which only the raw chain holds, so `_label_artifacts.py` looks each held contract up by
+# `(symbol, strike, expiration)` and returns the entry premium, the exit premium at each
+# horizon, and the contract's own delta on each day it is held.
+#
+# The entity a label may not cross is that contract. Entry is at the session after the
+# signal, so the whole window sits strictly in the future of the row that carries it, and no
+# eligibility filter runs before the label is built: dropping rows first would make a
+# forward offset count survivors rather than sessions, and the window would silently span
+# whatever was removed. Point-in-time liquidity screening is applied downstream, where
+# `setup.yaml: backtest.sweep.universe_filter` declares it.
 
 # %%
-artifact_paths = ensure_label_artifacts()
+ensure_label_artifacts(max_symbols=MAX_SYMBOLS, start_date=START_DATE)
 contract_returns = pl.read_parquet(LABELS_DIR / "contract_returns.parquet")
-print(f"Contract returns: {len(contract_returns):,} entries")
-print(f"  Symbols: {contract_returns['symbol'].n_unique()}")
-print(
-    f"  Date range: {contract_returns['feature_date'].min()} to {contract_returns['feature_date'].max()}"
-)
-
-for h in FORWARD_HORIZONS:
-    found = contract_returns[f"exit_found_{h}d"].sum()
-    total = len(contract_returns)
-    print(f"  Exit {h}d coverage: {found:,}/{total:,} ({found / total:.1%})")
-
-# %% [markdown]
-# ## 2. Unhedged Short Straddle Labels
-#
-# The unhedged label uses the same-contract mid-to-mid return directly from
-# the same-contract artifact builder. No additional computation needed - just filter to valid
-# exits and format for downstream consumption.
-#
-# $$r_{short} = \frac{(C_{entry} + P_{entry}) - (C_{exit} + P_{exit})}{C_{entry} + P_{entry}}$$
-
-# %%
-unhedged_labels = {}
-for h in FORWARD_HORIZONS:
-    label_col = f"fwd_ret_{h}d"
-    lbl = (
-        contract_returns.filter(pl.col(f"exit_found_{h}d"))
-        .select(
-            [
-                pl.col("feature_date").alias("timestamp"),
-                "symbol",
-                pl.lit(INSTRUMENT_ID).alias("instrument_id"),
-                label_col,
-            ]
-        )
-        .drop_nulls(subset=[label_col])
-    )
-    unhedged_labels[label_col] = lbl
-    stats = lbl[label_col]
-    print(
-        f"{label_col}: {len(lbl):,} rows, "
-        f"mean={stats.mean():.4f}, std={stats.std():.4f}, median={stats.median():.4f}"
-    )
-
-# %% [markdown]
-# ## 2b. Executable Short Straddle Labels (Bid/Ask)
-#
-# The mid-to-mid labels measure the economic signal. The **executable** labels
-# measure what a trader actually receives: sell at bid (entry), buy back at ask
-# (exit). The difference is the full bid-ask spread - the dominant cost for
-# single-stock options (~11% of premium round-trip).
-#
-# $$r_{exec} = \frac{(C_{bid}^{entry} + P_{bid}^{entry}) - (C_{ask}^{exit} + P_{ask}^{exit})}{C_{bid}^{entry} + P_{bid}^{entry}}$$
-
-# %%
-exec_labels = {}
-for h in FORWARD_HORIZONS:
-    label_col = f"fwd_ret_exec_{h}d"
-    valid = contract_returns.filter(pl.col(f"exit_found_{h}d"))
-    lbl = (
-        valid.with_columns(
-            (pl.col("entry_call_bid") + pl.col("entry_put_bid")).alias("_entry_bid"),
-            (pl.col(f"exit_call_{h}d_ask") + pl.col(f"exit_put_{h}d_ask")).alias("_exit_ask"),
-        )
-        .with_columns(
-            ((pl.col("_entry_bid") - pl.col("_exit_ask")) / pl.col("_entry_bid")).alias(label_col)
-        )
-        .select(
-            [
-                pl.col("feature_date").alias("timestamp"),
-                "symbol",
-                pl.lit(INSTRUMENT_ID).alias("instrument_id"),
-                label_col,
-            ]
-        )
-        .drop_nulls(subset=[label_col])
-    )
-    exec_labels[label_col] = lbl
-    stats = lbl[label_col]
-    print(
-        f"{label_col}: {len(lbl):,} rows, "
-        f"mean={stats.mean():.4f}, std={stats.std():.4f}, "
-        f"hit_rate={(stats > 0).mean():.1%}"
-    )
-
-# %% [markdown]
-# The executable returns are substantially lower than mid-to-mid because the
-# full bid-ask spread is baked into entry and exit prices. The unconditional
-# executable return is negative - the average straddle is unprofitable after
-# spreads. The ML model's value is selecting the subset that remains profitable.
-
-# %% [markdown]
-# ## 3. Delta-Hedged Short Straddle Labels
-#
-# The delta-hedged variant isolates the volatility bet by removing directional
-# exposure. We use the **held contract's** delta path from the same-contract artifacts,
-# not the constant-maturity delta that jumps between contracts daily.
-#
-# $$r_{dh} = r_{short} + \sum_{d=0}^{h-1} \Delta_d \cdot \frac{S_{d+1} - S_d}{P_{entry}}$$
-#
-# where $\Delta_d$ is the held contract's net delta on holding day $d$,
-# and $S_d$ is the underlying price.
-
-# %%
 hedge_path = pl.read_parquet(LABELS_DIR / "hedge_path.parquet")
-print(f"Hedge path: {len(hedge_path):,} rows")
-
-# %%
-# Compute daily underlying price changes along each holding path
-hedge_sorted = hedge_path.sort(["symbol", "feature_date", "holding_day"])
-
-# dS at each holding day: S[d] - S[d-1]
-hedge_sorted = hedge_sorted.with_columns(
-    (
-        pl.col("underlying_price")
-        - pl.col("underlying_price").shift(1).over(["symbol", "feature_date"])
-    ).alias("dS")
-)
-
-# Hedge P&L each day: delta[d-1] * dS[d] (hedge established at previous close)
-# For d=0, no dS (it's the entry day), so dS is null and excluded
-hedge_sorted = hedge_sorted.with_columns(
-    (pl.col("instr_delta").shift(1).over(["symbol", "feature_date"]) * pl.col("dS")).alias(
-        "daily_hedge_pnl"
-    )
-)
-
-# %%
-# Accumulate daily hedge P&L over each horizon before joining the option return.
-hedge_pnl_by_horizon = {}
-for h in FORWARD_HORIZONS:
-    hedge_pnl_by_horizon[h] = (
-        hedge_sorted.filter((pl.col("holding_day") >= 1) & (pl.col("holding_day") <= h))
-        .group_by(["feature_date", "symbol"])
-        .agg(pl.col("daily_hedge_pnl").sum().alias("hedge_pnl"))
-    )
-
-
-# %% [markdown]
-# Each horizon now combines the accumulated hedge P&L with its same-contract
-# option return and scales the hedge by the entry premium.
-
-# %%
-dh_labels = {}
-for h in FORWARD_HORIZONS:
-    label_col = f"fwd_ret_dh_{h}d"
-    dh = (
-        contract_returns.filter(pl.col(f"exit_found_{h}d"))
-        .select(
-            [
-                "feature_date",
-                "symbol",
-                f"fwd_ret_{h}d",
-                "entry_straddle_mid",
-            ]
-        )
-        .join(hedge_pnl_by_horizon[h], on=["feature_date", "symbol"], how="left")
-        .with_columns(
-            (
-                pl.col(f"fwd_ret_{h}d")
-                + pl.col("hedge_pnl").fill_null(0) / pl.col("entry_straddle_mid")
-            ).alias(label_col)
-        )
-    )
-
-    lbl = dh.select(
-        [
-            pl.col("feature_date").alias("timestamp"),
-            "symbol",
-            pl.lit(INSTRUMENT_ID).alias("instrument_id"),
-            label_col,
-        ]
-    ).drop_nulls(subset=[label_col])
-
-    dh_labels[label_col] = lbl
-    stats = lbl[label_col]
-    print(
-        f"{label_col}: {len(lbl):,} rows, "
-        f"mean={stats.mean():.4f}, std={stats.std():.4f}, median={stats.median():.4f}"
-    )
-
-# %% [markdown]
-# ## 3c. Hold-to-Expiry Short Straddle Label
-#
-# The horizon-based labels above close the position at $t + h$ days and pay the
-# full exit bid-ask spread. The **hold-to-expiry** (HTM) variant avoids the exit
-# spread entirely: cash settlement at expiration converts the option to
-# intrinsic value without any market transaction.
-#
-# $$r_{\text{htm}} = \frac{P_{\text{entry}} - |S_T - K|}{P_{\text{entry}}}$$
-#
-# where $S_T$ is the underlying close on the expiration date and $K$ is the
-# strike. Sign convention matches the other labels in this notebook: positive =
-# profitable short straddle. Verified on row (symbol=A, $K=50$, $S_T=51.63$,
-# $P_{\text{entry}}=3.60$): intrinsic $=1.63$, $r_{\text{htm}}=+54.7\%$.
-# Settlement uses the unadjusted historical close because the listed strike and
-# expiration spot are expressed in the same contemporaneous price basis.
-#
-# Days-to-expiry is tight by design (25–35 calendar days, mean 30, std 2.6),
-# so no per-day normalization. We add DTE as a feature in `03_financial_features`.
-#
-# This label grounds the cost-mitigation cascade introduced by O'Donovan & Yu
-# (2025): under conservative option transaction costs, HTM recovers 3 of 17
-# single-name option anomalies that fail at fixed holding periods.
-
-# %%
-underlying_close = load_sp500_daily_bars().select(
-    [
-        pl.col("symbol"),
-        pl.col("timestamp").alias("expiration"),
-        pl.col("close").alias("underlying_close_at_expiry"),
-    ]
-)
-
-htm_label = (
-    contract_returns.join(underlying_close, on=["symbol", "expiration"], how="inner")
-    .with_columns(
-        (pl.col("underlying_close_at_expiry") - pl.col("strike"))
-        .abs()
-        .alias("intrinsic_at_expiry"),
-        ((pl.col("expiration") - pl.col("feature_date")).dt.total_days()).alias("dte_calendar"),
-    )
-    .with_columns(
-        (
-            (pl.col("entry_straddle_mid") - pl.col("intrinsic_at_expiry"))
-            / pl.col("entry_straddle_mid")
-        ).alias("ret_to_expiry")
-    )
-    .select(
-        [
-            pl.col("feature_date").alias("timestamp"),
-            "symbol",
-            pl.lit(INSTRUMENT_ID).alias("instrument_id"),
-            "ret_to_expiry",
-            pl.col("dte_calendar").cast(pl.Int32),
-        ]
-    )
-    .drop_nulls(subset=["ret_to_expiry"])
-)
-
-htm_labels = {"ret_to_expiry": htm_label}
-
-
-# %% [markdown]
-# The summary confirms the available expiration coverage and the label's
-# return and horizon distribution.
-
-# %%
-_htm_dropped = len(contract_returns) - len(htm_label)
-_ret_htm = htm_label["ret_to_expiry"]
-print(
-    f"ret_to_expiry: {len(htm_label):,} rows "
-    f"(dropped {_htm_dropped:,} for expirations beyond underlying bars range)"
-)
-print(
-    f"  mean={_ret_htm.mean():.4f}, std={_ret_htm.std():.4f}, "
-    f"median={_ret_htm.median():.4f}, hit_rate={(_ret_htm > 0).mean():.1%}"
-)
-print(
-    f"  dte_calendar: min={htm_label['dte_calendar'].min()}, "
-    f"max={htm_label['dte_calendar'].max()}, "
-    f"mean={htm_label['dte_calendar'].mean():.1f}"
-)
-
-# %% [markdown]
-# ## 4. Label Quality Diagnostics
-#
-# Check distributions and the fraction of profitable trades.
-
-# %%
-_all_labels = {**unhedged_labels, **dh_labels, **exec_labels, **htm_labels}
-# The modelled label is the hold-to-expiry return (setup.yaml::labels.primary);
-# the diagnostics below characterise it, not the horizon-based variants.
-_primary_name = "ret_to_expiry"
-primary = _all_labels[_primary_name]
-y_col = _primary_name
-
-n_total = len(primary)
-n_positive = primary.filter(pl.col(y_col) > 0).height
-hit_rate = n_positive / n_total if n_total > 0 else 0
-
-print(f"Primary label: {y_col}")
-print(f"  Observations: {n_total:,}")
-print(f"  Mean: {primary[y_col].mean():.4f}")
-print(f"  Std: {primary[y_col].std():.4f}")
-print(f"  Hit rate (positive): {hit_rate:.1%}")
-
-# %% [markdown]
-# ### Delta hedging narrows 10-day returns
-#
-# Hold-to-expiry outcomes retain a pronounced loss tail, while delta hedging
-# concentrates the 10-day distribution by removing directional P&L.
-
-# %%
-fig = make_subplots(
-    rows=1,
-    cols=2,
-    horizontal_spacing=0.13,
-    subplot_titles=["Hold-to-Expiry (primary label)", "10-Day: hedged vs unhedged"],
-)
-
-htm_edges = np.arange(-3.0, 3.1, 0.1)
-htm_counts, _ = np.histogram(primary[y_col].to_numpy(), bins=htm_edges)
-htm_centers = (htm_edges[:-1] + htm_edges[1:]) / 2
-fig.add_trace(
-    go.Bar(
-        x=htm_centers,
-        y=htm_counts,
-        width=0.1,
-        marker_color=COLORS["blue"],
-        opacity=0.85,
-        name="ret_to_expiry",
-    ),
-    row=1,
-    col=1,
-)
-_ = fig.add_vline(x=0, line_dash="dash", line_color=COLORS["negative"], row=1, col=1)
-# %% [markdown]
-# The 10-day panel overlays unhedged and held-contract delta-hedged outcomes
-# using identical bins and limits for a direct dispersion comparison.
-
-# %%
-uh_10d = unhedged_labels["fwd_ret_10d"]["fwd_ret_10d"]
-dh_10d = dh_labels["fwd_ret_dh_10d"]["fwd_ret_dh_10d"]
-ten_day_edges = np.arange(-1.5, 1.55, 0.05)
-uh_counts, _ = np.histogram(uh_10d.to_numpy(), bins=ten_day_edges)
-dh_counts, _ = np.histogram(dh_10d.to_numpy(), bins=ten_day_edges)
-ten_day_centers = (ten_day_edges[:-1] + ten_day_edges[1:]) / 2
-fig.add_trace(
-    go.Bar(
-        x=ten_day_centers,
-        y=uh_counts,
-        width=0.05,
-        opacity=0.55,
-        marker_color=COLORS["amber"],
-        name="unhedged_10d",
-    ),
-    row=1,
-    col=2,
-)
-fig.add_trace(
-    go.Bar(
-        x=ten_day_centers,
-        y=dh_counts,
-        width=0.05,
-        opacity=0.55,
-        marker_color=COLORS["blue"],
-        name="dh_10d",
-    ),
-    row=1,
-    col=2,
-)
-_ = fig.add_vline(x=0, line_dash="dash", line_color=COLORS["negative"], row=1, col=2)
-# %% [markdown]
-# Both panels focus on their central mass. The rendered note states the exact
-# displayed ranges so the omitted extreme tails remain explicit to readers.
-
-# %%
-fig.update_layout(
-    template="ml4t",
-    height=470,
-    barmode="overlay",
-    title="Delta hedging narrows 10-day returns while HTM retains a loss tail",
-    margin=dict(b=105),
-)
-fig.update_xaxes(title_text="Return (fraction of entry premium)", range=[-3, 3], row=1, col=1)
-fig.update_xaxes(title_text="Return (fraction of entry premium)", range=[-1.5, 1.5], row=1, col=2)
-fig.update_yaxes(title_text="Count", row=1, col=1)
-fig.update_yaxes(title_text="Count", row=1, col=2)
-fig.add_annotation(
-    text="Displayed ranges truncate HTM outside [-3, 3] and 10-day returns outside [-1.5, 1.5].",
-    x=0.5,
-    y=-0.28,
-    xref="paper",
-    yref="paper",
-    showarrow=False,
-    font=dict(color=COLORS["neutral"], size=11),
-)
-fig.show()
-
-# %% [markdown]
-# ### Label Autocorrelation
-#
-# The ~30-day hold-to-expiry horizon on daily data creates heavily overlapping
-# returns (consecutive entry dates share most of their holding window). This is
-# why `setup.yaml::labels.buffer` is 35D - the CV purge/embargo must span the
-# full label horizon to keep training and validation windows independent.
-
-# %%
-max_lag = 20
-lag_acf = {}
-for lag in range(1, max_lag + 1):
-    acf_by_sym = []
-    for sym in primary["symbol"].unique().to_list():
-        sym_data = primary.filter(pl.col("symbol") == sym).sort("timestamp")
-        y = sym_data[y_col].to_numpy()
-        if len(y) > lag + 10:
-            corr, _ = spearmanr(y[:-lag], y[lag:])
-            if np.isfinite(corr):
-                acf_by_sym.append(corr)
-    if acf_by_sym:
-        lag_acf[lag] = float(np.mean(acf_by_sym))
-
-print("Label autocorrelation (avg across symbols):")
-for lag, acf in lag_acf.items():
-    marker = " ***" if lag <= 2 else ""
-    print(f"  Lag {lag:2d}: {acf:+.3f}{marker}")
-
-# Effective sample size
-_acf_vals = [v for v in lag_acf.values() if v > 0]
-_n_eff_denom = 1 + 2 * sum(_acf_vals)
-n_eff = int(n_total / _n_eff_denom)
-print(f"\nEffective sample size: N_eff = {n_eff:,} (N/{_n_eff_denom:.1f})")
-
-# %% [markdown]
-# ### Baseline IC: VRP Proxy
-#
-# The simplest VRP proxy ($IV_{atm} - RV_{21d}$) is the naive predictor of the
-# short-straddle return. Its rank IC against `ret_to_expiry` sets the floor that
-# engineered features must beat. **The floor is measured on the pre-2021
-# cross-validation window only** (`setup.yaml::evaluation.holdout_start`), so the
-# 2021 holdout stays sealed against every quantity used to motivate feature work.
-# Realized volatility uses split-adjusted closes within stable `sec_id`
-# segments. Returns are null at identity changes, so an adjustment-factor reset
-# cannot masquerade as a market move. The hold-to-expiry label spans roughly 21
-# trading days, so inference uses a 20-lag Newey-West adjustment.
-
-# %%
 straddles = load_sp500_options_straddles()
 underlying = load_sp500_daily_bars()
-underlying_rv = (
+
+# Recorded as each label's `inputs`: a re-run against a refreshed download is otherwise
+# indistinguishable from this one.
+CONTRACT_DIGEST = value_digest(contract_returns)
+HEDGE_DIGEST = value_digest(hedge_path)
+MARKET_DATA_DIGEST = value_digest(underlying, ["symbol", "timestamp", "close"])
+
+signals = contract_returns["feature_date"]
+print(
+    f"{contract_returns.height:,} round trips on {contract_returns['symbol'].n_unique()} names, "
+    f"signalled {signals.min()} to {signals.max()}\nDigests - contract_returns "
+    f"{CONTRACT_DIGEST}, hedge_path {HEDGE_DIGEST}, market_data {MARKET_DATA_DIGEST}"
+)
+
+# %% [markdown]
+# Every window below is counted on the straddle panel's own session calendar, numbered once
+# here on the source panel rather than on the rows that survive to a label. A name is quoted
+# on roughly half the sessions in this panel, so counting positions among surviving rows
+# would make the two rows either side of a gap adjacent and report windows that share
+# nothing as overlapping.
+
+# %%
+calendar = straddles.select("timestamp").unique().sort("timestamp").with_row_index("_bar")
+N_SESSIONS = calendar.height
+# Entry is the session after the signal, so a horizon-h trade closes h+1 sessions out.
+calendar = calendar.with_columns(
+    (N_SESSIONS - 1 - pl.col("_bar")).alias("from_end"),
+    *(
+        pl.col("timestamp").shift(-horizon - 1).alias(f"_end_{horizon}d")
+        for horizon in set(HORIZONS.values())
+    ),
+)
+
+panel = contract_returns.rename({"feature_date": "timestamp"}).join(
+    calendar, on="timestamp", how="left"
+)
+print(f"{N_SESSIONS:,} panel sessions; {panel['timestamp'].n_unique():,} carry a signal")
+
+# %% [markdown]
+# ## C. Label construction
+#
+# One execution convention, written once. A straddle sold at $t{+}1$ for the premium
+# $P_{t+1} = C_{t+1} + Q_{t+1}$ and bought back $h$ sessions later at $P_{t+1+h}$, with both
+# prices taken at the mid of the *same* contract, returns
+#
+# $$r^{(h)}_{i,t} = \frac{P_{i,t+1} - P_{i,t+1+h}}{P_{i,t+1}}$$
+#
+# for contract $i$. The sign convention is the seller's throughout: a positive number is a
+# profitable short straddle. The denominator is the premium collected, so the label is
+# already a return on the capital the trade puts at risk and needs no further scaling.
+#
+# The delta-hedged variant subtracts the directional part of that P&L. Holding the straddle
+# leaves a residual exposure $\Delta_d$ to the underlying that changes every day, so the
+# hedge is rebalanced at each close along the path the contract actually took:
+#
+# $$r^{(h),\text{dh}}_{i,t} = r^{(h)}_{i,t}
+#   + \frac{1}{P_{i,t+1}}\sum_{d=1}^{h} \Delta_{i,d-1}\,(S_{i,d} - S_{i,d-1})$$
+#
+# The delta is the held contract's own, not the panel's constant-maturity delta, which
+# jumps between contracts daily and would hedge a position nobody holds. `accrued_hedge_pnl`
+# returns the number of days it found a quote on as well as the accrued P&L, because a sum
+# over a path with holes is a partial hedge: a label built from one is not the quantity the
+# formula names, and Section D nulls it rather than presenting it as fully hedged.
+#
+# The primary label replaces the exit leg altogether. Carried to expiration, the straddle
+# settles into cash at its intrinsic value and there is no closing trade at all:
+#
+# $$r^{\text{exp}}_{i,t} = \frac{P_{i,t+1} - |S_{i,T} - K_i|}{P_{i,t+1}}$$
+#
+# where $K_i$ is the strike, $T$ the expiration, and $S_{i,T}$ the underlying's close that
+# day. Settlement reads the unadjusted historical close, because the listed strike and the
+# expiration spot are quoted in the same contemporaneous price basis and adjusting one
+# without the other would put them on different scales.
+#
+# **The three conventions divide by the price at entry rather than differencing a price
+# series, so none of them is a shift, and `fixed_time_horizon_labels` cannot express any of
+# them.** That is why the round trips are built in `_label_artifacts.py` and read back here.
+
+# %%
+panel = panel.join(accrued_hedge_pnl(hedge_path), on=["timestamp", "symbol"], how="left")
+
+# %% [markdown]
+# Each label is then one expression over the round-trip frame, and each carries `_label_end`
+# - the date its outcome is fully observed. For a fixed-horizon trade that is the session it
+# is closed on; for the primary label it is the expiration date, which is written into the
+# contract at entry and varies from trade to trade. Section D checks both against the
+# calendar, and everything from Section E onwards is sealed on this column.
+
+# %%
+settlement = underlying.select(
+    "symbol",
+    pl.col("timestamp").alias("expiration"),
+    pl.col("close").alias("_close_at_expiry"),
+)
+panel = panel.join(settlement, on=["symbol", "expiration"], how="left").with_columns(
+    (
+        (pl.col("entry_straddle_mid") - (pl.col("_close_at_expiry") - pl.col("strike")).abs())
+        / pl.col("entry_straddle_mid")
+    ).alias(PRIMARY_LABEL),
+    (pl.col("expiration") - pl.col("timestamp"))
+    .dt.total_days()
+    .cast(pl.Int32)
+    .alias("dte_calendar"),
+)
+for name, horizon in HORIZONS.items():
+    exit_mid = pl.col(f"exit_straddle_mid_{horizon}d")
+    ret = (pl.col("entry_straddle_mid") - exit_mid) / pl.col("entry_straddle_mid")
+    if name.startswith("fwd_ret_dh_"):
+        complete = pl.col(f"hedge_days_{horizon}d") == horizon
+        hedge = pl.col(f"hedge_pnl_{horizon}d") / pl.col("entry_straddle_mid")
+        ret = pl.when(complete).then(ret + hedge)
+    panel = panel.with_columns(ret.alias(name))
+
+END_OF = {PRIMARY_LABEL: pl.col("expiration")} | {
+    name: pl.col(f"_end_{horizon}d") for name, horizon in HORIZONS.items()
+}
+
+# %% [markdown]
+# The primary label settles on a date the contract fixes rather than a fixed number of
+# sessions out, so how long the money is committed is itself a distribution. Chapter 7.2
+# asks for it wherever the resolution time varies: a label whose window is sometimes a third
+# longer than at other times is not one horizon, and the spread is what the purge gap and
+# the cost of carry both have to cover.
+
+# %%
+# Entry is one session after the signal, so a trade settling on bar e is exposed to the
+# e - bar - 1 return intervals realised between them.
+expiry_bar = calendar.select(pl.col("timestamp").alias("expiration"), pl.col("_bar").alias("_e"))
+panel = panel.join(expiry_bar, on="expiration", how="left").with_columns(
+    (pl.col("_e") - pl.col("_bar") - 1).alias("window")
+)
+resolution = panel.drop_nulls(PRIMARY_LABEL)
+PRIMARY_WINDOW = int(resolution["window"].median())
+LONGEST_WINDOW = int(resolution["window"].max())
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+ax.hist(resolution["dte_calendar"].to_numpy(), bins=np.arange(24.5, 36.5, 1), color=COLORS["blue"])
+ax.axvline(resolution["dte_calendar"].median(), color=COLORS["copper"], linestyle="--", lw=1.2)
+ax.set_xlabel("Calendar days from signal to expiration")
+ax.set_ylabel("Trades")
+ax.yaxis.set_major_formatter(lambda v, _: f"{v:,.0f}")
+add_message_title(
+    ax,
+    "How long a trade is held varies by about a third of its own window",
+    subtitle="Dashed line marks the median; the label resolves when the contract expires",
+)
+show_with_alt(fig, "Histogram of calendar days between the signal date and expiration.")
+
+print(
+    f"Settlement: {resolution['dte_calendar'].min()}-{resolution['dte_calendar'].max()} calendar days, "
+    f"{resolution['window'].min()}-{LONGEST_WINDOW} sessions of exposure, "
+    f"median {PRIMARY_WINDOW}"
+)
+
+# %% [markdown]
+# ## D. Window validity
+#
+# A join always returns something; the question is whether what it returns is the quantity
+# the label claims. Each property below fails silently and leaves plausible numbers behind,
+# so each is asserted rather than described.
+#
+# The second assertion is a full reconciliation rather than a bound. Every row carrying no
+# label is attributed to exactly one cause - no premium quoted at entry, no quote for the
+# held contract on the exit date, a hedge path the contract was not quoted on every day of,
+# an expiration past the end of the underlying panel, or an expiration on which the
+# underlying itself did not trade - and the counts have to sum to the height of the frame. A label built from a stale exit, or one that had silently taken
+# its exit price from a neighbouring contract, would break that identity.
+#
+# The third assertion is what ties the recorded exit dates to the declared horizons. The
+# round-trip builder writes each exit date into the artifact, so the notebook can check it
+# rather than trust it: shifting the panel calendar by the horizon has to land on the same
+# session, and the whole window has to close on or before the contract expires.
+
+# %%
+NO_PREMIUM = pl.col("entry_straddle_mid").is_null()
+CAUSES = {
+    PRIMARY_LABEL: {
+        "no entry premium": NO_PREMIUM,
+        "expiry past the underlying panel": pl.col("expiration") > underlying["timestamp"].max(),
+        "no underlying close at expiry": pl.col("_close_at_expiry").is_null(),
+    }
+} | {
+    name: {
+        "no entry premium": NO_PREMIUM,
+        "no quote at exit": pl.col(f"exit_straddle_mid_{HORIZONS[name]}d").is_null(),
+    }
+    | (
+        {"incomplete hedge path": pl.col(f"hedge_days_{HORIZONS[name]}d") != HORIZONS[name]}
+        if "_dh_" in name
+        else {}
+    )
+    for name in VARIANT_LABELS
+}
+for name, causes in CAUSES.items():
+    # 1. An incomplete window is null, never a value.
+    unlabelled = panel.filter(pl.any_horizontal(*causes.values()))
+    assert unlabelled[name].null_count() == unlabelled.height, name
+
+    # 2. Labelled rows plus the causes, each counted once, account for every row.
+    seen, counts = pl.lit(False), {}
+    for cause, cond in causes.items():
+        counts[cause] = panel.filter(cond & ~seen).height
+        seen = seen | cond
+    assert panel.drop_nulls(name).height + sum(counts.values()) == panel.height, (name, counts)
+
+    # 3. Each recorded exit lands where the declared horizon says, inside the contract.
+    if name in HORIZONS:
+        assert panel.filter(pl.col(f"exit_{HORIZONS[name]}d_date") != END_OF[name]).height == 0
+    assert panel.filter(END_OF[name] > pl.col("expiration")).height == 0, name
+
+    # 4. No discrete label is derived from a null return - vacuous by dtype here, since
+    #    this notebook writes continuous labels only.
+    assert panel.schema[name] == pl.Float64, name
+
+    unlabelled = ", ".join(f"{n:,} {c}" for c, n in counts.items())
+    print(f"{name}: {panel.drop_nulls(name).height:,} labelled; unlabelled {unlabelled}")
+
+# %% [markdown]
+# Position zero below is the panel's last session. Every label has to fall to zero over its
+# own closing window and sit flat before it. A scalar count of valid rows shows neither
+# failure this catches - a tail fabricated instead of nulled, or a short label masked by a
+# longer one's null set - and two things it does show here. The primary label recovers much
+# deeper in than the others, because it needs an expiration the underlying panel still
+# covers rather than an exit session. And the five- and ten-session labels fall away at the
+# same depth rather than at their own, because the round-trip builder lays out one set of
+# exit and hedge dates sized for the longest window it has to fill, and stops every label
+# where that one runs out. The figure reads only the null structure and never a value, so it
+# is not sealed.
+
+# %%
+profile = (
+    calendar.select("timestamp", "from_end")
+    .join(panel.select("timestamp", *LABEL_NAMES), on="timestamp", how="left")
+    .filter(pl.col("from_end") <= 40)
+    .group_by("from_end")
+    .agg([pl.col(name).is_not_null().mean().alias(name) for name in LABEL_NAMES])
+    .sort("from_end")
+)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for name in LABEL_NAMES:
+    ax.plot(profile["from_end"], profile[name], ds="steps-mid", label=name, **STYLES[name])
+ax.axvline(PRIMARY_WINDOW, color=COLORS["neutral"], linestyle=":", lw=1.2)
+ax.set_xlabel("Sessions from the end of the straddle panel")
+ax.set_ylabel("Share of rows with a non-null label")
+ax.set_ylim(-0.05, 1.08)
+add_message_title(
+    ax,
+    "Every label nulls its tail rather than fabricating one",
+    subtitle="Dotted line marks the median settlement; a fabricated tail would sit flat across it",
+)
+ax.legend(loc="center right", frameon=False, fontsize=7)
+show_with_alt(fig, "Non-null label rate by session position from the end of the straddle panel.")
+
+# %% [markdown]
+# ## E. Distribution and base rate
+#
+# What scale is the label, and does it mean the same thing across names and across regimes?
+# Everything from here through Section G is computed on the development window only, sealed
+# on the date each trade **settles** rather than the date its signal is observed. A straddle
+# sold in the first week of December expires in January, so a filter on the signal date
+# looks sealed and is not: the holdout's own prices decide the outcome. The label files keep
+# every row, because the seal governs what this notebook looks at rather than what it
+# writes.
+
+# %%
+dev = {
+    name: panel.with_columns(END_OF[name].alias("_label_end"))
+    .drop_nulls(name)
+    .filter(pl.col("_label_end") < HOLDOUT_START)
+    for name in LABEL_NAMES
+}
+for name, frame in dev.items():
+    print(f"{name}: {frame.height:,} development rows through {frame['timestamp'].max()}")
+
+# %% [markdown]
+# All five labels go on one axis with identical bins and a logarithmic count axis. The claim
+# is about shape rather than width: closing the trade early truncates the distribution on
+# both sides, and hedging the direction away pulls the body in without moving the centre,
+# while carrying to expiration keeps a loss tail several times the premium collected. The
+# axis is narrower than the primary label's range, so rows outside it are counted below
+# rather than drawn.
+
+# %%
+bins = np.linspace(-2.0, 1.0, 121)
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for name in LABEL_NAMES:
+    series = dev[name][name]
+    label = f"{name}, std {series.std():.2f}"
+    ax.hist(series.to_numpy(), bins=bins, histtype="step", label=label, **STYLES[name])
+ax.axvline(0, color=COLORS["neutral"], linestyle="--", lw=0.8)
+ax.set_yscale("log")
+ax.set_ylim(top=ax.get_ylim()[1] * 40)
+ax.set_xlabel("Return as a fraction of the premium collected")
+ax.set_ylabel("Trades per bin, log scale")
+add_message_title(
+    ax,
+    "Carrying to expiration keeps a loss tail the early exits truncate",
+    subtitle="Identical bins, development window; trades beyond the axis are counted below",
+)
+ax.legend(loc="upper left", frameon=False, fontsize=7)
+show_with_alt(fig, "Histograms of all five labels on identical bins and a log count axis.")
+
+for name, frame in dev.items():
+    beyond = frame.filter(~pl.col(name).is_between(bins[0], bins[-1])).height
+    print(
+        f"{name}: mean {frame[name].mean():+.4f}, std {frame[name].std():.4f}, "
+        f"share positive {(frame[name] > 0).mean():.1%}, {beyond:,} beyond the axis"
+    )
+
+# %% [markdown]
+# Chapter 7.2 asks for the base rate to be tracked through time. For a continuous label
+# ranked across a cross-section, the quantity that has to be stable is the spread the model
+# ranks within: where it is not, the same rank correlation buys a different amount of
+# return. The spread is taken across names on each session first and only then averaged over
+# the year. Pooling every name-session in a year into one standard deviation instead adds
+# the movement of the panel's own mean from session to session to the spread across names on
+# a session, and a ranking model is scored on the second alone.
+
+# %%
+annual = (
+    dev[PRIMARY_LABEL]
+    .group_by("timestamp")
+    .agg(pl.col(PRIMARY_LABEL).std().alias("dispersion"), pl.len().alias("names"))
+    .with_columns(pl.col("timestamp").dt.year().alias("year"))
+    .group_by("year")
+    .agg(pl.col("dispersion").mean(), pl.col("names").median())
+    .sort("year")
+)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single_wide"])
+ax.bar(annual["year"], annual["dispersion"], color=COLORS["blue"], width=0.6)
+ax.axhline(
+    annual["dispersion"].median(),
+    color=COLORS["copper"],
+    linestyle="--",
+    lw=1.2,
+    label="median year",
+)
+ax.set_xticks(annual["year"].to_list())
+ax.set_ylim(0, annual["dispersion"].max() * 1.45)
+ax.set_xlabel("Year")
+ax.set_ylabel("Cross-sectional std, mean over sessions")
+add_message_title(
+    ax,
+    "The spread a model ranks within is stable across the development years",
+    subtitle=f"Daily spread across names in {PRIMARY_LABEL}, averaged over each year",
+)
+ax.legend(loc="upper right", frameon=False)
+show_with_alt(fig, "Annual mean of the daily cross-sectional dispersion of the primary label.")
+
+print(annual)
+
+# %% [markdown] tags=["results"]
+# On the development window the hold-to-expiry label has a mean of -0.0487 of the premium
+# collected against a standard deviation of 1.0369, while 58.5% of trades end profitable:
+# most positions expire worth keeping and the ones that do not are several times the size of
+# the ones that do. Closing at ten sessions instead leaves a mean of +0.0552 on a standard
+# deviation of 0.3547, and hedging that trade's direction away cuts the standard deviation
+# to 0.2182 while moving the mean to +0.0159 - the hedge takes out the moves in both
+# directions. Cross-sectional dispersion is steady across the development years, running from
+# 0.727038 in the quietest to 0.860721 in the loudest.
+
+# %% [markdown]
+# ## F. Overlap and effective sample size
+#
+# Sampling a month-long trade at every session makes consecutive rows share almost all of
+# their holding window, so the row count overstates the evidence. Two measurements answer
+# that in different units: how fast the overlap decays, and what the rows are worth once it
+# is priced in. `effective_sample_size` applies Chapter 7.2's average-uniqueness weighting
+# per name, because concurrency is a property of one name's own overlapping trades.
+#
+# Both are counted on `_bar`, the panel calendar the windows were built on. A name is quoted
+# on roughly half the sessions here, and closing over the gaps would pair trades that share
+# nothing and report the overlap as larger than it is.
+
+# %%
+max_lag = LONGEST_WINDOW + 4
+acf = {
+    name: panel_autocorrelation(dev[name], name, max_lag=max_lag, bar_col="_bar")
+    for name in LABEL_NAMES
+}
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+lags = np.arange(1, max_lag + 1)
+for name in LABEL_NAMES:
+    window = PRIMARY_WINDOW if name == PRIMARY_LABEL else HORIZONS[name]
+    ax.plot(lags, acf[name], label=name, **STYLES[name])
+    ax.axvline(window, color=STYLES[name]["color"], linestyle=":", lw=1.0)
+ax.axhline(0, color=COLORS["neutral"], lw=0.8)
+ax.set_xlabel("Lag in panel sessions")
+ax.set_ylabel("Panel autocorrelation")
+add_message_title(
+    ax,
+    "Each label's overlap decays to zero at its own holding window",
+    subtitle="Dotted lines mark each holding window; what remains past one is not overlap",
+)
+ax.legend(loc="upper right", frameon=False, fontsize=7)
+show_with_alt(fig, "Panel autocorrelation of all five labels against lag in panel sessions.")
+
+# A trade exposed for h sessions consumes the h returns realised over them, and the trade
+# one session later shares h-1 of those, so average uniqueness converges to 1/h on a dense
+# grid. The primary label is weighted by each trade's own window rather than by the median,
+# because a median window prices the overlap of a trade none of these rows is.
+for name in LABEL_NAMES:
+    window = PRIMARY_WINDOW if name == PRIMARY_LABEL else HORIZONS[name]
+    per_row = {"horizon_col": "window"} if name == PRIMARY_LABEL else {"horizon": window}
+    n_rows, n_eff = effective_sample_size(dev[name], bar_col="_bar", **per_row)
+    print(
+        f"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against "
+        f"{1 / window:.4f} for windows of {window} sessions overlapping fully; "
+        f"autocorrelation {acf[name][0]:.3f} at lag one, {acf[name][window - 1]:.3f} at that lag"
+    )
+
+# %% [markdown] tags=["results"]
+# The primary label's 282,470 development rows carry 22,897 effective observations, a ratio
+# of 0.0811 against the 0.0500 a fully overlapped 20-session window implies, weighting each
+# trade by its own exposure rather than by the median. The gap is the panel's own sparsity
+# rather than a shorter window: a name quoted on half the sessions has fewer concurrent
+# trades open than a dense grid would give it, and the shorter labels sit above their own
+# reference values for the same reason - 0.2463 against 0.2000 at five sessions.
+# Autocorrelation falls from 0.915 at lag one to -0.009 at the median window, so a purge
+# shorter than the exposure would leave training and validation sharing an outcome. That gap
+# is set by the window itself, not by these counts.
+
+# %% [markdown]
+# ## G. Baseline floor
+#
+# One signal against the primary label on the sealed development window, with no feature
+# engineering: the variance risk premium the hypothesis names, computed as the difference
+# between the at-the-money implied volatility quoted on the signal date and the volatility
+# the underlying realised over the previous month. Realised volatility is measured on
+# split-adjusted closes within stable `sec_id` segments, so a corporate action resetting the
+# adjustment factor cannot masquerade as a market move. Measuring the floor before building
+# features is what makes a later improvement meaningful.
+#
+# The information coefficient is the cross-sectional rank correlation on each session,
+# averaged over sessions, which is the quantity a ranking model is scored on; pooling every
+# name-session instead mixes a cross-sectional claim with a time-series one. The library call
+# returns its series ordered by time, which the standard error depends on. The minimum
+# cross-section is half the median rather than a bare count, so it means the same thing on a
+# universe of another size. The standard error is HAC-adjusted, because the IC series
+# inherits the label's overlap and a naive statistic would treat a month of consecutive
+# sessions as a month of independent evidence; the bandwidth is set from the longest window
+# any trade runs for, so it covers every overlap the series carries rather than half of them.
+
+# %%
+annualised_rv = pl.col("clean_log_return").rolling_std(21).over(["symbol", "sec_id"]) * np.sqrt(252)
+realised = (
     reconcile_underlying_log_returns(underlying)
     .sort(["symbol", "sec_id", "timestamp"])
-    .with_columns(
-        (
-            pl.col("clean_log_return").rolling_std(21).over(["symbol", "sec_id"]) * np.sqrt(252)
-        ).alias("rv_21d")
+    .with_columns(annualised_rv.alias("rv_21d"))
+)
+baseline = (
+    straddles.select(["timestamp", "symbol", "iv_atm"])
+    .join(
+        realised.select(["timestamp", "symbol", "rv_21d"]).drop_nulls(), on=["timestamp", "symbol"]
     )
-    .sort(["symbol", "timestamp"])
+    .with_columns((pl.col("iv_atm") - pl.col("rv_21d")).alias("vrp_proxy"))
+    .join(
+        dev[PRIMARY_LABEL].select(["timestamp", "symbol", PRIMARY_LABEL]),
+        on=["timestamp", "symbol"],
+    )
+    .drop_nulls(["vrp_proxy", PRIMARY_LABEL])
+)
+median_cross_section = int(baseline.group_by("timestamp").len()["len"].median())
+min_obs = median_cross_section // 2
+
+ic = cross_sectional_ic_series(
+    baseline,
+    baseline,
+    pred_col="vrp_proxy",
+    ret_col=PRIMARY_LABEL,
+    date_col="timestamp",
+    entity_col="symbol",
+    min_obs=min_obs,
+).sort("timestamp")  # HAC autocovariances are meaningless over a permutation of time
+stats = compute_ic_hac_stats(ic, ic_col="ic", label_horizon=LONGEST_WINDOW)
+
+print(
+    f"Baseline: implied minus realised volatility against {PRIMARY_LABEL}, {baseline.height:,} rows"
+)
+print(f"  median cross-section {median_cross_section} names, minimum {min_obs}")
+print(f"  sessions scored {ic.height:,}, mean IC {stats['mean_ic']:.4f}")
+print(
+    f"  HAC t {stats['t_stat']:.2f} on {stats['effective_lags']} Bartlett lags, "
+    f"naive t {stats['naive_t_stat']:.2f}, p {stats['p_value']:.3g}"
 )
 
-vrp_baseline = straddles.select(["timestamp", "symbol", "iv_atm"]).join(
-    underlying_rv.select(["timestamp", "symbol", "rv_21d"]).drop_nulls(),
-    on=["timestamp", "symbol"],
-    how="inner",
-)
-vrp_baseline = vrp_baseline.with_columns(
-    (pl.col("iv_atm") - pl.col("rv_21d")).alias("vrp_proxy"),
-)
-
-_holdout_start = (
-    pl.Series([load_evaluation_config("sp500_options")["holdout_start"]]).str.to_date().item()
-)
-vrp_eval = vrp_baseline.join(
-    primary.select(["timestamp", "symbol", y_col]),
-    on=["timestamp", "symbol"],
-    how="inner",
-).filter(pl.col("timestamp") < _holdout_start)  # seal the 2021 holdout
-
+# %% [markdown] tags=["results"]
+# The variance risk premium earns a mean information coefficient of -0.0100 against the
+# hold-to-expiry label over 968 scored sessions on a cross-section of at least 123 names.
+# The sign is the opposite of what the hypothesis implies: names whose options are priced
+# furthest above their recent realised volatility are, if anything, the ones whose short
+# straddles pay least. Under the naive standard error that is a t-statistic of -3.21, which
+# the Newey-West rule on 23 Bartlett lags reduces to -1.06 with a p-value of 0.291 - the
+# whole apparent significance was the overlap being counted as evidence. The floor a feature
+# has to clear is a mean IC of -0.0100 the data cannot separate from zero.
 
 # %% [markdown]
-# Daily rank IC is computed within each cross-section. Carrying the timestamp
-# with each estimate makes chronological ordering explicit before HAC inference.
+# ## H. Artifacts and the audit record
+#
+# Each label is written with a digest sidecar beside it, recording the content digest of the
+# values written, the row count, the key columns, the notebook that wrote it and the digests
+# of the artifacts it was built from. That last field is what ties a label to its data
+# vintage. `instrument_id` stays in the key alongside the name and the date because a symbol
+# can carry more than one option structure, and it is part of the identity stage 03 joins on.
+#
+# The folds that train models are derived per label by `case_studies/utils/cv_window.py`
+# from `config/setup.yaml` and the timeline of the label parquet written here, so which rows
+# land in these files is what sets where the fold boundaries fall.
 
 # %%
-ic_rows = []
-for _key, group in vrp_eval.partition_by("timestamp", as_dict=True).items():
-    valid = group.select(["vrp_proxy", y_col]).drop_nulls()
-    if len(valid) >= 3:
-        p = valid["vrp_proxy"].to_numpy()
-        r = valid[y_col].to_numpy()
-        if np.std(p) > 0 and np.std(r) > 0:
-            corr, _ = spearmanr(p, r)
-            if np.isfinite(corr):
-                ic_rows.append({"timestamp": _key[0], "ic": float(corr)})
-
+KEYS = ["timestamp", "symbol", "instrument_id"]
+for name in LABEL_NAMES:
+    extra = {"market_data": MARKET_DATA_DIGEST} if name == PRIMARY_LABEL else {}
+    inputs = {"contract_returns": CONTRACT_DIGEST} | (
+        {"hedge_path": HEDGE_DIGEST} if "_dh_" in name else extra
+    )
+    # The primary label carries its own settlement date: the notebooks that model it
+    # derive each row's label endpoint from it rather than from a fixed horizon.
+    columns = [name, "dte_calendar"] if name == PRIMARY_LABEL else [name]
+    record = write_artifact(
+        panel.drop_nulls(name).select(
+            "timestamp", "symbol", pl.lit(INSTRUMENT_ID).alias("instrument_id"), *columns
+        ),
+        LABELS_DIR / f"{name}.parquet",
+        keys=KEYS,
+        written_by="02_labels",
+        inputs=inputs,
+    )
+    print(f"{name}.parquet: {record['n_rows']:,} rows, digest {record['digest']}")
 
 # %% [markdown]
-# Horizon-aware HAC treats the overlapping daily IC observations as a time
-# series rather than independent draws.
+# The record Chapter 7.2 requires to close a label definition, one row per label, built from
+# the values computed above rather than written by hand. The buffer and the outcome horizon
+# are separate rows because they are separate numbers here: the buffer is declared in
+# calendar days and has to cover the longest settlement, while the outcome horizon is what
+# the label's overlap is measured in.
 
 # %%
-if ic_rows:
-    ic_series = pl.DataFrame(ic_rows).sort("timestamp")
-    baseline_stats = compute_ic_hac_stats(ic_series, ic_col="ic", label_horizon=21)
-    baseline_ic_mean = float(baseline_stats["mean_ic"])
-    baseline_ic_std = float(ic_series["ic"].std())
-    baseline_ic_tstat = float(baseline_stats["t_stat"])
-    baseline_ic_pvalue = float(baseline_stats["p_value"])
-    baseline_ic_lags = int(baseline_stats["effective_lags"])
-    print(f"Baseline VRP proxy IC vs {y_col} (pre-2021 CV window):")
-    print(f"  Mean IC: {baseline_ic_mean:.4f}")
-    print(f"  IC std: {baseline_ic_std:.4f}")
+READERS = {
+    PRIMARY_LABEL: "03_financial_features.py and every model stage, as labels.primary",
+    "fwd_ret_10d": "90_ic_diagnostic.py",
+    "fwd_ret_dh_10d": "03_financial_features.py, 05_evaluation.py, 90_ic_diagnostic.py",
+}
+print(f"\nLabel audit record - cross-validation buffer {LABEL_BUFFER} for every label")
+for name in LABEL_NAMES:
+    primary, frame = name == PRIMARY_LABEL, dev[name]
+    window = PRIMARY_WINDOW if primary else HORIZONS[name]
+    exit_leg = "cash settlement at intrinsic value" if primary else "mid of the same contract"
+    when = (
+        f"variable: {resolution['window'].min()}-{LONGEST_WINDOW} sessions of exposure"
+        if primary
+        else f"fixed at {window} sessions from entry"
+    )
     print(
-        f"  HAC t-stat: {baseline_ic_tstat:.2f} "
-        f"(p={baseline_ic_pvalue:.3f}, lags={baseline_ic_lags}, n_dates={len(ic_series)})"
+        f"\n{name}\n  anchor       mid of the straddle sold one session after the signal"
+        f"\n  exit         {exit_leg}"
+        f"\n  horizon      {window} sessions{' (median)' if primary else ''}"
+        f"\n  resolution   {when}"
+        f"\n  overlap      {window - 1} sessions shared by consecutive trades in one name"
+        f"\n  base rate    mean {frame[name].mean():+.5f}, share positive {(frame[name] > 0).mean():.3f}"
+        f"\n  consumed by  {READERS.get(name, 'the diagnostic notebooks, as a variant')}"
     )
-else:
-    baseline_ic_mean = 0.0
-    baseline_ic_tstat = 0.0
-    baseline_ic_pvalue = 1.0
-    baseline_ic_lags = 0
-    print("Insufficient data for baseline IC computation")
 
 # %% [markdown]
-# ## 5. Save Artifacts
-
-# %%
-LABELS_DIR.mkdir(parents=True, exist_ok=True)
-
-# Save label files
-for name, label_df in {**unhedged_labels, **dh_labels, **exec_labels, **htm_labels}.items():
-    label_path = LABELS_DIR / f"{name}.parquet"
-    label_df.write_parquet(label_path)
-    print(f"Saved labels/{name}.parquet ({len(label_df):,} rows)")
-
-# CV config from setup.yaml evaluation section
-_eval_cfg = load_evaluation_config("sp500_options")
-_cv_config_dict = {
-    "n_splits": _eval_cfg["n_splits"],
-    "train_size": str(_eval_cfg["train_size"]),
-    "test_size": str(_eval_cfg["val_size"]),
-    "holdout_start": _eval_cfg.get("holdout_start", ""),
-    "holdout_end": _eval_cfg.get("holdout_end", ""),
-    "calendar": _eval_cfg.get("calendar", "NYSE"),
-}
-_cv_path = CASE_DIR / "config" / "cv_config.json"
-_cv_path.parent.mkdir(parents=True, exist_ok=True)
-_cv_path.write_text(json.dumps(_cv_config_dict, indent=2))
-print(f"Saved cv_config.json (n_splits={_cv_config_dict['n_splits']})")
-
-# %% [markdown]
-# ## 6. Results Collection
-
-
-# %%
-def _git_commit_hash():
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], text=True, timeout=5
-        ).strip()
-    except Exception:
-        return "unknown"
-
-
-# %% [markdown]
-# Assemble the label, method, and diagnostic summaries separately so each
-# result group remains easy to inspect and reuse.
-
-# %%
-results_summary = {
-    "n_observations": n_total,
-    "n_symbols": primary["symbol"].n_unique(),
-    "primary_label": _primary_name,
-    "primary_mean": float(primary[y_col].mean()),
-    "primary_std": float(primary[y_col].std()),
-    "hit_rate": float(hit_rate),
-    "label_variants": (
-        list(unhedged_labels.keys())
-        + list(dh_labels.keys())
-        + list(exec_labels.keys())
-        + list(htm_labels.keys())
-    ),
-}
-results_techniques = {
-    "instrument": "30D ATM matched-strike straddle",
-    "sign_convention": "short straddle (positive = profitable)",
-    "entry": "t+1 mid (selling) - same contract as feature date",
-    "exit": "t+1+h mid (buying to close) - same contract looked up in raw chain",
-    "pricing": "mid-to-mid (execution costs deferred to Ch18)",
-    "hedging": "delta-hedged using held contract's delta path (not constant-maturity)",
-}
-results_diagnostics = {
-    "horizons": list(FORWARD_HORIZONS),
-    "n_cv_splits": _cv_config_dict["n_splits"],
-    "straddle_coverage": f"{primary['symbol'].n_unique()} symbols",
-}
-
-
-# %% [markdown]
-# The final record combines stable metadata with the current baseline estimate
-# and its overlap-aware uncertainty fields.
-
-# %%
-results = {
-    "case_study_id": STRATEGY_ID,
-    "chapter": 7,
-    "stage": "labels",
-    "timestamp": datetime.now(UTC).isoformat(),
-    "git_commit": _git_commit_hash(),
-    "notebook": f"case_studies/{STRATEGY_ID}/02_labels.py",
-    "data_version": "v2_matched_strike_same_contract",
-    "summary": results_summary,
-    "techniques": results_techniques,
-    "diagnostics": results_diagnostics,
-    "key_findings": [
-        f"Hold-to-expiry mean return: {float(primary[y_col].mean()):.4f}",
-        f"Hit rate: {hit_rate:.1%} of trades profitable",
-        f"Label std: {float(primary[y_col].std()):.4f}",
-        "Same-contract returns (v2) - no contract-roll contamination",
-        f"Baseline VRP IC: {baseline_ic_mean:.4f} (HAC t={baseline_ic_tstat:.2f})",
-    ],
-    "baseline_ic": {
-        "signal": "vrp_proxy",
-        "mean_ic": baseline_ic_mean,
-        "t_stat": baseline_ic_tstat,
-        "p_value": baseline_ic_pvalue,
-        "hac_lags": baseline_ic_lags,
-    },
-}
-
-
-# %% [markdown]
-# ## Key Takeaways
+# ## Key takeaways
 #
-# 1. **Primary label is `ret_to_expiry`** (hold-to-expiry): the short straddle is
-#    held to its natural expiration and settles at intrinsic value, eliminating
-#    the exit-leg bid-ask cost. DTE at entry is tight (25–35 days) so no
-#    variable-horizon normalization is needed. Every downstream model in this case
-#    study trains on this label; it is the pedagogical anchor for the O'Donovan-Yu
-#    cost-mitigation cascade in Ch18.
+# 1. **On an option panel, a forward return is a round trip in one contract, not a shift of
+#    a price column.** The 30-day at-the-money row is a different instrument every session,
+#    so a shifted difference reports the change of contract as profit. Look the held
+#    contract up in the raw chain instead.
+# 2. **Reconcile every unlabelled row to one cause.** A missing quote at exit, a premium
+#    that was never quoted, a hedge path with a hole in it and an expiration past the end
+#    of the price panel all fail without raising, and a reconciliation that has to balance
+#    catches what a row count passed over does not.
+# 3. **Seal a diagnostic on the date the position settles.** When the settlement date is
+#    written into the contract rather than fixed at a number of sessions, that date is the
+#    boundary - a trade opened before the holdout and expiring inside it is a holdout trade.
+# 4. **A row count overstates the evidence when holding windows overlap.** The effective
+#    count says by how much in rows, and the same overlap priced into a standard error is
+#    what turns a t-statistic that reads as decisive into one that cannot be separated from
+#    zero.
+# 5. **Check the sign of a baseline before assuming its size is the question.** The variance
+#    risk premium points the opposite way to the hypothesis on this universe, which is a
+#    fact about the cross-section that a mean-level argument about the premium would miss.
 #
-# 2. **Same-contract returns** (v2): Labels use the actual held contract's exit
-#    price from the raw option chain, not shift-based returns that mix contracts.
-#    Force-rebuilding the artifacts from the raw chain reproduces them exactly.
+# **Known limitations.** Mid-to-mid pricing is not what a trader receives; the entry
+# half-spread and the commission are swept in `14_costs.py`, and the primary label avoids
+# the exit half-spread only because cash settlement needs no closing trade. The delta hedge
+# is rebalanced at the close and charges nothing for doing so. The universe is every name
+# with a quoted matched-strike straddle, with the liquidity screen applied downstream rather
+# than here. The baseline is one signal, on one month of realised volatility.
 #
-# 3. **Diagnostic horizon variants**: the 5- and 10-day mid-to-mid, executable,
-#    and delta-hedged returns are also built to expose the pricing and hedging
-#    mechanics. Delta hedging (held contract's delta path) tightens the return
-#    distribution by removing directional P&L. These variants are not modelled.
-#
-# 4. **Mid-to-mid vs executable**: mid-to-mid pricing measures the economic signal
-#    (10-day mean +5.7%); the executable label (sell at bid, buy back at ask) bakes
-#    in the full round-trip spread and the same unconditional return falls to
-#    -9.6%. This single-stock-option microstructure is exactly what `ret_to_expiry`
-#    and the Ch18 cost cascade address.
-#
-# 5. **Baseline floor**: the naive VRP proxy ($IV_{atm} - RV_{21d}$) has a small
-#    *negative* rank IC against `ret_to_expiry` on the pre-2021 CV window, but
-#    the estimate is not statistically resolved after horizon-aware HAC
-#    adjustment. Its realized-volatility leg uses split-adjusted closes, so
-#    engineered features must do more than replay the raw premium to add value.
-#
-# **Next**: [`03_financial_features`](03_financial_features.ipynb) builds VRP, surface dynamics, and instrument
-# state features for predicting which straddles to sell.
+# **Next**: `03_financial_features.py` builds the volatility-surface, term-structure and
+# instrument-state features and evaluates them against these labels.

--- a/case_studies/sp500_options/README.md
+++ b/case_studies/sp500_options/README.md
@@ -29,7 +29,7 @@ The cost-mitigation cascade (O'Donovan & Yu 2024) is encoded in the `strategy.si
 | Stage | Notebook | Chapter | Description | Writes |
 |-------|----------|---------|-------------|--------|
 | Setup | [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) | Ch6 | Universe breadth, round-trip cost against premium, premium persistence, fold structure | Nothing |
-| Labels | [`02_labels`](02_labels.ipynb) | Ch7 | HTM short-straddle return + delta-hedged and raw forward variants | One parquet per label in `labels/` (hold-to-maturity, delta-hedged, execution, and raw forward variants), and `config/cv_config.json` |
+| Labels | [`02_labels`](02_labels.ipynb) | Ch7 | HTM short-straddle return + delta-hedged and raw forward variants | Five parquets in `labels/` — `ret_to_expiry` plus the 5- and 10-session forward returns and their delta-hedged counterparts — each with a `.digest.json` sidecar. Cross-validation folds come from `config/setup.yaml` |
 | Features | [`03_financial_features`](03_financial_features.ipynb) | Ch8 | VRP, IV surface, skew, term structure, and Greeks features | `features/financial.parquet` |
 | Temporal | [`04_model_based_features`](04_model_based_features.ipynb) | Ch9 | Walk-forward GJR-GARCH volatility + particle-filtered stochastic volatility | `features/model_based.parquet` |
 | Evaluation | [`05_evaluation`](05_evaluation.ipynb) | Ch7–9 | IC diagnostics on the engineered feature set | `evaluation/triage_ledger.parquet`, `evaluation/ic_timeseries.parquet` |

--- a/case_studies/sp500_options/_label_artifacts.py
+++ b/case_studies/sp500_options/_label_artifacts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import time
+import json
 from pathlib import Path
 
 import polars as pl
@@ -33,7 +33,15 @@ def ensure_label_artifacts(
     prices_path = labels_dir / "prices.parquet"
 
     required = [contract_returns_path, hedge_path_path]
-    if not force_rebuild and all(path.exists() for path in required):
+    # A cached artifact was built over whatever window the run that wrote it saw, so the
+    # scope is recorded beside it and the cache is only reused for the same request.
+    # Without that, a narrower run returns the full panel and leaves the reduction
+    # silently unapplied, and the reduced files a narrower run writes are then accepted
+    # by the next default run as if they covered everything.
+    scope_path = labels_dir / "contract_returns.scope.json"
+    scope = {"max_symbols": max_symbols, "start_date": start_date}
+    cached_scope = json.loads(scope_path.read_text()) if scope_path.exists() else None
+    if not force_rebuild and cached_scope == scope and all(path.exists() for path in required):
         return {
             "contract_returns": contract_returns_path,
             "hedge_path": hedge_path_path,
@@ -41,6 +49,15 @@ def ensure_label_artifacts(
         }
 
     straddles = load_sp500_options_straddles()
+    if start_date is not None:
+        straddles = straddles.filter(pl.col("timestamp") >= pl.lit(start_date).str.to_date())
+
+    # Horizons are counted in market sessions, so the calendar comes from the whole panel
+    # and `max_symbols` thins only the entries it is applied to. Deriving the offsets from
+    # a symbol subset instead would drop every session none of those symbols was quoted
+    # on, and the exit dates would then be that many sessions further out than declared.
+    trading_dates = straddles["timestamp"].unique().sort().to_list()
+    entry_rows = straddles
     if max_symbols > 0:
         top_syms = (
             straddles.group_by("symbol")
@@ -49,11 +66,7 @@ def ensure_label_artifacts(
             .head(max_symbols)["symbol"]
             .to_list()
         )
-        straddles = straddles.filter(pl.col("symbol").is_in(top_syms))
-    if start_date is not None:
-        straddles = straddles.filter(pl.col("timestamp") >= pl.lit(start_date).str.to_date())
-
-    trading_dates = straddles["timestamp"].unique().sort().to_list()
+        entry_rows = straddles.filter(pl.col("symbol").is_in(top_syms))
     valid_range = len(trading_dates) - (1 + MAX_HOLDING)
     offset_data = {"feature_date": trading_dates[:valid_range]}
     offset_data["entry_date"] = trading_dates[1 : valid_range + 1]
@@ -66,7 +79,7 @@ def ensure_label_artifacts(
 
     date_offsets = pl.DataFrame(offset_data)
     entries = (
-        straddles.select(["timestamp", "symbol", "strike", "expiration"])
+        entry_rows.select(["timestamp", "symbol", "strike", "expiration"])
         .join(date_offsets.rename({"feature_date": "timestamp"}), on="timestamp", how="inner")
         .rename({"timestamp": "feature_date"})
     )
@@ -223,6 +236,8 @@ def ensure_label_artifacts(
     ).sort(["symbol", "feature_date", "holding_day"])
     hedge_path_out.write_parquet(hedge_path_path)
 
+    scope_path.write_text(json.dumps(scope, sort_keys=True) + "\n")
+
     if save_prices:
         straddles.write_parquet(prices_path)
 
@@ -231,6 +246,46 @@ def ensure_label_artifacts(
         "hedge_path": hedge_path_path,
         "prices": prices_path,
     }
+
+
+def accrued_hedge_pnl(
+    hedge_path: pl.DataFrame, horizons: tuple[int, ...] = HORIZONS
+) -> pl.DataFrame:
+    """Hedge P&L accrued over each horizon, with the number of days it was observed on.
+
+    The hedge is rebalanced at each close, so the P&L on holding day ``d`` is the delta
+    set on day ``d-1`` applied to that day's move in the underlying. A day the contract
+    was not quoted on contributes nothing and is *counted*: a sum over a path with holes
+    is a partial hedge, and the count is what lets the caller null the label rather than
+    present it as fully hedged.
+
+    Summed in day order. An unordered parallel sum re-associates the floating point, which
+    moves the label's last bit and its content digest from one run to the next.
+    """
+    cohort = ["symbol", "feature_date"]
+    move = pl.col("underlying_price") - pl.col("underlying_price").shift(1).over(cohort)
+    daily = hedge_path.sort([*cohort, "holding_day"]).with_columns(
+        (pl.col("instr_delta").shift(1).over(cohort) * move).alias("daily_pnl")
+    )
+    accrued = daily.group_by(cohort).agg(
+        *[
+            expr
+            for horizon in horizons
+            for expr in (
+                pl.col("daily_pnl")
+                .filter(pl.col("holding_day").is_between(1, horizon))
+                .sort_by(pl.col("holding_day").filter(pl.col("holding_day").is_between(1, horizon)))
+                .sum()
+                .alias(f"hedge_pnl_{horizon}d"),
+                pl.col("daily_pnl")
+                .filter(pl.col("holding_day").is_between(1, horizon))
+                .is_not_null()
+                .sum()
+                .alias(f"hedge_days_{horizon}d"),
+            )
+        ]
+    )
+    return accrued.rename({"feature_date": "timestamp"})
 
 
 def summarize_label_artifacts(

--- a/case_studies/sp500_options/config/cv_config.json
+++ b/case_studies/sp500_options/config/cv_config.json
@@ -1,8 +1,0 @@
-{
-  "n_splits": 2,
-  "train_size": "2Y",
-  "test_size": "1Y",
-  "holdout_start": "2021-01-01",
-  "holdout_end": "2021-12-31",
-  "calendar": "NYSE"
-}

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -179,12 +179,18 @@ labels:
   # backtests, cohort_metrics, or rank-1 selection. See
   # .agents/issues/2026-05-17-sp500-options-legacy-10d-5d-labels-cleanup.md
   variants: []
-  # Diagnostic-only label buffers: variants below are NOT in the sweep
-  # but their parquets are still computed by 02_labels.py for EDA NBs
-  # (e.g. 90_ic_diagnostic uses fwd_ret_dh_10d for IV-decay analysis).
-  # Listing the buffer here keeps `resolve_label_buffer` from raising
-  # without re-introducing the variant into the sweep / cohort_metrics.
+  # Diagnostic-only labels: the four fixed-horizon variants below are NOT in
+  # the sweep, and their parquets are written by 02_labels.py for the notebooks
+  # that read them (03_financial_features and 05_evaluation contrast the primary
+  # against fwd_ret_dh_10d; 90_ic_diagnostic reads fwd_ret_10d and
+  # fwd_ret_dh_10d for the IV-decay analysis). Declaring each here is what makes
+  # the written label set equal the declared one, and gives
+  # `resolve_label_buffer` / `resolve_label_horizon` a value for each without
+  # re-introducing the variant into the sweep / cohort_metrics.
   variant_buffers:
+    fwd_ret_5d: 5D
+    fwd_ret_10d: 10D
+    fwd_ret_dh_5d: 5D
     fwd_ret_dh_10d: 10D
   # Vectorized-backtest thinning step per label: number of schedule slots
   # to advance per trade so holding periods don't overlap.

--- a/case_studies/utils/label_diagnostics.py
+++ b/case_studies/utils/label_diagnostics.py
@@ -68,11 +68,19 @@ def panel_autocorrelation(
 def effective_sample_size(
     frame: pl.DataFrame,
     *,
-    horizon: int,
     bar_col: str,
+    horizon: int | None = None,
+    horizon_col: str | None = None,
     entity_col: str = "symbol",
 ) -> tuple[int, float]:
     """Return (rows, N_eff) for a label sampled every bar over *horizon* bars.
+
+    Pass ``horizon_col`` instead of ``horizon`` where the window is not the same length
+    for every row - an event label that resolves when a barrier is hit or when a contract
+    expires. The column holds each row's window in the same units as ``bar_col``, and a
+    single ``horizon`` is the special case where every row carries the same value. A
+    median window standing in for a variable one prices the overlap of a label none of
+    the rows has.
 
     ``N_eff`` is Chapter 7.2's average-uniqueness sum: each row is weighted by the
     share of its forward window no concurrent label also spans. Concurrency is a
@@ -102,14 +110,16 @@ def effective_sample_size(
     array extended past the last window's end rather than truncated, which would
     shorten exactly those windows.
     """
+    if (horizon is None) == (horizon_col is None):
+        raise ValueError("pass exactly one of horizon and horizon_col")
     rows, weight = 0, 0.0
     for _, group in frame.group_by([entity_col]):
         bars = group[bar_col].to_numpy()
-        bars = bars - bars.min()
-        events = np.sort(bars)
-        weights = calculate_label_uniqueness(
-            events, events + horizon - 1, n_bars=int(events[-1]) + horizon
-        )
+        order = np.argsort(bars)
+        events = bars[order] - bars.min()
+        windows = horizon if horizon_col is None else group[horizon_col].to_numpy()[order]
+        ends = events + windows - 1
+        weights = calculate_label_uniqueness(events, ends, n_bars=int(ends.max()) + 1)
         rows += group.height
         weight += float(weights.sum())
     return rows, weight

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -34,6 +34,7 @@ HOLDOUT_SCOPED_NOTEBOOKS = [
     ("case_studies/crypto_perps_funding/02_labels.py", "cross_sectional_ic_series("),
     ("case_studies/cme_futures/02_labels.py", "cross_sectional_ic_series("),
     ("case_studies/fx_pairs/02_labels.py", "cross_sectional_ic_series("),
+    ("case_studies/sp500_options/02_labels.py", "cross_sectional_ic_series("),
 ]
 
 
@@ -131,6 +132,7 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
     "case_studies/crypto_perps_funding/02_labels.py",
     "case_studies/cme_futures/02_labels.py",
     "case_studies/fx_pairs/02_labels.py",
+    "case_studies/sp500_options/02_labels.py",
 ]
 
 # Of the four above, only etfs/05 uses a market-wide calendar; the other three
@@ -156,6 +158,14 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
 # which is checked by executing the notebook rather than by reading its source. A
 # source pattern cannot see the stronger check, so listing it here only produces a
 # false red. See agent-workspace #141.
+# ``sp500_options/02_labels`` is deliberately absent, and for the opposite reason to
+# ``etfs/05``: its endpoint is not an approximation that needs the per-symbol form. The
+# hold-to-expiry label settles on the expiration written into the contract and the
+# fixed-horizon variants on the exit session recorded in the round-trip artifact, so
+# ``_label_end`` is the exact resolution date of each individual trade rather than a
+# calendar shift of the signal date. The notebook checks the recorded exit dates against a
+# shift of the panel calendar by the declared horizon, which is what
+# ``test_holdout_purge_is_on_the_label_endpoint`` above matches on.
 PER_SYMBOL_ENDPOINT_NOTEBOOKS = [
     ("case_studies/etfs/02_labels.py", "symbol"),
     ("case_studies/crypto_perps_funding/02_labels.py", "symbol"),

--- a/tests/test_sp500_options_label_price_basis.py
+++ b/tests/test_sp500_options_label_price_basis.py
@@ -60,6 +60,13 @@ def test_vrp_rv_respects_splits_security_boundaries_and_segment_scale() -> None:
             "iv_atm": [0.25] * len(dates),
         }
     )
+    labels = pl.DataFrame(
+        {
+            "timestamp": dates,
+            "symbol": ["SPLT"] * len(dates),
+            "ret_to_expiry": np.linspace(-0.5, 0.5, len(dates)),
+        }
+    )
 
     def run_baseline(prices: pl.DataFrame) -> dict[str, object]:
         namespace = {
@@ -68,8 +75,12 @@ def test_vrp_rv_respects_splits_security_boundaries_and_segment_scale() -> None:
             "reconcile_underlying_log_returns": reconcile_underlying_log_returns,
             "load_sp500_daily_bars": lambda: prices,
             "load_sp500_options_straddles": lambda: straddles,
+            "PRIMARY_LABEL": "ret_to_expiry",
+            "dev": {"ret_to_expiry": labels},
         }
-        _run_assignments(("straddles", "underlying", "underlying_rv", "vrp_baseline"), namespace)
+        _run_assignments(
+            ("straddles", "underlying", "annualised_rv", "realised", "baseline"), namespace
+        )
         return namespace
 
     baseline = run_baseline(bars)
@@ -81,10 +92,10 @@ def test_vrp_rv_respects_splits_security_boundaries_and_segment_scale() -> None:
             .alias("close")
         )
     )
-    baseline_rv = baseline["underlying_rv"]
+    baseline_rv = baseline["realised"]
     boundaries = baseline_rv.filter(pl.col("identity_boundary"))
-    baseline_vrp = baseline["vrp_baseline"].sort("timestamp")
-    scaled_vrp = scaled["vrp_baseline"].sort("timestamp")
+    baseline_vrp = baseline["baseline"].sort("timestamp")
+    scaled_vrp = scaled["baseline"].sort("timestamp")
 
     assert boundaries.height == 1
     assert boundaries["clean_log_return"].null_count() == 1
@@ -96,7 +107,15 @@ def test_vrp_rv_respects_splits_security_boundaries_and_segment_scale() -> None:
 
 
 def test_expiry_intrinsic_value_keeps_historical_close_basis() -> None:
+    """Settlement reads the unadjusted close, on the same basis as the listed strike.
+
+    `adj_factor` is 4 here, so a label built from the split-adjusted close would price the
+    intrinsic value at a quarter of the strike's basis and report a profit where there is
+    a loss. Running the notebook's own `panel` assignments rather than a transcription of
+    them is what makes the check bind to the shipped formula.
+    """
     expiration = date(2020, 8, 31)
+    signal = date(2020, 8, 3)
     bars = pl.DataFrame(
         {
             "timestamp": [expiration],
@@ -107,32 +126,40 @@ def test_expiry_intrinsic_value_keeps_historical_close_basis() -> None:
     )
     contract_returns = pl.DataFrame(
         {
-            "feature_date": [date(2020, 8, 3)],
+            "feature_date": [signal],
             "expiration": [expiration],
             "symbol": ["SPLT"],
             "strike": [50.0],
             "entry_straddle_mid": [10.0],
         }
     )
+    calendar = pl.DataFrame({"timestamp": [signal, expiration], "_bar": [0, 21]})
     namespace = {
         "pl": pl,
-        "INSTRUMENT_ID": "straddle_30d_atm",
         "contract_returns": contract_returns,
-        "load_sp500_daily_bars": lambda: bars,
+        "calendar": calendar,
+        "underlying": bars,
+        "hedge_path": None,
+        "accrued_hedge_pnl": lambda _: pl.DataFrame(
+            {"timestamp": [signal], "symbol": ["SPLT"], "hedge_pnl_5d": [0.0]}
+        ),
+        "PRIMARY_LABEL": "ret_to_expiry",
     }
 
-    _run_assignments(("underlying_close", "htm_label"), namespace)
-    result = namespace["htm_label"]
+    _run_assignments(("panel", "settlement", "expiry_bar"), namespace)
+    result = namespace["panel"]
 
     assert result["ret_to_expiry"].item() == 0.8
     assert result["dte_calendar"].item() == 28
+    # Entry is one session after the signal, so 21 sessions to expiry is 20 of exposure.
+    assert result["window"].item() == 20
 
 
 def test_notebook_rv_rolls_within_full_security_identity() -> None:
-    assignments = _assignment_nodes("underlying_rv")
+    assignments = _assignment_nodes("annualised_rv", "realised")
 
-    assert len(assignments) == 1
-    expression = ast.dump(assignments[0])
+    assert len(assignments) == 2
+    expression = "".join(ast.dump(node) for node in assignments)
     assert "reconcile_underlying_log_returns" in expression
     assert "clean_log_return" in expression
     assert "symbol" in expression
@@ -151,16 +178,26 @@ def test_baseline_ic_uses_sorted_horizon_aware_hac() -> None:
 
     assert len(hac_calls) == 1
     keywords = {keyword.arg: keyword.value for keyword in hac_calls[0].keywords}
-    assert isinstance(keywords["label_horizon"], ast.Constant)
-    assert keywords["label_horizon"].value == 21
+    # The bandwidth is a name bound from the observed windows, not a literal: this label
+    # resolves at expiration, so its exposure varies from trade to trade and a constant
+    # here would drift from the data the first time the contract calendar moves.
+    horizon = keywords["label_horizon"]
+    assert isinstance(horizon, ast.Name)
+    assert horizon.id == "LONGEST_WINDOW"
+    window_bindings = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "LONGEST_WINDOW" for t in node.targets)
+    ]
+    assert len(window_bindings) == 1
+    assert "max" in ast.dump(window_bindings[0])
 
     sorted_ic_assignments = [
         node
         for node in ast.walk(tree)
         if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == "ic_series" for target in node.targets
-        )
+        and any(isinstance(target, ast.Name) and target.id == "ic" for target in node.targets)
         and isinstance(node.value, ast.Call)
         and isinstance(node.value.func, ast.Attribute)
         and node.value.func.attr == "sort"


### PR DESCRIPTION
`case_studies/sp500_options/02_labels` rebuilt to the stage-02 standard, re-run on
production data, and sealed on the date each position settles.

## The leak

The primary label `ret_to_expiry` is a short straddle carried to expiration, so the
date its outcome is known is written into the contract rather than fixed at a number
of sessions after the signal. The notebook sealed its baseline IC on the **signal**
date, so every trade opened from about 2020-12 onward settled inside the sealed 2021
holdout and still entered the statistic. Everything else was worse: the `primary`
frame was the unsealed full sample, so the mean, the standard deviation, the hit
rate, the autocorrelation, the effective sample size and the distribution figure all
included the holdout.

`_label_end` is now the date each label's outcome is fully observed - the contract's
`expiration` for the primary label, the recorded exit session for the four
fixed-horizon variants - and sections D through H are scoped on it. That is the same
boundary `04_model_based_features`, `05_evaluation`, `06_linear` and `07_gbm` already
derive from the `dte_calendar` column this notebook writes.

## Every number that moved, and why

Three of the five label parquets reproduce **bit for bit** - `ret_to_expiry`,
`fwd_ret_5d` and `fwd_ret_10d`, checked row by row against the previous construction on
the production artifacts. The two delta-hedged labels lose rows, for the reason in "The
hedge that was not a hedge" below. Everything else that moved is the notebook's own
diagnostics.

| Quantity | Was | Now | Cause |
|---|---|---|---|
| Primary label mean | -0.0242 | -0.0487 | was the unsealed full sample; now the development window |
| Primary label std | 1.1524 | 1.0369 | same |
| Share of trades profitable | 59.4% | 58.5% | same |
| Rows the diagnostics see | 354,473 | 282,470 | the endpoint seal drops 5,752 rows the signal-date seal kept, on top of the 66,251 the old frame never sealed at all |
| `N_eff` | 49,590 | 22,897 | the old figure came from `1 + 2·Σ max(ρ_k, 0)` on a per-symbol Spearman ACF over the full sample; the new one is Chapter 7.2's average uniqueness via `calculate_label_uniqueness`, weighting each trade by its own exposure |
| Lag-1 autocorrelation | +0.742 | +0.915 | was the mean of per-symbol Spearman correlations; now the panel Pearson autocorrelation, demeaned within symbol and paired on the panel calendar |
| Baseline mean IC | -0.0108 | -0.0100 | see below |
| Baseline HAC t | -1.23 (p 0.220) | -1.06 (p 0.291) | see below |
| Sessions scored | 986 | 968 | the endpoint seal |
| Minimum cross-section | 3 | 123 | half the median cross-section of 246, instead of a bare integer |
| `fwd_ret_dh_5d` rows | 352,179 | 349,934 | an incomplete hedge path now nulls the label |
| `fwd_ret_dh_10d` rows | 333,102 | 323,847 | same |
| `fwd_ret_dh_10d` mean / std (development) | - | +0.0159 / 0.2182 | as above; both were previously computed on the unsealed sample |

**The baseline IC, decomposed.** Holding the minimum cross-section at the old value
of 3 isolates the seal: signal-date seal -0.0108 with HAC t -1.23 over 986 sessions
(reproducing the shipped value exactly), endpoint seal -0.0112 with HAC t -1.26 over
968. Raising the minimum cross-section to half the median then moves it to -0.0100
with HAC t -1.09, and widening the Newey-West bandwidth from the median window to the
longest one (20 to 24 sessions of exposure, 23 Bartlett lags) gives -1.06. So the seal
made the floor slightly *more* negative and the
cross-section rule pulled it back; neither changes the reading, which is that the
variance risk premium points the opposite way to the hypothesis and the data cannot
separate the estimate from zero. The naive t of -3.21 against the HAC t of -1.09 is
the overlap being counted as evidence, and the notebook now says so.

## The label set against its own contract

`setup.yaml: labels.primary` plus `labels.variant_buffers` is now exactly what gets
written, five files:

- **`fwd_ret_exec_{5,10}d` deleted.** They appeared exactly once in the repository -
  on the line that built them. The writes and the two committed parquets are gone.
- **`fwd_ret_{5,10}d` and `fwd_ret_dh_{5,10}d` declared** in `labels.variant_buffers`,
  which previously listed only `fwd_ret_dh_10d`. They are written and read
  (`03_financial_features`, `05_evaluation`, `90_ic_diagnostic`,
  `13_dl_time_series/dl_sequences.py`), so the declaration had to catch up with the
  code rather than the other way round.
- **Not moved into `labels.variants`.** That list drives the sweep - it is what
  `tests/test_sweep_config_seam.py` reconciles against `backtest.sweep.top_k_grid`,
  and what the latent-factor and Ch20 paths iterate - and these four were removed
  from the sweep on 2026-05-17 because the vectorized backtest path treats their
  multi-day returns as daily ones. `variant_buffers` already existed for exactly this
  case and is not read by the sweep, so it is where they belong.

## The hedge that was not a hedge

`fwd_ret_dh_{5,10}d` add the hedge P&L accrued along the contract's own delta path. The
sum ignored days the contract was not quoted on, and a wholly missing path was turned
into zero by a `fill_null(0)`, so a partially hedged - or entirely unhedged - trade was
written out as a delta-hedged return. Measured on the production artifacts: 2,245 rows
at five sessions and 9,255 at ten, 0.6% and 2.8% of each label, of which 16 and 5 had no
hedge path at all.

`accrued_hedge_pnl` now returns the number of days it found a quote on alongside the
accrued P&L, and a label whose path is short of its horizon is null. That is a fourth
row in the Section D reconciliation rather than a silent pass.

Both labels are diagnostic-only - neither is in the sweep - but `fwd_ret_dh_10d` is
read by `03_financial_features`, `05_evaluation`, `90_ic_diagnostic` and
`dl_sequences.py`, so those four will show different numbers the next time they run.

## Two things that were not reproducible

**The digest of the delta-hedged labels moved on every re-run.** Three executions of
identical code on identical inputs produced three different content digests, while the
other three labels reproduced exactly. The cause is the parallel sum over each holding
path: an unordered reduction re-associates the floating point, which moved the label by
up to 9e-16 - immaterial to any number, and enough to make the sidecar useless as a
content address. The accrual is now summed in day order and all five digests reproduce
across processes.

**A reduced run poisoned the cache for the next full one.** `ensure_label_artifacts`
returned whatever was on disk, so a `MAX_SYMBOLS` or `START_DATE` run wrote a reduced
`contract_returns.parquet` that the next default run then accepted as the full panel.
The requested scope is now recorded beside the artifact and the cache is only reused for
the same request.

**And `MAX_SYMBOLS` counted horizons on a symbol-subset calendar.** The builder derived
its session calendar after filtering to the sampled symbols, so any session none of them
was quoted on vanished and the exit dates sat that many sessions further out than
declared, while the notebook counted on the whole panel. Latent rather than breaking: the
selection takes the most-quoted names, and those are quoted on all 1,259 production
sessions and all 1,008 fixture ones, so no session is dropped today. The calendar now
comes from the whole panel and the reduction thins only the entries it is applied to. A
run at `MAX_SYMBOLS=5, START_DATE=2018-01-01` executes clean, both parameters bite (5
names, signals from 2018-01-02), and every Section D assertion holds.

## The rest

- **Papermill.** `START_DATE` was declared and never read. Both parameters now reach
  `ensure_label_artifacts`, which no longer hands back a cached full-panel artifact
  when a narrower window is requested - without that the override could not have bitten
  whatever the call site did.
- **`N_eff`** comes from `case_studies/utils/label_diagnostics.effective_sample_size`,
  which gains an optional `horizon_col` so a label whose window is not the same length
  for every row is weighted per row rather than at the median. Checked at `h = 1` on a
  synthetic gapless grid, where it returns `N` exactly, and the scalar and per-row forms
  are checked to agree where the window is constant. The overlap of a trade held `h`
  sessions is `h` return intervals, not `h + 1`: the execution delay shifts the window
  without lengthening it.
- **The dead `results` dict** (60 lines, under a "Results Collection" heading) is gone,
  along with the sentence asserting what a later notebook found.
- **`config/cv_config.json`** was written here and opened by nothing. The write and
  the committed file are gone; section H states positively where the folds come from.
  The 35D cross-validation buffer and the label's own resolution time are separate
  rows of the audit record, because they are separate numbers here.
- **Digest sidecars** for all five labels, keyed
  `["timestamp", "symbol", "instrument_id"]`, with `inputs` naming
  `contract_returns`, `hedge_path` for the delta-hedged pair, and `market_data` for
  the primary's settlement closes.
- **Five figures** replace the printed tables: resolution time, window validity at the
  panel boundary, all five label distributions on one axis with identical bins,
  cross-sectional dispersion through time, and overlap decay across the panel with
  each holding window marked. Every PNG was extracted from the executed notebook and
  checked against its title.
- **Both static holdout gates** in `tests/test_holdout_boundary.py` now list this
  notebook, and `tests/test_sp500_options_label_price_basis.py` was updated to the
  rebuilt notebook: it now runs the notebook's own `panel` assignments rather than a
  transcription of them, and requires the HAC bandwidth to be bound from the observed
  windows instead of being a literal.
- **The case-study README** listed executable-return artifacts and `config/cv_config.json`
  among what this stage writes. It now names the five files and points at `setup.yaml`
  for the folds.

## Verification

```
python3 scripts/check_notebook_conformance.py --stage 02 --case-study sp500_options
  PASS  sp500_options
  1 notebooks checked, 0 failing
```

```
uv run pytest tests/test_case_studies.py -k "sp500_options and 02_labels"   1 passed
uv run pytest tests/test_holdout_boundary.py                                29 passed, 2 skipped
```

Executed on production data through `jupyter nbconvert`: zero error outputs, zero
unexecuted cells, five figures, no absolute paths, provenance stamped.

`test_notebook_output_hygiene.py::test_no_machine_specific_paths_in_committed_notebooks`
is red on the base commit for thirty-odd unrelated notebooks and is filed separately;
`02_labels` is not among them.
