### PR TITLE
Rebuild nasdaq100 labels: each label from its own nulls, horizon as a duration

### DIFF
--- a/case_studies/nasdaq100_microstructure/02_labels.ipynb
+++ b/case_studies/nasdaq100_microstructure/02_labels.ipynb
@@ -51,10 +51,10 @@
    "id": "b6dfca90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:34.929354Z",
-     "iopub.status.busy": "2026-07-31T09:11:34.928932Z",
-     "iopub.status.idle": "2026-07-31T09:11:36.891522Z",
-     "shell.execute_reply": "2026-07-31T09:11:36.891085Z"
+     "iopub.execute_input": "2026-07-31T09:30:02.592837Z",
+     "iopub.status.busy": "2026-07-31T09:30:02.592403Z",
+     "iopub.status.idle": "2026-07-31T09:30:04.540543Z",
+     "shell.execute_reply": "2026-07-31T09:30:04.539818Z"
     },
     "papermill": {
      "duration": 1.580942,
@@ -109,10 +109,10 @@
    "id": "810858da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:36.893209Z",
-     "iopub.status.busy": "2026-07-31T09:11:36.893115Z",
-     "iopub.status.idle": "2026-07-31T09:11:36.894676Z",
-     "shell.execute_reply": "2026-07-31T09:11:36.894368Z"
+     "iopub.execute_input": "2026-07-31T09:30:04.542001Z",
+     "iopub.status.busy": "2026-07-31T09:30:04.541888Z",
+     "iopub.status.idle": "2026-07-31T09:30:04.543725Z",
+     "shell.execute_reply": "2026-07-31T09:30:04.543406Z"
     },
     "papermill": {
      "duration": 0.004977,
@@ -155,10 +155,10 @@
    "id": "1457d387",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:36.895641Z",
-     "iopub.status.busy": "2026-07-31T09:11:36.895581Z",
-     "iopub.status.idle": "2026-07-31T09:11:36.905514Z",
-     "shell.execute_reply": "2026-07-31T09:11:36.905231Z"
+     "iopub.execute_input": "2026-07-31T09:30:04.544724Z",
+     "iopub.status.busy": "2026-07-31T09:30:04.544664Z",
+     "iopub.status.idle": "2026-07-31T09:30:04.554747Z",
+     "shell.execute_reply": "2026-07-31T09:30:04.554428Z"
     },
     "papermill": {
      "duration": 0.003947,
@@ -185,10 +185,10 @@
    "id": "d1fea063",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:36.906506Z",
-     "iopub.status.busy": "2026-07-31T09:11:36.906448Z",
-     "iopub.status.idle": "2026-07-31T09:11:36.909029Z",
-     "shell.execute_reply": "2026-07-31T09:11:36.908733Z"
+     "iopub.execute_input": "2026-07-31T09:30:04.555781Z",
+     "iopub.status.busy": "2026-07-31T09:30:04.555719Z",
+     "iopub.status.idle": "2026-07-31T09:30:04.558524Z",
+     "shell.execute_reply": "2026-07-31T09:30:04.558200Z"
     }
    },
    "outputs": [
@@ -285,10 +285,10 @@
    "id": "dbc8ece7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:36.909947Z",
-     "iopub.status.busy": "2026-07-31T09:11:36.909887Z",
-     "iopub.status.idle": "2026-07-31T09:11:38.303140Z",
-     "shell.execute_reply": "2026-07-31T09:11:38.302522Z"
+     "iopub.execute_input": "2026-07-31T09:30:04.559280Z",
+     "iopub.status.busy": "2026-07-31T09:30:04.559213Z",
+     "iopub.status.idle": "2026-07-31T09:30:05.949051Z",
+     "shell.execute_reply": "2026-07-31T09:30:05.948347Z"
     },
     "papermill": {
      "duration": 4.517577,
@@ -330,10 +330,10 @@
    "id": "a4444ea4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:38.304999Z",
-     "iopub.status.busy": "2026-07-31T09:11:38.304918Z",
-     "iopub.status.idle": "2026-07-31T09:11:38.456933Z",
-     "shell.execute_reply": "2026-07-31T09:11:38.456465Z"
+     "iopub.execute_input": "2026-07-31T09:30:05.950657Z",
+     "iopub.status.busy": "2026-07-31T09:30:05.950513Z",
+     "iopub.status.idle": "2026-07-31T09:30:06.100709Z",
+     "shell.execute_reply": "2026-07-31T09:30:06.100256Z"
     }
    },
    "outputs": [
@@ -381,10 +381,10 @@
    "id": "e6f803da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:38.458326Z",
-     "iopub.status.busy": "2026-07-31T09:11:38.458251Z",
-     "iopub.status.idle": "2026-07-31T09:11:39.155997Z",
-     "shell.execute_reply": "2026-07-31T09:11:39.155512Z"
+     "iopub.execute_input": "2026-07-31T09:30:06.101631Z",
+     "iopub.status.busy": "2026-07-31T09:30:06.101556Z",
+     "iopub.status.idle": "2026-07-31T09:30:06.815099Z",
+     "shell.execute_reply": "2026-07-31T09:30:06.814467Z"
     },
     "papermill": {
      "duration": 7.70059,
@@ -461,10 +461,10 @@
    "id": "ffe93104",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:39.157759Z",
-     "iopub.status.busy": "2026-07-31T09:11:39.157686Z",
-     "iopub.status.idle": "2026-07-31T09:11:40.126506Z",
-     "shell.execute_reply": "2026-07-31T09:11:40.125952Z"
+     "iopub.execute_input": "2026-07-31T09:30:06.816311Z",
+     "iopub.status.busy": "2026-07-31T09:30:06.816239Z",
+     "iopub.status.idle": "2026-07-31T09:30:07.826566Z",
+     "shell.execute_reply": "2026-07-31T09:30:07.826007Z"
     },
     "papermill": {
      "duration": 0.21529,
@@ -487,10 +487,10 @@
    "id": "c2fdca39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:40.128143Z",
-     "iopub.status.busy": "2026-07-31T09:11:40.128076Z",
-     "iopub.status.idle": "2026-07-31T09:11:44.237002Z",
-     "shell.execute_reply": "2026-07-31T09:11:44.236609Z"
+     "iopub.execute_input": "2026-07-31T09:30:07.827861Z",
+     "iopub.status.busy": "2026-07-31T09:30:07.827790Z",
+     "iopub.status.idle": "2026-07-31T09:30:11.994338Z",
+     "shell.execute_reply": "2026-07-31T09:30:11.993989Z"
     }
    },
    "outputs": [
@@ -549,10 +549,10 @@
    "id": "2e56cf7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:44.238137Z",
-     "iopub.status.busy": "2026-07-31T09:11:44.238060Z",
-     "iopub.status.idle": "2026-07-31T09:11:48.106657Z",
-     "shell.execute_reply": "2026-07-31T09:11:48.106162Z"
+     "iopub.execute_input": "2026-07-31T09:30:11.995360Z",
+     "iopub.status.busy": "2026-07-31T09:30:11.995287Z",
+     "iopub.status.idle": "2026-07-31T09:30:15.521424Z",
+     "shell.execute_reply": "2026-07-31T09:30:15.520988Z"
     },
     "papermill": {
      "duration": 0.01235,
@@ -592,10 +592,10 @@
    "id": "30e72558",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:48.108205Z",
-     "iopub.status.busy": "2026-07-31T09:11:48.108124Z",
-     "iopub.status.idle": "2026-07-31T09:11:48.425207Z",
-     "shell.execute_reply": "2026-07-31T09:11:48.424782Z"
+     "iopub.execute_input": "2026-07-31T09:30:15.522926Z",
+     "iopub.status.busy": "2026-07-31T09:30:15.522794Z",
+     "iopub.status.idle": "2026-07-31T09:30:15.841420Z",
+     "shell.execute_reply": "2026-07-31T09:30:15.841050Z"
     },
     "papermill": {
      "duration": 2.760897,
@@ -654,10 +654,10 @@
    "id": "15531267",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:48.426439Z",
-     "iopub.status.busy": "2026-07-31T09:11:48.426358Z",
-     "iopub.status.idle": "2026-07-31T09:11:54.230592Z",
-     "shell.execute_reply": "2026-07-31T09:11:54.230115Z"
+     "iopub.execute_input": "2026-07-31T09:30:15.842648Z",
+     "iopub.status.busy": "2026-07-31T09:30:15.842574Z",
+     "iopub.status.idle": "2026-07-31T09:30:21.354744Z",
+     "shell.execute_reply": "2026-07-31T09:30:21.354177Z"
     },
     "papermill": {
      "duration": 0.716492,
@@ -715,10 +715,10 @@
    "id": "5e1000d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:54.231845Z",
-     "iopub.status.busy": "2026-07-31T09:11:54.231758Z",
-     "iopub.status.idle": "2026-07-31T09:11:54.401077Z",
-     "shell.execute_reply": "2026-07-31T09:11:54.400621Z"
+     "iopub.execute_input": "2026-07-31T09:30:21.355967Z",
+     "iopub.status.busy": "2026-07-31T09:30:21.355892Z",
+     "iopub.status.idle": "2026-07-31T09:30:21.528026Z",
+     "shell.execute_reply": "2026-07-31T09:30:21.527613Z"
     },
     "papermill": {
      "duration": 0.017163,
@@ -771,10 +771,10 @@
    "id": "7d735ff3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:54.402097Z",
-     "iopub.status.busy": "2026-07-31T09:11:54.402030Z",
-     "iopub.status.idle": "2026-07-31T09:11:54.628448Z",
-     "shell.execute_reply": "2026-07-31T09:11:54.627814Z"
+     "iopub.execute_input": "2026-07-31T09:30:21.529583Z",
+     "iopub.status.busy": "2026-07-31T09:30:21.529483Z",
+     "iopub.status.idle": "2026-07-31T09:30:21.762867Z",
+     "shell.execute_reply": "2026-07-31T09:30:21.762397Z"
     },
     "papermill": {
      "duration": 0.885655,
@@ -800,10 +800,10 @@
    "id": "5fc6af1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:54.629646Z",
-     "iopub.status.busy": "2026-07-31T09:11:54.629571Z",
-     "iopub.status.idle": "2026-07-31T09:11:54.711131Z",
-     "shell.execute_reply": "2026-07-31T09:11:54.710703Z"
+     "iopub.execute_input": "2026-07-31T09:30:21.764293Z",
+     "iopub.status.busy": "2026-07-31T09:30:21.764221Z",
+     "iopub.status.idle": "2026-07-31T09:30:21.844029Z",
+     "shell.execute_reply": "2026-07-31T09:30:21.843661Z"
     }
    },
    "outputs": [
@@ -871,10 +871,10 @@
    "id": "6c0a715f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:11:54.712307Z",
-     "iopub.status.busy": "2026-07-31T09:11:54.712218Z",
-     "iopub.status.idle": "2026-07-31T09:12:08.791365Z",
-     "shell.execute_reply": "2026-07-31T09:12:08.790853Z"
+     "iopub.execute_input": "2026-07-31T09:30:21.845441Z",
+     "iopub.status.busy": "2026-07-31T09:30:21.845365Z",
+     "iopub.status.idle": "2026-07-31T09:30:35.861704Z",
+     "shell.execute_reply": "2026-07-31T09:30:35.861379Z"
     }
    },
    "outputs": [
@@ -932,10 +932,10 @@
    "id": "5b24fa62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:08.792862Z",
-     "iopub.status.busy": "2026-07-31T09:12:08.792794Z",
-     "iopub.status.idle": "2026-07-31T09:12:09.243517Z",
-     "shell.execute_reply": "2026-07-31T09:12:09.243201Z"
+     "iopub.execute_input": "2026-07-31T09:30:35.862829Z",
+     "iopub.status.busy": "2026-07-31T09:30:35.862753Z",
+     "iopub.status.idle": "2026-07-31T09:30:36.326148Z",
+     "shell.execute_reply": "2026-07-31T09:30:36.325797Z"
     },
     "papermill": {
      "duration": 3.280151,
@@ -984,10 +984,10 @@
    "id": "88933f8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:09.245412Z",
-     "iopub.status.busy": "2026-07-31T09:12:09.245321Z",
-     "iopub.status.idle": "2026-07-31T09:12:09.375759Z",
-     "shell.execute_reply": "2026-07-31T09:12:09.375251Z"
+     "iopub.execute_input": "2026-07-31T09:30:36.327276Z",
+     "iopub.status.busy": "2026-07-31T09:30:36.327192Z",
+     "iopub.status.idle": "2026-07-31T09:30:36.451230Z",
+     "shell.execute_reply": "2026-07-31T09:30:36.450842Z"
     }
    },
    "outputs": [
@@ -1044,10 +1044,10 @@
    "id": "5c0a6920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:09.377250Z",
-     "iopub.status.busy": "2026-07-31T09:12:09.377181Z",
-     "iopub.status.idle": "2026-07-31T09:12:14.683167Z",
-     "shell.execute_reply": "2026-07-31T09:12:14.682557Z"
+     "iopub.execute_input": "2026-07-31T09:30:36.452457Z",
+     "iopub.status.busy": "2026-07-31T09:30:36.452377Z",
+     "iopub.status.idle": "2026-07-31T09:30:41.743215Z",
+     "shell.execute_reply": "2026-07-31T09:30:41.742872Z"
     }
    },
    "outputs": [
@@ -1089,10 +1089,10 @@
    "id": "1fd6af3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:14.684825Z",
-     "iopub.status.busy": "2026-07-31T09:12:14.684698Z",
-     "iopub.status.idle": "2026-07-31T09:12:15.076246Z",
-     "shell.execute_reply": "2026-07-31T09:12:15.075867Z"
+     "iopub.execute_input": "2026-07-31T09:30:41.744294Z",
+     "iopub.status.busy": "2026-07-31T09:30:41.744212Z",
+     "iopub.status.idle": "2026-07-31T09:30:42.143002Z",
+     "shell.execute_reply": "2026-07-31T09:30:42.142594Z"
     }
    },
    "outputs": [
@@ -1148,10 +1148,10 @@
    "id": "ba77953b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:15.077332Z",
-     "iopub.status.busy": "2026-07-31T09:12:15.077263Z",
-     "iopub.status.idle": "2026-07-31T09:12:15.344235Z",
-     "shell.execute_reply": "2026-07-31T09:12:15.343812Z"
+     "iopub.execute_input": "2026-07-31T09:30:42.144036Z",
+     "iopub.status.busy": "2026-07-31T09:30:42.143957Z",
+     "iopub.status.idle": "2026-07-31T09:30:42.406349Z",
+     "shell.execute_reply": "2026-07-31T09:30:42.405977Z"
     },
     "papermill": {
      "duration": 6.237156,
@@ -1178,10 +1178,10 @@
    "id": "fc2042e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:15.345650Z",
-     "iopub.status.busy": "2026-07-31T09:12:15.345573Z",
-     "iopub.status.idle": "2026-07-31T09:12:15.426306Z",
-     "shell.execute_reply": "2026-07-31T09:12:15.425779Z"
+     "iopub.execute_input": "2026-07-31T09:30:42.407877Z",
+     "iopub.status.busy": "2026-07-31T09:30:42.407800Z",
+     "iopub.status.idle": "2026-07-31T09:30:42.491513Z",
+     "shell.execute_reply": "2026-07-31T09:30:42.490954Z"
     }
    },
    "outputs": [
@@ -1278,8 +1278,10 @@
     "horizon was converted into, and both treat the symbol-session as the entity, because a\n",
     "window cannot be concurrent with one on the other side of an overnight gap.\n",
     "\n",
-    "Read the decay as a straight line running out to each horizon: consecutive rows share all\n",
-    "but one bar of their window, and the share they have in common falls off by one bar per lag.\n",
+    "What a label consumes is return intervals, and it consumes one fewer than its horizon in\n",
+    "bars: entering a bar after the decision and leaving at the horizon spans the moves between\n",
+    "those two prices, not the move into the entry. Consecutive rows share all but one of those\n",
+    "intervals, so the decay reads as a straight line falling by one interval per lag.\n",
     "The longest label does not stop at zero when it gets there but keeps going negative, and\n",
     "that is a property of the session rather than of the label - a one-hour window is a fifth of\n",
     "a trading day, so each session holds few independent windows, and subtracting the session's\n",
@@ -1292,10 +1294,10 @@
    "id": "3f106ea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:12:15.427779Z",
-     "iopub.status.busy": "2026-07-31T09:12:15.427670Z",
-     "iopub.status.idle": "2026-07-31T09:15:24.796908Z",
-     "shell.execute_reply": "2026-07-31T09:15:24.796368Z"
+     "iopub.execute_input": "2026-07-31T09:30:42.493097Z",
+     "iopub.status.busy": "2026-07-31T09:30:42.492980Z",
+     "iopub.status.idle": "2026-07-31T09:33:49.512092Z",
+     "shell.execute_reply": "2026-07-31T09:33:49.511686Z"
     },
     "papermill": {
      "duration": 1.377173,
@@ -1322,10 +1324,10 @@
    "id": "728221d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:15:24.798016Z",
-     "iopub.status.busy": "2026-07-31T09:15:24.797946Z",
-     "iopub.status.idle": "2026-07-31T09:15:24.857848Z",
-     "shell.execute_reply": "2026-07-31T09:15:24.857363Z"
+     "iopub.execute_input": "2026-07-31T09:33:49.513484Z",
+     "iopub.status.busy": "2026-07-31T09:33:49.513408Z",
+     "iopub.status.idle": "2026-07-31T09:33:49.574062Z",
+     "shell.execute_reply": "2026-07-31T09:33:49.573428Z"
     },
     "papermill": {
      "duration": 1.24601,
@@ -1372,10 +1374,10 @@
    "id": "b6607a81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:15:24.858867Z",
-     "iopub.status.busy": "2026-07-31T09:15:24.858796Z",
-     "iopub.status.idle": "2026-07-31T09:18:16.853759Z",
-     "shell.execute_reply": "2026-07-31T09:18:16.853345Z"
+     "iopub.execute_input": "2026-07-31T09:33:49.575358Z",
+     "iopub.status.busy": "2026-07-31T09:33:49.575235Z",
+     "iopub.status.idle": "2026-07-31T09:36:45.525800Z",
+     "shell.execute_reply": "2026-07-31T09:36:45.525390Z"
     },
     "papermill": {
      "duration": 1.840498,
@@ -1390,33 +1392,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_15m: N=14,370,375, N_eff=993,791, ratio 0.0692 against 0.0667 for windows overlapping this fully; autocorrelation 0.920 at lag one and -0.038 at its horizon\n"
+      "fwd_ret_15m: N=14,370,375, N_eff=1,062,039, ratio 0.0739 against 0.0714 for 14 intervals overlapping fully; autocorrelation 0.920 at lag one and -0.038 at its horizon\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_5m: N=14,753,585, N_eff=2,981,374, ratio 0.2021 against 0.2000 for windows overlapping this fully; autocorrelation 0.741 at lag one and -0.023 at its horizon\n"
+      "fwd_ret_5m: N=14,753,585, N_eff=3,717,137, ratio 0.2519 against 0.2500 for 4 intervals overlapping fully; autocorrelation 0.741 at lag one and -0.023 at its horizon\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_60m: N=12,645,930, N_eff=248,448, ratio 0.0196 against 0.0167 for windows overlapping this fully; autocorrelation 0.976 at lag one and -0.219 at its horizon\n"
+      "fwd_ret_60m: N=12,645,930, N_eff=252,009, ratio 0.0199 against 0.0169 for 59 intervals overlapping fully; autocorrelation 0.976 at lag one and -0.219 at its horizon\n"
      ]
     }
    ],
    "source": [
     "for name in RETURN_LABELS:\n",
-    "    h_bars = HORIZON_BARS[name]\n",
+    "    h_bars, spans = HORIZON_BARS[name], HORIZON_BARS[name] - 1\n",
     "    n_rows, n_eff = effective_sample_size(\n",
-    "        dev[name], horizon=h_bars, bar_col=\"bar_in_session\", entity_col=\"entity\"\n",
+    "        dev[name], horizon=spans, bar_col=\"bar_in_session\", entity_col=\"entity\"\n",
     "    )\n",
     "    print(\n",
     "        f\"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against \"\n",
-    "        f\"{1 / h_bars:.4f} for windows overlapping this fully; autocorrelation \"\n",
+    "        f\"{1 / spans:.4f} for {spans} intervals overlapping fully; autocorrelation \"\n",
     "        f\"{acf[name][0]:.3f} at lag one and {acf[name][h_bars - 1]:.3f} at its horizon\"\n",
     "    )"
    ]
@@ -1430,13 +1432,14 @@
     ]
    },
    "source": [
-    "The primary label's 14,370,375 development rows carry 993,791 effective observations, a\n",
-    "ratio of 0.0692 against the 0.0667 a fully overlapped 15-bar window implies; the 5-minute\n",
-    "label's 14,753,585 rows carry 2,981,374 at 0.2021 against 0.2000, and the 60-minute label's\n",
-    "12,645,930 carry 248,448 at 0.0196 against 0.0167. Each sits above its reference because a\n",
-    "session end closes an overlap early, and the longest label sits furthest above it because\n",
-    "the session ends most often relative to its window. Fourteen million rows are worth about a\n",
-    "million: the row count overstates the evidence by a factor of fifteen, which is the horizon.\n",
+    "The primary label's 14,370,375 development rows carry 1,062,039 effective observations, a\n",
+    "ratio of 0.0739 against the 0.0714 that fourteen fully overlapping intervals imply; the\n",
+    "5-minute label's 14,753,585 rows carry 3,717,137 at 0.2519 against 0.2500, and the\n",
+    "60-minute label's 12,645,930 carry 252,009 at 0.0199 against 0.0169. Each sits above its\n",
+    "reference because a session end closes an overlap early, and the longest label sits\n",
+    "furthest above it because the session ends most often relative to its window. Fourteen\n",
+    "million rows are worth about a million: the row count overstates the evidence by roughly\n",
+    "the number of intervals each label spans.\n",
     "\n",
     "Autocorrelation falls from 0.920 at lag one to -0.038 at lag fifteen for the primary label\n",
     "and from 0.741 to -0.023 at lag five for the fast one. The 60-minute label falls from 0.976\n",
@@ -1471,10 +1474,10 @@
    "id": "600dd3b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:18:16.854792Z",
-     "iopub.status.busy": "2026-07-31T09:18:16.854718Z",
-     "iopub.status.idle": "2026-07-31T09:18:21.052953Z",
-     "shell.execute_reply": "2026-07-31T09:18:21.052434Z"
+     "iopub.execute_input": "2026-07-31T09:36:45.526823Z",
+     "iopub.status.busy": "2026-07-31T09:36:45.526748Z",
+     "iopub.status.idle": "2026-07-31T09:36:49.662841Z",
+     "shell.execute_reply": "2026-07-31T09:36:49.662421Z"
     },
     "papermill": {
      "duration": 0.150688,
@@ -1516,10 +1519,10 @@
    "id": "e662a973",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:18:21.054149Z",
-     "iopub.status.busy": "2026-07-31T09:18:21.054076Z",
-     "iopub.status.idle": "2026-07-31T09:18:21.056540Z",
-     "shell.execute_reply": "2026-07-31T09:18:21.056115Z"
+     "iopub.execute_input": "2026-07-31T09:36:49.664124Z",
+     "iopub.status.busy": "2026-07-31T09:36:49.664042Z",
+     "iopub.status.idle": "2026-07-31T09:36:49.666425Z",
+     "shell.execute_reply": "2026-07-31T09:36:49.666031Z"
     }
    },
    "outputs": [
@@ -1598,10 +1601,10 @@
    "id": "9a7e6691",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:18:21.057322Z",
-     "iopub.status.busy": "2026-07-31T09:18:21.057255Z",
-     "iopub.status.idle": "2026-07-31T09:18:24.028158Z",
-     "shell.execute_reply": "2026-07-31T09:18:24.027698Z"
+     "iopub.execute_input": "2026-07-31T09:36:49.667149Z",
+     "iopub.status.busy": "2026-07-31T09:36:49.667087Z",
+     "iopub.status.idle": "2026-07-31T09:36:52.635864Z",
+     "shell.execute_reply": "2026-07-31T09:36:52.635485Z"
     }
    },
    "outputs": [
@@ -1662,10 +1665,10 @@
    "id": "11e5d059",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-31T09:18:24.029484Z",
-     "iopub.status.busy": "2026-07-31T09:18:24.029402Z",
-     "iopub.status.idle": "2026-07-31T09:18:24.096690Z",
-     "shell.execute_reply": "2026-07-31T09:18:24.096253Z"
+     "iopub.execute_input": "2026-07-31T09:36:52.636922Z",
+     "iopub.status.busy": "2026-07-31T09:36:52.636819Z",
+     "iopub.status.idle": "2026-07-31T09:36:52.705287Z",
+     "shell.execute_reply": "2026-07-31T09:36:52.704780Z"
     }
    },
    "outputs": [
@@ -1680,7 +1683,7 @@
       "  anchor       quote midpoint one bar after the decision bar\n",
       "  horizon      0:15:00, which is 15 bars on this grid\n",
       "  resolution   fixed at t+0:15:00; the closing NBBO quote breaks the within-bar tie\n",
-      "  overlap      14 bars shared by consecutive rows\n",
+      "  overlap      13 of its 14 return intervals, with the next row\n",
       "  base rate    mean +0.000021, std 0.004142\n",
       "  consumed by  03_financial_features.py, as the label it names directly\n",
       "\n",
@@ -1688,7 +1691,7 @@
       "  anchor       quote midpoint one bar after the decision bar\n",
       "  horizon      0:05:00, which is 5 bars on this grid\n",
       "  resolution   fixed at t+0:05:00; the closing NBBO quote breaks the within-bar tie\n",
-      "  overlap      4 bars shared by consecutive rows\n",
+      "  overlap      3 of its 4 return intervals, with the next row\n",
       "  base rate    mean +0.000004, std 0.002324\n",
       "  consumed by  the model stages, as a variant\n",
       "\n",
@@ -1696,7 +1699,7 @@
       "  anchor       quote midpoint one bar after the decision bar\n",
       "  horizon      1:00:00, which is 60 bars on this grid\n",
       "  resolution   fixed at t+1:00:00; the closing NBBO quote breaks the within-bar tie\n",
-      "  overlap      59 bars shared by consecutive rows\n",
+      "  overlap      58 of its 59 return intervals, with the next row\n",
       "  base rate    mean +0.000063, std 0.007884\n",
       "  consumed by  the model stages, as a variant\n",
       "\n",
@@ -1704,7 +1707,7 @@
       "  anchor       quote midpoint one bar after the decision bar\n",
       "  horizon      0:15:00, which is 15 bars on this grid\n",
       "  resolution   fixed at t+0:15:00; the closing NBBO quote breaks the within-bar tie\n",
-      "  overlap      14 bars shared by consecutive rows\n",
+      "  overlap      13 of its 14 return intervals, with the next row\n",
       "  base rate    -1: 0.404, 0: 0.181, 1: 0.414\n",
       "  consumed by  the model stages, as a variant\n"
      ]
@@ -1724,7 +1727,7 @@
     "        f\"\\n{name}\\n  anchor       quote midpoint one bar after the decision bar\"\n",
     "        f\"\\n  horizon      {horizon}, which is {h_bars} bars on this grid\"\n",
     "        f\"\\n  resolution   fixed at t+{horizon}; the closing NBBO quote breaks the within-bar tie\"\n",
-    "        f\"\\n  overlap      {h_bars - 1} bars shared by consecutive rows\"\n",
+    "        f\"\\n  overlap      {h_bars - 2} of its {h_bars - 1} return intervals, with the next row\"\n",
     "        f\"\\n  base rate    {scale}\"\n",
     "        f\"\\n  consumed by  {readers.get(name, 'the model stages, as a variant')}\"\n",
     "    )"
@@ -1758,7 +1761,9 @@
     "**Known limitations.** The midprice is not a fill: a marketable order crosses the spread,\n",
     "and the round trip charted in Section E is the quoted spread rather than a measured\n",
     "execution cost - it carries no commission, no market impact and no queue position, so it\n",
-    "is a floor on what trading costs. The universe is the fixed NASDAQ-100 membership list\n",
+    "is a floor on what trading costs. It is also the spread quoted at the decision bar, doubled,\n",
+    "rather than the two spreads actually crossed at the entry and exit bars, so it prices the\n",
+    "round trip at the moment the decision is taken and not at the moments it is filled. The universe is the fixed NASDAQ-100 membership list\n",
     "`setup.yaml` declares, not a\n",
     "point-in-time index reconstruction, so a name that joined or left mid-sample is present\n",
     "throughout. The flat band is a single constant across every symbol and every regime,\n",
@@ -1791,8 +1796,8 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "d21d20b95e2be7119ed55687912477a34f8a4a83",
-   "executed_at": "2026-07-31T09:19:07.343345+00:00",
+   "source_py_blob": "f174f2af6283b35b4f1c9c5ab7b0db7fe6a131f9",
+   "executed_at": "2026-07-31T09:37:34.607305+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/nasdaq100_microstructure/02_labels.ipynb
+++ b/case_studies/nasdaq100_microstructure/02_labels.ipynb
@@ -15,39 +15,34 @@
    "source": [
     "# NASDAQ-100 Microstructure: Label Engineering\n",
     "\n",
-    "**Chapter 7: Defining the Learning Task**\n",
+    "Every model in this case study predicts the label defined here, so an error in it is\n",
+    "silent where it is made and reaches every metric and every backtest after it. This\n",
+    "notebook fixes the execution convention, proves each labelled row has a complete\n",
+    "forward window inside one trading session, measures how much independent information\n",
+    "those rows carry, establishes the floor a feature has to clear, and writes the files\n",
+    "stage 03 reads.\n",
     "\n",
-    "This notebook implements label engineering for the **NASDAQ-100 Microstructure**\n",
-    "case study. We construct forward midprice returns at multiple horizons (1-bar,\n",
-    "5-bar, 60-bar) using execution-consistent conventions.\n",
+    "## Learning objectives\n",
     "\n",
-    "**Learning Objectives**:\n",
-    "- Compute midprice-based labels that avoid bid-ask bounce contamination\n",
-    "- Apply session-bounded forward returns (no overnight gap leakage)\n",
-    "- Perform cost-sanity checks to assess horizon feasibility\n",
-    "- Generate walk-forward CV splits with appropriate purge/embargo\n",
+    "- Write an intraday forward return as an execution convention - which price is bought,\n",
+    "  at which time, and sold at which time - rather than as a row shift\n",
+    "- Measure the bar grid the horizon is counted on, and convert a declared duration into\n",
+    "  bars against it instead of assuming the two agree\n",
+    "- Assert, rather than describe, that every labelled window is complete inside one session\n",
+    "- Price the overlap in a per-bar label, both as decay and as an effective row count\n",
+    "- Establish the floor a feature has to clear, under a standard error that prices in that\n",
+    "  overlap\n",
     "\n",
-    "**Label Types**:\n",
-    "- `fwd_ret_15m`: Primary regression label (1-bar / 15-min forward mid return)\n",
-    "- `fwd_ret_5m`: Variant 1 (5-min forward mid return, from 5-bar shift)\n",
-    "- `fwd_ret_60m`: Variant 2 (60-min forward mid return, from 60-bar shift)\n",
-    "- `fwd_dir_15m`: Classification variant (ternary: up/flat/down, 5 bps threshold)\n",
+    "## Book reference, prerequisites and artifacts\n",
     "\n",
-    "**Execution Convention**:\n",
-    "- Decision time $t$ = bar close\n",
-    "- Enter at $t+1$ midprice (1-bar execution delay)\n",
-    "- Label: $y_H = \\text{mid}_{t+H} / \\text{mid}_{t+1} - 1$\n",
-    "\n",
-    "**Output Contract**:\n",
-    "- `labels/fwd_ret_15m.parquet` — primary label\n",
-    "- `labels/fwd_ret_5m.parquet` — fast variant\n",
-    "- `labels/fwd_ret_60m.parquet` — slow variant\n",
-    "- `labels/fwd_dir_15m.parquet` — classification variant\n",
-    "- `cv_config.json` — walk-forward CV configuration\n",
-    "\n",
-    "**Cross-References**:\n",
-    "- **Upstream**: Ch3 (AlgoSeek TAQ data), Ch6 ([`01_feasibility_analysis`](01_feasibility_analysis.ipynb))\n",
-    "- **Downstream**: Ch8 (`03_financial_features.py`), Ch9 (`04_temporal.py`)"
+    "Chapter 7, Section 7.2. Reads AlgoSeek NASDAQ-100 minute bars with NBBO quotes through\n",
+    "`load_nasdaq100_bars()`, whose coverage\n",
+    "[`01_feasibility_analysis`](01_feasibility_analysis.ipynb) establishes, and\n",
+    "`config/setup.yaml`, which declares the universe, the label set, the horizons and the\n",
+    "holdout boundary. Writes `labels/fwd_ret_5m.parquet`, `labels/fwd_ret_15m.parquet`,\n",
+    "`labels/fwd_ret_60m.parquet` and `labels/fwd_dir_15m.parquet`, each with a\n",
+    "`.digest.json` sidecar beside it. `03_financial_features.py` reads\n",
+    "`fwd_ret_15m.parquet`, which it names directly."
    ]
   },
   {
@@ -56,10 +51,10 @@
    "id": "b6dfca90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:00.240471Z",
-     "iopub.status.busy": "2026-07-14T04:54:00.240327Z",
-     "iopub.status.idle": "2026-07-14T04:54:01.818435Z",
-     "shell.execute_reply": "2026-07-14T04:54:01.817911Z"
+     "iopub.execute_input": "2026-07-31T09:11:34.929354Z",
+     "iopub.status.busy": "2026-07-31T09:11:34.928932Z",
+     "iopub.status.idle": "2026-07-31T09:11:36.891522Z",
+     "shell.execute_reply": "2026-07-31T09:11:36.891085Z"
     },
     "papermill": {
      "duration": 1.580942,
@@ -71,19 +66,41 @@
    },
    "outputs": [],
    "source": [
-    "\"\"\"NASDAQ-100 Microstructure: Label Engineering (Ch7).\"\"\"\n",
+    "\"\"\"NASDAQ-100 Microstructure: Label Engineering.\"\"\"\n",
     "\n",
     "import warnings\n",
-    "from datetime import UTC, date, datetime\n",
+    "from datetime import date, datetime, time, timedelta\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import polars as pl\n",
+    "import yaml\n",
+    "from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series\n",
+    "from ml4t.engineer.labeling import fixed_time_horizon_labels\n",
     "\n",
+    "from case_studies.utils.artifact_digest import value_digest, write_artifact\n",
+    "from case_studies.utils.label_diagnostics import effective_sample_size, panel_autocorrelation\n",
     "from data import load_nasdaq100_bars\n",
-    "from utils.cv_splits import generate_cv_splits\n",
+    "from utils.artifact_specs import resolve_label_horizon\n",
     "from utils.paths import get_case_study_dir\n",
+    "from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "CASE_STUDY_ID = \"nasdaq100_microstructure\"\n",
+    "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
+    "LABELS_DIR = CASE_DIR / \"labels\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad38bcc3",
+   "metadata": {},
+   "source": [
+    "All three parameters are read below. `MAX_SYMBOLS` keeps a seed-deterministic subset of\n",
+    "the universe and the two dates trim the history. Any of them shortens a run at the cost\n",
+    "of a thinner panel: the rank correlation in Section G needs a wide cross-section on each\n",
+    "decision minute, and the boundary profile in Section D needs whole sessions."
    ]
   },
   {
@@ -92,10 +109,10 @@
    "id": "810858da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:01.823096Z",
-     "iopub.status.busy": "2026-07-14T04:54:01.822830Z",
-     "iopub.status.idle": "2026-07-14T04:54:01.825314Z",
-     "shell.execute_reply": "2026-07-14T04:54:01.824787Z"
+     "iopub.execute_input": "2026-07-31T09:11:36.893209Z",
+     "iopub.status.busy": "2026-07-31T09:11:36.893115Z",
+     "iopub.status.idle": "2026-07-31T09:11:36.894676Z",
+     "shell.execute_reply": "2026-07-31T09:11:36.894368Z"
     },
     "papermill": {
      "duration": 0.004977,
@@ -110,10 +127,26 @@
    },
    "outputs": [],
    "source": [
-    "CASE_STUDY_ID = \"nasdaq100_microstructure\"\n",
+    "MAX_SYMBOLS = 0\n",
     "START_DATE = \"2020-01-01\"\n",
-    "END_DATE = \"2021-12-31\"\n",
-    "MAX_SYMBOLS = 0"
+    "END_DATE = \"2021-12-31\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb47ca20",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Everything that defines a label is declared in `config/setup.yaml` and bound here. A\n",
+    "horizon or a boundary typed into a cell is a second copy of a value the rest of the\n",
+    "pipeline reads from the file, and the two drift apart the first time either is edited.\n",
+    "\n",
+    "`resolve_label_horizon` returns each label's outcome horizon as a duration - `15min`\n",
+    "rather than a number of rows - which is the form the rest of the notebook keeps it in.\n",
+    "The flat band of the direction label is the friction floor the cost model declares:\n",
+    "a move smaller than it does not pay for its own spread."
    ]
   },
   {
@@ -122,10 +155,10 @@
    "id": "1457d387",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:01.828313Z",
-     "iopub.status.busy": "2026-07-14T04:54:01.828203Z",
-     "iopub.status.idle": "2026-07-14T04:54:01.830450Z",
-     "shell.execute_reply": "2026-07-14T04:54:01.830141Z"
+     "iopub.execute_input": "2026-07-31T09:11:36.895641Z",
+     "iopub.status.busy": "2026-07-31T09:11:36.895581Z",
+     "iopub.status.idle": "2026-07-31T09:11:36.905514Z",
+     "shell.execute_reply": "2026-07-31T09:11:36.905231Z"
     },
     "papermill": {
      "duration": 0.003947,
@@ -135,21 +168,54 @@
      "status": "completed"
     }
    },
+   "outputs": [],
+   "source": [
+    "setup = yaml.safe_load((CASE_DIR / \"config\" / \"setup.yaml\").read_text())\n",
+    "\n",
+    "\n",
+    "def declared_horizon(label: str) -> timedelta:\n",
+    "    \"\"\"The outcome horizon `setup.yaml` declares for *label*, as a duration.\"\"\"\n",
+    "    spec = resolve_label_horizon(CASE_STUDY_ID, label, setup)\n",
+    "    return timedelta(minutes=int(spec.removesuffix(\"min\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d1fea063",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:11:36.906506Z",
+     "iopub.status.busy": "2026-07-31T09:11:36.906448Z",
+     "iopub.status.idle": "2026-07-31T09:11:36.909029Z",
+     "shell.execute_reply": "2026-07-31T09:11:36.908733Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Date range: 2020-01-01 to 2021-12-31\n"
+      "Labels ['fwd_ret_15m', 'fwd_ret_5m', 'fwd_ret_60m', 'fwd_dir_15m'], primary fwd_ret_15m, flat band 0.05%\n",
+      "Holdout opens 2021-07-01 and seals each label on its own endpoint\n"
      ]
     }
    ],
    "source": [
-    "# Configuration\n",
-    "CASE_DIR = get_case_study_dir(\"nasdaq100_microstructure\")\n",
-    "LABELS_DIR = CASE_DIR / \"labels\"\n",
+    "PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
+    "LABEL_NAMES = [PRIMARY_LABEL, *setup[\"labels\"].get(\"variants\", [])]\n",
+    "RETURN_LABELS = [n for n in LABEL_NAMES if n.startswith(\"fwd_ret\")]\n",
+    "DIRECTION_LABEL = next(n for n in LABEL_NAMES if n.startswith(\"fwd_dir\"))\n",
+    "HORIZONS = {name: declared_horizon(name) for name in LABEL_NAMES}\n",
+    "PRIMARY_HORIZON = HORIZONS[PRIMARY_LABEL]\n",
+    "FLAT_BAND = setup[\"costs\"][\"friction_floor_bps\"] / 10_000\n",
+    "HOLDOUT_START = date.fromisoformat(setup[\"evaluation\"][\"holdout_start\"])\n",
+    "HOLDOUT_TS = datetime.combine(HOLDOUT_START, time())\n",
+    "GROUP_COLS = [\"symbol\", \"session_date\"]\n",
+    "PALETTE = dict(zip(RETURN_LABELS, (COLORS[\"blue\"], COLORS[\"amber\"], COLORS[\"copper\"])))\n",
     "\n",
-    "print(f\"Date range: {START_DATE} to {END_DATE}\")"
+    "print(f\"Labels {LABEL_NAMES}, primary {PRIMARY_LABEL}, flat band {FLAT_BAND:.2%}\")\n",
+    "print(f\"Holdout opens {HOLDOUT_START} and seals each label on its own endpoint\")"
    ]
   },
   {
@@ -165,42 +231,64 @@
     }
    },
    "source": [
-    "## 1. Load Minute Bar Data\n",
+    "## A. The learning task\n",
     "\n",
-    "Load AlgoSeek minute bars with microstructure fields. We need NBBO quotes\n",
-    "(CloseBidPrice, CloseAskPrice) to compute midprice-based labels that avoid\n",
-    "bid-ask bounce per Hasbrouck (2007).\n",
+    "The hypothesis is that the order flow of the last few minutes says something about where\n",
+    "a NASDAQ-100 name trades over the next few, and that whatever it says is small enough to\n",
+    "be eaten by the cost of acting on it. The label therefore has to be a return an intraday\n",
+    "trader could actually have captured, measured between two prices they could have traded\n",
+    "at, and it has to be honest about the delay between seeing a signal and getting filled.\n",
     "\n",
-    "**Memory requirement**: the full universe (114 symbols, 2020–2021) is ~40M\n",
-    "minute bars across 60+ microstructure columns and materializes to roughly\n",
-    "**28 GB** in memory — more than most laptops have. The raw load is about\n",
-    "**0.25 GB per symbol**, so:\n",
+    "The decision cadence comes from `setup.yaml`: a bar closes, that close is the last thing\n",
+    "observed, and the position goes on at the next bar. The primary horizon is the middle of\n",
+    "three - long enough that the move can exceed the spread, short enough to stay inside the\n",
+    "session and inside the regime the microstructure features describe. The fast and slow\n",
+    "variants ask the same question of a horizon a third as long and one four times longer,\n",
+    "which is a question about how quickly the information decays relative to what it costs\n",
+    "to trade on it. A direction variant discretises the primary label so the same hypothesis\n",
+    "can be posed as a classification task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35d184d4",
+   "metadata": {},
+   "source": [
+    "## B. Preparation before the label\n",
     "\n",
-    "| Symbols (`MAX_SYMBOLS`) | Approx. loaded size |\n",
-    "|---|---|\n",
-    "| 10 | ~2.5 GB |\n",
-    "| 25 | ~6 GB |\n",
-    "| 50 | ~13 GB |\n",
-    "| 114 (all, `0`) | ~28 GB |\n",
+    "Three things have to be true of the price series before a forward window means anything.\n",
     "\n",
-    "Peak usage runs higher than these figures because label computation holds\n",
-    "additional intermediates, so budget headroom. To run on a memory-constrained\n",
-    "machine, set `MAX_SYMBOLS` to a smaller value in the parameters cell (a\n",
-    "seed-deterministic subset), and/or narrow `START_DATE`/`END_DATE`. The\n",
-    "microstructure patterns this case study teaches are visible on any subset;\n",
-    "only the published full-universe results require the complete load."
+    "**The price has to be one a trade could cross at.** Trade prices alternate between bid\n",
+    "and ask as buyers and sellers arrive, so a return taken between two of them carries a\n",
+    "bounce that has nothing to do with information (Hasbrouck, 2007). The midprice of the\n",
+    "closing NBBO quote removes it, and the half-spread taken from the same quote is what\n",
+    "Section E prices the move against.\n",
+    "\n",
+    "**The window has to sit inside one session.** An overnight gap is not an intraday move,\n",
+    "so `session_date` joins `symbol` in the entity key and no label crosses either. Regular\n",
+    "hours only: the pre-market and after-hours books are thin enough that their quotes\n",
+    "describe a different market.\n",
+    "\n",
+    "**No eligibility filter runs before the label.** Once rows are dropped from inside a\n",
+    "series a shift counts survivors rather than bars, and the window silently spans whatever\n",
+    "was removed - which is the failure Section D exists to catch. The cost-feasible universe\n",
+    "`setup.yaml` declares is applied at backtest time, not here.\n",
+    "\n",
+    "Only four columns are read out of the sixty the microstructure schema carries. The label\n",
+    "needs the two quote sides and the keys, and projecting at the scan keeps a full-universe\n",
+    "run inside a couple of gigabytes instead of the twenty-eight the whole schema costs."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "dbc8ece7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:01.835811Z",
-     "iopub.status.busy": "2026-07-14T04:54:01.835591Z",
-     "iopub.status.idle": "2026-07-14T04:54:06.351010Z",
-     "shell.execute_reply": "2026-07-14T04:54:06.350585Z"
+     "iopub.execute_input": "2026-07-31T09:11:36.909947Z",
+     "iopub.status.busy": "2026-07-31T09:11:36.909887Z",
+     "iopub.status.idle": "2026-07-31T09:11:38.303140Z",
+     "shell.execute_reply": "2026-07-31T09:11:38.302522Z"
     },
     "papermill": {
      "duration": 4.517577,
@@ -210,34 +298,59 @@
      "status": "completed"
     }
    },
+   "outputs": [],
+   "source": [
+    "_hour, _minute = pl.col(\"timestamp\").dt.hour(), pl.col(\"timestamp\").dt.minute()\n",
+    "REGULAR_HOURS = ((_hour > 9) | ((_hour == 9) & (_minute >= 30))) & (_hour < 16)\n",
+    "_bid, _ask = pl.col(\"close_bid_price\"), pl.col(\"close_ask_price\")\n",
+    "\n",
+    "bars = (\n",
+    "    load_nasdaq100_bars(\n",
+    "        start_date=START_DATE,\n",
+    "        end_date=END_DATE,\n",
+    "        include_microstructure=True,\n",
+    "        max_symbols=MAX_SYMBOLS,\n",
+    "        lazy=True,\n",
+    "    )\n",
+    "    .select([\"timestamp\", \"symbol\", \"close_bid_price\", \"close_ask_price\"])\n",
+    "    .filter(REGULAR_HOURS)\n",
+    "    .with_columns(\n",
+    "        ((_bid + _ask) / 2).alias(\"mid_close\"),\n",
+    "        ((_ask - _bid) / (_bid + _ask)).alias(\"half_spread\"),\n",
+    "        pl.col(\"timestamp\").dt.date().alias(\"session_date\"),\n",
+    "    )\n",
+    "    .collect()\n",
+    ")\n",
+    "quoted = bars.filter(pl.col(\"mid_close\") > 0).sort([*GROUP_COLS, \"timestamp\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a4444ea4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:11:38.304999Z",
+     "iopub.status.busy": "2026-07-31T09:11:38.304918Z",
+     "iopub.status.idle": "2026-07-31T09:11:38.456933Z",
+     "shell.execute_reply": "2026-07-31T09:11:38.456465Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 48,211,601 minute bars\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Symbols: 114\n",
-      "Date range: 2020-01-02 04:00:00 to 2021-12-31 19:59:00\n"
+      "19,908,044 regular-hours bars, 114 symbols\n",
+      "104 dropped for a missing or non-positive quote midpoint\n",
+      "19,907,940 quoted bars over 505 sessions\n"
      ]
     }
    ],
    "source": [
-    "df = load_nasdaq100_bars(\n",
-    "    start_date=START_DATE,\n",
-    "    end_date=END_DATE,\n",
-    "    include_microstructure=True,\n",
-    "    max_symbols=MAX_SYMBOLS,\n",
-    ")\n",
-    "\n",
-    "print(f\"Loaded {len(df):,} minute bars\")\n",
-    "print(f\"Symbols: {df['symbol'].n_unique()}\")\n",
-    "print(f\"Date range: {df['timestamp'].min()} to {df['timestamp'].max()}\")"
+    "print(f\"{bars.height:,} regular-hours bars, {bars['symbol'].n_unique()} symbols\")\n",
+    "print(f\"{bars.height - quoted.height:,} dropped for a missing or non-positive quote midpoint\")\n",
+    "print(f\"{quoted.height:,} quoted bars over {quoted['session_date'].n_unique():,} sessions\")"
    ]
   },
   {
@@ -253,22 +366,25 @@
     }
    },
    "source": [
-    "## 2. Filter to Regular Trading Hours\n",
-    "\n",
-    "Restrict to 09:30--16:00 ET. Pre-market and after-hours bars have\n",
-    "wider spreads, lower liquidity, and different microstructure dynamics."
+    "The horizon is declared in minutes and applied to a frame of bars, so the spacing of\n",
+    "those bars is what converts one into the other. Measuring it is the whole of the fix for\n",
+    "a defect this notebook used to carry: a 15-row shift is a 15-minute return only on a\n",
+    "one-minute grid, and nothing in the loader promises one. The spacing is measured, the\n",
+    "grid is required to be uniform inside a session, and every horizon is required to be a\n",
+    "whole number of bars - at least two of them, so that the entry bar and the exit bar are\n",
+    "different bars."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "e6f803da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:06.357540Z",
-     "iopub.status.busy": "2026-07-14T04:54:06.357440Z",
-     "iopub.status.idle": "2026-07-14T04:54:14.055831Z",
-     "shell.execute_reply": "2026-07-14T04:54:14.055483Z"
+     "iopub.execute_input": "2026-07-31T09:11:38.458326Z",
+     "iopub.status.busy": "2026-07-31T09:11:38.458251Z",
+     "iopub.status.idle": "2026-07-31T09:11:39.155997Z",
+     "shell.execute_reply": "2026-07-31T09:11:39.155512Z"
     },
     "papermill": {
      "duration": 7.70059,
@@ -283,26 +399,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Regular hours bars: 19,908,044\n",
-      "Sessions: 505\n"
+      "Bar spacing 0:01:00, uniform within every session; horizons in bars {'fwd_ret_15m': 15, 'fwd_ret_5m': 5, 'fwd_ret_60m': 60, 'fwd_dir_15m': 15}\n"
      ]
     }
    ],
    "source": [
-    "df = df.filter(\n",
-    "    (pl.col(\"timestamp\").dt.hour() >= 10)  # >= 10:00 captures 09:30 due to bar labeling\n",
-    "    | ((pl.col(\"timestamp\").dt.hour() == 9) & (pl.col(\"timestamp\").dt.minute() >= 30))\n",
-    ")\n",
-    "df = df.filter(pl.col(\"timestamp\").dt.hour() < 16)\n",
+    "_gap = pl.col(\"timestamp\") - pl.col(\"timestamp\").shift(1).over(GROUP_COLS)\n",
+    "spacing = quoted.select(_gap.drop_nulls().unique().alias(\"gap\"))[\"gap\"].to_list()\n",
+    "assert len(spacing) == 1, f\"the intraday grid is not uniform: spacings {sorted(spacing)}\"\n",
+    "BAR = spacing[0]\n",
+    "HORIZON_BARS = {name: horizon // BAR for name, horizon in HORIZONS.items()}\n",
+    "for name, horizon in HORIZONS.items():\n",
+    "    assert horizon % BAR == timedelta(0), f\"{name}: {horizon} is not a whole number of {BAR} bars\"\n",
+    "    assert HORIZON_BARS[name] >= 2, (\n",
+    "        f\"{name}: a {horizon} horizon is {HORIZON_BARS[name]} bar on a {BAR} grid, so the \"\n",
+    "        f\"entry bar and the exit bar are the same bar and the label cannot be formed\"\n",
+    "    )\n",
     "\n",
-    "# Sort for time-series operations\n",
-    "df = df.sort([\"symbol\", \"timestamp\"])\n",
-    "\n",
-    "# Add session_date for session-bounded operations\n",
-    "df = df.with_columns(pl.col(\"timestamp\").dt.date().alias(\"session_date\"))\n",
-    "\n",
-    "print(f\"Regular hours bars: {len(df):,}\")\n",
-    "print(f\"Sessions: {df['session_date'].n_unique()}\")"
+    "print(f\"Bar spacing {BAR}, uniform within every session; horizons in bars {HORIZON_BARS}\")"
    ]
   },
   {
@@ -318,23 +432,39 @@
     }
    },
    "source": [
-    "## 3. Compute Midprice\n",
+    "## C. Label construction\n",
     "\n",
-    "Midprice = (CloseBidPrice + CloseAskPrice) / 2 reduces bid-ask bounce that\n",
-    "contaminates trade-price-based returns. This is standard practice for\n",
-    "intraday label construction (Hasbrouck, 2007)."
+    "One execution convention, written once and applied at all three horizons:\n",
+    "\n",
+    "$$r^{(H)}_{s,t} = \\frac{M_{s,t+H}}{M_{s,t+B}} - 1$$\n",
+    "\n",
+    "where $M$ is symbol $s$'s quote midpoint, $B$ is one bar and $H$ is the declared horizon.\n",
+    "The decision is taken on the bar closing at $t$, so the earliest price that can be\n",
+    "traded is the one a bar later - that is the execution delay `setup.yaml` declares - and\n",
+    "the position is held until $H$ after the decision. The numerator and the denominator are\n",
+    "both prices a trade could have crossed at, and the gap between them is what the strategy\n",
+    "actually earns.\n",
+    "\n",
+    "The entry price is the next bar's midpoint, which the uniform grid asserted above makes\n",
+    "exactly one bar of wall-clock time later; the last bar of a session has no next bar, so it\n",
+    "carries no entry and no label. The exit is resolved by **time**, not by counting rows: the\n",
+    "library looks for a bar at exactly $H - B$ past the entry, and a bar that is missing\n",
+    "resolves to nothing and nulls the label instead of letting a shift reach past the hole and\n",
+    "return a longer window under a shorter name. Materialising the entry price as its own\n",
+    "column is what lets the library express this convention - it divides by the price at $t$,\n",
+    "so shifting the series forward by one bar turns \"enter one bar late\" into \"start here\"."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "ffe93104",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:14.063650Z",
-     "iopub.status.busy": "2026-07-14T04:54:14.063547Z",
-     "iopub.status.idle": "2026-07-14T04:54:14.276424Z",
-     "shell.execute_reply": "2026-07-14T04:54:14.275889Z"
+     "iopub.execute_input": "2026-07-31T09:11:39.157759Z",
+     "iopub.status.busy": "2026-07-31T09:11:39.157686Z",
+     "iopub.status.idle": "2026-07-31T09:11:40.126506Z",
+     "shell.execute_reply": "2026-07-31T09:11:40.125952Z"
     },
     "papermill": {
      "duration": 0.21529,
@@ -344,52 +474,54 @@
      "status": "completed"
     }
    },
+   "outputs": [],
+   "source": [
+    "priced = quoted.with_columns(\n",
+    "    pl.col(\"mid_close\").shift(-1).over(GROUP_COLS).alias(\"entry_mid\")\n",
+    ").drop_nulls(\"entry_mid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c2fdca39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:11:40.128143Z",
+     "iopub.status.busy": "2026-07-31T09:11:40.128076Z",
+     "iopub.status.idle": "2026-07-31T09:11:44.237002Z",
+     "shell.execute_reply": "2026-07-31T09:11:44.236609Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Using midprice from NBBO quotes\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bars with valid midprice: 19,907,940\n"
+      "Constructed fwd_ret_15m, fwd_ret_5m, fwd_ret_60m on 19,856,894 bars with a tradable entry\n"
      ]
     }
    ],
    "source": [
-    "has_bid_ask = \"close_bid_price\" in df.columns and \"close_ask_price\" in df.columns\n",
+    "for name in RETURN_LABELS:\n",
+    "    held = f\"{(HORIZONS[name] - BAR) // timedelta(minutes=1)}m\"\n",
+    "    priced = fixed_time_horizon_labels(\n",
+    "        priced,\n",
+    "        horizon=held,\n",
+    "        method=\"returns\",\n",
+    "        price_col=\"entry_mid\",\n",
+    "        group_col=GROUP_COLS,\n",
+    "        timestamp_col=\"timestamp\",\n",
+    "        tolerance=\"0s\",\n",
+    "    ).rename({f\"label_return_{held}\": name})\n",
     "\n",
-    "if has_bid_ask:\n",
-    "    df = df.with_columns(\n",
-    "        mid_close=((pl.col(\"close_bid_price\") + pl.col(\"close_ask_price\")) / 2),\n",
-    "        half_spread=(\n",
-    "            (pl.col(\"close_ask_price\") - pl.col(\"close_bid_price\"))\n",
-    "            / (pl.col(\"close_bid_price\") + pl.col(\"close_ask_price\") + 1e-8)\n",
-    "        ),\n",
-    "    )\n",
-    "    print(\"Using midprice from NBBO quotes\")\n",
-    "else:\n",
-    "    df = df.with_columns(\n",
-    "        mid_close=pl.col(\"last_trade_price\"),\n",
-    "        half_spread=pl.lit(0.0005),  # Default 5 bps if no quotes\n",
-    "    )\n",
-    "    print(\"WARNING: No NBBO available, using last trade price\")\n",
-    "\n",
-    "# Filter bars with valid midprice (positive, non-null)\n",
-    "df = df.filter(pl.col(\"mid_close\").is_not_null() & (pl.col(\"mid_close\") > 0))\n",
-    "\n",
-    "print(f\"Bars with valid midprice: {len(df):,}\")"
+    "print(f\"Constructed {', '.join(RETURN_LABELS)} on {priced.height:,} bars with a tradable entry\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "2cd1ea41",
    "metadata": {
-    "lines_to_next_cell": 2,
     "papermill": {
      "duration": 0.002378,
      "end_time": "2026-07-14T04:54:14.281990+00:00",
@@ -399,39 +531,28 @@
     }
    },
    "source": [
-    "## 4. Create Labels\n",
+    "The direction label is the primary return discretised into a band around zero: a move\n",
+    "smaller than the friction floor is called flat because it does not pay for its own\n",
+    "spread. The library's binary method cannot express it - that method splits at zero and\n",
+    "reports whether the price merely changed - so the band stays notebook-local.\n",
     "\n",
-    "Forward midprice returns at three horizons. The shift(-1) in the denominator\n",
-    "enforces the 1-bar execution delay: you observe at bar $t$ close, enter at\n",
-    "$t+1$ midprice, and the label measures the return from entry to the target bar.\n",
-    "\n",
-    "**Implementation note**: Labels are computed at *minute* bar resolution using\n",
-    "`shift(-15)` rather than resampling to 15-min bars and using `shift(-1)`.\n",
-    "Both produce the same 15-minute forward midprice return. The minute-bar\n",
-    "approach avoids information loss from resampling and aligns the feature\n",
-    "matrix (also at minute resolution) with labels for exact row-level joins.\n",
-    "The setup notebook's \"1-bar at 15-min frequency\" specification is equivalent.\n",
-    "\n",
-    "**Session-bounded**: `.over([\"symbol\", \"session_date\"])` ensures shifts do not\n",
-    "cross overnight boundaries. This prevents overnight gap contamination in\n",
-    "intraday labels.\n",
-    "\n",
-    "**Horizons** (in minute bars):\n",
-    "- 5 bars = 5 minutes (fast, most cost-dominated)\n",
-    "- 15 bars = 15 minutes (primary, balances signal vs cost)\n",
-    "- 60 bars = 60 minutes (slow, tests residual microstructure content)"
+    "It is built by arithmetic rather than by a `when`/`otherwise` chain, because arithmetic\n",
+    "propagates nulls and that chain does not: a Polars comparison against a null is not true,\n",
+    "so an unguarded `otherwise` fires on every row with no forward window and files it as\n",
+    "\"down\". Here the outside-the-band test is null wherever the return is, and multiplying by\n",
+    "the sign carries that null through."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "2e56cf7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:14.285348Z",
-     "iopub.status.busy": "2026-07-14T04:54:14.285241Z",
-     "iopub.status.idle": "2026-07-14T04:54:14.295384Z",
-     "shell.execute_reply": "2026-07-14T04:54:14.294824Z"
+     "iopub.execute_input": "2026-07-31T09:11:44.238137Z",
+     "iopub.status.busy": "2026-07-31T09:11:44.238060Z",
+     "iopub.status.idle": "2026-07-31T09:11:48.106657Z",
+     "shell.execute_reply": "2026-07-31T09:11:48.106162Z"
     },
     "papermill": {
      "duration": 0.01235,
@@ -443,63 +564,38 @@
    },
    "outputs": [],
    "source": [
-    "def create_intraday_labels(df: pl.DataFrame) -> pl.DataFrame:\n",
-    "    \"\"\"Create forward midprice return labels at multiple horizons.\n",
+    "_outside = (pl.col(PRIMARY_LABEL).abs() > FLAT_BAND).cast(pl.Int8)\n",
+    "_direction = (_outside * pl.col(PRIMARY_LABEL).sign()).cast(pl.Int8)\n",
+    "_position = pl.int_range(pl.len()).over(GROUP_COLS)\n",
     "\n",
-    "    Each label computes: mid[t+H] / mid[t+1] - 1\n",
-    "    where t+1 is the entry bar (execution delay) and t+H is the exit bar.\n",
-    "\n",
-    "    Session-bounded: shifts do not cross overnight boundaries.\n",
-    "    \"\"\"\n",
-    "    group_cols = [\"symbol\", \"session_date\"]\n",
-    "\n",
-    "    df = df.with_columns(\n",
-    "        # Entry midprice (1-bar execution delay)\n",
-    "        entry_mid=pl.col(\"mid_close\").shift(-1).over(group_cols),\n",
-    "        # Exit midprices at each horizon\n",
-    "        exit_5m=pl.col(\"mid_close\").shift(-5).over(group_cols),\n",
-    "        exit_15m=pl.col(\"mid_close\").shift(-15).over(group_cols),\n",
-    "        exit_60m=pl.col(\"mid_close\").shift(-60).over(group_cols),\n",
+    "labels_df = (\n",
+    "    quoted.join(\n",
+    "        priced.select([\"symbol\", \"timestamp\", *RETURN_LABELS]),\n",
+    "        on=[\"symbol\", \"timestamp\"],\n",
+    "        how=\"left\",\n",
     "    )\n",
-    "\n",
-    "    # Compute returns from entry to exit\n",
-    "    df = df.with_columns(\n",
-    "        fwd_ret_5m=(pl.col(\"exit_5m\") / pl.col(\"entry_mid\") - 1),\n",
-    "        fwd_ret_15m=(pl.col(\"exit_15m\") / pl.col(\"entry_mid\") - 1),\n",
-    "        fwd_ret_60m=(pl.col(\"exit_60m\") / pl.col(\"entry_mid\") - 1),\n",
+    "    .with_columns(_direction.alias(DIRECTION_LABEL))\n",
+    "    .with_columns(\n",
+    "        (pl.len().over(GROUP_COLS) - 1 - _position).alias(\"from_end\"),\n",
+    "        _position.alias(\"bar_in_session\"),\n",
+    "        pl.col(\"timestamp\")\n",
+    "        .shift(-HORIZON_BARS[PRIMARY_LABEL])\n",
+    "        .over(GROUP_COLS)\n",
+    "        .alias(\"_label_end\"),\n",
     "    )\n",
-    "\n",
-    "    # Ternary classification: up / flat / down with cost-motivated threshold\n",
-    "    # 5 bps threshold: moves below this are within the friction floor\n",
-    "    flat_threshold = 0.0005  # 5 bps\n",
-    "\n",
-    "    df = df.with_columns(\n",
-    "        fwd_dir_15m=pl.when(pl.col(\"fwd_ret_15m\").is_null())\n",
-    "        .then(None)\n",
-    "        .when(pl.col(\"fwd_ret_15m\") > flat_threshold)\n",
-    "        .then(1)\n",
-    "        .when(pl.col(\"fwd_ret_15m\") < -flat_threshold)\n",
-    "        .then(-1)\n",
-    "        .otherwise(0)\n",
-    "        .cast(pl.Int8),\n",
-    "    )\n",
-    "\n",
-    "    # Drop intermediate columns\n",
-    "    df = df.drop([\"entry_mid\", \"exit_5m\", \"exit_15m\", \"exit_60m\"])\n",
-    "\n",
-    "    return df"
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "30e72558",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:14.299204Z",
-     "iopub.status.busy": "2026-07-14T04:54:14.299109Z",
-     "iopub.status.idle": "2026-07-14T04:54:17.057775Z",
-     "shell.execute_reply": "2026-07-14T04:54:17.057153Z"
+     "iopub.execute_input": "2026-07-31T09:11:48.108205Z",
+     "iopub.status.busy": "2026-07-31T09:11:48.108124Z",
+     "iopub.status.idle": "2026-07-31T09:11:48.425207Z",
+     "shell.execute_reply": "2026-07-31T09:11:48.424782Z"
     },
     "papermill": {
      "duration": 2.760897,
@@ -514,29 +610,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Labels created successfully\n",
-      "\n",
-      "Session boundary data loss:\n",
-      "  fwd_ret_5m: 255,230 rows lost (1.3%) — last 5 bars/session + 1-bar entry\n",
-      "  fwd_ret_15m: 765,690 rows lost (3.8%) — last 15 bars/session + 1-bar entry\n",
-      "  fwd_ret_60m: 3,062,760 rows lost (15.4%) — last 60 bars/session + 1-bar entry\n"
+      "market_data digest: 4d1187b627fe8bb0\n"
      ]
     }
    ],
    "source": [
-    "total_before_labels = len(df)\n",
-    "df = create_intraday_labels(df)\n",
-    "print(\"Labels created successfully\")\n",
-    "\n",
-    "# Session boundary data loss reporting\n",
-    "print(\"\\nSession boundary data loss:\")\n",
-    "for label_col, shift_bars in [(\"fwd_ret_5m\", 5), (\"fwd_ret_15m\", 15), (\"fwd_ret_60m\", 60)]:\n",
-    "    valid = df[label_col].drop_nulls().len()\n",
-    "    lost = total_before_labels - valid\n",
-    "    pct_lost = 100 * lost / total_before_labels\n",
-    "    print(\n",
-    "        f\"  {label_col}: {lost:,} rows lost ({pct_lost:.1f}%) — last {shift_bars} bars/session + 1-bar entry\"\n",
-    "    )"
+    "MARKET_DATA_DIGEST = value_digest(quoted, [\"symbol\", \"timestamp\", \"mid_close\"])\n",
+    "print(f\"market_data digest: {MARKET_DATA_DIGEST}\")"
    ]
   },
   {
@@ -552,21 +632,32 @@
     }
    },
    "source": [
-    "## 5. Label Quality Assessment\n",
+    "## D. Window validity\n",
     "\n",
-    "Evaluate label distributions, class balance, and cost-feasibility."
+    "A shift always returns something; the question is whether what it returns is the quantity\n",
+    "the label claims. Each property below fails silently and leaves plausible numbers behind,\n",
+    "so each is asserted rather than described.\n",
+    "\n",
+    "The second is what separates this construction from the row shift it replaces. Every\n",
+    "labelled window is required to span exactly its declared horizon in wall-clock time - not a\n",
+    "bar count that happens to agree - so a grid that was ever coarser or gappier than it looks\n",
+    "would raise here rather than ship a longer return under a shorter name.\n",
+    "\n",
+    "The third catches a short label masked by a longer one's null set. Each session has to be\n",
+    "short by exactly its own horizon and no more, so `fwd_ret_5m` carries ten more rows per\n",
+    "session than `fwd_ret_15m`; an equal count means one label was gated by the other's nulls."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "15531267",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:17.064034Z",
-     "iopub.status.busy": "2026-07-14T04:54:17.063954Z",
-     "iopub.status.idle": "2026-07-14T04:54:17.778181Z",
-     "shell.execute_reply": "2026-07-14T04:54:17.777428Z"
+     "iopub.execute_input": "2026-07-31T09:11:48.426439Z",
+     "iopub.status.busy": "2026-07-31T09:11:48.426358Z",
+     "iopub.status.idle": "2026-07-31T09:11:54.230592Z",
+     "shell.execute_reply": "2026-07-31T09:11:54.230115Z"
     },
     "papermill": {
      "duration": 0.716492,
@@ -581,50 +672,53 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Forward Return Statistics ===\n",
-      "  fwd_ret_5m: n=19,652,710, mean=0.000003, std=0.002172, [p5=-0.00295, p95=0.00292]\n",
-      "  fwd_ret_15m: n=19,142,250, mean=0.000017, std=0.003870, [p5=-0.00534, p95=0.00527]\n",
-      "  fwd_ret_60m: n=16,845,180, mean=0.000067, std=0.007358, [p5=-0.01045, p95=0.01011]\n"
+      "fwd_ret_15m: 19,142,250 labelled, every window exactly 0:15:00\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_5m: 19,652,710 labelled, every window exactly 0:05:00\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_60m: 16,845,180 labelled, every window exactly 1:00:00\n"
      ]
     }
    ],
    "source": [
-    "# Return statistics by horizon\n",
-    "label_stats = {}\n",
-    "for label_col, horizon_name in [\n",
-    "    (\"fwd_ret_5m\", \"5m\"),\n",
-    "    (\"fwd_ret_15m\", \"15m\"),\n",
-    "    (\"fwd_ret_60m\", \"60m\"),\n",
-    "]:\n",
-    "    vals = df[label_col].drop_nulls()\n",
-    "    label_stats[horizon_name] = {\n",
-    "        \"count\": len(vals),\n",
-    "        \"mean\": float(vals.mean()),\n",
-    "        \"std\": float(vals.std()),\n",
-    "        \"median\": float(vals.median()),\n",
-    "        \"p5\": float(vals.quantile(0.05)),\n",
-    "        \"p95\": float(vals.quantile(0.95)),\n",
-    "    }\n",
-    "\n",
-    "print(\"=== Forward Return Statistics ===\")\n",
-    "for horizon, stats in label_stats.items():\n",
-    "    print(\n",
-    "        f\"  fwd_ret_{horizon}: n={stats['count']:,}, \"\n",
-    "        f\"mean={stats['mean']:.6f}, std={stats['std']:.6f}, \"\n",
-    "        f\"[p5={stats['p5']:.5f}, p95={stats['p95']:.5f}]\"\n",
-    "    )"
+    "for name, h_bars in ((n, HORIZON_BARS[n]) for n in RETURN_LABELS):\n",
+    "    span = pl.col(\"timestamp\").shift(-h_bars).over(GROUP_COLS) - pl.col(\"timestamp\")\n",
+    "    checked = labels_df.with_columns(span.alias(\"_span\"))\n",
+    "    tail = checked.filter(pl.col(\"from_end\") < h_bars)\n",
+    "    labelled = checked.drop_nulls(name)\n",
+    "    # 1. An incomplete forward window is null, never a value.\n",
+    "    assert tail[name].null_count() == tail.height, name\n",
+    "    # 2. Every labelled window spans exactly the declared horizon in wall-clock time.\n",
+    "    assert labelled.filter(pl.col(\"_span\") != HORIZONS[name]).height == 0, name\n",
+    "    # 3. Each session labels its first n - h bars, so no label crosses a session boundary and\n",
+    "    #    none is gated by another label's null set.\n",
+    "    counted = checked.group_by(GROUP_COLS).agg(\n",
+    "        (pl.len() - pl.col(name).is_not_null().sum() - h_bars).alias(\"excess\")\n",
+    "    )\n",
+    "    assert counted.filter(pl.col(\"excess\") != 0).height == 0, name\n",
+    "    print(f\"{name}: {labelled.height:,} labelled, every window exactly {HORIZONS[name]}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "5e1000d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:17.782808Z",
-     "iopub.status.busy": "2026-07-14T04:54:17.782643Z",
-     "iopub.status.idle": "2026-07-14T04:54:17.797367Z",
-     "shell.execute_reply": "2026-07-14T04:54:17.796894Z"
+     "iopub.execute_input": "2026-07-31T09:11:54.231845Z",
+     "iopub.status.busy": "2026-07-31T09:11:54.231758Z",
+     "iopub.status.idle": "2026-07-31T09:11:54.401077Z",
+     "shell.execute_reply": "2026-07-31T09:11:54.400621Z"
     },
     "papermill": {
      "duration": 0.017163,
@@ -639,38 +733,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Direction label distribution (15m, threshold=5bps):\n",
-      "shape: (4, 2)\n",
-      "┌─────────────┬─────────┐\n",
-      "│ fwd_dir_15m ┆ len     │\n",
-      "│ ---         ┆ ---     │\n",
-      "│ i8          ┆ u32     │\n",
-      "╞═════════════╪═════════╡\n",
-      "│ null        ┆ 765690  │\n",
-      "│ -1          ┆ 7637812 │\n",
-      "│ 0           ┆ 3685713 │\n",
-      "│ 1           ┆ 7818725 │\n",
-      "└─────────────┴─────────┘\n",
-      "  ?: 765,690 (3.8%)\n",
-      "  Down: 7,637,812 (38.4%)\n",
-      "  Flat: 3,685,713 (18.5%)\n",
-      "  Up: 7,818,725 (39.3%)\n"
+      "fwd_dir_15m: null on all 765,690 bars where fwd_ret_15m is null\n"
      ]
     }
    ],
    "source": [
-    "# Classification label distribution\n",
-    "dir_dist = df.group_by(\"fwd_dir_15m\").len().sort(\"fwd_dir_15m\")\n",
-    "print(\"\\nDirection label distribution (15m, threshold=5bps):\")\n",
-    "print(dir_dist)\n",
-    "\n",
-    "# Compute class balance\n",
-    "total = dir_dist[\"len\"].sum()\n",
-    "for row in dir_dist.iter_rows(named=True):\n",
-    "    pct = 100 * row[\"len\"] / total\n",
-    "    label_name = {-1: \"Down\", 0: \"Flat\", 1: \"Up\"}.get(row[\"fwd_dir_15m\"], \"?\")\n",
-    "    print(f\"  {label_name}: {row['len']:,} ({pct:.1f}%)\")"
+    "# 4. No discrete label is derived from a null return.\n",
+    "_unlabelled = labels_df.filter(pl.col(PRIMARY_LABEL).is_null())[DIRECTION_LABEL]\n",
+    "assert _unlabelled.null_count() == _unlabelled.len()\n",
+    "print(f\"{DIRECTION_LABEL}: null on all {_unlabelled.len():,} bars where {PRIMARY_LABEL} is null\")"
    ]
   },
   {
@@ -686,23 +757,24 @@
     }
    },
    "source": [
-    "### Cost-Sanity Check\n",
-    "\n",
-    "Compare the typical return magnitude to the half-spread cost. If the median\n",
-    "absolute return is close to or less than the half-spread, the horizon is\n",
-    "cost-dominated and unlikely to be tradeable."
+    "Position zero below is the last bar of each session. Each label's non-null rate has to\n",
+    "fall to zero over exactly the last `horizon` positions and sit flat beyond them, and the\n",
+    "three curves have to step down at three different places. A scalar count of valid rows\n",
+    "shows neither failure this catches: a tail fabricated instead of nulled, and a short\n",
+    "label carried on a longer one's null set - which is what this notebook shipped until now,\n",
+    "and which would draw the 5-minute curve exactly on top of the 15-minute one."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "7d735ff3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:17.803720Z",
-     "iopub.status.busy": "2026-07-14T04:54:17.803638Z",
-     "iopub.status.idle": "2026-07-14T04:54:18.687164Z",
-     "shell.execute_reply": "2026-07-14T04:54:18.686703Z"
+     "iopub.execute_input": "2026-07-31T09:11:54.402097Z",
+     "iopub.status.busy": "2026-07-31T09:11:54.402030Z",
+     "iopub.status.idle": "2026-07-31T09:11:54.628448Z",
+     "shell.execute_reply": "2026-07-31T09:11:54.627814Z"
     },
     "papermill": {
      "duration": 0.885655,
@@ -712,85 +784,62 @@
      "status": "completed"
     }
    },
+   "outputs": [],
+   "source": [
+    "profile = (\n",
+    "    labels_df.filter(pl.col(\"from_end\") <= max(HORIZON_BARS.values()) + 2)\n",
+    "    .group_by(\"from_end\")\n",
+    "    .agg([pl.col(name).is_not_null().mean().alias(name) for name in RETURN_LABELS])\n",
+    "    .sort(\"from_end\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "5fc6af1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:11:54.629646Z",
+     "iopub.status.busy": "2026-07-31T09:11:54.629571Z",
+     "iopub.status.idle": "2026-07-31T09:11:54.711131Z",
+     "shell.execute_reply": "2026-07-31T09:11:54.710703Z"
+    }
+   },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Cost-Sanity Check ===\n"
-     ]
-    },
-    {
      "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>horizon</th><th>median_abs_ret_bps</th><th>median_half_spread_bps</th><th>pct_exceeds_cost</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;5m&quot;</td><td>8.17</td><td>2.42</td><td>80.2</td></tr><tr><td>&quot;15m&quot;</td><td>15.31</td><td>2.44</td><td>88.9</td></tr><tr><td>&quot;60m&quot;</td><td>30.6</td><td>2.55</td><td>94.1</td></tr></tbody></table></div>"
-      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApAAAAFnCAYAAAARynlsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAksJJREFUeJzs3XdYE1kXB+BfQiD0Lk0R7GBDRMWOBUVd+679s/euuLZd2+ra17r2gmXXta+uXbGAvWHviiAWioj0Ekju90dgdKQlFBOS8z4PzyWTyczJJLk5mXKPgDHGQAghhBBCiIKEqg6AEEIIIYSULJRAEkIIIYQQpVACSQghhBBClEIJJCGEEEIIUQolkIQQQgghRCmUQBJCCCGEEKVQAkkIIYQQQpRCCSQhhBBCCFEKJZCEEEIIIUQplECqyMUrN2Fk6wojW1cMGze9wMtp06Uft5w3Ye+LMML8FdVz0BTzl67htsdfew5x013rtOSmF5Vh46Zzy7x45WaRLZfkLqfXsbg/AxKJBHMXrUL1eq1hVroGjGxd0aP/mAIv7689h7h45y9dU4SRlmy5fXa1hSq/R1ShOPpkbSRSdQCqMn/pGiz4Y22u95uZmuDDS/piJiXL0RNn8eDxMwDA/3p0gVPZ0iqOSLVK+vZYvWEHFq/YoNRjshJDM1MTjBnevzjCIkStXbxyE5euyr+/27dtCbfqlCgWB61NIEnhudVwhf+RvwEANqWsVByNdpkyYTgG9PkJAFDNtTI3/eipc9i19zAAoEnDeiUuYSpqRbk9dm1ZhdS0tCKKTDGn/AO4/1cunoVqrpVhaWGe52OyfhiXdXSgBFJB/Xp1RfOmDQAAFcs7qzYYUmiXrt786nNQmhLIYkIJJIDWLZtg8vjhvGkiHR0VRaP+ZDIZJJJ0mJmaoKGnh6rD0UoVyzvTF913VrtW9e++zvCIKO7/If17QiAQfPcYtIFjGQc4lnFQdRhEgyUlJcPIyFDVYRQpOgcSQClrKzT09OD91atTi7s/KSkZ46fMQePWP8G5WmOYl6kJ+4p10bxdT+zYdSDHZZ45fwldeg+DU9WGMC9TExXdvNBn8HiEvc35/JLAyzfQrG0PWJZ1Q5XaLbBu819KP4+k5GRMmbkQztUaw8qpFjr3Gpbj+gIuXUfXPsNR1rUBzMvURGX35hg2bjpevQ7lzff1eUE7/jmIxcvXw8WjBcxK18DNoPu5nv+VNS2nP9c6LQsdy87d/2LNxh2o4ekDC8ea8GzeGQGXriu0jb6O49XrUHTrOwo25TxQpkp9jJs8B6mpX/Yw5Xa+2Juw99z0Nl36KbTenGzduReNW/8Em3IesHCUv0d++Gkglq/Zku9jvz0HMiumrL1tANC2a/9s50levHITP/w0EGWq1IdZ6RpwqtoQTX264+dfFyAuPiHf9UokEiz7czPqt+iCUs61Ye3sDs/mnfHH6s2QSCTcfNNmL+bWfT7wKje9Uq1m2bbb5u27uXk3b98NoPCvt6Lb44/Vm9GmSz9UqtUMVk61YO3sDo8m7fHbwpVITk7hLbOozpu6++Ax/jdkAspVbwLzMjVRrnoT9Bk8HnfvP+bmyXrvhYa946YZ21XN89zFrG2WJezth1w/d1n+PXIK9Zp1goVjTbg1aIOD/53MNs/H6BhMnbUINevLt3/pyp7o2mc4bt6+p9DzTUlJxS+/LeUeX8q5NqrW8UavgWNx5IR/gdelyOdHJpNhyYoNqNO0A6ycanH9a9c+w3l9d17nQCryegHZ+4vdB46gTtMOeW7bnOzYdQAdewxBldotUMq5NizLuqFmfR9Mmv47oj995s379bmLDx8/x6Tpv8OpaqNc+3+pVIr5S9egopsXrJ3d0bZLf+4UD0UV5HlGRH3Ez7/MR/V6rWHhWBMOleqhTZd++PfIKYXXq2jfY2Tryjs9bcT4X/I8vzX602cMGzcdpSt7wra8B/oNnYiYz7HZ5jt28hx++GkgSlf2hIVjTdRq2BYL/liLlJRU3nxfvyZ3HzzGiPG/oqxrA9iU17ydLbQHUgEJSUnYsmMvb1p6ejpuBt3HzaD7+BARiemTRnP3LVy2Fr8v4Xfy4RFROHzsDIYP6oOyjvzDaNdv3sHeg8eQkZEBAHj3PhyTZyyAS+UKaOHVUOE4+w6diGcvgrnb/ucvYdCoKTh7dBc3bdO2f+A7/Xcwxrhp7z9EYNfewzhy3B/HD2yDh3uNbMteunIjQt68VTgWRRQ0liUrNvBiefTkOXoOGIOnQedgYW6m0LpjY+PR4ode+BQTCwBISpZ/IVlZmmP29AmFel6K+Gf/fxg3eQ5vWnhEFMIjovDiVQh8xwwp8nW+eBWCrn2G8zq86E+fEf3pM4LuPcTIIX1gZmqS6+PT0iTo2GMwLl+7zZv+6MlzPHryHP7nL+Lovq3Q09NDI08P/LlhOwDgVtB9tPBqiHfvw/EhPBIAEHT3ETIyMiASiXDjq+SgUf062dZbFK93bnbtPYQXr0J40569CMazF8G4fuseTv67vVDL/9bxU+fRZ8gEpKenc9OiPkbj8LEzOH76AnZtWYkf2rQo0nXm5uB/J/H85Wvu9qvXbzBgxM+oUc0FlSuWAwC8ffcBLTv0wfsPEdx8Ekk6Tp+9iPOB1xSK13f6POzc/e+XxyMdb96+x5u372FgYICO7VopvS5FPz9LVm7AvMV/8uZ79z4c796HIz4+Ef0zTwPJTUFfr937j/Deszlt29z8e/Q0zgVc4U0LDglDcMguBFy+jiv+B6GvL872uF4Dx/LWmVP/P3nGAmz0+4e7ffHqTfh06lvgz5EizzP0zTu0aN8LkVHR3HwSSTouXb2FS1dv4e79x5g3c1Ke61Gm71GWT+e+vO/Ng0dOQaSrC791S7hp8xavxqLl63mPexkcivlL1yDg0jUc2++X47r7DplY5N+b6oT2QALYtfdwtj1lX+9RMzQwwMypY/HX5hU4sm8LTv67Azs2LkPF8k4AgJVr/bhfQHfuPeIlj/17/4gDf63D9g1/oGvHNhAKsx+CCg4JQxtvLxz4ax1+6tyOm+731z6lnsf7DxFYvXQOtq5dAnMzUwDAtZt38OTZSwDyjnPqrEVgjEEoFGLqxBE4uGsDunZsAwBISEzC8PHTeQldlpA3b9Hjxw44uGsDNq9ZBAd7m1zj8D/yN/d35r+/UL1qFe6+1i2aFEksvmOGYP/OdahRzYWbf9+/xxTeVvEJibC2ssQ/fqswa+o4brqy27ygjp86DwAQiURYvXQOjh/YBr91SzFu5EA4ly2j9PLsbEvB/8jfaN2yCTftj/m/cq+DWw35nsCs5HHU0L44fmAbdm1dhdnTxqN2rer5Hh5ds2kH14GXKW2Pbev/wPYNf8CxjD0A4PK12/hz4w4AQMP6HtzybgTdk7dfJYrJKSl4+Pi5fPot+XRLCzO4VqmYbb0Feb0V2R4AMLhfD2xZuxj//rMRpw7twP6d6+Dj3RQAcPHKDVy/dTfPbaKMpKRkjPKdwSUjQwf0xL//bMSwgb0AyH+UjvKdgaSkZPi0bAr/I3/D1saae3xW7P16dc1x+f16deXOSQYAWxtr7jG7tqzKNv/zl6/Rv/ePOPj3ejRrUh+AfI/d9q/2zE2YOpdL6Hp374TDezZj1ZLZMDYyRHp6OkZO/BVJScl5Pu/jp+Xv9bKODti1dRWO7NuCdSt+R+/unWCR2U8puy5FPz/HMuczNzPF1rVLcGy/HzavWYQh/XvAzrZUnnEr83p9K+TN23y3bW5+7NQW61fOx8FdG3Dq0A4c3LUBvbt3AiD/cfPfcf8cHxf9KSbP/v/5y9fYtE2+h18oFOLXyWNw8O/1qFenFt7kcmQsP4o8zwnT5nLJY9OG9bB/5zos+m0qlwQvX7MFt4Lu57keZfoe/yN/o2/PL5+RyeOHc58Dn5ZNsy07Ni4eW9cuwcrFs6CnpwsAOHD4BHdEJujuQy55tLMthXUrfsfhPZvRxtsLAHDlehC37m+9fR+OX34ejf/2bsHiudPyfI4lEe2BVICpiTHcqrti3Za/8eDRU3yOjYdUKuXuT0xKxvOXIahRrQp2HzjCTe/W5QesW/E773ZOSllbYeem5RCL9VC7Vg0cOHwCgDyxVMaMKWMxuF8PAMC1m0HcXtPXIWGo6lIJh46ehkQi7ww7tvPGrGnjAQAtvRriyvXbiIyKxtPnwXjw+Fm2k44b1KvN+0UGAB/Co5CTr8+LnDlvGR49kScKzZrUx7IFMwCgULG0b9OS+8WanJKC/sPl/yu7vbZt+ANu1V3R6Qdg77/H8Pzla0R/+oy4+IQ898QVBZFI/tHT09VFeeeyqF2rOkxNjNHjx/YFWp5YrIeGnh4oZf3lYqZqrpV5r4Wu7pePu3PZMnCpUgF2NvIv0SkTR+S7jn3/Huf+X7loJtq2bg4AMDYyxE99RwEA9h86gUljh8LK0gIulcvj6fNg3Aq6D8YYl0C6VqmIp89f4cbteyhT2h6vQ+WvW4N6HjkmsQV5vRXZHgDQwqshFq/YgGs37yDq4yfeniZA/oOwfl33fLeNIs4FXuEOQbq7VcPKxbMBAD4tm+LWnQe4e/8xoj99xvnAq+jQzhs2pawgFn/Zq5Hf+cbfnseXtQ1yU6OaC9c/WVlaoNmlngCA1yFvAAAxn2Nx+txFAPJkdOD/ugEAqrpUQguvhjhy4iw+xcTC/8JldG7fOtf1ZL3XzUxNUc7ZES6VKkAs1kP/3j9y8yi7LkU/P7qZ8xkaGqC8syOqV60CQ0MD9O7WKc9tCSj/eimzbfPSomkDLFq+HhcuXkN4ZBTS0iS8++/cf5RjP5Ff/3/89HnuB3nn9q3xy8/yo2YNPD1QsaYXklNSsi0zP4q8h85euAxA/n78e+tKWFlaAAA+RERh9fptAIB9h46jrodbrutRpu9p6OmBCxevcfNXKO+U5+dg5aJZ3Ot3/PQF+J+/BKlUijdv36NmNRfsOXiUm7dvz66oVMEZADCkfw+cOhsIANhz4CgmjR2abdkTRw/Gr5Plw255N2uUawwlFSWQyPkimq+vKv7v+Bn0HjQ+z2XExccDAO/cvbatmim0/noebtwXhZWl+ZdlxsUr9PgsjRvW5f7/+krN2MxfUl/HVqd2Te5/XV1duNVwxZlzl+TzBYdmS9raKPhcvrb97/3c+UgulStg19ZVXMdfmFgaN/hymPPr56nIOXxZsn4U5LicuPhiTyD79uqKg/+dRHJKCtp3GwQAKO1gh8YN6mLMsH7FcsHGD21a4LeFK/EpJhZTZi7ElJkLYWFuhjq1a6Jfr67c3t/c8F+zL529h3vNHOdpVL8Onj4PRsznOLwMDuXOYxszrB9GT5qF67fuooyDHTd/w/o5d/JF8XrnJOzte7Rs3xvxCYm5zpP1uS4KL4NDuf/rfvWeB4A67jW4c+pefnP+b3Fp3OCr/oLX78i36+uQMC7hiIyKRquO/8txOc+/OvyXk/69f8SSlRvx8PEzNGzZFTo6OqhUwRnezRtjwuhBsLe1UXpdin5++vf+UX6aUXgkmv/QCwKBAOWcHNGsSX2MGzkAlSrkfji5MK9Xfts2NwmJSWjRvjfvMP63cltGfv1/6Jsv59N+3b+YmZqgUkVn3H/4NM/YclxnPs8z+PUb7nUt7+zIJY+AfBtm+fac928p2/coI7ftlvX9+/Vyl67aiKWrNmZbxrenwWRp17pZgWIqKegQNnK+iObrK1w3bP1yzsj/enbBkX1b4H/kb975iTJZ9kOtijI3/3IYJyvBAgAG5ZZpYfblPBbecnI4DPyt/A5fKjtMz7nAKxg/dS4AwNrKAgf+Ws8dVilsLObmBX+eX5bBj0Uk+nLVfdZivo7j6z3On2L4J7IXhHezRjh3dBcG/q8b3Gq4wtDAAO8/RGDvwaPw6dwPIaFFf96MnU0pXD5zAL5jhqChpwesLM3xOTYO/ucvoe/Qidh/6Hj+C8lBbq9Xo/pfOuaLV27g/qOnsClljZ+6tIOOjg5u3r7HP/8xl70ERfF652TXvsNc8uhZpxb2bl8D/yN/Y+KYwdw8hflcK0MVV1dbfN3v6BS830lKznvP1axp47lTeCpXLAeBQIBnL4KxZuMOdOw+hDv3W5l1Kfr5GfC/bji0exN6deuIqi6VoKeni9ehYfD7ax98OvdDrJI/0rPk93oVdNseOeHPJY9VKpXHzk3L4X/kb97hTxmT5bzOYuz/c1OY91BRvOeLYhkWvP4l+/eAIjIyMrLtKQYAm1LWOcytOSiBVEB4RCT3/7IFv6KlVyPUr+vOm57l68Qza/e2uvg6tqC7D7n/09PTeb8+K1ZwxreU+aA+fvoC/xs8ARkZGRCL9bB3x1qUc3Yssli+FzMTY+7/r08A9z9/qdDLZozBs6471iybi6tn/0Xk69tY+NtUAPLDtP4XCrYOoeDLR1om43/RMMZQ1rE05s2cBP8jfyPs6TVcOr2fu//IibN5Lpv/mj3g/r99536O8zT6ao/iRr9/IJGkw7OOG4yNjFDVpRLevH2PY6fOAQCMDA3h7lZNsSephLy2x9enYEwePwzt27ZEQ08PxMfnvkeyMCp99V6+/dV7/tvblQo5PFPWZ7WwyW/5cmW5ZZV3Lov4D4+QFPmU9xf77gFmTh2b77K6dfkBf21egbtXTiAy+Da6dPABADx59hIvg0OVXpeinx/GGFq3aIItaxbjVuARRL0Owuhh8hEAIqOi8zzH9Xu9Xl/7+j05bGBv/NipLRp6eiA1h+REWc5OX84NvXvvEfd/XHwCXr4KLfTyc/L16/o69C3vx/etO1/6kPyGJFO27/n6WoNvP/fK4u1MWrUg2/syKfIpPobc4Z1ukkXTh92iQ9gAPkZ/wtUbQdmme9SqAbFYD45lHLjDGfMW/wnv5o2xe/8RPH2e/dBNzx87cEPw7Pv3GIwMDdC+TQskJafg2KnzGNyvO2+3//fUpYMPZv6+HOnp6fjvuD9+X/In6nq44Z+9hxER+REA4FqlAmpmXqhQEB+jY/Dj/0Zwe3YG9PkJMpmM2776YjFq16r+XWIprPLlynL/7zl4FOWcyyIpKQkr1voVetk//zIfEVEf0cKrIUo72EEkEuHq9S9XGOb0a1YRX+9Z3XPgKHR0hNDR0UFDTw/s+/c4tu7cg/ZtveFctjRMTUwQePnLcDj5rbN71x+481knTp+HhMQkCAQCzPp9OTdPty5fLgIr7WAH57JlEBr2jjuRP2t4LM86bnj4+Bl36KeuR03eXpOiktf2KPvV+YLrtvwNXT093L5zHzv+OVjkcQBAS69GsLI0x6eYWNy59wi+0+fBx9sLZ85exJ3ML3RrKwulRl7IiYW5KWI+xyE8Igp7DhxFWUcH2JSyUnrcUEsLc7Ru2QSnz17E69AwdOs3Cv17/whjYyO8ffsB9x89xX/H/XHh+J48B2hv2b433Gq4wsO9JhzsbJCYlIRnL15x96dJJEqvS9HPT5/B42FsbIRGnh5wcLCDNCODN/zO18O/ZIv7O71eX/v6Pblz90E4O5XB65AwLFGyGlFO2rVujpnzlgEADh/3x6Ll61CrZjVs9NuFpOS8L4QqKCtLC3g3bwz/85eQliZB36G+GDu8H16HvuWG7AKA7rlcH8Ddr2TfY/7V3tj/jp+Bc9ky0NUVcd/pyujRtT33nT5t1iJ8jo1DddfKiItPwOvQMJwLuIqyZRywYdV8pZarCSiBBHDm3CXunLuvPbl1Fk5lS2NQ3+7cWHZrNu7Amo07oK8vhrtbtWxjgXm418D0SaOwcNk6AMC2v/dj299f9vJknRyuCmVK22PJvGnwnf47ZDIZF2MWE2MjbFy1sFC/mp4+f4W378K52xv9/uENG1HW0QFPb5/7LrEUVjXXyvCsUws3bt9DamoaZs+Xd1YulSvwhn0oiJTUVBw+dgaHj53Jdp+BgT7at8l53L78eDWqxw2f89eef/HXHvnwKUmRTyFjMly5HoQr17P/WAL4HXBOxgzrj9NnA3HlehDC3n7AgBE/8+5v3KAOxn5T+aRhfQ/eWIaemQlkvTq1eENj5TR8T1HIa3v0/KkDlqzciOSUFJwPvMp9xhvUq41rN+8UeSxGRoZYt/x3/G/oRKSnp2f7bOjq6mLd8t8LPdhw00aeOHzsDKRSKQaPngIA6NOjMzatXqj0slYtns0NrXP67EWcPntR6WV8jI6RX/27bXe2+1yrVECNzFEalFmXop+fuPgE/HfcnzceaBabUtbwalw/13V8r9fra+18msPOthQiIj/i/sOn+LGP/OK2onhPulSugCH9e2DLjr2QSqXc8EYGBvpwsLflhtgqaisWzkTLDr0RGRWNwMvXeT9aAcB3zJA8L6ABlO97mjSsB4FAAMYY772U9Z2ujDq1a2Ka70gsWr4esXHxmD57cbZ5+vTorNQyNQUdwlZAlw4++HPpb6hY3gn6+mJ41KqBw7s3oapLpRznnzFlLA7u2oBWLZrAytIcurq6sLezQacfWsFZxaXlhg3sjaP7tqJ1yyawtDCDSCSCvZ0NenfvhMv+B3Icd1EbYsmN37ql8G7eGPr6YlhbWWLU0L74a/OKQi+3x48d0KdHZ1SuWA5mpibQ0dFBKWsrdGjbEv7//Z3tkL+i2rZujgVzpqC8c9lse/Q869TCqKF9UatmVVhbWUBHRwdmpiZoVN8DOzctz3WUgCxisR6O7vPD3Bm+qF61CgwM9KGvL0Y118r47VdfHNmbfRy2xl8lhrq6uqjtVp2L5WvFVdEor+3hWMYBR/ZtQR33mjAw0Ed557JYuXhWvmMDFkb7ti1x4fhudOngg1LWVhCJRLC2skSnH1rh/LF/imQMyGULZ+DHjm1gbWVZ6GU5lnHA1bP/YsLoQahSqTz09cUwMTZClUrl0bt7J+zfuQ5lStvluYyfxw1F+zYtUdbRAYYGBtDV1YWTY2kM6d8Dxw9sh05m1S9l1qXo52fYwF74qVNblHcuC2MjQ4hEIjjY26LHjx1w9ujf+V4s9z1er6+ZGBvh6L6t8GpcH8ZGhnCwt8XMqWMxY0r+pwkoYtmCGZjmOxJ2tqWgry9Gg3q1cXy/Hyp8dbSlqJVzdsSVswcxYlCfzD2BujA1MUbjBnWwc9PyfMeABJTve6pXrYzNaxbBpXIFpfc45mTm1HE4+Pd63ne6g70tGnp6YO4MX8zIvNJa2whYYc9EJ4QQQgghWoX2QBJCCCGEEKVQAqmGlq3ZjjmL1+Z434eIKNRp0R0JiUkAgAUrNmH1pr9znLekq9OiO54X09WBirp97zGadRig8PxHTwWg99DJRRrDuGkLsP+/00W6TG2hzOvht+tf/DJvZfEGpEHmL9uIFp0GwufH7AMoF6c5i9di2ZrtxbZ8ZT/zpGQoyr454PJNdOg1Ov8Zv5NhE+fgnwMFG4atMLT2IpphE+fg4ZMX0BWJIBAKYFvKGg3qumFAr868sa3yMmfxWpgYGWHSmAG85TZrVBe9f8r7fLKi8svEYd9lPUR1Vi/6RdUhaIVBfXIuEaiOcup7vqd7D5/h3MXrOLJrLYyNi+4iku/tQ0QUOvYegwtHtsHE2EjV4RCSL1V/9r+m1Xsgxw7tg4vHdyLgyHYsmjURUdEx+N+IqfgUE6vq0LSaMgMLazLGGKTSwo1hpo7o9S353odHwc7GukQnj98Lvd9JSaLM+1Vr90B+TSAQoLxzGcz7ZSx6D52Cv/cfw/jh8lJa12/dx+rNu/A+PBJl7O0wbngfeHrUxJ5/T+Dk2csQCIDDJ87B3rYUGtSrhXsPn+LhkxdY77cH7jVdsXrRL0hOScWfm3bh4rXbkEjS0aBuLUwZO4jrfO/cf4LFq7fiQ3gU6tdxg4mJ4r+Ev/41kvVr+rdpY7B5537ExiWgWeO6mDFpOHcF6rMXr7Fiw194GRwKUxNj9O/ZCV3ae3P3LVq1FSFv3kEkEqFm1UpYsSDnAvB1WnTH5LGDcODIaYRHRqN543qYPHYgFq7YjKs376G0gy0WzBjPXXX+9/5jOHjkDD7FxMLC3Ay9f/oBPbrIS+dlxT1r8kj47foXySmpOHNwM299b95+wLhpC3mP+1pGRga2/HUQJ89eRmJSEmpWq4JfJg5FKWv5lairNv4N/wtXEZ+QCFsbKwzv3x3ezRpwj3/64jVWbfgLL4JDIRQK0bp5I0wZN4i7//Dxc9i88wBS09LQsW0L7v2Rmy1/HcDeQ6cgEAgwoFdnbo80Ywy79h/D/v/OICExEdVcKmLq+CEo42ALAOjQazS6dvBG4JXbeBkcih3rFmLJn37cXu2fZy7FjaAvA+lK0jPQ1rsx5kwdjaTkFKxcvxMXr8mH6fFqVAcTR/SDgYG+Qu+NnkN+xoBendGmZeMcn1N0TCxWbdiJm3ceIS1NgkrlnfDnkl8R8zk2216cZWu2IyEpCXOmjs7x9W3dvCGSklMwe8oobvnbdx/G7buPsWbJr2CMYe+hk9j/n/w9U7miM6ZPGIJymYMh/73/GHYfPI6EhCSYmZpg8P+6ovMPeQ99tPvgCVy4fBObVszhpp0+fwVb/jqA/dtWYOP2fXgRHIpl8+RD39Rp0R3TJgzBvsOnERkVjdpuVTFv+thsn9vwiI/w9KgJExMjyGQyzJma86GtJ8+D8cea7Xgd+halrC0w+H8/ctt64/Z9ePbiNexsS+Hk2UswMjLA+OF90bp59jEGc+p79m1brtDr/6vvMPjtOoTklBS0atYQk0YP4NVI/1pefd/qjbuQIc1Ak3Z90dKrfo7P+d37CCxbux0Pn76EvliMzj+0xKA+XSAUChERGY25f6zHi1ehkEplqFmtMqaOHwwHOxsA8sGf9x0+hf3/ncHH6BhYWZpj8thBaFivFgD5MD7T563Elet3YG1lgV98h6FOrZwHos9ru/QfJd+73667fLicX3yHcX1GXp/5G0EPsHbLboS9C4eNtSVGD+kNr0byEQfmLF4LoVCI5OQUXLt1HyMH9UTPrm15MW3cvg9PX7xGKWtLnLlwBWYmxpg1ZRQSE5OwcsNfiItPxE+dWmP04F4KrfP6rftYu3U3wt6HQ18sRvPG9TBhZD/oZ16B3KHXaPzUqTUuXLqJ16Fv4VKpHOb+MhZ2NjlXSnn7PgKLV23Fk+evYGJsjB5d2nB92NFTAdh98DhaNPXMsY8D5J+rbf8cQkRkNMqWscek0QPgVr1KjusaNnEOqrlUxLMXr/Hw6UtULFcWS+ZMwqHjZ7H/v9PQ09XF5LGD0LxJPYWeq6J9w4EjZ/DX3iNYtXA6nBwd8uxvIj9+wtwl6/Ho6Us4lrZDi6aeOT6XLIp83+XVFyuTd+zbJh9eLuZzHMZMmY8Hj5/DsbQ9fps2GhXLy6+uzysHUeT7N1dMSw2dMJvt2n8s2/S1W3azfiOnM8YYC3sXzhr69GbnAq+z9IwM5h9wjTVs04e9+xDJGGNs9qI17I8/t+W73KlzlrFf5q1k8QmJLDk5hU2fu4LNmL+aMcZYXHwC82rfnx04coalZ2SwwCu3WP3WvdjsRWtyjPt9eCTzaN6NxSckZosh675f5q1kiUnJLOrjJ9au+wh25OQFxhhjHz99Zi06DWRnLlxhGRlS9vL1G+bz0zB2I+gBY4yxgaN/ZVv+OsikUilLS5OwoHuPc91+Hs27sZE/z2WxcQks6uMn1qrrENZj8CR298FTlp6RweYsWssm/LKIm/9s4DUWHvmRyWQyduvOQ9bQpze7+/ApL+5JM5aw+IRElpKSyq3j2csQ9vDJS9a223B25sKVXONZueEvNsL3N/YxOoZJJOlsxbodbMi4Wdz9J/wvsk8xsSwjQ8pOnbvMGrTuzb2OkVGfWNP2/di+w6dYaloaS0lJZXfuP2GMMXbr7iNWt2V3tmztdpaalsZeh75ljdr+j926+yjHOI6cvMDqefdkf+09wtLT09mtu49YPe+e7O27cMYYY0dPB7A2Pw1jL4PfsNS0NLZ83Q7WbcBElp6RwRhjrH3PUaxL33Es5M17lpEhZRJJeq7v1eCQt6xFp0Hs2s17jDHG5ixey4ZPnMM+x8azz7FxbOiE2ez3PzYo9N7Ij1QqZX1HTGOzF61hcfEJLD0jg9198JSlpUmyvScZY+yPP7dx7+GcXt/Hz16xpu37sZTUNO4x3Qb6shP+FxljjO07fIr1HPwze/P2A0vPyGC7Dx5nnfqMYRJJOgsNe88atunDQt68Y4wxFv3pM3vxKjTX16PXkJ8ZY4x9jo1nDX2+vO6MMTZ68u9sx+7/GGOMbdi2l/nOWMzd59G8Gxs+cQ77FBPL4hMSWe+hU9iGbXsZY18+t4dPnGPpGRns0rUg1qB171w/t/EJiaxFp0Fs98ETLD09nd2+95g1bvs/7jOwYdte5tmqJ/fZPHo6gDVp15clJiXnuLyc+h5FXv+xUxew+IREFvXxE+s15Ge2cfu+HJefX9/39XbNSUpKKmvfcxTbtf8Yk0jSWXjER9ZtoC87dPwcF8/l63dYaloaS0hMYlNmL2Mjf57LPX73weOsY+/R7MnzYCaTyVh4xEf2OvQt99yb/tCP3br7iGVkSNnmnQdY+56jco1Fke3y9Xs3v8/8i1ehrFmHAexm0EMmlUrZ3QdPWdP2/VjIm/dcfA3b9GFXb95lUqmU68++lvV6nwu8zjIypGy93x7WtttwNmfRWpacnMKCQ96yBq17s6fPgxVa5537T9jTF69ZRoaUvX0fwX7sP4Ft+esgt772PUexHoMnsXcfIllqWhobO3VBru/V9IwM1rXfeLZyw18sNS2NvXgVynx+GsZOnr3EvfZ59XGXrgWxtt2Gs6fPg5lUKmXnAq+zFp0Gss+x8Tmub+iE2axd9xHs1eswlpYmYSN/nss69RnDdh88ztIzMtih4+dYi06DWHp6er7PNa++4ev37IZte1n3Qb4sMuoTYyzv/oYxxoaMm8VmLfyTpaSkspA371iHXqPyfM8p8n2XW19c0Lyjbbfh7PmrEJaekcF+/2MDGzphNnd/XjlIbt+/itDqQ9g5sbG25KqonLlwFR61qqFFU0+IdHTg7VUftaq74PT5ywov73NsPM5fuoGp4wfDxNgIBgb6GDGwB/wDrkIqleHStTsoZW2BHzu0gkhHB00b1kFd9+r5LzgPQ/v9BCNDA5SytkSDum54+uI1AODEmYtwr+GKVs0aQkdHiIrlyqJDm2Y4dU7+fEQiHUREfsTHT5+hp6eL2m5V81xP3+4dYGZqjFLWlqhd0xXlncqgVg0XiHR00NKrPp6//FJgvmXT+rCzsYZAIEAd9+qoX9cNQfee8OPu3w0mxkbQ1xdz067dvIefZy3Fb9PGoFWznCs+MMZw4L/TmDiqH6ytLKCrK8LIwT1x//EzRGSWIGzrLR9rUkdHCJ8WjeBc1gEPHssrG5w4exGulcqjWycfiPX05IPE13T9avnAqEE9IdbTQzmnMqhZrTKeZW7TnJibmeB/3TtAJBKhTq1qcLArheeZlYxO+F9Ej65tUbF8WYj19DB6cC9EfvyEx0+/VOb4qWNrOJd1gI6OMNe9QzGf4zDhl4UYObAH6td1g0wmw6lzlzFmaG+Ym5nA3MwUowf3wvEzF3mlvHJ7b+TnyfNghLx5h2kThsLUxBgiHR3UquECPT1dhR4P8F/fqlUqwNbaCoFXbgEAnr0MQWSUfE82AOw/fBrDB3ZH2TL2EOnooGfXdkhLk+DR05fQEQoBxhAc+hapaRJYWZqjUgWnfNdvbmaCpg3r4NjpAABA1McY3Ln/BO1aN831Mf16doKlhRlMjI3Qoqkn97pfunYHNqWs0KltC4h0dNC4fm3UrZ375/by9TuwMDdFz65tIRKJ4OFWFW1aNsbx01/KnbpUKs99Nn9o1RTpGRkI+2pQ/rwo+voPy3wNSllbYkDvLjjhn/Ng3YXt+y5fvwMTEyP0/ukH6OqKYGdrjV5d2+J0Zl/jYGeDRp7uEOvpwdjIEIP+1xX3HjzjYj1wxB9D+3eDa+XyEAgEsLO15vYGAUBDT3fUqVUNOjpCdGzTHOGRHxEbl1Dg7fKtvD7z/x7zR3sfL9StXR1CoRC1arigSX0PnM0ciB4A6tepiQZ1a0EoFPL6s6+5Vi6PFk09oaMjP+IRFR2D/r06Z45JWgYVy5fFs8w+NL91utd0hUulctDREaKMgy26tvdG0DdFLn7q2Bql7W0g1tNDW+/GuX72Hz19ieiYz9zzr1TBCd07++DoqQBunrz6uP3/nUbfHh3hUrk8hEIhWjT1hJNjaVy5kXvZyLbeTVChnCP09HTRvHE9pKSmoWfXdhDp6KBNi0aIi09AeGR0vs81v75BKpNh/rKNuHX3ETav/A02peR7m/PqbyKionH34VOMH94X+vpiOJctja4dWuX6XAAFv+9y6YsL+tlr690ElSs4Q6Sjgx98vLj3a345CBdPDt+/+aFD2N+Iio6BaWYN5KiPn2BvW4p3f2kHG0R9jFF4eR8ioiCTMXTszR9oVCgQ4lNMLD5+ism2Djtba0gk6QV8BoCVpTn3v4G+PhKS5Fdsh0dG4crNu7wrDGUyGWrVkCdLsyaPxKadB9B3xDSYGBuhe+c2OR4uzmJp8WU9+vpimBgZ8W4np6Ryt0+evYS/9x1DeKR8e6SmpXGHq7LkdDhl98HjqFu7Rp5fzrFxCUhJTcPQCbMhwJfKNboiESKjPsHOxhq79h/DfyfOIzL6EwQQICUllfvCiYiMhmMZ+1yXb2RowPtQGeiLkZSckuv8VhZmvNsG+mIkJ8u3RdTHGN7z1tPThbWVBaKiP3HTcjuslCVNIsGkmUvg1agufurUGoC8k0hPz+C9l0o72EKSns77Ys3tvZGf8MiPKGVtyR0mKohvn1e7Vk1x/MxF+LRohONnAtGiiSe3nT9EfsSsBX9CKPzyGzc9IwORHz/BvaYr5kwbjX2HT2PukvWo7loJ44b/D1UqOucbQ8e2zbFo5RYM698Nx/0D4VmnJqy/2ibf4m8vMZIy39MfP8XAzsYq2/NLy6U0XuTHT3Cw+6YvsbfFnQdf6r5bWX553wgEAoj19PJ8n31N0dff3taa9//H6Jz7ssL2fR8iPiI45C2vr2GMwbaUFRfvH2u24d7DZ0hMkpfRk6SnIzk5FcbGhgiP/IiypXP/TFp/1fcYGMjfM8kpKTA34w8Mruh2+VZen/kPER9x++4jXkIllUphZPjlh0h+n2EAsPyqn9DXl3+uvn4PfN2H5rfOx89eYe2W3XgVEoa0NAkypFI4OX4piwiA9z7/uk/6VtTHGJSysuT9eC1tb4uTZ79Ua8urjwuP+Ii1W3dj4/Z93P0ZUmmu77Vs20Is5i0/63XI2hZ5Pdcype3y7Bsioz7h+LuLWP77FO57Hsi7v9HVFUGsp8uL8dvPxrcU+b7LrS8u6Gfv2+V9ee/knYNkUeQ9+y1KIL+SIZUi8OotNPJ0BwDYlLLC/UfPePOER3zk9k7lVGZP+M00WxtrCIUCnNq/McfMvpSVJcIzaz9niYj8BEsLxa4EV4ZtKWs0a1wPC2dOyPH+MqXtMHf6GDDGcP/Rc4z6eR5qVqsM18rlC7XeiMhozFm0FqsX/wKPWtUg0tHBpJlLgG+GsBcKs2/P338dj5Ub/sKS1X68cxK/ZmZqDH19MXasXZBjpZ97D59h08792LBsNqpUdIZQKETvoZPBMsfQt7O1xo3bD7I9rjjYlLLEh4go7nZ6egaiP32GjfWXZCSn7ZCFMYY5i9fB3MwUE0f246ZbmJtCV1eE8MiPXEcSHhEFPV1dmJuZICIqrVBx29uWwsfoGKRJJBB/U23G0EAfAJCamsadAxkd8zlbBYhvn1cb78bYuGMfoj7G4Mz5K/j91/HcfbalrDBp9ADunLdvtWrWEK2aNURqmgQbt+3FrIV/Yu/WZfk+D0+PmsiQShF0/wmOnQ7EmCG9831MTkpZWSIi6hNvWkRUdK4jONiWssKHCP7n/ENkFGxLFaxazLd9j6Kvf3hkNHd/RFQ0d77ft/Lr+/Jja2MF18rlsX1tzvWB12z5B6lpafh742JYmJvi+atQ9Bk2BSyzU7C3LYW37yNQs1plhdaXm/y2S9RH5X+o29pYoWfXdhg7rE+u8wgFRXtwL791/vr7KnRo0xzL5k2GgYE+/jlwnNvTriybUpb4+CkGGRkZ3Dl54REfeX1UfrF279IGP3VsXaD15ye/55pX3+BgVwqjh/TGr/NXY/EcX+682bz6m4ioaKRJ0hHzOY5LIrOObOVE0e+73BQk78hLfjlI1vdRXt87uaFD2JlCw95jzqK1SExKRp+f2gMAWjdviKB7jxFw5RYypFKcv3gDdx48RevmjQAAVhbmeBceySUigPyX1LsPX2qKWluaw6tRXSxevRWxcfEA5BcjXLh0EwDQuH5tREXH4NCxs8iQSnH5+h3cvvuoWJ5ju1ZNcfvuI5y7eB0ZGRnIyMjA81ehePxMfvj02JlAfIqJhUAggLGxIQRCAe8XWUElp6SCgcHS3AxCgQCXr9/BdQUTNlNTY6xfNhMPn7zAwhWbeds6i1AoxI8dWmHF+p3cBzs2LgFnLsgP7yQmJUNHKISFmSlkjOG/k+cRHPKWe3xb7yZ4/OwVDhw5A4kkHampabj71Z6hotTOuwn2Hz6N16HvIJGkY53fHpSytkQ114oKPX7Dtr148/YDFswYz3tthEIh2rRojHVb9yAuPhGxcQlYu2U32rVqovBr2KHXaN4ejq9VrVIBTo4OWLRyCxISk5AhleLew2eQSNJhbmYKOxtrHDsTCJlMhtt3H+V5uCqLnY01alV3wbw/1kOkK0Id9y8XQXTr5IMN2/YiNOwDAPlrGHDlFpKSUxAa9gHXbz9AapoEuiIRDAz0uXJ4+REK5Yc8l6/djviERDRpUFuhx32rcf3aiPwYjaOnApAhleLqzXt5fm4bebrjc2wc9v93GhlSKe4+eIpTZy/jh9ZeBVr/t32Poq//lr8OICExCR+jY7Dtn8No690kx+Xn1/flp0kDD8R8jsX+/04jTSKBVCpDaNgH3L4nP9SYlJQMfbEYJsaGiI1LwOYd+3mP79reG5t37sfzV6FgjCEiMhohb97ltKo85bddzM1NIRQKeH12frq2b4WjpwNw++4jSKUySCTpePD4RYHiK6p1JiWnwMTYEAYG+gh58w4HjmSvEa6o6i4VYWVhjg3b9kEiScerkDDsPXQS7X0Ue6926+SDv/YexdMXr8EYQ2pqGm4EPUDkx0/5P1gBeT1XRfqGRp7u+P3XsZg6Zzlu3nnIxZxbf2NnYw236lXw5+ZdSE2TIDTsA/49ejbX+ArzfQcULO/IS345SGFo9R7IPzfvwoZteyEQCmBjbYmG9dzx1/pF3K8Mx9J2WPLbz1i75R/MXrgGpe1t8Mfcn7krZju3a4Fpc1egRadBsLWxwp4tf6D3Tz9gzuJ1aNZhAGrVcMHKBdMwZ+pobNy+D/1GTkdcfCIsLczQqllDNG9SD2amxlg2bwqWrPbD8nU74OlRE228G+d5fk5B2ZSyxJ+Lf8Wfm3ZhwfLNYEwG57JlMGJgdwDAzaCH+HPj30hOSYWlhTnGK3hYMD/lnctgUJ+uGDFpLmQyGZo29EDThnXyf2AmUxNjrPtjJsZMmY/5yzbi10nDs/0KGzOkN3bs+Q8jJ83Fp5hYmJmaoG7t6mjdvCEa1quFlk3ro8eQSdDT1UW7Vk15VwTalrLCuj9mYdWGv7Bm8z/Q1RXBp0Ujhfe2KOOH1l749DkOE39dhPiEJFRzqYgV86dCpGACdML/Ej7FxKL1V4M3t23VBL9MHIZJYwZgxfqd6D5wIgCgacM6mPDVXsq8SCTpiI2LR42qOdd3FwqFWDF/Kpav34kf+0+ARJKOyhWduTEqZ00ZiUUrt2DbrkNoVL82WjdviAypNN/1/tC6KeYsXoeBvTvzXtMeXdpAR0eIKbP/QOTHTzA00EetGi6o614dGRkZ2LBtL0LevINAIEDlCk6YM3VUHmvh69CmGbb8dRC9fmyXrT62osxMjbFs7mQs+XMblqzeivp13NDSqwF0dXM+J9TUxBirFv6C5Wu3Y82Wf1DKyhLTJgxBrRouBVp/Tn2PIq+/V8M66D10CpKSk+HdrAEG9u6S4/Lz6/vyY2igj3VLZ2LVpr+xZecBpEnSUcbBFn17dAQADB/QHbMXrUXzjgNhU8oKfbq1R0Dm+bAA0LNrW8hkMkyfuwIfo2NQytoSk8cO5J0Hqai8tou+WA9D+3XDuGkLkJ6egWkThsDayiLP5blUKof5v47HOr+9CA17B4FAiCoVnTF+RF+lY1NUfuv8ZeIwrFi/A39u2gXXyuXh06IRd36xskQiEVbMn4olq/3g89MwmJoYoU+39rmOzvCtpg3rQCJJx+9/bMT78Ejo6emiWpUKmDp+SIHi+VZez1XRvqFB3VpYMHM8ps9difm/jsuzvwGA+b+Ox9w/1qN11yEoW8YeHds2x+Hj53KMr7DfdwXJO/KTVw5SGFQLmxCCoPtPcPDIGSzI5fQGTZKamoZWXYdg29r5qFiubJEtd8yU+XCv6YrB/1O/AclpwGxCSFHT6j2QhBA5D7eq8MjnqntNwBjDnkMnUaVSuUInj9dv3YdL5XIwNjbCucDruHX3ESaN7l9EkRJCiHqjBJIQohWkUhmadxwAczMTLJkzqdDLe/ryNWYsWI3UNAkc7Gwwf8b4Ah1iJYSQkogOYRNCCCGEEKXQVdiEEEIIIUQplEASQgghhBClUAJJCCGEEEKUonUX0chkMnz48AEmJiZKj+hOCCGEaArGGBISEuDg4FAkRSOIdtG6BPLDhw9wdHRUdRiEEEKIWnj79i3KlKERBIhytC6BNDExASD/wJiaFn296e9JlpEGSWI49IztIRRlr3GpLVJSUvE69C3KOzvCILMuMyGEqBNZeipSP72HvlVpCHXVo5+Kj4+Ho6Mj971IiDK0LoHMOmxtampa4hNIAIBlKVVHoHKmpqawtbVRdRiEEJIHU8BKPfspOp2LFASd9FCCpSdHI/LBdqQnR6s6FJX6EB6JWb8vx4fwSFWHQgghOZLERSHs5BpI4qJUHQohRYISyBJMmp6E+LdXIE1PUnUoKhUbF49DR08jNi5e1aEQQkiOMlISEPPgLDJSElQdCiFFQusq0cTHx8PMzAxxcXGacQibEEIIKQD6PiSFQXsgCSGEEEKIUiiBLMFS497g5YnhSI17o+pQVOrJs5eo1bAtnjx7qepQCCEkR8kRwbi/pCuSI4JVHQohRUKlCeTFixfRoUMHODg4QCAQ4PDhw/k+JiAgALVr14ZYLEbFihWxffv2Yo9TXenoGsHEwRM6ukaqDkWlzExN0M6nBcxMaSgKQoh60tE3hkVVL+joG6s6FEKKhEoTyKSkJLi5uWHt2rUKzR8SEoIffvgBzZs3x7179zBhwgQMGTIEp0+fLuZI1ZOuoTXsag2CrqG1qkNRqdIOdlgwezJKO9ipOhRCCMmR2NwWZduPh9jcVtWhEFIkVDoOZNu2bdG2bVuF59+wYQPKlSuHZcuWAQBcXV1x+fJlrFixAj4+PsUVptqSZaRBkhQBPSM7rR9IPOTNW5RzooHECSHqSR0HEiekMErUQOLXrl2Dt7c3b5qPjw8mTJiQ62PS0tKQlpbG3Y6P15yhXuLeXsaHmyugb14BQl0DVYejMlEfo/H8ZQieGRtCR0dH1eEQQkg2+olJMP/8Gem6IrBC1p1O1TNDq5kniygyQgqmRCWQERERsLXl7/63tbVFfHw8UlJSYGCQPYlauHAhfvvtt+8V4ncVFxYIAEiN1e6Tso0BeFQyAMAAZKg4GkIIyS45LgkyALrpRdFHxRXBMggpnBKVQBbE9OnT4evry93Oqv2pCZhUAgAQ6hpB37yciqNRnQePnyEuLgEikQ6MjAxVHQ4hhGRjmQboAZAJBMjQ0y3UslL1zIomKEIKoUQlkHZ2doiM5Jeri4yMhKmpaY57HwFALBZDLNbM8wOZNB0AIDYpg3ItFqk4GtUZvKwnbtx+Ds86bjh/fI+qwyGEkGwerRmIpLCHMHGsjupjtqk6HEIKrUSNA9mgQQOcO3eON83f3x8NGjRQUUSqxZiU12qr9MxDQulFcmiIEEKKXtYP/qyWkJJOpQlkYmIi7t27h3v37gGQD9Nz7949hIWFAZAffu7Xrx83/4gRI/D69WtMmTIFz549w7p167Bv3z5MnDhRFeGrnFCkz2u1VdZhazp8TQhRVzpiQ15LSEmn0gTy9u3bcHd3h7u7OwDA19cX7u7umDVrFgAgPDycSyYBoFy5cjh+/Dj8/f3h5uaGZcuWYcuWLVo5hA8hhBBCiKqo9BzIZs2agTGW6/05VZlp1qwZ7t69W4xRlRyyjFReq62Sk1N4LSGEqBupJIXXElLSlahzIMk3BEJ+q6WEOkJeSwgh6kYg1OG1hJR09I1bggl19HitttLPvMpeX0OvtieElHxCkR6vJaSkowSyBGNMxmu1lUwm47WEEKJuqL8mmoYSyBKMZaTxWm1F50ASQtSdTJLKawkp6SiBLMEEmYeuBdp+CFtfn9cSQoi6EeqKeS0hJR0lkCUYnZQtJxLp8FpCCFE31F8TTUMJZAnGZBm8VltJJOm8lhBC1I0sI53XElLSUQJZgjFZOq/VVpL0dF5LCCHqhkoZEk1DCWQJJhQZ8FptZZxZwtCYShkSQtQUlTIkmoYSSEIIIYQQohRKIEswWebwPTJtH8YnJYXXEkKIuqFhfIimUagW9oMHDxReYM2aNQscDFGSQMBvtZQws5SjUMtLOhJC1Bj110TDKJRA1qpVCwKBAIyxHO/Puk8gEEAqlRZpgCR3VMpQTl9fzGsJIUTd0DiQRNMolECGhIQUdxykALIS+twSe21BpQwJIeqO+muiaRRKIJ2cnIo7DlIALCOV12orKmVICFF3MkkKryWkpCvQSWN//fUXGjVqBAcHB7x58wYAsHLlSvz3339FGhzJG5UylKND2IQQdScU6fFaQko6pRPI9evXw9fXF+3atUNsbCx3zqO5uTlWrlxZ1PGRPFBpLDmRSMRrCSFE3Qh0RLyWkJJO6QTyzz//xObNm/Hrr79CR+dL4lKnTh08fPiwSIMjeaNShnJUiYYQou5kmRVoZFSJhmgIpRPIkJAQuLu7Z5suFouRlJRUJEERxVBpLDlJmoTXEkKIumGZNbAZ1cImGkLpBLJcuXK4d+9etumnTp2Cq6trUcREFCTUNeC12srY2IjXEkKIuqFShkTTKH0yhq+vL0aPHo3U1FQwxnDz5k3s3r0bCxcuxJYtW4ojRkIIIYQQokaUTiCHDBkCAwMDzJgxA8nJyejduzccHBywatUq9OzZszhiJLmgUoZyKSmpvJYQQtSNLD2V1xJS0hXocrA+ffqgT58+SE5ORmJiImxsbIo6LqIIKo0lJ/imJYQQtUMdFdEsBR5PICoqCs+fPwcgL2VYqlSpIguKKIZKGcoZ6OvzWkIIUTdUypBoGqUvoklISEDfvn3h4OAALy8veHl5wcHBAf/73/8QFxdXHDGSXFBpLDnaDoQQdUf9FNE0SieQQ4YMwY0bN3D8+HHExsYiNjYWx44dw+3btzF8+PDiiJHkgkoZyiUlJfNaQghRN1TKkGgapQ9hHzt2DKdPn0bjxo25aT4+Pti8eTPatGlTpMGRvAl0dHmtthKLxbyWEELUDZUyJJpG6T2QVlZWMDMzyzbdzMwMFhYWRRIUUYxAKOK12kpXV8RrCSFE3VApQ6JplE4gZ8yYAV9fX0RERHDTIiIiMHnyZMycObNIgyN5o1KGcunpGbyWEELUDZNm8FpCSjqFfgq5u7tD8NVQMS9fvkTZsmVRtmxZAEBYWBjEYjE+fvxI50F+R1TKUC4tLY3XEkKIupFlSHgtISWdQglk586dizkMUhACkT6v1VZGRoa8lhBC1I1Qz4DXElLSKZRAzp49u7jjIAWQtVdYoOUDidN2IISoO+qniKZR+hxIoj5kUgmv1VYpqam8lhBC1I0sPY3XElLSKX05mFQqxYoVK7Bv3z6EhYVBIuEnLzExMUUWHMkP+6bVUrQZCCFqjzoqolmU3gP522+/Yfny5ejRowfi4uLg6+uLrl27QigUYs6cOcUQIsmNUEfMa7WVgYE+ryWEEHUj1NXntYSUdEonkLt27cLmzZsxadIkiEQi9OrVC1u2bMGsWbNw/fr14oiREEIIIYSoEaUTyIiICNSoUQMAYGxszNW/bt++PY4fP1600ZE8ydJTeK22SkxM4rWEEKJupGnJvJaQkk7pBLJMmTIIDw8HAFSoUAFnzpwBANy6datApeTWrl0LZ2dn6Ovrw9PTEzdv3sxz/pUrV6JKlSowMDCAo6MjJk6ciFQtvXiCShnKicV6vJYQQtSNILOEoYBKGRINoXQC2aVLF5w7dw4AMHbsWMycOROVKlVCv379MGjQIKWWtXfvXvj6+mL27Nm4c+cO3Nzc4OPjg6ioqBzn/+effzBt2jTMnj0bT58+xdatW7F371788ssvyj4NjUClDOV0dXV5LSGEqBthZglDIZUyJBpC6XfyokWLuP979OiBsmXL4tq1a6hUqRI6dOig1LKWL1+OoUOHYuDAgQCADRs24Pjx4/Dz88O0adOyzX/16lU0atQIvXv3BgA4OzujV69euHHjRq7rSEtL41UoiY+PVypGdcZkUl6rrdIzMngtIYSoGyplSDRNoceBbNCgAXx9fZVOHiUSCYKCguDt7f0lGKEQ3t7euHbtWo6PadiwIYKCgrjD3K9fv8aJEyfQrl27XNezcOFCmJmZcX+Ojo5KxanOWOb4j0zLx4FMS03jtYQQom6olCHRNArtgTxy5IjCC+zYsaNC80VHR0MqlcLW1pY33dbWFs+ePcvxMb1790Z0dDQaN24MxhgyMjIwYsSIPA9hT58+Hb6+vtzt+Ph4jUkiqZShHJUyJISoOyplSDRNkdbCFggEkEqL73BqQEAAFixYgHXr1sHT0xOvXr3C+PHjMW/ePMycOTPHx4jF4gJd3FMSUGksOdoOhBB1R/0U0TQKJZAymazIV2xtbQ0dHR1ERkbypkdGRsLOzi7Hx8ycORN9+/bFkCFDAAA1atRAUlIShg0bhl9//RVCoXZVZqRShnKpmYeuU+kQNiFETVEpQ6JpVJZx6enpwcPDg7uiG5AnqufOnUODBg1yfExycnK2JFFHRwcAwJgWlofKes7a+Ny/Ist8/jIt3w6EEDVG/TXRMCodT8DX1xf9+/dHnTp1UK9ePaxcuRJJSUncVdn9+vVD6dKlsXDhQgBAhw4dsHz5cri7u3OHsGfOnIkOHTpwiaQ2EYrEvFZbGWaWMDSkUoaEEDUl1NPntYSUdCpNIHv06IGPHz9i1qxZiIiIQK1atXDq1CnuwpqwsDDeHscZM2ZAIBBgxowZeP/+PUqVKoUOHTpg/vz5qnoKhBBCCCFaR+Ujmo4ZMwZjxozJ8b6AgADebZFIhNmzZ2P27NnfITL1J8tI4bXaKjEpmdcSQoi6oVKGRNNo11UnGkYg1OW12kovswKNHlWiIYSoKYFIl9cSUtIVag9kamoqJBL+FcCmpqaFCogojkoZyunp6fJaQghRN0IdXV5LSEmn9B7I5ORkjBkzBjY2NjAyMoKFhQXvj3w/VMpQLiNDymsJIUTdUH9NNI3SCeTkyZNx/vx5rF+/HmKxGFu2bMFvv/0GBwcH7Ny5szhiJLmgUoZyqampvJYQQtQNjQNJNI3Sxz6PHj2KnTt3olmzZhg4cCCaNGmCihUrwsnJCbt27UKfPn2KI06SA0Hm8D0CbR/Gx9CA1xJCiLqhYXyIplF6D2RMTAzKly8PQH6+Y0xMDACgcePGuHjxYtFGR/IkEAh5rbbKGupJ2yoREUJKDuqviaZR+p1cvnx5hISEAABcXFywb98+API9k+bm5kUaHMkblTKUS01L47WEEKJuZBkSXktISad0Ajlw4EDcv38fADBt2jSsXbsW+vr6mDhxIiZPnlzkAZI8UGksAIBMKuO1hBCibphMxmsJKemUPgdy4sSJ3P/e3t549uwZgoKCULFiRdSsWbNIgyN5o1KGcnQOJCFE3elknvuoQ+dAEg1R6AEEnZyc4OTkVBSxEEIIIYSQEoDO5i3BZBmpvFZbJWWWMEyiUoaEEDVFpQyJpqEEsgQTCHV4rbbSzSxhqEulDAkhakqQWYFGQJVoiIagBLIEo1rYclTKkBCi7oSZNbCFVAubaAhKIEswxqS8VltJpVJeSwgh6oZKGRJNo/RFNPHx8TlOFwgEEIvF0NPTK3RQRDEsczwxpuXjiqWkpPJaQghRN1TKkGgapRNIc3NzCASCXO8vU6YMBgwYgNmzZ1NlkGJGpQzlaBgfQoi6E+rq81pCSjqlE8jt27fj119/xYABA1CvXj0AwM2bN7Fjxw7MmDEDHz9+xB9//AGxWIxffvmlyAMmX1BpLDkqZUgIUXeCzP5JQP0U0RBKJ5A7duzAsmXL0L17d25ahw4dUKNGDWzcuBHnzp1D2bJlMX/+fEogi5lMms5rtVVamoTXEkKIuqFShkTTKP1T6OrVq3B3d8823d3dHdeuXQMANG7cGGFhYYWPjuQt6+IZLb+IJiPz4pkMuoiGEKKm6CIaommUTiAdHR2xdevWbNO3bt0KR0dHAMCnT59gYWFR+OhInoQifV6rrYwyz300onMgCSFqSkfPgNcSUtIpfQj7jz/+QLdu3XDy5EnUrVsXAHD79m08e/YMBw4cAADcunULPXr0KNpICSGEEEKIWlA6gezYsSOePXuGjRs34sWLFwCAtm3b4vDhw3B2dgYAjBw5skiDJDmjUoZyVMqQEKLupJIUXktISad0AgkA5cqVw6JFi4o6FqIsgQ6/1VIiXRGvJYQQdUOlZ4mmKdA3bmxsLG7evImoqCjIZDLeff369SuSwEj+hJk1VYVaXltVnDl4vZgGsSeEqCmhSI/XElLSKZ1AHj16FH369EFiYiJMTU15g4oLBAJKIL8jxmS8VltRKUNCiLpjmTtbmEy7+2uiOZS+CnvSpEkYNGgQEhMTERsbi8+fP3N/MTExxREjyQXLSOO12opKGRJC1J0sPZXXElLSKZ1Avn//HuPGjYOhoWFxxEOUQKUM5QwM9HktIYSoGyplSDSN0gmkj48Pbt++XRyxECVRKUM5HR0dXksIIeqGShkSTaP0OZA//PADJk+ejCdPnqBGjRrQ1eVfwNGxY8ciC47kjUoZyqVJJLyWEELUDZUyJJpG6QRy6NChAIC5c+dmu08gENCFDN8TlTIEAGSkZ/BaQghRN1TKkGgapRPIb4ftIapDpQzljIwMeS0hhKgbKmVINA2djEEIIYQQQpSi0B7I1atXY9iwYdDX18fq1avznHfcuHFFEhjJH5UylEtKTuG1hBCibqiUIdE0CiWQK1asQJ8+faCvr48VK1bkOp9AIKAE8nuiUoYAAFHm1dciugqbEKKmqJQh0TQKJZAhISE5/k9Ui0oZyonFeryWEELUDZUyJJpG6XMgL1y4UBxxkAKgUoZyWRd20QVehBB1RaUMiaZROoFs06YNKlSogN9//x1v374tdABr166Fs7Mz9PX14enpiZs3b+Y5f2xsLEaPHg17e3uIxWJUrlwZJ06cKHQcJRGVMpRLzjz3MZnOgSSEqCkqZUg0TYFKGY4ZMwYHDhxA+fLl4ePjg3379kFSgEGc9+7dC19fX8yePRt37tyBm5sbfHx8EBUVleP8EokErVq1QmhoKA4cOIDnz59j8+bNKF26tNLr1gSCzEMhAi0/JEKlDAkpORhjGDZsGCwtLSEQCHDv3r1CLW/AgAHo3LlzkcRWnIS6Yl5LSEmndAJpbW2NiRMn4t69e7hx4wYqV66MUaNGwcHBAePGjcP9+/cVXtby5csxdOhQDBw4EFWrVsWGDRtgaGgIPz+/HOf38/NDTEwMDh8+jEaNGsHZ2RleXl5wc3NT9mloBEHmxTMCLb+IhkoZElJynDp1Ctu3b8exY8cQHh6O6tWrqzqkfDVr1gwTJkxQ6jHjxo2Dh4cHxGIxatWqle0imtDQUAgEgmx/169fL+rwCSkWhRoHsnbt2pg+fTrGjBmDxMRE+Pn5wcPDA02aNMHjx4/zfKxEIkFQUBC8vb2/BCMUwtvbG9euXcvxMUeOHEGDBg0wevRo2Nraonr16liwYEGe1W/S0tIQHx/P+9MUTJbOa7WVRJLOawkh6is4OBj29vZo2LAh7OzsIBIpXc+iyBTkyJkyBg0ahB49egAAZBnpvDbL2bNnER4ezv15eHgUa0yEFJUCJZDp6ek4cOAA2rVrBycnJ5w+fRpr1qxBZGQkXr16BScnJ3Tr1i3PZURHR0MqlcLW1pY33dbWFhERETk+5vXr1zhw4ACkUilOnDiBmTNnYtmyZfj9999zXc/ChQthZmbG/Tk6Oir/hNUUlcaSS09P57WEEPU0YMAAjB07FmFhYRAIBLC2tkb79u25+1euXAmBQIBTp05x0ypWrIgtW7YAAKRSKXx9fWFubg4rKytMmTIFjDGF19+sWTOMGTMGEyZMgLW1NXx8fAAAjx49Qtu2bWFsbAxbW1v07dsX0dHRXMyBgYFYtWoVt5cwNDQ033WtXr0ao0ePRvny5QEATJrOa7NYWVnBzs6O+9PV/TKqRtbh+QULFsDW1hbm5uaYO3cuMjIyMHnyZFhaWqJMmTLYtm2bwtuAkKKi9E+/sWPHYvfu3WCMoW/fvliyZAnvEISRkRH++OMPODg4FGmggPwqWxsbG2zatAk6Ojrw8PDA+/fvsXTpUsyePTvHx0yfPh2+vr7c7fj4eI1JIqmUoRyVMiQEmDxjAR4+fvbd11ujmguW/v6LQvOuWrUKFSpUwKZNm3Dr1i34+/tj7NixkEql0NHRQWBgIKytrREQEIA2bdrg/fv3CA4ORrNmzQAAy5Ytw/bt2+Hn5wdXV1csW7YMhw4dQosWLRSOd8eOHRg5ciSuXLkCQH5hZosWLTBkyBCsWLECKSkpmDp1Krp3747z589j1apVePHiBapXr465c+cCAEqVKqXcRgKgIzbktVk6duyI1NRUVK5cGVOmTEHHjh15958/fx5lypTBxYsXceXKFQwePBhXr15F06ZNcePGDezduxfDhw9Hq1atUKZMGaXjIqSglE4gnzx5gj///BNdu3aFWJzzycDW1tb5DvdjbW0NHR0dREZG8qZHRkbCzs4ux8fY29tDV1eXd66bq6srIiIiIJFIoKeX/WISsVica5yEEKIpHj5+hktXb6k6jDyZmZnBxMQEOjo6sLOzQ4cOHTBgwADcvXsXHh4euHjxIiZPnozDhw8DAAICAlC6dGlUrFgRgHwP5fTp09G1a1cAwIYNG3D69GmlYqhUqRKWLFnC3f7999/h7u6OBQsWcNP8/Pzg6OiIFy9eoHLlytDT04OhoWGu300FYWxsjGXLlqFRo0YQCoU4ePAgOnfujMOHD/OSSEtLS6xevRpCoRBVqlTBkiVLkJycjF9+kSft06dPx6JFi3D58mX07NmzyOIjJD9KJZDp6elwcnJC/fr180zKRCIRvLy88lyWnp4ePDw8cO7cOe4KOplMhnPnzmHMmDE5PqZRo0b4559/IJPJIBTKj76/ePEC9vb2OSaPmk6WOXyPjIbx4bWEaKMa1VxK3HrNzc3h5uaGgIAA6OnpQU9PD8OGDcPs2bORmJiIwMBA7rskLi4O4eHh8PT05B4vEolQp04dpQ5jf3uO4f3793HhwgUYGxtnmzc4OBiVK1cu4LPjk0pSea21tTXv6FjdunXx4cMHLF26lJdAVqtWjfu+A8Cd/59FR0cHVlZWuY5eQkhxUSqB1NXVxcGDBzFz5swiWbmvry/69++POnXqoF69eli5ciWSkpIwcOBAAEC/fv1QunRpLFy4EAAwcuRIrFmzBuPHj8fYsWPx8uVLLFiwQHvLJwoE/FZLCXWEvJYQbaToYWR106xZMwQEBEAsFsPLywuWlpZwdXXF5cuXERgYiEmTJhXp+oyMjHi3ExMT0aFDByxevDjbvPb29kW2XkFmEigQ5t5PeXp6wt/fnzft63MiAXnJ4JymUSEF8r0pfQg7axf7xIkTC73yHj164OPHj5g1axYiIiJQq1YtnDp1iruwJiwsjPfLy9HREadPn8bEiRNRs2ZNlC5dGuPHj8fUqVMLHUtJJNTR47XaSj9zb7g+napASInj5eUFPz8/iEQitGnTBoA8qdy9ezdevHjBnf9oZmYGe3t73LhxA02bNgUAZGRkICgoCLVr1y7w+mvXro2DBw/C2dk51yvC9fT08hztQxGKlDK8d+9ekSathBQnpRPISpUqYe7cubhy5Qo8PDyy/ZpTdm/gmDFjcj1kHRAQkG1agwYNaJysTFTKUI5KGRJScjVt2hQJCQk4duwYFi1aBECeQP7000+wt7fnHUIeP348Fi1ahEqVKsHFxQXLly9HbGxsodY/evRobN68Gb169cKUKVNgaWmJV69eYc+ePdiyZQt0dHTg7OyMGzduIDQ0FMbGxrC0tOTt3MjJq1evkJiYiIiICKSkpOBp2EckRyajhqP8KuwdO3ZAT08P7u7uAIB///0Xfn5+3BXnhKg7pRPIrVu3wtzcHEFBQQgKCuLdJxAItPdwsgpQKUM5OgeSkJLLwsICNWrUQGRkJFxc5OdTNm3aFDKZLNu59JMmTUJ4eDj69+8PoVCIQYMGoUuXLoiLiyvw+h0cHHDlyhVMnToVrVu3RlpaGpycnNCmTRsuSfz555/Rv39/VK1aFSkpKQgJCYGzs3Oeyx0yZAgCAwO52z8tfAEAOOn0JSGeN28e3rx5A5FIBBcXF+zduxc//fRTgZ8LId+TgClx9jFjDGFhYbCxsYGBgUFxxlVs4uPjYWZmhri4OJiamqo6nEJ5fXYyUj49hYGVK8p7L1V1OCrj3aEPrt28gwb1auPs0V2qDocQQrJ5vG4wEkPvw9jZDdVGbVV1OAA06/uQfH9KXXXAGEOlSpXw7t274oqHKOHb0ljaSiTS4bWEEKJuqL8mmkapBFIoFKJSpUr49OlTccVDlMBkGbxWW1EpQ0JIWFgYjI2Nc/0LCwsrsnWNGDEi1/WMGDEix8fIMivQyKTUTxHNoPQ5kIsWLcLkyZOxfv163lhU5PujWthykswShhIqZUiI1nJwcMC9e/fyvL+ozJ07Fz///HOO9+V2KJhl1sBmGdRPEc2gdALZr18/JCcnw83NDXp6etnOhYyJiSmy4EjehCIDXqutjDNLGBpTKUNCtJZIJOIq1hQ3Gxsb2NjYKPWY3EoZElJSKZ1Arly5shjCIIQQQgghJYXSCWT//v2LIw5SAFTKUC45JZXXEkKIupFlljDMagkp6ZROIL+WmpoKiUTCm0ZDAXxHVMoQACDMfP5CLd8OhBA1Rv010TBKFw9OSkrCmDFjYGNjAyMjI1hYWPD+yPdDpQzl9PXFvJYQQtSNUFfMawkp6ZROIKdMmYLz589j/fr1EIvF2LJlC3777Tc4ODhg586dxREjyUXWGPBKjAWvkWg7EELUHfVTRNMonUAePXoU69atw48//giRSIQmTZpgxowZWLBgAXbtoiog3xPLSOW12iopKZnXEkLUF2MMw4YNg6WlJQQCQZ5D7yhiwIAB6Ny5c5HEVpxkkhReS0hJp3QCGRMTg/LlywOQn++YNWxP48aNcfHixaKNjuRJkHnoWqDlh7DFmYeuxXQImxC1d+rUKWzfvh3Hjh1DeHh4iRhPuFmzZpgwYYJSjxEIBLy/mhN2wf9pDIQi7e6vieZQOoEsX748QkJCAAAuLi7Yt28fAPmeSXNz8yINjuSNSmPJ6YpEvJYQor6Cg4Nhb2+Phg0bws7ODiIVfm6/vQi0qG3btg3h4eEIDw9HwKI+aFrJHAId6qeIZlA6gRw4cCDu378PAJg2bRrWrl0LfX19TJw4EZMnTy7yAEnuqJShXHpmBZp0qkRDiFobMGAAxo4di7CwMAgEAlhbW6N9+/bc/StXroRAIMCpU6e4aRUrVsSWLVsAAFKpFL6+vjA3N4eVlRWmTJmi1DmFzZo1w5gxYzBhwgRYW1vDx8cHAPDo0SO0bdsWxsbGsLW1Rd++fREdHc3FHBgYiFWrVnF7E0NDQxVan7m5Oezs7GBnZwcrYz2IRULIpPL+es6cOahVqxb8/PxQtmxZGBsbY9SoUZBKpViyZAns7OxgY2OD+fPnK/z8CPmelP4pNHHiRO5/b29vPHv2DEFBQahYsSJq1qxZpMGRvLHMmqpMy2urpqVJeC0h2ij8ziakxr7+7uvVNy8P+9rDFJp31apVqFChAjZt2oRbt27B398fY8eOhVQqhY6ODgIDA2FtbY2AgAC0adMG79+/R3BwMJo1awYAWLZsGbZv3w4/Pz+4urpi2bJlOHToEFq0aKFwvDt27MDIkSNx5coVAEBsbCxatGiBIUOGYMWKFUhJScHUqVPRvXt3nD9/HqtWrcKLFy9QvXp1zJ07FwBQqlQphdY1evRoDBkyBOXLl0f7CjpoXYaBZXzpp4KDg3Hy5EmcOnUKwcHB+Omnn/D69WtUrlwZgYGBuHr1KgYNGgRvb294enoq/BwJ+R4KvS/dyckJTk5ORRELUZJQ14DXaitjYyNeS4g2So19jeSPj1QdRp7MzMxgYmICHR0d2NnZoUOHDhgwYADu3r0LDw8PXLx4EZMnT8bhw4cBAAEBAShdujRXonDlypWYPn06unbtCgDYsGEDTp8+rVQMlSpVwpIlS7jbv//+O9zd3bFgwQJump+fHxwdHfHixQtUrlwZenp6MDQ0hJ2dncLrmTt3Llq0aAFDQ0OcOXMGs2b8itimDhhSwYObRyaTwc/PDyYmJqhatSqaN2+O58+f48SJExAKhahSpQoWL16MCxcuUAJJ1I7SCeS4ceNQsWJFjBs3jjd9zZo1ePXqFZU6JIQQFdA3L1/i1mtubg43NzcEBARAT08Penp6GDZsGGbPno3ExEQEBgbCy8sLABAXF4fw8HBeIiUSiVCnTh2lDmN7eHjwbt+/fx8XLlyAsbFxtnmDg4NRuXLlAj23mTNncv+7u7sj9OJe7Lr0CEO6fZnH2dkZJiYm3G1bW1vo6OhAKBTypkVFRRUoBkKKk9IJ5MGDB3HkyJFs0xs2bIhFixZRAvkdyaRpvFZbpWSWMEyhUoZEiyl6GFndNGvWDAEBARCLxfDy8oKlpSVcXV1x+fJlBAYGYtKkSUW6PiMj/pGKxMREdOjQAYsXL842r729fZGtt4ajOTYkpCM1OYmbpqury5tHIBDkOE0mkxVZHIQUFaUTyE+fPsHMzCzbdFNTU+6kY/K9CL5ptRRtBkJKLC8vL/j5+UEkEqFNmzYA5Enl7t278eLFC+78RzMzM9jb2+PGjRto2rQpACAjIwNBQUGoXbt2gddfu3ZtHDx4EM7OzrleEa6npwepVFrgdQDAs3efYaqvAz1dugqbaAalr8KuWLEi7wq5LCdPnuTGhyTfB5UylDPQ1+e1hJCSo2nTpkhISMCxY8e4ZLFZs2bYtWsX7O3teYeQx48fj0WLFuHw4cN49uwZRo0ahdjY2EKtf/To0YiJiUGvXr1w69YtBAcH4/Tp0xg4cCCXNDo7O+PGjRsIDQ1FdHR0vnsEjx49ii1btuDRo0d49eoV1q9fjy3+j9DN3YZKGRKNofRPIV9fX4wZMwYfP37krnw7d+4cli1bRoevvzMqjSVH24GQksvCwgI1atRAZGQkXFxcAMiTSplMxp3/mGXSpEkIDw9H//79IRQKMWjQIHTp0gVxcXEFXr+DgwOuXLmCqVOnonXr1khLS4OTkxPatGnDnYv4888/o3///qhatSpSUlIQEhICZ2fnXJepq6uLtWvXYuLEiWCMoWLFipj8oyfalE6hfopoDAErwLt5/fr1mD9/Pj58+ABA/utszpw56NevX5EHWNTi4+NhZmaGuLg4mJqaqjqcQgk+PR6pscHQN6+ACj6rVB2OyjRu9SPuPngC95pVcdn/oKrDIYSQbB6u+h+S3z+DYWkX1Bj/t6rDAaBZ34fk+yvQyRgjR47EyJEj8fHjRxgYGOR49RopfgIdXV6rrcRiMa8lhBB1k1XCkEoZEk2h9DmQXytVqhQljyokEIp4rbbSzTwpXZdOTidEa4WFhcHY2DjXv7CwsCJb14gRI3Jdz4gRI3J8TFYJQyplSDQFvZNLMCplKJeensFrCSHax8HBAffu3cvz/qIyd+5c/Pzzzznel9uhYJZZwjCrJaSkowSyBKNShnJpaWm8lhCifUQiEVexprjZ2NjAxsZGqcfIMksYyjKo5CrRDIU6hE1USyDS57XaysjIkNcSQoi6EeoZ8FpCSroiSSALOw4XKRiBQMBrtRVtB0KIuqN+imgapRPIxYsXY+/evdzt7t27w8rKCqVLl8b9+/eLNDiSN5lUwmu1VUpqKq8lhBB1I0tP47WElHRKJ5AbNmyAo6MjAMDf3x/+/v44efIk2rZti8mTJxd5gCQPWUN4avvAtOyblhBC1A51VESzKH0RTUREBJdAHjt2DN27d0fr1q3h7OwMT0/PIg+Q5E4oEvNabWVgoM9rCSFE3Qh19XktISWd0nsgLSws8PbtWwDAqVOn4O3tDUBeRq6wxeYJIYRoNsYYhg0bBktLSwgEgjyH3lHEgAED0Llz5yKJjRCiOKUTyK5du6J3795o1aoVPn36hLZt2wIA7t69+92GUCBysvQUXqutEhOTeC0hRH2dOnUK27dvx7FjxxAeHo7q1aurOqR8NWvWDBMmTFD6cdu3b0fNmjWhr6+PxpN3Yql/GKRpydz9Dx48QJMmTaCvrw9HR0csWbKkCKMmpHgpfQh7xYoVKFeuHMLCwrBkyRKuEk14eDhGjRpV5AGS3FEpQzk9sR6vJYSor+DgYNjb26Nhw4aqDgUSiQR6esXTbyxfvhzLli3D0qVL4enpiXtbffH62WMIRPL+Oj4+Hq1bt4a3tzc2bNiAhw8fYtCgQTA3N8ewYcOKJSZCipJSeyDT09MxfPhwdO3aFatWrYK7uzt338SJEzFkyJAiD5DkjkoZyunp6vJaQoh6GjBgAMaOHYuwsDAIBAJYW1ujffv23P0rV66EQCDAqVOnuGkVK1bEli1bAABSqRS+vr4wNzeHlZUVpkyZAqbERYTNmjXDmDFjMGHCBFhbW8PHxwcA8OjRI7Rt2xbGxsawtbVF3759ER0dzcUcGBiIVatWQSAQQCAQIDQ0NM/1fP78GTNmzMDOnTvRu3dvVKhQAa5lbdG0ojmEmT/4d+3aBYlEAj8/P1SrVg09e/bEuHHjsHz5ct726ty5MxYsWABbW1uYm5tj7ty5yMjIwOTJk2FpaYkyZcpg27ZtCm8DQoqKUpmHrq4uDh48iJkzZxZXPEQJTCbltdoqIyOD1xKijd4cWYakD8+/+3qNHKrAqeMkheZdtWoVKlSogE2bNuHWrVvw9/fH2LFjIZVKoaOjg8DAQFhbWyMgIABt2rTB+/fvERwcjGbNmgEAli1bhu3bt8PPzw+urq5YtmwZDh06hBYtWigc744dOzBy5EhcuXIFgHwc4xYtWmDIkCFYsWIFUlJSMHXqVHTv3h3nz5/HqlWr8OLFC1SvXh1z584FAJQqVSrPdfj7+0Mmk+H9+/dwdXVFQkICqtvoYlQ9ExhnljK8du0amjZtytsD6uPjg8WLF+Pz58+wsLAAAJw/fx5lypTBxYsXceXKFQwePBhXr15F06ZNcePGDezduxfDhw9Hq1atUKZMGYW3AyGFpfSuq86dO+Pw4cOYOHFikQWxdu1aLF26FBEREXBzc8Off/6JevXq5fu4PXv2oFevXujUqRMOHz5cZPGUFCxz/Eem5eNApqam8VpCtFHSh+dIeH1H1WHkyczMDCYmJtDR0YGdnR06dOiAAQMG4O7du/Dw8MDFixcxefJkrj8PCAhA6dKlufPrV65cienTp6Nr164A5MPKnT59WqkYKlWqxDvX8Pfff4e7uzsWLFjATfPz84OjoyNevHiBypUrQ09PD4aGhrCzs1NoHa9fv4ZMJsOCBQuwatUqmJmZYUL/Lhi3Pxz/VqoGQD6iSbly5XiPs7W15e7LSiAtLS2xevVqCIVCVKlSBUuWLEFycjJ++eUXAMD06dOxaNEiXL58GT179lRqWxBSGEonkJUqVcLcuXNx5coVeHh4wMjIiHf/uHHjlFre3r174evriw0bNsDT0xMrV66Ej48Pnj9/nmet0dDQUPz8889o0qSJsk9BY1ApQzlDQwNeS4g2MnKoUuLWa25uDjc3NwQEBEBPTw96enoYNmwYZs+ejcTERAQGBsLLywsAEBcXh/DwcN5wcSKRCHXq1FHqMLaHhwfv9v3793HhwgXufP6vBQcHo3Llyko/L5lMhvT0dKxevRqtW7cGACwd3BLNpu3C7dBY1FZiWdWqVYNQ+OVsM1tbW96FRzo6OrCyskJUVJTScRJSGEonkFu3boW5uTmCgoIQFBTEu08gECidQC5fvhxDhw7FwIEDAch/UR4/fhx+fn6YNm1ajo+RSqXo06cPfvvtN1y6dElrSylSaSy5rM71606WEG2j6GFkddOsWTMEBARALBbDy8sLlpaWcHV1xeXLlxEYGIhJk4r2eX270yMxMREdOnTA4sWLs81rb29foHVkPa5q1arcNCtTQ5gZiBD+WT5ahJ2dHSIjI3mPy7r99Z5O3W/O7RYIBDlOk8lkBYqVkIJSOoEMCQkpspVLJBIEBQVh+vTp3DShUAhvb29cu3Yt18fNnTsXNjY2GDx4MC5dupTnOtLS0pCW9uXQZnx8fOEDVxNUylCODmETUnJ5eXnBz88PIpEIbdq0ASBPKnfv3o0XL15w5z+amZnB3t4eN27cQNOmTQHIz3sOCgpC7drK7NPjq127Ng4ePAhnZ2eIRDl/Jerp6Sk1znGjRo0AAM+fP+fOS/wcG4+4lAzYm8oLPzRo0AC//vor0tPTuYTQ398fVapU4Q5fE6LOVLrLJjo6GlKplDvvI4utrS0iIiJyfMzly5exdetWbN68WaF1LFy4EGZmZtxfVhUdjUClDAEAMibjtYSQkqNp06ZISEjAsWPHuGSxWbNm2LVrF+zt7XmHkMePH49Fixbh8OHDePbsGUaNGlXoI1CjR49GTEwMevXqhVu3biE4OBinT5/GwIEDuaTR2dkZN27cQGhoKKKjo/Pd21e5cmV06tQJ48ePx9WrV/Ho0SP8+vdlOFnqo24l+fdd7969oaenh8GDB+Px48fYu3cvVq1aBV9f30I9H0K+lwKN//Lu3TscOXIEYWFhkEj4e7++HoKgqCUkJKBv377YvHkzrK2tFXrM9OnTeR/I+Ph4jUkiqZShnKGBAa8lhJQcFhYWqFGjBiIjI+Hi4gJAnlTKZDLu/McskyZNQnh4OPr37w+hUIhBgwahS5cuiIuLK/D6HRwccOXKFUydOhWtW7dGWloanJyc0KZNG+60mJ9//hn9+/dH1apVkZKSgpCQEDg7O+e53J07d2LixIn44YcfIBQKUbusKVb+VAliA0MA8j2qZ86cwejRo+Hh4QFra2vMmjWLxoAkJYaAKXP2MYBz586hY8eOKF++PJ49e4bq1asjNDQUjDHUrl0b58+fV3hZEokEhoaGOHDgAK8UVf/+/REbG4v//vuPN/+9e/fg7u4OHR0dblrWL0GhUIjnz5+jQoUKea4zPj4eZmZmiIuLg6mpqcKxqqOQ89OQ/PERDEtVR7kWi1Qdjsq06dIPl67eQpOGdXHq0E5Vh0MIIdk82TAMCa/vwKR8bVQdsUnV4QDQrO9D8v0pfQh7+vTp+Pnnn/Hw4UPo6+vj4MGDePv2Lby8vNCtWzellqWnpwcPDw+cO3eOmyaTyXDu3Dk0aNAg2/wuLi54+PAh7t27x/117NgRzZs3x7179zRmz6KiZBkpvFZbJSYl81pCCFE3WSUMvy5lSEhJpnQC+fTpU/Tr1w+AfAiFlJQUGBsbY+7cuTlexZYfX19fbN68GTt27MDTp08xcuRIJCUlcVdl9+vXj7vIRl9fH9WrV+f9mZubw8TEBNWrVy+2klTqSiDU5bXaiirREELCwsJgbGyc619YWFiRrWvEiBG5rmfEiBE5PoZKzxJNo/Q5kEZGRtx5j/b29ggODka1avKBUbNKPymjR48e+PjxI2bNmoWIiAjUqlULp06d4i6sCQsLo+FZckGlDOX09HR5LSFE+zg4OODevXt53l9U5s6di59//jnH+3I7FCzMrIGd1RJS0imdedSvXx+XL1+Gq6sr2rVrh0mTJuHhw4f4999/Ub9+/QIFMWbMGIwZMybH+wICAvJ87Pbt2wu0Tk1ApQzlMjKkvJYQon1EIhFXsaa42djY5FnoIifUXxNNo3QCuXz5ciQmJgIAfvvtNyQmJmLv3r2oVKlSsV6BTbKjUoZyqampvJYQQtSNLD2N1xJS0imdQJYvX57738jICBs2bCjSgIjiBJnD9wi0fRgfKmVICFFzQj19XktISVfgk+du376Np0+fApCXa/q2vigpfgKBkNdqKyplSAhRd9RfE02jdAL57t079OrVC1euXIG5uTkAIDY2Fg0bNsSePXu4sk2k+FEpQ7nUzFKVqWl0aIgQop5kGRJeS0hJp/RPoSFDhiA9PR1Pnz5FTEwMYmJi8PTpU8hkMgwZMqQ4YiS5ySrdp+Ul/GRSGa8lhBB1QxfREE2j9B7IwMBAXL16FVWqVOGmValSBX/++SeaNGlSpMGRvAlF+rxWW9E5kIQQdaejZ8BrCSnplN4D6ejoiPT09GzTpVJpkY6zRQghhBBC1JPSCeTSpUsxduxY3L59m5t2+/ZtjB8/Hn/88UeRBkfyJstI5bXaKimzhGESlTIkhKgpKmVINI1Ch7AtLCwgEAi420lJSfD09IRIJH94RkYGRCIRBg0ahM6dOxdLoCQ7gUCH12orXV0RryWEEHVDpQyJplHoG3flypXFHAYpCOqQ5LJqoGtbLXRCSMlBpQyJplEogezfv39xx0EKgDEpr9VWUqmU1xJCiLqhq7CJpqERTUswljmeGNPyccVSUlJ5LSGEqBsqZUg0DSWQJRiVMpQzMDDgtYQQom6Euvq8lpCSjhLIEoxKY8np6Ah5LSGEqBtBZqlVAZVcJRpCoXfygwcPIJNRlQ91I5Om81ptlZYm4bWEEKJuqJQh0TQKJZDu7u6Ijo4GAJQvXx6fPn0q1qCIgrIuntHyi2gyMi+eyaCLaAghaoouoiGaRqEE0tzcHCEhIQCA0NBQ2hupJqiUoZxRZglDIyplSAhRU1TKkGgahYbx+fHHH+Hl5QV7e3sIBALUqVMHOjo5D179+vXrIg2QEEIIIYSoF4USyE2bNqFr16549eoVxo0bh6FDh8LExKS4YyP5oFKGcknJKbyWEELUjVSSwmsJKekUrv3Wpk0bAEBQUBDGjx9PCaQ6yCphqOWlDEWZe8NFuewVJ4QQVRMIdXgtISWd0sWDt23bxv3/7t07AECZMmWKLiKiMGFmCUOhlpcyFIv1eC0hhKgboUiP1xJS0ik9IJVMJsPcuXNhZmYGJycnODk5wdzcHPPmzaOLa74zxmS8VltJpTJeSwgh6oZlfj8y+p4kGkLpPZC//vortm7dikWLFqFRo0YAgMuXL2POnDlITU3F/PnzizxIkjOWkcZrtVVKSgqvJYQQdSNLT+W1hJR0SieQO3bswJYtW9CxY0duWs2aNVG6dGmMGjWKEsjviEoZyhkY6PNaQghRN0JdMa8lpKRT+hB2TEwMXFxcsk13cXFBTExMkQRFFEOlDOWyhpTKbWgpQghRNbqIhmgapTMPNzc3rFmzJtv0NWvWwM3NrUiCIophmSUMmZaXMpRIJLyWEELUjSwjndcSUtIpfQh7yZIl+OGHH3D27Fk0aNAAAHDt2jW8ffsWJ06cKPIASe5YZglDpuWlDNPTM3gtIYSoGybL4LWElHRK74H08vLCixcv0KVLF8TGxiI2NhZdu3bF8+fP0aRJk+KIkeSCShnKGRkZ8lpCCFE3VMqQaBql90ACgIODA10sQwghhBCipbT76osSjkoZylEpQ0KIuqNShkTTUAJZkmVdfa3lV2GLdIS8lhBC1A1dhU00DX3jlmBCHT1eq63EYjGvJYQQdUOlDImmoQSyBKNShnJZJTSplCYhRF1RKUOiaQqUQGZkZODs2bPYuHEjEhISAAAfPnxAYmJikQZH8kalDOWSM899TKZzIAkhaopKGRJNo/RV2G/evEGbNm0QFhaGtLQ0tGrVCiYmJli8eDHS0tKwYcOG4oiT5ECQeehaoOWHsPUzSxjqUylDQoiaolKGRNMovQdy/PjxqFOnDj5//gwDgy/jWXXp0gXnzp0r0uBI3uikbDlRZglDEZUyJISoKeqviaZReg/kpUuXcPXqVejp8fd6OTs74/3790UWGMkfVTaQk0jSeS0hhKgbKmVINI3SeyBlMhmk0uyl8969ewcTE5MCBbF27Vo4OztDX18fnp6euHnzZq7zbt68GU2aNIGFhQUsLCzg7e2d5/yajMnSea22kqSn81pCCFE3TJrOawkp6ZROIFu3bo2VK1dytwUCARITEzF79my0a9dO6QD27t0LX19fzJ49G3fu3IGbmxt8fHwQFRWV4/wBAQHo1asXLly4gGvXrsHR0RGtW7fWyr2fQpEBr9VWxpklDI2plCEhRE3piA15LSElndIJ5B9//IErV66gatWqSE1NRe/evbnD14sXL1Y6gOXLl2Po0KEYOHAgqlatig0bNsDQ0BB+fn45zr9r1y6MGjUKtWrVgouLC7Zs2QKZTJbr+ZdpaWmIj4/n/RFCCCGEkIJT+hxIR0dH3L9/H3v37sX9+/eRmJiIwYMHo0+fPryLahQhkUgQFBSE6dOnc9OEQiG8vb1x7do1hZaRnJyM9PR0WFpa5nj/woUL8dtvvykVV0khyxy+R6btw/ikpPBaQghRNzJJKq8lpKRTKoFMT0+Hi4sLjh07hj59+qBPnz6FWnl0dDSkUilsbW15021tbfHs2TOFljF16lQ4ODjA29s7x/unT58OX19f7nZ8fDwcHR0LHrQ6EQj4rZYSZpZyFGp5SUdCiBqj/ppoGKUSSF1dXaSmqs+vp0WLFmHPnj0ICAiAvn7OYwCKxWKNLXFHpQzl9PXFvJYQQtQNjQNJNI3Su2xGjx6NxYsXIyOj8EPHWFtbQ0dHB5GRkbzpkZGRsLOzy/Oxf/zxBxYtWoQzZ86gZs2ahY6lJGKM8VptRaUMCSHqjvprommUPgfy1q1bOHfuHM6cOYMaNWrAyMiId/+///6r8LL09PTg4eGBc+fOoXPnzgDAXRAzZsyYXB+3ZMkSzJ8/H6dPn0adOnWUfQoag2Wk8lptRaUMCSHqTiZJ4bWElHRKJ5Dm5ub48ccfiywAX19f9O/fH3Xq1EG9evWwcuVKJCUlYeDAgQCAfv36oXTp0li4cCEAYPHixZg1axb++ecfODs7IyIiAgBgbGwMY2PjIourJKBShnJ0CJsQou7oEDbRNEonkNu2bSvSAHr06IGPHz9i1qxZiIiIQK1atXDq1CnuwpqwsDAIhV+OtK9fvx4SiQQ//fQTbzmzZ8/GnDlzijQ2dUelseREIhGvJYQQdUP9NdE0avGNO2bMmFwPWQcEBPBuh4aGFn9AJQSVMpSjSjSEEHUny6xAI6NKNERDFCiBPHDgAPbt24ewsDBIJBLefXfu3CmSwEj+qDSWnCRNwmsJIUTdsMwa2IxqYRMNofRV2KtXr8bAgQNha2uLu3fvol69erCyssLr16/Rtm3b4oiR5EKoa8BrtZWxsRGvJYQQdUOlDImmUTqBXLduHTZt2oQ///wTenp6mDJlCvz9/TFu3DjExcUVR4yEEEIIIUSNKJ1AhoWFoWHDhgAAAwMDJCQkAAD69u2L3bt3F210JE9UylAuJSWV1xJCiLqRpafyWkJKOqUTSDs7O8TExAAAypYti+vXrwMAQkJCaIDU741KYwEABJnPX6Dl24EQos4E37SElGxKJ5AtWrTAkSNHAAADBw7ExIkT0apVK/To0QNdunQp8gBJ7qiUoRyNA0kIUXc0DiTRNEpfhb1p0yauZNzo0aNhZWWFq1evomPHjhg+fHiRB0hyR6Wx5Gg7EELUHfVTRNMonUAKhULewN49e/ZEz549izQoohgqZSiXlJTMawkhRN1QKUOiaQo0DmRsbCxu3ryJqKgobm9kln79+hVJYCR/VMpQTpx56FpMh7AJIWpKKNLjtYSUdEonkEePHkWfPn2QmJgIU1NT3oULAoGAEsjviEpjyelmljDUpVKGhBA1JdAR8VpCSjqlL6KZNGkSBg0ahMTERMTGxuLz58/cX9bV2eT7oFKGcunpGbyWEELUDZNm8FpCSjqlE8j3799j3LhxMDSk0fRVjUoZyqWlpfFaQghRN7IMCa8lpKRTOoH08fHB7du3iyMWoiSBSJ/XaisjI0NeSwgh6kaoZ8BrCSnpFDoZI2vcRwD44YcfMHnyZDx58gQ1atSArq4ub96OHTsWbYQkVzSAthxtB0KIuqN+imgahRLIzp07Z5s2d+7cbNMEAgGkUmmhgyKKkUnTeK22SklN5bWEEKJuZOlpvJaQkk6hBPLboXoIIYQQQoj2UvocSKI+hDpiXqutDPT1eS0hhKgbKmVINI3CCeS1a9dw7Ngx3rSdO3eiXLlysLGxwbBhw+gq2O+MSmPJ0XYghKg76qeIplE4gZw7dy4eP37M3X748CEGDx4Mb29vTJs2DUePHsXChQuLJUiSMyplKEelDAkh6o5KGRJNo3ACee/ePbRs2ZK7vWfPHnh6emLz5s3w9fXF6tWrsW/fvmIJkuRMoKPLa7WVWCzmtYQQom6olCHRNAonkJ8/f4atrS13OzAwEG3btuVu161bF2/fvi3a6EieBEIRr9VWuroiXksIIeqGShkSTaNwAmlra4uQkBAAgEQiwZ07d1C/fn3u/oSEhGxjQpLixWRSXqut0jMyeC0hhKgbKmVINI3CCWS7du0wbdo0XLp0CdOnT4ehoSGaNGnC3f/gwQNUqFChWIIkOWNSCa/VVmmpabyWEELUDZUyJJpG4X3p8+bNQ9euXeHl5QVjY2Ps2LEDenpfzuXw8/ND69atiyVIkjMqZShHpQwJIeqOShkSTaNwAmltbY2LFy8iLi4OxsbG0NHR4d2/f/9+GBsbF3mAJHdUGkuOtgMhRN1RP0U0jdJn85qZmeU43dLSstDBEOXIMg9dy7T8EHZq5qHrVDqETQhRU1TKkGgaqkRTkmUNSKvlA9PSAL2EEPXHvmkJKdkogSzBhCIxr9VWBgb6vJYQQtSNUFef1xJS0lECSQghhBBClEIJZAkmS0/htdoqMTGJ1xJCiLqRpiXzWkJKOkogSzAqZSinJ9bjtYQQom4EIl1eS0hJRwlkCUalDOX0Misg6VElJEKImhJm/tAXavkPfqI5KIEswaiUoVxGZgnDDCplSAhRU9RfE01DCWQJRqUM5WgcSEKIuqNxIImmoQSyBKNShnKGhga8lhBC1A2VMiSahhLIEoxKY8kJhUJeSwgh6ob6a6Jp1OIbd+3atXB2doa+vj48PT1x8+bNPOffv38/XFxcoK+vjxo1auDEiRPfKVL1QqUM5egQNiFE3dEhbKJpVJ5A7t27F76+vpg9ezbu3LkDNzc3+Pj4ICoqKsf5r169il69emHw4MG4e/cuOnfujM6dO+PRo0ffOXI1QKUMAQAyJuO1hBCidqi/JhpG5Qnk8uXLMXToUAwcOBBVq1bFhg0bYGhoCD8/vxznX7VqFdq0aYPJkyfD1dUV8+bNQ+3atbFmzZrvHLnqUSlDOUMDA15LCCHqRqinz2sJKelUOoCgRCJBUFAQpk+fzk0TCoXw9vbGtWvXcnzMtWvX4Ovry5vm4+ODw4cP5zh/Wloa0tK+HDKIj48vfODf8J/XFvqSuCJfbn70RIBQwBDz6CJu/Nv0u69fXXQzT0YXH32YmYbiyYZhqg6HEEKySf7wQtUhEFKkVJpARkdHQyqVwtbWljfd1tYWz549y/ExEREROc4fERGR4/wLFy7Eb7/9VjQB50JfEge9NBWch5gGyADoAShnqMXnQRoCgA6AZCS8vqPiYAghJA90CJtoCI0vYTJ9+nTeHsv4+Hg4OjoW6TpS9cwAfP89kACgIwCiE4VIlqj8bASVYYwhIyMD5Z3LwsLCTNXhEEJINrKMdEhTE+HQYqCqQyGkSKg0gbS2toaOjg4iIyN50yMjI2FnZ5fjY+zs7JSaXywWQywu3nMEW808WazLJ4QQQghRJyrdbaWnpwcPDw+cO3eOmyaTyXDu3Dk0aNAgx8c0aNCANz8A+Pv75zq/JpOmJyMp6gGk6cmqDkWlEhKTcPHKTSQkJqk6FEIIyZE0NQnxwbchTaV+imgGlR/39PX1xebNm7Fjxw48ffoUI0eORFJSEgYOlO/m79evH+8im/Hjx+PUqVNYtmwZnj17hjlz5uD27dsYM2aMqp6CykgSPiD0wi+QJHxQdSgq9ep1KNp27Y9Xr0NVHQohhOQoNfotnm4cgdTot6oOhZAiofJzIHv06IGPHz9i1qxZiIiIQK1atXDq1CnuQpmwsDBehZGGDRvin3/+wYwZM/DLL7+gUqVKOHz4MKpXr66qp6AyYrOyqNhuE3QNrVUdikq5Vq6IB9dPobR9zqcxEEKIqhnYloPblEPQM7NRdSiEFAkBY9p1SVh8fDzMzMwQFxcHU1NTVYdDCCGEqAR9H5LCUPkhbFJw6ckfEX5nI9KTP6o6FJV69z4cP/8yH+/eh6s6FEIIyVFabARC/1uKtNich5wjpKShBLIEk6anICnqIaTpKaoORaUSEpNw8SpdREMIUV/StGTEBwdBmqbdFz0SzUGHsAkhhBAtRN+HpDBoDyQhhBBCCFGKyq/C/t6ydrgWR03s7y019g3eXl0Ax4a/QN/cSdXhqMyTZ6/QZ/A47Nq6GlVdKqo6HEIIySY5Ihgv/pqCyn2XwNCugqrDAfDle1DLDkSSIqJ1h7DfvXtX5KUMCSGEkJLq7du3KFOmjKrDICWM1iWQMpkMHz58gImJCQQCQZEsM6u+9tu3b7X6PBLaDnK0Hb6gbSFH20GOtsMX6rAtGGNISEiAg4MDb7xlQhShdYewhUJhsf3SMjU11fpOEaDtkIW2wxe0LeRoO8jRdvhC1dvCzMxMZesmJRv95CCEEEIIIUqhBJIQQgghhCiFEsgiIBaLMXv2bIjFYlWHolK0HeRoO3xB20KOtoMcbYcvaFuQkk7rLqIhhBBCCCGFQ3sgCSGEEEKIUiiBJIQQQgghSqEEkhBCCCGEKIUSSEIIIYQQohRKIAtp7dq1cHZ2hr6+Pjw9PXHz5k1Vh1TsLl68iA4dOsDBwQECgQCHDx/m3c8Yw6xZs2Bvbw8DAwN4e3vj5cuXqgm2GC1cuBB169aFiYkJbGxs0LlzZzx//pw3T2pqKkaPHg0rKysYGxvjxx9/RGRkpIoiLh7r169HzZo1uQGRGzRogJMnT3L3a8M2yMmiRYsgEAgwYcIEbpq2bIs5c+ZAIBDw/lxcXLj7tWU7AMD79+/xv//9D1ZWVjAwMECNGjVw+/Zt7n5t6S+J5qEEshD27t0LX19fzJ49G3fu3IGbmxt8fHwQFRWl6tCKVVJSEtzc3LB27doc71+yZAlWr16NDRs24MaNGzAyMoKPjw9SU1O/c6TFKzAwEKNHj8b169fh7++P9PR0tG7dGklJSdw8EydOxNGjR7F//34EBgbiw4cP6Nq1qwqjLnplypTBokWLEBQUhNu3b6NFixbo1KkTHj9+DEA7tsG3bt26hY0bN6JmzZq86dq0LapVq4bw8HDu7/Lly9x92rIdPn/+jEaNGkFXVxcnT57EkydPsGzZMlhYWHDzaEt/STQQIwVWr149Nnr0aO62VCplDg4ObOHChSqM6vsCwA4dOsTdlslkzM7Oji1dupSbFhsby8RiMdu9e7cKIvx+oqKiGAAWGBjIGJM/b11dXbZ//35unqdPnzIA7Nq1a6oK87uwsLBgW7Zs0cptkJCQwCpVqsT8/f2Zl5cXGz9+PGNMu94Ps2fPZm5ubjnep03bYerUqaxx48a53q/N/SUp+WgPZAFJJBIEBQXB29ubmyYUCuHt7Y1r166pMDLVCgkJQUREBG+7mJmZwdPTU+O3S1xcHADA0tISABAUFIT09HTetnBxcUHZsmU1dltIpVLs2bMHSUlJaNCggVZug9GjR+OHH37gPWdA+94PL1++hIODA8qXL48+ffogLCwMgHZthyNHjqBOnTro1q0bbGxs4O7ujs2bN3P3a3N/SUo+SiALKDo6GlKpFLa2trzptra2iIiIUFFUqpf13LVtu8hkMkyYMAGNGjVC9erVAci3hZ6eHszNzXnzauK2ePjwIYyNjSEWizFixAgcOnQIVatW1aptAAB79uzBnTt3sHDhwmz3adO28PT0xPbt23Hq1CmsX78eISEhaNKkCRISErRqO7x+/Rrr169HpUqVcPr0aYwcORLjxo3Djh07AGhvf0k0g0jVARCiCUaPHo1Hjx7xzvPSJlWqVMG9e/cQFxeHAwcOoH///ggMDFR1WN/V27dvMX78ePj7+0NfX1/V4ahU27Ztuf9r1qwJT09PODk5Yd++fTAwMFBhZN+XTCZDnTp1sGDBAgCAu7s7Hj16hA0bNqB///4qjo6QwqE9kAVkbW0NHR2dbFcORkZGws7OTkVRqV7Wc9em7TJmzBgcO3YMFy5cQJkyZbjpdnZ2kEgkiI2N5c2vidtCT08PFStWhIeHBxYuXAg3NzesWrVKq7ZBUFAQoqKiULt2bYhEIohEIgQGBmL16tUQiUSwtbXVmm3xLXNzc1SuXBmvXr3SqveEvb09qlatypvm6urKHc7Xxv6SaA5KIAtIT08PHh4eOHfuHDdNJpPh3LlzaNCggQojU61y5crBzs6Ot13i4+Nx48YNjdsujDGMGTMGhw4dwvnz51GuXDne/R4eHtDV1eVti+fPnyMsLEzjtsW3ZDIZ0tLStGobtGzZEg8fPsS9e/e4vzp16qBPnz7c/9qyLb6VmJiI4OBg2Nvba9V7olGjRtmG9nrx4gWcnJwAaFd/STSQqq/iKcn27NnDxGIx2759O3vy5AkbNmwYMzc3ZxEREaoOrVglJCSwu3fvsrt37zIAbPny5ezu3bvszZs3jDHGFi1axMzNzdl///3HHjx4wDp16sTKlSvHUlJSVBx50Ro5ciQzMzNjAQEBLDw8nPtLTk7m5hkxYgQrW7YsO3/+PLt9+zZr0KABa9CggQqjLnrTpk1jgYGBLCQkhD148IBNmzaNCQQCdubMGcaYdmyD3Hx9FTZj2rMtJk2axAICAlhISAi7cuUK8/b2ZtbW1iwqKooxpj3b4ebNm0wkErH58+ezly9fsl27djFDQ0P2999/c/NoS39JNA8lkIX0559/srJlyzI9PT1Wr149dv36dVWHVOwuXLjAAGT769+/P2NMPjTFzJkzma2tLROLxaxly5bs+fPnqg26GOS0DQCwbdu2cfOkpKSwUaNGMQsLC2ZoaMi6dOnCwsPDVRd0MRg0aBBzcnJienp6rFSpUqxly5Zc8siYdmyD3HybQGrLtujRowezt7dnenp6rHTp0qxHjx7s1atX3P3ash0YY+zo0aOsevXqTCwWMxcXF7Zp0ybe/drSXxLNI2CMMdXs+ySEEEIIISURnQNJCCGEEEKUQgkkIYQQQghRCiWQhBBCCCFEKZRAEkIIIYQQpVACSQghhBBClEIJJCGEEEIIUQolkIQQQgghRCmUQBJCCCGEEKVQAklIEbly5Qpq1KgBXV1ddO7cWdXh5MrZ2RkrV65UdRgKEwgEOHz4cKGWUdDXZvv27TA3Ny/UutVJSXvtCSHqixJIUmINGDAAAoGA+7OyskKbNm3w4MEDlcTj6+uLWrVqISQkBNu3b1dJDF/TtOSnMBR5bbQhubp16xaGDRum6jAIIRqAEkhSorVp0wbh4eEIDw/HuXPnIBKJ0L59+0ItUyKRFOhxwcHBaNGiBcqUKZNj4sYYQ0ZGRqFiIwWT32ujLUqVKgVDQ0NVh0EI0QCUQJISTSwWw87ODnZ2dqhVqxamTZuGt2/f4uPHj9w8U6dOReXKlWFoaIjy5ctj5syZSE9P5+6fM2cOatWqhS1btqBcuXLQ19cHABw4cAA1atSAgYEBrKys4O3tjaSkpGwxhIaGQiAQ4NOnTxg0aBAEAgG2b9+OgIAACAQCnDx5Eh4eHhCLxbh8+TLS0tIwbtw42NjYQF9fH40bN8atW7e45WU97vTp03B3d4eBgQFatGiBqKgonDx5Eq6urjA1NUXv3r2RnJyc43YJCAjAwIEDERcXx+2hnTNnDnd/cnIyBg0aBBMTE5QtWxabNm3iPf7t27fo3r07zM3NYWlpiU6dOiE0NDTP1+LRo0do27YtjI2NYWtri759+yI6Opq7v1mzZhg3bhymTJkCS0tL2NnZ8WICgJcvX6Jp06bQ19dH1apV4e/vn+c6AeS5PXN7bb7VrFkzvHnzBhMnTuS219dOnz4NV1dXGBsbcz9avrZlyxa4urpCX18fLi4uWLduXZ4x5/feymt5EokEY8aMgb29PfT19eHk5ISFCxcCkP9ImTNnDsqWLQuxWAwHBweMGzeOe+y3e1nDwsLQqVMnGBsbw9TUFN27d0dkZCR3f9Zn46+//oKzszPMzMzQs2dPJCQk5Pn8CCFagBFSQvXv35916tSJu52QkMCGDx/OKlasyKRSKTd93rx57MqVKywkJIQdOXKE2drassWLF3P3z549mxkZGbE2bdqwO3fusPv377MPHz4wkUjEli9fzkJCQtiDBw/Y2rVrWUJCQrY4MjIyWHh4ODM1NWUrV65k4eHhLDk5mV24cIEBYDVr1mRnzpxhr169Yp8+fWLjxo1jDg4O7MSJE+zx48esf//+zMLCgn369IkxxrjH1a9fn12+fJnduXOHVaxYkXl5ebHWrVuzO3fusIsXLzIrKyu2aNGiHLdNWloaW7lyJTM1NWXh4eEsPDyci93JyYlZWlqytWvXspcvX7KFCxcyoVDInj17xhhjTCKRMFdXVzZo0CD24MED9uTJE9a7d29WpUoVlpaWluP6Pn/+zEqVKsWmT5/Onj59yu7cucNatWrFmjdvzs3j5eXFTE1N2Zw5c9iLFy/Yjh07mEAgYGfOnGGMMSaVSln16tVZy5Yt2b1791hgYCBzd3dnANihQ4dyfR/ktT1ze22+9enTJ1amTBk2d+5cbnsxxti2bduYrq4u8/b2Zrdu3WJBQUHM1dWV9e7dm3vs33//zezt7dnBgwfZ69ev2cGDB5mlpSXbvn17jvHm997Kb3lLly5ljo6O7OLFiyw0NJRdunSJ/fPPP4wxxvbv389MTU3ZiRMn2Js3b9iNGzfYpk2buHU7OTmxFStWcNu7Vq1arHHjxuz27dvs+vXrzMPDg3l5eXHzz549mxkbG7OuXbuyhw8fsosXLzI7Ozv2yy+/5Pp6EEK0AyWQpMTq378/09HRYUZGRszIyIgBYPb29iwoKCjPxy1dupR5eHhwt2fPns10dXVZVFQUNy0oKIgBYKGhoQrHY2ZmxrZt28bdzkoEDx8+zE1LTExkurq6bNeuXdw0iUTCHBwc2JIlS3iPO3v2LDfPwoULGQAWHBzMTRs+fDjz8fHJNZ5t27YxMzOzbNOdnJzY//73P+62TCZjNjY2bP369Ywxxv766y9WpUoVJpPJuHnS0tKYgYEBO336dI7rmjdvHmvdujVv2tu3bxkA9vz5c8aYPIFs3Lgxb566deuyqVOnMsYYO336NBOJROz9+/fc/SdPnswzgVRkezKW/bXJydfJVZZt27YxAOzVq1fctLVr1zJbW1vudoUKFbgELsu8efNYgwYNclxPfu+t/JY3duxY1qJFC97rk2XZsmWscuXKTCKR5Pscz5w5w3R0dFhYWBh3/+PHjxkAdvPmTcaY/LNhaGjI4uPjuXkmT57MPD09c1w+IUR70CFsUqI1b94c9+7dw71793Dz5k34+Pigbdu2ePPmDTfP3r170ahRI9jZ2cHY2BgzZsxAWFgYbzlOTk4oVaoUd9vNzQ0tW7ZEjRo10K1bN2zevBmfP38uUIx16tTh/g8ODkZ6ejoaNWrETdPV1UW9evXw9OlT3uNq1qzJ/W9ra8sdgv96WlRUVIFi+n87dxfSZBvGAfy/+bZw7ksrc8PpcmpNWB9LGyVkB8M+wIKiLEYUzKAspII6WR1MDGrDiOrsGeRBwcRqRPSlk2rgbBiUREU0y/IkCDJiNaWW78GLw7WpW/Plrd7/DwT37Lmu574vb8bl7fM4MbdIJEJBQUEsV39/P0KhEORyOWQyGWQyGfLy8jAyMoKBgYGk+fr7+3H37t3Y+TKZDIsWLYrNOdl1AUCtVseu+/z5c2i1Wmg0mtj7K1eunHIe6dTzZ0mlUuj1+qRj/vz5MwYGBmCz2eLm3tLSMmmtplpbqeTbvXs3Hj9+jIULF6KpqQmdnZ2x3Fu3bkUkEkFJSQn27NkDr9c76X234/XWarWxYxUVFVCpVHG10+l0kMvlSedPRP9ff/3XAyDKRE5ODkpLS2Ov3W43lEolBEFAS0sLent7YbVa4XA4sHbtWiiVSng8HrS2tibkmSgrKwtdXV0IBALo7OzEuXPnYLfbEQwGsWDBgrTH+DNmzZoV+14kEsW9Hj/2/fv3jHP/mCscDmP58uW4dOlSQtzEJnuicDiMuro6nDp1KuE9tVqd0nV/VcnGPDY2BuCfeQOAIAgwm81x52VlZSXNN9XaGn/AZap8JpMJr1+/xq1bt+Dz+bBt2zZYLBZcvnwZWq0WL168gM/nQ1dXFxobG+FyuXD//v2EeWQy/1/9Z0ZE/z7uQNIfRSQSQSwWIxKJAAACgQCKi4tht9tRWVmJsrKyuN3J6XJVV1fD4XDg0aNHkEgk8Hq9GY1Pr9dDIpGgp6cnduzr16/o6+tDRUVFRrl/JJFIEI1G044zmUx4+fIl8vPzUVpaGvelVConjXn69Cl0Ol1CTKoNtMFgwNDQUNwDKg8ePJgyZibr+TP1mj9/PjQaDV69epUw76l+0ZhsbaWaT6FQoL6+HoIgoL29HVeuXMGHDx8AANnZ2airq8PZs2dx79499Pb24smTJwljGK/30NBQ7NizZ8/w8ePHGV+LRPTn4Q4k/dZGR0fx7t07AMDw8DDOnz8f2w0DgLKyMrx9+xYejwdVVVW4ceNGSk1gMBhEd3c3amtrkZ+fj2AwiPfv38NgMGQ03pycHOzbtw9HjhxBXl4eioqK4HQ68eXLF9hstoxy/0in0yEcDqO7uxtLliyBVCpN6V+4WK1WuFwubNq0Cc3NzSgsLMSbN29w9epVHD16FIWFhQkx+/fvhyAI2LFjR+wp61AoBI/HA7fbPelu3EQWiwXl5eXYtWsXXC4XPn36BLvdPmXMTNZTp9PB7/dj+/btmD17NubOnZtSnMPhQFNTE5RKJdatW4fR0VE8fPgQw8PDOHz4cML5062t6fKdPn0aarUay5Ytg1gsRkdHBwoKCqBSqdDW1oZoNAqz2QypVIqLFy8iOzsbxcXFCeOwWCwwGo2wWq04c+YMvn37hsbGRtTU1MTddkFElAx3IOm3dvv2bajVaqjVapjNZvT19aGjowNr1qwBAGzcuBGHDh3CgQMHsHTpUgQCARw/fnzavAqFAn6/Hxs2bEB5eTmOHTuG1tZWrF+/PuMxnzx5Elu2bMHOnTthMpkQCoVw584d5ObmZpx7olWrVmHv3r2or6/HvHnz4HQ6U4qTSqXw+/0oKirC5s2bYTAYYLPZMDIyAoVCkTRGo9Ggp6cH0WgUtbW1MBqNOHjwIFQqFcTi1D5mxGIxvF4vIpEIVqxYgYaGBpw4cWLauJmqZ3NzMwYHB6HX6yf9U30yDQ0NcLvduHDhAoxGI2pqatDW1jbpDuR0a2u6fHK5HE6nE5WVlaiqqsLg4CBu3rwJsVgMlUoFQRBQXV2NxYsXw+fz4fr165gzZ07COEQiEa5du4bc3FysXr0aFosFJSUlaG9vT6tuRPT/JBobv5mHiIiIiCgF3IEkIiIiorSwgSQiIiKitLCBJCIiIqK0sIEkIiIiorSwgSQiIiKitLCBJCIiIqK0sIEkIiIiorSwgSQiIiKitLCBJCIiIqK0sIEkIiIiorSwgSQiIiKitPwNEwAh+dXzzk4AAAAASUVORK5CYII=",
       "text/plain": [
-       "shape: (3, 4)\n",
-       "┌─────────┬────────────────────┬────────────────────────┬──────────────────┐\n",
-       "│ horizon ┆ median_abs_ret_bps ┆ median_half_spread_bps ┆ pct_exceeds_cost │\n",
-       "│ ---     ┆ ---                ┆ ---                    ┆ ---              │\n",
-       "│ str     ┆ f64                ┆ f64                    ┆ f64              │\n",
-       "╞═════════╪════════════════════╪════════════════════════╪══════════════════╡\n",
-       "│ 5m      ┆ 8.17               ┆ 2.42                   ┆ 80.2             │\n",
-       "│ 15m     ┆ 15.31              ┆ 2.44                   ┆ 88.9             │\n",
-       "│ 60m     ┆ 30.6               ┆ 2.55                   ┆ 94.1             │\n",
-       "└─────────┴────────────────────┴────────────────────────┴──────────────────┘"
+       "<Figure size 583.3x340 with 1 Axes>"
       ]
      },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
+     "metadata": {
+      "image/png": {
+       "alt": "Non-null label rate by bar position from the end of each trading session."
+      }
+     },
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "# Cost sanity: compare |return| distribution to half-spread\n",
-    "cost_check = {}\n",
-    "for label_col, horizon_name in [\n",
-    "    (\"fwd_ret_5m\", \"5m\"),\n",
-    "    (\"fwd_ret_15m\", \"15m\"),\n",
-    "    (\"fwd_ret_60m\", \"60m\"),\n",
-    "]:\n",
-    "    joined = df.select([label_col, \"half_spread\"]).drop_nulls()\n",
-    "    abs_ret = joined[label_col].abs()\n",
-    "    hs = joined[\"half_spread\"]\n",
-    "\n",
-    "    median_abs_ret_bps = float(abs_ret.median()) * 10000\n",
-    "    median_half_spread_bps = float(hs.median()) * 10000\n",
-    "    pct_exceeds_cost = float((abs_ret > hs).mean()) * 100\n",
-    "\n",
-    "    cost_check[horizon_name] = {\n",
-    "        \"median_abs_ret_bps\": round(median_abs_ret_bps, 2),\n",
-    "        \"median_half_spread_bps\": round(median_half_spread_bps, 2),\n",
-    "        \"pct_exceeds_cost\": round(pct_exceeds_cost, 1),\n",
-    "    }\n",
-    "\n",
-    "print(\"\\n=== Cost-Sanity Check ===\")\n",
-    "pl.DataFrame(\n",
-    "    [\n",
-    "        {\n",
-    "            \"horizon\": h,\n",
-    "            \"median_abs_ret_bps\": c[\"median_abs_ret_bps\"],\n",
-    "            \"median_half_spread_bps\": c[\"median_half_spread_bps\"],\n",
-    "            \"pct_exceeds_cost\": c[\"pct_exceeds_cost\"],\n",
-    "        }\n",
-    "        for h, c in cost_check.items()\n",
-    "    ]\n",
-    ")"
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for name, colour in PALETTE.items():\n",
+    "    ax.plot(profile[\"from_end\"], profile[name], ds=\"steps-mid\", lw=1.8, c=colour, label=name)\n",
+    "    ax.axvline(HORIZON_BARS[name] - 0.5, color=colour, linestyle=\":\", lw=1)\n",
+    "ax.set_xlabel(\"Bars from the end of the session\")\n",
+    "ax.set_ylabel(\"Share of bars carrying a label\")\n",
+    "sub = \"Dotted lines mark each horizon; curves lying on top of each other mean one masked another\"\n",
+    "add_message_title(ax, \"Each horizon nulls its own tail of the session and no other\", sub)\n",
+    "ax.legend(loc=\"center right\", frameon=False)\n",
+    "show_with_alt(fig, \"Non-null label rate by bar position from the end of each trading session.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "bd35c908",
    "metadata": {
+    "lines_to_next_cell": 2,
     "papermill": {
      "duration": 0.001499,
      "end_time": "2026-07-14T04:54:18.690524+00:00",
@@ -800,10 +849,60 @@
     }
    },
    "source": [
-    "**Interpretation**: If `% > cost` is below 50%, most trades would lose money\n",
-    "to the spread alone. This confirms the cost-dominant regime identified in\n",
-    "[`01_feasibility_analysis`](01_feasibility_analysis.ipynb) and supports the pedagogical framing: microstructure signals\n",
-    "exist but are not tradeable at institutional horizons."
+    "## E. Distribution and base rate\n",
+    "\n",
+    "What scale is the label, and does it mean the same thing across the panel and across\n",
+    "time? Everything from here through Section G is computed on the development window only,\n",
+    "sealed on the label's **endpoint** rather than on the bar it was observed from: a\n",
+    "decision taken shortly before the holdout still resolves inside it, so a filter on the\n",
+    "observation time looks sealed and is not. The label files keep every row, because the\n",
+    "seal governs what this notebook looks at rather than what it writes.\n",
+    "\n",
+    "Each label is sealed on its own endpoint, because they do not resolve together: the\n",
+    "60-minute window closes three quarters of an hour after the 15-minute one opened from\n",
+    "the same bar, so one boundary applied to all three would leave the slowest label\n",
+    "reaching furthest into the holdout. The symbol-session is carried as one `entity` key,\n",
+    "because it is the entity no label may cross and Section F counts overlap within it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6c0a715f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:11:54.712307Z",
+     "iopub.status.busy": "2026-07-31T09:11:54.712218Z",
+     "iopub.status.idle": "2026-07-31T09:12:08.791365Z",
+     "shell.execute_reply": "2026-07-31T09:12:08.790853Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_15m: 14,370,375 development rows through 2021-06-30 15:44:00\n",
+      "fwd_ret_5m: 14,753,585 development rows through 2021-06-30 15:54:00\n",
+      "fwd_ret_60m: 12,645,930 development rows through 2021-06-30 14:59:00\n",
+      "fwd_dir_15m: 14,370,375 development rows through 2021-06-30 15:44:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "_entity = (pl.col(\"symbol\") + \"|\" + pl.col(\"session_date\").cast(pl.Utf8)).alias(\"entity\")\n",
+    "dev = {\n",
+    "    name: labels_df.with_columns(\n",
+    "        pl.col(\"timestamp\").shift(-HORIZON_BARS[name]).over(GROUP_COLS).alias(\"_label_end\"),\n",
+    "        _entity,\n",
+    "    )\n",
+    "    .filter(pl.col(\"_label_end\") < HOLDOUT_TS)\n",
+    "    .drop_nulls(name)\n",
+    "    .select([\"timestamp\", \"symbol\", \"half_spread\", \"entity\", \"bar_in_session\", name])\n",
+    "    for name in LABEL_NAMES\n",
+    "}\n",
+    "for name in LABEL_NAMES:\n",
+    "    print(f\"{name}: {dev[name].height:,} development rows through {dev[name]['timestamp'].max()}\")"
    ]
   },
   {
@@ -819,25 +918,24 @@
     }
    },
    "source": [
-    "### Baseline IC: Lagged Return vs Forward Return\n",
-    "\n",
-    "The simplest predictor of the next 15-minute return is the current 15-minute\n",
-    "return (testing for mean-reversion or momentum). This baseline IC provides\n",
-    "the reference that Ch8 features must beat. Measured on train+validation rows\n",
-    "only (timestamp < holdout_start) so this expectation-setting diagnostic never\n",
-    "reads the sealed holdout."
+    "All three horizons go on one axis with identical bins and a logarithmic count axis. The\n",
+    "claim is about shape rather than width: a longer horizon accumulates more variance, so\n",
+    "if the three are the same process observed over different spans the bodies should widen\n",
+    "in proportion to the square root of the horizon while the tails stay heavy throughout.\n",
+    "The axis is symmetric and narrower than any label's range, so rows outside it are counted\n",
+    "below rather than drawn."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "id": "5b24fa62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:18.696524Z",
-     "iopub.status.busy": "2026-07-14T04:54:18.696418Z",
-     "iopub.status.idle": "2026-07-14T04:54:21.974357Z",
-     "shell.execute_reply": "2026-07-14T04:54:21.973794Z"
+     "iopub.execute_input": "2026-07-31T09:12:08.792862Z",
+     "iopub.status.busy": "2026-07-31T09:12:08.792794Z",
+     "iopub.status.idle": "2026-07-31T09:12:09.243517Z",
+     "shell.execute_reply": "2026-07-31T09:12:09.243201Z"
     },
     "papermill": {
      "duration": 3.280151,
@@ -849,71 +947,70 @@
    },
    "outputs": [
     {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqwAAAFnCAYAAABjBRvaAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtBFJREFUeJzs3XdYU9cbB/Bv2HtvQUFFRQQRUBxVcOLedVZxa4u4Z93WOmpVULG4tXWPqlX7Qy0O3HWh4hZRHICiDBky7++P9F4TSEgCCQnk/TyPj+Qmufdk3bw55z3v4TEMw4AQQgghhBAVpaHsBhBCCCGEEFIaClgJIYQQQohKo4CVEEIIIYSoNApYCSGEEEKISqOAlRBCCCGEqDQKWAkhhBBCiEqjgJUQQgghhKg0ClgJIYQQQohKo4CVEEIIIYSoNApYVUT05X9haOsGQ1s3jJkwu8z76dhrKLefVwlv5dhCyeT1GCqLMRNmc483+vK/Em+vzNdGEf7Yd4R7PD+vXF8hx/x55XrumH/sO1KmfSjydZBH+6Ql6+Ngb+vm25bbpsjXUNbPh6oRdz6r7I9L3tZv3IlGLTrD3MkThrZuaNqmV4Ue/9ad++jUexgc6zblXpe7sY8qtA1ENmU9B2spsE2Vys8r12Ppr+Firzc1Mca7Z3RyIuqFDWJMTYwxfmyQkltDqoLjf/+Dew8eAwC+698LNapXk+v+q/J7Ni09A+GbfgcAVHeqhiEDKjY4LO7gkZOYOX+50o6f8TkTfb77Hh9SPiqtDaTiUMBK5KahhxvO/LULAGBjbank1ijejEljMWxwXwCAu1sdJbdGMdgfcdWdHKrcl7+6YT+berq6FXI8cZ+P45FR2L3/KACgZfMmcg9Y5fWeVcXzWXr6Z+7xtWzeWOkB6//OXOD+nj31B7Txbw5DQ4MKO/7N2/e4YNXP1wsLZk+CtrYWarvUqLA2kIpDAasIHdq2xPSJY4W2aWlqKqk1qq+oqAh5efkwNTFGcz8fZTenwtSu6YzaNZ2V3QxCpFLRn83K/vlQt/NZWSQmvef+/q5/LzjXcJTr/rOysksNgBOTvx6/jX9z+H/jJ3GfeXl50NDQgJaWeoc/7Pe2nl7F/ICVB8phFcHayhLN/XyE/jXx9eKuz8rKxsQZC/FNh75wdv8GZo6esK/dGK07D8DO3YdE7vP02YvoNWgMatRvDjNHT9Ru6I/BIyci4bXo/I0Ll64joFN/WFRviLrebbBh8x8yP46s7GzMmLcMzu7fwLKGF3oOHCPyeOcvXkPvwWNR3a0ZzBw9UadRa4yZMBvPX7wUup1gft7OPYexYvVvqOfTBqbVPPDvrbtic77YbaL+CebTlbUtv+/9E+s37oSHXyDMnTzh17onzl+8JvH5GTRiArePuPhXAICcnC8wc/Qs8Rjm/vQrd9tTUdEAxOeyFRYW4ueV61G7oT+snBuhU68gbghUnBP/i0KXvsNRrY4fzJ084dW8E5b+Go6cnC9CtxPM/bn/4Ammzl6CGvVbiH19oy//iy59h8OxblOYVvNAjfrN0SqwH6bNWYr0jM9i28M+v6yE1+/EvmasP/+KRJOAHjB38kTDZh1x+Nj/StzmQ8onzJy/HJ5N+a9VtTp+6D14LP69GVPq8yPJzt2H0L3/KNT1bgNrZ29YVG8Iz6aBmDp7CVI+poq9X3ZODqbNWYoa9VvA2tkbfQaPw4uXCSVud//BEwSNnYqaHi25z+8Pk+fi7bukMre5Rfs+MLR1g5mjJ/c6x8W/EplTOnT0ZG7746dxJfYlzWdd0utX3MtXbxA8ZR7q+bSBuZMnatRvgaGjJ4s8vijFPx+vEt7C0NaN610FgE69g0p8hhT5nn2XmIxxE+fAr3VPVHdrBtNqHnCs2xSdeg/D8b//EdqfrDn5ZW03wA8eflkTAd9W3WBZw4s77/cePJb7ThkzYTbqN27H3efilRtc+zr2GgoAePDoKYZ/Px0+LbsKtKMFeg8ei0tXb3DHqufTBoa2brB29kZmVpZQW5q17Q1DWzeYODTA+w+ih9rZ5yb68nVum3uT9kLP1a9rN6Njr6Fw9QqAZQ0vWDk3gk/Lrli0LBTZ2TlC+3Pzbcs9ltdv3mHQiAmwr90Yjf27i33O3HzbYkzI19dl2aoN3D7Y50vwnD1rwQrU9GgJi+peePsuGQA/eF21bjOatukFa2dvWDk3gl/rnvh17Wbk5eWJbWPC67foM3gcrJ29Uc+nDTZt38M9Ly0Dv4VF9YZiz4GiyHpeBxT3vf3nX5Hw/qYLrJwboX337xD78CmKioqwbFU4950mqk1lPQfLQr1/YpTR56wsbNm5X2hbfn4+/r11F//euot3ScmYPTWYu27ZqnAs+UV4QkNi0nscPXEaY0cMRnUn4SGxa//exv7DJ1BQUAAAePM2EdPnLkW9OrXQxr+51O0cUuzL5czZixjxwwz8c3w3t23T9j2YMnsJGIbhtr19l4Td+4/ir5NncPLQdvg08iix75WhGxH/6rXUbZFGWdvyy5oIobbEPnyCAcPG49GtKJibmYo9XnM/Hxw7eQYA8O+tu6jlUgO378YiPz+fv00giGL/1tDQQLMm3qU+julzl2Ljtj3c5egr/yKwxxCxbflpxVosX/2b0LZncS/x88r1OH/xKk4c3AYdHZ0S9xs4PETocRd/fZ8+j0fvwWOFgt6Uj6lI+ZiKWzH38f2owTA1MS71sUjr8LH/4cmzF9zl5y9eYdi4afBwr4c6tV0AAK/fvEPbboOFgry8vHyc+icaZy9cxe4toejSsU2Zjv/n8VOIOn9ZaFtcfALi4nfj/KVruHzmsMiehGHjpiH24RPucuQ/F3DvwWNcO3sElhbmAIBTUdEYODwEublfv8ASk95j557DiPznAs6e2FumnqXmfj6IufcQ+fn5uHPvAZr7+eC6wHtO6O9bdwEAVpYWqFenVol9SfNZl8Wdew/Qte8IpKVncNtSPn7C4b8icSoqGicPbYevt2eZ9l0aRb9n37xNxB/7/hTalpqWjujL1xF9+To2rVuGwf16Vni7fwmNwE8r1pVo65u3icjIyETQf6kVkjx8/AwH/jwhtC3l4yec+icaZ85ewomD2+D/jR+GDOiNpb+GIzsnB8f/F4WBfbtzx7z334SlgJZNy5UKsXv/ETx9Hi+07fHTODx+GodrN2Lwvz93iLxfp97DuPOamZlJmY8vaOrsJSW+r3Jz89C9/0hcunpTaHvswyeIffgEZ85G4/iBrSLPvV36juB+2Ga/ycHkWT/hzdskrNu4A3l5/O8PUedAaUg6rwOK+96+fPUm9hw4xu33yvVb6N5/JDp3aI3tuw6W2qaynoNlQT2sIuzef7RET6DgL2wDfX3MmxmCPzavwV8HtuB/f+7Ezo2rULsmP28mNHwb9+vsdkysULAaNKgPDv2xATsifkXv7h2hocErcfy4+AR0bOePQ39sQN+enbnt2/44INPjePsuCWtXLsTW8F9gZsr/4F/99zYePn4GgH9ymjl/ORiGgYaGBmZOHofDuyPQu3tHAMDnzCyMnThb6EPBin/1Gv37dMPh3RHYvH45HOxtxLbjzF+7uH+nj/2BBvXrctd1aNNSLm2ZMn4UDv6+AR7u9bjbFz9xF9eimS/3NxuQCgYJz+Je4uOnVOTn5+P23QcAAA/3ujAxNhK7zyfPXmDT9r0A+MHtnOnjcXjXb2ji64VXIn4l37pznwtW7WytsWHNEhzdtxkd2/kDAC5fu4V1G3eKPFbKx0+lvr5nL1zhvkB/GD0EJw9tx+6tYVgwayK8vRqAxyv53mMNHdiby98DAFsbK+413L0lTOTjDhrUB4d3/YaAlk0B8HtydgiMOEyauZgLVgf164Gj+zYj7JcFMDI0QH5+Pr6fPAdZWdli21SaPj064bfQn3F4dwQij+zE4d0RGNSvBwD+lyT7w6S4pOT3iAhbil1bQuFSwwkAvxduZdgmAEB2dg7GhMxGbm4etLS0sHD2JPx1YAsmjx8JAEh+n4JJsxaXqc3fCLz/2Ped4I+km7fvoaioCO8Sk/HmbSIAoLmf6B9Lkj7rsmAYBmNCZnPB6oTvh+OvA1vw07yp0NTURGZWNsZN+lHkZ7E0drbWOPPXLnRo25Lb9uvPc7j3VUMPN4W/Z21trLF47hTs2RaGEwe34X9/7sSmdctgZWkBgP/jtyzK024AOBF5FgBgZmqCreG/4MTBbdi8fjlGBfWHna01AH5O8K4todx9PBu4cY/v15/nAgBca7tg2aKZ2L9jPf4+vAMnD21H2C8LoKurg6KiIvy6lv++HjKgF9em/Ye/nidPnjrL/f1try5i28vm93o2+NqjvWtLKM78tQszJvHT6UYO7Y8t4Svw556NiDyyEwd/34DAdq0AANGXr+PajTsi9/3+w0csXzQTfx3YgukTxoq8DQDs3hImlLo3ZEBv7vkoLv7Va3w/agiO7tuMdSsXwcjIAOs37eSCVcdq9tj+26/YEfErnBztAQCXrt4Ue+7V1NTAvu3r8MPoIdy2Ves2w8fLA4f+2IAeXdoDKHkOlIak87oiv7dfJrzBd/174fDuCC7vPPl9CrbvOohpE8Zg3/Z1sLG2KtEmoOznYFlQD2sZmBgboWEDN2zYsgv3Yh8hNS0DhYWF3PWZWdl48iweHu51sffQX9z2b3t1wYY1S4Qui2JtZYnfN62Grq4OvL08cOjo3wD4gaws5s4Iwcih/QEAV/+9xfUKv4hPQP16rjhy/BT3a7B753aYP2siAKCtf3NcvnYTye9T8OhJHO49eIyGAicmAGjWxBvbNvwitO1d4nuIIpgHNu+nVVyPVkDLpli1lH+iLU9bunZsi5/mTQXAH+INGsv/W9Lz5eleDybGRsj4nFkiYHCrWxuPnjzHvzdjYGNtxX0ZNffzFbM3vpOnznInip5dO+DHafye9mZ+Pqjt6Y/sHOGhsH2Hj3N/DxnQG661nAEAo4L6I/If/oSGfYeOY2rI6BLHkvT6amt//Xg7V3dEvbq1YGfz35ff5HGlPg4nRwc4OTpwl3V1dUrN5/Nwr8e9ty0tzBFwccB/beGnWnxKTeNSKWxtrDD8u28BAPXruaKNf3P89fc/+PgpDWfOXULPrh1KbZsobVo1w/LVv+Fc9FUkJr8X6g0FgNt3Y9G/T9cS91v042Ru4oqpiTG69eMHoif+F4Xli2Yi6vxlpHz8xD+GfzPuR07nDq3x57FIvHr9Fv+cu4SUj6mwsjSXqc2C76WvP5j4Pans++/Rk+dCPdfiXgNJ7wVZ3HvwmPsi8mzghm6d+MPpTRs3gm8jD1y/GYNHT+IQc+8hGjV0l3q/7HvI2uprr527Wx2hx6To92yN6tVga2ON8E2/48GjZ0jP+Cz0xf78xStkfM4s9UepKOVpNwBo/5dPaWCgj5rOTmhQvy4MDPQx6Nse3G1q13SGtpY2d9nUxKjE4/OoXxeXr97EL6Eb8fT5C2RmZQs9vjv//fCu7lQNrVs1w9kLV3Au+iref/gIG2tL/H36PAD+c9e9czuIw+b3mpp8fZ68GzYQmkDXxr85VqyJwNV/b+P9h4/cyBXrdkwsmjZuVGLfKxbPxPAh/cQemzueVwM8EAiYnBztxX4++vXuil9//lFo24E/T3J/hy6fh04dWgMAjAwN0HfIDwCAg0f+FnnuXbVsLtr6t0AzPx+hdL1N65ahpnN12NpYcwEaew6UljK/tx2r2WPDmp+goaGBx0/jMGfRSgBAi6Y+WDRnMgDg3MWr3Aii4PmlrOdgWVDAKoKoSVeCQyPHTp7GoBETS91Hega/d0Iwn6RT+wCpjt/EpyF0dfnDEJYWZl/3KTA8J41vmjfm/rYw/7qftP/yqQTbJji8p62tjYYebjgddZF/u7iXJd74HaV8LIJ27DqI1eu3AADq1amF3VvDuMT38rRFsKdK8HFKyhvT1NSEX+NGOHP2ImIfPkVWVjau37wLHR1tjBk+EJNn/YRrN2KEXvsWTUufhPHy1Rvub2+vBtzfpibGcK3tjLv3hesDCj7ulWEbsTJsY4l9Fh9WY0l6fbt0bINFy0Lx8VMaZsxbhhnzlsHczBS+3p4YOrA394tcHr5pJtAWofcsvy0v4hO4L87k9ylo3/07kft5ImV+pKDPmVlo03VQqfmkbDuK8/VuKPD31/fdq9dvwTAMngm8PqejLnLvQ0EMw+Dp8xewspRtgo61lQXqutbEk2cvcP1mDDKzsvDg0VM4OdqjR5f2ePTkOa7fiMHjZ1+fkxZNRf9gkvRekMXzuJfc3/diH4l9rR4/i5MpYJWGot+z6yJ2YNaCFaXeJj09Q+aAtbztDhrUh59OlpiM1l0GgsfjwaWGEwJaNsWE74fBtZZ0Q8oz56/Ab1vEz3cQTPEIGtQHZy9cQUFBAQ4f+x+GDOyFi1f4ecSBbVuVK/Ui4fVbtO06CBmfM8Xehv2OLK5TYOsyH1eczh0CSmwT/s75eh7waeQp8jaCfP+7jYX51zQvczNT1HSuDgBcOhEg/twjjjK/txt51oeGBn/gXTCFrVHDr99lgo+NbVN5zsGyoIBVBHbSlTgRW7/mJ343oBf69e4CfT09LFu1AWcvXAEAFBXJNlwmSDBvR3AmIwPZ9mlu+vUNJ7QfKYbyJA1hyZrbFHXhMibO5A+dWlma49Afv3HDHeVti5lZ2R9ni6a+OHP2IgoLC3Ho2P/w/kMKGnt7olUL/mxTfg/r18danlnDkh6HOAUFBcjNzeN+xLAkvb52Nta4dPoQNu/Yh2s37uDJszh+L+bZi9xjLm3YTxbmgu9ZzbK/Z7OKTcaQxl9/n+FOlHVda2LO9PGwt7PB7ZhYrkZkEVMkcT9lfX2AsrUb4L//njx7geT3KTh8LBKFhYXw8/HiJnlevxXDBfFGhgZo6OEmcj/l+ayXVfGJM/Kg6PdsxNavOXeTx49Eu4BvoKOjjUkzF+PBo6cAynbuLm+7h333LRwc7HDgzxO4e/8R4uJf4cXLBLx4mYCTp87i9qWTEs+XeXl52L6LnzampaWF+bMmoLF3Q2hpaWLg8BCkfEwVej9069QOFuam+JSajn2HjsPO1prrFevXu3w9YbsPHOWCVT9fL0wZPwoWFmb4+/Q5rFm/FYD459n2vyFnebKRYZ/SnAfYYJ4N7gDA2NhQ5G0r0/e2icCPFMHHJu4HHNsmeZ2DJaGAtQwSk5K5v1ctnQMjQ0MUFRUJbWfVrunM/eKJ/OdCubvE5Umw5MytO/e5v/Pz84V6AmvXckZxsny5P3j0FN+NnISCggLo6upg/85wuDg7ya0t5SHYY7r+v3ylJr5eqOtaE2amJrgVE8v9gHCt5Qxbm9JPfIKTb+7ExHJ/p2d8xrPnL0vcXvD9ERG2VGRdxezsnBLBqjQYhkF1p2pcugTAH4ZrGcgfjv/r738kfvnzeDwwDFOuH2AAUNOlOrevms7VEXPlb2gWKxVXfMhQWoJDWmOGD0KfHp0AAFeu35Z431t37qFBfX6u1o3/JjYBQA2nauDxeHAVeF8O7t8Tm9YuK7GP7OwcGBjol6ntzZv6cLnpgu+/Jj4NwePxcPHyv1zpHr/GjUo8Z4og+Blr2bwxIo/8XuI25XnMGryvX4RFRcJfYop+z7777xxtaWGGJfOmAeBXfRF17pZFedvNMAw6tGnJ5fQXFBTgx0UrEb7pdyS/T8G1G3fQsZ2/0JyH4s/dx9Q0fPmSC4Cfa88OZScmvcen1PQSx9TV1UH/Pt3x25Y/cPPOPW5BAmMjQy6HvqwEP5PTJ47hhtv3HTou7i6c8vxwlGWftWs6c+lpt+7c43ofb96+K3QbVVNR39uyKM85WBYUsIrwIeUjrly/VWK7j5cHdHV14OTogGf/DZv9tGId2rX+BnsP/oVHT0oOZw7o043LcTnw5wkYGuija8c2yMrOwYnIsxg5tJ/QcGpF6tUtEPOWrEZ+fj6OnTyDJb+sQ2Ofhtiz/yiSkj8AANzq1oLnfxOZyuJDyif0+W4c92t72OC+KCoq4p5fPV1deHs1qJC2iOLbyAN6err48iWXy9vz8/UCj8dDY5+GOHP2IrKy+ROBpOld7dyhNeb9tAoAcPTkGSxfvQFenu7YuG03tx9B/Xt35d4fs+YvR2paOhq41UF6xme8eJmAqPNXUN3RARFhP8v82A78eRJbf9+Hrp3awbl6NZgYG+PCpa/lvornGIlibmaCT6npSEx6j32HjqO6kwNsrC1lPpFbmJuhQ9uWOPVPNF68TMC3Q39A0KA+MDIyxOvX73A39hGOnTyDcyf3yVxIvrpA3uLvew/DuYYjXsQnSDWBZv7Pa6CppQVDA30s+Hk1t52tVtDGvzmsLC2Q8vET9hw4BnMzU7Txb46iwkK8ev0OV/+9jdiHT3DrYukT/MT5RmCIX/D9Z25mijq1XYTyV1tUUE1QT/d6qF/PFQ8fP8PFKzcwavxM9O7WEVraWkh4/RY3b9/H8f/9g7dPr0vemQiCI0j7Dh2HpqYGNDU10dzPR+Hv2eqODnj+4hU+fkrDr2s3o0H9Otiw+Q+RAZ0sytvuwSMnwsjIEC38fODgYIfCggIu3xQAN4lXcDTpwaNnOP73P7C0NIdTNXtUc7DjzmUPHj3Ftt8PwMbaEsvX/FYiuGUFDerDpRBc/ZcfXHTt1Bb6+npleyL+I/iZ3LBlF7R1dHDz9l3s3HO4XPuVp369u3AB6+TZP+FzZhZ4PB7mL/l6Hvi2V2dxd1caZX1XlqY852BZUMAqgrhctYc3/kGN6tUwYkg/buh//cadWL9xJ/T0dNGoobvQSQYAfBp5YPbUH7Bs1QYAwPZdB4XKQ7CTT5TBsZo9fvlpFqbMXvJfnbUNQtcbGxliY9iycv0qe/TkOV6/SeQub9y2R6jkU3UnBzy6GVUhbRFFR0cHvo08hEqb+P03HOvnyw9YWc3F5A8KqlenFkYF9ceWnftRWFjIlarR19eDg70t3iUK9+T4enti1pTvsXz1b0hLz8BsEfl1g/v3LMMj4w/BXL52C5evlfzxBUh3Mm7Vwg9HT5xGYWEhRgbP4NojqqdRkrAVC7iyVqf+icapf6Jl3oconQNbw87WGknJH3D3/iP0Gcyf5NKsiTf3JSyOmakxxharsWlna41pE8YAAAwNDbBx7VIMGjEBubl53OddUHUnB5QVf6KQPfcZ0dPT5Yb9m/h4CU+4kpA/LS88Hg+b1i3jylrtPfgX9h78S/IdpeTfognWRewAAPyx70+uzFRW8iOFv2eHD+nHTSRhf6BYWZqjTm0Xsbni0ihvu9MzPuPYyTNCNWpZNtZW8P+GX3nD2MiQ+55JS8/AgOEhAIAfpwVjzvTxCBrUBxu37UFeXj5Cpi8AANSuWQPWVpYily/1cK8Lb68GuC0wGiSPNKEBfbvhl9CNyM7JwdkLV7jvS2k+kxVl/JggnPrnAi5fu4WE1+8wbNw0oeu/aeaLEBVc3U9Z35WlKc85WBZU1qoMenULxLqVi1C7Zg3o6enCx8sDR/duEjsbd+6MEBzeHYH2bVrC0sIM2trasLezQY8u7eEs52UJZTVm+CAcP7AVHdq2hIW5KbS0tGBvZ4NB/Xrg0plDImu5VbW2CE5kcbC3hWM1flkTwcUiAOl7uFYtnYtZU76Hna019PR00ayJN04e3IZaLtVF3n7ezAk4vOs3ofeHg70tmvv5YPHcKZg7fXyZHpefrxd+GD0EXp71YWVpDk1NTZiaGKNFUx/8vmm1VF9Mq5bNRZ/uHbmyP+Xh5OiAK//8iUnBI1DXtSb09HRhbGSIuq41MahfDxz8fQMcq9nJvF9jI0McP7AV/t80hZGhARzsbTFvZgjmzgiReN8/toRixJB+sLQwg76+Hjq0bYnTx/6AtdXXx9uxnT8unjqIgd92RzUHO2hra8PK0hyeDdwQMm4Ydm0OlbnNggTff4083aGtzZ8J7uf7dSKIjo42GgtMDFG0Rp7uuBr1J0YF9YdLDSfo6GjDzNQE9eu5YlRQf5w8tL3M++7UoTWWLpyBms7VS6w2pOj3bMjYICyYNRHVnRxgoK+PVs2b4OShHRJTfSQpb7vHDB+Ivj06oaZzdRgZGkBLSwsO9rbo36cb/jm+S2gC1I6IX9G+TUuRdZ2XLpiB4DFDYWdrDSNDA3QJbIOTh7ZDX198/cugQX24v60szdFWhlrf4jg5OuCvA1vg28gT+vp6qOlcHaEr5ktdT7Yi6Orq4PiBbVg8dwoa1K8LfX096Onpwt2tDhbNmYK/9ouuwaoKVOl7GyjfOVgWPEaRWfmEEEIIUVmv37xDPR9+6bLRwwYgdMUCJbeIENEoJYAQQghRM7m5ecjMysKGLV8L7QvWfSVE1VBKgJSmzvsFG3fIttKULCbMWoqDx06Vez8bdxzA1Hm/iL3et00/PBExWx0AkpJT0LLzEGRmlm21IWXqNjAY5y/9q7D9K/r1Zx2PPI9Bo6cr/DiqbtvuP/HjT6Flvv+q9TuwcEW4/BpUiYyZvBB7Dp2UfEMVIOvnSpU+H0vXbMLaTSVXVaosQqYvQHW35lj7Gz+9o41/8xJpUMpQ2nviZswDBHQbVuZ9L1wRjlXrd5T5/kS5KGD9T0We5EV9aNYu/xHf9giskOOLY2drhYt//wEjIwOltkOSyvSFrE7k+WUwYnBvLJ03SS77IpVTeYMTRftx8hhMGCN6UYXKxNTEGH17dMK2DSvLvS9FdxwQ9UYpAYQQogAFhYXQ1NCo0Nm6pGph68lqasq/b2nT2mVlqvZBiLJQwCpGVPQ1rNu0G6npGWjv3wyFhcJ17B4/fYE1EX/gWdxLmBgbIWhAD/Tqyl97eeOOA3j89AXsbK3xv38uwtBQHxPHDkGH1s2x78+/8b9/LoHHA47+HQV7W2sc2L4aYyYvRECLxhjUlz+b9NHTFwiL+ANP415CQ0MDHVq3wIwJI5Cd8wVzf16L+w+fIi8/H3VqOmP6hOGoI0NB/dt3H2L24jX4lJqOZo0bYs6UsTAyMsC7pPfoPmg8zv21HcZGhli4IhxamprIyvmCy9duw8rSHD9OGQNfL/5yjP/75yI27TyIj5/SYGigjz7d22PUENGzQK/duIu1m3fjbWIyHO3tMGHsYPj58JeVk3QcQWt++x0x9x/h/sOn+G3bPjTydMPa5fw1ol+9ScSw4Dl48fI16rm6YPGPIbD7b/bvp9R0rN6wEzfuxILH46G9fzOEjBkMHR3tEscoz+v/KTUdnfuPw5Hf18Lejr+WeF5ePgL7jkHYstnwdK+DN2+TsCp8B+4/egY9XV307NIWIwb3ElpZhPXxUxpWrtuGmzEPoKurg87tW2HssH7Q0tTEzZgHmDZvJcYN74/te44ADIPe3dpjTNC34PF4OB55HnsPn0Sr5r44eOw0tDQ1MHX8cNhYW2Dp6s1I/pCCtq2aYu7Usdyx5f2+FhT76BmmzluJU4c2ca/lvj//h3N/bYeBvh72/fk/XL95F2uWzsLGHQfwNO4lVv3EL0vk26YfZk0ahQNHTyH5fQq8G9bHT7NDuNGA23cfYsXarXiX+B5NfRuWWHXm4ZM4/Lp+B168fA1rK3OM/K4POrb9BgWFhWjTfTh+/20ZnKtXQ/SVm5gy9xesXf4jmjfxwvMXCRg1cT6ijm6DpqYGBoyahmEDe6Jj229Evm982/TD9JAROHz8DF6/TcQ/R7bi1et35T52ZlY2flr5G27dfQiGYeDoYIuVi6Zx77HiPqR8wpjJC/H46QvUcnHC/Onfw+W/RS2yc75g3abdiL56E3l5+WjW2AszQkbAyMgA0+athGutGhg77Ota7kvXbAIPPMyePBpZ2TkI/e13RF/ll2/yb+GLyeOGQl9fjzt/LJo1Hpt/P4i09M8I+KYx5k4dy1UDkPS5YqWlf8bEWUuRm5ePlp2HAAD3OQeALX8cwv4jkeDxeBg2sCd33gSAU2cvY/ueI0hKTkF1R3tMDR6Ghg3qijzO32eisWPvMSQlf4CxsSG6dvDHuOH9wePx8PjpC4ydughb1/6E2i7VkfE5EwNHT8f3w/uja2AAFq4Ih7GhIaaOH4a8vHwsC92M6Cu3UFBYAFtrKyyY8T3c69UuccxrN+4ifOteJLxNhJ6uLlp/0wSTvh8Kvf8WB+k2MBi9u7XDhcs38SzuJXZuWAYLc1OZzl/ivj/Y44s7Fxf/Hnry/CUGj5mBm2cPcNd71q+Dx8/ice/BEzhVs8eiWcGoXbM6Zi5cjaT3KZizJAwaGhro1L4lfpw8RuK5V9r3hKB9f/5P5DkPAK7fuofwLXuR8CYRNlYWCB41CP4tRJcklNd5gVQQhjAMwzCjJy1gdh88wTAMw7xMeMs07TCQuXD5BpNfUMAcPHaKadK2PxOxfT/DMAzz4WMq06bHcOb0uctMQUEh8+zFKyaw7xjm+q17DMMwTMT2/Yxf+wHc9cdPnWdadh7CZGZlMwzDMAuWr2d+Xbdd7PGT339kWnUdyhw4Gsl8yc1lcnK+MLfvPmQYhmE+Z2Yxp85eZrKzc5gvubnMynXbmF5DJjBFRUXcsafMXSH2cfq0/pb5buxM5v2Hj0zG50zmh2k/MQuXhzMMwzBvE5MZn9bfMhmfM7l2tuoylLlxJ5YpKChkNv9+iOk64AeGYRgmOzuHadJuAHMr5gHDMAyT8TmTiX30TOQxE94kMs0DBzFRF64x+QUFzJnzV5nmHQczb94lSzyOpNeK1XXAD0z/kVOZN++SmS+5uUzIzKXMguXrGYZhmKKiIibohx+Z1Rt2Mjk5X5jUtAxmzOSFzIate0Xuv7yv/8TZy5gtfxzm9nfm/FWm15AJDMMwTE7OF6brgB+Y3QdPMHl5+Uxi0gfm2+FTmCMnoxiGYZi//neOGThqGnffcVMWMXOWhDFZ2TnMu8T3zLfDJjNbd/H3feNOLNO4bT9m4fJwJifnCxP/6g3Tud845njkOW5fTdr2Z/YePsnkFxQwR05GMa26DmVmLlzFpKZlMO8/fGTa9x7FRF24JtXjKsv7WlB+QQHTqstQ5sXL1wzDMMzA0dOZHoPHM5eu3WYYhmGmzv2F2XXgOHcswfexT+tvmbGTFzIfP6UxGZ8zmUGjZ3CvR3rGZ8a/axBz6K/TTH5BAXPh8g2maYeB3Ouf8TmTadNjBLP38N9Mfn4+czPmAfNNp++YO/cfMQzDMCEzlzIHj55iGIZhfl2/nekxeDwTtvEPhmEYZs+hk8zkOeI/T8X5tP6WGR48h3n/4SOTm5vHpKV/lsux12/ezUyavYzJyfnCFBQUMo+fxTNp6Z9FtmH0pAVM6+7DmLuxT5i8vHxm/ZY9TK8hE5j8ggKGYRhm5sJVzI8/hTIZnzOZ7OwcZvbiNczcn9cyDMMw0VduMt0HBXPnky+5uYx/1yDus71wRTgzdvJCJjUtg0lNS2dGT1rALPk1gmGYr+ePH38KZTKzspn3Hz4ynfuNY/763zmGYSR/roq7cSeW8e8aJLTtr/+dY5q0G8D8sf8vJj8/n7lxJ5Zp0m4A8/pNIsMwDHPx6i2m07djmUdP4pjCwkIm6sI1pk2P4UxqWobIY1y6dpt5mfCWKSoqYh4/i2fa9x7F/H0mmrv+jwPHmW+HT2FyvuQy0+atZOYsCeOuE3y/Hz5+hhk8ZgaT8TmTKSoqYl4mvGUSkz+IPObtuw+ZR09fMAUFhczrt0lMn6BJQueLrgN+YHoNmcDEv3rLFBQUMrm5eTKdv0r7/pB0Li5+bn38LJ7xaf0td3n0pAVMp2/HMk+exzP5BQXMkl8jmNGTFgi1/dzF69xlSefesrwnSjvnPX3+kgnoNoz599Z9prCwkLlz7xHTqutQJv7V2xKvWUWeF4h80E8DEc6cv4LGjTzQqrkvtDQ10bd7Bzg52nPX/306Go083NA+oDk0NTVQ26U6unUMQGTUJe429Vxrctd3ad8K+QUFSBAooF+av/+JhptrTXzbIxC6Ojr8RQk8+cXEjQwN0KF1c+jr60FXRwdjh/VDwptEfEhJlfrxDR3QHdZWFjA2MsT3I/oj8uwlsSuhNPdrBF8vd2hqaqB7x9ZITP6AtPTPAAAtLU3EJ7xFZlY2jI0MRfYmAMDpc1fg4+WONq38oKWpiXb+TeHVoB5Onb0k1XGk1bd7B1Szt4Gujg46tfsGj57yi64/fBKH128TMXHsd9DT04WZqTGGD+qFyKjLIvdT3te/S4dW+PvM16L4f5+JRuf2/CUXL127DWNjQwzq2wXa2lqws7XCwN6dcErgvcN6/+ETbtyJxeTvh8JAXw/2dtYY8V1vnDh1gbtNURGDkDGDoaenC+fq1fBtz0D8febrYgdmZiYY0LsztDQ10bFNC2Rl5aBH5zYwMzWGtZUFvD3d8PhZvFSPCyjf+1pLUxNeHvVwM+YB0jMy8fFTGvp274CbMQ9QVFSE2/ceorF3A7H3HzqgByzMTWFsZIg2rfzw+L/X9+LV27C2Mkefbu2hpamJVs190bjR1/1cunYb5mYmGNC7E7S0tODTsD46tv0GJ/97Hn293HHzv8LpN+88wOih3+LmHf4CIDfuxArtSxrs50tHRxtX/r0jl2NraWkhPSMTCW8Toampgbq1nWFqInp9bwDo0LoFPN3rQFtbC2ODvsXH1DTEPnyG1LQMnL14HTMnjoSxkSH09fUwbnh/nDl/BYWFRWjepBHy8vJx6+5DAMC5i//CxtoS7vVqo6ioCJFRlzB+9CCYmRrDzNQEwSMH4uTpaKHzx+ihfWFooA9rKws0a9yQ+xxK+lxJy8zUGN/16wYtLS34ernDwc4aT/5befDgsVMY0r876tWpCQ0NDbRp5YcaTtVw+fodkftq4dcINZwcwOPxULe2MwJbt8CtmK+Lvwzu2wV2NpYYHjwHT+NeYdakUSL3o6WpieycL4h/9RYMw6CGkwM3ulNcI0831HN1gaamBhwdbNG7azvcKrbgTN/uHeBc3QGamhp49uKVTOev0r4/pDkXS9KpXUvUqeUMLU1NdAn05z6Hokg695blPVHaOe/PE2fQNdAfjb0bQENDA14e9dCyqQ/++W/hAkEVfV4g5UcpASJ8SEmFva3wyUbwcmLye1z+947QhICioiJ4/bdCDQBYWnwt6szj8aCro4Os7Bypjp+UnCL2Q/slNw+hv/2Oy9fvIONzJjcMkpaRARtr6Yq729t+HUa0s7VGfn4BUtMyRN7WytyM+5stPp2dkwMzU2Os+Xkmdh04gbWbdqG2S3V8P7w/fEV8iN9/+Ch0TACo5mCD9x8+SXUcaVlZCOxDTxfZ2V8AAIlJH/A5MwtteozgrmfAoEjM0FN5X/9WzX3x86pNiH30HI4ONrh6IwbTxvNv+y7pA+LiXwvdl2EY2FpblmjH+5SP0NXRhqXA46pmb4PkD19XrNHV0YaF+df3mr2tNd6nfH1eLQWu09PjP68WAs+1np4ucnK+SPW4gPK9r4H/vgTuPICFuSm8Pd3Q2NsDP6/aiCfPX4LH04BrzRpi72tZ7PXN+q/dHz5+KvH+srO1Ql5ePgAg+cNHOBQbOq9mb4vb9/jrbvs2cscfB/5CaloGUtMz0LHtNwiN+B0ZnzNx594j/DBigNSPD4BQoCKvYw/p3x25eXmYtWgNsrKy0b51c4wfPZgbRi7RBoH3q5aWFqwszPE+5RO0tbVQVMSg+yDhxSg0eBr4+CkNNtYW6NLBHydOnYevlztOnLqA7p3468CnpmUgP79A6Lmu5mCLvPx8oR+Xwq+THj5nZQGQ/LmSluB7mn8M4c96+Na9QrPMCwoL8UHgMyHo6o0YbN55CK/eJKKgsAD5eQVo3sSLu57H46F3t/aYNm8lJo0bAiND0RNSO3dohZRPqVi2hp9q06q5LyaNGwIzU5MSt33w+DnCt+zF8/gE5ObmoaCwEDWKrZYm+B6S9fxV2veHNOdiSYq/vtn/fQ5FkdT2srwnSjvnvUv6gJt3YnE88jx3fWFhIQwNWpXYT0WfF0j5UcAqgrWVOe49eCa0Lel9Chq48VeysrW2QsA3TbCsjLOYJU3CsLO1wvWb90Ret+vAcTx6+gJb1i6GrbUlPmdmoXX34ZBl+YfE5A/cY0lKToG2thbMzUyQ9D5F+p0AaOLtgSbeHigoKMDBY6cxdf5KnDu2vUQupo21Je7GPhZuQ9IH7le/rDRknMRia2MJczNTLndSkvK+/ro6Omjn3xR/n4lGDScHNKjnCgc7G64tbnVqYkf4zxLbYWNlidy8fHz8lMZ9SbxL+iAU3Obm5eNTajp3Ak96nwIbq7KtSqXo9zUA+DZqgJ37jsHczAS+jRqgTq0aSHqfgnMX/4WPV/0yTVCytrRA4n9raLOSkj/CwpwfLNhaW+JdkvD175Lfw/a/H3h1a7sgP78AB45GwtvTDZqaGvBqUA97D/8NLS1N1HJxkqk9PIH3v7yObaCvhwljvsOEMd/hbeJ7TJ6zAoeOncJ3/bqJbENS8tfPckFBAVI+pcLGygK2NlbQ0OAh8uBG7gdMcd07tcZ3Y2di2MBeuH33IRbP5ge35mYm0NbWQmLyB+79mJj0Hjra2jAzNUbS+9xSnxdJn6viZP2cA/zPV79eHdG3eweJt83PL8D0Baswa+JIdGjdAjo62li1fgfeJb/nbpPxORMr121Dr67tsH3PEbTzbyb0Y4ClpamJEYN7Y8Tg3vj4KQ1zloRh085DXN6ooDlLwtCtY2us+mk69PX1sOfQSZw4dV74sWt8feyynr9K+/6QdC420NfDl9yvr2PKR+lH7oq3G5DcdlnfE0Dp5zxbG0sM6N0ZIWMGS2xrRZ8XSPlRSoAI7fyb48ad+7h07TYKCgtx5MQ/SHj9ddizc/tWuHknFlHR11BQUICCggI8ef4SDx4/l2r/luZmeJOYDEZMlNmpXUs8ePwch/46jby8fHz5kos7//3qy8rOga6ONkyMDJGd8wXhW/bK/Pj+2H8cH1I+4XNmFjbu2I8OrZuLnPBTmo+f0nDu4r/Iys6BpqYmDA30oaWpKfK2HVo3x62YBzh/+QYKCgtxNvo6bt97hA6tW8jcdgCwMDfFm3fJUt++ft3asLW2xIat+5CVnQOGYZCY9EHsMKE8Xv8uHfxx+txlHI88hy4dvv66b9nMB59S03Dw2Cnk5uWhsLAILxPe4WaM8JAgANhYW8DXyx2hEX8gJ+cLkpJTsG33n+jSwZ+7jYYGD+u37MGX3Dy8THiHg0dPiZ0QJImi39cAULe2MwoLi/C/qIvw9XIHj8eDl0c97D/6vzIPsX3T1BvvUz7hyIl/UFBYiEvXbuPmna9ro7fwa4TUtHQcPHYKBYWFuHPvESL/ucQ9j5qaGmjk6YY9h09yIwS+jRpgz+GT8GkoHER3Gxgs1HsjibyOffHqLbx6/Q5FRUX8z5qWJjTFfN4A/lBr7KNnyM8vwObfD8Hc1AQN6rvCysIM/i0aY8XarUhL54+qpPz3WWZVd7RHPVcX/PjTGjRv4sUFBhoaGujY5hts2LoP6RmZSEv/jPAte9G5fUupzh+SPlfFWZibITsnB59S0yXum/Vtj0D8sZ//o55hGHz5kovrt+4JjUqw8vLzkZeXB1MTY+joaCP20TNEFhsa/+nXCHh7umHOlDHoFhiAuUvXipwUdON2LJ48f4mCwkLo6+tBR0dH7GScrOwcGBsZQF9fD/Gv3uDQX6dLfUyynr9K+/6QdC6u5+qCcxf/RWZmNj6lpuP3/X+V2rbiip+bJbVd1vcEUPo5r3fX9jh+6jxu3olFYWER8vLyce/BU8S/elNiP/I8L5CKQT2sIjhXd8Di2eOxct12pGVkoJ1/MzQTGCaysbbAuhVzsG7TbixdvRkMUwTn6o4YN7yf+J0K6Nm5DWYtXoM2PUbA1sYS+7b8KnS9rbUlNvw6H2ERf2D95j3Q1tZCYJsWaOTphsHfdsXcJWHo0Gc0zExNMG54f4knvOI6tWuJsVMW4WNqGpr6NMS08cNluj/AH8be++ffWPTLBjAMg+qO9lixYIrILy6nanb4ZdE0hG/ZgwXL1qOavQ1+XTwNjg62Mh8XAAb17YKFKzYgoNsweHnUQ+jSWaXeXlNTA6FLZ2Hdpt34dthkZGXnwNbGCr3/m/1enDxefy+PejA00Ef8qzdo59+M226gr4cNK+chbNMubPn9EHLz8uHoYIsh/buLbMuSuRPxy9qt6DowGHq6OujY9hsEDegusD991KnljB6Dx4NhGPTq0hZdA/1F7ksSRb+vAX7Q08jTDY+fvuCGQZs08sDZ6OtlDlhNTYyw6qcZ+GXtNqzesBN+Pp7o2O4bLq/SxNgIYct+xOrwHVi/ZQ+sLS0wa9IoeHnU4/bh6+WOi1dvcW1o4t0AK9flCKW45OXlIy09Ax71xff+FCevY79+m4Rf12/Hx9R0GOjroU1Lv1J7Ebt3bI21m3bj0ZM41HKpjl9/ms79oFw4MxgbdxzA0O9nIz0jExbmpmgf0BytWzb5ev/ObbBweTjGDusvtN+p44dhzW+/o9/wyQD46S+Tvh8q1XMh6XMl6vY9OrXBt8OnoLCwUOLnnG1PXl4+lvy6EW8Tk6Gjow33urUwc2LJ3FNDA33MmDASP6/ehJycL/BuWB/tA5oj+QO/d/rw8TN4+vwldm/iL8QyfvQgjAiZh627DmNM0LdC+/qYmoYVa7ci+X0KdHV10MTbo8RtWD9OHoM1v+3Euk274VanJgLbtMCFyzfEPiZZz1+lfX9IOhcP6tsFT57Fo8uA72FrY4V+PQOFcnolGT6oF35dvx1b/jiMjm2/waxJo0ptu6zvCaD0c149Vxf8PGciNmzbj5cJb8Dj8fO9J44bUmI/8vpskorDY0rrDiGEqCy2rNX54zuU3RS1cOvuQxz+67RaLGjAlr47eSBC7MgJIYRUJOphJYQQKfg0rA+fhvWV3QyFy88vwK6DJ9CzS1sKVgkhKoNyWAkhhADg9yK37jEcaemfxaapEEKIMlBKACGEEEIIUWnUw0oIIYQQQlQaBayEEEIIIUSlUcBKCCGEEEJUmtpXCSgqKsK7d+9gbGxMhYAJIYSoLYZh8PnzZzg4OMi8mAwhiqb2Aeu7d+/g5ERLrBFCCCEA8Pr1azg6Oiq7GYQIUfuA1djYGAD/A2piYqLk1hBCCCHKkZGRAScnJ+57kRBVovYBK5sGYGJiQgErIYQQtUfpcUQVUZIKIYQQQghRaWobsIaHh6N+/fpo3LixsptCCCGEEEJKofYrXWVkZMDU1BTp6emUEkAIIURt0fchUWVq28NKCCGEEEIqBwpYCSGEEEKISqOAlRBCCCGEqDQKWAkhhBBCiEqjgJUQQgghhKg0tV84gBCifIm3N+FL2gvusp5ZTdh7j1FiiwghhKgSClgJIUr3Je0Fsj/EKrsZhBBCVBSlBBBCCCGEEJVGASshhBBCCFFpFLASQgghhBCVRgErIYQQQghRaRSwEkIIIYQQlVYlAtb4+Hi0bt0a9evXh4eHB7KyspTdJEIIIYQQIidVoqzVsGHDsGTJErRs2RKfPn2Crq6usptECCmHL2nxiD87CwDVZCWEEFIFAtYHDx5AW1sbLVu2BABYWFgouUWEkNIUXyQA4Aeogorys6guKyGEEI7SUwKio6PRrVs3ODg4gMfj4ejRoyVuEx4eDmdnZ+jp6cHPzw///vsvd92zZ89gZGSEbt26wdvbG0uXLq3A1hNCZMUuEiD4ryj/axqPgXUDGFg3gIa2oRJbSQghRJUovYc1KysLDRs2xIgRI9C7d+8S1+/fvx9TpkxBREQE/Pz8EBoaisDAQDx58gQ2NjYoKCjAxYsXERMTAxsbG3Ts2BGNGzdG+/btRR4vNzcXubm53OWMjAyFPTZCiHga2obQM3MR2iY4/B9/dhb1shJCCAGgAgFrp06d0KlTJ7HXr169GqNHj8bw4cMBABERETh58iS2bduGWbNmoVq1avD19YWTkxMAoHPnzoiJiREbsC5btgyLFi2S/wMhhMhEz8wFLm2WK7sZhBBCKgGlpwSUJi8vD7du3UK7du24bRoaGmjXrh2uXr0KAGjcuDHev3+P1NRUFBUVITo6Gm5ubmL3OXv2bKSnp3P/Xr9+rfDHQQgpO3YCVuLtTcpuCiGEECVReg9raVJSUlBYWAhbW1uh7ba2tnj8+DEAQEtLC0uXLkWrVq3AMAw6dOiArl27it2nrq4uVREgpIIJTrQqPsFKEpqARQghRKUDVmlJSisQJTw8HOHh4SgsLFRQqwghLHailSz0zGr+d994oUlZhBBC1I9KpwRYWVlBU1MTycnJQtuTk5NhZ2dXrn0HBwfj4cOHuHHjRrn2QwiRnoa2IVcFgA1IxbH3HgOXNstLTMwihBCiflS6h1VHRwc+Pj6IiopCz549AQBFRUWIiorC+PHjlds4QojMxE20mj53Ke4/eMxd9nCvh5VLfqzIphFCCFFhSg9YMzMz8fz5c+5yfHw8YmJiYGFhgerVq2PKlCkICgqCr68vmjRpgtDQUGRlZXFVA8qKUgIIUR33HzzGxSulj3bQ6leEEKK+lB6w3rx5E61bt+YuT5kyBQAQFBSEHTt2oH///vjw4QPmz5+PpKQkeHl5ITIyssRELFkFBwcjODgYGRkZMDU1Lde+CCEllWeilSg0+YoQQtSX0gPWgIAAMAxT6m3Gjx9PKQCEVDJlmWglimCuK03AIoQQ9aT0gJUQUrUJrmglaaKVKIJD/7T6FSGEqCe1DVgph5WQikErWhFCCCkvlS5rpUhU1ooQ1XUv9jE69hqKjr2GYvrcpcpuDiGEECVT2x5WQohyiCphVVx6xudSqwZQxQBCCFEvFLASQuSKrQ4grjKApBJWLZs3BsDvZU3P+Mz1tnq418MPbfi3oYoBhBCiXtQ2YKUcVkIUQ1R1AMFe1Xuxj4WuE7zcsnljRB75HQDQsddQXLxyQ6i3Va/3NwLHoYoBhBCiLtQ2YKU6rIQoFlsdQM+sJu4/uCS2VzU947PI7WyqgGBP6/Cfvl73QxsX6mUlhBA1obYBKyFEsd6lamLlH+8AvON6UU1NjOHZgB+IXrxygxv+Zwnms7JLs4rqaQUAtHFQ7AMghBCiMihgJYQoRGZ2Ni5eeSK0zbNBPW7IX1qCQSzb20oIIUS9UMBKCFEowV5VURUBJGF7WoGvva33Yh/j3oMM1LYB0pIeIf7sLKoWQAghVZjaBqw06YoQ+WErAwD8AFJHE8jKygZQtl5VSdIzPiM9/TNgow8dzULKZSWEkCpObQNWmnRFiPwIVgbQ0eRvKyiQ/49BwR7aVx/eAMhBXUddGOlr4EV8AlzkfkRCCCGqQG0DVkKI/LyIT4CdEZCTx8PTt7koKCjEqw8MWjZvXKY0AHGKpwcs33cDv4U4wMdVH5nZ2XI7DiGEENVCASshpNwys7MBI+Dhq2x8v+4dAOGaqorABsJaWkkA+CkIHXsN5a4TDG4JIYRUbhSwEkLKjF0QYKhfNgAdaGlpcqWq5NmzKgobkB5b1xNAAQoKCktdQYsQQkjlRQErIaTMaurcgodPGmra6gAADA0NFNqrKoqRgQGADNSvYYDNk51QUFCIrCJaAYsQQqoStQ1YqUoAIeXnYF6I2jb63GV+8FixarpUR/aHWOjrMGjowg+cn7+nzzUhhFQlGspugLIEBwfj4cOHuHGDhhAJKa+cPB4MrBugfqOACj+2nllNGFg3gIF1A+Tk8QB8zWedPndphbeHEEKI/KltDyshpGzYvFUAXO7q2zRN+A5ZrpT2CC4WcG9dT9S2oXxWQgipaihgJYTI5P6Dx1wwOMjHQS77fPXXKmS9+7qMq6FDXdToPlXm/bD5rFpamnJpFyGEENVAASshpExMTYxhamoMoKDcuatZ757g84vb5W4Tm89qaMhvz73Yx1TqihBCqgAKWAkhZeLZoB483R2Q/SEWNV2qK7s5QqqZFeK3EAc8fZuLNX9SagAhhFR2FLASQqTC5q62qP4Gg3wcYGqagS9pucpulkj6Ogx8XPVhamoM03/ykJ7xWdlNIoQQUg5qWyUgPDwc9evXR+PGjZXdFEIqBTZ3tYY1Dz6u+qhtU4CifNWqd8pWDNDQNgQAeLrXg2cDxS5gQAghRPHK1MP6xx9/ICIiAvHx8bh69Spq1KiB0NBQuLi4oEePHvJuo0IEBwcjODgYGRkZMDU1VXZzCKk02AlNeYWaMLNzA8APFKUlaoJVcdnvnuJhxBjuemknYLEVA+LPzkL2h1ih69h8VsplJYSQykfmgPW3337D/PnzMWnSJPz8889c4X0zMzOEhoZWmoCVECKZYAmre7H8//kTmgpgZucGlzbSlbISDFKlmVxV+CWTu93nF7eFAlygbFUE0jM+U6krQgippGQOWNetW4fNmzejZ8+eWL7865eVr68vpk2bJtfGEUKUS7CElaxkDVJZxjW9S9yn+P1FBbGCCgo/QNOK/7eHOz8l4F7sY8plJYSQSkrmgDU+Ph6NGjUqsV1XVxdZWaqVz0YIkQ9TE2MuF9TIoABABoCSw/uCxAWpogJSwevqj9skdt+lBbGCtM3NoGmlBwDc8H/HXkNx8coNKnVFCCGVkMwBq4uLC2JiYlCjRg2h7ZGRkXBzc5NbwwghyiEqDcCzQT1sn/cNvqS9wJe0eBTl828rbf1UNkgVHMp/GDEGn1/cRva7pyLvI2rIv7QAGeDnvhZ+yUTB50wUPslC3tsbiMcsAECPRlm4eIVSAwghpDKSOWCdMmUKgoOD8eXLFzAMg3///Rd79+7FsmXLsGXLFkW0kRBSgcSlAXxJe4HsD7HIfZ2Bwux85L64iaKcAgCApp4RDBzqiNyfpHzTwi+ZUrdNUt4qGwQzBQVgMoG8zHSkXLoAAGigbYiWzflVQSg9gBBCKheZA9ZRo0ZBX18fc+fORXZ2NgYNGgQHBweEhYVhwIABimgjIUQJBNMA+Hmg/DSAopwiFGXmowhp3G0NHOpwQ/nSElUdQNS2suxTsNe3KJPfHWxoDkQe+R1AyfQASg0ghBDVVqayVoMHD8bgwYORnZ2NzMxM2NjYyLtdhJAKxqYCCKYBsAEeANwL74Xcjx/BfGEACPeqliXQlHWWvyz7FEwdyEy4B6agAAWfM/EwYoxQWyk9gBBCKodyrXRlYGAAg3KuIU4IUQ2iUgEEA7+cV6+FritLr2pFEQyGby9rh/zUNDAFBfj84jY+v7iN8XWsMKyaNWLfZWPNZZosSgghqk6qgLVRo0bg8XhS7fD2benL1xBCVA+bCuDhXg+pT84j90NiidsY1/Qu9/B9RdEyMUZhfhaXGgAA1kwKrA0Al9qAk5EeXmc+pMoBhBCiwqQKWHv27KngZlS88PBwhIeHcwsfEKKORFUEmBFghg4+egBeIjPhA/+Gmjxo6PNPF7qWdirbsyqKsVtdaH7I5yaLaWobIj81jbvey04TXgCcku4DAHKSkwBQwEoIIaqExzAMo+xGKBO7NGt6ejpMTEyU3RxCKhQ7+QgAghvroJaFBrzsNEvcTtNYD5YtvgHAX4aVXQK1Mki8vUmgHFcWDKwbQCPTutSSXKLKcBFS1dH3IVFl5cphJYRUbh2tktArUA9amppoYF3yem1zMxTmZ0HHwlrqZVhVDRtcx5+dhewPsQBET84StSjBi/gEClgJIUQFyBywFhYWYs2aNThw4AASEhKQl5cndP2nT5/k1jhCiGLsmtUfWpmJaGaeDaBkjyqbo1pk9AHZH2JhYF058lVlJRiMho7uAP1cfgpEbQsNGOnwYFTwiassQIErIYQoj4asd1i0aBFWr16N/v37Iz09HVOmTEHv3r2hoaGBhQsXKqCJhBB508pMhItBttA245reMK7pDbtvBqL+uE1qF6C9tQ3Akc8eOPLZAy/T+ZNM9TWL8PnF7VJX1yKEEKJ4Muew1qpVC2vXrkWXLl1gbGyMmJgYbtu1a9ewZ88eRbVVIShnh6gLweHv989ioK9ZhKw84H2BAQqM7PHd8v0AvuZ8AhDK+6ysKQEsNiVAQ9sQemYuAMTn47K9rXWttaGvWVSi5qy6BfNEPdD3IVFlMqcEJCUlwcPDAwBgZGSE9PR0AEDXrl0xb948+baOECI3gpOM9P/LAnhfYIAB66OFbscuwVpVFeVnSXx8kSl2uHjlNdZ25uf2Fn7J5J47tseVAldCCKk4Mgesjo6OSExMRPXq1VGrVi2cPn0a3t7euHHjBnR1dRXRRkJIObA9qx9f3IcOgJxCDcR9KkJBYSFydPXE3q94T2RlJ/gY2J5jSZ58yEdBoQZMTYyFUijEVRcghBCiGDIHrL169UJUVBT8/PwQEhKC7777Dlu3bkVCQgImT56siDYSQsqB7VnV+e/ykw/5mHLqCwCgZXM7TBJzPz0zl0qfBiBIcOhfsGKAKB7u9QAAu2IfIz3jM1o298DG4Q2R9e4Jst89ReGXTGS/e4qHEfx9Um8rIYQolswB6/LlX7/A+vfvjxo1auDKlStwdXVFt27d5No4QkjZCOarZr97CoDfs/rkQz5eZ2qiZfPGAL4GZkQYu9IVW6f2XuxjjN3Ov258HT1YI5PSBAghpAKVuw5r06ZN0bRpU3m0hRBSDuJqirLiPhVhyqkvaNm8MSKP/F7iesEC++riS1o84s/OkrgYQnrGZ26BhY5WTqjpw19YQFTtVkIIIfInc8C6bNky2NraYsSIEULbt23bhg8fPmDmzJlyaxwhRHriVm6KzzZAesZnxH0qKvX+VX2ylSiSJmAJ9kDf+y89IDLFDpP+W5qW/ZFAaQKEEKJYMgesGzduFFm6yt3dHQMGDKCAlZAKJhg0AShRgmnB9ru4eOUGTE2M0bJ5Q4lpAOxkq6ow0Uoc9rFJmnzFpgYAwsvYstiA9GHEGHx+cVtkmgBAwSshhJRXmcpa2dvbl9hubW2NxMREuTSKEFK60ob/DRzqYPsbZ9x/8BjAXdyLfQwA8GxQT2QqQHFVbbKVKKKWa5XWvdjH6NhrKDzc63EBraHD15XAKE2AEELkT+aA1cnJCZcvX4aLi4vQ9suXL8PBwUFuDZOFs7MzTExMoKGhAXNzc5w7d04p7SCkoogb/meXVL1/6m6J3kAiH4L5rCzB3tPiE94EUwWop5UQQspG5oB19OjRmDRpEvLz89GmTRsAQFRUFGbMmIGpU5V3Ir5y5QqMjIyUdnxCKoKk4X8uGNo+FABgamIMzwb8FABRqQDFV7VSV+zkK0D86lfs88fmsoojGJCKShUghBAiO5kD1unTp+Pjx4/44YcfkJeXBwDQ09PDzJkzMXv2bLk3kBDyVfGeVQOHOqj/3wSg6XOX4v5/gaq0aQDqONFKFGlWvxJV6qpjL/7zLZgeIIhNFaBJWYQQUj4yB6w8Hg8rVqzAvHnz8OjRI+jr68PV1bXMq1xFR0dj5cqVuHXrFhITE3HkyBH07NlT6Dbh4eFYuXIlkpKS0LBhQ6xbtw5NmjQRapO/vz80NDQwadIkDB48uExtIUQViaqpyvasCuZO3n/wuMxpAFVtVStplWX1K5ao1IDiSpuURQghRHplrsNqZGSExo0bIyMjA//73/9Qt25duLm5ybyfrKwsNGzYECNGjEDv3r1LXL9//35MmTIFERER8PPzQ2hoKAIDA/HkyRPY2NgAAC5duoRq1aohMTER7dq1g4eHBzw9PUUeLzc3F7m5udzljIwMmdtMSEVgA1VRAY5gz2pxktIARFGHiVaiyLL6FUtUqStJBH9YUF4rIYTITuaAtV+/fmjVqhXGjx+PnJwc+Pr64uXLl2AYBvv27UOfPn1k2l+nTp3QqVMnsdevXr0ao0ePxvDhwwEAEREROHnyJLZt24ZZs/g5Z9WqVQMA2Nvbo3Pnzrh9+7bYgHXZsmVYtGiRTG0kRBlEBavGNfkF6wUDoOlzl+L+g8cyVQNQx0UC5EVUqStRlQMElZbXSuWvCCFEMpkD1ujoaMyZMwcAcOTIETAMg7S0NOzcuRNLliyROWAtTV5eHm7duiWUG6uhoYF27drh6tWrAPg9tEVFRTA2NkZmZibOnj2Lfv36id3n7NmzMWXKFO5yRkYGnJyc5NZmQspD0vC/qGCmLKkAlLsqnjQTsIqTJj2Axf7YoPJXhBAiPZkD1vT0dFhYWAAAIiMj0adPHxgYGKBLly6YPn26XBuXkpKCwsJC2NraCm23tbXF48f83qTk5GT06tULAFBYWIjRo0ejcePGYvepq6tb5nxbQhRB0pKqpQ3/C2JTAaRNAwDUY5EAWUkzAYslbeUAQeyPDip/RQgh0itTHdarV6/CwsICkZGR2LdvHwAgNTUVenp6cm+gJDVr1sTdu3dlvl94eDjCw8NRWFiogFYRIr3SaqoCwsP/LDYNAJC+IoAo6pq7KkpZJmCVpXIAi8pfEUKI9GQOWNlZ+EZGRqhRowYCAgIA8FMFPDw85No4KysraGpqIjk5WWh7cnIy7OzsyrXv4OBgBAcHIyMjA6ampuXaFyFlIXVNVRHKUxGAiFaWCVjFyZIaIIjKXxFCSOlkDlh/+OEH+Pn5ISEhAe3bt4eGhgYAfk/nkiVL5No4HR0d+Pj4ICoqiit1VVRUhKioKIwfP16uxyKkopVWU1Wc4hOsZKkIQIsEKE5ZKgcIKq38FU3KIoSQMpa18vHxgY+Pj9C2Ll26lKkBmZmZeP78OXc5Pj4eMTExsLCwQPXq1TFlyhQEBQXB19cXTZo0QWhoKLKysriqAWVFKQFEGaStqSpO8Z5VWdIAaKKV7NgJWJImX5VWOQCQnB7AEnwP0KQsQgj5qsx1WOXl5s2baN26NXeZncEfFBSEHTt2oH///vjw4QPmz5+PpKQkeHl5ITIyssRELFlRSgCpSGWtqSpOWSZYsdR1kYCykGUCVnFlSQ8Q7D2lSVmEEPKV0gPWgIAAMAxT6m3Gjx9PKQCkUpO2pqoo8ppgxaKJVpKxgbysq18B5U8PYNGkLEII+UrpAauyUEoAUbSy1FQVhSZYVTx2+L8sk6/KsrCAJDQpixCi7tQ2YKWUAKJoonpVyzL8zyrLkqsArWqlCspaPYBV2qQsQghRBzIHrPfu3RO5ncfjQU9PD9WrV6fC/EStSSpXJa2yLLkqCk22Kr+yrH4FlG1hgdIIvn8or5UQok5kDli9vLzA4/HEXq+trY3+/ftj48aNSllIgBBlKG21qrL2qso7FYBWtSq7sk6+Ks/CAqKUltdK5a8IIVWZzAHrkSNHMHPmTEyfPh1NmjQBAPz7779YtWoVFixYgIKCAsyaNQtz587Fr7/+KvcGywvlsBJ5Km21Kll6VUUpT0UAQTTZSnZlWf2qNOVNDRDEvq+o/BUhRB3IHLD+/PPPCAsLQ2BgILfNw8MDjo6OmDdvHv79918YGhpi6tSpKh2wUg4rKa/SJlUBZevlkndFAFI+8lj9CpBf5QBB7HuLyl8RQtSBzAHr/fv3UaNGjRLba9Sogfv37wPgpw0kJiaWv3WEqCB511QVJK80AFrVSnGkXUxAkCIqB7Co/BUhRB3IHLDWq1cPy5cvx6ZNm6CjowMAyM/Px/Lly1GvHr8X4e3bt+Uu7E+IKiktRxWQvqaqtMpaEYBFE60UpzyLCQiSZ3oAi8pfEUKqKpkD1vDwcHTv3h2Ojo7w9PQEwO91LSwsxIkTJwAAL168wA8//CDflhKiRJJyVMsTCCgyDYBWtZKf8iwmIEjelQMEUfkrQkhVJXPA2rx5c8THx2P37t14+pSft/ftt99i0KBBMDY2BgAMGTJEvq1UAJp0RaQhqUSVPHqsFLkwAE20kp/yLCYgSN6VA0QprfwVez31thJCKpMyLRxgbGyMcePGybstFYomXRFpFO9ZLW+OamnKmwZAeauVkyJSAyTltbIlsChwJYRUFmUKWOPi4hAaGopHjx4BANzd3TFhwgTUqlVLro0jRBkkLakqL/JaGIBFeasVq6yLCbBEVQ6Q10QsQYLvWSqBRQiprGQOWE+dOoXu3bvDy8sLLVq0AABcvnwZGzduxPHjx9G+fXu5N5KQiqDI2f+iKCoVgPJWK0Z5J1+Jqhyg6N5WwRQXShMghFQmMgess2bNwuTJk7F8+fIS22fOnEkBK6m0RAWr8p79L2qClbwWBmBR3qpiyXsxAUCxE7EE0aQsQkhlxWMYhpHlDnp6erh//z5cXV2Ftj99+hSenp748uWLXBuoaGwOa3p6OkxMTJTdHFLBRBVdFxz+l3ePE9uTJqhl88blSgVgc1fZ4MnAugEFrBWEnYAlr+ecfX8Uz2eWV3oAq6Lf96RyoO9Dospk7mG1trZGTExMiYA1JiYGNjY2cmuYolGVAPUlqaaqIidWsco7wUoQ5a4qX1kWEyiNIlIDBJU2KYudkAVQmgAhRHXIHLCOHj0aY8aMwYsXL9C8eXMA/BzWFStWYMqUKXJvoKJQlQD1U1qOKiD/4X9B8p5gJQqbu0p5qxVPXosJlDYRi71e3r2t7PudJmQRQlSZzAHrvHnzYGxsjFWrVmH27NkAAAcHByxcuBATJkyQewMJkRdJOaqK7ElSZK1VFuWuVjx5LSbAqqiJWILY972oNAF2Uhb1tBJClE3mgJXH42Hy5MmYPHkyPn/mTw5gFwwgRNVIKlGlyC9hRU6wopqrqkFeiwmIIqq3VZEoTYAQosrKVIeVRYEqUVUVXaJKFFG9qvJKBaC8VdVU3tqsgkT1tiqiTqsolCZACFE1UgWsjRo1Ao/Hk2qHt2/TSY0oX0WUqJKWPCdYFUc1V1WLvHJZxVF0egBLmjQBgHpbCSEVR6qAtWfPngpuBiHlp8zhf0EVMcGKRXmrqkERtVkFVVSd1uIkLfFKCCEVRaqAdcGCBYpuByFlpgrD/4IUOcFKsOYqUR2CQ/+KyGdlh/+LpwYAiqkcIIrgyARNyiKEVLRy5bBWZlSHtepQheH/iljBCqDc1cpEnvmsxVVUaoAgmpRFCFEmtQ1YqQ5r5aYqw/8sRU6wEoVqrqo+ReSzllantaJ6WgGalEUIqXhqG7CSyknVhv+LU+QEK0GUu6q6FJnPqow6raJQ7VZCSEWjgJWoPElLqSpr9r+oNABF9KpSzdXKRdH5rCxlTcQSRGkChJCKQgErUUmSglSAH6gq84uwIlavAihvtSpg81nlmcuqChOxBFGaACFEkeQasC5evBitW7dGy5Yt5blboobEDftX1FKqpSletqqi0gCo5mrlpej6rIByJmIJojQBQogiyTVg3b59O5YvX462bdvi+PHj8tw1URPsl13xiVSA6gwrFu9ZVeTkKkGUt1r5sD8sFFGblVXRS7hKQmkChBBFkGvAGh8fj5ycHJw7d06euyVqpHjPqipMpAIqrmyVIKq5Wvmxw/9sLqsiSl0pcwlXSShNgBAiL3LPYdXX10fnzp3lvVtShUkqUaUKKrpsFUC5q1VRRaQGAMpPD2DREq+EEHkpU8CalpaGf//9F+/fv0dRUZHQdUOHDpVLw0jVp+olqkSpqHxVQVRztfJT9NKtrOKVA5Q9EYtFS7wSQspL5oD1+PHjGDx4MDIzM2FiYgIej8ddx+PxKGAlpVLVElXiFJ9gpeheVVElrCh3tfKrqFJXxSsHqEpPqyBa4pUQUhYyB6xTp07FiBEjsHTpUhgYGCiiTRWClmatWKX1pgLKL1ElTkWVrmJRGoD6UESpK1ZpK2Kx16tibytNyiKEiCNzwPr27VtMmDChUgerAC3NWtFEBauqUKJKFGVMsCqOSlhVfYrMZ1WVFbEkoUlZhBBpyRywBgYG4ubNm6hZk75ESekkTaZSpSBVkDImWBVHaQBVV0WUuhJUWm+rsqsIUO1WQoi0ZA5Yu3TpgunTp+Phw4fw8PCAtra20PXdu3eXW+NI5SMpR1VVJ1MBylsQgJZeVS8VUepKUGXobaU0AUKIJDIHrKNHjwbAX9WqOB6PRzmhak6aFapUlbIWBKC8VfVWUaWuANWtIiCotDQBNnilwJUQ9SNzwFq8jBUhQOVYoUpaFZ2vyqK8VfVSUaWuBFWGKgKi0gQox5UQIveFA4j6KG34X5WH/gWJmmBVUT2rxVeyorxV9SKq1JUiKwcIUrXlXEUR/JEr+IOYFh0gRD1JFbCuXbsWY8aMgZ6eHtauXVvqbSdMmCCXhhHVJW2JqsqgostWCaJUAFJcRaUHqPJyrqKwAamoRQcox5UQ9SBVwLpmzRoMHjwYenp6WLNmjdjb8Xg8CljVQGUqUSVKaWWrgIpbwYpFK1mRiq4cIIoqpgcUJ/hDmNIECFEvUgWs8fHxIv8m6qOylqgSRZllq2glKyJK8coBFakyTMRiiUoTAKgUFiHqoFw5rAzDAIDQ8qykailt+L+y5KmylFW2ShClARBpKLrUlaDKMBFLFCqFRYh6KVPAunXrVqxZswbPnj0DALi6umLSpEkYNWqUXBtHlENSLdXKUKJKFGWVrRKFKgKQ0lRkqSuWKi8wIAmtmEVI1SdzwDp//nysXr0aISEhaNasGQDg6tWrmDx5MhISEkTWZyWqT1KQCnydTFWZeitUYZlVUSgNgIiijFJXrMqwwIA4tGIWIVUfj2HH9aVkbW2NtWvXYuDAgULb9+7di5CQEKSkpMi1gdLKzs6Gm5sbvv32W/z6669S3y8jIwOmpqZIT0+HiYmJAluo2tghteIq02QqUdgvXkEtmzeu8J5VwRJWRflZMLBuQAErKRWbz1q8N16R6QEswfSZ9IzPJdJnVLm3lSXqnFbZz2eKRt+HRJXJ3MOan58PX1/fEtt9fHxQUFAgl0aVxc8//4ymTZsq7fiVVVUq+C9IFfJVBVHuKikrZaQHVNa8VkG0YhYhVYvMAeuQIUPw22+/YfXq1ULbN23ahMGDB8utYbJ49uwZHj9+jG7duiE2loICSapCwX9JVClfVRCVsCLSUmZ6AKu0vFb2elXtbaUVswipWqQKWKdMmcL9zePxsGXLFpw+fZrr0bx+/ToSEhIwdOhQmRsQHR2NlStX4tatW0hMTMSRI0fQs2dPoduEh4dj5cqVSEpKQsOGDbFu3To0adKEu37atGlYuXIlrly5IvPx1UlVKvgviqrlq1IJK1IeylwJi1WZ81pZtGIWIVWDVAHrnTt3hC77+PgAAOLi4gAAVlZWsLKywoMHD2RuQFZWFho2bIgRI0agd+/eJa7fv38/pkyZgoiICPj5+SE0NBSBgYF48uQJbGxscOzYMdSpUwd16tShgFUEWWb8V/aTtTLrq4pCaQBE3pSRHsCqzFUEWNKsmFUVzoWEVEVSBaznzp1TWAM6deqETp06ib1+9erVGD16NIYPHw4AiIiIwMmTJ7Ft2zbMmjUL165dw759+3Dw4EFkZmYiPz8fJiYmmD9/vsj95ebmIjc3l7uckZEh3wekIqTtTa2KJ2Zl56sWRyWsSHmpwkpYVaG3lVXaillUw5UQ1SRzlQBF4vF4QikBeXl5MDAwwKFDh4TSBIKCgpCWloZjx44J3X/Hjh2IjY0ttUrAwoULsWjRohLbq8KsSHXqTRVUfEazMqoAiMIO41JFACIvyqwcIKgqVBFgSfPjHqh6501RqEoAUWXlWulK0VJSUlBYWAhbW1uh7ba2tnj8+HGZ9jl79myhnNyMjAw4OTmVq52qQtxJtyr3pgKiUwGUSbCEFSGKoMzUAKBqVBFgSTs5i1IGCFEulQ5YZTVs2DCJt9HV1YWuri7Cw8MRHh6OwsJCxTdMgYoXygaqTmmq0qjaBCtBlLtKFEUVKgcIqgp5rSxRk7MAqixAiKpQ6YDVysoKmpqaSE5OFtqenJwMOzu7cu07ODgYwcHB3BBIZVPaMFZVKU0lChuoiurNUeYEK1EVAaiEFZE3VagcIKgq5bUKosoChKgemQLW/Px8jB07FvPmzYOLi4ui2sTR0dGBj48PoqKiuBzWoqIiREVFYfz48Qo/vqqRJUe1qhIVrLZs3hiAcidYiepVpRJWpCIoOz2AxX7+Klu9VkmosgAhqkGmgFVbWxuHDx/GvHnz5NaAzMxMPH/+nLscHx+PmJgYWFhYoHr16pgyZQqCgoLg6+uLJk2aIDQ0FFlZWVzVAHWgzjP+AcnD/6r0RUgVAUhFUYXKAYKqUl6rKFRZgBDlkrlKQFBQELy8vDB58mS5NOD8+fNo3bq1yOPs2LEDALB+/Xpu4QAvLy+sXbsWfn5+5TquYA7r06dPVXpWpLqvic1+AQpShUoAxdMAivKzqCIAqXCqUjmAVfwHpmAVAVX7gVlWVbUTgaoEEFUmc8C6ZMkSrFq1Cm3btoWPjw8MDQ2Frp8wYYJcG6hoqvYBFRz2Z7G5U+xkqsp4IpRVaV96gGoMMbKBgiAKWElFU+X3YfEfm6rwQ1OeqlopQVX7PiREkMyTrrZu3QozMzPcunULt27dErqOx+NVuoBV1ZT2q70qT6YqTtVWrSoNpQEQZRJVOUCZE7EEVdW8VpaoyVlUVYAQxZA5YI2Prxq1JVWprJWk0lSsqjyZiiVYkBxQvVWrgJJ1VmlyFVEmUZUDVGUiVlXPaxUkqp4rVRYgRH7KXNYqLy8P8fHxqFWrFrS0VLo6lkjKKmslashf3UpTFSc4/F8ZelWpzipRVao2EYtVWr1W9vrK3tvKEgxGqbIAIfIjc6SZnZ2NkJAQ7Ny5EwDw9OlT1KxZEyEhIahWrRpmzZol90ZWdpLynASpQ2mq4sTVVW3ZvLHK9KqKQnVWiaphe1uL12gFlDsRq6rWa5WktMoChBDZyBywzp49G3fv3sX58+fRsWNHbnu7du2wcOFCClhFKG3JVEHq9otb0vC/KvW4iFoYgFIBiKpTldQAQVVpdSxJpF2AgKVu3wGEyELmgPXo0aPYv38/mjZtCh6Px213d3dHXFycXBunSMrIYVWHJVNlUbxnVRWH/1mUBkAqE1VbwlVQab2tF6/c4NKDqmrwKipNgEX1XAkRT+aA9cOHD7CxsSmxPSsrSyiAVXWKymEVV5YKUK+8VHEkLQKgaopPsKKKAKQyKG0JV0C56QGC2M+84A9XdUoTYFG6ACGSyRyw+vr64uTJkwgJCQEALkjdsmULmjVrJt/WVUKllaUilatcFVCyZ5XSAEhlpYrpAWwPqqi6y+qQJsCSVFmARb2uRJ3JHLAuXboUnTp1wsOHD1FQUICwsDA8fPgQV65cwYULFxTRxkpJXctSiVMZylWxROWr0gQrUlmpcnoAS10nZbEkVRZgUcoAUWcyB6zffPMNYmJisHz5cnh4eOD06dPw9vbG1atX4eHhoYg2Vko0/F/5ylWxROWrUs8qqaxKSw9QldQAQVV9sQFJpE0ZoPJYRN2UqYBqrVq1sHnzZnm3pUKp0sIBVVVlLVfFonxVUlWpYnoAS50WGxBFUsoA5bsSdVWmgLWwsBBHjhzBo0ePAAD169dHjx49KtUCAspaOKCqK21SFVC5ekioV5VUNcUXFlDFiVgsdSp/JUlp5bEIURcyR5gPHjxA9+7dkZSUhLp1+UMXK1asgLW1NY4fP44GDRrIvZGk8qhsk6oEFa8IQEhVU3xhgcrQ0wqoV/krSYqXxyJEXcgcsI4aNQru7u64efMmzM3NAQCpqakYNmwYxowZgytXrsi9kUT1VaZJVeJQrVWiLirDRCxBpZW/UufglRB1InPAGhMTIxSsAoC5uTl+/vlnNG7cWK6NI6qtsk6qEkQVAYg6qmwTsUSVv1Kn2q2EkDIErHXq1EFycjLc3d2Ftr9//x61a9eWW8OI6qvsk6oAqghACEuV0wNYgr2n6lS7lRBShoB12bJlmDBhAhYuXIimTZsCAK5du4bFixdjxYoVyMjI4G5rYmIiv5bKGVUJKDtJw/+V8YuCKgIQdVV8IlZloe61WwlRNzIHrF27dgUA9OvXj1vlimEYAEC3bt24yzweT6WDQaoSUHbFe1Yry/A/S1QaAPWqEnVVfCKWKlcOEEfda7cSog5kDljPnTuniHYQFVdauarKMvzPoslVhIhXGVIDiiutdis7KYsCV0IqN5kDVn9/f0W0g6i4ylyuShxKAyDkK1GVA1R5IpYogj+eaVIWIVVL5an0T5SiKpSrYhWvs0ppAIR8JapyQGXrbRU1KYvSBAipGihgJSVUhXJVolAqACHSqUwrYolDaQKEVC0UsBIApQeprMpUropFdVYJkV1lWhFLktLSBGjRAUIqDwpYCYDSa6oClfdkTnVWCSm70vJa2etVvbdVVJoA5bcSUvnIHLDm5OSAYRgYGBgAAF69eoUjR46gfv366NChg9wbqChUh1W0qlBTFSiZr0oTrAiRXVXIaxUkasUsWnSAkMpB5oC1R48e6N27N8aNG4e0tDT4+flBW1sbKSkpWL16Nb7//ntFtFPu1LkOq+DJmsVOqqrMOaqCivesUq8qIeVTFaoIsGjRAUIqH5kD1tu3b2PNmjUAgEOHDsHW1hZ37tzB4cOHMX/+/EoTsKozccP/lR3lqxKiOFWtt5VFiw4QUjnIHLBmZ2fD2NgYAHD69Gn07t0bGhoaaNq0KV69eiX3BhLFERz+Z1W2SVWCKF+VkIpRFaoIsKSpJgBQ8EqIsskcsNauXRtHjx5Fr169cOrUKUyePBkA8P79e5iYmMi9gUR+itdUrSrD/5SvSkjFqkpVBFi06AAhqk3mgHX+/PkYNGgQJk+ejLZt26JZs2YA+L2tjRo1knsDifxU1VQAylclRDlE5bVWVqKqCQA0KYsQVSFzwNq3b1988803SExMRMOGDbntbdu2Ra9eveTaOFJ2pU2sYlMBKvPwP+WrEqJ8ovJaq4LSJmUJpgmwKIglRPFkCljz8/Ohr6+PmJiYEr2pTZo0kWvDiOykKf4PVI1UAMpXJUQ1VdbKAeKwP+wpTYAQ5ZIpYNXW1kb16tWpdqmKklT8n1WZe1aLo3xVQlRLVchnFSSqdiuLTRcghCiezCkBc+bMwY8//og//vgDFhYWimgTkUHxXCug6hT/F6X4BCvqVSVENVSlygGiiDqPsukCVAqLEMWTOWBdv349nj9/DgcHB9SoUQOGhoZC19++fVtujSPiiVpikFUVhvwFCearVqWeG0KqkqpYOUBa4kphsSiIJaT8ZA5Ye/bsqYBmVLzKuDSrpBxVdui/Kg35A6LzVQHAwLoBpQEQomKqUuUASQTPtYLpAZTjSoj8yRywLliwQBHtqHCVcWnW0nJU1eEXfPF81co+xEhIVSSqckBVm4jFElVNQJCpiTHluBIiJzIHrET5qnKOamkoX5WQyolND+AHr/z0nqoWvBYf2fJwr8d1MlCOKyHlJ3PAWlhYiDVr1uDAgQNISEhAXl6e0PWfPn2SW+PUWWl1VKtajqooouqsSkPU86Zo9AVEiGhseoBgSk9VzWsVNykLEJ3jSucNQmQjc8C6aNEibNmyBVOnTsXcuXMxZ84cvHz5EkePHsX8+fMV0Ua1VFVXpZKWuLxVSVT9eWMYBmPHjsWhQ4eQmpqKO3fuwMvLq1z7HDZsGNLS0nD06FG5tJFILyAgAF5eXggNDVV2U1QS24Na/AdoVawiIAot90qI/MgcsO7evRubN29Gly5dsHDhQgwcOBC1atWCp6cnrl27hgkTJiiinWqD7SEUVaKKVdUmVQkqXraqrHVWRT1v8laWGoyRkZHYsWMHzp8/j5o1a8LKykpBrZOvsgRmEyZMwOXLlxEbGws3NzfExMQIXf/y5Uu4uLiUuN/Vq1fRtGnTcra47M6fP4/WrVsjNTUVZmZmctnflClT8ODBAzg5OWHu3LkYNmxYqfe5d+8egoODcePGDVhbWyMkJAQzZswQus3Bgwcxb948vHz5Eq6urlixYgU6d+4scn/jxo3Dxo0bsWbNGkyaNInb/vPPP+PkyZOIiYmBjo4O0tLSxLbp48ePaNiwId6+fSvzcyMqr1WwigCbKlDVAldRy70WX+pVEPW6EiKezAFrUlISPDw8AABGRkZIT08HAHTt2hXz5s2Tb+uqMFFD14I5Tyx1G/6X1+pVFfG8iZpkIUlcXBzs7e3RvHlzBbVKNnl5edDR0VHY/keMGIHr16/j3r17Ym/zzz//wN3dnbtsaWmpsPZUtPj4eHTp0gXjxo3D7t27ERUVhVGjRsHe3h6BgYEi75ORkYEOHTqgXbt2iIiIwP379zFixAiYmZlhzBh+MHflyhUMHDgQy5YtQ9euXbFnzx707NkTt2/fRoMGDYT2d+TIEVy7dg0ODg4ljpWXl4dvv/0WzZo1w9atW0t9LCNHjoSnpyfevn1bxmeDT/CHpzqkCrDYQLT4Uq+CBEtiUfBKiDANWe/g6OiIxMREAECtWrVw+vRpAMCNGzegq6sr39ZVYWxgKvhvw+Y/hHpW2dn/VR07/F/8C6uqla0aNmwYQkJCkJCQAB6PB2dnZ0ybNg1du3blbhMaGgoej4fIyEhuW+3atbFlyxYA/BzyKVOmwMzMDJaWlpgxYwYYhpG6DQEBARg/fjwmTZoEKysrLmiKjY1Fp06dYGRkBFtbWwwZMgQpKSlcuy9cuICwsDDweDzweDy8fPlS4rHWrl2L4OBg1KxZ+mtoaWkJOzs77p+2trbQc9azZ08sXboUtra2MDMzw+LFi1FQUIDp06fDwsICjo6O2L59u9TPAQC8evUK3bp1g7m5OQwNDeHu7o6///4bL1++ROvWrQEA5ubm4PF4XG9oVlYWhg4dCiMjI9jb22PVqlUSjxMREQEXFxesWrUKbm5uGD9+PPr27Ys1a9aIvc/u3buRl5eHbdu2wd3dHQMGDMCECROwevVq7jZhYWHo2LEjpk+fDjc3N/z000/w9vbG+vXrhfb19u1bhISEYPfu3ULPK2vRokWYPHky1wkhzm+//Ya0tDRMmzZN4mOWxN57DFzaLIdLm+WwcO0OA+sG0NDm1/Nm0wTiz85C4u1N5T6WKvJwr4eWzRsL/RMk+H3QsddQTJ+7VEktJUS1yNzD2qtXL0RFRcHPzw8hISH47rvvsHXrViQkJGDy5MmKaGOVVrzsCfu3OvWsihv+r0pDgwA/yKhVqxY2bdqEGzduQFNTE9euXcOWLVtQWFgITU1NXLhwAVZWVjh//jw6duyIt2/fIi4uDgEBAQCAVatWYceOHdi2bRvc3NywatUqHDlyBG3atJG6HTt37sT333+Py5cvAwDS0tLQpk0bjBo1CmvWrEFOTg5mzpyJfv364ezZswgLC8PTp0/RoEEDLF68GABgbW0tt+ele/fu+PLlC+rUqYMZM2age/fuQtefPXsWjo6OiI6OxuXLlzFy5EhcuXIFrVq1wvXr17F//36MHTsW7du3h6Ojo1THDA4ORl5eHqKjo2FoaIiHDx/CyMgITk5OOHz4MPr06YMnT57AxMQE+vr6AIDp06fjwoULOHbsGGxsbPDjjz/i9u3bpeYgX716Fe3atRPaFhgYKDQsL+o+rVq1Eur5DgwMxIoVK5Camgpzc3NcvXoVU6ZMKbFfwTzmoqIiDBkyBNOnTxfqwZbVw4cPsXjxYly/fh0vXrwo835EUcfFBkT1moqrsU25roR8JXPAunz51+HZ/v37o3r16rh69SpcXV3RrVs3uTauKiqeo+rZoB6XCiBInXpWWVW9bJWpqSmMjY2hqakJOzs7AEDLli3x+fNn3LlzBz4+PoiOjsb06dO5wOP8+fOoVq0aateuDYDfAzt79mz07t0bAL8H79SpUzK1w9XVFb/88gt3ecmSJWjUqBGWLv3ak7Nt2zY4OTnh6dOnqFOnDnR0dGBgYMC1Wx6MjIywatUqtGjRAhoaGjh8+DB69uyJo0ePCgWtFhYWWLt2LTQ0NFC3bl388ssvyM7Oxo8/8r/4Z8+ejeXLl+PSpUsYMGCAVMdOSEhAnz59uJ5FwV5gdslpGxsbLk8zMzMTW7duxa5du9C2bVsA/MBfUoCclJQEW1tboW22trbIyMhATk4OFwwXv0/x3F52H0lJSTA3Nxe736SkJO7yihUroKWlVa55Bbm5uRg4cCBWrlyJ6tWryz1gZYlabKCq1m4VRdpcV0oTIOqs3HVYmzVrhmbNmsmjLVWWpBWq1OkEJKpcFduzWpWG/6VlZmaGhg0b4vz589DR0YGOjg7GjBmDBQsWIDMzExcuXIC/vz8AID09HYmJifDz8+Pur6WlBV9fX5nSAnx8fIQu3717F+fOnYORkVGJ28bFxaFOnTplfHSls7KyEuolbNy4Md69e4eVK1cKBazu7u7Q0PiavWRrayuUp6mpqQlLS0u8f/9e6mNPmDAB33//PU6fPo127dqhT58+8PT0FHv7uLg45OXlCT33FhYWqFu3rtTHrEi3bt1CWFgYbt++DR6PV+b9zJ49G25ubvjuu+/k2LqSJE3KUifS5LoSoo5kDlg/fvzITYp4/fo1Nm/ejJycHHTv3h0tW7aUewOrAkkrVKkDNlAV9QVU1XtWJQkICMD58+ehq6sLf39/WFhYwM3NDZcuXcKFCxcwdepUuR7P0NBQ6HJmZia6deuGFStWlLitvb29XI8tiZ+fH86cOSO0rXjuJY/HE7mtqKhI6uOMGjUKgYGBOHnyJE6fPo1ly5Zh1apVCAkJKXvjRbCzs0NycrLQtuTkZKFUA2nvw15X2m3Y6y9evIj379+jevXq3PWFhYWYOnUqQkNDpcpBBvjpGPfv38ehQ4cAgPthZGVlhTlz5mDRokVS7UcW7A9XdSp/JYqoZV8Fe1vH13kP+SXmEKL6pA5Y79+/j27duuH169dwdXXFvn370LFjR2RlZUFDQwNr1qzBoUOH0LNnTwU2t3IprUSVug3tiApWDaz5vWTq2LMqyN/fH9u2bYOWlhY6duwIgB/E7t27F0+fPuXyV01NTWFvb4/r16+jVatWAICCggLcunUL3t7eZT6+t7c3Dh8+DGdnZ2hpiT4l6OjooLCwsMzHkFZMTEyFBclOTk4YN24cxo0bh9mzZ2Pz5s0ICQnhckcFH2+tWrWgra2N69evc0Fgamoqnj59yvWAi9KsWTP8/fffQtvOnDlT6qhUs2bNMGfOHOTn53OB+ZkzZ1C3bl2Ym5tzt4mKihLKhRXc75AhQ0Tmzg4ZMgTDhw+X9NRwDh8+jJycHO7yjRs3MGLECFy8eBG1atWSej+yUMe8VlFELfsq2Nvay1gP1naaeBGfgPrKaiQhFUjqgHXGjBnw8PDA7t278ccff6Br167o0qULNm/eDAAICQnB8uXLKzxgTUtLQ7t27VBQUICCggJMnDgRo0ePrtA2iKOOJaokERz+V2RPiagah4o4hjy0atUKnz9/xokTJ7gc8YCAAPTt2xf29vZCQ/ITJ07E8uXL4erqinr16mH16tWl1s6URnBwMDZv3oyBAwdixowZsLCwwPPnz7Fv3z5s2bIFmpqacHZ2xvXr1/Hy5UsYGRnBwsJCaJhelOfPnyMzMxNJSUnIycnh6rDWr18fOjo62LlzJ3R0dNCoUSMAwJ9//olt27ZxFREUadKkSejUqRPq1KmD1NRUnDt3Dm5ubgCAGjVqgMfj4cSJE+jcuTP09fVhZGSEkSNHYvr06bC0tISNjQ3mzJkj8TkYN24c1q9fjxkzZmDEiBE4e/YsDhw4gJMnT3K3Wb9+PY4cOYKoqCgAwKBBg7Bo0SKMHDkSM2fORGxsLMLCwoQqC0ycOBH+/v5YtWoVunTpgn379uHmzZvYtIk/s97S0rJEeTBtbW3Y2dkJpTEkJCTg06dPSEhIQGFhIfca1a5dG0ZGRiWCUrZyhJubm1xq1JZGVF6ruhK3AAEAZGZlV3RzCFEKqQPWGzdu4OzZs/D09ETDhg2xadMm/PDDD9wJOyQkRCnFvo2NjREdHQ0DAwNkZWWhQYMG6N27t9JqOb6IT4A1+MHMvdgvAL72rKrL8D9LVL5qRQ3/V6a8L3Nzc3h4eCA5ORn16vHfI61atUJRUVGJ3rupU6ciMTERQUFB0NDQwIgRI9CrVy+uHnJZODg44PLly5g5cyY6dOiA3Nxc1KhRAx07duQ+39OmTUNQUBDq16+PnJwcxMfHw9nZudT9jho1ChcuXOAus4Gp4H1/+uknvHr1ClpaWqhXrx7279+Pvn37lvmxsAICAuDs7IwdO3aIvL6wsBDBwcF48+YNTExM0LFjRy4grFatGhYtWoRZs2Zh+PDhGDp0KHbs2IGVK1dy6RPGxsaYOnWqxOfdxcUFJ0+exOTJkxEWFgZHR0ds2bJFqAZrSkoK4uLiuMumpqY4ffo0goOD4ePjAysrK8yfP5+rwQoAzZs3x549ezB37lz8+OOPcHV1xdGjR0vUYJVk/vz52LlzJ3eZfY3OnTvH9ewri6i8VnWaiCVI1KQsLc2HSmwRIRWPx0g5W0NDQwNJSUmwsbEBwA8U7969y82uTU5OhoODQ4UMG4rz6dMneHt74+bNm1KvIJSRkQFTU1Okp6fDxMSk3G3YN74VXAyyEZNUiCmn+AFry+aN1bJnlf2SEWRg3UChAauoBRkUTd3SOyqDGjVqYNGiRRJXlCKVg7hzCaBeea2C2O+a+GwDDFgfLZd9yvv7kBB5kmnSVfHZpuWZfcqKjo7GypUrcevWLSQmJuLIkSMl0grCw8OxcuVKJCUloWHDhli3bh2aNGnCXZ+WlgZ/f388e/YMK1euVInlLrU0NbmC0OrUs1paFQBA8fmqFDiSBw8ewNTUFEOHKjYlhFQc9ryhTitjEUKEyRSwDhs2jFvN6suXLxg3bhw34zg3N7dMDcjKykLDhg0xYsQIrrakoP3792PKlCmIiIiAn58fQkNDERgYiCdPnnC9vWZmZrh79y6Sk5PRu3dv9O3bt0SNQlZubq5QWzMyMsrUbkkMDQ0QuV39elVFTa5S9yoAFSUhIQH164uffvHw4UOhWePlMW7cOOzatUvkdd999x0iIiLkcpyycHd3L3UpWFL5sD2oxX8Qq3NeKyHqRuqANSgoSOiyqLp8ZenR6NSpEzp16iT2+tWrV2P06NHczNaIiAicPHkS27Ztw6xZs4Rua2tri4YNG+LixYti8+CWLVumkFIs6k7SqlVE8RwcHLhJM+Kul5fFixeLXaaThhKJoojKawWEA1lAfdMECKnKpA5YZV2rWx7y8vJw69YtzJ49m9umoaGBdu3a4erVqwD4ubMGBgYwNjZGeno6oqOj8f3334vd5+zZs4WKlWdkZMDJyUlxD0JNqNuqVapIS0uLWxFL0WxsbLgRDkKU6UtaPKUHEKIGyr3SlSKlpKSgsLBQ5BKEjx/zJ9a8evUKY8aMAcMwYBgGISEh3HKLoujq6nJpDaR8aNUqQoiyiUoLUNfFBgipylQ6YJVGkyZNSh0GFSc8PBzh4eFKrWpQmRQfcgNET3qgnlVCSEUQ9aOYPSep62IDhFRlKh2wWllZQVNTs9QlCMsqODgYwcHBXBkPUjpxy6qyaNUqQkhFEtVrSpOyCKm6VDpg1dHRgY+PD6KiorhSV0VFRYiKisL48eOV2zg1JTiZikVDboQQVVDaYgOC6JxFSOWj9IA1MzMTz58/5y7Hx8cjJiYGFhYWqF69OqZMmYKgoCD4+vqiSZMmCA0NRVZWlkzrYYtCKQFlo+pD/qJSFxSNvvwIUV2UHkBI1aD0gPXmzZto3bo1d5mdwR8UFIQdO3agf//++PDhA+bPn4+kpCR4eXkhMjJSbJ1VaVFKQNUkKXVB2RiGwdixY3Ho0CGkpqbizp078PLyKtc+hw0bhrS0NBw9elQubSR89LxWbqLSkyhNgJDKS0PZDQgICOBm+Av+E1wDfPz48Xj16hVyc3Nx/fp1+Pn5Ka/Baibx9ibEn53FVQGoLDS0DWFg3UCh/zS0DWVuV2RkJHbs2IETJ04gMTFR5rXflSUgIACTJk2S6T48Hq/Ev3379immgVJ6+fIleDxemSZqinLv3j20bNkSenp6cHJywi+//CLxPgkJCejSpQsMDAxgY2OD6dOno6CgQOg258+fh7e3N3R1dVG7dm2h8yHAryfduHFjGBsbw8bGBj179sSTJ0+EbjN27FjUqlUL+vr6sLa2Ro8ePbjqKgBw9+5dDBw4EE5OTtDX14ebmxvCwsLK/mSoGHvvMXBps1zoX/F0JkJI5aH0Hlai2lS9x1KcikhdELW+uSRxcXGwt7dH8+bNFdQq2eTl5UFHR0dh+9++fTs6duzIXTYzM1PYsSpaRkYGOnTogHbt2iEiIgL379/HiBEjYGZmhjFjRKeIFBYWokuXLrCzs8OVK1eQmJiIoUOHQltbG0uXLgXAT4vq0qULxo0bh927dyMqKgqjRo2Cvb09AgMDAQAXLlxAcHAwGjdujIKCAvz444/o0KEDHj58yK0+6OPjg8GDB6N69er49OkTFi5ciA4dOiA+Ph6ampq4desWbGxssGvXLjg5OeHKlSsYM2YMNDU1q/wcATavldJ5CKk8lN7Dqizh4eGoX78+GjdurOymqBy2V1WwZ5XtsaQqAGU3bNgwhISEICEhATweD87Ozpg2bRq6du3K3SY0NBQ8Hg+RkZHcttq1a2PLli0A+AHPlClTYGZmBktLS8yYMQMMw0jdhoCAAIwfPx6TJk2ClZUVFwDFxsaiU6dOMDIygq2tLYYMGYKUlBSu3RcuXEBYWBjXU/ry5UupjmdmZgY7Ozvun56eHnfdwoUL4eXlhW3btqF69eowMjLCDz/8gMLCQvzyyy+ws7ODjY0Nfv75Z6kfHwCkpqZi8ODBsLa2hr6+PlxdXbmFT1xc+D1sjRo1Ao/HQ0BAAICyPa+7d+9GXl4etm3bBnd3dwwYMAATJkzA6tWrxd7n9OnTePjwIXbt2gUvLy906tQJP/30E8LDw5GXlweAv5qfi4sLVq1aBTc3N4wfPx59+/bFmjVruP1ERkZi2LBhcHd3R8OGDbFjxw4kJCTg1q1b3G3GjBmDVq1awdnZGd7e3liyZAlev37NvXYjRoxAWFgY/P39UbNmTXz33XcYPnw4/vzzT5me78qIzWv99Owv7lzH/ku8vUnZzSOEiKC2AWtwcDAePnyIGzduKLspKoftVc3+EMvle7E9ltQbUXZhYWFYvHgxHB0dkZiYiBs3bsDf3x+XLl3iJv9duHABVlZWOH/+PADg7du3iIuL4wKrVatWYceOHdi2bRsuXbqET58+4ciRIzK1Y+fOndDR0cHly5cRERGBtLQ0tGnTBo0aNcLNmzcRGRmJ5ORk9OvXj2t3s2bNMHr0aCQmJiIxMVHq1eGCg4NhZWWFJk2aYNu2bSWCwLi4OPzvf/9DZGQk9u7di61bt6JLly548+YNLly4gBUrVmDu3Lm4fv261I9v3rx5ePjwIf73v//h0aNH+O2332BlZQUA+PfffwEA//zzDxITE7ngrCzP69WrV9GqVSuhHurAwEA8efIEqampYu/j4eEhlIMfGBiIjIwMPHjwgLtNu3bthO4XGBjIre4nSnp6OgDAwsJC5PVZWVnYvn07XFxcSn3t0tPTxe6jKtAzq8mV4GOx5zr2X0VP2iSESIdSAohYgiWsqGe1/ExNTWFsbAxNTU2ujnDLli3x+fNn3LlzBz4+PoiOjsb06dO5iT7nz59HtWrVuCVXQ0NDMXv2bPTu3RsAvzfu1KlTMrXD1dVVKNdyyZIlaNSoETckDQDbtm2Dk5MTnj59ijp16kBHRwcGBgYy1T9evHgx2rRpAwMDA5w+fRo//PADMjMzMWHCBO42RUVF2LZtG4yNjVG/fn20bt0aT548wd9//w0NDQ3UrVsXK1aswLlz56TOXU9ISECjRo3g6+sLAHB2duaus7a2BgBYWloKPZayPK9JSUlcjy2LDUSTkpJgbm4u8j6iVu5jryvtNhkZGcjJyYG+vr7QdUVFRZg0aRJatGhRIid6w4YNmDFjBrKyslC3bl2cOXNGbArIlStXsH//fpw8ebLUx12ZsT+4RVUToQlZhKg2ClgJANHLrKp6CauqwMzMDA0bNsT58+eho6MDHR0djBkzBgsWLEBmZiYuXLgAf39/APzer8TERKHATUtLC76+vjKlBfj4+Ahdvnv3Ls6dOwcjI6MSt42Li0OdOnXK9NjmzZvH/d2oUSNkZWVh5cqVQgGrs7MzjI2Nucu2trbQ1NSEhoaG0Lb3799Lfdzvv/8effr0we3bt9GhQwf07Nmz1JxheT2vyhIcHIzY2FhcunSpxHWDBw9G+/btkZiYiF9//RX9+vXD5cuXhVIzAH5KSI8ePbBgwQJ06NChopquNKJGikTVbaUcV0JUh9qmBFAOqzBRaQCkYgQEBOD8+fNccGphYQE3NzdcunRJKGCVF3ZSDiszMxPdunVDTEyM0L9nz56hVatWcjuun58f3rx5g9zcXG6btra20G14PJ7IbUVFRVIfp1OnTnj16hUmT56Md+/eoW3btpg2bVr5Gi+CnZ2dyFX42OvKeh9xtzExMSnRuzp+/HicOHEC586dg6OjY4njmZqawtXVFa1atcKhQ4fw+PHjEqkODx8+RNu2bTFmzBjMnTtX0sOu8tj8VkoPIES1qG3Aqs45rIKTqsRNrqIJVhWHzWONioriclUDAgKwd+9ePH36lNtmamoKe3t7oXzOgoICoYk2ZeHt7Y0HDx7A2dkZtWvXFvrHBrc6OjrlXmQjJiYG5ubm0NXVLdd+pGFtbY2goCDs2rULoaGh2LSJP5GGHQ4XfCxlfV6bNWuG6Oho5Ofnc9vOnDmDunXrikwHYO9z//59oR7jM2fOwMTEBPXr1+duExUVJXS/M2fOoFmzZtxlhmEwfvx4HDlyBGfPni2RmiAKWzJQ8AfDgwcP0Lp1awQFBck8ua2qYfNby1qyjhCiWJQSUMWJytUqrRRTVUkDELUcoyKOIQ+tWrXC58+fceLECSxfzn/uAwIC0LdvX9jb2wsNyU+cOBHLly+Hq6sr6tWrh9WrVyMtLa1cxw8ODsbmzZsxcOBAzJgxAxYWFnj+/Dn27duHLVu2QFNTE87Ozrh+/TpevnwJIyMjWFhYCA3bF3f8+HEkJyejadOm0NPTw5kzZ7B06VKF9HQWN3/+fPj4+MDd3R25ubk4ceIE3NzcAAA2NjbQ19dHZGQkHB0doaenB1NT0zI9r4MGDcKiRYswcuRIzJw5E7GxsQgLCxOazX/kyBHMnj2bq3/aoUMH1K9fH0OGDMEvv/yCpKQkzJ07F8HBwVwgP27cOKxfvx4zZszAiBEjcPbsWRw4cEAotzQ4OBh79uzBsWPHYGxszOW/mpqaQl9fHy9evMD+/fvRoUMHWFtb482bN1i+fDn09fXRuXNnAPw0gDZt2iAwMBBTpkzh9qGpqcnl+qoTScu6UnoAIcpFAWsVJ6mOavEZs1WlV7UyLcdobm4ODw8PJCcno169egD4QWxRUVGJdICpU6ciMTERQUFB0NDQwIgRI9CrVy9ulnhZODg44PLly5g5cyY6dOiA3Nxc1KhRAx07duSC0mnTpiEoKAj169dHTk4O4uPjhSYzFaetrY3w8HBMnjwZDMOgdu3aWL16NUaPHl3mdrKGDRuGly9fcpUUitPR0cHs2bPx8uVL6Ovro2XLltyCBVpaWli7di0WL16M+fPno2XLljh//nyZnldTU1OcPn0awcHB8PHxgZWVFebPny9UgzU9PV2ooL+mpiZOnDiB77//Hs2aNYOhoSGCgoKwePFi7jYuLi44efIkJk+ejLCwMDg6OmLLli1cCTIA+O233wCA631nbd++HcOGDYOenh4uXryI0NBQpKamwtbWFq1atcKVK1dgY2MDADh06BA+fPiAXbt2YdeuXdw+atSoIXXZsqpO8DzCpghQ4EqIcvCYyjCrQIHYpVnT09NhYmJS7v3tG98KLgbZiM82wID10XJoYfmwPQWCM/5ZVfHEK6pHWdGq4vOoyvz9/dG6dWssXLhQ2U0hVZTgeaT4D18D6wYqMQqliO8aeX8fEiJPatvDGh4ejvDw8HLn5akq9oSrbjP+KXCs2tLT0xEXF1elSy8R5RM8jwieS4vysyhNgBAloUlXVXTSFZsKQDP+1UdCQgKMjIzE/ktISJDbscaNGyf2OOPGjZPbcYozNTXFmzdvRJbgIkQR7L3HwKXNcm6EiqoIEKIcatvDWlWIGgIXzENlUwGqSm4qEc/BwQExMTGlXi8vixcvFjuBioYSSVUkeA4V1dsqeDvqdSVE/ihgreQkTapSl1QAwp9QxK6IpWg2Njbc5B1C1IGoKgKiJnfS5CxCFIMC1iqCrRvI/uonhBCiGKJGrAQDV/ZvcSNgFMgSIjsKWCspUZOqAFDeKiGEKJiogLP45CxA8ggYIUR6ahuwVvYqAaJOhKJ+9VPuKiGEKB4bxAouOsASHAEjhJSN2gaswcHBCA4O5urOVVaCk6pomIkQQlSDYHAqOAJGCCkbtQ1YqwqaVCXs1V+rkPXuieQbypGhQ13U6D61Qo9JCFFN4ka6qAQWIeVDAWslUDxxn4b5xct69wSfX9xWdjPEYhgGY8eOxaFDh5Camoo7d+7Ay8urXPscNmwY0tLScPToUbm0kUgvICAAXl5eCA0NVXZTiIoQN9LFlr9iS2HRqBghslHbhQNUXeLtTYg/OwvxZ2fh07O/uELV2R9i8enZX1QJQAJNPSMY1/RW6D9NPdmL10dGRmLHjh04ceIEEhMT0aBBAwU8evkLCAjApEmTZL7fjh074OnpCT09PdjY2CA4OFjo+nv37qFly5bQ09ODk5MTfvnlFzm1uOzOnz8PHo+HtLQ0ue3P29sburq6qF27Nnbs2CHxPtI8LwcPHkS9evWgp6cHDw8P/P3330LX83g8kf9WrlzJ3ebp06fo0aMHrKysYGJigm+++Qbnzp0T2s+NGzfQtm1bmJmZwdzcHIGBgbh7927ZngzClcKiHldCZEM9rCpK0uxSSt4vnYFDHdQft0mhx3gYMUbm3ty4uDjY29ujefPmCmqVbPLy8qCjo6OQfa9evRqrVq3CypUr4efnh6ysLLx8+ZK7PiMjAx06dEC7du0QERGB+/fvY8SIETAzM8OYMVWj5yk+Ph5dunTBuHHjsHv3bkRFRWHUqFGwt7dHYGCgyPtI87xcuXIFAwcOxLJly9C1a1fs2bMHPXv2xO3bt7kfQYmJiUL7/d///oeRI0eiT58+3LauXbvC1dUVZ8+ehb6+PkJDQ9G1a1fExcXBzs4OmZmZ6NixI7p3744NGzagoKAACxYsQGBgIF6/fg1tbW0FPXNVDzsyRosOEFI21MOqYtieVbYHVUPbEAbWDWBgzf8SYv9m/1F6QOUxbNgwhISEICEhATweD87Ozpg2bRq6du3K3SY0NBQ8Hg+RkZHcttq1a2PLli0AgMLCQkyZMgVmZmawtLTEjBkzwDCM1G0ICAjA+PHjMWnSJFhZWXFBU2xsLDp16gQjIyPY2tpiyJAhSElJ4dp94cIFhIWFcb10goGnKKmpqZg7dy5+//13DBo0CLVq1YKnpye6d+/O3Wb37t3Iy8vDtm3b4O7ujgEDBmDChAlYvXq10HPWs2dPLF26FLa2tjAzM8PixYtRUFCA6dOnw8LCAo6Ojti+fbvUzwEAvHr1Ct26dYO5uTkMDQ3h7u6Ov//+Gy9fvkTr1q0BAObm5uDxeBg2bBgAICsrC0OHDoWRkRHs7e2xatUqiceJiIiAi4sLVq1aBTc3N4wfPx59+/bFmjVrxN5HmuclLCwMHTt2xPTp0+Hm5oaffvoJ3t7eWL9+PXcbOzs7oX/Hjh1D69atUbMm/5yRkpKCZ8+eYdasWfD09ISrqyuWL1+O7OxsxMbyfyw/fvwYnz59wuLFi1G3bl24u7tjwYIFSE5OxqtXr2R6ztVdaUu80lKvhEhGAauKYXtW2R5UdlKVS5vlcO9/gvub/Ue/xiuPsLAwLF68GI6OjkhMTMSNGzfg7++PS5cuceXVLly4ACsrK5w/fx4A8PbtW8TFxSEgIAAAsGrVKuzYsQPbtm3DpUuX8OnTJxw5ckSmduzcuRM6Ojq4fPkyIiIikJaWhjZt2qBRo0a4efMmIiMjkZycjH79+nHtbtasGUaPHo3ExEQkJibCycmp1GOcOXMGRUVFePv2Ldzc3ODo6Ih+/frh9evX3G2uXr2KVq1aCfXwBgYG4smTJ0hNTeW2nT17Fu/evUN0dDRWr16NBQsWoGvXrjA3N8f169cxbtw4jB07Fm/evJH6OQgODkZubi6io6Nx//59rFixAkZGRnBycsLhw4cBAE+ePEFiYiLCwsIAANOnT8eFCxdw7NgxnD59GufPn8ft26X3sF+9ehXt2rUT2hYYGIirV6+Weh9Jz4us+01OTsbJkycxcuRIbpulpSXq1q2L33//HVlZWSgoKMDGjRthY2MDHx8fAEDdunVhaWmJrVu3Ii8vDzk5Odi6dSvc3Nzg7Oxc6mMnoumZ1SzR8cCWvSKEiKe2KQHKrsMqagUUAEI9q2y5KlI1mJqawtjYGJqamrCzswMAtGzZEp8/f8adO3fg4+OD6OhoTJ8+nZtAdf78eVSrVo1bcjU0NBSzZ89G7969AfB78E6dOiVTO1xdXYVyIpcsWYJGjRph6dKl3LZt27bByckJT58+RZ06daCjowMDAwOu3ZK8ePECRUVFWLp0KcLCwmBqaoq5c+eiffv2uHfvHnR0dJCUlAQXFxeh+9na2gIAkpKSYG5uDgCwsLDA2rVroaGhgbp16+KXX35BdnY2fvzxRwDA7NmzsXz5cly6dAkDBgyQqn0JCQno06cPPDw8AIDrdWSPB/CXnzUzMwMAZGZmYuvWrdi1axfatm0LgB/4Ozo6lnqcpKQk7jEJPsaMjAzk5ORAX19f5H0kPS/i9puUlCSyHTt37oSxsTH3vgH4Oa7//PMPevbsCWNjY2hoaMDGxgaRkZHcc29sbIzz58+jZ8+e+OmnnwDw3z+nTp2Clpbafn2Ui6hOBrZ2qyBaJYsQYWp7xlF2HVZJOapUrko9mJmZoWHDhjh//jx0dHSgo6ODMWPGYMGCBcjMzMSFCxfg7+8PAEhPT0diYiL8/Py4+2tpacHX11emtAC294x19+5dnDt3DkZGJSeRxcXFoU6dOjI/rqKiIuTn52Pt2rXo0KEDAGDv3r2ws7PDuXPnxOZviuLu7g4Nja+DQba2tkKT1TQ1NWFpaYn3799Lvc8JEybg+++/x+nTp9GuXTv06dMHnp6eYm8fFxeHvLw8oefewsICdevWlfqYyrRt2zYMHjwYenp63DaGYRAcHAwbGxtcvHgR+vr62LJlC7p164YbN27A3t4eOTk5GDlyJFq0aIG9e/eisLAQv/76K7p06YIbN26IDLiJfNAqWYQIU9uAVVWwPanFUc+q+ggICMD58+ehq6sLf39/WFhYwM3NDZcuXcKFCxcwdap8a7waGgoPP2ZmZqJbt25YsWJFidva29uX6Rjs/erXr89ts7a2hpWVFRISEgDwcyyTk5OF7sdeFuzJLT6xh8fjidxWVFQkdftGjRqFwMBAnDx5EqdPn8ayZcuwatUqhISESL0PaYh7jCYmJmKDPWmeF3G3EdUDfvHiRTx58gT79+8X2n727FmcOHECqampMDExAQBs2LABZ86cwc6dOzFr1izs2bMHL1++xNWrV7kfDXv27IG5uTmOHTsmdY82KTtaJYsQPsphVTLBHFXKTVVPbB5rVFQUl6saEBCAvXv34unTp9w2U1NT2Nvb4/r169x9CwoKcOvWrXId39vbGw8ePICzszNq164t9I8NbnV0dGRKn2nRogUAfh4o69OnT0hJSUGNGjUAAM2aNUN0dDTy8/O525w5cwZ169blhqQVycnJCePGjcOff/6JqVOnYvPmzQDA5Y4KPt5atWpBW1tb6LlPTU3F06dPSz1Gs2bNEBUVJbTtzJkzaNasWan3kfS8yLLfrVu3wsfHBw0bNhTanp2dDQBCvdfsZTb4z87OhoaGBng8ntD1sv5AIGXHTw0r2alBiLqhHlZSJWW/e4qHEYoN+rPflR6sSKtVq1b4/PkzTpw4geXL+WkgAQEB6Nu3L+zt7YWG5CdOnIjly5fD1dUV9erVw+rVq8tdLzQ4OBibN2/GwIEDMWPGDFhYWOD58+fYt28ftmzZAk1NTTg7O+P69et4+fIljIyMYGFhUSLQEVSnTh306NEDEydOxKZNm2BiYoLZs2ejXr163Cz8QYMGYdGiRRg5ciRmzpyJ2NhYhIWFlTqDXl4mTZqETp06oU6dOkhNTcW5c+fg5uYGAKhRowZ4PB5OnDiBzp07Q19fH0ZGRhg5ciSmT58OS0tL2NjYYM6cOaU+BwAwbtw4rF+/HjNmzMCIESNw9uxZHDhwACdPnuRus379ehw5coQLQKV5XiZOnAh/f3+sWrUKXbp0wb59+3Dz5k1s2iRcyi0jIwMHDx4UWdGgWbNmMDc3R1BQEObPnw99fX1s3ryZK8UFAO3bt8f06dMRHByMkJAQFBUVYfny5dDS0uJeRyI/gqWuRNXaFrzeyqgQoN8MRI1QwFrB2ER6KvyvWIVfMlV6xStB5ubm8PDwQHJyMurVqweAH8QWFRVx+ausqVOnIjExEUFBQdDQ0MCIESPQq1cvpKenl/n4Dg4OuHz5MmbOnIkOHTogNzcXNWrUQMeOHbmAbNq0aQgKCkL9+vWRk5OD+Ph4ibPEf//9d0yePBldunSBhoYG/P39ERkZyQ3nm5qa4vTp0wgODoaPjw+srKwwf/58udRgDQgIgLOzs9gi/YWFhQgODsabN29gYmKCjh07cgFhtWrVsGjRIsyaNQvDhw/H0KFDsWPHDqxcuZJLnzA2NsbUqVMlPu8uLi44efIkJk+ejLCwMDg6OmLLli1CObwpKSmIi4vjLkvzvDRv3hx79uzB3Llz8eOPP8LV1RVHjx4tsRDFvn37wDAMBg4cWKJtVlZWiIyMxJw5c9CmTRvk5+fD3d0dx44d43pj69Wrh+PHj2PRokVo1qwZNDQ00KhRI0RGRpY5XYSIx5a6kuZ6XW0GyK2olhGifDxGltkaVRA76So9PZ3L4yqPfeNbwcUgG/HZBvAf8V2JWZ7FT0YG1g1ocpUcvfprFbLePZF8QzkydKiLGt3lm2dKyqdGjRpYtGgRV0OVkP+3d+dhTV3pH8C/YQsBDMgOLuDGUosgCBisgkpFp1O1nRkdS106blRbtVK3X7UROlatbe0y3aYWHK0F6rhRtVZF0YoIiIAIAZQCagVprYhMVbb394eTO1wICBgg6Pt5njyac88957x3Sd6Ec290WXN3jQEa/uDAT//99/4PD/x24TcY3atG0e8m+Os/TmplHNp+P2RMm/gb1g70oKs8+cb/2seJI8vJyYG5uTlmzJjR1UNhrFXacs2CpltgMfY44IRVy9Tzinr1rG1yT9WG+H56TNsuX74suiq/sdzcXPTt21crfYWFheHrr7/WuOzFF1/E559/rpV+2mPw4ME4f/58l/XPWGcwMgBw77/vOYw9Bjhh1TL1vCJjQ2rya1WMdSRHR0dkZma2uFxbIiMj8frrr2tcxn9KZKzj6UkI9fjvew5jjwFOWDtIPUlgYnP/Agj+sz/rDAYGBsIvYnU0W1tb2NradkpfjLH/Ub+fVOVpZ94qY93FY5uwdvRPs1bXgr9VZYwxplXqqWRXjwfAqIvHwlhnemx/OGDhwoXIzc1FWlpaVw+FMcYYY4y14LFNWBljjDHGWPfACStjjDHGGNNpnLAyxhhjjDGdxgkrY4wxxhjTaZywMsYYY4wxncYJK2OMMcYY02mcsDLGGGOMMZ322P5wgBrR/Z+1q6ys1Ep7/7lXi5p7dahGrdbaZIwxxhrqiPcadTvq90XGdImEHvMj8+rVq+jTp09XD4MxxhjTCVeuXEHv3r27ehiMiTz2CWt9fT2uXbuGHj16QCKRPHR7lZWV6NOnD65cuQK5XK6FEXatRykejkV3PUrxcCy661GKpyNiISLcvn0bjo6O0NPjGYNMtzz2UwL09PQ65JOkXC7v9i+IDT1K8XAsuutRiodj0V2PUjzajsXc3FxrbTGmTfwRijHGGGOM6TROWBljjDHGmE7jhFXLpFIplEolpFJpVw9FKx6leDgW3fUoxcOx6K5HKZ5HKRbGWuOxv+iKMcYYY4zpNv6GlTHGGGOM6TROWBljjDHGmE7jhJUxxhhjjOk0TlgZY4wxxphO44T1AX777TeEhoZCLpfDwsICs2fPRlVVVYvr3L17FwsXLoSVlRXMzMzwpz/9CdevXxeWZ2VlYdq0aejTpw9kMhnc3d3x4YcfNmknMTER3t7ekEqlGDhwILZu3apzsQDAokWL4OPjA6lUCi8vryZtFBcXQyKRNHmcOXOmW8YDAOfPn8fIkSNhbGyMPn364J133tHJWC5fvoxnnnkGJiYmsLW1xbJly1BbWyssT0xM1LhvysrK2jT+Tz75BM7OzjA2Noa/vz9SU1NbrL9z5064ubnB2NgYHh4eOHjwoGg5EeHNN9+Eg4MDZDIZgoODcfHiRVGd9mwzXY3F2dm5yT7YsGHDQ8fSEfHs3r0b48aNg5WVFSQSCTIzM5u00Zpjs7vEEhQU1GTfhIWF6VQsNTU1WLFiBTw8PGBqagpHR0fMmDED165dE7XRUecMY52CWIvGjx9Pnp6edObMGfrxxx9p4MCBNG3atBbXCQsLoz59+lBCQgKdPXuWhg8fTgEBAcLyr776ihYtWkSJiYlUWFhI27dvJ5lMRh9//LFQ56effiITExNaunQp5ebm0scff0z6+vp06NAhnYqFiOjVV1+lf/zjHzR9+nTy9PRs0kZRUREBoKNHj1JpaanwqK6ubncsXRnPrVu3yM7OjkJDQ+nChQsUExNDMpmMvvjiC52Kpba2lp588kkKDg6mjIwMOnjwIFlbW9OqVauEOsePHycAlJ+fL9o3dXV1rR57bGwsGRkZUVRUFOXk5NDcuXPJwsKCrl+/rrF+UlIS6evr0zvvvEO5ubm0evVqMjQ0pOzsbKHOhg0byNzcnPbu3UtZWVk0ceJE6tevH925c+ehtpmuxuLk5ESRkZGifVBVVfVQsXRUPNu2baOIiAj68ssvCQBlZGQ0aac151l3iSUwMJDmzp0r2je3bt3SqVgqKiooODiY4uLiKC8vj5KTk8nPz498fHxE7XTEOcNYZ+GEtQW5ubkEgNLS0oSy77//niQSCf38888a16moqCBDQ0PauXOnUKZSqQgAJScnN9vXggULaPTo0cLz5cuX0+DBg0V1pk6dSiEhITobi1KpbDFh1fRm0F5dGc+nn35KPXv2pHv37gllK1asIFdXV52K5eDBg6Snp0dlZWVCnc8++4zkcrkwdnXCevPmzXaNnYjIz8+PFi5cKDyvq6sjR0dHWr9+vcb6U6ZMoWeeeUZU5u/vT/Pnzyciovr6erK3t6dNmzaJ4pVKpRQTE0NE7dtmuhoL0f2EdfPmze0ed3O0HU9DzZ3X7X0N1MVYiO4nrIsXL273uDXpyFjUUlNTCQCVlJQQUcedM4x1Fp4S0ILk5GRYWFhg2LBhQllwcDD09PSQkpKicZ309HTU1NQgODhYKHNzc0Pfvn2RnJzcbF+3bt2CpaWlqO+GbQBASEhIi23oSizNmThxImxtbfHUU08hPj6+7UE00JXxJCcnY9SoUTAyMhLKQkJCkJ+fj5s3b+pMLMnJyfDw8ICdnZ1onJWVlcjJyRG15+XlBQcHBzz99NNISkpq9dirq6uRnp4uGoeenh6Cg4Ob3aYPOraLiopQVlYmqmNubg5/f39RbG3dZroai9qGDRtgZWWFoUOHYtOmTaKpG7oST2to+3UD6LpY1Hbs2AFra2s8+eSTWLVqFX7//fc2t6HWWbHcunULEokEFhYWQhvaPmcY60wGXT0AXVZWVgZbW1tRmYGBASwtLZud41dWVgYjIyPhRULNzs6u2XVOnz6NuLg4HDhwQNROw0RD3UZlZSXu3LkDmUymk7FoYmZmhvfeew8jRoyAnp4edu3ahcmTJ2Pv3r2YOHFim+JoOLauiqesrAz9+vVr0oZ6Wc+ePVvdlnqdjoiluWNIvQwAHBwc8Pnnn2PYsGG4d+8etmzZgqCgIKSkpMDb2/uBY//1119RV1ensZ+8vLxmx66pfsNxNxxrc3Xaus10NRbg/rxpb29vWFpa4vTp01i1ahVKS0vx/vvvtyuWjoqnNbR1njXUVbEAwAsvvAAnJyc4Ojri/PnzWLFiBfLz87F79+62BfFfnRHL3bt3sWLFCkybNg1yuVxoQ9vnDGOd6bFMWFeuXImNGze2WEelUnXKWC5cuIBJkyZBqVRi3LhxbV5fl2JpjrW1NZYuXSo89/X1xbVr17Bp06YmCWt3iKe1ukMsrq6ucHV1FZ4HBASgsLAQmzdvxvbt27twZI+XhufHkCFDYGRkhPnz52P9+vX805tdbN68ecL/PTw84ODggLFjx6KwsBADBgzowpFpVlNTgylTpoCI8Nlnn3X1cBjTmscyYQ0PD8esWbNarNO/f3/Y29ujvLxcVF5bW4vffvsN9vb2Gtezt7dHdXU1KioqRN8wXL9+vck6ubm5GDt2LObNm4fVq1c3aafxVbXXr1+HXC4XfbuqK7G0lb+/P44cOdKkvDvE09y+US/TlVjs7e2bXHmsaZyN+fn54dSpUy2OW83a2hr6+voat0dLY2+pvvrf69evw8HBQVRHfdeG9mwzXY1FE39/f9TW1qK4uFj0gaItOiKe1uiI142uikUTf39/AMClS5falbB2ZCzqZLWkpATHjh0Tvl1Vt6Htc4axzvRYzmG1sbGBm5tbiw8jIyMoFApUVFQgPT1dWPfYsWOor68XXrQa8/HxgaGhIRISEoSy/Px8XL58GQqFQijLycnB6NGjMXPmTKxbt65JOwqFQtQGABw5ckTUhq7E0h6ZmZmiN/DuFI9CocDJkydRU1MjlB05cgSurq6i6QBdHYtCoUB2drboTerIkSOQy+V44oknmo2vuX2jiZGREXx8fETjqK+vR0JCQrPb9EHHdr9+/WBvby+qU1lZiZSUFFFsbd1muhqLJpmZmdDT02vyJ9yujqc1OuJ1o6ti0UR966vWniONdVQs6mT14sWLOHr0KKysrJq0oe1zhrFO1dVXfem68ePH09ChQyklJYVOnTpFgwYNEt0G5OrVq+Tq6kopKSlCWVhYGPXt25eOHTtGZ8+eJYVCQQqFQlienZ1NNjY29OKLL4pulVJeXi7UUd/WatmyZaRSqeiTTz7Rym2ttB0LEdHFixcpIyOD5s+fTy4uLpSRkUEZGRnClehbt26lb775hlQqFalUKlq3bh3p6elRVFRUu2PpyngqKirIzs6Opk+fThcuXKDY2FgyMTF56NtaaTsW9W2txo0bR5mZmXTo0CGysbER3dZq8+bNtHfvXrp48SJlZ2fT4sWLSU9Pj44ePdrqscfGxpJUKqWtW7dSbm4uzZs3jywsLIS7E0yfPp1Wrlwp1E9KSiIDAwN69913SaVSkVKp1HgrKAsLC9q3bx+dP3+eJk2apPG2Vi1ts/boilhOnz5NmzdvpszMTCosLKSvv/6abGxsaMaMGQ8VS0fFc+PGDcrIyKADBw4QAIqNjaWMjAwqLS0V6rTmPOsOsVy6dIkiIyPp7NmzVFRURPv27aP+/fvTqFGjdCqW6upqmjhxIvXu3ZsyMzNF7ysN72bSEecMY52FE9YHuHHjBk2bNo3MzMxILpfTSy+9RLdv3xaWq2+Hcvz4caHszp07tGDBAurZsyeZmJjQc889J3oxVyqVBKDJw8nJSdT38ePHycvLi4yMjKh///4UHR2tc7EQ3b/ti6Z4ioqKiOh+wuru7k4mJiYkl8vJz89PdMub7hYPEVFWVhY99dRTJJVKqVevXrRhwwadjKW4uJgmTJhAMpmMrK2tKTw8nGpqaoTlGzdupAEDBpCxsTFZWlpSUFAQHTt2rM3j//jjj6lv375kZGREfn5+dObMGWFZYGAgzZw5U1T/22+/JRcXFzIyMqLBgwfTgQMHRMvr6+tpzZo1ZGdnR1KplMaOHUv5+flt2mbt1dmxpKenk7+/P5mbm5OxsTG5u7vT22+/TXfv3n3oWDoinujoaI3nh1KpFOq05tjsDrFcvnyZRo0aRZaWliSVSmngwIG0bNmyh74Pq7ZjUb8+aHo0fM3oqHOGsc4gISLq0K9wGWOMMcYYewiP5RxWxhhjjDHWfXDCyhhjjDHGdBonrIwxxhhjTKdxwsoYY4wxxnQaJ6yMMcYYY0ynccLKGGOMMcZ0GiesjDHGGGNMp3HCyhhjjDHGdBonrOyxt3btWnh5eWm93aCgICxZsqTFOs7Ozvjggw8euq+tW7fCwsLiodt5VOXl5WH48OEwNjbukH2tLa05Zh5VEokEe/fu7ephMMZ0FCesrM1mzZoFiUTS5HHp0qWuHppO2b17N956661O6Wvq1KkoKCjolL7aShcSEaVSCVNTU+Tn5yMhIaFLxwIAiYmJkEgkqKio6OqhtJq2Plwxxlh7GHT1AFj3NH78eERHR4vKbGxs2tVWdXU1jIyMtDGsFtXU1MDQ0LDD+1GztLTslH5qamogk8kgk8k6pb+G/Xbm9nyY46SwsBDPPPMMnJycmq3T2fE8iurq6iCRSKCnpxvfhXTWawtjrOPpxqsK63akUins7e1FD319fQDAiRMn4OfnB6lUCgcHB6xcuRK1tbXCukFBQXjllVewZMkSWFtbIyQkBK+//jr++Mc/CnU++OADSCQSHDp0SCgbOHAgtmzZAgBIS0vD008/DWtra5ibmyMwMBDnzp0TjVEikeCzzz7DxIkTYWpqinXr1gEANmzYADs7O/To0QOzZ8/G3bt3W4xV/W3YDz/8gKFDh0Imk2HMmDEoLy/H999/D3d3d8jlcrzwwgv4/fffRXE2/PNueXk5nn32WchkMvTr1w87duxo0pd6zBMmTIBMJkP//v3x73//W1heXFwMiUSCuLg4BAYGwtjYGDt27NA4JeC7776Dr68vjI2NYW1tjeeee05Ydu/ePbz++uvo1asXTE1N4e/vj8TExBa3Q3Pbc9++ffD29oaxsTH69++PiIgIYX87OzsDAJ577jlIJBLh+axZszB58mRR+0uWLEFQUJBo+zU+TtT7IiEhAcOGDYOJiQkCAgKQn5/f4rjT09MRGRkJiUSCtWvXNrsd6+vrERkZid69e0MqlcLLy0t0DKrX+/bbbzFy5EjIZDL4+vqioKAAaWlpGDZsGMzMzDBhwgT88ssvGsdTXFyM0aNHAwB69uwJiUSCWbNmCcvr6+uxfPlyWFpawt7eHmvXrhWtX1FRgTlz5sDGxgZyuRxjxoxBVlZWs/EDwJUrVzBlyhRYWFjA0tISkyZNQnFxsbBcvT/effddODg4wMrKCgsXLkRNTY2wL0pKSvDaa68Jf1EB/jcVJT4+Hk888QSkUilOnToFQ0NDlJWVicawZMkSjBw5ssVxlpaWNnvsA8CKFSvg4uICExMT9O/fH2vWrBHGCPxves+WLVvQr18/GBsbt9gfY6wbIcbaaObMmTRp0iSNy65evUomJia0YMECUqlUtGfPHrK2tialUinUCQwMJDMzM1q2bBnl5eVRXl4excfHk7m5OdXW1hIR0eTJk8na2ppWrFghtAuALl68SERECQkJtH37dlKpVJSbm0uzZ88mOzs7qqysFPoBQLa2thQVFUWFhYVUUlJCcXFxJJVKacuWLZSXl0dvvPEG9ejRgzw9PZuN9/jx4wSAhg8fTqdOnaJz587RwIEDKTAwkMaNG0fnzp2jkydPkpWVFW3YsEEU5+LFi4XnEyZMIE9PT0pOTqazZ89SQEAAyWQy2rx5s2jMVlZW9OWXX1J+fj6tXr2a9PX1KTc3l4iIioqKCAA5OzvTrl276KeffqJr165RdHQ0mZubC+3s37+f9PX16c0336Tc3FzKzMykt99+W1g+Z84cCggIoJMnT9KlS5do06ZNJJVKqaCgoNntoGl7njx5kuRyOW3dupUKCwvp8OHD5OzsTGvXriUiovLycgJA0dHRVFpaSuXl5USk+RhavHgxBQYGirZf4+NEvS/8/f0pMTGRcnJyaOTIkRQQENDsuEtLS2nw4MEUHh5OpaWldPv27Wa34/vvv09yuZxiYmIoLy+Pli9fToaGhsJ2Ua/n5uZGhw4dotzcXBo+fDj5+PhQUFCQ6PgICwvTOJ7a2lratWsXAaD8/HwqLS2liooKIWa5XE5r166lgoIC+te//kUSiYQOHz4srB8cHEzPPvsspaWlUUFBAYWHh5OVlRXduHFDY3/V1dXk7u5Of/vb3+j8+fOUm5tLL7zwArm6utK9e/eE/SGXyyksLIxUKhV99913ZGJiQv/85z+JiOjGjRvUu3dvioyMpNLSUiotLSUioujoaDI0NKSAgABKSkqivLw8+s9//kMuLi70zjvviMZgbW1NUVFRze6nBx37RERvvfUWJSUlUVFREcXHx5OdnR1t3LhRWK5UKsnU1JTGjx9P586do6ysrGb7Y4x1L5ywsjabOXMm6evrk6mpqfD485//TERE//d//0eurq5UX18v1P/kk0/IzMyM6urqiOj+m/LQoUNFbd68eZP09PQoLS2N6uvrydLSktavX0/+/v5ERPT1119Tr169mh1TXV0d9ejRg7777juhDAAtWbJEVE+hUNCCBQtEZf7+/q1KWI8ePSqUrV+/ngBQYWGhUDZ//nwKCQkRnjdMWPPz8wkApaamCstVKhUBaJKwNk50/P396eWXXyai/yVMH3zwgahO44RVoVBQaGioxnhKSkpIX1+ffv75Z1H52LFjadWqVc1uB03bc+zYsaJEmIho+/bt5ODgIFpvz549ojqtTVgbHyea9sWBAwcIAN25c6fZsXt6eoo+NDW3HR0dHWndunWiMl9fX+GYUa+3ZcsWYXlMTAwBoISEBKFs/fr15Orq2ux41HHcvHlTVB4YGEhPPfVUk/7VH9x+/PFHksvldPfuXVGdAQMG0BdffKGxr+3btzc5J+/du0cymYx++OEHIrq/P5ycnIQPjEREf/nLX2jq1KnCcycnJ9GxSnT/uANAmZmZovKNGzeSu7u78HzXrl1kZmZGVVVVGsdI9OBjX5NNmzaRj4+P8FypVJKhoaHwwYgx9ujgKQGsXUaPHo3MzEzh8dFHHwEAVCoVFAqF8CdDABgxYgSqqqpw9epVoczHx0fUnoWFBTw9PZGYmIjs7GwYGRlh3rx5yMjIQFVVFU6cOIHAwECh/vXr1zF37lwMGjQI5ubmkMvlqKqqwuXLl0XtDhs2TPRcpVLB399fVKZQKFoV85AhQ4T/29nZCX+WbFhWXl6ucV2VSgUDAwNR3G5ubhqv7G88HoVCAZVKJSprHFdjmZmZGDt2rMZl2dnZqKurg4uLC8zMzITHiRMnUFhY2GK7jfvNyspCZGSkqJ25c+eitLRUND2ivRofJ2oN94WDgwMANLvtW9IwnsrKSly7dg0jRowQ1RkxYkST7d/4WAAADw8PUVl7xtO4beB+fOq2srKyUFVVBSsrK9E2LyoqanbfZWVl4dKlS+jRo4dQ39LSEnfv3hWtM3jwYGFaT+N+W2JkZNRkzLNmzcKlS5dw5swZAPenDkyZMgWmpqYttvWgYz8uLg4jRoyAvb09zMzMsHr16ibnvJOTU7vn0zPGdBdfdMXaxdTUFAMHDnyo9RsLCgpCYmIipFIpAgMDYWlpCXd3d5w6dQonTpxAeHi4UHfmzJm4ceMGPvzwQzg5OUEqlUKhUKC6uvqB/bRXwwtyJBJJkwt0JBIJ6uvrtdZfSx4UV0sXYFVVVUFfXx/p6emiBAUAzMzM2tRvVVUVIiIi8Pzzzzep29L8QT09PRCRqKzhXMTm+lNrvC8AtGvbt/f40NR/47L2HgstHVdVVVVwcHDQON+4uduaVVVVwcfHR+Oc6YaJXXuPZ5lMJvqACgC2trZ49tlnER0djX79+uH7779/4BzpB0lOTkZoaCgiIiIQEhICc3NzxMbG4r333hPV0+Y5zxjTHZywMq1yd3fHrl27QETCm1hSUhJ69OiB3r17t7huYGAgoqKiYGBggPHjxwO4n8TGxMSgoKBAdEFOUlISPv30U/zhD38AcP+ikl9//bVV40tJScGMGTOEMvW3QB3Jzc0NtbW1SE9Ph6+vLwAgPz9f422Nzpw502R8Q4cObVN/Q4YMQUJCAl566aUmy4YOHYq6ujqUl5c/8CKYB/H29kZ+fn6LH14MDQ1RV1cnKrOxscGFCxdEZZmZmV16lb5cLoejoyOSkpJE3+YnJSXBz89Pq32pr1xvvF0exNvbG2VlZTAwMBAuYGvNOnFxcbC1tYVcLm/rUAVGRkZtGu+cOXMwbdo09O7dGwMGDGjyzbUmLR37p0+fhpOTE9544w1heUlJSRsiYIx1ZzwlgGnVggULcOXKFbz66qvIy8vDvn37oFQqsXTp0gfe6mbUqFG4ffs29u/fLySnQUFB2LFjBxwcHODi4iLUHTRoELZv3w6VSoWUlBSEhoa26rZOixcvRlRUFKKjo1FQUAClUomcnJyHirk1XF1dMX78eMyfPx8pKSlIT0/HnDlzNI55586diIqKEsaXmpqKV155pU39KZVKxMTEQKlUQqVSITs7Gxs3bgQAuLi4IDQ0FDNmzMDu3btRVFSE1NRUrF+/HgcOHGhTP2+++Sa2bduGiIgI5OTkQKVSITY2FqtXrxbqODs7IyEhAWVlZbh58yYAYMyYMTh79iy2bduGixcvQqlUNklgu8KyZcuwceNGxMXFIT8/HytXrkRmZiYWL16s1X6cnJwgkUiwf/9+/PLLL6iqqmrVesHBwVAoFJg8eTIOHz6M4uJinD59Gm+88QbOnj2rcZ3Q0FBYW1tj0qRJ+PHHH1FUVITExEQsWrRINE3nQZydnXHy5En8/PPPrfpwGBISArlcjr///e8aPzhp0tKxP2jQIFy+fBmxsbEoLCzERx99hD179rR6/Iyx7o0TVqZVvXr1wsGDB5GamgpPT0+EhYVh9uzZogSmOT179oSHhwdsbGzg5uYG4H4SW19fL/rGCwC++uor3Lx5E97e3pg+fToWLVoEW1vbB/YxdepUrFmzBsuXL4ePjw9KSkrw8ssvty/YNoqOjoajoyMCAwPx/PPPY968eRrHHBERgdjYWAwZMgTbtm1DTEwMnnjiiTb1FRQUhJ07dyI+Ph5eXl4YM2YMUlNTRWOZMWMGwsPD4erqismTJyMtLQ19+/ZtUz8hISHYv38/Dh8+DF9fXwwfPhybN28W3e/0vffew5EjR9CnTx/h27KQkBBhP/j6+uL27duib9a6yqJFi7B06VKEh4fDw8MDhw4dQnx8PAYNGqTVfnr16oWIiAisXLkSdnZ2rf5AIpFIcPDgQYwaNQovvfQSXFxc8Ne//hUlJSXCXNrGTExMcPLkSfTt2xfPP/883N3dhdu5teUb18jISBQXF2PAgAGtmiOqp6eHWbNmoa6urtX7tqVjf+LEiXjttdfwyiuvwMvLC6dPn8aaNWtaPX7GWPcmocYTyRhjXUYikWDPnj1N7lHKWHc0e/Zs/PLLL4iPj+/qoTDGujmew8oYY0yrbt26hezsbHzzzTecrDLGtIITVsYYY1o1adIkpKamIiwsDE8//XRXD4cx9gjgKQGMMcYYY0yn8UVXjDHGGGNMp3HCyhhjjDHGdBonrIwxxhhjTKdxwsoYY4wxxnQaJ6yMMcYYY0ynccLKGGOMMcZ0GiesjDHGGGNMp3HCyhhjjDHGdNr/A1vAyAiUDkv6AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Histograms of the three labels on identical bins, log count axis."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "bins = np.linspace(-0.02, 0.02, 161)\n",
+    "primary_std = dev[PRIMARY_LABEL][PRIMARY_LABEL].std()\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for name, colour in PALETTE.items():\n",
+    "    series = dev[name][name]\n",
+    "    tag = f\"{name}, std {series.std():.5f}\"\n",
+    "    ax.hist(series.to_numpy(), bins=bins, histtype=\"step\", lw=1.8, color=colour, label=tag)\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"Forward midprice return from the entry bar\")\n",
+    "ax.set_ylabel(\"Bars per bin, log scale\")\n",
+    "sub = \"Identical bins on the development window; rows beyond the axis are counted below\"\n",
+    "add_message_title(ax, \"Each horizon widens the label while its tails stay far from normal\", sub)\n",
+    "ax.legend(loc=\"lower center\", frameon=False)\n",
+    "show_with_alt(fig, \"Histograms of the three labels on identical bins, log count axis.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "88933f8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:12:09.245412Z",
+     "iopub.status.busy": "2026-07-31T09:12:09.245321Z",
+     "iopub.status.idle": "2026-07-31T09:12:09.375759Z",
+     "shell.execute_reply": "2026-07-31T09:12:09.375251Z"
+    }
+   },
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline IC: Lagged 15-min Return → fwd_ret_15m\n",
-      "  Mean IC: 0.00001\n",
-      "  IC t-stat: 0.01\n",
-      "  IC observations: 9,048\n",
-      "  → NOT significant. Ch8 features must create signal from scratch.\n"
+      "fwd_ret_15m: std 0.004142, kurtosis 298.8, 1.00x the primary label against 1.00 under square-root-of-horizon scaling, 63,228 beyond the axis\n",
+      "fwd_ret_5m: std 0.002324, kurtosis 1147.8, 0.56x the primary label against 0.58 under square-root-of-horizon scaling, 10,204 beyond the axis\n",
+      "fwd_ret_60m: std 0.007884, kurtosis 86.0, 1.90x the primary label against 2.00 under square-root-of-horizon scaling, 325,342 beyond the axis\n"
      ]
     }
    ],
    "source": [
-    "import yaml\n",
-    "\n",
-    "_holdout_start = yaml.safe_load((CASE_DIR / \"config\" / \"setup.yaml\").read_text())[\"evaluation\"][\n",
-    "    \"holdout_start\"\n",
-    "]\n",
-    "\n",
-    "# Compute lagged 15-minute return as baseline signal, pre-holdout rows only\n",
-    "df_baseline = (\n",
-    "    df.with_columns(\n",
-    "        lag_15m=(\n",
-    "            pl.col(\"mid_close\") / pl.col(\"mid_close\").shift(15).over([\"symbol\", \"session_date\"]) - 1\n",
-    "        )\n",
-    "    )\n",
-    "    .filter(pl.col(\"timestamp\").dt.date() < date.fromisoformat(_holdout_start))\n",
-    "    .drop_nulls(subset=[\"lag_15m\", \"fwd_ret_15m\"])\n",
-    ")\n",
-    "\n",
-    "# Sample every 15th timestamp for approximately independent observations\n",
-    "all_ts = df_baseline[\"timestamp\"].unique().sort()\n",
-    "sample_ts = all_ts.gather_every(15)\n",
-    "baseline_sample = df_baseline.filter(pl.col(\"timestamp\").is_in(sample_ts))\n",
-    "\n",
-    "min_cs_size = min(10, baseline_sample[\"symbol\"].n_unique())\n",
-    "baseline_ic = (\n",
-    "    baseline_sample.group_by(\"timestamp\")\n",
-    "    .agg(\n",
-    "        pl.corr(\"lag_15m\", \"fwd_ret_15m\", method=\"spearman\").alias(\"ic\"),\n",
-    "        pl.len().alias(\"n\"),\n",
-    "    )\n",
-    "    .filter(pl.col(\"n\") >= min_cs_size)\n",
-    ")\n",
-    "\n",
-    "if baseline_ic.height > 0 and baseline_ic[\"ic\"].null_count() < baseline_ic.height:\n",
-    "    baseline_ic_mean = float(baseline_ic[\"ic\"].mean())\n",
-    "    baseline_ic_std = float(baseline_ic[\"ic\"].std())\n",
-    "    baseline_ic_t = (\n",
-    "        baseline_ic_mean / (baseline_ic_std / np.sqrt(len(baseline_ic)))\n",
-    "        if baseline_ic_std > 0\n",
-    "        else 0.0\n",
-    "    )\n",
-    "else:\n",
-    "    baseline_ic_mean, baseline_ic_std, baseline_ic_t = 0.0, 0.0, 0.0\n",
-    "    print(\"  Warning: insufficient cross-sectional data for baseline IC\")\n",
-    "\n",
-    "print(\"Baseline IC: Lagged 15-min Return → fwd_ret_15m\")\n",
-    "print(f\"  Mean IC: {baseline_ic_mean:.5f}\")\n",
-    "print(f\"  IC t-stat: {baseline_ic_t:.2f}\")\n",
-    "print(f\"  IC observations: {len(baseline_ic):,}\")\n",
-    "if abs(baseline_ic_t) < 2.0:\n",
-    "    print(\"  → NOT significant. Ch8 features must create signal from scratch.\")\n",
-    "else:\n",
-    "    sign = \"mean-reverting\" if baseline_ic_mean < 0 else \"momentum\"\n",
-    "    print(f\"  → Significant ({sign}). Ch8 features should improve on this.\")"
+    "for name in RETURN_LABELS:\n",
+    "    series = dev[name][name]\n",
+    "    out = series.filter((series < bins[0]) | (series > bins[-1])).len()\n",
+    "    root_h = np.sqrt(HORIZONS[name] / PRIMARY_HORIZON)\n",
+    "    print(\n",
+    "        f\"{name}: std {series.std():.6f}, kurtosis {series.kurtosis():.1f}, \"\n",
+    "        f\"{series.std() / primary_std:.2f}x the primary label against {root_h:.2f} under \"\n",
+    "        f\"square-root-of-horizon scaling, {out:,} beyond the axis\"\n",
+    "    )"
    ]
   },
   {
@@ -929,12 +1026,100 @@
     }
    },
    "source": [
-    "**Reconciliation with Ch6 baseline**: The feasibility notebook ([`01_feasibility_analysis`](01_feasibility_analysis.ipynb)) reports a\n",
-    "much stronger baseline IC (~-0.17) because it uses close-to-close (trade price)\n",
-    "returns, which suffer from bid-ask bounce — an artifact that creates artificial\n",
-    "negative autocorrelation (Hasbrouck, 2007). The near-zero IC here, computed on\n",
-    "midprice returns, is the uncontaminated measure and is authoritative for downstream\n",
-    "feature evaluation."
+    "The label is what a trade earns before costs, and the spread is most of what it pays.\n",
+    "Both are in the same units, so they belong on the same axis: the curves are the\n",
+    "distribution of the absolute move at each horizon, and the vertical line is the spread a\n",
+    "**round trip** crosses - twice the half-spread, because the position is opened and closed\n",
+    "- on the same bars.\n",
+    "\n",
+    "The comparison is not the case study's answer, it is the reason the case study is worth\n",
+    "running. A move larger than the spread is necessary for the horizon to be tradable and\n",
+    "nowhere near sufficient: what a strategy earns is the move times how often it gets the\n",
+    "direction right, and Section G measures how little of that is on offer here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "5c0a6920",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:12:09.377250Z",
+     "iopub.status.busy": "2026-07-31T09:12:09.377181Z",
+     "iopub.status.idle": "2026-07-31T09:12:14.683167Z",
+     "shell.execute_reply": "2026-07-31T09:12:14.682557Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArYAAAFsCAYAAAA5Tvo4AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2DZJREFUeJzs3XV0FFcbwOHfxt09BIJrIBCcQgLF3Yq7FnenheIuLVZcSikUPtwtUKC4UzQ4JCEhxH13vj+WDNkIJJBskPucwyE7OzP3nd2Rd+/cuVchSZKEIAiCIAiCIHzhdHI6AEEQBEEQBEHICiKxFQRBEARBEL4KIrEVBEEQBEEQvgoisRUEQRAEQRC+CiKxFQRBEARBEL4KIrEVBEEQBEEQvgoisRUEQRAEQRC+CiKxFQRBEARBEL4KIrEVBEEQBEEQvgoisc2Ak6fPY+pYFFPHovQaOCanw/nq9Bo4Rv58T54+n9PhfLY2/LVd/pymzl6U0+EIgoacPI6fPH0hl123WSetlp0Tps5eJG/vhr+2f3D+us06yfM/efoCyNnPTJzLhOykl9MB5ISiZb/n6bOXGZp3///WZXM0wpdk974jXL91B4AOrZuRJ7drlq4/6SRvaWFO/96ds3Tdwqc5efo8/5xRJ2wN631PqRJFczgiQfh8iXOZkFO+ycRWED7W7gNH2bh5BwBVK5fP8sR22pzFAOR2cxEXg8/MP2fOJ/t+XEVi+xlxcrTn8K4/ALAwN8/haD4/c6aOJzwiAlB/VtogzmVCTvkmE9uNKxcSGxcnv+7QYzCBr4IBmDN1HKU83l2wihctxLUbt7Ueo7bFx8ejo6ODnt43uUsIwjdJpVIRH5+AkZFhTofy0aKjYzAxMaZyBa+cDuWzVaJYoZwOQfiCREVFY2pqktNhfLRvso1tGc8SVK7gJf8zNDSQ3ytetJDGe5YWqX/9nzh1Dp96rbHJXYrCZWqwZMWGVPNERkUxdfYiylZrhG0eT5zyl6Vus04cPHoyQzGqVCpmzV8mL59UVvP2vVm3cas8X/K2Vus3/Y/flq2lRPna2OQuRZVaLTh64rTGepO3gzt49CSjJ8wkn0dVbHJ78uJlIAAJCQn8umwtVWq1wN69DPbuZfCu25pNW3elinPOryuo26wTBT19sM3jiZ17abyqNuSX6QuIjo5JNf+yVRspUb42tnk8qVanFb7/nM3Q55HSlv/tpV6zzrgWqoC1W0mKlv2e7v1GEhYeIc8THx/P3N9WULFGM+zdy2DnXpoK1Zsy59cVxMfHa6zv+q07tOrUjzzFqmDp6oFbkYpUrNGMgSMm8uz5S7k9WlJtLUC95p1TtSk8efo8DVp2JVfhili6epCnWGWq1WnF8HHTNGJLKel7TPL02Ut53UXLfp/mMv/bdYDyPk2wditJqUp12bZzf6p5goJDGPXzDEpWrIO1W0lcC1WgefvenL94NSMfMzExsYz9Zba8vL17GYqVrUnbrgPYte+wPN+pfy/QocdgSlasg0vB8ljlKkn+ktXo2HMIN27dTXNbTR2Lsm7jVqbNWUw+j6o45S9L597DCA0LJ+RNKN37jcS5QDlyFa7IwBETiY2NSxkee/YfpUHLrvJ+4Fm5HtPmLCYmJjZD25fR/dfUsahcAwXw46CxmWrjmJE4f+jYV17n1Rv/aSzff9jP8nsHjpyQp9+4dZfOvYeRz6MqVrlKUqCUN32HjOfFywCN5TU+8z+3MXPeUop41cDS1YN/z1+W3+s5YLTGctdv3ZHfa9mhT4Y+U4DExERmzFtC4TI1sMldiu8btpOb8CR35fotOvQYTN4S6vjzlqhK++6DuHLtlsZ8Kdtkrlz3F56V62Hp6sG2XQfSbS9atOz38vS0/mVFLJu27qJstUbvPQ5TGj1hpryOYyfOyNMLevqk2oYVazfJ865YuynN9S1f86d8jFao3jTVeTWtNrbv8ynXr8/1XJaV553tuw9Sr1lnXAqWx9qtJMXL1WLomMn4B76S5xk+dqpcXvJzJcDsBb/L7y1f86c8/fGT5/Qb+hNFvGpg7VaSPMWq0KnnEO7c88vQNoL6zlLVOj9gk7sUJcrXZtmqjem2aU6+X1y5fosfB40jd9FKOOR79yMxPCKSidMWUOa7Btjm8cQxnxfedVuzav1mJEmS52vXbaC8Lr9HTwD19cMqV8lUzyeNnzxHIw8BeB3yhoEjJlLEqwZWuUrimM+LUpXq0rn3MLkJWEaJ6rlMOnv+Mpu37SExMRGA5y/8GTF+GkUK5aeGd2UAwsIjqNW4A7du35OXiyWOf85c4J8zF5g/4yd6dW333nJmLVjG5Jm/aUx7/sKf5y/8CQ+PpHP7lqmWmb9oJfcePJJfX73+Hy3a92Hv1tVUqVg21fzDxkzh0ZNnGtMSEhJo2rZXqhPjxSvX6dHvOrdu32PKT8Pl6Rs3b9coE+DOPT/u3PPj7IWr7P/fWnn6giWrGffLbPn1pas3aNq2F/nz5n7PJ5Fan8HjWL/pfxrTnj57ydNnL/l51CAsLcyJi4uncevunPr3osZ8N/+7y83/7nL42El2b1mFgYEBr0Pe0OiH7gS/DpHnC3kTRsibMG7cukPThrXJnzfPB+O69+ARzdv31khWgl+/Ifj1Gy5dvUGfHu3T/KH0Mbbt3M/d+w/l1w8ePqHLj8PxKF6EQgXyAvDs+Uu+b9ReI8mJj0/g4JGTHDvxLxtXLqBB3RrvLWfomMkan3U8CTx59oInz15gbGxM4/q1ADh74Srbdx/UWDYgMIj/7TrAgcMn+OfQ3xQplD/V+uf8uoKHj5/Kr7fu2EdYeARv3oRx8cp1efqq9ZuxtbFiwpjB8rTJM39lxrylGuu77/eYqbMX4fvPv+z5ezUGBga8T2b234+V0Thbt2jIvkPHAdix+xCeHsUAUCqV7N5/FAB7O1tq+lQB4ODRk7TtOoC4uHc/0vwDXrHuz20cOHKCY3s24Z4nV6p4Zi/4XeO419HRwT13Lh4/fc7ufUeImRWLsbERAPsOHpPna9W8YYa3ecT4aRoX47MXrtCmc3+unz0g3xXae+AY7XsMJiEhQZ7vVVAwO/YcYu/B4+nun5v+3pXqvPWpsiqWtI7DtFSp4MVvy9YCcOHSNWp4V+b5C39e+qsrFy5duUliYiJ6enqcS5a4pXUeX7B4lcZnffO/u7Tp0p/bl45ibWWZ4c8gSVZcvzJDW+ey5D7lvDN+8hzmL1qlsb7HT5/z++o/2bHnkHzctW7RkKWr1M1jtu8+JJ8rAbbvUZ8r9fX1adGkHqD+YdWwZTdCw8Ll+YJfh7Bt1wEOHj3J3q1rKFum5Hu36/zFqzRp01M+Jzx68oxhY6fgUbzIBz+Tjj2GpDqu3oSG8X3DdhrfD6jzgYtXrnPy9HnW/T4XgMoVvNi5V53An790jfx583D52k35mEr+AyTpbx0dHSqVL6Muv+dQTpx6l3ckJCTw4OETHjx8Qj53N6pWLv/BbUjyTdbYfgq/R0+pW9ObrRuW0LJpfXn66g1b5L9/mb5APinUqVmNbRuXsWLRDBwd7AAY9fMMnr/wf285ew6oLyhWlhasWjyLPX+vZsWiGfTo3DrdNlJ+j57y06gBbPtjKTWrfweod46RP01Pc/5HT57Rp0dHdvy1gt9m/4KZmQmLV2yQk9ryXqX4a81vbFy1UD7BzF+0iguXrsnr6N6pNSsXz+R/f/7Oge3r+Hv9EurUrAbAydPnOHvhCqA+QKbMepeo9+negW0bl9GiSd1M/RrdseeQnGjp6uoyqG83/vfn76xYNIMa3pVRKNTzLVq+Tk5qc7k6s2bpHNYum4NbLmcATv17kd9+Vz8YeP7iVTmp/aFZA3ZvWcXmtYuYNnEkVSuXQ1dXV27DV/v7qnIsc6aO4/CuPzi86w9KeahrXpKS2r49O7J36xo2rlrIhNGDKONZAkVScGno1La53EYQwNHBTl73xpULU81/9/5DOrdrwbY/luJTtSKgruVfm6w2f/CoSfKFoF2rJuz4awULZ03AzNSEhIQE+gwZR1RU9Hs/771vE5vcbi5sXLWQXVtWsmT+FNq1aoK1pYU8X9nSHsydNp6/1y9h///WsXvLKib/NAyA6JgYFv2e9kOYT569YMrPw1m/fB7mZqYAHD72D3fuPWDJvMksnDVBnjf5MXbpyg05WXRytGfJ/Cns+GsFdWt6A3D67CX5+32fjO6/h3f9Qcc2zeXlRgzqLX8/db6vlu76MxNngzo15M9g595D8jr+OXNB3j9bNqmHnp4e0dEx9Bowhri4ePT09Jg4ZjC7tqxkSP/uAAS+Cmbw6ElpxvToyTNat2gkn5dcXRzp2LYZABGRUfJ3DrD3oDrRNjE2pkGd6h/8PJP4PXrK5J+GsWnNr+RyVR9zT5694MjxU4D6VmffoePli17PLm3435+/06trW0B93uo7dHya++ejJ8+oWf07Nq9dxIYV8ylWuEC6cWxcuVD+ng7v+kOufACoVaNqlsTyoeMwLZUresnng3OXrqr/T3bhj46Jke90nLugnm5jbUnRNLb1zj0/hvbvwd/rl8gJTERkFFv+t+e9MaTnU69fn+u5LLmPPe9cuHRNTmqNjAyZNnEkf69fQrUqFQDN466cVym50ubAYd93yebjZ3LzxlrVv8PWxhpJkug1YIyc1A7s05VdW1Yy+adh6OrqEhkVzY+Dx2rUkKZl9ISZcjnVqlRg64YljB/ZX+NHSnqevfBn7PB+7Ny8kpmT1HduJk6bLye1xYsWYtOaX1kyb7L8g2nrjn1s3bEPgCqV3v3oSkpck+/T9/0e8zrkDQkJCVx+exfEo3hhLMzNiIiM4uTpcwCU8ijK3+uXsH3Tcn6dPZGmDWtjYpK5ZhGixjaT7O1sWb98HoaGBpTx9JC/VL9H6l9/KpWKLf/bC4CBgT4DenfB0NAAC3MzmjSoxfI1m4iPT2DbrgMM6tM13XL039ZqmJgYk8/djRLFCmNiYky7H5qku0zLpvUZPbQvAJUqeFGgpDfRMTFcvf4fz1/4yxeYJK2aN2TO1LEa0/7aulv+e8CPXbC1tQagdYuGcg3yX1t3U86rFAA1vCszc/4y/j1/mVdBrzVqPAAuX71JxXKlNZI+L08P5kwbB6gP7NNnL/Ls+fsT/SSb/n7XHGJIv+78Mm6I/Dr5Z5P0HQAsmPET9WqrL8pmpia07Kj+jP7evo9hA3qip68vz5vL1YlCBfLi6uKEQqHQ+I4qV/DC3s5Wfp3UbCWJvv67w8k9dy6KFM6Pk4P6R8jIIT++d7vccrnglstFfm1oaPDeNoMexYuwZP4UAGxtrPH5pw0AD9/eAgp5Eyrf4nF0sKNrhx8AKFakIDW8K7Nr3xFeh4Ry+PgpmjasnW45SbVrlhYW5HV3o0jB/BgaGtC5XQuN+cp7leLMuUus3rCFR4+fER2j2Qzl8rWbaa6/RZN6DOmnTsb+3LJTvs3ev3dn+a7EslUbuX33AcGv3xAWHoGlhTl/bXu3n3Zs05yC+d0B6NG5tbyOv7buZtiAnuluG2R8/61cwYvjJ/+Vp+fPlydDbTozE6exsRGNG9Ri4+Yd3HvwiJv/3aNEsULs2POuJrx1C3Wt6VHf03KyW8O7knxRqV+7Ov/beUBOIoNfv8Hu7TGcpFL5MqxeMktjWofWzZg6ezEqlYrN2/bQsml9/ANfybfh69epnqk2dz27tGFo/x6A+oL285R5wLvz5NETpwl+/QaA0qWKs2CmOpGo8301Lly+zpVrtwh+/YZjJ87QqH5NjXXndnNh2x9LNZ4HSO/2ehnPEvLfK9f9Jd/2L1akIOuXz/vkWD50HKbH1saaIoXycfuuHxcuXUOSJDkJKFq4ALfvPuDcxavkcnWWaxYrlfdK88dxw7rfa/yI7Nxb/XfSZ50ZWXH9+lzPZcl97Hlnc7LrSq+u7eTPoHxZTwqV9iEuLp4jx08R8iYUG2srWrdoxLQ5iwmPiOSo72nq16ku19bCu+P5+q07/HfnPgAlSxSlUT11k42K5UpTtrQH5y5e5fZdP65e/4/SpYqnuU2vgl7L+5ChoQF/rJyPrY019WpX5869h3Kukp4h/bozbkR/AGr6VEGlUrFt5wH5/TVLZ1O8qLqtdkxsHMPGqr+zv7fvo2XT+pQsXgQLczPCIyLlOM6n2KfPX7yKg72dnAtUrqA+b+np6qJQKJAkCVsba/LlzU2BfHnQ09Oje6fW7407LSKxzaTyXqXkNrm2Nlby9LC3v7SCX7/hTWgYoL5V0vCHbmmu5+4Haik7t2vB+UvXeOkfSPUGbVEoFOTN44ZP1YoM7NOFgvlT3+Yql+w2haWFOQULuMu/DB89eZYqsa1f2yfVOh48fCz/3bHnkFTvA9y5r4796bMXfN+wHeERkeluR1h4+Nvyn8vTvEq/u9jo6upSumTxDCe2yeOrl0b8ac1XtkypZGWXTDVPlQpeFMiXhwcPnzB/0SrmL1qFuZkpniWL0bp5Qzq3b4mOzodvbjSoW4Nfpi/gdUgoI3+azsifpmNtZUnZMiXp1LY5zRvXzdA2ZsR3lcrJf9to7IfqdrwPHz2Vf90HvgqmVuMOaa4nI/vhrAW/c+PWHSp/3xxdXV0K5nenZvXvGNyvG86ODgB0+XG4Rk1fSklxpVS2tIf8t7X1u9umZUq920eSJ2ZhYeFYWphrfL+zF/7O7IW/p1p3yiYGKWVm//1YmY2zTYtGcjvuHXsOUqxIAXbtOwJA/ry55R+U95Ot99DRfzh09J9U65UkiXsPHmJnq5lU1K3lk2reXK7OfO9ThcPH/uHw8VO8DnnD/oO+8j7UqlmDDG1vkqqV3+2fttZW8t9J7czv+72Lv1yK26tlS3vICXXy7UxSq3rVTD/keujYPwwbOxUAB3s7tv2xFAtzs0+O5UPH4ftUqViW23f9CHkTxn2/x3IS0L9XJ/oN+5mzF66Qy8VJnr9yxbSTw++S1ZTZpPFZZ0ZWXb8yQ1vnsuSy4ryTfF+xs7Umbx437tzzQ5IkHj56io21FW1aNpLb5m/fc5D6daqzY7f6boy5mSkN6qibTzxItg9ev3k73W28c98v3cT2cbJmBPnc3bC1eRd/hbKeH0xsU+YDQcEh8r5gYmwsJ7Wg+fklfSa6urpUKFeaw8f+4eZ/94iKiubcxWsYGOjTq2tbhoyezNkLV3Gwf1c5VOXtPm1sbMQPzRqwedtujp04g1fVhujr61O0cAHq1/ZhYJ+umWrGJ5oiZJKV1bvbr8lPrhLvv0WQUlQaD1Yl16XDD2zftJy2PzSmWJGCGBjo8/DxU1Zv2EKdpp002uGk5323vkF9gv8YSQ/VbNyyQ04KKpT1ZPPaRRze9Yd8OxRApfrw5/KhOLNSWmWZmBhzZPef/DRqAN7fVcTRwY6IyCj+OXOB/sMnMC9Fe6r0ODnYc+rQVob270HlCl7Y2ljxJjSMw8f+oWPPIfy9fe+HV5JB1sn3Q93s2w9/Hj2Itcvm0LxxXQoVyItCoeDOPT8W/b6Oxq16kJiYyLPnL+Wk1szUhAUzf+bA9nUc2P6uKYBKUqW5fotkJ6vkPx7M3yYdKX3gTpyGxMREjfanKWXV/vupksfpU7Uizk7qHws79hzkzLlLco8trVs0yvS60/p+k19YkkuqhU9ISOB/uw7I36m1lSW1anyXqXKtLN8lC7rJz5MZ+AI/fN5KO/703Lh1l049h5CYmIixsRF/r19MbreMddP3oVg+5TisUvFdQnfy9Dmu3byNg70dLZvVR1dXl/MXr2q2r02n1tMqWTtavUx+1h/rQ+eNzNDWuSy57DjvpLWr5M+bR06A9x08jt+jJ1y6egOAxg1qyW3ZMyqtB7LTiSZT64X35wMpj4P0joukNuBKpZKtO/fzKiiYUiWKyk01zl+8qtHWNnlN/u8Lp/Lb7F9oUKcG+dxzo1QquX7zNjPmLaVTr6GZ2hZRY5vF7Gytsbay5E1oGGamJvjdOImZqanGPEld7LyPJEnUrlGV2m/bgSUmJjL2l9ksXr6ewFfBnL1wRW6nlyR5o/ew8AjuP3gsv86bxy1VGWntnAXyuXPj7dPLt84fTvPhk6SD66X/uydARwzqJd/uT96c4V3579Zz+eq7p4yVSmW6t6nTUiCfu9wm98DhE1QsVzrd+W7+p26jdunKdbmW6uLlaxrzgPqztrezYfTQvox+e/w8fvKcCtWbEBkVza69hxk+UH1LW0fx7iSoUmkma5IkkdvNVb4tqN7Wm1Sto751tmvfEX74QM1X0u2YT02o8uXNLa8rn3turp7Zh66ursY8KW+7p+eHZg3kuGNj4+jRfxTbdx/kvzv3ue/3mPBkNUM1q39Hzy7qtokZfVr5YxTI5y7XUi5bOI2ObZqlmic6Okajx5OUMrP/AujovDteUn73WRWnjo4OLZvW57dla7l914+Z85fJ87Vp+S6xLfh23wVo37opy39N3Y4+qRuslNK7KDWoUx07W2uCX79h3Z/buH33AQBNGtT64EN4mZXUJAPg4pUbGu8lf518O5Nk5oewf8ArWnT4kYjIKBQKBSt+m5HqAZxPieVTVElWA/v76j+Jj0+gQtlSmJmaUqxIQW7cusOeA+qHBk1NTNKtqctKWXX9gs/zXPapCuRz5/Ax9fF88coN+S7c65A3PHysrjFVKBTkS/ZAdOsWjbhw+TqhYeEMHvWu3XubZD9UCyTbB6tWLseB7etTlZ3e8Zwkr/u7Mh89ecab0DC5Ley5DJyLUx5X9nY2WFlaEBoWTlR0NP/duU+xIgUBuHD5Xa5RINlxkXyfTnquonxZTwoXzIeVpQWXrt6UKwcL5neX222D+kdZt06t6NapFaDujaFZ216cvXCFo76nM9UFmUhss5iOjg4/NKvP8jWbiIyKpnGrHvTp0QFbG2te+Afy35377Np7mKULplKtSvpP+bXvPggzM1OqVPDCxcUJZWKiRrczKburAnVbl8IF8lHSoyi/r95IVLS6MX0pj6KpmiGkp3WLhnJi27Ljjwzu1wNXZ0cCXgVx7/5D9hw4xsA+XenYphm5k7WjWrLyD/QNDLh4+Rrr/tyWar01vCtjZGRIbGwcF69cZ8T4adSs/h1bd+zLcDMEUF/ck0728xevIlGZSLUqFQgJCeWvbbv5ddYEcru50qp5AzmxHTJmsnxhS2rrB/BDM/XDf2cvXGH4uKk0bVCb/PnyYGtjzc3/7hL9th1QXLLPOnmN/V9bd6Orq4Ouri6VK3ix5X97WbX+LxrWq4l7blcszM01nvJ8X+1hEmsrC0LehOEf8Iq/tu4mt5sLDva2GiePjLCxtqL291U5eOQkDx8/5YdOfencrgVmZqY8e/aSazdvs3PvYY7v/eu9g0x837AdpTyK4lW6JC5ODkRGRXHn3oN32xQfr1H7deLUObb8by+6ujpMnLYgUzFnRuvmDeVu9kb/PIM3oWGUKFqIsPAIHj5+ylHfM+TO5cKyhVPTXUdm9l/QrIXcufcQ7rlzoa+vh5enR7oJ9MfE2aZlI/mJ+aQ2oeXKlNTomaOGd2XsbG0Ifh3Cn1t2Ym1lSQ3vyqiUSp48e8m/5y9z87+7XPon4w8QGRgY0KZlYxb9vk7jXPOhH2Mf43vvKtjaWPE6JJTLV28ydMxk6tT05tCRk1y+qv6ha2drrfGwV2bFxsbRosOP8kNHTRrUwtHBjjPnLsnzVK7gpZVY0uLq4iT3RpHUvrJ8WU8AKpQtxY1bd+RmKuW8Smqlj/Gsun7B53cuywqtmtVn6Ur18fz76o04O9pTIF8eFi1fL5/fa1b/TqNJSMum9Rk9YSaJiYny8ezs5CA/KAdQsngRihUpyH937vPPmQv06D+K5o3qoqevx9NnL7h4+Qa79x/hxb1z6cZmb2dDxXKlOXvhCrGxcXTuPYy+PTpw9cZ//G/XgXSXS4/6R3Y9Vq7bDEC3viMZO7wvb0LDmTr73YPgSddRUDdRSLrOJ+3TFcp6olAoKOdVisPH/pHzkpTtrkuUr02ThrXxKF4YZ0cHgoJf8/ipugmjJEnExceLxDYnTRgzmNNnL3Hr9j3OpbidlFFh4RHs3HtYo9/UJA72dnh/VzHV9KKFC/DLDM2nTvX09Jjxy+hU86anX8+OHDl+Ct9/znL7rh+9k/U9l1Kblo2YteB3omNiOHbijHzQVipfhn/PX9aY19rKkrHD+8mJ5ZIVG1iyYgM6OjrkzeOW4e57mjWqQ/vWTdm4eQeJiYlym9gkSbeM+vfqzMEjJzh99hJPn72ky4/DNdbzXaWyDHg7Go4kSVy9/h9Xr2v2HZok+YXdu0p5OenY8Nf/2PCXuoeGqMDbqCQVp89e4vTZS2mtRuMEkJ5qVSqwY88hlEol3fuNBNKvkfuQhTMnyF3kHDxykoNHMtaHcnJBwSEsX7MJ1qTuP7No4fx4FCuMrq4udWt6c+DICd6EhtG1j/qzrlS+jEaXOlmpbJmSjB7ahxnzlhIaFs6YCTNTzdO+ddP3riMz+y+oR5pLqjlK/nn+d+FIuhfUj4nT06MYRQrl1+gtJGUzBFNTE37/dRrtug0kLi6eRb+vS9XzRG43FzKrc7sWGutxcrT/YALzMUxNTVgybwodeg4hISGB31f/ye+r3/Xnqa+vz5J5Uz6pk/jAV8Eag+vs2HOIHXsOacwTFXhbK7Gkp3JFL/niDeokANQJblJCAWl385VdsuL6BZ/fuSwrlC/ryZD+3Zm/aBWxsXGMTnE8OzrYsWDGzxrT7O1sqOFdSaMdfMum9TWaQCgUCpb/Nl3u7mvT37s0HpTOqOkTR1KnWSfi4xM46nuao77qfuxLFCssV/RkxoQxg/nnzAXu3n/IjVt3aNt1oMb7LZvWl7srA/WP47KlPTS62ayQ7MdaUm03QOUU+/SzF/4sXLI6zThS/lj4ENHGNhtYWVpwfO8mfh41EI/iRTA2NsLE2JgC+fLQrFEd1i6bQ3mvUu9dR6+ubWnZpB753HNjZmqCnp4eLs6OtG7RiCO7/0izIXX/3p2ZN308+dxzY2CgTymPomz9Y2mmLkwGBgbs/GsFc6aOo2zpkpibmWJkZIh77lzUrenNkvlTaPz2yWC3XC7s2rKSsqVLYmxsRD733CyY+XOafewCDBvQk9lTxpLHzRVDQwNKlijKlnWL0n0oIj3Lf53OysUzqVq5HJYW5hgY6OOWy5nWLRrJNaqGhgbs3rKaSeOHUqJYYYyNjTAyMqR40UL8Mm4ouzavkm+vFsjnztD+PSjvVQoHezv09PQwMzXBy9OD+TN+YtiAHnLZ9WpXZ9rEkeRzz52qBqVCWU/69uyIZ8li2Nlao6uri6WFOVUqerF++bwM1XzNnT6eFo3rYmdrk6nPJC1uuVw4c+R/DO7XjcIF82FkZIi5mSmFC+ajXasm/L1+Cblcnd67juEDe9Kw7vfkdnPBxNgYfX198ri50qNza/ZuXSvfEly5eCbtWzfFztYaK0sL2v7QmL83LPnkbXifn0YNZNsfS6lVoyq2Nlbo6+vj4uxI5QpeTBo/lPFvn/BNT2b33xLFCrFi0QyKFMr/3iYOWRFn8tuUenp6Gl0LJqlb05t/Dv5N2x8a4+rihL6+Pna21pQsUZQBP3bhjxULMhxjkmJFCmo8FNO8cd0MPTj5MRrW+57jezfRrFEd7O1s0dPTw87WhiYNanFsz5+Z6pf0S43lu2QXd319ffnhpaRkIIk2R1XLiusXfH7nsqwy5afhbFgxn6qVy2FhbiafE3t3a8fpI9vSbL7XpkVjzdctU7eXL12yOP8e/R89Orcmbx43DAz0sbK0oFiRgm/Pt2s+GFv5sp7s/GslZTxLYGCgjmvW5DF0avuuq8LMtOu1sbbi+L6/GD6wF4UK5MXQ0ABTE/W1ceGsCaxdNidVE4bkP8JcnB3lu8XlU+zTKduMTxw7mJrVv8PVxQlDQwMMDQ0oVCAvg/t144+VCzIcM4BCys4W5kK2mzp7kfzUZXpt+ARBEDJq+tzFTJmlHp3oxP7NH+wUXhCEz4MkSWm2Qe/cayhb347mtmnNrxqDRXyNRFMEQRAEgcioKAJfBbN1h/oCWLhgPpHUCsIX5Omzlwwa9Qs9OrWmeNFCxMbFsX33Qba9bWNrY21J9WpZ21b8cySaIqRj9wFf2vUc8cWsNyvKexnwirI1WhERGfVRZf2+dgvDfpr14RmzweqN/2Ps5AU5UnZmTJu/nF+X//HhGbNATn4fH+PPrXvpNWSi/Lpq/Y48eJg9bXQbte2H76nMjT+e5OLVW/g06iK/jouPZ/hPs/Fp1IVOfdJvk/45ioiMomyNVrwMeIVjvrKUrPhuJMBRQ/pkavns1mvIRP7cmnVd5n2pWnUdyj//pt2OPyN8GnXhYrKeaYSvy+Fj/9C6S39KVKhN2WqNmDp7EZIkYWCgbiueNNLa1+ybT2x/mbWEsjVaaQwg8DkpW6MVd5N12yWkrVv75kz7afAnr2fizMXMXbT2vfN8ygV27JBeDOyVdufbn0LbP5i04Z99GyiQL/eHZ8xhR0+c5cnzlxzatoL1SzP/YMznRKFQkNvNhdlTxsqjIgmfLivP41vWzKNqJe21uRW+HNbWlnRp35LCBfNhZmqCgYE+ud1caNeqCScP/J1q5Lyv1TfdFCEqOoYjvv9iaWHGzn3HGNynU06HlGnjRvSXh8ETBEH7Xga8IncuZwwM9D888ydIVCrR1dHJtgFNogJvf3gmQRA+WxbmZiyeNzmnw8hx33Rie/j4GYyNjejbrQ1LVv9F/57tUj3pvnjln/xvzxGMjAzp0rYpPzSpA8Cdew+ZsXAVj548R09Pj5LFCjJ/mrpbrWcvApi5cBX/3X2AuZkZrZvVpV3LtJ+IL1ujFRuXz6JwAXdAfTvW9/QFls+fKN/W7DZgPDoKBV3bN6Nb++Y8fxHA3MVruXH7PkaGhjRt8D3d2jfL0NPLf/y9h227DvE6JBRrK0vatWxA62aaQ70e8f2X1Ru3Ex0TQy2fygzr1wV9fT15u+cv28B9v8dYmJvRuU0TmjXM2K/Ahb//weHjZwiPiMTRwZbenVtR06fSu3JPnGXRio28CQunlnclgkNCKVooH727tCI6JpbxU3/lxn/3iE9IoFA+d0YM7Eqhtx1b/752C/f8HjN38kj5cx09uAdbdhwk8FUwZUoVY/KYAZiZmRAfn8D0BSs4eeYSicpEHO3tmDCyDzf+u8f+I6dQKGDHvqM4O9qzZc08jW2Yv3Q9V2/c5sZ/91i6+i9KlyxKwzo+/Ll1L2sXq/siHTFhDtdv3ePg1uXyMgkJiYwc2I2JMxdjbmrKsP5dAHj63J/5S9dz4797qFQqvEoVZ/YkdXdZGf2e79x/xPT5K0hUJlK1fkcA/l4zHwCVUsXMhavYf+QfTE2NGdS7I7Wrq9tYSZLE5u37+Xunen8oVMCdMYN7aAymkVyjtv1o3qgmx/85z8MnzylTsiiTxw5k6eq/OHD0FNZWFkwc1Y9SJQoD6kFFVm7Yxv4jp4iMiqJk8cKMHdITezv1U9J+j54xec4yHj5+RtHC+SlWOL9GecmPjTv3HzH7t9U8evIcHR0dypfxYOTA7lhZqnsH6TVkIiWLFeLO/Udcv3UXN1dnfhnd7701vk+e+9Ol3zgePn5GkYJ5mTR2AE5vOwz/0L6afH/YvH0/kkqiav2OdGjViN5dWmnM88L/FVPn/s6tuw/Q1dHBPXculswej5GRIY3a9qNpg+85dvIcz18G4FGsEBNG9pE/o7I1WjFiQDe27T7Msxf+HNm+ijdvwtLdLwICg5k0Zyn3HjxGqVRRsnghRg3qjsvb0czi4xOYu3gth33PYGZqQrf2zVNt0/t8aPn37VMb/97DP/9eYtm8CfL8h46f4fe1W9i2bgEAB4+dZs2f2wkIDCZ3LmeG9esi708pnb1wjV9XbOSFfyC5nJ0Y2Ls9FbzUbYInzlyMQqEgPCKS85du4OriyOhBPfD0KAKo95fiRQpw595Dbty+T4G8uZk1cRjb9x7h750HMdDXZ8SAblSvWv6D2wXqY6Nlk9rqYyPF/pTeeTy56fNXYGZqwoBe7ZEkiVrNe1CujAfT396F6tB7FF3bN+P7ahVp1LYfw/p1xue78uw+4MumbXupUa0Cm7cfQKFQ0KVtU/l6o1Kp+H3tFrbvPYqOjg7d2ms+XCxJEhv/3sPfOw8RERlJ8SIFGDWoB7lcHDl0/EyGz2uC8FmRvmFd+o2V5i5eK0VFx0jf1esgHT1xVn5v1/7jUvnvW0uLVv4pxccnSNdu3pWqNegkXbp6S5IkSerab5y0csM2SalUSnFx8fL0hMREqXmnQdKCZRuk2Lg46d6Dx1Kdlr2k/Uf+kdfbtsdwuRyv6j9Id+4/kl9v/HuP1HPwhHTfj4mJlRq26Stt/HuPFB+fIPkHBEk/dB0qbd97NM1tTFnekRP/Sv6BQZJKpZIuXL4hVa7TTrpy47YkSZL0wj9Q8qr+gzRg1DQpPCJSehX0WmrbY7j0+9otkiRJUtDrN1KNJl2lQ8dPS4mJSun+wydSnZa9pHOXrkuSJEnL1myWho6fme7nve/wSel1SKiUmKiUDhw9JVWq3U56/jJQkiRJevz0hVS5Tjvp9LkrUkJiovS/3Yel8jXbSMvWbJYkSZIiIqOkg8dOS9HRMVJsXJw0+7fVUrOOAyWVSpVm2V7Vf5B6D5kovQ4JlcIjIqV2PUfK69q2+7DUvtdIKTwiUlKpVNLjpy8k/8AgSZIkacKMRdKc39akuw2SJEk9B0+QNv69R34d/PqNVL5mGykyKlpSqVRSreY9pEZt+0oPHz+TJEmS2vYcIR07eS7V+qOjY6QGrftIi1ZslKKjY6T4+ATpwuUbWfI9J30mFWq1kb+v3Qd9par1O0qRUdGSJEnSlh0HpDbdh0tPnr2UEhITpU3b9kpN2veX4uMT0iyjYZu+UtsewyX/wCApIiJK+qHrUKlZx4HS0RNnpcREpbRszWapdfdh8vwLlm2Qfhz6ixQUHCLFxydI85esk3oM/FmSJPVx0rhdf43jq3rjLunu+3cfPJKuXL8tJSQkSMGv30g9Bv4sTZ69VOM7qfdDb+nug0dSQmKiNGXOMo11pbUtrbsPk56/DJRi4+KkAaOmSRNmLJLff9++euHKTcm7YWeNz/l9+/3YyQukqfN+lxISEqSEhATp6o078mfcsE1fqVHbvtKjJ8+lmJhY6efpv0m9h0zU+Ay69hsnvQp6LcXFxX9wv3jhHyidOntZio2LkyIio6SRE+ZKfYZPkte3dPVfUtsew6VXQa+l8IhIacCoaZJX9R+kF/6B6caf3IeWf98+Ffz6jVShVhv5WJMkSRo0Zrq0csM2SZIk6Z9/L0n1fugt3b7rJymVSunoibNSjSZdpTeh4ZIkaR53T5/7S5XrtJOOnjgrJSQmSod9/5Uq120vf0cTZiySKtVuJ504fUFKSEyU/t55UKreuIsUHhEpr6t+qx+lBw+fSnFx8VKf4ZOkJu37S5u27ZUSEhOl7XuPSjWadJMSEhI+uF0Z2Z9SnsdTOnT8tNSpzxhJktT7euN2/aXaLXpKkiRJYeERUvmabaTQsAi5rOP/qM8nu/Yfl8rXbCNt2LxLSkhIkC5cuSmVr9lGevbcX5IkSdqx76hUv9WP8v41ccZiqdz3raQLV25KkiRJuw/6SnVb9pLu+z2RYuPipHlL1kk/dBkiJSQmZuq8Jgifk2+2je3Dx8+58d99GtbxxsTYCJ/vyrNz/zGNeYyMDend+Qf09fUoWbwQdb//jr2H1R1D6+npEhAYRNDrNxgY6FOmVDEAbt6+T3DIG/p2a4OhgQEF8+ehVdM67D7gmyVxnzp7GXNzU9q1bIC+vh5Ojna0bV6Pg0dPZWj576tVxMnBDoVCQdnSJahYrhSXrmoOTNCr8w+Ym5lib2dDl3bN2Pd2m/cdOklpj6LU8qmMrq4OBfLmplFdHw5ksOx6NatiY22Jrq4OdWpUwT23C9dvqTuNPux7hnJlPKhc3hM9XV2aNaxJnlzvRkszMzWhdvXKGBsbYWhgQO8urXj63J+g4DfpltepTRNsrC0xNzOlRrUK3Ln3EAA9XV2iY2J59OQFkiSRx81Frqn7GLY2VuTJ5cyV67e5++AxTg52fFfRi4tXbxEWHonfo2d4eRZLtdw/Zy+jp6dL3+5tMTY2Ql9fj7Kl1f1Yfur3nKRIwXzy99WgVjUSEhN5+nakt793HKR311bkzuWMnq4ubZrXJy4unpu376e7vhaNa+PkYIeZmQlVKpTG0sKMGtUqoKurQy2fyvg9ekZCQiKSJLF150GG9O2Ena01+vp69Onehmu37hDwKpgbt+4RGh6ucXzV8kn/ad1C+d3x9CiCnp4etjZWtP+hAZeuae639WpWpVB+d/R0dWlQx1v+vtPTsnFtXJ0dMDQwoF7N77idbP737auZpaenS/DrUF4GBKGnp0epEoXlOyBJn6l7bleMjAwZ2KsDF6/eIjDotfx+pzaNsbezwcBA/4P7hYuTA1UqlMbQwEBdo9qhOVev35GHAN5/5BRd2zfD3s4GczNTenVOu8/e9Hxo+fftU7Y2VpQvU5IDR9SxhrwJ49yl6zSoVU297M6DdGzdmCKF8qGjo0ONahXI4+bK6XNXUsVx6PgZvDyLU6NaBfR0danpXRHPEkU4eOzd8VG2dAmqVS6Lnq4uLRvXxsbaSuOhq3o1q5I/r7q/0OrflScmNo42zeujp6tL3RpVCAuPwD8w+IPbleR9+9OHeJUqzp37j4iMiubC5ZvUqFYBK0tzHj5+zqWr/5E/rxuWFmZpLmtlaU6HVo3Q09OjrGdxXJzsuev3GIADR07Rqlldef/q37OdxhC3+w6fpHXzehTIlxtDAwP6dW9LYNBrbt1+8NHnNUHIad9sU4Sd+49RKH8e+VZ2wzreDBw1jVdBITjYq28D2tvaaDRNcHa05/Lb0al+HtGH5eu30vHH0ZibmdKqaV1aN6vLq6AQ7G1tNC5crs6O7D/ybsSNT/EyIAi/R880nsqWJAlHe9sMLb//yD/8sWUP/oGvUKkkYuPi5NuUSZwd7TT+DgoOAcA/8BWnz1/RKFulUuHpUTRDZW/8ew879x0jMPg1ChTExMQSGhYBQFDwm1Tb4JQsjti4eBYsXc/pc1cIj4iU2xmGhofL31dKtjZW8t/GRoZEvR0it37tagSHvGH6/BUEBgVTrXJZBv/YEStLizTXkxFensW5dPUWtjZWlC1dnJLFCrH/yClsrC0pmC83FuapL0r+gUHkcnFKs83kp37PSWxt3g0Dq1AoMDQwICo6Rl1GYBA/T/tNo2lDQmKiRlKVan3W79ZnZGiATfLXRgZIknqfSoxSEhMbR8/BE1Dwbvv09fQIfPWaoNdv0jy+Hj19kWa5z14EMH/pev6760dMTCwqlSpVsyHN79tIHhI5PXYp9o/o6Hfzv29ffZ/9R/5h2rzl8vZsWTOPQb07snzd3/QdPhmFQkHDOt707NRS/tydHe01tsFAX5+g4BD5u07+o+tD+8Wb0HDmLFrD1Rt3iIxSD10Zn5BAdHQsZmYmBL8O0SjPKdnfGfGh5T+0TzWoXY1VG7bRpV1TDh47TcniheXj3D8giMWrNvH72i3ysolKpXz+Se5V0GuNOABcXRx4FfRu3uTnsaTXr5KtS2PfNTTU3LeNDAHkfSgjx8r79qcPsbG2JI+bC1dv3OHilZu0bFKHxIRELl69yeOnLyn39gdvWpLHnbLsoNdv0ty/krwKCtE4/xsYqAf5eBWs3q6POa8JQk77JhPbxMRE9h0+SXRMLHVa9ARAApQqFbsP+tK9g7r9U9DrEBITE+ULaMCrYLntWy5XJyaN6Y8kSVy7eZe+wydTsnghHOxtUi3nHxCEg13aCYnx23GVkwSHaNZApkx6HB1sKVoon9zuKTMCAoOZOGMxv84ci5dncfR0ddXdQaUYosM/MFhOEpJvs6O9HT7flZfbfWXG1Rt3WL7+b5bNnUDhAu7o6OjQrucIpLfjg9jbWXPz9oNU8RYvUgCAP7bs5va9h6z8dRKO9rZEREZRvXFXPmZ4ET1dXbq1b0639s15HRLKuCkLWb5uKyMHdsvQgzk6acxTtnRx1v65AxtrS9o0r0eJogWZPn8F1lYWlPUsnuZ6nB3tef4yIM1OtTP7PSt0Mv9AkaO9LcP6daFyec9ML/shlhZmGBkZsm7xNNzTGG72yvXbaR5f6Zk+fwW5c6nbzZqbmeJ76jwTZ2bPyGYf2lffp17NqtSrWVVjmo21JaMHq0eve/DwKf1GTKZAvtx8X009LLZ/YJA8b8ibMOITEuRjDkCRLJn60H6xaOWfxMbF8cfvM7G2suDug8e07zUS6e1Bbmdrg39gECWKFgTUx1hmfGj5D+1T3lXKMW3+cm7fe8i+wydp2aS2xra1alaXlo1rp7lscg72tly7eUdjmn9AEKVLvvuR7Z8itoBXwTjYfdwoWJ96rGTkvFLWszjnLl7n+n/3mfrTYBITlew9fILHT14woFf7jyrX3tY6zf0riYO9jUZXbQkJiQS/fiNfrz7mvCYIOe2bbIpw4sxFoqJi2Pj7TDaumM3GFbP5c8VsenRswa79x+ULWGxMHCs3bCMhIZGbt++z/+g/1Pv+OwD2HDrB65BQFAoFZmYmKHQU6OjoUKJIAWytrVi2Zgvx8Qk8ePSUzdv307COd5qxFCmYj32HT5KoVHL3wWP2Hdas2bWxtuT5ywD5ddVKXoS8CeXvnQeJi49HqVTx+OnLDPVLGB0Ti4SEjZUlOgoFp85e5uzF66nmW7lhKxGRUQQFh7Dmzx3yhbp+rWpcvHKToyfPkpiYSGJiIncfPObWnQep1pFSZFQ0ujo6WFtaoJIkdu4/ht+jZ/L7Nb0rc/7SDc5euEaiUsnO/cd48vaWOah7sDA00MfCzJTomFgWr9z0wTLTc+HyTe4+eEyiUomxsREGBgbo6qoPBVtrK577B743iVF/J4Ea07xKFeOe3xNu/HcPzxJFMDczxcHelv1H/5GbF6T0XcUyJCQksmzNZmJiYklISOTilZtA5r9nW2tLgkNCiY2Lz/Dn8EOTOixbs5nHT18C6u/I9/QFuUb3U+jo6NCiUS3mL10vJ6yhYREcOn4GAI9iBbE0N9M4vg77nkl3fZFR0ZiYGGFqYkzAq2DWb979yTG+r6z37auZddj3DAGBwUiShJmZCTo6OvJQxAD/232Ex09fEhsXz2/LN1KmZNF0a+Y/tF9ERUVjZGiIuZkJoWERrFj3t8bydWpUYe2fOwkKDiEiMoqVG7ZqvH/x6i3K1tB8+C0zy39onzIyNOD7ahVZsmoTD588p6Z3JY1lN2xW/4CVJInY2DjOXbqe5h2E2tUrc+nqLXxPXyBRqeTYyXNcvn6b2tWrvNuWKzc5dfYyiUol2/ccIfh1KN9VLJPutr3Ppx4rKc/jaSnrWZxdB4+TJ5czJsZGeJUqxoXLN3ny3F8jYc+MOjWq8PeOg/L+tWjln+gk+xFcv2ZV/t5xkIePnxMfn8CS1X9hb2dD8aLqCoWPOa8JQk77Jmtsd+47/rbdnGZNUpvm9diweRcXr6gvEvnzuqFUKqn7Qy+MDA3p262tfDCfv3SD337/g+iYWGysrRjUu4Pcs8H8qaOY9etq6rTshYW5Ke1/aEjdtwlxSiMGdmXijMVUb9SFUiWK0LC2N9f/uye/36dra+b8toYpc36nc5smdGnXlCWzf2Lh8j9YuX4rcfEJ5HJxpGPrxmmuP7l87rno1r45Pw6bhEqlolplL6pVLptqPu/KZWnXcyRR0dHU9KlE13bqJ2kd7G34beY4flu+kWnzViBJKtxz5+LHrulfCJNULu/J99Uq0rrHMAz09alfq5rG087uuV2YOLof0xesJDRc3StCudIl5C6U2v/QkPFTFlK7RU+sLC34sWtrtu469MFy0/L6TSgzf11F4KtgDA0NKF/Gg16dfwCgaf0ajJ40nxpNuuHoYMtfK+ekWr5dywZMnLkEn0Zd8PQowoJpo7GytCBfnlyYmBjJY3GXK1OCe35P5PbXKZkYG7F49k/MW7KOhm37Aupbf2VLl8DE2ChT33O50iUoUbQg9Vv1RqWS0ow7pdbN6qKrq8PICXMIDHqNibERnh5F3nvbMzP692jHur920mfYJF6HhGJpYU65MiWoXb0yenp6zJsyislzlrHx7z0UK1KAxnWrc+uuX5rrGtq3M9PmLefvHQfJncuFerWq8vDxxyeb7/OhfTWzbt97yPwl6wmPjMLCzJQm9Wvgney4a1yvOuOmLOT5ywBKFC3I5HED013Xh/aL3l1aMWHGYqo37oqDvS3tf2iI7+kL8vLdOzbnTWgYrbsPw9TEhO4dmnPq7GX5/YBXwZQsnv62fmj5jOxTDWp703vIROrUqIKpibE8vVrlssTHJzBlzu+88A/EwECf4oXzM2pQj1RxuLk6MeuX4Sxe+ScTpi/C1dmBOZOGk8vFUZ6nzvdV2L73CGMmzcfF2YG5k0d89K3zTz1W0jqPp+TlWZzo6Fj5GmNmZkLuXM7qyhNTk4+Ku3G96rwIeEXPwT+/7RWhOcdOnpPfb1Dbm9dvwhgybgbhEVEUL1KA+VNHoff2h9fHnNcEIacppIzcXxOEHNC80yB6dmqZ6tauIHwtknfd9Dn4ZeYSateoTKVynjkdyidJ2a2eIAjfjm+yxlb4PJ08cxEvz+Lo6+mxZccBXoeEfvEXWEH4kkwY1TenQxAEQfgkIrEVPhv/XrjGxJmLSUxUksfNhblTRsod8AuCIAiCIHyIaIogCIIgCIIgfBW+yV4RBEEQBEEQhK+PSGwFQRAEQRCEr4JIbAVBEARBEISvwjf38JhKpeLly5eYm5tnaDQYQRAEQfgaSZJEREQELi4uGsMFC8KX7JtLbF++fImbm1tOhyEIgiAIn4Vnz56RK1eunA5DELLEN5fYmpuru4969uwZFhYWORyNIGhf5z5jAFi3dHoORyIIQk4KDw/Hzc1Nvi4Kwtfgm0tsk5ofWFhYiMRW+CbpGxgCiP1fEAQA0SxP+KqIRjWCIAiCIAjCV0EktoIgCIIgCMJX4ZtriiAI3zpXF8ecDkEQBEEQssU3N6RueHg4lpaWhIWFiTaGgiAIwjdLXA+Fr5FoiiAIgiAIgiB8FXI0sT158iSNGjXCxcUFhULBjh07PriMr68vZcqUwdDQkAIFCrB27dpsj1MQviZbdhxgy44DOR2GIAiCIGS5HE1so6KiKFWqFIsXL87Q/I8ePaJBgwZUr16dq1evMnjwYHr06MHBgwezOVJB+Hps3XmIrTsP5XQYgiAIgpDlcvThsXr16lGvXr0Mz79s2TLy5s3L3LlzAShatCinTp1i/vz51KlTJ7vCFARBEARAPQwtfODRlCx5dCXtdciPxUgSUop5kj8yI0kS72aV0pwnNiYqC+IUhM/LF9Urwr///kvNmjU1ptWpU4fBgwenu0xcXBxxcXHy6/Dw8OwKTxAEQXhLUilRxkeijA9HmRCNKjEGVWIsqgT1/5IyHpUyDkmVoP4/MR5JlaBOvCQVEiqQVOoETlL/LUkqQEKSlOrkUVK9TeCUKJWJJCYkoFQmokxMRKVSIqmUSEnLJVsPqN4meCoUcqKq/qd4+w8kFAoJBainKUChAJ10xjKQVBKSUgVK9f+SUlL/naj+W1KpQIU6DpWkjl/1NtGUAJX07m/ehpP0Itk0iZTzyG9oTNN4Llx+T3N9UXHKTHyjgvBl+KIS24CAABwdNbsqcnR0JDw8nJiYGIyNjVMtM336dH755RdthSgIgvBVklSJJEQHEx8VSGLMa5RxESjj1f8S3/6ffJoqITrHYtV9+y8Vxdt/HyCpJKQEJVK8ClWCElWCSp2gJmomrslff6gSVxAE7fiiEtuPMWbMGIYOHSq/Thob+2sjSRK9e/dm69atvHnzhitXruDp6fnR6+vSpQuhoaEZeqBPEIQvnySpSIgOIiEykPioQBKiX6n/jwokIeoVCTGv39Z2Zj2lpEuCUkFCokSiUklCgopEpRLl2xpN9f+gVKlvrysldfKpTKr4VEmoJFCpQCVJb/9PPv3t/xp/S+ipJIxRYSypMNUBE4UKU4UKI0X2ZKkSClQKHSSFDigUSG//lhQKePu/pEjKvtX1xupE/G118dt1KBTq/9XTSTZvUtaefD1Jk9TrkFCgACSFgqjYBOBqtmyrIOSULyqxdXJyIjAwUGNaYGAgFhYWadbWAhgaGmJoaKiN8HLUgQMHWLt2Lb6+vuTLlw87O7ucDumDfHx88PT0ZMGCBRleZuDAgZw+fZqbN29StGhRrl69qvH+48ePyZs3b6rl/v33XypWrPiJEX8dKpQtmdMhCDlMGR9FbKgfMW/8iAt9TGzYY+LCnyMp4z68sAYFugam6BqYq/8Zmr/7O9k0pWTAo2evuOP3jDv3n3PzziNu3H5ISFg08YkZTyINDQ2wt7PFztYaG2srrC0tsLKyxMrSAisrC6wtLTA3N8Pc3AxTE2MMDQzQN9BHLzEGRehjCHuJFPaCxJDnJIQ8QxWX8VplhY4ueiZW6BqZomtsjp6xObpGZugamaNnbKb+29gcPSP1dD1jc3STphuZoWtggkLn8+phMzw8HH6xzOkwBCFLfVGJbaVKldi3b5/GtMOHD1OpUqUciujz4efnh7OzM5UrV87pUIiPj8fAwCDb1t+tWzfOnTvH9evX053nyJEjFC9eXH5ta2ubbfF8aYb165LTIQhaJEkSCVGBRAfdIiroJtHBt4mPeJ6BJRXoGdtiYOqAvqkj+qYOGLz9X9/EHl0DC3T1TVDopL7pH/gqmH/+vcCZs5c4d+kqN27dJTEx8b2lGRkZ4p47F64uTrg6O8r/u7g44ershKuLI1aWFigUH25LEPcmgLD7Z4l4cIWIx9eIev3h7dXRN8LIwR1je3eM7NwwsHLEwNIRAwt79C3s0DO2+OwSU0EQUsvRxDYyMpIHDx7Irx89esTVq1exsbEhd+7cjBkzhhcvXrB+/XoAfvzxRxYtWsTIkSPp1q0bx44dY8uWLezduzenNuGz0KVLF9atWweAQqHA1taWihUrsmfPHgAWLFjAkCFD2L9/P3Xr1gWgQIECjB49mh49eqBUKhkxYgSrV69GV1eX7t27k5kB6Xx8fChRogR6enr88ccfeHh4cPz4cW7evMmIESP4559/MDU1pXbt2syfPx87Ozu6dOnCiRMnOHHiBAsXLgTU37+7u/t7y/r1118BCAoKem9ia2tri5OTU7qfV2hoKOXLl2fhwoXExcUxdOhQxo4dy5gxY1i1ahUmJiZMnjyZrl27ZvhzEITPhaRSEhV0k4jn/xLx8hwJ0UHpzqtraIGRpTuGlnkwtMiNgbkzBqaO6BnboaOrn6HyYmPjOHnmPEd9T3P85L/cun0v3XktzM0oUawwxYoUoGjhghQumI+C+d1xcXZE5yMTR2VsFOF+Fwm7f46w++eIDXqS7rx6ZjYYv01gjR3zYmTvjrFDXgwsHUTiKghfgRxNbC9evEj16tXl10ltYTt37szatWvx9/fn6dOn8vt58+Zl7969DBkyhIULF5IrVy5Wrlz5zXf1tXDhQvLnz8/y5cu5cOEChw8fZsCAASiVSnR1dTlx4gR2dnb4+vpSt25dXrx4gZ+fHz4+PgDMnTuXtWvXsnr1aooWLcrcuXPZvn07NWrUyHAM69ato0+fPpw+fRqA0NBQatSoQY8ePZg/fz4xMTGMGjWKVq1acezYMRYuXMi9e/coUaIEkyZNAsDe3j7LPpPGjRsTGxtLoUKFGDlyJI0bN9Z4/9ixY+TKlYuTJ09y+vRpunfvzpkzZ6hWrRrnzp1j8+bN9O7dm1q1apErV64si+tzMHfxWkDU3H5tVMp4ogKuEP78XyJenkcZn7oHGB09Y4xti2BiWxhjm4IY2RRAz8gmQ7WgKUVERrHv4HF27j3E4WOniI6JSTWPgYE+Xp4elPMqRdnSHpQpVQL3PLk+qryUVAmxvLl9itdXDxJ65zRSYnyqeXSNzDDLUxJz95KYuZXAxLUI+qZWn1y2IAifrxxNbH18fN5bM5jWqGI+Pj5cuXIlG6NKbcT4ady4dUerZQJ4FC/C7CljPzifpaUl5ubm6Orq4uTkRKNGjejSpQtXrlzBy8uLkydPMmLECPlBMF9fX1xdXSlQoACgrtEdM2YMzZs3B9T9BWd20IuCBQsya9Ys+fWUKVMoXbo006ZNk6etXr0aNzc37t27R6FChTAwMMDExCTdmtWPYWZmxty5c6lSpQo6Ojps27aNpk2bsmPHDo3k1sbGhl9//RUdHR0KFy7MrFmziI6OZuxY9ec9ZswYZsyYwalTp2jTpk2Wxfc5OHcx/Zpu4cuiTIgm0v8C4c/PEul/EVViiuRSoYOpgwdmzmUxtffAyCpvmk0HMioxMZHDx/7hz793se/QcWJjNdvk6unpUa5MSapXq4T3dxUoW7okRkZZ94yDpFISdv88r68eIOSmL6o4zX5YFbp6mOUpiWWhilgWrICpa5FP2l5BEL48X1Qb25xy49Yd/jlzIafDyDArKytKlSqFr68vBgYGGBgY0KtXLyZMmEBkZCQnTpzA29sbgLCwMPz9/alQoYK8vJ6eHmXLls1UcwQvLy+N19euXeP48eOYmZmlmtfPz49ChQp95Na9n52dnUYvGOXKlePly5fMnj1bI7EtXry4xm1PR0dHSpQoIb/W1dXF1taWV69eZUucgvCxJEkiKvAab/z2E/HyHJJKs+2qQtcAM6cyWLhWwsylPHqG5p9c5vMX/qxav5n1m/5HQKBmswYrSwvq1fahQZ0afO9TBQvz1Mf8p4qPCObV2e0End9BfJjmA8S6RqZYl6iBTYkaWOT3QtfQJMvLFwThyyES2wzwKF7kiyvXx8cHX19fDA0N8fb2xsbGRh6p7cSJEwwbNiwLIwVTU1ON15GRkTRq1IiZM2emmtfZ2TlLy/6QChUqcPjwYY1p+vqabQcVCkWa01Sq7OneSBAyS5UYS+jjY7y+tyvVw186+iaYO5fDPFclzJy80NVPu5eYzLpw6RqLfl/H9j2HUCrfdeZvamJCo/rf80OzBtSoVinbHhaNDXrKyxMbCL60B0mZIE9X6BlgXbQqtp51sCpSBR39r7/nG0EQMkYkthmQkeYAnxtvb29Wr16Nnp6e/MCYj48PmzZt4t69e3L7WktLS5ydnTl37hzVqlUD1LcbL126RJkyZT66/DJlyrBt2zbc3d3R00t7NzMwMNC4WGaXq1evaj2ZFoSskhgXQciDPYTc263Rblaha4CF23dY5vbG1KFkhh/0yoiTp88zfe4STp4+pzG9XJmSdO3wA82b1MPczDSdpT9d1Mu7vDy6mpCbxzSGpzVxKYxjxRbYeNZGzyjra4YFQfjyicT2K1WtWjUiIiLYs2cPM2bMANSJbcuWLXF2dtZoCjBo0CBmzJhBwYIFKVKkCPPmzSM0NPSTyu/Xrx8rVqygbdu2jBw5EhsbGx48eMBff/3FypUr0dXVxd3dnXPnzvH48WPMzMywsbH54FPRDx48IDIykoCAAGJiYuR+bIsVK4aBgQHr1q3DwMCA0qVLA/C///2P1atXs3Llyk/aHkHQNmVCNK/vbuf13R0abWf1TR2xKdAA63y10TXI2uTuzLlLTJqxUKPplb6+Pi2a1KV/r86ULlX8PUt/uphXj3l+cCkhN45qTLcqVg0Xn06Y5SmVJQ+eCYLw9RKJ7VfK2toaDw8PAgMDKVJE3aShWrVqqFQquX1tkmHDhuHv70/nzp3R0dGhW7duNGvWjLCwsI8u38XFhdOnTzNq1Chq165NXFwcefLkoW7dunLyOnz4cDp37kyxYsWIiYnJUHdfPXr04MSJE/LrpAQ2+bKTJ0/myZMn6OnpUaRIETZv3kzLli0/elu+Ni2b1M7pEIT3UCkTCHmwh+D//taooTWyyo9d0RZY5KqS5Q9EPXj4mHG/zGHPgXcJpbGxEd07tWbgj11wdcm6BzzTkhgdxvPDywn8dyuo3t7F0dHFrnRdnH06Y+KYL1vLFwTh66GQMvOE0FcgPDwcS0tLwsLCsLCwyOlwBEEQZBEvL+B/+XcSogLkaUbWBXAo0R4z57JZXlsZFRXNzPnL+HXZWhIS1G1YjYwM6dW1HYP7dsPRIXtHMJQkiaCLu3i291cSo9/+kFYosCtdD9davTCy/bq62vvciOuh8DUSNbaCIAg5LCHmNQGXlxP+/LQ8zcA8F44eHTHPVTlbbr/vP3ScwaMn8/yFvzytQ5tm/DxqYLbX0IK62cGjbdOIeHRZnmaRvyy5Gw3F1CV7ek0RBOHrJxJb4b2ePn1KsWLF0n3/v//+I3fu3FlS1o8//sgff/yR5nsdOnRg2bJlWVLOt27IOHVPFfOnjsrhSARJpSTkwT5e3Vgvt6PV0TfFwaMDNvnrZ0sfrCFvQhkxfhp/bd0tTytbuiTzpo/Hq7RHlpeXkiRJvPp3K0/2LEBKVPeDq29hT57Gw7Dx+F60oRUE4ZOIxFZ4LxcXF/kBrfTezyqTJk1i+PDhab4nbpNlnRcvAz88k5Dt4sKf8+LcfGJC7srTLHJXw8mzJ/rG1tlS5snT5+nWdwT+Aer+mS0tzJn80zC6dvjho4ezzYyEiNc8/HsyoXdOqScoFDhWbkWuOn1ELweCIGQJkdgK76WnpyePUJbdHBwccHBw0EpZgpBTJEnijd8BAq6uRFK+rbE0dcTFqy9mzl4fWPrjqFQq5ixczuRZv8l9M9et6c1vc37BxdkxW8pMKez+OR78OZ7EqDcAGFg5kr/1L1jkL6uV8gVB+DaIxFYQBEFLlPGRvDi/kIgX/76dosC2UBMcPDqgo2eULWUGv35Dj/6jOHzsH0D9cNicKWPp0uEHrdz2lySJgJN/8HTfbyCpk2rbUrVxbzYaPRNxJ0YQhKwlEltBEAQtiA19xLPT04iPVD+spWdsS64KwzB1LJltZZ69cIVOvYby4qW6l4WC+d3ZsGIBHsULZ1uZySnjY3m0dQqvrx4AQEffEPfmY7Ar00C0pRUEIVuIxFYQBCGbhT07xYtz8+WmB+Yu5XEpPxg9w+yrsVyzYQuDR08mMTERgBaN67Jo3mQszLXTljUuNIB7a4cR/VLdhtjA2plCnedg6qKdpFoQhG+TSGwF4RszpG+nnA7hmyFJEsF3tvHq+tq3UxQ4eHTErmj2NQNQKpWMmzSH35apy9TX12fmpFH06tpOa7WkUS/vcXf1IBLCgwB1N14FOsxA39RKK+ULgvDtEomtIHxjKpXzzOkQvgmSSon/5WW88dsPgI6+CbkqjcTcOfseloqJiaV7v5Hs3HsYAHs7W/5a+xsVy5XOtjJTCve7xL11Q1HGRgHgWPkHcjcaho6uuNwIgpD9xJlGEAQhiykTYnj+70wi/S8CoG9iT+6qEzCycs+2MkPDwmnVqS+nz14CoGjh/Gz743fy5HbNtjJTenPrBPc3jkFKjAcgd4PBOHt30Fr5giAI2d9xoaAVkiTRq1cvbGxsUCgU7+17NiO6dOlC06ZNsyQ24fPSqutQWnUdmtNhfLUSY8N4fHysnNQaWeUjb8052ZrUBgWHUL9FFzmprVq5HEd2/6nVpPb19SPc3zASKTEehY4u+dtMFkmtIAhaJxLbr8SBAwdYu3Yte/bswd/fnxIlSuR0SB/k4+PD4MGDM7WMQqFI9e+vv/7KngAFIZMSooN5dGwUsW/uA2Dm5IV7jRnoG9tmW5kBr4Ko17wT127cBqBJg1rs/GslVpba60rr9dVDPNg4FkmlRKFnSMHOc7ErU09r5QuCICQRTRG+En5+fjg7O1O5cuWcDoX4+HgMDAyybf1r1qyhbt268msrK6tsK0sQMio+MoDHvuNIiFKP7GaZpzqu5Qeh0Mm+02zAqyDqNevMvQePAGjXqglL509BT097p/aQG0d58NdPIKnQ0TekUJf5WBYsr7XyBUEQkhM1tl+BLl26MGDAAJ4+fYpCocDOzo6GDRvK7y9YsACFQsGBAwfkaQUKFGDlypWA+inqoUOHYmVlha2tLSNHjkSSpAyX7+PjQ//+/Rk8eDB2dnbUqVMHgJs3b1KvXj3MzMxwdHSkY8eOBAcHyzGfOHGChQsXyjWvjx8/zlB5VlZWODk5yf+MjN51bD9x4kQ8PT1ZvXo1uXPnxszMjL59+6JUKpk1axZOTk44ODgwderUDG+fIHxIfKQ/j46NlpNamwINcK0wJFuT2ldBr2nQoquc1Hbt8AO/L5ym1aQ29M5pHvw5Dt7W1BbqukAktYIg5ChRY5sB/peXExv6UOvlGlnlw7lMrw/Ot3DhQvLnz8/y5cu5cOEChw8fZsCAASiVSnR1dTlx4gR2dnb4+vpSt25dXrx4gZ+fHz4+PgDMnTuXtWvXsnr1aooWLcrcuXPZvn07NWrUyHCs69ato0+fPpw+fRqA0NBQatSoQY8ePZg/fz4xMTGMGjWKVq1acezYMRYuXMi9e/coUaIEkyZNAsDe3j5DZfXr148ePXqQL18+fvzxR7p27arRjZGfnx/79+/nwIED+Pn50bJlSx4+fEihQoU4ceIEZ86coVu3btSsWZMKFSpkeBsFIS3xkQE8Pj6WxBj1jza7Ii1xKNk5W7vWehMaRqNW3blzzw9QJ7W/zp6Ijo726iqint/m/oZRSMpEFLr6FOoyF8sC5bRWviAIQlpEYpsBsaEPiQ66mdNhpMvS0hJzc3N0dXVxcnKiUaNGdOnShStXruDl5cXJkycZMWIEO3bsAMDX1xdXV1cKFCgAqGt0x4wZQ/PmzQFYtmwZBw8ezFQMBQsWZNasWfLrKVOmULp0aaZNmyZPW716NW5ubty7d49ChQphYGCAiYkJTk5OGS5n0qRJ1KhRAxMTEw4dOkTfvn2JjIxk4MCB8jwqlYrVq1djbm5OsWLFqF69Onfv3mXfvn3o6OhQuHBhZs6cyfHjx0ViK3yS+KhX6uYH0er+Wu2KtsLBo2O2JrXR0TG07NCHm/+pBz7o2Ka51pPauDf+3F0zGFVCLCgUFGg/HatCFbVWviAIQnpEYpsBRlb5vqhyraysKFWqFL6+vhgYGGBgYECvXr2YMGECkZGRnDhxAm9vbwDCwsLw9/fXSPD09PQoW7ZsppojeHl5aby+du0ax48fx8ws9ShHfn5+FCpU6KO27aeffpL/Ll26NFFRUcyePVsjsXV3d8fc3Fx+7ejoiK6ursaF39HRkVevXn1UDF+6uVNG5nQIX4XE2FCenPhJbn5gW6RFtie1iYmJdOw5hLMXrgDQvHFdFs+bpNWkNjEmQj34QsRrAPI0HoZNCR+tlS8IgvA+IrHNgIw0B/jc+Pj44Ovri6GhId7e3tjY2FC0aFFOnTrFiRMnGDZsWJaWZ2pqqvE6MjKSRo0aMXPmzFTzOjs7Z1m5FSpUYPLkycTFxWFoaAioR1pKTqFQpDlNpVJlWRxfEjfXjNeQC2lTxkfx5MTPxEe8AMCmYGMcS3bJ1qRWkiQGDJ/AgSMnAKherRIrF81EV1c328pMSZWYwP31I4gJVDfNcvquLU5V2mitfEEQhA8Rie1Xytvbm9WrV6Onpyf3IODj48OmTZu4d++e3L7W0tISZ2dnzp07R7Vq1QB1rdClS5coU6bMR5dfpkwZtm3bhru7e7oPsxgYGKBUKj+6DICrV69ibW0tJ7XChz17EQCIBPdjqRLjeHpqktzu3sq9Jk6le2T7cLUz5y9l/ab/AeBZshib1vyGoWH29T6SkiRJPNo6mXA/df+81iWqk7vhYK2VLwiCkBGiV4SvVLVq1YiIiGDPnj1yEuvj48PGjRtxdnbWaAowaNAgZsyYwY4dO7hz5w59+/YlNDT0k8rv168fISEhtG3blgsXLuDn58fBgwfp2rWrnMy6u7tz7tw5Hj9+THBw8AdrUHfv3s3KlSu5efMmDx48YOnSpUybNo0BAwZ8UqzfmmHjZzFs/KwPzyikIqmUPD87h+igWwCYu1bEpdwAFIrsPZVu2rqLyTN/AyCPmyv/2/g75mamH1gqa704vJzgy/sAMM1dgvxtJqPQ0V5tsSAIQkZk+mzcqVMn1qxZg5+fX3bEI2QRa2trPDw8sLe3p0iRIoA62VWpVHL72iTDhg2jY8eOdO7cmUqVKmFubk6zZs0+qXwXFxdOnz6NUqmkdu3aeHh4MHjwYKysrOT2gMOHD0dXV5dixYphb2/P06dP37tOfX19Fi9eTKVKlfD09OT3339n3rx5TJgw4ZNiFYSMkCSJgKsriXjxLwAm9iXIVWlktid3Zy9coe+Q8QBYW1myfdNyHB3ssrXMlIIu7ubFkRUAGNq4UrjLPHQNjD6wlCAIgvYppMw8IQT06NGDkydP8uDBA1xdXfH29sbHxwdvb28KFiyYXXFmmfDwcCwtLQkLC8PCQnsj8wjC5yJpON0ta+blcCRfltd3dxJw9W1yZ5mHvDVmomuQ+uHIrPTk6Quq1W1F8OsQ9PT02LV5Jd7fabcnj4jHV7m9rDeSSomeiSXF+q3G2D6PVmMQsoe4Hgpfo0zX2K5cuZJ79+7x7NkzZs2ahZmZGXPnzqVIkSLkypUrO2IUBEHIUREvzhFwVT2giZ6xDXmqTcz2pDYqKppWnfsR/DoEgIUzf9Z6UhsfHqzuq1alRKGrR8HOc0RSKwjCZ+2jG4ZZW1tja2uLtbU1VlZW6OnpZbiDfeHL8fTpU8zMzNL996HmA5nx448/plvOjz/+mGXlCEJmxIY+5vnZ2YCEjp4RuatOQN8ke891kiTx4+Bxcl+1/Xp1okuHH7K1zJRUykTu/zFK7tbLvclILPKW1moMgiAImZXpXhHGjh2Lr68vV65coWjRonh7ezN69GiqVauGtbV1dsQo5CAXFxeuXr363vezyqRJkxg+fHia74nbZEJOSIwL4+mpyagSYwEFrhWHY2ydP9vLXbh0Df/bpR4Cu4Z3ZaZNGJHtZab0bN9vRD6+BoB9ucbYV/i0dveCIAjakOk2tjo6Otjb2zNkyBCaN2/+0R3t5xTRpkgQhIyQVEqenJxAVOBVABw8OmFfrFW2l3vy9HkatOyKSqUij5sr/xz6G1sb7VYavPnvJPfWqttim7gUpni/1ejoiy71vjbieih8jTJdY3vlyhVOnDiBr68vc+fOxcDAQH6AzMfH54tLdAVBENLy6sYGOam1cKuKXdHsbwrgH/iKzr2HoVKpMDIyZOPqhVpPauNCA3i45RcAdAxNKdhxpkhqBUH4YmQ6sS1VqhSlSpWShzC9du0a8+fPp1+/fqhUqk/ucF8QhOz174WrAFQq55mjcXzOwp+fIfjOVkDdA4Jr+UHZPgCDUqmkW5+RvAoKBmDe9J8oXbJ4tpaZkqRMxG/TTyRGhwGQr+V4jGzFQ8GCIHw5Mp3YSpLElStX8PX1xdfXl1OnThEeHk7JkiVT9Y8qCMLnZ/6S9QBUWuOZs4F8puIj/XlxfgEAOvomuFUZh45e9vfZOmPeUk6ePgdAu1ZN6NS2ebaXmdKLY6uJeHQFAPvyzbAtVUvrMQiCIHyKTCe2NjY2REZGUqpUKby9venZsydVq1bFysoqG8ITBEHQHpUynmdnZqBKiAbAtfwQDM2z7gHJ9Jw8fZ7pc5cAUKRQfhbM+Dnba4hTinhynRdH1F2aGTvmI0/jYVotXxAEIStkOrH9448/qFq1qmhoLgjCVyfw6mpi36hHVbQt1BSLXJWyvcyQN6F07zcSSZIwMjJk/fJ5mJqaZHu5ySnjovHb9BNIKhS6+uRvO0WMLCYIwhcp0/3YNmjQQE5qnz9/zvPnzz8pgMWLF+Pu7o6RkREVKlTg/Pnz751/wYIFFC5cGGNjY9zc3BgyZAixsbGfFMPXQJIkevXqhY2NDQqF4r1ddGVEly5daNq0aZbEJghfgvDn/xLyYA8AxjaFcSjZOdvLlCSJAcMn8NI/EIBZk8dQvKj2H8B9umc+cSEvAHCr1w9TF/EQsCAIX6ZMJ7YqlYpJkyZhaWlJnjx5yJMnD1ZWVkyePBmVSpWpdW3evJmhQ4cyYcIELl++TKlSpahTpw6vXr1Kc/4///yT0aNHM2HCBG7fvs2qVavYvHkzY8eOzexmfHUOHDjA2rVr2bNnD/7+/pQoUSKnQ/ogHx8fBg8enOnl1q5dS8mSJTEyMsLBwYF+/fppvH/9+nWqVq2KkZERbm5uzJo1K4siFr5W8VGvkrWrNSVX5ZHo6Opne7kbt+xkx55DADSs+z3dOmZ/d2Iphd4+xatz2wEwz+eF03fttB6DIAhCVsl0U4Rx48axatUqZsyYQZUqVQA4deoUEydOJDY2lqlTp2Z4XfPmzaNnz5507doVgGXLlrF3715Wr17N6NGjU81/5swZqlSpQrt26hOvu7s7bdu25dy5c5ndjK+On58fzs7OVK5cOadDIT4+HgMDg2xZ97x585g7dy6zZ8+mQoUKREVF8fjxY/n98PBwateuTc2aNVm2bBk3btygW7duWFlZ0atXr2yJ6Uvj6uKY0yF8ViSVkhdn56BKiALAtdxADEyz/zN68vQFw8dOAcDB3o5FcydpvV1tYnQYD7eqY9A1MiV/64kodD56QEpBEIScJ2WSs7OztHPnzlTTd+zYIbm4uGR4PXFxcZKurq60fft2jemdOnWSGjdunOYyGzdulCwtLaVz585JkiRJfn5+UpEiRaSpU6emW05sbKwUFhYm/3v27JkESGFhYRmO9XPXuXNnCZD/2draSg0aNJDfnz9/vgRI+/fvl6flz59fWrFihSRJkpSYmCgNGTJEsrS0lGxsbKQRI0ZInTp1kpo0aZKh8r29vaV+/fpJgwYNkmxtbSUfHx9JkiTpxo0bUt26dSVTU1PJwcFB6tChgxQUFJRmzID06NGj95YTEhIiGRsbS0eOHEl3niVLlkjW1tZSXFycPG3UqFFS4cKFNT6vJk2aSFOnTpUcHBwkS0tL6ZdffpESEhKk4cOHS9bW1pKrq6u0evXqDG2/8GULvPGHdPOvBtLNvxpILy4s0kqZSqVSqtu0k2TiUEQycSgiHThyQivlpnR/4zjp7Agv6ewIL+nV+dTndeHrFhYW9tVdDwUh0zW2ISEhFClSJNX0IkWKEBISkuH1BAcHo1QqcXTUrBlxdHTkzp07aS7Trl07goOD+e6775AkicTERH788cf3NkWYPn06v/zyS4bjSsuTXXOJenn3k9bxMUxdCmfoyeSFCxeSP39+li9fzoULFzh8+DADBgxAqVSiq6vLiRMnsLOzw9fXl7p16/LixQv8/Pzw8fEBYO7cuaxdu5bVq1dTtGhR5s6dy/bt26lRo0aGY123bh19+vTh9OnTAISGhlKjRg169OjB/PnziYmJYdSoUbRq1Ypjx46xcOFC7t27R4kSJZg0aRIA9vb27y3j8OHDqFQqXrx4QdGiRYmIiKBy5crMnTsXNzc3AP7991+qVaumUWNcp04dZs6cyZs3b+Rhn48dO0auXLk4efIkp0+fpnv37pw5c4Zq1apx7tw5Nm/eTO/evalVqxa5col+PL9W0cG3CfpvMwCGFrlx8uyhlXKXrNjAyTPq5wm6d2pNne+raaXc5EJu+fL6qnrYXquiVbEr20jrMQiCIGS1jxqgYdGiRfz6668a0xctWkSpUqWyLLC0+Pr6Mm3aNJYsWUKFChV48OABgwYNYvLkyfz0009pLjNmzBiGDh0qvw4PD5eToIyKenmXiIeXPyn27GRpaYm5uTm6uro4OTnRqFEjunTpwpUrV/Dy8uLkyZOMGDGCHTt2AOrP0dXVlQIFCgDqB/LGjBlD8+bqfjOXLVvGwYMHMxVDwYIFNdqyTpkyhdKlSzNt2jR52urVq3Fzc+PevXsUKlQIAwMDTExMcHJyylAZDx8+RKVSMW3aNBYuXIilpSXjx4+nVq1aXL9+HQMDAwICAsibN6/Gckk/ngICAuTE1sbGhl9//RUdHR0KFy7MrFmziI6Oln8kjRkzhhkzZnDq1CnatGmTqc/ic7dlhzqZadW0bg5HkrOUCTE8PztX3ROAjh65Ko1ARy/7R9i69+ARE6bNByBvHjemTRyR7WWmlBgdzuP/TQdA19icvC3Gab0ZhCAIQnbIdGI7a9YsGjRowJEjR6hUSd0Vzr///suzZ8/Yt29fhtdjZ2eHrq4ugYGBGtMDAwPTTXR++uknOnbsSI8e6loVDw8PoqKi6NWrF+PGjUMnjbZhhoaGGBp+2sXK1KXwJy2v7XKtrKwoVaoUvr6+GBgYYGBgQK9evZgwYQKRkZGcOHFCHkwjLCwMf39/KlSoIC+vp6dH2bJlkSQpw2V6eXlpvL527RrHjx/HzMws1bx+fn4fNfSySqUiISGBX3/9ldq1awOwadMmnJycOH78OHXq1MnwuooXL66xvzg6Omo8cKerq4utrW26DzJ+ybbuVD+s9K0ntoHX1pAQFQCAg0cnjKzyfmCJT6dUKvlx0FhiY+NQKBQs/206Zqam2V5uSk/3zCch4jUAeRoPw8DCTusxCIIgZIdMJ7be3t7cu3ePxYsXy00GmjdvTt++fXFxyXhH5gYGBnh5eXH06FG5WymVSsXRo0fp379/mstER0enSl51dXUBMpWEZdaX2FG5j48Pvr6+GBoa4u3tjY2NDUWLFuXUqVOcOHGCYcOydptMU1ycIyMjadSoETNnzkw1r7Oz80eVkbRcsWLF5Gn29vbY2dnx9OlTAJycnNL8sZT0XhJ9fc0n3hUKRZrTMtvTh/BliAy8yhs/9Q9xE/sS2BZuqpVyl678g3MXrwLQt2dHKlfwev8C2SDs/jmCLu4GwLJwZezKNNB6DIIgCNkl04ktgIuLS6Z6P0jP0KFD6dy5M2XLlqV8+fIsWLCAqKgouZeETp064erqyvTp6ltmjRo1Yt68eZQuXVpuivDTTz/RqFEjOcEV1Ly9vVm9ejV6enrUrauumfPx8WHTpk3cu3dPbl9raWmJs7Mz586do1o1dTu/xMRELl26RJkyZT66/DJlyrBt2zbc3d3R00t7NzMwMECpVGZ4nUm9cNy9e1du9xoSEkJwcDB58uQBoFKlSowbN46EhAQ5UT18+DCFCxeWmyEI3zZlQgwvz6ubUil0DXEtPxiFIvt7Anj4+CkTpy8AIJ97biaOGZztZaakSojl0TZ18yAdAxPyNh8rmiAIgvBVyVBie/369QyvsGTJkhmet3Xr1gQFBfHzzz8TEBCAp6cnBw4ckNtEPn36VKOGdvz48SgUCsaPH8+LFy+wt7enUaNGWZJkf22qVatGREQEe/bsYcaMGYA6sW3ZsiXOzs4aTQEGDRrEjBkzKFiwIEWKFGHevHmEhoZ+Uvn9+vVjxYoVtG3blpEjR2JjY8ODBw/466+/WLlyJbq6uri7u3Pu3DkeP36MmZkZNjY2aTYnSVKoUCGaNGnCoEGDWL58ORYWFowZM4YiRYpQvXp1QP2A4S+//EL37t0ZNWoUN2/eZOHChcyfP/+Ttkf4ery6vo6EaHUTE8dSXTEwy1gb708hvR2IISZGPZjMkvmTMTExzvZyU3pxdNW7gRjq9sHQOvu3XRAEQZsylNh6enqiUCg+eLtfoVBkqgYOoH///uk2PfD19dV4raenx4QJE5gwYUKmyvgWWVtb4+HhQWBgoNyLRbVq1VCpVHL72iTDhg3D39+fzp07o6OjQ7du3WjWrBlhYWEfXb6LiwunT59m1KhR1K5dm7i4OPLkyUPdunXl5HX48OF07tyZYsWKERMTw6NHj3B3d3/vetevX8+QIUNo0KABOjo6eHt7c+DAAbl21tLSkkOHDtGvXz+8vLyws7Pj559/Fn3YCgBEB/1HyIO9gLoJgk2B+lop969tu/H95yyg7gWhauXyWik3uZjAR/if2ACAqWtRHCtrfzAIQRCE7KaQMtA49cmTJxleYdIt4c9VeHg4lpaWhIWFyUMDC8K3ZO7itQAM69clR+PQNpUyHr+DA4mPeI5CR5/8dRdhaO6a7eWGhoXjWbk+QcGvcbC348rpvVhZavfcI0kSt3/vre7dRaFDiQHrMM1VVKsxCJ8fcT0UvkYZqrH93JNVQRAy7ltLaJME3fqT+IjnADiUaK+VpBZg6uxFBAWreyCYOWm01pNagODL++QuCx0rtRRJrSAIX62PemJiw4YNVKlSBRcXF7k2d8GCBezcuTNLgxNy3tOnTzEzM0v3X1JvBFnhxx9/TLecH3/8McvKEb49MW8eEnznfwAYWRfEtnAzrZR76/Y9fl/9JwBVK5fjh2baafqQXGJMBE/3LgRA39yWXHX6aj0GQRAEbcl0rwhLly7l559/ZvDgwUydOlVuU2tlZcWCBQto0qRJlgcp5BwXFxeuXr363vezyqRJkxg+fHia74nbZFnnW2uKIKmU+F/8DSQVKHRxLT8QhU7296IiSRLDx01DqVSio6PD7Ck5MwjC80PLSIxUjwqZu+EQ9IxT9y0tCILwtch0Yvvbb7+xYsUKmjZtKj9tD1C2bNl0kxLhy6WnpyePUJbdHBwccHBw0EpZ37JzFzPey8nXIMRvPzEh9wGwK9JMKwMxAPxv1wFOnj4HQO+u7fAorv2BXqJe3iXwzN8AmOfzwtYz44OYCIIgfIky3RTh0aNHlC5dOtV0Q0NDoqKisiQoQRCErJAY+4ZXN9YDoG/qiH0x7QyPHBUVzZiJ6iGm7WytGTcy7Z5fspMkSTzZMfvtkMG6uDcdKfqsFQThq5fpxDZv3rxp3po+cOAARYuKBxIEQfh8BF5biyohGgDnMj+io2eklXLn/LqcFy/Vw/X+MnYI1laWWik3uddXDhDx+CoAjlXaYOKUX+sxCIIgaFummyIMHTqUfv36ERsbiyRJnD9/nk2bNjF9+nRWrlyZHTEKgiBkWnTwbUIfHwXA3KU85i7ltFKu36MnLFiyGgAvTw86tWuhlXKTU8ZGvXtgzMwW11o9tR6DIAhCTsh0YtujRw+MjY0ZP3480dHRtGvXDhcXFxYuXEibNtq5zScIgvA+kqTC//JyABQ6+jiV1t4AHaN+mkF8fAIAc6eNe+9oetnlxfE1JEQEA+BWfwB6RuKBMUEQvg2ZTmwB2rdvT/v27YmOjiYyMlI88CMIX5CWTWrndAjZLvTREWLfqB8Ysy3SXCvD5gIcOOzL/sO+AHRs05xyXqW0Um5yscHPCDi5EQCz3B7YldF+F2OCIAg55aOrEl69esWlS5e4e/cuQUFBWRmT8Jnz8fFh8ODB8mt3d3cWLFiQY/HklJSfw6fw9fVFoVAQGhqaJet7n1ZN69Kqad1sLyenKOOjCLyufmBMz9gO+6I/aKXcuLh4Rv40HQALczN+GTdEK+Wm9HTvAiSlusY4T5PhKHKgxlgQBCGnZPqMFxERQceOHXFxccHb2xtvb29cXFzo0KEDYWFh2RGj8Jm7cOECvXpp71bvl2LixIl4enpmaN7KlSvj7++PpaX2HzL62gT99xfKuFAAnDy7au2BsV+XrcXvkXrAkvEjB+DoYKeVcpMLu3+ON7dOAGDn1RAzt+Jaj0EQBCEnZTqx7dGjB+fOnWPv3r2EhoYSGhrKnj17uHjxIr17986OGIXPnL29PSYmJlotU5IkEhMTtVpmdklISMDAwAAnJyetdMc0ZNxMhoybme3l5IS48Oe8vrcLABO7Yli4VdNKuS9eBjBr/jIAihYuQK+ubbVSbnKSMpEnu+cBoGNgjFs97XcxJgiCkNMyndju2bOH1atXU6dOHSwsLLCwsKBOnTqsWLGC3bt3Z0eMQgb4+PgwYMAABg8ejLW1NY6OjqxYsYKoqCi6du2Kubk5BQoUYP/+/RrL3bx5k3r16mFmZoajoyMdO3YkODhYfj8qKopOnTphZmaGs7Mzc+fOTVV2yqYI8+bNw8PDA1NTU9zc3Ojbty+RkZHy+2vXrsXKyoqDBw9StGhRzMzMqFu3Lv7+/uluX9Kt+v379+Pl5YWhoSGnTp0iLi6OgQMH4uDggJGREd999x0XLlxIVVZyO3bs0Eggk2pWN2zYgLu7O5aWlrRp04aIiIhMfQ7JrV27ll9++YVr166hUChQKBSsXbsWAIVCwdKlS2ncuDGmpqZMnTo1VVOEpLh37NhBwYIFMTIyok6dOjx79uy95WbEi5eBvHgZ+Mnr+RwFXF0BkhJQ4FSmt9b6bR07cRbRMTEAzJ02Hn19fa2Um9yr8zuICfADwKVGVwwstF9jLAiCkNMy/fCYra1tmrdLLS0tsba2zpKgPketug5Nc/rcKSNxc3Xi2YsAho2fleY8W9aoa1H+vXCV+UvWp3rf1cWR+VNHqefdcYCtOw/Jy2TGunXrGDlyJOfPn2fz5s306dOH7du306xZM8aOHcv8+fPp2LEjT58+xcTEhNDQUGrUqEGPHj2YP38+MTExjBo1ilatWnHs2DEARowYwYkTJ9i5cycODg6MHTuWy5cvv/cWu46ODr/++it58+bl4cOH9O3bl5EjR7JkyRJ5nujoaObMmcOGDRvQ0dGhQ4cODB8+nI0bN753G0ePHs2cOXPIly8f1tbWjBw5km3btrFu3Try5MnDrFmzqFOnDg8ePMDGxibDn52fnx87duxgz549vHnzhlatWjFjxgymTp36UZ9D69atuXnzJgcOHODIkSMAGsfNxIkTmTFjBgsWLEBPT4+HDx+mWkd0dDRTp05l/fr1GBgY0LdvX9q0acPp06czvF3fkoiXF4j0vwSAdb7aGFtrp9/Wk6fPs3Wn+gdji8Z18f6uglbKTS4xJoLnh9Q1xobWLjhXba/1GARBED4Hma6xHT9+PEOHDiUgIECeFhAQwIgRI/jpp5+yNDghc0qVKsX48eMpWLAgY8aMwcjICDs7O3r27EnBggX5+eefef36Ndevq4dUXbRoEaVLl2batGkUKVKE0qVLs3r1ao4fP869e/eIjIxk1apVzJkzh++//x4PDw/WrVv3wSYAgwcPpnr16ri7u1OjRg2mTJnCli1bNOZJSEhg2bJllC1bljJlytC/f3+OHj36wW2cNGkStWrVIn/+/BgaGrJ06VJmz55NvXr1KFasGCtWrMDY2JhVq1Zl6rNTqVSsXbuWEiVKULVqVTp27CjH8zGfg7GxMWZmZujp6eHk5ISTkxPGxsby++3ataNr167ky5eP3Llzp7mOhIQEFi1aRKVKlfDy8mLdunWcOXOG8+fPZ2rbvgUqZQIBV1YAoKNvioNHJ62Um5iYyLCxUwAwMTZm2sSRWik3pZdHV5MYFQqAW4OB6Ogb5kgcgiAIOS1DNbalS5fWuKV3//59cufOLV+Qnz59iqGhIUFBQV9tO9sP1aC6uTp9cJ5K5TyptMbzvfN8yhPrJUuWlP/W1dXF1tYWDw8PeZqjoyOg7tEC4Nq1axw/fhwzs9R9XPr5+RETE0N8fDwVKryrgbKxsaFw4fePeX/kyBGmT5/OnTt3CA8PJzExkdjYWKKjo+W2uCYmJuTP/65GzdnZWY7rfcqWLasRY0JCAlWqVJGn6evrU758eW7fvv3BdSXn7u6Oubl5mvH4+fl91OfwPsm3Iz16enqUK/duUIEiRYpgZWXF7du3KV++/EeX/TUKub+L+MiXADgUb4eekXYewlu+ZhP/3VF3KzZiUC9yuTprpdzkYl8/J+D0XwCY5SmJjcf3Wo9BEAThc5GhxLZp06bZHIaQFVK261MoFBrTkn6cqFQqQF0T2ahRI2bOTP0gkbOzMw8ePMh0DI8fP6Zhw4b06dOHqVOnYmNjw6lTp+jevTvx8fFyYptWrJIkfXD9pqammYpHR0cn1XoTEhJSzZdWPEmfU3bI7HYI6UuIeUPQLXViZ2jhhk3BBlop91XQa6bM+g2AfO65Gdinq1bKTenZvt/ede/VaKjW2hULgiB8jjKU2E6YMCG74xByQJkyZdi2bRvu7u7o6aXeFfLnz4++vj7nzp2Ta+ffvHnDvXv38Pb2TnOdly5dQqVSMXfuXHnEpZTNELJK/vz5MTAw4PTp0+TJkwdQJ60XLlyQ+5e1t7cnIiKCqKgoOZm8evVqpsvJ7OcAYGBggFKpzPyGvZWYmMjFixfl2tm7d+8SGhpK0aJFP3qdAEP6auc2vba8ur4OVaL6wS2n0j1R6HzUuDOZNnHafMLC1Q8Yzpo8GiMj7d/+j3h8jZAb6iYztqXrYZa7hNZjEARB+JyInru/Yf369SMkJIS2bdty4cIF/Pz8OHjwIF27dkWpVGJmZkb37t0ZMWIEx44d4+bNm3Tp0uW9Q4QWKFCAhIQEfvvtNx4+fMiGDRtYtmxZtsRvampKnz59GDFiBAcOHOC///6jZ8+eREdH0717dwAqVKiAiYkJY8eOxc/Pjz///FPunSCjPuZzAHXzhkePHnH16lWCg4OJi4vLVLn6+voMGDCAc+fOcenSJbp06ULFihU/uRlCpXKeVCrn+Unr+FxEv75L6GP1w3nmLhUwcyqjlXIvXr7O+k3/A6BOzWrUq11dK+UmJ0kST/csAEChZ4Bb3b5aj0EQBOFzIxLbb5iLiwunT59GqVRSu3ZtPDw8GDx4MFZWVnLSNnv2bKpWrUqjRo2oWbMm3333HV5eXumus1SpUsybN4+ZM2dSokQJNm7cyPTp07NtG2bMmEGLFi3o2LEjZcqU4cGDBxw8eFDuocPGxoY//viDffv24eHhwaZNm5g4cWKmy8ns5wDQokUL6tatS/Xq1bG3t2fTpk2ZKtPExIRRo0bRrl07qlSpgpmZGZs3b8507F8rSVIRcHk5AAodPRw9u2ulXJVKxdAxU5AkCQMDfWZNHqOVclMKuX6EyKc3AHCq2g5Da+237xUEQfjcKKSMNGz8ioSHh2NpaUlYWBgWFhY5HY4gpGnt2rUMHjw4W4bYTeq67mO6lPuchD46yovz8wGwK9ISx1JdtFLuuj+30XfIeACGD+yVI0PnqhITuD6nJXEhL9AztaLUyB3oGad+CFQQ3kdcD4WvkaixFQThi6NMiCbw+loA9IxssCvWSivlhoaF8/MU9Q8CF2dHRgzOmaGkX53dRlzICwBca/YUSa0gCMJbmUpsExISyJ8/f6a7UhIEQchKwbe3kBj7BgDHkp3R1dfOkM4z5i0l+HUIANMmjMAsB3q3SIyN5MXRlQAY2rrhULGF1mMQBEH4XGUqsdXX1yc2Nja7YhEE4a0uXbpkSzOEr0FcxEte390BgLFNYSzdtfPg1oOHj1m68g8AqlT0omXT+lopN6WAkxvfDcZQty86utrpBUIQBOFLkOmmCP369WPmzJkfHH1KEAQhOwReXYWkUp9/nMr0QqHQTouqcb/MITExEYVCwczJY3Kkv9j4iGD8T6qTa9NcxbApWVPrMQiCIHzOMv1T/8KFCxw9epRDhw7h4eGRqqP5//3vf1kWnCAIQnKRAZeJeHkOACv3mpjYfvzob5nh+89Z9hxQ9xfbvnVTSpcsrpVyU3pxZBWqeHWfvW71B4jBGARBEFLIdGJrZWVFixaiTZcgfKnmThmZ0yF8FEmlJOCKum2pjp4xDiU7a6VcpVLJ6Anq0flMTUyYOGawVspNKTb4GUHn1BUHloUqYVmg3AeWEARB+PZkOrFds2ZNdsQhCIKWuLk65XQIH+XNw4PEhT8FwK5YK/SNrbVS7sYtO7lx6w4AQwd0x9nJQSvlpvTs4BIklXokO7d6/XIkBkEQhM/dRz91EBQUxN27dwEoXLgw9vb2WRaUIAjZ59mLAODLSnCV8ZG8uqFuW6pv6ohtoSZaKTcqKppJMxYC6u69Bv7YVSvlporj+W1Crh0GwNazDqauRXIkDkEQhM9dpp+6iIqKolu3bjg7O1OtWjWqVauGi4sL3bt3Jzo6OjtiFAQhCw0bP4th42fldBiZEnRrE8r4cAAcS3VFR9dAK+UuWLIa/4BXAEwYMxgTE2OtlJvS0/2LAFDo6pGrTp8ciUEQBOFLkOnEdujQoZw4cYLdu3cTGhpKaGgoO3fu5MSJEwwbNiw7YhQE4RsWG/aU1/f3AGBiXxyLXFW0Uq5/wCsWLF4NQCmPorT7obFWyk0p7MFFwu+rH5hzqNAMI9tcORKHIAjClyDTTRG2bdvG1q1b8fHxkafVr18fY2NjWrVqxdKlS7MyPkEQvmGSJBF4dSVISlDo4FS6t9Z6Apg881eiY9Q9EEyfOAodHe0P1ChJEs/2/QqAjr4RLt9313oMgiAIX5JMn6mjo6NxdHRMNd3BwUE0RRAEIUtFvjxPZMBlAKzz1cbYOp9Wyr1x6y7rN6l7IKhfuzre31XQSrkphdw4StTz/wBwrtYBA3O7HIlDEAThS5HpxLZSpUpMmDBBYwSymJgYfvnlFypVqpSlwQmC8O1SKRMIuPq2ey99Uxw8Omqt7HGTZiNJErq6ukz5ebjWyk1OpUzk+YElAOiZWOLk3SFH4hAEQfiSZLopwsKFC6lTpw65cuWiVKlSAFy7dg0jIyMOHjyY5QEKgvBtCrm3k/hIfwAcSrRHz9BSK+UePn6Ko76nAejeqRWFC2qnljiloPM7iA1Wd2/m8n139IzMciQOQRCEL0mma2xLlCjB/fv3mT59Op6ennh6ejJjxgzu379P8eKZH41n8eLFuLu7Y2RkRIUKFTh//vx75w8NDaVfv344OztjaGhIoUKF2LdvX6bLFYRv1ZY189iyZl5Oh/FeCTFvCPpvMwCGFm7YFKivlXKVSiXjfpkNgLmZKWOH99dKuaniiI/hxZEVABhYO+NYqWWOxCEIgvCl+ah+bE1MTOjZs+cnF75582aGDh3KsmXLqFChAgsWLKBOnTrcvXsXB4fUnaDHx8dTq1YtHBwc2Lp1K66urjx58gQrK6tPjkUQhM/HqxvrUSWqH9xy8uyBQueju9zOlI1bdnLr9j0Ahg3oib2djVbKTSng1CYSIl4DkKv2j+joaad7M0EQhC+ddq4W6Zg3bx49e/aka1d1p+fLli1j7969rF69mtGjR6eaf/Xq1YSEhHDmzBn09fUBcHd312bIgvDF+/fCVQAqlfPM0TjSE/PmIaGPjgBg5lIOM2cvrZQbHR3D5JnqHgicnRzo16uTVspNKSEqFH/fdQAYOxXArnTdHIlDEAThS6T9/mveio+P59KlS9SsWfNdMDo61KxZk3///TfNZXbt2kWlSpXo168fjo6OlChRgmnTpqFUKtMtJy4ujvDwcI1/gvAtm79kPfOXrM/pMNIkd++FBApdnEppr3ur35at5aV/IAA/jx6UY4MxvDy2BmVsFABu9fqj0NHNkTgEQRC+RDmW2AYHB6NUKlN1Hebo6EhAQECayzx8+JCtW7eiVCrZt28fP/30E3PnzmXKlCnpljN9+nQsLS3lf25ublm6HYIgZJ2IF2eJenUdAJsC9TG00M5gBAGvgpj7m7oHhhLFCtO+lXaG7E0p7o0/gWe2AGCetwxWRbQzGIUgCMLXIscS24+hUqlwcHBg+fLleHl50bp1a8aNG8eyZcvSXWbMmDGEhYXJ/549e6bFiAVByCiVMoHAa+qRvnQNzLAv3k5rZU+dtYiot/1wT584El3dnKklfX7odyRlAgC5GwzU2mAUgiAIX4tMJ7b58uXj9evXqaaHhoaSL1/Gu8Wxs7NDV1eXwMBAjemBgYE4OTmluYyzszOFChXSuOgULVqUgIAA4uPj01zG0NAQCwsLjX+CIHx+Qh7slbv3si/eDj1Dc62U+9+d+6zduBWAOjWrUcO7slbKTSk64AHBl/cCYF2iOma5S+RIHIIgCF+yTCe2jx8/TrNNa1xcHC9evMjwegwMDPDy8uLo0aPyNJVKxdGjR9Md6KFKlSo8ePAAlUolT7t37x7Ozs4YGIinhgXhS5UYF0HQrU0AGJi7aq17L4Cxv8xGpVKho6PDlJ9yZjAGgGf7F4MkgUIHt7r9ciwOQRCEL1mGe0XYtWuX/PfBgwextHzXWbpSqeTo0aOZ7qFg6NChdO7cmbJly1K+fHkWLFhAVFSU3EtCp06dcHV1Zfr06QD06dOHRYsWMWjQIAYMGMD9+/eZNm0aAwcOzFS5gvAtc3VJPSR2Tgu6tQlVgvqBKcdS3bTWvdfh46c4fOwfALp2+IFiRQpqpdyUwh9eJvS2Og77ck0wdnDPkTgEQRC+dBm+ejRt2hQAhUJB586dNd7T19fH3d2duXPnZqrw1q1bExQUxM8//0xAQACenp4cOHBAfqDs6dOn6Oi8q1R2c3Pj4MGDDBkyhJIlS+Lq6sqgQYMYNWpUpsoVhG/Z/Kmf1/ESF/GSN37qQVZM7Etg7lJeK+WmHIxh/MgBWik3JUmSeLpP3c2Yjr4huWr1ypE4BEEQvgYZTmyTbv/nzZuXCxcuYGdnlyUB9O/fn/790x7dx9fXN9W0SpUqcfbs2SwpWxCEnBd4fS2SKhEAJ8/uWntg6s+/d8mDMQzt3wMHe1utlJvSm5vHiHp6EwCnqu0wsLTPkTgEQRC+Bpm+3/fo0aPsiEMQBC3ZsuMAAK2a5nzH/1GvbhLx/AwAlnmqY2yjnaYAMTGx8mAMLs6O9O/d+QNLZA+VMlHdthbQM7HE2Ttn4hAEQfhafFRDtqioKE6cOMHTp09T9UYg2rsKwudt685DQM4ntpKkIuCquu9Yha4hjiW1l9QtXfUHL16q+8seP6J/jg3GEHR+B7HBTwFwrdkDPWOzHIlDEATha5HpxPbKlSvUr1+f6OhooqKisLGxITg4GBMTExwcHERiKwhChoQ98SX2zQMA7Ao3Q98ka5o3fcjrkDfMWbgcgKKF89OhTTOtlJuSMi6aF4dXAGBo44pDxRY5EocgCMLXJNPdfQ0ZMoRGjRrx5s0bjI2NOXv2LE+ePMHLy4s5c+ZkR4yCIHxlVIlxvLqxAQA9I2tsi2gvqZu9cDlh4REATBo3LMcGY/A/uZGESHWf4Lnq9EFHT3RZKAiC8KkyndhevXqVYcOGoaOjg66uLnFxcbi5uTFr1izGjh2bHTEKgvCVCb77PxKigwBw8OiIrr52mgI8ffaC5Wv+BKBKRS/q1fbRSrkpJUSG4H9CndibuBbBtlTtHIlDEATha5PpxFZfX1/ugsvBwYGnT9XtwywtLcVwtYIgfFBCdBDBt9UjfRlaumPl/r3Wyp44fSFxcernAqb8NDzHhqx9cWQFqnj1EL656w9AofNFjW4uCILw2cp0G9vSpUtz4cIFChYsiLe3Nz///DPBwcFs2LCBEiXEEJCC8LmrULZkjpYfeG0tkjIOAOcyvVHoaKcpwMXL19m8bTcAzRrVoXxZT62Um1Js0FNenf0fAJaFKmJZsEKOxCEIgvA1ynRiO23aNCIi1O3Tpk6dSqdOnejTpw8FCxZk9erVWR6gIAhZa1i/LjlWdnTwHcKengDAwu07TB08tFKuJEmMmTgLAAMDfSaPH6aVctPy7OBSJJV6WHK3emn34S0IgiB8nEwntmXLlpX/dnBw4MCBA1kakCAIXyd1917qXgAUOvo4luqqtbJ37z/CmXOXAPixewfyurtprezkIp/dIuT6YQBsS9fD1LVIjsQhCILwtRINuwThGzN38VrmLl6r9XLDn/5DzOu7ANgWboKBqaNWyk1ISOCnyerhvq2tLBk5uLdWyk1JkiSe7lUPCqHQ1cetTp8ciUMQBOFr9lEDNAiC8OU6d/G61stUKeMJvLEeAF1DK+yKttJa2Ws3buXBwycAjB7aB2srS62VnVzY3TNEPFTXGjtWaomhjUuOxCEIgvA1EzW2giBku9f3dpEQFQiAQ4l26OqbaKXcyKgops1ZAkAeN1d6dmmrlXJTklRKnu77DQBdI1Ncvu+eI3EIgiB87URiKwhCtkqICSH4v80AGFq4YZ1Pe322Llm+gVdBwQD8PHoQhoY5MwhC8OX9xASoR1lz9umCvqlVjsQhCILwtcuSxDY0NDQrViMIwlco8PpaVIkxADiV7olCRzstoF6HvGH+4lUAlChWmFbNG2il3JRUCXE8P7QUAH0Le5y+y5laY0EQhG9BphPbmTNnsnnzZvl1q1atsLW1xdXVlWvXrmVpcIIgfNmiX98l7PExAMxdK2LmVEZrZc/9bSXhEZEA/DJuiDywjLYFntlCfKi6GUauWr3RNTDKkTgEQRC+BZk+0y9btgw3N3VXOYcPH+bw4cPs37+fevXqMWLEiCwPUBCErNWySW1aNsn+5gCSpCLg8nIAFDp6OHn2yPYykzx/4c+yVX8AULmCF3W+r6a1spNLjA7nxbE1ABg55MW+bMMciUMQBOFbkel7ggEBAXJiu2fPHlq1akXt2rVxd3enQoX/t3ff4U1XbQPHv0ma7r0HLbPsTdkioFUEZLkQERFFfRygooi4WCoCKjwCDlBxCyrCo6iI8IIoILuACAXK6C50N11pkvP+EYgts4U2oeX+XFeuJOc3zt3+kubuyRmygo4QV7u7ht5il3ryTvxOcfaZ6b2G4uwZapd6AabPese2dO6Ml59x2NK5qeuXYC7OByCq/xNodDIRjRBC1KQqt9j6+fmRlJQEwOrVq4mNjQWsczSazebqjU4IUStZTCVk7P0UACdX+07vFbfvH7765n8ADOp/I906d7Bb3eWV5qSTvsnabcuzQTt8Wzqm1VgIIa4lVW4+uO2227jnnnuIjo4mKyuL/v37A7B7926aNGlS7QEKIarX0y/OAmDua5NqrI5T/yzDVGydjSC4zX12m95LKcXkKbNRSuHk5MSMlx23dG7ybx+gTNZW46gB4x3WaiyEENeSKie2c+fOpWHDhiQmJjJ79mw8PT0BSEtL47HHHqv2AIUQ1SslNaNGz19akEJW/AoA3Pyj8W0YW6P1lffruo1s3LQVgIfuH0F044Z2q7u8orQjZO5cBYBf6754NWjnkDiEEOJaU6XEtqysjEceeYSXX36Zhg0rfmA8/fTT1RqYEKL2UUqRvusDlMUEaAjr+CgajX1mIzCbzbzy6tsAeHt58vwExy1Zm/TLfFAKtDoib3ncYXEIIcS1pkqfOHq9nuXLl9dULEKIWq4g5S8M6bsA8Gt0M24BTe1W9xdLV7D/wCEAJjwxlsAAP7vVXV7eke3kHtwEQHDnwbgFN3BIHEIIcS2qclPK0KFDWblyZQ2EIoSozSymEtJ3LwZA5+xJcNv77FZ3gaGQqTP/C0B4WAiPP2y/ustTFjOJq+YCoHV2I+KmRxwShxBCXKuq3Mc2Ojqa6dOns2nTJjp16oSHh0eF7ePHj6+24IQQtUfmge8oKzoJWAeMObn42K3uWXPfsy2dO+OlZ3B3d7Nb3eWd2rmKolRrq3FY7/tw9g50SBxCCHGt0iilVFUOOLtvbYWTaTQcPXr0ioOqSfn5+fj4+JCXl4e3t7ejwxHC7rZsjwOge+f21XZOoyGNI788hrKU4erXmEaxb6PR6qrt/Bdz6MgxuvQZQllZGV06teP/fvraITMQmEoM7J19O2WGLPQ+wbSbuByds2MSbCEqQz4PRV1U5RbbY8eO1UQcQgg7qc6E9oy03YtQljIAwjr+x25JrVKKZ154lbKyMjQaDW/PfNlxizH838eUGbIAiOo/TpJaIYRwAMcsni6EqDMKUrdhSN0OgG+DWNwDW9it7h9+/o3/+30zAA+MuosO7VrZre7ySjKTSP/jawA867cloIN9VncTQghR0WWt75icnMwPP/xAYmIiRqOxwra33367WgITQtSMu8ZMAOCbJVf+XrWYSkjb9QEAWr0HIe3uv+JzVlZRUTHPT7EuNuHv58OUyU/are6znVg1F2W2tljXHzRBFmMQQggHqXJiu27dOgYPHkyjRo04ePAgrVu35vjx4yil6NixY03EKIS4Sp3av5SyQuuCD8Ft7sXJ1ddudf/3vY9JTEoFYMrkpwjwd8z0XrmH/iL3n40ABMYMwjOqtUPiEEIIcRldESZPnsyzzz7Lvn37cHV1Zfny5SQlJdG7d2/uvPPOmohRCHEVKsk7QWa5Fcb8Gw+wW90pqem8Nf9DANq0as6Yex3zt8diNnHih7cA0Lp4ENlfFmMQQghHqnJie+DAAe67zzpHpJOTE8XFxXh6ejJ9+nRmzZpV7QEKIa4+SllI27EQlBk0WsJinrDbgDGAqTPnUVxcAsCcVyej09mv7vJObvmOkpPWAbURNz6As5dM7yWEEI5U5cTWw8PD1q82LCyMhIQE27bMzMzqi0wIcdXKObqGosx/AAiIHoSbX2O71b11+26++uZ/AAweEEuvHl3sVnd5ZYZskn+z9i92CahH6HUjHBKHEEKIf1W5j223bt34888/adGiBQMGDOCZZ55h3759fP/993Tr1q0mYhRCXEVMJTlk7FkCgN49iKDW99qtbrPZzNOTZwDg4uLM61Oes1vdZ0v6ZQHm4gLAOmBM6+TssFiEEEJYVTmxffvttzEYDABMmzYNg8HAsmXLiI6OlhkRhKgF3nr1ypLB9LiPsJQVAhDa8RF0evvN1/rRZ8vYs+8AAM+Me4iGDSLtVnd5BSf2cWr7DwD4Nu+JX8vrHRKHEEKIiqq88lhtJyutCHH5DOlxnPj9JQC8IroRdd1Ldqv7VGY27Xv0JzcvnwZR9dix8Ufc3FztVv8ZymLm7/mjKUo5iEanp+2z3+IaUM/ucQhxpeTzUNRFlzWPLcCOHTs4cMDactKyZUs6depUbUEJIWpOUko6AJERoVU6zmI2krZzIQBaJzfCOj5S7bFdzMsz3iI3Lx+A2TMmOySpBcj4azlFKQcBCO8zWpJaIYS4ilQ5sU1OTmbEiBFs2rQJX19fAHJzc+nRowdLly6lXj35Iy/E1eyZl2YDVV+gIfPAtxgNaQAEtR6J3j2o2mO7kD+3bOfzpd8D0C/2egb062u3usszFmSSvPpdAFz8Iwi/4X6HxCGEEOL8qjwrwtixYykrK+PAgQNkZ2eTnZ3NgQMHsFgsjB079rKCWLhwIQ0aNMDV1ZWuXbuybdu2Sh23dOlSNBoNQ4cOvax6hRCVU5qfROaBbwFw9W1EQPQgu9VdUlLKuGenAODm5srbr7/ssJW9En/6L+YS6xiD+kMmotU7ptVYCCHE+VU5sf3999957733aNasma2sWbNmzJ8/n40bN1Y5gGXLljFhwgSmTJnCrl27aNeuHf369ePkyZMXPe748eM8++yz9OrVq8p1CiEqTykLqdvnoywm0GgJt/OctXP++wGHjljnin3h2cdpUN8x3wrlHd5G1q5fAPBr1Qe/Ftc5JA4hhBAXVuXENjIykrKysnPKzWYz4eHhVQ7g7bff5qGHHmLMmDG0bNmS999/H3d3dz7++OMLHmM2mxk5ciTTpk2jUaNGVa5TCFF52Ud+ss1Z6x89CLeApnare9/+eN58ZzEAbVu3YPx/7rdb3eVZyko49v1MALTObtQf/KxD4hBCCHFxVU5s58yZw7hx49ixY4etbMeOHTz55JO8+eabVTqX0Whk586dxMbG/huQVktsbCxbtmy54HHTp08nODiYBx988JJ1lJaWkp+fX+EmhKgcY2EGJ/d+CoDeI4SQNqPsVrfJZOKxCS9hMpnQ6XS8O3cGTk6XPd71iqSs+4jSrCQA6t38H1z8qjbwTgghhH1U6lPCz8+vQp+2wsJCunbtavuQMZlMODk58cADD1Spv2tmZiZms5mQkJAK5SEhIRw8ePC8x/z555989NFHxMXFVaqOmTNnMm3atErHJISwUspCyrZ5WEzWpWvDY8ahdbJfn9L/vreEXXF/A/DUYw/QoW0ru9VdXlHaEdI2fAaAR0QLQnsOd0gcQgghLq1Sie28efNqOIzKKSgoYNSoUSxevJjAwMqtyT558mQmTJhge56fn09kpGMmdRfialDZ2RCy4ldSdHIfAH6NbsEztH0NRlVR/OGjvDZnAQBNmzTkhWcft1vd5SmLmaPLX0VZzKDV0fCOF9HoHNNqLIQQ4tIq9Rd69OjRNVJ5YGAgOp2OjIyMCuUZGRmEhp77VV9CQgLHjx9n0KB/R2RbLBYAnJyciI+Pp3HjimvWu7i44OLiUgPRC1F3leQe5+Q+ayuls2cYIe0v3e2nupjNZh596kVKS41oNBrem/carq6OeQ9nbPmOwkRrq3HYdffgEdHcIXEIIYSonCr3sa1Ozs7OdOrUiXXr1tnKLBYL69ato3v37ufs37x5c/bt20dcXJztNnjwYPr27UtcXJy0xApRCVu2x7Fle9wFt1vMZST/9aZtFoSIrs/Yddncdxd/ztYd1vgee2gU3Tp3sFvd5ZXmpJH0i3VBChe/cCJuftghcQghhKg8h3+nNmHCBEaPHk1MTAxdunRh3rx5FBYWMmbMGADuu+8+IiIimDlzJq6urrRu3brC8WcWiTi7XAhxfnPftbbEdl/S/rzbT/79OaV5xwEIanEX7oH2a6U8cvQ40974LwCNGkQxdfJTdqu7PKUUR797FYuxCIAGt7+Aztl+yb0QQojL4/DEdvjw4Zw6dYpXXnmF9PR02rdvz+rVq20DyhITE9FqHdqwLMQ1o/DkPrIOrgDA1a8JQa3utlvdZrOZR8a/QHGxdbDau3Nn4O7umGQyc8eP5B/eCkBQ5yH4Nu3mkDiEEEJUTaUS271799K6desaSzCfeOIJnnjiifNu27Bhw0WP/eSTT6o/ICGuQWZjISlb3wYUGp0z9bo9g0Zrv/993/vwC/7avhuAR8eOolePLnaruzxj3ilO/GgdYKf3CiTq1qccEocQQoiqq1Sm2qFDBzIzMwFo1KgRWVlZNRqUEML+0nZ/QFnRKQBC2o3Bxdt+fdYTjp1g6sx5ADSsH8m0F56yW93lKaU49v3rtmVzG942GSc3L4fEIoQQouoqldj6+vpy7Jh1Scvjx4/bZiIQQtQNeUl/knf8/wDwDO2If5Nb7Va32WzmP0++aOuC8N68V/HwcLdb/eVl7V5N7oE/AAhofwt+rXo7JA4hhBCXp1LfM95+++307t2bsLAwNBoNMTEx6HTnXyv+6NGj1RqgEKJ6RYRXXBClrDibtB3W0f86Z0/CuzxZYUGWmvbO+5+weetOAP7zwEgHdkE4yfH/zQHAydOf+kNk2VwhhKhtKpXYLlq0iNtuu40jR44wfvx4HnroIby85Os5IWqjua9Nsj1WSpG67b+YjQUAhMU8gd4twG6x7Nsfz/TTsyA0bhjF9JcmXOKImqEsFhK+mYq52LrkdsPbJqP38HVILEIIIS5fpUeG3HLLLQDs3LmTJ598UhJbIeqAnCM/Y0i3tpb61O+LT+R1dqu7tNTI2CcmYTSWodVq+XDBLId1QUjftJT8w9sACIoZhH/rvg6JQwghxJWp8pDnJUuW2B4nJycDUK9eveqLSAhRo75ZuRqAITe0Jn3PxwDo3YMI6/iIXeOYPuu//P1PPAATn3yYLjHt7Vr/GUVpR0j6xbp8r4t/BPUHSxcEIYSorao8f5fFYmH69On4+PhQv3596tevj6+vLzNmzJBBZULUAt/9bw3f/u9XkrfMQZlLAQ0RXZ9G5+xptxjWb9zCf9+1/pPcoV0rnp/wqN3qLs9SVsqRr19CmYyg0dL47unoXD0cEosQQogrV+UW2xdffJGPPvqIN954g549ewLw559/MnXqVEpKSnjttdeqPUghRPUyleRSkmud2iug+TA8gtvare5TmdmMfWISSinc3Fz5aOFsnJ2d7VZ/eUmr36U4/QgAETc+iFeDdg6JQwghRPWocmL76aef8uGHHzJ48GBbWdu2bYmIiOCxxx6TxFaIq5zZVGwbLObmH01w61F2q1spxSNPTiY9w5pUz5kxmWbRjexWf3l5h7eS/seXAHhEtiL8xgcdEocQQojqU+WuCNnZ2TRvfu7a8c2bNyc7O7taghJC1Iyy4ixMxdYFVrRObkR0m4hWp7db/QsXfcavazcCcPvgW7j/3jvtVnd5pqI8EpZNBUDr7EaTu2eg1Tl8hXEhhBBXqMqJbbt27ViwYME55QsWLKBdO/kaT4irlbKYSN48C6WsfeHDOj2Gi1e43erfvXc/L814C4D6kRG88+Y0u86Xe4ZSiqPLX6Ms39pqXH/QM7gGRdk9DiGEENWvyk0Us2fPZuDAgaxdu5bu3bsDsGXLFpKSkvj555+rPUAhRPXI2PcZRZn/0LqeHhfvKHwb2G9KK0NhIWP+8yxlZWU4OTnxyftv4uvjbbf6yzu1dQU5+6yrrPm16k1QlyEOiUMIIUT1q3KLbe/evTl06BDDhg0jNzeX3NxcbrvtNuLj4+nVq1dNxCiEuEL5KVvJOvg9AA8OqMfLU2bbrW6lFE88M4XDCccBeGniE46b2ivjKCd+tLYa632CaXjHyw5pNRZCCFEzLqtTWXh4uAwSE6KWMBrSSdn6NmDtV1uvx/NonVzsVv+iJV/x7YqfAOjTqxsTxo21W93lmUuLOPz5JCxlpaDR0Hj4dFldTAgh6pgqt9gKIWoPi9lI0uY3sJQVAhDR5SkWfPYbby38xC71b9+5h0mvzAIgPCyEJe+9iU6ns0vd5SmlOLb8NUpOHgMg4sax+DSJsXscQgghapYMAxaiDkvfvYiSHOs8rf5Nh+Ad2ZOtO5bbpe7MrBzufehpW7/aLxbPJTgowC51n+3kX8vJivsVAO/oLkTEOqbVWAghRM2SFlsh6qico2vISbAun+sW0JyQtvfbrW6z2cwDj00kOSUNgNenTKRr5w52q7+8wuSDnPjhdL9a7yCajHgNjdb+rcZCCCFqniS2QtRBxTkJpO18DwCdiy+RPZ6363y1b7z9Hus2bAKs89U+9pD9FoEoz1Ri4PCXz6PMZaDVET1yJnpPP4fEIoQQouZdVmJrMplYu3YtH3zwAQUF1hWMUlNTMRgM1RqcEKLqzEYDyZvfQFnKQKMlssck9O6Bdqt/9W8bmPnWuwA0i27EwrmvOmy+2mPfvUZpVjIAkf0exathe7vHIYQQwn6q3Mf2xIkT3HLLLSQmJlJaWspNN92El5cXs2bNorS0lPfff78m4hRCVIKymEn+602MBmsXgOA2o/AIbmO3+g8eSmDMoxNRSuHh7s4XH87Dy9PDbvWXd/Kv5WTv/Q0An2Y9COt9n0PiEEIIYT9VTmyffPJJYmJi2LNnDwEB/w4EGTZsGA899FC1BieEqDylFGm7PsCQtgMAr4huBDa//Zz97hhyc43Un5Obx133PUZ+gfWbm8ULZtKyeXSN1HUphqT9FfrVNr57Ohqt9LwSQoi6rsqJ7R9//MHmzZtxdnauUN6gQQNSUlKqLTAhRNVkHviWnATr6n8uPg2I6DoBjebcZO6uobdUe91lZWWMeuhpEo4lAvDixCcYMrBmEuhLxlKQxeHPnkOZy9BodUTfO1PmqxVCiGtElZswLBYLZrP5nPLk5GS8vLyqJSghRNXkHlvHyX2fAaB3D6J+72no9O52qVspxYTJr7J+4xYAht56M89PeNQudZ/NYjZx+PNJGPMyAIi69Sm8GrR3SCxCCCHsr8qJ7c0338y8efNszzUaDQaDgSlTpjBgwIDqjE0IUQkFaTtJ2f4OAFq9B1HXT0XvduH5Yp9+cRZPvzir2up/853FfPz5NwC0b9uSRe/MROugr/0TV82l4HgcAIGdBhLS826HxCGEEMIxqtwV4c033+SWW26hZcuWlJSUcM8993D48GECAwP5+uuvayJGIcQFFGXFk7TpdVBmNFo9Ub1extWn/kWPSUnNqLb6v/r2f0x9fS4A9SLC+O7z9/DwsE9L8dlObf+BjE3LAHCPaE7D215wyGwMQgghHKfKiW1kZCR79uxh2bJl7NmzB4PBwIMPPsjIkSNxc3OriRiFEOdRWpBC4sZpKHMpaLTU6z4Rj6DWdqt/7YZNPPrUSwD4+niz4qsPCAsNtlv95eUd2c6x718HwMnDl6b3zUGrd3FILEIIIRynSoltWVkZzZs3Z9WqVYwcOZKRI0fWVFxCiIswleRw4vcpmI35AIR1egzvej3sVv+uuL+5Z8x4TCYTzs56ln26wGEzIBSmHuLwZ8+izCY0Oj3R983BxS/MIbEIIYRwrCp1hNPr9ZSUlNRULEKISjCXFZH4x3TKCtMBCGp5N/6Nq3+mgwuJP3yUYfc8TGFRERqNho/fncN13Tvbrf7ySrJTiP9oHOaSQgAaD5+Kd0PHLN0rhBDC8ao8wuPxxx9n1qxZmEymmohHCHERFlMJiX/OoDj7MAC+DWIJam2/b06SU9IYPHwsmVk5AMx942WGDepnt/rLKyvMJf7DcZQVZAEQNWgCAe0dE4sQQoirQ5X72G7fvp1169axZs0a2rRpg4dHxVWFvv/++2oLTgjxL4vZSOKm1yg6uQ8Az7DOhHd+osoDpJ5+7PJW4MrMymHw8LEkp1hXNXtl0ngeun/EZZ3rSlnKSji05GlKMq3z5oZdP4qwXvc4JBYhhBBXjyontr6+vtx++7mrGQkhao7FbCTxzxkUpu8GwCOkHZE9J6PRVvktTPfO7at8TIGhkNvueYT4w0cBeOyhUTz39H+qfJ7qoCxmEpZNxZBoTfADOvYncsA4h8QihBDi6lLlT8UlS5bURBxCiAtQFjPJf71pS2rdg9sQdd3LaHXOlziyehQYCrnj3v+wM86aSN59xyBmTX/eIVNpKaU4vnI22XvXAuDVqCON7nhZlssVQggBXEZiK4SwH6UspO5cSEHyZgDcA1tSv9cUtE6ul33Ou8ZMAOCbJW9fct/snFyGjXiEHbv3AnBLbG/en/eawxZgSP71XU7+tRwAt5BG1mm9nOyT4AshhLj6XVZi+9133/HNN9+QmJiI0WissG3Xrl3VEpgQ1zplMZO6YyG5x9YA4OrbkKher1xRUlsV6SdPMejOB/nnoHWgWv+b+vDFh/PQ6/V2qf9sKes+IvX/rN8YufhH0HzsQpzcfRwSixBCiKtTlZtd3nnnHcaMGUNISAi7d++mS5cuBAQEcPToUfr3718TMQpxzVEWE8l/vWlLap29Ioi6fho6Z0+71J+YlMLNg++1JbV3DB3A10vewdXVMYsepKz7iORf3wNA7xVI84cW4uwT5JBYhBBCXL2qnNi+++67LFq0iPnz5+Ps7Mxzzz3Hb7/9xvjx48nLy6uJGIW4pljMZSRtep38pD8AcPFpQIO+b6B387dL/YcTjnHTkFEkHLPOOHD/yDv4+N3ZDmmpVUqRsvbDf5NazwBaPPI+rgH17B6LEEKIq1+VE9vExER69LCucOTm5kZBQQEAo0aN4uuvv67e6IS4xlhMJSRtepWC1G0AuPlH06DvTPRufnapf9/+eG4aPMo2pdcTj4xmwVvT0el0dqm/PKUUSb/MJ3nN+wDovaxJrVtwA7vHIoQQonaocmIbGhpKdnY2AFFRUfz1118AHDt2DKXUZQWxcOFCGjRogKurK127dmXbtm0X3Hfx4sX06tULPz8//Pz8iI2Nvej+QtQWZUWnOLZuEoa0ncDpgWJ9XsPJxcsu9W/fuYdbht3HqUzrggcvTnyCN6ZNcszsBxYzx1e8QdqGzwDQ+wTT4pEPcAtpaPdYhBBC1B5VTmxvuOEGfvjhBwDGjBnD008/zU033cTw4cMZNmxYlQNYtmwZEyZMYMqUKezatYt27drRr18/Tp48ed79N2zYwIgRI1i/fj1btmwhMjKSm2++mZSUlCrXLcTVoijzIEd/m0BJbgIAHqEdrH1q9e7VXtdbrz7HW68+V6Hs9z+3MvCOB8jNywdg5rRJvPDs4w5Jai2mMo589ZJt9gMX/whaPrpYWmqFEEJckkZVsZnVYrFgsVhwcrJOqLB06VI2b95MdHQ0jzzyCM7OVZt6p2vXrnTu3JkFCxbYzh8ZGcm4ceN4/vnnL3m82WzGz8+PBQsWcN99l15RKT8/Hx8fH/Ly8vD29q5SrELUhNwTG0jdNg9lsS5T7d9kIKEdHkajtc/X/7+sWc/IsU9RWmpEo9Ewf85Uxoy6yy51n81cUsihz58j//BWANxCG9P8wQUyUEyIGiCfh6IuqvJ0X1qttsIclnfffTd33333ZVVuNBrZuXMnkydPrnD+2NhYtmzZUqlzFBUVUVZWhr//+QfWlJaWUlpaanuen59/WbEKUd2UUmQe+IaT+z63Fmh0hHV8BP8mA2q03qSUdAAiI0L5dsVPjH3ieUwmE05OTny44A3uHDawRuu/kDJDDvEfP0lh8j8AeNZvS7Mxc2VKLyGEEJV2WfPY5ubmsm3bNk6ePInFYqmwrTKtpmdkZmZiNpsJCQmpUB4SEsLBgwcrdY5JkyYRHh5ObGzsebfPnDmTadOmVTomIexBWcyk7XqPnITVAGj1HkT1fBGPkLY1XvczL81GAV07tGDKa9ZFGlxcnPli8TwG9Otb4/WfT0l2CvEfjqMk0zoTg2/znjS5dxY6Z/vM2SuEEKJuqHJi++OPPzJy5EgMBgPe3t4V+uBpNJoqJbZX6o033mDp0qVs2LABV9fzfwBOnjyZCRMm2J7n5+cTGRlprxCFOIe5rIjkLXMwpG0HQO8eRNT103D1ibJL/Uop0jNOMeW1XwDw9vLk6yXz6dOrm13qP5sh8W/iP5mAyWAdlBrYcQAN73wFrU4WRhRCCFE1Vf7keOaZZ3jggQd4/fXXcXe/soEtgYGB6HQ6MjIyKpRnZGQQGhp60WPffPNN3njjDdauXUvbthdu5XJxccHFxTGTygtxNqMhjcQ/X6U07wQArr6NiLp+Cnq3ALvUn5ObR1JKGoWFRQBE1gtj+Rfv06pFU7vUf7asPb+RsGwqymTtLhTW5z4ib3kCjYOW7BVCCFG7VfnTIyUlhfHjx19xUgvg7OxMp06dWLduna3MYrGwbt06unfvfsHjZs+ezYwZM1i9ejUxMTFXHIcQ9lCQspWENU/ZklrPsE40uOENuyW1+/bH0+vmO21Jbaf2bVj/81KHJLVKKZJ/W8yRLydbk1qtjgbDnidqwHhJaoUQQly2KrfY9uvXjx07dtCoUaNqCWDChAmMHj2amJgYunTpwrx58ygsLGTMmDGAtc9uREQEM2fOBGDWrFm88sorfPXVVzRo0ID0dOtAGE9PTzw97bPcqBBVYTGXcXLfZ2TFr7CVBTS/nZA299lt5oOVq9bw8LjJFBYV0ahxNF5enqxe8RHu7m52qb88c0khCd9MJefv9QDoXD1pcu8b+DZ1TFcIIYQQdUelEtsz89YCDBw4kIkTJ/LPP//Qpk2bc5bZHDx4cJUCGD58OKdOneKVV14hPT2d9u3bs3r1atuAssTExAqzMLz33nsYjUbuuOOOCueZMmUKU6dOrVLdQtQ0oyGd5C2zKM4+DIDWyY2Irk/jXa+HXeo3m828Ons+s+d9AFj7wQcFBRDg7+eQpLb45HEOffYsJSePA+ASUI9m98+VhReEEEJUi0rNY6ut5FeDGo0Gs9l8xUHVJJm3T9hLXuJGUncswFJm/erf1bcx9Xo8h4tXhF3qP5WZzYOPP8e6DZsA8PH24uN3Z3PLTX3sUv/Zsv9eT8LSKViM1t+HT7MeNBnxKk7u8j4UwhHk81DURZVqsT17Si8hxIVZTCWk7V5E7tE1tjL/6EGEtHsArU5/kSOrz+69+7n7/nEkp6QB0LxpY5Z+Mp/oxvZvGbWYykhe/S5pGz+3lUXEPkRE7EPSn1YIIUS1kvl0hKhGpQUpJP35GqX51vlYdc7eRHR5Eq+IrnapXynFx59/w8SXXqe01AjAHUP6s+DtGXh5egCwZXscAN07t6/xeEqyUzjy5WQKk6yLLuhcPWh89wz8Wl5f43ULIYS49lS6uWTLli2sWrWqQtlnn31Gw4YNCQ4O5uGHH66wwpcQ1xKlFDlH13B0zVO2pNY9qDWN+71jt6Q2JTWdoSMeZvzEqZSWGtHpdMycNolPPnjLltQCzH33M+a++1mNx5O97//4e95IW1LrHt6M1uO/kKRWCCFEjal0i+306dPp06cPt956KwD79u3jwQcf5P7776dFixbMmTOH8PBwGcAlrjllRadI3T4fQ/ouW1lgizsJbn2vXWY9UErxxbKVTHp5Jnn5BQCEh4Xw8buz6dWjS43XfzZzSSEnVs3l1LaVtrKQnncTNXA8Widnu8cjhBDi2lHpxDYuLo4ZM2bYni9dupSuXbuyePFiACIjI2VmAnFNUUqRe3QN6XEfYjEVA+Dk5k94zDi8wjvbJYbEpBTGTZzK2vV/2spGDh/KrOnP4+frY5cYyss7soOj307DmGPt26tz86LRna/g39oxS/UKIYS4tlQ6sc3JybFNwQXw+++/079/f9vzzp07k5SUVL3RCXGVMhaeJHXHfArTd9vKfBvEEtphLDrnmp9P2WKxsOSLb3lh6mwMpxdcCA0JYv6caQzoZ/8k0lxSSNLqhWRs/sZW5t04hkZ3TcXF7+KrCAohhBDVpdKJbUhICMeOHSMyMhKj0ciuXbuYNm2abXtBQcE5c9oKUdcoi5mco7+SsWeJw1pp4w8f5alJ09m4aaut7L4Rt/H61Ofs3kqrlCJn/waO/28OZXknAdDqXYgcMJ6Q7nfKrAdCCCHsqtKJ7YABA3j++eeZNWsWK1euxN3dnV69etm27927l8aNG9dIkEJcDYpzEkjb+T7FWQdsZb4NYwltb59W2gJDIbPnvs/8Dz6lrKwMgHoRYSx8ewaxfXpW+jwR4SGX3qkSSrNTOb5yNrkH/+0G4dWwI43ufBnXwMhqqUMIIYSoikontjNmzOC2226jd+/eeHp68umnn+Ls/O9AkI8//pibb765RoIUwpFMJblk7PuM3KO/Adb1TPTuwYR1etQurbRKKVauWsOzL75GesYpwLoYykP33820Fyfg7VW1pHrua5OuKB5LWSlpGz8nZd0SlMk6E4rOzZuogeMJihksrbRCCCEcplIrj5WXl5eHp6cnOl3F0d7Z2dl4enpWSHavRrLSiqgsi7mM7COrOLX/a9vqYWh0BDQdTHDrkWidXGs8hgPxR3hh2mzWrPvDVtalUzveev0lOrZvXeP1ny334CaO/28OpVnJtrLATrcSNfBJ9J5+do9HCHH55PNQ1EVVXqDBx+f8ffj8/f2vOBghrgZKKQzpO0nf/SHGgn8TOM/QToR2GIuLd81/zZ6alsGrs+fz+dIVtpX/Avx9eW3Kc9w7fCgajeayz/3NytUA3DX0lkofU3IqkRM/zSP3n422MrfQJjQYNgnvhh0uOxYhhBCiOsnKY0KUU5R5gIx9n1F0cp+tzNkrgtD2Y+3S7SAnN4933lvC/A8+pbi4BACtVst9I25j2osTCAy48lbR7/5nXeq3MomtsSCTlLUfcWrr9yiLGbCuHlbv5kcJ6X4HGp38CRFCCHH1kE8lcc1TyoIhbSdZh/5HYUacrVyrdyeo5d34Rw9Cq6vZGT/S0k+yYNGnfPjJUtv0XQD9b+rD9Jcm0LJ5dI3Wf7aywlzSN35J+p9fYykrsZUHdrqVyAFP4OwVaNd4hBBCiMqQxFZcsyxmI7nH/4+s+JUVuhxotHr8mgwgqMWdOLn61mgMKanpvDV/MUu++BajscxW3ql9G16b8qzdVw4z5p0i/Y+vyPjrOyzGYlu5T9NuRPZ/Ao+I5naNRwghhKgKSWzFNaes6BTZR34i5+gazKX5tnKtkxu+DWMJbH47eveabZFMSk5l7sKPzkloe3TtxLNPPszNN/S6on60VVWak07a759ycutKlPnfeDzrt6Vev8fwaRJjt1iEEEKIyyWJrbgmKIsZQ/ouchJWU5C2HZTFtk3vHoR/9CD8GvVD5+xRo3Hs3X+QhYs+Y+l3P2IymWzlN/bpyQvPPk63zvYdiFWYeoiMP78mc/cvKPO/8Xg17Ej4jQ/gE93Vrgm2EEIIcSUksRV1mtGQTu7xdeQcXYOpOKvCNvfAlvg3GYh3ZE802pp7KxiNRn78ZR0ffrKUjZu3VdgW2/c6XnjmMbraMaHt2qkNpdmpHPjgP+Qn7KiwzadpNyJiH8KrQTu7xSOEEEJUF0lsRZ1jLDxJfvIm8pM2UZx1sMI2rZMr3lHX4994AG7+TWo0juSUNJZ88S1LvviWjJOZ/8ag1TJ4QCzPjHvIrnPRmksKObXzR24s/B+lhmTyDac3aLT4tepNeN/78YxsZbd4hBBCiOomia2oE8qKMslP3kJ+0h8UZf5zznZXv2j8GvfDJ+p6dHr3GotDKcXaDZtY9PFXrF77u20OWgA/Xx9GjbiNR8bcQ4P69WoshrMVZRzl5JbvOLXzJyylhbZynasHQZ2HEtLzLlz9I+wWjxBCCFFTJLEVtZJSitL8JAyp28hP+eucllkAvUcoPlHX4RPVB1ffBjUaz6nMbJZ+9wNLvviW+MNHK2zr1L4ND40ZwR1D+uPmVvOrlQFYTEay967j5NbvKTi2u8K2Fafq4xHejBdeeBGda832KRZCCCHsSRJbUSsopSgrTKfw5N8UntpHYUYcpuLsc/bTuwfhHdkLn/q9cfVtVKMDn0pLjaxZt5Gvvv0fP6/ZUGEwmLubG3fdNpCxo++mQzv7fL2vLBYMiXvJivuVrLg1mIryKmz3adqdkB53kjBnBZrUEklqhRBC1DmS2IqrkrKYKck9SlHmPxRlHqTo1H5MJecmsgDOnuF41euOT72euPpH12gyazQaWbdhE8t/WM1Pq/+P/AJDhe1NGtVnzKi7GH3P7fj5nn/56eqklKIwaT/Ze9eRtfc3jLnpFbY7efgRFHMrwV1vwzXQuhSwhpU1HpcQQgjhCJLYiquCuayY4qx4ijL3U5R5gOKsg1hMJefdV6t3xyOoNR4hHfAM7YCLd832VzUUFrJ2/SZ++vX/+PnX9eTm5VfY7unhzrBBtzBqxDB6dO1U49NjWUxlFBzdSc6BP8nZv+GcZBaNFp/oLgTFDMKvdV+0Ts41Go8QQghxtZDEVtidUgqjIY3izAPWJDY7npK8ExXmli3PydUXt8CWeAS2wj2oFa6+DdFodTUaY05uHv/3+2ZWrlrDz2vWU1JSWmG7m5sr/W68nmGD+jHg5r64u7vVaDxlhmxyD24m58BG8g5trTAIDACNBq/67fBvdxMBbWPRewXUaDxCCCHE1UgSW1HjzGVFlOQcpTj7EEWZ/1CcdRBTSe4F93f2qod70L+JrN4jpMZbQY1GI7v27GfDH1v47f/+ZNvOPRVmNABrv9kb+/TgtsH9GdCvD54eNddHVSlFcfoRcg78Qe6BPzEk7gOlKu6k1eHVoB3+bW7Av/UNOPsE11g8QgghRG0gia2oNspixliYgbEgmZLc45TkHqUkJwGjIe2Cx2h0LrgFNMXdvxlugc1xD2yJk4t3jcdaYChk+849bNm2iz+37GD7rj0UF5/b9cHTw52Bt9zIHUP60/f67jU6q4GxIJOCY3HkJ+wg98Cf53YxAHRu3vg274lfi+vwadodJ/eq/67uGHJzdYQrhBBCXHUksRVVppTCXJpPaX4SJXlnEthjlOafQJmNFz1W7x6EW2AL3AOsSaw9uhWYzWbiDx9lZ9zf7Ny9l20797Bvf/w5LbJntGjWmNi+vbjphuu4rltnXFyqv4+qUorS7BQMJ/aRf3QXBUd3UpKZeN59XYMb4tfiOnxbXo9XVBs0uit729419JYrOl4IIYS4WkliK87LYi7DVJyJ0ZCBsTCdssJ062NDOkZDKpaywkueQ+8ehKtvI1z9GuHq2wg3/2j07oE1GndpqZGDhxPYtz+effsPsmffP+zesx9DYdEFj2netDHXdY+hZ7fOXNc9hvCwkGqPy1SUhyFpP4bE/RQm/Y0haT+mwtzz7qvR6fFq1AG/Fr3wbdEL1wD7LeYghBBC1GaS2F6jLKZSTCXZlBVlYSrOwliYQVnhSYyGVIyGNMqKMgF1yfMAaPUeuPo2xNW3IS4+9XHxroeLd32cXLxqLH6TycTxxGQOxidw4FACB+KPsG//QQ4dOVZhPtmzubu50aFdS7rEtKdbTAe6delIYIBftcZmMRkpSj2EIelvDIn7MST+TWlW0gX31+pd8WzQFu9GHfFq0AHPqNZo9S7VGlN5T784C4C5r02qsTqEEEIIR5DEtg5QSqHMpVhMxZjLijAbDZiNBZhLCzAbDZhKczEV52AqzqKs2JrImo0FVatEo8PZIxi9RwjOnqE4e4ZbE1if+ujdg6t9cJfZbCYt/SSJyakkJqWSlJJGYlIKxxOTOX4imcTk1IsmsAB6vZ6WzZvQqX0bYjq0oWP7NrRo1hgnp+p72SuzieJTxylMiacwaT+GpL8pSj2EMl84NtfAKDwiW+EZ1QrPyNa4hzdD66SvtpguJSU1w251CSGEEPYkiW0NURYzSplRFhPKYgZlvVcW01nlZizmUiymEuutrBiLqfj08wvcl5VgMRX9e4yphMq2rl6MztnLlrTqPUNx9ghB7xGMs0coevegau0LW1pqJDk1jaTkNJJS0khOSeVEYiqJyakkJVsT2bKyskqfLzQkiFYtmtKmVTPatGxO65bNaBbdEL2+ehJGi8lIyalEik8e+/eWcYySUydQ5gvH6eThi2dk69OJbGs8I1vi5F7zCzcIIYQQ16JrNrHN2Ps5he56lDLD6SRTVUg+TXCeRFRZTFD+uTp/eXUkmtVGo8XJxQcnN3/0bgE4uQX8e+9+5j4Ind69WqorLCziVGY26SdPkZKaTmpaBqnpJ0lOSSMp2Zq8ZpzMrPJ5/f18qB9Vj4b1I2kQVY/GDaNo1rQxzZs2rpZVvpRSmAzZlGQlU5KZREnmCYpPHqco7Qil2SkXnGf3DI2TCx4RzfA8ncR6RLXGxS+8xqcqE0IIIYTVNZvYZh/+AaO7/b7+vSwaLVont9M3V+u93vXfx2fd65zc0Ord0Dl7oXP2PH1vfXwlra3FxSXk5uWTk5tHdk6u9Zady6nMbDJOZZFx8hRp6SfJOJlJxslMCosuPFDrYoKDAqkfGU5UvXCioiKoHxlBZL3TzyPDr2jeWKUU5pJCygoyMeZlYMw7iTE3g9LcdEpz0jDmpmPMTcdSVnrpkwHOvqG4hTTCLbgh7qGNcQ9viltoE7RXOGOBEEIIIS7fNfsprNE5o3VyRaN1siZ9Guu9RuuERqM7f7lWh+b0c87ar0L5ebZxnnPbnju5nDdRtW6//NY+i8WC0ViGoaCQ4pISDIZCDIYi8gsMFBQYyDdY73Nz88nJy7fe5+aRk5tLdk4eObl55Obln7Pq1uVwcXGmXngo9SKsiWpkvTAi64VTLzyUqMhw6oWH4epa9QFTlrISygy5lBmyrbeCzNO3LIz51nvrLbPSSauNRouLfzjuoY1tSaxbcENcg+qjc6me1m0hhBBCVJ9rNrFtPPATPD29sFgs1ptS/z62WLBYTj9XFpRFVShXSmFRZ+135rGyYDFbMJlMmMxm673JjMlsxmw2YzaZMZnLMJlKTpef3m4yUVpqpKS0FKPRePqxEWOpkVLj6fJSI6XGsnKPy+9fds6xVemjerm8PD0ICQ4kLDSYkOAggoMCCA4KJDgogJDgQCLCQgkLDSbA3/e8SboymzCXFmIqyqQwqwBTsQFziQFzSQHmEgOm4nL3xQWYivNt96aifCzG4iuK38nDFxffMJz9QnHxDcXZLwzXgHq4Bkbh4h+O1qn657B1tKcfu8/RIQghhBA1QqPU2et01m35+fn4+PjgFhhd4wsD1Cbubm74+nrj6+NNgL8vfr4+1pufD74+Pvj5eOHn44Gvlxt+nm74erri6+GGsxNYjNYBbWZjMRZjsfW+tAizsRhzSSHm0kJrslpa9O/j0wmspezc1b6qg87NC71XAM5egei9AtCfvnf2DsTZJxhn72CcfYPR6mtuJTEhhLianfk8zMvLw9u75ld8FMIerooW24ULFzJnzhzS09Np164d8+fPp0uXLhfc/9tvv+Xll1/m+PHjREdHM2vWLAYMGGDHiEEDnGmA1ADaM481/2670D2n99ecPlqn/fccOq31Xq/T4eqix81Fj4uzHhe9Ey4uelzPPHbW4ax3sj7WO6HX63Bx0uGs1+HspMVZp8VZr0Wv0+Cs06DXaXC17aM9vQ/osOCEGY2lDEtZablbCpayo9YZGE6WYkkthdP/A5UBp07f7EHr4oHO1QMnNy+c3LzRuXri5O5jfe7ph97DD72nP06e/jh7BaD3CqjReWCFEEIIcXVyeGK7bNkyJkyYwPvvv0/Xrl2ZN28e/fr1Iz4+nuDg4HP237x5MyNGjGDmzJnceuutfPXVVwwdOpRdu3bRunXrSte7YqQfHi46znw5rrHNYqBOl5V7rs48V9h/fLv59K0KTKdvF+lSagFqpq20HI0G3emkVOfiUfGxq+fpm/Wxk6snOlvS6nW6zAudq4e0rFezu8ZMAOCbJW87OBIhhBCiejm8K0LXrl3p3LkzCxYsAKwDniIjIxk3bhzPP//8OfsPHz6cwsJCVq1aZSvr1q0b7du35/33379kfWe+elk3vj0eLtdewqTROaHR6dHonNA6OVtnWdC7oHVysd47V3yuOb1dp3dFoz+9j+3m+u/xehd0zu5onV3RObuhdXFH6+SCRqt19I8sziKJrRACpCuCqJsc2mJrNBrZuXMnkydPtpVptVpiY2PZsmXLeY/ZsmULEyZMqFDWr18/Vq5ced79S0tLKS39t+kyPz8fgKCuw/DycAM01kFNGg1gvT/v8zOPT9+f2W7b9+znVDzu7POUP5dGowWttty9zpoQanWnZ1Uo91irhdPbrTcn0Jx5rLMlrRqdHu2ZJNZJb73X6mROVSGEEELUWQ5NbDMzMzGbzYSEhFQoDwkJ4eDBg+c9Jj09/bz7p6enn3f/mTNnMm3atHPK69/6lPyHKoQQQghRh9T574knT55MXl6e7ZaUlOTokIQQQgghRA1waIttYGAgOp2OjIyMCuUZGRmEhoae95jQ0NAq7e/i4oKLi4yQF0IIIYSo6xzaYuvs7EynTp1Yt26drcxisbBu3Tq6d+9+3mO6d+9eYX+A33777YL7CyEqeuvV53jr1eccHYYQQghR7Rw+3deECRMYPXo0MTExdOnShXnz5lFYWMiYMWMAuO+++4iIiGDmzJkAPPnkk/Tu3Zu33nqLgQMHsnTpUnbs2MGiRYsc+WMIUWtERpz/2w0hhBCitnN4Yjt8+HBOnTrFK6+8Qnp6Ou3bt2f16tW2AWKJiYloy00Z1aNHD7766iteeuklXnjhBaKjo1m5cmWV5rAV4lqWlGIdaCkJrhBCiLrG4fPY2pvM2yeudTKPrRAC5PNQ1E11flYEIYQQQghxbZDEVgghhBBC1AmS2AohhBBCiDpBElshhBBCCFEnOHxWBHs7M1YuPz/fwZEI4RhlxlJA3gNCXOvO/A24xsaQizrumpsV4ejRozRu3NjRYQghhBBXhYSEBBo1auToMISoFtdci62/vz9gnR/Xx8fHobF07tyZ7du3O/x8VTmuMvteap8Lba9seX5+PpGRkSQlJTl8ihq5hpdXLtfwyo6Ta1iRXMPLK8/LyyMqKsr2uShEXXDNJbZnFnvw8fFx+B9jnU5XrTFc7vmqclxl9r3UPhfaXtVyb29vuYaXcZxcw4rkGl5ZuVzDyzvuarqG5RdBEqK2k1ezAz3++ONXxfmqclxl9r3UPhfaXtXyq4FcwysrvxrINbyy8quBXMMrKxeiLrnm+tjKSiu1n1zD2k+uYe0n17D2k2so6qJrrsXWxcWFKVOm4OLi4uhQxGWSa1j7yTWs/eQa1n5yDUVddM212AohhBBCiLrpmmuxFUIIIYQQdZMktkIIIYQQok6QxFYIIYQQQtQJktgKIYQQQog6QRJbIYQQQghRJ0hiewnDhg3Dz8+PO+64w9GhiEpatWoVzZo1Izo6mg8//NDR4YjLIO+72i0pKYk+ffrQsmVL2rZty7fffuvokEQV5ebmEhMTQ/v27WndujWLFy92dEhCVIpM93UJGzZsoKCggE8//ZTvvvvO0eGISzCZTLRs2ZL169fj4+NDp06d2Lx5MwEBAY4OTVSBvO9qt7S0NDIyMmjfvj3p6el06tSJQ4cO4eHh4ejQRCWZzWZKS0txd3ensLCQ1q1bs2PHDvlbKq560mJ7CX369MHLy8vRYYhK2rZtG61atSIiIgJPT0/69+/PmjVrHB2WqCJ539VuYWFhtG/fHoDQ0FACAwPJzs52bFCiSnQ6He7u7gCUlpailELawURtUKsT240bNzJo0CDCw8PRaDSsXLnynH0WLlxIgwYNcHV1pWvXrmzbts3+gYpKu9JrmpqaSkREhO15REQEKSkp9ghdnCbvy9qvOq/hzp07MZvNREZG1nDUorzquIa5ubm0a9eOevXqMXHiRAIDA+0UvRCXr1YntoWFhbRr146FCxeed/uyZcuYMGECU6ZMYdeuXbRr145+/fpx8uRJ2z5n+g+dfUtNTbXXjyHKqY5rKhxLrmHtV13XMDs7m/vuu49FixbZI2xRTnVcQ19fX/bs2cOxY8f46quvyMjIsFf4Qlw+VUcAasWKFRXKunTpoh5//HHbc7PZrMLDw9XMmTOrdO7169er22+/vTrCFFVwOdd006ZNaujQobbtTz75pPryyy/tEq8415W8L+V9d3W43GtYUlKievXqpT777DN7hSouoDo+Hx999FH17bff1mSYQlSLWt1iezFGo5GdO3cSGxtrK9NqtcTGxrJlyxYHRiYuV2WuaZcuXfj7779JSUnBYDDwyy+/0K9fP0eFLM4i78varzLXUCnF/fffzw033MCoUaMcFaq4gMpcw4yMDAoKCgDIy8tj48aNNGvWzCHxClEVTo4OoKZkZmZiNpsJCQmpUB4SEsLBgwcrfZ7Y2Fj27NlDYWEh9erV49tvv6V79+7VHa6ohMpcUycnJ9566y369u2LxWLhueeek1G8V5HKvi/lfXf1qsw13LRpE8uWLaNt27a2vp2ff/45bdq0sXe44jwqcw1PnDjBww8/bBs0Nm7cOLl+olaos4ltdVm7dq2jQxBVNHjwYAYPHuzoMMQVkPdd7XbddddhsVgcHYa4Al26dCEuLs7RYQhRZXW2K0JgYCA6ne6czu4ZGRmEhoY6KCpxJeSa1n5yDWs/uYa1n1xDUZfV2cTW2dmZTp06sW7dOluZxWJh3bp18pVmLSXXtPaTa1j7yTWs/eQairqsVndFMBgMHDlyxPb82LFjxMXF4e/vT1RUFBMmTGD06NHExMTQpUsX5s2bR2FhIWPGjHFg1OJi5JrWfnINaz+5hrWfXENxzXLwrAxXZP369Qo45zZ69GjbPvPnz1dRUVHK2dlZdenSRf3111+OC1hcklzT2k+uYe0n17D2k2sorlUapWSNPCGEEEIIUfvV2T62QgghhBDi2iKJrRBCCCGEqBMksRVCCCGEEHWCJLZCCCGEEKJOkMRWCCGEEELUCZLYCiGEEEKIOkESWyGEEEIIUSdIYiuEEEIIIeoESWyFEEIIIUSdIImtuKgNGzag0WjIzc2tsTr69OnDU089VWPnvxilFA8//DD+/v5oNBri4uIcEseV0mg0rFy50tFh1Ah7vAbvv/9+hg4dWmPnr4wGDRowb948h8ZwNcVxJerCzyCEuDyS2Aq2bNmCTqdj4MCBjg6lUo4fP15tSejq1av55JNPWLVqFWlpabRu3frKAxS1zn//+18++eQTh8awfft2Hn744Urvb4+EXwghahtJbAUfffQR48aNY+PGjaSmpjo6HLtKSEggLCyMHj16EBoaipOTU5XPoZTCZDLVQHQVGY3GGq/jWuXj44Ovr69DYwgKCsLd3d2hMQghRG0nie01zmAwsGzZMh599FEGDhx4wVarTZs20bZtW1xdXenWrRt///23bduJEycYNGgQfn5+eHh40KpVK37++Wfb9t9//50uXbrg4uJCWFgYzz///EUTwfN9re7r62uLrWHDhgB06NABjUZDnz59bPt9+OGHtGjRAldXV5o3b8677757wXruv/9+xo0bR2JiIhqNhgYNGgBQWlrK+PHjCQ4OxtXVleuuu47t27fbjjvTUvbLL7/QqVMnXFxc+Omnn9DpdOzYsQMAi8WCv78/3bp1sx33xRdfEBkZaXs+adIkmjZtiru7O40aNeLll1+mrKzMtn3q1Km0b9+eDz/8kIYNG+Lq6grA4cOHuf7663F1daVly5b89ttvF/wZz+jTpw/jxo3jqaeews/Pj5CQEBYvXkxhYSFjxozBy8uLJk2a8Msvv1Q47mLXbtGiRYSHh2OxWCocM2TIEB544AHb8//973907NgRV1dXGjVqxLRp0y7rH4GLvQazsrIYMWIEERERuLu706ZNG77++usKx3/33Xe0adMGNzc3AgICiI2NpbCwEDi3K8LF9j3bmdfDTz/9dMH4AJYvX06rVq1wcXGhQYMGvPXWWxW2n/31uUaj4cMPP2TYsGG4u7sTHR3NDz/8AFi/tejbty8Afn5+aDQa7r///irHXhmJiYkMGTIET09PvL29ueuuu8jIyKiwz6uvvkpwcDBeXl6MHTuW559/nvbt21/wnDk5OYwcOZKgoCDc3NyIjo5myZIltu3JycmMGDECf39/PDw8iImJYevWrYD1n9EhQ4YQEhKCp6cnnTt3Zu3atRf9GXJzcxk7dixBQUF4e3tzww03sGfPnsv+nQghrmJKXNM++ugjFRMTo5RS6scff1SNGzdWFovFtn39+vUKUC1atFBr1qxRe/fuVbfeeqtq0KCBMhqNSimlBg4cqG666Sa1d+9elZCQoH788Uf1+++/K6WUSk5OVu7u7uqxxx5TBw4cUCtWrFCBgYFqypQptjp69+6tnnzySdtzQK1YsaJCnD4+PmrJkiVKKaW2bdumALV27VqVlpamsrKylFJKffHFFyosLEwtX75cHT16VC1fvlz5+/urTz755Lw/e25urpo+fbqqV6+eSktLUydPnlRKKTV+/HgVHh6ufv75Z7V//341evRo5efnZ6vnzO+kbdu2as2aNerIkSMqKytLdezYUc2ZM0cppVRcXJzy9/dXzs7OqqCgQCml1NixY9XIkSNt9c+YMUNt2rRJHTt2TP3www8qJCREzZo1y7Z9ypQpysPDQ91yyy1q165das+ePcpsNqvWrVurG2+8UcXFxanff/9ddejQ4by/s/J69+6tvLy81IwZM9ShQ4fUjBkzlE6nU/3791eLFi1Shw4dUo8++qgKCAhQhYWFlbp22dnZytnZWa1du9ZWT1ZWVoWyjRs3Km9vb/XJJ5+ohIQEtWbNGtWgQQM1derUC8Z6tsq8BpOTk9WcOXPU7t27VUJCgnrnnXeUTqdTW7duVUoplZqaqpycnNTbb7+tjh07pvbu3asWLlxouzajR49WQ4YMqdS+lxPfjh07lFarVdOnT1fx8fFqyZIlys3NzfaaVkqp+vXrq7lz59qeA6pevXrqq6++UocPH1bjx49Xnp6eKisrS5lMJrV8+XIFqPj4eJWWlqZyc3OrHPv5lI/DbDar9u3bq+uuu07t2LFD/fXXX6pTp06qd+/etv2/+OIL5erqqj7++GMVHx+vpk2bpry9vVW7du0uWMfjjz+u2rdvr7Zv366OHTumfvvtN/XDDz8opZQqKChQjRo1Ur169VJ//PGHOnz4sFq2bJnavHmzUsr63nr//ffVvn371KFDh9RLL72kXF1d1YkTJy74u4yNjVWDBg1S27dvV4cOHVLPPPOMCggIsL2nhRB1hyS217gePXqoefPmKaWUKisrU4GBgWr9+vW27Wc+tJcuXWory8rKUm5ubmrZsmVKKaXatGlzwUTlhRdeUM2aNauQLC9cuFB5enoqs9mslKp6Ynvs2DEFqN27d1fYp3Hjxuqrr76qUDZjxgzVvXv3C/78c+fOVfXr17c9NxgMSq/Xqy+//NJWZjQaVXh4uJo9e3aF38nKlSsrnGvChAlq4MCBSiml5s2bp4YPH67atWunfvnlF6WUUk2aNFGLFi26YCxz5sxRnTp1sj2fMmWK0uv1toRbKaV+/fVX5eTkpFJSUmxlv/zyS6US2+uuu8723GQyKQ8PDzVq1ChbWVpamgLUli1blFKVu3ZDhgxRDzzwgG37Bx98oMLDw23bb7zxRvX6669XiOXzzz9XYWFhF4z1bJV5DZ7PwIED1TPPPKOUUmrnzp0KUMePHz/vvuUT20vteznx3XPPPeqmm26qcNzEiRNVy5Ytbc/Pl9i+9NJLtucGg0EBttfTmXpzcnJs+1Q19vMpH8eaNWuUTqdTiYmJtu379+9XgNq2bZtSSqmuXbuqxx9/vMI5evbsedHEdtCgQWrMmDHn3fbBBx8oLy+vKiWdrVq1UvPnzz/vz/DHH38ob29vVVJSUuGYxo0bqw8++KDSdQghagfpinANi4+PZ9u2bYwYMQIAJycnhg8fzkcffXTOvt27d7c99vf3p1mzZhw4cACA8ePH8+qrr9KzZ0+mTJnC3r17bfseOHCA7t27o9FobGU9e/bEYDCQnJxcbT9LYWEhCQkJPPjgg3h6etpur776KgkJCZU+T0JCAmVlZfTs2dNWptfr6dKli+3nPSMmJqbC8969e/Pnn39iNpv5/fff6dOnD3369GHDhg2kpqZy5MiRCt0mli1bRs+ePQkNDcXT05OXXnqJxMTECuesX78+QUFBtucHDhwgMjKS8PBwW1n5a3Mxbdu2tT3W6XQEBATQpk0bW1lISAgAJ0+etNV1qWs3cuRIli9fTmlpKQBffvkld999N1qt9U/Lnj17mD59eoVr8tBDD5GWlkZRUVGl4j7fz3n2a9BsNjNjxgzatGmDv78/np6e/Prrr7bfZ7t27bjxxhtp06YNd955J4sXLyYnJ+e89VRl38rGd+DAgQqvKbD+Lg8fPozZbL7gOctfMw8PD7y9vW3Xpzpjv5Azr7fyXWhatmyJr6+v7WeLj4+nS5cuFY47+/nZHn30UZYuXUr79u157rnn2Lx5s21bXFwcHTp0wN/f/7zHGgwGnn32WVq0aIGvry+enp4cOHDgnPfOGXv27MFgMBAQEFDhdXjs2LEq/W0QQtQOkthewz766CNMJhPh4eE4OTnh5OTEe++9x/Lly8nLy6v0ecaOHcvRo0cZNWoU+/btIyYmhvnz5192XBqNBqVUhbLyfU/Px2AwALB48WLi4uJst7///pu//vrrsmO5GA8PjwrPr7/+egoKCti1axcbN26skNj+/vvvhIeHEx0dDVhnohg5ciQDBgxg1apV7N69mxdffPGcAWJn13El9Hp9hecajaZC2ZkE9uw+sxczaNAglFL89NNPJCUl8ccffzBy5EjbdoPBwLRp0ypck3379nH48GFbn+HqMGfOHP773/8yadIk1q9fT1xcHP369bP9PnU6Hb/99hu//PILLVu2ZP78+TRr1oxjx46dc66q7FvTznfNLnZ9rqbYL6Z///6cOHGCp59+mtTUVG688UaeffZZANzc3C567LPPPsuKFSt4/fXX+eOPP4iLi6NNmzYXHFxpMBgICwur8BqMi4sjPj6eiRMnVvvPJoRwLElsr1Emk4nPPvuMt956q8If+z179hAeHn7OwJvyyWFOTg6HDh2iRYsWtrLIyEj+85//8P333/PMM8+wePFiAFq0aMGWLVsqJKqbNm3Cy8uLevXqnTe2oKAg0tLSbM8PHz5coXXP2dkZoEJLV0hICOHh4Rw9epQmTZpUuJ0ZbFYZjRs3xtnZmU2bNtnKysrK2L59Oy1btrzosb6+vrRt25YFCxag1+tp3rw5119/Pbt372bVqlX07t3btu/mzZupX78+L774IjExMURHR3PixIlLxteiRQuSkpIq/H5qKnGvzLVzdXXltttu48svv+Trr7+mWbNmdOzY0bZ/x44diY+PP+eaNGnSxNaqW1kXew1u2rSJIUOGcO+999KuXTsaNWrEoUOHKhyv0Wjo2bMn06ZNY/fu3Tg7O7NixYrz1lWVfSsTX4sWLSq8ps7E3LRpU3Q6XeV/CeWc731wubFfyJnXW1JSkq3sn3/+ITc31/Z+aNasWYXBlcA5z88nKCiI0aNH88UXXzBv3jwWLVoEWFup4+LiyM7OPu9xmzZt4v7772fYsGG0adOG0NBQjh8/fsF6OnbsSHp6Ok5OTue8BgMDAy8ZpxCidqn63EaiTli1ahU5OTk8+OCD+Pj4VNh2++2389FHH/Gf//zHVjZ9+nQCAgIICQnhxRdfJDAw0DaK/KmnnqJ///40bdqUnJwc1q9fb/tAf+yxx5g3bx7jxo3jiSeeID4+nilTpjBhwoQLJjY33HADCxYsoHv37pjNZiZNmlSh5So4OBg3NzdWr15NvXr1cHV1xcfHh2nTpjF+/Hh8fHy45ZZbKC0tZceOHeTk5DBhwoRK/V48PDx49NFHmThxIv7+/kRFRTF79myKiop48MEHL3l8nz59mD9/PnfccQdg/Uq6RYsWLFu2jIULF9r2i46OJjExkaVLl9K5c2d++umnSiUfsbGxNG3alNGjRzNnzhzy8/N58cUXK/WzVVVlr93IkSO59dZb2b9/P/fee2+Fc7zyyivceuutREVFcccdd6DVatmzZw9///03r776apXiudhrMDo6mu+++47Nmzfj5+fH22+/TUZGhi352rp1K+vWrePmm28mODiYrVu3curUqQr/nJ1RlX0rG98zzzxD586dmTFjBsOHD2fLli0sWLDgorN2XEr9+vXRaDSsWrWKAQMG4Obmxv79+y8r9guJjY2lTZs2jBw5knnz5mEymXjsscfo3bu3rSvOuHHjeOihh4iJiaFHjx4sW7aMvXv30qhRowue95VXXqFTp060atWK0tJSVq1aZYtxxIgRvP766wwdOpSZM2cSFhbG7t27CQ8Pp3v37kRHR/P9998zaNAgNBoNL7/88kVbsWNjY+nevTtDhw5l9uzZNG3alNTUVH766SeGDRt2TpciIUQt59guvsJRbr31VjVgwIDzbtu6dasC1J49e2wDVH788UfVqlUr5ezsrLp06aL27Nlj2/+JJ55QjRs3Vi4uLiooKEiNGjVKZWZm2rZv2LBBde7cWTk7O6vQ0FA1adIkVVZWZtt+9uCxlJQUdfPNNysPDw8VHR2tfv755wqDx5RSavHixSoyMlJptdoKI7S//PJL1b59e+Xs7Kz8/PzU9ddfr77//vsL/h7OHjymlFLFxcVq3LhxKjAwULm4uKiePXvaBsoodf5BO2esWLFCAeq9996zlT355JMKUAcPHqyw78SJE1VAQIDy9PRUw4cPV3PnzlU+Pj627VOmTDnvAJz4+Hh13XXXKWdnZ9W0aVO1evXqSg0eK/87VurcwUpKnTtw71LXTinryPmwsDAFqISEhHPqXr16terRo4dyc3NT3t7eqkuXLhUG0Y0ePbrCNTxbZV6DWVlZasiQIcrT01MFBwerl156Sd133322AWH//POP6tevnwoKClIuLi6qadOmFQYblR88dql9Lyc+pZT67rvvVMuWLZVer1dRUVG2GTTOON/gsYsNolRKqenTp6vQ0FCl0WjU6NGjLxn7mViPHTt2wZ/n7DhOnDihBg8erDw8PJSXl5e68847VXp6eoVjpk+frgIDA5Wnp6d64IEH1Pjx41W3bt0uWMeMGTNUixYtlJubm/L391dDhgxRR48etW0/fvy4uv3225W3t7dyd3dXMTExthkujh07pvr27avc3NxUZGSkWrBgwTmv77N/hvz8fDVu3DgVHh6u9Hq9ioyMVCNHjqwwKE4IUTdolDqrM6MQQthR79696du3L1OnTnV0KJdlw4YN9O3bl5ycHIcv8nApS5Ys4fXXX+eff/45p/9udbrpppsIDQ3l888/r7E6hBDifKQrghDCYfLy8khISOCnn35ydCjXhJ9//pnXX3+9WpPaoqIi3n//ffr164dOp+Prr79m7dq1lVo4RAghqpsktkIIh/Hx8anWad/ExX377bfVfk6NRsPPP//Ma6+9RklJCc2aNWP58uXExsZWe11CCHEp0hVBCCGEEELUCTLdlxBCCCGEqBMksRVCCCGEEHWCJLZCCCGEEKJOkMRWCCGEEELUCZLYCiGEEEKIOkESWyGEEEIIUSdIYiuEEEIIIeoESWyFEEIIIUSd8P83HFh5QQYbwAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Empirical CDF of absolute moves per horizon against the median round trip."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "round_trip = 2 * dev[PRIMARY_LABEL][\"half_spread\"].median() * 10_000\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for name, colour in PALETTE.items():\n",
+    "    moves = (dev[name][name].abs() * 10_000).sort().to_numpy()\n",
+    "    ax.plot(moves, np.arange(1, len(moves) + 1) / len(moves), lw=1.8, color=colour, label=name)\n",
+    "ax.axvline(round_trip, color=COLORS[\"neutral\"], ls=\"--\", lw=1.2, label=\"median round trip\")\n",
+    "ax.set_xscale(\"log\")\n",
+    "ax.set_xlim(0.1, 1000)  # below a tenth of a bp the move is a stale quote, not a move\n",
+    "ax.set_xlabel(\"Absolute forward move, basis points, log scale\")\n",
+    "ax.set_ylabel(\"Share of bars at or below\")\n",
+    "sub = \"Absolute label against twice the median half-spread, development window\"\n",
+    "add_message_title(ax, \"The spread costs the same at every horizon while the move grows\", sub)\n",
+    "ax.legend(loc=\"upper left\", frameon=False)\n",
+    "show_with_alt(fig, \"Empirical CDF of absolute moves per horizon against the median round trip.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "1fd6af3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:12:14.684825Z",
+     "iopub.status.busy": "2026-07-31T09:12:14.684698Z",
+     "iopub.status.idle": "2026-07-31T09:12:15.076246Z",
+     "shell.execute_reply": "2026-07-31T09:12:15.075867Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_15m: median absolute move 16.34bps against a 5.03bps round trip, 79.3% clears it\n",
+      "fwd_ret_5m: median absolute move 8.74bps against a 4.98bps round trip, 65.3% clears it\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_60m: median absolute move 32.75bps against a 5.25bps round trip, 88.8% clears it\n"
+     ]
+    }
+   ],
+   "source": [
+    "for name in RETURN_LABELS:\n",
+    "    frame, moved = dev[name], dev[name][name].abs()\n",
+    "    clears = (moved > 2 * frame[\"half_spread\"]).mean()\n",
+    "    print(\n",
+    "        f\"{name}: median absolute move {moved.median() * 10_000:.2f}bps against a \"\n",
+    "        f\"{2 * frame['half_spread'].median() * 10_000:.2f}bps round trip, {clears:.1%} clears it\"\n",
+    "    )"
    ]
   },
   {
@@ -950,22 +1135,23 @@
     }
    },
    "source": [
-    "### Label Autocorrelation\n",
-    "\n",
-    "Autocorrelation of `fwd_ret_15m` at different lags reveals how quickly predictive\n",
-    "content decays and informs purge/embargo settings."
+    "Chapter 7.2 asks for the base rate to be tracked through time. The direction label is\n",
+    "where that question has an answer: its three classes are cut at a fixed band, so their\n",
+    "proportions are free to move, and a classifier trained on one regime and scored in\n",
+    "another is only comparable if they do not move much. The flat class is the interesting\n",
+    "one - it is the share of the session where nothing happens that is worth paying for."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 21,
    "id": "ba77953b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:21.984238Z",
-     "iopub.status.busy": "2026-07-14T04:54:21.984157Z",
-     "iopub.status.idle": "2026-07-14T04:54:28.216562Z",
-     "shell.execute_reply": "2026-07-14T04:54:28.206397Z"
+     "iopub.execute_input": "2026-07-31T09:12:15.077332Z",
+     "iopub.status.busy": "2026-07-31T09:12:15.077263Z",
+     "iopub.status.idle": "2026-07-31T09:12:15.344235Z",
+     "shell.execute_reply": "2026-07-31T09:12:15.343812Z"
     },
     "papermill": {
      "duration": 6.237156,
@@ -975,42 +1161,75 @@
      "status": "completed"
     }
    },
+   "outputs": [],
+   "source": [
+    "monthly = (\n",
+    "    dev[DIRECTION_LABEL]\n",
+    "    .with_columns(pl.col(\"timestamp\").dt.truncate(\"1mo\").alias(\"month\"))\n",
+    "    .group_by(\"month\")\n",
+    "    .agg([(pl.col(DIRECTION_LABEL) == k).mean().alias(str(k)) for k in (-1, 0, 1)])\n",
+    "    .sort(\"month\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "fc2042e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:12:15.345650Z",
+     "iopub.status.busy": "2026-07-31T09:12:15.345573Z",
+     "iopub.status.idle": "2026-07-31T09:12:15.426306Z",
+     "shell.execute_reply": "2026-07-31T09:12:15.425779Z"
+    }
+   },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  fwd_ret_15m autocorrelation at lag 1: 0.92294\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoIAAAEqCAYAAACBVzELAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAkwBJREFUeJzs3XV4U9cbwPFv6u5KaSletKUUirsNhwkMNmQCM8bGfhsyBmwM2diAIRuyocMdhsPQ4e4uReruktzfHymhoS200FKg7+d5+jS5+ubmJPfNueecq1IURUEIIYQQQhQ7BkUdgBBCCCGEKBqSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCAohhBBCFFOSCBYTC5euwdK1EpaulRgzYdpTb6dNl1667dwOuleAEYon6ff5UN2x3/vfkZdm2y+C5/X6iuo4Xrtxizff/YRSlevr9r9h0w7GTJime75w6ZrnFk9e3Q66p4uvTZdeRR1OgXrVP1PPQ2GW373/HdFtu9/nQ5+4fEGdQ/Mjt89HbselUkBz3fT8MCqwiF8yYyZMY+wv0wHo2a0zs6aM0827HXSPyrVa6J4nhl587vGJF8Pe/46w74D2S7z9a83xrZq/D5h4tdwOusffy7RfvNWr+NChbYsnrFH41Go13fsM4OLla4Wy/dPnLvLP5p0ANKxXm0b1axfKfsSrbdrM+cTGxQPw7defFXE0L46FS9cQdEdbqfJpv17Y2do89xiKbSIoRF7sO3BE94PBy9NDEsFi7vade3o/IF+ERPBW0F1dEliuTCkmjv8OczMzfCqU5cz5S8+8/TPnLule87D/IYmgeCrTZy8g6M59QBLBrBYtW8O+A0cBeKdbF71E0M3Vme3r/wbAxtq60GKQRFAIIV5iwSFhuse1A/xo3rh+EUbzckhMTMLS0qKowxDisUxNTagXWLPQ9yNtBPPh0ev1x0+epXXnd3HyrkHZ6o34YfxvZGRkPHE75y9eoe/HX1OzYXtKVqyDrUc1SlWuT9ee/dl/8Kjeso+2S1iycj0BjTpg71kd37ptWLVuc7bt7953iIat38TBy5eqtVsxc86ifL9WtVrNmAnTKOfbGCfvGrzWpfcTaxfWbNjKa116U6J8bew9q1OlVksGDR1NcOjDE9Wmrbt0r+f7cZN109/75BssXSth71md1NQ0AC5dua5btteHXwLZ23Vs37Vf91or+jfj99kL8/T6bgfdo89H/6Ns9UbYelSjRPna1GzYnv4Dh3H2/GUALF0r6WpCAD4aOCxbu4z5i1bSsdsHVPRvhrO3Pw5evlSv05qvhv5IRGQ0ALv2HtSt9+GAIXpxnDl/STfvjXc+zlPsABkZGYz9ZToVajTFsZQfrTq9w8kz5/WW2bBpB2+++wmVA1rgWqYmdiWr41OzGf0HDstz+85fpsymTZdelPdrgmMpP5y8a1CzYXu+HzeZpKRkvWWztk8JCQvn/U+/waNCIK5latLrwy+Jio7Jtv1t/+6jS49+lKpcD7uS1Snn25ie7w/UXSoBUBSFBUtW07x9D9zKBuBYyo/App2ZPmsBGo0m2zZn/LWIqrVb4VjKj0at32L3vkO5vr78tEFq06UXr3XtrXu+aNnax7YxysjIYPzE36no3wwHL1+at++R42fo7PnL9O7/FWWqNdQdg0++HM69+yGPjedBTK07P2w7tHj5ujy14c1LuQXte/rRwGG652N/mZ7ndlJ7/ztCuzf6ZvmOq0ej1m/xv2/H6i4RPurM+Uu0fb0vTt41KF21Id+Pm6z3Ht8PDuWjgd8S2LQzXpXqYutRjZIV6/Ba1z5s2LQj2/6zvj/rNm6jTrMu2HtWZ/Lvc3TL/XfoWGb7Sm0ZrBzQgsEjxhMdE/vY15dVfsocaL+ju/bsj1elutiVrE6FGk3p9/lQrt24lW3ZhMRExkyYRkCjDjiW8sOtbABtuvRi68692ZZd+882WnToiXu5WtiVrE7pqg1p0aEnw0f/gqIoj40p62dhwZLVTJs5n2qBrbH3rE5g0845vqbrN2/Tf+AwKtRoil3J6nj61KFLj37s2ntQt8yDc9iD2kBAt5/8tmWbNXcx1es8e0xPUhDn0CeV/wfl80FtIEDlWi30Pr/Pqw2t1Ag+pRu37vBa1z4kJiUBkJycwk+TZhARGc2UCaMeu+6FS1dZvvofvWkRkVFs3bGX7f/u558Vc2jcIDDbektWrOfm7Tu659du3KbPR/+jWhUfKpQrDcChoyfp0qMfaWnpANy8fYdBQ3+kauWK+Xp9Xw8fy8w5i3XP9x44QutO72JvZ5vj8sNH/8KkaX/pTbsVdJeZcxaz9p9t/PvPErxLlaRuoD8qlQpFUThy/LRu2SPHTgGQlpbOqTPnCaxVg8OZ0wDq1w3Its99B46wZMV63Yni7r1gvh4+Fp8KZWnWuF6ury0jI4NO3T/g6vVbummxcfHExsVz6cp16taqQbUqeTteqzdsZefu//SmXb8ZxPWbi9i9/xD/bV9Fk4Z18PYqya2gu2zYtIPkn1MwNzcDYNPWf3XrvdW1fZ72CTB01M+cu3BZ9/y/Q8dp27UPe7cup3xZbVnYvms/m7bt0lvvzt1g/l66hm0793F411pcnB0fu59Fy9Zw5dpNvWmXrlzn0pXrHDp6is2r5+W4Xov2PfXK6qr1WzAyNmbO7z/rpo37dTo//qyfTASHhLH2n230f68nXp4egLbR/eLl6/SWO3fhMt98N44jx04xf9ZE3fTJv8/h2+8n6J4fP3WWzm/3o2xpr8e+zsLw9fCxXLpyXff80NGTdO/9GWcObcHISPvVu3XnXt7uO0D34we0x2D+4lVs2bFH97kpaHkpt2Zmpk+9/SvXbtK1Z3+Sk1N00yIio4mIjOb4qbN8/EFPbG30L3XduHWHlh16kpD48Dv158kzKeXpQZ933gS0n/GFS1frrRcdE8ve/w6z97/DzJo6jp5vdc4Wz38Hj7F4+bpsydC8v1cw4OtResnm7Tv3mDZzPtt27uXfjUty/c57IL9lbtbcxQwa+qNeLPfuh7Bo2VrWb9zOxpVzqVmjGqD9XmrZ8R3OX7yiWzaFVPYdOMq+A0eZNP47+vXtAWi/D9/98Eu91xIWHkFYeAQHj5xg1NAvdOXuSX6eNEPv83vuwmW69/mMi8d36o7HsRNnaP/me8QnJOqWi4qOZdvOfWz/dz+Txn/Hh33eztP+8mLy9L/0Pk+FFVNBnEPzUv5fJFIj+JTu3Q+hTu0arFz4OyMGf46hoSEAfy1YpqtRyk35cqUZ9/1gls2bxqZV89i4ci6//TwSU1MTNBoNv0yZleN6N2/foXeP11n19x80aVgHAI1Gw7xFK3XLDB35k64AN21UVxdffhqSX756g1lzlwBgYGDAt19/xqq//6B2gB+372SvZTh6/LQuCTQzM2XsqG9YseB3GtXXJrOhYRF8MeQHAOztbKnsUx6A4yfPotFoCAuP1PvSOZSZAB4+elI3rV5g9kQw6M592rZqysqFv/NG57a66XMWLn/i63uQBDZtVJe1S2ez6u8/+HXscFo1b4iJqQkA29f/zbvdu+rW+3pgf7av/5vt6/+mdfNGALze6TX+mDyGVYtmsGXNfFYtmkGPtzoB2oRp3cbtqFQq3n27CwDxCYlszJL8bdyqTdQszM1p17rpY+PO6sbNICb8OIxl86bh71cVgLj4BEaOmaRbpnmTekyd8D0rF/7OljXzWbt0Np9/3BfQniDmZyk3uXm/Vzf+nP4TqxfPZMua+axY8DutW2hf+97/DnMoy3uUVXJKCn9N/5nJP43AxMQYgJVrN+lqgk6cOqeXBPbu8TorF/7OvBm/0LVjGwwMVIC2lvlBElihXGnmzfiFlQt/p3ZNX+02121m5dpNgDYh+PHnqbptfvz+O6xaNIPXO7XRO4E8rV/GDOeXMd/qnrdq3lBXHr75on+25a/fDGL0d1+xZO4USnq4A9okY8eu/QAkJSXTb8BQUlPTMDIyYtTQL1i//E++/Ox9QP9z8zQxubk657peXsotwKI/f+PrgQ9f27vdu+q23+vtrjluG+DfPQd0J8FPPnyXjSvnsuiv3xg5ZCD+flVRqVTZ1rl3P4RqVXxYPn86H3/wrm76X1k+z64uzvwwfBCL5/zGPyvmsHn1fGZNHYeTowOgTWBycivoLv6+Vfn7z8ksmzeNeoE1uR8cyqBhP6LRaLC2suTXscNZt+xP3Wf+yrWbjBo7KcftPZDfMnf3XjCDR4xHURQMDAwY/OVHrFo0g64d2wDa74f+A4fqksTvx03WJYGtWzRi1aIZzJ42HlcXJwAGjxjP3XvBAGzatluXBI4a9iUbV85l/sxfGfzlR1SqWDbHY56bm7fvMOizD1ix4HeqVfHRxfagAkNRFD76Ypgu4erSoTWrFs1gyKCPMTAwQFEUvvluHHfvBdO6eSO2r/9bFzOgK0MP2r/lxaUr1wsspscpiHNoXsq/b7VKbF//N9WztDv/+8/Jefr8FjSpEXxKFubmLJw9CVsba15r1ZTL126ybNUGADZu3fnYGqVqlSvy38Fj/Dx5Jleu3SAhMUnv1+HJ0+dzXq+KD79P+hEARwd7muzrDsCNm7cBCAuP1NWymZqasGDWRBzs7bLF9yQbt/6ri6dz+1YM+9+nANQNrEm56o1JSta/JLhs9Ubd4359ezAwM9moHeBHhRpNSE1NY8eu/URFx+Bgb0f9OjU5f/EK8QmJnL94ldtBdwGoVLEcFy9f09UOHjmu/W9na0OVSuWzxens5MiCWRMxNTXB36+aLiG4fjPosa/P2NhY99jN1ZlypUtRyssDAwMDPnr/4S+1eoE19S4nlC1TKlt7jWaN6jJ+4h/s2nuQ4NAwvZodgBOnz9Ht9fa8060LYyZMR6PRsGzVP7zRuS3BoWG697pt66b5arP0Wf9efPKh9mTpU7EsvnVfA7Q1TOnp6RgbG9OwXm1+njyTqTPncedesN6v0wexPUmzxvX4adIMDh45QVh4JOnp6frbOHWOOrVqZFtv8vgRuo4UG7fuYvu/+1Cr1dy+c4/qVXxYsnK9btk3u7TTlesHzx9YuvJhme3XtwceJdwAbeL4oKwvXbmBNzq31fvyrelXjV/GahOklk0b8N+hY9y5m/0E8O3Xn+W54XrVyhX0Lm87Ozk+tv3Oh326M+izDwC4ev0WI37U1lw+KJ87d/9HRGQUAM0a19XVerdt1ZTV67boksaIyGicHO0LJKYH8lpu/f2qcv7SVd10z5Luedq+sfHDU4u3V0l8KpbFzUV7Yvvmy49yXMfExJhFf/2Gq4sTr7VqwvxFK0lKTuZGls9zKS8PXF2cmT5rAecvXiU2Ll7vu/PajdvExSdgY22lt20rSwvWLp2Fg72dbtq0mfN1r7tz+9ZUr6pNLt59uwur1m0mKTmZFWs2MWn8CAwMcq4zyW+ZW7Nhqy7J6Ni2BSOGDASgeeN6/HfoGKFhEVy8fJ0z5y9RrXJFlmd+t5qYGDOgfx9MTU2wsbaiU7uWzJq7hLS0dFat38LAj/tinKW2r1yZUlSrUhFHB225ebCfvGrfpjmjv/sKgKTkZHr31z5+UHZPn7vIxcvaRNfVxYm5f0zA2NiYNi0ac+nKddb+s420tHTW/rONz/r3xsXZEdPMH9jAU7V7K+iYclJQ59C8lv96gTWxtXlYVv19q1LKyyNP+yhIxbZGMOuvo0cvF2R9ntuvqArlS+td2gjIrMoHuHn77mP3PXjET3zz3TiOnzpLfEJitv3HxMbluF6DurV0jx0c7HSPY2O1tSy3stSqlfH21PvSyxrfk9zKEv+D2iYAWxtrypfzzrZ81nYttfyr6x47OdpTupQnoD2mD77Q69d5WLt35Pgp3SXg/u/1wNjYmMPHThETG8elKzcAqFOrRo5fxLVr+uq+XBz1jkfOx++BcmVKUb+O9otoyYr1VA1shUuZmjRt251J0//KdlLMTXxCIs3a92Du3yu4FXQ3x/UevDclPdxp3kTbiH/7rv1ERkWzeetu3Xv/VpbkJy9q+ftmeT3euksjKSmpBIeEoVaraf/me0ydMY8r125mSwIBYmJzbqf1QNCdezRv34OVazdx735ItiQQIDYul7JaL0tZzVIOH7w3WcvMay2b5BpD1uX+9+0YWnZ8h5Yd3+HTr0bopl++qi0nWT93NWs8LLeGhobUqF4l130UloZZjoFj1mOQWSt6Nctr27Zzn+61tez4jq7mXVEUrly7UaBx5afcPq12bZrpPpPffDeOstUaUbJiHTq/3Y/V67fkuE6FcmV0tUYGBgbY2Wl7T2b9Ppw6Yx79Px/Kf4eOExMbl2O7t5w+/3Vq++uVQ9AvWwuXrtYd+1ad3tX92I2Ni9frjPOo/Ja5rPsMyPJdaWxsjG+1hzVD167fIiIyWtdOMS0tnfZvvqeL8cEVG4DLmTWP3V5vr/s+fOeDL/CqVA/vKg14u+8A/t1zINfXkJMGWZriOORQdq9laVbjV72y3o/rmlnONTm1eXxazyOmgjqHPk35L0rFNhG0srLUPY6Mitabl/W5dZblHiev1e5paWnM/Vt7qcPIyIgfhg9i8+r5bF//t+5Xf26Neu3tHnYrNzJ8+ItD4fGNgPMTX0FvJ6fFs7b3O3zslK7mr1H9QHyrViI4JIyVazfpjkO9Ojn/erTLejyM8n48DAwMWL14JuO+H0zLZg3xLOlOcnIKR46fZvgPv/D18LF5em3rN23XNeivWL4MC2ZNZPv6v/nph4cdQjTKw/Y6vXu8DkB6ejqr12/RXSK2t7OlZbMGedpnbh49zgePnOD0We34l26uzsyaOo5t6xYyb8YvumUUJXtHi6wWLV9LXHwCAIEBfiybN43t6//WXboE0GhyK6sP21UZGRlm2WfeXk9+PGin+zgFVf7zw8724TEwzFo+83kQEh/plPOs8ltun4abizP7t61k0GcfUC+wJo4OdkTHxLL93328++GXrFizMds6Wb/fQL/cPDDjr4eN9r/87H02rpzL9vV/U6VShYex51Amn9QW9nGe9vjn/7vy6crog/iqVKrA/m0r+fiDd6nlXx1bG2vCIyJZv2kHnbp/mGszjpzY6X1+81d2C+uzVtQx5WcbT1P+i1KxTQQrlPXWPT589BQJiQ8blz5owwPaX6k5uXrtlu4kCXD0xBnd49KPadwdGR1DSkoqANWqVOSrAR/SqH5tSpfyJCo6773UclLK6+F+b96+q9frLWt8T5K1cfrJUw8vH8bGxXP12q1sy5cr4617fOzkWd3jyKhobtzS/sJSqVSUyWw87e7qQhlv7eMDh45z4tR57O1sqVCuNLUDtDVd02ct0G2nQZYaxIKgKApWlpZ8/lEf1i6ZxaXj/3Lr/H94Zx6/B+2jAF1bNSBbD9X7wQ9rCvr17cHrnV6jXmBNUnKpUWzXuqku2Z+/eBW792t7vHVq1xITE5Mc18nNsZMP38/rN2/ryo6ZmSnubi56sb3VtT093+qsVxObF1m38fXAfrR/rTn1AmsSF5fwmLXyJmuZ2bJjT56W27x6PomhF7P9nTu8DdD/3J049bB5hVqtzvUyeH7vXPC48pBf5bO8tp7dOuf42sJvnqBl02f7kfCo/Jbbp3nNiqLg5enB6O++Yvv6vwm6eJB9W1fo5q9/pIdvnmMPCQW0VwB+/O5/NGlYJ/PHY+hj18vpJJ61bA3736e5Hv8HHfFykt8yl3Wfx7N8V6anp+t+uAGUK+uNk6O97geVlaUFoTeOZYsvPvg8M3/T/nBVFIXKPuX5Zcwwdm9exv2rR1j012+A9n3bsPnpjnlOymU5f54+e1FvtIxjWc41WV+vgephuvGsn52CiulRBXUOzU/5VxXyccmLYttGsHGDOjg62BEZFUNMbBxNXutO+zbNCQ4NY8mKh+2XOndoleP6iUlJ9Oo3iI/e68HZ85d17dMA2rVunut+XZ2dMDMzJSUllfMXrzBnwXJcnB0ZP+mPZy4Eri5O1PKvztETZ0hJSaV3/6/45IN3ssX3JG1bNeW70b8CsHbjdsZP/B2/6lWYOWdRjrUvb3Vpyx9/aodtmTlnEe6uzpQrU4ppsxboLju1aNpAr5q9fp0AbtwK0nUSaVAvAJVKRWCAH7/PXqjrqWpubkYN34K9rHc/OJT2b75H145t8KlQFhdnJ24F3dW110pLe3hCzFqrs27jNry9SmJsbERNv2p4lSyhm7dgySq8S5Xkxs2gXBusm5iY0P2NjkybOV+vHeib+bwsDDBt5gJcnJ3w9HDn58kzddNbNWuIsbExXp4PY1v3zzbq1fYnOjZO104tL7K+vt///BtjExOOnTjN/MWr8h3vo7q/3kE31M/y1f9gaWFO+zbNSExK5p8t//J+r7doULcW3V5vzz9btHe1+OCzwXzzRX/Kli5FRGQU12/eZsv2PbRq3ohh//uUZo3r6T5bx06e4evhY2nRtAEr127KsX3g08haHg4ePsHWnXuxtrKkXBnvfNc6NWtcDydHByIio1i8fB32drY0a1wPjVrN7Tv3OXjkBOcuXOb4vn+evLF8yG+5tc/ymrf/u5/6dQIwMzOlSqUK2Xr+PrB89Ub+WrCU9q+1wNvLAxtra/bsfzjUR16bX+QU+7Ubt4mMiuGXKbOpWrkCv89e+FQ/ort0aM2IMRNJTU3j16mzUalU1A7wIzkpmVtBd9n73xGSU1L4Z8WcXLeR3zLXpUNrvvtxIunp6azbuJ0ff55KrZq+LF62lpDQcAAqVSxL9So+qFQq3uzSlllzl5CQmETHtz7g4w/ewdHBnnvBoVy4dJX1G7fzx+QxNKpfm4nT/mTfgaO0adEYTw93LCzM9So1UlOzN+14Wr5VK+FToSyXrlwnJDSc9z7+mp7du3DsxBldkmNiYkzn9g/Pn3Z2NpDZ3POPP/+mhm8VbKytqVq5Qk67eC4xPaqgzqH5Kf9Za8Ln/r2C1i0aYW5mptcsq7AV20TQ3NyMSeNH0Pfjr1Gr1Vy8fC1br6CAGtX5+P13clzfy7MEh4+eZPu/+/Sm9+n5xmM7ihgYGNC7x+vMnLOYtLR0Bnw9EtC2W3N2ciQ8IvKZXteYkV/T7o33SE9PZ+fu/3RDRJQrU4prN27naRs+FcryQe9u/Dl/GWq1mtE/aXvFmZubUcLdlfvB+r++awf48eVn7zNp2l+kpKQyZORPevNdXZyYPH6E3rR6dWrqDQMRGOCn9/+BWjWq57u2LC+uXLvJ+Il/5Dgva2LWsF5t3XA3W3fsZesO7dhdF47uoG3rpri5OhMSGs7psxd5vae2EXDd2v4cPHIix2337vE602bO1z13c3V+qjs1uLs589WwH/WmWVlaMGqYdrzFWv7VqVq5IucuXOb2nXt07ztAF1tey1j3Nzrw8+SZJCUn8++eA7p2Ro97fXlVs0Y1hn71CeN+/R3QfgHO/fvhL+a+mcOFdO3Yhs3bd7N4+Tru3Q9h4DffZ9tWy2YNAe3l6GH/+1SX7P4+eyG/z16IgYEBpUt56vVMfyDrjy/TPJQznwradmyhYRHcCrpL1x7aHrUzfhvLu9275PXlA2BpacHMKWPp8d7npKamMW3mfL2yAegl9AUlv+W2doAfpqYmpKamcfzUWTq8pW0asHn1/FzLrkbR8N+h4/x36HiO89/s0jbH6U/S9923dEO1jByjfZ+dHO2pUK50tmGOnsSjhBsTxw5nwNejSE1Ny3FcxKztPHOS3zJX0sOdn0cPYdBQbW/lB+X/AWsrS2b+Nk5Xgzly6Bf8d+g45y9e4fCxU3pDaj0qIz2D7f/uy3ZOAu155/VObR77WvJDpVIx87exuqFaVq3fwqosbd9UKhU/jx6q6y0P2qY/p85cALTt5kB7fLesWUBBeJqYclIQ59D8lP9G9QN1V6F+nTqbX6fOxsuzBBeP7czTvgpCsb00DNohFHZuWETXjm1wd3PByMgIK0sL/KpXZtSwL9myZn6uY2mV8vRgy9oFNKpXG3NzM1xdnPh6YH9++3nkE/c7duQ3fNqvF26uzlhZWtCudTM2rpyLufnTj9v1QP06AaxeNAO/6pUxMdHWDI3+7iu++rxfvrbz69jhDBn0MW6uzpiZmVK3tj8bV8zJdWysH7/7HwtnT6JhvVrYWFthbGxMKU8P+r/Xg/92rMo2FlqDR8YFrF3TDwDPkiUo4e6qm55b+8Bn8eDLu2G9Wri5OmNsbIy5uRlVK1dk5JCB/Dr24XAcVStXYPa08fhUKKvX6w20X9oblv9F4wZ1sLK0oIS7K98NHsDwbwbkuu/KPuX1OtRoh0rJ/8fw13HfMeizD3BzddaNPr959Xwqltc2ZTA0NGT1ohm0b9McWxtrnBwd+OTDd5k+cXSe9+FZsgTrl/9JQI3qmJubUcbbi8k/jaB3zzfyHW9Ohn8zgFWLZtCyWUMcHewwNjbG3c2FTu1a4p2l59zsqeOZPW08DevVwtbGGhMTYzxLutOkYR1+GfOt3rhgXw34kAk/DqOUpwempiZUr1qJ5fOn5VqOzpzTDvBcupQnHfNwuzgjIyNWLPideoE189x++HHatGjMvq0rePvNjniUcMPY2BgnR3uqV63EgI/68Pfsyc+8j0flt9w6OdqzdN40fKtV0o1/+SSBAX588uG7+FWvjJOjPYaGhtjaWFO/Tk0WzJr4VLXgAAP692bkkIF4eZbAwtycRvVqs3HlPL2hSfKjzztvsm3dQjq1a4mLsxNGRka4ODsRUKM6QwZ9zKRHfsDmJL9lrl/fHmxY/hetmjfEwd4WIyMj3N1c6PFWJ/ZvX6nXscHO1oZdG5cwYvDnVKvig7m5GRbm5pQrU4ouHVozb8YvuqGUWrVoxPu9ulHZpzz2drYYGhriYG9L8yb1Wbd0NnVr+z/VMcpNgH919m9fSc9unSnh7oqRkVFme+eGrF/2Z7bx+ob971Pee/ct3N1cCq0dYX5jyklBnEPzU/7f7/UWgz77AM+S7k91LigIKiW/LZeLsdtB96hcS3uyKMhfMqJ4yTqQ8p7Ny/R6D4rnR6PR4OlTl5jYOFYu/J3XWuV9HEchhHhVFNtLw0I8bwmJiYSGRbByrfa2gBXLl5EksAidvXCZmNg42rRoLEmgEKLYKtaXhh/nfkgYAc3e0rtVTVHZsGU3PT78uqjDeCpBd4Pp9fFQGrXrxaQ/cq5BnTV/BS26vE/Dtu8+cWy7x1m8ciP9vhyV7/UuX7tFQLO3dM8/HzKWFeu2PnUcuXEtE0D1Og/vODD4y7zfWzivOrz9Kbv3Hynw7RaFwvgMfvXdz8ycpx2+ybdqJRJDL7JqUc6dJJ7Fy/yZLUhzFq1m2OjJT73+r9PmMeqn6U9eUAjx1Ip1jeCps5eYs2g1Zy9cRVEU3F2dadOiAT1ef7r2KyK7+UvXUa6MFwv+GJfj/JCwCP5auIq1f0/F3e353VLncaaMH/bU6y5bs4V/tu7m2s0g6tX249fR32RbxtjYBFc3V6b9tYxpfy1j9YLfcHZyeJaQXwkBzd5i0ayfqZjDoOXi+Rn103SsLS356rM+z7yt93rmfhs6IcSLodgmgvsOHufbH3/jo77d+GHoZ9jZ2nAr6B7zlqwlIjI6x3VKeXmQGHoxx3kvkwy1GiPD7IO1Fob7wWE0rJt7h4/gkHDMzc1emCTwSTIyMh5743ZnR3vef6crh4+fJeyR3rmJoRfp9+UomtSvRY835MeGEEKIolcsE0FFUfhl2lx6de+kd0L29vJg1GDtfXXvP3JboUNHTzP9ryUE3QvGzNSUpg1q88XHvTDL7En694p/WLJqI/HxidjaWPP+O13p3K4594LDGPPrTM5fvoahgQHeXiX5fcLwHHsj57aNB/5cuJJla7agUqno83ZnXeyXrt5kwtQ53Lx9FwMDA2r7V+Obz9/HzlY7xle/L0dRxaccV67d4vT5y4wdPpCAGlWZOmsRew8eIy0tnbq1/PhmwHtYWVmQlpbOuMmz2XvgOBnqDFydnRj5zcdU8SmXLeaMjAxmzF3O5p37SE1No1aNqnzz+fvY29nQ6+OhXLp6g1PnLvHHnKX8MvprAms+bBO3e/8Rvv3xN1LT0mnY9l2q+JTDxMSYRvUCeKNjKxISkmje+T3eeasDA/r1RFEUWnb9gKk/fUulCmW4fvMOo3+ZwY1bd6hUsSyVK5bN0/sfn5DImF9ncujYGRwd7Hizk/64UlmTtWOnzvO/7ybw2Qc9mLtkDY72drnWbgI0axQIaC83P5oI5kVAs7f4esB7rFy/leDQCJo2qM3XA/oybtJsDhw5hUcJV8YOH6jXq/ZR12/dZfaCVdy9H0K1yhUY+c3HODs58Ov0ecQnJOrKOMC8xWs5ceZCjrWgo36ajoGBAQmJSRw8cgp3V2fGjviC0+cu89fCVaSlp9O/z1u82ak1oP1cLVrxDyvWbSM+IYEqPuUYPPADSpbQ9gLv8PanvNGpFbv2HeHGrTv4lC/ND8MG4ObiRK+PhwLw3oDhGKhU9O3ZhTbNtQMp7z1wnNkLVhATG0+TBrUY/lX/xybjWe3ce4ipsxYRHRtHy8Z1Uav1x+q8dOUGk2Ys5Or1W9hYW9G7eye6tG9BVHQsbbt9xJoFU3Q/UtLS0mn9Rj9+GzeU6lUqcPdeCL9On8fZi1cxMzWlc7vmvNezS449/yKjYpgwdQ7HTp3H1NSEti0b0b/PWxgZGurK2Ed9uzF38RpQFLp2aEm/3m+iUqnYsGU3S1ZtpFG9AFas24aRoQFffdYXF2cHxk6cTWh4BM0b1WH4V/11+87tdQHMnLecS1du4ObqzOYd+7C0NGdg/3dp1bQeS1dvYvOO/ahUsHbTTtxdnVk+V3/syXMXr/LVdxPYunIWAJP+WMDS1ZvZtX4uFuZmLF29mcPHTjNp7BBmzlvOleu3dDXjAc3eYsgXH7B87VZCwyLw963M6KEDsLLS3mf7xOkL/DTlL+4Hh1EnwBdra/2e2RcuX+eXafO4cesOzk72vP/O67Rp3oAMtZpmHfuy4I9xeHt5sPfAMQYN/5kp44dRr7Yf124E8cHAEexcOwdDQ2kRJYQepRi6FXRPqdn0TeXO3eBcl7kXHKrUbPqmEhefoCiKopw4fUG5eOWGkpGhVu7cC1Fe7/2F8ufCVbrt1WvTU7l5+66iKIoSERmtXLl2S1EURRk2erIyZuJMJT09XUlPT1dOnb2kpKWl5xhTbttYv3mXUrtFd2XhsvVKenq6cvTkOaV2i+66+C9fu6mcPHNRSU9PVyIio5UPPh+hjJ7wh27bH34xUmnR5X3l7IWrikajUZJTUpXBo35Vho2erMTFJyhJScnK0B8mKcPHTFEURVFWbdiu9Oz3jRIXn6BoNBrlVtA9JTg0PMfjNGv+CuWt9wYpwSHhSmJSsjLkh0nKJ/8brbfvRSv+yfU4Hz15Tmncvrfu+bwla5Uh309UFEVRdu0/onTq+ZnS6+OhutfZtGMfRa1WK+kZGUrHHp8p0/5crKSlpSunz11Wmnbso3z4xchc9/XAd2OnKp/8b7QSF5+ghIVHKu/0H6zUbPpmjjEfPXlOqdX8LWXMxJlKcnKKkpyc8sTtK4qizJi7TBk0/Kds0z/8YqTSrNN7StOOfZS3P/xa2bB1t978mk3fVD7+3w9KTGy8EhYeqbTs+oHS7f2vtO9vRoYyavx05Yth43Pdb/vunygd3v5EuXn7rpKcnKKMGDdV6f/lKEVRFOXqjdtKw7bvKolJybrlu/YaqGzfdSDHbY0cP01p1K6XcvKsdt8jx09TOvb4TJk8Y6GSlpauHD5+RqnT6m0lIjJaURRF2bB1t9LmjX7K1eu3lZTUVGXi7/OVN/t8qaRnZOhi6/b+V8rd+6FKSmqqMmDwWGXk+Gl6r/3S1Zu65w8+g8NGT1YSEpOUsPBIpe1bHynrN+967LF/4FbQPaVOq7eVPf8dVdIzMpQV67YqtZt3U2bMXaYoiqKER0YrzTr1Vbbt+k/JyFArV2/cVlq/0U85fPyMoiiKMnDoON1nXFEUZfvug0qXdz9XFEVRkpNTlPbdP1EWrfhHSUtLV4JDwpU3+w5S1mzcqSiK9jP79gf/06370aDvlW9//E1JTEpW7geHKW/2+VL562/tth+UsVHjpyvJySnKzdt3lbZvfaRs2LJLt63azbspS1ZtVNIzMpQ1G3cqjdr3UgaP+lWJjonTlZOdew7l6XXNmLtMCWzZXTd/w9bdSsO27yoJiUm69/2XqXNzPa7pGRlKo3a9lBu37iiKoihvf/i10qnnZ8r+QycURVGUr4b/rPy9fINuX1k/BzWbvqn0/3KUEhkVo8TFJyg9PvxG937ExsUrjdv3Vlau36akZ2Qoe/47qtRp9baujMTFJyjNOr2nLFm1SUlPT1eOnTqvNHjtHeXk2YuKoijKgMFjlRVrtyqKoii/TJurdOr5mfLbzIWKoijK4pUblS+/zf55FEIoSrH8aRSdeVNyZ+e8t8uqUb0SPuVLY2hoQMkSrnRt34LjmXeHMDQwAEXh+q07pKSm4ehgR/mypQDt/TIjImO4HxKOkZERvlUrYmycvTbjcdsAsLO15p23OmBkZESAXxVKuDlzOfMm2xXKeuNXzQcjIyMcHezo+WY7jp++oLf9Ns0aULVSOVQqFcnJKfy77zCDB76PtZUl5uZmfNS3G9t3H0Ct1mBkaEhScgo3b99DURRKeZbALZdxujZt38v777yOm6sTFuZmDPq4F4ePnyE8IirPxzarAL8qutiPnTxH965tuXs/lITEJI6eOId/9coYGBhw9vwVYuLi6N/7TYyNjahepQItm9R74vbVag3bdx/g4/e6Y21libOTA+926/jYdTQahQEf9sTMzDTXcSXz6rMPerDu76lsWzWbAR/2YMLUOezap9+54923OmBrY4WzkwP+1StRplRJ7ftraEjzxnW4fPXxA+e+3rEV3l4emJmZ8nm/dzh26jyh4ZGUK+1F6VIl2blHO8L9mfNXiImNo1G93G89Vz+wBn5Vtftu0bguwaFh9O/zFsbGRtT2r4aVpQXXbmpvF7Bp+166dX2NcmW8MDUx4dP33yY0PJLzFx8O1P5Gx1Z4uLtgamLCay0acPHKjScesw97vYGlhTnOTg7UreWbp3UAtu8+QK0a1WhULwAjQ0Pe6NgKz5IPB5PdtG0vNapVomWTehgaGlCutBcd2jRhy07t3RjatWrEpu17Hy6/fS9tW2oHr95/6ATW1pb0eKMdxsZGuLk68XbX19i6cz+PCguP4ujJc3z5cS8sMptBvPdOV/7Z+vDWehqNwoB+2jLm7eXBm51bs2n7w4GB7exs6N61LUaGhrRpVp/ExGQ6tW2Gna21rpxcyiwXT3pdAD7ly+jmt2vZiPSMDILyePcVI0ND/Kr5cOzUeWLjEoiMiuGNjq04duo8Go2GE2cuUMs/97si9OreCQd7W6ytLGnWKJBLme/nvoMncHay5/UOLTEyNKRRvQBq1Xi4nf2HTmBvZ0P3rq9hZGRETd/KtGnegI2ZxzHArwrHMm+JeezkeT7s9SbHTmq/o4+ePKe3LSHEQ8Xy0rCdjfaWLuHhUZT0cMvTOucvXWP6n0u4djOI1NQ0MtRqSmWO+l/Sw41RQz5l+dqt/PDzH1StVJ7P+79DxXLeDOz/LrPmr+CT/41GpVLRvnVjPuz1RrbLR4/bBoCjva3e8uZmpiQlpQBw514Ik/5YwIXL10lOTkGj0WS7dObq+jCRux8Shkaj0LHHZ3rLGKgMiIyKoW2rRkRERTNukvayU6N6AXzx0bvY2erfFB4gLDySElna9zk7OWBibExoeNRTdYDwKV+G1LQ0rt+8w9GT53i9Q0uOnjzLqbOXOHbyHIGZ9yIOj4zG2dFB73W6uzpzM+jeY7cfExtHenoG7lmOR9bHObG0MC+QwYMBqld5eDulurX86Nq+Jdt2H6Bpw4d3aMh6Kz4zM1OsLS31niclpzx2H+6uD98PRwc7TIyNCY+IwtXZkY6vNWXD1t10aNOEDVt306Z5A0xMjHPdluMjsViYm+uaQwCYmZqSnBlPWHgUJdxcdPNMTLSDI2e9RO7k8HB7Wcvw4zjqrWNGfGLeehGHR0Rne2+zPg8ODeO/Iydp0qGPbppGo8GvWiUAGtULYMyvszh38RolS7hw8Ogp/pfZgeJ+SDjXb97RW1dRFFxzuM1cWEQkpibGeq/Dw92F0PCHx8XUxBiHLJ9xd1dnwrL8mMr6+X/wY+TRcvLgfXjS6wJwdHi4PZVKhamJCYlJydliz02AXxWOnTyPg70t/tUrUcu/GmN+ncnla7dQqQwoX6ZUrus6PlIGEjPjDo+M0iu7AG6uTqSlaW+NFvrIdw2Ah7srJ85o220H1KjCwuXriY6JIzo2jjbNGzB5xgLi4hM4eeYin7zXPc+vT4jipFgmgqU83Snh5szWXQd4/5289Wr79sff6NCmKb+O/hpzczMWr9zIP1t36+a3bFKPlk3qkZKaxsy5yxgxbirL/voVB3tbhnzxAQDXbgTx6dejKVfGi+aN6mTbR27beJJxk2bjVdKd74d8irWVJbv3H2HUT/q3LjLIMpK7q4sTBgYqtqyYmWsN13s9u/Jez65ERsXw7Y+/MWv+Sr75/L1sy7k4O3I/JJyqlcoDEBEVQ1p6Oq75qG3NytDQAP9qldi++wBxcQmULlWSWjWqcvjYGU6cvcinH/YAtJ0ywiOj9DpvhIRFPHH7drY2GBkZEhwaoTshPWm9whoFH/Tfl4ISnHnPUoCo6FjS0tN1SXnrZvWZ/McCbty6y/ZdB5gx8cl3wskrF2cHvba16ekZRERG4+KUt3vwFvRxdnay58z5q3rTQsIidGXV1dmJJg1qM+67L3Jc39TEhBaN67Bp+15KeZagqk95XaLr6uJIpQplmDd9zBPjcHFyJDUtncioGF2Zux8Srpc0pqalExUdq0sGQ8IicHnKnuRPel1Pkpf3IaBGVeYvXYe9nQ0BNapSoWwpQsIi2LXvCDX9Kj/Ve+ns6KBXdgFCQiNxsNf+AHXN/K7J6n5omO67pmK50qSnZ7B87Rb8q1fC0NAAv6o+LFm1CSMjQ8qW9sx3TEIUB8Xy0rBKpeLrAe8xf8lalq7erBu77vad+/ww4Q+CH/myAUhMSsbaygJzczNu3r7LyvXbdPNuBd3n0LEzpKSmYWxkhLm5GYaZvXK37z5ASGgEiqJgZWWBgYGBbl5Wj9vGkyQkJmFhYYalhTkhYREsWLbhscs7OdjRuH4tfpryFzGZl8kjomJ0lyiPnjjH5Wu3yFCrMTc3w8TEJNcG1q+1aMjcRWsICYsgKTmFSb/Pp3bNas80HErNGlVZsnoT/r6VAe1JZ/3WXZiamFAu8xZ31SqXx9baij8XriI9PYNzF6+yffeBJ27b0NCAlk3qMnPeMuITEgmPiGLhE45XfmSo1aSmpaFWa9BoFFLT0khPzwC0nVT2HzpBSkoqarWGIyfOsmrDdpo3DCyw/QOs3rCDW0H3SUlNY+qsRfhXr6RLOqwsLWjWKJDhY36jhLsLPuVLF9h+27ZoyIq1W7lx6y5paen8Pmcpzk4OVKmUvZNRThzsbbl7PyRf++zw9qds2LI7x3ktGtfj6Mmz7D90ggy1mjX/7CDozsPLn21bNuLYyXPs3HuIjIwMMjIyuHztFucvPbyU3a5VY7bt+o8NW3bRrlUj3fSGdWsSFR3DinVbde/3raD7HDt1PlscLs4OBPhVYfKMhSQnpxASGsGcRatp16qxbhkDAxXT/lxMSmoat4Lus2LtVl1nmfzKy+t6HEd7O+4Gh6I85qZTFct5o1Zr2LxzHwF+VVCpVPhV82HZ2s1PfQm2QR1/wiKiWPPPDjLUavYfOsGxk+d08+sH1iA6JpYV67aSoVZz8sxFtuzYrzuOhoYG1KheicWrNhKQGUNAjaosXrWRmr5Pl5wKURwUyxpB0H6RTxk/jL/+XsWMucsA7WWIti0a4ZRZ25TVsC/7MemP+UydtYhKFcrQull99vx3FHjQc3YZN2/fRaVSUaFsKUYN/gSAi1duMOn3BcQlJGJjZUmnts1onEObrMdt40kGfdKbsRNnsWLtVrxKluC1lg25cevOY9cZNfhTZs5bTq+PhxIbl4CDvS0tm9SjacPaREbH8NOUvwgNi8DU1ITa/tXo1/vNHLfTt0cXklNSee+z4aSmpRPgV4XRQ3O/125eBPhVYfIfC3QnlHKlvTAzMcHfr4puGSMjIyb+OJjRv8xg0Yp/qOxTjo5tmnL+8vUnbv/rAe/x468zaf/2Jzg52PNmp1ZcyMN6efHXwlXMXrBS97x+m3fw963MrEmjyMhQM3vBSr798TcA3N2c+fKTXrRoUrdA9v1Ax9ea8u2Pv3H3fghVK5Vn9Lef683v9Foz+n05SneZs6C0a9WYyOhYvvx2PHHxiVTxKcekMYPzPFTRx3278cvUufz4y0x6d+9Eq2aPb/OZlpZOTGwc1SqXz3G+t1cJfhj6GROmziUmLo4WjetSt7afbr6LswNTf/qWqbMWMXbibBRFg7dXST7q+3Bwcb9qPlhamHPz9l1aNH74PlmYm/H7hO/4bdbf/LlgJalp6ZQs4Zpre9Mfhw/k5yl/0f7tTzEzNaFN8wb07t4xy/bMqVDWm049P0NRFLq0a0771o1z3NaT5OV1PU7nts0Y8sMkmnV6D1cXR5b++Uu2ZQwMtEnXpSs3dE1kateoxr97Dz91ImhrY8Wvo7/h5ylzmPj7fAJrVqdNiwZoNNqe3jbWVvw2bhgTp89j2p+LcXZ0YMgXH+BXzUe3jQC/Kuw7eFwXQ23/qkyYmqxLDIUQ2cm9hoUoZkJCI+jS63M2L5+pG2LoZXT89AVWrd/G2Ke8BPqieDB8zO4N84o6FCFEMVRsawSFKI7Uag3zl66lReO6L3USCFDTtzI1M5sPCCGEeDqSCIpXzskzF/l8yNgc500ZP4wa1SvlOC8vNu/Yx9iJs3Kct2LuJNye0AO5KN0LDqPb+19Rws2FKeOGFnU4QgghXgByaVgIIYQQopgq0l7De/fupUOHDpQoUQKVSsXatWufuM7u3bvx9/fH1NSUcuXKMW/evEKPUwghhBDiVVSkiWBiYiK+vr5Mnz49T8vfvHmTdu3a0bRpU06dOsUXX3zBBx98wNatWws5UiGEEEKIV88Lc2lYpVKxZs0aOnfunOsygwcPZuPGjZw793Bsqe7duxMTE8OWLVueQ5RCCCGEEK+Ol2pA6YMHD9KiRQu9aa1bt+bgwYNFFJEQQgghxMvrpeo1HBISgqurq940V1dX4uLiSE5OxtzcPNs6qamppKam6p5rNBqioqJwdHSUkeaFEEIUW4qiEB8fT4kSJTAweKnqhUQBeqkSwacxbtw4vv/++6IOQwghhHgh3blzh5IlSxZ1GKKIvFSJoJubG6GhoXrTQkNDsbGxybE2EGDo0KEMGjRI9zw2NhYvLy/u3LmDjY1NocYrhBBCvKji4uLw9PTE2vrlHlxePJuXKhGsW7cumzZt0pu2fft26tbN/V6tpqammJqaZptuY2MjiaAQQohiT5pJFW9F2iggISGBU6dOcerUKUA7PMypU6cICgoCtLV5vXr10i3/0UcfcePGDb755hsuXbrE77//zvLly/nyyy+LInwhhBBCiJdakSaCx44do0aNGtSoUQOAQYMGUaNGDUaMGAFAcHCwLikEKF26NBs3bmT79u34+vry66+/8ueff9K6desiiV8IIYQQ4mX2wowj+LzExcVha2tLbGysXBoWQghRbMn5UMBLNo6gEEIIIYQoOJIICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU5IICiGEEEIUU/lOBJOTk0lKStI9v337NpMnT2bbtm0FGpgQQgghhChc+U4EO3XqxIIFCwCIiYkhMDCQX3/9lU6dOvHHH38UeIBCCCGEEKJw5DsRPHHiBA0bNgRg5cqVuLq6cvv2bRYsWMCUKVMKPEAhhBBCCFE48p0IJiUlYW1tDcC2bdvo2rUrBgYG1KlTh9u3bxd4gEIIIYQQonDkOxEsV64ca9eu5c6dO2zdupVWrVoBEBYWho2NTYEHKIQQQgghCke+E8ERI0bwv//9D29vbwIDA6lbty6grR2sUaNGgQcohBBCCCEKh0pRFCW/K4WEhBAcHIyvry8GBtpc8siRI9jY2ODj41PgQRakuLg4bG1tiY2NlRpMIYQQxZacDwWAUX4WTk9Px9zcnFOnTmWr/atdu3aBBiaEEEIIIQpXvi4NGxsb4+XlhVqtLqx4hBBCCCHEc5LvNoLffvstw4YNIyoqqjDiEUIIIYQQz0m+E8Fp06axd+9eSpQoQcWKFfH399f7y6/p06fj7e2NmZkZgYGBHDly5LHLT548mYoVK2Jubo6npydffvklKSkp+d6vEEIIIURxl682ggCdO3cusJ0vW7aMQYMGMWPGDAIDA5k8eTKtW7fm8uXLuLi4ZFt+8eLFDBkyhDlz5lCvXj2uXLlCnz59UKlUTJw4scDiEkIIIYQoDp6q13BBCQwMpFatWkybNg0AjUaDp6cnAwYMYMiQIdmW/+yzz7h48SI7d+7UTfvqq684fPgw+/fvz9M+pZeUEEIIIedDoZXvS8MFJS0tjePHj9OiRYuHwRgY0KJFCw4ePJjjOvXq1eP48eO6y8c3btxg06ZNtG3b9rnELIQQQgjxKsn3pWG1Ws2kSZNYvnw5QUFBpKWl6c3PayeSiIgI1Go1rq6uetNdXV25dOlSjuv06NGDiIgIGjRogKIoZGRk8NFHHzFs2LBc95OamkpqaqrueVxcXJ7iE0IIIYR41eW7RvD7779n4sSJdOvWjdjYWAYNGqS73/CoUaMKIcSHdu/ezdixY/n99985ceIEq1evZuPGjYwePTrXdcaNG4etra3uz9PTs1BjFEIIIYR4WeS7jWDZsmWZMmUK7dq1w9ramlOnTummHTp0iMWLF+dpO2lpaVhYWLBy5Uq9Dii9e/cmJiaGdevWZVunYcOG1KlThwkTJuim/f333/Tr14+EhATdXU6yyqlG0NPTU9pECCGEKNakjaCAp6gRDAkJoVq1agBYWVkRGxsLQPv27dm4cWOet2NiYkLNmjX1On5oNBp27typu3/xo5KSkrIle4aGhgDkls+amppiY2Oj9yeEEEIIIZ4iESxZsiTBwcGAtnZw27ZtABw9ehRTU9N8bWvQoEHMnj2b+fPnc/HiRT7++GMSExPp27cvAL169WLo0KG65Tt06MAff/zB0qVLuXnzJtu3b+e7776jQ4cOuoRQCCGEEELkTb47i3Tp0oWdO3cSGBjIgAEDeOedd/jrr78ICgriyy+/zNe2unXrRnh4OCNGjCAkJAQ/Pz+2bNmi60ASFBSkVwM4fPhwVCoVw4cP5969ezg7O9OhQwfGjBmT35chhBBCCFHsPfM4ggcPHuTgwYOUL1+eDh06FFRchUbaRAghhBByPhRa+a4RfFTdunVzbdMnhBBCCCFeXE+VCF6+fJmpU6dy8eJFACpVqsSAAQOoWLFigQYnhBBCCCEKT747i6xatYqqVaty/PhxfH198fX15cSJE1StWpVVq1YVRoxCCCGEEKIQPNU4gj179uSHH37Qmz5y5Ej+/vtvrl+/XqABFjRpEyGEEELI+VBo5btGMDg4mF69emWb/s477+iGlRFCCCGEEC++fCeCTZo0Yd++fdmm79+/n4YNGxZIUEIIIYQQovDlqbPI+vXrdY87duzI4MGDOX78OHXq1AHg0KFDrFixgu+//75wohRCCCGEEAUuT20Ec7qHb44bU6lQq9XPHFRhkjYRQgghhJwPhVaeagQ1Gk1hxyGEEEIIIZ6zfLcRFEIIIYQQrwZJBIUQQgghiilJBIUQQgghiilJBIUQQgghiilJBIUQQgghiqk89RqOi4vL8walC7oQQgghxMshT4mgnZ0dKpUqTxt80ccRFEIIIYQQWnlKBHft2qV7fOvWLYYMGUKfPn2oW7cuAAcPHmT+/PmMGzeucKIUQgghhBAFLk93FsmqefPmfPDBB7z99tt60xcvXsysWbPYvXt3QcZX4GQkdSGEEELOh0Ir351FDh48SEBAQLbpAQEBHDlypECCEkIIIYQQhS/fiaCnpyezZ8/ONv3PP//E09OzQIISQgghhBCFL09tBLOaNGkSr7/+Ops3byYwMBCAI0eOcPXqVVatWlXgAQohhBBCiMKR7xrBtm3bcuXKFTp06EBUVBRRUVF06NCBK1eu0LZt28KIUQghhBBCFIJ8dxZ52UnjWCGEEELOh0Lrqe4ssm/fPt555x3q1avHvXv3AFi4cCH79+8v0OCEEEIIIUThyXciuGrVKlq3bo25uTknTpwgNTUVgNjYWMaOHVvgAQohhBBCiMKR70Twxx9/ZMaMGcyePRtjY2Pd9Pr163PixIkCDU4IIYQQQhSefCeCly9fplGjRtmm29raEhMTUxAxCSGEEC8FRVHo168fDg4OqFQq7Ozs+OKLL4o6LCHyLN+JoJubG9euXcs2ff/+/ZQpU6ZAghJCCCFeBlu2bGHevHn8888/BAcHU7Vq1Xytv3v3blQqlVSkiCKT70Twww8/ZODAgRw+fBiVSsX9+/dZtGgR//vf//j4448LI0YhhBDihXT9+nXc3d2pV68ebm5uGBnle3heIYpUvhPBIUOG0KNHD5o3b05CQgKNGjXigw8+oH///gwYMCDfAUyfPh1vb2/MzMwIDAx84m3qYmJi+PTTT3F3d8fU1JQKFSqwadOmfO9XCCGEeBZ9+vRhwIABBAUFoVKp8Pb2zrbMwoULCQgIwNraGjc3N3r06EFYWBgAt27domnTpgDY29ujUqno06fPc3wFQjxFIqhSqfj222+Jiori3LlzHDp0iPDwcEaPHp3vnS9btoxBgwYxcuRITpw4ga+vL61bt9Z9SB6VlpZGy5YtuXXrFitXruTy5cvMnj0bDw+PfO9bCCGEeBa//fYbP/zwAyVLliQ4OJijR49mWyY9PZ3Ro0dz+vRp1q5dy61bt3TJnqenp+6OXJcvXyY4OJjffvvteb4EIfJ/i7kHTExMqFy58jPtfOLEiXz44Yf07dsXgBkzZrBx40bmzJnDkCFDsi0/Z84coqKiOHDggK7Hck6/wIQQQrzcfp02j8vXbz33/VYs681Xn/XJ07K2trZYW1tjaGiIm5tbjsu89957usdlypRhypQp1KpVi4SEBKysrHBwcADAxcUFOzu7Zw1fiHzLUyLYtWvXPG9w9erVeVouLS2N48ePM3ToUN00AwMDWrRowcGDB3NcZ/369dStW5dPP/2UdevW4ezsTI8ePRg8eDCGhoZ5jlEIIcSL7fL1W5w4faGow3hmx48fZ9SoUZw+fZro6Gg0Gg0AQUFBz1yZIkRByFMiaGtrW+A7joiIQK1W4+rqqjfd1dWVS5cu5bjOjRs3+Pfff+nZsyebNm3i2rVrfPLJJ6SnpzNy5Mgc10lNTdUNeg3aW+oIIYR4sVUs6/3S7zcxMZHWrVvTunVrFi1ahLOzM0FBQbRu3Zq0tLQC248QzyJPieDcuXMLO4480Wg0uLi4MGvWLAwNDalZsyb37t1jwoQJuSaC48aN4/vvv3/OkQohhHgWeb08+yK7dOkSkZGRjB8/Hk9PTwCOHTumt4yJiQkAarX6uccnBDzlvYYLgpOTE4aGhoSGhupNDw0NzbWthbu7OxUqVNC7DFypUiVCQkJy/XU1dOhQYmNjdX937twpuBchhBBC5MLLywsTExOmTp3KjRs3WL9+fbaOlaVKlUKlUvHPP/8QHh5OQkJCEUUriqs81QjWqFEDlUqVpw3m9TZzJiYm1KxZk507d9K5c2dAW+O3c+dOPvvssxzXqV+/PosXL0aj0WBgoM1hr1y5gru7u+5X1aNMTU0xNTXNU0xCCCFEQXF2dmbevHkMGzaMKVOm4O/vzy+//ELHjh11y3h4ePD9998zZMgQ+vbtS69evZg3b17RBS2KHZWiKMqTFsrPpdXcLtHmZNmyZfTu3ZuZM2dSu3ZtJk+ezPLly7l06RKurq706tULDw8Pxo0bB8CdO3eoUqUKvXv3ZsCAAVy9epX33nuPzz//nG+//TZP+4yLi8PW1pbY2FhsbGzyHKsQQgjxKpHzoYA81gjmJ7nLj27duhEeHs6IESMICQnBz8+PLVu26DqQBAUF6Wr+QDvm0tatW/nyyy+pXr06Hh4eDBw4kMGDBxdKfEIIIYQQr7I81Qg+KiYmhpUrV3L9+nW+/vprHBwcOHHiBK6uri/84M7yC0gIIYSQ86HQyveA0mfOnKFFixbY2tpy69YtPvzwQxwcHFi9ejVBQUEsWLCgMOIUQgghhBAFLN+9hgcNGkSfPn24evUqZmZmuult27Zl7969BRqcEEIIIYQoPPlOBI8ePUr//v2zTffw8CAkJKRAghJCCCGEEIUv34mgqalpjnfnuHLlCs7OzgUSlBBCCCGEKHz5TgQ7duzIDz/8QHp6OgAqlYqgoCAGDx7M66+/XuABCiGEEEKIwpHvRPDXX38lISEBFxcXkpOTady4MeXKlcPa2poxY8YURoxCCCGEEKIQ5LvXsK2tLdu3b2f//v2cOXOGhIQE/P39adGiRWHEJ4QQQgghCslTjSP4MpNxk4QQQgg5HwqtfF8aBti5cyft27enbNmylC1blvbt27Njx46Cjk0IIYQQQhSifCeCv//+O23atMHa2pqBAwcycOBAbGxsaNu2LdOnTy+MGIUQQgghRCHIdyI4duxYJk2axJIlS/j888/5/PPPWbx4MZMmTWLs2LGFEaMQQgjxwvH29mby5Ml60/z8/Bg1ahSgHVXjjz/+4LXXXsPc3JwyZcqwcuXK5x+oEI+R70QwJiaGNm3aZJveqlUrYmNjCyQoIYQQ4lXw3Xff8frrr3P69Gl69uxJ9+7duXjxYlGHJYROvnsNd+zYkTVr1vD111/rTV+3bh3t27cvsMCEEEIUX18PH8vZ85ee+36rVfFhwo/DCmx7b775Jh988AEAo0ePZvv27UydOpXff/+9wPYhxLPIUyI4ZcoU3ePKlSszZswYdu/eTd26dQE4dOgQ//33H1999VXhRCmEEKJYOXv+EvsOHC3qMJ7Zg/Nk1uenTp0qmmCEyEGeEsFJkybpPbe3t+fChQtcuHBBN83Ozo45c+YwfPjwgo1QCCFEsVOtis8Lv18DAwMeHYHtwV23hHhZ5CkRvHnzZmHHIYQQQugU5OXZwuLs7ExwcLDueVxcXLbz5aFDh+jVq5fe8xo1ajy3GIV4kny3ERRCCCEENGvWjHnz5tGhQwfs7OwYMWIEhoaGesusWLGCgIAAGjRowKJFizhy5Ah//fVXEUUsRHZPlQjevXuX9evXExQURFpamt68iRMnFkhgQgghxIts6NCh3Lx5k/bt22Nra8vo0aOz1Qh+//33LF26lE8++QR3d3eWLFlC5cqViyhiIbLLdyK4c+dOOnbsSJkyZbh06RJVq1bl1q1bKIqCv79/YcQoCtHK1evZvGopCZhj7+SGi7MjLs6OuLo44eLspHvuYG+HSqUq6nCFEOKFYWNjw9KlS/Wm9e7dW+95iRIl2LZt2/MMS4h8yXciOHToUP73v//x/fffY21tzapVq3BxcaFnz545ji8oXkyxcXH88d1nVE4/Rz8PA9LUCkfvqdlzJIMDd9QkPdLe2djYGGcnh4dJopNTloTRUZc0uro4YW9nK0mjEEII8RLIdyJ48eJFlixZol3ZyIjk5GSsrKz44Ycf6NSpEx9//HGBBykK1pGNi7n9z280tVaDqXZMcRNDFfW9jKjvZaRLCnffyuDgXW1SmJ6ezv3gUO4Hhz5x+w+SRl2S6ORESQ83qlauSLUqFSldyhMDg6e6zbUQQgghClC+E0FLS0tdu0B3d3euX79OlSpVAIiIiCjY6ESBir9zkf0zh+CQdg8va+20hAwjSjbrhXFyJFHndqFOjtNLChWVETHmntzSuHEu1py7YTGEhUcQFh5JeEQUGRkZ2fbzpKTRytJClxRWr1KJalUqUqVSBSwszAvz5QshxHP16NAyQryI8p0I1qlTh/3791OpUiXatm3LV199xdmzZ1m9ejV16tQpjBjFM0qNDubymokkXtyFQ+YV26R0hUiXOnT68meMzSwB8O46lLhrR4g6s4Ooc7tRJ8ehUjKwT7qJPTfxtzTBrk1dHKp3xb5SQ1Qm5kRFx+oSw9CwCN3jsIiHz0PDtH8PvhQTEpM4dPQkh46e1MWoUqkoX9abapUrUq2KD9Wq+lC9ig/ubi5ymVkIIYQoJColnz9Zbty4QUJCAtWrVycxMZGvvvqKAwcOUL58eSZOnEipUqUKK9YCERcXh62tLbGxsdjY2BR1OIUqIymO+//O5f6+JagUbc1dhkZhf6gFrQb8TI3adXNdV6POyJYUZqUyMsGuYj0cqrfAvlJDDDOTydwkJCZy4eJVzpy/xNnzlzh7/jLnLlwhMSnpses5OthpE8MqPlSv6kO1yj5ULF8aExOTPB4FIYQQOSlO50ORu3wngi+74lDwNemphB5Yzt2df6FJSdBN33Mrgxiv5nz7/WgsLS3yvr2M9IdJ4fk9z5wU6rar0XDjVhBnz1/mzLmLnD1/mbMXLnP3XvBj1zM2NqZSxXJUq1JRV4PoU7EsLk6O0vZQCCHyqDicD8WTSSL4ClE0GiJObubu1j9IiwnRTT8TqmbJZRMGfjeaTu1aPdM+9JPC3aiT4/Xmq4xMsfOph0O15vlKCrOKio7RJoXnL2XWIF7m4uVrT7x1k7GxMSXcXPAo4Zb554qHuxslPdzwcHfDw8NNkkUhhMj0Kp8PRd7lKRG0t7fPczutqKioZw6qML2qBT/2yiGCNk0h6f4V3bSgWA2zjqdh5OnPn9N/xqOEW4HuU5ORTtzVw0Se3Un0uV2os9Q+wsOk0LF6C+x8GjxVUvhAWloal6/e5OyFS7oaxHMXLhMRGZ2v7RgbG+Pu5kzJEu6UcHd9mCSWcNVOK+GKq7OTJIt5oCgK12/e5vCxUxw5dopTZy5iYW5GubLelC1TivJlvClX1pvSpUrKpXwhXkCv6vlQ5E+eEsH58+fneYOPDqb5onnVCn7ivUsEbZpK3NXDummRSRrmnUpn+y349pvP+fLT97Ld9qig6ZLCMzuIPr87W1IIYGRpj4mtCyZ2rpjYumJi64KpnWvmNDdMbJwxMDbN8z4VRSEkNJzT5y5y6/Zd7t0P4e79EO4Hh3D3Xgj3Q0JJS8v/DeCNjIwo4e6SmSBq/0q4uWBoaEh6RgZpaelkZKSTlpZOenoG6RkZpKel6+alZ6STkZ5BWvrD+dp1Hs5PT88gPXN+WmZNZ7nSpahapaKuPWSlCuUwNX1xEqiExESOnzzHkWOnOHzsFEdPnNZLxEtYqzAygIQ0SEhTSFNrpxsYGODtVZKyZUpRrow35cuWolxZb8qV9qakh1uhl01RtBRFITEpicjIGKKiY4iMjiEqKobIqGiiHjyOjiE2Lo6ypb2pX6cm9QJr4uriVNShv/JetfOheDpyafgllRodzJ2tvxN5cgtkvoXJGbDkbBorL6RToqQXc/+YQIB/9ecemyYjndirh4l6TFKYGyNLO12SaGLnpp8sZk7Pa7Ko0WiIiIzm3v0QXZJ4734I94ODiQi5T0x4KLHREZiQgbmxCktjMDdWYWEMFnr/VZgZQUSSwq0YDTejNdyK0RCf9uQYnoWRkREVypXO7CxTUddZxsXZsXB3jH5t39Hjpzl87DTnLlxGo9HoLVfGXkXjUkY0KW2Mp43+VYM0tUJCmkJCGsSnah8npj98nJAGKRoDLO2ccHBxx6mEJx5epSlVtjxlK1bC1VV6jD9viqKg0Wiy/Ofhc0X7PC0tjeiYWF0yFxkd+zCheyS5e/A86w8yYwPtj4aSNgaZfyo8bQ1wtlBxPVrDlmsZHL6rpkwZb+oF1qR+3QDqBwZQysvjpSkPTZo0wc/Pj8mTJxd1KI/1qpwPxbN5IRLB6dOnM2HCBEJCQvD19WXq1KnUrl37iestXbqUt99+m06dOrF27do87etlL/gPegKH/LcURa39ctWgYv2lNBaeTiM6BXp268yvY4djbfX0l2ILiiYjjdirR0i8e5G02DDSYkMz/8KytS/MK/1kUVu7aGBsiiY1CXVKIurUB3/Zn2tSE9GkpxbIa4tMUrgdp3A3XsW9REPuJRoRlmZCBsYYGxthbKz9b2JsjLGxMUZGRpiYGGNsZKSbbmRshLGRMRnqDC5evsbFy9dITX18hunq4qStNczsTV2tSkXKl/XGyOipbh0OPLm2L6sy9io6VXegoZcKO4Pkp97nkySnQ6piiNrQDAMzK0wsbVFMbUk3tibNyIpUQ0tSDCxJVpmTrlGRoVaTkZFBRnrGw8cZajLUatLTM1CrM59nZGSZlnW5DExNTPCtVokAf18CalTD3s620F5fQUhMTOLU2QscPXGGYydOc/PiOZKTk0hIU0hKV/QTOY2SJaHL8jxzfkGeCgxU4GyhTfBK2qh0CV9JGwNcLVUYGjw+oYtK1rDjhpot19K5FaONq4S7K/XrBFC/Tk3q1wnAp0LZF7YJhySC4mVS5IngsmXL6NWrFzNmzCAwMJDJkyezYsUKLl++jIuLS67r3bp1iwYNGlCmTBkcHBxe+UTwQU/ge//O0UugTkaaMmlvNHfjFGysrZgyYRRvdmlXhJHmnTo16WFyGKNNDlNjQgskWSwIKiNTDE0tMDSzRFEZkR4bgpKe8sT1TGxdMXcri7lrGSxcy2gfu5TG0PTJPbXT09O5cu1mZg/qS5mdZi4TFv74wdrNzEypVLGcXnJYrYoPtjbW2ZZ9UNt35PjpzMQv59q+B8zNzXitdllaVbCgjGEYRsnZY7H0rIxDtRaY2rmSkRxPRnI86pR41JmPHzzPSIonPSkWdUoCKiXn/T2NmBSF8EQNYYkK4UkKYYkKYYkawjOfRyQpZDzF7sqX9aZmjWrU8velln91qlWpWGTtHTUaDZeuXM9M+s5w9MRpYu5ep6oz+LkZUt3VAFerh4mRWqOtdU1MVzJrYcmsidXWzD54/KB29tHHKdnHis/G1hRK2hjgaWuAp60hZRxNtLV7ZmqMDfJ2ajGytMPMyQtjKwdirx5Gk6b/4+JShJrNVzP492YGiVlaejjY21K3dk3q1alJgzoB+FarhLGxcZ72WdgkERQvkyJPBAMDA6lVqxbTpk0DtF92np6eDBgwgCFDhuS4jlqtplGjRrz33nvs27ePmJiYVzYRTA6/TfS5XYQeXKnXEzjerAQjNgRx+r62dqtubX/+mv4zpbw8iirUQvH4ZFE7PWuymDV5MzS1wNDUKttzg6zPzTLnP7KsgaklBob6NWyKRkNqTDDJIddJDr1BUuh17eOwWygZT75ObGpfQpcgmruWwcKtLOYu3hgYmz1x3ZCwcF1P6gf/r1y7iVqtfux6pTw9dImhqYnJE2v7ALy9SlI7wJfGVUtSxSoW49DTpEYEZVvuQfLnUL05Zg75K3eKoqBJS9YmiMnxZKTEk5YQQ+i9IMLu3yE6LJiEqHCS46PRpMRjoE7FxlSFo7kKW7P8Xx7UKBCbCpEpKqJTDYlJMyQm3ZC4DGNiM4yJV5uQrJgRGRPL9ZvZX+sDJibG+FbV1hjW8q9OrZrVKV3Ks1AuWYaEhXPs+BmOntD+nTh1FluDJHxdDfF1M8TPzQAni8KrEdOgQm1gSoaBSeZ/U9SGpqhUhlgoCZikRmOQkbcaYQNjM8ycvTBzKpX53wtz51KYOXliZPGw1lWdmkTU2Z2EH91A/M0TetvIUFQcugfrLiRxMkSD5pEzl4W5ObUDfGlQN4B6gQHU8q/+XO5WlJiYyMcff8zq1auxtrbmf//7Hxs2bNAlgtHR0QwcOJANGzaQmppK48aNmTJlCuXLl0dRFFxcXPjjjz944403APDz8yM0NJTgYO0wWvv376d58+ZER0djYWGBSqVi9uzZbNy4ka1bt+Lh4cGvv/5Kx44d8x37y3Y+FIUjT4ngmTNnqFq1aoFXw6elpWFhYcHKlSvp3Lmzbnrv3r2JiYlh3bp1Oa43cuRIzpw5w5o1a+jTp88rlQgqikJS8FWiz+0i6ty/JIdc15tv7ODJ0ivGTN94FtA2xB/61Sd880X/Z7o0+DJTpyahqNNzTN6eB0WjJjXynjYxDL1OcsgNkkJvkBJ+C0X9hGoVlQGmDh5YuJXBzNkbM2cvzJ1KYeZcCiNLu8cmGCkpqVy8fE03xM65zBrEmNi4XNd5lLm5Gf6+Vagd4Eegvy++pWxQ3T1O1JkdpBRw8vcskpNTCLp7H41Gg6GSjio5FlVKNEpSJEpCFOrECNTxEWTEhZEeF44mNTH/OzEwxMTGGSN7D6I1ltyIyuDEjQh2HL/B7dDYXFdzdLDT1RoG+FcnoEY1HOzt8rXrpKRkTp45z9ETZzh+8ixHT5zmzt1gvGxVusTP19UAx1wSP5WpFbZlamBTxh9DM6uHNbDJCah1j+NRpyTokm9NHmq380NlYIipgwdmzqUwc/LSJX7mzl4Y2zjnO1lOibxL+LENRBz/h7QY/dtVphlbczbBgSXHIjlxLedbWRobG+PvW0VXY1intj92tgX/nf/JJ5+wceNG5syZg4uLC8OGDWPPnj289957TJ48mU6dOnH16lVmzpyJjY0NgwcP5vr161y4cAFjY2Nef/113N3dmTZtGtHR0bi5uWFubs6hQ4fw8fFhzJgxbN68mf379wPauzCVLFmSn3/+mVq1ajF16lTmzJnD7du3cXBwyFfsL/r5UDwfeUoEDQ0NCQ4OxsXFhTJlynD06FEcHZ+9wfr9+/fx8PDgwIED1K378C4X33zzDXv27OHw4cPZ1tm/fz/du3fn1KlTODk5PTERTE1NJTX1YZuwuLg4PD09X6iCr2g0JNw5T/S5f4k6t4vUyLvZljFzLkW0c23e+2U9oeHaIXq8PEsw5/cJ1K3t/7xDFnmgUWeQGnHnYc1hZi1iSsQd0Dy+Jg/A0Nxad0I1d8pycnUuhaFJzjUdiqJw5+79Ry4tX9LVcmlr+/wIzPyrUqk86RG3tONCvmDJ37PISEnIrEHOrEmOCSVVV6us/Z+fREhlbkOykT33Eg04fzeeg5eDuR6RTkRSzl+fZUt7Paw19K9OtSo+uh7gGo2Gy1dvZLnEe4bzF6+gVqvxtlNR3dUw81KvIQ7mOSdPhuY22JTxx7qMPzZl/LFwL4/KIH+9rzUZ6Q8TxOR4MlIyk8bMGlp1ckLmf/0kUklPxdShhF6yZ+bshamDR4H+ELu9/lcS718GBTKS40iPjyQjMQbQP+YqEwtSDcyJTtYQG5dAUnLu76uFuRnGxkYYGRphaGSIkaEhRkaGGBoaYZT5XOVQCvM6vbGxscY288/MLHsHNXVaCuE3zlKqej0mffk2TctaoqjVaNyqULvHED7s14/PPvuMChUq8N9//1GvXj0AIiMj8fT0ZP78+bz55ptMnTqVmTNncu7cOdatW8e4ceNwc3OjTZs2fPTRR7Rs2ZLatWszZswY7etVqRg+fDijR48GtDWSVlZWbN68mTZt2uTrGEsiKCCP9xq2s7Pj5s2buLi4cOvWrVzbEhW2+Ph43n33XWbPno2TU96GFhg3bhzff/99IUeWf4o6g7ibp4g+t5Ooc7tJjwvPtoxFiYpYVmhAqnMV5q7/j+m/zNPNe6NzW377eWSh/MIVBcPA0Ahz19KYu5aG6i100zUZaaSEB5EUco3k0Bu6v9SoeyhZEkR1cjyJd86TeOd8tm0b27pg7uSV48nYy1P7165NM93y8QmJpKWl4ehgr6t1jjqzg4tbv3tlkr+sjMysMHKzwsKtbI7zFUVBnRynbWaQJTlMibpLStgtksNv613uV5LjMCOOskDZEtCxhDFgjNrAhMh0M65FpHL2Tjy3YzUExWq4eSuI6zeDWLZqA6C9pFy9SiUsLS04efoccfEJqABvOxV+boZ0aWCEr5spdrlc9jaysM1M+mpiU7Ym5q5lUT3jFRoDI2MMrBwwtspfLdLzknj/MvE3TjxxOSUtCROScFWBqy1g+7iEOD3zL4uMzL/M+oJTV64z6PtNutkqwNPBhCruFlRwNsbbVoWHZQYORqlcD08iLT0Dj9hTxF3LbDt68wSeNirCj65j95xojIwMqeXvp9ueo6MjFStW5OLFiwA0btyYgQMHEh4ezp49e2jSpAlubm7s3r2b999/nwMHDvDNN9/ohVy9+sPRICwtLbGxsSEsLOyJx0qInOQpEXz99ddp3Lgx7u7uqFQqAgICch3768aNG3neuZOTE4aGhoSG6lfth4aG4uaWffDj69evc+vWLTp06KCb9iApNTIy4vLly5Qtq//FP3ToUAYNGqR7/qBGsCg86EGrrfnbgzo5++WmELUNp6PM2XMrnXO3L5GQqP9FaGVpwcTx39HjzU4vzVAKQp+BkQkW7uWwcC+nN12jziA16h4p4UGkRNzO/B9EckQQ6bH6X/LpsWGkx4YRd/2Y3vTHXZ4zSInhzpYlr1TN39NSqVQYWdhiZGGLZYkK2eYrGjWpUfdJDruZ+XdLm7CH3dK77GyoScPFMA0XV6jn+rATSbqi4l4c3IhK53aMRpsg3jxLtEpFi5IG+LqaUt3VMNf2jkaW9toav7I1sSnjj7lLmWdO/F42liUqPna+Ji2FtPgI0uOjQKPfBENlZIqxtSPG1o4oKgPi4hOIjY0nKTmZjAz1w97iajXqDLWujtFQpe141LGiEWXsDShrb0BpewMsjFXkmERmSlcrXIlUY2ygorS9QWZ8ycRcPoCiUXNweBNSbctgWroWHv4t9XpoV6tWDQcHB/bs2cOePXsYM2YMbm5u/PTTTxw9epT09HRdbeIDj3aKUalURVZBI15+eUoEZ82aRdeuXbl27Rqff/45H374IdbW2Xsj5peJiQk1a9Zk586dujaCGo2GnTt38tlnn2Vb3sfHh7Nnz+pNGz58OPHx8fz22285JnimpqaYmuZ9kOJnlZqaRkhoOMGhYQSHhBF6/y6ae2ewTbiGp0E4pgb6H1a1RuFkiIb9QRnsD1ITlZx726aAGtWZO2MCZby9CvtliCJgYGiEuXMpzJ1LAQ315qlTk0iJCMqSHGYmiuG39cZpVDRq7XI5JHo5KU7JX36oDAwxc/LEzMkT+8qNdNMVRSE9LlyXFCaH3SQ5VJssZiQ+7IBjrFLwtgVv27xdKjW2ctTW+JWtiXUZf8xdShf7H3qlOn6Vp+U06gxiL/1H+LENxFzch6JRo2SkkhZ9n7SYEGzLB+JTvxv2VRrrxiBV1BkkRwSRHHyNxOCrxN+9RHLINdTx2iszTbxzf99iMky4n2TE7VgV50MMUKlUvLsiCgNT7dUZZ3MNdyNSKGFvSUk7U9QauBwcR3WDa3DmGtcPL+TiuTOcskil39VLWLhXoERJL6b/PoNz587hV6MGLs7OpKamMnPmTAICArC0LPqhwMSrK88NOh60PTh+/DgDBw4skEQQYNCgQfTu3ZuAgABq167N5MmTSUxMpG/fvgD06tULDw8Pxo0bh5mZGVWrVtVb387ODiDb9Odl9fotzF+8iuCQMEJCw4iMisHKBOqWNKJhKUNqlTDE1Eild6TT1ArH7qvZe1vNwTsZuoGJTU1N8PZywd1N++fm6qx77FWyBIEBfsW2Q0hxZ2hqgaWHD5YePnrTFUUhIzGalPAsyWGENkFMibijG2syK0n+np5Kpcoc3NwF2wp19OalJ8aQHHaTlNAstYhhN7J1dAAwtnbSJX02ZWpi5lyq2Cd+T8vA0Aj7Ko2xr9KY9IQoIk5sJvzYBpJDroGiIfbKQWKvHNS2qyxbU1fT+6Se/gamlli4lcXCvXzmXznMXcthZG6lt9zHH3/Mpk2bmThpLBgY8vP48YSE3CbGqiyrkirh6RrKtxtu801LL9ysDZm+9x4u1iZ8VdcCI8MrRCRd4oI6lB27TmJgbEbZ6k1wdnLE0MSChQsX0qBxcxYtX0sZby+8S5UszEMpiql8ZxVz587VPb57V9upoWTJpy+c3bp1Izw8nBEjRhASEoKfnx9btmzB1dUVgKCgoBd20FCA4JAwduzaj72ZivpehjT0N6WGuyFGjwyYmpwBVxKsuGvgTopdeZwDPejayYVP3Vxwz0z47O1s5WQg8kWlUmGc2c7LurSf3jxFoyY1JkRXc4hKhV2lBpL8FRJjSzuMS9fApnQNvenq1CRdUohGg7W3H6ZOhTPkTHFnbOWAe6OeuDXsQdK9S4QfW0/Eya2ok+NQJ8cRfW5X9pVUBpg5eeqSPQs3beJnYu+ep/dowoQJJCQk0Ovdd7C2tuarr77C3MxEb/iYAQMG8MP69aSlplLF240f3vTAyFCbiDpZGPCuvy3bz93nLV9bapcz5cCdWLYHZ6AoCkdOXuL4gKF6+wyPiCyQ4yUEPMU4ghqNhh9//JFff/2VhATtJakHhf/bb799oZM2KPheUjsXTib04ArKWKaS7TvDxAqrCnVxr9kGuwp18nUfXSGEEM9Ok55K9IW92lrC0OuYOXlh4VZOV9Nn7lo6T2N5FrTU6GCiL+4j5sI+Yq8fgxxq72/GGbD3RgoH76q5GqlBQTtkWOTtkwUysLn0GhbwFDWC3377LX/99Rfjx4+nfv36gHZIl1GjRpGSkqLr4l5c+HjYYmX1cHgaY2sn7Ks2xaFqU6zL+BfJuHZCCCG0DIxNcfRtiaNvy6IORY+pvTtu9d7Crd5bqFOTiL16mJiL+4i5+B/pCdoav9I2Gkr7mdDbDzQmNkSaeXJPccEQ6RgiCk6+awRLlCjBjBkzso1ivm7dOj755BPu3btXoAEWtIL+BZQcdovLcwbqkj8rr2rFrnefEEKIgqFoNCTevaCtLby4j6T7V7ItU+3LJVi4l3/mfUmNoICnqBGMiorCx8cn23QfHx+ioqIKJKiXibmLN76D10p7HyGEEM9MZWCAlVdVrLyq4tn6Y1JjQoi5uJ+Yi/uIvXYUYysHzN3KPXlDQuRRvhNBX19fpk2bxpQpU/SmT5s2DV9f3wIL7GUiSaAQQojCYGrnhmvdN3Ct+wbqtGRSI+/JOUcUqHwngj///DPt2rVjx44dutvCHTx4kDt37rBp06YnrC2EEEKIp2FoYp5tIHohnlW+G7M1btyYK1eu0KVLF2JiYoiJiaFr165cvnyZhg0bPnkDQgghhBDihZDvziIvO2kcK4QQQsj5UGhJ91YhhBBCiGJKEkEhhBBCiGJKEkEhhBBCiGJKEkEhhBBCiGLqqRLBjIwMduzYwcyZM4mPjwfg/v37unsPCyGEEEKIF1++xxG8ffs2bdq0ISgoiNTUVFq2bIm1tTU//fQTqampzJgxozDiFEIIIYQQBSzfNYIDBw4kICCA6OhozM3NddO7dOnCzp07CzQ4IYQQQghRePJdI7hv3z4OHDiAiYmJ3nRvb2/u3btXYIEJIYQQQojCle8aQY1Gg1qtzjb97t27WFtbF0hQQgghhBCi8OU7EWzVqhWTJ0/WPVepVCQkJDBy5Ejatm1bkLEJIYQQQohClO9bzN25c4c2bdqgKApXr14lICCAq1ev4uTkxN69e3FxcSmsWAuE3FJHCCGEkPOh0Hqqew1nZGSwbNkyTp8+TUJCAv7+/vTs2VOv88iLSgq+EEKIl42iKBw+doaYuHjaNG9QINuU86GAfHYWSU9Px8fHh3/++YeePXvSs2fPwopLCCGEKPZSUlLZuH0vS1dv4ubte9jZWtO0YW1MH+mwKcTTylciaGxsTEpKSmHF8lLKUKtZvGIjbVs1wsnBrqjDEUII8QoICY1g+botrN24k7j4RN30lNQ0Ll25iW/VikUYnXiV5PvS8NixY7ly5Qp//vknRkb5Hn2myBV0Vfi/ew/zzahfMTIypEXjurzVuQ3VKpdHpVIVQLRCCCGKC0VROH3+MktXbWLXviOoNRrdPDcXJ97q3IbO7ZphY21VIPuTS8MCnmIcwaNHj7Jz5062bdtGtWrVsLS01Ju/evXqAgvuZXD4+BkAMjLUbNm5ny079+NTvjTdurxGy6b1MDOV6nshhBC5S0/PYNuuAyxdvYmLV27ozfOr5sPbr7elcf1aGBkaFlGE4lWW7xrBvn37Pnb+3LlznymgwlbQv4AUReHshassX7uFHXsOkpHxcIxFWxtrOrdtxhsdW+Hu5vzM+xJCCPHqiIqOZdWG7axcv43IqBjddGNjI1o1rcfbXdviU6FMoe1fagQFPGWv4ZdZYRb8iKgY1m7cwar12wmPjNZNNzBQ0bBuTd7q3Iba/tXksrEQQhRjl67eZOnqTWz99z/S0zN00x3sbXm9Q0te79jqubQ5l0RQgCSChbKPjIwMdu0/wvI1Wzl59qLePG8vD97q3Jp2rRpjafHiD7cjhBDi2anVGvb8d5Slqzdx4oz+eaFiudK8/UZbWjWph4mJ8XOLSRJBAU+ZCK5cuZLly5cTFBREWlqa3rwTJ04UWHCF4XkX/CvXb7F8zRY279xPaurDY2VpYU67Vo15q3NrvL08Cj0OIUTRUqs1qFRgYJDvGzqJAnA/JIyzF65ib2eDu6szLs4Oz2UIlviERNZt+pfla7dwPyRcN93AQEWTBrV5u2tb/Kr5FMmVIkkEBTxFIjhlyhS+/fZb+vTpw6xZs+jbty/Xr1/n6NGjfPrpp4wZM6awYi0QRVXwY+MS2LBlFyvWbeVecJjevMCa1Xmrcxsa1PHH0FBOEkK8KhRF4dzFq2zYuptt/x4gNS2N9q0a885bHSjlWaKowysWUtPSmLd4LfOWrNW7DAvgaG+Lq4sT7q7OuLk64ebihHvmfzdXJ2xtrJ86QbsVdJ9lazbxz9Y9JKek6qZbW1nSuV1z3urUusjbjksiKOApEkEfHx9GjhzJ22+/jbW1NadPn6ZMmTKMGDGCqKgopk2bVlixFoiiLvhqtYYDR06yfO0WDh49rTfP3dWZNzq1otNrzbCztX7usQkhCkZYeBSbtu9lw9bd3L5zP9t8lUpFkwa16N29E1UrlS+CCIuHw8fP8NNvfxF0N/ip1jczM9UmhS5OuLk44pYlYXRzccLV2RFj44eDbyiKwqFjp1myajMHjpzU25a3lwfdu7xGu1aNMDc3e6bXVVCK+nwoXgz5TgQtLCy4ePEipUqVwsXFhe3bt+Pr68vVq1epU6cOkZGR+Q5i+vTpTJgwgZCQEHx9fZk6dSq1a9fOcdnZs2ezYMECzp07B0DNmjUZO3Zsrss/6kUq+Lfv3Gflum2s37qLxMRk3XRTE2NaN2/AW53b4FO+dBFGKF4F6ekZHD99AY1GQ+2a1WQIikKSmpbGnv+O8c/W3Rw6dhqN5uFXq6GBAXVr+6FSqdh38Ljeev6+lenVrSP1A2tIR7ICEhEVw+Q/FrBl537dtArlvPm83zsYGhgQHBpOSFjEw7/QCELDIkhNS8/XflQqFU4Odtrk0NWZazduc/P2Pb1l6tWuwduvv0ZgzeovXLOAF+l8KIpOvhPBMmXKsGrVKmrUqEFAQAAffvgh/fv3Z9u2bXTv3p2oqKh8BbBs2TJ69erFjBkzCAwMZPLkyaxYsYLLly/j4uKSbfmePXtSv3596tWrh5mZGT/99BNr1qzh/PnzeHg8ua3di1jwE5OS2bx9H8vXbuHG7bt686pXqchbnVvTvFEdvV+eQjxOenoGR06cZceeg+zef5T4BO2dCby9PBjY/x0a1PGXpKMAKIrC+UvX2LBlN9t2HdAd5wfKlCpJhzZNeK1FQ5wc7QG4efsuC5atZ/OOfXrDTZUt7cm73TrSpln9l3Kw/heBRqNh9T87mDZ7MQmJSQCYm5nyUd9udOv62mN/BCmKQnRMnC4xzJoshoZFEhwaTnRMXJ7iMDMzpUPrxnTr8toL3Qb8RTwfiucv34ngBx98gKenJyNHjmT69Ol8/fXX1K9fn2PHjtG1a1f++uuvfAUQGBhIrVq1dJeUNRoNnp6eDBgwgCFDhjxxfbVajb29PdOmTaNXr15PXP5FLviKonD81HmWrdnCngNH9WoUHB3s+O5/H9Ggjn8RRiheZLklfzkJ8KvCFx+9W6hjlL3KwiOi2LRjH/9s3Z2tBsjG2pLWzRrQoU0TKlUok2vCHRYexZJVG1n9zw4Skx5eEXB1caTH6+3o3K65jCyQD1eu32LsxNmcu3hVN61pg9p89Vkf3FycCmQfKalphGYmh8GZtYghoQ+eh2NiYkKH1o3p1Lbg7v5RmF7k86F4fvKdCGo0GjQaje4X69KlSzlw4ADly5enf//+mOSjF1ZaWhoWFhasXLmSzp0766b37t2bmJgY1q1b98RtxMfH4+LiwooVK2jfvv0Tl39ZCn5IaASrNmxjzcadxMTGA9pfmfOmj6Fcaa8ijk68KJ6U/JkYG1Ovth8tmtQlPCKKOYvW6C3TtmUjPnm/e4GdKF9lqWlp7D1wjA1b9nDo2Cm9H2oGBirq1vKjQ+smNKoXkK8hQOITElm1YTtLVm3SG1TY2sqSNzu1pluXNjjKfcxzlZScwsx5y1m6apPulmxuLk588/l7NKoXUMTRvdhelvOhKFxFOo7g/fv38fDw4MCBA9StW1c3/ZtvvmHPnj0cPnz4idv45JNP2Lp1K+fPn8fMLHsD3NTUVFJTH/bYiouLw9PT86Up+KlpaWzYvJufpvyFoih4erix4I9xWFtZPnll8UrKT/LXsG5NvVqlmNh4/vp7FSvWbdVdljQ1MabHm+3p3b0TVpYWz/W1vOi0l36v88/W3Wz9979sx7p0KQ86tG5K25YPL/0+rdS0NDZv38eCZev1OjeYGBvTvk1j3n2rI54ebs+0j1fN7v1HmDB1LqHh2rbphoaG9HyzHR+++8YL0yHjRSaJoICnTARjYmI4cuQIYWFhaLLcFBvI0+XZB541ERw/fjw///wzu3fvpnr16jkuM2rUKL7//vts01+2gv/nwlXMmLsMgAZ1/Jn44zcvXMNjUXieJfnLyZ17IUydvYh/9z78jNnb2dC/91t0bt+82HcoedylX2srS9o0r0/71k2oXLFsgbe11Gg07PnvGPOXrtO7zKlSqWjWMJBe3TtSxadcge7zZRMcEs6EaXPZe+CYblr1KhUZ9uWHlCsjV0zyShJBAU+RCG7YsIGePXuSkJCAjY2N3pegSqXKV2eRZ7k0/Msvv/Djjz+yY8cOAgJyr/5/2WsEH9BoNHw98hf2/Kf94vuw1xv07/NWEUclClNBJ385OXXuEpP/WKiXcHh7efB5v540rFuz2HQoUas1RMfGcerMRTZs3c3Bo9kv/dYJ8KNDm8Y0qhfwXAYiVhSFU2cvsWDpOvYd0h+ov6ZfFXp370TdWr7F5j0C7V2bFq/cxKwFK0jJHJvPxtqSz/u9Q8fXmsqP43ySRFDAUySCFSpUoG3btowdOxYLi2e/jBQYGEjt2rWZOnUqoE14vLy8+Oyzz3LtLPLzzz8zZswYtm7dSp06dfK1v5e54CckJNHrk6G6y0YTf/xG2sC8Yp5H8vcoRVHYvvsg02Yv0rvzwavQoSQlNY3IqBgiIqOJiIrOfByT7XF0TKxe4vdA6VIetG/dhLYtGuLs5FAEr0Dr2s0g/l6+gc079qNWP+xpXK6MF726daRV03qF3tM4IyODhMRk1Go1Dva2zz0BPX3uMuMmz+bajSDdtHatGjGw/7s42Ns+11heFS/z+VAUnHwngpaWlpw9e5YyZQrm5LBs2TJ69+7NzJkzqV27NpMnT2b58uVcunQJV1dXevXqhYeHB+PGjQPgp59+YsSIESxevJj69evrtmNlZYWV1ZN7ab3sBf/m7bv0/mQYSckpWFqas/CP8XiVdC/qsMRTUhSFmNh4zl+6xs69h56Y/DWo419o7fjS0tJZvnYLf/29+oXuUKIoCnHxidpELiqaiMjMpC4z4cv6+MEQIvlhbWVJ62baS79VfAr+0u+zCAmLYMmqTaz5ZwdJySm66W4uTvR8sz2d2jbD4pG2cRqNhqTkFBKTkklISNL+T0wiMSlJ/3mi9n9CUpbHiQ/nZ71FpqO9LdUqV6BalQpUr1yBShXLYmZaOLWksXEJTPtzMWv+2aGbVsqzBEO/+ICAGlULZZ/Fxct+PhQFI9+JYNeuXenevTtvvVVwlyWnTZumG1Daz8+PKVOmEBgYCECTJk3w9vZm3rx5AHh7e3P79u1s2xg5ciSjRo164r5ehYL/797DfDPqV0A7Ttm838dm+/IXL5ak5BSC7gZn/t3n9p1g3fOchnl5XslfTnLtUPJGO3q/3fm5xaLRaAi6G8L5S9c4f+kal67eJDwiisioGNLS8zfwb1YGBirs7WxxcrDH0cEOJ0c73WMPdxdq+Vd9Lpd+n0VcfAIr129j6erNREXH6qbbWFvi7VXyYaKXmERSUgqF3SfQ0NCQiuW8qV6lAtUqV8C3SkVcXRyfKYlWFIVN2/cxecYC3fh9JsbGvPdOF3p165SvntkiZ6/C+VA8uzwlguvXr9c9Dg8P54cffqBv375Uq1YNY2P9D2PHjh0LPsoC9KoU/GmzFzNvyVoAWjSuw7gRX75QNRfFUXp6BveCwwi6e5+gu8HcfpD43blPeGT0E9cvyuQvJ7l1KOnX+026tGte4JciI6JiOH/xmi7xu3D5+mPHQnyUqYkxTo72ODrY4+Roh6O9HU6Ojz62x97W5pW5p3dqWhobt+1l4bL13LkX8kzbsrQwx8rS4uF/y0efW2BlaYFareb8pWucuXCF0LDc7yTl7GivqzGsXqUiPuVL5zl5uxV0n/GTZ3Ps1HndtMCa1RnyxQfSc7oAvSrnQ/Fs8pQI5rUBrkql0mu/8iJ6VQq+Wq1h4NBxHDqmvV/x5/3eoVf3FzsJfxVoNBrCwqO4ffc+d+6GcDsz6Qu6G8z94DDdOGZP4uLkgFdJd7w83fEqWYJSJd2pUb1SkSd/OSmMDiWJSclcvHJDl/Sdv3TtsUmFqYkxFcuVxqOEa2ayZ4eTQ2Zy56Ct0bO0NC+2P4bUag27/zvC+s27SEtLf2wi92iiZ2VhgYWF2VN1tAgNj+Ts+SucuXCFsxeucOnqTdLTM3Jc1tjYCJ/ypamWmRhWr1wBF2f9dpepaWnMW7yWeUvW6rbjaG/LoE/70KppvWL7/haWV+V8KJ5NkY4jWBRepYIfExtPr4+HcD8kHAMDFVN/+pbAmjkPoyOyS01LIyEhSdcWSu/vkenx8YncDQ7lzt3gPN+P1NrKklKeJbQJX0l3SmUmfZ4ebi/dpXxFUdix5yDTZi/mXnCYbnrNzA4llR7ToSQjI4NrN+/oEr5zF69x8/bdXC9XqlQqyniXpIpPOd1fudKectu1l0BqWhqXrtzk7IXM5PD8lcfWhru6OOpqDB3sbZkxd5muZlOlUvFGx5Z88v7bMm5qIXmVzofi6Uki+JK7dPUm7w8YTmpaOrY21vw9Yzzubs5FHdZzdfdeCHfvh+ac0OWQ1D1oAJ9bzUV+mJoY4/kg0SupTfQeJH22NtavXA1Gbh1KXmvRkE/ffxtXF0fu3Q/lnK6m7zqXr954bPLs6uKoS/iqViqPT/nScmu1V4SiKISGRXL6/GVtcnj+Cpev3XrilaMK5bwZ9mU/qlYq3uMlFrZX7Xwonk6eE8GDBw8SGRmpdxu3BQsWMHLkSBITE+ncuTNTp07F1NS00IItCK9iwd+0fS8jxmnv1exTvjR/ThldaD34XgTp6RmcOnuJfYeOs//QCb27MBQ0czNT7eUzKwvcXV20yZ7ng8SvBC7ODsVy7LLcOpSYmZkSG5eQ63pWlhZ6NX1VfMo+8x05xMslJTWNS1duaJPD89pLypGZHV4szM34qG833urSptgPav48vIrnQ5F/eU4EX3vtNZo0acLgwYMBOHv2LP7+/vTp04dKlSoxYcIE+vfvn6eeu0XpVS34v0yby9LVmwFo37oxI7/55JWqjYqOieO/IyfZf/A4B4+dJjEx+YnrPGwjpW0bpf0zx8oq6/OHf5bZnpvLyegJ7twLYdrsxezceyjbPGNjIyqU9dZL/LxKuhXLxFnkTlEU7oeEc/vOfSqW85b7Kj9Hr+r5UORPnhNBd3d3NmzYoLuLx7fffsuePXvYv38/ACtWrGDkyJFcuHCh8KItAK9qwc/IyODjr0Zz8uxFAAYPfJ83O7Uu4qienqIoXL1xm30HT7D/0HHOXbyWrU2ZgYEK3yo+1K9Tg+qVK2BjbaVL4p628bt4OqfPXWbFuq0YGBhQtZI26StfppQM8SHEC+xVPR+K/Mlz6+vo6GhcXV11z/fs2cNrr72me16rVi3u3LlTsNGJPDMyMmLcyC95t/9gwiOj+WXaPMqXLYVfVZ+iDi3PUlJSOXryHPsOHee/Qyd1N5LPytrKknq1/WhYtyZ1a/lha/PkQcRF4fOtWhHfqhWLOgwhhBD5lOdE0NXVlZs3b+Lp6UlaWhonTpzg+++/182Pj4/PNqageL6cHOz4+fuv+PCLkWRkqBk8aiKLZv70QrfBCgmNYP+hE+w7dJxjJ8/l2KmgTKmSNKjrT8M6NalWpYJcrhVCCCEKSJ4TwbZt2zJkyBB++ukn1q5di4WFBQ0bNtTNP3PmDGXLli2UIEXeVatcga8HvMe4SbOJjIrhm1ETmTlxJMbGL8bQG2q1hnMXr7L/0HH2HzrJ1RvZ7xJjbGxEgF8V6gf606COPyVLuOawJSGEEEI8qzxnB6NHj6Zr1640btwYKysr5s+fj0mW2zDNmTOHVq1aFUqQIn+6tm/BhcvXWbfpX86cv8zE3+czeOD7RRZPQmISB4+eYt/BE/x3+CSxcfHZlnF0sKNBHX8a1vGnds3qL904e0IIIcTLKN/jCMbGxmJlZYXhI5fnoqKisLKy0ksOX0TFpXFsaloaHw4cyYXL1wEYNfgT2rdu8lxjuHHrLsvWbGbT9r0kp6Rmm1+5Yllt8le3JhXLeUvnDiGEeI6Ky/lQPJ4MKP0KCwmL4N2PhhAdE4eJsTF/TR392DtAFAS1WsO+g8dYtmYLR0+e05tnbmZKnQBf6tfxp0FgjRe67aIQQrzqitP5UOROEsFX3LFT5/n0f6NRazS4uTjx98zx2NkW/OuOiY1n3eZ/WbluG8Gh4Xrz6tWuwZudWhFYs7oMJyKEEC+I4nY+FDmTRLAYWLTiHyb9sQCA2v7VmPLTsALreXv52i2WrdnM1p379Xr8Wlqa07FNU97s1Bqvku4Fsi8hhBAFpzieD0V2L0ZXUlGoerzRjvOXrrFt1wGOnDjL9D+XMLD/O0+9vYyMDHbtP8KyNVs4dfaS3rwypUryVuc2tG3VSDp8CCGEEC84SQSLAZVKxXf/+4gbt+9y7UYQC5etp0rFsrRoUjdf24mMimHNxh2sWr+d8Mho3XQDAxWN6gbQrctrBNSo8krd2k4IIYR4lcml4WLk7r0Q3v14KPEJiZibmTJ3+hjKlfZ64nrnLl5l2Zot7NhzkPT0DN10WxsrOrVtxhsdW1HCzaUwQxdCCFHAivP5UDwkiWAx89/hk3wxbDyKouBV0p35v4/F2soy23Jpaels332QZWs264ageaBCOW+6dWlD62YNMDN9sYcLEkIIkbPifj4UWpIIFkN/LlzFjLnLAGhYx59ff/xGN4ZfWHgUqzZsY83GnURFx+rWMTQ0pFmjQLp1boNv1Ypy+VcIIV5ycj4UIG0Ei6X3enbhwuXr7D1wjH2HTvDnwlXUqlGV5Wu38O++I6jVat2yDva2dG3fgq7tW+Li7FCEUQshhBCioEmNYDGVkJBEr0+GEnQ3OMf5VSuVp1uXNjRvVEfG/hNCiFeQnA8FSI1gsWVlZcEvP3xNn0+HkZScAoCxsREtm9SjW5c2VPEpV8QRCiGEEKKwSSJYjJXxLsmvo79h4fL1+Fb1oUu75jjY2xZ1WEIIIYR4TiQRLOZq+Velln/Vog5DCCGEEEXAoKgDEEIIIYQQRUMSQSGEEEKIYkoSQSGEEEKIYkoSQSGEEEKIYkoSQSGEEEKIYkoSQSGEEEKIYuqFSASnT5+Ot7c3ZmZmBAYGcuTIkccuv2LFCnx8fDAzM6NatWps2rTpOUUqhBBCCPHqKPJEcNmyZQwaNIiRI0dy4sQJfH19ad26NWFhYTkuf+DAAd5++23ef/99Tp48SefOnencuTPnzp17zpELIYQQQrzcivxew4GBgdSqVYtp06YBoNFo8PT0ZMCAAQwZMiTb8t26dSMxMZF//vlHN61OnTr4+fkxY8aMJ+5P7q0ohBBCyPlQaBXpnUXS0tI4fvw4Q4cO1U0zMDCgRYsWHDx4MMd1Dh48yKBBg/SmtW7dmrVr1+a4fGpqKqmpqbrnsbGxgPYDIIQQQhRXD86DRVwfJIpYkSaCERERqNVqXF1d9aa7urpy6dKlHNcJCQnJcfmQkJAclx83bhzff/99tumenp5PGbUQQgjx6oiPj8fWVu4zX1y98vcaHjp0qF4NokajISoqCkdHR1QqVYHsIy4uDk9PT+7cuSPV60VAjv+LQd6HoifvQdF5GY+9oijEx8dTokSJog5FFKEiTQSdnJwwNDQkNDRUb3poaChubm45ruPm5pav5U1NTTE1NdWbZmdn9/RBP4aNjc1L8wXwKpLj/2KQ96HoyXtQdF62Yy81gaJIew2bmJhQs2ZNdu7cqZum0WjYuXMndevWzXGdunXr6i0PsH379lyXF0IIIYQQOSvyS8ODBg2id+/eBAQEULt2bSZPnkxiYiJ9+/YFoFevXnh4eDBu3DgABg4cSOPGjfn1119p164dS5cu5dixY8yaNasoX4YQQgghxEunyBPBbt26ER4ezogRIwgJCcHPz48tW7boOoQEBQVhYPCw4rJevXosXryY4cOHM2zYMMqXL8/atWupWrVqUb0ETE1NGTlyZLZL0OL5kOP/YpD3oejJe1B05NiLl1WRjyMohBBCCCGKRpHfWUQIIYQQQhQNSQSFEEIIIYopSQSFEEIIIYopSQSFEEIIIYqplyoRHDduHLVq1cLa2hoXFxc6d+7M5cuX9ZZJSUnh008/xdHRESsrK15//XW9AahPnz7N22+/jaenJ+bm5lSqVInffvst2752796Nv78/pqamlCtXjnnz5j0xPkVRGDFiBO7u7pibm9OiRQuuXr2qt8yYMWOoV68eFhYW+RrY+syZMzRs2BAzMzM8PT35+eef9eafP3+e119/HW9vb1QqFZMnT87ztvPqVTj+D45P1r/x48c/cdtPimfv3r106NCBEiVKoFKpcr33dUF4Fd6HEydO0LJlS+zs7HB0dKRfv34kJCQ8cdsvwucAnt97EBwcTI8ePahQoQIGBgZ88cUXeY5x+vTpeHt7Y2ZmRmBgIEeOHNGbP2vWLJo0aYKNjQ0qlYqYmJg8bTcoKIh27dphYWGBi4sLX3/9NRkZGQUSc168Cse+SZMm2b6HPvrooydu90Up/+LV8lIlgnv27OHTTz/l0KFDbN++nfT0dFq1akViYqJumS+//JINGzawYsUK9uzZw/379+natatu/vHjx3FxceHvv//m/PnzfPvttwwdOpRp06bplrl58ybt2rWjadOmnDp1ii+++IIPPviArVu3Pja+n3/+mSlTpjBjxgwOHz6MpaUlrVu3JiUlRbdMWloab775Jh9//HGeX3dcXBytWrWiVKlSHD9+nAkTJjBq1Ci9sROTkpIoU6YM48ePz/UuK8/qVTj+AD/88APBwcG6vwEDBjx2u3mJJzExEV9fX6ZPn56nY/ksXvb34f79+7Ro0YJy5cpx+PBhtmzZwvnz5+nTp89jt/uifA7g+b0HqampODs7M3z4cHx9ffMc37Jlyxg0aBAjR47kxIkT+Pr60rp1a8LCwnTLJCUl0aZNG4YNG5bn7arVatq1a0daWhoHDhxg/vz5zJs3jxEjRjxzzHn1Khx7gA8//FDve+jRpO5RL1L5F68Y5SUWFhamAMqePXsURVGUmJgYxdjYWFmxYoVumYsXLyqAcvDgwVy388knnyhNmzbVPf/mm2+UKlWq6C3TrVs3pXXr1rluQ6PRKG5ubsqECRN002JiYhRTU1NlyZIl2ZafO3euYmtr+8TXqCiK8vvvvyv29vZKamqqbtrgwYOVihUr5rh8qVKllEmTJuVp28/iZTz+T3Ns8hsPoKxZsyZf+3gWL9v7MHPmTMXFxUVRq9W6Zc6cOaMAytWrV3Pd9ov6OVCUwnsPsmrcuLEycODAPMVTu3Zt5dNPP9U9V6vVSokSJZRx48ZlW3bXrl0KoERHRz9xu5s2bVIMDAyUkJAQ3bQ//vhDsbGx0Xtfnibmp/UyHvunOS4vcvkXL7eXqkbwUbGxsQA4ODgA2l956enptGjRQreMj48PXl5eHDx48LHbebANgIMHD/6/vfuPibr+4wD+PIE776BDCLxD9AyktQAZGpOZDiubRG4515YTIYk2hsGsaZismtGWYxG0Rq45M9BJo60oWzX7o3SK1BI6IPxxTUL65w5mhpIccHKv7x+Nz7cTDo4fAh/u+dhug/f783593p/3+/OBF597fw6PGACQnp4+ZoyOjg44HA6PdqGhoUhNTR2znS9++uknpKWlQavVevTHZrPh77//nlLsqVDr+JeWluL+++/HqlWrUFZW5vG21mgm05+ZpLZ5GBgYgFar9figeL1eDwCor6/3GnuuXgfAvZuDyRgcHERTU5PHvhcsWIAnn3xyWn4WrVy5UvnAf+DfObh16xYuXrw4pdiTpdaxr6mpQUREBBITE1FcXIy+vr4xY8/l85/Ubdb/s8hkud1uvPLKK1i3bp3yX0UcDge0Wu2ItXcmkwkOh2PUOA0NDfjss8/w7bffKmUOh8PjB91wjFu3bsHpdCq/tP5rOP5o7bzt21cOhwMxMTEj4g7XhYWFTSn+ZKh1/Hfv3o3Vq1cjPDwcDQ0NKC4uht1uR0VFhddjnUx/Zooa5+GJJ57Anj17UFZWhpdffhm3b9/G/v37Afy7LsubuXgdAPd2Dibj+vXrGBoaGnUOrly5MqXY3s6J4bqZptaxz8zMxPLly7FkyRK0trbitddeg81mQ11dndfYc/X8J/VT7R3BgoICtLW1oba2dtIx2trasGXLFhw4cACbNm3yuV1NTQ1CQkKU17lz5ybdh7slJCQocTMyMqYt7nRT6/jv2bMHjz32GJKSkpCfn4/y8nJUVlZiYGAAADzi+rJ4e7apcR4SEhJw7NgxlJeXw2AwwGw2IyYmBiaTSblLqJbrAJjdOTh37pzHHNTU1Ey6D3fLyMhQ4iYkJExb3Omk1rHPy8tDeno6Vq5ciR07duD48eP48ssv0d7eDkBd5z+pnyrvCBYWFuKbb77B2bNnsXTpUqXcbDZjcHAQPT09Hn8NdnV1jVg4e+nSJWzcuBF5eXl44403POrMZrPHE2bDMYxGI/R6PZ555hmkpqYqddHR0cqdjK6uLkRFRXm0S05O9vnYvvvuO7hcLgD/f7vMW3+G62bafBr/1NRU3LlzB9euXcNDDz2E5uZmpc5oNPrUn9mi5nnIzMxEZmYmurq6EBwcDI1Gg4qKCsTGxgJQx3UA3Ps5GE9KSorHOWsymaDT6RAQEDDqWE1knD7++GM4nU4AQFBQkHJcdz8BO1tzMJ/Gfvg6unr1KlasWKGa85/midlepDgRbrdbCgoKZMmSJfL777+PqB9eJPz5558rZVeuXBmxSLitrU0WL14sRUVFo+5n3759kpiY6FG2fft2nxbJv/fee0rZzZs3p/VhkcHBQaWsuLh4xhcJz6fxH3bixAlZsGCB3Lhxw+s2E+0P7vHDIvNxHo4ePSoGg2HMBxbmynUgMnNz8F8TfWChsLBQ+X5oaEiio6On7WGRrq4upezw4cNiNBqlv79/Sn321Xwa+2H19fUCQFpaWrxuM5fOf5pfVJUI7tq1S0JDQ+XMmTNit9uVV19fn7JNfn6+WCwW+fHHH6WxsVHWrl0ra9euVep/++03iYyMlKysLI8Y3d3dyjZ//PGHGAwGKSoqksuXL8uhQ4ckICBATp06NWb/SktLZdGiRXLy5ElpbW2VLVu2SExMjDidTmWbzs5OsVqtUlJSIiEhIWK1WsVqtUpvb6/XuD09PWIymSQ7O1va2tqktrZWDAaDHD58WNlmYGBAiRUVFSWvvvqqWK3WMZ/CnCi1j39DQ4O8//770tzcLO3t7XLixAmJjIyU559/fsy4vvSnt7dXGX8AUlFRIVarVTo7Oyc0xr5Q+zyIiFRWVkpTU5PYbDb58MMPRa/XywcffDBm3LlyHYjM3ByIiHI8jzzyiGRmZorVapWLFy+O2b/a2lrR6XRSXV0tly5dkry8PFm0aJHH0752u12sVqscOXJEAMjZs2fFarXKX3/95TXunTt3JDExUTZt2iTNzc1y6tQpiYyMlOLi4in32VdqH/urV6/K22+/LY2NjdLR0SEnT56U2NhYSUtLGzPuXDr/aX5RVSIIYNRXVVWVso3T6ZSXXnpJwsLCxGAwyNatW8Vutyv1Bw4cGDXG8uXLPfZ1+vRpSU5OFq1WK7GxsR778Mbtdsubb74pJpNJdDqdbNy4UWw2m8c2O3fuHHX/p0+fHjN2S0uLrF+/XnQ6nURHR0tpaalHfUdHx6hxN2zYMG6/faX28W9qapLU1FQJDQ2VhQsXysMPPywHDx4c9U7G3cbrz/BdlbtfO3fuHDf2RKl9HkREsrOzJTw8XLRarSQlJcnx48d9Ova5cB2IzOwc+LLNaCorK8VisYhWq5U1a9bIzz//7FHvbf/jzfG1a9ckIyND9Hq9REREyN69e8Xlck1Ln32h9rH/888/JS0tTcLDw0Wn00lcXJwUFRXJzZs3x407V85/ml80IiKjvWVMRERERPObap8aJiIiIqKpYSJIRERE5KeYCBIRERH5KSaCRERERH6KiSARERGRn2IiSEREROSnmAgSERER+SkmgkSkKhqNBl999dVsd4OIaF5gIkhEPsnJyYFGo0F+fv6IuoKCAmg0GuTk5Ezb/t566y0kJydPWzwiIhqJiSAR+WzZsmWora2F0+lUyvr7+/Hpp5/CYrHMYs+IiGgymAgSkc9Wr16NZcuWoa6uTimrq6uDxWLBqlWrlLKBgQHs3r0bixcvxsKFC7F+/XpcuHBBqT9z5gw0Gg1++OEHpKSkwGAw4NFHH4XNZgMAVFdXo6SkBC0tLdBoNNBoNKiurlbaX79+HVu3boXBYMCDDz6Ir7/++t4fPBHRPMREkIgmJDc3F1VVVcr3n3zyCV544QWPbfbt24cvvvgCx44dw6+//oq4uDikp6fjxo0bHtu9/vrrKC8vR2NjIwIDA5GbmwsA2LZtG/bu3YuEhATY7XbY7XZs27ZNaVdSUoLnnnsOra2tePrpp7Fjx44RsYmIaHxMBIloQrKyslBfX4/Ozk50dnbi/PnzyMrKUupv376Njz76CGVlZcjIyEB8fDyOHDkCvV6Po0ePesR65513sGHDBsTHx2P//v1oaGhAf38/9Ho9QkJCEBgYCLPZDLPZDL1er7TLycnB9u3bERcXh4MHD+Kff/7BL7/8MmNjQEQ0XwTOdgeISF0iIyOxefNmVFdXQ0SwefNmREREKPXt7e1wuVxYt26dUhYUFIQ1a9bg8uXLHrGSkpKUr6OiogAA3d3d4643/G+74OBgGI1GdHd3T+m4iIj8ERNBIpqw3NxcFBYWAgAOHTo06ThBQUHK1xqNBgDgdrsn1G64rS/tiIjIE98aJqIJe+qppzA4OAiXy4X09HSPuhUrVkCr1eL8+fNKmcvlwoULFxAfH+/zPrRaLYaGhqatz0RENBLvCBLRhAUEBChv8wYEBHjUBQcHY9euXSgqKkJ4eDgsFgveffdd9PX14cUXX/R5Hw888AA6OjrQ3NyMpUuX4r777oNOp5vW4yAi8ndMBIloUoxGo9e60tJSuN1uZGdno7e3FykpKfj+++8RFhbmc/xnn30WdXV1ePzxx9HT04Oqqqpp/cBqIiICNCIis90JIiIiIpp5XCNIRERE5KeYCBIRERH5KSaCRERERH6KiSARERGRn2IiSEREROSnmAgSERER+SkmgkRERER+iokgERERkZ9iIkhERETkp5gIEhEREfkpJoJEREREfoqJIBEREZGf+h9/9JoQvcepKAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x260 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Monthly class shares of the ternary direction label across the development window."
+      }
+     },
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  fwd_ret_15m autocorrelation at lag 15: -0.00700\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  fwd_ret_15m autocorrelation at lag 60: -0.00119\n"
+      "flat: 0.181 of labelled bars, ranging 0.061 to 0.268 across months\n",
+      "up: 0.414 of labelled bars, ranging 0.372 to 0.471 across months\n",
+      "down: 0.404 of labelled bars, ranging 0.359 to 0.468 across months\n"
      ]
     }
    ],
    "source": [
-    "# Label autocorrelation at 1-min, 15-min, and 60-min lags\n",
-    "autocorr_lags = {\"1_bar\": 1, \"15_bar\": 15, \"60_bar\": 60}\n",
-    "autocorr_results = {}\n",
+    "classes = {\"0\": \"flat\", \"1\": \"up\", \"-1\": \"down\"}\n",
+    "shades = (COLORS[\"neutral\"], COLORS[\"blue\"], COLORS[\"copper\"])\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single_wide\"])\n",
+    "for (key, tag), colour in zip(classes.items(), shades):\n",
+    "    ax.plot(monthly[\"month\"], monthly[key], lw=1.8, color=colour, label=tag)\n",
+    "ax.set_ylim(0, 1)\n",
+    "ax.set_xticks(monthly[\"month\"].to_list()[::4])\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Share of labelled bars\")\n",
+    "sub = f\"Class shares of {DIRECTION_LABEL} by month, development window\"\n",
+    "add_message_title(ax, \"Up and down stay balanced; the flat share does not hold still\", sub)\n",
+    "ax.legend(loc=\"center right\", frameon=False)\n",
+    "show_with_alt(\n",
+    "    fig, \"Monthly class shares of the ternary direction label across the development window.\"\n",
+    ")\n",
     "\n",
-    "for lag_name, lag_bars in autocorr_lags.items():\n",
-    "    lag_col = f\"fwd_ret_15m_lag_{lag_bars}\"\n",
-    "    valid = df.with_columns(\n",
-    "        pl.col(\"fwd_ret_15m\").shift(lag_bars).over([\"symbol\", \"session_date\"]).alias(lag_col)\n",
-    "    ).drop_nulls(subset=[\"fwd_ret_15m\", lag_col])\n",
-    "    rho = float(valid.select(pl.corr(\"fwd_ret_15m\", lag_col)).item())\n",
-    "    autocorr_results[lag_name] = round(rho, 5)\n",
-    "    print(f\"  fwd_ret_15m autocorrelation at lag {lag_bars}: {rho:.5f}\")"
+    "for key, tag in classes.items():\n",
+    "    lo, hi = monthly[key].min(), monthly[key].max()\n",
+    "    share = (dev[DIRECTION_LABEL][DIRECTION_LABEL] == int(key)).mean()\n",
+    "    print(f\"{tag}: {share:.3f} of labelled bars, ranging {lo:.3f} to {hi:.3f} across months\")"
    ]
   },
   {
@@ -1023,22 +1242,60 @@
      "exception": false,
      "start_time": "2026-07-14T04:54:28.229273+00:00",
      "status": "completed"
-    }
+    },
+    "tags": [
+     "results"
+    ]
    },
    "source": [
-    "## 6. Save Labels and CV Configuration"
+    "On the development window the primary label has a standard deviation of 0.004142, against\n",
+    "0.002324 for the 5-minute label and 0.007884 for the 60-minute one - 0.56x and 1.90x the\n",
+    "primary, against the 0.58x and 2.00x square-root-of-horizon scaling implies, so the shorter\n",
+    "horizon scales as that rule predicts and the longer one falls a little short of it. None of\n",
+    "the three is remotely normal: kurtosis runs from 86.0 at 60 minutes to 1147.8 at 5, so the\n",
+    "shorter the horizon the more of its variance sits in rare bars.\n",
+    "\n",
+    "Against cost, the median absolute move is 8.74bps at 5 minutes, 16.34bps at 15 and 32.75bps\n",
+    "at 60, while the median round trip is 4.98, 5.03 and 5.25bps on the same bars - the move\n",
+    "roughly doubles with each step up in horizon and the spread does not move at all. The share\n",
+    "of bars whose move clears that round trip climbs from 65.3% to 79.3% to 88.8%. Cut at the\n",
+    "5bps friction floor, the direction label splits 0.414 up, 0.404 down and 0.181 flat, and\n",
+    "while up and down hold between 0.372-0.471 and 0.359-0.468 across months, the flat share\n",
+    "runs from 0.061 to 0.268."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d16e68ba",
+   "metadata": {},
+   "source": [
+    "## F. Overlap and effective sample size\n",
+    "\n",
+    "Sampling a multi-bar label at every bar makes consecutive rows share most of their\n",
+    "forward window, so the row count overstates the evidence. Two measurements answer that in\n",
+    "different units: how fast the overlap decays, and what the rows are worth once it is\n",
+    "priced in. Both are counted on the bar position within the session, which is the grid the\n",
+    "horizon was converted into, and both treat the symbol-session as the entity, because a\n",
+    "window cannot be concurrent with one on the other side of an overnight gap.\n",
+    "\n",
+    "Read the decay as a straight line running out to each horizon: consecutive rows share all\n",
+    "but one bar of their window, and the share they have in common falls off by one bar per lag.\n",
+    "The longest label does not stop at zero when it gets there but keeps going negative, and\n",
+    "that is a property of the session rather than of the label - a one-hour window is a fifth of\n",
+    "a trading day, so each session holds few independent windows, and subtracting the session's\n",
+    "own mean from so few of them forces what is left to correlate negatively at long lags."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 23,
    "id": "3f106ea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:28.242811Z",
-     "iopub.status.busy": "2026-07-14T04:54:28.242559Z",
-     "iopub.status.idle": "2026-07-14T04:54:29.615708Z",
-     "shell.execute_reply": "2026-07-14T04:54:29.614834Z"
+     "iopub.execute_input": "2026-07-31T09:12:15.427779Z",
+     "iopub.status.busy": "2026-07-31T09:12:15.427670Z",
+     "iopub.status.idle": "2026-07-31T09:15:24.796908Z",
+     "shell.execute_reply": "2026-07-31T09:15:24.796368Z"
     },
     "papermill": {
      "duration": 1.377173,
@@ -1048,31 +1305,27 @@
      "status": "completed"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Rows after dropping incomplete labels: 19,142,250\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Drop incomplete rows (NaN labels from session boundaries)\n",
-    "df_clean = df.drop_nulls(subset=[\"fwd_ret_15m\"])\n",
-    "print(f\"Rows after dropping incomplete labels: {len(df_clean):,}\")"
+    "max_lag = max(HORIZON_BARS[name] for name in RETURN_LABELS) + 4\n",
+    "acf = {\n",
+    "    name: panel_autocorrelation(\n",
+    "        dev[name], name, max_lag=max_lag, bar_col=\"bar_in_session\", entity_col=\"entity\"\n",
+    "    )\n",
+    "    for name in RETURN_LABELS\n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 24,
    "id": "728221d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:29.620929Z",
-     "iopub.status.busy": "2026-07-14T04:54:29.620712Z",
-     "iopub.status.idle": "2026-07-14T04:54:30.863412Z",
-     "shell.execute_reply": "2026-07-14T04:54:30.862460Z"
+     "iopub.execute_input": "2026-07-31T09:15:24.798016Z",
+     "iopub.status.busy": "2026-07-31T09:15:24.797946Z",
+     "iopub.status.idle": "2026-07-31T09:15:24.857848Z",
+     "shell.execute_reply": "2026-07-31T09:15:24.857363Z"
     },
     "papermill": {
      "duration": 1.24601,
@@ -1084,56 +1337,45 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved labels/fwd_ret_5m.parquet (19,142,250 rows)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved labels/fwd_ret_15m.parquet (19,142,250 rows)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved labels/fwd_ret_60m.parquet (16,845,180 rows)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved labels/fwd_dir_15m.parquet (19,142,250 rows)\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApYAAAFnCAYAAAAc1AkrAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAy4RJREFUeJzs3XVYVFkfwPHv0BLSpaKoGNiKndiJ3a7d3bnrq+u6dq+6dq7d3Yq9dueKIAaIgDRSc98/RkYQkAEGB/R8nofnYe7ce87v3pk7c+akTJIkCUEQBEEQBEHIIC1NByAIgiAIgiD8GETBUhAEQRAEQVALUbAUBEEQBEEQ1EIULAVBEARBEAS1EAVLQRAEQRAEQS1EwVIQBEEQBEFQC1GwFARBEARBENRCFCwFQRAEQRAEtRAFS0EQBEEQBEEtRMHyB+Zcvi5Gts4Y2TprOpRkXbh8XRlfv2ETNR3Od5fS+fcbNlG5/cLl6xqMMH3+nLtUGf/m7fs0HY5Seu4Hdb1HG7XqpkznlffbdKcjZC3xr6lz+brfPe+sep8Jgo6mA8hu3vv5s2zVJk6cuYDXq9fExsVhZ2NN9aoVGNyvG6WKF9V0iIIgpMHSlRsJDgkF4NexQzQcTdYiro0gCGklCpZpcOnqDTr1HErgx+BE27283+Dl/YatOw8we9oEBvXtqqEIhR/BuBH96dGlLQDFnQtrOJofx5Y1i/kUFZVk+7LVm/B+/Q4QhaeviWuTdXXr1JraNasA4FTAUbPBCEIComCporfvfOnYYygfgxSFymqVXRjUtxtGRobsPXCMTdv2IpfLGTd5JgXy56VRvVoaizU8PAIjI0ON5S9kjFMBx2z5RZHV33flypTQdAhCFpDV36epiY/fIU8uHPLk0nQ4gpCE6GOpooVL1yoLlYWd8nNo5zpaNmtA/drV+XvRn/zSsRUAkiTxv+kLADhw5KSyD8yYX2ckSu/fG3eUz3XtO1K5PSw8nD/nLqV8TTcs85XBrmB5GrXqxokzFxId/8r7rfL4Rq26cenqDWo36YhlvjKMnPhHiucRHh7B8HFTqd6gLY7Fq2OWpxT2ThWo3aQjG7fs/mYet+48oGHLrlg5lqVgqZpMm7WY2NhYla7fvYdPaNSqG5b5ylCojCsz5i375rEf/AMZ/79ZlKrcEHOHUuQuXInWXfpz/ebdZPffufcIjVt1J3fhSpg7lMK5fF16Dx6nbMZ75/OeAcN/pVLtluR1roJp7pLkKVKZxq17cOjoaWU69Zv/ojxnT6/XifLo2GOI8rk79x4BcP/RU9p3G0y+YtUwzV0Sh6KVqVynFcPGTuX1m3cqXZuvpdTHMmF/rhcvvWjXdRA2+V3IU6Qyw8ZO5dOnxLVxkiSxadte6jbrjF3B8ljmK0Ol2i1ZtmoTcrk80b4bt+ymeYc+FClXB2vHcljkLU2pyg0ZPXE6/gEfE+2bsL/gnfuPGDD8V/I6V8GmgEuy5yOXyynqUgcjW2esHcsRFh6e6PkqdVtjZOtMzlwl8PsQkGwakiSR17kKRrbOFCrjqtx+9vyVZPuZ1WrUQZlmfH5f97HcvH0fRrbOyhq5hNc4pX6Y5y9dw7VxByzylqZIuTosX7052f1UNWHKbOo07USBkjUwdyiFTX4XqtZrzaLl65LcH3K5nJnzl1GojCtWjmVp3Kq78r5Stf+mqvdBeq5NQqp8jvl9CCBnrhIY2TpTqXbLRMdHRUVjV7A8RrbOFCxVk7i4OCBt7+mEr/frN+/o3GsY9k4VqFCrOb0Hj1M+d/7StUTHjZs8U/nc/sMnUz3XeK+839KxxxBsC3z7nly3aSeujTtgW8AFi7ylKVutCVP+XKj8rIqX2n2WXB/LhH2Ck/tL2E84vbE8ePSM0ROnk69YNSzzlaFlp354vxb9hoUvRI2lig4e+/KhO6B3F/T19RI9P2xAD/75fHM/evIcT6/XNKrniplpToKCQzh49BRzp09EJpMBsO/QCeWxHdu4ARAcEkr95r/w6Mlz5XOfiOLilRtcvHKDhbMm069n5ySxvXj5ihYd+yb5EEtOaHg4azbuSLQtJiaG67fucf3WPd75vmfi6MFJjnvp9ZrGrXsQHhEBQGTkJ2YvXIF/wEeWzJ36zTw9PF/RuFX3RIW8P+cupUSxIsnu//rNO+q6deHtO1/ltujoGE6cvsDZ81fZsmYRTRvVUT43cMSvbNq2N1Ea3q/f4f36Hf8bPxzTnCa8eevD5u2J9/kYFMyFy9e4cPkaq/6aSZf2LenWuQ1Xrt0CYOfew4wfNRCAT5+iOHv+KgCFCjpStnRxAgI/4tauN/4Bgco0Az8GE/gxmAePntKyWYNMqVEICgqhTtNOBAQGARAeAWs37cDSwowpE0co9+s3bCJbdx5IdOzDx88YN3km12/eZeOqBcrtew+d4Iz75UT7enh64+G5BfdL/3L51B4MDPSTxNK1z0g8X71Osj0hLS0tunZszYx5y4iIjOTQsTN0atscgDdvfbj/8AkArjUqY2NtmWwaMpmMKhVdOHz8DO983vP2nS+5c9lx/dZd5T7Xb96la8dWfPoUxb3PaZYu6YyxkdE341PVv9dvs2PPYWWB781bH8b+NoOihQtSp1bVdKW5av1WoqKilY+jo2O49+AJ9x484ekzD1Ys/lP53LjJs/h7zZeC7IUr12ncqjtmpjlVzk/V+yAjVP0cs7G2pE6tqpw6e5GHj5/x4qWXsqb+9LlLhIYpfhC0bdkEbW1tIG3v6YQat+6hfJ+ameWke+e2bN99CIAdew5Rq3ol5b7HTroDkNPEWOWWp5CQMGo37ch7P3/ltq/vSUmS6DFgDLv3H0107PMXnsxbsopDx05z5vBWzM1Mk6Svyn2WFhmJpVPPoYliOXX2Ir0GjeP0oS1qi0/I3kSNpQpCw8ITFXJKlUj6i71Y0ULo6uoqHz99/gJ9fT1aNmsAKJrSE9a2HTii+CVsaWFGg7o1APh95iLlh3HDejXZs2UFq5fOwtbGCoDx/5vFm7c+SfL28fUjt70ta5fNYe/Wlbg1SnmEomGOHEweP5TNqxdycOcaju3dyMaV83EqkA+ARcvWER0dneS4t+98qVyxLLs3L+d/44cpP+jXbtrBg0fPUswPYNqsJcpCZemSzuzYsJT5M37jpad3svuPGD9Neb07t2/B/u2rWTxnCsZGhsTExDBw5K+EhysKuPsPn1QWKrW1tRk+qBd7t65k9dJZ1KlVlc/leGxtrJn22yi2rlvM4V3rOLZ3I6v+momVpQUAcxauAKC1W0NMjBUFkR17Dytjcr94VVmobteqKaAoyMQXKtu1asqhnWvZsWEpM6aOo0bVCsprpG4hoWFYWVqwdd1i/jd+mHL7us07lf/vO3RC+QVc2Ck/G1bMY/fm5VR0KQ3A7gPHEn2ptGnRmL8X/cmeLSs4vm8je7asoHP7FgA8fe7BgSOnko3l9VsfJo0ZzIEda5g9bUKKMXft2Er5o2rHni/X9ciJs8r/469rSqpVKa/8/9rne+lagnvq3xt3ALh97yExMTEAVK2UfC0qQMO6NTl18B/l/QVw6uA/yr+veXh606heLXZvXk7blk2U2xNe97QaN6I/G1bMY//21Rzft5Ft65dQoVwpAP7ZsU95Hzx/4cmKtYqYtLS0mDh6ELs3L8elbElepaG2SNX7IK3XJqG0fI7F/6gG2HfoS+3gvsMJfni3dfv8fNre0wn5fQhg1u/jObhzDWOH9adG1QoUcMwLwIEjp5SF+8dP/+Oll+Jzya1JvWR/TCUnKDgEM9Oc37wn9ySIz9zMlKXzfmf7+r+UP7Cf/feSqTMWJpu+qvdZ6ZLOiV6nnRuXkdPEWPl8/drVMxyLf0AgS+ZOZe2yOcofNVev3+bx0/++fZGEn4aosVRBaGhYosdWluZJ9pHJZFiYmyp/sQaHKI7p0MaNDZ+bmPcdPkmlCmW5efs+r98oPlhbuTVEV1cXuVzOzr1HANDT02Vo/x7o6+uR08SYFk3rs2r9NqKjY9hz8DjDB/ZMlLeWlha7/1lBYaf8qZ5LThNjSpdwZvmaf7j/8Akfg0KUzUwAYeERPPvPk5LFE9cmGubIwebVCzHNaULjBrV59sKTHXsUv/iPnDiTZP94crmc46fclY/XLpuDcxEnAN77fWDOopWJ9g/8GKRsLrO1saLnL+0ARcG9Tq2qHDx6moDAIE6du0TLZg3Ytuug8tiRg3vz+69fuhV0btdC+X++vLmxtbFm2apNPHryH8EhoUiSpHz+xctXhISGkdPEmLYtm7D+n108++8ld+4/omyp4hw9+eUc4gtAOgl+SOTJbUdhp/zkzmWHTCZL8hqp2/oV8yhdwpkWTRUF4Gf/vcQ/4CPBIaGY5jRR1sYA9OvZmdy57ADo3rkN12/dA2D77kPKAlKdmlWYteBvzl24is97v0S1aKAorHVo0yxJHCMH91YO6qjnWi3FePM65KZ2zSqcPX+Fcxeu4vchABtrS+V11dfXo3mTet8852oJConXbt6llVtDbty6j2GOHNhYW/L0uQchoWGJCpvVKqdcsLSxtsTG2jJR68O3CqLWVpZsWrUAfX09ypUpqfxi9kjhB5IqalWvzKJl67hx+x4BgUGJmr8lSeLu/cfkzmXH4eNnlO/X5k3q8du4oQBUrliOQmVciYz8pFJ+qt4Hab028dL6OebWuC5GhoaER0Sw//AJxg7vR3R0tLLWsGjhgpQtVRwgze/phGZPG0/Pru0TbevWqTVTZy4iKDiE46fdadG0QbL3uapSuyfjrwvAb+OGKuMpkD8vFV0Vn1V7Dhxn0ewpyh9h8VS9z0xzmihfp+joaNza9ybk8/fXxNGDlOeUkVh+GzeU3t06AHD1+i1lC9hLT2+KFS2k8vUSflyiYKkCkwS/+AD8Az5SqGDiQpwkSYlGi5vmVBxTo2oF8uS2581bHw4cOcms38d/9Wu8uTLN+D6c0dExNGvXK9lYnj33SLLNqUA+lQqVoKgp7dxr+Df3CQ4JSbKtcKH8mOY0UT4uX7aksmDp+epNimn5+QcQ9rl20cjQUFmoVKRRKsn+Lz29lV907/38qd/8l2TTjb8OL156Kbc1buCaYhx/rdjAhCmzU3weIDg4hJwmxnTv3Ib1/+wCFLVrZUoW49jnwnHpks7Ka12tkgtOBfLx4uUrFi5dy8KlazExNqJMqWJ0aN2M7l3aoqWl/kaB+B8H8SzMzRKdg2lOk0TXZcyvf5KcZ/+9BBQ18nWadU5UK/+14ODQZLc3+cY1/1r3zm04e/4KsbGx7DlwjK6dWnHxiqIPacO6NRO9v5JTplQxjI0MCQuP4PrNuzx/4cnHoGCqVymPQ55ceHm/4fqte1z7XHMJUKVi6oUhVVV0Ka0saFlamCm3BwcnvV9UcfP2fRq37qGsXU1O0Od70SvBPVa+3Jf7xtzMlMJO+bn34IlKeablPkiPtH6OGRkZ0qxxXXbsOcTd+4/xevWGp/95EPT5mnZo/eXHTFre019r3LB2km2/dGzFH3P+Ii4ujh17DisKlp9r0K2tLKldo3IqZ/tFWu/JCglew+LOhTHMkYOIyEg+BgXzwT8wSZeQtNxn8QaO/I1LV28CikJy/I8RIEOxVK9aIdnzDApJ/jNC+PmIpnAVmBgbKX8dA8o+YQk9efYi0RdE0cKKApRMJqP951+J3q/fcevOAw4cVjQrOubNQ+UKZdMUS3hEZJJtKfVLS86KtVuV///SsRUHd67h1MF/EvURk8ul5A5N5OtfsemRkTSSuw7fsmLtl/4/I4f05sju9Zw6+E+i6Xziz7uCS2llAXjXviPcuvOAdz7vAWif4IvO0DAHpw9tZfL4odSqXhlbGytCw8K5eOUGQ8ZMYcHStek+v28xM0vcp05H50uTu5T6S6cU37R/8OgpZaGySKECbFq1gFMH/0nU5CaX5MmmYWNtlez25Lg1roeFuaLP1vbdhzh19pKyZjThdU2JtrY2lT7fL3cfPFYWSiu6lKFS+TKAonvCtZv3lOdibWWhcnypSXjddXS+/CaXSMNFT2DNxh3Kz4zG9V3Zu3Ulpw7+o+yCAMnfixm5b9JyH2SmhPdvfFM3KJrA939uEpfJZCq9LxKnG5Hsdttk3qf2djbKpuHjp8/zn4cnN27fB6B184aJXuPUqOueTEla7jOA6XP+UtbwVq5QlpWLZ6RyhOrMTb/0u0x0H6jjRIUfgqixVJFbo7qsWKf4UF61fhs9f2mHnt6XZqK/VmxQ/l/cuTD5HR2Ujzu0cWPB0jUATJ25SNnxuX3rpsovCStLc8zNTPkYFIyxkSEeDy4kGXQgl8uJjk5au5GWLxof3/fK/+fP+BVjIyPkcnmi7cn574WXsqkYUH4AA+TPlyfF42ysLJVNXeERETx97kHRwgU/p3Evyf4F8udFJpMhSRIFHPNy98rRJH0VExbgnQo48vRz7cfxU+dTLKi/+3x+lhZmTJ88BlCMkE/pvLt3bsOEKbPxff9BWcMjk8lo26Kxch9JkrC2smDCqEFMGKXY5vXqDZVqtyAsPIKDR04xZljfFK9NZkp4XY7t3UjNahWT7BPx+cv9nY+fclu/np1p8/kcr1y7nWo+aXnv6evr0aFNc/5es5mbd+6zbNUmQPHDTdVBEtUquXDG/TLR0TGsXKf4kVSpfBkcHBSDpHbtO4LfB0V3lGqVy6eYTkJasi+/r+VyeabUMifnXYL33u+/jlQW7mZ/7ueYUMLPk9t3Hij//xgUzPMXnmnOU9X7IK3XJj2fY3VqVsHaypIP/gHs3n9UOcK4coWyOCb4bEnLe/prKb1Pu3dpw/HT54mKimbgiN+UI8vT2gyuCqcCjsoa1Zt37uNStiSgGOwZEamI29zMNNkfQ2m5z7bs3M/M+csByJ/Pge0bliYZbJqRWAQhNaLGUkUjh/RWdlR++twDt/a9OXDkJKfOXWLwqMmJRiX/PmlEomNLFCus7BR99vwV5fb4ZnBQ9JNs10rRNygsPILm7fuwa98Rzp6/wubt+5g4dQ4lKzVU9iVKr4SjlP+Y/Renzl2iz5AJPHmWtIk9ofCICLr1G8XxU+7MXbQyUSf5pg1THiykpaVF4/pfCg19hozn8LEzrFq/lWWrkk7VYmH+ZTDTSy9v2nUbxIEjJzlz/jIb/tnFyAnTKFKujrIwlLC2Y+Gytfz2xzxOnr3I9t2HEk2DkffzeQcEBjFvyWqOnz5Pp17Dkkx2H69Tuxbo6Sn6UF69rihgVa1Ujjy57ZX7/HvjDtXqt2HuopXsPXic85euceTEWSI+93eLSmYQ1PeSsD9knyHjWbNxO+cuXGXXviPMWrAc18YdWLR8HfDl2gBs2raH46fPs3z1ZuVADnXq3rmN8v/469qscV1y5DBQ6fiEA3jiBwtULF+GEs6FMTI0TFTIqvqN/pUJJaxt+nvNP1y5douHj59/4wj1SHjd5y1ZzWn3y4ybPJPT5y4l2bdZozrKwsX+I6eYtWA5x0+5063fKJX7VybMU9X7IK3XJj2fYzo6Osp+kXfvP1bGkvDehrS9p1XVuL4r1laKFp/496NDHvs0tySpon3rL4XV6XP+YsM/uzh09DR9hnxpGWjTolGGaqQv/3uTwaP+Byhei9FD+/CfhydXrt3iyrVbyibw7xGL8PMSNZYqypPbnq3rltC51zCCgkO4dPWmsv9KPC0tLWZMGUvjBkn783Ro04yHj7+Mni5TqhhFChVItM+UiSO4/O8tHj15zrWbdxMNQlCXXl3bKwu3S1duZOnKjRgY6FO2dHHl3IzJyeuQi2s37nDq7MVE23t0aZviwJ14kycM4+TZi4SEhnHn3iM69FB0Qo/vn/i1xbOnKKcbOnH6AidOX0iyT7xWbg3p0qElW3bsJzY2VtnXMV5860zPru359fe5AEz5UzEliZWlOYWd8idb42NlaU7ThnUSTQv1dS1G/OCKu/cfJxtbZtR6qKp180YcO+XO1p0HePvOl+Hjfk+yT/06igJ8k4a1sbO1xvf9B+49eEKbLgMAqFKxnPLLVl1KFi9CuTIluH33oXJbWq5T+bKl0NfXUzah58/noOwK4lK2JBcuf5mTsJoKg00AalarpHwNx02eCSj6Rh/ft0nluNKjR5e2bNiyG0mS2Ln3MDv3HkYmk1GpfJkk936hgvkZ0PsX/l6zmbi4OP6Y/Reg6NuX1yFXovkmvyWt90F6rk16Psc6tmmWaColXV1dWrk1TLRPWt7TqtLV1aVz+xYsTlAgbduySaYUqNq0aMyho6fZfeAYgR+DGTz6f4meL1KoAFMnjUzhaNW4X/xX2aIjl8sZMmZKoue7dGjJqiUzv0ssws9L1FimQa3qlbh16TCjhvShWNFCGBkaoq+vRz6H3HTp0JKLJ3cxdECPZI/t0LpZomakhNNsxDMzzcm5I9v43/hhlCxelBw5DDDMkQOnAvlo5daQDSvmKafWSK9Wbg35a+7vOBXIh4GBPi5lSrJ/26pUR/Plc8jN8f2bqFm1IjlyGGBrY8XY4f1ZPGfKN48DRbPL0b0bqF6lPPr6etjaWDFqSB/mzfgt2f0d8uTiyum9jBjciyKFCmBgoI+JsRFFChWgc/sW7Nq0nDy5v/R5XbVkJmuWzaZG1QqY5jRBT08Xhzz2dGjjpqxxGdq/O1MmDCevQy4Mc+SgZtWKHNm9IdF0Kl/rlqB2TUdHh1ZujZKc16ghfajoUhobayt0dHQwNjLEpUxJFs6azOihfVK9Nplp9V+zWL10VpLr4lqjMvP+/JW+PToBiqboQzvXUqt6ZYyNDMllb8vk8UMTdfZXp4S1llaW5tRNwxyQ8e/ZeBU/960ElP0sQfFDMK9DbpXSnDRmML26tsfezua71tCUL1eK7ev/orhzYQwM9HEu4sQ/axZRN4VRv7OnjefXsUOwt7PBwECfapVdOLp3A2YJ+rylVvOb1vsgPdcmPZ9j5cuVolBBR+XjBnVqYGmRdPYNVd/TaZHw/QiZ94NQJpOxfsU8lsydSvmypZTfH4UKOjJ6aF/OHd2e7LyRP3oswo9HJoket0IKXnm/pVgFxRQw36MGJ6uJjY3FOn85oqNjaFC3Bvu2rtJ0SD+E12/eUdRF0X2ib4+OLJqd+o8TQVFD/nXhLiDwI0XL1SUiMhIz05y8fnr1u/UR/ZEUr1AfL+83FC1ckFsXD6d+gCAIKRJN4YLwlejoaCIiP/HP9n3KQQYJ58QU0icqKpqw8HCWr/kywba4rqpbtHwdHz8G07iBKw657fF+844/Zi1RDrZo5dZQFCrTIDY2lojIT5xxv4yXt2I6p07i/SgIGSY+hX4A85duYOrsZck+987Xj/J12iuXR5uxcBVLVn175Yzsqnyd9jx74ZXhdOYuXkXuwpUY/79ZgGKS5q/7e6Xk5t1HuLr1UDmvQ8fd6dx3bHrCTNGwCTPYdeBE6jt+Z0PHTiGvc1WW/L0egDq1qiZqyk4Lt06Dcb90PfUdkxEaFk75Ou155+uX+s5ZSEREJPP/Wk09ty4UKVeH+s1/4cLnKZeKFi6YaHGAzJDR92pGXjN1m7FwFb2HTMTeqQK/9BkBKOau7NO9g2YDy6B+I6eydfeR1HdMp29916hTWj9Hf1THTl+k15Dku4ypYuvuI/QbOVV9AalI1FiqqN/IqTx4/BxdHR1kWjJsra2oUqE0PTq1xPyrOcxSMnX2MkyMjBg9pEeidF2rVaBz2+8z0GPSyH7fJZ8fgbGRIVUru7BgxuQ0zWmnaUtmTdJ0CN9kmtOE+rWrp9jHVkhejaoVaVTvIfcfPcU/IBA9XV0KFshH8yb1GNK/u9rWRP8ZTBrZj83b97F732EMDPQpV7oEc6ZPTNO665qW3PeJoHkrN+zkuYcX8/8Yl+G0GterQeN6aRuQlhVkn2/LLGBo3y50btsUSZLwfPWW1Zt388uA8WxaPjPRShw/inx5cxP+XrUVPTQpNjZWrQW/X8cOUS6flp1IkoRcLqGtnTUbIlYtmcmqJTM1HcZ3o+7Xo2a1isnO3SikT9eOrejasZWmwxCEH44oWKaDTCajgGMe/pg0lM59x/HPrsMM769YevDfG/dYsnoLb33ek8fejmH9u1DJpRTb9x7l2OlLyGSw/+gZ7G2tqVKxDHcfPOHB4+f8vW47ZUs5s2TWJCIiP/HXqi1cuHqT6OgYqlQow7ihvTA2NgTg9r3HzF6ylnc+flQuXxoTE9VrKhL+yn3n60fzzkP4fcIQVm/aRVBwKK7VK/Db6P7KgtrT5y9ZuGIz/3l4KZY77NiCVs3qKZ+btXgtnq/eoKOjQ6lihVg4Y0Ky+Zav056xQ3ux++AJfN77U7t6RcYO7cnMhau5cv0uuXPZMuO34TjmVYzk/WfXYfYcPElAYBDmZqZ0btuUDq0Uo7Lj4/7f2IGs27KXiMhPnNyzOlF+r16/Y9iEmYmOSyg2NpY1m/dw7PQlwsLDKVW8CJNG9lVOCLx45T+cOneFkNAwbG0s6d+9PfVcqyiPf/L8JYtXbOa5hxdaWlo0qF2NccO+LF+3/8gZVm/azaeoKJo3rqN8f6Rkzebd7Nh3HJlMRo9OLZU12JIksWXXYXYdOEloWBjFizoxfngf8uSyBRTNi63d6nH+8k3+8/Bi4/KZzPlrnbIWfMzkuVy79WUy++iYWBrXq87U8YMJj4hk0d+buHD1FgC1qpVn5IBu5MhhoNJ7o2OfMfTo1JJGdaun+JqPHtyDXQdOEPgxmCoVSvPrqP7K9/HjZx7MW7qBl16vsbYyp/cvbZRppXbeX7t26z7L1mzD+40PNlYWDO7TmVrVFHNeRkfHMH/ZBk65X8HYyJBeXVp/87X498Y9lq3dhvdbHwz09aldvSIjBnbD4PMk02HhESxbs42LV28RGhZOPodczPl9NHY2Vsm+Hvr6esxevJbHz15gYmxMh1aNlK/vWx8//py/kkfPXqCtpYVj3jwsn/sbBgb6/LPrMNv2HCE0NBzTnCb0/qU1LZsmnTM2pTT2HTnDuUvXWbVwqnLfE2cvs2bzbnatX8jKDTt58vwl1lYWnDx3GVMTY/43bhBhYeEsWrGZ4JAw2rZowODeiUdaL1uzlb2HT2NgoE+PTi1p16Jhul6zr33rfL/1+v578z6LVmzinY8fBgaK12viyL5ER8cwc9FqLly5RWxcLLbWVkwZN5DiRZ2S1PZ96724csNOnj5/iZ2tNcdOX8TIKAfD+3elQe2q38w/ORnJJ6Hkvk92rldMHxX4MZgh4/7k/qNnOOS25/cJg3EqkBcg1e+Wr6X2XfPmrS/zl23gwZP/MNDXp2XTuvTq0gq5XE7Dtv2Z+/toypUupty/Xc+RynMO/BjMguUbuXHnITKZjPq1qjC0Xxfl/MEJqfJZ9euofqzbso+IyEjqu1Zl9OAe6OrqcPPuI8ZMnsvgPp1Y989ePkVF07dbW6pWLMOUWcvw8n5L+bLFmT5pmHJWhZTOS0tLi0PH3dm25wh1alZK8pntfuk667fuQ5JL1GjSFYCLRxPP1+wfGESzjgM5e2A9hjkM2L73GPOWrmf3hoU45s3NhSs3WbZ2GzvWzlfmtXW1Yoowt06DaduiAecuXuel12uKFsrPtElDsfs8q4OH52v+mLeCl16vcS5SkGJFCibK+/Vb3xQ/i9r2GMmoQd2pWrEML15607HPGCaM6EPb5g0IC4ugbqvenNi9UrVafUlQSd8RU6Qtuw4n2b5szTap28CJkiRJkvcbH6lqw87SmfP/SjGxsdIp96tS1UZdpDfv3kuSJElTZi2V5v21PtV0x0+dL036Y5EUEhomRUREShOnLZR++3OJJEmSFBwSKtVq1l3affCkFBMbK52/fEOq3KCTNGXW0mTjfuvzXnKp3U4KCQ1LEkP8c5P+WCSFhUdIfh8CpCbtB0gHj52TJEmSPgR8lOq06CmdPHdZio2Nk/57+Upq2LafdO3WfUmSJKnn4F+lNZv3SHFxcVJUVLR06+6jFK+fS+120sAx06Sg4FDJ70OAVL91H6lD79HSnftPpJjYWGnqrGXSiEmzlPufPn9V8nn/QZLL5dKN2w+kqg07S3cePEkU9+jf5kghoWFSZOQnZR5P//OUHjz+T2rcrr908tzlFONZtGKzNGDU79IH/0ApOjpGWrh8o9Rn2P+Uzx89dUEKCAySYmPjpONnLklVGnRWvo7v/QKkms26STv3H5c+RUVJkZGfpNv3HkuSJEk37jyUKtRtL81ftkH6FBUlvfR6LVVr/It0487DZOM4eOycVLFeR2nzjoNSTEyMdOPOQ6livY7S6zc+kiRJ0qET7lKjtv2k/zxeSZ+ioqQFyzdK7XqMlGJiYyVJkqRmHQdJrboOkzxfvZViY+Ok6OiYFN+rHp6vpToteklXr9+VJEmSps5eJvUfOVX6GBQifQwKlvqOmCJNn7dCpfeGKlxqt5N+6T9e8vsQIIWEhkmDxvwhTZ21TJIkSQoJDZPqtOglbdtzVIqJiZFu3n0kVW/8i/I1VuW8z128JkmSJD1/4SW5uvWQrt96IMXFxUl37j+RajbrJnm+eitJkiT9vW671KnPGGUcQ8fPkFxqt5Pe+rxPNu7b9x5LT56/lGJj46TXb32lNt1HSGs271E+P2byXGnIuOmS34cAKS4uTnry/KX0MSg4xdejdbfh0qIVm6VPUVHS8xdeUsO2/aRjpy9KkiRJk/5YJP25YKUUExMjxcTESHcfPJWio2MkL++3UtVGXSTPV28kSZIk/4CP0vMXXsnGm1IaH4NCpKoNv7xvJUmSBo+dLm3cdkCSJElasX6HVKl+R+nM+X+l2Ng46e9126XG7fpLU2ctkyIiIiUPz9dSlQadpSfPPCRJ+vxerdtBWrpmqxQdHSPde/hMqtm0m/K+T8tr9rVvnW9qr2/Dtv2kwyfOS5IkSRERkdLdB08lSZKkPYdOSV36jZNCQsMkuVwueXm/lXzef5AkKfHnYGrvxfjrFP85eOiEu1SjSVcpLDzim/l/LaP5fC2l75PG7fpLz154SjGxsdL0eSukviOmKJ//1nfL11L7romM/CQ16zhI2rLrsBQdHSP5+H6Q2vUcJe07ckaSJEmatWiN9Mfcv5XpPXr6QqrZrJsU+SlKksvlUvdBk6QFyzdKkZGfpI9BIVK/kVOl5Wu3SZKk+Byt1ay78lhVPquGjp8hhYSGSX4fAqROfcZIKzfsVKZVoW57adGKzVJ0dIz07817UsW6HaThE2dKPu8/SKGh4VK7nqOkzTsPqXReqX1mr1i/Qxr12+xkr2m8tj1GSJf+vS1JkiSN/m2O1KLLEGnX/hOSJEnSvKXrpbl/rVPm1anPGOVxzToOkjr0Hi29efde+hQVJQ0dP0P5esTExkrNOw9JdH/Wbt5D+frHxMZ+87No5sLV0uKVmyVJkqStu49ILboMkSb8vkCSJEk6d+m61LH3lzhSkzXbzLIRGysLQkLDADh57gouZYpTp2YldLS1qVerMmVKFOXE2aQraaTkY1AIZy9eY/zw3pgYG5EjhwEDenbglPsV4uLkXLx6G2src9q41UdHW5uaVctToWyJDJ1D325tMTLMgbWVBVUqlObJc8VSX0dPXqBsSWfqu1ZFW1sLp/x5cWvkyvEzivPR0dHG9/0HPgR8RE9PN9Ev0+R0be+GaU5jrK0sKFfKmQL58lCmZFF0tLWpW6syz/77MkFz3ZqVsbOxQiaTUb5sCSpXKM2tu4knIu/bvR0mxkYYGOgrt129fpcx/5vL7xOGUN81+fkRJUli94ETjBzUDStLc3R1dRjYuyP3Hj3F10+xHGDjejWwMDdFW1uLhnWq4Zg3F/cfKSa4P3r6As6FCtCuRUP09fQUE8yXck6QPgzq1RF9PT3y58tDqeKFefr5mibHzNSEX9q7oaOjQ/kyxcllZ80zDy9FXqcu0KF1Y5wK5EVfT4/BvTvx/kMAj568UB7ftnkDHPPmQltbC13d5BshAj8GM2LSTAb27EDlCqWRy+UcP3OJIX07Y2ZqgplpTgb37sSRkxeUy9pByu8NVXXr2BxrKwtMjI0Y2KsDx89eQi6Xc+nf25ib5aRj68bo6OjgUroYjepW58iJ8yqfd7y9h0/RrGEtKpQrgZaWFmVKFqVGZRdOf14I4NjpS/Ts0koZR7/ubb8Zc9lSzhQtlB9tbS3y5LKldbN63Pq8eEBAYBDnLl3n11H9sbayQEtLi6KF8if6FZ/w9Xj07AX+gR+V74dCBfPRvmVDDh13BxT3kH9AEO98P6Cjo0PpEkXQ1dVBW0sLJAkPr9d8iorG0sKMQgXzJRtvSmmYmZpQs2p5Dp9Q5OX3IZDb9x7TpEFN5bHOhQtQp2YltLUVte5+/oF079SSHDkMKOCYB6cCeXma4L40yKFP/+7t0NXVoVTxworX7NSFNL9mX/vW+ab2+upoa/PmnS8fg0LIkcOA0iWKKLdHRH7C89VbJEkin0MuZc1OQqm9FwGKFiqg/BxsWr8mMbGxeL/x+Wb+6s5HVY3r1aBwQUd0tLVp2rCW8rMnte+Wr6X2XXPp39uYmBjRuW1TdHV1sLO1olPrxpz4/P3QtEEtTp//V7kC2dFTF6hbszIG+no8fubB67c+DO//CwYG+piZmtCzcyuOn7mcJA5VP6v6ff4+sLayoEfnVhw9lXhhjf492qOrq0Mll1LkzGlMjSou2NlYYWxsSLVKZZVLXKZ2XvDtz2xVlC9TnJt3HyGXy7n36Bm9urTm5udFI27eeUT5b3ynt23egNz2Nujr6dG4XnXlZ/KDR88JCglJdH8m/A58+OS/b34WlS9TnJt3FJ9zN+48pE/XNty+9/hzTA8pX7a4yucnmsIzyM8/ULl+tt+HAOxtrRM9nzuXDX4fAlVO752vH3K5RPPOifv4acm0CAgM4kNAYJI87Gytkl1DXFUJ+4fmMDAgNFwxgtznvR+Xr99JNDpPLpdTpqSiEPW/sQNZtWk3XQdMwMTYiPYtGyXb7BzPwvxLPgYG+pgkGGxgYKCvXAoRFKPh/tl5GJ/3iuvxKSqKXHY2idJL7kti254jVChXkgrlUr4xg4JDifwURd8RU5DxZV5AXR0d3vsFYGdjxZZdhzlw9Czv/QOQISMy8hNBwaEA+L73xyGPfUrJY2SYI1FhN4eBPuEprGEMYGmeeCLiHAb6REQoroXfh8BE562np4uVpTl+/gHKbcldh4SioqMZPXkOtapVoG2LBoDiSyYmJjbReyl3LluiY2KU5wkpvzdUlTB9O1trYmJi+RgUwvsPAeSy++pesbfl9n1Fn15VzjveO98P3LzzUPkBCRAXF4eRoaIA5f/VPWP31f3ztUdPX7BszTZeeHoTFRVNbFwc+T6vRe7z3h89XV3sbFO+5glfD78PgVhbWiQq8Oe2t+XYacUKVsP7d2XVxl0MGvMHMpmMZg1r0bdbW/LktmPqhMHs3H+CaXP+poRzIYb1/4UiTo5J8kspDS0tLZo3rs2sRWvo170dR06dp1L5UlgleE0tErz3DAwUTf2WFgm3Jb4vrS0tEvVntre15vbnlXnS8pq17zkKn/cfAJg0qh+N69VI8XxTe33nTRvD2i17adN9OHa21vTs3JL6rlVp0qAm/oEfmblwNe8/+FOzanlGDOiapCkvtffi19dEJpOhr6envKdTyv9rGc1HVV/fs/GvX2rfLTbWidcFT+275p3vBzw8Xyf6fpAkCdvPK2GVcHbC0sKMC1duUrtGJU6cvcysKaMA8PH9QGhYOHVafOk+JCEhT6aAq+pnlX2Ce9Le1ooP/l++dw1z5FB2ZQEw0NdP9LlroK+X4Dp9+7zg25/ZqnApU4JN2w/w7IUXuexsqFWtAsvWbOVjUAgvX73B5RuVNFaJXt8v+X4I+Jjs/enprVjWOLXPIpcyxfn1zyWEhIZx/9Ez/pg0lK27j+Dh+Zobdx4m6RLzLaJgmQGxcXGcv3KDapUU68raWFty7+HTRPv4+H5Q1mYlt3KF1lfbbG2s0NKScXzXykSFk3jWlhbKD+R4vu8DsDBX/2hGW2srXKtXZObkEck+nye3HdMmDkGSJO49fMagMX9QqnhhnAsXSHZ/Vfm+92fqrGUsmT0JlzLF0dHWZvTkOfDVVP5aWkmv5/Rfh7NoxWbmLFmXqM9jQqY5jTEw0GfjshnKPp0J3X3wlFWbdrFi/hSKODmipaVF575jkT6vJWBna8W1m/eTHJcZbKwtEk2LExMTi3/AR2ysvnzIJXcd4kmSxNTZyzEzzcnIgd2U283NcqKrq4PP+w/KLyIfXz/0dHUxMzXB1y9KLfH7vP9ACWfFqk6+7/3R1dXB3CwnttaWvPNN/D5+994P289fbqqcdzxbG0s6tm7C0H5dko3B6vM9kzCOb/l1+mLcGtVm/h9jyZHDgK27jyhr/extrYiOicHXzz/FAn3C18PG2oIPAYGJBpj5+H5QnoeFuSkTRihWaHrx0pvBY//AqUBe6tasTH3XqtR3rcqnqGhWrt/B/2b+xY6185Pk9600KrmUIjYujlv3HnP4xHmG9On8zXNPzdfn4uvnr+yXnJbXLL4/YEIpnW9qr2/RwgWY+/sY5HI57pduMHHaQsqVKoalhRm9urSmV5fWBAQG8ev0xazauDvJ50Jq78XUfCt/debztbSuEpXad8vXUvuusbWxxLlwATYs+zPFNJrUr8nRkxcw0NfHQF+fcp+/C21tLDE3M+XE7tQXnVD1s8rnvb/y+YTvy7RS5by+RZW5ZMuXKcav0xdz7uJ1KpQtgWlOY6wsLdi5/ziFC+bDxDjtMzxYW5one3/GS+2zyNwsJ455c7Ftz1EcctthZJiD8mVLcMr9Cl7e7yhX6tstkgmJpvB08vJ+y9RZywgLj6BL22YANKhdlVt3H+F++QaxcXGcvXCN2/ef0KC2Yok2S3Mz3vi8VxZQQPGl8Obde+VjKwszalWrwOwlawkKDgEUnX3PXVTM/1a9cjn8/APZd/g0sXFxXPr3NjfvfFl3WZ2a1K/JzTsPOXPhX2JjY4mNjeXZCy8ePVU0bR0+eZ6AwCBkMhnGxobItGRqmaA5IvITEhIWZqZoyWRc+vc2/6pYkMuZ05i/50/mwePnzFy4OtG1jqelpUUbt/os/HuT8sYLCg7l5DlF01pYeATaWlqYm+ZELkkcOHYWD8/XyuMb16vBo6cv2H3wJNHRMXz6FMWd+5kzer5JvRrs2n+Cl15viI6OYfm67VhbWVDc2Uml41es38Gr1++Y8dvwRK+NlpYWjepUZ/na7QSHhBEUHMqyNdtoUr+Gyq+hW6fBiWqRkrN5xyE++AcSGhbOyg07aFC7KlpaWlSrVJaPQcHsOnCC2Lg47tx/wvHTl2jaoFaaz7t1s/ocOuHOzTsPiYuTEx0dw/1Hz/F8pZj0umGdamzYekAZx5rNu78Zc3hEJCbGhuTIYYDnqzfsPnhS+ZylhRm1qpVn5sLV+Ad8RC6X8/Q/z0Q1JwmVKOqEpbkZK9bvJDo6hhee3uzYd4xmDRXnecr9Cr7v/ZEkCWNjQ7S0tNDW1sbL+x3/3rzPp6hodHV0yJHDAG1t7WTzSCkNULzOzRvVZsGyDYSEhlGjSrlvnntqPkVGsWbzHmJiYnn45D+OnblI48+DTzLyXv3W+X7r9Y2JieXIyQuEhIahpaWl/ELW1tbmxu2HPHvhRWxcHDlyGKCnp5fsCP3U3ovf8q381ZlPcpL7PvmW1L5bvpbad02NKi4Efgxi14ETREVHExcnx8v7HTfvPlLu07R+Tf69dZ+tu4/QuF4NZWG4WBEnbK0tWb52O+ERkUiShI/vBy5fu5MkDlU/q9Zs3k1oWDgf/ANZv3V/uqfpUeW8vsXC3BSf9/7ExsWluI+ZaU7y58vNjv3HKF9G0cRcoWxxtu458s1m8G8pWawQpibGie7PU+5XlM+n9lkEiubwrXuOJIipBNv2HqWIk2OKA7ySI2os0+Cv1VtYsX4HMi0ZNlYWVK1Yls1/z1I2JznktmPO72NYtmYrU2YuJbe9DfOmjVGOimzZpA4Tpi2kTote2NpYsn3NPDq3bcrU2ctxdetBmZJFWTRjAlPHD2blhp10GziR4JAwLMxNqe9aldo1KmKa05j5f4xjzpJ1LFi+kUoupWhUr3qivibqYmNtwV+zf+WvVVuYsWA1kiTHMW8eBvRsD8D1Ww/4a+U/RER+wsLcjOEpNNWlVQHHPPTq0poBo6chl8upWdWFmlXLq3x8ThNjls+bzJBxf/Ln/JX8Orp/kl/3Q/p0ZuP2AwwcPY2AwCBMc5pQoVwJGtSuStWKZahbszId+oxGT1eXJvVrJuo3ZWttyfJ5/2Pxis0sXb0VXV0dGtaplqifpbo0bVCLgI/BjPx1FiGh4RQv6sTCP8ejk0Ih42tHT10kIDCIBm2+jFJtXL8Gk0b2Y/SQHiz8exPteyom1q5ZtTwjEtRqfkt0dAxBwSGULPbtNeYb16tB/1G/E/AxiMoupRkzpCegeI0Wz5zEgmUbWLpmK9aWFkwY0YcyJYum+byLFsrPn78OZ/m6HXh5v0Em06KIkyPDByhGZfbu2pqPQcF06D0aI0NDev/Smkv/3k4x5kkj+7Hw7438tWoLzoUL0LBONc5fvqF8/vfxQ1iy+h+6DphAROQnHPPmZs7vo5NNS0dHh4V/jmfOknU0bNuPnCZGdGnXTDkS+MnzlyxcvomQsHByGhvRokkdalUtj4fna1as34HnqzfIZDIKF8zH1PGDks0jpTTiuTVyZc3mPXRq0yTD03IVzO9AXFwcjdr1w0Bfn0G9Oim/CDPyXo2NjU3xfFN7fU+cvcSC5RuIiYnFzsaK6b8Nw8zUhICPQcxespb3fv7o6+tRsVxJ+nVvlyTv1N6LqUkpf3Xn87Xkvk9S863vlq+l9l1jmMOA5XMns3jVP6zZtJuo6Bjy5LKla4fmyjTsbK0oVbwIN+48VNaqA2hra7FoxgT+WrWFdj1GEh4Ria2NFa0/zzjyNVU+q2pVLU/nvuMIj4ignmsVenZO31RSqpzXt9SrVYUTZy5Rv1UfJEnC/dCGZPcrX6Y4ew6dUr7+FcqV5J9dh9M9ZkJHR4cF08fzx7wVbNl1mGJFnWjeqDaPnnkon//WZ5EiphLs2HdceU+XK12MT5+i0xyTWCtcEIQ0u3XvMXsOnmRGCt0kQDHd0JZVc9TyY0NIv0+foqjfug/rl/2JU/68mg5HENQqfrqhcwfXp6sJWVA/UWMpCEKauZQu9s0O5kLWIEkS2/cdo0ih/KJQKQjCdyEKloIgCD+guDg5tZv3wMzUhDlTk2+qFwRBUDfRFC4IgiAIgiCohRgVLgiCIAiCIKiFKFgKgiAIgiAIaiEKloIgCIIgCIJaiME7qZDL5bx79w4TE5M0r3QgCIIgCD8KSZIIDQ0lV65calkMQ/gxiYJlKt69e4eDg4OmwxAEQRCELOH169fkyZNH02EIWZQoWKbCxESxgsLr16/JmVP963FnliBvxcLyZnnTt6zVj2LPgeMAtGnRSMORCIIgQMC9UwBYlq6v4UjSLiQkBAcHB+X3oiAkR0w3lIqQkBBMTU0JDg7OVgVLQRAEQVAn8X0oqEJ0khAEQRAEQRDUIlsVLC9cuICbmxu5cuVCJpOxf//+VI9xd3enXLly6Ovr4+TkxIYNGzI9zqzA++I0vC9O03QYGteu6yDadR2k6TAEQRAAeLZ+JM/Wj9R0GIKQabJVwTI8PJzSpUuzbNkylfb39PSkadOm1K5dm7t37zJixAj69OnDiRMnMjlSQRAEQRCEn0+27WMpk8nYt28fLVu2THGf8ePHc+TIER4+fKjc1rFjR4KCgjh+/Hiyx0RFRREVFaV8HN9ZWfQpEQRBEH5moo+loIpsVWOZVlevXqVevXqJtjVs2JCrV6+meMzMmTMxNTVV/omphgRBEARBEFTzQxcsfX19sbW1TbTN1taWkJAQIiMjkz1m4sSJBAcHK/9ev379PUJVu6BX7gS9ctd0GBq3Y89hduw5rOkwBEEQAPC/cxz/O8m3mAnCj0DMY/kVfX199PX1NR1Ghvk/3gmAWT5XzQaiYXMXrwCgQ5tmGo5EEAQB3p1dB4BVWTG3rvBj+qELlnZ2drx//z7Rtvfv35MzZ05y5MihkZiCnl3h4+OL5G06HG09g0zLJ1fF4ZmWdnayYtEMTYcgCIKgVKDd/zQdgiBkqh+6YFmlShWOHj2aaNupU6eoUqWKRuKJCQ/i5c7fiQkNIOTFdQp2/ANjh2KZkpehZZFMSTe7KV+ulKZDEARBUDLOW0LTIQhCpspWfSzDwsK4e/cud+/eBRTTCd29exdvb29A0T+yW7duyv0HDBjAy5cvGTduHE+fPmX58uXs3LmTkSM1M4eYPCYKA0vFYKBPH17xeFlP3p5ZgxQXq5F4BEEQBEEQ1ClbFSxv3rxJ2bJlKVu2LACjRo2ibNmy/O9/iqYFHx8fZSETIH/+/Bw5coRTp05RunRp5s+fz5o1a2jYsKFG4tc3s8V5wEocGg9Bpq2DJI/jzYkVPF7Rj08Bb9Sa14tjg3hxTEwMXr5mM8rXFP0rBSE7kiSJfv36YWFhgUwmU1YqpFePHj2+OUXd93B/fnvuz2+v0RgEITNlq6ZwV1dXvjXtZnKr6ri6unLnzp1MjCptZFra5KrdA9NClXmxfTKf/DwJe3WfBws7k6/FaKzLN0cmk2U4HyO7smqINvurU6uapkMQBCGdjh8/zoYNG3B3d6dAgQJYWVlpOqRUubq6UqZMGRYtWpTs86aFKiXZNmzYMC5fvszDhw9xdnZOUoD28vIif/78SY67evUqlStXVkfYgqA22apg+SMxylOUksM34330L95f3oE8OgLPXX8Q9Pgi+VtPRNfEMkPp25ftq6ZIs7c5f0zUdAiCIKSTh4cH9vb2VK1aVdOhEB0djZ6eXobTydd8dLLbe/XqxbVr17h//36Kx54+fZrixYsrH1taZux7QhAyQ7ZqCv/RaOka4NhiLEV6/4WuieKX+MdH7txf0IGA+6c1HJ0gCILm9OjRg6FDh+Lt7Y1MJsPKyopmzb50a1m0aBEymSzRKmpOTk6sWbMGgLi4OEaNGoWZmRmWlpaMGzfumy1eX3N1dWXIkCGMGDECKysrZReqhw8f0rhxY4yNjbG1taVr1674+/srYz5//jyLFy9GJpMhk8nw8vJKNa8lS5YwePBgChQo8M39LC0tsbOzU/7p6uomul4tW7ZkxowZ2NraYmZmxrRp04iNjWXs2LFYWFiQJ08e1q9fr/I1EIT0EAXLLMCsSBVKjtqORSnFKkGx4UG8+GcCL7ZMIiY8KF1pfni0nQ+Ptqsxyuxp9oK/mb3gb02HIQhCGi1evJhp06aRJ08efHx8WLhwIZcuXSIuLg6A8+fPY2Vlhbu7OwBv377Fw8MDV1dXAObPn8+GDRtYt24dly5dIjAwkH379qUpho0bN6Knp8fly5dZsWIFQUFB1KlTh7Jly3Lz5k2OHz/O+/fvad++vTLmKlWq0LdvX3x8fPDx8UmyetvbM2t4e2ZNuq5J8+bNsbGxoXr16hw8eDDJ82fPnuXdu3dcuHCBBQsWMGXKFJo1a4a5uTnXrl1jwIAB9O/fnzdv1NunXxASEk3hWYSukRmFfplFwN2TeO2fTWxEMAH3ThLy8hb52/yGebEaaUov2PsCANbFO2ZGuNnGrv1HABg/aqCGIxGErGXsbzN48Ojpd8+3ZPGizJ0+KdX9TE1NMTExQVtbGzs7O9zc3OjRowd37tzBxcWFCxcuMHbsWPbv3w+Au7s7uXPnxsnJCVDUaE6cOJHWrVsDsGLFCk6cOJGmWAsVKsScOXOUj6dPn07ZsmWZMePL/Ljr1q3DwcGB58+fU7hwYfT09DA0NMTOzi7ZNAPungQgd90+KsdhbGzM/PnzqVatGlpaWuzZs4eWLVuyf/9+mjdvrtzPwsKCJUuWoKWlRZEiRZgzZw4RERFMmqS43hMnTmTWrFlcunSJjh1/7u8GIfOIgmUWY1mmASYFy+G5ZwZBjy8QExrA8w0jsSrvRj630ejkMFYpHcc6szM50uzh5IF/NB2CIGRJDx495eKVG5oOQ2VmZmaULl0ad3d39PT00NPTo1+/fkyZMoWwsDDOnz9PrVq1AAgODsbHx4dKlb4MlNHR0aF8+fJpag53cXFJ9PjevXucO3cOY+Okn8MeHh4ULlw41TSLDVytcv7xrKysGDVqlPJxhQoVePfuHXPnzk1UsCxevDhaWl8aIm1tbSlR4su8mdra2lhaWuLn55fmGARBVaJgmQXpmVhRuPt8/G8d4dXBecR9CsP/5iFCXlynQLv/JTuq8Gs6+ibfIdKsz8LcTNMhCEKWVLJ40WyXr6urK+7u7ujr61OrVi0sLCxwdnbm0qVLnD9/ntGjkx8Yk15GRkaJHoeFheHm5sbs2Ul/uNvb26uUpo6hqVpiq1SpEqdOnUq0LWGfSwCZTJbsNrlcrpYYBCE5omD5nfn4+rF20w56d+uAvZ1NivvJZDKsyzcjp1MFPHf/QfDzf4kOes/T1YOxqdKOvE2Goq1vmOLxUaHvANA3yaX2c8hOPDxfAVAwfz4NRyIIWYsqzdFZTa1atVi3bh06Ojo0aqRYa9vV1ZVt27bx/PlzZf9KU1NT7O3tuXbtGjVr1gQgNjaWW7duUa5cuXTnX65cOfbs2YOjoyM6Osl/ferp6Sn7gSbnk/9rAAysHFLcRxV3795VuTArCN+TKFh+Rx6eryhXvRmxsbHIZDJ+HTsk1WP0zWwp0vsv/K7txfvwIuTRkfhd3UXw86sUbD8Vk/xlkj3u9aXpADg1Xq7OU8h2OnQfDMDNC4c1HIkgCBlVs2ZNQkNDOXz4MLNmzQIUBcu2bdtib2+fqCl6+PDhzJo1i0KFClG0aFEWLFhAUFBQhvIfPHgwq1evplOnTowbNw4LCwtevHjB9u3bWbNmDdra2jg6OnLt2jW8vLwwNjbGwsIiUfP0842KWtVSo3cqt7148YKwsDB8fX2JjIxUzmNZrFgx9PT0lIOI4hcH2bt3L+vWrVOOgBeErEQULL+jAo55KVWiKLfvPmTtph2MHd5PpXnRZDIZtpXbYFqoEi93TiPU8zZRAW94vKIvdjW64NBwIFq6+omOMXdqklmnka307dFJ0yEIgqAm5ubmlCxZkvfv31O0qKJJvWbNmsjlcmX/ynijR4/Gx8eH7t27o6WlRa9evWjVqhXBwcHpzj9XrlxcvnyZ8ePH06BBA6KiosiXLx+NGjVSFh7HjBlD9+7dKVasGJGRkXh6euLo6KhMw6ZK2yTp9unTh/PnzysfxxcgEx77xx9/8OrVK3R0dChatCg7duygbdukaQmCpsmktPRk/gmFhIRgampKcHAwOXPmzHB6/+zYT/9hikm7N6yYR7tWTdN0vCSX43t5O6+PLUOKjQLAwCY/BdtPwThviVSOFgRBEIT0Uff3ofBjEvNYfmdtWzTG0sIMgJXrtqb5eJmWFvY1OlNyxBaMHBQrMHzy8+TRsl54H/0LeUyUOsMVBEEQBEFQmShYfmcGBvr06NIOgKvXb3Pv4ZN0pZPDxpHig9aSp9EgZNo6IMnxcd/Ig8W/EOb9kLfXFvL22kJ1hp4t9Rs2kX7DxLKOgiB84e3tjbGxcYp/3t7eastrwIABidI2MtDDyEAPY2NjBgwYoLZ8BCGrEE3hqciMqn/v128pXrEBcrmcHl3asmzBHxlKL8L3BS93/E7428+FVJkWho55MCqYnwIN5qsh4uyrnlsXAE4f2qLhSARByCpiY2O/udTit0Z9p5Wfnx8hISHKx//9o/ihW+iXmeTMmRMbm5RnB8lqRFO4oApRsExFZt1IHXsM4dCxM+TIYcDzO+cyPN+iFBfLu/ObeHtqFVJcLCD6XgqCIAjqIwqWgipEU7iG9OvZGYDIyE9s3p629WuTI9PWIXedXpQY/g9GuZ2BL30vXx1eRFz0pwznIQiCIAiC8C2iYKkhtWtWobBTfgBWr9/2zQl108LQzoniQ9ZjU62Fsu+l74V/eLCwEyEvb6slj+zk1LlLnDp3SdNhCIIgABD07CpBz65qOgxByDSiYKkhMpmM/r0U/f88X73m1NmL6ktbW4c4PR9yujhj9LkZPCrgNU9W9MNr/2ziPoWrLa+sbuKUWUycMkvTYQiCIADgfXgh3ofFwErhxyX6WKYiM/uUhISGUah0LcLCI6hfpwb7t61SW9phPrcAMLItg++lbbw58bdyKiI9c3sKtPkV08KV1ZZfVhVfW1m/dnUNRyIIgoCyttKsSBUNR5J2oo+loApRsExFZt9Ioyb+oZzP8t7VYzgVcFR7HqBYn/bl7j8ITdAcbl2hOXmbjUQnh0mm5CkIgiD8OETBUlCFaArXsPhBPACr1m/LtHwMrBxw7rcCx1YT0NIzBODDjYPcn9eOj4/Op3K0IAiCIAhC6kTBUsOKFi6Iaw1Fk/Q/2/cRFq6e/o+eZ8bheWZcom0yLS1sq7Sl1OgdmBZWNMPEhPrzfONoXmyZREzYR7XknZXUc+uinMtSEITsRZIk+vXrh4WFBTKZjLt372YovR49etCyZUu1xJZej5b35tHy3hqNQRAykyhYZgEDPg/iCQ4JZceew2pJU8/YHj1j+2Sf0ze3p0jvJRRoPwXtz83gAfdOcn9+OwLunuBH6h1RIH9eCuTPq+kwBEFIh+PHj7NhwwYOHz6Mj48PJUpk/Tl5XV1dGTFiRIrPG1g6YGDpkGibTCZL8rd9+/ZMjlQQMod6lhYQMqRxA1cc8tjz+o0PK9ZuoVfX9shksgylmbvSyG8+L5PJsC7vhmnhKnjtm8XHR+7EhgfxYuuvmN09Qf5WE9AzzT4rQqRk1ZKZmg5BEIR08vDwwN7enqpVq2o6FKKjo9HT08twOgU7TE12+/r162nUqJHysZmZWYbzEgRNEDWWWYCOjg69u3UE4PHT/7h45cZ3y1svpxWFus3FqctMdIzMAQh6fIH789vjd23/D1V7KQhC9tGjRw+GDh2Kt7c3MpkMKysrmjVrpnx+0aJFyGQyjh8/rtzm5OTEmjVrAIiLi2PUqFGYmZlhaWnJuHHj0vR55urqypAhQxgxYgRWVlY0bNgQgIcPH9K4cWOMjY2xtbWla9eu+Pv7K2M+f/48ixcvVtY8fmvpyITMzMyws7NT/hkYGCifmzp1KmXKlGHdunXkzZsXY2NjBg0aRFxcHHPmzMHOzg4bGxv+/PNPlc9PEDKLqLHMInr+0o6Z85cRFRXN8tWbqFmtYobSC/hP0aRuWahZKnsqai8tS9cnp1MFXh2YR8Dd48R9CsNzz3QC7p0gf5tfMbDMk6F4NGXlOsUa4fFzhgqCoOBzexWfgl5+93wNzApgX65fqvstXryYggULsmrVKm7cuMGpU6cYOnQocXFxaGtrc/78eaysrHB3d6dRo0a8ffsWDw8PXF1dAZg/fz4bNmxg3bp1ODs7M3/+fPbt20edOnVUjnXjxo0MHDiQy5cvAxAUFESdOnXo06cPCxcuJDIykvHjx9O+fXvOnj3L4sWLef78OSVKlGDatGkAWFtbJ0rT98pOAOyqtk+0ffDgwfTp04cCBQowYMAAevbsmajlysPDg2PHjnH8+HE8PDxo27YtL1++pHDhwpw/f54rV67Qq1cv6tWrR6VKlVQ+R0FQN1GwzCKsLM3p0LoZm7bt5fDxs3i9eoNjvvQX5j6+OAqoVrCMp2tkhlPn6ViWaYjnvpnEBPsR8uIGDxZ0IE/DQdhV74hMSzvdMWnC6g2KkfaiYCkIiX0KeknEh4eaDiNFpqammJiYoK2tjZ2dHW5ubvTo0YM7d+7g4uLChQsXGDt2LPv37wfA3d2d3Llz4+TkBChqNCdOnEjr1q0BWLFiBSdOnEhTDIUKFWLOnDnKx9OnT6ds2bLMmDFDuW3dunU4ODjw/PlzChcujJ6eHoaGhtjZ2SWbpt/V3UDiguW0adOoU6cOhoaGnDx5kkGDBhEWFsawYcOU+8jlctatW4eJiQnFihWjdu3aPHv2jKNHj6KlpUWRIkWYPXs2586dEwVLQaNEwTILGdS3G5u27UWSJFau38rMqeNSPygFDtV/S/ex5sVqYJK/LK+PLsHv2l7kMVF4H15IwP1TFGj7G4Z2TulO+3vbsXGZpkMQhCzJwKxAtsrXzMyM0qVL4+7ujp6eHnp6evTr148pU6YQFhbG+fPnqVWrFgDBwcH4+PgkKmDp6OhQvnz5NDWHu7i4JHp87949zp07h7GxcZJ9PTw8KFy4cKppFu4+P8m2yZMnK/8vW7Ys4eHhzJ07N1HB0tHREROTL3MO29raoq2tjZaWVqJtfn5+qcYgCJlJFCyzkJLFi1CzakUuXLnOxi27+XXsYIyNjNKVlr5JrgzFopPDmPxtJmFZpgEvd08nKuAN4d4Pebj4F3LV6UWu2j3R0tHNUB7fQ8H8+TQdgiBkSao0R2c1rq6uuLu7o6+vT61atbCwsMDZ2ZlLly5x/vx5Ro8erdb8jL76/A0LC8PNzY3Zs2cn2dfePvlZOL5mYOWQ6j6VKlXijz/+ICoqCn19fQB0dRN/3spksmS3yeVyleIQhMyS7QbvLFu2DEdHRwwMDKhUqRLXr1//5v6LFi2iSJEi5MiRAwcHB0aOHMmnT5++U7RpN6hvV0Ax9dDWnQfSnU5sVCixUaEZjidnwfKUHLkd+5pdQaaFFBfL21OreLi4C6GvHmQ4/cwW+DGIwI9Bmg5DEAQ1qFWrFpcuXeLMmTPKvpSurq5s27aN58+fK7eZmppib2/PtWvXlMfGxsZy69atDOVfrlw5Hj16hKOjI05OTon+4guhenp6xMXFpZhGbEQwsRHB38zn7t27mJubKwuVgpCdZKuC5Y4dOxg1ahRTpkzh9u3blC5dmoYNG6ZY9b9161YmTJjAlClTePLkCWvXrmXHjh1MmjTpO0euuiYNa5PPITcAK9ZuSfevT6+z4/E6O14tMWnrGZC32XCKD9mAoX0hACLfv+Tx8l68OjifuKgIteSTGRq0+IUGLX7RdBiCIKhBzZo1CQ0N5fDhw4kKllu2bMHe3j5RU/Tw4cOZNWsW+/fv5+nTpwwaNIigoKAM5T948GACAwPp1KkTN27cwMPDgxMnTtCzZ09lYdLR0ZFr167h5eWFv79/ks/wx3/35fHffZWPDx06xJo1a3j48CEvXrzg77//ZsaMGQwdOjRDsQqCpmSrguWCBQvo27cvPXv2pFixYqxYsQJDQ0PWrVuX7P5XrlyhWrVqdO7cGUdHRxo0aECnTp1SreXUJG1tbfr3Vgw0efbfS86cv5KudEzz1sQ0b011hoaxQzGKD9tMnoYDkWnrgiThe2kbDxZ0JPj5v2rNS13atWxKu5ZNNR2GIAhqYG5uTsmSJbG2tqZo0aKAorApl8uV/SvjjR49mq5du9K9e3eqVKmCiYkJrVq1ylD+uXLl4vLly8TFxdGgQQNKlizJiBEjMDMzU/Z1HDNmDNra2hQrVgxra2u8vb0TpWFZpgGWZRooH+vq6rJs2TKqVKlCmTJlWLlyJQsWLGDKlCkZilUQNEUmZZOJCqOjozE0NGT37t2JluTq3r07QUFBHDiQtNl469atDBo0iJMnT1KxYkVevnxJ06ZN6dq1a4q1llFRUURFRSkfh4SE4ODgQHBwMDlz5lT7eSUnKDiEQqVdiYiMpEHdGuzbuuq75JsWkX5evNz9B2Fe95TbrFyakbfZCHSNzDQXmCAIgpApQkJCMDU1/a7fh0L2k21qLP39/YmLi8PW1jbRdltbW3x9fZM9pnPnzkybNo3q1aujq6tLwYIFcXV1/WZT+MyZMzE1NVX+OTik3tFa3cxMc9KlQwsATp65yH8ent89htTksHGk2IDV5Gs5Di09QwD8bx3m/vz2BNw9KSZWFwRBEISfULYpWKaHu7s7M2bMYPny5dy+fZu9e/dy5MgR/vjjjxSPmThxIsHBwcq/169ff8eIvxjYp6vy/xVrtqT5eJ87q/G5s1qdISUh09LCrmp7So3ZiVnR6gDEhgXyYusknm8YRVTQ+0zNXxXjJs9k3GSxrKMgCF94e3tjbGyc4t/XzdcZMWDAgERpG+XQxyiHPsbGxgwYMEBt+QhCVvFDN4XXqFGDypUrM3fuXOW2f/75h379+hEWFpZo/q+UaLLqv0XHvpw+dwljI0Oe33XHNKdJ6gd99uLYIACcGi/PrPASkSSJgLsneHVwHrHhQQBo6RuRt8lQbCq1RqbCtc4M5WsqJoi/eeGwRvIXBCHriY2N/eZSi46OjujoqGc2Pj8/P0JCQpSPn65VzE1ZtPcScubMiY2NjVry+R5EU7igimwzj6Wenh4uLi6cOXNGWbCUy+WcOXOGIUOGJHtMREREksKjtrZi5ZjsUJ4e2OcXTp+7RFh4BJu27mHogB4qH/u9CpTxZDIZVmUbYVq4Mq8OzSfg9jHkUeF47ZuF/51j5G/zK4a2339CZlGgFAThazo6OsoVejKbjY1NosKj08yj3yVfQdCUbNUUPmrUKFavXs3GjRt58uQJAwcOJDw8nJ49ewLQrVs3Jk6cqNzfzc2Nv//+m+3bt+Pp6cmpU6eYPHkybm5uygJmVtagTg0KFXQEYOW6rd+cGy2r0DUyw6njHxTpvQQ9c8WEwWFe93i4qDNvTq5EHhOVSgqCIAiCIGRX2abGEqBDhw58+PCB//3vf/j6+lKmTBmOHz+uHNDj7e2dqIbyt99+QyaT8dtvv/H27Vusra1xc3Pjzz//1NQppImWlhYDev/C6EnT8Xz1muOnztO0UR2Vjo0IeAaAoWWRzAwxRWZFqlJq1A7enFyB76XtionVT68m4N5J8reeRM6CLqknogY3b98HoHy5Ut8lP0EQhG8J81asz26ct4SGIxGEzJFt+lhqiqb7lISGhVO4jCshoWG41qjMkd3rVTrue/ex/Jaw14/x3DOdiHfPldusK7Ykb5Nh6Bhm7jUVfSwFQchK7s9vD0Cp0Ts1HEnaafr7UMgeslVT+M/IxNiIrp1aA+B+8V8eP/1PpeOsirXHqlj7zAxNZcYOxSgxdBN5mw5HS1exRNmH6/u5N68t/neOZ2p/17HDBzB2uBh5KQhC1pCrTi9y1eml6TAEIdOIGstUZIVfaB6eryhdpTGSJNG7WweWzJ2qkTjU4VPgW7z2zky0Uo9p4So4tp6AgUVuDUYmCIIgfEtW+D4Usj5RY5kNFMyfj0b1FMuVbd11gI9BwRqOKP0MLHJTpPdfFOw0HR0jcwCCn1/lwfz2vDu3AXlcrIYjFAQhq5AkiX79+mFhYYFMJuPu3bsZSq9Hjx6JpqsTBEH9RMHyO5LHxfDh8Q7e3lhCyJu0rQE+sO8vAERGfmLj1j2p7u99cRreF6elK87MFj81Uemxu7GuoFhhSB4TxetjS3m0pKuyc7s6tOs6iHZdB6ktPUEQvp/jx4+zYcMGDh8+jI+PDyVKZP0BL66urowYMSLF55+tH8mz9SOTbN+wYQOlSpXCwMAAGxsbBg8enOj5+/fvU6NGDQwMDHBwcGDOnDnqDl0Q1EIULL8jmZYOHx7vJOjlScL90lZ4qlOzKkULFwRg5bot2WLqodToGJpSoN1knAeswsA6HwARPv/xaFlPvA7MI+5TuIYjFARBkzw8PLC3t6dq1arY2dmpbdLy9IiOjs60tBcsWMCvv/7KhAkTePToEadPn6Zhw4bK50NCQmjQoAH58uXj1q1bzJ07l6lTp7Jq1apMi0kQ0k0Svik4OFgCpODgYLWk99/RgdLD7U2lVxempfnYVeu3SoY2RSVDm6LSwSOn1BJPVhEXEyW9PrlSujahsvTvWBfp37Eu0u0/m0ofn1zSdGiCIGhA9+7dJUD5Z2lpKTVt2lT5/MKFCyVAOnbsmHJbwYIFpdWrV0uSJEmxsbHSyJEjJVNTU8nCwkIaO3as1K1bN6lFixYq5V+rVi1p8ODB0vDhwyVLS0vJ1dVVkiRJevDggdSoUSPJyMhIsrGxkX755Rfpw4cPycYMSJ6ent/MJzAwUMqRI4d0+vTpFPdZvny5ZG5uLkVFRSm3jR8/XipSpEii69WiRQvpzz//lGxsbCRTU1Pp999/l2JiYqQxY8ZI5ubmUu7cuaV169apdP7JUff3ofBjSvPPv/DwcGbNmsWZM2fw8/NDLpcnev7ly5cZLOr+2HSNbIgK8SY6PO3raHdq15wpfy4kOCSU5Wv+wa1JvUyIUDO0dPTIU78flqUb4LnnT0I97xAd5MuzdcOxLNOIfM1Ho2tsrukwBeGH8ergfMLfPfvu+RrlKkK+5qNT3W/x4sUULFiQVatWcePGDU6dOsXQoUOJi4tDW1ub8+fPY2Vlhbu7O40aNeLt27d4eHjg6uoKwPz589mwYQPr1q3D2dmZ+fPns2/fPurUUW0uYICNGzcycOBALl++DEBQUBB16tShT58+LFy4kMjISMaPH0/79u05e/Ysixcv5vnz55QoUYJp0xRdkaytrb+Zx6lTp5DL5bx9+xZnZ2dCQ0OpWrUq8+fPx8HBAYCrV69Ss2ZN9PT0lMc1bNiQ2bNn8/HjR8zNFZ+NZ8+eJU+ePFy4cIHLly/Tu3dvrly5Qs2aNbl27Ro7duygf//+1K9fnzx58qh8HQQhLdJcsOzTpw/nz5+na9eu2NvbI5PJMiOuH5aekWIy95jw90iSlKbrZ2xkRLfObfhrxQYuXL7Gw8fPKVGscLL7Br1yB8Asn2tGQ/6uctg44tx/JX7X9uJ99C/kUeEE3D1O8POr5HUbhVW5Jmm6Zjv2KOav7NCmWWaFLAjZUvi7Z4S+vK3pMFJkamqKiYkJ2tra2NnZ4ebmRo8ePbhz5w4uLi5cuHCBsWPHsn//fgDc3d3JnTu3cqnGRYsWMXHiRFq3VkzXtmLFCk6cOJGmGAoVKpSoL+P06dMpW7YsM2bMUG5bt24dDg4OPH/+nMKFC6Onp4ehoSF2dnbJpul/5zgAVmUbAYrKGLlczowZM1i8eDGmpqb89ttv1K9fn/v376Onp4evry/58+dPlE78wiC+vr7KgqWFhQVLlixBS0uLIkWKMGfOHCIiIpg0aRIAEydOZNasWVy6dImOHTum6VoIgqrSXLA8duwYR44coVq1apkRzw9P93PBUh4bSVx0KDr6aZuyoX/PzixduRFJklix9h+Wzk9+gI7/Y8Xku9mtYAkg09LCtkpbzIvVxGv/bD4+Ok9sRDAvd0wh4M4xHFtPVHlqormLVwCiYCkIXzPKpZlVudKbr5mZGaVLl8bd3R09PT309PTo168fU6ZMISwsjPPnz1OrlmL2jODgYHx8fKhUqZLyeB0dHcqXL5+meXNdXBKvEHbv3j3OnTuHsbFxkn09PDwoXDj5H/oJvTu7DvhSsJTL5cTExLBkyRIaNGgAwLZt27Czs+PcuXOJ+lqmpnjx4olWn7O1tU004ElbWxtLS0v8/PxUTlMQ0irNBUtzc3MsLCwyI5afgp7xl1+xMeHv01ywzO/oQJMGtTly4izb9xxi2m+jsDA3S7JfrorDMxqqxumZ2lCo2zw+PjyL1/45xIQGEPz8Xx7M70CehgOwq9YRmfa338IrFs345vOC8LNSpTk6q3F1dcXd3R19fX1q1aqFhYUFzs7OXLp0ifPnzzN6tHrPycjIKNHjsLAw3NzcmD17dpJ97e3tVUqzQLv/JXtcsWLFlNusra2xsrLC29sbADs7O96/T9x9Kv5xwppRXV3dRPvIZLJkt33dhU0Q1CnNo8L/+OMP/ve//xEREZEZ8fzw4mssgXT1swQY2Cf1qYcMLYtobJ1wdZLJZFiUrEup0buwrtgSAHnMJ7wPL+LR0p6p9hErX66UWCdcEH4QtWrV4tKlS5w5c0bZl9LV1ZVt27bx/Plz5TZTU1Ps7e25du2a8tjY2Fhu3bqVofzLlSvHo0ePcHR0xMnJKdFffCFUT0/vm7N2GOctkWid8PjWv2fPvnyWBQYG4u/vT758itkyqlSpwoULF4iJiVHuc+rUKYoUKaJsBheErCLNBcv58+dz4sQJbG1tKVmyJOXKlUv0J3ybXoKCZUyYb7rScK1RGeciX6Yeio398ScV1zHMSYG2v+HcfwUGVnkBCH/7hIdLuin6YsZ80nCEgiBktpo1axIaGsrhw4cTFSy3bNmCvb19oqbo4cOHM2vWLPbv38/Tp08ZNGgQQUFBGcp/8ODBBAYG0qlTJ27cuIGHhwcnTpygZ8+eysKko6Mj165dw8vLC39//1RrBwsXLkyLFi0YPnw4V65c4eHDh3Tv3p2iRYtSu3ZtADp37oyenh69e/fm0aNH7Nixg8WLFzNq1KgMnY8gZIY0N4WLVQsyRlvPGC1dI+Qx4USHp6+fi0wmY2CfrgwbO5XXb3w4evIczZvUT7TPi2OKScGdGi/PcMxZSc6C5Sk5citvz6zFx30TkjwOH/eNBD44Q/7WkzAtVDHR/uVrKvpW3rxwWBPhCoKgRubm5pQsWZL3799TtGhRQFHYlMvlyv6V8UaPHo2Pjw/du3dHS0uLXr160apVK4KD079yWa5cubh8+TLjx4+nQYMGREVFkS9fPho1aqTs2zhmzBi6d+9OsWLFiIyMxNPTE0dHR2Ua9+e3B6DU6J3KbZs2bWLkyJE0bdoULS0tatWqxfHjx5XN2Kamppw8eZLBgwfj4uKClZUV//vf/+jXr1+6z0UQMotYKzwVmbE2qseJYXwKeomxnQv5av2erjTCwyMoXLY2QcEh1KxakWP7NiZ63ufOagDsy/bNcLxZVYTPf7zc/Qfhrx8rt1m5NCNvsxHoGpkBMG7yTADm/DFREyEKgiAk8urgfCB79nEVa4ULqkh3wfLWrVs8efIEUIxEK1u2rFoDyyoy40byvvQnoW+vomeSh0JNVqQ7nUm/z2XxcsUIw6tn91GqeFG1xJedSPI43l/Zyevjy5FHRwKgY2RGPrfRWJZtJKbDEgRBUBNRsBRUkeY+ln5+ftSpU4cKFSowbNgwhg0bhouLC3Xr1uXDhw+ZEeMPJ/Fclukfnde/Z2dl88vyVZvVElt2I9PSxq56J0qN3olZUUUn+NjwIDy2T+bZ2mF8Cnyr4QgFQchqvL29MTY2TvEvfjS2OgwYMCDFfAYMGKC2fAQhq0hzjWWHDh14+fIlmzZtwtnZGYDHjx/TvXt3nJyc2LZtW6YEqimZ8Qst4L9D+N5eCUDh5hvRzWGZ7rQ69xrGgSOn0NfX4+mts9hYK9L68Gg7ANbFf55JcCVJIvD+aV4dmEdMWAAAcTIdPI3L0XnSklSnJhIE4ecQGxuLl5dXis87OjqqbV1yPz8/QkJClI99ryj6VtpVbU/OnDmxsbFRSz7fg6ixFFSR5oKlqakpp0+fpkKFCom2X79+nQYNGmR41F1Wkxk3Uui763hfVExsnr/OHAyti6VyRMou/3uTBi26AjB5/FAmjFIM2vlRB++oIjYiBO+jS/hwfb9ym1FuZ/K3/RWj3D9fdwFBELKO5AbvZBeiYCmoIs1N4XK5PMmEq6CYmFVMuqoadcxlGa9qJRdKl1TUHK9av43o6GgAHOvMxrFO0kl8fwYJpybSNVes0BP+9gkP/+qO95HFxEWLqYkEQdCMYgNXU2zgak2HIQiZJs0Fyzp16jB8+HDevXun3Pb27VtGjhxJ3bp11RrcjyrRXJYZLFjKZDIG9+sGwHs/f/YcVKxDq6Nvgo6+SYbSzu5yFixPmTE7yVWnFzItbZDH4XN+Mw8WdCD4v2upJyAIgqBmOoam6BiaajoMQcg0aS5YLl26lJCQEBwdHSlYsCAFCxYkf/78hISE8Ndff2VGjD8cLR0DtPXNgIzXWAK0bdEEG2srAJat2oQkSUSFviMq9F0qR/74PN/4El2kKSWGb8Ho82oXUYFvebp6MB47phITHqTZAAVB+Kl88n/NJ//Xmg5DEDJNuqYbkiSJ06dP8/TpUwCcnZ2pV6+e2oPLCjKrT8nLU6OJDHyGkU0pHGtnfD3rGfOW8efcpQCcPrQF64A1wM/ZxzKhhBOkK6Ym2sXr48sSTE1kTr7mo7Es01BMTSQIQqYTfSyFH52YID0VmXUjvb4ym5DXF9E1sqVws7UZTu+9nz9FXeoQHR1DK7eGLB6vKOhbFmqW4bSzs5XrtgDQv1cX5baoj7547ZtF0NNLym1mRavh2Goi+uZ23z1GQRB+HglHhWc3omApqEKlguWSJUvo168fBgYGLFmy5Jv7Dhs2TG3BZQWZdSO9v78B/ye7QaZFsbb7FH0AM6jfsIls2bEfLS0tHl0/SV6H3GqI9MckSRKB907idWAeseEfAdDSy4FDo0HYVm2vltdDEAThRyIKloIqVCpY5s+fn5s3b2JpaUn+/PlTTkwm4+XLl2oNUNMy60YK9DiOz01F03WhZmsTDehJr7sPHlOtXhsARgzuxZ//G5vhNH90MeFBeB9ZjP/NQ8ptRg7FKdB2Mob2ThqMTBAEIWsRBUtBFSrNAOvp6Zns/0L6JRoZHvZeLQXLMiWLUb1KeS5dvYlV+Am8LoNjtZ+7cNlvmGKN8FVLZib7vK6RGQXbT8GqbCM898wgKvAt4a8f8XBxF+xdu5O7bm+0dPW/Z8iCIPzAPHZMBaBgh6kajUMQMkuaR4VPmzaNiIiIJNsjIyOZNm2aWoL6GSSey9JXbenGTz1kYyrh8+qx2tLNrl56evPSM/Xl2UwLVaLkqB3Y1+oKWtpI8jjenV3Hg4WdCHl5+ztEKgjCz+BTwGs+BYhR4cKPK82Dd7S1tfHx8UmyDFVAQAA2NjbExcWpNUBNy6yqf3lcDE92twYkrIp1wLZkV7WkGxcXR8lKDXn1+i2FnfJz6+Jh5XrigmrC3zzl5e4/iHj3TLnNplIrHJoMQyfHzz03qCAIPy/RFC6oIs0lDkmSkp2W5d69e1hYWKglqJ+BlrYuOp/XCM/oJOkJaWtrM6DPLwA8f+HJaffLakv7Z2GUpyglhm4kb9PhymZwv2v7uD+vHYEPzmg4OkEQBEHIulQuWJqbm2NhYYFMJqNw4cJYWFgo/0xNTalfvz7t22f+9AnLli3D0dERAwMDKlWqxPXr17+5f1BQEIMHD8be3h59fX0KFy7M0aNHMz1OVegZK5rDY8L91Jput06tcS1tRuWiOVi6cqNa085uTp27xKlzl1Lf8SsybR3sa3Wl5Kgd5CxUEYCYUH/+2zye55vGEh3ir+5QBUH4CQQ9u0rQs6uaDkMQMo1Kg3cAFi1ahCRJ9OrVi99//x1T0y9LUunp6eHo6EiVKlUyJch4O3bsYNSoUaxYsYJKlSqxaNEiGjZsyLNnz5I0zQNER0dTv359bGxs2L17N7lz5+bVq1eYmZllapyq0jWyhQ+P1NrHEsDMNCcTO+fhY1AwHWde5vHT/yhWtJBa88guJk6ZBUD92ofTdbyBZR6K9lmG/+0jeB9aSGxEMB8fniPE4yb5mo3EqrybmFhdEASVeR9eCIBZkcz9vhQETUlzH8vz589TtWpVdHV1MyumFFWqVIkKFSqwdKlimh65XI6DgwNDhw5lwoQJSfZfsWIFc+fO5enTp+mONzP7lPg93MKHR9sAcG67Fy1tPbWl/fzOMQaO/I1/n0TQo0tbli34Q21pZyfxtZX1a1fPcFoxYYF4HZhL4L1Tym05C1Uif5tJGFiIOUMFQUhdfG1ldixYij6WgioytPLOp0+fiI6OTrQts95s0dHRGBoasnv3blq2bKnc3r17d4KCgjhw4ECSY5o0aYKFhQWGhoYcOHAAa2trOnfuzPjx49HWTn4C7KioKKKiopSPQ0JCcHBwyJQbKcjzDG+vK369OjVegX7OPGpNv0P3IRw+fgZ9fT2e3T6HtZXoA6sOgY/c8do7i5hQRXO4lq4BDo2HYFu1nZhYXRCEH5YoWAqqSPPgnYiICIYMGYKNjQ1GRkaYm5sn+sss/v7+xMXFYWubeL5HW1tbfH2Tb0p++fIlu3fvJi4ujqNHjzJ58mTmz5/P9OnTU8xn5syZmJqaKv8cHBzUeh4J6Rp9ab6PVuMAnnhD+iumHoqKimbNxm1qT/9nZVHclVJjdmFdsRUA8phPvDo4j8fL+xDh66Hh6ARBEARBc9JcsBw7dixnz57l77//Rl9fnzVr1vD777+TK1cuNm3alBkxpptcLsfGxoZVq1bh4uJChw4d+PXXX1mxYkWKx0ycOJHg4GDl3+vXmTffWMK5LNU5MhzA88w4ckfuokypYgCsWr+dqKjoVI768dRz60I9ty6p75hGOjlMKND2V4r2+xv9z83gYd4PeLi4C29OrkQe+/Nda0EQUvdoeW8eLe+t6TAEIdOkuWB56NAhli9fTps2bdDR0aFGjRr89ttvzJgxgy1btmRGjABYWVmhra3N+/eJC2Dv37/Hzs4u2WPs7e0pXLhwomZvZ2dnfH19kzThx9PX1ydnzpyJ/jKLbg5LZFqK8VPqrrHUM7ZH3zgXQ/p3B8Dvgz879x1Rax7ZQYH8eSmQP2+mpW/qVIGSo7ZjV6MLyLSQ4mJ5e3o1Dxf/Quir+5mWryAI2ZOBpQMGlpnXEiYImpbmgmVgYCAFChQAFP0pAwMDAahevToXLlxQb3QJ6Onp4eLiwpkzX+YRlMvlnDlzJsXR6NWqVePFixfI5XLltufPn2Nvb4+envoGyqSXTEsbXUNrQP01lrkrjSR3pZG0ad4IO1tFHn+t2EAGutRmS6uWzExxOUd10dbLQT63kRQfsh5De8Xo+8j3L3m8vDdeB+YS9yk8U/MXBCH7KNhhqljOUfihpblgWaBAAeV64UWLFmXnzp2AoiYzs6fxGTVqFKtXr2bjxo08efKEgQMHEh4eTs+ePQHo1q0bEydOVO4/cOBAAgMDGT58OM+fP+fIkSPMmDGDwYMHZ2qcaRHfHB4dpv4+lqAokA/orZgw/dGT57hf/DdT8hHA2KE4xYdtJk+jQch09ECSeH95B/cXtOfjk7TPpSkIgiAI2U2aC5Y9e/bk3r17AEyYMIFly5ZhYGDAyJEjGTt2rNoDTKhDhw7MmzeP//3vf5QpU4a7d+9y/Phx5YAeb29vfHx8lPs7ODhw4sQJbty4QalSpRg2bBjDhw9PdmoiTdEzip8kXb0Fy4D/DhPwn2Luxt7d2pMjhwHATzdh+sp1W1i5LvO6aHxNS1uH3HV6UXLEVkzylwMgOug9z9eP4MXWX4kJC/xusQiCkPX4XtmJ75Wdmg5DEDJNhqYbAnj16hW3bt3CycmJUqVKqSuuLCOzp1f48Hgnfg8Ug56Ktt6Jtq6hWtJ9cWwQAE6NlwMwfNxU1mzcAcDtS0coUqiAWvLJ6srXbAbAzQvpmyA9IyS5HL/r+3h9dImyOVzH0JS8zUZi5dJUTKwuCD+h+/MVK9SVGp39CpdiuiFBFRkuWP7oMvtGCn51njf/zgWgYMO/MDDLr5Z0o0LfAaBvkgtQrBtetloTAPp078DiOVPVkk9W5+H5CoCC+fNpLIboYD+8Dszl48Nzym05C1Ukf+tJGFiqd+5SQRCytk/+iplGDKyy3wAeUbAUVKFSwXLJkiUqJzhs2LAMBZTVZPaNFOH/FM8zYwBwqD6ZnLkrqT2PeG26DOD46fPkyGHAs9tnsbTIvHlHhaQCH5zFa/+cBBOr65O7fn/sa3RGpq3y6qqCIAgaIQqWgipUKljmz69aLZpMJuPly5cZDioryewbKfbTR54d6AqAXdm+WBZuoZ50o0IB0NE3UW47d+Eqzdr1AmDqxBGMHdFfLXllZYEfgwCwMDfTaBzxYiNDeX30L/yu7VVuM8xdlALtJmOUq4gGIxME4XuIjQgGFN1ishtRsBRUIZrCU5HZN5IkSTzZ0xYpLgqLQs2xL9dPLel+3ccyPq/KdVrx8PEz7GyteXLzdJaYdikzabKP5beEvLyN5+7pfPL3VmzQ0sa+Vlfy1OuDlq6BZoMTBCHTiD6Wwo8uzaPC40VHR/Ps2TNiY2PVGc9PRyaTZcrIcNO8NTHNWzNJXvETpvu+/8Ceg8fVll9W1a5lU9q1bKrpMJLIWaAcJUduI1edXor1xeVx+JzbwP0FnQjxuKnp8ARByCSWZRpgWaaBpsMQhEyT5hrLiIgIhg4dysaNimlrnj9/ToECBRg6dCi5c+fOUlP5qMP3+IX26sJUwnxuom/qiFOjpZmSR7yoqGiKutTF74M/pUs6c/nUHjE6WcPC3z3Hc/d0wt88Vm6zrtiKvE2HoZPD5BtHCoIgfD+ixlJQRZprLCdOnMi9e/dwd3fHwOBLk129evXYsWOHWoP7WSSssczsngn6+nr079UJgHsPnnDp6o1MzU9InVGuwhQfsp68zUYqm8E/XN/H/XltCbh/+qdbLUkQBEHIvtJcsNy/fz9Lly6levXqiWq6ihcvjoeHh1qD+1nEr74jj40kLjpULWn63FmNz53VyT7Xu1tH9PUVfSuXrtyklvyyqnGTZzJucuYu6agOMi1t7Gt2oeToHeQspJgZICY0gBf/TOD5hlFEBflqOEJBENTh1cH5vDo4X9NhCEKmSXPB8sOHD9jY2CTZHh4eLppU00nP2E75v7r6WYb73iHc906yz1lbWdCpbXMAjpw4q5zr8Ud09vxlzp6/rOkwVGZgkZuifZZSoMPvylGjQU8ucn9ee3wvbUeSx2k4QkEQMiL4v2sE/3dN02EIQqZJc8GyfPnyHDlyRPk4vjC5Zs0aqlSpor7IfiLxNZYA0WoqWDo1Xp5oRPjXBvfrBihGii9ftVkteWZFNy8cznIjwlMjk8mwdmlKqbF7sCqnmNReHh3Bq4PzeLSsFxE+/2k4QkEQ0qvU6J3ZckS4IKgqzQXLGTNmMGnSJAYOHEhsbCyLFy+mQYMGrF+/nj///DMzYvzh6SUoWMaEfZ8mz2JFC1GvdnUANm/fx8eg4O+Sr6A6XSMzCnacRtE+S9G3yA1A+OtHPFj8C95HlxAXHanhCAVBEAQhsTQXLKtXr869e/eIjY2lZMmSnDx5EhsbG65evYqLi0tmxPjD09YzRkvXCFBfjWVEwDMiAp59c5/4qYfCIyJY/88uteSb1dy8fZ+bt+9rOowMMS1cmZKjdmDv2g3ipyZy38SD+R0Iepp9mvkFQYAw74eEeT/UdBiCkGnSNN1QTEwM/fv3Z/LkySqvxpPdfa/pFTxODONT0EuM7VzIV+v3DKeX3ATpX5MkiQq13HjyzIPcuex4dP0kurq6Gc47K8mqE6SnV/i753ju+ZPw14+U2yxK1Sdf89Ho5bTSYGSCIKhCTJAu/OjSVGOpq6vLnj17MiuWn1p8P0t11VhaFWuPVbH239xHJpMxpJ+i1vLtO1/2Hz6plryzkrHDBzB2+ABNh6E2RrkKU3zwOhxbjkfbQFHLHXj/FPfnteH91d1IcrmGIxQE4Vty1elFrjq9NB2GIGSaNE+Q3r17d8qUKcPIkSMzK6Ys5Xv9QvO9s4aA5/uRaeni3HYPMlm6F0VKk8jITxR1qYt/QCAuZUpy/vgOMbo/m4gO/sCrQ/MJvH9auc04Xynyt5mEoZ2TBiMTBOFHJGosBVXopPWAQoUKMW3aNC5fvoyLiwtGRkaJnh82bJjagvuZ6BoraiwleQyxnz6im8Pyu+SbI4cBfXt0ZOb85dy6+4B/b9yhSsVy3yVvIWP0TK0p9MssPj65hNf+2UR/9CHs1X0eLuqCvWs3ctftLdYdFwRBEL6rNNdYfqtvpUwm4+XLlxkOKiv5Xr/QQt/dwPuiom9l/jpzMLQulqH0vC9OAyBvjf+luu97P3+KutQhOjqGFk3rs3XdkgzlnZW066roa7prc8p9TX8EcdGRvD25Cp+LW0BSNIfrWzqQv/VETAtV1HB0giDEe7Ze0dpXpOdCDUeSdqLGUlBFmtpbJUnC3d2dx48f4+npmeTvRytUfk+ZMZelqmxtrOjQ2g2AQ8fO4PXqzXfNX8g4bb0c5G02nBJDN2GU2xmAqIDXPF09CI8dU4kJD9JsgIIgCMJPIU01lnK5HAMDAx49ekShQoUyM64s43v9QpPHfuLJnrYAWJfogk3xTpmWV3IePn5OpdotABjUtytzp0/6rvkL6iPFxeJ7eQdvTvyNPOYTADqGpuR1G4lVuaaiD60gCOkiaiwFVaSpxlJLS4tChQoREBCQWfH8tLR0DNAxMAMgJuz71lgClChWmNo1FSsnbdq6h6DgkO8eg6AeMm0d7Gt2odSYXZgVrQZAbEQwL3dM5enqwXzyf63hCAVBEIQfVZqHHs+aNYuxY8fy8KGY4FXddI0Ua4ZHh2d89Z2gV+4EvXJP0zFDB/QAICz8x5kwfceew+zY82PMYZlW+ub2FO65CKcuM9E1VgwGC3lxnfsLOvL27DrksTEajlAQfj7+d47jf+e4psMQhEyT5sE75ubmREREEBsbi56eHjly5Ej0fGBgoFoD1LTvWfX/5upcgr3Po2toTWG39RlKS5UJ0r/2I06Y/qNNkJ5esZGhvD76F37X9iq35bAtQP42v2LiWFqDkQnCz0VMkC786NI83dCiRYsyIQwBQNdYUWMZE+GPPC4GLe30F+pyVRye5mNkMhlD+/dg0KjJvH3ny54Dx+nY1i3dMWQFKxbN0HQIWYJODhPyt5mElUsTPPfMIPL9SyLfv+Tx8t7YVGqNQ5Oh6OQw0XSYgvDDK9Au9Zk6BCE7S3ON5c/me/5C+/jyJO9uKKb6cWqyCn2TXJmaX3I+fYqiqEtdPvgHUKqEM1dO7xGDPX4w8tgYfM5v4u2ZtUix0QDoGluSr/loLErXF6+3IAjJEjWWgirStbxLXFwce/bsYfr06UyfPp19+/YRFxen7th+Onqf+1gCxHznKYfiGRjoM6B3ZwDuP3zC+UvXNBKHkHm0dHTJXbc3pUbtIKeTYo7LmLAAXmydxLN1w/kU+FbDEQqCIAjZVZoLli9evMDZ2Zlu3bqxd+9e9u7dyy+//ELx4sXx8PDIjBh/GvGr70DG57J8cWyQsp9lWvXp3okcORQrtixZkbG+nppWvmYzZT9LITEDKweK9l1GwY5/oGNkDkDwsys8mN+ed+c2II+L1XCEgvDjuT+/vbKfpSD8iNJcsBw2bBgFCxbk9evX3L59m9u3b+Pt7U3+/PnFco4ZpJvDCj6vER4TlrGR4UZ2ZTGyK5uuY60szenSXjGn5YnTF3j6PPv+YKhTqxp1alXTdBhZlkwmw6pcY0qP3Y11xZYAyGOieH1sKQ8XdyH01QPNBigIPxjTQpUwLVRJ02EIQqZJcx9LIyMj/v33X0qWLJlo+71796hWrRphYWFqDVDTvnefkueHexMT/p6cDjVwqDo+0/NLyX8enpSt1hRJkujRpS3LFvyhsViE7yfE8w6ee2bwyc9TsUEmw7ZKW/I0GoyOgbFmgxMEQaNEH0tBFWmusdTX1yc0NDTJ9rCwMPT09NQS1M9ML35kuBrmssyIQgXz06RBbQC27T7Iez9/jcYjfB8585el5Iit5Gk4AJm2LkgS76/s4v789gQ+PKfp8ARBEIQsLs0Fy2bNmtGvXz+uXbuGJElIksS///7LgAEDaN68eWbEmMiyZctwdHTEwMCASpUqcf36dZWO2759OzKZjJYtW2ZugBkUv2Z4RvtYfni0nQ+PtmcojWEDewAQFRXN6g3bMpSWpsxe8DezF/yt6TCyFcXgnj6UHLkNkwLlAIgJ9uO/TWN5vnEMUUGaGVgmCD+Ct2fW8PbMGk2HIQiZJs0FyyVLllCwYEGqVKmCgYEBBgYGVKtWDScnJxYvXpwZMSrt2LGDUaNGMWXKFG7fvk3p0qVp2LAhfn5+3zzOy8uLMWPGUKNGjUyNTx3iR4bHRYUQFxOR7nSCvS8Q7H0hQ7FUq1yecmVKALB6wzYiIz9lKD1N2LX/CLv2H9F0GNlSDhtHnPuvJH+7yWjnUDR7fXzkzv357fG9vB1JLmaCEIS0Crh7koC7JzUdhiBkmnTPY/nixQuePHkCgLOzM05OTmoNLDmVKlWiQoUKLF26FAC5XI6DgwNDhw5lwoQJyR4TFxdHzZo16dWrFxcvXiQoKIj9+/enmEdUVBRRUVHKxyEhITg4OHy3PiXBr87z5t+5ABRs+BcGZvnTlU5slKK7go5+xia93rXvCD0GjAFgydyp9O7WIUPpfW+BH4MAsDA302gc2V1MWCCvDi4g4O6XpeiM8hQjf5tJGOUuqsHIBCF7iY0IBkDH0FTDkaSd6GMpqCJd81gCODk54ebmhpub23cpVEZHR3Pr1i3q1aun3KalpUW9evW4evVqisdNmzYNGxsbevfurVI+M2fOxNTUVPnn4OCQ4djTIn71HchYc7iOvkmGC5UArdwa4pDHHoC/VmxALpdnOM3vycLcTBQq1UDX2AKnztMp0nsJ+ha5AQh/85iHS7rx6tAC4qLSX7suCD8THUPTbFmoFARVpblg2aZNG2bPnp1k+5w5c2jXrp1agkqOv78/cXFx2NraJtpua2uLr2/yA10uXbrE2rVrWb16tcr5TJw4keDgYOXf69evMxR3WukZfTm/mLD0FyyjQt8RFfouw/Ho6OgwqG83AP7z8OLYSfcMp/k9eXi+wsPzlabD+GGYFalKyVE7sK/dA5mWNkhyfC9u5f78dnx8dF7T4QlClvfJ/zWf/L/v94ogfE9pLlheuHCBJk2aJNneuHFjLlzIWJ8+dQoNDaVr166sXr0aKysrlY/T19cnZ86cif6+J219U2Ta+gBEZ2Bk+OtL03l9abpaYurRpS05TRRTzWS3CdM7dB9Mh+6DNR3GD0Vbz4C8jYdQYsQWjPOVAiA66D3PN47+PLhHszMaCEJWprhPRms6DEHINDppPSClaYV0dXUJCQlRS1DJsbKyQltbm/fvE9fivX//Hjs7uyT7e3h44OXlhZubm3JbfDOujo4Oz549o2DBgpkWb3rJZDL0jGyJCvHOUMHS3Clp4T+9cpoY07NrexYvX8elqze5decBLmVLpn5gFtC3RydNh/DDMrRzotjANXy4cQDvo0uIiwzl4yN3gv+7Rp76/bCt3gkt7TR/xAjCD82mSltNhyAImSrNNZYlS5Zkx44dSbZv376dYsWKqSWo5Ojp6eHi4sKZM2eU2+RyOWfOnKFKlSpJ9i9atCgPHjzg7t27yr/mzZtTu3Zt7t69+937TqaFci7LDDSFWxZqhmUh9S1lOKjPL+joKAoJS/7OPrWW/Xt1oX+vLpoO44cl09LCplIrSo/ZjWXZxgDIoyPxPrKYh4t/IdTrnoYjFISsxa5qe+yqiiUdhR9XmqsTJk+eTOvWrfHw8KBOnToAnDlzhm3btrFr1y61B5jQqFGj6N69O+XLl6dixYosWrSI8PBwevbsCUC3bt3InTs3M2fOxMDAgBIlSiQ63szMDCDJ9qwm4VyWkiQhk8k0HBHkyW1P25aN2b77EHsPnWCa91vy5c2t6bCELELXxBKnTn9gXd4Nr32z+OTvTaTvCx4v7411xZY4NB6CrpGZpsMUBEEQMlmaayzd3NzYv38/L168YNCgQYwePZo3b95w+vTpTJ98vEOHDsybN4///e9/lClThrt373L8+HHlgB5vb298fHwyNYbvIX4uSykuiriooHSl8fbaQt5eW6jGqGDYQEUBXi6Xs2z1JrWmnVn6DZtIv2ETNR3GT8O0UEVKjtquWLlHR9Fl5sP1/dyf15YPNw+TztnNBOGH4bFjKh47pmo6DEHINOmex/JnoYl5u0Le/qsceJO/7jwMrdI+T6DnmXGfj5+j1tiatu2J+8V/MTI05Nmds5ibZe1pM+q5KZrBTx/aouFIfj6fAt7gtX8Owc+uKLeZFHAhf+uJ5LBx1FxggqBBj5Yrpr4rPmithiNJOzGPpaCKdBcsb926pZwgvXjx4pQtW1atgWUVmriRPgV54XFiCAB5Ko/FNF+t75KvKk6evUirTv0AmPbbKEYP7avhiISsTJIkAh+c4dWBecSEKtabl2nrkqtOL3LV7o6WTtKBgIIgZE2iYCmoIs1N4X5+ftSpU4cKFSowbNgwhg0bhouLC3Xr1uXDhw+ZEeNPRzfBXJYZXTNc3erXro5zEcWE+H+v+Yfo6GgNRyRkZTKZDMtS9Sg1Zje2VduBTIYUF8PbUyt5sLATIR63NB2iIAiCoEZpLlgOHTqU0NBQHj16RGBgIIGBgTx8+JCQkBCGDRuWGTH+dLR1c6Ctr/g1GB2WvimHwnxuEeaj/i9tmUym7Gvp4+vHrv1H1Z6HOp06d4lT5y5pOoyfnk4OYxxbjqf44PUY2hcC4NOHVzxZ2Z+XO38nJjxIswEKwncS9OwqQc9SXi1OELK7NDeFm5qacvr0aSpUqJBo+/Xr12nQoAFBQUHqjE/jNFX1//LUSCID/8PIphSOtWek+fgXxwYB4NR4ubpDIyoqGufydXnv509x58JcO7c/S4xcT075moopl25eOKzhSIR48rhYfC9u5e2plchjogDQMTIjb7MRWJVrmmXfS4KgDvfnK6YaKjV6p4YjSTvRFC6oIs01lnK5HF1d3STbdXV1s9060lmZ7ueR4eltCrcr0xu7Mqqtj55W+vp6DOzTFYBHT55z5vyVVI7QnJm/T2Dm7xM0HYaQgJa2Drlcu1Fq9C5Mi1QFIDY8iJc7pvJ09SAiP4glOIUfV95mI8nbbKSmwxCETJPmGssWLVoQFBTEtm3byJUrFwBv376lS5cumJubs2/fvkwJVFM09Qvt/f0N+D/ZDTItirXdp1iXOQsJ/BhEkbJ1iIiMpK5rNQ7uWKPpkIRs6MvgnrnEhAYAINPRI3edXti7dhODewQhCxE1loIq0lxjuXTpUkJCQnB0dKRgwYIULFiQ/PnzExISwl9//ZUZMf6U4msskeTERGS9QVEW5mZ079wGgDPul3nw6JmGIxKyo4SDe2yqtFUM7omN5s3JFWJwjyAIQjaUrumGJEni9OnTPH36FABnZ2fq1aun9uCyAk39QgvzvcOr85MByOf6J8a2pdN0fGbNY5koD6/XlKrSCLlcTuf2LVj916xMyyu9xDyW2Uvoq/t47plBpO8L5TYrl2bkbTocXWNzDUYmCOoh5rEUfnRprrHctGkT0dHR1K9fn6FDhzJ06FDq1atHdHQ0mzZlj9VYsoP49cIBYtLRz1LP2B49Y3t1hpREfkcHWjStD8CufUfx8fXL1PzSo0D+vBTIn1fTYQgqMslXihLD/8Gh8RC0dPUB8L91mPvz2uJ3fT+S6MctZHMGlg4YWDpoOgxByDRprrHU1tbGx8cHGxubRNsDAgKwsbEhLi5OrQFqmqZ+oUnyWB7vbg2SHKtiHbAt2fW75Z0W12/epXbTTgCMHtqXab+N0nBEwo8iKvAdXvvnEPT0y3RRJo5lcGw9AUM7Jw1GJgg/J1FjKagizTWWkiQlOx3ImzdvMDXN2sv7ZScyLR10c1gCEJPOuSy/h4rly1C5gmLVpbWbdhAWHq7hiIQfhb5FLgr3XEihbnPRNVX8kA31usvDRV3wPvoXcdGRGo5QEARB+JqOqjuWLVsWmUyGTCajbt266Oh8OTQuLg5PT08aNWqUKUH+rHSNbImJ+EB0eNoLlgH/KeZttCzUTN1hJTFsYA/+vXGHoOAQNm3dy6C+Wad2deU6Rd/K/r26aDgSIT1kMhkWJWpj6lSRN6dW4ntpO5I8Dh/3jQTeO4Vjy3GYOVfXdJiCoDLfK4r5K+2qttdwJIKQOVQuWLZs2RKAu3fv0rBhQ4yNjZXP6enp4ejoSJs2bdQe4M9Mz9iOiA8P09XH8uMLxYo436Ng2axRXQo45uWllzfLVm2if6/OaGtnjemRVm/YBoiCZXanbWBEPrdRWJVrgufemYS/fkTUx3c8Wz8Ci5J1ydd8DHqm1poOUxBS5Xd1NyAKlsKPK819LDdu3EiHDh0wMDDIrJiyFE32KfF7tI0PDxU1bs5tdqOlo/o1jwp9B4C+Sa5Mie1rK9dtYdTE6QD8s2YRrdwafpd8U+PhqZhsu2D+fBqORFAXSR6H3797eX18KXGfFF0vtPSNcGg0ENsq7bLcnK+CkNAn/9cAGFhlvwE8oo+loIp0TTf0M9HkjRTkdY631+YDULDRcgxMs+7o5vDwCIqUq8PHoGAqupTm3NHtmg5J+MFFh/jz6tB8Au+dUm4zylOM/K0nYZSnqAYjE4QfkyhYCqpI8+AdLS0ttLW1U/wT1EfPyFb5f0wa+1nGRoUSGxWq7pBSZGRkSJ/uHQG4fuse/964893y/pbAj0EEfgzSdBhCJtDLaUWhLjMp0vsv9C1yAxD+5jEP/+rGq4Pzif0UpuEIBSGp2IhgYiOCNR2GIGQalftYxtu7d2+iUeExMTHcuXOHjRs38vvvv6s1uJ+dboK5LKPD0tbP0uvseACcGi9Xa0zf0r93Zxb/vY7o6BiW/L1eOVpckxq0+AWAmxcOazgSIbOYFalCqdE7eHtmLT7nNyPFxeJ7aRsB90+Tr/loLErWTXYmC0HQhMd/9wWg1OidGo5EEDJHmguW8YN4Emrbti3Fixdnx44d9O7dWx1xCYCOgTkybT2kuOg011ia5q2ZSVGlzN7Whvatm/HP9n0cPHqal17eFHDUbPN9u5ZNNZq/8H1o6Rrg0GgwlmUb47V3JqGed4gJ+cCLfyZgVrQa+VqOw+BzraYgaJJlmQaaDkEQMpXa+li+fPmSUqVKERb2YzU/abpPyX9HBxAd+gaT3JXJW/23755/Wj18/JxKtVsAMKBXF+bPzPoxCz8WSZLwv3kI7yOLlU2OWrr65K7XF7saXdDS0dVwhIKQPWn6+1DIHtLcxzI5kZGRLFmyhNy5RY2AuukZK/pZRmfhSdITKlGsMPVqK+YV3LRtr+jfKHx3MpkM6wrNKTV2D9YVmgMgj4ni9bGlPFjUmRCPmxqOUBAE4ceV5oKlubk5FhYWyj9zc3NMTExYt24dc+fOzYwYf2p6Rop+ljHh70lL5bLPndX43FmdWWF907CBPQCIiIxk7SbN9iMaN3km4ybP1GgMgmboGplRoN3/cB6wihy2BQD45OfJk5UDeLF9MjGhARqOUPgZvTo4n1cH52s6DEHINGnuY7lo0aJEj7W0tLC2tqZSpUqYm5urKy7hM93PI8PlsZHERYeio69a80O4r+ZGZdepWZUSxYrw8PEz/v5/e3ce3kS5Pnz8O9m7t4C0FNoCsssqCAKKCygqeEBR0YMKiAsCCoILnqOi57wKqCCgCIo/UY8LiAoICoJsbii7iGhVKJStFFq6ps067x+TBipbC0knae/PdeWadDKZ3DPNZO55tnnrfzw8fAhWq0WXWFav+16XzxWhI7bxxbQe/QFZ333IgZVz8LpKydmyjLyd35Jy3UjqXnqzjH0pqkz+nz/pHYIQQSXjWJ6F3m1KCvb/wL7vXwCg8TWvEFGraZXHcC7en7+IBx5+EoBZ057n7jtu1jkiIcBx7BB7P5/CsV/X+udFNWhFw5vGE53SSr/AhAgDep8PRXg458TSbreTmZmJ0+ksN79t27YBCSxU6H0glRzbxe4VowFo0PUJ4lIvr/IYzoXT6aTVJddwKCubls0vZMPazzEYAtKkV4jzdmznt+xd/BKOY9odqlAMJHa7lQbXPogpIvrMbxaihtL7fCjCQ6XP9EeOHKFPnz7ExMRw0UUX0aFDh3IPEVhlbSwBnJW4Z7g9Jx17TnowQqoQi8XCiPvuAuC39F2sWPWNLnFs2rKdTVu26/LZInQltLqcNuM+JvnqoShGE6heDn8/n+0v30LO9q8r1Z5ZiMooytxBUeYOvcMQImgqnViOGTOG/Px8fvrpJyIiIli+fDnvvvsuTZs25fPPPw9GjDWa0RKF0aKVoFRmLMuDG6ZzcMP0YIVVIcPuHkhMdBQA015/W5cYho/5F8PH/EuXzxahzWjRxr5sM+YjYhpfDICr8Ch/vT+e9LdHU5qzX+cIRXW0e8F/2L3gP3qHIUTQVLrzzurVq1m8eDGdOnXCYDCQlpbGNddcQ2xsLBMnTqRPHxmQOtDMUYl4nEWVKrGs0+q2IEZUMXGxMQy96zZmzJrLtz9sZPPWX+jYoU2VxvDY6OFV+nki/EQkNqLlA29wdPMXZC59Bbc9n/z0H9g+ZSD1e91LvR53ytiXImCSr75H7xCECKpKl1gWFxdTt25dQBt66MiRIwC0adOGLVu2BDY6ARy/Z7irErd1jE+7kvi0K4MUUcWNvO8uTCbt+kWPUsuBA/oycEDfKv9cEV4UReGCTn3LjX2puh3sXz6THdMHUZixTd8ARbVRp8N11Olwnd5hCBE0lU4smzdvTnq61navXbt2vPHGGxw4cIDZs2dTr169gAcojg855LJno6penaOpnAb163HrTTcAsGjpCjL27NM5IiFOzz/25YNz/GNflhzezc5Z97J7wX/9d/IRQghxapVOLEePHs2hQ4cAmDBhAsuWLSM1NZUZM2bwwgsvBDzAv5s5cyYNGzbEZrPRpUsXNmzYcNpl58yZw+WXX05CQgIJCQn06tXrjMuHqrLEUvW6cZfkVug9md/+h8xvQ6Mdz+gHtaofr9fLq2+8U6WffetdI7j1rhFV+pki/MU26kDr0R/Q4LqRKCYrAEc2Lubnl27hyOYvpHOPOGfpcx8hfe4jeochRNBUOrG88847GTJkCAAdO3Zk7969bNy4kX379jFw4MBAx1fO/PnzGTt2LBMmTGDLli20a9eO3r17k52dfcrl165dyx133MGaNWtYv349KSkpXHvttRw4cCCocQZaWVU4VK5neKhoc1Hzcrd5PJpzTOeIhDg7g8lM/auH0nbcfOKadQXAXXyM3fMn8PucEZQc2atzhEIIEXrCaoD0Ll26cMkll/Daa68BWglYSkoKDz30EOPHjz/r+z0eDwkJCbz22mvcfffdp1zG4XDgcDj8fxcUFJCSkqLruF2l+ZnsWq6VutXvMpb4hlfrEsf5WPPNevreqpVcPvX4KJ4cN1LniISoOFVVyf15JXuXTPHfClIxmkm+agjJVw3BYLbqHKEQwSfjWIqKCJsRq51OJ5s3b6ZXr17+eQaDgV69erF+/foKrcNut+NyuahVq9Zpl5k4cSJxcXH+R0pKynnHfr4sUXX9z8OxxBLgyssvpV2blgDM/r8PKSkp1TkiISpOURRqt7+Wto9+Qt2ut4KioHpcHPh6Dr+8cgf5f23UO0QhhAgJYZNYHj16FI/HQ2JiYrn5iYmJZGVVbHzHJ554guTk5HLJ6d89+eST5Ofn+x/79unf2cRgsmGyxQPgqmBimbd3LXl71wYvqEpSFIUxI4YBcDQnlw8+XlQlnzv/06XM/3RplXyWqP5METE0uukJLho5l8h6zQAoPZrJ728+yF/znsZVVLE20KLmOrp1OUe3Ltc7DCGCJmwSy/M1adIk5s2bx8KFC7HZbKddzmq1EhsbW+4RCso68FS0xPLozo85uvPjYIZUaTf/ozepKckAzJg1F4/HE/TPfGn6bF6aPjvonyNqlujU1rR++D1S+47BYIkAIGfLMn5+6Rayf1qI6g2v0RtE1Tm4+m0OrtbnhhFCVIWwSSzr1KmD0Wjk8OHyidXhw4dJSko6zbs0L7/8MpMmTWLFihVhey9z/5BDxafuqPR3yZ1Hk9x5dDBDqjSTycSo+wcDsCsjk6XLVwX9M2dPe4HZ04I/WoGoeRSjiXo97qTtuAUkXHQFAJ6SAjI+fZ6ds+/DnvWXzhGKUNT41mdofOszeochRNBUqPPO9u0Vv9dyMBO3Ll260LlzZ1599VVA67yTmprKqFGjTtt558UXX+T555/nq6++4tJLL630Z4ZKY+XD29/l6G8LQDHQ6paFKAajbrGcj6LiYlpc3JNjefl07tiO1V98hKIoeoclxHnL3bGWvYtfwpmvXfwqBiNJPe6kfq/7MFpOX0siRLgIlfOhCG0VuqVj+/btURTltGO3lb2mKEpQqzfHjh3L4MGD6dSpE507d2batGkUFxczdOhQAO6++27q16/PxIkTAZg8eTLPPPMMH374IQ0bNvS3xYyOjiY6OjpocQZDWYklqheX/QiW6DOX0oaq6Kgo7h18Oy9Nf4MNm39m/YYtdOvSUe+whDhvtVpfSVyTS9i/8g2yvpuH6vVwaO275P68kob9Hye+5WV6hyiEEEFXocQyIyMj2HFUyMCBAzly5AjPPPMMWVlZtG/fnuXLl/s79GRmZmIwHK/dnzVrFk6nk1tuuaXceiZMmMCzzz5blaGftxPHsnQVZ581sfxrmTY8UZPrXw9qXOdi+L2DmD7rbZxOF9Nmvh3UxLJTD+12jpu+kQ48IviMtijSbhxLnYtvIOOzFyjetxPHsYOkzx1DrTY9SfvHo1jiLtA7TKGj7VNuA6DtuNBqAy9EoFQosUxLSwt2HBU2atQoRo0adcrX1q5dW+7vPXv2BD+gKmIuN0h6FlGcuclBVFKHYId0zpLqXsCg2/oz9/0FfPHVatL/3E3zpo2D8llXX9E9KOsV4kyi6rfgopFzOfzjp+xfPhNPaTG5v6wi748fSb1+FHUvHYBiCJsm7iKA4pp20TsEIYLqnAZI/9///sfs2bPJyMhg/fr1pKWlMW3aNBo1akS/fv2CEaduQqVNidfj4rdPbgZU6rQaSGKbu3SLJRD++CuDiy/rg6qqDP7nAF5/5f/pHZIQQeHMP8LeJVPJ3b7SPy86tQ2NBvybyHpNdIxMiMoJlfOhCG2VvmSeNWsWY8eO5YYbbiAvL8/fpjI+Pp5p06YFOj7hYzCaMUfWASo+lmUoa9akEX16a3cQ+uiTzzl0uGK93YUIN5a4C2h650Sa3zMdS0I9AIoyf2HH9EFkLnsNr0tuFiCEqD4qnVi++uqrzJkzh3//+98Yjcd7Jnfq1IlffvkloMGJ8sy+O/BUZMihI7/O48iv84Id0nl5ZJQ2YLrT6WL2Wx8E5TMmT53F5KmzgrJuISojvkV32o77mHo97gKDUevcs+Ydtk8ZSP4fP+odnqgiB1a9xYFVb+kdhhBBU+nEMiMjgw4dTm6/Z7VaKS4uDkhQ4tSOD5J+9jsN5Wd+Q37mN8EO6bxcekkHLr1E+y699e48CosC//1ZsOgLFiz6IuDrFeJcGC0RpPYdTeuH3yOqQSsAHLkH+P2tUfz14b9xFh7VOUIRbDnbVpCzbYXeYQgRNJVOLBs1asS2bdtOmr98+XJatmwZiJjEaZT1DHeX5OL1OM+4bMOrJ9Pw6slVEdZ5GTPiHgDy8gt45/0FAV//isXvs2Lx+wFfrxDnIyq5OReNmkvaPx7FYIkEIGfbV2x/aQBZ389H9Qb/rlRCH60enEOrB+foHYYQQVPpxHLs2LGMHDmS+fPno6oqGzZs4Pnnn+fJJ5/k8ccfD0aMwscSdXyIIZf9yBmXNVljMFljgh3Seetz3dU0vbAhAK+9+R4ulyug66+VEE+thPiArlOIQFAMRpIuu522jy4goY3W3thTWszexS/x66tDKNq3U+cIRTCYIuMwRcbpHYYQQVPpxPLee+9l8uTJPPXUU9jtdv75z38ya9Yspk+fzu233x6MGIVPWRtLAFfRmavDHYUHcRQeDHZI581gMDD6QW2A+/0HDvHp4uUBXf+ujL3sytgb0HUKEUjW+ESa3fUizYdOw1qrPgDFB37j19cGk7FwMu6SQp0jFIFUenQfpUf36R2GEEFzTsMNlbHb7RQVFVG3bt2zLxymQml4BWdxNn8u1aqO63UcQa0mN5x22VAeIP3vSksdtOzUi+wjR2ndqjk/rl4YsNs8ygDpIpx4XaUcWD2XQ2vfRfW4ATBH1ya17xhqd7hObn9aDYTzAOmhdD4Uoeu8RuiNjIys1kllqDFH1AZF64nvPMuQQwlNbiDhDIlnKLHZrDw4bBAAO3ams2rdDwFb931D7uC+IXcEbH1CBJPBbCOl94O0eWQesU0uAcBVlMOueU/z+5sPUpK9R98AxXmr2/UW6na95ewLChGmKl1iefjwYR599FFWrVpFdnb2SfcPD+a9wvUQaldofyy9F1dxFrEpl5PS7Qm9wwmY3GN5tLi4J8V2O1f16MrSBW/rHZIQulJVlZxtX5G55BVcRTkAKEYT9a64i+Srh2G02HSOUNQ0oXY+FKGpQrd0PNGQIUPIzMzk6aefpl69elI1U8Us0Ym4irNwVWDIoXBSKyGewYMG8Pqc/7Hmm/Vs+2Un7du00jssIXSjKAp1OlxHfIvu7P9qFofXL0D1uDm4ei45W78ird9jJLS6XO8whRCinEqXWMbExPDtt9/Svn37IIUUWkLtCu3Axhnk7V6B0RpLi/4fnn65n14BoH6XR6oqtPOWue8Arbv0xuPxMHDAjbz9+ovnvc77H34SgDdnTDzvdQmhp+L9v5Hx2USK9x/vLZ5w0RWk/eNRrL47+ojQt2v+swBcOPBZXeM4F6F2PhShqdJtLFNSUk6q/hZVp2zIIY+jAI+r5LTLOYsO4Sw6VFVhBURqSn1u6nstAJ8uXsaBg+dfKrs7I5PdGZnnvR4h9BbVoCUXjZpLw5vGY7RFA3Ds13Vsf/kWDq55B687sEN1ieAozdlHaY70ChfVV6VLLFesWMGUKVN44403aNiwYZDCCh2hdoWWt3ctB358GYALe7+GLb6hvgEF2Oatv9DjOq3X5COjhvH/nn5U54iECD2uwhwyv5zB0c3H7yplq9uQhv2fIM7X6UeIQAu186EITZVOLBMSErDb7bjdbiIjIzGbzeVez83NDWiAegu1A8l+9DcyVj0GQOplTxNTv4vOEQXetf3u5PsfNxMXG0P61jXEREfpHZIQIalg12b2LJpMyeHd/nm12/cmte8jWGLr6BiZqI5C7XwoQlOlO+9MmzYtCGGIijKfcPedMw05VHRoMwDR9ToGPaZAe3j4UL7/cTP5BYW89+GnjLz/7nNe18o13wFwzVWXBSo8IUJG7IUdaT3mQw5/9xH7V76J11lCzravOPbbdzS49gGSut2GYqz0z7wIorz09QDEN++qcyRCBMd5DZBeE4TaFZqqqvz26QBUj5PazfqR1OG+Uy4XTgOk/53H46FD9xvYlZFJWkp9tv+4HJPp3E6OMkC6qCkceVnsXTKVY7+s9s+LSGpCw5ueILZRBx0jEyeSAdJFdXdel7KlpaU4nc5y8+TLFlyKomCOrIuzcP8ZSyyT2g+rwqgCy2g0MuqBwTwy/r/s3XeAz7/8mpv/cd05rWvic+MDHJ0Qockan0Szu14kL/0H9ix6CUfOPkqy/uK3WfdRp2MfUm94GHNMbb3DrPFS+4bPSB1CnItKl1gWFxfzxBNP8PHHH5OTk3PS6zJAevDt/WYCRYc2Y4tvxIW9X9U7nKCw20tofvFV5B7Lp3PHdqz5cp7eIQkRNrwuB4e++R8HVs1FdTsAMNqiaND7QRIvvUWqx8U5CcXzoQg9lR5u6PHHH2f16tXMmjULq9XKW2+9xXPPPUdycjLvvfdeMGIUf1PWztJZnK1zJMETGRnBvYNvB2DD5p/5ceNWnSMSInwYzFbq97yXdo8uIL5VDwA8pcXsXfwyO14dTFHmDp0jFEJUV5VOLJcsWcLrr7/OgAEDMJlMXH755Tz11FO88MILfPDBB8GIUfyNJUq7P7vXVYzHWXTKZTJWPU7GqserMqyAe2DYICwWbdSBGbPmntM6et04iF43DgpkWEKEDWutZJoPmUqzIa9grVUfAPvBdH6dOZSMT5/Hbc/XOcKa59fXh/Hr6+HbVEmIs6l0Ypmbm0vjxo0BrT1l2fBCl112Gd98801goxOnZI5K9D93Fp16EHFLdD0s0eF9N46kuhcw8OYbAfj8y6/ZvafyA503bpRK40apgQ5NiLCS0Opy2o6bT/1e96EYzaCqZP+0kJ9fGsCRTUvkphdVyFY7BVvtFL3DECJoKp1YNm7cmIyMDABatGjBxx9rPduWLFlCfHx8QIMTp2Y5Ycghl/3U1eH1uzwSVrdzPJ1RDwwGtN7wM9+ofFOLN2dMlNs5CgEYzDYaXPsAbcfOJ7apNv6tuziP3R8/x2+z7sOe9ZfOEdYMFw58Nixv5yhERVU6sRw6dCg///wzAOPHj2fmzJnYbDYeeeQRHnvssYAHKE5WkRLL6qJ1q2b0vLI7AO999Bm5x/L0DUiIMGe7IJUW975Gk0ETMcdog6gX7tnGL9MGkfnFdDwOu84RCiHC2XmPY7l37142b95MkyZNaNu2baDiChmh2AtOVVV+/+w2vO4SajXpQ72OD560TM6f2riNtZv2rerwAu7rtd/Tb+C9ADz377E8+vCpx+48lTfe1tr9PnCPtLMU4u/cpUUcWPkmWd/PB682ooclPpG0fzxKwkVXoiiKzhFWP1k/aLV8Sd1u0zmSygvF86EIPRUusfR6vUyePJnu3btzySWXMH78eEpKSkhLS+Pmm2+ulkllqFIUxV9qebqxLI/99SXH/vqyKsMKmp5XdOOils0AmPXW/04aO/VM5rzzEXPe+ShYoQkR1ky2aNJuHEvrh98jOrUNAM68w/z53mP8MfcRSnMP6Bxh9ZO9/hOy13+idxhCBE2FE8vnn3+ef/3rX0RHR1O/fn2mT5/OyJEjgxmbOANLtNbO0nWaIYdSLnuKlMueqsqQgkZRFB4aPgSArMNHWLCo4gnz/HdnMv/dmUGKTIjqISq5Oa1G/B+NBvwbY4RWEpX3+3f8MuU2Dqx+G6+74hdz4syaDZ5Cs8FT9A5DiKCpcFV406ZNefTRR3nggQcA+Prrr+nTpw8lJSUYDJVuqhk2QrXo/9CWN8n983MUo5WWAz6p9lVWDoeTlp16cjj7KK1bNefH1Qur/TYLoQdX0TEyv5zB0U1L/PNsdVJJ6/eY3N+6hgvV86EILRXOCDMzM7nhhhv8f/fq1QtFUTh48GBQAjudmTNn0rBhQ2w2G126dGHDhg1nXH7BggW0aNECm81GmzZt+PLL6lE9bInWqsJVjwOPI++k192OQtyOwiqOKnisVgvDfe0kd+xMZ+23P1bofbnH8qTDjxCVYI5O4MLbJtDywTlEJGpDy5UezST9/x7ij/cew5Fbtb/51Y3bni/jh4pqrcKJpdvtxmazlZtnNptxuVwBD+p05s+fz9ixY5kwYQJbtmyhXbt29O7dm+zsU1cH//DDD9xxxx0MGzaMrVu30r9/f/r378+OHeF/1wnzCUMOneoOPHtWP8Ge1U9UZUhBN2zwQCIitO/gjNkVGzD92n53cm2/O4MZlhDVUmyjDrQe8yGpfcdgsEYBcGzHGn5++VYOfP0WXpdD5wjD085Z97FzVsU7IAoRbipcFW4wGLj++uuxWq3+eUuWLOHqq68mKirKP++zzz4LfJQ+Xbp04ZJLLuG1114DtA5FKSkpPPTQQ4wfP/6k5QcOHEhxcTFLly71z7v00ktp3749s2fPrtBnhmrRf2neHnZ9NQqABl0fIy71inKvH/lVu7f2BRfdXuWxBdMj4//Dm3O1zjibvllCy+ZNzrj85KmzAHhi7Mk954UQFeMsOErml9PJ2bLMP89aq77We7zV5TpGFn4OrHoLgPo979U5ksoL1fOhCC0VTiyHDh1aoRXOnXtut947G6fTSWRkJJ988gn9+/f3zx88eDB5eXksXrz4pPekpqYyduxYxowZ4583YcIEFi1a5B+L8+8cDgcOx/Er8YKCAlJSUjhw8FBIHUgeVwl/LtEGD6/T6g7qtLhJ54iqRsbefXTvNQBVVfnnrf9gysSnT7mcqqqoHheqp8R/VxGtSWZZu8yyqVd7XfUCqv+51+NCdZfidTvwekrxehx43aWoqheD0YrBZMVgtGlTkw2DyYZiNKMYrL6p+aQ2oKqqonrdqB4nqteJ6nGiGEwYzNEoRou0Ga1iXo8Lj+MY7pJjeJxFeHy3SPU6i33PC1E9WqcV/4/kCT+XBrMNozkaoyUagzkKoyUaY9nUGovREoPBHIGiVJ826IV7t7Nv6TTsh3f558U160bqDQ9hrZWsY2QVo3o9qF4PisEAivG8jzmvx4XqcYHqQfst0daP6kVVvXhddjxOOx53EV6nHY/LjtdVpM132bWpu0S7Pa+rBK+7BED7zihGFMWIYjBqzw1G3++NFYPB95tjsmAw2jCaIzFYojFaYk74DmrPDeYobR0BUFBQQP3kepJYijMyVXTBYCWMFXX06FE8Hg+JiYnl5icmJvL777+f8j1ZWVmnXD4r6/SDik+cOJHnnnvupPl9Bj6I0WQ+h8iDKdI3Xex71AzNWrQCYPOOXVx54xB9gxGiRmp0/OnWQzD/X/qFUi15gKprZlZRHnfoxSRCT4UTy5riySefZOzYsf6/y0osv5g/K+Su0DJWP4kjbxeRdduS+rehhQ5vfxeAxLaDgxqD1+3E6yrA4yzWHq4i37QY1VWM21mEx1GIx1mA21GAx1GI11WI6nUHNS6hUYxWjNZ4jJZIDEYritFywtSCYjDidZVq/zdXWclJMaq7xFeyYwJDWcmJ2V/K43VrpStlJXqhQ+GE8sVzZjBFYDBHYTCd0K5cOaG0W/XidZfidRX7S5kCQjGcUEpl0B7gK1HHV2Kq+kvhtdLyCF+8EVop+omlpKqK6n+vFxQDRnMkRmsUBlO0r2QrGqMpGoMlCqM5AoMpSlvHKUq5tJL8EjyuYpz5WRz6Zj75v633v26OqUXdbn2JbNAEt7MQrzMft6MQj6NQO/6d2m+B11lMIP5P4cixvwjFaCLywlRtf/u+Z0ZzFAZThPY983q00k/VA16t9FP1unw1Jw7/sed1l6J6HGf8DtZucTMXtApMkyitxHJRQNYlqq+wSSzr1KmD0Wjk8OHyA4IfPnyYpKSkU74nKSmpUssDWK3Wcu1Iy0RHRRIdFXmKd+gnvlYSBfZdmN1HTootK+8XAP98VVXxukvwOApwO/JRvW5fdYt2ItOm2snI4yrG6yzyVQ/6ps4i7aTgKEsQ83E7ClA9FW/Ab/Q9zvitU4wYzRGgmFAMf6sKUgy+k53C73/uobDYjtFg5OL2bTCaLNoPtDkCoykSgzkSgzmCKa+9i8cLT44b4a/GVP0nNFXbdhRQFBTfFMWAwWjRTtrGsion31Qx+KvFve5Srbrc48DrKsHrq+L2erRq7rKp6nVryZzJqiVzxrKpBdXj0va3qwiP0+5L7LT9rVWj+RK9Suzn8hzgPgzusi3WykJOuetP/B8ZfI+yUpNTvdG/8OkZzFGYrLEYzFG+E6GWkHpcJb7qw0A7XbKiYLTGYY6ojSmyFmZbbUyRtbW/I2phssT6qhK16uzKVB2qXrfvwqqw/HHi1C6kjj8vwF2Sg6sk5wwJudf3+FvJ0N9bcPg/3AGufG3xkuPvPpOKXtL5k2ujxfc/s5/0PbTEQK1WCTgyC/CWuMGeQ+7X75IfZ8WaEoPBevxgV9AOfROApYJBAIrB5LsQ0pqeKP6mKFZfExKjL+lXtKptxeB7btBeN1ow+NahGMwoBpOvytqtNZfx+h4et++52/e6y1d17kb1ejCYLCck8ZFaMmiKQDFZtd8pxei7CDv+m6pVUUf5mkxo1dK/Th8MikLbAW9XfCecher1HP+tdhSW+y5G1GpKZIDOXV6PFAiIszvvWzpWpS5dutC5c2deffVVQOu8k5qayqhRo07becdut7NkyfHx2Lp160bbtm3DvvMOQNbPb5Pz+2coBhN1Wg3Ukhu33VeSUoLHbcfjKyX0OAt0KSXUEos4jNY4TNZYjNZY398xJ8zzTS2xGMyRFWr39MmiLxn8wDgAZrz0LMPuHhjsTdGV1+PSkk5nEaD621wdT7xNoHpxlx7DXZqHuzRXe16Si6v0GF5XiVay4Svx0BJfB6rX4y81MVqi/G2yjOZIMJjAd1LVTrZu39SL0Zd0GM2Rx6e+9x//f8acNkHT2pu6fAm5wxebS0vEPU68vjaoqur1XRB4Ub1aO1jK2qqedPJ3abGZozDZEjDZ4v0PoyU2YO3MzpeqqnichbjtR3GV5OCyH8XjyPeVUHlB9aB6vb7SKjdlFz7lEidFAa+v1NStHeteV4n/N0BVVd9xVJZoae32VNXjT4IDmdirqorriB3nwSLw+E4pCpiTYohMS8YUmeA/1o2WGN/zGIyWsqn20C64fG2UfUmgtD0OHaF8PhShI2xKLAHGjh3L4MGD6dSpE507d2batGkUFxf7Oxbdfffd1K9fn4kTJwIwevRorrjiCqZMmUKfPn2YN28emzZt4s0339RzMwLG4htySPW6ObLjg6B+lsEUof34W+Mw2bQk0H+isMZqJT2WaH9nBqMlGoPp1NVpgdC/77WkpiSTue8gr73xLkPvvDVsBupXVRWPx4Pb7cFkMmI0nr0TgcFoxmDUkqQzMdniAhhp8CiK4q+Or2kURcFk1Y4fW0JjXWLQajBKy5VsaRcuxb6OJUW+ziXFeN0OrSbAHF3uAkKrwrWilNUuGEy47YUcWvsRx7avARVchwopdRSR9o8HSGjVQ5dtDTWqqjVl8Hq9eDxevF7fwzfParFgtUpnPhG+wiqxHDhwIEeOHOGZZ54hKyuL9u3bs3z5cn8HnczMzHLJRbdu3fjwww956qmn+Ne//kXTpk1ZtGgRrVu31msTAiomuTPZOz7A49AG29WqiCL8VbaK0YolOvGEJNBXYmiJ0aphVa+/9yJlpSWgtcEyR59z1WBVMJlMjLj3LsZPmMwff2Xw1dfruP7aq05abtOW7QB0uli7l72qqtjtJRQUFlFQWITdXoK9pIRiewl2ewnFdjslJaUUFdspLrZTWFRMcbHd/7e9pASXy4XL5cblduNyuXG7tb89Hi9ujxu324PH48Xj8c1zu/F4vb75Hrze8pWViqJgsZixmM1YLGbMZVOTCbPZjMlkwmw2+f42+b/jZZUNJ1Y6mEwnvld7v9lswmQ0+ZJYAyajCaMvoTUYFG1bXC6cThdO39TlcqGqKgaD4W8PBYPB4D/p+ae+OlqP14PT6cLtdpdbn9vt9p9Q/x63No/jzzk+/8STr6oef64oitZsxWLBZrNgsViwWa1YrRaMBgPKCfEqyvGYDYr294kPg0HBbDJjsVqwWsxYrdr6tHVbiYyMICoygogIbVr2d2REhPa6bxpOiYCiKBjNEVqzk6i6gVtxLYi582IK9/zMnkWTsR/8A0fuAf54ZyzxLS4jrd+j2Go3CNjHqapKaakDe0kJJSWl2EtK/c+L7SWU2Euwl5RSUnaM+547fcew23ccO50uXG4XbrfH953zlDt2y/72+I9vD27fxaHb7S73Ho+3bNnj63C73f7lL4zTSop/P3r6RgsGg4HICBsRERFERtiIjNSe26xWLBYzNqsVm83q+95biIyIICoqkqhIbRodFUlkpDa9sHEazZvqcwEjaqawqgrXQ6gX/ateD153qZZMnpD8/bVsBABNrn9dr9CCrqCwiOYdrqKgsIjul3bkP0+N41BWNoeysjmYdZhDWdl8/uXXeD1e6iXVpaCwkPyCItxuaSckAi8iwuZPBmKiI4mKjCIqKpKY6Cj/yT4+LpZateKplRBP7YR4//P4uFgiImxE2KyYzaE2+sS5Ub0eDv/4Kfu/moWnRLsLmGKykHzF3SRdORinB/ILCykoKKKgoJD8wiLy8vLJLygkL7+AvLwC8gsKyc8voKCoyH+BV1RU7L/QK7aXEG6nsLf7RQBwz+IAdvo6g5H3382L/30yIOsK9fOhCA2SWJ5FuB5IeXvXAhCfdqWucQTbk8++yIxZwRsKKzIigujoKK3zVnQUkRE2rQTQX4pYViJoxGQ2YTQaMRm10kCTyYjRYMRgNGA2mzAajP6qb5PRiMFoxOvx+Ev1tKnT/1wrDXX7SkePl7CUlegpJ/bkUBRQVX8pqvZ+l790VSstcZ9QkqKVnnhVb/mSUt9zk0krGfVX0/kfKh6vVuJyvMQR/99GowGL+Xipa9lzbX3HSzlPKvEsN+/4fKPBiMFgwGj0lUAqin+/OZwuHE4njlIHDqeTUocDp9OJ16uWi9fr9aKi4vUer4I8XnqqtdV2u93auhzOk0qUq5rRaCTCZsVms2GzWbFZLb5OhZaTSqysVqu2rNWK1Xb8edl30WgwaFOjAaPBiNFkxGw2+f4vvu+vr4TbZPLta19pr9FoRPH9z7TS/OOl+nZ7CUXFdpwO5wklfsdL8J1Ol3951VHIlbH7uaTW8VvMZhWpvL7RwXeZwejAdWZlNQQn1ghYTtgHWkn+8f1mMpq0qcnkO26PPzeZtNf+/h7te6v4awvK9rvJaKKBZy8Gg4GjkU2177TxeI2Aoig4HE5KSo6XrmrTUortdhwO7Tei1OGgtFT7vpeUOvyvO50nDwf0xCPDeWb86IDsu3A9H4qqJYnlWciBFNr27T9Ih8v6UFJSWm6+2WwmKbEO9RLrUishntjYGOLjYoiNiSE2Npr4uFhioqN9VZw2bXpCFWdZEmk0hlYTABF8brebUocDh0NLNE9sKmEvKcFerP1dWlpW9aolANoJXku4yhKvE0vZCouKycsvqLEl5i3rGBh9qYVmtY8fUxsPuHltg5N9BSefhkwmE/FxsSTExxITE010lHaBV1b6e2LVb6SvyjgiIoIIm5WIyLIq5Aj/a2XPq3P7RafT6f+uln0P69ROIKVBYAavl/OhqAhJLM9CDqTQ9/OO39i2fSeJdetQL6kuyUmJ1K4VHzadeUTNoaoqhUXF5ObmkZN7jJxjeeTm5pFfUEBJqQNHqUNLUEtLKS0t1eY5nNodwZxOSkuPP3c4HJSWOn1JsPa+0lKHLlXDJtMJpaC+tr2RETaioqLKtUuNirTRLuoo7ZV0LKrvrkaKAUdaD8xtbyK+Tl3i42L9TQOqawIYruR8KCpCEsuzCNcDKfPb/wCQevkzOkeir1vv0tqaLvhf9W1rKkQZVVX9naXKdzrx+Kv8/VXXvk5bLpfW9KKs44nXq41aoPqaEqiqSkSkjajISO0RVZYoRmKzWjCZKj8kkKs4j/0rZpP946f+thTm2AtI7TOa2u17V+uEMn3uIwA0H/qKzpFUXrieD0XVCqte4UIIIU5P6y2vDVcTysxR8TS6aTx1L+nPnsUvUrR3O66CI+z66Cmyf1pIw/6PE5l0od5hCiHOgZRYnoVcoQkhRPCoXi9Ht3xJ5pczcBflAqAYjCRedgcNet2H0Ralc4SijJwPRUVIYnkWciAJIUTwuUsK2b9iNod/WOC/N3pNqR4PF3I+FBUhieVZhOuBVFOGGzqb+Z8uBWDggL46RyKEqIjig+nsWfQiRXt+9s+LadyRhjc9QWRi+A/0fXTrcgDqdLhO50gqL1zPh6JqSWJ5FuF6INWEAdIrolMPLaHc9M1SnSMRQlTU6arHk3rcSf1e92K0ROgc4bnbPuU2ANqO+1jnSCovXM+HompJYnkW4Xog2XPSAYis3VznSPT191s6CiHCh7ukkP1fzeLw+k/81eOW+ETSbhxHQuurwrJ6vChzBwDRqeF3a+FwPR+KqiWJ5VnIgSSEEPoq3v87GQsnUrzvV/+8uObdaNj/8YDee1ycmZwPRUVIYnkWciAJIYT+VK+XIxsXs2/Za7jt+YDv3uNXDSH5ysEYzFadI6z+5HwoKkJuTVJN/bVshL+dZU3WqUdffztLIUT4UgwG6na5ibaPfcoFl/QDQHU7ObDyTbZPuY28377TOcKK2T7lNn87SyGqIxkgvZqKSuqgdwgh4eoruusdghAigMxR8TS+9WkuuOQf7Fk4GfuhP3DkHiB97hgSLrqStH+Mw5pQT+8wTyuuaRe9QxAiqKQq/Cyk6F8IIUKT6nFz+MdP2P/VLDylxQAYzFaSew6jXo87MZhC+w5E4UbOh6IipCpcCCFEWFKMJpK6307bxz6lzsU3AOB1Odi//HV+mXo7+X/+pHOEQtQ8UmJ5FuF6hXbk13kAXHDR7TpHoq/JU2cB8MTYB3WORAgRbAW7t7Bn4SRKDu/2z6vV7hrS+o7FEneBjpEdd2DVWwDU73mvzpFUXrieD0XVkhLLaio/8xvyM7/ROwzdLVj0BQsWfaF3GEKIKhDb+GJaj/mQ1L5jMFgiAcj9eSU/v3wLWd99hOpx6xwh5GxbQc62FXqHIUTQSInlWYTrFZrbUQiAyRqjcyT6yj2WB0CthHhd4xBCVC1H3mEyl75C7vav/fMi6zWj4c3jiUnT74YJZUMlmSLjdIvhXIXr+VBULUksz0IOJCGECF956evZs+hFHDn7/PMu6NyflOtHYY6K1y+wMCTnQ1ERUhVeTTkKD+IoPKh3GLrblbGXXRl79Q5DCKGT+OZdaTt2HvWveQDF10v8yIZFbH/5Fo5s/BzV663SeEqP7qP06L6zLyhEmJISy7MI1yu0ssHRm1z/us6R6KtscPRN3yzVORIhhN5Kj+5jz+KXyE//wT8vpmF7Gt48nsikJlUSQ9ng6G3HfVwlnxdI4Xo+FFVLBkivphKa3KB3CCHhviF36B2CECJE2Oqk0Pye6eT+soq9n0/BVXCEwj3b2DFtEEmX/5P619yP0RIR1Bjqdr0lqOsXQm9SYnkWcoUmhBDVj7u0iAMr3iDr+/mgatXhlvhE0vo9Rq2LrtQ3uBAl50NREZJYnoUcSEIIUX0VH0wn47OJFGfu8M+Lb3k5Dfs9hrVWso6RhR45H4qKkMTyLML1QDrw0ysA1O/yiM6R6Ov+h58E4M0ZE3WORAgRqlSvlyMbFpG57DU8JQWAdmvI+r3uI+nyQRhM5oB91q75zwJw4cBnA7bOqhKu50NRtaRXeDXlLDqEs+iQ3mHobndGJrszMvUOQwgRwhSDgbqX3ky7xz6hTsc+gHZryH3LXmPH9EEU7NocsM8qzdlHaY70ChfVl5RYnoVcoQkhRM1SsGszGQsnUZqd4Z9Xp2NfUvuMxhydoGNk+pLzoagIKbEUQgghThB7YUfajPmQlOtHYTBbATi6eSnbX76F7A2LqnzsSyHCSdgklrm5uQwaNIjY2Fji4+MZNmwYRUVFZ1z+oYceonnz5kRERJCamsrDDz9Mfn5+FUatn6JDmyk6FLjqm3C1cs13rFzznd5hCCHCjMFkJvmqIbQdt4D4FpcB2u0YMz75f/w2+37sWbvOab156evJS18fyFCFCClhM47loEGDOHToECtXrsTlcjF06FDuv/9+Pvzww1Muf/DgQQ4ePMjLL79Mq1at2Lt3L8OHD+fgwYN88sknVRx91cva9n8ANKnXUedI9PXkhEkAXHOVDJAuhKg8a61kmg19hWM71rDn85dx5Wf7xr78J0lX3EX9nvditNgqvL7MpVrHyvjmXYMVshC6Cos2lr/99hutWrVi48aNdOrUCYDly5dzww03sH//fpKTKzYkxIIFC7jzzjspLi7GZKpYTh2ubUrKSiuja3hiWVZaec1Vl+kciRAi3HlKi9m/Yna5sS+tterT8KYniG/erULrKCutDMfEMlzPh6JqhUWJ5fr164mPj/cnlQC9evXCYDDw008/cdNNN1VoPWUHw5mSSofDgcPh8P9dUFBw7oHrqKYnlGUkoRRCBIrRFkXaP8ZRp2MfMj57geJ9O3HkHiD9/x6mdvvepN04FnNM7TOuIxwTSiEqIyzaWGZlZVG3bt1y80wmE7Vq1SIrK6tC6zh69Cj//e9/uf/++8+43MSJE4mLi/M/UlJSzjluIYQQ1U9U/RZcNHIuaf0fx2CNAiBn21f8/PKtWuee0K8IFCJodE0sx48fj6IoZ3z8/vvv5/05BQUF9OnTh1atWvHss8+ecdknn3yS/Px8/2PfvvAcbyxj1eNkrHpc7zB01+vGQfS6cZDeYQghqhnFYCSp2220e3QBCa2vAsBTUqB17nnjAUqy95zyfb++PoxfXx9WhZEKUbV0rQofN24cQ4YMOeMyjRs3Jikpiezs7HLz3W43ubm5JCUlnfH9hYWFXHfddcTExLBw4ULM5jPfQcFqtWK1WisUfyizRNfTO4SQ0LhRqt4hCCGqMUtcXZrd/RK5O9ayZ/GLWuee3Vv45ZU7iExuCijllnfkHADg19eGgqKAoqAohuNTgxGD0QQGI4rRhMFgQjGaUAxGbZ5iQDEaQTGiGAwoihGMRgyGsvcYUQxGFIMJxWgkqn4LYhq2r/odI2qssOq8s2nTJjp21NoOrlixguuuu+6MnXcKCgro3bs3VquVL7/8ksjIyEp/tjRWFkIIURHu0iL2fzWLwz98DCFyaq3X4y5S+44OyLrkfCgqIiw677Rs2ZLrrruO++67j9mzZ+NyuRg1ahS33367P6k8cOAAPXv25L333qNz584UFBRw7bXXYrfbef/99ykoKPB3xLngggswGo16bpIQQohqxmSLpmG/x6jT4Xqyvv0Qd+lpxlpWVUBFVb2gqr4B11XwelG9Hu3hcaN63b6p5/hU9ULZMr7lUbXXT0UxhsVpXlQjYfON++CDDxg1ahQ9e/bEYDAwYMAAZsyY4X/d5XKRnp6O3W4HYMuWLfz0008ANGnSpNy6MjIyaNiwYZXFroecP7VxG2s37atzJPp64+0PAHjgHmlnKYSoGtGprWky6IVTvpb1w8cAJHW7LeCfqyWaZYmoB9XrxmCyBPxzhDiTsKgK11O4Fv3/tWwEAE2uf13nSPTVqYeWWG/6RgZIF0Lob/sULaFsO+5jnSOpvHA9H4qqFTYllqJyUi57Su8QQsL8d2fqHYIQQvg1GzxF7xCECCpJLKspa0zF7kZU3V3YKE3vEIQQws9WR8ZGFtVbWAyQLirP7SjE7SjUOwzd5R7LI/dYnt5hCCEEAG57Pm57vt5hCBE0UmJZTe1Z/QQgbSyv7XcnIG0shRChYees+4DwbGMpREVIYllNxaX20DuEkHBr/z56hyCEEH6121+rdwhCBJX0Cj8L6QUnhBBCyPlQVIy0sRRCCCGEEAEhiWU1dWjrHA5tnaN3GLp7/OmJPP70RL3DEEIIAPZ+PoW9n8uQQ6L6kjaWZ1HWUqDsdpDhImu3dtehqAsH6hyJvlauWgtAwWMj9Q1ECCGAA798B0DClffpHEnllZ0HpQWdOBNpY3kW+/fvJyVFxh0TQgghAPbt20eDBg30DkOEKEksz8Lr9XLw4EFiYmJQFKXC7ysoKCAlJYV9+/bV2EbOsg9kH4DsgzKyH2QfQHjvA1VVKSwsJDk5GYNBWtKJU5Oq8LMwGAzndWUWGxsbdj8egSb7QPYByD4oI/tB9gGE7z6Ii4vTOwQR4uSSQwghhBBCBIQklkIIIYQQIiAksQwSq9XKhAkTsFqteoeiG9kHsg9A9kEZ2Q+yD0D2gaj+pPOOEEIIIYQICCmxFEIIIYQQASGJpRBCCCGECAhJLIUQQgghREBIYimEEEIIIQJCEssgmDlzJg0bNsRms9GlSxc2bNigd0hB9c0333DjjTeSnJyMoigsWrSo3OuqqvLMM89Qr149IiIi6NWrF3/++ac+wQbJxIkTueSSS4iJiaFu3br079+f9PT0csuUlpYycuRIateuTXR0NAMGDODw4cM6RRx4s2bNom3btv6Bn7t27cqyZcv8r1f37T+VSZMmoSgKY8aM8c+r7vvh2WefRVGUco8WLVr4X6/u21/mwIED3HnnndSuXZuIiAjatGnDpk2b/K/XhN9FUTNJYhlg8+fPZ+zYsUyYMIEtW7bQrl07evfuTXZ2tt6hBU1xcTHt2rVj5syZp3z9xRdfZMaMGcyePZuffvqJqKgoevfuTWlpaRVHGjzr1q1j5MiR/Pjjj6xcuRKXy8W1115LcXGxf5lHHnmEJUuWsGDBAtatW8fBgwe5+eabdYw6sBo0aMCkSZPYvHkzmzZt4uqrr6Zfv378+uuvQPXf/r/buHEjb7zxBm3bti03vybsh4suuohDhw75H999953/tZqw/ceOHaN79+6YzWaWLVvGzp07mTJlCgkJCf5lasLvoqihVBFQnTt3VkeOHOn/2+PxqMnJyerEiRN1jKrqAOrChQv9f3u9XjUpKUl96aWX/PPy8vJUq9WqfvTRRzpEWDWys7NVQF23bp2qqto2m81mdcGCBf5lfvvtNxVQ169fr1eYQZeQkKC+9dZbNW77CwsL1aZNm6orV65Ur7jiCnX06NGqqtaM78GECRPUdu3anfK1mrD9qqqqTzzxhHrZZZed9vWa+rsoagYpsQwgp9PJ5s2b6dWrl3+ewWCgV69erF+/XsfI9JORkUFWVla5fRIXF0eXLl2q9T7Jz88HoFatWgBs3rwZl8tVbj+0aNGC1NTUarkfPB4P8+bNo7i4mK5du9a47R85ciR9+vQpt71Qc74Hf/75J8nJyTRu3JhBgwaRmZkJ1Jzt//zzz+nUqRO33nordevWpUOHDsyZM8f/ek39XRQ1gySWAXT06FE8Hg+JiYnl5icmJpKVlaVTVPoq2+6atE+8Xi9jxoyhe/futG7dGtD2g8ViIT4+vtyy1W0//PLLL0RHR2O1Whk+fDgLFy6kVatWNWb7AebNm8eWLVuYOHHiSa/VhP3QpUsX3nnnHZYvX86sWbPIyMjg8ssvp7CwsEZsP8Du3buZNWsWTZs25auvvuLBBx/k4Ycf5t133wVq5u+iqDlMegcgRHUzcuRIduzYUa5dWU3RvHlztm3bRn5+Pp988gmDBw9m3bp1eodVZfbt28fo0aNZuXIlNptN73B0cf311/uft23bli5dupCWlsbHH39MRESEjpFVHa/XS6dOnXjhhRcA6NChAzt27GD27NkMHjxY5+iECC4psQygOnXqYDQaT+rhePjwYZKSknSKSl9l211T9smoUaNYunQpa9asoUGDBv75SUlJOJ1O8vLyyi1f3faDxWKhSZMmdOzYkYkTJ9KuXTumT59eY7Z/8+bNZGdnc/HFF2MymTCZTKxbt44ZM2ZgMplITEysEfvhRPHx8TRr1oy//vqrxnwP6tWrR6tWrcrNa9mypb9JQE37XRQ1iySWAWSxWOjYsSOrVq3yz/N6vaxatYquXbvqGJl+GjVqRFJSUrl9UlBQwE8//VSt9omqqowaNYqFCxeyevVqGjVqVO71jh07Yjaby+2H9PR0MjMzq9V++Duv14vD4agx29+zZ09++eUXtm3b5n906tSJQYMG+Z/XhP1woqKiInbt2kW9evVqzPege/fuJw039scff5CWlgbUnN9FUUPp3Xuoupk3b55qtVrVd955R925c6d6//33q/Hx8WpWVpbeoQVNYWGhunXrVnXr1q0qoE6dOlXdunWrunfvXlVVVXXSpElqfHy8unjxYnX79u1qv3791EaNGqklJSU6Rx44Dz74oBoXF6euXbtWPXTokP9ht9v9ywwfPlxNTU1VV69erW7atEnt2rWr2rVrVx2jDqzx48er69atUzMyMtTt27er48ePVxVFUVesWKGqavXf/tM5sVe4qlb//TBu3Dh17dq1akZGhvr999+rvXr1UuvUqaNmZ2erqlr9t19VVXXDhg2qyWRSn3/+efXPP/9UP/jgAzUyMlJ9//33/cvUhN9FUTNJYhkEr776qpqamqpaLBa1c+fO6o8//qh3SEG1Zs0aFTjpMXjwYFVVtaE1nn76aTUxMVG1Wq1qz5491fT0dH2DDrBTbT+gzp07179MSUmJOmLECDUhIUGNjIxUb7rpJvXQoUP6BR1g99xzj5qWlqZaLBb1ggsuUHv27OlPKlW1+m//6fw9sazu+2HgwIFqvXr1VIvFotavX18dOHCg+tdff/lfr+7bX2bJkiVq69atVavVqrZo0UJ98803y71eE34XRc2kqKqq6lNWKoQQQgghqhNpYymEEEIIIQJCEkshhBBCCBEQklgKIYQQQoiAkMRSCCGEEEIEhCSWQgghhBAiICSxFEIIIYQQASGJpRBCCCGECAhJLIUQQgghREBIYimE0N2ePXtQFIVt27bpug4hhBDnx6R3AEKI0DJkyBDy8vJYtGhRlX1mSkoKhw4dok6dOlX2mUIIIQJPSiyFELozGo0kJSVhMoXeta7T6dQ7BCGECBuSWAohKmXq1Km0adOGqKgoUlJSGDFiBEVFReWWmTNnDikpKURGRnLTTTcxdepU4uPjT7vOv1djr127FkVRWLVqFZ06dSIyMpJu3bqRnp5+1vh+//13unXrhs1mo3Xr1qxbt87/msfjYdiwYTRq1IiIiAiaN2/O9OnTy71/yJAh9O/fn+eff57k5GSaN28OwOuvv07Tpk2x2WwkJiZyyy23VHCPCSFEzSGJpRCiUgwGAzNmzODXX3/l3XffZfXq1Tz++OP+17///nuGDx/O6NGj2bZtG9dccw3PP//8OX3Wv//9b6ZMmcKmTZswmUzcc889Z33PY489xrhx49i6dStdu3blxhtvJCcnBwCv10uDBg1YsGABO3fu5JlnnuFf//oXH3/8cbl1rFq1ivT0dFauXMnSpUvZtGkTDz/8MP/5z39IT09n+fLl9OjR45y2SQghqjVVCCFOMHjwYLVfv34VXn7BggVq7dq1/X8PHDhQ7dOnT7llBg0apMbFxZ12HRkZGSqgbt26VVVVVV2zZo0KqF9//bV/mS+++EIF1JKSkjOuY9KkSf55LpdLbdCggTp58uTTfvbIkSPVAQMG+P8ePHiwmpiYqDocDv+8Tz/9VI2NjVULCgpOux4hhBCqKiWWQohK+frrr+nZsyf169cnJiaGu+66i5ycHOx2OwDp6el07ty53Hv+/ndFtW3b1v+8Xr16AGRnZ5/xPV27dvU/N5lMdOrUid9++80/b+bMmXTs2JELLriA6Oho3nzzTTIzM8uto02bNlgsFv/f11xzDWlpaTRu3Ji77rqLDz74wL+9QgghjpPEUghRYXv27KFv3760bduWTz/9lM2bNzNz5kwgOJ1czGaz/7miKIBWnX2u5s2bx6OPPsqwYcNYsWIF27ZtY+jQoSfFHhUVVe7vmJgYtmzZwkcffUS9evV45plnaNeuHXl5eeccixBCVEeSWAohKmzz5s14vV6mTJnCpZdeSrNmzTh48GC5ZZo3b87GjRvLzfv738H0448/+p+73W42b95My5YtAa39Z7du3RgxYgQdOnSgSZMm7Nq1q0LrNZlM9OrVixdffJHt27ezZ88eVq9eHZRtEEKIcBV6Y3sIIXSXn59/0kDjtWvXpkmTJrhcLl599VVuvPFGvv/+e2bPnl1uuYceeogePXowdepUbrzxRlavXs2yZcv8JY7BNnPmTJo2bUrLli155ZVXOHbsmL/TT9OmTXnvvff46quvaNSoEf/73//YuHEjjRo1OuM6ly5dyu7du+nRowcJCQl8+eWXeL1ef49xIYQQGimxFEKcZO3atXTo0KHc47nnnqNdu3ZMnTqVyZMn07p1az744AMmTpxY7r3du3dn9uzZTJ06lXbt2rF8+XIeeeQRbDZblcQ+adIkJk2aRLt27fjuu+/4/PPP/QOvP/DAA9x8880MHDiQLl26kJOTw4gRI866zvj4eD777DOuvvpqWrZsyezZs/noo4+46KKLgr05QggRVhRVVVW9gxBCVG/33Xcfv//+O99++63eoQghhAgiqQoXQgTcyy+/zDXXXENUVBTLli3j3Xff5fXXX9c7LCGEEEEmJZZCiIC77bbbWLt2LYWFhTRu3JiHHnqI4cOH6x2WEEKIIJPEUgghhBBCBIR03hFCCCGEEAEhiaUQQgghhAgISSyFEEIIIURASGIphBBCCCECQhJLIYQQQggREJJYCiGEEEKIgJDEUgghhBBCBIQklkIIIYQQIiD+P+IY1028KtrLAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Panel autocorrelation of each forward-return label against lag in bars."
+      }
+     },
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "LABELS_DIR.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "# Save individual label files\n",
-    "key_cols = [\"timestamp\", \"symbol\"]\n",
-    "\n",
-    "for label_col in [\"fwd_ret_5m\", \"fwd_ret_15m\", \"fwd_ret_60m\", \"fwd_dir_15m\"]:\n",
-    "    subset = df_clean.select(key_cols + [label_col]).drop_nulls(subset=[label_col])\n",
-    "    subset.write_parquet(LABELS_DIR / f\"{label_col}.parquet\")\n",
-    "    print(f\"Saved labels/{label_col}.parquet ({len(subset):,} rows)\")"
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "lags = np.arange(1, max_lag + 1)\n",
+    "for name, colour in PALETTE.items():\n",
+    "    ax.plot(lags, acf[name], lw=1.8, color=colour, label=name)\n",
+    "    ax.axvline(HORIZON_BARS[name], color=colour, linestyle=\":\", lw=1.2)\n",
+    "ax.axhline(0, color=COLORS[\"neutral\"], lw=0.8)\n",
+    "ax.set_xlabel(\"Lag in bars\")\n",
+    "ax.set_ylabel(\"Panel autocorrelation\")\n",
+    "sub = \"Dotted lines mark each horizon; pooled across symbol-sessions on the development window\"\n",
+    "add_message_title(ax, \"Overlap decays linearly with lag at every horizon\", sub)\n",
+    "ax.legend(loc=\"upper right\", frameon=False)\n",
+    "show_with_alt(fig, \"Panel autocorrelation of each forward-return label against lag in bars.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "id": "b6607a81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:30.871390Z",
-     "iopub.status.busy": "2026-07-14T04:54:30.871261Z",
-     "iopub.status.idle": "2026-07-14T04:54:32.707822Z",
-     "shell.execute_reply": "2026-07-14T04:54:32.707360Z"
+     "iopub.execute_input": "2026-07-31T09:15:24.858867Z",
+     "iopub.status.busy": "2026-07-31T09:15:24.858796Z",
+     "iopub.status.idle": "2026-07-31T09:18:16.853759Z",
+     "shell.execute_reply": "2026-07-31T09:18:16.853345Z"
     },
     "papermill": {
      "duration": 1.840498,
@@ -1148,33 +1390,92 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CV config: 2 folds from setup.yaml evaluation section\n"
+      "fwd_ret_15m: N=14,370,375, N_eff=993,791, ratio 0.0692 against 0.0667 for windows overlapping this fully; autocorrelation 0.920 at lag one and -0.038 at its horizon\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_5m: N=14,753,585, N_eff=2,981,374, ratio 0.2021 against 0.2000 for windows overlapping this fully; autocorrelation 0.741 at lag one and -0.023 at its horizon\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_60m: N=12,645,930, N_eff=248,448, ratio 0.0196 against 0.0167 for windows overlapping this fully; autocorrelation 0.976 at lag one and -0.219 at its horizon\n"
      ]
     }
    ],
    "source": [
-    "# CV splits (generated at runtime from setup.yaml, not saved as file)\n",
-    "splits = generate_cv_splits(\n",
-    "    df_clean,\n",
-    "    case_study_id=\"nasdaq100_microstructure\",\n",
-    "    label_buffer=\"15min\",\n",
-    "    date_col=\"timestamp\",\n",
-    ")\n",
-    "print(f\"CV config: {len(splits)} folds from setup.yaml evaluation section\")"
+    "for name in RETURN_LABELS:\n",
+    "    h_bars = HORIZON_BARS[name]\n",
+    "    n_rows, n_eff = effective_sample_size(\n",
+    "        dev[name], horizon=h_bars, bar_col=\"bar_in_session\", entity_col=\"entity\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against \"\n",
+    "        f\"{1 / h_bars:.4f} for windows overlapping this fully; autocorrelation \"\n",
+    "        f\"{acf[name][0]:.3f} at lag one and {acf[name][h_bars - 1]:.3f} at its horizon\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d0c11d8",
+   "metadata": {
+    "tags": [
+     "results"
+    ]
+   },
+   "source": [
+    "The primary label's 14,370,375 development rows carry 993,791 effective observations, a\n",
+    "ratio of 0.0692 against the 0.0667 a fully overlapped 15-bar window implies; the 5-minute\n",
+    "label's 14,753,585 rows carry 2,981,374 at 0.2021 against 0.2000, and the 60-minute label's\n",
+    "12,645,930 carry 248,448 at 0.0196 against 0.0167. Each sits above its reference because a\n",
+    "session end closes an overlap early, and the longest label sits furthest above it because\n",
+    "the session ends most often relative to its window. Fourteen million rows are worth about a\n",
+    "million: the row count overstates the evidence by a factor of fifteen, which is the horizon.\n",
+    "\n",
+    "Autocorrelation falls from 0.920 at lag one to -0.038 at lag fifteen for the primary label\n",
+    "and from 0.741 to -0.023 at lag five for the fast one. The 60-minute label falls from 0.976\n",
+    "to -0.219 at lag sixty, crossing zero around lag fifty. The purge gap a fold needs is set by\n",
+    "the forward window itself, not by any of these counts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "034725e0",
+   "metadata": {},
+   "source": [
+    "## G. Baseline floor\n",
+    "\n",
+    "One signal against the primary label on the sealed development window, with no feature\n",
+    "engineering: the trailing return over the same span as the label looks forward. If the\n",
+    "order flow of the last fifteen minutes carries information about the next fifteen, the\n",
+    "simplest form it can take is that the move continues or that it reverses, and Chapter 8's\n",
+    "features have to beat whatever that is worth before they have earned their place.\n",
+    "\n",
+    "The information coefficient is the cross-sectional rank correlation across the symbols\n",
+    "priced at each decision minute, averaged over minutes, which is the quantity a ranking\n",
+    "model is scored on. The minimum cross-section is half the median rather than a bare\n",
+    "count, so it means the same thing on a universe of another size. The standard error is\n",
+    "HAC-adjusted: consecutive decision minutes share fourteen of their fifteen bars of\n",
+    "outcome, and a naive statistic would count each of them as fresh evidence."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 26,
    "id": "600dd3b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T04:54:32.712148Z",
-     "iopub.status.busy": "2026-07-14T04:54:32.712049Z",
-     "iopub.status.idle": "2026-07-14T04:54:32.860103Z",
-     "shell.execute_reply": "2026-07-14T04:54:32.859642Z"
+     "iopub.execute_input": "2026-07-31T09:18:16.854792Z",
+     "iopub.status.busy": "2026-07-31T09:18:16.854718Z",
+     "iopub.status.idle": "2026-07-31T09:18:21.052953Z",
+     "shell.execute_reply": "2026-07-31T09:18:21.052434Z"
     },
-    "lines_to_next_cell": 0,
     "papermill": {
      "duration": 0.150688,
      "end_time": "2026-07-14T04:54:32.860552+00:00",
@@ -1185,45 +1486,61 @@
    },
    "outputs": [],
    "source": [
-    "# Results JSON for chapter agent\n",
-    "results = {\n",
-    "    \"case_study_id\": \"nasdaq100_microstructure\",\n",
-    "    \"chapter\": 7,\n",
-    "    \"stage\": \"labels\",\n",
-    "    \"timestamp\": datetime.now(UTC).isoformat(),\n",
-    "    \"git_commit\": \"unknown\",\n",
-    "    \"notebook\": \"case_studies/nasdaq100_microstructure/code/02_labels.py\",\n",
-    "    \"summary\": {\n",
-    "        \"n_rows\": len(df_clean),\n",
-    "        \"n_symbols\": df_clean[\"symbol\"].n_unique(),\n",
-    "        \"n_sessions\": df_clean[\"session_date\"].n_unique(),\n",
-    "        \"labels\": [\"fwd_ret_5m\", \"fwd_ret_15m\", \"fwd_ret_60m\", \"fwd_dir_15m\"],\n",
-    "        \"primary_label\": \"fwd_ret_15m\",\n",
-    "    },\n",
-    "    \"techniques\": [\n",
-    "        \"midprice-based forward returns\",\n",
-    "        \"session-bounded computation\",\n",
-    "        \"1-bar execution delay\",\n",
-    "        \"cost-sanity check\",\n",
-    "    ],\n",
-    "    \"diagnostics\": {\n",
-    "        \"label_stats\": label_stats,\n",
-    "        \"cost_check\": cost_check,\n",
-    "        \"baseline_ic\": {\n",
-    "            \"signal\": \"lagged_15m_return\",\n",
-    "            \"mean_ic\": round(baseline_ic_mean, 5),\n",
-    "            \"ic_t_stat\": round(baseline_ic_t, 2),\n",
-    "            \"n_observations\": len(baseline_ic),\n",
-    "        },\n",
-    "        \"label_autocorrelation\": autocorr_results,\n",
-    "    },\n",
-    "    \"key_findings\": [\n",
-    "        f\"Primary label fwd_ret_15m: mean={label_stats['15m']['mean']:.6f}, std={label_stats['15m']['std']:.6f}\",\n",
-    "        f\"Cost dominance confirmed: {cost_check['15m']['pct_exceeds_cost']:.0f}% of 15m returns exceed half-spread\",\n",
-    "        f\"Baseline IC (lagged 15m return): {baseline_ic_mean:.5f} (t={baseline_ic_t:.2f})\",\n",
-    "        \"Direction label (5bps threshold): ternary up/flat/down with 5 bps cost-motivated threshold\",\n",
-    "    ],\n",
-    "}"
+    "_h = HORIZON_BARS[PRIMARY_LABEL]\n",
+    "_trailing = pl.col(\"mid_close\") / pl.col(\"mid_close\").shift(_h).over(GROUP_COLS) - 1\n",
+    "baseline = (\n",
+    "    labels_df.with_columns(\n",
+    "        _trailing.alias(\"trailing_return\"),\n",
+    "        pl.col(\"timestamp\").shift(-_h).over(GROUP_COLS).alias(\"_label_end\"),\n",
+    "    )\n",
+    "    .filter(pl.col(\"_label_end\") < HOLDOUT_TS)\n",
+    "    .drop_nulls([PRIMARY_LABEL, \"trailing_return\"])\n",
+    ")\n",
+    "min_obs = int(baseline.group_by(\"timestamp\").len()[\"len\"].median() // 2)\n",
+    "\n",
+    "ic = cross_sectional_ic_series(\n",
+    "    baseline,\n",
+    "    baseline,\n",
+    "    pred_col=\"trailing_return\",\n",
+    "    ret_col=PRIMARY_LABEL,\n",
+    "    date_col=\"timestamp\",\n",
+    "    entity_col=\"symbol\",\n",
+    "    min_obs=min_obs,\n",
+    ").sort(\"timestamp\")  # HAC autocovariances are meaningless over a permutation of time\n",
+    "stats = compute_ic_hac_stats(ic, ic_col=\"ic\", label_horizon=_h)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "e662a973",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:18:21.054149Z",
+     "iopub.status.busy": "2026-07-31T09:18:21.054076Z",
+     "iopub.status.idle": "2026-07-31T09:18:21.056540Z",
+     "shell.execute_reply": "2026-07-31T09:18:21.056115Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline: trailing 0:15:00 return against fwd_ret_15m\n",
+      "  13,795,560 rows, minimum cross-section 51 symbols\n",
+      "  decision minutes scored 135,720, mean IC -0.00798, HAC t -6.02 on 19 Bartlett lags, naive t -16.78, p 1.74e-09\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Baseline: trailing {PRIMARY_HORIZON} return against {PRIMARY_LABEL}\")\n",
+    "print(f\"  {baseline.height:,} rows, minimum cross-section {min_obs} symbols\")\n",
+    "print(\n",
+    "    f\"  decision minutes scored {ic.height:,}, mean IC {stats['mean_ic']:.5f}, \"\n",
+    "    f\"HAC t {stats['t_stat']:.2f} on {stats['effective_lags']} Bartlett lags, \"\n",
+    "    f\"naive t {stats['naive_t_stat']:.2f}, p {stats['p_value']:.3g}\"\n",
+    ")"
    ]
   },
   {
@@ -1236,27 +1553,219 @@
      "exception": false,
      "start_time": "2026-07-14T04:54:32.862378+00:00",
      "status": "completed"
-    }
+    },
+    "tags": [
+     "results"
+    ]
    },
    "source": [
-    "## Key Takeaways\n",
+    "The trailing 15-minute return earns a mean information coefficient of -0.00798 against the\n",
+    "primary label, over 135,720 scored decision minutes drawn from 13,795,560 rows on a\n",
+    "cross-section of at least 51 symbols. The sign is negative, so on this universe the recent\n",
+    "move tends to give part of itself back rather than continue.\n",
     "\n",
-    "1. **Midprice labels** avoid bid-ask bounce contamination that would add noise\n",
-    "   to trade-price returns — essential for intraday microstructure research\n",
-    "2. **Session-bounded** forward returns prevent overnight gap artifacts\n",
-    "3. **1-bar execution delay** reflects realistic entry timing: you observe at\n",
-    "   bar close, enter at next bar's midprice\n",
-    "4. **Cost-sanity check** quantifies what fraction of returns exceed the\n",
-    "   half-spread — the primary feasibility gate for intraday strategies\n",
-    "5. **Three horizons** (5m, 15m, 60m) demonstrate signal decay: microstructure\n",
-    "   content is highest at short horizons but so are costs\n",
-    "6. **Baseline IC** from lagged returns establishes the reference bar that\n",
-    "   Ch8 engineered features must exceed\n",
-    "7. **Label autocorrelation** reveals how quickly predictive content decays,\n",
-    "   informing purge/embargo settings for walk-forward CV\n",
+    "The Newey-West rule picks 19 Bartlett lags and returns a t-statistic of -6.02 against a\n",
+    "naive -16.78, so pricing in the overlap cuts the apparent evidence by nearly two thirds -\n",
+    "and what is left is still far from zero, at p 1.74e-09. That is the floor: a feature that\n",
+    "ranks the cross-section no better than the last quarter-hour of price has added nothing.\n",
+    "It is a floor on ranking, not on profit - a coefficient of this size is small next to the\n",
+    "round trip Section E priced, which is the tension the rest of the case study works through."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04e3671",
+   "metadata": {},
+   "source": [
+    "## H. Artifacts and the audit record\n",
     "\n",
-    "**Next**: `03_financial_features.py` engineers microstructure features from the raw\n",
-    "minute bar data (order flow, liquidity, volatility, Kyle's lambda)."
+    "Each label is written with a digest sidecar beside it, recording the content digest of\n",
+    "the values written, the row count, the key columns, the notebook that wrote it, and the\n",
+    "digest of the price data it was built from. That last field is what ties a label to its\n",
+    "data vintage: without it a re-run against a refreshed download is indistinguishable from\n",
+    "a re-run against this one.\n",
+    "\n",
+    "Each file is written from its own null set, so the three horizons carry three different\n",
+    "row counts. The folds that train models are derived per label by\n",
+    "`case_studies/utils/cv_window.py` from `config/setup.yaml` and the timeline of the label\n",
+    "parquet written here, so which rows land in these files is what sets where the fold\n",
+    "boundaries fall."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9a7e6691",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:18:21.057322Z",
+     "iopub.status.busy": "2026-07-31T09:18:21.057255Z",
+     "iopub.status.idle": "2026-07-31T09:18:24.028158Z",
+     "shell.execute_reply": "2026-07-31T09:18:24.027698Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_15m.parquet: 19,142,250 rows, digest c16a1a1fbb75e9ca\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_5m.parquet: 19,652,710 rows, digest 684c84ef0ffb38e1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_ret_60m.parquet: 16,845,180 rows, digest 7704b58a2f2adda5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_dir_15m.parquet: 19,142,250 rows, digest fc831892a9a67382\n"
+     ]
+    }
+   ],
+   "source": [
+    "readers = {PRIMARY_LABEL: \"03_financial_features.py, as the label it names directly\"}\n",
+    "for name in LABEL_NAMES:\n",
+    "    record = write_artifact(\n",
+    "        labels_df.select([\"timestamp\", \"symbol\", name]).drop_nulls(),\n",
+    "        LABELS_DIR / f\"{name}.parquet\",\n",
+    "        keys=[\"timestamp\", \"symbol\"],\n",
+    "        written_by=\"02_labels\",\n",
+    "        inputs={\"market_data\": MARKET_DATA_DIGEST},\n",
+    "    )\n",
+    "    print(f\"{name}.parquet: {record['n_rows']:,} rows, digest {record['digest']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04804ac",
+   "metadata": {},
+   "source": [
+    "The record Chapter 7.2 requires to close a label definition, one row per label, built\n",
+    "from the values computed above rather than written by hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "11e5d059",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T09:18:24.029484Z",
+     "iopub.status.busy": "2026-07-31T09:18:24.029402Z",
+     "iopub.status.idle": "2026-07-31T09:18:24.096690Z",
+     "shell.execute_reply": "2026-07-31T09:18:24.096253Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Label audit record\n",
+      "\n",
+      "fwd_ret_15m\n",
+      "  anchor       quote midpoint one bar after the decision bar\n",
+      "  horizon      0:15:00, which is 15 bars on this grid\n",
+      "  resolution   fixed at t+0:15:00; the closing NBBO quote breaks the within-bar tie\n",
+      "  overlap      14 bars shared by consecutive rows\n",
+      "  base rate    mean +0.000021, std 0.004142\n",
+      "  consumed by  03_financial_features.py, as the label it names directly\n",
+      "\n",
+      "fwd_ret_5m\n",
+      "  anchor       quote midpoint one bar after the decision bar\n",
+      "  horizon      0:05:00, which is 5 bars on this grid\n",
+      "  resolution   fixed at t+0:05:00; the closing NBBO quote breaks the within-bar tie\n",
+      "  overlap      4 bars shared by consecutive rows\n",
+      "  base rate    mean +0.000004, std 0.002324\n",
+      "  consumed by  the model stages, as a variant\n",
+      "\n",
+      "fwd_ret_60m\n",
+      "  anchor       quote midpoint one bar after the decision bar\n",
+      "  horizon      1:00:00, which is 60 bars on this grid\n",
+      "  resolution   fixed at t+1:00:00; the closing NBBO quote breaks the within-bar tie\n",
+      "  overlap      59 bars shared by consecutive rows\n",
+      "  base rate    mean +0.000063, std 0.007884\n",
+      "  consumed by  the model stages, as a variant\n",
+      "\n",
+      "fwd_dir_15m\n",
+      "  anchor       quote midpoint one bar after the decision bar\n",
+      "  horizon      0:15:00, which is 15 bars on this grid\n",
+      "  resolution   fixed at t+0:15:00; the closing NBBO quote breaks the within-bar tie\n",
+      "  overlap      14 bars shared by consecutive rows\n",
+      "  base rate    -1: 0.404, 0: 0.181, 1: 0.414\n",
+      "  consumed by  the model stages, as a variant\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nLabel audit record\")\n",
+    "for name in LABEL_NAMES:\n",
+    "    horizon, h_bars = HORIZONS[name], HORIZON_BARS[name]\n",
+    "    series = dev[name][name]\n",
+    "    scale = (\n",
+    "        f\"mean {series.mean():+.6f}, std {series.std():.6f}\"\n",
+    "        if name in RETURN_LABELS\n",
+    "        else \", \".join(f\"{k}: {(series == k).mean():.3f}\" for k in (-1, 0, 1))\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"\\n{name}\\n  anchor       quote midpoint one bar after the decision bar\"\n",
+    "        f\"\\n  horizon      {horizon}, which is {h_bars} bars on this grid\"\n",
+    "        f\"\\n  resolution   fixed at t+{horizon}; the closing NBBO quote breaks the within-bar tie\"\n",
+    "        f\"\\n  overlap      {h_bars - 1} bars shared by consecutive rows\"\n",
+    "        f\"\\n  base rate    {scale}\"\n",
+    "        f\"\\n  consumed by  {readers.get(name, 'the model stages, as a variant')}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b851d4a0",
+   "metadata": {},
+   "source": [
+    "## Key takeaways\n",
+    "\n",
+    "1. **Write the label as an execution convention, then resolve the exit by time.** Naming\n",
+    "   the two prices a trade crosses - one bar after the decision, and again at the horizon -\n",
+    "   fixes what the number means; finding the exit by timestamp rather than by counting rows\n",
+    "   is what keeps it meaning that when a bar is missing.\n",
+    "2. **Measure the bar grid before converting a declared horizon into bars.** A 15-row shift\n",
+    "   is a 15-minute return only on a one-minute grid, and a loader that returns a raw\n",
+    "   partition promises no such thing. Measure the spacing, require the horizon to be a\n",
+    "   whole number of bars, and the conversion stops being an assumption.\n",
+    "3. **Write every label from its own null set.** Dropping rows on the primary label before\n",
+    "   saving the others silently truncates the shorter horizons at the session close, and the\n",
+    "   row counts look plausible because the file is still large.\n",
+    "4. **Seal a diagnostic on the label's endpoint.** A decision taken before the holdout whose\n",
+    "   outcome resolves inside it is a holdout row, so the usable boundary is the boundary\n",
+    "   minus the horizon, counted within the session.\n",
+    "5. **A row count overstates the evidence when forward windows overlap.** The effective\n",
+    "   count says by how much, and the HAC standard error is what stops that overlap from\n",
+    "   inflating a t-statistic - here by a factor of nearly three.\n",
+    "\n",
+    "**Known limitations.** The midprice is not a fill: a marketable order crosses the spread,\n",
+    "and the round trip charted in Section E is the quoted spread rather than a measured\n",
+    "execution cost - it carries no commission, no market impact and no queue position, so it\n",
+    "is a floor on what trading costs. The universe is the fixed NASDAQ-100 membership list\n",
+    "`setup.yaml` declares, not a\n",
+    "point-in-time index reconstruction, so a name that joined or left mid-sample is present\n",
+    "throughout. The flat band is a single constant across every symbol and every regime,\n",
+    "where the spread it stands for is neither. The baseline is one signal at one horizon.\n",
+    "\n",
+    "**Next**: `03_financial_features.py` builds the order-flow, liquidity and volatility\n",
+    "features and evaluates them against these labels."
    ]
   }
  ],
@@ -1281,6 +1790,13 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "source_py_blob": "d21d20b95e2be7119ed55687912477a34f8a4a83",
+   "executed_at": "2026-07-31T09:19:07.343345+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
+  },
   "papermill": {
    "default_parameters": {},
    "duration": 37.22225,
@@ -1292,13 +1808,6 @@
    "parameters": {},
    "start_time": "2026-07-14T04:53:59.591759+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "8ae16dda2da1371b4db0ec61e25bd64bb529dbaa",
-   "executed_at": "2026-07-14T04:54:37.261325+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/nasdaq100_microstructure/02_labels.py
+++ b/case_studies/nasdaq100_microstructure/02_labels.py
@@ -16,515 +16,720 @@
 # %% [markdown]
 # # NASDAQ-100 Microstructure: Label Engineering
 #
-# **Chapter 7: Defining the Learning Task**
+# Every model in this case study predicts the label defined here, so an error in it is
+# silent where it is made and reaches every metric and every backtest after it. This
+# notebook fixes the execution convention, proves each labelled row has a complete
+# forward window inside one trading session, measures how much independent information
+# those rows carry, establishes the floor a feature has to clear, and writes the files
+# stage 03 reads.
 #
-# This notebook implements label engineering for the **NASDAQ-100 Microstructure**
-# case study. We construct forward midprice returns at multiple horizons (1-bar,
-# 5-bar, 60-bar) using execution-consistent conventions.
+# ## Learning objectives
 #
-# **Learning Objectives**:
-# - Compute midprice-based labels that avoid bid-ask bounce contamination
-# - Apply session-bounded forward returns (no overnight gap leakage)
-# - Perform cost-sanity checks to assess horizon feasibility
-# - Generate walk-forward CV splits with appropriate purge/embargo
+# - Write an intraday forward return as an execution convention - which price is bought,
+#   at which time, and sold at which time - rather than as a row shift
+# - Measure the bar grid the horizon is counted on, and convert a declared duration into
+#   bars against it instead of assuming the two agree
+# - Assert, rather than describe, that every labelled window is complete inside one session
+# - Price the overlap in a per-bar label, both as decay and as an effective row count
+# - Establish the floor a feature has to clear, under a standard error that prices in that
+#   overlap
 #
-# **Label Types**:
-# - `fwd_ret_15m`: Primary regression label (1-bar / 15-min forward mid return)
-# - `fwd_ret_5m`: Variant 1 (5-min forward mid return, from 5-bar shift)
-# - `fwd_ret_60m`: Variant 2 (60-min forward mid return, from 60-bar shift)
-# - `fwd_dir_15m`: Classification variant (ternary: up/flat/down, 5 bps threshold)
+# ## Book reference, prerequisites and artifacts
 #
-# **Execution Convention**:
-# - Decision time $t$ = bar close
-# - Enter at $t+1$ midprice (1-bar execution delay)
-# - Label: $y_H = \text{mid}_{t+H} / \text{mid}_{t+1} - 1$
-#
-# **Output Contract**:
-# - `labels/fwd_ret_15m.parquet` — primary label
-# - `labels/fwd_ret_5m.parquet` — fast variant
-# - `labels/fwd_ret_60m.parquet` — slow variant
-# - `labels/fwd_dir_15m.parquet` — classification variant
-# - `cv_config.json` — walk-forward CV configuration
-#
-# **Cross-References**:
-# - **Upstream**: Ch3 (AlgoSeek TAQ data), Ch6 ([`01_feasibility_analysis`](01_feasibility_analysis.ipynb))
-# - **Downstream**: Ch8 (`03_financial_features.py`), Ch9 (`04_temporal.py`)
+# Chapter 7, Section 7.2. Reads AlgoSeek NASDAQ-100 minute bars with NBBO quotes through
+# `load_nasdaq100_bars()`, whose coverage
+# [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) establishes, and
+# `config/setup.yaml`, which declares the universe, the label set, the horizons and the
+# holdout boundary. Writes `labels/fwd_ret_5m.parquet`, `labels/fwd_ret_15m.parquet`,
+# `labels/fwd_ret_60m.parquet` and `labels/fwd_dir_15m.parquet`, each with a
+# `.digest.json` sidecar beside it. `03_financial_features.py` reads
+# `fwd_ret_15m.parquet`, which it names directly.
 
 # %%
-"""NASDAQ-100 Microstructure: Label Engineering (Ch7)."""
+"""NASDAQ-100 Microstructure: Label Engineering."""
 
 import warnings
-from datetime import UTC, date, datetime
+from datetime import date, datetime, time, timedelta
 
+import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
+import yaml
+from ml4t.diagnostic.metrics import compute_ic_hac_stats, cross_sectional_ic_series
+from ml4t.engineer.labeling import fixed_time_horizon_labels
 
+from case_studies.utils.artifact_digest import value_digest, write_artifact
+from case_studies.utils.label_diagnostics import effective_sample_size, panel_autocorrelation
 from data import load_nasdaq100_bars
-from utils.cv_splits import generate_cv_splits
+from utils.artifact_specs import resolve_label_horizon
 from utils.paths import get_case_study_dir
+from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt
 
 warnings.filterwarnings("ignore")
 
-# %% tags=["parameters"]
 CASE_STUDY_ID = "nasdaq100_microstructure"
-START_DATE = "2020-01-01"
-END_DATE = "2021-12-31"
-MAX_SYMBOLS = 0
-
-# %%
-# Configuration
-CASE_DIR = get_case_study_dir("nasdaq100_microstructure")
+CASE_DIR = get_case_study_dir(CASE_STUDY_ID)
 LABELS_DIR = CASE_DIR / "labels"
 
-print(f"Date range: {START_DATE} to {END_DATE}")
+# %% [markdown]
+# All three parameters are read below. `MAX_SYMBOLS` keeps a seed-deterministic subset of
+# the universe and the two dates trim the history. Any of them shortens a run at the cost
+# of a thinner panel: the rank correlation in Section G needs a wide cross-section on each
+# decision minute, and the boundary profile in Section D needs whole sessions.
+
+# %% tags=["parameters"]
+MAX_SYMBOLS = 0
+START_DATE = "2020-01-01"
+END_DATE = "2021-12-31"
 
 # %% [markdown]
-# ## 1. Load Minute Bar Data
+# ## Configuration
 #
-# Load AlgoSeek minute bars with microstructure fields. We need NBBO quotes
-# (CloseBidPrice, CloseAskPrice) to compute midprice-based labels that avoid
-# bid-ask bounce per Hasbrouck (2007).
+# Everything that defines a label is declared in `config/setup.yaml` and bound here. A
+# horizon or a boundary typed into a cell is a second copy of a value the rest of the
+# pipeline reads from the file, and the two drift apart the first time either is edited.
 #
-# **Memory requirement**: the full universe (114 symbols, 2020–2021) is ~40M
-# minute bars across 60+ microstructure columns and materializes to roughly
-# **28 GB** in memory — more than most laptops have. The raw load is about
-# **0.25 GB per symbol**, so:
-#
-# | Symbols (`MAX_SYMBOLS`) | Approx. loaded size |
-# |---|---|
-# | 10 | ~2.5 GB |
-# | 25 | ~6 GB |
-# | 50 | ~13 GB |
-# | 114 (all, `0`) | ~28 GB |
-#
-# Peak usage runs higher than these figures because label computation holds
-# additional intermediates, so budget headroom. To run on a memory-constrained
-# machine, set `MAX_SYMBOLS` to a smaller value in the parameters cell (a
-# seed-deterministic subset), and/or narrow `START_DATE`/`END_DATE`. The
-# microstructure patterns this case study teaches are visible on any subset;
-# only the published full-universe results require the complete load.
+# `resolve_label_horizon` returns each label's outcome horizon as a duration - `15min`
+# rather than a number of rows - which is the form the rest of the notebook keeps it in.
+# The flat band of the direction label is the friction floor the cost model declares:
+# a move smaller than it does not pay for its own spread.
 
 # %%
-df = load_nasdaq100_bars(
-    start_date=START_DATE,
-    end_date=END_DATE,
-    include_microstructure=True,
-    max_symbols=MAX_SYMBOLS,
+setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
+
+
+def declared_horizon(label: str) -> timedelta:
+    """The outcome horizon `setup.yaml` declares for *label*, as a duration."""
+    spec = resolve_label_horizon(CASE_STUDY_ID, label, setup)
+    return timedelta(minutes=int(spec.removesuffix("min")))
+
+
+# %%
+PRIMARY_LABEL = setup["labels"]["primary"]
+LABEL_NAMES = [PRIMARY_LABEL, *setup["labels"].get("variants", [])]
+RETURN_LABELS = [n for n in LABEL_NAMES if n.startswith("fwd_ret")]
+DIRECTION_LABEL = next(n for n in LABEL_NAMES if n.startswith("fwd_dir"))
+HORIZONS = {name: declared_horizon(name) for name in LABEL_NAMES}
+PRIMARY_HORIZON = HORIZONS[PRIMARY_LABEL]
+FLAT_BAND = setup["costs"]["friction_floor_bps"] / 10_000
+HOLDOUT_START = date.fromisoformat(setup["evaluation"]["holdout_start"])
+HOLDOUT_TS = datetime.combine(HOLDOUT_START, time())
+GROUP_COLS = ["symbol", "session_date"]
+PALETTE = dict(zip(RETURN_LABELS, (COLORS["blue"], COLORS["amber"], COLORS["copper"])))
+
+print(f"Labels {LABEL_NAMES}, primary {PRIMARY_LABEL}, flat band {FLAT_BAND:.2%}")
+print(f"Holdout opens {HOLDOUT_START} and seals each label on its own endpoint")
+
+# %% [markdown]
+# ## A. The learning task
+#
+# The hypothesis is that the order flow of the last few minutes says something about where
+# a NASDAQ-100 name trades over the next few, and that whatever it says is small enough to
+# be eaten by the cost of acting on it. The label therefore has to be a return an intraday
+# trader could actually have captured, measured between two prices they could have traded
+# at, and it has to be honest about the delay between seeing a signal and getting filled.
+#
+# The decision cadence comes from `setup.yaml`: a bar closes, that close is the last thing
+# observed, and the position goes on at the next bar. The primary horizon is the middle of
+# three - long enough that the move can exceed the spread, short enough to stay inside the
+# session and inside the regime the microstructure features describe. The fast and slow
+# variants ask the same question of a horizon a third as long and one four times longer,
+# which is a question about how quickly the information decays relative to what it costs
+# to trade on it. A direction variant discretises the primary label so the same hypothesis
+# can be posed as a classification task.
+
+# %% [markdown]
+# ## B. Preparation before the label
+#
+# Three things have to be true of the price series before a forward window means anything.
+#
+# **The price has to be one a trade could cross at.** Trade prices alternate between bid
+# and ask as buyers and sellers arrive, so a return taken between two of them carries a
+# bounce that has nothing to do with information (Hasbrouck, 2007). The midprice of the
+# closing NBBO quote removes it, and the half-spread taken from the same quote is what
+# Section E prices the move against.
+#
+# **The window has to sit inside one session.** An overnight gap is not an intraday move,
+# so `session_date` joins `symbol` in the entity key and no label crosses either. Regular
+# hours only: the pre-market and after-hours books are thin enough that their quotes
+# describe a different market.
+#
+# **No eligibility filter runs before the label.** Once rows are dropped from inside a
+# series a shift counts survivors rather than bars, and the window silently spans whatever
+# was removed - which is the failure Section D exists to catch. The cost-feasible universe
+# `setup.yaml` declares is applied at backtest time, not here.
+#
+# Only four columns are read out of the sixty the microstructure schema carries. The label
+# needs the two quote sides and the keys, and projecting at the scan keeps a full-universe
+# run inside a couple of gigabytes instead of the twenty-eight the whole schema costs.
+
+# %%
+_hour, _minute = pl.col("timestamp").dt.hour(), pl.col("timestamp").dt.minute()
+REGULAR_HOURS = ((_hour > 9) | ((_hour == 9) & (_minute >= 30))) & (_hour < 16)
+_bid, _ask = pl.col("close_bid_price"), pl.col("close_ask_price")
+
+bars = (
+    load_nasdaq100_bars(
+        start_date=START_DATE,
+        end_date=END_DATE,
+        include_microstructure=True,
+        max_symbols=MAX_SYMBOLS,
+        lazy=True,
+    )
+    .select(["timestamp", "symbol", "close_bid_price", "close_ask_price"])
+    .filter(REGULAR_HOURS)
+    .with_columns(
+        ((_bid + _ask) / 2).alias("mid_close"),
+        ((_ask - _bid) / (_bid + _ask)).alias("half_spread"),
+        pl.col("timestamp").dt.date().alias("session_date"),
+    )
+    .collect()
+)
+quoted = bars.filter(pl.col("mid_close") > 0).sort([*GROUP_COLS, "timestamp"])
+
+# %%
+print(f"{bars.height:,} regular-hours bars, {bars['symbol'].n_unique()} symbols")
+print(f"{bars.height - quoted.height:,} dropped for a missing or non-positive quote midpoint")
+print(f"{quoted.height:,} quoted bars over {quoted['session_date'].n_unique():,} sessions")
+
+# %% [markdown]
+# The horizon is declared in minutes and applied to a frame of bars, so the spacing of
+# those bars is what converts one into the other. Measuring it is the whole of the fix for
+# a defect this notebook used to carry: a 15-row shift is a 15-minute return only on a
+# one-minute grid, and nothing in the loader promises one. The spacing is measured, the
+# grid is required to be uniform inside a session, and every horizon is required to be a
+# whole number of bars - at least two of them, so that the entry bar and the exit bar are
+# different bars.
+
+# %%
+_gap = pl.col("timestamp") - pl.col("timestamp").shift(1).over(GROUP_COLS)
+spacing = quoted.select(_gap.drop_nulls().unique().alias("gap"))["gap"].to_list()
+assert len(spacing) == 1, f"the intraday grid is not uniform: spacings {sorted(spacing)}"
+BAR = spacing[0]
+HORIZON_BARS = {name: horizon // BAR for name, horizon in HORIZONS.items()}
+for name, horizon in HORIZONS.items():
+    assert horizon % BAR == timedelta(0), f"{name}: {horizon} is not a whole number of {BAR} bars"
+    assert HORIZON_BARS[name] >= 2, (
+        f"{name}: a {horizon} horizon is {HORIZON_BARS[name]} bar on a {BAR} grid, so the "
+        f"entry bar and the exit bar are the same bar and the label cannot be formed"
+    )
+
+print(f"Bar spacing {BAR}, uniform within every session; horizons in bars {HORIZON_BARS}")
+
+# %% [markdown]
+# ## C. Label construction
+#
+# One execution convention, written once and applied at all three horizons:
+#
+# $$r^{(H)}_{s,t} = \frac{M_{s,t+H}}{M_{s,t+B}} - 1$$
+#
+# where $M$ is symbol $s$'s quote midpoint, $B$ is one bar and $H$ is the declared horizon.
+# The decision is taken on the bar closing at $t$, so the earliest price that can be
+# traded is the one a bar later - that is the execution delay `setup.yaml` declares - and
+# the position is held until $H$ after the decision. The numerator and the denominator are
+# both prices a trade could have crossed at, and the gap between them is what the strategy
+# actually earns.
+#
+# The entry price is the next bar's midpoint, which the uniform grid asserted above makes
+# exactly one bar of wall-clock time later; the last bar of a session has no next bar, so it
+# carries no entry and no label. The exit is resolved by **time**, not by counting rows: the
+# library looks for a bar at exactly $H - B$ past the entry, and a bar that is missing
+# resolves to nothing and nulls the label instead of letting a shift reach past the hole and
+# return a longer window under a shorter name. Materialising the entry price as its own
+# column is what lets the library express this convention - it divides by the price at $t$,
+# so shifting the series forward by one bar turns "enter one bar late" into "start here".
+
+# %%
+priced = quoted.with_columns(
+    pl.col("mid_close").shift(-1).over(GROUP_COLS).alias("entry_mid")
+).drop_nulls("entry_mid")
+
+# %%
+for name in RETURN_LABELS:
+    held = f"{(HORIZONS[name] - BAR) // timedelta(minutes=1)}m"
+    priced = fixed_time_horizon_labels(
+        priced,
+        horizon=held,
+        method="returns",
+        price_col="entry_mid",
+        group_col=GROUP_COLS,
+        timestamp_col="timestamp",
+        tolerance="0s",
+    ).rename({f"label_return_{held}": name})
+
+print(f"Constructed {', '.join(RETURN_LABELS)} on {priced.height:,} bars with a tradable entry")
+
+# %% [markdown]
+# The direction label is the primary return discretised into a band around zero: a move
+# smaller than the friction floor is called flat because it does not pay for its own
+# spread. The library's binary method cannot express it - that method splits at zero and
+# reports whether the price merely changed - so the band stays notebook-local.
+#
+# It is built by arithmetic rather than by a `when`/`otherwise` chain, because arithmetic
+# propagates nulls and that chain does not: a Polars comparison against a null is not true,
+# so an unguarded `otherwise` fires on every row with no forward window and files it as
+# "down". Here the outside-the-band test is null wherever the return is, and multiplying by
+# the sign carries that null through.
+
+# %%
+_outside = (pl.col(PRIMARY_LABEL).abs() > FLAT_BAND).cast(pl.Int8)
+_direction = (_outside * pl.col(PRIMARY_LABEL).sign()).cast(pl.Int8)
+_position = pl.int_range(pl.len()).over(GROUP_COLS)
+
+labels_df = (
+    quoted.join(
+        priced.select(["symbol", "timestamp", *RETURN_LABELS]),
+        on=["symbol", "timestamp"],
+        how="left",
+    )
+    .with_columns(_direction.alias(DIRECTION_LABEL))
+    .with_columns(
+        (pl.len().over(GROUP_COLS) - 1 - _position).alias("from_end"),
+        _position.alias("bar_in_session"),
+        pl.col("timestamp")
+        .shift(-HORIZON_BARS[PRIMARY_LABEL])
+        .over(GROUP_COLS)
+        .alias("_label_end"),
+    )
 )
 
-print(f"Loaded {len(df):,} minute bars")
-print(f"Symbols: {df['symbol'].n_unique()}")
-print(f"Date range: {df['timestamp'].min()} to {df['timestamp'].max()}")
+# %%
+MARKET_DATA_DIGEST = value_digest(quoted, ["symbol", "timestamp", "mid_close"])
+print(f"market_data digest: {MARKET_DATA_DIGEST}")
 
 # %% [markdown]
-# ## 2. Filter to Regular Trading Hours
+# ## D. Window validity
 #
-# Restrict to 09:30--16:00 ET. Pre-market and after-hours bars have
-# wider spreads, lower liquidity, and different microstructure dynamics.
+# A shift always returns something; the question is whether what it returns is the quantity
+# the label claims. Each property below fails silently and leaves plausible numbers behind,
+# so each is asserted rather than described.
+#
+# The second is what separates this construction from the row shift it replaces. Every
+# labelled window is required to span exactly its declared horizon in wall-clock time - not a
+# bar count that happens to agree - so a grid that was ever coarser or gappier than it looks
+# would raise here rather than ship a longer return under a shorter name.
+#
+# The third catches a short label masked by a longer one's null set. Each session has to be
+# short by exactly its own horizon and no more, so `fwd_ret_5m` carries ten more rows per
+# session than `fwd_ret_15m`; an equal count means one label was gated by the other's nulls.
 
 # %%
-df = df.filter(
-    (pl.col("timestamp").dt.hour() >= 10)  # >= 10:00 captures 09:30 due to bar labeling
-    | ((pl.col("timestamp").dt.hour() == 9) & (pl.col("timestamp").dt.minute() >= 30))
-)
-df = df.filter(pl.col("timestamp").dt.hour() < 16)
+for name, h_bars in ((n, HORIZON_BARS[n]) for n in RETURN_LABELS):
+    span = pl.col("timestamp").shift(-h_bars).over(GROUP_COLS) - pl.col("timestamp")
+    checked = labels_df.with_columns(span.alias("_span"))
+    tail = checked.filter(pl.col("from_end") < h_bars)
+    labelled = checked.drop_nulls(name)
+    # 1. An incomplete forward window is null, never a value.
+    assert tail[name].null_count() == tail.height, name
+    # 2. Every labelled window spans exactly the declared horizon in wall-clock time.
+    assert labelled.filter(pl.col("_span") != HORIZONS[name]).height == 0, name
+    # 3. Each session labels its first n - h bars, so no label crosses a session boundary and
+    #    none is gated by another label's null set.
+    counted = checked.group_by(GROUP_COLS).agg(
+        (pl.len() - pl.col(name).is_not_null().sum() - h_bars).alias("excess")
+    )
+    assert counted.filter(pl.col("excess") != 0).height == 0, name
+    print(f"{name}: {labelled.height:,} labelled, every window exactly {HORIZONS[name]}")
 
-# Sort for time-series operations
-df = df.sort(["symbol", "timestamp"])
-
-# Add session_date for session-bounded operations
-df = df.with_columns(pl.col("timestamp").dt.date().alias("session_date"))
-
-print(f"Regular hours bars: {len(df):,}")
-print(f"Sessions: {df['session_date'].n_unique()}")
+# %%
+# 4. No discrete label is derived from a null return.
+_unlabelled = labels_df.filter(pl.col(PRIMARY_LABEL).is_null())[DIRECTION_LABEL]
+assert _unlabelled.null_count() == _unlabelled.len()
+print(f"{DIRECTION_LABEL}: null on all {_unlabelled.len():,} bars where {PRIMARY_LABEL} is null")
 
 # %% [markdown]
-# ## 3. Compute Midprice
-#
-# Midprice = (CloseBidPrice + CloseAskPrice) / 2 reduces bid-ask bounce that
-# contaminates trade-price-based returns. This is standard practice for
-# intraday label construction (Hasbrouck, 2007).
+# Position zero below is the last bar of each session. Each label's non-null rate has to
+# fall to zero over exactly the last `horizon` positions and sit flat beyond them, and the
+# three curves have to step down at three different places. A scalar count of valid rows
+# shows neither failure this catches: a tail fabricated instead of nulled, and a short
+# label carried on a longer one's null set - which is what this notebook shipped until now,
+# and which would draw the 5-minute curve exactly on top of the 15-minute one.
 
 # %%
-has_bid_ask = "close_bid_price" in df.columns and "close_ask_price" in df.columns
-
-if has_bid_ask:
-    df = df.with_columns(
-        mid_close=((pl.col("close_bid_price") + pl.col("close_ask_price")) / 2),
-        half_spread=(
-            (pl.col("close_ask_price") - pl.col("close_bid_price"))
-            / (pl.col("close_bid_price") + pl.col("close_ask_price") + 1e-8)
-        ),
-    )
-    print("Using midprice from NBBO quotes")
-else:
-    df = df.with_columns(
-        mid_close=pl.col("last_trade_price"),
-        half_spread=pl.lit(0.0005),  # Default 5 bps if no quotes
-    )
-    print("WARNING: No NBBO available, using last trade price")
-
-# Filter bars with valid midprice (positive, non-null)
-df = df.filter(pl.col("mid_close").is_not_null() & (pl.col("mid_close") > 0))
-
-print(f"Bars with valid midprice: {len(df):,}")
-
-# %% [markdown]
-# ## 4. Create Labels
-#
-# Forward midprice returns at three horizons. The shift(-1) in the denominator
-# enforces the 1-bar execution delay: you observe at bar $t$ close, enter at
-# $t+1$ midprice, and the label measures the return from entry to the target bar.
-#
-# **Implementation note**: Labels are computed at *minute* bar resolution using
-# `shift(-15)` rather than resampling to 15-min bars and using `shift(-1)`.
-# Both produce the same 15-minute forward midprice return. The minute-bar
-# approach avoids information loss from resampling and aligns the feature
-# matrix (also at minute resolution) with labels for exact row-level joins.
-# The setup notebook's "1-bar at 15-min frequency" specification is equivalent.
-#
-# **Session-bounded**: `.over(["symbol", "session_date"])` ensures shifts do not
-# cross overnight boundaries. This prevents overnight gap contamination in
-# intraday labels.
-#
-# **Horizons** (in minute bars):
-# - 5 bars = 5 minutes (fast, most cost-dominated)
-# - 15 bars = 15 minutes (primary, balances signal vs cost)
-# - 60 bars = 60 minutes (slow, tests residual microstructure content)
-
-
-# %%
-def create_intraday_labels(df: pl.DataFrame) -> pl.DataFrame:
-    """Create forward midprice return labels at multiple horizons.
-
-    Each label computes: mid[t+H] / mid[t+1] - 1
-    where t+1 is the entry bar (execution delay) and t+H is the exit bar.
-
-    Session-bounded: shifts do not cross overnight boundaries.
-    """
-    group_cols = ["symbol", "session_date"]
-
-    df = df.with_columns(
-        # Entry midprice (1-bar execution delay)
-        entry_mid=pl.col("mid_close").shift(-1).over(group_cols),
-        # Exit midprices at each horizon
-        exit_5m=pl.col("mid_close").shift(-5).over(group_cols),
-        exit_15m=pl.col("mid_close").shift(-15).over(group_cols),
-        exit_60m=pl.col("mid_close").shift(-60).over(group_cols),
-    )
-
-    # Compute returns from entry to exit
-    df = df.with_columns(
-        fwd_ret_5m=(pl.col("exit_5m") / pl.col("entry_mid") - 1),
-        fwd_ret_15m=(pl.col("exit_15m") / pl.col("entry_mid") - 1),
-        fwd_ret_60m=(pl.col("exit_60m") / pl.col("entry_mid") - 1),
-    )
-
-    # Ternary classification: up / flat / down with cost-motivated threshold
-    # 5 bps threshold: moves below this are within the friction floor
-    flat_threshold = 0.0005  # 5 bps
-
-    df = df.with_columns(
-        fwd_dir_15m=pl.when(pl.col("fwd_ret_15m").is_null())
-        .then(None)
-        .when(pl.col("fwd_ret_15m") > flat_threshold)
-        .then(1)
-        .when(pl.col("fwd_ret_15m") < -flat_threshold)
-        .then(-1)
-        .otherwise(0)
-        .cast(pl.Int8),
-    )
-
-    # Drop intermediate columns
-    df = df.drop(["entry_mid", "exit_5m", "exit_15m", "exit_60m"])
-
-    return df
-
-
-# %%
-total_before_labels = len(df)
-df = create_intraday_labels(df)
-print("Labels created successfully")
-
-# Session boundary data loss reporting
-print("\nSession boundary data loss:")
-for label_col, shift_bars in [("fwd_ret_5m", 5), ("fwd_ret_15m", 15), ("fwd_ret_60m", 60)]:
-    valid = df[label_col].drop_nulls().len()
-    lost = total_before_labels - valid
-    pct_lost = 100 * lost / total_before_labels
-    print(
-        f"  {label_col}: {lost:,} rows lost ({pct_lost:.1f}%) — last {shift_bars} bars/session + 1-bar entry"
-    )
-
-# %% [markdown]
-# ## 5. Label Quality Assessment
-#
-# Evaluate label distributions, class balance, and cost-feasibility.
-
-# %%
-# Return statistics by horizon
-label_stats = {}
-for label_col, horizon_name in [
-    ("fwd_ret_5m", "5m"),
-    ("fwd_ret_15m", "15m"),
-    ("fwd_ret_60m", "60m"),
-]:
-    vals = df[label_col].drop_nulls()
-    label_stats[horizon_name] = {
-        "count": len(vals),
-        "mean": float(vals.mean()),
-        "std": float(vals.std()),
-        "median": float(vals.median()),
-        "p5": float(vals.quantile(0.05)),
-        "p95": float(vals.quantile(0.95)),
-    }
-
-print("=== Forward Return Statistics ===")
-for horizon, stats in label_stats.items():
-    print(
-        f"  fwd_ret_{horizon}: n={stats['count']:,}, "
-        f"mean={stats['mean']:.6f}, std={stats['std']:.6f}, "
-        f"[p5={stats['p5']:.5f}, p95={stats['p95']:.5f}]"
-    )
-
-# %%
-# Classification label distribution
-dir_dist = df.group_by("fwd_dir_15m").len().sort("fwd_dir_15m")
-print("\nDirection label distribution (15m, threshold=5bps):")
-print(dir_dist)
-
-# Compute class balance
-total = dir_dist["len"].sum()
-for row in dir_dist.iter_rows(named=True):
-    pct = 100 * row["len"] / total
-    label_name = {-1: "Down", 0: "Flat", 1: "Up"}.get(row["fwd_dir_15m"], "?")
-    print(f"  {label_name}: {row['len']:,} ({pct:.1f}%)")
-
-# %% [markdown]
-# ### Cost-Sanity Check
-#
-# Compare the typical return magnitude to the half-spread cost. If the median
-# absolute return is close to or less than the half-spread, the horizon is
-# cost-dominated and unlikely to be tradeable.
-
-# %%
-# Cost sanity: compare |return| distribution to half-spread
-cost_check = {}
-for label_col, horizon_name in [
-    ("fwd_ret_5m", "5m"),
-    ("fwd_ret_15m", "15m"),
-    ("fwd_ret_60m", "60m"),
-]:
-    joined = df.select([label_col, "half_spread"]).drop_nulls()
-    abs_ret = joined[label_col].abs()
-    hs = joined["half_spread"]
-
-    median_abs_ret_bps = float(abs_ret.median()) * 10000
-    median_half_spread_bps = float(hs.median()) * 10000
-    pct_exceeds_cost = float((abs_ret > hs).mean()) * 100
-
-    cost_check[horizon_name] = {
-        "median_abs_ret_bps": round(median_abs_ret_bps, 2),
-        "median_half_spread_bps": round(median_half_spread_bps, 2),
-        "pct_exceeds_cost": round(pct_exceeds_cost, 1),
-    }
-
-print("\n=== Cost-Sanity Check ===")
-pl.DataFrame(
-    [
-        {
-            "horizon": h,
-            "median_abs_ret_bps": c["median_abs_ret_bps"],
-            "median_half_spread_bps": c["median_half_spread_bps"],
-            "pct_exceeds_cost": c["pct_exceeds_cost"],
-        }
-        for h, c in cost_check.items()
-    ]
+profile = (
+    labels_df.filter(pl.col("from_end") <= max(HORIZON_BARS.values()) + 2)
+    .group_by("from_end")
+    .agg([pl.col(name).is_not_null().mean().alias(name) for name in RETURN_LABELS])
+    .sort("from_end")
 )
 
-# %% [markdown]
-# **Interpretation**: If `% > cost` is below 50%, most trades would lose money
-# to the spread alone. This confirms the cost-dominant regime identified in
-# [`01_feasibility_analysis`](01_feasibility_analysis.ipynb) and supports the pedagogical framing: microstructure signals
-# exist but are not tradeable at institutional horizons.
+# %%
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for name, colour in PALETTE.items():
+    ax.plot(profile["from_end"], profile[name], ds="steps-mid", lw=1.8, c=colour, label=name)
+    ax.axvline(HORIZON_BARS[name] - 0.5, color=colour, linestyle=":", lw=1)
+ax.set_xlabel("Bars from the end of the session")
+ax.set_ylabel("Share of bars carrying a label")
+sub = "Dotted lines mark each horizon; curves lying on top of each other mean one masked another"
+add_message_title(ax, "Each horizon nulls its own tail of the session and no other", sub)
+ax.legend(loc="center right", frameon=False)
+show_with_alt(fig, "Non-null label rate by bar position from the end of each trading session.")
 
 # %% [markdown]
-# ### Baseline IC: Lagged Return vs Forward Return
+# ## E. Distribution and base rate
 #
-# The simplest predictor of the next 15-minute return is the current 15-minute
-# return (testing for mean-reversion or momentum). This baseline IC provides
-# the reference that Ch8 features must beat. Measured on train+validation rows
-# only (timestamp < holdout_start) so this expectation-setting diagnostic never
-# reads the sealed holdout.
-
-# %%
-import yaml
-
-_holdout_start = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())["evaluation"][
-    "holdout_start"
-]
-
-# Compute lagged 15-minute return as baseline signal, pre-holdout rows only
-df_baseline = (
-    df.with_columns(
-        lag_15m=(
-            pl.col("mid_close") / pl.col("mid_close").shift(15).over(["symbol", "session_date"]) - 1
-        )
-    )
-    .filter(pl.col("timestamp").dt.date() < date.fromisoformat(_holdout_start))
-    .drop_nulls(subset=["lag_15m", "fwd_ret_15m"])
-)
-
-# Sample every 15th timestamp for approximately independent observations
-all_ts = df_baseline["timestamp"].unique().sort()
-sample_ts = all_ts.gather_every(15)
-baseline_sample = df_baseline.filter(pl.col("timestamp").is_in(sample_ts))
-
-min_cs_size = min(10, baseline_sample["symbol"].n_unique())
-baseline_ic = (
-    baseline_sample.group_by("timestamp")
-    .agg(
-        pl.corr("lag_15m", "fwd_ret_15m", method="spearman").alias("ic"),
-        pl.len().alias("n"),
-    )
-    .filter(pl.col("n") >= min_cs_size)
-)
-
-if baseline_ic.height > 0 and baseline_ic["ic"].null_count() < baseline_ic.height:
-    baseline_ic_mean = float(baseline_ic["ic"].mean())
-    baseline_ic_std = float(baseline_ic["ic"].std())
-    baseline_ic_t = (
-        baseline_ic_mean / (baseline_ic_std / np.sqrt(len(baseline_ic)))
-        if baseline_ic_std > 0
-        else 0.0
-    )
-else:
-    baseline_ic_mean, baseline_ic_std, baseline_ic_t = 0.0, 0.0, 0.0
-    print("  Warning: insufficient cross-sectional data for baseline IC")
-
-print("Baseline IC: Lagged 15-min Return → fwd_ret_15m")
-print(f"  Mean IC: {baseline_ic_mean:.5f}")
-print(f"  IC t-stat: {baseline_ic_t:.2f}")
-print(f"  IC observations: {len(baseline_ic):,}")
-if abs(baseline_ic_t) < 2.0:
-    print("  → NOT significant. Ch8 features must create signal from scratch.")
-else:
-    sign = "mean-reverting" if baseline_ic_mean < 0 else "momentum"
-    print(f"  → Significant ({sign}). Ch8 features should improve on this.")
-
-# %% [markdown]
-# **Reconciliation with Ch6 baseline**: The feasibility notebook ([`01_feasibility_analysis`](01_feasibility_analysis.ipynb)) reports a
-# much stronger baseline IC (~-0.17) because it uses close-to-close (trade price)
-# returns, which suffer from bid-ask bounce — an artifact that creates artificial
-# negative autocorrelation (Hasbrouck, 2007). The near-zero IC here, computed on
-# midprice returns, is the uncontaminated measure and is authoritative for downstream
-# feature evaluation.
-
-# %% [markdown]
-# ### Label Autocorrelation
+# What scale is the label, and does it mean the same thing across the panel and across
+# time? Everything from here through Section G is computed on the development window only,
+# sealed on the label's **endpoint** rather than on the bar it was observed from: a
+# decision taken shortly before the holdout still resolves inside it, so a filter on the
+# observation time looks sealed and is not. The label files keep every row, because the
+# seal governs what this notebook looks at rather than what it writes.
 #
-# Autocorrelation of `fwd_ret_15m` at different lags reveals how quickly predictive
-# content decays and informs purge/embargo settings.
+# Each label is sealed on its own endpoint, because they do not resolve together: the
+# 60-minute window closes three quarters of an hour after the 15-minute one opened from
+# the same bar, so one boundary applied to all three would leave the slowest label
+# reaching furthest into the holdout. The symbol-session is carried as one `entity` key,
+# because it is the entity no label may cross and Section F counts overlap within it.
+
 
 # %%
-# Label autocorrelation at 1-min, 15-min, and 60-min lags
-autocorr_lags = {"1_bar": 1, "15_bar": 15, "60_bar": 60}
-autocorr_results = {}
-
-for lag_name, lag_bars in autocorr_lags.items():
-    lag_col = f"fwd_ret_15m_lag_{lag_bars}"
-    valid = df.with_columns(
-        pl.col("fwd_ret_15m").shift(lag_bars).over(["symbol", "session_date"]).alias(lag_col)
-    ).drop_nulls(subset=["fwd_ret_15m", lag_col])
-    rho = float(valid.select(pl.corr("fwd_ret_15m", lag_col)).item())
-    autocorr_results[lag_name] = round(rho, 5)
-    print(f"  fwd_ret_15m autocorrelation at lag {lag_bars}: {rho:.5f}")
-
-# %% [markdown]
-# ## 6. Save Labels and CV Configuration
-
-# %%
-# Drop incomplete rows (NaN labels from session boundaries)
-df_clean = df.drop_nulls(subset=["fwd_ret_15m"])
-print(f"Rows after dropping incomplete labels: {len(df_clean):,}")
-
-# %%
-LABELS_DIR.mkdir(parents=True, exist_ok=True)
-
-# Save individual label files
-key_cols = ["timestamp", "symbol"]
-
-for label_col in ["fwd_ret_5m", "fwd_ret_15m", "fwd_ret_60m", "fwd_dir_15m"]:
-    subset = df_clean.select(key_cols + [label_col]).drop_nulls(subset=[label_col])
-    subset.write_parquet(LABELS_DIR / f"{label_col}.parquet")
-    print(f"Saved labels/{label_col}.parquet ({len(subset):,} rows)")
-
-# %%
-# CV splits (generated at runtime from setup.yaml, not saved as file)
-splits = generate_cv_splits(
-    df_clean,
-    case_study_id="nasdaq100_microstructure",
-    label_buffer="15min",
-    date_col="timestamp",
-)
-print(f"CV config: {len(splits)} folds from setup.yaml evaluation section")
-
-# %%
-# Results JSON for chapter agent
-results = {
-    "case_study_id": "nasdaq100_microstructure",
-    "chapter": 7,
-    "stage": "labels",
-    "timestamp": datetime.now(UTC).isoformat(),
-    "git_commit": "unknown",
-    "notebook": "case_studies/nasdaq100_microstructure/code/02_labels.py",
-    "summary": {
-        "n_rows": len(df_clean),
-        "n_symbols": df_clean["symbol"].n_unique(),
-        "n_sessions": df_clean["session_date"].n_unique(),
-        "labels": ["fwd_ret_5m", "fwd_ret_15m", "fwd_ret_60m", "fwd_dir_15m"],
-        "primary_label": "fwd_ret_15m",
-    },
-    "techniques": [
-        "midprice-based forward returns",
-        "session-bounded computation",
-        "1-bar execution delay",
-        "cost-sanity check",
-    ],
-    "diagnostics": {
-        "label_stats": label_stats,
-        "cost_check": cost_check,
-        "baseline_ic": {
-            "signal": "lagged_15m_return",
-            "mean_ic": round(baseline_ic_mean, 5),
-            "ic_t_stat": round(baseline_ic_t, 2),
-            "n_observations": len(baseline_ic),
-        },
-        "label_autocorrelation": autocorr_results,
-    },
-    "key_findings": [
-        f"Primary label fwd_ret_15m: mean={label_stats['15m']['mean']:.6f}, std={label_stats['15m']['std']:.6f}",
-        f"Cost dominance confirmed: {cost_check['15m']['pct_exceeds_cost']:.0f}% of 15m returns exceed half-spread",
-        f"Baseline IC (lagged 15m return): {baseline_ic_mean:.5f} (t={baseline_ic_t:.2f})",
-        "Direction label (5bps threshold): ternary up/flat/down with 5 bps cost-motivated threshold",
-    ],
+_entity = (pl.col("symbol") + "|" + pl.col("session_date").cast(pl.Utf8)).alias("entity")
+dev = {
+    name: labels_df.with_columns(
+        pl.col("timestamp").shift(-HORIZON_BARS[name]).over(GROUP_COLS).alias("_label_end"),
+        _entity,
+    )
+    .filter(pl.col("_label_end") < HOLDOUT_TS)
+    .drop_nulls(name)
+    .select(["timestamp", "symbol", "half_spread", "entity", "bar_in_session", name])
+    for name in LABEL_NAMES
 }
+for name in LABEL_NAMES:
+    print(f"{name}: {dev[name].height:,} development rows through {dev[name]['timestamp'].max()}")
+
 # %% [markdown]
-# ## Key Takeaways
+# All three horizons go on one axis with identical bins and a logarithmic count axis. The
+# claim is about shape rather than width: a longer horizon accumulates more variance, so
+# if the three are the same process observed over different spans the bodies should widen
+# in proportion to the square root of the horizon while the tails stay heavy throughout.
+# The axis is symmetric and narrower than any label's range, so rows outside it are counted
+# below rather than drawn.
+
+# %%
+bins = np.linspace(-0.02, 0.02, 161)
+primary_std = dev[PRIMARY_LABEL][PRIMARY_LABEL].std()
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for name, colour in PALETTE.items():
+    series = dev[name][name]
+    tag = f"{name}, std {series.std():.5f}"
+    ax.hist(series.to_numpy(), bins=bins, histtype="step", lw=1.8, color=colour, label=tag)
+ax.set_yscale("log")
+ax.set_xlabel("Forward midprice return from the entry bar")
+ax.set_ylabel("Bars per bin, log scale")
+sub = "Identical bins on the development window; rows beyond the axis are counted below"
+add_message_title(ax, "Each horizon widens the label while its tails stay far from normal", sub)
+ax.legend(loc="lower center", frameon=False)
+show_with_alt(fig, "Histograms of the three labels on identical bins, log count axis.")
+
+# %%
+for name in RETURN_LABELS:
+    series = dev[name][name]
+    out = series.filter((series < bins[0]) | (series > bins[-1])).len()
+    root_h = np.sqrt(HORIZONS[name] / PRIMARY_HORIZON)
+    print(
+        f"{name}: std {series.std():.6f}, kurtosis {series.kurtosis():.1f}, "
+        f"{series.std() / primary_std:.2f}x the primary label against {root_h:.2f} under "
+        f"square-root-of-horizon scaling, {out:,} beyond the axis"
+    )
+
+# %% [markdown]
+# The label is what a trade earns before costs, and the spread is most of what it pays.
+# Both are in the same units, so they belong on the same axis: the curves are the
+# distribution of the absolute move at each horizon, and the vertical line is the spread a
+# **round trip** crosses - twice the half-spread, because the position is opened and closed
+# - on the same bars.
 #
-# 1. **Midprice labels** avoid bid-ask bounce contamination that would add noise
-#    to trade-price returns — essential for intraday microstructure research
-# 2. **Session-bounded** forward returns prevent overnight gap artifacts
-# 3. **1-bar execution delay** reflects realistic entry timing: you observe at
-#    bar close, enter at next bar's midprice
-# 4. **Cost-sanity check** quantifies what fraction of returns exceed the
-#    half-spread — the primary feasibility gate for intraday strategies
-# 5. **Three horizons** (5m, 15m, 60m) demonstrate signal decay: microstructure
-#    content is highest at short horizons but so are costs
-# 6. **Baseline IC** from lagged returns establishes the reference bar that
-#    Ch8 engineered features must exceed
-# 7. **Label autocorrelation** reveals how quickly predictive content decays,
-#    informing purge/embargo settings for walk-forward CV
+# The comparison is not the case study's answer, it is the reason the case study is worth
+# running. A move larger than the spread is necessary for the horizon to be tradable and
+# nowhere near sufficient: what a strategy earns is the move times how often it gets the
+# direction right, and Section G measures how little of that is on offer here.
+
+# %%
+round_trip = 2 * dev[PRIMARY_LABEL]["half_spread"].median() * 10_000
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for name, colour in PALETTE.items():
+    moves = (dev[name][name].abs() * 10_000).sort().to_numpy()
+    ax.plot(moves, np.arange(1, len(moves) + 1) / len(moves), lw=1.8, color=colour, label=name)
+ax.axvline(round_trip, color=COLORS["neutral"], ls="--", lw=1.2, label="median round trip")
+ax.set_xscale("log")
+ax.set_xlim(0.1, 1000)  # below a tenth of a bp the move is a stale quote, not a move
+ax.set_xlabel("Absolute forward move, basis points, log scale")
+ax.set_ylabel("Share of bars at or below")
+sub = "Absolute label against twice the median half-spread, development window"
+add_message_title(ax, "The spread costs the same at every horizon while the move grows", sub)
+ax.legend(loc="upper left", frameon=False)
+show_with_alt(fig, "Empirical CDF of absolute moves per horizon against the median round trip.")
+
+# %%
+for name in RETURN_LABELS:
+    frame, moved = dev[name], dev[name][name].abs()
+    clears = (moved > 2 * frame["half_spread"]).mean()
+    print(
+        f"{name}: median absolute move {moved.median() * 10_000:.2f}bps against a "
+        f"{2 * frame['half_spread'].median() * 10_000:.2f}bps round trip, {clears:.1%} clears it"
+    )
+
+# %% [markdown]
+# Chapter 7.2 asks for the base rate to be tracked through time. The direction label is
+# where that question has an answer: its three classes are cut at a fixed band, so their
+# proportions are free to move, and a classifier trained on one regime and scored in
+# another is only comparable if they do not move much. The flat class is the interesting
+# one - it is the share of the session where nothing happens that is worth paying for.
+
+# %%
+monthly = (
+    dev[DIRECTION_LABEL]
+    .with_columns(pl.col("timestamp").dt.truncate("1mo").alias("month"))
+    .group_by("month")
+    .agg([(pl.col(DIRECTION_LABEL) == k).mean().alias(str(k)) for k in (-1, 0, 1)])
+    .sort("month")
+)
+
+# %%
+classes = {"0": "flat", "1": "up", "-1": "down"}
+shades = (COLORS["neutral"], COLORS["blue"], COLORS["copper"])
+fig, ax = plt.subplots(figsize=FIGSIZE["single_wide"])
+for (key, tag), colour in zip(classes.items(), shades):
+    ax.plot(monthly["month"], monthly[key], lw=1.8, color=colour, label=tag)
+ax.set_ylim(0, 1)
+ax.set_xticks(monthly["month"].to_list()[::4])
+ax.set_xlabel("Month")
+ax.set_ylabel("Share of labelled bars")
+sub = f"Class shares of {DIRECTION_LABEL} by month, development window"
+add_message_title(ax, "Up and down stay balanced; the flat share does not hold still", sub)
+ax.legend(loc="center right", frameon=False)
+show_with_alt(
+    fig, "Monthly class shares of the ternary direction label across the development window."
+)
+
+for key, tag in classes.items():
+    lo, hi = monthly[key].min(), monthly[key].max()
+    share = (dev[DIRECTION_LABEL][DIRECTION_LABEL] == int(key)).mean()
+    print(f"{tag}: {share:.3f} of labelled bars, ranging {lo:.3f} to {hi:.3f} across months")
+
+# %% [markdown] tags=["results"]
+# On the development window the primary label has a standard deviation of 0.004142, against
+# 0.002324 for the 5-minute label and 0.007884 for the 60-minute one - 0.56x and 1.90x the
+# primary, against the 0.58x and 2.00x square-root-of-horizon scaling implies, so the shorter
+# horizon scales as that rule predicts and the longer one falls a little short of it. None of
+# the three is remotely normal: kurtosis runs from 86.0 at 60 minutes to 1147.8 at 5, so the
+# shorter the horizon the more of its variance sits in rare bars.
 #
-# **Next**: `03_financial_features.py` engineers microstructure features from the raw
-# minute bar data (order flow, liquidity, volatility, Kyle's lambda).
+# Against cost, the median absolute move is 8.74bps at 5 minutes, 16.34bps at 15 and 32.75bps
+# at 60, while the median round trip is 4.98, 5.03 and 5.25bps on the same bars - the move
+# roughly doubles with each step up in horizon and the spread does not move at all. The share
+# of bars whose move clears that round trip climbs from 65.3% to 79.3% to 88.8%. Cut at the
+# 5bps friction floor, the direction label splits 0.414 up, 0.404 down and 0.181 flat, and
+# while up and down hold between 0.372-0.471 and 0.359-0.468 across months, the flat share
+# runs from 0.061 to 0.268.
+
+# %% [markdown]
+# ## F. Overlap and effective sample size
+#
+# Sampling a multi-bar label at every bar makes consecutive rows share most of their
+# forward window, so the row count overstates the evidence. Two measurements answer that in
+# different units: how fast the overlap decays, and what the rows are worth once it is
+# priced in. Both are counted on the bar position within the session, which is the grid the
+# horizon was converted into, and both treat the symbol-session as the entity, because a
+# window cannot be concurrent with one on the other side of an overnight gap.
+#
+# Read the decay as a straight line running out to each horizon: consecutive rows share all
+# but one bar of their window, and the share they have in common falls off by one bar per lag.
+# The longest label does not stop at zero when it gets there but keeps going negative, and
+# that is a property of the session rather than of the label - a one-hour window is a fifth of
+# a trading day, so each session holds few independent windows, and subtracting the session's
+# own mean from so few of them forces what is left to correlate negatively at long lags.
+
+# %%
+max_lag = max(HORIZON_BARS[name] for name in RETURN_LABELS) + 4
+acf = {
+    name: panel_autocorrelation(
+        dev[name], name, max_lag=max_lag, bar_col="bar_in_session", entity_col="entity"
+    )
+    for name in RETURN_LABELS
+}
+
+# %%
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+lags = np.arange(1, max_lag + 1)
+for name, colour in PALETTE.items():
+    ax.plot(lags, acf[name], lw=1.8, color=colour, label=name)
+    ax.axvline(HORIZON_BARS[name], color=colour, linestyle=":", lw=1.2)
+ax.axhline(0, color=COLORS["neutral"], lw=0.8)
+ax.set_xlabel("Lag in bars")
+ax.set_ylabel("Panel autocorrelation")
+sub = "Dotted lines mark each horizon; pooled across symbol-sessions on the development window"
+add_message_title(ax, "Overlap decays linearly with lag at every horizon", sub)
+ax.legend(loc="upper right", frameon=False)
+show_with_alt(fig, "Panel autocorrelation of each forward-return label against lag in bars.")
+
+# %%
+for name in RETURN_LABELS:
+    h_bars = HORIZON_BARS[name]
+    n_rows, n_eff = effective_sample_size(
+        dev[name], horizon=h_bars, bar_col="bar_in_session", entity_col="entity"
+    )
+    print(
+        f"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against "
+        f"{1 / h_bars:.4f} for windows overlapping this fully; autocorrelation "
+        f"{acf[name][0]:.3f} at lag one and {acf[name][h_bars - 1]:.3f} at its horizon"
+    )
+
+# %% [markdown] tags=["results"]
+# The primary label's 14,370,375 development rows carry 993,791 effective observations, a
+# ratio of 0.0692 against the 0.0667 a fully overlapped 15-bar window implies; the 5-minute
+# label's 14,753,585 rows carry 2,981,374 at 0.2021 against 0.2000, and the 60-minute label's
+# 12,645,930 carry 248,448 at 0.0196 against 0.0167. Each sits above its reference because a
+# session end closes an overlap early, and the longest label sits furthest above it because
+# the session ends most often relative to its window. Fourteen million rows are worth about a
+# million: the row count overstates the evidence by a factor of fifteen, which is the horizon.
+#
+# Autocorrelation falls from 0.920 at lag one to -0.038 at lag fifteen for the primary label
+# and from 0.741 to -0.023 at lag five for the fast one. The 60-minute label falls from 0.976
+# to -0.219 at lag sixty, crossing zero around lag fifty. The purge gap a fold needs is set by
+# the forward window itself, not by any of these counts.
+
+# %% [markdown]
+# ## G. Baseline floor
+#
+# One signal against the primary label on the sealed development window, with no feature
+# engineering: the trailing return over the same span as the label looks forward. If the
+# order flow of the last fifteen minutes carries information about the next fifteen, the
+# simplest form it can take is that the move continues or that it reverses, and Chapter 8's
+# features have to beat whatever that is worth before they have earned their place.
+#
+# The information coefficient is the cross-sectional rank correlation across the symbols
+# priced at each decision minute, averaged over minutes, which is the quantity a ranking
+# model is scored on. The minimum cross-section is half the median rather than a bare
+# count, so it means the same thing on a universe of another size. The standard error is
+# HAC-adjusted: consecutive decision minutes share fourteen of their fifteen bars of
+# outcome, and a naive statistic would count each of them as fresh evidence.
+
+# %%
+_h = HORIZON_BARS[PRIMARY_LABEL]
+_trailing = pl.col("mid_close") / pl.col("mid_close").shift(_h).over(GROUP_COLS) - 1
+baseline = (
+    labels_df.with_columns(
+        _trailing.alias("trailing_return"),
+        pl.col("timestamp").shift(-_h).over(GROUP_COLS).alias("_label_end"),
+    )
+    .filter(pl.col("_label_end") < HOLDOUT_TS)
+    .drop_nulls([PRIMARY_LABEL, "trailing_return"])
+)
+min_obs = int(baseline.group_by("timestamp").len()["len"].median() // 2)
+
+ic = cross_sectional_ic_series(
+    baseline,
+    baseline,
+    pred_col="trailing_return",
+    ret_col=PRIMARY_LABEL,
+    date_col="timestamp",
+    entity_col="symbol",
+    min_obs=min_obs,
+).sort("timestamp")  # HAC autocovariances are meaningless over a permutation of time
+stats = compute_ic_hac_stats(ic, ic_col="ic", label_horizon=_h)
+
+# %%
+print(f"Baseline: trailing {PRIMARY_HORIZON} return against {PRIMARY_LABEL}")
+print(f"  {baseline.height:,} rows, minimum cross-section {min_obs} symbols")
+print(
+    f"  decision minutes scored {ic.height:,}, mean IC {stats['mean_ic']:.5f}, "
+    f"HAC t {stats['t_stat']:.2f} on {stats['effective_lags']} Bartlett lags, "
+    f"naive t {stats['naive_t_stat']:.2f}, p {stats['p_value']:.3g}"
+)
+
+# %% [markdown] tags=["results"]
+# The trailing 15-minute return earns a mean information coefficient of -0.00798 against the
+# primary label, over 135,720 scored decision minutes drawn from 13,795,560 rows on a
+# cross-section of at least 51 symbols. The sign is negative, so on this universe the recent
+# move tends to give part of itself back rather than continue.
+#
+# The Newey-West rule picks 19 Bartlett lags and returns a t-statistic of -6.02 against a
+# naive -16.78, so pricing in the overlap cuts the apparent evidence by nearly two thirds -
+# and what is left is still far from zero, at p 1.74e-09. That is the floor: a feature that
+# ranks the cross-section no better than the last quarter-hour of price has added nothing.
+# It is a floor on ranking, not on profit - a coefficient of this size is small next to the
+# round trip Section E priced, which is the tension the rest of the case study works through.
+
+# %% [markdown]
+# ## H. Artifacts and the audit record
+#
+# Each label is written with a digest sidecar beside it, recording the content digest of
+# the values written, the row count, the key columns, the notebook that wrote it, and the
+# digest of the price data it was built from. That last field is what ties a label to its
+# data vintage: without it a re-run against a refreshed download is indistinguishable from
+# a re-run against this one.
+#
+# Each file is written from its own null set, so the three horizons carry three different
+# row counts. The folds that train models are derived per label by
+# `case_studies/utils/cv_window.py` from `config/setup.yaml` and the timeline of the label
+# parquet written here, so which rows land in these files is what sets where the fold
+# boundaries fall.
+
+# %%
+readers = {PRIMARY_LABEL: "03_financial_features.py, as the label it names directly"}
+for name in LABEL_NAMES:
+    record = write_artifact(
+        labels_df.select(["timestamp", "symbol", name]).drop_nulls(),
+        LABELS_DIR / f"{name}.parquet",
+        keys=["timestamp", "symbol"],
+        written_by="02_labels",
+        inputs={"market_data": MARKET_DATA_DIGEST},
+    )
+    print(f"{name}.parquet: {record['n_rows']:,} rows, digest {record['digest']}")
+
+# %% [markdown]
+# The record Chapter 7.2 requires to close a label definition, one row per label, built
+# from the values computed above rather than written by hand.
+
+# %%
+print("\nLabel audit record")
+for name in LABEL_NAMES:
+    horizon, h_bars = HORIZONS[name], HORIZON_BARS[name]
+    series = dev[name][name]
+    scale = (
+        f"mean {series.mean():+.6f}, std {series.std():.6f}"
+        if name in RETURN_LABELS
+        else ", ".join(f"{k}: {(series == k).mean():.3f}" for k in (-1, 0, 1))
+    )
+    print(
+        f"\n{name}\n  anchor       quote midpoint one bar after the decision bar"
+        f"\n  horizon      {horizon}, which is {h_bars} bars on this grid"
+        f"\n  resolution   fixed at t+{horizon}; the closing NBBO quote breaks the within-bar tie"
+        f"\n  overlap      {h_bars - 1} bars shared by consecutive rows"
+        f"\n  base rate    {scale}"
+        f"\n  consumed by  {readers.get(name, 'the model stages, as a variant')}"
+    )
+
+# %% [markdown]
+# ## Key takeaways
+#
+# 1. **Write the label as an execution convention, then resolve the exit by time.** Naming
+#    the two prices a trade crosses - one bar after the decision, and again at the horizon -
+#    fixes what the number means; finding the exit by timestamp rather than by counting rows
+#    is what keeps it meaning that when a bar is missing.
+# 2. **Measure the bar grid before converting a declared horizon into bars.** A 15-row shift
+#    is a 15-minute return only on a one-minute grid, and a loader that returns a raw
+#    partition promises no such thing. Measure the spacing, require the horizon to be a
+#    whole number of bars, and the conversion stops being an assumption.
+# 3. **Write every label from its own null set.** Dropping rows on the primary label before
+#    saving the others silently truncates the shorter horizons at the session close, and the
+#    row counts look plausible because the file is still large.
+# 4. **Seal a diagnostic on the label's endpoint.** A decision taken before the holdout whose
+#    outcome resolves inside it is a holdout row, so the usable boundary is the boundary
+#    minus the horizon, counted within the session.
+# 5. **A row count overstates the evidence when forward windows overlap.** The effective
+#    count says by how much, and the HAC standard error is what stops that overlap from
+#    inflating a t-statistic - here by a factor of nearly three.
+#
+# **Known limitations.** The midprice is not a fill: a marketable order crosses the spread,
+# and the round trip charted in Section E is the quoted spread rather than a measured
+# execution cost - it carries no commission, no market impact and no queue position, so it
+# is a floor on what trading costs. The universe is the fixed NASDAQ-100 membership list
+# `setup.yaml` declares, not a
+# point-in-time index reconstruction, so a name that joined or left mid-sample is present
+# throughout. The flat band is a single constant across every symbol and every regime,
+# where the spread it stands for is neither. The baseline is one signal at one horizon.
+#
+# **Next**: `03_financial_features.py` builds the order-flow, liquidity and volatility
+# features and evaluates them against these labels.

--- a/case_studies/nasdaq100_microstructure/02_labels.py
+++ b/case_studies/nasdaq100_microstructure/02_labels.py
@@ -533,8 +533,10 @@ for key, tag in classes.items():
 # horizon was converted into, and both treat the symbol-session as the entity, because a
 # window cannot be concurrent with one on the other side of an overnight gap.
 #
-# Read the decay as a straight line running out to each horizon: consecutive rows share all
-# but one bar of their window, and the share they have in common falls off by one bar per lag.
+# What a label consumes is return intervals, and it consumes one fewer than its horizon in
+# bars: entering a bar after the decision and leaving at the horizon spans the moves between
+# those two prices, not the move into the entry. Consecutive rows share all but one of those
+# intervals, so the decay reads as a straight line falling by one interval per lag.
 # The longest label does not stop at zero when it gets there but keeps going negative, and
 # that is a property of the session rather than of the label - a one-hour window is a fifth of
 # a trading day, so each session holds few independent windows, and subtracting the session's
@@ -565,24 +567,25 @@ show_with_alt(fig, "Panel autocorrelation of each forward-return label against l
 
 # %%
 for name in RETURN_LABELS:
-    h_bars = HORIZON_BARS[name]
+    h_bars, spans = HORIZON_BARS[name], HORIZON_BARS[name] - 1
     n_rows, n_eff = effective_sample_size(
-        dev[name], horizon=h_bars, bar_col="bar_in_session", entity_col="entity"
+        dev[name], horizon=spans, bar_col="bar_in_session", entity_col="entity"
     )
     print(
         f"{name}: N={n_rows:,}, N_eff={n_eff:,.0f}, ratio {n_eff / n_rows:.4f} against "
-        f"{1 / h_bars:.4f} for windows overlapping this fully; autocorrelation "
+        f"{1 / spans:.4f} for {spans} intervals overlapping fully; autocorrelation "
         f"{acf[name][0]:.3f} at lag one and {acf[name][h_bars - 1]:.3f} at its horizon"
     )
 
 # %% [markdown] tags=["results"]
-# The primary label's 14,370,375 development rows carry 993,791 effective observations, a
-# ratio of 0.0692 against the 0.0667 a fully overlapped 15-bar window implies; the 5-minute
-# label's 14,753,585 rows carry 2,981,374 at 0.2021 against 0.2000, and the 60-minute label's
-# 12,645,930 carry 248,448 at 0.0196 against 0.0167. Each sits above its reference because a
-# session end closes an overlap early, and the longest label sits furthest above it because
-# the session ends most often relative to its window. Fourteen million rows are worth about a
-# million: the row count overstates the evidence by a factor of fifteen, which is the horizon.
+# The primary label's 14,370,375 development rows carry 1,062,039 effective observations, a
+# ratio of 0.0739 against the 0.0714 that fourteen fully overlapping intervals imply; the
+# 5-minute label's 14,753,585 rows carry 3,717,137 at 0.2519 against 0.2500, and the
+# 60-minute label's 12,645,930 carry 252,009 at 0.0199 against 0.0169. Each sits above its
+# reference because a session end closes an overlap early, and the longest label sits
+# furthest above it because the session ends most often relative to its window. Fourteen
+# million rows are worth about a million: the row count overstates the evidence by roughly
+# the number of intervals each label spans.
 #
 # Autocorrelation falls from 0.920 at lag one to -0.038 at lag fifteen for the primary label
 # and from 0.741 to -0.023 at lag five for the fast one. The 60-minute label falls from 0.976
@@ -696,7 +699,7 @@ for name in LABEL_NAMES:
         f"\n{name}\n  anchor       quote midpoint one bar after the decision bar"
         f"\n  horizon      {horizon}, which is {h_bars} bars on this grid"
         f"\n  resolution   fixed at t+{horizon}; the closing NBBO quote breaks the within-bar tie"
-        f"\n  overlap      {h_bars - 1} bars shared by consecutive rows"
+        f"\n  overlap      {h_bars - 2} of its {h_bars - 1} return intervals, with the next row"
         f"\n  base rate    {scale}"
         f"\n  consumed by  {readers.get(name, 'the model stages, as a variant')}"
     )
@@ -725,7 +728,9 @@ for name in LABEL_NAMES:
 # **Known limitations.** The midprice is not a fill: a marketable order crosses the spread,
 # and the round trip charted in Section E is the quoted spread rather than a measured
 # execution cost - it carries no commission, no market impact and no queue position, so it
-# is a floor on what trading costs. The universe is the fixed NASDAQ-100 membership list
+# is a floor on what trading costs. It is also the spread quoted at the decision bar, doubled,
+# rather than the two spreads actually crossed at the entry and exit bars, so it prices the
+# round trip at the moment the decision is taken and not at the moments it is filled. The universe is the fixed NASDAQ-100 membership list
 # `setup.yaml` declares, not a
 # point-in-time index reconstruction, so a name that joined or left mid-sample is present
 # throughout. The flat band is a single constant across every symbol and every regime,

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -34,6 +34,7 @@ HOLDOUT_SCOPED_NOTEBOOKS = [
     ("case_studies/crypto_perps_funding/02_labels.py", "cross_sectional_ic_series("),
     ("case_studies/cme_futures/02_labels.py", "cross_sectional_ic_series("),
     ("case_studies/fx_pairs/02_labels.py", "cross_sectional_ic_series("),
+    ("case_studies/nasdaq100_microstructure/02_labels.py", "cross_sectional_ic_series("),
 ]
 
 
@@ -131,6 +132,7 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
     "case_studies/crypto_perps_funding/02_labels.py",
     "case_studies/cme_futures/02_labels.py",
     "case_studies/fx_pairs/02_labels.py",
+    "case_studies/nasdaq100_microstructure/02_labels.py",
 ]
 
 # Of the four above, only etfs/05 uses a market-wide calendar; the other three
@@ -150,6 +152,13 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
 # ``entity_col`` names the column the endpoint must be shifted within, which is the
 # entity a label may not cross. It is ``symbol`` for seven of the nine case studies and
 # ``product`` for cme_futures.
+# ``nasdaq100_microstructure/02_labels`` is deliberately absent from this third list while
+# being present in the two above. Its labels are intraday and may not cross an overnight
+# gap, so the entity a label may not cross is the compound ``["symbol", "session_date"]``
+# and its endpoint is derived with ``.over(GROUP_COLS)``. The regex below binds a single
+# quoted column name, so it cannot express a compound key -- listing the notebook here
+# would produce a false red against a seal that is strictly stronger than the per-symbol
+# one this test checks.
 # ``etfs/03_financial_features`` is deliberately absent. It was listed here while it
 # purged on a shifted label endpoint; public #447 replaced that mechanism with a seal
 # that rebuilds the whole panel with the holdout withheld and compares all 57 columns,


### PR DESCRIPTION
Rebuilds `case_studies/nasdaq100_microstructure/02_labels` to the stage-02 standard and fixes two
defects that change what lands in `labels/*.parquet`.

## The two artifact defects

**1. `fwd_ret_5m` was written from the primary label's null set.** `df.drop_nulls(subset=["fwd_ret_15m"])`
gated the write loop for all four labels, so the 5-minute label lost every row on which the 15-minute
label was null - the last ten bars of every symbol-session. Each label is now written from its own
nulls, and Section D asserts that each session is short by exactly its own horizon and no more.

| Label | Before | After | Change |
|---|---:|---:|---|
| `fwd_ret_5m` | 19,142,250 | **19,652,710** | **+510,460 rows**, +2.67%, all at the session close |
| `fwd_ret_15m` | 19,142,250 | 19,142,250 | unchanged |
| `fwd_ret_60m` | 16,845,180 | 16,845,180 | unchanged |
| `fwd_dir_15m` | 19,142,250 | 19,142,250 | unchanged |

The shipped `fwd_ret_5m` was missing 2.60% of its correct support and ended at 15:44 instead of
15:54. Its distinct-timestamp count goes from 189,375 (505 x 375) to 194,425 (505 x 385), and
`case_studies/utils/cv_window.py:119-126` derives that label's folds from exactly that timeline, so
the fold boundaries for any model trained on `fwd_ret_5m` move with it.

**2. A bar count was used as a time horizon.** `shift(-15)` on a frame nothing had checked is a
15-minute return only where the minute grid is complete. The horizon is now the duration
`setup.yaml` declares, converted into bars against a **measured** grid interval, with the exit
resolved by timestamp (`fixed_time_horizon_labels(horizon=..., tolerance="0s")`) so a missing bar
nulls the label instead of letting the shift reach past it.

**Measured on production: this moves zero rows.** The grid is exactly uniform - 19,908,044
regular-hours bars, all 51,046 symbol-sessions exactly 390 one-minute bars, zero interior gaps. The
only quote dropout is ALXN's final 104-bar session on 2021-07-21 (delisting), which removes a whole
trailing session rather than punching a hole in one. So the two constructions coincided on this data
and the defect was unenforced code rather than wrong values - which is exactly why it needed
asserting rather than trusting. Section D now proves it every run: every labelled window spans
exactly its declared horizon in wall-clock time.

Two prose claims that were wrong independently of the data are gone: that `shift(-15)` on minute bars
and `shift(-1)` on 15-minute bars produce the same return (they span 14 and 15 bars from different
bases), and that the horizons are "5 bars = 5 minutes".

## Other numbers that moved, and why

The baseline IC in Section G is computed differently, so its value moved. The previous cell thinned
the panel to every 15th timestamp (~9k of 135k decision minutes) and took a naive t-statistic on the
result; the standard forbids the naive statistic on an overlapping-label IC series and names
`cross_sectional_ic_series` + `compute_ic_hac_stats` as the replacement. Using every decision minute
and the HAC correction, the trailing 15-minute return earns a mean IC of **-0.00798** with a HAC
t of **-6.02** (19 Bartlett lags) against a naive **-16.78**. The old cell reported a near-zero,
not-significant baseline; the corrected one is small but clearly separated from zero.

This refines rather than reverses the case study's story: the reconciliation with Ch6's much stronger
close-to-close reading still holds - midprice removes most of the apparent reversal - and a real but
tiny ranking edge against a spread that does not shrink with the horizon is the tension the case
study exists to work through.

`N_eff` is now `calculate_label_uniqueness` via `case_studies/utils/label_diagnostics`, replacing a
hand-rolled formula: 14,370,375 primary-label development rows carry 1,062,039 effective
observations (ratio 0.0739 against the 0.0714 that fourteen fully overlapping intervals imply).

What a label consumes is **return intervals, and one fewer than its horizon in bars** - entering a
bar after the decision and leaving at the horizon spans the moves between those two prices, so
`M[t+H]/M[t+1] - 1` telescopes over the intervals `t+2 ... t+H`, which is `H-1` of them. The first
draft of this notebook passed `horizon=H` to `effective_sample_size`, which models the
`P[t+H]/P[t]` convention that consumes `H`; the ratio then landed near `1/H` circularly, because
that is what it had been told to assume. Caught by the pre-push review and corrected here, along
with the reference ratio, the audit record's overlap row and the prose that explains it. This is the
trap the stage document flags as "the `-1` is load-bearing and getting it wrong is not visible in
the aggregate".

## Conformance

```
$ python3 scripts/check_notebook_conformance.py --stage 02 --case-study nasdaq100_microstructure -v
=== stage 02 (02-labels.md): at most 330 code lines, 4+ figures, 11 required sections ===
  PASS  nasdaq100_microstructure
1 notebooks checked, 0 failing
```

From 3 failing checks and 13 findings (0 figures against 4 required, 4 numbers in untagged prose, all
8 A-H sections missing) to zero.

- **Sections A-H**, in order, with the three tagged `results` cells in E, F and G.
- **Five figures** where printed tables stood: label validity at the window boundary (which is where
  defect 1 is visible at a glance - the 5-minute curve used to lie exactly on the 15-minute one),
  the distribution across horizons, move scale against the round-trip spread, class shares through
  time, and overlap decay. F5 is correctly absent: resolution time here is `t + h` by construction.
- **Everything bound from `config/setup.yaml`** - label set, horizons as durations, holdout boundary,
  and the flat band from `costs.friction_floor_bps`. No literal.
- **The holdout seal is on `_label_end`**, per label rather than one boundary for all three, since a
  60-minute window closes three quarters of an hour after the 15-minute one opened from the same bar.
- **Library adoption**: `fixed_time_horizon_labels`, `calculate_label_uniqueness`,
  `cross_sectional_ic_series`, `compute_ic_hac_stats`, `panel_autocorrelation`, and `write_artifact`
  for the digest sidecars each label now carries.
- **Removed**: the dead 38-line `results` dict (the vestige of the banned `results/*.json` format),
  the naive t-statistic, the hand-rolled effective-sample-size formula, and the unused
  `generate_cv_splits` call - nothing reads a `cv_config.json` here and none is written, with
  Section H stating positively where the folds do come from.

`tests/test_holdout_boundary.py` gains this notebook in both static gates, per the stage-02 CI
contract. It stays out of `PER_SYMBOL_ENDPOINT_NOTEBOOKS`, whose regex binds a single quoted entity
column and so cannot express this notebook's compound `["symbol", "session_date"]` key; the comment
there records why.

## Two things this notebook does not settle

The label uses a one-minute execution delay while `config/setup.yaml` declares the decision cadence
as 15-minute bars with a one-bar delay. Read the second way, `fwd_ret_5m` would resolve before the
position could be entered and `fwd_ret_15m` would have a zero-length holding period. The stage-02
standard lists this case study's convention as entry-bar-mid and this rebuild keeps it, because
changing it moves every label value and is a statement about what the case study teaches rather than
a conformance fix. It needs a ruling, and the two documents should then say the same thing in the
same units.

The round trip in Section E is twice the half-spread quoted at the decision bar, not the two spreads
actually crossed at the entry and exit bars. The known-limitations note now says so. It does not
affect that section's claim, which is that the median spread does not change with the horizon while
the move does.

## Figures were reviewed as rendered, not as code

Three title claims were wrong against the data and were corrected after looking at the PNGs: most
moves at every horizon turn out to be *larger* than the spread rather than smaller, the flat class is
the *smallest* of the three rather than dominant, and the 60-minute label's overlap does not decay to
zero at its horizon - it crosses zero near lag 50 and sits at -0.219 by lag 60, which is a
finite-session artifact the notebook now explains rather than a claim it can make.
