### PR TITLE
A PR that touches one test file should not run all nine case studies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,13 +73,34 @@ jobs:
         id: filter
         with:
           filters: |
+            # "shared" fans the matrix out to every chapter and every case study.
+            # Only files that can change what test-chapters or test-case-studies
+            # DO belong here. Those two jobs run exactly one test module each
+            # (test_chapter_notebooks.py, test_case_studies.py), and the harness
+            # they import is conftest -> preset_patches and pm_helpers ->
+            # overrides.yaml. The other ~100 files in tests/ are unit tests owned
+            # by test-unit, which is required and runs on every commit anyway, so
+            # listing 'tests/**' here re-ran nine notebook pipelines to re-test
+            # something that had already been tested in ninety seconds.
             shared:
               - 'utils/**'
               - 'data/**'
-              - 'tests/**'
               - 'pyproject.toml'
               - '.github/workflows/test.yml'
               - 'matplotlibrc'
+              - 'tests/__init__.py'
+              - 'tests/conftest.py'
+              - 'tests/pm_helpers.py'
+              - 'tests/preset_patches.py'
+              - 'tests/overrides.yaml'
+              - 'tests/fixtures/**'
+              - 'tests/test_case_studies.py'
+              - 'tests/test_chapter_notebooks.py'
+            # test-py312, test-neo4j and test-benchmark all run this module. It is
+            # not in `shared` because it drives none of the chapter or case-study
+            # matrix; it gets its own filter, wired into run_py312 below.
+            docker-notebooks:
+              - 'tests/test_docker_notebooks.py'
             ch01:
               - '01_process_is_edge/**'
             ch02-03:
@@ -238,6 +259,7 @@ jobs:
              || [[ "${{ steps.filter.outputs.ch08-09 }}" == "true" ]] \
              || [[ "${{ steps.filter.outputs.ch10 }}" == "true" ]] \
              || [[ "${{ steps.filter.outputs.ch14-15 }}" == "true" ]] \
+             || [[ "${{ steps.filter.outputs.docker-notebooks }}" == "true" ]] \
              || [[ "${{ steps.filter.outputs.ch21 }}" == "true" ]]; then
             run_py312="true"
           fi


### PR DESCRIPTION
## The problem

`shared` in the path filter fans the matrix out to every chapter and every case study. It listed
`tests/**`.

Every stage-02 label PR open right now touches `tests/test_holdout_boundary.py` alongside its one
notebook:

```
case_studies/us_firm_characteristics/02_labels.py
case_studies/us_firm_characteristics/config/cv_config.json
tests/test_holdout_boundary.py          <-- trips `shared`
```

So a PR that changed one label notebook ran all nine case-study pipelines and inherited the four
that are red on `main`. #457, #459, #461, #462 and #463 each report four failing jobs, and not one
of those jobs is attributable to the change under review.

## Why the fan-out bought nothing

`test-chapters` and `test-case-studies` run exactly one test module each -
`tests/test_chapter_notebooks.py` and `tests/test_case_studies.py`. The harness they import is
`conftest.py` → `preset_patches.py` and `pm_helpers.py` → `overrides.yaml`, plus
`tests/fixtures/seed_results.py` via the `seeded_output_dir` fixture.

`tests/test_holdout_boundary.py` is in none of that. It is a unit test, already run by `test-unit`,
which is required and runs on every commit regardless. The fan-out re-ran nine notebook pipelines to
re-test something that had finished ninety seconds earlier in another job.

## The change

`shared` now names the harness instead of the directory: `conftest.py`, `pm_helpers.py`,
`preset_patches.py`, `overrides.yaml`, `tests/fixtures/**`, and the two test modules.

`tests/test_docker_notebooks.py` gets its own `docker-notebooks` filter wired into `run_py312`. It
drives `test-py312`, `test-neo4j` and `test-benchmark` but no part of the chapter or case-study
matrix, so it does not belong in `shared` and must not silently stop triggering its own job.

`data/**` stays. The notebook jobs do not exercise the download scripts either, but that is a second
change and this one is the evidenced one.

## Effect

A case-study PR runs its own `cs-` job. A chapter PR runs its own `ch-` job. Failures already on
`main` stay on `main` until their stage reaches them, instead of appearing on every unrelated PR.

Required checks are unchanged: `guards`, `lint`, `test-unit`.

## Verification

The filters parse and resolve as intended:

```
$ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/test.yml')); \
    f=yaml.safe_load(d['jobs']['changes']['steps'][1]['with']['filters']); \
    print(f['shared']); print(f['docker-notebooks'])"
['utils/**', 'data/**', 'pyproject.toml', '.github/workflows/test.yml', 'matplotlibrc',
 'tests/conftest.py', 'tests/pm_helpers.py', 'tests/preset_patches.py', 'tests/overrides.yaml',
 'tests/fixtures/**', 'tests/test_case_studies.py', 'tests/test_chapter_notebooks.py']
['tests/test_docker_notebooks.py']
```

This PR touches `.github/workflows/test.yml`, which is itself in `shared`, so it runs the full matrix
once - that is correct and expected, and is the last time an unrelated PR should do so.
