### PR TITLE
Point Mac readers at their chip's path, and say "install" above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,9 @@ Option B compiles several dependencies from source, `scikit-learn` among them, s
 `sudo apt install build-essential python3-dev`, on macOS `xcode-select --install`. Docker
 carries its own and needs none of this.
 
-**macOS readers:** on **Apple Silicon** take Option B. Every dependency has a native arm64
-wheel, so Docker costs you a 13 GB image and buys nothing. On an **Intel Mac** take Option A:
+**macOS readers:** on **Apple Silicon** take Option B. It is the path walked on real hardware
+before each release, it needs only the Xcode command-line tools for the packages that build from
+source, and Docker would add a 13 GB image for no benefit. On an **Intel Mac** take Option A:
 PyTorch publishes no macOS x86_64 wheel, so Option B cannot work there.
 
 **Windows readers:** both options run inside WSL2, not in PowerShell. Run

--- a/README.md
+++ b/README.md
@@ -394,9 +394,10 @@ Option B compiles several dependencies from source, `scikit-learn` among them, s
 carries its own and needs none of this.
 
 **macOS readers:** on **Apple Silicon** take Option B. It is the path walked on real hardware
-before each release, it needs only the Xcode command-line tools for the packages that build from
-source, and Docker would add a 13 GB image for no benefit. On an **Intel Mac** take Option A:
-PyTorch publishes no macOS x86_64 wheel, so Option B cannot work there.
+before each release, and it needs only the Xcode command-line tools for the packages that build
+from source. Docker there is worth a 13 GB image only for the ten `ml4t-py312` notebooks, which
+have no arm64 build and ship pre-executed. On an **Intel Mac** take Option A: PyTorch publishes
+no macOS x86_64 wheel, so Option B cannot work there.
 
 **Windows readers:** both options run inside WSL2, not in PowerShell. Run
 `wsl --install -d Ubuntu` from an Administrator PowerShell, restart, run it a second time

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ carries its own and needs none of this.
 
 **macOS readers:** on **Apple Silicon** take Option B. It is the path walked on real hardware
 before each release, and it needs only the Xcode command-line tools for the packages that build
-from source. Docker there is worth its 13 GB only for the twelve `ml4t-py312` notebooks, which have no
+from source. Docker there is worth its disk only for the twelve `ml4t-py312` notebooks, which have no
 arm64 build and ship pre-executed, and for Chapter 2's containerized database benchmarks. On an **Intel Mac** take Option A: PyTorch publishes
 no macOS x86_64 wheel, so Option B cannot work there.
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ carries its own and needs none of this.
 
 **macOS readers:** on **Apple Silicon** take Option B. It is the path walked on real hardware
 before each release, and it needs only the Xcode command-line tools for the packages that build
-from source. Docker there is worth a 13 GB image only for the ten `ml4t-py312` notebooks, which
+from source. Docker there is worth a 13 GB image only for the twelve `ml4t-py312` notebooks, which
 have no arm64 build and ship pre-executed. On an **Intel Mac** take Option A: PyTorch publishes
 no macOS x86_64 wheel, so Option B cannot work there.
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ systems:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env   # the installer's own line; puts uv on PATH here and now
 uv sync
 ```
 
@@ -395,8 +396,8 @@ carries its own and needs none of this.
 
 **macOS readers:** on **Apple Silicon** take Option B. It is the path walked on real hardware
 before each release, and it needs only the Xcode command-line tools for the packages that build
-from source. Docker there is worth a 13 GB image only for the twelve `ml4t-py312` notebooks, which
-have no arm64 build and ship pre-executed. On an **Intel Mac** take Option A: PyTorch publishes
+from source. Docker there is worth its 13 GB only for the twelve `ml4t-py312` notebooks, which have no
+arm64 build and ship pre-executed, and for Chapter 2's containerized database benchmarks. On an **Intel Mac** take Option A: PyTorch publishes
 no macOS x86_64 wheel, so Option B cannot work there.
 
 **Windows readers:** both options run inside WSL2, not in PowerShell. Run

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ strategy you can actually run, and keep running, in a live market.
   and [six production Python libraries](https://ml4trading.io/libraries/)
   that facilitate substantial parts of the workflow.
 
+**Start here: [Installation](docs/installation.md)** walks a blank Linux, Windows or macOS
+machine to a running notebook, prerequisites included. The short version is under
+[Quick Start](#quick-start) below.
+
 > **Free reader's guide:** Join [Navigate ML for Trading, 3rd Edition](https://maven.com/p/c6e0e7/navigate-ml-for-trading-3rd-edition)
 > on **July 30, 2026 at 11:00 AM ET** for a 30-minute map of the book, case studies, code, and companion resources.
 > See all current [courses and workshops](https://maven.com/stefan-jansen); the cohort courses are listed under
@@ -388,6 +392,10 @@ Option B compiles several dependencies from source, `scikit-learn` among them, s
 **C/C++ compiler and the Python headers**: on Ubuntu, Debian and WSL2
 `sudo apt install build-essential python3-dev`, on macOS `xcode-select --install`. Docker
 carries its own and needs none of this.
+
+**macOS readers:** on **Apple Silicon** take Option B. Every dependency has a native arm64
+wheel, so Docker costs you a 13 GB image and buys nothing. On an **Intel Mac** take Option A:
+PyTorch publishes no macOS x86_64 wheel, so Option B cannot work there.
 
 **Windows readers:** both options run inside WSL2, not in PowerShell. Run
 `wsl --install -d Ubuntu` from an Administrator PowerShell, restart, run it a second time

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,8 @@ services:
   # Covers: Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06,
   # Ch15 NB06, Ch21 deep_hedging.
   # Start with: docker compose --profile py312 run --rm py312 python ...
+  # This service reserves no GPU, so it starts on macOS and on any machine
+  # without NVIDIA. Use the py312-gpu service below where a GPU is available.
   # Apple Silicon: there is no native arm64 image (signatory/esig/gensim have no
   # arm64 wheels). Either read the committed .ipynb outputs for the notebooks
   # above, or run the amd64 image under Rosetta emulation (slow, no GPU):
@@ -238,6 +240,20 @@ services:
         - linux/amd64
     container_name: ml4t-py312
     profiles: ["py312"]
+
+  # Same image with an NVIDIA GPU attached, for the py312 notebooks that train
+  # (Ch21 deep_hedging). Linux and Windows WSL2 only, exactly like ml4t-gpu.
+  # Start with: docker compose --profile py312-gpu run --rm py312-gpu python ...
+  py312-gpu:
+    <<: *common
+    image: ml4t/ml4t-py312:latest
+    build:
+      context: .
+      dockerfile: envs/py312/Dockerfile
+      platforms:
+        - linux/amd64
+    container_name: ml4t-py312-gpu
+    profiles: ["py312-gpu"]
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@
 #   - Linux x86_64:     All services work, GPU optional
 #   - Windows x86_64:   All services via Docker Desktop (WSL2), GPU via WSL2+nvidia-toolkit
 #   - macOS Intel:      All services except GPU
-#   - Apple Silicon:    ml4t + benchmark (native arm64); ml4t-py312 not available (see below)
+#   - Apple Silicon:    ml4t + benchmark native arm64; ml4t-py312 amd64 only, runs under
+#                       Rosetta emulation (see below)
 #
 # IMAGES ON DOCKER HUB (docker.io/ml4t/):
 #   ml4t:latest           — All chapters, Python 3.14, PyTorch CUDA 12.8 (amd64+arm64)
@@ -21,7 +22,8 @@
 # WHICH IMAGE DO I NEED?
 #   Most readers: ml4t only (covers Ch01-Ch27 + case studies)
 #   Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06, Ch15 NB06, Ch21 deep_hedging:
-#       ml4t-py312 (x86 only, Apple Silicon: see .ipynb outputs)
+#       ml4t-py312 (amd64; on Apple Silicon read the committed .ipynb outputs, or run it
+#       under Rosetta with DOCKER_DEFAULT_PLATFORM=linux/amd64)
 #   Ch02 storage benchmarks: benchmark + database services
 #   Ch12 GBM GPU benchmark: rapids (requires NVIDIA GPU)
 #
@@ -241,8 +243,9 @@ services:
     container_name: ml4t-py312
     profiles: ["py312"]
 
-  # Same image with an NVIDIA GPU attached, for the py312 notebooks that train
-  # (Ch21 deep_hedging). Linux and Windows WSL2 only, exactly like ml4t-gpu.
+  # Same image with an NVIDIA GPU attached, for the seven GPU-tagged py312 notebooks
+  # (Ch05 NB01/03/07, Ch10 NB03, Ch12 NB10, Ch14 NB06, Ch21 deep_hedging), whether they
+  # train or run inference. Linux and Windows WSL2 only, exactly like ml4t-gpu.
   # Start with: docker compose --profile py312-gpu run --rm py312-gpu python ...
   py312-gpu:
     <<: *common

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,9 +101,9 @@ does not work on Intel Macs or in native Windows Python.
 > above, which is the one that is tested.
 
 > **macOS: which path depends on the chip.** On **Apple Silicon**, use the local `uv`
-> environment: it builds natively against the Xcode command-line tools, and the only reason to
-> add Docker is the twelve `ml4t-py312` notebooks, which have no arm64 build and run emulated.
-> On
+> environment: it builds natively against the Xcode command-line tools. Docker is worth adding
+> there only for the twelve `ml4t-py312` notebooks, which have no arm64 build, and for Chapter
+> 2's containerized database benchmarks. On
 > an **Intel Mac**, Docker is the only option, because PyTorch stopped publishing macOS x86_64
 > wheels and `uv sync` stops immediately with `Distribution torch==2.10.0 ... doesn't have a
 > source distribution or wheel for the current platform`. There is nothing to configure around
@@ -301,14 +301,15 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 has an arm64 wheel or builds from source against the Xcode command-line tools, the same way it
 does on Linux, so Docker would add a 13 GB image and change nothing. Go to
 [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path walked on
-real hardware before every release. The one exception is the twelve `ml4t-py312` notebooks, which
-have no arm64 build at all: they ship pre-executed, and
-[Py312 Image](#py312-image-specific-notebooks) covers running them under Rosetta if you want to,
-which is the only reason to install Docker Desktop on an Apple Silicon Mac.
+real hardware before every release. Two things still want Docker on that machine: the twelve
+`ml4t-py312` notebooks, which have no arm64 build at all and are covered under
+[Py312 Image](#py312-image-specific-notebooks), and Chapter 2's storage benchmarks, which compare
+databases that run as containers. Everything else is `uv`.
 
 ```bash
 xcode-select --install                        # compiler, if you do not have it already
 curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env                   # puts uv on PATH in this shell
 git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
 cd machine-learning-for-trading
 cp .env.example .env
@@ -453,8 +454,8 @@ Silicon setup above does not install:
    `py312-gpu` one: it reserves an NVIDIA device, which no Mac has, so all twelve notebooks go
    through the CPU-only service here.
 
-It runs at emulation speed. This is the only thing on an Apple Silicon Mac that Docker is needed
-for.
+It runs at emulation speed. Apart from Chapter 2's database benchmarks, this is the only thing
+on an Apple Silicon Mac that Docker is needed for.
 
 ---
 
@@ -573,6 +574,9 @@ Docker is recommended because it guarantees a consistent environment. But if you
 # Install uv — use this installer, not `pip install uv`. Most current systems either
 # ship no `pip` at all or refuse the install with `externally-managed-environment`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
+# The installer puts uv in ~/.local/bin, which your current shell does not know about
+# yet. Load it now rather than opening a new terminal:
+source $HOME/.local/bin/env        # sh, bash, zsh;  env.fish for fish
 # Windows PowerShell: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # Clone and enter the repository (about 0.9 GB of history)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,8 +101,9 @@ does not work on Intel Macs or in native Windows Python.
 > above, which is the one that is tested.
 
 > **macOS: which path depends on the chip.** On **Apple Silicon**, use the local `uv`
-> environment: it builds natively against the Xcode command-line tools and Docker buys you
-> nothing there. On
+> environment: it builds natively against the Xcode command-line tools, and the only reason to
+> add Docker is the twelve `ml4t-py312` notebooks, which have no arm64 build and run emulated.
+> On
 > an **Intel Mac**, Docker is the only option, because PyTorch stopped publishing macOS x86_64
 > wheels and `uv sync` stops immediately with `Distribution torch==2.10.0 ... doesn't have a
 > source distribution or wheel for the current platform`. There is nothing to configure around
@@ -432,7 +433,8 @@ Chapter 15 notebook 06 uses the isolated `/opt/bsts` interpreter so its NumPy 1 
 pandas 2.2 constraints do not replace dependencies required by the other py312 notebooks.
 
 The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. Seven of the
-twelve notebooks train a model and are faster with one: Ch05 `01_timegan`,
+twelve are GPU-tagged and run faster with one, whether they train or only do inference: Ch05
+`01_timegan`,
 `03_sigcwgan_signatures` and `07_dp_gan`, Ch10 `03_sentiment_evolution`, Ch12
 `10_shap_nlp_sentiment`, Ch14 `06_conditional_autoencoder` and Ch21
 `05_deep_hedging_pfhedge`. The `py312-gpu` service is the same image with an NVIDIA GPU
@@ -446,11 +448,13 @@ Silicon setup above does not install:
 1. Install Docker Desktop from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/),
    choosing the **Apple chip** download.
 2. Enable Settings → General → **Use Rosetta for x86_64/amd64 emulation**.
-3. Prefix each command above with `DOCKER_DEFAULT_PLATFORM=linux/amd64`, for example
-   `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --profile py312 pull py312`.
+3. Prefix the **`py312`** commands above with `DOCKER_DEFAULT_PLATFORM=linux/amd64`, for example
+   `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --profile py312 pull py312`. Skip the
+   `py312-gpu` one: it reserves an NVIDIA device, which no Mac has, so all twelve notebooks go
+   through the CPU-only service here.
 
-It runs at emulation speed and without a GPU. This is the only thing on an Apple Silicon Mac
-that Docker is needed for.
+It runs at emulation speed. This is the only thing on an Apple Silicon Mac that Docker is needed
+for.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,11 +98,12 @@ does not work on Intel Macs or in native Windows Python.
 > machine that already has the Visual Studio Build Tools. Inside WSL2 you are on the Linux path
 > above, which is the one that is tested.
 
-> **Intel Macs: use Docker, not the local `uv` path.** PyTorch stopped publishing macOS x86_64
-> wheels, so `uv sync` on an Intel Mac stops immediately with `Distribution torch==2.10.0 ...
-> doesn't have a source distribution or wheel for the current platform`. There is nothing to
-> configure around it. The `ml4t` image is amd64 and runs fine, so Docker is the Intel Mac path.
-> Apple Silicon has native wheels and the local `uv` path works there.
+> **macOS: which path depends on the chip.** On **Apple Silicon**, use the local `uv`
+> environment: every dependency has a native arm64 wheel and Docker buys you nothing there. On
+> an **Intel Mac**, Docker is the only option, because PyTorch stopped publishing macOS x86_64
+> wheels and `uv sync` stops immediately with `Distribution torch==2.10.0 ... doesn't have a
+> source distribution or wheel for the current platform`. There is nothing to configure around
+> it. See [macOS](#macos).
 
 ### Which image do I need?
 
@@ -115,7 +116,11 @@ does not work on Intel Macs or in native Windows Python.
 
 **Most readers need only `ml4t`.** The other images are for specific notebooks.
 
-**Apple Silicon users**: The notebooks requiring `ml4t-py312` are not runnable on ARM64 because the underlying libraries (signatory, esig) have no ARM64 builds. View the pre-executed `.ipynb` files on GitHub or in Jupyter instead.
+**Apple Silicon users**: `signatory` and `esig` have no ARM64 builds, so the `ml4t-py312`
+notebooks do not run natively. Every one of them ships pre-executed, so reading the `.ipynb` on
+GitHub or in Jupyter is the intended route. To execute them anyway, enable Docker Desktop →
+Settings → General → **Use Rosetta for x86_64/amd64 emulation** and pull the amd64 image; it
+works, at emulation speed. Nothing else in the book needs this.
 
 ---
 
@@ -287,21 +292,38 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 
 **Tip**: Keep the repo at `~/machine-learning-for-trading` in WSL, not under `/mnt/c/...`. Windows drives reach WSL through the 9P protocol bridge, which costs roughly 8x on a 512 MB sequential write, 240x on creating two thousand small files, and 470x on reading their metadata. `git clone` and `uv sync` are almost entirely small-file and metadata work, so those last two ratios are the ones a reader pays. Access WSL files from Windows Explorer via `\\wsl$\Ubuntu\home\<username>\machine-learning-for-trading`.
 
-### macOS (Intel and Apple Silicon)
+### macOS
 
-1. **Install Docker Desktop** from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
-   - Choose the correct chip: **Intel** or **Apple chip**
-   - Recommended resources: 4+ CPUs, 8+ GB memory, 64+ GB disk
+**Apple Silicon: use the local `uv` path, not Docker.** Every dependency has a native arm64
+wheel, `uv sync` needs nothing beyond the Xcode command-line tools, and it costs you no 13 GB
+image. Go to [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path
+that is walked on real hardware before every release.
 
-2. **Apple Silicon only**: In Docker Desktop Settings → General, enable **Use Rosetta for x86_64/amd64 emulation** (needed only for the `ml4t-py312` image, which most readers won't use).
+```bash
+xcode-select --install                        # compiler, if you do not have it already
+curl -LsSf https://astral.sh/uv/install.sh | sh
+git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
+cd machine-learning-for-trading
+cp .env.example .env
+uv sync
+```
 
-3. **Clone and pull**:
+**Intel Macs: Docker is the only local option.** PyTorch publishes no macOS x86_64 wheel, so the
+`uv` path cannot be made to work on that hardware. The `ml4t` image is amd64 and runs, so:
+
+1. Install Docker Desktop from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/),
+   choosing the **Intel chip** download. Give it 4+ CPUs, 8+ GB memory and 64+ GB disk in
+   Settings → Resources, and note that the image plus data wants about 17 GB of that disk.
+2. Clone and pull:
    ```bash
    git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
    cd machine-learning-for-trading
    cp .env.example .env
    docker compose pull ml4t
    ```
+
+If that machine is tight on memory or disk, a Linux box or a cloud instance is the more
+comfortable route, and it is the same Linux path documented above.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -294,11 +294,13 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 
 ### macOS
 
-**Apple Silicon: use the local `uv` path, not Docker.** Everything the book needs either has an
-arm64 wheel or builds from source against the Xcode command-line tools, the same way it does on
-Linux, and Docker would add a 13 GB image for no benefit. Go to
+**Apple Silicon: use the local `uv` path, not Docker.** Everything in the main environment either
+has an arm64 wheel or builds from source against the Xcode command-line tools, the same way it
+does on Linux, so Docker would add a 13 GB image and change nothing. Go to
 [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path walked on
-real hardware before every release.
+real hardware before every release. The one exception is the ten or so `ml4t-py312` notebooks,
+which have no arm64 build at all: they ship pre-executed, and
+[Py312 Image](#py312-image-specific-notebooks) covers running them under Rosetta if you want to.
 
 ```bash
 xcode-select --install                        # compiler, if you do not have it already

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,10 +118,9 @@ does not work on Intel Macs or in native Windows Python.
 **Most readers need only `ml4t`.** The other images are for specific notebooks.
 
 **Apple Silicon users**: `signatory` and `esig` have no ARM64 builds, so the `ml4t-py312`
-notebooks do not run natively. Every one of them ships pre-executed, so reading the `.ipynb` on
-GitHub or in Jupyter is the intended route. To execute them anyway, enable Docker Desktop →
-Settings → General → **Use Rosetta for x86_64/amd64 emulation** and pull the amd64 image; it
-works, at emulation speed. Nothing else in the book needs this.
+notebooks do not run natively. They all ship pre-executed, and
+[Py312 Image](#py312-image-specific-notebooks) covers both reading them and running them under
+Rosetta. Nothing else in the book needs this.
 
 ---
 
@@ -422,7 +421,15 @@ docker compose --profile py312 run --rm py312 \
 Chapter 15 notebook 06 uses the isolated `/opt/bsts` interpreter so its NumPy 1 and
 pandas 2.2 constraints do not replace dependencies required by the other py312 notebooks.
 
-**Apple Silicon**: These notebooks cannot run natively. View the pre-executed `.ipynb` files in Jupyter or on GitHub.
+The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. On a machine with
+an NVIDIA GPU, `--profile py312-gpu run --rm py312-gpu` is the same image with the GPU attached,
+which Ch21 `05_deep_hedging_pfhedge` benefits from.
+
+**Apple Silicon**: these notebooks have no arm64 build and all of them ship pre-executed, so
+reading the `.ipynb` in Jupyter or on GitHub is the intended route. To execute them anyway,
+enable Docker Desktop → Settings → General → **Use Rosetta for x86_64/amd64 emulation** and
+prefix the commands above with `DOCKER_DEFAULT_PLATFORM=linux/amd64`. It works, at emulation
+speed and without a GPU.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -298,9 +298,10 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 has an arm64 wheel or builds from source against the Xcode command-line tools, the same way it
 does on Linux, so Docker would add a 13 GB image and change nothing. Go to
 [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path walked on
-real hardware before every release. The one exception is the ten or so `ml4t-py312` notebooks,
-which have no arm64 build at all: they ship pre-executed, and
-[Py312 Image](#py312-image-specific-notebooks) covers running them under Rosetta if you want to.
+real hardware before every release. The one exception is the twelve `ml4t-py312` notebooks, which
+have no arm64 build at all: they ship pre-executed, and
+[Py312 Image](#py312-image-specific-notebooks) covers running them under Rosetta if you want to,
+which is the only reason to install Docker Desktop on an Apple Silicon Mac.
 
 ```bash
 xcode-select --install                        # compiler, if you do not have it already
@@ -413,7 +414,8 @@ A small number of notebooks require Python 3.12 libraries not available on Pytho
 | `05_deep_hedging_pfhedge` | pfhedge (unmaintained, numpy<2) | Ch21 |
 
 ```bash
-# x86 systems only (Linux, Windows WSL2, macOS Intel)
+# On x86 (Linux, Windows WSL2, Intel Mac) run these as they stand. On Apple Silicon
+# prefix each with DOCKER_DEFAULT_PLATFORM=linux/amd64, see below.
 docker compose --profile py312 pull py312
 docker compose --profile py312 run --rm py312 python 05_synthetic_data/03_sigcwgan_signatures.py
 docker compose --profile py312 run --rm py312 \
@@ -428,10 +430,18 @@ an NVIDIA GPU, `--profile py312-gpu run --rm py312-gpu` is the same image with t
 which Ch21 `05_deep_hedging_pfhedge` benefits from.
 
 **Apple Silicon**: these notebooks have no arm64 build and all of them ship pre-executed, so
-reading the `.ipynb` in Jupyter or on GitHub is the intended route. To execute them anyway,
-enable Docker Desktop → Settings → General → **Use Rosetta for x86_64/amd64 emulation** and
-prefix the commands above with `DOCKER_DEFAULT_PLATFORM=linux/amd64`. It works, at emulation
-speed and without a GPU.
+reading the `.ipynb` in Jupyter or on GitHub is the intended route, and the local `uv` path
+covers everything else in the book. To execute them anyway you need Docker, which the Apple
+Silicon setup above does not install:
+
+1. Install Docker Desktop from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/),
+   choosing the **Apple chip** download.
+2. Enable Settings → General → **Use Rosetta for x86_64/amd64 emulation**.
+3. Prefix each command above with `DOCKER_DEFAULT_PLATFORM=linux/amd64`, for example
+   `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --profile py312 pull py312`.
+
+It runs at emulation speed and without a GPU. This is the only thing on an Apple Silicon Mac
+that Docker is needed for.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -299,7 +299,7 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 
 **Apple Silicon: use the local `uv` path, not Docker.** Everything in the main environment either
 has an arm64 wheel or builds from source against the Xcode command-line tools, the same way it
-does on Linux, so Docker would add a 13 GB image and change nothing. Go to
+does on Linux, so Docker would add an image you have no use for. Go to
 [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path walked on
 real hardware before every release. Two things still want Docker on that machine: the twelve
 `ml4t-py312` notebooks, which have no arm64 build at all and are covered under
@@ -425,7 +425,7 @@ docker compose --profile py312 run --rm py312 python 09_model_based_features/06_
 docker compose --profile py312 run --rm py312 \
   /opt/bsts/bin/python 15_causal_estimation/06_fed_announcement_bsts.py
 
-# The seven that train a model, on a machine with an NVIDIA GPU:
+# The seven GPU-tagged notebooks, on a machine with an NVIDIA GPU:
 docker compose --profile py312-gpu run --rm py312-gpu \
   python 05_synthetic_data/03_sigcwgan_signatures.py
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,8 @@ does not work on Intel Macs or in native Windows Python.
 > above, which is the one that is tested.
 
 > **macOS: which path depends on the chip.** On **Apple Silicon**, use the local `uv`
-> environment: every dependency has a native arm64 wheel and Docker buys you nothing there. On
+> environment: it builds natively against the Xcode command-line tools and Docker buys you
+> nothing there. On
 > an **Intel Mac**, Docker is the only option, because PyTorch stopped publishing macOS x86_64
 > wheels and `uv sync` stops immediately with `Distribution torch==2.10.0 ... doesn't have a
 > source distribution or wheel for the current platform`. There is nothing to configure around
@@ -294,10 +295,11 @@ Desktop can start, so complete steps 1-3 in order and do not skip the restart.
 
 ### macOS
 
-**Apple Silicon: use the local `uv` path, not Docker.** Every dependency has a native arm64
-wheel, `uv sync` needs nothing beyond the Xcode command-line tools, and it costs you no 13 GB
-image. Go to [Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path
-that is walked on real hardware before every release.
+**Apple Silicon: use the local `uv` path, not Docker.** Everything the book needs either has an
+arm64 wheel or builds from source against the Xcode command-line tools, the same way it does on
+Linux, and Docker would add a 13 GB image for no benefit. Go to
+[Local Setup with uv](#local-setup-with-uv-alternative-to-docker); this is the path walked on
+real hardware before every release.
 
 ```bash
 xcode-select --install                        # compiler, if you do not have it already

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,9 +83,11 @@ does not work at all — see the note under [Platform Support](#platform-support
 | **Linux x86_64**        |  ✅  |   ✅   |    ✅     | ✅* |
 | **Windows 11 (WSL2)**   |  ✅  |   ✅   |    ✅     | ✅* |
 | **macOS Intel**         |  ✅  |   ✅   |    ✅     |  -  |
-| **macOS Apple Silicon** |  ✅  |   -    |    ✅     |  -  |
+| **macOS Apple Silicon** |  ✅  |   †    |    ✅     |  -  |
 
 \* Requires NVIDIA GPU + nvidia-container-toolkit
+† `ml4t-py312` is amd64 only. It has no native build on Apple Silicon and runs under Rosetta
+emulation, which [Py312 Image](#py312-image-specific-notebooks) covers.
 
 The table is about the **Docker images**, which work on all four rows. The local `uv` path is
 narrower: it works on Linux, on Apple Silicon, and inside WSL2 (which is the Linux path), and it
@@ -417,17 +419,24 @@ A small number of notebooks require Python 3.12 libraries not available on Pytho
 # On x86 (Linux, Windows WSL2, Intel Mac) run these as they stand. On Apple Silicon
 # prefix each with DOCKER_DEFAULT_PLATFORM=linux/amd64, see below.
 docker compose --profile py312 pull py312
-docker compose --profile py312 run --rm py312 python 05_synthetic_data/03_sigcwgan_signatures.py
+docker compose --profile py312 run --rm py312 python 09_model_based_features/06_path_signatures.py
 docker compose --profile py312 run --rm py312 \
   /opt/bsts/bin/python 15_causal_estimation/06_fed_announcement_bsts.py
+
+# The seven that train a model, on a machine with an NVIDIA GPU:
+docker compose --profile py312-gpu run --rm py312-gpu \
+  python 05_synthetic_data/03_sigcwgan_signatures.py
 ```
 
 Chapter 15 notebook 06 uses the isolated `/opt/bsts` interpreter so its NumPy 1 and
 pandas 2.2 constraints do not replace dependencies required by the other py312 notebooks.
 
-The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. On a machine with
-an NVIDIA GPU, `--profile py312-gpu run --rm py312-gpu` is the same image with the GPU attached,
-which Ch21 `05_deep_hedging_pfhedge` benefits from.
+The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. Seven of the
+twelve notebooks train a model and are faster with one: Ch05 `01_timegan`,
+`03_sigcwgan_signatures` and `07_dp_gan`, Ch10 `03_sentiment_evolution`, Ch12
+`10_shap_nlp_sentiment`, Ch14 `06_conditional_autoencoder` and Ch21
+`05_deep_hedging_pfhedge`. The `py312-gpu` service is the same image with an NVIDIA GPU
+attached, for those.
 
 **Apple Silicon**: these notebooks have no arm64 build and all of them ship pre-executed, so
 reading the `.ipynb` in Jupyter or on GitHub is the intended route, and the local `uv` path

--- a/envs/README.md
+++ b/envs/README.md
@@ -50,7 +50,8 @@ The Chapter 15 command uses the isolated `/opt/bsts` interpreter. The default
 `/opt/ml4t` interpreter and its NumPy 2 signature, gensim, and pfhedge dependencies
 remain unchanged for every other py312 notebook.
 
-Not available on Apple Silicon — view pre-executed `.ipynb` files instead.
+No native arm64 image. On Apple Silicon, read the committed `.ipynb` outputs, or run the
+amd64 image under Rosetta with `DOCKER_DEFAULT_PLATFORM=linux/amd64`.
 
 ### benchmark (Storage Benchmarks)
 


### PR DESCRIPTION
Docker was presented as *the* macOS route for both chips. On Apple Silicon that is wrong: the
local `uv` environment builds natively, it is the path walked on real hardware before each
release, and Docker adds an image for nothing. This PR sends each chip to its own path and fixes
three defects found while doing it.

## macOS by chip

- **Apple Silicon → local `uv`.** The two things that still want Docker there are named where
  the recommendation is made: the twelve `ml4t-py312` notebooks, which have no arm64 build, and
  Chapter 2's containerized database benchmarks.
- **Intel Mac → Docker, kept deliberately.** PyTorch publishes no macOS x86_64 wheel, so `uv`
  cannot work on that hardware and deleting the macOS Docker section would leave those readers
  with nothing. The section now says which chip each path is for and notes that the image plus
  data wants about 17 GB, which is the real constraint on those machines.

## Three defects

1. **`uv` was not on `PATH` in the shell that installed it.** The macOS block and the README's
   Option B ran `uv sync` immediately after `curl … | sh`, which on a blank machine exits with
   `uv: command not found`. The installer's own output says to `source $HOME/.local/bin/env` or
   restart the shell; the commands now do the first. Confirmed against the macOS walk transcript.
2. **The `py312` service reserved an NVIDIA GPU, so it could not start on any Mac.** Its own
   header comment told Apple Silicon readers to run it under Rosetta, "slow, no GPU", while the
   service demanded a device Docker Desktop on macOS cannot provide. Split the way `ml4t` and
   `ml4t-gpu` already are: `py312` carries no reservation, `py312-gpu` is the same image with the
   GPU attached for the seven GPU-tagged notebooks.
3. **The Rosetta route assumed Docker Desktop was installed**, which the Apple Silicon path no
   longer does. The Py312 section now carries the three steps: install it, enable Rosetta, prefix
   with `DOCKER_DEFAULT_PLATFORM=linux/amd64`. `docker-compose.yml` and `envs/README.md` stop
   saying py312 is unavailable on Apple Silicon.

## README entry point

The README carried no installation link above the fold: a reader met the cover image and 350
lines of chapter listings before anything told them how to install. One line now does, before the
first callout.
