### PR TITLE
Tell local readers how to start Jupyter Lab, and give it a data path that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,9 +445,15 @@ uv run python scripts/download_artifacts.py
 `.ipynb`). Run a quick smoke test, or open Jupyter Lab:
 
 ```bash
-uv run python 01_process_is_edge/factor_regimes.py
-docker compose up -d ml4t # then open http://localhost:8888
+uv run python 01_process_is_edge/factor_regimes.py                # smoke test
+ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab  # local: open the URL it prints
+docker compose up -d ml4t                                         # Docker: same address
 ```
+
+`uv sync` already installed Jupyter Lab. Start it from the repo root: the `ML4T_DATA_PATH` prefix
+gives the loaders an absolute path, because Jupyter runs each notebook with its chapter folder as the
+working directory, and they would otherwise search inside that folder and report the datasets as
+missing. It keeps a value you have already exported and defaults to this repository's `data/`.
 
 See the guide to **[running notebooks](docs/running-notebooks.md)** for case-study pipelines, Papermill parameters, and
 the experiment workflow.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -595,7 +595,21 @@ cp .env.example .env
 
 # Verify
 uv run python -c "import polars, torch, lightgbm; print('Ready')"
+
+# Start Jupyter Lab, from the repo root, and open the URL it prints
+ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab
 ```
+
+`uv sync` installs Jupyter Lab along with everything else. The `ML4T_DATA_PATH` prefix gives the data
+loaders an absolute path: Jupyter runs each notebook with its own chapter folder as the working
+directory, so they would otherwise search inside that folder and report the datasets as missing. The
+form above keeps a value you have already exported and falls back to this repository's `data/`.
+
+Jupyter prints its address with a freshly generated access token attached
+(`http://localhost:8888/lab?token=…`). Open that whole line; a bare `http://localhost:8888` only
+shows a token prompt. On Windows, run the command in your WSL2 Ubuntu terminal and paste the URL into
+your normal Windows browser - no browser opens by itself there, and WSL2 forwards `localhost` for
+you.
 
 ### How pyproject.toml Works
 

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -61,11 +61,31 @@ uv sync
 
 # Run a notebook
 uv run python 11_ml_pipeline/01_ols_inference.py
+
+# Or start Jupyter Lab, from the repo root, and open the URL it prints
+ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab
 ```
+
+A local Jupyter Lab generates an access token on each start and prints the address with the token
+attached:
+
+```
+http://localhost:8888/lab?token=ef2600091d6010aa5e7f044172907ebf893f16f5d1aaa851
+```
+
+Open that whole line, not a bare `http://localhost:8888`, which only shows a token prompt. On
+Windows the server runs inside WSL2 and no browser opens by itself, so copy the URL into your normal
+Windows browser; WSL2 forwards `localhost` for you.
+
+`uv sync` installs Jupyter Lab, so no separate install is needed. The `ML4T_DATA_PATH` prefix gives
+the data loaders an absolute path: Jupyter runs each notebook with its own chapter folder as the
+working directory, and without it they look for `01_process_is_edge/data/…` and report the data as
+missing. The form above keeps a value you already exported and falls back to the repository's own
+`data/` only when you have not set one. If you keep the datasets elsewhere, export that path in your
+shell profile - setting it in `.env` alone is not enough, because `uv run` does not read `.env`.
 
 **Platform notes for local setup:**
 - **Python 3.14+** required
-- **TA-Lib** must be installed separately ([instructions](https://ta-lib.github.io/ta-lib-python/install.html))
 - **GPU**: PyTorch auto-detects CUDA if NVIDIA drivers are installed
 - **Apple Silicon**: Most packages have native ARM64 wheels; the py312 notebooks above cannot run on ARM64 — view their pre-executed `.ipynb` files instead
 
@@ -73,9 +93,12 @@ uv run python 11_ml_pipeline/01_ols_inference.py
 
 ## Your First Notebook
 
-If you started Jupyter Lab with `docker compose up ml4t`, open
-**http://localhost:8888** in your web browser. The repository's file tree appears
-on the left.
+Once Jupyter Lab is running - `docker compose up ml4t` on the Docker path, or
+`ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab` from the repo
+root on the local path - open it in your web browser: **http://localhost:8888**
+for Docker, and for the local path the tokenized URL the server printed. The
+repository's file tree appears on the left. On Windows, start it inside your WSL2
+Ubuntu terminal and open the address in your normal Windows browser.
 
 1. In the file browser (left panel), open a chapter folder — e.g.
    `01_process_is_edge` — and **double-click** a `.ipynb` file to open it.
@@ -113,7 +136,10 @@ uv run python 11_ml_pipeline/01_ols_inference.py
 docker compose run --rm ml4t python 11_ml_pipeline/01_ols_inference.py
 ```
 
-**Important**: Always run from the repository root. Running from a subdirectory will fail with `ImportError: No module named 'utils'`.
+**Important**: Run `.py` notebooks from the repository root. The data loaders resolve `data/` relative
+to the working directory, so running from a chapter folder reports the datasets as missing even when
+they are downloaded. Setting `ML4T_DATA_PATH` to an absolute path removes the constraint, which is
+why the Jupyter Lab command above sets it.
 
 ---
 


### PR DESCRIPTION
A reader who picks the local `uv` path installs Jupyter Lab as part of `uv sync` and is never told it
is there. The README answered its own "or open Jupyter Lab" with `docker compose up -d ml4t`, and the
"Your First Notebook" walkthrough opened with *"If you started Jupyter Lab with `docker compose up
ml4t`"*, so the local path had no way in at all.

Starting it is not sufficient on its own, which is the substance of this change. Jupyter runs each
notebook with its **own chapter folder** as the working directory. The data root falls back to
`cwd/data` whenever `ML4T_DATA_PATH` is unset, and on the local path it is unset - `.env.example`
ships it commented out. Every data-loading notebook then looks for `01_process_is_edge/data/…` and
reports datasets that are downloaded and present as missing. Docker never sees this because
`docker-compose.yml` sets `ML4T_DATA_PATH=/data` in the container.

So the three places that start Jupyter Lab now pass a data path:

```bash
ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab
```

which keeps a path the reader already exported and falls back to the repository's own `data/`.

## Verified on a clean install

Walked on a blank Windows 11 Pro 25H2 VM, WSL2, Ubuntu 26.04, following `docs/installation.md` from
the top: 7/7 free datasets downloaded (4.1 GB, ~14 min), Jupyter Lab started from the repo root and
reached from the **Windows** browser at `localhost:8888` (200, `<title>JupyterLab</title>`).

`01_process_is_edge/factor_regimes.ipynb`, executed with a Jupyter kernel:

| | result |
|---|---|
| without `ML4T_DATA_PATH` | `FileNotFoundError: AQR data directory not found at …/01_process_is_edge/data/factors/aqr` |
| with it set | 46 cells, **0 errors, 9 rendered figures**, 22 s |

## Also in this change

- **Drop "TA-Lib must be installed separately".** `pyproject.toml` pins `ta-lib>=0.6.8` and the
  lockfile carries cp314 wheels for every supported platform, so `uv sync` installs it; `import
  talib` works with nothing installed by hand.
- **Document the access token.** A local Jupyter Lab mints a token per start; a bare
  `http://localhost:8888` returns a token prompt, measured as a 302 from the Windows side. On WSL2 no
  browser opens by itself, so the printed URL has to be copied across.
- **Correct the subdirectory warning.** It named `ImportError: No module named 'utils'`; `utils` is
  an installed package after `uv sync` and imports from any directory. What actually breaks when you
  run from a chapter folder is the data path above.
