### PR TITLE
Give readers a working first hour: AlgoSeek data, the data root, and honest download status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,10 @@
 # ML4T_PATH=/path/to/third-edition
 
 # Data directory path — LEAVE THIS COMMENTED OUT unless you keep your data on a
-# separate drive. The default (./data, the repo's own data folder) is correct for
-# all early chapters; you do not need to set or edit it to get started. Only
-# uncomment and set an absolute path to store data outside the repository:
+# separate drive. The default is the repo's own data folder, and it is the same
+# folder whichever directory you start from, so you do not need to set or edit
+# this to get started. Only uncomment and set a path to store data outside the
+# repository; a relative path is taken relative to the repository root:
 # ML4T_DATA_PATH=/path/to/data
 
 # ============================================================================

--- a/.github/workflows/reader-install.yml
+++ b/.github/workflows/reader-install.yml
@@ -42,6 +42,7 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.env.example'
+      - 'sitecustomize.py'
       - 'docs/installation.md'
       - 'README.md'
       - 'data/**'
@@ -97,6 +98,23 @@ jobs:
         run: |
           set -o pipefail
           time uv sync 2>&1 | tail -30
+
+      # What no earlier walk checked: a process whose working directory is a chapter
+      # directory, which is what Jupyter Lab gives every kernel. The data root used to
+      # resolve to <repo>/<chapter>/data there, so every data-loading notebook failed
+      # on the local uv path while the same notebook run from the repo root worked.
+      - name: The data root is anchored to the repo, not to the working directory
+        run: |
+          set -euo pipefail
+          root=$(uv run python -c "import os;print(os.environ['ML4T_DATA_PATH'])")
+          chapter=$(cd 01_process_is_edge && uv run python -c "import os;print(os.environ['ML4T_DATA_PATH'])")
+          echo "repo root: $root"
+          echo "chapter:   $chapter"
+          test "$root" = "$PWD/data"
+          test "$chapter" = "$root"
+          hook=$(uv run python -c "import sitecustomize;print(sitecustomize.__file__)")
+          echo "sitecustomize: $hook"
+          test "$hook" = "$PWD/sitecustomize.py"
 
       - name: Copy the environment template
         run: cp .env.example .env

--- a/data/README.md
+++ b/data/README.md
@@ -34,10 +34,10 @@ cross-asset (factors, macro, prediction markets, news, text).
 | ------------------------ | ------------ | ------------- | ------------ | ------- | --------- | ---------------- | ------ |
 | ETF Universe             | Equity       | Market        | Daily        | 100     | 2006-2025 | Yahoo Finance    | No     |
 | US Equities              | Equity       | Market        | Daily        | 3,199   | 1962-2018 | NASDAQ DL        | Free   |
-| S&P 500 Bars             | Equity       | Market        | Daily        | ~638    | 2017-2021 | AlgoSeek         | Soon   |
-| S&P 500 Options          | Equity       | Market        | Daily        | ~500    | 2017-2021 | AlgoSeek         | Soon   |
-| NASDAQ-100 Bars          | Equity       | Market        | Minute       | ~100    | 2020-2021 | AlgoSeek         | Soon   |
-| TAQ Tick                 | Equity       | Market        | Tick         | 1       | Mar 2020  | AlgoSeek         | Soon   |
+| S&P 500 Bars             | Equity       | Market        | Daily        | ~638    | 2017-2021 | AlgoSeek         | Pending|
+| S&P 500 Options          | Equity       | Market        | Daily        | 634     | 2017-2021 | AlgoSeek         | Convert|
+| NASDAQ-100 Bars          | Equity       | Market        | Minute       | ~100    | 2020-2021 | AlgoSeek         | Convert|
+| TAQ Tick                 | Equity       | Market        | Tick         | 1       | Mar 2020  | AlgoSeek         | Pending|
 | MBO Tick                 | Equity       | Market        | Tick         | 1       | Nov 2024  | Databento        | Manual |
 | NASDAQ ITCH              | Equity       | Market        | Tick         | all     | varies    | NASDAQ FTP       | No     |
 | IEX DEEP/TOPS            | Equity       | Market        | Tick         | all     | varies    | IEX public       | No     |
@@ -69,9 +69,10 @@ unauthenticated script. `Free` — script-download, free API key required.
 `Paid` — script-download, billed API (see per-dataset estimates).
 `Manual` — reader downloads from a hosted URL or provider portal and
 places the files under `$ML4T_DATA_PATH` (no script); the DataBento MBO
-one-off has step-by-step instructions below. `Soon` — the reduced
-reader-facing AlgoSeek datasets are being prepared for hosting; the
-download URL and instructions will be published before launch.
+one-off has step-by-step instructions below. `Convert` — AlgoSeek hosts
+the archive openly, and one script turns it into what the loaders read; see
+[AlgoSeek datasets](#algoseek-datasets). `Pending` — AlgoSeek has not
+published this one yet, and nothing you can run substitutes for it.
 
 ---
 
@@ -133,6 +134,49 @@ total cost is under $10 and the files stay available for 30 days.
 See `data/equities/market/microstructure/MBO_DOWNLOAD.md` for step-by-step
 instructions. An API-based alternative (`mbo_download.py`) is available
 for users who already have a `DATABENTO_API_KEY`.
+
+### AlgoSeek datasets
+
+AlgoSeek publishes two of the four datasets this book uses at
+<https://algoseek.com/ml-for-trading/> — plain download links, no account, no
+API key. Both are CSV; every loader reads parquet, so one conversion step sits
+between the download and the notebooks.
+
+| Archive | Size | What it is |
+| --- | --- | --- |
+| `nasdaq-100-constituents-taq-ext.zip` | 5.9 GB | NASDAQ-100 extended minute bars, 505 days, 2020-01-02 to 2021-12-31 |
+| `options_daily_greeks_sp500.zip` | 13.8 GB | S&P 500 daily option chains with Greeks, 1,259 days 2017-2021, 634 symbols |
+
+```bash
+# NASDAQ-100 minute bars -> equities/market/nasdaq100/minute_bars/
+uv run python data/equities/market/algoseek_convert.py \
+    --dataset nasdaq100-minute-bars --source ~/Downloads/nasdaq-100-constituents-taq-ext.zip
+
+# S&P 500 raw option chains -> equities/market/sp500/options/
+uv run python data/equities/market/algoseek_convert.py \
+    --dataset sp500-options --source ~/Downloads/options_daily_greeks_sp500.zip
+
+# then build what the options notebooks actually load
+uv run python data/equities/market/sp500/build_options_eda.py
+uv run python data/equities/market/sp500/build_options_straddles_raw.py
+uv run python data/equities/market/sp500/materialize_options.py
+```
+
+`--source` also takes a directory you have already extracted, which is
+considerably faster for the options archive: it holds 1,275,314 gzipped files,
+and reading them out of the zip pays the archive's index on every open. Both
+conversions resume, so an interrupted run continues where it stopped.
+
+**Two datasets are not published yet.** AlgoSeek staged them for hosting and has
+not packaged them; nothing in this repo substitutes for either.
+
+| Missing | Blocks |
+| --- | --- |
+| S&P 500 daily bars | `18_transaction_costs/01_cost_taxonomy`, `02_spread_estimation`, `03_market_impact_calibration`, and the `sp500_equity_option_analytics` backtest |
+| NASDAQ-100 TAQ ticks | `03_market_microstructure/11_algoseek_taq_eda`, `12_algoseek_taq_lob_reconstruction` |
+
+The published minute-bar archive cannot stand in for the ticks: it is
+quote-aware bar aggregates, and reconstructing an order book needs the events.
 
 ### Update Existing Data
 

--- a/data/README.md
+++ b/data/README.md
@@ -101,7 +101,7 @@ uv run python data/futures/positioning/cot_download.py                    # ~2-3
 
 **Note on crypto download time**: The Binance public API returns max 1,500 rows per request with ~1s server response time. Downloading 5 years of hourly data for 19 symbols requires ~700 API calls. Downloads run in parallel (5 concurrent), but the total still takes 10-15 minutes. This is a Binance server-side rate limit, not a bug.
 
-If some symbols do not arrive, the script names them and exits non-zero. Re-running fetches only what is missing. Pass `--allow-partial` to keep what arrived and exit 0.
+If a symbol is missing from the result, the script names it and exits non-zero. Re-running fetches every symbol again and merges into what is already on disk, so one that failed can arrive on the second run; the status is then computed from the merged data, not from the second run's failures. Pass `--allow-partial` to keep what arrived and exit 0.
 
 ### Free API Key Required
 

--- a/data/README.md
+++ b/data/README.md
@@ -100,6 +100,8 @@ uv run python data/futures/positioning/cot_download.py                    # ~2-3
 
 **Note on crypto download time**: The Binance public API returns max 1,500 rows per request with ~1s server response time. Downloading 5 years of hourly data for 19 symbols requires ~700 API calls. Downloads run in parallel (5 concurrent), but the total still takes 10-15 minutes. This is a Binance server-side rate limit, not a bug.
 
+If some symbols do not arrive, the script names them and exits non-zero. Re-running fetches only what is missing. Pass `--allow-partial` to keep what arrived and exit 0.
+
 ### Free API Key Required
 
 ```bash

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -58,6 +58,21 @@ def combine_existing(output_path: Path, new_df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
+def missing_symbols(df: pl.DataFrame, symbols: list[str]) -> list[str]:
+    """Which requested symbols are absent from what is now on disk.
+
+    The status has to come from the merged dataset, not from the symbols that
+    failed in this request. combine_existing() folds a retry into what a previous
+    run already wrote, so a symbol that fails on the retry is still present, and
+    reporting the request's failures would fail a download that is in fact
+    complete.
+    """
+    if df.is_empty():
+        return list(symbols)
+    present = set(df["symbol"].unique().to_list())
+    return [s for s in symbols if s not in present]
+
+
 def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> str | None:
     if not output_path.exists():
         return None
@@ -222,6 +237,10 @@ def main() -> None:
     storage_path.mkdir(parents=True, exist_ok=True)
     dictionary_path = write_dictionary(storage_path, symbol_groups)
     summary: dict[str, object] = {"dictionary_file": str(dictionary_path)}
+    # What is absent from the merged dataset, which is what the exit status is
+    # about. Not the same as the failed lists below, which are per-request.
+    perps_missing: list[str] = []
+    premium_missing: list[str] = []
     perps_failed: list[str] = []
     premium_failed: list[str] = []
 
@@ -262,6 +281,7 @@ def main() -> None:
             perps_df = clamp_date_range(perps_df, perps_start, perps_end)
             if not args.symbol:
                 perps_df = perps_df.filter(pl.col("symbol").is_in(symbols))
+            perps_missing = missing_symbols(perps_df, symbols)
             atomic_write_parquet(perps_df, perps_output)
             save_partitioned(perps_df, storage_path / "ohlcv_1h")
             profile_path = save_dataset_profile(
@@ -269,9 +289,11 @@ def main() -> None:
             )
             summary["perps_rows"] = len(perps_df)
             summary["perps_symbols"] = perps_df["symbol"].n_unique()
-            summary["perps_failed"] = len(perps_failed)
+            summary["perps_missing"] = len(perps_missing)
             summary["perps_output"] = str(perps_output)
             summary["perps_profile"] = str(profile_path)
+        else:
+            perps_missing = list(symbols)
 
     if download_premium_flag:
         premium_output = storage_path / premium_file
@@ -314,6 +336,7 @@ def main() -> None:
             premium_df = clamp_date_range(premium_df, premium_start, premium_end)
             if not args.symbol:
                 premium_df = premium_df.filter(pl.col("symbol").is_in(symbols))
+            premium_missing = missing_symbols(premium_df, symbols)
             atomic_write_parquet(premium_df, premium_output)
             save_partitioned(premium_df, storage_path / "premium_index")
             profile_path = save_dataset_profile(
@@ -321,25 +344,34 @@ def main() -> None:
             )
             summary["premium_rows"] = len(premium_df)
             summary["premium_symbols"] = premium_df["symbol"].n_unique()
-            summary["premium_failed"] = len(premium_failed)
+            summary["premium_missing"] = len(premium_missing)
             summary["premium_output"] = str(premium_output)
             summary["premium_profile"] = str(profile_path)
+        else:
+            premium_missing = list(symbols)
 
     print_download_summary(summary)
 
-    # Exit non-zero when any symbol is missing. Binance rate-limits this download —
-    # roughly 700 calls over 10-15 minutes — so coming back short is the expected
-    # failure, and exiting 0 makes it indistinguishable from a complete download to
-    # download_all.py, to CI, and to a reader who checks the status rather than
-    # reading the summary. --allow-partial keeps what arrived; re-running resumes.
-    if perps_failed or premium_failed:
-        for label, failed in (("perpetual OHLCV", perps_failed), ("premium index", premium_failed)):
-            if failed:
-                print(f"\n{len(failed)} {label} symbol(s) failed: {', '.join(sorted(failed))}")
+    # Exit non-zero when a requested symbol is absent from what is now on disk.
+    # Binance rate-limits this download — roughly 700 calls over 10-15 minutes —
+    # so coming back short is the expected failure, and exiting 0 makes it
+    # indistinguishable from a complete download to download_all.py, to CI, and to
+    # a reader who checks the status rather than reading the summary.
+    if perps_missing or premium_missing:
+        for label, missing in (
+            ("perpetual OHLCV", perps_missing),
+            ("premium index", premium_missing),
+        ):
+            if missing:
+                print(f"\n{len(missing)} {label} symbol(s) missing: {', '.join(sorted(missing))}")
+        # Re-running fetches every configured symbol again and merges the result
+        # into what is already on disk, so a symbol that failed once can arrive on
+        # the second run. It is a retry, not a resume; --update is the incremental
+        # path, and it extends the window rather than filling gaps in it.
         if args.allow_partial:
-            print("\nPartial download accepted (--allow-partial). Re-run to fetch the rest.")
+            print("\nPartial download accepted (--allow-partial). Re-run to try the rest.")
         else:
-            print("\nPartial download. Re-run to fetch the missing symbols,")
+            print("\nPartial download. Re-run to try the missing symbols again,")
             print("or pass --allow-partial to accept what arrived.")
             sys.exit(1)
 

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -81,10 +81,22 @@ def missing_symbols(
 
 
 def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> str | None:
+    """Where an incremental update has to start so no symbol is skipped.
+
+    The *earliest* per-symbol last timestamp, not the dataset-wide maximum. Those
+    differ exactly when an earlier update was partial: the symbols that succeeded
+    carry the dataset maximum, so starting there would step over the gap left by
+    the ones that failed and never fill it, while the run reported success. The
+    cost of starting earlier is refetching rows for symbols that are already
+    current, which combine_existing() dedups on (symbol, timestamp).
+    """
     if not output_path.exists():
         return None
 
-    last_ts = pl.read_parquet(output_path).select(pl.col("timestamp").max()).item()
+    per_symbol = pl.read_parquet(output_path).group_by("symbol").agg(pl.col("timestamp").max())
+    if per_symbol.is_empty():
+        return None
+    last_ts = per_symbol["timestamp"].min()
     if last_ts is None:
         return None
 
@@ -276,8 +288,11 @@ def main() -> None:
             print("\nDownloading perpetual OHLCV...")
             new_df, perps_failed = download_perps(provider, symbols, start_date, perps_end)
             if new_df.is_empty():
-                print("ERROR: no perpetual OHLCV data downloaded")
-                sys.exit(1)
+                # Not necessarily a failure: a fully rate-limited retry against a
+                # complete dataset arrives here. Fall through to the merged-dataset
+                # check rather than exiting, so the status reflects what is on disk
+                # and --allow-partial still applies.
+                print("No perpetual OHLCV rows returned; falling back to what is on disk.")
             perps_df = (
                 combine_existing(perps_output, new_df)
                 if perps_output.exists() and not args.force
@@ -331,8 +346,7 @@ def main() -> None:
                 provider, symbols, start_date, premium_end, premium_interval
             )
             if new_df.is_empty():
-                print("ERROR: no premium index data downloaded")
-                sys.exit(1)
+                print("No premium index rows returned; falling back to what is on disk.")
             premium_df = (
                 combine_existing(premium_output, new_df)
                 if premium_output.exists() and not args.force

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -163,6 +163,11 @@ def main() -> None:
         action="store_true",
         help="Extend the configured end date to today and append new rows",
     )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Exit 0 even if some symbols failed (keeps what arrived; re-run to resume)",
+    )
     args = parser.parse_args()
 
     load_dotenv()
@@ -217,6 +222,8 @@ def main() -> None:
     storage_path.mkdir(parents=True, exist_ok=True)
     dictionary_path = write_dictionary(storage_path, symbol_groups)
     summary: dict[str, object] = {"dictionary_file": str(dictionary_path)}
+    perps_failed: list[str] = []
+    premium_failed: list[str] = []
 
     if download_perps_flag:
         perps_output = storage_path / perps_template.format(frequency="1h")
@@ -229,7 +236,7 @@ def main() -> None:
                 perps_df = (
                     pl.read_parquet(perps_output) if perps_output.exists() else pl.DataFrame()
                 )
-                perps_failed: list[str] = []
+                perps_failed = []
             else:
                 start_date = incremental_start
                 print(f"\nAppending perpetual OHLCV from {start_date}...")
@@ -277,7 +284,7 @@ def main() -> None:
                 premium_df = (
                     pl.read_parquet(premium_output) if premium_output.exists() else pl.DataFrame()
                 )
-                premium_failed: list[str] = []
+                premium_failed = []
             else:
                 start_date = incremental_start
                 print(f"\nAppending premium index from {start_date}...")
@@ -319,6 +326,22 @@ def main() -> None:
             summary["premium_profile"] = str(profile_path)
 
     print_download_summary(summary)
+
+    # Exit non-zero when any symbol is missing. Binance rate-limits this download —
+    # roughly 700 calls over 10-15 minutes — so coming back short is the expected
+    # failure, and exiting 0 makes it indistinguishable from a complete download to
+    # download_all.py, to CI, and to a reader who checks the status rather than
+    # reading the summary. --allow-partial keeps what arrived; re-running resumes.
+    if perps_failed or premium_failed:
+        for label, failed in (("perpetual OHLCV", perps_failed), ("premium index", premium_failed)):
+            if failed:
+                print(f"\n{len(failed)} {label} symbol(s) failed: {', '.join(sorted(failed))}")
+        if args.allow_partial:
+            print("\nPartial download accepted (--allow-partial). Re-run to fetch the rest.")
+        else:
+            print("\nPartial download. Re-run to fetch the missing symbols,")
+            print("or pass --allow-partial to accept what arrived.")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -58,19 +58,26 @@ def combine_existing(output_path: Path, new_df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def missing_symbols(df: pl.DataFrame, symbols: list[str]) -> list[str]:
-    """Which requested symbols are absent from what is now on disk.
+def missing_symbols(
+    df: pl.DataFrame, symbols: list[str], failed: list[str], *, updating: bool
+) -> list[str]:
+    """Which requested symbols this run did not deliver.
 
-    The status has to come from the merged dataset, not from the symbols that
-    failed in this request. combine_existing() folds a retry into what a previous
-    run already wrote, so a symbol that fails on the retry is still present, and
-    reporting the request's failures would fail a download that is in fact
-    complete.
+    On a plain run the answer comes from the merged dataset, not from the symbols
+    that failed in this request: combine_existing() folds a retry into what a
+    previous run already wrote, so a symbol that fails on the retry is still
+    present, and reporting the request's failures would fail a download that is in
+    fact complete.
+
+    --update inverts that. Every symbol is already on disk by construction, so
+    presence proves nothing about whether the window was extended - there the
+    request's failures are exactly what did not arrive.
     """
-    if df.is_empty():
-        return list(symbols)
-    present = set(df["symbol"].unique().to_list())
-    return [s for s in symbols if s not in present]
+    present = set() if df.is_empty() else set(df["symbol"].unique().to_list())
+    absent = {s for s in symbols if s not in present}
+    if updating:
+        absent |= {s for s in failed if s in symbols}
+    return sorted(absent)
 
 
 def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> str | None:
@@ -181,7 +188,7 @@ def main() -> None:
     parser.add_argument(
         "--allow-partial",
         action="store_true",
-        help="Exit 0 even if some symbols failed (keeps what arrived; re-run to resume)",
+        help="Exit 0 even if symbols are missing (keeps what arrived; re-run to retry them)",
     )
     args = parser.parse_args()
 
@@ -281,7 +288,7 @@ def main() -> None:
             perps_df = clamp_date_range(perps_df, perps_start, perps_end)
             if not args.symbol:
                 perps_df = perps_df.filter(pl.col("symbol").is_in(symbols))
-            perps_missing = missing_symbols(perps_df, symbols)
+            perps_missing = missing_symbols(perps_df, symbols, perps_failed, updating=args.update)
             atomic_write_parquet(perps_df, perps_output)
             save_partitioned(perps_df, storage_path / "ohlcv_1h")
             profile_path = save_dataset_profile(
@@ -336,7 +343,9 @@ def main() -> None:
             premium_df = clamp_date_range(premium_df, premium_start, premium_end)
             if not args.symbol:
                 premium_df = premium_df.filter(pl.col("symbol").is_in(symbols))
-            premium_missing = missing_symbols(premium_df, symbols)
+            premium_missing = missing_symbols(
+                premium_df, symbols, premium_failed, updating=args.update
+            )
             atomic_write_parquet(premium_df, premium_output)
             save_partitioned(premium_df, storage_path / "premium_index")
             profile_path = save_dataset_profile(

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -80,6 +80,13 @@ def missing_symbols(
     return sorted(absent)
 
 
+def _empty_response_note(force: bool) -> str:
+    """What happens next when nothing arrived, which --force changes."""
+    if force:
+        return "--force replaces rather than merges, so there is nothing to fall back to."
+    return "Falling back to what is already on disk."
+
+
 def get_update_start(
     output_path: Path,
     end_date: str,
@@ -312,7 +319,7 @@ def main() -> None:
                 # --force means replace, not merge, so there is nothing to fall
                 # back to: a forced refresh that returned nothing has failed, and
                 # keeping the old rows would report stale data as the result.
-                print("No perpetual OHLCV rows returned; falling back to what is on disk.")
+                print(f"No perpetual OHLCV rows returned. {_empty_response_note(args.force)}")
                 perps_df = (
                     pl.read_parquet(perps_output)
                     if perps_output.exists() and not args.force
@@ -374,7 +381,7 @@ def main() -> None:
                 provider, symbols, start_date, premium_end, premium_interval
             )
             if new_df.is_empty():
-                print("No premium index rows returned; falling back to what is on disk.")
+                print(f"No premium index rows returned. {_empty_response_note(args.force)}")
                 premium_df = (
                     pl.read_parquet(premium_output)
                     if premium_output.exists() and not args.force

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -309,8 +309,15 @@ def main() -> None:
                 # check rather than exiting, so the status reflects what is on disk
                 # and --allow-partial still applies. The provider returns a frame
                 # with no columns at all, so it can be neither combined nor sorted.
+                # --force means replace, not merge, so there is nothing to fall
+                # back to: a forced refresh that returned nothing has failed, and
+                # keeping the old rows would report stale data as the result.
                 print("No perpetual OHLCV rows returned; falling back to what is on disk.")
-                perps_df = pl.read_parquet(perps_output) if perps_output.exists() else new_df
+                perps_df = (
+                    pl.read_parquet(perps_output)
+                    if perps_output.exists() and not args.force
+                    else new_df
+                )
             else:
                 perps_df = (
                     combine_existing(perps_output, new_df)
@@ -368,7 +375,11 @@ def main() -> None:
             )
             if new_df.is_empty():
                 print("No premium index rows returned; falling back to what is on disk.")
-                premium_df = pl.read_parquet(premium_output) if premium_output.exists() else new_df
+                premium_df = (
+                    pl.read_parquet(premium_output)
+                    if premium_output.exists() and not args.force
+                    else new_df
+                )
             else:
                 premium_df = (
                     combine_existing(premium_output, new_df)

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -80,8 +80,14 @@ def missing_symbols(
     return sorted(absent)
 
 
-def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> str | None:
-    """Where an incremental update has to start so no symbol is skipped.
+def get_update_start(
+    output_path: Path,
+    end_date: str,
+    interval_hours: int,
+    symbols: list[str] | None = None,
+    configured_start: str | None = None,
+) -> str | None:
+    """Where an incremental update has to start so no symbol is left short.
 
     The *earliest* per-symbol last timestamp, not the dataset-wide maximum. Those
     differ exactly when an earlier update was partial: the symbols that succeeded
@@ -89,6 +95,10 @@ def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> s
     the ones that failed and never fill it, while the run reported success. The
     cost of starting earlier is refetching rows for symbols that are already
     current, which combine_existing() dedups on (symbol, timestamp).
+
+    A symbol missing from the file entirely has no history at all, not a recent
+    gap, so the window has to reopen at *configured_start* — otherwise the symbol
+    arrives with only the tail, and its presence then reads as success.
     """
     if not output_path.exists():
         return None
@@ -96,6 +106,12 @@ def get_update_start(output_path: Path, end_date: str, interval_hours: int) -> s
     per_symbol = pl.read_parquet(output_path).group_by("symbol").agg(pl.col("timestamp").max())
     if per_symbol.is_empty():
         return None
+
+    if symbols and configured_start:
+        present = set(per_symbol["symbol"].to_list())
+        if any(s not in present for s in symbols):
+            return None if configured_start > end_date else configured_start
+
     last_ts = per_symbol["timestamp"].min()
     if last_ts is None:
         return None
@@ -268,7 +284,7 @@ def main() -> None:
         provider = BinancePublicProvider(market=str(perps_cfg.get("market", "futures")))
         start_date = perps_start
         if args.update and not args.force:
-            incremental_start = get_update_start(perps_output, perps_end, interval_hours=1)
+            incremental_start = get_update_start(perps_output, perps_end, 1, symbols, perps_start)
             if incremental_start is None:
                 print("\nPerpetual OHLCV already up to date.")
                 perps_df = (
@@ -283,7 +299,7 @@ def main() -> None:
                     combine_existing(perps_output, new_df)
                     if not new_df.is_empty()
                     else pl.read_parquet(perps_output)
-                )
+                )  # the update branch only runs with an existing file
         else:
             print("\nDownloading perpetual OHLCV...")
             new_df, perps_failed = download_perps(provider, symbols, start_date, perps_end)
@@ -291,13 +307,16 @@ def main() -> None:
                 # Not necessarily a failure: a fully rate-limited retry against a
                 # complete dataset arrives here. Fall through to the merged-dataset
                 # check rather than exiting, so the status reflects what is on disk
-                # and --allow-partial still applies.
+                # and --allow-partial still applies. The provider returns a frame
+                # with no columns at all, so it can be neither combined nor sorted.
                 print("No perpetual OHLCV rows returned; falling back to what is on disk.")
-            perps_df = (
-                combine_existing(perps_output, new_df)
-                if perps_output.exists() and not args.force
-                else new_df.sort(["symbol", "timestamp"])
-            )
+                perps_df = pl.read_parquet(perps_output) if perps_output.exists() else new_df
+            else:
+                perps_df = (
+                    combine_existing(perps_output, new_df)
+                    if perps_output.exists() and not args.force
+                    else new_df.sort(["symbol", "timestamp"])
+                )
 
         if not perps_df.is_empty():
             perps_df = clamp_date_range(perps_df, perps_start, perps_end)
@@ -322,7 +341,9 @@ def main() -> None:
         provider = BinancePublicProvider(market=str(config.get("market", "futures")))
         start_date = premium_start
         if args.update and not args.force:
-            incremental_start = get_update_start(premium_output, premium_end, interval_hours=8)
+            incremental_start = get_update_start(
+                premium_output, premium_end, 8, symbols, premium_start
+            )
             if incremental_start is None:
                 print("\nPremium index already up to date.")
                 premium_df = (
@@ -347,11 +368,13 @@ def main() -> None:
             )
             if new_df.is_empty():
                 print("No premium index rows returned; falling back to what is on disk.")
-            premium_df = (
-                combine_existing(premium_output, new_df)
-                if premium_output.exists() and not args.force
-                else new_df.sort(["symbol", "timestamp"])
-            )
+                premium_df = pl.read_parquet(premium_output) if premium_output.exists() else new_df
+            else:
+                premium_df = (
+                    combine_existing(premium_output, new_df)
+                    if premium_output.exists() and not args.force
+                    else new_df.sort(["symbol", "timestamp"])
+                )
 
         if not premium_df.is_empty():
             premium_df = clamp_date_range(premium_df, premium_start, premium_end)

--- a/data/crypto/market/download.py
+++ b/data/crypto/market/download.py
@@ -80,10 +80,12 @@ def missing_symbols(
     return sorted(absent)
 
 
-def _empty_response_note(force: bool) -> str:
-    """What happens next when nothing arrived, which --force changes."""
+def _empty_response_note(output_path: Path, force: bool) -> str:
+    """What happens next when nothing arrived."""
     if force:
         return "--force replaces rather than merges, so there is nothing to fall back to."
+    if not output_path.exists():
+        return "Nothing has been downloaded before either."
     return "Falling back to what is already on disk."
 
 
@@ -319,7 +321,9 @@ def main() -> None:
                 # --force means replace, not merge, so there is nothing to fall
                 # back to: a forced refresh that returned nothing has failed, and
                 # keeping the old rows would report stale data as the result.
-                print(f"No perpetual OHLCV rows returned. {_empty_response_note(args.force)}")
+                print(
+                    f"No perpetual OHLCV rows returned. {_empty_response_note(perps_output, args.force)}"
+                )
                 perps_df = (
                     pl.read_parquet(perps_output)
                     if perps_output.exists() and not args.force
@@ -381,7 +385,9 @@ def main() -> None:
                 provider, symbols, start_date, premium_end, premium_interval
             )
             if new_df.is_empty():
-                print(f"No premium index rows returned. {_empty_response_note(args.force)}")
+                print(
+                    f"No premium index rows returned. {_empty_response_note(premium_output, args.force)}"
+                )
                 premium_df = (
                     pl.read_parquet(premium_output)
                     if premium_output.exists() and not args.force

--- a/data/equities/loader.py
+++ b/data/equities/loader.py
@@ -9,6 +9,76 @@ from data.exceptions import DataNotFoundError
 from utils import ML4T_DATA_PATH
 from utils.data_quality import apply_max_symbols
 
+# --------------------------------------------------------------------------------
+# AlgoSeek datasets
+# --------------------------------------------------------------------------------
+#
+# AlgoSeek publishes two of the four datasets this book uses, openly and with no
+# account, at the page below. Both are CSV; every loader here reads parquet, so the
+# reader's path is download -> algoseek_convert.py -> (for the options, one build
+# script) -> loader. The instructions below are what a reader sees when a dataset is
+# missing, so they name that path rather than an address to write to.
+
+ALGOSEEK_PAGE = "https://algoseek.com/ml-for-trading/"
+ALGOSEEK_CONVERT = "data/equities/market/algoseek_convert.py"
+
+_NASDAQ100_MINUTE_BARS_INSTRUCTIONS = f"""AlgoSeek publishes this dataset for the book.
+No account, no API key, no license request.
+
+  1. Download nasdaq-100-constituents-taq-ext.zip (5.9 GB) from
+     {ALGOSEEK_PAGE}
+  2. Convert it to the layout this loader reads:
+     uv run python {ALGOSEEK_CONVERT} \\
+       --dataset nasdaq100-minute-bars --source <path to the zip>
+
+Coverage: 505 trading days, 2020-01-02 to 2021-12-31, extended-hours minute bars."""
+
+_SP500_OPTIONS_INSTRUCTIONS = f"""AlgoSeek publishes this dataset for the book.
+No account, no API key, no license request.
+
+  1. Download options_daily_greeks_sp500.zip (13.8 GB) from
+     {ALGOSEEK_PAGE}
+  2. Convert it to the layout this loader reads:
+     uv run python {ALGOSEEK_CONVERT} \\
+       --dataset sp500-options --source <path to the zip>
+
+The archive holds 1,275,314 gzipped files, so unpacking it first and pointing
+--source at the extracted directory is considerably faster than reading from
+the zip.
+
+Coverage: 1,259 trading days 2017-2021, 634 symbols, full daily chains with Greeks."""
+
+
+def _derived_from_raw_options(build_script: str) -> str:
+    """Instructions for a dataset built out of the raw option chains."""
+    return f"""This dataset is derived from the raw S&P 500 option chains.
+
+  1. Obtain the raw chains first — download options_daily_greeks_sp500.zip
+     (13.8 GB) from {ALGOSEEK_PAGE} and convert it:
+     uv run python {ALGOSEEK_CONVERT} --dataset sp500-options --source <path>
+  2. Build this dataset from them:
+     uv run python {build_script}"""
+
+
+def _not_yet_published(what: str, affects: str, why_no_substitute: str = "") -> str:
+    """Instructions for the two datasets AlgoSeek has not packaged yet.
+
+    Saying so plainly is the point: without it a reader hits a missing file with no
+    way to tell whether they did something wrong.
+    """
+    lines = [
+        f"AlgoSeek has not yet published {what}.",
+        "",
+        "It was staged for hosting and has not been packaged. Nothing you can run",
+        "will produce it, so this is not something you have done wrong.",
+        "",
+        f"Affected: {affects}",
+    ]
+    if why_no_substitute:
+        lines += ["", why_no_substitute]
+    lines += ["", f"Check for it at: {ALGOSEEK_PAGE}"]
+    return "\n".join(lines)
+
 
 def load_sp500_index() -> pl.DataFrame:
     """Load S&P 500 index OHLCV data (bundled with repository).
@@ -195,15 +265,7 @@ def load_nasdaq100_bars(
         raise DataNotFoundError(
             dataset_name="NASDAQ-100 Minute Bars",
             path=hive_path,
-            instructions="""This dataset requires a commercial license from AlgoSeek.
-
-To obtain the data:
-  1. Contact AlgoSeek: https://www.algoseek.com/
-  2. Request NASDAQ-100 Minute Bar data (2020-2021)
-  3. Download data to: $ML4T_DATA_PATH/algoseek/minute_nq100/
-  4. Run extraction: python data/_licensed/algoseek/nasdaq100_minute_bars.py
-
-Note: Academic pricing may be available for educational use.""",
+            instructions=_NASDAQ100_MINUTE_BARS_INSTRUCTIONS,
         )
 
     lf = pl.scan_parquet(hive_path / "**/*.parquet", hive_partitioning=True)
@@ -305,15 +367,12 @@ def load_sp500_daily_bars(
         raise DataNotFoundError(
             dataset_name="S&P 500 Daily Bars",
             path=path,
-            instructions="""This dataset requires a commercial license from AlgoSeek.
-
-To obtain the data:
-  1. Contact AlgoSeek: https://www.algoseek.com/
-  2. Request S&P 500 Daily OHLCV data (2017-2021)
-  3. Download data to: $ML4T_DATA_PATH/algoseek/sp500_daily/
-  4. Run extraction: python data/_licensed/algoseek/sp500_daily_bars.py
-
-Note: Academic pricing may be available for educational use.""",
+            instructions=_not_yet_published(
+                "the S&P 500 daily bars",
+                "18_transaction_costs/01_cost_taxonomy, 02_spread_estimation and "
+                "03_market_impact_calibration, and the sp500_equity_option_analytics "
+                "case-study backtest",
+            ),
         )
 
     lf = pl.scan_parquet(path)
@@ -406,15 +465,7 @@ def load_sp500_options(
         raise DataNotFoundError(
             dataset_name="S&P 500 Options Greeks",
             path=base_path,
-            instructions="""This dataset requires a commercial license from AlgoSeek.
-
-To obtain the data:
-  1. Contact AlgoSeek: https://www.algoseek.com/
-  2. Request S&P 500 Options Greeks data (2017-2021)
-  3. Download data to: $ML4T_DATA_PATH/algoseek/options_sp500/
-  4. Run extraction: python data/_licensed/algoseek/sp500_options.py
-
-Note: Academic pricing may be available for educational use.""",
+            instructions=_SP500_OPTIONS_INSTRUCTIONS,
         )
 
     # Use lazy scan with Hive partitioning
@@ -459,9 +510,6 @@ Note: Academic pricing may be available for educational use.""",
     return lf if lazy else lf.collect()
 
 
-_SP500_OPTIONS_S3_BASE = "https://algoseek-public.s3.amazonaws.com/ml4t/sp500_options"
-
-
 def load_sp500_options_eda(
     symbols: list[str] | None = None,
     option_type: Literal["C", "P", "all"] = "all",
@@ -495,7 +543,9 @@ def load_sp500_options_eda(
         raise DataNotFoundError(
             dataset_name="S&P 500 Options — EDA subset",
             path=base_path,
-            download_url=f"{_SP500_OPTIONS_S3_BASE}/options_eda/",
+            instructions=_derived_from_raw_options(
+                "data/equities/market/sp500/build_options_eda.py"
+            ),
         )
 
     lf = pl.scan_parquet(base_path / "year=*.parquet", hive_partitioning=True)
@@ -556,7 +606,9 @@ def load_sp500_options_straddles_raw(
         raise DataNotFoundError(
             dataset_name="S&P 500 Options — ATM-band straddle raw chains",
             path=base_path,
-            download_url=f"{_SP500_OPTIONS_S3_BASE}/options_straddles_raw.tar.zst",
+            instructions=_derived_from_raw_options(
+                "data/equities/market/sp500/build_options_straddles_raw.py"
+            ),
         )
 
     lf = pl.scan_parquet(base_path / "year=*.parquet", hive_partitioning=True)
@@ -606,7 +658,9 @@ def load_sp500_options_surface(
         raise DataNotFoundError(
             dataset_name="S&P 500 Options — Daily IV Surface",
             path=path,
-            download_url=f"{_SP500_OPTIONS_S3_BASE}/options_surface_daily.parquet",
+            instructions=_derived_from_raw_options(
+                "data/equities/market/sp500/materialize_options.py"
+            ),
             derivation_notebook=(
                 "case_studies/sp500_equity_option_analytics/03_financial_features.py"
             ),
@@ -642,7 +696,9 @@ def load_sp500_options_straddles(
         raise DataNotFoundError(
             dataset_name="S&P 500 Options — Daily 30D ATM Straddles",
             path=path,
-            download_url=f"{_SP500_OPTIONS_S3_BASE}/options_straddles_daily.parquet",
+            instructions=_derived_from_raw_options(
+                "data/equities/market/sp500/materialize_options.py"
+            ),
             derivation_notebook="data/equities/market/sp500/materialize_options.py",
         )
     lf = pl.scan_parquet(path)
@@ -709,15 +765,12 @@ def load_nasdaq100_taq(
     """
     base_path = ML4T_DATA_PATH / "equities" / "market" / "microstructure" / "trade_and_quotes"
 
-    algoseek_instructions = """This dataset requires a commercial license from AlgoSeek.
-
-To obtain the data:
-  1. Contact AlgoSeek: https://www.algoseek.com/
-  2. Request Trade and Quote (TAQ) data for March 2020
-  3. Download data to: $ML4T_DATA_PATH/algoseek/taq/
-  4. Run extraction: python data/_licensed/algoseek/trade_and_quotes.py
-
-Note: Academic pricing may be available for educational use."""
+    algoseek_instructions = _not_yet_published(
+        "the NASDAQ-100 trade-and-quote ticks",
+        "03_market_microstructure/11_algoseek_taq_eda and 12_algoseek_taq_lob_reconstruction",
+        "The published minute-bar archive cannot stand in: it is quote-aware bar\n"
+        "aggregates, and reconstructing an order book needs the individual events.",
+    )
 
     if not base_path.exists() or not list(base_path.glob("symbol=*")):
         raise DataNotFoundError(

--- a/data/equities/market/algoseek_convert.py
+++ b/data/equities/market/algoseek_convert.py
@@ -312,6 +312,18 @@ class DaySource:
     # -- extracted directory ------------------------------------------------
 
     def _days_from_directory(self) -> Iterator[tuple[str, object]]:
+        # Extracting the NASDAQ-100 archive gives per-day zips, not CSVs — its outer
+        # archive is a zip of zips. A reader who unpacks one level and points at the
+        # result has done nothing wrong, so read both shapes.
+        day_zips = sorted(
+            (p for p in self.path.rglob("*.zip") if "__MACOSX" not in p.parts and _day_of(p)),
+            key=lambda p: _day_of(p),
+        )
+        if day_zips:
+            for path in day_zips:
+                yield _day_of(path), lambda path=path: _read_day_zip(path)
+            return
+
         suffix = "*.csv.gz" if self.dataset == "sp500-options" else "*.csv"
         by_day: dict[str, list[Path]] = defaultdict(list)
         for file in self.path.rglob(suffix):
@@ -368,13 +380,22 @@ def _read_member(archive: zipfile.ZipFile, name: str) -> bytes:
     return gzip.decompress(payload) if name.endswith(".gz") else payload
 
 
+def _members_of_day_zip(inner: zipfile.ZipFile) -> list[bytes]:
+    return [
+        inner.read(m)
+        for m in sorted(inner.namelist())
+        if _NASDAQ_MEMBER.search(m) and "__MACOSX" not in m
+    ]
+
+
 def _read_inner_zip(archive: zipfile.ZipFile, name: str) -> list[bytes]:
     with zipfile.ZipFile(io.BytesIO(archive.read(name))) as inner:
-        return [
-            inner.read(m)
-            for m in sorted(inner.namelist())
-            if _NASDAQ_MEMBER.search(m) and "__MACOSX" not in m
-        ]
+        return _members_of_day_zip(inner)
+
+
+def _read_day_zip(path: Path) -> list[bytes]:
+    with zipfile.ZipFile(path) as inner:
+        return _members_of_day_zip(inner)
 
 
 # --------------------------------------------------------------------------------

--- a/data/equities/market/algoseek_convert.py
+++ b/data/equities/market/algoseek_convert.py
@@ -1,0 +1,550 @@
+"""Convert the AlgoSeek archives to the parquet layout the loaders read.
+
+AlgoSeek publishes two datasets for this book at https://algoseek.com/ml-for-trading/,
+as plain Dropbox links with no signup and no account. Both are CSV; every loader in
+``data/equities/loader.py`` reads zstd parquet under a Hive layout, so a reader who
+downloads the archives still cannot run anything until this script has run.
+
+    nasdaq-100-constituents-taq-ext.zip   5.9 GB    NASDAQ-100 extended minute bars
+                                                    505 days, 2020-01-02 to 2021-12-31
+    options_daily_greeks_sp500.zip       13.8 GB    S&P 500 daily option chains + Greeks
+                                                    1,259 days 2017-2021, 634 symbols
+
+Run from the repository root, once per archive:
+
+    uv run python data/equities/market/algoseek_convert.py \\
+        --dataset nasdaq100-minute-bars --source ~/Downloads/nasdaq-100-constituents-taq-ext.zip
+
+    uv run python data/equities/market/algoseek_convert.py \\
+        --dataset sp500-options --source ~/Downloads/options_daily_greeks_sp500.zip
+
+``--source`` takes either the ``.zip`` or a directory you have already extracted.
+Extracting first is faster for the options archive, which holds **1,275,314** gzip
+members: reading them out of the zip pays the archive's index on every open, and
+unpacking that many small files is slow on any filesystem and slower on Windows.
+
+Output, under ``$ML4T_DATA_PATH``:
+
+    equities/market/nasdaq100/minute_bars/year=YYYY/month=MM.parquet
+    equities/market/sp500/options/year=YYYY/YYYYMMDD.parquet
+
+The options output is the *raw chain*. It is the input to the three build scripts
+that produce what the notebooks actually load, and they run after this one:
+
+    uv run python data/equities/market/sp500/build_options_eda.py
+    uv run python data/equities/market/sp500/build_options_straddles_raw.py
+    uv run python data/equities/market/sp500/materialize_options.py
+
+Both conversions resume: an output partition that already exists is skipped, so an
+interrupted run continues where it stopped. Pass ``--force`` to rebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import re
+import sys
+import time
+import zipfile
+from collections import defaultdict
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+
+from utils.downloading import print_section, resolve_data_dir
+
+# --------------------------------------------------------------------------------
+# NASDAQ-100 extended minute bars
+# --------------------------------------------------------------------------------
+
+# AlgoSeek ships 90 columns; the loaders read 62 of them. The dropped ones are
+# either counts whose volume twin is already kept (TradeAtBidCount), FINRA/PRP
+# splits the book does not use, or the SecId the canonical schema replaces with
+# `symbol`. Left is the CSV header, right is the canonical name.
+NASDAQ100_COLUMNS: dict[str, str] = {
+    "Date": "date",
+    "Ticker": "symbol",
+    "TimeBarStart": "time",
+    "OpenBarTime": "open_bar_time",
+    "OpenBidPrice": "open_bid_price",
+    "OpenBidSize": "open_bid_size",
+    "OpenAskPrice": "open_ask_price",
+    "OpenAskSize": "open_ask_size",
+    "FirstTradeTime": "first_trade_time",
+    "FirstTradePrice": "first_trade_price",
+    "FirstTradeSize": "first_trade_size",
+    "HighBidTime": "high_bid_time",
+    "HighBidPrice": "high_bid_price",
+    "HighBidSize": "high_bid_size",
+    "HighAskTime": "high_ask_time",
+    "HighAskPrice": "high_ask_price",
+    "HighAskSize": "high_ask_size",
+    "HighTradeTime": "high_trade_time",
+    "HighTradePrice": "high_trade_price",
+    "HighTradeSize": "high_trade_size",
+    "LowBidTime": "low_bid_time",
+    "LowBidPrice": "low_bid_price",
+    "LowBidSize": "low_bid_size",
+    "LowAskTime": "low_ask_time",
+    "LowAskPrice": "low_ask_price",
+    "LowAskSize": "low_ask_size",
+    "LowTradeTime": "low_trade_time",
+    "LowTradePrice": "low_trade_price",
+    "LowTradeSize": "low_trade_size",
+    "CloseBarTime": "close_bar_time",
+    "CloseBidPrice": "close_bid_price",
+    "CloseBidSize": "close_bid_size",
+    "CloseAskPrice": "close_ask_price",
+    "CloseAskSize": "close_ask_size",
+    "LastTradeTime": "last_trade_time",
+    "LastTradePrice": "last_trade_price",
+    "LastTradeSize": "last_trade_size",
+    "MinSpread": "min_spread",
+    "MaxSpread": "max_spread",
+    "CancelSize": "cancel_size",
+    "VolumeWeightPrice": "vwap",
+    "NBBOQuoteCount": "nbbo_quote_count",
+    "TradeAtBid": "trade_at_bid",
+    "TradeAtBidMid": "trade_at_bid_mid",
+    "TradeAtMid": "trade_at_mid",
+    "TradeAtMidAsk": "trade_at_mid_ask",
+    "TradeAtAsk": "trade_at_ask",
+    "TradeAtCrossOrLocked": "trade_at_cross",
+    "Volume": "volume",
+    "TotalTrades": "total_trades",
+    "FinraVolume": "finra_volume",
+    "FinraVolumeWeightPrice": "finra_vwap",
+    "UptickVolume": "uptick_volume",
+    "DowntickVolume": "downtick_volume",
+    "RepeatUptickVolume": "repeat_uptick_volume",
+    "RepeatDowntickVolume": "repeat_downtick_volume",
+    "UnknownTickVolume": "unknown_tick_volume",
+    "TradeToMidVolWeight": "trade_to_mid_vol_weight",
+    "TradeToMidVolWeightRelative": "trade_to_mid_vol_weight_rel",
+    "TimeWeightBid": "time_weight_bid",
+    "TimeWeightAsk": "time_weight_ask",
+}
+
+# String columns keep AlgoSeek's nanosecond time-of-day text verbatim ("04:00:57.069651992"),
+# which no datetime type round-trips. Everything else is numeric.
+_NASDAQ100_STRING = {"Ticker", "TimeBarStart"} | {
+    c for c in NASDAQ100_COLUMNS if c.endswith("Time")
+}
+_NASDAQ100_INT = {
+    "OpenBidSize",
+    "OpenAskSize",
+    "FirstTradeSize",
+    "HighBidSize",
+    "HighAskSize",
+    "HighTradeSize",
+    "LowBidSize",
+    "LowAskSize",
+    "LowTradeSize",
+    "CloseBidSize",
+    "CloseAskSize",
+    "LastTradeSize",
+    "CancelSize",
+    "NBBOQuoteCount",
+    "TradeAtBid",
+    "TradeAtBidMid",
+    "TradeAtMid",
+    "TradeAtMidAsk",
+    "TradeAtAsk",
+    "TradeAtCrossOrLocked",
+    "Volume",
+    "TotalTrades",
+    "FinraVolume",
+    "UptickVolume",
+    "DowntickVolume",
+    "RepeatUptickVolume",
+    "RepeatDowntickVolume",
+    "UnknownTickVolume",
+}
+
+
+def _nasdaq100_schema() -> dict[str, pl.DataType]:
+    schema: dict[str, pl.DataType] = {}
+    for csv_name in NASDAQ100_COLUMNS:
+        if csv_name == "Date":
+            schema[csv_name] = pl.Int64
+        elif csv_name in _NASDAQ100_STRING:
+            schema[csv_name] = pl.String
+        elif csv_name in _NASDAQ100_INT:
+            schema[csv_name] = pl.Int64
+        else:
+            schema[csv_name] = pl.Float64
+    return schema
+
+
+def parse_nasdaq100_csv(payload: bytes) -> pl.DataFrame:
+    """One symbol-day of extended minute bars, in canonical schema."""
+    df = pl.read_csv(
+        payload,
+        columns=list(NASDAQ100_COLUMNS),
+        schema_overrides=_nasdaq100_schema(),
+        null_values=[""],
+    )
+    return (
+        df.rename(NASDAQ100_COLUMNS)
+        .with_columns(
+            pl.col("date").cast(pl.String).str.to_date("%Y%m%d"),
+        )
+        .with_columns(
+            # AlgoSeek's bar label is the minute the bar opens, which is what the
+            # loaders filter regular hours on.
+            (pl.col("date").cast(pl.String) + pl.lit(" ") + pl.col("time"))
+            .str.to_datetime("%Y-%m-%d %H:%M")
+            .alias("timestamp"),
+        )
+        .select(list(NASDAQ100_COLUMNS.values()) + ["timestamp"])
+    )
+
+
+# --------------------------------------------------------------------------------
+# S&P 500 daily option chains with Greeks
+# --------------------------------------------------------------------------------
+
+# 1:1 onto the option-chain schema the sp500_options case study reads. AlgoSeek's
+# three timestamp columns (UnderLastMidTime, LastBidTime, LastAskTime) are dropped:
+# nothing downstream reads them and they double the width of the largest dataset.
+SP500_OPTIONS_COLUMNS: dict[str, str] = {
+    "TradeDate": "date",
+    "Ticker": "symbol",
+    "CallPut": "call_put",
+    "OptionStyle": "option_style",
+    "Strike": "strike",
+    "Expiration": "expiration",
+    "YearsToMaturity": "years_to_maturity",
+    "DaysToMaturity": "days_to_maturity",
+    "UnderLastMidPrice": "underlying_price",
+    "LastBidPrice": "bid",
+    "LastAskPrice": "ask",
+    "LastMidPrice": "mid_price",
+    "MidImpliedVol": "implied_vol",
+    "MidTheoPrice": "theo_price",
+    "MidDelta": "delta",
+    "MidGamma": "gamma",
+    "MidTheta": "theta",
+    "MidVega": "vega",
+    "MidRho": "rho",
+    "ImpliedVolConvergence": "iv_convergence",
+}
+
+_SP500_OPTIONS_SCHEMA: dict[str, pl.DataType] = {
+    "TradeDate": pl.Int64,
+    "Ticker": pl.String,
+    "CallPut": pl.String,
+    "OptionStyle": pl.String,
+    "Strike": pl.Float64,
+    "Expiration": pl.Int64,
+    "YearsToMaturity": pl.Float64,
+    "DaysToMaturity": pl.Int32,
+    "UnderLastMidPrice": pl.Float64,
+    "LastBidPrice": pl.Float64,
+    "LastAskPrice": pl.Float64,
+    "LastMidPrice": pl.Float64,
+    "MidImpliedVol": pl.Float64,
+    "MidTheoPrice": pl.Float64,
+    "MidDelta": pl.Float64,
+    "MidGamma": pl.Float64,
+    "MidTheta": pl.Float64,
+    "MidVega": pl.Float64,
+    "MidRho": pl.Float64,
+    "ImpliedVolConvergence": pl.String,
+}
+
+
+def parse_sp500_options_csv(payload: bytes) -> pl.DataFrame:
+    """One symbol-day of option chain, in canonical schema."""
+    df = pl.read_csv(
+        payload,
+        columns=list(SP500_OPTIONS_COLUMNS),
+        schema_overrides=_SP500_OPTIONS_SCHEMA,
+        null_values=[""],
+    )
+    return (
+        df.rename(SP500_OPTIONS_COLUMNS)
+        .with_columns(
+            pl.col("date").cast(pl.String).str.to_date("%Y%m%d"),
+            pl.col("expiration").cast(pl.String).str.to_date("%Y%m%d"),
+        )
+        # read_csv keeps the file's order, which interleaves the time columns and so
+        # puts mid before ask. Select explicitly so the layout matches the delivery.
+        .select(list(SP500_OPTIONS_COLUMNS.values()))
+    )
+
+
+# --------------------------------------------------------------------------------
+# Reading a day out of either archive shape
+# --------------------------------------------------------------------------------
+
+_DAY_ZIP = re.compile(r"(?:^|/)(\d{4})/(\d{8})\.zip$")
+_OPTIONS_MEMBER = re.compile(r"(?:^|/)(\d{4})/(\d{8})/([^/]+)\.csv\.gz$")
+_NASDAQ_MEMBER = re.compile(r"(?:^|/)(\d{8})/[A-Z0-9]/([^/]+)\.csv$", re.IGNORECASE)
+
+
+class DaySource:
+    """The per-day members of one archive, whether zipped or already extracted.
+
+    ``days()`` yields ``(YYYYMMDD, reader)``, and calling ``reader()`` returns the
+    CSV payloads for that day. Reading is deferred so a resumed run pays nothing
+    for the days it skips.
+    """
+
+    def __init__(self, path: Path, dataset: str) -> None:
+        self.path = path
+        self.dataset = dataset
+
+    def days(self) -> Iterator[tuple[str, object]]:
+        if self.path.is_dir():
+            yield from self._days_from_directory()
+        elif zipfile.is_zipfile(self.path):
+            yield from self._days_from_zip()
+        else:
+            msg = f"--source is neither a directory nor a zip archive: {self.path}"
+            raise SystemExit(msg)
+
+    # -- extracted directory ------------------------------------------------
+
+    def _days_from_directory(self) -> Iterator[tuple[str, object]]:
+        suffix = "*.csv.gz" if self.dataset == "sp500-options" else "*.csv"
+        by_day: dict[str, list[Path]] = defaultdict(list)
+        for file in self.path.rglob(suffix):
+            # macOS zips carry a __MACOSX shadow tree of resource forks.
+            if "__MACOSX" in file.parts:
+                continue
+            day = _day_of(file)
+            if day:
+                by_day[day].append(file)
+        for day in sorted(by_day):
+            files = sorted(by_day[day])
+            yield day, lambda files=files: [_read_file(f) for f in files]
+
+    # -- zip archive --------------------------------------------------------
+
+    def _days_from_zip(self) -> Iterator[tuple[str, object]]:
+        archive = zipfile.ZipFile(self.path)
+        names = [n for n in archive.namelist() if "__MACOSX" not in n]
+
+        # NASDAQ-100: one inner zip per day. Options: members grouped by day directory.
+        inner_zips = [n for n in names if _DAY_ZIP.search(n)]
+        if inner_zips:
+            for name in sorted(inner_zips, key=lambda n: _DAY_ZIP.search(n).group(2)):
+                day = _DAY_ZIP.search(name).group(2)
+                yield day, lambda name=name: _read_inner_zip(archive, name)
+            return
+
+        by_day: dict[str, list[str]] = defaultdict(list)
+        for name in names:
+            day = _day_of(Path(name))
+            if day:
+                by_day[day].append(name)
+        for day in sorted(by_day):
+            members = sorted(by_day[day])
+            yield day, lambda members=members: [_read_member(archive, m) for m in members]
+
+
+def _day_of(path: Path) -> str | None:
+    """The YYYYMMDD a member belongs to, from its own name or a parent directory."""
+    for part in reversed(path.parts):
+        stem = part.split(".", 1)[0]
+        if len(stem) == 8 and stem.isdigit():
+            return stem
+    return None
+
+
+def _read_file(path: Path) -> bytes:
+    payload = path.read_bytes()
+    return gzip.decompress(payload) if path.suffix == ".gz" else payload
+
+
+def _read_member(archive: zipfile.ZipFile, name: str) -> bytes:
+    payload = archive.read(name)
+    return gzip.decompress(payload) if name.endswith(".gz") else payload
+
+
+def _read_inner_zip(archive: zipfile.ZipFile, name: str) -> list[bytes]:
+    with zipfile.ZipFile(io.BytesIO(archive.read(name))) as inner:
+        return [
+            inner.read(m)
+            for m in sorted(inner.namelist())
+            if _NASDAQ_MEMBER.search(m) and "__MACOSX" not in m
+        ]
+
+
+# --------------------------------------------------------------------------------
+# Conversion
+# --------------------------------------------------------------------------------
+
+
+def _log(message: str) -> None:
+    print(f"[{datetime.now():%H:%M:%S}] {message}", flush=True)
+
+
+def _parse_day(payloads: list[bytes], parse, workers: int) -> pl.DataFrame | None:
+    """Parse one day's CSVs. Decompression and CSV parsing both release the GIL,
+    so threads are what make a 504-file day tolerable."""
+    frames: list[pl.DataFrame] = []
+    if workers > 1:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            frames = [f for f in pool.map(parse, payloads) if f.height]
+    else:
+        frames = [f for f in (parse(p) for p in payloads) if f.height]
+    if not frames:
+        return None
+    return pl.concat(frames, how="vertical")
+
+
+def _write(df: pl.DataFrame, path: Path) -> float:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".parquet.tmp")
+    df.write_parquet(tmp, compression="zstd", compression_level=9, statistics=True)
+    tmp.replace(path)
+    return path.stat().st_size / 1024 / 1024
+
+
+def convert_nasdaq100(source: Path, out_root: Path, workers: int, force: bool) -> int:
+    """One parquet per month, matching the layout load_nasdaq100_bars() scans."""
+    out_dir = out_root / "equities" / "market" / "nasdaq100" / "minute_bars"
+    days = list(DaySource(source, "nasdaq100-minute-bars").days())
+    if not days:
+        _log(f"No day archives found under {source}")
+        return 1
+
+    by_month: dict[tuple[str, str], list[tuple[str, object]]] = defaultdict(list)
+    for day, reader in days:
+        by_month[(day[:4], day[4:6])].append((day, reader))
+
+    _log(f"{len(days)} days across {len(by_month)} months -> {out_dir}")
+    total_rows = 0
+    for (year, month), entries in sorted(by_month.items()):
+        out_path = out_dir / f"year={year}" / f"month={month}.parquet"
+        if out_path.exists() and not force:
+            _log(f"{year}-{month}: already converted, skipping")
+            continue
+
+        t0 = time.time()
+        frames = []
+        for day, reader in entries:
+            df = _parse_day(reader(), parse_nasdaq100_csv, workers)
+            if df is not None:
+                frames.append(df)
+            else:
+                _log(f"  {day}: no rows")
+        if not frames:
+            _log(f"{year}-{month}: nothing to write")
+            continue
+
+        month_df = pl.concat(frames, how="vertical").sort("symbol", "timestamp")
+        size_mb = _write(month_df, out_path)
+        total_rows += month_df.height
+        _log(
+            f"{year}-{month}: {month_df.height:,} rows, {month_df['symbol'].n_unique()} symbols, "
+            f"{size_mb:.0f} MB, {time.time() - t0:.0f}s"
+        )
+
+    _log(f"NASDAQ-100 minute bars: {total_rows:,} rows written")
+    return 0
+
+
+def convert_sp500_options(source: Path, out_root: Path, workers: int, force: bool) -> int:
+    """One parquet per trading day, under the year the build scripts glob."""
+    out_dir = out_root / "equities" / "market" / "sp500" / "options"
+    days = list(DaySource(source, "sp500-options").days())
+    if not days:
+        _log(f"No daily option chains found under {source}")
+        return 1
+
+    _log(f"{len(days)} days -> {out_dir}")
+    total_rows = 0
+    converted = 0
+    t_start = time.time()
+    for index, (day, reader) in enumerate(days, start=1):
+        out_path = out_dir / f"year={day[:4]}" / f"{day}.parquet"
+        if out_path.exists() and not force:
+            continue
+
+        t0 = time.time()
+        df = _parse_day(reader(), parse_sp500_options_csv, workers)
+        if df is None:
+            _log(f"{day}: no rows")
+            continue
+        df = df.sort("symbol", "expiration", "call_put", "strike")
+        size_mb = _write(df, out_path)
+        total_rows += df.height
+        converted += 1
+        rate = index / max(time.time() - t_start, 1e-9)
+        remaining = (len(days) - index) / rate
+        _log(
+            f"{day} ({index}/{len(days)}): {df.height:,} rows, {df['symbol'].n_unique()} symbols, "
+            f"{size_mb:.0f} MB, {time.time() - t0:.0f}s, ~{remaining / 60:.0f} min left"
+        )
+
+    _log(f"S&P 500 option chains: {converted} days converted, {total_rows:,} rows written")
+    if converted:
+        _log("Next, from the repository root:")
+        _log("  uv run python data/equities/market/sp500/build_options_eda.py")
+        _log("  uv run python data/equities/market/sp500/build_options_straddles_raw.py")
+        _log("  uv run python data/equities/market/sp500/materialize_options.py")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert the published AlgoSeek CSV archives to the parquet the loaders read",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        choices=["nasdaq100-minute-bars", "sp500-options"],
+        help="Which archive to convert",
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        type=Path,
+        help="The downloaded .zip, or a directory you have already extracted it to",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=None,
+        help="Data storage location (default: $ML4T_DATA_PATH or repo/data)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Threads used to parse one day's files (default: 8)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rebuild partitions that already exist instead of skipping them",
+    )
+    args = parser.parse_args()
+
+    source = args.source.expanduser()
+    if not source.exists():
+        _log(f"--source does not exist: {source}")
+        return 1
+
+    out_root = resolve_data_dir(args.data_path)
+    print_section(f"ALGOSEEK CONVERSION - {args.dataset}")
+    _log(f"Source: {source}")
+    _log(f"Output: {out_root}")
+
+    if args.dataset == "nasdaq100-minute-bars":
+        return convert_nasdaq100(source, out_root, args.workers, args.force)
+    return convert_sp500_options(source, out_root, args.workers, args.force)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/equities/market/microstructure/README.md
+++ b/data/equities/market/microstructure/README.md
@@ -22,7 +22,7 @@ is identical to the full commercial feed.
 
 | Property | Value |
 |----------|-------|
-| **Source** | AlgoSeek (slim reader package, hosted) |
+| **Source** | AlgoSeek — **not published yet**, see below |
 | **Frequency** | Tick (trades + NBBO quote events) |
 | **Dates** | 2020-03-13, 2020-03-16 |
 | **Symbols** | AAPL |
@@ -30,11 +30,17 @@ is identical to the full commercial feed.
 | **Schema** | `timestamp` (µs), `symbol`, `event_type`, `price`, `quantity`, `exchange`, `conditions` |
 | **License** | Commercial — slim slice redistributed under reader license |
 
-```bash
-# Slim package download (URL + instructions pending AlgoSeek reader bundle)
-# For book readers: fetch the bundle, unpack under:
-#   $ML4T_DATA_PATH/equities/market/microstructure/trade_and_quotes_slim/
-```
+**AlgoSeek has not published this slice.** It was staged for hosting and has not
+been packaged, so `11_algoseek_taq_eda` and `12_algoseek_taq_lob_reconstruction`
+cannot run yet. Check <https://algoseek.com/ml-for-trading/>, which is where
+AlgoSeek publishes this book's datasets; when it appears, unpack it under
+`$ML4T_DATA_PATH/equities/market/microstructure/trade_and_quotes_slim/`.
+
+The NASDAQ-100 archive AlgoSeek *has* published cannot stand in. Despite the
+"taq-ext" in its name it is quote-aware minute-bar aggregates — `OpenBidPrice`,
+`TradeAtBid`, `NBBOQuoteCount` and so on — not individual events, and an order
+book cannot be reconstructed from bars. It converts to the minute-bar dataset
+instead; see [AlgoSeek datasets](../../../README.md#algoseek-datasets).
 
 ```python
 from data import load_nasdaq100_taq

--- a/data/equities/market/sp500/build_options_eda.py
+++ b/data/equities/market/sp500/build_options_eda.py
@@ -15,24 +15,49 @@ Run from repo root:
 
 from __future__ import annotations
 
+import argparse
 import time
 from pathlib import Path
 
 import polars as pl
 
-RAW_DIR = Path(__file__).parent / "options"
-OUT_DIR = Path(__file__).parent / "options_eda"
+from utils.downloading import resolve_data_dir
+
+
+def sp500_data_dir(data_path: Path | None = None) -> Path:
+    """Where the loaders read this dataset from.
+
+    Not ``Path(__file__).parent``: the converter writes under ``$ML4T_DATA_PATH``,
+    which a reader may point outside the repository, and a build script anchored
+    to its own directory would then look in the wrong place and leave its output
+    somewhere the loaders never read.
+    """
+    return resolve_data_dir(data_path) / "equities" / "market" / "sp500"
+
 
 EDA_SYMBOLS = ["AAPL", "MSFT", "GOOGL", "AMZN", "JPM", "BA", "XOM", "KO"]
 EDA_YEARS = [2019, 2020]
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=None,
+        help="Data storage location (default: $ML4T_DATA_PATH or repo/data)",
+    )
+    args = parser.parse_args()
+
+    base = sp500_data_dir(args.data_path)
+    RAW_DIR = base / "options"
+    OUT_DIR = base / "options_eda"
+
     if not RAW_DIR.exists():
         msg = f"Raw options directory not found: {RAW_DIR}"
         raise FileNotFoundError(msg)
 
-    OUT_DIR.mkdir(exist_ok=True)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     print("=" * 60)
     print("Building SP500 options EDA subset")
@@ -47,6 +72,12 @@ def main() -> None:
     total_mb = 0.0
     for year in EDA_YEARS:
         t0 = time.time()
+        # A reader may have converted only part of the archive. Skipping a year
+        # with no chains beats a polars schema error naming a glob;
+        # build_options_straddles_raw.py already does the same.
+        if not list(RAW_DIR.glob(f"year={year}/*.parquet")):
+            print(f"\n[{year}] No converted chains — skipping")
+            continue
         df = (
             pl.scan_parquet(RAW_DIR / f"year={year}/*.parquet", hive_partitioning=True)
             .filter(pl.col("symbol").is_in(EDA_SYMBOLS))

--- a/data/equities/market/sp500/build_options_straddles_raw.py
+++ b/data/equities/market/sp500/build_options_straddles_raw.py
@@ -22,14 +22,26 @@ Run from repo root:
 
 from __future__ import annotations
 
+import argparse
 import gc
 import time
 from pathlib import Path
 
 import polars as pl
 
-RAW_DIR = Path(__file__).parent / "options"
-OUT_DIR = Path(__file__).parent / "options_straddles_raw"
+from utils.downloading import resolve_data_dir
+
+
+def sp500_data_dir(data_path: Path | None = None) -> Path:
+    """Where the loaders read this dataset from.
+
+    Not ``Path(__file__).parent``: the converter writes under ``$ML4T_DATA_PATH``,
+    which a reader may point outside the repository, and a build script anchored
+    to its own directory would then look in the wrong place and leave its output
+    somewhere the loaders never read.
+    """
+    return resolve_data_dir(data_path) / "equities" / "market" / "sp500"
+
 
 YEARS = [2017, 2018, 2019, 2020, 2021]
 
@@ -69,11 +81,24 @@ def identify_candidate_contracts(df: pl.DataFrame) -> pl.DataFrame:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=None,
+        help="Data storage location (default: $ML4T_DATA_PATH or repo/data)",
+    )
+    args = parser.parse_args()
+
+    base = sp500_data_dir(args.data_path)
+    RAW_DIR = base / "options"
+    OUT_DIR = base / "options_straddles_raw"
+
     if not RAW_DIR.exists():
         msg = f"Raw options directory not found: {RAW_DIR}"
         raise FileNotFoundError(msg)
 
-    OUT_DIR.mkdir(exist_ok=True)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     print("=" * 60)
     print("Building SP500 options straddles raw slice (ATM-band, lifecycle-preserving)")

--- a/data/equities/market/sp500/materialize_options.py
+++ b/data/equities/market/sp500/materialize_options.py
@@ -22,20 +22,29 @@ After materialization, notebooks use:
 
 from __future__ import annotations
 
+import argparse
 import gc
 import time
 from pathlib import Path
 
 import polars as pl
 
+from utils.downloading import resolve_data_dir
+
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
-RAW_DIR = Path(__file__).parent / "options"
-OUT_DIR = Path(__file__).parent
+def sp500_data_dir(data_path: Path | None = None) -> Path:
+    """Where the loaders read this dataset from.
 
-SURFACE_OUT = OUT_DIR / "options_surface_daily.parquet"
-STRADDLES_OUT = OUT_DIR / "options_straddles_daily.parquet"
+    Not ``Path(__file__).parent``: the converter writes under ``$ML4T_DATA_PATH``,
+    which a reader may point outside the repository, and a build script anchored
+    to its own directory would then look in the wrong place and leave its output
+    somewhere the loaders never read.
+    """
+    return resolve_data_dir(data_path) / "equities" / "market" / "sp500"
+
 
 YEARS = [2017, 2018, 2019, 2020, 2021]
 
@@ -341,6 +350,21 @@ def compute_straddles(df: pl.DataFrame) -> pl.DataFrame:
 # Main: year-by-year processing
 # ===================================================================
 def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=None,
+        help="Data storage location (default: $ML4T_DATA_PATH or repo/data)",
+    )
+    args = parser.parse_args()
+
+    base = sp500_data_dir(args.data_path)
+    RAW_DIR = base / "options"
+    SURFACE_OUT = base / "options_surface_daily.parquet"
+    STRADDLES_OUT = base / "options_straddles_daily.parquet"
+    base.mkdir(parents=True, exist_ok=True)
+
     print("=" * 60)
     print("SP500 Options Materialization")
     print(f"Raw data: {RAW_DIR}")

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -496,7 +496,11 @@ Some datasets require API keys (set in `.env`):
 - **OANDA** (FX pairs): Free API key from [oanda.com](https://www.oanda.com/)
 - **NASDAQ Data Link** (US equities): Free API key from [data.nasdaq.com](https://data.nasdaq.com/)
 - **Databento** (CME futures): $125 free signup credit from [databento.com](https://databento.com/)
-- **AlgoSeek** (microstructure, options): Requires commercial license
+
+**AlgoSeek** (NASDAQ-100 minute bars, S&P 500 option chains) needs no key and no account. Download
+the archives from [algoseek.com/ml-for-trading](https://algoseek.com/ml-for-trading/) and convert
+them once — see [AlgoSeek datasets](../data/README.md#algoseek-datasets), which also names the two
+datasets AlgoSeek has not published yet and the notebooks that wait on them.
 
 ---
 

--- a/docs/what-this-is.md
+++ b/docs/what-this-is.md
@@ -106,12 +106,14 @@ all: the four `crypto_perps_funding` model notebooks (`07_gbm`, `08_tabular_dl`,
 deep notebooks are marked GPU-only. Gradient boosting on GPU is also not bitwise reproducible against
 a CPU run. See [installation](installation.md) for the GPU setup.
 
-**Licensed data.** Three case studies read AlgoSeek data that requires a license:
-`nasdaq100_microstructure`, `sp500_options`, and `sp500_equity_option_analytics`. The reduced
-reader-facing versions of those datasets are marked `Soon` in the
-[data guide](../data/README.md) and are not downloadable yet. Until they are, those three case
-studies cannot be rebuilt from raw data, though their published results download and their analysis
-stages run normally.
+**AlgoSeek data.** Three case studies read AlgoSeek data: `nasdaq100_microstructure`,
+`sp500_options` and `sp500_equity_option_analytics`. AlgoSeek publishes the NASDAQ-100 minute bars
+and the S&P 500 option chains openly — no account, no API key, no license request — and one script
+converts them to what the loaders read; see
+[AlgoSeek datasets](../data/README.md#algoseek-datasets). Two of the four datasets are not published
+yet: the S&P 500 daily bars, without which `sp500_equity_option_analytics` cannot backtest and three
+Chapter 18 notebooks cannot run, and the NASDAQ-100 TAQ ticks, without which the two Chapter 3
+order-book notebooks cannot run. Everything else in those case studies rebuilds from raw data.
 
 ## 4. Not promised
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ dependencies = [
     # ===================
     # ML4T Libraries (PyPI, pre-release)
     # ===================
-    "ml4t-data>=0.1.0b15",
+    # b19: the missing-data errors name the download command a reader can run and
+    # the path the data root resolved from, instead of a Python API call.
+    "ml4t-data>=0.1.0b19",
     "ml4t-diagnostic>=0.1.0b25",
     "ml4t-engineer>=0.1.0b10",
     "ml4t-backtest>=0.1.0b20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,15 @@ dev = [
 # warning on every single `uv run` a reader types.
 prerelease = "if-necessary"
 
+# Download CPython rather than reusing whatever the machine already has. uv reuses
+# the system interpreter whenever it satisfies requires-python, so on a distro that
+# ships 3.14 (Ubuntu 26.04 does) a reader inherits Debian's interpreter behaviour:
+# missing Python.h unless python3-dev is installed, and a distro sitecustomize.py in
+# the stdlib directory that shadows this repo's and silently disables chapter imports
+# and the data-root anchor. Pinning the interpreter gives every reader the environment
+# the book was validated on.
+python-preference = "only-managed"
+
 # Force protobuf >= 5.0 for Python 3.14 compatibility.
 # protobuf 4.x has a C extension metaclass bug on Python 3.14.
 # opentelemetry-proto 1.27.0 pins protobuf<5; override until it upgrades.

--- a/scripts/verify_installation.py
+++ b/scripts/verify_installation.py
@@ -557,7 +557,40 @@ def check_runtime():
     except Exception as exc:
         results.append((cat, "Plotly ML4T template", "FAIL", str(exc)[:120]))
 
-    # 7. ML4T_DATA_PATH set and exists
+    # 7. The startup hook. sitecustomize.py is what puts the chapter directories on
+    # sys.path and anchors ML4T_DATA_PATH to the repo. Debian and Ubuntu ship their
+    # own sitecustomize.py in the stdlib directory, which shadows this repo's when the
+    # venv is built on the system interpreter — and nothing else reports that it did
+    # not load. Everything downstream of it then fails for reasons that name the
+    # symptom rather than the cause, so this check names the cause.
+    try:
+        import sitecustomize
+
+        loaded = Path(sitecustomize.__file__).resolve()
+        expected = (repo_root / "sitecustomize.py").resolve()
+        if loaded == expected:
+            results.append((cat, "sitecustomize (startup hook)", "PASS", str(loaded)))
+        else:
+            results.append(
+                (
+                    cat,
+                    "sitecustomize (startup hook)",
+                    "FAIL",
+                    f"shadowed by {loaded}; rebuild the venv with `uv sync`",
+                )
+            )
+    except Exception as exc:
+        results.append((cat, "sitecustomize (startup hook)", "FAIL", str(exc)[:120]))
+
+    # 8. Chapter helper imports, the contract sitecustomize exists to provide.
+    try:
+        importlib.import_module("limit_orderbook")
+        results.append((cat, "Chapter helper imports", "PASS", "import limit_orderbook"))
+    except Exception as exc:
+        results.append((cat, "Chapter helper imports", "FAIL", str(exc)[:120]))
+
+    # 9. ML4T_DATA_PATH set and exists. sitecustomize anchors it to the repo at
+    # interpreter startup, so an unset value means the startup hook did not run.
     data_path = os.environ.get("ML4T_DATA_PATH")
     if data_path:
         p = Path(data_path)
@@ -568,21 +601,11 @@ def check_runtime():
                 (cat, "ML4T_DATA_PATH", "FAIL", f"Set to {data_path} but directory does not exist")
             )
     else:
-        # Check .env fallback
-        env_file = repo_root / ".env"
-        if env_file.exists():
-            results.append(
-                (
-                    cat,
-                    "ML4T_DATA_PATH",
-                    "PASS",
-                    "Not in env but .env file found (loaded at runtime)",
-                )
-            )
-        else:
-            results.append((cat, "ML4T_DATA_PATH", "FAIL", "Not set and no .env file found"))
+        results.append(
+            (cat, "ML4T_DATA_PATH", "FAIL", "not set - the startup hook above did not run")
+        )
 
-    # 8. Python version
+    # 10. Python version
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     results.append((cat, "Python version", "PASS", py_ver))
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -34,11 +34,16 @@ made every data-loading notebook fail on the local ``uv`` path. Setting the
 variable here gives every entry point the same answer: an explicit value in the
 environment wins, then ``.env``, then ``<repo>/data``. Reading ``.env`` here is
 what makes the two groups of notebooks agree — those that import
-``utils.config`` (which calls ``load_dotenv``) and those that do not.
+``utils.config`` (which calls ``load_dotenv``) and those that do not. When the
+value is the ``<repo>/data`` default rather than anyone's choice,
+``ML4T_DATA_PATH_IS_DEFAULT`` says so, which is what lets ``tests/conftest.py``
+still prefer a populated test-data checkout over the tracked source tree.
 
 Nothing here may raise: this module runs at the startup of every interpreter in
 the environment, so a failure would break the whole install rather than one
-notebook.
+notebook. Failing means leaving the variable unset, never setting a guess —
+``utils.config`` calls ``load_dotenv(override=False)``, so a wrong value set
+here is one nothing downstream can correct.
 """
 
 import os
@@ -55,26 +60,26 @@ for _chapter_dir in sorted(_REPO_ROOT.glob("[0-9][0-9]_*")):
 
 
 def _data_root_from_dotenv(repo_root: Path) -> str | None:
-    """Read ``ML4T_DATA_PATH`` out of ``<repo>/.env`` without importing dotenv.
+    """Read ``ML4T_DATA_PATH`` out of ``<repo>/.env``, or report that it cannot.
 
-    ``python-dotenv`` is not guaranteed to be importable at interpreter startup,
-    and importing it there would cost every process in the environment. Only the
-    one variable is parsed; ``load_dotenv`` still handles the rest of the file
-    later, and leaves this value alone because it does not override.
+    Returns the configured value, or ``None`` when the file does not exist or
+    does not set the variable. Raises when there is a ``.env`` whose value cannot
+    be read the way ``load_dotenv`` would read it — the caller must then leave the
+    environment alone, because ``utils.config`` calls ``load_dotenv(override=False)``
+    and so cannot correct a wrong value set here.
+
+    ``python-dotenv`` is imported lazily and only when there is a file to parse.
+    Importing it unconditionally costs ~15 ms on every interpreter start in the
+    environment, which roughly doubles bare startup; hand-rolling the parse
+    instead gets ``export KEY=``, inline comments and ``${VAR}`` interpolation
+    wrong, and each of those is a value a reader may legitimately write.
     """
     env_file = repo_root / ".env"
     if not env_file.is_file():
         return None
-    for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
-        line = line.strip()
-        if not line.startswith("ML4T_DATA_PATH"):
-            continue
-        key, _, value = line.partition("=")
-        if key.strip() != "ML4T_DATA_PATH":
-            continue
-        value = value.strip().strip("'\"")
-        return value or None
-    return None
+    from dotenv import dotenv_values
+
+    return dotenv_values(env_file).get("ML4T_DATA_PATH") or None
 
 
 def _anchor_data_root(repo_root: Path) -> None:
@@ -87,9 +92,17 @@ def _anchor_data_root(repo_root: Path) -> None:
     if not data_root.is_absolute():
         data_root = repo_root / data_root
     os.environ["ML4T_DATA_PATH"] = str(data_root)
+    if configured is None:
+        # This value is the repo-anchored default, not something anyone asked for.
+        # tests/conftest.py needs the difference: the tracked data/ tree is never
+        # empty, so an unmarked default would hide the populated test-data
+        # checkout and silently skip every data-dependent notebook test.
+        os.environ["ML4T_DATA_PATH_IS_DEFAULT"] = "1"
 
 
 try:
     _anchor_data_root(_REPO_ROOT)
 except Exception:  # noqa: BLE001 - startup hook: never break the interpreter
+    # Leaving ML4T_DATA_PATH unset is the safe failure: load_dotenv still applies
+    # the reader's .env later, which a wrong value set here would have blocked.
     pass

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,27 +1,47 @@
-"""Make numbered chapter directories importable from any working directory.
-
-Chapter directories (e.g. ``25_live_trading``) are prefixed with a number so
-the repo lists them in reading order. That prefix makes them invalid Python
-package names, so their per-chapter helper modules (``async_utils``,
-``limit_orderbook``, ``rl_environments`` …) cannot be imported from the repo
-root — only when the chapter directory happens to be the working directory
-(which Jupyter Lab and the test harness arrange, but a bare ``python`` /
-``docker compose run`` from the repo root does not).
+"""Anchor the repo's chapter imports and data root to the repo, not to ``cwd``.
 
 Python imports ``sitecustomize`` automatically at interpreter startup whenever
 it is found on the path. This module is loaded in both supported environments:
 
 * Docker — the repo is bind-mounted at ``/app`` with ``PYTHONPATH=/app``, so
   ``/app/sitecustomize.py`` is on the startup path.
-* Local editable install — declared as a top-level ``py-module`` in
+* Local ``uv`` install — declared as a top-level ``py-module`` in
   ``pyproject.toml``, so the editable finder resolves ``sitecustomize`` to this
   file and ``site`` imports it at startup.
 
-It appends every ``NN_*`` chapter directory to ``sys.path`` (append, not
+Debian and Ubuntu ship their own ``/usr/lib/pythonX.Y/sitecustomize.py``, which
+shadows this file whenever the venv is built on the system interpreter — the
+stdlib directory precedes the editable finder. ``pyproject.toml`` therefore
+pins ``python-preference = "only-managed"`` so ``uv`` downloads its own CPython
+rather than reusing the distro's. ``scripts/verify_installation.py`` checks that
+this module actually loaded, because nothing else reports that it did not.
+
+Two things are set up here, both anchored to this file's directory so they do
+not depend on the working directory:
+
+**Chapter imports.** Chapter directories (e.g. ``25_live_trading``) are
+number-prefixed so the repo lists them in reading order, which makes them
+invalid Python package names, so their helper modules (``async_utils``,
+``limit_orderbook``, ``rl_environments`` …) are importable only when the chapter
+directory is on ``sys.path``. Every ``NN_*`` directory is appended (append, not
 insert, so nothing shadows stdlib or installed packages). Chapter helper module
 names do not collide, so a flat append is unambiguous.
+
+**The data root.** ``resolve_data_root()`` falls back to ``cwd/data`` when
+``ML4T_DATA_PATH`` is unset, so the answer depends on where the process started.
+Jupyter Lab starts each kernel in the notebook's own chapter directory, which
+made every data-loading notebook fail on the local ``uv`` path. Setting the
+variable here gives every entry point the same answer: an explicit value in the
+environment wins, then ``.env``, then ``<repo>/data``. Reading ``.env`` here is
+what makes the two groups of notebooks agree — those that import
+``utils.config`` (which calls ``load_dotenv``) and those that do not.
+
+Nothing here may raise: this module runs at the startup of every interpreter in
+the environment, so a failure would break the whole install rather than one
+notebook.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -32,3 +52,44 @@ for _chapter_dir in sorted(_REPO_ROOT.glob("[0-9][0-9]_*")):
         _entry = str(_chapter_dir)
         if _entry not in sys.path:
             sys.path.append(_entry)
+
+
+def _data_root_from_dotenv(repo_root: Path) -> str | None:
+    """Read ``ML4T_DATA_PATH`` out of ``<repo>/.env`` without importing dotenv.
+
+    ``python-dotenv`` is not guaranteed to be importable at interpreter startup,
+    and importing it there would cost every process in the environment. Only the
+    one variable is parsed; ``load_dotenv`` still handles the rest of the file
+    later, and leaves this value alone because it does not override.
+    """
+    env_file = repo_root / ".env"
+    if not env_file.is_file():
+        return None
+    for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line.startswith("ML4T_DATA_PATH"):
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() != "ML4T_DATA_PATH":
+            continue
+        value = value.strip().strip("'\"")
+        return value or None
+    return None
+
+
+def _anchor_data_root(repo_root: Path) -> None:
+    if os.environ.get("ML4T_DATA_PATH"):
+        return
+    configured = _data_root_from_dotenv(repo_root)
+    # A relative path in .env is relative to the repo, not to the process cwd —
+    # otherwise the setting reintroduces the defect it is being used to avoid.
+    data_root = Path(configured).expanduser() if configured else repo_root / "data"
+    if not data_root.is_absolute():
+        data_root = repo_root / data_root
+    os.environ["ML4T_DATA_PATH"] = str(data_root)
+
+
+try:
+    _anchor_data_root(_REPO_ROOT)
+except Exception:  # noqa: BLE001 - startup hook: never break the interpreter
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,23 @@ CASE_STUDY_IDS = [
 ]
 
 
+def generated_env_contents(repo_root: Path, environ: Mapping[str, str]) -> str:
+    """What a generated ``.env`` should contain, given the environment.
+
+    Carries only a data path someone actually chose. ``sitecustomize.py`` sets
+    ML4T_DATA_PATH to ``<repo>/data`` when nothing else did, and marks it as a
+    default; writing that into ``.env`` would promote the default to an explicit
+    setting that step 2 of ``_resolve_data_path()`` returns — shadowing the
+    populated test-data checkout and silently skipping every data-dependent
+    notebook test on a clean clone.
+    """
+    lines = [f"ML4T_PATH={repo_root}\n"]
+    data_path = environ.get("ML4T_DATA_PATH")
+    if data_path and not environ.get("ML4T_DATA_PATH_IS_DEFAULT"):
+        lines.append(f"ML4T_DATA_PATH={data_path}\n")
+    return "".join(lines)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def ci_env_setup():
     """Create .env file if running in CI (where ML4T_DATA_PATH is set externally).
@@ -45,11 +63,7 @@ def ci_env_setup():
     created = False
 
     if not env_file.exists():
-        # Create minimal .env for CI
-        env_file.write_text(
-            f"ML4T_PATH={REPO_ROOT}\n"
-            f"ML4T_DATA_PATH={os.environ.get('ML4T_DATA_PATH', REPO_ROOT / 'data')}\n"
-        )
+        env_file.write_text(generated_env_contents(REPO_ROOT, os.environ))
         created = True
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,14 @@ def _resolve_data_path() -> Path | None:
     pytest-xdist workers may not inherit env vars set by the parent process,
     so we also check the .env file and well-known test-data locations.
     """
-    # 1. Explicit env var (works in single-process pytest and CI)
+    # 1. Explicit env var (works in single-process pytest and CI).
+    #    sitecustomize.py sets ML4T_DATA_PATH to <repo>/data when nothing else
+    #    did, and marks it. That default must not win here: the tracked data/
+    #    tree is never empty, so taking it would shadow the populated test-data
+    #    checkout below and silently skip every data-dependent notebook test.
+    #    Step 4 applies the real test — does it hold parquet — to that path.
     env_path = os.environ.get("ML4T_DATA_PATH")
-    if env_path:
+    if env_path and not os.environ.get("ML4T_DATA_PATH_IS_DEFAULT"):
         p = Path(env_path).expanduser().resolve()
         if p.exists() and any(p.iterdir()):
             return p

--- a/tests/test_algoseek_convert.py
+++ b/tests/test_algoseek_convert.py
@@ -351,11 +351,83 @@ def test_day_source_reads_an_extracted_options_tree(convert, tmp_path):
     assert convert.parse_sp500_options_csv(payloads[0]).height == 1
 
 
+def test_day_source_reads_an_extracted_nasdaq_tree(convert, tmp_path):
+    """Extracting the NASDAQ-100 archive one level gives day *zips*, not CSVs.
+
+    Its outer archive is a zip of zips, so a reader who unpacks it and points
+    --source at the result has an ``2020/20200313.zip`` tree. Globbing for CSVs
+    finds nothing there and the run used to report an empty source.
+    """
+    year_dir = tmp_path / "2020"
+    year_dir.mkdir()
+    for day in ("20200313", "20200316"):
+        with zipfile.ZipFile(year_dir / f"{day}.zip", "w") as z:
+            z.writestr(f"{day}/A/AAPL.csv", _nasdaq100_csv(convert, day=day))
+            z.writestr(f"{day}/M/MSFT.csv", _nasdaq100_csv(convert, symbol="MSFT", day=day))
+
+    days = list(convert.DaySource(tmp_path, "nasdaq100-minute-bars").days())
+    assert [d for d, _ in days] == ["20200313", "20200316"]
+    payloads = days[0][1]()
+    assert len(payloads) == 2
+    assert convert.parse_nasdaq100_csv(payloads[0]).height == 2
+
+
+def test_extracted_nasdaq_tree_converts_end_to_end(convert, tmp_path):
+    year_dir = tmp_path / "archive" / "2020"
+    year_dir.mkdir(parents=True)
+    with zipfile.ZipFile(year_dir / "20200313.zip", "w") as z:
+        z.writestr("20200313/A/AAPL.csv", _nasdaq100_csv(convert))
+
+    out = tmp_path / "data"
+    assert convert.convert_nasdaq100(tmp_path / "archive", out, workers=1, force=False) == 0
+    written = out / "equities" / "market" / "nasdaq100" / "minute_bars" / "year=2020"
+    assert (written / "month=03.parquet").is_file()
+
+
 def test_day_source_rejects_a_source_that_is_neither(convert, tmp_path):
     junk = tmp_path / "notes.txt"
     junk.write_text("not an archive")
     with pytest.raises(SystemExit):
         list(convert.DaySource(junk, "sp500-options").days())
+
+
+def test_the_documented_workflow_works_with_an_external_data_root(convert, tmp_path, monkeypatch):
+    """Convert, then build, with ML4T_DATA_PATH outside the repository.
+
+    The converter always honored the data root; the three build scripts resolved
+    their input and output from their own directory, so with an external root
+    they looked where nothing had been written and left their output where no
+    loader reads. This walks conversion followed by a build and asserts both
+    landed under the configured root.
+    """
+    import importlib.util
+
+    source = tmp_path / "chains" / "2020" / "20200313"
+    source.mkdir(parents=True)
+    for symbol in ("AAPL", "MSFT"):
+        (source / f"{symbol}.csv.gz").write_bytes(
+            gzip.compress(_options_csv(convert, symbol=symbol))
+        )
+
+    data_root = tmp_path / "elsewhere"
+    assert convert.convert_sp500_options(tmp_path / "chains", data_root, 1, False) == 0
+    raw = data_root / "equities" / "market" / "sp500" / "options" / "year=2020" / "20200313.parquet"
+    assert raw.is_file(), "the converter must write under the configured data root"
+
+    build_py = Path(da.__file__).parent / "equities" / "market" / "sp500" / "build_options_eda.py"
+    spec = importlib.util.spec_from_file_location("build_options_eda_under_test", build_py)
+    build = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = build
+    spec.loader.exec_module(build)
+
+    monkeypatch.setenv("ML4T_DATA_PATH", str(data_root))
+    monkeypatch.setattr(sys, "argv", ["build_options_eda.py", "--data-path", str(data_root)])
+    build.main()
+
+    built = data_root / "equities" / "market" / "sp500" / "options_eda" / "year=2020.parquet"
+    assert built.is_file(), "the build script must read and write under the same root"
+    # Both fixture symbols are in EDA_SYMBOLS, so both rows survive the filter.
+    assert sorted(pl.read_parquet(built)["symbol"].to_list()) == ["AAPL", "MSFT"]
 
 
 # --------------------------------------------------------------------------------

--- a/tests/test_algoseek_convert.py
+++ b/tests/test_algoseek_convert.py
@@ -1,0 +1,406 @@
+"""Tests for the AlgoSeek CSV to parquet converter.
+
+AlgoSeek publishes both of its book datasets as CSV; every loader in
+``data/equities/loader.py`` reads parquet. ``algoseek_convert.py`` is the only
+thing between a reader's download and a working notebook, so what it has to get
+right is the *schema contract* — the exact column names, order and dtypes the
+loaders project out of the result. A converter that runs but renames one column
+fails much later, inside a notebook, with an error naming neither.
+
+The mapping was established against the real archives by converting 2020-03 and
+comparing to the delivery AlgoSeek shipped in April: all 62 columns, all dtypes,
+and every value in the shipped rows matched. These tests pin that outcome
+against fixtures so a later edit cannot quietly break it.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import io
+import sys
+import zipfile
+from datetime import date, datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import data.download_all as da
+
+CONVERT_PY = Path(da.__file__).parent / "equities" / "market" / "algoseek_convert.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("algoseek_convert", CONVERT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def convert():
+    return _load_module()
+
+
+# --------------------------------------------------------------------------------
+# Fixtures shaped like the real archives
+# --------------------------------------------------------------------------------
+
+# Columns AlgoSeek ships that the loaders do not read. Interleaved with the kept
+# ones in the real file, which is why the converter selects by name.
+_DROPPED = [
+    "SecId",
+    "TotalVolumeWeightPrice",
+    "VolumeWeightPriceExcludePRP",
+    "TradeAtBidCount",
+    "TotalQuoteCount",
+    "OddLotTradeCount",
+    "RetailTRFBuySize",
+]
+
+
+def _nasdaq100_csv(convert, symbol: str = "AAPL", day: str = "20200313") -> bytes:
+    """One symbol-day, with the dropped columns interleaved and blanks for nulls."""
+    kept = list(convert.NASDAQ100_COLUMNS)
+    header = kept[:5] + _DROPPED[:3] + kept[5:] + _DROPPED[3:]
+
+    def row(minute: str, price: float) -> list[str]:
+        values = {name: "" for name in header}
+        values.update(
+            {
+                "Date": day,
+                "Ticker": symbol,
+                "TimeBarStart": minute,
+                "OpenBarTime": f"{minute}:00.000000000",
+                "OpenBidPrice": str(price),
+                "OpenBidSize": "200",
+                "FirstTradePrice": str(price + 0.5),
+                "FirstTradeSize": "1785",
+                "LastTradePrice": str(price + 1.0),
+                "Volume": "7486",
+                "TotalTrades": "90",
+                "TradeAtBid": "668",
+                "TradeAtCrossOrLocked": "0",
+                "VolumeWeightPrice": str(price + 0.25),
+                "NBBOQuoteCount": "153",
+            }
+        )
+        return [values[name] for name in header]
+
+    lines = [",".join(header), ",".join(row("04:00", 255.1)), ",".join(row("04:01", 259.2))]
+    return ("\n".join(lines) + "\n").encode()
+
+
+def _options_csv(convert, symbol: str = "AAPL", day: str = "20200313") -> bytes:
+    """One symbol-day of chain, in AlgoSeek's column order.
+
+    The time columns sit between the price columns in the real file, which is why
+    the converter cannot rely on read_csv preserving a usable order.
+    """
+    header = [
+        "TradeDate",
+        "Ticker",
+        "CallPut",
+        "OptionStyle",
+        "Strike",
+        "Expiration",
+        "YearsToMaturity",
+        "DaysToMaturity",
+        "UnderLastMidPrice",
+        "UnderLastMidTime",
+        "LastBidPrice",
+        "LastBidTime",
+        "LastMidPrice",
+        "LastAskPrice",
+        "LastAskTime",
+        "MidImpliedVol",
+        "MidTheoPrice",
+        "MidDelta",
+        "MidGamma",
+        "MidTheta",
+        "MidVega",
+        "MidRho",
+        "ImpliedVolConvergence",
+    ]
+    row = [
+        day,
+        symbol,
+        "C",
+        "A",
+        "250.0",
+        "20200417",
+        "0.0959",
+        "35",
+        "255.5",
+        "15:59",
+        "12.5",
+        "15:59:59.592",
+        "13.0",
+        "13.5",
+        "15:59:59.896",
+        "0.55",
+        "12.9",
+        "0.52",
+        "0.01",
+        "-0.09",
+        "0.28",
+        "0.11",
+        "Converged",
+    ]
+    return (",".join(header) + "\n" + ",".join(row) + "\n").encode()
+
+
+# --------------------------------------------------------------------------------
+# The schema contract
+# --------------------------------------------------------------------------------
+
+# What load_nasdaq100_bars() projects out of the result, in order. Any drift here
+# is a reader whose notebook fails on a missing column.
+NASDAQ100_EXPECTED = [
+    "date",
+    "symbol",
+    "time",
+    "open_bar_time",
+    "open_bid_price",
+    "open_bid_size",
+    "open_ask_price",
+    "open_ask_size",
+    "first_trade_time",
+    "first_trade_price",
+    "first_trade_size",
+    "high_bid_time",
+    "high_bid_price",
+    "high_bid_size",
+    "high_ask_time",
+    "high_ask_price",
+    "high_ask_size",
+    "high_trade_time",
+    "high_trade_price",
+    "high_trade_size",
+    "low_bid_time",
+    "low_bid_price",
+    "low_bid_size",
+    "low_ask_time",
+    "low_ask_price",
+    "low_ask_size",
+    "low_trade_time",
+    "low_trade_price",
+    "low_trade_size",
+    "close_bar_time",
+    "close_bid_price",
+    "close_bid_size",
+    "close_ask_price",
+    "close_ask_size",
+    "last_trade_time",
+    "last_trade_price",
+    "last_trade_size",
+    "min_spread",
+    "max_spread",
+    "cancel_size",
+    "vwap",
+    "nbbo_quote_count",
+    "trade_at_bid",
+    "trade_at_bid_mid",
+    "trade_at_mid",
+    "trade_at_mid_ask",
+    "trade_at_ask",
+    "trade_at_cross",
+    "volume",
+    "total_trades",
+    "finra_volume",
+    "finra_vwap",
+    "uptick_volume",
+    "downtick_volume",
+    "repeat_uptick_volume",
+    "repeat_downtick_volume",
+    "unknown_tick_volume",
+    "trade_to_mid_vol_weight",
+    "trade_to_mid_vol_weight_rel",
+    "time_weight_bid",
+    "time_weight_ask",
+    "timestamp",
+]
+
+# The option-chain schema, in the order the sp500_options case study reads.
+SP500_OPTIONS_EXPECTED = [
+    "date",
+    "symbol",
+    "call_put",
+    "option_style",
+    "strike",
+    "expiration",
+    "years_to_maturity",
+    "days_to_maturity",
+    "underlying_price",
+    "bid",
+    "ask",
+    "mid_price",
+    "implied_vol",
+    "theo_price",
+    "delta",
+    "gamma",
+    "theta",
+    "vega",
+    "rho",
+    "iv_convergence",
+]
+
+
+def test_nasdaq100_schema_matches_what_the_loader_projects(convert):
+    df = convert.parse_nasdaq100_csv(_nasdaq100_csv(convert))
+    assert df.columns == NASDAQ100_EXPECTED
+
+
+def test_nasdaq100_dtypes(convert):
+    df = convert.parse_nasdaq100_csv(_nasdaq100_csv(convert))
+    schema = df.schema
+    assert schema["date"] == pl.Date
+    assert schema["timestamp"] == pl.Datetime("us")
+    assert schema["symbol"] == pl.String
+    # Nanosecond time-of-day text no datetime type round-trips.
+    assert schema["open_bar_time"] == pl.String
+    assert schema["first_trade_price"] == pl.Float64
+    assert schema["volume"] == pl.Int64
+
+
+def test_nasdaq100_timestamp_is_the_bar_open(convert):
+    """The loader filters regular hours on this, so it has to be the label minute."""
+    df = convert.parse_nasdaq100_csv(_nasdaq100_csv(convert))
+    assert df["timestamp"].to_list() == [
+        datetime(2020, 3, 13, 4, 0),
+        datetime(2020, 3, 13, 4, 1),
+    ]
+    assert df["date"].to_list() == [date(2020, 3, 13)] * 2
+
+
+def test_nasdaq100_blank_fields_become_null(convert):
+    """AlgoSeek leaves a field empty rather than writing a zero, and the difference
+    matters: cancel_size is null when nothing was cancelled, not 0."""
+    df = convert.parse_nasdaq100_csv(_nasdaq100_csv(convert))
+    assert df["cancel_size"].to_list() == [None, None]
+    assert df["finra_vwap"].to_list() == [None, None]
+
+
+def test_nasdaq100_maps_the_columns_that_are_easy_to_confuse(convert):
+    """TradeAtBid vs TradeAtBidCount, Volume vs TotalVolume, VolumeWeightPrice vs
+    TotalVolumeWeightPrice: each pair differs by a suffix and by an order of
+    magnitude, and picking the wrong one is silent."""
+    df = convert.parse_nasdaq100_csv(_nasdaq100_csv(convert))
+    row = df.row(0, named=True)
+    assert row["trade_at_bid"] == 668
+    assert row["volume"] == 7486
+    assert row["total_trades"] == 90
+    assert row["vwap"] == pytest.approx(255.35)
+    assert row["trade_at_cross"] == 0
+
+
+def test_sp500_options_schema_and_order(convert):
+    """read_csv keeps the file's order, which puts mid before ask. The delivery has
+    bid, ask, mid_price, and the case study reads positionally in places."""
+    df = convert.parse_sp500_options_csv(_options_csv(convert))
+    assert df.columns == SP500_OPTIONS_EXPECTED
+    row = df.row(0, named=True)
+    assert (row["bid"], row["ask"], row["mid_price"]) == (12.5, 13.5, 13.0)
+
+
+def test_sp500_options_dates_are_parsed(convert):
+    df = convert.parse_sp500_options_csv(_options_csv(convert))
+    row = df.row(0, named=True)
+    assert row["date"] == date(2020, 3, 13)
+    assert row["expiration"] == date(2020, 4, 17)
+    assert df.schema["days_to_maturity"] == pl.Int32
+
+
+# --------------------------------------------------------------------------------
+# Finding the days in either archive shape
+# --------------------------------------------------------------------------------
+
+
+def test_day_source_reads_the_nested_day_zips(convert, tmp_path):
+    """The NASDAQ-100 archive is a zip of per-day zips of per-symbol CSVs."""
+    inner = io.BytesIO()
+    with zipfile.ZipFile(inner, "w") as z:
+        z.writestr("20200313/A/AAPL.csv", _nasdaq100_csv(convert))
+        z.writestr("20200313/M/MSFT.csv", _nasdaq100_csv(convert, symbol="MSFT"))
+    outer = tmp_path / "nasdaq.zip"
+    with zipfile.ZipFile(outer, "w") as z:
+        z.writestr("2020/20200313.zip", inner.getvalue())
+
+    days = list(convert.DaySource(outer, "nasdaq100-minute-bars").days())
+    assert [d for d, _ in days] == ["20200313"]
+    assert len(days[0][1]()) == 2
+
+
+def test_day_source_reads_an_extracted_options_tree(convert, tmp_path):
+    """A reader who unpacks the 1.27M-member archive first still gets a working run."""
+    day_dir = tmp_path / "2020" / "20200313"
+    day_dir.mkdir(parents=True)
+    for symbol in ("AAPL", "MSFT"):
+        (day_dir / f"{symbol}.csv.gz").write_bytes(gzip.compress(_options_csv(convert)))
+    # macOS zips carry a shadow tree of resource forks that is not data.
+    shadow = tmp_path / "__MACOSX" / "2020" / "20200313"
+    shadow.mkdir(parents=True)
+    (shadow / "AAPL.csv.gz").write_bytes(b"not data")
+
+    days = list(convert.DaySource(tmp_path, "sp500-options").days())
+    assert [d for d, _ in days] == ["20200313"]
+    payloads = days[0][1]()
+    assert len(payloads) == 2
+    assert convert.parse_sp500_options_csv(payloads[0]).height == 1
+
+
+def test_day_source_rejects_a_source_that_is_neither(convert, tmp_path):
+    junk = tmp_path / "notes.txt"
+    junk.write_text("not an archive")
+    with pytest.raises(SystemExit):
+        list(convert.DaySource(junk, "sp500-options").days())
+
+
+# --------------------------------------------------------------------------------
+# End to end
+# --------------------------------------------------------------------------------
+
+
+def test_convert_writes_the_layout_the_loader_scans(convert, tmp_path):
+    inner = io.BytesIO()
+    with zipfile.ZipFile(inner, "w") as z:
+        z.writestr("20200313/A/AAPL.csv", _nasdaq100_csv(convert))
+    archive = tmp_path / "nasdaq.zip"
+    with zipfile.ZipFile(archive, "w") as z:
+        z.writestr("2020/20200313.zip", inner.getvalue())
+
+    out = tmp_path / "data"
+    assert convert.convert_nasdaq100(archive, out, workers=1, force=False) == 0
+
+    written = out / "equities" / "market" / "nasdaq100" / "minute_bars" / "year=2020"
+    assert (written / "month=03.parquet").is_file()
+    # Exactly how load_nasdaq100_bars() reads it.
+    scanned = pl.scan_parquet(written.parent / "**/*.parquet", hive_partitioning=True).collect()
+    assert scanned.height == 2
+    assert scanned["year"].unique().to_list() == [2020]
+
+
+def test_convert_resumes_and_force_rebuilds(convert, tmp_path, capsys):
+    day_dir = tmp_path / "2020" / "20200313"
+    day_dir.mkdir(parents=True)
+    (day_dir / "AAPL.csv.gz").write_bytes(gzip.compress(_options_csv(convert)))
+    out = tmp_path / "data"
+
+    convert.convert_sp500_options(tmp_path, out, workers=1, force=False)
+    written = out / "equities" / "market" / "sp500" / "options" / "year=2020" / "20200313.parquet"
+    assert written.is_file()
+    first = written.stat().st_mtime_ns
+
+    convert.convert_sp500_options(tmp_path, out, workers=1, force=False)
+    assert written.stat().st_mtime_ns == first, "an existing partition must be skipped"
+
+    convert.convert_sp500_options(tmp_path, out, workers=1, force=True)
+    assert written.stat().st_mtime_ns != first, "--force must rebuild it"
+
+
+def test_convert_reports_an_empty_source(convert, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert convert.convert_sp500_options(empty, tmp_path / "data", workers=1, force=False) == 1

--- a/tests/test_chapter_imports.py
+++ b/tests/test_chapter_imports.py
@@ -4,13 +4,17 @@ Chapter directories are number-prefixed (``25_live_trading``), so they are not
 Python packages and their helper modules (``async_utils`` etc.) are only
 importable when the chapter directory is on ``sys.path``. ``sitecustomize.py``
 (declared as a top-level py-module in pyproject) arranges that at interpreter
-startup in every environment. This test pins that contract: a bare
-``import async_utils`` must succeed in a fresh interpreter started from the
-repo root, with no chapter directory injected onto the path.
+startup. This test pins that contract: a bare ``import async_utils`` must
+succeed in a fresh interpreter started from the repo root, with no chapter
+directory injected onto the path.
 
 If this fails, ``sitecustomize.py`` or its ``[tool.setuptools] py-modules``
-declaration was likely removed, or the package needs reinstalling
-(``uv pip install -e .``).
+declaration was likely removed, the package needs reinstalling
+(``uv pip install -e .``), or the venv was built on a Debian/Ubuntu system
+interpreter whose own ``/usr/lib/pythonX.Y/sitecustomize.py`` shadows this
+repo's. ``pyproject.toml`` pins ``python-preference = "only-managed"`` against
+that last case; ``tests/test_data_root_anchor.py`` covers the other half of the
+same hook.
 """
 
 from __future__ import annotations

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -45,8 +45,16 @@ def _load_download_module():
 
 
 def _frame(symbols) -> pl.DataFrame:
-    """One in-window row per symbol, the minimum the write path needs."""
+    """One in-window row per symbol, the minimum the write path needs.
+
+    An empty response is a frame with *no columns*, which is what the provider
+    actually returns and what an earlier version of these tests got wrong: a
+    zero-row frame that still carries named columns hides every crash on the
+    empty path, because combine_existing() and sort() both need `timestamp`.
+    """
     symbols = list(symbols)
+    if not symbols:
+        return pl.DataFrame()
     return pl.DataFrame(
         {
             "symbol": symbols,
@@ -226,6 +234,27 @@ def test_update_starts_from_the_earliest_symbol(downloader, tmp_path):
 
     start = downloader.get_update_start(output, "2021-12-31", interval_hours=1)
     assert start == "2021-06-01", "must resume from the symbol that is furthest behind"
+
+
+def test_update_reopens_the_window_for_a_symbol_with_no_history(downloader, tmp_path):
+    """An absent symbol needs the configured start, not the recent gap.
+
+    Resuming from the earliest *stored* symbol would give it only the tail, and
+    its presence afterwards would then read as a complete download.
+    """
+    output = tmp_path / "perps_1h.parquet"
+    pl.DataFrame(
+        {
+            "symbol": ["BTCUSDT", "ETHUSDT"],
+            "timestamp": [datetime(2021, 6, 10), datetime(2021, 6, 1)],
+            "close": [30000.0, 2000.0],
+        }
+    ).write_parquet(output)
+
+    start = downloader.get_update_start(
+        output, "2021-12-31", 1, ["BTCUSDT", "ETHUSDT", "SOLUSDT"], "2020-01-01"
+    )
+    assert start == "2020-01-01", "a symbol with no history reopens the configured window"
 
 
 def test_a_single_requested_symbol_that_arrives_is_complete(downloader, monkeypatch, tmp_path):

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -235,11 +235,31 @@ def test_an_empty_forced_download_exits_nonzero(
     assert exc.value.code == 1
 
 
-def test_an_empty_first_run_exits_nonzero(downloader, monkeypatch, tmp_path, configured_symbols):
-    """The converse: nothing on disk and nothing arrived is still a failure."""
+def test_an_empty_first_run_exits_nonzero(
+    downloader, monkeypatch, tmp_path, capsys, configured_symbols
+):
+    """The converse: nothing on disk and nothing arrived is still a failure.
+
+    The message matters as much as the status here. A reader on their first run
+    has no earlier download, so telling them the script is falling back to what
+    is on disk describes something that does not exist.
+    """
     with pytest.raises(SystemExit) as exc:
         _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
     assert exc.value.code == 1
+
+    out = capsys.readouterr().out
+    assert "Nothing has been downloaded before either." in out
+    assert "Falling back to what is already on disk." not in out
+
+
+def test_an_empty_retry_says_it_is_using_what_is_on_disk(
+    downloader, monkeypatch, tmp_path, capsys, configured_symbols
+):
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+    capsys.readouterr()
+    _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
+    assert "Falling back to what is already on disk." in capsys.readouterr().out
 
 
 def test_update_starts_from_the_earliest_symbol(downloader, tmp_path):

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -209,6 +209,28 @@ def test_an_empty_retry_against_a_complete_dataset_exits_zero(
     _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
 
 
+def test_an_empty_forced_download_exits_nonzero(
+    downloader, monkeypatch, tmp_path, configured_symbols
+):
+    """--force replaces rather than merges, so there is nothing to fall back to.
+
+    A forced refresh that returned nothing has failed. Reporting success on the
+    strength of the rows it was about to replace would present stale data as the
+    result of the run.
+    """
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+    with pytest.raises(SystemExit) as exc:
+        _run(
+            downloader,
+            monkeypatch,
+            tmp_path,
+            arrived=[],
+            failed=configured_symbols,
+            cli=("--force",),
+        )
+    assert exc.value.code == 1
+
+
 def test_an_empty_first_run_exits_nonzero(downloader, monkeypatch, tmp_path, configured_symbols):
     """The converse: nothing on disk and nothing arrived is still a failure."""
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -1,0 +1,121 @@
+"""Exit-status tests for the crypto downloader (``data/crypto/market/download.py``).
+
+The downloader makes roughly 700 Binance calls over 10-15 minutes against a
+documented server-side rate limit, so coming back short is its expected failure
+mode. It used to exit non-zero only when the downloaded frame was *entirely*
+empty: 18 of 19 symbols could fail and the script still exited 0, which
+``data/download_all.py`` reads as ``[OK] Crypto``.
+
+These pin the status, not the summary text: a non-empty failed-symbol list on
+either dataset must exit 1, and ``--allow-partial`` must be the only way to keep
+what arrived and still exit 0.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import data.download_all as da
+
+DOWNLOAD_PY = Path(da.__file__).parent / "crypto" / "market" / "download.py"
+
+
+def _load_download_module():
+    """Load ``crypto/market/download.py`` (not a package) as a module."""
+    spec = importlib.util.spec_from_file_location("crypto_market_download", DOWNLOAD_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _frame(symbol: str) -> pl.DataFrame:
+    """One in-window row, the minimum the write path needs."""
+    return pl.DataFrame(
+        {
+            "symbol": [symbol],
+            "timestamp": [datetime(2021, 6, 1)],
+            "close": [30000.0],
+        }
+    )
+
+
+@pytest.fixture
+def downloader(monkeypatch, tmp_path):
+    """The real ``main()`` with the network and the profiler replaced."""
+    mod = _load_download_module()
+
+    class _StubProvider:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("ml4t.data.providers.binance_public.BinancePublicProvider", _StubProvider)
+    monkeypatch.setattr(mod, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "save_dataset_profile", lambda *a, **k: tmp_path / "profile.json")
+    return mod
+
+
+def _run(mod, monkeypatch, tmp_path, *, perps_failed, premium_failed, cli=()):
+    monkeypatch.setattr(
+        mod,
+        "download_perps",
+        lambda *a, **k: (_frame("BTCUSDT"), list(perps_failed)),
+    )
+    monkeypatch.setattr(
+        mod,
+        "download_premium",
+        lambda *a, **k: (_frame("BTCUSDT"), list(premium_failed)),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["download.py", "--data-path", str(tmp_path), "--symbol", "BTCUSDT", *cli],
+    )
+    mod.main()
+
+
+def test_complete_download_exits_zero(downloader, monkeypatch, tmp_path):
+    _run(downloader, monkeypatch, tmp_path, perps_failed=[], premium_failed=[])
+
+
+def test_partial_perps_exits_nonzero(downloader, monkeypatch, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        _run(downloader, monkeypatch, tmp_path, perps_failed=["ETHUSDT"], premium_failed=[])
+    assert exc.value.code == 1
+
+
+def test_partial_premium_exits_nonzero(downloader, monkeypatch, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        _run(downloader, monkeypatch, tmp_path, perps_failed=[], premium_failed=["ETHUSDT"])
+    assert exc.value.code == 1
+
+
+def test_allow_partial_keeps_what_arrived(downloader, monkeypatch, tmp_path, capsys):
+    _run(
+        downloader,
+        monkeypatch,
+        tmp_path,
+        perps_failed=["ETHUSDT"],
+        premium_failed=["ETHUSDT"],
+        cli=("--allow-partial",),
+    )
+    assert "ETHUSDT" in capsys.readouterr().out
+
+
+def test_failed_symbols_are_named(downloader, monkeypatch, tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        _run(
+            downloader,
+            monkeypatch,
+            tmp_path,
+            perps_failed=["ETHUSDT", "SOLUSDT"],
+            premium_failed=[],
+        )
+    out = capsys.readouterr().out
+    assert "ETHUSDT" in out and "SOLUSDT" in out

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -10,10 +10,14 @@ These pin the status, not the summary text: a requested symbol absent from what
 is now on disk must exit 1, and ``--allow-partial`` must be the only way to keep
 what arrived and still exit 0.
 
-The status comes from the *merged* dataset rather than from the symbols that
-failed in the last request. ``combine_existing()`` folds a retry into what an
-earlier run wrote, so a symbol that fails on the retry is still on disk — basing
-the status on the request would fail a download that is in fact complete.
+On a plain run the status comes from the *merged* dataset rather than from the
+symbols that failed in the last request. ``combine_existing()`` folds a retry
+into what an earlier run wrote, so a symbol that fails on the retry is still on
+disk — basing the status on the request would fail a download that is complete.
+
+``--update`` inverts that, and both directions are pinned below. Every symbol is
+already on disk by construction, so presence proves nothing about whether the
+window was extended; there the request's failures are what did not arrive.
 """
 
 from __future__ import annotations
@@ -155,6 +159,34 @@ def test_a_retry_that_is_still_short_exits_nonzero(
     with pytest.raises(SystemExit) as exc:
         _run(downloader, monkeypatch, tmp_path, arrived=second)
     assert exc.value.code == 1
+
+
+def test_update_reports_a_failed_extension(downloader, monkeypatch, tmp_path, configured_symbols):
+    """--update inverts what presence proves.
+
+    Every symbol is already on disk by construction, so an update whose every
+    incremental request failed would look complete to a presence check even
+    though no new rows arrived. There the request's failures are the answer.
+    """
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+
+    with pytest.raises(SystemExit) as exc:
+        _run(
+            downloader,
+            monkeypatch,
+            tmp_path,
+            arrived=configured_symbols,
+            failed=configured_symbols,
+            cli=("--update",),
+        )
+    assert exc.value.code == 1
+
+
+def test_update_that_extends_everything_exits_zero(
+    downloader, monkeypatch, tmp_path, configured_symbols
+):
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols, cli=("--update",))
 
 
 def test_a_single_requested_symbol_that_arrives_is_complete(downloader, monkeypatch, tmp_path):

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -209,16 +209,20 @@ def test_an_empty_retry_against_a_complete_dataset_exits_zero(
     _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
 
 
+@pytest.mark.parametrize("dataset", ["--perps", "--premium"])
 def test_an_empty_forced_download_exits_nonzero(
-    downloader, monkeypatch, tmp_path, configured_symbols
+    downloader, monkeypatch, tmp_path, configured_symbols, dataset
 ):
     """--force replaces rather than merges, so there is nothing to fall back to.
 
     A forced refresh that returned nothing has failed. Reporting success on the
     strength of the rows it was about to replace would present stale data as the
     result of the run.
+
+    One dataset at a time: perps and premium have separate fallbacks, and a run
+    covering both would exit 1 on either, so it could not tell which was fixed.
     """
-    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols, cli=(dataset,))
     with pytest.raises(SystemExit) as exc:
         _run(
             downloader,
@@ -226,7 +230,7 @@ def test_an_empty_forced_download_exits_nonzero(
             tmp_path,
             arrived=[],
             failed=configured_symbols,
-            cli=("--force",),
+            cli=(dataset, "--force"),
         )
     assert exc.value.code == 1
 

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -189,6 +189,45 @@ def test_update_that_extends_everything_exits_zero(
     _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols, cli=("--update",))
 
 
+def test_an_empty_retry_against_a_complete_dataset_exits_zero(
+    downloader, monkeypatch, tmp_path, configured_symbols
+):
+    """A fully rate-limited retry is not a failed download.
+
+    Nothing arrives, but everything is already on disk from the first run. This
+    used to exit 1 before the status logic ran, and ignored --allow-partial too.
+    """
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
+    _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
+
+
+def test_an_empty_first_run_exits_nonzero(downloader, monkeypatch, tmp_path, configured_symbols):
+    """The converse: nothing on disk and nothing arrived is still a failure."""
+    with pytest.raises(SystemExit) as exc:
+        _run(downloader, monkeypatch, tmp_path, arrived=[], failed=configured_symbols)
+    assert exc.value.code == 1
+
+
+def test_update_starts_from_the_earliest_symbol(downloader, tmp_path):
+    """An update must not step over a gap a previous partial update left.
+
+    Symbols that succeeded carry the dataset maximum; the ones that failed sit
+    behind it. Starting from the maximum would skip the gap permanently while
+    reporting success, so the start comes from the earliest symbol.
+    """
+    output = tmp_path / "perps_1h.parquet"
+    pl.DataFrame(
+        {
+            "symbol": ["BTCUSDT", "ETHUSDT"],
+            "timestamp": [datetime(2021, 6, 10), datetime(2021, 6, 1)],
+            "close": [30000.0, 2000.0],
+        }
+    ).write_parquet(output)
+
+    start = downloader.get_update_start(output, "2021-12-31", interval_hours=1)
+    assert start == "2021-06-01", "must resume from the symbol that is furthest behind"
+
+
 def test_a_single_requested_symbol_that_arrives_is_complete(downloader, monkeypatch, tmp_path):
     """--symbol narrows what was asked for, so nothing else can be missing."""
     _run(

--- a/tests/test_crypto_partial_download.py
+++ b/tests/test_crypto_partial_download.py
@@ -6,9 +6,14 @@ mode. It used to exit non-zero only when the downloaded frame was *entirely*
 empty: 18 of 19 symbols could fail and the script still exited 0, which
 ``data/download_all.py`` reads as ``[OK] Crypto``.
 
-These pin the status, not the summary text: a non-empty failed-symbol list on
-either dataset must exit 1, and ``--allow-partial`` must be the only way to keep
+These pin the status, not the summary text: a requested symbol absent from what
+is now on disk must exit 1, and ``--allow-partial`` must be the only way to keep
 what arrived and still exit 0.
+
+The status comes from the *merged* dataset rather than from the symbols that
+failed in the last request. ``combine_existing()`` folds a retry into what an
+earlier run wrote, so a symbol that fails on the retry is still on disk — basing
+the status on the request would fail a download that is in fact complete.
 """
 
 from __future__ import annotations
@@ -35,13 +40,14 @@ def _load_download_module():
     return mod
 
 
-def _frame(symbol: str) -> pl.DataFrame:
-    """One in-window row, the minimum the write path needs."""
+def _frame(symbols) -> pl.DataFrame:
+    """One in-window row per symbol, the minimum the write path needs."""
+    symbols = list(symbols)
     return pl.DataFrame(
         {
-            "symbol": [symbol],
-            "timestamp": [datetime(2021, 6, 1)],
-            "close": [30000.0],
+            "symbol": symbols,
+            "timestamp": [datetime(2021, 6, 1)] * len(symbols),
+            "close": [30000.0] * len(symbols),
         }
     )
 
@@ -61,61 +67,103 @@ def downloader(monkeypatch, tmp_path):
     return mod
 
 
-def _run(mod, monkeypatch, tmp_path, *, perps_failed, premium_failed, cli=()):
-    monkeypatch.setattr(
-        mod,
-        "download_perps",
-        lambda *a, **k: (_frame("BTCUSDT"), list(perps_failed)),
-    )
-    monkeypatch.setattr(
-        mod,
-        "download_premium",
-        lambda *a, **k: (_frame("BTCUSDT"), list(premium_failed)),
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["download.py", "--data-path", str(tmp_path), "--symbol", "BTCUSDT", *cli],
-    )
+@pytest.fixture
+def configured_symbols():
+    """The symbols a plain run requests, read from the shipped config."""
+    from utils.downloading import flatten_group_values, load_section
+
+    config = load_section(DOWNLOAD_PY.parent / "config.yaml", "crypto")
+    symbols = flatten_group_values(config.get("symbols", {}), "symbols")
+    assert len(symbols) > 3, "these tests need a multi-symbol universe"
+    return symbols
+
+
+def _run(mod, monkeypatch, tmp_path, *, arrived, failed=(), cli=()):
+    """Run ``main()`` with both download functions replaced.
+
+    *arrived* is what the provider returns this time. *failed* is what the
+    request reports, which on a retry is deliberately allowed to disagree with
+    what an earlier run already put on disk.
+    """
+    monkeypatch.setattr(mod, "download_perps", lambda *a, **k: (_frame(arrived), list(failed)))
+    monkeypatch.setattr(mod, "download_premium", lambda *a, **k: (_frame(arrived), list(failed)))
+    monkeypatch.setattr(sys, "argv", ["download.py", "--data-path", str(tmp_path), *cli])
     mod.main()
 
 
-def test_complete_download_exits_zero(downloader, monkeypatch, tmp_path):
-    _run(downloader, monkeypatch, tmp_path, perps_failed=[], premium_failed=[])
+def test_complete_download_exits_zero(downloader, monkeypatch, tmp_path, configured_symbols):
+    _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols)
 
 
-def test_partial_perps_exits_nonzero(downloader, monkeypatch, tmp_path):
+def test_missing_symbol_exits_nonzero(downloader, monkeypatch, tmp_path, configured_symbols):
     with pytest.raises(SystemExit) as exc:
-        _run(downloader, monkeypatch, tmp_path, perps_failed=["ETHUSDT"], premium_failed=[])
-    assert exc.value.code == 1
-
-
-def test_partial_premium_exits_nonzero(downloader, monkeypatch, tmp_path):
-    with pytest.raises(SystemExit) as exc:
-        _run(downloader, monkeypatch, tmp_path, perps_failed=[], premium_failed=["ETHUSDT"])
-    assert exc.value.code == 1
-
-
-def test_allow_partial_keeps_what_arrived(downloader, monkeypatch, tmp_path, capsys):
-    _run(
-        downloader,
-        monkeypatch,
-        tmp_path,
-        perps_failed=["ETHUSDT"],
-        premium_failed=["ETHUSDT"],
-        cli=("--allow-partial",),
-    )
-    assert "ETHUSDT" in capsys.readouterr().out
-
-
-def test_failed_symbols_are_named(downloader, monkeypatch, tmp_path, capsys):
-    with pytest.raises(SystemExit):
         _run(
             downloader,
             monkeypatch,
             tmp_path,
-            perps_failed=["ETHUSDT", "SOLUSDT"],
-            premium_failed=[],
+            arrived=configured_symbols[:1],
+            failed=configured_symbols[1:],
         )
+    assert exc.value.code == 1
+
+
+def test_missing_symbols_are_named(downloader, monkeypatch, tmp_path, capsys, configured_symbols):
+    with pytest.raises(SystemExit):
+        _run(downloader, monkeypatch, tmp_path, arrived=configured_symbols[:-2])
     out = capsys.readouterr().out
-    assert "ETHUSDT" in out and "SOLUSDT" in out
+    for symbol in configured_symbols[-2:]:
+        assert symbol in out
+
+
+def test_allow_partial_keeps_what_arrived(
+    downloader, monkeypatch, tmp_path, capsys, configured_symbols
+):
+    _run(
+        downloader,
+        monkeypatch,
+        tmp_path,
+        arrived=configured_symbols[:-1],
+        cli=("--allow-partial",),
+    )
+    assert configured_symbols[-1] in capsys.readouterr().out
+
+
+def test_a_retry_that_completes_the_dataset_exits_zero(
+    downloader, monkeypatch, tmp_path, configured_symbols
+):
+    """The case a request-based status gets wrong.
+
+    The first run comes back short. The second fetches the rest and reports the
+    already-downloaded symbols as failures, which is what a rate-limited retry
+    looks like. The merged dataset is complete, so the run has succeeded.
+    """
+    first, rest = configured_symbols[:2], configured_symbols[2:]
+    with pytest.raises(SystemExit):
+        _run(downloader, monkeypatch, tmp_path, arrived=first, failed=rest)
+
+    # Nothing may raise: across the two runs every symbol is now on disk.
+    _run(downloader, monkeypatch, tmp_path, arrived=rest, failed=first)
+
+
+def test_a_retry_that_is_still_short_exits_nonzero(
+    downloader, monkeypatch, tmp_path, configured_symbols
+):
+    """The converse, so the fix cannot degrade into always exiting 0."""
+    first, second = configured_symbols[:2], configured_symbols[2:-1]
+    with pytest.raises(SystemExit):
+        _run(downloader, monkeypatch, tmp_path, arrived=first)
+    with pytest.raises(SystemExit) as exc:
+        _run(downloader, monkeypatch, tmp_path, arrived=second)
+    assert exc.value.code == 1
+
+
+def test_a_single_requested_symbol_that_arrives_is_complete(downloader, monkeypatch, tmp_path):
+    """--symbol narrows what was asked for, so nothing else can be missing."""
+    _run(
+        downloader,
+        monkeypatch,
+        tmp_path,
+        arrived=["BTCUSDT"],
+        failed=["ETHUSDT"],
+        cli=("--symbol", "BTCUSDT"),
+    )

--- a/tests/test_data_root_anchor.py
+++ b/tests/test_data_root_anchor.py
@@ -1,0 +1,145 @@
+"""Guard: the data root is anchored to the repo, not to the working directory.
+
+``resolve_data_root()`` falls back to ``cwd/data`` when ``ML4T_DATA_PATH`` is
+unset, so the answer used to depend on where the process started. Jupyter Lab
+starts every kernel in the notebook's own chapter directory, which made every
+data-loading notebook fail on the local ``uv`` path with a FileNotFoundError
+naming a path under the chapter directory.
+
+``sitecustomize.py`` now sets the variable at interpreter startup. These tests
+pin the three things that has to get right: an explicit value in the environment
+wins, ``.env`` is honored (so the notebooks that import ``utils.config`` and the
+ones that do not agree on the answer), and a chapter directory as cwd resolves to
+the same place as the repo root.
+
+``tests/test_chapter_imports.py`` covers the other half of the same hook.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHAPTER_DIR = REPO_ROOT / "01_process_is_edge"
+
+PROBE = "import os; print(os.environ.get('ML4T_DATA_PATH', ''))"
+
+
+def _load_sitecustomize():
+    """Load *this repo's* sitecustomize.py by path.
+
+    A bare ``import sitecustomize`` returns whichever copy the running
+    interpreter resolved at startup, which in a shared-venv worktree is another
+    checkout's and on Ubuntu is the distro's. The unit tests below are about this
+    file, so they load this file.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "ml4t_sitecustomize_under_test", REPO_ROOT / "sitecustomize.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Executing it runs the anchor for real; put the variable back so loading the
+    # module under test cannot change the environment the rest of the suite sees.
+    before = os.environ.get("ML4T_DATA_PATH")
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        if before is None:
+            os.environ.pop("ML4T_DATA_PATH", None)
+        else:
+            os.environ["ML4T_DATA_PATH"] = before
+    return mod
+
+
+def _probe(cwd: Path, env_overrides: dict[str, str] | None = None) -> str:
+    """Read ML4T_DATA_PATH out of a fresh interpreter started in *cwd*."""
+    env = dict(os.environ)
+    env.pop("ML4T_DATA_PATH", None)
+    env.update(env_overrides or {})
+    out = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def anchor_ran() -> None:
+    """Skip when the startup hook is shadowed rather than reporting a false failure.
+
+    On a venv built against a Debian/Ubuntu system interpreter the distro's own
+    sitecustomize.py wins and this repo's never runs. That is a real defect, but
+    it is the one ``scripts/verify_installation.py`` diagnoses by name; these
+    tests are about what the hook does once it runs.
+    """
+    if not _probe(REPO_ROOT):
+        pytest.skip("sitecustomize.py did not run in this environment")
+
+
+def test_repo_root_resolves_to_repo_data(anchor_ran) -> None:
+    assert Path(_probe(REPO_ROOT)) == REPO_ROOT / "data"
+
+
+def test_chapter_directory_resolves_to_the_same_place(anchor_ran) -> None:
+    """The defect itself: this used to be <repo>/01_process_is_edge/data."""
+    assert Path(_probe(CHAPTER_DIR)) == REPO_ROOT / "data"
+
+
+def test_explicit_environment_value_wins(anchor_ran, tmp_path) -> None:
+    assert _probe(CHAPTER_DIR, {"ML4T_DATA_PATH": str(tmp_path)}) == str(tmp_path)
+
+
+def test_dotenv_value_is_honored(tmp_path, monkeypatch) -> None:
+    """A reader who follows .env.example must get the same answer everywhere.
+
+    ``utils.config`` calls ``load_dotenv``, so notebooks that import it always
+    honored ``.env``; notebooks that do not import it silently ignored the value.
+    The startup hook reads the one variable so both groups agree.
+    """
+    sitecustomize = _load_sitecustomize()
+
+    monkeypatch.setattr(sitecustomize, "_data_root_from_dotenv", lambda _root: str(tmp_path))
+    monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
+    sitecustomize._anchor_data_root(REPO_ROOT)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path)
+
+
+def test_dotenv_relative_path_is_relative_to_the_repo(monkeypatch) -> None:
+    """Otherwise the setting reintroduces the cwd dependence it is used to avoid."""
+    sitecustomize = _load_sitecustomize()
+
+    monkeypatch.setattr(sitecustomize, "_data_root_from_dotenv", lambda _root: "elsewhere/data")
+    monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
+    sitecustomize._anchor_data_root(REPO_ROOT)
+    assert Path(os.environ["ML4T_DATA_PATH"]) == REPO_ROOT / "elsewhere" / "data"
+
+
+def test_dotenv_parser_reads_the_value(tmp_path) -> None:
+    sitecustomize = _load_sitecustomize()
+
+    (tmp_path / ".env").write_text(
+        "# a comment\nOTHER=1\nML4T_DATA_PATH='/mnt/big/data'\nML4T_PATH=/nope\n"
+    )
+    assert sitecustomize._data_root_from_dotenv(tmp_path) == "/mnt/big/data"
+
+
+def test_dotenv_parser_ignores_a_similar_name(tmp_path) -> None:
+    sitecustomize = _load_sitecustomize()
+
+    (tmp_path / ".env").write_text("ML4T_DATA_PATH_OLD=/wrong\n")
+    assert sitecustomize._data_root_from_dotenv(tmp_path) is None
+
+
+def test_dotenv_parser_tolerates_a_missing_file(tmp_path) -> None:
+    sitecustomize = _load_sitecustomize()
+
+    assert sitecustomize._data_root_from_dotenv(tmp_path) is None

--- a/tests/test_data_root_anchor.py
+++ b/tests/test_data_root_anchor.py
@@ -85,13 +85,34 @@ def anchor_ran() -> None:
         pytest.skip("sitecustomize.py did not run in this environment")
 
 
-def test_repo_root_resolves_to_repo_data(anchor_ran) -> None:
-    assert Path(_probe(REPO_ROOT)) == REPO_ROOT / "data"
+def _expected_root() -> Path:
+    """What the hook should resolve to on *this* machine.
+
+    Not unconditionally ``<repo>/data``: a reader who keeps data on another drive
+    sets ML4T_DATA_PATH in ``.env``, and honoring that is the whole point of
+    reading the file. Asserting the repo path regardless would fail on every
+    correctly-configured machine, including this one.
+    """
+    configured = _load_sitecustomize()._data_root_from_dotenv(REPO_ROOT)
+    if not configured:
+        return REPO_ROOT / "data"
+    path = Path(configured).expanduser()
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def test_repo_root_resolves_to_the_configured_root(anchor_ran) -> None:
+    assert Path(_probe(REPO_ROOT)) == _expected_root()
 
 
 def test_chapter_directory_resolves_to_the_same_place(anchor_ran) -> None:
     """The defect itself: this used to be <repo>/01_process_is_edge/data."""
-    assert Path(_probe(CHAPTER_DIR)) == REPO_ROOT / "data"
+    assert Path(_probe(CHAPTER_DIR)) == _expected_root()
+
+
+def test_every_directory_agrees(anchor_ran) -> None:
+    """Whatever the answer is, it must not depend on where the process started."""
+    seen = {_probe(d) for d in (REPO_ROOT, CHAPTER_DIR, REPO_ROOT / "tests", Path.home())}
+    assert len(seen) == 1, seen
 
 
 def test_explicit_environment_value_wins(anchor_ran, tmp_path) -> None:
@@ -143,3 +164,74 @@ def test_dotenv_parser_tolerates_a_missing_file(tmp_path) -> None:
     sitecustomize = _load_sitecustomize()
 
     assert sitecustomize._data_root_from_dotenv(tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("ML4T_DATA_PATH=/mnt/big/data", "/mnt/big/data"),
+        ('ML4T_DATA_PATH="/mnt/big/data"', "/mnt/big/data"),
+        ("ML4T_DATA_PATH=/mnt/big/data # external disk", "/mnt/big/data"),
+        ("export ML4T_DATA_PATH=/mnt/big/data", "/mnt/big/data"),
+        ("ML4T_DATA_PATH=", None),
+    ],
+    ids=["plain", "quoted", "inline-comment", "export", "empty"],
+)
+def test_dotenv_parser_matches_load_dotenv(tmp_path, line, expected) -> None:
+    """Every one of these is valid .env syntax a reader may write.
+
+    A hand-rolled parser gets the last three wrong, and a wrong value here is one
+    nothing downstream can fix: ``utils.config`` calls ``load_dotenv`` with
+    ``override=False``, so whatever the hook sets is what the run uses.
+    """
+    sitecustomize = _load_sitecustomize()
+
+    (tmp_path / ".env").write_text(line + "\n")
+    assert sitecustomize._data_root_from_dotenv(tmp_path) == expected
+
+
+def test_dotenv_parser_interpolates(tmp_path) -> None:
+    sitecustomize = _load_sitecustomize()
+
+    (tmp_path / ".env").write_text("ROOT=/mnt/big\nML4T_DATA_PATH=${ROOT}/data\n")
+    assert sitecustomize._data_root_from_dotenv(tmp_path) == "/mnt/big/data"
+
+
+def test_the_default_is_marked_as_a_default(monkeypatch) -> None:
+    """tests/conftest.py distinguishes on this.
+
+    The tracked ``data/`` tree is never empty, so an unmarked default would look
+    like a configured data root and hide the populated test-data checkout,
+    silently skipping every data-dependent notebook test.
+    """
+    sitecustomize = _load_sitecustomize()
+
+    monkeypatch.setattr(sitecustomize, "_data_root_from_dotenv", lambda _root: None)
+    monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
+    monkeypatch.delenv("ML4T_DATA_PATH_IS_DEFAULT", raising=False)
+    sitecustomize._anchor_data_root(REPO_ROOT)
+    assert Path(os.environ["ML4T_DATA_PATH"]) == REPO_ROOT / "data"
+    assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
+
+
+def test_a_configured_value_is_not_marked_as_a_default(monkeypatch, tmp_path) -> None:
+    sitecustomize = _load_sitecustomize()
+
+    monkeypatch.setattr(sitecustomize, "_data_root_from_dotenv", lambda _root: str(tmp_path))
+    monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
+    monkeypatch.delenv("ML4T_DATA_PATH_IS_DEFAULT", raising=False)
+    sitecustomize._anchor_data_root(REPO_ROOT)
+    assert "ML4T_DATA_PATH_IS_DEFAULT" not in os.environ
+
+
+def test_conftest_ignores_the_anchored_default(monkeypatch) -> None:
+    """The regression the marker exists to prevent, at the site that consumes it."""
+    import tests.conftest as conftest
+
+    monkeypatch.setenv("ML4T_DATA_PATH", str(REPO_ROOT / "data"))
+    monkeypatch.setenv("ML4T_DATA_PATH_IS_DEFAULT", "1")
+    resolved = conftest._resolve_data_path()
+    # Whatever it picks, it must not be the source tree taken on the strength of
+    # being non-empty. Step 4 may still return it, but only if it holds parquet.
+    if resolved == REPO_ROOT / "data":
+        assert list((REPO_ROOT / "data").glob("*/*.parquet"))

--- a/tests/test_data_root_anchor.py
+++ b/tests/test_data_root_anchor.py
@@ -224,6 +224,31 @@ def test_a_configured_value_is_not_marked_as_a_default(monkeypatch, tmp_path) ->
     assert "ML4T_DATA_PATH_IS_DEFAULT" not in os.environ
 
 
+def test_a_generated_env_omits_the_anchored_default() -> None:
+    """Otherwise the marker is defeated one step later.
+
+    conftest writes a .env when a clean clone has none. Writing the marked
+    default into it promotes the default to an explicit setting, which the .env
+    branch of _resolve_data_path() then returns — the same silent skip the marker
+    exists to prevent, one indirection further along.
+    """
+    from tests.conftest import generated_env_contents
+
+    written = generated_env_contents(
+        REPO_ROOT,
+        {"ML4T_DATA_PATH": str(REPO_ROOT / "data"), "ML4T_DATA_PATH_IS_DEFAULT": "1"},
+    )
+    assert "ML4T_DATA_PATH=" not in written
+    assert f"ML4T_PATH={REPO_ROOT}" in written
+
+
+def test_a_generated_env_keeps_a_chosen_data_path() -> None:
+    from tests.conftest import generated_env_contents
+
+    written = generated_env_contents(REPO_ROOT, {"ML4T_DATA_PATH": "/mnt/big/data"})
+    assert "ML4T_DATA_PATH=/mnt/big/data" in written
+
+
 def test_conftest_ignores_the_anchored_default(monkeypatch) -> None:
     """The regression the marker exists to prevent, at the site that consumes it."""
     import tests.conftest as conftest

--- a/uv.lock
+++ b/uv.lock
@@ -4367,7 +4367,7 @@ requires-dist = [
     { name = "llama-index-vector-stores-chroma", specifier = ">=0.5.5" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "ml4t-backtest", specifier = ">=0.1.0b20" },
-    { name = "ml4t-data", specifier = ">=0.1.0b15" },
+    { name = "ml4t-data", specifier = ">=0.1.0b19" },
     { name = "ml4t-diagnostic", specifier = ">=0.1.0b25" },
     { name = "ml4t-engineer", specifier = ">=0.1.0b10" },
     { name = "ml4t-live", specifier = ">=0.1.0b3" },
@@ -4468,7 +4468,7 @@ wheels = [
 
 [[package]]
 name = "ml4t-data"
-version = "0.1.0b15"
+version = "0.1.0b19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4492,9 +4492,9 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/79/924aa894833ff4b58870e0580f6438dfb459787ef469d01cb7ee47793071/ml4t_data-0.1.0b15.tar.gz", hash = "sha256:025e43569220a02521060ca5c2d8f9c10361f2682bd9a12579531b8a7d0be91d", size = 639375, upload-time = "2026-07-07T02:52:38.838Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/08/0216821194a2ed4669c2c2f05b54dc85eaac1f614ca5331cd0779d8dea04/ml4t_data-0.1.0b19.tar.gz", hash = "sha256:b16b8982aaa035ad3dceaf3a2a3568b1f9b4b7a6bbf626c1031c777eef220486", size = 683844, upload-time = "2026-07-31T22:02:38.511Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/82/824a12df68c712bce3eb7cd126055f6a4bb0cf04aee887da59f150ec510b/ml4t_data-0.1.0b15-py3-none-any.whl", hash = "sha256:9093cb35811dc0a5a7f180cc13ef175b0f9f9dd45c54de57618a833cdf8d7c79", size = 422027, upload-time = "2026-07-07T02:52:37.167Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/72/7dd67501914af614fea25bbaa5d58dd38d61a3aa4db48dabe47f943c91ff/ml4t_data-0.1.0b19-py3-none-any.whl", hash = "sha256:3af2cccade45f7d7799afa36b8b58285c8e90d24beb9c280c13c4e3fac7efa13", size = 448648, upload-time = "2026-07-31T22:02:36.711Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Infrastructure batch 1: what a reader hits in their first hour. Five defects on
one surface — obtaining the data, and running a notebook against it.

## No working path to the AlgoSeek data

A reader had no way to obtain any AlgoSeek dataset, including the two AlgoSeek
publishes openly at <https://algoseek.com/ml-for-trading/> with no account, no
API key and no license request. The loaders said "Contact AlgoSeek", `data/README.md`
marked all four "Soon", and the S3 base the options loaders pointed at returns 403
on a prefix that was never public.

The blocking piece was format: both archives are CSV and every loader reads
Hive-partitioned zstd parquet. `data/equities/market/algoseek_convert.py` closes
that for both, from either the zip or a directory already extracted — which
matters for the options archive, whose 1,275,314 gzip members are slow to read
out of the zip and slower to unpack on Windows. Both conversions resume.

**The mapping was established against the real archives, not the documentation.**
Converting 2020-03 of the minute bars reproduces the delivery AlgoSeek shipped in
April on all 62 columns and all dtypes; every one of the 70,148 shipped option
rows for 2020-03-13 matches on every column. Both archives were then converted in
full — 48.9 M minute-bar rows and 1,259 days of chains.

Two of the four datasets are still unpublished. The loaders now say so and name
the notebooks that wait on them, instead of failing on a missing file with no way
for a reader to tell whether they did something wrong.

## The data root followed the working directory

Jupyter Lab starts every kernel in the notebook's own chapter directory, and
`resolve_data_root()` falls back to `cwd/data`, so on the local `uv` path every
data-loading notebook failed with a path under the chapter directory. Docker was
immune because compose sets `ML4T_DATA_PATH`, and every earlier walk ran `.py`
files from the repo root, where the fallback happens to give the right answer.

`sitecustomize.py` now sets the variable from the repo: an explicit value wins,
then `.env`, then `<repo>/data`. Reading `.env` there is what makes the two groups
of notebooks agree — those that import `utils.config`, which calls `load_dotenv`,
and those that do not, which silently ignored the reader's setting.

## The startup hook did not run on Ubuntu

Ubuntu 26.04 ships Python 3.14, so `uv` reuses the system interpreter and the
machine inherits Debian's `sitecustomize.py` from the stdlib directory, which wins
over the editable finder. Chapter helper modules were then unimportable from the
repo root, and nothing said why. `uv` now downloads its own CPython, which also
removes the missing-`Python.h` class of failure the same reuse causes.

Reproduced and verified on `ubuntu:26.04`: before, the distro hook loaded,
`limit_orderbook` did not resolve, and a chapter directory gave
`<repo>/<chapter>/data`. After, the repo's hook loads, the module resolves, and the
repo root and a chapter directory both give `<repo>/data`.

## The crypto downloader reported success on a partial download

It exited non-zero only when the frame came back entirely empty, so 18 of 19
symbols could fail and `download_all.py` still reported `[OK] Crypto`. Crypto is
the dataset most likely to come back short — roughly 700 Binance calls over
10-15 minutes against a documented rate limit.

The status now comes from the merged dataset rather than the last request, since
re-running merges into what is already on disk; `--update` inverts that and takes
the request's failures, because there every symbol is present by construction.
`--allow-partial` keeps what arrived.

## The wrong-directory error named the wrong cause

`ml4t-data` told a reader to run `AQRFactorProvider.download()` — a Python API
call, not something to type — and named a cause that often was not the cause: a
reader who had the data and was looking at the wrong path was told to download it
again. Fixed in `ml4t-data 0.1.0b19`, which this PR pins; the messages now report
the resolved path, where it came from, and the command this repo has.

## Verification

- `ubuntu:26.04` walk for the startup hook, before and after.
- Both AlgoSeek archives converted in full and diffed against the April delivery.
- 130 tests across the touched surface, including new suites for the converter
  (17), the crypto exit status (16) and the data-root anchor (18).
- `ml4t-data 0.1.0b19` messages verified against the wheel on PyPI.

## Filed rather than fixed here

The published NASDAQ-100 archive carries 123 symbols; `nasdaq100_microstructure`
was built on 114. Values agree — `volume` differs on 1 row in 19.9 M regular-hours
rows — but the universe does not, and deciding which one the case study uses is
not the infrastructure lane's call.
