### PR TITLE
Stop pointing readers at a tracker they cannot see

### DIFF
--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -166,7 +166,7 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
 # that rebuilds the whole panel with the holdout withheld and compares all 57 columns,
 # which is checked by executing the notebook rather than by reading its source. A
 # source pattern cannot see the stronger check, so listing it here only produces a
-# false red. See agent-workspace #141.
+# false red.
 PER_SYMBOL_ENDPOINT_NOTEBOOKS = [
     ("case_studies/etfs/02_labels.py", "symbol"),
     ("case_studies/crypto_perps_funding/02_labels.py", "symbol"),


### PR DESCRIPTION
Infra batch 2 was five issues about gates giving a lane agent the wrong answer. Three
of them turned out not to need a change to this repository, so what lands here is one
line.

## What is in this PR

`tests/test_holdout_boundary.py` ships to readers, and its exemption comment ended with a
pointer to an issue in the project's private tracker. A reader who follows that kind of
reference gets a 404 and learns the project keeps a register they cannot see. The nine
lines above it already carry the whole reason the notebook is exempt - #447 replaced the
shifted-endpoint purge with a seal that rebuilds the panel and compares all 57 columns,
and a source pattern cannot see the stronger check - so nothing is lost by deleting the
link.

```
$ git grep -rin 'agent-workspace' -- .
(no output)
```

One further instance exists and is not repairable: commit `60979bb0` on `main` carries
the same reference in a squash-merge message. Removing it would mean rewriting public
history, so it is recorded and left alone.

## What turned out to be already fixed

Two of the five were reported red on `main` at `6c99305d` and are green at `73507cc4`,
both fixed by #469:

- the `future-aware-fill` ratchet in `tests/test_leakage_detectors.py`, whose two stale
  Chapter 17 `bfill` rows #469 deleted along with the occurrences;
- `tests/test_pm_helpers.py`, where #469 restored the `parameters` cell on four notebooks
  and renamed five stale `overrides.yaml` keys.

Verified rather than assumed, on a clean tree at the branch point:

```
$ ML4T_DATA_PATH=~/ml4t/test-data/data ML4T_OUTPUT_DIR=/tmp/ml4t-test-output \
    uv run pytest tests/test_leakage_detectors.py tests/test_pm_helpers.py -q
tests/test_leakage_detectors.py ....                                     [  5%]
tests/test_pm_helpers.py ............................................... [ 67%]
.........................                                                [100%]
76 passed in 4.99s
```

## What landed elsewhere

The remaining two were defects in `scripts/check_notebook_prose.py`, which lives in the
private agent workspace rather than in this repository, so they are not in this diff. For
the record, since one of them changes what a lane agent sees when reviewing notebooks
here:

- the checker reported the stage-01 book-reference line (`Chapter 6, Sections 6.2-6.6`)
  as a prose decimal on every notebook that writes it in the form the standard requires;
- its figure-title check only inspected `add_message_title`, so Plotly's
  `update_layout(title=)` and Matplotlib's `set_title`/`suptitle` - between them nearly
  every figure in the book - were never looked at. It reported zero violations across the
  40 Chapter 2-3 notebooks while 53 of their titles broke the rule.

Both are fixed and pinned by tests. The widened title check reports 399 findings across
24 chapters and all nine case studies that were previously invisible; those are notebook
work for the groups that own them, filed separately, and none of them are in this PR.

## Two more gates that lie, found while this was open

Neither is in this batch's five and neither is fixed here. Both are filed, because both
are the same failure this batch is about - a check that answers, and the answer is wrong.
Together they are one path, which is why they are worth reading as a pair:

- `jupyter nbconvert --to notebook --execute --inplace` run under `nohup ... &` **exits 0
  having written nothing**. The signal is the `Writing N bytes to ...` line in the log,
  not the exit code. Two separate lanes lost a run to this today. The command is
  documented in `notebooks/TEACHING_WORKER.md`, `notebooks/CASE_STUDY_WORKER.md` and
  `notebooks/REVIEW_PROMPT.md`, in each case with the provenance stamp as the very next
  step.
- the provenance sync gate compares the stamp's `source_py_blob` against
  `git hash-object` of the paired `.py` and **never compares the stored outputs against
  the cells that produced them**. So a committed `.ipynb` whose `.py` is untouched passes
  carrying figure metadata from a superseded run. One lane caught it by hand.

So an agent whose `nbconvert` silently no-ops stamps the previous run's outputs, and the
gate that exists to catch exactly that passes it. Stale figures reach `main` having
cleared every check in the repository.

The `nbconvert` half is filed by the Chapter 6-7 lane, which reached the same defect
from the other direction - `--execute` also takes the kernel's working directory from
the notebook rather than the caller, so "always run from the repo root" cannot be
followed as written - and proposes papermill, which answers both. The provenance-gate
half is filed from here.

## Checks

```
$ uvx ruff@0.15.14 check utils/ data/ tests/          # the lint job's own command
All checks passed!
$ uvx ruff@0.15.14 format --check utils/ data/ tests/
184 files already formatted

$ uv run python .github/scripts/check_windows_safe_paths.py
OK: all tracked paths are valid on Windows.
$ uv run python .github/scripts/check_import_resolution.py
OK: every import in 776 files resolves.
$ uv run pytest tests/test_notebook_output_hygiene.py -q
7 passed in 11.42s

$ uv run pytest <the fifteen files test-unit runs> -q
262 passed, 2 skipped in 36.74s
```

