### PR TITLE
Rebuild the nasdaq minute fixture on the one-minute grid it is named for

### DIFF
--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -369,7 +369,7 @@ NASDAQ100_MINUTE_RUN_STRIDE = 6
 def _session_runs(sessions: pl.Series, run: int, stride: int) -> pl.Series:
     """Every ``stride``-th consecutive run of ``run`` sessions, in order."""
     keep: list = []
-    for start in range(0, len(sessions), run * stride):
+    for start in range(0, len(sessions) - run + 1, run * stride):
         keep.extend(sessions[start : start + run].to_list())
     return pl.Series("date", keep, dtype=sessions.dtype)
 

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -47,6 +47,7 @@ import shutil
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import timedelta
 from pathlib import Path
 
 import polars as pl
@@ -332,7 +333,84 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
     return written
 
 
+# --- nasdaq100 minute bars ----------------------------------------------------
+#
+# This fixture is reduced on symbol and on session, never on the clock. The
+# previous one kept every session and every symbol but only every fifth minute,
+# so CI ran a one-minute dataset at five-minute spacing: every declared horizon
+# was five times its nominal length, `fwd_ret_5m` resolved to a single bar, and
+# the microstructure chapter analysed bars the exchange never published. A
+# horizon is a duration, the notebooks convert it to a bar count by measuring the
+# grid, and a fixture that changes the grid changes what every consumer computes.
+#
+# So whole sessions are kept at native one-minute resolution, including
+# extended hours, which 03_market_microstructure profiles by session. The stride
+# is uniform across the two years rather than a contiguous block, because the
+# case study builds two cross-validation folds plus a holdout over the full span
+# and validate_temporal_fold_coverage fails when an artifact covers none of a
+# fold. Sessions are the safe axis to drop: features here restart their warmup at
+# every session boundary, so a wider overnight gap changes nothing they compute.
+
+NASDAQ100_MINUTE_DIR = Path("equities") / "market" / "nasdaq100" / "minute_bars"
+NASDAQ100_MINUTE_SYMBOLS = ("AAPL", "AMD", "AMZN", "FB", "GOOGL", "MSFT")
+NASDAQ100_MINUTE_SESSION_STRIDE = 6
+
+
+def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
+    """Keep every sixth session, whole and at native one-minute spacing."""
+    source_dir = source / NASDAQ100_MINUTE_DIR
+    if not source_dir.exists() or not list(source_dir.glob("year=*")):
+        raise FileNotFoundError(
+            f"NASDAQ-100 minute bars not found at {source_dir}. Build them with "
+            "data/equities/market/algoseek_convert.py."
+        )
+
+    # Not hive_partitioning: the production layout is year=/month=, and reading
+    # those as columns would add two the fixture's consumers do not expect.
+    lf = pl.scan_parquet(source_dir / "**/*.parquet", hive_partitioning=False).filter(
+        pl.col("symbol").is_in(NASDAQ100_MINUTE_SYMBOLS)
+    )
+    sessions = lf.select("date").unique().collect()["date"].sort()
+    keep = sessions.gather(range(0, len(sessions), NASDAQ100_MINUTE_SESSION_STRIDE))
+    frame = lf.filter(pl.col("date").is_in(keep.implode())).collect().sort("symbol", "timestamp")
+
+    # The reduction is only sound if the grid it leaves is the production grid.
+    # Measured the way the notebooks measure it: consecutive spacing within a
+    # symbol-session, which must be one minute and nothing else.
+    gap = pl.col("timestamp") - pl.col("timestamp").shift(1).over("symbol", "date")
+    spacing = frame.select(gap.drop_nulls().unique().alias("gap"))["gap"].to_list()
+    if spacing != [timedelta(minutes=1)]:
+        raise ValueError(f"fixture grid is not one-minute within a session: {sorted(spacing)}")
+
+    written: list[Path] = []
+    for year, part in frame.group_by(pl.col("date").dt.year(), maintain_order=True):
+        dst = output / NASDAQ100_MINUTE_DIR / f"year={year[0]}" / "data.parquet"
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        part.write_parquet(dst)
+        print(
+            f"    year={year[0]}: {len(part):,} rows ({dst.stat().st_size / 1e6:.1f} MB), "
+            f"{part['date'].n_unique()} sessions, {part['symbol'].n_unique()} symbols"
+        )
+        written.append(dst)
+    return written
+
+
 DATASETS: tuple[Dataset, ...] = (
+    Dataset(
+        name="nasdaq100_minute_bars",
+        description=(
+            f"{len(NASDAQ100_MINUTE_SYMBOLS)} symbols, every "
+            f"{NASDAQ100_MINUTE_SESSION_STRIDE}th session kept whole at native "
+            "one-minute spacing including extended hours"
+        ),
+        build=build_nasdaq100_minute_bars,
+        owns=(NASDAQ100_MINUTE_DIR,),
+        budget={
+            "symbols": list(NASDAQ100_MINUTE_SYMBOLS),
+            "session_stride": NASDAQ100_MINUTE_SESSION_STRIDE,
+            "bar_spacing": "1m (unchanged from production)",
+        },
+    ),
     Dataset(
         name="firm_characteristics",
         description=(

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -343,21 +343,39 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
 # horizon is a duration, the notebooks convert it to a bar count by measuring the
 # grid, and a fixture that changes the grid changes what every consumer computes.
 #
-# So whole sessions are kept at native one-minute resolution, including
-# extended hours, which 03_market_microstructure profiles by session. The stride
-# is uniform across the two years rather than a contiguous block, because the
-# case study builds two cross-validation folds plus a holdout over the full span
-# and validate_temporal_fold_coverage fails when an artifact covers none of a
-# fold. Sessions are the safe axis to drop: features here restart their warmup at
-# every session boundary, so a wider overnight gap changes nothing they compute.
+# So whole sessions are kept at native one-minute resolution, including extended
+# hours, which 03_market_microstructure profiles by session. They are kept in
+# consecutive runs rather than one session in six, because not every window in
+# this case study is session-bounded: 04_model_based_features fits HAR on a
+# 120-bar rolling window and signatures on 30-bar windows spanning overnight
+# gaps, and it documents the resulting contamination in its own prose. One
+# session in six would silently turn every one of those overnight gaps into a
+# six-session gap. Inside a run the gaps are the production gaps.
+#
+# The runs are spread evenly over the two years rather than taken as one block,
+# because the case study builds two cross-validation folds plus a holdout over
+# the full span and validate_temporal_fold_coverage fails when an artifact
+# covers none of a fold.
 
 NASDAQ100_MINUTE_DIR = Path("equities") / "market" / "nasdaq100" / "minute_bars"
 NASDAQ100_MINUTE_SYMBOLS = ("AAPL", "AMD", "AMZN", "FB", "GOOGL", "MSFT")
-NASDAQ100_MINUTE_SESSION_STRIDE = 6
+# Six consecutive sessions kept per six skipped runs: one week in six, which
+# keeps a fifth of the fixture's sessions preceded by their true predecessor and
+# leaves 84 of 505 sessions, holding the fixture near its previous size.
+NASDAQ100_MINUTE_RUN_SESSIONS = 6
+NASDAQ100_MINUTE_RUN_STRIDE = 6
+
+
+def _session_runs(sessions: pl.Series, run: int, stride: int) -> pl.Series:
+    """Every ``stride``-th consecutive run of ``run`` sessions, in order."""
+    keep: list = []
+    for start in range(0, len(sessions), run * stride):
+        keep.extend(sessions[start : start + run].to_list())
+    return pl.Series("date", keep, dtype=sessions.dtype)
 
 
 def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
-    """Keep every sixth session, whole and at native one-minute spacing."""
+    """Keep one week of sessions in six, whole and at native one-minute spacing."""
     source_dir = source / NASDAQ100_MINUTE_DIR
     if not source_dir.exists() or not list(source_dir.glob("year=*")):
         raise FileNotFoundError(
@@ -371,7 +389,7 @@ def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
         pl.col("symbol").is_in(NASDAQ100_MINUTE_SYMBOLS)
     )
     sessions = lf.select("date").unique().collect()["date"].sort()
-    keep = sessions.gather(range(0, len(sessions), NASDAQ100_MINUTE_SESSION_STRIDE))
+    keep = _session_runs(sessions, NASDAQ100_MINUTE_RUN_SESSIONS, NASDAQ100_MINUTE_RUN_STRIDE)
     frame = lf.filter(pl.col("date").is_in(keep.implode())).collect().sort("symbol", "timestamp")
 
     # The reduction is only sound if the grid it leaves is the production grid.
@@ -400,14 +418,16 @@ DATASETS: tuple[Dataset, ...] = (
         name="nasdaq100_minute_bars",
         description=(
             f"{len(NASDAQ100_MINUTE_SYMBOLS)} symbols, every "
-            f"{NASDAQ100_MINUTE_SESSION_STRIDE}th session kept whole at native "
-            "one-minute spacing including extended hours"
+            f"{NASDAQ100_MINUTE_RUN_STRIDE}th run of "
+            f"{NASDAQ100_MINUTE_RUN_SESSIONS} consecutive sessions kept whole at "
+            "native one-minute spacing including extended hours"
         ),
         build=build_nasdaq100_minute_bars,
         owns=(NASDAQ100_MINUTE_DIR,),
         budget={
             "symbols": list(NASDAQ100_MINUTE_SYMBOLS),
-            "session_stride": NASDAQ100_MINUTE_SESSION_STRIDE,
+            "session_run": NASDAQ100_MINUTE_RUN_SESSIONS,
+            "run_stride": NASDAQ100_MINUTE_RUN_STRIDE,
             "bar_spacing": "1m (unchanged from production)",
         },
     ),


### PR DESCRIPTION
The CI `minute_bars` fixture kept every session and every symbol but only every fifth minute, so CI ran a one-minute dataset at five-minute spacing. Every horizon declared in `case_studies/nasdaq100_microstructure/config/setup.yaml` was five times its nominal length there, `fwd_ret_5m` resolved to a single bar, and `03_market_microstructure` profiled bars the exchange never published.

That is why `cs-nasdaq100_microstructure` went red on the last merge. The rebuilt `02_labels` measures the bar grid instead of assuming it, and refused to build a label whose entry bar and exit bar are the same bar. The notebook was right; the fixture was wrong. Production data is one-minute and there is no reason to downsample it to compute a five-minute forward label.

Every dataset in the fixture set was checked against production: this is the only one whose bar spacing differs.

## What changed

`tests/create_test_data.py` gains a `nasdaq100_minute_bars` spec that reduces on **symbol and session, never on the clock**: the same six symbols, one run of six consecutive sessions in six, kept whole at native one-minute spacing including extended hours.

Runs rather than single sessions because not every window here is session-bounded - `04_model_based_features` fits HAR on a 120-bar rolling window and signatures on 30-bar windows that span overnight gaps, and documents the contamination at lines 177-184. Inside a run the gaps are the production gaps. The runs are spread over the full span because the case study builds two folds plus a holdout across it and `validate_temporal_fold_coverage` fails when an artifact covers none of a fold.

The generator asserts the surviving grid is one-minute within a symbol-session before it writes, so this class of defect now fails the generator rather than a notebook.

Regenerated fixture: `ml4t/third-edition-test-data@b74e883`, 84 sessions, 483,837 rows, 67.5 MB against 435,600 rows and 61 MB before.

## Verified

```
pytest tests/test_case_studies.py tests/test_chapter_notebooks.py \
  -k "nasdaq100_microstructure or algoseek"     20 passed, 2 skipped
```
`cs-nasdaq100_microstructure` was red on `main`; it passes locally on this fixture.