### PR TITLE
ch14-15: seed every prediction set of a label onto one joinable panel

### DIFF
--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -760,18 +760,120 @@ def _backfill_all_backtest_artifacts(cs_dir: Path) -> None:
         df.write_parquet(path)
 
 
+# The identifier a prediction artifact names its assets with. `symbol` everywhere
+# except cme_futures, which uses `product`; the older test-data vintages also carry
+# `entity` and `ticker`. Resolved from the frame rather than declared per case study
+# so a reference panel can be read whichever convention wrote it.
+ENTITY_COLUMN_CANDIDATES = ("symbol", "product", "entity", "ticker")
+
+# Distinct dates a seeded artifact carries. Matches the fabricated grid's budget:
+# a reference panel is adopted for its keys, not for its length.
+SEEDED_DATE_BUDGET = 60
+
+
+def _reference_panels(cs_dir: Path, hash_rows: list, survives, entity_col: str, _pl) -> dict:
+    """One key/target panel per (split, label), taken from an artifact left in place.
+
+    Which artifact: the panel that the most untouched artifacts in the group already
+    share, then the larger panel, then the lowest hash. The choice has to come out
+    the same on every regeneration, and seeding onto the panel the group already
+    agrees on is what makes the seeded sets joinable with the copied ones rather
+    than only with each other.
+
+    Only artifacts this function will not rewrite are eligible, so the panel is one
+    that survives seeding. The dates are subsampled to ``SEEDED_DATE_BUDGET``; they
+    are a subset of the reference's own dates, which the registry places inside the
+    split window, so the split boundary the fabricated grid enforces still holds.
+    """
+    groups: dict = {}
+    for p_hash, split, label in hash_rows:
+        if survives(p_hash):
+            groups.setdefault((split, label), []).append(p_hash)
+
+    panels = {}
+    for key, hashes in groups.items():
+        by_signature: dict = {}
+        for p_hash in sorted(hashes):
+            frame = _pl.read_parquet(
+                cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet"
+            )
+            entity = next((c for c in ENTITY_COLUMN_CANDIDATES if c in frame.columns), None)
+            if entity is None or not {"timestamp", "actual"} <= set(frame.columns):
+                continue
+            # Only ever compared for equality, so stringifying the identifiers is
+            # enough and keeps a column carrying nulls from raising in sorted().
+            signature = (
+                frame.height,
+                tuple(sorted(map(str, frame[entity].unique().to_list()))),
+                tuple(map(str, frame["timestamp"].unique().sort().to_list())),
+            )
+            by_signature.setdefault(signature, []).append((p_hash, frame, entity))
+        if not by_signature:
+            continue
+        _, entries = min(
+            by_signature.items(),
+            key=lambda item: (-len(item[1]), -item[0][0], item[1][0][0]),
+        )
+        _, frame, entity = entries[0]
+        panels[key] = _subsampled_panel(frame, entity, entity_col, _pl)
+    return panels
+
+
+def _subsampled_panel(frame, entity: str, entity_col: str, _pl):
+    """A reference artifact reduced to the canonical seeded columns and date budget.
+
+    Keeps the reference's own timestamp and identifier dtypes: a seeded artifact has
+    to meet the reference on an exact join, and a cast on either side of that key
+    would silently drop every row. The identifier is still renamed to the case
+    study's declared ``entity_col`` - cme_futures registers ``product`` while its
+    copied artifacts carry ``symbol``, and the notebooks resolve that column per
+    frame, so following the reference's name here would change what every seeded
+    cme artifact is called to fix a join that already works on values.
+    """
+    dates = frame["timestamp"].unique().sort()
+    step = max(1, dates.len() // SEEDED_DATE_BUDGET)
+    kept = dates.gather(range(0, dates.len(), step))
+    if kept[-1] != dates[-1]:
+        kept = kept.append(dates[-1:])
+    panel = frame.filter(_pl.col("timestamp").is_in(kept.implode()))
+    if "fold" in panel.columns:
+        fold = _pl.col("fold")
+    else:
+        # Mirrors the fabricated grid: folds partition dates, never rows, or every
+        # symbol lands in one fold and per-symbol conformal calibration breaks.
+        fold = (
+            _pl.col("timestamp")
+            .rank("dense")
+            .sub(1)
+            .floordiv(max(1, kept.len() // 2 + 1))
+            .mod(2)
+            .alias("fold")
+        )
+    return panel.select(
+        _pl.col(entity).alias(entity_col),
+        _pl.col("timestamp"),
+        fold.alias("fold"),
+        _pl.col("actual"),
+    )
+
+
 def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
     """Generate synthetic prediction parquets for every hash in the registry.
 
-    Uses real symbols from setup.yaml. Each hash gets dates drawn from the window
-    its own registry row declares — the CV validation window for ``validation``
-    rows, the configured holdout for ``holdout`` rows — so a seeded artifact can
-    never claim decisions outside the split it is registered under. Predictions
-    are random noise. Crypto artifacts are normalized even when copied
-    intermediates exist because its model analysis requires one common key and
-    target panel - except each label's cohort-leader prediction, which a
-    replay notebook pins by hash and checks against real historical values;
-    those keep whatever real artifact already exists on disk.
+    Every hash registered under one (split, label) is seeded on one key and target
+    panel, so any two of them join. Where the fixture already carries an artifact
+    this function leaves alone, that artifact supplies the panel - see
+    ``_reference_panels``. Otherwise the panel is built from setup.yaml's symbols
+    over the window the registry row declares - the CV validation window for
+    ``validation`` rows, the configured holdout for ``holdout`` rows - so a seeded
+    artifact can never claim decisions outside the split it is registered under.
+    Predictions are random noise either way.
+
+    Crypto artifacts are normalized even when copied intermediates exist because its
+    model analysis requires that one common panel - except each label's cohort-leader
+    prediction, which a replay notebook pins by hash and checks against real
+    historical values; those keep whatever real artifact already exists on disk, and
+    are the panel the rest of the label is seeded onto.
     """
     db_path = cs_dir / "run_log" / "registry.db"
     if not db_path.exists():
@@ -980,12 +1082,35 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
             RuntimeWarning,
             stacklevel=2,
         )
+
+    def _survives(p_hash: str) -> bool:
+        """True when the loop below leaves this artifact exactly as it is."""
+        pred_file = cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet"
+        return pred_file.is_file() and (p_hash in cohort_leader_hashes or not rewrite_existing)
+
+    # Two prediction sets of one (split, label) have to be joinable on
+    # (timestamp, entity), or a notebook that pairs them measures nothing:
+    # 14_latent_factors/09_case_study_insights ranks a latent and a supervised
+    # configuration against their common target and read "Aligned targets disagree:
+    # maximum gap None" - max() over an empty join - because the latent set was a
+    # fabricated weekday grid over SYM0..SYM4 and the supervised set was an artifact
+    # copied from production. Placeholder symbols cannot meet real ones on any key,
+    # so where the fixture already carries an artifact this function will not
+    # rewrite, the seeded sets take its keys, folds and realized targets and
+    # synthesize only the score. Groups with no such artifact keep the fabricated
+    # grid, which is still the only option there.
+    reference_panels = _reference_panels(cs_dir, hash_rows, _survives, entity_col, _pl)
+
     for p_hash, split, label in hash_rows:
         pred_dir = cs_dir / "run_log" / "predictions" / p_hash
         pred_file = pred_dir / "predictions.parquet"
-        if pred_file.exists() and (p_hash in cohort_leader_hashes or not rewrite_existing):
+        if _survives(p_hash):
             continue
-        template, n = _template_for(_window_for(split, label))
+        reference = reference_panels.get((split, label))
+        if reference is not None:
+            template, n = reference, reference.height
+        else:
+            template, n = _template_for(_window_for(split, label))
         pred_dir.mkdir(parents=True, exist_ok=True)
         score_seed = int(hashlib.sha256(p_hash.encode()).hexdigest()[:16], 16)
         scores = np.random.default_rng(score_seed).normal(0, 0.01, n).tolist()

--- a/tests/test_seed_prediction_fixtures.py
+++ b/tests/test_seed_prediction_fixtures.py
@@ -58,6 +58,56 @@ def test_crypto_prediction_hashes_share_keys_and_targets(tmp_path):
     assert frames[0].height > 1
 
 
+def test_a_seeded_hash_joins_the_copied_artifact_it_shares_a_label_with(tmp_path):
+    """14/09_case_study_insights pairs a latent and a supervised prediction set of one
+    case study on their common (timestamp, entity) keys. Seeding the latent one onto a
+    fabricated grid of placeholder symbols while the supervised one is an artifact
+    copied from production leaves that join empty, which the notebook reported as
+    "Aligned targets disagree: maximum gap None" - max() over no rows.
+    """
+    cs_dir = tmp_path / "us_equities_panel"
+    run_log = cs_dir / "run_log"
+    run_log.mkdir(parents=True)
+    with sqlite3.connect(run_log / "registry.db") as connection:
+        connection.execute(
+            "CREATE TABLE prediction_sets "
+            "(prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE training_runs (training_hash TEXT PRIMARY KEY, label TEXT)"
+        )
+        connection.execute("INSERT INTO training_runs VALUES ('train_a', 'fwd_ret_1d')")
+        connection.executemany(
+            "INSERT INTO prediction_sets VALUES (?, ?, ?)",
+            [("hash_copied", "train_a", "validation"), ("hash_seeded", "train_a", "validation")],
+        )
+
+    copied_dir = run_log / "predictions" / "hash_copied"
+    copied_dir.mkdir(parents=True)
+    days = [date(2015, 1, 5 + offset) for offset in range(5)]
+    copied = pl.DataFrame(
+        {
+            "symbol": [s for _ in days for s in ("AAPL", "MSFT")],
+            "timestamp": [d for d in days for _ in range(2)],
+            "fold": [0] * 10,
+            "prediction": [0.01 * i for i in range(10)],
+            "actual": [0.002 * i for i in range(10)],
+        }
+    )
+    copied.write_parquet(copied_dir / "predictions.parquet")
+
+    _backfill_all_prediction_parquets(cs_dir, "us_equities_panel")
+
+    seeded = pl.read_parquet(run_log / "predictions" / "hash_seeded" / "predictions.parquet")
+    joined = seeded.join(copied, on=["timestamp", "symbol"], how="inner")
+    assert joined.height == seeded.height, "the seeded set shares no keys with the copied one"
+    gap = joined.select((pl.col("actual") - pl.col("actual_right")).abs().max()).item()
+    assert gap == 0.0, "the two sets disagree on the realized target they are scored against"
+    assert not seeded["prediction"].equals(copied["prediction"]), (
+        "the seeded set copied the scores too, so it is not an independent configuration"
+    )
+
+
 def test_seeded_predictions_stay_inside_the_split_they_are_registered_under(tmp_path, monkeypatch):
     """A ``validation`` hash must not be handed decisions from the holdout period.
 


### PR DESCRIPTION
Turns the `ch14-15` CI job green. One notebook was failing; one commit fixes it.

## The run, not the triage table

`14_latent_factors/09_case_study_insights` failed at cell 28 with
`ValueError: Aligned targets disagree: maximum gap None`. That was the job's only
failure - `17 passed, 3 skipped` otherwise, the three skips declared in the notebooks
themselves.

The triage hint also named the crypto temporal fold-coverage gate
(`ml4t/agent-workspace#64`). It does not apply: `15_causal_estimation/04_dml_crypto_regime`
passed on the first run and nothing was changed for it.

## What was actually wrong

Not the notebook. `paired_daily_ic` ranks a case study's rank-1 latent and rank-1
supervised configuration against their common target and refuses a pair whose targets
disagree - correct behaviour, refusing an empty comparison. `max()` over a zero-row join
returns `None`, which is why an empty join was reported as a target disagreement.

The fixture is what was wrong. `tests/fixtures/seed_results.py` synthesizes any
prediction set the fixture carries no artifact for, on a fabricated weekday grid over
the placeholder symbols `SYM0..SYM4`. For three of the five qualifying case studies the
latent side was synthetic and the supervised side was an artifact copied from
production carrying real tickers and real dates, so the two panels shared no key at all:

| case study | latent panel | supervised panel | shared keys |
|---|---|---|---|
| `sp500_equity_option_analytics` | 325 rows / 65 dates, `SYM0..SYM4` | 3575 / 504, real | **0** |
| `us_firm_characteristics` | 310 rows / 62 dates, `SYM0..SYM4` | 960 / 120, real | **0** |
| `us_equities_panel` | 310 rows / 62 dates, `SYM0..SYM4` | 16744 / 4014, real | **0** |

`ml4t/agent-workspace#257` reads this as two configurations seeded on disjoint
*validation windows*. Measured, the windows overlap; it is the **entity** namespaces
that are disjoint.

## The change

Every prediction set registered under one `(split, label)` is now seeded onto one key
and target panel, so any two of them join. Where the fixture already carries an artifact
the seeder leaves alone, that artifact supplies the keys, folds and realized targets and
only the score is synthesized. Groups with no such artifact keep the fabricated grid,
which remains the only option there.

The reference panel is the one the most untouched artifacts in the group already share,
which keeps the choice stable across regenerations rather than dependent on which
configuration a registry happens to rank first. That matters concretely:
`us_equities_panel` carries two mutually inconsistent copied panels for `fwd_ret_1d`
whose targets differ by `2.6e-08`, two orders of magnitude past the notebook's `1e-10`
tolerance, and the rule picks the one four of its seven artifacts agree on.

Dates are subsampled to the same budget the fabricated grid uses and are a subset of the
reference's own dates, which the registry places inside the split window - so the
split-boundary guarantee the existing tests cover is unchanged.

All five qualifying case studies now join with a maximum target gap of exactly `0.0`:

| case study | shared keys | dates with >=5 obs | before |
|---|---|---|---|
| `etfs` | 15120 | 2016 | already joined |
| `sp500_equity_option_analytics` | 454 | 64 | **0** |
| `us_firm_characteristics` | 488 | 61 | **0** |
| `cme_futures` | 10317 | 1290 | already joined |
| `us_equities_panel` | 259 | 28 | **0** |

`us_equities_panel` is thin because the fixture's own copied `gbm` panel averages 4.2
symbols per date; the subsampling neither causes that nor can fix it.

The change also closes the same gap for `crypto_perps_funding`, whose cohort-leader
carriers are exempt from its rewrite and so could not previously be joined against the
sets normalized around them.

Covered by a new regression test,
`test_a_seeded_hash_joins_the_copied_artifact_it_shares_a_label_with`.

## Verification

```
17 passed, 3 skipped, 267 deselected in 196.95s
```

Green locally on the same filter CI uses (`14_latent or 15_causal`), from a fixture
directory rebuilt from `test-data/intermediates`.

Two caveats worth stating rather than burying:

- An intermediate whole-job run showed `15_causal_estimation/03_econml_dml` and
  `/04_dml_crypto_regime` failing on the 360s papermill cell timeout. Both are machine
  contention, not defects: neither notebook reads `run_log`, the registry or any
  prediction artifact; the cell papermill blamed runs in 0.1s standalone and 2.16s in a
  cell-by-cell in-process run of the whole notebook; and both pass here. The same 20
  notebooks took 1419s under load average 37-56 and 197s under load average 8.
- The failure was re-measured from scratch after each lane worktree moved off the shared
  venv, with the fix reverted to `origin/main`. It reproduced identically - same cell,
  same exception.

## Filed, not fixed here

`ml4t/agent-workspace#288` - the copied fixture artifacts for one `(split, label)`
disagree on the realized target by `2.6e-08`, past the `1e-10` tolerance this notebook
applies. The seeded sets are now aligned to the larger of the two clusters, but the two
copied clusters remain inconsistent with each other, and rewriting them is exactly what
must not happen: they are pinned by hash in
`tests/sample_registry_for_tests.py::PINNED_PREDICTION_HASHES`. No change confined to
the seeder can fix it.
