### PR TITLE
cs-etfs: let 05_evaluation reach its own IC floor (1 of 5; job not yet green)

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1344,7 +1344,12 @@ case_studies/etfs/04_model_based_features:
   timeout: 300
 case_studies/etfs/05_evaluation:
   parameters:
-    MAX_SYMBOLS: 5
+    # MAX_SYMBOLS must stay above the notebook's MIN_PERIODS (10), the symbols a
+    # date needs before its IC enters the series. At 5 no date could ever qualify,
+    # so every date was dropped, eval_summary came out empty, and the first figure
+    # failed on make_subplots(rows=0). The fixture carries 56 symbols; 20 leaves
+    # margin for dates where some are null. Measured at 112s against the 300s cap.
+    MAX_SYMBOLS: 20
   timeout: 300
 case_studies/etfs/06_linear:
   parameters:


### PR DESCRIPTION
# cs-etfs

**Status: not green.** 1 of 5 real failures fixed. Baseline measured on a quiet box
(load 3-12), 23 notebooks selected: **4 failed, 15 passed, 4 skipped**, 11m02s.

## Per notebook

| Notebook | Failing cell | Cause | Fix | Re-run |
|---|---|---|---|---|
| `05_evaluation` | 26 | `MAX_SYMBOLS: 5` sat below the notebook's `MIN_PERIODS = 10`, so no date could carry enough symbols, `eval_summary` came out empty, and `make_subplots(rows=0)` raised | Raised the cap to 20 in `tests/overrides.yaml`. Guard untouched | **PASSES**, 54s isolated; 20 symbols, 1,995 dates, correctness gate 64 PASS / 6 FAIL |
| `08_tabular_dl` | 12 | `RuntimeError: Training completed but registered checkpoints are incomplete for tabm_s` | not started | red |
| `11a_pca` | 8 | `ValueError: temporal artifact not aligned with canonical CV splits: fold 0 validation 231/247`. Writer `etfs/04:118` derives folds from `prices`; reader `utils/modeling.py:596` derives from `labels`. They differ by exactly the 21-session label horizon | diagnosed, not applied - moves production numbers | red |
| `11b_ipca` | - | `Timeout waiting for execute reply (300s)`, reproduced at load 3.8, so genuine rather than contention | not started | red |
| `18_strategy_analysis` | 36 | `RuntimeError: No holdout backtest matches val rank-1 (57f770b1195a) strategy spec` | not started | red |

## Withdrawn - measurement artifacts, not defects

| Notebook | Reported as | Actually |
|---|---|---|
| `03_financial_features` | `hurst_100` point-in-time leak (#203/#260) | Fails at load 60-76, passes at load 14. Five reproductions - synthetic, `.over("symbol")`, real 56-ETF panel, full `per_entity_features`, and the exact seal assertion - all give max diff **0.0** |
| `07_gbm` | LightGBM CUDA failure | Local only. The guard probes `torch.cuda.is_available()` and hands the answer to LightGBM. CI has no GPU, takes the fallback, passes |
| `13_model_analysis` | join key `datetime[us]` vs `datetime[ms]` | Passed once the worktree got its own venv. Shared-venv artifact |
| `09_dl_lstm`, `10_dl_tsmixer`, `12_causal_dml` | failures | All three `Timeout waiting for execute reply` under 3x CPU contention; pass at low load |

## Environment findings that cost measurement time

1. **Shared `.venv`** (until 20:39 UTC) resolved `utils/` from another lane's branch and carried different `ml4t-*` pins. Any pre-20:39 measurement is void.
2. **`/tmp/ml4t-pm-<notebook>.log` is not namespaced by case study** (`tests/pm_helpers.py:961`). Four case studies have an `05_evaluation`; concurrent lanes overwrite each other's diagnostics. This misled me once.
3. **CPU contention at load 60-76 on 24 cores** makes timeout failures unmeasurable, and - per `03` above - can make a *named exception* appear too. Exception type is not proof of a real defect.
4. **#290 is live**: `~/ml4t/test-data` has uncommitted modifications. HEAD's etfs fixture is 24 symbols; the working copy differs. Seed from HEAD via `git archive`.
5. **The squash merge of #478 breaks `git rebase origin/main`** for branches cut from `group/stage-01-05-assembly`: it replays all 33 sweep commits. Cherry-pick your own commits onto a fresh branch instead.
