### PR TITLE
Record which version of a notebook was verified, and refuse to change it silently

### DIFF
--- a/.github/scripts/check_verified_notebooks.py
+++ b/.github/scripts/check_verified_notebooks.py
@@ -1,0 +1,107 @@
+"""Gate: a notebook that has been verified may not be changed by accident.
+
+Verification is an assertion about one exact version of a file. Four times in the seven days to
+2026-08-06, a batch "bring everything to the standard" commit landed on top of notebooks that had
+already been verified - PR #478 did it to 34 of 45 in a single commit - and every one of those
+verdicts silently stopped describing anything that exists. Nothing in the tooling noticed, because
+nothing recorded which version had been verified.
+
+``.verified-notebooks.tsv`` records it: one row per verified notebook, with the git blob hash of the
+``.py`` at the moment its verifier signed off. This gate fails a commit that changes a listed ``.py``
+while leaving its row intact. Discarding a verification stays possible and becomes explicit - drop or
+update the row in the same commit, which puts it in the diff where a reviewer sees it.
+
+Usage::
+
+    uv run python .github/scripts/check_verified_notebooks.py            # staged changes
+    uv run python .github/scripts/check_verified_notebooks.py --audit    # worktree vs the manifest
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / ".verified-notebooks.tsv"
+HEADER = ("path", "py_blob", "verified_at", "verifier")
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(["git", *args], cwd=REPO_ROOT, capture_output=True, text=True).stdout
+
+
+def _parse(text: str) -> dict[str, str]:
+    """path -> py_blob, from a manifest's text. Blank lines and the header are skipped."""
+    rows: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if parts[0] == HEADER[0]:
+            continue
+        if len(parts) < 2:
+            raise SystemExit(f"{MANIFEST.name}: malformed row: {line!r}")
+        rows[parts[0]] = parts[1]
+    return rows
+
+
+def _staged_paths() -> list[str]:
+    out = _git("diff", "--cached", "--name-only", "--diff-filter=ACMRT")
+    return [p for p in out.splitlines() if p.endswith(".py")]
+
+
+def _staged_blob(path: str) -> str | None:
+    """The blob hash git would commit for ``path``, or None if it is not staged."""
+    out = _git("ls-files", "--stage", "--", path).split()
+    return out[1] if len(out) >= 2 else None
+
+
+def main(argv: list[str]) -> int:
+    if not MANIFEST.exists():
+        return 0
+
+    audit = "--audit" in argv
+    if audit:
+        recorded = _parse(MANIFEST.read_text())
+        changed = [
+            (p, b)
+            for p, b in recorded.items()
+            if (REPO_ROOT / p).exists() and _git("hash-object", str(REPO_ROOT / p)).strip() != b
+        ]
+        for path, blob in changed:
+            print(f"CHANGED  {path}  verified at {blob[:8]}, worktree differs")
+        print(f"--- {len(changed)} of {len(recorded)} verified notebooks have moved ---")
+        return 1 if changed else 0
+
+    # The manifest as this commit will leave it: a row dropped or updated here is consent.
+    after = _parse(_git("show", ":" + MANIFEST.name) or MANIFEST.read_text())
+
+    violations = []
+    for path in _staged_paths():
+        recorded = after.get(path)
+        if recorded is None:
+            continue
+        staged = _staged_blob(path)
+        if staged is not None and staged != recorded:
+            violations.append((path, recorded, staged))
+
+    if not violations:
+        return 0
+
+    print("a verified notebook is being changed while its verification still stands:")
+    for path, recorded, staged in violations:
+        print(f"  {path}\n      verified at {recorded[:8]}, this commit writes {staged[:8]}")
+    print(
+        f"\nA verdict describes one exact version of the file. Changing it here voids the verdict\n"
+        f"without saying so, which is how four batch rewrites erased ~30 verifications in the week\n"
+        f"to 2026-08-06.\n"
+        f"\nIf the change is intended, drop or update the row in {MANIFEST.name} in this same commit\n"
+        f"and re-run the verifier afterwards. If it is not, unstage the notebook."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/check_verified_notebooks.py
+++ b/.github/scripts/check_verified_notebooks.py
@@ -47,15 +47,26 @@ def _parse(text: str) -> dict[str, str]:
     return rows
 
 
-def _staged_paths() -> list[str]:
-    out = _git("diff", "--cached", "--name-only", "--diff-filter=ACMRT")
-    return [p for p in out.splitlines() if p.endswith(".py")]
+def _index_blobs(paths: list[str]) -> dict[str, str]:
+    """path -> the blob git would commit for it. Absent means the commit has no such file.
 
-
-def _staged_blob(path: str) -> str | None:
-    """The blob hash git would commit for ``path``, or None if it is not staged."""
-    out = _git("ls-files", "--stage", "--", path).split()
-    return out[1] if len(out) >= 2 else None
+    Asking about the listed paths rather than about the staged ones is what makes a
+    deletion and a rename visible. Both leave the recorded path with no blob in the index,
+    and a rename additionally writes the same content somewhere the manifest cannot vouch
+    for, so neither can be distinguished from "still there" by looking at what changed.
+    """
+    if not paths:
+        return {}
+    out = _git("ls-files", "--stage", "-z", "--", *paths)
+    blobs: dict[str, str] = {}
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        meta, _, path = entry.partition("\t")
+        fields = meta.split()
+        if len(fields) >= 2 and path:
+            blobs[path] = fields[1]
+    return blobs
 
 
 def main(argv: list[str]) -> int:
@@ -65,26 +76,26 @@ def main(argv: list[str]) -> int:
     audit = "--audit" in argv
     if audit:
         recorded = _parse(MANIFEST.read_text())
-        changed = [
-            (p, b)
-            for p, b in recorded.items()
-            if (REPO_ROOT / p).exists() and _git("hash-object", str(REPO_ROOT / p)).strip() != b
-        ]
-        for path, blob in changed:
-            print(f"CHANGED  {path}  verified at {blob[:8]}, worktree differs")
-        print(f"--- {len(changed)} of {len(recorded)} verified notebooks have moved ---")
-        return 1 if changed else 0
+        moved = []
+        for path, blob in recorded.items():
+            target = REPO_ROOT / path
+            if not target.exists():
+                moved.append((path, blob, "GONE", "no such file in the worktree"))
+            elif _git("hash-object", str(target)).strip() != blob:
+                moved.append((path, blob, "CHANGED", "worktree differs"))
+        for path, blob, kind, why in moved:
+            print(f"{kind:8} {path}  verified at {blob[:8]}, {why}")
+        print(f"--- {len(moved)} of {len(recorded)} verified notebooks have moved ---")
+        return 1 if moved else 0
 
     # The manifest as this commit will leave it: a row dropped or updated here is consent.
     after = _parse(_git("show", ":" + MANIFEST.name) or MANIFEST.read_text())
 
     violations = []
-    for path in _staged_paths():
-        recorded = after.get(path)
-        if recorded is None:
-            continue
-        staged = _staged_blob(path)
-        if staged is not None and staged != recorded:
+    blobs = _index_blobs(list(after))
+    for path, recorded in after.items():
+        staged = blobs.get(path)
+        if staged != recorded:
             violations.append((path, recorded, staged))
 
     if not violations:
@@ -92,13 +103,16 @@ def main(argv: list[str]) -> int:
 
     print("a verified notebook is being changed while its verification still stands:")
     for path, recorded, staged in violations:
-        print(f"  {path}\n      verified at {recorded[:8]}, this commit writes {staged[:8]}")
+        wrote = f"this commit writes {staged[:8]}" if staged else "this commit removes it"
+        print(f"  {path}\n      verified at {recorded[:8]}, {wrote}")
     print(
         f"\nA verdict describes one exact version of the file. Changing it here voids the verdict\n"
         f"without saying so, which is how four batch rewrites erased ~30 verifications in the week\n"
         f"to 2026-08-06.\n"
         f"\nIf the change is intended, drop or update the row in {MANIFEST.name} in this same commit\n"
-        f"and re-run the verifier afterwards. If it is not, unstage the notebook."
+        f"and re-run the verifier afterwards. If it is not, unstage the notebook.\n"
+        f"A renamed notebook is a removal here and an unverified file at the new path: move the\n"
+        f"row too, and it is the verifier who decides whether the verdict survives the move."
     )
     return 1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,16 @@ repos:
         entry: python3 .github/scripts/notebook_provenance.py check
         pass_filenames: false
         always_run: true
+
+      # Verification gate: a notebook whose verifier signed off on one exact
+      # version may not be silently changed. `.verified-notebooks.tsv` records
+      # the .py blob at sign-off; this fails a commit that changes a listed .py
+      # while leaving its row intact. Four batch rewrites in the week to
+      # 2026-08-06 erased ~30 verifications this way, PR #478 doing 34 notebooks
+      # in one commit. See .github/scripts/check_verified_notebooks.py.
+      - id: verified-notebooks
+        name: verified notebook not silently changed
+        language: system
+        entry: python3 .github/scripts/check_verified_notebooks.py
+        pass_filenames: false
+        always_run: true

--- a/.verified-notebooks.tsv
+++ b/.verified-notebooks.tsv
@@ -1,0 +1,1 @@
+path	py_blob	verified_at	verifier

--- a/tests/test_verified_notebooks_guard.py
+++ b/tests/test_verified_notebooks_guard.py
@@ -103,6 +103,54 @@ def test_updating_the_row_to_the_new_blob_is_allowed(repo: Path) -> None:
     assert _run_gate(repo).returncode == 0
 
 
+def test_deleting_a_verified_notebook_is_rejected(repo: Path) -> None:
+    """Removing the file voids the verdict as surely as rewriting it."""
+    _verify(repo)
+    _git(repo, "rm", "-q", NOTEBOOK)
+
+    result = _run_gate(repo)
+
+    assert result.returncode == 1, result.stdout
+    assert NOTEBOOK in result.stdout
+    assert "removes it" in result.stdout
+
+
+def test_renaming_a_verified_notebook_is_rejected(repo: Path) -> None:
+    """A rename leaves the row pointing at nothing and the content somewhere unvouched for."""
+    _verify(repo)
+    _git(repo, "mv", NOTEBOOK, "case_studies/demo/01_renamed.py")
+
+    result = _run_gate(repo)
+
+    assert result.returncode == 1, result.stdout
+    assert NOTEBOOK in result.stdout
+
+
+def test_moving_the_row_with_the_rename_is_allowed(repo: Path) -> None:
+    """Consent for a rename is moving the row, which puts the decision in the diff."""
+    _verify(repo)
+    renamed = "case_studies/demo/01_renamed.py"
+    _git(repo, "mv", NOTEBOOK, renamed)
+    blob = _git(repo, "ls-files", "--stage", "--", renamed).stdout.split()[1]
+    (repo / MANIFEST_NAME).write_text(HEADER + f"{renamed}\t{blob}\t2026-08-06\ttester\n")
+    _git(repo, "add", MANIFEST_NAME)
+
+    assert _run_gate(repo).returncode == 0
+
+
+def test_audit_reports_a_verified_notebook_that_is_gone(repo: Path) -> None:
+    """--audit must not read a missing file as an unchanged one."""
+    _verify(repo)
+    _git(repo, "commit", "-qm", "record the verification")
+    (repo / NOTEBOOK).unlink()
+
+    result = _run_gate(repo, "--audit")
+
+    assert result.returncode == 1, result.stdout
+    assert "GONE" in result.stdout
+    assert NOTEBOOK in result.stdout
+
+
 def test_an_unlisted_notebook_is_untouched(repo: Path) -> None:
     """Nothing is verified yet, so the gate must not stand in the way of ordinary work."""
     (repo / NOTEBOOK).write_text("# %%\nprint('nobody has verified this')\n")

--- a/tests/test_verified_notebooks_guard.py
+++ b/tests/test_verified_notebooks_guard.py
@@ -1,0 +1,136 @@
+"""The gate that stops a batch rewrite from silently voiding a verification.
+
+``.github/scripts/check_verified_notebooks.py`` fails a commit that changes a ``.py``
+listed in ``.verified-notebooks.tsv`` unless the same commit drops or updates its row.
+Four batch rewrites in the week to 2026-08-06 erased roughly thirty verifications
+without anything noticing, PR #478 rewriting 34 notebooks in one commit.
+
+The gate is only worth having if it actually fires, so each test below builds a throwaway
+git repository, stages a real change, and runs the script the way pre-commit runs it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "check_verified_notebooks.py"
+MANIFEST_NAME = ".verified-notebooks.tsv"
+HEADER = "path\tpy_blob\tverified_at\tverifier\n"
+NOTEBOOK = "case_studies/demo/01_feasibility_analysis.py"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _run_gate(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the gate as pre-commit does: from the repo root, no filenames passed."""
+    return subprocess.run(
+        [sys.executable, str(repo / ".github" / "scripts" / SCRIPT.name), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A git repo holding one committed notebook and an empty manifest."""
+    repo = tmp_path / "repo"
+    (repo / ".github" / "scripts").mkdir(parents=True)
+    (repo / "case_studies" / "demo").mkdir(parents=True)
+    shutil.copy(SCRIPT, repo / ".github" / "scripts" / SCRIPT.name)
+
+    (repo / NOTEBOOK).write_text("# %%\nprint('verified')\n")
+    (repo / MANIFEST_NAME).write_text(HEADER)
+
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "initial")
+    return repo
+
+
+def _verify(repo: Path, path: str = NOTEBOOK) -> str:
+    """Record ``path`` as verified at its committed blob. Returns the blob hash."""
+    blob = _git(repo, "rev-parse", f"HEAD:{path}").stdout.strip()
+    manifest = repo / MANIFEST_NAME
+    manifest.write_text(manifest.read_text() + f"{path}\t{blob}\t2026-08-06\ttester\n")
+    _git(repo, "add", MANIFEST_NAME)
+    return blob
+
+
+def test_changing_a_verified_notebook_is_rejected(repo: Path) -> None:
+    """The case PR #478 was: the .py moves, the row claiming it was verified does not."""
+    _verify(repo)
+    (repo / NOTEBOOK).write_text("# %%\nprint('rewritten by a batch pass')\n")
+    _git(repo, "add", NOTEBOOK)
+
+    result = _run_gate(repo)
+
+    assert result.returncode == 1, result.stdout
+    assert NOTEBOOK in result.stdout
+    assert "verified" in result.stdout.lower()
+
+
+def test_dropping_the_row_in_the_same_commit_is_allowed(repo: Path) -> None:
+    """Discarding a verification stays possible; it has to appear in the diff."""
+    _verify(repo)
+    (repo / NOTEBOOK).write_text("# %%\nprint('rewritten, and the row goes with it')\n")
+    manifest = repo / MANIFEST_NAME
+    manifest.write_text(HEADER)
+    _git(repo, "add", NOTEBOOK, MANIFEST_NAME)
+
+    assert _run_gate(repo).returncode == 0
+
+
+def test_updating_the_row_to_the_new_blob_is_allowed(repo: Path) -> None:
+    """A re-verification records the new blob, which is consent for that exact version."""
+    _verify(repo)
+    (repo / NOTEBOOK).write_text("# %%\nprint('re-verified at this version')\n")
+    _git(repo, "add", NOTEBOOK)
+    new_blob = _git(repo, "ls-files", "--stage", "--", NOTEBOOK).stdout.split()[1]
+    (repo / MANIFEST_NAME).write_text(HEADER + f"{NOTEBOOK}\t{new_blob}\t2026-08-07\ttester\n")
+    _git(repo, "add", MANIFEST_NAME)
+
+    assert _run_gate(repo).returncode == 0
+
+
+def test_an_unlisted_notebook_is_untouched(repo: Path) -> None:
+    """Nothing is verified yet, so the gate must not stand in the way of ordinary work."""
+    (repo / NOTEBOOK).write_text("# %%\nprint('nobody has verified this')\n")
+    _git(repo, "add", NOTEBOOK)
+
+    assert _run_gate(repo).returncode == 0
+
+
+def test_audit_reports_a_verified_notebook_the_worktree_has_moved(repo: Path) -> None:
+    """--audit answers "does the manifest still describe the tree", staged or not."""
+    _verify(repo)
+    _git(repo, "commit", "-qm", "record the verification")
+    (repo / NOTEBOOK).write_text("# %%\nprint('edited, never staged')\n")
+
+    result = _run_gate(repo, "--audit")
+
+    assert result.returncode == 1, result.stdout
+    assert NOTEBOOK in result.stdout
+
+    (repo / NOTEBOOK).write_text("# %%\nprint('verified')\n")
+    assert _run_gate(repo, "--audit").returncode == 0
+
+
+def test_the_installed_hook_names_the_installed_script() -> None:
+    """The gate is only in force if .pre-commit-config.yaml actually calls it."""
+    config = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+
+    assert "id: verified-notebooks" in config
+    assert ".github/scripts/check_verified_notebooks.py" in config
+    assert SCRIPT.exists()
+    assert (REPO_ROOT / MANIFEST_NAME).exists()


### PR DESCRIPTION
A verification is an assertion about one exact version of a file, and nothing in the repository recorded which version. Four times in the seven days to 2026-08-06 a batch "bring everything to the standard" commit landed on top of notebooks that had already been verified - #478 did it to 34 of 45 in a single commit - and every one of those verdicts stopped describing anything that exists. No tool noticed, because no tool knew.

`.verified-notebooks.tsv` records it: one row per verified notebook, carrying the git blob hash of its `.py` at sign-off. A pre-commit hook fails a commit that changes, deletes or renames a listed `.py` while leaving its row intact.

Discarding a verification stays possible and stops being silent. Drop the row, or update it to the new blob, in the same commit; the decision is then in the diff where a reviewer sees it, instead of being inferred later from a verdict that no longer matches the code.

The manifest ships empty, so the gate is inert until the first sign-off writes a row.

`check_verified_notebooks.py --audit` answers the other question - does the manifest still describe the working tree - for changes that were never staged.

## Verification

`tests/test_verified_notebooks_guard.py` builds a throwaway git repository per test and runs the script the way pre-commit runs it: the rewrite, the deletion, the rename, all three consent paths, the unlisted notebook, `--audit` against a changed file and against a missing one, and that the config actually calls the script.

Each rejection test is proven to fail without the code that makes it pass. Neutering `main()` to `return 0` fails the two original rejection tests and leaves the permissive ones green; the second commit's three tests fail against the first commit's script.

Also verified end to end against this repository before the first commit: with `case_studies/etfs/05_evaluation.py` listed and modified, `git commit` was rejected and HEAD did not move; dropping the row in the same staged change let it through.

The deletion and rename gap in the first commit was found by the roborev push gate and fixed in the second.