### PR TITLE
Default the data root to the main working tree in a linked worktree, and gate the contract in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -524,6 +524,42 @@ jobs:
             tests/test_holdout_boundary.py \
             -v --tb=short
 
+      # Where every entry point in the repo looks for data. Forty tests covered
+      # the rule and no job ran any of them, so the contract was unguarded on
+      # every PR — found when adding the linked-worktree fallback turned three
+      # of them red and CI stayed green, because the failure only appears in a
+      # worktree and the file did not run anywhere anyway.
+      #
+      # The precondition is the load-bearing half. `anchor_ran` skips rather
+      # than fails when the startup hook did not load, which is right locally
+      # (Debian's own sitecustomize.py shadows this one on a system-interpreter
+      # venv) and wrong here: it would turn the whole step green while testing
+      # nothing. Asserting the same condition the fixture skips on makes that
+      # state red instead. It has to be the hook FIRING, not the module being
+      # importable — cwd is on sys.path, so `import sitecustomize` succeeds in
+      # the workspace whether or not anything ran it at startup.
+      - name: Run data-root anchoring contract
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
+        run: |
+          .venv/bin/python - <<'PY'
+          import os, subprocess, sys
+          env = {k: v for k, v in os.environ.items() if k != "ML4T_DATA_PATH"}
+          out = subprocess.run(
+              [sys.executable, "-c", "import os; print(os.environ.get('ML4T_DATA_PATH', ''))"],
+              env=env, cwd=os.environ["ML4T_PATH"], capture_output=True, text=True,
+          )
+          if not out.stdout.strip():
+              sys.exit("sitecustomize did not run at startup; every test below would skip")
+          print("startup hook ran ->", out.stdout.strip())
+          PY
+          .venv/bin/python -m pytest \
+            tests/test_data_root_anchor.py \
+            tests/test_sitecustomize_data_root.py \
+            -v --tb=short -rs
+
   # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)
   #

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -47,6 +47,7 @@ here is one nothing downstream can correct.
 """
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -82,6 +83,46 @@ def _data_root_from_dotenv(repo_root: Path) -> str | None:
     return dotenv_values(env_file).get("ML4T_DATA_PATH") or None
 
 
+def _has_datasets(data_root: Path) -> bool:
+    """True where a data directory holds datasets and not just the tracked skeleton.
+
+    ``data/`` is committed for ``download.py``, each dataset's ``config.yaml`` and the dataset
+    cards, while every parquet under it is gitignored. So the directory existing proves nothing,
+    and neither does a subdirectory: ``data/etfs/market/`` is tracked and arrives empty. Datasets
+    land at ``data/<domain>/*.parquet`` or ``data/<domain>/<source>/*.parquet``; both globs stop
+    at the first match and neither descends into the full tree.
+    """
+    return any(next(data_root.glob(p), None) for p in ("*/*.parquet", "*/*/*.parquet"))
+
+
+def _main_worktree(repo_root: Path) -> Path | None:
+    """The repository's main working tree, or ``None`` if ``repo_root`` is not a linked worktree.
+
+    ``--git-dir`` and ``--git-common-dir`` are equal in the main working tree and differ in a
+    linked one, and the common dir's parent IS the main working tree. Both are plumbing commands
+    with a stable contract.
+
+    Every failure returns ``None`` rather than propagating, and that is load-bearing: this runs
+    before ``ML4T_DATA_PATH`` is assigned, so an escaping error would reach the module-level
+    guard and leave the variable unset entirely - worse than the default it was refining. No
+    git, no git on PATH, a tarball install and a hung invocation all fall back to the default.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # noqa: BLE001 - startup hook: a missing or hung git is not an error here
+        return None
+    parts = out.stdout.split()
+    if out.returncode != 0 or len(parts) != 2 or parts[0] == parts[1]:
+        return None
+    return Path(parts[1]).parent
+
+
 def _anchor_data_root(repo_root: Path) -> None:
     if os.environ.get("ML4T_DATA_PATH"):
         return
@@ -91,6 +132,20 @@ def _anchor_data_root(repo_root: Path) -> None:
     data_root = Path(configured).expanduser() if configured else repo_root / "data"
     if not data_root.is_absolute():
         data_root = repo_root / data_root
+    if configured is None and not _has_datasets(data_root):
+        # A reader has one clone, downloads into <repo>/data, and never reaches this branch.
+        # A linked `git worktree` does: it is a second working directory of one repository, so
+        # it gets the tracked skeleton of data/ and none of the gitignored datasets, which live
+        # only in the main working tree. Defaulting to the worktree's own data/ therefore names
+        # a directory that exists and holds nothing, and the reader is told to download tens of
+        # gigabytes already on the disk.
+        #
+        # Symlinking the datasets into the worktree is the other obvious fix and is worse: a
+        # directory symlink under data/ is not gitignored, so a `git add -A` commits an absolute
+        # machine-specific path into the repository.
+        main_tree = _main_worktree(repo_root)
+        if main_tree is not None and _has_datasets(main_tree / "data"):
+            data_root = main_tree / "data"
     os.environ["ML4T_DATA_PATH"] = str(data_root)
     if configured is None:
         # This value is the repo-anchored default, not something anyone asked for.

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -117,7 +117,10 @@ def _main_worktree(repo_root: Path) -> Path | None:
         )
     except Exception:  # noqa: BLE001 - startup hook: a missing or hung git is not an error here
         return None
-    parts = out.stdout.split()
+    # One path per line, and splitting on whitespace instead would break on any checkout whose
+    # path contains a space: the two paths would arrive as three or more parts, fail the length
+    # test, and silently disable the fallback for exactly the reader who cannot tell why.
+    parts = [line.strip() for line in out.stdout.splitlines() if line.strip()]
     if out.returncode != 0 or len(parts) != 2 or parts[0] == parts[1]:
         return None
     return Path(parts[1]).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,17 @@ def ci_env_setup():
         env_file.unlink()
 
 
+def _holds_datasets(path: Path) -> bool:
+    """True where a data directory holds parquet at either documented depth.
+
+    The same test ``sitecustomize._has_datasets`` applies, and for the same
+    reason: ``data/`` is tracked for its ``config.yaml`` and ``download.py``
+    while every parquet under it is gitignored, so existing and being non-empty
+    say nothing about whether there is data to read.
+    """
+    return any(next(path.glob(p), None) for p in ("*/*.parquet", "*/*/*.parquet"))
+
+
 def _resolve_data_path() -> Path | None:
     """Find ML4T_DATA_PATH from env var, .env file, or default location.
 
@@ -91,7 +102,12 @@ def _resolve_data_path() -> Path | None:
         if p.exists() and any(p.iterdir()):
             return p
 
-    # 2. Read from .env file (works in xdist workers)
+    # 2. Read from .env file (works in xdist workers).
+    #    Non-empty is not the test here either, for the same reason it is not in
+    #    step 1: a .env naming the repo's own data/ passes it on the strength of
+    #    the tracked skeleton, which reintroduces exactly what the marker above
+    #    and the glob in step 4 both exist to block. CI writes such a .env by
+    #    hand, so this branch is the one that fires there.
     env_file = REPO_ROOT / ".env"
     if env_file.exists():
         for line in env_file.read_text().splitlines():
@@ -100,7 +116,7 @@ def _resolve_data_path() -> Path | None:
                 val = line.split("=", 1)[1].strip().strip('"').strip("'")
                 if val and not val.startswith("#"):
                     p = Path(val).expanduser().resolve()
-                    if p.exists() and any(p.iterdir()):
+                    if _holds_datasets(p):
                         return p
 
     # 3. Well-known test-data repo location

--- a/tests/test_data_root_anchor.py
+++ b/tests/test_data_root_anchor.py
@@ -85,6 +85,24 @@ def anchor_ran() -> None:
         pytest.skip("sitecustomize.py did not run in this environment")
 
 
+def _expected_default_root() -> Path:
+    """Where the hook lands with nothing configured.
+
+    ``<repo>/data``, except in a linked ``git worktree``, which gets the tracked
+    skeleton of ``data/`` and none of the gitignored datasets under it: those live
+    only in the main working tree, so the hook borrows that one rather than naming
+    a directory that exists and holds nothing.
+    """
+    sitecustomize = _load_sitecustomize()
+    default = REPO_ROOT / "data"
+    if sitecustomize._has_datasets(default):
+        return default
+    main_tree = sitecustomize._main_worktree(REPO_ROOT)
+    if main_tree is not None and sitecustomize._has_datasets(main_tree / "data"):
+        return main_tree / "data"
+    return default
+
+
 def _expected_root() -> Path:
     """What the hook should resolve to on *this* machine.
 
@@ -92,10 +110,15 @@ def _expected_root() -> Path:
     sets ML4T_DATA_PATH in ``.env``, and honoring that is the whole point of
     reading the file. Asserting the repo path regardless would fail on every
     correctly-configured machine, including this one.
+
+    *Which* of the possible roots the rule picks is pinned in
+    ``tests/test_sitecustomize_data_root.py``, against a repository and a linked
+    worktree built for the test. What the tests here add is the other half: a
+    fresh interpreter started in any directory arrives at that same answer.
     """
     configured = _load_sitecustomize()._data_root_from_dotenv(REPO_ROOT)
     if not configured:
-        return REPO_ROOT / "data"
+        return _expected_default_root()
     path = Path(configured).expanduser()
     return path if path.is_absolute() else REPO_ROOT / path
 
@@ -210,7 +233,7 @@ def test_the_default_is_marked_as_a_default(monkeypatch) -> None:
     monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
     monkeypatch.delenv("ML4T_DATA_PATH_IS_DEFAULT", raising=False)
     sitecustomize._anchor_data_root(REPO_ROOT)
-    assert Path(os.environ["ML4T_DATA_PATH"]) == REPO_ROOT / "data"
+    assert Path(os.environ["ML4T_DATA_PATH"]) == _expected_default_root()
     assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
 
 

--- a/tests/test_sitecustomize_data_root.py
+++ b/tests/test_sitecustomize_data_root.py
@@ -89,6 +89,107 @@ def test_a_directory_outside_any_repository_is_not_a_worktree(tmp_path):
     assert sc._main_worktree(tmp_path) is None
 
 
+# --- the same rules against a repository built for the test -----------------------------------
+#
+# The three tests above read whatever checkout the suite happens to run in, so the two that
+# matter skip in a plain clone - which is every CI run and every reader. The branch this change
+# exists for would then never be taken under test. Building a real repository with a real linked
+# worktree costs a few git invocations, runs everywhere, and keeps `--git-common-dir` itself
+# under test rather than assuming its contract and mocking around it.
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _repo_with_worktree(root: Path) -> tuple[Path, Path]:
+    """Build ``root/main`` as a repository and ``root/linked`` as a linked worktree of it."""
+    main = root / "main"
+    main.mkdir(parents=True)
+    _git(main, "init", "-q", "-b", "main")
+    _git(main, "config", "user.email", "test@example.com")
+    _git(main, "config", "user.name", "Test")
+    (main / "README.md").write_text("x\n")
+    _git(main, "add", "README.md")
+    _git(main, "commit", "-qm", "init")
+    linked = root / "linked"
+    _git(main, "worktree", "add", "-q", str(linked), "-b", "side")
+    return main, linked
+
+
+@pytest.fixture
+def worktree_pair(tmp_path):
+    return _repo_with_worktree(tmp_path)
+
+
+def _dataset(data_root: Path) -> None:
+    (data_root / "etfs").mkdir(parents=True, exist_ok=True)
+    (data_root / "etfs" / "bars.parquet").write_bytes(b"")
+
+
+def _skeleton(data_root: Path) -> None:
+    """What a linked worktree actually gets: the tracked directories, no parquet."""
+    (data_root / "etfs" / "market").mkdir(parents=True)
+    (data_root / "etfs" / "market" / "config.yaml").write_text("name: etfs\n")
+
+
+def test_a_built_linked_worktree_resolves_to_its_main_tree(worktree_pair):
+    main, linked = worktree_pair
+    assert sc._main_worktree(linked) == main.resolve()
+    assert sc._main_worktree(main) is None
+
+
+def test_a_built_linked_worktree_borrows_the_main_trees_datasets(clean_env, worktree_pair):
+    """The defect, end to end: skeleton in the worktree, datasets in the main tree."""
+    main, linked = worktree_pair
+    _dataset(main / "data")
+    _skeleton(linked / "data")
+    sc._anchor_data_root(linked)
+    assert os.environ["ML4T_DATA_PATH"] == str(main.resolve() / "data")
+    assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
+
+
+def test_a_worktree_with_its_own_datasets_keeps_them(clean_env, worktree_pair):
+    """The fallback refines an empty default; it never moves a data root that works."""
+    main, linked = worktree_pair
+    _dataset(main / "data")
+    _dataset(linked / "data")
+    sc._anchor_data_root(linked)
+    assert os.environ["ML4T_DATA_PATH"] == str(linked / "data")
+
+
+def test_an_empty_main_tree_is_not_borrowed_from(clean_env, worktree_pair):
+    """Borrowing an equally empty directory would only move where the error names."""
+    main, linked = worktree_pair
+    _skeleton(main / "data")
+    _skeleton(linked / "data")
+    sc._anchor_data_root(linked)
+    assert os.environ["ML4T_DATA_PATH"] == str(linked / "data")
+
+
+def test_the_main_working_tree_of_a_built_repo_never_falls_back(clean_env, worktree_pair):
+    """The reader with one clone, stated as a repository rather than as an assumption."""
+    main, _linked = worktree_pair
+    _skeleton(main / "data")
+    sc._anchor_data_root(main)
+    assert os.environ["ML4T_DATA_PATH"] == str(main / "data")
+
+
+def test_a_checkout_path_containing_a_space_still_resolves(clean_env, tmp_path):
+    """`git rev-parse` prints one path per line, so the two paths must be split on lines.
+
+    Splitting on whitespace yields three parts here, fails the length test, and silently
+    disables the fallback - for a reader with a space in a directory name, who has no way to
+    connect that to a missing dataset.
+    """
+    main, linked = _repo_with_worktree(tmp_path / "my checkouts")
+    _dataset(main / "data")
+    _skeleton(linked / "data")
+    assert sc._main_worktree(linked) == main.resolve()
+    sc._anchor_data_root(linked)
+    assert os.environ["ML4T_DATA_PATH"] == str(main.resolve() / "data")
+
+
 # --- the anchoring rule -----------------------------------------------------------------------
 
 

--- a/tests/test_sitecustomize_data_root.py
+++ b/tests/test_sitecustomize_data_root.py
@@ -273,6 +273,11 @@ def test_the_resolved_root_is_the_one_the_loader_uses():
     )
     if out.returncode != 0:
         pytest.skip(f"utils not importable here: {out.stderr.strip()[-200:]}")
-    anchored, resolved = out.stdout.split()
+    anchored, resolved = out.stdout.splitlines()
     assert Path(anchored).resolve() == Path(resolved).resolve()
-    assert sc._has_datasets(Path(resolved))
+    # Only where this machine has data at all. A clean clone that has never run
+    # a downloader resolves correctly to a directory holding none, and that is
+    # the state CI checks out - asserting datasets here would fail every reader
+    # for whom the rule is working exactly as documented.
+    if sc._has_datasets(REPO_ROOT / "data") or sc._main_worktree(REPO_ROOT) is not None:
+        assert sc._has_datasets(Path(resolved))

--- a/tests/test_sitecustomize_data_root.py
+++ b/tests/test_sitecustomize_data_root.py
@@ -1,0 +1,177 @@
+"""`sitecustomize` decides where every entry point looks for data, so its rules are pinned here.
+
+The rule under test: the default is `<repo>/data`, which is right for a reader with one clone
+and wrong for a linked `git worktree`, because a worktree gets the tracked skeleton of `data/`
+and none of the gitignored datasets. Those live only in the main working tree.
+
+Both directions matter. Falling back for a reader would silently move their data root; not
+falling back in a worktree tells them to download tens of gigabytes already on the disk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_sitecustomize():
+    """Import `sitecustomize` under its own name so the installed one is not shadowed."""
+    spec = importlib.util.spec_from_file_location(
+        "_sitecustomize_under_test", REPO_ROOT / "sitecustomize.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = load_sitecustomize()
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("ML4T_DATA_PATH", raising=False)
+    monkeypatch.delenv("ML4T_DATA_PATH_IS_DEFAULT", raising=False)
+
+
+# --- what counts as a populated data directory ------------------------------------------------
+
+
+def test_the_tracked_skeleton_is_not_datasets(tmp_path):
+    """`data/etfs/market/` is committed and arrives empty, so a directory test is not enough."""
+    (tmp_path / "etfs" / "market").mkdir(parents=True)
+    (tmp_path / "etfs" / "market" / "config.yaml").write_text("name: etfs\n")
+    (tmp_path / "etfs" / "market" / "download.py").write_text("# downloader\n")
+    assert not sc._has_datasets(tmp_path)
+
+
+@pytest.mark.parametrize("rel", ["etfs/market/etf_universe.parquet", "factors/mom_daily.parquet"])
+def test_a_parquet_at_either_documented_depth_counts(tmp_path, rel):
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"")
+    assert sc._has_datasets(tmp_path)
+
+
+def test_a_missing_directory_is_not_datasets(tmp_path):
+    assert not sc._has_datasets(tmp_path / "nope")
+
+
+# --- telling a worktree from a clone ----------------------------------------------------------
+
+
+def test_the_main_working_tree_reports_no_main_worktree():
+    """The reader's case. `--git-dir` and `--git-common-dir` are equal, so there is no fallback."""
+    common = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    main_tree = Path(common).parent
+    assert sc._main_worktree(main_tree) is None
+
+
+def test_a_linked_worktree_reports_the_tree_that_holds_the_data():
+    if sc._main_worktree(REPO_ROOT) is None:
+        pytest.skip("this checkout is the main working tree")
+    assert (sc._main_worktree(REPO_ROOT) / ".git").exists()
+
+
+def test_a_directory_outside_any_repository_is_not_a_worktree(tmp_path):
+    assert sc._main_worktree(tmp_path) is None
+
+
+# --- the anchoring rule -----------------------------------------------------------------------
+
+
+def test_an_explicit_value_is_never_touched(monkeypatch, tmp_path):
+    monkeypatch.setenv("ML4T_DATA_PATH", str(tmp_path))
+    monkeypatch.delenv("ML4T_DATA_PATH_IS_DEFAULT", raising=False)
+    sc._anchor_data_root(REPO_ROOT)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path)
+    assert "ML4T_DATA_PATH_IS_DEFAULT" not in os.environ
+
+
+def test_a_populated_repo_data_directory_wins_and_is_marked_default(clean_env, tmp_path):
+    """The reader with one clone: no fallback runs, and the default is still marked as one."""
+    (tmp_path / "data" / "etfs").mkdir(parents=True)
+    (tmp_path / "data" / "etfs" / "bars.parquet").write_bytes(b"")
+    sc._anchor_data_root(tmp_path)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path / "data")
+    assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
+
+
+def test_an_unpopulated_non_worktree_keeps_the_repo_default(clean_env, tmp_path):
+    """No datasets and no main tree to borrow from: the answer is unchanged, and the error
+    downstream is the correct 'you have not downloaded the data yet'."""
+    (tmp_path / "data" / "etfs" / "market").mkdir(parents=True)
+    sc._anchor_data_root(tmp_path)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path / "data")
+
+
+def test_a_linked_worktree_falls_back_to_the_main_working_tree(clean_env):
+    main_tree = sc._main_worktree(REPO_ROOT)
+    if main_tree is None:
+        pytest.skip("this checkout is the main working tree")
+    if sc._has_datasets(REPO_ROOT / "data"):
+        pytest.skip("this worktree has its own datasets")
+    sc._anchor_data_root(REPO_ROOT)
+    assert os.environ["ML4T_DATA_PATH"] == str(main_tree / "data")
+    assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
+
+
+def test_a_broken_git_still_anchors_the_variable(clean_env, tmp_path, monkeypatch):
+    """The regression the fallback introduced, pinned shut.
+
+    The worktree probe runs BEFORE `ML4T_DATA_PATH` is assigned. If it propagated an error the
+    module-level guard would swallow it and the variable would be left unset entirely - worse
+    than the `<repo>/data` default it was meant to refine. A tarball install and a container
+    with no git both take this path.
+    """
+
+    def explode(*_args, **_kwargs):
+        raise FileNotFoundError("git: command not found")
+
+    monkeypatch.setattr(sc.subprocess, "run", explode)
+    (tmp_path / "data" / "etfs" / "market").mkdir(parents=True)
+    sc._anchor_data_root(tmp_path)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path / "data")
+    assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"
+
+
+def test_a_hung_git_is_not_an_error_either(clean_env, tmp_path, monkeypatch):
+    def hang(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=10)
+
+    monkeypatch.setattr(sc.subprocess, "run", hang)
+    (tmp_path / "data").mkdir()
+    sc._anchor_data_root(tmp_path)
+    assert os.environ["ML4T_DATA_PATH"] == str(tmp_path / "data")
+
+
+def test_the_resolved_root_is_the_one_the_loader_uses():
+    """End to end, in whatever tree this runs: the anchored value is what `utils` reports."""
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; from utils import ML4T_DATA_PATH;"
+            " print(os.environ['ML4T_DATA_PATH']); print(ML4T_DATA_PATH)",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        pytest.skip(f"utils not importable here: {out.stderr.strip()[-200:]}")
+    anchored, resolved = out.stdout.split()
+    assert Path(anchored).resolve() == Path(resolved).resolve()
+    assert sc._has_datasets(Path(resolved))

--- a/tests/test_sitecustomize_data_root.py
+++ b/tests/test_sitecustomize_data_root.py
@@ -275,9 +275,15 @@ def test_the_resolved_root_is_the_one_the_loader_uses():
         pytest.skip(f"utils not importable here: {out.stderr.strip()[-200:]}")
     anchored, resolved = out.stdout.splitlines()
     assert Path(anchored).resolve() == Path(resolved).resolve()
-    # Only where this machine has data at all. A clean clone that has never run
-    # a downloader resolves correctly to a directory holding none, and that is
-    # the state CI checks out - asserting datasets here would fail every reader
-    # for whom the rule is working exactly as documented.
-    if sc._has_datasets(REPO_ROOT / "data") or sc._main_worktree(REPO_ROOT) is not None:
+    # Only where this machine has data for the rule to find. A clean clone that
+    # has never run a downloader resolves correctly to a directory holding none,
+    # and that is the state CI checks out - asserting datasets here would fail
+    # every reader for whom the rule is working exactly as documented. Being a
+    # linked worktree is not enough on its own: its main tree can be just as
+    # empty, and then the correct answer is again a directory with no data.
+    main_tree = sc._main_worktree(REPO_ROOT)
+    reachable = sc._has_datasets(REPO_ROOT / "data") or (
+        main_tree is not None and sc._has_datasets(main_tree / "data")
+    )
+    if reachable:
         assert sc._has_datasets(Path(resolved))


### PR DESCRIPTION
## What

`sitecustomize` defaults `ML4T_DATA_PATH` to `<repo>/data`. That is right for a reader with one
clone and wrong for a linked `git worktree`, which gets the tracked skeleton of `data/` - the
`config.yaml`, the `download.py`, the dataset cards - and none of the parquet under it, which is
gitignored and lives only in the main working tree.

The result is a directory that exists, holds nothing, and produces an error telling the reader to
download tens of gigabytes already on the disk:

```
$ uv run python -c "from data import load_etfs; load_etfs()"
To download this dataset (from repo root):
  uv run python data/etfs/market/download.py
```

`--git-dir` and `--git-common-dir` are equal in the main working tree and differ in a linked one,
and the common dir's parent **is** the main working tree. Two plumbing commands, no new
configuration, no environment variable to remember.

**The reader's path does not change.** A plain clone has datasets under `<repo>/data`, so the
fallback never runs; the resolved value and `ML4T_DATA_PATH_IS_DEFAULT` are what they were.

## Why not a symlink

A directory symlink under `data/` is not gitignored, so `git add -A` commits an absolute
machine-specific path into the public repo.

## Testing for datasets, not for the directory

This is the load-bearing half. `data/etfs/market/` is tracked and arrives empty, so `.exists()`
on it is always true - the first version of this change did exactly that and had no effect at
all. The test is a parquet at either documented depth, `data/<domain>/*.parquet` or
`data/<domain>/<source>/*.parquet`, and both globs stop at the first match rather than descending
the tree.

## Three defects found by review after the first commit

**The tests that exercised the fallback skipped everywhere it matters.** Both read whichever
checkout the suite runs in and `pytest.skip` when that is the main working tree - every clean
clone and every CI run. Seven tests now build a repository and a real linked worktree with
`git init` and `git worktree add` and drive the rule through both, so the branch this change
exists for is tested rather than assumed.

**A checkout path containing a space silently disabled the fallback.** `out.stdout.split()`
splits `/home/me/my checkouts/main/.git` into three parts, the length guard rejects it, and the
reader with a space in a directory name gets the download error with nothing connecting the two.
`git rev-parse` prints one path per line.

**Three existing tests in `tests/test_data_root_anchor.py` went red** and CI could not have said
so, because they only fail in a worktree and the file runs in no job. Confirmed introduced here
rather than pre-existing: checking out `origin/main`'s `sitecustomize.py` into the same worktree
turns all twenty green.

## Gating the contract (ml4t/agent-workspace#344, fixed rather than filed)

Forty tests covered the rule that decides where every entry point in this repo looks for data,
and no workflow ran any of them. They are now a `test-unit` step. Two things had to be fixed to
get there:

- **`conftest._resolve_data_path` step 2 applied no dataset test.** Step 1 declines the anchored
  default on its marker and step 4 declines the repo tree unless it holds parquet; step 2
  accepted any path that exists and is non-empty, which the tracked skeleton always is. So a
  `.env` naming the repo's own `data/` reintroduced exactly what the other two steps block - and
  CI writes such a `.env` by hand, bypassing `generated_env_contents`, which omits it for this
  reason. No change to local resolution, which comes from the test-data checkout at step 3.
- **The step asserts the startup hook fired before trusting the result.** `anchor_ran` skips when
  `sitecustomize` did not run, which is right locally (Debian's own copy shadows this one on a
  system-interpreter venv) and wrong in CI, where it would turn the step green having tested
  nothing. It probes a fresh interpreter rather than importing the module: cwd is on `sys.path`,
  so `import sitecustomize` succeeds in the workspace whether or not anything ran it at startup.

## Verification

Run against a fresh clone in a directory with no parquet, with the job's own venv, dependency
list and `.env`, reproducing the CI condition rather than reasoning about it:

- **38 passed, 2 skipped** on the data-less clone. Both skips are the checkout-dependent worktree
  probes, whose behaviour is covered by the hermetic tests, which do run there.
- **40 passed** in a linked worktree with data.
- **259 passed** locally across the `test-unit` allowlist plus both data-root files.
- The precondition guard exits 0 with `PYTHONPATH` set and 1 without.
- Mutation-checked: removing the fallback fails 4 tests, letting the skeleton count as datasets
  fails 1, restoring `.split()` fails exactly the space-in-path test.
- End to end in a linked worktree with no manual prefix, `load_etfs()` returns 470,662 rows.
