### PR TITLE
Expose TabM coverage fields and prime sequences across label-buffer gaps

### DIFF
--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -298,23 +298,25 @@ def _build_val_df_with_priming(
     val_start: pd.Timestamp,
     lookback: int,
 ) -> pd.DataFrame:
-    """Per-symbol, keep last `lookback` train-tail rows + all val rows.
+    """Per-symbol, keep last `lookback` pre-val rows + all val rows.
 
-    Train-tail rows provide the input window (priming) for the first val
+    Pre-val rows provide the input window (priming) for the first val
     target prediction; their labels are not emitted as val targets because
     sequence positions start at index `lookback` within each symbol's
     sorted array, and with exactly `lookback` priming rows the first
-    target falls at val_start.
+    target falls at val_start. The priming window must include every
+    observable feature row immediately before ``val_start``, including
+    any label-buffer gap between ``train_end`` and ``val_start``.
     """
     pieces: list[pd.DataFrame] = []
     for _, sym_df in full_val_source.groupby(entity_col, sort=False):
         sym_df = sym_df.sort_values(date_col, kind="stable")
         is_val = sym_df[date_col] >= val_start
-        train_tail = sym_df.loc[~is_val].tail(lookback)
+        context_tail = sym_df.loc[~is_val].tail(lookback)
         val_part = sym_df.loc[is_val]
-        if train_tail.empty and val_part.empty:
+        if context_tail.empty and val_part.empty:
             continue
-        pieces.append(pd.concat([train_tail, val_part], ignore_index=True))
+        pieces.append(pd.concat([context_tail, val_part], ignore_index=True))
     if not pieces:
         return full_val_source.iloc[0:0].copy()
     return pd.concat(pieces, ignore_index=True)
@@ -340,10 +342,12 @@ def prepare_fold_sequence_stores(
     """Build normalized train/validation sequence stores for a fold.
 
     When ``val_start`` is provided, val sequences are built from the
-    concatenation of (a) each symbol's last ``lookback`` train-tail rows
-    and (b) its val-period rows. This "train-tail priming" ensures the
-    first val sequence predicts the target at ``val_start`` — matching
-    production behavior and Chapter 13's teaching implementation.
+    concatenation of (a) each symbol's last ``lookback`` rows with
+    ``date < val_start`` and (b) its val-period rows. This context priming
+    ensures the first val sequence predicts the target at ``val_start`` —
+    matching production behavior and Chapter 13's teaching implementation.
+    Rows in a label-buffer gap after ``train_end`` remain valid context
+    features and are included in the priming window.
 
     When ``val_start`` is None, val sequences start at position
     ``lookback`` within the val slice, which discards the first
@@ -388,12 +392,13 @@ def prepare_fold_sequence_stores(
         )
 
         if val_start_ts is not None:
-            # Source = train-rows-before-val + val-rows (temporal columns
-            # replaced consistently per fold across both halves).
-            train_tail_mask = train_mask & (dataset_pd[date_col] < val_start_ts)
+            # Source = every observable row before val_start + val rows
+            # (temporal columns replaced consistently per fold). Include
+            # label-buffer gap rows after train_end; they are valid context.
+            context_mask = dataset_pd[date_col] < val_start_ts
             full_val_source = _replace_temporal_columns(
                 dataset_pd,
-                train_tail_mask | val_mask,
+                context_mask | val_mask,
                 temporal_by_fold,
                 temporal_keys,
                 temporal_feature_names,
@@ -423,8 +428,8 @@ def prepare_fold_sequence_stores(
         train_df = dataset_pd.loc[train_mask, use_cols].dropna(subset=[label_col]).copy()
 
         if val_start_ts is not None:
-            train_tail_mask = train_mask & (dataset_pd[date_col] < val_start_ts)
-            full_val_source = dataset_pd.loc[train_tail_mask | val_mask, use_cols].dropna(
+            context_mask = dataset_pd[date_col] < val_start_ts
+            full_val_source = dataset_pd.loc[context_mask | val_mask, use_cols].dropna(
                 subset=[label_col]
             )
             val_df = _build_val_df_with_priming(

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -369,6 +369,21 @@ def _decision_time_checkpoint_metrics(
     }
 
 
+def _n_invalid_scores(frame: pl.DataFrame) -> int:
+    """Count null / NaN / infinite prediction scores in one checkpoint frame."""
+    if frame.is_empty() or "y_score" not in frame.columns:
+        return 0
+    return int(
+        frame.select(
+            (
+                pl.col("y_score").is_null().sum()
+                + pl.col("y_score").is_nan().sum()
+                + pl.col("y_score").is_infinite().sum()
+            ).alias("n_invalid")
+        ).item()
+    )
+
+
 def _load_incremental_preds_for_config(incr_dir: Path, config_name: str) -> pl.DataFrame:
     """Reassemble one config's predictions from its per-fold incremental saves."""
     parquet_files = sorted(incr_dir.glob(f"{config_name}_fold*.parquet"))
@@ -505,6 +520,8 @@ def _load_cached_tabm_config(
                 "epoch": int(epoch),
                 "ic_mean": float(metric["ic_mean"]),
                 "ic_std": float(metric.get("ic_std", 0.0)),
+                "ic_n_days": int(metric["n_periods"]),
+                "n_invalid": _n_invalid_scores(predictions),
             }
         )
         frames.append(
@@ -515,11 +532,15 @@ def _load_cached_tabm_config(
         )
     if not curves:
         raise ValueError(f"No cached {prediction_split} checkpoints for {config_name}")
-    best = max(curves, key=lambda row: row["ic_mean"])
+    full_days = max(row["ic_n_days"] for row in curves)
+    eligible = [row for row in curves if row["ic_n_days"] == full_days]
+    best = max(eligible, key=lambda row: row["ic_mean"])
     result = {
         "config_name": config_name,
         "best_epoch": best["epoch"],
         "best_ic": best["ic_mean"],
+        "ic_n_days": int(best["ic_n_days"]),
+        "n_invalid": int(best["n_invalid"]),
         "elapsed_s": 0.0,
         "started_at": None,
         "cached": True,
@@ -541,12 +562,80 @@ def _assemble_tabm_results(
     """Select the winner and build the same result for trained or cached configs."""
     if not config_results:
         raise ValueError("No configs completed successfully.")
-    ranked = sorted(
-        config_results,
+
+    def _positive_days(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            days = int(value)
+        except (TypeError, ValueError):
+            return None
+        return days if days > 0 else None
+
+    coverage_days = [
+        days
+        for row in config_results
+        if (days := _positive_days(row.get("ic_n_days"))) is not None
+    ]
+    full_coverage_days = max(coverage_days) if coverage_days else None
+
+    ranked: list[dict[str, Any]] = []
+    for row in config_results:
+        enriched = dict(row)
+        best_ic = float(enriched.get("best_ic", float("nan")))
+        checkpoint_preds = pl.DataFrame()
+        if all_predictions.height and {"config", "epoch"}.issubset(all_predictions.columns):
+            checkpoint_preds = all_predictions.filter(
+                (pl.col("config") == enriched["config_name"])
+                & (pl.col("epoch") == enriched["best_epoch"])
+            )
+        ic_n_days = _positive_days(enriched.get("ic_n_days")) or 0
+        if ic_n_days == 0 and checkpoint_preds.height:
+            actual_col = eval_col if eval_col else "y_true"
+            if actual_col in checkpoint_preds.columns and "y_score" in checkpoint_preds.columns:
+                ic_n_days = int(
+                    _decision_time_checkpoint_metrics(
+                        checkpoint_preds,
+                        date_col=date_col,
+                        entity_col=entity_col,
+                        ret_col=actual_col,
+                    )["ic_n_days"]
+                )
+        n_invalid = (
+            int(enriched["n_invalid"])
+            if "n_invalid" in enriched and enriched["n_invalid"] is not None
+            else _n_invalid_scores(checkpoint_preds)
+        )
+        selectable = bool(
+            np.isfinite(best_ic)
+            and n_invalid == 0
+            and ic_n_days > 0
+            and (full_coverage_days is None or ic_n_days == full_coverage_days)
+        )
+        enriched["ic_n_days"] = ic_n_days
+        enriched["n_invalid"] = n_invalid
+        enriched["selectable"] = selectable
+        ranked.append(enriched)
+
+    # Recompute coverage after optional recovery from predictions.
+    coverage_days = [
+        days for row in ranked if (days := _positive_days(row.get("ic_n_days"))) is not None
+    ]
+    full_coverage_days = max(coverage_days) if coverage_days else None
+    for row in ranked:
+        row["selectable"] = bool(
+            np.isfinite(row["best_ic"])
+            and int(row["n_invalid"]) == 0
+            and int(row["ic_n_days"]) > 0
+            and (full_coverage_days is None or int(row["ic_n_days"]) == full_coverage_days)
+        )
+
+    ranked.sort(
         key=lambda row: row["best_ic"] if not np.isnan(row["best_ic"]) else -999,
         reverse=True,
     )
-    best = ranked[0]
+    selectable_ranked = [row for row in ranked if row["selectable"]]
+    best = selectable_ranked[0] if selectable_ranked else ranked[0]
     best_name = best["config_name"]
     best_epoch = best["best_epoch"]
     best_ic = best["best_ic"]
@@ -1166,18 +1255,40 @@ def run_tabm_cv(
                 int(epoch): {
                     "ic_mean": float(np.nanmean(values)),
                     "ic_std": float(np.nanstd(values)) if len(values) > 1 else 0.0,
+                    "ic_n_days": 0,
                 }
                 for epoch, values in fold_checkpoint_ics.items()
             }
 
+        best_n_invalid = 0
         if checkpoint_metrics:
+            days = [
+                int(metric.get("ic_n_days", 0))
+                for metric in checkpoint_metrics.values()
+                if int(metric.get("ic_n_days", 0)) > 0
+            ]
+            if days:
+                full_days = max(days)
+                eligible_metrics = {
+                    epoch: metric
+                    for epoch, metric in checkpoint_metrics.items()
+                    if int(metric.get("ic_n_days", 0)) == full_days
+                }
+            else:
+                eligible_metrics = checkpoint_metrics
             best_cp = max(
-                checkpoint_metrics, key=lambda epoch: checkpoint_metrics[epoch]["ic_mean"]
+                eligible_metrics, key=lambda epoch: eligible_metrics[epoch]["ic_mean"]
             )
             best_ic_val = float(checkpoint_metrics[best_cp]["ic_mean"])
+            best_ic_n_days = int(checkpoint_metrics[best_cp].get("ic_n_days", 0))
+            if cfg_all_preds.height:
+                best_n_invalid = _n_invalid_scores(
+                    cfg_all_preds.filter(pl.col("epoch") == best_cp)
+                )
         else:
             best_cp = 0
             best_ic_val = float("nan")
+            best_ic_n_days = 0
 
         elapsed = time.perf_counter() - t0
         config_results.append(
@@ -1185,6 +1296,8 @@ def run_tabm_cv(
                 "config_name": config_name,
                 "best_epoch": best_cp,
                 "best_ic": best_ic_val,
+                "ic_n_days": best_ic_n_days,
+                "n_invalid": best_n_invalid,
                 "elapsed_s": elapsed,
                 "started_at": config_started_at,
             }
@@ -1192,11 +1305,18 @@ def run_tabm_cv(
 
         cfg_curves_list = []
         for ep, metric in sorted(checkpoint_metrics.items()):
+            epoch_preds = (
+                cfg_all_preds.filter(pl.col("epoch") == ep)
+                if cfg_all_preds.height
+                else pl.DataFrame()
+            )
             entry = {
                 "config": config_name,
                 "epoch": ep,
                 "ic_mean": float(metric["ic_mean"]),
                 "ic_std": float(metric.get("ic_std", 0.0)),
+                "ic_n_days": int(metric.get("ic_n_days", 0)),
+                "n_invalid": _n_invalid_scores(epoch_preds),
             }
             all_curves.append(entry)
             cfg_curves_list.append(entry)

--- a/tests/test_sequence_dataset.py
+++ b/tests/test_sequence_dataset.py
@@ -200,3 +200,55 @@ def test_backwards_compatible_without_val_start():
         assert int(end_positions.min()) == lookback, (
             "Legacy path should start sequences at position=lookback"
         )
+
+
+def test_priming_includes_label_buffer_gap_rows():
+    """Context priming must use the latest bar before val_start, not train_end.
+
+    Walk-forward folds often leave a label-buffer gap between train_end and
+    val_start. Features in that gap are observable at decision time and must
+    prime the first validation sequence.
+    """
+    from case_studies.utils.sequence_dataset import prepare_fold_sequence_stores
+
+    train_end = pd.Timestamp("2020-12-30")
+    df, train_mask, val_mask, val_start_ts, _ = _synthetic_fold_df(
+        train_end=str(train_end.date()),
+        val_start="2021-01-04",
+    )
+    gap_mask = (df["timestamp"] > train_end) & (df["timestamp"] < val_start_ts) & ~train_mask
+    assert gap_mask.any(), "Fixture must leave observable rows in the label-buffer gap"
+    lookback = 20
+
+    _, val_store, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=lookback,
+        val_start=val_start_ts,
+    )
+
+    for symbol_id in range(val_store.n_symbols):
+        entity = val_store.entities[symbol_id]
+        end_positions = val_store.end_idx[val_store.symbol_idx == symbol_id]
+        if len(end_positions) == 0:
+            continue
+        first_end = int(end_positions.min())
+        first_target = pd.Timestamp(val_store.timestamps[symbol_id][first_end])
+        last_context = pd.Timestamp(val_store.timestamps[symbol_id][first_end - 1])
+        expected_context = pd.Timestamp(
+            df.loc[(df["symbol"] == entity) & (df["timestamp"] < val_start_ts), "timestamp"].max()
+        )
+        assert first_target == val_start_ts
+        assert last_context == expected_context, (
+            f"Symbol {entity!r}: last context is {last_context.date()}, "
+            f"expected {expected_context.date()} (latest observable pre-val row, "
+            f"not train_end={train_end.date()})."
+        )
+        assert last_context > train_end, (
+            f"Symbol {entity!r}: priming stopped at train_end and skipped the gap"
+        )


### PR DESCRIPTION
## Summary
- Attach `ic_n_days`, `n_invalid`, and `selectable` to TabM `grid_results` under full-coverage checkpoint selection so FX tabular DL summaries match the notebook contract on fresh and cached paths.
- Include label-buffer gap rows in DL sequence priming so the first validation context is the latest observable bar before `val_start`, not `train_end`.
- Add a regression test for gap-aware priming.

## Test plan
- [ ] Re-run `case_studies/fx_pairs/08_tabular_dl.ipynb` through the grid summary cell and confirm `grid_table` shows `ic_n_days` / `n_invalid` / `selectable` without `ColumnNotFoundError`
- [ ] Re-run the sequence audit cell in `case_studies/fx_pairs/09_dl_tcn.ipynb` and confirm fold 0 no longer raises `ConfigError: omits the latest observable context row`
- [ ] `pytest tests/test_sequence_dataset.py -q`


Made with [Cursor](https://cursor.com)