### PR TITLE
Fix the shared helpers stages 03 and 04 depend on, before nine agents each need them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -429,10 +429,14 @@ jobs:
         # scipy/statsmodels/scikit-learn are the import surface of
         # case_studies/utils/causal.py, so the p-value tail test can actually
         # run its numeric case rather than skipping past the behavior it pins.
+        #
+        # matplotlib and hmmlearn are the import surface of the shared stage-03
+        # and stage-04 helpers below. Neither pulls torch or an ml4t-* package,
+        # so this stays a fast per-commit gate.
         run: |
           uv venv --python 3.14
           uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium requests \
-            scipy statsmodels scikit-learn
+            scipy statsmodels scikit-learn matplotlib hmmlearn
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -505,6 +509,23 @@ jobs:
           ML4T_DATA_PATH: ${{ github.workspace }}/data
         run: |
           .venv/bin/python -m pytest tests/test_pvalue_tail_precision.py -v --tb=short
+
+      # The helpers the case-study stages share. One defect in any of these is a
+      # defect in eight rendered notebooks at once, which is exactly why they are
+      # fixed centrally rather than per notebook - and why the fix needs a gate
+      # rather than trusting that eight re-runs would catch a regression.
+      - name: Run shared case-study helper tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
+          MPLBACKEND: Agg
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_data_quality.py \
+            tests/test_feature_engineering_figures.py \
+            tests/test_temporal.py \
+            -v --tb=short
 
       # The methodology ratchet. Both files are static AST/source scans over the
       # notebook tree, so they need no data and no model deps, and both were

--- a/case_studies/utils/feature_engineering.py
+++ b/case_studies/utils/feature_engineering.py
@@ -560,7 +560,16 @@ def plot_coverage_through_time(
     # is for: where, and by how much, a family is actually thin.
     minima = [coverage[f].min() for f in families]
     lowest = min([float(v) for v in minima if v is not None], default=1.0)
-    ax.set_ylim(min(lowest - 0.02 * (1 - lowest) - 0.002, 0.999), 1.0005)
+    # The headroom scales with the range too, for the same reason the floor does. The
+    # stage-03 notebooks pass the panel before the null policy, so every family starts at
+    # zero and the axis spans the full unit; a fixed 1.0005 ceiling then leaves the dense
+    # stretch half a thousandth below the top, drawn underneath the spine. That stretch is
+    # what the figure claims - the families fill and never thin again - so it has to be
+    # visible as a line rather than as the frame.
+    ax.set_ylim(
+        min(lowest - 0.02 * (1 - lowest) - 0.002, 0.999),
+        1.0 + max(0.0005, 0.03 * (1 - lowest)),
+    )
     ax.set_ylabel("non-null share")
     ax.legend(fontsize=6, ncol=3, frameon=False, loc="lower right")
     add_message_title(ax, title, subtitle=subtitle)
@@ -901,7 +910,12 @@ def plot_persistence(
     acf["_n"] = counts
 
     width, height = FIGSIZE["dual_h_tall"]
-    fig, (left, right) = plt.subplots(1, 2, figsize=(width, height + 0.5))
+    # The left panel carries a full lag axis and every curve the prose reads off; the right
+    # is a horizontal bar per feature on a 0-1 axis. Equal columns compressed the panel that
+    # holds the information and left a band of white between the two.
+    fig, (left, right) = plt.subplots(
+        1, 2, figsize=(width, height + 0.5), gridspec_kw={"width_ratios": [2, 1]}
+    )
     # An interval around each curve, at each lag. A single width drawn around zero is
     # a white-noise significance band, which is a different statement and not one this
     # estimator supports: the quantity plotted is a median over ETFs, so its
@@ -963,8 +977,14 @@ def plot_persistence(
     lowest = float(np.nanmin(stability))
     right.set_xlim(min(lowest, 0.0) - 0.08, 1.0)
     right.axvline(0, color=COLORS["neutral"], linewidth=0.8)
-    right.set_xlabel("rank correlation, consecutive rebalances", fontsize=8)
+    # Wrapped, and anchored to the panel's right edge rather than centred under it. On one
+    # centred line this label is wider than the panel, so it ran past the right edge of the
+    # figure and was cut mid-word - "consecutive rebala" - in every stage-03 render. How far
+    # past depends on how long the feature names are, since those are the panel's y-tick
+    # labels and they set how much width is left; anchoring makes it grow into the gap
+    # between the panels instead, which no case study can exhaust.
+    right.set_xlabel("rank correlation,\nconsecutive rebalances", fontsize=8, ha="right", x=1.0)
     add_message_title(left, title, subtitle=subtitle)
-    fig.tight_layout(w_pad=2.5)
+    fig.tight_layout()
     show_with_alt(fig, alt)
     return None

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -45,9 +45,15 @@ def filtered_state_probs(model: GaussianHMM, X: np.ndarray) -> np.ndarray:
 
     ``model._compute_log_likelihood`` is a **private** ``hmmlearn`` API (present through
     0.3.x) and is the one version-fragile call in this module. It is here, once, rather
-    than at six call sites. If a future release removes it, the public replacement is
-    ``model.score_samples(X)``, whose second return value is the smoothed posterior - so
-    it substitutes for the emission term only, and this recursion still has to run.
+    than at six call sites.
+
+    What it returns is the per-state emission log-density,
+    :math:`\log p(x_t \mid z_t = k)`, as an ``(n_samples, n_components)`` array. If a
+    future release removes it, there is no public method that returns that:
+    ``score_samples`` gives the sequence log-likelihood and the *smoothed* posterior, and
+    ``predict_proba`` gives the smoothed posterior alone - neither is the emission term.
+    The replacement is to evaluate the fitted Gaussians directly, column ``k`` being
+    ``scipy.stats.multivariate_normal(model.means_[k], model.covars_[k]).logpdf(X)``.
 
     Parameters
     ----------
@@ -142,8 +148,10 @@ def fit_hmm_kmeans_init(
     (``init_params="st"``); the emission parameters are set here and then refit.
 
     The covariance of each cluster is regularised by ``1e-6`` on the diagonal so a cluster
-    whose members are nearly collinear - or a one-observation cluster - still yields a
-    positive-definite matrix.
+    whose members are nearly collinear still yields a positive-definite matrix. A cluster
+    with a single member has no covariance at all - ``np.cov`` divides by zero degrees of
+    freedom and returns NaN, which the ridge does not repair and ``fit`` does not survive
+    - so it starts from the covariance of the whole sample instead.
 
     This is not a reproducible fit on its own. ``KMeans`` reduces its Lloyd iterations in
     parallel, so the partition can differ run to run even at a fixed seed; pinning that
@@ -171,14 +179,24 @@ def fit_hmm_kmeans_init(
         init_params="st",
     )
     model.means_ = kmeans.cluster_centers_
-    # np.cov of a single-feature cluster returns a 0-d array rather than a 1x1 matrix, so
-    # the result is widened before the ridge is added. The univariate case is the common
-    # one here - most of these HMMs read one series.
+    ridge = np.eye(X.shape[1]) * 1e-6
+    pooled = np.atleast_2d(np.cov(X.T))
     model.covars_ = np.array(
-        [
-            np.atleast_2d(np.cov(X[kmeans.labels_ == k].T)) + np.eye(X.shape[1]) * 1e-6
-            for k in range(n_states)
-        ]
+        [_cluster_covariance(X[kmeans.labels_ == k], pooled) + ridge for k in range(n_states)]
     )
     model.fit(X)
     return model
+
+
+def _cluster_covariance(cluster: np.ndarray, pooled: np.ndarray) -> np.ndarray:
+    """Covariance of one k-means cluster, widened to a matrix and never NaN.
+
+    ``np.cov`` of a single-feature cluster returns a 0-d array rather than a 1x1 matrix,
+    so the result is widened; the univariate case is the common one here, since most of
+    these HMMs read one series. With fewer than two members there is nothing to estimate
+    from and ``np.cov`` returns NaN, so the sample covariance stands in - a starting point
+    for EM, which refits it either way.
+    """
+    if cluster.shape[0] < 2:
+        return pooled.copy()
+    return np.atleast_2d(np.cov(cluster.T))

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -1,0 +1,184 @@
+"""Fitted-model helpers shared by the stage-04 ``04_model_based_features`` notebooks.
+
+A model-based feature is a function of parameters estimated from bars, so the estimation
+window is part of the feature's information set. That makes two things shared rather than
+per-notebook: how inference is run forward over a fold without reading the future, and how
+the fitted states are put in an order that means the same thing from one fold to the next.
+
+Both were copied into every notebook that needed them. The forward recursion in particular
+existed in six near-verbatim copies, each calling a private ``hmmlearn`` method, and only
+three of the six said so - an upstream rename would have broken all six and been documented
+at half of them.
+
+Nothing here is a new behaviour. Each helper reproduces what the notebooks already ran, and
+``tests/test_temporal.py`` pins that by running the notebook implementations beside these
+and asserting the results are identical.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from hmmlearn.hmm import GaussianHMM
+from sklearn.cluster import KMeans
+
+__all__ = [
+    "filtered_state_probs",
+    "fit_hmm_kmeans_init",
+    "relabel_states",
+    "sort_states_by_mean",
+    "sort_states_by_variance",
+]
+
+# Guards the log of a zero transition or start probability. Small enough not to move a
+# fitted probability, large enough that log() stays finite.
+_LOG_FLOOR = 1e-300
+
+
+def filtered_state_probs(model: GaussianHMM, X: np.ndarray) -> np.ndarray:
+    r"""Filtered state probabilities :math:`P(z_t \mid x_{1:t})`, by forward recursion.
+
+    ``hmmlearn``'s ``predict_proba`` returns the *smoothed* posterior
+    :math:`P(z_t \mid x_{1:T})`, which conditions on the whole sequence including
+    observations after :math:`t`. Used as a feature that is look-ahead: the value at
+    :math:`t` moves when data arrives later. The forward pass conditions on the past and
+    the present only, which is what a feature computed in production can know.
+
+    ``model._compute_log_likelihood`` is a **private** ``hmmlearn`` API (present through
+    0.3.x) and is the one version-fragile call in this module. It is here, once, rather
+    than at six call sites. If a future release removes it, the public replacement is
+    ``model.score_samples(X)``, whose second return value is the smoothed posterior - so
+    it substitutes for the emission term only, and this recursion still has to run.
+
+    Parameters
+    ----------
+    model
+        A fitted ``GaussianHMM``.
+    X
+        Observations, shape ``(n_samples, n_features)``, in time order.
+
+    Returns
+    -------
+    ndarray
+        Shape ``(n_samples, n_components)``, each row summing to one.
+    """
+    framelogprob = model._compute_log_likelihood(X)
+    n_samples = X.shape[0]
+    n_components = model.n_components
+
+    log_startprob = np.log(model.startprob_ + _LOG_FLOOR)
+    log_transmat = np.log(model.transmat_ + _LOG_FLOOR)
+
+    # Accumulated in the log domain: the joint P(z_t, x_{1:t}) underflows to zero in the
+    # linear domain within a few hundred observations, and these run to thousands.
+    fwdlattice = np.zeros((n_samples, n_components))
+    fwdlattice[0] = log_startprob + framelogprob[0]
+    for t in range(1, n_samples):
+        for j in range(n_components):
+            fwdlattice[t, j] = framelogprob[t, j] + np.logaddexp.reduce(
+                fwdlattice[t - 1] + log_transmat[:, j]
+            )
+
+    log_normalizer = np.logaddexp.reduce(fwdlattice, axis=1, keepdims=True)
+    return np.exp(fwdlattice - log_normalizer)
+
+
+def sort_states_by_variance(model: GaussianHMM) -> np.ndarray:
+    """State indices ordered by fitted variance, ascending, so state 0 is the calm one.
+
+    EM returns the states in an arbitrary order, so the same fitted state can come back as
+    state 0 in one fold and state 1 in the next - and a feature named for one of them then
+    means different things across folds. The ordering rule has to be the quantity the
+    feature name claims.
+
+    The dispersion of a multivariate state is summarized by the trace of its covariance,
+    which is the sum of the per-feature variances and reduces to the variance itself when
+    there is one feature.
+    """
+    dispersion = np.array([np.trace(model.covars_[k]) for k in range(model.n_components)])
+    return np.argsort(dispersion)
+
+
+def sort_states_by_mean(model: GaussianHMM, dim: int = 0) -> np.ndarray:
+    """State indices ordered by fitted mean of observation *dim*, ascending.
+
+    The companion to :func:`sort_states_by_variance`, for a feature emitted as the
+    probability of the high-*level* state rather than the high-dispersion one - a carry
+    regime, for instance, where the states differ in where the mean sits and not in how
+    far the observation travels.
+    """
+    means = np.array([float(model.means_[k][dim]) for k in range(model.n_components)])
+    return np.argsort(means)
+
+
+def relabel_states(
+    states: np.ndarray, probs: np.ndarray, order: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply an ordering from one of the ``sort_states_by_*`` helpers.
+
+    ``order[i]`` is the fitted state that becomes state ``i``, so the probability columns
+    are taken in that order and the state labels are mapped through its inverse.
+
+    Returns
+    -------
+    tuple of ndarray
+        The relabelled state sequence and the reordered probability columns.
+    """
+    inverse = np.argsort(order)
+    return inverse[states], probs[:, order]
+
+
+def fit_hmm_kmeans_init(
+    X: np.ndarray,
+    n_states: int = 2,
+    random_state: int = 42,
+    n_iter: int = 200,
+) -> GaussianHMM:
+    """Fit a ``GaussianHMM`` whose emissions start from a k-means partition of *X*.
+
+    EM on a Gaussian HMM converges to a local optimum, and from a random start the one it
+    reaches moves with the seed. Seeding the means and covariances from k-means starts it
+    somewhere the data chose, which makes the fit far less sensitive to that draw. Only
+    the start and transition probabilities are left to ``hmmlearn`` to initialise
+    (``init_params="st"``); the emission parameters are set here and then refit.
+
+    The covariance of each cluster is regularised by ``1e-6`` on the diagonal so a cluster
+    whose members are nearly collinear - or a one-observation cluster - still yields a
+    positive-definite matrix.
+
+    This is not a reproducible fit on its own. ``KMeans`` reduces its Lloyd iterations in
+    parallel, so the partition can differ run to run even at a fixed seed; pinning that
+    down is the caller's business (ml4t/agent-workspace#328).
+
+    Parameters
+    ----------
+    X
+        Observations, shape ``(n_samples, n_features)``, in time order.
+    n_states
+        Number of hidden states.
+    random_state
+        Seed passed to both ``KMeans`` and the ``GaussianHMM``.
+    n_iter
+        EM iteration cap.
+    """
+    kmeans = KMeans(n_clusters=n_states, random_state=random_state, n_init=10)
+    kmeans.fit(X)
+
+    model = GaussianHMM(
+        n_components=n_states,
+        covariance_type="full",
+        n_iter=n_iter,
+        random_state=random_state,
+        init_params="st",
+    )
+    model.means_ = kmeans.cluster_centers_
+    # np.cov of a single-feature cluster returns a 0-d array rather than a 1x1 matrix, so
+    # the result is widened before the ridge is added. The univariate case is the common
+    # one here - most of these HMMs read one series.
+    model.covars_ = np.array(
+        [
+            np.atleast_2d(np.cov(X[kmeans.labels_ == k].T)) + np.eye(X.shape[1]) * 1e-6
+            for k in range(n_states)
+        ]
+    )
+    model.fit(X)
+    return model

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -17,6 +17,7 @@ from utils.data_quality import (
     check_ohlc_invariants,
     describe_coverage,
     null_rate,
+    validate_features,
 )
 
 
@@ -213,3 +214,50 @@ def test_null_rate_reports_per_column() -> None:
     # 1/3 ≈ 33.33 for a, 2/3 ≈ 66.66 for b
     assert round(by_col["a"], 2) == 33.33
     assert round(by_col["b"], 2) == 66.67
+
+
+# -----------------------------------------------------------------------------
+# validate_features
+# -----------------------------------------------------------------------------
+
+
+def test_validate_features_warm_up_nan_is_not_an_extreme_value() -> None:
+    # The head every rolling window leaves, on a quantity bounded well below the
+    # threshold. Polars evaluates NaN > x as True, so this was reported as extreme.
+    entropy = pl.DataFrame({"fft_spectral_entropy": [float("nan")] * 4 + [4.7, 4.6]})
+    assert validate_features(entropy, ["fft_spectral_entropy"]) == []
+
+
+def test_validate_features_still_reports_a_genuine_extreme_beside_a_nan_head() -> None:
+    df = pl.DataFrame({"f": [float("nan"), 1.0, 5e6]})
+    (issue,) = validate_features(df, ["f"])
+    assert "f(1)" in issue and "|x| >" in issue
+
+
+def test_validate_features_reports_an_all_nan_column_as_carrying_no_value() -> None:
+    df = pl.DataFrame({"f": [float("nan"), float("nan")]})
+    (issue,) = validate_features(df, ["f"])
+    assert "carry no value" in issue and "'f'" in issue
+
+
+def test_validate_features_reports_an_all_null_column_as_carrying_no_value() -> None:
+    df = pl.DataFrame({"f": [None, None]}, schema={"f": pl.Float64})
+    (issue,) = validate_features(df, ["f"])
+    assert "carry no value" in issue
+
+
+def test_validate_features_reports_infinities_separately_from_nan() -> None:
+    df = pl.DataFrame({"f": [float("nan"), float("inf"), 1.0]})
+    (issue,) = validate_features(df, ["f"])
+    assert issue.startswith("CRITICAL") and "f(1)" in issue
+
+
+def test_validate_features_handles_an_integer_column() -> None:
+    # is_nan and is_infinite are undefined on an integer series.
+    df = pl.DataFrame({"f": [1, 2, 3]})
+    assert validate_features(df, ["f"]) == []
+    assert validate_features(pl.DataFrame({"f": [1, 2 * 10**9]}), ["f"], max_abs_value=1e6) != []
+
+
+def test_validate_features_skips_columns_the_frame_does_not_have() -> None:
+    assert validate_features(pl.DataFrame({"a": [1.0]}), ["absent"]) == []

--- a/tests/test_feature_engineering_figures.py
+++ b/tests/test_feature_engineering_figures.py
@@ -1,0 +1,120 @@
+"""Tests for the shared stage-03 figure helpers in case_studies/utils/feature_engineering.py.
+
+Pins:
+- plot_coverage_through_time: the dense stretch stays visible below the top spine when the
+  frame starts at zero, which is what the stage-03 notebooks pass, while the zoom the
+  helper exists for still happens on an already-dense frame.
+- plot_persistence: the left panel is the wider of the two, and the right panel's x-axis
+  label is drawn inside the figure rather than cut off at the edge.
+
+All eight 03_financial_features notebooks draw both, so a regression here is a regression
+in eight rendered pages at once.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import polars as pl
+import pytest
+from matplotlib.figure import Figure
+
+import case_studies.utils.feature_engineering as fe
+
+
+@pytest.fixture
+def captured(monkeypatch) -> list[Figure]:
+    """Intercept the figure the helper would display, so it can be measured."""
+    figures: list[Figure] = []
+    monkeypatch.setattr(fe, "show_with_alt", lambda fig, alt: figures.append(fig))
+    return figures
+
+
+def _dates(n: int) -> list[date]:
+    return [date(2018, 1, 1) + timedelta(days=i) for i in range(n)]
+
+
+def _coverage(warmups: dict[str, int], n: int = 400) -> pl.DataFrame:
+    frame = {"timestamp": _dates(n)}
+    for family, w in warmups.items():
+        frame[family] = [0.0] * w + [1.0] * (n - w)
+    return pl.DataFrame(frame)
+
+
+def test_coverage_leaves_the_dense_stretch_visible_below_the_spine(captured) -> None:
+    # What the stage-03 notebooks pass: the panel before the null policy, so every family
+    # starts at zero. A fixed 1.0005 ceiling drew the flat stretch under the top spine.
+    fe.plot_coverage_through_time(
+        _coverage({"momentum": 21, "volatility": 63, "flow": 252}),
+        title="t",
+        alt="a",
+    )
+    (fig,) = captured
+    bottom, top = fig.axes[0].get_ylim()
+    headroom = (top - 1.0) / (top - bottom)
+    assert headroom > 0.02, f"the stretch at 1.0 sits {headroom:.2%} below the top of the axis"
+
+
+def test_coverage_still_zooms_when_the_frame_is_already_dense(captured) -> None:
+    # The case the helper's scaling exists for: a matrix 99% dense everywhere must not
+    # draw as one flat line at the top of a full 0-1 axis.
+    n = 400
+    frame = pl.DataFrame({"timestamp": _dates(n), "momentum": [0.99] * n, "flow": [0.995] * n})
+    fe.plot_coverage_through_time(frame, title="t", alt="a")
+    (fig,) = captured
+    bottom, top = fig.axes[0].get_ylim()
+    assert bottom > 0.98, "an already-dense frame must still be zoomed, not pinned near zero"
+    assert top - 1.0 < 0.001, "and must not gain the headroom a full-range frame needs"
+
+
+def _panel(
+    n_entities: int = 8, n_days: int = 120, columns: list[str] | None = None
+) -> tuple[pl.DataFrame, list[str], list[date]]:
+    rng = np.random.default_rng(0)
+    columns = list(columns) if columns else ["mom_21d", "vol_63d"]
+    days = _dates(n_days)
+    level = {f"E{i}": rng.normal(0, 1, len(columns)) for i in range(n_entities)}
+    rows = []
+    for day in days:
+        for entity, value in level.items():
+            level[entity] = 0.97 * value + rng.normal(0, 0.25, len(columns))
+            rows.append({"symbol": entity, "timestamp": day, **dict(zip(columns, level[entity]))})
+    return pl.DataFrame(rows), columns, [d for d in days if d.day in (1, 15)]
+
+
+def test_persistence_gives_the_lag_panel_the_greater_width(captured) -> None:
+    panel, columns, schedule = _panel()
+    fe.plot_persistence(
+        panel, columns, entity="symbol", max_lag=10, decision_dates=schedule, title="t", alt="a"
+    )
+    (fig,) = captured
+    left, right = fig.axes[0].get_position().width, fig.axes[1].get_position().width
+    assert left > right, "the panel the prose reads off must not be the compressed one"
+
+
+def test_persistence_draws_its_right_hand_axis_label_inside_the_figure(captured) -> None:
+    # Feature names of the length the case studies actually use. They are the right panel's
+    # y-tick labels, so they set how little width the x-axis label has left - which is why
+    # this was seen in cme_futures and not in a two-short-column sketch.
+    panel, columns, schedule = _panel(
+        columns=[
+            "realised_vol_63d",
+            "momentum_since_21d",
+            "turnover_zscore_252d",
+            "spread_bps_median_21d",
+        ]
+    )
+    fe.plot_persistence(
+        panel, columns, entity="symbol", max_lag=10, decision_dates=schedule, title="t", alt="a"
+    )
+    (fig,) = captured
+    fig.canvas.draw()
+    label = fig.axes[1].xaxis.get_label()
+    extent = label.get_window_extent(fig.canvas.get_renderer())
+    assert extent.x1 <= fig.bbox.x1, "the label runs off the right edge and is cut mid-word"
+    assert extent.x0 >= fig.bbox.x0

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -12,6 +12,8 @@ value must not.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 from hmmlearn.hmm import GaussianHMM
@@ -195,6 +197,32 @@ def test_fit_hmm_kmeans_init_returns_a_fitted_model_of_the_right_shape(n_feature
     assert model.covars_.shape == (2, n_features, n_features)
     np.testing.assert_allclose(model.transmat_.sum(axis=1), 1.0)
     assert filtered_state_probs(model, X).shape == (X.shape[0], 2)
+
+
+@pytest.mark.parametrize("n_features", [1, 3])
+def test_fit_hmm_kmeans_init_survives_a_one_observation_cluster(n_features) -> None:
+    """np.cov of a single member divides by zero degrees of freedom and returns NaN.
+
+    The 1e-6 ridge does not repair a NaN, so without a fallback the fit is handed a
+    covariance of NaN. A far outlier is the way k-means is made to produce such a cluster.
+    """
+    X = _series(n=200, n_features=n_features)
+    X = np.vstack([X, np.full((1, n_features), 1e6)])
+    model = fit_hmm_kmeans_init(X, n_states=2, random_state=42)
+    assert np.isfinite(model.covars_).all()
+    assert np.isfinite(filtered_state_probs(model, X)).all()
+
+
+def test_cluster_covariance_falls_back_rather_than_returning_nan() -> None:
+    from case_studies.utils.temporal import _cluster_covariance
+
+    pooled = np.array([[2.0]])
+    with np.errstate(invalid="ignore", divide="ignore"), warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        assert np.isnan(np.cov(np.array([[1.5]]).T)), "the condition the fallback is for"
+    np.testing.assert_array_equal(_cluster_covariance(np.array([[1.5]]), pooled), pooled)
+    two = np.array([[1.0], [3.0]])
+    np.testing.assert_allclose(_cluster_covariance(two, pooled), np.cov(two.T).reshape(1, 1))
 
 
 def test_fit_hmm_kmeans_init_separates_the_two_regimes() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,204 @@
+"""Tests for case_studies/utils/temporal.py.
+
+This module is an extraction, not a new behaviour, so the tests that matter run the
+implementations the stage-04 notebooks carry today beside the shared ones and assert the
+results are identical. `_notebook_*` below are verbatim copies of what is in the
+notebooks; if one of these tests fails, the extraction changed a fitted feature.
+
+Also pinned: the property the forward recursion exists for. `predict_proba` is smoothed,
+so the value it gives for time t moves when observations after t arrive; the filtered
+value must not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hmmlearn.hmm import GaussianHMM
+
+from case_studies.utils.temporal import (
+    filtered_state_probs,
+    fit_hmm_kmeans_init,
+    relabel_states,
+    sort_states_by_mean,
+    sort_states_by_variance,
+)
+
+# ---------------------------------------------------------------------------
+# Verbatim copies of what the notebooks run today.
+# ---------------------------------------------------------------------------
+
+
+def _notebook_compute_filtered_probs(model, X):
+    """case_studies/etfs and cme_futures 04_model_based_features, unchanged."""
+    framelogprob = model._compute_log_likelihood(X)
+    n_samples = X.shape[0]
+    n_components = model.n_components
+    log_startprob = np.log(model.startprob_ + 1e-300)
+    log_transmat = np.log(model.transmat_ + 1e-300)
+    fwdlattice = np.zeros((n_samples, n_components))
+    fwdlattice[0] = log_startprob + framelogprob[0]
+    for t in range(1, n_samples):
+        for j in range(n_components):
+            fwdlattice[t, j] = framelogprob[t, j] + np.logaddexp.reduce(
+                fwdlattice[t - 1] + log_transmat[:, j]
+            )
+    log_normalizer = np.logaddexp.reduce(fwdlattice, axis=1, keepdims=True)
+    return np.exp(fwdlattice - log_normalizer)
+
+
+def _notebook_sort_states_by_variance(model):
+    """case_studies/etfs and crypto_perps_funding, unchanged; fx_pairs inlines it."""
+    variances = np.array([np.trace(model.covars_[k]) for k in range(model.n_components)])
+    return np.argsort(variances)
+
+
+def _notebook_sort_states_by_carry(model):
+    """case_studies/cme_futures, unchanged."""
+    means = np.array([float(model.means_[k][0]) for k in range(model.n_components)])
+    return np.argsort(means)
+
+
+def _notebook_relabel_states(states, probs, order):
+    """case_studies/etfs, unchanged."""
+    inv_order = np.argsort(order)
+    return inv_order[states], probs[:, order]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a two-regime series, and a model fitted on it.
+# ---------------------------------------------------------------------------
+
+
+def _series(n: int = 400, n_features: int = 1, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    calm = rng.normal(0.0, 0.4, (n // 2, n_features))
+    stressed = rng.normal(0.6, 2.0, (n - n // 2, n_features))
+    return np.vstack([calm, stressed, calm])
+
+
+@pytest.fixture(scope="module")
+def fitted() -> tuple[GaussianHMM, np.ndarray]:
+    X = _series()
+    model = GaussianHMM(n_components=2, covariance_type="full", n_iter=50, random_state=0)
+    model.fit(X)
+    return model, X
+
+
+# ---------------------------------------------------------------------------
+# filtered_state_probs
+# ---------------------------------------------------------------------------
+
+
+def test_filtered_state_probs_matches_the_notebook_recursion(fitted) -> None:
+    model, X = fitted
+    np.testing.assert_array_equal(
+        filtered_state_probs(model, X), _notebook_compute_filtered_probs(model, X)
+    )
+
+
+def test_filtered_state_probs_rows_are_a_distribution(fitted) -> None:
+    model, X = fitted
+    probs = filtered_state_probs(model, X)
+    assert probs.shape == (X.shape[0], model.n_components)
+    np.testing.assert_allclose(probs.sum(axis=1), 1.0)
+    assert (probs >= 0).all()
+
+
+def test_filtered_state_probs_does_not_move_when_later_observations_arrive(fitted) -> None:
+    """The property the recursion exists for: no value depends on its own future."""
+    model, X = fitted
+    prefix = filtered_state_probs(model, X[:200])
+    full = filtered_state_probs(model, X)
+    np.testing.assert_allclose(prefix, full[:200])
+
+
+def test_predict_proba_does_move_when_later_observations_arrive(fitted) -> None:
+    """The reason `predict_proba` may not be used as the feature."""
+    model, X = fitted
+    prefix = model.predict_proba(X[:200])
+    full = model.predict_proba(X)
+    assert not np.allclose(prefix, full[:200]), "smoothed and filtered would be the same quantity"
+
+
+# ---------------------------------------------------------------------------
+# State ordering
+# ---------------------------------------------------------------------------
+
+
+def test_sort_states_by_variance_matches_the_notebook_rule(fitted) -> None:
+    model, _ = fitted
+    np.testing.assert_array_equal(
+        sort_states_by_variance(model), _notebook_sort_states_by_variance(model)
+    )
+
+
+def test_sort_states_by_variance_puts_the_calm_state_first(fitted) -> None:
+    model, _ = fitted
+    order = sort_states_by_variance(model)
+    dispersion = [np.trace(model.covars_[k]) for k in order]
+    assert dispersion == sorted(dispersion)
+
+
+def test_sort_states_by_mean_matches_the_notebook_rule(fitted) -> None:
+    model, _ = fitted
+    np.testing.assert_array_equal(sort_states_by_mean(model), _notebook_sort_states_by_carry(model))
+
+
+def test_relabel_states_matches_the_notebook_helper(fitted) -> None:
+    model, X = fitted
+    probs = filtered_state_probs(model, X)
+    states = probs.argmax(axis=1)
+    order = sort_states_by_variance(model)
+    shared = relabel_states(states, probs, order)
+    notebook = _notebook_relabel_states(states, probs, order)
+    np.testing.assert_array_equal(shared[0], notebook[0])
+    np.testing.assert_array_equal(shared[1], notebook[1])
+
+
+def test_relabel_states_is_the_identity_under_an_ordering_that_changes_nothing(fitted) -> None:
+    model, X = fitted
+    probs = filtered_state_probs(model, X)
+    states = probs.argmax(axis=1)
+    relabelled, reordered = relabel_states(states, probs, np.arange(model.n_components))
+    np.testing.assert_array_equal(relabelled, states)
+    np.testing.assert_array_equal(reordered, probs)
+
+
+# ---------------------------------------------------------------------------
+# fit_hmm_kmeans_init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_features", [1, 3])
+def test_kmeans_covariance_widening_reproduces_both_notebook_expressions(n_features) -> None:
+    """The one line the two notebook copies differ on.
+
+    etfs writes ``np.cov(cluster.T)`` and cme_futures writes ``np.cov(cluster.T).reshape(1, 1)``,
+    because np.cov of a single-feature cluster returns a 0-d array. ``np.atleast_2d`` is
+    each of them in its own case, which is what lets one helper serve both.
+    """
+    cluster = _series(n=60, n_features=n_features, seed=1)
+    shared = np.atleast_2d(np.cov(cluster.T))
+    if n_features == 1:
+        np.testing.assert_array_equal(shared, np.cov(cluster.T).reshape(1, 1))
+    else:
+        np.testing.assert_array_equal(shared, np.cov(cluster.T))
+    assert shared.shape == (n_features, n_features)
+
+
+@pytest.mark.parametrize("n_features", [1, 3])
+def test_fit_hmm_kmeans_init_returns_a_fitted_model_of_the_right_shape(n_features) -> None:
+    X = _series(n_features=n_features)
+    model = fit_hmm_kmeans_init(X, n_states=2, random_state=42)
+    assert model.means_.shape == (2, n_features)
+    assert model.covars_.shape == (2, n_features, n_features)
+    np.testing.assert_allclose(model.transmat_.sum(axis=1), 1.0)
+    assert filtered_state_probs(model, X).shape == (X.shape[0], 2)
+
+
+def test_fit_hmm_kmeans_init_separates_the_two_regimes() -> None:
+    X = _series()
+    model = fit_hmm_kmeans_init(X, n_states=2, random_state=42)
+    calm, stressed = sort_states_by_variance(model)
+    assert np.trace(model.covars_[calm]) < np.trace(model.covars_[stressed])

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -436,7 +436,15 @@ def validate_features(
     feature_cols: Sequence[str],
     max_abs_value: float = 1e6,
 ) -> list[str]:
-    """Check feature columns for infinities, all-null, and extreme values.
+    """Check feature columns for infinities, absent values, and extreme values.
+
+    A NaN counts as absent here, not as a number. Polars evaluates ``NaN > x`` as
+    True, so a feature carrying the warm-up head every rolling window leaves would
+    otherwise be reported as holding values above ``max_abs_value``: a 252-session
+    warm-up over 30 products reported 7,560 extreme values for a Shannon entropy
+    bounded well below ten. Reading it the other way round also matters - a column
+    that is entirely NaN carries no value at all, and was previously reported as
+    neither absent nor extreme.
 
     Args:
         df: DataFrame containing feature columns
@@ -446,41 +454,44 @@ def validate_features(
     Returns list of warning/error strings.
     """
     issues: list[str] = []
-    n_rows = df.height
 
     inf_cols = []
-    null_cols = []
+    absent_cols = []
     extreme_cols = []
 
     for col in feature_cols:
         if col not in df.columns:
             continue
 
-        series = df[col]
-        n_null = series.null_count()
-        non_null = series.drop_nulls()
+        present = df[col].drop_nulls()
+        is_float = present.dtype.is_float()
+        if is_float:
+            present = present.filter(present.is_not_nan())
 
-        if n_null == n_rows:
-            null_cols.append(col)
+        if present.len() == 0:
+            absent_cols.append(col)
             continue
 
-        if non_null.len() > 0:
-            n_inf = non_null.filter(non_null.is_infinite()).len()
+        if is_float:
+            n_inf = present.filter(present.is_infinite()).len()
             if n_inf > 0:
                 inf_cols.append((col, n_inf))
+            # The three conditions are reported separately, so an infinity is not
+            # also counted among the finite values that ran large.
+            present = present.filter(present.is_finite())
 
-            n_extreme = non_null.filter(non_null.abs() > max_abs_value).len()
-            if n_extreme > 0:
-                extreme_cols.append((col, n_extreme))
+        n_extreme = present.filter(present.abs() > max_abs_value).len()
+        if n_extreme > 0:
+            extreme_cols.append((col, n_extreme))
 
     if inf_cols:
         details = ", ".join(f"{c}({n})" for c, n in inf_cols[:10])
         issues.append(f"CRITICAL: {len(inf_cols)} features have infinite values: {details}")
 
-    if null_cols:
+    if absent_cols:
         issues.append(
-            f"WARNING: {len(null_cols)} features are entirely null: "
-            f"{null_cols[:10]}{'...' if len(null_cols) > 10 else ''}"
+            f"WARNING: {len(absent_cols)} features carry no value, null or NaN throughout: "
+            f"{absent_cols[:10]}{'...' if len(absent_cols) > 10 else ''}"
         )
 
     if extreme_cols:


### PR DESCRIPTION
Three shared helpers the case-study stages depend on, fixed once rather than nine times.

Stages 03 and 04 dispatch nine agents onto one shared branch, and the only collision that
design has is two agents editing the same shared file. Three rows of those stages'
checklists are shared-helper work, so they land here first.

## `validate_features` read a NaN as a number

Polars evaluates `NaN > x` as True, so the warm-up head every rolling window leaves was
counted as a value above the threshold. On `case_studies/cme_futures` the data-quality gate
printed

```
WARNING: 5 features have values |x| > 1e+06: fft_spectral_energy(7560),
fft_dominant_period(7560), fft_spectral_entropy(7560), fft_energy_63d(7560),
fft_energy_126d(7560)
```

for five columns whose maximum is 4.77 - a Shannon entropy over a 252-point spectrum. 7,560
is the 252-session warm-up across 30 products. Measured on that artifact, the gate goes from
five warnings to none.

A NaN now counts as absent, which the function had no reading of at all: an all-NaN column
was reported as neither absent nor extreme, and now reports as carrying no value. The three
conditions are also disjoint - an infinity is no longer counted a second time among the
finite values that ran large.

Six notebooks call `validate_modeling_inputs` and each prints a count that moves.
`cme_futures/05_evaluation` additionally carries a paragraph telling the reader to read that
line as a null count; it is left in place here, because its committed output still shows the
warning, and it goes with that notebook's re-run.

## Two shared stage-03 figures did not show their claims

`plot_coverage_through_time` scaled its floor to the data and pinned its ceiling at 1.0005.
The stage-03 notebooks pass the panel *before* the null policy, so every family starts at
zero and the axis spans (-0.022, 1.0005) - the dense stretch sits a twentieth of one percent
below the top, drawn under the spine. The figure titled "Each family fills as its longest
window does, and never thins again" showed the filling and not the never-thinning. The
ceiling now scales with the range as the floor does; an already-dense frame still zooms, and
a test pins that.

`plot_persistence` gave a full lag axis and a three-bar 0-1 chart equal columns, so the panel
the prose reads off rendered at about a quarter of the figure with a band of white beside it.
Now `width_ratios=[2, 1]` with default padding.

Its right-hand x-axis label ran off the figure and was cut to "consecutive rebala". With
feature names of the length the case studies use, one centred line overhangs by 60px and
wrapping alone still overhangs by 12px - the feature names are that panel's y-tick labels and
they decide how much width the label has left. It is now wrapped and anchored to the panel's
right edge, growing into the gap between panels instead: 17px inside the figure, independent
of name length.

No number moves. The eight stage-03 notebooks re-render as each is re-run.

## `case_studies/utils/temporal.py` now exists

The stage-04 standard requires it and it had never been created, so every notebook carried
its own copy. What lands here is the half that is pure extraction:

| helper | replaced |
|---|---|
| `filtered_state_probs` | six near-verbatim copies of the forward algorithm |
| `sort_states_by_variance` | identical in etfs and crypto, inline in fx_pairs |
| `sort_states_by_mean` | cme_futures' `sort_states_by_carry` |
| `relabel_states` | etfs |
| `fit_hmm_kmeans_init` | etfs and cme_futures |

`tests/test_temporal.py` keeps the notebook implementations beside the shared ones and
asserts equality, so the extraction provably moves no number. Beyond that it pins the
property the forward recursion exists for: the filtered value at `t` does not change when
observations after `t` arrive, and `predict_proba` on the same model does.

`model._compute_log_likelihood` is a private hmmlearn API called from six sites and
documented at three. It is now called once.

Two defects found by the pre-push review and fixed here, both in claims this branch's own
docstrings made: a one-observation k-means cluster gave a covariance of NaN rather than the
positive-definite matrix the ridge was said to guarantee, which `fit` does not survive and
which the notebooks share; and the migration note named `score_samples` as the replacement
for the private call, which returns the smoothed posterior and not the per-state emission
log-density.

**Three helpers the standard lists are deliberately absent** - `fit_then_filter_garch`,
`write_model_based`, `validation_only_slice`. None is an extraction: each changes what some
notebooks emit, so each belongs with the notebook re-run that records `old -> new -> cause`.
Rewiring the eight notebooks onto the helpers that are here is likewise per case study.

## CI

All three test files are added to `test-unit`, a required check. They were in the state this
workflow's own comments describe twice - covering a contract that no job invokes.
`tests/test_data_quality.py` had never been run by CI at all. `matplotlib` and `hmmlearn`
join the minimal environment; neither pulls torch or an `ml4t-*` package.
