### PR TITLE
Shared figure, render and gate fixes from the stage-03 escalations

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -334,7 +334,33 @@ def stamped_at(ref: str = "HEAD") -> set[str]:
     return {line[len(prefix) :] for line in result.stdout.splitlines() if line.startswith(prefix)}
 
 
-def destamped(ref: str = "HEAD") -> list[str]:
+def stamp_reference(base_branch: str = "main") -> str:
+    """The commit a stamp must not have disappeared since.
+
+    Not ``HEAD``. Comparing the working tree with ``HEAD`` catches a removal that has
+    not been committed yet and nothing else: once it is committed both sides are
+    unstamped, and the check goes quiet exactly where it is needed, which is CI
+    reading a pushed branch. The fork point from the base branch makes the question
+    "did this branch drop a stamp", and answers it the same way in the pre-commit
+    hook, in CI, and days later.
+
+    Falls back to ``HEAD`` when there is no base branch to fork from - a fresh clone
+    with no remote, or work on ``main`` itself, where the fork point IS ``HEAD``.
+    """
+    for ref in (f"origin/{base_branch}", base_branch):
+        merge_base = subprocess.run(
+            ["git", "merge-base", "HEAD", ref],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if merge_base.returncode == 0 and merge_base.stdout.strip():
+            return merge_base.stdout.strip()
+    return "HEAD"
+
+
+def destamped(ref: str | None = None) -> list[str]:
     """Notebooks stamped at *ref* and unstamped now.
 
     The gate says nothing about a notebook with no stamp, which is deliberate - the
@@ -347,7 +373,7 @@ def destamped(ref: str = "HEAD") -> list[str]:
     """
     return sorted(
         rel
-        for rel in stamped_at(ref)
+        for rel in stamped_at(ref or stamp_reference())
         if (REPO_ROOT / rel).exists()
         and not json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
         .get("metadata", {})
@@ -409,7 +435,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
     lost = destamped()
     fail = bool(stale or testmode or contradicted or lost) or (args.strict and bool(unverified))
     if lost:
-        print("DE-STAMPED (had a provenance stamp at HEAD and does not now):")
+        print("DE-STAMPED (carried a provenance stamp where this branch forked, and does not now):")
         for r in lost:
             print(f"  {r}")
     if stale:

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -317,6 +317,44 @@ def stamp_notebook(
     return stamp
 
 
+def stamped_at(ref: str = "HEAD") -> set[str]:
+    """Repo-relative notebooks whose committed version at *ref* carries a stamp.
+
+    One `git grep` over the tree rather than a read per notebook, because the answer
+    is needed for every unstamped file and there are several hundred of them.
+    """
+    result = subprocess.run(
+        ["git", "grep", "-l", f'"{STAMP_KEY}"', ref, "--", "*.ipynb"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    prefix = f"{ref}:"
+    return {line[len(prefix) :] for line in result.stdout.splitlines() if line.startswith(prefix)}
+
+
+def destamped(ref: str = "HEAD") -> list[str]:
+    """Notebooks stamped at *ref* and unstamped now.
+
+    The gate says nothing about a notebook with no stamp, which is deliberate - the
+    corpus is being stamped as notebooks are re-run, and failing the ones that have
+    not been yet would fail hundreds of teaching notebooks that are not the subject.
+    The hole that leaves is that DROPPING a stamp turns the check off for that file
+    instead of failing it, which is the same shape as a review that passes because
+    it never looked. A stamp is only ever added, so a notebook that had one and does
+    not is a regression whatever removed it.
+    """
+    return sorted(
+        rel
+        for rel in stamped_at(ref)
+        if (REPO_ROOT / rel).exists()
+        and not json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
+        .get("metadata", {})
+        .get(STAMP_KEY)
+    )
+
+
 def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str], list[str]]:
     """Return (stale, testmode, contradicted, unverified) repo-relative offenders."""
     stale: list[str] = []
@@ -368,7 +406,12 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 def _cmd_check(args: argparse.Namespace) -> int:
     stale, testmode, contradicted, unverified = check_all(strict=args.strict)
-    fail = bool(stale or testmode or contradicted) or (args.strict and bool(unverified))
+    lost = destamped()
+    fail = bool(stale or testmode or contradicted or lost) or (args.strict and bool(unverified))
+    if lost:
+        print("DE-STAMPED (had a provenance stamp at HEAD and does not now):")
+        for r in lost:
+            print(f"  {r}")
     if stale:
         print(
             "STALE (paired .py changed since the notebook was executed — re-run in the canonical env):"

--- a/.github/scripts/render_notebook.py
+++ b/.github/scripts/render_notebook.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""Render an executed notebook to standalone HTML, keeping the figures' alt text.
+
+    uv run .github/scripts/render_notebook.py case_studies/etfs/03_financial_features.ipynb \
+        --out-dir ~/ml4t/review
+
+`jupyter nbconvert --to html` uses the `lab` template, which reads width, height and
+the background hints out of an output's `image/png` metadata and never reads `alt`.
+`utils.style.show_with_alt` stores the description exactly where a renderer should
+look for it, and `HTMLExporter` then replaces every missing alt with "No description
+has been provided for this image". So every figure description written for this book
+was accurate, stored correctly, and absent from the page.
+
+This selects the repo's `ml4t` template, which is the `lab` template with those two
+image blocks overridden, and reports how many images carry a real description. That
+count is the check: a notebook whose figures all went through `show_with_alt` should
+report zero missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_BASEDIR = REPO_ROOT / ".jupyter" / "nbconvert_templates"
+TEMPLATE_NAME = "ml4t"
+PLACEHOLDER = "No description has been provided for this image"
+
+
+def render(notebook: Path, out_dir: Path, name: str | None) -> Path:
+    import nbformat
+    from nbconvert import HTMLExporter
+
+    # Both go to the constructor. `extra_template_basedirs` is `affects_environment`,
+    # and the template is resolved during __init__, so assigning it afterwards is too
+    # late and the repo template is not found.
+    exporter = HTMLExporter(
+        template_name=TEMPLATE_NAME, extra_template_basedirs=[str(TEMPLATE_BASEDIR)]
+    )
+
+    body, _ = exporter.from_notebook_node(
+        nbformat.read(notebook, as_version=4),
+        resources={"metadata": {"path": str(notebook.parent)}},
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{name or notebook.stem}.html"
+    out_path.write_text(body, encoding="utf-8")
+    return out_path
+
+
+def report_alt_coverage(html: str) -> tuple[int, int]:
+    """Return (images carrying a description, images carrying the placeholder)."""
+    from bs4 import BeautifulSoup
+
+    images = BeautifulSoup(html, features="html.parser").select("img")
+    missing = sum(1 for img in images if img.attrs.get("alt", PLACEHOLDER) == PLACEHOLDER)
+    return len(images) - missing, missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("notebook", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path.home() / "ml4t" / "review")
+    parser.add_argument(
+        "--name",
+        help="output stem; defaults to the notebook's, so pass <case_study>_<notebook> "
+        "when rendering nine notebooks that share a name into one directory",
+    )
+    args = parser.parse_args()
+
+    out_path = render(args.notebook, args.out_dir.expanduser(), args.name)
+    described, missing = report_alt_coverage(out_path.read_text(encoding="utf-8"))
+
+    print(f"{out_path}")
+    print(f"{described} image(s) carry a description, {missing} do not")
+    if missing:
+        print(
+            f"The {missing} without one render as '{PLACEHOLDER}'. Every figure a "
+            "notebook shows should go through utils.style.show_with_alt.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/render_notebook.py
+++ b/.github/scripts/render_notebook.py
@@ -52,11 +52,17 @@ def render(notebook: Path, out_dir: Path, name: str | None) -> Path:
 
 
 def report_alt_coverage(html: str) -> tuple[int, int]:
-    """Return (images carrying a description, images carrying the placeholder)."""
+    """Return (images carrying a description, images carrying none).
+
+    An empty or whitespace-only ``alt`` counts as none. It reaches the page exactly as
+    the placeholder does - a screen reader announces an unlabelled image either way -
+    so counting it would let this report call the coverage complete while the figure
+    is undescribed.
+    """
     from bs4 import BeautifulSoup
 
     images = BeautifulSoup(html, features="html.parser").select("img")
-    missing = sum(1 for img in images if img.attrs.get("alt", PLACEHOLDER) == PLACEHOLDER)
+    missing = sum(1 for img in images if img.attrs.get("alt", "").strip() in ("", PLACEHOLDER))
     return len(images) - missing, missing
 
 

--- a/.jupyter/nbconvert_templates/ml4t/conf.json
+++ b/.jupyter/nbconvert_templates/ml4t/conf.json
@@ -1,0 +1,6 @@
+{
+  "base_template": "lab",
+  "mimetypes": {
+    "text/html": true
+  }
+}

--- a/.jupyter/nbconvert_templates/ml4t/index.html.j2
+++ b/.jupyter/nbconvert_templates/ml4t/index.html.j2
@@ -1,0 +1,80 @@
+{% extends 'lab/index.html.j2' %}
+
+{#
+  The `lab` template reads width, height and the background hints out of an output's
+  `image/png` metadata and never reads `alt`, so the description
+  `utils.style.show_with_alt` stores there is dropped on export. `HTMLExporter` then
+  fills every `<img>` that has no alt with "No description has been provided for this
+  image", which is what the rendered page has been saying for every figure in the book.
+
+  These two blocks are `lab/base.html.j2`'s, with the alt attribute added. Nothing else
+  differs, so a figure with no alt text renders exactly as it did before.
+#}
+
+{% block data_png scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/png' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/png'] | posix_path | escape_html }}"
+{%- else %}
+<img src="data:image/png;base64,{{ output.data['image/png'] | escape_html }}"
+{%- endif %}
+{%- set alt=output | get_metadata('alt', 'image/png') -%}
+{%- if alt is not none %}
+alt="{{ alt | escape_html }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/png') -%}
+{%- if width is not none %}
+width={{ width | escape_html }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/png') -%}
+{%- if height is not none %}
+height={{ height | escape_html }}
+{%- endif %}
+class="
+{%- if output | get_metadata('unconfined', 'image/png') %}
+unconfined
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/png') == 'light' %}
+jp-needs-light-background
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/png') == 'dark' %}
+jp-needs-dark-background
+{%- endif %}
+"
+>
+</div>
+{%- endblock data_png %}
+
+{% block data_jpg scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/jpeg'] | posix_path | escape_html }}"
+{%- else %}
+<img src="data:image/jpeg;base64,{{ output.data['image/jpeg'] | escape_html }}"
+{%- endif %}
+{%- set alt=output | get_metadata('alt', 'image/jpeg') -%}
+{%- if alt is not none %}
+alt="{{ alt | escape_html }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/jpeg') -%}
+{%- if width is not none %}
+width={{ width | escape_html }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/jpeg') -%}
+{%- if height is not none %}
+height={{ height | escape_html }}
+{%- endif %}
+class="
+{%- if output | get_metadata('unconfined', 'image/jpeg') %}
+unconfined
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/jpeg') == 'light' %}
+jp-needs-light-background
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/jpeg') == 'dark' %}
+jp-needs-dark-background
+{%- endif %}
+"
+>
+</div>
+{%- endblock data_jpg %}

--- a/case_studies/utils/feature_engineering.py
+++ b/case_studies/utils/feature_engineering.py
@@ -519,15 +519,16 @@ def family_coverage(
 def _cycle(n: int) -> list[tuple[str, str]]:
     """Colour and line style per series, so more series than hues stay separable.
 
-    The palette has six hues. Beyond that, cycling colour alone puts two series in
-    the same navy and the reader cannot tell which line is which; the style cycles
-    at a different rate, so each pair is distinct.
+    The palette's sixth entry is ``slate``, a second navy that its own definition
+    describes as reading close to ``blue``. Cycling the style once per six put the
+    first and sixth series in near-identical navy, both solid, in the same block -
+    so every stage-03 coverage figure with six or more families drew two of them as
+    one line. The style therefore turns over every *five*, which puts the twin in a
+    different style from the original while still keeping the first five solid.
     """
     styles = ["-", "--", ":", "-."]
-    return [
-        (COLOR_CYCLER[i % len(COLOR_CYCLER)], styles[(i // len(COLOR_CYCLER)) % len(styles)])
-        for i in range(n)
-    ]
+    hues = len(COLOR_CYCLER)
+    return [(COLOR_CYCLER[i % hues], styles[(i // (hues - 1)) % len(styles)]) for i in range(n)]
 
 
 def plot_coverage_through_time(
@@ -769,8 +770,11 @@ def plot_redundancy_clusters(
 ) -> dict[str, int]:
     """F5. Hierarchical clustering on distance :math:`1 - |\\rho|`, with the cut drawn.
 
-    Returns the cluster each column falls in, which is what ``05_evaluation`` needs
-    in order to pick one representative per cluster on a fold-aware criterion.
+    Returns the cluster each column falls in, which the calling notebook uses to state
+    how many distinct orderings its matrix carries. Nothing downstream reads it: the
+    feature screens in ``05_evaluation`` test one column at a time, and the one case
+    study that does pick a representative per cluster builds its own clusters from its
+    own fold ICs rather than from this tree.
     """
     columns = list(columns)
     frame = df.select(columns)
@@ -792,13 +796,19 @@ def plot_redundancy_clusters(
     labels = fcluster(tree, t=height, criterion="distance")
 
     fig, ax = plt.subplots(figsize=(FIGSIZE["single"][0], max(2.4, 0.13 * len(columns) + 1.2)))
-    set_link_color_palette([c for c, _ in _cycle(6)])
+    # Five hues, not six: the sixth is `slate`, a second navy, and a cluster drawn in it
+    # is indistinguishable from one drawn in `blue`. Above the cut the links are the
+    # figure's background - they say only "these two clusters eventually join" - so they
+    # recede to a light slate. They were `neutral`, #334155, which is the same dark
+    # blue-grey as `blue` and `slate` at the same weight, so all three read as one thing
+    # and the cluster structure the figure exists to show was not visible.
+    set_link_color_palette([c for c, _ in _cycle(5)])
     dendrogram(
         tree,
         labels=columns,
         orientation="left",
         color_threshold=height,
-        above_threshold_color=COLORS["neutral"],
+        above_threshold_color=COLORS["recede"],
         ax=ax,
     )
     ax.axvline(height, color=COLORS["amber"], linestyle="--", linewidth=1)
@@ -814,9 +824,18 @@ def plot_redundancy_clusters(
 def _bootstrap_median_interval(
     values: np.ndarray, *, seed: int, draws: int = 500, level: float = 0.95
 ) -> tuple[float, float]:
-    """Percentile bootstrap interval for the median of *values*, resampling entities."""
+    """Percentile bootstrap interval for the median of *values*, resampling entities.
+
+    *values* is sorted first. The median does not care what order it arrives in, but
+    ``rng.choice`` draws by index, so the same entities in a different order give the
+    same seed a different resample and a different interval. The callers read their
+    values out of a ``group_by``, whose row order Polars does not guarantee, so the
+    ribbon moved between runs on byte-identical input - a seed that fixed the sampling
+    and not the ordering (#329, #333).
+    """
     if values.size < 3:
         return float("nan"), float("nan")
+    values = np.sort(values)
     rng = np.random.default_rng(seed)
     medians = np.median(rng.choice(values, size=(draws, values.size), replace=True), axis=1)
     lo, hi = np.quantile(medians, [(1 - level) / 2, (1 + level) / 2])
@@ -927,16 +946,17 @@ def plot_persistence(
     left.set_xlabel("lag (bars)")
     left.set_ylabel("autocorrelation")
     # Below the axes, not inside them. A persistent feature fills the upper half and a
-    # decaying one fills the lower left, so every in-axes position covers either a
-    # curve or the y-axis label depending on the data - which is not something the
-    # caller should have to tune per notebook.
-    left.legend(
-        fontsize=6,
-        ncol=3,
-        loc="upper center",
-        bbox_to_anchor=(0.5, -0.22),
-        frameon=False,
-    )
+    # decaying one fills the lower left, so every in-axes position covers either a curve
+    # or the y-axis label depending on the data - which is not something the caller
+    # should have to tune per notebook.
+    #
+    # It belongs to the FIGURE, not to the left panel. `tight_layout` packs each axes
+    # together with its decorations, and a legend of feature names centred under a
+    # panel is far wider than the panel - so the whole column was sized to the legend
+    # and the axes inside it shrank to whatever was left. Measured on four names of
+    # `premium_vol_ratio_7d_30d` length: the lag panel held 27% of the figure with the
+    # legend attached and 42% without it. A figure legend is outside that packing, so
+    # the space it needs is reserved once, in the `rect` below.
 
     # One cross-sectional rank correlation per consecutive pair of decision dates, then
     # the median over pairs. Pooling every entity-date row into one correlation instead
@@ -971,6 +991,15 @@ def plot_persistence(
     right.barh(range(len(columns)), stability, color=COLORS["blue"], height=0.6)
     right.set_yticks(range(len(columns)))
     right.set_yticklabels(columns, fontsize=6)
+    # Feature names on the OUTER edge. `width_ratios` divides the axes, not the figure,
+    # and these labels are drawn outside the right panel - so on the inner edge they take
+    # their width out of the gap between the panels, and `tight_layout` pays for it by
+    # shrinking both. Names in this corpus run to `premium_vol_ratio_7d_30d`, which left
+    # the autocorrelation panel - the one the prose reads four curves off - at about a
+    # third of the figure. On the outer edge they grow into the right margin, which
+    # nothing else is using.
+    right.yaxis.set_ticks_position("right")
+    right.yaxis.set_label_position("right")
     # The lower bound follows the data and is never clipped at zero: a negative value is
     # rank reversal between rebalances, which is the most interesting thing this panel can
     # show and the one an axis pinned at zero hides.
@@ -985,6 +1014,21 @@ def plot_persistence(
     # between the panels instead, which no case study can exhaust.
     right.set_xlabel("rank correlation,\nconsecutive rebalances", fontsize=8, ha="right", x=1.0)
     add_message_title(left, title, subtitle=subtitle)
-    fig.tight_layout()
+    # The legend is drawn, measured, and only then is the strip it needs reserved. A
+    # guess from the row count leaves a band of dead space under one notebook's figure
+    # and clips another's, because how tall it is depends on the feature names.
+    legend = fig.legend(
+        *left.get_legend_handles_labels(),
+        fontsize=6,
+        ncol=min(3, len(columns)),
+        loc="lower center",
+        bbox_to_anchor=(0.5, 0.0),
+        frameon=False,
+    )
+    fig.canvas.draw()
+    strip = legend.get_window_extent(fig.canvas.get_renderer()).transformed(
+        fig.transFigure.inverted()
+    )
+    fig.tight_layout(rect=(0.0, strip.height + 0.02, 1.0, 1.0))
     show_with_alt(fig, alt)
     return None

--- a/tests/test_feature_engineering_figures.py
+++ b/tests/test_feature_engineering_figures.py
@@ -6,6 +6,14 @@ Pins:
   helper exists for still happens on an already-dense frame.
 - plot_persistence: the left panel is the wider of the two, and the right panel's x-axis
   label is drawn inside the figure rather than cut off at the edge.
+- plot_persistence: the lag panel keeps its width when the feature names are as long as
+  the case studies actually make them.
+- _bootstrap_median_interval: the ribbon is a function of the values, not of the order
+  they arrive in.
+- _cycle: no two series share a colour and a style, and the palette's two navies are
+  never both solid.
+- plot_redundancy_clusters: the links above the cut are separable from every colour a
+  cluster can be drawn in.
 
 All eight 03_financial_features notebooks draw both, so a regression here is a regression
 in eight rendered pages at once.
@@ -118,3 +126,81 @@ def test_persistence_draws_its_right_hand_axis_label_inside_the_figure(captured)
     extent = label.get_window_extent(fig.canvas.get_renderer())
     assert extent.x1 <= fig.bbox.x1, "the label runs off the right edge and is cut mid-word"
     assert extent.x0 >= fig.bbox.x0
+
+
+LONG_NAMES = [
+    "funding_half_life_14d",
+    "premium_quantile_pos_30d",
+    "premium_vol_ratio_7d_30d",
+    "funding_rate_zscore_72h",
+]
+
+
+def test_persistence_keeps_the_lag_panel_wide_under_long_feature_names(captured) -> None:
+    # `tight_layout` packs each axes together with its decorations. A legend of feature
+    # names centred under the left panel is much wider than that panel, so the column was
+    # sized to the legend and the axes shrank into what was left - measured at 27% of the
+    # figure for the lag panel against 43% with the legend owned by the figure instead.
+    # crypto_perps_funding, whose names are these lengths, reported it as both panels
+    # squeezed into the left half.
+    panel, columns, schedule = _panel(columns=LONG_NAMES)
+    fe.plot_persistence(
+        panel, columns, entity="symbol", max_lag=10, decision_dates=schedule, title="t", alt="a"
+    )
+    (fig,) = captured
+    lag_panel = fig.axes[0].get_position().width
+    assert lag_panel > 0.40, (
+        f"the lag panel holds {lag_panel:.0%} of the figure width; something anchored to "
+        "the axes is being packed with them"
+    )
+
+
+def test_bootstrap_interval_does_not_depend_on_the_order_of_its_values() -> None:
+    # The callers read these out of a `group_by`, whose row order Polars does not
+    # guarantee, and `rng.choice` draws by index. So the same entities in a different
+    # order gave the same seed a different ribbon, and F6 moved on every re-run (#329).
+    values = np.array([0.9, 0.1, 0.55, 0.42, 0.7, 0.33, 0.61, 0.28, 0.84, 0.05, 0.5, 0.47])
+    first = fe._bootstrap_median_interval(values, seed=42)
+    assert first == fe._bootstrap_median_interval(values[::-1], seed=42)
+    assert first == fe._bootstrap_median_interval(
+        np.random.default_rng(7).permutation(values), seed=42
+    )
+
+
+def test_cycle_never_draws_two_series_the_same_way() -> None:
+    # Six hues over four styles is 24 combinations, but the styles turn over every five
+    # so that the palette's two navies never share one - which costs the last few. Twenty
+    # is well past what any coverage figure in the corpus needs; the most is eleven.
+    assert len(set(fe._cycle(20))) == 20
+
+
+def test_cycle_separates_the_palettes_two_navies() -> None:
+    # COLOR_CYCLER's sixth entry is `slate`, which its own definition says reads close to
+    # `blue`, the first. They are one line to a reader unless something else parts them.
+    from utils.style import COLORS
+
+    styles = {color: style for color, style in fe._cycle(6)}
+    assert styles[COLORS["blue"]] != styles[COLORS["slate"]]
+
+
+def test_redundancy_clusters_draw_above_the_cut_unlike_any_cluster() -> None:
+
+    from matplotlib.colors import to_rgb
+
+    from utils.style import COLORS
+
+    def distance(a: str, b: str) -> float:
+        return float(np.linalg.norm(np.array(to_rgb(a)) - np.array(to_rgb(b))))
+
+    # Everything below the cut is a cluster and carries meaning; everything above it is
+    # background. The background was `neutral`, #334155, which sits 0.13 away from `slate`
+    # and 0.29 from `blue` - so the links above the cut, a navy cluster and a slate cluster
+    # were one indistinguishable mass, and the structure the figure exists to show was not
+    # visible. The palette is five hues for the same reason: the sixth is that second navy.
+    cluster_colors = [color for color, _ in fe._cycle(5)]
+    assert len(set(cluster_colors)) == 5
+    assert COLORS["slate"] not in cluster_colors
+
+    for color in cluster_colors:
+        gap = distance(COLORS["recede"], color)
+        assert gap > 0.35, f"background {COLORS['recede']} sits {gap:.2f} from cluster {color}"

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -36,6 +36,7 @@ import notebook_provenance  # noqa: E402
 from notebook_provenance import (  # noqa: E402
     check_all,
     contradicts_injected_cell,
+    destamped,
     injected_parameters,
     production_parameters,
     stamp_notebook,
@@ -253,4 +254,19 @@ def test_stamped_notebooks_are_current_and_production() -> None:
             if contradicted
             else ""
         )
+    )
+
+
+def test_no_notebook_loses_a_provenance_stamp_it_already_had() -> None:
+    """The hole in "unstamped notebooks are not failed here".
+
+    Not failing an unstamped notebook is deliberate, and it means dropping a stamp
+    switches this gate off for that file rather than failing it - a gate that passes
+    because its subject is absent, which is the shape the September sign-offs had.
+    fx_pairs lost its stamp twice during stage 03 before anything said so. Stamps are
+    only ever added, so a notebook stamped at HEAD and unstamped now is a regression.
+    """
+    lost = destamped()
+    assert not lost, "these notebooks had a provenance stamp at HEAD and do not now:\n    " + (
+        "\n    ".join(lost)
     )

--- a/utils/style.py
+++ b/utils/style.py
@@ -53,6 +53,7 @@ COLORS = {
     "positive": "#10b981",  # Success green - profits, gains
     "negative": "#ef4444",  # Error red - losses (use sparingly!)
     "neutral": "#334155",  # Slate gray - neutral elements
+    "recede": "#94a3b8",  # Light slate - structure that must not compete with the data
     # Backgrounds
     "bg_light": "#FAFAF9",  # Warm off-white (light mode)
     "bg_dark": "#0a1628",  # Deep blue (dark mode)


### PR DESCRIPTION
Nine panes finished stage 03 of the case studies, and each one ended with items it had found and
was not allowed to fix: shared drawing code, the render path, a gate. Deduplicated, the twenty-odd
reports are twelve problems. This lands the eight that live in this repo.

### The two figures every stage-03 notebook draws

`plot_persistence`'s legend belonged to the left panel. `tight_layout` packs each axes together with
its decorations, so the column was sized to a legend of feature names much wider than the panel and
the axes shrank into what was left. On four names of `premium_vol_ratio_7d_30d` length the
autocorrelation panel - the one the prose reads four curves off - held **27%** of the figure. The
legend now belongs to the figure and is measured before the strip it needs is reserved; **43%**. The
right panel's feature names move to its outer edge, which empties the band of white between the
panels instead of taking it out of both.

Its bootstrap ribbon moved on every re-run (#329, reopened after a seed fix that did not hold).
`_bootstrap_median_interval` seeds the RNG, but `rng.choice` draws by index and the values arrive
from a `group_by` whose row order Polars does not guarantee. Same values, same seed, different
order: `(0.33, 0.66)` against `(0.28, 0.66)`. Sorting first makes the interval a function of the
multiset, in the estimator, so no call site has to remember `maintain_order`.

`plot_redundancy_clusters` drew above-cut links in `neutral` #334155, which sits 0.13 in RGB from
`slate` and 0.29 from `blue` - background, a slate cluster and a navy cluster as one mass. And its
docstring said the returned labels are what `05_evaluation` uses to pick a representative per
cluster; no `05_evaluation` reads them.

`_cycle` turned the style over every six, so series 1 and series 6 were both solid navy in the same
block - two families drawn as one line in every coverage figure with six or more (#320).

### Alt text (#352)

`show_with_alt` stores a figure's description in `metadata["image/png"]["alt"]`. nbconvert's `lab`
template reads `width`, `height` and the background hints from that same metadata and never reads
`alt`, so `HTMLExporter` filled every image with "No description has been provided for this image".
Measured on an unmodified notebook: 6 placeholders before, 6 real descriptions after. Every figure
description written for this book was accurate, stored correctly, and absent from the page.

`.jupyter/nbconvert_templates/ml4t` is the `lab` template with two image blocks overridden;
`.github/scripts/render_notebook.py` selects it and prints how many images carry a description, so a
figure that bypassed `show_with_alt` is visible at render time.

### A gate that passed because its subject was absent

The sync gate does not fail an unstamped notebook, deliberately. The hole is that *dropping* a stamp
switched the gate off for that file rather than failing it; fx_pairs lost its stamp twice during
stage 03 and nothing said so. Stamps are only ever added, so a notebook stamped at the branch's fork
point and unstamped now is a regression.

### Tests

`tests/test_feature_engineering_figures.py` gains five, each reproducing one of the above.
`tests/test_notebook_sync.py` gains the de-stamp regression. 109 passed across the helper,
leakage and holdout blocks.

The push gate's own review caught two holes in this branch and both are fixed in `7edfaa1b`: the
de-stamp check compared against `HEAD`, which goes quiet once the removal is committed, and blank
alt text counted as a description.
