### PR TITLE
Six series get six colours: unify the palette across all four places it is ordered

### DIFF
--- a/case_studies/utils/feature_engineering.py
+++ b/case_studies/utils/feature_engineering.py
@@ -519,16 +519,19 @@ def family_coverage(
 def _cycle(n: int) -> list[tuple[str, str]]:
     """Colour and line style per series, so more series than hues stay separable.
 
-    The palette's sixth entry is ``slate``, a second navy that its own definition
-    describes as reading close to ``blue``. Cycling the style once per six put the
-    first and sixth series in near-identical navy, both solid, in the same block -
-    so every stage-03 coverage figure with six or more families drew two of them as
-    one line. The style therefore turns over every *five*, which puts the twin in a
-    different style from the original while still keeping the first five solid.
+    The style turns over once per full pass through the palette, so the first six
+    series are told apart by hue alone and only a seventh onwards needs a dash to
+    part it from the series six earlier.
+
+    It used to turn over every *five*. ``COLOR_CYCLER``'s sixth entry was ``slate``,
+    a second navy, so a solid first and a solid sixth series were one line, and
+    parting them by style was the only lever this helper had. The palette now ends
+    in ``recede``, which is a hue away from navy in colour and in gray, so the
+    workaround is gone and with it the combinations it cost.
     """
     styles = ["-", "--", ":", "-."]
     hues = len(COLOR_CYCLER)
-    return [(COLOR_CYCLER[i % hues], styles[(i // (hues - 1)) % len(styles)]) for i in range(n)]
+    return [(COLOR_CYCLER[i % hues], styles[(i // hues) % len(styles)]) for i in range(n)]
 
 
 def plot_coverage_through_time(
@@ -730,6 +733,7 @@ def plot_timing_contract(
     ax.set_yticklabels([f.name for f in reversed(families)], fontsize=7)
     ax.axvline(0, color=COLORS["negative"], linewidth=1)
     ax.set_xlabel(f"{bar_unit} before the decision timestamp")
+    legend = None
     if any(f.lag for f in families):
         ax.barh(
             0,
@@ -741,11 +745,34 @@ def plot_timing_contract(
             linewidth=0.8,
             label="published but not yet available",
         )
-        ax.legend(fontsize=7, frameon=False, loc="lower left")
+        # Below the axes, and owned by the figure. Inside them at the bottom left it
+        # sat on the last family's bar - the register declares the families and the
+        # axes grow one row per family, so the more a case study declares the further
+        # the bottom row reaches under the legend, and at the eight of
+        # us_firm_characteristics and cme_futures the entry crossed the `interaction`
+        # bar and touched the tick labels under it. There is no in-axes corner that is
+        # safe here: a lag bar can reach any of them, because which families are
+        # lagged and how far is exactly what the figure is drawn to show.
+        legend = fig.legend(
+            *ax.get_legend_handles_labels(),
+            fontsize=7,
+            frameon=False,
+            loc="lower center",
+            bbox_to_anchor=(0.5, 0.0),
+        )
+    # A strip under the bottom row that belongs to the "decision" label and to nothing
+    # else, and the label anchored to the axes' floor rather than to a data coordinate
+    # guessed once. At -0.45 it was inside the bottom row's bar - which spans 0.55 - so
+    # it was drawn over the last family's lookback and its lag hatch, the same thing the
+    # legend was doing a few lines above and in the same corner. How far the label
+    # reached into the bar varied with the family count, because that sets the axes
+    # height and so what 7pt is worth in data units.
+    ax.set_ylim(-1.0, len(families) - 0.5)
     ax.annotate(
         "decision",
-        xy=(0, -0.45),
-        xytext=(-3, 0),
+        xy=(0, 0),
+        xycoords=ax.get_xaxis_transform(),
+        xytext=(-3, 3),
         textcoords="offset points",
         ha="right",
         va="bottom",
@@ -753,7 +780,17 @@ def plot_timing_contract(
         color=COLORS["negative"],
     )
     add_message_title(ax, title, subtitle=subtitle)
-    fig.tight_layout()
+    # The strip the legend needs is measured after it is drawn, not guessed from the
+    # entry count, so a longer label cannot clip and a shorter one cannot leave a band
+    # of dead space. Same reservation `plot_persistence` makes for its own legend.
+    if legend is not None:
+        fig.canvas.draw()
+        strip = legend.get_window_extent(fig.canvas.get_renderer()).transformed(
+            fig.transFigure.inverted()
+        )
+        fig.tight_layout(rect=(0.0, strip.height + 0.02, 1.0, 1.0))
+    else:
+        fig.tight_layout()
     show_with_alt(fig, alt)
 
 
@@ -884,6 +921,20 @@ def plot_persistence(
     # ago", which is a different date for every entity and crosses any stretch the
     # entity was absent for - after an eligibility gate, by months or years.
     dates = frame[time].unique().sort()
+    # Both lag maps below are built from Python objects and handed to
+    # `replace_strict`, which types its output from the values it was given, not from
+    # the column it replaces. A Python `datetime` carries microseconds, so on a panel
+    # stamped in anything else the new column came back `datetime[us]` and the join
+    # that follows failed outright:
+    #
+    #   SchemaError: `_then`: datetime[us, UTC] does not match `_then`: datetime[ms, UTC]
+    #
+    # Binance stamps in milliseconds, so the whole crypto_perps_funding pipeline is
+    # `datetime[ms]` and this figure could not be drawn for it at all; its notebook
+    # cast the frame it passed here and nothing else, which fixes one caller and
+    # leaves the helper broken for the next. Pinning the return type to the column's
+    # own dtype fixes it for every panel, at whatever precision it is stamped in.
+    when = frame.schema[time]
     acf: dict[str, list[float]] = {c: [] for c in columns}
     lower: dict[str, list[float]] = {c: [] for c in columns}
     upper: dict[str, list[float]] = {c: [] for c in columns}
@@ -891,7 +942,7 @@ def plot_persistence(
     for lag in lags:
         back = dict(zip(dates[lag:].to_list(), dates[: -int(lag)].to_list(), strict=True))
         pairs = frame.with_columns(
-            pl.col(time).replace_strict(back, default=None).alias("_then")
+            pl.col(time).replace_strict(back, default=None, return_dtype=when).alias("_then")
         ).join(
             frame.select(
                 *keys,
@@ -977,7 +1028,9 @@ def plot_persistence(
             time, *keys, pl.col(column).rank().over(time).alias("_r")
         ).drop_nulls()
         joined = (
-            ranked.with_columns(pl.col(time).replace_strict(step, default=None).alias("_prev"))
+            ranked.with_columns(
+                pl.col(time).replace_strict(step, default=None, return_dtype=when).alias("_prev")
+            )
             .join(
                 ranked.select(*keys, pl.col(time).alias("_prev"), pl.col("_r").alias("_r_prev")),
                 on=[*keys, "_prev"],

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -36,7 +36,11 @@ axes.labelsize: 9
 axes.labelpad: 4
 axes.grid: False
 axes.axisbelow: True
-axes.prop_cycle: cycler('color', ['0a1628', 'D4A84B', 'C87533', '1a2d4a', '10b981', 'ef4444'])
+# Must stay equal to utils.style.COLOR_CYCLER, which tests/test_style.py asserts. This
+# file is what a bare plt.subplots() draws from, so it is the cycle almost every figure
+# in the repo actually uses. It carried `1a2d4a` (slate) at the fourth position, a second
+# navy next to the first entry, so a four-series chart drew two of them as one line.
+axes.prop_cycle: cycler('color', ['0a1628', 'D4A84B', 'C87533', '10b981', 'ef4444', '94a3b8'])
 
 # Grid (disabled by default; enable per-axes via ax.grid(axis='y') when needed)
 grid.color: e8e8e6

--- a/tests/test_feature_engineering_figures.py
+++ b/tests/test_feature_engineering_figures.py
@@ -10,8 +10,11 @@ Pins:
   the case studies actually make them.
 - _bootstrap_median_interval: the ribbon is a function of the values, not of the order
   they arrive in.
-- _cycle: no two series share a colour and a style, and the palette's two navies are
-  never both solid.
+- _cycle: no two series share a colour and a style, and six series get six colours a
+  reader can tell apart on the page and in gray.
+- plot_persistence: the panel it is handed can be stamped at any precision, not only
+  the microseconds a Python datetime happens to carry.
+- plot_timing_contract: the legend is clear of every bar, whatever the register declares.
 - plot_redundancy_clusters: the links above the cut are separable from every colour a
   cluster can be drawn in.
 
@@ -21,7 +24,7 @@ in eight rendered pages at once.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import matplotlib
 
@@ -155,6 +158,72 @@ def test_persistence_keeps_the_lag_panel_wide_under_long_feature_names(captured)
     )
 
 
+@pytest.mark.parametrize("unit", ["us", "ms", "ns"])
+def test_persistence_draws_a_panel_stamped_at_any_precision(captured, unit) -> None:
+    # Both lag maps go through `replace_strict`, which types its output from the Python
+    # objects it was handed rather than from the column it replaces - and a Python
+    # datetime is microseconds. On a millisecond panel the join that follows raised
+    # outright, so the figure could not be drawn at all: Binance stamps in milliseconds,
+    # so every crypto_perps_funding frame is `datetime[ms]`. Its notebook cast the frame
+    # it passed and nothing else, which is a fix for one caller and no fix for the helper.
+    panel, columns, schedule = _panel()
+    panel = panel.with_columns(
+        pl.col("timestamp").cast(pl.Datetime(time_unit=unit, time_zone="UTC"))
+    )
+    schedule = [
+        d.replace(tzinfo=UTC)
+        if isinstance(d, datetime)
+        else datetime(d.year, d.month, d.day, tzinfo=UTC)
+        for d in schedule
+    ]
+    fe.plot_persistence(
+        panel, columns, entity="symbol", max_lag=10, decision_dates=schedule, title="t", alt="a"
+    )
+    (fig,) = captured
+    assert fig.axes[0].get_lines(), "the autocorrelation panel drew nothing"
+
+
+def test_timing_contract_keeps_its_legend_clear_of_every_bar(captured) -> None:
+    # The register declares the families and the axes grow a row per family, so the more
+    # a case study declares the further its bottom row reaches under a legend pinned to
+    # the axes' lower left. At the eight of us_firm_characteristics the entry crossed the
+    # `interaction` bar and touched the tick labels beneath it.
+    families = [
+        fe.FeatureFamily(
+            name=name,
+            pattern=f"{name}_*",
+            role="signal",
+            hypothesis="h",
+            inputs="close",
+            lookback=20 + 5 * i,
+            lag=2 if i % 2 else 0,
+            frame="cross-sectional",
+            representation="z-score",
+            failure_mode="f",
+        )
+        for i, name in enumerate(
+            ["momentum", "volatility", "volume", "value", "quality", "carry", "flow", "interaction"]
+        )
+    ]
+    fe.plot_timing_contract(families, bar_unit="sessions", title="t", alt="a")
+    (fig,) = captured
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    axes = fig.axes[0]
+    bars = [patch.get_window_extent(renderer) for patch in axes.patches]
+    legend = fig.legends[0].get_window_extent(renderer)
+    for bar in bars:
+        assert not legend.overlaps(bar), "the legend is drawn on top of a family's bar"
+    assert legend.y1 <= axes.get_window_extent(renderer).y0, "the legend is inside the axes"
+
+    # The same corner, and the same failure: at a fixed -0.45 this label sat inside the
+    # bottom row's bar, which spans 0.55, and how far in depended on the family count.
+    decision = next(t for t in axes.texts if t.get_text() == "decision")
+    label = decision.get_window_extent(renderer)
+    for bar in bars:
+        assert not label.overlaps(bar), "the decision label is drawn on top of a family's bar"
+
+
 def test_bootstrap_interval_does_not_depend_on_the_order_of_its_values() -> None:
     # The callers read these out of a `group_by`, whose row order Polars does not
     # guarantee, and `rng.choice` draws by index. So the same entities in a different
@@ -168,19 +237,28 @@ def test_bootstrap_interval_does_not_depend_on_the_order_of_its_values() -> None
 
 
 def test_cycle_never_draws_two_series_the_same_way() -> None:
-    # Six hues over four styles is 24 combinations, but the styles turn over every five
-    # so that the palette's two navies never share one - which costs the last few. Twenty
-    # is well past what any coverage figure in the corpus needs; the most is eleven.
-    assert len(set(fe._cycle(20))) == 20
+    # Six hues over four styles is 24 combinations. Twenty is well past what any
+    # coverage figure in the corpus needs; the most is eleven.
+    assert len(set(fe._cycle(24))) == 24
 
 
-def test_cycle_separates_the_palettes_two_navies() -> None:
-    # COLOR_CYCLER's sixth entry is `slate`, which its own definition says reads close to
-    # `blue`, the first. They are one line to a reader unless something else parts them.
+def test_cycle_tells_six_families_apart_on_hue_alone() -> None:
+    # The first six series carry the whole palette and nothing repeats, so a reader
+    # separates them without consulting a line style. It took a style to do that while
+    # COLOR_CYCLER ended in `slate`, a second navy; the palette now ends in `recede`.
     from utils.style import COLORS
 
-    styles = {color: style for color, style in fe._cycle(6)}
-    assert styles[COLORS["blue"]] != styles[COLORS["slate"]]
+    six = fe._cycle(6)
+    assert len({color for color, _ in six}) == 6
+    assert {style for _, style in six} == {"-"}
+    assert COLORS["slate"] not in {color for color, _ in six}
+
+
+def test_cycle_parts_a_seventh_family_from_the_first() -> None:
+    # Past the palette the hues repeat, so the style has to carry the difference.
+    seven = fe._cycle(7)
+    assert seven[6][0] == seven[0][0]
+    assert seven[6][1] != seven[0][1]
 
 
 def test_redundancy_clusters_draw_above_the_cut_unlike_any_cluster() -> None:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -17,10 +17,13 @@ series as one line and no check anywhere noticed.
 from __future__ import annotations
 
 import importlib.util
+import re
+from pathlib import Path
 
 import matplotlib
 import numpy as np
 import pytest
+from cycler import cycler
 
 matplotlib.use("Agg")
 
@@ -36,6 +39,7 @@ from utils.style import (  # noqa: E402
     SUBPLOT_TITLE_SIZE,
     add_message_title,
     apply_book_style,
+    ml4t_palette,
     style_subplot_titles,
 )
 
@@ -129,6 +133,56 @@ def test_a_six_series_chart_draws_six_different_colours():
         ax.plot([0, 1], [i, i + 1], label=f"series {i}")
     drawn = [line.get_color() for line in ax.get_lines()]
     plt.close(fig)
+    assert len(set(drawn)) == 6
+    worst = min(_distance(a, b) for i, a in enumerate(drawn) for b in drawn[i + 1 :])
+    assert worst >= SEPARABLE
+
+
+def _matplotlibrc_cycle() -> list[str]:
+    """The colours repo-root `matplotlibrc` hands a bare `plt.subplots()`."""
+    text = (Path(__file__).resolve().parents[1] / "matplotlibrc").read_text()
+    line = next(
+        ln
+        for ln in text.splitlines()
+        if ln.startswith("axes.prop_cycle") and not ln.startswith("#")
+    )
+    return ["#" + h.lower() for h in re.findall(r"'([0-9a-fA-F]{6})'", line)]
+
+
+def test_every_cycle_in_the_repo_is_the_same_cycle():
+    """Four palettes ordered by hand in four files, and three of them held a stale one.
+
+    `COLOR_CYCLER` is what `apply_book_style("color")` sets and what the book-figure
+    scripts read, and it is the only one the first version of this fix corrected. It is
+    also the one almost nothing draws from: `matplotlibrc` is what a bare
+    `plt.subplots()` uses, the Plotly template colorway is what a bare `go.Figure()`
+    uses, and `ml4t_palette(categorical=True)` is what the figure skill tells a notebook
+    to call. All three still carried `slate` - at the fourth, third and third positions
+    - so the two-navy collision arrived at four series, three traces and three
+    categories rather than at six, in the paths that draw nearly every figure here.
+    """
+    assert _matplotlibrc_cycle() == [c.lower() for c in COLOR_CYCLER], (
+        "matplotlibrc and COLOR_CYCLER disagree, so a bare plt.subplots() draws "
+        "something other than the palette"
+    )
+    assert ml4t_palette(5, categorical=True) == COLOR_CYCLER[:5]
+
+
+@requires_plotly
+def test_the_plotly_colorway_is_the_same_cycle():
+    import plotly.io as pio
+
+    assert list(pio.templates["ml4t"].layout.colorway) == COLOR_CYCLER
+
+
+def test_a_bare_matplotlib_figure_draws_six_different_colours():
+    """What a notebook actually gets: no style call, just `matplotlibrc`."""
+    with plt.rc_context({"axes.prop_cycle": cycler(color=_matplotlibrc_cycle())}):
+        fig, ax = plt.subplots()
+        for i in range(6):
+            ax.plot([0, 1], [i, i + 1])
+        drawn = [line.get_color() for line in ax.get_lines()]
+        plt.close(fig)
     assert len(set(drawn)) == 6
     worst = min(_distance(a, b) for i, a in enumerate(drawn) for b in drawn[i + 1 :])
     assert worst >= SEPARABLE

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,38 +1,192 @@
 """Tests for the shared figure style module.
 
-These pin the one invariant the Plotly template cannot enforce on its own: a
-subplot figure's panel labels must read as subordinate to its figure title.
+These pin two invariants nothing else can enforce.
+
+A subplot figure's panel labels must read as subordinate to its figure title.
 Plotly writes ``subplot_titles`` as annotations with an explicit 16pt, and an
 explicit value beats anything the template sets in ``annotationdefaults``, so a
 template edit that lowers ``title.font.size`` silently inverts the hierarchy on
 every subplot figure in the repo.
+
+And ``COLOR_CYCLER``'s six entries must be six colours a reader can tell apart,
+on the page and once the page is reduced to gray. Its sixth was ``slate``, a
+second navy, so every six-series chart in the book drew its first and last
+series as one line and no check anywhere noticed.
 """
 
 from __future__ import annotations
 
+import importlib.util
+
+import matplotlib
+import numpy as np
 import pytest
 
-plotly = pytest.importorskip("plotly")
+matplotlib.use("Agg")
 
-import plotly.io as pio  # noqa: E402
-from plotly.subplots import make_subplots  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
 
 from utils.style import (  # noqa: E402
     _PLOTLY_SUBPLOT_TITLE_SIZE,
+    COLOR_CYCLER,
+    COLORS,
+    GRAY_CYCLER,
+    LINESTYLE_CYCLER,
+    MARKER_CYCLER,
     SUBPLOT_TITLE_SIZE,
+    add_message_title,
+    apply_book_style,
     style_subplot_titles,
+)
+
+# Only the Plotly template tests need Plotly. Guarding the whole module on it, as this
+# file used to, would let the palette tests below disappear without a word on any
+# machine that happened not to have it.
+requires_plotly = pytest.mark.skipif(
+    importlib.util.find_spec("plotly") is None, reason="plotly is not installed"
 )
 
 
 def _template_title_size() -> int:
+    import plotly.io as pio
+
     return pio.templates["ml4t"].layout.title.font.size
 
 
+def make_subplots(*args, **kwargs):
+    from plotly.subplots import make_subplots as _make_subplots
+
+    return _make_subplots(*args, **kwargs)
+
+
+# =============================================================================
+# THE PALETTE: six series, six colours
+# =============================================================================
+
+
+def _lab(hexcolor: str) -> np.ndarray:
+    """CIE L*a*b* for *hexcolor*, so distance means what an eye would call distance.
+
+    Distance in RGB does not: ``blue`` and ``slate`` sit further apart in RGB than
+    ``amber`` and ``copper``, and it is the first pair a reader cannot separate.
+    """
+    rgb = np.array([int(hexcolor.lstrip("#")[i : i + 2], 16) / 255 for i in (0, 2, 4)])
+    linear = np.where(rgb <= 0.04045, rgb / 12.92, ((rgb + 0.055) / 1.055) ** 2.4)
+    matrix = np.array(
+        [[0.4124, 0.3576, 0.1805], [0.2126, 0.7152, 0.0722], [0.0193, 0.1192, 0.9505]]
+    )
+    xyz = matrix @ linear / np.array([0.95047, 1.0, 1.08883])
+    f = np.where(xyz > 0.008856, np.cbrt(xyz), 7.787 * xyz + 16 / 116)
+    return np.array([116 * f[1] - 16, 500 * (f[0] - f[1]), 200 * (f[1] - f[2])])
+
+
+def _distance(a: str, b: str) -> float:
+    return float(np.linalg.norm(_lab(a) - _lab(b)))
+
+
+def _gray(hexcolor: str) -> float:
+    """0-255, what a naive grayscale reduction of a printed page gives."""
+    rgb = np.array([int(hexcolor.lstrip("#")[i : i + 2], 16) / 255 for i in (0, 2, 4)])
+    linear = np.where(rgb <= 0.04045, rgb / 12.92, ((rgb + 0.055) / 1.055) ** 2.4)
+    return 255 * float(linear @ np.array([0.2126, 0.7152, 0.0722])) ** (1 / 2.2)
+
+
+# 20 sits above the 12.9 that `blue`/`slate` scored, which is the pair a reader could
+# not separate, and below the 25.7 of `amber`/`copper`, which the palette has always
+# shipped and which reads as two colours. It is a floor on the defect, not a re-pick
+# of the palette.
+SEPARABLE = 20.0
+
+
+def test_six_series_get_six_colours_a_reader_can_separate():
+    assert len(COLOR_CYCLER) == len(set(COLOR_CYCLER)) == 6
+    worst = min(
+        (_distance(a, b), a, b) for i, a in enumerate(COLOR_CYCLER) for b in COLOR_CYCLER[i + 1 :]
+    )
+    assert worst[0] >= SEPARABLE, f"{worst[1]} and {worst[2]} are {worst[0]:.1f} apart"
+
+
+def test_the_sixth_series_is_not_a_second_navy():
+    """The defect itself: entry 5 against entry 0, in colour and in gray.
+
+    Both readings are needed. ``slate`` failed on colour at 12.9 while clearing any
+    gray bar one might set at 20, and a colour picked to clear the gray gap alone
+    could be another navy at a different weight.
+    """
+    navy, sixth = COLOR_CYCLER[0], COLOR_CYCLER[-1]
+    assert _distance(navy, sixth) >= SEPARABLE
+    # 26 is the tightest gap GRAY_CYCLER itself ships, so it is this file's own
+    # standing answer to "how far apart is far enough in gray".
+    assert abs(_gray(navy) - _gray(sixth)) >= 26
+    assert sixth != COLORS["slate"]
+
+
+def test_a_six_series_chart_draws_six_different_colours():
+    """The acceptance test, through the path a figure actually takes."""
+    apply_book_style("color")
+    fig, ax = plt.subplots()
+    for i in range(6):
+        ax.plot([0, 1], [i, i + 1], label=f"series {i}")
+    drawn = [line.get_color() for line in ax.get_lines()]
+    plt.close(fig)
+    assert len(set(drawn)) == 6
+    worst = min(_distance(a, b) for i, a in enumerate(drawn) for b in drawn[i + 1 :])
+    assert worst >= SEPARABLE
+
+
+def test_the_degradation_cyclers_still_cover_every_hue():
+    """A figure that loses its colour falls back on these, so they cannot run short."""
+    for fallback in (GRAY_CYCLER, LINESTYLE_CYCLER, MARKER_CYCLER):
+        assert len(fallback) >= len(COLOR_CYCLER)
+    assert len(set(GRAY_CYCLER)) == len(GRAY_CYCLER)
+    assert len(set(MARKER_CYCLER)) == len(MARKER_CYCLER)
+
+
+def test_a_long_subtitle_does_not_widen_the_figure():
+    """#248's silent half: `savefig.bbox="tight"` pays for whatever the subtitle asks.
+
+    Unwrapped, a subtitle wider than the axes did not clip and did not warn - it
+    widened the saved canvas, and the plot came out in the left quarter of an image
+    whose remaining three quarters held one line of 9pt gray.
+    """
+    fig, ax = plt.subplots(figsize=(5.833, 3.0))
+    ax.plot([0, 1], [0, 1])
+    add_message_title(
+        ax,
+        "Every family reads a window that closes before the decision",
+        subtitle=(
+            "Lookback and information lag per declared family, in trading sessions, "
+            "over the full sample, gross of costs, on the primary label's rebalance "
+            "schedule and its configured five-session purge gap"
+        ),
+    )
+    fig.tight_layout()
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    subtitle = next(
+        child
+        for child in ax.get_children()
+        if getattr(child, "get_text", None) and "Lookback" in str(child.get_text())
+    )
+    assert "\n" in subtitle.get_text(), "a subtitle this long has to wrap"
+    assert subtitle.get_window_extent(renderer).x1 <= fig.bbox.x1 + 1, (
+        "the subtitle runs past the figure, so bbox='tight' widens the canvas to fit it"
+    )
+    plt.close(fig)
+
+
+# =============================================================================
+# THE PLOTLY TEMPLATE
+# =============================================================================
+
+
+@requires_plotly
 def test_panel_labels_stay_below_the_figure_title():
     """The hierarchy this helper exists to enforce."""
     assert _template_title_size() > SUBPLOT_TITLE_SIZE
 
 
+@requires_plotly
 def test_style_subplot_titles_restyles_panel_labels():
     fig = make_subplots(rows=2, cols=2, subplot_titles=["A", "B", "C", "D"])
 
@@ -48,6 +202,7 @@ def test_style_subplot_titles_restyles_panel_labels():
         assert annotation.font.size < _template_title_size()
 
 
+@requires_plotly
 def test_style_subplot_titles_leaves_other_annotations_alone():
     """A bare update_annotations() would restyle these too - it must not."""
     fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
@@ -81,6 +236,7 @@ def test_style_subplot_titles_leaves_other_annotations_alone():
     assert by_text["source"].font.size == 9
 
 
+@requires_plotly
 def test_style_subplot_titles_spares_a_note_sharing_the_paper_signature():
     """The near-miss: paper-referenced, arrowless, bottom-anchored, centered.
 
@@ -108,6 +264,7 @@ def test_style_subplot_titles_spares_a_note_sharing_the_paper_signature():
     assert by_text["A"].font.size == SUBPLOT_TITLE_SIZE
 
 
+@requires_plotly
 def test_style_subplot_titles_applies_once():
     """A restyled label loses the 16pt signature, so a second call does nothing."""
     fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
@@ -116,11 +273,13 @@ def test_style_subplot_titles_applies_once():
     assert {a.font.size for a in fig.layout.annotations} == {SUBPLOT_TITLE_SIZE}
 
 
+@requires_plotly
 def test_style_subplot_titles_is_chainable():
     fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
     assert style_subplot_titles(fig) is fig
 
 
+@requires_plotly
 def test_style_subplot_titles_accepts_an_explicit_size():
     fig = make_subplots(rows=1, cols=2, subplot_titles=["A", "B"])
     style_subplot_titles(fig, size=11)

--- a/utils/style.py
+++ b/utils/style.py
@@ -68,6 +68,36 @@ GRAYSCALE = {
     "silver": 0.97,  # ~97% gray (nearly white)
 }
 
+# Categorical cyclers for `axes.prop_cycle`. The print track pairs GRAY_CYCLER
+# with LINESTYLE_CYCLER so a B&W readout stays legible; the color track relies
+# on hue alone (no linestyle pairing - see apply_book_style). Color order
+# prioritizes perceptual separation for the first 4 entries (most figures use
+# <=4 series). GRAY_CYCLER mirrors the GRAY_FILLS weight order (secondary widened
+# to #808080 for print contrast) while keeping every entry dark enough to read
+# as a line on white.
+#
+# The sixth entry was `slate`, and slate is a second navy: CIEDE2000 8.1 from
+# `blue`, and 48 against 28 once a page is reduced to gray. So every six-series
+# chart drew its first and last series as one line, which is what a reader saw in
+# the stage-03 coverage figure and in the six products of ch16's futures backtest.
+# `recede` is the only entry in the locked palette that parts from navy on both
+# readings at once - CIEDE2000 50.1, gray 160 against 28 - and it stays clear of
+# the other five in color (nearest is 30.6, to `positive`). It is light, so it
+# reads as the least emphatic series; that is the trade a sixth series buys, and
+# there is no seventh. Beyond six, pair the hue with a line style (`_cycle` in
+# case_studies/utils/feature_engineering.py) rather than extending this list.
+COLOR_CYCLER = [
+    COLORS["blue"],  # navy   - primary
+    COLORS["amber"],  # gold   - secondary
+    COLORS["copper"],  # orange - tertiary
+    COLORS["positive"],  # green  - fourth
+    COLORS["negative"],  # red    - fifth (semantic, use sparingly)
+    COLORS["recede"],  # light slate - sixth (only when >=6 series)
+]
+GRAY_CYCLER = ["#000000", "#808080", "#404040", "#a8a8a8", "#666666", "#c8c8c8"]
+LINESTYLE_CYCLER = ["-", "--", ":", "-.", "-", "--"]
+MARKER_CYCLER = ["o", "s", "^", "D", "v", "P"]
+
 # =============================================================================
 # MATPLOTLIB STYLE CONFIGURATIONS
 # =============================================================================
@@ -174,13 +204,11 @@ def ml4t_palette(n: int = 5, categorical: bool = False) -> list[str]:
         List of hex color strings
     """
     if categorical:
-        colors = [
-            COLORS["blue"],
-            COLORS["amber"],
-            COLORS["slate"],
-            COLORS["copper"],
-            COLORS["silver_muted"],
-        ]
+        # The cycle's first five, so the one categorical helper a notebook is told to
+        # call and the cycle a bare figure draws from cannot disagree. This list had
+        # `slate` third, so three categories already drew two navies, and
+        # `silver_muted` fifth, which is #e8e8e6 and barely visible on the page at all.
+        colors = list(COLOR_CYCLER[:5])
     else:
         colors = [
             COLORS["blue"],
@@ -541,14 +569,11 @@ def _register_plotly_template() -> None:
                 showgrid=True,
                 gridwidth=0.5,
             ),
-            colorway=[
-                COLORS["blue"],
-                COLORS["amber"],
-                COLORS["slate"],
-                COLORS["copper"],
-                COLORS["positive"],
-                COLORS["negative"],
-            ],
+            # The list itself, not a copy of it. This carried `slate` third, so a bare
+            # `go.Figure` with three traces already drew two of them in navy - the same
+            # defect as the Matplotlib cycle and one series sooner. Deriving it removes
+            # the possibility of the two drifting apart again.
+            colorway=list(COLOR_CYCLER),
             legend=dict(
                 bgcolor="rgba(255,255,255,0.8)",
                 bordercolor=COLORS["silver_muted"],
@@ -615,35 +640,6 @@ COLOR_FILLS = {
     "canvas": "#ffffff",
 }
 
-# Categorical cyclers for `axes.prop_cycle`. The print track pairs GRAY_CYCLER
-# with LINESTYLE_CYCLER so a B&W readout stays legible; the color track relies
-# on hue alone (no linestyle pairing - see apply_book_style). Color order
-# prioritizes perceptual separation for the first 4 entries (most figures use
-# <=4 series). GRAY_CYCLER mirrors the GRAY_FILLS weight order (secondary widened
-# to #808080 for print contrast) while keeping every entry dark enough to read
-# as a line on white.
-#
-# The sixth entry was `slate`, and slate is a second navy: CIEDE2000 8.1 from
-# `blue`, and 48 against 28 once a page is reduced to gray. So every six-series
-# chart drew its first and last series as one line, which is what a reader saw in
-# the stage-03 coverage figure and in the six products of ch16's futures backtest.
-# `recede` is the only entry in the locked palette that parts from navy on both
-# readings at once - CIEDE2000 50.1, gray 160 against 28 - and it stays clear of
-# the other five in color (nearest is 30.6, to `positive`). It is light, so it
-# reads as the least emphatic series; that is the trade a sixth series buys, and
-# there is no seventh. Beyond six, pair the hue with a line style (`_cycle` in
-# case_studies/utils/feature_engineering.py) rather than extending this list.
-COLOR_CYCLER = [
-    COLORS["blue"],  # navy   - primary
-    COLORS["amber"],  # gold   - secondary
-    COLORS["copper"],  # orange - tertiary
-    COLORS["positive"],  # green  - fourth
-    COLORS["negative"],  # red    - fifth (semantic, use sparingly)
-    COLORS["recede"],  # light slate - sixth (only when >=6 series)
-]
-GRAY_CYCLER = ["#000000", "#808080", "#404040", "#a8a8a8", "#666666", "#c8c8c8"]
-LINESTYLE_CYCLER = ["-", "--", ":", "-.", "-", "--"]
-MARKER_CYCLER = ["o", "s", "^", "D", "v", "P"]
 
 # =============================================================================
 # CANONICAL FIGURE SIZES (Packt embed width = 5.833")

--- a/utils/style.py
+++ b/utils/style.py
@@ -23,6 +23,7 @@ before any other config. No imports or function calls needed.
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -270,6 +271,57 @@ def format_pct_axis(ax: Axes, axis: Literal["x", "y", "both"] = "y") -> None:
         ax.xaxis.set_major_formatter(formatter)
 
 
+SUBTITLE_SIZE = 9
+
+
+def _wrap_text_to_axes(ax: Axes, text: object, minimum: int = 24) -> int:
+    """Break *text* onto as many lines as it takes to fit the axes' width.
+
+    Returns the number of lines added, which the caller pays for in layout.
+
+    The break points come from measuring the drawn text rather than from a
+    characters-per-inch estimate: the ratio of the rendered width to the axes' width
+    says directly how much of the string fits on one line, and it holds for whatever
+    font, size and DPI are actually in force. That ratio is an average over the
+    string, so a line that draws a run of unusually wide characters can still come
+    out slightly over; the second pass measures the wrapped text and takes it back.
+    """
+    figure = ax.figure
+    if figure is None or figure.canvas is None:
+        return 0
+    # A renderer, not a draw. `matplotlibrc` turns constrained layout on for every
+    # figure in the repo, and drawing here runs that engine before the caller has
+    # added its legend or called `tight_layout` - which on a small figure collapses
+    # the axes and warns, into the notebook's own output. Measuring needs a renderer
+    # and nothing else.
+    renderer = getattr(figure.canvas, "get_renderer", None)
+    if renderer is None:
+        return 0
+    renderer = renderer()
+    axes_box = ax.get_window_extent(renderer)
+    # The axes' width is what the subtitle should sit within; the room between the
+    # subtitle's own left edge and the figure's is what it must not exceed, on pain
+    # of `bbox="tight"` widening the canvas. Callers run `tight_layout` after this,
+    # which moves the axes' left edge right to make room for tick labels, so the
+    # second bound is taken with a margin covering that shift.
+    limit = min(axes_box.width, (figure.bbox.x1 - axes_box.x0) * 0.92)
+    if limit <= 0:
+        return 0
+    # `get_window_extent` on a multi-line Text returns the bounding box of every
+    # line, so its width is the widest line's, which is the one that has to fit.
+    for _ in range(2):
+        drawn = text.get_window_extent(renderer)
+        if drawn.width <= limit:
+            break
+        longest = max(text.get_text().split("\n"), key=len)
+        per_char = drawn.width / max(len(longest), 1)
+        # `fill` treats its input as one paragraph and collapses the newlines a
+        # previous pass put in, so this re-wraps the subtitle rather than wrapping
+        # the wrapping.
+        text.set_text(textwrap.fill(text.get_text(), max(minimum, int(limit / per_char))))
+    return text.get_text().count("\n")
+
+
 def add_message_title(
     ax: Axes,
     message: str,
@@ -283,15 +335,9 @@ def add_message_title(
     frequency, period); `source` is a small bottom-left note. No figure number — the
     publisher captions separately.
     """
-    ax.set_title(
-        message,
-        loc="left",
-        color=COLORS["blue"],
-        fontweight="semibold",
-        pad=15 if subtitle else 8,
-    )
+    extra_lines = 0
     if subtitle:
-        ax.annotate(
+        note = ax.annotate(
             subtitle,
             xy=(0, 1),
             xycoords="axes fraction",
@@ -299,9 +345,31 @@ def add_message_title(
             textcoords="offset points",
             ha="left",
             va="bottom",
-            fontsize=9,
+            fontsize=SUBTITLE_SIZE,
             color=COLORS["neutral"],
         )
+        # A subtitle was one line anchored to the axes' left edge and never measured
+        # against the axes' width, and every figure here saves with
+        # `savefig.bbox="tight"`. So a subtitle wider than the axes did not overflow
+        # and did not wrap: it widened the saved canvas to fit itself, and the figure
+        # came out with the plot in the left quarter and one line of gray running
+        # across the rest - which reads as a broken render rather than a long
+        # subtitle. Three of the six figures in us_firm_characteristics/03 hit it on
+        # a single pass, and nothing warned. Wrapping here retires the whole class:
+        # no caller can trip it, and no caller has to count characters against an
+        # axes width it cannot see.
+        extra_lines = _wrap_text_to_axes(ax, note)
+    ax.set_title(
+        message,
+        loc="left",
+        color=COLORS["blue"],
+        fontweight="semibold",
+        # The subtitle sits inside the title's pad and is anchored by its bottom, so
+        # each wrapped line grows up towards the title. `tight_layout` reserves the
+        # pad, so paying for those lines here is what keeps the figure from
+        # overlapping them.
+        pad=(15 + extra_lines * (SUBTITLE_SIZE + 2)) if subtitle else 8,
+    )
     if source:
         ax.figure.text(
             0.01, 0.005, source, ha="left", va="bottom", fontsize=8, color=COLORS["neutral"]
@@ -549,19 +617,29 @@ COLOR_FILLS = {
 
 # Categorical cyclers for `axes.prop_cycle`. The print track pairs GRAY_CYCLER
 # with LINESTYLE_CYCLER so a B&W readout stays legible; the color track relies
-# on hue alone (no linestyle pairing — see apply_book_style). Color order
+# on hue alone (no linestyle pairing - see apply_book_style). Color order
 # prioritizes perceptual separation for the first 4 entries (most figures use
-# ≤4 series); slate is positioned last because it reads as a second navy next
-# to blue. GRAY_CYCLER mirrors the GRAY_FILLS weight order (secondary widened
+# <=4 series). GRAY_CYCLER mirrors the GRAY_FILLS weight order (secondary widened
 # to #808080 for print contrast) while keeping every entry dark enough to read
 # as a line on white.
+#
+# The sixth entry was `slate`, and slate is a second navy: CIEDE2000 8.1 from
+# `blue`, and 48 against 28 once a page is reduced to gray. So every six-series
+# chart drew its first and last series as one line, which is what a reader saw in
+# the stage-03 coverage figure and in the six products of ch16's futures backtest.
+# `recede` is the only entry in the locked palette that parts from navy on both
+# readings at once - CIEDE2000 50.1, gray 160 against 28 - and it stays clear of
+# the other five in color (nearest is 30.6, to `positive`). It is light, so it
+# reads as the least emphatic series; that is the trade a sixth series buys, and
+# there is no seventh. Beyond six, pair the hue with a line style (`_cycle` in
+# case_studies/utils/feature_engineering.py) rather than extending this list.
 COLOR_CYCLER = [
-    COLORS["blue"],  # navy   — primary
-    COLORS["amber"],  # gold   — secondary
-    COLORS["copper"],  # orange — tertiary
-    COLORS["positive"],  # green  — fourth
-    COLORS["negative"],  # red    — fifth (semantic, use sparingly)
-    COLORS["slate"],  # navy   — sixth (only when ≥6 series; reads close to blue)
+    COLORS["blue"],  # navy   - primary
+    COLORS["amber"],  # gold   - secondary
+    COLORS["copper"],  # orange - tertiary
+    COLORS["positive"],  # green  - fourth
+    COLORS["negative"],  # red    - fifth (semantic, use sparingly)
+    COLORS["recede"],  # light slate - sixth (only when >=6 series)
 ]
 GRAY_CYCLER = ["#000000", "#808080", "#404040", "#a8a8a8", "#666666", "#c8c8c8"]
 LINESTYLE_CYCLER = ["-", "--", ":", "-.", "-", "--"]


### PR DESCRIPTION
Shared figure code only. No notebook is edited and no notebook is re-run; the 25-notebook
re-run that follows depends on this landing first, so that it does not have to happen twice.

## Six series, six colours

`COLOR_CYCLER` ended in `slate`, which is a second navy - CIEDE2000 8.1 from `blue`, and 48
against 28 once a page is reduced to gray. Its own comment conceded it "reads close to blue".
`recede` replaces it: of the locked palette it is the only entry that parts from navy on both
readings at once (CIEDE2000 50.1, gray 160 against 28) while staying clear of the other five,
nearest 30.6 to `positive`. It is a light hue, so the sixth series reads as the least emphatic
one - that is what a sixth series costs, and there is no seventh.

**The palette was ordered by hand in four places and three of them were missed on the first
pass**, each colliding sooner than six series:

| Where | `slate` sat | Collides at | Draws |
|---|---|---|---|
| `COLOR_CYCLER` | 6th | 6 series | `apply_book_style("color")`, book-figure scripts |
| `matplotlibrc` | 4th | 4 series | **every bare `plt.subplots()`** |
| Plotly template colorway | 3rd | 3 traces | **every bare `go.Figure()`** |
| `ml4t_palette(categorical=True)` | 3rd | 3 categories | what the figure skill tells notebooks to call |

All four are now one list. The colorway is `COLOR_CYCLER` itself and the categorical helper is
its first five, so only `matplotlibrc` is still a copy - and a test reads it off disk and
compares it, so a fifth copy or a re-ordering fails.

`_cycle` turned its line style over every five to keep the two navies apart. With a real sixth
hue that workaround is gone: the first six families separate on hue alone, and only a seventh
takes a dash.

## Three more defects in the same shared code

- **`plot_persistence` raised on any panel not stamped in microseconds.** Both its lag maps go
  through `replace_strict`, which types its output from the Python datetimes it is handed
  rather than from the column it replaces, and the join that follows failed on the mismatch.
  Binance stamps in milliseconds, so `crypto_perps_funding` could not draw the figure at all;
  its notebook cast the frame it passed and nothing else. The return dtype is now the column's.
- **`plot_timing_contract` drew its legend on the last family's bar.** The axes grow a row per
  declared family, so the more a case study declares the further its bottom row reaches under a
  legend pinned to the axes' lower left; at eight families the entry crossed the `interaction`
  bar. The legend now belongs to the figure, below the axes, in a strip measured after it is
  drawn. The "decision" label was doing the same thing in the same corner and is now anchored
  to the axes' floor.
- **A long subtitle silently widened the canvas.** `add_message_title` never measured its
  subtitle against the axes, and everything here saves with `savefig.bbox="tight"`, so a
  subtitle wider than the axes did not clip or wrap - it widened the image, leaving the plot in
  the left quarter. It now wraps to the axes width, measured through the renderer.

## Verification

Figures were drawn through the helpers on a synthetic panel and read at print width: six
families in six colours, eight with the seventh and eighth dashed, the timing contract at eight
families under a subtitle three times the axes width, the persistence panel on millisecond
stamps, and a bare `plt.subplots()` taking only `matplotlibrc`.

31 tests pass. Separation is asserted in CIE L*a*b* and in grayscale at thresholds taken from
the palette's own shipped pairs - above the 12.9 of blue/slate, below the 25.7 of amber/copper -
through the cycle a figure actually draws from rather than the constant alone. The Plotly guard
in `tests/test_style.py` became per-test, so a missing Plotly can no longer skip the palette
tests along with it.

**No computed number moves**; every change is in drawing code. The stage-03 notebooks of
`crypto_perps_funding` and `sp500_options` were re-run and their feature artifacts reproduced
their recorded digests exactly (`873623a4af13b3fc` / 99,877 rows and `fc8c04b2451bf8a7` /
354,265 rows).

**Known and deliberate**: in grayscale `positive` and `recede` reduce to 161 and 160, and
`copper` and `negative` to 136 and 130. The colour cycle has never been separable in gray past
about three series - `GRAY_CYCLER` and `LINESTYLE_CYCLER` exist for that, and
`apply_book_style("print")` pairs them. Making all six separable in both would mean re-picking
the locked brand palette, which is a larger decision than this defect.
