### PR TITLE
fix: stage-01 panel autocorrelation, and regular hours bounded by the exchange session

### DIFF
--- a/case_studies/utils/feasibility.py
+++ b/case_studies/utils/feasibility.py
@@ -138,8 +138,13 @@ def panel_acf(
         band is drawn wider than the estimate. ``pooled_se`` is the standard error of
         the plotted quantity itself, the cross-entity mean, and stays usable there.
         ``obs_per_entity`` is the mean entity length the band is built from.
-        ``n_dropped`` counts entities whose curve was not finite - a constant series
-        has no autocorrelation - and which are therefore not in the mean.
+
+        ``n_entities`` is counted **per lag**. A sparse entity can have pairs at lag
+        1 and none at lag 12, and it contributes wherever it has them rather than
+        being dropped from the whole curve; where the count moves across lags, the
+        mean at each lag is over a different set and the column says so.
+        ``n_dropped`` counts the entities that contributed at no lag at all, which is
+        what a constant series does - it has no autocorrelation to report.
     """
     curves: list[np.ndarray] = []
     lengths: list[int] = []
@@ -150,10 +155,10 @@ def panel_acf(
         if observed < max(min_obs, max_lags + 1):
             continue
         curve = _lag_exact_acf(series, max_lags)
-        # A zero-variance entity has no autocorrelation to report, and a plain mean
-        # over the stack would propagate its NaN to every lag and draw the figure
-        # empty with nothing raised. One firm in 10,587 did exactly that.
-        if not np.all(np.isfinite(curve)):
+        # A zero-variance entity has nothing to report at any lag. Pooling it with a
+        # plain mean would propagate its NaN to every lag and draw the figure empty
+        # with nothing raised; one firm in 10,587 did exactly that.
+        if not np.any(np.isfinite(curve[1:])):
             dropped += 1
             continue
         curves.append(curve)
@@ -163,19 +168,28 @@ def panel_acf(
         raise ValueError(f"no {entity_col} carries {min_obs} observations of {value_col}")
 
     stacked = np.vstack(curves)
+    finite = np.isfinite(stacked)
     obs_per_entity = float(np.mean(lengths))
-    filled = np.full(max_lags + 1, np.nan)
+
+    def per_lag(reduce) -> np.ndarray:
+        out = np.full(max_lags + 1, np.nan)
+        for lag in range(max_lags + 1):
+            column = stacked[finite[:, lag], lag]
+            if column.size:
+                out[lag] = reduce(column)
+        return out
+
     return pl.DataFrame(
         {
             "lag": np.arange(max_lags + 1),
-            "acf": stacked.mean(axis=0),
-            "acf_p10": np.percentile(stacked, 10, axis=0),
-            "acf_p90": np.percentile(stacked, 90, axis=0),
+            "acf": per_lag(np.mean),
+            "acf_p10": per_lag(lambda c: np.percentile(c, 10)),
+            "acf_p90": per_lag(lambda c: np.percentile(c, 90)),
             "band": np.full(max_lags + 1, 1.96 / np.sqrt(obs_per_entity)),
-            "pooled_se": (
-                stacked.std(axis=0, ddof=1) / np.sqrt(len(curves)) if len(curves) > 1 else filled
+            "pooled_se": per_lag(
+                lambda c: c.std(ddof=1) / np.sqrt(c.size) if c.size > 1 else np.nan
             ),
-            "n_entities": np.full(max_lags + 1, len(curves)),
+            "n_entities": finite.sum(axis=0),
             "obs_per_entity": np.full(max_lags + 1, obs_per_entity),
             "n_dropped": np.full(max_lags + 1, dropped),
         }
@@ -242,6 +256,8 @@ def _entity_series(
     # Trim to the observed span: a leading or trailing hole carries no pair, and
     # leaving it in would lengthen T and taper every coefficient for nothing.
     observed = np.flatnonzero(~np.isnan(grid))
+    if observed.size == 0:
+        return np.empty(0)
     return grid[observed[0] : observed[-1] + 1]
 
 

--- a/case_studies/utils/feasibility.py
+++ b/case_studies/utils/feasibility.py
@@ -8,8 +8,6 @@ version is longer than a cell should be.
 
 from __future__ import annotations
 
-import logging
-
 import numpy as np
 import polars as pl
 
@@ -86,15 +84,24 @@ def panel_acf(
     value_col: str,
     max_lags: int,
     min_obs: int = 30,
+    period_col: str | None = None,
 ) -> pl.DataFrame:
     """Within-entity autocorrelation of a panel series, pooled across entities.
 
     A single-series ACF over a stacked panel measures dependence across the
     cross-section wherever one entity's last observation meets the next entity's
-    first. This computes the ACF separately per entity with
-    :func:`ml4t.diagnostic.evaluation.autocorrelation.compute_acf` and returns the
-    cross-entity mean at each lag, with the 10th and 90th percentiles of the
-    per-entity curves and the white-noise band a single entity's sample implies.
+    first. This computes the ACF separately per entity and returns the cross-entity
+    mean at each lag, with the 10th and 90th percentiles of the per-entity curves
+    and two references for reading it.
+
+    The per-entity estimator is the one
+    :func:`ml4t.diagnostic.evaluation.autocorrelation.compute_acf` uses, and
+    ``tests/test_feasibility_helpers.py`` pins the two together on a series with no
+    gaps. It is computed here rather than called because the library's estimator has
+    no gap-aware form: its ``missing="drop"`` closes the gaps and its
+    ``missing="conservative"`` keeps them but shrinks every coefficient by the share
+    of pairs the gaps removed, which on a panel with 20% of periods missing reported
+    0.48 for a first-order autocorrelation of 0.60.
 
     Parameters
     ----------
@@ -108,44 +115,134 @@ def panel_acf(
         observations are skipped.
     min_obs
         Minimum observations an entity needs to contribute a curve.
+    period_col
+        Integer period index, one step per period of the cadence, unique within an
+        entity. Supply it wherever an entity can be missing a period. Each entity's
+        series is then laid out on its own dense period grid and correlated with the
+        gaps in place, so a curve reported at lag *k* pairs observations *k* periods
+        apart. Without it the rows are taken as consecutive, and a pair straddling a
+        missing period is counted at too short a lag. On the ``us_equities_panel``
+        development window that mislabels one pair in ten thousand; on an intraday
+        panel, or a carrier defined on only some periods, it is far higher.
 
     Returns
     -------
     pl.DataFrame
-        Columns ``lag``, ``acf``, ``acf_p10``, ``acf_p90``, ``band``, ``n_entities``.
-    """
-    from ml4t.diagnostic.evaluation.autocorrelation import compute_acf
+        Columns ``lag``, ``acf``, ``acf_p10``, ``acf_p90``, ``band``, ``pooled_se``,
+        ``n_entities``, ``obs_per_entity``, ``n_dropped``.
 
-    logger = logging.getLogger("ml4t.diagnostic.evaluation.autocorrelation")
-    previous_level = logger.level
-    logger.setLevel(logging.WARNING)
-    try:
-        curves: list[np.ndarray] = []
-        lengths: list[int] = []
-        for block in frame.partition_by(entity_col, maintain_order=True):
-            series = block[value_col].drop_nulls().to_numpy()
-            if len(series) < max(min_obs, max_lags + 1):
-                continue
-            curves.append(np.asarray(compute_acf(series, nlags=max_lags).values)[: max_lags + 1])
-            lengths.append(len(series))
-    finally:
-        logger.setLevel(previous_level)
+        ``band`` is ``1.96 / sqrt(T)`` for the mean entity length ``T``: the white
+        noise reference for *one* entity's curve, which is the right reference for a
+        daily panel and useless on an intraday one, where the entity that avoids
+        pooling across session boundaries carries a few dozen observations and the
+        band is drawn wider than the estimate. ``pooled_se`` is the standard error of
+        the plotted quantity itself, the cross-entity mean, and stays usable there.
+        ``obs_per_entity`` is the mean entity length the band is built from.
+        ``n_dropped`` counts entities whose curve was not finite - a constant series
+        has no autocorrelation - and which are therefore not in the mean.
+    """
+    curves: list[np.ndarray] = []
+    lengths: list[int] = []
+    dropped = 0
+    for block in frame.partition_by(entity_col, maintain_order=True):
+        series = _entity_series(block, value_col=value_col, period_col=period_col)
+        observed = int(np.count_nonzero(~np.isnan(series)))
+        if observed < max(min_obs, max_lags + 1):
+            continue
+        curve = _lag_exact_acf(series, max_lags)
+        # A zero-variance entity has no autocorrelation to report, and a plain mean
+        # over the stack would propagate its NaN to every lag and draw the figure
+        # empty with nothing raised. One firm in 10,587 did exactly that.
+        if not np.all(np.isfinite(curve)):
+            dropped += 1
+            continue
+        curves.append(curve)
+        lengths.append(observed)
 
     if not curves:
         raise ValueError(f"no {entity_col} carries {min_obs} observations of {value_col}")
 
     stacked = np.vstack(curves)
-    band = 1.96 / np.sqrt(float(np.mean(lengths)))
+    obs_per_entity = float(np.mean(lengths))
+    filled = np.full(max_lags + 1, np.nan)
     return pl.DataFrame(
         {
             "lag": np.arange(max_lags + 1),
             "acf": stacked.mean(axis=0),
             "acf_p10": np.percentile(stacked, 10, axis=0),
             "acf_p90": np.percentile(stacked, 90, axis=0),
-            "band": np.full(max_lags + 1, band),
+            "band": np.full(max_lags + 1, 1.96 / np.sqrt(obs_per_entity)),
+            "pooled_se": (
+                stacked.std(axis=0, ddof=1) / np.sqrt(len(curves)) if len(curves) > 1 else filled
+            ),
             "n_entities": np.full(max_lags + 1, len(curves)),
+            "obs_per_entity": np.full(max_lags + 1, obs_per_entity),
+            "n_dropped": np.full(max_lags + 1, dropped),
         }
     )
+
+
+def _lag_exact_acf(series: np.ndarray, max_lags: int) -> np.ndarray:
+    """Autocorrelation of one series, pairing observations by position, not by row.
+
+    ``series`` is laid out one element per period, NaN where the entity has none.
+    At each lag the sum runs over the pairs that exist and is divided by how many
+    there are, so a gap costs the pairs it straddles and nothing else. The
+    ``(T - lag) / T`` taper and the division by the whole-series variance are what
+    ``statsmodels`` applies, which is what makes this equal
+    :func:`ml4t.diagnostic.evaluation.autocorrelation.compute_acf` on a series with
+    no gaps.
+
+    Returns all-NaN for a constant series, which has no autocorrelation.
+    """
+    observed = ~np.isnan(series)
+    n_observed = int(np.count_nonzero(observed))
+    total = float(len(series))
+    out = np.full(max_lags + 1, np.nan)
+    if n_observed == 0 or total <= max_lags:
+        return out
+
+    centred = np.where(observed, series - series[observed].mean(), 0.0)
+    variance = float(np.dot(centred, centred) / n_observed)
+    if variance <= 0.0:
+        return out
+
+    out[0] = 1.0
+    for lag in range(1, max_lags + 1):
+        pairs = observed[:-lag] & observed[lag:]
+        n_pairs = int(np.count_nonzero(pairs))
+        if n_pairs == 0:
+            continue
+        cross = float(np.dot(centred[:-lag], centred[lag:]))
+        out[lag] = (cross / n_pairs) * ((total - lag) / total) / variance
+    return out
+
+
+def _entity_series(
+    block: pl.DataFrame,
+    *,
+    value_col: str,
+    period_col: str | None,
+) -> np.ndarray:
+    """One entity's values, on its own dense period grid when it has one.
+
+    Without ``period_col`` the rows are taken as consecutive and nulls are dropped,
+    which closes the gaps. With it, a missing period stays a hole.
+    """
+    if period_col is None:
+        return block[value_col].drop_nulls().to_numpy().astype(float)
+
+    periods = block[period_col].to_numpy().astype(np.int64)
+    values = block[value_col].cast(pl.Float64).to_numpy()
+    order = np.argsort(periods, kind="mergesort")
+    periods, values = periods[order], values[order]
+
+    grid = np.full(int(periods[-1] - periods[0]) + 1, np.nan)
+    grid[periods - periods[0]] = values
+    # Trim to the observed span: a leading or trailing hole carries no pair, and
+    # leaving it in would lengthen T and taper every coefficient for nothing.
+    observed = np.flatnonzero(~np.isnan(grid))
+    return grid[observed[0] : observed[-1] + 1]
 
 
 def cross_sectional_persistence(

--- a/data/equities/loader.py
+++ b/data/equities/loader.py
@@ -1,5 +1,6 @@
 """Equities loaders: market (OHLCV, options, microstructure), fundamentals (SEC filings, XBRL), and positioning (13F)."""
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
@@ -223,6 +224,67 @@ _QUOTE_OHLCV_AGGS = [
 
 _RESAMPLE_FREQUENCIES = {"5m": "5m", "15m": "15m", "30m": "30m", "1h": "1h", "4h": "4h"}
 
+# NYSE and NASDAQ keep the same US equity session calendar - identical sessions and
+# identical open and close on every one of them - so either name gives the same bound.
+# NYSE is the one `config/setup.yaml` declares for nasdaq100_microstructure.
+_SESSION_CALENDAR = "NYSE"
+
+
+@lru_cache(maxsize=1)
+def _exchange_sessions() -> pl.DataFrame:
+    """One row per trading session: its date, and the exchange's open and close.
+
+    Timestamps in the AlgoSeek archive are naive Eastern, so the bounds are converted
+    to Eastern and stripped of their timezone to compare against them directly.
+    """
+    import pandas_market_calendars as mcal
+
+    schedule = mcal.get_calendar(_SESSION_CALENDAR).schedule(
+        start_date="1990-01-01", end_date="2035-12-31"
+    )
+    eastern = {
+        name: schedule[name].dt.tz_convert("America/New_York").dt.tz_localize(None).to_numpy()
+        for name in ("market_open", "market_close")
+    }
+    return pl.DataFrame(
+        {
+            "session_date": pl.Series(schedule.index.to_numpy()).cast(pl.Date),
+            "session_open": pl.Series(eastern["market_open"], dtype=pl.Datetime("us")),
+            "session_close": pl.Series(eastern["market_close"], dtype=pl.Datetime("us")),
+        }
+    )
+
+
+def _filter_to_exchange_sessions(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Keep the bars the exchange was open for, session by session.
+
+    A fixed 09:30-16:00 clock bound is wrong on the two sessions a year the exchange
+    closes early: NYSE and NASDAQ close at 13:00 ET the day after Thanksgiving and on
+    Christmas Eve, so the 13:00-16:00 prints on those dates passed as ordinary bars.
+    They are thin - the five narrowest 15-minute cross-sections in the
+    nasdaq100_microstructure development window are all post-close bars on 2020-11-27
+    and 2020-12-24, 40 to 52 symbols against a median of 102 - which is immaterial to a
+    distribution and not immaterial to a rank across the universe or a long-short book
+    that has to fill both legs.
+
+    A date the exchange did not hold a session drops for the same reason.
+    """
+    columns = lf.collect_schema().names()
+    return (
+        lf.with_columns(pl.col("timestamp").dt.date().alias("_session_date"))
+        .join(
+            _exchange_sessions().lazy(),
+            left_on="_session_date",
+            right_on="session_date",
+            how="inner",
+        )
+        .filter(
+            (pl.col("timestamp") >= pl.col("session_open"))
+            & (pl.col("timestamp") < pl.col("session_close"))
+        )
+        .select(columns)
+    )
+
 
 def load_nasdaq100_bars(
     frequency: str = "1m",
@@ -237,9 +299,9 @@ def load_nasdaq100_bars(
 ) -> pl.DataFrame | pl.LazyFrame:
     """Load AlgoSeek NASDAQ-100 bar data.
 
-    Default: minute-frequency trade OHLCV, filtered to regular trading hours
-    (09:30-16:00 ET). Supports resampling to coarser frequencies, optional
-    bid/ask quote OHLCV, and a raw 60-column microstructure mode.
+    Default: minute-frequency trade OHLCV, filtered to the exchange's own session
+    hours. Supports resampling to coarser frequencies, optional bid/ask quote
+    OHLCV, and a raw 60-column microstructure mode.
 
     Args:
         frequency: Bar frequency. ``"1m"`` returns raw minute bars (no
@@ -256,8 +318,11 @@ def load_nasdaq100_bars(
             without projection, regular-hours filtering, or resampling.
             Mutually exclusive with ``frequency != "1m"`` and
             ``include_quotes``.
-        regular_hours: If True (default), filter to 09:30-16:00 ET. Ignored
-            when ``include_microstructure=True``.
+        regular_hours: If True (default), keep only the bars the exchange was
+            open for, bounded by the session open and close the NYSE calendar
+            reports rather than by a fixed 09:30-16:00 clock. The two sessions a
+            year that close at 13:00 ET therefore end at 13:00, and a date with
+            no session drops. Ignored when ``include_microstructure=True``.
         lazy: If True, return a LazyFrame for deferred execution.
         max_symbols: Limit to N random symbols (0 = all). Seed-deterministic.
 
@@ -327,10 +392,7 @@ def load_nasdaq100_bars(
     )
 
     if regular_hours:
-        lf = lf.filter(
-            (pl.col("timestamp").dt.hour() >= 10)
-            | ((pl.col("timestamp").dt.hour() == 9) & (pl.col("timestamp").dt.minute() >= 30))
-        ).filter(pl.col("timestamp").dt.hour() < 16)
+        lf = _filter_to_exchange_sessions(lf)
 
     lf = lf.sort("symbol", "timestamp")
 

--- a/tests/test_feasibility_helpers.py
+++ b/tests/test_feasibility_helpers.py
@@ -163,6 +163,56 @@ class TestOneConstantEntity:
         assert result["n_dropped"][0] == 1
         assert result["n_entities"][0] == N_ENTITIES
 
+    def test_an_entity_with_no_values_at_all_is_skipped(self):
+        """An all-null entity has no period grid, and must not raise on the way out."""
+        rng = np.random.default_rng(6)
+        panel = _panel(rng)
+        empty = pl.DataFrame(
+            {
+                "symbol": ["GONE"] * N_PERIODS,
+                "period": np.arange(N_PERIODS),
+                "value": np.full(N_PERIODS, None, dtype=object),
+            },
+            schema={"symbol": pl.String, "period": pl.Int64, "value": pl.Float64},
+        )
+
+        result = panel_acf(
+            pl.concat([panel, empty]),
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+
+        assert result["n_entities"][1] == N_ENTITIES
+        assert np.all(np.isfinite(result["acf"].to_numpy()))
+
+    def test_an_entity_short_of_pairs_at_one_lag_still_counts_at_the_others(self):
+        """Dropping it from every lag would discard estimates that are perfectly good."""
+        rng = np.random.default_rng(7)
+        panel = _panel(rng)
+        # Periods 0, 1, 100, 101, 200, 201, ...: plenty of lag-1 pairs, no lag-3 pairs.
+        periods = np.concatenate([[100 * k, 100 * k + 1] for k in range(60)])
+        sparse = pl.DataFrame(
+            {
+                "symbol": ["SPARSE"] * periods.size,
+                "period": periods,
+                "value": _ar1(rng, periods.size),
+            }
+        )
+
+        result = panel_acf(
+            pl.concat([panel, sparse]),
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+
+        assert result["n_entities"][1] == N_ENTITIES + 1, "it has lag-1 pairs"
+        assert result["n_entities"][3] == N_ENTITIES, "it has no lag-3 pairs"
+        assert result["n_dropped"][0] == 0, "it contributed somewhere, so it is not dropped"
+
     def test_every_entity_constant_is_an_error_not_a_blank_figure(self):
         frame = pl.DataFrame(
             {

--- a/tests/test_feasibility_helpers.py
+++ b/tests/test_feasibility_helpers.py
@@ -1,0 +1,232 @@
+"""Tests for the stage-01 helpers in ``case_studies/utils/feasibility.py``.
+
+``panel_acf`` is what every stage-01 notebook draws F4 from, so a defect in it is
+a defect in nine figures at once. Three are pinned here: the lag a gap is reported
+at, what one constant entity does to the pooled curve, and the reference the band
+gives an intraday panel.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.utils.feasibility import panel_acf
+
+PHI = 0.6
+N_ENTITIES = 40
+N_PERIODS = 400
+MAX_LAGS = 5
+
+
+def _ar1(rng: np.random.Generator, n: int, phi: float = PHI) -> np.ndarray:
+    values = np.zeros(n)
+    for i in range(1, n):
+        values[i] = phi * values[i - 1] + rng.normal()
+    return values
+
+
+def _panel(rng: np.random.Generator) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": np.repeat([f"S{i}" for i in range(N_ENTITIES)], N_PERIODS),
+            "period": np.tile(np.arange(N_PERIODS), N_ENTITIES),
+            "value": np.concatenate([_ar1(rng, N_PERIODS) for _ in range(N_ENTITIES)]),
+        }
+    )
+
+
+class TestGapsAreReportedAtTheRightLag:
+    """Dropping nulls before lagging closes the gap instead of preserving it."""
+
+    def test_a_gapped_panel_recovers_the_ungapped_autocorrelation(self):
+        rng = np.random.default_rng(0)
+        panel = _panel(rng)
+
+        dense = panel_acf(
+            panel,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+        # Punch out a fifth of the periods at random, independently per entity.
+        gapped = panel.filter(pl.Series(rng.random(panel.height) > 0.2))
+
+        exact = panel_acf(
+            gapped,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+        compacted = panel_acf(gapped, entity_col="symbol", value_col="value", max_lags=MAX_LAGS)
+
+        truth = dense["acf"].to_numpy()
+        # Pairing by period recovers the ungapped curve; pairing by row does not,
+        # because a pair straddling a gap is counted one lag too early.
+        assert np.abs(exact["acf"].to_numpy()[1] - truth[1]) < 0.03
+        assert compacted["acf"].to_numpy()[1] < truth[1] - 0.03
+
+    def test_a_single_gap_is_charged_to_the_lag_it_spans(self):
+        """One entity, one missing period, at a lag where the answer is arithmetic."""
+        values = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0], dtype=float)
+        periods = np.arange(len(values))
+        keep = periods != 3  # the alternation now looks like ... 1, -1, 1, 1, -1 ...
+
+        frame = pl.DataFrame(
+            {
+                "symbol": ["A"] * int(keep.sum()),
+                "period": periods[keep],
+                "value": values[keep],
+            }
+        )
+
+        exact = panel_acf(
+            frame,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=2,
+            min_obs=5,
+            period_col="period",
+        )
+        compacted = panel_acf(frame, entity_col="symbol", value_col="value", max_lags=2, min_obs=5)
+
+        # Every surviving pair one period apart still alternates, so the pairwise
+        # correlation at lag 1 is -1, tapered by the (T - lag) / T that the biased
+        # ACF estimator applies over the eight-period span: -7/8.
+        assert exact["acf"][1] == pytest.approx(-7 / 8)
+        # Compacted, the pair that straddled the gap reads as a lag-1 pair of equal
+        # signs, which pulls the coefficient a long way off: -0.607.
+        assert compacted["acf"][1] > exact["acf"][1] + 0.25
+
+    def test_period_col_does_not_change_a_panel_with_no_gaps(self):
+        rng = np.random.default_rng(1)
+        panel = _panel(rng)
+
+        with_periods = panel_acf(
+            panel,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+        without = panel_acf(panel, entity_col="symbol", value_col="value", max_lags=MAX_LAGS)
+
+        np.testing.assert_allclose(
+            with_periods["acf"].to_numpy(), without["acf"].to_numpy(), rtol=1e-12
+        )
+
+
+class TestEstimatorMatchesTheLibrary:
+    """The per-entity estimator is the library's, computed here only to see gaps."""
+
+    def test_agrees_with_compute_acf_on_a_series_with_no_gaps(self):
+        from ml4t.diagnostic.evaluation.autocorrelation import compute_acf
+
+        rng = np.random.default_rng(2)
+        series = _ar1(rng, 500)
+        frame = pl.DataFrame({"symbol": ["A"] * 500, "period": np.arange(500), "value": series})
+
+        ours = panel_acf(
+            frame, entity_col="symbol", value_col="value", max_lags=10, period_col="period"
+        )["acf"].to_numpy()
+        theirs = np.asarray(compute_acf(series, nlags=10).values)[:11]
+
+        np.testing.assert_allclose(ours, theirs, rtol=1e-10, atol=1e-12)
+
+
+class TestOneConstantEntity:
+    """A zero-variance entity used to turn every pooled lag into NaN."""
+
+    def test_a_constant_entity_is_dropped_and_counted(self):
+        rng = np.random.default_rng(3)
+        panel = _panel(rng)
+        constant = pl.DataFrame(
+            {
+                "symbol": ["FLAT"] * N_PERIODS,
+                "period": np.arange(N_PERIODS),
+                "value": np.zeros(N_PERIODS),
+            }
+        )
+
+        result = panel_acf(
+            pl.concat([panel, constant]),
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+
+        assert np.all(np.isfinite(result["acf"].to_numpy())), "one flat entity nulled the curve"
+        assert result["n_dropped"][0] == 1
+        assert result["n_entities"][0] == N_ENTITIES
+
+    def test_every_entity_constant_is_an_error_not_a_blank_figure(self):
+        frame = pl.DataFrame(
+            {
+                "symbol": ["A"] * 100 + ["B"] * 100,
+                "period": np.tile(np.arange(100), 2),
+                "value": np.zeros(200),
+            }
+        )
+
+        with pytest.raises(ValueError, match="observations"):
+            panel_acf(
+                frame,
+                entity_col="symbol",
+                value_col="value",
+                max_lags=MAX_LAGS,
+                period_col="period",
+            )
+
+
+class TestTheBandAnIntradayPanelCanUse:
+    """`band` is the reference for one entity's curve; `pooled_se` for the mean."""
+
+    def test_pooled_se_is_the_error_of_the_plotted_quantity(self):
+        rng = np.random.default_rng(4)
+        panel = _panel(rng)
+
+        result = panel_acf(
+            panel,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=MAX_LAGS,
+            period_col="period",
+        )
+
+        # The band is 1.96/sqrt(T) for one entity; the standard error of a mean over
+        # 40 entities is far smaller, which is the whole point on short entities.
+        assert result["band"][0] == pytest.approx(1.96 / np.sqrt(N_PERIODS))
+        assert result["obs_per_entity"][0] == pytest.approx(N_PERIODS)
+        assert float(result["pooled_se"][1]) < float(result["band"][1]) / 5
+
+    def test_short_entities_make_the_band_useless_but_not_the_pooled_se(self):
+        """The intraday bind: 25 observations per entity, band 0.39, estimate inside it."""
+        rng = np.random.default_rng(5)
+        per_entity, n_entities = 25, 300
+        frame = pl.DataFrame(
+            {
+                "symbol": np.repeat([f"B{i}" for i in range(n_entities)], per_entity),
+                "period": np.tile(np.arange(per_entity), n_entities),
+                "value": np.concatenate([_ar1(rng, per_entity) for _ in range(n_entities)]),
+            }
+        )
+
+        result = panel_acf(
+            frame,
+            entity_col="symbol",
+            value_col="value",
+            max_lags=4,
+            min_obs=20,
+            period_col="period",
+        )
+
+        band = float(result["band"][1])
+        pooled = float(result["pooled_se"][1])
+        assert band > 0.3, "the per-entity band should be wide here, that is the problem"
+        assert pooled < band / 5, "the pooled standard error has to stay usable"
+        # And it is usable: the AR(1) signal clears it many times over.
+        assert float(result["acf"][1]) > 4 * pooled

--- a/tests/test_nasdaq100_session_hours.py
+++ b/tests/test_nasdaq100_session_hours.py
@@ -93,6 +93,62 @@ class TestSessionBounds:
         }
 
 
+class TestThroughTheLoader:
+    """The helper is only worth anything if `load_nasdaq100_bars` still calls it."""
+
+    @pytest.fixture
+    def archive(self, tmp_path, monkeypatch):
+        """A minute-bar archive in the layout the loader scans."""
+        rows = []
+        for date in [FULL_DAY, HOLIDAY, *HALF_DAYS]:
+            stamp = dt.datetime.combine(date, dt.time(9, 0))
+            while stamp.time() <= dt.time(16, 45):
+                rows.append(
+                    {
+                        "timestamp": stamp,
+                        "symbol": "AAPL",
+                        "date": date,
+                        "first_trade_price": 100.0,
+                        "high_trade_price": 101.0,
+                        "low_trade_price": 99.0,
+                        "last_trade_price": 100.5,
+                        "volume": 1_000.0,
+                    }
+                )
+                stamp += dt.timedelta(minutes=15)
+
+        partition = tmp_path / "equities" / "market" / "nasdaq100" / "minute_bars" / "year=2020"
+        partition.mkdir(parents=True)
+        pl.DataFrame(rows).write_parquet(partition / "part.parquet")
+
+        from data.equities import loader
+
+        monkeypatch.setattr(loader, "ML4T_DATA_PATH", tmp_path)
+        return loader
+
+    def test_regular_hours_stops_at_the_early_close(self, archive):
+        bars = archive.load_nasdaq100_bars(regular_hours=True)
+        last = (
+            bars.group_by(pl.col("timestamp").dt.date().alias("date"))
+            .agg(pl.col("timestamp").max().dt.time().alias("last"))
+            .sort("date")
+        )
+
+        assert dict(zip(last["date"], last["last"], strict=True)) == {
+            FULL_DAY: dt.time(15, 45),
+            HALF_DAYS[0]: dt.time(12, 45),
+            HALF_DAYS[1]: dt.time(12, 45),
+        }
+        assert HOLIDAY not in last["date"].to_list()
+
+    def test_regular_hours_false_keeps_everything(self, archive):
+        bars = archive.load_nasdaq100_bars(regular_hours=False)
+
+        assert bars["timestamp"].min().time() == dt.time(9, 0)
+        assert bars["timestamp"].max().time() == dt.time(16, 45)
+        assert bars["timestamp"].dt.date().n_unique() == 4
+
+
 class TestTheSessionTable:
     def test_the_two_early_closes_are_the_only_ones_in_the_window(self):
         sessions = _exchange_sessions().filter(

--- a/tests/test_nasdaq100_session_hours.py
+++ b/tests/test_nasdaq100_session_hours.py
@@ -1,0 +1,113 @@
+"""The regular-hours filter in ``data/equities/loader.py`` follows the exchange calendar.
+
+A fixed 09:30-16:00 clock bound is right on 250 sessions a year and wrong on two:
+NYSE and NASDAQ close at 13:00 ET the day after Thanksgiving and on Christmas Eve, and
+the afternoon prints on those dates entered every downstream notebook as ordinary bars.
+`nasdaq100_microstructure` reads this loader at stages 01 through 04.
+
+The bars here are constructed rather than sampled, so the test states the shape it is
+about - a half day, a full day, a holiday - instead of depending on the archive.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import polars as pl
+import pytest
+
+from data.equities.loader import _exchange_sessions, _filter_to_exchange_sessions
+
+HALF_DAYS = [dt.date(2020, 11, 27), dt.date(2020, 12, 24)]
+FULL_DAY = dt.date(2020, 11, 25)
+HOLIDAY = dt.date(2020, 11, 26)  # Thanksgiving
+
+
+def _bars(dates: list[dt.date]) -> pl.LazyFrame:
+    """One bar every 15 minutes from 09:00 to 16:45 on each date."""
+    rows = []
+    for date in dates:
+        stamp = dt.datetime.combine(date, dt.time(9, 0))
+        while stamp.time() <= dt.time(16, 45):
+            rows.append({"timestamp": stamp, "symbol": "AAPL", "close": 1.0})
+            stamp += dt.timedelta(minutes=15)
+    return pl.DataFrame(rows).lazy()
+
+
+def _kept(dates: list[dt.date]) -> pl.DataFrame:
+    return _filter_to_exchange_sessions(_bars(dates)).collect()
+
+
+class TestSessionBounds:
+    def test_a_full_session_runs_to_the_close(self):
+        kept = _kept([FULL_DAY])
+
+        assert kept["timestamp"].min().time() == dt.time(9, 30)
+        assert kept["timestamp"].max().time() == dt.time(15, 45)
+
+    @pytest.mark.parametrize("half_day", HALF_DAYS)
+    def test_an_early_close_ends_the_session(self, half_day: dt.date):
+        kept = _kept([half_day])
+
+        assert kept["timestamp"].min().time() == dt.time(9, 30)
+        # 13:00 is the close, so the 12:45 bar is the last one inside the session.
+        assert kept["timestamp"].max().time() == dt.time(12, 45)
+        assert kept.filter(pl.col("timestamp").dt.hour() >= 13).height == 0
+
+    @pytest.mark.parametrize("half_day", HALF_DAYS)
+    def test_a_clock_bound_would_keep_the_afternoon(self, half_day: dt.date):
+        """What the filter used to do, stated so a revert cannot pass quietly."""
+        clock_bound = (
+            _bars([half_day])
+            .filter(
+                (pl.col("timestamp").dt.hour() >= 10)
+                | ((pl.col("timestamp").dt.hour() == 9) & (pl.col("timestamp").dt.minute() >= 30))
+            )
+            .filter(pl.col("timestamp").dt.hour() < 16)
+            .collect()
+        )
+
+        after_close = clock_bound.filter(pl.col("timestamp").dt.hour() >= 13)
+        assert after_close.height == 12, "the market was shut for these twelve bars"
+        assert _kept([half_day]).height == clock_bound.height - 12
+
+    def test_a_holiday_keeps_nothing(self):
+        assert _kept([HOLIDAY]).height == 0
+
+    def test_the_schema_is_unchanged(self):
+        assert _kept([FULL_DAY]).columns == ["timestamp", "symbol", "close"]
+
+    def test_only_the_early_closes_are_shortened(self):
+        """The fix must not touch the 250 sessions a year that close at 16:00."""
+        kept = _kept([FULL_DAY, *HALF_DAYS])
+        last = (
+            kept.group_by(pl.col("timestamp").dt.date().alias("date"))
+            .agg(pl.col("timestamp").max().dt.time().alias("last"))
+            .sort("date")
+        )
+
+        assert dict(zip(last["date"], last["last"], strict=True)) == {
+            FULL_DAY: dt.time(15, 45),
+            HALF_DAYS[0]: dt.time(12, 45),
+            HALF_DAYS[1]: dt.time(12, 45),
+        }
+
+
+class TestTheSessionTable:
+    def test_the_two_early_closes_are_the_only_ones_in_the_window(self):
+        sessions = _exchange_sessions().filter(
+            pl.col("session_date").is_between(dt.date(2020, 1, 1), dt.date(2021, 7, 1))
+        )
+
+        early = sessions.filter(pl.col("session_close").dt.hour() < 16)
+        assert early["session_date"].to_list() == HALF_DAYS
+        assert sessions.height == 378
+
+    def test_open_and_close_are_naive_eastern(self):
+        """The archive's timestamps are naive Eastern; the bounds have to match."""
+        sessions = _exchange_sessions()
+        full = sessions.filter(pl.col("session_date") == FULL_DAY)
+
+        assert sessions.schema["session_open"] == pl.Datetime("us")
+        assert full["session_open"][0].time() == dt.time(9, 30)
+        assert full["session_close"][0].time() == dt.time(16, 0)


### PR DESCRIPTION
Two shared pieces of code that every reader of a stage-01 figure, and every
`nasdaq100_microstructure` notebook, depends on.

## `case_studies/utils/feasibility.py::panel_acf`

Three defects in the one helper the nine stage-01 notebooks draw F4 from.

**The lag a gap is reported at.** Each entity's curve was taken over
`block[value_col].drop_nulls()`, which closes the gaps rather than preserving them,
so a coefficient reported at lag *k* paired observations *k* rows apart after
compaction rather than *k* periods apart. The new optional `period_col` lays each
entity out on its own dense period grid and pairs by position. On a synthetic AR(1)
panel with 20% of periods removed, the first-order coefficient reads 0.55 compacted
against a true 0.60, and 0.59 pairing by period.

The estimator is computed in the helper rather than called from `ml4t.diagnostic`
because the library has no gap-aware form: `missing="drop"` closes the gaps, and
`missing="conservative"` keeps them but divides by a count that includes the pairs
the gaps removed, reporting 0.48 for the same 0.60. On a series with no gaps the two
agree to 1e-10, and a test pins that.

**One constant entity.** Pooling with a plain mean let a single zero-variance
entity's all-NaN curve reach every lag, so the figure drew empty with nothing
raised: one firm of 10,587 did that to `us_firm_characteristics`. Each lag is now
pooled over the entities that have an estimate at that lag, `n_entities` is reported
per lag, and `n_dropped` counts the entities that contributed at no lag at all.

**The white-noise band.** `band` is `1.96/sqrt(T)` for one entity's series - the
right reference for a daily panel and useless for an intraday one, where the entity
that avoids pooling across session boundaries carries a few dozen observations and
the band is drawn wider than the estimate it is meant to judge. The new `pooled_se`
is the standard error of what the figure actually plots, the cross-entity mean.

The per-entity library warning that took one executed notebook to 827,494 bytes of
repeated stderr goes with the library call, and so does the suppression that never
worked - it set the logger to WARNING to silence a WARNING.

**No caller changes.** The eight stage-01 notebooks pass keywords and read columns
by name, `period_col` defaults to the old behaviour, and no column was removed.
Adopting `period_col` moves F4 in nine notebooks and needs their re-execution, so it
belongs with the notebooks rather than with the helper.

## `data/equities/loader.py::load_nasdaq100_bars`

`regular_hours=True` filtered on `09:30 <= t < 16:00` on every date. NYSE and NASDAQ
close at 13:00 ET the day after Thanksgiving and on Christmas Eve, so the 13:00-16:00
prints on those dates passed as ordinary bars. The bound now comes from the session
open and close the calendar reports, and a date with no session drops.

Measured on 2020-01-01 to 2021-07-01 at 1m:

| | |
|---|---|
| rows | 14,943,874 -> 14,934,105 (9,769 dropped, 0.065%) |
| sessions | 378 -> 378, none lost |
| last bar 2020-11-27 | 15:59 -> 12:59 |
| last bar 2020-12-24 | 15:59 -> 12:59 |
| any other date | unchanged |

At 15m the effect is the one that matters: the five thinnest cross-sections in the
window were all post-close bars on those two dates, 40 to 52 symbols against a median
of 102. The thinnest is now 100. A distributional statistic did not care; a rank
across the universe, or a long-short book that has to fill both legs, did. The loader
feeds `nasdaq100_microstructure` 01 through 04, `_build_cost_feasible_universe.py`
and `case_studies/utils/backtest_loaders.py`, so labels, features and the backtest
schedule all carried those bars.

## Tests

`tests/test_feasibility_helpers.py` (10) and `tests/test_nasdaq100_session_hours.py`
(12). Both construct their data rather than sampling the archive, so they state the
shape they are about - a gap at a known lag, a constant entity, a half day, a
holiday - and run without it. Two of them show the old behaviour beside the new one,
so a revert cannot pass quietly. All 10 feasibility tests fail against the previous
helper.