### PR TITLE
Pin the notebook kernel's thread pools, and make the fixture seed a reset rather than a fill

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,11 +249,21 @@ def seeded_output_dir(tmp_path_factory):
             dst = output_dir / cs_id
             # Copy features, labels, evaluation, run_log, results, benchmark —
             # anything that downstream notebooks look for in get_case_study_dir()
+            # Replace rather than fill a gap. CI checks the fixture out into a
+            # clean container every time; a lane re-running into an existing
+            # ML4T_OUTPUT_DIR kept whatever the previous run had left, which for
+            # run_log/registry.db means every training run, prediction set and
+            # backtest that run registered. The notebooks then saw identities
+            # neither the fixture nor production carries, so the same code
+            # produced a different failure list locally than in CI.
             for subdir in ["features", "labels", "evaluation", "run_log", "results", "benchmark"]:
                 src_sub = src / subdir
                 dst_sub = dst / subdir
-                if src_sub.exists() and not dst_sub.exists():
-                    shutil.copytree(src_sub, dst_sub)
+                if not src_sub.exists():
+                    continue
+                if dst_sub.exists():
+                    shutil.rmtree(dst_sub)
+                shutil.copytree(src_sub, dst_sub)
             # Copy top-level intermediate files (e.g. etfs/eligibility.csv,
             # protocol.yaml, baseline_checkpoint.yaml) that sit directly in
             # intermediates/{cs_id}/ rather than in a subdir. Downstream
@@ -261,10 +271,8 @@ def seeded_output_dir(tmp_path_factory):
             # get_case_study_dir(); without this they fail with FileNotFoundError.
             for item in src.iterdir():
                 if item.is_file():
-                    dst_file = dst / item.name
-                    if not dst_file.exists():
-                        dst.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(item, dst_file)
+                    dst.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(item, dst / item.name)
             # Schema reconciliation: test-data predictions parquets were
             # generated with an older column convention (y_score / y_true /
             # fold_id). Production registry uses (prediction / actual / fold).
@@ -283,8 +291,9 @@ def seeded_output_dir(tmp_path_factory):
             if not src.exists():
                 continue
             dst = output_dir / extra_id
-            if not dst.exists():
-                shutil.copytree(src, dst)
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
 
     # Seed minimal results fixtures so downstream notebooks (latent factors, DL,
     # backtest) can find baseline results without depending on upstream execution.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,41 @@ def intermediates_dir(test_data_dir):
     return None
 
 
+SEEDED_SUBDIRS = ("features", "labels", "evaluation", "run_log", "results", "benchmark")
+
+
+def seed_case_study_intermediates(src: Path, dst: Path) -> None:
+    """Make ``dst`` hold the fixture's intermediates for one case study, and only those.
+
+    Replace, never fill a gap. CI checks the fixture out into a clean container every
+    time; a lane re-running into an existing ``ML4T_OUTPUT_DIR`` used to keep whatever
+    the previous run had left, which for ``run_log/registry.db`` means every training
+    run, prediction set and backtest that run registered. The notebooks then resolved
+    identities neither the fixture nor production carries, so the same code produced a
+    different failure list locally than it did in CI.
+
+    A destination subdir is removed whether or not the fixture still ships a source for
+    it. One the fixture has stopped shipping is precisely the leftover nothing would
+    ever overwrite.
+
+    ``src`` also holds top-level files (``etfs/eligibility.csv``, ``protocol.yaml``,
+    ``baseline_checkpoint.yaml``) that downstream notebooks read through
+    ``get_case_study_dir()``, so they are copied too.
+    """
+    for subdir in SEEDED_SUBDIRS:
+        src_sub = src / subdir
+        dst_sub = dst / subdir
+        if dst_sub.exists():
+            shutil.rmtree(dst_sub)
+        if src_sub.exists():
+            shutil.copytree(src_sub, dst_sub)
+
+    for item in src.iterdir():
+        if item.is_file():
+            dst.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dst / item.name)
+
+
 @pytest.fixture(scope="session")
 def seeded_output_dir(tmp_path_factory):
     """Session-scoped output dir seeded with case study config files.
@@ -247,32 +282,7 @@ def seeded_output_dir(tmp_path_factory):
             if not src.exists():
                 continue
             dst = output_dir / cs_id
-            # Copy features, labels, evaluation, run_log, results, benchmark —
-            # anything that downstream notebooks look for in get_case_study_dir()
-            # Replace rather than fill a gap. CI checks the fixture out into a
-            # clean container every time; a lane re-running into an existing
-            # ML4T_OUTPUT_DIR kept whatever the previous run had left, which for
-            # run_log/registry.db means every training run, prediction set and
-            # backtest that run registered. The notebooks then saw identities
-            # neither the fixture nor production carries, so the same code
-            # produced a different failure list locally than in CI.
-            for subdir in ["features", "labels", "evaluation", "run_log", "results", "benchmark"]:
-                src_sub = src / subdir
-                dst_sub = dst / subdir
-                if not src_sub.exists():
-                    continue
-                if dst_sub.exists():
-                    shutil.rmtree(dst_sub)
-                shutil.copytree(src_sub, dst_sub)
-            # Copy top-level intermediate files (e.g. etfs/eligibility.csv,
-            # protocol.yaml, baseline_checkpoint.yaml) that sit directly in
-            # intermediates/{cs_id}/ rather than in a subdir. Downstream
-            # notebooks (etfs 02_labels, 03_financial_features) read these via
-            # get_case_study_dir(); without this they fail with FileNotFoundError.
-            for item in src.iterdir():
-                if item.is_file():
-                    dst.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(item, dst / item.name)
+            seed_case_study_intermediates(src, dst)
             # Schema reconciliation: test-data predictions parquets were
             # generated with an older column convention (y_score / y_true /
             # fold_id). Production registry uses (prediction / actual / fold).

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -1068,17 +1068,26 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
         # The exemption above can only preserve an artifact that exists. A leader with
         # none still falls through to the synthetic write, and the notebook that pins
         # its hash then fails a >0.99 correlation gate against real prices several
-        # stages downstream, nowhere near this function. Nothing here can reconstruct
-        # the artifact - it has to be copied in from the production run_log - so the
-        # gap is reported by hash at regeneration time rather than left to surface as
-        # an unexplained correlation failure. Not fatal: seven of the nine fixtures
-        # are missing at least one leader artifact today, so raising would stop every
-        # regeneration on a pre-existing gap this function did not introduce.
+        # stages downstream, nowhere near this function. The gap is reported by hash
+        # at regeneration time rather than left to surface there. Not fatal: seven of
+        # the nine fixtures are missing at least one leader artifact today, so raising
+        # would stop every regeneration on a pre-existing gap this function did not
+        # introduce.
+        #
+        # Do NOT close the gap by copying the production artifact in. A copied fixture
+        # is stale the moment anything upstream is regenerated, and every case study is
+        # being retrained end to end. What the correlation gate needs is a panel whose
+        # entities and timestamps are the ones the fixture's own labels carry, and whose
+        # historical target is derived from the same synthetic series the scores come
+        # from, so the check is satisfied by construction. That is what the branch below
+        # already does wherever a reference panel exists; a leader with no artifact of
+        # its own is the case that still falls back to a fabricated grid.
         warnings.warn(
             f"{cs_id}: no predictions.parquet on disk for cohort-leader prediction(s) "
-            f"{', '.join(missing_leaders)}; each gets synthetic scores that a replay "
-            "notebook's historical-target check will reject. Copy the real artifacts "
-            "from the production run_log into the fixture.",
+            f"{', '.join(missing_leaders)}; each gets synthetic scores on a fabricated "
+            "entity grid that a replay notebook's historical-target check will reject. "
+            "Generate the artifact against the fixture's own labels, deriving its "
+            "target from the series the scores come from; never copy the production one.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/tests/notebook_worker.py
+++ b/tests/notebook_worker.py
@@ -54,6 +54,8 @@ def _run_full_notebook(
 ) -> dict:
     import papermill as pm
 
+    from tests.pm_helpers import KERNEL_THREAD_CAPS
+
     start = time.perf_counter()
     ipynb_path = _sync_if_needed(py_path, sync_policy)
     tmp_out = Path(tempfile.gettempdir()) / f"ml4t-full-{os.getpid()}-{py_path.stem}.ipynb"
@@ -67,6 +69,7 @@ def _run_full_notebook(
         "PLOTLY_RENDERER": "json",
         "PYTHONUNBUFFERED": "1",
         "MATPLOTLIBRC": str(rc_file),
+        **KERNEL_THREAD_CAPS,
     }
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -64,6 +64,31 @@ import yaml
 REPO_ROOT = Path(__file__).parent.parent
 OVERRIDES_PATH = REPO_ROOT / "tests" / "overrides.yaml"
 
+# Thread-pool caps for the papermill kernel.
+#
+# scikit-learn, NumPy's BLAS, numexpr and their dependencies each default to one
+# thread per core. A notebook kernel therefore opens ~24 threads per pool on this
+# box, and several suites run at once, so the pools oversubscribe the machine by
+# about an order of magnitude. OpenMP pools spin rather than block while they
+# wait, so the cost lands as wall-clock time inside whichever cell happens to be
+# running and reads as that cell timing out. Measured on
+# 11_ml_pipeline/02_regularization_paths: the ten-fit LASSO alpha grid took 761 s
+# for one fold unpinned and 0.90 s pinned, with identical iteration counts, so the
+# optimizer did identical work both times. End to end that notebook went from a
+# 300 s cell timeout to passing in 41 s.
+#
+# CI runners have few cores and lose nothing. A notebook that genuinely wants more
+# threads asks the library rather than the environment (LightGBM's num_threads and
+# torch.set_num_threads both win over these), or a caller raises them via
+# extra_env, which is applied after this table.
+KERNEL_THREAD_CAP = os.environ.get("ML4T_TEST_THREADS", "1")
+KERNEL_THREAD_CAPS = {
+    "OMP_NUM_THREADS": KERNEL_THREAD_CAP,
+    "OPENBLAS_NUM_THREADS": KERNEL_THREAD_CAP,
+    "MKL_NUM_THREADS": KERNEL_THREAD_CAP,
+    "NUMEXPR_NUM_THREADS": KERNEL_THREAD_CAP,
+}
+
 # Cache loaded overrides
 _overrides_cache: dict | None = None
 
@@ -904,6 +929,7 @@ def run_notebook(
         "MPLBACKEND": "Agg",
         "PLOTLY_RENDERER": "json",
         "DISABLE_HPO": "1",
+        **KERNEL_THREAD_CAPS,
     }
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import Path
@@ -910,3 +911,68 @@ def test_unusable_parameters_keeps_a_class_read_before_its_attribute(tmp_path: P
     )
 
     assert unusable_parameters(py, ["LIMIT"]) == {}
+
+
+def test_run_notebook_caps_the_kernel_thread_pools(tmp_path: Path, monkeypatch) -> None:
+    """Every pool the kernel can open is pinned before papermill starts it.
+
+    Unpinned, each of scikit-learn, the BLAS and numexpr opens one thread per
+    core, several suites run at once, and the OpenMP pools spin rather than block
+    while they wait. The wall-clock cost lands inside whichever cell is running
+    and is indistinguishable in the log from that cell being slow.
+    """
+    import papermill
+
+    py = tmp_path / "01_demo.py"
+    py.write_text('# %% tags=["parameters"]\nX = 1\n', encoding="utf-8")
+    monkeypatch.setattr(pm_helpers, "sync_notebook", lambda p: py.with_suffix(".ipynb"))
+
+    seen: dict[str, str | None] = {}
+
+    def capture(*args, **kwargs):
+        for name in pm_helpers.KERNEL_THREAD_CAPS:
+            seen[name] = os.environ.get(name)
+
+    monkeypatch.setattr(papermill, "execute_notebook", capture)
+    for name in pm_helpers.KERNEL_THREAD_CAPS:
+        monkeypatch.setenv(name, "24")
+
+    pm_helpers.run_notebook(py_path=py, timeout=5)
+
+    assert seen == dict.fromkeys(pm_helpers.KERNEL_THREAD_CAPS, pm_helpers.KERNEL_THREAD_CAP)
+    # ...and restored afterwards, so the caps do not leak into the pytest process.
+    assert os.environ["OMP_NUM_THREADS"] == "24"
+
+
+def test_notebook_worker_caps_the_same_pools(tmp_path: Path, monkeypatch) -> None:
+    """The full-execution path builds its own env table, so it can drift from
+    run_notebook's. Both read one table, and this is what notices if they stop."""
+    import papermill
+
+    from tests import notebook_worker
+
+    py = tmp_path / "01_demo.py"
+    py.write_text('# %% tags=["parameters"]\nX = 1\n', encoding="utf-8")
+    py.with_suffix(".ipynb").write_text("{}", encoding="utf-8")
+
+    seen: dict[str, str | None] = {}
+    monkeypatch.setattr(
+        papermill,
+        "execute_notebook",
+        lambda *a, **k: seen.update(
+            {name: os.environ.get(name) for name in pm_helpers.KERNEL_THREAD_CAPS}
+        ),
+    )
+    for name in pm_helpers.KERNEL_THREAD_CAPS:
+        monkeypatch.setenv(name, "24")
+
+    notebook_worker._run_full_notebook(
+        py_path=py,
+        timeout=5,
+        output_dir=None,
+        data_dir=None,
+        extra_env={},
+        sync_policy="never",
+    )
+
+    assert seen == dict.fromkeys(pm_helpers.KERNEL_THREAD_CAPS, pm_helpers.KERNEL_THREAD_CAP)

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -913,6 +914,36 @@ def test_unusable_parameters_keeps_a_class_read_before_its_attribute(tmp_path: P
     assert unusable_parameters(py, ["LIMIT"]) == {}
 
 
+class _FakePapermill(types.ModuleType):
+    """Stands in for papermill, which `test-unit` deliberately does not install.
+
+    Both execution paths do `import papermill as pm` inside the function, so a module
+    placed in sys.modules is what they get. Recording os.environ at that moment is
+    exactly what the kernel would inherit.
+    """
+
+    class PapermillExecutionError(Exception):
+        cell_index = 0
+        ename = "x"
+        evalue = "x"
+
+    def __init__(self, seen: dict[str, str | None]) -> None:
+        super().__init__("papermill")
+        self.seen = seen
+
+    def execute_notebook(self, *args, **kwargs) -> None:
+        for name in pm_helpers.KERNEL_THREAD_CAPS:
+            self.seen[name] = os.environ.get(name)
+
+
+def _fake_papermill(monkeypatch) -> dict[str, str | None]:
+    seen: dict[str, str | None] = {}
+    monkeypatch.setitem(sys.modules, "papermill", _FakePapermill(seen))
+    for name in pm_helpers.KERNEL_THREAD_CAPS:
+        monkeypatch.setenv(name, "24")
+    return seen
+
+
 def test_run_notebook_caps_the_kernel_thread_pools(tmp_path: Path, monkeypatch) -> None:
     """Every pool the kernel can open is pinned before papermill starts it.
 
@@ -921,21 +952,10 @@ def test_run_notebook_caps_the_kernel_thread_pools(tmp_path: Path, monkeypatch) 
     while they wait. The wall-clock cost lands inside whichever cell is running
     and is indistinguishable in the log from that cell being slow.
     """
-    import papermill
-
     py = tmp_path / "01_demo.py"
     py.write_text('# %% tags=["parameters"]\nX = 1\n', encoding="utf-8")
     monkeypatch.setattr(pm_helpers, "sync_notebook", lambda p: py.with_suffix(".ipynb"))
-
-    seen: dict[str, str | None] = {}
-
-    def capture(*args, **kwargs):
-        for name in pm_helpers.KERNEL_THREAD_CAPS:
-            seen[name] = os.environ.get(name)
-
-    monkeypatch.setattr(papermill, "execute_notebook", capture)
-    for name in pm_helpers.KERNEL_THREAD_CAPS:
-        monkeypatch.setenv(name, "24")
+    seen = _fake_papermill(monkeypatch)
 
     pm_helpers.run_notebook(py_path=py, timeout=5)
 
@@ -947,24 +967,12 @@ def test_run_notebook_caps_the_kernel_thread_pools(tmp_path: Path, monkeypatch) 
 def test_notebook_worker_caps_the_same_pools(tmp_path: Path, monkeypatch) -> None:
     """The full-execution path builds its own env table, so it can drift from
     run_notebook's. Both read one table, and this is what notices if they stop."""
-    import papermill
-
     from tests import notebook_worker
 
     py = tmp_path / "01_demo.py"
     py.write_text('# %% tags=["parameters"]\nX = 1\n', encoding="utf-8")
     py.with_suffix(".ipynb").write_text("{}", encoding="utf-8")
-
-    seen: dict[str, str | None] = {}
-    monkeypatch.setattr(
-        papermill,
-        "execute_notebook",
-        lambda *a, **k: seen.update(
-            {name: os.environ.get(name) for name in pm_helpers.KERNEL_THREAD_CAPS}
-        ),
-    )
-    for name in pm_helpers.KERNEL_THREAD_CAPS:
-        monkeypatch.setenv(name, "24")
+    seen = _fake_papermill(monkeypatch)
 
     notebook_worker._run_full_notebook(
         py_path=py,

--- a/tests/test_seeded_output_dir.py
+++ b/tests/test_seeded_output_dir.py
@@ -1,0 +1,84 @@
+"""The fixture seed has to leave the output dir holding the fixture and nothing else.
+
+CI checks the test-data repo out into a clean container on every run. A lane re-runs
+into an existing ML4T_OUTPUT_DIR, so anything the seed leaves behind is a difference
+between what CI measures and what the lane measures, on identical code.
+"""
+
+from pathlib import Path
+
+from tests.conftest import SEEDED_SUBDIRS, seed_case_study_intermediates
+
+
+def _fixture(root: Path, **subdirs: str) -> Path:
+    src = root / "etfs"
+    for name, content in subdirs.items():
+        (src / name).mkdir(parents=True, exist_ok=True)
+        (src / name / f"{name}.txt").write_text(content, encoding="utf-8")
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "eligibility.csv").write_text("symbol\nSPY\n", encoding="utf-8")
+    return src
+
+
+def test_seed_replaces_a_registry_left_by_a_previous_run(tmp_path: Path) -> None:
+    """run_log/registry.db is the one that matters: a previous run's registry carries
+    every training run, prediction set and backtest that run registered, and the
+    notebooks then resolve identities the fixture does not carry."""
+    src = _fixture(tmp_path / "intermediates", run_log="fixture registry")
+    dst = tmp_path / "out" / "etfs"
+    (dst / "run_log").mkdir(parents=True)
+    (dst / "run_log" / "run_log.txt").write_text("previous run registry", encoding="utf-8")
+
+    seed_case_study_intermediates(src, dst)
+
+    assert (dst / "run_log" / "run_log.txt").read_text(encoding="utf-8") == "fixture registry"
+
+
+def test_seed_removes_a_subdir_the_fixture_no_longer_ships(tmp_path: Path) -> None:
+    """Nothing overwrites a subdir with no source, so a leftover there survives every
+    later run while reading as fixture data."""
+    src = _fixture(tmp_path / "intermediates", labels="fixture labels")
+    dst = tmp_path / "out" / "etfs"
+    (dst / "results").mkdir(parents=True)
+    (dst / "results" / "stale.json").write_text("{}", encoding="utf-8")
+
+    seed_case_study_intermediates(src, dst)
+
+    assert not (dst / "results").exists()
+    assert (dst / "labels" / "labels.txt").read_text(encoding="utf-8") == "fixture labels"
+
+
+def test_seed_refreshes_top_level_files(tmp_path: Path) -> None:
+    src = _fixture(tmp_path / "intermediates", labels="fixture labels")
+    dst = tmp_path / "out" / "etfs"
+    dst.mkdir(parents=True)
+    (dst / "eligibility.csv").write_text("symbol\nSTALE\n", encoding="utf-8")
+
+    seed_case_study_intermediates(src, dst)
+
+    assert (dst / "eligibility.csv").read_text(encoding="utf-8") == "symbol\nSPY\n"
+
+
+def test_seed_is_idempotent(tmp_path: Path) -> None:
+    src = _fixture(tmp_path / "intermediates", run_log="fixture registry", labels="fixture labels")
+    dst = tmp_path / "out" / "etfs"
+
+    seed_case_study_intermediates(src, dst)
+    first = sorted(p.relative_to(dst).as_posix() for p in dst.rglob("*"))
+    seed_case_study_intermediates(src, dst)
+
+    assert sorted(p.relative_to(dst).as_posix() for p in dst.rglob("*")) == first
+    assert (dst / "run_log" / "run_log.txt").read_text(encoding="utf-8") == "fixture registry"
+
+
+def test_every_seeded_subdir_is_reset(tmp_path: Path) -> None:
+    """Whatever the list is, a stale copy of each entry does not survive the seed."""
+    src = _fixture(tmp_path / "intermediates")
+    dst = tmp_path / "out" / "etfs"
+    for name in SEEDED_SUBDIRS:
+        (dst / name).mkdir(parents=True)
+        (dst / name / "stale").write_text("x", encoding="utf-8")
+
+    seed_case_study_intermediates(src, dst)
+
+    assert [name for name in SEEDED_SUBDIRS if (dst / name).exists()] == []


### PR DESCRIPTION
Three changes to the test harness, all of them cases where a local run and a CI run measured
different things on identical code.

## The kernel opened one thread per core, per pool

scikit-learn, the BLAS and numexpr each default that way, several suites run at once on a
24-core box, and OpenMP pools spin rather than block while they wait. The cost lands as
wall-clock time inside whichever cell happens to be running, so the log shows that cell being
slow and nothing else.

Measured on `11_ml_pipeline/02_regularization_paths`, whose failing cell is a ten-fit LASSO
alpha grid:

| | Wall | CPU | Iterations used |
|---|---|---|---|
| unpinned, load 24-45 | 761 s for one fold | not measured | 1, 45, 48, 79, 110, 80, 110, 255, 289, 404 |
| pinned, load 12-34 | **0.90 s** | 0.90 s | 1, 45, 48, 79, 110, 80, 110, 255, 289, 404 |

Identical iteration counts at every alpha, so the optimizer did identical work both times, and
every fit converged well inside `max_iter`. Wall equals CPU when pinned, which is what says the
unpinned run was not computing. End to end that notebook went from a 300 s cell timeout that did
not finish inside 2400 s to passing in 41 s.

Both execution paths built their own env table, so they could drift apart. They now share
`KERNEL_THREAD_CAPS`, and `tests/test_pm_helpers.py` watches each one through papermill, so
dropping the caps from either fails. `ML4T_TEST_THREADS` raises the cap, and a library-level
setting still wins over the environment: LightGBM's `num_threads` and `torch.set_num_threads`
are unaffected.

This matters beyond the one notebook because the failure is indistinguishable from a real
timeout in the logs, and it moves between notebooks depending on which lanes are busy. Any lane
reading a timeout as a notebook defect will change shipped code to work around a scheduling
artifact.

## The fixture seed filled gaps instead of replacing

CI checks the test-data repo out into a clean container every run. A lane re-running into an
existing `ML4T_OUTPUT_DIR` kept whatever the previous run had left, and for `run_log/registry.db`
that means every training run, prediction set and backtest the previous run registered. The
notebooks then resolved identities neither the fixture nor production carries, so the same code
produced a different failure list locally than in CI.

It now replaces what it seeds, which is what the config copy directly above it already did. The
destination goes first whether or not the fixture still ships a source for it: a subdir the
fixture has stopped shipping is exactly the leftover nothing would ever overwrite. The loop is
extracted as `seed_case_study_intermediates` so it is testable, and `tests/test_seeded_output_dir.py`
covers the registry left by a previous run, the subdir with no source, the top-level files,
idempotence, and every entry in `SEEDED_SUBDIRS`. Three of those five fail against the code this
replaces.

## `seed_results` told the next reader to copy a production artifact in

The warning for a cohort-leader prediction with no `predictions.parquet` said to copy the real
artifact from the production `run_log`. A copied fixture is stale the moment anything upstream is
regenerated, and the case studies are being retrained end to end, so following that instruction
guarantees the fixture drifts out from under the tests depending on it.

What the downstream correlation gate needs is a panel carrying the entities and timestamps the
fixture's own labels carry, with its historical target derived from the same synthetic series the
scores come from, so the check is satisfied by construction. The code already does that wherever a
reference panel exists. A leader with no artifact of its own still falls back to a fabricated grid,
and that gap is **not** closed here - only the instruction is corrected.

## Verification

`tests/test_pm_helpers.py` 74 passed, `tests/test_seeded_output_dir.py` 5 passed,
`tests/test_seed_prediction_fixtures.py` 8 passed. Each new test was watched failing against the
pre-change code before being trusted.

The wider unit run (`tests/` less the four notebook suites) was 1235 passed / 13 failed before
these changes, and clean `main` gives the identical 13, so none of them are introduced here. They
are `test_artifact_specs`, `test_import_coverage`, and the `sp500_options` financial-features,
GARCH-PIT and fold-alignment tests. A confirming re-run after the final commit was still in
progress when this was opened; the box was heavily loaded and it had not reached the changed
areas' dependents.
