### PR TITLE
Correctness in the shared statistics and cross-validation code

### DIFF
--- a/case_studies/utils/cv_window.py
+++ b/case_studies/utils/cv_window.py
@@ -13,11 +13,13 @@ re-running ``run_backtest`` on a sliced parquet is a no-op.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Sequence
 from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
+import pandas as pd
 import yaml
 
 from utils.paths import get_case_study_dir
@@ -154,6 +156,96 @@ def modeling_fold_boundaries(case_study: str, label: str) -> list[dict] | None:
         }
         for split in splits
     ]
+
+
+def configured_labels(case_study: str) -> list[str]:
+    """Every label the case study configures, primary first."""
+    setup = _load_setup_yaml(case_study) or {}
+    labels = setup.get("labels", {}) or {}
+    primary = labels.get("primary")
+    variants = list(labels.get("variants", []) or [])
+    return ([primary] if primary else []) + [v for v in variants if v != primary]
+
+
+def assert_variant_folds_are_out_of_sample(
+    case_study: str,
+    primary_label: str,
+    *,
+    variants: Sequence[str] | None = None,
+) -> list[dict]:
+    """Every variant label's fold F must validate after the primary's fold F stops training.
+
+    A stage-04 artifact carries one fold set, built on the primary label's geometry,
+    and a model trained on a variant label reads that artifact by ``fold`` id. So the
+    values it reads for fold F were fit on data through the **primary** label's
+    ``train_end``. The variant's own validation window has to start after that, or the
+    model is scored on sessions the features already saw:
+
+        variant.val_start > primary.train_end,  per fold, per configured variant
+
+    Nothing checked this. Measured across the eight stage-04 case studies on
+    2026-08-09, 20 variant labels, zero violations, so no artifact leaks today; what
+    was missing is anything that would notice if a label's buffer changed. Of the
+    two notebooks that assert something, only sp500_equity_option_analytics tests
+    this property; fx_pairs compares the outer span
+    (``variant.train_start >= primary.train_start and variant.val_end <= primary.val_end``),
+    which never reads ``val_start`` and would pass on a geometry that leaks.
+
+    **Compares timestamps, never dates.** At date granularity
+    nasdaq100_microstructure fold 0 reads as a violation, 2020-12-29 against
+    2020-12-29; the bars are minutes, the fit closes at 15:22 and the variant's
+    validation opens at 15:38.
+
+    Returns one row per (label, fold) with the gap, so a notebook can display what it
+    just asserted. A variant with no label parquet is skipped, which is what the
+    producers do with it too.
+    """
+    primary = _derive_modeling_splits(case_study, primary_label)
+    if primary is None:
+        raise ValueError(
+            f"No folds derivable for the primary label '{primary_label}' of "
+            f"'{case_study}', so no variant geometry can be checked against it."
+        )
+    by_fold = {int(s["fold"]): s for s in primary}
+
+    if variants is None:
+        variants = [x for x in configured_labels(case_study) if x != primary_label]
+
+    rows: list[dict] = []
+    violations: list[str] = []
+    for label in variants:
+        splits = _derive_modeling_splits(case_study, label)
+        if splits is None:
+            continue
+        for split in splits:
+            fold = int(split["fold"])
+            if fold not in by_fold:
+                violations.append(f"{label} fold {fold} has no counterpart in {primary_label}")
+                continue
+            fit_end = pd.Timestamp(by_fold[fold]["train_end"])
+            val_start = pd.Timestamp(split["val_start"])
+            rows.append(
+                {
+                    "label": label,
+                    "fold": fold,
+                    f"{primary_label} train_end": fit_end,
+                    "val_start": val_start,
+                    "gap": val_start - fit_end,
+                }
+            )
+            if val_start <= fit_end:
+                violations.append(
+                    f"{label} fold {fold}: validation opens {val_start}, and the features "
+                    f"for that fold were fit through {fit_end}"
+                )
+
+    if violations:
+        raise AssertionError(
+            "the artifact's per-fold estimation windows reach into a variant label's "
+            "validation span, so a model reading fold F by id is scored on sessions its "
+            "features already saw: " + "; ".join(violations)
+        )
+    return rows
 
 
 def _validation_window_for_label(case_study: str, label: str) -> tuple[date, date] | None:

--- a/case_studies/utils/feature_engineering.py
+++ b/case_studies/utils/feature_engineering.py
@@ -40,6 +40,7 @@ __all__ = [
     "drawdown_block",
     "families_from_config",
     "family_coverage",
+    "has_value",
     "plot_coverage_through_time",
     "plot_cross_sectional_dispersion",
     "plot_feature_distributions",
@@ -385,6 +386,27 @@ def trailing_sharpe(
 # ---------------------------------------------------------------------------
 
 
+def has_value(dtype: pl.DataType, column: str) -> pl.Expr:
+    """True where the column holds a number: neither null nor NaN.
+
+    Polars counts NaN as a value, so ``is_not_null()`` is True for it, and the
+    feature calls do not agree on which one a warm-up head is written with -
+    polars' own ``rolling_mean`` emits null, ``ml4t.engineer.features.momentum``
+    emits NaN. Reading a NaN as covered breaks both directions: ``warmup_audit``
+    takes the first bar as populated for any NaN-warmup column and raises the
+    look-ahead assertion on a column that is correctly warmed up, which is what
+    ``rsi_14d`` did in fx_pairs, and ``family_coverage`` draws a stretch holding
+    no values as fully covered, which is silent.
+
+    A notebook should not have to normalize its frame before a helper can count
+    it, so both helpers apply this rather than expecting a ``fill_nan(None)``.
+    """
+    populated = pl.col(column).is_not_null()
+    if dtype.is_float():
+        populated = populated & pl.col(column).is_not_nan()
+    return populated
+
+
 def warmup_audit(
     df: pl.DataFrame,
     expected: Mapping[str, int],
@@ -399,13 +421,16 @@ def warmup_audit(
     bars. A column that is populated **earlier** than its lookback allows is
     reading rows it cannot see, so the check raises rather than reporting.
 
+    A NaN is not a value here: see :func:`has_value`.
+
     Returns the per-column census so the notebook can show it.
     """
     keys = [entity] if isinstance(entity, str) else list(entity)
     ranked = df.sort([*keys, time]).with_columns(pl.col(time).cum_count().over(keys).alias("_bar"))
+    schema = ranked.schema
     rows = []
     for column, bars in expected.items():
-        observed = ranked.filter(pl.col(column).is_not_null())["_bar"].min()
+        observed = ranked.filter(has_value(schema[column], column))["_bar"].min()
         observed = None if observed is None else int(observed)
         rows.append(
             {
@@ -493,7 +518,11 @@ def family_coverage(
     time: str = "timestamp",
     every: str | None = None,
 ) -> pl.DataFrame:
-    """Non-null share per family per decision timestamp.
+    """Share of a family's columns holding a value, per decision timestamp.
+
+    A NaN is not a value here: see :func:`has_value`. Counting one as covered
+    draws a warm-up head, or any stretch a library call filled with NaN, as a
+    dense line.
 
     *every* buckets the time axis (``"1mo"``) where the panel has more decision
     timestamps than a chart can resolve.
@@ -501,11 +530,12 @@ def family_coverage(
     frame = df
     if every is not None:
         frame = frame.with_columns(pl.col(time).dt.truncate(every).alias(time))
+    schema = frame.schema
     families: dict[str, list[str]] = {}
     for column, family in assignment.items():
         families.setdefault(family, []).append(column)
     aggs = [
-        pl.mean_horizontal([pl.col(c).is_not_null() for c in cols]).mean().alias(family)
+        pl.mean_horizontal([has_value(schema[c], c) for c in cols]).mean().alias(family)
         for family, cols in families.items()
     ]
     return frame.group_by(time).agg(aggs).sort(time)

--- a/case_studies/utils/notebook_contracts.py
+++ b/case_studies/utils/notebook_contracts.py
@@ -7,6 +7,34 @@ import polars as pl
 # Families excluded from ALL backtest sweeps — predictions lack y_score column
 _BACKTEST_EXCLUDED_FAMILIES: set[str] = {"causal_dml"}
 
+# The minimum cross-section `cross_sectional_ic_series` needs before it will return a
+# coefficient for a date. 5 at every case-study call site; the library default is 10.
+IC_MIN_OBS = 5
+
+# The predictions parquet schema is not uniform across the nine case studies, so the
+# validity rule has to resolve its own column names before it can count anything.
+# Measured: etfs / fx_pairs / us_firm_characteristics use prediction+actual+symbol,
+# sp500_equity_option_analytics uses y_score+y_true+symbol, cme_futures keys on product.
+_PREDICTION_ALIASES = ("prediction", "y_score", "y_pred", "score")
+_ACTUAL_ALIASES = ("actual", "y_true", "realized", "target")
+_ENTITY_ALIASES = ("symbol", "product", "asset", "entity")
+
+
+def _first_present(columns: list[str], aliases: tuple[str, ...]) -> str | None:
+    return next((a for a in aliases if a in columns), None)
+
+
+def _is_finite(dtype: pl.DataType, column: str) -> pl.Expr:
+    """True where the column holds a real number, as the IC series requires.
+
+    Null, NaN and infinity each mean the entity contributes nothing to that date's
+    rank correlation. ``is_finite`` is undefined on a non-float column, where being
+    non-null is the whole of the condition.
+    """
+    if dtype.is_float():
+        return pl.col(column).is_not_null() & pl.col(column).is_finite()
+    return pl.col(column).is_not_null()
+
 
 def excluded_families(case_study: str, *, for_backtest: bool = False) -> set[str]:
     return set(_BACKTEST_EXCLUDED_FAMILIES) if for_backtest else set()
@@ -84,7 +112,7 @@ def canonical_coverage_days(
     prediction_hash: str,
     case_dir: Path | None = None,
 ) -> int | None:
-    """Count of a prediction set's decision dates inside ``canonical_window``.
+    """Count of a prediction set's *scorable* decision dates inside ``canonical_window``.
 
     ``ic_n_days`` (stored in ``prediction_metrics`` at registration time) counts every
     date in the predictions parquet passed to the metrics function at write time, which
@@ -98,8 +126,18 @@ def canonical_coverage_days(
     window, for use by the ``coverage_window="canonical"`` path of
     ``resolve_best_predictions`` / ``resolve_best_backtest_runs``.
 
-    Returns ``None`` when the window or the parquet file is unavailable — callers must
-    treat that as "cannot evaluate", not zero coverage.
+    **A date counts only where its cross-section could be scored.** This stands in for
+    ``ic_n_days``, which counts the days ``cross_sectional_ic_series`` actually produced
+    a coefficient for, and that function nulls a day unless at least ``min_obs``
+    entities carry a finite prediction *and* a finite realized return. Counting rows
+    present would let a prediction set with a row every day but two usable names on some
+    of them read as full coverage while the raw path correctly discounted it, and the
+    two counts are compared against each other. ``min_obs`` is 5 at every case-study
+    call site.
+
+    Returns ``None`` when the window, the parquet, or the columns the validity rule
+    needs are unavailable. Callers must treat that as "cannot evaluate", not as zero
+    coverage.
     """
     from case_studies.utils.cv_window import canonical_window
     from utils.paths import get_case_study_dir
@@ -116,22 +154,43 @@ def canonical_coverage_days(
     date_col = "timestamp" if "timestamp" in cols else ("date" if "date" in cols else None)
     if date_col is None:
         return None
-    dates = pl.scan_parquet(path).select(date_col).collect().to_series()
-    if dates.dtype != pl.Date:
+    prediction_col = _first_present(cols, _PREDICTION_ALIASES)
+    actual_col = _first_present(cols, _ACTUAL_ALIASES)
+    if prediction_col is None or actual_col is None:
+        return None
+    entity_col = _first_present(cols, _ENTITY_ALIASES)
+
+    selected = [date_col, prediction_col, actual_col] + ([entity_col] if entity_col else [])
+    frame = pl.scan_parquet(path).select(selected).collect()
+    if frame.is_empty():
+        return 0
+
+    # Cast to a calendar date BEFORE grouping, never after: on an intraday case
+    # study the column is a Datetime and every timestamp within a day is distinct,
+    # so grouping first counts one decision date many times and the count stops
+    # being comparable to the daily `ic_n_days` it stands in for.
+    if frame.schema[date_col] != pl.Date:
         try:
-            dates = dates.cast(pl.Date)
+            frame = frame.with_columns(pl.col(date_col).cast(pl.Date))
         except pl.exceptions.PolarsError:
             # A column named `timestamp` that is not a calendar date is one more
             # "cannot evaluate" case, so it degrades to None like the others
             # rather than raising past every caller.
             return None
-    # Deduplicate AFTER the cast, never before: on an intraday case study the
-    # column is a Datetime and every timestamp within a day is distinct, so
-    # deduplicating first counts one decision date many times and the count stops
-    # being comparable to the daily `ic_n_days` it stands in for.
-    dates = dates.unique()
+
     lo, hi = window
-    return int(((dates >= lo) & (dates <= hi)).sum())
+    scorable = frame.filter(
+        pl.col(date_col).is_between(lo, hi)
+        & _is_finite(frame.schema[prediction_col], prediction_col)
+        & _is_finite(frame.schema[actual_col], actual_col)
+    )
+    if scorable.is_empty():
+        return 0
+    # The cross-section is a set of entities, so a duplicated entity on a date does
+    # not widen it. Without an entity column a row is the best available proxy.
+    breadth = pl.col(entity_col).n_unique() if entity_col else pl.len()
+    per_date = scorable.group_by(date_col).agg(breadth.alias("_breadth"))
+    return int((per_date["_breadth"] >= IC_MIN_OBS).sum())
 
 
 def filter_active_model_rows(

--- a/case_studies/utils/notebook_contracts.py
+++ b/case_studies/utils/notebook_contracts.py
@@ -16,7 +16,11 @@ IC_MIN_OBS = 5
 # Measured: etfs / fx_pairs / us_firm_characteristics use prediction+actual+symbol,
 # sp500_equity_option_analytics uses y_score+y_true+symbol, cme_futures keys on product.
 _PREDICTION_ALIASES = ("prediction", "y_score", "y_pred", "score")
-_ACTUAL_ALIASES = ("actual", "y_true", "realized", "target")
+# `eval_actual` first: for a classification label the stored IC is computed against
+# the continuous return, which `registry/store.py:712-745` writes under that name
+# beside the class target. Resolving `actual`/`y_true` ahead of it would judge a
+# date's validity on the class column while the metric used the return.
+_ACTUAL_ALIASES = ("eval_actual", "actual", "y_true", "realized", "target")
 _ENTITY_ALIASES = ("symbol", "product", "asset", "entity")
 
 
@@ -189,8 +193,21 @@ def canonical_coverage_days(
     # The cross-section is a set of entities, so a duplicated entity on a date does
     # not widen it. Without an entity column a row is the best available proxy.
     breadth = pl.col(entity_col).n_unique() if entity_col else pl.len()
-    per_date = scorable.group_by(date_col).agg(breadth.alias("_breadth"))
-    return int((per_date["_breadth"] >= IC_MIN_OBS).sum())
+    per_date = scorable.group_by(date_col).agg(
+        breadth.alias("_breadth"),
+        # A rank correlation is undefined where either side is the same value for
+        # every name on the date, so breadth alone would count a date the IC series
+        # returns null for. n_unique rather than a variance: Spearman ranks, and a
+        # constant column has one rank whatever its spread.
+        pl.col(prediction_col).n_unique().alias("_pred_levels"),
+        pl.col(actual_col).n_unique().alias("_actual_levels"),
+    )
+    defined = (
+        (per_date["_breadth"] >= IC_MIN_OBS)
+        & (per_date["_pred_levels"] > 1)
+        & (per_date["_actual_levels"] > 1)
+    )
+    return int(defined.sum())
 
 
 def filter_active_model_rows(

--- a/tests/test_artifact_sidecar_verification.py
+++ b/tests/test_artifact_sidecar_verification.py
@@ -1,0 +1,86 @@
+"""The digest sidecar gets a read side.
+
+`artifact_digest.py` writes `<artifact>.digest.json` beside every artifact and its
+own docstring said the chain stopped there: "It is a record, not propagation.
+Nothing downstream reads these sidecars today." The registry records feature-set
+names and no digest of feature values, so a model trained on corrected features and
+one trained on the leaky version it replaced produce the identical training_hash.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.utils.artifact_digest import value_digest, write_artifact
+from utils.modeling import verify_artifact_sidecars
+
+
+def _artifact(tmp_path: Path, name: str = "financial", values=(1.0, 2.0, 3.0)) -> Path:
+    frame = pl.DataFrame(
+        {"timestamp": [1, 2, 3], "symbol": ["A", "B", "C"], "feature": list(values)}
+    )
+    path = tmp_path / f"{name}.parquet"
+    write_artifact(frame, path, keys=["timestamp", "symbol"], written_by="test")
+    return path
+
+
+def test_an_artifact_matching_its_sidecar_verifies(tmp_path: Path) -> None:
+    path = _artifact(tmp_path)
+    assert verify_artifact_sidecars({"financial": path}) == {
+        "financial": value_digest(pl.read_parquet(path))
+    }
+
+
+def test_a_changed_feature_value_is_caught(tmp_path: Path) -> None:
+    """The case the issue is about: values move, the sidecar does not."""
+    path = _artifact(tmp_path)
+    pl.DataFrame(
+        {"timestamp": [1, 2, 3], "symbol": ["A", "B", "C"], "feature": [9.0, 9.0, 9.0]}
+    ).write_parquet(path)
+
+    with pytest.raises(ValueError, match="hashes .*, its sidecar records"):
+        verify_artifact_sidecars({"financial": path})
+
+
+def test_an_artifact_with_no_sidecar_is_refused(tmp_path: Path) -> None:
+    """An artifact whose producer recorded nothing cannot be told from a changed one."""
+    bare = tmp_path / "model_based.parquet"
+    pl.DataFrame({"timestamp": [1], "symbol": ["A"], "f": [1.0]}).write_parquet(bare)
+
+    with pytest.raises(ValueError, match="no digest sidecar"):
+        verify_artifact_sidecars({"model_based": bare})
+
+
+def test_a_sidecar_recording_no_digest_is_refused(tmp_path: Path) -> None:
+    path = _artifact(tmp_path)
+    side = Path(f"{path}.digest.json")
+    side.write_text(json.dumps({"n_rows": 3}))
+
+    with pytest.raises(ValueError, match="records no digest"):
+        verify_artifact_sidecars({"financial": path})
+
+
+def test_an_unreadable_sidecar_is_refused(tmp_path: Path) -> None:
+    path = _artifact(tmp_path)
+    Path(f"{path}.digest.json").write_text("{not json")
+
+    with pytest.raises(ValueError, match="unreadable"):
+        verify_artifact_sidecars({"financial": path})
+
+
+def test_every_failing_artifact_is_named_not_just_the_first(tmp_path: Path) -> None:
+    """A run with two stale inputs should report two, so one pass fixes both."""
+    good = _artifact(tmp_path, "financial")
+    stale = _artifact(tmp_path, "label")
+    pl.DataFrame({"timestamp": [1], "symbol": ["A"], "feature": [0.0]}).write_parquet(stale)
+    bare = tmp_path / "model_based.parquet"
+    pl.DataFrame({"timestamp": [1], "symbol": ["A"], "f": [1.0]}).write_parquet(bare)
+
+    with pytest.raises(ValueError) as excinfo:
+        verify_artifact_sidecars({"financial": good, "label": stale, "model_based": bare})
+    message = str(excinfo.value)
+    assert "label:" in message and "model_based:" in message and "financial:" not in message

--- a/tests/test_artifact_specs.py
+++ b/tests/test_artifact_specs.py
@@ -112,3 +112,50 @@ def test_microstructure_pilot_helpers_preserve_current_outputs() -> None:
     assert len(mds.splits) == 2
     assert mds.label_buffer == "15min"
     assert mds.task_type == "regression"
+
+
+def test_universe_reduction_breaks_row_count_ties_on_entity_name() -> None:
+    """Tied row counts must reduce to the same universe on every call.
+
+    ``max_symbols`` picks the entities with the most rows. When counts tie at the
+    cutoff, an unstable sort lets two callers reducing the same dataset to the
+    same size pick different symbols - a reduced stage-04 run and the reduced
+    model notebooks downstream of it, for instance. The symbols only one of them
+    chose then carry null model-based features, which runs clean and is wrong.
+
+    The panel gives every symbol the same row count, so the cutoff is decided
+    entirely by the tie-break, and the frame is then reordered to show the
+    reduction does not follow frame order.
+    """
+    import polars as pl
+
+    from utils.modeling import reduce_to_top_entities
+
+    dataset = pl.DataFrame(
+        {
+            "symbol": [s for s in ("DELTA", "ALPHA", "CHARLIE", "BRAVO") for _ in range(3)],
+            "value": list(range(12)),
+        }
+    )
+
+    def kept(frame: pl.DataFrame) -> list[str]:
+        return sorted(reduce_to_top_entities(frame, "symbol", 2)["symbol"].unique())
+
+    assert kept(dataset) == ["ALPHA", "BRAVO"]
+    assert kept(dataset.sort("value", descending=True)) == ["ALPHA", "BRAVO"]
+    assert kept(dataset.sample(fraction=1.0, shuffle=True, seed=7)) == ["ALPHA", "BRAVO"]
+
+
+def test_universe_reduction_prefers_history_over_name() -> None:
+    """The name is the tie-break, never the criterion: more rows still wins."""
+    import polars as pl
+
+    from utils.modeling import reduce_to_top_entities
+
+    dataset = pl.DataFrame(
+        {"symbol": ["ZULU"] * 5 + ["ALPHA"] * 2 + ["BRAVO"] * 2, "value": list(range(9))}
+    )
+    assert sorted(reduce_to_top_entities(dataset, "symbol", 2)["symbol"].unique()) == [
+        "ALPHA",
+        "ZULU",
+    ]

--- a/tests/test_canonical_coverage_bar.py
+++ b/tests/test_canonical_coverage_bar.py
@@ -136,8 +136,10 @@ def test_intraday_timestamps_count_one_decision_date_once(
 
     The frame carries a realized return and an entity column because the count is
     of *scorable* dates, and a date is scorable only where at least `min_obs`
-    entities hold a finite prediction and a finite return. Eight names per bar puts
-    every date above the floor, so what this measures is the dedup and nothing else.
+    entities hold a finite prediction and a finite return, varying across the
+    cross-section - a rank correlation is undefined where either side is constant.
+    Eight names per bar, each with its own value, puts every date above the floor
+    with a defined coefficient, so what this measures is the dedup and nothing else.
     """
     import datetime as dt
 
@@ -153,8 +155,8 @@ def test_intraday_timestamps_count_one_decision_date_once(
         {
             "timestamp": [t for t, _ in rows],
             "symbol": [s for _, s in rows],
-            "prediction": [0.5] * len(rows),
-            "actual": [0.1] * len(rows),
+            "prediction": [float(s[1:]) for _, s in rows],
+            "actual": [float(s[1:]) * 0.5 for _, s in rows],
         }
     ).write_parquet(pred_dir / "predictions.parquet")
     monkeypatch.setattr(

--- a/tests/test_canonical_coverage_bar.py
+++ b/tests/test_canonical_coverage_bar.py
@@ -132,7 +132,13 @@ def test_intraday_timestamps_count_one_decision_date_once(
 ) -> None:
     """A minute-bar case study's `timestamp` is a Datetime, so deduplicating before
     the cast to Date counts every bar as its own decision date and the count stops
-    being comparable to the daily `ic_n_days` it stands in for."""
+    being comparable to the daily `ic_n_days` it stands in for.
+
+    The frame carries a realized return and an entity column because the count is
+    of *scorable* dates, and a date is scorable only where at least `min_obs`
+    entities hold a finite prediction and a finite return. Eight names per bar puts
+    every date above the floor, so what this measures is the dedup and nothing else.
+    """
     import datetime as dt
 
     import polars as pl
@@ -142,9 +148,15 @@ def test_intraday_timestamps_count_one_decision_date_once(
     pred_dir = tmp_path / "run_log" / "predictions" / "H"
     pred_dir.mkdir(parents=True)
     bars = [dt.datetime(2020, 1, day, hour) for day in (6, 7, 8) for hour in (9, 10, 11, 12)]
-    pl.DataFrame({"timestamp": bars, "prediction": [0.0] * len(bars)}).write_parquet(
-        pred_dir / "predictions.parquet"
-    )
+    rows = [(bar, f"S{i}") for bar in bars for i in range(8)]
+    pl.DataFrame(
+        {
+            "timestamp": [t for t, _ in rows],
+            "symbol": [s for _, s in rows],
+            "prediction": [0.5] * len(rows),
+            "actual": [0.1] * len(rows),
+        }
+    ).write_parquet(pred_dir / "predictions.parquet")
     monkeypatch.setattr(
         cv_window,
         "canonical_window",

--- a/tests/test_canonical_coverage_days.py
+++ b/tests/test_canonical_coverage_days.py
@@ -1,0 +1,146 @@
+"""A date counts toward canonical coverage only where its cross-section is scorable.
+
+This count stands in for ``ic_n_days``, which is the number of days
+``cross_sectional_ic_series`` returned a coefficient for, and that function nulls a
+day unless at least ``min_obs`` entities carry a finite prediction and a finite
+realized return. Counting rows present instead let a prediction set with a row every
+day but two usable names on some of them read as full coverage while the raw path
+correctly discounted it - and the two counts are compared against each other in
+``full_coverage_prediction_sql``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import case_studies.utils.notebook_contracts as contracts
+from case_studies.utils.notebook_contracts import IC_MIN_OBS, canonical_coverage_days
+
+WINDOW = (dt.date(2020, 1, 1), dt.date(2020, 1, 31))
+
+
+def _write(
+    case_dir: Path,
+    rows: list[dict],
+    prediction_hash: str = "abc",
+    prediction_col: str = "prediction",
+    actual_col: str = "actual",
+    entity_col: str = "symbol",
+) -> None:
+    out = case_dir / "run_log" / "predictions" / prediction_hash
+    out.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        [
+            {
+                "timestamp": r["timestamp"],
+                entity_col: r["entity"],
+                prediction_col: r["prediction"],
+                actual_col: r["actual"],
+            }
+            for r in rows
+        ]
+    ).write_parquet(out / "predictions.parquet")
+
+
+def _rows(day: int, n: int, prediction=1.0, actual=1.0) -> list[dict]:
+    return [
+        {
+            "timestamp": dt.datetime(2020, 1, day, 16, 0),
+            "entity": f"S{i}",
+            "prediction": prediction if not callable(prediction) else prediction(i),
+            "actual": actual if not callable(actual) else actual(i),
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _fixed_window(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(contracts, "canonical_window", None, raising=False)
+    import case_studies.utils.cv_window as cv_window
+
+    monkeypatch.setattr(cv_window, "canonical_window", lambda *a, **k: WINDOW)
+
+
+def _count(case_dir: Path, **kwargs) -> int | None:
+    return canonical_coverage_days("cs", "fwd_ret_5d", "validation", "abc", case_dir=case_dir)
+
+
+def test_a_date_whose_cross_section_is_too_thin_does_not_count(tmp_path: Path) -> None:
+    """Three names on the 2nd. The IC series returns no coefficient for that day."""
+    rows = _rows(2, IC_MIN_OBS - 2) + _rows(3, 40) + _rows(6, 40)
+    _write(tmp_path, rows)
+    assert _count(tmp_path) == 2
+
+
+def test_a_date_at_exactly_min_obs_counts(tmp_path: Path) -> None:
+    """The rule is >= min_obs, so the boundary date is scored, not dropped."""
+    _write(tmp_path, _rows(2, IC_MIN_OBS) + _rows(3, 40))
+    assert _count(tmp_path) == 2
+
+
+def test_rows_present_but_unusable_do_not_make_a_date_scorable(tmp_path: Path) -> None:
+    """Forty rows on the 2nd, all NaN. Present is not the same as scorable."""
+    rows = _rows(2, 40, prediction=float("nan")) + _rows(3, 40)
+    _write(tmp_path, rows)
+    assert _count(tmp_path) == 1
+
+
+def test_an_infinite_prediction_is_not_a_value(tmp_path: Path) -> None:
+    rows = _rows(2, 40, actual=float("inf")) + _rows(3, 40)
+    _write(tmp_path, rows)
+    assert _count(tmp_path) == 1
+
+
+def test_a_repeated_entity_does_not_widen_the_cross_section(tmp_path: Path) -> None:
+    """The cross-section is a set of names. Four names duplicated is still four."""
+    duplicated = _rows(2, IC_MIN_OBS - 1) * 3
+    _write(tmp_path, duplicated + _rows(3, 40))
+    assert _count(tmp_path) == 1
+
+
+def test_dates_outside_the_window_are_excluded(tmp_path: Path) -> None:
+    outside = [{**r, "timestamp": dt.datetime(2019, 12, 31, 16, 0)} for r in _rows(3, 40)]
+    _write(tmp_path, _rows(3, 40) + outside)
+    assert _count(tmp_path) == 1
+
+
+def test_intraday_timestamps_collapse_to_one_decision_date(tmp_path: Path) -> None:
+    """Every minute of a session is one date, not many."""
+    minutes = [
+        {**r, "timestamp": dt.datetime(2020, 1, 3, 9, 30 + m)}
+        for m in range(20)
+        for r in _rows(3, 40)
+    ]
+    _write(tmp_path, minutes)
+    assert _count(tmp_path) == 1
+
+
+def test_the_eoa_column_names_resolve(tmp_path: Path) -> None:
+    """The predictions schema is not uniform: eoa writes y_score / y_true."""
+    _write(tmp_path, _rows(3, 40), prediction_col="y_score", actual_col="y_true")
+    assert _count(tmp_path) == 1
+
+
+def test_the_cme_entity_column_resolves(tmp_path: Path) -> None:
+    """cme_futures keys on product, so a symbol-only lookup would count rows."""
+    _write(tmp_path, _rows(3, IC_MIN_OBS - 1) * 3, entity_col="product")
+    assert _count(tmp_path) == 0
+
+
+def test_an_unrecognised_schema_is_cannot_evaluate_not_zero(tmp_path: Path) -> None:
+    """Callers distinguish None from 0; a schema we cannot read must not read as empty."""
+    out = tmp_path / "run_log" / "predictions" / "abc"
+    out.mkdir(parents=True)
+    pl.DataFrame({"timestamp": [dt.datetime(2020, 1, 3)], "mystery": [1.0]}).write_parquet(
+        out / "predictions.parquet"
+    )
+    assert _count(tmp_path) is None
+
+
+def test_a_missing_parquet_is_cannot_evaluate(tmp_path: Path) -> None:
+    assert _count(tmp_path) is None

--- a/tests/test_canonical_coverage_days.py
+++ b/tests/test_canonical_coverage_days.py
@@ -46,13 +46,18 @@ def _write(
     ).write_parquet(out / "predictions.parquet")
 
 
-def _rows(day: int, n: int, prediction=1.0, actual=1.0) -> list[dict]:
+def _rows(day: int, n: int, prediction=None, actual=None) -> list[dict]:
+    """A cross-section that varies across names, because a rank correlation needs it.
+
+    ``prediction`` and ``actual`` override the per-name value with a constant, which
+    is how a test asks for the undefined-correlation case.
+    """
     return [
         {
             "timestamp": dt.datetime(2020, 1, day, 16, 0),
             "entity": f"S{i}",
-            "prediction": prediction if not callable(prediction) else prediction(i),
-            "actual": actual if not callable(actual) else actual(i),
+            "prediction": float(i) if prediction is None else prediction,
+            "actual": float(i) * 0.5 if actual is None else actual,
         }
         for i in range(n)
     ]
@@ -100,6 +105,47 @@ def test_a_repeated_entity_does_not_widen_the_cross_section(tmp_path: Path) -> N
     """The cross-section is a set of names. Four names duplicated is still four."""
     duplicated = _rows(2, IC_MIN_OBS - 1) * 3
     _write(tmp_path, duplicated + _rows(3, 40))
+    assert _count(tmp_path) == 1
+
+
+def test_a_constant_cross_section_has_no_correlation_to_count(tmp_path: Path) -> None:
+    """Forty names on the 2nd, every one scored the same. Spearman is undefined.
+
+    Breadth alone would count the date, and the IC series returns null for it, so
+    the two counts this stands in for would disagree by exactly that date.
+    """
+    _write(tmp_path, _rows(2, 40, prediction=0.7) + _rows(3, 40))
+    assert _count(tmp_path) == 1
+
+
+def test_a_constant_realized_return_is_the_same_case(tmp_path: Path) -> None:
+    _write(tmp_path, _rows(2, 40, actual=0.0) + _rows(3, 40))
+    assert _count(tmp_path) == 1
+
+
+def test_the_continuous_return_decides_a_classification_prediction_set(tmp_path: Path) -> None:
+    """A classification label stores the class target and the return it is scored on.
+
+    `registry/store.py` writes the continuous return as `eval_actual` beside the
+    class column. IC is computed against the return, so a date whose classes vary
+    while its returns do not produces no coefficient - and resolving `actual` first
+    would count it.
+    """
+    out = tmp_path / "run_log" / "predictions" / "abc"
+    out.mkdir(parents=True)
+    rows = _rows(2, 40) + _rows(3, 40)
+    pl.DataFrame(
+        {
+            "timestamp": [r["timestamp"] for r in rows],
+            "symbol": [r["entity"] for r in rows],
+            "prediction": [r["prediction"] for r in rows],
+            # The class target varies on both dates ...
+            "actual": [float(i % 2) for i in range(len(rows))],
+            # ... while the return the IC is taken against is flat on the 2nd.
+            "eval_actual": [0.0 if r["timestamp"].day == 2 else r["actual"] for r in rows],
+        }
+    ).write_parquet(out / "predictions.parquet")
+
     assert _count(tmp_path) == 1
 
 

--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -562,6 +562,47 @@ def test_an_ascending_fold_list_is_refused_rather_than_returned() -> None:
     _assert_newest_first(list(reversed(ascending)))
 
 
+def test_a_precomputed_split_set_is_held_to_the_same_order() -> None:
+    """A caller cannot tell which path produced its list, so both owe the contract.
+
+    The two committed configs disagree with each other:
+    us_firm_characteristics/config/cv_config.json runs newest first, and
+    fx_pairs/config/cv_config.json runs oldest first - fold 0 validates from
+    2015-10-28 against fold 7 at 2022-12-15 - while fx_pairs/04_model_based_features
+    tags its artifact through generate_cv_splits. Fold 0 then means the earliest
+    window on one side of the join and the latest on the other.
+    """
+    df = pl.DataFrame({"timestamp": pd.date_range("2010-01-01", "2020-01-01", freq="B")})
+    ascending = {
+        "splits": [
+            {"fold": 0, "val_start": "2015-10-28", "val_end": "2016-10-28"},
+            {"fold": 1, "val_start": "2016-11-15", "val_end": "2017-11-15"},
+        ]
+    }
+    with pytest.raises(RuntimeError, match="not ordered newest first"):
+        generate_cv_splits(df, cv_config=ascending)
+
+    descending = {"splits": list(reversed(ascending["splits"]))}
+    assert len(generate_cv_splits(df, cv_config=descending)) == 2
+
+
+def test_the_order_check_reads_a_stored_config_spelling() -> None:
+    """A legacy config writes test_start where the generated path writes val_start."""
+    _assert_newest_first(
+        [
+            {"fold": 0, "test_start": pd.Timestamp("2020-01-01")},
+            {"fold": 1, "test_start": pd.Timestamp("2019-01-01")},
+        ]
+    )
+    with pytest.raises(RuntimeError):
+        _assert_newest_first(
+            [
+                {"fold": 0, "test_start": pd.Timestamp("2019-01-01")},
+                {"fold": 1, "test_start": pd.Timestamp("2020-01-01")},
+            ]
+        )
+
+
 def test_most_recent_split_reads_the_boundaries_not_the_position() -> None:
     """Same folds, three orders, one answer - unlike splits[0] and splits[-1]."""
     folds = [

--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -559,7 +559,13 @@ def test_an_ascending_fold_list_is_refused_rather_than_returned() -> None:
     ]
     with pytest.raises(RuntimeError, match="not ordered newest first"):
         _assert_newest_first(ascending)
-    _assert_newest_first(list(reversed(ascending)))
+
+    # Reversing the list alone leaves fold 0 on the oldest window. Every join is
+    # by id, so the ids have to move with the positions.
+    with pytest.raises(RuntimeError, match="fold ids"):
+        _assert_newest_first(list(reversed(ascending)))
+
+    _assert_newest_first([{**split, "fold": i} for i, split in enumerate(reversed(ascending))])
 
 
 def test_a_precomputed_split_set_is_held_to_the_same_order() -> None:
@@ -582,8 +588,16 @@ def test_a_precomputed_split_set_is_held_to_the_same_order() -> None:
     with pytest.raises(RuntimeError, match="not ordered newest first"):
         generate_cv_splits(df, cv_config=ascending)
 
-    descending = {"splits": list(reversed(ascending["splits"]))}
-    assert len(generate_cv_splits(df, cv_config=descending)) == 2
+    # Reversing the list is not the fix: fold 0 still names the oldest window and
+    # every downstream join is by id.
+    reversed_only = {"splits": list(reversed(ascending["splits"]))}
+    with pytest.raises(RuntimeError, match="fold ids"):
+        generate_cv_splits(df, cv_config=reversed_only)
+
+    renumbered = {
+        "splits": [{**split, "fold": i} for i, split in enumerate(reversed(ascending["splits"]))]
+    }
+    assert [s["fold"] for s in generate_cv_splits(df, cv_config=renumbered)] == [0, 1]
 
 
 def test_the_order_check_reads_a_stored_config_spelling() -> None:

--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -27,13 +27,16 @@ import pytest
 import yaml
 
 from utils.cv_splits import (
+    _assert_newest_first,
     _map_calendar_id,
     _normalize_duration,
     _normalize_label_buffer,
+    earliest_train_start,
     generate_cv_splits,
     load_evaluation_config,
     make_walk_forward_config,
     make_wf_config,
+    most_recent_split,
 )
 from utils.modeling import validate_temporal_fold_coverage
 
@@ -528,3 +531,63 @@ def test_make_wf_config_is_alias_of_make_walk_forward_config() -> None:
     a = make_walk_forward_config("etfs", label_horizon="21D")
     b = make_wf_config("etfs", label_horizon="21D")
     assert a.model_dump() == b.model_dump()
+
+
+# -----------------------------------------------------------------------------
+# Fold ordering, and the accessors that do not depend on it
+# -----------------------------------------------------------------------------
+
+
+def test_generate_cv_splits_returns_folds_newest_first(etfs_splits) -> None:
+    """Fold 0 validates most recently. Roughly forty call sites read it that way."""
+    val_starts = [s["val_start"] for s in etfs_splits]
+    assert val_starts == sorted(val_starts, reverse=True)
+    assert etfs_splits[0]["val_end"] > etfs_splits[-1]["val_end"]
+
+
+def test_fold_0_carries_the_latest_train_start_not_the_earliest(etfs_splits) -> None:
+    """The shape behind the measured defect: indexing for "everything available"."""
+    assert etfs_splits[0]["train_start"] > etfs_splits[-1]["train_start"]
+    assert etfs_splits[0]["train_start"] != earliest_train_start(etfs_splits)
+
+
+def test_an_ascending_fold_list_is_refused_rather_than_returned() -> None:
+    """A library change to fold_direction must fail here, not at forty call sites."""
+    ascending = [
+        {"fold": 0, "val_start": pd.Timestamp("2020-01-01"), "val_end": pd.Timestamp("2020-12-31")},
+        {"fold": 1, "val_start": pd.Timestamp("2021-01-01"), "val_end": pd.Timestamp("2021-12-31")},
+    ]
+    with pytest.raises(RuntimeError, match="not ordered newest first"):
+        _assert_newest_first(ascending)
+    _assert_newest_first(list(reversed(ascending)))
+
+
+def test_most_recent_split_reads_the_boundaries_not_the_position() -> None:
+    """Same folds, three orders, one answer - unlike splits[0] and splits[-1]."""
+    folds = [
+        {
+            "fold": 0,
+            "val_end": pd.Timestamp("2023-11-29"),
+            "train_start": pd.Timestamp("2013-01-17"),
+        },
+        {
+            "fold": 1,
+            "val_end": pd.Timestamp("2022-12-28"),
+            "train_start": pd.Timestamp("2012-01-18"),
+        },
+        {
+            "fold": 2,
+            "val_end": pd.Timestamp("2016-12-23"),
+            "train_start": pd.Timestamp("2006-01-13"),
+        },
+    ]
+    for ordering in (folds, list(reversed(folds)), [folds[1], folds[2], folds[0]]):
+        assert most_recent_split(ordering)["fold"] == 0
+        assert earliest_train_start(ordering) == pd.Timestamp("2006-01-13")
+
+
+def test_the_accessors_refuse_an_empty_fold_set() -> None:
+    with pytest.raises(ValueError, match="No splits"):
+        most_recent_split([])
+    with pytest.raises(ValueError, match="No splits"):
+        earliest_train_start([])

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -11,6 +11,7 @@ Pins:
 from __future__ import annotations
 
 import polars as pl
+import pytest
 
 from utils.data_quality import (
     apply_max_symbols,
@@ -18,6 +19,7 @@ from utils.data_quality import (
     describe_coverage,
     null_rate,
     validate_features,
+    validate_modeling_inputs,
 )
 
 
@@ -259,5 +261,62 @@ def test_validate_features_handles_an_integer_column() -> None:
     assert validate_features(pl.DataFrame({"f": [1, 2 * 10**9]}), ["f"], max_abs_value=1e6) != []
 
 
-def test_validate_features_skips_columns_the_frame_does_not_have() -> None:
-    assert validate_features(pl.DataFrame({"a": [1.0]}), ["absent"]) == []
+def test_validate_features_refuses_a_column_the_frame_does_not_have() -> None:
+    with pytest.raises(ValueError, match="cannot find 1 of the 1 columns"):
+        validate_features(pl.DataFrame({"a": [1.0]}), ["absent"])
+
+
+def test_validate_features_refuses_an_empty_column_list() -> None:
+    with pytest.raises(ValueError, match="no columns to check"):
+        validate_features(pl.DataFrame({"a": [1.0]}), [])
+
+
+def test_validate_features_allow_missing_reports_the_skipped_names_rather_than_hiding_them() -> (
+    None
+):
+    issues = validate_features(pl.DataFrame({"a": [1.0]}), ["a", "absent"], allow_missing=True)
+    (issue,) = issues
+    assert issue.startswith("WARNING") and "1 of 2" in issue and "absent" in issue
+
+
+def test_the_gate_refuses_a_feature_frame_that_holds_none_of_the_columns_named() -> None:
+    """The nasdaq100_microstructure/05 shape: the financial frame, the model-based names.
+
+    Two artifacts share a key and are joined further down the notebook, so the
+    column list and the frame both exist and neither looks wrong on its own. Every
+    name was skipped and the gate printed ALL CLEAR over nothing.
+    """
+    keys = {"timestamp": [1, 2], "symbol": ["A", "B"]}
+    financial = pl.DataFrame({**keys, "ret_5m": [0.01, -0.02], "spread": [0.3, 0.4]})
+    model_based = pl.DataFrame({**keys, "regime_prob": [0.7, 0.2], "ffd_close": [1.5, 1.6]})
+    labels = pl.DataFrame({**keys, "fwd_ret_15m": [0.01, -0.01]})
+    model_based_cols = [c for c in model_based.columns if c not in keys]
+
+    with pytest.raises(ValueError, match="cannot find 2 of the 2 columns"):
+        validate_modeling_inputs(
+            features_df=financial,
+            label_df=labels,
+            feature_cols=model_based_cols,
+            label_col="fwd_ret_15m",
+        )
+
+    # Against the frame those names come from it passes, and it reads a value:
+    # an infinity in a model-based column is what the gate is there to stop.
+    assert (
+        validate_modeling_inputs(
+            features_df=model_based,
+            label_df=labels,
+            feature_cols=model_based_cols,
+            label_col="fwd_ret_15m",
+        )["n_critical"]
+        == 0
+    )
+
+    broken = model_based.with_columns(pl.Series("regime_prob", [float("inf"), 0.2]))
+    with pytest.raises(ValueError, match="critical issues"):
+        validate_modeling_inputs(
+            features_df=broken,
+            label_df=labels,
+            feature_cols=model_based_cols,
+            label_col="fwd_ret_15m",
+        )

--- a/tests/test_feature_engineering_coverage.py
+++ b/tests/test_feature_engineering_coverage.py
@@ -1,0 +1,95 @@
+"""A NaN is not a value, in the warm-up audit or in the coverage figure.
+
+Polars evaluates ``is_not_null()`` as True for NaN, and the library feature calls
+do not agree on which one a warm-up head is written with: polars' own
+``rolling_mean`` emits null, ``ml4t.engineer.features.momentum.rsi`` emits NaN.
+Both stage-03 helpers read presence, so both were wrong for the NaN half of the
+corpus - loudly in one direction and silently in the other.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.utils.feature_engineering import family_coverage, warmup_audit
+
+
+def _panel(values: list[float | None], symbol: str = "AAA") -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": [symbol] * len(values),
+            "timestamp": pl.datetime_range(
+                pl.datetime(2020, 1, 1), pl.datetime(2020, 1, len(values)), "1d", eager=True
+            ),
+            "rsi_14d": values,
+        }
+    )
+
+
+def test_the_library_still_writes_a_nan_warm_up_head() -> None:
+    """The premise. If this fails, the two helpers below are guarding nothing."""
+    from ml4t.engineer.features.momentum import rsi
+
+    df = pl.DataFrame({"close": np.linspace(100, 120, 30) + np.sin(np.arange(30))})
+    head = df.with_columns(rsi("close", period=14).alias("r"))["r"].to_list()[:3]
+    assert all(np.isnan(v) for v in head), f"expected a NaN head, got {head}"
+
+
+def test_a_nan_warm_up_does_not_fail_a_correctly_warmed_column() -> None:
+    """The loud direction, measured on fx_pairs' rsi_14d.
+
+    Fourteen NaN bars then a value at bar 15, against a declared warmup of 14.
+    Read as populated at bar 1, that raises the look-ahead assertion - a report
+    that reads exactly like a leak on a column that has none.
+    """
+    census = warmup_audit(
+        _panel([float("nan")] * 14 + [55.0, 56.0, 57.0]),
+        {"rsi_14d": 14},
+        entity="symbol",
+    )
+    assert census["first populated bar"].to_list() == [15]
+
+
+def test_a_column_populated_before_its_window_allows_still_raises() -> None:
+    """The check keeps its teeth: this is what it exists to catch."""
+    with pytest.raises(AssertionError, match="fewer bars than their window spans"):
+        warmup_audit(_panel([50.0] * 17), {"rsi_14d": 14}, entity="symbol")
+
+
+def test_an_all_nan_column_is_reported_as_null_everywhere() -> None:
+    """Read as covered, a column holding nothing passed the audit."""
+    with pytest.raises(AssertionError, match="null everywhere"):
+        warmup_audit(_panel([float("nan")] * 17), {"rsi_14d": 14}, entity="symbol")
+
+
+def test_a_null_warm_up_behaves_the_same_as_a_nan_one() -> None:
+    """Which one the library emitted must not change the answer."""
+    nan_head = warmup_audit(
+        _panel([float("nan")] * 14 + [55.0, 56.0, 57.0]), {"rsi_14d": 14}, entity="symbol"
+    )
+    null_head = warmup_audit(
+        _panel([None] * 14 + [55.0, 56.0, 57.0]), {"rsi_14d": 14}, entity="symbol"
+    )
+    assert nan_head["first populated bar"].to_list() == null_head["first populated bar"].to_list()
+
+
+def test_coverage_draws_a_nan_stretch_as_empty_not_as_dense() -> None:
+    """The silent direction: F1 drew a stretch holding no values as fully covered."""
+    frame = _panel([float("nan")] * 3 + [55.0, 56.0, 57.0])
+    coverage = family_coverage(frame, {"rsi_14d": "momentum"})
+    assert coverage["momentum"].to_list() == [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+
+
+def test_coverage_leaves_an_integer_column_alone() -> None:
+    """is_not_nan is undefined on an integer series, so the dtype decides."""
+    frame = pl.DataFrame(
+        {
+            "timestamp": pl.datetime_range(
+                pl.datetime(2020, 1, 1), pl.datetime(2020, 1, 3), "1d", eager=True
+            ),
+            "n_quotes": [1, None, 3],
+        }
+    )
+    assert family_coverage(frame, {"n_quotes": "breadth"})["breadth"].to_list() == [1.0, 0.0, 1.0]

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -801,3 +801,66 @@ def test_the_holdout_fold_trains_on_everything_before_the_seal(tmp_path, monkeyp
     )
     assert holdout["train_end"] == pd.Timestamp("2018-01-02")
     assert mds._input_lineage is None, "the memoized lineage describes the pre-append fold set"
+
+
+def test_the_holdout_fold_covers_every_bar_of_the_final_configured_session(
+    tmp_path, monkeypatch
+) -> None:
+    """An intraday panel loses its whole last session to a midnight upper bound.
+
+    ``holdout_end`` is configured as a date. Parsed it is that date at midnight,
+    and every fold filter here is ``timestamp <= val_end``, so on minute bars the
+    entire final session sorts after the bound and is written but never scored.
+    Measured on nasdaq100_microstructure: the producer side was fixed in
+    ``04_model_based_features`` and the holdout fold went 19,800,687 to 19,839,297
+    rows, none of which the consumer could read.
+    """
+    import pandas as pd
+
+    import utils.modeling as modeling
+    from utils.modeling import ModelingDataset, append_holdout_fold_if_needed
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "config" / "setup.yaml").write_text(
+        yaml.safe_dump({"evaluation": {"holdout_start": "2021-01-04", "holdout_end": "2021-12-31"}})
+    )
+    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _cs: case_dir)
+
+    mds = ModelingDataset.__new__(ModelingDataset)
+    mds.splits = [
+        {
+            "fold": 0,
+            "train_start": pd.Timestamp("2020-01-02 09:30"),
+            "train_end": pd.Timestamp("2020-12-30 15:58"),
+            "val_start": pd.Timestamp("2020-12-31 09:32"),
+            "val_end": pd.Timestamp("2020-12-31 15:58"),
+        }
+    ]
+    mds._input_lineage = object()
+
+    append_holdout_fold_if_needed(mds, "holdout", "whatever")
+    holdout = mds.splits[-1]
+
+    # The decision minutes of the final configured session, as an intraday panel
+    # carries them. Not one of these is at midnight.
+    final_session = pd.date_range("2021-12-31 09:32", "2021-12-31 15:58", freq="2min")
+    in_window = (final_session >= holdout["val_start"]) & (final_session <= holdout["val_end"])
+    assert in_window.all(), (
+        f"{(~in_window).sum()} of {len(final_session)} bars of the final configured "
+        f"session fall outside [{holdout['val_start']}, {holdout['val_end']}]"
+    )
+    # And it stops there: the session after the configured end stays out.
+    next_session = pd.Timestamp("2022-01-03 09:32")
+    assert next_session > holdout["val_end"]
+
+
+def test_a_holdout_end_naming_an_instant_is_taken_literally() -> None:
+    """A config that names a time of day means that time, not the end of the day."""
+    import pandas as pd
+
+    from utils.modeling import _inclusive_end_of
+
+    assert _inclusive_end_of(pd.Timestamp("2021-12-31 15:58")) == pd.Timestamp("2021-12-31 15:58")
+    assert _inclusive_end_of(pd.Timestamp("2021-12-31")) > pd.Timestamp("2021-12-31 23:59:59")
+    assert _inclusive_end_of(pd.Timestamp("2021-12-31")) < pd.Timestamp("2022-01-01")

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -861,6 +861,10 @@ def test_a_holdout_end_naming_an_instant_is_taken_literally() -> None:
 
     from utils.modeling import _inclusive_end_of
 
-    assert _inclusive_end_of(pd.Timestamp("2021-12-31 15:58")) == pd.Timestamp("2021-12-31 15:58")
-    assert _inclusive_end_of(pd.Timestamp("2021-12-31")) > pd.Timestamp("2021-12-31 23:59:59")
-    assert _inclusive_end_of(pd.Timestamp("2021-12-31")) < pd.Timestamp("2022-01-01")
+    assert _inclusive_end_of("2021-12-31 15:58") == pd.Timestamp("2021-12-31 15:58")
+    assert _inclusive_end_of("2021-12-31") > pd.Timestamp("2021-12-31 23:59:59")
+    assert _inclusive_end_of("2021-12-31") < pd.Timestamp("2022-01-01")
+
+    # An explicitly configured midnight is an instant, not a day. It parses to the
+    # same Timestamp as the bare date, so the configured string is what decides.
+    assert _inclusive_end_of("2021-12-31 00:00:00") == pd.Timestamp("2021-12-31")

--- a/tests/test_variant_fold_geometry.py
+++ b/tests/test_variant_fold_geometry.py
@@ -1,0 +1,149 @@
+"""A variant label's fold must validate after the primary's fold stops training.
+
+A stage-04 artifact carries one fold set, built on the primary label's geometry.
+A model trained on a variant label reads that artifact by ``fold`` id, so the values
+it gets for fold F were fit on data through the *primary* label's ``train_end``. The
+variant's validation window has to open after that.
+
+Measured across the eight stage-04 case studies on 2026-08-09: 20 variant labels,
+zero violations. Nothing in the code would have noticed if there had been one - five
+of the eight assert nothing, and fx_pairs' assertion compares the outer span, which
+never reads ``val_start``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import case_studies.utils.cv_window as cv_window
+from case_studies.utils.cv_window import assert_variant_folds_are_out_of_sample
+
+
+def _splits(spec: list[tuple[str, str, str, str]]) -> list[dict]:
+    return [
+        {
+            "fold": i,
+            "train_start": pd.Timestamp(ts),
+            "train_end": pd.Timestamp(te),
+            "val_start": pd.Timestamp(vs),
+            "val_end": pd.Timestamp(ve),
+        }
+        for i, (ts, te, vs, ve) in enumerate(spec)
+    ]
+
+
+@pytest.fixture
+def geometries(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict]]:
+    """One fold set per label, returned by the derivation the producers also use."""
+    store: dict[str, list[dict]] = {}
+    monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, label: store.get(label))
+    monkeypatch.setattr(
+        cv_window,
+        "_load_setup_yaml",
+        lambda _cs: {"labels": {"primary": "primary", "variants": ["variant"]}},
+    )
+    return store
+
+
+def test_a_variant_validating_before_the_fit_ends_is_refused(geometries) -> None:
+    """The leak: fold 0's features were fit through the 20th, the variant scores the 15th."""
+    geometries["primary"] = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+    geometries["variant"] = _splits([("2020-01-01", "2020-06-10", "2020-06-15", "2020-12-31")])
+
+    with pytest.raises(AssertionError, match="reach into a variant label's validation span"):
+        assert_variant_folds_are_out_of_sample("cs", "primary")
+
+
+def test_the_outer_span_holding_is_not_enough(geometries) -> None:
+    """fx_pairs' assertion passes on this geometry. That is the point of the issue.
+
+    train_start >= primary's and val_end <= primary's both hold, and the variant is
+    still scored on sessions the fold's features were fit on.
+    """
+    geometries["primary"] = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+    geometries["variant"] = _splits([("2020-02-01", "2020-06-10", "2020-06-15", "2020-12-01")])
+
+    p, v = geometries["primary"][0], geometries["variant"][0]
+    assert v["train_start"] >= p["train_start"] and v["val_end"] <= p["val_end"]
+
+    with pytest.raises(AssertionError):
+        assert_variant_folds_are_out_of_sample("cs", "primary")
+
+
+def test_a_clean_geometry_returns_the_gap_per_fold(geometries) -> None:
+    geometries["primary"] = _splits(
+        [
+            ("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31"),
+            ("2019-01-01", "2019-06-20", "2019-06-25", "2019-12-31"),
+        ]
+    )
+    geometries["variant"] = _splits(
+        [
+            ("2020-01-01", "2020-06-24", "2020-06-30", "2020-12-31"),
+            ("2019-01-01", "2019-06-24", "2019-06-30", "2019-12-31"),
+        ]
+    )
+
+    rows = assert_variant_folds_are_out_of_sample("cs", "primary")
+    assert [r["fold"] for r in rows] == [0, 1]
+    assert rows[0]["gap"] == pd.Timedelta(days=10)
+
+
+def test_the_comparison_is_at_full_resolution_not_by_date(geometries) -> None:
+    """nasdaq100_microstructure fold 0, which reads as a violation at date granularity.
+
+    The bars are minutes: the fit closes 15:22 and the variant's validation opens
+    15:38, both on 2020-12-29. Truncating to a date reports a leak that is not there.
+    """
+    geometries["primary"] = _splits(
+        [("2020-01-02 09:32", "2020-12-29 15:22", "2020-12-29 15:40", "2021-12-31 15:58")]
+    )
+    geometries["variant"] = _splits(
+        [("2020-01-02 09:32", "2020-12-29 15:20", "2020-12-29 15:38", "2021-12-31 15:58")]
+    )
+
+    rows = assert_variant_folds_are_out_of_sample("cs", "primary")
+    assert rows[0]["gap"] == pd.Timedelta(minutes=16)
+
+    truncated = [
+        {
+            k: (pd.Timestamp(v).normalize() if isinstance(v, pd.Timestamp) else v)
+            for k, v in s.items()
+        }
+        for s in geometries["variant"]
+    ]
+    geometries["variant"] = truncated
+    geometries["primary"] = [
+        {
+            k: (pd.Timestamp(v).normalize() if isinstance(v, pd.Timestamp) else v)
+            for k, v in s.items()
+        }
+        for s in geometries["primary"]
+    ]
+    with pytest.raises(AssertionError):
+        assert_variant_folds_are_out_of_sample("cs", "primary")
+
+
+def test_a_variant_with_no_label_parquet_is_skipped(geometries) -> None:
+    """The producers skip it too, so the check must not invent a failure."""
+    geometries["primary"] = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+    assert assert_variant_folds_are_out_of_sample("cs", "primary") == []
+
+
+def test_a_variant_fold_with_no_counterpart_is_a_violation(geometries) -> None:
+    """A fold id the artifact does not carry is read as missing, not as safe."""
+    geometries["primary"] = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+    geometries["variant"] = _splits(
+        [
+            ("2020-01-01", "2020-06-24", "2020-06-30", "2020-12-31"),
+            ("2019-01-01", "2019-06-24", "2019-06-30", "2019-12-31"),
+        ]
+    )
+    with pytest.raises(AssertionError, match="no counterpart"):
+        assert_variant_folds_are_out_of_sample("cs", "primary")
+
+
+def test_a_missing_primary_geometry_raises_rather_than_passing(geometries) -> None:
+    with pytest.raises(ValueError, match="No folds derivable"):
+        assert_variant_folds_are_out_of_sample("cs", "primary")

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -435,6 +435,16 @@ def _assert_newest_first(
             "ascending set joins each fold against the wrong end of the sample. "
             "Renumber the source rather than reversing it at the call site."
         )
+    # The ids, not just the order. Reversing an ascending list leaves fold 0 on the
+    # oldest window while the list reads newest first, and every join is by id.
+    ids = [s["fold"] for s in splits]
+    if ids != list(range(len(splits))):
+        raise RuntimeError(
+            f"{source} produced fold ids {ids} against list positions "
+            f"{list(range(len(splits)))}. The list runs newest first, so fold 0 is "
+            "the most recent fold and the ids have to follow the positions - a "
+            "downstream artifact is joined on the id, never on the position."
+        )
 
 
 def _split_value(split: dict[str, Any], *names: str) -> Any:

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -29,6 +29,7 @@ Design decisions:
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -269,8 +270,19 @@ def generate_cv_splits(
     Returns
     -------
     list[dict]
-        List of split dicts with keys: ``fold``, ``train_start``,
-        ``train_end``, ``val_start``, ``val_end``.
+        Split dicts with keys ``fold``, ``train_start``, ``train_end``,
+        ``val_start``, ``val_end``, **ordered newest first**. Fold 0 validates
+        on the most recent window and carries the *latest* ``train_start``; the
+        last element is the oldest fold and carries the earliest. The order is
+        asserted before the list is returned, so it cannot change silently.
+
+        Index it only when you mean a position in that order. For "the most
+        recent fold" and "everything available before the holdout", call
+        :func:`most_recent_split` and :func:`earliest_train_start`, which read
+        the boundaries rather than the position and are correct whatever order
+        the list is in. ``splits[0]["train_start"]`` under a comment reading
+        "train on everything up to holdout_start" is the measured failure: on
+        etfs it starts 2013-01-17 where the earliest fold starts 2006-01-13.
     """
     from ml4t.diagnostic.splitters import WalkForwardCV
     from ml4t.diagnostic.splitters.config import WalkForwardConfig as LibWalkForwardConfig
@@ -384,4 +396,49 @@ def generate_cv_splits(
             }
         )
 
+    _assert_newest_first(splits)
     return splits
+
+
+def _assert_newest_first(splits: list[dict[str, Any]]) -> None:
+    """Fail if the folds are not ordered newest first.
+
+    The order is a property of ``fold_direction="backward"`` in the library
+    config, and roughly forty call sites depend on it - some by indexing, some
+    by writing the fold id into an artifact that a later stage reads back by id.
+    If a library change reversed it, every one of them would keep running and
+    quietly mean the opposite. This turns that into an immediate failure.
+    """
+    val_starts = [s["val_start"] for s in splits]
+    if any(later >= earlier for earlier, later in zip(val_starts, val_starts[1:], strict=False)):
+        raise RuntimeError(
+            "generate_cv_splits returned folds that are not ordered newest first: "
+            f"val_starts {val_starts}. Every caller reads fold 0 as the most recent "
+            "fold, and stage-04 artifacts carry these ids. Fix the ordering here "
+            "rather than at the call sites."
+        )
+
+
+def most_recent_split(splits: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """The fold whose validation window ends last.
+
+    Reads the boundaries rather than a list position, so it is correct whichever
+    end of the list that fold sits at. Use it wherever a caller means "the latest
+    fold" - ``splits[-1]`` under the name ``last_fold`` takes the *earliest* one.
+    """
+    if not splits:
+        raise ValueError("No splits to choose from")
+    return max(splits, key=lambda s: pd.Timestamp(s["val_end"]))
+
+
+def earliest_train_start(splits: Sequence[dict[str, Any]]) -> pd.Timestamp:
+    """The earliest training start across the folds - "everything available".
+
+    A holdout retrain trains on the whole history before the holdout boundary,
+    which is ``min(train_start)`` over the fold set and never one fold's own
+    start. Folds run newest first, so ``splits[0]["train_start"]`` is the latest
+    start in the set and hands the retrain the shortest window it could have had.
+    """
+    if not splits:
+        raise ValueError("No splits to choose from")
+    return min(pd.Timestamp(s["train_start"]) for s in splits)

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -287,9 +287,13 @@ def generate_cv_splits(
     from ml4t.diagnostic.splitters import WalkForwardCV
     from ml4t.diagnostic.splitters.config import WalkForwardConfig as LibWalkForwardConfig
 
-    # Legacy path: pre-computed explicit splits
+    # Legacy path: pre-computed explicit splits. Held to the same contract as the
+    # generated ones, because the caller cannot tell which path produced its list
+    # and reads fold 0 the same way either way.
     if cv_config is not None and "splits" in cv_config:
-        return cv_config["splits"]
+        precomputed = cv_config["splits"]
+        _assert_newest_first(precomputed, source="the precomputed splits in cv_config")
+        return precomputed
 
     # Normalize label buffer (strip ISO prefix, convert M → days)
     label_buffer = _normalize_label_buffer(label_buffer)
@@ -400,7 +404,10 @@ def generate_cv_splits(
     return splits
 
 
-def _assert_newest_first(splits: list[dict[str, Any]]) -> None:
+def _assert_newest_first(
+    splits: list[dict[str, Any]],
+    source: str = "generate_cv_splits",
+) -> None:
     """Fail if the folds are not ordered newest first.
 
     The order is a property of ``fold_direction="backward"`` in the library
@@ -408,15 +415,34 @@ def _assert_newest_first(splits: list[dict[str, Any]]) -> None:
     by writing the fold id into an artifact that a later stage reads back by id.
     If a library change reversed it, every one of them would keep running and
     quietly mean the opposite. This turns that into an immediate failure.
+
+    It applies to a ``cv_config`` carrying explicit splits too. A caller cannot
+    tell which path produced its list, so a stored fold set that runs oldest
+    first hands fold id 0 to the earliest window while everything built through
+    the generated path gives it to the latest. Measured on the two committed
+    configs: ``us_firm_characteristics/config/cv_config.json`` runs newest first
+    and agrees, ``fx_pairs/config/cv_config.json`` runs oldest first - fold 0
+    validates from 2015-10-28, fold 7 from 2022-12-15 - while
+    ``fx_pairs/04_model_based_features`` tags its artifact through
+    ``generate_cv_splits``. The two meanings of "fold 0" then meet in a join.
     """
-    val_starts = [s["val_start"] for s in splits]
+    val_starts = [_split_value(s, "val_start", "test_start") for s in splits]
     if any(later >= earlier for earlier, later in zip(val_starts, val_starts[1:], strict=False)):
         raise RuntimeError(
-            "generate_cv_splits returned folds that are not ordered newest first: "
-            f"val_starts {val_starts}. Every caller reads fold 0 as the most recent "
-            "fold, and stage-04 artifacts carry these ids. Fix the ordering here "
-            "rather than at the call sites."
+            f"{source} produced folds that are not ordered newest first: "
+            f"val_starts {[str(v) for v in val_starts]}. Fold 0 is read as the most "
+            "recent fold everywhere, and stage-04 artifacts carry these ids, so an "
+            "ascending set joins each fold against the wrong end of the sample. "
+            "Renumber the source rather than reversing it at the call site."
         )
+
+
+def _split_value(split: dict[str, Any], *names: str) -> Any:
+    """Read the first key a split carries, so a stored config's spelling still resolves."""
+    for name in names:
+        if split.get(name) is not None:
+            return split[name]
+    raise KeyError(f"split carries none of {names}: {sorted(split)}")
 
 
 def most_recent_split(splits: Sequence[dict[str, Any]]) -> dict[str, Any]:

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -435,6 +435,7 @@ def validate_features(
     df: pl.DataFrame,
     feature_cols: Sequence[str],
     max_abs_value: float = 1e6,
+    allow_missing: bool = False,
 ) -> list[str]:
     """Check feature columns for infinities, absent values, and extreme values.
 
@@ -446,14 +447,51 @@ def validate_features(
     that is entirely NaN carries no value at all, and was previously reported as
     neither absent nor extreme.
 
+    A column named in ``feature_cols`` that ``df`` does not carry raises. A check
+    that cannot find what it is checking has not passed, and reporting success is
+    the one thing it must not do: called with one frame's column names against a
+    different frame, this skipped all 22 columns it was given and reported the
+    panel clean. An empty ``feature_cols`` fails for the same reason. Where a
+    caller genuinely holds a superset - a column list spanning several artifacts,
+    checked one artifact at a time - pass ``allow_missing=True`` and the absent
+    names are reported as a warning instead.
+
     Args:
         df: DataFrame containing feature columns
         feature_cols: List of feature column names to validate
         max_abs_value: Threshold for flagging extreme values
+        allow_missing: Report columns absent from ``df`` as a warning rather than
+            raising. The default refuses them.
 
     Returns list of warning/error strings.
+
+    Raises:
+        ValueError: If ``feature_cols`` is empty, or names a column ``df`` does
+            not carry and ``allow_missing`` is False.
     """
     issues: list[str] = []
+
+    if not feature_cols:
+        raise ValueError(
+            "validate_features was given no columns to check. A gate over nothing "
+            "reports success without reading a value; pass the columns the frame "
+            "carries, or do not call the gate."
+        )
+
+    missing = [col for col in feature_cols if col not in df.columns]
+    if missing and not allow_missing:
+        raise ValueError(
+            f"validate_features cannot find {len(missing)} of the {len(feature_cols)} "
+            f"columns it was asked to check: {missing[:10]}"
+            f"{'...' if len(missing) > 10 else ''}. The frame carries "
+            f"{len(df.columns)} columns. Pass the frame these names come from, or "
+            f"allow_missing=True if the list deliberately spans several frames."
+        )
+    if missing:
+        issues.append(
+            f"WARNING: {len(missing)} of {len(feature_cols)} columns are not in the frame "
+            f"and were not checked: {missing[:10]}{'...' if len(missing) > 10 else ''}"
+        )
 
     inf_cols = []
     absent_cols = []
@@ -514,6 +552,7 @@ def validate_modeling_inputs(
     max_abs_return: float = 0.5,
     max_abs_feature: float = 1e6,
     fail_on_critical: bool = True,
+    allow_missing_features: bool = False,
 ) -> dict:
     """Run all data quality checks before modeling.
 
@@ -531,12 +570,16 @@ def validate_modeling_inputs(
         max_abs_return: Max plausible absolute return for labels
         max_abs_feature: Max plausible absolute feature value
         fail_on_critical: If True, raise ValueError on CRITICAL issues
+        allow_missing_features: Passed to ``validate_features``. The default
+            refuses a feature column ``features_df`` does not carry, because the
+            gate would otherwise skip it and still report the panel clean.
 
     Returns:
         Dict with 'issues' (list of strings), 'n_critical', 'n_warning'
 
     Raises:
-        ValueError: If fail_on_critical=True and any CRITICAL issues found
+        ValueError: If fail_on_critical=True and any CRITICAL issues found, or if
+            ``feature_cols`` names a column ``features_df`` does not carry
     """
     all_issues: list[str] = []
 
@@ -548,7 +591,14 @@ def validate_modeling_inputs(
     all_issues.extend(validate_labels(label_df, label_col, max_abs_return))
 
     # 3. Feature checks
-    all_issues.extend(validate_features(features_df, feature_cols, max_abs_feature))
+    all_issues.extend(
+        validate_features(
+            features_df,
+            feature_cols,
+            max_abs_feature,
+            allow_missing=allow_missing_features,
+        )
+    )
 
     # Summarize
     n_critical = sum(1 for i in all_issues if i.startswith("CRITICAL"))

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -685,6 +685,25 @@ def load_modeling_dataset(
     )
 
 
+def _inclusive_end_of(boundary: pd.Timestamp) -> pd.Timestamp:
+    """Widen a configured end *date* to cover every bar of that session.
+
+    ``setup.yaml`` configures ``holdout_end`` as a date. Parsed, it is that date
+    at midnight, and every fold filter in this module is ``timestamp <= val_end``.
+    On a daily panel the bar already sits at midnight and the two agree. On an
+    intraday panel every bar of the final session sorts *after* midnight, so the
+    whole session is excluded from every modeling path: nasdaq100_microstructure
+    writes 2021-12-31 into its holdout fold - 38,610 rows added when the producer
+    side was fixed - and no consumer scores one of them.
+
+    A boundary that already carries a time of day is meant literally and is
+    returned unchanged, so a config can still name an instant inside a session.
+    """
+    if boundary != boundary.normalize():
+        return boundary
+    return boundary + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
+
+
 def append_holdout_fold_if_needed(
     mds: ModelingDataset,
     prediction_split: str,
@@ -740,7 +759,7 @@ def append_holdout_fold_if_needed(
     # made the idempotency check below never match (str(Timestamp) != YAML
     # string) and risked a tz-naive/aware comparison on the pandas filter path.
     ho_start_ts = pd.Timestamp(holdout_start)
-    ho_end_ts = pd.Timestamp(holdout_end)
+    ho_end_ts = _inclusive_end_of(pd.Timestamp(holdout_end))
     # Any fold covering the holdout window, not just the trailing one: the CV
     # folds run newest first and only the appended holdout fold lands at the end,
     # so reading one position is a second place the ordering has to be right.

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -25,6 +25,7 @@ import json
 import os
 import random
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -416,11 +417,72 @@ def get_classification_eval_label(case_study_id: str, label: str) -> str:
     return str(mapping[label])
 
 
+def verify_artifact_sidecars(artifacts: Mapping[str, Path]) -> dict[str, str]:
+    """Check each input artifact against the digest sidecar its producer wrote.
+
+    ``case_studies/utils/artifact_digest.py`` writes ``<artifact>.digest.json``
+    beside every artifact, recording the content hash, the row count and the key
+    columns. Until this function existed nothing read one: stage 02 and stage 03
+    wrote them and the chain stopped, so an upstream value change could not reach
+    a downstream identity. What it closes is narrow and worth stating exactly - the
+    registry records feature-set *names* and no digest of feature *values*, so a
+    model trained on corrected features and one trained on the leaky version it
+    replaced produce the identical training_hash unless something reads the values.
+
+    Raises on a digest that disagrees with the file, and on an artifact with no
+    sidecar: an artifact whose producer never recorded what it wrote is exactly the
+    case this cannot distinguish from a silent change.
+
+    Returns the verified digest per artifact, so the caller can carry it into the
+    training spec.
+
+    **Not yet on by default**, and the precondition is measured rather than assumed:
+    on 2026-08-09 the production artifacts carried 49 sidecars out of 51, both gaps
+    in sp500_options, while the CI fixtures under
+    ``ml4t/third-edition-test-data/intermediates`` carried **none** - 0 of 7 for
+    cme_futures, 0 of 5 for etfs, 0 of 6 for fx_pairs, 0 of 6 for us_equities_panel.
+    Turning ``verify_input_digests`` on before those are regenerated fails every
+    case-study CI job for a missing sidecar rather than for a changed value.
+    """
+    from case_studies.utils.artifact_digest import read_digest, sidecar_path, value_digest
+
+    verified: dict[str, str] = {}
+    problems: list[str] = []
+    for name, path in sorted(artifacts.items()):
+        side = sidecar_path(path)
+        if not side.exists():
+            problems.append(f"{name}: no digest sidecar beside {path.name}")
+            continue
+        try:
+            record = read_digest(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            problems.append(f"{name}: sidecar unreadable ({exc})")
+            continue
+        recorded = record.get("digest")
+        if not recorded:
+            problems.append(f"{name}: sidecar records no digest")
+            continue
+        actual = value_digest(pl.read_parquet(path))
+        if actual != recorded:
+            problems.append(f"{name}: {path.name} hashes {actual}, its sidecar records {recorded}")
+            continue
+        verified[name] = recorded
+
+    if problems:
+        raise ValueError(
+            "input artifacts do not match the digests their producers recorded, so a "
+            "training run built on them would carry an identity that does not describe "
+            "its inputs: " + "; ".join(problems)
+        )
+    return verified
+
+
 def load_modeling_dataset(
     case_study_id: str,
     primary_label: str,
     max_symbols: int = 0,
     symbols: list[str] | None = None,
+    verify_input_digests: bool = False,
 ) -> ModelingDataset:
     """Load and join features + temporal + labels for a case study.
 
@@ -658,6 +720,8 @@ def load_modeling_dataset(
         input_artifacts["model_based"] = temporal_path
     if eval_label_path is not None:
         input_artifacts["eval_label"] = eval_label_path
+    if verify_input_digests:
+        verify_artifact_sidecars(input_artifacts)
     return ModelingDataset(
         dataset=dataset,
         feature_names=feature_names,

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -574,9 +574,7 @@ def load_modeling_dataset(
         primary_entity = entity_cols[0]
         dataset = dataset.filter(pl.col(primary_entity).is_in(list(symbols)))
     elif max_symbols > 0 and entity_cols:
-        primary_entity = entity_cols[0]
-        top = dataset.group_by(primary_entity).len().sort("len", descending=True).head(max_symbols)
-        dataset = dataset.filter(pl.col(primary_entity).is_in(top[primary_entity]))
+        dataset = reduce_to_top_entities(dataset, entity_cols[0], max_symbols)
 
     # Feature columns = everything except IDs and label
     feature_names = [c for c in dataset.columns if c not in ID_COLS and c != label_col]
@@ -683,6 +681,34 @@ def load_modeling_dataset(
             "symbols": symbols,
         },
     )
+
+
+def reduce_to_top_entities(
+    dataset: pl.DataFrame,
+    primary_entity: str,
+    max_symbols: int,
+) -> pl.DataFrame:
+    """Keep the ``max_symbols`` entities with the most rows, ties broken by name.
+
+    Row counts tie readily on these panels, and a tie broken by frame order is
+    not stable across runs or across callers. The entity name is the secondary
+    key so that every caller reducing the same dataset to the same size gets the
+    same universe. Without it a reduced stage-04 run and the reduced model
+    notebooks downstream of it can choose different equal-history symbols, and
+    the ones only a single side chose carry null temporal features - a wrong
+    answer that runs clean rather than a failure.
+
+    Production runs set ``max_symbols=0`` and never reach this.
+    """
+    top = (
+        dataset.group_by(primary_entity)
+        .len()
+        .sort(["len", primary_entity], descending=[True, False])
+        .head(max_symbols)
+    )
+    # implode: is_in against a bare Series of the same dtype is deprecated in
+    # polars as ambiguous, and membership in the value set is what is meant.
+    return dataset.filter(pl.col(primary_entity).is_in(top[primary_entity].implode()))
 
 
 def _inclusive_end_of(boundary: pd.Timestamp) -> pd.Timestamp:

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -775,7 +775,7 @@ def reduce_to_top_entities(
     return dataset.filter(pl.col(primary_entity).is_in(top[primary_entity].implode()))
 
 
-def _inclusive_end_of(boundary: pd.Timestamp) -> pd.Timestamp:
+def _inclusive_end_of(boundary: str) -> pd.Timestamp:
     """Widen a configured end *date* to cover every bar of that session.
 
     ``setup.yaml`` configures ``holdout_end`` as a date. Parsed, it is that date
@@ -787,11 +787,16 @@ def _inclusive_end_of(boundary: pd.Timestamp) -> pd.Timestamp:
     side was fixed - and no consumer scores one of them.
 
     A boundary that already carries a time of day is meant literally and is
-    returned unchanged, so a config can still name an instant inside a session.
+    returned unchanged, so a config can still name an instant inside a session -
+    including an explicit midnight. That is why this reads the configured *string*
+    rather than the parsed Timestamp: "2021-12-31" and "2021-12-31 00:00:00" parse
+    to the same instant, and only the first one means the whole day.
     """
-    if boundary != boundary.normalize():
-        return boundary
-    return boundary + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
+    parsed = pd.Timestamp(boundary)
+    names_a_time = any(sep in str(boundary) for sep in (" ", "T"))
+    if names_a_time or parsed != parsed.normalize():
+        return parsed
+    return parsed + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
 
 
 def append_holdout_fold_if_needed(
@@ -849,7 +854,7 @@ def append_holdout_fold_if_needed(
     # made the idempotency check below never match (str(Timestamp) != YAML
     # string) and risked a tz-naive/aware comparison on the pandas filter path.
     ho_start_ts = pd.Timestamp(holdout_start)
-    ho_end_ts = _inclusive_end_of(pd.Timestamp(holdout_end))
+    ho_end_ts = _inclusive_end_of(holdout_end)
     # Any fold covering the holdout window, not just the trailing one: the CV
     # folds run newest first and only the appended holdout fold lands at the end,
     # so reading one position is a second place the ordering has to be right.

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -42,7 +42,7 @@ from utils.artifact_specs import (
     resolve_market_semantics,
     resolve_storage_path,
 )
-from utils.cv_splits import generate_cv_splits, make_wf_config
+from utils.cv_splits import earliest_train_start, generate_cv_splits, make_wf_config
 
 RANDOM_SEED = 42
 MIN_TEMPORAL_DATE_COVERAGE = 0.95  # Allow short calendar-edge gaps, not missing windows.
@@ -741,16 +741,20 @@ def append_holdout_fold_if_needed(
     # string) and risked a tz-naive/aware comparison on the pandas filter path.
     ho_start_ts = pd.Timestamp(holdout_start)
     ho_end_ts = pd.Timestamp(holdout_end)
-    trailing = mds.splits[-1]
-    if (
-        trailing.get("val_end") is not None
-        and pd.Timestamp(trailing.get("val_end")) == ho_end_ts
-        and pd.Timestamp(trailing.get("val_start")) == ho_start_ts
-    ):
-        return  # already covered
+    # Any fold covering the holdout window, not just the trailing one: the CV
+    # folds run newest first and only the appended holdout fold lands at the end,
+    # so reading one position is a second place the ordering has to be right.
+    already_covered = any(
+        s.get("val_end") is not None
+        and pd.Timestamp(s["val_end"]) == ho_end_ts
+        and pd.Timestamp(s["val_start"]) == ho_start_ts
+        for s in mds.splits
+    )
+    if already_covered:
+        return
     holdout_fold = {
         "fold": len(mds.splits),
-        "train_start": min(pd.Timestamp(s["train_start"]) for s in mds.splits),
+        "train_start": earliest_train_start(mds.splits),
         "train_end": ho_start_ts,
         "val_start": ho_start_ts,
         "val_end": ho_end_ts,


### PR DESCRIPTION
Correctness in the shared statistics and cross-validation code every stage 01-05 notebook runs. No notebook is edited here; where a fix needs one, the commit message says which and why it is not made.

## What each commit fixes

**A feature gate that cannot find its columns fails instead of reporting clean.** `validate_features` skipped a column the frame did not carry and returned no issues, so a caller passing one artifact's column names against a different artifact's frame got "Data Quality Gate: ALL CLEAR" over nothing checked. It now raises, and on an empty column list, which is the same vacuous gate reached a different way. `allow_missing=True` reports the absent names rather than hiding them.

**Assert the fold order rather than leaving forty call sites to guess it.** `generate_cv_splits` returns folds newest first because the library config sets `fold_direction="backward"`, and nothing said so at the return. The order is now stated, asserted before the list is returned, and served by two accessors that read boundaries rather than list positions. No fold is renumbered - stage-04 artifacts carry those ids. The trap this closes: `splits[0]["train_start"]` under a comment reading "train on everything up to holdout_start" gave etfs 2013-01-17 where the earliest fold starts 2006-01-13.

**The holdout fold covers the final configured session on an intraday panel.** `holdout_end` is a date, parsed to midnight, and every fold filter is `timestamp <= val_end`. On minute bars the whole final session was written and never scored: the test reports 194 of 194 decision minutes of 2021-12-31 outside the old window.

**Break row-count ties on the entity name in the shared universe reduction.** One panel of four equal-history symbols reduced to two gave `CHARLIE,DELTA`, `BRAVO,CHARLIE` or `ALPHA,BRAVO` depending only on frame order.

**A NaN is not a value in the warm-up audit or the coverage figure.** `is_not_null()` is True for NaN, and `rsi` emits NaN where `rolling_mean` emits null. `warmup_audit` raised a false look-ahead failure on a correctly warmed column; `family_coverage` drew a stretch holding no values as fully covered.

**`canonical_coverage_days` counts scorable dates, not dates a row exists on.** It stands in for `ic_n_days`, which counts days the IC series returned a coefficient for, and that needs `min_obs` entities with a finite prediction and a finite return.

**One shared check that a variant label's folds are out of sample.** `variant.val_start > primary.train_end`, per fold, comparing timestamps rather than dates. Five stage-04 notebooks check nothing and fx_pairs' assertion compares the outer span, which never reads `val_start`.

**Give the artifact digest sidecar a read side.** `verify_artifact_sidecars` checks every input against the digest its producer recorded. Wired into `load_modeling_dataset` behind `verify_input_digests`, default off, with the precondition measured in the commit message.

## Numbers that move, and who owns them

| Change | What moves | State of the owner |
|---|---|---|
| Intraday holdout end | six `nasdaq100_microstructure` stage 06-11 notebooks gain one session of holdout predictions; a holdout `training_hash` built from the fold set moves with it | all six rows `todo` |
| NaN coverage | F1 and the warm-up census in the eight stage-03 notebooks that draw them | fx_pairs will not move: its `fill_nan(None)` was the workaround for this and is now redundant |
| Universe tie-break | reduced runs only. Production sets `max_symbols=0` and never enters the branch | CI and local `MAX_SYMBOLS` runs |
| Scorable-date count | nothing measured. Old rule and new rule agree on 237 of 237 prediction sets in the live `sp500_equity_option_analytics` registry | the other eight registries are unchecked |
| Fold order, sidecar read side, variant-fold check | nothing. All three add a check or a name; none changes a computation | |

## The fold-order assertion, and what it stops

`_assert_newest_first` now covers the precomputed `cv_config` path and checks the fold ids against their list positions, not only the order of the windows. Both came from roborev review 12700/12722.

`fx_pairs/config/cv_config.json` fails it, and measuring why turned up more than the review reported. It is not an ascending copy of the generated folds - it is a **different fold set**:

```
generated from fwd_ret_1d   fold 0 validates 2023-01-03 .. 2023-12-28
committed cv_config.json    fold 0 validates 2015-10-28 .. 2016-11-14
```

Not one of its eight validation windows appears in the eight `generate_cv_splits` derives, in either order, while `fx_pairs/04_model_based_features` tags its temporal artifact through `generate_cv_splits`. So `fx_pairs` 06 through 10 train on windows their stage-04 features were not fitted for, and read fold ids that run the opposite way. They now raise rather than joining silently. All six rows are `todo`. Renumbering the config would change every FX model's training windows, which is a six-notebook re-run and belongs with the retrain.

## Two call sites on `main` that will now raise, both superseded

`validate_features` refusing a column it cannot find makes `us_equities_panel/05_evaluation.py:164` and `nasdaq100_microstructure/05_evaluation.py:276` raise: both pass `financial_cols + temporal_cols` against a frame holding only the financial columns, which is the defect. Both are superseded on `cs/stage-05`, where the call site passes `eval_panel`. All seven stage-05 call sites on that branch were checked one by one and none is affected.

## Not done here, and why

- **Five stage-04 notebooks adopting `assert_variant_folds_are_out_of_sample`**, and fx_pairs replacing its outer-span assertion. Notebook edits and a re-render.
- **Turning `verify_input_digests` on.** The CI fixtures carry no sidecars at all: 0 of 7 for cme_futures, 0 of 5 for etfs, 0 of 6 for fx_pairs, 0 of 6 for us_equities_panel, against 49 of 51 in production. They need regenerating first.
- **Removing `np.random.seed(SEED)` from `etfs/04`.** Redundant once the library seeds its own bootstrap, but a notebook edit.

## Companion library work

Two branches in `ml4t/diagnostic`, neither in this PR:

- `fix/stationary-bootstrap-seed` - the stationary bootstrap drew from numpy's legacy global generator, so `robust_ic` returned a different p-value on every call. Measured: three identical calls gave 0.679, 0.668, 0.647. Two other callers seeded by mutating process-global state and now pass the generator they already had.
- `test/pvalue-tail-detector` - the `1 - cdf` tail-underflow sites were fixed on that repo's `main` by another route, so what is left is the detector that stops them coming back. 14 pass against `main` unmodified; reintroducing the expression fails three.
