### PR TITLE
Unblock the stage 01-05 sweep: restore four stamped notebooks, and give two dormant guards a call site

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,10 +433,17 @@ jobs:
         # matplotlib and hmmlearn are the import surface of the shared stage-03
         # and stage-04 helpers below. Neither pulls torch or an ml4t-* package,
         # so this stays a fast per-commit gate.
+        #
+        # pyarrow is what polars converts through in `DataFrame.to_pandas`, which
+        # `load_modeling_dataset` calls on the fold-tagged temporal artifact. The
+        # variant-geometry guard hangs off exactly that frame, so without pyarrow
+        # the tests that establish the guard runs on a real load fail at the
+        # conversion rather than at the property. Found by this job, not by
+        # inspection: the helper-level tests never reach the conversion and passed.
         run: |
           uv venv --python 3.14
           uv pip install pytest numpy polars pyyaml python-dotenv plotly gymnasium requests \
-            scipy statsmodels scikit-learn matplotlib hmmlearn
+            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -514,6 +514,15 @@ jobs:
       # defect in eight rendered notebooks at once, which is exactly why they are
       # fixed centrally rather than per notebook - and why the fix needs a gate
       # rather than trusting that eight re-runs would catch a regression.
+      #
+      # The last three are the guards over what load_modeling_dataset returns,
+      # and adding them here is the point rather than tidiness. Both
+      # assert_variant_folds_are_out_of_sample and verify_artifact_sidecars
+      # shipped with tests that no job invoked, which is the same shape as the
+      # defect they were written to catch: a check nothing runs establishes
+      # nothing. They need no data and no ml4t-* package - every ml4t import in
+      # utils/cv_splits.py is inside a function, and these tests substitute the
+      # functions that reach them.
       - name: Run shared case-study helper tests
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -525,7 +534,21 @@ jobs:
             tests/test_data_quality.py \
             tests/test_feature_engineering_figures.py \
             tests/test_temporal.py \
+            tests/test_variant_fold_geometry.py \
+            tests/test_artifact_sidecar_verification.py \
+            tests/test_artifact_digest.py \
             -v --tb=short
+
+      # Reads only committed notebook JSON and its paired .py, so it belongs to
+      # the fast per-commit gate rather than to a job that needs data. What it
+      # holds is the state a 44-notebook re-execution depends on: a pair without
+      # cell_metadata_filter desyncs on the run, and the notebook-sync gate then
+      # refuses every commit in the repo, not only that notebook's.
+      - name: Every stage 01-05 notebook pair survives a re-execution
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_notebook_pair_metadata_filter.py \
+            -q --tb=short
 
       # The methodology ratchet. Both files are static AST/source scans over the
       # notebook tree, so they need no data and no model deps, and both were

--- a/case_studies/crypto_perps_funding/01_feasibility_analysis.ipynb
+++ b/case_studies/crypto_perps_funding/01_feasibility_analysis.ipynb
@@ -982,9 +982,8 @@
     "\n",
     "What evaluation spends is independent observations, not rows. Summing the initial positive\n",
     "sequence of B.4's mean curve gives the integrated autocorrelation time, the funding periods one\n",
-    "independent premium observation is worth - for one contract's own premium series, not for the\n",
-    "decisions a portfolio takes across contracts. The sequence never turns negative here, so the\n",
-    "count below is a ceiling."
+    "independent premium observation is worth - for one contract's carrier, not for the decisions a\n",
+    "portfolio takes. The sequence never turns negative here, so the count below is a ceiling."
    ]
   },
   {

--- a/case_studies/crypto_perps_funding/01_feasibility_analysis.py
+++ b/case_studies/crypto_perps_funding/01_feasibility_analysis.py
@@ -491,9 +491,8 @@ print(
 #
 # What evaluation spends is independent observations, not rows. Summing the initial positive
 # sequence of B.4's mean curve gives the integrated autocorrelation time, the funding periods one
-# independent premium observation is worth - for one contract's own premium series, not for the
-# decisions a portfolio takes across contracts. The sequence never turns negative here, so the
-# count below is a ceiling.
+# independent premium observation is worth - for one contract's carrier, not for the decisions a
+# portfolio takes. The sequence never turns negative here, so the count below is a ceiling.
 
 # %%
 curve = acf["acf"].to_numpy()

--- a/case_studies/sp500_equity_option_analytics/02_labels.ipynb
+++ b/case_studies/sp500_equity_option_analytics/02_labels.ipynb
@@ -1380,7 +1380,7 @@
    ],
    "source": [
     "surface = load_sp500_options_surface(start_date=START_DATE, end_date=END_DATE)\n",
-    "signal_panel = (\n",
+    "carrier = (\n",
     "    prices.select(\"timestamp\", \"symbol\", ENTITY, \"session\")\n",
     "    .join(surface.select(\"timestamp\", \"symbol\", IV_COL), on=[\"timestamp\", \"symbol\"], how=\"left\")\n",
     "    .sort([ENTITY, \"session\"])\n",
@@ -1390,7 +1390,7 @@
     "    .drop_nulls(\"signal\")\n",
     ")\n",
     "baseline = dev[PRIMARY_LABEL].join(\n",
-    "    signal_panel.select(\"timestamp\", \"symbol\", \"signal\"), on=[\"timestamp\", \"symbol\"], how=\"inner\"\n",
+    "    carrier.select(\"timestamp\", \"symbol\", \"signal\"), on=[\"timestamp\", \"symbol\"], how=\"inner\"\n",
     ")\n",
     "min_obs = int(baseline.group_by(\"timestamp\").len()[\"len\"].median() // 2)\n",
     "\n",

--- a/case_studies/sp500_equity_option_analytics/02_labels.py
+++ b/case_studies/sp500_equity_option_analytics/02_labels.py
@@ -634,7 +634,7 @@ for label_name in PLAIN_RETURNS:
 
 # %%
 surface = load_sp500_options_surface(start_date=START_DATE, end_date=END_DATE)
-signal_panel = (
+carrier = (
     prices.select("timestamp", "symbol", ENTITY, "session")
     .join(surface.select("timestamp", "symbol", IV_COL), on=["timestamp", "symbol"], how="left")
     .sort([ENTITY, "session"])
@@ -644,7 +644,7 @@ signal_panel = (
     .drop_nulls("signal")
 )
 baseline = dev[PRIMARY_LABEL].join(
-    signal_panel.select("timestamp", "symbol", "signal"), on=["timestamp", "symbol"], how="inner"
+    carrier.select("timestamp", "symbol", "signal"), on=["timestamp", "symbol"], how="inner"
 )
 min_obs = int(baseline.group_by("timestamp").len()["len"].median() // 2)
 

--- a/case_studies/sp500_options/02_labels.ipynb
+++ b/case_studies/sp500_options/02_labels.ipynb
@@ -1862,10 +1862,9 @@
     "with a quoted matched-strike straddle, with the liquidity screen applied downstream rather\n",
     "than here. The baseline is one signal, on one month of realised volatility.\n",
     "\n",
-    "**Next**: `03_financial_features.py` builds the instrument-state, surface-level and\n",
-    "surface-dynamics features on the same panel, along with the variance risk premium, realised\n",
-    "volatility, cross-sectional and underlying families; `05_evaluation.py` is where those\n",
-    "features are first measured against the labels written here."
+    "**Next**: `03_financial_features.py` builds the volatility-surface, term-structure and\n",
+    "instrument-state features on the same panel; `05_evaluation.py` is where those features\n",
+    "are first measured against the labels written here."
    ]
   }
  ],

--- a/case_studies/sp500_options/02_labels.py
+++ b/case_studies/sp500_options/02_labels.py
@@ -869,7 +869,6 @@ for name in LABEL_NAMES:
 # with a quoted matched-strike straddle, with the liquidity screen applied downstream rather
 # than here. The baseline is one signal, on one month of realised volatility.
 #
-# **Next**: `03_financial_features.py` builds the instrument-state, surface-level and
-# surface-dynamics features on the same panel, along with the variance risk premium, realised
-# volatility, cross-sectional and underlying families; `05_evaluation.py` is where those
-# features are first measured against the labels written here.
+# **Next**: `03_financial_features.py` builds the volatility-surface, term-structure and
+# instrument-state features on the same panel; `05_evaluation.py` is where those features
+# are first measured against the labels written here.

--- a/case_studies/us_firm_characteristics/02_labels.ipynb
+++ b/case_studies/us_firm_characteristics/02_labels.ipynb
@@ -1466,9 +1466,9 @@
     "to measure that difference with. The comparison signal is one characteristic of the several\n",
     "dozen the release carries.\n",
     "\n",
-    "**Next**: `03_financial_features.py` builds value, quality, investment, momentum and risk\n",
-    "features from these characteristics, and the composites and interactions over them;\n",
-    "`04_evaluation.py` is where those features are scored against these labels."
+    "**Next**: `03_financial_features.py` builds fundamental, momentum and cross-sectional rank\n",
+    "features from these characteristics; `04_evaluation.py` is where those features are scored\n",
+    "against these labels."
    ]
   }
  ],

--- a/case_studies/us_firm_characteristics/02_labels.py
+++ b/case_studies/us_firm_characteristics/02_labels.py
@@ -696,6 +696,6 @@ for name in LABEL_NAMES:
 # to measure that difference with. The comparison signal is one characteristic of the several
 # dozen the release carries.
 #
-# **Next**: `03_financial_features.py` builds value, quality, investment, momentum and risk
-# features from these characteristics, and the composites and interactions over them;
-# `04_evaluation.py` is where those features are scored against these labels.
+# **Next**: `03_financial_features.py` builds fundamental, momentum and cross-sectional rank
+# features from these characteristics; `04_evaluation.py` is where those features are scored
+# against these labels.

--- a/scripts/verify_artifact_sidecars.py
+++ b/scripts/verify_artifact_sidecars.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Check every case-study artifact against the digest sidecar its producer wrote.
+
+`case_studies/utils/artifact_digest.py` writes `<artifact>.digest.json` beside every
+label and feature parquet, recording a hash of the values, the row count, the key
+columns, and the digest of each input. Nothing read one until
+`utils.modeling.verify_artifact_sidecars`, and that runs only under
+`load_modeling_dataset(..., verify_input_digests=True)` because verifying a *content*
+digest means hashing every row - a multi-GB re-read on the larger panels, paid on
+every load, for a state only an artifact regeneration can create.
+
+This is the other end of that trade: run it once, after the regeneration, over
+everything. A run costs what one full load would have cost per artifact, and it
+reports the whole set rather than stopping at the first disagreement.
+
+    uv run python scripts/verify_artifact_sidecars.py
+    uv run python scripts/verify_artifact_sidecars.py --case-study etfs
+    uv run python scripts/verify_artifact_sidecars.py --require-sidecar
+
+Exit 0 means every artifact hashes to what its producer recorded. Exit 1 names each
+one that does not. Without `--require-sidecar` an artifact with no sidecar is
+reported and does not fail, because artifacts written before the sidecar existed are
+in that state and cannot be told apart from a silent change - which is the whole
+reason to regenerate them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import polars as pl  # noqa: E402
+
+from case_studies.utils.artifact_digest import read_digest, sidecar_path, value_digest  # noqa: E402
+from utils.paths import get_case_study_dir  # noqa: E402
+
+
+def artifacts_for(case_dir: Path) -> list[Path]:
+    """Every label and feature parquet the case study has written."""
+    return sorted(
+        p
+        for sub in ("labels", "features")
+        for p in (case_dir / sub).glob("*.parquet")
+        if (case_dir / sub).is_dir()
+    )
+
+
+def check(path: Path, *, require_sidecar: bool) -> tuple[str, str]:
+    """Return (status, detail) for one artifact. Status is ok, absent or a failure."""
+    if not sidecar_path(path).exists():
+        return ("missing" if require_sidecar else "absent", "no digest sidecar")
+    try:
+        record = read_digest(path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return "unreadable", str(exc)
+    recorded = record.get("digest")
+    if not recorded:
+        return "no-digest", "sidecar records no digest"
+    frame = pl.read_parquet(path)
+    actual = value_digest(frame)
+    if actual != recorded:
+        return "changed", f"hashes {actual}, sidecar records {recorded}"
+    rows = record.get("n_rows")
+    if rows is not None and int(rows) != frame.height:
+        return "changed", f"{frame.height} rows, sidecar records {rows}"
+    return "ok", recorded
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case-study", action="append", dest="case_studies")
+    parser.add_argument(
+        "--require-sidecar",
+        action="store_true",
+        help="fail on an artifact whose producer recorded nothing, not only on one that changed",
+    )
+    args = parser.parse_args()
+
+    root = REPO_ROOT / "case_studies"
+    names = args.case_studies or sorted(
+        d.name for d in root.iterdir() if d.is_dir() and (d / "config" / "setup.yaml").exists()
+    )
+
+    failures: list[str] = []
+    absent = 0
+    verified = 0
+    checked_any = False
+    for name in names:
+        # Resolved the way the notebooks resolve it, so a --case-study worktree
+        # reads the canonical artifacts through its symlink rather than an empty
+        # directory beside the checkout.
+        for path in artifacts_for(get_case_study_dir(name, create=False)):
+            checked_any = True
+            rel = path
+            status, detail = check(path, require_sidecar=args.require_sidecar)
+            if status == "ok":
+                verified += 1
+            elif status == "absent":
+                absent += 1
+                print(f"  no sidecar  {rel}")
+            else:
+                failures.append(f"{rel}: {detail}")
+                print(f"  {status.upper():10s} {rel}: {detail}")
+
+    print(f"\n{verified} verified, {absent} without a sidecar, {len(failures)} failed")
+    if not checked_any:
+        print(
+            "\nNo artifact was found for any of "
+            f"{', '.join(names)}. A worktree built without --case-study has no "
+            "labels/ or features/ to read; re-create it with --case-study, or run "
+            "this from one that has them."
+        )
+        return 1
+    if failures:
+        print(
+            "\nAn artifact that does not hash to what its producer recorded has changed since it "
+            "was written, so anything trained on it carries an identity that does not describe "
+            "its inputs. Re-run the notebook that writes it."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_artifact_sidecars.py
+++ b/scripts/verify_artifact_sidecars.py
@@ -61,8 +61,14 @@ def check(path: Path, *, require_sidecar: bool) -> tuple[str, str]:
     recorded = record.get("digest")
     if not recorded:
         return "no-digest", "sidecar records no digest"
-    frame = pl.read_parquet(path)
-    actual = value_digest(frame)
+    try:
+        frame = pl.read_parquet(path)
+        actual = value_digest(frame)
+    except (OSError, KeyError, pl.exceptions.PolarsError) as exc:
+        # Reported and carried on rather than raised: the point of this script is
+        # that one run tells you about every artifact, and a truncated parquet is
+        # exactly the kind of thing you want listed beside the others.
+        return "unreadable", f"{type(exc).__name__}: {exc}"
     if actual != recorded:
         return "changed", f"hashes {actual}, sidecar records {recorded}"
     rows = record.get("n_rows")

--- a/tests/test_artifact_sidecar_verification.py
+++ b/tests/test_artifact_sidecar_verification.py
@@ -118,3 +118,96 @@ def test_every_failing_artifact_is_named_not_just_the_first(tmp_path: Path) -> N
         verify_artifact_sidecars({"financial": good, "label": stale, "model_based": bare})
     message = str(excinfo.value)
     assert "label:" in message and "model_based:" in message and "financial:" not in message
+
+
+def _tiny_case_study(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, stale: bool):
+    """A case study whose `financial.parquet` sidecar either agrees with it or does not."""
+    from datetime import datetime
+
+    import utils.modeling as modeling
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "features").mkdir()
+    (case_dir / "labels").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text("labels:\n  primary: primary\n  buffer: 1D\n")
+
+    days = pl.datetime_range(datetime(2020, 1, 1), datetime(2020, 3, 1), "1d", eager=True).dt.date()
+    keys = {"timestamp": days, "symbol": ["AAA"] * len(days)}
+    write_artifact(
+        pl.DataFrame({**keys, "primary": [0.1] * len(days)}),
+        case_dir / "labels" / "primary.parquet",
+        keys=["timestamp", "symbol"],
+        written_by="test",
+    )
+    features = case_dir / "features" / "financial.parquet"
+    write_artifact(
+        pl.DataFrame({**keys, "feature": [1.0] * len(days)}),
+        features,
+        keys=["timestamp", "symbol"],
+        written_by="test",
+    )
+    if stale:
+        # The values move and the sidecar beside them does not, which is the defect.
+        pl.DataFrame({**keys, "feature": [9.0] * len(days)}).write_parquet(features)
+
+    splits = [
+        {
+            "fold": 0,
+            "train_start": days[0],
+            "train_end": days[20],
+            "val_start": days[25],
+            "val_end": days[-1],
+        }
+    ]
+    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _case_id: case_dir)
+    monkeypatch.setattr(modeling, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(modeling, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(
+        modeling, "resolve_storage_path", lambda _case_id, _spec, fallback: case_dir / fallback
+    )
+    monkeypatch.setattr(modeling, "resolve_label_buffer", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "resolve_label_horizon", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "generate_cv_splits", lambda *_a, **_k: splits)
+    monkeypatch.setattr(modeling, "make_wf_config", lambda *_args, **_kwargs: None)
+    return modeling
+
+
+def test_the_loader_refuses_a_stale_sidecar_under_the_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without this the helper's tests pass with no production call site at all.
+
+    Every other test in this file calls `verify_artifact_sidecars` directly, so
+    deleting the call inside `load_modeling_dataset` would leave them all green and
+    put the defect back. This one fails if the call goes.
+    """
+    modeling = _tiny_case_study(tmp_path, monkeypatch, stale=True)
+
+    with pytest.raises(ValueError, match="hashes .*, its sidecar records"):
+        modeling.load_modeling_dataset("cs", "primary", verify_input_digests=True)
+
+
+def test_the_loader_is_silent_about_digests_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifying a content digest re-reads and re-hashes the whole artifact.
+
+    That is why the flag exists rather than being on: the cost is a multi-GB read
+    plus a sort of every row hash, per load, and the state it catches is created
+    only by regenerating an artifact. `scripts/verify_artifact_sidecars.py` is where
+    it is paid once, over everything.
+    """
+    modeling = _tiny_case_study(tmp_path, monkeypatch, stale=True)
+
+    assert modeling.load_modeling_dataset("cs", "primary").label_col == "primary"
+
+
+def test_the_loader_accepts_an_artifact_that_matches_its_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modeling = _tiny_case_study(tmp_path, monkeypatch, stale=False)
+
+    assert modeling.load_modeling_dataset("cs", "primary", verify_input_digests=True).label_col == (
+        "primary"
+    )

--- a/tests/test_artifact_sidecar_verification.py
+++ b/tests/test_artifact_sidecar_verification.py
@@ -72,6 +72,40 @@ def test_an_unreadable_sidecar_is_refused(tmp_path: Path) -> None:
         verify_artifact_sidecars({"financial": path})
 
 
+def test_a_missing_sidecar_is_skipped_when_presence_is_not_required(tmp_path: Path) -> None:
+    """The CI fixtures predate the sidecar, so absence must not fail an ordinary load.
+
+    A skipped artifact is absent from the returned mapping rather than present with a
+    null, so a caller carrying these into a training spec records what it verified and
+    not what it declined to.
+    """
+    good = _artifact(tmp_path, "financial")
+    bare = tmp_path / "model_based.parquet"
+    pl.DataFrame({"timestamp": [1], "symbol": ["A"], "f": [1.0]}).write_parquet(bare)
+
+    verified = verify_artifact_sidecars(
+        {"financial": good, "model_based": bare}, require_sidecar=False
+    )
+    assert verified == {"financial": value_digest(pl.read_parquet(good))}
+
+
+def test_a_disagreeing_sidecar_is_refused_even_when_presence_is_not_required(
+    tmp_path: Path,
+) -> None:
+    """Absence and disagreement carry different evidence, and only absence is excused.
+
+    This is the case the issue is about, and it is the one that has to fire on an
+    ordinary load: the values moved and the record did not move with them.
+    """
+    path = _artifact(tmp_path)
+    pl.DataFrame(
+        {"timestamp": [1, 2, 3], "symbol": ["A", "B", "C"], "feature": [9.0, 9.0, 9.0]}
+    ).write_parquet(path)
+
+    with pytest.raises(ValueError, match="hashes .*, its sidecar records"):
+        verify_artifact_sidecars({"financial": path}, require_sidecar=False)
+
+
 def test_every_failing_artifact_is_named_not_just_the_first(tmp_path: Path) -> None:
     """A run with two stale inputs should report two, so one pass fixes both."""
     good = _artifact(tmp_path, "financial")

--- a/tests/test_artifact_sidecar_verification.py
+++ b/tests/test_artifact_sidecar_verification.py
@@ -211,3 +211,42 @@ def test_the_loader_accepts_an_artifact_that_matches_its_sidecar(
     assert modeling.load_modeling_dataset("cs", "primary", verify_input_digests=True).label_col == (
         "primary"
     )
+
+
+def test_the_cheap_check_catches_an_artifact_whose_row_count_moved(tmp_path: Path) -> None:
+    """`write_artifact` writes the parquet first, so a crash leaves new data, old record.
+
+    The row count comes out of parquet metadata, so this costs no column read and can
+    run on every load.
+    """
+    path = _artifact(tmp_path)
+    pl.DataFrame({"timestamp": [1], "symbol": ["A"], "feature": [1.0]}).write_parquet(path)
+
+    with pytest.raises(ValueError, match="holds 1 rows, its sidecar records 3"):
+        verify_artifact_sidecars({"financial": path}, values=False)
+
+
+def test_the_cheap_check_does_not_see_a_value_change_at_the_same_row_count(
+    tmp_path: Path,
+) -> None:
+    """Stated rather than left implicit: this is what `values=True` is for."""
+    path = _artifact(tmp_path)
+    pl.DataFrame(
+        {"timestamp": [1, 2, 3], "symbol": ["A", "B", "C"], "feature": [9.0, 9.0, 9.0]}
+    ).write_parquet(path)
+
+    assert verify_artifact_sidecars({"financial": path}, values=False) == {}
+    with pytest.raises(ValueError, match="hashes .*, its sidecar records"):
+        verify_artifact_sidecars({"financial": path})
+
+
+def test_the_loader_catches_a_truncated_artifact_without_the_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default load is not silent about everything, only about values."""
+    modeling = _tiny_case_study(tmp_path, monkeypatch, stale=False)
+    features = tmp_path / "cs" / "features" / "financial.parquet"
+    pl.read_parquet(features).head(3).write_parquet(features)
+
+    with pytest.raises(ValueError, match="holds 3 rows, its sidecar records"):
+        modeling.load_modeling_dataset("cs", "primary")

--- a/tests/test_notebook_pair_metadata_filter.py
+++ b/tests/test_notebook_pair_metadata_filter.py
@@ -1,0 +1,73 @@
+"""A paired notebook must filter papermill's cell metadata out of its ``.py``.
+
+Papermill stamps ``metadata.papermill`` on every cell it executes. Without
+``cell_metadata_filter: tags,-all`` in the jupytext header that stamp round-trips
+into the ``.py`` on the next ``jupytext --sync``, so the pair disagrees with what
+is committed and JupyterLab's contents manager refuses to open the notebook with a
+``File Load Error`` (public #372).
+
+The defect is invisible until something re-executes: a committed pair whose ``.py``
+carries the markers inline agrees with its ``.ipynb`` and opens fine. Five stage
+01-05 notebooks sat in that state, and a sweep that re-executes all 44 would have
+turned every one of them into a tree the ``notebook-sync`` pre-commit gate refuses.
+
+Nothing checked the header, which is why it could be dropped by editing a notebook
+by hand or by adding one from a template that predates the convention.
+
+Scoped to stages 01-05, which are clean: 0 of 45 lack the header and 0 carry an
+inline marker. Measured on the same pass, stages 06 and later are not - 125
+notebooks have no ``cell_metadata_filter`` and 5 carry inline markers (3 in
+cme_futures, 2 in etfs) - and they are filed rather than fixed here, because a
+notebook only stops carrying the markers when it is re-executed and stages 06-13
+are re-executed by the retrain, not by this sweep. Widen the glob when that lands.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_FILTER = "tags,-all"
+STAGE_01_05 = re.compile(r"^0[1-5]_[a-z_]+$")
+
+
+def _paired_notebooks() -> list[Path]:
+    """Every stage 01-05 ``.ipynb`` under ``case_studies`` with a ``.py`` beside it."""
+    return sorted(
+        nb
+        for nb in (REPO_ROOT / "case_studies").rglob("*.ipynb")
+        if ".ipynb_checkpoints" not in nb.parts
+        and STAGE_01_05.match(nb.stem)
+        and nb.with_suffix(".py").exists()
+    )
+
+
+@pytest.mark.parametrize("notebook", _paired_notebooks(), ids=lambda p: p.stem)
+def test_the_jupytext_header_filters_cell_metadata(notebook: Path) -> None:
+    metadata = json.loads(notebook.read_text())["metadata"]
+    jupytext = metadata.get("jupytext", {})
+    assert jupytext.get("cell_metadata_filter") == REQUIRED_FILTER, (
+        f"{notebook.relative_to(REPO_ROOT)} has no cell_metadata_filter, so the next "
+        f"production run writes papermill's cell metadata back into its .py and the "
+        f"pair stops opening in JupyterLab"
+    )
+
+
+@pytest.mark.parametrize("notebook", _paired_notebooks(), ids=lambda p: p.stem)
+def test_the_paired_py_carries_no_papermill_marker(notebook: Path) -> None:
+    """The state the filter prevents, read from the other side of the pair.
+
+    A ``.py`` carrying ``papermill={...}`` on its cell markers is a pair that already
+    round-tripped once. It opens today and desyncs on the next run, which is the
+    trap: the header check above would pass on a file someone has since re-added the
+    header to without stripping what the earlier runs left behind.
+    """
+    source = notebook.with_suffix(".py").read_text()
+    assert "papermill={" not in source, (
+        f"{notebook.with_suffix('.py').relative_to(REPO_ROOT)} carries inline papermill "
+        f"cell metadata from an earlier run; strip it and re-execute"
+    )

--- a/tests/test_variant_fold_geometry.py
+++ b/tests/test_variant_fold_geometry.py
@@ -13,6 +13,9 @@ never reads ``val_start``.
 
 from __future__ import annotations
 
+from datetime import datetime
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -147,3 +150,118 @@ def test_a_variant_fold_with_no_counterpart_is_a_violation(geometries) -> None:
 def test_a_missing_primary_geometry_raises_rather_than_passing(geometries) -> None:
     with pytest.raises(ValueError, match="No folds derivable"):
         assert_variant_folds_are_out_of_sample("cs", "primary")
+
+
+def _tiny_case_study(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, splits: list[dict]):
+    """A case study with one primary label, one variant, and a fold-tagged artifact.
+
+    Small enough to be read at a glance and complete enough that
+    ``load_modeling_dataset`` runs the same path a model notebook does.
+    """
+    import polars as pl
+
+    import utils.modeling as modeling
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "features").mkdir()
+    (case_dir / "labels").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text(
+        "labels:\n  primary: primary\n  buffer: 1D\n  variants: [variant]\n"
+        "  variant_buffers:\n    variant: 1D\n"
+    )
+
+    days = pl.datetime_range(
+        datetime(2020, 1, 1), datetime(2020, 12, 31), "1d", eager=True
+    ).dt.date()
+    frame = {"timestamp": days, "symbol": ["AAA"] * len(days)}
+    pl.DataFrame({**frame, "primary": [0.1] * len(days)}).write_parquet(
+        case_dir / "labels" / "primary.parquet"
+    )
+    pl.DataFrame({**frame, "variant": [0.1] * len(days)}).write_parquet(
+        case_dir / "labels" / "variant.parquet"
+    )
+    pl.DataFrame({**frame, "feature": [1.0] * len(days)}).write_parquet(
+        case_dir / "features" / "financial.parquet"
+    )
+    pl.DataFrame({**frame, "fold": [0] * len(days), "fitted": [2.0] * len(days)}).write_parquet(
+        case_dir / "features" / "model_based.parquet"
+    )
+
+    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _case_id: case_dir)
+    monkeypatch.setattr(modeling, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(modeling, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(
+        modeling,
+        "resolve_storage_path",
+        lambda _case_id, _spec, fallback: case_dir / fallback,
+    )
+    monkeypatch.setattr(modeling, "resolve_label_buffer", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "resolve_label_horizon", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "generate_cv_splits", lambda *_a, **_k: splits)
+    monkeypatch.setattr(modeling, "make_wf_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cv_window,
+        "_load_setup_yaml",
+        lambda _cs: {"labels": {"primary": "primary", "variants": ["variant"]}},
+    )
+    return modeling
+
+
+# The whole fold: the artifact's fold 0 covers it, so coverage has nothing to say.
+_WHOLE_YEAR = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+
+
+def test_loading_a_variant_whose_validation_opens_inside_the_fit_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard had no production call site, so nothing ran it on a real load.
+
+    ``validate_temporal_fold_coverage`` passes here - the artifact covers every date
+    in the window - which is why coverage was never going to catch this.
+    """
+    modeling = _tiny_case_study(tmp_path, monkeypatch, _WHOLE_YEAR)
+    store = {
+        "primary": _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")]),
+        "variant": _splits([("2020-01-01", "2020-06-10", "2020-06-15", "2020-12-31")]),
+    }
+    monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, lab: store.get(lab))
+
+    with pytest.raises(AssertionError, match="reach into a variant label's validation span"):
+        modeling.load_modeling_dataset("cs", "variant")
+
+
+def test_loading_a_variant_whose_validation_opens_after_the_fit_is_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modeling = _tiny_case_study(tmp_path, monkeypatch, _WHOLE_YEAR)
+    store = {
+        "primary": _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")]),
+        "variant": _splits([("2020-01-01", "2020-06-24", "2020-06-30", "2020-12-31")]),
+    }
+    monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, lab: store.get(lab))
+
+    mds = modeling.load_modeling_dataset("cs", "variant")
+    assert mds.label_col == "variant"
+    # The check hangs off the fold-tagged artifact, so a fixture that loaded no
+    # artifact would pass this file vacuously.
+    assert mds.temporal_by_fold is not None
+
+
+def test_loading_the_primary_label_does_not_check_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The artifact is built on the primary's own geometry, so there is nothing to check.
+
+    The variant geometry left in the store leaks, and loading the primary still
+    succeeds: the check is scoped to the label being loaded rather than sweeping
+    every configured label on every load.
+    """
+    modeling = _tiny_case_study(tmp_path, monkeypatch, _WHOLE_YEAR)
+    store = {
+        "primary": _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")]),
+        "variant": _splits([("2020-01-01", "2020-06-10", "2020-06-15", "2020-12-31")]),
+    }
+    monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, lab: store.get(lab))
+
+    assert modeling.load_modeling_dataset("cs", "primary").label_col == "primary"

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -417,7 +417,11 @@ def get_classification_eval_label(case_study_id: str, label: str) -> str:
     return str(mapping[label])
 
 
-def verify_artifact_sidecars(artifacts: Mapping[str, Path]) -> dict[str, str]:
+def verify_artifact_sidecars(
+    artifacts: Mapping[str, Path],
+    *,
+    require_sidecar: bool = True,
+) -> dict[str, str]:
     """Check each input artifact against the digest sidecar its producer wrote.
 
     ``case_studies/utils/artifact_digest.py`` writes ``<artifact>.digest.json``
@@ -429,20 +433,27 @@ def verify_artifact_sidecars(artifacts: Mapping[str, Path]) -> dict[str, str]:
     model trained on corrected features and one trained on the leaky version it
     replaced produce the identical training_hash unless something reads the values.
 
-    Raises on a digest that disagrees with the file, and on an artifact with no
-    sidecar: an artifact whose producer never recorded what it wrote is exactly the
-    case this cannot distinguish from a silent change.
+    Raises on a digest that disagrees with the file. Whether a *missing* sidecar
+    also raises is the caller's to choose, because the two carry different
+    evidence. A disagreeing sidecar is a value that moved without its record
+    moving with it, which is the defect itself, and it is never acceptable. A
+    missing sidecar means the producer recorded nothing, which cannot be told
+    apart from a silent change but is also the state of every artifact written
+    before the sidecar existed.
 
     Returns the verified digest per artifact, so the caller can carry it into the
-    training spec.
+    training spec. Artifacts skipped under ``require_sidecar=False`` are absent
+    from the mapping rather than present with a null.
 
-    **Not yet on by default**, and the precondition is measured rather than assumed:
+    ``load_modeling_dataset`` checks agreement on every load and requires presence
+    only under ``verify_input_digests``. The split is measured rather than assumed:
     on 2026-08-09 the production artifacts carried 49 sidecars out of 51, both gaps
     in sp500_options, while the CI fixtures under
     ``ml4t/third-edition-test-data/intermediates`` carried **none** - 0 of 7 for
     cme_futures, 0 of 5 for etfs, 0 of 6 for fx_pairs, 0 of 6 for us_equities_panel.
-    Turning ``verify_input_digests`` on before those are regenerated fails every
-    case-study CI job for a missing sidecar rather than for a changed value.
+    Requiring presence before those are regenerated fails every case-study CI job
+    for a missing sidecar rather than for a changed value, which is the failure the
+    gate is not for.
     """
     from case_studies.utils.artifact_digest import read_digest, sidecar_path, value_digest
 
@@ -451,7 +462,8 @@ def verify_artifact_sidecars(artifacts: Mapping[str, Path]) -> dict[str, str]:
     for name, path in sorted(artifacts.items()):
         side = sidecar_path(path)
         if not side.exists():
-            problems.append(f"{name}: no digest sidecar beside {path.name}")
+            if require_sidecar:
+                problems.append(f"{name}: no digest sidecar beside {path.name}")
             continue
         try:
             record = read_digest(path)
@@ -667,6 +679,25 @@ def load_modeling_dataset(
             splits,
             date_col=date_col,
         )
+        # The artifact carries one fold set, built on the primary label's geometry, and
+        # the rows above were selected from it by ``fold`` id. So the values this load
+        # returns for fold F were fit on data through the *primary* label's train_end,
+        # and a label whose own validation opens earlier than that is scored on sessions
+        # its features already saw. Coverage does not see this: an artifact can cover
+        # every date a variant is scored on and still have been fit past the start of
+        # that window. Checked here rather than in a notebook because every model
+        # notebook reaches its data through this call, and only the label being loaded
+        # is checked, so the cost is one label timeline rather than all of them.
+        from case_studies.utils.cv_window import (
+            assert_variant_folds_are_out_of_sample,
+            configured_labels,
+        )
+
+        configured = configured_labels(case_study_id)
+        if configured and primary_label != configured[0]:
+            assert_variant_folds_are_out_of_sample(
+                case_study_id, configured[0], variants=[primary_label]
+            )
 
     # WalkForwardConfig for library integration
     # Normalize month-based buffers to days (pd.Timedelta rejects 'M' as ambiguous)
@@ -720,8 +751,11 @@ def load_modeling_dataset(
         input_artifacts["model_based"] = temporal_path
     if eval_label_path is not None:
         input_artifacts["eval_label"] = eval_label_path
-    if verify_input_digests:
-        verify_artifact_sidecars(input_artifacts)
+    # Agreement is checked on every load: a sidecar that disagrees with its artifact
+    # is a value that changed without its record changing, which is the defect the
+    # sidecar exists to catch. Presence is required only on request, because the CI
+    # fixtures predate the sidecar and would fail for the wrong reason.
+    verify_artifact_sidecars(input_artifacts, require_sidecar=verify_input_digests)
     return ModelingDataset(
         dataset=dataset,
         feature_names=feature_names,

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -421,6 +421,7 @@ def verify_artifact_sidecars(
     artifacts: Mapping[str, Path],
     *,
     require_sidecar: bool = True,
+    values: bool = True,
 ) -> dict[str, str]:
     """Check each input artifact against the digest sidecar its producer wrote.
 
@@ -442,18 +443,35 @@ def verify_artifact_sidecars(
     before the sidecar existed.
 
     Returns the verified digest per artifact, so the caller can carry it into the
-    training spec. Artifacts skipped under ``require_sidecar=False`` are absent
-    from the mapping rather than present with a null.
+    training spec. Artifacts skipped under ``require_sidecar=False``, and every
+    artifact under ``values=False``, are absent from the mapping rather than
+    present with a null.
 
-    ``load_modeling_dataset`` checks agreement on every load and requires presence
-    only under ``verify_input_digests``. The split is measured rather than assumed:
-    on 2026-08-09 the production artifacts carried 49 sidecars out of 51, both gaps
-    in sp500_options, while the CI fixtures under
+    ``values`` chooses what the check costs, and the two settings answer different
+    questions. With it, the parquet is read and every row hashed, which is what the
+    recorded content digest is - order-independent, so it moves when and only when
+    a value moves. Without it, only the row count is compared, which parquet
+    metadata answers without reading a column. The cheap check cannot see a value
+    change that preserves the row count, and it does see the case that a crash
+    creates: ``write_artifact`` writes the parquet before its sidecar, so an
+    interrupted regeneration leaves new data beside the previous record, and new
+    data almost always has a different number of rows.
+
+    ``load_modeling_dataset`` runs the cheap check on every load and the full one
+    under ``verify_input_digests``; ``scripts/verify_artifact_sidecars.py`` runs the
+    full one over every case study, once, after a regeneration. That split is about
+    cost: hashing us_equities_panel's feature matrix is a multi-GB read plus a sort
+    over 68M row hashes.
+
+    Whether a *missing* sidecar raises is the caller's to choose, because presence
+    and disagreement carry different evidence. A missing sidecar means the producer
+    recorded nothing, which is the state of every artifact written before the
+    sidecar existed, and requiring presence before those are regenerated fails for
+    absence rather than for a changed value. Measured rather than assumed: on
+    2026-08-09 the production artifacts carried 49 sidecars out of 51, both gaps in
+    sp500_options, while the CI fixtures under
     ``ml4t/third-edition-test-data/intermediates`` carried **none** - 0 of 7 for
     cme_futures, 0 of 5 for etfs, 0 of 6 for fx_pairs, 0 of 6 for us_equities_panel.
-    Requiring presence before those are regenerated fails every case-study CI job
-    for a missing sidecar rather than for a changed value, which is the failure the
-    gate is not for.
     """
     from case_studies.utils.artifact_digest import read_digest, sidecar_path, value_digest
 
@@ -474,9 +492,35 @@ def verify_artifact_sidecars(
         if not recorded:
             problems.append(f"{name}: sidecar records no digest")
             continue
-        actual = value_digest(pl.read_parquet(path))
+
+        rows = record.get("n_rows")
+        if not values:
+            if rows is None:
+                continue
+            try:
+                actual_rows = pl.scan_parquet(path).select(pl.len()).collect().item()
+            except (OSError, pl.exceptions.PolarsError) as exc:
+                problems.append(f"{name}: {path.name} unreadable ({exc})")
+                continue
+            if int(rows) != int(actual_rows):
+                problems.append(
+                    f"{name}: {path.name} holds {actual_rows} rows, its sidecar records {rows}"
+                )
+            continue
+
+        try:
+            frame = pl.read_parquet(path)
+        except (OSError, pl.exceptions.PolarsError) as exc:
+            problems.append(f"{name}: {path.name} unreadable ({exc})")
+            continue
+        actual = value_digest(frame)
         if actual != recorded:
             problems.append(f"{name}: {path.name} hashes {actual}, its sidecar records {recorded}")
+            continue
+        if rows is not None and int(rows) != frame.height:
+            problems.append(
+                f"{name}: {path.name} holds {frame.height} rows, its sidecar records {rows}"
+            )
             continue
         verified[name] = recorded
 
@@ -751,15 +795,21 @@ def load_modeling_dataset(
         input_artifacts["model_based"] = temporal_path
     if eval_label_path is not None:
         input_artifacts["eval_label"] = eval_label_path
-    # Opt-in here, and the reason is cost rather than caution. The sidecar records
-    # a *content* digest, deliberately independent of row and column order, so
-    # verifying one means reading the parquet and hashing every row of it. On
-    # us_equities_panel that is a multi-GB re-read plus a sort over 68M row hashes,
-    # paid on every load, to catch a state only an artifact regeneration creates.
-    # The place the check belongs is once after that regeneration, which is what
-    # scripts/verify_artifact_sidecars.py does across every case study.
-    if verify_input_digests:
-        verify_artifact_sidecars(input_artifacts)
+    # Two depths, and the flag chooses between them rather than between checking
+    # and not. The row-count comparison reads parquet metadata and no column, so it
+    # runs always: write_artifact writes the parquet before its sidecar, and an
+    # interrupted regeneration therefore leaves new data beside the previous
+    # record, which almost always has a different number of rows. Comparing the
+    # content digest is what catches a value change that keeps the row count, and
+    # that means hashing every row - a multi-GB read plus a sort over 68M row
+    # hashes on us_equities_panel, paid per load. It is the same work
+    # scripts/verify_artifact_sidecars.py does once over everything after a
+    # regeneration, which is where a sweep should pay it.
+    verify_artifact_sidecars(
+        input_artifacts,
+        require_sidecar=verify_input_digests,
+        values=verify_input_digests,
+    )
     return ModelingDataset(
         dataset=dataset,
         feature_names=feature_names,

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -751,11 +751,15 @@ def load_modeling_dataset(
         input_artifacts["model_based"] = temporal_path
     if eval_label_path is not None:
         input_artifacts["eval_label"] = eval_label_path
-    # Agreement is checked on every load: a sidecar that disagrees with its artifact
-    # is a value that changed without its record changing, which is the defect the
-    # sidecar exists to catch. Presence is required only on request, because the CI
-    # fixtures predate the sidecar and would fail for the wrong reason.
-    verify_artifact_sidecars(input_artifacts, require_sidecar=verify_input_digests)
+    # Opt-in here, and the reason is cost rather than caution. The sidecar records
+    # a *content* digest, deliberately independent of row and column order, so
+    # verifying one means reading the parquet and hashing every row of it. On
+    # us_equities_panel that is a multi-GB re-read plus a sort over 68M row hashes,
+    # paid on every load, to catch a state only an artifact regeneration creates.
+    # The place the check belongs is once after that regeneration, which is what
+    # scripts/verify_artifact_sidecars.py does across every case study.
+    if verify_input_digests:
+        verify_artifact_sidecars(input_artifacts)
     return ModelingDataset(
         dataset=dataset,
         feature_names=feature_names,


### PR DESCRIPTION
Nine case-study panes are about to re-run stages 01-05 of all nine case studies, 44 notebooks and
26 artifacts. This is the shared work that has to land first, because it is code every one of them
executes.

## `main` could not accept a commit from anyone

The `notebook-sync` pre-commit gate runs repo-wide rather than on staged paths, and it was red:

```
STALE (paired .py changed since the notebook was executed):
  case_studies/crypto_perps_funding/01_feasibility_analysis.ipynb
  case_studies/sp500_equity_option_analytics/02_labels.ipynb
  case_studies/sp500_options/02_labels.ipynb
  case_studies/us_firm_characteristics/02_labels.ipynb
```

A merge order, not a mistaken edit. #508 re-executed and re-stamped 23 notebooks; #506 then landed
prose on four of them, having been written and checked against the pre-#508 stamps. The four are
restored to what their stamps record. Three of the edits are markdown and one renames a local
(`carrier` to `signal_panel`); each is recorded against the case study that owns it, so the pane
re-executing that notebook re-applies it and re-stamps. Re-executing them here was not open to this
worktree - it has no `--case-study` symlinks, and three of the four are label producers with nowhere
canonical to write.

## Two guards existed and neither ran

`assert_variant_folds_are_out_of_sample` (#40) asserts `variant.val_start > primary.train_end`, the
property a model reading a fold by id needs. It had **zero production call sites**: its tests run on
monkeypatched geometries, so nothing would have noticed a `labels.variant_buffers` entry changing in
a `setup.yaml`. It now runs inside `load_modeling_dataset`, scoped to the label being loaded, so the
cost is one label timeline rather than every configured label on every load. Coverage cannot
substitute for it - an artifact can cover every date a variant is scored on and still have been fit
past the start of that window, which is what the new tests build.

`verify_artifact_sidecars` (#323) sat behind `verify_input_digests`, default False. It now runs on
every load at the depth parquet metadata can answer for free, and at full depth under the flag:

- **row count, always.** `write_artifact` writes the parquet before its sidecar, so an interrupted
  regeneration leaves new data beside the previous record. New data almost always has a different
  number of rows, and the count comes out of metadata without reading a column.
- **content digest, under the flag and in `scripts/verify_artifact_sidecars.py`.** The recorded
  digest is order-independent by design, so verifying it means hashing every row - a multi-GB read
  plus a sort over 68M row hashes on `us_equities_panel`. That belongs once after a regeneration,
  not on every load. Run over the production tree the script reports **49 verified, 2 without a
  sidecar, 0 failed**, both gaps in `sp500_options`.

## Three test files CI has never run

`test-unit` names its files one by one and `test_variant_fold_geometry.py`,
`test_artifact_sidecar_verification.py` and `test_artifact_digest.py` were in none of the lists. That
is the same defect one level up: a guard with no call site establishes nothing about production, and
a test with no CI step establishes nothing about the guard. All three are added, none needs data or
an `ml4t-*` package.

`tests/test_notebook_pair_metadata_filter.py` is new and gets its own step. It holds #304 closed over
all 45 stage 01-05 pairs: the jupytext header is present, and the paired `.py` carries no inline
`papermill={...}` marker. The second half matters on its own - re-adding a header to a file that
already round-tripped once leaves the old markers behind and the first check passes.

## Four issues closed on measurement, no code needed

- **#304** - 0 of 45 pairs without `cell_metadata_filter`, 0 with an inline marker. Proved by
  stamping fresh papermill metadata on all 59 cells of `cme_futures/05_evaluation.ipynb` and running
  `jupytext --sync`: the `.py` does not move.
- **#32**, the Gate-0 holdout leak - all nine evaluation notebooks seal on the **label endpoint**, by
  three mechanisms that are each correct. The widened `03_financial_features` scope has exactly one
  notebook running the IC/FDR triage and it purges per symbol. Every `compute_ic_hac_stats` site in
  stages 01-05 sets its bandwidth from the label horizon.
- **#33** - zero hits of all four palette signature parts across all 45 notebooks. The last one came
  clean with #507.
- **#322** - one `_compute_log_likelihood` call site in the corpus, inside `temporal.py`. The line
  budget in its title does not exist under M10.

**#309** stays open: six notebooks still carry the templated sidecar sentence, all provenance-stamped,
and editing one here would make it stale and block every pane. The rewrite is already written and
still applies cleanly; each of the six now has a row on its own stage's checklist.

Stages 06 and later carry the #304 defect at scale - 125 notebooks with no `cell_metadata_filter`, 5
with inline markers - and are filed rather than fixed here, because a notebook stops carrying the
markers only when it is re-executed.
