### PR TITLE
Take every ml4t-* library to its stable release

### DIFF
--- a/07_defining_the_learning_task/10_ml4t_library_ecosystem.ipynb
+++ b/07_defining_the_learning_task/10_ml4t_library_ecosystem.ipynb
@@ -6,16 +6,16 @@
    "id": "1f379f97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:02.814753Z",
-     "iopub.status.busy": "2026-07-19T22:28:02.814276Z",
-     "iopub.status.idle": "2026-07-19T22:28:02.835805Z",
-     "shell.execute_reply": "2026-07-19T22:28:02.835097Z"
+     "iopub.execute_input": "2026-08-10T13:05:36.057822Z",
+     "iopub.status.busy": "2026-08-10T13:05:36.057709Z",
+     "iopub.status.idle": "2026-08-10T13:05:36.061180Z",
+     "shell.execute_reply": "2026-08-10T13:05:36.060587Z"
     },
     "papermill": {
-     "duration": 0.034478,
-     "end_time": "2026-07-19T22:28:02.837576+00:00",
+     "duration": 0.0065,
+     "end_time": "2026-08-10T13:05:36.061715+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:02.803098+00:00",
+     "start_time": "2026-08-10T13:05:36.055215+00:00",
      "status": "completed"
     }
    },
@@ -40,10 +40,10 @@
    "id": "39470e69",
    "metadata": {
     "papermill": {
-     "duration": 0.005533,
-     "end_time": "2026-07-19T22:28:02.849110+00:00",
+     "duration": 0.001348,
+     "end_time": "2026-08-10T13:05:36.064603+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:02.843577+00:00",
+     "start_time": "2026-08-10T13:05:36.063255+00:00",
      "status": "completed"
     }
    },
@@ -87,29 +87,20 @@
    "id": "60e0070e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:02.855964Z",
-     "iopub.status.busy": "2026-07-19T22:28:02.855840Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.815313Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.814911Z"
+     "iopub.execute_input": "2026-08-10T13:05:36.067929Z",
+     "iopub.status.busy": "2026-08-10T13:05:36.067801Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.178350Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.177808Z"
     },
     "papermill": {
-     "duration": 1.963361,
-     "end_time": "2026-07-19T22:28:04.816069+00:00",
+     "duration": 2.113263,
+     "end_time": "2026-08-10T13:05:38.179124+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:02.852708+00:00",
+     "start_time": "2026-08-10T13:05:36.065861+00:00",
      "status": "completed"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      ".venv/lib/python3.14/site-packages/ml4t/engineer/features/ml/__init__.py:9: UserWarning: Feature 'cyclical_encode': lookback=0 but has period/window parameter. Consider using lookback='period' or specifying the actual lookback.\n",
-      "  from ml4t.engineer.features.ml.cyclical_encode import *  # noqa: F403\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from __future__ import annotations\n",
     "\n",
@@ -134,16 +125,16 @@
    "id": "add85b0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.820381Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.820294Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.821712Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.821490Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.182970Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.182870Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.184785Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.184386Z"
     },
     "papermill": {
-     "duration": 0.00357,
-     "end_time": "2026-07-19T22:28:04.822078+00:00",
+     "duration": 0.004429,
+     "end_time": "2026-08-10T13:05:38.185062+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.818508+00:00",
+     "start_time": "2026-08-10T13:05:38.180633+00:00",
      "status": "completed"
     },
     "tags": [
@@ -161,10 +152,10 @@
    "id": "06759b61",
    "metadata": {
     "papermill": {
-     "duration": 0.001095,
-     "end_time": "2026-07-19T22:28:04.824340+00:00",
+     "duration": 0.001283,
+     "end_time": "2026-08-10T13:05:38.187661+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.823245+00:00",
+     "start_time": "2026-08-10T13:05:38.186378+00:00",
      "status": "completed"
     }
    },
@@ -182,16 +173,16 @@
    "id": "d401480c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.827103Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.827043Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.849250Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.848913Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.190935Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.190854Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.227779Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.227320Z"
     },
     "papermill": {
-     "duration": 0.024137,
-     "end_time": "2026-07-19T22:28:04.849622+00:00",
+     "duration": 0.03912,
+     "end_time": "2026-08-10T13:05:38.228078+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.825485+00:00",
+     "start_time": "2026-08-10T13:05:38.188958+00:00",
      "status": "completed"
     }
    },
@@ -219,16 +210,16 @@
    "id": "5604cb63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.852885Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.852799Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.856131Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.855809Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.231498Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.231417Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.235162Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.234758Z"
     },
     "papermill": {
-     "duration": 0.005813,
-     "end_time": "2026-07-19T22:28:04.856793+00:00",
+     "duration": 0.006129,
+     "end_time": "2026-08-10T13:05:38.235663+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.850980+00:00",
+     "start_time": "2026-08-10T13:05:38.229534+00:00",
      "status": "completed"
     }
    },
@@ -256,10 +247,10 @@
    "id": "76dfbe29",
    "metadata": {
     "papermill": {
-     "duration": 0.002389,
-     "end_time": "2026-07-19T22:28:04.861640+00:00",
+     "duration": 0.001323,
+     "end_time": "2026-08-10T13:05:38.238438+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.859251+00:00",
+     "start_time": "2026-08-10T13:05:38.237115+00:00",
      "status": "completed"
     }
    },
@@ -277,16 +268,16 @@
    "id": "d5211d30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.867238Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.867078Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.871315Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.870326Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.242023Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.241903Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.244746Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.244271Z"
     },
     "papermill": {
-     "duration": 0.007628,
-     "end_time": "2026-07-19T22:28:04.872082+00:00",
+     "duration": 0.005251,
+     "end_time": "2026-08-10T13:05:38.245002+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.864454+00:00",
+     "start_time": "2026-08-10T13:05:38.239751+00:00",
      "status": "completed"
     }
    },
@@ -335,10 +326,10 @@
    "id": "ca5dadb2",
    "metadata": {
     "papermill": {
-     "duration": 0.00233,
-     "end_time": "2026-07-19T22:28:04.877059+00:00",
+     "duration": 0.001327,
+     "end_time": "2026-08-10T13:05:38.247820+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.874729+00:00",
+     "start_time": "2026-08-10T13:05:38.246493+00:00",
      "status": "completed"
     }
    },
@@ -358,16 +349,16 @@
    "id": "0cbe0f0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.881270Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.881165Z",
-     "iopub.status.idle": "2026-07-19T22:28:04.883887Z",
-     "shell.execute_reply": "2026-07-19T22:28:04.883378Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.251118Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.250983Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.253999Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.253524Z"
     },
     "papermill": {
-     "duration": 0.004991,
-     "end_time": "2026-07-19T22:28:04.884151+00:00",
+     "duration": 0.005123,
+     "end_time": "2026-08-10T13:05:38.254252+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.879160+00:00",
+     "start_time": "2026-08-10T13:05:38.249129+00:00",
      "status": "completed"
     }
    },
@@ -390,7 +381,7 @@
       "Category:    volatility\n",
       "Description: ATR - Average True Range\n",
       "Formula:     (not recorded)\n",
-      "Parameters:  {}\n",
+      "Parameters:  {'period': 14}\n",
       "Input type:  close\n",
       "\n",
       "==================================================\n",
@@ -398,7 +389,7 @@
       "Category:    volatility\n",
       "Description: Garman-Klass Volatility - OHLC-based estimator\n",
       "Formula:     (not recorded)\n",
-      "Parameters:  {}\n",
+      "Parameters:  {'period': 20, 'annualize': True, 'trading_periods': 252}\n",
       "Input type:  close\n"
      ]
     }
@@ -420,10 +411,10 @@
    "id": "1a9e6eb4",
    "metadata": {
     "papermill": {
-     "duration": 0.001239,
-     "end_time": "2026-07-19T22:28:04.886684+00:00",
+     "duration": 0.001317,
+     "end_time": "2026-08-10T13:05:38.257004+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.885445+00:00",
+     "start_time": "2026-08-10T13:05:38.255687+00:00",
      "status": "completed"
     }
    },
@@ -443,10 +434,10 @@
    "id": "c6032f04",
    "metadata": {
     "papermill": {
-     "duration": 0.001358,
-     "end_time": "2026-07-19T22:28:04.889352+00:00",
+     "duration": 0.001296,
+     "end_time": "2026-08-10T13:05:38.259718+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.887994+00:00",
+     "start_time": "2026-08-10T13:05:38.258422+00:00",
      "status": "completed"
     }
    },
@@ -460,16 +451,16 @@
    "id": "61aa72e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:04.892640Z",
-     "iopub.status.busy": "2026-07-19T22:28:04.892550Z",
-     "iopub.status.idle": "2026-07-19T22:28:05.003236Z",
-     "shell.execute_reply": "2026-07-19T22:28:05.002871Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.263363Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.263226Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.462195Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.461670Z"
     },
     "papermill": {
-     "duration": 0.113337,
-     "end_time": "2026-07-19T22:28:05.003939+00:00",
+     "duration": 0.201453,
+     "end_time": "2026-08-10T13:05:38.462497+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:04.890602+00:00",
+     "start_time": "2026-08-10T13:05:38.261044+00:00",
      "status": "completed"
     }
    },
@@ -478,7 +469,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Computed 4 features: ['atr', 'ema', 'rsi', 'sma']\n"
+      "Computed 4 features: ['rsi', 'sma', 'ema', 'atr']\n"
      ]
     },
     {
@@ -491,21 +482,21 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>close</th><th>atr</th><th>ema</th><th>rsi</th><th>sma</th></tr><tr><td>date</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-24</td><td>688.499695</td><td>6.774438</td><td>678.078296</td><td>61.844868</td><td>679.29946</td></tr><tr><td>2025-12-26</td><td>688.429871</td><td>6.460795</td><td>679.06416</td><td>61.758785</td><td>679.929361</td></tr><tr><td>2025-12-29</td><td>685.976562</td><td>6.301341</td><td>679.722484</td><td>58.668815</td><td>680.252148</td></tr><tr><td>2025-12-30</td><td>685.138916</td><td>5.992287</td><td>680.238335</td><td>57.608979</td><td>680.688171</td></tr><tr><td>2025-12-31</td><td>680.062744</td><td>5.966736</td><td>680.221612</td><td>51.533487</td><td>680.807739</td></tr></tbody></table></div>"
+       "<small>shape: (5, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>close</th><th>rsi</th><th>sma</th><th>ema</th><th>atr</th></tr><tr><td>date</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-24</td><td>686.73053</td><td>61.844894</td><td>677.553928</td><td>676.335904</td><td>6.757029</td></tr><tr><td>2025-12-26</td><td>686.660889</td><td>61.758815</td><td>678.182211</td><td>677.319236</td><td>6.444192</td></tr><tr><td>2025-12-29</td><td>684.213867</td><td>58.668818</td><td>678.504169</td><td>677.975867</td><td>6.285149</td></tr><tr><td>2025-12-30</td><td>683.378357</td><td>57.60896</td><td>678.939069</td><td>678.49039</td><td>5.976889</td></tr><tr><td>2025-12-31</td><td>678.315247</td><td>51.533485</td><td>679.058331</td><td>678.47371</td><td>5.951404</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 6)\n",
-       "┌────────────┬────────────┬──────────┬────────────┬───────────┬────────────┐\n",
-       "│ timestamp  ┆ close      ┆ atr      ┆ ema        ┆ rsi       ┆ sma        │\n",
-       "│ ---        ┆ ---        ┆ ---      ┆ ---        ┆ ---       ┆ ---        │\n",
-       "│ date       ┆ f64        ┆ f64      ┆ f64        ┆ f64       ┆ f64        │\n",
-       "╞════════════╪════════════╪══════════╪════════════╪═══════════╪════════════╡\n",
-       "│ 2025-12-24 ┆ 688.499695 ┆ 6.774438 ┆ 678.078296 ┆ 61.844868 ┆ 679.29946  │\n",
-       "│ 2025-12-26 ┆ 688.429871 ┆ 6.460795 ┆ 679.06416  ┆ 61.758785 ┆ 679.929361 │\n",
-       "│ 2025-12-29 ┆ 685.976562 ┆ 6.301341 ┆ 679.722484 ┆ 58.668815 ┆ 680.252148 │\n",
-       "│ 2025-12-30 ┆ 685.138916 ┆ 5.992287 ┆ 680.238335 ┆ 57.608979 ┆ 680.688171 │\n",
-       "│ 2025-12-31 ┆ 680.062744 ┆ 5.966736 ┆ 680.221612 ┆ 51.533487 ┆ 680.807739 │\n",
-       "└────────────┴────────────┴──────────┴────────────┴───────────┴────────────┘"
+       "┌────────────┬────────────┬───────────┬────────────┬────────────┬──────────┐\n",
+       "│ timestamp  ┆ close      ┆ rsi       ┆ sma        ┆ ema        ┆ atr      │\n",
+       "│ ---        ┆ ---        ┆ ---       ┆ ---        ┆ ---        ┆ ---      │\n",
+       "│ date       ┆ f64        ┆ f64       ┆ f64        ┆ f64        ┆ f64      │\n",
+       "╞════════════╪════════════╪═══════════╪════════════╪════════════╪══════════╡\n",
+       "│ 2025-12-24 ┆ 686.73053  ┆ 61.844894 ┆ 677.553928 ┆ 676.335904 ┆ 6.757029 │\n",
+       "│ 2025-12-26 ┆ 686.660889 ┆ 61.758815 ┆ 678.182211 ┆ 677.319236 ┆ 6.444192 │\n",
+       "│ 2025-12-29 ┆ 684.213867 ┆ 58.668818 ┆ 678.504169 ┆ 677.975867 ┆ 6.285149 │\n",
+       "│ 2025-12-30 ┆ 683.378357 ┆ 57.60896  ┆ 678.939069 ┆ 678.49039  ┆ 5.976889 │\n",
+       "│ 2025-12-31 ┆ 678.315247 ┆ 51.533485 ┆ 679.058331 ┆ 678.47371  ┆ 5.951404 │\n",
+       "└────────────┴────────────┴───────────┴────────────┴────────────┴──────────┘"
       ]
      },
      "metadata": {},
@@ -525,10 +516,10 @@
    "id": "40961587",
    "metadata": {
     "papermill": {
-     "duration": 0.002636,
-     "end_time": "2026-07-19T22:28:05.011005+00:00",
+     "duration": 0.001583,
+     "end_time": "2026-08-10T13:05:38.465788+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.008369+00:00",
+     "start_time": "2026-08-10T13:05:38.464205+00:00",
      "status": "completed"
     }
    },
@@ -548,16 +539,16 @@
    "id": "da0b2b41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:05.018962Z",
-     "iopub.status.busy": "2026-07-19T22:28:05.018684Z",
-     "iopub.status.idle": "2026-07-19T22:28:05.028459Z",
-     "shell.execute_reply": "2026-07-19T22:28:05.027620Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.469541Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.469423Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.476438Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.475950Z"
     },
     "papermill": {
-     "duration": 0.015718,
-     "end_time": "2026-07-19T22:28:05.029364+00:00",
+     "duration": 0.009455,
+     "end_time": "2026-08-10T13:05:38.476669+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.013646+00:00",
+     "start_time": "2026-08-10T13:05:38.467214+00:00",
      "status": "completed"
     }
    },
@@ -566,16 +557,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Parameterized features (3 columns): atr, bollinger_bands, rsi\n"
+      "Parameterized features (3 columns): rsi, atr, bollinger_bands\n"
      ]
     }
    ],
    "source": [
-    "# Distinct features, each with an explicit (non-default) parameter set:\n",
+    "# Distinct features, each with an explicit parameter set. Bollinger bands take the\n",
+    "# two deviations separately, following TA-Lib, so the upper and lower band need not\n",
+    "# sit the same distance from the moving average:\n",
     "parameterized = [\n",
     "    {\"name\": \"rsi\", \"params\": {\"period\": 10}},\n",
     "    {\"name\": \"atr\", \"params\": {\"period\": 20}},\n",
-    "    {\"name\": \"bollinger_bands\", \"params\": {\"period\": 20, \"std_dev\": 2.0}},\n",
+    "    {\"name\": \"bollinger_bands\", \"params\": {\"period\": 20, \"nbdevup\": 2.0, \"nbdevdn\": 2.0}},\n",
     "]\n",
     "\n",
     "result = compute_features(spy, parameterized)\n",
@@ -590,16 +583,16 @@
    "id": "2138f537",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:05.036724Z",
-     "iopub.status.busy": "2026-07-19T22:28:05.036630Z",
-     "iopub.status.idle": "2026-07-19T22:28:05.050091Z",
-     "shell.execute_reply": "2026-07-19T22:28:05.049266Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.480588Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.480460Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.493204Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.492792Z"
     },
     "papermill": {
-     "duration": 0.017655,
-     "end_time": "2026-07-19T22:28:05.050985+00:00",
+     "duration": 0.01526,
+     "end_time": "2026-08-10T13:05:38.493551+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.033330+00:00",
+     "start_time": "2026-08-10T13:05:38.478291+00:00",
      "status": "completed"
     }
    },
@@ -621,7 +614,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>rsi_10</th><th>rsi_21</th><th>rsi_63</th></tr><tr><td>date</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-24</td><td>64.91459</td><td>59.481274</td><td>57.801041</td></tr><tr><td>2025-12-26</td><td>64.78233</td><td>59.427998</td><td>57.784295</td></tr><tr><td>2025-12-29</td><td>60.009157</td><td>57.527087</td><td>57.19273</td></tr><tr><td>2025-12-30</td><td>58.377377</td><td>56.874874</td><td>56.99031</td></tr><tr><td>2025-12-31</td><td>49.342926</td><td>53.047947</td><td>55.774759</td></tr></tbody></table></div>"
+       "<small>shape: (5, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>rsi_10</th><th>rsi_21</th><th>rsi_63</th></tr><tr><td>date</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-24</td><td>64.91462</td><td>59.481294</td><td>57.801049</td></tr><tr><td>2025-12-26</td><td>64.782367</td><td>59.42802</td><td>57.784304</td></tr><tr><td>2025-12-29</td><td>60.009153</td><td>57.527092</td><td>57.192733</td></tr><tr><td>2025-12-30</td><td>58.377341</td><td>56.874866</td><td>56.99031</td></tr><tr><td>2025-12-31</td><td>49.34292</td><td>53.047949</td><td>55.774763</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 4)\n",
@@ -630,11 +623,11 @@
        "│ ---        ┆ ---       ┆ ---       ┆ ---       │\n",
        "│ date       ┆ f64       ┆ f64       ┆ f64       │\n",
        "╞════════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ 2025-12-24 ┆ 64.91459  ┆ 59.481274 ┆ 57.801041 │\n",
-       "│ 2025-12-26 ┆ 64.78233  ┆ 59.427998 ┆ 57.784295 │\n",
-       "│ 2025-12-29 ┆ 60.009157 ┆ 57.527087 ┆ 57.19273  │\n",
-       "│ 2025-12-30 ┆ 58.377377 ┆ 56.874874 ┆ 56.99031  │\n",
-       "│ 2025-12-31 ┆ 49.342926 ┆ 53.047947 ┆ 55.774759 │\n",
+       "│ 2025-12-24 ┆ 64.91462  ┆ 59.481294 ┆ 57.801049 │\n",
+       "│ 2025-12-26 ┆ 64.782367 ┆ 59.42802  ┆ 57.784304 │\n",
+       "│ 2025-12-29 ┆ 60.009153 ┆ 57.527092 ┆ 57.192733 │\n",
+       "│ 2025-12-30 ┆ 58.377341 ┆ 56.874866 ┆ 56.99031  │\n",
+       "│ 2025-12-31 ┆ 49.34292  ┆ 53.047949 ┆ 55.774763 │\n",
        "└────────────┴───────────┴───────────┴───────────┘"
       ]
      },
@@ -662,10 +655,10 @@
    "id": "379f748c",
    "metadata": {
     "papermill": {
-     "duration": 0.004175,
-     "end_time": "2026-07-19T22:28:05.058527+00:00",
+     "duration": 0.001523,
+     "end_time": "2026-08-10T13:05:38.496864+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.054352+00:00",
+     "start_time": "2026-08-10T13:05:38.495341+00:00",
      "status": "completed"
     }
    },
@@ -701,10 +694,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00346,
-     "end_time": "2026-07-19T22:28:05.065598+00:00",
+     "duration": 0.001536,
+     "end_time": "2026-08-10T13:05:38.499885+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.062138+00:00",
+     "start_time": "2026-08-10T13:05:38.498349+00:00",
      "status": "completed"
     }
    },
@@ -722,16 +715,16 @@
    "id": "245c4a39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:05.075349Z",
-     "iopub.status.busy": "2026-07-19T22:28:05.075171Z",
-     "iopub.status.idle": "2026-07-19T22:28:05.098815Z",
-     "shell.execute_reply": "2026-07-19T22:28:05.098280Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.503997Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.503868Z",
+     "iopub.status.idle": "2026-08-10T13:05:38.515682Z",
+     "shell.execute_reply": "2026-08-10T13:05:38.515189Z"
     },
     "papermill": {
-     "duration": 0.029537,
-     "end_time": "2026-07-19T22:28:05.099646+00:00",
+     "duration": 0.014786,
+     "end_time": "2026-08-10T13:05:38.516161+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.070109+00:00",
+     "start_time": "2026-08-10T13:05:38.501375+00:00",
      "status": "completed"
     }
    },
@@ -753,7 +746,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (10, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>rsi_manual</th><th>rsi</th></tr><tr><td>date</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-17</td><td>32.116736</td><td>43.389717</td></tr><tr><td>2025-12-18</td><td>44.148938</td><td>48.679788</td></tr><tr><td>2025-12-19</td><td>55.223312</td><td>54.247795</td></tr><tr><td>2025-12-22</td><td>61.355666</td><td>57.677619</td></tr><tr><td>2025-12-23</td><td>65.392737</td><td>60.05802</td></tr><tr><td>2025-12-24</td><td>68.343047</td><td>61.844868</td></tr><tr><td>2025-12-26</td><td>68.149098</td><td>61.758785</td></tr><tr><td>2025-12-29</td><td>61.117531</td><td>58.668815</td></tr><tr><td>2025-12-30</td><td>58.730214</td><td>57.608979</td></tr><tr><td>2025-12-31</td><td>46.130607</td><td>51.533487</td></tr></tbody></table></div>"
+       "<small>shape: (10, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>rsi_manual</th><th>rsi</th></tr><tr><td>date</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2025-12-17</td><td>32.116707</td><td>43.389713</td></tr><tr><td>2025-12-18</td><td>44.148969</td><td>48.679809</td></tr><tr><td>2025-12-19</td><td>55.223321</td><td>54.247807</td></tr><tr><td>2025-12-22</td><td>61.355685</td><td>57.677637</td></tr><tr><td>2025-12-23</td><td>65.39272</td><td>60.058015</td></tr><tr><td>2025-12-24</td><td>68.343079</td><td>61.844894</td></tr><tr><td>2025-12-26</td><td>68.149141</td><td>61.758815</td></tr><tr><td>2025-12-29</td><td>61.117516</td><td>58.668818</td></tr><tr><td>2025-12-30</td><td>58.730154</td><td>57.60896</td></tr><tr><td>2025-12-31</td><td>46.130598</td><td>51.533485</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (10, 3)\n",
@@ -762,16 +755,16 @@
        "│ ---        ┆ ---        ┆ ---       │\n",
        "│ date       ┆ f64        ┆ f64       │\n",
        "╞════════════╪════════════╪═══════════╡\n",
-       "│ 2025-12-17 ┆ 32.116736  ┆ 43.389717 │\n",
-       "│ 2025-12-18 ┆ 44.148938  ┆ 48.679788 │\n",
-       "│ 2025-12-19 ┆ 55.223312  ┆ 54.247795 │\n",
-       "│ 2025-12-22 ┆ 61.355666  ┆ 57.677619 │\n",
-       "│ 2025-12-23 ┆ 65.392737  ┆ 60.05802  │\n",
-       "│ 2025-12-24 ┆ 68.343047  ┆ 61.844868 │\n",
-       "│ 2025-12-26 ┆ 68.149098  ┆ 61.758785 │\n",
-       "│ 2025-12-29 ┆ 61.117531  ┆ 58.668815 │\n",
-       "│ 2025-12-30 ┆ 58.730214  ┆ 57.608979 │\n",
-       "│ 2025-12-31 ┆ 46.130607  ┆ 51.533487 │\n",
+       "│ 2025-12-17 ┆ 32.116707  ┆ 43.389713 │\n",
+       "│ 2025-12-18 ┆ 44.148969  ┆ 48.679809 │\n",
+       "│ 2025-12-19 ┆ 55.223321  ┆ 54.247807 │\n",
+       "│ 2025-12-22 ┆ 61.355685  ┆ 57.677637 │\n",
+       "│ 2025-12-23 ┆ 65.39272   ┆ 60.058015 │\n",
+       "│ 2025-12-24 ┆ 68.343079  ┆ 61.844894 │\n",
+       "│ 2025-12-26 ┆ 68.149141  ┆ 61.758815 │\n",
+       "│ 2025-12-29 ┆ 61.117516  ┆ 58.668818 │\n",
+       "│ 2025-12-30 ┆ 58.730154  ┆ 57.60896  │\n",
+       "│ 2025-12-31 ┆ 46.130598  ┆ 51.533485 │\n",
        "└────────────┴────────────┴───────────┘"
       ]
      },
@@ -835,10 +828,10 @@
    "id": "3e7801b0",
    "metadata": {
     "papermill": {
-     "duration": 0.001521,
-     "end_time": "2026-07-19T22:28:05.102970+00:00",
+     "duration": 0.001759,
+     "end_time": "2026-08-10T13:05:38.520387+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.101449+00:00",
+     "start_time": "2026-08-10T13:05:38.518628+00:00",
      "status": "completed"
     }
    },
@@ -857,10 +850,10 @@
    "id": "bbfd82cf",
    "metadata": {
     "papermill": {
-     "duration": 0.001423,
-     "end_time": "2026-07-19T22:28:05.105872+00:00",
+     "duration": 0.001508,
+     "end_time": "2026-08-10T13:05:38.523428+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.104449+00:00",
+     "start_time": "2026-08-10T13:05:38.521920+00:00",
      "status": "completed"
     }
    },
@@ -882,16 +875,16 @@
    "id": "f19ca0d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:28:05.110105Z",
-     "iopub.status.busy": "2026-07-19T22:28:05.110014Z",
-     "iopub.status.idle": "2026-07-19T22:29:02.840857Z",
-     "shell.execute_reply": "2026-07-19T22:29:02.839716Z"
+     "iopub.execute_input": "2026-08-10T13:05:38.528034Z",
+     "iopub.status.busy": "2026-08-10T13:05:38.527924Z",
+     "iopub.status.idle": "2026-08-10T13:06:09.976037Z",
+     "shell.execute_reply": "2026-08-10T13:06:09.975421Z"
     },
     "papermill": {
-     "duration": 57.735865,
-     "end_time": "2026-07-19T22:29:02.843209+00:00",
+     "duration": 31.454058,
+     "end_time": "2026-08-10T13:06:09.979473+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:28:05.107344+00:00",
+     "start_time": "2026-08-10T13:05:38.525415+00:00",
      "status": "completed"
     }
    },
@@ -901,9 +894,9 @@
      "output_type": "stream",
      "text": [
       "Evaluated on 100 assets over 4,466 dates\n",
-      "   1D  IC=-0.0034  t-stat=-0.79  quantile spread=-0.0001\n",
-      "   5D  IC=-0.0056  t-stat=-1.30  quantile spread=-0.0003\n",
-      "  21D  IC=-0.0019  t-stat=-0.46  quantile spread=-0.0008\n"
+      "   1D  IC=-0.0041  t-stat=-0.94  quantile spread=-0.0001\n",
+      "   5D  IC=-0.0061  t-stat=-1.42  quantile spread=-0.0003\n",
+      "  21D  IC=-0.0033  t-stat=-0.79  quantile spread=-0.0009\n"
      ]
     }
    ],
@@ -943,10 +936,10 @@
    "id": "1f474234",
    "metadata": {
     "papermill": {
-     "duration": 0.001609,
-     "end_time": "2026-07-19T22:29:02.847010+00:00",
+     "duration": 0.002959,
+     "end_time": "2026-08-10T13:06:09.985530+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.845401+00:00",
+     "start_time": "2026-08-10T13:06:09.982571+00:00",
      "status": "completed"
     }
    },
@@ -965,10 +958,10 @@
    "id": "546beae7",
    "metadata": {
     "papermill": {
-     "duration": 0.001464,
-     "end_time": "2026-07-19T22:29:02.849982+00:00",
+     "duration": 0.001631,
+     "end_time": "2026-08-10T13:06:09.990091+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.848518+00:00",
+     "start_time": "2026-08-10T13:06:09.988460+00:00",
      "status": "completed"
     }
    },
@@ -985,10 +978,10 @@
    "id": "8bae8371",
    "metadata": {
     "papermill": {
-     "duration": 0.00146,
-     "end_time": "2026-07-19T22:29:02.852941+00:00",
+     "duration": 0.001641,
+     "end_time": "2026-08-10T13:06:09.993326+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.851481+00:00",
+     "start_time": "2026-08-10T13:06:09.991685+00:00",
      "status": "completed"
     }
    },
@@ -1005,16 +998,16 @@
    "id": "5ea00e0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:29:02.856492Z",
-     "iopub.status.busy": "2026-07-19T22:29:02.856415Z",
-     "iopub.status.idle": "2026-07-19T22:29:02.862448Z",
-     "shell.execute_reply": "2026-07-19T22:29:02.862052Z"
+     "iopub.execute_input": "2026-08-10T13:06:09.997728Z",
+     "iopub.status.busy": "2026-08-10T13:06:09.997589Z",
+     "iopub.status.idle": "2026-08-10T13:06:10.005314Z",
+     "shell.execute_reply": "2026-08-10T13:06:10.004886Z"
     },
     "papermill": {
-     "duration": 0.008392,
-     "end_time": "2026-07-19T22:29:02.862796+00:00",
+     "duration": 0.010608,
+     "end_time": "2026-08-10T13:06:10.005625+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.854404+00:00",
+     "start_time": "2026-08-10T13:06:09.995017+00:00",
      "status": "completed"
     }
    },
@@ -1036,7 +1029,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (10, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>symbol</th><th>timestamp</th><th>close</th><th>ret_1d</th><th>vol_21d</th></tr><tr><td>str</td><td>date</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;SPY&quot;</td><td>2025-12-17</td><td>667.598694</td><td>-0.011004</td><td>0.119933</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-18</td><td>672.639954</td><td>0.007551</td><td>0.11784</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-19</td><td>678.736389</td><td>0.009063</td><td>0.120667</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-22</td><td>682.964844</td><td>0.00623</td><td>0.10519</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-23</td><td>686.086304</td><td>0.00457</td><td>0.101958</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-24</td><td>688.499695</td><td>0.003518</td><td>0.091486</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-26</td><td>688.429871</td><td>-0.000101</td><td>0.08719</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-29</td><td>685.976562</td><td>-0.003564</td><td>0.08613</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-30</td><td>685.138916</td><td>-0.001221</td><td>0.084598</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-31</td><td>680.062744</td><td>-0.007409</td><td>0.087235</td></tr></tbody></table></div>"
+       "<small>shape: (10, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>symbol</th><th>timestamp</th><th>close</th><th>ret_1d</th><th>vol_21d</th></tr><tr><td>str</td><td>date</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;SPY&quot;</td><td>2025-12-17</td><td>665.88324</td><td>-0.011004</td><td>0.119933</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-18</td><td>670.91156</td><td>0.007551</td><td>0.11784</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-19</td><td>676.99231</td><td>0.009063</td><td>0.120667</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-22</td><td>681.2099</td><td>0.00623</td><td>0.10519</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-23</td><td>684.323303</td><td>0.00457</td><td>0.101958</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-24</td><td>686.73053</td><td>0.003518</td><td>0.091486</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-26</td><td>686.660889</td><td>-0.000101</td><td>0.08719</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-29</td><td>684.213867</td><td>-0.003564</td><td>0.08613</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-30</td><td>683.378357</td><td>-0.001221</td><td>0.084598</td></tr><tr><td>&quot;SPY&quot;</td><td>2025-12-31</td><td>678.315247</td><td>-0.007409</td><td>0.087235</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (10, 5)\n",
@@ -1045,16 +1038,16 @@
        "│ ---    ┆ ---        ┆ ---        ┆ ---       ┆ ---      │\n",
        "│ str    ┆ date       ┆ f64        ┆ f64       ┆ f64      │\n",
        "╞════════╪════════════╪════════════╪═══════════╪══════════╡\n",
-       "│ SPY    ┆ 2025-12-17 ┆ 667.598694 ┆ -0.011004 ┆ 0.119933 │\n",
-       "│ SPY    ┆ 2025-12-18 ┆ 672.639954 ┆ 0.007551  ┆ 0.11784  │\n",
-       "│ SPY    ┆ 2025-12-19 ┆ 678.736389 ┆ 0.009063  ┆ 0.120667 │\n",
-       "│ SPY    ┆ 2025-12-22 ┆ 682.964844 ┆ 0.00623   ┆ 0.10519  │\n",
-       "│ SPY    ┆ 2025-12-23 ┆ 686.086304 ┆ 0.00457   ┆ 0.101958 │\n",
-       "│ SPY    ┆ 2025-12-24 ┆ 688.499695 ┆ 0.003518  ┆ 0.091486 │\n",
-       "│ SPY    ┆ 2025-12-26 ┆ 688.429871 ┆ -0.000101 ┆ 0.08719  │\n",
-       "│ SPY    ┆ 2025-12-29 ┆ 685.976562 ┆ -0.003564 ┆ 0.08613  │\n",
-       "│ SPY    ┆ 2025-12-30 ┆ 685.138916 ┆ -0.001221 ┆ 0.084598 │\n",
-       "│ SPY    ┆ 2025-12-31 ┆ 680.062744 ┆ -0.007409 ┆ 0.087235 │\n",
+       "│ SPY    ┆ 2025-12-17 ┆ 665.88324  ┆ -0.011004 ┆ 0.119933 │\n",
+       "│ SPY    ┆ 2025-12-18 ┆ 670.91156  ┆ 0.007551  ┆ 0.11784  │\n",
+       "│ SPY    ┆ 2025-12-19 ┆ 676.99231  ┆ 0.009063  ┆ 0.120667 │\n",
+       "│ SPY    ┆ 2025-12-22 ┆ 681.2099   ┆ 0.00623   ┆ 0.10519  │\n",
+       "│ SPY    ┆ 2025-12-23 ┆ 684.323303 ┆ 0.00457   ┆ 0.101958 │\n",
+       "│ SPY    ┆ 2025-12-24 ┆ 686.73053  ┆ 0.003518  ┆ 0.091486 │\n",
+       "│ SPY    ┆ 2025-12-26 ┆ 686.660889 ┆ -0.000101 ┆ 0.08719  │\n",
+       "│ SPY    ┆ 2025-12-29 ┆ 684.213867 ┆ -0.003564 ┆ 0.08613  │\n",
+       "│ SPY    ┆ 2025-12-30 ┆ 683.378357 ┆ -0.001221 ┆ 0.084598 │\n",
+       "│ SPY    ┆ 2025-12-31 ┆ 678.315247 ┆ -0.007409 ┆ 0.087235 │\n",
        "└────────┴────────────┴────────────┴───────────┴──────────┘"
       ]
      },
@@ -1082,10 +1075,10 @@
    "id": "310078a8",
    "metadata": {
     "papermill": {
-     "duration": 0.001551,
-     "end_time": "2026-07-19T22:29:02.865973+00:00",
+     "duration": 0.001927,
+     "end_time": "2026-08-10T13:06:10.009384+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.864422+00:00",
+     "start_time": "2026-08-10T13:06:10.007457+00:00",
      "status": "completed"
     }
    },
@@ -1099,10 +1092,10 @@
    "id": "43001242",
    "metadata": {
     "papermill": {
-     "duration": 0.001519,
-     "end_time": "2026-07-19T22:29:02.869049+00:00",
+     "duration": 0.001709,
+     "end_time": "2026-08-10T13:06:10.012754+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.867530+00:00",
+     "start_time": "2026-08-10T13:06:10.011045+00:00",
      "status": "completed"
     }
    },
@@ -1121,16 +1114,16 @@
    "id": "da0e4ee3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:29:02.872610Z",
-     "iopub.status.busy": "2026-07-19T22:29:02.872544Z",
-     "iopub.status.idle": "2026-07-19T22:29:02.876906Z",
-     "shell.execute_reply": "2026-07-19T22:29:02.876480Z"
+     "iopub.execute_input": "2026-08-10T13:06:10.017257Z",
+     "iopub.status.busy": "2026-08-10T13:06:10.017141Z",
+     "iopub.status.idle": "2026-08-10T13:06:10.021594Z",
+     "shell.execute_reply": "2026-08-10T13:06:10.021231Z"
     },
     "papermill": {
-     "duration": 0.006574,
-     "end_time": "2026-07-19T22:29:02.877168+00:00",
+     "duration": 0.007468,
+     "end_time": "2026-08-10T13:06:10.022056+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.870594+00:00",
+     "start_time": "2026-08-10T13:06:10.014588+00:00",
      "status": "completed"
     }
    },
@@ -1152,7 +1145,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>trade_price</th><th>quote_price</th></tr><tr><td>date</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2015-01-02</td><td>170.125</td><td>170.125</td></tr><tr><td>2015-01-05</td><td>167.052643</td><td>167.052643</td></tr><tr><td>2015-01-06</td><td>165.479126</td><td>165.479126</td></tr><tr><td>2015-01-07</td><td>167.541199</td><td>167.541199</td></tr><tr><td>2015-01-08</td><td>170.514221</td><td>170.514221</td></tr></tbody></table></div>"
+       "<small>shape: (5, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>timestamp</th><th>trade_price</th><th>quote_price</th></tr><tr><td>date</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2015-01-02</td><td>169.687897</td><td>169.687897</td></tr><tr><td>2015-01-05</td><td>166.623337</td><td>166.623337</td></tr><tr><td>2015-01-06</td><td>165.053955</td><td>165.053955</td></tr><tr><td>2015-01-07</td><td>167.110687</td><td>167.110687</td></tr><tr><td>2015-01-08</td><td>170.07608</td><td>170.07608</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 3)\n",
@@ -1161,11 +1154,11 @@
        "│ ---        ┆ ---         ┆ ---         │\n",
        "│ date       ┆ f64         ┆ f64         │\n",
        "╞════════════╪═════════════╪═════════════╡\n",
-       "│ 2015-01-02 ┆ 170.125     ┆ 170.125     │\n",
-       "│ 2015-01-05 ┆ 167.052643  ┆ 167.052643  │\n",
-       "│ 2015-01-06 ┆ 165.479126  ┆ 165.479126  │\n",
-       "│ 2015-01-07 ┆ 167.541199  ┆ 167.541199  │\n",
-       "│ 2015-01-08 ┆ 170.514221  ┆ 170.514221  │\n",
+       "│ 2015-01-02 ┆ 169.687897  ┆ 169.687897  │\n",
+       "│ 2015-01-05 ┆ 166.623337  ┆ 166.623337  │\n",
+       "│ 2015-01-06 ┆ 165.053955  ┆ 165.053955  │\n",
+       "│ 2015-01-07 ┆ 167.110687  ┆ 167.110687  │\n",
+       "│ 2015-01-08 ┆ 170.07608   ┆ 170.07608   │\n",
        "└────────────┴─────────────┴─────────────┘"
       ]
      },
@@ -1198,10 +1191,10 @@
    "id": "b7cc0b9c",
    "metadata": {
     "papermill": {
-     "duration": 0.001628,
-     "end_time": "2026-07-19T22:29:02.880437+00:00",
+     "duration": 0.001706,
+     "end_time": "2026-08-10T13:06:10.025767+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.878809+00:00",
+     "start_time": "2026-08-10T13:06:10.024061+00:00",
      "status": "completed"
     }
    },
@@ -1215,10 +1208,10 @@
    "id": "cd84f50a",
    "metadata": {
     "papermill": {
-     "duration": 0.001576,
-     "end_time": "2026-07-19T22:29:02.883688+00:00",
+     "duration": 0.00184,
+     "end_time": "2026-08-10T13:06:10.029305+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.882112+00:00",
+     "start_time": "2026-08-10T13:06:10.027465+00:00",
      "status": "completed"
     }
    },
@@ -1236,16 +1229,16 @@
    "id": "a17ef9fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T22:29:02.887458Z",
-     "iopub.status.busy": "2026-07-19T22:29:02.887344Z",
-     "iopub.status.idle": "2026-07-19T22:29:02.894890Z",
-     "shell.execute_reply": "2026-07-19T22:29:02.894444Z"
+     "iopub.execute_input": "2026-08-10T13:06:10.033961Z",
+     "iopub.status.busy": "2026-08-10T13:06:10.033858Z",
+     "iopub.status.idle": "2026-08-10T13:06:10.043042Z",
+     "shell.execute_reply": "2026-08-10T13:06:10.042501Z"
     },
     "papermill": {
-     "duration": 0.009895,
-     "end_time": "2026-07-19T22:29:02.895181+00:00",
+     "duration": 0.012291,
+     "end_time": "2026-08-10T13:06:10.043591+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.885286+00:00",
+     "start_time": "2026-08-10T13:06:10.031300+00:00",
      "status": "completed"
     }
    },
@@ -1283,10 +1276,10 @@
    "id": "91d41571",
    "metadata": {
     "papermill": {
-     "duration": 0.001612,
-     "end_time": "2026-07-19T22:29:02.898533+00:00",
+     "duration": 0.003059,
+     "end_time": "2026-08-10T13:06:10.050016+00:00",
      "exception": false,
-     "start_time": "2026-07-19T22:29:02.896921+00:00",
+     "start_time": "2026-08-10T13:06:10.046957+00:00",
      "status": "completed"
     }
    },
@@ -1327,25 +1320,24 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "source_py_blob": "042ea8910db7421c122a3883b5cbb2ad784feb28",
+   "executed_at": "2026-08-10T13:08:25.538042+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
+  },
   "papermill": {
    "default_parameters": {},
-   "duration": 61.733593,
-   "end_time": "2026-07-19T22:29:04.018437+00:00",
+   "duration": 37.142894,
+   "end_time": "2026-08-10T13:06:12.548684+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "07_defining_the_learning_task/10_ml4t_library_ecosystem.ipynb",
    "output_path": "07_defining_the_learning_task/10_ml4t_library_ecosystem.ipynb",
    "parameters": {},
-   "start_time": "2026-07-19T22:28:02.284844+00:00",
+   "start_time": "2026-08-10T13:05:35.405790+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "78432a6385968d8da082a0d4cd5907ed81aa5598",
-   "executed_at": "2026-07-19T22:31:52.512959+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {},
-   "notes": "de-em-dash pass (prose+figure titles+print output); numbers byte-identical to prior run"
   }
  },
  "nbformat": 4,

--- a/07_defining_the_learning_task/10_ml4t_library_ecosystem.py
+++ b/07_defining_the_learning_task/10_ml4t_library_ecosystem.py
@@ -166,11 +166,13 @@ display(result.select(["timestamp", "close"] + new_cols).tail(5))
 # and suffix the columns before joining.
 
 # %%
-# Distinct features, each with an explicit (non-default) parameter set:
+# Distinct features, each with an explicit parameter set. Bollinger bands take the
+# two deviations separately, following TA-Lib, so the upper and lower band need not
+# sit the same distance from the moving average:
 parameterized = [
     {"name": "rsi", "params": {"period": 10}},
     {"name": "atr", "params": {"period": 20}},
-    {"name": "bollinger_bands", "params": {"period": 20, "std_dev": 2.0}},
+    {"name": "bollinger_bands", "params": {"period": 20, "nbdevup": 2.0, "nbdevdn": 2.0}},
 ]
 
 result = compute_features(spy, parameterized)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ml4t"
 version = "3.0.0"
 description = "Machine Learning for Algorithmic Trading — 3rd Edition"
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.14,<3.15"
 license = "MIT"
 authors = [{ name = "Stefan Jansen" }]
 
@@ -48,14 +48,15 @@ dependencies = [
     "gymnasium>=1.2",
     "stable-baselines3>=2.7",
     # ===================
-    # ML4T Libraries (PyPI, pre-release)
+    # ML4T Libraries (PyPI)
     # ===================
-    # b19: the missing-data errors name the download command a reader can run and
-    # the path the data root resolved from, instead of a Python API call.
-    "ml4t-data>=0.1.0b19",
-    "ml4t-diagnostic>=0.1.0b25",
-    "ml4t-engineer>=0.1.0b10",
-    "ml4t-backtest>=0.1.0b20",
+    # ml4t-live is the only one still pre-release; the rest are on stable releases.
+    # ml4t-data 0.1.0: the missing-data errors name the download command a reader can
+    # run and the path the data root resolved from, instead of a Python API call.
+    "ml4t-data>=0.1.0",
+    "ml4t-diagnostic>=0.1.0",
+    "ml4t-engineer>=0.1.2",
+    "ml4t-backtest>=0.1.1",
     "ml4t-live>=0.1.0b3",
     # ===================
     # Deep Learning
@@ -182,7 +183,7 @@ dependencies = [
     "llama-index-embeddings-huggingface>=0.7.0",
     "chromadb>=1.5.5",
     "pfhedge>=0.22.0",
-    "ml4t-models>=0.1.0b0",
+    "ml4t-models>=0.1.0",
     "llama-index-vector-stores-chroma>=0.5.5",
     "llama-index-llms-openai>=0.7.7",
     # Ch24 Autonomous Agents (required at notebook runtime; Docker installs
@@ -248,9 +249,9 @@ dev = [
 ]
 
 [tool.uv]
-# ml4t-engineer only has pre-release versions on PyPI. Spelled "if-necessary" rather
-# than the deprecated "if-necessary-or-explicit", which makes uv print a deprecation
-# warning on every single `uv run` a reader types.
+# ml4t-live has only pre-release versions on PyPI; every other ml4t-* is on a stable
+# release. Spelled "if-necessary" rather than the deprecated "if-necessary-or-explicit",
+# which makes uv print a deprecation warning on every single `uv run` a reader types.
 prerelease = "if-necessary"
 
 # Download CPython rather than reusing whatever the machine already has. uv reuses

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
-]
+requires-python = "==3.14.*"
 
 [options]
 prerelease-mode = "if-necessary"
@@ -2383,26 +2379,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
-    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
-    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
-    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
-    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
-    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
-    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
-    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
-    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
-    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -2625,19 +2601,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
-]
-
-[[package]]
-name = "html5lib"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -4367,12 +4330,12 @@ requires-dist = [
     { name = "llama-index-llms-openai", specifier = ">=0.7.7" },
     { name = "llama-index-vector-stores-chroma", specifier = ">=0.5.5" },
     { name = "matplotlib", specifier = ">=3.8" },
-    { name = "ml4t-backtest", specifier = ">=0.1.0b20" },
-    { name = "ml4t-data", specifier = ">=0.1.0b19" },
-    { name = "ml4t-diagnostic", specifier = ">=0.1.0b25" },
-    { name = "ml4t-engineer", specifier = ">=0.1.0b10" },
+    { name = "ml4t-backtest", specifier = ">=0.1.1" },
+    { name = "ml4t-data", specifier = ">=0.1.0" },
+    { name = "ml4t-diagnostic", specifier = ">=0.1.0" },
+    { name = "ml4t-engineer", specifier = ">=0.1.2" },
     { name = "ml4t-live", specifier = ">=0.1.0b3" },
-    { name = "ml4t-models", specifier = ">=0.1.0b0" },
+    { name = "ml4t-models", specifier = ">=0.1.0" },
     { name = "mlflow", specifier = ">=3.10.1" },
     { name = "mlflow", marker = "extra == 'mlops'", specifier = ">=2.16" },
     { name = "nbconvert", specifier = ">=7.16" },
@@ -4452,7 +4415,7 @@ dev = [{ name = "httpx", specifier = ">=0.28.1" }]
 
 [[package]]
 name = "ml4t-backtest"
-version = "0.1.0b20"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml4t-specs" },
@@ -4460,33 +4423,30 @@ dependencies = [
     { name = "pandas" },
     { name = "pandas-market-calendars" },
     { name = "polars" },
-    { name = "pyarrow" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/76/f4cb5d2feabd0e264866de5467123096bb88b7a6db20faffba89313fcc1f/ml4t_backtest-0.1.0b20.tar.gz", hash = "sha256:e421f8ac1c0fffbd3fc5bdb9ff46d54250a48415d2669c970ba37ee140a4976e", size = 315436, upload-time = "2026-05-17T18:49:24.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e7/e7fd9b2b5655f36f6b030b6f194a6d332cf88ae120a6c064faf12f547a80/ml4t_backtest-0.1.1.tar.gz", hash = "sha256:73774a51caa87db1aa8cb9e77777a13bc2a844460b32754fd40d42e75ba4bf3a", size = 446031, upload-time = "2026-08-10T01:27:59.617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/92/721fe85283995b69dac2569729ac98b13977041101a0dd525652f81a9c90/ml4t_backtest-0.1.0b20-py3-none-any.whl", hash = "sha256:2f00165a11fd2b5e2f4cca0a686a1b9fff98668eba25c7322171f53fb364384f", size = 179103, upload-time = "2026-05-17T18:49:22.794Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/95defe7e62d72b2e23d7da9cff0813699592a2d6976177814b0ab2059452/ml4t_backtest-0.1.1-py3-none-any.whl", hash = "sha256:94891ea800c93a6ded6c12461cc0ac21187f0e0c403bd4b9062cceda6f5fd1f9", size = 222163, upload-time = "2026-08-10T01:27:57.737Z" },
 ]
 
 [[package]]
 name = "ml4t-data"
-version = "0.1.0b19"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "click" },
     { name = "filelock" },
-    { name = "html5lib" },
     { name = "httpx" },
-    { name = "lxml" },
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pandas-market-calendars" },
     { name = "platformdirs" },
     { name = "polars" },
-    { name = "pyarrow" },
     { name = "pybreaker" },
+    { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -4494,22 +4454,19 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/08/0216821194a2ed4669c2c2f05b54dc85eaac1f614ca5331cd0779d8dea04/ml4t_data-0.1.0b19.tar.gz", hash = "sha256:b16b8982aaa035ad3dceaf3a2a3568b1f9b4b7a6bbf626c1031c777eef220486", size = 683844, upload-time = "2026-07-31T22:02:38.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a8/a67b6a46c776b33e210cfbe7e2c1882d2debdd85f3a4549c5e99b84b11b2/ml4t_data-0.1.0.tar.gz", hash = "sha256:5cc514da6aec248208b2c2916124d2504cc006d321c193b14330d814de76eb99", size = 762911, upload-time = "2026-08-09T13:20:36.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/72/7dd67501914af614fea25bbaa5d58dd38d61a3aa4db48dabe47f943c91ff/ml4t_data-0.1.0b19-py3-none-any.whl", hash = "sha256:3af2cccade45f7d7799afa36b8b58285c8e90d24beb9c280c13c4e3fac7efa13", size = 448648, upload-time = "2026-07-31T22:02:36.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3c/a842989f053dfe20a3d8f2273e8f3893be9bd4ea1937c9794a6f27d84968/ml4t_data-0.1.0-py3-none-any.whl", hash = "sha256:090e49820fbf72878cedbd00b03be6f035f8a731bf73d5bfbed680c6f454a283", size = 485529, upload-time = "2026-08-09T13:20:35.218Z" },
 ]
 
 [[package]]
 name = "ml4t-diagnostic"
-version = "0.1.0b25"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arch" },
     { name = "jinja2" },
     { name = "joblib" },
-    { name = "ml4t-engineer" },
-    { name = "ml4t-specs" },
-    { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pandas-market-calendars" },
@@ -4519,21 +4476,19 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "shap" },
     { name = "statsmodels" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/17/3aaa0b955dc5358e3c4b0fb0eed8c7c8f2bcfcb67ca16df4c695f183b423/ml4t_diagnostic-0.1.0b25.tar.gz", hash = "sha256:6e3c12fd51e67be1841d213bf7e30555bf9f0be284a2f1b129602e15169914f9", size = 1388197, upload-time = "2026-07-23T02:07:15.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/4f/d7b8593465f9c7626176966f54214773272e30a3434313c7a5262fcc147e/ml4t_diagnostic-0.1.0.tar.gz", hash = "sha256:4af7a447bdc926164df86a8c41a8175aab5d81bc33f814c7882fa33b97594989", size = 6756389, upload-time = "2026-08-08T09:43:58.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/3f/0cc42bdab3d97ece8727234c24356397906600a721281560e4600b94a22a/ml4t_diagnostic-0.1.0b25-py3-none-any.whl", hash = "sha256:ffb284a15f7f7ff48a16eaf07d18269e0ffa3f749aadb2ba34c7e58f12bdc8a0", size = 941470, upload-time = "2026-07-23T02:07:13.558Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b0/4576b1daf034dc9ad0fdcbe97d7e4fd8fecd2f2e7a212460766c29d412df/ml4t_diagnostic-0.1.0-py3-none-any.whl", hash = "sha256:640e0eb74a62aca6ba4faaa43b041aa847b1f66f38036f9512180d9045cc642c", size = 942159, upload-time = "2026-08-08T09:43:55.988Z" },
 ]
 
 [[package]]
 name = "ml4t-engineer"
-version = "0.1.0b10"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib" },
     { name = "ml4t-specs" },
     { name = "numba" },
     { name = "numpy" },
@@ -4548,9 +4503,9 @@ dependencies = [
     { name = "statsmodels" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/06/a237d311f95fc5814c388e41dbe8f2a12e65f088e93f96745b65a5e8b2f1/ml4t_engineer-0.1.0b10.tar.gz", hash = "sha256:0265225e1dc4200b8a837c692b758fe86ff06d1d4539647e74f599574c529c58", size = 544606, upload-time = "2026-07-20T13:15:09.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/78/0d3eaf446ad6940be19fedaaae54049c398dbfe266306c5546973207e27c/ml4t_engineer-0.1.2.tar.gz", hash = "sha256:8063bcc71377c1e28c9b207a78b493e340b411b8b3e90eea182af663e322d021", size = 608867, upload-time = "2026-08-10T03:05:22.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/ac113185f6c8224f6d091b36f8a72342cc00ae1c158ba00448bbb50c0401/ml4t_engineer-0.1.0b10-py3-none-any.whl", hash = "sha256:6e19e5b6412c6914db0c93fc98f19f834c5ee013027f620727e03e3839cd06a1", size = 365611, upload-time = "2026-07-20T13:15:07.576Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/02/9c59efb9133338d8d3a1e4b6e89d407a48e15a587af9a592d63651e0dfa8/ml4t_engineer-0.1.2-py3-none-any.whl", hash = "sha256:6e5a30c9552edc7224fb12344169d689081fea3937bad6a9a794c3221fbf70c0", size = 386726, upload-time = "2026-08-10T03:05:20.562Z" },
 ]
 
 [[package]]
@@ -4571,26 +4526,26 @@ wheels = [
 
 [[package]]
 name = "ml4t-models"
-version = "0.1.0b0"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/9b/ec8265362880b0514b6d78069812daf6123e42b744c758a5b4d6b44f09eb/ml4t_models-0.1.0b0.tar.gz", hash = "sha256:621f13436c25500a7799a3a5814e1a2763f218f3f65ff14f108772c95ad47b33", size = 66541, upload-time = "2026-07-23T01:57:18.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/82/dab69c1ecee14a54dd7f3d9058e31d10c7178031d7d8dc3b4f04ff832354/ml4t_models-0.1.0.tar.gz", hash = "sha256:ea98567cc58a7e1a86872ae088c4ae4096630d330199f9f563529b194f893305", size = 12989592, upload-time = "2026-08-09T13:48:51.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/b9/5d169af60f2d1fa3e919bdc7bd5f50cd39ea6113e698424fb1bb701c9920/ml4t_models-0.1.0b0-py3-none-any.whl", hash = "sha256:d94356d06b073ccab5d1ef4d619c8f6cbe6392c16916fb204f065b0a66324016", size = 79458, upload-time = "2026-07-23T01:57:16.35Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f4/55fe5268ad5e8849831e6e111b87f6b5f27ae2fa0590bea00aa37ecc1843/ml4t_models-0.1.0-py3-none-any.whl", hash = "sha256:ad804d0f7430b1ade3f5b78818e671aaba254ba7c8d3274643fcdda213ba05c5", size = 103527, upload-time = "2026-08-09T13:48:49.915Z" },
 ]
 
 [[package]]
 name = "ml4t-specs"
-version = "0.1.0b0"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/bb/35dfe733a7d7f57d426fcf38759acb70a8b56ff65e4e9ee60a4de30be397/ml4t_specs-0.1.0b0.tar.gz", hash = "sha256:2325a9a3ebf2f04ac369334dee14eec949d44b03d53a58ce8c7da598497c77e1", size = 5857, upload-time = "2026-04-02T03:14:18.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/6b/58aacbc7ccf9239edb5f3b350b418aff543f87698852e1507892c2ce8c26/ml4t_specs-0.1.2.tar.gz", hash = "sha256:72131624220bdded7d01d9c09e4c9e6637e8e977a37be283bc7f38d4fe0b1e1a", size = 50590, upload-time = "2026-08-10T00:53:01.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/1e/2d2ecb9ca0004731664569702e9dbc4779f50236408f94206329fd642a83/ml4t_specs-0.1.0b0-py3-none-any.whl", hash = "sha256:b45250fadd556f18181971e0dc88352eb235df0c56521eb63912e1c120ba0526", size = 6238, upload-time = "2026-04-02T03:14:17.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/1508cd131272885391fe17eb54865d8c2ee0a853d15bdd5cfd838b20ce44/ml4t_specs-0.1.2-py3-none-any.whl", hash = "sha256:c9e6749bc28c087f1a97494690edae94460aeffe2c223494a19c41c4915b9532", size = 33763, upload-time = "2026-08-10T00:53:00.474Z" },
 ]
 
 [[package]]
@@ -8711,7 +8666,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiolimiter" },
     { name = "langchain-text-splitters" },
-    { name = "numpy", marker = "python_full_version < '3.15'" },
+    { name = "numpy" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "requests" },
@@ -8766,17 +8721,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
     { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
     { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
-    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
-    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Every `ml4t-*` dependency except `ml4t-live` now has a stable release, and this repo was pinned to pre-releases of all of them.

| | from | to |
|---|---|---|
| `ml4t-data` | 0.1.0b19 | 0.1.0 |
| `ml4t-diagnostic` | 0.1.0b25 | 0.1.0 |
| `ml4t-backtest` | 0.1.0b20 | 0.1.1 |
| `ml4t-models` | 0.1.0b0 | 0.1.0 |
| `ml4t-engineer` | 0.1.0b10 | 0.1.2 (carrying `ml4t-specs` 0.1.0b0 -> 0.1.2) |
| `ml4t-live` | 0.1.0b3 | still pre-release only |

`requires-python` moves to `>=3.14,<3.15`. That is the true statement rather than a workaround: `ml4t-diagnostic` 0.1.0 and `ml4t-engineer` 0.1.2 both publish `requires-python "<3.15,>=3.12"`, so the book already cannot run on 3.15. Declaring `>=3.14` made uv resolve a 3.15 split in which two libraries are unsatisfiable.

## One notebook needed a source change

The stable `ml4t-engineer` follows TA-Lib and names the Bollinger deviations `nbdevup` and `nbdevdn`, so `07/10`'s `std_dev=2.0` is not a parameter the function has. Re-executed and re-stamped, 34 cells, no errors.

## Two notebooks stay broken until ml4t-data 0.1.1

Recorded rather than worked around. Both are in `ch02-03`, a job already red on `main`.

- `02/13_data_quality_framework` cell 12, `Expected a datetime scalar, received date`. An `ml4t-data` regression, fixed at `b7f073e`, unreleased.
- `02/18_data_management` cell 26, `ColumnNotFoundError: "period"`. The `HiveStorage` layout is no longer addressable from outside; the fix adds `HiveStorage.partitions()` at `7de163b`, unreleased.

Releasing 0.1.1 needs nine live provider-contract dispatches on the release commit, two of which are billed.