### PR TITLE
The eoa universe assertion took three notebooks red in CI, because it asserted about the wrong dataset

### DIFF
--- a/case_studies/sp500_equity_option_analytics/02_labels.ipynb
+++ b/case_studies/sp500_equity_option_analytics/02_labels.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3514bd8e",
+   "id": "99efb252",
    "metadata": {
     "papermill": {
-     "duration": 0.0076,
-     "end_time": "2026-08-10T19:15:53.947520+00:00",
+     "duration": 0.00186,
+     "end_time": "2026-08-10T20:01:57.119104+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:53.939920+00:00",
+     "start_time": "2026-08-10T20:01:57.117244+00:00",
      "status": "completed"
     }
    },
@@ -52,19 +52,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8e0ee7e1",
+   "id": "cf65a807",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:53.965941Z",
-     "iopub.status.busy": "2026-08-10T19:15:53.965638Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.370669Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.370107Z"
+     "iopub.execute_input": "2026-08-10T20:01:57.122734Z",
+     "iopub.status.busy": "2026-08-10T20:01:57.122628Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.141893Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.141324Z"
     },
     "papermill": {
-     "duration": 5.419337,
-     "end_time": "2026-08-10T19:15:59.371337+00:00",
+     "duration": 2.021752,
+     "end_time": "2026-08-10T20:01:59.142375+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:53.952000+00:00",
+     "start_time": "2026-08-10T20:01:57.120623+00:00",
      "status": "completed"
     }
    },
@@ -93,13 +93,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e18eba09",
+   "id": "b6ace9dc",
    "metadata": {
     "papermill": {
-     "duration": 0.001649,
-     "end_time": "2026-08-10T19:15:59.374971+00:00",
+     "duration": 0.001662,
+     "end_time": "2026-08-10T20:01:59.145614+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.373322+00:00",
+     "start_time": "2026-08-10T20:01:59.143952+00:00",
      "status": "completed"
     }
    },
@@ -113,19 +113,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "56eec4f1",
+   "id": "349a32b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.378894Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.378756Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.380861Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.380428Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.148893Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.148797Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.150656Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.150272Z"
     },
     "papermill": {
-     "duration": 0.004731,
-     "end_time": "2026-08-10T19:15:59.381248+00:00",
+     "duration": 0.004156,
+     "end_time": "2026-08-10T20:01:59.151103+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.376517+00:00",
+     "start_time": "2026-08-10T20:01:59.146947+00:00",
      "status": "completed"
     },
     "tags": [
@@ -140,13 +140,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f078f0e0",
+   "id": "3dfb09e3",
    "metadata": {
     "papermill": {
-     "duration": 0.00146,
-     "end_time": "2026-08-10T19:15:59.384321+00:00",
+     "duration": 0.001718,
+     "end_time": "2026-08-10T20:01:59.155508+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.382861+00:00",
+     "start_time": "2026-08-10T20:01:59.153790+00:00",
      "status": "completed"
     }
    },
@@ -172,19 +172,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "64525adf",
+   "id": "55adf7ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.388229Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.388109Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.402222Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.401689Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.158714Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.158642Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.171279Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.170948Z"
     },
     "papermill": {
-     "duration": 0.016754,
-     "end_time": "2026-08-10T19:15:59.402557+00:00",
+     "duration": 0.014755,
+     "end_time": "2026-08-10T20:01:59.171600+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.385803+00:00",
+     "start_time": "2026-08-10T20:01:59.156845+00:00",
      "status": "completed"
     }
    },
@@ -240,13 +240,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b0d4b49",
+   "id": "637ca9dc",
    "metadata": {
     "papermill": {
-     "duration": 0.001649,
-     "end_time": "2026-08-10T19:15:59.405980+00:00",
+     "duration": 0.001353,
+     "end_time": "2026-08-10T20:01:59.174366+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.404331+00:00",
+     "start_time": "2026-08-10T20:01:59.173013+00:00",
      "status": "completed"
     }
    },
@@ -278,13 +278,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9af6d42f",
+   "id": "4e437d3c",
    "metadata": {
     "papermill": {
-     "duration": 0.001497,
-     "end_time": "2026-08-10T19:15:59.409049+00:00",
+     "duration": 0.001345,
+     "end_time": "2026-08-10T20:01:59.177070+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.407552+00:00",
+     "start_time": "2026-08-10T20:01:59.175725+00:00",
      "status": "completed"
     }
    },
@@ -320,15 +320,19 @@
     "was passing, so every count below and every label file would otherwise have covered names the\n",
     "strategy can never hold.\n",
     "\n",
-    "The roster is derived from the surface rather than typed out, and then checked in both\n",
-    "directions: its size against the declared `n_assets`, and every roster name against the share\n",
-    "bars. Checking one direction is what let this through - a guard that only asks whether every\n",
-    "declared name is present says nothing about a present name that was never declared.\n",
+    "The roster is derived from the surface rather than typed out, and every roster name is then\n",
+    "checked against the share bars: a name that can be ranked must have a price to trade at.\n",
     "\n",
-    "**The roster is read off the whole extract, not off the requested window.** `universe.n_assets`\n",
-    "is a statement about the dataset, so a run that narrows `START_DATE` would otherwise assert\n",
-    "against a roster missing every name that had not yet listed - the declaration would fail on a\n",
-    "parameter the notebook documents as free to change. The dates bound the panels below it.\n",
+    "**The roster is read off the whole extract, not off the requested window**, because which names\n",
+    "have listed options is a property of the dataset. Deriving it after `START_DATE` would give a\n",
+    "roster missing every name not yet listed, and the bound would then vary with a parameter the\n",
+    "notebook documents as free to change.\n",
+    "\n",
+    "**How many names that comes to is a fact about the extract, so it is reported rather than\n",
+    "asserted.** `universe.n_assets` describes the production dataset, and the reduced extract CI\n",
+    "runs on carries a handful of names by design; an assertion on the count fails there for being\n",
+    "small rather than for being wrong. `tests/test_eoa_universe_roster.py` holds the declaration to\n",
+    "the production data, which is the only place the comparison means anything.\n",
     "\n",
     "The session grid is taken from the **unbounded** extract, because a session is a property of the\n",
     "market rather than of the universe, and the horizon is counted on it."
@@ -337,19 +341,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "86b96d60",
+   "id": "6b8032da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.413061Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.412946Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.684167Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.683562Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.180305Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.180233Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.412362Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.411760Z"
     },
     "papermill": {
-     "duration": 0.274303,
-     "end_time": "2026-08-10T19:15:59.684859+00:00",
+     "duration": 0.234347,
+     "end_time": "2026-08-10T20:01:59.412776+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.410556+00:00",
+     "start_time": "2026-08-10T20:01:59.178429+00:00",
      "status": "completed"
     }
    },
@@ -359,7 +363,7 @@
      "output_type": "stream",
      "text": [
       "market_data digest: ff1ae4d6c1490ee6\n",
-      "Universe 633 names with an option surface, as universe.n_assets declares; 5 priced names carry no surface and are excluded (BF.B, BMS, BRK.B, NVR, ONL)\n"
+      "Universe 633 names with an option surface (as universe.n_assets declares); 5 priced names carry no surface and are excluded (BF.B, BMS, BRK.B, NVR, ONL)\n"
      ]
     },
     {
@@ -377,10 +381,7 @@
     "full_bars = load_sp500_daily_bars()\n",
     "ROSTER = sorted(full_surface[\"symbol\"].unique().to_list())\n",
     "\n",
-    "assert len(ROSTER) == setup[\"universe\"][\"n_assets\"], (\n",
-    "    f\"{len(ROSTER)} names carry an option surface against a declared \"\n",
-    "    f\"universe.n_assets of {setup['universe']['n_assets']}\"\n",
-    ")\n",
+    "assert ROSTER, \"the option-surface extract carries no names to rank\"\n",
     "priced = set(full_bars[\"symbol\"].unique().to_list())\n",
     "assert not set(ROSTER) - priced, f\"no share bars for {sorted(set(ROSTER) - priced)}\"\n",
     "outside = sorted(priced - set(ROSTER))\n",
@@ -408,8 +409,14 @@
     "PRICE_COLS = [\"symbol\", \"sec_id\", \"timestamp\", \"open\", \"close\", \"adj_factor\"]\n",
     "MARKET_DATA_DIGEST = value_digest(bars, PRICE_COLS)\n",
     "print(f\"market_data digest: {MARKET_DATA_DIGEST}\")\n",
+    "DECLARED = setup[\"universe\"][\"n_assets\"]\n",
+    "against = (\n",
+    "    \"as universe.n_assets declares\"\n",
+    "    if len(ROSTER) == DECLARED\n",
+    "    else f\"a reduced extract; universe.n_assets declares {DECLARED}\"\n",
+    ")\n",
     "print(\n",
-    "    f\"Universe {len(ROSTER)} names with an option surface, as universe.n_assets declares; \"\n",
+    "    f\"Universe {len(ROSTER)} names with an option surface ({against}); \"\n",
     "    f\"{len(outside)} priced names carry no surface and are excluded ({', '.join(outside)})\"\n",
     ")\n",
     "\n",
@@ -437,14 +444,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f34122c",
+   "id": "09842512",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002889,
-     "end_time": "2026-08-10T19:15:59.690894+00:00",
+     "duration": 0.002342,
+     "end_time": "2026-08-10T20:01:59.418133+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.688005+00:00",
+     "start_time": "2026-08-10T20:01:59.415791+00:00",
      "status": "completed"
     }
    },
@@ -477,19 +484,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3f54f3fd",
+   "id": "fe9dbf50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.697926Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.697817Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.778386Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.777619Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.421799Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.421695Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.478737Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.478104Z"
     },
     "papermill": {
-     "duration": 0.085077,
-     "end_time": "2026-08-10T19:15:59.779013+00:00",
+     "duration": 0.059857,
+     "end_time": "2026-08-10T20:01:59.479460+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.693936+00:00",
+     "start_time": "2026-08-10T20:01:59.419603+00:00",
      "status": "completed"
     }
    },
@@ -518,13 +525,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9120d3b",
+   "id": "a77293c9",
    "metadata": {
     "papermill": {
-     "duration": 0.002777,
-     "end_time": "2026-08-10T19:15:59.784928+00:00",
+     "duration": 0.002719,
+     "end_time": "2026-08-10T20:01:59.485509+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.782151+00:00",
+     "start_time": "2026-08-10T20:01:59.482790+00:00",
      "status": "completed"
     }
    },
@@ -551,19 +558,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9478a890",
+   "id": "45c91345",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.792219Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.791971Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.815858Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.815205Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.490902Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.490830Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.509942Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.509354Z"
     },
     "papermill": {
-     "duration": 0.028919,
-     "end_time": "2026-08-10T19:15:59.816812+00:00",
+     "duration": 0.02226,
+     "end_time": "2026-08-10T20:01:59.510522+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.787893+00:00",
+     "start_time": "2026-08-10T20:01:59.488262+00:00",
      "status": "completed"
     }
    },
@@ -583,13 +590,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8fe4b3e",
+   "id": "09195591",
    "metadata": {
     "papermill": {
-     "duration": 0.001748,
-     "end_time": "2026-08-10T19:15:59.821507+00:00",
+     "duration": 0.001593,
+     "end_time": "2026-08-10T20:01:59.514136+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.819759+00:00",
+     "start_time": "2026-08-10T20:01:59.512543+00:00",
      "status": "completed"
     }
    },
@@ -616,19 +623,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f0940ba0",
+   "id": "5423a16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.825637Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.825530Z",
-     "iopub.status.idle": "2026-08-10T19:15:59.959800Z",
-     "shell.execute_reply": "2026-08-10T19:15:59.959111Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.519348Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.519154Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.635121Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.634594Z"
     },
     "papermill": {
-     "duration": 0.137034,
-     "end_time": "2026-08-10T19:15:59.960132+00:00",
+     "duration": 0.11972,
+     "end_time": "2026-08-10T20:01:59.635512+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.823098+00:00",
+     "start_time": "2026-08-10T20:01:59.515792+00:00",
      "status": "completed"
     }
    },
@@ -637,14 +644,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_5d: 629,443 labelled, spans up to 11d against a 14d tolerance; unlabelled 3,113 with no forward window, 34 with a hole in the window, 12 with a missing price\n"
+      "fwd_ret_5d: 629,443 labelled, spans up to 11d against a 14d tolerance; unlabelled 3,113 with no forward window, 34 with a hole in the window, 12 with a missing price\n",
+      "fwd_ret_10d: 626,318 labelled, spans up to 18d against a 21d tolerance; unlabelled 6,208 with no forward window, 64 with a hole in the window, 12 with a missing price\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_10d: 626,318 labelled, spans up to 18d against a 21d tolerance; unlabelled 6,208 with no forward window, 64 with a hole in the window, 12 with a missing price\n",
       "fwd_ret_risk_adj_5d: 616,995 labelled, spans up to 11d against a 14d tolerance; unlabelled 3,113 with no forward window, 34 with a hole in the window, 12,448 with no trailing volatility yet, 12 with a missing price\n",
       "fwd_dir_5d: the sign of fwd_ret_5d, and null wherever fwd_ret_5d is\n",
       "fwd_dir_10d: the sign of fwd_ret_10d, and null wherever fwd_ret_10d is\n"
@@ -690,13 +697,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b0517d1",
+   "id": "55e11d83",
    "metadata": {
     "papermill": {
-     "duration": 0.001874,
-     "end_time": "2026-08-10T19:15:59.963860+00:00",
+     "duration": 0.00157,
+     "end_time": "2026-08-10T20:01:59.638806+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.961986+00:00",
+     "start_time": "2026-08-10T20:01:59.637236+00:00",
      "status": "completed"
     }
    },
@@ -713,19 +720,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1c4fc505",
+   "id": "c0b5c2c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:15:59.967797Z",
-     "iopub.status.busy": "2026-08-10T19:15:59.967665Z",
-     "iopub.status.idle": "2026-08-10T19:16:00.081650Z",
-     "shell.execute_reply": "2026-08-10T19:16:00.081041Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.642473Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.642391Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.740426Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.740034Z"
     },
     "papermill": {
-     "duration": 0.116696,
-     "end_time": "2026-08-10T19:16:00.082179+00:00",
+     "duration": 0.100472,
+     "end_time": "2026-08-10T20:01:59.740781+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:15:59.965483+00:00",
+     "start_time": "2026-08-10T20:01:59.640309+00:00",
      "status": "completed"
     }
    },
@@ -776,13 +783,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01620fd2",
+   "id": "75d6fdc2",
    "metadata": {
     "papermill": {
-     "duration": 0.003323,
-     "end_time": "2026-08-10T19:16:00.089131+00:00",
+     "duration": 0.001697,
+     "end_time": "2026-08-10T20:01:59.744334+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.085808+00:00",
+     "start_time": "2026-08-10T20:01:59.742637+00:00",
      "status": "completed"
     }
    },
@@ -801,19 +808,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e1670d3f",
+   "id": "4820437b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:00.096479Z",
-     "iopub.status.busy": "2026-08-10T19:16:00.096364Z",
-     "iopub.status.idle": "2026-08-10T19:16:00.208992Z",
-     "shell.execute_reply": "2026-08-10T19:16:00.208399Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.748300Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.748228Z",
+     "iopub.status.idle": "2026-08-10T20:01:59.841741Z",
+     "shell.execute_reply": "2026-08-10T20:01:59.841335Z"
     },
     "papermill": {
-     "duration": 0.117245,
-     "end_time": "2026-08-10T19:16:00.209655+00:00",
+     "duration": 0.09629,
+     "end_time": "2026-08-10T20:01:59.842259+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.092410+00:00",
+     "start_time": "2026-08-10T20:01:59.745969+00:00",
      "status": "completed"
     }
    },
@@ -845,13 +852,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ebfbc2b",
+   "id": "51e95443",
    "metadata": {
     "papermill": {
-     "duration": 0.003694,
-     "end_time": "2026-08-10T19:16:00.217303+00:00",
+     "duration": 0.001673,
+     "end_time": "2026-08-10T20:01:59.845974+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.213609+00:00",
+     "start_time": "2026-08-10T20:01:59.844301+00:00",
      "status": "completed"
     }
    },
@@ -866,19 +873,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3f59b108",
+   "id": "ef5d0d15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:00.225954Z",
-     "iopub.status.busy": "2026-08-10T19:16:00.225776Z",
-     "iopub.status.idle": "2026-08-10T19:16:00.436612Z",
-     "shell.execute_reply": "2026-08-10T19:16:00.436071Z"
+     "iopub.execute_input": "2026-08-10T20:01:59.850007Z",
+     "iopub.status.busy": "2026-08-10T20:01:59.849928Z",
+     "iopub.status.idle": "2026-08-10T20:02:00.030079Z",
+     "shell.execute_reply": "2026-08-10T20:02:00.029673Z"
     },
     "papermill": {
-     "duration": 0.21619,
-     "end_time": "2026-08-10T19:16:00.437336+00:00",
+     "duration": 0.182975,
+     "end_time": "2026-08-10T20:02:00.030605+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.221146+00:00",
+     "start_time": "2026-08-10T20:01:59.847630+00:00",
      "status": "completed"
     }
    },
@@ -938,13 +945,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf058ab7",
+   "id": "71fcda7d",
    "metadata": {
     "papermill": {
-     "duration": 0.003918,
-     "end_time": "2026-08-10T19:16:00.445361+00:00",
+     "duration": 0.001835,
+     "end_time": "2026-08-10T20:02:00.035342+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.441443+00:00",
+     "start_time": "2026-08-10T20:02:00.033507+00:00",
      "status": "completed"
     }
    },
@@ -958,14 +965,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bde844a",
+   "id": "34f32af6",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00384,
-     "end_time": "2026-08-10T19:16:00.452996+00:00",
+     "duration": 0.001747,
+     "end_time": "2026-08-10T20:02:00.038881+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.449156+00:00",
+     "start_time": "2026-08-10T20:02:00.037134+00:00",
      "status": "completed"
     }
    },
@@ -983,19 +990,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "95ccd1f0",
+   "id": "dc30eb40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:00.461188Z",
-     "iopub.status.busy": "2026-08-10T19:16:00.461029Z",
-     "iopub.status.idle": "2026-08-10T19:16:00.514967Z",
-     "shell.execute_reply": "2026-08-10T19:16:00.514231Z"
+     "iopub.execute_input": "2026-08-10T20:02:00.043084Z",
+     "iopub.status.busy": "2026-08-10T20:02:00.042999Z",
+     "iopub.status.idle": "2026-08-10T20:02:00.083954Z",
+     "shell.execute_reply": "2026-08-10T20:02:00.083486Z"
     },
     "papermill": {
-     "duration": 0.058754,
-     "end_time": "2026-08-10T19:16:00.515581+00:00",
+     "duration": 0.043972,
+     "end_time": "2026-08-10T20:02:00.084642+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.456827+00:00",
+     "start_time": "2026-08-10T20:02:00.040670+00:00",
      "status": "completed"
     }
    },
@@ -1020,13 +1027,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bac4de0d",
+   "id": "51363767",
    "metadata": {
     "papermill": {
-     "duration": 0.002463,
-     "end_time": "2026-08-10T19:16:00.521997+00:00",
+     "duration": 0.001864,
+     "end_time": "2026-08-10T20:02:00.088597+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.519534+00:00",
+     "start_time": "2026-08-10T20:02:00.086733+00:00",
      "status": "completed"
     }
    },
@@ -1041,19 +1048,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ba0a3aba",
+   "id": "15598c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:00.526486Z",
-     "iopub.status.busy": "2026-08-10T19:16:00.526373Z",
-     "iopub.status.idle": "2026-08-10T19:16:00.657416Z",
-     "shell.execute_reply": "2026-08-10T19:16:00.656775Z"
+     "iopub.execute_input": "2026-08-10T20:02:00.092934Z",
+     "iopub.status.busy": "2026-08-10T20:02:00.092850Z",
+     "iopub.status.idle": "2026-08-10T20:02:00.188629Z",
+     "shell.execute_reply": "2026-08-10T20:02:00.188150Z"
     },
     "papermill": {
-     "duration": 0.134031,
-     "end_time": "2026-08-10T19:16:00.657927+00:00",
+     "duration": 0.098509,
+     "end_time": "2026-08-10T20:02:00.188944+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.523896+00:00",
+     "start_time": "2026-08-10T20:02:00.090435+00:00",
      "status": "completed"
     }
    },
@@ -1120,13 +1127,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "557535ef",
+   "id": "593ffa8f",
    "metadata": {
     "papermill": {
-     "duration": 0.004328,
-     "end_time": "2026-08-10T19:16:00.666794+00:00",
+     "duration": 0.002041,
+     "end_time": "2026-08-10T20:02:00.193199+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.662466+00:00",
+     "start_time": "2026-08-10T20:02:00.191158+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1144,13 +1151,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efc009c4",
+   "id": "3b6c26b7",
    "metadata": {
     "papermill": {
-     "duration": 0.002234,
-     "end_time": "2026-08-10T19:16:00.671448+00:00",
+     "duration": 0.00197,
+     "end_time": "2026-08-10T20:02:00.197162+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.669214+00:00",
+     "start_time": "2026-08-10T20:02:00.195192+00:00",
      "status": "completed"
     }
    },
@@ -1171,19 +1178,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "c0c136e8",
+   "id": "9f433db3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:00.676788Z",
-     "iopub.status.busy": "2026-08-10T19:16:00.676614Z",
-     "iopub.status.idle": "2026-08-10T19:16:01.492762Z",
-     "shell.execute_reply": "2026-08-10T19:16:01.492176Z"
+     "iopub.execute_input": "2026-08-10T20:02:00.201857Z",
+     "iopub.status.busy": "2026-08-10T20:02:00.201748Z",
+     "iopub.status.idle": "2026-08-10T20:02:00.921816Z",
+     "shell.execute_reply": "2026-08-10T20:02:00.921437Z"
     },
     "papermill": {
-     "duration": 0.819535,
-     "end_time": "2026-08-10T19:16:01.493142+00:00",
+     "duration": 0.723015,
+     "end_time": "2026-08-10T20:02:00.922155+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:00.673607+00:00",
+     "start_time": "2026-08-10T20:02:00.199140+00:00",
      "status": "completed"
     }
    },
@@ -1232,13 +1239,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddd8493b",
+   "id": "399b2fdd",
    "metadata": {
     "papermill": {
-     "duration": 0.004529,
-     "end_time": "2026-08-10T19:16:01.501591+00:00",
+     "duration": 0.002173,
+     "end_time": "2026-08-10T20:02:00.926689+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:01.497062+00:00",
+     "start_time": "2026-08-10T20:02:00.924516+00:00",
      "status": "completed"
     }
    },
@@ -1253,19 +1260,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "95e90c86",
+   "id": "78f079f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:01.511383Z",
-     "iopub.status.busy": "2026-08-10T19:16:01.511211Z",
-     "iopub.status.idle": "2026-08-10T19:16:14.361475Z",
-     "shell.execute_reply": "2026-08-10T19:16:14.360857Z"
+     "iopub.execute_input": "2026-08-10T20:02:00.931768Z",
+     "iopub.status.busy": "2026-08-10T20:02:00.931673Z",
+     "iopub.status.idle": "2026-08-10T20:02:09.844967Z",
+     "shell.execute_reply": "2026-08-10T20:02:09.844556Z"
     },
     "papermill": {
-     "duration": 12.855902,
-     "end_time": "2026-08-10T19:16:14.361952+00:00",
+     "duration": 8.916439,
+     "end_time": "2026-08-10T20:02:09.845317+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:01.506050+00:00",
+     "start_time": "2026-08-10T20:02:00.928878+00:00",
      "status": "completed"
     }
    },
@@ -1326,13 +1333,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a719384c",
+   "id": "34591552",
    "metadata": {
     "papermill": {
-     "duration": 0.002572,
-     "end_time": "2026-08-10T19:16:14.367454+00:00",
+     "duration": 0.002219,
+     "end_time": "2026-08-10T20:02:09.849967+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.364882+00:00",
+     "start_time": "2026-08-10T20:02:09.847748+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1351,13 +1358,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23ff9bde",
+   "id": "81e108ab",
    "metadata": {
     "papermill": {
-     "duration": 0.002296,
-     "end_time": "2026-08-10T19:16:14.372115+00:00",
+     "duration": 0.002088,
+     "end_time": "2026-08-10T20:02:09.854231+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.369819+00:00",
+     "start_time": "2026-08-10T20:02:09.852143+00:00",
      "status": "completed"
     }
    },
@@ -1396,19 +1403,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "fcf89744",
+   "id": "56990af4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:14.378012Z",
-     "iopub.status.busy": "2026-08-10T19:16:14.377815Z",
-     "iopub.status.idle": "2026-08-10T19:16:14.523743Z",
-     "shell.execute_reply": "2026-08-10T19:16:14.523185Z"
+     "iopub.execute_input": "2026-08-10T20:02:09.859078Z",
+     "iopub.status.busy": "2026-08-10T20:02:09.858996Z",
+     "iopub.status.idle": "2026-08-10T20:02:09.979985Z",
+     "shell.execute_reply": "2026-08-10T20:02:09.979615Z"
     },
     "papermill": {
-     "duration": 0.149639,
-     "end_time": "2026-08-10T19:16:14.524064+00:00",
+     "duration": 0.124063,
+     "end_time": "2026-08-10T20:02:09.980434+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.374425+00:00",
+     "start_time": "2026-08-10T20:02:09.856371+00:00",
      "status": "completed"
     }
    },
@@ -1461,13 +1468,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73cc5373",
+   "id": "967ea2c6",
    "metadata": {
     "papermill": {
-     "duration": 0.002579,
-     "end_time": "2026-08-10T19:16:14.529269+00:00",
+     "duration": 0.002235,
+     "end_time": "2026-08-10T20:02:09.985043+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.526690+00:00",
+     "start_time": "2026-08-10T20:02:09.982808+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1486,13 +1493,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36c288b8",
+   "id": "80ab5ac4",
    "metadata": {
     "papermill": {
-     "duration": 0.002351,
-     "end_time": "2026-08-10T19:16:14.533994+00:00",
+     "duration": 0.002132,
+     "end_time": "2026-08-10T20:02:09.989423+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.531643+00:00",
+     "start_time": "2026-08-10T20:02:09.987291+00:00",
      "status": "completed"
     }
    },
@@ -1519,19 +1526,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f26dd9ae",
+   "id": "a08b363a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:14.539621Z",
-     "iopub.status.busy": "2026-08-10T19:16:14.539451Z",
-     "iopub.status.idle": "2026-08-10T19:16:14.662050Z",
-     "shell.execute_reply": "2026-08-10T19:16:14.661409Z"
+     "iopub.execute_input": "2026-08-10T20:02:09.994380Z",
+     "iopub.status.busy": "2026-08-10T20:02:09.994294Z",
+     "iopub.status.idle": "2026-08-10T20:02:10.098203Z",
+     "shell.execute_reply": "2026-08-10T20:02:10.097778Z"
     },
     "papermill": {
-     "duration": 0.126682,
-     "end_time": "2026-08-10T19:16:14.663038+00:00",
+     "duration": 0.107366,
+     "end_time": "2026-08-10T20:02:10.099005+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.536356+00:00",
+     "start_time": "2026-08-10T20:02:09.991639+00:00",
      "status": "completed"
     }
    },
@@ -1540,7 +1547,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fwd_ret_5d.parquet: 629,443 rows, digest 58ed638de369cc08\n",
+      "fwd_ret_5d.parquet: 629,443 rows, digest 58ed638de369cc08\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "fwd_ret_10d.parquet: 626,318 rows, digest 99712590f070d268\n",
       "fwd_ret_risk_adj_5d.parquet: 616,995 rows, digest cb86e29556fe64b2\n",
       "fwd_dir_5d.parquet: 629,443 rows, digest d8c31c17d548fc0a\n",
@@ -1563,13 +1576,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a0e5af2",
+   "id": "9561288a",
    "metadata": {
     "papermill": {
-     "duration": 0.003766,
-     "end_time": "2026-08-10T19:16:14.671832+00:00",
+     "duration": 0.00223,
+     "end_time": "2026-08-10T20:02:10.103831+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.668066+00:00",
+     "start_time": "2026-08-10T20:02:10.101601+00:00",
      "status": "completed"
     }
    },
@@ -1582,19 +1595,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "36fd6539",
+   "id": "9af71123",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:14.678026Z",
-     "iopub.status.busy": "2026-08-10T19:16:14.677838Z",
-     "iopub.status.idle": "2026-08-10T19:16:14.686070Z",
-     "shell.execute_reply": "2026-08-10T19:16:14.685498Z"
+     "iopub.execute_input": "2026-08-10T20:02:10.108955Z",
+     "iopub.status.busy": "2026-08-10T20:02:10.108832Z",
+     "iopub.status.idle": "2026-08-10T20:02:10.115795Z",
+     "shell.execute_reply": "2026-08-10T20:02:10.115298Z"
     },
     "papermill": {
-     "duration": 0.012087,
-     "end_time": "2026-08-10T19:16:14.686422+00:00",
+     "duration": 0.010093,
+     "end_time": "2026-08-10T20:02:10.116085+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.674335+00:00",
+     "start_time": "2026-08-10T20:02:10.105992+00:00",
      "status": "completed"
     }
    },
@@ -1669,13 +1682,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2045886e",
+   "id": "95ab7ffd",
    "metadata": {
     "papermill": {
-     "duration": 0.00237,
-     "end_time": "2026-08-10T19:16:14.692240+00:00",
+     "duration": 0.002881,
+     "end_time": "2026-08-10T20:02:10.121432+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:14.689870+00:00",
+     "start_time": "2026-08-10T20:02:10.118551+00:00",
      "status": "completed"
     }
    },
@@ -1737,19 +1750,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 23.816614,
-   "end_time": "2026-08-10T19:16:16.412339+00:00",
+   "duration": 14.860841,
+   "end_time": "2026-08-10T20:02:11.340193+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/02_labels.ipynb",
    "output_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/02_labels.ipynb",
    "parameters": {},
-   "start_time": "2026-08-10T19:15:52.595725+00:00",
+   "start_time": "2026-08-10T20:01:56.479352+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "e2dd287e476018c905781eacefc4fce7ece68847",
-   "executed_at": "2026-08-10T19:16:22.002250+00:00",
+   "source_py_blob": "f64b522dadbf9357e84406489b5d263e535d0154",
+   "executed_at": "2026-08-10T20:02:16.268150+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/sp500_equity_option_analytics/02_labels.py
+++ b/case_studies/sp500_equity_option_analytics/02_labels.py
@@ -189,15 +189,19 @@ print(
 # was passing, so every count below and every label file would otherwise have covered names the
 # strategy can never hold.
 #
-# The roster is derived from the surface rather than typed out, and then checked in both
-# directions: its size against the declared `n_assets`, and every roster name against the share
-# bars. Checking one direction is what let this through - a guard that only asks whether every
-# declared name is present says nothing about a present name that was never declared.
+# The roster is derived from the surface rather than typed out, and every roster name is then
+# checked against the share bars: a name that can be ranked must have a price to trade at.
 #
-# **The roster is read off the whole extract, not off the requested window.** `universe.n_assets`
-# is a statement about the dataset, so a run that narrows `START_DATE` would otherwise assert
-# against a roster missing every name that had not yet listed - the declaration would fail on a
-# parameter the notebook documents as free to change. The dates bound the panels below it.
+# **The roster is read off the whole extract, not off the requested window**, because which names
+# have listed options is a property of the dataset. Deriving it after `START_DATE` would give a
+# roster missing every name not yet listed, and the bound would then vary with a parameter the
+# notebook documents as free to change.
+#
+# **How many names that comes to is a fact about the extract, so it is reported rather than
+# asserted.** `universe.n_assets` describes the production dataset, and the reduced extract CI
+# runs on carries a handful of names by design; an assertion on the count fails there for being
+# small rather than for being wrong. `tests/test_eoa_universe_roster.py` holds the declaration to
+# the production data, which is the only place the comparison means anything.
 #
 # The session grid is taken from the **unbounded** extract, because a session is a property of the
 # market rather than of the universe, and the horizon is counted on it.
@@ -207,10 +211,7 @@ full_surface = load_sp500_options_surface()
 full_bars = load_sp500_daily_bars()
 ROSTER = sorted(full_surface["symbol"].unique().to_list())
 
-assert len(ROSTER) == setup["universe"]["n_assets"], (
-    f"{len(ROSTER)} names carry an option surface against a declared "
-    f"universe.n_assets of {setup['universe']['n_assets']}"
-)
+assert ROSTER, "the option-surface extract carries no names to rank"
 priced = set(full_bars["symbol"].unique().to_list())
 assert not set(ROSTER) - priced, f"no share bars for {sorted(set(ROSTER) - priced)}"
 outside = sorted(priced - set(ROSTER))
@@ -238,8 +239,14 @@ prices = (
 PRICE_COLS = ["symbol", "sec_id", "timestamp", "open", "close", "adj_factor"]
 MARKET_DATA_DIGEST = value_digest(bars, PRICE_COLS)
 print(f"market_data digest: {MARKET_DATA_DIGEST}")
+DECLARED = setup["universe"]["n_assets"]
+against = (
+    "as universe.n_assets declares"
+    if len(ROSTER) == DECLARED
+    else f"a reduced extract; universe.n_assets declares {DECLARED}"
+)
 print(
-    f"Universe {len(ROSTER)} names with an option surface, as universe.n_assets declares; "
+    f"Universe {len(ROSTER)} names with an option surface ({against}); "
     f"{len(outside)} priced names carry no surface and are excluded ({', '.join(outside)})"
 )
 

--- a/case_studies/sp500_equity_option_analytics/03_financial_features.ipynb
+++ b/case_studies/sp500_equity_option_analytics/03_financial_features.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "93a5d5dc",
+   "id": "798f9536",
    "metadata": {
     "papermill": {
-     "duration": 0.002195,
-     "end_time": "2026-08-10T19:16:23.788374+00:00",
+     "duration": 0.002066,
+     "end_time": "2026-08-10T20:02:17.876160+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:23.786179+00:00",
+     "start_time": "2026-08-10T20:02:17.874094+00:00",
      "status": "completed"
     }
    },
@@ -62,19 +62,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "22c591a5",
+   "id": "ed54a72c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:23.792895Z",
-     "iopub.status.busy": "2026-08-10T19:16:23.792740Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.033692Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.033121Z"
+     "iopub.execute_input": "2026-08-10T20:02:17.880430Z",
+     "iopub.status.busy": "2026-08-10T20:02:17.880323Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.739048Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.738631Z"
     },
     "papermill": {
-     "duration": 2.244219,
-     "end_time": "2026-08-10T19:16:26.034456+00:00",
+     "duration": 1.86187,
+     "end_time": "2026-08-10T20:02:19.739803+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:23.790237+00:00",
+     "start_time": "2026-08-10T20:02:17.877933+00:00",
      "status": "completed"
     }
    },
@@ -116,13 +116,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "666184e4",
+   "id": "49a3dd13",
    "metadata": {
     "papermill": {
-     "duration": 0.002283,
-     "end_time": "2026-08-10T19:16:26.040439+00:00",
+     "duration": 0.002932,
+     "end_time": "2026-08-10T20:02:19.745928+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.038156+00:00",
+     "start_time": "2026-08-10T20:02:19.742996+00:00",
      "status": "completed"
     }
    },
@@ -137,19 +137,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "77ae98f4",
+   "id": "a2e0cf48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.045010Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.044877Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.047311Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.046697Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.752434Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.752332Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.753995Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.753699Z"
     },
     "papermill": {
-     "duration": 0.005298,
-     "end_time": "2026-08-10T19:16:26.047656+00:00",
+     "duration": 0.005639,
+     "end_time": "2026-08-10T20:02:19.754457+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.042358+00:00",
+     "start_time": "2026-08-10T20:02:19.748818+00:00",
      "status": "completed"
     },
     "tags": [
@@ -164,13 +164,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00e4ed55",
+   "id": "78af9eb9",
    "metadata": {
     "papermill": {
-     "duration": 0.001813,
-     "end_time": "2026-08-10T19:16:26.051586+00:00",
+     "duration": 0.001655,
+     "end_time": "2026-08-10T20:02:19.757751+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.049773+00:00",
+     "start_time": "2026-08-10T20:02:19.756096+00:00",
      "status": "completed"
     }
    },
@@ -189,19 +189,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e08aabbf",
+   "id": "53656404",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.056367Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.056160Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.072573Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.071783Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.761549Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.761468Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.773438Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.773177Z"
     },
     "papermill": {
-     "duration": 0.019715,
-     "end_time": "2026-08-10T19:16:26.073182+00:00",
+     "duration": 0.014435,
+     "end_time": "2026-08-10T20:02:19.773786+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.053467+00:00",
+     "start_time": "2026-08-10T20:02:19.759351+00:00",
      "status": "completed"
     }
    },
@@ -275,13 +275,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac488ad7",
+   "id": "27e52ddd",
    "metadata": {
     "papermill": {
-     "duration": 0.003378,
-     "end_time": "2026-08-10T19:16:26.080310+00:00",
+     "duration": 0.001628,
+     "end_time": "2026-08-10T20:02:19.777100+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.076932+00:00",
+     "start_time": "2026-08-10T20:02:19.775472+00:00",
      "status": "completed"
     }
    },
@@ -319,19 +319,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7097a3ad",
+   "id": "6b1de878",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.087968Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.087774Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.111824Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.111351Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.780823Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.780744Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.804928Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.804592Z"
     },
     "papermill": {
-     "duration": 0.028888,
-     "end_time": "2026-08-10T19:16:26.112405+00:00",
+     "duration": 0.026592,
+     "end_time": "2026-08-10T20:02:19.805328+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.083517+00:00",
+     "start_time": "2026-08-10T20:02:19.778736+00:00",
      "status": "completed"
     }
    },
@@ -392,13 +392,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6485eb25",
+   "id": "8596cbd2",
    "metadata": {
     "papermill": {
-     "duration": 0.003516,
-     "end_time": "2026-08-10T19:16:26.119915+00:00",
+     "duration": 0.00172,
+     "end_time": "2026-08-10T20:02:19.808871+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.116399+00:00",
+     "start_time": "2026-08-10T20:02:19.807151+00:00",
      "status": "completed"
     }
    },
@@ -458,33 +458,32 @@
     "off. The share-bar extract is wider than that and the loader takes a `symbols=` argument nothing\n",
     "was passing. The keep-or-drop in Section C would have removed the surplus names from the matrix\n",
     "anyway, so bounding here moves no emitted value; what it changes is that the universe becomes a\n",
-    "stated bound with an assertion behind it rather than a by-product of a later filter. The roster\n",
-    "is derived from the surface rather than typed out, and checked in both directions: its size\n",
-    "against the declared `n_assets`, and every roster name against the share bars. A guard that only\n",
-    "asks whether every declared name is present says nothing about a present name never declared.\n",
+    "stated bound rather than a by-product of a later filter. The roster is derived from the surface\n",
+    "rather than typed out, and every roster name is checked against the share bars.\n",
     "\n",
-    "The roster is read off the **whole** extract rather than off the requested window, because\n",
-    "`n_assets` is a statement about the dataset: a run that narrows `START_DATE` would otherwise\n",
-    "assert against a roster missing every name that had not yet listed, and the declaration would\n",
-    "fail on a parameter this notebook documents as free to change. The dates bound the panels."
+    "The roster is read off the **whole** extract rather than off the requested window, because which\n",
+    "names have listed options is a property of the dataset rather than of a run. How many that comes\n",
+    "to is reported rather than asserted: `n_assets` describes the production extract, and the reduced\n",
+    "one CI runs on carries a handful of names by design.\n",
+    "`tests/test_eoa_universe_roster.py` holds the declaration to the production data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f153f305",
+   "id": "55cb1503",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.128506Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.128383Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.259954Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.259414Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.812767Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.812690Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.921174Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.920715Z"
     },
     "papermill": {
-     "duration": 0.13696,
-     "end_time": "2026-08-10T19:16:26.260704+00:00",
+     "duration": 0.111024,
+     "end_time": "2026-08-10T20:02:19.921638+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.123744+00:00",
+     "start_time": "2026-08-10T20:02:19.810614+00:00",
      "status": "completed"
     }
    },
@@ -497,7 +496,7 @@
       "624 securities behind those tickers\n",
       "530,503 surface rows carrying 13 columns\n",
       "2017-01-03 to 2021-12-31\n",
-      "5 priced names carry no option surface and are outside the declared universe (BF.B, BMS, BRK.B, NVR, ONL)\n"
+      "Universe 633 names with an option surface; 5 priced names carry none and are excluded (BF.B, BMS, BRK.B, NVR, ONL)\n"
      ]
     }
    ],
@@ -505,10 +504,7 @@
     "full_surface = load_sp500_options_surface()\n",
     "full_bars = load_sp500_daily_bars()\n",
     "ROSTER = sorted(full_surface[\"symbol\"].unique().to_list())\n",
-    "assert len(ROSTER) == setup[\"universe\"][\"n_assets\"], (\n",
-    "    f\"{len(ROSTER)} names carry an option surface against a declared \"\n",
-    "    f\"universe.n_assets of {setup['universe']['n_assets']}\"\n",
-    ")\n",
+    "assert ROSTER, \"the option-surface extract carries no names to rank\"\n",
     "priced = set(full_bars[\"symbol\"].unique().to_list())\n",
     "assert not set(ROSTER) - priced, f\"no share bars for {sorted(set(ROSTER) - priced)}\"\n",
     "outside = sorted(priced - set(ROSTER))\n",
@@ -529,28 +525,30 @@
     "print(f\"{daily[SECURITY].n_unique()} securities behind those tickers\")\n",
     "print(f\"{surface_raw.height:,} surface rows carrying {len(SURFACE_COLS)} columns\")\n",
     "print(f\"{daily['timestamp'].min()} to {daily['timestamp'].max()}\")\n",
+    "DECLARED = setup[\"universe\"][\"n_assets\"]\n",
     "print(\n",
-    "    f\"{len(outside)} priced names carry no option surface and are outside the declared universe \"\n",
-    "    f\"({', '.join(outside)})\"\n",
+    "    f\"Universe {len(ROSTER)} names with an option surface\"\n",
+    "    + (\"\" if len(ROSTER) == DECLARED else f\" (a reduced extract; n_assets declares {DECLARED})\")\n",
+    "    + f\"; {len(outside)} priced names carry none and are excluded ({', '.join(outside)})\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2c087a6f",
+   "id": "cef3518e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.271829Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.271401Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.319766Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.319007Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.926384Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.926223Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.957625Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.957323Z"
     },
     "papermill": {
-     "duration": 0.055497,
-     "end_time": "2026-08-10T19:16:26.320300+00:00",
+     "duration": 0.034242,
+     "end_time": "2026-08-10T20:02:19.957953+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.264803+00:00",
+     "start_time": "2026-08-10T20:02:19.923711+00:00",
      "status": "completed"
     }
    },
@@ -630,14 +628,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53831c77",
+   "id": "84ae9062",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003885,
-     "end_time": "2026-08-10T19:16:26.328430+00:00",
+     "duration": 0.001895,
+     "end_time": "2026-08-10T20:02:19.961894+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.324545+00:00",
+     "start_time": "2026-08-10T20:02:19.959999+00:00",
      "status": "completed"
     }
    },
@@ -653,19 +651,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "258c75ca",
+   "id": "35cf424b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.336838Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.336683Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.339650Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.339276Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.966228Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.966142Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.968452Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.968194Z"
     },
     "papermill": {
-     "duration": 0.008262,
-     "end_time": "2026-08-10T19:16:26.340280+00:00",
+     "duration": 0.00495,
+     "end_time": "2026-08-10T20:02:19.968706+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.332018+00:00",
+     "start_time": "2026-08-10T20:02:19.963756+00:00",
      "status": "completed"
     }
    },
@@ -690,13 +688,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c604deae",
+   "id": "9d256c8a",
    "metadata": {
     "papermill": {
-     "duration": 0.003741,
-     "end_time": "2026-08-10T19:16:26.348018+00:00",
+     "duration": 0.001792,
+     "end_time": "2026-08-10T20:02:19.972340+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.344277+00:00",
+     "start_time": "2026-08-10T20:02:19.970548+00:00",
      "status": "completed"
     }
    },
@@ -731,19 +729,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "10f0c8b4",
+   "id": "5917fecf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.356134Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.356011Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.359562Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.359126Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.976533Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.976448Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.979623Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.979233Z"
     },
     "papermill": {
-     "duration": 0.008463,
-     "end_time": "2026-08-10T19:16:26.360128+00:00",
+     "duration": 0.005782,
+     "end_time": "2026-08-10T20:02:19.979947+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.351665+00:00",
+     "start_time": "2026-08-10T20:02:19.974165+00:00",
      "status": "completed"
     }
    },
@@ -786,13 +784,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49da9e46",
+   "id": "c0eb26d3",
    "metadata": {
     "papermill": {
-     "duration": 0.003725,
-     "end_time": "2026-08-10T19:16:26.367744+00:00",
+     "duration": 0.001816,
+     "end_time": "2026-08-10T20:02:19.983682+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.364019+00:00",
+     "start_time": "2026-08-10T20:02:19.981866+00:00",
      "status": "completed"
     }
    },
@@ -832,19 +830,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "81ba9c0d",
+   "id": "0056bc14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.376594Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.376263Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.380247Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.379744Z"
+     "iopub.execute_input": "2026-08-10T20:02:19.988196Z",
+     "iopub.status.busy": "2026-08-10T20:02:19.988091Z",
+     "iopub.status.idle": "2026-08-10T20:02:19.991422Z",
+     "shell.execute_reply": "2026-08-10T20:02:19.991141Z"
     },
     "papermill": {
-     "duration": 0.009118,
-     "end_time": "2026-08-10T19:16:26.380735+00:00",
+     "duration": 0.006348,
+     "end_time": "2026-08-10T20:02:19.991878+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.371617+00:00",
+     "start_time": "2026-08-10T20:02:19.985530+00:00",
      "status": "completed"
     }
    },
@@ -904,13 +902,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bef7b7b7",
+   "id": "d00ed8fd",
    "metadata": {
     "papermill": {
-     "duration": 0.003952,
-     "end_time": "2026-08-10T19:16:26.388794+00:00",
+     "duration": 0.00327,
+     "end_time": "2026-08-10T20:02:19.998785+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.384842+00:00",
+     "start_time": "2026-08-10T20:02:19.995515+00:00",
      "status": "completed"
     }
    },
@@ -930,20 +928,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "014d277c",
+   "id": "3931f07e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.395364Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.395218Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.398954Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.398357Z"
+     "iopub.execute_input": "2026-08-10T20:02:20.006471Z",
+     "iopub.status.busy": "2026-08-10T20:02:20.006372Z",
+     "iopub.status.idle": "2026-08-10T20:02:20.009198Z",
+     "shell.execute_reply": "2026-08-10T20:02:20.008936Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007141,
-     "end_time": "2026-08-10T19:16:26.399359+00:00",
+     "duration": 0.007406,
+     "end_time": "2026-08-10T20:02:20.009535+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.392218+00:00",
+     "start_time": "2026-08-10T20:02:20.002129+00:00",
      "status": "completed"
     }
    },
@@ -994,14 +992,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23a3536f",
+   "id": "77c14ce9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002824,
-     "end_time": "2026-08-10T19:16:26.404630+00:00",
+     "duration": 0.001843,
+     "end_time": "2026-08-10T20:02:20.013314+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.401806+00:00",
+     "start_time": "2026-08-10T20:02:20.011471+00:00",
      "status": "completed"
     }
    },
@@ -1028,20 +1026,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "722c8be2",
+   "id": "a0e5468d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.412292Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.412145Z",
-     "iopub.status.idle": "2026-08-10T19:16:26.416401Z",
-     "shell.execute_reply": "2026-08-10T19:16:26.415618Z"
+     "iopub.execute_input": "2026-08-10T20:02:20.017546Z",
+     "iopub.status.busy": "2026-08-10T20:02:20.017471Z",
+     "iopub.status.idle": "2026-08-10T20:02:20.019652Z",
+     "shell.execute_reply": "2026-08-10T20:02:20.019427Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008913,
-     "end_time": "2026-08-10T19:16:26.417357+00:00",
+     "duration": 0.004777,
+     "end_time": "2026-08-10T20:02:20.019946+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.408444+00:00",
+     "start_time": "2026-08-10T20:02:20.015169+00:00",
      "status": "completed"
     }
    },
@@ -1071,14 +1069,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b6ee1ce",
+   "id": "44ab25a5",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002242,
-     "end_time": "2026-08-10T19:16:26.422504+00:00",
+     "duration": 0.001873,
+     "end_time": "2026-08-10T20:02:20.023663+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.420262+00:00",
+     "start_time": "2026-08-10T20:02:20.021790+00:00",
      "status": "completed"
     }
    },
@@ -1103,19 +1101,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "91767c91",
+   "id": "86c6627f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:26.427597Z",
-     "iopub.status.busy": "2026-08-10T19:16:26.427460Z",
-     "iopub.status.idle": "2026-08-10T19:16:27.360097Z",
-     "shell.execute_reply": "2026-08-10T19:16:27.359447Z"
+     "iopub.execute_input": "2026-08-10T20:02:20.027922Z",
+     "iopub.status.busy": "2026-08-10T20:02:20.027842Z",
+     "iopub.status.idle": "2026-08-10T20:02:20.513951Z",
+     "shell.execute_reply": "2026-08-10T20:02:20.513462Z"
     },
     "papermill": {
-     "duration": 0.935833,
-     "end_time": "2026-08-10T19:16:27.360477+00:00",
+     "duration": 0.488736,
+     "end_time": "2026-08-10T20:02:20.514297+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:26.424644+00:00",
+     "start_time": "2026-08-10T20:02:20.025561+00:00",
      "status": "completed"
     }
    },
@@ -1161,13 +1159,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "928d2842",
+   "id": "60a3a1ce",
    "metadata": {
     "papermill": {
-     "duration": 0.002066,
-     "end_time": "2026-08-10T19:16:27.364938+00:00",
+     "duration": 0.001945,
+     "end_time": "2026-08-10T20:02:20.518338+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:27.362872+00:00",
+     "start_time": "2026-08-10T20:02:20.516393+00:00",
      "status": "completed"
     }
    },
@@ -1214,19 +1212,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "c97ad6e8",
+   "id": "add90051",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:27.370235Z",
-     "iopub.status.busy": "2026-08-10T19:16:27.370120Z",
-     "iopub.status.idle": "2026-08-10T19:16:28.231093Z",
-     "shell.execute_reply": "2026-08-10T19:16:28.230451Z"
+     "iopub.execute_input": "2026-08-10T20:02:20.522658Z",
+     "iopub.status.busy": "2026-08-10T20:02:20.522584Z",
+     "iopub.status.idle": "2026-08-10T20:02:21.111536Z",
+     "shell.execute_reply": "2026-08-10T20:02:21.111217Z"
     },
     "papermill": {
-     "duration": 0.864584,
-     "end_time": "2026-08-10T19:16:28.231650+00:00",
+     "duration": 0.591842,
+     "end_time": "2026-08-10T20:02:21.112080+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:27.367066+00:00",
+     "start_time": "2026-08-10T20:02:20.520238+00:00",
      "status": "completed"
     }
    },
@@ -1293,13 +1291,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "397f603a",
+   "id": "a70c43ab",
    "metadata": {
     "papermill": {
-     "duration": 0.004949,
-     "end_time": "2026-08-10T19:16:28.241298+00:00",
+     "duration": 0.002127,
+     "end_time": "2026-08-10T20:02:21.116335+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:28.236349+00:00",
+     "start_time": "2026-08-10T20:02:21.114208+00:00",
      "status": "completed"
     }
    },
@@ -1317,19 +1315,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "38fca81c",
+   "id": "0aca8e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:28.253691Z",
-     "iopub.status.busy": "2026-08-10T19:16:28.253403Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.195706Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.195046Z"
+     "iopub.execute_input": "2026-08-10T20:02:21.120810Z",
+     "iopub.status.busy": "2026-08-10T20:02:21.120716Z",
+     "iopub.status.idle": "2026-08-10T20:02:21.707007Z",
+     "shell.execute_reply": "2026-08-10T20:02:21.706644Z"
     },
     "papermill": {
-     "duration": 0.949833,
-     "end_time": "2026-08-10T19:16:29.196087+00:00",
+     "duration": 0.589149,
+     "end_time": "2026-08-10T20:02:21.707403+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:28.246254+00:00",
+     "start_time": "2026-08-10T20:02:21.118254+00:00",
      "status": "completed"
     }
    },
@@ -1377,13 +1375,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74fe1889",
+   "id": "753265b6",
    "metadata": {
     "papermill": {
-     "duration": 0.002251,
-     "end_time": "2026-08-10T19:16:29.200728+00:00",
+     "duration": 0.002037,
+     "end_time": "2026-08-10T20:02:21.711704+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.198477+00:00",
+     "start_time": "2026-08-10T20:02:21.709667+00:00",
      "status": "completed"
     }
    },
@@ -1407,19 +1405,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "363c91ad",
+   "id": "737b1053",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.206770Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.206589Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.259703Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.258844Z"
+     "iopub.execute_input": "2026-08-10T20:02:21.716180Z",
+     "iopub.status.busy": "2026-08-10T20:02:21.716094Z",
+     "iopub.status.idle": "2026-08-10T20:02:21.755015Z",
+     "shell.execute_reply": "2026-08-10T20:02:21.754657Z"
     },
     "papermill": {
-     "duration": 0.057454,
-     "end_time": "2026-08-10T19:16:29.260448+00:00",
+     "duration": 0.042031,
+     "end_time": "2026-08-10T20:02:21.755702+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.202994+00:00",
+     "start_time": "2026-08-10T20:02:21.713671+00:00",
      "status": "completed"
     }
    },
@@ -1433,19 +1431,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f00dbff0",
+   "id": "b6a9db3c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.267169Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.266969Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.344098Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.343557Z"
+     "iopub.execute_input": "2026-08-10T20:02:21.761581Z",
+     "iopub.status.busy": "2026-08-10T20:02:21.761482Z",
+     "iopub.status.idle": "2026-08-10T20:02:21.825250Z",
+     "shell.execute_reply": "2026-08-10T20:02:21.824896Z"
     },
     "papermill": {
-     "duration": 0.081169,
-     "end_time": "2026-08-10T19:16:29.344397+00:00",
+     "duration": 0.067542,
+     "end_time": "2026-08-10T20:02:21.825602+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.263228+00:00",
+     "start_time": "2026-08-10T20:02:21.758060+00:00",
      "status": "completed"
     }
    },
@@ -1517,13 +1515,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3751cf7d",
+   "id": "2488f813",
    "metadata": {
     "papermill": {
-     "duration": 0.00237,
-     "end_time": "2026-08-10T19:16:29.349304+00:00",
+     "duration": 0.002117,
+     "end_time": "2026-08-10T20:02:21.830022+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.346934+00:00",
+     "start_time": "2026-08-10T20:02:21.827905+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1544,13 +1542,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "804c358b",
+   "id": "bee58084",
    "metadata": {
     "papermill": {
-     "duration": 0.00252,
-     "end_time": "2026-08-10T19:16:29.354737+00:00",
+     "duration": 0.002025,
+     "end_time": "2026-08-10T20:02:21.834099+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.352217+00:00",
+     "start_time": "2026-08-10T20:02:21.832074+00:00",
      "status": "completed"
     }
    },
@@ -1578,19 +1576,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "96cc7983",
+   "id": "4f2b3389",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.360499Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.360321Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.484110Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.483648Z"
+     "iopub.execute_input": "2026-08-10T20:02:21.839006Z",
+     "iopub.status.busy": "2026-08-10T20:02:21.838898Z",
+     "iopub.status.idle": "2026-08-10T20:02:21.941812Z",
+     "shell.execute_reply": "2026-08-10T20:02:21.941170Z"
     },
     "papermill": {
-     "duration": 0.12738,
-     "end_time": "2026-08-10T19:16:29.484455+00:00",
+     "duration": 0.106007,
+     "end_time": "2026-08-10T20:02:21.942138+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.357075+00:00",
+     "start_time": "2026-08-10T20:02:21.836131+00:00",
      "status": "completed"
     }
    },
@@ -1633,13 +1631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db3cf617",
+   "id": "b9e7e6a9",
    "metadata": {
     "papermill": {
-     "duration": 0.002853,
-     "end_time": "2026-08-10T19:16:29.490547+00:00",
+     "duration": 0.00232,
+     "end_time": "2026-08-10T20:02:21.947031+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.487694+00:00",
+     "start_time": "2026-08-10T20:02:21.944711+00:00",
      "status": "completed"
     }
    },
@@ -1665,19 +1663,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "428af5c5",
+   "id": "13b5463c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.496910Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.496672Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.638545Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.638051Z"
+     "iopub.execute_input": "2026-08-10T20:02:21.952202Z",
+     "iopub.status.busy": "2026-08-10T20:02:21.952121Z",
+     "iopub.status.idle": "2026-08-10T20:02:22.055516Z",
+     "shell.execute_reply": "2026-08-10T20:02:22.054976Z"
     },
     "papermill": {
-     "duration": 0.145808,
-     "end_time": "2026-08-10T19:16:29.638997+00:00",
+     "duration": 0.106541,
+     "end_time": "2026-08-10T20:02:22.055833+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.493189+00:00",
+     "start_time": "2026-08-10T20:02:21.949292+00:00",
      "status": "completed"
     }
    },
@@ -1718,13 +1716,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "393bdfb8",
+   "id": "873e6a3b",
    "metadata": {
     "papermill": {
-     "duration": 0.002977,
-     "end_time": "2026-08-10T19:16:29.645220+00:00",
+     "duration": 0.002475,
+     "end_time": "2026-08-10T20:02:22.061019+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.642243+00:00",
+     "start_time": "2026-08-10T20:02:22.058544+00:00",
      "status": "completed"
     }
    },
@@ -1748,19 +1746,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "fbdb867e",
+   "id": "14095342",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.652305Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.652113Z",
-     "iopub.status.idle": "2026-08-10T19:16:29.975341Z",
-     "shell.execute_reply": "2026-08-10T19:16:29.974765Z"
+     "iopub.execute_input": "2026-08-10T20:02:22.066755Z",
+     "iopub.status.busy": "2026-08-10T20:02:22.066622Z",
+     "iopub.status.idle": "2026-08-10T20:02:22.335892Z",
+     "shell.execute_reply": "2026-08-10T20:02:22.335447Z"
     },
     "papermill": {
-     "duration": 0.327731,
-     "end_time": "2026-08-10T19:16:29.975826+00:00",
+     "duration": 0.272902,
+     "end_time": "2026-08-10T20:02:22.336333+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.648095+00:00",
+     "start_time": "2026-08-10T20:02:22.063431+00:00",
      "status": "completed"
     }
    },
@@ -1807,13 +1805,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60b5e0d4",
+   "id": "83fd3c9a",
    "metadata": {
     "papermill": {
-     "duration": 0.002826,
-     "end_time": "2026-08-10T19:16:29.982049+00:00",
+     "duration": 0.003424,
+     "end_time": "2026-08-10T20:02:22.345045+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.979223+00:00",
+     "start_time": "2026-08-10T20:02:22.341621+00:00",
      "status": "completed"
     }
    },
@@ -1831,19 +1829,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "e904c903",
+   "id": "89c47a90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:29.988786Z",
-     "iopub.status.busy": "2026-08-10T19:16:29.988674Z",
-     "iopub.status.idle": "2026-08-10T19:16:30.089535Z",
-     "shell.execute_reply": "2026-08-10T19:16:30.088944Z"
+     "iopub.execute_input": "2026-08-10T20:02:22.350669Z",
+     "iopub.status.busy": "2026-08-10T20:02:22.350586Z",
+     "iopub.status.idle": "2026-08-10T20:02:22.428167Z",
+     "shell.execute_reply": "2026-08-10T20:02:22.427678Z"
     },
     "papermill": {
-     "duration": 0.104973,
-     "end_time": "2026-08-10T19:16:30.090047+00:00",
+     "duration": 0.081073,
+     "end_time": "2026-08-10T20:02:22.428667+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:29.985074+00:00",
+     "start_time": "2026-08-10T20:02:22.347594+00:00",
      "status": "completed"
     }
    },
@@ -1884,13 +1882,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92d6c7fe",
+   "id": "bb4b3f4a",
    "metadata": {
     "papermill": {
-     "duration": 0.006243,
-     "end_time": "2026-08-10T19:16:30.100687+00:00",
+     "duration": 0.002904,
+     "end_time": "2026-08-10T20:02:22.436068+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:30.094444+00:00",
+     "start_time": "2026-08-10T20:02:22.433164+00:00",
      "status": "completed"
     }
    },
@@ -1910,19 +1908,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "161e221d",
+   "id": "a6c631d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:30.109811Z",
-     "iopub.status.busy": "2026-08-10T19:16:30.109637Z",
-     "iopub.status.idle": "2026-08-10T19:16:30.760339Z",
-     "shell.execute_reply": "2026-08-10T19:16:30.759836Z"
+     "iopub.execute_input": "2026-08-10T20:02:22.442292Z",
+     "iopub.status.busy": "2026-08-10T20:02:22.442204Z",
+     "iopub.status.idle": "2026-08-10T20:02:23.019793Z",
+     "shell.execute_reply": "2026-08-10T20:02:23.019423Z"
     },
     "papermill": {
-     "duration": 0.655309,
-     "end_time": "2026-08-10T19:16:30.760752+00:00",
+     "duration": 0.581488,
+     "end_time": "2026-08-10T20:02:23.020402+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:30.105443+00:00",
+     "start_time": "2026-08-10T20:02:22.438914+00:00",
      "status": "completed"
     }
    },
@@ -1968,13 +1966,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15d8185d",
+   "id": "d01d93b1",
    "metadata": {
     "papermill": {
-     "duration": 0.003649,
-     "end_time": "2026-08-10T19:16:30.768201+00:00",
+     "duration": 0.003157,
+     "end_time": "2026-08-10T20:02:23.026903+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:30.764552+00:00",
+     "start_time": "2026-08-10T20:02:23.023746+00:00",
      "status": "completed"
     }
    },
@@ -1998,19 +1996,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "13a4469b",
+   "id": "e26fdd56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:30.776317Z",
-     "iopub.status.busy": "2026-08-10T19:16:30.776163Z",
-     "iopub.status.idle": "2026-08-10T19:16:32.364885Z",
-     "shell.execute_reply": "2026-08-10T19:16:32.364436Z"
+     "iopub.execute_input": "2026-08-10T20:02:23.033856Z",
+     "iopub.status.busy": "2026-08-10T20:02:23.033772Z",
+     "iopub.status.idle": "2026-08-10T20:02:24.324841Z",
+     "shell.execute_reply": "2026-08-10T20:02:24.324530Z"
     },
     "papermill": {
-     "duration": 1.593587,
-     "end_time": "2026-08-10T19:16:32.365160+00:00",
+     "duration": 1.295296,
+     "end_time": "2026-08-10T20:02:24.325341+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:30.771573+00:00",
+     "start_time": "2026-08-10T20:02:23.030045+00:00",
      "status": "completed"
     }
    },
@@ -2069,13 +2067,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1403b26d",
+   "id": "d6cbb490",
    "metadata": {
     "papermill": {
-     "duration": 0.003728,
-     "end_time": "2026-08-10T19:16:32.373204+00:00",
+     "duration": 0.003528,
+     "end_time": "2026-08-10T20:02:24.332584+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:32.369476+00:00",
+     "start_time": "2026-08-10T20:02:24.329056+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2090,19 +2088,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "ea29db31",
+   "id": "77fe5a14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:32.381887Z",
-     "iopub.status.busy": "2026-08-10T19:16:32.381750Z",
-     "iopub.status.idle": "2026-08-10T19:16:32.384315Z",
-     "shell.execute_reply": "2026-08-10T19:16:32.383796Z"
+     "iopub.execute_input": "2026-08-10T20:02:24.340217Z",
+     "iopub.status.busy": "2026-08-10T20:02:24.340116Z",
+     "iopub.status.idle": "2026-08-10T20:02:24.342149Z",
+     "shell.execute_reply": "2026-08-10T20:02:24.341756Z"
     },
     "papermill": {
-     "duration": 0.007446,
-     "end_time": "2026-08-10T19:16:32.384598+00:00",
+     "duration": 0.006787,
+     "end_time": "2026-08-10T20:02:24.342742+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:32.377152+00:00",
+     "start_time": "2026-08-10T20:02:24.335955+00:00",
      "status": "completed"
     }
    },
@@ -2121,13 +2119,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afa8df27",
+   "id": "47d9fe2a",
    "metadata": {
     "papermill": {
-     "duration": 0.004015,
-     "end_time": "2026-08-10T19:16:32.392768+00:00",
+     "duration": 0.003262,
+     "end_time": "2026-08-10T20:02:24.350395+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:32.388753+00:00",
+     "start_time": "2026-08-10T20:02:24.347133+00:00",
      "status": "completed"
     }
    },
@@ -2154,19 +2152,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "e1ff94ff",
+   "id": "cdeb44b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:32.400857Z",
-     "iopub.status.busy": "2026-08-10T19:16:32.400742Z",
-     "iopub.status.idle": "2026-08-10T19:16:32.600688Z",
-     "shell.execute_reply": "2026-08-10T19:16:32.600200Z"
+     "iopub.execute_input": "2026-08-10T20:02:24.357733Z",
+     "iopub.status.busy": "2026-08-10T20:02:24.357636Z",
+     "iopub.status.idle": "2026-08-10T20:02:24.532076Z",
+     "shell.execute_reply": "2026-08-10T20:02:24.531509Z"
     },
     "papermill": {
-     "duration": 0.204801,
-     "end_time": "2026-08-10T19:16:32.601210+00:00",
+     "duration": 0.178915,
+     "end_time": "2026-08-10T20:02:24.532550+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:32.396409+00:00",
+     "start_time": "2026-08-10T20:02:24.353635+00:00",
      "status": "completed"
     }
    },
@@ -2199,13 +2197,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52d1e298",
+   "id": "31960849",
    "metadata": {
     "papermill": {
-     "duration": 0.007509,
-     "end_time": "2026-08-10T19:16:32.614067+00:00",
+     "duration": 0.00588,
+     "end_time": "2026-08-10T20:02:24.545450+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:32.606558+00:00",
+     "start_time": "2026-08-10T20:02:24.539570+00:00",
      "status": "completed"
     }
    },
@@ -2276,19 +2274,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.603014,
-   "end_time": "2026-08-10T19:16:33.735200+00:00",
+   "duration": 8.33534,
+   "end_time": "2026-08-10T20:02:25.565441+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/03_financial_features.ipynb",
    "output_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/03_financial_features.ipynb",
    "parameters": {},
-   "start_time": "2026-08-10T19:16:23.132186+00:00",
+   "start_time": "2026-08-10T20:02:17.230101+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "8b30643f476c7a0a1f4f627b536bfae195c6e7d5",
-   "executed_at": "2026-08-10T19:16:39.680238+00:00",
+   "source_py_blob": "ee2b8736bce28648a95dd0f7abe019b350a5b59f",
+   "executed_at": "2026-08-10T20:02:30.457503+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/sp500_equity_option_analytics/03_financial_features.py
+++ b/case_studies/sp500_equity_option_analytics/03_financial_features.py
@@ -257,24 +257,20 @@ register_frame(FAMILIES).select(
 # off. The share-bar extract is wider than that and the loader takes a `symbols=` argument nothing
 # was passing. The keep-or-drop in Section C would have removed the surplus names from the matrix
 # anyway, so bounding here moves no emitted value; what it changes is that the universe becomes a
-# stated bound with an assertion behind it rather than a by-product of a later filter. The roster
-# is derived from the surface rather than typed out, and checked in both directions: its size
-# against the declared `n_assets`, and every roster name against the share bars. A guard that only
-# asks whether every declared name is present says nothing about a present name never declared.
+# stated bound rather than a by-product of a later filter. The roster is derived from the surface
+# rather than typed out, and every roster name is checked against the share bars.
 #
-# The roster is read off the **whole** extract rather than off the requested window, because
-# `n_assets` is a statement about the dataset: a run that narrows `START_DATE` would otherwise
-# assert against a roster missing every name that had not yet listed, and the declaration would
-# fail on a parameter this notebook documents as free to change. The dates bound the panels.
+# The roster is read off the **whole** extract rather than off the requested window, because which
+# names have listed options is a property of the dataset rather than of a run. How many that comes
+# to is reported rather than asserted: `n_assets` describes the production extract, and the reduced
+# one CI runs on carries a handful of names by design.
+# `tests/test_eoa_universe_roster.py` holds the declaration to the production data.
 
 # %%
 full_surface = load_sp500_options_surface()
 full_bars = load_sp500_daily_bars()
 ROSTER = sorted(full_surface["symbol"].unique().to_list())
-assert len(ROSTER) == setup["universe"]["n_assets"], (
-    f"{len(ROSTER)} names carry an option surface against a declared "
-    f"universe.n_assets of {setup['universe']['n_assets']}"
-)
+assert ROSTER, "the option-surface extract carries no names to rank"
 priced = set(full_bars["symbol"].unique().to_list())
 assert not set(ROSTER) - priced, f"no share bars for {sorted(set(ROSTER) - priced)}"
 outside = sorted(priced - set(ROSTER))
@@ -295,9 +291,11 @@ print(f"{daily.height:,} name-sessions of share bars, {daily['symbol'].n_unique(
 print(f"{daily[SECURITY].n_unique()} securities behind those tickers")
 print(f"{surface_raw.height:,} surface rows carrying {len(SURFACE_COLS)} columns")
 print(f"{daily['timestamp'].min()} to {daily['timestamp'].max()}")
+DECLARED = setup["universe"]["n_assets"]
 print(
-    f"{len(outside)} priced names carry no option surface and are outside the declared universe "
-    f"({', '.join(outside)})"
+    f"Universe {len(ROSTER)} names with an option surface"
+    + ("" if len(ROSTER) == DECLARED else f" (a reduced extract; n_assets declares {DECLARED})")
+    + f"; {len(outside)} priced names carry none and are excluded ({', '.join(outside)})"
 )
 
 # %%

--- a/case_studies/sp500_equity_option_analytics/04_model_based_features.ipynb
+++ b/case_studies/sp500_equity_option_analytics/04_model_based_features.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3111bdd3",
+   "id": "0e301c52",
    "metadata": {
     "papermill": {
-     "duration": 0.003516,
-     "end_time": "2026-08-10T19:16:47.542135+00:00",
+     "duration": 0.002084,
+     "end_time": "2026-08-10T20:02:32.073917+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:47.538619+00:00",
+     "start_time": "2026-08-10T20:02:32.071833+00:00",
      "status": "completed"
     }
    },
@@ -70,19 +70,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "37d62b97",
+   "id": "ad4b6148",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:47.546815Z",
-     "iopub.status.busy": "2026-08-10T19:16:47.546624Z",
-     "iopub.status.idle": "2026-08-10T19:16:50.598192Z",
-     "shell.execute_reply": "2026-08-10T19:16:50.597645Z"
+     "iopub.execute_input": "2026-08-10T20:02:32.078303Z",
+     "iopub.status.busy": "2026-08-10T20:02:32.078185Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.031888Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.031259Z"
     },
     "papermill": {
-     "duration": 3.054874,
-     "end_time": "2026-08-10T19:16:50.598883+00:00",
+     "duration": 1.956581,
+     "end_time": "2026-08-10T20:02:34.032286+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:47.544009+00:00",
+     "start_time": "2026-08-10T20:02:32.075705+00:00",
      "status": "completed"
     }
    },
@@ -113,13 +113,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "856f8ae3",
+   "id": "ea4b3fce",
    "metadata": {
     "papermill": {
-     "duration": 0.001716,
-     "end_time": "2026-08-10T19:16:50.602533+00:00",
+     "duration": 0.001653,
+     "end_time": "2026-08-10T20:02:34.035777+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.600817+00:00",
+     "start_time": "2026-08-10T20:02:34.034124+00:00",
      "status": "completed"
     }
    },
@@ -135,19 +135,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "819fbe65",
+   "id": "2d218187",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:50.607034Z",
-     "iopub.status.busy": "2026-08-10T19:16:50.606848Z",
-     "iopub.status.idle": "2026-08-10T19:16:50.609427Z",
-     "shell.execute_reply": "2026-08-10T19:16:50.608837Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.039683Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.039600Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.041586Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.041134Z"
     },
     "papermill": {
-     "duration": 0.005575,
-     "end_time": "2026-08-10T19:16:50.609947+00:00",
+     "duration": 0.00445,
+     "end_time": "2026-08-10T20:02:34.041855+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.604372+00:00",
+     "start_time": "2026-08-10T20:02:34.037405+00:00",
      "status": "completed"
     },
     "tags": [
@@ -166,19 +166,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bbc3ca08",
+   "id": "ee6aa6ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:50.616949Z",
-     "iopub.status.busy": "2026-08-10T19:16:50.616773Z",
-     "iopub.status.idle": "2026-08-10T19:16:50.619637Z",
-     "shell.execute_reply": "2026-08-10T19:16:50.619147Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.045605Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.045544Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.047492Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.047060Z"
     },
     "papermill": {
-     "duration": 0.006644,
-     "end_time": "2026-08-10T19:16:50.620064+00:00",
+     "duration": 0.004221,
+     "end_time": "2026-08-10T20:02:34.047700+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.613420+00:00",
+     "start_time": "2026-08-10T20:02:34.043479+00:00",
      "status": "completed"
     }
    },
@@ -193,13 +193,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb9f0809",
+   "id": "2934f77a",
    "metadata": {
     "papermill": {
-     "duration": 0.001729,
-     "end_time": "2026-08-10T19:16:50.623656+00:00",
+     "duration": 0.001574,
+     "end_time": "2026-08-10T20:02:34.050900+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.621927+00:00",
+     "start_time": "2026-08-10T20:02:34.049326+00:00",
      "status": "completed"
     }
    },
@@ -219,19 +219,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fd602087",
+   "id": "4dfea3a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:50.627966Z",
-     "iopub.status.busy": "2026-08-10T19:16:50.627874Z",
-     "iopub.status.idle": "2026-08-10T19:16:50.835516Z",
-     "shell.execute_reply": "2026-08-10T19:16:50.834969Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.054669Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.054611Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.210485Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.209949Z"
     },
     "papermill": {
-     "duration": 0.210773,
-     "end_time": "2026-08-10T19:16:50.836255+00:00",
+     "duration": 0.158263,
+     "end_time": "2026-08-10T20:02:34.210757+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.625482+00:00",
+     "start_time": "2026-08-10T20:02:34.052494+00:00",
      "status": "completed"
     }
    },
@@ -284,13 +284,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5adc8e00",
+   "id": "6d8d82da",
    "metadata": {
     "papermill": {
-     "duration": 0.001816,
-     "end_time": "2026-08-10T19:16:50.840048+00:00",
+     "duration": 0.001769,
+     "end_time": "2026-08-10T20:02:34.214415+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.838232+00:00",
+     "start_time": "2026-08-10T20:02:34.212646+00:00",
      "status": "completed"
     }
    },
@@ -321,13 +321,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65c2153f",
+   "id": "8e2ef1a9",
    "metadata": {
     "papermill": {
-     "duration": 0.001798,
-     "end_time": "2026-08-10T19:16:50.843648+00:00",
+     "duration": 0.001642,
+     "end_time": "2026-08-10T20:02:34.217712+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.841850+00:00",
+     "start_time": "2026-08-10T20:02:34.216070+00:00",
      "status": "completed"
     }
    },
@@ -359,19 +359,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f5501d33",
+   "id": "79d0ab4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:50.848170Z",
-     "iopub.status.busy": "2026-08-10T19:16:50.848063Z",
-     "iopub.status.idle": "2026-08-10T19:16:50.853201Z",
-     "shell.execute_reply": "2026-08-10T19:16:50.852662Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.221656Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.221577Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.225880Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.225508Z"
     },
     "papermill": {
-     "duration": 0.008071,
-     "end_time": "2026-08-10T19:16:50.853543+00:00",
+     "duration": 0.006758,
+     "end_time": "2026-08-10T20:02:34.226123+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.845472+00:00",
+     "start_time": "2026-08-10T20:02:34.219365+00:00",
      "status": "completed"
     }
    },
@@ -442,13 +442,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd5a70ee",
+   "id": "b4c0302d",
    "metadata": {
     "papermill": {
-     "duration": 0.001846,
-     "end_time": "2026-08-10T19:16:50.857459+00:00",
+     "duration": 0.001737,
+     "end_time": "2026-08-10T20:02:34.229640+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.855613+00:00",
+     "start_time": "2026-08-10T20:02:34.227903+00:00",
      "status": "completed"
     }
    },
@@ -462,19 +462,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d5bfd2e8",
+   "id": "f256c234",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:50.861934Z",
-     "iopub.status.busy": "2026-08-10T19:16:50.861790Z",
-     "iopub.status.idle": "2026-08-10T19:16:51.542686Z",
-     "shell.execute_reply": "2026-08-10T19:16:51.541986Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.233596Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.233526Z",
+     "iopub.status.idle": "2026-08-10T20:02:34.802735Z",
+     "shell.execute_reply": "2026-08-10T20:02:34.802012Z"
     },
     "papermill": {
-     "duration": 0.683904,
-     "end_time": "2026-08-10T19:16:51.543185+00:00",
+     "duration": 0.571705,
+     "end_time": "2026-08-10T20:02:34.803099+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:50.859281+00:00",
+     "start_time": "2026-08-10T20:02:34.231394+00:00",
      "status": "completed"
     }
    },
@@ -512,13 +512,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a113ecb",
+   "id": "61d793c5",
    "metadata": {
     "papermill": {
-     "duration": 0.011296,
-     "end_time": "2026-08-10T19:16:51.557180+00:00",
+     "duration": 0.001932,
+     "end_time": "2026-08-10T20:02:34.807059+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:51.545884+00:00",
+     "start_time": "2026-08-10T20:02:34.805127+00:00",
      "status": "completed"
     }
    },
@@ -534,19 +534,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "580c93d5",
+   "id": "e667ad16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:51.562014Z",
-     "iopub.status.busy": "2026-08-10T19:16:51.561911Z",
-     "iopub.status.idle": "2026-08-10T19:16:52.920593Z",
-     "shell.execute_reply": "2026-08-10T19:16:52.919974Z"
+     "iopub.execute_input": "2026-08-10T20:02:34.811169Z",
+     "iopub.status.busy": "2026-08-10T20:02:34.811100Z",
+     "iopub.status.idle": "2026-08-10T20:02:36.085822Z",
+     "shell.execute_reply": "2026-08-10T20:02:36.085189Z"
     },
     "papermill": {
-     "duration": 1.361838,
-     "end_time": "2026-08-10T19:16:52.920993+00:00",
+     "duration": 1.277351,
+     "end_time": "2026-08-10T20:02:36.086198+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:51.559155+00:00",
+     "start_time": "2026-08-10T20:02:34.808847+00:00",
      "status": "completed"
     }
    },
@@ -817,14 +817,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "951ae8fd",
+   "id": "07efb853",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002742,
-     "end_time": "2026-08-10T19:16:52.927302+00:00",
+     "duration": 0.002083,
+     "end_time": "2026-08-10T20:02:36.090541+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.924560+00:00",
+     "start_time": "2026-08-10T20:02:36.088458+00:00",
      "status": "completed"
     }
    },
@@ -893,20 +893,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d9440ed9",
+   "id": "2afe4459",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:52.932600Z",
-     "iopub.status.busy": "2026-08-10T19:16:52.932494Z",
-     "iopub.status.idle": "2026-08-10T19:16:52.936134Z",
-     "shell.execute_reply": "2026-08-10T19:16:52.935607Z"
+     "iopub.execute_input": "2026-08-10T20:02:36.095369Z",
+     "iopub.status.busy": "2026-08-10T20:02:36.095253Z",
+     "iopub.status.idle": "2026-08-10T20:02:36.099245Z",
+     "shell.execute_reply": "2026-08-10T20:02:36.098973Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006858,
-     "end_time": "2026-08-10T19:16:52.936447+00:00",
+     "duration": 0.007043,
+     "end_time": "2026-08-10T20:02:36.099641+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.929589+00:00",
+     "start_time": "2026-08-10T20:02:36.092598+00:00",
      "status": "completed"
     }
    },
@@ -946,14 +946,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0f95962",
+   "id": "00e545ad",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002291,
-     "end_time": "2026-08-10T19:16:52.940906+00:00",
+     "duration": 0.002041,
+     "end_time": "2026-08-10T20:02:36.103754+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.938615+00:00",
+     "start_time": "2026-08-10T20:02:36.101713+00:00",
      "status": "completed"
     }
    },
@@ -967,19 +967,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3b3ed5c8",
+   "id": "11b3bc2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:52.949803Z",
-     "iopub.status.busy": "2026-08-10T19:16:52.949703Z",
-     "iopub.status.idle": "2026-08-10T19:16:52.953206Z",
-     "shell.execute_reply": "2026-08-10T19:16:52.952491Z"
+     "iopub.execute_input": "2026-08-10T20:02:36.108443Z",
+     "iopub.status.busy": "2026-08-10T20:02:36.108381Z",
+     "iopub.status.idle": "2026-08-10T20:02:36.110955Z",
+     "shell.execute_reply": "2026-08-10T20:02:36.110711Z"
     },
     "papermill": {
-     "duration": 0.008632,
-     "end_time": "2026-08-10T19:16:52.953713+00:00",
+     "duration": 0.00539,
+     "end_time": "2026-08-10T20:02:36.111282+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.945081+00:00",
+     "start_time": "2026-08-10T20:02:36.105892+00:00",
      "status": "completed"
     }
    },
@@ -1024,13 +1024,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e5e8b61",
+   "id": "ede1dc29",
    "metadata": {
     "papermill": {
-     "duration": 0.002188,
-     "end_time": "2026-08-10T19:16:52.958296+00:00",
+     "duration": 0.002023,
+     "end_time": "2026-08-10T20:02:36.115397+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.956108+00:00",
+     "start_time": "2026-08-10T20:02:36.113374+00:00",
      "status": "completed"
     }
    },
@@ -1062,26 +1062,28 @@
     "argument nothing was passing, so this artifact carried a fitted conditional volatility for\n",
     "names the strategy can never hold - they have no implied volatility to rank on, so\n",
     "`garch_ivrv_spread` was null for every one of their rows while the other two columns were not.\n",
-    "The roster is derived from the surface rather than typed out, and checked in both directions:\n",
-    "its size against the declared `n_assets`, and every roster name against the share bars."
+    "The roster is derived from the surface rather than typed out, and every roster name is checked\n",
+    "against the share bars. How many names that comes to is reported rather than asserted:\n",
+    "`n_assets` describes the production extract, and the reduced one CI runs on carries a handful by\n",
+    "design. `tests/test_eoa_universe_roster.py` holds the declaration to the production data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "9e29b5d9",
+   "id": "c82aa919",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:52.963240Z",
-     "iopub.status.busy": "2026-08-10T19:16:52.963139Z",
-     "iopub.status.idle": "2026-08-10T19:16:53.755508Z",
-     "shell.execute_reply": "2026-08-10T19:16:53.755030Z"
+     "iopub.execute_input": "2026-08-10T20:02:36.120120Z",
+     "iopub.status.busy": "2026-08-10T20:02:36.120060Z",
+     "iopub.status.idle": "2026-08-10T20:02:36.786707Z",
+     "shell.execute_reply": "2026-08-10T20:02:36.786323Z"
     },
     "papermill": {
-     "duration": 0.795474,
-     "end_time": "2026-08-10T19:16:53.755943+00:00",
+     "duration": 0.669524,
+     "end_time": "2026-08-10T20:02:36.787074+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:52.960469+00:00",
+     "start_time": "2026-08-10T20:02:36.117550+00:00",
      "status": "completed"
     }
    },
@@ -1103,22 +1105,21 @@
    ],
    "source": [
     "ENTITY = \"sec_id\"\n",
-    "# The surface is loaded for its roster alone; no column of it is read here. Both extracts are\n",
-    "# read whole rather than over the requested window: `n_assets` is a statement about the dataset,\n",
-    "# so a narrowed START_DATE must not fail the declaration. The dates bound the panel below.\n",
+    "# The surface is loaded for its roster alone; no column of it is read here. Both extracts are read\n",
+    "# whole rather than over the requested window, because which names have listed options is a\n",
+    "# property of the dataset. The dates bound the panel below.\n",
     "_surface = load_sp500_options_surface()\n",
     "full_bars = load_sp500_daily_bars()\n",
     "ROSTER = sorted(_surface[\"symbol\"].unique().to_list())\n",
-    "assert len(ROSTER) == SETUP[\"universe\"][\"n_assets\"], (\n",
-    "    f\"{len(ROSTER)} names carry an option surface against a declared \"\n",
-    "    f\"universe.n_assets of {SETUP['universe']['n_assets']}\"\n",
-    ")\n",
+    "assert ROSTER, \"the option-surface extract carries no names to rank\"\n",
     "priced = set(full_bars[\"symbol\"].unique().to_list())\n",
     "assert not set(ROSTER) - priced, f\"no share bars for {sorted(set(ROSTER) - priced)}\"\n",
     "outside = sorted(priced - set(ROSTER))\n",
+    "DECLARED = SETUP[\"universe\"][\"n_assets\"]\n",
     "print(\n",
-    "    f\"Universe {len(ROSTER)} names with an option surface; {len(outside)} priced names carry none \"\n",
-    "    f\"and are excluded ({', '.join(outside)})\"\n",
+    "    f\"Universe {len(ROSTER)} names with an option surface\"\n",
+    "    + (\"\" if len(ROSTER) == DECLARED else f\" (a reduced extract; n_assets declares {DECLARED})\")\n",
+    "    + f\"; {len(outside)} priced names carry none and are excluded ({', '.join(outside)})\"\n",
     ")\n",
     "\n",
     "window = pl.col(\"timestamp\").is_between(\n",
@@ -1165,13 +1166,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e1de60d",
+   "id": "8ff33a4c",
    "metadata": {
     "papermill": {
-     "duration": 0.002458,
-     "end_time": "2026-08-10T19:16:53.761323+00:00",
+     "duration": 0.002193,
+     "end_time": "2026-08-10T20:02:36.791707+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:53.758865+00:00",
+     "start_time": "2026-08-10T20:02:36.789514+00:00",
      "status": "completed"
     }
    },
@@ -1195,19 +1196,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a3646cdb",
+   "id": "eddc60be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:53.767093Z",
-     "iopub.status.busy": "2026-08-10T19:16:53.766984Z",
-     "iopub.status.idle": "2026-08-10T19:16:54.144986Z",
-     "shell.execute_reply": "2026-08-10T19:16:54.144508Z"
+     "iopub.execute_input": "2026-08-10T20:02:36.796639Z",
+     "iopub.status.busy": "2026-08-10T20:02:36.796546Z",
+     "iopub.status.idle": "2026-08-10T20:02:37.114427Z",
+     "shell.execute_reply": "2026-08-10T20:02:37.113951Z"
     },
     "papermill": {
-     "duration": 0.381871,
-     "end_time": "2026-08-10T19:16:54.145628+00:00",
+     "duration": 0.321032,
+     "end_time": "2026-08-10T20:02:37.114873+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:53.763757+00:00",
+     "start_time": "2026-08-10T20:02:36.793841+00:00",
      "status": "completed"
     }
    },
@@ -1269,13 +1270,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05f1e418",
+   "id": "48b0f16d",
    "metadata": {
     "papermill": {
-     "duration": 0.00236,
-     "end_time": "2026-08-10T19:16:54.150526+00:00",
+     "duration": 0.002227,
+     "end_time": "2026-08-10T20:02:37.119560+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:54.148166+00:00",
+     "start_time": "2026-08-10T20:02:37.117333+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1294,19 +1295,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "dd0fa4e2",
+   "id": "33826815",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:16:54.156101Z",
-     "iopub.status.busy": "2026-08-10T19:16:54.155993Z",
-     "iopub.status.idle": "2026-08-10T19:17:12.808315Z",
-     "shell.execute_reply": "2026-08-10T19:17:12.807213Z"
+     "iopub.execute_input": "2026-08-10T20:02:37.124378Z",
+     "iopub.status.busy": "2026-08-10T20:02:37.124257Z",
+     "iopub.status.idle": "2026-08-10T20:02:51.833254Z",
+     "shell.execute_reply": "2026-08-10T20:02:51.832897Z"
     },
     "papermill": {
-     "duration": 18.655881,
-     "end_time": "2026-08-10T19:17:12.808714+00:00",
+     "duration": 14.711981,
+     "end_time": "2026-08-10T20:02:51.833685+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:16:54.152833+00:00",
+     "start_time": "2026-08-10T20:02:37.121704+00:00",
      "status": "completed"
     }
    },
@@ -1374,13 +1375,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc875c01",
+   "id": "06395f26",
    "metadata": {
     "papermill": {
-     "duration": 0.004183,
-     "end_time": "2026-08-10T19:17:12.815679+00:00",
+     "duration": 0.002274,
+     "end_time": "2026-08-10T20:02:51.838399+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:12.811496+00:00",
+     "start_time": "2026-08-10T20:02:51.836125+00:00",
      "status": "completed"
     }
    },
@@ -1414,19 +1415,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "49da6eba",
+   "id": "f3cf1005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:12.821937Z",
-     "iopub.status.busy": "2026-08-10T19:17:12.821802Z",
-     "iopub.status.idle": "2026-08-10T19:17:14.403542Z",
-     "shell.execute_reply": "2026-08-10T19:17:14.402721Z"
+     "iopub.execute_input": "2026-08-10T20:02:51.843415Z",
+     "iopub.status.busy": "2026-08-10T20:02:51.843329Z",
+     "iopub.status.idle": "2026-08-10T20:02:53.061079Z",
+     "shell.execute_reply": "2026-08-10T20:02:53.060714Z"
     },
     "papermill": {
-     "duration": 1.585347,
-     "end_time": "2026-08-10T19:17:14.403914+00:00",
+     "duration": 1.220881,
+     "end_time": "2026-08-10T20:02:53.061476+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:12.818567+00:00",
+     "start_time": "2026-08-10T20:02:51.840595+00:00",
      "status": "completed"
     }
    },
@@ -1745,19 +1746,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "fc8c5954",
+   "id": "239504e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:14.411581Z",
-     "iopub.status.busy": "2026-08-10T19:17:14.411409Z",
-     "iopub.status.idle": "2026-08-10T19:17:14.417394Z",
-     "shell.execute_reply": "2026-08-10T19:17:14.416829Z"
+     "iopub.execute_input": "2026-08-10T20:02:53.067477Z",
+     "iopub.status.busy": "2026-08-10T20:02:53.067394Z",
+     "iopub.status.idle": "2026-08-10T20:02:53.071569Z",
+     "shell.execute_reply": "2026-08-10T20:02:53.071291Z"
     },
     "papermill": {
-     "duration": 0.010571,
-     "end_time": "2026-08-10T19:17:14.417882+00:00",
+     "duration": 0.007556,
+     "end_time": "2026-08-10T20:02:53.071868+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:14.407311+00:00",
+     "start_time": "2026-08-10T20:02:53.064312+00:00",
      "status": "completed"
     }
    },
@@ -1828,13 +1829,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6304f251",
+   "id": "cad01dda",
    "metadata": {
     "papermill": {
-     "duration": 0.005365,
-     "end_time": "2026-08-10T19:17:14.428922+00:00",
+     "duration": 0.002605,
+     "end_time": "2026-08-10T20:02:53.077184+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:14.423557+00:00",
+     "start_time": "2026-08-10T20:02:53.074579+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1856,13 +1857,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85f236e5",
+   "id": "c9cbf033",
    "metadata": {
     "papermill": {
-     "duration": 0.005117,
-     "end_time": "2026-08-10T19:17:14.439487+00:00",
+     "duration": 0.00256,
+     "end_time": "2026-08-10T20:02:53.082385+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:14.434370+00:00",
+     "start_time": "2026-08-10T20:02:53.079825+00:00",
      "status": "completed"
     }
    },
@@ -1887,19 +1888,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "5e194d3a",
+   "id": "37a9aee1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:14.446445Z",
-     "iopub.status.busy": "2026-08-10T19:17:14.446321Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.224784Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.224219Z"
+     "iopub.execute_input": "2026-08-10T20:02:53.088036Z",
+     "iopub.status.busy": "2026-08-10T20:02:53.087964Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.402508Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.402060Z"
     },
     "papermill": {
-     "duration": 1.783305,
-     "end_time": "2026-08-10T19:17:16.225648+00:00",
+     "duration": 1.317834,
+     "end_time": "2026-08-10T20:02:54.402816+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:14.442343+00:00",
+     "start_time": "2026-08-10T20:02:53.084982+00:00",
      "status": "completed"
     }
    },
@@ -4115,13 +4116,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "620da820",
+   "id": "85a9b794",
    "metadata": {
     "papermill": {
-     "duration": 0.006852,
-     "end_time": "2026-08-10T19:17:16.240204+00:00",
+     "duration": 0.003383,
+     "end_time": "2026-08-10T20:02:54.409835+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.233352+00:00",
+     "start_time": "2026-08-10T20:02:54.406452+00:00",
      "status": "completed"
     }
    },
@@ -4148,19 +4149,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "9ed8de6e",
+   "id": "8f9ad553",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.255095Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.254920Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.467521Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.466613Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.417167Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.417037Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.581998Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.581567Z"
     },
     "papermill": {
-     "duration": 0.221329,
-     "end_time": "2026-08-10T19:17:16.468223+00:00",
+     "duration": 0.169443,
+     "end_time": "2026-08-10T20:02:54.582628+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.246894+00:00",
+     "start_time": "2026-08-10T20:02:54.413185+00:00",
      "status": "completed"
     }
    },
@@ -4191,13 +4192,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaa881d4",
+   "id": "bfecda56",
    "metadata": {
     "papermill": {
-     "duration": 0.004011,
-     "end_time": "2026-08-10T19:17:16.477126+00:00",
+     "duration": 0.003405,
+     "end_time": "2026-08-10T20:02:54.589660+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.473115+00:00",
+     "start_time": "2026-08-10T20:02:54.586255+00:00",
      "status": "completed"
     }
    },
@@ -4216,19 +4217,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "b280dee0",
+   "id": "bba4daec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.487132Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.486962Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.506340Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.505854Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.597019Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.596934Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.609917Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.609582Z"
     },
     "papermill": {
-     "duration": 0.025859,
-     "end_time": "2026-08-10T19:17:16.506810+00:00",
+     "duration": 0.017466,
+     "end_time": "2026-08-10T20:02:54.610461+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.480951+00:00",
+     "start_time": "2026-08-10T20:02:54.592995+00:00",
      "status": "completed"
     }
    },
@@ -4278,19 +4279,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "4ecf4836",
+   "id": "3e07da1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.519695Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.519575Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.559029Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.558538Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.621107Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.621023Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.652603Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.652282Z"
     },
     "papermill": {
-     "duration": 0.04626,
-     "end_time": "2026-08-10T19:17:16.559637+00:00",
+     "duration": 0.036129,
+     "end_time": "2026-08-10T20:02:54.653121+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.513377+00:00",
+     "start_time": "2026-08-10T20:02:54.616992+00:00",
      "status": "completed"
     }
    },
@@ -4340,13 +4341,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a24f6b7",
+   "id": "91658b62",
    "metadata": {
     "papermill": {
-     "duration": 0.007105,
-     "end_time": "2026-08-10T19:17:16.574186+00:00",
+     "duration": 0.0035,
+     "end_time": "2026-08-10T20:02:54.660523+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.567081+00:00",
+     "start_time": "2026-08-10T20:02:54.657023+00:00",
      "status": "completed"
     }
    },
@@ -4370,19 +4371,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "2c616bae",
+   "id": "2dbebfc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.585454Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.585303Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.664443Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.663777Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.667987Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.667893Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.734858Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.734224Z"
     },
     "papermill": {
-     "duration": 0.086318,
-     "end_time": "2026-08-10T19:17:16.664902+00:00",
+     "duration": 0.071171,
+     "end_time": "2026-08-10T20:02:54.735125+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.578584+00:00",
+     "start_time": "2026-08-10T20:02:54.663954+00:00",
      "status": "completed"
     }
    },
@@ -4417,13 +4418,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2616df36",
+   "id": "6fa6d461",
    "metadata": {
     "papermill": {
-     "duration": 0.005647,
-     "end_time": "2026-08-10T19:17:16.674910+00:00",
+     "duration": 0.003531,
+     "end_time": "2026-08-10T20:02:54.742454+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.669263+00:00",
+     "start_time": "2026-08-10T20:02:54.738923+00:00",
      "status": "completed"
     }
    },
@@ -4446,20 +4447,20 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "3a2416ce",
+   "id": "f43c2313",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.683862Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.683735Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.741001Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.740589Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.750018Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.749903Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.796835Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.796246Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.062625,
-     "end_time": "2026-08-10T19:17:16.741619+00:00",
+     "duration": 0.051401,
+     "end_time": "2026-08-10T20:02:54.797327+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.678994+00:00",
+     "start_time": "2026-08-10T20:02:54.745926+00:00",
      "status": "completed"
     }
    },
@@ -4493,19 +4494,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "885b859f",
+   "id": "934ae4fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.752408Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.752219Z",
-     "iopub.status.idle": "2026-08-10T19:17:16.825775Z",
-     "shell.execute_reply": "2026-08-10T19:17:16.825151Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.805868Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.805736Z",
+     "iopub.status.idle": "2026-08-10T20:02:54.867406Z",
+     "shell.execute_reply": "2026-08-10T20:02:54.867076Z"
     },
     "papermill": {
-     "duration": 0.078802,
-     "end_time": "2026-08-10T19:17:16.826128+00:00",
+     "duration": 0.06652,
+     "end_time": "2026-08-10T20:02:54.868184+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.747326+00:00",
+     "start_time": "2026-08-10T20:02:54.801664+00:00",
      "status": "completed"
     }
    },
@@ -4597,13 +4598,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0868ee7",
+   "id": "e385839b",
    "metadata": {
     "papermill": {
-     "duration": 0.003828,
-     "end_time": "2026-08-10T19:17:16.834113+00:00",
+     "duration": 0.003559,
+     "end_time": "2026-08-10T20:02:54.876707+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.830285+00:00",
+     "start_time": "2026-08-10T20:02:54.873148+00:00",
      "status": "completed"
     }
    },
@@ -4621,19 +4622,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "9d95b891",
+   "id": "d3adce90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:16.842635Z",
-     "iopub.status.busy": "2026-08-10T19:17:16.842486Z",
-     "iopub.status.idle": "2026-08-10T19:17:18.877197Z",
-     "shell.execute_reply": "2026-08-10T19:17:18.876665Z"
+     "iopub.execute_input": "2026-08-10T20:02:54.884693Z",
+     "iopub.status.busy": "2026-08-10T20:02:54.884560Z",
+     "iopub.status.idle": "2026-08-10T20:02:56.148001Z",
+     "shell.execute_reply": "2026-08-10T20:02:56.147634Z"
     },
     "papermill": {
-     "duration": 2.040026,
-     "end_time": "2026-08-10T19:17:18.877903+00:00",
+     "duration": 1.268038,
+     "end_time": "2026-08-10T20:02:56.148343+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:16.837877+00:00",
+     "start_time": "2026-08-10T20:02:54.880305+00:00",
      "status": "completed"
     }
    },
@@ -4831,13 +4832,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06ead6cf",
+   "id": "c9bd2c1e",
    "metadata": {
     "papermill": {
-     "duration": 0.004622,
-     "end_time": "2026-08-10T19:17:18.887516+00:00",
+     "duration": 0.004214,
+     "end_time": "2026-08-10T20:02:56.156883+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:18.882894+00:00",
+     "start_time": "2026-08-10T20:02:56.152669+00:00",
      "status": "completed"
     }
    },
@@ -4863,19 +4864,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "f38e1a04",
+   "id": "20ae95fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:18.902523Z",
-     "iopub.status.busy": "2026-08-10T19:17:18.902318Z",
-     "iopub.status.idle": "2026-08-10T19:17:18.976019Z",
-     "shell.execute_reply": "2026-08-10T19:17:18.975481Z"
+     "iopub.execute_input": "2026-08-10T20:02:56.165369Z",
+     "iopub.status.busy": "2026-08-10T20:02:56.165259Z",
+     "iopub.status.idle": "2026-08-10T20:02:56.212754Z",
+     "shell.execute_reply": "2026-08-10T20:02:56.212261Z"
     },
     "papermill": {
-     "duration": 0.081918,
-     "end_time": "2026-08-10T19:17:18.976664+00:00",
+     "duration": 0.052425,
+     "end_time": "2026-08-10T20:02:56.213194+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:18.894746+00:00",
+     "start_time": "2026-08-10T20:02:56.160769+00:00",
      "status": "completed"
     }
    },
@@ -4939,19 +4940,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "f0f586a4",
+   "id": "cf69b290",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:17:18.992186Z",
-     "iopub.status.busy": "2026-08-10T19:17:18.992050Z",
-     "iopub.status.idle": "2026-08-10T19:17:20.384688Z",
-     "shell.execute_reply": "2026-08-10T19:17:20.384153Z"
+     "iopub.execute_input": "2026-08-10T20:02:56.221889Z",
+     "iopub.status.busy": "2026-08-10T20:02:56.221758Z",
+     "iopub.status.idle": "2026-08-10T20:02:57.481325Z",
+     "shell.execute_reply": "2026-08-10T20:02:57.480778Z"
     },
     "papermill": {
-     "duration": 1.401345,
-     "end_time": "2026-08-10T19:17:20.384994+00:00",
+     "duration": 1.264287,
+     "end_time": "2026-08-10T20:02:57.481617+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:18.983649+00:00",
+     "start_time": "2026-08-10T20:02:56.217330+00:00",
      "status": "completed"
     }
    },
@@ -5150,13 +5151,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d41b9bc",
+   "id": "9652a50a",
    "metadata": {
     "papermill": {
-     "duration": 0.004923,
-     "end_time": "2026-08-10T19:17:20.394927+00:00",
+     "duration": 0.004275,
+     "end_time": "2026-08-10T20:02:57.490441+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:20.390004+00:00",
+     "start_time": "2026-08-10T20:02:57.486166+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5177,13 +5178,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bf537f4",
+   "id": "2a425503",
    "metadata": {
     "papermill": {
-     "duration": 0.004735,
-     "end_time": "2026-08-10T19:17:20.404457+00:00",
+     "duration": 0.004239,
+     "end_time": "2026-08-10T20:02:57.499160+00:00",
      "exception": false,
-     "start_time": "2026-08-10T19:17:20.399722+00:00",
+     "start_time": "2026-08-10T20:02:57.494921+00:00",
      "status": "completed"
     }
    },
@@ -5261,19 +5262,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 34.751741,
-   "end_time": "2026-08-10T19:17:21.625587+00:00",
+   "duration": 27.08527,
+   "end_time": "2026-08-10T20:02:58.519318+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/04_model_based_features.ipynb",
    "output_path": "~/ml4t/public-eoa/case_studies/sp500_equity_option_analytics/04_model_based_features.ipynb",
    "parameters": {},
-   "start_time": "2026-08-10T19:16:46.873846+00:00",
+   "start_time": "2026-08-10T20:02:31.434048+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "91e7c17f38349c8485d9c802fa8f06128390c22c",
-   "executed_at": "2026-08-10T19:17:27.467537+00:00",
+   "source_py_blob": "9b5c9a54d352d3869c6a3b5706925b03ac49e7cc",
+   "executed_at": "2026-08-10T20:03:03.448090+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/sp500_equity_option_analytics/04_model_based_features.py
+++ b/case_studies/sp500_equity_option_analytics/04_model_based_features.py
@@ -479,27 +479,28 @@ def fit_and_filter(returns: pd.Series, row: dict) -> tuple[pd.Series, dict] | No
 # argument nothing was passing, so this artifact carried a fitted conditional volatility for
 # names the strategy can never hold - they have no implied volatility to rank on, so
 # `garch_ivrv_spread` was null for every one of their rows while the other two columns were not.
-# The roster is derived from the surface rather than typed out, and checked in both directions:
-# its size against the declared `n_assets`, and every roster name against the share bars.
+# The roster is derived from the surface rather than typed out, and every roster name is checked
+# against the share bars. How many names that comes to is reported rather than asserted:
+# `n_assets` describes the production extract, and the reduced one CI runs on carries a handful by
+# design. `tests/test_eoa_universe_roster.py` holds the declaration to the production data.
 
 # %%
 ENTITY = "sec_id"
-# The surface is loaded for its roster alone; no column of it is read here. Both extracts are
-# read whole rather than over the requested window: `n_assets` is a statement about the dataset,
-# so a narrowed START_DATE must not fail the declaration. The dates bound the panel below.
+# The surface is loaded for its roster alone; no column of it is read here. Both extracts are read
+# whole rather than over the requested window, because which names have listed options is a
+# property of the dataset. The dates bound the panel below.
 _surface = load_sp500_options_surface()
 full_bars = load_sp500_daily_bars()
 ROSTER = sorted(_surface["symbol"].unique().to_list())
-assert len(ROSTER) == SETUP["universe"]["n_assets"], (
-    f"{len(ROSTER)} names carry an option surface against a declared "
-    f"universe.n_assets of {SETUP['universe']['n_assets']}"
-)
+assert ROSTER, "the option-surface extract carries no names to rank"
 priced = set(full_bars["symbol"].unique().to_list())
 assert not set(ROSTER) - priced, f"no share bars for {sorted(set(ROSTER) - priced)}"
 outside = sorted(priced - set(ROSTER))
+DECLARED = SETUP["universe"]["n_assets"]
 print(
-    f"Universe {len(ROSTER)} names with an option surface; {len(outside)} priced names carry none "
-    f"and are excluded ({', '.join(outside)})"
+    f"Universe {len(ROSTER)} names with an option surface"
+    + ("" if len(ROSTER) == DECLARED else f" (a reduced extract; n_assets declares {DECLARED})")
+    + f"; {len(outside)} priced names carry none and are excluded ({', '.join(outside)})"
 )
 
 window = pl.col("timestamp").is_between(

--- a/tests/test_eoa_universe_roster.py
+++ b/tests/test_eoa_universe_roster.py
@@ -11,6 +11,12 @@ did, at different times:
   declaration fail on any run that narrows `START_DATE` - a documented parameter that
   `tests/overrides.yaml` is allowed to set. It passes at the full window, which is why it
   survived a re-run and was caught only by review.
+
+The count itself is checked **here and not in the notebooks**. `universe.n_assets` describes the
+production extract; the reduced one CI runs the pipeline against carries 23 names by design, so an
+assertion on the count inside a notebook fails there for being small rather than for being wrong -
+which is exactly what it did, taking three notebooks red. A declaration about the dataset belongs
+in a test over the dataset, and this file skips when that dataset is absent.
 """
 
 import ast


### PR DESCRIPTION
Reverses a regression #515 introduced, and reports what was already red.

## The regression

#515 bound `sp500_equity_option_analytics` stages 02, 03 and 04 to the 633-name universe
`setup.yaml` declares - the right fix, and the artifacts it moved stand. It also asserted the
count inside each notebook:

```python
assert len(ROSTER) == setup["universe"]["n_assets"]
```

CI runs the pipeline against a reduced extract carrying 23 names, so all three failed at their
first cell with `23 names carry an option surface against a declared universe.n_assets of 633`.
The assertion fired for the extract being small, not for anything being wrong.

`n_assets` describes the production dataset, so it is checked over the production dataset.
`tests/test_eoa_universe_roster.py` already asserts it and skips when that data is absent. The
notebooks now assert only what holds on any extract - the roster is non-empty, every roster name
has share bars - and report the count, naming the reduced case when the two disagree. **The
universe bound itself is unchanged**, which was the correctness fix.

Verified against the fixture rather than reasoned about: `02` and `03` now pass
`test_case_study_pipeline` on the reduced extract, where they failed before.

On production nothing computes differently. One line of wording moves in `02` and `03`, `04` is
byte-identical, and all seven artifacts validate unchanged.

## Two failures older than #515, not addressed here

Both are defects in `ml4t/third-edition-test-data`, which this repo cannot change, and both were
already failing on `f325e98e` before this case study was touched.

**`04` - the fixture gives three companies one `sec_id`.** The notebook asserts that one security
trades under one ticker on one session, because every window it takes is bounded by `sec_id`. In
the fixture `sec_id = 0` covers AMZN, GOOG and GOOGL:

| `sec_id` | tickers | rows |
|---|---|---|
| 0 | AMZN, GOOG, GOOGL | 3,777 |

That is the only duplicate in the extract, and production carries none. The assertion is right and
the fixture is wrong - as it stands, every GARCH fit in CI would pool Amazon's price series with
Alphabet's. `sec_id = 0` reads like a null sentinel three symbols fell into.

**`01` - the fixture is smaller than the diagnostic's floor.** The persistence measurement needs a
pair of decision dates sharing 20 securities; the fixture holds 21 distinct `sec_id` values in
total, and fewer than that on any pair of dates once surface coverage is applied.

`17_risk_management` also fails, on `Paired uncertainty failed for stop_loss_5pct`. That is stage
17 and outside this sweep.

## Verification

- `tests/test_eoa_universe_roster.py`: 10 passed against production data.
- `test_case_study_pipeline` for `02` and `03` on the reduced fixture: 2 passed.
- `validate_artifact.py`: OK on all seven files against their sidecars, digests unchanged.
- `ruff`, `check_notebook_prose.py`, the notebook-pair and provenance gates, and the roborev
  pre-push gate: pass.
