### PR TITLE
Lock Docker environments to stable ML4T releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -235,7 +235,6 @@ jobs:
           import torch; print(f'torch {torch.__version__}')
           import kaleido, importlib.metadata; print(f'kaleido {importlib.metadata.version(\"kaleido\")}')
           import causalimpact; print('pycausalimpact OK')
-          import pfhedge; print(f'pfhedge {pfhedge.__version__}')
           print('ALL PY312 IMPORTS OK')
           "
           docker run --rm ${{ env.PY312_IMAGE }}:latest /opt/bsts/bin/python -c "

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@
 #
 # Images published:
 #   ml4t/ml4t:latest            — Main (Python 3.14, PyTorch CUDA 12.8)
-#   ml4t/ml4t-py312:latest      — Python 3.12 (signatory/esig/gensim/pfhedge/tfcausalimpact)
+#   ml4t/ml4t-py312:latest      — Python 3.12 (signatory/esig/gensim/tfcausalimpact)
 #   ml4t/ml4t-benchmark:latest  — Storage benchmarks (DuckDB, HDF5, DB clients)
 
 name: Docker Publish

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -127,7 +127,7 @@ jobs:
             --timeout=600
 
   # ---------------------------------------------------------------------------
-  # Py312 notebooks (signatory, gensim, esig, pfhedge, tfcausalimpact, torch CUDA bug)
+  # Py312 notebooks (signatory, gensim, esig, tfcausalimpact, torch CUDA bug)
   # ---------------------------------------------------------------------------
   py312:
     if: github.event.inputs.scope == 'all'

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -159,8 +159,7 @@ jobs:
                 or 01_word2vec or 02_asset_embeddings or 03_sentiment_evolution \
                 or 01_timegan or 07_dp_gan \
                 or 10_shap_nlp_sentiment or 06_conditional_autoencoder \
-                or 06_fed_announcement_bsts \
-                or deep_hedging_pfhedge"
+                or 06_fed_announcement_bsts"
 
   # ---------------------------------------------------------------------------
   # Summary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -807,8 +807,7 @@ jobs:
                 or 01_word2vec or 02_asset_embeddings or 03_sentiment_evolution \
                 or 01_timegan or 07_dp_gan \
                 or 10_shap_nlp_sentiment or 06_conditional_autoencoder \
-                or 06_fed_announcement_bsts \
-                or deep_hedging_pfhedge"
+                or 06_fed_announcement_bsts"
 
   # ---------------------------------------------------------------------------
   # Neo4j Docker service (Ch23 Knowledge Graphs)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,8 +265,7 @@ jobs:
              || [[ "${{ steps.filter.outputs.ch08-09 }}" == "true" ]] \
              || [[ "${{ steps.filter.outputs.ch10 }}" == "true" ]] \
              || [[ "${{ steps.filter.outputs.ch14-15 }}" == "true" ]] \
-             || [[ "${{ steps.filter.outputs.docker-notebooks }}" == "true" ]] \
-             || [[ "${{ steps.filter.outputs.ch21 }}" == "true" ]]; then
+             || [[ "${{ steps.filter.outputs.docker-notebooks }}" == "true" ]]; then
             run_py312="true"
           fi
           echo "run_py312=$run_py312" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -757,8 +757,8 @@ jobs:
             -k "$FILTER"
 
   # ---------------------------------------------------------------------------
-  # Py312 Docker image (Python 3.12: gensim, signatory, esig, pfhedge,
-  # tfcausalimpact, plus notebooks affected by the Py3.14 torch CUDA bug)
+  # Py312 Docker image (Python 3.12: gensim, signatory, esig, tfcausalimpact,
+  # plus notebooks affected by the Py3.14 torch CUDA bug)
   # ---------------------------------------------------------------------------
   test-py312:
     timeout-minutes: 45

--- a/25_live_trading/13_runtime_safety_showcase.ipynb
+++ b/25_live_trading/13_runtime_safety_showcase.ipynb
@@ -44,7 +44,7 @@
     "- Use the `ml4t-live` CLI to inspect the persisted state file out of process.\n",
     "\n",
     "**Prerequisites**\n",
-    "- `ml4t-live >= 0.1.0b1` installed (`uv sync` from repo root).\n",
+    "- `ml4t-live >= 0.1.0` installed (`uv sync` from repo root).\n",
     "- Read §25.7 for the operational framing; `10_safety_risk_demo` for the configurable surface.\n",
     "- No broker credentials, no exchange access — every demo runs against a synthetic broker."
    ]
@@ -1427,12 +1427,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "ee274ed6462517b4eb350f47d13a88e09e70e5d5",
    "executed_at": "2026-07-23T14:49:10.568013+00:00",
    "executor": "local-uv-py314-cpu",
-   "production": true,
+   "notes": "isolated temporary state and journals; residue-free cleanup",
    "parameters": {},
-   "notes": "isolated temporary state and journals; residue-free cleanup"
+   "production": true,
+   "source_py_blob": "ee274ed6462517b4eb350f47d13a88e09e70e5d5"
   },
   "papermill": {
    "default_parameters": {},

--- a/25_live_trading/13_runtime_safety_showcase.py
+++ b/25_live_trading/13_runtime_safety_showcase.py
@@ -45,7 +45,7 @@
 # - Use the `ml4t-live` CLI to inspect the persisted state file out of process.
 #
 # **Prerequisites**
-# - `ml4t-live >= 0.1.0b1` installed (`uv sync` from repo root).
+# - `ml4t-live >= 0.1.0` installed (`uv sync` from repo root).
 # - Read §25.7 for the operational framing; `10_safety_risk_demo` for the configurable surface.
 # - No broker credentials, no exchange access — every demo runs against a synthetic broker.
 

--- a/25_live_trading/README.md
+++ b/25_live_trading/README.md
@@ -122,7 +122,7 @@ loaded from `.env`):
 
 Key libraries:
 - `ml4t-backtest` — backtest engine and strategy base class
-- `ml4t-live` (>=0.1.0b1) — live engine, `SafeBroker` with enforced position/order/daily-loss caps, persisted `RiskState`, startup reconciliation, `VirtualPortfolio` for shadow mode, and the `ml4t-live` CLI (`status`, `shadow`)
+- `ml4t-live` (>=0.1.0) - live engine, `SafeBroker` with enforced position/order/daily-loss caps, persisted `RiskState`, startup reconciliation, `VirtualPortfolio` for shadow mode, and the `ml4t-live` CLI (`status`, `shadow`)
 - `alpaca-py` — Alpaca broker integration
 - `ib_async` — Interactive Brokers connection
 - `python-okx` — OKX exchange SDK (used by NB09)

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ preamble. Full details in the **[Docker environments guide](envs/README.md)**.
 |--------------|------------------------------------------------------------------|-------------------------|
 | `ml4t`       | All 27 chapters + 9 case studies (CPU)                           | Default for everything  |
 | `ml4t-gpu`   | Same `ml4t` image, run with the NVIDIA runtime (`--profile gpu`) | Deep-learning chapters  |
-| `ml4t-py312` | Python 3.12 for signatory, esig, gensim, pfhedge, tfcausalimpact | ~10 notebooks           |
+| `ml4t-py312` | Python 3.12 for signatory, esig, gensim, tfcausalimpact           | ~10 notebooks           |
 | `benchmark`  | Database clients (TimescaleDB, ClickHouse, QuestDB, InfluxDB)    | Ch02 storage benchmarks |
 | `rapids`     | RAPIDS cuML + LightGBM CUDA (build locally)                      | One Ch12 GPU benchmark  |
 

--- a/data/futures/market/futures_specs.yaml
+++ b/data/futures/market/futures_specs.yaml
@@ -16,7 +16,7 @@
 # initial_margin_pct / maintenance_margin_pct:
 #   Per-product percentage-of-notional initial and maintenance margin,
 #   wired through ContractSpec.margin_pct -> Broker.margin_pct_schedule
-#   (ml4t-backtest >= 0.1.0b18). The dollar margin tracks price changes
+#   (ml4t-backtest >= 0.1.3). The dollar margin tracks price changes
 #   naturally while the rate stays constant; only the rate needs to be
 #   re-anchored when CME publishes a new SPAN schedule.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@
 #
 # WHICH IMAGE DO I NEED?
 #   Most readers: ml4t only (covers Ch01-Ch27 + case studies)
-#   Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06, Ch15 NB06, Ch21 deep_hedging:
+#   Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06, Ch15 NB06:
 #       ml4t-py312 (amd64; on Apple Silicon read the committed .ipynb outputs, or run it
 #       under Rosetta with DOCKER_DEFAULT_PLATFORM=linux/amd64)
 #   Ch02 storage benchmarks: benchmark + database services
@@ -220,10 +220,11 @@ services:
 
   # ============================================
   # PY312 (Python 3.12, x86 Only)
-  # For packages without Python 3.14 support: gensim, signatory, esig, pfhedge,
+  # For packages without Python 3.14 support: gensim, signatory, esig,
   # tfcausalimpact, plus notebooks hitting the Python 3.14 torch CUDA import bug.
   # Covers: Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06,
-  # Ch15 NB06, Ch21 deep_hedging.
+  # Ch15 NB06. Ch21 deep hedging is NOT here: pfhedge is a main dependency and
+  # 0.22.0 works on Python 3.14, so that notebook runs in the default image.
   # Start with: docker compose --profile py312 run --rm py312 python ...
   # This service reserves no GPU, so it starts on macOS and on any machine
   # without NVIDIA. Use the py312-gpu service below where a GPU is available.
@@ -243,9 +244,9 @@ services:
     container_name: ml4t-py312
     profiles: ["py312"]
 
-  # Same image with an NVIDIA GPU attached, for the seven GPU-tagged py312 notebooks
-  # (Ch05 NB01/03/07, Ch10 NB03, Ch12 NB10, Ch14 NB06, Ch21 deep_hedging), whether they
-  # train or run inference. Linux and Windows WSL2 only, exactly like ml4t-gpu.
+  # Same image with an NVIDIA GPU attached, for the six GPU-tagged py312 notebooks
+  # (Ch05 NB01/03/07, Ch10 NB03, Ch12 NB10, Ch14 NB06), whether they train or run
+  # inference. Linux and Windows WSL2 only, exactly like ml4t-gpu.
   # Start with: docker compose --profile py312-gpu run --rm py312-gpu python ...
   py312-gpu:
     <<: *common

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,7 +133,7 @@ does not work on Intel Macs or in native Windows Python.
 | Image | What it covers | Platforms |
 |-------|----------------|-----------|
 | **ml4t** | All chapters (Ch01-Ch27) + all 9 case studies | amd64 + arm64 |
-| **ml4t-py312** | Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06, Ch15 NB06, Ch21 deep_hedging (signatory, esig, gensim, pfhedge, tfcausalimpact) | amd64 only |
+| **ml4t-py312** | Ch05 NB01/03/07, Ch09 NB06/12, Ch10 NB01-03, Ch12 NB10, Ch14 NB06, Ch15 NB06 (signatory, esig, gensim, tfcausalimpact) | amd64 only |
 | **benchmark** | Ch02 storage benchmarks (DuckDB, HDF5, database clients) | amd64 + arm64 |
 | **rapids** | Ch12 GBM GPU benchmark (RAPIDS cuML, LightGBM CUDA) | amd64 + NVIDIA GPU |
 
@@ -436,7 +436,6 @@ A small number of notebooks require Python 3.12 libraries not available on Pytho
 | `10_shap_nlp_sentiment` | torch CUDA bug + shap | Ch12 |
 | `06_conditional_autoencoder` | torch CUDA bug + shap | Ch14 |
 | `06_fed_announcement_bsts` | tfcausalimpact (TFP BSTS) | Ch15 |
-| `05_deep_hedging_pfhedge` | pfhedge (unmaintained, numpy<2) | Ch21 |
 
 ```bash
 # On x86 (Linux, Windows WSL2, Intel Mac) run these as they stand. On Apple Silicon
@@ -446,7 +445,7 @@ docker compose --profile py312 run --rm py312 python 09_model_based_features/06_
 docker compose --profile py312 run --rm py312 \
   /opt/bsts/bin/python 15_causal_estimation/06_fed_announcement_bsts.py
 
-# The seven GPU-tagged notebooks, on a machine with an NVIDIA GPU:
+# The six GPU-tagged notebooks, on a machine with an NVIDIA GPU:
 docker compose --profile py312-gpu run --rm py312-gpu \
   python 05_synthetic_data/03_sigcwgan_signatures.py
 ```
@@ -454,13 +453,11 @@ docker compose --profile py312-gpu run --rm py312-gpu \
 Chapter 15 notebook 06 uses the isolated `/opt/bsts` interpreter so its NumPy 1 and
 pandas 2.2 constraints do not replace dependencies required by the other py312 notebooks.
 
-The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. Seven of the
-twelve are GPU-tagged and run faster with one, whether they train or only do inference: Ch05
-`01_timegan`,
-`03_sigcwgan_signatures` and `07_dp_gan`, Ch10 `03_sentiment_evolution`, Ch12
-`10_shap_nlp_sentiment`, Ch14 `06_conditional_autoencoder` and Ch21
-`05_deep_hedging_pfhedge`. The `py312-gpu` service is the same image with an NVIDIA GPU
-attached, for those.
+The `py312` service reserves no GPU, so it runs anywhere the amd64 image does. Six of the
+eleven are GPU-tagged and run faster with one, whether they train or only do inference: Ch05
+`01_timegan`, `03_sigcwgan_signatures` and `07_dp_gan`, Ch10 `03_sentiment_evolution`, Ch12
+`10_shap_nlp_sentiment` and Ch14 `06_conditional_autoencoder`. The `py312-gpu` service is the
+same image with an NVIDIA GPU attached, for those.
 
 **Apple Silicon**: these notebooks have no arm64 build and all of them ship pre-executed, so
 reading the `.ipynb` in Jupyter or on GitHub is the intended route, and the local `uv` path
@@ -657,7 +654,6 @@ A few notebooks require Docker because their dependencies have no Python 3.14 wh
 | Ch12 `10_shap_nlp_sentiment` | torch CUDA bug on 3.14 + shap | py312 |
 | Ch14 `06_conditional_autoencoder` | torch CUDA bug on 3.14 + shap | py312 |
 | Ch15 `06_fed_announcement_bsts` | tfcausalimpact requires Python 3.12 | py312 |
-| Ch21 `05_deep_hedging_pfhedge` | pfhedge requires numpy<2 | py312 |
 | Ch02 `21_storage_benchmark_database` | requires database services | benchmark |
 
 For these, use `docker compose` with the appropriate profile even if your main workflow is local.

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -40,7 +40,6 @@ subset requires a non-default profile such as `py312`, `benchmark`, or `rapids`.
 | Ch12 `10_shap_nlp_sentiment` | torch CUDA bug on 3.14 + shap | py312 |
 | Ch14 `06_conditional_autoencoder` | torch CUDA bug on 3.14 + shap | py312 |
 | Ch15 `06_fed_announcement_bsts` | tfcausalimpact (TFP BSTS, isolated `/opt/bsts/bin/python`) | py312 |
-| Ch21 `05_deep_hedging_pfhedge` | pfhedge (unmaintained, numpy<2) | py312 |
 | Ch02 `21_storage_benchmark_database` | requires benchmark image + database services | benchmark |
 | Ch12 `02_gbm_comparison` (GPU section) | RAPIDS cuML, LightGBM CUDA | rapids |
 

--- a/envs/README.md
+++ b/envs/README.md
@@ -37,7 +37,6 @@ For notebooks requiring libraries without Python 3.14 wheels:
 | Ch09 `06_path_signatures`, `12_wasserstein_regimes` | signatory, esig |
 | Ch10 `01_word2vec`, `02_asset_embeddings`, `03_sentiment_evolution` | gensim |
 | Ch15 `06_fed_announcement_bsts` | tfcausalimpact (TFP BSTS) |
-| Ch21 `05_deep_hedging_pfhedge` | pfhedge |
 
 ```bash
 docker compose --profile py312 pull py312
@@ -123,7 +122,7 @@ docker compose run --rm ml4t python envs/test_all_imports.py --chapter 15 --verb
 | Image | Packages | ML4T Libs | Utils Modules | Chapters |
 |-------|----------|-----------|---------------|----------|
 | **ml4t** | 50 third-party | 6 (data, engineer, models, diagnostic, backtest, live) | 22 (4 repo + 18 case study) | Ch01-Ch26 |
-| **py312** | 5 (signatory, esig, gensim, pfhedge, tfcausalimpact) | 1 (diagnostic) | — | Ch05, Ch09, Ch10, Ch12, Ch14, Ch15, Ch21 |
+| **py312** | 4 (signatory, esig, gensim, tfcausalimpact) | 1 (diagnostic) | — | Ch05, Ch09, Ch10, Ch12, Ch14, Ch15 |
 | **benchmark** | 5 (duckdb, tables, DB clients) | 0 | — | Ch02 |
 
 The test groups packages by chapter, so failures map directly to which notebooks are affected. Exit code is 0 (all pass) or 1 (failures). py312-only packages are shown as informational when running the ml4t test.

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -135,11 +135,10 @@ RUN sed -i '/"lightgbm/d; /"torch>=/d' /build/pyproject.toml
 # --constraint pins every package to its uv.lock version (reproducible, no drift).
 # --override keeps the preinstalled cu128 torch stack (excluded from the constraint).
 # Force cvxpy>=1.5 for numpy 2.x C API compat (riskfolio-lib pins 1.4).
-# --prerelease=if-necessary-or-explicit allows the explicitly-pinned pre-only builds
-# (e.g. the ml4t libs) while otherwise preferring the stable versions in the lock.
+# Allow prereleases only when no stable release satisfies the constraints.
 RUN echo 'cvxpy>=1.5' >> /tmp/ml4t-constraints.txt && \
     uv pip install --python /opt/ml4t/bin/python --no-cache \
-    --prerelease=if-necessary-or-explicit \
+    --prerelease=if-necessary \
     --constraint /tmp/locked-constraints.txt \
     --override /tmp/ml4t-constraints.txt '/build[live]'
 

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -64,14 +64,14 @@ RUN /opt/ml4t/bin/pip freeze | grep -E '^(torch|torchaudio|torchvision)==' > /tm
 
 # Pre-install the ml4t libraries so they land in their own cached layer. Exact
 # versions are enforced by the uv.lock-derived constraint applied to the resolve
-# step below, so this only needs the lower bounds (--pre allows the pre-only builds).
-RUN /opt/ml4t/bin/pip install --no-cache-dir --pre \
-    "ml4t-data>=0.1.0b15" \
-    "ml4t-diagnostic>=0.1.0b25" \
-    "ml4t-engineer>=0.1.0b8" \
-    "ml4t-live>=0.1.0b3" \
-    "ml4t-backtest>=0.1.0b16" \
-    "ml4t-models>=0.1.0a1"
+# step below, so this only needs the lower bounds.
+RUN /opt/ml4t/bin/pip install --no-cache-dir \
+    "ml4t-data>=0.1.2" \
+    "ml4t-diagnostic>=0.1.1" \
+    "ml4t-engineer>=0.1.3" \
+    "ml4t-live>=0.1.0" \
+    "ml4t-backtest>=0.1.3" \
+    "ml4t-models>=0.1.2"
 
 # amd64 only: Install CUDA toolkit (nvcc + headers) for building LightGBM with CUDA
 # Minimal install: nvcc-12.6 + runtime dev headers (12.4 not packaged for Ubuntu 24.04)

--- a/envs/py312/Dockerfile
+++ b/envs/py312/Dockerfile
@@ -42,12 +42,53 @@ RUN /opt/ml4t/bin/pip install --no-cache-dir pip setuptools wheel
 
 WORKDIR /build
 COPY envs/py312/pyproject.toml /build/
-RUN uv pip install --python /opt/ml4t/bin/python --no-cache /build
+COPY pyproject.toml uv.lock /build/root/
 
-# x86-only signature stack (signatory + esig) for Ch05/Ch09 notebooks
+# Derive a fully-pinned constraint from uv.lock so this image reproduces the
+# locked environment readers get from `uv sync`, the same way envs/ml4t and
+# envs/benchmark do. Without it this image free-resolved and drifted off the
+# lock: the published image carries numpy 2.4.6 where the lock pins 2.3.5,
+# pyarrow 25.0.0 where the lock pins 23.0.1, polars 1.42.1 for 1.41.1, plotly
+# 6.9.0 for 6.7.0, and an ml4t-diagnostic older than the one in the lock. A
+# reader on the container path and a reader on `uv sync` were running different
+# libraries.
+#
+# Packages this image deliberately holds away from the lock, and only these:
+# - kaleido: capped <1.0 here because 1.x needs a Chrome runtime this image does
+#   not carry (fig.write_image is wrapped in try/except for that reason). Same
+#   exemption, same reason, as envs/benchmark/Dockerfile.
+# - pfhedge: the lock pins 0.22.0, whose metadata is Requires-Python <3.12, so it
+#   cannot install here at all; 0.23.0 is the first release that allows 3.12.
+#   0.23.0 in turn declares numpy>=1.26,<2.0, which no constrained resolve can
+#   satisfy alongside arviz (numpy>=2.0). It is installed --no-deps below.
+# Only packages the lock knows about are pinned; this image's 3.12-only extras
+# (gensim, signatory, esig, pyrecombine, roughpy) are absent from the lock and
+# resolve freely.
+RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
+      | grep -iE '^[a-z0-9._-]+==' \
+      | grep -viE '^(kaleido|pfhedge)==' \
+      > /tmp/locked-constraints.txt && \
+    test -s /tmp/locked-constraints.txt
+RUN uv pip install --python /opt/ml4t/bin/python --no-cache \
+    --constraint /tmp/locked-constraints.txt /build
+
+# x86-only signature stack (signatory + esig) for Ch05/Ch09 notebooks.
+# numpy carries the constraint too, or this step would immediately undo the
+# pinning above - it is what pulled numpy to 2.4.6 in the published image.
 RUN /opt/ml4t/bin/pip install --no-cache-dir --no-build-isolation "signatory>=1.2" && \
     /opt/ml4t/bin/pip install --no-cache-dir --no-deps "esig>=1.0" && \
-    /opt/ml4t/bin/pip install --no-cache-dir "numpy>=2,<2.5" "pyrecombine>=1.0" "roughpy>=0.2"
+    /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
+        "numpy>=2,<2.5" "pyrecombine>=1.0" "roughpy>=0.2"
+
+# pfhedge (Ch21 deep hedging): --no-deps because its declared numpy>=1.26,<2.0 is
+# unsatisfiable next to arviz, and because the published image has always ended up
+# running it on numpy 2.x anyway - the old free-resolving `numpy>=2,<2.5` step
+# above overrode the bound after the fact. Verified against numpy 2.4.6 in
+# ml4t/ml4t-py312:latest and 2.3.5 here: BrownianStock/EuropeanOption simulate and
+# payoff both work. torch and tqdm, its only other dependencies, come from
+# pyproject.toml above.
+RUN /opt/ml4t/bin/pip install --no-cache-dir --no-deps "pfhedge>=0.23" && \
+    /opt/ml4t/bin/python -c "import pfhedge, numpy; print('pfhedge', pfhedge.__version__, 'numpy', numpy.__version__)"
 
 # tfcausalimpact requires pandas<=2.2 and NumPy 1.x, while the signature stack
 # above requires NumPy 2.x. Keep both valid dependency sets in isolated
@@ -61,7 +102,7 @@ RUN uv pip install --python /opt/bsts/bin/python --no-cache /build/bsts && \
 COPY envs/py312/kernels/bsts-quiet/kernel.json /opt/bsts/share/jupyter/kernels/bsts-quiet/kernel.json
 
 # Test infrastructure — pytest + helpers so CI doesn't need runtime pip install
-RUN /opt/ml4t/bin/pip install --no-cache-dir \
+RUN /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
     "pytest>=8.0" "pytest-timeout>=2.3"
 
 WORKDIR /app

--- a/envs/py312/Dockerfile
+++ b/envs/py312/Dockerfile
@@ -87,8 +87,12 @@ RUN /opt/ml4t/bin/pip install --no-cache-dir --no-build-isolation "signatory>=1.
 # ml4t/ml4t-py312:latest and 2.3.5 here: BrownianStock/EuropeanOption simulate and
 # payoff both work. torch and tqdm, its only other dependencies, come from
 # pyproject.toml above.
-RUN /opt/ml4t/bin/pip install --no-cache-dir --no-deps "pfhedge>=0.23" && \
-    /opt/ml4t/bin/python -c "import pfhedge, numpy; print('pfhedge', pfhedge.__version__, 'numpy', numpy.__version__)"
+# The version is pinned exactly rather than floated: uv.lock cannot carry it (the
+# lock's 0.22.0 does not install on 3.12) and --no-deps means a later release
+# could add a dependency that is then silently missing. 0.23.0 is also currently
+# the newest release; pfhedge is unmaintained.
+RUN /opt/ml4t/bin/pip install --no-cache-dir --no-deps "pfhedge==0.23.0" && \
+    /opt/ml4t/bin/python -c "import pfhedge; assert pfhedge.__version__ == '0.23.0', pfhedge.__version__; import numpy; print('pfhedge', pfhedge.__version__, 'numpy', numpy.__version__)"
 
 # tfcausalimpact requires pandas<=2.2 and NumPy 1.x, while the signature stack
 # above requires NumPy 2.x. Keep both valid dependency sets in isolated

--- a/envs/py312/Dockerfile
+++ b/envs/py312/Dockerfile
@@ -1,5 +1,5 @@
 # ML4T Python 3.12 Environment (x86 only)
-# For packages without Python 3.14 support: gensim, signatory, esig, pfhedge, pycausalimpact
+# For packages without Python 3.14 support: gensim, signatory, esig, pycausalimpact
 # Also covers notebooks hitting Python 3.14 torch CUDA import bug
 #
 # Covers:
@@ -14,7 +14,10 @@
 #   Ch12 NB10 (shap_nlp_sentiment)   — torch CUDA + shap
 #   Ch14 NB06 (conditional_autoencoder) — torch CUDA + shap
 #   Ch15 NB06 (fed_announcement_bsts) - tfcausalimpact in isolated /opt/bsts
-#   Ch21 deep_hedging_pfhedge        — pfhedge (unmaintained, numpy<2)
+#
+# Ch21 deep_hedging_pfhedge is NOT here: pfhedge is a main dependency and 0.22.0
+# imports and prices on Python 3.14 under numpy 2.3.5, so that notebook runs in
+# the default image and declares `ml4t-gpu`.
 #
 # Usage:
 #   docker compose --profile py312 run --rm py312 python 10_text_feature_engineering/01_word2vec_training.py
@@ -53,20 +56,16 @@ COPY pyproject.toml uv.lock /build/root/
 # reader on the container path and a reader on `uv sync` were running different
 # libraries.
 #
-# Packages this image deliberately holds away from the lock, and only these:
-# - kaleido: capped <1.0 here because 1.x needs a Chrome runtime this image does
-#   not carry (fig.write_image is wrapped in try/except for that reason). Same
-#   exemption, same reason, as envs/benchmark/Dockerfile.
-# - pfhedge: the lock pins 0.22.0, whose metadata is Requires-Python <3.12, so it
-#   cannot install here at all; 0.23.0 is the first release that allows 3.12.
-#   0.23.0 in turn declares numpy>=1.26,<2.0, which no constrained resolve can
-#   satisfy alongside arviz (numpy>=2.0). It is installed --no-deps below.
+# One package is held away from the lock: kaleido, capped <1.0 here because 1.x
+# needs a Chrome runtime this image does not carry (fig.write_image is wrapped in
+# try/except for that reason). Same exemption, same reason, as
+# envs/benchmark/Dockerfile.
 # Only packages the lock knows about are pinned; this image's 3.12-only extras
 # (gensim, signatory, esig, pyrecombine, roughpy) are absent from the lock and
 # resolve freely.
 RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
       | grep -iE '^[a-z0-9._-]+==' \
-      | grep -viE '^(kaleido|pfhedge)==' \
+      | grep -viE '^kaleido==' \
       > /tmp/locked-constraints.txt && \
     test -s /tmp/locked-constraints.txt
 RUN uv pip install --python /opt/ml4t/bin/python --no-cache \
@@ -79,20 +78,6 @@ RUN /opt/ml4t/bin/pip install --no-cache-dir --no-build-isolation "signatory>=1.
     /opt/ml4t/bin/pip install --no-cache-dir --no-deps "esig>=1.0" && \
     /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
         "numpy>=2,<2.5" "pyrecombine>=1.0" "roughpy>=0.2"
-
-# pfhedge (Ch21 deep hedging): --no-deps because its declared numpy>=1.26,<2.0 is
-# unsatisfiable next to arviz, and because the published image has always ended up
-# running it on numpy 2.x anyway - the old free-resolving `numpy>=2,<2.5` step
-# above overrode the bound after the fact. Verified against numpy 2.4.6 in
-# ml4t/ml4t-py312:latest and 2.3.5 here: BrownianStock/EuropeanOption simulate and
-# payoff both work. torch and tqdm, its only other dependencies, come from
-# pyproject.toml above.
-# The version is pinned exactly rather than floated: uv.lock cannot carry it (the
-# lock's 0.22.0 does not install on 3.12) and --no-deps means a later release
-# could add a dependency that is then silently missing. 0.23.0 is also currently
-# the newest release; pfhedge is unmaintained.
-RUN /opt/ml4t/bin/pip install --no-cache-dir --no-deps "pfhedge==0.23.0" && \
-    /opt/ml4t/bin/python -c "import pfhedge; assert pfhedge.__version__ == '0.23.0', pfhedge.__version__; import numpy; print('pfhedge', pfhedge.__version__, 'numpy', numpy.__version__)"
 
 # tfcausalimpact requires pandas<=2.2 and NumPy 1.x, while the signature stack
 # above requires NumPy 2.x. Keep both valid dependency sets in isolated

--- a/envs/py312/pyproject.toml
+++ b/envs/py312/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "opacus>=1.4",
     # pfhedge is deliberately absent: it is a main dependency of the project and
     # 0.22.0 works on Python 3.14, so Ch21 deep hedging runs in the default image.
-    "ml4t-diagnostic>=0.1.0b25",
+    "ml4t-diagnostic>=0.1.1",
     # Bayesian (arviz/pymc for uncertainty features, pycausalimpact for ARIMA event studies)
     "arviz>=0.18,<1.0",
     "pymc>=5.14",

--- a/envs/py312/pyproject.toml
+++ b/envs/py312/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     "lightgbm>=4.3",
     "shap>=0.45",
     "opacus>=1.4",
-    "pfhedge>=0.23",
+    # pfhedge is installed --no-deps in the Dockerfile: its declared
+    # numpy>=1.26,<2.0 cannot be satisfied alongside arviz under the uv.lock
+    # constraint, and the image has always run it on numpy 2.x regardless.
     "ml4t-diagnostic>=0.1.0b25",
     # Bayesian (arviz/pymc for uncertainty features, pycausalimpact for ARIMA event studies)
     "arviz>=0.18,<1.0",

--- a/envs/py312/pyproject.toml
+++ b/envs/py312/pyproject.toml
@@ -24,9 +24,8 @@ dependencies = [
     "lightgbm>=4.3",
     "shap>=0.45",
     "opacus>=1.4",
-    # pfhedge is installed --no-deps in the Dockerfile: its declared
-    # numpy>=1.26,<2.0 cannot be satisfied alongside arviz under the uv.lock
-    # constraint, and the image has always run it on numpy 2.x regardless.
+    # pfhedge is deliberately absent: it is a main dependency of the project and
+    # 0.22.0 works on Python 3.14, so Ch21 deep hedging runs in the default image.
     "ml4t-diagnostic>=0.1.0b25",
     # Bayesian (arviz/pymc for uncertainty features, pycausalimpact for ARIMA event studies)
     "arviz>=0.18,<1.0",

--- a/envs/py312/pyproject.toml
+++ b/envs/py312/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ml4t-py312"
 version = "3.0.0"
-description = "ML4T 3rd Edition - Python 3.12 image for packages without 3.14 wheels (gensim, signatory, esig, pfhedge, pycausalimpact)"
+description = "ML4T 3rd Edition - Python 3.12 image for packages without 3.14 wheels (gensim, signatory, esig, pycausalimpact)"
 requires-python = ">=3.12,<3.13"
 license = { text = "MIT" }
 

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -74,12 +74,11 @@ RUN pip install --no-cache-dir -c /tmp/locked-constraints.txt \
     "catboost>=1.2" \
     "psutil>=5.9" \
     "jupyterlab>=4.1" \
-    "ml4t-data>=0.1.0b15" \
-    "ml4t-diagnostic>=0.1.0b25" \
-    "ml4t-engineer>=0.1.0b2" \
+    "ml4t-data>=0.1.2" \
+    "ml4t-diagnostic>=0.1.1" \
+    "ml4t-engineer>=0.1.3" \
     "pytest>=8.0" \
-    "pyyaml>=6.0" \
-    --pre && \
+    "pyyaml>=6.0" && \
     python -c "import cudf, cuml; print('cudf', cudf.__version__, 'cuml', cuml.__version__)"
 
 # XGBoost: already included in RAPIDS with GPU support — verify

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -43,16 +43,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # at the versions shipped by the base image. For example, cuDF 25.4 requires
 # pandas<2.2.4 and pyarrow<20, CuPy requires numpy<2.3, and cudf-polars requires
 # polars<1.26. The root lock is authoritative for packages outside that stack.
-# Capture the base versions as constraints and remove the same names from the
-# root constraints before installing the benchmark additions.
+# Stable ml4t-diagnostic requires scipy>=1.17, while this base image ships
+# scipy 1.15.2. SciPy is the one tracked package that moves to the root lock;
+# every other tracked package remains at the base version. Verify both sets.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock /build/root/
 COPY envs/rapids/base_constraints.py /build/base_constraints.py
-RUN python /build/base_constraints.py > /tmp/rapids-base-constraints.txt && \
+RUN python /build/base_constraints.py > /tmp/rapids-base-versions.txt && \
+    grep -viE '^scipy==' /tmp/rapids-base-versions.txt > /tmp/rapids-base-constraints.txt && \
     test -s /tmp/rapids-base-constraints.txt && \
     cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
       | grep -iE '^[a-z0-9._-]+==' \
       > /tmp/root-constraints.txt && \
+    grep -iE '^scipy==' /tmp/root-constraints.txt | head -1 | cut -d';' -f1 \
+      | sed 's/[[:space:]]//g' \
+      > /tmp/scipy-pin.txt && \
+    test -s /tmp/scipy-pin.txt && \
     python -c 'from pathlib import Path; import re; norm=lambda value: re.sub(r"[-_.]+", "-", value.lower()); base={norm(line.split("==", 1)[0]) for line in Path("/tmp/rapids-base-constraints.txt").read_text().splitlines()}; root=Path("/tmp/root-constraints.txt").read_text().splitlines(); Path("/tmp/locked-constraints.txt").write_text("\n".join(line for line in root if norm(line.split("==", 1)[0]) not in base) + "\n")' && \
     test -s /tmp/locked-constraints.txt && \
     grep -iE '^lightgbm==' /tmp/locked-constraints.txt | head -1 | cut -d';' -f1 | tr -d '[:space:]' \
@@ -75,8 +81,11 @@ RUN pip install --no-cache-dir \
     "pytest>=8.0" \
     "pyyaml>=6.0" && \
     python -c "import cudf, cuml; print('cudf', cudf.__version__, 'cuml', cuml.__version__)" && \
-    python /build/base_constraints.py > /tmp/rapids-final-constraints.txt && \
-    diff -u /tmp/rapids-base-constraints.txt /tmp/rapids-final-constraints.txt
+    python /build/base_constraints.py > /tmp/rapids-final-versions.txt && \
+    grep -viE '^scipy==' /tmp/rapids-final-versions.txt > /tmp/rapids-final-constraints.txt && \
+    grep -iE '^scipy==' /tmp/rapids-final-versions.txt > /tmp/scipy-final.txt && \
+    diff -u /tmp/rapids-base-constraints.txt /tmp/rapids-final-constraints.txt && \
+    diff -u /tmp/scipy-pin.txt /tmp/scipy-final.txt
 
 # XGBoost: already included in RAPIDS with GPU support — verify
 RUN python -c "import xgboost; print(f'XGBoost {xgboost.__version__}')"

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -47,8 +47,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # RAPIDS stack - cudf/cuml/rmm declare only numpy<3.0a0,>=1.23 and scipy>=1.8.0,
 # which the locked numpy 2.3.5 and scipy 1.17.1 satisfy.
 #
-# xgboost stays at the base image's conda build for the same reason, and it is
-# not pinned here: pip never resolves it, so the constraint does not reach it.
+# The constraint reaches only what pip resolves. Everything the RAPIDS conda env
+# already provides and pip never touches keeps the base image's version - about
+# 28 packages, xgboost (2.1.4 against the lock's 3.2.0) and dask, xarray, fsspec,
+# aiohttp, networkx and cuda-bindings among them. Forcing those would mean
+# installing over the conda stack cuDF and cuML are built against, which is the
+# same conflict as pandas above. Everything the benchmark actually measures is
+# pinned: numpy, scipy, scikit-learn, polars, matplotlib, lightgbm, catboost and
+# the three ml4t-* libraries all match the lock.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock /build/root/
 RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -39,35 +39,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 0.1.0b7, ml4t-diagnostic 0.1.0b2 and ml4t-engineer 0.1.0b1, all far behind the
 # lock. Nothing builds this image in CI, so that drift went unnoticed.
 #
-# pandas and pyarrow are excluded because the RAPIDS base image caps them below
-# the lock and cuDF is the reason this image exists: cudf 25.4.0 declares
-# pandas<2.2.4dev0 (base ships 2.2.3, lock pins 2.3.3) and pyarrow<20.0.0a0
-# (base ships 19.0.1, lock pins 23.0.1). Pinning either to the lock would pull
-# them out from under cuDF. Everything else in the lock is compatible with the
-# RAPIDS stack - cudf/cuml/rmm declare only numpy<3.0a0,>=1.23 and scipy>=1.8.0,
-# which the locked numpy 2.3.5 and scipy 1.17.1 satisfy.
-#
-# The constraint reaches only what pip resolves. Everything the RAPIDS conda env
-# already provides and pip never touches keeps the base image's version - about
-# 28 packages, xgboost (2.1.4 against the lock's 3.2.0) and dask, xarray, fsspec,
-# aiohttp, networkx and cuda-bindings among them. Forcing those would mean
-# installing over the conda stack cuDF and cuML are built against, which is the
-# same conflict as pandas above. Everything the benchmark actually measures is
-# pinned: numpy, scipy, scikit-learn, polars, matplotlib, lightgbm, catboost and
-# the three ml4t-* libraries all match the lock.
+# RAPIDS is a compiled environment, so its core scientific packages must remain
+# at the versions shipped by the base image. For example, cuDF 25.4 requires
+# pandas<2.2.4 and pyarrow<20, CuPy requires numpy<2.3, and cudf-polars requires
+# polars<1.26. The root lock is authoritative for packages outside that stack.
+# Capture the base versions as constraints and remove the same names from the
+# root constraints before installing the benchmark additions.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock /build/root/
-RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
+COPY envs/rapids/base_constraints.py /build/base_constraints.py
+RUN python /build/base_constraints.py > /tmp/rapids-base-constraints.txt && \
+    test -s /tmp/rapids-base-constraints.txt && \
+    cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
       | grep -iE '^[a-z0-9._-]+==' \
-      | grep -viE '^(pandas|pyarrow)==' \
-      > /tmp/locked-constraints.txt && \
+      > /tmp/root-constraints.txt && \
+    python -c 'from pathlib import Path; import re; norm=lambda value: re.sub(r"[-_.]+", "-", value.lower()); base={norm(line.split("==", 1)[0]) for line in Path("/tmp/rapids-base-constraints.txt").read_text().splitlines()}; root=Path("/tmp/root-constraints.txt").read_text().splitlines(); Path("/tmp/locked-constraints.txt").write_text("\n".join(line for line in root if norm(line.split("==", 1)[0]) not in base) + "\n")' && \
     test -s /tmp/locked-constraints.txt && \
     grep -iE '^lightgbm==' /tmp/locked-constraints.txt | head -1 | cut -d';' -f1 | tr -d '[:space:]' \
       > /tmp/lightgbm-pin.txt && \
     test -s /tmp/lightgbm-pin.txt && cat /tmp/lightgbm-pin.txt
 
 # Core packages needed for the benchmark notebook
-RUN pip install --no-cache-dir -c /tmp/locked-constraints.txt \
+RUN pip install --no-cache-dir \
+    -c /tmp/rapids-base-constraints.txt \
+    -c /tmp/locked-constraints.txt \
     "polars>=1.0" \
     "matplotlib>=3.8" \
     "scikit-learn>=1.5" \
@@ -79,7 +74,9 @@ RUN pip install --no-cache-dir -c /tmp/locked-constraints.txt \
     "ml4t-engineer>=0.1.3" \
     "pytest>=8.0" \
     "pyyaml>=6.0" && \
-    python -c "import cudf, cuml; print('cudf', cudf.__version__, 'cuml', cuml.__version__)"
+    python -c "import cudf, cuml; print('cudf', cudf.__version__, 'cuml', cuml.__version__)" && \
+    python /build/base_constraints.py > /tmp/rapids-final-constraints.txt && \
+    diff -u /tmp/rapids-base-constraints.txt /tmp/rapids-final-constraints.txt
 
 # XGBoost: already included in RAPIDS with GPU support — verify
 RUN python -c "import xgboost; print(f'XGBoost {xgboost.__version__}')"

--- a/envs/rapids/Dockerfile
+++ b/envs/rapids/Dockerfile
@@ -32,8 +32,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Use the RAPIDS conda env's pip for all installs
 # RAPIDS images use conda; we install additional packages into that env
 
+# Derive a fully-pinned constraint from uv.lock so this image reproduces the
+# locked environment readers get from `uv sync`, the same way envs/ml4t and
+# envs/benchmark do. Without it this image free-resolved its ml4t-* pins from
+# open lower bounds and drifted badly: the last local build carried ml4t-data
+# 0.1.0b7, ml4t-diagnostic 0.1.0b2 and ml4t-engineer 0.1.0b1, all far behind the
+# lock. Nothing builds this image in CI, so that drift went unnoticed.
+#
+# pandas and pyarrow are excluded because the RAPIDS base image caps them below
+# the lock and cuDF is the reason this image exists: cudf 25.4.0 declares
+# pandas<2.2.4dev0 (base ships 2.2.3, lock pins 2.3.3) and pyarrow<20.0.0a0
+# (base ships 19.0.1, lock pins 23.0.1). Pinning either to the lock would pull
+# them out from under cuDF. Everything else in the lock is compatible with the
+# RAPIDS stack - cudf/cuml/rmm declare only numpy<3.0a0,>=1.23 and scipy>=1.8.0,
+# which the locked numpy 2.3.5 and scipy 1.17.1 satisfy.
+#
+# xgboost stays at the base image's conda build for the same reason, and it is
+# not pinned here: pip never resolves it, so the constraint does not reach it.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY pyproject.toml uv.lock /build/root/
+RUN cd /build/root && uv export --frozen --no-emit-project --no-hashes --format requirements-txt \
+      | grep -iE '^[a-z0-9._-]+==' \
+      | grep -viE '^(pandas|pyarrow)==' \
+      > /tmp/locked-constraints.txt && \
+    test -s /tmp/locked-constraints.txt && \
+    grep -iE '^lightgbm==' /tmp/locked-constraints.txt | head -1 | cut -d';' -f1 | tr -d '[:space:]' \
+      > /tmp/lightgbm-pin.txt && \
+    test -s /tmp/lightgbm-pin.txt && cat /tmp/lightgbm-pin.txt
+
 # Core packages needed for the benchmark notebook
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir -c /tmp/locked-constraints.txt \
     "polars>=1.0" \
     "matplotlib>=3.8" \
     "scikit-learn>=1.5" \
@@ -45,7 +73,8 @@ RUN pip install --no-cache-dir \
     "ml4t-engineer>=0.1.0b2" \
     "pytest>=8.0" \
     "pyyaml>=6.0" \
-    --pre
+    --pre && \
+    python -c "import cudf, cuml; print('cudf', cudf.__version__, 'cuml', cuml.__version__)"
 
 # XGBoost: already included in RAPIDS with GPU support — verify
 RUN python -c "import xgboost; print(f'XGBoost {xgboost.__version__}')"
@@ -53,9 +82,17 @@ RUN python -c "import xgboost; print(f'XGBoost {xgboost.__version__}')"
 # LightGBM: build from source with CUDA (mandatory, no fallback)
 # NOTE: GPU verification cannot run during build (no GPU access).
 # detect_gpu_capabilities() verifies at runtime.
+#
+# The version comes from uv.lock, never from a floating ">=4.6". A free resolve
+# takes 4.7.0, which device-links a CUDA-13-built libnccl_static.a that nvcc's
+# nvlink cannot read, and this image failed to build on 2026-08-10 with
+# "nvlink fatal: Input file libnccl_static.a:common.cu.o ABI version '8' is
+# incompatible with target ABI version '7' (target: sm_80)". envs/ml4t/Dockerfile
+# has read the version from the lock since the same drift hit it on 2026-07-27;
+# this image was left behind because nothing builds it in CI.
 RUN pip install --no-cache-dir --force-reinstall --no-deps \
     --no-binary lightgbm \
-    --config-settings=cmake.define.USE_CUDA=ON "lightgbm>=4.6" && \
+    --config-settings=cmake.define.USE_CUDA=ON "$(cat /tmp/lightgbm-pin.txt)" && \
     python -c "import lightgbm; print(f'LightGBM {lightgbm.__version__} — CUDA build installed')"
 
 # CatBoost: verify import (GPU test requires runtime GPU access)

--- a/envs/rapids/base_constraints.py
+++ b/envs/rapids/base_constraints.py
@@ -15,6 +15,7 @@ EXACT_NAMES = {
     "pandas",
     "pyarrow",
     "scikit-learn",
+    "scipy",
 }
 PREFIXES = (
     "cuda-",

--- a/envs/rapids/base_constraints.py
+++ b/envs/rapids/base_constraints.py
@@ -1,0 +1,61 @@
+"""Print exact constraints for packages owned by the RAPIDS base image."""
+
+import importlib.metadata
+import re
+
+EXACT_NAMES = {
+    "aiohttp",
+    "distributed",
+    "fsspec",
+    "llvmlite",
+    "markdown-it-py",
+    "mdit-py-plugins",
+    "networkx",
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "scikit-learn",
+}
+PREFIXES = (
+    "cuda-",
+    "cudf",
+    "cugraph",
+    "cuml",
+    "cupy",
+    "cuspatial",
+    "cuxfilter",
+    "dask",
+    "libcudf",
+    "libcugraph",
+    "libcuml",
+    "libcuspatial",
+    "libraft",
+    "librmm",
+    "numba",
+    "nx-cugraph",
+    "polars",
+    "pylib",
+    "raft",
+    "rmm",
+    "ucx",
+    "xarray",
+)
+
+
+def normalize_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value.lower())
+
+
+def main() -> None:
+    versions = {
+        normalize_name(name): distribution.version
+        for distribution in importlib.metadata.distributions()
+        if (name := distribution.metadata["Name"])
+    }
+    for name, version in sorted(versions.items()):
+        if name in EXACT_NAMES or name.startswith(PREFIXES):
+            print(f"{name}=={version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/envs/test_all_imports.py
+++ b/envs/test_all_imports.py
@@ -218,6 +218,7 @@ CHAPTER_PACKAGES = {
         "gymnasium",
         "numpy",
         "pandas",
+        "pfhedge",
         "sklearn",
         "stable_baselines3",
         "torch",
@@ -237,11 +238,12 @@ PY312_PACKAGES = {
     9: ["esig"],
     10: ["gensim"],
     15: ["causalimpact"],  # tfcausalimpact pip dist; module imports as `causalimpact`
-    21: ["pfhedge"],
+    # Ch21 is not here: pfhedge is a main dependency and works on Python 3.14, so
+    # it belongs to the ml4t image, not to the py312-only set.
 }
 
 # All py312-only package names (for skip detection in ml4t image)
-PY312_ONLY = {"esig", "gensim", "signatory", "pfhedge", "causalimpact"}
+PY312_ONLY = {"esig", "gensim", "signatory", "causalimpact"}
 
 # =========================================================================
 # Benchmark image — database clients

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,15 +50,14 @@ dependencies = [
     # ===================
     # ML4T Libraries (PyPI)
     # ===================
-    # ml4t-live is the only one still pre-release; the rest are on stable releases.
     # ml4t-data 0.1.2: HiveStorage.partitions() reports what a write committed, the anomaly
     # detectors accept a date-typed timestamp column, and get_metadata() no longer lets a
     # null in the provider block erase the timestamp an update just wrote.
     "ml4t-data>=0.1.2",
-    "ml4t-diagnostic>=0.1.0",
-    "ml4t-engineer>=0.1.2",
-    "ml4t-backtest>=0.1.1",
-    "ml4t-live>=0.1.0b3",
+    "ml4t-diagnostic>=0.1.1",
+    "ml4t-engineer>=0.1.3",
+    "ml4t-backtest>=0.1.3",
+    "ml4t-live>=0.1.0",
     # ===================
     # Deep Learning
     # ===================
@@ -184,7 +183,7 @@ dependencies = [
     "llama-index-embeddings-huggingface>=0.7.0",
     "chromadb>=1.5.5",
     "pfhedge>=0.22.0",
-    "ml4t-models>=0.1.0",
+    "ml4t-models>=0.1.2",
     "llama-index-vector-stores-chroma>=0.5.5",
     "llama-index-llms-openai>=0.7.7",
     # Ch24 Autonomous Agents (required at notebook runtime; Docker installs
@@ -250,9 +249,7 @@ dev = [
 ]
 
 [tool.uv]
-# ml4t-live has only pre-release versions on PyPI; every other ml4t-* is on a stable
-# release. Spelled "if-necessary" rather than the deprecated "if-necessary-or-explicit",
-# which makes uv print a deprecation warning on every single `uv run` a reader types.
+# Permit a pre-release only when a transitive dependency has no stable release.
 prerelease = "if-necessary"
 
 # Download CPython rather than reusing whatever the machine already has. uv reuses

--- a/tests/README.md
+++ b/tests/README.md
@@ -155,7 +155,7 @@ Each notebook is assigned to exactly one Docker environment via `docker_env` in 
 |-------------|---------------|-----------|-----------------|
 | `ml4t` | `ml4t` | ~410 | CPU, all Python packages |
 | `gpu` | `ml4t-gpu` | ~31 | NVIDIA GPU (PyTorch CUDA) |
-| `py312` | `py312` | ~10 | gensim, signatory, esig, pfhedge, tfcausalimpact (Python 3.12) |
+| `py312` | `py312` | ~10 | gensim, signatory, esig, tfcausalimpact (Python 3.12) |
 | `benchmark` | `benchmark` + database services | 2 | TimescaleDB, ClickHouse, QuestDB, InfluxDB |
 | `neo4j` | `ml4t` + Neo4j service | 7 | Neo4j graph database |
 

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -885,7 +885,6 @@
     TOTAL_TIMESTEPS: 1000
   timeout: 600
 21_rl_execution_hedging/05_deep_hedging_pfhedge:
-  docker_env: py312
   gpu: true
   parameters:
     N_EPOCHS: 2

--- a/tests/test_docker_notebooks.py
+++ b/tests/test_docker_notebooks.py
@@ -9,7 +9,7 @@ The skip flag stays in overrides.yaml so the uv-native runner still skips them.
 This file runs them in Docker where the dependencies are available.
 
 Usage:
-    # Py312 notebooks (signatory, gensim, esig, pfhedge, tfcausalimpact, torch CUDA bug)
+    # Py312 notebooks (signatory, gensim, esig, tfcausalimpact, torch CUDA bug)
     python -m pytest tests/test_docker_notebooks.py -v -k "03_sigcwgan or ..."
 
     # Neo4j notebooks

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "alpaca-py"
-version = "0.43.4"
+version = "0.43.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msgpack" },
@@ -188,9 +188,9 @@ dependencies = [
     { name = "sseclient-py" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/9d/3003f661c15b8003655c447c187aec10f0843647e5c98b391701b04ac3d8/alpaca_py-0.43.4.tar.gz", hash = "sha256:7d529b3654d4e817d9fd7ab461131c4f06a315c736b6a9e4a87d5406bb71114a", size = 97990, upload-time = "2026-04-29T08:41:48.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/9c/0d5b0565f31a6a439876cb343282c1b7353f20ff90fefb57d33f94b4e215/alpaca_py-0.43.5.tar.gz", hash = "sha256:7b09ba442cb0c6f957c2c57a30c6035456e2e670e63e383d439c639ffdbf98ba", size = 98289, upload-time = "2026-07-02T07:22:07.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d5/1f57cc03e7b5925a927cb7f8e7ee5f873e22632633778d28d5d23681c871/alpaca_py-0.43.4-py3-none-any.whl", hash = "sha256:dd49ac30e0f2a8f38550ef1f27a58e7fd8f3f3875deaa4e757443cdbd033a1b4", size = 122534, upload-time = "2026-04-29T08:41:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/02/40/83c7ef8bc3e74e73cda6308f7107fe57815dcfc808dc9cd03bd09aa22dd3/alpaca_py-0.43.5-py3-none-any.whl", hash = "sha256:0b4cac9b743851310f19f6a9aa84f57ddf95ae75b601350395746a893f54a2da", size = 122677, upload-time = "2026-07-02T07:22:08.06Z" },
 ]
 
 [[package]]
@@ -2726,15 +2726,16 @@ wheels = [
 
 [[package]]
 name = "ib-async"
-version = "2.0.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aeventkit" },
     { name = "nest-asyncio" },
+    { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/05/daa22cdd2b452c95d051dc038c2eedd7377d2e3763abbeb414c197f6034c/ib_async-2.0.1.tar.gz", hash = "sha256:331c915645f49b46fdf42c9f06bbd56d264cab0cd24535eca2476f5d212ab113", size = 86669, upload-time = "2025-06-22T16:07:33.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4d/dfc1da8224c3ffcdcd668da7283c4e5f14239a07f83ea66af99700296fc3/ib_async-2.1.0.tar.gz", hash = "sha256:6a03a87d6c06acacb0217a5bea60a8a168ecd5b5a7e86e1c73678d5b48cbc796", size = 87678, upload-time = "2025-12-08T01:42:32.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/d5/310c3642f6008b43d751811d09302c8abf490f2086ff16f280f030a2bd24/ib_async-2.0.1-py3-none-any.whl", hash = "sha256:4c0794264844a441b4ece468dda8550663eab38009b258e49c748900c6f79822", size = 86800, upload-time = "2025-06-22T16:07:31.39Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e7/8f33801788c66f15e9250957ff7f53a8000843f79af1a3ed7a96def0e96b/ib_async-2.1.0-py3-none-any.whl", hash = "sha256:f6d8b991bdbd6dd38e700c61b3dced06ebe0f14be4e5263e2ef10ba10b88d434", size = 88876, upload-time = "2025-12-08T01:42:30.883Z" },
 ]
 
 [[package]]
@@ -4330,12 +4331,12 @@ requires-dist = [
     { name = "llama-index-llms-openai", specifier = ">=0.7.7" },
     { name = "llama-index-vector-stores-chroma", specifier = ">=0.5.5" },
     { name = "matplotlib", specifier = ">=3.8" },
-    { name = "ml4t-backtest", specifier = ">=0.1.1" },
+    { name = "ml4t-backtest", specifier = ">=0.1.3" },
     { name = "ml4t-data", specifier = ">=0.1.2" },
-    { name = "ml4t-diagnostic", specifier = ">=0.1.0" },
-    { name = "ml4t-engineer", specifier = ">=0.1.2" },
-    { name = "ml4t-live", specifier = ">=0.1.0b3" },
-    { name = "ml4t-models", specifier = ">=0.1.0" },
+    { name = "ml4t-diagnostic", specifier = ">=0.1.1" },
+    { name = "ml4t-engineer", specifier = ">=0.1.3" },
+    { name = "ml4t-live", specifier = ">=0.1.0" },
+    { name = "ml4t-models", specifier = ">=0.1.2" },
     { name = "mlflow", specifier = ">=3.10.1" },
     { name = "mlflow", marker = "extra == 'mlops'", specifier = ">=2.16" },
     { name = "nbconvert", specifier = ">=7.16" },
@@ -4415,7 +4416,7 @@ dev = [{ name = "httpx", specifier = ">=0.28.1" }]
 
 [[package]]
 name = "ml4t-backtest"
-version = "0.1.1"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml4t-specs" },
@@ -4425,9 +4426,9 @@ dependencies = [
     { name = "polars" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/e7/e7fd9b2b5655f36f6b030b6f194a6d332cf88ae120a6c064faf12f547a80/ml4t_backtest-0.1.1.tar.gz", hash = "sha256:73774a51caa87db1aa8cb9e77777a13bc2a844460b32754fd40d42e75ba4bf3a", size = 446031, upload-time = "2026-08-10T01:27:59.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c9/c3655ba677c4cbacd0be14379bc3192fe83aa6bac7f99c6e636fa06c4d6c/ml4t_backtest-0.1.3.tar.gz", hash = "sha256:a3439abc6e35695b43ae9788aaa86b1d60091546fc36cbc1dad3cfa5cad70fec", size = 446153, upload-time = "2026-08-12T02:00:54.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/34/95defe7e62d72b2e23d7da9cff0813699592a2d6976177814b0ab2059452/ml4t_backtest-0.1.1-py3-none-any.whl", hash = "sha256:94891ea800c93a6ded6c12461cc0ac21187f0e0c403bd4b9062cceda6f5fd1f9", size = 222163, upload-time = "2026-08-10T01:27:57.737Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5b/7e3067c764d58e442fc5dfdc883ad74ad69f244334dd7cb7af9a509a9437/ml4t_backtest-0.1.3-py3-none-any.whl", hash = "sha256:a6d56f0a4c9f57ff2a9a83ab41e0ac2e523fd98303cdd6e87827e5ac8e666df2", size = 222165, upload-time = "2026-08-12T02:00:52.862Z" },
 ]
 
 [[package]]
@@ -4461,7 +4462,7 @@ wheels = [
 
 [[package]]
 name = "ml4t-diagnostic"
-version = "0.1.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arch" },
@@ -4479,14 +4480,14 @@ dependencies = [
     { name = "statsmodels" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/4f/d7b8593465f9c7626176966f54214773272e30a3434313c7a5262fcc147e/ml4t_diagnostic-0.1.0.tar.gz", hash = "sha256:4af7a447bdc926164df86a8c41a8175aab5d81bc33f814c7882fa33b97594989", size = 6756389, upload-time = "2026-08-08T09:43:58.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/05/7a21cf55d59e324db6fd61cde31c6a90c895ca98017118a79b60dc00c36c/ml4t_diagnostic-0.1.1.tar.gz", hash = "sha256:7d3b19f085bde922f257b1618e65a8164de3a520e517060795bf672e76531520", size = 6764208, upload-time = "2026-08-12T03:07:18.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/b0/4576b1daf034dc9ad0fdcbe97d7e4fd8fecd2f2e7a212460766c29d412df/ml4t_diagnostic-0.1.0-py3-none-any.whl", hash = "sha256:640e0eb74a62aca6ba4faaa43b041aa847b1f66f38036f9512180d9045cc642c", size = 942159, upload-time = "2026-08-08T09:43:55.988Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5e/431af33ebd103ccc7cf03627b414cb4ec88d10a855fe46252aff0540f3cf/ml4t_diagnostic-0.1.1-py3-none-any.whl", hash = "sha256:91acd1f435bce1988522a21da4ef2972daa59ae145d0290eda589b40e85261dc", size = 944114, upload-time = "2026-08-12T03:07:16.316Z" },
 ]
 
 [[package]]
 name = "ml4t-engineer"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml4t-specs" },
@@ -4494,23 +4495,19 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "polars" },
-    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "statsmodels" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/78/0d3eaf446ad6940be19fedaaae54049c398dbfe266306c5546973207e27c/ml4t_engineer-0.1.2.tar.gz", hash = "sha256:8063bcc71377c1e28c9b207a78b493e340b411b8b3e90eea182af663e322d021", size = 608867, upload-time = "2026-08-10T03:05:22.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/54/98b4fbf556eee83543babe7e62e1e6de7be23ef8490fdcb156a0dbbb43d6/ml4t_engineer-0.1.3.tar.gz", hash = "sha256:196b0a3cb1535700d3eee0e0722c3128c7db6f0630c7f741fe44229d1083cb86", size = 609060, upload-time = "2026-08-12T03:24:09.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/02/9c59efb9133338d8d3a1e4b6e89d407a48e15a587af9a592d63651e0dfa8/ml4t_engineer-0.1.2-py3-none-any.whl", hash = "sha256:6e5a30c9552edc7224fb12344169d689081fea3937bad6a9a794c3221fbf70c0", size = 386726, upload-time = "2026-08-10T03:05:20.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/bf/31e61dfd615dd10ee70f98fecf9cb684a8c531ea4119b6725bb19f84f6d5/ml4t_engineer-0.1.3-py3-none-any.whl", hash = "sha256:ddad6ae086644b92eab4368c84fa67b38690f28051edc04d1984dd1c37490044", size = 386827, upload-time = "2026-08-12T03:24:07.826Z" },
 ]
 
 [[package]]
 name = "ml4t-live"
-version = "0.1.0b3"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alpaca-py" },
@@ -4518,34 +4515,35 @@ dependencies = [
     { name = "httpx" },
     { name = "ib-async" },
     { name = "ml4t-backtest" },
+    { name = "ml4t-specs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/97/d7690ee93d779ee9fa607e81039aecfc5ed75c6b31270d55aa000a996c13/ml4t_live-0.1.0b3.tar.gz", hash = "sha256:1bd353c14cf7279c493f52fe8ace427415b3a89c382292e2f02b34fa5e3ed150", size = 4906900, upload-time = "2026-04-27T20:13:58.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/b3/a2bfb095294f78bee709dddb261d8cda81cc5584827e4d35af75a88c2b42/ml4t_live-0.1.0.tar.gz", hash = "sha256:3d527dce062441b83668df7e89b127d4db311ea5bd9d6dfaea469a3a0864a3f2", size = 109594, upload-time = "2026-08-10T19:03:37.41Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/91/8c79cd4f1e8d8b64fa99e985b7d76ce97e6b27ab7a6a39526d2d6f8242ca/ml4t_live-0.1.0b3-py3-none-any.whl", hash = "sha256:53cfed9e1d3a92dbc61e7d7cbe2a48a70e1b3f230acfb7ff061f5104caa7139d", size = 66770, upload-time = "2026-04-27T20:13:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/27/087001b44f9ef821806d120322f20bf46b4d5a8b5d66cdd58a0ab9c9a776/ml4t_live-0.1.0-py3-none-any.whl", hash = "sha256:0eb873aa1068652bdb6d12e08561c543219c4d63366b2005366bfb03ad0fb4b1", size = 127884, upload-time = "2026-08-10T19:03:35.834Z" },
 ]
 
 [[package]]
 name = "ml4t-models"
-version = "0.1.0"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/82/dab69c1ecee14a54dd7f3d9058e31d10c7178031d7d8dc3b4f04ff832354/ml4t_models-0.1.0.tar.gz", hash = "sha256:ea98567cc58a7e1a86872ae088c4ae4096630d330199f9f563529b194f893305", size = 12989592, upload-time = "2026-08-09T13:48:51.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/d5/403d9eb80e7bea0b0ea01c2d83049de2be11f7bdbbac2ff712bc01d5f633/ml4t_models-0.1.2.tar.gz", hash = "sha256:f78dfe27ac7e979fa59d355eb2c8db461d9c735bbfdc5acd67d1225cd5a2ca11", size = 12990041, upload-time = "2026-08-12T03:15:48.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/f4/55fe5268ad5e8849831e6e111b87f6b5f27ae2fa0590bea00aa37ecc1843/ml4t_models-0.1.0-py3-none-any.whl", hash = "sha256:ad804d0f7430b1ade3f5b78818e671aaba254ba7c8d3274643fcdda213ba05c5", size = 103527, upload-time = "2026-08-09T13:48:49.915Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9c/22f9b9ec3dbdc09a469f28f06882e217fdf5f16d594fbea9292e9843ba67/ml4t_models-0.1.2-py3-none-any.whl", hash = "sha256:6d18ac3106e475ef8be812732a4ba6541fb0fd0b933ac90c879a18dff9e10d63", size = 103543, upload-time = "2026-08-12T03:15:46.318Z" },
 ]
 
 [[package]]
 name = "ml4t-specs"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6b/58aacbc7ccf9239edb5f3b350b418aff543f87698852e1507892c2ce8c26/ml4t_specs-0.1.2.tar.gz", hash = "sha256:72131624220bdded7d01d9c09e4c9e6637e8e977a37be283bc7f38d4fe0b1e1a", size = 50590, upload-time = "2026-08-10T00:53:01.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/ca/aba7ea1f4e9a1da0b4f465dea03d3e4320d63db348245a2a9976096407ac/ml4t_specs-0.1.3.tar.gz", hash = "sha256:9578038af96d59cd50317e78f8781772833b308076da13ad24c0b304bb20961d", size = 50758, upload-time = "2026-08-12T02:27:14.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/97/1508cd131272885391fe17eb54865d8c2ee0a853d15bdd5cfd838b20ce44/ml4t_specs-0.1.2-py3-none-any.whl", hash = "sha256:c9e6749bc28c087f1a97494690edae94460aeffe2c223494a19c41c4915b9532", size = 33763, upload-time = "2026-08-10T00:53:00.474Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6c/0a35ee16313441a68a14d811ffa8b79eb63a013d548b6bbb50dfd208c6b1/ml4t_specs-0.1.3-py3-none-any.whl", hash = "sha256:2b9302d27746f5859b62c6748bf217ca4eae76d4842c783575c58f4880d1568f", size = 33860, upload-time = "2026-08-12T02:27:12.929Z" },
 ]
 
 [[package]]
@@ -8435,11 +8433,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

The published Docker images had drifted from `uv.lock` and still contained prerelease ML4T libraries. This PR constrains the main, Python 3.12, and RAPIDS environments while preserving the compatibility requirements of each image.

## Stable ML4T releases

| package | version |
|---|---:|
| ml4t-backtest | 0.1.3 |
| ml4t-data | 0.1.2 |
| ml4t-diagnostic | 0.1.1 |
| ml4t-engineer | 0.1.3 |
| ml4t-live | 0.1.0 |
| ml4t-models | 0.1.2 |
| ml4t-specs | 0.1.3 |

The root project requires Python `>=3.14,<3.15`, so uv does not attempt to resolve a future unsupported Python release.

## Image behavior

- `ml4t`: installs the stable packages from the lock and builds LightGBM 4.6.0 with CUDA.
- `py312`: derives constraints from the root lock. Kaleido remains below 1.0 because the image has no Chrome runtime. The signature stack and isolated tfcausalimpact environment remain available.
- `pfhedge`: stays in the default Python 3.14 image, where version 0.22.0 imports and computes successfully. The notebook and CI routing no longer send it to `py312`.
- `rapids`: snapshots the base image compiled package versions, constrains them during installation, and verifies they did not change. SciPy is the documented exception because stable ml4t-diagnostic requires 1.17 or newer; it is separately required to match the root lock. LightGBM is pinned to 4.6.0 and built with CUDA.

## Verification

- Main, py312, and RAPIDS images built locally from this branch.
- Main smoke: exact stable ML4T versions, LightGBM 4.6.0, Ridge fit, and pfhedge payoff.
- py312 smoke: signature, esig, gensim, torch, Kaleido, pycausalimpact, and isolated tfcausalimpact imports.
- RAPIDS smoke: exact ML4T and scientific versions plus cuDF, cuML, XGBoost, LightGBM, and CatBoost imports.
- 95 focused tests pass; Ruff, YAML, Actionlint, Compose validation, and pre-commit pass.
- Automated branch review passes with no findings.