### PR TITLE
Add the four missing alt texts to nasdaq100_microstructure/04

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -263,6 +263,21 @@ def git_blob(path: Path) -> str:
 ALT_FUNCS = frozenset({"show_with_alt", "show_plotly_with_alt"})
 
 
+def _alt_call_name(func: ast.expr) -> str | None:
+    """The called name for a bare ``f(...)`` or a qualified ``mod.f(...)``, else None.
+
+    Both forms occur in the corpus: ``from utils.style import show_plotly_with_alt``
+    gives the bare call, and ``import utils.style as style`` gives the qualified one.
+    Matching only ``ast.Name`` left the qualified form outside the exception, so a
+    corrected caption there was still read as a stale run.
+    """
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
 def _percent_cells(src: str) -> list[tuple[str, str, str]]:
     """(marker line, kind, body) per jupytext percent cell.
 
@@ -306,8 +321,7 @@ def _blank_alts(code: str) -> tuple[str, list[str]] | None:
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id in ALT_FUNCS
+            and _alt_call_name(node.func) in ALT_FUNCS
             and len(node.args) >= 2
             and isinstance(node.args[1], ast.Constant)
             and isinstance(node.args[1].value, str)

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -260,6 +260,108 @@ def git_blob(path: Path) -> str:
     ).stdout.strip()
 
 
+ALT_FUNCS = frozenset({"show_with_alt", "show_plotly_with_alt"})
+
+
+class _AltBlanker(ast.NodeTransformer):
+    """Replace each ``show_*_with_alt`` alt-text argument with a placeholder.
+
+    Collects the literals it replaced in source order, so the same walk answers both
+    "is this the only thing that changed" and "does the notebook's output metadata
+    still agree with the source".
+    """
+
+    def __init__(self) -> None:
+        self.alts: list[str] = []
+
+    def visit_Call(self, node: ast.Call) -> ast.Call:
+        self.generic_visit(node)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in ALT_FUNCS
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            self.alts.append(node.args[1].value)
+            node.args[1] = ast.Constant(value="<alt>")
+        return node
+
+
+def _blanked(src: str) -> tuple[str, list[str]] | None:
+    """(alt-blanked AST dump, alt literals) for *src*, or None if it does not parse."""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None
+    blanker = _AltBlanker()
+    tree = blanker.visit(tree)
+    ast.fix_missing_locations(tree)
+    # No attributes: the dump must not depend on the line numbers that a longer or
+    # shorter alt string shifts.
+    return ast.dump(tree), blanker.alts
+
+
+def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
+    """Whether the ``.py`` drifted from its stamp ONLY in alt text already in the outputs.
+
+    A stamp records the ``.py`` blob that was executed, and any edit to the ``.py``
+    moves the blob, so the gate reads a corrected figure description as a notebook
+    that needs re-executing. For alt text that is the wrong answer, and expensively
+    so: ``show_plotly_with_alt`` publishes ``metadata={..., "image/png": {"alt": alt}}``
+    and takes the image itself from ``fig._repr_mimebundle_()``, which never sees the
+    alt string. So the alt in a notebook's output metadata is a verbatim copy of the
+    source literal, and re-executing to change one cannot produce different outputs.
+    ``nasdaq100_microstructure/04`` is 90 minutes and 43 GB to restate four sentences.
+
+    Both halves have to hold, and neither is a judgement:
+
+    * the two sources are identical once every alt literal is blanked, so nothing that
+      executes changed - comments and markdown cells are invisible to ``ast`` and
+      cannot affect outputs either, and
+    * every alt in the notebook's output metadata already equals the literal in its own
+      cell, so the outputs on disk are the ones this source produces.
+
+    Anything else - a changed constant, a reordered call, an alt the outputs do not
+    carry - is stale, which is what the stamp is for.
+    """
+    old = subprocess.run(
+        ["git", "cat-file", "blob", stamped_blob],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if old.returncode != 0:
+        return False  # the stamped blob is not in this repo; cannot compare
+    old_blanked = _blanked(old.stdout)
+    new_blanked = _blanked(py.read_text(encoding="utf-8"))
+    if old_blanked is None or new_blanked is None:
+        return False
+    if old_blanked[0] != new_blanked[0]:
+        return False
+
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        if not any(fn in src for fn in ALT_FUNCS):
+            continue
+        blanked = _blanked(src)
+        if blanked is None:
+            return False
+        carried = [
+            (out.get("metadata") or {}).get("image/png", {}).get("alt")
+            for out in cell.get("outputs", [])
+            if "image/png" in out.get("data", {})
+        ]
+        if len(blanked[1]) != len(carried) or any(
+            a != c for a, c in zip(blanked[1], carried, strict=True)
+        ):
+            return False
+    return True
+
+
 def contradicts_injected_cell(nb: dict, parameters: dict[str, object]) -> str | None:
     """Why ``parameters`` disagrees with the notebook's injected cell, or None.
 
@@ -381,12 +483,20 @@ def destamped(ref: str | None = None) -> list[str]:
     )
 
 
-def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str], list[str]]:
-    """Return (stale, testmode, contradicted, unverified) repo-relative offenders."""
+def check_all(
+    strict: bool = False,
+) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
+    """Return (stale, testmode, contradicted, unverified, alt_only) repo-relative rows.
+
+    Only the first four fail. ``alt_only`` is reported so that forgiving a drift is
+    never silent: a notebook in that list has a ``.py`` that no longer matches its
+    stamp, and the reason it is allowed is printed rather than assumed.
+    """
     stale: list[str] = []
     testmode: list[str] = []
     contradicted: list[str] = []
     unverified: list[str] = []
+    alt_only: list[str] = []
     for nb_path in iter_notebooks():
         rel = str(nb_path.relative_to(REPO_ROOT))
         py = paired_py(nb_path)
@@ -400,14 +510,18 @@ def check_all(strict: bool = False) -> tuple[list[str], list[str], list[str], li
         if not stamp:
             unverified.append(rel)
             continue
-        if stamp.get("source_py_blob") != git_blob(py):
-            stale.append(rel)
+        stamped_blob = stamp.get("source_py_blob")
+        if stamped_blob != git_blob(py):
+            if alt_text_only_drift(stamped_blob, py, nb):
+                alt_only.append(rel)
+            else:
+                stale.append(rel)
         if not stamp.get("production", False):
             testmode.append(f"{rel} (params={stamp.get('parameters')})")
         conflict = contradicts_injected_cell(nb, stamp.get("parameters") or {})
         if conflict:
             contradicted.append(f"{rel} ({conflict})")
-    return stale, testmode, contradicted, unverified
+    return stale, testmode, contradicted, unverified, alt_only
 
 
 def _cmd_stamp(args: argparse.Namespace) -> int:
@@ -431,7 +545,7 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
-    stale, testmode, contradicted, unverified = check_all(strict=args.strict)
+    stale, testmode, contradicted, unverified, alt_only = check_all(strict=args.strict)
     lost = destamped()
     fail = bool(stale or testmode or contradicted or lost) or (args.strict and bool(unverified))
     if lost:
@@ -457,6 +571,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
         )
         for r in contradicted:
             print(f"  {r}")
+    if alt_only:
+        print(
+            "ALT-TEXT ONLY (the .py drifted from its stamp only in figure alt text the "
+            "outputs already carry, so re-executing could not change them — allowed):"
+        )
+        for r in alt_only:
+            print(f"  {r}")
     if unverified:
         verb = "UNVERIFIED (no provenance stamp"
         verb += (
@@ -468,7 +589,8 @@ def _cmd_check(args: argparse.Namespace) -> int:
     if not fail:
         print(
             f"notebook sync OK: {len(stale)} stale, {len(testmode)} test-mode, "
-            f"{len(contradicted)} contradicted, {len(unverified)} unverified (advisory)"
+            f"{len(contradicted)} contradicted, {len(alt_only)} alt-text-only, "
+            f"{len(unverified)} unverified (advisory)"
         )
     return 1 if fail else 0
 

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -263,43 +263,131 @@ def git_blob(path: Path) -> str:
 ALT_FUNCS = frozenset({"show_with_alt", "show_plotly_with_alt"})
 
 
-class _AltBlanker(ast.NodeTransformer):
-    """Replace each ``show_*_with_alt`` alt-text argument with a placeholder.
+def _percent_cells(src: str) -> list[tuple[str, str, str]]:
+    """(marker line, kind, body) per jupytext percent cell.
 
-    Collects the literals it replaced in source order, so the same walk answers both
-    "is this the only thing that changed" and "does the notebook's output metadata
-    still agree with the source".
+    Comparing cell structure and raw source, rather than an AST, is deliberate. An AST
+    is blind to three things that change a notebook's outputs: a trailing semicolon,
+    which suppresses a cell's automatic display; a moved ``# %%``, which changes which
+    code shares a cell and therefore which value is the cell's last expression; and a
+    changed cell tag, which changes how the cell is treated. All three leave the AST
+    identical, so an AST comparison would forgive them.
     """
+    cells: list[tuple[str, str, list[str]]] = []
+    marker, kind, buf = "", "code", []
+    for line in src.splitlines(keepends=True):
+        if line.startswith("# %%"):
+            cells.append((marker, kind, buf))
+            marker = line
+            kind = "markdown" if "[markdown]" in line or "[raw]" in line else "code"
+            buf = []
+            continue
+        buf.append(line)
+    cells.append((marker, kind, buf))
+    return [(m, k, "".join(b)) for m, k, b in cells]
 
-    def __init__(self) -> None:
-        self.alts: list[str] = []
 
-    def visit_Call(self, node: ast.Call) -> ast.Call:
-        self.generic_visit(node)
+def _blank_alts(code: str) -> tuple[str, list[str]] | None:
+    """(*code* with each alt literal replaced by a placeholder, the literals in source order).
+
+    None if *code* does not parse. Works in bytes because ``col_offset`` is a UTF-8
+    byte offset, and replaces from the end so earlier spans keep their offsets.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None
+    data = code.encode("utf-8")
+    line_start = [0]
+    for line in data.splitlines(keepends=True):
+        line_start.append(line_start[-1] + len(line))
+
+    found: list[tuple[int, int, str]] = []
+    for node in ast.walk(tree):
         if (
-            isinstance(node.func, ast.Name)
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
             and node.func.id in ALT_FUNCS
             and len(node.args) >= 2
             and isinstance(node.args[1], ast.Constant)
             and isinstance(node.args[1].value, str)
         ):
-            self.alts.append(node.args[1].value)
-            node.args[1] = ast.Constant(value="<alt>")
-        return node
+            arg = node.args[1]
+            if arg.end_lineno is None or arg.end_col_offset is None:
+                return None
+            found.append(
+                (
+                    line_start[arg.lineno - 1] + arg.col_offset,
+                    line_start[arg.end_lineno - 1] + arg.end_col_offset,
+                    arg.value,
+                )
+            )
+    # ast.walk is breadth-first, not source order; the outputs it is compared against
+    # are in source order.
+    found.sort()
+    for begin, finish, _ in reversed(found):
+        data = data[:begin] + b'"<alt>"' + data[finish:]
+    return data.decode("utf-8"), [alt for _, _, alt in found]
 
 
-def _blanked(src: str) -> tuple[str, list[str]] | None:
-    """(alt-blanked AST dump, alt literals) for *src*, or None if it does not parse."""
-    try:
-        tree = ast.parse(src)
-    except SyntaxError:
-        return None
-    blanker = _AltBlanker()
-    tree = blanker.visit(tree)
-    ast.fix_missing_locations(tree)
-    # No attributes: the dump must not depend on the line numbers that a longer or
-    # shorter alt string shifts.
-    return ast.dump(tree), blanker.alts
+def _semicolon_flags(code: str, tree: ast.Module) -> tuple[bool, ...]:
+    """Whether each top-level statement is terminated by ``;``, in source order.
+
+    An AST cannot see this and it changes the outputs: Jupyter suppresses the automatic
+    display of a cell's last expression when it ends with a semicolon, so ``summary``
+    and ``summary;`` produce identical ASTs and different notebooks. Only top-level
+    statements matter, because only the last of them is auto-displayed.
+    """
+    lines = code.encode("utf-8").splitlines()
+    flags = []
+    for stmt in tree.body:
+        if stmt.end_lineno is None or stmt.end_col_offset is None:
+            flags.append(False)
+            continue
+        line = lines[stmt.end_lineno - 1] if stmt.end_lineno - 1 < len(lines) else b""
+        rest = line[stmt.end_col_offset :].split(b"#", 1)[0].strip()
+        flags.append(rest.startswith(b";"))
+    return tuple(flags)
+
+
+def _comparable(src: str) -> list[tuple] | None:
+    """Cells of *src* reduced to what an alt-text edit is allowed to leave alone.
+
+    Per cell: the marker line, the kind, and for a code cell an alt-blanked AST dump
+    plus its semicolon flags. The AST dump is taken without attributes so that neither
+    a longer alt string nor ``ruff format`` rewrapping a call can move it - both are
+    formatting, and formatting cannot change an output.
+
+    What the AST would miss is added back explicitly. The marker line carries the cell
+    tags, so retagging is a change. The list of cells carries the ``# %%`` boundaries,
+    so moving one is a change - it decides which code shares a cell and therefore which
+    value is the cell's last expression. The semicolon flags carry display suppression.
+
+    A markdown cell's body is dropped: it is a comment in the ``.py`` and cannot affect
+    outputs, so its text may change freely while its marker and position still count.
+    """
+    out: list[tuple] = []
+    for marker, kind, body in _percent_cells(src):
+        if kind != "code":
+            # Only when the body really is all comments. A percent-format markdown cell
+            # holds nothing else, so a non-comment line means the marker does not
+            # describe the content - and dropping the body would then hide executable
+            # code. Measured: appending `fig;` after the last `# %% [markdown]` marker
+            # of a real notebook was forgiven until this compared the body.
+            if all(not ln.strip() or ln.lstrip().startswith("#") for ln in body.splitlines()):
+                out.append((marker, kind))
+            else:
+                out.append((marker, kind, body))
+            continue
+        blanked = _blank_alts(body)
+        if blanked is None:
+            return None
+        try:
+            tree = ast.parse(blanked[0])
+        except SyntaxError:
+            return None
+        out.append((marker, kind, ast.dump(tree), _semicolon_flags(blanked[0], tree)))
+    return out
 
 
 def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
@@ -316,14 +404,15 @@ def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
 
     Both halves have to hold, and neither is a judgement:
 
-    * the two sources are identical once every alt literal is blanked, so nothing that
-      executes changed - comments and markdown cells are invisible to ``ast`` and
-      cannot affect outputs either, and
+    * every cell lines up - same markers, same kinds, same order - and every code cell's
+      source is byte-identical once the alt literals are blanked, so nothing that
+      executes changed. Only markdown bodies are free, because they are comments in the
+      ``.py``, and
     * every alt in the notebook's output metadata already equals the literal in its own
       cell, so the outputs on disk are the ones this source produces.
 
-    Anything else - a changed constant, a reordered call, an alt the outputs do not
-    carry - is stale, which is what the stamp is for.
+    Anything else - a changed constant, a reordered call, a trailing semicolon, a moved
+    ``# %%``, an alt the outputs do not carry - is stale, which is what the stamp is for.
     """
     old = subprocess.run(
         ["git", "cat-file", "blob", stamped_blob],
@@ -334,11 +423,9 @@ def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
     )
     if old.returncode != 0:
         return False  # the stamped blob is not in this repo; cannot compare
-    old_blanked = _blanked(old.stdout)
-    new_blanked = _blanked(py.read_text(encoding="utf-8"))
-    if old_blanked is None or new_blanked is None:
-        return False
-    if old_blanked[0] != new_blanked[0]:
+    old_cells = _comparable(old.stdout)
+    new_cells = _comparable(py.read_text(encoding="utf-8"))
+    if old_cells is None or new_cells is None or old_cells != new_cells:
         return False
 
     for cell in nb.get("cells", []):
@@ -347,7 +434,7 @@ def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
         src = "".join(cell.get("source", []))
         if not any(fn in src for fn in ALT_FUNCS):
             continue
-        blanked = _blanked(src)
+        blanked = _blank_alts(src)
         if blanked is None:
             return False
         carried = [

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "840b0dc6",
+   "id": "82d21bf6",
    "metadata": {
     "papermill": {
-     "duration": 0.003053,
-     "end_time": "2026-08-10T14:20:49.469389+00:00",
+     "duration": 0.004384,
+     "end_time": "2026-08-11T11:07:54.970060+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:49.466336+00:00",
+     "start_time": "2026-08-11T11:07:54.965676+00:00",
      "status": "completed"
     }
    },
@@ -65,19 +65,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5a00597e",
+   "id": "f679e168",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:49.475911Z",
-     "iopub.status.busy": "2026-08-10T14:20:49.475781Z",
-     "iopub.status.idle": "2026-08-10T14:20:51.685518Z",
-     "shell.execute_reply": "2026-08-10T14:20:51.684831Z"
+     "iopub.execute_input": "2026-08-11T11:07:54.976196Z",
+     "iopub.status.busy": "2026-08-11T11:07:54.976093Z",
+     "iopub.status.idle": "2026-08-11T11:08:00.176492Z",
+     "shell.execute_reply": "2026-08-11T11:08:00.176029Z"
     },
     "papermill": {
-     "duration": 2.213901,
-     "end_time": "2026-08-10T14:20:51.685993+00:00",
+     "duration": 5.204779,
+     "end_time": "2026-08-11T11:08:00.177532+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:49.472092+00:00",
+     "start_time": "2026-08-11T11:07:54.972753+00:00",
      "status": "completed"
     }
    },
@@ -102,7 +102,7 @@
     "from utils.artifact_specs import resolve_label_buffer, resolve_label_horizon\n",
     "from utils.cv_splits import generate_cv_splits, load_evaluation_config\n",
     "from utils.paths import get_case_study_dir\n",
-    "from utils.style import COLORS\n",
+    "from utils.style import COLORS, show_plotly_with_alt\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
@@ -110,19 +110,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "c88a1247",
+   "id": "9777962c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:51.692134Z",
-     "iopub.status.busy": "2026-08-10T14:20:51.692041Z",
-     "iopub.status.idle": "2026-08-10T14:20:51.694141Z",
-     "shell.execute_reply": "2026-08-10T14:20:51.693648Z"
+     "iopub.execute_input": "2026-08-11T11:08:00.183736Z",
+     "iopub.status.busy": "2026-08-11T11:08:00.183643Z",
+     "iopub.status.idle": "2026-08-11T11:08:00.185242Z",
+     "shell.execute_reply": "2026-08-11T11:08:00.184951Z"
     },
     "papermill": {
-     "duration": 0.005788,
-     "end_time": "2026-08-10T14:20:51.694520+00:00",
+     "duration": 0.005233,
+     "end_time": "2026-08-11T11:08:00.185620+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.688732+00:00",
+     "start_time": "2026-08-11T11:08:00.180387+00:00",
      "status": "completed"
     },
     "tags": [
@@ -139,13 +139,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e32d4d0c",
+   "id": "10c930fb",
    "metadata": {
     "papermill": {
-     "duration": 0.002461,
-     "end_time": "2026-08-10T14:20:51.699486+00:00",
+     "duration": 0.002517,
+     "end_time": "2026-08-11T11:08:00.191172+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.697025+00:00",
+     "start_time": "2026-08-11T11:08:00.188655+00:00",
      "status": "completed"
     }
    },
@@ -161,19 +161,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8e72478e",
+   "id": "388c028f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:51.705199Z",
-     "iopub.status.busy": "2026-08-10T14:20:51.705136Z",
-     "iopub.status.idle": "2026-08-10T14:20:51.741131Z",
-     "shell.execute_reply": "2026-08-10T14:20:51.740490Z"
+     "iopub.execute_input": "2026-08-11T11:08:00.196870Z",
+     "iopub.status.busy": "2026-08-11T11:08:00.196801Z",
+     "iopub.status.idle": "2026-08-11T11:08:00.222258Z",
+     "shell.execute_reply": "2026-08-11T11:08:00.221881Z"
     },
     "papermill": {
-     "duration": 0.039827,
-     "end_time": "2026-08-10T14:20:51.741799+00:00",
+     "duration": 0.028975,
+     "end_time": "2026-08-11T11:08:00.222672+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.701972+00:00",
+     "start_time": "2026-08-11T11:08:00.193697+00:00",
      "status": "completed"
     }
    },
@@ -231,19 +231,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "243a99dc",
+   "id": "913fe990",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:51.747789Z",
-     "iopub.status.busy": "2026-08-10T14:20:51.747708Z",
-     "iopub.status.idle": "2026-08-10T14:20:51.750539Z",
-     "shell.execute_reply": "2026-08-10T14:20:51.750193Z"
+     "iopub.execute_input": "2026-08-11T11:08:00.229002Z",
+     "iopub.status.busy": "2026-08-11T11:08:00.228931Z",
+     "iopub.status.idle": "2026-08-11T11:08:00.231361Z",
+     "shell.execute_reply": "2026-08-11T11:08:00.231111Z"
     },
     "papermill": {
-     "duration": 0.006328,
-     "end_time": "2026-08-10T14:20:51.750883+00:00",
+     "duration": 0.00609,
+     "end_time": "2026-08-11T11:08:00.231740+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.744555+00:00",
+     "start_time": "2026-08-11T11:08:00.225650+00:00",
      "status": "completed"
     }
    },
@@ -290,13 +290,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b8bc177",
+   "id": "adb68e84",
    "metadata": {
     "papermill": {
-     "duration": 0.002566,
-     "end_time": "2026-08-10T14:20:51.756073+00:00",
+     "duration": 0.002641,
+     "end_time": "2026-08-11T11:08:00.237137+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.753507+00:00",
+     "start_time": "2026-08-11T11:08:00.234496+00:00",
      "status": "completed"
     }
    },
@@ -313,19 +313,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "779036b0",
+   "id": "e289f7d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:51.761704Z",
-     "iopub.status.busy": "2026-08-10T14:20:51.761635Z",
-     "iopub.status.idle": "2026-08-10T14:20:56.827645Z",
-     "shell.execute_reply": "2026-08-10T14:20:56.826987Z"
+     "iopub.execute_input": "2026-08-11T11:08:00.243409Z",
+     "iopub.status.busy": "2026-08-11T11:08:00.243289Z",
+     "iopub.status.idle": "2026-08-11T11:08:05.810001Z",
+     "shell.execute_reply": "2026-08-11T11:08:05.809307Z"
     },
     "papermill": {
-     "duration": 5.069916,
-     "end_time": "2026-08-10T14:20:56.828567+00:00",
+     "duration": 5.57065,
+     "end_time": "2026-08-11T11:08:05.810468+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:51.758651+00:00",
+     "start_time": "2026-08-11T11:08:00.239818+00:00",
      "status": "completed"
     }
    },
@@ -371,13 +371,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c3511d0",
+   "id": "68f38ad2",
    "metadata": {
     "papermill": {
-     "duration": 0.002723,
-     "end_time": "2026-08-10T14:20:56.836311+00:00",
+     "duration": 0.00277,
+     "end_time": "2026-08-11T11:08:05.816453+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:56.833588+00:00",
+     "start_time": "2026-08-11T11:08:05.813683+00:00",
      "status": "completed"
     }
    },
@@ -393,19 +393,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "baec65d8",
+   "id": "9cfbc3bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:56.842676Z",
-     "iopub.status.busy": "2026-08-10T14:20:56.842501Z",
-     "iopub.status.idle": "2026-08-10T14:20:58.981189Z",
-     "shell.execute_reply": "2026-08-10T14:20:58.980675Z"
+     "iopub.execute_input": "2026-08-11T11:08:05.822987Z",
+     "iopub.status.busy": "2026-08-11T11:08:05.822803Z",
+     "iopub.status.idle": "2026-08-11T11:08:08.114735Z",
+     "shell.execute_reply": "2026-08-11T11:08:08.114157Z"
     },
     "papermill": {
-     "duration": 2.142722,
-     "end_time": "2026-08-10T14:20:58.981736+00:00",
+     "duration": 2.296003,
+     "end_time": "2026-08-11T11:08:08.115214+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:56.839014+00:00",
+     "start_time": "2026-08-11T11:08:05.819211+00:00",
      "status": "completed"
     }
    },
@@ -451,13 +451,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a782d31",
+   "id": "94c7a159",
    "metadata": {
     "papermill": {
-     "duration": 0.00274,
-     "end_time": "2026-08-10T14:20:58.987414+00:00",
+     "duration": 0.002752,
+     "end_time": "2026-08-11T11:08:08.121380+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:58.984674+00:00",
+     "start_time": "2026-08-11T11:08:08.118628+00:00",
      "status": "completed"
     }
    },
@@ -469,19 +469,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6a179acc",
+   "id": "77a5f1a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:58.993521Z",
-     "iopub.status.busy": "2026-08-10T14:20:58.993424Z",
-     "iopub.status.idle": "2026-08-10T14:20:59.592703Z",
-     "shell.execute_reply": "2026-08-10T14:20:59.592285Z"
+     "iopub.execute_input": "2026-08-11T11:08:08.127680Z",
+     "iopub.status.busy": "2026-08-11T11:08:08.127569Z",
+     "iopub.status.idle": "2026-08-11T11:08:08.690191Z",
+     "shell.execute_reply": "2026-08-11T11:08:08.689763Z"
     },
     "papermill": {
-     "duration": 0.602949,
-     "end_time": "2026-08-10T14:20:59.593039+00:00",
+     "duration": 0.566592,
+     "end_time": "2026-08-11T11:08:08.690656+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:58.990090+00:00",
+     "start_time": "2026-08-11T11:08:08.124064+00:00",
      "status": "completed"
     }
    },
@@ -550,13 +550,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d058ee91",
+   "id": "69bb978d",
    "metadata": {
     "papermill": {
-     "duration": 0.002775,
-     "end_time": "2026-08-10T14:20:59.600250+00:00",
+     "duration": 0.002784,
+     "end_time": "2026-08-11T11:08:08.696457+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:59.597475+00:00",
+     "start_time": "2026-08-11T11:08:08.693673+00:00",
      "status": "completed"
     }
    },
@@ -585,19 +585,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "774385fd",
+   "id": "fccffa68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:20:59.606392Z",
-     "iopub.status.busy": "2026-08-10T14:20:59.606284Z",
-     "iopub.status.idle": "2026-08-10T14:21:02.109687Z",
-     "shell.execute_reply": "2026-08-10T14:21:02.109272Z"
+     "iopub.execute_input": "2026-08-11T11:08:08.702607Z",
+     "iopub.status.busy": "2026-08-11T11:08:08.702516Z",
+     "iopub.status.idle": "2026-08-11T11:08:11.337829Z",
+     "shell.execute_reply": "2026-08-11T11:08:11.337421Z"
     },
     "papermill": {
-     "duration": 2.507117,
-     "end_time": "2026-08-10T14:21:02.110093+00:00",
+     "duration": 2.639013,
+     "end_time": "2026-08-11T11:08:11.338251+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:20:59.602976+00:00",
+     "start_time": "2026-08-11T11:08:08.699238+00:00",
      "status": "completed"
     }
    },
@@ -649,13 +649,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dedf8044",
+   "id": "c0d904e5",
    "metadata": {
     "papermill": {
-     "duration": 0.0028,
-     "end_time": "2026-08-10T14:21:02.116558+00:00",
+     "duration": 0.002818,
+     "end_time": "2026-08-11T11:08:11.344109+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:02.113758+00:00",
+     "start_time": "2026-08-11T11:08:11.341291+00:00",
      "status": "completed"
     }
    },
@@ -697,13 +697,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bceaf18e",
+   "id": "77aa57cc",
    "metadata": {
     "papermill": {
-     "duration": 0.002778,
-     "end_time": "2026-08-10T14:21:02.122086+00:00",
+     "duration": 0.002746,
+     "end_time": "2026-08-11T11:08:11.349652+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:02.119308+00:00",
+     "start_time": "2026-08-11T11:08:11.346906+00:00",
      "status": "completed"
     }
    },
@@ -729,19 +729,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "22d3ada5",
+   "id": "26405ece",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:02.128179Z",
-     "iopub.status.busy": "2026-08-10T14:21:02.128070Z",
-     "iopub.status.idle": "2026-08-10T14:21:04.610965Z",
-     "shell.execute_reply": "2026-08-10T14:21:04.610659Z"
+     "iopub.execute_input": "2026-08-11T11:08:11.355867Z",
+     "iopub.status.busy": "2026-08-11T11:08:11.355787Z",
+     "iopub.status.idle": "2026-08-11T11:08:13.875155Z",
+     "shell.execute_reply": "2026-08-11T11:08:13.874747Z"
     },
     "papermill": {
-     "duration": 2.486822,
-     "end_time": "2026-08-10T14:21:04.611641+00:00",
+     "duration": 2.523049,
+     "end_time": "2026-08-11T11:08:13.875451+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:02.124819+00:00",
+     "start_time": "2026-08-11T11:08:11.352402+00:00",
      "status": "completed"
     }
    },
@@ -832,13 +832,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7d343ee",
+   "id": "b4215134",
    "metadata": {
     "papermill": {
-     "duration": 0.002891,
-     "end_time": "2026-08-10T14:21:04.617666+00:00",
+     "duration": 0.002901,
+     "end_time": "2026-08-11T11:08:13.881457+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.614775+00:00",
+     "start_time": "2026-08-11T11:08:13.878556+00:00",
      "status": "completed"
     }
    },
@@ -854,19 +854,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a1b97ec1",
+   "id": "5cc72add",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:04.624053Z",
-     "iopub.status.busy": "2026-08-10T14:21:04.623969Z",
-     "iopub.status.idle": "2026-08-10T14:21:04.626174Z",
-     "shell.execute_reply": "2026-08-10T14:21:04.625917Z"
+     "iopub.execute_input": "2026-08-11T11:08:13.888211Z",
+     "iopub.status.busy": "2026-08-11T11:08:13.888108Z",
+     "iopub.status.idle": "2026-08-11T11:08:13.890718Z",
+     "shell.execute_reply": "2026-08-11T11:08:13.890285Z"
     },
     "papermill": {
-     "duration": 0.00621,
-     "end_time": "2026-08-10T14:21:04.626708+00:00",
+     "duration": 0.006562,
+     "end_time": "2026-08-11T11:08:13.890956+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.620498+00:00",
+     "start_time": "2026-08-11T11:08:13.884394+00:00",
      "status": "completed"
     }
    },
@@ -894,13 +894,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8432dd3c",
+   "id": "1fd587a8",
    "metadata": {
     "papermill": {
-     "duration": 0.002858,
-     "end_time": "2026-08-10T14:21:04.632423+00:00",
+     "duration": 0.002834,
+     "end_time": "2026-08-11T11:08:13.896717+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.629565+00:00",
+     "start_time": "2026-08-11T11:08:13.893883+00:00",
      "status": "completed"
     }
    },
@@ -915,19 +915,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "43d5237a",
+   "id": "0f281e46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:04.638876Z",
-     "iopub.status.busy": "2026-08-10T14:21:04.638794Z",
-     "iopub.status.idle": "2026-08-10T14:21:04.641365Z",
-     "shell.execute_reply": "2026-08-10T14:21:04.640982Z"
+     "iopub.execute_input": "2026-08-11T11:08:13.902992Z",
+     "iopub.status.busy": "2026-08-11T11:08:13.902814Z",
+     "iopub.status.idle": "2026-08-11T11:08:13.905772Z",
+     "shell.execute_reply": "2026-08-11T11:08:13.905316Z"
     },
     "papermill": {
-     "duration": 0.006507,
-     "end_time": "2026-08-10T14:21:04.641771+00:00",
+     "duration": 0.006914,
+     "end_time": "2026-08-11T11:08:13.906492+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.635264+00:00",
+     "start_time": "2026-08-11T11:08:13.899578+00:00",
      "status": "completed"
     }
    },
@@ -971,19 +971,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "803ae34b",
+   "id": "63185122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:04.647993Z",
-     "iopub.status.busy": "2026-08-10T14:21:04.647924Z",
-     "iopub.status.idle": "2026-08-10T14:21:04.650183Z",
-     "shell.execute_reply": "2026-08-10T14:21:04.649882Z"
+     "iopub.execute_input": "2026-08-11T11:08:13.914549Z",
+     "iopub.status.busy": "2026-08-11T11:08:13.914465Z",
+     "iopub.status.idle": "2026-08-11T11:08:13.916542Z",
+     "shell.execute_reply": "2026-08-11T11:08:13.916243Z"
     },
     "papermill": {
-     "duration": 0.005951,
-     "end_time": "2026-08-10T14:21:04.650592+00:00",
+     "duration": 0.005794,
+     "end_time": "2026-08-11T11:08:13.916836+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.644641+00:00",
+     "start_time": "2026-08-11T11:08:13.911042+00:00",
      "status": "completed"
     }
    },
@@ -1010,13 +1010,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78760700",
+   "id": "aa0ec9fe",
    "metadata": {
     "papermill": {
-     "duration": 0.002896,
-     "end_time": "2026-08-10T14:21:04.656381+00:00",
+     "duration": 0.002955,
+     "end_time": "2026-08-11T11:08:13.922752+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.653485+00:00",
+     "start_time": "2026-08-11T11:08:13.919797+00:00",
      "status": "completed"
     }
    },
@@ -1031,19 +1031,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "02b49429",
+   "id": "c3f3b813",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:04.662657Z",
-     "iopub.status.busy": "2026-08-10T14:21:04.662591Z",
-     "iopub.status.idle": "2026-08-10T14:21:06.188030Z",
-     "shell.execute_reply": "2026-08-10T14:21:06.187684Z"
+     "iopub.execute_input": "2026-08-11T11:08:13.930577Z",
+     "iopub.status.busy": "2026-08-11T11:08:13.930482Z",
+     "iopub.status.idle": "2026-08-11T11:08:15.206821Z",
+     "shell.execute_reply": "2026-08-11T11:08:15.206321Z"
     },
     "papermill": {
-     "duration": 1.529245,
-     "end_time": "2026-08-10T14:21:06.188501+00:00",
+     "duration": 1.280732,
+     "end_time": "2026-08-11T11:08:15.207138+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:04.659256+00:00",
+     "start_time": "2026-08-11T11:08:13.926406+00:00",
      "status": "completed"
     }
    },
@@ -1293,7 +1293,11 @@
       },
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAHMCAYAAAA3cHsfAAAQAElEQVR4AeydBWAURxfH/xfBoS1eKFKkWHF3KPbh7u7uLsEhuLsHd4eipbi7u0uB4lCcb9+QPS6Xu+QSYnf3h8zu7MybNzO/N7v3bnZ2z+X9+3dfGMiAY4BjgGOAY4BjgGOAY4BjwFHHgAv4jwRIgARIAAAhkAAJkAAJOCoBOryOaln2iwRIgARIgARIgAQCQ8ABy9DhdUCjskskQAIkQAIkQAIkQALfCNDh/caCMRIgAdsJUJIESIAESIAE7IYAHV67MRUbSgIkQAIkQAIkEPYIsEX2QIAOrz1YiW0kARIgARIgARIgARIINAE6vIFGx4IkYDsBSpIACZAACZAACYQeATq8oceeNZMACZAACZCAsxFgf0kgVAjQ4Q0V7KyUBEiABEiABEiABEggpAjQ4Q0p0qzHdgKUJAESIAESIAESIIEgJECHNwhhUhUJkAAJkAAJBCUB6iIBEggaAnR4g4YjtZAACZAACZAACZAACYRRAnR4w6hhbG8WJUmABEiABEiABEiABPwiQIfXLzrMIwESIAESsB8CbCkJkAAJWCFAh9cKGCaTAAmQAAmQAAmQAAk4BgFnc3gdw2rsBQmQAAmQAAmQAAmQgM0E6PDajIqCJEACJOBIBNgXEiABEnAeAnR4ncfW7CkJkAAJkAAJkAAJOCUBPx1epyTCTpMACZAACZAACZAACTgUATq8DmVOdoYESCCYCFAtCZAACZCAHROgw2vHxmPTSYAESIAESIAESCBkCdhnbXR47dNubDUJkAAJkAAJkAAJkICNBOjw2giKYiRAArYToCQJkAAJkAAJhCUCdHjDkjXYFhIgARIgARIgAUciwL6EEQJ0eMOIIdgMEiABEiABEiABEiCB4CFAhzd4uFIrCdhOgJIkQAIkQAIkQALBSoAOb7DipXISIAESIAESIAFbCVCOBIKLAB3e4CJLvSRAAiRAAiRAAiRAAmGCAB3eMGEGNsJ2ApQkARIgARIgARIggYARoMMbMF6UJgESIAESIIGwQYCtIAESsJkAHV6bUVGQBEiABEiABEiABEjAHgnQ4bVHq9neZkqSAAmQAAmQAAmQgNMToMPr9EOAAEiABEjAGQiwjyRAAs5MgA6vM1uffScBEiABEiABEiABJyBAh9fEyIySAAmQAAmQAAmQAAk4HgE6vI5nU/aIBEiABL6XAMuTAAmQgEMRoMPrUOZkZ0iABEiABEiABEiABMwJBN7hNdfEYxIgARIgARIgARIgARIIgwTo8IZBo7BJJEAC9kWArSUBEiABEgjbBOjwhm37sHUkQAIkQAIkQAIkYC8Ewmw76fCGWdOwYSRAAiRAAiRAAiRAAkFBgA5vUFCkDhIgAdsJUJIESIAESIAEQpgAHd4QBs7qSIAESIAESIAESEAIMIQcATq8IceaNZEACZAACZAACZAACYQCATq8oQCdVZKA7QQoSQIkQAIkQAIk8L0E6PB+L0GWJwESIAESIAESCH4CrIEEvoMAHd7vgMeiJEACJEACJEACJEACYZ8AHd6wbyO20HYClCQBEiABEiABEiABXwTo8PpCwgQSIAESIAESsHcCbD8JkIApATq8pjQYJwESIAESIAESIAEScDgCdHgdzqS2d4iSJEACJEACJEACJOAMBOjwOoOV2UcSIAESIAG/CDCPBEjAwQnQ4XVwA7N7JEACJEACJEACJODsBOjw2joCKEcCJEACJEACJEACJGCXBOjw2qXZ2GgSIAESCD0CrJkESIAE7I0AHV57sxjbSwIkQAIkQAIkQAIkECACweTwBqgNFCYBEiABEiABEiABEiCBYCNAhzfY0FIxCZAACQAgBBIgARIggVAnQIc31E3ABoQVAtdu3ELNRu2QJG1+JEyV26ZmTZm5EPn/V81P2ebtPNCu2wA/ZYIyU9qUr1jVoFTpS1ey9AWwZsM2X+l+JUyaPl+x+vGX9Jgwda5fogHO2/b3XpSu0ghxk2VTNrRVwcjxM1G8Qn1bxUNUrm7TTujed5ixzrpNO6Jbn6HGY0uR9LlKYOnKDZayApSWNF3+ANs3QBWEceHA9P/U2QuQsf3436dhvHff37ygGmff3xJqsDcCodleOryhSd+B67556666+MsHgHkIqKMUUpimzFyAN2/e4siuNbh1fm9IVYvjJ88qVs+evwiSOn+OGxsZ0qUOEl1BpeTho3/Ro99wdG7bBE9uHUerpnWUY9qz/4ggqaLvoDHIkjEtbpzZjQUzxljUKV9iNmzaYTHPHhJT/pYUvyZKEKRNlS8eBUvW8KUzR7aMiBH9R1/pzpJg2n9bz8/IkSKiQN4ccHd3cxZM7CcJ2BUBOrx2ZS77a+yQfl2xbukMHyFX9kxhsiN37/+DtKl/Q/Sf7PuDvmzJwhg3vE+YYnz33gPVnvx5s8PFxa/LjhIL8ObWnXvIniUjIkQIH+Cy9lKge8cWaNrAt3MaHO2XLw15cmYJDtV2oTMw/U/6ayKsXjQVP0SLahd9ZCNJwNkIBP0nj7MRZH/9JJAmVXLkzZXVR4gVMzqu37wNmfk9e/6yj/JzF61E8gwF8eHDB5V+4dI11GrcHikzFVbpzdt5wHQmVL8lLTNV2QqUxU8JMmDhsrVKXtehFGmbJm16oF6zzlrM91+KjIUgs3/jpnipdulLEI4eP41y1ZsiUeo8yJSnFHoNGIn//nvrW4F3yqvXbyBlf8v4B9LmKK5mNb2zLO5kJlyfYUucJq+qW9opwpVqtYDMgLbs0BtpshVT7ZD06XMWQfJEPku+Mhg0fAI+fvwoWSqYL2kQWY+BI9G++0CkylJEtav/kHE+yqzduA0VajRX/RS7FChRHfe0LwBKoQ0bv+w0w2sx9D4mSJlL9bFhiy6K98Rp89Sx1Hnx8nWLNf3z6DGEibQ9uTY26jfvgjt37yvZcxeuqPIvXr5CtfqtVdzSLf3MeUtDZGTJitSVOmtRVV7fSBuz5i+jlrM0atUNDx4+0rPUfstfu/G/8vUUH2E+ZNQUfPr0SeWZb2wZ2zJOBg4bj6Ll6kCYCO+VazeZq/JxbL6k4cbNO6hat5VafpO9YHksXrHOh7wc+DVW5DyR8azPYAqXOfOXSzGY39L3ywZSQD8Pp81eBL84iqwehEG7rgOQq3BFZbf4v+WEnH96voxbya/RsK069+V86jt4jI9x61f/RE9g2iXl9P77dX6KnGkwX9LgX/9My0r8zPlLkGUsMjbFFnLO/737gGSpIEuu9Hy5Hsp14fzFqypPNouWr4WMI+FYoHh1zJ63TJKNIWbizPBauEKd53LtGDp6qsrzb2zbMs6UIpPN+/cfIONbxoKM71KVG2HfwaMmEoC0Z97iVahcu4Uaw3mKVMaSFet9yDj9AQEEKQE6vEGKk8psJSC3ZrNnyYBV63x+yK9cuxnlSxfVbgu6Q26Dl63aGOl/T411y2Ziy5q5+OGHKKiifch//vzZWNWJ0+dw9MQZLPWaiJvn9qBimf/hw8cP2LRtl1Hm+YuXWLNhK6pXLmNMM41cPL4d/yucD22b18OzOycxZogHZFayTNUmiBs7Fo7uXocJI/thkeZMd+o52LSoj3jPfiOwTnMe50wZju3r5uOfh//ir537fMiYHiRKGB87NixUSTfO7lZ1Txv3Tf8s7UMraZJE2L15CeZOG6nkXrx8g45tGuHUgT8xbGA37D1wDJ4jJ6k8a5sFS9Yia6Z02Lt1GUZ59oToXbHmK/uXr16jYctuqFapFE7u34gTezegXo2KMBgM1tT5SPfPTo3qVsNWzXZS6M7F/aqPMycNQ8n/FUTLJrXVsTBPkfxXEfERvnz5gqp1WuOC9sG+csEUTc885YhXqNlMfSlKnTKZKh8xYgQsnjNexatUKOlDhxyI/aJFjaKWO0hd5w5vkWQVrl2/hfWbdqBdy4bo0q6pxvMohoycovJks3PPQbTp1A/1alVU42Dy6AE4dOQk+nmOlWxfwZax/f79e4QPHwGjPT0U85aNa2tfjkZg2997femzlCDOdtV6rfH0+Qvs2rQEc6aMgHzRefbshQ9xv8ZKDe1cGOjRERnTp1HchEu9WpV8lJcD/2wgMhLkPJQvScvmTsLqxVNx7cZtHxxFxjSMnTQLN27dwYwJQ3H30n4smj0W8X+ObSqCBUvXIFvmDDi8cw3GDPXAkpUbMGLcDKOMX/3ThQLaLr2c7P07P0XGWrClf6Zlu3oMxS/x42Lzqjm4fmYXxDYyrkVGzrGiZesgcqRIWDF/MvZtX47c2gz8i5cvJRvyhbW5NhlQvVJpnD28GQ3rVlFfcOcvWa3y9Y04ufVrV8KFo9vQvFFN+De2bR1nun5932fwaEyfswRDB3RT41uW45St1hSXr97URdR++uzFaNaolpKpUaUsmrXrBXGwVSY3JBDEBOjwBjFQqvNJQB4kktkK0yCOpEhVKFMMy72dLjmWdLkAVyxbXA6VU5bu9xTo3LYxkidNpNYvevbtgrPnLqt1r0rIeyMfhokT/QJxasKHD4fK5Uv4mPFatmoDYseKiSIFc3uX8H8ns81RIkfC6CG9EDPGT8iVPTM8urZWH8KPHj/xpUBmdKRM947NlWzsWDEg7Xr95o0vWVsTMqZLgw6tGqplFtI3KdexdUPkzJZJ+oo/8uVC1/ZNtTatlSyrobDWb3FwZLlGkYJ5UKhAbhw+dlrJ//vvU+U85tE+QH/8IRqEYz3N8ZG1wErAn404z7bayR9VvrJlPIjDMm5EH6RKkVS1bdzwvrh05QY2btnpSz4wCR+02fFFs8aipnzgNqwBWTZw8MgJo6rRE2ehcf3qqFaxtBoHWTOnR49OzdX4NAqZRfwb22IHGddyB0TiMl7r1ayExct9z9LCwr8d2szfxcvXMHZoH8VE2Azo1QHyxc5UPDBjxbS8xG21wU8//oC+Pdqp9qRLk1LjWQaHjn7jKLpMw/0Hj/Br4gRIrX1pEUcuX+5s0M99XU7WZbdrUR8yLgvlzwX5YjBnwXI9G7b0L6DtMir/zogt/TOt4v6Df5AhbWok+CUeftJYyhd/mRQQmdnazLsslRg3vLc6D2TMyPms50+fsxglihVQY1dY1a5WHvLFb9qsRVLcGGpULo3SxQuppT9yPfFvbNs6zowVaBG5AzbDayk6tWmirk/S1iH9OiPez7Exc+5iTeLbX4M6lSF2lf62aFwLsWPGwLGTZ74JMEYCQUiADm8QwqQq3wQsreGNGSO6Eixfuph2a/qB8VbXyrVblGOrX8SvXr+JrTv2qtudusMsSxbEgbyu3c5VSrRNiuRJIB8GWtT4V7taBWzaugv6E9OLlq/XHJaSAVo/elWb+cubOyv0WRZRLs6i7K/duCU7H+HW7XuQ2bD8eXIa06NGiQxxJI0JAYxkSJfKV4kDh4+jhnabN2XmwhAuZas1wYN/HuHNm/98yeoJ8X+Oo0fVPlbMn/Do8b8qLg5u7hxZUESbQZIHy6bPWQS5lasybdjYaicbE5o8ygAAEABJREFUVPkSEc5x48SCOAJ6ZgptJliC1Kunfc9eZtBNbZw44S9GNqJXHMsBQ8cp1sJbQuEytSFfcO4/eCgivoJ/Y1sKyC3okpUaqtu5onPIqMm4fee+ZPkbbty8rRwjcXR1YVk6ZNoPSQ/MWJFypsFWGySI/7NpMe3LQQx1l8ZHoslBee0L79yFKyHLMoaPnY4/tS8wcv6YiCBtmt9MD5E+bSofY92W/gW0XT4q/I4DW/pnqr5SueJo13UAZKnC2MlzcEy7a6XnX7l2A5kzpoWbm5ue5GN/+eoNFNa+xJomyvH5S1fVNUlPz5A2jR5Ve//Gtq3jTCnz3ty4dVd9gZYv2d5Jqt0F8+WE3E3R02Qfz+y6FCd2TO3c8z2ZILL+B0qQgN8E6PD6zYe530lAZrDkg9g0yAysqJUZ0MIFcmHVuq1yiJXrNqFCma+zu5JgMBjUjI/cajUP8uEgMhIiRoggOx9B6hXHWW6Jyto4WYtbq2p5HzK2HLi6uvoQc3Xzeewj0/vAzc3naWVLGe+ivnYRzR7CEievcu2WqFqhtHbr0wv/3jyGjStmqXLvvdc9qwOzjYuLwSxFDr/IRoUV8yfBo2srRAgfHvLlIPsf5bFn/xGV59/GYLDNTv7psZbv7u7uK8vcLr4EApDgZmZjg8Hgw0kwGAwYObiH8ba/6Vi0Ngvu39iWtYpye7l3t9Y49PdqpbtXl9bwy4bmXTJvt+S7urjIToXAjhVV2Gxjiw0sPYxo7sCaqpWZvb82LEBO7c6JOHRN2/ZQX+RMZazFhZOt/Qtou6zVGdD0gPavR6eWmDV5GBImiI99B46gUOlaGD9lrs3Vmp8Tbtq1SvgbDN/O/QgRw/vQZzD4P7b9G2c+FJocmDvnbq6+nXXLtjFRwigJBCGBb1fHIFRKVSRgKwG5hbl6/WbIw2vy8EzVit/WX6ZInhR7tQu/3CKzVZ+pXK1q5TBv0UosXLoGMrsg6/FM8/2LJ/01IU6dueBD7PiJc+o4SeKEam+6SZggnlr3eurMRWOyrIE7fvJrGWOiWSS85mRKkum6ZDm2FI6dOKvNnEWHvIlB+iMfcqfPfqvPUhlb0iJojrXcsu/drQ3+Wr8AmTOkxaZtti0ZCKydwocL78OxtNRO4SwPqJnOpMqsvcy+J/01kaUiVtPki9HnL5+t5lvLSJ0iGf7atd9attV0v8b2gSMnkFtz9ORLmcxgi5LTZ32ONUmzFhInSgB5M4Xp0pqLl69DZp31MraMlQgRwuHL529ffPSypvugtIGpXomn/z0V2rWoj6ljB2HO1OFqltd0Wcbps5dEzBhOnj6POLFiQm7b29I/Y8HviATk/DSvxr/+mcsXK5QXXds3xRKvCejUphFWaddGkUmWJLGa8TV9OFXS9ZA8aWLtWuXzOnD81Fmk1sauLmNpL/l+jW1bxpm53sQJ40OuS6fO+LzuHTt5Bkm0a6q5PI9JIKQI0OENKdJOWo84srv3HYZpEAdGxyHrzsSh7dB9IGRdqjzwo+c1qF1JRRu36Y5TmjMgDuH5i1cgbxgw/VBUQhY25UsVxZOnzyHr3+RhDgsifibJOjhZpiD1iZMlDyoNGDYOstZT3jRhXljW+9apXgGDR0zE+YtX8fbtO3gMHIWnz56bi/o4TvDLzwgfPhzOnPP54e5DyPsgTarfcO/BPzh97uuHm/5mCe/sQO3Oa0xHjp8J3S7y0MjVazfxa6JfbNIXWDslSfyL4iR2tVaRrOtMr93GbtulH8Shk7bJWEmkfbkoXiS/tWIW02XpgoxHi5l+JMoDgsJZHgyU+qW9sq5VZmj9KKbWVFob22lT/6YetHzy9Jm6/Ttqwkxs+Wu3X+p85BXIkx3JkiRE2679tDH+DPcfPETX3kPUONIFbRkrv2pf3MRxNn3ziV5e3welDXSdspc3dGzevlu97UK+GO7acwji/MvaUsmXIOu35fa+tG/7zn2YOH0e6teuLFmwpX9K8Ds3ATk/TauaOG0e/Oufqby8MeOY9zIGeZBU1tj/qn2xEZn6tSpBGLTp3F+dMzJu5C0b+lrzxvWqqfXf8oYSkVu1bjPmLlyFJg2qS3FLQaX5N7ZtGWdKkclGltU0qV8NniMnqwkLaeuwMdNwWvtiLu00EWWUBEKUAB3eEMXtfJXJL0PJg2umYfX6r0sYhIY8rFLqf4UgF+7ypX2+KuqnH39Qt+0jRYyI2o07IHGavOjQfRBkds/dylo20akHufCWL10M4bRb4vKghp5u6/6X+D9j/bIZOHL8tHolWbN2PVGoQC6MGNTDqopBfTpBHPfy1ZsiR6EK6sO8TInCVuUlQ9b5tm/ZAGWqNlbrROUVXJJuKcgDPhNH9keLdh7IXrA8Rk6Ygf4921kStTlN+O7ccwC/Z/+fqj9zvjIoVjgf5CEqW5QE1k41q5bDzVt3ED1hRsgaVnFozeuTW56LZ49DlChRUK56ExQpW1vNoi+fNxnhwvle6mBe3vS4ddO6mDhtrqpLXv1kmudXXOy5bukMHDp6Cn+UqolUmYtg5PgZeP/+nV/F1BP11sa2sC1ZrAAKlaqFbAXKqy877Vs29FOfaabcLl48Zzw+vP+A/MWrQ25/VypXXDmMupwtY6Vg3hxI93tKyLklNtBfS6brkH1Q2kD06eHT589o1bE3YiTKpMKGzX9h+nhPZV9dpoHm3J7WvuxK+2R9a7WKpdSDapJvS/9E7ntDQM5P07ps6Z+p/D8PH6NEpQZqfMqrvOSLlX5uyxKZ9ctm4eWrVyhfo6l6fd5o7dyPFCmiUiHXGHm4dtKM+UiTtRjGTpqD/r3ao5Z2jikBK5uc2TLBr7FtyzizpLpfj/YoV6oI2nXtj/Q5S2DX3kNYs3gqAnpXxpJuppFAYAnQ4Q0sOUcv9539k9vtpmsdTePyK1um6qeMHajWMDapX900WcVFj7ym6+S+jZBfP/tz5Wx4TR0B/ULfsXVDSJoStrARh6pKhVI+HjyzIKaSFmsORL+e7VVc32RMnwZrl0xXdR/bsx4DenX0oatZwxrYuWmxLg6Z5R0z1AMXjm2DvN5raP9u6natvObMKGQh0q1Dc+iMpL8islytq20jUR9BHJvdW5bi4I5VavmB3DqXsnKbVwSlTbs2L5GoCpb0yMOEXlNHqnxhLH0UHRJkXfDYYb3VbUklYGFz5eTfalmFniU6pN3W7CRvNhDdwkcvI7NXwlTSJciDaHqe6V5m/WZNGorzR7bi8okdyv6yfMRU5v7lg+q1cqZp5vHiRfPj9oV9irP+WjJL40eWi1w95XM5h6xBX7VwCq6d3gl5hZ3w8ujq2zbmdVob2+JESvnje9dDgvSvS7sm2OH9ijrR46WNc8++XSSqgpdmL7GbOtA2wm/ZvEk4feBPSH/EuRH+8nS+lq3+/Bsr0g75sQThL0HeziEFpf/CQeIS/LOBrRxFlx7aNKur7Cn1Sji8c616X7eeL/sI2p2PGROGKJtJP/t0b6teWSh5EvzrX2DaJXrN+2/p/BQ50yBvppB+yBtdJN2W/omcHsTZf3DlkOqr6JExFj9eXD0bKX9LgnnTR6lXikm+8EqbOoUxX+z+98ZF6hVvf/+5CHVrVDTmSeTxjaO+HmyTdP/Gti3jTPSYBvkyKmvSpY1yzq3XJg7kLTemMpbas0u7bsn1y1SOcRIIKgJ0eIOKJPWEOQKy/nfb33u1mUqfF/4w11A2iARIIEwTYONIgATsnwAdXvu3IXtggUD6XCXQtkt/jB/RF/LGBgsiTCIBEiABEiABEnASAnR4g8TQVBLWCMit3SO71kIePAtrbWN7SIAE/CdgaSmO/6UoQQIkQAKWCdDhtcyFqWGMQPEK9dXDHPJgjWn4e/cBZC9YTr0RISiaLD++IG9kCIgu+YU4aV9AypjKbtq2C/Jwn2laQOJrNmxD38FjbC4i8n0GjbZZ3i/Bdt0G2PxzuH7p8Svv3IUr+GvXPqPI99QZGFvl/181H6/70hsiDIWlfhyQ/QyvxXj//kNAitiN7CYr41nG+eWrN439CMrzVpTKGwrkB0IkHpgQUHtKf77nvLXWRtEpuq3l25ouY1P6ZIu81Gdqm+85x2ypjzIkEBoE6PCGBnXWGWAC8mCaPKghTxQXLpDb+GBHgbw5AqzL2Qvkyp4JdWvaz7rmC5euYOfugw5lNvk5ZvnxBIfqlD+d2bZjL+THIvwRc/rsRnWrIWumdN/NISDnOW3z3bipwA4IhIbDawdY2ER7I+A5chJklrVGw7Z4+eq1av6Dh4/QoEVX9cqm8jWa4dKVGyrddCPvSW3WtpeSadiyG96/e6+yZbZDZqAKlKiOavVbQ2YGJUPe41q3aScULVcHKTMVhrxjUtLfvnuHes06449SNWE6q3Lk2CnIK9nktVHN23kY27Z1xx7kLVoFlWq1sPoDDzLLIuuQK9RojmmzF6m+HD56UqqDvGuzYMkaKm66saXP+w4eg9eCFarYsDHTIGzkNV3Dx05XafpGXnIva6Hl+MbNO2qG/cq1rzN02QqUheRL3qatu1CuelMUKF4d5y9ekSSVJ7POkiaz5pu0WT/JkFm4Ok06qn5L/0SHJTmR1YO8YmnNxm2qjh3ePwARkDp1Pfremq3kXdEyhsSGnXp6WpyBHT1xFnIXqYQqdVriusZE1zl9ziJle7HJrHlLVbLMTFer11rFZdOz/wjI+3zlV9bk/c41GrSFjD3JMw3W2iHjsUe/4ShZqaGy2c1bd1UxazYXvtIPsW+Jig2MtrE2hpUybSOvw5I68hWrCrGdPPypJatzQPon41zsLXaTdAn+jWepc/P2XfAcMUnZUf/BjMCet6LP0nl45dotVKzZXJ1b8i5aaZu1/kieNXsG5XlrzT5yLpWt1kTZ02PgSAhvaZPM/h/WrhsS92ssyHVG7CAc9GuelNGD6Xm+Vjt/qtZtpbjI9USXkb2wtGSb7znHRC8DCYQ1AnR4w5pF2J5AEciQLo16PVnmDOkwb9EqpWPg0AkoXDA3tq+bjz7d26Bjj4Eq3XQzb/EqyK9viUytqmVx8sx5lR0zxo9Yt3Qm5DU/NauUw6Dhk1T65Bnz0bheNWxZPRf7ti9HlMiRVfpVzRGUOraumYsLl65CXpgvL9OX9wYPG9BNtUF+QGHc5Nn48OGDep/w1HGDsXjOOFy/cVvpsLQxGAxYsWASLL2yzZK8LX3Wy4kTu//QMcjrts4e2oza1cvpWWov7+BMmjiRmpWTD+D8ebLj8LGTEEcrfryfIfki6OpqUDo8+3XGYM2hkbQlKzfgxcvX2Lp2LpZofRw0bIJy0iVPys+dNhLyqja/5ERWQtsW9VC2RGHI67PkF/MkLaB1Shk9WLLVx48f0bJjH3j27Yxta+fh3oMHWLR8rV5E7cUxWLx8HTat8sK44X1x8PAJlX7h0jX1hUQ4yk80y8/BWvpypYS1TdWKpSCvVVs4ayymjPU5Jv1rh7wzd8PymVA/cKJ9ySlwbYUAABAASURBVNPUwS+bC6eVCyZj6tiBRttYG8OiS4LBYMCYob0hr4iaNm4QungMkWQVdHZii6fPXqhxbst4lgdHixXKh+6dWig76j/cEtjz1lof7v/zUL26a+3S6RBnWpxdg8Fyf6zZM6jPW2v2GTB0PMqXKgqxp7wLWwE22fg3FoSd2EFet6df80yK+4h6jpwMea2dvM5w0uj+PvKs2UbGjoxpW89rH0p5QAJhkIBLGGwTm0QCASYgPwghhbJk/B2Xr92QKPYeOAqZUZRZkL6Dx+KU2c8Ei9Dxk+dQo3IZiUKcqSSJE6i4/AztyrWbIbORM+cuxXnttrpkZM7wOyZM9cLI8TPx4J/Hxh8/SJ7sV8j7KuUnNeXdvZev3MDtO/dx594DdO87HNKG1eu3QH4a9dade5Cf35QX54vTWK1SKVFtMRT9I6+PF/FbFDJJtKXPunic2DHx9OlzzRGaiPlLViPGTz/qWcZ9tizpNSf3lBZOonmjWjh89DQOabPM2bV0XahAnpyqjdkyp9dm0a+r5P3aLPKxk2dQuU4rNTP9+MlTXLx8TeXlzZ3V+B5lv+SUsJVNQOs0VWPJVjdv30X8n+MgQ7rUkHfT1q1RSevrKdNikP6UK1UE8kME8l5a+XEOEZAvAWU0h/yHaFERXWMo76+VNMkLaPCvHUUK5lUq5SdoZRZSDvyyecF8uZRt4seLa7SNtTEsuiQYDAacu3AZzbU7Eu27DcT9B4+MX1ZS/JZUjXOR+zlubMg4D8h4lnKmIbDnrbU+yLiUd3T/9OMPiBsntnaOPlL9t9Qfa/YM6vPWmn3kS3F172uPfKk25SJxf8fCH3lEDD9r/dSveSrBwub31L+hZ/+RmDR9vhrfFkR8JX3POeZLGRNIwBYCwSxDhzeYAVN9yBCQX1OTmsRZ+fjho0TxRfu/ZM54NaMkMyE3z+1R6aabL1+++PiBhXDhwqns6XOWaB+WDzGkXxfIi+/fvHmj0uvXroxhA7prH6YxNWe4A2SWVDL0+iVuMLjggzZjKPWnSJ7EWP+mVXOwdO5EaFX6qNPdzV2KWQzhwn/Lc3Nz1Wajvyi5jx8/qb35Rur0r896GfklOpmBzZc7O/bsP4Ie/b7+EIWeL3txIA5rTq7MWP6vcD5cvnpdOb9ZTNYYuodzE1HVp49av+VAuPbq0grCXYL8aET2LBkkC+FNfiHNLzklbGUT0DpN1YRz/8ZUt5XkC1/ZS3B3d9Xs9JW1HEuQtrq4uEpUBTeTX/szjbu7u6myrq6ukBlGJaxtZOZQ2/n756bZWRcyb4e0Qc/T937ZXNfl4uKilplIGWtjWPIkHD95Vi156dC6EWR2+BfNWX79+uv4d9P6JDISDAbD13GuYZK+SpoEv8az5JuGcN62UO0LwHlrrQ+6PqlDdH7QdFrrj7B0cfFtT+EZlOet6LN0Tsp1QH6gQdoqY0b25kG3n6S7u7uqcSVxCW7etnAR22r9lDRrQX7Uok6N8nil2bGK9iXUdFxaK/M955g1nUwngdAk4BKalbNuEghOAvlyZVOzl1KHfLjJ7XuJm4ZMGdKomWBJE+dVn4W8dvMW8uTKinjarN+Wv3ZLtgrPX7xUt6NrVikLmcmV29kqw8Im4S/x8OTpU/y5ZafKfa05zTKrkyhBPNy5e1+75f9Kpcs6PRXxZyPlZDmAiMlPAcvePNjSZ72MtMdgMCBPzixo37Ihjp86q2cZ9/ILaXsPHIH+K24yg7lzz0HkyJrRKGMpkidXFm0mfK76gJV8mY209FYCW+QiRYqEF1/XZYsqq8EWXdYKJ0oQX5vJfKhu0Ysz4LVgJbJn/eqg62UyabP7+w4eVYfi2OvxrJnSY+3G7ZCxIWu6127chmyZM+CX+HFw++4DJS9933/wuIrLJnLkyHihjSWJmwb/2rFw2VolLjPymTOmVfGA2FwKSDtlSYW1MSxrSzOmT4XkSRPh+s3bOHfxihSzGhLZOJ4jR4qAly+/jnmryrQMW/rjXx80NcY/a/2xZs+gPm+t9SdT+jTYtfeQaufOvQfV3nSTyIYxaSrvV1x4pf89FTq0aoAnz54bz0u9jK22+Z5zTK+LexIILQJ0eEOLPOsNdgIeXVvj0eOnkAdt5KGsDZt3+KpT3tN7+849yAMdHgNHIemvCZVM/VqV0LPfcPVw1e0791WabDr38kTyDAW12d2OkHWIhQrklGSLwVWbgZF1uvIQijz8kzlPGcgaSHdtVstTmzlu3Kob5CE7U/0WFXknVi5fCiPHz1BtkofqvJN97Gzps17gxs27+CVlLvVg0qgJM9Bb46Xn6fsokSMhshbEOZC0LBnTIWLEiJB0ObYWqlUsDZkdlgf2chWuCI+Bll+DZoucOORv3vynHhTTH1qzVK8tuiyVkzSZoR09xAPd+wxH4TK1NdvGgOiTPD38nuo3yFtB5EHDOk07Ki6SJz/52qB2JfUgWcVaLdC0QQ38liwxImuOer7cWRXfZu16QX5+WeQltGhUC509PH09tOZfO+7dfwB5EPDPrTvRs1NLUYWA2FwK+DeGZanG33sOqWU44yZ7QZZ5SDlrwdbxLD/xvX7TX4rTo8dPrKmzqT/+9cFUubX+WLNnUJ+31uwjd0BmzVv29Xy+ch0//BDVtNlqjbx/Y9JHAT8OchaqqF7f2Ly9B9q1qIdoUaP4kLbVNnJO2HJe+1DOg2AiQLUBJUCHN6DEKB+qBPJqs67yQnrTRhzcsRoRIoRXSZIvv64mB+KQygMaOzYshNxSH+jRUZJ9hIgRI2DiqP5Y4jVBPewiP1YRM8ZPSJcmJUSv1NW1fVMVl4LTxg3G5RM7IA9dDe7TGfJhL+sj5bVpki9B5PV1wRnSpsaKBZOhHmY7tg0VyxYXERQpmEfVuXDmWKxcOBlD+nVV6aYbeaircIHcxiRxog7uWAVpU7cOzSD9kkxZM9q3RzuJao5adPjXZ5Hv17O9+gW6B1cOqbZJv/LlzqZ0mG/kgb42zeqq5NbN6qgH+dSBtjFv49Hd67RUwGAwoHvHFqqN+7atUA8Uyu3bKhVKag5NG+j/DAbLcnq+7MW5njp2kFoOIuusA1qn6NCDX7aSsSN2/Gv9AowY1N24PnvnpsVGB799ywaKv9hNuAhL0d24XnVIObFJg9pVJEmFof27Kb6zJg1VY6bk/wqq9PKli2LBjDGYMnagOjbdWGuHyPTt3g5//7lIPSSoO9DWxrk1TmLry2ZjWHTrQZwh6ZssRRk7rDfkIT7hJkH46HKm49yW8ZwmVXJ4TR2h2i5tlvMrsOetpT6Yjy1pvzCy1h/phzV7BuV5K321dE7GjRNL8ZDzOXGiBMis3UGQNsm1QJYPSdzaWLDGTsroQcamnOdyfO7wFnUNk6UNpuNT8iSY28ba2DEY/D9fRR8DCYRFAnR4w6JV2CYSCAICVEECJBB2CRw9fhoJtDssBUpUx45dB9Cq6dcvlWG3xWwZCdg3ATq89m0/tp4ESMBJCJjO6jlJlx26m/Kav9sX9kFefSh3AOTOkkN3OHQ7x9pJAHR4OQhIgARIgARIgARIgAQcmgAdXoc2LztnMwEKkgAJkAAJkAAJOCwBOrwOa1p2jARIgARIgAQCToAlSMARCdDhdUSrsk8kQAIkQAIkQAIkQAJGAnR4jSgYsZ0AJUmABEiABEiABEjAfgjQ4bUfW7GlJEACJEACYY0A20MCJGAXBOjw2oWZ2EgSIAESIAESIAESIIHAEqDDG1hytpejJAmQAAmQAAmQAAmQQCgSoMMbivBZtXUC2QuWw9u376wLmOV07zsMm7btMkuFSuvWZ6ivdFsSRN/lqzctiopOyZfMGV6L8f79B4kGOOT/XzW8ev1GlZu/ZDXKVW+KkeNnqmPTjbD48Zf0sBQWLVuLAUPHmYoHKG7aBlsLSpu9Fq6wKu5XX/RCAbWZKXNdh7W92MbUdgEdT9b0hlb643+fokjZOqr6cxeu4K9d+1RcNuZ9lbSQDubjYenKDVbGpOWWmZe3LBVyqcJamFurUfKKlvtqD2syIZneZ9BorNmwLUirNB9n7boNwLa/9wZpHVRGAiFJgA5vSNJmXXZFYNuOvbh63bLD26huNWTNlE71Z9a8ZXj/IXAOr1LgvRkzcRZWzJ+Ejq0beqd820WIEB7P7pxUoXvHFvDo2kbFJc3V1fWbYAjFXr1+jflL1litza++WC3kT4Ypc39E4Zft/CsbFvN/iBYFwwd0U027cOkKdu4+qOKyCQt99W88SDv9Ct9b3i/dzAscAfNxFjgtLEUCYYdAmHN4ww4atiS0CXiOnITiFeqjRsO2ePnqtWrO7Tv3UL1BGxQrV1ft7957oNJNN1t37EHeolVQqVYLbYZ3pzFr977DSt8fpWqiU09P6LOy6XOVMMps2LQDPfuPwNnzl7F5+y54jpikZl0fPX5ilJGIzOoePnYKS1asx63b91CjQVs0a9sLL16+Qtsu/VGmamMkz1DQOBN3RJMtXaURCpWuhebtPIz9EV0Sunh44o7Wl4pam//c8q3NkmdLuHLtFirWbK76vWrdZmORxSvWqToLlqyBEeNmGNMtRT5//oySlRoiX7GqajZx74EjSsxSn8ZOmo1Ll68pNuOnzFVy+sa8L99jM12n7HXmEh82ZhrK12iG1FmLYvjY6ZJkDNZsZ2k8PXj4CA1adFWMRN+lKzeMevTIu3fv0bHHYCUjfPYfOqayZBazbtNOinuJig2gc//48SP6Dh6DAsWrK44yA6sKmGxGTZiJ2doXJUlq1bGPGjsSn7toJSRPxnWBEtVRt2lHNZZkRrGzxxARwdhJc7Bm4zbFfva85b7GqbU+yQydjHvpp7T3/MUrSp/pRthJn2T2MmWmwnjy9JnKnj5nEf7QzhsZR7PmLVVpphtL48HSmLQ2xiyV1/VbK6Pny154SdvqN++izoGuvYdg3Z/b1XgWm91/8FDEYM2W//33VtlAzs+GLbvhvWZzKWCLLUVOD5b4SfvlDoy0L13OEpg8Y4ESt3Y9krsRcg2S81nOQWvn8GjtC3LuIpVQpU5LXL95R+k031g792wZC6bjbMeu/Ur1pq271LiTsa2Pn4AyUoq4IYFQIECHNxSgs0rbCGRIlwZ/rpyNzBnSYd6iVapQvyHjkD93Dmxe7YVc2bKg/9DxKl3ffNBmWjt0H4Sp4wZj8ZxxuH7jtsqSi3JLzbHw7NsZ29bOw70HD7Bo+VqVZ2mTJlVyFCuUD907tcDqRVMRK2Z0S2KoWrEUEiaIh4WzxmLK2IHqQzZ+vLhYu2Q6zhzcjAxpU+PTp0+QNg3TZui2r5uP9GlTYdzk2T70DRvQHXFix1R1FS+a30eeLQf3/3mIedNHYe3S6RDHTj5kr1y7iVmaUyWzxlvXzIV8QJneCjfXazAYMGZob+zavATTxg1CF28HSxwH8z61bVEfvyVPotrbupnPW7vmfQmszczbpx/f0D7cxelctXAKzh7ajNrVy+kiaVoaAAAQAElEQVRZam/NdpbG08ChE1C4YG6IXfp0b6M5tgOVDtPNgqWr8fjfJ2rc9O/ZDs3beyibiozOfeOKWRg3xQvCfYl2O//Fy9fYunYulmhjcNCwCXj2/IWIG0P2LOlx6OgpdXxL+xL38NG/Kn5YS8uWOb2Knzl3CX17tFNjyd3dXaXJpm2LeihborBiX792JV/j1K8+uboasHLBZEwdOxCDtS9zos80TJ4xH43rVcOW1XOxb/tyRIkcGRcuXcO02YsgvGUsjde+4Jh/MWhrYTzobEzHpMFggKUxZqm83i6DwXIZPV/fX9XGez+N1zbtHNt34Jj60rph+UztHC2p2i9y1mw5b/EqfP7yWY2DWlXL4uSZ8yIOW2ypBL03lvgt1r4Unzh1HptWzsGx3WtRomgB+Hc9SpcmJVZodooTO5bFc1gc68XL12HTKi+MG94XBw+f8G6Bz51f555/Y6GtyTgrmC+nUixlZBx49utsHD8BZaQUcUMCoUDAJRTqZJUkYBOBQgVyKbksGX/H5Ws3VPzI8dOoW6OCijeoUwmHjpxUcX1zS3MeEieMj9Qpk8HNzQ3VKpVSWTdv30X8n+MgQ7rUcHFx0XRUgjgXKjMIN2lSJlezykNHT8UebYY0+k8/4vad+2r2tnvf4Wp2ZPX6LTh5+usHalBVLQ5UpEgR8dOPPyBunNh48M8jHDxyAo+1mel6zTqjUu2WOHfhMuSDF1b+GQwGJdNcm4Fu320g7j94pBw1S32yosJicmBtZlGZlhhH+2Lw9Olz7QN3IuYvWY0YGmMt2d8/S+Np74GjkJlaWTvdd/BYnDpzwZeew0dPa051eRgMBmTOmBaxY8VQNhXBnFkzQrhLPFrUKIr7/oPHcOzkGVSu00rNHj9+8hQXtdlwkdFD5gxpNZnT+PfJM6VPdN7XZiGPnjiNLFodIpfu95T4NVECiQYo+NWngvlyqX7IF5hLV6770ps5w++YMNVLrSN/8M9jhAvnjsPHTqKM5mD/EC0qZDyXLVlYpfkqbJZgaUwaDJbHmFlRH4cGg21lkif7VX35DB8+HFJp53+2LOmUnozp0xivH9ZsefzkOdSoXEbJi3OXJPFX7rbYUhXy3ljit08bY00a1IC0S65JibTrk3/Xo/8V+fql19o5fEwbX+VKFUHUKJG18z0WihXO590Cnzu/zj3/xoJPTV+PCuTJqcaPfCnTx09AGX3VxC0JBJTA98vT4f1+htQQTATCec9qiYP68cNHVcuXL180R9ZVxcOHC6f2phstG6ZrWt3d3I3Zbm5fy0mCu7srRJfETcNHbTbW9Dig8QyaQy0zIGlTp8AwzeldtW4Lvmj/U3jPhsps8aZVc7B07sSAqvZTPpw3KxESXh80XtK/8qWLqplAqXf/9hXo0Mr3+mApI+H4ybPwWqDJtG6kZgF/0WaqX79+o74kmPdJ5G0N0g6dfUBtZqmOiBEjqNnTfLmzY8/+I+jRb6QlMV9pOiPhYxxPmm2WzBlvZHTz3B5f5STBzdVk7Li5a6W+SLJxLMqBwWCAzr1Xl1ZGneePbEX2LBlExBgiRAiPGNGjY+OWHVpeehU2b9uFaFGjQvJE0BIrSfcvyHiz1ifdDorBx6/nlKm++rUrQ2bo48aJiTpNOkBm0yVfHDXZS3B3d7N47kieaQhnYUxaG2Om5czjtpYxrc/VxRX6uS9x3d6i25ItZYy6mtg4nPe1RdL9s6Xo1IMlfqLD3f3b+NFl3fy4Hum2l7KWzmFJd3H5ptPUPrp+2YucXo+uU9Il6OkuLi5qxlnS/Avu4dyUiKvGSmap5UDqCAgjKcNAAqFBwCU0KmWdJBBYAvKgmKxzlPIz5y7VHAWfjkSiBPFw5+59tZZWZGSdnOwTJYivzVg+xInT5yC3nb0WrET2rF/L/hLvZ8gaQJHbtfeQ7FSIHCkCXr58peJ+bSJrt31fvHipRJ5re5kJK1GsAKpVLIXj2kxMwl/i4cnTp9DX5r5+80a1QxWwsHn56rVW7qyFnIAl5cyWESvWboYsbZCSwkV3YOTYPIhcxvSpkDxpIly/eRvnvNd4WuqT3OrW+2yux/w4sDYz16MfCz+DwYA8ObOgfcuGOH7qKys9X/a22i5frmxqpljKyAe3LJWQuGnImjmtmkmW/OPal4JHjx9DbGoqYxrPkyuLNks6F/LmAUk/cuyUcb24HOshhzb+ZDY1W5YMyJolPSbPnA9J0/Ot7SNFioQX2hjR8yObjVNb+qSXNd+LrWWJTs0qZSEzo7KcIWum9Fi7cTskT9b0rt24Ddkyfz139PK2jgdrY8yv8tbK6HUHZG/NlpkypIHMjIsuOUf0GXlbbSnlJAgjc365cmTGDK8lav2wyMi48Ot6JDJ6sHYOZ9Jm4vcdPKrExPHU4yrBZJM1Uzr4db00EfUVjWQ2znwJeCcElJF3Me5IIMQJ0OENceSs8HsI9OnWRr0ap1i5uvh7zwF4dG3lQ527Nqvk2a8LGrfqBnnYTZYTiICbmxtGD/FA9z7DUbhMbcSKGUNzSEtLFhrVrQJ5WKxW4/Y+Zq6qVCiF9Zv+Ug9HmT+0pgp6b1o0qoXOHp7qoZdVmoP5c/LsqFy7BfYfPq7WQ8psiKwpnuG1WD3ElDlPGch6Q+/ivnZXrt5Ax56DfaUHNCHpr4kgvFp26K0eOJLb9v+9fWtVjdwW/XvPIYjcuMleamZXhC31KUrkSCj1v4Ko2agdZE2nyFkL0oZtf+9VDxoGxGbW9N24eRe/pMylWI6aMAO9u7b2JWqr7Ty0so8eP4U8UCQPwG3YvMOXrppVyuGHaNHUuOk1YBTGDuvj4y6CeYFqFUtDbufLQ4q5CleEx8DR5iLqOKvmSP7z8F/I3YDUKZJpX9T+QZaMX2/DKwErG3H037z5Tz2sJA8TmffVlj5ZUY3OvTzVw5Z1mnTUzpHoKFQgJ1L+lgQNaldS54GcJ0212/O/JUvsQ4Wt48HaGPOrvLUyPhpg44E1W9auVh6379xD1bqtNHuNQtJfEyqNttpSCWsbS/yqViiJ35L+iiLadSdtjuKYOmuRdmfA+vVIU2P8S2rlHP491W8okDcH5MHcOk07IrJ2PhoLmUT8O/dMRH1FzceZLwHvhIAy8i7GXfASoHYLBOjwWoDCpNAncHDHauOt3by5smL8iL6qUQm02dJFs8aph9ZkL2sRJcOzbxf8z3sdW5GCebDEawIWzhyLlQsnY0i/riIC0SMPwf21fgFGDOqu1idKRvnSxXDgr5WYP300Rnn2xKDenSQZ8vCT19QR6mGdWGYPrYlOvb7ypYtiwYwxkIfW6tWqhPuXD2LZvEmYNm4wpL2iTB5ek4dQ5OGxC8e2oWLZ4pKMnZsWQz7s5eDkvo2yUzNr0kZ1YGHTtX1TdGz9bWlCFe0DVV5TpovK8gVZJyjH5bW+yQN+ou/IrrVIpTlWkm4a9DZEixoF8vCWlB87rDfk4T7ha61PUqf02/yhNdGt90XiwkBsJe2QveiUdFtsJnJ60JmLXR5cOQRhKYzz5c6mixj3ImNqO2vjSew6aXR/7NiwELL0YKBHR6MOPSJrL0cO7qHYbFg+EzmzZVJZ1rgbDAZ079hC6dy3bYV68DJcOHdVxnQjDyfeOLtbrSmX28p3L+1HqeJ/KBFhJGNVHWibmDF+Uv3Vomq8TB07SC2LkfWmaVIlh2lfrfVpjPaFr3CB3KJChaO716m96UZ4Xj6xA3OnjcTgPp0hXyAlv3G96pAxJJwa1K4iSb6C6XiwxsbaGBNlpuXlWA9+ldFlzHlNHjNAne+SL+v5F88ZL1G1jtaSLWWZzMRR/dV1Qx7+lHNFmBsMlm0peVtW+3w7iVRgiZ982ZaHD+Vh0NMH/jSeu9auR6ZjVXRaO4fbt2yA5fMnqeucnLeytlrkTYO1c8+WsSDXJdNxZq2MwWCZkWk7GCeBsECADm9YsALbQAIhTYD1kQAJkAAJkIATEaDD60TGZldJgARIgARIgAR8EuCRcxCgw+scdmYvSYAESIAESIAESMBpCdDhdVrTs+O2E6AkCZAACZAACZCAPROgw2vP1mPbSYAESIAESCAkCbAuErBTAnR47dRwbDYJkAAJkAAJkAAJkIBtBOjw2saJUrYToCQJkAAJkAAJkAAJhCkCdHjDlDnYGBIgARIgAcchwJ6QAAmEFQJ0eMOKJdgOEiABEiABEiABEiCBYCFAhzdYsNqu1Bkl23UbgG1/77W562s2bEPfwWN8yb96/Qb5ilX1lW5LgpT1WrjCoujSlRswYOg4i3mBTTx05CSq1GmJhi27BVjFuQtX8NeufQEuF9gC5myCg4d/bRO7SjskWLOTJR0Bldd1yBjrM2i0fmhxb4uMxYJmiXfvPUDxCvXNUkPmsHvfYdi0bZeqLP//qkF4qYNg2khd3foM9VO7yFy+etNPGfPMGV6L8f79B2Ny9oLl8PbtO+NxcETE/pauQ7bU9fLVa7Ts0Bs5/qiATHlKoVq91rYUswsZ0zFlFw1mI52WAB1epzW9c3f81evXmL9kTYhBmDF3CTq0boSZE4cEuM4Ll65g5+6DAS4X2AIhzcZSO8cM9UDECOE1hyxgdgps23Nlz4S6NStaaooxzRYZozAjNhPYtmMvrl5XDq/NZWbNW4b3H745vDYXDCXBmXOX4sPHj9i1aQmO7VmPpg1qhFJLWC0JOC8BOrzOa/tQ7fmmrbtQrnpTFCheHecvXlFteffuPTr2GIxCpWuhZKWG2H/oGMz/yQejlCtRsQGGjp5szLZWVmaCxkyabZQrWLIGnj1/gbFa2qXL11Qbxk+Za8zXI1eu3ULFms2Rt2gVrFq3WSV//vxZtUtmH4uUrYO9B46o9BcvX6Ftl/4oU7Uxkmco6Gs2VmYoxWHtNWAUho+djo/aB5/MFEnfRc8m7xk3meWSmaoCJaqjWv3WkJlAqWDspDlYs3GbauuOXfvRoEVXHD56UrJUX6RPciAzsXWadESlWi0gs+jW6jl7/jLqNu2EouXqIGWmwnjy9JkUNwZLbCzxkAKLV6xT9pI2jBg3Q5JUu6UPdZt2VEz+++8/NUNv3l/pX+qsRVUZ8027rgPwnzZjZ96WgLbdnIk1xvsOHoPXgq8z/sKuU09PlK/RDDLO9PFpi8ybN/+hadueKFymtrKTzKI+/vepefe0vr3VbNARwk1m/vTZyf5DxiFz3tJqJnCm9iVJLyjjomf/EWpMyrgbNmaaap/wkzGly+l7mY1Mm6O4ugMi55TpbKguY2kvNtFtZ9428zYcOXYKpas0UvZv3s4DMospOrfu2KPOGxmHm7btlCQVLPVN7Ll5+y54jpikxvejx09gTa9Som2WrFiPW7fvoUaDtmjWtpeW8vXPc+QkNXNeo2FbY1sePHyk7CDXFLHnpSs3vgqbbMXecv5WqNEc02YvUvKWzi+TIrBFr6n843+fIFvmdAgXzl0lF8yXU+394m2JlxQSO8jdCLkOynmsY1hW8wAAEABJREFUc1+rXSOq1m2l2EtfRNY0WLtGFitXF3fu3jeK5ixUUfXPWh/NeRkLahG/2tyj33B1/RQ73Lx1V5PmHwmELAH7cnhDlg1rC0YCrq4GrFo4BZ79OmOw9mEnVS1YuhrywbBt7Tz079kOzdt74NOnT5JlDAOGTkC5kkWwccUsbQYwgjHdlrJGYS3StkV9/JY8CVYvmorWzepoKT7/7v/zEPOmj8LapdMhH6Ti7BoMBowZ2hu7Ni/BtHGD0MVjiCq07s/tiB8vLtYumY4zBzcjQ9rUKl3f1K1RETmyZcDwAd3QuW1jLFm5AS9evsbWtXOxZM44DBo2QTmuMWP8iHVLZ+LvjYtQs0o5DBo+Salo26IeypYorNqqf1CqDAsb+SCZO20kxgzxsFrP5Bnz0bheNWxZPRf7ti9HlMiRfWhqa4GNJR5Xrt2EzLStmD8JW9fMVV9c9KUXZ85dQt8e7RSTleu2WOlvdMyePMxH3eYH5m0JTNtNmVhjbF6vjM+VCyZj6tiBxvFpi8y8xavw5csXyBiuU708Tp45b15MHZ84dQ7NGtbEX+sX4NmLF5AvDpJRrVIZHN29DtvWzcfKtVt8zHymS5MSK7Q2xf85LuTLoJw/Zw9tRu3q5aSoj5AhbSoc2bkGf/+5COHDu2tjYb2PfL8OxAnt16M9dmxYiMiRI/ooq7chR9aM6NB9EIZpY3q71tb0Wn3jJs/GB23WVdKnjhuMxdrYvn7jtrEqS31Lkyo5ihXKh+6dWqjxHf2nHyzqNSrRIlUrlkLCBPGwcNZYTNHsoyWpvwzp0uDPlbOROUM6zFu0SqUN1K4XhQvmhrSxT/c22hfqgSrdfGMwGDS2k9CkfnXzLIvHturVC9eqWh5TZi5UX1jGTfFSXwr1PGu8LfHSy0hf5dpVvGh+Y189R06G19SR2L1lKSaN7q+LGvcLllq+vpYuXgjLVv+p5GT5VJzYMRE3diz41UeDwWCRl19tTvd7SmxYPhN1qlfAYO3LiaqQGxIIQQIuIVgXqyIBI4ECeXLCYDBosx7pcenKdZV++Ohp7cO7vErPnDEtYseKgdt3vs08iNDxU2dRvXIZiUI+RFRE29hSVhOz+S97lvSIFCkifvrxB8SNExsP/nmk2nXuwmU012az2ncbiPsPHilHNU3K5JCZrKGjp2KPNusb/acf/axnvzabeOzkGVSu00rNJj1+8hQXtdnmiBEiaE7OZsgsrdwCPX/pip96LGXmzZ1VtVvyrNWTOcPvmDDVCyPHz9T69dg46yRlrAVLPA4eOYHH2oxcvWadUal2SwibE6e+Onjy4fZrogSQf9baET58OGTPkkFEbA6BabspE1sZF8yXS9lbvsjo49O8kZZkpP81vMdngbw5kCRxAvNi6jh1ymTImS2TqqNm5XKQcpLx+vVryExY7cYdtPH1Dy5cvCbJKvyvSH61F4fk6dPnGDxiIuYvWY0YFsabu7sbRk+cher120Bmpi9cuqrK2rJJnSIZEif6RYkWLpgHR4+fUXHZ6G2Q8/LOvQfo3nc4ZKZx9fotOHn6PG7duYfECeND+ufm5oZqlUpJMRX86psS0DbW9GpZ/v4VKpBLyWTJ+DsuX7uh4nsPHIXM8ksb+w4ei1NnLqh0803RP/IqW5inWzu2Va9ePuVvSbBnyzI0bVhD3Z2R2XP9zoo13n7xKvJHHqX6Z+3apPf199S/oWf/kZg0fT5cXHx/tFu7RpYtWRgyOywKZV+mRCGJwq8+WuPlZ5sL5lV6ixXKq2bx1QE3JBCCBHyfFSFYOatyXgLu4dxU511dXdUtfnWgbdy0Y22n/tzd3PFF+68OvDfa5JnRQZMPde9ktbNU1s3VDTI7qwS0zaePn7St/3/h3N2NQvLh8eHDRxw/eVbd9pa1uDL794s2q/v69RtkSJdazVanTZ0CwzSnd5U2o2ksbCEiM4C9urRSM1oyS3P+yFbl+E2fs0RzQB9iSL8umDFhCN68eWOhNODm5orPAkLL/WjWn/Det0y1LDXTaKme+rUrazNz3TVHPqbmXHfAjZt3RNzPYImH9KN86aLGfuzfvgIdWjVUesKHC6f2shE5S+2QvICGwLTdlElAGEvbxPYfP36UqK8gdpBEUxnpq4xpSZcQzoSDHOtBxqUx7u6q7mTILefm2l2NyuVKYPHscSiqOQavTcaAzjRixAjq7kC+3NmxZ/8R9Og3Uldl3HfqNRgpkv+K6do4at+yIV6/+c+Y519E+mAqY3qst0HOyxTed0hkDG9aNQdL507Uxhxg2n85h0WXf30TGQnW9Eqef0Efo8oe2vkq8qJvyZzxxjF689weSfYVwoX/dr6LXa2dX3pBW/Xq8rKPECE8xFGUO0eZ0qfB9r/3SbLG7Iva6xvh7R8vN+/rpGlfp4/3RJ0a5fFKuyZV0b5Mm173dN16OTkW20g/EvwSD8JOlout2bAVJYoVlGztyvtFuwNlmZ0pLyWsbfxrs/RLE+MfCQQHAZt0utgkRSESCAECWTOnVTNWcmEU5/LR48dIqF2MTauWD4pdew+ppJ17D6q9bKyVTZgwnpp1Ehm5tX3p6tfZZLmN/+LFS0m2Ocgt/IzpUyF50kS4fvM2zl38OgP7XNPzQ7So2gdFAVTTbrce12Zv/VKaJ1cWbYZ1rvpgEjlZsyhrLK/dvIU8ubIi3s9xsOWv3ZKlQqRIkfDi1WsVl00i7Xau9EXiO/cckJ3FkMdKPdJeuSVcs0pZZNQ+eC9cuuajvK1scmbLiBVrN0O4iAJZB2jJebbWjhcvXykOUtZaMG/L97bdGmNr9Qc0PVOGNGpmTMoJC5m5l7h5OKvdKZAZchnrC5eu1W7D/45/tZn+H3+Ipmzi4mLA31YeVHytOcEGgwF5cmaBOLNy18Nc/9VrN9VSgWhRo2DbDstOnnkZ/dhS2/Q8fS/n5ZOnT/Hnlp0qSdp04vQ5yNiUcSC2lYzd+w7Lzs++RY4UAS+1sSCC1vRKnmmIHDkybDl/8+XKBpkJl7LCWpaCSNyvIH3w7/yyplf6Lo6juX45x/UZ3cf/PlVLVeQOlshZ4m3rWJDyepBzI/3vqbQvnQ3w5Nlz4/VFz7d2jZT8MiUKQ+5QxY0TC7KcAdo/a33Usiz++dfmhcvWqnJyVyKzdgdPHXBDAiFIgA5vCMJmVX4TkHWrP0SLBnngRx7wGjusj4/ZIindu1trtW5UHojZseubs2etbN6cWSFr5OSW5vipc5Hs10SiBlEiR0Kp/xVEzUbtMN7CQ2tKyGxTrHA+/L3nEETXuMleamZXRFZpTt/PybOjcu0W2H/4uFofK+nWQrWKpbUZ3fTqgZ9chSvCY+BoJVq/ViX07Dcc0je5tasStY04Nm+0GboqdVpCHlqrXL4URo6foeTkISxNxOKftXo69/JUD9fJ0olYMaOjUIGcPsrbyiapxrJPtzbqdUt/lKqpuPz39q0PXXJgrR3ywM7GLX+LiNVg3pZAt927BmuMvbO/e1erajn1QFXVuq0gD0vKchdxOs0Vp02TAsPHTFMPGEWOFFG79V9afdFJliQR5EHGRq26IXXK5ObF1PGNm3fxS8pcSm7UhBno3bW1SjfdtGleH3LbvFbj9ogYMbxplr9xS20zLySzuLJOVx4KlfZmzlMG4mS7a3dGPLU7FI219svDY/o4li9x1vpWpUIprN/0l3oI78nT57Ck17z+Fo1qobOHp4+H1sxl5NhDY/Po8VPFQh7w27B5hyT7GWw5v6zpXb1+K2bPX+5L/41bdyHniDzklzbH/1Agby7kz5NdyVni7RcvVcjCRh42kwfa5C5Buxb1YD7urF0jRZUsY5ClH6WL/yGHKljro8q0sPGvzffuP0CB4tXx59ad6NmppQUNTCKB4CXgErzqqZ0EfBOQB6oKF8htzJCHdOQgfPhwGDm4B+QBkw3LZ6o1jpIua8zkASiJJ0mcEF5TR2D5/EmYOnaQeoBM0q2VlQ9geaBKbruOGNQde7Yug8yiSRmPrm2wYMYYXw+tValQEpInMhKkbKKE8dUHiLRNjscO6w15MEnWeNarVQn3Lx/EsnmTMG3cYMgtQilnGrymjlQzd5JmMBjQvWML9VDQvm0r1IM24cK5I12alDi4Y7XqW9f2TVVc5MXpk77KLWN5aO23ZIm1vFVKrluHZkqPyJm322CwXI+08fKJHZCH2wb36QxhJOVNg/RfZ2OuV/ovPES+fOli2LzaSz18dWTXWqRKkUw9wCcPD0m+BIPBcjuOHD+NhnUqi4ivIA8GSr8lw7Qt39t2a4xljPXr2V6qg7XxaYuM2HGUZ08s8ZqgHkr76acfjEtwlHJtI2NGHkyUMSzjceKo/oig3e7WsjBhZD/IeJXxMmvSUAh7SZdxocukSZUcD64cUnLCI1/ubCLiI8js/cEdqzB/+mi1fEX6JAKefbvgf9oXN4nv3LRYffGTuGmQdc6W2mbaBpGXhzPlITpp74Vj21CxbHFJRpGCeVT/F84ci5ULJ2NIv64q3VrfpD9e2jktD+HJFzBrepUS70350kXVuas/tGbatrzaXZLxI/oqSdEnD3Dt2LAQsnRooEdHlW66ETam1yNr55fYX78OWdPbqmkdWKqjUrniOLF3A9YtnaGuFcMHdjM2wRpva7ys9fXc4S3adWE1ZGlDg9pVjPr1iLVrpOTLNevZnZMwLWetj+a8TMeUtTZLHX27t8Pffy5Sy7/064ekM4Q8AWetkQ6vs1qe/SaBUCZQu1p5o5MUyk0JsurfvnuPZOkLqBnFTj0HY4BHhyDTTUUkQAIkQAKBJ0CHN/DsWJIEHJQAuxVYAjIrfefifjXrvn7ZDMhsZWB1hUY5mX02nZ0PjTY4U53Owtt0VtqZ7Mu+hi0CdHjDlj3YGhIgARIgARIggbBCgO1wGAJ0eB3GlOwICZAACZAACZAACZCAJQJ0eC1RYRoJ2E6AkiRAAiRAAiRAAmGcAB3eMG4gNo8ESIAESIAE7IMAW0kCYZcAHd6waxu2jARIgARIgARIgARIIAgI0OENAohUYTsBSpIACZAACZAACZBASBOgwxvSxFkfCZAACZAACQBkQAIkEIIE6PCGIGxW5ZuA/BTm27fvfGdYSdm0bRcuX71pJTdkkr98+YIe/Yarn0LdvH231Urz/68aXr1+4yu/z6DRWLNhm690Swntug3Atr/3WsoKk2nm9gmofU079b2c5SdvH//71FSlisvP4b5//0HFQ3LTve8wCJ+A1nnuwhX8tWtfQIuFGXnz9gflmJbzy2vhCmNf5edxBwwdZzwOzkhI1NWtz9BAjZnv7Xdgx+r31svyJBCcBOjwBifd79XN8r4IbNuxF1evh67DKw735SvXsWrhFBQrlNdXG505ISjtE1ycZ81bhvcfQt7hDey4uHDpCnbuPhjY4qFeLjjb/+r1a8xfsibU+xhcDWhUtxqyZkoXXOqplwScigAdXqcyd9jsbH9tRqZkpYZqxtqq8JMAABAASURBVPTmrbuqkQ8ePkKDFl1RqHQtlX7pyg2cPX8Zm7fvgueISShXvSnuP3iI9LlKKPkbN+/gx1/S48q1r85wtgJl8fHjR1jSIwWspcvsU6eenqrOEhUb4PzFKyJuDDIz2LJjb5w8c0G14fade9i97zCKV6iPP0rVhJQVGWMB78joibOQu0glVKnTEte1tnonY9iYaaqu1FmLYvjY6Xqyj/26jdtRqnIjFChRHTt27Vd50re+g8egQPHqkJnMTdrMt2R8/vwZMsNVsGQNpMtZApNnLICkCd98xaoq2b0HjogoZOatWr3WKi6bnv1HYMOmHRK12K4jx06hdJVGyibN23ng5avXSlbfmNvn0eMnKstz5CTFp0bDtsYy1virAtpGGAaU83//vUWztr1U+xq27Ib3795rmnz+LVmxHrdu30ONBm2VrDU2UmrUhJnKZpVrt0CdJh0tzsqv3bgNVeu2Qt6iVVChRnMpZnXMqUzvjTWWJ06fU+NKbJoqSxEIh7GT5mCNVo+MebG/pTq91aqdzDxKeyvVagEZzzJGqzdog2Ll6kL2d+89UOeGf+dOQOuRLygyoy/jtFr91pB6pEHm7Ze0TVt3qX7K+NXPsY/a+WppTOv90fsj5fUwdtJsXLp8TekaP2WuSr5y7RYq1myubLJq3WaVZs3O0kY5V+o166x0SP2qgNnGkl1EJKjq2vLXbtVevY8ysyv65W7EYe2886ud1spKeT2I7e/cva8fImehimqcyp2mtDmKQ64NHXsMVuPNKOQd0ceJHMr1Qa4TErd2Dvs3bqQsAwmEBgE6vKFBnXX6IBAjenRsWD4ThfLnwqARE1XewKETULhgbmxfNx99urdBxx4DkSZVcm1GNR+6d2qB1Yum4ue4sZE0cSI14ysfCvnzZMfhYychTnP8eD/Dzc0NlvRIBdbSJc/V1YCVCyZj6tiBGKw515Kmh3Dh3DFycA9kzZzO2IaWHfvAs29nbFs7D/cePMCi5Wt1cbUXR3Dx8nXYtMoL44b3xcHDJ1S6OOn7Dx1TM8VnD21G7erlVLr55t79B1i7ZBpGDe6JNl36Kwd2ycoNePHyNbaunYslc8Zh0LAJePb8BRZrDt2JU+exaeUcHNu9FiWKFoDBYMCYob2xa/MSTBs3CF08hphX4ePYUrs+ffqEDt0HYdiAbsom6dOmwrjJs32UM7dPrJjRVX6GdGkgP1ebOUM6zFu0SqX5xV8EAsN53uJV+Pzls2pfrapltS8l50WVj1C1YikkTBAPC2eNxRTNvgaDwSIbsZk4x2KziaMGGG3mQ5l24DlyMrymjsTuLUsxaXR/LQVWx5zK1DbWWEp641bd0LZ5PWxdMxcbV8zSxrAr2raoh7IlCqvxVjBfTliqU1Pr40/OgbnTRmLMEA/0GzIO+XPnwObVXsiVLQv6Dx2v6XXz99wJaD0xY/yIdUtn4u+Ni1CzSjkMGj5Jtcm8/ZIo59gq7Q6JZ7/OxnPM2pgWedP+yLEe2raoj9+SJ1FsWjero5Lv//MQ86aPwtql0zVWkyDOrsFggLVz4Kr2JbmPdo2Ra8rTZy8gzq1S5L2xZhfJDoq6Pmh3G9p3G4ip4wZjidd4XL9xW1T7CpbaaWvZ0sULYdnqP5VO+aIbJ3ZMxI0dCxm08/jIzjX4+89FCB/eHUtWrlcytmysncO2jBtb9FOGBIKagEtQKww9fazZXgnUrFpGNb1uzYo4fvKMiu89cBQysyOzWn0Hj8UpbUZVZZhtsmVJrzm5p7RwEs0b1cLho6dx6OhJZNfSRdSaHmvpUqZgvlzKSYwfLy4uXbkuSVbDzdt3Ef/nOMiQLjVcXFxQt0YlrQ2nfMgf0/pUrlQRRI0SGXHjxEKxwvlUvnzoPH36XPvAn6jdll2NGD/9qNLNN9Url1G6M2X4HeJE3rv/D/YfPAbRW7lOKzUT/vjJU1y8fA37NG5NGtTQPrzCKacmUcL4qi/nLlxGc21WVj5Y7z94pJxj83r0Y0vtun3nPu5oM4Pd+w6H2GT1+i04efq8XsTPfaECuVR+loy/4/K1GyruF38lYLaxhfPxk+dQQ2MlRcUxTJI4gUT9DAaDQZvp9s3mmInNYseKYbSZubLfU/+Gnv1HYtL0+cpGku9f36yxlPSftDEgbRc9vyZKYNQpx3qwVKeep+/z5s6KSJEiqsMjx09r47KCijeoUwmHjpxUcf/OnYDWEzFCBKxcuxkyuzxz7lKcv+Tz7oiq1HtTIE9ONS6zZU5vPMesjWkpYtofOfYryLkvff/pxx+08y02HvzzSNVl7RxI8VtSCGvRKV+iL1/5OkblWIJfdgmKum5pd4lkrKZOmQyurq6oVqmUVOsrWGqnrWXLliwMmXkVpbIvU6KQROHu7ga5+1S9fhvs064pFy5dVem2bKyNc1vGjS36KUMCQU2ADm9QE6W+ABNwc3VTZVxdXLTZmC8q/gVfsGTOeDVzIzMvN8/tUenmG/nAOaw5ubLk4X+aI3n56nXl/GbxXvdmTY+1dNHv5uYqO+VsyG1WdeDHRpcXEXd3V8jDVhLXgxy7uHzVKWky8yz7iBEjqBnafLmzY8/+I+jRb6Qk+wqu3nwkw12btf706bOqo1eXVkY+549s1Zz8DCpd2iCyejh+8iy8FqxAh9aN1Mz1L5oj//r1G7hqH64y+6XLyUyWxC21S3il8J5JE3tsWjUHS+dOFHF/Qzh3dyXjotn344ePKi76bLGvEvbe2MJZ+uQtjnDhwulRq3trbKzZzFzR9PGeqFOjPOThqSralw/h6V/fJN8SS0l3d/vKyrwe02NLdZrmSzy8didC9hKkLzq78CZM/Dt3AlrP9DlLNOfyIYb064IZE4bgzZs3Ur3F4B7O+5zXxqB+jkk7LY1pURDepD9y7FcI5z3eREbG3AdtzFmzs8i4aW2QvQSDwYAPH7+OUTmW4JddgqKuL9olz3TcWhsDltppa9kEv8SDtFWef1izYStKFCsoXUOnXoORIvmvmK7Zq33Lhnj95j+Vbm3zUbvTo+cJF0vnsC3jRtfBPQmEJAE6vCFJm3VZJLBw2VqVPn/JamTOmFbF8+XKpmY+5UA+COXWv8QjR4qAly9fSVSFrNoM0d4DR/DjD9HUcXRthmznnoPIkTWjOramx1q6KhSATaIE8dVaYrkNKs6O14KVyJ41gw8NMjO77+BRlSYf7nr8teYQGAwG5MmZBfJhc/zUWSVjvlmycp32ReAzTpw6h8f/PsEv8eMiT64smDB1rnK0RP7IsVNq/V2uHJkxw2sJ3nmvXxVHTNY1Z0yfCsmTJsL1m7dx7uIVKaLpiYPbdx+ouKwV3X/wuIpbaldC7QPzydOn+HPLTqOM9FkdmGzM7WOS5SMaUP62cU6DvdoMt1QkyzJkxlvi5iFy5Mh48eKlSrbGxprNVCGTzXNNT/rfU6FDqwZ48uy5sod/fbPGUtLFvjJ+pQpZkyxjKlKkSHhhsl7aUp0iby3IQ09zF61U2TLzmj3L1/Hp37kT0Hqu3byljcusiKfd8djy17e3l5i3XzXEwsbamLYgakyKYmJLY6KFiDU7WxD1lWTNLr4EvRMCWleiBPFw5+59vPC+rskzAd6q/N0FpGyZEoUxdPRUbdY7FmQ5A7R/skyiWKF8iBY1Crbt2KOl+P77Jd7PxvXYu/YeMgpYG+eWxo30T5xtY2FGSCAECehV0eHVSXAfagTu3X+AAsWr48+tO9GzU0vVDo+urfHo8VPIAyXyQNeGzV8fpqpSoRTWb/pLPej16PETRIkcCZG1kEm73S8Fs2RMh4gRI6p0Obamx1q6lAlIcNNmXEcP8UD3PsNRuExtxIoZA9Uqlvah4vdUv6FA3hyQB1LqNO2o2isCN27exS8pc6kHyUZNmIHeWp8l3TzEihEDf5SsCXkAacSgHmpmVuqQGTp5iCxX4YrwGDhaFataoSR+S/orimhtSZujOKbOWqRux/+95xBkKcK4yV5q+YUIR9YcqXzarW95QKpZu16Q5Q+SbqldMgMlawxneC2GyGfOUwbyYSnypsHcPqZ5pvGA8reFc+1q5XFbuz0sD5F5DByFpL8mNK3SGG/RqBY6e3iqh9ZkeYklNmIzWRMuNpMH4JL8mgA/RIti1KFHchaqCHlQq3l7D7RrUU85Dv71zRpLSZ84sh9Gjp8BeVgzRaZC+Pjxk/pC9EabeatSpyXkoTVLdertsbTv062NerVdsXJ18feeA/Do2kqJ+XfuBLSe+rUqoWe/4Wqc375zX9UhG/lCZ9p+SbMUrI1pS7J6mvSh1P8KomajdtAfWtPzTPfW7GwqYy1uzS7W5ANal7s2Iz24b2fI+m3ph9xp+SFaVGvqfaQHpKwsY1i6cgNKF//DqKNN8/rqGlurcXvtuhnemG4aaVS3CirWagGRkckHPc9Du149snCNtjRuVq/fitnzl+tFuSeBUCHgEiq1slIS8CZwcMdq7RZoV/XQhDzEojtdsWJGVw8B7diwEHK7fqBHR1VCHozymjpCPeglMpIoD7a1aVZXopAHV+ShGXWgbURGHiYy12MtXR7yKVwgt1by69/R3eu+Rky26dKkxIIZY4wpeXNlVQ9l/bV+AUYM6q7dSndXeTs3LTY63u1bNsDy+ZOwcOZY9VCVrKmTvjy4cgjygNK0cYORL3c2Vc50I+0ZO6y34iP90td3GgwGdO/YAtKvfdtWqPrDabd9xTHs26OdekDt9IE/0bF1Q+WECSNZiiC65OE6WZ8s9Qzt303VP2vSUMhDTiU15yFNquSw1K4MaVNjxYLJSv7CsW2oWLa4qPARpKypfcS+ESJ8/SAVTuNH9FXy1virTO9NQDlHjBgBE0f1xxKvCeqhpSO71iJmjJ+8tX3blS9dVNlPHlqTma3t6+arpSHmbJrUr65sNm54H21m/SnS/Z7ymxLv2LnDWyB9lNu4DWpXUanW+ubZtwtk2Y0IWWMpS3HWLpmuxsit83vVWBKnburYQWoJidjfUp2iUw9VtC89Hl3b6IeQ29mLZo1TD63JXre9CMi4sHbuBLQesZewkHHetX1TxUXqMG+/jGlL55jBYHlMm/dHdJoG6aucj3Lum8vKmJdrijU7Cwt5oFLXJ+3W14HrabK3ZJegrCtX9sxq3HpNGaG+0GbK8PVO15B+XdWY8aud1spKu02DjINnd05CH6eSV7NKWc1OqzB/+mgMG9AdYhtJNx2r5UsXw4G/ViqZUZ49Mah3JxHRvtxHt3iNtjRuWjWtA/0argpzQwKhQIAObyhAZ5UkQAJhn4C8uix3kUpqZrxJveqQ5TJhv9VsoT0SmDDVS71GMH/xato4+wFF/8hjcze+p6zNlVDQeQg4cE/p8Dqwcdk1EiCBwBOQmda9W5erWfRK5XzPZgdeM0uSgE8C3To0x6n9GyHjrU/3tuqtErDx3/eUtbEKipGAQxCgwxtCZnR3DwcGx2Ag7750c3N3Vns6ZL/Fnh8/fnTWf+wpAAAQAElEQVTIvjnjdedtx054XaIk3p48g7fvPzE4EANbPrKfPPkXDI7PwJaxYCpDh9eUBuMkQAIkQAIkQAJ2TyB27LgI/sA6QotxYAYoHd7AUGMZEiABEiABEiABEiABuyFAh9duTMWG2iMBtpkESIAESIAESCD0CdDhDSEbRI6TCgyOwSDWr1kQJW5q2tOBxrTYM2bizLSpg9j04OET6sr+564TmLtqF0PYYBAkdlCG5YYEAkGADm8goLEICZAACZAACZAACZCA/RCgw2s/tnL8lrKHJEACJBAEBMpee4SVTbriUez4QaCNKkiABByBgIsjdIJ9IAESIAESIAFHIsC+kAAJBC0Bp3J4Dxw5iZzFahlDsUrN/KRZq1l39ZOi5kJzl6zDwuUbzZNx/NR5dOs/BoXLN0ajtn2xc99RXzJMIAESIAESIAESIAESCFkCTuXwCtpsmdJi/+b5KmxePkWSgixEihgBnVrVw+YVU1G3WhkMGjktyHT7VsQUEiABEiABEiABEiABWwg4ncNrCYrMzDZu1w91W/SEx+AJePnqtS8xmdWtXL8jWnUZjIuXr/vKl4QUyX9FzOg/wtXFBXlyZIT8Itd/b99KFgMJkAAJkEBwEaBeErCBwKp1mzF4xMQQD+cuXLahdRQJbgJO5/AeOnbauKRhwIhp+PjpE3p7TkTzBlXgNWkQXF1dMW/JOh/cr928gxVrt2L62L7w7N0W5y5e85Fv6WDV+u1IliQRIkaIYCmbaSRAAiRAAsFI4MuXL8GonartkcDq9VtC3NkVB9uSw1u3RQ9kLVTVV1ixbqtNaKs36mxxyaVpYVtkTOWtxR//+xSiy1q+vaQ7i8NrtIfpkgaPTk1w995DRI0aGZnSpVIyVcoVxamzPr+NnTxzEQXzZsWP0aIiapTIKJQ/u5K1tjl19hIWLN+I3p2bWhNhOgmQAAmQAAmQgJMS8Jo0GIe3L8G8yZ5IkSyxistxxdJFbCLSs2NT/KD5JH4J2yLjV3lHy3M6h9eSAd3d3IzJblr8C3zPDMjMry7k5uaqR33tHz1+ggkzFmHCsO5IED+ur3wmkAAJkEDoEnCO2g0Gg3N0lL10GAIyk1qxbjt07TsKTTv0w4OHj9GobW9Urt9BzbD+veeQsa+DRk7F8xcv1SxvpXrt0X3AGDRs44H+wyfj0+fPSs4WmVt37qNJ+76o36onhoyZgeJVLD/M//7DB3TuMxI1m3RV+xcvX6k6Jmr+jpSRdk/zWqbSZCN19x06Ec07DcDUOUvx1+6DaNVlEKo06IiqDTuKSIgHp3d448eLjRcvX+Pk2YsK/rI1W5AhbQoV1zdpUyXH0RPn8FkbRHKb7PCxs3qWj70M1p6DxqNH+8b4OU4sH3k8IAESIAESIAESIAG/CCgHtF5lTB3VB3Fjx9T8iSZYNnsUxg3pjrFTF8DSc0H3HjxEkzqVMHPcAPz4QzTs2nvEVxXWZMZOnY+8OTJh9oRBSPjLz/jvv7e+ykqCtKts8YJYMG0o5AH9+cvWSzKKF86LP5dO0dKH4fS5yzhy/IxKl8279x8wcVhPNK1XBWOnzMfw/h2xdNZITBjaU7JDPFh0eEO8FaFYoZurq1p6MGH6YvXQ2tu371C7SmkfLUqWJCH+yJsdrbt6okOvERCn14eA94E4y2Lw6o27GNcJyzc072zuSIAESIAEQoDAmiSxUEH7YI718G4I1MYqSCDoCIjTmTRxAqPC67fuoM+QiegxcCxevnqFO3f/Mebpkfg/x8GviX5Rh7FjRoeUUQcmG2sy5y5cQYXSX5dR6HuTYsZonFgxkEdzjCWhSrliOHv+ikTx9t07jJw4B227e+LOvQe4fO2WSpdN/lxZ4OLy1c1M/3sKDBs7C7MXrMLnUFpf/7Ul0jInCDmypMdYz66+epoxXSpMH9NHPbQ2oEcrRIkcScnMn+KJmDF+UvE61Upj4vCeGD2oM2aN748alUqodNNN8wZV1evO9NeeyV6+oZnKME4CJGBXBNhYEiABEggxAuHc3Y11nbt4FQuWbUDdamUxRZvxTZ4kEd5YmIGViTu9kIuLAR8/ftIPjXtrMuJ7hg/3tU5ZrmkwGIxlTCOSpx/L0k+54/3hw0f0GDAGhfPnVDPQMttr2j5392/LRft3b4VqFUtAlow269Bfc5Tf6+pCbO9UDm+IUWVFJEACJEACJEACJPAdBG7cuosUyRMjSeJf8OLFK5zRZmO/Q53FomlSJcO+QydU3sEjp6zewb57/yH2H/4qt2z1ZvyeOjmePX+BcOHCQWZvxVHX9ShlZpuXr14jRbLEaFCzAtxcXdT6ZDORYD+kwxvsiFkBCZAACZAACZAACQSMQL5cWXDm3GXIg2uybCBNiqQBU2CDdNumtbDmzx1o1qEfjpw4i+g//WCxlCy1kF+YrVyvPZ6/fKWWfsaKGR1pUiZD9cad0aHnMD8f1JeH1UpXb4lu/Uaj2B+5kThBPIv1BGciHd7gpEvdJOBkBNhdEiABEiAB2wmk/C0J5k8dqgrIEspFM4aruGxkeeW8KUMwY2x/DOzZRi1rkNlUyRM5kZcgcUmTUKXc/9CkbmWJQtIlX4LEVaK2MZWJEf1HjBzQ+avuNL+pWVhNxMeflF/hNQbjh/bAsjmjMbxfR0SLGkXJ9OnSHIumD8fowV0xoEdrNKxVQaXLK9EK5cuh4rKRB9vWLZqIIX3ao1GdSpIU4oEObwghf/3PeTA4BoNH14/g1YNztKcDjWmx5+MbR2lTB7Fp9qwZ1JW9eL4MqFM+H4MDMVCGDeSmXKmi6NGpZUgFYz2pUyYPZIuDv9jFy9eRp3htNUsrP3rRRpvxDf5aQ6cGOryhw521kgAJkAAJkAAJhCCB8qWLGZ3QkHR8w7LDmyl9auz5cx5klnb80J4O/UpVOrwheLKxKhLwQYAHJEACJEACJEACIUKADm+IYGYlJEACJEACJEAC1ggwnQSCmwAd3uAmTP0kQAIkQAIhSiDS6NEwrFwFpEoVovWyMhIggbBLgA5v2LUNW+aDAA9IgARIgARIgARIIHAE6PAGjhtLkQAJkAAJkEDoEGCtJEACASZAhzfAyFiABEiABEiABEiABEjAngjQ4bUna9neVkqSAAmQAAmQAAmQAAl4E6DD6w2COxIgARIgAUckwD6RAAmQAECHl6OABEiABEiABEiABEjAoQnQ4QXg0BZm50iABEiABEiABEjAyQnQ4XXyAcDukwAJkIAJAUZJgARIwCEJ0OF1SLOyUyRAAiTgvATetG+PLxXKA+fPOy8E9pwESMAHgYA7vD6K84AESIAESIAESIAESIAEwjYBOrxh2z5sHQmQQBgmwKaRAAmQAAnYBwE6vPZhJ7aSBEiABEiABEiABMIqgTDfLjq8Yd5EbCAJkAAJkAAJkAAJkMD3EKDD+z30WJYESMB2ApQkARIgARIggVAiQIc3lMCzWhIgARIgARIggZAj8OL2Hjw6uzDEw7vnN311kgkhT4AOb8gzZ40kQAIkQAIkQAIhTODFnX2as7soxMNbCw7v1DlLMW7aAh8ELly+jnK1WvtIMz0YMWE2/ty2WyVVb9QZj/99quKmmzmLVmP+0nWmSb7iu/YdwZXrt4zpw8d/02tMDERE2iPtCkTREClChzdEMLMSEggoAcqTAAmQAAk4KoHihfNi8/Y9Prq3Zcc+FC+Sz0eatYOeHZvih2hRrWX7mb7v0Alcu3HHKFOlXDFky5zWeOyoETq8jmpZ9osESIAEnJRApNGjYVi5CkiVykkJOFi3HbA7CX/5GT/+EA2nzl4y9k4c4OKF8mD7rgMoVqkJKtfvgF6DxuHV6zdGGT0yaORUPH/xUh3KrG752m3RvGN/XNRmiVWitrGk59LVG9i59zCmey1D43Z9cPP2PSxdvRmHjp7WSgDHTp5Dg9YeqNW0K3oOHIuXr16rdKlv4IipaNahn8oTOZVhtnn/4QM69xmJmk26qv2Ll6+UxMQZi1C8SjNUrNsO07S6VaK2qVCnLUZOnIPmnQbgr90HVWjVZRCqNOiIqg07ahJB90eHN+hYUhMJkAAJkAAJkAAJ2ESgSMGc2Pr3PiV7+twl/PRjNIgjnCLZr1i7cAKWzhqpjhcs36BkLG2u3riNZZrDOnviQAzr1xFnzl8xilnS81vSxMifOysa162M6WP6IVGCeEb5j58+KSe3ZaPqmD91KFxdXeG1aI0x/5OWP3GEB6aO7otRk7yM6aaRW3fuo2zxglgwbSgiRYyA+cvWq2yZ0f5z6RQtfRhOn7uMI8fPqHTZJIgfF5M1vX/kzY6xU+ZjeP+Oqu8ThvaU7CALdHiDDCUVhSIBVk0CJEACJEACdkXgf3/kwZYd+/Dlyxe1L1Iwl2p/uHDumLNwNVp3HYzd+4/iytWbKt3S5sTpCyiUPwd+jBYVUaNEhq5DZAOiR+Tv3vsH0aJFQeb0qeUQVcv/DyfPXFRx2eTMlgGuLi6IHCkinj57IUm+QpxYMZAnRyaVLkslzno74G/fvVMzuW27e+LOvQe4fO2WkpHNH/lyyE6F9L+nwLCxszB7wSp81rioxCDa0OENIpBUQwIkQAIkQAKhT4AtsBcCcePERML4P+PoibPK4S1ZNL9q+uBR0/BznFgY7NEW7ZvXwX9v36l0axuZidXz3Nxc9SgCqkcKuru5yU4FNy3+BV9UXDaurt9cRmvOqGn9Uv7z58/48OEjegwYg8L5c2LckO6Q2d43/70VlSqEc/9WZ//urVCtYgmt1i9o1qE/3r57r2SCYvOt9UGhjTpIgARIgARIgARIgARsIiDLGsZMmaeWLsSM/qMqI8sC8uXOgmhRo2D3gWMqzdomXerf1PIAcSxlplhfiyvy1vREjBgBL158XVsrcnqIHy8OnmvpJ85cUElLV29CxnSpVNzWzd37D7H/8AklLkstfk+dHM+ev0C4cOEgs7fh3N0hD80pAQsbWTOcIlliNKhZAW6ag/3g4WMLUoFLosMbOG52XYqNJwESIAESIAESCH0Cxf7Io27vFymQ09iYBjXLo27zHmpJw8ePH43pliLJkyZCoXw50KLTALTtPkQtj9DlrOkpWSQf9mlOadMO/dRDa7q8m6sr+nVriXFTF6gH095qM8t1q5XVs23ayxrkhcs3onK99nj+8hVqVymNWDGjI03KZKjeuDM69BwGWbNrTZk8rFa6ekt06zcaxf7IjcQma4ytlbE1nQ6vraQoRwIkQAIk4GgE2B8SCFUCP0SLgoNbF6FKuf8Z21GqWAGsWTAe44f2QMeW9TBh2NeHtzq1qq+WA4jgohnDETPGTxJFvRrlMGVUH7VcwGvSYNTSnEzJsKYnWZKEGDWwC6ZqZeShtc6tv+nNlD41Zo0foB5aG9SrLaJEjiSqIK9BE8daHWgbeQBN2/n4k/as8Bqj2r1szmgM79dRzVKLUJ8uzbFo+nCMHtwVA3q0RsNaFSQZK+eONcpIguhdt2giafvSEAAAEABJREFUhvRpj0Z1KklSkAU6vEGGkopIgARIgARIgATCKoFov+RCrDTVQzxE+CFRWEXiVO2iw+ufuZlPAiRAAiRAAiRg9wSiJcijObs1QjyEp8MbJsYOHd4wYQY2ggRIgATCPgF7aeGb9u3xpUJ54Px5e2ky20kCJBDMBOjwBjNgqicBEiABEiABEiABEghdAkHs8IZuZ1g7CZAACZAACZAACZAACZgToMNrToTHJEACJBAUBKiDBEiABEggzBCgwxtmTMGGkAAJkAAJkAAJkIDjEQgLPaLDGxaswDaQAAmQAAmQAAmQAAkEGwE6vMGGlopJgARsJ0BJEiABEiABEgg+AnR4g48tNZMACZAACZAACZBAwAhQOlgI0OENFqxUSgIkQAIkQAIkQAIkEFYI0OENK5ZgO0jAdgKUJAES8INApNGjYVi5CkiVyg8pZpEACTgTATq8zmRt9pUESIAESIAEHIoAO0MCthGgw2sbJ0qRAAmQAAmQAAmQAAnYKQE6vHZqODbbdgKUJAESIAESIAEScG4CdHid2/7sPQmQAAmQgPMQYE9JwGkJ0OF1WtOz4yRAAiRAAiRAAiTgHATo8DqHnW3vJSVJgARIgARIgARIwMEI0OF1MIOyOyRAAiRAAkFDgFpIgAQchwAdXsexJXtCAiRAAiRAAiRghcDVW//g8OmrIR6ePH9lpUVMDkkCdHi/izYLkwAJkAAJhDUCb9q3x5cK5YHz58Na09ieUCSgHN5TmsMbwuHfZ5Yd3gatPXDyzEUjkTPnr6Buix7GY0uRFy9foWLddpay0KabJy5cumYxz7/EXfuO4Mr1WxbF/ty2G8PHz7aYZ0+JdHjtyVpsKwmQAAmEVQJsFwmQgN0S2HfoBK7duGO37bel4XR4baFEGRIgARIgARIgARIIIQIfPnzEkDEzUKNJF9Rp3h3bdx3wVfO79+/hMXg8qjfujLbdPfHq9RujzPI1W1BbKyd5U+csNaYXrdjYGJfZ5fY9h+LS1RvYufcwpnstQ+N2fXDz9j2jjB65dec+mnfsj8r12mPctAV6Mhq17Y3K9TugeqPO+HvPIWN6hTptMXLiHDTvNAB/7T6IGXOXo0n7vihZtXmozRaHpMNrBMEICZAACZAACZAACTg7AXEYsxaqCgn1W/U04li9cTtuak7mvClD0L97KwwaOQ3PX/hcGrFq/TaVtmDqUDSpWxmnz11S5WWmdvq85Rg7uBtmjR+AbTsPQGZwVaaFzW9JEyN/7qxorOmYPqYfEiWI50vq7IUrqh1zp3hi9/6jOHDklJLp0b4Jls0ehXFDumPs1AX47+1blS6bBPHjYvIID6T+LSn2HDyOaaP7YsOSyahbvaxkh3igwxviyFkhCZAACZAACZAACQAzxvbH4e1LVJg9YZARyYnTF1CxVGG4urggccL4SJs6OS5cvmbMl8jpc5dRoXRhuGgyaVImgwRJP376PP7Ilx3Rf/oBESNEQKli+X2sFRaZgIY8OTIhVszoRn1nzl9WKq7fuoM+Qyaix8CxePnqFe7c/Uely+aPfDlkhxjRf8S7d+8xfvoCLF65EdGiRlHpIb2hwxvSxFkfCZAACZAACZAACfhDwM3dzSjh5uaGL1+Mh8aIm6vrt7jbt7i7Jq9niMwXfC3sqsl//vxZZX369EntbdlIOV1O9ImOcxevYsGyDahbrSymjOqD5EkS4c1/32Z4w3m3313bz5s6BLmzZcSVa7fRS3OOdV1qH0IbOrwhBJrVkAAJkAAJkAAJkIAtBDKkTYk1G/7CJ805vXHrLmRGNXWKJD6KyqzvoWOnVdqz5y9w4dJ1Fc+YNhV27DmEJ0+fqyUGG7buQqZ0qVRe/J9j4/bdByp+4OjXZQlyEDFiBLwwWzIh6XrYe/AYHj1+YtSXLs1vkHalSJ4YSRL/osqeuXBFF/exV06w5q1nSp8azRtWxWnv2WEfQiFwQIc3BCCzChIgge8iwMIkQAIk4FQEypUohDixY6B2s27o7TkBXds29LUUoHypwnj67AVadh6oyUxE3DgxFSNxQOtWLYu2PYZAXn2WP1cW5MiSXuVVLf8/9YBb666D8fLVa5Umm5JF8mHf4RNo2qGfxYfWUiT7Vemr1bSb0iX68ml6z5y7DFmHLA+opUmRVFT5Cvf/eYS8JeqoB/BGjJ+t+uJLKAQS6PCGAGRWQQIkQAIkQAIkQAKmBOSBsvS/pzAm/Z4qGbwmDVbHsgygW7tGWDhtGOZO9sQfebOr9GhRo2CF1xgVDx8uHAb0aI2Jw3uph8aWzxmNlL99nQWuVLYo5mnlFk0fjqb1qih52RQpkAur54/H+KE90LVNQ4we1FWSkSxJQowa2AVTR/Xx9dBa8cJ5lby0Repu06SmKhMlciTIQ3WyDnlgzzZqWYPen5Vzxxod9KSJE2D/loWqL5692xv7opSE4IYObwjCZlUkQAIkQALBTyDS6NEwrFwFpPp6Gzf4a2QN9kAgacI4yJouaYiHGD+GzkNa9mCTkGwjHd6QpM26SCAECLAKEiABEiAB3wSUw5tWc3hDOET/gQ6vb2uEfAod3pBnzhpJgARIgARIgASCnwBrIAEjATq8RhSMkAAJkAAJkAAJkAAJOCIBOryOaFX2yXYClCQBEiABEiABEnB4AnR4Hd7E7CAJkAAJkAAJ+E+AEiTgyATo8Dqyddk3EiABEiABEiABEiAB0OHlIAgAAYqSAAmQAAmQAAmQgP0RoMNrfzZji0mABEiABEKbAOsnARKwKwJ0eO3KXGwsCZAACZCAfwTetG+PLxXKA+fP+yfKfBIgASchQIc3+AxNzSRAAiRAAiRAAqFA4OHDB2BwXAaBGVJ0eANDjWVIgARIgAQCQICiJBByBKJHjwEGx2cQ0BFFhzegxChPAiRAAiRAAiRAAiRgVwTCjMNrV9TYWBIgARIgARIgARIgAbshQIfXbkzFhpIACTgJAXaTBEiABEggiAnQ4Q1ioFRHAiRAAiRAAiRAAiQQFASCTgcd3qBjSU0kQAIkQAIkQAIkQAJhkAAd3jBoFDaJBEjAdgKUJAESIAESIAH/CNDh9Y8Q80mABEiABOyKQKTRo2FYuQpIlcqu2s3GksB3EmBxPwjQ4fUDDrNIgARIgARIgARIgATsnwAdXvu3IXtAArYToCQJkAAJkAAJOCEBOrxOaHR2mQRIgARIgAScnQD771wE6PA6l73ZWxIgARIgARIgARJwOgJ0eJ3O5Oyw7QQoSQIkQAIkQAIk4AgE6PA6ghXZBxIgARIgARIITgLUTQJ2ToAOr50bkM0nARIgARIgARIgARLwmwAdXr/5MNd2ApQkARIgARIgARIggTBJgA5vmDQLG0UCJEACJBBYAm/at8eXCuWB8+cDq+I7y7E4CZBAWCNAhzesWYTtIQESIAESIAESIAESCFICdHiDFKftyihJAiRAAiRAAiRAAiQQMgTo8IYMZ9ZCAiRAAiRgmQBTSYAESCDYCdDhDXbErIAESIAESIAESIAESCA0CdiHwxuahFg3CZAACZAACZAACZCAXROgw2vX5mPjSYAEnI0A+0sCJEACJBBwAnR4A84sUCUix0kFBvtnULJSfdzb3QPnlpbG2SWlGByAwaX1jQJ1TrMQCZAACZBAqBIIUOV0eAOEi8IkQAIkQAIkQAIkQAL2RoAOr71ZjO0lARKwnQAlnZJApNGjYVi5CkiVyin7z06TAAn4JkCH1zcTppAACZAACZAACZCAQxFw9s44lcN74MhJ5CxWyxiKVWrmp/1rNeuOx/8+9SUzd8k6LFy+0Vf602cv0MljBAqWbYhh42b7ymcCCZAACZAACZAACZBAyBNwKodX8GbLlBb7N89XYfPyKZIUpKFE0XxoXLtikOqkMhIIGQKshQRIgARIgAQck4DTObyWzHj81Hk0btcPdVv0hMfgCXj56rUvMZnVrVy/I1p1GYyLl6/7ypeEn36Mhj/yZkPEiOHlkIEESIAESIAESMAeCbDNDkfA6RzeQ8dOG5c0DBgxDR8/fUJvz4lo3qAKvCYNgqurK+YtWefD0Ndu3sGKtVsxfWxfePZui3MXr/nI54HzEPjy5YvWWQnajn8OQ+DDh/f49OkjZM/w3iE4fP78CZ81mzJ8dCgODnPRYUdCnIDTObymSxo8OjXB3XsPETVqZGRK9/Vp3irliuLU2cs+DHHyzEUUzJsVP0aLiqhRIqNQ/uw+8nnglATYaRIgARIgARIgATsh4HQOryW7uLu5GZPdtPgX+J7Bk5lfXcjNzVWPcu9kBAwGg9ZjCdqOfw5DwN09nHZ3xw2yZwjnEBxcXFzh4urGECIMQo6zw1x02JEQJ+AS4jWGsQrjx4uNFy9f4+TZi6ply9ZsQYa0KVRc36RNlRxHT5zD58+fIbe0Dx87q2dxTwIkQAIkQAIkQAIkEMYJOL3D6+bqit6dm2LC9MXqobW3b9+hdpXSPsyWLElC/JE3O1p39USHXiOU0+tDwPtA1gPLa8/klWSrNmxXa4WtPeDmXcRpduwoCZAACYQUgTft2+NLhfLA+fMhVSXrIQESCOMEnMrhzZElPcZ6dvVlkozpUmH6mD7qobUBPVohSuRISmb+FE/EjPGTitepVhoTh/fE6EGdMWt8f9SoVEKlm27EedZfeabvUyT/1VSEcRIgARIgAecmwN6TAAmEAgGncnhDgS+rJAESIAESIAESIAESCGUCdHhD2QAWq2ciCZAACZAACZAACZBAkBGgwxtkKKmIBEiABEggqAlQHwmQAAkEBQE6vEFB0QYdr/85Dwb7Z7Bh+WzEyzsYqausQ5qq6xkcgMFvpWbYcAZThARIgARIwJ4JOIDDa8/42XYSIAESIAESIAESIIHgJkCHN7gJUz8JkAAJhBQB1kMCJEACJGCRAB1ei1iYSAIkQAIkQAIkQAIkYK8EzNtNh9ecCI9JgARIgATsmkCk0aNhWLkKSJXKrvvBxpMACQQdATq8QceSmkiABOyKABtLAiRAAiTgLATo8DqLpdlPEiABEiABEiABErBEwAnS6PA6gZHZRRIgARIgARIgARJwZgJ0eJ3Z+uw7CdhOgJIkQAIkQAIkYLcE6PDarenYcBIgARIgARIggZAnwBrtkQAdXnu0GttMAiRAAiRAAiRAAiRgMwE6vDajoiAJ2E6AkiRAAiRAAiRAAmGHAB3esGMLtoQESIAESIAEHI0A+0MCYYIAHd4wYQY2ggRIgARIIKgIvGnfHl8qlAfOnw8qldRDAiRg5wTo8Nq5AR2i+ewECZAACZAACZAACQQjATq8wQiXqkmABEiABEggIAQoSwIkEDwE6PAGD1dqJQESIAESIAESIAESCCME6PCGEUPY3gxKkgAJkAAJkAAJkAAJBIQAHd6A0KIsCZAACZBA2CHAlpAACZCAjQTo8NoIimIkQAIkQAIkQAIkQAL2ScDRHV77tApbTQIkQAIkQAIkQAIkEGQE6PAGGZvD/XgAABAASURBVEoqIgESIIGwTIBtIwESIAHnJUCH13ltz56TAAmQgEMSiDR6NAwrVwGpUjlk/9gpEiCBgBPw4fAGvDhLkAAJkAAJkAAJkAAJkEDYJkCHN2zbh60jARIIHQKslQRIgARIwIEI0OF1IGOyKyRAAiRAAiRAAiQQtAQcQxsdXsewI3tBAiRAAiRAAiRAAiRghQAdXitgmEwCJGA7AUqSAAmQAAmQQFgmQIc3LFuHbSMBEiABEiABErAnAmxrGCVAhzeMGobNIgESIAESIAESIAESCBoCdHiDhiO1kIDtBChJAiRAAiRAAiQQogTo8IYoblZGAiRAAiQQ3ATetG+PLxXKA+fPB3dV1P+dBFicBEKKAB3ekCLNekiABEiABEiABEiABEKFAB3eUMHOSm0nQEkSIAESIAESIAES+D4CdHi/jx9LkwAJkAAJkEDIEGAtJEACgSZAhzfQ6FiQBEiABEiABEiABEjAHgjQ4bUHK9neRkqSAAmQAAmQAAmQAAmYEaDDawaEhyRAAiRAAo5AgH0gARIggW8E6PB+Y8EYCZAACZAACZAACZCAAxJwaofXAe3JLpEACZAACZAACZAACZgRoMNrBoSHJEACJOCEBByqy5FGj4Zh5SogVSqH6hc7QwIkEHgCdHgDz44lSYAESIAESIAESIAE7ICA7Q6vHXSGTSQBEiABEiABEiABEiABcwJ0eM2J8JgESIAE/CHAbBIgARIgAfsiQIfXvuzF1pIACZAACZAACZBAWCFgN+2gw2s3pmJDSYAESIAESIAESIAEAkOADm9gqLEMCZCA7QQoSQIkQAIkQAKhTIAObygbgNWTAAmQAAmQAAk4BwH2MvQI0OENPfasmQRIgARIgARIgARIIAQI0OENAcisggRsJ0BJEiCB7yXwpn17fKlQHjh//ntVsTwJkICDEKDD6yCGZDdIgARIgARIwKEIsDMkEIQE6PAGIUyqIgESIAESIAESIAESCHsE6PCGPZuwRbYToCQJkAAJkAAJkAAJ+EuADq+/iChAAiRAAiRAAmGdANtHAiTgFwE6vH7RYR4JkAAJkAAJkAAJkIDdE6DDa/cmtL0DlCQBEiABEiABEiABZyRAh9cZrc4+kwAJkIBzE2DvSYAEnIwAHV4nMzi7SwIkQAIkQAIkQALORoAOrzWLM50ESIAESMAuCUQaPRqGlauAVKnssv1sNAmQQNAToMMb9EypkQRIgAQcigA7QwIkQAL2ToAOr71bkO0nARIgARIgARIgARLwk0AQObx+1sFMEiABEiABEiABEiABEgg1AnR4Qw09KyYBEnBIAuwUCZAACZBAmCNAhzfMmYQNIgESIAESIAESIAH7JxCWekCHNyxZg20hARIgARIgARIgARIIcgJ0eIMcKRWSAAnYToCSJEACJEACJBD8BOjwBj9j1kACJEACJEACJEACfhNgbrASoMMbrHipnARIgARIIKQJvGnfHl8qlAfOnw/pqlkfCZBAGCVAhzeMGobNIgELBJhEAiRAAiRAAiQQCAJ0eAMBjUVIgARIgARIgARCkwDrJoGAEaDDGzBelCYBEiABEiABEiABErAzAnR47cxgbK7tBChJAiRAAiRAAiRAAkKADq9QYCABEiABEiABxyXAnpGA0xOgw+v0Q4AASIAESIAESIAESMCxCdDhdWz72t47SpIACZAACZAACZCAgxKgw+ughmW3SIAESIAEAkeApUiABByPAB1ex7Mpe0QCJEACTk0g0ujRMKxcBaRK5dQc2HkSIIFvBOjwfmMRgBhFSYAESIAESIAESIAE7IUAHV57sRTbSQIkQAJhkQDbRAIkQAJ2QIAOrx0YiU0kARIgARIgARIgARIIPIGQcHgD3zqWJAESIAESIAESIAESIIHvJECH9zsBsjgJkAAJ2E6AkiRAAiRAAqFBgA5vaFBnnSRAAiRAAiRAAiTgzARCuO90eEMYOKsjARIgARIgARIgARIIWQJ0eEOWN2sjARKwnQAlSYAESIAESCBICNDhDRKMVEICJEACJBBWCLxp3x5fKpQHzp8PK01iO0jgOwmw+PcSoMP7vQRZngRIgARIgARIgARIIEwToMMbps3DxpGA7QQoSQIkQAIkQAIkYJkAHV7LXJhKAiRAAiRAAiRgnwTYahLwRYAOry8kTCABEiABEiABEiABEnAkAnR4Hcma7IvtBChJAiRAAiRAAiTgNATo8DqNqdlREiABEiABEvBNgCkk4AwE6PA6g5XZxyAlUKRsHUSJmxqR46RicAAGhYoUw7mlpXFtbRWcXVKKwQEY/PcvX0cWpBc9KiMBByBAh9cBjBj8XWANJEACJEACJEACJGC/BOjw2q/t2HISIAESIAELBB6VCQ/DihVAqlQWcr8zicVJgATskgAdXrs0GxtNAiRAAiRAAiRAAiRgKwGncngPHDmJnMVqGUOxSs385FSrWXc8/vepL5m5S9Zh4fKNvtIlYenqzZBydZr3xK79xySJgQRIgARIgARIgARIIBQJOJXDK5yzZUqL/Zvnq7B5+RRJCrJw8/Z9zF28DlNH9cawvu0xaOQ0vH33Psj0UxEJkAAJ2BcBtpYESIAEwgYBp3N4LWE/fuo8Grfrh7otesJj8AS8fPXal5jM6lau3xGtugzGxcvXfeVLwp4Dx5A/dxZEjhQRcePERMrkv+LwsTPgPxIgARIgARIgARIggdAjEOoOb0h3/dCx08YlDQNGTMPHT5/Q23MimjeoAq9Jg+Dq6op5S9b5aNa1m3ewYu1WTB/bF5692+LcxWs+8vWDR/8+Qby4sfRD/BIvDh4+/lcdf/jwHgyOwQD4omzKjaMQoD0dxZKm/fj8+RM+f/rI4GAMTG3MOAkEhIDTObymSxo8OjXB3XsPETVqZGRK9/Vp3irliuLU2cs+GJ48cxEF82bFj9GiImqUyCiUP7uPfNMDg8s3pAaDwTSLcRIgARLwiwDzSIAESIAEgonAN+8smCqwB7Xubm7GZrpp8S8WZvBk5lcXcnNz1aM+9rFiRMezZ8+NaU+ePkPsmDHUsbt7ODA4BgOAX2TgUP9oT4cyp3dnXFxc4eLqxuBgDLzNy53DEwj6DroEvUr70hg/Xmy8ePkaJ89eVA1ftmYLMqRNoeL6Jm2q5Dh64hw+f/6ML1++4PCxs3qWj32eHJmw+8AxvHv/Hk+ePldLH7JnSetDhgckQAIkQAIkQAIkQAIhS8DpHV43V1f07twUE6YvVg+tvX37DrWrlPZhhWRJEuKPvNnRuqsnOvQaoZxeHwLeB4kS/IzyJQuhYZs+aNdjGNq3qINw7u7eudyRAAkEJQHqIgFrBGKtfYcvFSsC589bE2E6CZCAkxFwKoc3R5b0GOvZ1ZeJM6ZLhelj+qiH1gb0aIUokSMpmflTPBEzxk8qXqdaaUwc3hOjB3XGrPH9UaNSCZVuvqlSrhik3NzJg5A/V2bzbB6TAAmQAAmQAAmQQFASoC4bCDiVw2sDD4qQAAmQAAmQAAmQAAk4GAE6vA5mUHaHBCwSYCIJkAAJkAAJODEBOrxObHx2nQRIgARIgAScjQD765wE6PA6p93Z6+8gsHXNXLx6cA6v/znP4AAMtm/djNRV1iFJmaVIU3U9gwMwiBjj63vVv+M0Z1ESIAEHI0CH18EMyu4EBQHqIAESIAESIAEScCQCdHgdyZrsCwmQAAmQAAkEJQHqIgEHIUCH10EMyW6QAAmQAAmQAAmQAAlYJkCH1zKXIE/98OE9HDQ4Xb/c3d3x8eMHp+u3I49fsaebmxtt6iDXqQgjRyDyxg2IkP53RAjnyuBADIL8w5kKnYYAHV6nMTU7SgIkQAIkELwEqJ0ESCCsEqDDG1Ytw3aRAAmQAAmQAAmQAAkECQE6vEGC0XYllAwdAo3b9cOps5f8rHzUJC9s/muvL5kNW3ZByhcu3xgdPYbj+s27RpmlqzejVrPuqNO8J3btP2ZMnzRzMao16oxS1Vqh//ApePf+vcr7+OkTBo2ajnote6FJ+364c++BSucmYATEHv7Z0xaNDx4+hufoGSheubmyl9eitcZij/99ilZdBqNB697oMWAs/nv7VuUdP3Ue3fqPgYyHRm37Yue+oypdNiMmeKFktZao3riLHDIEgICcG/lK1fO3hJxvYhtzwYCec37ZcfXGv1BdO39zFquFp89emFfFYxsI2GpPG1TBr2vwyTMXUa+VB2o374EZ81YY1VkbD37Z3ViYEYckQIfXIc3KTgUlgTixY2DCsO5Yt2g8kidNhCmzlyj1N2/fx9zF6zB1VG8M69seg0ZOw9t3Xx3b9GlTYvGM4Zg7eRCePH2OVev/UmXWbfpbO36GORMHolKZIhgyZpZK5yZ0CLi4uKBS2SL4c9lkDOrVBsvWbMHV67dVY8ZOXYAcWdJj1vj+iBYtKhYs26jSI0WMgE6t6mHziqmoW62MsrvK0Dbp0iTHgB6ttBj/bCAQpCIBPef8smOcWDHQX7NjzBg/BWkbqSxwBKxdg798+YLenhPRpXU9zJ4wAH/tPgRxaKUWa+PBL7tLOQbHJUCH13Fty55ZIVCiagtjjswSduo9wnhsKZIlQxqEDxcOESNEQO5sGfHP46dKbM+BY8ifOwsiR4qIuHFiImXyX3H42BnIv9zZMsgO0X/6ARk05/fh43/V8d4Dx1GiSF4V/yNfdpy9eBWv3/ynjrkJHIHJs5agdI3WqNqwk48ZHpm5HTxqBlp2HoS6LXoaPwhNa4kdMzqSJ0kE+Zc0cQIk/TUB7j14JIfYe/AEShb9aquSms32HDyu0lNodo4Z/Ue4urggT46M+PDhg3H2t2jBXIjx049KjpvAE1i+dgumeS0zKmjbfSguXr5uPLYUCeg555cdc2ZNbxwXlupiWsAJNO3QH3Lno1bT7ti594hSIDP1cies56Dx6o7XQG3S4NPnzyrPdGPtGnzxyg1E0q6/qVMkhZurK+T8233g6502a+PBL7ub1sm44xFwCdNdYuNIIIwRWLRiI7Jn+l216tG/TxAvbiwVl80v8eJAd2zlWILcBl+/eSeyGcs8Rfyf40iWukDHjR0TDx89UcfcBI5AsT/yYN3C8fCaNBhnzl/F0RNnjYo+ffqEcUO7Y9KIXhgzZb4x3VJEZnbPX7qGtNosrXwJMRiAn36MpkQTxI+DR49922nV+u1IpjnM8mVICXIT6gQCc87RjsFvtq5tGmLR9GEYPagzJsxYZPySKF8wG9WqgGmj++DHH6Ji976vDqu1Fpleg//Rrp3xTa7Bcp7+8/Dr5IJe3nw86Omyp92FgvMEOrzOY2v29DsJLFi2Ac9evEKDWuWNmgzaLJ9+YDBoHpJ+oO3ldlsvbebij7zZ1K1xLUn9GQzf5FxM4iqTmwATePf+HUZPnosOvYbj7v1/cOX6HaOOnNnSq5lYmYV/9vylMd088uzFS3QfMAa9OjXFj9GiqmxZ7qAi2sZg8H2plLsDC5ZVtMPNAAAOmUlEQVRvRO/OTTWJ4P9jDf4TCMw5Rzv6zzUoJG7cvot+w6bAw3MiXr56jbv3Hiq18X+OjV8TxVdxueMicurAwsbyNfjb9RTweZ5aGw+imnYXCs4VfI4O5+o7e+ukBFy1W1+fvW+byQygLRgOHTuNoyfPYszgLmp5g5SJFSM6nj17LlEVnjx9htgxY6i4bOQBClnm0KJhNTlUIVaMn/DkqUmZZy8QO1Z0lcdNwAl8+PARHoMnoFC+HGrmqNgfufHmv68Pl4k2U6f185cvkuQryC3U/sMmo33zOsiXM5PKFwf506fPeP/hgzr+V7NtrJjf7CSzvTJLJWu7E8SPq2S4CToC6hw1sZet52lAzznaMehs5pcmuXOyaMWfqF2lNCYO74lkvybEG+/z1NXF1VjUxcWAjx8/GY9NI5auwXG0a+fTZ9++yD7RzlNZ76uXszQeJI92Fwp2HQLVeDq8gcLGQvZMQJYh3L77j+rCQc2RVRE/NifPXsTshWsw2KMdwrm7GyXz5MgEWS8mb2B4ojmx5y5eQ/YsaVX+klWb8fjfZ2hcp5I61je5smfAtp0H1eHBo6eRRJvZEOdKJXATYALPnr+A/BBIujS/KdvsP3wyQDrEYe7jOQkliuSDrNs0LZwrm2arv/erpC079iGPZjs5kHWHsuawR/vG+DnOtyUtkscQNATixY1tnAF8qn0pvHT1pr+KA3rO0Y7+Ig0ygZu37+G3ZImQJHF8vNDuksmzCwFRbu0anCJZYu06+xS37z6AfHHdrl1b5bosuq2NB9pd6DhnoMPrnHZ3ul5/+PhRm5n96qxWKVdUvV6sXY9h2q21N/6ymDB9MU6cvoCCZRpAXlNUqV4HVSZRgp9RvmQhNGzTB6KrfYs6yun6+OkTxkyZh7Wb/lbyUmbAiGmqTJniBSGzGPJaspnzV6Jr24YqnZuAEdDtKbOu8sCKvKqqc++RkHXUSpONG5m1377rgJolFjtJ2Lh1lyrdrllNrNu8S72W7Nbt+6hZuaRKlzc5nD53WT2AI/IS5PVmktm4XT/1erMbt+4p2y9cvlGSGWwgIA//6V8oM2dIrZwYedBpzJT5SPjLz35qCMw555cd5UFIsas4R/KQq38PtvrZOCfNNLWnOKFnz1+B2HP05HlI/VuSAFGxdg02GAzo162FOn/lmpo5Y2pkSpcKfo0Hv+weoEZR2O4IuNhdi9lgEggggVev3+De/Yf42fvhBrn9vXzOKLU8oXOrehjRv5PS2KFFXcgtcXVgspk+pg/2b55vDFJWz65SrhjmT/FUrx/LnyuzSpanhU3lJe7RqYkxr2eHxuq1ZPKQRsJfeDtcgQnAxtyewlZsMGJAJ/XhV79GWaWte/tGkPXT6kDbyINt2s7Hn7x2TOxjGmS2V4RixvgJk0f0Uq8lG+zRVr2lQ9KbN6hqHAt6ubixY0oWzMdKjUolVDo3/hM4dfYy9OUhcg7Jq/vklX/i0MwY2xfydL1oEVuLbSSuB5HXbaHvZVxIvuRZOuf8sqN5nn6NEH0MthEwtWeUyJGg27N/95ZqWYPclRE7zp/qaVRYqUxRNKpdwXisR8zPK9NrcPrfUyjd8yYPRuPaFVURsbk+DvS9Ph7MbSv5+vmrCjvghl36SoAO71cO3DoogQNHTqJKg05o0bAqokWN4qC9dJ5u0Z6OaWuZUR07dT46tqzjmB10sl7Rnk5mcDvpLh1eOzEUmxk4AjKDt3HJJJQr8UfgFDhFKfvpJO1pP7YKSEtl1m3htKH4PVXygBSjbBglQHuGUcM4ebPo8Dr5AGD3SYAESIAESIAEvAlw57AE6PA6rGnZMRIgARIgARIgARIgASFAh1coMJCA7QQoSQIkQAIkQAIkYGcE6PDamcHYXBIgARIgARIIGwTYChKwHwJ0eO3HVmwpCZAACZAACZAACZBAIAjQ4Q0ENBaxnQAlSYAESIAESIAESCC0CdDhDW0LsH4SIAESIAFnIMA+kgAJhCIBOryhCJ9VkwAJkAAJkAAJkAAJBD8BOrzBz9j2GihJAiRAAiRAAiRAAiQQ5ATo8AY5UiokARIgARL4XgIsTwIkQAJBSYAOb1DSpC4SIAESIAESIAESIIEwR8COHd4wx5INIgESIAESIAESIAESCIME6PCGQaOwSSRAAiQQIAIUJgESIAES8JMAHV4/8TCTBEiABEiABEiABEjAXghYaycdXmtkmE4CJEACJEACJEACJOAQBOjwOoQZ2QkSIAHbCVCSBEiABEjA2QjQ4XU2i7O/JEACJEACJEACJCAEnCjQ4XUiY7OrJEACJEACJEACJOCMBOjwOqPV2WcSsJ0AJUmABEiABEjA7gnQ4bV7E7IDJEACJEACJEACwU+ANdgzATq89mw9tp0ESIAESIAESIAESMBfAnR4/UVEARKwnQAlQ47Ag4eP0X3AGFRp0BHVG3dBxbodcPLsxSBtwKmzl9Cgde8g1UllJEACJEACIU+ADm/IM2eNJEACQUBgmtdyuLi4Yu5kTyyaPgxjBndBlEiRgkDzNxVJEv+Czq3rfUtgjARIwFYClCOBMEWADm+YMgcbQwIkYCuBx/8+Q7aMaRAhfDhVJEH8uEj6awIV/+/tW4ycOFeb+e2Kmk26YcKMRfj8+bPKW7FuK1p39UStpt1RrFIzPP73KT58+IgxU+aheaeBqFCnPZp1HKBkr924g+Hj56i4bGbOX4VazbqjTvOeGDBiGl69fiPJmOa1DD0GjEUrTW+jtn3gOWYmPn76pPK4IQESIAESCH0CdHhD3wbO2wL2nAS+g0D9GmUxQ3NAxUmdNHMxzpy/bNQ2Y95KfNIczrmTBmHOxIH45+G/WLp6i3JQZ8xbhTGeXTF/qicWzxiGqFEjY9/hk7j/4BEmj+iFlXNHo2/X5kZdeuSv3YewcetuTBjaHbMm9Me/T55i9oJVejYeaHUM6d0WM8b2g8FgwF+7DhrzGCEBEiABEghdAnR4Q5c/aycBEggkgYzpUmGF1yjUq14G/z59gZadB2Plum1K28EjpzUH+Apad/NU4fK1mzh19iIiRYyAOLFjYOQEL8xeuAZPn71E+HDhkDxJAly7eRfiOC9a8adx1lgp894cO3keJYrkxY8/RIObqyuqVyyBo1qadzayarPNUSJ/XVIRV6vj6o3behb3JOAvAQqQAAkELwE6vMHLl9pJgASCkUA4d3dkz5wOHp2aoG3Tmli18a+vtRmAji3rYMpIDxUWzxiOwR5t4eLigjkTBqBM8QII5+6Gtt09IY5pvLixsXDaUE1XWm2m9jEat+unljl8VfZ1+wVflKP79Qiq/JcvX/RDuLp+u5y6aPV8/PjJmMcICZAACZBA6BL4doUO3Xawdn8JUIAESMCUwP7DJ9USBUl7/+EDTp+/gtgxf5JD5M6WAVO9luPlq9fq+N+nz3Dxyg28ffce796/R8rkv6Jm5ZJqze/Fy9fx/MUruGsOcOYMadCiYVU8e/5SmzV+psrqm8zpU+PP7bvx4uUrtT530co/kUWb1dXzuScBEiABEgi7BOjwhl3bsGUkQAJ+EDh/8RqqNOiEph3643+VmuPK9Vto06SWKlG/ZnnNqU2MZh0GqIfM6rXohafPnuOJ5vgWrdAUlet3RK9BExA/Xhz8kS8HDh49hVz/q426LXqi/7ApaKCVjxs7ptKlb/7Imw2F8+dEi06D0KBVb0SNEgX1a5TTs7kPSQKsiwRIgAQCSIAObwCBUZwESCBsEGhQqzw2LpmEqaN64681MzBv8mAkSvCzalyE8OE057cmFkwbgvlTPLFu0QTkyJIesnRh5/rZWDZ7JAb2bIXOreqp9bpFC+bCvk3z4DVpEAb1aoPqFYsrPenS/IZZ4/uruGwa1a4Aedht7uRBahmFvma3Sd3KkADvf3WqlkbrxjW8j7gjARIgARIIbQKO6vCGNlfWTwIkQAIkQAIkQAIkEEYI0OENI4ZgM0iABEggeAhQKwmQAAmQAB1ejgESIAESIAESIAESIAGHJqAcXofuITtHAiRAAiRAAiRAAiTg1ATo8Dq1+dl5EiABMwI8JAESIAEScEACdHgd0KjsEgmQAAmQAAmQAAl8HwHHKk2H17Hsyd6QAAmQAAmQAAmQAAmYEaDDawaEhyRAArYToCQJkAAJkAAJ2AMBOrz2YCW2kQRIgARIgARIICwTYNvCOAE6vGHcQGweCZAACZAACZAACZDA9xGgw/t9/FiaBGwnQEkSIAESIAESIIFQIUCHN1Sws1ISIAESIAEScF4C7DkJhDQBOrwhTZz1kQAJkAAJkAAJkAAJhCgBOrwhipuV2U6AkiRAAiRAAiRAAiQQNATo8AYNR2ohARIgARIggeAhQK0kQALfTYAO73cjpAISIAESIAESIAESIIGwTIAOb1i2ju1toyQJkAAJkAAJkAAJkIAVAnR4rYBhMgmQAAmQgD0SYJtJgARIwDcBOry+mTCFBEiABEiABEiABEjAgQg4pcPrQPZjV0iABEiABEiABEiABPwhQIfXH0DMJgESIAEHJsCukQAJkIBTEKDD6xRmZidJgARIgARIgARIwHkJ+O/wOi8b9pwESIAESIAESIAESMABCNDhdQAjsgskQAIhQ4C1kAAJkAAJ2CcBOrz2aTe2mgRIgARIgARIgARCi4Dd1UuH1+5MxgaTAAmQAAmQAAmQAAkEhAAd3oDQoiwJkIDtBChJAiRAAiRAAmGEAB3eMGIINoMESIAESIAESMAxCbBXoU+ADm/o24AtIAESIAESIAESIAESCEYCdHiDES5Vk4DtBChJAiRAAiRAAiQQXATo8AYXWeolARIgARIgARIIOAGWIIFgIECHNxigUiUJkAAJkAAJkAAJkEDYIUCHN+zYgi2xnQAlSYAESIAESIAESMBmAnR4bUZFQRIgARIgARIIawTYHhIgAVsI0OG1hRJlSIAESIAESIAESIAE7JYAHV67NZ3tDackCZAACZAACZAACTgzgf8DAAD//9bzNPAAAAAGSURBVAMAlE2i41kwbqcAAAAASUVORK5CYII="
      },
-     "metadata": {},
+     "metadata": {
+      "image/png": {
+       "alt": "Horizontal timeline with one row per fold on a session axis. Each row is a long blue training bar followed by the shorter amber validation bar it is scored on, and successive rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The bottom row is the extra fold written for the holdout: its training bar runs up to the rule and its grey holdout bar sits inside the band. No training bar of any row crosses the rule."
+      }
+     },
      "output_type": "display_data"
     }
    ],
@@ -1356,18 +1360,26 @@
     "    height=460,\n",
     "    margin={\"l\": 90, \"t\": 140},\n",
     ")\n",
-    "fig.show()"
+    "show_plotly_with_alt(\n",
+    "    fig,\n",
+    "    \"Horizontal timeline with one row per fold on a session axis. Each row is a long blue \"\n",
+    "    \"training bar followed by the shorter amber validation bar it is scored on, and successive \"\n",
+    "    \"rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks \"\n",
+    "    \"where the holdout opens and a shaded band to its right is the holdout itself. The bottom \"\n",
+    "    \"row is the extra fold written for the holdout: its training bar runs up to the rule and its \"\n",
+    "    \"grey holdout bar sits inside the band. No training bar of any row crosses the rule.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f20de985",
+   "id": "6d83be10",
    "metadata": {
     "papermill": {
-     "duration": 0.003242,
-     "end_time": "2026-08-10T14:21:06.195159+00:00",
+     "duration": 0.003319,
+     "end_time": "2026-08-11T11:08:15.214160+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.191917+00:00",
+     "start_time": "2026-08-11T11:08:15.210841+00:00",
      "status": "completed"
     }
    },
@@ -1392,19 +1404,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b13b9e58",
+   "id": "119be181",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:06.202152Z",
-     "iopub.status.busy": "2026-08-10T14:21:06.202067Z",
-     "iopub.status.idle": "2026-08-10T14:21:06.472872Z",
-     "shell.execute_reply": "2026-08-10T14:21:06.472325Z"
+     "iopub.execute_input": "2026-08-11T11:08:15.221263Z",
+     "iopub.status.busy": "2026-08-11T11:08:15.221177Z",
+     "iopub.status.idle": "2026-08-11T11:08:15.511202Z",
+     "shell.execute_reply": "2026-08-11T11:08:15.510745Z"
     },
     "papermill": {
-     "duration": 0.274805,
-     "end_time": "2026-08-10T14:21:06.473191+00:00",
+     "duration": 0.294227,
+     "end_time": "2026-08-11T11:08:15.511650+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.198386+00:00",
+     "start_time": "2026-08-11T11:08:15.217423+00:00",
      "status": "completed"
     }
    },
@@ -1458,14 +1470,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "483ef09e",
+   "id": "c5b317c5",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003293,
-     "end_time": "2026-08-10T14:21:06.481010+00:00",
+     "duration": 0.003334,
+     "end_time": "2026-08-11T11:08:15.520079+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.477717+00:00",
+     "start_time": "2026-08-11T11:08:15.516745+00:00",
      "status": "completed"
     }
    },
@@ -1497,20 +1509,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d7fedc32",
+   "id": "a77d7689",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:06.488142Z",
-     "iopub.status.busy": "2026-08-10T14:21:06.488074Z",
-     "iopub.status.idle": "2026-08-10T14:21:06.490309Z",
-     "shell.execute_reply": "2026-08-10T14:21:06.490035Z"
+     "iopub.execute_input": "2026-08-11T11:08:15.528654Z",
+     "iopub.status.busy": "2026-08-11T11:08:15.528558Z",
+     "iopub.status.idle": "2026-08-11T11:08:15.531285Z",
+     "shell.execute_reply": "2026-08-11T11:08:15.530832Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006548,
-     "end_time": "2026-08-10T14:21:06.490785+00:00",
+     "duration": 0.007831,
+     "end_time": "2026-08-11T11:08:15.531679+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.484237+00:00",
+     "start_time": "2026-08-11T11:08:15.523848+00:00",
      "status": "completed"
     }
    },
@@ -1542,14 +1554,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0d70cb9",
+   "id": "96144dbb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003221,
-     "end_time": "2026-08-10T14:21:06.497263+00:00",
+     "duration": 0.003326,
+     "end_time": "2026-08-11T11:08:15.538347+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.494042+00:00",
+     "start_time": "2026-08-11T11:08:15.535021+00:00",
      "status": "completed"
     }
    },
@@ -1565,20 +1577,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "fc78fff9",
+   "id": "7a0649c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:06.504542Z",
-     "iopub.status.busy": "2026-08-10T14:21:06.504467Z",
-     "iopub.status.idle": "2026-08-10T14:21:06.507578Z",
-     "shell.execute_reply": "2026-08-10T14:21:06.507180Z"
+     "iopub.execute_input": "2026-08-11T11:08:15.546042Z",
+     "iopub.status.busy": "2026-08-11T11:08:15.545938Z",
+     "iopub.status.idle": "2026-08-11T11:08:15.560744Z",
+     "shell.execute_reply": "2026-08-11T11:08:15.560192Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007654,
-     "end_time": "2026-08-10T14:21:06.508144+00:00",
+     "duration": 0.019364,
+     "end_time": "2026-08-11T11:08:15.561049+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.500490+00:00",
+     "start_time": "2026-08-11T11:08:15.541685+00:00",
      "status": "completed"
     }
    },
@@ -1639,14 +1651,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7c7b6bc",
+   "id": "80f93f4b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003227,
-     "end_time": "2026-08-10T14:21:06.514633+00:00",
+     "duration": 0.003371,
+     "end_time": "2026-08-11T11:08:15.568101+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.511406+00:00",
+     "start_time": "2026-08-11T11:08:15.564730+00:00",
      "status": "completed"
     }
    },
@@ -1660,19 +1672,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "eee6af1d",
+   "id": "429dffd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:06.521818Z",
-     "iopub.status.busy": "2026-08-10T14:21:06.521715Z",
-     "iopub.status.idle": "2026-08-10T14:21:06.525166Z",
-     "shell.execute_reply": "2026-08-10T14:21:06.524813Z"
+     "iopub.execute_input": "2026-08-11T11:08:15.576089Z",
+     "iopub.status.busy": "2026-08-11T11:08:15.575989Z",
+     "iopub.status.idle": "2026-08-11T11:08:15.579131Z",
+     "shell.execute_reply": "2026-08-11T11:08:15.578649Z"
     },
     "papermill": {
-     "duration": 0.007601,
-     "end_time": "2026-08-10T14:21:06.525490+00:00",
+     "duration": 0.007699,
+     "end_time": "2026-08-11T11:08:15.579524+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.517889+00:00",
+     "start_time": "2026-08-11T11:08:15.571825+00:00",
      "status": "completed"
     }
    },
@@ -1726,19 +1738,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "f93436b3",
+   "id": "541c3e9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:21:06.532628Z",
-     "iopub.status.busy": "2026-08-10T14:21:06.532558Z",
-     "iopub.status.idle": "2026-08-10T14:30:19.254960Z",
-     "shell.execute_reply": "2026-08-10T14:30:19.254409Z"
+     "iopub.execute_input": "2026-08-11T11:08:15.586891Z",
+     "iopub.status.busy": "2026-08-11T11:08:15.586817Z",
+     "iopub.status.idle": "2026-08-11T11:17:47.101666Z",
+     "shell.execute_reply": "2026-08-11T11:17:47.101189Z"
     },
     "papermill": {
-     "duration": 552.729669,
-     "end_time": "2026-08-10T14:30:19.258415+00:00",
+     "duration": 571.522001,
+     "end_time": "2026-08-11T11:17:47.104937+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:21:06.528746+00:00",
+     "start_time": "2026-08-11T11:08:15.582936+00:00",
      "status": "completed"
     }
    },
@@ -1815,13 +1827,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12c69296",
+   "id": "a690f5ea",
    "metadata": {
     "papermill": {
-     "duration": 0.003344,
-     "end_time": "2026-08-10T14:30:19.265219+00:00",
+     "duration": 0.0034,
+     "end_time": "2026-08-11T11:17:47.111959+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.261875+00:00",
+     "start_time": "2026-08-11T11:17:47.108559+00:00",
      "status": "completed"
     }
    },
@@ -1836,19 +1848,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "eba95227",
+   "id": "07c170be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:19.272473Z",
-     "iopub.status.busy": "2026-08-10T14:30:19.272390Z",
-     "iopub.status.idle": "2026-08-10T14:30:19.297020Z",
-     "shell.execute_reply": "2026-08-10T14:30:19.296721Z"
+     "iopub.execute_input": "2026-08-11T11:17:47.119645Z",
+     "iopub.status.busy": "2026-08-11T11:17:47.119552Z",
+     "iopub.status.idle": "2026-08-11T11:17:47.141907Z",
+     "shell.execute_reply": "2026-08-11T11:17:47.141509Z"
     },
     "papermill": {
-     "duration": 0.028933,
-     "end_time": "2026-08-10T14:30:19.297479+00:00",
+     "duration": 0.026804,
+     "end_time": "2026-08-11T11:17:47.142300+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.268546+00:00",
+     "start_time": "2026-08-11T11:17:47.115496+00:00",
      "status": "completed"
     }
    },
@@ -1895,13 +1907,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37d9e44f",
+   "id": "f39af555",
    "metadata": {
     "papermill": {
-     "duration": 0.003564,
-     "end_time": "2026-08-10T14:30:19.304664+00:00",
+     "duration": 0.003485,
+     "end_time": "2026-08-11T11:17:47.149530+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.301100+00:00",
+     "start_time": "2026-08-11T11:17:47.146045+00:00",
      "status": "completed"
     }
    },
@@ -1919,19 +1931,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "4de565bc",
+   "id": "bb9ba007",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:19.311997Z",
-     "iopub.status.busy": "2026-08-10T14:30:19.311919Z",
-     "iopub.status.idle": "2026-08-10T14:30:19.545256Z",
-     "shell.execute_reply": "2026-08-10T14:30:19.544811Z"
+     "iopub.execute_input": "2026-08-11T11:17:47.157277Z",
+     "iopub.status.busy": "2026-08-11T11:17:47.157186Z",
+     "iopub.status.idle": "2026-08-11T11:17:47.395270Z",
+     "shell.execute_reply": "2026-08-11T11:17:47.394784Z"
     },
     "papermill": {
-     "duration": 0.237451,
-     "end_time": "2026-08-10T14:30:19.545528+00:00",
+     "duration": 0.242841,
+     "end_time": "2026-08-11T11:17:47.395815+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.308077+00:00",
+     "start_time": "2026-08-11T11:17:47.152974+00:00",
      "status": "completed"
     }
    },
@@ -1997,13 +2009,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b06c7c95",
+   "id": "77401c99",
    "metadata": {
     "papermill": {
-     "duration": 0.003466,
-     "end_time": "2026-08-10T14:30:19.552694+00:00",
+     "duration": 0.003628,
+     "end_time": "2026-08-11T11:17:47.404572+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.549228+00:00",
+     "start_time": "2026-08-11T11:17:47.400944+00:00",
      "status": "completed"
     }
    },
@@ -2023,19 +2035,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "949eeefc",
+   "id": "595d14c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:19.560154Z",
-     "iopub.status.busy": "2026-08-10T14:30:19.560042Z",
-     "iopub.status.idle": "2026-08-10T14:30:20.358112Z",
-     "shell.execute_reply": "2026-08-10T14:30:20.357596Z"
+     "iopub.execute_input": "2026-08-11T11:17:47.412163Z",
+     "iopub.status.busy": "2026-08-11T11:17:47.412090Z",
+     "iopub.status.idle": "2026-08-11T11:17:48.188296Z",
+     "shell.execute_reply": "2026-08-11T11:17:48.187797Z"
     },
     "papermill": {
-     "duration": 0.802586,
-     "end_time": "2026-08-10T14:30:20.358682+00:00",
+     "duration": 0.780803,
+     "end_time": "2026-08-11T11:17:48.188836+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:19.556096+00:00",
+     "start_time": "2026-08-11T11:17:47.408033+00:00",
      "status": "completed"
     }
    },
@@ -2067,19 +2079,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "a2e65ef2",
+   "id": "6fdc294a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:20.366729Z",
-     "iopub.status.busy": "2026-08-10T14:30:20.366654Z",
-     "iopub.status.idle": "2026-08-10T14:30:21.614932Z",
-     "shell.execute_reply": "2026-08-10T14:30:21.614637Z"
+     "iopub.execute_input": "2026-08-11T11:17:48.199223Z",
+     "iopub.status.busy": "2026-08-11T11:17:48.199115Z",
+     "iopub.status.idle": "2026-08-11T11:17:49.558169Z",
+     "shell.execute_reply": "2026-08-11T11:17:49.557610Z"
     },
     "papermill": {
-     "duration": 1.252931,
-     "end_time": "2026-08-10T14:30:21.615359+00:00",
+     "duration": 1.363588,
+     "end_time": "2026-08-11T11:17:49.558502+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:20.362428+00:00",
+     "start_time": "2026-08-11T11:17:48.194914+00:00",
      "status": "completed"
     }
    },
@@ -2735,7 +2747,11 @@
       },
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAG4CAYAAACnwzTIAAAQAElEQVR4AexdB4AUNRf+Zst1erUiKogKiDR7AwRRQJAiIE39VZpIlSbSBQREEBEQCwgiqKhYQQQFRVAEBAWk996Pa1tm/7zMzN7s3u4Vru3evbtNJuWlfcnMvLy8ZCwOR4qHDWPAY4DHAI8BHgM8BngM8BjgMVBQx4AF/McIMAKMACMAgEFgBBgBRoARKKgIMMNbUHuW28UIMAKMACPACDACjMDlIFAA0zDDWwA7lZvECDACjAAjwAgwAowAI5CKADO8qViwixFgBDKPAFMyAowAI8AIMAJhgwAzvGHTVVxRRoARYAQYAUaAEQg9BLhG4YAAM7zh0EtcR0aAEWAEGAFGgBFgBBiBy0aAGd7Lho4TMgKZR4ApGQFGgBFgBBgBRiD/EGCGN/+w55IZAUaAEWAEGIHChgC3lxHIFwSY4c0X2LlQRoARYAQYAUaAEWAEGIG8QoAZ3rxCmsvJPAJMyQgwAowAI8AIMAKMQA4iwAxvDoLJWTECjAAjwAgwAjmJAOfFCDACOYMAM7w5gyPnwggwAowAI8AIMAKMACMQoggwwxuiHZP5ajElI8AIMAKMACPACDACjEB6CDDDmx46HMcIMAKMACMQPghwTRkBRoARCIIAM7xBgOFgRoARYAQYAUaAEWAEGIGCgUBhY3gLRq9xKxgBRoARYAQYAUaAEWAEMo0AM7yZhooJGQFGgBEoSAhwWxgBRoARKDwIMMNbePqaW8oIMAKMACPACDACjEChRCBdhrdQIsKNZgQYAUaAEWAEGAFGgBEoUAgww1ugupMbwwgwArmEAGfLCDACjAAjEMYIMMMbxp3HVWcEGAFGgBFgBBgBRiBvEQjP0pjhDc9+41ozAowAI8AIMAKMACPACGQSAWZ4MwkUkzECjEDmEWBKRoARYAQYAUYglBBghjeUeoPrwggwAowAI8AIMAIFCQFuS4ggwAxviHQEV4MRYAQYAUaAEWAEGAFGIHcQYIY3d3DlXBmBzCPAlIwAI8AIMAKMACOQqwgww5ur8HLmjAAjwAgwAowAI5BZBJiOEcgtBJjhzS1kOV9GgBFgBBgBRoARYAQYgZBAgBnekOgGrkTmEWBKRoARYAQYAUaAEWAEsoYAM7xZw4upGQFGgBFgBBiB0ECAa8EIMAKZRoAZ3kxDxYSMACPACDACjAAjwAgwAuGIADO84dhrma8zUzICjAAjwAgwAowAI1DoEWCGt9APAQaAEWAEGIHCgAC3kRFgBAozAszwFube57YzAowAI8AIMAKMACNQCBBghtfUyexkBBgBRoARYAQYAUaAESh4CDDDW/D6lFvECDACjEB2EeD0jAAjwAgUKASY4S1Q3cmNYQQYAUaAEWAEGAFGgBHwR+DyGV7/nNjPCDACjAAjwAgwAowAI8AIhCACzPCGYKdwlRgBRiC8EODaMgKMACPACIQ2Aszwhnb/cO0YAUaAEWAEGAFGgBEIFwRCtp7M8IZs13DFGAFGgBFgBBgBRoARYARyAgFmeHMCRc6DEWAEMo8AUzICjAAjwAgwAnmMADO8eQw4F8cIMAKMACPACDACjAAhwCbvEGCGN++w5pIYAUaAEWAEGAFGgBFgBPIBAWZ48wF0LpIRyDwCTMkIMAKMACPACDAC2UWAGd7sIsjpGQFGgBFgBBgBRiD3EeASGIFsIMAMbzbA46SMACPACDACjAAjwAgwAqGPADO8od9HXMPMI8CUjAAjwAgwAowAI8AIpEGAGd40kOR9QOnramHFz7/lfcF5VKLT6UTvQaNx292PovjVt2HT3//mUcmFo5jf/9gocU1OTgn5Bnd+oT8Gj3jdW8/OL/TDoOETvP7ccNC4W7zk29zIOsM8b6j+AL76dkWGdKFMsHXbf3J8nTl7Ps+q6T9O8qzgTBTUrfcw0PMsE6T5TJK2+FYdumP0hGlpI0IwZOZ7H+P+Rk+GYM0yrtLkt95D4yeezpiQKfIUAWZ4cxHuhx/vJF8UxOQFMnc3aJmLpQO17muKCVNmpSmDbsZb6jRME06MaaUaD+G6W+/DpYTENPGUn9GOa6rcLW/ojz75Ig2df8A3P6zCUvHS/2rhbJw//Dduv+1Wf5Kw8U+fNQ8PPdY+w/o+9b/eGDpqUoZ0hZ2gSuUbULHCNQUWhjvr3o5SJYsX2PZxwxiBQAjkxPPvivJlUaP6Ld7scyJPb2bsKJQIMMObi90+cfQgfL14jjRvvzFKlvTGuKHST+FvTRwhw/LL8i/3u+W/4JYqlXDf3XXwaRCJWMe2LWT957w9AQ/dfxd6DRiJbwVD65+X2X/k6HFcX/FaXFfhanMwuxkBDO7XHS88k/EEIlyhWjDnTdx7V+1wrT7XmxHINwQef6wBpk0cnm/lc8EFDwFmeHOxT2l2Sswjmdura1LNarfcJBlKCqt1ezVv6SdOnkbrjt1x7c334N6HW2PR599448hx7vwF9B86DjXvbQKSrj7Rvhv+2b6TonLMLPzsKzzRrJEwj+Djz74OmO/VV10h69+o/n14uffzqFmjKr7/8eeAtBT4TPeBeGX0ZGzYuAUkHb7joeYUDIfDiTGvv4U6DzST7WnS+n9Yu/4vGUeWsUz/w4rVePDRdih/Y12sWfsn3G433po5T2J0VeW7QNLWpd+toCRes3f/QdCSKEmxq9RsgB59X8X2//bI+G07duPlYeNwx0MtJNaPt30ef/+zXcYZ1sSp76Jh804od0MdUJ2f7vayjPr406WyLaSSQeFkPpz/mYwzWy/2HyEnAW/P/kimJ7r/du1DsDZlpk6qqoKW+Oo1eQrUblo9mP3BQnOxXndKigNPdu6JR1p0wfkLF2V4sDbJSD8rWD0zwp5WBahPCTsao9RvS5b+4Je7r9es0mCUS3iZTfN2L3gTLV+5Rrarwi33ovb9zTD+jZlyTBgE+w8clm2n+4j6+JPPA49jg37fgUOyj/7dvssIktd5C5eAVjto1SMz7aKlYpLo01i7tW4jGHX2V2l498OFIFpaRaH6j504HS6XS5ZJFq2+0FIo9S3dG9dXewD/6zkIx0+eomiv+emXtWja5n9yDN8h7qkhIyciMTFJxl/OsyIr44sK+WvTVtlG6gd6JtE9npSUTFHS0D1JzyiKp76ksXD02AkZR1ZG/Ug0hqH7icaJ4acr1bf6XY+CcCK/v8lMn/lhjUBYUz6kvlD59nqodmdjEM7+ZQXyL/xsqXxu0b36YON2+OCjT71kcz/+HDfXfthn3FJk15deQcfn+pJTmowwKn1dLVBehDONJ1rNk/UdOBq0eki4U/nTZs6V+RmW262iz+Axsg7UplHjp/mMwROnTuP5XkNkPN0D9Pw7fOSYkVxe02sf9RcJQfyff5mpm8xct+h5Z6g05FSeRp/TO4BWLAk3ekedPnNOL1W7ZIR9RvexlkuqTfjR/d538Fh4PB65gto7g35KTc2unEKAGd6cQjKb+Uyd8T5uq3YzZrwxGpUrXY+uvV8BvbyNbDs+1w/xly7h3bfGYfPa79Ck8UN4on1XkPTUoMnO9fiJU/h5zXo0e7QBGj/8AHbu2pshQ02M399bt8NiCT6M3p8xASOG9EadWreB1BnWr/pSVnP4a1Pw7oeLMEFIwf/+/TvQ0vbjbV/Arj0HZLxhTX5rDiaNGYzDO9ZKVYjX35yFpd+vwMhX+mDbhuUY2LsrRrz2JogxpjQnT51Bw8c7ITYmBp/Pfwdrf/oM9wgJ28X4eIrGhYsXUe3WKlg8dzp++/FT1HvgbomjwVCsXL1W1GshRr/SF/u2rsbqZYtQV9SdErdv3QxjhvWT9aC2kOnSoRVF+Zi3Jo3AY488hB7Pd5RtJrqbKlX00vi3KaM6UcIJU2Zi6jsfoFfXLtj+1494fdRAJAXQ2Y2/lIBWYuLkdLrxxcczUbxYUaTXJso7mPGvZ0bYOxwOREZGYcq4YaA+7fFcR8EgTMq0fvpddWt68SLM/lqzVKoD3FH7NlnFX35dj179R6JLh5b4a83XeGfKaPyx4W+MHDdVxhND/mSXF3FOMPmrf1iED2dOkpOE8+c1pl8S+VmkTnFH7Rr44mtfxnzJ0mVo0bQh7Ha7mJw5EJmJdr0vmJobrq+ANWLMzJs92a8kzXsxPhH9ev0PW9Z9j9fHDMJv6zZi3OQZWqRub966DcQcfjpvBr78ZBb27j+E8ZNn6rEA4UBM88P17sOG1Uvx8ftTBU4l4dQZ546X8azI7PiiStAzp9mTz6N82TKyH6ZPHomFYjLYf+hrFC2eUwl4tscgtG3VRI6Dzb99iy7tW0JRFBlP9U+vHyWRyerQtjlILcrMlKz4+TecEJOAJ1s2MVGmOjM7FjPCeujISfhaTKg/nDkRP309X5R5BivFZCO1pLQuYva79R6Gdq2a4t8/l+HZzm0kgzl/kfbso2fs2XPn8bMYz0bqZHEvf/39T1LYQGGZxWjClFl4umMr7PhrBbr97ynQe2T/wcOYM30Cjuz8HQs/mIqrrihLWXrNJ0KY4nK68Lp49rZu3hjEEH/+lTb+iRl7stOL2CEEBEsWzMSPX30kx+ITT3UFTf4g/jJqX7DnX2bqJrIP+MvJPDeIydqZsxfw5cJZ+Oaz92T7numuCTWo8Mxgn5n7mPIiQ8KOxi2fQSuBNa3wKoqSqX6itGxyFoHgnErOlhP+ueVyC9q2aoZXXn5RMLL1MHvaWBQtEoe/Nm+Vpa7+7Q+50ett8WKpJaTCpBP4TMc2Qrp6Kz4XL2ZJFMSilynN9M0m0KaFuR8vQUPxAi1RvBiioiLRvElDzA+gn2vOj6SrdrsNnds/EaT0wMEkCZozdzH693oe9e6/GyVLFMf4kQNwpXgwvzfvE59Eg/p2Re2a1WGz2WAX5s0ZHwhmtA/qC0a1WNEieOTh+9H5qVZC0qFJWj8QElcKnzbxVdx80w0yb2JUiamhjImp6ti2BSpcexWuufpKvNStC6oKqft3y1ZRNI4dPyXTEJMbExON6oI5pheJjMwhy9ymuNgYZFQnkgBSu4f07y765WE5NkgPmupOVVIUhS4gyV5TISkvXaokFs2dhujoKBl+uW0y1zMz2FM/DnjpOdx6cyWJYesWj6KL6JtPgqwWyMoFsS7GX0KH//VFHdH3A/t0lVRT3n4fzz3dDm1bNkXpUiVAk6gh/buBGE0iWLVmHf4TE7WpE4aD1Geo/2nicuGiNtkhmkCGVjU+01/4FE8MHb30Wj7emLyyLZlpF63i9O35rKSn+1cm9rP6vfis7G+Kp7E/sM8LWLB4qQ9VCXEP0iSR2kDj76k2zfDHX5u9NIRDO/G86NW1M8qWKYUbKlYA5Uvj/nKeFRmNL2/BuoOk3zRup4x/RfbD3XfUwrCBL4p2fIVTp8/ijJCWEXN0r5ho0oSL2tGlQytcUb6szIHqn14/SiKTRfdupRuug3kcffLZN3JyTm02kXqdmR2LJdLBmiSS1NbB/bqB2khYvzlhGBISE73lBHK8++EneLTRAMqyXwAAEABJREFUgyBVHWo/PW/aPPEYZr+/UJJTmY80eABLvtKYTAr85oeV4hlnlcIG8mcWo/atm6Jp4/rymU1jiu71itddg1uq3Cgn/fffUxfGOKZ8yVS/9SYQA0npXh3UCw0evFuMry0UJSdTNAmYNmm4fH5S302bOAI7d+8HqbwRUUbtI5pAJjN1C5QuvbDLydNqtYAYT3r+V725MsaNGAC6b7YLJp/Kygz2dL/Rc5swD3YfK4oiVw+btH5GvGc6Y1DfbpS9NJdTb5mQrWwhYMlWak6cYwjcUqWSNy9i7q4VzJgh0diz94B8yJYWS1hmxvWHH1fDLAX2ZmBy0MOW9IXNhpgQE4lcYiHpwxPNHvEGExPw6RffgSQP3kDhMPL74J2JgkG+F2Nf7QdiwkVUpn/7Dx6R0oIGD93jTUNtJp3gvfsOesPIUdO0wW2fWK5OEcv1tFRvxmH42CnYt/8wkWP33v2yPpSfDPCzEsWyLy2DPyiWGctUrC2Xs4m5OXRYW7J7+KF7xUv7DB56tL1UuaAlcWK+/LLJltfcJsooozrt3nsQ1O66tWoQeRpDUhkKfLztc6hcqSJIqm4XkkkKI3O5bTLXMzPYU1m01PlYq2flUjv10fg33oGBLcVnxtBydZcXBkhS0hW36CsIxMzSZI3yNUyDZh1BjMmx4yfFvXBITmKI0ZWJhUWqQwbjL7wBfy2aNsLhI8e9KjVLli5HpRsqgBgtI0Fm2lWj+s0GedDruj83of2zL6FKrQZy7D3e9nnQ6gqNASPRNVddYTjltXSpUqCVC+kRFuFQt1Z14Ur723MZz4rdGYwv/1L27DuI++6p451QUTyNMbru3X9QTjbuubM2SO2GVABo+feAuOcpngzVP71+JBp/80zH1vj4069kME1gvl22Eu0EsycDgliZ6bP0sD546Kh8Nj5w713eEorExWaok71rz37BRKY+2yhxgwfvwfade2R+5G/5+CMgJtd4vi4RKwwkZCBhA8VnFqMa1W4lcq9p0awR5gnhBak0kRrT98t/8ZZpEN18042GU15p8n/6zFnppv4rX64MalS7RfrJotUpMnv2HSCvWIXLuH2S0M/KTN38kmTovZw8bxQTRPNEqZqYACiKIt4hh2R5mcE+M/fxfiFpbyoEEEP798D/OreVeRvW5dTbSMvXy0eAGd7Lxy5HU9psVp/8FEURDyotSFEUKcmhZV5/QzNVjSqwbejc0ovfMDSzNVOvXP27YEqOokvX/vIlTMwEvYjPnD0PWmYz0xr5tRDLve8Lppcequs3pEqfzLQZuf2ZUpvVliZJdFSUN0xRNEnm7z99Dn8c1q1c4qVLzzFELFFu3vov3po8Ajs3/STzIWmxw+mUyUiKs2bZYrQXUrUEwRyPm/wOHmzc1ofhkITZsMxtomwyqhPRkFEUrf3kNhtF0cJbNX9MSipIGmOOv9w2meupKFoZ6WFPeue0xPrqoBfxx89fSmxp1cLA1lyn9NykU0hSpoViqZ4kiQatoiiY/NoQma9//xvSQ5vV9z6itFaLhS5BDeHTQEi5vvj6R0mzRDAfTzRrLN1kZbZd0WJlhOiDGWIYWnfsgSefaIplX8zFmQMb8d3n70tyM0YGgy8jdMuY1OheQOsO+P8pyuU/KxQlSKb+hQi/1Q9nq9/z6/P5M4TUtyeiIiOxUEhj76jXAr/+vkGkBBQl436E3x+pLtCki/YCLPz0a/E8LI2H7ktlRP3I5R6IzIzFzGBts/mOH/+2+pdNfn98bAIf6kNF0TAmtTGi+/7Hn+XKzPKffgUJGSiMjKJkDqOo6Egi9xp6lq38dgHuElJ3mvy/8NIQOcHyEggH1UVcvD9FoTp5vH7zZNkI9G+Pv5/yNLfPSGe+ZqZuZvrMuHMqT3oXUf2pTEVJH/vM3sdXXlEOd99ZE4uWfCsn5ZS3YXKq3kZ+fM0cAr53cubSZIKKSXISgZsqXy8ZLtKZzcl8jbxoqZBUA8xSYHK3FUvHFGfQ+V+JGXm6Q2sMHTXZPypd/3XXXgV6YG75Z5sP3ca//5GnOfgEmjw3VLxGSpV++nmtKdTXeeP112Hj5n98NmGYKWhjVJNH6qPaLTehhFjOJMnpvzt8NyzRg+p5sXQ+bsTL+H3F5zgopL8bNmrqJVFREfCoqS8Hc95md2REJIwHqDk8kDujOt14/bWIjIwQy47pTyxIxYGk9yTp/W/XPp+i0muTD2EQT2awX7dhM+4RL9o7atcASYkoq63/7qBLps2X3/yI6bM/woczJ0pJoTnhLUIyRZMzc5jZfV2Fa0RfHRUS+rPeYMKBJMDegCCOlo83xpffLANtXqP77MmWj3kpc6JdlNnGzf+idKmSoN3nJFWje2Drv/9RVJbMTZWux59/aUvQ/gkv51mR2fFllHVDxWux5R/fft20WbuXr7/uWkkWJZh/en68KpbMV36zALVqVMMPK36RcRn1oyTys0gi10r0ETHP8xZ+DlppUhRi1PwIdW9O9Nm111wpmfMt/6T2EemJb/pba6teVJoLqV+Y0xDBpi3/gtpNbjLEVD4hpLxffL0cX3y9DFdfVR6kfkBxZIg2vbFONMHMbVVvRu/uT2PW1LH4cNZEkJSXpOLB6M3h14v+ow1WtGJihJ8+cw4k1b9BSEYpLDPtC/b8y07dcirP3UJSbcaD7kFSwal43TXUPNlP6WG/MZP3cYRYZZs36w3EREeBJrr+z6HsYCErylaWEWCGN8uQ5X0C0hWiGWGPfq9i5eq1oGUw2mRFZ8LS0kp2akQPM9qE8FSb5vL0BUMKTFfaDPHTL2thXo70L6vzU0/g763b8d2yn/2jgvppifn5p9uCpKe/rduAs+fO4/U3Z4MePM918V36MWdCs3DS+31j+ntieXOpTEf6wJ99+T1IJYNon+7QCnQyQa8Bo+TJDJQ3na5gSKFp+Yr0tUhvkdrerc8wmB9+9JEAOlvYeDit/u1PyTxXvE47Uq2ieCEcPHxUlkHlBTPXC3rSCaPl+WA0RnhGdaJ20wts7MS3BVP2I0jFgpiyqe98aGThvQ7q2xWtmjeGmenNqE3exOk4qA4ZYV/tlsr4S0w2CHN6gVA/LV+5Jp1cfaPo1JFufV6R+tzml79BRZu9aPf3uMkzQKo8hC2po5Akj2gevPcOEPP20sCRcmzQS3vgq+PlZIHi0zOkc0ljqe/gMaD7jTazGfTZbRf0jG69uTKOHj8B+pADBVFbaMMQubNi+vR4Ro5/SkuqDiRxmvzWe3IcU92z+qygvs3s+KJ6ErNJy/0kiad7iDYOjn59Gp5q8zjKlC4p7rvdoPoQ40T01Fd79h5ARf1Ywoz6kdIEMk89+bho91fYtmO3KKtZIBJvWE70GU3oO7V7Aq9Nelu0aY987g4b84aUyHoLCuCgZxgJCuhjJ/QsIoZ23sdf4Pln2vlQt2z2CJb9tBofffIlWjZrJJlrg+ByMaKTEZb9tEaeAEHM+epf/wBNPknX1Mg7vSvdd7dVuxkvvTwSNFmkvqN7ooJg/g2pdGbaF+j597aYyGanbjmVp6Io6Dt4LA6J5zg9cwaPmCgnG7dUuVFCkxH2WbmPIyLsWPDem7DbbT5Mb3axkBVlK8sIMMObZcjyJ8Hc2ZNBm8qGjJiEG6o/iHZPvySWr9cjLi42WxWihzItXT/S4P40+ZCkjiSD8xd9kSbOCChXpjTatmyCsZOmG0GZuo4c0gfNmzyM3gNH4ba7HhVt+QNffTJLbsBJL4O+PZ8BLZnTRqVqdzTGfY3aSGY3NiZaJqPl6W8+fR/xly6hRfsX5FFDU6bPAW1AI4LXhg8AMUp0bM/9jzwJkpbVeyB1aTQuLgb0MLr6prtAqh1dew/FxDGDYOi9PXTfnahetQquu/U+GR/oWDIq56knm4uJwmGUvPZ2SUcvDwoPZDKqE6V5ufcLoFMPJk2dLY/LIt1V2qVOcYYk2biOGdYPzR6tL5leYoYyahPlkRmTEfYkXX6s0YOo36QD6j7YAv9s24k+PZ7NTNaShph4Yjr7Dx0nMSP8yRhHfN1Vt6Y8A/oPId2s1+Qp3FzrYcFYzYHDkSLTE+P2yYdvwelw4oHG7VC/aQe0Esx/+XJlZHx6VmxMDEjyTxMjUtcx02a3XUZe9EJ9e/IodO89DHc81AKTxbgcNbS3EZ3p6wOCsV88b7qQ3P0sj2ardV8z/PLrOtDGQsrkcp4V6Y0vytNsrr7qCnzz6RzQbnc6kozukfoP3o1JY4dIspjoaFmfqnc8Ivux1v3N0Eg8XwhHIsioH4kmkLmzzu2ocM1V4jl4L666snwgEm8YlZWdsWhkNHZ4f1B9W7R7AXfWf0Iyks0ebWBEB7xS/JTxr2DGnPm4tU4jTJ3xIUa90gcdxDPBnOCeO2vJjXw07lsI5tccR2XSKluwsW6mNbvdqoqeQjBSqkJNkCFdZzrZR1GCS8PN6UnF45MPpon3Shyat3seDz/eUTLin330Doh5I9rMtC/Q8y+7dcupPEk/uaqYnN9ZryUea/mMnBC8O30cNU2ajLDP7H1sPI+joiJBmFLmJOlNTExCdrGgvMLV5Ge9meHNI/TpJiG9Q9pZ7l/k6f1/pdnksHrZInR9tr2XlKQNtHObdFWP7Pwdq779GIvnvY2qQmrkJfJz0NFNtAvcL1ju6N7253IZ3P25Dtj/7xrYxfKLDPCziG7ogJ4yNFh+tOP3tx8/kzSBrN5iee3Hr+b5RNHDk/Q7//xlKQ7tWCtfoLQT2iCihw7hRQ8LI4yuiqKAXmYrln4kj92hY5noeJkWTRtRtDRVKl+Pj959Qx7VQ3lQGdVuuUnGEUM8Z/p4/PHzV6C2ET70cYCxr/aX8fUfuBuEMaUjQ9g816WdjCOLXghUHsWRod3nFO5vKorl9Y2/fuPVN6VNH8HalFGdKG9a/u75Qif8+uOnOLHnT5D+JzHKFBco39dHD5btp2XIjNpEeZhNoPwoXlHSx56wGTawFzb99o00tHnu5d7Py7FK6cnMnTUJ40a8TE5p5s6aLCS6A6WbJIeEqb8hvCWBsGjl4YuPZ2Lv1l/w36afsHTRu6AyRZT8Ee6ffjQDW9d9L/uXmIy/134H2iUvCdKxZk4dI/vr+adT+5vIM9Ouz6TOai8i9zF7tvwiVRiMwFaCAV+zfDHWr/oCtNRPqhTUXtrNTzS0+/v7JR+Q02tIBYLy8QYIB20SI7qD23+TdSYcYvRJ3+U8K9IbX3TvUB3pdBhRtPzdftutEnsqn8b56Ff6SXUjiiR1DaoPpSFDY3Xq669KNSaKJ5NRP871GyeUhhgF2uDXrnX60l2izUyfZQZrwpJOZtixcQXoeLUJowZJVYE3xw+jYoIaGm8/f7dQPqN+/n4hOrdvmYZWURSZJ2EU6DmeEUaB3ht0cseuzatAeZKhZx/lYxQeaJyOHzkQc8V9aNDQBJHu3e0bfgTlNVf0Bal3GPF0zah9dB/SuKA6kKHnX0Z1o3zNhm3KPxkAABAASURBVN5/9B40wnIiTyOvPmKVhN6jB7b9ClKfIsGNEUdXwiy950xW72O6N+l+JUPurGJBdWKTfQSY4c0+hpwDI8AI5BgCnBEjEBiBGXMWyOO3mjxSLzABhzICjAAjkA4CzPCmAw5HMQKMACPACOQvAqSWQ6ot9MEHksYFW43K31py6YxALiDAWeYoAszw5iicnBkjwAgwAoxATiJAajm0LE5HuJEeb07mzXkVLgQCqbEULgQKd2uZ4S3c/R+WracPYtBX3mhjGX2Egvzh0JA5cz+Bw6Gd90v1pe/EG6dBkP8yjE8S2jHfsHknn7Cc9lB9qd6UL53+QB/9IDebwAjQplD6yELg2LShedGHaUvNvZBBwyfghxWrc6+ATOQ8eMTr3jrQ2KUx7J+MxjGNZ/9ws998/1I/0Yc1zPEFzf3AI23TnB9b0NrI7SlcCDDDW7j6O+xbS8dcjZk4HS+/9AJ2bPwJrw3vjxMnTyMc/uhkCfMHBmgzTEYfKwjldt19R010firtZpxQrjPXLW8RoC9M0eeh87bU4KVl554z37/FisZh4uhBwQvimHxAgItkBNJHgBne9PHh2BBDYPb7C/HKgJ5o3PAB0A7qmjWqgk4voGre8VBzDB01CS2f6gY63/fdDxeCjq8iafD7Hy0mEnmG7Usvj0KzJ5+Tx3vRucYU8fqbs9GifVfcUqch6OtxFGY29EGCzi/0B0lQq9RsADprluI/+fxrefwVlTFp2hwKkmbJ0h8k7X0N26DzC/3kl5/o7NL2z7yEri+9Iml6DxyNpGTtSK1AdSXpIJVJ7Xm05TPygHpKSMeqPdbqWZC0iqRM1FYKD2aOHD0Oqt/T3V4G1YfOpqUv6FEeZI4dPymT0tnOz3QfKNtDWBhfbCMdyubtXgDVYcKUdyQtWWvXb8TcBZ+TEyQdq3ZnY1mnfkNe80qyew8aDTpmjPKj9Nv/2y3pzdauPQdAfffgo+3Q9ukXQfWleGonSUep7tXvehTvzFlAwZL2cvqZzi8O1PcyU93yHwcJiYmo++Dj3o+IHD12QmJJ5FTnV8e8gUbNO6Npm/+BztelvrrjoRber4oRHbXvifbdQEfh0dnZFEbm3QDjk8INE2zMGfGEE2FG44sw6tH3VXlWLMUHGpdm+mZi/NNZyURrGP+2U/iGjVtk2+iIt269hyH+UgIFg87ufrJzTzmeqG0UGCiMpKJ/ijwofs3aP9H4iaflPUljwljtuEPctyRhpTFG490og9IEMoS3ccYvxd9VvyVo7AYbg0RjGPM9N+Xt93HPw63QplMP0FfcDBo6X7jWfU1xZ70n8N68RTKYvrZnvn8vXLyEAcPGyzj6eA2NecKI7if6kAxFBLt/Kc4wgfok0LigM60/+OhTmaxnv+HeZ8i8hUtAcZkZ25eLP517/eGC1FN4+gweAzpDWlaGLUYgjBCwhFFduaqMgPziT91atwVFovqtVfD5gndQqmRJzP5gIehoGfrM6Vsz54EYOGL06AxPOjbpn/XLQGcy7j9wGPSSItp//1iGju2ap8n/nTnz8VyXtlj+5Tys/ekzwWzHYvfeA3hfvIQofzp2jZg5YqCJQRwxbho+mPE61ixfDPra1JMtm4CO9vn4/amg46/MBezYuTdgXYnm2ImT8og10l+cNnOuPENYURS8OeFV0JE9s6eNxcv6i5fogxk6+H/kkN5Y8fV8rF23UX5R7NvP3sOTLR+TZVO6MROmo8FD9+AnQTN8cC/0GzKGgjFahDd/7GFQHejMZhnoZ9WodjM2/PIV6AimyEg7Fi35xkthtSpYIvpk1tQxeG3SDG+44Shdqji+Xvwe6Bgn+gDK2IkazSeff4PNW7bjhyUfYuOapXi04YNGElxOPwfqe2+GwhFoHMTGxKBWjepYufp3QQFQnZ58ool0k0XHDC77ci6uv+5ajB4/TR4yP3/Omxg94S2KlobOq313+jiB3weYIxgoYoDT63OZSFiBxpwI9vkRUzxySB959FtsbLTEPdi4pIR0NjIdb0jj3246ijBQ2+nDBX0Hj8XrQpJJY+I20cfT3tGOTBs3+R15lBWN7xlTRlHW8kMyc2dNlmPeCJMRwnK5XOghGLVxIwaAjhQ8evw4Fn62VMRovxrVbwUdP9dYTGQ/WviFFhjEbtq4Pj798nsZSx+hKFe2NMqXLYP0xqAkNlmEG30c4ocv5mLaxBFY/+dmb2zbVs1ARzDSvbJk6XLxzDkg7pPg9++CxV/i9Jmzsl10rnK3PsPkeb2UYaD7l8LNxtwne/YdkvcjPYvoufLWzHmg59YdtW8DnclL6Q4ePiq/vElu+uIePQ8zGtvZwb+dwGPR599ScXJCtUrcCw3r3yv9bDEC4YQAM7zh1FtcV4mAoijyGsh65OEHZPCfG/9Gs0cboFjRIihZorg8C5XCbq1SCT+s+AX0da5f122QcfTCPHfugmDG3pYfsSgl6GUmJquWkCRPnzUX9AWp4ydOy0PY6SMFp0+fRZeuA9CqYw9s27FLMmjrxMvziaYNvYfj06YbpPNH9QpUV0pyV53bvR/NoK8l0TmkiqLIsroJiVufQWNw7Pgp0BediD6YqXRjRclw0yeKb65yI+rWri5J6TzVXXv3S/dv6/4CSaVI0jbitanez8fSZ1GNs087PNlC0vpbdrsNJDFr93QvkOR3x849XpKH7r9bHl5PE42du/d5ww0HMdFLli5Dp+f7CYnaYmzfuVtGrRX1ef6Z9vJLafRRCTrfVUYI63L6OVDfi6y8v2DjgCYFiwTzTYSLhES/5eOPkFMa+ggEOW6/7RYQQxgVFYlKN1TAiVOnKViaRxs+JCZgxUFn7dKRWhs3b0V6fS4TCSvQmBPBPj/6BO11+hfMGjx0L/7a9A+CjUtKWL1qFdB5puQ2m0BtP3T4GA6L1YHBIyaCxsSX3yyXX1WkdFVvqYyhoyZjxrvzQWfeBgujcDIHDh3BVVeUQ43qt0j6zu1b+Xwe+eF69xIZrihXFsZ4lAEBLDqXmKTJFEVX+sgKudMbgxRvNhv//kd++KZIXCzKlysjP4xhxCckJGDIyIno+FxfHDt+Ajv+22tEBbz++ddWMUluIcd4rdurgc7VJuyIOND9S+FmY+6TYOOiVo1q2Pj3Vpw5e17mT2UcEyszf4mxVFuUmdHYDoB/pvGn8UXnNNOkiD5k8Vijh4Ke225uF7sZgVBDgBneUOsRrk+6CNxQ8Vps2LQlKE1kRIQ3jpgkw0MvQ/ryDb1wSXpS7Zab8PqUWfji6+XywPwfl87D/ffcIZeih4ycLJmGO8TSNJmf16zD0x1bC0nXYPFyLC0Ys76ghz/l16JpQymZIunU7z99jr49n5XL31SeUXZmroHqSulsNitdpFEUBU6nC/RlJlIl6Pvi/6Tk9OoryyMhIVHSBLMiTNI8q8UKu80uScntEnmSxwMPFn34lrc9dCi7DPdAMvjkDtau/q+8Bjpc/t3p49Gnx7NISEwicmmMNhBjRJImGWiy3v1wEY4LSfb4kS9jjkifmKi1hfC1260mylTn5fRzoL5PzREBxwHFE1O7ecu/+OXX9ahS+Ub5+VwKJxOh42q1WmGzaZhSONWdrmRsNgtdpLHbbPIrS+SxCTddyRCu5jQUFmjMUbjZ+KchP5lA45LSmXEjv2Gio6Pgfw/QeKAvEdLYJvPDFx/Kj91QGvp6V6f2LXBJjLs2nXrKlYdAYURrGJtpLNtFv1I9vXECP3LLMaKPR/IHMtdcfSUiBO60kvLVtz/iUcGAEV16Y5DizYbKtlhSx5bRF6Se0K3PMLRu/ijo61gN698nxrI2Hs3p/d02vf4UbrfZxZ0kbhrhMbdZUbT7VwT7/Pz7xKgLERnjIkpMpGjV6rvlq0DSXjLLVqxG0SJF5NnEGY1tystcF7vdKp9TFE7GptffYrHAeB5QuGFo0keSbNogTKtVRjhfGYFwQiD1SRxOtea65j4CIVrCc0+3wyixXLzi599kDUnP85vvV0q32apT8zYs/e4nXLgYL/Vtl363AnVr1ZB+kvo+2uhBtG3ZRDCP/8gXmqIouPeu2pJZI4nmHbVryK9h0RexHrzvTpmOVBKeavM4br/tVtCS9F11b8fnQjJJS8hUNukVEiNMRyeRNIz08yicmAK6xsbG4qKoD7nNJlhdzTRmN5V3+203S0nivgOHsC2AXqyZPrPu+++uK6XcRE8MAal5kLumaO/q3/4gJ375bb28+lukMtGo/v3iBRyHFat+9Y9O17/3wEHce3cdXCkkgLQp0SC++85amDN3EYgJoTADR3IbJhh21O/+/RwozMiHrgmC0VYU33FA4YqioEXTRuje91W0afEYBWXJLFuxRkrmSApPErLat1dHsHqbM6b6+o85czy5/xWrCiTRpf76ePFS1BIrEcHGJdEHM4Hafq1gLM+eO4fvl/8ikxHN5q3bpJvqdlvVm8UE7xmcPX9BMr6BwiSxsCpcc5WQlp4Epad7du6CJbijTg0RE/z3z/adIL3cQBS0IkKrNOWFdJbUGYgmK2OwpsBp7fq/KBloEma4z5w9B5LE0z1usSj4eU3qeA96/9aqJleGqA9oMnrq9GkQdjLzLFrpjYs7BV7TxSpT3do1UKf2bXjnvfmgMCqCsPcf7xRumMvB30hL18cfexi0CnNMrCaROhE962jCQXFsGIFwQYAZ3nDpKa6nRKCRkLjQprWxE9+Wm1/adnkRScnJMs5s0eeFn+nYSm5Ea9mhO14QS+OVb7wOXwgG9YpKd6B1x+74/c9NUi93/4EjuLrK3aANYG9Mn4NXB75ozkq6B7wyTm5yo2X3MqVLov6Dd+GGihUwfFAv0Gahek2eksu+VJcbr6+Afr2eQ5duL+Peh1vj6a79ZR7d/9cBA4aN8244kYHCClZXERXw16jB/fj51z9kedPemSuXiQMSZjFwmGj3qdPnQBugaPPet8tWyRxeHfSi1FVuJXBctXqdDPO3enV7Wqbr8FwfISmN9I9O1/90h1YYKpaQKX9jKZgSPPnEY6h8Q0U83Kwjqt3ZGLPeX0jBPiYYdoH6OVCYObP0xkGLpo/A4XCgYX1t6d2cLiN3tVtvQisx3ho/8TQ6tWsJGofB6m3OK9CYM8eTm/Ke+OZsuXksNiYabVs1DTouiT6YCdR2q5D6zZr2mph0fAK6N2rd2wzEVFIed9VvKTcPkjS0d/cucqITKIxoyZDUcsr4YRg8fCIaiP4sU7qUmHA2paigZr24P7f+uz1gPKkxkPpN08b1vPFZGYNVb64MmsjSmOv0Qj/ExsbIfGjSRfcvtfd/PQfhliqVZDhZwe5f0jsvVrSobNcro9/A1NeHg7CjNFk16Y0LYoZPnDwDWp0iVZbDR06gtpg8URkZje3LwZ/yNUzRInGoKSYJhmrTl9/8iA/mp25kM+j4ygiEMgLM8IZy73DdAiLQqnljuUln5TcL5BJr6xaPSrr1q76Uy3vSI6znurQHF9MUAAAQAElEQVQD0az69mM807GNCAG6CObq2K71+PSjGZgtXua0PHrrzZVwfPcfoI1nFHb/PXUlrdmi8F2bV2He7Ml4bfgA2MWSKsWT5G/Zl3NlORtWL8XNN91IwfJlTvn9+uOnsiwKbNG0IRbMeRPGpjXadEYnTVBcoLq2EQzfsIG9KFoaWlYmPVZ6+dAmIvJPff1VuVmG9GNLlyohN9VJYpNFcd8v0TYbUfA7b47GfUKiSu5bqtyITz58i5xyqZ42GxFe2zf8iDHD+slw2pA1d9YkfDZ/BmZNHSs3y1HE4481wMihfcgJknyTNHz+u1Ok6sebgrmhCLo2ePAeckpDm4Gkw2SRxIj6jvIf2OcFIVn/UsbSS5o2WBFOW9d9Dzo0niKIlpZ4yU0mEHaB+jlQGKU3THrjgHSSO7d/wtvvlMZcj45tW4DqTuFk/l77HV1AfUhjhjAllRfjRBGKDFRvcx8GG3OU1jCk/0y40Th7+41R3vHfQkik/cel/zgw8qBrsLbTpk7aBEpjecfGFWj5eGMix7Y/l8t+IjUG494KFDZ+5EA8IiZolIjGHI1DuicnjR3sVZMx40g0b00aQeSgDYtG3jLAZNF9Sx+jMMcHG4PjRrzsrQONJeOe69PjGTmmP35vKuh+ovFMRUyfPFI+C+bOmoz3Z0yQfUjhLUz3L/UTYULhpBc/+bUhMo9vP3sPd9WtScEyXaD7V0bqVqA+eS7Ac4vIaUPf/n/XSB1oUj04svN3NNEZ/ozGNqUnbLOC/y8/fAIDK5LKHzl6Asazlsax8XygvNkwAuGAADO8OdJLnAkjwAgUVARGjpuKsRPfQtdnOxTUJoZku4jxJYlrSFauEFVq+3975GoaCQJKlSxeiFrOTS1oCDDDW9B6lNvDCDACOYrA8MEv4c9floKkejmacTYzCyQdzGaWOZOccylQCNx80w2gIwMH9e1aoNrFjSl8CDDDW/j6nFvMCDACjAAjwAgwAoxAoUIgPxjeQgUwN5YRYAQYAUaAEWAEGAFGIH8RYIY3f/Hn0hkBRqBQI8CNZwQYAUaAEcgLBJjhzQuUuQxGgBFgBBgBRoARYAQYgeAI5HIMM7y5DDBnzwgwAowAI8AIMAKMACOQvwgww5u/+HPpjAAjkHkEmJIRYAQYAUaAEbgsBJjhvSzYOBEjwAgwAowAI8AIMAL5hQCXm1UEmOHNKmJMzwgwAowAI8AIMAKMACMQVggwwxtW3RU6lU1OTkHxq2/zMZPfei/LFew9aDRW/PxbltI9/HgnnD5zLmiaSwmJmPvx5954f783IgNHRuVkkBwPPNIWVHZGdEb8/Y2ezBK9kS7Y9Y6HmoP6KVh8TodnF69A9Tly9DgaP/F0oKigYXPmfgKHwxk0niOAbTt2Y+XqtV4ovvp2BYaPneL155XDuEeClU/3D90X6dUnv9oSrM7B6pqZtgRLe7nhdO/Qc7pUhZpo9uRz+Pr7n9LNiupofnYuXvItRk+Ylm6a7EZS/1K52c2H0zMCGSHADG9GCHF8UATKlSmN84f/9pp+Lz4blDYvIy4lJGD+oq+8Rfr7vREh5nhzwjBER0WGWK3Crzrvf/QpHE5meNPruR07d+OXNeu9JHffUROdn2rp9ee1Izvl51dbslPnvMR37YrPcXLvn+jb81kMeGVcukXnx7Myj5576babIwsHAszwFo5+zrNWqqqKx1o9C5q1k8Tvt3UbvGUvWfoDGjbvhPsatkHnF/p5w3/4cTWat3sBDzZuh+3/7faGG46kpGR0fekV1G/aAc/2GARHisOIwrsfLkS9Jk/hocfa4/2PFsvwqTM+wM5de2Web82cB3+/y+XCiNfelOVRHX9YsVqmS68cSSAskjg++Gg7Wf9mQmLy99YdaNvlRRGj/YaOmoRvf1ileUz2J59/LetP9Zw0bY4pJtXZe+BoJAnJ+cX4S3jp5VFSIlOpxkM+kjiiTg9jijebUUI6Q/3Ron1XHDh4REYdOnwU7Z7phUbNO8srtYkinuk+EH/+9Tc5cf7CRYkpeUjK0/mF/mj5VDc82vIZfPH1MgpGMLyC1Y/KMWM35vXp+HDBZzIvsvoMHhMQu6TkZIk3Ydej76teqfWGjVvQtM3/JK7deg9D/KUELPr8Gxw8dBTtn3lJjpk3pr+HDwQDTPn37DdchpF73sIloDhyB8onvXCSnJM0lMYs4ULlEr3ZnDx1Bv/rOUiO98q318MfGzRcA41XwoXa1qXrADlmaWxSXsHGQbD6bt66TaanMX1z7YdBUu5gfTp1xof46rsVkn7V6t+xdv1GzF3wucSQ2kflkzlx6rS8X8kdrFyKI/Pjql/Rvc+r5JTmi6+XY+Cr46V71PhpqHVfU9xZ7wm8N2+RDDNbRvkUtmffAVkvGmsTprxDQdLs2nMAVDcaQ22ffhGEG0UEawvFrVn7p1whoGdE/6HjJCYUTvlk1IdtOvXAjp17iRw1720CGjPkoWfR+g2bvZhRGK1UUf50n1G9jedYsLakiGdYvyGvybFL9+fvf2ykbJBRmf9u3yXuhf5yXFWp2QBnz52X6TKyrFYrihUtgvJly3hJA41F/2clEe/ee1De+/TcNu59CjdMVscpYU/PSXqe0PvBeO5RfoGek8HyJ3o2jEBWELBkhZhpGQEzAvQypOUyw9ASn6IoeHPCq1i9bBFmTxuLl4dpLzx68I8YNw0fzHgda5YvxquDenmzsloVfPHxTIwbOQCvTZrhDTccH33yBVSPip++no8OTz6Ov//ZLqPoZTT7g4Uy7efzZ4CY25279+Ol7k+jcqXr8eXCWXixa6c0/kVime5ifAJ+XDoPiz6chrGC8TovGLxg5cjCTNY/23ZixJDeWLroXdjtNlNMYOfuvQcEM/4pqI4/fjVPMvXm5WT/VLTseNWV5WX+/6xfhhrVbvEhUZTAGPsQ6Z5SJUvi28/eQ/0H7sbYSW/L0JGC+Xjgnjux7Mu5uLtubYya8JYMT886duIkPnr3DXz3+fuYNnMuiKkNhpeiBK+fGbsOTzYXDOq3slhSvSDGq2H9e6XfbG3esg1dn30KK79ZgPMXL4Jeim63G30Hj8XrowfJcXFbtZsx7Z0P8GTLJrj2mivx8ftTMXPqGNxR+zb88dcWmd1BwegTI0qeP0VY3Vq3IVg+wcIpLZka1W+V46txwwfw0cIvKMjHjBaY3lDxWiz/ch7WrVyCG2+oIJmnQOOVEu4RY2T44F4yz3PnL4KY10DjIFi9KPw5wWC/1K0LaIxRP9lsVso6oHmpexc8/mgDWd5D99/lpSkSFyvqeh0MBv1rwRQ3aVw/KE7ehMJRT+Tzq5jgOnXpOtW/ySP1RQzQtlUz/LXma6wQ9/CSpctBzwMZEcAaPWE6mj/2MKgN0VFRXorSpYrj68Xv4efvFuKpNs0xduIMGResLS4xse0hJjnjRgzAiqUf4ejx41j42VKZhqyM+rBOrRr4c+PfOHb8JK6+6gps2LiVkmHj31tRq0ZV6TZb9BxbsuAdzJo6xvscC9aWBYu/xOkzZ2W9Rg3tjW59hkmMMyrznTnz8VyXtnJcrf3pM8TFxpqrENB9d4OWUvWMJkKD+3eXNJl9dhKxce8vXfwuxk2eIe99CjcM9bP/84rGY6D700hT/dYq+Fxgdc+dtY0gBHtOBsrfm4gdjEAWEGCGNwtgMakvAv4qDY8/1gCKomDbjl3oJiRufQaNES+LUyBp4bo/N+OJpg1BD0bK5YaKFegizYP33iXTEQOyc/c+GWa2Nv29De1bN5NB9HK+/rprpJteRs3ES5skFyVLFAeVT2EyMh3rdyHN2vj3P2jdqSdIAnb67Dn8JyTCm4KU459V9apVULGCVgf/uEB+kgadPn0WJMFr1bGHxGfzlu0I9ndrlUr4YcUvmDBlFoiBoLaZaRUlMMZmGsP91JMabrRcvUm0mcI3bNqKzu2fICee6dTKy9zIgCDWXXVuR0xMtIwtWiQOx0+cQjC8FCV4/czYXVfhapDkaf+Bw/h22Uo81ughMYGwyzLM1i1VbsRddWvKMfJU6+Yg7A4dPobDR49j8IiJIEnrl98sx99b02Jaq0Y1yaCcOXseZcuUkoYYmL82b0Xt26shWD7Bwo16PVzvXum8olxZ7Nq7X7rN1q+/b0Cvbl1kEPUfGRqbwcbrTZVv8I6pK8qLPMXELdA4CFYvCi8h7gG6P6hQGp8Wy+U93psKBnfp9ysoG3z9/UpQnSn/jPCmvnzovjvx48rfQNJ/wvjeu2rLfBISEjBk5ER0fK6veCacwI7/9srwQNamLf+inX6/d3iyhZeEmN8lS5eh0/P9hJR4Mbbv3O2NC+Q4cOgIrrqiHGpUvwWERef2rcQKxhYvaUZ9SJMlYnLp2dWiSUNQfjR2ygkpqc1m8+ZjOB66/245RukZZzzHgrXlz7+2omO7FpK+lhiHNDYJ44zKrCUY7emz5mLyW++Je/A0IiLS3i9GfYwrqTScO7QZP3+/UOpp0+QyvbFI6cyG6kT3fonixVBejHe6983xWRmnRrpHHn7AcHqvwZ6TgfL3JmIHI5AFBC7viZiFApi0cCGw6e9/5dJo3xf/B5J2XC0klQkJifB4PIKZSfuSIHTsEVo4vTBJKkNhZkNpKc4Ii4iIMJywmV48JG0lWm9kEAfRvPJyTyndIinw9g0/CklgDVnHYOWYs4o0lU/0JO004kmyYbiNK5XXQjD7VBaZ33/6HH17Btd3phc0Sbyr3XITXhdMLy0NG3nRNRjGFOdvbFYdW8H8qKpHRlN9DOmfuS0Upop+IiKXy00Xr6E4w6MoCpxOV1C80qufuTzK78mWj4GkXZ9+8Z2UzlKYvzHaQOE2u1VKwjzw4CZdik+Y/vDFh1g8720i8TFRUZEgKfd3y1eJPr5NmmUrVqNokSKguGD5BAs3MrdZrdJJjJRLYCE9fpZ/Wyk62Hg18iMaRRH4CulkoHEQrF4UbrelZX6o34L1KZUVyDzWqB5ILef4yVMgifjNN90g0M4c3k0frY+lQir8g5iwPdLgfsnQ0fJ9tz7D0Lr5o/jkg2loWP8+JCQmBipahtEQjNAZObqnZaCw3v1wkWDyTmL8yJcxZ/p4JKaThyCXP2q/dAjLbrfKMSuc8mfLoA9pAv7HX39LKW/d2jVQulRJLBNjhxhAmYGfZZQlx4ToP4oO1haKM8onN/Ud9WFGZT7dsbVY1RiM8uVKC8a/L2iySOkzMoqioOrNlVGmdEkYK2TBxqJ/XhH21HFFbaN730yTlXFqpIs0PUONMHouBXpOBsrfSMNXRiArCFiyQsy0jICGQHCblqVuv+1mVBJLuPsOHMK2/zQpzJ1CQkhSOEPv7pJggoPn4htTs8at+G3dXzKQHvAkjSVPnZq3iZfrT7hwMV7qstGLtm6tGnKZ76IIIxoytOxn9t97d21MnzUPRh02bNwidfuClUN5BDNXX1UOh44cl9GkM/n7+k3Sbbbuqns7PheS17a4nwAAEABJREFUKcKGwg8fOZbui4raQ1LrRxs9iLZiiX6TLpmltGQon0AYU5y/+fhTbQl3/qIvQZIkiq9Ts7pXH/G9eYsFE1iDglHhmith6Pn+8us6GZaeFQyvrNTvcbF0TVK7Y8dPgZY5A5X3r1gxIOkPvRA/XrwUJOW69uorRZ+fw/fLf5FJiIEiNQDyxIplXnN/31mnhujvuSCmpU7t2/DOe/NBYUQbLJ9g4ZQmM+aeO2th6jtzvaQ01uoEGa9eIj9HoHEQrF4UTkvkv/y6XuZCElZVVYP2aUxMDC5eSpC0/hapNdx6SyW8OmYKWjRtJKMp/7PnAuMtCXSLJLy//LYeX3y9HE0bN5ChZ8QKSvFiRXH7bbcKSauCn02b5SSBn1VT0K3+7Q8ZSnlJh7D2HjiIe++ugyuF1Hb5yjUiRPsFa0uFa67CseMnQeOCsJi7YAnuEGNBS5WxHSUmS0XFasbvf2wCMf3E6NLYIbWDjFNrFMHaUqdWNdA9SWN6kxASnDp9GoRxRmXSmCCVnafaPC7xJNUEKmnt+r/g0pls8gcyhAXpANPKXLCx6P+sDJSPfxjVyf95RW3JzHgx5xXsORkof3M6djMCmUWAGd7MIsV0aRDw1+GljQiNhFTn51//AC0zTxMvfJqdU8Ibr6+Afr2eQ5duL+Peh1vj6a79KThTpmPbFjh0+Cie7NwTw8a8gRsqXivTVal8PZ7p2Aq0UaRlh+544Zn2qHzjdYLhjUGTRx7CU//rLfV642J9/W1bNgW9vGjDE+m3DRMvdsowWDkUF8zECsbh/nvqgPTjuvZ+BRWuvSoN6Q0VK2D4oF7o0fdV1GvyFAgb2oiVhlAP+EIwx1dUugOtO3bH739ukjp7epS8BMNYRvpZR48dx4ON2+H7H3/B0P49ZCzVZcXPv8lNaz8LxnbYwJ4yvHWLJmKpdA5aCSxpg5AMTMcKhldW6kcMRU2xTGssYQcqrtqtN2Him7Pl5qnYmGi0bdVUqkLMmvYa6Agywr7Wvc1AerCUvvv/OmDAsHHeDWr0cj9x8gxIYn7LTTfi8JETqH17dSINmg9J7oPlLxNmYL0iMP13+040aNYR11S5G1v/3YFg4zVYVoHGQbB6Ufjbk0fK/qPNnTfVrC8YIDeC9SmpGiQmJslNUqQ77V+HJo/UA21WbNq4voyi/DODB9E1rHcf1olxS0w/JSYGle5/6ifayHdLlUoUHNS8OuhFqfNO43DV6nVeuqc7tMLQkRPl+Dx0+Jg3PFhbSII5ZfwwDB4+UfZDmdKlxASyqTddZhx1a1cHSVNJskkqMP/t2gc6ncEnbTqeYG0hHeRiRYvKer0y+g1MfX24HIuUVXpl0ikLlWo8JKS7/aS0tv6Dd1EStHv6Je8EXgaYrN6DRskNsLff2wTPP90WpEoUbCz6PytN2QR1ZmWcBs1ERAR7TgbKX5DzjxHIMgKWLKfgBIyAQCBKSD/MR5KRe+yr/cVScRxocxktM099/VW5KYN02kQS+bKhDTW//vgpPv1oBgXhTfFCavDgPdJNFm1soavZREdH4e03RmHR3Oly49SG1UvF8mIJSfJcl3ZyM9Oqbz8WzG8bGUbWsIG9sGDOm3LTmr9fURQM7tcdlIb0275f8oHUhUuvHMqDDLWF6MltmAmjBsmNQu/PmIB5syfjMcFsU9wvP3wimW9yk6Rs2ZdzZV2p/jffdCMF+5jVyxZJ+i7ixX5s13qJ0WzB1F0jpJlmQmISg2Fsplu/6kux/DsQpLtHKhIGM075LXx/mty0RldqE6WjycL6VV/gs/kzMKhvV4kPhbd54jEQnuQmQ31LeQXDK1j9qBx/7EjyduToCbRu8ShlncZQGtqkRHWicUPjgMYeEdJmPtr4QmNqx8YVaPl4YwoWUsmGsu9p0xoFNG74APb/u0ZIFy3SHNn5O5o0rkdR0gTLJ1g44WrU4T4hcXxr0giZj9kqX7YMaDzQZqlDO9ZKHWSKfy7AeKU2mnEZ2OcFqbMebBwEq1dtIbmnjZQ0Ng5u/02O6WB9SozNrKljQWogpPf7+GMNMHJoH6qiNDQppHv65ptukH6ygpVLcWZD9/3OTSulOoMRPl0w49RPc2dNlrjQmKI44x4xl3/9dddi7qxJchxSHem+INrqt1YBYU9jgTAiN4Wn1xbqH8KWNjxOGjtYYkJpKG1GfUh0o1/pB7pHyF1TTMwIE5KAk99c52DPsWBtiYyMwOTXhshn5befvecdH5RvemXS82DX5lXyOfPa8AGw6+oGB7b9CpKiU3qzobbTxkkaF8d3/yHu627e6EBjkSLpXjeendRP5KdwMsa9T27DZHWcmrGnPKh/qQ/JHeg5GSx/omfDCGQFAWZ4s4LW5dFyKkaAEQiAwPb/9kiJ9/331EWpksUDUHAQI8AIMAKMACOQMwgww5szOHIujAAjkEUESHpI0luSJmcxKZOHLQJccUaAEWAE8gcBZnjzB3culRFgBBgBRoARYAQYAUYgjxAIOYY3j9rNxTACjAAjwAgwAowAI8AIFBIEmOEtJB3NzWQEGIGwQ4ArzAgwAowAI5BDCDDDm0NAcjaMACPACDACjAAjwAgwArmBQPbzZIY3+xhyDowAI8AIMAKMACPACDACIYwAM7wh3DlcNUaAEcg8AkzJCDACjAAjwAgEQ4AZ3mDIcDgjwAgwAowAI8AIMALhhwDXOAACzPAGAIWDGAFGIPQQmL/oSzRv9wImv/Ve6FXOr0bDx07BV9+u8AvNX++g4RPww4rVl1WJbTt2Y+XqtVlKS+0f8dqbWUqTHWJq2649B7KTBadlBBiBAowAM7wFuHO5aYxAUATCMOLNt9/H5/NnoN+Lz4Zh7fO/yv/r3BZ1ala/rIrs2Lkbv6xZf1lp8yrRilW/Yc8+ZnjzCm8uhxEINwSY4Q23HuP6FnoEVFXFY62exf2NnsTDj3fCb+s2SEyOHD2OBx9th84v9EOzJ59DUlISSML2YON2ko4kYJLQZFGahx5rj6e7vYz7GrbBwFfH4+vvf5L5UxnHjp+U1MdPnsIz3QeiftMOaNG+K3bu3i/DSYpX7c7Gsi79hrwGh8Mpw3sPGo3+Q8dJ2kdbPoPt/+2W4f9u3yXq1x8Nm3dClZoNcPbceRlutt79cKH85DDV6/2PFsuol4eNw2HRvpYduuP75b/IMMNa+t0KPNm5p6z/E+27yeCkpGR0fekVWd9newzCA4+0xekz50CSyrZdXpQ0ZA0dNQnf/rAKmcXU6XTik8+/lvlS/SZNm0PZSDNFMOT3PNwKbTr1wL4Dh2WYv7Vm7Z9o/MTTsn2Ej4HXHQ81B0mFSYLd+YX+iL+UIJMGw11G6lZm+3DO3E/w58YtMlWw8qiP//zrb0lz/sJFUBvJM3XGh/hK4Ez1W7X6d2SmXpTOMIcOH0W7Z3qhUfPO8kp1prjdew/g8bbPy/E2bMxkOY4o3GwWL/kWnZ7vh1ai72lcBSqbxtWyn1Zj3KQZchXg1OmzcrwGaot/fpQn9QWN66yOVXM92R2+CHDNCwcCzPAWjn7mVhYgBBRFwZsTXsXqZYswe9pYvDxsvLd1/2zbiRFDemPponex5OvluBifgB+XzsOiD6dh7OvTQUyMl1h37BFMx0iRZsXX87F23UYQ8/DtZ+/hyZaPYfYHCyXVmAnT0eChe/CToBk+uBf6DRkjw2tUuxkbfvkKP3+/EJGRdixa8o0MJ8tqVbBkwTuYNXUMXhOMCIW9M2c+nuvSFsu/nIe1P32GuNhYCvaaHTv3yjK/+HimlOa+NXOeZK5fHz0Y5cqWxpcLZ6Fxwwe89OQYN/kdzJ01GWuWL8aMKaMoCB998gVUjyrr2+HJx/H3P9tleDBLUZRMYXrg0FG8/9Gnsm4/fjVPMvK01E+YffLZ1/jhi7mYNnEE1v+5OU1RLpcLPfoNx7gRA7Bi6Uc4evw4Fn621EtXo/qt3vZ9tPALGR4MdxlpsjLThyZy6QxUnowIYL3UvQsef7SBrN9D99+FzNbLyGrk+Gl44J47sezLubi7bm2MmvCWjBotri2aNASNt5joaBkWyDpw8AjmzZ6MN8cPC1j2rTdXQqP692Nw/+6yjmVKlwyUjTfMnB8FXs5YpXRsGAFGIHwQsIRPVbmmjEB+IRBa5SqKIiSVu9Ct9zD0GTQGx46f8jKy1atWQcUK18gK/75+Izb+/Q9ad+oppV2nz57Df7v2yjizVenGirj2misFwxqBm6vciLq1q8vo22+7Fbv27pfu39b9BZKMkYRvxGtTseWfHTLcbreBJJvtnu6FtaK8HTv3yHCyHrr/biiKgquuLC+Y1n0UhFo1qmL6rLlSD/f4idOIiLDLcMP6c+PfaCYYq2JFi6BkieJ4/LEGQir5txEd8Fr1lsoYOmoyZrw7HxaL9kjb9Pc2tG/dTNITg3b9dRomMiCApSiZw3T9hs04LaSHXboOQKuOPWQ/bN6yXeLcvMnDKBIXi/LlyqBRg/vh/3fg0BFcdUU51Kh+i6xn5/at8OdfW7xkD9e7V7qvKFc2Q9wlocnKTB+ayKUzUHkyIhNWsPEQLOmGTVvRuf0TMvqZTq3wxwatTzdv3YZ2ej891aa5jA9k3XdPHcTEaAxxVsvOKD+Kv5yxSunYMAKMQPggoL0dwqe+XFNGoNAjsOnvfzF3wefo++L/pAT1asFQJiQkSlwiIyLklSyPx4NXXu4pJV4kGd2+4UfcUbsGRfmYCHsq02m1WGG3aX5yu5wuSeuBR0iJ3/LmdWDbrzK8/yuv4aZKFfHu9PHo0+NZJCQmyXCybDYrXSRzR9JN8jzdsTVIWlu+XGmxTN0X+wMs/dtsNiKVhhhqaof0BLHefWscOrVvgUsCgzaCuSf1BEpjtWrlU7IIHRcKo3gKI+N2u+mCrGDaomlDLw6//yT6oeezoPIsltTyzG2QBeiWgQl57XarTEduMja9vhaLBRnhfsdDLUDG2MAXkYk+pDLMJlB5VD9VjBuic7k0bMjtb4KNB386w0/4UN7k9x2j8E56qK8pPpCJNE2MMls2lResLeb8qDyipavEXkjiyZ2ZsUp0hc5wgxmBMEXAEqb15mozAoUWAdJ7vP22m1HphgrYd+AQtun6sf6A3Ht3bSFNnScZQYrbsHGLV8eW/Fkx999dF69NelsmIebl9z82SjctpdNSctEicVixSmOCZUQQ68LFeClNfqrN4yAJMqkwmEnr1LwNS7/7CURH+r1Lv1uBurXSMunmNER7W9Wb0bfnMzh7/oJsb80at4JUDIhu9W9/wJA8X31VORw6cpyCJRa/r98k3ZnF9K66t+PzpctA9JTw8JFjIKa9ppBcr13/FwXBJRgmwy0DdKvCNVcJafxJkFSTmO65C5bgjjrpty0Y7utXfQEyOb2Br4KQ9NNyP1X5l1/X0UWamJgYXNT1iikgWL0oLpCpU7M65i1cIqPem7cYxsSrplhFoP6hiF9+W0+XDE2wsmNjohAff0iYI3YAABAASURBVMmbPlhbvAQZOGhc0cqHeazGCwxocpRBUo5mBBiBEESAGd4Q7JQwrxJXP5cRoOXyn3/9A6ReMO2duXKJPFCRbVs2FYzFbWja5n+4u0FLDBszJRBZpsKGDXwRp06fA21iuqVOQ3y7bJVM16vb0zKsw3N9EB0dKcPSswa8Mg6VajwkpLv9QHqW9R+8y4e8SuXr8UzHVnKzG21Qe+GZ9qh843U+NP6eu+q3FNLO5ujWZxh6d+8CYr47tm0Bt1uVG9lmvr8AxBBTuljBuN0vlsdps1/X3q+gwrVXUbBUQcgMpjdUrIDhg3qhR99XUa/JU7IPkpKTUfXmynjwvjtBG6s6vdAPsbExMl+zRVLfKeOHYfDwiWjQrKNofylQH5lp/N3BcPenyyl/6xZNMPmtObId5iO+7r2rNhKF9L5Npx6gTWtZrRdhtuLn3+SmtZ8FIz1sYE9ZZVqBIJ1owm3X7n0oVqyIDE/PGhZkLLZ5ogm++WGlHDunTp9FsLakl7c5LtBY3b1nP/oNfc1Mxm5GgBEIEwSY4Q2TjuJqMgIGAsTQ0eYxUlOY+vqrcgMU6cmS+X7JBwaZ1J8d3K87Vn37Mdau+BwUF2FaGiZC/zTvvDka991dh6JwS5Ub8cmHb0k3Mae0IYzyItWIMcP6yXCSfpGkcf67U6SqAm0qogi6NnjwHnJK89ear+V19rTXsGvzKrkB6bXhA2A3LcVLAmE916UdVn6zQNb7mY5tRIj2+3vtd5rDz97253Ih7fwSpNpg0EdHR2Hm1DFyI9vH701FRGSEN9WEUYNAG87enzFB1uOxRx6STHJmMKVMWjRtJDdfUR03rF6Km2+6kYLRp8cz+Gz+DFB5lBfpH8sIk0XYUj9Q2kljB8Poj/WrvkRUlDZhIJq3Jo2QqYLhLiN1K7N9OH7kQDyi6xYHK48mF9Sf1I5BfbvKPqBi4gQDP2vqWCye9zZIJzoz9aL20wZKSn/N1Vdi4fvTJG50pTpTePlyZTB31iSJ23UVrpE63hRuNm2eeAzDBvbyBgUrmzauUV5ffDxTTCZKyolSoLb455eVsUqrEtR33spk6GACRoARCBUEmOENlZ7gejACjAAjUMgQ+GvTVlxT5W48+Gg7ITleh54vdC5kCHBzGQFGIK8QYIY3r5AOUg4HMwKMQO4jQBLd0qVK5H5BXEKWEHjg3jtwaMda/PzdQpDEnfsoS/AxMSPACGQBAWZ4swAWkzICjAAjwAjkGgKcMSPACDACuYYAM7y5Bi1nzAgwAowAI8AIMAKMACMQCgiEF8MbCohxHRgBRoARYAQYAUaAEWAEwgoBZnjDqru4sowAI8AIaAiwzQgwAowAI5B5BJjhzTxWTMkIMAKMACPACDACjAAjEFoIZKo2zPBmCiYmYgQYAUaAEWAEGAFGgBEIVwSY4TX13Iz3PkHb/w1Ak7Y9MWriTKQ4HKZYdjICjEDYIsAVZwQYAUaAESjUCDDDa+r+26pVwSdzJmLeO2Nx9twFfPHNSlMsOxkBRoARYAQYAUaAEQhvBApr7ZnhNfX8PXVrSF/JEsVQQzC/J0+fkf7Pli7H7LmfSjdZLw2egP927SMnLBYLVFWF3R7BJh0MXC63wMrKGAXBSFEUeDwexicIPnR/OcSKC13Z+D5rnE4nj5t0xo3brUJRLIxREIyQib+zZ8+ADWMQamMgE0PXh4QZXh84NE9ScjK+WfYL6tasqgWwzQgUKgS4sYwAI8AI+CJQtmx5sGEMQmUM+I7OzPmY4fXDiaRsr4x9C/Xuq4s7a9/mF5vWm5iYiGTBICckXAKb4BikpCQjMTGBMQoyTpKSaBwlMT5B8KF7iyS8dGXje585HCk8btIZN/TsofuLx43vuDHwSPtW4xAfBNhTYBBghtevK+d89DmqVKqI7s+29YtJ9brdbq8nOjoakZGRiImJZZMOBhERkYiOjmGMgmAUFUXjKIrxMeGz7q9/8EDTZzB8wkyJi91ul1e+13yfNaTiwZj4YmLGg549dH+Zw9idihf4jxEoJAhYCkk7M9XMRV8sw+kz5/Fcp1Zp6HfuPgCXYHRpM9vufQfhVlVJoygKFIWNohRaDLj/c7Hv5U0mLEXh8aUojIGiMAaKkrMYiNuLf4xAoUCAGV69m4mZfXPmR1j6w8+4q1EHaUZPmq3HAonJKejYdQh6vPwaateoijdmzPPGsYMRYAQYAUaAEWAEGAFGIHQRYIZX7xub1Yrfl833McP6P6/HAjWqVsbCdydIM2ZoT8yZOtIbxw5GgBHIeQTq3XcHNqxcjEmj+ud85pwjI8AIMAKMQKFCgBneQtXd+d9YrgEjwAgwAowAI8AIMAJ5jQAzvJlAvFWzhni+c+tMUDIJI8AIMAKMACOQKQSYiBFgBPIQAWZ48xBsLooRYAQyj8DKNetRu14b9H91UuYTMSUjwAgwAowAIxAAAWZ4A4ASMkFcEUaAEWAEGAFGgBFgBBiBbCPADG+2IeQMGAFGgBFgBHIbAc6fEUgPgd//3IyHmj2N53oPR+un+2LC1PdAH5JKL02wuEnTP8D3K9bI6Hb/G4DTZ85Jd3asxm26Bkxev/mzqFP/SWnue6xTQBoqn+oRMDIfAn9avQ5jJ8/Kh5KzVyQzvNnDj1MzAoxALiHApzRkHdh/FzfDv4uaAB7tnPCs58ApGIHwReDWKjfi3TdH4oPpY7Bh0z/4Ze2GbDdmaL8XUKxokWznEywDq9WCP39aJM2ab8PjuNOa1W/BU63FcyZYo0I0vAAxvCGKMFeLEWAEGIG8QkBndFVXYl6VyOUwAiGHQFxsDG6+6QavZHbbf3uk5Lf98y+jz5AJOHPuvKzz23MWgiSvLTv3xuy5n8owf4skmRcuxuOHn36VeZAE+cln+8GQuAbL+/DRE3i+zwg83XMoxk151z/bLPsdTicGDJ+Mp54fKK8X4y/JPIK14YlOL2Hy2x+iW//RoP0Qkli3Oncfgt17D+o+yHb9s303SHLbqNXzUkL+ythpuJSQKGlI2v3iwNfQrd8oWfbGLduw4NNvZFx6aQjrHgPGSAwWfv6dpCeLsOzUbbAsp0uPoRQk+2TwqClo99wASU/1kRE5aDHDm4NgclaMACPACIQCAqrbGQrV4DoUYAROnjqD1b/9kedm+3+7M0Q1MSkZ+w4ewb131IRbVfHquOno060TPp79OhrWuxtT9A9HNW5wH75fPBMLRPjWbbukVDhY5o/Uv1dKj2dPGYHixYri8UfrpZv31FnzcXfdGkLaPBZXX1kOSaJOgfJWRf3ue7QjWnXpg6XfrwpEIsMOHj6Gxxs/JOo6ATHRUZivM5zpteGaq8rjnUnDQKtlMhPdavDAnVj+81rpO332PI4dP4WqN9+Im26siKUfT8fi9yfj2quvwILPvpU0ZB0+ehyTRg/AxJH9yOs16aU5duIUJozoKzFY8cvvOC8mDgcOHcXkt+fitWG98ekHb2DEoB4yr6kz56NGtZux8N2JGDGwB4a99pYMz0mLGd6cRJPzYgQYgRxDgKQSfEpDFuDUpbuUwuN20IUNI5BrCPzy6zo82rJLnpsJU2YGbdP6v7ZIXdgHmnSWDFz5cqUFM3cSJwRzPuWdeVKS+dnS5SCpLGWSnJIimK8P8dLgcSCGbpdJ6knxgQxJgkuVKI62TzRON+9/tu9C68cbySxaN39EXgNZxOCt+vpDdH36SUyf8zE2/7MjEBnKlSmFe++sKePaNG+Ef4VEljzptaHe/XcSSRrT+OH78eOq32X4DyvWgJhm8kRE2PHhx1+CpLlrfv8Lu/ccoGBpat9eFbEx0dJtttJLU6NaFZC0nehLlSyOg4eOYdOW7ah//x1yEkDh111zJV2w8e9tWL7qN9lHYybPwumz53Dq9FkZl13LSM8Mr4EEXxkBRoARCGsEPN7aqyzh9WLBjtxB4IF778R3n3+Y52Zgn8Cbv6iVd9Sqjj9WfIL3po3GT7+s0yW2Cq4sX0ZKZ0m/l+KWzJsKp9OFIaPfRIMH7sK08YMl00eSYconmCFm7dd1GzFiUHedJHDeMtLjQaRgIMlts1mhKAo505gypUuCvvTaQEhdG9W7F7SUv3nrDrTo2EuaFT9rjCnlYSS22WwgyXBGbYiw24wkPtfSgvkks2PnXvwo8m/40N0y/rU3ZuOKcmWE9PUlKRFPSk6R4WRF2O10SWPSS2O1Wr30FsUCl8sF2khoD1KvyWNe9vYT6TMTNt4McsDBDG8OgMhZMAKMQDgjUDDq7vGR8Ka+qApG67gVoYZAWSFxvP+eushrc/NNN6YLhaIoqH5rZXR6shneW/CFZHaJMSQ9VIg/cv/9z384f+EiIiIicFvVm0DM3No/NovY4D+iHysYQmLKiJ4oiZGm/Pzzpriqt1TGr+s3kRPr/vxbMnrSY7ISEpOkWgQF0XI/bbQj1QKSjH7x0TSQafDgXRSNI8dOgk6iIM+nXy5D1VsqZbkNlNYw9QWD/dHir0G6wJVuqCCDSW3i/ntqo2iROKxZt1GGZWRlNU3N227BT6vXC4n6CZk1YUCOO2pXx4z3PvHi9Oemfyg4Rw0zvDkKJ2fGCDACOYUA6Z1tWLkYk0b1z6ksC3Y+ZoZXZZWGgt3Z3LqMECCVgz37DmL/waMYP7wPvl2+Gh1eGIhH23TF1u27QNJDOtWBNkn1Hfo6SN81vTznLvxK6uEOHTNVLruPfP0dWCyWgHlTPi+90AFffbcSXfuOxLc/rkZkZAQF+5hDh4/h7kZPSTWMrn1Gon2rx1CjahUfGsNDOrUff/YdWnfpgwvxl9CxTdMst8HIi66kxrB81Vop2SY/mWeeaoHO3YZIlQaSxlJYRiaraSpccyVefK49Bo54A3R83NM9X5FFvPj8U3A4HGj/3MtyI+HnS3+U4TlpMcObk2hyXowAI8AI5BMCHrGEahTNKg0GEnwtLAjcVacGpr8+1NtcWvZf/vm7uP66q1H5hutk3PxZE/DjF3PQQT9Sa/jL3eQmqSmvDcToIS/i2Q5PyPT9ez7tZQQXzpmI0qVK4KWuHfHtone8S+6UloiD5U0b1aaMHYiZbwzHuGG9seyz2UTuY6pUvh7rf1wojyT75L1JaPrIgz7xhofK/3zum3hrwhB8+uEUuXGMpLAUT/UgPWD/NpDahkFDdP6mWNE4We7znVt7o5o0ehBfLXhLltOvRxeJGUUSczzgxafJKU39++8EHddGnsymoUkHSXcpDeW3YPYEuWlt8fuTKQjFixYBbVYjvGkjIdHLiBy0mOHNQTA5K0agECDATQxZBFJ1eHnTWsh2EleMEWAE8gkBZnjzCXgulhFgBNJHgE9pSB+fNLEetzdI5VMavFiwgxHIPQQ453BCgBnecOotrisjwAgwAkEQMKs0sIQ3CEgczAgwAoUWAWZ4C23Xc8PzAgEugxHIMwRYhzfPoOaCGAFGIPwQYIY3/PqMa8wIFAoE+JSGrHaz6k3g4VMavFiwI2TKm68+AAAQAElEQVQQ4IowAvmKADO8+Qo/F84IMAKMQM4gwCoNOYMj58IIMAIFE4GwYniTUxygA6PpQGLDFMxuKaSt4mYzAozA5SNgOoeXN61dPoyckhFgBAomAmHD8L4//wu06Ngbb7/3Cd4TbsMUzG7hVjECjACf0pC1MeAxMby8aS1r2IUiNdeJEWAEchaBsGF4f9+wBd8tehuzpwzHzMnDvCZn4eDcGAFGgBEIVwRSz+FV3c5wbQTXmxFgBBiBXEEgbBjeEsWLQFGUXAEhPDPlWjMCjAAjYELALOHlTWsmYNjJCDACjAAQNgxvVGQkXhk7HT//ugGG/i5duRMZAUagYCLApzRkrV89pmPJPO6UrCUOd2quf6FH4Pc/N6Pny2N9cOg1aBx+XbfRG3bh4iXc8XA7LP7yB2+Yy+1GnfpP4rnew9HufwPQb9hEnDx91htvdvyzfTd6DBiD7v1Hm4Pzzb1730GsXrsh38oPt4LDhuGlAXj67Dl88sX3rMMbbqOM68sIMAK5j4BJwquySkPu480lhB0Cy1b+ikrXX4sff/7dp+52uw3vvjkS82dPQEx0FOYv/ton3vB8+tUytGv5KGZMGmYE5et17/7DWPvH5nytQzgVHhYML83AGj54l1dv9zJ0eMOpT7iujAAjwAhkGQFfCa8jy+k5ASNQ0BH4cdXvGPDiMzh67CROnz2fprlWiwW1atyK02fSxi35ZgXWrt+Et+csxJszP4LT6cL4N+eg/fMvo1O3wfhp9TqZ3/cr1uDFga+hW79RGDB8MlRVxbTZC/Dks/3w1PMD8c2ynyUd3a/T3/1YSpWbtO0uaSiC8m/cpitadu6N2XM/pSBpaBMvSbDbPNNP5kWB783/HL/89qeUTi9ftZaC2KSDQFgwvDarFb+s/SudZnAUI8AIFDQE6AFfu14b9H91UkFrWi61R/Xm63SkeN1pHRzCCGQfgZQLB3Dq34/z3Fw89GvQyq//a4tUTyAVBTKk5mAQHz9xGqfOnMVtVW9C4wb34dvlvxhR3isxoZu2bEeDB+/0hhmOJ5o0kMxwn+6d0LtrR3z53U84cPgYPpo5HqMG98TYybNBKhNEf/jocUwaPQATR/bD0h9+xqnTZyXdrCnDsejLZdh/8IgIXyXVM9+fPhpfL3wbjzd+iJLKun2/eCYWzH4dW7ftwoZN/8jwqTPnY+Koflj8/mRMnzBUhj3boSUeuKeOlE43fOhuGcZWcATCguGl6l99ZTl8/Nl3OHvuAnnZMAKMACPACJgRMOnwut3J5hh2MwI5jkCyZHgXCoY3b038kd+DtuWOWtXx50+LvOauOjW8tD+s/BWN6t0r/Y8/Wg/LV6ZKRElaSwxy3QZtsWffQdx7Z01Jl561eesOtBRMsNViwXXXXoVqt1TCjl17ZZLat1dFbEy0dP+1+V/8t3u/1P3tM3QCzgjJ8rb/9ghG9l881boJoqOi5Ib8CtdcKemTU1Iw+e0P8dLgcSDGedfegzKcGPXXp76PDxZ8AdV0r8tItjKFQECGN1Mp85iIlhPeEuL/x9r2wF2NOnhNHleDi2MEGAFGICQR8Jh1eJ0pIVlHrlTBQSCqWAWUubVdnpsiV911WSCSOsP7C5aAGNsnOr2EnXv246CQ0FJmpMNLjPJXC95CdHQUPvj4SwrO0NjsNi+NzWaDwYdG2O3ecEVR8HynVlIKS3rC3y16B48+fL+Mt4s00qFbxHgPGf0mGjxwF6aNHyylvYlJyTKWpMhtWz4Kj/jv2ncU6ENcMoKtTCNgyTRlPhP+vmw+Apl8rhYXzwgwArmEQIic0pBLrcuFbM0Mr5t1eHMBYc7ShECkZHjbC4Y3b03RazQprakqGTqJsb1wMd4r+SXmtnPbx/H9T77qEVeWL4t+3Tvjk8+/Q1KyxmgGy7xGtSr46tuVcKuqVFH4Z/su3HLT9WnISeo8b9FSxF9KkHF0ssL5CxelesTHn3/rLSchMQkUHhERIdUuiGk2b0ij9DfdeB2eeeoJ2KwWHD95Wm6wuxB/SebLVsYIhA3Dm3FTmIIRYAQYgcKMgMfbeA8zvF4s2MEI0EayBg/6SobJ//2Pq9OAU6Xy9SCVhM+/XpEmzhzQ/NH6KFe2FDp2HYRXx03HwJeeRdEicWYS6X6s4f24586aeL73CLTq0gdDx0yFqnrQ7JEHUe2WyujSYyho0xptYCtTuiRurXIj2j03AH2Hvo5rriov8yCLNqs1bdcDg0ZOQaN69+C6a64UTPMtUN2qPI4tbzatUU3C14QNw2tWYzC7wxd6rjkjwAgwAjmHgI9KAx9LlnPAck5hgcBddWpg+utDfepKagGkj/tClzZyo5k5skqlivhy/ltCWmrF2h8WmKPkZrMOrZv4hJFn/PA+qFuzGjlBahCDev8PH89+HfPeGQdakaII2hA34MWnyek1L3RujYVzJuKzD6dg0XuTUbJEMVgsFvR6/inp/+aTGZJhpgTDX+6Ghe9OxJTXBmL0kBfxbIcnKBi0kY02t1Ed/teplQwj/d8JI/rKdvOmNQlJulbYMLxmdYYfl8xGn24dhWi/ebqN40hGgBHIWwRysjQ+pSGLaBoKhJSMv7RGKLBhBBgBRsCLQNgwvN4aC0dcbAzaNG+EHbv2CR//GAFGgBFgBMwSXo/qYkAYAUYgfxHg0kMMgbBkeAlDOtfuyLGT5GTDCDACjAAjANWLgQKn180ORoARYAQYASBsGF6z3i652zw7AF3aPc59yAiELwJc83QRIJ24DSsXY9Ko/unScaSOgEmlQfGwhFdHhS+MACPACEgEwobhNevwknvVV+/hkfpZP55EtpotRoARYAQKGAIeE8NLTWO1BkKBTbggwPVkBHIbgbBheCe/PS8NFqMnzU4TxgGMACPACBRKBEzn8FL7PW7++AThwIYRYAQYAUIgbBjeXXsPUH19zLYdu3z87CnICHDbChsCfEpD1nrc48fwqnw0WdYAZGpGgBEo0AiEPMO79Ief0bXfaOzee1BeyU2mc/ehuP66awp053DjGAFGgBHIPAKpH56gNB4+moxgKJiGW8UIMAJZRiDkGd6a1W/Gsx1aoHzZ0vJKbjLjXn0JY1/pleUGcwJGgBFgBAokAn4SXv7aWoHsZW4UI8AIXCYCIc/wXn1lOdS5vSrmzxqH6rdWBp3BS3765vVltrkwJOM2MgJhjwCf0pC1LvT4bVpT3Y6sZcDUjAAjwAgUYARCnuE1sF/7x2Y0f+olDB//tgyij070HjJButliBBgBRqDQI+An4VWdCYUeEg0AtnMCgZMnj4MNYxAqY+ByxnTYMLzT5yzEu1NHoGSJ4rKdVSpVxKnT56SbLUaAEWAEGIHUD08QFm5nMl3YMALZRqBkyVJgwxiE2hjI6sAOG4bXbrOB1BvMDfTAd5OGOS4rbqZlBBiB0EOAT2nIWp+kUWlwJWUtA6ZmBBgBRqAAIxA+DK/dhrPnLni7YuOW7V5przeQHYwAI8AIFFYE/FUaXJcl4S2s6HG7GQFGoIAjEDYMb/+eXTBq4kzteLK+ozH+zTno9Xz7At493DxGgBFgBDKLgO+Kl8oS3swCx3SMACNQCBDIOsObD6C43G44nS68MWYARgzsjtbNH8bCORNR+YYK+VAbLpIRYATyAgE+pSFrKKuq2yeByhJeHzzYwwgwAoUbgbBgeG1WK96d9zksFgvuvfN21L//TlgtYVH1wj26uPWMQAFHIJSa50nD8LIObyj1D9eFEWAE8heBsOEaIyPt+G/XvvxFi0tnBBgBRiBEEVBV31MaWMIboh3F1WIECiYCId+qsGF4jxw7iS49h6Hd/waga7/RXhPyCHMFGQFG4LIQ4FMasgZbWpUGlvBmDUGmZgQYgYKMQNgwvH26dcS08YPQt0dnn08MZ6Zzzp2/iP7DJuGhx5/F69M+CJpk0MgpuKtRB6/5d8eeoLQcwQgwAllEgMlzFQGPLuGNT9J0eVU+hzdX8ebMGQFGILwQCBuGt87tVRHIZBbuRxvej+c6tsyQfMbEofh92Xxpbq1yQ4b0TMAIMAKMQCggYKg0JCRpqg18SkMo9ArXgREIjACH5j0CYcPwZgeaEsWLot59dREdHXlZ2Xy2dDlmz/3Um/alwRNYn9iLBjsYgdxBoN59d2DDysWYNKp/7hRQwHJV3S7ZokvJ2vFkrMMr4WCLEWAEGAGJQKFgeGVLM2n1GzYZjVt3w6Tpc+VRaBklo68bsfGAMchpDDg/HlNZGwOqR1NlSEhOlfB6PFnLg+kLH14ZveM4nhEoKAgww2vqSdIPXvnVHEwY0Qc7du3DR4u/McUGdqakpAjG2IHk5CQ26WDgcjmRkpLMGAXByOFIgcPB4yi9+8gtJJjpxRfWOJfLJe+rlBSHfEglJGuMr9vJzyQaE06nQ9xbKRIj8rPxHRdy0IS6xfVjBHIAgbBheP/c9A/8zZ59h2DoreUAFihbuqTMpvqtldGxTRNs3xl405rbrb1QiDgqKgoREZGIjo5hkw4GdnsEoqKiGaMgGEVGRiEykseR+T76fcNW3PdYFwwbN0OOG5vNLq9mGnbHwG7XcLFZFXok4ZKuw+txJzNe4n6LEM/nSHF/8VgJ/I6Sg4YtRqAQIGAJlza+PecT9Bo0HiMnzJSG3INGvYnmHXtj05btl90MSktfcaMMLiUk0gUkMVmzbiNurpy6aW3n7gOgL76dPXcBu/cdhFvfES0TsJXfCHD5jEChR4DUEQiEZJf2WFf5S2sEBxtGgBFgBCQC2pNROkPbKl2qOCaP7o+vF74lDbkrXH0FJo7sizfe+SjdyhOjSseN0ZFkX3z7kzx2zPiIxcsjpuDCxXiZvmXnvjKOrsWKxqFT26YynKzE5BR07DoEPV5+DbVrVMUbM+ZRMBtGgBFgBEICAY9H192FTdaHGV4JQyG0uMmMACMQCIGwYXhPnDqLu+vWgKIo0pD76IlTuOnG6wK1yyfMZrXKY8aM48boelOlipLmxyWzUbpUCele9tlMSffVgml48bn2oHQyQlg1qlbGwncnSDNmaE/MmTpShPKPEWAEcgsBPqUhi8jqnxa22yORmKIzv66kLGbC5IwAI8AIFEwEwobhFWwu/ti41dsL6//aAqtgZCmA4ujKJnMI5DdV0tldOLfnezjiD+d3Vbh8RqDAIGCoWUVE2JHoPakhpcC0jxvCCDACjEB2EAgbhndI3/9h4lsf4vGnekkz+e25GNz7WSQmJaPV4w9nB4MM07Zq1hDPd26dIR0TZA6BE1vm4uiGt5F45r/MJWAqRoARyBAB40trtEkryaFLeJ3avoQMExdeAm45I8AIFBIEwobhrVKpIha/PwlTxg6UZtF7k3DLTTcgJjoKzR55sJB0V8FopqFb6Eq+UDAaxK3IFQRWrlmP2vXaoP+rk3Il/4KXqXZ6TGRkBFiloeD1LreIEWAEsodA2DC8Ho8H/+3ej41b/pVm554D8mMH2Wt+JlIzSY4jFrO+kQAAEABJREFU4HFry6zuFGZ4cxxczrDQIuDWj0uMiIhCUgp/ba3QDgRuOCPACAREIGwY3gnTPkD3/mOxacsOabr1GyO/hhawVRwY0gh4JbwpF0O6nlw5RiCsENBPaYiMzL1Na2GFB1eWEWAEGAETAmHD8G7Y9A8WfzAJY1/pJc3i9ydi3YYtpqawM1wQMBhelvCGS4/lTz35lIas4W58hIcYXpbwZg07pmYEGIGCj0AOM7y5BxjtPC5dsri3ADpKzG63ev3sCB8EDIbXxSoN4dNpXNOQR8DYtBYZFYVEY9MaH0sW8v3GFWQEGIG8QSBsGN5SJYpjxnufeD8v/NbsBShXpnTeoMSl5CgCBsPrZpWGHMWVMwsxBPK4Oh5om9aio6JZhzePsefiGAFGIPQRCBuGd+Sg7jh99jyGj58hzfkLlzD85a6hjzDX0AcBj+oUfm1DjYslvAIL/gVDgE9pCIZM4HBDwmu12pCYojG/Kkt4A4PFoYwAI5CnCIRCYWHD8JYsUQyvDuiK7xbNkGbYgBdAYaEAItch8wgY0l1KocozQjXml/xsGAFG4PIR8Kj6vURfo7RGyYzczmR5ZYsRYAQYgcKOQMgzvNPnLER6prB3YLi138zwUt1dSWfpwqbQI8AAZBcBj0eT6losFqiKXWbHEl4JA1uMACPACCDkGd642BikZ7gPwwsB1aWdwWvU2sV6vAYUfPVDgE9p8AMkA69H1RheRbFCUTQJLzO8GYDG0YxAKCLAdcoVBEKe4e3S7nGkZ3IFFc401xDwuH2XWN2sx5trWHPGhQ0BTaVBURQotkjZeNXle7/JQLYYAUaAESiECIQ8w1sI+6RAN9n/BexiCe/l9DenYQTSIKCqqgxTLFZYbdHSzRJeCQNbjAAjwAjAwhgwAnmJgOqn0uBmCW9ewh9WZfEpDVnrLo/+pTVFUWCNjAX9qbxpjWBgU6AR4MYxAplDgBnezOHEVDmEgOqn0uBiCW8OIcvZFHYEPLqEF4oF9sgY0B9LeAkFNowAI8AIILwkvCkOB7bv3Mv9FsYIqH46he48kPCGMVxcdUYgCwhoKg0WixWRUXGgP//7jcLYMAKMACNQGBEIGwnv2j82o/lTL2H4+LdlP+3YtQ+9h0yQbrbCBwFVV2m4kOCSlXaxhFfiwFZaBPiUhrSYpBfiVWmQDG8RScoSXgkDW6kIsIsRKLQIhA3DS2fxvjt1BEqWKC47q0qlijh1+px0sxU+CBinNBw9qzG8bpbwhk/ncU1DGgGPRz+lQSzcRcdqz0nVb0UlpBvAlWMEGAFGIBcRCBuG126z4eory/lA4YH2gPcJZE/2EMjl1Kou4T1+1ilLcrGEV+LAFiOQbQT0c3gtViti4orJ7FjCK2FgixFgBBgBIQoIExDsdhvOnrvgre3GLdu90l5vIDtCHgFVlzgdPaNJeF3JqX0a8pXnCuYpAnxKQ9bg9hinNFgUFClSBMkOTafXuOeylhtTEwJsGAFGoOAgEDYS3v49u2DUxJnYvfcguvYdjfFvzkGv59sXnJ4oJC0xXr4XkiJki90p5+WVLUaAEcguAtqKl0WxCIY3DokpzPBmF1FOzwgwAgUHgbBheEln940xAzBiYHe0bv4wFs6ZiMo3VMjnnuDis4pAclK8TBJbrCTik9zS7XZoYdLDFiPACFweArqEFxYrisbFIilFY4BZreHy4ORUjAAjULAQCBuGd/Lb82CxWHDvnbej/v13wmqxYPSk2QWrNwpBa5wpibKVJYqXwvlLOsPLG9ckJmz5IsCnNPjikZFPNTatKZb8kfBmVEGOZwQYAUYgHxEIG4Z3194DaWDatmNXmjAOCG0EXI4kWcGSpUp7GV4XM7wSE7YYgewgoOgSXquQ8BZhCW92oOS0jAAjUAARyEuG97LgW/rDz+jab7Smuyuu5CbTuftQXH/dNZeVJyfKPwTcLo3hLV32CsHwajqGbj6pIf86hEsuQAho95NCDG+ROCQ6tBUUQ2++ADWUm8IIMAKMQJYRCHmGt2b1m/FshxYoX7a0vJKbzLhXX8LYV3plucGcIH8RcDs1hrdcuStxVldp4JMa8rdPQrX0gn1KQ86jbqg0kOoXS3hzHl/OkRFgBMIbgZBneK++shzq3F4V82eNk1dyk7myfNnwRr6w1l5NkS0vUqwkkhxW6XaxhFfiwBYjkC0EdB1ei8UGYnodLu3xzhLebKHKiRkBRiC3Ecij/LUnYh4Vlp1iSI0hkMlOnpw2HxBwO2ShMbFF4UKUdLtZh1fiwBYjkB0EFBgqDdpj3e3RJpSqvqqSnbw5LSPACDAC4Y6A9mQMg1aQGoNh2j3RGCWKF8FNN/KxZGHQdT5V9Ohfg4qJLQLVGiPjXCzhlTiw5YuA6ZQG3wj2BUQgVaVBY3TdHrukU93J8soWI8AIMAKFGYGwYXhJjcEwD9xTG+OG9caBQ8fAf+GFgPE1qJiYWNgii8rKu1nCK3FgixHIDgKKfkqDxaoxvB6LzvA6taMAs5M3p2UEGIFQQYDrcbkIhA3D699Aj8eDc+cv+gezP8QRMJZd42JjERFTQtbWxQyvxIEtRiA7CHigfWhCUbTHumKNktmxDq+EgS1GgBEo5AhoT8YwAMFff/fJZ/uj+q03hUHNuYq+CGgvZYvVhpi4UjLKzSoNEoecsgpKPnxKQ1Z7Ur+3LNpjXbFGygz4S2sSBrYYAUagkCOgPRnDAARDf9e4jhzUA/16dAqDmnMVfRHQN9YIKVRcsXIyypV8Tl7ZYgQYgctHIFWlQVNlsNo1HXm3k3V4Lx9VThnmCHD1GQEvAmHD8Br6u8b15srXexvBjvBBQNGrqlisKFXmCjhdYiFWdYGXXXVg+MIIBEEg/uh6/LuoCfavGhKEQpPwWq3aY90WGSPp+N6SMLDFCDAChRwB7ckYBiAcOnIc77y/CC8OHCe/vGaoOIRB1bmKJgQsivZShpDwlipVHGfjXTI23zauydLZCkUE+JQG317xqNrqiNtxyTfC8HlS7y0KskfG0kVMJrWPvUgPW4wAI8AIFFIEwobhHTN5NooVK4oObR7z+eJaIe23sG22ojO8tLGmTOlSOGd8bY31eMO2T7nieYSAR/tUsNsZmOGljbxUE4tFO6UhIjKOvHA5mOGVQLCVIQJMwAgUZATChuEtWiQW7Vs2xh21qvt8ca0gd05BbJvFq9NgRZlSJXE+QZda8UkNBbG7uU05iIBH1VdDgkl4Fe1esurHkkXF6Mf+ORNysBacFSPACDAC4YlA2DC8EXY79h88Gp4oF5haZ7Mh+jmhqqotvZYvVwbn4zWplYsZ3myCW/CS8ykNvn3q0SW8qjxXV7uHzBSKfiyZIeGNNhheF29aM+PEbkaAESicCIQNw7v3wBG0e+5ldOw2hHV4w3SsegyGV39XK4qCRKe2/OpmlYYw7VWudl4hYOjwUnluRwCprX5fWSw2IkFsnHbONVys0iAByWmL82MEGIGwQiBsGN6+3Tti2vhB6PV8e9bhDashZqqsLqEy9tZQjNOjnRXqYgkvwcGGEQiOgEdTaSACdyC1Bn1CadHP4Y0pojO8qoOSsGEEGAFGoFAjEDYMr3Ecmf81hHuPq+aHQKqE11DkFQRWbWMNn9IgsOCfDwJ8SoMPHPComvoPhaoBNq6JBROKgs0eIa9FixWVx/4BHnjcKTKMLUaAEWAECisCIc/w0vFje/Yf8lFjoDDDFNaOC8t266Jdt770KttgLyIvLlZpkDiwFXoInNgyD/tWDkLiqX/ztXKJSamqCYEkvMaEkk5AoYoWiYvFpSRtI5vqym+Gl2rEhhFgBBiB/EMg5Ble+rJauTKlfNQYKMww+Qcdl5xVBIxNNx5PqoQ3Kqa4zMbNDK/EIT0r8fS/uHR8Y3okHJcLCCSf3yuY3X/gTDqTC7lnPkvV7fQSuwOcvGBsWoOiPdaLFIlDksNgeFOZZW8m7GAEGAFGoBAhoD0ZQ6DBwapAKgxxsTE+R5FRmGGCpePwEETA0OE1VS0qrpT0uZIvyCtbwRFIuXgYB355FQdWDwe5g1MWjJiQOaVB14315LNagNuVqovrTokP0MnG0ok2oSwSG4ukFGZ4AwDFQYwAI1AIEQh5htfoE/mltQ/4S2sGHuF49Xi0F7Kqai9kakNc8bJ0gYs3rUkc0rNU/XipS8f+wpE/3kyPlONyEAGPzvCqJglrDmYfKKuAYao7VYfXHUCH10hkqDTExESbJLx8NJmBD18ZAUagcCIQNgxv31cmwma1ol3Lxj7qDYWz28K01YaEV+N7ZSOKl7xSXtUAS7Qygi0vAgbDKwN0Jky62cpdBIxxq6aqFORugYFzd7tNEt4ApzSkqjSkTigdLqvMzO1klQYJBFuMACMQZgjkXHXDhuG1WS14rlMr3F23ho96Q85BwTnlNgLGLnMPUl/IZUqXxNl47bglV/K53K5CWOevmpgWj/7VrbBuUAaVD5VTGjz66QiefFZpUN3afUKwBdq0pigeioKipN5fLo/2iPeZLEkqthgBRoARKFwIaE/DMGhz5RsrYuu2XWFQU65iMAS8S8OmTWulBcN7/pK2VOtmtYZg0Mlw1fQBAWMDoIwo5FZuN987bvNdpSF9hhe6yhD0TWuEi8ujfYRCdSWSlw0jwAgwAoUWgbBheBvVuxvd+4/BXY06+JhC23Ph2HB9GV6TQ2kNKFOqJM5d0jbWuPikBg2UILbqNulhGsxNEFoOzkEEjHGbTwzvxUO/4uQ/C6AmHvY2KpCEl87b1QhSJbxu2GWQyseSSRzYYgQKOALcvHQQCBuG9/VpH6D7s22x4ot38fuy+V6TTts4KsQQSJVKpr6Qy5UtjQsJLOHNTFepzmQvmacQqDSEyikNJ06elLgnJl6U17y2LhxcjVP/LgSSUhneQDrvin5bKSYJL5QIWV2W8EoY2GIEGIFCjEDYMLxFi8TJDWuxMdG51l1ffrcS7f43QEqQz53Pn5dbrjUuFDLWJWUqUoedoihIcGgba/hosvQ7Sc0JlYb0i+DYAAgYm8Hczvz5eIN3oqimblpzBTiWzKgnxD1lNEOxRkqnebIkA9hiBBgBRqCQIZDKeYR4w+vWqooPF36F8xcDnT+ZM5WnD1yMGtITpUuVyJkMORcfBDzGMrzHJxhOT5QMcDt4kiGBCGKlJCWkxuiTh9QAduUWAh5oKjeq6Rzc3CorUL4efdOc4kk9JcKVzqkmiqJNICkvi027t3zUYSiCDSPACIAhKFwIhA3Du+DTbzHrw0/RuHU3KYE1dHlzsrvuqnMbKl1fIU2Wny1djtlzP/WGvzR4Av7btc/rZ0fmEPDoy/CqScJLKT0WTWrPEl5CI7hxJKdOCDw6ExScOvxjQuWUBkWfXDhNp2TkKbr6sWjmMj0B6uKV8ELXbRAJLDbt3jKf8CGC+ccIMAKMQKFDIGwYXrPertmd3z3mcrngdrtBVzauoDgQRm79WCWPBz50ir2I7EZn8nJiNgUAABAASURBVAWf8PzHM3h7cr5u7gzHkdt0LJbD6Sh0WKmqmi9tViAGrBihavI5XDy2GQln9uRpPczHkYlqaD9P6th0uzVcjHq6dD+NUatdY3hdjsQ8rTOVHSrGzc/ndPteG1BsMwIFH4GwYXjNXbHw8+/N3nx1q0LSRsYtmDk2LsG0BTYeISVTvbvcLT50tqhisg/pHF53IcVRFdJvVYyl9NoP0ykNLkeyD4bppSsoccTw5kdboKs0WJIP4NDqV3Byywd5ir1HjA15g/hZzuTzsh6k40u4QD+HVxX05Cdjj4yWqRzJ8ZKWwgqbUcV9RaawtTuz7ZUDJDMW0zACYY5AWDK8S75Zka+wu4XEwKhAREQk7PYIREZGIZINIoNgYLPZYbNpuoUeRUGkiS62aBkJp+pMQKQpvDC5IzIxjsw6nBBSx4KOz29//I17GnfC0LHTESnGhc1mQ6S45rUxJKdykArLIyYeeVkHUWTAn92q3Uc2cW9RfQxFhsioWETqOEVFa/sR3M4kROphhe1Kz2e6vwpbuzPb3oCDiwMZgQKIgKUAtilXmrRz9wG4BKN79twF7N53EG6xvJorBYVvphnXXEh5iUjx0+GN0xleZxJ/aQ3p/FmRumnJ+KpWOuQclUMIKGJyYc5KdV4ye3Pf7Un94IS5MLcz0exF6pgwWF8gKjZW0rhMR9rJALYYAUaAEShkCIQlw/tEkwa50k3vvL9Ibog7feYcHn2yO/q/OslbTmJyCjp2HYIeL7+G2jWq4o0Z87xx7MgkAjrDSxJec4qiJcpLr+q4IK9spUXAY9LfpVirvnxNbja5i0AqI6mV43b4MppaaO7ZHrEkHyh38zF1FC8WTugiGN9UhjcmRtOPd3vViSQJW7mOABfACDACoYZAWDK87Vo2zhUcuz3zpPeDFrQxbtKo/t5yalStjIXvTpBmzNCemDN1pDeOHZlDgPR4NUrfYVe6TFkkpmgfn/Bn7DR6tlVXsgThXLyGk6UQMLyhc0qDtmlNdoCw/BlNEZSrP9LRDVSAMSaMOGNIGGfvUnhsbBxdoDLDK3FgixFgBAovAr6cR5jh0LT9i2FW49TqFkqXfrySx0+loXSpknDqq7b8Yg48MgwmK9Hhy3wFpubQnETAX8Ir+0JfrcjJcoLmpd83RvylJG3SI+thBIqrUU+Pqt9MIiwmVpPwetRUdRgRzD9GgBFgBAodAiHP8P656R8EM05n3jzEWzVriOc7ty50gyOnG+zR9Z4VJXXJlcqgzws73RojZ35ZUxwbDQHVlSIdDpcCtyqdgB8jpIfyJYcRCCRNd/vpz+ZwkT7ZnT/vq+pzKUkbAP5n61r020oxfVo4LraozCvE7ytZR7YYAUaAEchNBEKe4e01aDzem/9FQJOQqC3z5iZAnHfOIWCoNHjSSHhLwK0zvAiyQSfnahGeORnSPIfLAlU1JgeapC88W5RxrVeuWY/a9dr46NJnnCrnKQzJqTln1Wn66p05Ilfcqk+uSU7tsa3qai5GpHceaWZ4i2gqDTBJfQ16vjICjAAjUJgQ0J6cIdziMqVL4pV+z2Hm5GFpTPFi2nJdCFefq2ZGQJdImiVQFK0oClSdCfbwi5kgSWMM5sbtsXglvMF0O9Mk5oBsIaD4ndJAmeWlhFfR7xsql0yKSzveT3WZN895KAoe+qqLdGlWiZKlNAcK9uRIbyRfGAFGgBEIikDIM7yN69+DM+d8l/SM1txa5QbDydcwQMDl0lRQPDpza66yEcYMrxmVVLfqSpIep2qDLuBllQaJSO5bhqqAuaS8lPAqimouGiluu/QbkyDp0RldFbpegwwEFIsN9KeIKSVd2TACjAAjUFgRCHmGl05OuO3WmwL2z/hXewcM58DQRMDYkKaYllyNmiqK9mL2BDmCyaArrFeDuVFBDK/G1Bg60QUVk5A5pUGD2wdmd16qNGjCW2/5qhIh3W6nNgkij0ffROfxzoYoFILh1ZjjQHrI4D9GgBFgBMIbgSzVPuQZ3iy1holDGgG392WsLcmaK+vRmeCLh3/D4XWTcPHQr+boQu82GF6PYveqNICldvk2Lvw3jOVmRfwlvB5LtCzOGBPkMSS5qseXOzeOKLP5SYkpDRtGgBFgBAoTAszwFqbezue2qi6HVoMAo071aIEXDv2GCwd+RsKpfzRatiUChkoDrJHw6EyNh/WdJTbpWtmM9Lj1MeuXj9uRd19bs/jpECv2GFkb75gQPo/+YRI/YbCI4R8jwAgwAowAIaBxGeRiwwjkMgIut0uWoChpJbzQGV7VOH4r/qikZUtDQNV35CuWKMH+aFI8Yxlboyh4diic0hAMY3ceHktms/huOLPatc8Fm6XM3noG4Hhd+gkoniDMe8EbOdwiRoARCIRAYQ9jhrewj4A8bL+qM7zQ1RfMRRsqDQZj57jEDK8ZH7dTO4LPao+Czr/Aw/rOZohyx+13QoJRSF5uWjPKNK4Wm3bUmDMlwQgCPBqnq19Sw4XLpfPLfKqHAIN/jAAjUGgRCHmGt2u/0UjPFNqeC8OGGwyaEojh1U9uMJZpHZeOh2ELc6/KBi4WsZztZWqCMGOXXwtO6Y+AV3LqF5Gnm9b8yrZHaccxuhypDK9RT7eu7mJO4lI1n4e/tqYBwTYjwAgUSgRCnuF9tkMLkLn2qivgcrnw4D118OjD9yEqMhKlS5YolJ0Wro1WDYlkAJUGDzQ1B4+ui0htdMQfoQsbgUByYrywAXtENDz65MCYQMiIAmiFxCkN+ukH/vCqeajS4F92ZGwxGeT2OYdXlWGBLOPLfB7W+Q4ED4cxAoER4NACh4Al1FtU5/aqIPPf7n2YNWU42j7xCJo98iDefO1lJKdoy7yh3gaun4aA6tbO4Q0k4Q2k5pDCDK8GnLANaZ49Mg6qWjh0eEWz8/0XTA0gOSnw2eA5XWGPaQJo5B0RpU30VV3NRYbrYn9NsUGGeC23qj3mmeH1QsIORoARKIQIaE/CMGh4ckpKmlo6HNomqDQRHBCSCKQr4Q0g9XWE9sa1PMXY6dC+qhUZHSckvBrDC1ZpyP0+CCLhdSRpEvfcroChqmAuJ6aIxvCamWGPwfAGUGnwSngNHXpzZuxmBBgBRqCQIBA2DG/dmtXRrd9ofLZ0Ob5f8Sv6vzoJFStcVUi6qWA006OqsiGKRVNfkB6vlTbMkVCw9XjpaKuEk1uRfH6fF4VgDmMJPSKqiGB4tdvWE4QZC5ZHuIWH4ikN5y9pO8DySofXY6gBmTovtlg56bN4zCtcmmxX53tlvGF5Jbw8QTIg4WuOI8AZMgKhj4D25gz9eqJv945o/lg9bNqyA7+u24gGD9yJ3l07gP/CBwG3LmGyWNIOO8WaluF1JZ0Ln8ZdRk0TT2/D/lWDQR/ayCi56taYm+gYYng1CW8gZiijfDg+awgYkzQj1emLGsNrTECM8Fy7BmBSi8TFIsWhTR49hsqDTqexvb610SgBDx9L5gsM+xgBRqBQIZCW8wjR5iuKgvr334EObZpg7Cu98Ej9e6Eo2os/RKvM1TIhQE6PvmkmoIQ3gEqD23GRkhVYYzArmdqcpzM20bRhyVi21pmcAgtQKDTMD+NTFzQ1KkXVJiC5XUXjnjHKIfWEOMHwJqZorK2qn8/s8Yp20z4TPdAe88H0kY28+coIMAKMQEFGQHsShkEL1/6xGc2fegnDx78ta7tj1z70HjJBusPVSj63Gyf/WYD4I+vDtQlZqreqL8ErAZhbxWJPk5crpWAzvKr+kQ1ialxJZ7ztT7lwQI4Ln88rq9oXv2KLlIBHn+h5dDy9CQuYIxROafB4GUkN3GR3pHRYoW3AlJ5ctDx+fexSPSgaF4eEFFWWquoMr5Dfan5PWobXrWqrJzTOJBFb+Y0Al88IMAL5gEDYMLzT5yzEu1NHoGSJ4hKmKpUq4tTp8F7yTjy9Haf+XYjzB1bJNhV0y6OrNCgBdHiVAGfzugs8w5vs7XJnwjGvO0lMhPzHhcVjMLzF4IF22zID44Us9xweTaJrFECbBuOTDLWG1HNwjficvvr3MfHf0dFRSNJVGowvvvmrXvjUw5gg6aek+MSxhxFgBBiBQoKA9uYMg8babTZcfaW2WcOorke8+g13OF5VXacujT5gODYmE3U2XsqWAAyvJZCENzm8JzQZQaLqagpElxKfukHPozMmHn18QEj5LIoKVUj3ihQtARiTA7/ldvBfjiPgL2GFEoFEfZ5iMJs5Xqg5Q78+dutH0qU4tUe38UESQNVTpZXwemCTcft/Hop/FzUBf8VQwsEWI8AIFDIEtKdmGDTabrfh7LnUsy83btnulfaGQfUDVtFgaPLkxRmwBnkb6NFf3kqgTWsW7aXsX6PUF7p/TPj7ExNSVTacphMpjC9ieSdEOmNMy9ixMTGi4dptm4YZEzEF6RcKpzTQZIMwPXXehXe/P4ujl0ogSddmyIvPC/v3sZjzUHXgdGtjwKvSoKn0woiXRLrlgUare0WTfKXWRnhmru6UC5Jp3v5568yQ5wgNZ8IIMAKMQE4g4PskzIkccymP/j27YNTEmdi99yC69h2N8W/OQa/n2+dSaXmTraozMqrzUt4UmM+lePQjlhQlLXOrWH3DzlzUXsoFWa3BmZy6JO68lKrSYDC6Hl3Ca6wApGhaDfDoEl4Dz3zu1gJdvEffaHn8nFMwvOdwzlVWMJuaTmxeHE1mlG+ArKqaBNelf0zCGBvGZNKgM189+ngxwjz6CoLhz8rVmIAa16ykZVpGgBFgBPITgbBheEln940xAzBiYHe0bv4wFs6ZiMo3VACQn/Blr2yPztC4nUnZyyhMUquqKmuqBFRpiJBxhnVaZ3hdBViP1+lMNJoLZ8JRr9sYFwbja0jxUrQ5ABTot60uMQf/5RoChoTVkJzGxcbA6dE2WLr1j4HkWuEiY48+SRRO+TPq4YZWB2NsCLGtjPcYY0P6DEtj0A2fR2fiDX9Wrqq+0ZLSGMw2udkwAowAIxDqCOhvztCupsvtRtd+o2ERS+H33nk76t9/J6yWsKh6usB6GRoT45NugnCP1DcAWW2+0lxqltXm+1I+G69SMC5Hwktn2+5bOUimD2XL5dCVQUUlU+JTJbwGQ2LEq/pO/BSXNuYVfcJgMGMieYH8hcIpDQYj6XJrEMcKhldVtJMaVGeqhF6LzQ3b45Opqp/CoCraBDFV0qrRecR0yCcBeSy+95tHvw8pKqtG1VelKF1q2eRjwwgwAoxAaCOgvUFDu46wWa2wCSYpKTmVQQjxKmeqeh5dwltYXhyqR2NiFcWXuSWwFNOmNYfTA+8XrYKcxetMPEXJ0hhiDunrZYmn/kGo4+p2pEr2PYKRcCWfl+25cEG7Jug6vtQminCpCl1gMD0GMyYD2coVBDy6hNUD7VFJEl7FGiXLcufBRNXjJ401+l6FwfAmy7oYkx+PzhDLQMPyu9882VBp8OjPLMraXUhWpqitbBgBRiD8EPCvsfYU9w+yzdGUAAAQAElEQVQNQb9NML2tu/THhKnvY/bcT70mBKua6SqpppeHmgcvz0xXLLcIdeZBsfhKnKg4q017gZObXuqXUjTmzpUST0FeQ0e5bfvsCez+vhsSTmz2hhsOs9TNk40Xu5Ffbl7dgsk1529sXHM7NSbGoqssGAyv060tY0NnYFxOXanXnAm7cxgBTXJq0VeUSMKrWGnjIMSEKlUlJYcLTc1OHwNGgOrRHtkWqy5ldmmTJo8+lty6bq9BL6+K7/1mbIqUcVm0VLNKgysP2p/F+jE5I8AIMALBENCensFiQyj8lpsqolnjB1CieJEQqlX2qpJi2rTkLhQb11QJmNWWVsJrsUbIOLJcgkxVdCmanw4vfaDBIyYKqljmP7R2ApH7GLdp4uDRP9bgQxBCHo/+ueALCW5ZK6d+Fq9bZyosiqa0a0iqVUXDzaKrNOg8mExbEK3cP6UhY9Q8+iTNmGTExcbCFhknEyYnXJDX3LS85RuFKNpE0GKPliF0H5BD1ceMS2eIKcwwisWX4VX187CN+KxcVX3MUppCMUmnhrJhBBiBAoFA2DC8z3dujUAmnHshOSlVB9DtSHWHc5vSq7txDq/VpL5g0FttqS9ll1uBxxoro1wpvkyFwfxRpNsRj6Qz28npNeaXsBriEl6PXr/thzSJrvPSCdkOg+G1WQTnL0KMNqv6MjYU7bZNTtake4KEf7mEgEeXsBpqOHGxMYiMKSpLS07UVE+kJ5csf4ZX1dVarDrD69bVCrwMr5p6HxlVUvzvN482kTLis3I1yqE0xrgkNxtGgBEIcwQKQfW1N2eYNPTfHXswd+FSrzoDqTaESdUDVlPVl64p0syokb8gGo+uj6gompTK3EYflQYosEZoUjS3n4RXFZJdmP4uHvnD5APcpo1EHiEJ9okMNY+aImt0Ml6TZqdKeFNVFQgzb5stmhRc0Rle1aUfCCtzYStXENAZXotVe1TGxEQjMlpneBPygOH1Y0490O4dW4QxIdSONFR1yatbZ4jNWFis2sqAEaZm477wjkWRmdu0miK8/GMEGAFGIKQR0J7iIV1FrXLvL/gSr097H19+txJnzl4Q11U4dESTiGkU4Wd7dL07qrmZUSN/QTTGxhqLNa0UymbTdBKp3W6PgoioEuSE22/TmvHCjS51s4yPP+rL8Pro8KohzhDq9XPby8q2OPSzeD0mhoTGiFeSpqt9KLpKgytvGV5Zx7y0QuGUBo+u0lCmdBkknNiOB++7EzFxJSUMzhSN2ZSeXLKMVRFv9vpkMSJSY3idKQkyStVVGtzwZW4pUvFTafDoKwsUl1VD49FIo+rSZcPPV0aAEWAEQhkBSyhXzly3H35ag/emjUS5MqUwuM//sGTem0hO0SRkZrpwcnt0hofqrBYCaYnH46GmwmrTN19Jn2aZw1SPBdFFSskI/01rqi7hLXLF7bDYY5By4QDMJza4TS9hNZ0X+8mt8+UXo078/YEsJz8sBS5ZbFzpG+TVeemIvJrrTW6jzVZbjIyHok0YPLrEXAtkO3cQ0MYsdKk6lRFXXBubeaKGpEuYqVwyHmiP7AhdrcKlnwXs0SfPbo82NojWMBZ9omT4DTUNw5+Vq2qajHknYlnJgGkZgQKBADciHBHQnp5hUPOYmBjYbDY4nE64VRVRkRGwKNryXhhUP3AVTZuq3IWA4QXcEgerJa0UyhYRJePIolMaipYoR04YR3VJj7AM5u/X9f8ARXQp75F1Ikb7qabNfx7Ty1mLTbWNl7XLT2UilSL3XRZ9ufra66viUpIb1DaSaHtM48IjGBm3zsRb7JGyUhYdP1WXPspAtnIFAY8X49RnTbGipWVZHneivOam5fGb1Hh0CW5MTDFZrFt/btDYkQH++roi0Oo3wUzvvhDk6f6M+4aIjLLJzYYRYAQYgVBHIGwY3tjoKDidLlSscDXGTJqNt2YvQIpDk5CFOshB66czPBSvmnRPyV8QjaKfw2sRExf/9tFkxhsmJLzFSpSXXneKr56kI1lbRv506Qp8smyXpDGrNbh15pAizIwj+c3GYBDcDt9jz8w02XFnJm2EVVO5uP76G3DolDaWHfFHIThfb3JVMO3JSRel367rNSu6TmZ2dtvLDEPcCoVTGlJStA2Fij7JIMiKl9RUUCweB3lz1aSVxmqMd1SspkdsjGNVV2mw2FInjkbFLH4qRP5MtEGXmatRDtGamV/ys2EEGAFGIJQRCBuGt1+PLlK626dbB1xzZTlECgnv0L7/C2VsM6yboi9pE6G7EDC8qs7wWi1pl13tNk16SViosKJM2XJITFHJC1WXYpHHYHgt1kjM/FQ7h/fSib/hEZJQijdPHNJjCI2XtdvvnF/KI0+MjgWVVbHi9YLh1ZgnB+nxejRGmOJIGudM1iSJtghNpUFRNPxcLi0N0bHJHQTchlqMkvqojC2qqTRYkJI7hZpy9YjVLJMXHmj1iCtSXAZ79M1qKbour9V0H0kCYVnFvSIu3p/T9METb2AmHR79PiNy831JfjaMQBAEOJgRCAkEtKdnSFQl/Upcf91ViI2JBh0L9EyHFvKIsjKltc0j6acM3ViLvsRPNSwMLw/FYPJ0CSW12zDWiAjDCY9gLkqVLBHwa2tO/fi2WrXq4FKyB5c8Qtom8o0/tkGmd+gSYPJkTsKrSU+JPi+NqusiJzs8KFa0CM5c0m7FFJLwmiX/QsJrbEyKiNJOrrBYNNrsSOrysq3hXJbbuzFQw5zaYrVrEw+7oqnoUFhuGbffpIbuDSorJk7b1KnoUmanfqa3VT+ujGgMY7HaDae8OrKx9yE5UVthoYzMqynkZ8MIMAKMQCgjkPoUD+Vairrd1agDAhkRFbY/i+Lx1r0wvDy8m9b8JbwCBZtpKVb1CAlvmZJehtdlksK69U06t9WogXJlSmPttiSRGog/+qe8OpJSVRTSYwgNhjM/VBpO/bsQ+38ZLuubomkyIEUpJv2ahDeVkfKoThjS6KiYIpJG0fFzu1XpL6hWKJzSoOoYKyaVBogJWZIQrisKvH2TW33g8jLcWgkeaPrvRYpqDK9FXyVy6veFsQqgUWu2Vdf91nyA2ySlNcIye3UGWG3JbFqmYwQYAUYgPxEIG4b392XzYZgfl8xGn24d8cxTzfMTu2yVbTAxRiaqabOVEVbwrqpsktVvEw0FRkSmqjRAsUpm9kKiRu82fXzCrUtGo2OKokWzRvjw638pOeLlebweOEzMsarrNUoCP+tS/DkZ4r8pTgbmspV0bq/3gxn0kQ0qzh6n6SyTDq/FJPmnJWSjzVHRmt6mRdfJVAUzTGnZ5B4CBsY+DK8oLsUluF1xdTtSJZ7Cm+M/t5DwmzO1CGab/EXFqgBtdCQ3rQ659DO9I6O048oo3DA2v/vNnY1PUrtN6hCuPDiWzWhDYbpyWxkBRiB3EAgbhtfcfFJraNO8EXbs2mcODiu3x+9FZpZMhlVDslBZQ6XBqjNs5qRmCS/0l3qSU5NmmaWwHpcm0Y0W0s4WTRth91EnHIiV5/UmnflPXFMZEHc6DK8rRdOLpTr4Tz4oLDcNMbFG/g63xjgVLXWdDCIJr2JieFUxTjy6nmaUYPKJSFE0XDzZ+EQs5cMmYwTcOsaKPiaNFA631gfEbBphuXF1+0l4ofd9bEw0ElM8skiPGB8unRENKOE1rZ5QAlc69wXFp2dUfcJJNIVh3wG1kw0jwAgUDATCkuEl6E+dPosjx06SMywNLVWbK+7SdVPNYYHd4RtqqDT4S5yoRVHRml4kuaFom7IcqqbX6zJJbQ3c4oqWxL131UHZMqXw936ZComnt8FgiCnEqUu9yO1vPLruI4W7c1lKR2WYTfzF1JMnXKrGOF1xdSXBwLgFwx6PSKuu5yASyYmRfkxZEWMZWz/lwuPRJOCCrED+QuGUBo9bw9ijM5oG0G6PNjbdpiV+Iy4nr6rfsWQGw2uxWJDk0BheYkJVnYmllQ//8m2mI/8ozu3PRFNgJo3b2MQn6I0yhZN/jAAjwAiEPAJhw/D66++2eXYAurR7POQBDlZB1W8ziiuDUxqO/fUOdnzZARcOrg6WZciHK9CYB4tVYxbMFfZZMtYZXo9VY4LdJpUG4yio2KLaLvXHH2uIzdu1Dza4nUnwuDUJMOXtTE51k99sFJ2JpDB3Hp/FGx9/gYqVhvSVyVGxwlU4fDqV0aUwMqqQ8Cr6qQ0xcVqbLTo+qi59JDo2uYOAW1cbsSjaxMQoRVW0MZzrEl6n35gw6RKnOLXVAY+Q8Hp0vVx7lHbPGPWkq9VPpUEVY4rC/c2ZnV9h38pB6T5jPCYJL1Tt/rp46Fcc3/w+zPcp8uqPy2EEGAFGIJMIhA3Da+jvGtdVX72HR+rfm8lmhh6Zqr+gjp91ysp5BLMmHUGs5PP7xQvlvPyyWBCSMAjWJFJWa9php5gOzFf0TVkWm7ZJy6zSYFMcsp3Fims6r6TWcClJYwpU8TJWTJLb9CS8Fn2zD2Vmzp/8uW0U0ykMbo+GxfXXXYtjZ7SxYC7fI5gTu97mIsVKyyiL1SqvHu9HEaS3UFqO+CNIOLkVruSzudJ+Y1KhCImqTwH6V+9cubw6oJokqlS+YmK8nao2dkglh8YJxRsfpCC3Yex2k368CFT9JtsiSP6Sz+9D4ql/kHRWO99aBvpbpvvLItzHNs7CobXjcea/JTjy5zR/avYzAowAIxAyCGhPzJCpTo5XJGQzNF5QFxI1KY3Fo0lLglVY1Rnk5AsHg5GEfLihm2q1adIxc4V9GAqd4bVHaycXuJJTJaJGmpiYaOm8/566sOpnj6pCSm41MbIuZ/BzUq2mI6VceSzhVZDK2KrQjowqX64MEgJUN0U/dSLFocJos1WXkKue1NMcJBgFzErvlIZ/FzUBmZP/LMD+VYNx8dBa5MZfKsOrqdkYZVjtmiT14rlTRlCuXN1+UnyLRZvsUGEut1YnOdGDNhGMidMmiRRvGHuEH8Prx0QbdJQPuV1JwScPip+KxdldX1MSaXJb2i0LYYsRYAQYgctEIGwYXn+VBn//ZbY/35KpQnJHhauwSd1N6RYSSroGMh6dPuXigUDRYRWm+G0AosorivbyJrdFZ3ijYkuRV+q1kkPVT7K4lKySVxpFUVC1WjXpTrrkq9PtDqLDSxIxmUC38lqH12LSvfXobaWqWOxpd9g7ErXTJJKdmnSc6BRDwuvHDFFcYTCupNPeZhp9p+oTQm9EDjk8el9Z/MasPVLrq4RLwZnDnKiCcUqEw5jbmCS8bvHsoDJU0t/VGdGYWG2SSOGGsUVok0NAC/HotJov1TYYVleyNuZSY1JdxmTtQoJLBlps0Shb9SnpJpUi6WCLEWAEGIEQRMASgnUKWKUnWzRC+1aP4uPZE6Rp37Kx9BsqDgEThXCgR39BW2xRSEz2yJqqQkIpHQGspETtfFk6tipAdFgEGTq8ML20jYpbdIkZ+RX9oPwixcuQF8kJ2gtYvthFiKG7KJzyC11IuQAAEABJREFUV61qdXlNuODL8Kr6JEFGmqy0DO9FU2zuOxWTdBmWSG+BkbpE2xsgHM7k88IGUpzyIi2roZNZwCW8srEBLGeSNh4oylBH8QTpa6LJjlF15lAxTUwovwi9r1IS064+UHxOGbdb43Rdbv1RbZLwqoq2OkB66xZFGyAlSmr3jLn8CD8JL3S9ZDMNuY37wpUcnIk3VkZemHoUey+Wx/UPv4FiFR6g5CLbRHllixFgBBiBUERAf4pqVQtle9OWHXjxufagzT1kXnz+Kfz+59+hXOV066bqL2irPRLxSZrEMj0JSUpKqspD8vm96eYdupEaYx9Iwmuus1VneIuVuEIGu/VNa6ouAU/RhEsyjqy4ovoX95y+zIcriK6ikQ+lJeM2nQJB/tw2NkXrbypHMekuxxTRJNoUbhiX3naHK/VWterHuhnSR4O2oF2DndLgSjYzvAmy2ao+gZSeHLJIN9iTclbmppgYTQqIjtU+/JCclLuTJePoud/3l0bdXntw0noHFS+NR58sqWIlw65oN4ViTZ1ASSJhRUZGCzv1ZzDxqSGaKylBa4uxqqCFptoeHeNLSW4kuIvhx11XI7LoNTDUO1QXM7ypaLGLEWAEQg2B1LdoqNXMrz7JKSk4f0F7IFPUufMX4XJpD3nyh5sxXh4WayQSNfU7ISHRXt6B2mLWTU25EJ5qDQo0hhd+y8P+7bXoOqqlyl2rRbm0flf1M3hd+lFeWiQQGR0nnVbVFz+PPqmQkSZL9dsgaEgJTSS56rRbNaldt7eO4HBKJW9ZRYqllc65HVrbHfoGJSK26vigkEp4zQyvS58QOE0TQsIou8aZcELqBtviN8usrFarvBqWcWKGKzn13GcjLievxjF8drum9243pPuiEIs1StjwPjdSTGovMkK3YmK1+0P3AqZNk94w4UhJjhc2RScg0L2j6hNOh0tBXFwsLl7U2j5ywkyZzqGnl54wtRJObsGub5+Tp1WEaRO42owAIxAEgbBheDs92QxPPvsyho+fgVfHvY12z72MLu3D+EtrOjOm2CLg1Jcr3emoNCgmqWDyhUNBujPUgzWGV/Hf8a5X2+HS4i26hLd06ZIgaRJFq4LZVUlXUXj8Gd6omLQbdQQZgu1GV3VJFdGQcST5SoYpLC/MX7uS4bHr0mlRYFSsduyYcHp/HofGhJjbbLVp+s6qmiop9iYoBA4zw2uoAV24oElic6r55jIoT8WiYU5uMkX0EzOM8iksN4xb19O26Qyv1Zr6yLbYNYbX7dDGbzCGV/Gru7gxAldVTd016UrRVGnMhMZ94xTztWLFiuCCEEC8M2c+Jr89V5JZTB9MkQFhaDkTToI+/kKnVdAzJwybwFVmBHIBgYKRZerTM8Tb81jD+/HB9FGodsuNqH5rJXz49hg82uC+EK918Op5dIbXYomAS9Vepmo6h9jbLanMDT2Qg+ccujEWRWNog6k0qFo0LPqSfelSJXEhQWs3qTWo+pKpW9+sY7Q0Nk5bXjb85xM80mlIx6THZKm6pOpCgnhzi/CUxJxllkSWQX+qYNwpMiFZa1d0lMa0UFh0kVTml/zSuDWptdvUZovBwASR1Ml0BcAKdkqDy6TDazTTpX9pzPBn9+r0K0Pxm6TFFdXUTzzu3F3G96jaGDUYXrtde1ZQ+yzG0Wi6njdJXinc3yhKahqKU4KsDJhXkVxJae8J476hCXqxokWwfOUa9B86lrIU96lWT7c+QZOBYWgZ9ydVnaS9dGXDCDACBQOBsGF4Ce4ry5dFq2YNUfv2alj7x2Y4nNpGDYoLN5OQoEllLLZIGIfYu9NheM3tcyacMHu9bmfiKdAxTef2/OANCyWHAo3Jg+K7PGzU0a1qR7RZdclV0SJxuJDokdGulHghmEqRbuiH/mseIK6Ir2Q0Uf8kcXCGV9OHPnVBe0lT3kZeuX01JjpJDg2LGP14NSq3aDGNiSK3YRSdqfVA26BE4XZd2gf9BAEKy2+Tl+W7dAbPXKaqS//NYdlx+0t4LYYaiZ6pLSJWusznPsuAHLYMhjciUpsY2U0qDRGRmqqCwZwTIxqoeGtkUcxdEY+PV+q6z+ZNk6YEVlO4f/uJzBi7LtWC4sWKUhDoWMCEE9uRpD+KzQyjJAgzKyVJU9OgaiecCN89IlR/NowAI+CLQNgwvF16DsOlhEQcPnoCfYZMwNr1mzF28ru+rQkjn1P/Chgxd6qivcyCLY/6S34dl44HbGnS2Z049e9CwfTODxgfKoGKEozh1WpoNb3Uk3TmlSRHqi6Z9QipuEap2XHGpjXNC4caqbmC7kZPlvEXkyPk1ePSpKjSk8uWwYQ7dX3LmBit76nYovomPXL7G3ObLTa93szwemFS9RUTb0A2Hf4Mn9XiO2Yt+hFyNkXn9LJZXrDkqi6NNc7StZkkvLYojel2i8kgpSdGlK6BzMerU/DlH24Zpeh5So9uqfrKg+6FwUQbfrqquiqQ22NFzxc64+kOrfHJh9MpCilORV5VP/14GRhGVsIlfVIg6nxu30qc2rZIuNL+ks7ukh88MZ5JaSk4pBAjwE0PUQTChuGFx4O42Bis2/A3mj7yICaN7o+de/ZnGtbFXy5Dh66D0anbUKz+fWPAdINGToH5fN9/d+wJSJfVwAsHfpaH5B9cM9qb1KEvwdqENFOxaruog0l4jRfNyfMuJKaocDsuCmlnkjcvw+FM1M4nJQlYKD6ILfqmNf/lYaP+biE5IrfNlsoEOtUICoI75YK3zYq+WUdGCIuOdhMX78+txGhuXTqqeVJtVZcGuiwaw2BR02KZSp2zLm/ZHgvatW6GW6pU9hZQssxVXnd8st+taUnFxKbr8KKAM7zBTmlISdDGuRcs4fDozJhw5sjPn+FV/DatWXUJr92SuxtnjVMaypcthyH9e+DG6yt42xcVrUlZPU5ttYgYUW+knyPCbkdklPacsRgrLSYa1W91yb/9RKrqzKxLMLx31rkd0yePQrGiRSgKDpc2IQj2DJNEYWA5k7XJ75mLKlTnJZzc+pG4Jqap+eF1k+SmRkf84TRxHMAIMAKhiYDfWzU0K0m1UlUPklMc+Ovvbbi1yg0UBIuSueofOHQM8z75GrPeeBWvj+gjJMOzZV4yEz9rxsShMM72NcrxI8my161vRjNLUVwO7SFqj4iGop9Bq/q9dIyCPLr0yuFScfi0JlEKJOV1JqZ+9SkU9XwVXYc3mEqD6tGkRFZjyV4AoOqMnktIsRwp2svIYmKIBYn8GSoC5LFEaIwAgjK8GoMbFV0EZ+NdlERMIrTNYdKTi5ZKfSnyt9ujMWf6BFS64Trh0360TJyiqzo4db1uLQaw2HSptQiw2gz1Bk1iJ4IK1c+dkiqFMxpuSM4Nf3av/jqsFl2v3MjXGqExejERHiMol67a+CxTtgyGDuiJihWu8ZYTbXxkQt9spkJjOr0EJoc9QjC8kdpEUDFtgDVIVH31xPCnXEzLyBlS32R36uTLoCcmmNzBnmEUFw7G6dBUGmZ8fVo8l7XniEfVj9ExNcB4Jhv3symKnYwAIxCiCGSOYwyByj9wT2089fwgHD56ErVuuxknTp1BVFQqE5BeFX9dtxGUPjYmGuXLlUaVShXx58Z/kNm/z5Yux+y5n3rJXxo8Af/t2uf1Z+Rwp2hHS5lfKk7BwFE6e1QR2CM0XTyDMaZwszEeqh7YcTQ9hjchTBheKObmed1uneG1Cam3N9CmMRZuIeFNStReRj7xOqGxpEpeW5Sm06vATd40xuiHqJiiuJio6dK682izjfdFGUSt41KyR9bXjQh5NSwzk28wvEoBl/AabTdfZd8FYECEGM5Mlm13SsIZnzysfioNFOnUdc5lnSggF4zHrY1hq5+EmYqiCRtdDaMqvpvTjHC6RggJr1VMsshtt2h5ktswqq7ScER/vlw8tEasqmjPLYPGpX/hzqFGGUHeq9tjl25V31gqPWFoOVM0QQRNoFOcqmyBqq8ISY9uqfoEQQ0Qp5PwJZMIMBkjkFcIhA3D+2yHFvh87hv46J3XYBNLupFCYjG033OZwunUmbO4snzqGadXX1kOJ0/7vtCMjPoNm4zGrbth0vS5cDo16YoRd7lXty41UPWHpMwn+YS8RMReiYhoTZKQlJD2KCAi8ujLtRZbBI6cMSS8xyjKxyScP+r1Oy6lur2B+ewwBpvFlvaFSVXz6Iyw3Z7K7EVEadgQQ2qc82nTN+tQGsM43alMdGS0dmqDJQjDm6QfsG+PiEGSQ6uV0UdGfrlxpQ2FZ/d8J7P2iGVh6fCzkpxaO5zQ1C2MaJu+hE7+mOgYusDj8chrQbUCndLgSk4r3aX25/TmMUei7ykFFqvG0FFZhnG6NQZT1VdwjPCcvHr0SY3NmnpPGPn76657kJbGoI2IsCM2Vhs3CPCn6gzvUfF8Wb0lQVKc2/ejvBqWM0l7ZroU37FJ8aquV+8OskpFNOFgjGd0UoqKiwkpssqqW3vmSo9uqfoz2aOv2OjBfGEEGIEQRkB724dwBYNVjZZ/r69wdbDoNOGKJbWpiqIxFf5EfXt0xsqv5mDCiD7YISS4Hy3+Bhn9OZ1O+QEMh8OBYObiOY25PX/ulJfG5tJeHpbocrBFai8QR1K8N96cV0qyJnVQPTYkqZrEMyX+WBpap67DS3VOvng0Tbw5z7x2u1wu2KwagxasbFWX8CqKzVt3e7TGvCZdOoPkRE3iZLVFe+O9eZkYXq+EVzAL3nhT/yQlajqPimC8k/RNcSlCoheINqfCLp3dLzcUnt/3E3WPYMVT20hl0DiiCVaSU2Oi3JY4GEeXUQKaJBAdGadLpSDEWi9i708DkXD+SFo8TO2lNAXBuIW0Myk+dRVDgmBYqitHMYDTl7GmuYU/hm5dqknj0j8up/we0S5qokexpGlfhP7coHgybiUiDY1RD7sQEkSLFbEUV+B7MEU/ncDhtuDrP7T77Pz+Vb756brTTiXGN1yMNY8om+rgTA78DDPqkR9XevbQ/ZWZst26nnLDhg/j9Nl4ahIcKQlp26szuoHiMlNOKNHIRrLFCBQCBFK5wALc2DKlSuL8eY3JoWaePXceZUunPQKqbGntHNTqt1ZGxzZNsH1n4E1r9OKlfMh4xPuDDLmDGUey9gKxwiVJXMlnYYFT6o+WKnsVYuK0JXhXkGV1jyFNEMvg1qjSMg9nQtqTGiyq9oAmgkDxFB7SxqMNR5s90lvNGP1s2pSEs2LVWmP8I/Td6V4i4XCrqfqLMUU1jCyms4sFifyRaoQr8aR02yNi4PJoZbl0FRMZkQuWM0Er05u16Euv2+vwwC0mNeS1CImZIc0nv3EEFbkVi9ZWm2hf0ul/4dIlbxRXkI1H3GvulMCrIOYjtbKLgduh3a/mfCwWbSJiDvPo+uXxF06bg3PWrZ+oYBEMq3/GRYpr49wIdyvaxNnwm6+rly3G4nlvQ8wZZLAh0ZUeYRl+YqLX70gSIUDKBd9NwfTckm5RwD8AABAASURBVBF2bRIq3YalY2HkYwSH21XxpMgqt2r+OCDuQfIYz19ykzH781zCSxVgwwgwApeFgMZhXFbS8El07501sWbdRqQIScTZcxew7b+9uKN2NdmATVu2e1UXLiVoDBVJBIj+5so3SBqydu4+AJd4W1D63fsOwq1qUjZaKrTbbYiIiAhqXDozZVVckgYp2gvy8CkVV191BYoVL0tFAK5kGe+fl03jbwAh+Ywqrkm1nYJpM9MpfhKp5AuHA+ZlTpOXbpvphR2s3E//qYy6vfag6BXVvXUvUVo7uYAwVHV9OZog+Ofhhg3GX7FSV0qnXTCE/nSH1wyDcmmnjI+OLQZVf1EramDs/dNfrh8OTaIvCybLGultI+Vpt9tBxq1EUSys9iicvuiRbrKi44qZ6CMpyGusSDHFBR+HVE44mV/Xb8Ldj3TAkDHTZPtsdCO4Uid1XgCEQ1HckiYn2mdRteeAyNb7i4yOSpO/xxYn4xMvnkoTlxP1oDxAXL4oJUpM8shvNuXLlUWyvslRkMBjL5ZhPVwqUQJ2m8WH1iIm4BQTW7QUIoTk+EyCnbxQEw7CKNNYQSpZ9hpvmBFnN9SM3Ll7HxnlZeVKzx67uL8yk8ZQjSlV5kpERcdJDKwW+LTXWKmiSIui+sRlpoxQo6F2sGEECgMC4lYu+M2scM0VaPFYfTzbazh6D3kdfbp3Am3ioJa/PGIKLlzUXqItO/eVx5LRtVjROHRq25RIpElMTkHHrkPQ4+XXULtGVbwxY54Mz5Tl0jZbWS0aA5Oi74C+4NAYlzj9M6UQTFeg/AxGT1XsKHPFTZLEEX9EXg1Lfxlh674kGaSmnJXXcLJo8kD1Na7kNhhej/OS91iyGMGoUpzZqNBe0BRWvGR5ugQ0bsdFeARzPOvbM7AXryzmENpLzdhYGDBRDgQ6LmlqLUZWpLZhuH2uVk3P0iqk3KfjU2/PmJgiqWR+0mG3Q9O5TCUouC6X/gW00xdcPo2kyY1PQDY8rgBfGbMG0OG1RmqSzksXjmWjtIySahxqhBgPgSgTkrV4ilMEw0vX9IzLrY0pj74kb9CqYrJNbptY9XjskXr4678L5EXSuX3ySpYq7h26li2ferII+clYdR3zpIS00nGKDxdj0U92iY4rKp4TVllts0SXAlR94k1u/zgKY8MIMAKhiYD29AvNuvnU6tCR43jn/UV4ceA4dO032mt8iNLxtGneCPNnjsO8d8bigbtreSl/XDIbpUtpL65ln82UR5J9tWAaXnyuPWymndE1qlbGwncnSDNmaE/MmTrSm0eGDrfGhBIdbXBJ0c9udFi0couX0JYmFf14IaIzG4/+AQVaVq143dU4ftYpo52Jp+SVLKeQ+NL15AUPDp1ykBMGYy09QSxaDj/5zwKc3f1tEIqcDU5vHyBJYqg00jekK5ky5bVzR60eYni1D0aQZJbizEZFKsNbuuzVQvKlTS78l1iJsVXgwnvLziOmaBlYjRMy9Je5Oc/LcatBNu0kCYm7OT/FGmH2et27kmpIKXd89J1CbpvK5EZGF/PSKBbtRWwEuIOowhjxBenq0jetndbmqLnSNKMMc+aWACoN9tjSkiQ53ncyIwNzytJVGqw2W8AcU1yKN9wSUdzrDuZQtdsCxjPFoHMkaYyq1R6NZo82wPaDmpQ7+bym1uXUnzXHzjhx5RXljGTea0SUNlZTdPUtb0S+OrJeuE2swlEqizUKHkW7z1S/TWtmhjcxzBl8aisbRqCwIBA2DO+YybNRrFhRdGjzGOjEBsOEQ0fZFY1Ro7qqQpKSclGTzkYV0dQTiukMr0UsyxKNv1ENiYIlAtdfVwFHzrgkicP0xTXjJW2JLI7Dp434jCVPyef3yc1Up7YtlnnmluXR9ZCNF26gcgzJblRUpDf6ivJlEZ/kln47EuW1iCERlz7Nsli1NMn6UUJOfROb+cVOkw2iduln3BaJi0VkjMYkOJI0iRbFX65xXDqGvSv64tDa8WmySDjve66p1RaRhoYCSpbQ6hMdEw1bdBkKkia2iInhVXxv2+SEc5KmoFnpndKQ6IpO01xVrAKkCbyMAOO8WXPSQAxnbNHyksSdnJurKZoENyo6VpblbzlMDG/xMtrzxJ/G7Fd1PXmPqt1TRlxKkjaDsAsJb8N69+PASY2RTjq7W5IYUu9TF9y4+iqt3TJCtyKjNYbXFearDXarhovFHgNFPG+pecazi9xkzH5HShIFsWEEGIEwQMD3zRnCFS5aJBbtWzbGHbWqo87tVb0mO1XObNpWzRri+c6tM0vuQ+cvYVQFw5t0/qCkKV6ukrwWLRKHc/Hag5YkkDLQZCUnJ0ifIqSCFYWE9/BpTYLrTEiVLDmNZVh7UVxyaMwAMWAyYTqWIbnJbSmhx6O9uNNjeM2SXXOV45M0sVSkRXu5GBMEMw10hjdRn1sYZ/p6TNIZ0gOmNCfPafnExsQgKk7bvJickDHTcn7/T9j59dMBGVqHkNrvWdZLStUvHvoVR/6YQkV5jTtZ09s2AhRblOH0uRoMb1RkBGJLpDIwcUVLptIpvtK+pEsFk+FNbXCqKylew9FtLZ4aqLtUU1/rQZd1celS5H0ntIkjZWK1pa4gkJ9MbDFNV9zjzP5kifILZBRoY1/xm+QYtE7964R0jFaZctcYwUGv3vtCXzUyCFOSNbUrW2QcaMJZrLymOkUTYqJxJmk66OfEo4juGwozm6gYrT+CrXCYaUPV7dEn5SnaAhqgaPeZ6k4dBxB/qk4nnHDpHxAiNxtGgBEIbQTChuGNsNux/2DonS2bUfe69TN4DTryu5M0RvWqitWMYCTrD1m3aUncnXIB+1YOwoU9mroBMbz0sjmfpEkHHaazdg0JjD2qFFw6M+AQEkdk8GcwvB63A2QyIL/8aH1pVtWPHguU0f86t8WyL9PqRiem+A5Tiy0qTXIjLFmXeLlVTUKlmpggg6m/lOzBrTdXQmxsNOKKa1JUZ3J8mjz9AxJPbwfhRQytvzQx/thGqWMcXbIyLLZo0PFjyee05WCitXp0TlzP1Gb6cpoeJC+333ar/IQsfVGrZLkbZBhZpcukStUUiy8eyTkgnaYysmqIqafx6fDTJ89qPlmhd+rSVHtcKh5GetWl7bA3/Jd7dSVrE4jzyRHeLKxWm9dtOMpcWVE6bWrGY0cSXo6lTxSVACoVlJ3LbaULTl904YpyZaU7Pcujn//s0Y87M2idKQnSGRGt6bTfVKUajoqVJI9g7qh/SfWJCFJUbSWF3GYTE1dMes3PLxkQRpYhnEgx+Fur1laP2/feNY8zl0ObPIdRM7mqjEChRcD3zRnCMOw9cATtnnsZHbsN8ervki5vCFdZVs3tx/AaEpP9Jxw+nwlNduoMmmlZ1iUY3sRT/8CddFLmZdUfwKqthPQ7TBuhkhM0yVdMsXKwxZbT4zNWaTA2u1ECgyEkd04bj5qxhPe6Clfj3rvqpCna/yVLDKU/kVUwmRTm1BkAly758pi+ymW0z2OJwR8/LwVNHooW05gEtwl3yieQMU8gzh9Y7UOSdHaX9Je4/mGUvLGxdJ/d8728OvyPJBOhliAMb+UbK8pPyF51ZXlcceXVUp/3jpf2QtH7XiSF4iftc2aT4U25eBDn9vxAWWfJJJzcChqfDtNKQ5YyyIB45Zr1qF2vDfq/OslLqTjPS3fxUpput/ToljPhuJCwH9J9l39JvqTpxrssmtSScorWP/ZBbsPYo0tLZ6SSO0yP23ERMTaN2VLE6o4szM9y6brrpy64UEY/VtGPxMdrqDS49JNjjEin/oWxyChNNaF61Sr477BWdvL5vTAkvC6LxhAb6YxrTFHtmWNx5yLzbxSWjSvtV/hvaWcx3rV705yV26m116Fv7LPok4ykRCHWNhF6xCTA8LqcOTPJMvLjKyPACOQeApZMZ53PhH27d8S08YPQ6/n2YaXD607RNoMY8CWd03Tijpxx+2z+cOh6pWYJidtPH85q1yROkUWukNmZGTDHJY3hLVryKhQvo0kGk/XTICSxybpwcLWQ5moP6kvnUnVLXX51NSXJvlNRcCHx8rJxI1Wim+zQlnj9c7JHxsggh/H1K2hD25mgMS8UafSFW0nNr2QZbVna4k7AsY2zpEQ96exOIk9jHCadacLQTJCs9+vH32zEgQSNGaOD+0lq5IhPuzJhs2tqJ+Y8/N0VrtGOZCtaxJfJsNjj8P1GN/7alSSTqNn40hdJM3d/3x1HN0zHmf++lPll1lJ1BsGdkntL+ua6qPqk5EKCG+WvutYcJd37f34Fe1f0l+7sWA59zNhjTFJkRZOkmvMlPc8kMR5J71N1acySOT677hNb5sFmcePXbUmwx5QJmJ1H0VQt4pNtUBRt0hyQUA/0WLR2HP59ApLPm05gcCVKCmNDaM0aVbHjUIoMSxIrFc5ETaXBHmVSrZGxmlW81JVSLcuGFBjSYC0mtOzk8/tl/VzJ59NUjO5VCnSpGkYWfVLq1D9GQXFkVLEaRlcy7lzod8qXDSPACOQ8AhpXkPP55niOZr1dszvHC8rhDP0lh8ni5UFFXNT1bMlNRvXY6ALV9HA1XvAyQlgGk1Si7PXCBzhMkjW3Q1uGLXNFRZS/5iYZ7xISL+kwWbu+fQ6Hf38dxzbOlKFO09fZ3Lm4218VeRcTPGmKLj2RhWfSUuypG3ZSdJUF/6T2SI3Go2iTgu0nNencsY3veJl7ty5t91hSmc1SpcvJrCxw4tLxv6TE0mnCVUbqljk86cx/eihAzE7KRU2y+PJr89Hn1RmIKVNVlkubfhy6hHfvcac3jT0ytQ7eQD/HtVdrzHhcnNY2c/T8NcDrn2rMvEdnVszxmXU7TW09sWUuaPn60rG/5BghneX08vEyCMkX0iPLsTiXfgLA2XgXSPodKGNVMP+Xjm8KFJXpMGNiVFy/zyih4idVpzAy5xM0JjOnmbxkMYEiqbtbVTD7B21iQ+WlMfo50slqxuOJ0nqgMXN0L5zbu4yCpFH0843j9BWPGypWwAFteIHGsNG+KF2SKxOZLBqju46myJDkCwfkNRQtVb9X4sUYJ3WcY3+9460m3cfkcetqH1a7NjF26dJviiNj0JHbY5L2kp8NI8AIhC4CYcPwpjgcmLtwKXoPmRBeKg1+S4dJ+tK321baZ1S4oDFqZgbZ7SfhtUVoL7WrrrkBl5LcIMma6koSDFcSLB4nElNUXHVVBVSseH3q0WUmhoYKNKTC5/b+iAsHVkFxpm7WMl70RHc5hupCy9z0svZPr+ovmiSHxtj7x6fnt0UW9UY7XEGGbNGb0XXaUWw8qUn+tp++Ev8ecoOkssc2vSvTuwXTTQ6LkJDSlUyJ4sVgnOlqSGJdASTdDl1f+vBpJw4LYZdHdcJgepP1Scz2Q8no+uxT2Lx1G85dUil7UJkOXZf6TFKqpNau96UkCmJFR0ehbJlSiIsVMwU/GpvNhvhEbaOjoqbDEPml8/c6Ek56g6jKBXnqAAAQAElEQVRNh9e/gXN7l4Mk2HT1RgZwED0Fu1LO0yXHjf8pDapDKyc+2YIiRbQJTaBC44/8HigYJ7Z8iINrRkkJX0ACPdCi61tfVUGbOMrgIAzvJacmYXWaJo6S3mQRg0SM1cFfx5pC03ce3TBDEmw+fiXOJgQZ84Jib/w1GL3gJA5eCCx5FSQ+P7N60Pn9P8PQ27ep2kpUXHFtkkWJooprE+vkc3thqHkUK6GtOlC82RQRk7LdR1JkkP8X2mRgiFiqvkci6cwOObm9dGKzt2aqeJaSR4X2LDYYXqef2oKZyVVN0l5Ky4YRKIQIhE2Tgz9JQ6wJo16fiVNnzuH0mfNo8Vg9xMVEo0ql6/K9lie3fIBj6yfAeJD6VyiYtCOq6NW+pFaNmTUzuW5ngg+NPUKTOFx/3bU4ckaTFjoFQ2tsWCM9vgrXXoWbKl0v4l0yrcFskcftx8gdXjeZgr2GmDOv5zIcyef3Yv+qwTi8LlXn0sjGKPtyJLwR0ZrOMuXl0pcbyW02MUXKYuNuwfzbysjgiIgIvPHlJSjWSJCk7NKxDUiMPy3jbFHF5NWwLqUohlNeEy9qdNKjW8Q4k/OIYHg36IfyJ57eRkFCAqbp7+446MCIIX0kk/rrH1octTvpgnYMnSVWU3WgRBG6Cga50zPXXnMVYgMwvHbB8F53XSWZ1KZojIb0ZNGi8UNJilesD4s9VjLxFw//RkFyQiUdASzzeE+6dCYARc4HuVM0hjfZFYHo2NTJg39JFw+vk0EkwSQp3tnd34n7MwGnt3+G+KN/4MTW+TI+kEWbEimczrqucJ2mGkR+xWKlSxqT7IqSYYaOq/T4WbR8TudcEyNOxi86jff8vhViTO2EPbYslm21giY3aYj0AE9EGXy9Ph6uyGv0kPQvf526Ff3mnBZ5lxeYXMLFw2tFP1+EVXHJSXS5K1Lzub5yNZy56BaTtotwJ2r7AUqWD/7MPXxWkYUnn98vr6FoXbzgO1bdKamrEzQxoTobaiJ2m9a3btOqG8UnJcbTRRpjwiA9bDECjEBII2AJ6dqZKrd3/yH079kZsbHRaFTvHkwa3R+Hj54wUeSP8+zOr5Bw7E8YH5Pwr4XbcUkGJQiJrHToVskrNGZF98KiP1yNhy6Fu/0kvHa7xhRXvO4aHDGdtevUjyS7mJTanecStRe0D8OrSzgPnnIjsmxdKsLHuPyk0T6RmfC4U7S2+tebktJSM10dLq1e5M6siSmaKg13wxYwWazOFBYrVlTGR0ZGYOfBi4i54UnpP7z+TSSd19QOomJSGWiKTHam4kb+pABHlBkM7/HzKs47ShIZvAyvWH6mgAS1JEjSRUzvwWOaionbeQlJFzUd3tJXVyMyaf7P3nnAR1F8cfx3l957QidUpYNIEQsCdhEbFkBpSlOQP4oUBVSQIlhAQSwoVZogIAoCgkhHBKR3CIRAek8uV/PfN3N7uTRIID0vn8zstJ2Z/e7e7ps3b2ddXD3E9mbe3xtXYOemn3MVG9C3BwYP7A+90aIIK5Zc+QVNUM1ifv3rLKq3GZptN9WEIFuiNaJqwyiqav8oXJzObBV4TRp3aPN5iYvaN2XEC4ExLeqI0OKlx55SNP1SYKP8xEtboM9n2t1kXaEhWQf4+MrzTPvkZ9KQbvGibKWdE2Kbl2dRrgE1PUERZtWw/ZbMjEg4J8165JH5IivV51Gs/f0vPPZwRxHPy/PylIJ/SHBgXtm50uh3sfNoEgIadhN5NCgwpkst/7V4OUgWGYrXolkjnL6aoYTkP80gVcvDdlrmAol6ORNREgKvLv4saDYps5AmBfYDNeq32Xp/prDtmnaQgq6jVcFgstqqUxlyeusykRTW2L0US3F2TIAJlF0C2Z/0ZbefiqArb6YmkxnpOnkTNhrNpd5j9+AWog+qDaeI2HmpcVL7dy4qC3WyMhVdu04ju1KA1vppTvuHo7rmqFrQ2VUyoGnu6KRMkUyCmEkntRYZZheRRp4+U2ox9SlZD3qTVcMbl2TAZ2tT4OxZhYranD493ha+lQAJd7SfOYdmmtIspnTawGiRU8AiUkDP2zfYVtKscbaF7QOeHh4i6usjBZDePZ6HRqNBv3Fr4BHSQtFiJcKcJLWuHj4Boqzq6c3Z68xIk8Kqmk9bdeCQ6eQPs1stSkJ6nHy5TWc1U3ENqC/S+/R8HnXr3ynCJDRqDFJjXL1Be5FGnpOrHLxQ+FZc/94voscL3ZCul3ub9YkyUEjfaDVpWL1hP0ZO3wDvGvfaajAb5DS3LcEuYDHJ3yAlGdJvrW3a90Yu5yoN5gzZjtbZBxrrRwFy7r/zmJwVSb66VxmESs26SRdrC6vlI48sUIPZtiadPPfpRidonaQwKQposn6/Im71EixSI5qcjxkFFTPbDVxTIvYLEyRKV12GMmAiQTc95riwnTbrk+BZtTXenroGnspAbsLo4WrRXFsaYFFilRA5s0HhGzlnZ3mtN3lkrChGQmNa9FERTtI5iq3qtWreBGevGtQoohJMqFZF2rzbEu0CQTWaiFh+90KRWUTelV1TxGySPo8XQm/UhAOyC/VUVh3kZKQlURQaBynwOllnYcw5TBqMdgJvpvVTxGJH9m6VAO/HBEqEQN538RJpunCNeHp4IDE5Bfe2bYl+Q8cpbjyqBGcXXFAKfx7BVoE3SWoP7btA013mVLkKQlSajy3rSpQB9epIoUlNdHaRglpqcryahIx0+YBXE5ysN2CKGzRSkykEXkWjRWkWrayDwlrrV7oMVttTSlMFmKQ0MxYt/w0xHk9jwS5P/LhJtnm7HzAwW7UldNzUnr0zWx/6mVbTDfu8m4V9A7LsCqFxyrN4rZrVkBZ1CgP79RT5tM7u3C8m459//8PcjXqRpnpePtkf2hZN1kCBypgUgYO29s6QclVEPfxDEVjNKswqAw2zMogwWNehrd0wS6CtUlWe37R4uRavmCKvWR0pOjlQcXO1E6ZEzbfmqdpp0y1q5zNS5IDIJ6gOflq5Fgt2eSCt3sdISJWDSTq+vHpmsdo7Up7FmL9gTPlF5czW8+Lk5q8IJVJwo7oNdjLMih1SaElWpupVm2xjehzUcJS5oSLIuiNVmZUhAZP2t3cm62/JkJl9QKLR5D0z4eBRHdfijMqAKhmkSbavSw2bjVIIV+PUHzVM25y20g4uvjgY0xgHDh7BhDHDcaPlxjwUgZjqqBJcMIHX1UVyS9FZsOeshnZFzEk5g6DPzH5NNrqjPi5FyeuACsanWBDgn7/tdJu770aYcm8j226D9fdC+xWHs1iZ2l+HBWnHUWt3sVh3UK+rDOvX5hysL6up91uL3VretIvJbu1dbR4CNJVhxwSYQNkjUG4E3plTRsHX2wv9X3kW740YgDdeewmjhvcvdaJL1u0RfdAnXxFbey8jKUxEL0Xq4eyW9aAIizaherXs2lVnV6sAa/cBBL0uuyDh4ia1mFSpg5sU2gxpkVAfoI52tq6e/rWpWLapXLNVIA1WhLGG9etg0OjZWL8nBqcj5EPNoIsX+9yql5Gatb/6EFHryjTJh76j3Qtoat7NtoEhWfbOqvblZvtQ/ovPPSleIpu94HfoMrMGA77+2dnDwZ2K25zFysmWoARSY04rPhBcqxXq1w3F1ViDiKuavVNX9LirZVORRp6ruz9tkGHV/pIphK+PN3TKbgkpZvjk7IMoXXhPZ5RaOfXcFrYGU5oUePv1e12wmvb5XPQZPBIJKVIwMFmFzJz1Wuw+8qC1pOfMLpa4LkVOvXtYVwrQm+TgIcNqJkMfX6jVqBNoBsWgDEIsVqHckB6raHilWcl3y3ci2a2D6F/kfz+Irb1ntP4GMh3l9ZKaIdvIz4bXz9cH24+kiip0dit3iASrZ1YGRdag2Jj1UotMkUxlSj7x8nYKgtZwpkDVdu9i9KS5oN/omwN7U1K+jmz2O7Rrjbp15O8934LWjK6Pd8FrfV4Saz0v3CgHcWarqZPGOeseZS0OjUdWvWmGvAebatl2bVqB7nUUL26zBvXcWnLY11Lb+TmL9YW1nPlkY01ptj47SQ7O1pVU6BxRvupM1uuK4izwEgV2TKB8ECg3Ai/hPHriLFau3YQWTe9AnVrVEX41kpJL1f269ZhoP0+BN+GiyDupCEMhVbK0lDqLfJiKTKvn5iE1wEY7TZ36ILIWgatblgbGM0AKgaThTYmVU+vOnlXVogiq1lCE7af81Aevo7Mn5nw+CRfDrigMr8EvUL55XZCvjYlK8/HS7T5xa87xIFKnCx2tmux8qsgz2T9IThtTptb6gQkKF8R9NmUc2rVpiV93yIc77eMfnHUuKK51zn4+NGYpnFMeOWN6NDKNKWI1h0ZN70KD+qG4HicFQvUFqTMRBjRvIjW/tI+7ajZhTqcoUo0uYjvlNz88+n4YnDzkgEUk3oZngpPY+9q/c8Qawpd3fICIf2Yh+tgixJ9bj+TwXYr2MUmUUb1L20bj7G+vgV7mojQSFEPr1AOxeuDetrgSHoFEZRaA8tRrhsL2ThU4KI2miXMKBZSenzOKQVpMftm29JyrNKgDMh+rxt9okhpKg3Xt5UhF0zp8SD/sOCaZQ/2zGKCanYTHmPD2ZzsV/sEiLVnhoxajrSlDCqOOLtLO+48jjli2I0PRCntQdi5XtUowthyW10vMyRW2VQ/sC5qNUiBW00x2y7iRJpoEsUSjHwZ88h+8m76Bucv24Nr1KHw65X11l3y37RUhc93yb0EzGvkWssuoG1oLX07/EG8PfR2XYp2RYP1qIxVxyWHiRGk1QpsgTScHxCaNByXl61o2a2xbyiwjHxvpfHcuRIb9fdFiNZUqyO4WO0HVvrxJGZCY9Ykwxx0QyWaPZmLrarWzz1SuH5Fg9czGDGsI0EKysSWUQICbYAJM4NYIlBuBl5YkmzrzB6zb8Jc40szMTEz+/HsRLk3vzaEjoDdYFE1qpHjY0QMzSdHYXDvwlTJVuEJ07VqiI2qH1hVh8izOuacf3b3kA9ZskA9PUS6HRsLFJUvgDa4mhSvSZBniT1FxeARLGzqK1KnbAPGkpbMYkaw81OklnbSUWMqCg7MPSCv06svPiniNmvXENtOU/cEsEgvhZdi97GXJ8ZDX66R5hruHPM5CVCuKplhNARysL+6JxAJ6P82bhePhUlNHu3j7Zhc2HV3lYIPyyGkz9bSxOZ3VVvd4WAbIrpE0vFGJ8kFHU+NUMD0zu3mNt53dMeWbHORx+/h4wd3djZKKxJkhBWl9Uhhoij71+kHQS1kxJ1fi+qFvEb5nmlhiTG2MBKz0mBMwpkWJN/QpnQRF+sodhZf++CUaKVPZpkxXisKkTxLbnJ7FzoaX8vIrR3k5Xfie6Ti7vh9iT63MmXXDeKZVExkQIrWOJotGlDdrZF9TDE5Cy34hLut3IgoonsE6xV6lVmP8d+wkLmVIU6SctrzpVi2yu7f8je656IOVe8zIb6D1QIe2CItxQKzOEySIJV7+VoNougAAEABJREFUW2kt+39qcly2BJMiYKkJ8Rc2ieAPv4Vh+859eHbIXMyY9S2efKwzunTMsqcWhYrQc3V1wSvK73/p1qwXf30CQ3O10KpFE5xW7Xidsv9OchVWEhw95OCZrkclWiz/Fqs5A1VuL3xS/EbObLeffTmzPkkZ/G0USev3J8PNeu6dbQKvUeSpnsVudsPJwaIm85YJMIEyTqDcCLx/bN2JRV9PhpeXh0AaFOiPtPR0ES5N764WTRWthrwhntswCGfWvSqW5ZJvP0stlkdAQ7jYaWc9/KR9p32/Pbz8RTTTTguRadaJNNVzc/dQg6gTWhP/nMk6/rMRelSvQYKrLEICDC2hRTESepIj9kOXKh+8zu7ywTVp/EjM/GQCXnrpJSoGZ0siTq1+Id832EWhG3jZtdNZgjvtomq13KyCPaUVxukMUrhxtL7cV5h9SQtX686O+H5jPBZvz9LOqHW45hDCnbTyfKr5qnYw0SC5eXl6IFXvrGaLrbtyjkXA6vkGZDebcHIPFjn+vr5wdZFCqki4Te9ATFP0nBGHeo/MRO0HPkC1NsMQ3OxV+Nd/Eu6BjUXt+uQs+/LI/34UaeSpU/DxaQ7i5ShK8/P1wY4/VkJrNT0hYYDSczqL3XVKeaaMRNrc1BkVbbkuXs5I2M8+3HRHpYAj5PVepbocPJrMGiUVSDRXFef2v6tS0G10d1eRntNL15sxbOgwtFKEuP9NWw83/waK4B8pf68X/hDF9dZBoZefnC3x9HCHg4ODyMvLI8GRVlFYuk3+tuLO5v5anT5dDhpiEk2iCrNesiL7+vSY47DAAb/ujsOg/r1w6sx5kNZ2xqT3RNni9F7v8zLW7U6EzqjF+WsGhNSQs0Kw+6OVGqatiMHgL68hUZN1f0E+f15BskyxaniNWfdFS6E0vBl59tqYHou4c7+LvJ//TkLzplKZ4O7hJdI0mXJwa0yPUWZNfoPWFC/S2WMCTKB8ESg3Aq+LqyucnKS9oopYA40aLLWtECzjMkX7dEOkgIt3TfjVfRRu9fvgpSlXUKfJg3C1CpmUH1CtEW2yOR9VI2jOuimrmsZUZUrxUqQRWjvtZt3QWli1M9lWx8GzOtS1exHO388XUUm2bJDQo0+TD1o3L6mNpEEDLW/VqtXd2H0yTRS2KIKMwe4TuiKxgJ69djqnNkXN8/IJLmBt2YtlmJ1EgrOrFGpEpBDegx07KkJRArafzr2/p92yZ2qVqlBCcVVAc/KRD3NK07j60cbmat/R3hamQGBIdm2Zh68c5IwaMQg/L5YfFaByt+t8vL1wPjwRKWZ/ROqCcDGpGjQhj6Bq6yGK4PuKqJ7OPQXizq4TAh6FydG5pq0+x8tK7ooGWuMgOZnstJFUVnWWnBpe6zS9QdGknt84GNH5rHWbdGWnWoXtRTJbQo6A/SoNZquQSOYXNIChoqZMefsyudQR5zbBLLWLL3V/Dgu3JGDtniScULTyVJbc6XA9aI3qaR+NxpXwCOy+UoOSIWZk/p0N+v2q7fgHyfPloQi81arc+Jp9pusjWLLpKsxwg16ZyichVlRs9Qw6+UOMTtGKFJOVVcKFzSK+57QFDRveic+njsPZw3/h91XzQba5IrMYvQb1QtHyrrbo+M459JwWjlqhDXK1JswUoo04dF6HwBDJJFchu4RqoS1EjF4SLIyZi9ipgJ69hleXKu9p+e5ql6Heg+ySRDDh0hbQeT8WZkCrex6DnzLoowwPT2/aAJlyAJwcvlOZNfkGLpnS7EVmQqxnrIZ5ywSYQNklIO/AZbd/tp75+Xjj5Bn5xjuZM/ywZA3q1735DdhWQTEGohRBY9MxR9S6fzxcW3+Ks9oXsXSvCz78di9IUH3w/vbwUKbJDp7T4c/DqaiXxwsmPn6BoocOGoPYkuds1TT2/CwNg79OgoOz9QasZNapXRPbj6ZBXYoswRwCX4WRkmX7PxTujd+PS80xCT0mq/DiqfTFVsgaGLcoGWcTqomYyfqmuogUwtNYpNBMu5BdIm1Vl2mRgryPX7CaVKit2Tp17+zmVaj91MKdHrhHBAMC/MTW3stLCDfpU21F0mLPiHD1eneLLXke3lVpI9zJyxm4S9EaiojV8/byBK1bao0isGp9ESRziPZtWolwUXjqOQ9tci9a3PM4HnjsRcW9gFHjp6LrK2NFE/pkRRgzpCL6+FIR//d6TbG1eS65mThZX6I0K9O9tnJ2gdTk7A/9jMQLQpi+tG2sMri6ipiTy6EOFOx2g73Am5ESYZ91w7BRJ9tL0WUNcg9f9VME3Xi4+chzoQrC1aqG4ERiQ0xZHouTEVm3uC2HDaAy993TBk882gnvf7oKwe3GwSOkpWibPlDiYJGDyJBqdUTaou8+x9bfJDeRkIf3xCOdEKhcV5uPmEVu7Jl1Yqt6JoU9hXVmee2aMhIpCnVN3h83hIO0rZSY82VWSitOp7ZLbeTXNgm9Mj+ENjd0Te5sANIWU6HY07/QpsidveCaYdWeF6QRdYCXs6zZel9c9lc8XustZ7uojNbBmTbQZkrNfMq1AyKe07OYpUCcM72k4jkHnyXVLrfDBMobgaynQRnv+QejB+OX37bixOkLeODJvgiPiMSIIa/cbq+LZH+Nf2uM//4MarcfiOb3PosXer+BDyZ/IV4KGzqoD0jI8fKviSFfXcN786PyFHg9fYJEXxw18uaqCowpukyEBAeCpk5FATuPhN7pm6ui7VsXUK1hJ7scGbS4hWLDP1JQIIE302qj6+0n25KlpO/n54PTF6NExGh9U11ECuFpMzNspc057I+1Fr3I8/O/+UNTFMzhHU+8Q0yrugZKDVKO7JtGSRP69RcfY+L7b+cq6xuY3fyACpita9CSxg4WA65EG9CiZZbA619FTqtT2bPXTGisPOgpbO9SlXNHcZpKr1E793Qx5d2u69C+Nd4b+WY2l56uw5zvFuFarA4pyuyAKSMBkf/NA2nGPIKbYfriY9ma9fCRmlH7RBcPOVBKy+Orc1ROr0ulDU5cluc1/vwfuPTXOFBbIkPx9ElXFD/rn2YOaM1Zk1mjDAbMsCjCNPUpq0T+IbXedIOTrdDZ+CqKwJsAb3/ZfxJ01czxo98STGqEyulpo9LmNV3Wef54/EjExSdiztK9qNKir9gt7txvYpuUZkat2tk19CIjH49+m+8OH4SvfpYDI/qaWsLFLbbSqoCmdZODvbTkGKRE7BNaxfh0F1yM1uLF57vaypdk4NmnHkVwUADoXpJfu62sg7lqN1iDV933zjvqY8XfUqCPPv4T6GVKNe92tlTXiRVdcWXXJJjt3g/QZ8jrsCB1q/dUtezlqCxBNTEtE+GpIbin7V1qNjRaq8CrUa5VY5r40IUt0y5gsbPptUsukaBFYUEvoeqsZkIl0ig3wgTKKQFteem3rzJ1O+6dgdiwYg7WLJmFD0cPyaXRLK1jITs3mip9RpnapOnSbb8tE2vC7tq8Cp9MHCO65aP0XwQUr1ZNqUlVgtn+0/XSNIJuzKrAlWHUSIE3D7tPMmv4beNWUcfDne4TW3uPHmIH/jsPmgbONOvhmhkvsv0Ccrcf4OeLo2eui3zTLQq8LlaNNFWSluNFHSet1FwH5FghgcoWxLl41xLTqt5+UptXkH1ylqEPQrRu1SxnMgKCa9vSwuNk0GxdLUNnXVbsTIQJTRtnCa01aktBikpnaHIPIChdZ5Q/L1rRobimqEn79v67Q2HvSCNJ1x59pe1ypOROn6ulPkVo7kHY1Tjo9BaKCucbnCW8iwTF87QOwPRpViBKmv2/waoBPxLugquxRph0sULDS9rSoCY9RFEaZImA1Uu6skOEdp1IR1ikFDb0N9Dy2q/SoAq8RriJOshzcZUCia+vN0VhL5CRFp2YeAQ1VYTieMxYlYA6daSWnQrT7/W1Pi/hy28W4PFXxiMi0UUMCCgvKT2TNoVyr/d5GQ4u/lj1j4vY79qBWUiNPCzCGou0OfUKrCfipOElG3+K/PRnJF7u/pTNhprSStpt+XUJ9m5bAyDvlh9S7i19e3VH/Xo3HwR4eXrgULgX1h6Vg4uECxtxZeck0P0n79oLlpoee1IUTIs6ogwUkkWYPGM+Am/s6dU482sfMdCjcuTUQfj6AwahJFi414eShSPtLp1DEbF6Ggc5uHLQZCLl+kFratYm3SB/37d7bFk1Fi5kUYTwsO3jkZFwAbHFpE0vXI+4NBMo2wTkL7YM9/HA4eOwd6fPXcKly1dtaWWh610f64JDu37Hj1/PwLDBfcUyWPn1i9bWzC+PhFvKozfsEy9vpyD0Ji2mfDgKC775VMTtvZnTJ+D+Dm1BwnTbu+W0rH1+ndCaYqrVXpNB+QFBUiNGYdU9rQjr6UZHEU1LihTbwngkpNuXz0iXWh5KsxilFiYpLUvIovTCuJeffwobf1mI/AYLhakrZ1l/RdjfdzodZHKSYnAX2SbrNKfOqjkhG1mRYfXqN7gDSWlmEfMMukNsc3rqclkxyZoSFWjIZIa0clVCghAel8XcN7QLJs1aLboZmyz7TpHqeWifvfxCKAvm9Gsg4UFE7DyTdZrewzsAq3ZKG1Wvam3h2ng43pu+TJTU51ibmmwgKWPjgSSEx0iBl2w9Ke1mThV4M622xVTe3c1NrHjRomkjMcAkwZHS7V1A9UaKwJuAtbvjQNpM+zwSiLVarfg4ya6jsbasNIP8HdgSChAgLe+oEYMxfclJpLu3FnuE756MjMRL0FhnN6qFNhHpmYYEqNPjv+5NtJkziMxS8MQMlCKo5tc0DeRpGUPVfCa/cmo6mTWs3RWNOp2ngla3SLm2H2Tqog7i1XKF2abHynWwLaYMJEVkCZ+qEJuzLhpsmHRxtpVIKD8lSQ7e1PcpQus2AplfJKdbsOHfDPR88WkqZnPUd4o4OZht54tmeiiNXIbRgTawmA1iW9Je1LEl0FkH5Mnhu8SAs6T7wO0xgfJEQFuYzpZG2bfGTMONXGn06Vbb9PP1ydOcQa3PoEy7Ujj29CrbSz+mTCexTNTddzWnrGyubmgt/LFmIVb/9E22dDXS6f57cHj3BsSkZD3ADcZMaKy2aWo52o5WHtZvvzOSgshIzXr4i4QCeGZF22BfzJCRpYUxWbWB6daVFuzLFTRMtpe0RmxByxe23MQVGcLkJMNBCnrqi0fp1iXJ3Pyzv9BDL/w8PDZMaIpCc7ywprZtyHQRQZ1FCtEiUsJeeqbUfmq0TvjjmDt27vkHI98aiBS9vCYSU83ZNJ9q9wIC5aBIa05B1JH52bRqVMZo/dpUo0aNsH5fCqKNteHccAgefbo3dh68TEWQniC3FDGkXAUJfwaTBmEJXjBal2mjlQrMhhSRR+XycyadNM1xtPu4Cs2exFw6lN8uIr1mdTkjUEPZkt2uSLR6IUGBWL3kG/yy9FscOpdlf26wuFpLFG4z+LVeoOv0o0Xh8KrWBiScXf57Aly00tSnVn05KNXCKCredz2ZffEAABAASURBVC4T9Ro0BgnsIqGCeLSs3cnT5/DK8NlwbvQOHF19FcHsLC7+OUowudlhmpTZArou1HI6ZdCZqcxQ2eIx/6lBpb50W9g+QHbrFDemRUOfFEZBZFjtfT29pblOo8bNxMt6D425hC5dHsWNBPqUa/+A/n7alkQb4TJMUgOc15clRYFi9kzWmThHtwDRUtzZX8WWPSbABPImUOYF3o4dWuOOBnXwxmsv47fls7F305JsLu/DKpup9HAlbW1+vVt/1B8r9joioOHT8KzaGhHxFhTk4Wtvd2ZfN60gQdpL+3V/k3X2JbKHQ6rKqW2LIeumnr1E7ti53wfi3IaBoPVf7XPtpxpVDa/BLDUi9uXKSjjA309oYdOdGoouJUfsUx6mOmW68LyIhzZsJ7b2HmlSKX5Xy6a0yeUSDT5Ca5xsDsyVV1IJceb6mLvZDMe6ffHuxK/RtHFDfPT+COjMrqIL1+NNQkgTETsvqGoovt8YjzSzFJjTc3xFzGJdfL9B/TtRo1ZdjJ4Xjoe7vYJrkVHo3XeQqMmsi7ZNZSdZV2fYdjgZzzz1JBzdQ0QZnaKhOr2mBy5sGqZoaY+INNWzX6UhNVHOOrh55m0+ou6Tc1u7ZnX0f/VFjH3njZxZIt7xvnZ4tMsDCIvNujYtWg+RdxMvz+zZn03EXzv2Yvk/fnD1rWOzaSZzpSrBQYhLNtn2+2nz9VLX7to6U4SBd/83CENefwWbtu5A8079sCmsFZy9qoMGPdcPzcWN/sjU48yvfXF132e2YurgMzJeDhRsGUrAYtIrfvZ/i6IFJqFZTdXFHhdBo17ONNWuXVfMFtHMHN0fKfO1Pi/RJpfLsCpvLcqAPiLWCAd/OWihgsZMaVJjsRPGKb2knNkglQpBjbqLJhPDtokte0yACeRNQJt3ctlJnfbBCMyaMhouzk4Y/eFMDB/7CTb+uQsZekPZ6WQBe9KuTUvcyKQh0RSEtfsyUKXVANR+4CP0+yIO+6KbFbD2/Iv5BNUXmSTsbj7uJsJ5edVqynKOmam5svVJl8VLG2brVD8ViD+3HqSJoWnp5Ij9lGRzqsaXHhQ09UYZBrPUKlK4rDl68NEKDq7e1UCrLlC/486sEd2kNY5btsp60IlExaNz6eHuDtL2KtFc/5d1DYXWWOfSKFdeSSXUrHMH5v8Whtff/wl65Tczf640jcl08BJdSDXKh7aI2Hl+/kGKwJuATf/KwY8uh8CrrhHt7uktpoJPnDqH61HRWLf8ewwd1AfEjKpTP9eaePlvimLL4VS81P0pePvLlSLUqWrKjPxvHm3ydBmpMSLdyy+3/bnIyMdzd3fDV59+BLJBzaeISG7f4UFEJkozD0c7LbLILIT32EMdxSeaP5o+F3GeT9r2TLfKZakZGpGWpHMQK0i8+GxWGZFRATwfby98Ovl9/LP9V9zb/m6MnTIPb3x5GZkaJyRe2oqkK/JayOtQjWlRIjkj4aLYkpcWc4I2WLlDXosiYvW0OT4SQ8mGHHbhcccXIDl8BwxWe19aEYdmiwID/HDfPW1AGnay+aZ9czqjJStl5/E0DHj9ddBLwn2/Vh6dyqwJ5dprnyleUs5kvRc/+MI4pBrdYDakKoPGLO13SfWD22ECQPlgoPxqy35Hfbw98eIzj2LerA/RvdvD+GzOQixbvbHsd7yQPfRRHhQXLl2GR0gj4RKTkhGgaB4LWU2u4rXqt8KstbF4ctwFnE0IzpWvJnh7eSI6x+L4at6V3VMR9tdYxFsX6KebfPSJFWo20mNPiXBCuhRqM03pwqbswpZ3FO3vv0hMs2B/ROGEFVFhCXkD+vbAiDdfQ1CAv1g6jpqNPb2GNjh/3Yz6dUNF2N5btWQuoi9l2RPa51GYBGjaFtcLa1T3zVzjO6QpxsHDxzD1w1G21SRStHUUgTYeZ2MD862ierUq2HXkusjXxZ8RW5tnkQNOdw9fkH21i4szVi2eK77gJ67jaAdR9Prh75Qp5ctCu0fasmh9FTRrfAdCatQT+WZDitiSl5F4SRGI/qQgTLo4RB1bLMLkmfSJtIFfcA2xLWqPlhb7dU8S1u1NhsVdDvxutY3JE94VZki935oBR48QUY3eLG+1OpP8fazcHoMeLzwNNzdXkV8RvSaNGmDzusX4Yc50XLiahi/WynNIX6E0pssBTM7jToq7IpIyLUbb7Ep6jLy37D1jQlJaloacCmoz5XVIYdWpL0JuPpiCRX9niuTr/3wOxwwpRLsq16xIVLxl87/Enq2/KKG8/80Wed4ol9a5JgGZwjSQMlpfoCR7YUoraWfWy99OUpoZK7dFiOaTwneJLXtMgAnkJpD1a86dV2ZSkpJTsXLtJvQfNgHfLVqFN157CS89+2iZ6V9RdeStIX2xcuEc8YCYNf0DfDxhJDrd3/62q2/SvA3I9kxvxA2XH6KGUvVSUDFabSYpjYQPQ8pVCipaXjntTGuNmhUhxGhxFukW64tp6hS4c2YyLmz+nxB0XP3qYeg3SdBr5cNf7FDGvJee7woSeu/r0AY7T8qHqMWkE73M0OY/SBAF8vFIa0xZtZRpddqWhmuqCJceihaaNG1vDeln64J7QCNF4E2A0f0OW1rOAPFod383kZxmXYtYRBRPYxV4Pbx8Ua1qCHZvWY0H7a7VIzH1EBGfCdIMX945Ccou2PpfMl7uLuurU78ZJdlcjHWgFXV0EWgwpYs/j+YBYVg4KB3TJwyFxiRnHapUk+vj2nYsosDDne/HvD8SMHlZDPJ7CbGgTdELbIu//wLRMbHYfVIvdjNaP5yy5J+qeHHyFSzfnlQhzRnEwebwXlY0+isWzsbyrZG4khwAMjlIidiXo5SM6hKl4Eax9Liz0CeHK5rLZND18Vz3XmJdc8pTnYM2uwBM6bQPbS9HGzF79UXEuj9CUThmpouth6ef2BbEM1kFXlrVpHbjzmKXu1o2RfMmd+K6oa6I03rKpF0VkRL0TBnxorWhQ9/CntNydiL56h6Rxh4TYAK5CZR5gXfMR1/gmVeH48y5MIwY8ioWz52C57o+BPcKqBkhm9AnH+usCAVPiYchaRzbtG6R+6wVMqVmjWpC87Z8/leYPmnsDffWmV1EvvpCBEVSo/6jjXC0LBDdaGNP/Szi73wjXwgREcVLc5IClKPGoDyoUuFVvT0S/V/F2cvx8PfzVUqU7X/Scre/twvOXZMPEOqtZ+CtmSQ8/siDIJtOejhSPaXhatWsJrTQS3/8Mlvz1arJwUfd0FrZ0u0j7w4fiK5dn0Fskgmksb+09V1cO/Al4s/9BkeNFOTcPHzELvSikghYvUaNGmP68usiZkyT9rd/HkqFOoVfp05dJKRkMf5ld5KiSTdBXFunf4EuQdpOUwWG1OtKewYKomr13Jp2kXGbHi2n1aXjvaIW++XNRMIteMSDlij8dPFRTFsRg52Xq4paQoIDERZlRKMmzUEaUJFYCTy6j/V68Rks+FVqa0mYRR5/Fr0U4iiLZhXSreYMhy/oMHRQ31wCr5PWzuaAdlKc+j5BaIPWuKNBXTzx+lyc0nVQcoBUnRmevlVQ0D9LpoMoSiu4PP7wgyK8c9PPwkzG7BQMMnPINBuQcHGzyCspjwYN1FZahgX9XnkB7e5/EuGxRpj1yYpS4ihlsSu7BLhnpUSgzAu8f+85iOpVghERGY05PyzH4HcmZXOlxK3cNbvl1yV46omHbtrvdLOPKBN//nexJS81MkvgpXj47qmKlkaHi3Ge2HdaJ9ZhpXTSgjgGtMSh81I4CWz0Iubv9MQDT74qlhPr+ngXKlbmHU012z7YYbCgXpMOt9TnkKBA8TCqEhJ0S/sX5U6BAX7ZqiO7Rfpghb1WNlsBa6SZosk6cTlDxMhshR7s1w99AxcHo0jTOrqIbU6vT8/ncfKaI64lyltMmlKFUdEm04uUVNbTwx1xdgJv/TtbYsbKKMpCjDKYUoUWStDFn6UNoq02tiJSDF6fXs+D+l23Tv6DgMI0O7BfTzh5Vscvu5Ohg5wlCAmW14L9F70KU2d5Ljtpwju4HCttmHXx5/I8FCek2dJTok5Btd9NMASIJRYNWn9bvhqwGKXmVo3rkuV1VK1uS/z9x0o8omjv+4xejP6zEtB5dBhCajZWi950a8mU1++Ryxq0zrGGt5uidKGZM6ok6fJftCkxp5oCJaWZBZceyszJ5n+liQMtUVZiHeGGmEA5IiB/zWW4w19OG4Phg3vhtVeezdOV4a6Xy65dtzQBvUlOy/DQF6PoIFIjD9EGu07IhxEJPpTw3rcnMXrEYIRFmyiqCL/puLfDvZi61oKxK9zwzP/WYPrMb4UQsUN58DRTptdFwTLu0Uc8Dl1ywoI/kzFzbRxat2xWsj0ugdZo+Sxah5Y0kTdqjh7qC3Z747PNQajTeRqqtxsBtwCpxaf9tE6etMnlyP73yxkf4otVEYhIr4rpP0fhpee6ZiuXanCxxZs0a4vW9z2Dv46kgjRmOkXI/feSFn2+dcf4metEuTSDtH8VkWLwnn/6cdDX+IpyJqLfqy+Invr6eIttP0UbN+Pj9/B8t8dEvDJ5NAB8sdcAZCiDSDKRyimoZiReEjhik+Vgypx+zfbxDu+qzUWe+vEOiiSlS+FZNT2iNEPqNcCUJD6206BJe3h5emDZ/C9BsxXHL8SDzE2oXEHdhvON8NKUK3AKapNrl8ce6oiz1zUgMzDqu2g7V6kbJ8SdWQu61964VO5csz5JJKYbtGJLL0SfipK/xSS24xVM2GMCOQnIX0vO1DIUb9OqKW7kylBXK0RXgkJq4Mt1ceJYrh38FiR40M01KsGItYcUje4Z+TD655IL0hRtMK3pujusCiYvi8bBiEAE+PvC19sbW3cfF0tU0YtMJESQRk9UWk68x598Bl//GoMdpx1Bwls56XaxdLNV86b4Y8cJfLFgO+b8fAprj1bF/vMafPdn7ulk+w50f+YJnL7ujmfH7MLGA6kggdI+36jxsEX9Q2pjwpjhWLRNmkrYMpSAWS81V3qrvbiSVG7+eynT+DSz0rmjnCUgDfcbA16t0C+r3ejkPNP1EZy9KmeAdAkXbEUTLm4BLU1HCbEpTjh1RV4HZn2iMENo1f5hykJow1ZITjfj3HULdCYHkWY26sSWvLRo+dnsQ+d0uLOBfDGS0seNGoY1y77D3xtXUrTAztnNU5hRdOmSe3asWtUQTJs4BpsOSDOM5PDdBa6XCtIsRuR/83Bl50QxY0ZpBXUm62/CYLUNp/3uffApXI42CLOG9BjJgdLLu+P+M4GiIlDmBd6iOlCup2AEyOxgxwkLria5w6SLFTdj2vPgBQNe7tkXb825grVnmmLi/DP44L3/iS9dVa3dDOv2pqBBs05UFDRVTstA/bvjN5Adq0gsZ5761aW7W0nNUjnrfpF295Eu9yO0Vg38tHIt5s5bgvGf/IBhX57HoStZAmt+Dfbu+ZzIeujBexEU6C/CNs8py8yiSo0GYrDNWlDaAAAQAElEQVQ0cMhwrPhbaq/UcmbrlLXZTkBW88r6lo55+fyvQOv9lvW+lkT/6obWwuU4+dhRZ4piTq7AtQOzbM3r4YnodHdb/PCFDNzT5i4Rb96qAx4aE4bp611hznQSaRZTlklDmlXgjdb55xpUPNL5frEOtdipgF6nB+4B3RM7W+27c+5GGvtjV11EsqpZJW0v9cNskAM1kZmHZ6/ZNabH5VEi/yS1bhNk21SyxwvdsOVgKgWRdGWX2LLHBJhAFgF558mKc6iSE6gSHIQPFUH27dmnBQlThlxKKMVSDd2eeAh3NqyHKXPWIahqXWGqQIU6K9orWq6HNFkUpwcEfYqUHvYUL15XPLXTVD/ZPX8yaUzxNFCOaiXNLC3ddPLAn7h6Zh+2b1guek9CsAjcwOvTq7vQ7I5+e0iuUm7ewSKN7BCrVqspwq/3eRm7LgZi8JfXsP1gFBYOSsfwR/UiT+MkzQJEhL1ySyDDKVT0nV5+vPbvbETbLT9HGRZHX2g96lBQuESDvxhYU4ReQiMzBV9fb1jgTEmwWDW8tLpHynW5TGBg7btF3u16JCSvWDAbN5qhatT6CaF1zlA01obUSFzd96lYwvFmKyZkE3jTpN1xQftr1ifLoo7SjIEi9NJzpL46BXGztkUh9phAJSPAAm8lO+EFOVyacvUKqItf/82asg4MbQ8/Xx/8sWYRSBic+tFoW1WPdnkAm9YuEuur2hIrQKBDu9Y3/BR0BTjEWzoEeuP+1L9bQUtv3ayCOrVrYtF3n4tVQnKW9fSVD+d4qZSyZU/7+AOcj3JAaFM5ja1mOLnn0BCrGbwtVwSq39FJTL3TihwJF/4Qff92CzDkqwi8OTsCsY5tUSW0tUgnz6tKM9rY3IbVCzDj4/eRqZXazbDt7+Pq3hmI/O8HWBSt6vFLOrS5J/u1Y9u5GAIvPtcVfx+T7zfQy2v6pMuiFXUrInaeURFuw3dPgdFuLWL7sFqUBHg1nHOranidXLMPAjs+9AzCogwwZSRAXeEi574cZwKVlQALvJX1zN/kuOmFoxnLLmHNQWcM//oa2t9zv9iDtLZ/KRo+dQknkchepSNAy53d7kEH1W4rvlr1+ebsy9W1vbslrp8/gFGjxmVrwsOqEc6WyJFyR4BmhJZus5qtaBwxcXkaftkZizPXtDhwNgPVq4ag+d0d8f3GeOGatX0C9n93tWwqlnQ7q2thM39JuvI34s9vEMWWbE8FfUlNRErAa9q4Ic7HSsEz1vp1Rmo2KTpraT2KkyO73fOb3hIaWPqoxdVYAyUrwm+02KpewoWNuH74ezWaa5uaHCPSXNyz/3ZoNmbLITmCVE0sRMEcniElIkcKR5lAxSfAAm/FP8f2R1jgMAkdL7/wPKYuPIUjVwCKqzvTlKIa5i0TuFUCtD407Zvfurd7/z0iVmmYtUlq8rz9y+6X+ug42BWMAE29B9Z7CBGxRoz4Ngphid7Yt20N3hs5FDWqV8Wdd9RH3dBaWL0vUxF4E9A2n7XIXT0C8dnqWGwIfwD+DZ4SjV+KMsG3ZgcRLkmvUZunka63wGK1N6e2jUlncWnbGEQe/o6iiDmxFJd3fKCUSYN7UBOMXuYkjg/KX2KscpNVtvQfd+YXXPt3DlIi/kHipS2IPv4TDCnXKMvmdMmxIuzunf1LiaSQ0LvKdcPze4mO+hj294RbWh1CNMoeEyinBFjgLacnriS6PXHcO6ClhF7uLh8mJdEmt1F5CFStEiw0cfQVuBsd9dGLOjz1wWUE1ZYvLt2oLOeVDwJjR49A/5lR8KvZGtt+XyYE3eFv9MOZQ9tsplGTP3gX9MXJ/JYSe/Xl5/D20Nfx4Yz5eHzoWiz6rxk+XHwdbw7sXUAIRVeMPqiy63hatgo1mSakxxxH3NlfQR9tiT6+VOR7hD6NsYvTsWP/SdSu20Sk6ZIjxZaE26hjS0TYlBGPiH9mKYLyMqhLQ4oMxdPrEhUf8PYNEVt7r/Ojz+FSJJk1xCM99qR9lghf3f85yKwi5uRKEWePCVQWAizwVpYzfQvHGRjgh4vHd+KrGR/dwt68CxO4OYGNvyzEkNdfuWHB+FQzohJMYvB1w4KcWW4I0EB69dIFoBfCPNzd8+x37x7PiS9O5pmpJLq7u2HS+Hfw356NqFWjOmb/uBYegXeifZtWSm7J/tNsxXVdlXwbTY89BQcXX1x1eQb39/kRf/29R6z5PGzoCLlPRiTCd08Wwi2tQx0WnSnTrb4+OUsDLOrSh4sc/6Dcsx5dH+uCHcfli57J4buQFnVE2PTSDnFn1yma430UhC7utCIQnxBh9phAZSDAAu8NzjJnMQEmUHoEOt/fDj/P/wy/r/gWMZcOlV5HuOViIUAfSyiKihvUC8WvK+eJD0y8N/LNoqjylupo3KYbktLMuHBNj8MXjaKOg+d00Bky4RzQFLO2BuC5QZ+Jl34P/L1erHIT2rCFKOeIDCRf3Qs4uOLjn02YviK7CUNC1BlRjl6EI7MIBxix/Ugqqtq93AfrH30sxsFPCv1J4bsRceArXD/0nSLgnkLk4e9FqX/PyqXcwvfMEHH2mEBlIMACb2U4y3yMTKCcEqBVHkigIW1eOT2EitLtMn8c3Z54GLRiTGl19OluXfHw2DD0mHYVl0z3iKX1pq1KwtA5EWjZax0WrdyMqR+OwuZ1i2H/0mdcitTmmhz88OonV7DjaALue7gn9p1Ow+HzOnE4ppSroJUcwra/D7LBPXFVi0/W6G3LtYlCdt7DT74ozRp0cTCmRSI5fCfCtk8QJb5eH4f35kchUpk1sZilYC4y2GMCFZwAC7wV/ATz4TEBJsAEmEDxE/Dz9cE7wwZAfLK7WVscUoTV0aPGIirVEy2bNcahXb/jrSH9cnVkzjZ/fLk+FY+OPAh3v1rY/9dakP3yuMWpGPTlNSSmmuEAvXgBjtZFP3ddg9HzIrF2mdTW5qpQSejcsQP2nrEooax/i0mHA+fN2H8lECuXLkS3Dy7jg5XZy2SV5hATqHgEik7grXhs+IiYABMoRQLbdu7H3Z1fxMgJn5ZiL7hpJlBwAhPHvQ0yq+j+zBNIizolzBaWzf8Ku/9cDfpoRl41NWzUEku2RKHHyz2wa/Mq8QIflZv5yQf4ZOIYRCY5UFTR1EbhQlQmRs2Pw7pVi3BXy6YiPT/PudqD+GBxFD5eGo1zEQbEpWrw0U9RWL7gK9CLotTP8KiM/HbndCZQ4QiwwFvhTikfEBNgAqVNgNtnAiqBm71ERy/enT64FV9MG6/uIrYvPd8VQwf1QYJZrsRwOdqMcYtSsH7VEjRvcqcocyPv2We7Y+OBVJyJC8IkRdAd8fUVfDF9GurXDRW7kSZ677Y1IsweE6gMBFjgrQxnmY+RCTABJsAEyiwBWuUhv86Z/Duj86iLGL80A2sVYTc/TXHO/UkovnB0Bzb8sgAv9BqMh57sgWe6PpKzGMeZQHETKDP1s8BbZk4Fd4QJMAF7ArRKw7/bVuLTiSPtkznMBCoVge7PPIFJH47Dr6uXiQ9yFObgq4QEoUpwEMa8PUSYRxRmXy7LBCoaARZ4K9oZ5eNhAuWNAPeXCTCBfAnQeugD+/VE9Wr5r/Ob786cwQSYgI0AC7w2FBxgAkyACTABJsAEmEDpEeCWi48AC7zFx5ZrZgJM4DYI8CoNtwGPd2UCTIAJMIFsBFjgzYaDI0ygrBPg/jEBJsAEmAATYAKFJcACb2GJcXkmwASYABNgAkyg9AlwD5hAIQiwwFsIWFyUCTCBkiPAqzSUHGtuiQkwASZQ0QmwwFvRz3DlPj4+eibABJgAE2ACTIAJgAVevgiYABNgAkyACVR4AnyATKByE2CBt3Kffz56JlBmCfAqDWX21HDHmAATYALljgALvOXulBVfh7lmJsAEmAATYAJMgAlURAIs8FbEs8rHxASYABNgArdDgPdlAkygghFggfc2T6jFYoFWq4XRaGB3AwaOjg6wWMzMKB9GmZmZ0Gg0zMeOz/3tW2HvpiWYOv4twcXZ2Vls+beW/V7j5OTEXOyum5zXh4ODFpmZFmaUD6PbfATy7kyg3BBggfdWTxXvxwSYABNgAkyACTABJlAuCLDAWy5OE3eSCTABJlB2CXDPmAATYAJlnUClFHj3/XsEw8d+ctNz88rgsYiNS8hWLjI6FlO/mIfHXxiCl19/FwuX/WrLN5nNmPz59+j75jgMHPERrl6LFHmHj57CmIkz8dCzA/D68A/x956DIp08qn/oqCnoP2wC3ps0C7qMDEouNffDkjV4ZdBY4Z7t/T+cOH3htvtS1MyOHD+DvkPH49Uh72He4tW33b+CVkDn955HX8EXcxfbdlm0Yj2+W/izLX6rgRtdI/kd7++bd2DA/z4S19U742fg0uUIW/Mr124CXb+9h7yPHXsP2dJLKjD3xxWYv3TdbTdX1NfO2g3b0EP53dJ5TEhMvu3+FbQCuudQm+s3bbft8t+x06C0Vb9utqUVNlCU1w3xGDn+U3R6+jVM/3J+YbtyW+XpOn6611vZ6hg6eiqeeOmNbGm3Einqa+jT2Qvx5MtvoseAUbfSHd6HCTCBUiJQQgJvKR1dMTSr1WrR/emHsfHnuZg87i38vG4zLlwKFy2t/2M74hMSsWDOx+je7WFMm/mjSHd3c8XIoX2xafW36PNyN0z+7DuRTt6sb39C+7tb4MevJsLb2ws//byBkkvFkXC79vet+Hzyu1jy7VTMnTEObq6ut92XomSWmZmJCVPnYNSwvpg/exK27fwH9NC/7U4WsAJXF2fsVATIxKSiFZbyu0ZudLwhwQGYPX0s1i/7Cg3q1cY381eIo7gcfh2Llq/Ht59PwPQPR4jrLUNvEHnlzSvKa4eOPSQoABPfG4rAAD+KlpjTaDQIrVUdW//eb2vzTyVcp3Z1YbttSyxkoCivG2r6iUcewIBXn6dgiToFDzw83GwD7KTkVCQkJN0WG/UAivoaat6kASYp15BaP2+ZABMoHwQqvcC7StGu2GvoSPN75tylfM9ecKA/GtStDfqrF1oT9erUxLXIGIpi977DeOLh+0W48wPtcOLMBaSl63BHgzoI9PeFg1aL+9q3gtFotGlyd+//D08+Ivd5Utl31/7DYv/S8OKUB0xd5ZjoGKn9KiGBqBtanYI4dfYiBr8zSWhVSQsUpwj2lDFV0XZ/NP0bkJb6pddGYsv2vZSczVF9RcXszPkwuLu7ofEd9eDo4IBHOnXAzn0lo8HUaDRwdHTE0493wvI1f2Q7RoqQJok0raThf/PdyWIglJqWjm6K5ooEVypDgufjL74Bk8lEUZvL7xq50fHe3bIJXJydxaDk3ratEBWbIOrbpfDoeO/d8FA40Tm8U7n+Dhw6LvJKw6NBiaoRo8EKMaF+0LUz5fN5IFZ93ng/z4FLUV471OY9bVrYfr8UL0lXo1owEpNSkKpcE3Q9HDh8DK2aN7J1gbTiT/UcBvod2c9cEKeJM5TfmKLxkDWibgAAEABJREFU/H7RKlt5ChTldePn643O97eFm5sLVV3irssD7fHn3/L+sfmvPaB7qNoJGsS90O8d9Bo4BoPfnoSLYREi65sFK7F01QYRJo8YLlu9kYI2V9TXEN1zAvx8bfVzgAkwgfJBQFs+ulk2e0maXRIEmykjfuphTFwCqlcNoaAQxqoEByI6Jl7EVW/Nb1tRXxGYSXNKwrAiQ4EeNJRfs3oIYmKzl6f0knJt72qKDL1emFfM+GoBaMqV2jZbLPho+lwMH9QLi+dOwcOd7sGsb36iLOEMigD/5bQx+PaLD/C1MpWtCjQiM4d3u8yiFJ7VqwTZaiVmUdFxtnhJBEjDv2nbHjGYsW/vq++WolHDekLD//hD92HqzB/g6eGOhnVr4R+rwPn37gPo0LalEJzt97UP218jBT3eZas3oJ1y/qiemLh4VLNjVKNaCKJjS5YR9UN1DRXt8y+LvsDS7z5BrRpVsOyXLIHEbDbjy0/G4utPx2HmN0vUXfLc3u61k2elJZzY+f52ipZ3Hw4cPo67mjeGVkMrCGSKXjza+T6sX/oVFn49BcdPXcDB/06IdPL0BiO+nDoaA3p3p2ie7navmzwrLcHE9nc3x74DR0SLpAnvoigNRETx/Hy9MFe5Rn76bhpee/VZfDpngZIKdH2kI9Zt3CbCNIjY/NdedH30ARHPy6sI11Bex8VpTKC8EijJfrPAe4u0E5NTMHbSTIwbOQi+3l62WjQajS2stQtT4tETZ/GToo2Y8O4gigpH020ioHga5eGnbErtn6brv/lsPEa91Q8ODhq8Pe5TbNiyA9cjo0GCF5lfDFa0vKvX/4nT5y7a+nlvu5ag4yAODRTh7vzFK7Y8+0BRMdNosxgDJX8Jk+b08S73YtW6LfaHh6Mnz4GEYUp88pEHEHYlQmhyH3qwvSLk7KdkoQF/+MF2IpyXl9c1crPj/enn35GoTAH3f+VZW5UaZTZBjWg0GjVYKltnZycsWv4r/vfedOxSZkEu2F0f97RtAQetVmijSfuZXweL6trJr/6SSn+k0z2KFnO/uB4e6pj9OtAb9Phi7iLldzcDEdejcP7SVVu3OnZoDfqN2RJyBIrquslRbYlGaenCxnfUx1+7DkDroIW/nzdIiKVOuLq6CG6jPvwc9J7B5fBrlAwazAX6+4kZqD3/HFEGnHXg5ekh8nJ6FeUaynlcHGcCTKBgBEpeWihYv0qslIODAyyZUsNCjZLGibY3cqTxnKhoPEcM6Y0H7rnLVjQowA/xCUm2eHxiMoKD/EU8RtHczp63TNhc1qxeRaSR4GQ2W0AaUkogM4GgQFme4qXhNBoNaAr87Tf6YOTQ3tjw526lGxpUDQkECcPkvlM0uSt//ExJt/7b8aMU9SFFYdUVFbMQhWdCYoparcI7EWTLaksoxgAdFzlq4uXnHscvv/2pCLRmaDRZAqWToyNlizSNRgMSPB+8ry32HvgPySmpOHH6Itrc1UyUyenldY3c7Hj/OXQMB4+cwMwpo4R5A9UZFOCPxES76zAhEcGBAZRVKu6TWT8o108QJr33ppgl0GVk2RNrFWFX7ZT971BNA4Ciunbs6yzpMF035MjEhH7vx0+dx10tGtu6YTSaMH7KbNC0/heT38Wjne9Fui7rBVYypbEVzhEoqusmR7UlGhW3EMXrogwCZnw1Hw/ZaXepIyvXbEb4tUi8rdxzv57xPnQ6PdS/px7riN8271Dcdjz5aEc1Odu2IlxD2Q6II0yACRSaQKUXeKtVCUbEtWgBLkERUM9euCzC+Xn0YPpg6td44uEHQPaA9uU6tGsptBCUtv/gMdStXV1ormglhvcnf4X3RgwQD37KVx1Nb/9ptXvd/Nce3KfUoeaV9PbK1UibbRw9II4r06oBfj5iepxsTjdt2y26RAxIoyQiivfb5p0wKVPTYeHXcezEOdRXtLxKsu2fyhcVszvqh4qVM8IjIoUgRFOf97XPGnTYGi3mgLeXJ+jhTBpwEmSoueaNG4C03xSmcxlaq7rQXrq6OKNp4/r45Mv5wkbSQaulItlcftfIjY73yIkzYiWEKeP/B2cnJ1t9xIPsmvUGgzIgSMLJMxfR7u5mtvySDtC5uk8ZGBKzwtqoF+W1U9LHnV97/Xs9C3IajcZWJDEpGfQBieZNGopzudc6tW8rkE+gKK+bfJoo0eR2dzfHM090QmdF8LVv+MrV67irWSPQgGHvgaPK/SbLBr7T/W2xT0k7c+4yOrRpYb+bCFfEa0gcGHuVjwAf8W0RyP3kva3qysfORqNZebg4iM62btkY9EAe9PZEYUNYq0ZVkZ6fR9q0rTv2CW0MLSlEjoQeKt/t8U7QKtPt9NLSD0t+wejhr1GyWMnhmDLdTcvYUHly9IITZf5vcC+s37RD2M1eUQTGXi88Scml4mhK9b2PZ6Lf0PF4qsdQHD52GoP6dleOSStWpNiwZRfo5aJuPYfhuN1yZSFBAeg95D2M+ehzvP1m71xTikXJTKPR4KMxbwj+xLl1q8a4y+7Fn5IE9+qLTwlTD7XNYQN74sjx02JZunUb/sKY//VXs/BQx/bYtmO/sm1nS7MP0GofeV0jGk3+xzv7++UgO+tO3fqL5a26931bVFm7ZlU8+2QXvPbWB8KMYMQbvYUQJTJLyDOaTIrGWQrhfXs8jdeGyb7QwKkwXSjKa4fapZea6PdHgiIteTVywqeUXKKuXetmYrBk3yjN7NCLmLSU3LsTPgNN1dvn5xcuyuuGBq3EhpYkW/P7VnFN3egF3vz6dDvpDlotBvZ5AWQeZV8PmQrNnb8Cb7w7GYeOnoSPnRmZi7MzWiva8se6dBAzK/b7Ubior6EB//tILEkZduWaYGT/0hy1x44JMIGySUBbNrtVvL06ceY8alsFW3rTf8Gcj0FLOJEgNW/Wh6A3n6kHS76ZisAAPwraXPu7W4jPndInT1VH2l4qQHW9//YAUH007V+rhjRdGNL/pVz70AtttA/VTy9j0LJkU8YPB73MRuml4RrUrY3l82aI5b42rPgay77/RNHuBouuUN6sqaOx8OvJYkm2ns8/LtLJu1/R3tELSbTvww/eQ0nZXFEza9H0DsGYXqArySWU6Pz+ueZ727H5+Xpj5+8LxAOaEumcfjbpXdG3Ocq0a73QmpQsXJcH2otrwP6tfJFh9W50jeR3vN/P/EDUqV6HqxZ8bq0NePGZR0HX76K5k0H2n7aMEghYLBacPH0Rtay/Mfp9rF74uTC7IDMguo6oG2NHvC403hQmRy9s0dbeFfW1k5PzpxNH2jdXbGE6jrzaekcZIHbv9ohod/zIgeKcfTpppBjU9ev5tEjPyUkkWr2cx0PXAl2HlF3Y64aub9rf3qn3QqqvOB1dyznbohkBug9Ruw3r1caqBZ+DzBmGDegpXu6jdHI0w3LpSgS6PdaJorkcsbc/JgrTNUkF6ZgLe8+mvlIdquvZ/Qmqih0TYAJlnEClE3gHvzMJp85cQq8XupbxU8PdYwLljwBpCbs8OwC0viy9zFj+joB7XJ4I0MdW6AM0je+oI8wdylPfua/FTYDrZwLZCVQ6gZdeuiINk7+fT3YSHLslAjfSPt1ShbxTuSZAGrO/1v2A0cP75zm9XK4Pjjtf5gjQwIpmMmjmoMx1jjvEBJhAmSJQ6QTeMkWfO1OqBLhxJsAEmAATYAJMoHIQYIG3cpxnPkomwASYABNgAvkR4HQmUOEJsMBb4U8xHyATYAJMgAkwASbABCo3ARZ4K/f5L/jRc0kmwASYABNgAkyACZRTAizwltMTx91mAkyACTCB0iHArTIBJlD+CLDAW/7OGfeYCTABJsAEmAATYAJMoBAEWOAtBKyCF+WSTIAJMAEmwASYABNgAmWFAAu8ZeVMcD+YABNgAhWRAB8TE2ACTKAMEGCBtwycBO4CE2ACTIAJMAEmwASYQPERKAsCb/EdHdfMBJgAE2ACTIAJMAEmUOkJsMBb6S8BBsAEmEDZIcA9YQJMgAkwgeIgwAJvcVDlOpkAE2ACTIAJMAEmwARunUAR78kCbxED5eqYABNgAkyACTABJsAEyhYBFnjL1vng3jABJlBwAlySCTABJsAEmECBCLDAWyBMXIgJMAEmwASYABNgAmWVAPfrZgRY4L0ZIc5nAkyACTABJsAEmAATKNcEWOAt16ePO88ECk6ASzIBJsAEmAATqKwEWOCtrGeej5sJMAEmwASYQOUkwEddCQmwwFsJTzofMhNgAkyACTABJsAEKhMBFngr09nmYy04AS7JBJgAE2ACTIAJVBgCLPBWmFPJB8IEmAATYAJMoOgJcI1MoCIQYIG3IpxFPgYmUEYIREbHYuykmXix/zvoMWAUnu/zNo6cOFOkvTt64iz6D5tQpHVyZUyACTABJlCxCbDAW7HPbwkdHTfDBCSB7xauglbrgEVzp2LZ99Mxc8ooeLq7y8wi8uuG1sC7w/oWUW1cDRNgAkyACVQGAizwVoazzMfIBEqIQGxcItq2agJXF2fRYs3qVVCvTk0R1mVk4LM5ixTN72j0GjgGs+ctg8ViEXmr12/BsNFT8cqgsXi0+2DExiXAaDRh5jeLMWTkx3iu9wgMfmeSKHsx7CpmfLVAhMn7YckavDJ4LHoPeR+TPv0OqWnplIzvFv6M9ybNwlCl3teHf4CpM3+AyWwWeewxgWIjwBUzASZQJgmwwFsmTwt3igmUTwL9ej6NeYoASkLq1z8sx/FT52wHMm/xLzArAueirydjwZyPERUdh5VrNwsBdd7iNZg5dTSWfDsVy+dNh5eXB/YcOILrkTGY++k4/LLoC3w4eoitLjWwbec/2LBlJ2Z/MhY/zp6IuPgEzP9pjZqNSKWNaROGY96sj6DRaLBtx35bHgeYABNgAkyg8hBggbfkzzW3yAQqLIFWzRth9cLP0bdHN8QlJOPNd6fgl/V/iuPd/+8xRQA+j2Fjpgp37uJlHD1xBu5urggJDsBnsxdi/tJ1SEhMgYuzMxrUrYmLlyNAgvOy1RttWmNRmdU7dOQUnnj4fvj6eMPRwQE9nn8CB5U0azbaKNpmTw9pUlFFaeNCWLiaxVsmwASYABOoRARY4K1EJ5sPlQmUBAFnJye0a90c40cOxPBBvbBmwzbZrAZ4583e+Oaz8cItnzcDU8YPh1arxYLZk9Dt8Qfh7OSI4WOnggTTalWCsfS7T5S6mima2lgM+N9HwsxBVib9TGQKQVfGIPbPzMxUo3BwyLrFaZV2TCazLY8DZYEA94EJMAEmUDIEsp4GJdMet8IEmEAFJrD3wBFhokCHaDAacezUeQQH+lEU97ZtiW8XrkJKapqIxyUk4sz5MGToDdAbDLizQR30euFJYfN75twlJCWnwkkRgFu3bII3XnsJiUkpitY4Ueyreq1bNMbGrTuRnJIq7HOX/bIRdytaXTWft0yACTABJsAEiECZF3ipk+yYABMoHwROnbmIF/uPxKC3J+Kx7kNw/sZORyAAAARoSURBVNIVvDXwFdH5fr2eVYTaUAx+e5J4yazvG+OQkJiEeEXwfeS5QXih3zsYN3k2qlcLQecH2mP/waPo8Nir6PPG+5g4/Rv0V/avEhwo6lK9zve3xUMd78EbIyej/9AJ8PL0RL+ez6jZvGUCTIAJMAEmIAiwwCswsMcEmEBREOj/yrPYsOJrfPv5BGxbNw+L505B7ZpVRdWuLs6K8NsLP303DUu+mYr1y2aj/d0tQKYLf/82Hz/P/wwfvz8U7w7tK+x1H+nUAXv+WIyFX0/G5HFvocfzj4t6mjdpiB+/mijC5L3+6nOgl90WzZ0szChUm92BfV4AOVj/er/0FIYN6GmNlcsNd5oJMAEmwARukQALvLcIjndjAkyACTABJsAEmAATKA0ChW+TBd7CM+M9mAATYAJMgAkwASbABMoRARZ4y9HJ4q4yASZQcAJckgkwASbABJiASoAFXpUEb5kAE2ACTIAJMAEmUPEI8BEpBFjgVSDwPxNgAkyACTABJsAEmEDFJcACb8U9t3xkTKDgBLgkE2ACTIAJMIEKTIAF3gp8cvnQmAATYAJMgAkwgcIR4NIVkwALvBXzvPJRMQEmwASYABNgAkyACVgJsMBrBcEbJlBwAlySCTABJsAEmAATKE8EWOAtT2eL+8oEmAATYAJMoCwR4L4wgXJCgAXecnKiuJtMgAkwASbABJgAE2ACt0aABd5b48Z7FZwAl2QCTIAJMAEmwASYQKkSYIG3VPFz40yACTABJlB5CPCRMgEmUFoEWOAtLfLcLhNgAkyACTABJsAEmECJEGCBt0QwF7wRLskEmAATYAJMgAkwASZQtARY4C1anlwbE2ACTIAJFA0BroUJMAEmUGQEWOAtMpRcERNgAkyACTABJsAEmEBZJFC+Bd6ySJT7xASYABNgAkyACTABJlCmCLDAW6ZOB3eGCTABJnBrBHgvJsAEmAATyJ8AC7z5s+EcJsAEmAATYAJMgAkwgfJFIM/essCbJxZOZAJMgAkwASbABJgAE6goBFjgrShnko+DCTCBghPgkkyACTABJlCpCLDAW6lONx8sE2ACTIAJMAEmwASyCFSWEAu8leVM83EyASbABJgAE2ACTKCSEmCBt5KeeD5sJlBwAlySCTABJsAEmED5JsACb/k+f9x7JsAEmAATYAJMoKQIcDvllgALvOX21HHHmQATYAJMgAkwASbABApCgAXeglDiMkyg4AS4JBNgAkyACTABJlDGCLDAW8ZOCHeHCTABJsAEmEDFIMBHwQTKDgEWeMvOueCeMAEmwASYABNgAkyACRQDARZ4iwEqV1lwAlySCTABJsAEmAATYALFTYAF3uImzPUzASbABJgAE7g5AS7BBJhAMRJggbcY4XLVTIAJMAEmwASYABNgAqVPgAXe0j8HBe8Bl2QCTIAJMAEmwASYABMoNAEWeAuNjHdgAkyACTCB0ibA7TMBJsAECkOABd7C0OKyTIAJMAEmwASYABNgAuWOwP8BAAD//yzXH74AAAAGSURBVAMAXLhqXXY82rgAAAAASUVORK5CYII="
      },
-     "metadata": {},
+     "metadata": {
+      "image/png": {
+       "alt": "Two lines over validation sessions on a shared axis of mean squared one-minute log return. A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A thicker amber line is the HAR forecast, following the same path closely but smoother, and rising above the blue line where it peaks. Dotted vertical rules divide the axis into consecutive validation windows."
+      }
+     },
      "output_type": "display_data"
     }
    ],
@@ -2777,19 +2793,26 @@
     "    height=440,\n",
     "    margin={\"t\": 120},\n",
     ")\n",
-    "fig.show()"
+    "show_plotly_with_alt(\n",
+    "    fig,\n",
+    "    \"Two lines over validation sessions on a shared axis of mean squared one-minute log return. \"\n",
+    "    \"A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A \"\n",
+    "    \"thicker amber line is the HAR forecast, following the same path closely but smoother, and \"\n",
+    "    \"rising above the blue line where it peaks. Dotted vertical rules divide the axis into \"\n",
+    "    \"consecutive validation windows.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "61a18d47",
+   "id": "52777228",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003995,
-     "end_time": "2026-08-10T14:30:21.623622+00:00",
+     "duration": 0.003988,
+     "end_time": "2026-08-11T11:17:49.566855+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:21.619627+00:00",
+     "start_time": "2026-08-11T11:17:49.562867+00:00",
      "status": "completed"
     }
    },
@@ -2816,20 +2839,20 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "3371ce61",
+   "id": "36a35d57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:21.632296Z",
-     "iopub.status.busy": "2026-08-10T14:30:21.632216Z",
-     "iopub.status.idle": "2026-08-10T14:30:21.635234Z",
-     "shell.execute_reply": "2026-08-10T14:30:21.634994Z"
+     "iopub.execute_input": "2026-08-11T11:17:49.575626Z",
+     "iopub.status.busy": "2026-08-11T11:17:49.575498Z",
+     "iopub.status.idle": "2026-08-11T11:17:49.579089Z",
+     "shell.execute_reply": "2026-08-11T11:17:49.578787Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007863,
-     "end_time": "2026-08-10T14:30:21.635632+00:00",
+     "duration": 0.008455,
+     "end_time": "2026-08-11T11:17:49.579354+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:21.627769+00:00",
+     "start_time": "2026-08-11T11:17:49.570899+00:00",
      "status": "completed"
     }
    },
@@ -2887,14 +2910,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c84f9d1a",
+   "id": "0d25aea1",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003952,
-     "end_time": "2026-08-10T14:30:21.643552+00:00",
+     "duration": 0.003953,
+     "end_time": "2026-08-11T11:17:49.587404+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:21.639600+00:00",
+     "start_time": "2026-08-11T11:17:49.583451+00:00",
      "status": "completed"
     }
    },
@@ -2908,19 +2931,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "2f90d399",
+   "id": "68030287",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:21.651946Z",
-     "iopub.status.busy": "2026-08-10T14:30:21.651879Z",
-     "iopub.status.idle": "2026-08-10T14:30:21.654259Z",
-     "shell.execute_reply": "2026-08-10T14:30:21.653994Z"
+     "iopub.execute_input": "2026-08-11T11:17:49.595847Z",
+     "iopub.status.busy": "2026-08-11T11:17:49.595782Z",
+     "iopub.status.idle": "2026-08-11T11:17:49.598026Z",
+     "shell.execute_reply": "2026-08-11T11:17:49.597724Z"
     },
     "papermill": {
-     "duration": 0.0072,
-     "end_time": "2026-08-10T14:30:21.654709+00:00",
+     "duration": 0.007115,
+     "end_time": "2026-08-11T11:17:49.598424+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:21.647509+00:00",
+     "start_time": "2026-08-11T11:17:49.591309+00:00",
      "status": "completed"
     }
    },
@@ -2959,19 +2982,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "eef87b4e",
+   "id": "0d217401",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:30:21.663012Z",
-     "iopub.status.busy": "2026-08-10T14:30:21.662949Z",
-     "iopub.status.idle": "2026-08-10T14:57:39.013170Z",
-     "shell.execute_reply": "2026-08-10T14:57:39.012694Z"
+     "iopub.execute_input": "2026-08-11T11:17:49.606852Z",
+     "iopub.status.busy": "2026-08-11T11:17:49.606793Z",
+     "iopub.status.idle": "2026-08-11T11:45:27.012730Z",
+     "shell.execute_reply": "2026-08-11T11:45:27.012275Z"
     },
     "papermill": {
-     "duration": 1637.354871,
-     "end_time": "2026-08-10T14:57:39.013537+00:00",
+     "duration": 1657.410907,
+     "end_time": "2026-08-11T11:45:27.013314+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:30:21.658666+00:00",
+     "start_time": "2026-08-11T11:17:49.602407+00:00",
      "status": "completed"
     }
    },
@@ -3047,14 +3070,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ba43a4c",
+   "id": "6034dd47",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004125,
-     "end_time": "2026-08-10T14:57:39.022179+00:00",
+     "duration": 0.004337,
+     "end_time": "2026-08-11T11:45:27.037547+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.018054+00:00",
+     "start_time": "2026-08-11T11:45:27.033210+00:00",
      "status": "completed"
     }
    },
@@ -3085,19 +3108,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "7a237310",
+   "id": "0a938e68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:57:39.031357Z",
-     "iopub.status.busy": "2026-08-10T14:57:39.031273Z",
-     "iopub.status.idle": "2026-08-10T14:57:39.033740Z",
-     "shell.execute_reply": "2026-08-10T14:57:39.033361Z"
+     "iopub.execute_input": "2026-08-11T11:45:27.046857Z",
+     "iopub.status.busy": "2026-08-11T11:45:27.046730Z",
+     "iopub.status.idle": "2026-08-11T11:45:27.049806Z",
+     "shell.execute_reply": "2026-08-11T11:45:27.049312Z"
     },
     "papermill": {
-     "duration": 0.007743,
-     "end_time": "2026-08-10T14:57:39.034033+00:00",
+     "duration": 0.00846,
+     "end_time": "2026-08-11T11:45:27.050135+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.026290+00:00",
+     "start_time": "2026-08-11T11:45:27.041675+00:00",
      "status": "completed"
     }
    },
@@ -3132,13 +3155,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dea5e0fd",
+   "id": "426a2011",
    "metadata": {
     "papermill": {
-     "duration": 0.004471,
-     "end_time": "2026-08-10T14:57:39.042840+00:00",
+     "duration": 0.004129,
+     "end_time": "2026-08-11T11:45:27.058357+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.038369+00:00",
+     "start_time": "2026-08-11T11:45:27.054228+00:00",
      "status": "completed"
     }
    },
@@ -3154,19 +3177,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "f442afe6",
+   "id": "30db0c96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:57:39.052626Z",
-     "iopub.status.busy": "2026-08-10T14:57:39.052507Z",
-     "iopub.status.idle": "2026-08-10T14:57:39.057664Z",
-     "shell.execute_reply": "2026-08-10T14:57:39.057393Z"
+     "iopub.execute_input": "2026-08-11T11:45:27.067777Z",
+     "iopub.status.busy": "2026-08-11T11:45:27.067683Z",
+     "iopub.status.idle": "2026-08-11T11:45:27.073138Z",
+     "shell.execute_reply": "2026-08-11T11:45:27.072705Z"
     },
     "papermill": {
-     "duration": 0.010856,
-     "end_time": "2026-08-10T14:57:39.058099+00:00",
+     "duration": 0.010571,
+     "end_time": "2026-08-11T11:45:27.073460+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.047243+00:00",
+     "start_time": "2026-08-11T11:45:27.062889+00:00",
      "status": "completed"
     }
    },
@@ -3195,20 +3218,20 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "743178a7",
+   "id": "2120ff61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:57:39.067118Z",
-     "iopub.status.busy": "2026-08-10T14:57:39.067030Z",
-     "iopub.status.idle": "2026-08-10T14:57:39.069007Z",
-     "shell.execute_reply": "2026-08-10T14:57:39.068629Z"
+     "iopub.execute_input": "2026-08-11T11:45:27.082311Z",
+     "iopub.status.busy": "2026-08-11T11:45:27.082233Z",
+     "iopub.status.idle": "2026-08-11T11:45:27.084218Z",
+     "shell.execute_reply": "2026-08-11T11:45:27.083851Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007039,
-     "end_time": "2026-08-10T14:57:39.069448+00:00",
+     "duration": 0.006982,
+     "end_time": "2026-08-11T11:45:27.084586+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.062409+00:00",
+     "start_time": "2026-08-11T11:45:27.077604+00:00",
      "status": "completed"
     }
    },
@@ -3224,14 +3247,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7493beb9",
+   "id": "ae526bbe",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00417,
-     "end_time": "2026-08-10T14:57:39.077884+00:00",
+     "duration": 0.004024,
+     "end_time": "2026-08-11T11:45:27.092719+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.073714+00:00",
+     "start_time": "2026-08-11T11:45:27.088695+00:00",
      "status": "completed"
     }
    },
@@ -3248,19 +3271,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "50f2875e",
+   "id": "ce82c8cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:57:39.086743Z",
-     "iopub.status.busy": "2026-08-10T14:57:39.086581Z",
-     "iopub.status.idle": "2026-08-10T14:57:39.090775Z",
-     "shell.execute_reply": "2026-08-10T14:57:39.090495Z"
+     "iopub.execute_input": "2026-08-11T11:45:27.101899Z",
+     "iopub.status.busy": "2026-08-11T11:45:27.101799Z",
+     "iopub.status.idle": "2026-08-11T11:45:27.105282Z",
+     "shell.execute_reply": "2026-08-11T11:45:27.104898Z"
     },
     "papermill": {
-     "duration": 0.009207,
-     "end_time": "2026-08-10T14:57:39.091136+00:00",
+     "duration": 0.008918,
+     "end_time": "2026-08-11T11:45:27.105716+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.081929+00:00",
+     "start_time": "2026-08-11T11:45:27.096798+00:00",
      "status": "completed"
     }
    },
@@ -3314,19 +3337,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "cbc5d1a0",
+   "id": "8126c00f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T14:57:39.116079Z",
-     "iopub.status.busy": "2026-08-10T14:57:39.115981Z",
-     "iopub.status.idle": "2026-08-10T15:40:22.859721Z",
-     "shell.execute_reply": "2026-08-10T15:40:22.859234Z"
+     "iopub.execute_input": "2026-08-11T11:45:27.114750Z",
+     "iopub.status.busy": "2026-08-11T11:45:27.114669Z",
+     "iopub.status.idle": "2026-08-11T12:34:55.900838Z",
+     "shell.execute_reply": "2026-08-11T12:34:55.900449Z"
     },
     "papermill": {
-     "duration": 2563.76481,
-     "end_time": "2026-08-10T15:40:22.860258+00:00",
+     "duration": 2968.791592,
+     "end_time": "2026-08-11T12:34:55.901515+00:00",
      "exception": false,
-     "start_time": "2026-08-10T14:57:39.095448+00:00",
+     "start_time": "2026-08-11T11:45:27.109923+00:00",
      "status": "completed"
     }
    },
@@ -3402,13 +3425,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fbd4b60",
+   "id": "67f26739",
    "metadata": {
     "papermill": {
-     "duration": 0.008039,
-     "end_time": "2026-08-10T15:40:22.876396+00:00",
+     "duration": 0.004513,
+     "end_time": "2026-08-11T12:34:55.910923+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:40:22.868357+00:00",
+     "start_time": "2026-08-11T12:34:55.906410+00:00",
      "status": "completed"
     }
    },
@@ -3430,19 +3453,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "264b5639",
+   "id": "8df61398",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:40:22.900102Z",
-     "iopub.status.busy": "2026-08-10T15:40:22.899958Z",
-     "iopub.status.idle": "2026-08-10T15:41:43.003091Z",
-     "shell.execute_reply": "2026-08-10T15:41:43.002765Z"
+     "iopub.execute_input": "2026-08-11T12:34:55.920515Z",
+     "iopub.status.busy": "2026-08-11T12:34:55.920397Z",
+     "iopub.status.idle": "2026-08-11T12:36:16.621766Z",
+     "shell.execute_reply": "2026-08-11T12:36:16.621305Z"
     },
     "papermill": {
-     "duration": 80.121163,
-     "end_time": "2026-08-10T15:41:43.007514+00:00",
+     "duration": 80.711086,
+     "end_time": "2026-08-11T12:36:16.626425+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:40:22.886351+00:00",
+     "start_time": "2026-08-11T12:34:55.915339+00:00",
      "status": "completed"
     }
    },
@@ -3494,13 +3517,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5ec8b05",
+   "id": "2017c866",
    "metadata": {
     "papermill": {
-     "duration": 0.004379,
-     "end_time": "2026-08-10T15:41:43.016217+00:00",
+     "duration": 0.004215,
+     "end_time": "2026-08-11T12:36:16.635009+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:43.011838+00:00",
+     "start_time": "2026-08-11T12:36:16.630794+00:00",
      "status": "completed"
     }
    },
@@ -3528,19 +3551,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "7c74c1c7",
+   "id": "e586e472",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:43.025505Z",
-     "iopub.status.busy": "2026-08-10T15:41:43.025415Z",
-     "iopub.status.idle": "2026-08-10T15:41:43.052858Z",
-     "shell.execute_reply": "2026-08-10T15:41:43.052402Z"
+     "iopub.execute_input": "2026-08-11T12:36:16.643943Z",
+     "iopub.status.busy": "2026-08-11T12:36:16.643856Z",
+     "iopub.status.idle": "2026-08-11T12:36:16.676882Z",
+     "shell.execute_reply": "2026-08-11T12:36:16.676447Z"
     },
     "papermill": {
-     "duration": 0.032746,
-     "end_time": "2026-08-10T15:41:43.053292+00:00",
+     "duration": 0.037961,
+     "end_time": "2026-08-11T12:36:16.677163+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:43.020546+00:00",
+     "start_time": "2026-08-11T12:36:16.639202+00:00",
      "status": "completed"
     }
    },
@@ -3584,19 +3607,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "3c815e35",
+   "id": "9c9066ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:43.063550Z",
-     "iopub.status.busy": "2026-08-10T15:41:43.063459Z",
-     "iopub.status.idle": "2026-08-10T15:41:44.371367Z",
-     "shell.execute_reply": "2026-08-10T15:41:44.370857Z"
+     "iopub.execute_input": "2026-08-11T12:36:16.687261Z",
+     "iopub.status.busy": "2026-08-11T12:36:16.687138Z",
+     "iopub.status.idle": "2026-08-11T12:36:18.189963Z",
+     "shell.execute_reply": "2026-08-11T12:36:18.189470Z"
     },
     "papermill": {
-     "duration": 1.313152,
-     "end_time": "2026-08-10T15:41:44.371768+00:00",
+     "duration": 1.508185,
+     "end_time": "2026-08-11T12:36:18.190234+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:43.058616+00:00",
+     "start_time": "2026-08-11T12:36:16.682049+00:00",
      "status": "completed"
     }
    },
@@ -3810,7 +3833,11 @@
       },
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAG4CAYAAACnwzTIAAAQAElEQVR4AeydBWAURxfH/wfBpbiWDyjuDsXd3d2luBd3d3crbi1SXIsVt+IUd4dQiuu3b5K9Xo6zkEtyd/kH3u7szJs3M7+Z3Xs3O7sX6v37d18oZMAxwDHAMcAxwDHAMcAxwDHgqWMgFPhHAiRAAiQAgBBIgARIgAQ8lQAdXk/tWbaLBEiABEiABEiABL6FgAfmocPrgZ3KJpEACZAACZAACZAACfxHgA7vfywYIgEScJwANUmABEiABEjAbQjQ4XWbrmJFSYAESIAESIAEXI8Aa+QOBOjwukMvsY4kQAIkQAIkQAIkQALfTIAO7zejY0YScJwANUmABEiABEiABIKPAB3e4GPPkkmABEiABEggpBFge0kgWAjQ4Q0W7CyUBEiABEiABEiABEggqAjQ4Q0q0izHcQLUJAESIAESIAESIAEnEqDD60SYNEUCJEACJEACziRAWyRAAs4hQIfXORxphQRIgARIgARIgARIwEUJ0OF10Y5xvFrUJAESIAESIAESIAESsEWADq8tOkwjARIgARJwHwKsKQmQAAlYIUCH1woYRpMACZAACZAACZAACXgGgZDm8HpGr7EVJEACJEACJEACJEACDhOgw+swKiqSAAmQgCcRYFtIgARIIOQQoMMbcvqaLSUBEiABEiABEiCBEEnApsMbIomw0SRAAiRAAiRAAiRAAh5FgA6vR3UnG0MCJBBIBGiWBEiABEjAjQnQ4XXjzmPVSYAESIAESIAESCBoCbhnaXR43bPfWGsSIAESIAESIAESIAEHCdDhdRAU1UiABBwnQE0SIAESIAEScCUCdHhdqTdYFxIgARIgARIgAU8iwLa4CAE6vC7SEawGCZAACZAACZAACZBA4BCgwxs4XGmVBBwnQE0SIAESIAESIIFAJUCHN1Dx0jgJkAAJkAAJkICjBKhHAoFFgA5vYJGlXRIgARIgARIgARIgAZcgQIfXJbqBlXCcADVJgARIgARIgARIwH8E6PD6jxe1SYAESIAESMA1CLAWJEACDhOgw+swKiqSAAmQAAmQAAmQAAm4IwE6vO7Ya47XmZokQAIkQAIkQAIkEOIJ0OEN8UOAAEiABEggJBBgG0mABEIyATq8Ibn32XYSIAESIAESIAESCAEE6PCadDKDJEACJEACJEACJEACnkeADq/n9SlbRAIkQAIBJcD8JEACJOBRBOjwelR3sjEkQAIkQAIkQAIkQALmBL7d4TW3xGMSIAESIAESIAESIAEScEECdHhdsFNYJRIgAfciwNqSAAmQAAm4NgE6vK7dP6wdCZAACZAACZAACbgLAZetJx1el+0aVowESIAESIAESIAESMAZBOjwOoMibZAACThOgJokQAIkQAIkEMQE6PAGMXAWRwIkQAIkQAIkQAJCgBJ0BOjwBh1rlkQCJEACJEACJEACJBAMBOjwBgN0FkkCjhOgJgmQAAmQAAmQQEAJ0OENKEHmJwESIAESIAESCHwCLIEEAkCADm8A4DErCZAACZAACZAACZCA6xOgw+v6fcQaOk6AmiRAAiRAAiRAAiTwFQE6vF8hCXkRsZJkw47d+4O04dXqtcbgkZOCtExLhQVm2xv+1AU9+o+0VCzjSMAugRlzl6JAyZp29Zyt4CrnpqV2Jc9UCL9v3GEpyV9xyTIWNNo5c/5vRPs+E54+e65snD53UR0/eeqtjp252b7rT5St1hSxk2ZH3WYdsXvfIVWWf8twbGz416rr68vnVPkazRAveU7Fz5EaN/ypK3oOGGVTtVXHvujYY7BNHSa6PwE6vO7fh1ZbULxiA3UxlYu5JclTrKrVvO6cMGXmQhQuWyfYm5A6ZTIkTZwo2OvBCtgn8L80ebFxyy77ikGoET9eHGTOmDbQSjx56hzkuvD8nxeBVkZwG7Z2LfgxZxbEjBHNYvUiRYyAQvl/RJgwXirdmg2V6M/NwGETkTNbRty+sB9L5kxAtO+iqrJ0M472SWCPDb0+rrYfMHQCsmfJgBtn9yl+rlY/1se1CdDhde3+CVDtRg/ugfUr5yiZOm6QsjVueG91LPGTRw9QcdwEDoGeXVrjpybB73gHTutoNbAJVCxbDJNG9w/sYkKkfXE28+XObrHtyZImxtplM/Fd1CgW0wMSeevOPeTKngXhw4dTZuQLjZSlDvyxCaljw5yfP5BRlQRAh9eDB4FcTPPnyQGRLBnTqZZmSJtKHUtcNu2bsorUNg8fPUH1+q0hM135ilfHilUbtNj//l+8dA31mndC6qzFkCJzYcgtIHszQ6MnzkaJSg0QN1kONZPUuFW3/wxqoU+fPqNTzyFIk704MvxYGoNGTMLHjx+1FJ//Dx8/QYv2vVS6lCn579y975OobQ8eOaHsbtmxF4XK1Ibc5uqvzaD0GTwW+kyJzGDNX/ybpm39v722Hz95BpVq/4TEafMha75yEPtv3rw1Ghw7eS5KV2kMmQnKWagioifKrNJMlzSIjtTFXEaOn6l037//gCGjJiNHwQpIlDoPylVvhgOHj6s0fRMrSTYsWr7GZj/puvr+8+fPkNufRcrVRcKUuSGz/rN+WaYnwx5jqbe0bfqcJcheoILqp+Fjp+HTp09Ys36buj0rfdO93whIG3TDclu8Y/fBqNO0gxov0r8Dhk3wV//qZUt9hcsPGQqiWdseePDosV6M2m/7Yx9KVW6k+kfqOGLcDFU/lahtYtnhli1/ebz496W6RSr9kzZHCS2X5f+iJ8tUpD5yrtRs2BZSvmifv3gF3foOR67CldV5VLFWC5w6e0GSjCJceg8agzad+yFdzpJqXFkax/sOHFX9ZrqkQZhPnrEQcn5KX8pdjHWbdhhtS8DeOSc6Ijdv3YXkl3CSdPkh7ZZzTY5F7J2b3s//Qdfew9X5IOO1Sp1WOHvhkmS1KAuWrlLnsbTBVKFlhz6o37yzMWrZb+sg57K0r1Dp2vhl0a/GNPPAy1ev1Tkj1xipg+RbvW6LUW3pr+vUuWrpWmC6pME3g3FnuqTBmo12XQdAzm9jJi0g51rG3GUg41U79PNfxoYwlvFTq3E7xVuOdRFle30iOrrIOW06Nhw9V/T8+t7Wdf36zduqnucuXNbV1X7hstXqnP7w4YM6tmVDFCyNeWfwW7l6o5iHveuzUjLZyLiR5QspsxRR17NeA0ebpDLoyQTo8Hpy7/qjbROnzUOmDGkwbdxgpEzxA1p27IMbN+8oC48eP0XFms2RKX1arP91Lrb9vhDffRcZNbQPe7nIKyWzzR97D2D2/GUY3Kczrp/Zi71bV2i38jL50VquOdUfP3zEKG0munql0pg0YwFW/e7zgfXlyxfUbNAOF/++itVLZmD774tw7/5DVKnbEvqFFr5/YyfPwZghPXHn4gH83KE5hvTtgiyZ0uH5nVNKGtWr5qtpeWer7XfvPUCFmi0QL05sHN+3HlPGDsQy7YO0a+9hfoz9deY8jv91FisXTMXN83/6SZODLu2aqrrodVowc6xEa0wyqn3/YeM1XiswUmNx6uAmyHKIirV+wuWrN1W6vpn9y3K0bFYPolOnRkU//aTrmO5Hjp+BidN/QfuWjXDh+HaMGtQdb96+UyqOMr56/Sa2//GnxrYFGtWtpjn2i1S5K1atR7OGNTWphflLVmHF6g3Krr5ZsvJ3rX2ZcXTP75gwsq+WvhFjJs1RyY6WLVyl339dOA1rl8/EtRu3MWLsDGVDNnv+PIz2XQeiUb2qqn+mjx+MI8dOYeDwiZJsFFvcpF+jRomsbpFK/5w/us2YzzxQt2lH7cvUeUweMxDnj21H88a18c8//yq1f168QIZ0qbUxMAX7t/+KIgXzoEqdll856PM0Jy7ZD4mxTzsnFs7yGQdiYKzJOJbxK3GmMmrCTKzbvAMD+3TSyt6G7h1bQr5EyBc+0XPknBM9kcT/S4hdG5dKEDfO7VNjc9ak/8a0rXNTMtVv3gX/vnyJ2ZOH468Dm1CudGHVVjlfJN1cKpQphmfez7Fb6y897a02Dtdv3okqFUqpKHHe5Yt07Wrlce7oVjRtWEN9IV68Yq1KN9+8f/8e4cKFx/jhfdX50KZ5ffQaOMb4PEKd6hX8fS0wL8OajXq1KmHDll0wXecr60sfal/GalYtZ24GaVMnV4wjRAiP5fMnq7CMNdPZXXt98pVRswh754qZOuxd12U5Vq7smbUvtj7XZD3/6nVbUbl8CYQJE8auDT2P+Zh3Br8aVcpCxpsj12e9HrLvrY2R9doXxfkzRmPn+sV4+Ogp/thzQJIoHk6ADq+jHezherWqVUCfbu20D64imDVpKMQBOP7XGdVquVhlTJ9Kc3iaI0WyxGpd6vAB3XDu/GXtw/+c0jHf3H/wGDGiR9McnkyIGDECMmqOQKtmdf2oZUyXSnMcBqB86aLo16M9ihXKgyPHTysdcWTkAj5pTH+kSZUMSRJ/r93eHYBLV25g07Y9Skff9OjcEtmzZoSXlxciR4qoRzu8t9V2mc0Qm+NH9EGsmNGRJ1c29O3eDuLMPX7yzE8Z4tRJPYWdnwSzA5lBatO5Lwb06ojCBXJDZovnLFiJru1boEiBPIrbiIE/I0H8OJi7cLmf3E0aVEdRzZGKHu07tG5eD3FixcSJU2f96OgHH7XZ8gnTfkGvrq1RqVxx1afiSHVo1UipOMr448dPWPbLRMgHuTjuZUsVxt4/j2DR7HHqg697p59QvEg+babFbz1krV3H1o0h6xSlzuKQzF/iM9vuaNnSTuEkXGUM1a1RQRsjf6n6y2b81HnK6axVtbzqnxzZMmntbQUZs5Kui3+46XnM9zLrKjJt/CD8mCOLGmvFCuVF9cpllGrunFlRv1ZliOOS6PsEEM7ptTsqm7buUun6Ru62dG7bVPWz6VixNY7fvXsP6cvBmrMrLOV2e6niBdBQ+wKyYOlvyrQj55xSdGBj69zcu/+IOu+nal/+sml3iWQtbJP6NZA1czqs0pwhS+alH0sVK4jVv//nPG3Y8od2zoZG6eIFVZbZ85ejTMlCkGVAMmaEpTg1s+YtU+nmG7m+yBfcdGlSKJbSD/KFbPlv681VnX4sjmCKZElgWtby3zZAHHvpG6cX6IBBYWzrXDE3IeeIvet6lQol8ZtJn4mDKedu1YqllTlHbIii+Zh3Fj//XJ+lHjK7K3l6dmmlruVxYseEXLdfvX4tyRQPJxDKw9vH5jlIIG3qFEZNcRz/p31g67MXaoZv1351e0u/BSe37eUicd13FtiY2TdQvHA+PH7yFIXL1FG3HZdrs4FyO883We3SpEqu9vpGHIUnT32cyGs3biFe3NjInCGtnoxUKZIqkfoYI7VAVm02V9vZ/N9vyDg/9b91+55R33bbbyF/3hyQmRk9g7RNwlJH2Yuk0mbFHfmgEye5btNOKKV9yIszKHlv3LqrZq2LFc4rh0qkD8QZvnb9ljrWNwnix9WDah83TiyN8zMVNt9cuXYL4ijlzOazxMI8XeofzwHGAibLKwAAEABJREFUMhsZLlxYY/Yk2uxgSq0vZIZHj1Tj5ZnfemRIl1JPVvtM2h2EBw8f4/XrN9pM7S2H+jdRwvgqr76JFTOmmlXSj/++fA3ytg99XMq+WIX6kA+2+w8e6WralwfHuRkzmQWuXL2h7MgaT7MkdSjtkuUUhbRb8bGTZlfjTZyD23fuq3R9kzljGj3oZ29rHMt5Jn1ZqnIjZVfaKdJ/6Hhcv3FH2ZFxae+cU4oObGydm1ev3YSc+7GSZPNTly3b90K/K2SpiKoVS2mzon9AZnYlffX6LahUroRxPetlja98gZA0XeT4wqWrkDsCepzpXpZAlK3WVC0hER4jxk2HOW9TfWeGm9SvjqW//q5M/vPiX2zc+gdqVy+vjoNjY+9cMa+TXEe327muVy5fEnfuPjAur1q9bpua9BCHVew5YkP0LI15Z/C7ql0fHbk+Sx1E5LovY6lgvtxyqCRK5EjIlzu7CnPj2QTo8Hp2/zrcOi+v0H50DQaD9iHjE2UwGFBV+0Yvt+DMpVql0j5KZlv55rxv60rU0WbkXmkOzvCx01GodC0/zoqlMoEvRkumDpUeGTq033pKfITw4WVnU9r+1BBHdv9ulP8lSmDUt1SPL/9VA+ZlhjZjJYYcqYMsxajXrBNix4qBqWMHSTY/Ik6uaYRXaJ+nxE3jQoX6+pQ1rauprh42GAx68Ku9I4y9zJgbDIavmBgMMl5MoMH633vftX+OlG25vf+VYzAYMHZYL5iPSzmOHy+OsRKW7RiTHQ4YDNZZyu30v86cw+SxA3Dp5E5VJ5mN1durFxLB94El/Vjf2xpDBoNPuQd3rlJ2pX26HPpjtTLhyDmnFB3YWDon9HPTYDBAytLLN93LQ7HWzOszuZu374b383+wbeefkBlEU33zc03qIQ6KweDTflNdec5g5PiZ2t2hdtp5vVZxkbtU5rxN8zgzLHc85IvIsROnsezX9RqTWCic/z9HypllOWLL8hj/71wxt2Ew2L+uSz8XK5QHa9ZvV9lXa19SqlT475pvMNi3IRktjXln8TMfM5auz1IHU/HyCmV6CEfy+MnAA7ck4LfXndYEGvIkAqlSJMP+Q8fUrXf/tEtmI1s0ro3hA7rh4I5VuKXNdB074bNMwp6dH5L8T5tZuA/TWbonT70h3+itzbDpNsOHD4svn/1e6OXCnTJ5Euii69rbJ0v6P5w+e9GP2sm/zqtjqaMKOLjp0G0w7mmzjkvnToD5jGlozak8fdbHrm5Olir8oJWvH/t3n/yH/6lyjhz/bwmAqQ2pvzwE+C2MTe1YC585d8lP0qkzFxA3diy1xMFZZafV7hL8sfegn3K+5UCczc9fPtvMmly7hS3riWVm3JKiPHxWrlRRZEibCtGjfadm189d9PvAj6V8jsQlS5pI3WXYudv2WkP/nHPhwoVTRVtbh68SLWxSpfxBfXGVh8EsJFuNki84VbRZ3jXrt2kO1FZ8nzAeCuTNadSXJQKnz/5tPJbAydPnIH0sYXM5dOwv5M2VDTLbKHcqJP3MOb/nqqVrgej5R6zZkDs61bSJgGW/bcDCZavUchaD4WvH3D9lfWuf+KcMXdfR67pMdqzdsBXy8Jr0ec2qZXUTcNSGMYNJwBn8/Ht9lokOg8GgXdP/G2fyIOXJU36vvSbVZNCDCNDh9aDODKymNKlfTZlu3r4nTmsfKPIBeeHvK+qtCnIrTyWabeTl8PJGAbm1LEl79x9VT+gnTfK9HNoV+SCUW+Adug3E35evQ26Vdu45BIm1mVl9psiakaSas3zrzj3Ye4uEtfym8bKOUG6DyRskxOGWB6IGj5qEujUqqplaU11bYXlTxO8bt2PhzDGIFze2H1VZLtGicS3ILLh8sXjm/RyjJszCmXN/o3mjWn50/XMgM8YdWzfG0NFTsXbDdvUmAvnAmjh9vjITEMbKgJ2NrMGWsqQfdu45gKmzF6GxdhtYsjmr7C7tm0Henzt87DQ1RmRsyjICmfmTchwVWbYhH+i29OXNJnLrs1XHvjh09CRkbO/YvR+/rtmksmVIlwp79x9R41zGSqtOfaHOD5UasI30pazxHjdlrnYbfZ16AEzWfv+2djP0h7r8e84l+j6++kJ09rzfLyb2aiprlWXmuk2Xfvhj7wG1REHenCFvKREutvJXrVAKW3fuxaLla1G1QkkYDP85iDLWZU2sPH0vY2bN+q1YuHQNWjSpbdFkhrQp1YOicr7I3RNhs+2PfX50nXEtsGWjbs2KWn/8jvMXr2jXhAp+yv6Wg2/tk28py9HruqyrlrEm11/pe3mYTS/PURu6vvk+oPz8e32W5zEa1K6CYWOm4sLfV9XY7TtknLrjYF43HnseATq8ntenTm+RzFZtXbMAESNEUK8QSpIuPzr3HKpmW8N4eVksL3LkiJg6axG+T5VbrfNr2bE3Rg/pAfO1gRYza5Fye275L5MQOXJkVKrdAsUr1lcfjr8tmo6wYcNoGtb/F87/IzKmTw2pp6zrE2fTurbtlO8TxseGX+fg2Mkz6hVM0o6ihfJgzNBetjOapR4+dgqvXr+GvApK6qSL7pgN7NUJ8mBZx+6DkCl3GeU4/b58JpIlTWxmyX+H3Tr+hDbN62PMxFnqVUKyvlWeJBcrAWEs+e1JE825PaN9QZJ+6Nh9MGpVLQd56E3yOats+QBev3IO5GHHIuXqIk224pC3Hbx//06KcVja/dRQG68L1Vi19VoyeatCxvRpIK8Vk7HdrE0PiJMtBQ3r/7MKyw+6FChVE6lS/IAiBZ13i7tz2ybq9r08KJQhV2nkL1lDObvyQwlSvn/POVm72KlNE1So2Vy12/S1ZGLPliyYNRYliuRHrwFjkCxjIdRu3EEbs4e18zUSbP3l/TEbZKmJfPGqrDm/proVyhTD+BF9MG3OYqTLURITp83HoD6dUK9mJVM1Y1geUCtbshCKlquHnIUqQxz3Tm2aGtMl4IxrgS0b8vBi4kQJNRb5kDBBPCkyQBKQPvFvwY5e1yNFjAi5c3FYm1GvXL6En2IcteEnk8lBQPl9y/V5aP+uyJ0zKyrX/gk/Fq2iXmEoY8+kWgwGIoHgNE2HNzjpB2HZaX1fiyNPsZsX++TGcRQrlNdP9N6tK9CyaR1jnDxQJq8tOnVgE25d2I/Nq3/BAm22MmLECEYd00DRgnkgawv19X03zu3TZitrG1V+WzwNfbu3Nx5LYMTA7prNsRJUEk+bCZ03bSQuHNuOy3/t0tLGQG5JqURtIxctsR/ebE2kOFPyuh9JE7H1WjJH2i5vNli3YrZq94k/N2Bwny7q9rJWBfW/S7umioc6MNksmDkW0iaJmj5hsFpjKPUxFXnDgaSLEy/rD4/uWYfbFw8oJ1veCCFpujhSV11X38tSibY/NcCf23/Fw6tH8fTmCYhjpqfbY2ypbfKDGsJXtyH7of26qtd6SViX8OHCYs6UEardZw5tRv+eHdSrjPT0bylbXrh/9bTft3TIzOuapTNw7cwe/H1yJ6SvTMeWI9xKlyiouEvf2HotmXzAyxc3eZWZ6Mq4lrWI0iZZNiPtlbXiYkP6Vn7gQNhIuoilcW9tHMv5t1c7DyWfiMFggDh5O9Ytwt1LB3Fs7zpIP1QuX1KS1ds7bJ1zSsls06NzK9U/0hY5vyXZUh1lHMt4lnQRmSmTNwJIeVKXXRuXYuXCqUifJqUkWxWDwYC/9m9UZVrSlbcy7N60TLVv9+ZlaFinqh9bV07thowBiZTzXPr55P4NEJFrRbeOLYyvW9N1hJG0T6RRPZ+7VTKGdDsZ0qZS9ZG3TUgeeRuI6MpbWeRYyrFkQ9Jev34DeRCzdvUKcmhX7l8+jFLFChj15BfdpCxjhBaw1CdatJ//5mPD0nkq7ZN2+sloduDodX3GxCGKUYvG/13DdVP2bFgaT3regPITO/auzwu0zylZVie6IjJ25c0MF0/sUGNx5KAemDlxKCaM6CvJFA8mQIfXgzuXTSMB9yPAGpOA+xCYNmeJestEuVJF3KfSLlRT8nOhzggBVaHDGwI6mU0kARIgARJwHgF5HZcsS5IfLJg/Y7SfOxfOK8VzLZGfg31LNacSoMPrVJw0RgIkIARs3caUdAoJuDOBZEkTq1v8m1bNg6xDdee2BEfdyS84qLNMOrwcAx5JQP8xAvkBgFyFK6NH/5F+3togv0MvT9lbarzEL1i6ylKSipOn4eWF/3LQscdg40+ZyrE9MbdtasteXgvpdqPkHaa9Bo5G5TotsXXnPj/6W3bsxeWrN41xuQpXUk8tGyMCIdBzwChIuWK6YKla6k0Hgc1AygousTXOgrpO+lioVPsnNRbkLSolKjWAvOFCzg+9XyzVy166pTx6nNg1HWd6fHDu5de2KtZqgbGT56Jd1wGQX9CT+sxZsBzv33+Q4DeJ+fltzYgzx3zxig0gbwWxVhbjSYAEfAjQ4fXhwK0HEhgztCceXDmMOVNH4J9/XqJu007GVspDC5Zehi4KL1+9wuIVv0vQouTJlRUN6/p9mMaiooVIc9sBsWXB/FdR4mhcvnId8lBXyaL5/aTv2LUfcmvRT2QwHAQ2g2BokrFIW+PMqBREARkLly5fhzyAJWNhxtwlWLd8NuQhxGYNayFH1oxWa2Iv3WpGLcFVxplWFeP/SdPnY/WS6eqtIW1/aogM6VKpNHkDRkB+uML8/FZGLWw8ecxbaG4QRbEYErBNgA6vbT5MdXMC8pYCeQp76riB8H7+HPLjANIkeU3Wm7fv1MvUG/7UFTLTlTprMcg7PSdO+wWXLl+DzIRNnrEQ8l7QBi26oFq91pAZ3QOHT2DBkv9mgNdv2oly1ZuhUJna2LX3oJiHzBRN0OyoA20jryOTd4ua2za1dfvOPdRu0h4lKzVU+7v3Hmg5ocrs2nu4mqUtU7UJLvx9RcWbbt69e48uvYahaPl6KFutKaSdMlPVpks/nDp7UbVF7MP3T945u3XnXgwfM02lPX7yTKXIbF/pKo1Rp2kH/PvylYqTd6w2ad1d2ZaZ4ktXbqh4041w6dBtEKrUaYVZvyyDlGWpLaZ59LApA7Fjqa3yNPdPHXpDXqsmdZHZYUuzWjJL3XvQGFSt20r9WMryVetVvYX/mElz9CIh72zNW7waqtdvDelbmXGTREfyv/j3JaSt8jqvFJkLq3fRSt5RE2apPpLXmo2eOFuioI8zOZg9fxnk1WlSl3mLVkoUpI/luFHLn1U/DBg2QcWbb+SdxjIeZTYvTfbiahbSUp9Lvo8fP0LsFCpdG6K/RZvJ18eCvEdb7Ihcu3EbtRq3V+VW0XgdPXFassNSWTKe9fRjml75Gs0U11Yd+xrHibCTOx9iu6F2Tsn4sTTOLHFSBVvYWGujnJNShvSznBPyzl7JbqntEm8q3foOxx3t3Kqqnc9S18p1flLvvJZfbpN3btdp0gEtO/QxzaLC0j57Y8v8/JYvGZJPrg21GrdT/S3GHBnz1toi78SV+sm53ouV/x0AABAASURBVLRND7zXzn2xaSoyrqTMhj91Ua9CbNO5H95q1zvRsdV/pu0TXQoJeBKBUJ7UGLaFBKwRkFcL5cyWWbuF79dZmz5nMZo3qoVtaxfiwM7fEDlSJHRo3RgpU/wAmQlr17KBMnnz1l3IO1gtvbrm3v0HWLdiFsYN6432mtOnv5dVZTTbWLKtqwwcMQkF8/6IrWsXIE/O7Bg0crKehNChDWpGaubEIRimOanGBN/AkpVrtduazyCvrBrUuyPkRw9Chw6FscN6IUe2jKotib5P4KsNpEuTAiWLFkDPrq1VWuxYMVRa5ozp1CvWsmXOiEXL1qi4ISOnoFjhvNi5fjH692yvOdZDVLz5xmAwYNWSaZBXF9lqi3k+82NLbZXb73JLXtrXoHZlnDp7wTyb8VheK7VKm72LGyc25i36FasWT8P23xeqLwryQwnihIlzs2XNAkwdNxiHj/r9JTp7+ddv3qneubpuxWycPbwVmTOkxY2bdyBfMmQm/dyRrahf2++7Yy9euqa+CEi61Ee+SOlfHK5eu6m4ynjzfv5COZzGxmgB+SWo5m17oEOrRqodsm7Uyys0LPW56K5YvREv/n2F7esWYsX8SRg6agpev3njZyxIWQnixVF9L+EyJQpqJUG9k9RSWSpR24j9zj2HYtTgHmo8ZMqQBpOm/6Kl+PyX8SP25DVvMn7Mx9mrV69tcvKx8t/WWhtF4/7DR1g0exyEx6QZC9Q7kC21Xb5oir4uowb3RNw4sYxtl1coSpq8Xk5ee7h03kTIa7gkzlzsjQ3z8ztWzGhYv3Iu5FVrdWtUwtDR08xNqmNLY95aW+RckF8FlPOxXs2KVs8FGefyfm95ZVykSBGwYvUG1b+2+k9vX94fs6t6cUMCnkQglCc1hm0hAVsEQoX6erhny5weU2YuUGv5Hjx8YvVHLfLnzQFr7xyuXb0CxHZWzZY4jvfuP7RVDatp8uMWDetUUelNGlSD/KqbOtA2hQvkUT+8IS+3v3Tluhbj9//R42c0J6uy0smWJQPknbC379z3q+TAUdFCeZRW9izpcfnaDRXef+i4muWW2bABwybitDZjrBLMNvJDBAaDzy9n2WqLWbavDi219a/TF1BH4yzK8u7SH5IkkqBFKVXcx3mTF+U/0WauZfa0Wv02OH/xMsTOiVNnIT/yIS/5F04lTd6LCu3PXv50qVNgy449kB8N+fPQMcSIHk05UN7e/2hfRqZi8Yq1iKnFaaaM/4+eOIUKZYpBfk5V9OUdqRInCqlSJoP+61XyowyXzWbQpR+ja/YKF8gt6kpXxpu1Pj+o3YGQNlZv0BYyG/7kmTf+1u5YqMx2NtbK0rNJusyO9hwwGjIe1m7YBvnJaD29eJF8Khg/bhzj+FERvhtxNG1x8lUz7qy1URRy58hiPCejRoms3ocbkLaLTXtib2yY55efrF69bivkLsLchStx4dIVcxV1bGnMW2vLyVPnjeeCjIkfrJwL8pPMSRJ/r+wXK5wPx0+e1e683Fez2z0HjIal/tPbpzJxQwIeRuBrD8DDGsjmkIBO4PLV60j+Q2L9UO0b16+uzVb1RLy4sbQPpc5qpk4lmG3C2fh1t9ChvYza8stznz59hpcWZzrT++njJ6OOtYDMYMrMnaSHCxtWdkbR48XRkVudxgSTgFfo0MajMF5h8EX7Z4xwMBA2TBilqcr58FGFxc6K+ZONM2I3z/+p4s03YcP55JV4W22RdFtiqa1iL7RJ+8Ka8TG1p7OTPJXLlzDW++DOVejctikkPlSo/1jJz/b6J3/mjGnVmugMaVNh1PiZWLN+m/ohEplRLZA3F/48eAy9Bo41NanCpuWECeOl6iEJpv1mMBjw4aMPd0kTEf7SnxI2F9O8oiO60r4+3doa2y0/3JIre2bzrBaPJb/YsZioRUq6/IKczOKKbFkzX/3ghJak/uv1CaV9ufzoO35Ugu8mQoTwaubZFidfVeNOtykRUjepg4S9tFlu2YsYDBo3rbyAtF3s2BN7Y8s8/+z5KzRH/BFGDOwG+VGS169fm6uoY70tiptv/1tri8SHduBcED1l3Hcjx8LOVv/p7fPNwh0JeBSBUB7VGjbGeQQ8yJJc6OWp7M+fvyBPrmx+WvbPi3/Vr7fVrVER8os9cutZljW80OL9KNo4WLF6vbqd+tfp83jy9Bm+TxgP//tfAty6c0/lkuUQlzRnWw5s2ZaHhqSeoiezQY46KaKfI1sGNbMobT156hweP3mC/5ksYRAdc4kUMTz+/felefRXxwXy5FQzl5Ig9uXWvYRtSUDaYslu1szpIDPNkibLBxyZscydMwtWabNrV67dlGy4c/e++kIjM/EHDh9XcfLlQQ+rCJONtfwyZmSmtkzJQqhVtRxOajPGrzRHxmAwIF/u7OjUpilOnj5nYgnIkTUT1m3aCcn7zPu5Ft4BWWLjR8nKgfSjjKs9fx5WGrKG8/Pnz7DW5/nyZNfuWiyEvDFAMsiaTVnDK2F7Yq0sPZ+kP/P2xuZte1SUtFvW/KoDKxvTcSb6BsPXnM5euAR9HbWpGWttNNUxDQek7WInUqRIcOTctzY2zM/vazdvIV+eHEgQPy62/bFPinBY8lnpR0fPhXPaHQ25yyHn7NKV6yB3s76l/xyuMBVJwMUJ0OF18Q5i9b6dgMyuVKnTCqWrNMbZ839j8ZxxXxn7uc9wpMhcWJvd7QJZjlC0UG5EjhQR5UoVRt1mHTF5xsKv8phHxI4ZE0XK1oU8cDVmaC/I7Ev+3DnUA3Fy23DyzIVInjSxymbLdv8e7dUrzuShtd1/HkLf7m1VHkc2sj7wu6hR1UNdfQaPw8RR/VU9bOWtUaUcNmz5Qz1opT+0Zkm/b/d2mgPtDXm4Sh7I2rh1lyU1P3EBaYsfQ74H9WpWgjxQVLNhW8jDgLKsQG5j+yZb3Mm7PqUebTr3Uw+LSV+8eftW/fxtwXy51EOI8tDPD0kT4buokb+ykUzrM0v512hOdPwUudQDbwePnlRrwG/cvIvvU+dRD4mNmzIH/TRmpgZTp/wBTepXU6zlYamfmtRByuRJTFWshmU8TR07EGMnz4E8qJQqa1F81O4YWOvzWlXLI1f2TJAHy/IUq4q+Q8ZbtW2eYK0sXU/SZ04aph7KlAfisuWrAFmDrKdb2puOsxN/nYclToc1jmfOfb0u21obLZUjcQFpu+Rv3awefu47/KuH1iTNVKyNDfPzu3G9aug9cLQaa7IcxNSGvbC1ttSvVRm3tS/Tci70HTIOyZL+z6IpefPE6AmzkL9EDUSKGAG1qpVX1wT/9p9F44wkATckQIfXDTuNVbZPoG/39ji8aw1WL50Oue0qD6pEj/adMePerSuUYztL+/C+/Ncu9UDasP4/I4zvLX3Jv2TOBMhDazWqlNWcz/bGvLL+cmDvTupYHmKbOKofdm9eBnkwRdbUSYLYkQel5LavvB7tz+2/Itp3USVJ2dJtm9qSh8qWzZukHlqTvazXlQxSRrFCeSWo5Pi+9WpvugkXLqx6KEkeZNn421zkzplVJctDKFKWOjDbyANFC2aOUbfnxdk/vGut+plUUcuvzUpNHjNAguqLwLTxgyAPv8jt8SF9u6h40415Ha21ZfiAbijlu2Z2z5blqg9MGZjb0dsaNmwYjBveGysWTEHLpnURPfp3Ftdbm7ZB6le5fEnF848NS3Bs7zqkSZVcotWDdfLjGJNG99dm5b2RMX1qFe9I/kaaE3P/8mH8umgaZPxIW4XlgytH1ENlElcgb05lTx9nctC8UW1IPYRjk/o1JEo9/LZ59S8qLJvunX4yrs+UY12yZ80IeUhO+vfWhf2q7db63GAwoGeX1qq/DuxYpR5CFH7mY0FnK2WMGNjd2C+WyjJNl4f05KFAGd8XT+xA1YqlxYR2vlkeP+nSpIA+zvLnyQ5LnP46fUH7QuDDRBnz3Vhro/k5KedZ4v8lVGvYLbXd15xxd+rAJmNYxnl+bbxLROXyJSDni6WH1hwZG2LD9NohzCWfjDXpWwmLjiNj3mCw3I+yLGTquEHqXJCH9mRcx4oZXcz6EVk/LOXKtUf0w4cPp9Id6T+lyA0JeBgBOrxO6VAaIQESCEwCb9+9R/JMhdQsc9fewzC4b+cAFSevnpLXksmsbwvNEZUHyQJkkJkDRECcTrntHyAjzEwCJEACNgjQ4bUBh0kkQAKuQUBuFd/5+6Catdzw6xzILFVAaiazpfu3/6bsVavkM0MZEHvMa0KAwWAnIHeHTO8cBHuFWAEScAECdHhdoBNYBRIgARIgARIgARIggcAjEBwOb+C1hpZJgARIgARIgARIgARIwIwAHV4zIDwkARIggaAjwJJIgARIgASCggAd3qCgzDJIgARIgARIgARIgASsEwjkFDq8gQyY5kmABEiABEiABEiABIKXAB3e4OXP0kmABBwnQE0SIAESIAES+CYCdHi/CRszkQAJkAAJkAAJkEBwEWC5/iVAh9e/xKhPAiRAAiRAAiRAAiTgVgTo8LpVd7GytgjkKlwJb9++s6XiJ63ngFHYsmOvn7jAOnjy1BvFKzYILPMW7To7smCpWnj56jVstUXaKOnWypb8C5auMib/vnEH+g8dbzx2p4CMtWjfZ4JIotR50PCnLjh34bI7NcHhup6/eAV/7D1g1O/YYzB27N5vPHaVgJzPl6/eNFanQMmaxjFbolLwnn9Stx79Rxrr5mjAGmt75461fI6Wa09vzoLleP/+g1K7e+8BSldprMLckICrEqDD66o9w3p5FIHvokbG6ME9PKJNAWnLy1evsHjF70YOeXJlRcO6VY3H7haIGzsWnt85hb9P7ETG9GkxYdo8d2uCQ/W9eOkK9uw77JBucCrt2LUfV6//5/BOGNkXEcKHC84qBVrZwX3uzFv0K95/8HF4A62RzjNMSyQAOrwcBMFCQGbCGv7UFTLrkjprMTzzfo5y1Zvhxs07xvrIjO3jJ8+wcvVGbfasK2o2bIscBStg2W/rMGzMVBSrUB+tO/XDp0+foP8NGjkJZas1ReU6LXHz1l0VffvOPdRu0h4lKzVUe5mNUAlWNpbq9vHjRwwYNgGFStdWM7UyWyPZLem++PclOnQbhAo1myNF5sJqZuyfFy/xc98RkgXv3r1Hl17DULR8PVXXg0dOqHi9nVXrtkKZqk2wZv1WFW9rs+/AUTWzUqRcXXTtPRz6jIuwk5nTSrV/Uuz+ffnKjxk5Fh098uHjJ8hfooY6HDRiErLlL48fi1TB3IUrVJzpxrQtb968RcsOfVRbmrbpgfda20T38+fPqm0ywyazvvsPHZNoTJz2Cy5dvgap1+QZC3Hg8AksWOIz42utn2SmStomfSpcLvx9Rdky3Qi7Bi26oFq91hB9a4xrNGiDi5euqaxZ85XDwmWrVVjacPjYX2qG1nxcKgU7m4gRIyBsmDCIHSuG0rRWfq1G7bBxyy6lM0Fj0W/IOBVevmq9Yli4bB3rd5AuAAAQAElEQVSMmTRHxVkaRyrBZDNqwiw11tPmKIHRE2erFOnXXgNHK/7CTD8PZEYww4+lIX0i408fK8LLHt+J0+bj9007VL/t2ntQlbNl+151LOeE3ifWzhOVwWQzfuo85C1eDdIf0m9SN0nOlKeM7JQIp96DxqiwpFuru5xrVeq0woDhE7F1514MHzNN1UuuHR27D8Ybs7s+H/1xLqvCfTfWxrRcT6TfGrX8WZUr1wnfLNi+6091Xsm43LJjjx5t3Etd9DbLtU/uFly55uOw5yxUEZIuypZYm54767S+keujnMPCQvLo8uXLFwiHEeOmqyhLY03aUKhMbe1a0UVdt54+8/7qGqYy+25WrNqAW7fvoU6TDur8l+i3795BGBTRrkVy7ZE4kWMnTqN8jWZqfLfq2Bdy7ZF4CgkENQE6vEFNnOUpAtPnLEbzRrWwbe1CHNj5GyJHioSaVctqs39rVLo4H6lTJjM6EA8fPcH8GWPw26Lp6NFvFLJlyYgd6xZBPoR27vnvVmvMGDGw8be5KFowD4ZqTrEYG6g5cAXz/oitaxcgT87sGDRyskT7FZMjS3VboTndL/59he3rFmLF/EkYOmoKnv/zApZ012/eiYQJ4mHditk4e3grMmdIa2IdWLJyLZ48fabqP6h3R7Tq1NfotN9/+AiLZo/DplXzMGnGAtU+P5lNDuTDsE2X/hg+4Gdl696DB+rLgK6SOWM6rF02E6VLFMSiZT5c9bQokSMhebIkOHLslIpar31glitdVIVrVauA4/vWY8f6xVi9bpufGTOlYLJZtHwNPn/5jJ2abr2aFXHq7AWVajAYMGFkP+zdugKzJg1FN19nv0PrxkiZ4gdVr3Yt/d5ittVPoUMbsHrJdMycOATDNIdGFWK2Ecdu4ayxmDCir1XGObJlxtETp3D/wSN8nzA+jp04o6ycOHUG2TKnt9ifSsHKRr4oiJMiMm3OIrRoVFtpWuvjyWMGYtjYqcqxXrl6A3p2aQ1xcGS2bNXiadj++0Jc0Bx6WT5gbxyJgyRfltYsnYFzR7aifu1KqmzZZEyfWp0HDWpX0cqbJlHaOEyDY3t+x+7NyxAuXBis0MpXCdrGHt8OrRuhYpliqt8KF8it5QAkj5Q9fODP0PtkhZXzRGXw3ciXxOW/rceWNQswafQAHD76l2+K9V3mDNbrbjAYsGrJNAzo2QElixZAz66tVT31Lx/mVq3V0dK5bJrXYLA8pkXn6rWb6N+zvSrX+/kL/HXmPD5os5+dew7FzEnDsFy7Zly/cVtU/YiXlxeSJUmszrGjmmNYMF8uNT5lLCdMEB+SLhkssZZ4XYaPnY4FM8di37aVmDZ+kIo2GAzadeUzmrfrCbmW9ujcyupYkwxnz1/CgF4d1XVry469Nq9hNauWw/8SJcDSeRMxQzsnJb/OQMbwxUtXFQOZjBAGo7S7W3KNyKT146Tpv4g6hQSCnECoIC+RBZKARkCciykzF2Ds5Ll48PAJwoYNgyoVSkJmKmRGYuXqTahRuZym6fM/R7YMiBAhPBL/LyEia85a4fw/qoQsmdLi8pUbKiybujUryE7dJj956qwKHzt5Bg3rVFHhJg2qGZ08FWFhY6luB7WZyBOaveoN2qJJ6+54os2A/K3NVFrSTZc6BWQ2Z+T4mfhTm9mMET2an1KOHj+jOSeVYTAYkC1LBsSJHRO379xXOrlzZIHMFspB1CiRNTaPJWhRbt6+i4Tx4yJzxrQIFSqU1sZqOHr8tFG3eJF8Khw/bhxcvvYfIxWpbcprDu66zTu0ELB+8x+ooDk0cvDq1SvIDGH95p01x/AhLv59TaItyslT51Gnug9zcYR+SJJI6RkMBpy/eBmttBmdTj2GaHYeQ74gqEQrG1v9VLhAHsUrofZF4tKV6xYt5M+bw8juqBXGubJnUk7uIc3JqlyuBIShOL9x48RWzoWl/rRYmG+kvqTh4dWjGNqvC/oMGatSrJUvTlinNk21WflG2heVbmpMy5e7J9qdDJkdq1a/jeL21+kLsDeO4saJBW/vfzRnc6r2RXEtYpqMs+KF80P+ShbNr7XXZ0yECeMFmVmt3bi9mlkXp0R0RBzhK3qmUihfbtUnObNlgt4n1s4T03wntPOoUrnikC9d8eLGRsliBUyTLYZt1b1EkfyqHhYzWoi0Vkd7fW8wWB/TqbQv50kT+4z9+PG08027Jt3S7iwl0a5XaVMnV2OrVrX/rmem1cqpjUlxduWLWKtm9bRz+AyOHD8FGau6niXWeprs06dNid6DxmLa7MXqWiBxch3tO3gMUiRLipZN60gUrI01SZQvSXob7I090TeXFMmTQvKHDh0aWTKlU9dlua7dufcAPQeMhtzVWbthG06d8flSbJ6fxyQQ2ATo8AY2Ydq3SKBx/eoYNbgn4sWNhQYtOkNmqyJFjIjsWTJBbt/t3LMfJYrmM+aV28X6gZdXaOUgQ/sLHToUPmi3KLWg+u8V2kvtQ4cKhc+fv6iwXPgljxyECxtWdn5EPgRyFa4Mkd37DsFS3cRGn25t1QyOzJpeOLZd+0DKbFE3s+aAysxXhrSpMEpzetes3wbzPy/tQ0GPC+MVBl+0f3Ks11PCBoNBmyX6KEGrYqofJkxoSD11ZS/fMkJpLD5++NpO2ZJF1O31B48e49Hjp0iTKplabiEzztUrlcHyXyZpfZAfr16/1k1+tZfyQvuWI4lhffmePHVOLVXo3K6Zmpn9XnNUX72ybkfyii29Peb9pMertpj0t+TTJZz2pUkPy15vv4R1xuKciTMhzkXO7JkRK2YMbNVms3TnwlLfS357Ei5cWFTSHOitO/YZVS2VL4myDEX2nz5/kp3qs8rlSxjH1sGdq9C5bVPYG0fyBVDuOBTImwt/HjymfUnxcbbFqLCUval07TMMqVIkxewpIyBO96vXb4zJjvA1KvsGwoT1Pde0/pe7DRIt5Vo6TyRNF9EJFSq0fqicQeOBSeCjyVIlW3UPGy6MSS77QSnfUh3t9b2tMW3a1waDQV2TvmiXn9AaG71GMgb1sOlext5R7QvaJc1JLqU5/5evXlezvNmzZjSqWWJtTNQCsycPR4M6lfFSO8dqaF/KP3/+rL4ElNBmvLfs2GNcRiBttzTWNBMwPefsjT3RN5ewYf7rB4PB57os17VUvnd05Lq5Zc18rFw41Twrj0kgSAiECpJSWIiHEQh4c/558a+6JVa3RkU1G6Cvq6xRpQzkw61sycIIY3IBdbTEpb+uU6qLV6xVs6dykEP74NDXas5duFI5qhKvSy7N8Tm8aw1ECmkzx5bqli9PdkyZuVB9oEi+Y9rtR1kDaUlX4r6LGgVlShZCLe3W30ltRkvy6CKz1VI/+fA5qTmGj588wf++T6AnW9zP+mUZnjz19pOWOFFCbeb0kbp1KB9wC5asRq4cmf3o2DqQGbZ0aVOg35DxqFy+pFKVtXvRvouq+iRUKAN223lQKWvmdNh/6LjKK19aZNZbDuQ2fZZMabTZpcS4fvM2zv99RaLV0pUXWt+rA7ONvX4yU7d5aI1x+PDhIDPnB4+cVA6+OBvT5y6GLHWA9id9J7dqTcelrDmUftKSbf7fuecAEiWMp3SslS+O6bGTp7Ht90Xo3ncEXvz7ErlzZsGqdVvV7WbJfOfufQhLqYutcfRK+yJiMBiQL3d25cCePH1OsiuxdB7ILeeSmgMk7d+x60+l5+gmovZl9IXZOnBLea2dJ6a62TJnwIbNO5UT9uDhY7XOVU//XruNL+tJ5Xjv/iOyU+Jo3SNFDI9/NaYqk5WNtToKb/O+NzVhbUyb6piGE2u3/KUvpY8lXv+iI2FTyaHNkO/X7gTJeSfxckdoz5+H8WOOLHLokEjdM6VPo31RaoJnz/8xXqfkrkurpnVRt2lHtb7f2lgzL0Ts2Rp7oh8pUiRYO5clXUSua8+8vbF52x45VF+eZbmHOuCGBIKYAB3eIAbO4nwI/NxnuHqgq0GLLmqdbtFCuVWCrGGTgKwRk71/5d79B+rBss3b96B31zYqe/8e7bFj93710NruPw+hb/e2Kt7axlLdalUtD3GO5OGLPMWqoq/mJEp+S7prNOclfopcqF6/NQ4ePanWKouuLnVrVMJ3UaOqh+76DB6HiaP6w3QmSNcz3U+cPl+bCftvVkzSvLy8MH5EX/TsP1rZih0rpuZgl5ckh6VcqSLqoUBZ3iCZEsSPi+Q/JFYP5jVr2wNpU6eQaKtSv1Zl3NZu3coDM32HjEOypP9TunKbevefRyC3MSdNXwCZMZKEyJEiolypwqjbrCMmz1goUUbxbz8ZM1oI2GKcM3tGxNPuLIQKFUq7o5ABf1++DnniXcxY6s8rV2+gS+9hkvyViHMhbZQH85q16YEhfbsqHUvlf/z4Cd36DldrOlOn/AFtmjfQnN6RGrPEkLa36dwPRcrVhdh78/Yt7I2jGzfv4vvUeVRfjZsyB/26t1Nly8bSedC+VWPIw1X1mndChAjhRM1hEaf6tTYjXKNBG+gPrVnKbO08MdVNlyYFqlQspZ2PDVBfO/+zaHdE9PRmDWugar3WkDrKF0I93tG616hSDhu2/KEe5JOH1vT8pntrdbTU96b5rI1pmCqZhOUL+/CB3dC8bQ/UadpBO098li2ZqKignBORtPMia+b06jh7loxa/0TQvhxGVMeObHIXrardoaoEuTvTsXUj9aVOz1ejSlnIsg85n2XJgaWxpuvqe3tjT/RaN6uHn7Xx3LJDHzm0KHJdkzXM8gozOUey5asA+fJiUZmRJBDIBOjwBjJgmrdMYNakYbj81y7IQ0bD+v8M+XAQTVlP+UOSRMiYLrUcKpELdt/u7VVYNqcObJKdkmYNa6Fj68YqfHjXWowY2B27Ny+DLCmQ9b6SkEibPV02b5J6aE32sg5U4ocP6Aa5hShhU7FUN4PBgJ5dWmPXxqU4sGMVNq/+RS2rsKTbqF413L98GL8umgZJl/JjxYwOeZhDygkXLizGDusFeYhj429ztRm+rBIN83bKLUBpw7Ubt7R6FoQ+A6SUfTf58+RQdfljwxKMGdpT1UmShEV4bTZTwqIzecwACX4l8uEvr9WS5Qx64pSxA1Vd5SGYedNGqnpJ2p4ty9WHsGlb5Lb61HGDsGLBFPWw3bG96yDpMoso7ZM2TBzVD/KAoc5d+nLJnAmQh9Yqli2Ggb07iXkIJ+mfrWsXQPa6vjyEVqxQXqUjG3mgTvamYs7OGmPJM7hPF2Vfwlk1J0PaL7Pdciz9ZT4uZT2i8JV0UxG+j68fU0sRpG9vnv9TzeqLjqXyJU7GTvo0KUUFMk6mTxiswjLDLu2WcoRhmlTJVbr5OFLKvpt0muP44MoR1VdS7wJ5c/qmAAN6dvzqPJBZa7mLsXj2eLWcSLhKBtnb4ytO2cyJQ9XtaJk1tJbHYLB8nkg5ptKpTRN1Hgm3pIm/NyYJh0N/rIbUcdzw3hjaT/8CUVHdgZF4WQolAK+uDQAAEABJREFU5Usm2ZvWXZgsmDlGnf+xY8VQD01K3WVMblu7ULLAYLBcR2Fo3vcqg+/G2piWcSrXA181dO/0k3Fde/HC+dS5sXTuRKxeOl1dn3Q9072cK+1bNlRRcl7s3rRMhWVj3kZ9/JueO+ePbtP4rIUsbWhSv4Zkw/jhfdTDu3LQ9qcG6lorX/KEsflYM2+DjE1bY09sVi5fAnIey0Nr5vlNGchDu6uWTFfj9OKJHahasbRkp5BAkBOgwxv4yFmCgwR+W7sZFWs1R5d2zRzMETLUfkjyP+Ugh4zWspUkQAIkQAIk4HwCdHidz5QWv5FAtUqlcXTPOsg62m80wWwkEOIJmM7uux6Mr2skM/wyW/l1CmNIgARIwHkE6PA6jyUtkQAJkAAJkAAJkAAJuCABl3N4XZARq0QCJEACJEACJEACJODGBOjwunHnseokQAIeTYCNIwESIAEScBIBOrxOAkkzJEACJEACJEACJEACgUEg4Dbp8AacIS2QAAmQAAmQAAmQAAm4MAE6vC7cOawaCZCA4wSoSQIkQAIkQALWCNDhtUaG8SRAAiRAAiRAAiTgfgRYYwsE6PBagMIo1yQwY+5SRPs+k1FWr9uiKnr+4hX8sfeACsumY4/B2LF7vwStystXr7Fg6Sqr6dYSlv22DkXL10PBUrWwcvVGo1qyjAWN9cpTrKoxXn5S8/37D8bjXIUr4e3bd8ZjVw6Y1v3JU2/IT4NKfX/fuAMDhk2QoFPEvC+E6+CRk5xiO7iNmDL0T10KlKwJ4eKfPJZ0t+zYix79R36V9ODRYzT8qQsq1f4Jh46eVHtRMj+XJE4XR84rXdeRvbTPkXPQdOz1HDAK0iZH7H+rjmkZcp5LPc1tucJ5LPWScWJeN/M+dHa/mZfHYxJwFwJ0eN2lp1hPRUB+Olh+ClakSoVSKu7ipSvYs++wCju6efnqFRav+N1RdaV34e8rmDFnKeTncjf8NhfTZi/Gw8dPVJr87K/USUR+PlZFapt5i37F+w//ObxalGv8d6AWpnX/LmpkjB7cw4Fc/lf5lr7wfynBk8OUoX9qMGFkX0QIH84/Wfylu2X7HmRMn1aN5cwZ0mJQn04q/7ecSyrjN2wc7ffAHHvfUG2XzxKUfejyMFhBEjAhQIfXBAaD7klg4rT5+H3TDjVLtWvvQdWILdv3quNCpWtDHFUVabKZOO0XXLp8TelMnrEQ7969R5dew9TsbdlqTXHwyAmY/52/eBmZMqRBlMiRlGRIlwrb//jTXM14vGLVBty6fQ91mnRAyw59jPHDx05D6SqNUadpB/z78pUxXg/IjEyHboNQrnozFCpTG3qbPn78qGZWpU0y27pFm72TPDIj2qBFF1Sr1xqS99Hjp2jWtgdKVGqAlFmK4MixU6KG5avWq/YVLlsHYybNUXF37z2AHDdq+bNioc/cmtf9nxcv8XPfESqP6UZmCpu07q7sVq7TEpeu3FDJ67T+qNmwLfKXqIEqdVqpOKlni/a9VNh0Y94Xknbl2i1UrdtK5V+zfqtEKbHUBpVgssmUp4zxaOOWXeg9aIw6FjZdew+H1LNM1SbGcfH582fIjLJwyJi7DKbPWaL0Z89fhiLl6io+8xatVHHWeEniqAmzlO20OUpg9MTZMGcoOjIzKPWRtu0/dAyDRkxCtvzl8WORKpi7cIWoKOnYfTDeaHcCbJV37MRplK/RTLFv1bGvcSxt3/Wn4ibjYcuOPcqe6eb4yTNaGxdr9Vun+lx49BsyXqlYOpdUgu/G0nl1+epNSLtkrNZq3A5SZ1E/d+GyNovcVY3D1FmL4Zn3c4k2inm/Sz/IuSezljK+hY8oWxt75rxFV5eP2rmij4MbN++ouy9Xrt1UyTkLVYSkWxu7SsmBzSDtLoTUV/jdvHVX5bDUJ69ev4aU+eXLF6Vz7/5DNabkYN+Bo+paIONMxqZ+N0h49h86XvVPw5+6Gvv26vWbKk7G78jx08XEV2KpDy31mzCQ893S9UTKlPM3R8EKkLtaw8ZMRbEK9dG6Uz98+vQJnvbH9oQMAnR4Q0Y/e0wrR4ybjiTp8qsLr/fzf1S7OrRuhIpliqnZqsIFcqu40KENWLN0BoYP/BnDxkxTcaabDq0bI2WKH1Sedi0bYMnKtXjy9Bl2rFuEQb07olWnvl9d2NOkSoFTZy5APsBEJHz/wWNl9uXL10iYMjfkw0OcLImsWbUc/pcoAZbOm4gZE4dIlJLMGdNh8+pfkC1zRixatkbFWdqsXzkbi2ePw899hkOcgRWrN+LFv6+wfd1CrJg/CUNHTcHzf16orPKBu3DWWEwY0Vdz3iYjWdL/YdvahTj0x2okT5YY8mE/T5ttXrV4Grb/vlA5e/oykKuaI9C/Z3vFwvv5C/x15jys1V0VZrIZMnIKihXOi53rF0NsdOnl087hY6djwcyx2LdtJaaNH6RyFMyfC53aNFVh0415X0ja/YePsEhr+zqNwXDtC4K031YbJI8jIuNi9ZLpmKn1hz4ulmtfTP46fQFbVs/HiX3rUKZEIVy8dA2zflmmxpAwky9FujNviZc4VfIlScbcuSNbUb92JasMM6ZLjVVaHfL+mB21qlXA8X3rsUPjt3rdNohDY94OS+WJ09G551CM0mbdhb18EZs0/Rd80O4mSPzMScOwXBsj12/cNjeHbFkyoHG9GmhQu6rq8xkTfPpMFDtYOJckXhfhJ200Pa9ixYyG9SvnYvemZahboxKGjp6m1KfPWYzmjWqpcXhg52+IHCmSitc3HczOQYPBgAkj+2Hv1hWYNWkouln4gqXntcRbT5O9l5cXkiVJrHge1b4YFMyXC0dPnIKcJwkTxIekWxu7kt8RiRkjBjZqd3qKFsyDoZpDaK1PIkWMCDnX//D9Mi7jrWaVcsrpbtOlP4YP+Bly3bn34IFyLvWy5Tohd5NKlyhovE4M1s63SmWLY9OqedodgPC6qp99Bwt9aKnfbF1PHj56gvkzxuC3RdPRo98oZMuSUdVRzsOdew74KY8HJOAuBOjwuktPsZ6oWrEUrpzapTl8i/H23TsMGDbRKpVC+XLDYDAgZ7ZMuHTlulU9PeHo8TOak1JZ5RGHIE7smLh9575vss8uberkmqNQDXmKVUOOgpWQIEEchArlcwrt2bIc18/uhXzYdOg+ENdu3PLJZGFbtFAeFZs9S3pcvnZDhc03omMwGPB9wviIGSM67tx9gIOHT+DEqbOo3qAtZFb1yTNv/K3NUkve/HlzIGLECBLEnwePoX2rRiocI3o0iBw+9heePHmGRtpMbrX6bSCz1eLkQftLlTIZkiZOpIWA+PHi4LLvLK2KsLPZf+i4Wsssa0GlP06fvahypE+bEr0HjVXLPnRGcWPHQppUyeDIX67smVR7okf7DvHixsGDh49hqw2O2BSdwgXyqD5OmCCecVwc0NrQokkdhAsXVjlCif+XUDlHFbQvUd9FjaL4VSxbTMWJDUu84saJBW/vf7QvV1OxeMVaxNS4i64lKVW8oDH61atX6DVwNOo374z7Dx7i4t/XjGl6wFJ5Mjbv3HuAngNGQ9iv3bBNfRm7decekmj1l7EqTl2tauV0M07ZWzqvIoQPj9XrtkLuMsxduBIXLl1RZWXLnB5TZi7A2Mlztf57grBhw6h4axuDwaDGZStttrpTjyEaj8fQv9CZ53GEd05tDImzK45uq2b1IOf4keOnIGNL7Fkbu5LmiNStWUGpNaxbFSe189Jan4hSzapltRn1DRLU9utRVbuW3bx9Fwnjx0XmjGnVdaRhnWpaHU8rHdkUL5JPdoivjX/9OnHy9DnUru5Tbr2alVW6IxtL/WbrepIjWwZEiBAeci5EjhwJhfP/qIrJkimtv64PKhM3JOAiBHw+rV2kMqwGCdgiEDtWDOWQpNBmLHt1bY2/Tp+3qh4mrJdKCx06tJpJUQd2Nl6arq4SxisMvmj/9GN936heNZw6sAnnj25D1ChR8L/v46ukeHFjqw/0yuVLolihfDh7/pKKt7QJG8bng18cwY8fPlpSge/dT2Oa3A4V6dOtrZqVk5mfC8e2ax/emZVOODNnIlzYsCpe30jeyuVLGPMe3LkKnds2Vcmm7TYYDPig3Q5WCQ5shNGK+ZONdm+e91niMXvycDSoUxkvX71GDc1Bl5khB8wZVXRGEiGcPmicbLVB9CzJR7Pbr15eoZWa2JRbunIgdsOE8YmXY128tFlCPRwmjJfWJz63pL1MxonB4MNLnAOZeS+QN5f6wtFr4Fg961d7vW/evXuv7iRUr1QGy3+ZhBJF86u7B+YZLJUn3FP53qGQsbBlzXysXDhVqyMgY163IeNYDztjb+m8mj1/hebQPsKIgd0wZ8oIvNZu4UtZjetX12age2pfWGJpznBnyKysxFuTk6fOYcESbVy2awaZhf9e+1LyShs/lvQd4Z1LHF7ti6zMzJcqVgCXr15XX1qyZ82oTApDS2NXJTqw8Qrte43RvvR+/izWvsBSn4gpmWH+S3NW9/x5GKlTJodcyyTey3c8SljGoIxFCYvo/a7Gqjb+JU6uC2F9z3UZkxLniFjqNynL2vUkrO81SmxLHfUyQ4cOhQ/+uD5IfgoJuAqBUK5SEdaDBOwRePHvS6UiF+pN23YjS6Z06jiidsvwhYW1sCrRykZur7548a8xVWY0ZGZObMsH7+MnTzRnNoExXQ/IUgZZZ7do+Rrs/fMISmu3v8Wp+/z5s1KRh9hkSYDMcEpEJO02rmk5EueIrFi9Xi1jEKdellp8nzAe8uXJrs2YLVROpNiQ9YJSFwmbSt4fs2Hi9AXGKKlf7pxZsEqbhZNlAZJw5+59uw6II3UvkCenmtUUm8JObutL+B+Nbab0aTSnugmePf9H1fnshUuQNzxIuqmY94VpmmnY0TZ8r92y1teR7t1/xNSExXAejdecBSvUOm5REF45smbCuk07Ie2QtafrNu3Q7hb4fLkQHXORcWEwGJAvd3a1bENm4kTHFsOn2gy9POwo4zhUKAN2++PBy/99nwDPvL2xedseKUY5yjLuEidKoN0NuA/9XJE1okrBwc23nEvXbt7SxmYOJNBmK7f9sc9YkrCTJT11a1RU56osEzEmagHzfpexmSVTGsgX2us3b+P83z4zxZrqV/+t8TZVzKHd3dl/6BiEscTLnQ5xOH/MkUUOYW3sqkQHNkt/Xae05Lohd4Ws9YkoGQwGVNa+DLfu3A81KpeVKCROlBD3HzyC9JtcPxYsWY1cOayPMcmUVbvm6WN6z/7DEvWVONqHjl5PvirAN0LWaD956u17xB0JuD4BOryu30fuVsNAq2+7rv3VwyepshbFteu3MKBXB1WWOBmvX7/RZhLbQH/ASyXY2ESOFBHlShVG3WYdIeszZe3hd1Gjqgcz+gweh4mj+vuZKdNNFSxVC/FT5II4vEvnTYDYuXzlOmInzY6YibOiTpOO6N+jA35I8j+VpbV2K/XnvsP9PBcK/i4AABAASURBVLSmEuxsYseMiSJl60IetBoztJeqS62q5SGzVvKgkrz6rK/vg0bmpvp0b4tzFy6ptiRKnQdnzl1EsqSJtXq1RxvtA7dIubqQ2+Bv3r41z+rn2JG69+3eDo+feEMe+JKHtTZu3aVs5C5aVT3I1KpTX3Rs3UibDY+Mw0dPanW5oNJNN8LQtC9M00zDjrahWcMaqFqvNeo176TNePrMypraMQ/XrFIWKZMlRfEK9ZHhx9KYOW8ZUqf8AU3qV1MPoYmtn5rUQcrkScyzGo9v3LyL7zXWxSs2wLgpc9BP4yKJthiKg5j8h8SQPPKQYdrUKSSLQxJam2WWdbpzFixX+bPlq4Cr124ijDYzN1ybaW3etgfkoUi5ze6QQV+lbzmXGmt3PXoPHK0emjQtT9aep8hcWJvd7aJmNIsWyu1bis/OvN9LarOwu7UvkTI2J2lf2ORWv4/m11trvE01xX4k7TzPmjm9is6eJaN2mz6COmclwtrYlTRH5N79B5A1+5u370Hvrm3UOWqpT3RblcuXwvv371GiaD4VJXcQxo/oi579R6tzNXasmJBzXCVa2fTr0Q6yFl8eSNy195BFLUf7UMpy5HpisRAtcvi4ado5/ZcW4n8ScA8CdHjdo59YS42APAQlr/26dPIPyGub9Jkb+WCbOXGouqUrD63Jg1vFCuXVcvj8l4eCfEJ+t327t8eSORMgD63J+s2xw3pBHgDa+Ntc5M6Z1a+y79Gxvevw9OYJ9SBOVt8PUpmhkzgRyV+6REFfbWizOiVUGfpDa4d3rUV439dN5c+TA5PHDDDqmgbKlymK3ZuXQR4EkjZJmsFgQM8urbFr41LIq8/kwTe51VhDc9ikLaIjEi9ObMybNhLyIMztiweMbZEZpq1rF+CPDUsg7UiTKjlkLavYkXwi3Tv9hDq+awQrl/+v7rFiRlcPu4mOrGcd0KujBJUjIw+lSZ1kicWQvl1UvCz5kLbK0oYm9WuouL9OX9CcSJ+wijDZSP31vjBvj9yyl7WEol5ZmyUzb4PEm4royMN6i2ePx7jhvTG0X1eVbG1ciOMh7dm7dQXOHNqMLu2aKv3mjWorVtI2vQ3WeKVLkwIPrhxRjGZNGoYCeXMqG5VNGEqEMNH7X46njB2o8sjYlj6Ttku81EXGtbXyREdeJyYPv8lDiBdP7EDViqUlGsUL58OKBVOwdO5ErF46HSMGdlfxppuWTeug7U8NVJSwFcZyIGWanksSp4s1fhnTpYa067fF0yDjR8KSRzhc/msX5GHKYf1/Vs64xJuKab9HjRJZnX9Sl4mj+qnxK+03HXvDB3SDLE+wxtvUtoTlfGzfsqEE1Xku55M60DaxY8VQD1RK/5qOXb0MTQWyNl+YSNhUpI3CVc5ReYhPGEr6133i0yeSdvHSVTSsU8UPB7kGyPkn5+SYoT3VsijRFfv6OBEd/TohX6QXzBwDYS39JONE9E1F6itpssRFrh3W+s1gcOx6Iku4dPvNGtZCx9aN1aGcX2W1SQN1wA0JuAEBOrxu0EmsIgl4AgH50JZZTU9oC9tAAv4hMHD4RAwdPRktm9bzTzbqkgAJOJEAHV4nwvwWU8xDAuYEzGdkzNN5TAIk4F4E+vfsgKN71kFmq92r5qwtCXgOATq8ntOXbAkJkAAJuDMB1p0ESIAEAo0AHd5AQ0vDJEACJEACJEACJEACrkDAvRxeVyDGOpAACZAACZAACZAACbgVATq8btVdrCwJkAAJ+BDglgRIgARIwHECdHgdZ0VNEiABEiABEiABEiAB1yLgUG3o8DqEiUokQAIkQAIkQAIkQALuSoAOr7v2HOtNAiTgOAFqkgAJkAAJhGgCdHhDdPez8SRAAiRAAiRAAiGJQEhtKx3eAPZ8mDBhQQmZDN6/f8++5/jnGAiBY4Dnfsi85uuf9Y66Dc+ePQUl8Bg42g+6Hh1enQT3JEACvgS4IwESIAEScAaBOHHigeJ8Bt/SN3R4v4Ua85AACZAACZAACXg+AbbQYwjQ4fWYrmRDSIAESIAESIAESIAELBGgw2uJCuNIwHEC1CQBEiABEiABEnBxAnR4Hegg7+cv0LXvGBSu2BSjJv3iQA6qkAAJkAAJkEBII8D2koDrEqDD62DflClRAM3rV3VQm2okQAIkQAIkQAIkQAKuQoAOrwM9ET1aVBTJnxMRIoRzQJsqtggwjQRIgARIgARIgASCmgAd3gAS//LlCyhkwDHAMcAxwDHgzzHAzw43/fwMoNtgN7v31S14fG6pv+Xj22d2bYdkBTq8Aez9t2/fgBIyGXz69JF9z/HPMRACxwDP/ZB5zdc/6wPoNtjN7n1tq+bsLvO3fHxDh9cWXDq8tug4kBYhQkQEmtC2S7P18grj0vXjuOS5yTEQOGOA537gcHWX8eqAa+AUlfDRkyNi7PR2JZRXeKeU5+lG6PB6eg87oX3PrmzCuRXlnCpi0wlVowkSIIEQQoDNJIGQRiBC9GSIFCejXQnlFTFAaKo06IAX/7502MaV67ew98Axh/VNFS9fvYkcRWsapX2P4abJgRqmw+sA3o+fPiF3yXrqlWRrNu5U4b8vX3cgJ1VIgARIgARIgARIwHMIXLtxBweO/PXNDcqeOR2O7lyhZNKInt9sx78ZPcjh9W/THdf3Ch0aB7cu9iOpUiR13ICba8ZIXgbpam6wK3ozHdEVm7o+9yRAAiRAAiRAAsFHYOb8X9GkXV80atMbl67eUBV56v0cPQeNR+3mP6Nx2944e+GKip+7eBX27D+K5h37Y9uuA9i59xBKVmuB6o07o8/QSXj56rXSc7UNHV5X6xHWhwRIgAQCSsBJ+WXpEZczOQkmzZCACxMIGzYM5k0ejKrli2t3s+dB/ibOWIzMGdJg2ezRGNC9DfoOmyzRaFqvKgrmzYHZEwaiROE8SJU8KdYtnYKV88bif9/Hx5LfNio9a5uzF6/gx+K1NSe6D06d/duamtPj6fA6HSkNkgAJkAAJkAAJkID7EBBHV2pbrmRBXL95V70y78Sp89oM7n41kztk7Ew8eeaNx0++fhOEOMvzl65Fu+7DsO/gcVy5elNMWZSECeJi04rp2L5mDooW/BGdeo/E6zdvEZh/um06vDoJ7kmABEiABPwQiMHlTH548IAEPJWAl1do1TSDwYBQmsD3b+yQbmomV2Zz921ciNixYvim/LcbNm4W4seNjWF9O6BTqwZ48/bdf4lmoYgRwiNK5EhK6lUvp/LdunPfTCtwDunwBg5XWiUBEnAbAqwoCZAACYRsAqvWb1cAtuz8E/9LFB8GgwG5smfEtLnL1WyvJB49eVZ2EKf1H5O3OojDWiBvdkSNEhn7Dp1QOtY2put75Y0Nz57/A1kGYU3fmfF0eJ1Jk7ZIgARIgARIgARIwM0IiCNao0kXLF+9Gd07NFW1b9eiLt6/f486zbuhdI2WWLXOxynOljktPn/6jLbdhkIeWmtStzIatuqlljR8/PhR5bW22bB1t3olWe6SdTF6yi8Y2b+zcqCt6Tszng6vM2nSFgmQAAmQAAmQAAm4EYHVCyeie/um6qGz+VOHImWyJKr20aJGgTystmzOaGxeOQMj+ndS8RHCh8fIAZ0xZVRv9dBauZKF8PuSyZg8she6tGmk4pWihU2tKmXU68gObl2CWeMHIGO6lBa0AieKDm/gcKVVEvBUAmwXCZAACZBAEBB4430Vrx6dtiufP7rma8CCAJG/iqDD6y9cVCYBEiABEiABEiABIRC48tb7Cl4/PmtXPn8Mmrcc+Ke1h4+fRotOA/yI/loz/9hxpi4dXmfSpC0SIAESIAESIAESCACB6D+UROx0tf0tXhG+foNCAKoRoKy5smVUSxZk2YIug3u1C5DNgGamwxtQgsxPAjYIMIkESIAESIAE/EMgerJSmrNbx9/iFd51HF7/tDeodOnwBhVpFyvn7pGJuP5HD6eK3kRn2713dKJumnsSIAESIAH3JMBak0CwEqDDG6z4g6/wN88u210X5MjaIVMdvTWmcc4Iv3l2RTfNPQmQQAAJXNncGs7+uWD4/jnbrtTV1zR3JEACJBAgAnR4A4TP/TNHTpAL3yUp6hpiVg+pm/sTZgtIwNUIfHG1CrE+JEACJBDoBOjwBjpiVy3A50MvTIQYCBsprkuK1E3offniU1cJU0iABJxDIHqyMv5eIxg7nf/XFX5LHqmbc1rpvlZY85BL4NHh1bi7fZa/5cOLJyEXmgMtp8PrACSqkAAJkAAJkAAJkEBQEHh8eA3u7pjtb3n/Lx1eW/1Dh9cWHZdOY+VIgARIgARIgAQ8lUCkhKkR5YesdiV02IieisCp7aLD61ScNEYCJEACJBDkBFigvwk8ePQUB46edqqITX9XhBmsEoj4fVpETZbdroQOFzCHt0qDDnjx70ur9TBPuHL9FvYeOGYe7dCx9/MX6NRrJPKXbYARE+b4yVO0UlPkKFpTiaT7SXTCAR1eJ0B0ZxPeVzfj8bmlLilSN3dmy7qTgGsSMKhqvfW+ZPcnSx35WdPA0HnrfVnVkZvAI7Bt92FUb9rTqSI2A6/GtOwqBK7duIMDR/765uqUK1UQPzWs/lX+0KFD4ejOFUr2bVz4VXpAI0KKwxtQTsxPAiRAAh5CwOchUHndnzNeGxgYNuS1iR4C22WbES92DPyYLb1d0RvgiK7Y1PW5dy8CM+f/iibt+qJRm964dPWGqvxT7+foOWg8ajf/GY3b9sbZC1dU/NzFq7Bn/1E079gf23YdwM69h1CyWgtUb9wZfYZOwstXr5WepU30aFFRtMCPiBAhvKXkQI2jwxuoeF3fePRkpV34Se3Srg+QNSQBtyPgM8MbIUZyRIyd3iUlQowUbkfV3SpcovCPWPXLSLuit8sRXbGp63PvXgTChg2DeZMHo2r54hg1aR7kb+KMxcicIQ2WzR6NAd3boO+wyRKNpvWqomDeHJg9YSBKFM6DVMmTYt3SKVg5byz+9318LPlto9Lz7+bz58/IX6Y+qjXqhHWbd/k3u119Orx2EVGBBDyXwLZdh1C1cXenitj0XGKe0DKfGd7w0VMiUpyMLinho9Ph9YSRxja4DwFxdKW25UoWxPWbdyGvAz1x6rw2g7tfzeQOGTsTT5554/GTZ6LmR8RZnr90Ldp1H4Z9B4/jytWbftIdPRDHetf6+WjZuCamzFmKv85edDSrQ3oWHV6HclKJBEjA7Qk8ePwMh46fdaqITbcHwwaQAAmQQAgi4OUVWrXWYDAglCbw/Rs7pJuayZXZXFlXGztWDN+U/3bDxs1C/LixMaxvB3Rq1QBv3r77L9EfIbHtFTo0ihX8ESWL5DMuofCHCZuqdHht4mEiCXg2gRKFcuHXucPtik7BEV2xqet7wJ5NIAESIAGPJ7Bq/XbVxi07/8T/EsWHwWBAruwZMW3ucjXbK4lHT56VHSJGCI9/TN7qcOvOfRTImx1Ro0TGvkMnlI5/N69ev8EaTRfvAAAQAElEQVSnz59Vtucv/sUxraz0aZKrY2dt6PA6i6Tb2fFZx/fhzTO8f/XQJUXqJlgNBp+6SpjiXALx4sREnhwZ7YpeqiO6YlPX554ESIAESMD1CciDZjWadMHy1ZvRvUNTVeF2Leri/fv3qNO8G0rXaIlV63yc4myZ0+Lzp89o220o5KG1JnUro2GrXmpJw8ePH1Vea5uPnz6p147JK8nEyZbXkF28dA23Nac5T8m6Kq1lp4GoU60sMqdPbc3MN8XT4f0mbJ6T6eW9w/jnxk6XFKmb55BmS0jAtQh4X93kkq8jlNckSt1cixZrQwKeS2D1wono3r6peuhs/tShSJksiWpstKhRIA+rLZszGptXzsCI/p1UfITw4TFyQGdMGdVbPbRWrmQh/L5kMiaP7IUubRqpeKVoYSNLFvRXj+n71Cl/gMjh7cvUK8mWzx2D8qUKWcgdsCg6vAHj57a55SloZz+hrcNwtt0IMZx7W0OvJ/fOJ0CLJEACJEACziHw+s55vLh6zK58emf9NWDOqYlnWKHD6xn96O9WJMzZAUmLjHCq6JVwtt0EOTroprknARIIIIHkpacjXc0NThW9Ss62m7z0NN009yTgbgQCXN9Xdy/i32sn7Mqn967n8B4+fhotOg3wI/przQIM5hsNuI3D27LL4K+aWO+nnl/FMYIESIAESIAESIAE3JVA7FyVkbBYc39L2CixXKbJubJlxKzxA/zI4F7tgrV+buPwmlOSJ/revX9vHs1jEnAfAqwpCZAACZAACZgRiJOrChIWb+FvCRPVdRxesya5xKHLO7yzFvyK3CXr4dTZv9VewiL1WvZElXLFXAIiK0ECJEACJEACJPDtBJiTBAKbgMs7vC0aVsfBrYtRrUIJtZewyJqFE1C7aunA5kP7JEACJEACJEACJEACbk7A5R1enW+XNg30IPchkgAbTQIkQAIkQAIkQALfRsBtHN4/D51E844Dkb9MQz9LG76t2cxFAiRAAiRAAm5KgNX2aAKLf9uMcdOX+lsePn7m0VwC2ji3cXjnLl6Nrm0bYveGX/wsbQgoAOYnARIgARIgARIgAVchsGTVVoyboTm8/pRHdHhtdqHbOLxx48REquRJEDqU21QZwfjn1KI/vnmKV4/O2BW9UEd0xaauzz0JkIBrEpDz1JHzWa+9I7piU9fnngRIwDqBDGmTIXf2DHYlUsTw1o0wxUjAbbzHmDGiYfWGHXj5yvVesGyk6aGBF3cP48aunnZFb74jumJT1+eeBEjANQnIeerI+azX3hFdsanrB82epZCAexLImCY5cufQHF47EilSxAA1sEqDDnjx70uHbVy5fgt7DxxzWN9c8eyFy6jfqid+LF4bJao2x6fPn5XKX2cuqvg6LbpB3tClIp24cRuHd/X6HRg9eT6KV2nBNbxOHACOmAoTISYixk7vVBGbjpRNHRIggeAjIOcpz/3g48+SScAVCVy7cQcHjvz1TVWT31Bo32M4KpYqjN0bFmD2hIEIZTDgy5cv6D1kInp0aIqF04dj595DOHHq/DeVYS2T2zi88ioyS2KtYf6Jp65tAlES5kLSIiOcKmLTdqlMJQESCG4Ccp7y3A/uXmD5JBD4BGbO/xVN2vVFoza9cenqDVXgU+/n6DloPGo3/xmN2/bG2QtXVPzcxauwZ/9RNO/YH9t2HVDOaclqLVC9cWf0GTrJ5p34XX8eQdpUyVCtYgmEDxcWiRMlgMFgwMXL1yEz1elSJ4dX6NAoWSQv9h48rspz1sZtHF5p8Olzl7By7VYJ4slTb9y4dU+FuSEBEiABEnAKARohARIIgQTChg2DeZMHo2r54hg1aR7kb+KMxcicIQ2WzR6NAd3boO+wyRKNpvWqomDeHGp2tkThPEiVPCnWLZ2ClfPG4n/fx8eS3zYqPUube/cfqejqjTqp5Qzzl61Vxw8fP0XCeHFUWDaJEsbDw0dPJOg0cRuHd8GydRg+YS5+37RLNV6mv4eOm63C3JAACZAACZAACZAACXwbAXF0JWe5kgVx/eZdtcRAlhRs27VfzeQOGTsTT5554/GTr199Js7y/KVr0a77MOzTZmWvXL0ppiyK+G73HjzCmME/Y+msUdj951EcO3lW6RpCGdReNgaD891T/1uUmgSDbNm5DwunDUWUKJFU6bFjxcCr169VmBsSIAESIAESIAESIIFvI+DlFVplNBgMak0tfP/GDummZnJlre2+jQshvpdvknE3bNwsxI8bG8P6dkCnVg3w5u07Y5p5QF5AIMsWZClDrJjRkTFdSly8cgNxY8eE9/MXRvWnz54jbpxYxmNnBNzG4Q0XPjzChPHy02YDDH6OeUACJEACQUmAZZEACZCAJxBYtX67asaWnX/if4niw2AwIFf2jJg2d7ma7ZXEo74zsREjhMc/Jm91uHXnPgrkzY6oUSJj36ETompVCubJrtbryhu33r1/j9PnLiFNyh+QOkVSNXt8++4D9daGHbsPIn/ubFbtfEuC2zi80b+LivN/X1VtlCnxuYvXIPkP/1PH3JAACZAACZAACZAACXwbAXFAazTpguWrN6N7h6bKSLsWdfFec0rrNO+G0jVaYtU6H6c4W+a0+PzpM9p2G6oeWmtStzIatuqlljR8/PhR5bW2kRnihrUqqAfkGrftg2KFciNbprTKwR7Suz16DZ6A+i17IHvW9Cremp1viXcbh7d/95ZYvWEnzl28igJlG0G+BXRqVe9b2sw8JEACJEACJEACJEACGoHVCyeie/um6qGz+VOHImWyJFosEC1qFMjDasvmjMbmlTMwon8nFR9Bu+M+ckBnTBnVGyUK50G5koXw+5LJmDyyF7q0aaTilaKVjeivnDdWreGtV72cUStzhtRYNGOEiv+pYXVjvLMCbuPwCvg+XVpg04qpWLN4otYJrRBNm/V1FgjaIQESCGQCNE8CJEACJOAwgdMXruDg0TN25RV/kMshpi7v8MqaEZlql72IvKvt+s07kLCIQ62kEgmQAAmQAAmQAAm4CAFHqnHm/FUcPKY5vHbk1eu3jpgLUp3Dx0+jRacBfkR/rVmQVsSkMJd3eGWtrryfTfaWxKQtDJIACZAACZAACZCAWxOoW7UkOres42+JEzuGy7Q7V7aMmDV+gB8Z3KtdsNbP5R3eGWP7IlmSRJC9JQlWeiycBAKNAA2TAAmQAAmERAL1qpVG51Z1/C1xXcjhdcV+c3mHV4e2cdtePP/H5B1t3s+xecefejL3JEACJEACJEACnkiAbSIBJxBwG4dXfqrO9CG1mNGjYeHy352AgCZIgARIgARIgARIgAQ8mYDbOLxv3743vvxYOkTexfv23QcJUkiABEiABEiABEiABEjAKgG3cXgTxo+DOYtWGRsya8FvSJwovvGYARIgARIgARIgARIgARKwRMBtHN6BPVrj7v3HyFe6AfKXaQh5c0P/bq0stYlxJEACJEACJEACJEACJGAk4DYOb4zo36kfm1i/bArWL5uMfj+3RPRoUY0NYcBxAtQkARIgARIgARIggZBEwG0cXr1TxMk1fXhNj+eeBEiABEiABPxJgOokEKgEHj16AIrzGXxLp7m8w5u7ZD2cOX8Zsrck39Jo5iEBEiABEiABEiCBwCQQI0ZMUAKPgX/7zuUd3rmTBiJD2hTIlD4VDm5d/JX4t8H+1mcGEiABEiABEiABEiABtybg8g7vyInzAhXwqbN/o1Hbvqjfqpeft0CYFnrl2i0/M8ydeo82TWaYBEiABEIEATaSBEiABNyVgMs7vO/fv8esBb/i4aOnai9hUwkIeHmXb7/hU9GtXSP8MmUw/th3BCdPX7BoMlumtMbZ5fFDf7aow0gSIAESIAESIAESIAHXI+Bkh9f5DezYqoHzjfpa/PvKDUSMGAFpUyWDV+jQKFE4D/YdOuGbyh0JkAAJkAAJkAAJkIAnEHB5h/fuvYdo0bA64saJqfYSNpWAdMLDx8+QMF5so4lECeOqmWRjhEng3N9X1TuAm3UYgNPnLhlTPn78AErIZPD586cQ0/f6gOdY98dY57XBY88Pnvsh+zzQr4fcuxcBl3d4127aFahEDaEMJvYt40gQPw7WLZmEzb9OR5ECudC131i8fvNW5fv8+TMoIZOBLIkJKX2vBru2CSntZTtD5jntaL/z3A/Z40O7FPK/Pwm4grplD88VauZbh1gxv0PzjgMhD4617DIY5uKr9k27uLFjwPv5v8a8z7yfq5lkY4RvIGKE8IgSOZKSOlVLI16cWLh994FKDRs2HCghk0Ho0F4hpu/VYNc2HOshc6yz3/32O899vzxC2vjQLoX874YEXN7hHTekG7q0aaCczKb1KsNcAsI8VfIkePLUWzmvn7SZ2p17DiPfj1mVyQePnuDGrXsq/PLVa7WXjTje3v+8QKKE8eSQQgIk4BQCNEICJEACJEACgUfA5R1eaXrqFEnRt2sL5MiS/iuR9G8Vg8GAgT1ao++wKWjUpg+yZUmLrBnTKHN/7D2CZas3q/Cm7fvUa8nyl22EsdMWYlif9pBZX5XIDQmQAAmQAAmQAAk4iwDtBAoBt3B4peWRIkVA+x4jUL1xFznE35evY8b8lSockI38oMX8qUOwaPowNK9f1WiqTrUy6NmxqTquUamkeiXZvo3zMX1MH/VDGCqBGxIgARIgARIgARIgAZcn4DYO78BRM1GmeD7EjB5NQU2ZPAn+PHhShbkhgRBGgM0lARIgARIgARLwBwG3cXjlByhKFc0H+L5UwWAw4POXz+AfCZAACZAACZBASCXAdpOAYwTcxuH98gX4+PGjsVXysFkYLy/jMQMkQAIkQAIkQAIkQAIkYImA2zi8NSuXhPwMsPzE8Mz5v6J5p4FoULOCpTYxjgT8EOABCZAACZAACZBAyCbgNg5v2RIF0LZ5bRTJnwMv/n2FicN6oGjBXCG799h6EiABEiABEnCcADVJIMQScBuHV3ooQbw4aNeiLn5u1wj/+57vwRUmFBIgARIgARIgARIgAdsE3MbhPXfxCrr2HYMyNVsr+bn/WJy7eNV265jqfwLMQQIkQAIkQAIkQAIeRsBtHN6h42YjcaL4mDqqtxL5pbPhE+Z4WHewOSRAAiRAAq5CgPUgARLwHAJu4/B++fJFLWdImjghRNq3qAt5VZnndAVbQgIkQAIkQAIkQAIkEBgE3Mbh/fz5M7yfvzAykNeSGQ+CLcCCSYAESIAESIAESIAEXJ2A2zi8tauWQc2mP6Nll8FK6rTogXrVy7k6X9aPBEiABEIGAbaSBEiABFyYgNs4vJXKFMG8yQNRrGAuJfMmD0KF0oVdGC2rRgIkQAIkQAIkQAIk4AoEgtLhDVB7r16/jejRvkO1CiWURPsuCq7euB0gm8xMAiRAAiRAAiRAAiTg+QTcxuHtP2IawoYJY+yRMGG80H/4NOMxAyRAAiTgPgRYUxIgARIggaAk4DYO78dPHyFOrg4nXNiw6XvOewAAEABJREFUePf+vX7IPQmQAAmQAAmQAAmQgLsRCKL6uo3DazAYcPj4aSOWg0dP+ZnxNSYwQAIkQAIkQAIkQAIkQAImBNzG4e3TpQXGTl2g3tAgb2qYMGMRendpbtIUBkmABDyUAJtFAiRAAiRAAgEi4DYOb7rUybFszmjUqFRSybLZo5A2VbIANZ6ZSYAESIAESIAESMB9CLCm30rAbRxeaWDoUKFQJH9OJaG0sMRRSIAESIAESIAESIAESMAWAbdyeG01hGkk4CwCxwcWx+Fu2e3K2YGF7OqInRODSjirag7ZoRIJkAAJkAAJkIBfAnR4/fLgEQmQAAmQAAmQgGcQYCtIwEiADq8RBQMk4EMgW//tyDXqmE1JWMzngUnZ29PN2m+bj2FuSYAESIAESIAEgoWA2zi8Hz9+xKFjpzBv8RrMWvCrUYKFGgv1HAJsCQmQAAmQAAmQgMcTcBuHt/eQSVi1fgfefeCPTXj8qGQDSYAESCAYCIT09fvBgJxFkkCQEXAbh/ftuw8YPbALWjWuiRYNqxslyEixIBIgARIgARIgARIgAbck4DYOb9iwXvjw4aNbQvacSrMlJEACJOC5BLh+33P7li0jAbdxeN+//4gaTbti/PSFxvW7spaXXUgCJEACJEACQU6ABZIACbgVAbdxeNOl/gGli+ZFpIgR3AowK0sCJEACJEACJEACJBC8BNzG4TVdt2saDl58NktnIgmQAAmQAAmQAAmQgAsQcBuH1/v5Cyz5dSPkbQ0iS1dthsS5AENWgQRIgARIwCYBJpIACZBA8BJwG4e3/4hp2L3/GLJmSqPkj72HMXDUjOClx9JJgARIgARIgARIgARcnoDLOLz2SD149BgzxvVF1fLFlcwY2wd37j2wl43pJEACJEACJEACJEACIZyA2zi8oUJ9XdVQoQwhvPvYfBIgAQ8kwCaRAAmQAAk4mcDXXqSTC3CWucwZ0qB11yHGV5K16joUObJkcJZ52iEBEiABEiABEiABEnApAs6rjNs4vN3aNUL5kgVx8/Z9JZXKFEaXNg2cR4KWSIAESIAESIAESIAEPJKA2zi8sqShnObwDu3THiJlSxSAxHlkr7BRJEACDhOgIgmQAAmQAAnYI+DyDm/LLoNx9cZtyN6S2Gsg00mABEiABEiABEggBBBgE20QcHmHt2m9yogbOyZkb0lstI1JJEACJEACJEACJEACJACXd3hzZEmPyJEiQva6ZM2UFrFjxVRx7EMSIAF/EKAqCZAACZAACYRAAi7v8Op9MmLiPLx89Rov/n2JOs27oV23oVi4Yr2ezD0JkAAJkAAJhGgCC1duwthpS5wqOlBn252/fINuOtj2LDhkEXAbh/f8xatqpvfg0VPInSMTls8djc3b94as3mJrSYAESIAESMAKgQUrNmDcjKVOFb0oZ9tdsGKjbpp7EggSAm7j8IYK7VPVE6cuIGO6VIgUMQJCe3kFCSQWElIJsN0kQAIk4H4EMqZNjtzZM7ikZEyX3P2AssYeQcDHi3SDpnwfPy56D52Mw8fPIEeWdGp5A764QcVZRRIgARIgARIIQgIZ06dA7hyaw+tMcZKtTOlSBiEJFkUC/xFwG4e3V+dmkB+bmDamN6JEjoTn/7xAw9oV/msJQyRAAiRAAiRAAiRAAiRggYDbOLwRI4TXZnbTI0G8OLhx+z6OnDiLgnmzW2gSo4KJAIt1EQLFqrZBwoxlnSp605xtt3DlVrpp7kmABEiABEgg0Ai4jcPbqG1ftYzhzr2H6NRrJA4c/gtDx84ONDA0TALuSuAL1/q4a9ex3h5DgA0hARJwNQJu4/Diyxf1loZDx06hfKlCGDO4Ky5dveFqPFkfEnAZAvVqlEbnVnVcUurXKOMynFgREiABEiABzyfgNg7v589f8Pbdexw/dR7pUidTPRPK4DbVV/U13TAcdAS8z+7C4W7ZnSp3d/jcXZC9s217n9sddHBYEgmQAAmQAAmEAAJu4zHKet26LXrgzr1HyJYpDR4+forw4cOFgC5iEwNK4It2dyCgNoI0v7vVN0jhsDAPJMAmkQAJkECgE3Abh7dpvcpYtWAcFk0fBi8vL4QLGwa9uzQPdEAswHMIhI+dBAmLt3CaxCnUyGm2pF5SP8+hzZaQQPAT+Pf6SZyf0cKp8viYzy98yt7Ztv+9djz4obEGJOChBNzD4dXgv//wAfOWrEX/EdO0I+CZ97+4fuOuCnNDAiRAAiRAAuYEPr56jn+vnXCqvH/+QBUje2fb/vDSW9nmhgRIwPkE3MbhHThqBh48fIJbd+4rCgnix8bCFetUmBsSIAESCCkE2E7/EwgbPR5iZSvrNImWqaTTbEm9wkaL5/9GMQcJkIC/CLiNw3vj5l3Ij0+ECxdWNTC8tv/w8aMKc0MCJEACJEAC5gT09fuhvMIjXIyETpOw0eM7zZbUK3S4COZV5zEJkIB9Av7ScBuH18srtJ+GfaSz64cHD0iABEiABEiABEiABCwTcBuHN2O6VFi0cgNevnyNIyfOoGu/sSicP6flVjGWBEiABIQAhQRIgARIgAQ0Am7j8HZuXR8xY3yHMGG8MH76YhQpkAtN61bWmsD/JEACJEACJEACJEACtgiE9DS3cHg/fvqEMVMWoEyx/PhlymAsmz0SFUoVQqhQQVf9lWu3ol7LnmjQqjf2HjwR0scN208CJEACJEACJEACbkMg6DzGACDxCh0aN24F3yvIbt6+j4XL12PmuH4YNaATho6dpX71LQBNYlYScEECrBIJkAAJkAAJeCYBt3B4BX2smNHRtd8YbN99EEdPnjWKpAW2/HnoBOSX3iJFjIB4cWMhdYqkOHriLPhHAiRAAiRAAiTggQTYJI8j4DYO78PHT/Hy1RusWr8DcxevMUpQ9Mjjp8+QIF5sY1HfJ4iLR0+equNjf52DPVGKdjb2bEi6HRMqWfTsiVK0s7FnQ9LtmFDJomdPlKKdjT0bkm7HhEo+c/MZ7IlStLMRG2dvPbdpy44JlSx2dLmoDalLL8Ljr8t3/YwppWhnI+3X5cOH9wjjFQrPvJ/j4aMnRrFjQiWb6lsLK0U7G2t59Xipmx0TKllvk629UrSzsZVfT7NjQiXrurb2StHOxlZ+Pc2OCZWs69raK0U7G1v59TQ7JlSyrmtrrxTtbGzl19PsmFDJci7JOSXnln6eme+Vop2NeR5L574dEyrZ3I5+fMF47t9TevY2OgPzvem5b8+GpOvno6296NkTW/n1NHs2JN28PZaORc+eWMpnHmfPhqSb59GPJY3ifgTcxuGdMbYvLElQITeYrBc2GAzGYlt2Hgh7MmjQINgTezYk3Z4NSRc9eyJ69sSeDUm3Z0PSRc+eiJ49sWdD0q3ZWLlypeqvF4/voe/SE3blzM5VsCd9l57AwJWnbdqyZ0PSTesz+kgoTLyUAD9PXudnTFlrl2m8tF+X1y9fIFa0CDh58jT+2LPfKHv27IE9MdW3FrZnQ9Kt5dXjT5w8pfrk8ePHNs8NvU229qYcrIVt5dfTrOU1jdd1be1N9a2FbeXX06zlNY3XdW3tTfWthW3l19Os5TWN13Vt7U31rYVt5dfTrOU1je82Zb06p+TcMj3XTMMyXu2Jqb6ELZ379mxIuuS1JKMPGVQ9u03dYPN80NumMzDfm577Up490c9HW3t7NiTdVn49TfREjh07ZvXcN2+PpWOdga29pXzmcbby62nmefRj1QBu3I6A2zi8pssY9PDV67fx+fPnQIceO2YMPH/+j7EcmZ2KEyumOk6WJCHsSaFChVDIjtizIen2bEi66NkT0bMn9mxIuj0bki569kT07Ik9G5JuzUb69OlVX4XFe6SI8sauxPj8FPYkMO0kS/CdnzFlrV2m8dJ+XWAIhXcfPiFixAiIGiWyUZIkSYIkdsRU31rYng1Jt5ZXj5e6SadEihQJpu0wD+ttsrU3z2Pp2FZ+Pc1SPvM4XdfW3jyPpWNb+fU0S/nM43RdW3vzPJaObeXX0yzlM4/TdW3tzfNYOraVX0+zlM88Ts4lOVeTR/uE5HEiWBQZr/bEPG+y2OG/smXPhqSb2zEea/WTeiaL/53N80Fvn87AfG967kt59kQ/H23t7dmQ9KhR/rvOWLMleiIJEySUUx+Wzn3z9lg61hnY2lvKZx5nK7+eZp5HP1YN4MbtCLiNwzt1znK07zECA0fOUCLhHoMmoFL9jjh5+kKggs/3Y1bsO3QC796/124T/4Pzf19DruwZVJkr5o2HPSlQoADsiT0bkm7PhqSLnj0RPXtiz4ak27Mh6aJnT0TPntizIenWbKRNm1b1lVfEaOhbOr5difJDVtgTsdO7RBybtuzZkHSxo0vXLG/QMdV9zOhZ18+YstYu03hpvy7fRYuBZ/+8Re4fc6BsqaJGSZw4MeyJqb61sD0bkm4trx6f50efd2hHjBjR5rmht8nW3pSDtbCt/Hqatbym8bqurb2pvrWwrfx6mrW8pvG6rq29qb61sK38epq1vKbxuq6tvam+tbCt/Hqatbym8TN61FHnVPcc7zC0chKLEi+KF+yJed5BFRJ9ZcueDUk3t6Mfd8/+TtVzeveaNs8HvW06A/O96bkv56E90c9HW3t7NiTdVn49TfRE4ieIr67Hls598/ZYOtYZ2NpbymceZyu/nmaeRz9WDeDG7Qi4jcMbK2Y0jB3cFeuXTVYi4cTfx8fogZ0xbvqiQAWfOFF8VC5bFE3b90fHXqPQqXUDhA0TJlDL9DTjrtAer0jREDVZdqdJpKRZnGZL6iX1U5y+fFE7bkiABAJG4IvvufTe+wGeHN/oNHl+aqvTbEm93j9/ELCGMjcJkIBdAm7j8D58/Ax5cmaGwWBQIuF7Dx8jVfIkdhvpDIUalUpi8YzhWDh9KArmyeYMk7RBAiRAAiQQiAQMBoOyHipMeISNHt9pEiZa3IDY+iqv1E9VlBsSIIFAI+A2Dq8BBhw5ccYI4vDx0wgdOrQ6ljQV4IYESIAESIAEfAnoM7xho8VD7OzlnSbRM5d2mi2pV7gYPrf5favNHQmQQCAQcBuHt1fnZhg9eT4q1m2vZOzUBejZsSlev3mLahWLBwKaYDTJokmABEiABEiABEiABJxGwG0c3tQpkmLlvDEYP7S7khVzxyBtqmSIGCG8+plhpxGhIRIgARIgAZchwIqQAAmQgDMIuI3D+/7DB/yy9HcsWP47fkiSENdv3sPOPYedwYA2SIAESIAESMBjCCxeuRnjpi91SVm0cpPHcGZD3IuA2zi8A0fNwIOHT3Drzn1FOEH82Fi4Yh0AdcgNCZAACZAACZAACZAACVgk4DYO742bdyHreMOFC6saEl7bf/j4UYW5IQESIAESAEAIJKARqFejNDq3quOSUr9GGa2G/E8CQU/AbRxeLy+fNzLoiD7S2dVRcE8Cfgjoby3ZtusQVq7d4ZKydddBP3XmAQmQAAmQAAk4k4C5LbdxeDOmS4VFK6Zp8EwAABAASURBVDfg5cvX6vVkXfuNReH8Oc3bw2MSCPEEvsDnhysePfbGnfuPXFKkbiG+owiABEiABEggyAi4jcPbuXV9xIzxHcKE8cL46YtRpEAuNK1bOchAsSD3J/D28Q3c3T7LafJo93yn2ZJ6Sf2cQVmf4S1RKBeqVyjqklK8cC5nNDWANpidBEiABEggpBBwC4f346dPGDNlAcoUy49fpgzGstkj1avIQoVyi+qHlLHEdroIAX2GN06cGEiUMK5LSrzYMV2EFqvhyQQMBoNq3uePb/Hu2V2nyXvv+06zJfX69O6Nqic3JBBsBEJAwW7hMXqFDo0bt+6GgO5gEwODQIwMRZBr1DGnSsJizVVVZe9s29HTF1a2uSEBEnAOgffeD/Dk+EanyfNTW51mS+r1/vkD5zSUVkiABKwScAuHV2ofK2Z0dO03Btt3H8TRk2eNImkUEiCBQCfAAkjA7Qh4RYqGKD9kdaqEjRZPcZC9s22HiRxd2eaGBEjA+QTcxuF9+PgpXr56g1Xrd2Du4jVGcT4SWiQBEiABEvAEAlGSZkHalrOcKrGzl1doZO9s21F+yKZsc+PqBFg/dyTgNg7vjLF9YUncETrrTAIkQAIkQAIkQAIkEHQE3MbhDTokLIkEAk6AFkiABEiABEiABFyHAB1e1+kL1oQESIAESIAEPI0A20MCLkGADq9LdAMrQQIkQAIkQAIkQAIkEFgE6PAGFlnadZwANUmABEiABEiABEggEAm4jcPbsstgmEuPQROwesMOyA9TBCIjmiYBEiABEiCBICHAQkiABAKHgNs4vEn/lxCfP39G8UI/KpFwGC8vHDx6CiMmzA0cOrRKAiRAAiRAAiRAAiTg9gTcxuE9//dVTB/bF1XLF1ci4eu37mL0wC44d/GK23eE4w2gJgmQAAmQAAmQAAmQgH8IuI3D+/79exjMWiZxEhUhfHjZUUiABEiABEISAbaVBEiABBwk4DYOb/YsGdCm2zD8vukPJW1+HoqcWTPi9Zu3+Pzli4PNpRoJkAAJkAAJkAAJkEBII+A2Dm/n1vVRvlRBHDlxVknF0oUhcREjhMf8KYOt9RvjSYAESIAESIAESIAEQjgBt3F4DQYDyhTLj6F92ispXSwfQoVym+qH8GHG5pMACQQ/AdaABEiABEIuAbfxGG/ffYDp81agXffhfl5PFnK7ji0nARIgARIgARIgARJwhIAfh9eRDMGlM2TsLHz3XVTUq1EWTetVNkpw1YflkgAJkAAJkAAJkAAJuAcBt3F4o0aJhDpVSyNXtozIkSW9UdwDM2tJAiTgZgRYXRJwOwIG33cZPXr0DLfvPnRJefD4qdtxZYU9g4DbOLxhw4TBjVv3PIM6W0ECJEACJEACgURg2+7D+HXdTpeU7bsOB1KraTbwCHiGZbdxeK/dvIvazbuhfqteXMPrGWOPrQgkApzlCSSwNEsCLk4gU7oU+DFbeqeK3mRn282cPqVumnsSCBICbuPwyivIJo3ogfYt6oBreINkbLAQNycQlLM8/p1N4iyPmw8uVt8lCYwd1BGrfhnpVNEb6my74wd30k1zTwJBQsBtHF7Tdbum4SChxEJCFIHjA4vjcLfsNuXujtmKiezt6Z4YVELpBtWGszxBRZrlkAAJkMBXBBjhogRc3uFt2WUwrt647WcZg8Tp4qJcWS0SCDYCnOUJNvQsmARIgARIwEUJuLzDK8sX4saO6WcZg8Tp4qJcWS03JpCt/3bkGnXMrqTvv9uujtjJ2m+bXxo8IgEScEkClxZ0xfkZLWzK42PrVd1lb09X7CllbkiABIKdgMs7vLJ8IXKkiMbXkMmxqQQ7QVaABEiABEjAIwi8vHka/147YVPeP3+g2ip7e7piTylzY5UAE0ggqAi4vMM7Zc4y2JKgAsVySIAESIAEPJtAygajkeanGXYlacPxdnXEjtjzbGJsHQm4DwGXd3hldteWuA9q1vTbCDAXCZAACQQNgchJMiFqsux2JVKSLHZ1xI7YC5qasxQSIAF7BFze4W1UuyJsib0GMp0ESIAESIAEPIIAG0ECJPDNBFze4bW1nEHSvrnlzEgCJEACJEACJEACJBAiCLi8w2trOYOkhYhecryR1CQBEiABEiABEiABEjAj4PIOr63lDJJm1h4ekgAJkAAJkAAAQiABEiCB/wi4vMOrV9X7+Qss+XUjeg+ZpGTpqs2QOD2dexIgARIgARIgARIgARKwRMBtHN7+I6Zh9/5jyJopjZI/9h7GwFEzLLXJ4TgqkgAJkAAJkAAJkAAJeD4Bt3F4Hzx6jBnj+qJq+eJKZoztgzv3fF4A7vndxBaSAAmQQKASoHESIAES8GgCbuPwhgr1dVVDhTJ4dOewcSRAAiRAAiRAAiRAAgEn8LUXac1mMMdnzpAGrbsOwawFvypp1XUocmTJEMy1YvEkQAIkQAIkQAIkQAKuTsBtHN5u7RqhfMmCuHn7vpJKZQqjS5sGrs6X9SMBEvBAAmwSCZAACZCAexFwG4dXljSU0xzeoX3aY0jvdogQITxadBrkXrRZWxIgARIgARIgARLwHAJu0xKXd3gvXb2Jxm37onDFpup1ZPKgWo0mXfHL0rVoVr+y24BmRUmABEiABEiABEiABIKHgMs7vEPGzELuHBkxqEcbxIzxHVp2HoJsmdNh4bSh+DF7puChxlJJgAQcJ0BNEiABEiABEghmAi7v8L5+8wYtGlZH/txZ0bl1Q7zSjju1qgeDgW9oCOaxw+JJgARIgARIgAT8QYCqwUfA5R1eczTRokZBuLBhzaN5TAIkQAIkQAIkQAIkQAIWCbi8w3v3/iPkLlnPKA8ePTGGJd5iqxhJAm5LgBUnARIgARIgARJwNgGXd3gnjegBW+JsILRHAiRAAiRAAiTgAgRYBRJwIgGXd3hzZEkPW+JEFjRFAiRAAiRAAiRAAiTggQRc3uH1QOZskvMI0BIJkAAJkAAJkAAJ2CVAh9cuIiqQAAmQAAmQgKsTYP1IgARsEQjxDu+ps3+jUdu+qN+qF+YsWmWR1Yo1W/08KLdwxXqLeowkARIgARIgARIgARJwPQIh2uH98uUL+g2fim7tGuGXKYPxx74jOHn6gsVealqvCg5uXaykQc3yFnVcPZL1IwESIAESIAESIIGQSCBEO7x/X7mBiBEjIG2qZPAKHRolCufBvkMnQuI4YJtJgARIICQRYFtJgARCGIEQ7fA+fPwMCePFNnZ5ooRx8fDRU+OxaWDpb5tQuGJTdBswDo+ePDNNYpgESIAESIAESIAESMCFCXi0w3vz9n206DTQorx6/UZ1iyGU6U8Um+BQqT6b4oV+xLZVM7Bo+jBEiRwZQ8bM8knQtq9evQQlZDJ4//59iOl7bair/xzrIXOss9/99jvPfb88Qtr4UBdDbtyOgGUPz+2aYbnCiRPFx9jBXS1KpIgREDd2DHg//9eY+Zn3c8SNE9N4rAdiRP8OXl5e+D5BXHRqVQ8XLl3TkxAxYiRKCGUQJkyYENP38P3jeA+Z5zv73W+/89z3yyOkjQ/fyyF3bkYglJvV19/VjRI5kjYr+7WIoVTJk+DJU2/cvvsAnz5/xs49h5Hvx6yShAePnuDGrXsq/PLVa7WXzR97DyNNyh8kqMRgMMBgoBgMZGAweC4DNdi1jcHguW00GNg2g4EMDAYyMBj+Y6Cd9uq/wfBfnMEQssMKCDduR8BJDq/btVtV2GAwYGCP1ug7bAoatemDbFnSImvGNCrtj71HsGz1ZhUeMmamei1Z0UrNcPj4GfTt2gL8IwESIAESIAESIAEScA8CIdrhlS7KlD4V5k8dotbnNq9fVaKU1KlWBj07NlXhEf07qdeR7Vw7B0P7tEfsWDFUPDckQAIk8BUBRpAACZAACbgcgRDv8Lpcj7BCJEACJEACJEACJOABBFypCXR4Xak3WBcSIAESIAESIAESIAGnE6DD63SkNEgCJOA4AWqSAAmQAAmQQOAToMMb+IxZAgmQAAmQAAmQAAnYJsDUQCVAhzdQ8dI4CZAACZAACZAACZBAcBOgwxvcPcDyScBxAtQkARIgARIgARL4BgJ0eL8BGrOQAAmQAAmQAAkEJwGWTQL+I0CH13+8qE0CJEACJEACJEACJOBmBOjwulmHsbqOE6AmCZAACZAACZAACQgBOrxCgUICJEACJEACnkuALSOBEE+ADm+IHwIEQAIkQAIkQAIkQAKeTYAOr2f3r+OtoyYJkAAJkAAJkAAJeCgBOrwe2rFsFgmQAAmQwLcRYC4SIAHPI0CH1/P6lC0iARIgARIgARIgARIwIUCH1wSG40FqkoBnENi26xCqNu5uV/TWOqIrNnV97kmABEiABEjAFQjQ4XWFXmAdSCCYCDx4/AyHjp+1K3r1HNEVm7o+9yGAAJtIAiRAAm5AgA6vG3QSq0gCgUWgRKFc+HXucKeK2Ays+tIuCZCAcwgsWLERCTOWtSt6aY7oLly5SVfnngRcjkBQOLwu12hWiARIwIdAvDgxkSdHRqeK2PSxzi0JkAAJkAAJuAYBOryu0Q+sBQmQQIggwEaSgGsQaFizLO6e3uhUaVCjjGs0jrUgAQsE6PBagMIoEiABEiABEiABEiCBQCQQxKbp8AYxcBZHAiRAAiRAAiRAAiQQtATo8AYtb5ZGAiTgOAFqkgAJkAAJkIBTCNDhdQpGGiEBEiABEiABEiCBwCJAuwElQIc3oASZnwRIgARIgARIgARIwKUJ0OF16e5h5UjAcQLUJAESIAESIAESsEyADq9lLowlARIgARIgARJwTwKsNQl8RYAO71dIGEECJEACJEACJEACJOBJBOjwelJvsi2OE6AmCZAACZAACZBAiCFAhzfEdDUbSgIkQAIkQAJfE2AMCYQEAnR4A9jLHz68ByVkMggbNiz7nuOfYyAEjgGe+yHzmq9/1gfQbWD2YCJAhzeYwLtXsawtCZAACZAACZAACbgvATq87tt3rDkJkAAJkEBQE2B5JEACbkmADq9bdhsrHZwEnjz1Rttuw9CkXT/0GjwRb96+Dc7qsGwSIIEgIrB20x+o3exn5C5ZD97PXwRRqSyGBEjAGQTo8DqDol8bPPJwAhNnLsGP2TNh3uRBiBo1Cpb8usnDW8zmkQAJCIG4sWNiUK+2iBUzuhxSSIAE3IgAHV436ixW1TUI7D/8F8qWyK8qU7Z4fvx5+KQKc0MCJGBOwLOOc+fIhBQ/JPasRrE1JBBCCNDhDSEdzWY6h8Cr129gMADRo0VVBhMljIvHT56pMDckQAIkQAIkQAKuSSDYHV7XxMJakYB1AqFC/XfaGAz/ha3nYAoJkAAJkAAJkEBwEuCndXDSZ9luRyBSxAj49Okz3n/4oOr+1Ps5YseKocLckEAACTA7CZAACZBAIBGgwxtIYGnWcwnkyZkZO3YfVA3ctusA8uXKrMLckAAJkAAJkAAJOIOA823Q4XU+U1r0cAIdW9bF+q171WvykxU1AAAHxklEQVTJbt2+j7rVy3p4i9k8EiABITB93gr1SjJ5NWGZmq3Rtd8YiaaQAAm4AYFQblBHVpEEXIqAvJJo+pg+6rVkw/p2QITw4V2qfiGlMmwnCQQ1gVZNauLg1sVGGTOoa1BXgeWRAAl8IwE6vN8IjtlIgARIgARIgARIwAUIsAoOEKDD6wAkqpAACZAACZAACZAACbgvATq87tt3rDkJOE6AmiRAAiRAAiQQggnQ4Q3Bnc+mkwAJkAAJkEBII8D2hkwCdHhDZr+z1SRAAiRAAiRAAiQQYgjQ4Q0xXc2GOk6AmiRAAiRAAiRAAp5EgA6vJ/Um20ICJEACJEACziRAWyTgIQTo8HpIR7IZJEACJEACJEACJEAClgnQ4bXMhbGOE6AmCZAACZAACZAACbg0ATq8Lt09rBwJkAAJkID7EGBNSYAEXJUAHV5X7RnWiwRIgARIgARIgARIwCkE6PA6BaPjRqhJAiRAAiRAAiRAAiQQtATo8AYtb5ZGAiRAAiTgQ4BbEiABEggyAnR4gww1CyIBEiABEiABEiABEggOAq7t8AYHEZZJAiRAAiRAAiRAAiTgUQTo8HpUd7IxJEACnkqA7SIBEiABEvh2AnR4v50dc5IACZAACZAACZAACQQtgW8qjQ7vN2FjJhIgARIgARIgARIgAXchQIfXXXqK9SQBEnCcADVJgARIgARIwIQAHV4TGAySAAmQAAmQAAmQgCcRYFt8CNDh9eHALQmQAAmQAAmQAAmQgIcSoMProR3LZpGA4wSoSQIkQAIkQAKeTYAOr2f3L1tHAiRAAiRAAiTgKAHqeSwBOrwe27VsGAmQgH8JXLl2C7lL1vMjS3/bZNNMh54jsf/wXxZ1WnYZjJOnL1hMYyQJkAAJkEDQEaDDG3SsWZJnEGArPJxA1CiRcXDrYqPUqVbGw1vM5pEACZCA5xOgw+v5fcwWkgAJBJDAvy9fYfCYWajXsifq/dQTvyz93aLFi5evo1mH/poMQPcB4/D23XuLeowkAc8gwFaQgPsQoMPrPn3FmpIACQQBgRf/vvSzpOHJU2/MWrAK/758iYXThmLiiO5Yu3En/jx08qvaDBw1HWWK5ceciQNQoXQR/K05wF8pMYIESIAESCDICdDhDXLkIatAtpYE3I2A+ZKGWDGj48Sp86hTtQxChQqFmNGjoXTxfDh+6pyfpv3z4iUePX6GSmWLqPi8uTIjcaL4KswNCZAACZBA8BKgwxu8/Fk6CZCAGxD4gi/w8gptrKlXaC98+fLFeCwB0RGHWESORURP9hQSAEAIJEACwUiADm8wwmfRJEAC7kEgW6Z0WLZqs3Jyn3o/x9Y/9iNHlgx+Kh8tahTEihkNp87+reLvPXiEG7fuqjA3JEACJEACwUuADm/w8vdbOo9IgARckkCLhlURPnx4NGjdGx16jESZ4gUgSxbMKzugWyvMX7YObX4einFTFyJ+vNjmKjwmARIgARIIBgJ0eIMBOoskARJwTQLJf/gftv4246vKRYkcCX27tsCi6cOweOZwNK5T0agzcXh3o/ObKkVSjB/6M6aO7o0xg7vi11/GIkvGNEZdBhwnQE0SIAEScCYBOrzOpElbJEACJEACJEACJEACLkfAjR1el2PJCpEACZAACZAACZAACbggATq8LtgprBIJkAAJ+IsAlUmABEiABGwSoMNrEw8TSYAESIAESIAESIAE3IWAtXrS4bVGhvEkQAIkQAIkQAIkQAIeQYAOr0d0IxtBAiTgOAFqkgAJkAAJhDQCdHhDWo+zvSRAAiRAAiRAAiQgBEKQ0OENQZ3NppIACZAACZAACZBASCRAhzck9jrbTAKOE6AmCZAACZAACbg9ATq8bt+FbAAJkAAJkAAJkEDgE2AJ7kyADq879x7rTgIkQAIkQAIkQAIkYJcAHV67iKhAAo4ToCYJkAAJkAAJkIDrEaDD63p9whqRAAmQAAmQgLsTYP1JwKUI0OF1qe5gZUiABEiABEiABEiABJxNgA6vs4nSnuMEqEkCJEACJEACJEACQUCADm8QQGYRJEACJEACJGCLANNIgAQClwAd3sDlS+skQAIkQAIkQAIkQALBTIAObzB3gOPFU5MESIAESIAESIAESOBbCNDh/RZqzEMCJEACJBB8BFgyCZAACfiTAB1efwKjOgmQAAmQAAmQAAmQgHsR8FSH1716gbUlARIgARIgARIgARIINAJ0eAMNLQ2TAAmQgCsQYB1IgARIgATo8HIMkAAJkAAJkAAJkAAJeDQB5fB6dAvZOBIgARIgARIgARIggRBNgA5viO5+Np4ESMCMAA9JgARIgAQ8kAAdXg/sVDaJBEiABEiABEiABAJGwLNy0+H1rP5ka0iABEiABEiABEiABMwI0OE1A8JDEiABxwlQkwRIgARIgATcgQAdXnfoJdaRBEiABEiABEjAlQmwbi5OgA6vi3cQq0cCJEACJEACJEACJBAwAnR4A8aPuUnAcQLUJAESIAESIAESCBYCdHiDBTsLJQESIAESIIGQS4AtJ4GgJkCHN6iJszwSIAESIAESIAESIIEgJUCHN0hxszDHCVCTBEiABEiABEiABJxDgA6vczjSCgmQAAmQAAkEDgFaJQESCDABOrwBRkgDJEACJEACJEACJEACrkzg/wAAAP//SEZiCwAAAAZJREFUAwBScCtB9DxIeAAAAABJRU5ErkJggg=="
      },
-     "metadata": {},
+     "metadata": {
+      "image/png": {
+       "alt": "Grouped box plots with one group of three boxes per fold along the horizontal axis, coloured amber, copper and slate for the 5-, 15- and 60-minute components. A dashed rule marks zero. In every fold the amber 5-minute box sits highest and above the rule, while the copper and slate boxes for the two longer horizons sit lower and straddle it. Boxes span the quartiles and the whiskers the 5th to 95th percentiles."
+      }
+     },
      "output_type": "display_data"
     }
    ],
@@ -3849,18 +3876,25 @@
     "    height=440,\n",
     "    margin={\"t\": 120},\n",
     ")\n",
-    "fig.show()"
+    "show_plotly_with_alt(\n",
+    "    fig,\n",
+    "    \"Grouped box plots with one group of three boxes per fold along the horizontal axis, \"\n",
+    "    \"coloured amber, copper and slate for the 5-, 15- and 60-minute components. A dashed rule \"\n",
+    "    \"marks zero. In every fold the amber 5-minute box sits highest and above the rule, while the \"\n",
+    "    \"copper and slate boxes for the two longer horizons sit lower and straddle it. Boxes span \"\n",
+    "    \"the quartiles and the whiskers the 5th to 95th percentiles.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3148b6fd",
+   "id": "44e50d07",
    "metadata": {
     "papermill": {
-     "duration": 0.004655,
-     "end_time": "2026-08-10T15:41:44.381328+00:00",
+     "duration": 0.004774,
+     "end_time": "2026-08-11T12:36:18.200223+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:44.376673+00:00",
+     "start_time": "2026-08-11T12:36:18.195449+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3882,13 +3916,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2629092b",
+   "id": "0cd01948",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-08-10T15:41:44.390404+00:00",
+     "duration": 0.004626,
+     "end_time": "2026-08-11T12:36:18.209535+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:44.385889+00:00",
+     "start_time": "2026-08-11T12:36:18.204909+00:00",
      "status": "completed"
     }
    },
@@ -3903,19 +3937,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "26385fde",
+   "id": "0cbb07c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:44.400427Z",
-     "iopub.status.busy": "2026-08-10T15:41:44.400279Z",
-     "iopub.status.idle": "2026-08-10T15:41:48.227878Z",
-     "shell.execute_reply": "2026-08-10T15:41:48.227476Z"
+     "iopub.execute_input": "2026-08-11T12:36:18.219823Z",
+     "iopub.status.busy": "2026-08-11T12:36:18.219647Z",
+     "iopub.status.idle": "2026-08-11T12:36:22.092355Z",
+     "shell.execute_reply": "2026-08-11T12:36:22.092027Z"
     },
     "papermill": {
-     "duration": 3.833494,
-     "end_time": "2026-08-10T15:41:48.228436+00:00",
+     "duration": 3.878832,
+     "end_time": "2026-08-11T12:36:22.092968+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:44.394942+00:00",
+     "start_time": "2026-08-11T12:36:18.214136+00:00",
      "status": "completed"
     }
    },
@@ -3955,13 +3989,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be22e4d0",
+   "id": "91ecb2cb",
    "metadata": {
     "papermill": {
-     "duration": 0.004661,
-     "end_time": "2026-08-10T15:41:48.238025+00:00",
+     "duration": 0.0049,
+     "end_time": "2026-08-11T12:36:22.104132+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:48.233364+00:00",
+     "start_time": "2026-08-11T12:36:22.099232+00:00",
      "status": "completed"
     }
    },
@@ -3976,19 +4010,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "5ed5e6a1",
+   "id": "585b59ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:48.247931Z",
-     "iopub.status.busy": "2026-08-10T15:41:48.247827Z",
-     "iopub.status.idle": "2026-08-10T15:41:51.722015Z",
-     "shell.execute_reply": "2026-08-10T15:41:51.721582Z"
+     "iopub.execute_input": "2026-08-11T12:36:22.114437Z",
+     "iopub.status.busy": "2026-08-11T12:36:22.114335Z",
+     "iopub.status.idle": "2026-08-11T12:36:25.687127Z",
+     "shell.execute_reply": "2026-08-11T12:36:25.686687Z"
     },
     "papermill": {
-     "duration": 3.47982,
-     "end_time": "2026-08-10T15:41:51.722376+00:00",
+     "duration": 3.578823,
+     "end_time": "2026-08-11T12:36:25.687715+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:48.242556+00:00",
+     "start_time": "2026-08-11T12:36:22.108892+00:00",
      "status": "completed"
     }
    },
@@ -4070,13 +4104,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2953edbe",
+   "id": "0e21418f",
    "metadata": {
     "papermill": {
-     "duration": 0.004699,
-     "end_time": "2026-08-10T15:41:51.732180+00:00",
+     "duration": 0.004862,
+     "end_time": "2026-08-11T12:36:25.697855+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:51.727481+00:00",
+     "start_time": "2026-08-11T12:36:25.692993+00:00",
      "status": "completed"
     }
    },
@@ -4090,19 +4124,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "7641fa32",
+   "id": "91bf4219",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:51.742256Z",
-     "iopub.status.busy": "2026-08-10T15:41:51.742165Z",
-     "iopub.status.idle": "2026-08-10T15:41:54.376752Z",
-     "shell.execute_reply": "2026-08-10T15:41:54.376303Z"
+     "iopub.execute_input": "2026-08-11T12:36:25.708365Z",
+     "iopub.status.busy": "2026-08-11T12:36:25.708256Z",
+     "iopub.status.idle": "2026-08-11T12:36:28.440132Z",
+     "shell.execute_reply": "2026-08-11T12:36:28.439493Z"
     },
     "papermill": {
-     "duration": 2.640421,
-     "end_time": "2026-08-10T15:41:54.377229+00:00",
+     "duration": 2.738037,
+     "end_time": "2026-08-11T12:36:28.440658+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:51.736808+00:00",
+     "start_time": "2026-08-11T12:36:25.702621+00:00",
      "status": "completed"
     }
    },
@@ -4164,13 +4198,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec040187",
+   "id": "75a37a4f",
    "metadata": {
     "papermill": {
-     "duration": 0.005085,
-     "end_time": "2026-08-10T15:41:54.388580+00:00",
+     "duration": 0.006581,
+     "end_time": "2026-08-11T12:36:28.452814+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:54.383495+00:00",
+     "start_time": "2026-08-11T12:36:28.446233+00:00",
      "status": "completed"
     }
    },
@@ -4192,19 +4226,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "1483e3b8",
+   "id": "94f4bba3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:54.398976Z",
-     "iopub.status.busy": "2026-08-10T15:41:54.398875Z",
-     "iopub.status.idle": "2026-08-10T15:41:54.934272Z",
-     "shell.execute_reply": "2026-08-10T15:41:54.933799Z"
+     "iopub.execute_input": "2026-08-11T12:36:28.464385Z",
+     "iopub.status.busy": "2026-08-11T12:36:28.464195Z",
+     "iopub.status.idle": "2026-08-11T12:36:29.061757Z",
+     "shell.execute_reply": "2026-08-11T12:36:29.061270Z"
     },
     "papermill": {
-     "duration": 0.541226,
-     "end_time": "2026-08-10T15:41:54.934729+00:00",
+     "duration": 0.604284,
+     "end_time": "2026-08-11T12:36:29.062229+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:54.393503+00:00",
+     "start_time": "2026-08-11T12:36:28.457945+00:00",
      "status": "completed"
     }
    },
@@ -4252,13 +4286,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aae73a05",
+   "id": "e7b9c5a3",
    "metadata": {
     "papermill": {
-     "duration": 0.004904,
-     "end_time": "2026-08-10T15:41:54.946835+00:00",
+     "duration": 0.005258,
+     "end_time": "2026-08-11T12:36:29.073730+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:54.941931+00:00",
+     "start_time": "2026-08-11T12:36:29.068472+00:00",
      "status": "completed"
     }
    },
@@ -4276,19 +4310,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "c46698d0",
+   "id": "8a8b9605",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:54.956904Z",
-     "iopub.status.busy": "2026-08-10T15:41:54.956773Z",
-     "iopub.status.idle": "2026-08-10T15:41:56.216432Z",
-     "shell.execute_reply": "2026-08-10T15:41:56.215976Z"
+     "iopub.execute_input": "2026-08-11T12:36:29.085254Z",
+     "iopub.status.busy": "2026-08-11T12:36:29.085140Z",
+     "iopub.status.idle": "2026-08-11T12:36:30.517229Z",
+     "shell.execute_reply": "2026-08-11T12:36:30.516668Z"
     },
     "papermill": {
-     "duration": 1.265224,
-     "end_time": "2026-08-10T15:41:56.216719+00:00",
+     "duration": 1.438942,
+     "end_time": "2026-08-11T12:36:30.517939+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:54.951495+00:00",
+     "start_time": "2026-08-11T12:36:29.078997+00:00",
      "status": "completed"
     }
    },
@@ -4391,13 +4425,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e24e6842",
+   "id": "aa24af25",
    "metadata": {
     "papermill": {
-     "duration": 0.005177,
-     "end_time": "2026-08-10T15:41:56.227341+00:00",
+     "duration": 0.00832,
+     "end_time": "2026-08-11T12:36:30.537395+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:56.222164+00:00",
+     "start_time": "2026-08-11T12:36:30.529075+00:00",
      "status": "completed"
     }
    },
@@ -4415,19 +4449,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "ca3f9e0a",
+   "id": "69f098f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:41:56.238441Z",
-     "iopub.status.busy": "2026-08-10T15:41:56.238333Z",
-     "iopub.status.idle": "2026-08-10T15:42:04.045091Z",
-     "shell.execute_reply": "2026-08-10T15:42:04.044330Z"
+     "iopub.execute_input": "2026-08-11T12:36:30.553880Z",
+     "iopub.status.busy": "2026-08-11T12:36:30.553756Z",
+     "iopub.status.idle": "2026-08-11T12:36:38.816147Z",
+     "shell.execute_reply": "2026-08-11T12:36:38.814304Z"
     },
     "papermill": {
-     "duration": 7.813121,
-     "end_time": "2026-08-10T15:42:04.045503+00:00",
+     "duration": 8.271944,
+     "end_time": "2026-08-11T12:36:38.816636+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:41:56.232382+00:00",
+     "start_time": "2026-08-11T12:36:30.544692+00:00",
      "status": "completed"
     }
    },
@@ -4457,19 +4491,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "077268e2",
+   "id": "8b889b0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:04.138202Z",
-     "iopub.status.busy": "2026-08-10T15:42:04.138035Z",
-     "iopub.status.idle": "2026-08-10T15:42:07.521042Z",
-     "shell.execute_reply": "2026-08-10T15:42:07.520361Z"
+     "iopub.execute_input": "2026-08-11T12:36:40.245584Z",
+     "iopub.status.busy": "2026-08-11T12:36:40.245360Z",
+     "iopub.status.idle": "2026-08-11T12:36:43.717554Z",
+     "shell.execute_reply": "2026-08-11T12:36:43.716740Z"
     },
     "papermill": {
-     "duration": 3.47076,
-     "end_time": "2026-08-10T15:42:07.521677+00:00",
+     "duration": 4.89538,
+     "end_time": "2026-08-11T12:36:43.717946+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:04.050917+00:00",
+     "start_time": "2026-08-11T12:36:38.822566+00:00",
      "status": "completed"
     }
    },
@@ -4495,13 +4529,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fa3abe3",
+   "id": "5a91c95b",
    "metadata": {
     "papermill": {
-     "duration": 0.005105,
-     "end_time": "2026-08-10T15:42:07.535757+00:00",
+     "duration": 0.009543,
+     "end_time": "2026-08-11T12:36:43.733632+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:07.530652+00:00",
+     "start_time": "2026-08-11T12:36:43.724089+00:00",
      "status": "completed"
     }
    },
@@ -4540,19 +4574,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "26b610af",
+   "id": "792f7bbc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:07.547297Z",
-     "iopub.status.busy": "2026-08-10T15:42:07.547109Z",
-     "iopub.status.idle": "2026-08-10T15:42:09.229968Z",
-     "shell.execute_reply": "2026-08-10T15:42:09.229369Z"
+     "iopub.execute_input": "2026-08-11T12:36:43.744899Z",
+     "iopub.status.busy": "2026-08-11T12:36:43.744792Z",
+     "iopub.status.idle": "2026-08-11T12:36:45.592212Z",
+     "shell.execute_reply": "2026-08-11T12:36:45.591566Z"
     },
     "papermill": {
-     "duration": 1.689542,
-     "end_time": "2026-08-10T15:42:09.230432+00:00",
+     "duration": 1.853877,
+     "end_time": "2026-08-11T12:36:45.592683+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:07.540890+00:00",
+     "start_time": "2026-08-11T12:36:43.738806+00:00",
      "status": "completed"
     }
    },
@@ -4585,13 +4619,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32e856c4",
+   "id": "11905945",
    "metadata": {
     "papermill": {
-     "duration": 0.005615,
-     "end_time": "2026-08-10T15:42:09.242778+00:00",
+     "duration": 0.032895,
+     "end_time": "2026-08-11T12:36:45.633943+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:09.237163+00:00",
+     "start_time": "2026-08-11T12:36:45.601048+00:00",
      "status": "completed"
     }
    },
@@ -4604,19 +4638,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "47682c17",
+   "id": "0efc1fc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:09.255818Z",
-     "iopub.status.busy": "2026-08-10T15:42:09.255631Z",
-     "iopub.status.idle": "2026-08-10T15:42:10.743485Z",
-     "shell.execute_reply": "2026-08-10T15:42:10.742729Z"
+     "iopub.execute_input": "2026-08-11T12:36:45.646584Z",
+     "iopub.status.busy": "2026-08-11T12:36:45.646453Z",
+     "iopub.status.idle": "2026-08-11T12:36:47.061080Z",
+     "shell.execute_reply": "2026-08-11T12:36:47.060482Z"
     },
     "papermill": {
-     "duration": 1.495617,
-     "end_time": "2026-08-10T15:42:10.743845+00:00",
+     "duration": 1.421527,
+     "end_time": "2026-08-11T12:36:47.061390+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:09.248228+00:00",
+     "start_time": "2026-08-11T12:36:45.639863+00:00",
      "status": "completed"
     }
    },
@@ -4656,13 +4690,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3598b612",
+   "id": "e36c701c",
    "metadata": {
     "papermill": {
-     "duration": 0.005589,
-     "end_time": "2026-08-10T15:42:10.755079+00:00",
+     "duration": 0.00504,
+     "end_time": "2026-08-11T12:36:47.071904+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:10.749490+00:00",
+     "start_time": "2026-08-11T12:36:47.066864+00:00",
      "status": "completed"
     }
    },
@@ -4679,19 +4713,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "ed2e7701",
+   "id": "5d7c36bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:10.766881Z",
-     "iopub.status.busy": "2026-08-10T15:42:10.766701Z",
-     "iopub.status.idle": "2026-08-10T15:42:10.780129Z",
-     "shell.execute_reply": "2026-08-10T15:42:10.779613Z"
+     "iopub.execute_input": "2026-08-11T12:36:47.082563Z",
+     "iopub.status.busy": "2026-08-11T12:36:47.082455Z",
+     "iopub.status.idle": "2026-08-11T12:36:47.096485Z",
+     "shell.execute_reply": "2026-08-11T12:36:47.096068Z"
     },
     "papermill": {
-     "duration": 0.020366,
-     "end_time": "2026-08-10T15:42:10.780637+00:00",
+     "duration": 0.019973,
+     "end_time": "2026-08-11T12:36:47.096835+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:10.760271+00:00",
+     "start_time": "2026-08-11T12:36:47.076862+00:00",
      "status": "completed"
     }
    },
@@ -4729,19 +4763,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "ae3a176a",
+   "id": "67489073",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:10.795591Z",
-     "iopub.status.busy": "2026-08-10T15:42:10.795471Z",
-     "iopub.status.idle": "2026-08-10T15:42:10.799500Z",
-     "shell.execute_reply": "2026-08-10T15:42:10.799032Z"
+     "iopub.execute_input": "2026-08-11T12:36:47.107300Z",
+     "iopub.status.busy": "2026-08-11T12:36:47.107208Z",
+     "iopub.status.idle": "2026-08-11T12:36:47.110973Z",
+     "shell.execute_reply": "2026-08-11T12:36:47.110592Z"
     },
     "papermill": {
-     "duration": 0.013435,
-     "end_time": "2026-08-10T15:42:10.799748+00:00",
+     "duration": 0.009625,
+     "end_time": "2026-08-11T12:36:47.111452+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:10.786313+00:00",
+     "start_time": "2026-08-11T12:36:47.101827+00:00",
      "status": "completed"
     }
    },
@@ -4787,13 +4821,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a30f22",
+   "id": "fe87b206",
    "metadata": {
     "papermill": {
-     "duration": 0.024675,
-     "end_time": "2026-08-10T15:42:10.829825+00:00",
+     "duration": 0.005057,
+     "end_time": "2026-08-11T12:36:47.126409+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:10.805150+00:00",
+     "start_time": "2026-08-11T12:36:47.121352+00:00",
      "status": "completed"
     }
    },
@@ -4808,19 +4842,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "4d95102a",
+   "id": "4b8e02d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T15:42:10.841591Z",
-     "iopub.status.busy": "2026-08-10T15:42:10.841466Z",
-     "iopub.status.idle": "2026-08-10T15:42:12.102427Z",
-     "shell.execute_reply": "2026-08-10T15:42:12.102048Z"
+     "iopub.execute_input": "2026-08-11T12:36:47.137086Z",
+     "iopub.status.busy": "2026-08-11T12:36:47.136960Z",
+     "iopub.status.idle": "2026-08-11T12:36:48.636702Z",
+     "shell.execute_reply": "2026-08-11T12:36:48.636071Z"
     },
     "papermill": {
-     "duration": 1.267546,
-     "end_time": "2026-08-10T15:42:12.102787+00:00",
+     "duration": 1.505775,
+     "end_time": "2026-08-11T12:36:48.637214+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:10.835241+00:00",
+     "start_time": "2026-08-11T12:36:47.131439+00:00",
      "status": "completed"
     }
    },
@@ -5029,7 +5063,11 @@
       },
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAJECAYAAAD0e/c3AAAQAElEQVR4AeydBUAUzxfHv0fb/dffz+4uVOzu7m7FbsUWW7FbMLBRjJ/d3d3dXdhNCvznDdx5nHdw5N3BQ2d2duZNfWZ27+3b2V0zX1+fQHbMgOcAzwGeAzwHeA7wHOA5wHMgts4BM/AfE2ACTIAJAGAITIAJMAEmEFsJsMIbW0eW+8UEmAATYAJMgAkwgYgQiIV5WOGNhYPKXWICTIAJMAEmwASYABP4Q4AV3j8sOMQEmID+BFiSCTABJsAEmIDJEGCF12SGihvKBJgAE2ACTIAJGB8BbpEpEGCF1xRGidvIBJgAE2ACTIAJMAEmEGECrPBGGB1nZAL6E2BJJsAEmAATYAJMwHAEWOE1HHuumQkwASbABJhAXCPA/WUCBiHACq9BsHOlTIAJMAEmwASYABNgAjFFgBXemCLN9ehPgCWZABNgAkyACTABJhCFBFjhjUKYXBQTYAJMgAkwgagkwGUxASYQNQRY4Y0ajlwKE2ACTIAJMAEmwASYgJESYIXXSAdG/2axJBNgAkyACTABJsAEmEBoBFjhDY0OpzEBJsAEmIDpEOCWMgEmwAR0EGCFVwcYjmYCTIAJMAEmwASYABOIHQTimsIbO0aNe8EEmAATYAJMgAkwASagNwFWePVGxYJMgAkwgdhEgPvCBJgAE4g7BFjhjTtjzT1lAkyACTABJsAEmECcJBCqwhsniXCnmQATYAJMgAkwASbABGIVAVZ4Y9VwcmeYABOIJgJcLBNgAkyACZgwAVZ4TXjwuOlMgAkwASbABJgAE4hZAqZZGyu8pjlu3GomwASYABNgAkyACTABPQmwwqsnKBZjAkxAfwIsyQSYABNgAkzAmAiwwmtMo8FtYQJMgAkwASbABGITAe6LkRBghddIBoKbwQSYABNgAkyACTABJhA9BFjhjR6uXCoT0J8ASzIBJsAEmAATYALRSoAV3mjFy4UzASbABJgAE2AC+hJgOSYQXQRY4Y0uslwuE2ACTIAJMAEmwASYgFEQYIXXKIaBG6E/AZZkAkyACTABJsAEmED4CLDCGz5eLM0EmAATYAJMwDgIcCuYABPQmwArvHqjYkEmwASYABNgAkyACTABUyTACq8pjpr+bWZJJsAEmAATYAJMgAnEeQKs8Mb5KcAAmAATYAJxgQD3kQkwgbhMgBXeuDz63HcmwASYABNgAkyACcQBAqzwqg0yB5kAE2ACTIAJMAEmwARiHwFWeGPfmHKPmAATYAKRJcD5mQATYAKxigArvLFqOLkzTIAJMAEmwASYABNgApoEIq7wapbE+0yACTABJsAEmAATYAJMwAgJsMJrhIPCTWICTMC0CHBrmQATYAJMwLgJsMJr3OPDrWMCTIAJMAEmwASYgKkQMNp2ssJrtEPDDWMCTIAJMAEmwASYABOICgKs8EYFRS6DCTAB/QmwJBNgAkyACTCBGCbACm8MA+fqmAATYAJMgAkwASZABNjFHAFWeGOONdfEBJgAE2ACTIAJMAEmYAACrPAaADpXyQT0J8CSTIAJMAEmwASYQGQJsMIbWYKcnwkwASbABJgAE4h+AlwDE4gEAVZ4IwGPszIBJsAEmAATYAJMgAkYPwFWeI1/jLiF+hNgSSbABJgAE2ACTIAJ/EWAFd6/kJhuhPNSN5Sv0QJJ0xXEgsWrY6QjT569QGv7/siSvzwy5C4dI3XG9kpmzl+Gmo06RrqbUVVOpBsShwrIWqA8tu8+ZDQ9TpmpCA4dO2007eGG/E3g7IUr8pzt7e3zd2KkYiKW+ead+7I9nz5/1VnAmvVbUbxiA53plMC/DUSBnTERYIXXmEZDrS1+fn7IXqgiMuUti5+/PNVStAfff/iEEeOmY3C/rvj84ip6d2unXTCKYxctWwtPT29cOrEdL+5G3Q8rKdEjx8+I4tbG3uLoYmP3vqOxt4NG1jO6oKxYu9VfrSphVxgpkif9Kz66I3S1J7rrjcryY9sxf/X6bak4fv32PSox6V2WoeuPrt8GvQGwIBPQIMAKrwYQY9ndc+A48uTKjrKlimHTlt1hNuv1Gw8pU75scZiZ6TesMkMkvddv3yF/nhxInizmf+Qj2XTOzgSinMBa1zkoU7JolJfLBTIBUyPAvw2mNmKxv70xpxnFfpZR2kP3/7ajUb3qwtXAuv92hlq266r1UFqb0ucqJa0KSgX4wJGTqNGwAzLmKYOi5ephyqxF8Pf3l+UdErc6Kf73799yn25B0XIIh5FOcp+8KbNc0KRNTwr+5XIWrgyyKs5btErW2X/YBCnz5es3UBm2ZeqA2tOoVQ/cuvtAppF3594jDHF0ErfEGsplEPVbdMX1W3cpSbo+DmNluQuXrAG1h9z9h09lHFkypVCwR/GUruyv8jY+WbzsKtRHsvSFpGRYbaL2te/mgDzFqsk689pVx7GT52RebR4xIQt0r4GjQbINWnaTYktXukteZJkn3pOmL4CSLwkob18eOXFGjhnxqdvMHpev3qRkre7V67dy7AYOn4TAwMC/ZIqUrYvvP37KpSXEgvqgLkTzo1j5enLZiX3vYfB4/0E9GaHNkRCCajuHj58BtZvGg25t0t0FT08vKaGLDfWRONGco7kxasJMeHl5yzzk7dhzCDRXKJ36UaFWS7wRF1SUFt7xobsi/YdOQKkqjeV4ps1REjRPqSxy/uIYmL9oNcpUbQpKo+OH6qc0paPjQTknctlWAY313fuPsW7TDlDblRY0autKt/9kNs0lDWH1WTlfl6xwR2hjJAvX4YXWHsry7v1HNG3bUx5r1N8Nm3dRtMrde/AEbboMAPWR7ir16O+IsKyStFRi1brNcrxork+dvVieV8JiOn3uUlRr0A6psxaT49KxxxDZDl3HvEzU8AICArBo2TpUqtNajl3V+u1A/EiMxn3itPmyDjq2aA5t2bGPklROB/MQxwXNYceJMzFg+ETkLloV+UvUxPgp80Icy76+fqC6aNyorjpN7XHm/GVZz/MXr+XxTTvEh+ZI174jaFenO3HmAirUbIl0OUuiVuNOoPmlLhye4zS0+kNrt3p96mE6n9L5jPrSqnM/fPv2Qz35r7C23wbluW/foROgcUmTzQ4nz1xEWO1R5jt49JTMR8dYzwGj8eHjZ1y7eQdtuwyUd0LpDoHyd+CvBokIGncaB01Hc1ck6zV/tc37sNpPZbMzDgJmxtEMboU6AY93H4SydR71alVBzarl8eDhkxAKo7oshe3bt8DB7UFrdl/dP4uvr64j7b9pcPzUefR1GIcObRrj8smdcJk9ARcuXcc4p7mUDSWKFcYvoaQoT6xnzl9BqpTJxUn7kkwn7+yFqyhZvAgF/3L3rx5GjSrl0K9HB1nnnCmOUqZtl0H48fMnls53wrUze1CnZkXxw9gdypPRt+/fkT9vLmxctQCnD25CpfKlZLpSEZs/Yyxq16iIXl3bynKpPzmzZ5Zl6+PRSfDytVui/IV4fueUzBJWm4Y6TkW6tGmwf+tKPL11AhMdByFePBuZV5e3fM0mZM2SESf3b8DqJTOl2PcfnhjU1x43zu3FtInDcPrcFTjNdJZp6t7qdVsxc9IIXDi2DenT/ovu/UdqVWZJoa8pfvyaNKiJWU4joVAo1IuRYRrbxIkSgqyLxOrOxQMynrwnT19g176j6N+rM4b07ybacxlTZi6iJOnCmiNSSMOjPKQQVK1UFpdO7MC65XPFbfzk8Au+cCJxTTY09vWad0Wa/6WSc3HBzHFwF4qjw8jJJC7myy907jUMLZrUwfWze3Dt9G50aNVY1d/wjs9c5+V49uIVXBdMxesHZ+G+Yi7S/vM/WRd50+Ysxo69hzBu1ADcuXQAQ/t3x9jJc0A/xpROS4SqCUUqQfz42OzmgjOH/0NpYbn9/uMHWjWtJ+dH4YJ5VfOzQ5smlC2EC6vPSmGar6TYb1rtjG3rF+PJs5chxmijuMNDP9IfP31RZgmxDas9xKJg/txwnjUBObJnEXNtFJ49fyXLoH7Wb94FBfPlwc5Ny3BAnEeSJEmIZu17gxRLKaTDI0WhY9smuHf5EHrYt0ZYTOkijy4IJ4waiKc3T+CEOG7sihSUpYfnmJ86exHmuqxA3+4dcPfyQUwbPxRewetffX19YW1tg9lOjnIe9erSFiPGzfhrHXNYzKlRazfsQDHbAvIcRccezenN2/dRknRjJs/G0pUbMHXCMFlXrhxZUb9FNzx8/BwZM6TF0d3rpNyz2ydBx+WSeZPlvi7PxXWtPMavirmfO2c2NGzVHXShTvJ0zIV2LicZdRda/aG1W70MZXj95p3yAq9fz464enoXShYrgvnCyKFM17bV9dtAsjPnu2LGxOF4de8M6BjStz1zFq5Ai8Z1MV7Mn/OXrqLXQEeMHDdT3lEZL47jm7cfiAuQhVSFVjeoT2c5DjQW5FYtninl7IoUkNuw5q8UEt5UcXGnPu/1bb/Iyv8NTIAVXn0HIAblVq3bgmqVyiJZ0iSwsbFGgzrV4LZ+a7hbMHvhcnTp2FKeJFKmSIZi4sdlhEMP0ImbCkuYID7ohH7qXJBV4qxQeEl5phM2KZ/e4keElOBSxQuTuF7uxOkL0jKxUCg0RQrnF4pQUnRq2wy2hfJi8479soySdrZo26Kh/FFIn+5fqTDny5MTe/YflelR4c2Z6ohMGdOBFEF92vTW4x0K5c8Dak8ywb1h3WooXjTIOqyrPYUL5MXA3p3lcg6qh+QGiZMq9Y/2K5UrhaEDumHtxh2UFMKNcOglmOTDP2n+hz7d28kfyXcfPqpkFAoFyOpdp2knwac9hg3soUoLT4CUUHehkLZuVh/dO7dCt06tcP7SNVURYc0RlaBagPK0bFJPKBzt8b9UKZA1c0ZQv5MkTqSS0mSz2n0LaL7NnjIKNBdLFS8Cx6F9BJvt0lLzSShztG69jFAqkyZJLMeOlEjiQ4WGd3zeenxA5kzpkSdXNpDSWq60HRrXr0lFwcfHF3OcV2CC+JGsXL4UqN01qpZD+9ZNsGrdf1JmhbDYUvy86aORO2dWOcathKIb1pyQmYO9sPocLCaP87Ej+ss+FxAXgq2b1cOFy3/GiC5CK5QtAUtLC2WWcG1biLEaNaSPuPCshCXzJslj4vK1m7IMOhcUyJcTg/t1QfasGZE5Y3o4jR2C23ceyuNYCunwWjWti7o1K8tzlLWVFcJiSmNCS5/sxHkofvx4oL6SoqyjeK3RdLeE6hnh0BMN6lSVfSGliS66KQOVT33Jmzu7HLOmDWuhgxjX9Rp3yegYD405lVWlYml5cUNlVq1YBpUrlMbFK0Hc6M6E66qNcOjbFXSck8yUcYPxr7ioWrZ6PWUPt6MLfNtC+aTRwWnsYDneW3cGnTPpmAvtXK5vZRFp96q1W+SdRjpnJxPnRjpf5RbHlb51asoNG9gdRcWFhIWFBczNzKAvxzHD+spzWGtxLuvTvT0OHDmFyWMd5DmtXctG6CZ+6y5fu6FZndb9G7fvSYWZ9ofZMgAAEABJREFU5kDFciX1OicoC1Kf95aiD/q2X5mft4YjYGa4qrlmbQTolrXbhm3yBKNMb1SvOjZt3QNSQJVx+mzvC8vwhKnzQNYhpatSr618CO6tx3tZBCmzZ4Nvwx0TFuFK5UqgVHFbnDpzSSpGVpaWUimWwnp4j588F1ZjT6TMVCREvfsOnlBZlTyFVZmWVlQQt+9SZS4q5ciC8fLVWz1qCFskp7BikbKilNSnTU2EBbW/uAVOt63nuqzEFWEhVubXtS1UIPdfSecuXkUrccsvV5Eqsl/1W3QFWeypz+rC6f5NrdpNlTKFDNMtOhkQHlkn64pbpCOFYkwXISIqQv/JAq1uqc6UIZ1QMD+pytJnjqiEgwOUxy7YKhIc9ddGk81jYWkuW7pYCKs5KRGU8cmzF6CLk9IliqKqsKrS8giyBNJtWUonF9r4VBO3yJXzu3jFhiSOhuKYWS0uHJsLSyXdRt974LjKgv5UWDdJ6a3RsIMcI2XeMZNm4+mzIMvnoyfPQBds9KMsC4yAF1aflUWmT/uPMii3KVOkAFle5Y7w6Ad5m/tiqZiL3XD/z5MruyoP9SeDuMhUWosfP32Og0dPh+BAy4B+eXqCOKkyagRot1D+vLSRjmTDYkrj/eHjJ1Ss1UpY4uaDLIe0FEcWoKf36MkLqZzYFdF9Mer+3w7UbtJZLuGgsaVlWZrnlrCYU3PS/vPnGKX9VCmTqY6dZy9egy7QSCmmNHLElsaK7qrQfngdXQAo81hZWSJv7hzS2k9xdMyFdS4nubBcRNpN/Slfxi5E0XQBFiIiHDu24s6IUjw87ckjLmKU+TKmTyuDedXmNsW9e//n3CYFtHh0nm3deQBqiLun/Xt2lBL6zF8pKDz1eR+e9ous/N/ABFjhNfAAaFZ/5MRZvHz1Bh26O6h+hEhp+vT5K3buPawpHuq+QqHAzMkjQLdvNJ3SclZKKBknz16SFsafP3/JW0xkoaSlDGcvXEFJu8KgE3moFaklKhQKafXTrI/26bYgidItxms3b2P+zLF4cPWwbB9Z2nz9/ChZp1MoFH+l0VpMzch4NjYhohQKPdokFMvlLtOQQZxIz5y7hMp124jbdkHLREIUprYTT1jf1XZBykPTtr3QvFFd7N+6Cp+eX8GezculiGbftD1YSBc7Ulh4/4of21IlbLFB3M6mdYkiKkL/LczNQ+RTKBQqxY8SFIqw5wjJ/eX+HooQIppsKNFcoy3mFiHbttnNWVh9e8PG2hru/+1C8UoNcUrMTco7IpTxWTrPCReObZdu/cp5JA6aT0d2rwUtxyHltVu/EfJChBIViqDGnz28Wc49mptKd+7IFhKJMhdWn6misOYCyUTGWWhwVihoDgSVqFAoQJZvZf/Vt3SRESSl3beJZ61KUCjCZkp3A07u34hWwoL9S1z0Os10QYWaLUIo96oCwwgoFEH1aYrR+mS65Tx6WB8xH7bJ8SXrdniPPyrXzExbHSHX0GueGy3MI2aFp/q0OeU5QaGI4HGqrVARF952a85jzfOKKFLv/5rnZ8qoT3vU61QogsZGPZ9CQfM65PhQ2eqOLlLa2A+QVvSFM8erkhSKoPL0OSeoz3tlAertoLiongdUJrvIEzCLfBHaSuC4iBKgW281xO3VnRtdoe5o7RKlhafcPDmzgRTo0PLQLdrfv/2xcOlqkIJFB27pEkVwWih9Z84LhVfceg4tv2ZazhxZ5A+Ycl2wZjrtkyJdp0Zl5M+TU97OJcvQ7XsPKUnlrK2sQyhmlEAWFrIIqVu67z14REmhOn3aRAVUr1wWtARhw6oF4lalPbbu2k/Rersr126L2/XJUb92Fblcg34kbt6+r3d+dUGyrK9ePAvx49mAlOiwlF76EQkIDFAvQq9wHj3miGZBZEG/ePmGZnSo+1kzZ8CNW/dCyFy9dkfuZ8mUQW5p+Q7N89Hi1uWRXWtRpFB+7Dt0XKaRp2t8aL1ijmyZQI5uyZMsuYL5coMsOIvnTsLKxdNBVt5v338ga+b00tJ8+NgZEtPqsmXJJK38v9XWJasL2thYITAg9B9XffqsXmZkwvq0R1v5ObNnlcc63erWlq5vnD5MqSy6kOsqbj07jR2Cs4c244W4q3MpeJmAtmOe8qi7bFkywNraKsSSD/X0c5euobQ4Z9F5LU3qVDLpprh9LQNR6GXKkBZ0fN+4FTSHlUVfuX4LWcRcp31rceFG27DWQpMMObrNTltyvr5+uH33ATJnTEe7iMhxqq1+fdotK1TzqD+37oQ8j6m3VU003MGItCfclahl6DdkAt6Iu5vrls2R80iZlFWPc4JSVn0b0+1Xr5vD4SfACm/4mUVbDrrNSE+Kt27WQL6OjF5JpnS0SP7w8TNQv80bVkPo4Sl6i4LTTGfQQyp04qWlA2QBUealdZVFC+eXDxCVLl5URtO63kdPnsslDaXCsX6XMpN1mKxrvQaNFsr2GZBySuuB6Slfut1PMvnz5gStqyVlgvrcY4AjSBGhNKXLkikd7t5/HOLBmVxCOaP1nbS+kuS+fP0GZZj2dTl92kRP3V8JXsbwQ1i6aa1e5ozpdRWpNT6vuAX5xuMd6MXtJEDs54XxcAfJ6XJW4rbmWnFiprWbYSm9tHTh9t2QFw26ylWP12eOqMtTeECvTvJNBdQ3uvVOlu2Z85f9NYYkq3S0/u/FyzfySXcac3p4csK0eaD1eKlSJhdj/QhUBr2RgvLQfH0s5mDm4B/88I4PveFj/+GT8slrugtw4tQFkAJEa6vpoo7WXs5asEz24/OXr/JtEf9t2wtaTkT1d2zTBPSmgr6Dx4u2PQbJ0NsQlOufMwsl/YW4E0MyJK/Nqfo8ZR609VlbHm1x9IYKOmY9hVVUWzrF6dMektN0ndo2kVFd+g4HKTF0jrh7/5Ecp2/i4kAm6uHpw5Q+yEEfLFBevJ04fVG+9SCzONapiixie1fjmKd4dUf10EXMpOkLsW3XQfl2Erq4pmVIJJc/Tw5cFscxjRdZ82iMDxw5SUlR6miZUNeOLeAkrNRkHKD6ps1ZgpviArdLhxayrvTp/pFK1a07D+R+WN60OYvlRRbdch82Zhr8/H6jSYNaMltEjlNt9evTblmhmte+dSOs3bBdviUH4o+WjBwQx5YIRvp/RNoT0UrpTSrbdx/E6sUz5LlAvRyaV2GdE9TlleGYbL+yTt5GnAArvBFnF+U56WlsstTRmw80CyeLBVlH3DZs1UzSuU+KHlmJLwhrHL3CJ3eRqkKpcIWvr0+IPKTUkpWVLLuUYCNu1dPDQ3RbhpRfiguPW7VkJuihuxFjZyBrgQpo2bGfUHDPI2HCBLKYyWMGS0WWXhlVrkZz5MyeBZXKl5RpSq918wZCuX+F5BkKg9bh3X/4FIlEfteFU6TlNUVGW9Ru0gnKHxdlPl3bsNr07v1H1BLlUV30iiH64R8/sr+u4rTG58mVDXSbrGd/R9Ba0pkLXBHeMpQFK29l0lisXxF0m56UXl1KT59u7bFwyWrJSvO1ZMoytW31nSPqecuXKY6NqxcIi+kx+bq0ImXr4fipc6AHONTl1MPp0v6DXZtccenqTdArybr3H4nKFUphxqQRUix+vHiyjHzFa8g+FClXD9WrlAM9cEQC4R0f/4AA9BYXXTRPyO3ef0S+NUShCLp1ObB3J9Btb3poK3/xmihbvZlUdhPEj0fVyWU5uzYtx4+fP9GwVTf5SrfZYjzpYSsSqFi2BArky4VMecuC5gz9mFK8ugurz+qyoYXJuuY00xmat+XV8+jTHnV5ZThZ0iSg5TfEv23w650GDp8EWn8c2ngq86tvw2KaMGF8MUfXgF67RcxoDkyfOAz0RgIqR9sxT/Gabkj/bqC3L8yYu0R+nIeeS3gX/Ko9mi+1q1dA5TptYFehIUjZHNCrs2YRUbI/bsQA0INz/YeOR8GStcQ57gK2r18s7iBklOXT+WqAuDis17yLnCNhvZZsYC97tBa32/MVr457Dx5j67pFoAt8Kqykna284xfWuZxklU5X/WG1W5lfuaW7LkMHdAe9jaBQ6drYuGUPBvSOOqbhbY+yXeHdnr90XT5fQq8gpPmndHQxSWWFNX9JRpuLqfZrq9sU4wzZZlZ4DUlfo+6eXdrg2e2TsLS01EgJ2qXXTY0c3DtoR8OnNzDQ+juy2KonkYWYTpxPbh4HvSpmx4alcBzaV11E7lNeetpZmUAPybx+cBZ05auM07Zdv3I+xo0cECKJ2kBPv9J6SCrj6O51QkFaiHzCAkqCtJbPdcEUXDi2HdQnWkZAr9SaNNqBkqXLLKyrV07tkmvwqG05s2eW8VUqlMaBbatB62PPiFui9WpVkTJp/00j0+ltAXu3rJBhdS+sNtEr1DweXZBlUX3ESVmmejnK8H9yvWlIjpTWpEFNnDywEeePbgXdlleuj1T/4aLySZEleXL01gKKUz60otkHUrKoT+QoTHk0Xc1q5fHy3hnZfmJK6ZrlUBwtt3h84zgFVU6fOaISDg7QA0jUHvq6HrWdeCnbposNzS+Sozw0thNGDZJLC6hIWpZAaVQWORrfudNGy9vGlB7e8enbvT0eXjsqeVB5F4/vkHdNqCxyCoVCKtOHdqyRry2j16vRnG9YtzolS5crRxasWTpLvnZLWUb+PDllGq27JXmKJ0dvlKAEYkuMKUwutD5Tuj5jdPfeI9SqXkGl/FA+TaerPR+fXQYdM+ryJ/ZvkE+7K+OIPb0y6/qZPaCxoXFdJaxgyvFUyqlvtZWrUITOtHL5UqBzAvEiR+e6Lh1aqorVdcyrBIIDtJSAviR56uAmvHt8UZ4L6CKakokDnd/o9VnkljtPxZD+XUHnIEonpw9zbXN4yrihWBX8Kisqh+7A0Ppgmlt07NEFXaniRShJ5YYN7KGag8RYlaAWIGWWeNSoWg53Lx2UfaK1/zR31MTk/A3rXK4uT2Ft9YfVbprj1B71LwYSbzpG6HWB1IZ+PTrg/NFtVIVOp/nboOyn+rmPMofVHm356KE5aiPlV7raNSrK+avc19y6zJmgGgvKq3T0+0OyCkXo85dktM37sNpP+dgZBwFWeI1jHLgVTIAJSALsaRI4c+EqyMKmGc/7TIAJMAEmoD8BVnj1Z8WSTIAJMIEYJ0AflaEH8GK8Yq6QCTABwxLg2qOUACu8UYqTC2MCTIAJMAEmwASYABMwNgKs8BrbiHB7/iLg7e0jH/qgDxIoE+mrZPSCfOUDB8r4OLbV2l3XVetBrzWiRHo7AH3MgcJR5ajMag3a/VXcj5+/0GvgaJSo1Eg+mNaiQ5+/ZEwtguZeLtsqqmZfu3EHDVp2Q8Y8ZVCmalPQB1TobSMqgSgMEOeIjB29BWHVus1aW6KZ9vqNB2o26qhVNiojh42Zin2HTkRlkXqXRW+HGDt5Tqjy/YdNwKFjp0OVUU/Up0x1+egIDx87TcW0XPXmoLHVrIc+pkJt1YxX34/u84V6XRxmAoYkwAqvIaTVdfcAABAASURBVOlz3XoRUCgUSJM6FU6evgjl2wu27TwgP02qUAQ9da9XQXFEiN48oHyiP0nihJg+YViM9HzZ6o2gTxmf2LcB9FAafcY4RiqOoUroIqtpu16oU6Oi7N+qJTPka6e8fXyjpQURHbufv37BbcN2rW0KLU1rhiiKpK8FRuSNL1FUfawvhj6lru1jL/p03FDnC33aFj4ZlmYCoRNghTd0PpxqJAToyezixQrjwuXrskW79h1BreoVZZi8S1duoG4ze9AX0nr0dwRZGymerBv5S9QEWUAGjZissnySRcdhpBMatuqOWo074e79RyQewtGryehznvQamwIla8HFdS3IIlahVku07zYI9Lohetfn0pXuoNe+kdzyNRtlGfSBjH5DxkuZ7IUqyncSa4uTwmoevUu3fTcHkAWVLIv0fk+yIJKFqkLNliCL375gS5m29tGXpuh9t6069UP3fqPw7ftPDHacImugV88RA2JUu0ln0AdAIP7odXjtRZ2NW/eQLLbuDPrgBpVPcsSO6qX3jQpxnf8/fvoMuyIFQE8tkxB9ZpW26syIEVmByXJKabrGbfyUeShStq60Fi9bvYFEpStesQFGjp8Bauv2XQdA5XXsMQRlqzXD0NFT5NcIqc3k3nq8l3kePn4Oykfj1qJjHzmGlKCr35Smzbmt3446NSuDlDd6gj1r5owY0KsT6A0g6vK66vP09EK3fiNBr9Hq1HMoytdoId/Pq4uz+tjpaqu2OTXXeQUePHwiLdHzF61Wbxq0pXn7+KBD98FyDpNFUJmBPv1Lc4UYz5jnqowOsSWudOeFeNOxpHxPOB1fNP8bteqBJSvcQVbEi+IYpcyUZ/TEWajeoL08Zum91TSexSs2hPLLeroYEod2XQehSZueoDrqNLXHs+evqFjpiov5Qe+xlTtaPF3nAxLduecwqDyaJ0dPnKUo+Z5gbceeTNTi0VcyW3bqK/tGW5r7JEZtDet8QzyU76GmPCUrNwa9wzy0NpMcuf5DJ8BL3Amj8OyFy1G6ahM0Exdn9MlciiOn7ZiKyvMF1cGOCRgzAVZ4jXl0uG0hCNStWQm79h0GWdrofankyOJLHxagd4dOE5bMwzvdUDB/bsxzCXo1WSERvnR8O47tdYe1tSU2bNmlKtPcXIEta12weO5ETJ7hrIpXBtZv3oVrN+5i35aVuHJyB2pVqyCT6N2e9No1eo3W46cv5Q86vapns5szSMF48OiZVLzotWYkc+v8fhTKn0drnCxQzXNxdZPvFqZXr505/J9QphKINu/G9x+/cHDHamxYOQ+Tpi0AffBAW/uaN66DDOn/xbrlc7FI9EutaKzduE0oWJ9Br+Ki9wPTBz+IHcm8ffdevoKLXoc0b9Eq+Z5khUKBOVNH48T+DVgybxKGBCvOJK/NtWneEIuWrZPKKJWh/LEnWVLk6X2V9HqoBAniiT7tkh+F0DVuLZrUw+WTO3FIjOeWHQdAH7egcsjR69s2i3EralsA9HGKcSP6S7kz566A6tn93zI0b1xbjgvJp0yRFDs3LsOxPe6gj7pMmu5M0dJp67dM0OI9efoc+lgpddVHH12g+Ur827VsiOu37spaFAqFXpy1tXXn3sPQnGf9enZEjuxZQK9N69M95NITbWnEcMzwvqCH4+j9r9du3gF9eGb5mk2gOU3xd+8/wpETZ2R7NT16HzExb9eyESbP/MNWoVBg81pndO3YUjML6DWK+7etQpZMGTBBXNzQB1bcXOdgwtT5UlYXQ0okpXr1kpmYM8VRjrPy3eTnL11DrhxZQR8yITltLrTzwZu3HtixYQlmTR6JvuJilS5ENmzZrfXY01Y2xY0TfSlfugSob6XsimJ8cH8oLazzTV1xMbVp214SxZ17j5D6fymR5n+pxLkjN3Sdw6Swmkfzn77IuW/rKsybPhbnL15TpWo7pqLyfKGqiANMwEgJsMJrpAPDzfqbAH0M49iJ89iyfT/q1qqiEnj56i1evfHA8LHTpVVrm7D8Xb95V6ZbWlqALB4tO/YFfSqZftBlgvAqlisFhUIhFYYHj56KmJD/z5y7jK6dWsnb1vQ+YnpfKUnQDzy9M5TCF69cRz3RliSJEyF5sqTys8IUlzdXduw7dBy0xvjUuUsyTVsclaHuihTKhwWLV2Hm/GXwePdRWkvPnr8C+mRp03a9QZbBj5+/4L6w4Olqn3p56uGLl2+irVC0FAoFihTOLz+uQOxIpmSxwlC+d5W+Rubx7oNkc+feQ/QQFvMBwybirccHqWiTvDaXK0cWnDqwCd06t8JFYYkny+DnL1+laJ6c2ZAp+KtpVSqWweWrt0B16xq3X+K2PFkO6WMIbz3e4d79J7Ic8mpULU8b6bJnyywVfGtrK+TOlQ12RQvI+MIF8+Lhk2cyTB9z2bJjP8gySMsu7qp9jlpbv2UmHZ5ApyPlT7Su+ujiqVXTelKQ3iOaJVN6GVYoFELBeRgmZ21t1WdOyUpC8YghzWe6iyK5iQs2Uh4/fvwMsvw2adtLto/aDy1/VSuWlbH06Wey2Msd4dHHZxQKhQj9/b98meIysnDBPPIC1cbGGtmzZgRdzFKCLoaUVrZ0MdVcbVSvOujrlHQhQR9EaNawDonodKGdD1qKsaH3+NqKY5CU5jdv30HXsaerAvqwSvtWjWRyp3ZNQF8UlDvCC+t8Q+9vpr4IUdmnerUqUxChtVkKqHl0nqCPYdBHJ2gZGH28RZmscUyFOKaUMurb8J4v1PNymAkYIwFWeI1xVLhNIQjQjxk5+kEuYWcLZ2EFra22nCEQgaCvtZFFi9y+rSvlhy6oEIdRk0VaZixdMAUDenXGL3FbmeLJWViY0wb0I/f7928ZVveoTkvLIBn1eGsrK/XdEB/noB8nyleoQB75paT8eXJi2uzF2LrzALTFkWJRXNzKJXfs5Dl0bNsU0yYMR5rUKYWCNlDerqXyRg3pLS121D96OX3xooXkemZt7QvROI0dC/M//bG0sBTkAqWEkgXtKBQK+VlT+mTrqrWbMbCPvbSEp/s3DX798iQRnc5GKC6k6NAHG2yF0nn4WJBVkPqgnon2dY2bj48vegxwRNMGtUBfmatWuawYtz/1qvO3UvtIi7mZOahPVA+Ff/sFjenSlRvExcN7TBk3BPTBE0/PP2Vp6zfl1+ayZM4oFPXb2pJCxOmqj/psrsbfKnge6ctZW1u1zakQjdFjR52hQmEm12FTWxvWraaac2cPi3nQW/vXtUhWWzVW1pbaomWcsk7iYWHxR05Zli6GlNna6o98gvjxUbRwQew7eAKHj59GtcplSESnC+18YG5uocpnaWEh7kAEyGNM27GnEtQIUPuV46Q+T0lMGa/rfJM+3b+wEvOZ7mZs330QtYLPcaG1mcpVd1S/mdmfY9xC9IPSwzqmSEabC8/5Qlt+jmMCxkTAzJgaw20xIgJG2pSObZrAoa99iK9OZRA/FJ+/fMHeA0FfEPslFBq6LUtdoNu11SuXA1ktDx09RVF6u1IlisB11QbQjwVl+qlF2StmW1BYYw7j2/cfIGsmWWjsihSS+2T1rVW9Alo0roOr129pjSPFlb7KRo6sflQOLUlo3aw+CguF8d6DJyhTqqiw+q6Gsn6yotFbGHS1L0GCBPgu2kNtVnfFiuSH24Zt8kf86vXb+PDxI4iduox6mG5rFy6YW1renj5/iTvitrZ6umaY2kUMKP7jpy+gH276qh7t3xaWYlLu6Qd53cYdIEs21a1t3D4JCzZ9mY76b2amwLGT56mICLsnz18IhsXw7z+pceDIyQiX07p5PWzffQC0plh5gURrPZXjoixYV322hfLitLhrQHK07pSs9BQOL2fKo3Q0XzTnWUId4095QkujdKUraVcYm4VVnNpGcbS2lNpMYU23btMOGUVzi+4cyJ1IeroYaiu2WaNaIKWQLoIthcKoTUYZF9r5YMOWnXIpz7Ubd/Dx02ekS5tGzBvtx56yPM1tMdsCWO2+RUbT3QQ6vuWOnh7dLaK7QmlSpwItZ6BsobWZ0tUdWafPnL8so2iOKsOhHVNRdb6QlbLHBIyYACu8Rjw43LS/CeQRt63bt2ocIsFcWM0Wz5sslNP18qGuImXqgX4kSKhvj46gW+ttugxAvHjWFKW3a96oNnJkzYyq9dqCHnxbvNz9r7x0G79T2yagB3Yat+kJejNBjmyZsFUoC/9kL46mbXvi7MWrcl2utjjNAgePckL2QhWFdXeQXItYuUJJoTDXRfGiBeUDPqWqNIbjxNkym6729bRvg8GOTvKhNSkY7NH61SSJE4Memho1YRbmThsDYhec/NeGboceO3UB9BqueS6rpIX6LyG1iGcvXqNSndaynflL1ECFsqWgvHWdP29OTJ+zRD5cRmuvWzSpK+vWNm6kmGbLkhH0oJx972HIkyu7Wi3hD9JF0shx0+WDTrSMIvwlBOUgBWTT6oXYufcIylZvLss7f+k6bKytggSCfV31tWneAPRAYfP2vTHHeQVoOQJdiIWXc3A1cqNtTiVMEB91alREa/v+ck25FAz2QksLFpEbeiBvzLC+8jVzNKY0B7y8vWWapvfmrQcq1GyJvQePY6RDL83kCO3rYqitsPLByyNoPaq2dPW40M4HqVKkQKXarUEPmM2YNELOzxaNg449eiBW/dhTL1M9TMwOHTstH1o7duocHIf2Vk8OM0zLGDZu2Y26NSupZENrs0ooOJAvdw5x3JWQc7Ndt0FIIOYCJYV2TEXV+YLqYccEjJmAmTE3jtvGBIiAjbhNfufiAQqGcL27tcPQAd1kXKH8ebB5rUvQgzdXDqFx/ZoyniylZD11WzpbLhWgB10ogbZVKpSmoHT0gJQMqHl0O5AeTqOHtm6e24tBfTrL9b57t6xQk4JQZlviyK61OLp7HTq1bSbTOghL9NuH57FpjTOWCGWcbldqi5PCah7JPrx2FPRQzuQxg0EWK4VCgeGDesryzxzaDKrfStzW1dY+KopuRa91nQN6aC1limSSCcVbC8Vs5uQRoAf7dv+3DCXtbCkazYRi7zi0rwyTR8smaL0yKWMkS/tzp40GPWxFD0hRmQe2rSbREK5Jg5q4dno3dm50BfV9+sRhqnRak/mfmzNOHdyEhbPGg8aUEnWN24KZ42S7Vy2eieXOU2UbSf780W2qvNQWYkHx5FzmTEDZUsUoKJTkbFi/cr4MF8ibC5SP6qf5QmFK0NVvSlM6auc9MZ+U+7SEgHjQLX4qb9jA7iGWtJCcrvpozGY5jcSGVQvQvXNrJEuWRK7RDo0zPTBGZepqq645ReNJc0DzoTUqSz1NkyHxUa4zbli3unz4iub2pRM7kDtnNsr+lxs7vD/ooVB6cJPmDQloHl9Txg1FjSrlKEmOBXGlnbYtGqqOYdq/fmYPbeQrB2mciDG1icKUoMmB4t56vEeWTOllHtrXdLQ2lo5jig/tfEBznPpBDzcq3zCiUGg/9tTLpHJYarC3AAAQAElEQVSVjo5z9+XzJDfaEl9K0+Sh7XxDcpT/66vrqvMIxelqs9PYISqmJ/ZvAF3MkPyAXp1A3NYtmyuPdWorxes6phrWrQaaK5E9X1Ad7JiAMRNghTdKRocLYQJMgAmEToDe15utYAV5x8Fh5GRMcBwYegZODZPAf9v2on6LLuJi1D5MWRZgAkwgbhNghTdujz/3nglEOwGycqlbYqO9QiOtgCxwr+6flZb6XZtcQdZtI22q3s0iy6vSWqvKFIOBJg1q4uLxHfI2fgxWy1UxASZgggRY4TXBQeMmMwEmwASYABNgAkyACehPwBAKr/6tY0kmwASYABNgAkyACTABJhBJAqzwRhIgZ2cCTIAJRJwA52QCTIAJMIGYIMAKb0xQ5jqYABNgAkyACTABJsAEdBOI5hRWeKMZMBfPBJgAE2ACTIAJMAEmYFgCrPAalj/XzgSYgP4EWJIJMAEmwASYQIQIsMIbIWyciQkwASbABJgAE2AChiLA9YaXACu84SXG8kyACTABJsAEmAATYAImRYAVXpMaLm5sZAkMGzMV+w6dkMW4rloPX18/GSaveMUG8Pb2oaBON2HqPGTKWxY/fv6SMh8/fQHlkzsG8CrVaY37D5/KmqlNSdMVxMkzF+V+QECAbKuf358+yoRQvJ+/PLFq3WatElTeqAkzQXVWqdcWt+8+VMllLVAeVDe5UlUay/jAwEAMcXRCveZdMG3OEhlH3sRp83Hu4lUK/uW27z6EMZNm/xWvHnHn3iMcOXFGPSpawuVrtADxiEjhm7bukV9US5ezJGo07ADaD62cyNQVWrm60ogxsdZMp7kc1jGgmcdQ+5rzoP+wCTh07HSEm+O2YRsatOyGmfOXhbsMOqc8fPw83PmiO4O+7SpXvXmE57p6H6g+Oseqx1E4smNDZbBjApElwApvZAlyfpMiYN++BYrZFpBtXr5mE3zDoQzKTMJLlTIZVrj9J0KG/1+0cD5cunpDNuT8pWsoXaIoLl+7Jfdv3rmPvLlzwNLSUu7r4/389QtuG7ZrFV259j98+/YDh3asgfOsCeg1cLRKLmmSxPj66rp0Zw5tlvGPn76Ap6c3dmxYilNnL8LLyxuvXr8V7h1KFCssZTS9UsVt0b51kMKsmabcv/fgEY6fPK/cNbrtgSMnMXH6Agzp1w33rhzG5DEOePf+I/gvaglE9TyYs3A5Nrs5Y1CfzuFu6KGjp/H4qfEpvPq2a85UR8SzsQ53v00oAzeVCYAVXp4E0UaArur7DRmPRq16YMkKd2l5rNmoo7QQOox0AllXSUnr0me4bMPajdtRoGQtGX705Dmateslw2QdbNiqO/IUq4bpc5fKOG3e79+/UbBUUP5nz19JiyOVQ7J2FeqD0smqe/HKDWzYvAsvXr5Bq0790L3fKBKRzmmmM6iNrTr3U1lxZUKwp1Ao0L5VE7it3yLbHxwtN1T+2MlzUKFmS1St305lSaZ+3HvwRMrYlqmD1e5bZJjqpf7rykdtISVTCgtvwPCJ2L3vqAj9+V+kUH5cvnpLRly6chP27ZupFODLV2+iSKG8st/a2kUW2vbdHFCtQTvksq2Cz1++Yq7zCjx4+ERauuYvWi3LVXq37z5CqRK2MDMzQ45smQSfn3j6/KUy+a+tjbWVlPH394ef32+Ym5tLS++QAV3/klVGnDl/BavWBinMNH9ontDY12rcCXfvP5Jic51XYvueQ7KNR0+chcf7D+jUcygq120Dkn3w6JmUo/zK+Tdv0coQlvh3Hz6ibLVmUm78lHkoUrYuSlRqhGWrN8g4de/7j5+gcshSnb1QxTCty0uWu2PU4N6oWa08EiaID9tC+dC7WztZJFnfaX5VEpZ56hsdAzJBzVu60l0eIxVrt8LyNRtlClkzW3ToI8PkjRw/QzUXyCpL+41b98Dpc5ewfvNOyYLyz5jnSuLSzRYKXemqTeRx9VQcHzJSizde3MWo3aSzZPn8xWspQdbg/CVqgiyBg0ZMVs19dcZ0jO8Q49K8fW/Jlo57mVnNIysotbdCrZZo0bEPXr/xkKkbt+xGu66D0KRNT1CZv8WxrG3OSuFgT3MeUPS+gyfkvKBjUDlf9CmL7kS8Em1pLOrfe+C4zjmljQMdR/sPn4DTDGdZ94ePn1XnIWoTHbM0PhSmvtFcIjbE65I4F9VtZi/Hq0d/R3G8/CIxeZzQXNZ1ztOnHG3t0jXX+w+dAC9xd4vGg+ZNh+6DZV9oDGSDhKerrQePnpLjTWO379BxIan9/849h1GnqT1o7Om4JSnap3M1hcnR3CB+FGbHBKKagFlUF8jlMQF1AgqFApvXOqNT26boNWgMnMYOlhbCNx4ecP9vh1DI8gmF7abMckkoaJkzppOK6IXL11HUtiDoZHj2whVsXbcIty/sR9uWDaSsNs/CwgJZM2WUlhZSasuXKY6LV66DfrTT/vsPKF2Zr3njOsiQ/l+sWz4Xi+ZOBIITChXIi71bVoh2FcAa963BsSE3CRPGR+3qlWT71VM2iB/t7z9+4eCO1diwch4mTVuAr9++o1iRQrIdbz3eI13af3BJKKaU78p1UkjzQVe+lk3qCcV8N4nKpRb0I1Gtchm5r/SK2ub/w0/8eFauUBofPnyWyZeu3EKRwgV0lu/i6oYuHVrgwLbVOHP4P6GcJUC/nh2RI3sWbHNfjD7d28lylF7unFlw7sI10FIFupB48eot3rx9J5N//vRE2hwlQYoG/cBTJPXVVijkPQY4on3rRrh99wESJ06ILJkyULJeztxcgS1rXbB47kRMFgoFZerXswPq16oi21ixXElMnLoAVSqWxuGdbhgzvC8GjZhIYtIpFAo5//p274BsWTPhwqXrMn6nUMzq1Kwswy0E58snd+KQyL9lxwE5f2RCsLdz72Gk/TeNtFTfOr8fhfLnCU7RviHLtl2Rgn8lkuKl7RhQF6QLI1KEaL6TtXG+uOhQKvDqcprhAnlziX66IPX/UgkleRMo78Htq+VFAi3/uH33Idb/txP7tq7CvOljcf7iNc0iVPspkifH7v+WoXL5Upg0Y6GML5Q/Ny4d345je91hbW0p5tQuGU+eQhHEuGvHlnCa6YJVi2fi5IGNcJ49npJDuJQpkmLnxmU4tscdrZs1wKTpzqp0Ok5XL5mJOVMcRfm7oe1YUgmLgOY8EFHiokohzxVO4war5ouu44vklW7ahOGCXUo5p+hCRdec0sYhb+7sqF65HIY79JT5U6VMrixW61ahCOLVuV0zDBw+CdMmDJNzt6BgPM9lBfQ95ykUoZejrV1hzXVq8GNhbKDjiM4BX75+x7Wbd0AXrdraSsulKH7xvMlYL855T5/pvgB+89ZDHENLMGvySPQVhhBaItW8cW24bdhK1YIu/nPlyIqw+Elh9phABAiYRSAPZ2ECehOoVqksFAoFnr98jbT/pEahAnmkhZCspBcv35BKaIb0afHy1Rs8FJa5Jg1q4oJQdklhLV60oPwR+vLlm/jxWihOjNuQIlnSUOu2E3koLym6Pezb4OLlm7I8KivUjMGJlSuUkiFaKvDwyTMZ1ub17NIWi5atk8ofoAD9nT1/BVeu30LTdr2lxfHj5y+4L6ylVDcpueeEktGwTjXJgpRfUk5ICdeVL5NQ/skqSj+Au/cfEUp2xb+WJ2TNnBHvP37Ct+8/QOtNEydKiMwZ00vL66Wr11FMKMS6yi8iLI8LFq+SaxY93n2ElZUldUOna9eysVR2shaogG79RiJvruxyLCnD8X3r8fTWCaEwd0C/oePw5NkLika/Hh2wRPwYtmhcFzMXuIrbxfYgC/fwsdNwVlzISKFQvIrlSkGhUEiF88GjoLXKmuKnz10GWQhp/eXYyXNx49Y9lYhy/lFEXaHg7th7iILYufcI6gmlmXZ+/fqFEeOmo22XgXjr8Q737j+haJWjfpLlaursxTglLKjJk4U+BymjQqGgTQin6xhQF6J5S+1KkjgRqJ76tavIiyV1GW3hGlXLy2hSGj4KCyNZ6Jq07YU79x7i2o27cl42qFMViRImQJrUqVC9Sjno+mvdvJ5Mat+6Ma6K+Uw7lpYWIAtxy459QVb4ew8eU7R06ozz5cmBkeNnwnmpm2puSKFgL56NDbbs2C+tuctWb8TdB4+CU4CypYshfvx4cl/XnJWJoXgVypSU84UuOJTzJSJl6ZpToXEIpVkhkpS8XooLRrIqDx87HTR3t+06gOs37+p9zgurnBCVBu+ENddJLGeOrKBzCIX/SfM/eV7W1dYX4rydKUNa5MmVTZ7LWzSpQ9m0upZN68k5YSvOO6TUvnn7Do3qVQfdFaCL6I1b9qBZQ935tRbKkUwgHARY4Q0HLBYNPwEr6z9KlIWFuaoAS0vzYGURsCtSAEfEremUKZIJBa2g/IG/JJTh4kULIV48G2kxLVe6OE6dvSQUk5mqMrQFSLkkJZesYjXEj/rDx09leUWD1+1qy6MeZxW83pVu2//2+62eJMN0YkYgpBWipJ2tuK18RMaTR2mjhvSWVh6yjty9dBDUBzth7bsglfjrsCtaCClTJMf+QydEWpAVUFc+KrO5sICs3bhNPvREVmmKK16xobg931AqqrRfTPSNlmiQdYT2ixTOiwOHT8JXtP9fcZGhq/yOwuo+TVi20qROiXZdB4IUa8qvy5FCTPJPbh4HWQ8/f/2GTBnSSfE0Qomi9IZ1q6NKhTK4deeBjFd6ZCUtW7IY6AeebuuPHd5fjOUMZbLOrXLOyPEQt7m1CQaKAdmwcr6K+/M7p1Ri6vOPrPJkfaYlEO8/fELunFnh4+MLskA3bVAL61fMQ7XKZfHL01OVnwKFxEUaWVzz58mJaULp3brzAEXrdFkzZ8Cl4HXVmkLK/lC8pdoxQPtKRxdByrClpYU8TujChyxiyniyuCnDtLW2sqKNlG1Yt5qKxdnDmzGwd2cZb2b25/hTr0NmVPMszC3knrmZGQICxGQXew6jJiNn9sxYumAKBvTqLBh5idig/+qMl853QrtWDeXFVzNx4RcQEBAkFOwvXbkBHu/eY8q4IXAVZXmqsbZWu+DSNWeDi9G5sbQKbru5uVzKQ4IRKUvXnAqNA9Wlzf329w8RreRFdeQMvptC54t9W1di4+qFep/zwionRKViR5+5LsRgIdjRlpxCoYCfOO50tTVQTA9zNXlLiz/ne8qv7syD5xXFWYq7cf7+AUgQPz6KFi4IWopy+PhpcfyVoWR2TCBaCJhFS6lcaCwnEP7uZRRWXLJq0u0x+hFctXYLihcrJAsqJhRC56VrQMphrhxZcPnabdgIRdfGxlr8sHpKi02ZkkXlD+3VG7dlnr0HjgvrU1BYRgR7VNZpYYWjh6goiqxkx0+dh7aHpBIkSIDv33+QWIRczy5t4LJsrcgrzvrCL1OqKBYsXi1/7MUuLl25AVqjSf0gy+vZC1elklW8aEGRzw201IHkdOWjtPq1q0qL2FuPD6Db1hR3ehBW+AAAEABJREFU/uhWkBvUJ+jhGrKYLF3pDttCeSkZRQrlB61VJkWbInSVT1bhDOn/FbeW66Nwwbyg2+kJQ2FCD52RovVFKLojx89AbjFWZAH6+ctTKEZBig2tjaUxJksf1U3Oz88Pq9dtlstaKD9Zd6ytrZAwQXxE5C+++JH8HvyWDMpfrpSdvANAYVJuzuqwHJN1M2+e7Bg9cTYaCsWc5D8JKzzNFeq/mZkCx7Q8DEecyOJaq3oFtGhcR8y7W5QVtEyA3tIhd9S8LuLW/vip83Ho2GkZS/N9l7Aoh3YMSEHhFbMtKCxeh6XF/vOXryJ8SFwQFkK6tKnx8rWHkICcU2fPX5VhTa+kXWFsFhZUWnJCaa9evwVdyNAcOXP+MkVJRVAZlhEa3rpNO2SM24ZtKFI4vwzTbe7qlcuB5vGho38uKGSimkesCubLLZTsTqALIpobasl48vwFypQqBroQO3DkpHpSiHAZHceSupDmPFBPUw/rU5a6PIV1zSldHBLEt8GPHz8pq3Tp/v1HtT75xOkLMk7Ty5DuX3z+8gV0LqM0utCiY4e2CoUCmuc8ktHmdJVDsurt0meuUx5tTlcdGcX5g+bY9+C+08WstvwUt2HLTnmeuHbjDj5++izmdBqKRrNGtUAXErWrV/zrDpYUYI8JRBEBVnijCCQXEzoBC3FFP3uKI4aPmQ56pVWqlCmE8lBXZiJl9P7Dp+KHvYDc/1+q5ChmG/RD++z5a6TLVUo+BDZL3BIfPbSPlPlv+175gyp31DxSohIIRYp+4Cm6aOECwmIST6ty1dO+DQY7OoV4aI3y6OuyZcmIfMLqp5RvIW7bkzJLD6HQq7kchWKlTLMrWgBphCXVzMxMWDTyg/pLbySg9NDykYJBfaHbgSSrzRURtwjpYSBS2ig9f96ceCFul9oWzEe7krO2dg0e5YTshSoK6+4gabGuXKGk5FSnRkW0tu8PWj8qCwj2yDL6vyzFkL94DaF8vcW8GWNlysNHT5Eqc1GkyGiLVp36Y8ywfiHW6S5fs0lY/RrLHzNShh49fgZ6CK18mRIyf3g9UgQ8Pb3QrF0v0LpmRzEnPnz8AnrYhh7y2b0/5IN96uXXqVFJLn+g5Q0UT4oXjWPV+u1g33uYuDWbnaJDuK1Cgfwne3E0bdsTZy9eleueScBplrPWtbDVhZWYHlqbNH0h6OG0Fh36wMvbW97y1XUMUHnk6IKvU9sm8oExeoCqW6dWyJEtk7SElRO3/Kmd3fuPQkZxG5nkNV3WzBkF/77oNXC0rJtulVPd+XLnQIWyJUAPFrXrNgh0jGjmVe6/eeuBCjVbYu/B4xjp0EtG9+3RUfJt02WAOJ6sZZw2r2TlxuLuQwNpNe/fs4NUkNXlOrZpgpHjpst20G1y9TT1cGjHhFJOcx4o4zW3+pSlmUfXnNLKQWRu1qgOdu07Isftw8fPoIdHafyIF12ECZG//pNllNa+0sUpjWuRMvVACrWuc95fBQRH6CqHktXbZSnuXoU11ymPNqerDirTSVjru4hjp1XnfghtTFOlSIFKtVuDHribMWkEqEyqi561oK3yDhaF2TGB6CBgFh2FcplMgAjQwydVKpSmoHRlhWWHHgg7smstZkwarlozSpY3eqVVkWBr0rplczF5zGCZhx688Hh0Qd5Cp7Wg5UrbyfivwspYqVxJGdb06OGlvt3by2h68IoekJE7wpsybihoqYMICitfNax1nQPlQ2vnj26DjbAqUxq1dX6wQkf7Suc4tC86tGmi3MWyhVOEtXWb3FcoFBg+qCeO7l4HejUX9dUq+DbthFGD4L58npSzFQoq9Zf6TREKhe58ZB18/eYdmjasRaJaHbWVyqNb7iRAP0LvHl9E986taFdayLW1i3g+vHYU9KAQ8aZ8lIH6SFyIHe0rHa3r+/T8Cl7dPwu3pbOROlVKmVRYWIcpnhyxp4d+ZEKwR0pb3ZqV5Z5CoQDdtt2zeTkc+trLOHWvfu0qGDdygIzSnD/0YBkl0EXN4rmTZDn00FqqlMnlA1LEnZaRTHQcRGLQzE+RpPwQK1rOQPvkFswcJ+fXqsUzsdx5Kpo1qk3ROL5vvbwAoPF++/A8Nq1xluuR0wvLHAkQg9ri4oDCmq5Jg5pyHtBcp/4qx4/GiuYFxasfA8q6qJwuHVqC0qk/ndo2oyjppo4fJttJbaQxU9atPm9JkKzX+7etkmVcOrEDuXNmo2hxh6QT/nNzBh1fNE7EWiaoeVQWHSPH9rrLh7+UinXrZvXFPN8qx52WtRBbykbbKmrH+J2LB4TcNtDSBvW2kyy5AnlzyXRqx9AB3WSY4ok5zTsKk1ModB8TlE5Ocx5otkU5XxSKsMui8q6f2UMb6XTNKV0c8ubOjlWLZ0hmlJfG4NyRLZLXLKeRmDTaQZar2UZ6AHLzWhc5rveuHELj+jVBZWk758kCgj19yiFRKku9Xbrm+on9G+Rcp4czaX5SXnI0Rq2a1qMgtLWVEqpWLIMNqxbIebVlnQto/lC8uqP2zp02GjSv6HxMx60y/a3He3GBnF51B0sZz1smENUEWOGNaqJ/l8cx0UCAfiQUir8fDIqGqgxW5N37j6WVjpT8FMmTGqwdXDETYAJMIDoI/LdtL+q36CIfZo2O8rlMJqBOgBVedRocZgJGRICskGQNGTawuxG1ipvCBCJDgPMygT8E6E7IxeM7QMtt/sRyiAlEDwFWeKOHK5fKBJgAE2ACTIAJMAEmYCQEjE7hNRIu3AwmwASYABNgAkyACTCBWEKAFd5YMpDcDSbABGIdAe4QE2ACTIAJRBEBVnijCCQXwwSYABNgAkyACTABJhAdBCJfJiu8kWfIJTABJsAEmAATYAJMgAkYMQFWeI14cLhpTIAJ6E+AJZkAE2ACTIAJ6CLACq8uMhzPBJgAE2ACTIAJMAHTI8At1kKAFV4tUDiKCRgbgZqNOiJpuoJIkdEW9Zp3wc69hyPcxHLVm+PnL88I51dmHDZmKvYdOqHc1brVJXPo2Gl06jk0RJ6KtVvh/sOnIeL02ek/bAKoPE3ZjVt2Y8LUeZrRMbJPfFet26yzrqwFysvxpDEtVaWxlKNP0A5xdJLjO23OEhlH3sRp83Hu4lUKGrWjT+T6+vrJNr5+4wGas3Inmj2agw8fP49QLRHJS3loXkeoQs7EBJiAwQiwwmsw9FwxEwgfAfpc8fsnFzGwd2cMHuUUvsxq0nOmOiKejbVaTMSC9u1boJhtgVAz6yMTagEmmvjz1y+4bdius/VJkyTG11fXpaNxJcHHT1/A09MbOzYsxamzF+Hl5Y1Xr98K9w4lihUmEaN2y9dsgq9fkMIbkw09dPQ0Hj+NmMIbmbwx2UeuiwkwgcgTYIU38gy5BCYQYwTMzc2RJHEipPlfKlWd6zfvROW6bUAW0hnzXGU8Wdhov0P3wWjQshvGTp4j48nrP3QCvLx9EBAQgNpNOoMsvlXrt8Ppc5coGcq8HXsMQdlqzTB09BRpUSZZcm893ks5suhdvHJDhotXbIAxk2bLutp3c8CPn79kvLqMjNDTW7rSXX5WmfqwfM1GVa4tO/ahWoN2sl3tuw1Sxe87eELWXaFmS9y9/0gVT5a/Rq16gKyoCxavVsXrYlahVktQufWEFf3bt+/o1m8kqtRrK63R5Wu0wMdPX1RlUEAXw7nOK/Dg4RPZpvmL/tRLeXQ5G2srwe0n/P394ef3GzTWZOkdMqCrriyg/hF7aneLjn3k2JEwtYus28SvQMlacHFdK9NITtk/P6GcauP8/cdP9BsyXlqasxeqiCMnzkBbHNWjdBs278KLl2/QqlM/dO83SkZ7+/iA5l+lOq3l3JCRwjt55qK0/lK8w0gnKK3C1NeGrbojT7FqmD53qZAEPN5/kOxpflPag0fPZLzSu333IfYfPgGnGc6S9YePn3FJzMm6zezlMdGjv6NgGjQXd+w5hObte8u5Q3MiPHkPHj0l8zVp01Pc1TiurJ63sYQAdyNuEGCFN26MM/cyFhAgpY1ugZNyOtyhp+zRoyfPsVxY1ja7OePg9tVS2SMFhRIfi7Qxw/tim/tifPn6Hddu3qFolVMoFJgzdTRO7N+AJfMmYYjjFFUa5R03oj8O7XTDmXNXQMrB7v+WoXnj2liywl0lpx4oVCCvrKtmtfJY475VPUlrmJRX6o/SXb1+W8rde/BE1rF13SJQv0hhJEWHrHhjneZhhfM0nDywEaOH9ZXy5JmbK0DyTuMGY7JQfiiO3KWrN7F0gRP2bF4B19UbpIIYGrNbdx5grOg3WVnXCyWOlhkc2rEG7Vo2xPVbd6nIEE6h0M6wX8+OyJE9i+TRp3u7EHlo5+dPT6TNURKkoO/ed5SikC7tP7AtlB89BjiifetGgvkDJE6cEFkyZYCuv5QpkmLnxmU4tscdrZs1wKTpzlKU2n7txl3s27ISV07uQK1qFWS8ev8eP32plTMtl0n7bxppab51fj8K5c8jL3g042SBwV7zxnWQIf2/WLd8LhbNnShjaQ7R/KN5ee/BYzn/fv/+jV6DxsBp7GAQ1zceHnD/bweePX+FsxeuyDG8fWE/2rZsIMuYOHUBqlQsjcNiHlJZg0YElS0ThZc3d3ZUr1wOdDzQPE+eLAkGDp+EaROGyTwF8+fGPJcVQhJwmumCVYtnyrnjPHs89M1LFwZU5uJ5k7F+5Tw8ffZSlsceE2ACpkXAzLSay61lAoYgYBx10q3vLy+v4dhed2kx8xZW2vOXruGjsGp1EJbcJm174c69hyBFB+IvZ46syJwxvQgB/6T5Hx4+CmkdUygUUp6sYAOGTcRbjw/4KqyalCF7tsxSgbG2tkLuXNlgV7QARaNwwbx4+CRkOTJBeFUrlRG+qCu1qEuHjBQI9hrVqwHlbX3aUtmUdPHKddSrVUVaspMnS4r6tauA4s5dvIZGdauBFC+Sy5o5I22kq1CmJBQKBeyKFMSDR3/WAdeqVhEpkicFLSGoU6MSrly7idCYFciXS8WMOLZqWi+o/LIlhOIZxFJGBHsKhW6GwSJaN8f3rcfTWyfQr2cH9Bs6Dk+evZBy/Xp0EBcfk9GicV3MXOCKQX3ssdp9C4aPnSYVQimk5sWzscGWHfvRrusgLFu9EXcfPJKpZ85dRtdOrUDjZ2FhgYwZ0sp49f4RU22c8+bKLq2YU2cvxilh9acx0BYnCwzFozlE848s1TS2NP+ev3yNtP+kRqECeWBmZob2rZrg4uUbSP2/lPjy5Zu4WFkItw3bkEKMOxV9WvSD1mIH3aWYixu37lG0Tvfy1Vu8euMheE2XFt9tuw7g+s2gC5V8eXJg5PiZcF7qJuvWLERX3hev3iCT4JdHHAfEskWTOppZeZ8JMAETIMAKrwkMEjeRCSgJKBQK5MudA6lSJgdZHMkC2bBuNWlJJAvX2cOb5RpfkrcwN6eNdAqFAn7CuiZ3gj2yqK5aK+SFUrVlrQvSCaver+CH2awsLYOlAH3KHnYAABAASURBVHMzc1haBO1T+Lffb1WaekBZHykymjKkZBav2BDkjp08p55Na5gUC2WCpaUFqJ/kKKyMV99aWlnIXXPRZ7Iiyh3hWVj8OcVZCsXPPyBAlqWLmbWVlcgV9J/qo/KC9gArtTRlXGgMlTLatmlSpxLlWaJh3eqoUqEMyPKqLkdW1rIli0nljZYAjB3eHyPGzVAXkeGlKzfA4917TBk3BK4LpsDT01PGU9stLc1lWN1T7x/FWwgmtCVHbCkfKaNkLc+fJyemCaV3684D0BZHeUJzVmpzSKEwU80/C4s/7bIUbaQ648WzwcEdq1GudHGcOntJ9HWmLDoQgdiwcr5qfj+/c0rG6/JIPmewZZ2Oh31bV2Lj6oVSfOl8J7Rr1RD0QGGzdr3lkh6ZEOzpyhsYCKjPA0uLoGMhOFvc23CPmYCJEvjza2CiHeBmM4G4RuCtx3txu/shUqdKiZJ2hbFZWPjoNj1xoIec6PYwhcNylKdwwdzInjUjnj5/iTtqa1/Dyhve9OJFC+H80a3SVRDW0tDyF7MtiB17DuPb9x/4/OWrCB8SlttCoAe3yGJHa4wpPykutA3N7T90Ep8+f5WW6937j6Bo4QJ6M7MtlBdkYaTyien9h08oGMLpYpgwQQJ8F+0PIRy8Q+2mNba0++7DR9BSE7I+0j45uoW+et1mdGrbVK7npYsbstQmTBCfkkO4J89foEypYvhXWE0PHDmpSitVoghcV22Aj4+vjKM6ZUDN08WZuNM68VrVKwhLcx1cvX5LjoVmnFpRMpgglD5LAeFlTJ9W3El4L/tMDFat3YLixQrhl1DUFQoFypQsigG9OuPqjdtCGihXyk5afWmHFGNa9kBhdZcgvg1+/PgpozKk+1fMmS/Ye+C43KdyiS/tUL8K5sstLgg74fPXb1Lx1SdvxvT/go4rWsdM5dAFCG3JUfzjCD4wR/nZMQEmEHMEWOGNOdZxpSbuZzQR6D9svHyQqHCZOujasQUyZUwHuq0/Zlhf9Bo4GvQQEN369fL21qsF1auUw7FTF0B55rmsklY8vTJGs1CuHFmEstcE9JBS4zY90U3cms+RLROyZcmIQX27oEOPIShTtSk6dncIsyX58+ZEk7Y95UNS7Vo2BpWjL7M2zRvIB7HoQac5zitAt/UTJ0oYok5dDEk5rVOjIlrb9wetQVbP9PDRU6TKXFS+Yq5Vp/4YM6wfsqit06U12e1aNYalsJCSgvbo8TPUatwJ5cuUUC9Ghju2aYKR46aDHqaiW/IyUnjNG9VGjqyZUbVeW+QvUROLl7uL2JD/dXHeKi6g/sleHE0Ft7MXr6JLhxbQFheyNKCnfRsMdnRSPbSmmU77ZFGePcURw8dMlw8DpkqZQijVdfHs+Wuky1UKVeu3w6wFrhg9tA+Jw1FsP3z8Ih/IpIfZdu8PWu8sE4O9Zo3qYNe+I3K+fP7yDbTW1nXVellWkTL1QGuJSbRk5cbiDkMD0Brp/j07gMZSn7w0Dk7Cgt6l9zC06twP6py37TqIFW7/UfHsmAATMHICrPAa+QBx85gAEdi7ZQUObFsNepjK49EFDBvYg6Klo9vi+7etwpFda3HpxA7kzplNrnOlPFJAeEMHdINyPaqPrw/ix7ORP/j0MBDd+p07bTToISJaH0tOPa/LnAkoK6yIohjQOsb14hYzhaeMG4oaQmmm8Pmj22AT/Kozkp0/YyxFi1vtf2RkRLBXpUJpLHeeGrwXtDm6ex1yZs8sd7p0aCn7Q3Gd2jaTceTR2lZ6COrUwU3YtMaZojBHKFBUntwR3uWTO4UPNBNK3+olM0Fl0FKP3t3ayXjy9GFmZWWJWU4jsWHVAnTv3BrJkiWRyxAov9KR0qSNIaU7Du2Lta5zoPnQGq1n/fT8CshR3prVypO4ypGCX7dmZbmvUCjkLfk9m5fDoa+9jFP3CuTNJazm2/CfmzNojGkcKJ0US3r47sT+Dbh5bi8G9en815wgOW2cO7RpgrcPz0u+S+ZNRnphNdUWR/nVXcO61WR/6aE1zTlEbVPOP5ofNL9ovs6YNFwypQfIaF7T2FKd5UrbyaJTpUwOesCMxvDupYOY6DhIxqt7lHfV4hnygTeSp4fsNq91kQ9x3rtyCI3r15Tidy4ekKxoaYNyTumbt2rFMnIerFs2F1vWuch5TYXSnNLWJkoLcuwzASZgLARY4TWWkeB2MIEYINCsXS9x29gOtM42Bqoz6Sq8fXyRrWAF0Ku9HEZOxgTHgSbdH248E2ACTCAuE2CF18Cjz9UzgZgkQA/wzJw8IiarNNm6aFnCq/tnpYV41yZXkOXQZDvDDWcCTIAJxHECrPDG8QnA3WcCTIAJGAkBbgYTYAJMINoIsMIbbWi5YCbABJgAE2ACTIAJMAFjIGBaCq8xEOM2MAEmwASYABNgAkyACZgUAVZ4TWq4uLFMgAkwgSAC7DMBJsAEmID+BFjh1Z8VSzIBJsAEmAATYAJMgAkYFwG9WsMKr16YWIgJMAEmwASYABNgAkzAVAmwwmuqI8ftZgJMQH8CLMkEmAATYAJxmgArvHF6+LnzTIAJMAEmwASYQFwiEFf7ygpvXB35WNpvS0srxLyzhJ+fnwHqNURfja9Of/8AKBRmzN8Ac79d9+EoWb0Nbt19zPwNwJ/OO+bmFszeAOwR/BeTvzfBVfImggRY4Y0gOM7GBGIvAe4ZEwgfgRvf3+LU52fsYpjBma8vjZb5/V8fwzeJWJoJRDMBVnijGTAXzwSYABOIrQSG9G6DX91yo7/nKdS9tJpdDDNoemsj6l9xM0ruMx6fiB3TnnsRawiwwhtrhpI7wgSYABNgAkyACTABJqCNACu82qjEgbg23Ybj46cvofZ094ET6NJ/HKo07IJBjtPx9PlrnfKPn73EybNXdKZrJgwYOR33Hz7VjA7Xvpe3NzZu2x+uPNEgzEUyASbABLQT+OUHszuhn2e1Z+RYUyVw+/4T3Lr3xFSbH6vbzQpvrB5e3Z0bPsAeSRIn0i0gUlL/LwUWTBuOne7zkT1rRixasUHEav9PyvDZi9e1J0ZTrLe3L7buPhxNpXOxTIAJMIHIEVB88YXlAd2GgsiVboy5uU37j5zD/iNnGYQREmCF1wgHJaqbtNxtK3o4TET91n0xc+FqWbzTbFd8+/5Dhle570DTjoPQe6gTRk6ch3X/7ZHxRQvlhbWVFeLZ2KC0XWG8+6jbUrF87VZh4b2M7oMm4NBxOuBPo/+Iaeg9ZDKGjZ8DH19fjJnijDbdh2PgqGn4+ctT1qHNI8tz884OGDFhLnoOngSP9x/FCeQ02vYYIfPPdlkN/4AAuLptgce7j7JOl+W6lXFtdXAcE2ACTIAJMAEmEHcImMWdrsbNnnoIhfD0hWtwmTEK29fOQ9vmdUKAePjkObbtOYLl88fDybEv7j7QvszAffMeFLfNFyKv+k6n1g1RtmQRLJrpiCrlS8ik12/fYerYAZgyuj+27zmK7z9+YbXzJNi3bYxbdx9KGV3ei1cesG/XGM7TR8LHxw8rhVI+d/JQUH4f39/Yue8Y7Ns0QprUKWWdPTo111UUxzMBJsAEmAATYAJxnAArvLF8AqRInlQojL5YuMxdrndNnChhiB7fuvsI5UsXQaKECaSrVM4uRDrtrN20G1+//0SnNg1pV29nWzAPEsSPJ+Vv3nmIBrUrwczMDHlyZpVOJujwMqRLgywZ08nU67fu4ZenF0YI6zNZfK/fuo87OtZIeXr+giGcr7BgG6JervOXmN/e8Pb2Msi4x3X+3t7eCAwMlMcpe9oJKL74wGbSVW0uVscd6b8edtU7xFpXuk5XkNPs45I1W0HvR46Oc4P2Gcax+hJghVdfUiYqZ2lpgZXOE1GqWCE8evISY5wWhOgJ/ViZm5ur4iws/oQp8sKVm7h8/TbmTB4ilzdQnL7OytIyhKhFKPWEEBQ7lhZqeRUKYT22lZZcsiC7L52KEQPthdTf/21s4sEQzsLCwiD1GqKvxlYnvfjdysqa+Rtg7ltZWUGhUID/dBMITGIJn+6545wrPqIWNrk6xVrnvmg8yGn2sVm9Koiu3wPds4xT9CHACq8+lAwlEwX1enp5Q5hgULhAbnTr2AS37j0OUWq+3Nlx5fpdIRIo3aWrt1Xp12/fx4p12zHZsT+sNJRXlVBwgNb5fvvxM3jv703+PNlx8epNmfD123fcf/hMhvXxihbKg2OnLuLx05dS/MvX76C3QsSPb4MfP0KuBSYLMjszaUlnDswhJuaAPCjZ001A3NUKTGGDuOYS/C8xMqb/J9Y6ugtJTrOPSZMkkheB0XHs6Z5knKIPAVZ49aFkwjL0wFfFep3lA1+zFq6GQ+8OIXqTI2tGVChdDH2GOsFh9AykTJ4UCRPGlzILlq7HtZv3ULFeJ/n50CYdBsp4bZ5twVwIDAhAv+FT5UNrmjL1a1XEl68/0HfYFIybthhpUqfQFNG5/2+a/2FQr/aYNGup7Ee7niPxVSi99EBd7WplZZ380JpOfJzABKKNwLQFbkiw+C5sXvyKtjqUBfOWCTABJhAZAqzwRoaeCeSldbAn96zCGpfJmDSqLyqWKSZb7bbYCSlTJJPhJvWrYsG0EZg4sg++fvuJfLmyy/ilc8bg7H43lftv5SwZr80jC+9kx36Y6zRUPrRWvVJpoaS2U4mScjpuWE/MmzIMsycNxnrX6ciZPbMqXT1A7aL2qcdVKmsnH6yjfuxcNx9FCuWVyfSwGtVJWxnBHhNgAkzAWAjEt0BAnqDzrLE0idsRvQTy5soCctFbC5ceEQJmEclknHm4VRElMHTcHDTrNAid+oxGBaEQZ8mUNqJFcT4mwASYABMIJhCY3Bp+1fh8GowjTmyqVyyBGpVKxom+mlonWeE1tRGLhvYumDocG5fPhPvSaWjRqEaoNdBDbPROX3VH79cNNZOOxG/ff8r3A6uXRWGK15GFo5kAE9CHAMswASbABJhACAKs8IbAwTthEbCzzS/f6Uvv9VU6WqoQVj5t6UkSJ/yrLCqT4rXJcxwTYALGSaBV2kIYmrU8uxhmMDBDKQzJUs4ouddNnds4Jyu3Ks4RUHaYFV4lCd4yASbABJhAhAi0EQrvMKHssSuPmGQwKENJDBUKb0zWqW9d9VjhjdCxxJmij4BZ9BXNJTMBJsAETIEAt5EJMAEmwARiOwFWeGP7CHP/mAATYAJMgAkwASagD4FYLMMKbyweXO4aE2ACTCAmCNj3G42ilZrFGue8bH1MYOM6mAATiEECrPDGIGyuignEAgLcBSagIjCkdxskSWgtvyyliuQAE2ACTMAICbDCa4SDEl1N+v7jp3zfbmjl05fZnGa7ombTHmhhPxir3HeEJo6TZ6/Iz/yGKhScePveY/k1t+Bd3jABJhDLCPgHBMSyHpl2dz5+/orAwEDT7oRRt54bZ0oEWOE1pdGKZFvjx4+H0YO7h1qKmZkZ6Mtreze5yC+zbdp+AI/nMQwgAAAQAElEQVSfvtSZ5+zF63j6/LXOdE5gAkwgbhAIEIrV+8+ecaOzJtLLsnW74vuPXybSWm4mE4heAqzwRi9fg5X++NlLDBs3Gx17O6Ja42549cYDnp5eGD99kWyTt48v6IMRbboPxyDH6ejSfxzuP3yK/6VMjuxZMoL+smZKj6yZ0+ONxwfa/cs9fPJcWHgvY9mazeg+aAKev3wrLcizXVaj91AnHD11EaQQt+46TJa/a//xv8pQj9DWZvr6m7rCTfWQpVibrHpZxhLmdjABJsAEmAATYAKGJ8AKr+HHIFpasG7THtStWRErFkzAltWzkTxZ0hD1bN11GL88PbHGZTK6tmuCW3cfhkinHVI07z54gvx5s9PuX44U47Ili6Bz28ZYNNMRGdP/I2XSp00D+npb2ZK2mDRzKYYP6Iwls0fjw6fPMl2Xp63NlcsVx8HjZ2UWuj3n8e4j8ubKCm2yUog9JsAEmAATMEYC3CYmYFACZgatnSuPNgIFhJLqvnkvlgrr68vXHogfzyZEXXfuP0bdGhXlwyY5s2dGnpxZQ6R//f4DwyfMwSiHbkiaOFGItLB2KpSxkyKv37xHiuRJkC93dllPwzpVZLwuT1ubq1cujcPHz8ssB46cQfVKpWRYmywl+Pj4wBDu9+/fBqnXEH01tjr9/Pzg6+vL/A0w94l9iDWigcDXH94m73YfOovBY+cavRvltBhDxs3T2U5f3998XETTceHr6yfOO34xypd+49hFnAArvBFnZ9Q569eqhFEDuyBtmlQYNWkByFKr3uDAQMDC3FwVZWHxJ0wPnoyf5oIBPdqhnLDSqoT0DFhZWqgkzdXrUAurBNQC9bW0OWXypEghrNO03OLQ8XOoWqGkzKGrf7QG2RBOoVDAEPVynWbyYoo5mBlk/ikUCskfan+W4lxi6i51qmTCCJDF6F2u7JlCbaPCTAE+NqLr2CC25KKr/L/LBf9FioBZpHJzZqMl8OPnL6RJnRK1qpaDnW2+vxReWhZw+fpt2f7vP37i/sNnMuzn9xtjnJxlvpLFCsq40Lx48azx/ftPrSJp//0fPn/5hi9fv8v0C1duyq0uT1ebK5Wzg9um3aD0bFkyyOwU1tY/S0tLGMKRYm+IerlOS1hYWEjHLCxjfO4Te3lAKj0FkCCepcm7ogVzoWPLugZ1+tTfpkl1dGhRR2c7Leniw0DnxNh+PNLcJxeT/QT/RYoAK7yRwme8mafNW4EqDbvAwXEGfIUSW71S6RCNbVinslBGv6Pf8KmYPn8lMmdMiwQJ4oOU4MMnzsFx8gKUrN5Guj0HT4TIq75Tq0pZnL10HT0HT5IPramnkQV5+IDOGDvVRdZDa4LV0zXDutpMbSfrLm2VeXTJKtN5ywSYABNgAkyACTABJQFWeJUkTG4beoMnjOiNQ1uXYsYEBzg6dEWC+PGQOFFCbFw+U2akZQfD+nfGXKeh6NGpGby9vfFPmlQoUbQgzu53C+HISiwzafHoLQ7Txw2C8/SR8qE1Kp/qUYoWL1JA1kH1zJk8FDPGOyiT/tpqazMJJUmcULbHvm0j2pVOl6xMZI8JMIEYITBtgRu+/fQJfterQt4+B/8ZDYFUKZLymBjNaHBDDE2AFV5Dj4CB6vf3D0DNpt1BrwwbMWEeBvZqD3Mzng4GGg6ulgmYPAEzBZA6eXzD9INr1UrgxI4lSJSQx0QrHI6McwRYw4lzQx7UYUtLCxzdsRxrl0zByoUTUaxwvqAEHf7aTbvRw2FiCEdxOsRDjaa1vJpl0TuBQ83EiUyACTABJsAEmAATiCCBuKLwRhAPZ1MSaN20NlxmjArhKA4R+LOzzR+iHCp33LCeESiJszABJmAMBHJmy4QiBfPEGvfvP/8zBqzcBibABKKQACu8UQiTi2ICTIAJGD+BqG/h4D6dsHj22FjjGtSqFPWQuEQmwAQMSoAVXoPi58qZABNgAkyACTABJsAEopuAVoU3uivl8pkAE2ACTIAJMAEmwASYQEwRYIU3pkhzPUyACZgiAW6zHgSmz1+ObgPGmpS7dPWWHj1jESbABGILAVZ4Y8tIcj+YABNgAgYicP/RM1y+fsek3OevQV+ANBAyrpYJmCAB024yK7ymPX7ceibABJiAwQgM6d0GSRJaQ6FQGKwNXDETYAJMQB8CrPDqQ8lEZTZu2w8vb+9wt36W8yrsP3I63Pl0ZXj87CVOnr2iK5njYxEB7krsI/D9xy80aD849nUslvXo+u2HGOA4O5b1irvDBKKOACu8UcfS6ErauvswvL19Dd6up89f4+zF6wZvBzeACTCB8BPw9/fHoycvw5+Rc8QoAU8vb7x45RGjdXJloRLgRCMjwApvFAxIs06DMNtlNXoPdYLLio0YNn6OqtSLV29hwMjpqn3NwHK3rfLrZfVb98XMhatlMpVH4S79x6Fz3zF4+OS5jA8ICMACV3e06joU7XqMxJ6DJ2R8YGAgnJetR5tuw9GgTT8ps/vACXi8+4jBY2ap6qdyle08euoijpy8gNoteqFllyEY7bQQP395yvLC8u4+eILugyagbY8RcHCcgU9fvsosTrNdMXmWK3oNnoT2PUfi6o27Mn752q3CwntZ5jl0/Jy0HvcfMQ29h0yWrDzef8Qgx+no0GuUzPv4adCPK1mZlXIt7QfLflGBi1ZuxLr/9lBQOpflG+C+ea8Ms8cEmAATYAJMgAkwAU0CrPBqEongfvq0abBg6nB0bd8Et+8+grePryzp0LFzqFqhuAxreh5CIT194Zr86tj2tfPQtnkdlUjG9GmwdM4Y9OnSEtPnr5Txu4QS++HjF9CngJ1njMTG7Qfx7MUb7DpwHJeu3cHSuWOwdc0c1K1eAbWrlUOa1CkxfdxAzJ7053aksp0VyxRDjqwZsWX1bKxbMhUZ0qWB+5awlUZ/oXSPm+aCft1aY43LZFStWBJzF62V7SOPrEHzBAfnGaMwZ5EbRaFT64YoW7IIFs10RJXyJWTc67fvMHXsAEwZ3R/zl6xD7hxZZb9qVikDpznLpAx5Srk1i5zw8PELnL98E3Wqlcf2vUcoGaTsHzh6FnWql5P7/v6/YQgXEOAf/noN1FZD8InOOpl9TMx5f+zcf+Ivd/L8TXz/5Qsv798m5y5cvfNXf7T10Zjj9h4+I/pwUrgTOH3hOvz8/Pg8FGPnVTrnk4uJ4y+oDvkjx16ECbDCG2F0ITNWKGMnI8zNzFCyWCEcO3UBpByeOHsF5UoVlWmaXorkSeEjFOOFy9yxcdt+JE6UUCVCCiLtFMqfS9ymeisVu8tCqX3w+Dn6DpsCh9Ez8fnLN9x7+ASXxIm7VZNaiGdjIx8eyZj+H8qq1SnbSYlWVpZYvX4HyIp66txVPH7ygqJDdW893uPdh8+Yu3ittNhu3nlItkGZqaRdQZibmSFB/Hj4+u2HMvqvrW3BPFKGEm7ceYgm9atSUCrqz168xu/fv+V+wXw5pZyFhQVKFC2AW+JiIt2/qZEyeTKQpfmMOMnnzpEZiRImkPKUzxCOrO+GqJfrpB8C+tHxl3OGefyOHg7+/ti298Rf7vi5G/j+0wdevkLhNTF3/vKdv/qjrY/GHLfr4Bls3xc0LqfPX4evUHhN9RgwtXb7i2OCXEy2W/7IsRdhAqzwRhhdyIxWlhaqiCrCoku37s9dvIGCebMjYYL4qjT1gKXIs9J5IkoJBZnWyI1xWqBKJsulckcBhQwqFArYt2kkLaVkLd0hrMI1KpeRaRbmf+qXETo89XZOnbsM/6ROhQkjekmLrZde630VIk9KVRuWzB6DjctnqmozE8qucicgMFAZ/GtrZWkZIs5SKLQUoVAooFAIF1yOZhFKLnVrlBeW7RPCHUPt6uUpq3TW1jawNoCzsLCEtQHq5TptYGlpBSsra1gzf1hHFwMrKyybM+ovN6pfa6RLnQjJE9uYnOtj3+Sv/mjrozHHLZziANfZI2U/hvRpJ4wD8WEdXXOAy4W1GgMrcUyQU4+L7rD8kWMvwgRY4Y0wOt0ZixXOhwfi9vvOfUflLX9dkp5e3hCmWxQukBvdOjbBrXuPVaL0wBntHDh6BunTpZFKYPEi+eG2aRd+/PxFSXj87KWwon5HkUJ5sH7rXnFLUZQnUn55egkf0uL77ftPGdbmvXztgTIlbaVl+dT5q9pE/or7N00qaUHaH/wWBz+/37hx+8FfcuoRZHn+9kN3OwrkyQ6yFFMe6m+mDGmllZj2z168hg8fP8PL2xt7Dp1E/jzZKBoVy9qBLijuP3wuLhgKyjj2mAATYAJMgAkwASagjQArvNqoRDJOoVCgbAlbnLt0E6WL2+osjR7Wqlivs3z4a9bC1XDo3UEl+/OXF1p2GYoNW/djcJ+geFrfWqp4IfQYNBEt7AfDcfICBAQEok61csiXO5t8wK1Bm35wXrZBlkPLHOYvXat6aE1GqnkdWtZH5z5j5JIGui2jlqQzSBbcSaP6Ys/BU/LBtHqt+oRQ1LVltC2YC4EBAeg3fCrI8q0p06drK1y/dQ/00Nr2PUcxrH8nlUiOrJkw0HGGTCOFv3iRAjLNWlxdFymYBzUql5IXAzKSPSbABJhAXCDAfWQCTCDcBFjhDTeyvzNsFLf01dffkgQpqcd2LoeNtRXtanVZMqbDyT2r5MNfpERWLFNMJdetfRO4L52KZfPGIXuWjKr4Lm0bw22xE9a7TpcPmyVPlgSkhPa2byn3t7nNVSnI9IDYzAmDVQ+tabazVtVy2LxqFuZMHoIBPdphrtNQWc/Anu1RvVJpGdbmUXtIdpXzJOzd5IJWjWtKseED7FFJWF7ljvB2rpsvfEhL82THfrJ8ahOVPahXO5lGXpr/pQS1c+XCiVg4fSSyZkpP0dLRQ3b0cNyGZTNAfZSRwqOlDU9fvEa9GhXFHv9nAkwgugjQuW3bau1vmpm2wA3ffvqAjsfoqp/L1Y9Aobw5MHvCAP2EWYoJxEECrPDGzkGP1b2i9/rSK9Hy5Mws30QRqzvLnWMCBiZgbm6GbJn/XIQauDlcvQ4C8eJZy7ft6EjmaCYQ5wmwwhtDU2DMFGf5vt0eDhNV2wtXbmqtXdMSq1UoBiLD0+boaI6mJVhZR+aMaeG2yElapZVxvGUCTIAJaCfAsUyACTABgBXeGJoF44b1lO/bdZkxSrW1s80fQ7VHrBpTbHPEesq5mAATiAwB17njcenIRpNy1SqWikyXOS8TYAImRoAVXgAmNmbcXCbABJgAE2ACTIAJMIFwEGCFNxywWJQJMAEmEMsJcPeYABNgArGSACu8sXJYuVNMgAkwgZgjsH3vESxeudGk3PdQ3g0ec+S4JibABGKKQPgV3phqGdfDBJgAE2ACJkFg575jWLr6P5NyrPCaxNTiRjKBKCPACm+UoeSCmAATiGsEuL9MgAkwASZgGgRY4TWNcTLqVrbpNhwfP30JtY3Xb99H1wHjULpmO61fW4Pa3+NnL3Hy7BW1mNCDA0ZOx/2H8YqWcQAAEABJREFUT0MX4lQmwATCRWDXgVO4eO1uqHmG9G6DJAmt+WuHoVKK2cQvX79j7pL1MVsp18YEAKNnwAqv0Q+R8TeQvrCWJHGiUBtqY20N+npchdJFQ5WjRPqwxNmL1ynIjgkwAQMROHX+Gu4+4AtJA+GPcLXffvzChm0HI5yfMzKB2EqAFd7YOrLR0K9fnl6YMGMJug0cj2qNu+HA0TOyFqfZrvj2/YcMr3LfgaYdB6H3UCeMnDgP6/7bI+NzZsuEIoXyys8gy4hQvOVrtwoL72V0HzRBWoP3HzmN/iOmofeQyRg2fg58fH1BH8Vo0304Bo6ahp+/PEMpjZOMhgA3hAkwASbABJiAgQiwwmsg8KZY7bFTF5EsaSIsnjUaezY6o6hQYNX78fDJc2zbcwTL54+Hk2PfCFuHOrVuiLIli2DRTEdUKV9CVvH67TtMHTsAU0b3x/Y9R/FdWDFWO0+CfdvGuHX3oZRhjwkwgagl4O3tI481Ot60uZ+/vODvH4CAgECTcz9+eobaN239NYU46ldAYGDUTgQuLcoJcIExT4AV3phnbrI15siWEWcuXMOSVZuEBfYKkidLEqIvt+4+QvnSRZAoYQLpKpWzC5EemR3bgnmQIH48WcTNOw/RoHYlaS3OkzMryMkE4Xl6/oIhnJ+fr0HqNURfja1OX18feHt7Mf8onvs/f/3ClHmrYFe9g07XadAMPH71Fe+/eJqcq99usM5+hdZnY0qr0LAnStTsFKIfjTsOEceCt3CGORca2/khutrj7e0tzjsxy1n8xPH/SBBghTcS8OJa1uxZMmLJ7DHIlSMrNm7bj/Vb9oVAECisCubm5qo4C4s/YVVkBANWlpYhclroqCd+/AQwhLO0tIrieg3TD0Owi2ydVlbWsLGJx/yjeO4nTJAAY4d0xb0zm3S6jYsckSNjcqRJkcDk3JEtC3X2K7Q+G1PalUOrcOfUhhD9OLBpARIm4OMhsueVsPLb2NiI845NjJ53QvwI8k64CbDCG25kcTfDt+8/xYk0PsqVtEWjOpVBFl11GvlyZ8eV63dBii+5S1dvqyfrHY4nTiTfQnkpfP482XHx6k1Z3tdv33H/4TMZZo8JMAEmwARiIQHuEhOIAgKs8EYBxLhSxNFTF1C2dgf0HDwJx09fRsfW9UN0PUfWjKhQuhj6DHWCw+gZSJk8KRImjC9lzl26jpLV28iH0BwnL0CVhl1kvDbPtmAuBAYEoN/wqVJeU6Z+rYr48vUH+g6bgnHTFiNN6hSaIrzPBJgAE2ACTIAJMAEVATNViANMIAwCDWpVwsndK+E8fSQmjuyNrJnSyxxui52QMkUyGW5SvyoWTBsh0vvg67efyJcru4wvUbQgzu53U7lDW5fKeG0eWXgnO/bDXKeh8qG16pVKY1CvdipRaysrjBvWE/OmDMPsSYOx3nU6cmbPrErnABNgApEnUKdaWRQrnCfyBXEJMUogedLE6NetZYzWyZUxAVMgYGYKjeQ2mg6BoePmoFmnQejUZzQqlCmGLJnSmk7juaVMgAmoCJQpXhC5s2dS7WsLTFvghm8/fUBLmLSlc1zME0icKAGa168S8xVzjUzAyAmwwmvkA2RqzVswdTg2Lp8J96XT0KJRjVCbf+HKTfRwmBjC0ft1Q83EiUyACTABJsAEmAATCCcBVnjDCSw2iBtLH+xs88NlxqgQjpYqGEv7uB1MgAnoR8Chd0csmjXGpFzKFMn16xxLMQEmECsIsMIbK4aRO8EEmAATMByBXNkzyw/RFC2U12S2NtZWBIwdE2ACcYQAK7xxZKC5m0yACTABJsAEmAATiKsEWOENa+Q5nQkwASbABEIl8OrNOzx68kJv9+zF61DL40QmwASYQFQTYIU3qolyeUyACTCBWEpAV7fGTl2IFvYOertegyfqKorjmQATYALRQoAV3mjByoUyASbABJgAE2ACTIAJGAuBKFZ4jaVb3A5dBNp0G46Pn77oSpbxzsvWC0vNYNRp0Rvjpy+Cj6+vjDc2z8vbGxu37Te2ZnF7mECUE3j09CVevXkf5eVygVFD4Na9J/gQxnk1amriUpgAE4goAVZ4I0rORPMNH2CPJIkThdr6gvlzya+XrXaZhM9fvmHrriOhyhsq0dvbF1t3HzZU9VwvEwidQBSmrtm0F3sPn4nCEqOmqCG92yBJQmsoFIqoKdBES5m3dD3OX75toq3nZjOBuEGAFd5YOs6/PL0wYcYSdBs4HtUad8OBo0E/lk6zXfHt+w/Z61XuO9C04yD0HuqEkRPnYd1/e2R8abtCcps8WRIUEsrv+4+f5L427/Gzlxg2bjY69naU9bx644H5S9eFsLwuWbUJqzfshDZZbWWSBbp5ZweMmDAXPQdPgsf7j9h/5DTa9hiBNt2HY7bLavgHBMDVbQs83n1E90ET4LJ8g7aiOI4JMAEmwASYABMwMAFjqJ4VXmMYhWhow7FTF5EsaSIsnjUaezY6y3djqlfz8MlzbNtzBMvnj4eTY1/cffBUPVmGacnArv3HYWebT+5r89Zt2oO6NStixYIJ2LJ6NpInS4qqFUri8InzKvGDx86hmojTJqsS0gi8eOUB+3aN4Tx9JHx8/LBSKOdzJw/FaudJ8PH9jZ37jsG+TSOkSZ0Si2Y6oken5hol8C4TYAJMgAkwASbABIIIsMIbxCHW+TmyZcSZC9dA1tWTZ68IRTRJiD7euvsI5UsXQaKECaSrVM4uRHpgYCBGTZqPSmXtUKJowRBp6jsF8maH++a9WLpmM16+9kD8eDagl9DTUoiPn7/i/sOnSJoksVRMtcmql6UezpAuDbJkTCejrt+6B7JYjxBWaLL4Xr91H3fuPZFpmp6XlycM4fz8fA1SryH6Gj11RnzcfH194O3tFbv5e3tjyZqtqN2qv1G5geNc8OztN3z86hku9+DpW6PqR2S5XrlxDzQPY/rYoPNOrJ/7BjqnhzWWPj7ewhjjHaPnHc3fO94PHwGz8ImztKkQyJ4lI5bMHoNcObLK5QXrt+wL0XRSaM3NzVVxFhZ/whTpKhRYUlx7dm5Buzpd/VqVMGpgF6RNk0ooyAuEpThIEa1SvgQOHDmDA8fOgsJUgC5ZStN0lhaWf6IUCpQtaSstuWTNdV86FSMG2v9JVwtZWVnDEM7c3MIg9Rqir8ZWJ7G3tLSK3fxF/2pULIkxg7sYlbNvVQv/Sx4fiRJYh8v9mya5UfUjslyzZkoHC3HOsorh80+cmPsxzFTfMaTxJqevfLjkdPRZ7aeOgxEgwApvBKCZQpZv338iYYL4KCcUxUZ1KoMsuurtzpc7O65cvwtSfMlduvrngYsNW/fj46ev6NKuiXoWreEfP39J622tquXk0oe7D4IU3hqVy+CgUHYPHz+PyuWLy7y6ZGViKF7RQnlASzQeP30ppb58/S7XA8ePb4MfPzxlnNIjJd4QzszMDIaol+s0jyPczUB3PewK54UxuTzZMyK+tSWsLc3D5RLGszaqfkSWaZLECWGIc4Ah6uRzjuHOOeC/SBEwi1Ruzmy0BI6euoCytTvIh76On76Mjq3rh2hrjqwZUaF0MfQZ6gSH0TOQMnlSJEwYH7/9/TFn0Rrs2HcMJau3kY4efguRWW1n2rwVqNKwCxwcZ8DX7zeqVyotUzOm/wfePr5I929qWTZF6pKltNDcv2n+h0G92mPSrKXywbV2PUfiq1B6ra2sULtaWfQbPjWuPbQWGi5OYwJMgAkwASbABDQIsMKrASS27DaoVQknd6+UD31NHNkbWTOll11zW+yElCmSyXCT+lWxYNoITBzZB1+//US+XNlhYW6Os/vdQjhHh65SXps3YURvHNq6FDMmOIDkEsSPpxKjpQdUvjIiNFmlDG2pfdROCisdrSVePn881rhMxs5181GkUF6ZRA+rzXUayg+tSRrsxVYC2bOkR/q0qWNr90y+X/lyZcX/UgadV02+MybXAW4wE9CPACu8+nGKlVJDx81Bs06D0KnPaFQoUwxZMqWNlf3kTjEBUyfQpklN1KhU0tS7EWvb37dLc9jZBl2Ex9pOcseYgIkTYIXXxAcwMs1fMHU4Ni6fCfel09CiUY1Qi7pw5SZ6OEwM4cZMcQ41T1iJtM5Ys0zap/iw8oYnnWWZABOIHgLTFrjh208f+SxA9NTApTIBJsAEooYAK7xRwzHWl2Jnmx8uM0aFcOOG9YxUv+lBD80yaZ/iI1UwZ2YCTCBGCdCrC2tWKQt9XcWyIV+DGKONjduVce+ZQJwlwApvnB167jgTYAJMIGoI2LdtjAkj+ujtHHp3jJqKuRQmwASYgJ4EWOHVE1ScEeOOMgEmwASYABNgAkwglhFghTeWDSh3hwkwASbABKKGAJfCBJhA7CHACm/sGUvuCRNgAkzAIAQGjpqGao27aHVdB4w1SJu4UibABJiAOgFWeNVphDvMGZgAE2ACTOD7j5/4/OWbVvft2w8GxASYABMwOAFWeA0+BNwAJsAEmEAsIMBdYAJMgAkYMQFWeGN4cNp0H46Pn77EcK1B1W3cth9e3t5BO+HwDdnmcDSTRZmA0ROYtmAN5ixeb/Tt5AZGjkC5et3w6OnLyBXCuZkAE4hSAjGp8EZpw7mw8BPYuvswvL19w5+RczABJsAEtBAY0rsNkiS0hkKh0JLKUUyACTAB4yHACm8kxuL0+WsYNn6OqoSLV29hwMjpcn/LzkPo0NsRZB1duvo/GReW98vTCxNmLEG3geNRrXE3HDh6Rmahz//OXLgaXfqPQ+e+Y/DwyXMZ/+nLV4ycOE/WYd9vDG7feyzjAwMD4bxsPdp0G44Gbfphgas7dh84AY93HzF4zCxVG6nc2S6r0XuoE46eugiX5RtQt1UfNO/sANc1m2VZ+nh3HzxB90ET0LbHCDg4zgC1i/JR+fOWrEX3gRPQb/hUfPj4maIREBAg29Sq61C06zESew6ekPH7j5xG/xHT0HvIZMnV28cX9DU3YjjIcbrs//2HT7Fo5Uas+2+PzEMetdt9814KsmMCJkKAm8kEmAATYAIxSYAV3kjQLlGsAG7ffQRSzKiYQ8fOoWqF4njy7DWWrd2KWRMcsHTOGBw5eQFnL14nkVDdMaF0JkuaCItnjcaejc4oWiivSj5j+jSyrD5dWmL6/JUyfv4SdxTKnwtui5zg6NAdY6c6y/hdB47j0rU7WDp3DLaumYO61SugdrVySJM6JaaPG4jZkwZLOfLSp02DBVOHo2KZYqheqQx2rpuPVc6TcevuY1y+dptEQnX+QnkdN80F/bq1xhqXyahasSTmLlqrypM5Y1osmuWIZg2rw23TLhm/SyjfHz5+wcqFE+E8YyQ2bj+IZy/eyLTXb99h6tgBmDK6P7buOoxfnp6y3K7tmog2PZQydaqVx/a9R2SYlPsDR8+iTvVyct/PzxeGcP7+vw1SryH6amx1Evvfv/1Mgr+/vz9OnbuG6QvWxArntvkQPn7xwo9fvptZeUAAABAASURBVDrd89cfYkVfwzNmP395ivkY/XPSn887grNhzvl0ziEXk+dD+SMXG70Y6hMrvJEAbW5mhpLFCuHYqQsgxe/E2SsoV6oort++hwpCgUyeLAni2digVtVyuHH7QZg15ciWEWcuXMOSVZtwUpRF+ZWZypYsIoOk4L549Rak6F27eQ8Hj50FWVed5rji4+ev0op66eodtGpSS9atUCiQMf0/Mq82r0IZO1W0j68PyOI7cNR0kOL56OkrVZquwFuP93j34TPmLhaWXGHl3Sws2/cePlGJlyluK8Np/pdCKLVvZfiyUMYfPH6OvsOmwGH0TPlktzKPbcE8SBA/npS7c/8x6taoKG+X5syeGXlyZpXx6f5NjZTJk4Esy2cuXEfuHJmRKGECmcYeEzBuAoHBzaNtbHHBXQp1E1v6ql8/6PwcKg5OZAJMIMYJsMIbSeRVhEX30PFzOHfxBgrmzY6ECeLLEi0tzOWWPAtzcwSKfxQOzWXPkhFLZo9BrhxZQQ+Yrd+yTyWufgJVQKGKnyYstotmOoLc0e3LkCplcplmYW4ht2F5VpZBcn5+v+E4eQEqlyshLcDVK5WGp5d3WNlFugL/CMsx1U+O2r9x+UwRH/Tf3DxoiilgBn9h3YL4UygUsG/TSLaZ8uxYOw81KpcRKYCVpaXckhcofluIHYXJWagxrVujPHYJS/GuA8dQu3p5SpbO0tIKhnDmgrch6o0jdYY6psTewsIyVBlj4URtLVOiEAb3bhcrXJvGVZEyWTwkSmCl02VMmypW9DU8Y0YX4JbiXBbd847mU3TXweVr/02hcw65mOQD/osUgSBtJFJFxO3MxQrnw4PHL7Bz31F5O59oFMybC8fPXJaWS3orwp5DJ1E4fy5KCtV9+/5TKszlStqiUZ3K4hb+I5U8PXBGOweOnkH6dGmgUChQzDYfFq3YJK29lHYpeAlCkUJ5sH7rXtUbGX55elGytPhSHXJHw/v67btQGCxRIG8OqXTqswSDivg3TSr8/v0b+4+cpl1xe+l3mNbs4kXyy+UNP37+knkeP3sJql/uqHl5c2XF5etByyroPZ/3Hz5TpVYsaycvMu4/fI5SxQqq4jnABJgAE2ACTCD2EuCeRZQAK7wRJRecT6FQoGwJW5y7dBOlg2/fZ8mUFm2b1sFAxxnyQStSYIsXKRCcQ/fm6KkLKFu7A3oOnoTjpy+jY+v6KuGfv7zQsstQbNi6H4P7dJDxvexbwNfXF227j5APm9GaV0qoU60c8uXOJh9wo4fWnJdtoGi5zGH+0rWqh9ZkZLBHlmFaMtCm+3AMHj0TtGwgOCnUjZmZGSaN6os9B0+hfc+RqNeqD24FPzynK2PNKmVQqngh9Bg0ES3sB0vLckCAMOdqZGgolP7PX77LB95o3TKtB04QbEG3trJCkYJ5hGW4lFT+NbLyLhNgAkyACTABJsAEVARY4VWhiHiAFNBjO5fDxtpKVUijulWwcsEE+UBZl3ZNVPH0gFnKFMlU++qBBrUq4eTulXCePhITR/ZG1kzpVcnd2jeB+9KpWDZvHGjpAyUkTZwIowd3h9tiJ/mwGSmeFE9KaG/7lli3ZCq2uc1VKchVypfAzAmD5ZIFkqOlB4kTJaSgdI4OXUHtmzHBAeOG9UTHVkEKN8XpajNlpPbMdRqKVc6TsHeTC1o1rknRUC+fLgIWTBsh48nr0rYxqN3rXafLdtJ6ZVpGMahXO0qWzsrSAsP6dwaV3aNTM3h7e+MfYVGmRFri8fTFa9SrUZF22akR4KDxEhjSuy36d2thvA3klkUJgRM7FiNb5j/n7ygplAthAkwgUgRY4Y0UPs4cnQT8/QNQs2l3tO46DCMmzMPAXu1hbmaGp89fg16BlidnZvnmiehsA5fNBJgAE2ACJkuAG84EVARY4VWhiLkAraPt4TARmo7itbVC3VKqLT2m4uiduJptvnDlZrRVbyksvEd3LMfaJVOwcuFE0HppqoyWNpDVeUCPdrTLjgkwAQMRmLbADd9++si3pNBdGm0uSZJEBmodV8sEmAAT+EOAFd4/LGIslCRxQrjMGPWXo/gYa0QEKqJlDprttrPNH4GSjCgLN4UJMIFIE5g1cQgObF6q1S2ZPTbS5XMBTIAJMIHIEmCFN7IEOT8TYAJMgAkwgVhAgLvABGIzAVZ4Y/Poct+YABNgAkyACTABJsAEwAovT4JwEGBRJsAEmMDfBFzXbIbj5Pl/ucvX7/wtzDFMgAkwAQMQYIXXANC5SibABJhAbCJw7tJ17D108i/38rVHbOpmyL7wHhNgAiZFgBVekxoubiwTYAJMgAkwASbABJhAeAmwwhteYvrLG7XkzIWrsf/I6VDbePXGXQwbPwdVGnaBfb+xOH7mcqjy+iR6eXtj47b9+oiGKROVZYVZGQswgSgm4LJyszimrkRxqVxcTBJYtnYHDh6/EJNVcl1MgAlEkAArvBEEZ+rZmtSriqKF84bajfjxbODQuwP2b16M9i3qYdLMJaHK65Po7e2LrbsP6yMapkxUlhVmZSzABKKYwIPHL+Dx4XMUl2qsxcXOdj188gJv332MnZ3jXjGBWEaAFd5YNqDaurPcbav8yEX91n1Bll2S+W/HQVy6epuCOH3hmvyaWdcB4zB17nI4jJ4h43Nmz4yUyZPKr5uVKVEYfn5+IKuqTNTwPn76guadHTBiwlz0HDwJHu8/SgsyfRGtTffhmO2yGv4BAXB12wIP8QPRfdAEuCzfoFFK0G5UlhVUIvtMgAlEB4EhvdsgSUJrKBSK6Ciey2QCTIAJRBkBo1F4o6xHXFAIAh5CuSSFlj4YsX3tPLRtXidE+u/fvzFxxhKMHNQFi2eNxqcvX0OkK3e27jqMbFkyIp6NjTLqr+2LVx6wb9cYztNHwsfHDyvdd2Du5KFY7TwJPr6/sXPfMdi3aYQ0qVNi0UxH9OjU/K8ylBERLSsgwB+GcIGBAQap1xB9NbY6TZW9v78/njx7hfOXb5qsu3XvKTy9/eDr56/VPXr60mT7ps+4fBAX+oacf4as29jOA3GhPcrfR95GjAArvBHjZjK5UggLrY+PLxYuc5drZxMnShii7a/ffsD/UiZDnpxZpZWmfq1KIdJp58btB1j73x6MHtyNdnW6DOnSIEvGdDL9+q17+OXphRET50mL7/Vb93Hn3hOZpo8X0bJ8fX1hCEfKiyHq5Tp9QRdtdPfB1Fh4+/hg5/6TmDR7haYzmf2VG/fjwxdPfP/lo9Vt23vCZPoSkXG4efexmH/+Bjnn0Hyn844pzn1qu6k7Ou+Qi8l+6PPbyTK6CbDCq5tNrEixtLTASueJKFWsEB49eYkxTgtC9CtQ7Jmbmws/6L+FWphiPnz8jAWu7lgwbTjSp01DUTqdpYXlnzRxi7NsSVtpySVrrvvSqRgx0P5PehihiJZlYxMPhnAWou+GqJfrjAdLSytYW9sYZNwjwz9B/Pjo160ldrjNMlk3Y3R3ZPwnCVImja/VOfRsbbJ902dcKpUpKuafpcHmHp13THHuR+a4MZa8VlbWIBeT7UGc/Iu6TptFXVFckjES8PTyBgIDUbhAbnTr2AS37j0O0cx0/6TCp89f8e37Txl/6dotuSWP1tKOnDQfIwZ0wT+pU1GU3q5ooTw4duoiHotbmpTpy9fvePzsJeLHt8GPH54UpbeLyrL0rpQFmQATYAJMgAkwgVhDgBXeWDOU2jtCD49VrNcZ9PDYrIWr5VsX1CUtLCwwpF8njJmyEP2GT8W3b7+QMEECKbJp+wHcvPMQLbsMQcnqbaSj8mRiGN6/af6HQb3aY9KspbLudj1H4qtQeq2trFC7WllZl66H1jSLjsqyNMvmfdMnwD1gAkyACTABJhAWAVZ4wyJk4um0pvbknlVY4zIZk0b1RcUyxWSPBvVqh+qVSstwoXw5MWfyUOGGCAusNfLnySbj6aGys/vdoO7S/C+lTNP0UqZIBrfFTiGiK5W1w/L542XdO9fNR5FCeWU6lTvXaajOh9aisixZIXtMwAgJ9OjQGBVK2Rphy7hJ+hKwb1MfVcsX11ec5ZhAdBPg8kMhwApvKHDiStL6LftQs2kPtOo6DJ6ePqhbo0Jc6Tr3kwkYjECOrBmQOlVyg9XPFUeeQLbM6fFP6hSRL4hLYAJMINoJsMIb7YiNv4LObRpi7yYXKB8ss7K01NloWuvbw2GifK+v+pbidWbSkUB51MtQhileRxaOjiwBzs8EmAATYAJMIA4SYIU3Dg56ZLqcJHFC0Dt9NR3Fh7dcyqNZDu1TfHjLYnkmwARinsC0BW749tMHY4b0xHrXGX85WtYU863iGpmAfgRYKm4RYIU3bo0395YJMAEmEOUE0v2bGtmyZPjLab73O8or5gKZABNgAnoSYIVXT1AsFhcJcJ+ZABNgAkyACTCB2ECAFd7YMIrcBybABJiAAQmcu3Qdew+dDOEuXf3zTm8DNo2rjioCXA4TMHECrPCa+ABy85kAE2AChibgumYzHCfPD+HWbNxp6GZx/UyACTABFQFWeFUoOBBJApydCTABJsAEmAATYAJGSYAV3mgellnOq7D/yOlorkV78Ru37YeXt7f2xFBio7rN9Enhk2evhFIjJzGBuEvg1r0nOHnuWtwFYEI9p0+kb9h+SI8WswgTYALGRoAVXmMbkShsz9bdh+Ht7RuFJUasqKfPX+PsxesRy8y5mEAsJ3Dx6h3sO3I2lvcydnTv/ccvWLRyc+zoDPeCCcQxAqzwhmPAT5+/hmHj56hyXLx6CwNGTpf7V2/cRZf+49C+50g4Tl6AHz9/yXhdnjJ+udtW+RGH+q37YubC1TK6WadBMkzlde47Bg+fPJfxAQEBWODqjlZdh6Jdj5HYc/CEjA8MDITzsvVo0204GrTpJ2V2HzgBj3cfMXjMLFUbqdzZLqvRe6gTjp66iCMnL6B2i15o2WUIRjstxM9fnrK8sLy7D56g+6AJaNtjBBwcZ+DTl68yi9NsV0ye5YpegydJDsSEEpav3YqTZy/LPIeOn5MW7/4jpqH3kMmSp8f7jxjkOB0deo2SeR8/fUnZQsi1tB8s+0UJi1ZuxLr/9lBQOpflG+C+ea8Ms8cEmAATYAJMgAkwAU0CrPBqEgllv0SxArh99xG8fXyl1KFj51C1QnH89veXCmOPTs2wynkSzM3NsWZD2A9seAiF9PSFa/JDDtvXzkPb5nVkueRlTJ8GS+eMQZ8uLTF9/kqKwi6hxH4QFoaVCyfCecZIbNx+EM9evBHxx3Hp2h0snTsGW9fMQd3qFVC7WjmkSZ0S08cNxOxJg2V+8tKnTYMFU4ejYpliyJE1I7asno11S6YiQ7o0cN8SttLoL5TucdNc0K9ba6xxmYyqFUti7qK1VLR0/oLFPFG+84xRmLPITcZ1at0QZUsWwaKZjqhSvoSMe/32HaaOHYApo/tj/pJ1yJ0jK6hfNauUgdOcZVKGPKXcmkVOePj4Bc47afMOAAAQAElEQVRfvok61cpj+94jlAxS9g8cPYs61cvJffaYABOIOQJDerdBkoTWUCgUkamU8zIBJsAEop0AK7zhQGxuZoaSxQrh2KkLIMXvxNkrKFeqKF6/eY9EiRLAtkBuWVqzBtVw4/ZDGQ7NS5E8KXyE8rxwmTs2btuPxIkSqsRJQaSdQvlz4cWrt1KxuyyU2gePn6PvsClwGD0Tn798w72HT3BJ3BJt1aQW4tnYyB+ejOn/oaxaXYUydqp4KytLrF6/A2RtPXXuKh4/eaFK0xV46/Ee7z58xtzFa6XFdvPOQ7INSvmSdgVhbmaGBPHj4eu3H8rov7a2BfNIGUq4cechmtSvSkGpqD978Rq/f/+W+wXz5ZRyFhYWKFG0AG6JCw56yX3K5MlAluYzF64LZTkzEiVMIOV//foJQzhfXx+D1GuIvhpbnT4+3vDy8jRZ/jR3Nu44jOzFG5uca9J1PO4/+4y3H3/95bbuPWNy/QlrDGq17I/vP34ZzVyjuePpaTztMbZzQ3S2x8vLS5x3vGJ0LsgfOfYiTMA0FN4Idy/qM1YRFl26LX/u4g0UzJsdCRPEl5VYCoVMBoRHylkgAkUo9P+WlhZY6TwRpYQS/ejJS4xxWqDKQJZL5Y4CChlUKBSwb9NIWkrJWrpDWIVrVC4j0yzMLeQ2LM9K1KmUmTp3Gf5JnQoTRvSSFlsvvdb7KkSelKo2LJk9BhuXz1QWCTOh7Cp3AgJ1M7CytFSKya2Sn0KhgEIhXHA5mkUoudStUV5Ytk8Idwy1q5eXZZAXP34CGMJZWloZpF5D9NXY6rSysoaNTTyT5U9zp2Gt8rh6ZI3JudVzhyBbhqRInTz+X65OVTuT609YY7BpmZO4uI5vNHON5k68eMbTHmM7N0Rne2yEgYlcdNahWTb9xrGLOAFWeMPJrljhfHggbq3v3HdU3s6n7Gn//Z+86r9++z7tYtP2AyiUP6cMh+Z5enlDmG5RWFiGu3Vsglv3HqvE6YEz2jlw9AzSp0sjlcDiRfLDbdMu1fpgevvB12/fUaRQHqzfulf1RoZfnl6UVVp8v33/KcPavJevPVCmpK20LJ86f1WbyF9x/6ZJJa2v+4PfPOHn91tYsx/8JaceQZbnbz90t6NAnuwgSzHlof5mypBWWolp/+zFa/jw8bPs255DJ5E/TzaKRsWydqCLjvsPn4sLhoIyjjyFQiFZKRS8VSiYgUJhGgzogo8unvVxxiQTP56NPFbNzBTiYjekM9U+hcY3gbhzpVCYxpxSKLidCkXsYgD+ixQBVnjDiU+hUKBsCVucu3QTpYvbytwW5uYYPbgbFixdLx/W8vb2QdtmdWVaaB49rFWxXmf58Neshavh0LuDSvznLy+07DIUG7bux+A+QfG0vrVU8ULoMWgiWtgPlg/HBQQEok61csiXOxvoAbcGbfrBedkGWQ4tc5i/dK3qoTUZqeZ1aFkfnfuMkUsalEsI1JK1BsmCO2lUX+w5eEr2tV6rPiEUdW2ZbAvmQmBAAPoNnwqyjmvK9OnaCtdv3QM9tLZ9z1EM699JJZIjayYMdJwh00jhL16kgEyztrJCkYJ5UKNyKangykj2mAATYAJMgAkwgbhCIFz9ZIU3XLiChEkBPbZzOWysrYIihE9W2qVzxsiH1iaM6K1a6jCwZ3tUr1RaSPz9P0vGdDi5Z5V8+IuUyIpliqmEurVvAvelU7Fs3jhkz5JRFd+lbWO4LXbCetfp8mGz5MmSCMuKGXrbt5T729zmqhRkekBs5oTBqofWNi6fKa25ysJqVS2HzatmYc7kIRjQox3mOg2VSaG1mQSoPSRLD+jt3eSCVo1rUjSGD7BHJWF5lTvC27luvvAhLc2THfvJ8qlNxGNQr3Yyjbw0/0sJaufKhROxcPpIZM2UnqKlo4fs6OG4DctmyD7KSOHR0oanL16jXo2KYo//MwHTJZAvd1ZxEV3IdDsQh1qePFliNG9QNQ71mLvKBGIPAVZ4Y89Yxpme0Ht96ZVoeXJmlm+iiDMd546Gn4AJ5ChWKDdqVCppAi3lJqZKkQzd2zdiEEyACZggAVZ4Y2jQxkxxlu/b7eEwUbW9cOWm1to1LbFahWIgMjxtjo7maFqClXVkzpgWboucpFVaGcdbJsAEmAATYAJMQDeBuJ7CCm8MzYBxw3rK9+26zBil2trZ5o+h2iNWjSm2OWI95VxMgAlElEC6/yVG/x7t/nINalWOaJGcjwkwASYQ5QRY4Y1ypFwgEzBVAtxuJhA+AtMWuOH2kw/ImzMr2jStE8JVVFvPH75SWZoJMAEmEPUEWOGNeqZcIhNgAkyACTABJmDKBLjtsY4AK7yxbki5Q0yACTCB6CdAX3r8/ds/+iviGpgAE2ACUUCAFd4ogMhFxEkC3GkmEGcJHDx2BtUad8HTF2/iLAPuOBNgAqZFgBVe0xovbi0TYAJMgAkwASMjwM1hAsZPgBVeIx2jNt2H4+OnL1pb9/3HTzTv7KA1LbKRew6dRLeB4zFvydrIFhXp/Bu37YeXt7csh/rcrNMgGWaPCRgrgR8/PfHilYexNo/bFQ4CX779wBuPD+HIwaJMgAkYMwFWeI15dAzQtqWrN2PelGHo27V1lNYekcK27j4Mb29fmTV+/HgYPbi7DLPHBIyVwPkrtzDKaZGxNo/bFQ4C+w6fwUyXdeHIwaJMgAkYMwFWeGNgdE6fv4Zh4+eoarp49RYGjJwu97fsPIQOvR1BFt2lq/+TceHx/Px+Y9q8FaAvj3UU5Rw5eUFm7z9iGh48fi7DlLZ0zWYZXrxyE7bsOiTDmt70+Svx8eMX9Bs+FXsPnYLTbFeMn74IvYc6gdr26ctXjJw4T7bVvt8Y3L73WBbx6s07+TENips6dznqtuoj47V5ZLUm6/SICXPRc/AkeLz/KC3KLbsMQZtuw3H89CWZbfeBE/B49xGDx8ySrDw9vWRbZKLwIstNFMH/mQATYAKGIMB1MgEmYAACrPDGAPQSxQrg9t1H8PYJslYeOnYOVSsUx5Nnr7Fs7VbMmuCApXPG4IhQVs9evB6uFu3YdxQvXntg5cKJGDOkB6bMWYZv33+iQN4cuHbzHn7+8oS1lRVu3n4oy71x+wEK5cstw5re4D4dkChRAiya6YiaVcrIZB9fP8xzGoou7Zpg/hJ3FMqfS37lzNGhO8ZOdZYyC1zdUbJYQbjOHYd0/6aGl1fQMgSZqMWjW7727RrDefpIpPlfSgzt2xnuS6dh9qTBoLK8vL1Ru1o5pEmdEtPHDZTx6sVEBTf18jjMBJgAE2ACTIAJxG4CrPDGwPiam5kJhbAQjp26AP+AAJw4ewXlShXF9dv3UKFMMSRPlgTxbGxQq2o5kEKKcLTp2s37aFirEszNzJApw7/Ilzsr7j96CtsCuUT5D2R5pIz+EhbS3/7+ePHqLbJkSqt3DeVLFYGZKJsyXBMK9MFjZ9F90AQ4zXHFx89f8eHjZ2npbVy3Comgcb2qchualyFdGmTJmE4l8uzla4ybtgiOTgvx4+cvvH7zXpWmLRAaN2+hLBvCkaXdEPVynd7w8/ODj48PjIGFr6+vuLPyAh36jIvVbs7iDfj8zQufv3vB3z8Ac5dujHX9XbZuB+jOkjHMK11toPOOscx9XW2MrfF0rJOLyf5p+z3kOP0JsMKrP6tISVYRFt1Dx8/h3MUbKJg3OxImiC/Ls7Qwl1vyLMzNESj+UTg8zsLSQiVuYWGBwEAgX57suHXnoVB676NQvhzInSMLtu85gry5sqpk9QlQeepy04TFlSzA5I5uX4ZUKZODKrS2spRiFqI/CoVChnV5lhZBspR+98ETuG/ei7bN6mKhsPhmy5wBnmFYiCmfpaiHtuTUuVF7DeHMzBQwRL1cp4W8IDMXx44xsKB2pEyRFE3rVY7VrnTxAohvYykdfVo4OvtrqLKLFcwNS3FeM4Z5pasNdN6hOacrneMtou28bGZmLs495tFWvraxA/9FioBZpHJzZr0JFCucT1p+du47iqoVS8p8BfPmwvEzl0EvcKfb+HsOnUTh/Llkmr5eofw5sXPvUWk5fvbijbS25s6RGaQE0pKAoycvSOW3oFB6SbEskC985au3o5htPixasUnot0KjFgmXrt0WPpA3dzZs3H5QhmltbSBp3HIvbO/5yzfIkS2jtDp///4Tt+8/VmUiqzctz1BFBAdC46btJBETceZGonDFRF+NrQ5jYk9tSZ40MWpXLROrXbFCuWFjbSHdPykTxsq+FhCGCUuL6FOYouI4ovkWFeVwGREZZ1J2yUUkb8TygP8iRSAWKLyR6n+MZVYoFChbwhbnLt1E6eK2sl5aWtC2aR0MdJyBLv3HoVxJWxQvUkCm6evVq1ER/0uVAh16jcK4aS5w6N0BiRMllNnphE1hWsNbMF9OvH77XijUOWVaRLxe9i1At3Dadh8hH0zbuuuwLKa3fUucPHsZLbsMxaMnLxEvno2M18crI5jQ+uZuA8djtssa5MmRRZWtVZNamL90rXxoTRUpAlHBTRTD/5kAE2ACTIAJMIE4QoAV3hgcaHoo7NjO5cIqYqWqtVHdKli5YIJ8EIweDFMmuC1yQsoUyZS7IbakxG5YNkPGWVpaYEjfjljjMhkrRDkVyxST8eT16txSPkhG4f+lTI6z+93k0gba1+X2bAh6EI3Shw+wR6WydhSULmniRPLVYG6LnbBz3XxMGtVXxtODai4zRsF96VSMGGgv43R51CfKr0ynpR30wN3iWaMxfngvuayhQN4cMrlK+RKYOWGwfGiN+rxx+UwZT54ubpTGjgkYikDihAlAa9QNVT+44igjkExY6tP+kyrKyuOCmAATMCwBVngNy59rZwJMIBYRsLPNi4nD+X3RsWFIa1QqiYHdW4H/mAATME0Cmq1mhVeTiBHt0/rVHg4T5Ttu1bcUH5lmUn718pRhio9Mucq8ZP2lspTlqm8pXinHWybABJgAE2ACTIAJxAQBVnhjgnIE60iSOCFoqYCmo/gIFimzUX7NMmmf4qVAFHhUFpWp6Sg+CornIphAFBDgIiJKIHmypPJ5gzw5MsPcXBHRYjgfE2ACTCDGCLDCG2OouSImwASYQOwgUKRgHiycPgoDurVAovjWsaNT3AsmEJcJxIG+s8IbBwaZu8gEmAATiA4C0xa44cilZ7h64250FM9lMgEmwASijAArvFGGkgtiArGaAHeOCTABJsAEmIDJEmCF12SHjhvOBJgAE4hZAodPnEMLeweVe/7KI2YbwLUxAaMgwI0wRQKs8JriqHGbmQATYAIGIEBfQ3z05AWUztfXzwCt4CqZABNgAuEnwApv+JlxDiYQJgEWYAJMgAkwASbABIyHACu80TgWR05egNOcZXrXULdVH71lQxOU9c52DU0kQmkbt+2Hl7d3hPLqmykibR8wcjruP3yqbxUsxwSinYCXlw/sqneM9nq4gsgT6NhvAi5evRP5grgEXQQ4ngkY+roUwwAAEABJREFUBQFWeI1iGKK2EYXz50LLxrWitlBR2tbdh+Ht7StC0fc/utoefS3mkpnA3wQCEYjPX7/9ncAxRkfgx49f8Pv92+jaxQ1iAkwgagmwwqsnz5+/PFGvdV8EBgbKHN4+vqjZrCd+ixOlx/uPGOQ4HR16jUKvwZPw+OlLKROW9+rNO/kVNft+YzB17nKVuJ/fb0ybtwJte4xAx96OIKsnJX789AUt7Adj5MR5aBm8vXLjriyjWadBuBds5bx68x7cN++hLHASlt7Js1xlu9r3HKl6fdDzl2/RtOMgtO46DN0HTsCTZ6+lvKqOSfPRdcA4TJy5BP4BAdh94AQ83n3E4DGzQBZVKazFo3bMXLgaXfqPQ+e+Y/DwyXMp9enLV9nuNt2Hg/p7+95jGb//yGn0HzENvYdMxrDxc6Dedl1cfXx9MWaKM6isgaOmgcZGFsYeE2ACTIAJMAEmwAS0EGCFVwsUbVEJE8RHjiwZcOHKLZl8/PRFlLIrBAsLC8xfsg65c2TFyoUTUbNKGb2XMSxwdUfJYgXhOncc0v2bGl5eQcsFduw7ihevPWR5Y4b0wJQ5y6D8JO8bjw/o0q4J1iyego+fv2LvoVNYMG0EhvW3x6IVG2XbND1/f3/MmzoczjNGYc4iN5mcLGki+RW3tUumoHPbhpixcKWMJ4/qsG/TCEtmj0HSJIlw8swV1K5WDmlSp8T0cQMxe9JgEtPpMqZPg6VzxqBPl5aYPj+o3PlL3FFIWJ7dFjnB0aE7xk51VuV//fYdpo4dgCmj+6viKDBfB9fte47iu7DKrHaeBPu2jXHr7kMSl87Pzw+GcMTYEPVynX7yopMuPI2NRYC4UHR1247Y5I6evoqfnn4q5x8QKI+7XQdOmWw/P335JueQscyf8LSDzzuGOd/TGNE5hxyFY8rJg429CBNghTcc6KpUKIHDx8/LHAePnUXVCsVl+Madh2hSv6oMk2L47MVreQKVEaF4ZOVsXLeKlGhcLyg/7Vy7eR8Na1WCuZkZMmX4F/lyZ8X9R0FrVP9Nk0rGWZibI2e2jMiXK6uUy5c7G56/ekvZ/3Il7QpKmQTx4+Hrtx8y3cbGGodEX4aMnYVlblvx/OUbGU9e2n/+h8wZ01IQ/0uZHM9evpZhfb2yJYtIUVJwX4g2kVX8mrA6E7PugyaICwJXqax/+PhZytkWzANqm9xR83RxvSl4N6hdCWaCT56cWUFOmS0wMEBY4WPeQdzCNlTdcb1e42UPPH72Mla5dx8+yzs+/kKZJ/fTyxdWFubw9PYx2X76iLt1geLOXaCBzh2Rqdd4537Mn4Mjw9FU8ip/53gbMQKs8IaDW4Uydjh78ZqwLv7E7XtPUMw2vyq3pbD00o5CoYBCIZxQxmg/VCdOstZWllLEQvxoKBQKGSbPwtKCNtKRFVmIBoXN/8STwmcZLEfh37/9pYymR2nKuIDggjZuPYCXbzwwsEc7OE8fKazLPlD+mZuZK4NCqVQI5V17uSohjUBgcB0UrYCCNtJNE9bhRTMdQe7o9mVIJZRpSrCyDGJAYU2niysp/EpZC8FOGbaysoYhnLm5hUHqNURfja1OCwtLWFpaGR1/c3MzOI3qHatciwaVkSShdQiXL2sqk+4jGREsxTnIykDnjsjUy+cdw5zvaczonEOOwjHlwH+RIsAKbzjw2VhbIV+ebJg6bwUqlbWDuVkQvgJ5smPzzkOypANHzwgLbFpVmozU4eUVVtnTF67L1POXbgrLZNDtwUL5c2Ln3qPSkvLsxRuhXD9G7hyZpVxUeWR5tc2fG2lSpxRK/A389g/7oY14NjaqpRWhtYMebqN0YpE+XRooFApxcZAPi1ZsUvXx0rXbJBKq08U1v+B98epNmffrt++4//CZDLPHBJhAHCPA3WUCTIAJ6EkgSGPTU5jFgCrlS+DIifNiW1yFo0/XVrh+6x7ooTVaXzqsfydVWmiB3vYtsXPfUflA2Z5DJ2EtFGqIv3o1KuJ/qVLI8sZNc4FD7w5InCihSIm6/7QEw2XFBvQcPAlXbtxBksSJwiy8VZNamL90bagPrVEhP395oWWXodiwdT8G9+lAUehl3wK+vr5o230E6PVrW3cdlvGhebq41q9VEV++/kDfYVMwbtpiobSnCK0YTmMCTIAJMAEmwATiOIHYrvBG+fBWLlcCZ/e7oXCB3Kqy0/wvJWZOGIyVCydi4fSRyJopvUyrJKzAw/t3lmFtHj2oNmO8g8wzaWQf7F6/UIpZWlpgSN+OWOMyGSsWTEDFMsVkfMoUyeC22EmGyevfvS1qVS1HQdAt/p3r5suwrHeAvQwPF1valzvCU8rkyJoR/62cJZcz9OnSCsp4zTqa1KsG+7aNRM4gZZ/6GdZDa93aN4H70qlYNm8csmfJKPMmFQr16MHdZfuprkmj+sr46pVKY1CvdjJMHrWV2kxhXVytrawwblhPzJsyTD5At951OnJmj1oLONXPjglElED8eDa4uD/ogc2IlsH5YobAinmjUaxwnpipjGthAkzAYATMDFazEVVMr7m6++CJEbWIm8IEmICpE0iWNLGRdYGbo41AooTxoXxWQFs6xzEBJhA7CMR5hffMhWto0LofxkwJsq7Su2z7j5gapaO7dtNu+a7cHg4TVVuKi9JKYrgweg+uen8ofOHKTWxcPjPKl1/EcNe4OibABJgAE2ACTCCWEQih8MayvunVHXoX7tK5Y5E8WVIpn0vcGv/w8YsMR5XXumlt+c5blxmjVFuKgwn/0ZIC9f5Q2E7trRUm3DVuOhNgAjoINKxTBZeObFS5pTOHI2kiGx3SHM0EmAATMB4CcV7hpVtZtJZWfUjos6Dq+xxmAkwgzhHgDjMBJsAEmEAsIsAKr6UFPn/5phrSKzfuqqy9qkgOMAEmwASYwF8Epi1ww5FLz3BVnDf/SuQIJsAEYgmB2NGNOK/w0iu/xk9fhEdPXqD7wAmYMscVfbu2ih2jy71gAkyACUQhgTkuq6HuPnz6GoWlc1FMgAkwgegjEKcV3t/+/vDz+41ZEwdj7NCeaNqgKtxdp4Ne2RV9yLlkJhD7CHCP4gYBt027oO6+fvsRNzrOvWQCTMDkCcRphZfeXbt09WaYmZmhTInCoHfsmpvFaSQmP6G5A0yACTABJsAEDEiAqzZSAnFeu7O2tsT9h0+NdHgi3qz9R05j5sLVES8gGnIeOXkBTrNdtZZMX1/TmqBHZJvuw/HxU9S+WUOPalkkFhNw37IfZy7eiMU95K5FBYGT565i046wvxoZFXVxGUyACUSOQJxXeF+/fY8OvR3R0n4wug+aoHKRw8q5tREonD8XWjaupS0pbsVxb42ewOUb9/HsxVujbyc30LAEHj19jWu3Hhi2EVw7E2ACehGI8wrvgB5t5SdqB/Zqj85tGqqcXvSMXOitx3v0HTYFzTs7YOO2/arWuizfALKoUrzrms2q+GadBmG2y2r0HuqEo6cuquLVA5oy9IU6ulBo22MEHBxn4NOXoIdYKH+/4VPRsstQtOo6VBZx9eY9uG/eI8Ov3ryTH+Gw7zcGU+cul3Hk/bfjAJas2kRB6agMpQW+28DxorwhaNNtOI6fviTT2WMCTIAJMAHTJcAtZwIxRSDOK7zFCueDNhdTAxCd9bx99xGTHftixYKJ2LzzIL5+D3rApHqlMti5bj5WOU/GrbuPcfnabVUz0qdNgwVTh6NimWKqOM2AUqZcqSIYN80F/bq1xhqXyahasSTmLlorxRcsdceUMf3gvnQq5k4OUnhlQrBHH/woWawgXOeOA70H2cvLOzhF92Zo386ivGmYPWkwKL+X9995AgMDwY4ZRMUc+Pj5K56+eMNOjcFv/wCoO+JMRyyda+IiK5ojgQEBfM7h826MzAE61thFnECcV3jJOqnNRRyp8eTMnzcHEiaIj/jxbJA5Yzq8fOUhG+fj6yMtuQNHTcfrt+/w6OkrGU9ehTJ2tAnVKWXIgvzuw2fMXbxWLgXZvPMQ7j18IvPmz5MdM+avwir3HQgQJ0MZqebdvvcYjetWkTGN61WVW+3en9hnL18LBXsRHJ0W4sfPX3j95v2fxOCQt7cXDOF+//5tkHoN0Vdjq9PPzxe+Yk5HZbt+eXph6eptaNVtFDs1Bp+/eUHd+QkFmA69cdOXxklOq9bvgqe3j8GOfTrv+Ph4G6z+qDzmTK0sOueQi8l207HGLuIE4rzCq76MoWWjmkiWNBFyZssYcaJGlJO+IqdsjrmZGejkSK9hc5y8QL6Rgiyl1SuVhqeaddXK0kKZRef2j4wC/6ROiUUzHaVbMnsMNi6fKfONHdoDzRvVQKD413vIZHj7+Mp4lSeUYGsrS7lrYWEOhUIhw+bm5iEUZH9/fxlPSyfcN+9F22Z1sXD6SGTLnAHq7ZZCwosXLz4M4SwtLQ1SryH6amx1WllZw9raJkr504Xi8P4dcHbvcnZqDP6XPAHUnZWlOWxzpsH5A6vjJKdBPdsgQfx4UTr3Qj2+NM5vluK8Y2NjuPrD09bYJkvnHHIx2S/wX6QIxHmFV305Q/nSReHk2B/PX8beh1W+fvsOOkkWENZfK3GyPHvxOiL692+aVFKJ3n/ktCyClOkbt4Me4CALbI6sGdGhZX1YmJvB4/0nKaP08ubOhtMXguo+f+mmvB1Eaf+m+Z/Kcvvl63c8ePycosWYvEEOcSGSJVNafP/+E7fvP5bx7DEBJsAEmAATYAJMICwCcV7h1QREa9JI0dKMN5H9MJuZKmVy5MmZFfQqr8GjZ8r1s2Fm0iFgJqzGk0b1xZ6Dp9C+50jUa9UHt+4FKaKtug5Dw7b9MXLiPFStUAqZ0v8TopTe9i2xc99R9Bo8CXsOnYS1tRXor0ihPHj52gP0gNqcRW7IkC4oX5kStrh995GMn+2yBnlyZCFxdkyACTABJsAEmAATCJNAnFd4u6u9iozC9OaCAnlzhgnO2AVoqcKgXu1UzSTFtHCB3HLf0aEr3BY5YcYEB4wb1hMdW9WX8bQcIXGihDKsy9OUyZ4lI+Y6DcUq50nYu8kFrRrXlFnpobita+aA6u3UpqGMq1TWDsMH2MswPag2Y7yDXJ4waWQf7F6/UMZbmJtj5cKJWDxrtGyb69yxyJk9s1yLrIwfP7yXzFdAWKkpE/UlZYpkFGTHBKKEQKtG1VHKrkCUlMWFGIpA9NdbrmRhNK1XOfor4hqYABOINIE4r/Cqr+Gl8LhhvaCuKEaaMBfABJiAyRGwLZDzr7sSJtcJbnC0E8iaKS0K5csR7fVwBUyACUSeQJxWeAkfvU5HfR1vbnGr/L8dBygpTrsxU5zle3J7OExUbS9cuRmnmXDnmQATYAJMgAkwAdMkEOcV3j0HT/41ctt2H/0rLq5FjBvWEy4zRoVwdrb54xoG7i8TiCsE9OrnwumjoO4GdGuBBPGC3raiVwEsxASYABMwEIE4q/BevHpLftHr3ftPcktf9yI3Z9EaAw0FV/CPuAMAABAASURBVMsEmAATMG4CxYsUgLrLkyMzLC3MjbvR3DomwASYgCCgv8IrhOPC/6yZ08N5xsi40FXuIxNgAkyACTABJsAE4gSBOKvw0rrdru2bYsrofqCt0tWtXgFhvakgTswM7iQTYAI6CcSmhDv3H+P85RsRcmOnu+LIpWe4euNubELCfWECTCAWEoizCq9yLOmVV7fvPcYq9x0hljYo03nLBJgAE4jNBGa7rEavwRMj5F6//RCb0XDfmAATCJuAyUjEeYV3+dptmDZvObbtOYJPn7+J7VG8fP3OZAaQG8oEmAATYAJMgAkwASYQOoE4r/DuO3wSy+aNQ+pUKeRHEbasngNvH5/QqZlwaptuw/Hx05dQe+C8bD1a2A9GnRa9MX76Ivj4+oYqr0/i42cvcfLsFX1EWSa2EYhF/fn2/Sf2Hz0Xi3oUu7ry7OVbXLhyO3Z1invDBJhAlBCI8wpv/PjxYWFhAV8/P/gHBMDG2gpmCkWUwDXGQuhLZ0kSJwq1aQXz58J61+lY7TIJn798w9ZdR0KV1yfx6fPXOHvxuj6iLMMEjJaAx/tPmDJvldG2L643jJTddVv2x3UM3H8jJsBNMxyBOK/wJohnAz+/38icMR0mzliC+UvWCovmb8ONSBTV/MvTCxNEf7oNHI9qjbvhwNEzsmSn2a749v2HDNO65aYdB6H3UCeMnDgP6/7bI+NL2xWS2+TJkqCQUH7ff/wk97V5+4+cRv8R09B7yGQMGz8Hn758lWW16T4c9v3GgNZHU77la7cKC+9ldB80AYeOa7eQkRV42LjZ6NjbUbb51RsPdOozGo+fvqQipKP8VKY2WSnAHhNgAkyACTABJsAENAjEeYV3UK8O0ro7oEcbpP83NayFhXfkQHsNTKa3e+zURSRLmgiLZ43Gno3OKFoob4hOPHzyHLRuefn88XBy7Iu7D56GSKcdL29v7Np/HHa2+WhXp3v99h2mjh2AKaP7iwsGd6kkuy1ygqNDd4yd6izzdWrdEGVLFsGimY6oUr6EjNP01m3ag7o1K2LFggnYsno2kidLisrliuPg8bNS9OPnr/B49xF5c2WFNlkpZPIed4AJMAEmwASYABOIagJxXuHNkiktLCzM8fK1sCa2aQh6PVmqlMmjmnOMl5cjW0acuXBNvnmC1s6StVa9EbfuPkL50kWQKGEC6SqVs1NPRmBgIEZNmo9KZe1QomjBEGmaO7YF8yBB/Hgy+trNezh47Ky05DrNcQUpqR8+fpZpYXkF8maH++a9WLpmsxyP+ML6Xr1yaRw+fl5mPXDkDKpXKiXD2mQpwdPzFwzhfH19DVKvIfpqbHX6+HjD29srRvh7eXnh3YdPsKveIda4I2eu493nXxFyvr/96bBD10GTjYLH+Bmu+P7DMOcAQxwXdN7x8vKMkblviP55Guh8rk9fvYVBiJw+slElIw829iJMIM4rvKQUNmjdD2OmLJQQ7z18Km7RT5VhU/ayZ8mIJbPHIFeOrNi4bT/Wb9kXojuk0Jqb//lCEin96gKuQunMlT0zenZuoR6tNWxlaRkiftq4gdKSS9bco9uXQd8LiPq1KmHUwC5ImyaVULYXCKvzE6RMnhQphKX3vhiXQ8fPoWqFkrIubbKUYGMTD4ZwtA7cEPVynfFgaWkFKyvrGBl3a2trOSc3uTohtrgShXMhReJ4EXKW5kE/IeOHdjMKHr06NREX3zYxMheM4dij8461ddzprzEwV7bByorOO1YxOtfAf5EiYBap3LEg8wJXdyydO1bePqfukJL34eMXCpq0o6fJEyaIj3IlbdGoTmWQRVe9Q/lyZ8eV63elJZeU30tX/zzZvGHrfnz89BVd2jVRz6JXuJhtPixasUmWSxkuXQsqN56NDb79+ElROt2Pn7+QJnVK1KpaTi6juPvgiZQl67Pbpt2g9GxZMsg4CqdJnfIvWTMzM7BjBtE5B+hCMWP6fxBbXPx41uIul1mEnMJMAducaVCzShmj4JFCXCDT+ETn+HPZfH4x1BwA/0WKQJxXeC0tLJDu39QhIAYiMMS+Ke4cPXUBZWt3QM/Bk3D89GV0bF0/RDdyZM2ICqWLoc9QJziMniGtVgkTxsdvf3/MWbQGO/YdQ8nqbaSjh99CZA5lp5d9C9BttrbdR6Buqz7YuuuwlLYtmAuBAQHoN3yqzofWps1bgSoNu8DBcQZ8/X6jeqXSMi9tybpLWxkhPF2yIon/MwEmwATiIAHuMhNgAqERYIXX0kK+eksJ6cqNuyprrzLOFLcNalXCyd0r4Tx9JCaO7I2smdLLbrgtdkLKFMlkuEn9qlgwbYRI74Ov334iX67ssDA3x9n9biGco0NXKa/NIyV0UK92qqSkiRNh9ODuoHp2rpuPSaP6yjSy8E527Ie5TkN1PrQ2YURvHNq6FDMmOIDqVK4LTpI4oWyPfdtGsizydMlSGjsmEF0EaC7WqFQyuornciNJIHOGf2FXOG8kS+HsTIAJxEYCcV7hdejdQX5c4dGTF+g+cAKmzHFF366tYuNYQ7NTQ8fNQbNOg+SrvyqUKYYsmdJqivA+E2ACagTS/C8Fhvb5c4GnlsRBIyBQrHAetGpc3Qhawk1gAkzA2AjEeYWX1uzOmjgYY4f2RNMGVeHuOh10u9/YBio62rNg6nBsXD4T7kunoUWjGqFWceHKTfRwmBjCjZkS9MqxUDNqSYzKsrQUz1FMgAkwgbAIcDoTYAJxjECcVXhpfalyrOkNBmVKFEblciVgbhZnkShxaN3a2eaHy4xRIdy4YT21yoYVGZVlhVUXpzMBJhA6gWoVS6FN0zoRctXK28HK0jz0CjiVCTABJmAEBFi7E4OwafsB4Wv8510mwASYQBwg0LR+dfTv0S5Crmm9yohvYxkHKHEXmQATMHUCrPCa+ghy+5kAE2AC0UyAi2cCTIAJmDqBOKvw/vrlJb9CtmTVJvl+V9qqO1MfWG4/E2ACTIAJMAEmwASYQBCBKFJ4gwozJT9Htoy4cuOedPQxA2VYuTWlvnBbmQATYAJhEZg4YxGKVmoWpa7LQCccufQMV2/cDat6TmcCTIAJGJRAnFV46bO3oTmDjgpXzgSYgOkS4JYzASbABJiA0RGIswqv0Y1ENDboyMkLcJrtGmoNHu8/SpmaTXughf1grHLfEao8JzKBuEbgy9fv+P3bP6512yj66+Xlg5+/vIyiLdwIJsAE9CdgTJKs8BrTaERTWwrnz4WWjWuFWrqZmRma1K+KvZtc5NfR6M0Vj5++DDUPJzKBuESgeZeRuPfoeVzqstH0df22g3Cau9Jo2sMNYQJMwPQIsMJremMWaosfP3uJYeNmo2NvR1Rr3A2v3njg6s17cN+8R+Z78cpDfjzCvt8YTJu3Asr3Ef8vZXJkz5IR9EefIc6aOT3eeHygXa1uudtWWU791n0xc+FqYX3xRD0RDgwMlPLePr6o2aynsIj9xtFTF9Fv+FS07DIUrboOlenaPG1t79RnNNQV7+6DJuD2vcfQJqutTI4zdgLcPibABJgAE2AC0U+AFd7oZxyjNazbtAd1a1bEigUTsGX1bCRPljRE/Qtc16FM8cJwnTsOGdL9Ay8v7xDptEMK5t0HT5A/b3ba/ct5vPuI0xeuyY9QbF87D22b10HCBPGRI0sGXLhyS8ofP30RpewKwcLCAguWumPKmH5wXzoVcyfrVni1tb1yueI4ePysLPPj56+guvPmygptslKIPSbABJgAE2ACpkiA2xytBFjhjVa8MV94AaGkum/ei6VrNuPlaw/Ej2cTohF37z9Bg9qVZJxyK3eCva/ff2D4hDkY5dANSRMnCo4NuUmRPCl8hAV34TJ3bNy2H4kTJZQCVSqUwOHj52X44LGzqFqhuAznz5MdM+avkuuCA4ItwDJBw9PW9uqVS6vKPHDkDKpXKiVzaZOlBB8fH9G2mHe/f/82SL2G6q8x1evn5wdfX99o5+/l7YPZi9Zh8Ni5JumOnbmGrz+8o9T99g+gww7OyzdFK5Nte47C20DHtjHNdc228Hkn5s/1yjHw9fUT5x2/aD/vKOujrTzY2IswAVZ4I4zOODPWr1UJowZ2Qdo0qTBq0gKQpVa9paRvWlsFfRnJwsIcCoVClewfEIDx01wwoEc7lCtpq4rXDFhaWmCl80SUKlYIj568xBinBVKkQhk7nL14Dd9//MTte09QzDa/jB87tAeaN6qBQPGv95DJ4ofLV8ZretranlIo1ymElfr+w6c4dPycUKJLymzaZCmB1iIbwikUCsRAvVyHmdlfDBSKmGFvbmaGLBnTIk/OLCbpUiRPAktxzEelUyiCzh+ZMvwbrUzS/C8lzBR/j31cP+YUipiZ+3Gds/b+E3tyMTcvwX+RIsAKb6TwGV/mHz9/IU3qlKhVtRzsbPP9pfDmyZVFKKU3ZMMvXL4J5ZpbP7/fQnF1lvlKFiso03V5nrQMQmjOhQvkRreOTXDr3mMpamNthXx5smHqvBWoVNYO5mZB04valCNrRnRoWR8W5mbweP9Jymt6JKet7ZXK2cFt0275gRB6ZzLl0yVraWkJQzhzc3OD1GuIvhpbnbRshlx0t8tKXCjWr1keHVvWNUmXP1dmJIhnGaXO3EwB+qtVpXS0MilRND+If3SPsamVH7fPO4Y51yvnCJ1zyCn3Y2JLxxq7iBMI0kginp9zGhkBehCtSsMucHCcAV+hxFavVDpEC3vbt8LO/cfQa/AkXL5+B8mTJZbpl6/fxuET5+A4eQFKVm8j3Z6DJ2Sapufx/iMq1uuMtj1GYNbC1XDo3UElUqV8CRw5cR5VyhdXxbXqOgwN2/bHyInzhIW2FDKl/0eVph7Q1XbqA1l3aauU1yWrTOctE2ACMUBA6Lu2OdOALn7Bf0yACTABIybACq8RD05EmjZhRG8c2roUMyY4wNGhKxLEjyetrcMH2Mvi6LbmtLEDsXD6SBTIk0P1ZoYSRQvi7H63EI6sxDKThpclYzqc3LMKa1wmy1eYVSxTTCVRuVwJWYb6D+DOdfOxdc0cKdupTUOVrGZAW9tJJknihLJM+7aNaFc6XbIyMdjjDROISgJ0cUjLAaKyTC5LPwLx49vIB2P1k2YpJsAEmMDfBFjh/ZtJrI558OgZKtTthDbdh2Pr7sPo3aVlrO4vd44JRBWB9UsmIWe2oFf3RVWZXI5+BJrXr4Lh/drrJ8xS2ghwHBOI8wRY4Y1jU4Asr8d2LofbIifMmTwU/6ROFSqBMVOc5ft2ezhMVG0vXLkZap6wEim/enkUpnrCysfpTIAJMAEmwASYABOICAFWeCNCLTbm0dGnccN6yvftuswYpdra2Qa9fUFHljCjKb96eRSmesLMyAJMgAlEmMD/UqUAPfQZlS7tP6mgfHAtwg3jjEyACTCBGCDACm8MQOYqmAATYAKGJtC1fVOsd50RpW6sgz0SJbA2dNeivH4ukAkwgdhHgBXe2Dem3CMmwASYABNgAkwy0MMDAAAQAElEQVSACTABNQKs8KrB0D/IkkyACTABJsAEmAATYAKmQoAVXlMZKW4nE2ACTCCCBK7euItegydGuZu9eD1+ePpEsFWcjQkwASYQcwRY4Y051lwTE2ACTMAgBD59+Ybzl29Eubtz/yku3nkLUqgN0jGulAkwASagJ4GYUHj1bAqLMQEmwASYABNgAkyACTCBqCfACm/UM41zJc5cuBr7j5wOtd9fvn6XnzuuWL8z6LPAoQrrmejl7Y2N2/brKc1icYGA09xVOHj8ghF3lZtmLAT8fv9G9eZ9jaU53A4mwASimQArvNEMOC4U36ReVRQtnDfMrtaqVg5d2jYOU05fAW9vX/m1OH3lWS72E3jj8QHff/yM/R3lHkaaQEBAIB48eh7pcrgAJsAEIkgghrOxwhvDwE29uuVuW+UX1+q37guy7FJ//ttxEJeu3qYgTl+4htZdh6HrgHGYOnc5HEbPkPHJkiZGpbJ2iBcv7Hd2fvz0Bc07O2DEhLnoOXgSPN5/lBbktj1GoE334Zjtshr+AQFwddsCj3cf0X3QBLgs3yDrYY8JMAEmwASYABNgApoEWOHVJML7Ogl4COWSFFr6Mtr2tfPQtnmdELK/xS3CiTOWYOSgLlg8azQ+ffkaIj08Oy9eecC+XWM4Tx8JHx8/rHTfgbmTh2K18yT4+P7Gzn3HYN+mEdKkTolFMx3Ro1NzWby//28YwgUE+BukXkP0NQbr1IupOnu6TX31xj3s3H+CnRqDC1duw8v7d5Q7spLSgXf6wnWT47374ClQ+41tPoenPepzPzz5WDYqfifonE8uKsrSrww61thFnAArvBFnF+dypkieVCifvli4zF2unU2cKGEIBq/ffsD/UiZDnpxZoVAoUL9WpRDp4dnJkC4NsmRMJ7Ncv3UPvzy9MGLiPGnxvX7rPu7ceyLTND1Sug3hAoTF2RD1cp30Q0E/Ov4gFn6+frgkFN5te0+A3R8GZy8LhVdcKHpFsfMPDJSH4Mlz10yO9879J0XbA+W8obljio7PO78NNn7+/v7igtw/Buv/LeYr/48MAVZ4I0MvjuW1tLTASueJKFWsEB49eYkxTgtCEKCfPnNzc1WchVpYFalnwNLC8o+kUJ7LlrSVllyy5rovnYoRA+3/pKuFrK1tYG0AZyHaa4h6uU4bWFpawcrKGtZi3OPHj4cubRpg2ZxR7NQY9OvSDMkT20S5szQP+gkZ1re9yfFeNGM4zMzMYC3mjak6Pu8Y5nxP88XKis47VrCOwfmj9lP3f/bOA0Cm44/j372mi5YQJXqvIUTvLUREkH/UCKd3Tnc45xzn9N57CRERJdGDINEFQUTviXDaOVf/7zfn1t65XevKtvsev9l5M7+Z+c1n5r397ey8t4zGgUDk1SoOBVkk6REIfB4EaCs6H5YojM7fNMOZ85eiQcj+/rv470EAHj2OvGno6Mkz0fLjevBRqSL45dcjuHTlhqpCnvhw6eoNpEyZHE+eBKo0BiRAAiRAAiRAAiRgjAAdXmNkmP4aAbl5rMZnHSA3j02auQwePdpF03FxccHA3u0xctxM9B4yHo8ePUPqVKmUTqj29U+Feq3VI8k2bNkFiV+4eEXlvSnImuU99O/+NXwmzVdtt+02DAEBj5FM+4TdsG4V1RZvWotBkYckYAkCOqB0wSyQD8HgHwmQAAnYMAE6vDY8OLZmmuyp3b91KZbPHguf4b1Qo3JZZWL/7m1Rr2YlFS9VrCCmjB2kyUBtBTYZihfJp9Jle8OhbStgKAXz51Z5MYNMGdNjxVzfaMnyhIdF00ertjetmo4ypSIfgyY3q031HaS/aS1aIR4kOQJD+rRDnWofJ7l+s8NvT8DN1QXb1k5/+4IsYXcEaDAJCAE6vEKBkmAE1nz/Mz5p3hUtOw1GYOALNKpfPcHqZkUk8CYCWTNnQto0kd8qvEmX+UmbgE6nQ4G8HyRtCOw9CSQhAnR4k9BgW6KrHVo3wU/rZiPqxjI3V1ejzcpe364eY9RzfQ1fJd1ooUTJYKUkQAIkQAIkQAKOTIAOryOPro337Z20qSHP9I0pkm7jptM8ErArArWrlcf29fMTXCaO6oV0aZLbFQsa+wYCzCYBByVAh9dBB5bdIgESIAFDAhnSv4OEFm4fMSTMOAmQgC0ToMNry6Njm7bRKhIgARIgARIgARKwKwJ0eO1quGgsCZAACbwicOvOP5i7ZK3V5Mdt+xH0Iin/AtSrsWCMBEjAtgnQ4bXt8aF1JEACJGCUwK079zB/2XdWk03bf0VQMB1eowPEDBIgAZshQIc3kYeC1ZMACZCAwxKIAI5fuIsTf5xz2C6yYyRAAo5BgA6vDY1jo5Y9E8Sa3fsPw3fyggSpy7CStT9sw/OgIMOkBI/Hxfa+wybA3F9tS3CDWaHdEVi8ejOuXL9td3Y7gMEmu7BgxUbcvP2PSR1mkgAJkEBcCdDhjSs5Gy73YfFCaNG0QYJbuGHLLgQFBSd4vYYVJpbthm0wnrQJbNnxK+7cu5+0Idhg7zf+vBf37j+wQctoEgmQgCMQsC2H1w6Jykrq6Alz0GOQL2YsWIXPWvVCRIT2PZ/Wl6AXwfjky24IDY19j9vN2/fUjy649x6J8VMXaSUi/4eEhMJv2mK06ToU3/TwhKx6Ss79/x7iK/cBGDZmGlq8fD2ufZUoP9rwZfv+OH/xiqjhxOnzWL1+q4qLfWMnLUD3AT74utswRH31eO3GHTT/pj9adRqMLv28cfnqLaW/bfcBeHj6o9fgcRC7vt2wTaVv2b4PdzUnYcDISZAVVZUYSyB2TJy5DB37eKFDr5G4ePma0vrvYYCyu3WXIares+cvqXRpr89QP/QYOBaDR0+Boe13/7mP/p4T0K77cGX/pSs3VJkXwcEYOW4WpK5+w/3w9FmgSmdAAiRAAiRAAiRAArERoMMbG5W3THsRHIJpvoPQw70lCuT5AIePn1E17D1wBBXLlYKLi4s6jhnMWLAaFcqWxIKpXsieNTOeP4/cLvDjz3tw/dZdLJk5BiMHdsW4KQsR9etjt+/+i45tm2H53HG4/yAAP+38FTP8hmJwH3fMWbw2ZhPqOCwsDNPGD8Es/+GYMmeFSkufLo360YeV88ahQ5sm8J+5RKVLIKtfYz17Kbt27fsNAY+foGHdqsiSORMmePXDZJ8BomZUcubIgvlTRqJnxxaYMD2y3unzVqOUtvK8Yo4vPD26YNT4WfrycuPN+FF9MW5EH32aRKbPW4XCBfJCOHxSuzJ8NQ6SvnHrHjx+8gzLZvnAvU1TnDl3UZIpJGAWAfk8+iwwSM0hmUe2KubY9ezZc4SHR1hNIl4Sfxb4PN48w8PCX9bGFxIgARJIeAJ0eBOAabWKZeDkFImydvXy2LX3d1Xrjl8OoU71j1U8tkBWOZs2qq2ymn5WR71KcPL0BTRpUBPOTk7I9UFWFCucFxf+jly9zZrlXZXm4uyMgvlyolihvEqvWOF8uHbzjhR/TSqUK6l0UqVMgYBHT1R+8uTJsFOzc+CoSVi4YgOu3Xi1p7FksYJInSql0suY4R3cuHlXxc0NqlQoo1TFwb2u2SQr3ie1VWfh0aW/t+a4LlDO+r8vv74sXbIIxDZVyCD448+LaNY4kos43Fev31Kr5ae19M8b1lTMixTMC5GoYoGBz2ANCQkJtkq71uirrbUZHPwCQUHPzeb/+MkTdB0wDuXqtbN76eQxDv88DLSahISEqVOvU/+x8WZ5RfvW6W3G0dbmoTXskevO8+eBZs99a9joqG0GBQVp150gi7JXJ1vSDBKk15FeWoJUlXQrMVzBrV65HA4dOamtdjzF2fOXUbZ0ceNgtKWmZG6uKt/FxRk6nU7FJXBxfbUqLPVrqpIMF+dX6eJku77Uk3hoaOSbj1I0CCQv6jD8ZUVrN2zHjdt30a9rW8yaMExbXX6BqD9nzZmOijvpnJSTGXVszqs4uFF6OuiiovDTVofnTPSEyJ6NC/Fupgwqz801koE6iBG4vlwd1+l00Ok00T4EiIo4/PIq4qKxk1eRlClTwRri6upmlXat0Vdba9PNLRmSJ09hNv930qbBspmjcP7gOruXlbO9kCVjKquJm6uznHZYOds73izz5sr2VuNoa/PQGvbIdSdFipRmz31r2OiobSZPnlybr8ktyl6dbAziTIAOb5zRxV4weTI3FCuSD+OnLUbNKuXUymrsmkBRbVX2wOFTKvv3o6f1e39LFS+ITT/tQVh4OK5ev605zpe0r/ZzK72ECmTltXTxwsiSOZPmoP+B0LDY9xkbtpdCO8GjtlYYpseMy81tkrZ9z0HkyJ5FOaplSxfDnMXr9H08evKsqJiUEkXyY/2mnUpH6sr1QTbFs7iWfuTEaZUe8OgxLly8quIMkjABdp0ESIAESIAETBCgw2sCTlyzalcrj937fkftah+brKKHewts+nmPuiFr6879SKY5y9D+PqtfA++9mxFys5aX32x49GiHtGlSazkJ91+2Csxe/C26DfDB8T/+hKx6van2ls0aYPr8lSZvWpM6nj57jhYdB0FueBvQs50kobv7VwgODkabLkMhj1/bsHmXSjcV9OzUEqfOnFccZN/u4D7tlXrjBjXwMOCJurHOy2+u5rRnVOkMSIAESIAESCCpE2D/YydAhzd2LmanDunrrlZyDQvUqloeh7atwIclChsmvxaXG9X8R3tg5oRh8BnWE1vWzFQ6rq4uGNjrGyyfPRaLZ3ijRuWyKj1TxvRYMddXxSXo06UNGtSpKlG4ODtj06rpKl5TW1kWu+RAXuVY4iJROgXy5sR3Syap7Qw9O7bUl61XsxL6d28rqkp8hvfS90Mc+YneA95401rnr5th9fzxWDjNC/nz5FT1pEubBiMGdFH2iw1Sr2TEbE9sFZslL8t7mSDtLZk5RjHKmyuHJCOZmxu8BnfDtHGDlS1rFkxAwfwJuwKuGmLgkAS+adEIuT7I6pB9s3indEDpgln01wjE48+99efIkTVzPGpgURIgARIwTsDJeBZzSIAEHJNA0u5VwzqVkDVzpqQNwQZ737h+VbyXKb0NWkaTSIAEHIEAHV4LjOLKdVsgz8o1FEmzQNOJ1oQ8B9ewPxI/fPw01i6amODbLxKtE6yYBEiABEggaRNg75MMATq8FhjqVs0bqmfezvYfrn+VNNjxn2wpMOyPxMuZeiKFHfeVppOArRIolD835kwaaTXp37UlUqd0s1U8tIsESIAE9ATo8OpRMEICsRJgIgnYLAG5mfWjUkVhLSmULydcnPk2YrMThIaRAAnoCfBKpUfBCAmQAAmQAAmQgHECzCEB+yVAh9d+x46WkwAJJGECT58FQp5nbU05//c1hPIngZPwLGTXScB+CNDhtZ+xsgtLaSQJkIBlCPz191V06edlVZk4exWeBgZbpsNshQRIgATiQYAObzzgsSgJkAAJkAAJGCHAZBIgARsiQIfXhgbDUqY8fvIUX7bv6HvpNwAAEABJREFU/8bmZi1cg6/cB+DTr3pg9IQ5eBFsfCVn/6HjuHT1xhvrjFKQX1uLisd8lXqkvpjpxo77DpuACxevGMtmOgnoCRw6elqbxyH6Y0biSSACOH7hLk78cS5eFf116Tpu3/03XnWwMAmQAAmYIkCH1xSdxM6zUv0pU6ZQv3r2puZLFi8E+RWzZbN98ODhI2zYvNtokUNHTuHKtVtG898mQ+qR+t6mDHVJwBwCPYdMwH/aXDZHlzqWI7Bo1Y/Yue+I5RpkSyRAAkmOAB1eBx/yZ4HP4e0/D537jUbdpp2xfc9BBGppsmIb1fWlq39E82/6o8cgXwwbMw2rvtuqsiqVK6VeM6R/B6U05/ef+/+p45jBxcvXsP/QMSxcvh5d+nvj2o078J28QK0KS53zl32Hm7fvqR/fcO89EuOnLopZRbTjRSs3qPqkrp17f8O23QfQZ6gfegwci8Gjp2grdMGQH75o3WUI+g33g9y8E60CHpAACdgdARpMAiRAAolJgA5vYtK1gbp/+fUI0qdLg7mTRmDr2lnqeZ2GZomz+sPW3Vg0fTR8PXvh3F+vbw14HhSEzdv2olzpYoZF9fH8eXKiSoUy6NCmKeZM9ETOHO+rvBfBIZjmOwgd2zbDjAWrUaFsSSyY6oXsWTPj+fMgpRNb0L5VE1Wf1FW7WnmlcuvOPYwf1RfjRvTBxq178PjJMyyb5QN3rc0z5y4qHQYkQAIkQAIkQAIkEBsBp9gSbTONVsWFQIF8OXHw8EnMW7pOWzU9DlmtNaznzLm/Ua1SGaRJnUpJzarlDLMRERGB4T7TUbNKOZT/qGS0vDcdVKtYBk5OkVPs7PlLaNqotirS9LM66vVtgtIliyBVyhSqyOk/L+LzhjVV3UUK5oWIytCC588DNWfa8hISEmyVdq3VX1tqNzj4BYKCnpvFPyjoBdr2GImGLfvYvfQfORX3AwKtKiGhYdpZBwz0mhYvnrv2HQHPobe/bgkzc+e+LZ2zjmDLixdBELFkX9TJxiDOBCK9kTgXZ0FbJyCrr/Mmj0ShAnmx9odtWPP9z9FMFofW2dlZn+bi8iouiQuWr4f8fGm3Dl/J4VuJi4vLK33NcU7m5qqOpQ2dTqfi5gZurpFlo/RdjNjs5pYM1hBnZxertGuNvtpam8Le1dXNTP6u6NelJUYO6GjfotnfvtVnSJMqmVXF2TnyLeSbFo3ixbNk0fxw5jlk5hx+dY0TZubP/Vfl3Kx0nXSkdl1cXCFiyT5Fvf/xNW4EIq9WcSvLUnZA4NHjp0idKiWqViiNLz6tBVnRNTS7WOH8OH7qnFrJFef36Imz+uxvN2zD/f8C1JYEfaKRSIoUyfBYa8tINooWzocDh0+p7N+PnlbtqYNYghTJk+PRk6ex5EQmFS+SH0dOnFYHAY8e48LFqyougbPmCFtDnLSVbGu0yzad8TYMZJxKFSuIch8WtXspWiA3krk6W1WcXn5wLazZEh+mmTKmU9/YvM1YUteZzKx0vbfW3AP/YiVgbqKTuYrUs08Ce349jCoN26HbAB/sPXAM37RqHK0jBfLmRPVKZdFzkC88RvgjU4Z0SJ06JULDwjBlznL8+PMvqFCvtRK5+S1aYYODBrWr4NDRU6oduWnNIEtFe7i3wKaf96C7ZsfWnfuRLJkbjP2VLlkIEeHh6D1kPOSmtZh6jRvUwMOAJ+g1eBy8/OYiS+aMMVV4TAIkQAIkQAIkQAJ6AnR49SgcM/J5g5rYv2UJZk0YhjHDeiBvrhxImyY11i6aqO9ws8Z1MMNvqJbfEwGPnqJYofxw0T45H9q2Aobi6dFJXyZmJG/uHJjg1V+1IzetDenrrvb9RunJjWr+oz0wU7PDZ1hPbFkzMyrrtVdZ4R3r2RtTfQdBblqrV7MS+ndvq9dL5uYGr8HdMG3cYEz2GaAenVYwf259PiMkEJ3Aq6MKH5VAcm3+vEphzBYIFMyXE9nef9cWTKENJEACDkrAyUH7xW69BYFBXlPUD1G07zkC1SuXRZ5c2d6iNFVJwH4ITPf1QIb0ae3HYFu3VAeULpgFH5YojPj8yR7gWlXKxqcKliUBEjCHQBLWocObhAc/quszxg9RK76r5/vhqy/qRyXH+rpy3Rb1PN2uHmP0r5IWq/IbEg8fP62vI6o+eb7uG4oxmwRIgARIgARIgATeigAd3rfCReVWzRtitv/waCJpiMNfudLFo9Uj9cpWhThUxSIJR4A12QkBeZRgmZJFYE0pmPcDODtpy7x2woxmkgAJJF0CdHiT7tiz5yRAAnZMIH/enJg7eZRVxaNbK/VYNDvGSNNJwAQBZjkSATq8jjSa7AsJkAAJkAAJkAAJkMBrBOjwvoaECSRgPgFqkgAJkAAJkAAJ2D4BOry2P0a0kARIwMEIePnNwkc1v7R76djfFwFPghxsdNidOBJgMRKwaQJ0eG16eGgcCZAACZAACZAACZBAfAnQ4Y0vQZY3nwA1SYAESIAESIAESMAKBOjwWgF6fJt8/OQp/tfBI77VxFpefva3c7/RmDZvZaz5lkxc+8M2PA+K/LpU+vxl+/6WbJ5tWZHA8T8u4NNW/axoAZs2i0AEcPzCXZz445xSfxEcgtxlov98ucpg8BoBJpAACViWAB1ey/K2+dbmL1uPaeMGo1enVla3dcOWXQgKClZ2pEyZAiMGdFFxBiRAAiRAAiRAAiTwNgTo8L4NrQTUvf/fQ7VKO9R7KroN8MG4qQshK5pRTcxbug7Lvt0UdWj0NSQkFH7TFqNN16H4pocndu8/rHT7DPXDX5euqbjkzV++XsXnLlmH7zfvVPGYwYTpS3D//kP0HjIeP+38Fb6TF2D0hDnoMcgX85d9h/8eBmDYmGlo3WUI3HuPxNnzl1QVN2/fU7+YJmnjpy5Co5Y9VXpsQcx+3/3nPmRFuUXHgWjdeQj2Hjiqim3Zvg93793HgJGT0HfYBAQGPle2qEwt+H7TTrTT+iu2iG1aEv+TAAmQAAmQAAmQQKwE6PDGisUyiddv3oV726aYNWEYPm9QE7v2/a5veMcvv6Fu9Qr6Y2ORH3/eg+u37mLJzDEYObArxk1ZiEePn6JE0QI4efo8nj4LRDI3N5w+e1FV8cfZv1CqWGEVjxkM6NkOadKkwpyJnvikdmWVLV9RTvMdhI5tm2H6vNUoVbwQVszxhadHF4waP0vpzFiwGhXKlsSCqV7InjUznj+P3IagMmMJDPud5b1MGNSrA+RnjSf7DIDU9TwoCA3rVkWWzJkwwasfJN2wmstXb2Hhyg2Y5O2B+VNGKif/0JFTSiUkJBjWkLCwUKu0a42+WqLN0NAQPHj4CBNmLH+jTJm7BpNmr3yjnjl1WUrn6Km/8ORZsN1LWFi4Ou9Wr9+m+E/WxiE8PCLhzwUrndeWmOvxaYPXHetc72XM5BolInFLiTrZGMSZAB3eOKOLf8EPsmdBnpzZVUWF8udWb/D3HwTgwsUrSPdOWuXwqUwTwcnTF9BEc5adnZyQ64OsKFY4Ly78fQWlSxTCKc25FQdXnNFn2gppaFgYrt+8gzy5spmoMXpWtYpl4KTVLaknNQd6xy+H0KW/N3ynLIDY+u/9B2qlt2mj2qKCpp/VUa+mAsN+i97VG7fg5TcHnr4z8eTpM9y6/Y8kG5VTZ8+jeuWyyJD+HaRInhwN6lSF9NNoAWbYJYEIZbWEb5YIUYEEdiKRBqseOkYQyV1CqHFwjF6xFyRAAo5DwMlBumKX3XB1cY1md+1q5bF990Fs15xKiUfLNHHg4uqiz3VxcYG8lxYrkh9n/ryoOb0XUKpYARQukAcbt+5G0UJ59brmRKQ+Qz0/bcVVVoBF9mxciHczZdDe3yK0VeTIvri4OEOn0xkWeS1u2O9zf13G6vU/oc2XjTBTW+nOl/sDBL5hhVgqdNXakVcRF2dn7S028q3W1dUN1hBnZxertGuNvlqiTRft3MiofaAZ0KMt3iR9OrdA/26t3qj3pnosmf9RqYJIk8rN7sXZOfItpEXT+op/v66t1AdkS8wRtuEGZ153rHbdlWuUiCXnIfgXLwKRV6t4VcHCCUWgfq3KkBXUXXt/R61qH5tVbaniBbHppz0ICw/H1eu31Wpr4QK5IU6gbAnYs/8wxPktqTm94liWKFbIrHpjUypbuhjmLF6nOdSRzuXRk2eVWtHC+bB24w4Vl721EeJxq6M3B9du3EaBfDnVqvPjx09x9sIlfSFZvZXtGfqEl5GSRQth78FjakVctj/IkyU+LB73fr2sli8k4CAE2A0SIAESIIGYBOjwxiRixeOcOd5H0ItgtQ82U4Z0ZlnyWf0aeO/djGjXfTi8/GbDo0c7pE2TWpUtUTS/isse3pLFCuLWnX/woeYgq8w4BN3dv0JwcDDadBmqbkzbsHmXqqWHewvsP3QMLToOwt+XbyBFiuQq3ZygcvnSOHvub3Xj2uTZy1FEW4mOKteyWQNMn79S3bQWlSavsiWjTfNP0c/THx37eKFqhdL4uEwJyaKQAAmQAAmQAAmQQCQBg5AOrwEMS0YzZUyPFXN9X2ty9fzxmOE39LV0wwRxaL9d6K+SXF1dMLDXN1g+eywWz/BGjcplVboE3Tu0UDeSSfy9TBlwaNsKtbVBjo3J1m8jb0ST/CF93VGzSjmJKkmXNo16NJjYvWnVdPgM76XS5Ua12f7DIbYP7eeu0owFMfudOlVKyA13cyeNwOgh3dW2BrnhTsrXrlYeE70HqJvWpM9rF02UZCVfNKqNJVp/5QY6uaFOJTJwGAKlSxTE5pWTHKY/SaUjydxcceXYxqTSXfaTBEjAjgjQ4bWjwaKpJEACCU6AFcaHgA4oXTALPixRGPwjARIgAVsmQIfXhkdH9q929RijnnFr+Crp8TFbyhvWFxWX9PjUG1VWVn+lrqh6DV8lPUqPryRAAiRAAiRAArZCwLHtoMNrw+P7TtrUkK0CMUXS42O2lI9ZpxxLenzqNSwrdUmdMUXSDfUYJ4GkSGDkwG44unut3cv8iUOQLo35e/aT4lizzyRAArZBgA6vbYwDrSABuyBAI0mABEiABEjAHgnQ4bXHUaPNJEACJEACJEAC1iTAtu2MAB1eOxswmksCJGDfBOYuWYvOfUc5hPjPWoknz17Y94DQehIggSRBgA5vkhhmdtIqBNgoCcRC4PLVmzh26k+HkAuXriMsPPKHaGLpKpNIgARIwGYI0OG1maGgISRAAiRAAiTgmATYKxKwNgE6vNYeATtuv3XnIbj/30OTPfhh6260cB+ACvVa42HAY5O6zCSB2Ah81WlYbMlMswECL0LCcPHGAxuwhCaQAAmQgGkCdHhN82GuCQLyS2zvpE1jQgPI/G5GjB7aA/ILayYVwVwSiJ3A/t9Oxp7BVKsTcHFywpPAYJz445zVbaEBJEACJGCKAB1eU3SYpwg8C3wOb/956NxvNOo27Yztew6qdN/JC/Do8RMVX7r6RzT/pj96DPLFsNTzMm0AABAASURBVDHTsOq7rSq9QtmSyJ8np4q/Kbh09QYGe03GNz08VTs3b99F+54jcOnKDX3RLv29cfb8JcSmq1dihARIgATsmQBtJwESSHACdHgTHKnjVfjLr0eQPl0azJ00AlvXzsJHpYpG6+TFy9cgWxcWTR8NX89eOPfXlWj55h6sWrcVjT6pgcUzvPH9ssnIkD4dalX9GDv2HlJV3H8QgLv37qNoobyITVeUwsPDYA2JiAi3SrvW6Kul25Rx/f3YaRiToyf/xOHjZ4zmGytnrfR/7j9EcEiYQ0hEROQNa5aeE2wv8joXwetOkrruyrWQEncCdHjjzs6aJS3adoF8OXHw8EnMW7oO+w8d1xzRd6K1f+bc36hWqQzSpE6lpGbVctHyzT0oUTQ/Vq//CfOXr8eNW3eRMkVy1KtVCbv2/q6q2L77IOrVrKjiselKRnBwMKwhYWGaA2Oltq3RX0u2KePqM3kxjMn46csxbtpSo/nGylkr/cSZv/H42QuHkPCXDm9oaKhVzjtLzkNbbEuuOyEhIWRvhWuvzHkRS84LuRZS4k6ADm/c2SWZkrIlYd7kkShUIC/W/rANa77/OVrfI7Q3PWdnZ32ai8uruD7RjEjjBjUxvF9HZMvyLob7zNBWii8jU4Z0yKit9F64eAU79/6GOtUrqJpi05WM5MlTwBri4uJqlXat0VdLtynj+uOKSTAm6xb64vslE4zmGytnrfR61csiU7qUDiHOTpFvIW5uyaw4/61zzlv6PIitPbnuJEuWnOytcN2XOS8S27gkVhr4Fy8CkVereFXBwo5O4NHjp0idKiWqViiNLz6tBVnRNexzscL5cfzUOYjjK3L0xFnDbLPjT54+Q5bMmdCgTlWUK11MObxSWFaMV6zbAsnPl+cDSVLx2HRVJgMSIAESIAESIAESMCCQJBxeg/4yGgcCe349jCoN26HbAB/sPXAM37RqHK2WAnlzonqlsug5yBceI/zVqmzq1CmVzuxF36pHksnjyxr8r5vKVxmxBH7TFqN2k47w8PRHcEgo6tWspLTkVVZ35VUlaIExXS2L/0mABEiABEiABEggGgE6vNFw8CA2Ap83qIn9W5Zg1oRhGDOsB/LmyqHUVsz1RdTjxpo1roMZfkO1/J4IePQUxQrlVzpd2/8Ph7at0Iv/aA+VHlvgPbQHdm6YD39vD3h6dEKqlCmU2jtpU6vy7m2+UMcSGNOVPIpjEVgzz8exOmTd3iRo6y93NCRonayMBEiABBKDAB3exKCaBOsc5DUFX7bvrx4jVr1yWeTJlS0JUmCXE4NAlfKlEqNa1pkABHTQJUAtrIIESIAEEp/A6w5v4rfJFhyQwIzxQ7B20USsnu+Hr76ob7KHh4+fRlePMdFk5LhZJsswkwRIwAYJaP5u6YJZ8GGJwuAfCZAACdgyATq8tjw6DmpbudLFMdt/eDTxGtzNQXvLbtkzgcSwvVO75pgzaaRDSP+uLZE6pVtiYGKdJEACJJCgBOjwJihOVkYCJEACpgnIHnj58RZHkEL5csLFmW8jpkecuSTgEATsvhO8Utn9ELIDJEACJEACJEACJEACpgjQ4TVFh3kkQALmE6CmUQKBz4Nw9ORZh5Pzf19DaFi40X4zgwRIgARshQAdXlsZCdpBAiTgsARu3r6LLv28HE4mzl6Fp4HBDjtu7BgJxJUAy9keATq8tjcmtIgESIAESIAESIAESCABCdDhTUCYtl7V4ydP1bNyTdl595/78J28AJ8074qv3Adg6eofTaknSt6lqzew/9Bxs+vuO2wCLly8Yra+bSjSCnMIzFu+AREREeaoUscCBEJCwvEiONQCLbEJEiABEkhYAnR4E5anTdeWMmUKjBjQxaSNTk5OkF9N+2ndbPgM74V1G7fj0pUbJsskdOaVa7dw6MiphK6W9dkhgTGTFiGMe0RtZuRCQsMQ+CLMZuyhIQ5CgN0gAQsQoMNrAcjWaEJWSQd7TcY3PTxRt2lnyB7CwMDnGD1hjjIn6EUw5MceWncZgv6eE9Cxj5daJX0vUwbkz5MT8iePT8qbOwdu3/1XDmOVPb8eQe8h49Gi4yC07DRI6bTvOSKak9ylvzfOnr+E2HRVgRjBopUbtBXeY5ByO/f+hm27D6DPUD/0GDgWg0dP0VaYXtneb7gfnj4LjFEDD0mABCxCQFt8P37hLk78cc4izbEREiABEogrATq8cSVn4+VWrduKRp/UwOIZ3vh+2WRkSJ8umsUbNu/Cs8BALJ89Fp3aNsOZcxej5cuBrOye++syihfNL4exyoz5qzFuZG+snj8eU8dGOry1qn6MHXsPKf37DwJw9959FC2UF7HpKqUYQftWTVClQhnMmeiJ2tXKSy5u3bmH8aP6YtyIPti4dQ8eP3mGZbN84N6maay2q0IMSIAESIAESIAESEAjQIdXg+CI/0toTurq9T9h/vL1uHHrLlKmSB6tm39euIRG9WtAp9OhYP7cKFIwb7T8gMdPMMR7CoZ7dEa6tGmi5RkeFC+SH/7Tl6q9vuEv91rWq1UJu/b+rtS27z6IejUrqnhsuirDjKB0ySJIlTKF0jz950V83rAmZPuF2C2iMrTg2bOnsIYEB7+wSrvW6Ksl2wwPj0Chis2R/+OmRqV4tVYoXOl/RvNNlbVU3idf9cWd+8/sXh49DYaMiXaqRfv//Plzzn+LXXteXePkuhMY+IzsrcBe5ryIJa+H0U46Hrw1Aae3LsECdkGgcYOaGN6vI7JleRfDfWZAVmoNDRff1MXZWZ/k4vIqHhYejtF+s9G3a1tUrVBarxNbZNSgrvjfF/URof3rMXAsZKtEpgzpkFFbUZYbyXbu/Q11qldQRWPTVRlmBG6urtG0jNmeMmUqWENcXd2s0q41+mrJNp2cdDi6YylO7F5uVA5tnY8j2xcbzTdV1lJ53y0ai8wZUtq9pE3lqn1IjnYqqoPkyZNz/lvh2iPXnRQpUpK9FdjLnBex5PVQnWwM4kyADm+c0dluQbHsydNnyJI5ExrUqYpypYu95vDKFoNjp86KKh4/eYoLF6+qeEhIKEb6zlLlKpQtqdJMBdJOgbw50a5FY7g4O+HuP/8p9ZpVy2HFui2Q/Hx5PlBpEo9NV2UaBCm0N89Hmk0GSdGislJ85MRplRbw6LHedknQ6XTaGzJFp3MMBjKmqVOlhL1LKu3bCXHe7V10ush5JeNiKDpdZLpOx1edjgx0OjLQ6RKegeE5x/jbE6DD+/bM7KKE37TFqN2kIzw8/RGsObH1alaKZneTT2vhwcPH6oazCdOXIHfObEilORbiBO/a9xs8x85AhXqtlWzdsS9aWcODlp0Go0mbPhg2Zpq2klsRuXK8r7KlPVndlVeVoAXGdLWsaP9LlyyECG2VWW6GkzqiZWoHjRvUwMOAJ+g1eBy8/OZqjn1GLZX/SYAESOA1AkwgARIgAUWADq/C4HiB99Ae2LlhPvy9PeDp0QmywpQ2TWqsXTRRddbN1QWD+3TAVN9B6Nr+SwQFBeH9LO+i/EclcWjbimgiq8SqUCzBplXTsWH5FPUIs/atm+g13kmbWtXh3uYLfZoxXb3Cy4is8I717K1sk5vWxGnu373ty1wgmZsbvAZ3w7RxgzHZZwDWLJgA2YesV2DEYQh0btsEsirqMB2y8464uDghuRvfNux8GGk+CSRJArxyJclhh3q26SfNu6CVtkI71Hsa+nX/Gs5OnA5JdDrYbLeH9W2vObycl7YyQG6uzkiRzNVWzKEdJEACJGA2Ab6TmI3KsRRdXV2w58dFWDlvHJbMHIOyHxYz2cGV67agq8eYaCJpJgu9IfPw8dPR6pP65dnAbyjGbBIggUQiwGpJgARIwFEJ0OF11JFN4H61at4Qs/2HRxNJQzz+ypUuHq0+qV+2KsSjShYlAZskkDFDOnRs28zhpFG9yqhYPDs+LFHYJrnTKBIgARKIIvCWDm9UMb6SAAmQAAmYS0Ae09e53ZdwNPmsXhUkT+ZiLgbqkQAJkIDVCNDhtRp6NkwCJGDXBGg8CZAACZCA3RCgw2s3Q0VDSYAESIAESIAESMD2CNiDRXR47WGUaCMJkIBVCfzy62F8VPNLSgwGHfv7IuBJkFXHho2TAAmQgDkE6PCaQ4k6JEAC8STA4iRAAiRAAiRgPQJ0eK3HPkFb/rJ9f/UTwQla6VtUVq9ZF/WrbPLrbDUad3iLkvFX7TtsAi5cvBL/imywhsDnQbhy/bYNWkaTSMCyBB4GPMbte/ct2yhbI4HEIMA6rUKADq9VsDteo87OTuqX1eRX2vZsXOh4HbRSj86ev4y+wydZqXU2SwK2Q2DzjgOYOneN7RhES0iABOyKAB1euxou08YuWb0R7r1Hokt/b/x7/4FS3r3/MBp+1R0tOg7ECN+ZePosUKVv230AfYb6ocfAsRg8eopKixnE1Jk+fxXW/rBNrzZv6Tos+3aT/tjciKxGT5y5DB37eKFDr5G4ePmaKuo7eQFGT5iDHoN8MX/Zd/jvYQCGjZmG1l2GqH6dPX9J6b0IDob8QIWk9xvup++TynSMgL0gARIgARIgARJIQAJ0eBMQprWryp0zGxZM9ULd6hWwYt1mZU6BvDnx/bLJWDVvPD7IngWrv/9JpUtw6849jB/VF+NG9JHDWMVQp071Cti173e93o5fflNtSUJ4eDhqfNYeX7kPwOZteyXJpOTMkQXzp4xEz44tMGH6Er3ui+AQTPMdpB7QP33eapQqXggr5vjC06MLRo2fpfQ2bt2Dx0+eYdksH7i3aYoz5y6qdAYkQAIWJhABHL9wFyf+OGfhhtlc0iHAnpJAwhCgw5swHG2ilorlSik7ShYriKvX76i4m5srlq35Ua3m/vrbCVy6fF2lS1C6ZBGkSplCokbFUKdQ/tx48PAR7j8IUHtm072TFlkyZ1Jll88eix0b5muOanPMWvQtTp29oNKNBVUqlFFZ4tBev3kHERHaO6eWUq1iGTg5OWkx4OTp89jxyyG1Yu07ZYFqV1auT/95EZ83rKn0ihTMCxFVQAuCgoJgDQkJCU2UdoO11eybt/9Bu55eFCMMOvX3RYc+YxKVj/+sVXjw6DklBoOQ0HDtrAPGTlmcqPxl/i9Zsxmyp90a57ettinXnRcvXiTKtcdW+2wrdsm1WcSS9qiTjUGcCUR6FnEuzoK2RMDVJfIXj3Q6J4SFhSnTxk9diPczvwvvod3Ru3MrPA8KVukSuLm6yotJialTu1p5bN99ENs1R1TiUYXfzZQBLs7OqFW1HGQlWPaeRuXF9hrl4EqeDjp5UeLysg/qQAv8vPphzkRPJbI3WNrRklVb8iri4uIsL0qkvDXEyUmHxGjXWWP6TtrUaP5ZLYoRBl80rI6mn9ZIVD5VK5RCyuSulBgMnLV5D+2vRqUyicpf5v9HJQslyjmWGOetpeqU645cIyzVHttx0c9BJydniFiSiXaq8X88CDjFoyyL2gGBG7fuonK4RUkhAAAQAElEQVSF0kibJjV+/f1EvC2uX6uyWnXdtfd31Kr2sarvWeBzhIVHrvQEPH6CYyf/RNFCeVSesWDDll0qa/ueg8iRPQt0uldOr8rQgrKli2HO4nX61d+jJ89qqUDxIvlx5MRpFQ949Fhbbb6q4hJY8uJj2Jaz5pgaHidUXOpNkzolGtapTDHCoH7NCmhQu1Ki8in3YRH1E7ryM7oUFz0Lcbig/VUoWyJR+cv8L1Y4H9xcXzkcCXWO2XM9cn2IYb/eIWN6Ys8VZ421SGK386p+7VTj/3gQoMMbD3j2ULRdi8bo0HOk2tIQGhoab5Nz5ngfQS+CkT1rZmTKkE7Vd1Nzqqs2bKceS9bdwwctmn6CkkULqjxjwdNnz9Gi4yB8u2EbBvRsF6tad/evIF8ZtekyFI1a9sSGzZFOcuMGNfAw4Al6DR4HL7+5yJI5Y6zlmUgCJEACJEACJEACQoAOr1BwAFm7aKJaxZWu5MmVDTP8hkoUDepUxfqlkzBl7ED07doWU30HqfR6NSuhf/e2Km4sMKazev54ff1StmD+3Djw0zL1WLKV88ahYd2qkmxSOn/dDFLPwmleyJ8np9Id0tcdNauUU3EJ0qVNgxEDumDFXF9sWjUdPsN7STKSubnBa3A3TBs3GJN9BmDNggkQG1SmgwUpUyaH3IzoYN1id0jgrQlkSJcWWbNkeutyLEACJEACQsBJAgoJkIBtEihaMA8me/e1TeNoFQlYkEDDOpXQu9NXCdoiKyMBEkg6BOjwJp2xNtrTw8dPo6vHmGgiz7k1WsDMDKkjZr3SluFqtJlVUY0ESIAESIAESIAE4kyADq9JdEkjs1zp4pjtPzyayJaB+PZe6ohZr7QV33pZngQsTUAewVemZBFQojNIkTyZpYeC7ZEACZBAnAjQ4Y0TNhYiARJISgTkedFzJ49CkpZY+j9tbD/U/CgXPixROClNB/aVBEjADgnQ4bXDQaPJJEACJEACJEACJEAC5hNISIfX/FapSQIkQAIkQAIkQAIkQAIWIkCH10Kg2QwJkIDtE+gzZBw69x2VAJI06vCftRJPnr2w/YGlhSRAAkmeAB3eJD8FCIAESCCKwMkz53Hs1J8UMxlcuHQdYeERUfj4SgIkQAKvE7CRFDq8NjIQNIMESIAESIAESIAESCBxCNDhTRyuNlnr2h+24XlQ0Fvb1rrLENz/7+Fbl0uKBVp1HYE//vw7KXY9Pn1mWRKIF4Hb9+6j3pc941UHC5MACTg2ATq8jj2+0Xq3YcsuBAUFR0vjQcISePzkKUJCQxO2UtZGAiRgkkB4WDgePnpqUoeZJGAfBGhlYhGgw5vAZGUl9H8dPDDUeyq6DfDBuKkLISurUc3MW7oOy77dFHUY7fVZ4HN4+89D536jUbdpZ2zfc1Dlf9m+PybOXIaOfbzQoddIXLx8TaX/9zAAw8ZMg6zAuvceibPnL6n0iIgIzFq4Bq07D8HnrXtjxoLV2LJ9H+5qqyADRk5C32ETlJ7UO3n2MvQY5Is9vx7B7EXfolHLnhD7Fyxfr3TMCc79dRld+nujTdeh8PD0h9gl5aT+afNWoks/b/QeMh7/3n8gyQgPD1c2tew0CG27DsPWHftU+rbdB9BnqB96DByLwaOnIOhFMOTX2qR//T0nqP5fuHgFc5asxarvtqoyEojdq9f/JFEKCZAACZAACZAACbxGgA7va0jin3D95l24t22KWROG4fMGNbFr3+/6Snf88hvqVq+gPzaM/KI5nenTpcHcSSOwde0sfFSqqD47Z44smD9lJHp2bIEJ05eo9OnzVkMeiL9iji88Pbpg1PhZKn3z9r04evJPzJ86EhuWT0GjetXRsG5VZMmcCRO8+mGyzwClJ0GObFkwY/wQ1KhcFvVqVsamVdOxdNZYnDl3CcdOnhUVkxKmOa9efrPRu3MrLJ89FnVqVMDUOSv1ZXLnzIY5kzzxZZN6WLFus0rfrDnf/95/iCUzx2CW/zCs3bgDV6/fVnm37tzD+FF9MW5EH2zYvAvPAgNVvZ3aNtNsuqh0Pq1bDRt/2q3i4txv33MIn9arqo5DQkJgDQkLC1PtvggOxo8/78OCFRsTTVh3dLZL1mzBolWbEoT3w8fP8TQwhGImg7CwCBy/cFf7oD4/QfjHdW6v2bBdfbNijXPfmm1GXXesaUNSbTtU+yZPxJL9V29yDOJMgA5vnNEZL/hB9izIkzO7UiiUPzcePHyE+w8CIKuT8hOl4niqzBhBgXw5cfDwScgq8P5Dx5Eh/Tt6jSoVyqi4OLjXb96BOHonT5/Hjl8OQVZXfacsUG38q62iHj3xJ1o2a4AUyZNDp9MhZ473VdnYguqVy+mTXwS/gKz49hs+AeJ4/n3lpj7PWOTO3X9w798HmDpXW8nVVnnXb9qJ8xcv69Urf1xaxbO8l1Fzau+o+DHNGf/r0jX0GjwOHiMmKj5RZUqXLIJUKVMovT8vXEKj+jVUHwpqHIsUzKvSs2fNjEwZ0kNWlg8ePoXCBXIjTepUKi8iIlxjY3kBIlS7snp9U3PaL129AYplGFy+dktjfVOT+LcXEhoG+RBHCTeLQ4T2bZKceHK9sOZ8v6ZdE8M15zvCSue/tdqNuu5Yq30baFddd5OKHXKuUeJOgA5v3NkZLenq4hotr3a18ti++yC2a86pxKNlGhzkz5MT8yaPRKECeSHbINZ8/7M+N+LlG4sk6KCTFyV+2ortnImeENmzcSHezZRBpbs4u6jXNwVurpF6ISGh8Bw7A7WqllcrwPVqVkLgc3NucNPhfW3lWNoXEfvXLpqob9bZOXKK6eAEWY2A9qfT6eDe+gtls5T5ceU01K9VWcsB3FxfsZMuuzg7q3QJXFxexRvVrwZZKd68/Rc0rFdNspW4uSWDNcRZ4y3tyoeMbt80h+/wHhQLMRg9qBN8hnZNEN7vZUiNd1Ino5jJwOXl+d3566YJwj+u582gnl8jWTJXq5z7ct5bS6KuO9ZqPym36+rqBhE3C77ngH/xIhDpjcSrChZ+EwFx5mQldtfe31Gr2sdG1R89forUqVKiaoXS+OLTWtpX+K/u9pcbzqTg9j0HkUNbQdbpdChbuhjmLF6nfcKNkCwcfbkFoUypIliz4Sf9ExmeBT5X+eKMSRvqIEYQ8OixdvK6okTRAsrpPHTkVAyN2A+zZnkX8rXOtt0HlII4zn+c/UvFjQUflymutjc8efpMqcjKkLSvDgyCooXy4tipsypFbga7cPGqiktQo0o5/HbkD23V/Boqli0pSbELU0mABEiABEiABJI8ATq8FpgCsqVAbsCK/Co+ndEW9/x6GFUatlM3u+09cAzftGqs13367DladByEbzdsw4Ce7VR6d/evEBwcjDZdhqqbzWTPq2R8WrcqihXOp25wk5vWZi38VpLVNofp81fqb1pTiS8DWRmWLQOtuwzBgBETIba+zDL54uTkBJ/hvbB1x6/4utswfNayJ868vHnOWMFPaldGxY9LoWv/MfjKfYBaWQ6P5eH1TTSn/8HDx+qGN9m3nDtnNqTSPhBIvcnc3FCmZBFtZbgidLpXK96SRyEBEiABEnidAFNIICkToMObwKOfKWN6rJjr+1qtq+ePxwy/oa+lGybIDW77tyxRN7uNGdYDeXPl0Gd3/roZpI6F07wgWx8kI13aNBgxoItqT242E8dT0sUJ7eHeAqvmjccPK6bqHeTa1cpjovcAtWVB9GTrQdo0qSWqxNOjE+QGOH9vD3gN7oZvWkY63JIm/VJKsQRiz1TfQVg6ywc/rZuNlk0/UVqG9efJlS1a/zu2aQrhtGbBBGWn7FeWbRT9u7dVZSVwc3XB4D4dIHV3bf8lgoKC8L62oix5ssXjyvVb+Kx+DTm0GVk52xsli+S3GXtoCAkkBQJZs2TC9nXTk0JX2UcSIIE4EqDDG0dwjlnMtnoVFhaOT5p3QatOgzHUexr6df8azk5OuHLtFuQRaEUK5lZPnrAlq9OmSQUXg73GtmQbbSEBRyUgH/LTpX314d1R+8l+kQAJxJ0AHd64s4tzSdlH29VjDGKKpMdWqeFKaWz5lkqTZ+LGtPnw8dOJ1ryrqwv2/LgIK+eNU48wK/thMdWWbG2QVee+XduqYwYkQAIkkOAEWCEJkIBDEaDDa4XhfEdbiZjtPxwxRdKtYI7ZTco2h5g2lytd3OzyVCQBWyfwy6YlOLp7LcVMBvnzvNp2ZetjS/tIgASSNgE6vHEff5YkARIggSRNYGCP1qj5US58WKJwkubAzpMACdg+ATq8tj9GtJAESIAEbJwAzSMBEiAB2yZAh9e2x4fWkYBVCUT89x+Cli2zaQldtQrBK1bYtI22zjCu9qXfsQNpg4OtOkfZOAmQAAmYQ8BiDq85xlCHBEjAtgiEi8O7fDmCbFhCV69G8MqVNm2jLfOLj23pNIf3HTq8tnXS0hoSIIFYCdDhjRULE0mABEgg0QiwYhIgARIgAQsToMNrYeC20lzrzkNw/7+HJs3Zsn0fOvbxQu0mHdHfc4J6/q3JAmZkXrp6A/sPHTepaY6OYQV9h03AhYtXDJMSNP7TroPYuvNAgtbJymyfwNjHzngUbvt20kISIAESsF8ClrOcDq/lWNtUS0P6uuOdtGlM2pT5vYyY4TcEm1ZPR/68OTFn8bcm9c3JlB+NOHTklElVc3RMVpDAmef+ugqRBK6W1dk4gV0vdAiMsHEjaR4JkAAJkIBZBOjwmoXJvpUWrdigfuSicatemDhzmeqM7+QFePT4iYovXf0jmn/THz0G+WLYmGlY9d1Wlf5RqaJI5uaGFMmTo1K5D3HvvvEV4W27D6DPUD/0GDgWg0dPQXh4OGYsWI2WnQahbddh2Lpjn6pz0coN2grvMXTp742de39TaTGDmDox634RHAz5EYzWXYag33A/PH0WGLMKHjsQAXaFBEiABEiABOJLwCm+FbC8bRO4e+8+Dhw+qX7kYuPKaWjzv0+jGXzx8jX8sHU3Fk0fDV/PXtpKZuxbA1av34qPS0f+0lm0CgwObt25h/Gj+mLciD7YvH0f/tUc5CUzx2CW/zCs3bgDV6/fRvtWTVClQhnMmeiJ2tXKG5R+FY1Nx7DujVv34PGTZ1g2ywfubZrizLmL+sIRERFIDAl49ARXNPuNydUbd0zmGytn8+l3/sX1UCRJCePqrv68elMkMc451pk41zJytV+uAN50KjLfBAE6vCbgOEJWxgzp8OJFMGYuXI21P2xD2jSpo3XrzLm/Ua1SGaRJnUpJzarlouXLwcp1WxDw+Cnat24ih0aldMkiSJUyhco/dvJP/HXpGnoNHgePERPx4OEjnL94WeXFJTCs+/SfF/F5w5pwcnJCkYJ5lUTVGRT0HAktoaGhWL95N1p2Hm5EPNG+t4+RPGNl7CO9jfccdHrokiTlWYQualrx1QiBPmFpsPT8ffx+9GSCn3dBiXAuO1qdcm168SKI7K0wV4KDX0DEknPKUGFlUgAAEABJREFUyGnIZDMJ0OE1E5S9qrm6umDJrDGoWLYU/r58AyN9Z0Trinzad3Z21qe5uLyKS+Lh46dx7NRZTBk7UG1vkDRj4ubqqs/S6XRwb/2FWsmV1dwftdXl+rUq6/PfNmJYt5R1MWJzihQpkdDiqvWrQ6vGOPTTIiOyELu/n2Ekz1iZREo3amPc2vt1lid+fjc0SUpaJy7xyrlmjiRLljzBz7uEPo8dsT65NiVPnoLsE+G6/6b5InNe5E16CZlvzrlIHeME6PAaZ+MQOYHPg6B9x69++rPzN81w5vylaP0qVjg/jp86p6lEfs1z9MRZff6psxeweNVGjPXsg5gOp17JSOTjMsWxYt1mPHn6TGlcunoDAY8eQ/YDP3ryVKUZC96kU7xIfhw5cVoVlzovXLyq4gxIgARIgARIIIoAX0nAkAAdXkMaDhi/+8991PisA9p0HYpJM5fBo0e7aL0skDcnqlcqi56DfOExwh+ZMqRD6tQplc6M+Wtw8vR5rXx7VKjXGs3a9VPp5gSf1K6Mih+XQtf+Y/CV+wB4jp2B8PAIlC5ZCBHh4eg9ZLzRm9bepNO4QQ08DHiitkt4+c1FlswZzTGJOiRAAiRAAiRAAkmUAB1eBx/4PDmzY//WpVg+eyx8hvdCjcplVY9XzPVFpozpVbxZ4zqY4TcUY4b11FZhn6JYofwqff6UkTi0bYVevlsySaXHFtSrWQn9u7eNltWxTVNIO2sWTMCqeeORIf07aoV3rGdvTPUdZPSmNVnhNdSJWbc8OcJrcDdMGzcYk30GQOovmD93tLbNOzBP65PaFSFinja1HIXAkDRhSKcD/0iABEiABByAgJMD9IFdiCeBQV5T8GX7/mjfcwSqaw5xnlzZ4lmjYxUvnD8XihRIPIfasWg5Tm9qJ49ACl4hHWdA2RPTBJhLAg5OgJdzBx9gc7o3Y/wQrF00Eavn++GrL+qbLCI3sXX1GKOe6xv1Ks/ENVnISGZC1mWkCSaTAAmQAAmQAAmQAOjwchKYS0DplStdXD3Td7b/cP2rbC9QmW8ZJGRdb9k01c0k4Jw9O1L7+9u0uI0dixTjx9u0jbbOMK72BWfJYuZMohoJkAAJWJcAHV7r8mfrJGDbBFKmhEvJkjYtTsWLw7lECZu20dYZxtW+iBSRz9227UmcGNaxThIgAXsjQIfX3kaM9pokEBISDMtLCOR5mJZv1xp9tb02nZ2dEBERboVxtz0Wlp6Dy+b4qptaixXOS/5WuPbIdScsLJTsrcA+6o3IkudcVJt8jRsBOrxx4/bGUlQgARIgARIgARIgARKwDQJ0eG1jHGgFCZAACTgqAfaLBEiABKxOgA6v1YeABtgTgdCwMPhMmo923YejU18v3Lx9N1bzT525gHY9PNUPfixYvl6vI79eJ+UqfdLW6A9vgH/RCKz9YRtadxmCtl2HYd+h49Hyog7u//cQPQaOVY/WG+o9Fc+DglSWqfGq16yL+kEV+VGVGo07KH0G5hMwNsfNr4GahgSMzWFDHYkbOx+Mlf92wzb9PJe5vuzbTVINxQQBc+a2sWvLw4DH8PD0h1xT/KYtNtEKsyxNwDYcXkv3mu2RQBwJbPr5Fzx4GIAlM8eg2Wd1MG7KotdqioiIwAjfmRjYsx0Wz/DG7v2HceKPc0ovebJk6Px1M1Sv9JE6ZmCawLUbd7BszSbMnTQCfqP6wmfiPAS9CH6t0NS5K1H+o5JYNH000qZNg5XrtiodU+Mle3+jflhlz8aFSp+BeQRMzXHzaqBWTALG5rChnqnzwVT5Dq2/UHutZb63/V8jwyoZj0HA3Llt6trSoG5VyA8vxaiah1YmQIfXygPA5u2LwIHfTqBBnSrK6JpVP8bZC5fwLPC5Oo4KLvx9FSlTpkCRgnnh4uyMujUqYv9vkSuTBfPlQplSReHkxFMvipep1181btW0DwepNJ5ZMmdCofy5ceT4GcT8O/D7STSsGzkuDbXx+fX3E0rFnPFSijYU2IMppua4PdhvizYam8OGtpo6H8wpb1gX47ETMHduG7u2pE+XFjWrlEOKFMlib4CpViPAd12roWfD9kjgX+2r82zvZ1amizOb5b1M+OffB+o4KrinHWfL8m7UIXJky4x7//ynP2bEfAL//vcAWQ1YZs+aGf/cj85SPnDodIC80UjNwvvf+5Fj8q+J8QoPD0eNz9rjK/cB2LxtrxSlmEmAc9xMUGaqmZrDhlX8a+R8eFP5Vd9thXzFPnDUJO38iTw3DOtl/BUBc+f2vyauLa9qYyyeBBK0OB3eBMXJyuydQO8h49XeXNlnayjHX25JkP7pdJp3JRFNnAzi2qH+v87plQ74+y56LjEjMxeujpX3mu9/1qvqDFbDdTqdPt0wYrhirtNFv6zpdK/KOBnEl88eix0b5qNj2+aYtehbyP5qwzoZN01A5/SKKxCduemSzI2NgKk5bKivM3I+GCtfp3p5bF8/BzLf06ROjTH+8wyrYzwWAubObZ1Opy/tZBDXJzJiUwR4lbKp4aAx1ibgM7wnJnp7vCalSxRWpr2bMT0ePHyk4hI8CHiM997NIFG9ZNaOHwY80R8/eBiAzO9l1B8z8opA+1ZNXmMt/Jt8WlMpvZsxAwICDHhrLN/LZMBS05LtDmFh4QgOCdGOgP80nXczRY6JqfESHVmlr1W1HOpUr4Cz5y+r8gzeTIBz/M2M3kbD1Bw2rMfY+WCqfIb078DFxQXy7Ujfrq1x7i/Oc0OmMePmzm1T15aYdfLYNgjQ4bWNcaAVNkIgdaqUSJM61WsSZV7Fj0th597f1eHvx04jT85skDcb+UrxzLmLKl326cod0zdu3UWY9rX5Lk2/cvnSKo9BdAIpkid/jbXwT+bmphSFm+x/fhEcrD5o/HnhMj7+qLjKkxsBQ0JCVbxiOW1cfjmk4tv3HERlbZzkwNR4ydiITsDjJzh28k8ULZRHDilmEOAcNwPSW6oYm8OG1xZT54Ox8k+fBeot2b3vdxQuwHmuBxJLxNTc/vvydfWBWooZu7ZInrWE7ZomQIfXNB/mkkA0Ap99UgNOTjr1WLKFK77HoN4dVP5Nzbn19p+r4jqdDl6Du8Fz7AylV+bDIohaIf7t6Cn1iKCde39T+bWbdFRlGMROIGeO99GkYS106DUSfYb6oW+3tnBzdVXKA0dNxiPNWZWDPl1aYdO2feqxZNdv3EGr5g0lGabGq2rDdmosunv4oEXTT1CyaEFVhsGbCeh0xuf4m0tTIzYCxuaw4bXF1PlgrPwY7bokjyOr9bk75EO6p0cn8M84AZ3O+Nyeu3Qdjp44qwobu7aEhoWp64o8kmzDll0qfuHiFVWGgXUJOFm3ebZOAvZFQL4CH9avo3os2bzJI/FB9iyqAwXz58a3C/1VXIKSxQoqHdk3Z/h4Gnl0ljwaKEp2bpgv6hYS+2zmy8/rYcUcXyyb7YNqFcvoO7Hj+3nIlDG9OpbX2f7D1WPJxnr2hqwcS4ap8Trw0zL1qKaV88ahYd2qok55CwLG5vhbVEFVAwLG5nDMa4ux88FY+XEj+6p5vuuHBfAZ3guylcegWUZjIWBsbk/w6o96NSupEsauLZIedX2PepUxVIUYWJUAHV6r4mfjJEACJEACJEACFifABpMcATq8SW7I2WESIAESIAESIAESSFoE6PAmrfFmb80nQE0SIAESIAESIAEHIUCH10EGkt0gARIgARIggcQhwFpJwP4J0OG1/zFkD0iABEiABEiABEiABEwQoMNrAg6zzCdATRIgARIgARIgARKwVQJ0eG11ZGgXCZAACZCAPRKgzSRAAjZIgA6vDQ4KTSIBEiABEiABEiABEkg4AnR4E46l+TVRkwRIgARIgARIgARIwGIE6PBaDDUbIgESIAESiEmAxyRAAiRgCQJ0eC1BmW2QAAmQAAmQAAmQAAlYjYAdOLxWY8OGSYAESIAESIAESIAEHIAAHV4HGER2gQRIIIkQYDdJgARIgATiRIAOb5ywsRAJkAAJkAAJkAAJkIC1CLxtu3R435YY9UmABEiABEiABEiABOyKAB1euxouGksCJGA+AWqSAAmQAAmQQCQBOryRHBiSAAmQAAmQAAmQgGMSYK9Ah5eTgARIgARIgARIgARIwKEJ0OF16OFl50jAbAJUJAESIAESIAGHJUCH12GHlh0jARIgARIgARJ4ewIs4YgE6PA64qiyTyRAAiRAAiRAAiRAAnoCdHj1KBghAfMJUJMESIAESIAESMB+CNDhtZ+xoqUkQAIkQAIkYGsEaA8J2AUBOrx2MUw0kgQSl8Bgr8moUK81bt6+q29I4pImefpERswicOfev9i4dXc03aqftsOL4OBoaQl1sHjVRsxYsDrW6r7fvBPuvUeidZchqNu0M8ZMnBerniMk/n35Ouo376LvSnBICOYtXaf63rnfaPQYOFYdh4aG6nUMIwuWr8d3P243THqr+B9n/0KHXiNVGYm37zlCxWMGR06cUbbETI95fOzkWfx+7HS05ISeR3Kee4zwR1ePMTiqtRetMYMD6U9U3wySVdSc/vz48y+Yvfhbpc+ABKxBgA6vNagntTbZX9snoNMhf56c2LJ9v95WiefL8wGg5YF/b0Xg7r372GzAUgpPHjMAri4uErWY3L77D6bMWYE+XVpjxRxfbF07CzUql7NY+9ZuyHvCXBz/4zzmTPTE3EkjMMNvKArkzY3nQS9eM+3ps0Bs+nkvGn9S87W8uCTkyZUdA3q2i0tRfZkTpy/g+Kk/9ccSSeh5tHXHfhQpmA+z/Yfjo1JFpYlEkQZ1qmDHnt/w6PHTRKmflZLAmwjQ4X0TIeaTQBIhUL92Zfy86wAiIiKUSLxujYrRer/2h21o03WokqHeU/HfwwCVf/yPc/i8dW+07TpMyaEjp1S6BF36e8N/xlJ0H+Cj8tZt3C7Jscr6TTvwdbfIOuo164IHDx9BVo/a9fCErDT3GOQLWYXae+CoWrWU9N5DxuPKtVuqPllZHe4zA7KaJ+VnL4pcUZI6+ntOgKy41W7SEXsPHlP6MQNpv6fWRuvOQyDl7//3UKkcPn5a1Sm2Sd1/Xrik0iWQMpIufZcyYvPMhWtw+eoNSN/HTlogaug7fAJCXq4sGrNf7JQ+CVtpp++wCfjn/gNVXuoV9i07DcL/OnhgxdotKt1U8K9mf4Z072gOTV6l5uLsjEofl1JxCWQFf/q8lejU1wst3Adgxy+HJFmJsT6bskNWU4d4T1Grl+69R+G3Y39A+iNjJ0y/0cbx6o07kLGQ9kaNn43QsDDVXkLNIVWZFlzT2vnl1yPwHtIdqVOl1FIi/1ev/BHSpE4VeWAQ7tr7Gz76sBhcXV3USnydLzrh8ZNXztmUOcsxf9l3qoTMsUYteuArjZnPpPmaAx2k0g2Dy1dvYsL0JfokWYFv/k1/dNPOg1+0+RuVYYynzOktO/Zh2+6Dah5FnTfxnUdR7crrj9qqq3ww26q1I3FGiJ0AAA4WSURBVHP1WeBzGJubom8oxvpj7ByUuVf+oxJafw4YVsM4CViMAB1ei6FmQyRg2wTSpE6B/Hk/UA6mOF4F8+XUHIUU0LxfZfiBwye1N6uDmD5+CJbPHotSxQvBb+oilZc9a2YsmTUGy2b7YNSgbhg7eQHkzVNlakF4eDimaeUk/3vNqY1y4rQs/X+pf4n21bzP8F6qnoXTRiF16khH5eKla+jyzf8wQ6sjV46sGOU3G/26tcWSGd7KjtET5qh6vt3wM4oVzqdW837SVjObflZHpc+Yv1or/yUWTR+NzWtmomTR/CrdMJAVvgXLN2CK7yCsmOuLNQv8kCZNKuXUj5k4HwN6tMPSWT6q3SGjpypHzZjN3Tt8hTy5cqiVxaH93A2bgTjRxuwXxWs3bqNTuy9VHz6pXQmLVv4gyUiRIhnGamxWzRuPBVO9sHv/79rq5TmVZywoVji/xiM/WnQciMGjp2DDll148vRZNPWcGs95k0di2rghmDRzmeqvfJAx1uc32XH1+m2MH9VXs3EUnJ2cIP3p7t4Cy+eMRd7cOTBwpD+G9uuIFVo/Hj95gt37flf2JMQcUhW9DK5ev4XsWd/Du5kyvEwx/SIrwVHzIpmbG6pW/Ei/Si/zd9vuQ2jcIHL1t+1XjbBp9QxtnoyDOHIr1pn+8LFr32/Yd/AoFmvzdcrYgZCtF1HWGOOZO2c2NKxTFfVqVlTzqHnjulFF1Gtc55Eq/DL4rH511KxSFl98Wlu18fx5EEzNzZfFYKo/xs5BKVtCO+9OnDY9Z0WPQgKJQYAOb2JQjVedLEwC1iPQsG41/LTzALbu+BWfaG+2hpb8duQPBDx6oq20TlErTtv3HMQff/6tVJInc1NfBw8cNQl+0xdB3jhv3nq1H7hqxdLK+RHl997NpK3I3pRoNJH6P/ukuuakZFbp2bNmgZurq4oXyJsTuT7IquKnzl5E0UL59KuWrZo3wIW/ryoHu3jhAtiirVbJSuNPO39FxgzpVJnSJQtDVnvnL1+P03/+hXTvpFXphkHKFMmR+b2MmKitRsue2IcBTyCOz6kzfyFI+wrcf+ZSdNFWqyfPXq6+lr1+8w5M2WxYt2HclP2ily/3B8iV432J4v3M76qVYjlIniwZTpw+Dy+/ORgwchIeBjzG+b+uSJZRcXZywphhPTDR2wOlihXCdxt3aCvowxH04tVe4ppVP4b8iWNYqEAenD77N0z1+U12VCxbEqlSppAqleTJmR05smWBTqdDyWIF1AeBjOnTqflQtFB+XNJWwkUxeQLMIaknrnL77r/RnONP61bRzoN9qrp9B48jt+aAvvfSeZaV30mzlqL34HHafLqICxdNj8OJPy6gUf0a2gfIlGpON21UW9UrQfI4jKuUi+s8krLG5E11RpUz1R9j56CUlfl88/Y/EqWQgMUJ0OG1OHI2SAI2SEBtY4D6uvvUmQuQG1QMv/oWi3W6CG3FqYpaCZI9kbLKKKuokjd59go81VYO+3Zto/YCZnkvEwK11SLJE3HWvkqXVxEnzQkLDQ2X6Gvi4hLp4MbMSKY5Q/o0zVYX51eXLtkX66Q5U5Jfq9rH2irwUBQqkFetQskeTknv3bm1WpnN/n5mbRVzKeSrXHGS5StmkXHaSrWTZpesGH+mOd1u2tfavYf4KmdMp9OhYL5c+n5L33/ZtAh5NEdO6jZms+TFKibsF31n51d9c9JsCg2N/Mp/8/a9ajW0zZeN1F7UyuVLw5CxlDUm8uHhqy/qY5m2yirbKsRRN6Yr6Tqd8T6/yY5oY6VVJlsEtBf139nJCTJeePln2L9Y51Ac5tDLqrUPSNkgztW/L7eERKUbe5UxD3nJWnQ+LFEYgYFB2geOW9i6c5+a+5J+7cYdjPGfp628VsLEMQPQvnUTBAW9+gAhOjElAhFqJTgq3cVgL/ebeEaVee01jvPotXoME95QZ5Sqqf4YOwelrHzQcnv5IVaOKSRgSQKvrqyWbJVtkQAJ2CQBF80xla/jRSRuaGTFcqWwYetuXL4WuTord8DLvkvRka+PK2gre7KCc0X7KllE0t9Gypctgc3b9mpOyj1VTOoXUQcGgawSnj1/CedfrqqtXv8TCmgOqawqyg0x76RNjaoVSqN9qyY4c+6iKinp4vR9Ursy6teqolYwxYldt3giRAb3bg95M5anKBTKnxutmjdUX7/Lyl2pYgUhzvGuvZFfvUuFUXuUjdksWzHk63rRjSmm7I+pa3h89dotFC8iK6TZIE7woSMnDbNjjd+9d1+tQEZlylfpT548Q5bMGaOSsOb7n1Vc+iqr38WL5oOpPsfFDtXAG4KEmEOGTeTUVsmrVy6LgaMmQ+ZLVN4vvx59bVuH5OXLk0M/9+RYpGHdqliy+gec+OM8alcvL0m4oX1zkV1bsS6qfcuQXPsgtuvllgyVaSQoXaIQZPtLhOZQisqB31+NnSmesvc4wMhNXnGdR9K+MTG3TlP9kXMttnNQ2pQnQhTQvq2ROIUELE3A3h1eS/NieyTg8ARkhUYkZkfLf1QSHbTVrNET5qJd9+Fo+L/u2tffkQ6le9umkBuQunqMwarvtiJ/HN7UKmkO9f+a1MNQ72nqprg6TTppq8aBMc1ApozpMbx/J3VDkNwEJY9t8vTorPRmL16Lqp+2U49YEke4f/evVXrnfl6Qm5A8PP3x1+VraNfiM5VuGDx4GIC6X3SGrPgO95mBbFkzo2bV8kifLi3GjewDebyX3IAlj72SvbBS1pjNeXLlgGwh6DfcD2Nf3rQm+iKm7Jd8Y9Lk09r4edev6NLPW2M9C+Y4DiGhoZAtGHKTW6tOg9Gpjxfa/q8RxKmPaifw+XPIjXCjxs/CIM3xl+0G6U30OS52RLVl6jUh5lDM+j0HdEYF7YOUl98syE2F3Qf44OKVa0iRPFlMVbViezLG/tJG9aupG/lkP69sb5FC5coUU9sxpD4Z3/SxbI8RPUOppc2jgvlyQm6wlDKGq86meNasWg4PAx6pclE3rUXVG9d5FFU+tldz6zTVH2PnoLQn+6RlT7LEKSRgaQJOlm6Q7ZEACdgegXEj+0JuYIlpWZOGtTRnr68++fMGNbFkhjeWzByDHd/Pw9ctIh1Hcfx+WDFVbWcQZ1R05CthKShbAMp+WEyiSib7DFBbJ9RBjODLz+upG9aWzx6LvZsXI0P6dyBlpQ5D1WqVPsLCaV7qJqCpvoPU/krJl5XafZuXKDvk5rcK2qqzpK9ZMEHZ6+/tAZ9hPdWeUkk3lKxZ3lNtyoqv7HuVm9RkBU90Smtfb8+cMAzSr5/XzYHfqH6SrCQ2m52dnDCkrzsmjRmIoS9vWhO7opwmY/bH7GvRQnnVjXbSUHbNARfb5kzyxLgRfTDWszfc23whWfimZWP0cG+h4oaB7J2VG/W+XeiPlfPGqf7JV/CGOr06tYLcCLdaY1SnegV9lrE+m7Kj09fNIRJVScz+NKhTFd5De0RlK7t7dmypjhNiDslj9GR8VIVaIF+fiz1rF01U80rGsGObpjDcUqCpqf9FCubVVn4Dcf9BgDqWQPbsHtq2Ap4eneRQidQpc27ZbB81vh49vlZbTCSzRNECal5GxYW9xEWkn9PGDVZl5FUekSbppnhK+zLXpL2om9biO4+kTUPp06UNWjZroE8yNjcN+ybKxvpj7Bx8GPAY//0XgFLFC0lxCglYnAAdXosjZ4MkQAIkQAK2SKB/t7aQrRW2aJu92yRc+3ZrY+/doP32QiAWO+nwxgKFSSRAAiSQFAjI6mVS6Ke5fZQV4sT88QVz7XBEPfnGR/bNO2Lf2Cf7IECH1z7GiVaSAAkkLAHWRgIkQAIkkIQI0OFNQoPNrpIACZAACZAACZBAdAJJ44gOb9IYZ/aSBEiABEiABEiABJIsATq8SXbo2XESMJ8ANUmABEiABEjAngnQ4bXn0aPtJEACJEACJEACliTAtuyUAB1eOx04mk0CJEACJEACJEACJGAeATq85nGiFgmYT4CaJEACJEACJEACNkWADq9NDQeNIQESIAESIAHHIcCekICtEKDDaysjQTtIgARIgARIgARIgAQShQAd3kTBykrNJ0BNEiABEiABEiABEkhcAnR4E5cvaycBEiABEiAB8whQiwRIINEI0OFNNLSsmARIgARIgARIgARIwBYI0OG1hVEw3wZqkgAJkAAJkAAJkAAJvCUBOrxvCYzqJEACJEACtkCANpAACZCA+QTo8JrPipokQAIkQAIkQAIkQAJ2SMChHV47HA+aTAIkQAIkQAIkQAIkkMAE6PAmMFBWRwIkQAI2SIAmkQAJkECSJkCHN0kPPztPAiRAAiRAAiRAAo5P4JXD6/h9ZQ9JgARIgARIgARIgASSIAE6vElw0NllEiAB0wSYSwIkQAIk4FgE6PA61niyNyRAAiRAAiRAAiSQUAQcph46vA4zlOwICZAACZAACZAACZBAbATo8MZGhWkkQALmE6AmCZAACZAACdg4ATq8Nj5ANI8ESIAESIAESMA+CNBK2yVAh9d2x4aWkQAJkAAJkAAJkAAJJAABOrwJAJFVkID5BKhJAiRAAiRAAiRgaQJ0eC1NnO2RAAmQAAmQAAkAZEACFiRAh9eCsNkUCZAACZAACZAACZCA5QnQ4bU8c7ZoPgFqkgAJkAAJkAAJkEC8CdDhjTdCVkACJEACJEACiU2A9ZMACcSHAB3e+NBjWRIgARIgARIgARIgAZsnQIfX5ofIfAOpSQIkQAIkQAIkQAIk8DoBOryvM2EKCZAACZCAfROg9SRAAiQQjQAd3mg4eEACJEACJEACJEACJOBoBP4PAAD//0HkgfkAAAAGSURBVAMAFDDxyNVq1EgAAAAASUVORK5CYII="
      },
-     "metadata": {},
+     "metadata": {
+      "image/png": {
+       "alt": "Horizontal bar chart with one bar per temporal feature, feature names down the left and mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the bottom to the most positive at the top. Every bar is short, within a few hundredths of zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most whiskers cross it and those bars are left neutral grey, while the few features Benjamini-Hochberg retains are coloured, green where the IC is positive and red where it is negative."
+      }
+     },
      "output_type": "display_data"
     }
    ],
@@ -5076,20 +5114,29 @@
     "        margin={\"l\": 180, \"t\": 120},\n",
     "        height=580,\n",
     "    )\n",
-    "    fig.show()\n",
+    "    show_plotly_with_alt(\n",
+    "        fig,\n",
+    "        \"Horizontal bar chart with one bar per temporal feature, feature names down the left and \"\n",
+    "        \"mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the \"\n",
+    "        \"bottom to the most positive at the top. Every bar is short, within a few hundredths of \"\n",
+    "        \"zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most \"\n",
+    "        \"whiskers cross it and those bars are left neutral grey, while the few features \"\n",
+    "        \"Benjamini-Hochberg retains are coloured, green where the IC is positive and red where \"\n",
+    "        \"it is negative.\",\n",
+    "    )\n",
     "else:\n",
     "    print(\"Validation IC chart omitted: too few symbols per timestamp to rank a cross-section.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a66e506c",
+   "id": "13a29d00",
    "metadata": {
     "papermill": {
-     "duration": 0.005847,
-     "end_time": "2026-08-10T15:42:12.114663+00:00",
+     "duration": 0.005571,
+     "end_time": "2026-08-11T12:36:48.649723+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:12.108816+00:00",
+     "start_time": "2026-08-11T12:36:48.644152+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5126,13 +5173,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87159213",
+   "id": "c68338c2",
    "metadata": {
     "papermill": {
-     "duration": 0.005464,
-     "end_time": "2026-08-10T15:42:12.125632+00:00",
+     "duration": 0.005415,
+     "end_time": "2026-08-11T12:36:48.660620+00:00",
      "exception": false,
-     "start_time": "2026-08-10T15:42:12.120168+00:00",
+     "start_time": "2026-08-11T12:36:48.655205+00:00",
      "status": "completed"
     }
    },
@@ -5211,19 +5258,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4885.483035,
-   "end_time": "2026-08-10T15:42:14.306504+00:00",
+   "duration": 5336.86582,
+   "end_time": "2026-08-11T12:36:50.683965+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-nq100/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb",
-   "output_path": "~/ml4t/public-nq100/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb",
+   "input_path": "~/ml4t/public-nq100-alt/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb",
+   "output_path": "~/ml4t/public-nq100-alt/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb",
    "parameters": {},
-   "start_time": "2026-08-10T14:20:48.823469+00:00",
+   "start_time": "2026-08-11T11:07:53.818145+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "26dd248b87e340976790a1f3275dba651128fcdf",
-   "executed_at": "2026-08-10T15:42:19.317013+00:00",
+   "source_py_blob": "883bde857c7ae73f5ca0f56899df203926f5f152",
+   "executed_at": "2026-08-11T12:36:56.776444+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
@@ -1295,7 +1295,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the bottom row and holds the latest validation window; each row above it holds an earlier one, so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The top row is the extra fold written for the holdout: its training bar runs from the left edge up to the rule and its light grey holdout bar sits inside the band. No training bar of any row crosses the rule."
+       "alt": "Horizontal timeline with one row per fold on a session axis. Every row below the top is a validation fold: a long dark navy training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the bottom row and holds the latest of those validation windows, and each validation row above it holds an earlier one, so their bars overlap. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The top row is the extra fold written for the holdout and has no validation bar: its training bar runs from the left edge up to the rule and its light grey holdout bar sits inside the band, later than every validation window. No training bar of any row crosses the rule."
       }
      },
      "output_type": "display_data"
@@ -1362,13 +1362,15 @@
     ")\n",
     "show_plotly_with_alt(\n",
     "    fig,\n",
-    "    \"Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy \"\n",
-    "    \"training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the \"\n",
-    "    \"bottom row and holds the latest validation window; each row above it holds an earlier one, \"\n",
-    "    \"so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens \"\n",
-    "    \"and a shaded band to its right is the holdout itself. The top row is the extra fold written \"\n",
-    "    \"for the holdout: its training bar runs from the left edge up to the rule and its light grey \"\n",
-    "    \"holdout bar sits inside the band. No training bar of any row crosses the rule.\",\n",
+    "    \"Horizontal timeline with one row per fold on a session axis. Every row below the top is a \"\n",
+    "    \"validation fold: a long dark navy training bar followed by the shorter amber validation bar \"\n",
+    "    \"it is scored on. Fold 0 is the bottom row and holds the latest of those validation windows, \"\n",
+    "    \"and each validation row above it holds an earlier one, so their bars overlap. A dashed red \"\n",
+    "    \"rule marks where the holdout opens and a shaded band to its right is the holdout itself. \"\n",
+    "    \"The top row is the extra fold written for the holdout and has no validation bar: its \"\n",
+    "    \"training bar runs from the left edge up to the rule and its light grey holdout bar sits \"\n",
+    "    \"inside the band, later than every validation window. No training bar of any row crosses \"\n",
+    "    \"the rule.\",\n",
     ")"
    ]
   },

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
@@ -1022,7 +1022,7 @@
    },
    "source": [
     "**Figure F1** draws what the artifact will contain. Each fold is a training span and the\n",
-    "validation span that follows it; the last row is the extra fold written for the holdout\n",
+    "validation span that follows it; the top row is the extra fold written for the holdout\n",
     "period, whose training bars all lie before the holdout opens so that a model scored on the\n",
     "holdout has features for it without any of them having been built from it. The point to read\n",
     "off the figure is that no bar of any training span lies to the right of the rule."
@@ -1295,7 +1295,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Horizontal timeline with one row per fold on a session axis. Each row is a long blue training bar followed by the shorter amber validation bar it is scored on, and successive rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The bottom row is the extra fold written for the holdout: its training bar runs up to the rule and its grey holdout bar sits inside the band. No training bar of any row crosses the rule."
+       "alt": "Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the bottom row and holds the latest validation window; each row above it holds an earlier one, so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The top row is the extra fold written for the holdout: its training bar runs from the left edge up to the rule and its light grey holdout bar sits inside the band. No training bar of any row crosses the rule."
       }
      },
      "output_type": "display_data"
@@ -1362,12 +1362,13 @@
     ")\n",
     "show_plotly_with_alt(\n",
     "    fig,\n",
-    "    \"Horizontal timeline with one row per fold on a session axis. Each row is a long blue \"\n",
-    "    \"training bar followed by the shorter amber validation bar it is scored on, and successive \"\n",
-    "    \"rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks \"\n",
-    "    \"where the holdout opens and a shaded band to its right is the holdout itself. The bottom \"\n",
-    "    \"row is the extra fold written for the holdout: its training bar runs up to the rule and its \"\n",
-    "    \"grey holdout bar sits inside the band. No training bar of any row crosses the rule.\",\n",
+    "    \"Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy \"\n",
+    "    \"training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the \"\n",
+    "    \"bottom row and holds the latest validation window; each row above it holds an earlier one, \"\n",
+    "    \"so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens \"\n",
+    "    \"and a shaded band to its right is the holdout itself. The top row is the extra fold written \"\n",
+    "    \"for the holdout: its training bar runs from the left edge up to the rule and its light grey \"\n",
+    "    \"holdout bar sits inside the band. No training bar of any row crosses the rule.\",\n",
     ")"
    ]
   },
@@ -2749,7 +2750,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Two lines over validation sessions on a shared axis of mean squared one-minute log return. A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A thicker amber line is the HAR forecast, following the same path closely but smoother, and rising above the blue line where it peaks. Dotted vertical rules divide the axis into consecutive validation windows."
+       "alt": "Two lines over validation sessions on a shared axis of mean squared one-minute log return. A thin dark navy line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A thicker amber line is the HAR forecast, tracking the same path closely and rising above the navy line at every peak. A single dotted vertical rule near the middle is the boundary between the two consecutive validation windows."
       }
      },
      "output_type": "display_data"
@@ -2796,10 +2797,10 @@
     "show_plotly_with_alt(\n",
     "    fig,\n",
     "    \"Two lines over validation sessions on a shared axis of mean squared one-minute log return. \"\n",
-    "    \"A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A \"\n",
-    "    \"thicker amber line is the HAR forecast, following the same path closely but smoother, and \"\n",
-    "    \"rising above the blue line where it peaks. Dotted vertical rules divide the axis into \"\n",
-    "    \"consecutive validation windows.\",\n",
+    "    \"A thin dark navy line is realized 5-bar variance, spiky, with occasional tall isolated \"\n",
+    "    \"peaks. A thicker amber line is the HAR forecast, tracking the same path closely and rising \"\n",
+    "    \"above the navy line at every peak. A single dotted vertical rule near the middle is the \"\n",
+    "    \"boundary between the two consecutive validation windows.\",\n",
     ")"
    ]
   },
@@ -5065,7 +5066,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Horizontal bar chart with one bar per temporal feature, feature names down the left and mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the bottom to the most positive at the top. Every bar is short, within a few hundredths of zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most whiskers cross it and those bars are left neutral grey, while the few features Benjamini-Hochberg retains are coloured, green where the IC is positive and red where it is negative."
+       "alt": "Horizontal bar chart with one bar per temporal feature, feature names down the left and mean cross-sectional Spearman IC across the bottom, sorted from the most positive at the top to the most negative at the bottom. Every bar is short, within one hundredth of zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most whiskers cross it and those bars are left dark slate, while the two features Benjamini-Hochberg retains are coloured, green for the positive IC at the top and red for the negative one at the bottom."
       }
      },
      "output_type": "display_data"
@@ -5117,12 +5118,12 @@
     "    show_plotly_with_alt(\n",
     "        fig,\n",
     "        \"Horizontal bar chart with one bar per temporal feature, feature names down the left and \"\n",
-    "        \"mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the \"\n",
-    "        \"bottom to the most positive at the top. Every bar is short, within a few hundredths of \"\n",
+    "        \"mean cross-sectional Spearman IC across the bottom, sorted from the most positive at \"\n",
+    "        \"the top to the most negative at the bottom. Every bar is short, within one hundredth of \"\n",
     "        \"zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most \"\n",
-    "        \"whiskers cross it and those bars are left neutral grey, while the few features \"\n",
-    "        \"Benjamini-Hochberg retains are coloured, green where the IC is positive and red where \"\n",
-    "        \"it is negative.\",\n",
+    "        \"whiskers cross it and those bars are left dark slate, while the two features \"\n",
+    "        \"Benjamini-Hochberg retains are coloured, green for the positive IC at the top and red \"\n",
+    "        \"for the negative one at the bottom.\",\n",
     "    )\n",
     "else:\n",
     "    print(\"Validation IC chart omitted: too few symbols per timestamp to rank a cross-section.\")"
@@ -5256,6 +5257,13 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "executed_at": "2026-08-11T12:36:56.776444+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "883bde857c7ae73f5ca0f56899df203926f5f152"
+  },
   "papermill": {
    "default_parameters": {},
    "duration": 5336.86582,
@@ -5267,13 +5275,6 @@
    "parameters": {},
    "start_time": "2026-08-11T11:07:53.818145+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "883bde857c7ae73f5ca0f56899df203926f5f152",
-   "executed_at": "2026-08-11T12:36:56.776444+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.py
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.py
@@ -500,7 +500,7 @@ def validation_rows(frame: pl.DataFrame) -> pl.DataFrame:
 
 # %% [markdown]
 # **Figure F1** draws what the artifact will contain. Each fold is a training span and the
-# validation span that follows it; the last row is the extra fold written for the holdout
+# validation span that follows it; the top row is the extra fold written for the holdout
 # period, whose training bars all lie before the holdout opens so that a model scored on the
 # holdout has features for it without any of them having been built from it. The point to read
 # off the figure is that no bar of any training span lies to the right of the rule.
@@ -566,12 +566,13 @@ fig.update_layout(
 )
 show_plotly_with_alt(
     fig,
-    "Horizontal timeline with one row per fold on a session axis. Each row is a long blue "
-    "training bar followed by the shorter amber validation bar it is scored on, and successive "
-    "rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks "
-    "where the holdout opens and a shaded band to its right is the holdout itself. The bottom "
-    "row is the extra fold written for the holdout: its training bar runs up to the rule and its "
-    "grey holdout bar sits inside the band. No training bar of any row crosses the rule.",
+    "Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy "
+    "training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the "
+    "bottom row and holds the latest validation window; each row above it holds an earlier one, "
+    "so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens "
+    "and a shaded band to its right is the holdout itself. The top row is the extra fold written "
+    "for the holdout: its training bar runs from the left edge up to the rule and its light grey "
+    "holdout bar sits inside the band. No training bar of any row crosses the rule.",
 )
 
 # %% [markdown]
@@ -921,10 +922,10 @@ fig.update_layout(
 show_plotly_with_alt(
     fig,
     "Two lines over validation sessions on a shared axis of mean squared one-minute log return. "
-    "A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A "
-    "thicker amber line is the HAR forecast, following the same path closely but smoother, and "
-    "rising above the blue line where it peaks. Dotted vertical rules divide the axis into "
-    "consecutive validation windows.",
+    "A thin dark navy line is realized 5-bar variance, spiky, with occasional tall isolated "
+    "peaks. A thicker amber line is the HAR forecast, tracking the same path closely and rising "
+    "above the navy line at every peak. A single dotted vertical rule near the middle is the "
+    "boundary between the two consecutive validation windows.",
 )
 
 # %% [markdown]
@@ -1776,12 +1777,12 @@ if n_tested > 0:
     show_plotly_with_alt(
         fig,
         "Horizontal bar chart with one bar per temporal feature, feature names down the left and "
-        "mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the "
-        "bottom to the most positive at the top. Every bar is short, within a few hundredths of "
+        "mean cross-sectional Spearman IC across the bottom, sorted from the most positive at "
+        "the top to the most negative at the bottom. Every bar is short, within one hundredth of "
         "zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most "
-        "whiskers cross it and those bars are left neutral grey, while the few features "
-        "Benjamini-Hochberg retains are coloured, green where the IC is positive and red where "
-        "it is negative.",
+        "whiskers cross it and those bars are left dark slate, while the two features "
+        "Benjamini-Hochberg retains are coloured, green for the positive IC at the top and red "
+        "for the negative one at the bottom.",
     )
 else:
     print("Validation IC chart omitted: too few symbols per timestamp to rank a cross-section.")

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.py
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.py
@@ -82,7 +82,7 @@ from data import load_nasdaq100_bars
 from utils.artifact_specs import resolve_label_buffer, resolve_label_horizon
 from utils.cv_splits import generate_cv_splits, load_evaluation_config
 from utils.paths import get_case_study_dir
-from utils.style import COLORS
+from utils.style import COLORS, show_plotly_with_alt
 
 warnings.filterwarnings("ignore")
 
@@ -564,7 +564,15 @@ fig.update_layout(
     height=460,
     margin={"l": 90, "t": 140},
 )
-fig.show()
+show_plotly_with_alt(
+    fig,
+    "Horizontal timeline with one row per fold on a session axis. Each row is a long blue "
+    "training bar followed by the shorter amber validation bar it is scored on, and successive "
+    "rows step to the right, so the bars of neighbouring folds overlap. A dashed red rule marks "
+    "where the holdout opens and a shaded band to its right is the holdout itself. The bottom "
+    "row is the extra fold written for the holdout: its training bar runs up to the rule and its "
+    "grey holdout bar sits inside the band. No training bar of any row crosses the rule.",
+)
 
 # %% [markdown]
 # ## C. One section per model: what it infers, and why it cannot see ahead
@@ -910,7 +918,14 @@ fig.update_layout(
     height=440,
     margin={"t": 120},
 )
-fig.show()
+show_plotly_with_alt(
+    fig,
+    "Two lines over validation sessions on a shared axis of mean squared one-minute log return. "
+    "A thin blue line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A "
+    "thicker amber line is the HAR forecast, following the same path closely but smoother, and "
+    "rising above the blue line where it peaks. Dotted vertical rules divide the axis into "
+    "consecutive validation windows.",
+)
 
 # %% [markdown]
 # ### C.2 A rolling spectrum of volume and of variance
@@ -1327,7 +1342,14 @@ fig.update_layout(
     height=440,
     margin={"t": 120},
 )
-fig.show()
+show_plotly_with_alt(
+    fig,
+    "Grouped box plots with one group of three boxes per fold along the horizontal axis, "
+    "coloured amber, copper and slate for the 5-, 15- and 60-minute components. A dashed rule "
+    "marks zero. In every fold the amber 5-minute box sits highest and above the rule, while the "
+    "copper and slate boxes for the two longer horizons sit lower and straddle it. Boxes span "
+    "the quartiles and the whiskers the 5th to 95th percentiles.",
+)
 
 # %% [markdown] tags=["results"]
 # ### What the coefficient distributions say
@@ -1751,7 +1773,16 @@ if n_tested > 0:
         margin={"l": 180, "t": 120},
         height=580,
     )
-    fig.show()
+    show_plotly_with_alt(
+        fig,
+        "Horizontal bar chart with one bar per temporal feature, feature names down the left and "
+        "mean cross-sectional Spearman IC across the bottom, sorted from the most negative at the "
+        "bottom to the most positive at the top. Every bar is short, within a few hundredths of "
+        "zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most "
+        "whiskers cross it and those bars are left neutral grey, while the few features "
+        "Benjamini-Hochberg retains are coloured, green where the IC is positive and red where "
+        "it is negative.",
+    )
 else:
     print("Validation IC chart omitted: too few symbols per timestamp to rank a cross-section.")
 

--- a/case_studies/nasdaq100_microstructure/04_model_based_features.py
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.py
@@ -566,13 +566,15 @@ fig.update_layout(
 )
 show_plotly_with_alt(
     fig,
-    "Horizontal timeline with one row per fold on a session axis. Each row is a long dark navy "
-    "training bar followed by the shorter amber validation bar it is scored on. Fold 0 is the "
-    "bottom row and holds the latest validation window; each row above it holds an earlier one, "
-    "so the bars of neighbouring folds overlap. A dashed red rule marks where the holdout opens "
-    "and a shaded band to its right is the holdout itself. The top row is the extra fold written "
-    "for the holdout: its training bar runs from the left edge up to the rule and its light grey "
-    "holdout bar sits inside the band. No training bar of any row crosses the rule.",
+    "Horizontal timeline with one row per fold on a session axis. Every row below the top is a "
+    "validation fold: a long dark navy training bar followed by the shorter amber validation bar "
+    "it is scored on. Fold 0 is the bottom row and holds the latest of those validation windows, "
+    "and each validation row above it holds an earlier one, so their bars overlap. A dashed red "
+    "rule marks where the holdout opens and a shaded band to its right is the holdout itself. "
+    "The top row is the extra fold written for the holdout and has no validation bar: its "
+    "training bar runs from the left edge up to the rule and its light grey holdout bar sits "
+    "inside the band, later than every validation window. No training bar of any row crosses "
+    "the rule.",
 )
 
 # %% [markdown]

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -342,10 +342,57 @@ def test_alt_text_the_outputs_do_not_carry_is_stale(tmp_path, monkeypatch) -> No
     assert not _drift(tmp_path, monkeypatch, old, new, nb)
 
 
+def test_a_trailing_semicolon_is_stale(tmp_path, monkeypatch) -> None:
+    """A semicolon suppresses a cell's automatic display and leaves the AST identical."""
+    old = '# %%\nfig = build()\nshow_plotly_with_alt(fig, "words")\nsummary\n'
+    new = '# %%\nfig = build()\nshow_plotly_with_alt(fig, "words")\nsummary;\n'
+    nb = _notebook([_alt_cell("words")])
+    assert not _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_moving_a_cell_boundary_is_stale(tmp_path, monkeypatch) -> None:
+    """Which code shares a cell decides which value is its last expression."""
+    old = "# %%\nfig = build()\n\n# %%\nsummary\n"
+    new = "# %%\nfig = build()\nsummary\n"
+    assert not _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_retagging_a_cell_is_stale(tmp_path, monkeypatch) -> None:
+    """The marker carries cell tags, so it is compared even for a markdown cell."""
+    old = "# %% [markdown]\n# words\n"
+    new = '# %% [markdown] tags=["results"]\n# words\n'
+    assert not _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_rewrapping_the_alt_literal_is_not_stale(tmp_path, monkeypatch) -> None:
+    """ruff format rewraps a long alt string; the value is what matters, not the wrapping."""
+    old = '# %%\nshow_plotly_with_alt(fig, "one two three")\n'
+    new = '# %%\nshow_plotly_with_alt(\n    fig,\n    "one two "\n    "three",\n)\n'
+    nb = _notebook([_alt_cell("one two three")])
+    assert _drift(tmp_path, monkeypatch, old, new, nb)
+
+
 def test_a_comment_only_change_is_not_stale(tmp_path, monkeypatch) -> None:
     """Markdown cells are comments in a jupytext .py and cannot affect outputs."""
     old = "# %% [markdown]\n# the last row is the holdout\n\n# %%\nfig = build()\n"
     new = "# %% [markdown]\n# the top row is the holdout\n\n# %%\nfig = build()\n"
+    assert _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_code_appended_into_a_markdown_cell_is_stale(tmp_path, monkeypatch) -> None:
+    """A markdown body is only ignorable while it is all comments.
+
+    Measured against the real notebook: its last cell is `# %% [markdown]`, so appending
+    `fig;` landed in a markdown body and was forgiven until the body was compared.
+    """
+    old = "# %% [markdown]\n# words\n"
+    new = "# %% [markdown]\n# words\nfig;\n"
+    assert not _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_editing_markdown_prose_is_still_not_stale(tmp_path, monkeypatch) -> None:
+    old = "# %% [markdown]\n# the last row is the holdout\n"
+    new = "# %% [markdown]\n# the top row is the holdout\n"
     assert _drift(tmp_path, monkeypatch, old, new, _notebook([]))
 
 

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -235,7 +235,7 @@ def test_stamp_records_declared_overrides_as_test_mode(tmp_path, monkeypatch) ->
 
 
 def test_stamped_notebooks_are_current_and_production() -> None:
-    stale, testmode, contradicted, _unverified = check_all(strict=False)
+    stale, testmode, contradicted, _unverified, _alt_only = check_all(strict=False)
     assert not stale and not testmode and not contradicted, (
         "Committed notebooks are out of sync with their source .py:\n"
         + (
@@ -270,3 +270,96 @@ def test_no_notebook_loses_a_provenance_stamp_it_already_had() -> None:
     assert not lost, "these notebooks had a provenance stamp at HEAD and do not now:\n    " + (
         "\n    ".join(lost)
     )
+
+
+# -----------------------------------------------------------------------------
+# Alt-text-only drift
+#
+# The stamp records the .py blob, so any edit to the .py moves it and the gate reads
+# a corrected figure description as a notebook needing re-execution. For alt text
+# that is wrong: show_plotly_with_alt puts the string in output metadata and takes
+# the image from fig._repr_mimebundle_(), which never sees it, so no re-run can
+# produce different outputs. nasdaq100_microstructure/04 is 90 minutes to restate
+# four sentences. These pin the carve-out and its edges.
+# -----------------------------------------------------------------------------
+
+
+def _alt_cell(alt: str, *, png: str = "iVBORw0KGgo=", carried: str | None = None) -> dict:
+    """A code cell calling show_plotly_with_alt with one png output carrying *carried*."""
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "source": f'fig = build()\nshow_plotly_with_alt(fig, "{alt}")\n',
+        "outputs": [
+            {
+                "output_type": "display_data",
+                "data": {"image/png": png},
+                "metadata": {"image/png": {"alt": alt if carried is None else carried}},
+            }
+        ],
+    }
+
+
+def _drift(tmp_path, monkeypatch, old_src: str, new_src: str, nb: dict) -> bool:
+    """Run alt_text_only_drift with *old_src* as the stamped blob and *new_src* on disk."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=tmp_path,
+        input=old_src,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    py = tmp_path / "nb.py"
+    py.write_text(new_src, encoding="utf-8")
+    return notebook_provenance.alt_text_only_drift(blob, py, nb)
+
+
+def test_correcting_only_the_alt_text_is_not_stale(tmp_path, monkeypatch) -> None:
+    old = 'fig = build()\nshow_plotly_with_alt(fig, "the bottom row is the holdout")\n'
+    new = 'fig = build()\nshow_plotly_with_alt(fig, "the top row is the holdout")\n'
+    nb = _notebook([_alt_cell("the top row is the holdout")])
+    assert _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_a_code_change_beside_an_alt_change_is_still_stale(tmp_path, monkeypatch) -> None:
+    """The whole point of the stamp. One changed constant must not ride along."""
+    old = 'fig = build(n=5)\nshow_plotly_with_alt(fig, "old words")\n'
+    new = 'fig = build(n=20)\nshow_plotly_with_alt(fig, "new words")\n'
+    nb = _notebook([_alt_cell("new words")])
+    assert not _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_alt_text_the_outputs_do_not_carry_is_stale(tmp_path, monkeypatch) -> None:
+    """A source-only edit. The outputs still describe the figure the old way."""
+    old = 'fig = build()\nshow_plotly_with_alt(fig, "old words")\n'
+    new = 'fig = build()\nshow_plotly_with_alt(fig, "new words")\n'
+    nb = _notebook([_alt_cell("new words", carried="old words")])
+    assert not _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_a_comment_only_change_is_not_stale(tmp_path, monkeypatch) -> None:
+    """Markdown cells are comments in a jupytext .py and cannot affect outputs."""
+    old = "# %% [markdown]\n# the last row is the holdout\n\n# %%\nfig = build()\n"
+    new = "# %% [markdown]\n# the top row is the holdout\n\n# %%\nfig = build()\n"
+    assert _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_an_unparseable_source_is_stale(tmp_path, monkeypatch) -> None:
+    old = "fig = build()\n"
+    new = "fig = build(\n"
+    assert not _drift(tmp_path, monkeypatch, old, new, _notebook([]))
+
+
+def test_a_stamped_blob_this_repo_does_not_have_is_stale(tmp_path, monkeypatch) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    py = tmp_path / "nb.py"
+    py.write_text("fig = build()\n", encoding="utf-8")
+    assert not notebook_provenance.alt_text_only_drift("0" * 40, py, _notebook([]))

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -284,12 +284,18 @@ def test_no_notebook_loses_a_provenance_stamp_it_already_had() -> None:
 # -----------------------------------------------------------------------------
 
 
-def _alt_cell(alt: str, *, png: str = "iVBORw0KGgo=", carried: str | None = None) -> dict:
-    """A code cell calling show_plotly_with_alt with one png output carrying *carried*."""
+def _alt_cell(
+    alt: str,
+    *,
+    png: str = "iVBORw0KGgo=",
+    carried: str | None = None,
+    call: str = "show_plotly_with_alt",
+) -> dict:
+    """A code cell calling *call* with one png output carrying *carried*."""
     return {
         "cell_type": "code",
         "metadata": {},
-        "source": f'fig = build()\nshow_plotly_with_alt(fig, "{alt}")\n',
+        "source": f'fig = build()\n{call}(fig, "{alt}")\n',
         "outputs": [
             {
                 "output_type": "display_data",
@@ -324,6 +330,27 @@ def test_correcting_only_the_alt_text_is_not_stale(tmp_path, monkeypatch) -> Non
     new = 'fig = build()\nshow_plotly_with_alt(fig, "the top row is the holdout")\n'
     nb = _notebook([_alt_cell("the top row is the holdout")])
     assert _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_correcting_alt_text_on_a_qualified_call_is_not_stale(tmp_path, monkeypatch) -> None:
+    """``import utils.style as style`` gives ``style.show_plotly_with_alt(...)``.
+
+    The exception matched only bare ``ast.Name`` calls, so the qualified form fell
+    outside it. ``case_studies/etfs/05_evaluation.py`` is the one notebook in the
+    corpus written this way, and ``import utils.style as style`` appears 19 times.
+    """
+    old = 'fig = build()\nstyle.show_plotly_with_alt(fig, "the bottom row is the holdout")\n'
+    new = 'fig = build()\nstyle.show_plotly_with_alt(fig, "the top row is the holdout")\n'
+    nb = _notebook([_alt_cell("the top row is the holdout", call="style.show_plotly_with_alt")])
+    assert _drift(tmp_path, monkeypatch, old, new, nb)
+
+
+def test_a_code_change_beside_a_qualified_alt_change_is_still_stale(tmp_path, monkeypatch) -> None:
+    """Recognising the qualified form must not also forgive a changed constant."""
+    old = 'fig = build(n=5)\nstyle.show_plotly_with_alt(fig, "old words")\n'
+    new = 'fig = build(n=20)\nstyle.show_plotly_with_alt(fig, "new words")\n'
+    nb = _notebook([_alt_cell("new words", call="style.show_plotly_with_alt")])
+    assert not _drift(tmp_path, monkeypatch, old, new, nb)
 
 
 def test_a_code_change_beside_an_alt_change_is_still_stale(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Closes the last open stage 01-05 item: `nasdaq100_microstructure/04_model_based_features` had four
figures with no alt text.

The notebook was re-executed once to add them, and the artifact confirms the run changed only
display calls: `features/model_based.parquet` reproduced exactly at digest `e88721b54b7bb236`,
40,114,054 rows, 25 columns, with all five input digests unchanged.

Three of the four descriptions were then corrected against the rendered figures rather than the
plotting code, which is where they had been written from.

Landing them exposed a provenance-gate defect. `show_plotly_with_alt` publishes
`metadata={**metadata, "image/png": {"alt": alt}}` and takes the image from
`fig._repr_mimebundle_()`, which never sees the alt string, so the alt in output metadata is a
verbatim copy of the source literal and correcting one cannot change the outputs. The gate had no
way to tell that from a code edit and reported a corrected caption as a stale run - 90 minutes and
43 GB to restate a sentence. It now recognises the case, with both halves required: every cell
lines up and every code cell is byte-identical once alt literals are blanked, and every changed alt
already appears in the outputs. A changed constant beside a changed caption is still stale.

34 tests, up from 20.