### PR TITLE
Add research experiment interface

### DIFF
--- a/20_strategy_synthesis/holdout.py
+++ b/20_strategy_synthesis/holdout.py
@@ -51,7 +51,10 @@ from case_studies.utils.backtest_explorer import BacktestExplorer
 from case_studies.utils.backtest_loaders import load_backtest_prices_for
 from case_studies.utils.backtest_runner import run_backtest
 from case_studies.utils.carrier_pins import prioritize_carrier_hash
-from case_studies.utils.conformal import compute_holdout_conformal_widths
+from case_studies.utils.conformal import (
+    compute_holdout_conformal_widths,
+    holdout_conformal_embargo_steps,
+)
 from case_studies.utils.registry import (
     register_backtest_run,
     register_prediction_metrics,
@@ -86,54 +89,6 @@ def _parse_buffer_to_days(buffer: str) -> int:
         n = int(buf.replace("min", "").replace("T", ""))
         return 1  # intraday → 1 day minimum
     return 0
-
-
-# Forward-return label horizon in data-step units. Drives the conformal
-# calibration embargo so that no val residual uses returns realized inside the
-# holdout window (a residual at val timestamp t depends on returns over
-# (t, t+h]; if t+h falls inside the holdout window the residual leaks
-# holdout-period prices into calibration). Mirrors EMBARGO_STEPS in the
-# now-archived ``scripts/run_conformal_holdout_sweep.py``. sp500_options is
-# absent - see project_sp500_options_conformal_permanently_skipped.
-HOLDOUT_CONFORMAL_EMBARGO_STEPS: dict[str, int] = {
-    "etfs/fwd_ret_21d": 21,
-    "cme_futures/fwd_ret_5d": 5,
-    "cme_futures/fwd_ret_21d": 21,
-    "fx_pairs/fwd_ret_1d": 1,
-    "fx_pairs/fwd_ret_5d": 5,
-    "fx_pairs/fwd_ret_21d": 21,
-    "crypto_perps_funding/fwd_ret_24h": 3,
-    "crypto_perps_funding/fwd_ret_8h": 1,
-    "nasdaq100_microstructure/fwd_ret_15m": 1,
-    "nasdaq100_microstructure/fwd_ret_60m": 4,
-    "nasdaq100_microstructure/fwd_ret_5m": 1,
-    "sp500_equity_option_analytics/fwd_ret_5d": 5,
-    "sp500_equity_option_analytics/fwd_ret_risk_adj_5d": 5,
-    "us_equities_panel/fwd_ret_5d": 5,
-    "us_equities_panel/fwd_ret_1d": 1,
-    "us_equities_panel/fwd_ret_21d": 21,
-    "us_firm_characteristics/fwd_ret_1m_win": 1,
-    "us_firm_characteristics/fwd_ret_1m": 1,
-    "us_firm_characteristics/fwd_class_1m": 1,
-}
-
-
-def _holdout_conformal_embargo(cs_id: str, label: str) -> int:
-    """Embargo step count for the val→holdout conformal calibration.
-
-    Refuses to fall back to 0 silently: any new (cs, label) combination
-    must be added to ``HOLDOUT_CONFORMAL_EMBARGO_STEPS`` explicitly so
-    that the horizon is reviewed.
-    """
-    key = f"{cs_id}/{label}"
-    if key not in HOLDOUT_CONFORMAL_EMBARGO_STEPS:
-        raise KeyError(
-            f"No conformal embargo defined for {key}. Add it to "
-            f"HOLDOUT_CONFORMAL_EMBARGO_STEPS in 20_strategy_synthesis/"
-            f"holdout.py. Silent fallback to 0 would leak holdout-period "
-            f"prices into calibration residuals."
-        )
-    return HOLDOUT_CONFORMAL_EMBARGO_STEPS[key]
 
 
 def _delete_pre_registered_prediction(cs_id: str, prediction_hash: str) -> None:
@@ -1259,7 +1214,7 @@ def generate_holdout(
                     task_type=mds.task_type,
                     class_values=mds.class_values or None,
                 )
-                embargo = _holdout_conformal_embargo(cs_id, label)
+                embargo = holdout_conformal_embargo_steps(cs_id, label)
                 alpha = float(alloc_spec.get("alpha", 0.20))
                 widths = compute_holdout_conformal_widths(
                     cs_id,

--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -1,0 +1,25 @@
+from .comparison import CandidateSet
+from .contracts import ExecutionTier, LifecycleState
+from .cv import CVSpec, ResolvedCVSpec
+from .labels import LabelDefinition, LabelRef
+from .lifecycle import ResearchLock
+from .results import BacktestResult, PredictionResult, Result, TrainingResult
+from .strategy import Strategy
+from .workspace import Study
+
+__all__ = [
+    "BacktestResult",
+    "CVSpec",
+    "CandidateSet",
+    "ExecutionTier",
+    "LabelDefinition",
+    "LabelRef",
+    "LifecycleState",
+    "PredictionResult",
+    "ResearchLock",
+    "ResolvedCVSpec",
+    "Result",
+    "Strategy",
+    "Study",
+    "TrainingResult",
+]

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.registry.specs import canonical_json, compute_hash
+from case_studies.utils.registry.store import _git_hash, _open_registry, _utc_now
+
+from .results import Result
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class CandidateSet:
+    study: Study
+    hash: str
+    name: str
+    member_kind: str
+    members: tuple[str, ...]
+    comparison_contract: dict[str, Any]
+
+    @classmethod
+    def create(
+        cls,
+        study: Study,
+        name: str,
+        members: Iterable[Result],
+        *,
+        comparison_contract: dict[str, Any] | None = None,
+    ) -> CandidateSet:
+        study.require_writable()
+        study.activate()
+        resolved = tuple(members)
+        if not resolved:
+            raise ValueError("candidate set requires at least one member")
+        if any(member.study != study for member in resolved):
+            raise ValueError("candidate set member belongs to another study")
+        kinds = {member.kind for member in resolved}
+        if len(kinds) != 1 or kinds.pop() not in {"prediction", "backtest"}:
+            raise ValueError("candidate set members must share prediction or backtest kind")
+        member_kind = resolved[0].kind
+        if any(member.execution_tier == "preview" for member in resolved):
+            raise ValueError("preview results cannot enter a canonical candidate set")
+        if any(not member.complete for member in resolved):
+            raise ValueError("partial results cannot enter a candidate set")
+        protocols = [member.protocol() for member in resolved]
+        if any(protocol["split"] != "validation" for protocol in protocols):
+            raise ValueError("canonical candidate sets require validation results")
+
+        contract = dict(comparison_contract or {})
+        comparable_fields = set(contract.get("comparable_fields") or [])
+        base = protocols[0]
+        for protocol in protocols[1:]:
+            differences = {key for key in base if base.get(key) != protocol.get(key)}
+            undeclared = differences - comparable_fields
+            if undeclared:
+                raise ValueError(
+                    f"candidate set contains protocol-incompatible results: {sorted(undeclared)}"
+                )
+        supplied_protocol = contract.get("protocol")
+        if supplied_protocol is not None and supplied_protocol != base:
+            raise ValueError("comparison contract protocol does not match its members")
+        contract["protocol"] = base
+        contract.setdefault("comparable_fields", sorted(comparable_fields))
+        member_hashes = tuple(sorted(member.hash for member in resolved))
+        if len(set(member_hashes)) != len(member_hashes):
+            raise ValueError("candidate set members must be unique")
+        set_hash = compute_hash(
+            canonical_json(
+                {
+                    "member_kind": member_kind,
+                    "members": member_hashes,
+                    "comparison_contract": contract,
+                }
+            )
+        )
+        db = _open_registry(study.root)
+        try:
+            existing = db.execute(
+                "SELECT member_kind, comparison_contract_json FROM candidate_sets WHERE set_hash = ?",
+                (set_hash,),
+            ).fetchone()
+            expected = (member_kind, canonical_json(contract))
+            if existing is not None and existing != expected:
+                raise ValueError(f"immutable candidate-set conflict for {set_hash}")
+            if existing is None:
+                db.execute(
+                    "INSERT INTO candidate_sets "
+                    "(set_hash, name, member_kind, comparison_contract_json, created_at, git_commit) "
+                    "VALUES (?,?,?,?,?,?)",
+                    (set_hash, name, member_kind, expected[1], _utc_now(), _git_hash()),
+                )
+                db.executemany(
+                    "INSERT INTO candidate_set_members (set_hash, member_hash, ordinal) "
+                    "VALUES (?,?,?)",
+                    [(set_hash, value, ordinal) for ordinal, value in enumerate(member_hashes)],
+                )
+                db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+        return cls(study, set_hash, name, member_kind, member_hashes, contract)
+
+    @classmethod
+    def open(cls, study: Study, set_hash: str) -> CandidateSet:
+        db_path = study.root / "run_log" / "registry.db"
+        with sqlite3.connect(db_path) as db:
+            row = db.execute(
+                "SELECT name, member_kind, comparison_contract_json FROM candidate_sets "
+                "WHERE set_hash = ?",
+                (set_hash,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"Unknown candidate set {set_hash!r}")
+            members = tuple(
+                value[0]
+                for value in db.execute(
+                    "SELECT member_hash FROM candidate_set_members WHERE set_hash = ? "
+                    "ORDER BY ordinal",
+                    (set_hash,),
+                ).fetchall()
+            )
+        return cls(study, set_hash, row[0], row[1], members, json.loads(row[2]))
+
+    def extend(self, name: str, members: Iterable[Result]) -> CandidateSet:
+        existing = [Result.open(self.study, member_hash) for member_hash in self.members]
+        return self.create(
+            self.study,
+            name,
+            [*existing, *members],
+            comparison_contract=self.comparison_contract,
+        )
+
+    def best_validation_sharpe(self) -> Result:
+        """Select deterministically within this immutable backtest set."""
+        if self.member_kind != "backtest":
+            raise ValueError("validation Sharpe selection requires backtest members")
+        placeholders = ",".join("?" for _ in self.members)
+        with sqlite3.connect(self.study.root / "run_log" / "registry.db") as db:
+            rows = db.execute(
+                f"""
+                SELECT m.backtest_hash, m.sharpe
+                FROM backtest_metrics m
+                JOIN backtest_runs b ON b.backtest_hash = m.backtest_hash
+                JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
+                JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash
+                JOIN training_runs t ON t.training_hash = p.training_hash
+                WHERE m.backtest_hash IN ({placeholders})
+                  AND p.split = 'validation'
+                  AND c.status = 'complete'
+                  AND t.execution_tier = 'canonical'
+                  AND b.stage IN ('signal', 'allocation', 'risk_overlay')
+                  AND m.sharpe IS NOT NULL
+                ORDER BY m.sharpe DESC, m.backtest_hash ASC
+                """,
+                self.members,
+            ).fetchall()
+        if len(rows) != len(self.members):
+            raise ValueError("candidate set contains an ineligible selection member")
+        return Result.open(self.study, rows[0][0])

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -48,7 +48,8 @@ class CandidateSet:
             raise ValueError("preview results cannot enter a canonical candidate set")
         if any(not member.complete for member in resolved):
             raise ValueError("partial results cannot enter a candidate set")
-        protocols = [member.protocol() for member in resolved]
+        ordered = tuple(sorted(resolved, key=lambda member: member.hash))
+        protocols = [member.protocol() for member in ordered]
         if any(protocol["split"] != "validation" for protocol in protocols):
             raise ValueError("canonical candidate sets require validation results")
 
@@ -62,12 +63,15 @@ class CandidateSet:
                 raise ValueError(
                     f"candidate set contains protocol-incompatible results: {sorted(undeclared)}"
                 )
+        common_protocol = {
+            key: value for key, value in base.items() if key not in comparable_fields
+        }
         supplied_protocol = contract.get("protocol")
-        if supplied_protocol is not None and supplied_protocol != base:
+        if supplied_protocol is not None and supplied_protocol != common_protocol:
             raise ValueError("comparison contract protocol does not match its members")
-        contract["protocol"] = base
-        contract.setdefault("comparable_fields", sorted(comparable_fields))
-        member_hashes = tuple(sorted(member.hash for member in resolved))
+        contract["protocol"] = common_protocol
+        contract["comparable_fields"] = sorted(comparable_fields)
+        member_hashes = tuple(member.hash for member in ordered)
         if len(set(member_hashes)) != len(member_hashes):
             raise ValueError("candidate set members must be unique")
         set_hash = compute_hash(

--- a/case_studies/research/contracts.py
+++ b/case_studies/research/contracts.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ExecutionTier(StrEnum):
+    CANONICAL = "canonical"
+    PREVIEW = "preview"
+
+
+class LifecycleState(StrEnum):
+    DEVELOPMENT = "DEVELOPMENT"
+    LOCKED = "LOCKED"
+    HOLDOUT_EVALUATED = "HOLDOUT_EVALUATED"

--- a/case_studies/research/cv.py
+++ b/case_studies/research/cv.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from case_studies.utils.registry.specs import canonical_json, compute_hash
+from utils.cv_splits import generate_cv_splits
+
+
+def _normalize_boundary(value: Any) -> str:
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+@dataclass(frozen=True)
+class ResolvedCVSpec:
+    request: dict[str, Any]
+    normalized_folds: tuple[dict[str, Any], ...]
+    identity: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "request": self.request,
+            "folds": list(self.normalized_folds),
+            "identity": self.identity,
+        }
+
+
+@dataclass(frozen=True)
+class CVSpec:
+    training_window: int | float | str | None
+    validation_window: int | float | str
+    retrain_every: int | str | None
+    folds: tuple[int, ...]
+    expanding: bool = False
+    horizon: str = "0D"
+    gap: str | None = None
+    holdout_start: str | None = None
+    holdout_end: str | None = None
+    calendar: str | None = None
+    decision_cadence: str | None = None
+
+    def __post_init__(self) -> None:
+        normalized_folds = tuple(sorted({int(fold) for fold in self.folds}))
+        if not normalized_folds or normalized_folds[0] < 0:
+            raise ValueError("folds must contain at least one non-negative fold id")
+        object.__setattr__(self, "folds", normalized_folds)
+
+    @classmethod
+    def walk_forward(
+        cls,
+        *,
+        training_window: int | float | str | None,
+        validation_window: int | float | str,
+        retrain_every: int | str | None = None,
+        folds=None,
+        expanding: bool = False,
+        horizon: str = "0D",
+        gap: str | None = None,
+        holdout_start: str | None = None,
+        holdout_end: str | None = None,
+        calendar: str | None = None,
+        decision_cadence: str | None = None,
+    ) -> CVSpec:
+        normalized_folds = tuple(int(fold) for fold in (range(5) if folds is None else folds))
+        return cls(
+            training_window=training_window,
+            validation_window=validation_window,
+            retrain_every=retrain_every,
+            folds=normalized_folds,
+            expanding=expanding,
+            horizon=horizon,
+            gap=gap,
+            holdout_start=holdout_start,
+            holdout_end=holdout_end,
+            calendar=calendar,
+            decision_cadence=decision_cadence,
+        )
+
+    def with_changes(self, **changes) -> CVSpec:
+        return replace(self, **changes)
+
+    def resolve(self, timeline, *, date_col: str = "timestamp") -> ResolvedCVSpec:
+        step_size = self.retrain_every
+        if isinstance(step_size, str):
+            if step_size != self.validation_window:
+                raise ValueError(
+                    "a distinct retrain_every duration must be expressed as an integer "
+                    "observation step for the existing splitter"
+                )
+            step_size = None
+        config = {
+            "n_splits": max(self.folds) + 1,
+            "train_size": self.training_window,
+            "val_size": self.validation_window,
+            "holdout_start": self.holdout_start,
+            "holdout_end": self.holdout_end,
+            "calendar": self.calendar,
+            "step_size": step_size,
+            "expanding": self.expanding,
+        }
+        generated = generate_cv_splits(
+            timeline,
+            label_buffer=self.gap or self.horizon,
+            outcome_horizon=self.horizon,
+            date_col=date_col,
+            cv_config=config,
+        )
+        selected = [split for split in generated if int(split["fold"]) in self.folds]
+        if len(selected) != len(self.folds):
+            raise ValueError("requested folds were not all produced by the existing CV generator")
+        normalized = tuple(
+            {
+                "fold": int(split["fold"]),
+                "train_start": _normalize_boundary(split["train_start"]),
+                "train_end": _normalize_boundary(split["train_end"]),
+                "val_start": _normalize_boundary(split["val_start"]),
+                "val_end": _normalize_boundary(split["val_end"]),
+            }
+            for split in selected
+        )
+        request = {
+            "training_window": self.training_window,
+            "validation_window": self.validation_window,
+            "retrain_every": self.retrain_every,
+            "folds": list(self.folds),
+            "expanding": self.expanding,
+            "horizon": self.horizon,
+            "gap": self.gap or self.horizon,
+            "holdout_start": self.holdout_start,
+            "holdout_end": self.holdout_end,
+            "calendar": self.calendar,
+            "decision_cadence": self.decision_cadence,
+        }
+        identity = compute_hash(canonical_json({"request": request, "folds": normalized}))
+        return ResolvedCVSpec(request=request, normalized_folds=normalized, identity=identity)

--- a/case_studies/research/labels.py
+++ b/case_studies/research/labels.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import polars as pl
+
+from case_studies.utils.artifact_digest import digest_sidecar, sidecar_path, value_digest
+from utils.artifact_specs import load_label_spec, resolve_label_horizon, resolve_storage_path
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class LabelDefinition:
+    name: str
+    task_type: Literal["regression", "classification"]
+    horizon: str
+    continuous_eval_label: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name or any(char in self.name for char in "/\\"):
+            raise ValueError("label name must be a non-empty path-safe name")
+        if self.task_type not in {"regression", "classification"}:
+            raise ValueError("task_type must be regression or classification")
+        if not self.horizon:
+            raise ValueError("label horizon is required")
+        if self.task_type == "classification" and not self.continuous_eval_label:
+            raise ValueError("classification labels require continuous_eval_label")
+
+
+@dataclass(frozen=True)
+class LabelRef:
+    definition: LabelDefinition
+    path: Path
+    digest: str
+
+    @property
+    def name(self) -> str:
+        return self.definition.name
+
+    def load(self) -> pl.DataFrame:
+        if not self.path.exists():
+            raise FileNotFoundError(self.path)
+        return pl.read_parquet(self.path)
+
+
+class LabelCatalog:
+    def __init__(self, study: Study) -> None:
+        self.study = study
+
+    def _path(self, name: str) -> Path:
+        return self.study.root / "labels" / f"{name}.parquet"
+
+    def list(self) -> tuple[LabelRef, ...]:
+        self.study.activate()
+        setup_path = self.study.root / "config" / "setup.yaml"
+        names: set[str] = set()
+        if setup_path.exists():
+            import yaml
+
+            setup = yaml.safe_load(setup_path.read_text()) or {}
+            labels = setup.get("labels") or {}
+            if labels.get("primary"):
+                names.add(str(labels["primary"]))
+            names.update(str(name) for name in labels.get("variants") or [])
+        label_dir = self.study.root / "labels"
+        if label_dir.exists():
+            names.update(path.stem for path in label_dir.glob("*.parquet"))
+        return tuple(self.get(name) for name in sorted(names))
+
+    def get(self, name: str) -> LabelRef:
+        self.study.activate()
+        path = self._path(name)
+        metadata_path = sidecar_path(path)
+        if metadata_path.exists():
+            metadata = json.loads(metadata_path.read_text())
+            raw_definition = metadata.get("definition")
+            if raw_definition:
+                if not path.is_file():
+                    raise FileNotFoundError(f"label sidecar has no artifact: {path}")
+                actual_digest = value_digest(pl.read_parquet(path))
+                if actual_digest != metadata.get("digest"):
+                    raise ValueError(f"label artifact digest does not match its sidecar: {path}")
+                return LabelRef(
+                    definition=LabelDefinition(**raw_definition),
+                    path=path,
+                    digest=actual_digest,
+                )
+
+        import yaml
+
+        setup_path = self.study.root / "config" / "setup.yaml"
+        setup = yaml.safe_load(setup_path.read_text()) if setup_path.exists() else {}
+        labels = (setup or {}).get("labels") or {}
+        configured = {labels.get("primary"), *(labels.get("variants") or [])}
+        if name not in configured:
+            raise KeyError(f"Unknown label {name!r}")
+        continuous = (labels.get("classification_eval_label") or {}).get(name)
+        task_type = "classification" if continuous else "regression"
+        definition = LabelDefinition(
+            name=name,
+            task_type=task_type,
+            horizon=resolve_label_horizon(self.study.case_study, name, setup) or "unknown",
+            continuous_eval_label=continuous,
+        )
+        spec = load_label_spec(self.study.case_study, name)
+        path = resolve_storage_path(self.study.case_study, spec, f"labels/{name}.parquet")
+        if not path.is_file():
+            raise FileNotFoundError(f"label artifact is missing: {path}")
+        resolved_metadata_path = sidecar_path(path)
+        if resolved_metadata_path.exists():
+            metadata = json.loads(resolved_metadata_path.read_text())
+            digest = value_digest(pl.read_parquet(path))
+            if metadata.get("digest") != digest:
+                raise ValueError(f"label artifact digest does not match its sidecar: {path}")
+        else:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+        return LabelRef(definition=definition, path=path, digest=digest)
+
+    def publish(self, definition: LabelDefinition, frame: pl.DataFrame) -> LabelRef:
+        self.study.require_writable()
+        self.study.activate()
+        if not isinstance(frame, pl.DataFrame):
+            raise TypeError("label publication requires a Polars DataFrame")
+        required = {"symbol", "timestamp", definition.name}
+        missing = required - set(frame.columns)
+        if missing:
+            raise ValueError(f"label artifact missing columns: {sorted(missing)}")
+        if frame.select("symbol", "timestamp").null_count().row(0) != (0, 0):
+            raise ValueError("label keys cannot contain nulls")
+        if frame.n_unique(["symbol", "timestamp"]) != frame.height:
+            raise ValueError("label keys must be unique")
+        if not frame.get_column(definition.name).dtype.is_numeric():
+            raise ValueError("label values must be numeric")
+        if definition.task_type == "classification":
+            eval_label = definition.continuous_eval_label
+            assert eval_label is not None
+            if eval_label not in frame.columns:
+                raise ValueError(f"continuous evaluation target {eval_label!r} is missing")
+            if not frame.get_column(eval_label).dtype.is_numeric():
+                raise ValueError("continuous evaluation target must be numeric")
+
+        path = self._path(definition.name)
+        metadata_path = sidecar_path(path)
+        record = digest_sidecar(
+            frame,
+            keys=("symbol", "timestamp"),
+            written_by="case_studies.research.LabelCatalog.publish",
+        )
+        record["definition"] = asdict(definition)
+        if path.exists() or metadata_path.exists():
+            if path.exists() and metadata_path.exists():
+                existing = json.loads(metadata_path.read_text())
+                if existing == record:
+                    return LabelRef(definition, path, str(record["digest"]))
+            raise FileExistsError(f"immutable label artifact already exists: {path}")
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        token = uuid.uuid4().hex
+        parquet_tmp = path.with_name(f".{path.name}.{token}.tmp")
+        metadata_tmp = metadata_path.with_name(f".{metadata_path.name}.{token}.tmp")
+        try:
+            frame.write_parquet(parquet_tmp)
+            metadata_tmp.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+            os.replace(metadata_tmp, metadata_path)
+            try:
+                os.replace(parquet_tmp, path)
+            except Exception:
+                metadata_path.unlink(missing_ok=True)
+                raise
+        finally:
+            parquet_tmp.unlink(missing_ok=True)
+            metadata_tmp.unlink(missing_ok=True)
+        return LabelRef(definition, path, str(record["digest"]))

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from case_studies.utils.registry.specs import canonical_json, compute_hash
+from case_studies.utils.registry.specs import (
+    canonical_json,
+    compute_hash,
+    project_training_identity,
+    training_hash_from_spec,
+)
 from case_studies.utils.registry.store import _open_registry, _utc_now
 
 from .comparison import CandidateSet
@@ -22,6 +28,32 @@ class ResearchLock:
     hash: str
     state: str
     record: dict[str, Any]
+
+
+def _locked_training_spec(validation_spec: dict[str, Any], holdout_spec: dict[str, Any]) -> dict:
+    projected_validation = project_training_identity(validation_spec)
+    projected_holdout = project_training_identity(holdout_spec)
+    if projected_holdout.get("execution_tier") != "canonical":
+        raise ValueError("holdout retraining must use the canonical execution tier")
+    validation_cv = projected_validation.pop("cv", None)
+    holdout_cv = projected_holdout.pop("cv", None)
+    if holdout_cv is None or holdout_cv == validation_cv:
+        raise ValueError("holdout retraining requires an explicit, distinct CV interval")
+    if projected_holdout != projected_validation:
+        raise ValueError("holdout retraining may differ from selected training only in CV interval")
+    return project_training_identity(holdout_spec)
+
+
+def _locked_strategy_projection(spec: dict[str, Any]) -> dict[str, Any]:
+    projected = deepcopy(spec)
+    projected.pop("_runtime_backtest_config", None)
+    metadata = projected.get("backtest_config", {}).get("metadata")
+    if isinstance(metadata, dict):
+        metadata.pop("prediction_hash", None)
+    input_identity = projected.get("input_identity")
+    if isinstance(input_identity, dict):
+        input_identity.pop("prices", None)
+    return projected
 
 
 class Lifecycle:
@@ -48,6 +80,7 @@ class Lifecycle:
         candidate_set_hash: str,
         selected_backtest_hash: str,
         selection_evidence: dict[str, Any],
+        holdout_training_spec: dict[str, Any],
     ) -> ResearchLock:
         self.study.require_writable()
         self.study.activate()
@@ -68,6 +101,8 @@ class Lifecycle:
         training = Result.open(self.study, prediction_record["training_hash"])
         assert isinstance(training, TrainingResult)
         training_record = training.registry_record()
+        locked_holdout_spec = _locked_training_spec(training.spec(), holdout_training_spec)
+        holdout_training_hash = training_hash_from_spec(locked_holdout_spec)
         lock_record = {
             "candidate_set_hash": candidates.hash,
             "selection_evidence": selection_evidence,
@@ -76,6 +111,8 @@ class Lifecycle:
             "feature_artifacts": training.spec().get("feature_artifacts"),
             "cv": training.spec().get("cv"),
             "training_hash": training.hash,
+            "holdout_training_hash": holdout_training_hash,
+            "holdout_training_spec": locked_holdout_spec,
             "prediction_hash": prediction.hash,
             "checkpoint_kind": prediction_record["checkpoint_kind"],
             "checkpoint_value": prediction_record["checkpoint_value"],
@@ -137,16 +174,26 @@ class Lifecycle:
             isinstance(training, TrainingResult)
             and training.complete
             and training.execution_tier == "canonical"
+            and training.hash == lock.record["holdout_training_hash"]
+            and project_training_identity(training.spec()) == lock.record["holdout_training_spec"]
             and isinstance(prediction, PredictionResult)
             and prediction.complete
+            and prediction.execution_tier == "canonical"
             and prediction.registry_record()["split"] == "holdout"
             and prediction.registry_record()["training_hash"] == training.hash
+            and prediction.registry_record()["checkpoint_kind"] == lock.record["checkpoint_kind"]
+            and prediction.registry_record()["checkpoint_value"] == lock.record["checkpoint_value"]
             and isinstance(backtest, BacktestResult)
             and backtest.complete
+            and backtest.execution_tier == "canonical"
             and backtest.registry_record()["prediction_hash"] == prediction.hash
+            and _locked_strategy_projection(backtest.spec())
+            == _locked_strategy_projection(lock.record["strategy_spec"])
         )
         if not valid:
-            raise ValueError("holdout transition requires one complete canonical holdout lineage")
+            raise ValueError(
+                "holdout transition requires the exact complete canonical lineage in the lock"
+            )
 
         db = _open_registry(self.study.root)
         try:

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.registry.specs import canonical_json, compute_hash
+from case_studies.utils.registry.store import _open_registry, _utc_now
+
+from .comparison import CandidateSet
+from .contracts import LifecycleState
+from .results import BacktestResult, PredictionResult, Result, TrainingResult
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class ResearchLock:
+    study: Study
+    hash: str
+    state: str
+    record: dict[str, Any]
+
+
+class Lifecycle:
+    def __init__(self, study: Study) -> None:
+        self.study = study
+
+    @property
+    def state(self) -> str:
+        db_path = self.study.root / "run_log" / "registry.db"
+        if not db_path.exists():
+            return LifecycleState.DEVELOPMENT.value
+        with sqlite3.connect(db_path) as db:
+            exists = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'research_locks'"
+            ).fetchone()
+            if exists is None:
+                return LifecycleState.DEVELOPMENT.value
+            row = db.execute("SELECT state FROM research_locks LIMIT 1").fetchone()
+        return row[0] if row else LifecycleState.DEVELOPMENT.value
+
+    def lock(
+        self,
+        *,
+        candidate_set_hash: str,
+        selected_backtest_hash: str,
+        selection_evidence: dict[str, Any],
+    ) -> ResearchLock:
+        self.study.require_writable()
+        self.study.activate()
+        candidates = CandidateSet.open(self.study, candidate_set_hash)
+        if candidates.member_kind != "backtest" or selected_backtest_hash not in candidates.members:
+            raise ValueError("selected backtest must be an exact member of the candidate set")
+        if candidates.best_validation_sharpe().hash != selected_backtest_hash:
+            raise ValueError("research lock must select highest validation backtest Sharpe")
+        selected = Result.open(self.study, selected_backtest_hash)
+        if not isinstance(selected, BacktestResult) or not selected.complete:
+            raise ValueError("lock requires a complete backtest")
+        if selected.execution_tier != "canonical":
+            raise ValueError("preview ancestry cannot enter a lock")
+        backtest_record = selected.registry_record()
+        prediction = Result.open(self.study, backtest_record["prediction_hash"])
+        assert isinstance(prediction, PredictionResult)
+        prediction_record = prediction.registry_record()
+        training = Result.open(self.study, prediction_record["training_hash"])
+        assert isinstance(training, TrainingResult)
+        training_record = training.registry_record()
+        lock_record = {
+            "candidate_set_hash": candidates.hash,
+            "selection_evidence": selection_evidence,
+            "label": training.spec().get("label"),
+            "label_artifact": training.spec().get("label_artifact"),
+            "feature_artifacts": training.spec().get("feature_artifacts"),
+            "cv": training.spec().get("cv"),
+            "training_hash": training.hash,
+            "prediction_hash": prediction.hash,
+            "checkpoint_kind": prediction_record["checkpoint_kind"],
+            "checkpoint_value": prediction_record["checkpoint_value"],
+            "validation_backtest_hash": selected.hash,
+            "strategy_spec": selected.spec(),
+            "source_identity": training_record.get("git_commit"),
+            "runtime_provenance": json.loads(training_record.get("runtime_json") or "{}"),
+        }
+        lock_hash = compute_hash(canonical_json(lock_record))
+        db = _open_registry(self.study.root)
+        try:
+            db.execute("BEGIN IMMEDIATE")
+            if db.execute("SELECT 1 FROM research_locks LIMIT 1").fetchone() is not None:
+                raise ValueError("lifecycle can lock only from DEVELOPMENT")
+            db.execute(
+                "INSERT INTO research_locks (lock_hash, lock_json, state, created_at) "
+                "VALUES (?,?,?,?)",
+                (
+                    lock_hash,
+                    canonical_json(lock_record),
+                    LifecycleState.LOCKED.value,
+                    _utc_now(),
+                ),
+            )
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+        return ResearchLock(self.study, lock_hash, LifecycleState.LOCKED.value, lock_record)
+
+    def open(self, lock_hash: str) -> ResearchLock:
+        with sqlite3.connect(self.study.root / "run_log" / "registry.db") as db:
+            row = db.execute(
+                "SELECT lock_json, state FROM research_locks WHERE lock_hash = ?", (lock_hash,)
+            ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown research lock {lock_hash!r}")
+        return ResearchLock(self.study, lock_hash, row[1], json.loads(row[0]))
+
+    def record_holdout(
+        self,
+        lock_hash: str,
+        *,
+        holdout_training_hash: str,
+        holdout_prediction_hash: str,
+        holdout_backtest_hash: str,
+    ) -> ResearchLock:
+        self.study.require_writable()
+        self.study.activate()
+        lock = self.open(lock_hash)
+        if lock.state != LifecycleState.LOCKED.value:
+            raise ValueError("holdout evaluation requires a LOCKED research lock")
+        training = Result.open(self.study, holdout_training_hash)
+        prediction = Result.open(self.study, holdout_prediction_hash)
+        backtest = Result.open(self.study, holdout_backtest_hash)
+        valid = (
+            isinstance(training, TrainingResult)
+            and training.complete
+            and training.execution_tier == "canonical"
+            and isinstance(prediction, PredictionResult)
+            and prediction.complete
+            and prediction.registry_record()["split"] == "holdout"
+            and prediction.registry_record()["training_hash"] == training.hash
+            and isinstance(backtest, BacktestResult)
+            and backtest.complete
+            and backtest.registry_record()["prediction_hash"] == prediction.hash
+        )
+        if not valid:
+            raise ValueError("holdout transition requires one complete canonical holdout lineage")
+
+        db = _open_registry(self.study.root)
+        try:
+            db.execute("BEGIN IMMEDIATE")
+            state = db.execute(
+                "SELECT state FROM research_locks WHERE lock_hash = ?", (lock_hash,)
+            ).fetchone()
+            if state != (LifecycleState.LOCKED.value,):
+                raise ValueError("research lock is not available for holdout evaluation")
+            db.execute(
+                "INSERT INTO holdout_evaluations "
+                "(lock_hash, holdout_training_hash, holdout_prediction_hash, "
+                "holdout_backtest_hash, evaluated_at) VALUES (?,?,?,?,?)",
+                (
+                    lock_hash,
+                    training.hash,
+                    prediction.hash,
+                    backtest.hash,
+                    _utc_now(),
+                ),
+            )
+            updated = db.execute(
+                "UPDATE research_locks SET state = ? WHERE lock_hash = ? AND state = ?",
+                (
+                    LifecycleState.HOLDOUT_EVALUATED.value,
+                    lock_hash,
+                    LifecycleState.LOCKED.value,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise ValueError("research lock transition lost an atomicity race")
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+        return self.open(lock_hash)

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -19,6 +19,7 @@ from case_studies.utils.registry.store import _open_registry, _utc_now
 from .comparison import CandidateSet
 from .contracts import LifecycleState
 from .results import BacktestResult, PredictionResult, Result, TrainingResult
+from .strategy import strategy_warmup_periods
 
 if TYPE_CHECKING:
     from .workspace import Study
@@ -176,6 +177,7 @@ class Lifecycle:
             self.study.case_study,
             str(lock.record["label"]),
             split="holdout",
+            warmup_periods=strategy_warmup_periods(lock.record["strategy_spec"]),
         )
         canonical_price_digest = value_digest(canonical_holdout_prices)
         valid = (

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import load_backtest_prices_for
 from case_studies.utils.registry.specs import (
     canonical_json,
     compute_hash,
@@ -170,6 +172,12 @@ class Lifecycle:
         training = Result.open(self.study, holdout_training_hash)
         prediction = Result.open(self.study, holdout_prediction_hash)
         backtest = Result.open(self.study, holdout_backtest_hash)
+        canonical_holdout_prices = load_backtest_prices_for(
+            self.study.case_study,
+            str(lock.record["label"]),
+            split="holdout",
+        )
+        canonical_price_digest = value_digest(canonical_holdout_prices)
         valid = (
             isinstance(training, TrainingResult)
             and training.complete
@@ -187,6 +195,7 @@ class Lifecycle:
             and backtest.complete
             and backtest.execution_tier == "canonical"
             and backtest.registry_record()["prediction_hash"] == prediction.hash
+            and backtest.spec().get("input_identity", {}).get("prices") == canonical_price_digest
             and _locked_strategy_projection(backtest.spec())
             == _locked_strategy_projection(lock.record["strategy_spec"])
         )

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.registry import register_prediction_set, register_training_run
+
+from .contracts import ExecutionTier
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+def _record(db: sqlite3.Connection, query: str, params: tuple) -> dict[str, Any] | None:
+    cursor = db.execute(query, params)
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return dict(zip((column[0] for column in cursor.description), row, strict=True))
+
+
+@dataclass(frozen=True)
+class Result:
+    study: Study
+    hash: str
+    kind: str
+    execution_tier: str
+    identity_version: int | None
+
+    @classmethod
+    def open(
+        cls,
+        study: Study,
+        result_hash: str,
+        *,
+        include_preview: bool = False,
+    ) -> Result:
+        roots = [(study.root, ExecutionTier.CANONICAL.value)]
+        if include_preview and not study.read_only and study.output_root is not None:
+            roots.append(
+                (study.output_root / ".preview" / study.case_study, ExecutionTier.PREVIEW.value)
+            )
+        for root, namespace in roots:
+            db_path = root / "run_log" / "registry.db"
+            if not db_path.exists():
+                continue
+            with sqlite3.connect(db_path) as db:
+                tables = {
+                    row[0]
+                    for row in db.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    ).fetchall()
+                }
+                if "training_runs" not in tables:
+                    continue
+                training = _record(
+                    db,
+                    "SELECT identity_version, execution_tier FROM training_runs "
+                    "WHERE training_hash = ?",
+                    (result_hash,),
+                )
+                if training is not None:
+                    tier = training["execution_tier"] or namespace
+                    return TrainingResult(
+                        study, result_hash, "training", tier, training["identity_version"]
+                    )
+                prediction = _record(
+                    db,
+                    """
+                    SELECT t.identity_version, t.execution_tier
+                    FROM prediction_sets p
+                    JOIN training_runs t ON t.training_hash = p.training_hash
+                    WHERE p.prediction_hash = ?
+                    """,
+                    (result_hash,),
+                )
+                if prediction is not None:
+                    tier = prediction["execution_tier"] or namespace
+                    return PredictionResult(
+                        study, result_hash, "prediction", tier, prediction["identity_version"]
+                    )
+                backtest = _record(
+                    db,
+                    """
+                    SELECT t.identity_version, t.execution_tier
+                    FROM backtest_runs b
+                    JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
+                    JOIN training_runs t ON t.training_hash = p.training_hash
+                    WHERE b.backtest_hash = ?
+                    """,
+                    (result_hash,),
+                )
+                if backtest is not None:
+                    tier = backtest["execution_tier"] or namespace
+                    return BacktestResult(
+                        study, result_hash, "backtest", tier, backtest["identity_version"]
+                    )
+        raise KeyError(f"Unknown result hash {result_hash!r}")
+
+    @property
+    def root(self) -> Path:
+        return self.study.storage_root(self.execution_tier)
+
+    @property
+    def complete(self) -> bool:
+        return False
+
+    def registry_record(self) -> dict[str, Any]:
+        table, key = {
+            "training": ("training_runs", "training_hash"),
+            "prediction": ("prediction_sets", "prediction_hash"),
+            "backtest": ("backtest_runs", "backtest_hash"),
+        }[self.kind]
+        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+            record = _record(db, f"SELECT * FROM {table} WHERE {key} = ?", (self.hash,))
+        assert record is not None
+        return record
+
+    def spec(self) -> dict[str, Any]:
+        record = self.registry_record()
+        if self.kind == "prediction":
+            return {
+                "training_hash": record["training_hash"],
+                "checkpoint_kind": record["checkpoint_kind"],
+                "checkpoint_value": record["checkpoint_value"],
+                "split": record["split"],
+            }
+        return json.loads(record.get("spec_json") or "{}")
+
+    def artifacts(self) -> tuple[Path, ...]:
+        directory = (
+            self.root
+            / "run_log"
+            / {
+                "training": "training",
+                "prediction": "predictions",
+                "backtest": "backtest",
+            }[self.kind]
+            / self.hash
+        )
+        if not directory.exists():
+            return ()
+        return tuple(sorted(path for path in directory.rglob("*") if path.is_file()))
+
+    def lineage(self) -> dict[str, Any]:
+        if self.kind == "training":
+            return {"training_hash": self.hash, "training_spec": self.spec()}
+        record = self.registry_record()
+        if self.kind == "prediction":
+            training = Result.open(
+                self.study,
+                record["training_hash"],
+                include_preview=self.execution_tier == ExecutionTier.PREVIEW.value,
+            )
+            return {
+                "training_hash": training.hash,
+                "training_spec": training.spec(),
+                "prediction_hash": self.hash,
+            }
+        prediction = Result.open(
+            self.study,
+            record["prediction_hash"],
+            include_preview=self.execution_tier == ExecutionTier.PREVIEW.value,
+        )
+        return {
+            **prediction.lineage(),
+            "backtest_hash": self.hash,
+            "strategy_spec": self.spec(),
+        }
+
+    def protocol(self) -> dict[str, Any]:
+        lineage = self.lineage()
+        training = lineage["training_spec"]
+        split = None
+        if self.kind == "prediction":
+            split = self.registry_record()["split"]
+        elif self.kind == "backtest":
+            prediction = Result.open(
+                self.study,
+                self.registry_record()["prediction_hash"],
+                include_preview=self.execution_tier == ExecutionTier.PREVIEW.value,
+            )
+            split = prediction.registry_record()["split"]
+        return {
+            "label_artifact": training.get("label_artifact"),
+            "feature_artifacts": training.get("feature_artifacts"),
+            "cv": training.get("cv"),
+            "split": split,
+            "execution_tier": self.execution_tier,
+        }
+
+
+@dataclass(frozen=True)
+class TrainingResult(Result):
+    @property
+    def complete(self) -> bool:
+        return self.identity_version == 2 and bool(self.spec())
+
+
+@dataclass(frozen=True)
+class PredictionResult(Result):
+    def coverage(self) -> dict[str, Any] | None:
+        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+            return _record(
+                db,
+                "SELECT * FROM prediction_coverage WHERE prediction_hash = ?",
+                (self.hash,),
+            )
+
+    @property
+    def complete(self) -> bool:
+        coverage = self.coverage()
+        prediction_file = self.root / "run_log" / "predictions" / self.hash / "predictions.parquet"
+        return bool(coverage and coverage["status"] == "complete" and prediction_file.is_file())
+
+    def load(self):
+        import polars as pl
+
+        path = self.root / "run_log" / "predictions" / self.hash / "predictions.parquet"
+        return pl.read_parquet(path)
+
+
+@dataclass(frozen=True)
+class BacktestResult(Result):
+    @property
+    def complete(self) -> bool:
+        record = self.registry_record()
+        prediction = Result.open(
+            self.study,
+            record["prediction_hash"],
+            include_preview=self.execution_tier == ExecutionTier.PREVIEW.value,
+        )
+        if not isinstance(prediction, PredictionResult) or not prediction.complete:
+            return False
+        returns = self.root / "run_log" / "backtest" / self.hash / "daily_returns.parquet"
+        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+            metrics = db.execute(
+                "SELECT 1 FROM backtest_metrics WHERE backtest_hash = ?", (self.hash,)
+            ).fetchone()
+        return returns.is_file() and metrics is not None
+
+
+class ResultsCatalog:
+    def __init__(self, study: Study) -> None:
+        self.study = study
+
+    def register_training(
+        self,
+        spec: dict[str, Any],
+        *,
+        execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
+        runtime_provenance: dict[str, Any] | None = None,
+    ) -> TrainingResult:
+        self.study.require_writable()
+        tier = ExecutionTier(execution_tier)
+        resolved = dict(spec)
+        resolved.setdefault("identity_version", 2)
+        resolved.setdefault("execution_tier", tier.value)
+        if resolved["identity_version"] != 2 or resolved["execution_tier"] != tier.value:
+            raise ValueError(
+                "training spec identity version or execution tier conflicts with request"
+            )
+        if tier is ExecutionTier.PREVIEW and not resolved.get("preview_reductions"):
+            raise ValueError("preview training specs must identity-cover every preview reduction")
+        if tier is ExecutionTier.CANONICAL and resolved.get("preview_reductions"):
+            raise ValueError("canonical training specs cannot contain preview reductions")
+        case_dir = self.study.activate(tier)
+        training_hash = register_training_run(
+            self.study.case_study,
+            resolved,
+            case_dir=case_dir,
+            runtime_provenance=runtime_provenance,
+        )
+        result = Result.open(
+            self.study,
+            training_hash,
+            include_preview=tier is ExecutionTier.PREVIEW,
+        )
+        assert isinstance(result, TrainingResult)
+        return result
+
+    def publish_predictions(
+        self,
+        training: TrainingResult,
+        *,
+        checkpoint_kind: str,
+        checkpoint_value: int | None,
+        split: str,
+        predictions,
+        expected_keys,
+        allow_partial: bool = False,
+    ) -> PredictionResult:
+        self.study.require_writable()
+        if training.study != self.study or training.kind != "training":
+            raise ValueError("training result belongs to another study")
+        tier = ExecutionTier(training.execution_tier)
+        case_dir = self.study.activate(tier)
+        prediction_hash = register_prediction_set(
+            self.study.case_study,
+            training.hash,
+            checkpoint_kind=checkpoint_kind,
+            checkpoint_value=checkpoint_value,
+            split=split,
+            predictions=predictions,
+            expected_keys=expected_keys,
+            allow_partial=allow_partial,
+            case_dir=case_dir,
+        )
+        result = Result.open(
+            self.study,
+            prediction_hash,
+            include_preview=tier is ExecutionTier.PREVIEW,
+        )
+        assert isinstance(result, PredictionResult)
+        return result
+
+    def open(self, result_hash: str, *, include_preview: bool = False) -> Result:
+        return Result.open(self.study, result_hash, include_preview=include_preview)

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -22,6 +22,26 @@ def _record(db: sqlite3.Connection, query: str, params: tuple) -> dict[str, Any]
     return dict(zip((column[0] for column in cursor.description), row, strict=True))
 
 
+def _columns(db: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in db.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _training_identity_projection(db: sqlite3.Connection, alias: str = "") -> str:
+    columns = _columns(db, "training_runs")
+    prefix = f"{alias}." if alias else ""
+    identity = (
+        f"{prefix}identity_version AS identity_version"
+        if "identity_version" in columns
+        else "NULL AS identity_version"
+    )
+    tier = (
+        f"{prefix}execution_tier AS execution_tier"
+        if "execution_tier" in columns
+        else "NULL AS execution_tier"
+    )
+    return f"{identity}, {tier}"
+
+
 @dataclass(frozen=True)
 class Result:
     study: Study
@@ -56,10 +76,10 @@ class Result:
                 }
                 if "training_runs" not in tables:
                     continue
+                identity_projection = _training_identity_projection(db)
                 training = _record(
                     db,
-                    "SELECT identity_version, execution_tier FROM training_runs "
-                    "WHERE training_hash = ?",
+                    f"SELECT {identity_projection} FROM training_runs WHERE training_hash = ?",
                     (result_hash,),
                 )
                 if training is not None:
@@ -67,32 +87,38 @@ class Result:
                     return TrainingResult(
                         study, result_hash, "training", tier, training["identity_version"]
                     )
-                prediction = _record(
-                    db,
-                    """
-                    SELECT t.identity_version, t.execution_tier
-                    FROM prediction_sets p
-                    JOIN training_runs t ON t.training_hash = p.training_hash
-                    WHERE p.prediction_hash = ?
-                    """,
-                    (result_hash,),
-                )
+                prediction = None
+                if "prediction_sets" in tables:
+                    identity_projection = _training_identity_projection(db, "t")
+                    prediction = _record(
+                        db,
+                        f"""
+                        SELECT {identity_projection}
+                        FROM prediction_sets p
+                        JOIN training_runs t ON t.training_hash = p.training_hash
+                        WHERE p.prediction_hash = ?
+                        """,
+                        (result_hash,),
+                    )
                 if prediction is not None:
                     tier = prediction["execution_tier"] or namespace
                     return PredictionResult(
                         study, result_hash, "prediction", tier, prediction["identity_version"]
                     )
-                backtest = _record(
-                    db,
-                    """
-                    SELECT t.identity_version, t.execution_tier
-                    FROM backtest_runs b
-                    JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
-                    JOIN training_runs t ON t.training_hash = p.training_hash
-                    WHERE b.backtest_hash = ?
-                    """,
-                    (result_hash,),
-                )
+                backtest = None
+                if {"prediction_sets", "backtest_runs"} <= tables:
+                    identity_projection = _training_identity_projection(db, "t")
+                    backtest = _record(
+                        db,
+                        f"""
+                        SELECT {identity_projection}
+                        FROM backtest_runs b
+                        JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
+                        JOIN training_runs t ON t.training_hash = p.training_hash
+                        WHERE b.backtest_hash = ?
+                        """,
+                        (result_hash,),
+                    )
                 if backtest is not None:
                     tier = backtest["execution_tier"] or namespace
                     return BacktestResult(
@@ -204,6 +230,11 @@ class TrainingResult(Result):
 class PredictionResult(Result):
     def coverage(self) -> dict[str, Any] | None:
         with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+            exists = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'prediction_coverage'"
+            ).fetchone()
+            if exists is None:
+                return None
             return _record(
                 db,
                 "SELECT * FROM prediction_coverage WHERE prediction_hash = ?",

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -13,6 +13,7 @@ from case_studies.utils.backtest_loaders import (
     get_backtest_config,
     load_backtest_prices_for,
     load_contract_specs_from_yaml,
+    warmup_periods_for,
 )
 from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
 from case_studies.utils.backtest_runner import run_backtest
@@ -28,6 +29,22 @@ from .results import BacktestResult, PredictionResult, Result
 
 if TYPE_CHECKING:
     from .workspace import Study
+
+
+_MOMENT_ALLOCATORS = {"inverse_vol", "risk_parity", "hrp", "mvo", "mvo_ledoit_wolf"}
+
+
+def strategy_warmup_periods(strategy_spec: dict[str, Any]) -> int:
+    strategy = strategy_spec.get("strategy", strategy_spec)
+    allocation = strategy.get("allocation") or {}
+    method = allocation.get("method")
+    if method not in _MOMENT_ALLOCATORS:
+        return 0
+    key = "lookback" if method in {"mvo", "mvo_ledoit_wolf"} else "vol_window"
+    value = allocation.get(key, allocation.get("lookback"))
+    if value is None:
+        raise ValueError(f"rolling allocator {method!r} has no resolved {key}")
+    return int(value)
 
 
 @dataclass(frozen=True)
@@ -116,6 +133,23 @@ class Strategy:
     def label(self) -> str:
         return str(self.prediction.lineage()["training_spec"]["label"])
 
+    def _resolved_allocation(self) -> dict[str, Any] | None:
+        if self.allocation is None:
+            return None
+        allocation = deepcopy(self.allocation)
+        method = allocation.get("method")
+        if method in _MOMENT_ALLOCATORS:
+            lookback = warmup_periods_for(self.study.case_study)
+            if lookback <= 0 and not any(key in allocation for key in ("vol_window", "lookback")):
+                raise ValueError(f"rolling allocator {method!r} has no configured lookback")
+            key = "lookback" if method in {"mvo", "mvo_ledoit_wolf"} else "vol_window"
+            allocation.setdefault(key, lookback)
+        return allocation
+
+    def _warmup_periods(self) -> int:
+        allocation = self._resolved_allocation()
+        return strategy_warmup_periods({"allocation": allocation}) if allocation else 0
+
     def resolve(self, *, prices: pl.DataFrame | None = None) -> dict[str, Any]:
         self.study.activate(ExecutionTier.CANONICAL)
         if self.split == "holdout" and prices is not None:
@@ -124,7 +158,10 @@ class Strategy:
         resolved_prices = prices
         if resolved_prices is None:
             resolved_prices = load_backtest_prices_for(
-                self.study.case_study, self.label, split=self.split
+                self.study.case_study,
+                self.label,
+                split=self.split,
+                warmup_periods=self._warmup_periods(),
             )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
@@ -139,7 +176,7 @@ class Strategy:
             prediction_hash=self.prediction.hash,
             initial_cash=case_config.initial_cash,
             signal=self.signal,
-            allocation=self.allocation,
+            allocation=self._resolved_allocation(),
             risk=self.risk,
             costs=self.costs,
             chapter=self.chapter,
@@ -177,7 +214,10 @@ class Strategy:
         self.study.activate(ExecutionTier.CANONICAL)
         if resolved_prices is None:
             resolved_prices = load_backtest_prices_for(
-                self.study.case_study, self.label, split=self.split
+                self.study.case_study,
+                self.label,
+                split=self.split,
+                warmup_periods=self._warmup_periods(),
             )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -13,7 +13,6 @@ from case_studies.utils.backtest_loaders import (
     get_backtest_config,
     load_backtest_prices_for,
     load_contract_specs_from_yaml,
-    warmup_periods_for,
 )
 from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
 from case_studies.utils.backtest_runner import run_backtest
@@ -23,6 +22,7 @@ from case_studies.utils.conformal import (
     holdout_conformal_embargo_steps,
 )
 from case_studies.utils.registry import backtest_hash_from_parts, canonical_json, compute_hash
+from case_studies.utils.sweep_config import get_allocator_lookback
 
 from .contracts import ExecutionTier
 from .results import BacktestResult, PredictionResult, Result
@@ -139,11 +139,11 @@ class Strategy:
         allocation = deepcopy(self.allocation)
         method = allocation.get("method")
         if method in _MOMENT_ALLOCATORS:
-            lookback = warmup_periods_for(self.study.case_study)
-            if lookback <= 0 and not any(key in allocation for key in ("vol_window", "lookback")):
-                raise ValueError(f"rolling allocator {method!r} has no configured lookback")
-            key = "lookback" if method in {"mvo", "mvo_ledoit_wolf"} else "vol_window"
-            allocation.setdefault(key, lookback)
+            if method in {"mvo", "mvo_ledoit_wolf"}:
+                if "lookback" not in allocation:
+                    allocation["lookback"] = get_allocator_lookback(self.study.case_study)
+            elif not any(key in allocation for key in ("vol_window", "lookback")):
+                allocation["vol_window"] = get_allocator_lookback(self.study.case_study)
         return allocation
 
     def _warmup_periods(self) -> int:

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 from copy import deepcopy
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import polars as pl
 
@@ -14,6 +16,7 @@ from case_studies.utils.backtest_loaders import (
 )
 from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
 from case_studies.utils.backtest_runner import run_backtest
+from case_studies.utils.conformal import ensure_conformal_calibration_identity
 from case_studies.utils.registry import backtest_hash_from_parts, canonical_json, compute_hash
 
 from .contracts import ExecutionTier
@@ -36,13 +39,42 @@ class Strategy:
     min_weight_change: float | None = None
     min_trade_value: float | None = None
 
+    def _active_lock_record(self) -> dict[str, Any]:
+        db_path = self.study.root / "run_log" / "registry.db"
+        with sqlite3.connect(db_path) as db:
+            row = db.execute(
+                "SELECT lock_json FROM research_locks WHERE state = 'LOCKED' LIMIT 1"
+            ).fetchone()
+        if row is None:
+            raise ValueError("holdout strategy execution requires a LOCKED research lock")
+        return json.loads(row[0])
+
     def __post_init__(self) -> None:
         if self.prediction.study != self.study:
             raise ValueError("prediction belongs to another study")
         if not self.prediction.complete:
             raise ValueError("partial predictions cannot enter strategy execution")
-        if self.prediction.registry_record()["split"] != "validation":
-            raise ValueError("development strategy execution requires validation predictions")
+        prediction_record = self.prediction.registry_record()
+        split = prediction_record["split"]
+        if split == "validation":
+            return
+        if split != "holdout" or self.prediction.execution_tier != "canonical":
+            raise ValueError("strategy execution requires validation or locked holdout predictions")
+        lock_record = self._active_lock_record()
+        matches_lock = (
+            prediction_record["training_hash"] == lock_record.get("holdout_training_hash")
+            and prediction_record["checkpoint_kind"] == lock_record.get("checkpoint_kind")
+            and prediction_record["checkpoint_value"] == lock_record.get("checkpoint_value")
+        )
+        if not matches_lock:
+            raise ValueError("holdout prediction does not match the locked retraining contract")
+
+    @property
+    def split(self) -> Literal["validation", "holdout"]:
+        split = self.prediction.registry_record()["split"]
+        if split not in {"validation", "holdout"}:
+            raise ValueError(f"unsupported prediction split {split!r}")
+        return split
 
     @classmethod
     def from_request(cls, study: Study, request: dict[str, Any]) -> Strategy:
@@ -86,7 +118,7 @@ class Strategy:
         resolved_prices = prices
         if resolved_prices is None:
             resolved_prices = load_backtest_prices_for(
-                self.study.case_study, self.label, split="validation"
+                self.study.case_study, self.label, split=self.split
             )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
@@ -117,7 +149,14 @@ class Strategy:
                 symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
             }
             spec["input_identity"]["contract_specs"] = compute_hash(canonical_json(serialized))
-        return spec
+        resolved = ensure_conformal_calibration_identity(spec)
+        if self.split == "holdout":
+            from .lifecycle import _locked_strategy_projection
+
+            locked = self._active_lock_record()["strategy_spec"]
+            if _locked_strategy_projection(resolved) != _locked_strategy_projection(locked):
+                raise ValueError("holdout strategy does not match the locked validation strategy")
+        return resolved
 
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:
         spec = self.resolve(prices=prices)
@@ -130,7 +169,7 @@ class Strategy:
         self.study.activate(ExecutionTier.CANONICAL)
         if resolved_prices is None:
             resolved_prices = load_backtest_prices_for(
-                self.study.case_study, self.label, split="validation"
+                self.study.case_study, self.label, split=self.split
             )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import (
+    get_backtest_config,
+    load_backtest_prices_for,
+    load_contract_specs_from_yaml,
+)
+from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
+from case_studies.utils.backtest_runner import run_backtest
+from case_studies.utils.registry import backtest_hash_from_parts, canonical_json, compute_hash
+
+from .contracts import ExecutionTier
+from .results import BacktestResult, PredictionResult, Result
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class Strategy:
+    study: Study
+    prediction: PredictionResult
+    signal: dict[str, Any]
+    allocation: dict[str, Any] | None = None
+    risk: dict[str, Any] | None = None
+    costs: dict[str, Any] | None = None
+    chapter: str | None = None
+    execution_mode: str | None = None
+    min_weight_change: float | None = None
+    min_trade_value: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.prediction.study != self.study:
+            raise ValueError("prediction belongs to another study")
+        if not self.prediction.complete:
+            raise ValueError("partial predictions cannot enter strategy execution")
+        if self.prediction.registry_record()["split"] != "validation":
+            raise ValueError("development strategy execution requires validation predictions")
+
+    @classmethod
+    def from_request(cls, study: Study, request: dict[str, Any]) -> Strategy:
+        supported = {
+            "prediction",
+            "signal",
+            "allocation",
+            "risk",
+            "costs",
+            "chapter",
+            "execution_mode",
+            "min_weight_change",
+            "min_trade_value",
+        }
+        unknown = set(request) - supported
+        if unknown:
+            raise ValueError(f"unsupported strategy request fields: {sorted(unknown)}")
+        prediction = request.get("prediction")
+        if not isinstance(prediction, PredictionResult):
+            raise TypeError("strategy request requires one PredictionResult")
+        return cls(
+            study=study,
+            prediction=prediction,
+            signal=deepcopy(request.get("signal") or {}),
+            allocation=deepcopy(request.get("allocation")),
+            risk=deepcopy(request.get("risk")),
+            costs=deepcopy(request.get("costs")),
+            chapter=request.get("chapter"),
+            execution_mode=request.get("execution_mode"),
+            min_weight_change=request.get("min_weight_change"),
+            min_trade_value=request.get("min_trade_value"),
+        )
+
+    @property
+    def label(self) -> str:
+        return str(self.prediction.lineage()["training_spec"]["label"])
+
+    def resolve(self, *, prices: pl.DataFrame | None = None) -> dict[str, Any]:
+        self.study.activate(ExecutionTier.CANONICAL)
+        case_config = get_backtest_config(self.study.case_study)
+        resolved_prices = prices
+        if resolved_prices is None:
+            resolved_prices = load_backtest_prices_for(
+                self.study.case_study, self.label, split="validation"
+            )
+        contract_specs = (
+            load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
+        )
+        return self._build_spec(resolved_prices, case_config, contract_specs)
+
+    def _build_spec(self, prices, case_config, contract_specs) -> dict[str, Any]:
+        spec = build_backtest_spec(
+            self.study.case_study,
+            case_config,
+            prices=prices,
+            prediction_hash=self.prediction.hash,
+            initial_cash=case_config.initial_cash,
+            signal=self.signal,
+            allocation=self.allocation,
+            risk=self.risk,
+            costs=self.costs,
+            chapter=self.chapter,
+            execution_mode=self.execution_mode,
+            min_weight_change=self.min_weight_change,
+            min_trade_value=self.min_trade_value,
+        )
+        spec["identity_version"] = 2
+        spec["execution_tier"] = self.prediction.execution_tier
+        spec["input_identity"] = {"prices": value_digest(prices)}
+        if contract_specs is not None:
+            serialized = {
+                symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
+            }
+            spec["input_identity"]["contract_specs"] = compute_hash(canonical_json(serialized))
+        return spec
+
+    def identity(self, *, prices: pl.DataFrame | None = None) -> str:
+        spec = self.resolve(prices=prices)
+        return backtest_hash_from_parts(self.prediction.hash, spec, identity_version=2)
+
+    def run(self, *, prices: pl.DataFrame | None = None) -> BacktestResult:
+        self.study.require_writable()
+        predictions = self.prediction.load()
+        resolved_prices = prices
+        self.study.activate(ExecutionTier.CANONICAL)
+        if resolved_prices is None:
+            resolved_prices = load_backtest_prices_for(
+                self.study.case_study, self.label, split="validation"
+            )
+        contract_specs = (
+            load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
+        )
+        case_config = get_backtest_config(self.study.case_study)
+        spec = self._build_spec(resolved_prices, case_config, contract_specs)
+        tier = ExecutionTier(self.prediction.execution_tier)
+        self.study.activate(tier)
+        result = run_backtest(
+            self.study.case_study,
+            self.prediction.hash,
+            spec,
+            prices=resolved_prices,
+            predictions=predictions,
+            label=self.label,
+            initial_cash=float(spec["backtest_config"]["cash"]["initial"]),
+            calendar=case_config.calendar,
+            contract_specs=contract_specs,
+        )
+        expected_hash = backtest_hash_from_parts(
+            self.prediction.hash,
+            serializable_backtest_spec(spec),
+            identity_version=2,
+        )
+        if result.backtest_hash != expected_hash:
+            raise RuntimeError(
+                f"backtest identity changed during execution: {expected_hash} -> "
+                f"{result.backtest_hash}"
+            )
+        reopened = Result.open(
+            self.study,
+            expected_hash,
+            include_preview=tier is ExecutionTier.PREVIEW,
+        )
+        assert isinstance(reopened, BacktestResult)
+        return reopened

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -16,7 +16,11 @@ from case_studies.utils.backtest_loaders import (
 )
 from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
 from case_studies.utils.backtest_runner import run_backtest
-from case_studies.utils.conformal import ensure_conformal_calibration_identity
+from case_studies.utils.conformal import (
+    compute_holdout_conformal_widths,
+    ensure_conformal_calibration_identity,
+    holdout_conformal_embargo_steps,
+)
 from case_studies.utils.registry import backtest_hash_from_parts, canonical_json, compute_hash
 
 from .contracts import ExecutionTier
@@ -114,6 +118,8 @@ class Strategy:
 
     def resolve(self, *, prices: pl.DataFrame | None = None) -> dict[str, Any]:
         self.study.activate(ExecutionTier.CANONICAL)
+        if self.split == "holdout" and prices is not None:
+            raise ValueError("locked holdout strategy must load canonical holdout prices")
         case_config = get_backtest_config(self.study.case_study)
         resolved_prices = prices
         if resolved_prices is None:
@@ -164,6 +170,8 @@ class Strategy:
 
     def run(self, *, prices: pl.DataFrame | None = None) -> BacktestResult:
         self.study.require_writable()
+        if self.split == "holdout" and prices is not None:
+            raise ValueError("locked holdout strategy must load canonical holdout prices")
         predictions = self.prediction.load()
         resolved_prices = prices
         self.study.activate(ExecutionTier.CANONICAL)
@@ -176,6 +184,18 @@ class Strategy:
         )
         case_config = get_backtest_config(self.study.case_study)
         spec = self._build_spec(resolved_prices, case_config, contract_specs)
+        allocation = spec.get("strategy", {}).get("allocation", {})
+        if self.split == "holdout" and allocation.get("method") == "conformal_weighted":
+            lock_record = self._active_lock_record()
+            compute_holdout_conformal_widths(
+                self.study.case_study,
+                lock_record["prediction_hash"],
+                self.prediction.hash,
+                alpha=float(allocation.get("alpha", 0.2)),
+                min_calibration_n=int(allocation["min_calibration_n"]),
+                embargo_steps=holdout_conformal_embargo_steps(self.study.case_study, self.label),
+                write=True,
+            )
         tier = ExecutionTier(self.prediction.execution_tier)
         self.study.activate(tier)
         result = run_backtest(

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scripts.create_experiment import create_experiment
+from utils.paths import REPO_ROOT
+
+from .contracts import ExecutionTier
+
+if TYPE_CHECKING:
+    from .labels import LabelCatalog
+    from .lifecycle import Lifecycle
+    from .results import ResultsCatalog
+    from .strategy import Strategy
+
+
+_ACTIVE_OUTPUT_ROOT: Path | None = None
+
+
+def _release_manifest_digest(case_dir: Path) -> str:
+    release_manifest = case_dir / "run_log" / ".release" / "SHA256SUMS"
+    if release_manifest.exists():
+        return hashlib.sha256(release_manifest.read_bytes()).hexdigest()
+    digest = hashlib.sha256()
+    for path in sorted(p for p in case_dir.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(case_dir)).encode())
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _source_commit(release_root: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def _clear_root_sensitive_caches() -> None:
+    from case_studies.utils import backtest_loaders, cv_window
+    from case_studies.utils.registry import specs
+    from utils import artifact_specs
+
+    for cached in (
+        artifact_specs._load_setup_config_cached,
+        artifact_specs._load_market_data_spec_cached,
+        artifact_specs._load_label_spec_cached,
+        artifact_specs._load_feature_spec_cached,
+        cv_window._load_setup_yaml,
+        cv_window._fold_splits,
+        cv_window._holdout_window,
+        backtest_loaders._load_backtest_preset_config,
+        backtest_loaders._load_case_setup_yaml,
+    ):
+        cached.cache_clear()
+    specs._CONFIG_DIR = None
+
+
+@dataclass(frozen=True)
+class Study:
+    case_study: str
+    root: Path
+    release_root: Path
+    output_root: Path | None
+    read_only: bool
+    manifest: dict
+
+    @classmethod
+    def open(
+        cls,
+        case_study: str,
+        workspace: str | Path | None = None,
+        *,
+        release_root: str | Path = REPO_ROOT,
+    ) -> Study:
+        release_root = Path(release_root).expanduser().resolve()
+        release_case_dir = release_root / "case_studies" / case_study
+        if not release_case_dir.is_dir():
+            raise FileNotFoundError(f"Unknown released case study: {release_case_dir}")
+
+        if workspace is None:
+            study = cls(
+                case_study=case_study,
+                root=release_case_dir,
+                release_root=release_root,
+                output_root=None,
+                read_only=True,
+                manifest={
+                    "schema_version": 1,
+                    "case_study": case_study,
+                    "baseline_source_commit": _source_commit(release_root),
+                    "baseline_manifest_sha256": _release_manifest_digest(release_case_dir),
+                },
+            )
+            study.activate()
+            return study
+
+        output_root = Path(workspace).expanduser().resolve()
+        target = output_root / case_study
+        manifest_path = target / ".study.json"
+        if target.exists():
+            if not manifest_path.is_file():
+                raise ValueError(f"Existing workspace has no .study.json manifest: {target}")
+            manifest = json.loads(manifest_path.read_text())
+            if manifest.get("schema_version") != 1 or manifest.get("case_study") != case_study:
+                raise ValueError(f"Invalid workspace manifest: {manifest_path}")
+        else:
+            manifest = {
+                "schema_version": 1,
+                "case_study": case_study,
+                "baseline_source_commit": _source_commit(release_root),
+                "baseline_manifest_sha256": _release_manifest_digest(release_case_dir),
+                "created_at": datetime.now(UTC).isoformat(),
+            }
+            create_experiment(
+                case_study,
+                output_root,
+                repo_root=release_root,
+                manifest=manifest,
+            )
+        study = cls(
+            case_study=case_study,
+            root=target,
+            release_root=release_root,
+            output_root=output_root,
+            read_only=False,
+            manifest=manifest,
+        )
+        study.activate()
+        return study
+
+    def activate(self, execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL) -> Path:
+        global _ACTIVE_OUTPUT_ROOT
+        tier = ExecutionTier(execution_tier)
+        if self.read_only:
+            os.environ.pop("ML4T_OUTPUT_DIR", None)
+            _ACTIVE_OUTPUT_ROOT = None
+            _clear_root_sensitive_caches()
+            return self.root
+
+        base_output_root = self.output_root
+        assert base_output_root is not None
+        output_root = base_output_root
+        if tier is ExecutionTier.PREVIEW:
+            output_root = output_root / ".preview"
+            preview_case = output_root / self.case_study
+            if not preview_case.exists():
+                preview_case.mkdir(parents=True)
+                shutil.copytree(self.root / "config", preview_case / "config")
+                shared_config = base_output_root / "config"
+                if shared_config.exists():
+                    shutil.copytree(shared_config, output_root / "config", dirs_exist_ok=True)
+        if output_root != _ACTIVE_OUTPUT_ROOT:
+            os.environ["ML4T_OUTPUT_DIR"] = str(output_root)
+            _ACTIVE_OUTPUT_ROOT = output_root
+            _clear_root_sensitive_caches()
+        return output_root / self.case_study
+
+    def storage_root(self, execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL) -> Path:
+        tier = ExecutionTier(execution_tier)
+        if tier is ExecutionTier.PREVIEW:
+            if self.read_only:
+                raise PermissionError("read-only release cannot create preview results")
+            assert self.output_root is not None
+            return self.output_root / ".preview" / self.case_study
+        return self.root
+
+    def require_writable(self) -> None:
+        if self.read_only:
+            raise PermissionError("released baseline is read-only; open a workspace to write")
+
+    @property
+    def labels(self) -> LabelCatalog:
+        from .labels import LabelCatalog
+
+        return LabelCatalog(self)
+
+    @property
+    def results(self) -> ResultsCatalog:
+        from .results import ResultsCatalog
+
+        return ResultsCatalog(self)
+
+    @property
+    def lifecycle(self) -> Lifecycle:
+        from .lifecycle import Lifecycle
+
+        return Lifecycle(self)
+
+    def strategy(self, **request) -> Strategy:
+        from .strategy import Strategy
+
+        return Strategy.from_request(self, request)

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -138,6 +138,9 @@ class Study:
             read_only=False,
             manifest=manifest,
         )
+        from case_studies.utils.registry.store import _open_registry
+
+        _open_registry(target).close()
         study.activate()
         return study
 

--- a/case_studies/utils/backtest_presets.py
+++ b/case_studies/utils/backtest_presets.py
@@ -433,6 +433,7 @@ def build_backtest_spec(
     signal: dict[str, Any],
     allocation: dict[str, Any] | None = None,
     risk: dict[str, Any] | None = None,
+    costs: dict[str, Any] | None = None,
     chapter: str | None = None,
     execution_mode: str | None = None,
     min_weight_change: float | None = None,
@@ -466,7 +467,9 @@ def build_backtest_spec(
                 else getattr(case_config, "min_trade_value", 100.0)
             ),
         },
-        "costs": _costs_block_from_case_config(case_config),
+        "costs": (
+            deepcopy(costs) if costs is not None else _costs_block_from_case_config(case_config)
+        ),
     }
     if chapter is not None:
         strategy_spec["chapter"] = chapter

--- a/case_studies/utils/conformal.py
+++ b/case_studies/utils/conformal.py
@@ -41,6 +41,39 @@ DEFAULT_MIN_CALIBRATION_N: int = 30
 CALIBRATION_VERSION: str = "walk_forward_v2"
 POOLED_FALLBACK: str = "pooled_prior_oos"
 
+HOLDOUT_CONFORMAL_EMBARGO_STEPS: dict[str, int] = {
+    "etfs/fwd_ret_21d": 21,
+    "cme_futures/fwd_ret_5d": 5,
+    "cme_futures/fwd_ret_21d": 21,
+    "fx_pairs/fwd_ret_1d": 1,
+    "fx_pairs/fwd_ret_5d": 5,
+    "fx_pairs/fwd_ret_21d": 21,
+    "crypto_perps_funding/fwd_ret_24h": 3,
+    "crypto_perps_funding/fwd_ret_8h": 1,
+    "nasdaq100_microstructure/fwd_ret_15m": 1,
+    "nasdaq100_microstructure/fwd_ret_60m": 4,
+    "nasdaq100_microstructure/fwd_ret_5m": 1,
+    "sp500_equity_option_analytics/fwd_ret_5d": 5,
+    "sp500_equity_option_analytics/fwd_ret_risk_adj_5d": 5,
+    "us_equities_panel/fwd_ret_5d": 5,
+    "us_equities_panel/fwd_ret_1d": 1,
+    "us_equities_panel/fwd_ret_21d": 21,
+    "us_firm_characteristics/fwd_ret_1m_win": 1,
+    "us_firm_characteristics/fwd_ret_1m": 1,
+    "us_firm_characteristics/fwd_class_1m": 1,
+}
+
+
+def holdout_conformal_embargo_steps(case_study: str, label: str) -> int:
+    """Return the reviewed label horizon in prediction data steps."""
+    key = f"{case_study}/{label}"
+    try:
+        return HOLDOUT_CONFORMAL_EMBARGO_STEPS[key]
+    except KeyError as error:
+        raise KeyError(
+            f"No conformal holdout embargo is defined for {key}; add a reviewed data-step value"
+        ) from error
+
 
 def ensure_conformal_calibration_identity(strategy_spec: dict[str, Any]) -> dict[str, Any]:
     """Return a spec whose conformal allocation carries its full identity."""

--- a/case_studies/utils/registry/__init__.py
+++ b/case_studies/utils/registry/__init__.py
@@ -47,8 +47,10 @@ Usage::
 # --- completeness ---
 from .completeness import (
     BacktestRunStatus,
+    PredictionCoverage,
     TrainingRunStatus,
     backtest_run_status,
+    evaluate_prediction_coverage,
     skip_backtest_if_complete,
     skip_training_if_complete,
     training_run_status,
@@ -117,12 +119,14 @@ from .registration import (
 from .specs import (
     DEFAULT_SEED,
     HASH_LENGTH,
+    IDENTITY_VERSION,
     backtest_hash_from_parts,
     build_training_spec,
     canonical_json,
     compute_hash,
     load_preset,
     prediction_hash_from_parts,
+    project_training_identity,
     training_hash_from_spec,
 )
 
@@ -137,10 +141,12 @@ __all__ = [
     # specs
     "DEFAULT_SEED",
     "HASH_LENGTH",
+    "IDENTITY_VERSION",
     "canonical_json",
     "compute_hash",
     "training_hash_from_spec",
     "prediction_hash_from_parts",
+    "project_training_identity",
     "backtest_hash_from_parts",
     "load_preset",
     "build_training_spec",
@@ -164,6 +170,8 @@ __all__ = [
     # completeness
     "TrainingRunStatus",
     "BacktestRunStatus",
+    "PredictionCoverage",
+    "evaluate_prediction_coverage",
     "training_run_status",
     "backtest_run_status",
     "skip_training_if_complete",

--- a/case_studies/utils/registry/completeness.py
+++ b/case_studies/utils/registry/completeness.py
@@ -50,6 +50,7 @@ silently reuse a partial state because the result would be misleading
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -61,6 +62,123 @@ from .store import (
     _open_registry,
     _prediction_dir,
 )
+
+
+@dataclass(frozen=True)
+class PredictionCoverage:
+    """Exact expected-versus-actual prediction coverage evidence."""
+
+    expected_key_digest: str
+    actual_key_digest: str
+    n_expected: int
+    n_actual: int
+    n_duplicates: int
+    n_missing: int
+    n_extra: int
+    n_null: int
+    n_non_finite: int
+    n_folds_expected: int
+    n_folds_actual: int
+    schema_json: str
+    status: str
+
+    @property
+    def complete(self) -> bool:
+        return self.status == "complete"
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {
+            "expected_key_digest": self.expected_key_digest,
+            "actual_key_digest": self.actual_key_digest,
+            "n_expected": self.n_expected,
+            "n_actual": self.n_actual,
+            "n_duplicates": self.n_duplicates,
+            "n_missing": self.n_missing,
+            "n_extra": self.n_extra,
+            "n_null": self.n_null,
+            "n_non_finite": self.n_non_finite,
+            "n_folds_expected": self.n_folds_expected,
+            "n_folds_actual": self.n_folds_actual,
+            "schema_json": self.schema_json,
+            "status": self.status,
+        }
+
+
+def _canonical_key_frame(frame):
+    import polars as pl
+
+    if not isinstance(frame, pl.DataFrame):
+        frame = pl.from_pandas(frame)
+    if "fold" in frame.columns and "fold_id" not in frame.columns:
+        frame = frame.rename({"fold": "fold_id"})
+    required = {"symbol", "timestamp", "fold_id"}
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(
+            f"prediction coverage requires columns {sorted(required)}; missing {missing}"
+        )
+    return frame.select(
+        pl.col("symbol").cast(pl.String),
+        pl.col("timestamp").cast(pl.String),
+        pl.col("fold_id").cast(pl.Int64),
+    )
+
+
+def _key_digest(frame) -> str:
+    from case_studies.utils.artifact_digest import value_digest
+
+    return value_digest(frame, ("symbol", "timestamp", "fold_id"))
+
+
+def evaluate_prediction_coverage(expected_keys, predictions) -> PredictionCoverage:
+    """Compare exact prediction keys and finite scores without mutating storage."""
+    import polars as pl
+
+    expected = _canonical_key_frame(expected_keys)
+    actual = _canonical_key_frame(predictions)
+    if expected.n_unique(["symbol", "timestamp", "fold_id"]) != expected.height:
+        raise ValueError("expected prediction coverage keys must be unique")
+
+    unique_actual = actual.unique(["symbol", "timestamp", "fold_id"])
+    n_duplicates = actual.height - unique_actual.height
+    n_missing = expected.join(
+        unique_actual, on=["symbol", "timestamp", "fold_id"], how="anti"
+    ).height
+    n_extra = unique_actual.join(expected, on=["symbol", "timestamp", "fold_id"], how="anti").height
+
+    if not isinstance(predictions, pl.DataFrame):
+        predictions = pl.from_pandas(predictions)
+    score_col = "y_score" if "y_score" in predictions.columns else "prediction"
+    if score_col not in predictions.columns:
+        raise ValueError("prediction coverage requires y_score or prediction")
+    score = predictions.get_column(score_col).cast(pl.Float64, strict=False)
+    n_null = score.null_count()
+    n_non_finite = (score.is_not_null() & ~score.is_finite()).sum()
+    expected_digest = _key_digest(expected)
+    actual_digest = _key_digest(unique_actual)
+    complete = not any((n_duplicates, n_missing, n_extra, n_null, n_non_finite)) and (
+        expected_digest == actual_digest
+    )
+    return PredictionCoverage(
+        expected_key_digest=expected_digest,
+        actual_key_digest=actual_digest,
+        n_expected=expected.height,
+        n_actual=actual.height,
+        n_duplicates=n_duplicates,
+        n_missing=n_missing,
+        n_extra=n_extra,
+        n_null=n_null,
+        n_non_finite=int(n_non_finite),
+        n_folds_expected=expected.get_column("fold_id").n_unique(),
+        n_folds_actual=actual.get_column("fold_id").n_unique(),
+        schema_json=json.dumps(
+            {name: str(dtype) for name, dtype in predictions.schema.items()},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        status="complete" if complete else "partial",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Dataclasses

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import shutil
+import uuid
 from pathlib import Path
 
 from .specs import (
+    IDENTITY_VERSION,
     _validate_spec,
     backtest_hash_from_parts,
     build_training_spec,
     canonical_json,
     prediction_hash_from_parts,
+    project_training_identity,
     training_hash_from_spec,
 )
 from .store import (
@@ -32,6 +37,15 @@ logger = logging.getLogger(__name__)
 
 VALID_PREDICTION_SPLITS = frozenset({"validation", "holdout"})
 MAX_PREDICTION_STD_RATIO = 100.0
+
+
+def _atomic_save_json(path: Path, data: dict) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        _save_json(temporary, data)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _validate_prediction_dispersion(predictions) -> None:
@@ -182,6 +196,10 @@ def clear_prediction_sets(
             prediction_hashes,
         )
         db.execute(
+            f"DELETE FROM prediction_coverage WHERE prediction_hash IN ({placeholders})",
+            prediction_hashes,
+        )
+        db.execute(
             f"DELETE FROM prediction_sets WHERE prediction_hash IN ({placeholders})",
             prediction_hashes,
         )
@@ -242,6 +260,66 @@ def register_training_run(
     spec = _validate_spec(spec)
     t_hash = training_hash_from_spec(spec)
     spec_json_str = canonical_json(spec)
+
+    if spec.get("identity_version") == IDENTITY_VERSION:
+        tier = spec.get("execution_tier")
+        if tier not in {"canonical", "preview"}:
+            raise ValueError("version-2 training spec requires execution_tier canonical or preview")
+        db = _open_registry(case_dir)
+        try:
+            existing = db.execute(
+                "SELECT spec_json, identity_version, execution_tier FROM training_runs "
+                "WHERE training_hash = ?",
+                (t_hash,),
+            ).fetchone()
+            if existing is not None:
+                existing_spec = json.loads(existing[0])
+                if project_training_identity(existing_spec) != project_training_identity(
+                    spec
+                ) or existing[1:] != (IDENTITY_VERSION, tier):
+                    raise ValueError(f"immutable training identity conflict for {t_hash}")
+                return t_hash
+
+            train_dir = _training_dir(case_dir, t_hash)
+            spec_path = train_dir / "spec.json"
+            _atomic_save_json(spec_path, spec)
+            if runtime_provenance is not None:
+                _atomic_save_json(train_dir / "runtime.json", runtime_provenance)
+            try:
+                db.execute(
+                    """
+                    INSERT INTO training_runs
+                    (training_hash, family, label, config_name, spec_json, created_at,
+                     git_commit, entry_point, started_at, elapsed_s, runtime_json,
+                     identity_version, execution_tier)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        t_hash,
+                        spec["family"],
+                        spec["label"],
+                        spec.get("config_name"),
+                        spec_json_str,
+                        _utc_now(),
+                        _git_hash(),
+                        entry_point,
+                        started_at,
+                        elapsed_s,
+                        canonical_json(runtime_provenance)
+                        if runtime_provenance is not None
+                        else None,
+                        IDENTITY_VERSION,
+                        tier,
+                    ),
+                )
+                db.commit()
+            except Exception:
+                db.rollback()
+                spec_path.unlink(missing_ok=True)
+                raise
+        finally:
+            db.close()
+        return t_hash
 
     # Write spec.json (authoritative identity artifact)
     train_dir = _training_dir(case_dir, t_hash)
@@ -500,6 +578,8 @@ def register_prediction_set(
     eval_col: str | None = None,
     label: str | None = None,
     case_dir: Path | None = None,
+    expected_keys=None,
+    allow_partial: bool = False,
 ) -> str:
     """Register a prediction set. Returns prediction_hash.
 
@@ -548,39 +628,147 @@ def register_prediction_set(
     if predictions is not None:
         _validate_prediction_dispersion(predictions)
 
-    p_hash = prediction_hash_from_parts(training_hash, checkpoint_value, split)
-
-    # Save predictions
-    if predictions is not None:
-        pred_dir = _prediction_dir(case_dir, p_hash)
-        _save_parquet(pred_dir / "predictions.parquet", predictions)
-
-    # Insert into DB
     db = _open_registry(case_dir)
     try:
-        db.execute(
-            """
-            INSERT OR REPLACE INTO prediction_sets
-            (prediction_hash, training_hash, checkpoint_value, checkpoint_kind,
-             split, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                p_hash,
-                training_hash,
-                checkpoint_value,
-                checkpoint_kind,
-                split,
-                _utc_now(),
-            ),
-        )
-
-        if metrics:
-            _upsert_wide_metrics(db, "prediction_metrics", {"prediction_hash": p_hash}, metrics)
-
-        db.commit()
+        parent = db.execute(
+            "SELECT identity_version, execution_tier FROM training_runs WHERE training_hash = ?",
+            (training_hash,),
+        ).fetchone()
     finally:
         db.close()
+    if parent is None:
+        raise ValueError(f"unknown training_hash {training_hash}")
+    identity_version, _execution_tier = parent
+    coverage = None
+    if identity_version == IDENTITY_VERSION:
+        if predictions is None or expected_keys is None:
+            raise ValueError(
+                "version-2 prediction registration requires predictions and expected_keys"
+            )
+        from .completeness import evaluate_prediction_coverage
+
+        coverage = evaluate_prediction_coverage(expected_keys, predictions)
+        if not coverage.complete and not allow_partial:
+            raise ValueError(f"prediction coverage is partial: {coverage.as_dict()}")
+        db = _open_registry(case_dir)
+        try:
+            existing_schema = db.execute(
+                """
+                SELECT c.schema_json
+                FROM prediction_coverage c
+                JOIN prediction_sets p ON p.prediction_hash = c.prediction_hash
+                WHERE p.training_hash = ? AND p.split = ?
+                LIMIT 1
+                """,
+                (training_hash, split),
+            ).fetchone()
+        finally:
+            db.close()
+        if existing_schema is not None and existing_schema[0] != coverage.schema_json:
+            raise ValueError("prediction schema differs from an existing checkpoint")
+
+    p_hash = prediction_hash_from_parts(
+        training_hash,
+        checkpoint_value,
+        split,
+        checkpoint_kind=checkpoint_kind,
+        identity_version=identity_version,
+    )
+
+    if identity_version == IDENTITY_VERSION:
+        pred_dir = _prediction_dir(case_dir, p_hash)
+        pred_path = pred_dir / "predictions.parquet"
+        temporary = pred_dir / f".predictions.{uuid.uuid4().hex}.tmp"
+        db = _open_registry(case_dir)
+        try:
+            existing = db.execute(
+                "SELECT training_hash, checkpoint_value, checkpoint_kind, split "
+                "FROM prediction_sets WHERE prediction_hash = ?",
+                (p_hash,),
+            ).fetchone()
+            expected_row = (training_hash, checkpoint_value, checkpoint_kind, split)
+            if existing is not None:
+                if existing != expected_row:
+                    raise ValueError(f"immutable prediction identity conflict for {p_hash}")
+                import polars as pl
+
+                from case_studies.utils.artifact_digest import value_digest
+
+                new_predictions = (
+                    predictions
+                    if isinstance(predictions, pl.DataFrame)
+                    else pl.from_pandas(predictions)
+                )
+                if not pred_path.exists() or value_digest(
+                    pl.read_parquet(pred_path)
+                ) != value_digest(new_predictions):
+                    raise ValueError(f"immutable prediction artifact conflict for {p_hash}")
+                return p_hash
+
+            _save_parquet(temporary, predictions)
+            try:
+                db.execute(
+                    """
+                    INSERT INTO prediction_sets
+                    (prediction_hash, training_hash, checkpoint_value, checkpoint_kind,
+                     split, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (p_hash, *expected_row, _utc_now()),
+                )
+                values = coverage.as_dict()
+                columns = ", ".join(("prediction_hash", *values))
+                placeholders = ", ".join("?" for _ in range(len(values) + 1))
+                db.execute(
+                    f"INSERT INTO prediction_coverage ({columns}) VALUES ({placeholders})",
+                    (p_hash, *values.values()),
+                )
+                if metrics:
+                    _upsert_wide_metrics(
+                        db, "prediction_metrics", {"prediction_hash": p_hash}, metrics
+                    )
+                pred_dir.mkdir(parents=True, exist_ok=True)
+                os.replace(temporary, pred_path)
+                db.commit()
+            except Exception:
+                db.rollback()
+                pred_path.unlink(missing_ok=True)
+                raise
+        finally:
+            temporary.unlink(missing_ok=True)
+            db.close()
+    else:
+        # Save predictions
+        if predictions is not None:
+            pred_dir = _prediction_dir(case_dir, p_hash)
+            _save_parquet(pred_dir / "predictions.parquet", predictions)
+
+        # Insert into DB
+        db = _open_registry(case_dir)
+        try:
+            db.execute(
+                """
+                INSERT OR REPLACE INTO prediction_sets
+                (prediction_hash, training_hash, checkpoint_value, checkpoint_kind,
+                 split, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    p_hash,
+                    training_hash,
+                    checkpoint_value,
+                    checkpoint_kind,
+                    split,
+                    _utc_now(),
+                ),
+            )
+
+            if metrics:
+                _upsert_wide_metrics(db, "prediction_metrics", {"prediction_hash": p_hash}, metrics)
+
+            db.commit()
+        finally:
+            db.close()
 
     # Auto-compute fold metrics when predictions are provided
     if predictions is not None and _has_fold_column(predictions):
@@ -774,8 +962,61 @@ def register_backtest_run(
     if stage is None:
         stage = _infer_stage(strategy_spec, case_dir=case_dir, prediction_hash=prediction_hash)
 
-    b_hash = backtest_hash_from_parts(prediction_hash, strategy_spec)
+    identity_version = strategy_spec.get("identity_version")
+    if identity_version == IDENTITY_VERSION:
+        db = _open_registry(case_dir)
+        try:
+            ancestry = db.execute(
+                """
+                SELECT t.execution_tier, c.status
+                FROM prediction_sets p
+                JOIN training_runs t ON t.training_hash = p.training_hash
+                LEFT JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash
+                WHERE p.prediction_hash = ?
+                """,
+                (prediction_hash,),
+            ).fetchone()
+        finally:
+            db.close()
+        if ancestry is None or ancestry[1] != "complete":
+            raise ValueError("backtest requires complete prediction coverage")
+        requested_tier = strategy_spec.get("execution_tier", "canonical")
+        if requested_tier not in {"canonical", "preview"}:
+            raise ValueError("backtest execution_tier must be canonical or preview")
+        if ancestry[0] != requested_tier:
+            raise ValueError("backtest execution tier conflicts with prediction ancestry")
+
+    b_hash = backtest_hash_from_parts(
+        prediction_hash, strategy_spec, identity_version=identity_version
+    )
     spec_json_str = canonical_json(strategy_spec)
+
+    if identity_version == IDENTITY_VERSION:
+        db = _open_registry(case_dir)
+        try:
+            existing = db.execute(
+                "SELECT prediction_hash, spec_json FROM backtest_runs WHERE backtest_hash = ?",
+                (b_hash,),
+            ).fetchone()
+        finally:
+            db.close()
+        if existing is not None:
+            if existing != (prediction_hash, spec_json_str):
+                raise ValueError(f"immutable backtest identity conflict for {b_hash}")
+            import polars as pl
+
+            from case_studies.utils.artifact_digest import value_digest
+
+            existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
+            if returns is not None:
+                new_returns = (
+                    returns if isinstance(returns, pl.DataFrame) else pl.from_pandas(returns)
+                )
+                if not existing_returns.exists() or value_digest(
+                    pl.read_parquet(existing_returns)
+                ) != value_digest(new_returns):
+                    raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
+            return b_hash
 
     # Write spec.json
     bt_dir = _backtest_dir(case_dir, b_hash)
@@ -855,24 +1096,50 @@ def register_backtest_run(
     try:
         db.execute("DELETE FROM backtest_fold_metrics WHERE backtest_hash = ?", (b_hash,))
         db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = ?", (b_hash,))
-        db.execute(
-            """
-            INSERT OR REPLACE INTO backtest_runs
-            (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
-             started_at, elapsed_s)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                b_hash,
-                prediction_hash,
-                spec_json_str,
-                stage,
-                _utc_now(),
-                _git_hash(),
-                started_at,
-                elapsed_s,
-            ),
-        )
+        if identity_version == IDENTITY_VERSION:
+            existing = db.execute(
+                "SELECT prediction_hash, spec_json FROM backtest_runs WHERE backtest_hash = ?",
+                (b_hash,),
+            ).fetchone()
+            if existing is not None and existing != (prediction_hash, spec_json_str):
+                raise ValueError(f"immutable backtest identity conflict for {b_hash}")
+            db.execute(
+                """
+                INSERT OR IGNORE INTO backtest_runs
+                (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
+                 started_at, elapsed_s)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    b_hash,
+                    prediction_hash,
+                    spec_json_str,
+                    stage,
+                    _utc_now(),
+                    _git_hash(),
+                    started_at,
+                    elapsed_s,
+                ),
+            )
+        else:
+            db.execute(
+                """
+                INSERT OR REPLACE INTO backtest_runs
+                (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
+                 started_at, elapsed_s)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    b_hash,
+                    prediction_hash,
+                    spec_json_str,
+                    stage,
+                    _utc_now(),
+                    _git_hash(),
+                    started_at,
+                    elapsed_s,
+                ),
+            )
 
         if metrics:
             _upsert_wide_metrics(db, "backtest_metrics", {"backtest_hash": b_hash}, metrics)

--- a/case_studies/utils/registry/specs.py
+++ b/case_studies/utils/registry/specs.py
@@ -20,6 +20,21 @@ DEFAULT_SEED = 42
 # two runs with different seeds always produce different hashes.
 _REQUIRED_SPEC_FIELDS = {"family", "label", "seed"}
 
+IDENTITY_VERSION = 2
+_V2_PROVENANCE_FIELDS = {
+    "chapter",
+    "config_name",
+    "created_at",
+    "display_name",
+    "entry_point",
+    "friendly_name",
+    "git_commit",
+    "notebook_path",
+    "preset_path",
+    "runtime",
+    "runtime_provenance",
+}
+
 # ---------------------------------------------------------------------------
 # Hashing
 # ---------------------------------------------------------------------------
@@ -60,15 +75,45 @@ def training_hash_from_spec(spec: dict) -> str:
     Validates that ``seed`` is present (injects default if missing).
     """
     spec = _validate_spec(spec)
+    if spec.get("identity_version") == IDENTITY_VERSION:
+        return compute_hash(canonical_json(project_training_identity(spec)))
     return compute_hash(canonical_json(spec))
+
+
+def project_training_identity(spec: dict) -> dict:
+    """Return the version-2 semantic training identity projection."""
+    if spec.get("identity_version") != IDENTITY_VERSION:
+        raise ValueError("version-2 identity projection requires identity_version=2")
+    projected = {
+        key: copy.deepcopy(value) for key, value in spec.items() if key not in _V2_PROVENANCE_FIELDS
+    }
+    projected["identity_version"] = IDENTITY_VERSION
+    return projected
 
 
 def prediction_hash_from_parts(
     training_hash: str,
     checkpoint_value: int | None,
     split: str,
+    *,
+    checkpoint_kind: str | None = None,
+    identity_version: int | None = None,
 ) -> str:
     """Compute prediction_hash from its defining components."""
+    if identity_version == IDENTITY_VERSION:
+        if not checkpoint_kind:
+            raise ValueError("version-2 prediction identity requires checkpoint_kind")
+        return compute_hash(
+            canonical_json(
+                {
+                    "checkpoint_kind": checkpoint_kind,
+                    "checkpoint_value": checkpoint_value,
+                    "identity_version": IDENTITY_VERSION,
+                    "split": split,
+                    "training_hash": training_hash,
+                }
+            )
+        )
     cp = str(checkpoint_value) if checkpoint_value is not None else "final"
     return compute_hash(f"{training_hash}|{cp}|{split}")
 
@@ -109,15 +154,27 @@ def _hashable_strategy_spec(strategy_spec: dict) -> dict:
 def backtest_hash_from_parts(
     prediction_hash: str,
     strategy_spec: dict,
+    *,
+    identity_version: int | None = None,
 ) -> str:
     """Compute backtest_hash from prediction_hash + strategy spec.
 
     Non-portable provenance (see ``_HASH_EXCLUDED_METADATA``) is stripped before
     hashing so the same strategy hashes identically regardless of where it runs.
     """
-    return compute_hash(
-        f"{prediction_hash}|{canonical_json(_hashable_strategy_spec(strategy_spec))}"
-    )
+    hashable = _hashable_strategy_spec(strategy_spec)
+    resolved_version = identity_version or strategy_spec.get("identity_version")
+    if resolved_version == IDENTITY_VERSION:
+        return compute_hash(
+            canonical_json(
+                {
+                    "identity_version": IDENTITY_VERSION,
+                    "prediction_hash": prediction_hash,
+                    "strategy": hashable,
+                }
+            )
+        )
+    return compute_hash(f"{prediction_hash}|{canonical_json(hashable)}")
 
 
 # ---------------------------------------------------------------------------

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -452,6 +452,8 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
     # Migration 2: add runtime columns to training_runs
     if "training_runs" in tables:
         tr_cols = {row[1] for row in db.execute("PRAGMA table_info(training_runs)").fetchall()}
+        if "config_name" not in tr_cols:
+            db.execute("ALTER TABLE training_runs ADD COLUMN config_name TEXT")
         if "started_at" not in tr_cols:
             db.execute("ALTER TABLE training_runs ADD COLUMN started_at TEXT")
         if "elapsed_s" not in tr_cols:

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -34,7 +34,9 @@ CREATE TABLE IF NOT EXISTS training_runs (
     entry_point       TEXT,
     started_at        TEXT,
     elapsed_s         REAL,
-    runtime_json      TEXT
+    runtime_json      TEXT,
+    identity_version  INTEGER,
+    execution_tier    TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_training_family_label ON training_runs(family, label);
@@ -51,6 +53,23 @@ CREATE TABLE IF NOT EXISTS prediction_sets (
 
 CREATE INDEX IF NOT EXISTS idx_pred_training ON prediction_sets(training_hash);
 CREATE INDEX IF NOT EXISTS idx_pred_split ON prediction_sets(split);
+
+CREATE TABLE IF NOT EXISTS prediction_coverage (
+    prediction_hash     TEXT PRIMARY KEY REFERENCES prediction_sets(prediction_hash),
+    expected_key_digest TEXT NOT NULL,
+    actual_key_digest   TEXT NOT NULL,
+    n_expected          INTEGER NOT NULL,
+    n_actual            INTEGER NOT NULL,
+    n_duplicates        INTEGER NOT NULL,
+    n_missing           INTEGER NOT NULL,
+    n_extra             INTEGER NOT NULL,
+    n_null              INTEGER NOT NULL,
+    n_non_finite        INTEGER NOT NULL,
+    n_folds_expected    INTEGER NOT NULL,
+    n_folds_actual      INTEGER NOT NULL,
+    schema_json          TEXT NOT NULL,
+    status              TEXT NOT NULL
+);
 
 CREATE TABLE IF NOT EXISTS prediction_metrics (
     prediction_hash  TEXT PRIMARY KEY REFERENCES prediction_sets(prediction_hash),
@@ -201,6 +220,40 @@ CREATE TABLE IF NOT EXISTS cohort_metrics (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_cohort_unique
     ON cohort_metrics(cohort_type, COALESCE(stage, ''), label, COALESCE(family, ''));
 CREATE INDEX IF NOT EXISTS idx_cohort_leader ON cohort_metrics(leader_hash);
+
+CREATE TABLE IF NOT EXISTS candidate_sets (
+    set_hash                 TEXT PRIMARY KEY,
+    name                     TEXT NOT NULL,
+    member_kind              TEXT NOT NULL,
+    comparison_contract_json TEXT NOT NULL,
+    created_at               TEXT NOT NULL,
+    git_commit               TEXT
+);
+
+CREATE TABLE IF NOT EXISTS candidate_set_members (
+    set_hash    TEXT NOT NULL REFERENCES candidate_sets(set_hash),
+    member_hash TEXT NOT NULL,
+    ordinal     INTEGER NOT NULL,
+    PRIMARY KEY (set_hash, ordinal),
+    UNIQUE (set_hash, member_hash)
+);
+
+CREATE TABLE IF NOT EXISTS research_locks (
+    lock_hash  TEXT PRIMARY KEY,
+    lock_json  TEXT NOT NULL,
+    state      TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_research_singleton ON research_locks((1));
+
+CREATE TABLE IF NOT EXISTS holdout_evaluations (
+    lock_hash               TEXT PRIMARY KEY REFERENCES research_locks(lock_hash),
+    holdout_training_hash   TEXT NOT NULL,
+    holdout_prediction_hash TEXT NOT NULL,
+    holdout_backtest_hash   TEXT NOT NULL,
+    evaluated_at            TEXT NOT NULL
+);
 """
 
 
@@ -405,6 +458,17 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
             db.execute("ALTER TABLE training_runs ADD COLUMN elapsed_s REAL")
         if "runtime_json" not in tr_cols:
             db.execute("ALTER TABLE training_runs ADD COLUMN runtime_json TEXT")
+        if "identity_version" not in tr_cols:
+            db.execute("ALTER TABLE training_runs ADD COLUMN identity_version INTEGER")
+        if "execution_tier" not in tr_cols:
+            db.execute("ALTER TABLE training_runs ADD COLUMN execution_tier TEXT")
+
+    if "prediction_coverage" in tables:
+        coverage_cols = {
+            row[1] for row in db.execute("PRAGMA table_info(prediction_coverage)").fetchall()
+        }
+        if "schema_json" not in coverage_cols:
+            db.execute("ALTER TABLE prediction_coverage ADD COLUMN schema_json TEXT")
 
     # Migration 2b: add runtime columns to backtest_runs
     if "backtest_runs" in tables:

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -448,22 +448,34 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
         if "stage" not in cols:
             db.execute("ALTER TABLE backtest_runs ADD COLUMN stage TEXT")
             db.execute("CREATE INDEX IF NOT EXISTS idx_backtest_stage ON backtest_runs(stage)")
+            cols.add("stage")
 
     # Migration 2: add runtime columns to training_runs
     if "training_runs" in tables:
         tr_cols = {row[1] for row in db.execute("PRAGMA table_info(training_runs)").fetchall()}
-        if "config_name" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN config_name TEXT")
-        if "started_at" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN started_at TEXT")
-        if "elapsed_s" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN elapsed_s REAL")
-        if "runtime_json" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN runtime_json TEXT")
-        if "identity_version" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN identity_version INTEGER")
-        if "execution_tier" not in tr_cols:
-            db.execute("ALTER TABLE training_runs ADD COLUMN execution_tier TEXT")
+        training_columns = {
+            "config_name": "TEXT",
+            "spec_json": "TEXT",
+            "git_commit": "TEXT",
+            "entry_point": "TEXT",
+            "started_at": "TEXT",
+            "elapsed_s": "REAL",
+            "runtime_json": "TEXT",
+            "identity_version": "INTEGER",
+            "execution_tier": "TEXT",
+        }
+        for column, sql_type in training_columns.items():
+            if column not in tr_cols:
+                db.execute(f"ALTER TABLE training_runs ADD COLUMN {column} {sql_type}")
+
+    if "prediction_sets" in tables:
+        prediction_cols = {
+            row[1] for row in db.execute("PRAGMA table_info(prediction_sets)").fetchall()
+        }
+        prediction_columns = {"checkpoint_value": "INTEGER", "checkpoint_kind": "TEXT"}
+        for column, sql_type in prediction_columns.items():
+            if column not in prediction_cols:
+                db.execute(f"ALTER TABLE prediction_sets ADD COLUMN {column} {sql_type}")
 
     if "prediction_coverage" in tables:
         coverage_cols = {
@@ -474,10 +486,16 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
 
     # Migration 2b: add runtime columns to backtest_runs
     if "backtest_runs" in tables:
-        if "started_at" not in cols:
-            db.execute("ALTER TABLE backtest_runs ADD COLUMN started_at TEXT")
-        if "elapsed_s" not in cols:
-            db.execute("ALTER TABLE backtest_runs ADD COLUMN elapsed_s REAL")
+        backtest_columns = {
+            "spec_json": "TEXT",
+            "stage": "TEXT",
+            "git_commit": "TEXT",
+            "started_at": "TEXT",
+            "elapsed_s": "REAL",
+        }
+        for column, sql_type in backtest_columns.items():
+            if column not in cols:
+                db.execute(f"ALTER TABLE backtest_runs ADD COLUMN {column} {sql_type}")
 
     # Migration 3: tall → wide metric tables
     if "prediction_metrics" in tables:

--- a/scripts/create_experiment.py
+++ b/scripts/create_experiment.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import stat
 import uuid
@@ -23,6 +24,7 @@ def create_experiment(
     output_root: Path,
     *,
     repo_root: Path = REPO_ROOT,
+    manifest: dict | None = None,
 ) -> Path:
     """Copy available generated state into a new ML4T_OUTPUT_DIR."""
     source = repo_root / "case_studies" / case_study
@@ -60,6 +62,11 @@ def create_experiment(
         # config reads to ML4T_OUTPUT_DIR, so the experiment must carry its own copy
         # (else notebooks crash on config/setup.yaml before any reader edit is reached).
         shutil.copytree(source_config, staging / "config")
+
+        if manifest is not None:
+            (staging / ".study.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+            )
 
         _make_writable(staging)
         release_metadata = staging / "run_log/.release"

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -37,6 +37,17 @@ def _prices() -> pl.DataFrame:
     ).with_columns(pl.col("timestamp").str.to_date())
 
 
+def _patch_holdout_prices(monkeypatch: pytest.MonkeyPatch, prices: pl.DataFrame) -> None:
+    from case_studies.research import lifecycle, strategy
+
+    def load_prices(case_study: str, label: str, *, split: str):
+        assert (case_study, label, split) == ("etfs", "fwd_ret_21d", "holdout")
+        return prices
+
+    monkeypatch.setattr(lifecycle, "load_backtest_prices_for", load_prices)
+    monkeypatch.setattr(strategy, "load_backtest_prices_for", load_prices)
+
+
 def test_fake_prediction_to_backtest_flow_survives_restart(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
@@ -172,7 +183,7 @@ def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> N
         Result.open(study, preview_backtest.hash)
 
 
-def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
+def test_lock_transition_failure_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     release = _seed_release(tmp_path)
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
     training = study.results.register_training(_training_spec())
@@ -192,6 +203,10 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
     ).run(prices=_prices())
     candidates = CandidateSet.create(study, "selection", [backtest])
     assert candidates.best_validation_sharpe().hash == backtest.hash
+    _patch_holdout_prices(
+        monkeypatch,
+        _prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp")),
+    )
     invalid_holdout_spec = _training_spec(
         cv={"phase": "holdout", "train_end": "2024-01-04"},
         model={"class": "Ridge", "params": {"alpha": 2.0}},
@@ -226,7 +241,9 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
 
 
-def test_locked_holdout_lineage_transitions_once(tmp_path: Path) -> None:
+def test_locked_holdout_lineage_transitions_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     release = _seed_release(tmp_path)
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
     frame = _predictions()
@@ -250,6 +267,8 @@ def test_locked_holdout_lineage_transitions_once(tmp_path: Path) -> None:
     ).run(prices=_prices())
     candidates = CandidateSet.create(study, "selection", [validation_backtest])
     holdout_spec = _training_spec(cv={"phase": "holdout", "train_end": "2024-01-04"})
+    holdout_prices = _prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
+    _patch_holdout_prices(monkeypatch, holdout_prices)
     lock = study.lifecycle.lock(
         candidate_set_hash=candidates.hash,
         selected_backtest_hash=validation_backtest.hash,
@@ -281,16 +300,36 @@ def test_locked_holdout_lineage_transitions_once(tmp_path: Path) -> None:
     holdout_backtest = study.strategy(
         prediction=holdout_prediction,
         **request,
-    ).run(prices=_prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp")))
+    ).run()
+
+    with pytest.raises(ValueError, match="canonical holdout prices"):
+        study.strategy(prediction=holdout_prediction, **request).run(prices=holdout_prices)
     with pytest.raises(ValueError, match="locked validation strategy"):
         study.strategy(
             prediction=holdout_prediction,
             signal={"method": "equal_weight_top_k", "top_k": 2},
             execution_mode="vectorized",
-        ).run(prices=_prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp")))
+        ).run()
+
+    from case_studies.research import lifecycle
+
+    changed_prices = holdout_prices.with_columns((pl.col("close") + 1).alias("close"))
+    monkeypatch.setattr(
+        lifecycle,
+        "load_backtest_prices_for",
+        lambda case_study, label, *, split: changed_prices,
+    )
+    with pytest.raises(ValueError, match="exact complete canonical lineage"):
+        study.lifecycle.record_holdout(
+            lock.hash,
+            holdout_training_hash=holdout_training.hash,
+            holdout_prediction_hash=holdout_prediction.hash,
+            holdout_backtest_hash=holdout_backtest.hash,
+        )
     assert study.lifecycle.open(lock.hash).state == "LOCKED"
     with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
+    _patch_holdout_prices(monkeypatch, holdout_prices)
 
     evaluated = study.lifecycle.record_holdout(
         lock.hash,
@@ -307,3 +346,99 @@ def test_locked_holdout_lineage_transitions_once(tmp_path: Path) -> None:
             holdout_prediction_hash=holdout_prediction.hash,
             holdout_backtest_hash=holdout_backtest.hash,
         )
+
+
+def test_locked_conformal_holdout_uses_validation_residuals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    timestamps = pl.date_range(date(2023, 12, 18), date(2024, 1, 9), eager=True)
+    validation = pl.DataFrame(
+        {
+            "timestamp": [value for value in timestamps for _ in range(2)],
+            "symbol": [symbol for _ in timestamps for symbol in ("A", "B")],
+            "fold_id": [
+                fold for index in range(len(timestamps)) for fold in ([int(index >= 15)] * 2)
+            ],
+            "y_true": [0.01, -0.02] * len(timestamps),
+            "y_score": [0.02, -0.01] * len(timestamps),
+        }
+    )
+    prices = pl.DataFrame(
+        {
+            "timestamp": [value for value in timestamps for _ in range(2)],
+            "symbol": [symbol for _ in timestamps for symbol in ("A", "B")],
+            "close": [
+                100.0 + index if symbol == "A" else 100.0 - 0.3 * index
+                for index in range(len(timestamps))
+                for symbol in ("A", "B")
+            ],
+            "volume": [1_000] * (2 * len(timestamps)),
+        }
+    ).with_columns(
+        open=pl.col("close"),
+        high=pl.col("close") + 1,
+        low=pl.col("close") - 1,
+    )
+    training = study.results.register_training(_training_spec())
+    validation_prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=validation,
+        expected_keys=validation.select("symbol", "timestamp", "fold_id"),
+    )
+    request = {
+        "signal": {"method": "equal_weight_top_k", "top_k": 1},
+        "allocation": {
+            "method": "conformal_weighted",
+            "alpha": 0.2,
+            "min_calibration_n": 1,
+        },
+        "execution_mode": "vectorized",
+    }
+    validation_backtest = study.strategy(
+        prediction=validation_prediction,
+        **request,
+    ).run(prices=prices)
+    holdout_prices = _prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
+    _patch_holdout_prices(monkeypatch, holdout_prices)
+    candidates = CandidateSet.create(study, "conformal-selection", [validation_backtest])
+    holdout_spec = _training_spec(cv={"phase": "holdout", "train_end": "2024-01-09"})
+    lock = study.lifecycle.lock(
+        candidate_set_hash=candidates.hash,
+        selected_backtest_hash=validation_backtest.hash,
+        selection_evidence={"metric": "validation_backtest_sharpe"},
+        holdout_training_spec=holdout_spec,
+    )
+    holdout_training = study.results.register_training(holdout_spec)
+    holdout_frame = _predictions().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
+    holdout_prediction = study.results.publish_predictions(
+        holdout_training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="holdout",
+        predictions=holdout_frame,
+        expected_keys=holdout_frame.select("symbol", "timestamp", "fold_id"),
+    )
+
+    holdout_backtest = study.strategy(prediction=holdout_prediction, **request).run()
+    widths = pl.read_parquet(
+        study.root
+        / "run_log"
+        / "predictions"
+        / holdout_prediction.hash
+        / "conformal_widths.parquet"
+    )
+    evaluated = study.lifecycle.record_holdout(
+        lock.hash,
+        holdout_training_hash=holdout_training.hash,
+        holdout_prediction_hash=holdout_prediction.hash,
+        holdout_backtest_hash=holdout_backtest.hash,
+    )
+
+    assert widths.get_column("fold_id").unique().to_list() == [-1]
+    assert widths.get_column("calibration_n").min() == 2
+    assert evaluated.state == "HOLDOUT_EVALUATED"

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from datetime import date
 from pathlib import Path
 
 import polars as pl
@@ -108,6 +109,35 @@ def test_strategy_identity_covers_prices_costs_and_rejects_unknown_fields(tmp_pa
         )
 
 
+def test_strategy_normalizes_conformal_identity_before_hashing(tmp_path: Path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    strategy = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        allocation={"method": "conformal_weighted", "alpha": 0.2},
+        execution_mode="vectorized",
+    )
+
+    spec = strategy.resolve(prices=_prices())
+    allocation = spec["strategy"]["allocation"]
+
+    assert allocation["calibration_version"] == "walk_forward_v2"
+    assert allocation["min_calibration_n"] == 30
+    assert allocation["sparse_fallback"] == "pooled_prior_oos"
+
+
 def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
@@ -135,10 +165,7 @@ def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> N
 
     canonical_db = study.root / "run_log" / "registry.db"
     with sqlite3.connect(canonical_db) as db:
-        backtest_table = db.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'backtest_runs'"
-        ).fetchone()
-        assert backtest_table is None
+        assert db.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0] == 0
     assert preview_backtest.execution_tier == "preview"
     assert Result.open(study, preview_backtest.hash, include_preview=True).complete
     with pytest.raises(KeyError):
@@ -165,13 +192,28 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
     ).run(prices=_prices())
     candidates = CandidateSet.create(study, "selection", [backtest])
     assert candidates.best_validation_sharpe().hash == backtest.hash
+    invalid_holdout_spec = _training_spec(
+        cv={"phase": "holdout", "train_end": "2024-01-04"},
+        model={"class": "Ridge", "params": {"alpha": 2.0}},
+    )
+    with pytest.raises(ValueError, match="only in CV interval"):
+        study.lifecycle.lock(
+            candidate_set_hash=candidates.hash,
+            selected_backtest_hash=backtest.hash,
+            selection_evidence={"metric": "validation_backtest_sharpe"},
+            holdout_training_spec=invalid_holdout_spec,
+        )
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert db.execute("SELECT COUNT(*) FROM research_locks").fetchone()[0] == 0
+
     lock = study.lifecycle.lock(
         candidate_set_hash=candidates.hash,
         selected_backtest_hash=backtest.hash,
         selection_evidence={"metric": "validation_backtest_sharpe"},
+        holdout_training_spec=_training_spec(cv={"phase": "holdout", "train_end": "2024-01-04"}),
     )
 
-    with pytest.raises(ValueError, match="complete canonical holdout"):
+    with pytest.raises(ValueError, match="exact complete canonical lineage"):
         study.lifecycle.record_holdout(
             lock.hash,
             holdout_training_hash=training.hash,
@@ -182,3 +224,86 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
     assert study.lifecycle.open(lock.hash).state == "LOCKED"
     with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
+
+
+def test_locked_holdout_lineage_transitions_once(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    frame = _predictions()
+    expected = frame.select("symbol", "timestamp", "fold_id")
+    validation_training = study.results.register_training(_training_spec())
+    validation_prediction = study.results.publish_predictions(
+        validation_training,
+        checkpoint_kind="epoch",
+        checkpoint_value=3,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+    request = {
+        "signal": {"method": "equal_weight_top_k", "top_k": 1},
+        "execution_mode": "vectorized",
+    }
+    validation_backtest = study.strategy(
+        prediction=validation_prediction,
+        **request,
+    ).run(prices=_prices())
+    candidates = CandidateSet.create(study, "selection", [validation_backtest])
+    holdout_spec = _training_spec(cv={"phase": "holdout", "train_end": "2024-01-04"})
+    lock = study.lifecycle.lock(
+        candidate_set_hash=candidates.hash,
+        selected_backtest_hash=validation_backtest.hash,
+        selection_evidence={"metric": "validation_backtest_sharpe"},
+        holdout_training_spec=holdout_spec,
+    )
+    holdout_training = study.results.register_training(holdout_spec)
+    holdout_frame = frame.with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
+    holdout_expected = holdout_frame.select("symbol", "timestamp", "fold_id")
+    wrong_checkpoint = study.results.publish_predictions(
+        holdout_training,
+        checkpoint_kind="epoch",
+        checkpoint_value=4,
+        split="holdout",
+        predictions=holdout_frame,
+        expected_keys=holdout_expected,
+    )
+    with pytest.raises(ValueError, match="locked retraining contract"):
+        study.strategy(prediction=wrong_checkpoint, **request)
+
+    holdout_prediction = study.results.publish_predictions(
+        holdout_training,
+        checkpoint_kind="epoch",
+        checkpoint_value=3,
+        split="holdout",
+        predictions=holdout_frame,
+        expected_keys=holdout_expected,
+    )
+    holdout_backtest = study.strategy(
+        prediction=holdout_prediction,
+        **request,
+    ).run(prices=_prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp")))
+    with pytest.raises(ValueError, match="locked validation strategy"):
+        study.strategy(
+            prediction=holdout_prediction,
+            signal={"method": "equal_weight_top_k", "top_k": 2},
+            execution_mode="vectorized",
+        ).run(prices=_prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp")))
+    assert study.lifecycle.open(lock.hash).state == "LOCKED"
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
+
+    evaluated = study.lifecycle.record_holdout(
+        lock.hash,
+        holdout_training_hash=holdout_training.hash,
+        holdout_prediction_hash=holdout_prediction.hash,
+        holdout_backtest_hash=holdout_backtest.hash,
+    )
+
+    assert evaluated.state == "HOLDOUT_EVALUATED"
+    with pytest.raises(ValueError, match="LOCKED"):
+        study.lifecycle.record_holdout(
+            lock.hash,
+            holdout_training_hash=holdout_training.hash,
+            holdout_prediction_hash=holdout_prediction.hash,
+            holdout_backtest_hash=holdout_backtest.hash,
+        )

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from case_studies.research import CandidateSet, Result, Strategy, Study
+from case_studies.research import CandidateSet, PredictionResult, Result, Strategy, Study
 from tests.test_research_registry import _predictions, _training_spec
 from tests.test_research_workspace import _seed_release
 
@@ -56,6 +56,19 @@ def _patch_holdout_prices(monkeypatch: pytest.MonkeyPatch, prices: pl.DataFrame)
     monkeypatch.setattr(lifecycle, "load_backtest_prices_for", load_prices)
     monkeypatch.setattr(strategy, "load_backtest_prices_for", load_prices)
     return warmups
+
+
+def _publish_validation_prediction(study: Study) -> PredictionResult:
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    return study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
 
 
 def test_fake_prediction_to_backtest_flow_survives_restart(tmp_path: Path) -> None:
@@ -157,6 +170,62 @@ def test_strategy_normalizes_conformal_identity_before_hashing(tmp_path: Path) -
     assert allocation["calibration_version"] == "walk_forward_v2"
     assert allocation["min_calibration_n"] == 30
     assert allocation["sparse_fallback"] == "pooled_prior_oos"
+
+
+def test_strategy_default_lookback_ignores_larger_unrelated_sweep_variant(
+    tmp_path: Path,
+) -> None:
+    from case_studies.utils.backtest_loaders import warmup_periods_for
+
+    release = _seed_release(tmp_path)
+    setup_path = release / "case_studies" / "etfs" / "config" / "setup.yaml"
+    setup_path.write_text(
+        setup_path.read_text()
+        + "execution:\n"
+        + "  allocator_lookback: 3\n"
+        + "backtest:\n"
+        + "  sweep:\n"
+        + "    allocators:\n"
+        + "      - method: risk_parity\n"
+        + "        vol_window: 99\n"
+    )
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    prediction = _publish_validation_prediction(study)
+    strategy = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        allocation={"method": "inverse_vol"},
+        execution_mode="vectorized",
+    )
+
+    spec = strategy.resolve(prices=_prices())
+
+    assert warmup_periods_for("etfs") == 99
+    assert spec["strategy"]["allocation"]["vol_window"] == 3
+
+
+def test_strategy_preserves_explicit_lookback_alias_without_injecting_vol_window(
+    tmp_path: Path,
+) -> None:
+    from case_studies.research.strategy import strategy_warmup_periods
+
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    prediction = _publish_validation_prediction(study)
+    strategy = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        allocation={"method": "inverse_vol", "lookback": 7},
+        execution_mode="vectorized",
+    )
+
+    spec = strategy.resolve(prices=_prices())
+    allocation = spec["strategy"]["allocation"]
+
+    assert allocation["lookback"] == 7
+    assert "vol_window" not in allocation
+    assert strategy_warmup_periods(spec) == 7
 
 
 def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> None:

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import CandidateSet, Result, Strategy, Study
+from tests.test_research_registry import _predictions, _training_spec
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _prices() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["A", "B"],
+            "timestamp": ["2024-01-05", "2024-01-05"],
+            "open": [100.0, 100.0],
+            "high": [101.0, 101.0],
+            "low": [99.0, 99.0],
+            "close": [100.5, 99.5],
+            "volume": [1_000, 1_000],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+
+
+def test_fake_prediction_to_backtest_flow_survives_restart(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    training = study.results.register_training(_training_spec())
+    predictions = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=predictions,
+        expected_keys=predictions.select("symbol", "timestamp", "fold_id"),
+    )
+    direct = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        execution_mode="vectorized",
+    )
+    first = direct.run(prices=_prices())
+
+    reopened_study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    reopened_prediction = Result.open(reopened_study, prediction.hash)
+    notebook_request = {
+        "prediction": reopened_prediction,
+        "signal": {"method": "equal_weight_top_k", "top_k": 1},
+        "execution_mode": "vectorized",
+    }
+    notebook_style = Strategy.from_request(reopened_study, notebook_request)
+    second = notebook_style.run(prices=_prices())
+
+    assert reopened_prediction.hash == prediction.hash
+    assert direct.identity(prices=_prices()) == notebook_style.identity(prices=_prices())
+    assert first.hash == second.hash
+
+
+def test_strategy_identity_covers_prices_costs_and_rejects_unknown_fields(tmp_path: Path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    base = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        execution_mode="vectorized",
+    )
+    changed_costs = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        costs={"commission_bps": 5.0, "slippage_bps": 2.0},
+        execution_mode="vectorized",
+    )
+    changed_prices = _prices().with_columns((pl.col("close") + 1).alias("close"))
+
+    assert base.identity(prices=_prices()) != changed_costs.identity(prices=_prices())
+    assert base.identity(prices=_prices()) != base.identity(prices=changed_prices)
+    with pytest.raises(ValueError, match="unsupported"):
+        study.strategy(
+            prediction=prediction,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            typo=True,
+        )
+
+
+def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    training = study.results.register_training(
+        _training_spec(
+            execution_tier="preview",
+            preview_reductions={"folds": [0], "max_rows": 2},
+        ),
+        execution_tier="preview",
+    )
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    preview_backtest = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        execution_mode="vectorized",
+    ).run(prices=_prices())
+
+    canonical_db = study.root / "run_log" / "registry.db"
+    with sqlite3.connect(canonical_db) as db:
+        backtest_table = db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'backtest_runs'"
+        ).fetchone()
+        assert backtest_table is None
+    assert preview_backtest.execution_tier == "preview"
+    assert Result.open(study, preview_backtest.hash, include_preview=True).complete
+    with pytest.raises(KeyError):
+        Result.open(study, preview_backtest.hash)
+
+
+def test_lock_transition_failure_is_atomic(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    backtest = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        execution_mode="vectorized",
+    ).run(prices=_prices())
+    candidates = CandidateSet.create(study, "selection", [backtest])
+    assert candidates.best_validation_sharpe().hash == backtest.hash
+    lock = study.lifecycle.lock(
+        candidate_set_hash=candidates.hash,
+        selected_backtest_hash=backtest.hash,
+        selection_evidence={"metric": "validation_backtest_sharpe"},
+    )
+
+    with pytest.raises(ValueError, match="complete canonical holdout"):
+        study.lifecycle.record_holdout(
+            lock.hash,
+            holdout_training_hash=training.hash,
+            holdout_prediction_hash=prediction.hash,
+            holdout_backtest_hash=backtest.hash,
+        )
+
+    assert study.lifecycle.open(lock.hash).state == "LOCKED"
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -37,15 +37,25 @@ def _prices() -> pl.DataFrame:
     ).with_columns(pl.col("timestamp").str.to_date())
 
 
-def _patch_holdout_prices(monkeypatch: pytest.MonkeyPatch, prices: pl.DataFrame) -> None:
+def _patch_holdout_prices(monkeypatch: pytest.MonkeyPatch, prices: pl.DataFrame) -> list[int]:
     from case_studies.research import lifecycle, strategy
 
-    def load_prices(case_study: str, label: str, *, split: str):
+    warmups: list[int] = []
+
+    def load_prices(
+        case_study: str,
+        label: str,
+        *,
+        split: str,
+        warmup_periods: int = 0,
+    ):
         assert (case_study, label, split) == ("etfs", "fwd_ret_21d", "holdout")
+        warmups.append(warmup_periods)
         return prices
 
     monkeypatch.setattr(lifecycle, "load_backtest_prices_for", load_prices)
     monkeypatch.setattr(strategy, "load_backtest_prices_for", load_prices)
+    return warmups
 
 
 def test_fake_prediction_to_backtest_flow_survives_restart(tmp_path: Path) -> None:
@@ -241,7 +251,7 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path, monkeypatch: pytest.M
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
 
 
-def test_locked_holdout_lineage_transitions_once(
+def test_locked_rolling_allocator_holdout_preserves_warmup_and_transitions_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     release = _seed_release(tmp_path)
@@ -259,6 +269,7 @@ def test_locked_holdout_lineage_transitions_once(
     )
     request = {
         "signal": {"method": "equal_weight_top_k", "top_k": 1},
+        "allocation": {"method": "inverse_vol", "vol_window": 2},
         "execution_mode": "vectorized",
     }
     validation_backtest = study.strategy(
@@ -267,8 +278,16 @@ def test_locked_holdout_lineage_transitions_once(
     ).run(prices=_prices())
     candidates = CandidateSet.create(study, "selection", [validation_backtest])
     holdout_spec = _training_spec(cv={"phase": "holdout", "train_end": "2024-01-04"})
-    holdout_prices = _prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
-    _patch_holdout_prices(monkeypatch, holdout_prices)
+    holdout_prices = pl.concat(
+        [
+            _prices().with_columns(
+                pl.lit(date(2024, 1, day)).alias("timestamp"),
+                (pl.col("close") + day / 10).alias("close"),
+            )
+            for day in range(8, 12)
+        ]
+    )
+    warmups = _patch_holdout_prices(monkeypatch, holdout_prices)
     lock = study.lifecycle.lock(
         candidate_set_hash=candidates.hash,
         selected_backtest_hash=validation_backtest.hash,
@@ -308,6 +327,7 @@ def test_locked_holdout_lineage_transitions_once(
         study.strategy(
             prediction=holdout_prediction,
             signal={"method": "equal_weight_top_k", "top_k": 2},
+            allocation={"method": "inverse_vol", "vol_window": 2},
             execution_mode="vectorized",
         ).run()
 
@@ -317,7 +337,7 @@ def test_locked_holdout_lineage_transitions_once(
     monkeypatch.setattr(
         lifecycle,
         "load_backtest_prices_for",
-        lambda case_study, label, *, split: changed_prices,
+        lambda case_study, label, *, split, warmup_periods=0: changed_prices,
     )
     with pytest.raises(ValueError, match="exact complete canonical lineage"):
         study.lifecycle.record_holdout(
@@ -329,7 +349,7 @@ def test_locked_holdout_lineage_transitions_once(
     assert study.lifecycle.open(lock.hash).state == "LOCKED"
     with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
-    _patch_holdout_prices(monkeypatch, holdout_prices)
+    restored_warmups = _patch_holdout_prices(monkeypatch, holdout_prices)
 
     evaluated = study.lifecycle.record_holdout(
         lock.hash,
@@ -339,6 +359,7 @@ def test_locked_holdout_lineage_transitions_once(
     )
 
     assert evaluated.state == "HOLDOUT_EVALUATED"
+    assert warmups + restored_warmups == [2, 2, 2]
     with pytest.raises(ValueError, match="LOCKED"):
         study.lifecycle.record_holdout(
             lock.hash,

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import CandidateSet, Result, Study
+from case_studies.utils.registry import (
+    backtest_hash_from_parts,
+    prediction_hash_from_parts,
+    training_hash_from_spec,
+)
+from case_studies.utils.registry.store import _open_registry
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _study(tmp_path: Path) -> Study:
+    return Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+
+
+def _training_spec(**changes) -> dict:
+    spec = {
+        "identity_version": 2,
+        "family": "linear",
+        "label": "fwd_ret_21d",
+        "label_artifact": "label-a",
+        "feature_artifacts": {"financial": "features-a"},
+        "feature_names": ["momentum", "volatility"],
+        "cv": {"folds": [{"fold": 0, "val_start": "2024-01-05"}]},
+        "model": {"class": "Ridge", "params": {"alpha": 1.0}},
+        "numerics": {"seed": 42, "precision": "float64"},
+        "execution_tier": "canonical",
+        "seed": 42,
+    }
+    spec.update(changes)
+    return spec
+
+
+def _predictions() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["A", "B"],
+            "timestamp": ["2024-01-05", "2024-01-05"],
+            "fold_id": [0, 0],
+            "y_true": [0.01, -0.02],
+            "y_score": [0.02, -0.01],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+
+
+def test_version_2_identity_is_semantic_and_legacy_hashes_are_pinned() -> None:
+    base = _training_spec()
+    same = {**base, "display_name": "Reader experiment", "notebook_path": "/tmp/book.ipynb"}
+    assert training_hash_from_spec(base) == training_hash_from_spec(same)
+
+    for mutation in (
+        {"label_artifact": "label-b"},
+        {"feature_artifacts": {"financial": "features-b"}},
+        {"cv": {"folds": [{"fold": 0, "val_start": "2024-01-06"}]}},
+        {"model": {"class": "Ridge", "params": {"alpha": 2.0}}},
+        {"execution_tier": "preview"},
+    ):
+        assert training_hash_from_spec(base) != training_hash_from_spec({**base, **mutation})
+
+    legacy = {"family": "linear", "label": "fwd_ret_21d", "seed": 42}
+    assert training_hash_from_spec(legacy) == "a32ccdc1db2e"
+    assert prediction_hash_from_parts("abc", None, "validation") == "f8d8ffe712a3"
+    assert backtest_hash_from_parts("pred", {"top_k": 10}) == "921c296be434"
+
+
+def test_checkpoint_kind_is_part_of_version_2_prediction_identity() -> None:
+    a = prediction_hash_from_parts(
+        "training", 10, "validation", checkpoint_kind="epoch", identity_version=2
+    )
+    b = prediction_hash_from_parts(
+        "training", 10, "validation", checkpoint_kind="tree_limit", identity_version=2
+    )
+    assert a != b
+
+
+def test_legacy_result_reopens_without_being_inferred_complete(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    db = _open_registry(study.root)
+    try:
+        db.execute(
+            "INSERT INTO training_runs "
+            "(training_hash, family, label, spec_json, created_at) VALUES (?,?,?,?,?)",
+            ("legacy-training", "linear", "fwd_ret_21d", "{}", "2024-01-01"),
+        )
+        db.execute(
+            "INSERT INTO prediction_sets "
+            "(prediction_hash, training_hash, split, created_at) VALUES (?,?,?,?)",
+            ("legacy-prediction", "legacy-training", "validation", "2024-01-01"),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    reopened = Result.open(study, "legacy-prediction")
+
+    assert reopened.hash == "legacy-prediction"
+    assert reopened.identity_version is None
+    assert not reopened.complete
+    assert reopened.coverage() is None
+
+
+def test_legacy_registry_schema_migrates_additively(tmp_path: Path) -> None:
+    case_dir = tmp_path / "legacy" / "etfs"
+    db_path = case_dir / "run_log" / "registry.db"
+    db_path.parent.mkdir(parents=True)
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY,
+                family TEXT NOT NULL,
+                label TEXT NOT NULL,
+                config_name TEXT,
+                spec_json TEXT,
+                created_at TEXT NOT NULL,
+                git_commit TEXT,
+                entry_point TEXT
+            )
+            """
+        )
+        db.execute(
+            "INSERT INTO training_runs "
+            "(training_hash, family, label, spec_json, created_at) VALUES (?,?,?,?,?)",
+            ("legacy-training", "linear", "fwd_ret_21d", "{}", "2024-01-01"),
+        )
+        db.commit()
+
+    migrated = _open_registry(case_dir)
+    try:
+        columns = {
+            row[1] for row in migrated.execute("PRAGMA table_info(training_runs)").fetchall()
+        }
+        tables = {
+            row[0]
+            for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        row = migrated.execute(
+            "SELECT training_hash, identity_version, execution_tier FROM training_runs"
+        ).fetchone()
+    finally:
+        migrated.close()
+
+    assert {"identity_version", "execution_tier"} <= columns
+    assert {"prediction_coverage", "candidate_sets", "research_locks"} <= tables
+    assert row == ("legacy-training", None, None)
+
+
+def test_invalid_coverage_registration_is_atomic(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec())
+    actual = _predictions().head(1)
+    expected = _predictions().select("symbol", "timestamp", "fold_id")
+
+    with pytest.raises(ValueError, match="coverage"):
+        study.results.publish_predictions(
+            training,
+            checkpoint_kind="final",
+            checkpoint_value=None,
+            split="validation",
+            predictions=actual,
+            expected_keys=expected,
+        )
+
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert db.execute("SELECT COUNT(*) FROM prediction_sets").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM prediction_coverage").fetchone()[0] == 0
+    assert not list((study.root / "run_log" / "predictions").glob("*"))
+
+
+def test_version_2_registration_is_immutable(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec(display_name="first"))
+    assert (
+        study.results.register_training(_training_spec(display_name="second")).hash == training.hash
+    )
+    frame = _predictions()
+    expected = frame.select("symbol", "timestamp", "fold_id")
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+
+    with pytest.raises(ValueError, match="artifact conflict"):
+        study.results.publish_predictions(
+            training,
+            checkpoint_kind="final",
+            checkpoint_value=None,
+            split="validation",
+            predictions=frame.with_columns((pl.col("y_score") + 1).alias("y_score")),
+            expected_keys=expected,
+        )
+
+    assert prediction.load().get_column("y_score").to_list() == [0.02, -0.01]
+
+
+def test_checkpoint_prediction_schema_must_match(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    expected = frame.select("symbol", "timestamp", "fold_id")
+    study.results.publish_predictions(
+        training,
+        checkpoint_kind="epoch",
+        checkpoint_value=1,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+
+    with pytest.raises(ValueError, match="schema"):
+        study.results.publish_predictions(
+            training,
+            checkpoint_kind="epoch",
+            checkpoint_value=2,
+            split="validation",
+            predictions=frame.with_columns(pl.lit("extra").alias("diagnostic")),
+            expected_keys=expected,
+        )
+
+
+def test_preview_requires_identity_covered_reductions(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+
+    with pytest.raises(ValueError, match="identity-cover"):
+        study.results.register_training(
+            _training_spec(execution_tier="preview"), execution_tier="preview"
+        )
+
+    assert not (study.output_root / ".preview" / "etfs" / "run_log").exists()
+
+
+def test_candidate_sets_are_immutable_and_validate_protocols(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    expected = frame.select("symbol", "timestamp", "fold_id")
+    first = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+    second = study.results.publish_predictions(
+        training,
+        checkpoint_kind="epoch",
+        checkpoint_value=2,
+        split="validation",
+        predictions=frame.with_columns((pl.col("y_score") * 2).alias("y_score")),
+        expected_keys=expected,
+    )
+
+    original = CandidateSet.create(study, "baseline", [first])
+    extended = original.extend("baseline-plus", [second])
+
+    assert original.members == (first.hash,)
+    assert extended.members == (first.hash, second.hash)
+    assert original.hash != extended.hash
+    assert CandidateSet.open(study, original.hash).members == (first.hash,)
+
+    other_training = study.results.register_training(
+        _training_spec(cv={"folds": [{"fold": 1, "val_start": "2024-01-06"}]})
+    )
+    incompatible = study.results.publish_predictions(
+        other_training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+    with pytest.raises(ValueError, match="protocol"):
+        CandidateSet.create(study, "invalid", [first, incompatible])
+
+
+def test_partial_and_preview_results_are_rejected_from_canonical_sets(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    canonical_training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    partial = study.results.publish_predictions(
+        canonical_training,
+        checkpoint_kind="epoch",
+        checkpoint_value=1,
+        split="validation",
+        predictions=frame.head(1),
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+        allow_partial=True,
+    )
+    with pytest.raises(ValueError, match="partial"):
+        CandidateSet.create(study, "partial", [partial])
+    with pytest.raises(ValueError, match="partial"):
+        study.strategy(
+            prediction=partial,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            execution_mode="vectorized",
+        )
+
+    preview_training = study.results.register_training(
+        _training_spec(execution_tier="preview", preview_reductions={"folds": [0], "max_rows": 2}),
+        execution_tier="preview",
+    )
+    preview = study.results.publish_predictions(
+        preview_training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+
+    with pytest.raises(ValueError, match="preview"):
+        CandidateSet.create(study, "canonical", [preview])
+    with pytest.raises(KeyError):
+        Result.open(study, preview.hash)
+    assert Result.open(study, preview.hash, include_preview=True).hash == preview.hash

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -119,6 +119,61 @@ def test_legacy_result_reopens_without_being_inferred_complete(tmp_path: Path) -
     assert reopened.coverage() is None
 
 
+def test_read_only_legacy_registry_reopens_without_schema_writes(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    db_path = release / "case_studies" / "etfs" / "run_log" / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE training_runs ("
+            "training_hash TEXT PRIMARY KEY, family TEXT NOT NULL, label TEXT NOT NULL, "
+            "spec_json TEXT, created_at TEXT NOT NULL)"
+        )
+        db.execute(
+            "CREATE TABLE prediction_sets ("
+            "prediction_hash TEXT PRIMARY KEY, training_hash TEXT NOT NULL, "
+            "split TEXT NOT NULL, created_at TEXT NOT NULL)"
+        )
+        db.execute(
+            "INSERT INTO training_runs VALUES (?,?,?,?,?)",
+            ("legacy-training", "linear", "fwd_ret_21d", "{}", "2024-01-01"),
+        )
+        db.execute(
+            "INSERT INTO prediction_sets VALUES (?,?,?,?)",
+            ("legacy-prediction", "legacy-training", "validation", "2024-01-01"),
+        )
+        db.commit()
+    before = db_path.read_bytes()
+
+    study = Study.open("etfs", release_root=release)
+    reopened = Result.open(study, "legacy-prediction")
+
+    assert reopened.identity_version is None
+    assert not reopened.complete
+    assert db_path.read_bytes() == before
+
+
+def test_workspace_open_migrates_copied_legacy_registry(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    db_path = release / "case_studies" / "etfs" / "run_log" / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE training_runs ("
+            "training_hash TEXT PRIMARY KEY, family TEXT NOT NULL, label TEXT NOT NULL, "
+            "spec_json TEXT, created_at TEXT NOT NULL)"
+        )
+        db.commit()
+
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        columns = {row[1] for row in db.execute("PRAGMA table_info(training_runs)")}
+        coverage_table = db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'prediction_coverage'"
+        ).fetchone()
+
+    assert {"identity_version", "execution_tier"} <= columns
+    assert coverage_table == (1,)
+
+
 def test_legacy_registry_schema_migrates_additively(tmp_path: Path) -> None:
     case_dir = tmp_path / "legacy" / "etfs"
     db_path = case_dir / "run_log" / "registry.db"
@@ -298,6 +353,35 @@ def test_candidate_sets_are_immutable_and_validate_protocols(tmp_path: Path) -> 
     )
     with pytest.raises(ValueError, match="protocol"):
         CandidateSet.create(study, "invalid", [first, incompatible])
+
+    comparison = {"comparable_fields": ["cv"]}
+    ordered = CandidateSet.create(
+        study,
+        "cv-comparison",
+        [first, incompatible],
+        comparison_contract=comparison,
+    )
+    reversed_set = CandidateSet.create(
+        study,
+        "cv-comparison-reversed",
+        [incompatible, first],
+        comparison_contract=comparison,
+    )
+    third = study.results.publish_predictions(
+        study.results.register_training(
+            _training_spec(cv={"folds": [{"fold": 2, "val_start": "2024-01-07"}]})
+        ),
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=expected,
+    )
+    extended_comparison = ordered.extend("cv-comparison-plus", [third])
+
+    assert ordered.hash == reversed_set.hash
+    assert ordered.comparison_contract["protocol"].get("cv") is None
+    assert set(extended_comparison.members) == {first.hash, incompatible.hash, third.hash}
 
 
 def test_partial_and_preview_results_are_rejected_from_canonical_sets(tmp_path: Path) -> None:

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -161,6 +161,11 @@ def test_workspace_open_migrates_copied_legacy_registry(tmp_path: Path) -> None:
             "training_hash TEXT PRIMARY KEY, family TEXT NOT NULL, label TEXT NOT NULL, "
             "spec_json TEXT, created_at TEXT NOT NULL)"
         )
+        db.execute(
+            "CREATE TABLE prediction_sets ("
+            "prediction_hash TEXT PRIMARY KEY, training_hash TEXT NOT NULL, "
+            "split TEXT NOT NULL, created_at TEXT NOT NULL)"
+        )
         db.commit()
 
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
@@ -172,6 +177,20 @@ def test_workspace_open_migrates_copied_legacy_registry(tmp_path: Path) -> None:
 
     assert {"identity_version", "execution_tier"} <= columns
     assert coverage_table == (1,)
+
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+
+    assert training.complete
+    assert prediction.complete
 
 
 def test_legacy_registry_schema_migrates_additively(tmp_path: Path) -> None:

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import CVSpec, LabelDefinition, Study
+from utils.artifact_specs import load_setup_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(root)).encode())
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _seed_release(tmp_path: Path, *, marker: str = "release") -> Path:
+    release = tmp_path / "release"
+    case_dir = release / "case_studies" / "etfs"
+    (case_dir / "run_log").mkdir(parents=True)
+    (case_dir / "run_log" / "registry.db").write_bytes(b"")
+    (case_dir / "config").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text(
+        "\n".join(
+            [
+                f"marker: {marker}",
+                "labels:",
+                "  primary: fwd_ret_21d",
+                "  buffer: 2D",
+                "  horizons: {fwd_ret_21d: 2D}",
+                "evaluation:",
+                "  n_splits: 2",
+                "  train_size: 4D",
+                "  val_size: 2D",
+                "  holdout_start: '2024-01-11'",
+                "  holdout_end: '2024-01-12'",
+                "  calendar: crypto",
+                "decision:",
+                "  cadence: daily_close",
+                "  execution_delay: next_bar_open",
+                "mapping:",
+                "  position_state_space: long_only",
+                "costs:",
+                "  class: negligible",
+            ]
+        )
+        + "\n"
+    )
+    shared = release / "case_studies" / "config" / "linear"
+    shared.mkdir(parents=True)
+    (shared / "ridge.yaml").write_text("family: linear\nparams: {}\n")
+    return release
+
+
+def test_study_create_and_reopen_do_not_change_release_bytes(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    before = _tree_digest(release)
+
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    reopened = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+
+    assert study.root == reopened.root == tmp_path / "workspace" / "etfs"
+    assert study.manifest == reopened.manifest
+    assert _tree_digest(release) == before
+
+
+def test_release_study_is_read_only(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+
+    study = Study.open("etfs", release_root=release)
+
+    assert study.read_only
+    with pytest.raises(PermissionError, match="read-only"):
+        study.labels.publish(
+            LabelDefinition("custom", "regression", "1D"),
+            pl.DataFrame(
+                {
+                    "symbol": ["A"],
+                    "timestamp": [pl.date(2024, 1, 1)],
+                    "custom": [0.1],
+                }
+            ),
+        )
+
+
+def test_switching_workspaces_invalidates_root_sensitive_config_cache(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    first = Study.open("etfs", workspace=tmp_path / "first", release_root=release)
+    (first.root / "config" / "setup.yaml").write_text(
+        (first.root / "config" / "setup.yaml").read_text().replace("release", "first")
+    )
+    assert load_setup_config("etfs")["marker"] == "first"
+
+    second = Study.open("etfs", workspace=tmp_path / "second", release_root=release)
+    (second.root / "config" / "setup.yaml").write_text(
+        (second.root / "config" / "setup.yaml").read_text().replace("release", "second")
+    )
+
+    assert load_setup_config("etfs")["marker"] == "second"
+
+
+def test_custom_classification_label_resolves_continuous_target(tmp_path: Path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    frame = pl.DataFrame(
+        {
+            "symbol": ["A", "B"],
+            "timestamp": ["2024-01-01", "2024-01-01"],
+            "up_90p_5d": [0, 1],
+            "fwd_ret_5d": [-0.01, 0.03],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+
+    published = study.labels.publish(
+        LabelDefinition(
+            name="up_90p_5d",
+            task_type="classification",
+            horizon="5D",
+            continuous_eval_label="fwd_ret_5d",
+        ),
+        frame,
+    )
+    reopened = Study.open("etfs", workspace=tmp_path / "workspace", release_root=study.release_root)
+    resolved = reopened.labels.get("up_90p_5d")
+
+    assert published.digest == resolved.digest
+    assert resolved.definition.continuous_eval_label == "fwd_ret_5d"
+    assert resolved.load().get_column("fwd_ret_5d").to_list() == [-0.01, 0.03]
+
+
+def test_invalid_label_publication_has_no_partial_writes(tmp_path: Path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    definition = LabelDefinition(
+        name="up_90p_5d",
+        task_type="classification",
+        horizon="5D",
+        continuous_eval_label="fwd_ret_5d",
+    )
+    invalid = pl.DataFrame(
+        {
+            "symbol": ["A", "A"],
+            "timestamp": ["2024-01-01", "2024-01-01"],
+            "up_90p_5d": [0, 1],
+        }
+    )
+
+    with pytest.raises(ValueError):
+        study.labels.publish(definition, invalid)
+
+    assert not (study.root / "labels" / "up_90p_5d.parquet").exists()
+    assert not (study.root / "labels" / "up_90p_5d.parquet.digest.json").exists()
+
+
+def test_label_discovery_rejects_artifact_digest_mismatch(tmp_path: Path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    frame = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": ["2024-01-01"],
+            "custom": [0.1],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    published = study.labels.publish(LabelDefinition("custom", "regression", "1D"), frame)
+    frame.with_columns(pl.lit(0.2).alias("custom")).write_parquet(published.path)
+
+    with pytest.raises(ValueError, match="digest"):
+        study.labels.get("custom")
+
+
+def test_cvspec_resolves_stable_exact_boundaries_and_changes_with_protocol() -> None:
+    timeline = pl.DataFrame(
+        {"timestamp": pl.date_range(pl.date(2024, 1, 1), pl.date(2024, 1, 12), eager=True)}
+    )
+    base = CVSpec.walk_forward(
+        training_window="4D",
+        validation_window="2D",
+        retrain_every="2D",
+        folds=range(2),
+        horizon="1D",
+        holdout_start="2024-01-11",
+        holdout_end="2024-01-12",
+        calendar=None,
+    )
+
+    first = base.resolve(timeline)
+    second = base.resolve(timeline)
+    reordered = base.with_changes(folds=(1, 0)).resolve(timeline)
+    changed = base.with_changes(training_window="3D").resolve(timeline)
+
+    assert first == second == reordered
+    assert first.normalized_folds != changed.normalized_folds
+    assert first.identity != changed.identity

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -313,6 +313,8 @@ def generate_cv_splits(
             "holdout_start": cv_config.get(holdout_start_key),
             "holdout_end": cv_config.get(holdout_end_key),
             "calendar": cv_config.get("calendar"),
+            "step_size": cv_config.get("step_size"),
+            "expanding": bool(cv_config.get("expanding", False)),
         }
     elif setup_path is not None:
         with open(setup_path) as f:
@@ -346,6 +348,7 @@ def generate_cv_splits(
         label_horizon=label_horizon,
         calendar_id=calendar_id,
         fold_direction="backward",
+        step_size=eval_config.get("step_size"),
     )
 
     # Extract sorted unique timestamps from the dataset
@@ -367,9 +370,9 @@ def generate_cv_splits(
         index=ts_index,
     )
 
-    # Create WalkForwardCV with rolling window (expanding=False)
+    # Create WalkForwardCV with the resolved rolling or expanding behavior.
     cv = WalkForwardCV(config=config)
-    cv.expanding = False
+    cv.expanding = bool(eval_config.get("expanding", False))
 
     # Generate splits and extract date boundaries.
     # Match tz-awareness to the input data so comparisons work.


### PR DESCRIPTION
## Summary

- add root-isolated research workspaces, labels, CV identities, immutable result references, candidate sets, and lifecycle locks
- extend the existing registry with versioned training, prediction, backtest, coverage, and lifecycle records while preserving legacy reads
- dispatch canonical and preview strategies through the existing backtest engine, including exact allocator warmup and locked holdout validation
- add behavioral coverage for atomic failure paths, process restarts, identity changes, preview rejection, partial predictions, and rolling allocator holdout transitions

## Verification

- `ML4T_DATA_PATH=/home/stefan/ml4t/code/data PYTHONUNBUFFERED=1 uv run pytest --ignore=tests/test_case_studies.py --ignore=tests/test_chapter_notebooks.py --ignore=tests/test_docker_notebooks.py --ignore=tests/test_model_registry.py`
- `uv run pre-commit run --all-files`
- RoboRev branch review job 13110: no issues found