### PR TITLE
Add shared research model catalog and linear runner

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -1,13 +1,16 @@
+from .adapters import AdapterBinding, get_adapter, register_adapter, registered_adapters
 from .comparison import CandidateSet
 from .contracts import ExecutionTier, LifecycleState
 from .cv import CVSpec, ResolvedCVSpec
 from .labels import LabelDefinition, LabelRef
 from .lifecycle import ResearchLock
+from .models import ModelRequest, ModelRun, ResolvedModelRequest
 from .results import BacktestResult, PredictionResult, Result, TrainingResult
 from .strategy import Strategy
 from .workspace import Study
 
 __all__ = [
+    "AdapterBinding",
     "BacktestResult",
     "CVSpec",
     "CandidateSet",
@@ -15,11 +18,17 @@ __all__ = [
     "LabelDefinition",
     "LabelRef",
     "LifecycleState",
+    "ModelRequest",
+    "ModelRun",
     "PredictionResult",
     "ResearchLock",
+    "ResolvedModelRequest",
     "ResolvedCVSpec",
     "Result",
     "Strategy",
     "Study",
     "TrainingResult",
+    "get_adapter",
+    "register_adapter",
+    "registered_adapters",
 ]

--- a/case_studies/research/adapters.py
+++ b/case_studies/research/adapters.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from types import ModuleType
+
+
+@dataclass(frozen=True)
+class AdapterBinding:
+    kind: str
+    name: str
+    module: str
+
+    def load(self) -> ModuleType:
+        return importlib.import_module(self.module)
+
+
+_BINDINGS: dict[tuple[str, str], AdapterBinding] = {}
+_KINDS = {"causal", "model"}
+
+
+def register_adapter(kind: str, name: str, module: str, *, replace: bool = False) -> None:
+    if kind not in _KINDS:
+        raise ValueError(f"unsupported adapter kind {kind!r}; expected {sorted(_KINDS)}")
+    if not name or not module:
+        raise ValueError("adapter name and module are required")
+    key = (kind, name)
+    binding = AdapterBinding(kind, name, module)
+    existing = _BINDINGS.get(key)
+    if existing is not None and existing != binding and not replace:
+        raise ValueError(f"adapter {kind}/{name} is already registered by {existing.module}")
+    _BINDINGS[key] = binding
+
+
+def get_adapter(kind: str, name: str) -> ModuleType:
+    try:
+        binding = _BINDINGS[(kind, name)]
+    except KeyError as exc:
+        available = sorted(key_name for key_kind, key_name in _BINDINGS if key_kind == kind)
+        raise ValueError(
+            f"unsupported {kind} adapter {name!r}; available adapters: {available}"
+        ) from exc
+    return binding.load()
+
+
+def registered_adapters(kind: str) -> tuple[AdapterBinding, ...]:
+    if kind not in _KINDS:
+        raise ValueError(f"unsupported adapter kind {kind!r}; expected {sorted(_KINDS)}")
+    return tuple(
+        binding for (binding_kind, _), binding in sorted(_BINDINGS.items()) if binding_kind == kind
+    )
+
+
+for _name, _module in {
+    "deep_learning": "case_studies.utils.deep_learning",
+    "gbm": "case_studies.utils.gbm",
+    "latent_factors": "case_studies.utils.latent_factors",
+    "linear": "case_studies.utils.linear",
+    "tabular_dl": "case_studies.utils.tabular_dl",
+}.items():
+    register_adapter("model", _name, _module)
+
+register_adapter("causal", "dml", "case_studies.utils.causal")

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections.abc import Iterable
+from contextlib import closing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -115,7 +116,7 @@ class CandidateSet:
     @classmethod
     def open(cls, study: Study, set_hash: str) -> CandidateSet:
         db_path = study.root / "run_log" / "registry.db"
-        with sqlite3.connect(db_path) as db:
+        with closing(sqlite3.connect(db_path)) as db:
             row = db.execute(
                 "SELECT name, member_kind, comparison_contract_json FROM candidate_sets "
                 "WHERE set_hash = ?",
@@ -147,7 +148,7 @@ class CandidateSet:
         if self.member_kind != "backtest":
             raise ValueError("validation Sharpe selection requires backtest members")
         placeholders = ",".join("?" for _ in self.members)
-        with sqlite3.connect(self.study.root / "run_log" / "registry.db") as db:
+        with closing(sqlite3.connect(self.study.root / "run_log" / "registry.db")) as db:
             rows = db.execute(
                 f"""
                 SELECT m.backtest_hash, m.sharpe

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -68,7 +69,7 @@ class Lifecycle:
         db_path = self.study.root / "run_log" / "registry.db"
         if not db_path.exists():
             return LifecycleState.DEVELOPMENT.value
-        with sqlite3.connect(db_path) as db:
+        with closing(sqlite3.connect(db_path)) as db:
             exists = db.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'research_locks'"
             ).fetchone()
@@ -149,7 +150,7 @@ class Lifecycle:
         return ResearchLock(self.study, lock_hash, LifecycleState.LOCKED.value, lock_record)
 
     def open(self, lock_hash: str) -> ResearchLock:
-        with sqlite3.connect(self.study.root / "run_log" / "registry.db") as db:
+        with closing(sqlite3.connect(self.study.root / "run_log" / "registry.db")) as db:
             row = db.execute(
                 "SELECT lock_json, state FROM research_locks WHERE lock_hash = ?", (lock_hash,)
             ).fetchone()

--- a/case_studies/research/models.py
+++ b/case_studies/research/models.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.registry.specs import training_hash_from_spec
+
+from .adapters import get_adapter, registered_adapters
+from .contracts import ExecutionTier
+from .cv import CVSpec
+from .results import PredictionResult, TrainingResult
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class ModelRun:
+    training: TrainingResult
+    predictions: tuple[PredictionResult, ...]
+
+    def __post_init__(self) -> None:
+        if not self.predictions:
+            raise ValueError("model run requires at least one prediction result")
+        if any(result.study != self.training.study for result in self.predictions):
+            raise ValueError("model run results must belong to one study")
+        if any(
+            result.registry_record()["training_hash"] != self.training.hash
+            for result in self.predictions
+        ):
+            raise ValueError("prediction result does not belong to the training result")
+
+
+@dataclass(frozen=True)
+class ResolvedModelRequest:
+    study: Study
+    family: str
+    spec: dict[str, Any]
+    _context: Any
+
+    @property
+    def identity(self) -> str:
+        return training_hash_from_spec(self.spec)
+
+    def run(self) -> ModelRun:
+        module = _family_module(self.family)
+        runner = getattr(module, "run_resolved_request", None)
+        if runner is None:
+            raise NotImplementedError(f"{self.family!r} has no shared model runner")
+        result = runner(self.study, self.spec, self._context)
+        if not isinstance(result, ModelRun):
+            raise TypeError(
+                f"{self.family!r} runner returned {type(result).__name__}, not ModelRun"
+            )
+        return result
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    study: Study
+    family: str
+    label: str
+    config_name: str
+    overrides: dict[str, Any]
+    cv: CVSpec | None
+    execution_tier: ExecutionTier
+    preview_reductions: dict[str, Any]
+
+    @classmethod
+    def from_request(cls, study: Study, request: dict[str, Any]) -> ModelRequest:
+        supported = {
+            "family",
+            "label",
+            "config_name",
+            "overrides",
+            "cv",
+            "execution_tier",
+            "preview_reductions",
+        }
+        unknown = set(request) - supported
+        if unknown:
+            raise ValueError(f"unsupported model request fields: {sorted(unknown)}")
+        missing = {"family", "label", "config_name"} - set(request)
+        if missing:
+            raise ValueError(f"model request is missing fields: {sorted(missing)}")
+        family = str(request["family"])
+        available = {binding.name for binding in registered_adapters("model")}
+        if family not in available:
+            raise ValueError(f"unsupported predictive family {family!r}")
+        cv = request.get("cv")
+        if cv is not None and not isinstance(cv, CVSpec):
+            raise TypeError("model request cv must be a CVSpec")
+        tier = ExecutionTier(request.get("execution_tier", ExecutionTier.CANONICAL))
+        reductions = dict(request.get("preview_reductions") or {})
+        if tier is ExecutionTier.PREVIEW and not reductions:
+            raise ValueError("preview model requests must declare every reduction")
+        if tier is ExecutionTier.CANONICAL and reductions:
+            raise ValueError("canonical model requests cannot declare preview reductions")
+        return cls(
+            study=study,
+            family=family,
+            label=str(request["label"]),
+            config_name=str(request["config_name"]),
+            overrides=dict(request.get("overrides") or {}),
+            cv=cv,
+            execution_tier=tier,
+            preview_reductions=reductions,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "family": self.family,
+            "label": self.label,
+            "config_name": self.config_name,
+            "overrides": dict(self.overrides),
+            "cv": self.cv,
+            "execution_tier": self.execution_tier.value,
+            "preview_reductions": dict(self.preview_reductions),
+        }
+
+    def resolve(self) -> ResolvedModelRequest:
+        module = _family_module(self.family)
+        resolver = getattr(module, "resolve_model_request", None)
+        if resolver is None:
+            raise NotImplementedError(f"{self.family!r} has no shared model resolver")
+        spec, context = resolver(self.study, self.as_dict())
+        if spec.get("identity_version") != 2:
+            raise ValueError("family resolver did not produce a version-2 request")
+        if spec.get("family") != self.family or spec.get("label") != self.label:
+            raise ValueError("family resolver changed the requested family or label")
+        if spec.get("execution_tier") != self.execution_tier.value:
+            raise ValueError("family resolver changed the execution tier")
+        return ResolvedModelRequest(self.study, self.family, spec, context)
+
+    def run(self) -> ModelRun:
+        return self.resolve().run()
+
+
+def _family_module(family: str):
+    return get_adapter("model", family)

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,7 +68,7 @@ class Result:
             db_path = root / "run_log" / "registry.db"
             if not db_path.exists():
                 continue
-            with sqlite3.connect(db_path) as db:
+            with closing(sqlite3.connect(db_path)) as db:
                 tables = {
                     row[0]
                     for row in db.execute(
@@ -140,7 +141,7 @@ class Result:
             "prediction": ("prediction_sets", "prediction_hash"),
             "backtest": ("backtest_runs", "backtest_hash"),
         }[self.kind]
-        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+        with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             record = _record(db, f"SELECT * FROM {table} WHERE {key} = ?", (self.hash,))
         assert record is not None
         return record
@@ -229,7 +230,7 @@ class TrainingResult(Result):
 @dataclass(frozen=True)
 class PredictionResult(Result):
     def coverage(self) -> dict[str, Any] | None:
-        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+        with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             exists = db.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'prediction_coverage'"
             ).fetchone()
@@ -267,7 +268,7 @@ class BacktestResult(Result):
         if not isinstance(prediction, PredictionResult) or not prediction.complete:
             return False
         returns = self.root / "run_log" / "backtest" / self.hash / "daily_returns.parquet"
-        with sqlite3.connect(self.root / "run_log" / "registry.db") as db:
+        with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             metrics = db.execute(
                 "SELECT 1 FROM backtest_metrics WHERE backtest_hash = ?", (self.hash,)
             ).fetchone()
@@ -323,6 +324,11 @@ class ResultsCatalog:
         predictions,
         expected_keys,
         allow_partial: bool = False,
+        metrics: dict[str, float | dict] | None = None,
+        task_type: str = "regression",
+        class_values: list | None = None,
+        eval_col: str | None = None,
+        label: str | None = None,
     ) -> PredictionResult:
         self.study.require_writable()
         if training.study != self.study or training.kind != "training":
@@ -338,6 +344,11 @@ class ResultsCatalog:
             predictions=predictions,
             expected_keys=expected_keys,
             allow_partial=allow_partial,
+            metrics=metrics,
+            task_type=task_type,
+            class_values=class_values,
+            eval_col=eval_col,
+            label=label,
             case_dir=case_dir,
         )
         result = Result.open(

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Literal
@@ -62,7 +63,7 @@ class Strategy:
 
     def _active_lock_record(self) -> dict[str, Any]:
         db_path = self.study.root / "run_log" / "registry.db"
-        with sqlite3.connect(db_path) as db:
+        with closing(sqlite3.connect(db_path)) as db:
             row = db.execute(
                 "SELECT lock_json FROM research_locks WHERE state = 'LOCKED' LIMIT 1"
             ).fetchone()

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -18,6 +18,7 @@ from .contracts import ExecutionTier
 if TYPE_CHECKING:
     from .labels import LabelCatalog
     from .lifecycle import Lifecycle
+    from .models import ModelRequest
     from .results import ResultsCatalog
     from .strategy import Strategy
 
@@ -206,3 +207,8 @@ class Study:
         from .strategy import Strategy
 
         return Strategy.from_request(self, request)
+
+    def model(self, **request) -> ModelRequest:
+        from .models import ModelRequest
+
+        return ModelRequest.from_request(self, request)

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -24,6 +24,7 @@ Usage::
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -291,7 +292,13 @@ def compute_portfolio_metrics(
         }
 
     analysis = PortfolioAnalysis(returns=returns, periods_per_year=periods_per_year)
-    pm = analysis.compute_summary_stats()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Precision loss occurred in moment calculation",
+            category=RuntimeWarning,
+        )
+        pm = analysis.compute_summary_stats()
 
     def _safe(v: float) -> float:
         """Sanitize metric value: handle complex, inf, nan."""
@@ -334,8 +341,6 @@ def compute_portfolio_metrics(
             )
             out.update(unc)
         except Exception as exc:  # pragma: no cover - never block point estimates
-            import warnings
-
             warnings.warn(
                 f"compute_backtest_uncertainty failed: {exc}; point metrics returned without CIs",
                 stacklevel=2,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -114,7 +114,11 @@ def _normalize_folds(splits: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]
     )
 
 
-def _select_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def _select_splits(
+    mds,
+    request: dict[str, Any],
+    label_timeline: pl.DataFrame,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     cv = request.get("cv")
     if cv is None:
         splits = list(mds.splits)
@@ -125,7 +129,7 @@ def _select_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], 
             "identity": value_digest(pl.DataFrame(list(normalized))),
         }
     else:
-        resolved = cv.resolve(mds.dataset.select(mds.date_col).unique(), date_col=mds.date_col)
+        resolved = cv.resolve(label_timeline, date_col=mds.date_col)
         splits = [dict(fold) for fold in resolved.normalized_folds]
         cv_record = resolved.as_dict()
 
@@ -156,13 +160,17 @@ def _load_preset(config_name: str) -> dict[str, Any]:
     return config
 
 
-def _expected_keys(folds: list[dict[str, Any]], join_cols: list[str]) -> pl.DataFrame:
+def _expected_keys(folds: list[dict[str, Any]], entity_col: str, date_col: str) -> pl.DataFrame:
     frames = []
     for fold in folds:
-        frame = pl.from_pandas(fold["meta"][join_cols]).with_columns(
+        frame = pl.from_pandas(fold["meta"][[entity_col, date_col]]).with_columns(
             pl.lit(int(fold["fold"]), dtype=pl.Int64).alias("fold")
         )
-        frames.append(frame.select("symbol", "timestamp", "fold"))
+        frames.append(
+            frame.rename({entity_col: "symbol", date_col: "timestamp"}).select(
+                "symbol", "timestamp", "fold"
+            )
+        )
     expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
     if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
         raise ValueError("linear request produced duplicate expected prediction keys")
@@ -171,8 +179,11 @@ def _expected_keys(folds: list[dict[str, Any]], join_cols: list[str]) -> pl.Data
 
 def _effective_params(config: dict[str, Any], overrides: dict[str, Any], folds) -> dict[str, dict]:
     merged = {**dict(config.get("params") or {}), **overrides}
-    candidate = {**config, "params": merged}
     cls = _MODEL_CLASSES[config["model_class"]]
+    supported = cls().get_params(deep=True)
+    if "random_state" in supported and "random_state" not in merged:
+        merged["random_state"] = 42
+    candidate = {**config, "params": merged}
     effective = {}
     for fold in folds:
         resolved = resolve_linear_params(candidate, fold["X_train"], fold["y_train"])
@@ -201,16 +212,20 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     if not 0 < train_sample_frac <= 1:
         raise ValueError("train_sample_frac must be in (0, 1]")
     mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
-    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
-        raise ValueError("linear runner requires canonical symbol and timestamp keys")
-    splits, cv_record = _select_splits(mds, request)
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("linear runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+    if entity_col not in {"product", "symbol"}:
+        raise ValueError(f"linear runner does not support entity key {entity_col!r}")
+    label_timeline = label_ref.load().select(mds.date_col).unique()
+    splits, cv_record = _select_splits(mds, request, label_timeline)
     folds = prepare_cv_folds(
         mds.dataset.to_pandas(),
         splits,
         mds.feature_names,
         mds.label_col,
         mds.date_col,
-        mds.entity_cols[0],
+        entity_col,
         temporal_by_fold=mds.temporal_by_fold,
         temporal_keys=mds.temporal_keys,
         temporal_feature_names=mds.temporal_feature_names,
@@ -222,7 +237,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
 
     config = _load_preset(request["config_name"])
     effective = _effective_params(config, request["overrides"], folds)
-    expected = _expected_keys(folds, mds.join_cols)
+    expected = _expected_keys(folds, entity_col, mds.date_col)
     input_lineage = mds.input_lineage
     spec = {
         "identity_version": 2,
@@ -269,7 +284,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         label_col=mds.label_col,
         eval_label_col=mds.eval_label_col,
         date_col=mds.date_col,
-        entity_col=mds.entity_cols[0],
+        entity_col=entity_col,
         task_type=mds.task_type,
         class_values=tuple(mds.class_values),
         expected_keys=expected,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import joblib
+import numpy as np
+import polars as pl
+from sklearn.linear_model import ElasticNet, Lasso, LinearRegression, LogisticRegression, Ridge
+
+from case_studies.research.contracts import ExecutionTier
+from case_studies.research.models import ModelRun
+from case_studies.research.results import PredictionResult, Result, TrainingResult
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+from utils.modeling import load_modeling_dataset, prepare_cv_folds, resolve_linear_params
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+
+
+_MODEL_CLASSES = {
+    "LinearRegression": LinearRegression,
+    "Ridge": Ridge,
+    "Lasso": Lasso,
+    "ElasticNet": ElasticNet,
+    "LogisticRegression": LogisticRegression,
+}
+_PREVIEW_FIELDS = {"folds", "max_symbols", "train_sample_frac"}
+
+
+def _module_source(module_name: str) -> Path:
+    source = importlib.import_module(module_name).__file__
+    if source is None:
+        raise RuntimeError(f"module {module_name!r} has no source file")
+    return Path(source)
+
+
+_SOURCE_FILES = (Path(__file__), _module_source("utils.modeling"))
+
+
+@dataclass(frozen=True)
+class LinearContext:
+    folds: tuple[dict[str, Any], ...]
+    feature_names: tuple[str, ...]
+    label_col: str
+    eval_label_col: str | None
+    date_col: str
+    entity_col: str
+    task_type: str
+    class_values: tuple[Any, ...]
+    expected_keys: pl.DataFrame
+    runtime_provenance: dict[str, Any]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _source_identity() -> dict[str, str]:
+    return {str(path.name): _sha256(path) for path in _SOURCE_FILES}
+
+
+def _runtime_identity() -> dict[str, str]:
+    return {
+        "joblib": importlib.metadata.version("joblib"),
+        "numpy": importlib.metadata.version("numpy"),
+        "scikit-learn": importlib.metadata.version("scikit-learn"),
+    }
+
+
+def _runtime_provenance(study: Study) -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(study.release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = "unknown"
+    return {
+        "entry_point": "case_studies.utils.linear",
+        "packages": _runtime_identity(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": commit,
+    }
+
+
+def _normalize_folds(splits: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+    return tuple(
+        {
+            key: int(split[key]) if key == "fold" else str(split[key])
+            for key in fields
+            if split.get(key) is not None
+        }
+        for split in splits
+    )
+
+
+def _select_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    cv = request.get("cv")
+    if cv is None:
+        splits = list(mds.splits)
+        normalized = _normalize_folds(splits)
+        cv_record = {
+            "request": {"source": "case_study_default"},
+            "folds": list(normalized),
+            "identity": value_digest(pl.DataFrame(list(normalized))),
+        }
+    else:
+        resolved = cv.resolve(mds.dataset.select(mds.date_col).unique(), date_col=mds.date_col)
+        splits = [dict(fold) for fold in resolved.normalized_folds]
+        cv_record = resolved.as_dict()
+
+    reductions = request["preview_reductions"]
+    requested_folds = reductions.get("folds")
+    if requested_folds is not None:
+        selected = {int(fold) for fold in requested_folds}
+        splits = [split for split in splits if int(split["fold"]) in selected]
+        if {int(split["fold"]) for split in splits} != selected:
+            raise ValueError("preview fold reduction refers to an unavailable fold")
+        cv_record = {**cv_record, "preview_folds": sorted(selected)}
+    if not splits:
+        raise ValueError("model request resolved no cross-validation folds")
+    return splits, cv_record
+
+
+def _load_preset(config_name: str) -> dict[str, Any]:
+    from case_studies.utils.registry.specs import load_preset
+
+    config = load_preset("linear", config_name)
+    if config.get("family") != "linear":
+        raise ValueError(f"preset {config_name!r} belongs to {config.get('family')!r}")
+    model_class = config.get("model_class")
+    if model_class not in _MODEL_CLASSES:
+        raise ValueError(
+            f"unsupported linear model class {model_class!r}; expected {sorted(_MODEL_CLASSES)}"
+        )
+    return config
+
+
+def _expected_keys(folds: list[dict[str, Any]], join_cols: list[str]) -> pl.DataFrame:
+    frames = []
+    for fold in folds:
+        frame = pl.from_pandas(fold["meta"][join_cols]).with_columns(
+            pl.lit(int(fold["fold"]), dtype=pl.Int64).alias("fold")
+        )
+        frames.append(frame.select("symbol", "timestamp", "fold"))
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("linear request produced duplicate expected prediction keys")
+    return expected
+
+
+def _effective_params(config: dict[str, Any], overrides: dict[str, Any], folds) -> dict[str, dict]:
+    merged = {**dict(config.get("params") or {}), **overrides}
+    candidate = {**config, "params": merged}
+    cls = _MODEL_CLASSES[config["model_class"]]
+    effective = {}
+    for fold in folds:
+        resolved = resolve_linear_params(candidate, fold["X_train"], fold["y_train"])
+        try:
+            model = cls(**resolved)
+        except TypeError as exc:
+            raise ValueError(
+                f"invalid parameters for {config['model_class']}: {sorted(resolved)}"
+            ) from exc
+        effective[str(int(fold["fold"]))] = model.get_params(deep=True)
+    return effective
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported linear preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+
+    label_ref = study.labels.get(request["label"])
+    max_symbols = int(reductions.get("max_symbols", 0))
+    train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
+    if not 0 < train_sample_frac <= 1:
+        raise ValueError("train_sample_frac must be in (0, 1]")
+    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
+    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
+        raise ValueError("linear runner requires canonical symbol and timestamp keys")
+    splits, cv_record = _select_splits(mds, request)
+    folds = prepare_cv_folds(
+        mds.dataset.to_pandas(),
+        splits,
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        mds.entity_cols[0],
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=train_sample_frac,
+        eval_label_col=mds.eval_label_col,
+    )
+    if len(folds) != len(splits):
+        raise ValueError("linear request did not prepare every declared fold")
+
+    config = _load_preset(request["config_name"])
+    effective = _effective_params(config, request["overrides"], folds)
+    expected = _expected_keys(folds, mds.join_cols)
+    input_lineage = mds.input_lineage
+    spec = {
+        "identity_version": 2,
+        "execution_tier": tier.value,
+        "family": "linear",
+        "label": label_ref.name,
+        "seed": 42,
+        "config_name": request["config_name"],
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": input_lineage["artifacts"],
+        "feature_names": list(mds.feature_names),
+        "task": {
+            "type": mds.task_type,
+            "class_values": list(mds.class_values),
+            "continuous_eval_label": label_ref.definition.continuous_eval_label,
+        },
+        "cv": cv_record,
+        "model": {
+            "class": config["model_class"],
+            "implementation": "scikit-learn",
+            "objective": "classification" if mds.task_type == "classification" else "regression",
+            "effective_params_by_fold": effective,
+        },
+        "preprocessing": {
+            "imputer": {"class": "SimpleImputer", "strategy": "median"},
+            "scaler": {"class": "StandardScaler", "with_mean": True, "with_std": True},
+        },
+        "checkpoint_schedule": [{"kind": "final", "value": None}],
+        "expected_prediction_keys": {
+            "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+            "n_rows": expected.height,
+            "n_folds": expected.get_column("fold").n_unique(),
+        },
+        "input_data_spec": input_lineage,
+        "sampling": {"train_sample_frac": train_sample_frac, "max_symbols": max_symbols},
+        "source_identity": _source_identity(),
+        "runtime_identity": _runtime_identity(),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        spec["preview_reductions"] = reductions
+    context = LinearContext(
+        folds=tuple(folds),
+        feature_names=tuple(mds.feature_names),
+        label_col=mds.label_col,
+        eval_label_col=mds.eval_label_col,
+        date_col=mds.date_col,
+        entity_col=mds.entity_cols[0],
+        task_type=mds.task_type,
+        class_values=tuple(mds.class_values),
+        expected_keys=expected,
+        runtime_provenance=_runtime_provenance(study),
+    )
+    return spec, context
+
+
+def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> ModelRun | None:
+    training_hash = training_hash_from_spec(spec)
+    prediction_hash = prediction_hash_from_parts(
+        training_hash,
+        None,
+        "validation",
+        checkpoint_kind="final",
+        identity_version=2,
+    )
+    try:
+        training = Result.open(
+            study,
+            training_hash,
+            include_preview=spec["execution_tier"] == "preview",
+        )
+        prediction = Result.open(
+            study,
+            prediction_hash,
+            include_preview=spec["execution_tier"] == "preview",
+        )
+    except KeyError:
+        return None
+    if not isinstance(training, TrainingResult) or not isinstance(prediction, PredictionResult):
+        return None
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    manifest = model_dir / "manifest.json"
+    expected_files = {f"fold_{int(fold['fold'])}.joblib" for fold in context.folds}
+    if not prediction.complete or not manifest.is_file():
+        return None
+    record = json.loads(manifest.read_text())
+    if set(record.get("files") or {}) != expected_files:
+        return None
+    if any(_sha256(model_dir / name) != digest for name, digest in record["files"].items()):
+        return None
+    return ModelRun(training=training, predictions=(prediction,))
+
+
+def _fit_predictions(spec: dict[str, Any], context: LinearContext, staging: Path) -> pl.DataFrame:
+    cls = _MODEL_CLASSES[spec["model"]["class"]]
+    prediction_frames = []
+    files = {}
+    for fold in context.folds:
+        fold_id = int(fold["fold"])
+        params = spec["model"]["effective_params_by_fold"][str(fold_id)]
+        model = cls(**params)
+        model.fit(fold["X_train"], fold["y_train"])
+        if context.task_type == "classification":
+            predict_proba = getattr(model, "predict_proba", None)
+            if not callable(predict_proba):
+                raise ValueError("classification linear model must expose predict_proba")
+            probabilities = predict_proba(fold["X_val"])
+            predictions = probabilities @ np.asarray(sorted(context.class_values), dtype=np.float64)
+        else:
+            predictions = np.asarray(model.predict(fold["X_val"]), dtype=np.float64)
+        if not np.isfinite(predictions).all() or np.nanstd(predictions) <= 1e-15:
+            raise ValueError(f"linear fold {fold_id} produced non-finite or constant predictions")
+
+        artifact = staging / f"fold_{fold_id}.joblib"
+        joblib.dump(
+            {
+                "feature_names": context.feature_names,
+                "model": model,
+                "preprocessor": fold["preprocessor"],
+            },
+            artifact,
+        )
+        files[artifact.name] = _sha256(artifact)
+        frame = pl.from_pandas(fold["meta"][[context.entity_col, context.date_col]]).with_columns(
+            pl.lit(fold_id, dtype=pl.Int64).alias("fold"),
+            pl.Series("prediction", predictions),
+            pl.Series("actual", fold["y_val"]),
+        )
+        if fold.get("y_eval") is not None:
+            frame = frame.with_columns(pl.Series("eval_actual", fold["y_eval"]))
+        prediction_frames.append(
+            frame.rename({context.entity_col: "symbol", context.date_col: "timestamp"})
+        )
+    (staging / "manifest.json").write_text(
+        json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
+    )
+    return pl.concat(prediction_frames).sort("symbol", "timestamp", "fold")
+
+
+def run_resolved_request(
+    study: Study,
+    spec: dict[str, Any],
+    context: LinearContext,
+) -> ModelRun:
+    cached = _cached_run(study, spec, context)
+    if cached is not None:
+        return cached
+
+    started = time.perf_counter()
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    train_dir = training.root / "run_log" / "training" / training.hash
+    model_dir = train_dir / "models"
+    if model_dir.exists():
+        raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+    staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+    staging.mkdir(parents=True)
+    try:
+        predictions = _fit_predictions(spec, context, staging)
+        os.replace(staging, model_dir)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=predictions,
+        expected_keys=context.expected_keys,
+        task_type=context.task_type,
+        class_values=list(context.class_values) or None,
+        eval_col="eval_actual" if context.eval_label_col else None,
+        label=context.label_col,
+    )
+    runtime_path = train_dir / "runtime.json"
+    if runtime_path.exists():
+        runtime = json.loads(runtime_path.read_text())
+        runtime["elapsed_s"] = time.perf_counter() - started
+        runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+    return ModelRun(training=training, predictions=(prediction,))

--- a/case_studies/utils/registry/maintenance.py
+++ b/case_studies/utils/registry/maintenance.py
@@ -51,7 +51,7 @@ def deduplicate_semantic_backtests(
         return duplicates
 
     drops = [item for group in duplicates for item in group.drop_hashes]
-    with closing(sqlite3.connect(str(db_path))) as db:
+    with closing(sqlite3.connect(str(db_path))) as db, db:
         db.execute("PRAGMA foreign_keys = ON")
         placeholders = ",".join("?" for _ in drops)
         references = {

--- a/case_studies/utils/registry/maintenance.py
+++ b/case_studies/utils/registry/maintenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,7 +20,7 @@ class DuplicateBacktest:
 
 def find_semantic_backtest_duplicates(db_path: Path) -> list[DuplicateBacktest]:
     """Find rows differing only by normalized, identity-neutral spec defaults."""
-    with sqlite3.connect(str(db_path)) as db:
+    with closing(sqlite3.connect(str(db_path))) as db:
         rows = db.execute(
             "SELECT backtest_hash, prediction_hash, stage, spec_json FROM backtest_runs"
         ).fetchall()
@@ -50,7 +51,7 @@ def deduplicate_semantic_backtests(
         return duplicates
 
     drops = [item for group in duplicates for item in group.drop_hashes]
-    with sqlite3.connect(str(db_path)) as db:
+    with closing(sqlite3.connect(str(db_path))) as db:
         db.execute("PRAGMA foreign_keys = ON")
         placeholders = ",".join("?" for _ in drops)
         references = {

--- a/tests/test_registry_maintenance.py
+++ b/tests/test_registry_maintenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from case_studies.utils.registry.maintenance import deduplicate_semantic_backtests
@@ -26,7 +27,7 @@ def _seed_duplicate_registry(path: Path) -> None:
             }
         }
     }
-    with sqlite3.connect(str(path)) as db:
+    with closing(sqlite3.connect(str(path))) as db, db:
         db.executescript(REGISTRY_SCHEMA_SQL)
         db.execute(
             "INSERT INTO training_runs "
@@ -62,6 +63,6 @@ def test_semantic_backtest_deduplication_is_idempotent(tmp_path: Path) -> None:
     assert applied == dry_run
     assert deduplicate_semantic_backtests(db_path, apply=True) == []
 
-    with sqlite3.connect(str(db_path)) as db:
+    with closing(sqlite3.connect(str(db_path))) as db:
         assert db.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0] == 1
         assert db.execute("SELECT COUNT(*) FROM backtest_metrics").fetchone()[0] == 1

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from contextlib import closing
 from datetime import date
 from pathlib import Path
 
@@ -254,7 +255,7 @@ def test_preview_prediction_to_backtest_flow_stays_isolated(tmp_path: Path) -> N
     ).run(prices=_prices())
 
     canonical_db = study.root / "run_log" / "registry.db"
-    with sqlite3.connect(canonical_db) as db:
+    with closing(sqlite3.connect(canonical_db)) as db:
         assert db.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0] == 0
     assert preview_backtest.execution_tier == "preview"
     assert Result.open(study, preview_backtest.hash, include_preview=True).complete
@@ -297,7 +298,7 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path, monkeypatch: pytest.M
             selection_evidence={"metric": "validation_backtest_sharpe"},
             holdout_training_spec=invalid_holdout_spec,
         )
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
         assert db.execute("SELECT COUNT(*) FROM research_locks").fetchone()[0] == 0
 
     lock = study.lifecycle.lock(
@@ -316,7 +317,7 @@ def test_lock_transition_failure_is_atomic(tmp_path: Path, monkeypatch: pytest.M
         )
 
     assert study.lifecycle.open(lock.hash).state == "LOCKED"
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
 
 
@@ -416,7 +417,7 @@ def test_locked_rolling_allocator_holdout_preserves_warmup_and_transitions_once(
             holdout_backtest_hash=holdout_backtest.hash,
         )
     assert study.lifecycle.open(lock.hash).state == "LOCKED"
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone()[0] == 0
     restored_warmups = _patch_holdout_prices(monkeypatch, holdout_prices)
 

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import os
 from types import SimpleNamespace
 
+import numpy as np
 import polars as pl
 import pytest
 
 from case_studies.research import (
+    CVSpec,
     LabelDefinition,
     ModelRun,
     Study,
@@ -162,6 +164,52 @@ def test_linear_override_changes_training_identity(tmp_path, monkeypatch) -> Non
     ).resolve()
 
     assert base.identity != changed.identity
+
+
+def test_linear_effective_params_bind_seed_for_stochastic_estimators() -> None:
+    config = {
+        "model_class": "LogisticRegression",
+        "params": {"solver": "liblinear"},
+    }
+    folds = [{"fold": 0, "X_train": np.ones((4, 2)), "y_train": np.array([0, 1, 0, 1])}]
+
+    effective = linear._effective_params(config, {}, folds)
+
+    assert effective["0"]["random_state"] == 42
+
+
+def test_custom_cv_uses_label_timeline_not_feature_availability() -> None:
+    timeline = pl.DataFrame(
+        {"timestamp": pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 3, 31), eager=True)}
+    )
+    request = {
+        "cv": CVSpec.walk_forward(
+            training_window="20D",
+            validation_window="5D",
+            folds=(0,),
+            horizon="0D",
+        ),
+        "preview_reductions": {},
+    }
+    full = SimpleNamespace(splits=[], date_col="timestamp", dataset=timeline)
+    reduced = SimpleNamespace(splits=[], date_col="timestamp", dataset=timeline.tail(12))
+
+    full_splits, full_record = linear._select_splits(full, request, timeline)
+    reduced_splits, reduced_record = linear._select_splits(reduced, request, timeline)
+
+    assert full_splits == reduced_splits
+    assert full_record == reduced_record
+
+
+def test_product_entity_is_normalized_at_prediction_boundary() -> None:
+    meta = pl.DataFrame(
+        {"product": ["ES", "NQ"], "timestamp": ["2024-01-01", "2024-01-01"]}
+    ).to_pandas()
+
+    expected = linear._expected_keys([{"fold": 0, "meta": meta}], "product", "timestamp")
+
+    assert expected.columns == ["symbol", "timestamp", "fold"]
+    assert expected.get_column("symbol").to_list() == ["ES", "NQ"]
 
 
 def test_preview_request_requires_hash_covered_reductions(tmp_path) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from case_studies.research import (
+    LabelDefinition,
+    ModelRun,
+    Study,
+    get_adapter,
+    register_adapter,
+    registered_adapters,
+)
+from case_studies.utils import linear
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _linear_study(tmp_path, monkeypatch):
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    dates = ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
+    symbols = [f"S{index}" for index in range(6)]
+    rows = []
+    for date_index, date in enumerate(dates):
+        for symbol_index, symbol in enumerate(symbols):
+            x1 = float(symbol_index - 2.5)
+            x2 = float(date_index) + x1 / 10
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "timestamp": date,
+                    "x1": x1,
+                    "x2": x2,
+                    "fwd_ret_1d": 0.03 * x1 + 0.01 * x2,
+                }
+            )
+    dataset = pl.DataFrame(rows).with_columns(pl.col("timestamp").str.to_date())
+    study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        dataset.select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-02",
+            "val_start": "2024-01-03",
+            "val_end": "2024-01-03",
+        },
+        {
+            "fold": 1,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-03",
+            "val_start": "2024-01-04",
+            "val_end": "2024-01-04",
+        },
+    ]
+    modeling_dataset = SimpleNamespace(
+        dataset=dataset,
+        feature_names=["x1", "x2"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        join_cols=["symbol", "timestamp"],
+        splits=splits,
+        task_type="regression",
+        class_values=[],
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        eval_label_col=None,
+        input_lineage={
+            "artifacts": {
+                "financial": {"sha256": "features-v1", "size": 1},
+                "label": {"sha256": "label-v1", "size": 1},
+            },
+            "feature_names": ["x1", "x2"],
+            "splits": splits,
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr(linear, "load_modeling_dataset", lambda *args, **kwargs: modeling_dataset)
+    monkeypatch.setattr(
+        linear,
+        "_load_preset",
+        lambda config_name: {
+            "config_name": config_name,
+            "family": "linear",
+            "library": "sklearn",
+            "model_class": "Ridge",
+            "params": {"alpha": 1.0},
+        },
+    )
+    return study
+
+
+def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    notebook_request = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        overrides={"alpha": 2.5},
+    )
+    api_request = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        overrides={"alpha": 2.5},
+    )
+
+    notebook_resolved = notebook_request.resolve()
+    api_resolved = api_request.resolve()
+
+    assert notebook_resolved.identity == api_resolved.identity
+    assert notebook_resolved.spec == api_resolved.spec
+    assert notebook_resolved.spec["model"]["effective_params_by_fold"]["0"]["alpha"] == 2.5
+
+
+def test_linear_runner_persists_complete_reusable_result(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    request = study.model(family="linear", label="fwd_ret_1d", config_name="ridge")
+
+    fresh = request.run()
+    cached = request.run()
+
+    assert isinstance(fresh, ModelRun)
+    assert fresh.training.hash == cached.training.hash
+    assert fresh.predictions[0].hash == cached.predictions[0].hash
+    assert fresh.predictions[0].complete
+    assert fresh.predictions[0].coverage()["n_expected"] == 12
+    assert fresh.predictions[0].load().select("symbol", "timestamp", "fold").height == 12
+    model_dir = fresh.training.root / "run_log" / "training" / fresh.training.hash / "models"
+    assert sorted(path.name for path in model_dir.glob("fold_*.joblib")) == [
+        "fold_0.joblib",
+        "fold_1.joblib",
+    ]
+
+
+def test_linear_override_changes_training_identity(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    base = study.model(family="linear", label="fwd_ret_1d", config_name="ridge").resolve()
+    changed = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        overrides={"alpha": 3.0},
+    ).resolve()
+
+    assert base.identity != changed.identity
+
+
+def test_preview_request_requires_hash_covered_reductions(tmp_path) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    with pytest.raises(ValueError, match="declare every reduction"):
+        study.model(
+            family="linear",
+            label="fwd_ret_21d",
+            config_name="ridge",
+            execution_tier="preview",
+        )
+
+
+def test_model_and_causal_adapters_have_one_extension_seam() -> None:
+    register_adapter("model", "fixture_family", "case_studies.utils.linear")
+    register_adapter("causal", "fixture_causal", "case_studies.utils.causal")
+
+    assert get_adapter("model", "fixture_family") is linear
+    assert get_adapter("causal", "fixture_causal").__name__ == "case_studies.utils.causal"
+    assert "tabular_dl" in {binding.name for binding in registered_adapters("model")}
+    assert "dml" in {binding.name for binding in registered_adapters("causal")}

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import polars as pl
@@ -122,7 +123,7 @@ def test_legacy_result_reopens_without_being_inferred_complete(tmp_path: Path) -
 def test_read_only_legacy_registry_reopens_without_schema_writes(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     db_path = release / "case_studies" / "etfs" / "run_log" / "registry.db"
-    with sqlite3.connect(db_path) as db:
+    with closing(sqlite3.connect(db_path)) as db:
         db.execute(
             "CREATE TABLE training_runs ("
             "training_hash TEXT PRIMARY KEY, family TEXT NOT NULL, label TEXT NOT NULL, "
@@ -155,7 +156,7 @@ def test_read_only_legacy_registry_reopens_without_schema_writes(tmp_path: Path)
 def test_workspace_open_migrates_copied_legacy_registry(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     db_path = release / "case_studies" / "etfs" / "run_log" / "registry.db"
-    with sqlite3.connect(db_path) as db:
+    with closing(sqlite3.connect(db_path)) as db:
         db.execute(
             "CREATE TABLE training_runs ("
             "training_hash TEXT PRIMARY KEY, family TEXT NOT NULL, label TEXT NOT NULL, "
@@ -169,7 +170,7 @@ def test_workspace_open_migrates_copied_legacy_registry(tmp_path: Path) -> None:
         db.commit()
 
     study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
         columns = {row[1] for row in db.execute("PRAGMA table_info(training_runs)")}
         coverage_table = db.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'prediction_coverage'"
@@ -197,7 +198,7 @@ def test_legacy_registry_schema_migrates_additively(tmp_path: Path) -> None:
     case_dir = tmp_path / "legacy" / "etfs"
     db_path = case_dir / "run_log" / "registry.db"
     db_path.parent.mkdir(parents=True)
-    with sqlite3.connect(db_path) as db:
+    with closing(sqlite3.connect(db_path)) as db:
         db.execute(
             """
             CREATE TABLE training_runs (
@@ -257,7 +258,7 @@ def test_invalid_coverage_registration_is_atomic(tmp_path: Path) -> None:
             expected_keys=expected,
         )
 
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
         assert db.execute("SELECT COUNT(*) FROM prediction_sets").fetchone()[0] == 0
         assert db.execute("SELECT COUNT(*) FROM prediction_coverage").fetchone()[0] == 0
     assert not list((study.root / "run_log" / "predictions").glob("*"))

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1421,6 +1421,7 @@ def prepare_cv_folds(
                 "entities": val_meta[entity_col].values if entity_col else None,
                 "n_train": len(X_train),
                 "n_val": len(X_val),
+                "preprocessor": preprocessor,
             }
         )
 


### PR DESCRIPTION
## Summary
- add the canonical model request and result facade with an adapter registry for predictive and causal family extensions
- add the version-2 linear family resolver and runner with complete fitted-state persistence, coverage, and cache checks
- close research registry readers explicitly and preserve transaction behavior

## Verification
- focused warnings-as-errors research suite: 37 passed
- Ruff: passed
- ty: passed
- RoboRev jobs 13120 and 13125: final review found no issues