### PR TITLE
Add deep research family adapters

### DIFF
--- a/case_studies/utils/conformal.py
+++ b/case_studies/utils/conformal.py
@@ -19,9 +19,11 @@ normalization), regardless of whether the source predictions.parquet uses
 from __future__ import annotations
 
 import copy
+import math
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import polars as pl
 
 from utils.paths import get_case_study_dir
@@ -62,6 +64,76 @@ HOLDOUT_CONFORMAL_EMBARGO_STEPS: dict[str, int] = {
     "us_firm_characteristics/fwd_ret_1m": 1,
     "us_firm_characteristics/fwd_class_1m": 1,
 }
+
+
+def split_conformal_coverage(
+    predictions: pl.DataFrame,
+    *,
+    levels: tuple[float, ...] = (0.80, 0.90, 0.95),
+    min_rows: int = 30,
+) -> list[dict[str, float | int]]:
+    """Measure split-conformal coverage with chronological calibration.
+
+    The earliest validation fold supplies both the absolute-residual quantile
+    and the target scale. Later folds are evaluation data only. Quantiles use
+    the exact finite-sample order statistic rather than interpolation.
+    """
+    renames = {
+        legacy: canonical
+        for legacy, canonical in _LEGACY_RENAME.items()
+        if legacy in predictions.columns and canonical not in predictions.columns
+    }
+    if renames:
+        predictions = predictions.rename(renames)
+
+    required = {"timestamp", "fold_id", "y_true", "y_score"}
+    missing = required - set(predictions.columns)
+    if missing:
+        raise ValueError(f"prediction artifact missing {sorted(missing)}")
+    predictions = predictions.drop_nulls(required).with_columns(
+        (pl.col("y_true") - pl.col("y_score")).abs().alias("abs_resid")
+    )
+    if predictions.is_empty():
+        raise ValueError("prediction artifact has no finite predictions")
+    for column in ("y_true", "y_score", "abs_resid"):
+        if not np.isfinite(predictions[column].to_numpy()).all():
+            raise ValueError(f"prediction artifact has non-finite {column} values")
+
+    fold_windows = (
+        predictions.group_by("fold_id")
+        .agg(pl.col("timestamp").min().alias("validation_start"))
+        .sort("validation_start")
+    )
+    if fold_windows.height < 2:
+        raise ValueError("conformal coverage requires at least two validation folds")
+    calibration_fold = fold_windows["fold_id"][0]
+    calibration = predictions.filter(pl.col("fold_id") == calibration_fold)
+    test = predictions.filter(pl.col("fold_id") != calibration_fold)
+    if calibration.height < min_rows or test.height < min_rows:
+        raise ValueError(f"conformal calibration or test panel has fewer than {min_rows} rows")
+
+    scale = float(calibration["y_true"].std() or 0.0)
+    if not math.isfinite(scale) or scale <= 0:
+        raise ValueError("conformal calibration target scale is invalid")
+    calibration_residuals = np.sort(calibration["abs_resid"].to_numpy())
+    test_residuals = test["abs_resid"].to_numpy()
+    n_calibration = len(calibration_residuals)
+
+    rows: list[dict[str, float | int]] = []
+    for level in levels:
+        if not 0 < level < 1:
+            raise ValueError(f"invalid conformal level: {level}")
+        rank = math.ceil((n_calibration + 1) * level)
+        quantile = float("inf") if rank > n_calibration else float(calibration_residuals[rank - 1])
+        rows.append(
+            {
+                "nominal_level": float(level),
+                "empirical_coverage": float((test_residuals <= quantile).mean()),
+                "mean_interval_width_frac_std": float((2.0 * quantile) / scale),
+                "n_test": int(len(test_residuals)),
+            }
+        )
+    return rows
 
 
 def holdout_conformal_embargo_steps(case_study: str, label: str) -> int:

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -28,6 +28,7 @@ from utils.modeling import RANDOM_SEED, seed_everything
 SUPPORTED_DARTS_ARCHITECTURES = {"nbeats", "tsmixer"}
 BASE_TARGET_COL = "_darts_target_1d"
 _DARTS_PERIOD_COL = "_darts_expected_period"
+_CME_MAX_SESSION_GAP_DAYS = 5
 
 
 def darts_checkpoint_path(root: Path, config_name: str, fold: int, checkpoint: int) -> Path:
@@ -501,10 +502,30 @@ def _attach_expected_periods(
     *,
     date_col: str,
     calendar_id: str | None,
+    case_study: str | None = None,
 ) -> pd.DataFrame:
     from case_studies.utils.sequence_dataset import _sequence_period_numbers
 
     result = dataset_pd.copy()
+    if case_study == "cme_futures":
+        product_dates = (
+            result[["product", date_col]]
+            .drop_duplicates()
+            .sort_values(["product", date_col], kind="mergesort")
+        )
+        within_product = product_dates.groupby("product", sort=False)
+        sequence = within_product.cumcount()
+        breaks = within_product[date_col].diff().dt.days.gt(_CME_MAX_SESSION_GAP_DAYS)
+        product_dates[_DARTS_PERIOD_COL] = (
+            sequence + breaks.groupby(product_dates["product"], sort=False).cumsum()
+        )
+        return result.merge(
+            product_dates,
+            on=["product", date_col],
+            how="left",
+            validate="many_to_one",
+            sort=False,
+        )
     result[_DARTS_PERIOD_COL] = _sequence_period_numbers(
         result[date_col],
         calendar_id=calendar_id,
@@ -624,6 +645,7 @@ def darts_validation_keys(
         dataset_pd,
         date_col=date_col,
         calendar_id=make_walk_forward_config(case_study, date_col=date_col).calendar_id,
+        case_study=case_study,
     )
     identity_cols = _panel_identity_columns(dataset_pd, entity_col)
     frames: list[pl.DataFrame] = []
@@ -920,6 +942,7 @@ def run_darts_cv(
         dataset_pd,
         date_col=date_col,
         calendar_id=make_walk_forward_config(case_study, date_col=date_col).calendar_id,
+        case_study=case_study,
     )
 
     config_results: list[dict[str, Any]] = []

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 import re
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -24,6 +27,162 @@ from utils.modeling import RANDOM_SEED, seed_everything
 
 SUPPORTED_DARTS_ARCHITECTURES = {"nbeats", "tsmixer"}
 BASE_TARGET_COL = "_darts_target_1d"
+
+
+def darts_checkpoint_path(root: Path, config_name: str, fold: int, checkpoint: int) -> Path:
+    return Path(root) / config_name / f"fold_{fold:02d}" / f"epoch_{checkpoint:04d}.pt"
+
+
+def _darts_checkpoint_files(path: Path) -> tuple[Path, Path, Path]:
+    path = Path(path)
+    return path, Path(f"{path}.ckpt"), Path(f"{path}.json")
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_darts_checkpoint(
+    path: Path,
+    *,
+    model: Any,
+    architecture: str,
+    metadata: dict[str, Any],
+) -> Path:
+    """Persist an immutable Darts model, Lightning weights, and digest record."""
+    path = Path(path)
+    model_path, weights_path, sidecar_path = _darts_checkpoint_files(path)
+    existing = [item for item in (model_path, weights_path, sidecar_path) if item.exists()]
+    if existing:
+        raise FileExistsError(f"immutable Darts checkpoint conflict: {existing[0]}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    token = uuid.uuid4().hex
+    temporary_model = path.with_name(f".{path.name}.{token}.tmp")
+    temporary_weights = Path(f"{temporary_model}.ckpt")
+    temporary_sidecar = path.with_name(f".{path.name}.{token}.json.tmp")
+    published: list[Path] = []
+    try:
+        model.save(str(temporary_model), clean=True)
+        if not temporary_model.is_file() or not temporary_weights.is_file():
+            raise RuntimeError(f"Darts did not persist both checkpoint files for {path}")
+        record = {
+            "schema_version": 1,
+            "architecture": architecture,
+            "metadata": metadata,
+            "model_sha256": _file_sha256(temporary_model),
+            "model_size": temporary_model.stat().st_size,
+            "weights_sha256": _file_sha256(temporary_weights),
+            "weights_size": temporary_weights.stat().st_size,
+        }
+        temporary_sidecar.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+        for source, target in (
+            (temporary_model, model_path),
+            (temporary_weights, weights_path),
+            (temporary_sidecar, sidecar_path),
+        ):
+            os.replace(source, target)
+            published.append(target)
+    except Exception:
+        for item in published:
+            item.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary_model.unlink(missing_ok=True)
+        temporary_weights.unlink(missing_ok=True)
+        temporary_sidecar.unlink(missing_ok=True)
+    return path
+
+
+def load_darts_checkpoint(path: Path):
+    """Load a Darts checkpoint after both persisted files pass their digests."""
+    model_path, weights_path, sidecar_path = _darts_checkpoint_files(Path(path))
+    if not all(item.is_file() for item in (model_path, weights_path, sidecar_path)):
+        raise FileNotFoundError(f"Darts checkpoint population is incomplete: {model_path}")
+    record = json.loads(sidecar_path.read_text())
+    if record.get("schema_version") != 1:
+        raise ValueError(f"unsupported Darts checkpoint schema at {model_path}")
+    if record.get("model_sha256") != _file_sha256(model_path) or record.get(
+        "weights_sha256"
+    ) != _file_sha256(weights_path):
+        raise ValueError(f"Darts checkpoint digest does not match its sidecar: {model_path}")
+    model_cls = {
+        "nbeats": NBEATSModel,
+        "tsmixer": TSMixerModel,
+    }.get(record.get("architecture"))
+    if model_cls is None:
+        raise ValueError(f"unsupported Darts architecture at {model_path}")
+    model = model_cls.load(
+        str(model_path),
+        pl_trainer_kwargs=_trainer_kwargs("cpu"),
+        weights_only=False,
+    )
+    return model, record["metadata"]
+
+
+def validate_darts_checkpoint_population(
+    root: Path,
+    *,
+    config_name: str,
+    fold_ids: list[int] | tuple[int, ...],
+    checkpoints: list[int] | tuple[int, ...],
+    architecture: str,
+) -> tuple[Path, ...]:
+    """Require the exact Darts fitted-state population declared by one request."""
+    expected = tuple(
+        darts_checkpoint_path(root, config_name, fold, checkpoint)
+        for fold in sorted({int(value) for value in fold_ids})
+        for checkpoint in sorted({int(value) for value in checkpoints})
+    )
+    if not expected:
+        raise ValueError("Darts checkpoint validation requires folds and checkpoint values")
+    expected_files: set[Path] = set()
+    for path in expected:
+        expected_files.update(_darts_checkpoint_files(path))
+        try:
+            _model_path, _weights_path, sidecar_path = _darts_checkpoint_files(path)
+            if not all(item.is_file() for item in _darts_checkpoint_files(path)):
+                raise FileNotFoundError(path)
+            record = json.loads(sidecar_path.read_text())
+            if (
+                record.get("schema_version") != 1
+                or record.get("model_sha256") != _file_sha256(path)
+                or record.get("weights_sha256") != _file_sha256(Path(f"{path}.ckpt"))
+            ):
+                raise ValueError(path)
+        except (FileNotFoundError, json.JSONDecodeError, ValueError) as error:
+            raise ValueError(f"Darts fitted checkpoint population is incomplete: {path}") from error
+        fold = int(path.parent.name.removeprefix("fold_"))
+        checkpoint = int(path.stem.removeprefix("epoch_"))
+        required_metadata = {
+            "config_name": config_name,
+            "fold": fold,
+            "checkpoint_kind": "epoch",
+            "checkpoint_value": checkpoint,
+        }
+        mismatches = {
+            key: (record.get("metadata", {}).get(key), value)
+            for key, value in required_metadata.items()
+            if record.get("metadata", {}).get(key) != value
+        }
+        if record.get("architecture") != architecture:
+            mismatches["architecture"] = (record.get("architecture"), architecture)
+        if mismatches:
+            raise ValueError(f"Darts fitted checkpoint metadata mismatch at {path}: {mismatches}")
+
+    config_root = Path(root) / config_name
+    actual_files = {path for path in config_root.glob("fold_*/epoch_*.pt*") if path.is_file()}
+    extras = actual_files - expected_files
+    if extras:
+        raise ValueError(
+            "Darts fitted checkpoint population contains undeclared artifacts: "
+            f"{[str(path) for path in sorted(extras)]}"
+        )
+    return expected
 
 
 def uses_darts_backend(configs: list[dict[str, Any]]) -> bool:
@@ -416,6 +575,72 @@ def _attach_base_target(
     return merged
 
 
+def darts_validation_keys(
+    dataset_pd: pd.DataFrame,
+    splits: list[dict[str, Any]],
+    *,
+    config: dict[str, Any],
+    feature_names: list[str],
+    label_col: str,
+    date_col: str,
+    entity_col: str,
+    case_study: str,
+    temporal_by_fold=None,
+    temporal_keys: list[str] | None = None,
+    temporal_feature_names: list[str] | None = None,
+) -> pl.DataFrame:
+    """Return exact finite validation keys eligible for Darts forecasting."""
+    input_chunk_length, output_chunk_length = _resolve_chunk_lengths(
+        config, _parse_label_horizon(label_col)
+    )
+    dataset_pd = _attach_base_target(dataset_pd.copy(), case_study, date_col)
+    frames: list[pl.DataFrame] = []
+    has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
+    for split in splits:
+        fold_dataset = (
+            _overlay_fold_temporal_features(
+                dataset_pd,
+                split,
+                date_col,
+                temporal_by_fold,
+                temporal_keys,
+                temporal_feature_names,
+            )
+            if has_fold_temporal
+            else dataset_pd
+        )
+        states = _prepare_fold_series(
+            fold_dataset,
+            split,
+            feature_names,
+            label_col,
+            date_col,
+            entity_col,
+            input_chunk_length,
+            output_chunk_length,
+        )
+        rows = [
+            {
+                "symbol": state.entity,
+                "timestamp": pd.Timestamp(state.dates[position]),
+                "fold": int(split["fold"]),
+            }
+            for state in states
+            for position in range(state.val_start_pos, state.val_end_pos + 1)
+            if np.isfinite(state.y_true[position])
+        ]
+        if rows:
+            frames.append(pl.from_dicts(rows))
+    if not frames:
+        return pl.DataFrame(
+            schema={"symbol": pl.String, "timestamp": pl.Datetime("ns"), "fold": pl.Int64}
+        )
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("Darts request produced duplicate expected prediction keys")
+    return expected
+
+
 def _prepare_fold_series(
     dataset_pd: pd.DataFrame,
     split: dict[str, Any],
@@ -552,6 +777,8 @@ def _predict_fold(
                 continue
             if base_pos < 0 or base_pos >= len(state.dates):
                 continue
+            if not np.isfinite(state.y_true[base_pos]):
+                continue
             score_path = forecast.values(copy=False).reshape(-1).astype(np.float64, copy=False)
             rows.append(
                 {
@@ -590,6 +817,8 @@ def run_darts_cv(
     temporal_by_fold=None,
     temporal_keys: list[str] | None = None,
     temporal_feature_names: list[str] | None = None,
+    checkpoint_root: Path | None = None,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Run Darts-backed global forecasting models and emit standard DL artifacts."""
     if case_study is None:
@@ -635,6 +864,7 @@ def run_darts_cv(
         started_at = datetime.now(UTC).isoformat()
         elapsed_total = 0.0
         cfg_prediction_frames: list[pl.DataFrame] = []
+        expected_fold_ids: list[int] = []
 
         print(
             f"Darts CV: {config_name} ({params['architecture']}) "
@@ -668,8 +898,13 @@ def run_darts_cv(
                 output_chunk_length,
             )
             if not fold_series:
+                if strict:
+                    raise ValueError(
+                        f"Darts fold {split['fold']} has no series after eligibility filtering"
+                    )
                 print(f"  Fold {split['fold']}: skipped (insufficient series after filtering)")
                 continue
+            expected_fold_ids.append(int(split["fold"]))
 
             stride, max_samples_per_ts = _resolve_sampling(
                 fold_series,
@@ -728,6 +963,23 @@ def run_darts_cv(
                     max_samples_per_ts=max_samples_per_ts,
                 )
                 epochs_trained += epochs_to_train
+                if checkpoint_root is not None:
+                    write_darts_checkpoint(
+                        darts_checkpoint_path(
+                            checkpoint_root,
+                            config_name,
+                            int(split["fold"]),
+                            epochs_trained,
+                        ),
+                        model=model,
+                        architecture=str(params["architecture"]),
+                        metadata={
+                            "config_name": config_name,
+                            "fold": int(split["fold"]),
+                            "checkpoint_kind": "epoch",
+                            "checkpoint_value": epochs_trained,
+                        },
+                    )
 
                 checkpoint_preds = _predict_fold(
                     model,
@@ -739,6 +991,11 @@ def run_darts_cv(
                 )
                 elapsed = time.perf_counter() - t0
                 if checkpoint_preds.height == 0:
+                    if strict:
+                        raise ValueError(
+                            f"Darts fold {split['fold']} checkpoint {epochs_trained} "
+                            "produced no validation predictions"
+                        )
                     print(
                         f"        checkpoint {epochs_trained:3d}/{n_epochs}: "
                         f"no validation predictions ({elapsed:.1f}s elapsed)",
@@ -894,6 +1151,16 @@ def run_darts_cv(
             f"  {config_name}: epoch={best_epoch}, IC={best_ic:+.4f} "
             f"(std={best_ic_std:.4f}, {elapsed_total:.1f}s)"
         )
+        if checkpoint_root is not None:
+            from case_studies.utils.deep_model_state import declared_epoch_checkpoints
+
+            validate_darts_checkpoint_population(
+                checkpoint_root,
+                config_name=config_name,
+                fold_ids=expected_fold_ids,
+                checkpoints=declared_epoch_checkpoints(n_epochs, checkpoint_interval),
+                architecture=str(params["architecture"]),
+            )
 
     if not config_results:
         raise RuntimeError("Darts run produced no config results.")

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -27,6 +27,7 @@ from utils.modeling import RANDOM_SEED, seed_everything
 
 SUPPORTED_DARTS_ARCHITECTURES = {"nbeats", "tsmixer"}
 BASE_TARGET_COL = "_darts_target_1d"
+_DARTS_PERIOD_COL = "_darts_expected_period"
 
 
 def darts_checkpoint_path(root: Path, config_name: str, fold: int, checkpoint: int) -> Path:
@@ -201,8 +202,8 @@ class _FoldSeries:
     entity: str
     full_target: TimeSeries
     full_covariates: TimeSeries
-    train_target: TimeSeries
-    train_covariates: TimeSeries
+    train_target: TimeSeries | None
+    train_covariates: TimeSeries | None
     prediction_start_pos: int
     val_start_pos: int
     val_end_pos: int
@@ -495,6 +496,22 @@ def _resolve_sampling(
     return stride, max_samples_per_ts
 
 
+def _attach_expected_periods(
+    dataset_pd: pd.DataFrame,
+    *,
+    date_col: str,
+    calendar_id: str | None,
+) -> pd.DataFrame:
+    from case_studies.utils.sequence_dataset import _sequence_period_numbers
+
+    result = dataset_pd.copy()
+    result[_DARTS_PERIOD_COL] = _sequence_period_numbers(
+        result[date_col],
+        calendar_id=calendar_id,
+    )
+    return result
+
+
 def _load_base_target_frame(
     case_study: str,
     dataset_pd: pd.DataFrame,
@@ -593,7 +610,14 @@ def darts_validation_keys(
     input_chunk_length, output_chunk_length = _resolve_chunk_lengths(
         config, _parse_label_horizon(label_col)
     )
+    from utils.cv_splits import make_walk_forward_config
+
     dataset_pd = _attach_base_target(dataset_pd.copy(), case_study, date_col)
+    dataset_pd = _attach_expected_periods(
+        dataset_pd,
+        date_col=date_col,
+        calendar_id=make_walk_forward_config(case_study, date_col=date_col).calendar_id,
+    )
     frames: list[pl.DataFrame] = []
     has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
     for split in splits:
@@ -626,7 +650,8 @@ def darts_validation_keys(
                 "fold": int(split["fold"]),
             }
             for state in states
-            for position in range(state.val_start_pos, state.val_end_pos + 1)
+            for position in range(state.prediction_start_pos - 1, state.val_end_pos + 1)
+            if state.val_start_pos >= 0
             if np.isfinite(state.y_true[position])
         ]
         if rows:
@@ -655,7 +680,16 @@ def _prepare_fold_series(
     train_end = pd.Timestamp(split["train_end"]).to_datetime64()
     val_start = pd.Timestamp(split["val_start"]).to_datetime64()
     val_end = pd.Timestamp(split["val_end"]).to_datetime64()
-    cols = [date_col, entity_col, label_col, BASE_TARGET_COL, *feature_names]
+    if _DARTS_PERIOD_COL not in dataset_pd.columns:
+        raise ValueError("Darts dataset is missing expected-period identity")
+    cols = [
+        date_col,
+        entity_col,
+        label_col,
+        BASE_TARGET_COL,
+        _DARTS_PERIOD_COL,
+        *feature_names,
+    ]
     fold_mask = (dataset_pd[date_col] >= train_start) & (dataset_pd[date_col] <= val_end)
     fold_df = dataset_pd.loc[fold_mask, cols].copy().dropna(subset=[BASE_TARGET_COL])
     train_df = fold_df.loc[fold_df[date_col] <= train_end].copy()
@@ -671,48 +705,55 @@ def _prepare_fold_series(
     fold_df.loc[:, feature_names] = ((feature_frame - means) / stds).fillna(0.0).astype(np.float32)
 
     series: list[_FoldSeries] = []
-    for entity, sym_df in fold_df.groupby(entity_col, sort=False):
-        sym_df = sym_df.sort_values(date_col).reset_index(drop=True)
-        dates = sym_df[date_col].to_numpy()
-        train_cut = int((dates <= train_end).sum())
-        val_positions = np.flatnonzero((dates >= val_start) & (dates <= val_end))
-        if len(val_positions) == 0:
-            continue
-        if train_cut < input_chunk_length + output_chunk_length:
-            continue
-
-        val_start_pos = int(val_positions[0])
-        val_end_pos = int(val_positions[-1])
-        prediction_start_pos = val_start_pos + 1
-        if prediction_start_pos <= 0 or prediction_start_pos >= len(sym_df):
-            continue
-
-        t = np.arange(len(sym_df), dtype=np.int32)
-        target_df = pd.DataFrame(
-            {"t": t, BASE_TARGET_COL: sym_df[BASE_TARGET_COL].to_numpy(np.float32)}
-        )
-        cov_df = pd.DataFrame(
-            {"t": t, **{f: sym_df[f].to_numpy(np.float32) for f in feature_names}}
-        )
-
-        full_target = TimeSeries.from_dataframe(target_df, time_col="t", value_cols=BASE_TARGET_COL)
-        full_covariates = TimeSeries.from_dataframe(cov_df, time_col="t", value_cols=feature_names)
-
-        series.append(
-            _FoldSeries(
-                entity=str(entity),
-                full_target=full_target,
-                full_covariates=full_covariates,
-                train_target=full_target[:train_cut],
-                train_covariates=full_covariates[:train_cut],
-                prediction_start_pos=prediction_start_pos,
-                val_start_pos=val_start_pos,
-                val_end_pos=val_end_pos,
-                dates=dates,
-                y_true=sym_df[label_col].to_numpy(np.float32),
-                n_train_samples=train_cut,
+    for entity, entity_df in fold_df.groupby(entity_col, sort=False):
+        entity_df = entity_df.sort_values(date_col).reset_index(drop=True)
+        segments = entity_df[_DARTS_PERIOD_COL].diff().ne(1).cumsum()
+        for _, sym_df in entity_df.groupby(segments, sort=False):
+            sym_df = sym_df.reset_index(drop=True)
+            dates = sym_df[date_col].to_numpy()
+            train_cut = int((dates <= train_end).sum())
+            val_positions = np.flatnonzero((dates >= val_start) & (dates <= val_end))
+            can_train = train_cut >= input_chunk_length + output_chunk_length
+            val_start_pos = int(val_positions[0]) if len(val_positions) else -1
+            val_end_pos = int(val_positions[-1]) if len(val_positions) else -1
+            first_prediction_base = max(val_start_pos, input_chunk_length - 1)
+            prediction_start_pos = first_prediction_base + 1 if val_start_pos >= 0 else -1
+            can_predict = (
+                val_start_pos >= 0
+                and first_prediction_base <= val_end_pos
+                and prediction_start_pos < len(sym_df)
             )
-        )
+            if not can_train and not can_predict:
+                continue
+
+            t = np.arange(len(sym_df), dtype=np.int32)
+            target_df = pd.DataFrame(
+                {"t": t, BASE_TARGET_COL: sym_df[BASE_TARGET_COL].to_numpy(np.float32)}
+            )
+            cov_df = pd.DataFrame(
+                {"t": t, **{f: sym_df[f].to_numpy(np.float32) for f in feature_names}}
+            )
+            full_target = TimeSeries.from_dataframe(
+                target_df, time_col="t", value_cols=BASE_TARGET_COL
+            )
+            full_covariates = TimeSeries.from_dataframe(
+                cov_df, time_col="t", value_cols=feature_names
+            )
+            series.append(
+                _FoldSeries(
+                    entity=str(entity),
+                    full_target=full_target,
+                    full_covariates=full_covariates,
+                    train_target=full_target[:train_cut] if can_train else None,
+                    train_covariates=full_covariates[:train_cut] if can_train else None,
+                    prediction_start_pos=prediction_start_pos if can_predict else -1,
+                    val_start_pos=val_start_pos if can_predict else -1,
+                    val_end_pos=val_end_pos if can_predict else -1,
+                    dates=dates,
+                    y_true=sym_df[label_col].to_numpy(np.float32),
+                    n_train_samples=train_cut if can_train else 0,
+                )
+            )
 
     return series
 
@@ -753,6 +794,8 @@ def _predict_fold(
 ) -> pl.DataFrame:
     frames: list[pl.DataFrame] = []
     for state in fold_series:
+        if state.val_start_pos < 0:
+            continue
         forecasts = model.historical_forecasts(
             state.full_target,
             past_covariates=state.full_covariates,
@@ -847,6 +890,13 @@ def run_darts_cv(
 
     label_horizon = _parse_label_horizon(label_col)
     dataset_pd = _attach_base_target(dataset_pd.copy(), case_study, date_col)
+    from utils.cv_splits import make_walk_forward_config
+
+    dataset_pd = _attach_expected_periods(
+        dataset_pd,
+        date_col=date_col,
+        calendar_id=make_walk_forward_config(case_study, date_col=date_col).calendar_id,
+    )
 
     config_results: list[dict[str, Any]] = []
     learning_rows: list[dict[str, Any]] = []
@@ -897,17 +947,20 @@ def run_darts_cv(
                 input_chunk_length,
                 output_chunk_length,
             )
-            if not fold_series:
+            training_states = [state for state in fold_series if state.train_target is not None]
+            prediction_states = [state for state in fold_series if state.val_start_pos >= 0]
+            if not training_states or not prediction_states:
                 if strict:
                     raise ValueError(
-                        f"Darts fold {split['fold']} has no series after eligibility filtering"
+                        f"Darts fold {split['fold']} has no trainable or predictable series "
+                        "after gap filtering"
                     )
-                print(f"  Fold {split['fold']}: skipped (insufficient series after filtering)")
+                print(f"  Fold {split['fold']}: skipped (insufficient gap-free series)")
                 continue
             expected_fold_ids.append(int(split["fold"]))
 
             stride, max_samples_per_ts = _resolve_sampling(
-                fold_series,
+                training_states,
                 input_chunk_length,
                 output_chunk_length,
                 max_train_sequences,
@@ -918,10 +971,13 @@ def run_darts_cv(
                     msg += f", max_samples_per_ts={max_samples_per_ts}"
                 print(msg)
             else:
-                print(f"  Fold {split['fold']}: {len(fold_series)} series")
+                print(
+                    f"  Fold {split['fold']}: {len(training_states)} training series, "
+                    f"{len(prediction_states)} validation series"
+                )
 
-            train_series = [state.train_target for state in fold_series]
-            train_covariates = [state.train_covariates for state in fold_series]
+            train_series = [state.train_target for state in training_states]
+            train_covariates = [state.train_covariates for state in training_states]
             epoch_rows: list[dict[str, Any]] = []
             checkpoint_frames: list[pl.DataFrame] = []
             checkpoint_ics: dict[int, float] = {}
@@ -945,7 +1001,7 @@ def run_darts_cv(
                         config_name=config_name,
                         fold=split["fold"],
                         n_epochs=n_epochs,
-                        n_train=int(sum(state.n_train_samples for state in fold_series)),
+                        n_train=int(sum(state.n_train_samples for state in training_states)),
                         log_dir=log_dir,
                         epoch_rows=epoch_rows,
                     )
@@ -983,7 +1039,7 @@ def run_darts_cv(
 
                 checkpoint_preds = _predict_fold(
                     model,
-                    fold_series,
+                    prediction_states,
                     split["fold"],
                     date_col,
                     entity_col,

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -199,7 +199,7 @@ def uses_darts_backend(configs: list[dict[str, Any]]) -> bool:
 
 @dataclass
 class _FoldSeries:
-    entity: str
+    identity: dict[str, Any]
     full_target: TimeSeries
     full_covariates: TimeSeries
     train_target: TimeSeries | None
@@ -592,6 +592,13 @@ def _attach_base_target(
     return merged
 
 
+def _panel_identity_columns(dataset_pd: pd.DataFrame, entity_col: str) -> list[str]:
+    identity_cols = [entity_col]
+    if "position" in dataset_pd.columns and entity_col != "position":
+        identity_cols.append("position")
+    return identity_cols
+
+
 def darts_validation_keys(
     dataset_pd: pd.DataFrame,
     splits: list[dict[str, Any]],
@@ -618,6 +625,7 @@ def darts_validation_keys(
         date_col=date_col,
         calendar_id=make_walk_forward_config(case_study, date_col=date_col).calendar_id,
     )
+    identity_cols = _panel_identity_columns(dataset_pd, entity_col)
     frames: list[pl.DataFrame] = []
     has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
     for split in splits:
@@ -645,7 +653,7 @@ def darts_validation_keys(
         )
         rows = [
             {
-                "symbol": state.entity,
+                **state.identity,
                 "timestamp": pd.Timestamp(state.dates[position]),
                 "fold": int(split["fold"]),
             }
@@ -657,11 +665,13 @@ def darts_validation_keys(
         if rows:
             frames.append(pl.from_dicts(rows))
     if not frames:
+        identity_schema = pl.from_pandas(dataset_pd[identity_cols].head(0)).schema
         return pl.DataFrame(
-            schema={"symbol": pl.String, "timestamp": pl.Datetime("ns"), "fold": pl.Int64}
+            schema={**identity_schema, "timestamp": pl.Datetime("ns"), "fold": pl.Int64}
         )
-    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
-    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+    key_cols = [*identity_cols, "timestamp", "fold"]
+    expected = pl.concat(frames).sort(key_cols)
+    if expected.n_unique(key_cols) != expected.height:
         raise ValueError("Darts request produced duplicate expected prediction keys")
     return expected
 
@@ -682,9 +692,10 @@ def _prepare_fold_series(
     val_end = pd.Timestamp(split["val_end"]).to_datetime64()
     if _DARTS_PERIOD_COL not in dataset_pd.columns:
         raise ValueError("Darts dataset is missing expected-period identity")
+    identity_cols = _panel_identity_columns(dataset_pd, entity_col)
     cols = [
         date_col,
-        entity_col,
+        *identity_cols,
         label_col,
         BASE_TARGET_COL,
         _DARTS_PERIOD_COL,
@@ -705,7 +716,12 @@ def _prepare_fold_series(
     fold_df.loc[:, feature_names] = ((feature_frame - means) / stds).fillna(0.0).astype(np.float32)
 
     series: list[_FoldSeries] = []
-    for entity, entity_df in fold_df.groupby(entity_col, sort=False):
+    identity_grouper: str | list[str] = (
+        identity_cols[0] if len(identity_cols) == 1 else identity_cols
+    )
+    for identity_key, entity_df in fold_df.groupby(identity_grouper, sort=False):
+        identity_values = identity_key if isinstance(identity_key, tuple) else (identity_key,)
+        identity = dict(zip(identity_cols, identity_values, strict=True))
         entity_df = entity_df.sort_values(date_col).reset_index(drop=True)
         segments = entity_df[_DARTS_PERIOD_COL].diff().ne(1).cumsum()
         for _, sym_df in entity_df.groupby(segments, sort=False):
@@ -721,7 +737,7 @@ def _prepare_fold_series(
             can_predict = (
                 val_start_pos >= 0
                 and first_prediction_base <= val_end_pos
-                and prediction_start_pos < len(sym_df)
+                and prediction_start_pos <= len(sym_df)
             )
             if not can_train and not can_predict:
                 continue
@@ -741,7 +757,7 @@ def _prepare_fold_series(
             )
             series.append(
                 _FoldSeries(
-                    entity=str(entity),
+                    identity=identity,
                     full_target=full_target,
                     full_covariates=full_covariates,
                     train_target=full_target[:train_cut] if can_train else None,
@@ -796,19 +812,27 @@ def _predict_fold(
     for state in fold_series:
         if state.val_start_pos < 0:
             continue
-        forecasts = model.historical_forecasts(
-            state.full_target,
-            past_covariates=state.full_covariates,
-            start=state.prediction_start_pos,
-            start_format="position",
-            forecast_horizon=output_chunk_length,
-            stride=1,
-            retrain=False,
-            overlap_end=True,
-            last_points_only=False,
-            verbose=False,
-            show_warnings=False,
-        )
+        if state.prediction_start_pos == len(state.full_target):
+            forecasts = model.predict(
+                output_chunk_length,
+                series=state.full_target,
+                past_covariates=state.full_covariates,
+                verbose=False,
+            )
+        else:
+            forecasts = model.historical_forecasts(
+                state.full_target,
+                past_covariates=state.full_covariates,
+                start=state.prediction_start_pos,
+                start_format="position",
+                forecast_horizon=output_chunk_length,
+                stride=1,
+                retrain=False,
+                overlap_end=True,
+                last_points_only=False,
+                verbose=False,
+                show_warnings=False,
+            )
         if isinstance(forecasts, TimeSeries):
             forecasts = [forecasts]
 
@@ -826,7 +850,7 @@ def _predict_fold(
             rows.append(
                 {
                     date_col: pd.Timestamp(state.dates[base_pos]),
-                    entity_col: state.entity,
+                    **state.identity,
                     "y_true": float(state.y_true[base_pos]),
                     "y_score": float(np.expm1(score_path.sum())),
                     "fold_id": fold_id,

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -556,9 +556,16 @@ def _load_base_target_frame(
     if case_study == "cme_futures":
         from data import load_cme_futures
 
+        join_keys = [date_col, "product", "position"]
+        missing_keys = set(join_keys) - set(dataset_pd.columns)
+        if missing_keys:
+            raise ValueError(f"CME Darts dataset is missing panel keys: {sorted(missing_keys)}")
+        target_df = load_cme_futures().rename({"session_date": "timestamp", "tenor": "position"})
+        eligible_keys = pl.from_pandas(dataset_pd[join_keys].drop_duplicates()).with_columns(
+            *(pl.col(key).cast(target_df.schema[key]) for key in join_keys)
+        )
         target_df = (
-            load_cme_futures()
-            .rename({"session_date": "timestamp", "tenor": "position"})
+            target_df.join(eligible_keys, on=join_keys, how="inner", validate="m:1")
             .sort(["product", "position", "timestamp"])
             .with_columns(
                 (
@@ -570,9 +577,6 @@ def _load_base_target_frame(
             )
             .select(["timestamp", "product", "position", BASE_TARGET_COL])
         )
-        join_keys = [date_col, "product"]
-        if "position" in dataset_pd.columns:
-            join_keys.append("position")
         assert isinstance(target_df, pl.DataFrame)
         return target_df.to_pandas(), join_keys
 

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -203,6 +203,7 @@ def _train_one_config(
     checkpoint_callback: Callable[[dict[int, np.ndarray], np.ndarray, np.ndarray, np.ndarray], None]
     | None = None,
     epoch_callback: Callable[[dict[str, Any]], None] | None = None,
+    state_callback: Callable[[int, nn.Module], None] | None = None,
 ) -> tuple[dict[int, float], dict[int, np.ndarray], dict[int, float]]:
     """Train a single model config, storing predictions at ALL checkpoints.
 
@@ -295,6 +296,8 @@ def _train_one_config(
             )["ic_mean"]
             checkpoint_ics[epoch] = ic
             checkpoint_preds[epoch] = val_preds.copy()
+            if state_callback is not None:
+                state_callback(epoch, model)
             if checkpoint_callback is not None:
                 checkpoint_callback(checkpoint_preds, y_val, val_dates, val_entities)
             if epoch_callback is not None:
@@ -460,6 +463,7 @@ def run_dl_cv(
     prediction_split: str = "validation",
     identity_params: dict[str, Any] | None = None,
     input_data_spec: dict[str, Any] | None = None,
+    checkpoint_root: Path | None = None,
 ) -> dict[str, Any]:
     """Walk-forward DL CV with epoch-checkpoint IC evaluation.
 
@@ -857,6 +861,48 @@ def run_dl_cv(
                 if _log_dir is not None:
                     flush_fold_training_log(_log_dir, _config_name, _fold, _epoch_rows)
 
+            train_kwargs: dict[str, Any] = {}
+            if checkpoint_root is not None:
+                from case_studies.utils.deep_model_state import write_deep_checkpoint
+
+                if train_store.feature_mean is None or train_store.feature_scale is None:
+                    raise ValueError("sequence fold has no fitted preprocessing state")
+                preprocessing = {
+                    "feature_names": list(feature_names),
+                    "mean": train_store.feature_mean.copy(),
+                    "scale": train_store.feature_scale.copy(),
+                    "lookback": int(lookback),
+                }
+
+                def persist_state(
+                    epoch: int,
+                    fitted_model: nn.Module,
+                    *,
+                    _fold: int = int(split["fold"]),
+                    _config_name: str = config_name,
+                    _architecture: str = arch_name,
+                    _model_kwargs: dict[str, Any] = arch_kwargs,
+                    _preprocessing: dict[str, Any] = preprocessing,
+                ) -> None:
+                    write_deep_checkpoint(
+                        checkpoint_root
+                        / _config_name
+                        / f"fold_{_fold:02d}"
+                        / f"epoch_{epoch:04d}.pt",
+                        model=fitted_model,
+                        architecture=_architecture,
+                        model_kwargs=_model_kwargs,
+                        preprocessing=_preprocessing,
+                        metadata={
+                            "config_name": _config_name,
+                            "fold": _fold,
+                            "checkpoint_kind": "epoch",
+                            "checkpoint_value": epoch,
+                        },
+                    )
+
+                train_kwargs["state_callback"] = persist_state
+
             checkpoint_ics, checkpoint_preds, epoch_losses = _train_one_config(
                 model=model,
                 train_loader=train_loader,
@@ -866,6 +912,7 @@ def run_dl_cv(
                 device=torch_device,
                 checkpoint_callback=_on_checkpoint,
                 epoch_callback=_on_epoch,
+                **train_kwargs,
             )
 
             elapsed = time.perf_counter() - t0

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -464,6 +464,7 @@ def run_dl_cv(
     identity_params: dict[str, Any] | None = None,
     input_data_spec: dict[str, Any] | None = None,
     checkpoint_root: Path | None = None,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Walk-forward DL CV with epoch-checkpoint IC evaluation.
 
@@ -585,6 +586,22 @@ def run_dl_cv(
                 )
                 split_complete = not split_rows.is_empty()
                 if status.complete and split_complete:
+                    if checkpoint_root is not None:
+                        from case_studies.utils.deep_model_state import (
+                            declared_epoch_checkpoints,
+                            validate_deep_checkpoint_population,
+                        )
+
+                        validate_deep_checkpoint_population(
+                            checkpoint_root,
+                            config_name=cfg["config_name"],
+                            fold_ids=tuple(int(split["fold"]) for split in splits),
+                            checkpoints=declared_epoch_checkpoints(
+                                int(cfg.get("n_epochs", 100)),
+                                int(cfg.get("checkpoint_interval", 5)),
+                            ),
+                            architecture=resolve_arch_name(cfg["config_name"]),
+                        )
                     print(
                         f"  SKIP {cfg['config_name']:25s}  ({status.summary()}, split={prediction_split})"
                     )
@@ -644,6 +661,8 @@ def run_dl_cv(
                 )
 
     if uses_darts_backend(configs):
+        if checkpoint_root is not None:
+            raise ValueError("Darts fitted-state persistence requires its family adapter")
         fresh_result = run_darts_cv(
             dataset_pd,
             splits,
@@ -742,6 +761,11 @@ def run_dl_cv(
         )
 
         if fold_info["train_sequences"] < 100 or fold_info["val_sequences"] < 50:
+            if strict:
+                raise ValueError(
+                    f"Fold {split['fold']} is too small: "
+                    f"train={fold_info['train_sequences']}, val={fold_info['val_sequences']}"
+                )
             print(
                 "    Skipped "
                 f"(train={fold_info['train_sequences']}, val={fold_info['val_sequences']})"
@@ -1049,6 +1073,23 @@ def run_dl_cv(
             f"  {config_name}: best_epoch={best_cp}, IC={best_ic_val:+.4f} ({acc['elapsed_s']:.1f}s)"
         )
 
+        if checkpoint_root is not None:
+            from case_studies.utils.deep_model_state import (
+                declared_epoch_checkpoints,
+                validate_deep_checkpoint_population,
+            )
+
+            validate_deep_checkpoint_population(
+                checkpoint_root,
+                config_name=config_name,
+                fold_ids=tuple(expected_fold_ids),
+                checkpoints=declared_epoch_checkpoints(
+                    int(cfg.get("n_epochs", 100)),
+                    int(cfg.get("checkpoint_interval", 5)),
+                ),
+                architecture=resolve_arch_name(config_name),
+            )
+
         # Incremental registration: persist every complete checkpoint as soon as
         # aggregation finishes. Registering only the raw-IC peak would prevent a
         # reader from applying the checkpoint-level coverage guard when that peak
@@ -1099,6 +1140,8 @@ def run_dl_cv(
                     f"({len(epoch_scores)} per-epoch slices)"
                 )
             except Exception as exc:
+                if strict:
+                    raise
                 print(f"    WARN: incremental registration failed for {config_name}: {exc}")
 
     del config_acc

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -863,7 +863,10 @@ def run_dl_cv(
 
             train_kwargs: dict[str, Any] = {}
             if checkpoint_root is not None:
-                from case_studies.utils.deep_model_state import write_deep_checkpoint
+                from case_studies.utils.deep_model_state import (
+                    deep_checkpoint_path,
+                    write_deep_checkpoint,
+                )
 
                 if train_store.feature_mean is None or train_store.feature_scale is None:
                     raise ValueError("sequence fold has no fitted preprocessing state")
@@ -885,10 +888,7 @@ def run_dl_cv(
                     _preprocessing: dict[str, Any] = preprocessing,
                 ) -> None:
                     write_deep_checkpoint(
-                        checkpoint_root
-                        / _config_name
-                        / f"fold_{_fold:02d}"
-                        / f"epoch_{epoch:04d}.pt",
+                        deep_checkpoint_path(checkpoint_root, _config_name, _fold, epoch),
                         model=fitted_model,
                         architecture=_architecture,
                         model_kwargs=_model_kwargs,

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -20,12 +20,21 @@ Usage:
 from __future__ import annotations
 
 import gc
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import subprocess
 import time
+import uuid
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -50,12 +59,507 @@ from case_studies.utils.sequence_dataset import (
     collate_with_metadata,
     materialize_store_metadata,
     prepare_fold_sequence_stores,
+    sequence_validation_keys,
 )
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 from utils.modeling import RANDOM_SEED, seed_everything
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+
+_SEQUENCE_PREVIEW_FIELDS = {"folds", "max_symbols", "max_train_sequences"}
+
+
+@dataclass(frozen=True)
+class SequenceResearchContext:
+    dataset_pd: pd.DataFrame
+    splits: tuple[dict[str, Any], ...]
+    config: dict[str, Any]
+    feature_names: tuple[str, ...]
+    label_col: str
+    date_col: str
+    entity_col: str
+    task_type: str
+    class_values: tuple[Any, ...]
+    temporal_by_fold: pd.DataFrame | None
+    temporal_keys: tuple[str, ...]
+    temporal_feature_names: tuple[str, ...]
+    expected_keys: pl.DataFrame
+    max_train_sequences: int
+    runtime_provenance: dict[str, Any]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _sequence_source_identity(config: dict[str, Any]) -> dict[str, str]:
+    from case_studies.utils import deep_model_state, sequence_dataset
+
+    paths = [Path(__file__), Path(deep_model_state.__file__), Path(sequence_dataset.__file__)]
+    if config.get("library") == "darts":
+        from case_studies.utils import darts_forecasting
+
+        paths.append(Path(darts_forecasting.__file__))
+    else:
+        architecture = str(config["params"]["architecture"])
+        model_class = _get_model_registry()[architecture]
+        module = __import__(model_class.__module__, fromlist=[model_class.__name__])
+        paths.append(Path(module.__file__))
+    return {path.name: _sha256(path) for path in paths}
+
+
+def _sequence_runtime_identity(config: dict[str, Any]) -> dict[str, str]:
+    packages = {
+        "numpy": importlib.metadata.version("numpy"),
+        "torch": importlib.metadata.version("torch"),
+    }
+    if config.get("library") == "darts":
+        packages.update(
+            {
+                "darts": importlib.metadata.version("u8darts"),
+                "pytorch-lightning": importlib.metadata.version("pytorch-lightning"),
+            }
+        )
+    return packages
+
+
+def _sequence_runtime_provenance(study: Study, config: dict[str, Any]) -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(study.release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = "unknown"
+    return {
+        "entry_point": "case_studies.utils.deep_learning",
+        "packages": _sequence_runtime_identity(config),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": commit,
+    }
+
+
+def _normalize_sequence_splits(
+    splits: list[dict[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+    return tuple(
+        {
+            key: int(split[key]) if key == "fold" else str(split[key])
+            for key in fields
+            if split.get(key) is not None
+        }
+        for split in splits
+    )
+
+
+def _sequence_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    from case_studies.utils.artifact_digest import value_digest
+
+    cv = request.get("cv")
+    if cv is None:
+        splits = [dict(split) for split in mds.splits]
+        normalized = _normalize_sequence_splits(splits)
+        cv_record = {
+            "request": {"source": "case_study_default"},
+            "folds": list(normalized),
+            "identity": value_digest(pl.DataFrame(list(normalized))),
+        }
+    else:
+        resolved = cv.resolve(mds.dataset.select(mds.date_col).unique(), date_col=mds.date_col)
+        splits = [dict(fold) for fold in resolved.normalized_folds]
+        cv_record = resolved.as_dict()
+    requested_folds = request["preview_reductions"].get("folds")
+    if requested_folds is not None:
+        selected = {int(fold) for fold in requested_folds}
+        splits = [split for split in splits if int(split["fold"]) in selected]
+        if {int(split["fold"]) for split in splits} != selected:
+            raise ValueError("preview fold reduction refers to an unavailable fold")
+        cv_record = {**cv_record, "preview_folds": sorted(selected)}
+    if not splits:
+        raise ValueError("sequence request resolved no cross-validation folds")
+    return splits, cv_record
+
+
+def _resolve_sequence_config(config: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    resolved = {**config, "params": dict(config.get("params") or {})}
+    top_level = {"batch_size", "checkpoint_interval", "n_epochs", "seed"}
+    runtime_fields = {"device", "num_threads"}
+    unknown = set(overrides) - top_level - runtime_fields - set(resolved["params"])
+    if unknown:
+        raise ValueError(f"unsupported sequence overrides: {sorted(unknown)}")
+    for key, value in overrides.items():
+        if key in top_level:
+            resolved[key] = value
+        elif key not in runtime_fields:
+            resolved["params"][key] = value
+    architecture = str(resolved["params"].get("architecture", ""))
+    library = resolved.get("library", "pytorch")
+    if library == "darts":
+        from case_studies.utils.darts_forecasting import SUPPORTED_DARTS_ARCHITECTURES
+
+        if architecture not in SUPPORTED_DARTS_ARCHITECTURES:
+            raise ValueError(f"unsupported Darts sequence architecture {architecture!r}")
+    elif library != "pytorch" or architecture not in _get_model_registry():
+        raise ValueError(f"unsupported PyTorch sequence architecture {architecture!r}")
+    from case_studies.utils.deep_model_state import declared_epoch_checkpoints
+
+    declared_epoch_checkpoints(
+        int(resolved.get("n_epochs", 100)),
+        int(resolved.get("checkpoint_interval", 5)),
+    )
+    return resolved
+
+
+def _sequence_runtime_spec(
+    device: str,
+    *,
+    seed: int,
+    num_threads: int,
+) -> dict[str, Any]:
+    if num_threads < 1:
+        raise ValueError("num_threads must be at least 1")
+    normalized = device.lower().replace("gpu", "cuda")
+    if normalized == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested for sequence training, but CUDA is unavailable")
+    if normalized not in {"cpu", "cuda"}:
+        raise ValueError(f"unsupported sequence device {device!r}")
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    return {
+        "device": normalized,
+        "deterministic_algorithms": True,
+        "cublas_workspace_config": os.environ["CUBLAS_WORKSPACE_CONFIG"],
+        "num_threads": num_threads,
+        "seed": seed,
+    }
+
+
+def _configure_sequence_runtime(spec: dict[str, Any]) -> None:
+    torch.set_num_threads(int(spec["num_threads"]))
+    torch.use_deterministic_algorithms(True, warn_only=False)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    seed_everything(int(spec["seed"]))
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    from case_studies.research.contracts import ExecutionTier
+    from case_studies.utils.artifact_digest import value_digest
+    from case_studies.utils.deep_model_state import declared_epoch_checkpoints
+    from utils.cv_splits import make_walk_forward_config
+    from utils.modeling import load_configs, load_modeling_dataset
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _SEQUENCE_PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported sequence preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"])
+    mds = load_modeling_dataset(
+        study.case_study,
+        label_ref.name,
+        max_symbols=int(reductions.get("max_symbols", 0)),
+    )
+    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
+        raise ValueError("sequence runner requires canonical symbol and timestamp keys")
+    if mds.task_type != "regression":
+        raise ValueError("sequence runner currently supports regression labels only")
+    splits, cv_record = _sequence_splits(mds, request)
+    configs = {
+        config["config_name"]: config
+        for config in load_configs(study.case_study, label_ref.name, "deep_learning")
+    }
+    try:
+        configured = configs[request["config_name"]]
+    except KeyError as error:
+        raise ValueError(f"unknown sequence configuration {request['config_name']!r}") from error
+    config = _resolve_sequence_config(configured, request["overrides"])
+    if config.get("family") != "deep_learning":
+        raise ValueError(f"sequence preset belongs to unsupported family {config.get('family')!r}")
+    seed = int(config.get("seed", RANDOM_SEED))
+    runtime = _sequence_runtime_spec(
+        str(request["overrides"].get("device", "cuda")),
+        seed=seed,
+        num_threads=int(request["overrides"].get("num_threads", 8)),
+    )
+    max_train_sequences = int(reductions.get("max_train_sequences", 0))
+    calendar_id = make_walk_forward_config(study.case_study, date_col=mds.date_col).calendar_id
+    lookback = int(config["params"].get("lookback", 60))
+    dataset_pd = mds.dataset.to_pandas()
+    if config.get("library") == "darts":
+        from case_studies.utils.darts_forecasting import (
+            darts_training_identity,
+            darts_validation_keys,
+        )
+
+        expected = darts_validation_keys(
+            dataset_pd,
+            splits,
+            config=config,
+            feature_names=list(mds.feature_names),
+            label_col=mds.label_col,
+            date_col=mds.date_col,
+            entity_col=mds.entity_cols[0],
+            case_study=study.case_study,
+            temporal_by_fold=mds.temporal_by_fold,
+            temporal_keys=list(mds.temporal_keys),
+            temporal_feature_names=list(mds.temporal_feature_names),
+        )
+        sequence_identity = darts_training_identity(
+            config,
+            mds.label_col,
+            case_study=study.case_study,
+            input_data_spec=mds.input_lineage,
+            max_train_sequences=max_train_sequences,
+        )
+        preprocessing = {
+            "class": "fold_train_standardization",
+            "base_target": "one_period_log_return",
+            "input_chunk_length": sequence_identity["input_chunk_length"],
+            "output_chunk_length": sequence_identity["output_chunk_length"],
+        }
+    else:
+        expected = sequence_validation_keys(
+            dataset_pd,
+            splits,
+            label_col=mds.label_col,
+            date_col=mds.date_col,
+            entity_col=mds.entity_cols[0],
+            lookback=lookback,
+            calendar_id=calendar_id,
+        )
+        sequence_identity = {
+            "input_data_spec": mds.input_lineage,
+            "lookback": lookback,
+            "max_train_sequences": max_train_sequences,
+        }
+        preprocessing = {
+            "class": "fold_train_standardization",
+            "gap_policy": "exclude_windows_crossing_missing_expected_periods",
+            "lookback": lookback,
+        }
+    checkpoints = declared_epoch_checkpoints(
+        int(config.get("n_epochs", 100)), int(config.get("checkpoint_interval", 5))
+    )
+    spec = {
+        "identity_version": 2,
+        "execution_tier": tier.value,
+        "family": "deep_learning",
+        "label": label_ref.name,
+        "seed": seed,
+        "config_name": config["config_name"],
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": mds.input_lineage["artifacts"],
+        "feature_names": list(mds.feature_names),
+        "task": {"type": "regression", "class_values": []},
+        "cv": cv_record,
+        "model": {
+            "class": config["params"]["architecture"],
+            "implementation": config.get("library", "pytorch"),
+            "objective": "regression",
+            "params": {
+                **config["params"],
+                "batch_size": int(config["batch_size"]),
+                "checkpoint_interval": int(config["checkpoint_interval"]),
+                "n_epochs": int(config["n_epochs"]),
+            },
+        },
+        "preprocessing": preprocessing,
+        "checkpoint_schedule": [
+            {"kind": "epoch", "value": checkpoint} for checkpoint in checkpoints
+        ],
+        "expected_prediction_keys": {
+            "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+            "n_rows": expected.height,
+            "n_folds": expected["fold"].n_unique(),
+        },
+        "input_data_spec": sequence_identity,
+        "sampling": {
+            "max_symbols": int(reductions.get("max_symbols", 0)),
+            "max_train_sequences": max_train_sequences,
+        },
+        "numerics": runtime,
+        "source_identity": _sequence_source_identity(config),
+        "runtime_identity": _sequence_runtime_identity(config),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        spec["preview_reductions"] = reductions
+    context = SequenceResearchContext(
+        dataset_pd=dataset_pd,
+        splits=tuple(splits),
+        config=config,
+        feature_names=tuple(mds.feature_names),
+        label_col=mds.label_col,
+        date_col=mds.date_col,
+        entity_col=mds.entity_cols[0],
+        task_type=mds.task_type,
+        class_values=tuple(mds.class_values),
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=tuple(mds.temporal_keys),
+        temporal_feature_names=tuple(mds.temporal_feature_names),
+        expected_keys=expected,
+        max_train_sequences=max_train_sequences,
+        runtime_provenance=_sequence_runtime_provenance(study, config),
+    )
+    return spec, context
+
+
+def _cached_sequence_run(study: Study, spec: dict[str, Any], context: SequenceResearchContext):
+    from case_studies.research.models import ModelRun
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+    from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+
+    training_hash = training_hash_from_spec(spec)
+    checkpoint_values = tuple(item["value"] for item in spec["checkpoint_schedule"])
+    try:
+        training = Result.open(
+            study, training_hash, include_preview=spec["execution_tier"] == "preview"
+        )
+        predictions = tuple(
+            Result.open(
+                study,
+                prediction_hash_from_parts(
+                    training_hash,
+                    checkpoint,
+                    "validation",
+                    checkpoint_kind="epoch",
+                    identity_version=2,
+                ),
+                include_preview=spec["execution_tier"] == "preview",
+            )
+            for checkpoint in checkpoint_values
+        )
+    except KeyError:
+        return None
+    if not isinstance(training, TrainingResult) or any(
+        not isinstance(result, PredictionResult) or not result.complete for result in predictions
+    ):
+        return None
+    model_root = training.root / "run_log" / "training" / training.hash / "models"
+    fold_ids = tuple(int(split["fold"]) for split in context.splits)
+    try:
+        if context.config.get("library") == "darts":
+            from case_studies.utils.darts_forecasting import (
+                validate_darts_checkpoint_population,
+            )
+
+            validate_darts_checkpoint_population(
+                model_root,
+                config_name=context.config["config_name"],
+                fold_ids=fold_ids,
+                checkpoints=checkpoint_values,
+                architecture=context.config["params"]["architecture"],
+            )
+        else:
+            from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
+
+            validate_deep_checkpoint_population(
+                model_root,
+                config_name=context.config["config_name"],
+                fold_ids=fold_ids,
+                checkpoints=checkpoint_values,
+                architecture=context.config["params"]["architecture"],
+            )
+    except ValueError:
+        return None
+    return ModelRun(training=training, predictions=predictions)
+
+
+def run_resolved_request(
+    study: Study,
+    spec: dict[str, Any],
+    context: SequenceResearchContext,
+):
+    from case_studies.research.models import ModelRun
+
+    cached = _cached_sequence_run(study, spec, context)
+    if cached is not None:
+        return cached
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    train_dir = training.root / "run_log" / "training" / training.hash
+    model_dir = train_dir / "models"
+    if model_dir.exists():
+        raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+    staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+    _configure_sequence_runtime(spec["numerics"])
+    try:
+        result = run_dl_cv(
+            context.dataset_pd,
+            list(context.splits),
+            configs=[context.config],
+            n_features=len(context.feature_names),
+            feature_names=list(context.feature_names),
+            label_col=context.label_col,
+            date_col=context.date_col,
+            entity_col=context.entity_col,
+            device=spec["numerics"]["device"],
+            save_dir=train_dir / "diagnostics",
+            max_train_sequences=context.max_train_sequences,
+            register=False,
+            case_study=study.case_study,
+            temporal_by_fold=context.temporal_by_fold,
+            temporal_keys=list(context.temporal_keys),
+            temporal_feature_names=list(context.temporal_feature_names),
+            checkpoint_root=staging,
+            strict=True,
+            seed=int(spec["seed"]),
+            num_threads=int(spec["numerics"]["num_threads"]),
+        )
+        os.replace(staging, model_dir)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    prediction_results = []
+    for checkpoint in (item["value"] for item in spec["checkpoint_schedule"]):
+        predictions = (
+            result["all_predictions"]
+            .filter(
+                (pl.col("config") == context.config["config_name"])
+                & (pl.col("epoch") == checkpoint)
+            )
+            .drop("config", "epoch")
+            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
+        )
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="epoch",
+                checkpoint_value=int(checkpoint),
+                split="validation",
+                predictions=predictions,
+                expected_keys=context.expected_keys,
+                task_type="regression",
+                class_values=None,
+                label=context.label_col,
+            )
+        )
+    runtime_path = train_dir / "runtime.json"
+    if runtime_path.exists():
+        runtime = json.loads(runtime_path.read_text())
+        runtime["elapsed_s"] = sum(
+            float(row.get("elapsed_s", 0.0)) for row in result["grid_results"]
+        )
+        runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+    return ModelRun(training=training, predictions=tuple(prediction_results))
+
 
 # ---------------------------------------------------------------------------
 # Model Factory (lazy imports — models package may not be deployed)
@@ -465,6 +969,8 @@ def run_dl_cv(
     input_data_spec: dict[str, Any] | None = None,
     checkpoint_root: Path | None = None,
     strict: bool = False,
+    seed: int = RANDOM_SEED,
+    num_threads: int = 8,
 ) -> dict[str, Any]:
     """Walk-forward DL CV with epoch-checkpoint IC evaluation.
 
@@ -513,6 +1019,10 @@ def run_dl_cv(
         darts_training_identity,
         run_darts_cv,
         uses_darts_backend,
+    )
+
+    _configure_sequence_runtime(
+        _sequence_runtime_spec(device, seed=int(seed), num_threads=int(num_threads))
     )
 
     if register and save_dir is None:
@@ -587,21 +1097,37 @@ def run_dl_cv(
                 split_complete = not split_rows.is_empty()
                 if status.complete and split_complete:
                     if checkpoint_root is not None:
-                        from case_studies.utils.deep_model_state import (
-                            declared_epoch_checkpoints,
-                            validate_deep_checkpoint_population,
-                        )
+                        from case_studies.utils.deep_model_state import declared_epoch_checkpoints
 
-                        validate_deep_checkpoint_population(
-                            checkpoint_root,
-                            config_name=cfg["config_name"],
-                            fold_ids=tuple(int(split["fold"]) for split in splits),
-                            checkpoints=declared_epoch_checkpoints(
-                                int(cfg.get("n_epochs", 100)),
-                                int(cfg.get("checkpoint_interval", 5)),
-                            ),
-                            architecture=resolve_arch_name(cfg["config_name"]),
+                        checkpoint_values = declared_epoch_checkpoints(
+                            int(cfg.get("n_epochs", 100)),
+                            int(cfg.get("checkpoint_interval", 5)),
                         )
+                        fold_ids = tuple(int(split["fold"]) for split in splits)
+                        if uses_darts_backend([cfg]):
+                            from case_studies.utils.darts_forecasting import (
+                                validate_darts_checkpoint_population,
+                            )
+
+                            validate_darts_checkpoint_population(
+                                checkpoint_root,
+                                config_name=cfg["config_name"],
+                                fold_ids=fold_ids,
+                                checkpoints=checkpoint_values,
+                                architecture=cfg["params"]["architecture"],
+                            )
+                        else:
+                            from case_studies.utils.deep_model_state import (
+                                validate_deep_checkpoint_population,
+                            )
+
+                            validate_deep_checkpoint_population(
+                                checkpoint_root,
+                                config_name=cfg["config_name"],
+                                fold_ids=fold_ids,
+                                checkpoints=checkpoint_values,
+                                architecture=resolve_arch_name(cfg["config_name"]),
+                            )
                     print(
                         f"  SKIP {cfg['config_name']:25s}  ({status.summary()}, split={prediction_split})"
                     )
@@ -661,8 +1187,6 @@ def run_dl_cv(
                 )
 
     if uses_darts_backend(configs):
-        if checkpoint_root is not None:
-            raise ValueError("Darts fitted-state persistence requires its family adapter")
         fresh_result = run_darts_cv(
             dataset_pd,
             splits,
@@ -683,6 +1207,8 @@ def run_dl_cv(
             temporal_by_fold=temporal_by_fold,
             temporal_keys=temporal_keys,
             temporal_feature_names=temporal_feature_names,
+            checkpoint_root=checkpoint_root,
+            strict=strict,
         )
         if cached_result is not None:
             return combine_cv_results(
@@ -702,7 +1228,7 @@ def run_dl_cv(
         if not splits:
             raise ValueError(f"No splits matched selected_folds={selected_folds}")
 
-    seed_everything(RANDOM_SEED)
+    seed_everything(seed)
 
     # Extract lookback from configs (must be uniform for fold-major sequencing)
     lookback = configs[0].get("params", {}).get("lookback", 60)
@@ -736,7 +1262,7 @@ def run_dl_cv(
     _has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
 
     for split in splits:
-        seed_everything(RANDOM_SEED + split["fold"])
+        seed_everything(seed + split["fold"])
 
         train_mask = (dates_series >= split["train_start"]) & (dates_series <= split["train_end"])
         val_mask = (dates_series >= split["val_start"]) & (dates_series <= split["val_end"])

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -124,7 +124,7 @@ def _sequence_runtime_identity(config: dict[str, Any]) -> dict[str, str]:
     if config.get("library") == "darts":
         packages.update(
             {
-                "darts": importlib.metadata.version("u8darts"),
+                "darts": importlib.metadata.version("darts"),
                 "pytorch-lightning": importlib.metadata.version("pytorch-lightning"),
             }
         )
@@ -189,6 +189,9 @@ def _sequence_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]]
         cv_record = {**cv_record, "preview_folds": sorted(selected)}
     if not splits:
         raise ValueError("sequence request resolved no cross-validation folds")
+    from utils.modeling import validate_temporal_split_geometry
+
+    validate_temporal_split_geometry(splits, mds.splits, mds.temporal_by_fold)
     return splits, cv_record
 
 

--- a/case_studies/utils/deep_model_state.py
+++ b/case_studies/utils/deep_model_state.py
@@ -15,6 +15,15 @@ from torch import nn
 SCHEMA_VERSION = 1
 
 
+def declared_epoch_checkpoints(n_epochs: int, checkpoint_interval: int) -> tuple[int, ...]:
+    if n_epochs < 1 or checkpoint_interval < 1:
+        raise ValueError("n_epochs and checkpoint_interval must be positive")
+    checkpoints = list(range(checkpoint_interval, n_epochs + 1, checkpoint_interval))
+    if not checkpoints or checkpoints[-1] != n_epochs:
+        checkpoints.append(n_epochs)
+    return tuple(checkpoints)
+
+
 def _cpu_state_dict(model: nn.Module) -> dict[str, torch.Tensor]:
     return {name: value.detach().cpu() for name, value in model.state_dict().items()}
 

--- a/case_studies/utils/deep_model_state.py
+++ b/case_studies/utils/deep_model_state.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+
+SCHEMA_VERSION = 1
+
+
+def _cpu_state_dict(model: nn.Module) -> dict[str, torch.Tensor]:
+    return {name: value.detach().cpu() for name, value in model.state_dict().items()}
+
+
+def _tensorize(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return torch.from_numpy(value.copy())
+    if isinstance(value, Mapping):
+        return {str(key): _tensorize(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_tensorize(item) for item in value]
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    raise TypeError(f"unsupported checkpoint value {type(value).__name__}")
+
+
+def _untensorize(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.cpu().numpy()
+    if isinstance(value, dict):
+        return {key: _untensorize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_untensorize(item) for item in value]
+    return value
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _semantic_digest(value: Any) -> str:
+    digest = hashlib.sha256()
+
+    def update(item: Any) -> None:
+        if isinstance(item, torch.Tensor):
+            array = item.detach().cpu().contiguous().numpy()
+            digest.update(b"tensor")
+            digest.update(str(array.dtype).encode())
+            digest.update(str(array.shape).encode())
+            digest.update(array.tobytes())
+        elif isinstance(item, Mapping):
+            digest.update(b"mapping")
+            for key in sorted(item):
+                digest.update(str(key).encode())
+                update(item[key])
+        elif isinstance(item, list | tuple):
+            digest.update(b"sequence")
+            for member in item:
+                update(member)
+        else:
+            digest.update(repr(item).encode())
+
+    update(value)
+    return digest.hexdigest()
+
+
+def checkpoint_sidecar(path: Path) -> Path:
+    return path.with_suffix(f"{path.suffix}.json")
+
+
+def write_deep_checkpoint(
+    path: Path,
+    *,
+    model: nn.Module,
+    architecture: str,
+    model_kwargs: Mapping[str, Any],
+    preprocessing: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> Path:
+    """Write one immutable fitted checkpoint and its digest sidecar."""
+    path = Path(path)
+    sidecar = checkpoint_sidecar(path)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "architecture": architecture,
+        "model_kwargs": _tensorize(model_kwargs),
+        "preprocessing": _tensorize(preprocessing),
+        "metadata": _tensorize(metadata),
+        "state_dict": _cpu_state_dict(model),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    token = uuid.uuid4().hex
+    checkpoint_tmp = path.with_name(f".{path.name}.{token}.tmp")
+    sidecar_tmp = sidecar.with_name(f".{sidecar.name}.{token}.tmp")
+    try:
+        torch.save(payload, checkpoint_tmp)
+        record = {
+            "schema_version": SCHEMA_VERSION,
+            "sha256": _sha256(checkpoint_tmp),
+            "content_sha256": _semantic_digest(payload),
+            "size": checkpoint_tmp.stat().st_size,
+            "architecture": architecture,
+            "metadata": _tensorize(metadata),
+        }
+        sidecar_tmp.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+        if path.exists() or sidecar.exists():
+            if path.is_file() and sidecar.is_file():
+                existing = json.loads(sidecar.read_text())
+                if existing.get("content_sha256") == record["content_sha256"] and _sha256(
+                    path
+                ) == existing.get("sha256"):
+                    return path
+            raise FileExistsError(f"immutable checkpoint conflict: {path}")
+        os.replace(checkpoint_tmp, path)
+        try:
+            os.replace(sidecar_tmp, sidecar)
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+    finally:
+        checkpoint_tmp.unlink(missing_ok=True)
+        sidecar_tmp.unlink(missing_ok=True)
+    return path
+
+
+def load_deep_checkpoint(path: Path) -> dict[str, Any]:
+    """Load a checkpoint only after its immutable digest contract passes."""
+    path = Path(path)
+    sidecar = checkpoint_sidecar(path)
+    if not path.is_file() or not sidecar.is_file():
+        raise FileNotFoundError(f"checkpoint or sidecar is missing: {path}")
+    record = json.loads(sidecar.read_text())
+    actual_digest = _sha256(path)
+    if record.get("schema_version") != SCHEMA_VERSION or record.get("sha256") != actual_digest:
+        raise ValueError(f"checkpoint digest does not match its sidecar: {path}")
+    payload = torch.load(path, map_location="cpu", weights_only=True)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported checkpoint schema: {payload.get('schema_version')}")
+    return _untensorize(payload)
+
+
+def restore_deep_model(
+    path: Path,
+    factory: Callable[[str, Mapping[str, Any]], nn.Module],
+) -> tuple[nn.Module, dict[str, Any], dict[str, Any]]:
+    """Rebuild a fitted model and return its preprocessing and metadata."""
+    payload = load_deep_checkpoint(path)
+    model = factory(payload["architecture"], payload["model_kwargs"])
+    tensor_state = {
+        name: torch.from_numpy(value) if isinstance(value, np.ndarray) else value
+        for name, value in payload["state_dict"].items()
+    }
+    model.load_state_dict(tensor_state, strict=True)
+    model.eval()
+    return model, payload["preprocessing"], payload["metadata"]

--- a/case_studies/utils/deep_model_state.py
+++ b/case_studies/utils/deep_model_state.py
@@ -79,6 +79,10 @@ def checkpoint_sidecar(path: Path) -> Path:
     return path.with_suffix(f"{path.suffix}.json")
 
 
+def deep_checkpoint_path(root: Path, config_name: str, fold: int, checkpoint: int) -> Path:
+    return Path(root) / config_name / f"fold_{fold:02d}" / f"epoch_{checkpoint:04d}.pt"
+
+
 def write_deep_checkpoint(
     path: Path,
     *,
@@ -164,3 +168,54 @@ def restore_deep_model(
     model.load_state_dict(tensor_state, strict=True)
     model.eval()
     return model, payload["preprocessing"], payload["metadata"]
+
+
+def validate_deep_checkpoint_population(
+    root: Path,
+    *,
+    config_name: str,
+    fold_ids: list[int] | tuple[int, ...],
+    checkpoints: list[int] | tuple[int, ...],
+    architecture: str | None = None,
+) -> tuple[Path, ...]:
+    """Require the exact fitted-state population declared by one request."""
+    expected = tuple(
+        deep_checkpoint_path(root, config_name, fold, checkpoint)
+        for fold in sorted({int(value) for value in fold_ids})
+        for checkpoint in sorted({int(value) for value in checkpoints})
+    )
+    if not expected:
+        raise ValueError("checkpoint validation requires folds and checkpoint values")
+    for path in expected:
+        try:
+            payload = load_deep_checkpoint(path)
+        except (FileNotFoundError, ValueError) as error:
+            raise ValueError(f"fitted checkpoint population is incomplete: {path}") from error
+        metadata = payload["metadata"]
+        fold = int(path.parent.name.removeprefix("fold_"))
+        checkpoint = int(path.stem.removeprefix("epoch_"))
+        required_metadata = {
+            "config_name": config_name,
+            "fold": fold,
+            "checkpoint_kind": "epoch",
+            "checkpoint_value": checkpoint,
+        }
+        mismatches = {
+            key: (metadata.get(key), value)
+            for key, value in required_metadata.items()
+            if metadata.get(key) != value
+        }
+        if architecture is not None and payload["architecture"] != architecture:
+            mismatches["architecture"] = (payload["architecture"], architecture)
+        if mismatches:
+            raise ValueError(f"fitted checkpoint metadata mismatch at {path}: {mismatches}")
+    actual = {
+        path for path in (Path(root) / config_name).glob("fold_*/epoch_*.pt") if path.is_file()
+    }
+    extras = actual - set(expected)
+    if extras:
+        raise ValueError(
+            f"fitted checkpoint population contains undeclared artifacts: "
+            f"{[str(path) for path in sorted(extras)]}"
+        )
+    return expected

--- a/case_studies/utils/insight_chapter.py
+++ b/case_studies/utils/insight_chapter.py
@@ -44,6 +44,7 @@ import polars as pl
 import torch  # noqa: F401
 
 from case_studies.utils.analytics import PRIMARY_LABELS, SHORT_NAMES
+from case_studies.utils.conformal import split_conformal_coverage
 from utils.paths import get_case_study_dir
 
 LabelResolver = Callable[[str], str | None]
@@ -307,8 +308,6 @@ def conformal_coverage_for_selected_prediction(
     levels: tuple[float, ...] = (0.80, 0.90, 0.95),
 ) -> pl.DataFrame:
     """Measure split-conformal coverage for one exact selected prediction artifact."""
-    import numpy as np
-
     required = {
         "case_study",
         "family",
@@ -338,77 +337,43 @@ def conformal_coverage_for_selected_prediction(
     if not prediction_path.exists():
         raise RegistrySelectionError(f"missing prediction artifact: {prediction_path}")
     predictions = pl.read_parquet(prediction_path)
-    renames = {}
-    if "actual" in predictions.columns and "y_true" not in predictions.columns:
-        renames["actual"] = "y_true"
-    if "prediction" in predictions.columns and "y_score" not in predictions.columns:
-        renames["prediction"] = "y_score"
-    if "fold" in predictions.columns and "fold_id" not in predictions.columns:
-        renames["fold"] = "fold_id"
-    if renames:
-        predictions = predictions.rename(renames)
-
-    required_columns = {"y_true", "y_score", "fold_id"}
+    required_columns = {"timestamp", "y_true", "y_score", "fold_id"}
+    legacy_columns = {"actual": "y_true", "prediction": "y_score", "fold": "fold_id"}
+    present_legacy = {
+        legacy: canonical
+        for legacy, canonical in legacy_columns.items()
+        if legacy in predictions.columns and canonical not in predictions.columns
+    }
+    if present_legacy:
+        predictions = predictions.rename(present_legacy)
     missing_columns = required_columns - set(predictions.columns)
     if missing_columns:
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: "
             f"prediction artifact missing {sorted(missing_columns)}"
         )
-    predictions = predictions.drop_nulls(required_columns).with_columns(
-        (pl.col("y_true") - pl.col("y_score")).abs().alias("abs_resid")
-    )
-    if predictions.is_empty():
-        raise RegistrySelectionError(
-            f"{selected['case_study']}/{selected['prediction_hash']}: no finite predictions"
-        )
-    for column in ("y_true", "y_score", "abs_resid"):
-        if not np.isfinite(predictions[column].to_numpy()).all():
-            raise RegistrySelectionError(
-                f"{selected['case_study']}/{selected['prediction_hash']}: "
-                f"non-finite {column} values"
-            )
-
     fold_ids = sorted(predictions["fold_id"].unique().to_list())
     if fold_ids != list(range(n_folds)):
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: "
             f"expected fold IDs {list(range(n_folds))}, observed {fold_ids}"
         )
-    calibration = predictions.filter(pl.col("fold_id") == 0)
-    test = predictions.filter(pl.col("fold_id") != 0)
-    if calibration.height < 30 or test.height < 30:
+    try:
+        coverage_rows = split_conformal_coverage(predictions, levels=levels)
+    except ValueError as error:
         raise RegistrySelectionError(
-            f"{selected['case_study']}/{selected['prediction_hash']}: "
-            "conformal calibration or test panel has fewer than 30 rows"
-        )
-
-    scale = float(predictions["y_true"].std() or 0.0)
-    if not math.isfinite(scale) or scale <= 0:
-        raise RegistrySelectionError(
-            f"{selected['case_study']}/{selected['prediction_hash']}: invalid target scale"
-        )
-    calibration_residuals = calibration["abs_resid"].to_numpy()
-    test_residuals = test["abs_resid"].to_numpy()
-    n_calibration = len(calibration_residuals)
-    rows = []
-    for level in levels:
-        if not 0 < level < 1:
-            raise RegistrySelectionError(f"invalid conformal level: {level}")
-        quantile_level = min(math.ceil((n_calibration + 1) * level) / n_calibration, 1.0)
-        quantile = float(np.quantile(calibration_residuals, quantile_level))
-        rows.append(
-            {
-                "case_study": selected["case_study"],
-                "family": selected["family"],
-                "config_name": selected["config_name"],
-                "prediction_hash": selected["prediction_hash"],
-                "nominal_level": float(level),
-                "empirical_coverage": float((test_residuals <= quantile).mean()),
-                "mean_interval_width_frac_std": float((2.0 * quantile) / scale),
-                "n_test": int(len(test_residuals)),
-            }
-        )
+            f"{selected['case_study']}/{selected['prediction_hash']}: {error}"
+        ) from error
+    rows = [
+        {
+            "case_study": selected["case_study"],
+            "family": selected["family"],
+            "config_name": selected["config_name"],
+            "prediction_hash": selected["prediction_hash"],
+            **row,
+        }
+        for row in coverage_rows
+    ]
     return pl.DataFrame(rows)
 
 

--- a/case_studies/utils/insight_chapter.py
+++ b/case_studies/utils/insight_chapter.py
@@ -362,7 +362,7 @@ def conformal_coverage_for_selected_prediction(
             f"expected fold IDs {list(range(n_folds))}, observed {fold_ids}"
         )
     try:
-        coverage_rows = split_conformal_coverage(usable, levels=levels)
+        coverage_rows = split_conformal_coverage(predictions, levels=levels)
     except ValueError as error:
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: {error}"

--- a/case_studies/utils/insight_chapter.py
+++ b/case_studies/utils/insight_chapter.py
@@ -352,14 +352,17 @@ def conformal_coverage_for_selected_prediction(
             f"{selected['case_study']}/{selected['prediction_hash']}: "
             f"prediction artifact missing {sorted(missing_columns)}"
         )
-    fold_ids = sorted(predictions["fold_id"].unique().to_list())
+    usable = predictions.drop_nulls(required_columns)
+    for column in ("y_true", "y_score"):
+        usable = usable.filter(pl.col(column).cast(pl.Float64, strict=False).is_finite())
+    fold_ids = sorted(usable["fold_id"].unique().to_list())
     if fold_ids != list(range(n_folds)):
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: "
             f"expected fold IDs {list(range(n_folds))}, observed {fold_ids}"
         )
     try:
-        coverage_rows = split_conformal_coverage(predictions, levels=levels)
+        coverage_rows = split_conformal_coverage(usable, levels=levels)
     except ValueError as error:
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: {error}"

--- a/case_studies/utils/notebook_render.py
+++ b/case_studies/utils/notebook_render.py
@@ -34,6 +34,7 @@ from case_studies.utils.analytics import (
     _query,
     registry_path,
 )
+from case_studies.utils.conformal import split_conformal_coverage
 from case_studies.utils.notebook_contracts import (
     degenerate_prediction_sql,
     full_coverage_prediction_sql,
@@ -721,78 +722,11 @@ def conformal_coverage_diagnostic(
         pq = pred_dir / p_hash / "predictions.parquet"
         if not pq.exists():
             continue
-        df = pl.read_parquet(pq)
-        ren = {}
-        if "actual" in df.columns and "y_true" not in df.columns:
-            ren["actual"] = "y_true"
-        if "prediction" in df.columns and "y_score" not in df.columns:
-            ren["prediction"] = "y_score"
-        if "fold" in df.columns and "fold_id" not in df.columns:
-            ren["fold"] = "fold_id"
-        if ren:
-            df = df.rename(ren)
-        if "y_true" not in df.columns or "y_score" not in df.columns:
+        try:
+            coverage_rows = split_conformal_coverage(pl.read_parquet(pq), levels=levels)
+        except ValueError:
             continue
-        df = df.drop_nulls(["y_true", "y_score"])
-        if df.height == 0 or "fold_id" not in df.columns or "timestamp" not in df.columns:
-            continue
-
-        df = df.with_columns((pl.col("y_true") - pl.col("y_score")).abs().alias("abs_resid"))
-
-        fold_windows = (
-            df.group_by("fold_id")
-            .agg(pl.col("timestamp").min().alias("validation_start"))
-            .sort("validation_start")
-        )
-        if fold_windows.height < 2:
-            continue
-
-        calibration_fold = fold_windows["fold_id"][0]
-        test_folds = fold_windows["fold_id"][1:].to_list()
-        cal = df.filter(pl.col("fold_id") == calibration_fold)
-        tst = df.filter(pl.col("fold_id").is_in(test_folds))
-        if cal.height < 30 or tst.height < 30:
-            continue
-
-        # The width is normalized by the calibration window's own return scale,
-        # not the whole panel's: everything the procedure reports has to be a
-        # property of the data it was allowed to see when it calibrated. Using
-        # every fold's std here let the evaluation windows set the divisor.
-        scale = float(cal["y_true"].std() or 0.0)
-        if not np.isfinite(scale) or scale == 0:
-            continue
-
-        cal_res = np.sort(cal["abs_resid"].to_numpy())
-        tst_res = tst["abs_resid"].to_numpy()
-        n_cal = len(cal_res)
-        for level in levels:
-            # Split conformal calls for the ceil((n+1)*level)-th smallest
-            # calibration residual. Index that rank directly rather than asking
-            # for a quantile at k/n: every np.quantile method maps a probability
-            # onto p*(n-1), so k/n lands a rank high, and the default linear
-            # method additionally interpolates to a value no residual attains.
-            rank = int(np.ceil((n_cal + 1) * level))
-            if rank > n_cal:
-                # The calibration set is too small to certify this level at all:
-                # the conformal interval is genuinely unbounded, so coverage is
-                # trivially 1 and the width infinite. Reported rather than
-                # clamped to the largest residual, which would under-cover while
-                # still claiming the nominal level.
-                q_hat = float(np.inf)
-            else:
-                q_hat = float(cal_res[rank - 1])
-            cov = float((tst_res <= q_hat).mean())
-            width_std = (2.0 * q_hat) / scale
-            out_rows.append(
-                {
-                    "family": fam,
-                    "config_name": cfg,
-                    "nominal_level": float(level),
-                    "empirical_coverage": cov,
-                    "mean_interval_width_frac_std": float(width_std),
-                    "n_test": int(len(tst_res)),
-                }
-            )
+        out_rows.extend({"family": fam, "config_name": cfg, **row} for row in coverage_rows)
 
     if not out_rows:
         return pl.DataFrame()

--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -26,6 +26,8 @@ class SequenceStore:
     symbol_idx: np.ndarray
     end_idx: np.ndarray
     lookback: int
+    feature_mean: np.ndarray | None = None
+    feature_scale: np.ndarray | None = None
 
     @property
     def n_sequences(self) -> int:
@@ -591,6 +593,8 @@ def prepare_fold_sequence_stores(
         symbol_idx=train_symbol_idx,
         end_idx=train_end_idx,
         lookback=lookback,
+        feature_mean=means.copy(),
+        feature_scale=stds.copy(),
     )
     val_store = SequenceStore(
         features=val_features,
@@ -600,6 +604,8 @@ def prepare_fold_sequence_stores(
         symbol_idx=val_symbol_idx,
         end_idx=val_end_idx,
         lookback=lookback,
+        feature_mean=means.copy(),
+        feature_scale=stds.copy(),
     )
 
     return (

--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import torch
 from torch.utils.data import Dataset
 
@@ -421,6 +422,95 @@ def _build_val_df_with_priming(
     return pd.concat(pieces, ignore_index=True)
 
 
+def _ensure_sequence_periods(
+    dataset_pd: pd.DataFrame,
+    *,
+    date_col: str,
+    calendar_id: str | None,
+) -> None:
+    cache_key = (
+        date_col,
+        calendar_id,
+        len(dataset_pd),
+        dataset_pd[date_col].iloc[0] if len(dataset_pd) else None,
+        dataset_pd[date_col].iloc[-1] if len(dataset_pd) else None,
+    )
+    if (
+        _SEQUENCE_PERIOD_COL not in dataset_pd.columns
+        or dataset_pd.attrs.get(_SEQUENCE_PERIOD_CACHE_ATTR) != cache_key
+    ):
+        dataset_pd[_SEQUENCE_PERIOD_COL] = _sequence_period_numbers(
+            dataset_pd[date_col],
+            calendar_id=calendar_id,
+        )
+        dataset_pd.attrs[_SEQUENCE_PERIOD_CACHE_ATTR] = cache_key
+
+
+def _coerce_boundary(value: pd.Timestamp | str, series: pd.Series) -> pd.Timestamp:
+    boundary = pd.Timestamp(value)
+    col_tz = getattr(series.dtype, "tz", None)
+    if col_tz is not None and boundary.tz is None:
+        return boundary.tz_localize(col_tz)
+    if col_tz is None and boundary.tz is not None:
+        return boundary.tz_localize(None)
+    return boundary
+
+
+def sequence_validation_keys(
+    dataset_pd: pd.DataFrame,
+    splits: list[dict],
+    *,
+    label_col: str,
+    date_col: str,
+    entity_col: str,
+    lookback: int,
+    calendar_id: str | None = None,
+) -> pl.DataFrame:
+    """Return exact validation keys eligible for gap-free sequence prediction."""
+    _ensure_sequence_periods(dataset_pd, date_col=date_col, calendar_id=calendar_id)
+    use_cols = [date_col, entity_col, label_col, _SEQUENCE_PERIOD_COL]
+    frames: list[pl.DataFrame] = []
+    for split in splits:
+        val_start = _coerce_boundary(split["val_start"], dataset_pd[date_col])
+        val_end = _coerce_boundary(split["val_end"], dataset_pd[date_col])
+        val_mask = dataset_pd[date_col].between(val_start, val_end, inclusive="both")
+        source = dataset_pd.loc[(dataset_pd[date_col] < val_start) | val_mask, use_cols]
+        val_df = _build_val_df_with_priming(
+            source,
+            entity_col=entity_col,
+            date_col=date_col,
+            val_start=val_start,
+            lookback=lookback,
+        )
+        _, _, timestamps, entities, valid_positions = _build_symbol_arrays(
+            val_df,
+            feature_names=[],
+            label_col=label_col,
+            date_col=date_col,
+            entity_col=entity_col,
+            lookback=lookback,
+        )
+        rows = [
+            {
+                "symbol": entities[symbol_id],
+                "timestamp": pd.Timestamp(timestamps[symbol_id][position]),
+                "fold": int(split["fold"]),
+            }
+            for symbol_id, positions in enumerate(valid_positions)
+            for position in positions
+        ]
+        if rows:
+            frames.append(pl.from_dicts(rows))
+    if not frames:
+        return pl.DataFrame(
+            schema={"symbol": pl.String, "timestamp": pl.Datetime("ns"), "fold": pl.Int64}
+        )
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("sequence request produced duplicate expected prediction keys")
+    return expected
+
+
 def prepare_fold_sequence_stores(
     dataset_pd: pd.DataFrame,
     *,
@@ -452,36 +542,13 @@ def prepare_fold_sequence_stores(
     ``val_start`` so the val window aligns with production.
     """
 
-    cache_key = (
-        date_col,
-        calendar_id,
-        len(dataset_pd),
-        dataset_pd[date_col].iloc[0] if len(dataset_pd) else None,
-        dataset_pd[date_col].iloc[-1] if len(dataset_pd) else None,
-    )
-    if (
-        _SEQUENCE_PERIOD_COL not in dataset_pd.columns
-        or dataset_pd.attrs.get(_SEQUENCE_PERIOD_CACHE_ATTR) != cache_key
-    ):
-        dataset_pd[_SEQUENCE_PERIOD_COL] = _sequence_period_numbers(
-            dataset_pd[date_col],
-            calendar_id=calendar_id,
-        )
-        dataset_pd.attrs[_SEQUENCE_PERIOD_CACHE_ATTR] = cache_key
+    _ensure_sequence_periods(dataset_pd, date_col=date_col, calendar_id=calendar_id)
     use_cols = [date_col, entity_col, label_col, _SEQUENCE_PERIOD_COL, *feature_names]
     val_start_ts: pd.Timestamp | None
     if val_start is None:
         val_start_ts = None
     else:
-        val_start_ts = pd.Timestamp(val_start)
-        # Match the date column's timezone — crypto's timestamps are
-        # tz-aware (datetime64[ms, UTC]); a tz-naive literal raises
-        # `Invalid comparison between dtype=datetime64[ms, UTC] and Timestamp`.
-        col_tz = getattr(dataset_pd[date_col].dtype, "tz", None)
-        if col_tz is not None and val_start_ts.tz is None:
-            val_start_ts = val_start_ts.tz_localize(col_tz)
-        elif col_tz is None and val_start_ts.tz is not None:
-            val_start_ts = val_start_ts.tz_localize(None)
+        val_start_ts = _coerce_boundary(val_start, dataset_pd[date_col])
 
     if (
         temporal_by_fold is not None

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -19,6 +19,7 @@ import gc
 import os
 import time
 import warnings
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -255,6 +256,7 @@ def _train_tabm_fold(
     batch_size: int,
     checkpoint_interval: int,
     device: torch.device,
+    state_callback: Callable[[int, nn.Module], None] | None = None,
 ) -> tuple[dict[int, float], dict[int, np.ndarray], dict[int, float]]:
     """Train TabM on one fold, storing predictions at ALL checkpoints.
 
@@ -302,6 +304,8 @@ def _train_tabm_fold(
         # Evaluate and store predictions at checkpoint epochs
         if epoch % checkpoint_interval == 0 or epoch == n_epochs:
             val_preds = _predict_in_chunks(model, X_val, device)
+            if state_callback is not None:
+                state_callback(epoch, model)
             ic_frame = pl.DataFrame(
                 {
                     "timestamp": val_dates,
@@ -790,6 +794,7 @@ def run_tabm_cv(
     num_threads: int = 8,
     input_data_spec: dict[str, Any] | None = None,
     identity_params: dict[str, Any] | None = None,
+    checkpoint_root: Path | None = None,
 ) -> dict[str, Any]:
     """Walk-forward tabular DL CV with epoch-checkpoint IC evaluation.
 
@@ -1059,6 +1064,12 @@ def run_tabm_cv(
                 "val_entities": val_entities,
                 "n_train": len(X_train),
                 "n_val": len(X_val),
+                "preprocessing": {
+                    "feature_names": list(feature_names),
+                    "imputer_statistics": imputer.statistics_.astype(np.float32),
+                    "scaler_mean": scaler.mean_.astype(np.float32),
+                    "scaler_scale": scaler.scale_.astype(np.float32),
+                },
             }
         )
         print(f"  Fold {split['fold']}: train={len(X_train):,}  val={len(X_val):,}")
@@ -1205,6 +1216,37 @@ def run_tabm_cv(
                 # TabM: train to completion, store ALL checkpoint predictions
                 tabm_kwargs = {"n_features": n_features, **cfg_params}
                 model = TabMModel(**tabm_kwargs)
+                train_kwargs: dict[str, Any] = {}
+                if checkpoint_root is not None:
+                    from case_studies.utils.deep_model_state import write_deep_checkpoint
+
+                    def persist_state(
+                        epoch: int,
+                        fitted_model: nn.Module,
+                        *,
+                        _fold: int = int(fd["fold"]),
+                        _preprocessing: dict[str, Any] = fd["preprocessing"],
+                        _config_name: str = config_name,
+                        _model_kwargs: dict[str, Any] = tabm_kwargs,
+                    ) -> None:
+                        write_deep_checkpoint(
+                            checkpoint_root
+                            / _config_name
+                            / f"fold_{_fold:02d}"
+                            / f"epoch_{epoch:04d}.pt",
+                            model=fitted_model,
+                            architecture="tabm",
+                            model_kwargs=_model_kwargs,
+                            preprocessing=_preprocessing,
+                            metadata={
+                                "config_name": _config_name,
+                                "fold": _fold,
+                                "checkpoint_kind": "epoch",
+                                "checkpoint_value": epoch,
+                            },
+                        )
+
+                    train_kwargs["state_callback"] = persist_state
                 checkpoint_ics, checkpoint_preds, epoch_losses = _train_tabm_fold(
                     model=model,
                     X_train=fd["X_train"],
@@ -1218,6 +1260,7 @@ def run_tabm_cv(
                     batch_size=cfg_batch_size,
                     checkpoint_interval=cfg_checkpoint,
                     device=torch_device,
+                    **train_kwargs,
                 )
 
                 for ep, ic in checkpoint_ics.items():

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -81,14 +81,11 @@ def _tabm_checkpoint_epochs(config: dict[str, Any]) -> tuple[int, ...]:
     """Return the exact checkpoint surface implied by one effective config."""
     if str(config["config_name"]).startswith("tabpfn"):
         return (1,)
+    from case_studies.utils.deep_model_state import declared_epoch_checkpoints
+
     n_epochs = int(config.get("n_epochs", 200))
     checkpoint_interval = int(config.get("checkpoint_interval", 25))
-    if n_epochs < 1 or checkpoint_interval < 1:
-        raise ValueError("n_epochs and checkpoint_interval must be positive")
-    checkpoints = list(range(checkpoint_interval, n_epochs + 1, checkpoint_interval))
-    if not checkpoints or checkpoints[-1] != n_epochs:
-        checkpoints.append(n_epochs)
-    return tuple(checkpoints)
+    return declared_epoch_checkpoints(n_epochs, checkpoint_interval)
 
 
 def _build_tabm_training_spec(
@@ -795,6 +792,7 @@ def run_tabm_cv(
     input_data_spec: dict[str, Any] | None = None,
     identity_params: dict[str, Any] | None = None,
     checkpoint_root: Path | None = None,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Walk-forward tabular DL CV with epoch-checkpoint IC evaluation.
 
@@ -946,6 +944,18 @@ def run_tabm_cv(
                 )
                 split_complete = not split_rows.is_empty()
                 if status.complete and split_complete:
+                    if checkpoint_root is not None:
+                        from case_studies.utils.deep_model_state import (
+                            validate_deep_checkpoint_population,
+                        )
+
+                        validate_deep_checkpoint_population(
+                            checkpoint_root,
+                            config_name=cfg["config_name"],
+                            fold_ids=tuple(int(split["fold"]) for split in splits),
+                            checkpoints=_tabm_checkpoint_epochs(cfg),
+                            architecture="tabm",
+                        )
                     cached_result, cached_predictions, cached_curve_rows = _load_cached_tabm_config(
                         case_study=case_study,
                         training_spec=spec,
@@ -1092,6 +1102,8 @@ def run_tabm_cv(
 
     for cfg in configs:
         config_name = cfg["config_name"]
+        if checkpoint_root is not None and config_name.startswith("tabpfn"):
+            raise ValueError("TabPFN fitted-state persistence is not implemented")
         if register and case_study and force_retrain:
             from case_studies.utils.registry import build_training_spec, training_hash_from_spec
 
@@ -1418,6 +1430,17 @@ def run_tabm_cv(
 
         print(f"    → best_epoch={best_cp}, IC={best_ic_val:+.4f} ({elapsed:.1f}s)")
 
+        if checkpoint_root is not None:
+            from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
+
+            validate_deep_checkpoint_population(
+                checkpoint_root,
+                config_name=config_name,
+                fold_ids=tuple(int(fd["fold"]) for fd in fold_data),
+                checkpoints=_tabm_checkpoint_epochs(cfg),
+                architecture="tabm",
+            )
+
         # Incremental registration: persist this config immediately so a later
         # interruption or re-run doesn't lose work. Safe because config-major
         # loop: this config's folds are all complete at this point.
@@ -1489,6 +1512,8 @@ def run_tabm_cv(
                         f"    registered {config_name} incrementally ({len(epochs)} per-epoch slices)"
                     )
             except Exception as exc:
+                if strict:
+                    raise
                 print(f"    WARN: incremental registration failed for {config_name}: {exc}")
 
         gc.collect()

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -16,13 +16,21 @@ Usage:
 from __future__ import annotations
 
 import gc
+import hashlib
+import importlib.metadata
+import json
 import os
+import platform
+import shutil
+import subprocess
 import time
+import uuid
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -36,12 +44,387 @@ from ml4t.diagnostic.metrics import cross_sectional_ic
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler
 
+from case_studies.utils.artifact_digest import value_digest
 from case_studies.utils.registry import clear_prediction_sets, compute_fold_metrics_from_predictions
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 from utils.modeling import RANDOM_SEED, seed_everything
+
+_TABM_PREVIEW_FIELDS = {"folds", "max_symbols"}
+
+
+@dataclass(frozen=True)
+class TabMResearchContext:
+    dataset_pd: pd.DataFrame
+    splits: tuple[dict[str, Any], ...]
+    config: dict[str, Any]
+    feature_names: tuple[str, ...]
+    label_col: str
+    eval_label_col: str | None
+    date_col: str
+    entity_col: str
+    task_type: str
+    class_values: tuple[Any, ...]
+    temporal_by_fold: pd.DataFrame | None
+    temporal_keys: tuple[str, ...]
+    temporal_feature_names: tuple[str, ...]
+    expected_keys: pl.DataFrame
+    runtime_provenance: dict[str, Any]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _tabm_source_identity() -> dict[str, str]:
+    from case_studies.utils import deep_model_state
+
+    return {
+        Path(__file__).name: _sha256(Path(__file__)),
+        Path(deep_model_state.__file__).name: _sha256(Path(deep_model_state.__file__)),
+    }
+
+
+def _tabm_runtime_identity() -> dict[str, str]:
+    return {
+        "numpy": importlib.metadata.version("numpy"),
+        "scikit-learn": importlib.metadata.version("scikit-learn"),
+        "torch": importlib.metadata.version("torch"),
+    }
+
+
+def _tabm_runtime_provenance(study: Study) -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(study.release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = "unknown"
+    return {
+        "entry_point": "case_studies.utils.tabular_dl",
+        "packages": _tabm_runtime_identity(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": commit,
+    }
+
+
+def _normalize_splits(splits: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+    return tuple(
+        {
+            key: int(split[key]) if key == "fold" else str(split[key])
+            for key in fields
+            if split.get(key) is not None
+        }
+        for split in splits
+    )
+
+
+def _tabm_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    cv = request.get("cv")
+    if cv is None:
+        splits = [dict(split) for split in mds.splits]
+        normalized = _normalize_splits(splits)
+        cv_record = {
+            "request": {"source": "case_study_default"},
+            "folds": list(normalized),
+            "identity": value_digest(pl.DataFrame(list(normalized))),
+        }
+    else:
+        resolved = cv.resolve(mds.dataset.select(mds.date_col).unique(), date_col=mds.date_col)
+        splits = [dict(fold) for fold in resolved.normalized_folds]
+        cv_record = resolved.as_dict()
+    requested_folds = request["preview_reductions"].get("folds")
+    if requested_folds is not None:
+        selected = {int(fold) for fold in requested_folds}
+        splits = [split for split in splits if int(split["fold"]) in selected]
+        if {int(split["fold"]) for split in splits} != selected:
+            raise ValueError("preview fold reduction refers to an unavailable fold")
+        cv_record = {**cv_record, "preview_folds": sorted(selected)}
+    if not splits:
+        raise ValueError("TabM request resolved no cross-validation folds")
+    return splits, cv_record
+
+
+def _resolve_tabm_config(config: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    resolved = {**config, "params": dict(config.get("params") or {})}
+    top_level = {"batch_size", "checkpoint_interval", "n_epochs"}
+    unknown = set(overrides) - top_level - set(resolved["params"]) - {"device", "num_threads"}
+    if unknown:
+        raise ValueError(f"unsupported TabM overrides: {sorted(unknown)}")
+    for key, value in overrides.items():
+        if key in top_level:
+            resolved[key] = value
+        elif key not in {"device", "num_threads"}:
+            resolved["params"][key] = value
+    if resolved.get("library") != "tabm" or str(resolved["config_name"]).startswith("tabpfn"):
+        raise ValueError("the TabM research adapter requires a persisted TabM configuration")
+    _tabm_checkpoint_epochs(resolved)
+    return resolved
+
+
+def _tabm_expected_keys(mds, splits: list[dict[str, Any]]) -> pl.DataFrame:
+    frames = []
+    for split in splits:
+        date_dtype = mds.dataset.schema[mds.date_col]
+        frame = mds.dataset.filter(
+            pl.col(mds.date_col).is_between(
+                pl.lit(split["val_start"]).cast(date_dtype, strict=False),
+                pl.lit(split["val_end"]).cast(date_dtype, strict=False),
+                closed="both",
+            )
+        ).drop_nulls([mds.label_col, *([mds.eval_label_col] if mds.eval_label_col else [])])
+        frames.append(
+            frame.select(
+                pl.col(mds.entity_cols[0]).alias("symbol"),
+                pl.col(mds.date_col).alias("timestamp"),
+            ).with_columns(pl.lit(int(split["fold"]), dtype=pl.Int64).alias("fold"))
+        )
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("TabM request produced duplicate expected prediction keys")
+    return expected
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    from case_studies.research.contracts import ExecutionTier
+    from utils.modeling import load_configs, load_modeling_dataset
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _TABM_PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported TabM preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"])
+    mds = load_modeling_dataset(
+        study.case_study,
+        label_ref.name,
+        max_symbols=int(reductions.get("max_symbols", 0)),
+    )
+    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
+        raise ValueError("TabM runner requires canonical symbol and timestamp keys")
+    splits, cv_record = _tabm_splits(mds, request)
+    configs = {
+        config["config_name"]: config
+        for config in load_configs(study.case_study, label_ref.name, "tabular_dl")
+    }
+    try:
+        configured = configs[request["config_name"]]
+    except KeyError as error:
+        raise ValueError(f"unknown TabM configuration {request['config_name']!r}") from error
+    config = _resolve_tabm_config(configured, request["overrides"])
+    device = str(request["overrides"].get("device", "cuda"))
+    num_threads = int(request["overrides"].get("num_threads", 8))
+    runtime = tabm_runtime_spec(device, num_threads=num_threads)
+    expected = _tabm_expected_keys(mds, splits)
+    input_lineage = mds.input_lineage
+    checkpoints = _tabm_checkpoint_epochs(config)
+    spec = {
+        "identity_version": 2,
+        "execution_tier": tier.value,
+        "family": "tabular_dl",
+        "label": label_ref.name,
+        "seed": int(runtime["seed"]),
+        "config_name": config["config_name"],
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": input_lineage["artifacts"],
+        "feature_names": list(mds.feature_names),
+        "task": {
+            "type": mds.task_type,
+            "class_values": list(mds.class_values),
+            "continuous_eval_label": label_ref.definition.continuous_eval_label,
+        },
+        "cv": cv_record,
+        "model": {
+            "class": "TabMModel",
+            "implementation": "pytorch",
+            "objective": "classification" if mds.task_type == "classification" else "regression",
+            "params": {
+                **config["params"],
+                "batch_size": int(config["batch_size"]),
+                "checkpoint_interval": int(config["checkpoint_interval"]),
+                "n_epochs": int(config["n_epochs"]),
+            },
+        },
+        "preprocessing": {
+            "imputer": {"class": "SimpleImputer", "strategy": "median"},
+            "scaler": {"class": "StandardScaler", "with_mean": True, "with_std": True},
+        },
+        "checkpoint_schedule": [
+            {"kind": "epoch", "value": checkpoint} for checkpoint in checkpoints
+        ],
+        "expected_prediction_keys": {
+            "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+            "n_rows": expected.height,
+            "n_folds": expected["fold"].n_unique(),
+        },
+        "input_data_spec": input_lineage,
+        "sampling": {"max_symbols": int(reductions.get("max_symbols", 0))},
+        "numerics": runtime,
+        "source_identity": _tabm_source_identity(),
+        "runtime_identity": _tabm_runtime_identity(),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        spec["preview_reductions"] = reductions
+    context = TabMResearchContext(
+        dataset_pd=mds.dataset.to_pandas(),
+        splits=tuple(splits),
+        config=config,
+        feature_names=tuple(mds.feature_names),
+        label_col=mds.label_col,
+        eval_label_col=mds.eval_label_col,
+        date_col=mds.date_col,
+        entity_col=mds.entity_cols[0],
+        task_type=mds.task_type,
+        class_values=tuple(mds.class_values),
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=tuple(mds.temporal_keys),
+        temporal_feature_names=tuple(mds.temporal_feature_names),
+        expected_keys=expected,
+        runtime_provenance=_tabm_runtime_provenance(study),
+    )
+    return spec, context
+
+
+def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResearchContext):
+    from case_studies.research.models import ModelRun
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+    from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
+    from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+
+    training_hash = training_hash_from_spec(spec)
+    checkpoint_values = tuple(item["value"] for item in spec["checkpoint_schedule"])
+    try:
+        training = Result.open(
+            study, training_hash, include_preview=spec["execution_tier"] == "preview"
+        )
+        predictions = tuple(
+            Result.open(
+                study,
+                prediction_hash_from_parts(
+                    training_hash,
+                    checkpoint,
+                    "validation",
+                    checkpoint_kind="epoch",
+                    identity_version=2,
+                ),
+                include_preview=spec["execution_tier"] == "preview",
+            )
+            for checkpoint in checkpoint_values
+        )
+    except KeyError:
+        return None
+    if not isinstance(training, TrainingResult) or any(
+        not isinstance(result, PredictionResult) or not result.complete for result in predictions
+    ):
+        return None
+    model_root = training.root / "run_log" / "training" / training.hash / "models"
+    try:
+        validate_deep_checkpoint_population(
+            model_root,
+            config_name=context.config["config_name"],
+            fold_ids=tuple(int(split["fold"]) for split in context.splits),
+            checkpoints=checkpoint_values,
+            architecture="tabm",
+        )
+    except ValueError:
+        return None
+    return ModelRun(training=training, predictions=predictions)
+
+
+def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResearchContext):
+    from case_studies.research.models import ModelRun
+
+    cached = _cached_research_run(study, spec, context)
+    if cached is not None:
+        return cached
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    train_dir = training.root / "run_log" / "training" / training.hash
+    model_dir = train_dir / "models"
+    if model_dir.exists():
+        raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+    staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+    try:
+        result = run_tabm_cv(
+            context.dataset_pd,
+            list(context.splits),
+            configs=[context.config],
+            n_features=len(context.feature_names),
+            feature_names=list(context.feature_names),
+            label_col=context.label_col,
+            eval_label_col=context.eval_label_col,
+            task_type=context.task_type,
+            class_values=list(context.class_values) or None,
+            date_col=context.date_col,
+            entity_col=context.entity_col,
+            device=spec["numerics"]["device"],
+            save_dir=train_dir / "diagnostics",
+            register=False,
+            temporal_by_fold=context.temporal_by_fold,
+            temporal_keys=list(context.temporal_keys),
+            temporal_feature_names=list(context.temporal_feature_names),
+            seed=int(spec["seed"]),
+            num_threads=int(spec["numerics"]["num_threads"]),
+            checkpoint_root=staging,
+            strict=True,
+        )
+        os.replace(staging, model_dir)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    prediction_results = []
+    for checkpoint in (item["value"] for item in spec["checkpoint_schedule"]):
+        predictions = (
+            result["all_predictions"]
+            .filter(
+                (pl.col("config") == context.config["config_name"])
+                & (pl.col("epoch") == checkpoint)
+            )
+            .drop("config", "epoch")
+            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
+        )
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="epoch",
+                checkpoint_value=int(checkpoint),
+                split="validation",
+                predictions=predictions,
+                expected_keys=context.expected_keys,
+                task_type=context.task_type,
+                class_values=list(context.class_values) or None,
+                eval_col="eval_actual" if context.eval_label_col else None,
+                label=context.label_col,
+            )
+        )
+    runtime_path = train_dir / "runtime.json"
+    if runtime_path.exists():
+        runtime = json.loads(runtime_path.read_text())
+        runtime["elapsed_s"] = sum(
+            float(row.get("elapsed_s", 0.0)) for row in result["grid_results"]
+        )
+        runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+    return ModelRun(training=training, predictions=tuple(prediction_results))
 
 
 def resolve_torch_device(device: str) -> torch.device:

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -1218,7 +1218,10 @@ def run_tabm_cv(
                 model = TabMModel(**tabm_kwargs)
                 train_kwargs: dict[str, Any] = {}
                 if checkpoint_root is not None:
-                    from case_studies.utils.deep_model_state import write_deep_checkpoint
+                    from case_studies.utils.deep_model_state import (
+                        deep_checkpoint_path,
+                        write_deep_checkpoint,
+                    )
 
                     def persist_state(
                         epoch: int,
@@ -1230,10 +1233,7 @@ def run_tabm_cv(
                         _model_kwargs: dict[str, Any] = tabm_kwargs,
                     ) -> None:
                         write_deep_checkpoint(
-                            checkpoint_root
-                            / _config_name
-                            / f"fold_{_fold:02d}"
-                            / f"epoch_{epoch:04d}.pt",
+                            deep_checkpoint_path(checkpoint_root, _config_name, _fold, epoch),
                             model=fitted_model,
                             architecture="tabm",
                             model_kwargs=_model_kwargs,

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -156,6 +156,9 @@ def _tabm_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], di
         cv_record = {**cv_record, "preview_folds": sorted(selected)}
     if not splits:
         raise ValueError("TabM request resolved no cross-validation folds")
+    from utils.modeling import validate_temporal_split_geometry
+
+    validate_temporal_split_geometry(splits, mds.splits, mds.temporal_by_fold)
     return splits, cv_record
 
 

--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -38,7 +38,7 @@ from utils.cv_splits import (
     make_wf_config,
     most_recent_split,
 )
-from utils.modeling import validate_temporal_fold_coverage
+from utils.modeling import validate_temporal_fold_coverage, validate_temporal_split_geometry
 
 # -----------------------------------------------------------------------------
 # Pure: _map_calendar_id
@@ -415,6 +415,41 @@ def test_temporal_fold_metadata_remap_restores_coverage(backward_temporal_fixtur
     validate_temporal_fold_coverage(dataset, remapped, splits, date_col="timestamp")
 
     assert remapped["value"].sort().to_list() == values_before
+
+
+def test_custom_cv_cannot_reuse_temporal_features_from_different_geometry() -> None:
+    canonical = [
+        {
+            "fold": 0,
+            "train_start": "2018-01-01",
+            "train_end": "2019-12-31",
+            "val_start": "2020-01-01",
+            "val_end": "2020-12-31",
+        }
+    ]
+    requested = [{**canonical[0], "val_start": "2019-07-01"}]
+    temporal = pl.DataFrame({"fold": [0], "timestamp": [pd.Timestamp("2020-01-01")]})
+
+    with pytest.raises(ValueError, match=r"fold 0 differs in \['val_start'\]"):
+        validate_temporal_split_geometry(requested, canonical, temporal)
+
+
+def test_custom_cv_can_select_exact_fitted_temporal_fold_geometry() -> None:
+    canonical = [
+        {
+            "fold": fold,
+            "train_start": f"{2018 + fold}-01-01",
+            "train_end": f"{2019 + fold}-12-31",
+            "val_start": f"{2020 + fold}-01-01",
+            "val_end": f"{2020 + fold}-12-31",
+        }
+        for fold in (0, 1)
+    ]
+    temporal = pl.DataFrame(
+        {"fold": [0, 1], "timestamp": [pd.Timestamp("2020-01-01"), pd.Timestamp("2021-01-01")]}
+    )
+
+    validate_temporal_split_geometry([canonical[1]], canonical, temporal)
 
 
 @pytest.fixture

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from darts import TimeSeries
+from darts.models import TSMixerModel
+
+from case_studies.utils.darts_forecasting import (
+    BASE_TARGET_COL,
+    darts_checkpoint_path,
+    darts_validation_keys,
+    load_darts_checkpoint,
+    run_darts_cv,
+    validate_darts_checkpoint_population,
+    write_darts_checkpoint,
+)
+from case_studies.utils.registry import evaluate_prediction_coverage
+
+
+def _fit_tiny_tsmixer() -> tuple[TSMixerModel, TimeSeries]:
+    series = TimeSeries.from_values(np.arange(24, dtype=np.float32))
+    model = TSMixerModel(
+        input_chunk_length=4,
+        output_chunk_length=1,
+        hidden_size=4,
+        ff_size=4,
+        num_blocks=1,
+        n_epochs=1,
+        batch_size=8,
+        random_state=7,
+        save_checkpoints=False,
+        force_reset=True,
+        pl_trainer_kwargs={
+            "accelerator": "cpu",
+            "devices": 1,
+            "enable_checkpointing": False,
+            "enable_progress_bar": False,
+            "logger": False,
+        },
+    )
+    model.fit(series, verbose=False)
+    return model, series
+
+
+def test_darts_checkpoint_reconstructs_identical_predictions(tmp_path) -> None:
+    model, series = _fit_tiny_tsmixer()
+    expected = model.predict(2, series=series).values()
+    root = tmp_path / "models"
+    path = darts_checkpoint_path(root, "tsmixer", 0, 1)
+
+    write_darts_checkpoint(
+        path,
+        model=model,
+        architecture="tsmixer",
+        metadata={
+            "config_name": "tsmixer",
+            "fold": 0,
+            "checkpoint_kind": "epoch",
+            "checkpoint_value": 1,
+        },
+    )
+    validate_darts_checkpoint_population(
+        root,
+        config_name="tsmixer",
+        fold_ids=(0,),
+        checkpoints=(1,),
+        architecture="tsmixer",
+    )
+    restored, metadata = load_darts_checkpoint(path)
+    actual = restored.predict(2, series=series).values()
+
+    np.testing.assert_array_equal(actual, expected)
+    assert metadata["checkpoint_value"] == 1
+
+
+def test_darts_checkpoint_population_rejects_missing_weights(tmp_path) -> None:
+    model, _series = _fit_tiny_tsmixer()
+    root = tmp_path / "models"
+    path = darts_checkpoint_path(root, "tsmixer", 0, 1)
+    write_darts_checkpoint(
+        path,
+        model=model,
+        architecture="tsmixer",
+        metadata={
+            "config_name": "tsmixer",
+            "fold": 0,
+            "checkpoint_kind": "epoch",
+            "checkpoint_value": 1,
+        },
+    )
+    path.with_suffix(".pt.ckpt").unlink()
+
+    with pytest.raises(ValueError, match="population is incomplete"):
+        validate_darts_checkpoint_population(
+            root,
+            config_name="tsmixer",
+            fold_ids=(0,),
+            checkpoints=(1,),
+            architecture="tsmixer",
+        )
+
+
+def test_darts_runner_persists_state_with_exact_prediction_keys(tmp_path, monkeypatch) -> None:
+    dates = pd.date_range("2024-01-02", periods=16, freq="B")
+    dataset = pd.DataFrame(
+        [
+            {
+                "timestamp": timestamp,
+                "symbol": f"S{symbol}",
+                "feature": symbol + day / 10,
+                "fwd_ret_1d": np.sin(day / 3) + symbol / 100,
+            }
+            for symbol in range(6)
+            for day, timestamp in enumerate(dates)
+        ]
+    )
+
+    def attach_base_target(frame, _case_study, _date_col):
+        return frame.assign(**{BASE_TARGET_COL: np.log1p(frame["fwd_ret_1d"] / 10)})
+
+    monkeypatch.setattr(
+        "case_studies.utils.darts_forecasting._attach_base_target", attach_base_target
+    )
+    config = {
+        "family": "deep_learning",
+        "library": "darts",
+        "config_name": "tsmixer_probe",
+        "params": {
+            "architecture": "tsmixer",
+            "lookback": 4,
+            "hidden_dim": 4,
+            "n_blocks": 1,
+            "dropout": 0.0,
+        },
+        "n_epochs": 1,
+        "batch_size": 32,
+        "checkpoint_interval": 1,
+    }
+    split = {
+        "fold": 0,
+        "train_start": dates[0],
+        "train_end": dates[9],
+        "val_start": dates[10],
+        "val_end": dates[-1],
+    }
+    model_root = tmp_path / "models"
+
+    result = run_darts_cv(
+        dataset,
+        [split],
+        configs=[config],
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        save_dir=tmp_path / "run",
+        max_train_sequences=0,
+        register=False,
+        case_study="etfs",
+        notebook=None,
+        checkpoint_root=model_root,
+    )
+    expected = darts_validation_keys(
+        dataset,
+        [split],
+        config=config,
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_col="symbol",
+        case_study="etfs",
+    )
+    predictions = result["all_predictions"].rename({"fold_id": "fold"})
+
+    assert evaluate_prediction_coverage(expected, predictions).complete
+    assert (
+        len(
+            validate_darts_checkpoint_population(
+                model_root,
+                config_name="tsmixer_probe",
+                fold_ids=(0,),
+                checkpoints=(1,),
+                architecture="tsmixer",
+            )
+        )
+        == 1
+    )

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pandas_market_calendars as mcal
+import polars as pl
 import pytest
 from darts import TimeSeries
 from darts.models import TSMixerModel
 
 from case_studies.utils.darts_forecasting import (
     BASE_TARGET_COL,
+    _attach_expected_periods,
+    _predict_fold,
+    _prepare_fold_series,
     darts_checkpoint_path,
     darts_validation_keys,
     load_darts_checkpoint,
@@ -121,6 +125,15 @@ def test_darts_runner_persists_state_with_exact_gap_free_prediction_keys(
     )
     missing_date = dates[12]
     dataset = dataset.loc[dataset["timestamp"] != missing_date].reset_index(drop=True)
+    exact_lookback = pd.DataFrame(
+        {
+            "timestamp": dates[-4:],
+            "symbol": "S6",
+            "feature": np.arange(4, dtype=np.float32),
+            "fwd_ret_1d": np.arange(4, dtype=np.float32) / 100,
+        }
+    )
+    dataset = pd.concat([dataset, exact_lookback], ignore_index=True)
 
     def attach_base_target(frame, _case_study, _date_col):
         return frame.assign(**{BASE_TARGET_COL: np.log1p(frame["fwd_ret_1d"] / 10)})
@@ -186,6 +199,9 @@ def test_darts_runner_persists_state_with_exact_gap_free_prediction_keys(
     assert not {date.date() for date in dates[13:16]} & observed_dates
     assert {date.date() for date in dates[16:]} <= observed_dates
     assert (
+        expected.filter((pl.col("symbol") == "S6") & (pl.col("timestamp") == dates[-1])).height == 1
+    )
+    assert (
         len(
             validate_darts_checkpoint_population(
                 model_root,
@@ -197,3 +213,62 @@ def test_darts_runner_persists_state_with_exact_gap_free_prediction_keys(
         )
         == 1
     )
+
+
+def test_darts_segments_and_predicts_each_cme_contract_position() -> None:
+    dates = pd.date_range("2024-01-02", periods=8)
+    dataset = pd.DataFrame(
+        [
+            {
+                "timestamp": timestamp,
+                "product": product,
+                "position": position,
+                "feature": float(day + position),
+                "fwd_ret_1d": float(day) / 100,
+                BASE_TARGET_COL: np.log1p(float(day) / 100),
+            }
+            for product in ("ES", "NQ")
+            for position in range(3)
+            for day, timestamp in enumerate(dates)
+        ]
+    )
+    dataset = _attach_expected_periods(dataset, date_col="timestamp", calendar_id=None)
+    split = {
+        "fold": 0,
+        "train_start": dates[0],
+        "train_end": dates[3],
+        "val_start": dates[4],
+        "val_end": dates[-1],
+    }
+
+    states = _prepare_fold_series(
+        dataset,
+        split,
+        ["feature"],
+        "fwd_ret_1d",
+        "timestamp",
+        "product",
+        4,
+        1,
+    )
+
+    assert len(states) == 6
+    assert {tuple(state.identity.items()) for state in states} == {
+        (("product", product), ("position", position))
+        for product in ("ES", "NQ")
+        for position in range(3)
+    }
+
+    class _OneStepModel:
+        def historical_forecasts(self, series, *, start, **_kwargs):
+            return [
+                TimeSeries.from_times_and_values(
+                    pd.RangeIndex(start, start + 1), np.array([0.01], dtype=np.float32)
+                )
+            ]
+
+    predictions = _predict_fold(
+        _OneStepModel(), states, 0, "timestamp", "product", output_chunk_length=1
+    )
+    assert {"product", "position"} <= set(predictions.columns)
+    assert predictions.select("product", "position").n_unique() == 6

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pandas_market_calendars as mcal
 import pytest
 from darts import TimeSeries
 from darts.models import TSMixerModel
@@ -101,8 +102,11 @@ def test_darts_checkpoint_population_rejects_missing_weights(tmp_path) -> None:
         )
 
 
-def test_darts_runner_persists_state_with_exact_prediction_keys(tmp_path, monkeypatch) -> None:
-    dates = pd.date_range("2024-01-02", periods=16, freq="B")
+def test_darts_runner_persists_state_with_exact_gap_free_prediction_keys(
+    tmp_path, monkeypatch
+) -> None:
+    dates = mcal.get_calendar("NYSE").valid_days("2024-01-02", "2024-02-15")[:20]
+    dates = dates.tz_localize(None)
     dataset = pd.DataFrame(
         [
             {
@@ -115,6 +119,8 @@ def test_darts_runner_persists_state_with_exact_prediction_keys(tmp_path, monkey
             for day, timestamp in enumerate(dates)
         ]
     )
+    missing_date = dates[12]
+    dataset = dataset.loc[dataset["timestamp"] != missing_date].reset_index(drop=True)
 
     def attach_base_target(frame, _case_study, _date_col):
         return frame.assign(**{BASE_TARGET_COL: np.log1p(frame["fwd_ret_1d"] / 10)})
@@ -175,6 +181,10 @@ def test_darts_runner_persists_state_with_exact_prediction_keys(tmp_path, monkey
     predictions = result["all_predictions"].rename({"fold_id": "fold"})
 
     assert evaluate_prediction_coverage(expected, predictions).complete
+    observed_dates = set(expected["timestamp"].dt.date().to_list())
+    assert missing_date.date() not in observed_dates
+    assert not {date.date() for date in dates[13:16]} & observed_dates
+    assert {date.date() for date in dates[16:]} <= observed_dates
     assert (
         len(
             validate_darts_checkpoint_population(

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -227,12 +227,14 @@ def test_darts_segments_and_predicts_each_cme_contract_position() -> None:
                 "fwd_ret_1d": float(day) / 100,
                 BASE_TARGET_COL: np.log1p(float(day) / 100),
             }
-            for product in ("ES", "NQ")
+            for product in ("ES", "ZC")
             for position in range(3)
-            for day, timestamp in enumerate(dates)
+            for day, timestamp in enumerate(dates if product == "ES" else dates.delete(2))
         ]
     )
-    dataset = _attach_expected_periods(dataset, date_col="timestamp", calendar_id=None)
+    dataset = _attach_expected_periods(
+        dataset, date_col="timestamp", calendar_id="CME_Equity", case_study="cme_futures"
+    )
     split = {
         "fold": 0,
         "train_start": dates[0],
@@ -255,7 +257,7 @@ def test_darts_segments_and_predicts_each_cme_contract_position() -> None:
     assert len(states) == 6
     assert {tuple(state.identity.items()) for state in states} == {
         (("product", product), ("position", position))
-        for product in ("ES", "NQ")
+        for product in ("ES", "ZC")
         for position in range(3)
     }
 
@@ -272,3 +274,6 @@ def test_darts_segments_and_predicts_each_cme_contract_position() -> None:
     )
     assert {"product", "position"} <= set(predictions.columns)
     assert predictions.select("product", "position").n_unique() == 6
+    assert predictions.filter(pl.col("product") == "ZC")["timestamp"].unique().to_list() == [
+        dates[4]
+    ]

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -10,6 +10,7 @@ from darts.models import TSMixerModel
 
 from case_studies.utils.darts_forecasting import (
     BASE_TARGET_COL,
+    _attach_base_target,
     _attach_expected_periods,
     _predict_fold,
     _prepare_fold_series,
@@ -277,3 +278,31 @@ def test_darts_segments_and_predicts_each_cme_contract_position() -> None:
     assert predictions.filter(pl.col("product") == "ZC")["timestamp"].unique().to_list() == [
         dates[4]
     ]
+
+
+def test_cme_base_target_uses_only_finalized_panel_sessions(monkeypatch) -> None:
+    raw = pl.DataFrame(
+        {
+            "session_date": [
+                pd.Timestamp("2024-01-02").date(),
+                pd.Timestamp("2024-01-03").date(),
+                pd.Timestamp("2024-01-04").date(),
+            ],
+            "product": ["ES"] * 3,
+            "tenor": [0] * 3,
+            "adj_close": [100.0, 110.0, 121.0],
+        }
+    )
+    monkeypatch.setattr("data.load_cme_futures", lambda: raw)
+    finalized = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-02", "2024-01-04"]),
+            "product": ["ES", "ES"],
+            "position": [0, 0],
+        }
+    )
+
+    attached = _attach_base_target(finalized, "cme_futures", "timestamp")
+
+    assert attached[BASE_TARGET_COL].isna().sum() == 1
+    assert attached.loc[1, BASE_TARGET_COL] == pytest.approx(np.log(121.0 / 100.0))

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import os
+from importlib.metadata import version
 from types import SimpleNamespace
 
 import polars as pl
 import pytest
 
 from case_studies.research import LabelDefinition, Study
+from case_studies.utils import deep_learning, tabular_dl
 from tests.test_research_workspace import _seed_release
 
 
@@ -105,3 +107,128 @@ def test_sequence_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> 
     assert spec["sampling"] == {"max_symbols": 0, "max_train_sequences": 0}
     assert context.expected_keys.height == 12
     assert context.config["n_epochs"] == 3
+
+
+def test_darts_request_resolves_installed_runtime_identity(tmp_path, monkeypatch) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    dates = [
+        "2024-01-02",
+        "2024-01-03",
+        "2024-01-04",
+        "2024-01-05",
+        "2024-01-08",
+        "2024-01-09",
+    ]
+    frame = pl.DataFrame(
+        {
+            "symbol": [f"S{symbol}" for symbol in range(3) for _ in dates],
+            "timestamp": dates * 3,
+            "feature": [float(index) for index in range(18)],
+            "fwd_ret_1d": [float(index % 3) / 100 for index in range(18)],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    split = {
+        "fold": 0,
+        "train_start": "2024-01-02",
+        "train_end": "2024-01-05",
+        "val_start": "2024-01-08",
+        "val_end": "2024-01-09",
+    }
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        splits=[split],
+        task_type="regression",
+        class_values=[],
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "batch_size": 64,
+                "checkpoint_interval": 1,
+                "n_epochs": 1,
+                "params": {"architecture": "tsmixer", "lookback": 2},
+                "config_name": "tsmixer_probe",
+                "family": "deep_learning",
+                "library": "darts",
+            }
+        ],
+    )
+    expected = (
+        frame.filter(pl.col("timestamp") >= pl.date(2024, 1, 8))
+        .select("symbol", "timestamp")
+        .with_columns(pl.lit(0, dtype=pl.Int64).alias("fold"))
+    )
+    monkeypatch.setattr(
+        "case_studies.utils.darts_forecasting.darts_validation_keys",
+        lambda *args, **kwargs: expected,
+    )
+    monkeypatch.setattr(
+        "case_studies.utils.darts_forecasting.darts_training_identity",
+        lambda *args, **kwargs: {
+            "input_data_spec": mds.input_lineage,
+            "input_chunk_length": 2,
+            "output_chunk_length": 1,
+            "max_train_sequences": 0,
+        },
+    )
+
+    resolved = study.model(
+        family="deep_learning",
+        label=label.name,
+        config_name="tsmixer_probe",
+        overrides={"device": "cpu"},
+    ).resolve()
+
+    assert resolved.spec["runtime_identity"]["darts"] == version("darts")
+    assert resolved.spec["model"]["implementation"] == "darts"
+
+
+@pytest.mark.parametrize(
+    "split_resolver", [deep_learning._sequence_splits, tabular_dl._tabm_splits]
+)
+def test_deep_adapters_reject_custom_cv_with_stale_temporal_geometry(split_resolver) -> None:
+    canonical = {
+        "fold": 0,
+        "train_start": "2020-01-01",
+        "train_end": "2020-12-31",
+        "val_start": "2021-01-01",
+        "val_end": "2021-12-31",
+    }
+    requested = {**canonical, "val_start": "2020-07-01"}
+    resolved_cv = SimpleNamespace(
+        normalized_folds=(requested,),
+        as_dict=lambda: {"folds": [requested]},
+    )
+    cv = SimpleNamespace(resolve=lambda *args, **kwargs: resolved_cv)
+    mds = SimpleNamespace(
+        dataset=pl.DataFrame({"timestamp": ["2020-01-01"]}).with_columns(
+            pl.col("timestamp").str.to_date()
+        ),
+        date_col="timestamp",
+        splits=[canonical],
+        temporal_by_fold=pl.DataFrame({"fold": [0], "timestamp": ["2021-01-01"]}).with_columns(
+            pl.col("timestamp").str.to_date()
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Custom CV cannot reuse fold-specific temporal features"):
+        split_resolver(mds, {"cv": cv, "preview_reductions": {}})

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from case_studies.research import LabelDefinition, Study
+from case_studies.utils import deep_learning
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def test_sequence_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    dates = [
+        "2024-01-02",
+        "2024-01-03",
+        "2024-01-04",
+        "2024-01-05",
+        "2024-01-08",
+        "2024-01-09",
+        "2024-01-10",
+        "2024-01-11",
+    ]
+    frame = pl.DataFrame(
+        {
+            "symbol": [f"S{symbol}" for symbol in range(3) for _ in dates],
+            "timestamp": dates * 3,
+            "feature": [float(index) for index in range(24)],
+            "fwd_ret_1d": [float(index % 3) / 100 for index in range(24)],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-02",
+            "train_end": "2024-01-05",
+            "val_start": "2024-01-08",
+            "val_end": "2024-01-11",
+        }
+    ]
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        splits=splits,
+        task_type="regression",
+        class_values=[],
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "batch_size": 64,
+                "checkpoint_interval": 2,
+                "n_epochs": 4,
+                "params": {"architecture": "nlinear", "dropout": 0.0, "lookback": 2},
+                "config_name": "nlinear_probe",
+                "family": "deep_learning",
+                "library": "pytorch",
+            }
+        ],
+    )
+
+    spec, context = deep_learning.resolve_model_request(
+        study,
+        {
+            "family": "deep_learning",
+            "label": label.name,
+            "config_name": "nlinear_probe",
+            "overrides": {"device": "cpu", "n_epochs": 3},
+            "cv": None,
+            "execution_tier": "canonical",
+            "preview_reductions": {},
+        },
+    )
+
+    assert spec["identity_version"] == 2
+    assert spec["label_artifact"]["digest"] == label.digest
+    assert spec["model"]["params"]["n_epochs"] == 3
+    assert [row["value"] for row in spec["checkpoint_schedule"]] == [2, 3]
+    assert spec["expected_prediction_keys"]["n_rows"] == 12
+    assert spec["sampling"] == {"max_symbols": 0, "max_train_sequences": 0}
+    assert context.expected_keys.height == 12
+    assert context.config["n_epochs"] == 3

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -7,7 +7,6 @@ import polars as pl
 import pytest
 
 from case_studies.research import LabelDefinition, Study
-from case_studies.utils import deep_learning
 from tests.test_research_workspace import _seed_release
 
 
@@ -89,18 +88,14 @@ def test_sequence_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> 
         ],
     )
 
-    spec, context = deep_learning.resolve_model_request(
-        study,
-        {
-            "family": "deep_learning",
-            "label": label.name,
-            "config_name": "nlinear_probe",
-            "overrides": {"device": "cpu", "n_epochs": 3},
-            "cv": None,
-            "execution_tier": "canonical",
-            "preview_reductions": {},
-        },
-    )
+    resolved = study.model(
+        family="deep_learning",
+        label=label.name,
+        config_name="nlinear_probe",
+        overrides={"device": "cpu", "n_epochs": 3},
+    ).resolve()
+    spec = resolved.spec
+    context = resolved._context
 
     assert spec["identity_version"] == 2
     assert spec["label_artifact"]["digest"] == label.digest

--- a/tests/test_deep_learning_state.py
+++ b/tests/test_deep_learning_state.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import torch
+
+from case_studies.utils.deep_learning import create_model, run_dl_cv
+from case_studies.utils.deep_model_state import restore_deep_model
+from case_studies.utils.sequence_dataset import (
+    materialize_sequences,
+    prepare_fold_sequence_stores,
+)
+
+
+def test_sequence_runner_checkpoint_reconstructs_registered_values(tmp_path) -> None:
+    timestamps = pd.date_range("2020-01-01", periods=30, freq="B")
+    dataset = pd.DataFrame(
+        [
+            {
+                "timestamp": timestamp,
+                "symbol": f"S{symbol}",
+                "feature": float(symbol) + day / 100.0,
+                "target": float(symbol) / 10.0 + np.sin(day / 5.0),
+            }
+            for symbol in range(10)
+            for day, timestamp in enumerate(timestamps)
+        ]
+    )
+    split = {
+        "fold": 0,
+        "train_start": timestamps[0],
+        "train_end": timestamps[19],
+        "val_start": timestamps[20],
+        "val_end": timestamps[-1],
+    }
+    config = {
+        "family": "deep_learning",
+        "config_name": "nlinear",
+        "params": {"architecture": "nlinear", "lookback": 2, "dropout": 0.0},
+        "n_epochs": 1,
+        "batch_size": 64,
+        "checkpoint_interval": 1,
+    }
+    checkpoint_root = tmp_path / "checkpoints"
+
+    result = run_dl_cv(
+        dataset,
+        [split],
+        configs=[config],
+        n_features=1,
+        feature_names=["feature"],
+        label_col="target",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        save_dir=tmp_path / "run",
+        checkpoint_root=checkpoint_root,
+    )
+
+    checkpoint = checkpoint_root / "nlinear" / "fold_00" / "epoch_0001.pt"
+    restored, preprocessing, metadata = restore_deep_model(checkpoint, create_model)
+    train_mask = (dataset["timestamp"] >= split["train_start"]) & (
+        dataset["timestamp"] <= split["train_end"]
+    )
+    val_mask = (dataset["timestamp"] >= split["val_start"]) & (
+        dataset["timestamp"] <= split["val_end"]
+    )
+    _, val_store, _ = prepare_fold_sequence_stores(
+        dataset,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feature"],
+        label_col="target",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=2,
+        val_start=split["val_start"],
+    )
+    X_val, _y_val, val_dates, val_entities = materialize_sequences(val_store)
+    with torch.no_grad():
+        scores = restored(torch.from_numpy(X_val)).numpy()
+    reconstructed = pl.DataFrame(
+        {"timestamp": val_dates, "symbol": val_entities, "restored": scores}
+    ).sort("timestamp", "symbol")
+    produced = (
+        result["all_predictions"]
+        .filter((pl.col("config") == "nlinear") & (pl.col("epoch") == 1) & (pl.col("fold_id") == 0))
+        .sort("timestamp", "symbol")
+    )
+
+    np.testing.assert_allclose(
+        reconstructed["restored"].to_numpy(),
+        produced["y_score"].to_numpy(),
+        rtol=1e-7,
+        atol=1e-8,
+    )
+    np.testing.assert_array_equal(preprocessing["mean"], val_store.feature_mean)
+    np.testing.assert_array_equal(preprocessing["scale"], val_store.feature_scale)
+    assert metadata["checkpoint_value"] == 1

--- a/tests/test_deep_model_state.py
+++ b/tests/test_deep_model_state.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from case_studies.utils.deep_model_state import (
+    checkpoint_sidecar,
+    load_deep_checkpoint,
+    restore_deep_model,
+    write_deep_checkpoint,
+)
+
+
+def _factory(_architecture: str, kwargs) -> nn.Module:
+    return nn.Linear(int(kwargs["n_features"]), 1)
+
+
+def test_checkpoint_reconstructs_identical_predictions_and_preprocessing(tmp_path) -> None:
+    torch.manual_seed(7)
+    model = nn.Linear(2, 1)
+    raw = np.array([[2.0, 7.0], [4.0, 11.0]], dtype=np.float32)
+    preprocessing = {
+        "feature_names": ["value", "quality"],
+        "mean": np.array([1.0, 3.0], dtype=np.float32),
+        "scale": np.array([2.0, 4.0], dtype=np.float32),
+    }
+    transformed = (raw - preprocessing["mean"]) / preprocessing["scale"]
+    expected = model(torch.from_numpy(transformed)).detach().numpy()
+    path = tmp_path / "fold_00" / "epoch_005.pt"
+
+    write_deep_checkpoint(
+        path,
+        model=model,
+        architecture="linear-probe",
+        model_kwargs={"n_features": 2},
+        preprocessing=preprocessing,
+        metadata={"config_name": "probe", "fold": 0, "checkpoint_value": 5},
+    )
+    restored, restored_preprocessing, metadata = restore_deep_model(path, _factory)
+    restored_input = (raw - restored_preprocessing["mean"]) / restored_preprocessing["scale"]
+    actual = restored(torch.from_numpy(restored_input)).detach().numpy()
+
+    np.testing.assert_array_equal(actual, expected)
+    assert restored_preprocessing["feature_names"] == ["value", "quality"]
+    assert metadata == {"config_name": "probe", "fold": 0, "checkpoint_value": 5}
+
+
+def test_checkpoint_is_immutable_and_digest_verified(tmp_path) -> None:
+    model = nn.Linear(1, 1)
+    path = tmp_path / "epoch_001.pt"
+    request = {
+        "model": model,
+        "architecture": "linear-probe",
+        "model_kwargs": {"n_features": 1},
+        "preprocessing": {"mean": np.array([0.0]), "scale": np.array([1.0])},
+        "metadata": {"checkpoint_value": 1},
+    }
+    write_deep_checkpoint(path, **request)
+    write_deep_checkpoint(path, **request)
+
+    changed = nn.Linear(1, 1)
+    with torch.no_grad():
+        changed.weight.add_(1.0)
+    with pytest.raises(FileExistsError, match="immutable checkpoint conflict"):
+        write_deep_checkpoint(path, **{**request, "model": changed})
+
+    path.write_bytes(path.read_bytes() + b"corrupt")
+    with pytest.raises(ValueError, match="digest"):
+        load_deep_checkpoint(path)
+
+    record = json.loads(checkpoint_sidecar(path).read_text())
+    assert record["schema_version"] == 1

--- a/tests/test_deep_model_state.py
+++ b/tests/test_deep_model_state.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from case_studies.utils.deep_model_state import (
     checkpoint_sidecar,
+    declared_epoch_checkpoints,
     deep_checkpoint_path,
     load_deep_checkpoint,
     restore_deep_model,
@@ -49,6 +50,11 @@ def test_checkpoint_reconstructs_identical_predictions_and_preprocessing(tmp_pat
     np.testing.assert_array_equal(actual, expected)
     assert restored_preprocessing["feature_names"] == ["value", "quality"]
     assert metadata == {"config_name": "probe", "fold": 0, "checkpoint_value": 5}
+
+
+def test_declared_checkpoint_schedule_includes_the_final_epoch() -> None:
+    assert declared_epoch_checkpoints(10, 5) == (5, 10)
+    assert declared_epoch_checkpoints(11, 5) == (5, 10, 11)
 
 
 def test_checkpoint_is_immutable_and_digest_verified(tmp_path) -> None:

--- a/tests/test_deep_model_state.py
+++ b/tests/test_deep_model_state.py
@@ -9,8 +9,10 @@ from torch import nn
 
 from case_studies.utils.deep_model_state import (
     checkpoint_sidecar,
+    deep_checkpoint_path,
     load_deep_checkpoint,
     restore_deep_model,
+    validate_deep_checkpoint_population,
     write_deep_checkpoint,
 )
 
@@ -74,3 +76,41 @@ def test_checkpoint_is_immutable_and_digest_verified(tmp_path) -> None:
 
     record = json.loads(checkpoint_sidecar(path).read_text())
     assert record["schema_version"] == 1
+
+
+def test_checkpoint_population_requires_exact_folds_epochs_and_metadata(tmp_path) -> None:
+    model = nn.Linear(1, 1)
+    root = tmp_path / "checkpoints"
+    for fold in (0, 1):
+        for epoch in (5, 10):
+            write_deep_checkpoint(
+                deep_checkpoint_path(root, "probe", fold, epoch),
+                model=model,
+                architecture="linear-probe",
+                model_kwargs={"n_features": 1},
+                preprocessing={"mean": np.array([0.0]), "scale": np.array([1.0])},
+                metadata={
+                    "config_name": "probe",
+                    "fold": fold,
+                    "checkpoint_kind": "epoch",
+                    "checkpoint_value": epoch,
+                },
+            )
+
+    paths = validate_deep_checkpoint_population(
+        root,
+        config_name="probe",
+        fold_ids=(0, 1),
+        checkpoints=(5, 10),
+        architecture="linear-probe",
+    )
+    assert len(paths) == 4
+
+    deep_checkpoint_path(root, "probe", 1, 10).unlink()
+    with pytest.raises(ValueError, match="population is incomplete"):
+        validate_deep_checkpoint_population(
+            root,
+            config_name="probe",
+            fold_ids=(0, 1),
+            checkpoints=(5, 10),
+        )

--- a/tests/test_insight_chapter.py
+++ b/tests/test_insight_chapter.py
@@ -1,0 +1,82 @@
+"""Behavioral tests for cross-case-study insight diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import polars as pl
+
+from case_studies.utils import insight_chapter
+
+
+def test_selected_prediction_conformal_coverage_uses_chronology_and_exact_rank(
+    tmp_path, monkeypatch
+) -> None:
+    case_dir = tmp_path / "case_studies" / "probe"
+    prediction_dir = case_dir / "run_log" / "predictions" / "prediction-a"
+    prediction_dir.mkdir(parents=True)
+    calibration = [0.1] * 33 + [5.0] * 7
+    evaluation = [1.0] * 40
+    pl.DataFrame(
+        {
+            "timestamp": ["2019-01-02"] * 40 + ["2020-01-02"] * 40,
+            "y_true": calibration + evaluation,
+            "y_score": [0.0] * 80,
+            "fold_id": [1] * 40 + [0] * 40,
+        }
+    ).write_parquet(prediction_dir / "predictions.parquet")
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    result = insight_chapter.conformal_coverage_for_selected_prediction(
+        {
+            "case_study": "probe",
+            "family": "gbm",
+            "config_name": "probe-config",
+            "prediction_hash": "prediction-a",
+            "spec_json": json.dumps({"n_folds": 2}),
+        },
+        levels=(0.80,),
+    )
+
+    calibration_scale = pl.Series(calibration).std()
+    expected_quantile = sorted(calibration)[int(np.ceil(41 * 0.80)) - 1]
+    implied_quantile = result["mean_interval_width_frac_std"][0] * calibration_scale / 2.0
+    assert expected_quantile == 0.1
+    assert implied_quantile == expected_quantile
+    assert result["empirical_coverage"].to_list() == [0.0]
+
+
+def test_selected_prediction_conformal_coverage_uses_calibration_scale(
+    tmp_path, monkeypatch
+) -> None:
+    case_dir = tmp_path / "case_studies" / "probe"
+    prediction_dir = case_dir / "run_log" / "predictions" / "prediction-a"
+    prediction_dir.mkdir(parents=True)
+    calibration = [0.1] * 33 + [5.0] * 7
+    evaluation = [40.0, -40.0] * 20
+    pl.DataFrame(
+        {
+            "timestamp": ["2019-01-02"] * 40 + ["2020-01-02"] * 40,
+            "y_true": calibration + evaluation,
+            "y_score": [0.0] * 80,
+            "fold_id": [1] * 40 + [0] * 40,
+        }
+    ).write_parquet(prediction_dir / "predictions.parquet")
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    result = insight_chapter.conformal_coverage_for_selected_prediction(
+        {
+            "case_study": "probe",
+            "family": "gbm",
+            "config_name": "probe-config",
+            "prediction_hash": "prediction-a",
+            "spec_json": json.dumps({"n_folds": 2}),
+        },
+        levels=(0.80,),
+    )
+
+    quantile = 0.1
+    width = result["mean_interval_width_frac_std"][0]
+    assert width == 2.0 * quantile / pl.Series(calibration).std()
+    assert width != 2.0 * quantile / pl.Series(calibration + evaluation).std()

--- a/tests/test_insight_chapter.py
+++ b/tests/test_insight_chapter.py
@@ -110,3 +110,32 @@ def test_selected_prediction_conformal_coverage_rejects_all_null_declared_fold(
             },
             levels=(0.80,),
         )
+
+
+def test_selected_prediction_conformal_coverage_rejects_non_finite_rows(
+    tmp_path, monkeypatch
+) -> None:
+    case_dir = tmp_path / "case_studies" / "probe"
+    prediction_dir = case_dir / "run_log" / "predictions" / "prediction-a"
+    prediction_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "timestamp": ["2019-01-02"] * 40 + ["2020-01-02"] * 40,
+            "y_true": [0.1] * 80,
+            "y_score": [0.0] * 79 + [float("inf")],
+            "fold_id": [0] * 40 + [1] * 40,
+        }
+    ).write_parquet(prediction_dir / "predictions.parquet")
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    with pytest.raises(insight_chapter.RegistrySelectionError, match="non-finite y_score"):
+        insight_chapter.conformal_coverage_for_selected_prediction(
+            {
+                "case_study": "probe",
+                "family": "gbm",
+                "config_name": "probe-config",
+                "prediction_hash": "prediction-a",
+                "spec_json": json.dumps({"n_folds": 2}),
+            },
+            levels=(0.80,),
+        )

--- a/tests/test_insight_chapter.py
+++ b/tests/test_insight_chapter.py
@@ -6,6 +6,7 @@ import json
 
 import numpy as np
 import polars as pl
+import pytest
 
 from case_studies.utils import insight_chapter
 
@@ -80,3 +81,32 @@ def test_selected_prediction_conformal_coverage_uses_calibration_scale(
     width = result["mean_interval_width_frac_std"][0]
     assert width == 2.0 * quantile / pl.Series(calibration).std()
     assert width != 2.0 * quantile / pl.Series(calibration + evaluation).std()
+
+
+def test_selected_prediction_conformal_coverage_rejects_all_null_declared_fold(
+    tmp_path, monkeypatch
+) -> None:
+    case_dir = tmp_path / "case_studies" / "probe"
+    prediction_dir = case_dir / "run_log" / "predictions" / "prediction-a"
+    prediction_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "timestamp": ["2019-01-02"] * 40 + ["2020-01-02"] * 40,
+            "y_true": [0.1] * 40 + [None] * 40,
+            "y_score": [0.0] * 40 + [None] * 40,
+            "fold_id": [0] * 40 + [1] * 40,
+        }
+    ).write_parquet(prediction_dir / "predictions.parquet")
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    with pytest.raises(insight_chapter.RegistrySelectionError, match=r"observed \[0\]"):
+        insight_chapter.conformal_coverage_for_selected_prediction(
+            {
+                "case_study": "probe",
+                "family": "gbm",
+                "config_name": "probe-config",
+                "prediction_hash": "prediction-a",
+                "spec_json": json.dumps({"n_folds": 2}),
+            },
+            levels=(0.80,),
+        )

--- a/tests/test_sequence_dataset.py
+++ b/tests/test_sequence_dataset.py
@@ -133,6 +133,28 @@ def test_val_sequence_count_matches_val_calendar_days():
     )
 
 
+def test_sequence_store_carries_fitted_training_preprocessing():
+    from case_studies.utils.sequence_dataset import prepare_fold_sequence_stores
+
+    df, train_mask, val_mask, val_start_ts, _ = _synthetic_fold_df()
+    train_store, val_store, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+        val_start=val_start_ts,
+    )
+
+    assert train_store.feature_mean is not None
+    assert train_store.feature_scale is not None
+    np.testing.assert_array_equal(val_store.feature_mean, train_store.feature_mean)
+    np.testing.assert_array_equal(val_store.feature_scale, train_store.feature_scale)
+
+
 def test_val_sequence_targets_never_include_train_period():
     """No val sequence should have a target timestamp < val_start.
 

--- a/tests/test_sequence_dataset.py
+++ b/tests/test_sequence_dataset.py
@@ -19,6 +19,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from case_studies.utils.sequence_dataset import (
+    materialize_store_metadata,
+    prepare_fold_sequence_stores,
+    sequence_validation_keys,
+)
+
 
 def _synthetic_fold_df(
     *,
@@ -153,6 +159,52 @@ def test_sequence_store_carries_fitted_training_preprocessing():
     assert train_store.feature_scale is not None
     np.testing.assert_array_equal(val_store.feature_mean, train_store.feature_mean)
     np.testing.assert_array_equal(val_store.feature_scale, train_store.feature_scale)
+
+
+@pytest.mark.parametrize("missing_validation_row", [False, True])
+def test_declared_validation_keys_equal_sequence_store(missing_validation_row):
+    df, train_mask, val_mask, val_start_ts, val_end_ts = _synthetic_fold_df()
+    if missing_validation_row:
+        df = df.loc[
+            ~((df["symbol"] == "S1") & (df["timestamp"] == pd.Timestamp("2021-02-01")))
+        ].reset_index(drop=True)
+        train_mask = df["timestamp"] <= pd.Timestamp("2020-12-31")
+        val_mask = df["timestamp"].between(val_start_ts, val_end_ts, inclusive="both")
+    df.loc[(df["symbol"] == "S2") & (df["timestamp"] == pd.Timestamp("2021-03-01")), "y"] = np.nan
+    split = {
+        "fold": 3,
+        "train_start": pd.Timestamp("2020-01-01"),
+        "train_end": pd.Timestamp("2020-12-31"),
+        "val_start": val_start_ts,
+        "val_end": val_end_ts,
+    }
+
+    _, val_store, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+        val_start=val_start_ts,
+    )
+    _, timestamps, symbols = materialize_store_metadata(val_store)
+    actual = {
+        (str(symbol), pd.Timestamp(timestamp), 3)
+        for symbol, timestamp in zip(symbols, timestamps, strict=True)
+    }
+    declared = sequence_validation_keys(
+        df,
+        [split],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+    )
+
+    assert set(declared.iter_rows()) == actual
 
 
 def test_val_sequence_targets_never_include_train_period():

--- a/tests/test_tabular_dl.py
+++ b/tests/test_tabular_dl.py
@@ -1,7 +1,13 @@
 import numpy as np
 import pandas as pd
+import torch
 
-from case_studies.utils.tabular_dl import run_tabm_cv
+from case_studies.utils.deep_model_state import restore_deep_model
+from case_studies.utils.tabular_dl import (
+    TabMModel,
+    _predict_in_chunks,
+    run_tabm_cv,
+)
 
 
 def test_run_tabm_cv_returns_fold_metrics_after_training(tmp_path):
@@ -33,6 +39,7 @@ def test_run_tabm_cv_returns_fold_metrics_after_training(tmp_path):
         }
     ]
 
+    checkpoint_root = tmp_path / "checkpoints"
     result = run_tabm_cv(
         dataset,
         splits,
@@ -43,8 +50,34 @@ def test_run_tabm_cv_returns_fold_metrics_after_training(tmp_path):
         date_col="timestamp",
         device="cpu",
         save_dir=tmp_path,
+        checkpoint_root=checkpoint_root,
     )
 
     assert result["best_config_name"] == "tabm_test"
     assert result["fold_metrics"].height == 1
     assert result["fold_metrics"]["n_entities"].to_list() == [10]
+
+    checkpoint = checkpoint_root / "tabm_test" / "fold_00" / "epoch_0001.pt"
+    restored, preprocessing, metadata = restore_deep_model(
+        checkpoint,
+        lambda architecture, kwargs: TabMModel(**kwargs) if architecture == "tabm" else None,
+    )
+    validation = dataset[dataset["timestamp"] >= timestamps[10]].sort_values(
+        ["timestamp", "symbol"]
+    )
+    raw = validation[["feature"]].to_numpy(dtype=np.float32)
+    imputed = np.where(np.isnan(raw), preprocessing["imputer_statistics"], raw)
+    transformed = (imputed - preprocessing["scaler_mean"]) / preprocessing["scaler_scale"]
+    actual = _predict_in_chunks(restored, transformed, torch.device("cpu"))
+    expected = (
+        result["all_predictions"]
+        .filter(
+            (result["all_predictions"]["config"] == "tabm_test")
+            & (result["all_predictions"]["epoch"] == 1)
+        )
+        .sort("timestamp", "symbol")["y_score"]
+        .to_numpy()
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-7, atol=1e-8)
+    assert metadata["checkpoint_value"] == 1

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -7,7 +7,6 @@ import polars as pl
 import pytest
 
 from case_studies.research import LabelDefinition, Study
-from case_studies.utils import tabular_dl
 from tests.test_research_workspace import _seed_release
 
 
@@ -84,18 +83,14 @@ def test_tabm_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None
         ],
     )
 
-    spec, context = tabular_dl.resolve_model_request(
-        study,
-        {
-            "family": "tabular_dl",
-            "label": label.name,
-            "config_name": "tabm_probe",
-            "overrides": {"device": "cpu", "n_epochs": 11},
-            "cv": None,
-            "execution_tier": "canonical",
-            "preview_reductions": {},
-        },
-    )
+    resolved = study.model(
+        family="tabular_dl",
+        label=label.name,
+        config_name="tabm_probe",
+        overrides={"device": "cpu", "n_epochs": 11},
+    ).resolve()
+    spec = resolved.spec
+    context = resolved._context
 
     assert spec["identity_version"] == 2
     assert spec["label_artifact"]["digest"] == label.digest

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from case_studies.research import LabelDefinition, Study
+from case_studies.utils import tabular_dl
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def test_tabm_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    frame = pl.DataFrame(
+        {
+            "symbol": [f"S{index}" for index in range(6)] * 4,
+            "timestamp": [
+                date
+                for date in ("2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04")
+                for _ in range(6)
+            ],
+            "feature": [float(index) for index in range(24)],
+            "fwd_ret_1d": [float(index % 6) / 100 for index in range(24)],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-02",
+            "val_start": "2024-01-03",
+            "val_end": "2024-01-04",
+        }
+    ]
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        splits=splits,
+        task_type="regression",
+        class_values=[],
+        eval_label_col=None,
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "batch_size": 64,
+                "checkpoint_interval": 5,
+                "n_epochs": 10,
+                "params": {"dropout": 0.0, "hidden_dim": 4, "n_members": 2},
+                "config_name": "tabm_probe",
+                "family": "tabular_dl",
+                "library": "tabm",
+            }
+        ],
+    )
+
+    spec, context = tabular_dl.resolve_model_request(
+        study,
+        {
+            "family": "tabular_dl",
+            "label": label.name,
+            "config_name": "tabm_probe",
+            "overrides": {"device": "cpu", "n_epochs": 11},
+            "cv": None,
+            "execution_tier": "canonical",
+            "preview_reductions": {},
+        },
+    )
+
+    assert spec["identity_version"] == 2
+    assert spec["label_artifact"]["digest"] == label.digest
+    assert spec["model"]["params"]["n_epochs"] == 11
+    assert [row["value"] for row in spec["checkpoint_schedule"]] == [5, 10, 11]
+    assert spec["expected_prediction_keys"] == {
+        "digest": spec["expected_prediction_keys"]["digest"],
+        "n_rows": 12,
+        "n_folds": 1,
+    }
+    assert context.expected_keys.height == 12
+    assert context.config["n_epochs"] == 11

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1259,6 +1259,39 @@ def validate_temporal_fold_coverage(
         )
 
 
+def validate_temporal_split_geometry(
+    requested_splits: list[dict[str, Any]],
+    canonical_splits: list[dict[str, Any]],
+    temporal_by_fold: pl.DataFrame | pd.DataFrame | None,
+) -> None:
+    """Require requests to use the fold geometry that fitted temporal features."""
+    if temporal_by_fold is None:
+        return
+    fields = ("train_start", "train_end", "val_start", "val_end")
+    canonical = {int(split["fold"]): split for split in canonical_splits}
+    failures: list[str] = []
+    for requested in requested_splits:
+        fold = int(requested["fold"])
+        fitted = canonical.get(fold)
+        if fitted is None:
+            failures.append(f"fold {fold} has no fitted temporal artifact geometry")
+            continue
+        mismatches = [
+            field
+            for field in fields
+            if pd.Timestamp(requested[field]).tz_localize(None)
+            != pd.Timestamp(fitted[field]).tz_localize(None)
+        ]
+        if mismatches:
+            failures.append(f"fold {fold} differs in {mismatches}")
+    if failures:
+        raise ValueError(
+            "Custom CV cannot reuse fold-specific temporal features fitted on different "
+            f"boundaries: {'; '.join(failures)}. Use canonical folds or regenerate the "
+            "temporal artifact for the requested geometry."
+        )
+
+
 def replace_temporal_columns(
     dataset_pd: pd.DataFrame,
     mask: np.ndarray,


### PR DESCRIPTION
## Summary

- attach TabM and Darts sequence families to the public research model catalog
- persist complete immutable deep checkpoints and require exact fitted-state identity for reuse
- enforce the requested temporal fold geometry and gap-free sequence construction
- preserve complete CME product-position identity and derive targets from finalized panel sessions
- reject incomplete conformal inputs while retaining chronological calibration

## Why

The official downstream runs must execute through the student-facing research request/result boundary. These shared adapters make notebook and public-interface requests resolve to the same family implementations without permitting preview, partial, stale, or differently fitted state to enter production reuse.

## Verification

- `uv run ruff check` over all changed shared modules and focused tests
- `uv run ruff format --check` over all changed shared modules and focused tests
- focused research suite: 161 passed, 1 skipped
- required RoboRev PR gate: job 13161, no issues found

## Scope

No notebook production execution, registry mutation, or canonical artifact generation is included in this PR.
