### PR TITLE
Lock the main image test dependencies

### DIFF
--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -209,7 +209,7 @@ RUN mkdir -p /etc/jupyter/labconfig && \
     echo '{"disabledExtensions": {"catboost-widget": true}}' > /etc/jupyter/labconfig/page_config.json
 
 # Test infrastructure — pytest + helpers so CI doesn't need runtime pip install
-RUN /opt/ml4t/bin/pip install --no-cache-dir \
+RUN /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
     "pytest>=8.0" "pytest-rerunfailures>=16.0" "pytest-timeout>=2.3"
 
 # Copy import test script

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -110,7 +110,7 @@ COPY pyproject.toml uv.lock /build/
 # device-links the CUDA-13-built libnccl_static.a, which nvcc 12.6's nvlink cannot read
 # ("nvlink error: Uncompress failed (target: sm_80)"). Reading the version from the lock
 # means the image cannot drift off the version readers get from `uv sync`.
-RUN cd /build && uv export --frozen --extra live --no-emit-project --no-hashes \
+RUN cd /build && uv export --frozen --extra live --extra dev --no-emit-project --no-hashes \
       --format requirements-txt \
       | grep -iE '^[a-z0-9._-]+==' > /tmp/locked-all.txt && \
     grep -viE '^(torch|torchvision|torchaudio|lightgbm|triton|setuptools)==|^nvidia-' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,7 @@ rag = [
 dev = [
     "pytest>=8.0",
     "pytest-rerunfailures>=15.0",
+    "pytest-timeout>=2.3",
     "jupytext>=1.16",
     "pre-commit>=3.6",
     # Pinned exactly, and the same version .pre-commit-config.yaml pins. Two

--- a/uv.lock
+++ b/uv.lock
@@ -4256,6 +4256,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 live = [
@@ -4367,6 +4368,7 @@ requires-dist = [
     { name = "pyportfolioopt", specifier = ">=1.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=15.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "python-okx", marker = "extra == 'live'", specifier = ">=0.3" },
     { name = "pytorch-lightning", specifier = ">=2.2" },
@@ -6690,6 +6692,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Direct inspection of the published image found that the test harness imported successfully but resolved `pytest-rerunfailures` 16.5 instead of the lock version 16.3. The final test-infrastructure install was not constrained, and the exported constraints omitted the `dev` extra.\n\nThis adds pytest-timeout to the dev extra and lock, exports both live and dev constraints, and installs all three test packages under that constraint. The exported versions are pytest 9.0.3, pytest-rerunfailures 16.3, and pytest-timeout 2.4.0. Focused tests, pre-commit, and automated branch review pass.