### PR TITLE
Prove ETF research execution contracts

### DIFF
--- a/case_studies/cme_futures/config/setup.yaml
+++ b/case_studies/cme_futures/config/setup.yaml
@@ -335,6 +335,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: gpu
+    max_bin: 63
   latent_factors:
     persistent_entities: true
     model_kwargs:

--- a/case_studies/config/lgb/default_huber.yaml
+++ b/case_studies/config/lgb/default_huber.yaml
@@ -1,4 +1,5 @@
 checkpoint_interval: 50
+huber_alpha_scale: 0.5
 max_iterations: 500
 params:
   objective: huber

--- a/case_studies/config/lgb/leaves_15_huber.yaml
+++ b/case_studies/config/lgb/leaves_15_huber.yaml
@@ -1,4 +1,5 @@
 checkpoint_interval: 50
+huber_alpha_scale: 0.5
 max_iterations: 500
 params:
   bagging_fraction: 0.8

--- a/case_studies/config/lgb/leaves_31_huber.yaml
+++ b/case_studies/config/lgb/leaves_31_huber.yaml
@@ -1,4 +1,5 @@
 checkpoint_interval: 50
+huber_alpha_scale: 0.5
 max_iterations: 500
 params:
   bagging_fraction: 0.8

--- a/case_studies/config/lgb/leaves_63_huber.yaml
+++ b/case_studies/config/lgb/leaves_63_huber.yaml
@@ -1,4 +1,5 @@
 checkpoint_interval: 50
+huber_alpha_scale: 0.5
 max_iterations: 500
 params:
   bagging_fraction: 0.8

--- a/case_studies/config/lgb/leaves_7_huber.yaml
+++ b/case_studies/config/lgb/leaves_7_huber.yaml
@@ -1,4 +1,5 @@
 checkpoint_interval: 50
+huber_alpha_scale: 0.5
 max_iterations: 500
 params:
   bagging_fraction: 0.8

--- a/case_studies/crypto_perps_funding/config/setup.yaml
+++ b/case_studies/crypto_perps_funding/config/setup.yaml
@@ -296,6 +296,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: cpu
+    max_bin: 63
 
 causal:
   treatment: premium_zscore_14d

--- a/case_studies/etfs/config/setup.yaml
+++ b/case_studies/etfs/config/setup.yaml
@@ -273,6 +273,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: gpu
+    max_bin: 63
   latent_factors:
     persistent_entities: true
     macro_context:

--- a/case_studies/fx_pairs/config/setup.yaml
+++ b/case_studies/fx_pairs/config/setup.yaml
@@ -279,6 +279,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: gpu
+    max_bin: 63
 
 causal:
   treatment: mom_skip_recent

--- a/case_studies/nasdaq100_microstructure/config/setup.yaml
+++ b/case_studies/nasdaq100_microstructure/config/setup.yaml
@@ -591,6 +591,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: cpu
+    max_bin: 63
 
 causal:
   treatment: signed_vol_share

--- a/case_studies/research/cv.py
+++ b/case_studies/research/cv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
 from typing import Any
 
 from case_studies.utils.artifact_digest import value_digest
@@ -9,7 +10,40 @@ from utils.cv_splits import generate_cv_splits
 
 
 def _normalize_boundary(value: Any) -> str:
-    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+    raw = value.isoformat() if hasattr(value, "isoformat") else str(value)
+    try:
+        boundary = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return raw
+    if boundary.tzinfo is not None:
+        boundary = boundary.astimezone(UTC).replace(tzinfo=None)
+    return boundary.isoformat()
+
+
+def require_fold_scoped_temporal_compatibility(
+    requested_folds: list[dict[str, Any]],
+    artifact_folds: list[dict[str, Any]],
+) -> None:
+    """Reject CV geometry that cannot reuse fold-scoped temporal features."""
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+
+    def normalize(split: dict[str, Any]) -> dict[str, Any]:
+        return {
+            field: int(split[field]) if field == "fold" else _normalize_boundary(split[field])
+            for field in fields
+        }
+
+    source = {int(split["fold"]): normalize(split) for split in artifact_folds}
+    incompatible = [
+        normalize(split)
+        for split in requested_folds
+        if source.get(int(split["fold"])) != normalize(split)
+    ]
+    if incompatible:
+        raise ValueError(
+            "custom CV is incompatible with fold-scoped temporal features; "
+            "use the artifact's original fold boundaries"
+        )
 
 
 @dataclass(frozen=True)

--- a/case_studies/research/labels.py
+++ b/case_studies/research/labels.py
@@ -13,6 +13,8 @@ import polars as pl
 from case_studies.utils.artifact_digest import digest_sidecar, sidecar_path, value_digest
 from utils.artifact_specs import load_label_spec, resolve_label_horizon, resolve_storage_path
 
+from .contracts import ExecutionTier
+
 if TYPE_CHECKING:
     from .workspace import Study
 
@@ -75,8 +77,13 @@ class LabelCatalog:
             names.update(path.stem for path in label_dir.glob("*.parquet"))
         return tuple(self.get(name) for name in sorted(names))
 
-    def get(self, name: str) -> LabelRef:
-        self.study.activate()
+    def get(
+        self,
+        name: str,
+        *,
+        execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
+    ) -> LabelRef:
+        self.study.activate(execution_tier)
         path = self._path(name)
         metadata_path = sidecar_path(path)
         if metadata_path.exists():

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -39,6 +39,15 @@ class OfficialPopulation:
         normalized = tuple(dict.fromkeys(str(member) for member in members))
         if not normalized or len(normalized) != len(members):
             raise ValueError("official population members must be non-empty and unique")
+        for member_hash in normalized:
+            try:
+                result = Result.open(study, member_hash, include_preview=True)
+            except KeyError:
+                continue
+            if result.execution_tier == "preview":
+                raise ValueError(
+                    f"preview result {member_hash} cannot enter an official population"
+                )
         snapshot = {
             "schema_version": 1,
             "name": name,

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import subprocess
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -69,6 +70,53 @@ def _clear_root_sensitive_caches() -> None:
     ):
         cached.cache_clear()
     specs._CONFIG_DIR = None
+
+
+def _resolved_directory_symlink(path: Path) -> Path | None:
+    if not path.is_symlink():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return None
+    return resolved if resolved.is_dir() else None
+
+
+def _ensure_input_link(preview_case: Path, source: Path) -> None:
+    resolved = source.resolve(strict=True)
+    if not resolved.is_dir():
+        raise ValueError(f"preview input is not a directory: {source}")
+    link = preview_case / source.name
+    if link.is_symlink():
+        if link.resolve(strict=True) != resolved:
+            raise ValueError(f"preview input link targets the wrong directory: {link}")
+        return
+    if link.exists():
+        raise ValueError(f"preview input path must be a directory symlink: {link}")
+    link.symlink_to(resolved, target_is_directory=True)
+
+
+def _ensure_config_link(link: Path, source: Path) -> None:
+    resolved = source.resolve(strict=True)
+    if not resolved.is_dir():
+        raise ValueError(f"preview config is not a directory: {source}")
+    if _resolved_directory_symlink(link) == resolved:
+        return
+    if link.is_symlink():
+        link.unlink()
+    elif link.exists():
+        if not link.is_dir():
+            raise ValueError(f"preview config path is not a directory: {link}")
+        backup = link.with_name(f".{link.name}.{uuid.uuid4().hex}.stale")
+        link.rename(backup)
+        try:
+            link.symlink_to(resolved, target_is_directory=True)
+        except Exception:
+            backup.rename(link)
+            raise
+        shutil.rmtree(backup)
+        return
+    link.symlink_to(resolved, target_is_directory=True)
 
 
 @dataclass(frozen=True)
@@ -148,6 +196,41 @@ class Study:
         study.activate()
         return study
 
+    @classmethod
+    def regenerate(
+        cls,
+        case_study: str,
+        *,
+        release_root: str | Path = REPO_ROOT,
+    ) -> Study:
+        """Open the canonical generated-artifact links for maintainer regeneration."""
+        release_root = Path(release_root).expanduser().resolve()
+        case_dir = release_root / "case_studies" / case_study
+        if not case_dir.is_dir():
+            raise FileNotFoundError(f"Unknown released case study: {case_dir}")
+        generated = (case_dir / "features", case_dir / "labels", case_dir / "run_log")
+        invalid = [path for path in generated if _resolved_directory_symlink(path) is None]
+        if invalid:
+            raise PermissionError(
+                f"canonical regeneration requires generated-artifact directory symlinks: {invalid}"
+            )
+        study = cls(
+            case_study=case_study,
+            root=case_dir,
+            release_root=release_root,
+            output_root=case_dir.parent,
+            read_only=False,
+            manifest={
+                "schema_version": 1,
+                "case_study": case_study,
+                "baseline_source_commit": _source_commit(release_root),
+                "baseline_manifest_sha256": _release_manifest_digest(case_dir),
+                "regeneration": True,
+            },
+        )
+        study.activate()
+        return study
+
     def activate(self, execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL) -> Path:
         global _ACTIVE_OUTPUT_ROOT
         tier = ExecutionTier(execution_tier)
@@ -163,16 +246,22 @@ class Study:
         if tier is ExecutionTier.PREVIEW:
             output_root = output_root / ".preview"
             preview_case = output_root / self.case_study
-            if not preview_case.exists():
-                preview_case.mkdir(parents=True)
-                shutil.copytree(self.root / "config", preview_case / "config")
-                shared_config = base_output_root / "config"
-                if shared_config.exists():
-                    shutil.copytree(shared_config, output_root / "config", dirs_exist_ok=True)
+            preview_case.mkdir(parents=True, exist_ok=True)
+            _ensure_config_link(preview_case / "config", self.root / "config")
+            shared_config = base_output_root / "config"
+            if shared_config.exists():
+                _ensure_config_link(output_root / "config", shared_config)
+            for name in ("labels", "features"):
+                source = self.root / name
+                if source.exists():
+                    _ensure_input_link(preview_case, source)
+            from case_studies.utils.registry.store import _open_registry
+
+            _open_registry(preview_case).close()
         if output_root != _ACTIVE_OUTPUT_ROOT:
             os.environ["ML4T_OUTPUT_DIR"] = str(output_root)
             _ACTIVE_OUTPUT_ROOT = output_root
-            _clear_root_sensitive_caches()
+        _clear_root_sensitive_caches()
         return output_root / self.case_study
 
     def storage_root(self, execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL) -> Path:

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -355,6 +355,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: gpu
+    max_bin: 63
 
 causal:
   treatment: vrp_21d

--- a/case_studies/us_equities_panel/config/setup.yaml
+++ b/case_studies/us_equities_panel/config/setup.yaml
@@ -172,6 +172,7 @@ modeling:
     libraries: [lightgbm]
     preset: default
     device: cpu
+    max_bin: 63
   latent_factors:
     persistent_entities: true
     # Down-tune the SDF schedule on this large-N CS so training time stays

--- a/case_studies/utils/cv_window.py
+++ b/case_studies/utils/cv_window.py
@@ -12,12 +12,13 @@ re-running ``run_backtest`` on a sliced parquet is a no-op.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Sequence
 from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, cast
 
 import pandas as pd
 import yaml
@@ -25,6 +26,18 @@ import yaml
 from utils.paths import get_case_study_dir
 
 Split = Literal["validation", "holdout"]
+
+_LEGACY_TEMPORAL_FOLD_ROUTES = {
+    "cme_futures": ("primary_label", False),
+    "crypto_perps_funding": ("primary_label", True),
+    "etfs": ("primary_label", True),
+    "fx_pairs": ("primary_label", False),
+    "nasdaq100_microstructure": ("primary_label", True),
+    "sp500_equity_option_analytics": ("primary_label", True),
+    "sp500_options": ("financial", False),
+    "us_equities_panel": ("primary_label", True),
+}
+_TEMPORAL_FOLD_FIELDS = ("fold", "train_start", "train_end", "val_start", "val_end")
 
 
 def _to_date(x) -> date:
@@ -118,7 +131,10 @@ def _derive_modeling_splits(case_study: str, label: str) -> list[dict] | None:
             f"Found: {schema_names}. Canonical schema requires 'timestamp'."
         )
 
-    ts_df = pl.scan_parquet(label_path).select(date_col).unique().sort(date_col).collect()
+    ts_df = cast(
+        pl.DataFrame,
+        pl.scan_parquet(label_path).select(date_col).unique().sort(date_col).collect(),
+    )
     splits = generate_cv_splits(
         ts_df,
         case_study_id=case_study,
@@ -149,13 +165,100 @@ def modeling_fold_boundaries(case_study: str, label: str) -> list[dict] | None:
     return [
         {
             "fold": int(split["fold"]),
-            "train_start": _to_date(split["train_start"]),
-            "train_end": _to_date(split["train_end"]),
-            "val_start": _to_date(split["val_start"]),
-            "val_end": _to_date(split["val_end"]),
+            "train_start": split["train_start"],
+            "train_end": split["train_end"],
+            "val_start": split["val_start"],
+            "val_end": split["val_end"],
         }
         for split in splits
     ]
+
+
+def _validated_temporal_folds(raw_folds: Any, *, source: str) -> list[dict[str, Any]]:
+    if not isinstance(raw_folds, list) or not raw_folds:
+        raise ValueError(f"{source} has no temporal fold geometry")
+    folds: list[dict[str, Any]] = []
+    for raw in raw_folds:
+        if not isinstance(raw, dict) or any(field not in raw for field in _TEMPORAL_FOLD_FIELDS):
+            raise ValueError(f"{source} has invalid temporal fold geometry")
+        folds.append(
+            {
+                field: int(raw[field]) if field == "fold" else raw[field]
+                for field in _TEMPORAL_FOLD_FIELDS
+            }
+        )
+    if len({fold["fold"] for fold in folds}) != len(folds):
+        raise ValueError(f"{source} has duplicate temporal fold ids")
+    return folds
+
+
+def temporal_artifact_fold_boundaries(
+    case_study: str,
+    primary_label: str,
+    artifact_path: str | Path,
+) -> list[dict[str, Any]]:
+    """Load producer fold metadata or mirror the locked Stage 04 producer route."""
+    from case_studies.utils.artifact_digest import sidecar_path
+    from utils.artifact_specs import (
+        load_feature_spec,
+        load_label_spec,
+        resolve_label_buffer,
+        resolve_label_horizon,
+    )
+    from utils.cv_splits import generate_cv_splits
+
+    artifact_path = Path(artifact_path)
+    metadata_path = sidecar_path(artifact_path)
+    if metadata_path.is_file():
+        metadata = json.loads(metadata_path.read_text())
+        if "fold_geometry" in metadata:
+            return _validated_temporal_folds(
+                metadata["fold_geometry"],
+                source=str(metadata_path),
+            )
+
+    route = _LEGACY_TEMPORAL_FOLD_ROUTES.get(case_study)
+    if route is None:
+        raise ValueError(
+            f"no verified legacy temporal-fold resolver exists for case study {case_study!r}"
+        )
+    timeline_source, include_outcome_horizon = route
+    setup = _load_setup_yaml(case_study) or {}
+    label_buffer = resolve_label_buffer(case_study, primary_label, setup)
+    if not label_buffer:
+        raise ValueError(f"no label buffer configured for primary label {primary_label!r}")
+
+    if timeline_source == "financial":
+        timeline_spec = load_feature_spec(case_study, "financial")
+        fallback = "features/financial.parquet"
+    else:
+        timeline_spec = load_label_spec(case_study, primary_label)
+        fallback = f"labels/{primary_label}.parquet"
+    relative_path = str((timeline_spec or {}).get("storage", {}).get("path", fallback))
+    timeline_path = artifact_path.parent.parent / relative_path
+    if not timeline_path.is_file():
+        raise FileNotFoundError(timeline_path)
+
+    import polars as pl
+
+    schema = pl.scan_parquet(timeline_path).collect_schema()
+    date_col = "timestamp" if "timestamp" in schema else "date"
+    timeline = cast(
+        pl.DataFrame,
+        pl.scan_parquet(timeline_path).select(date_col).unique().collect(),
+    )
+    split_kwargs: dict[str, Any] = {
+        "case_study_id": case_study,
+        "label_buffer": label_buffer,
+        "date_col": date_col,
+    }
+    if include_outcome_horizon:
+        split_kwargs["outcome_horizon"] = resolve_label_horizon(case_study, primary_label, setup)
+    folds = generate_cv_splits(timeline, **split_kwargs)
+    return _validated_temporal_folds(
+        folds,
+        source=f"legacy Stage 04 route for {case_study}",
+    )
 
 
 def configured_labels(case_study: str) -> list[str]:

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -1641,13 +1641,15 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
                 config[field] = int(reductions[field])
     setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
     setup_gbm = (setup.get("modeling") or {}).get("gbm") or {}
-    device = str(request_fields.get("device", setup_gbm.get("device", "cpu"))).lower()
-    if device == "gpu":
-        device = "cuda"
-    max_bin = int(request_fields.get("max_bin", 63 if device == "cuda" else 255))
-    num_threads = int(request_fields.get("num_threads", DEFAULT_GBM_CPU_THREADS))
-    if device not in {"cpu", "cuda"} or max_bin < 2 or num_threads < 1:
-        raise ValueError("invalid GBM execution configuration")
+    execution_config = {
+        **setup_gbm,
+        **{
+            key: request_fields[key]
+            for key in ("device", "max_bin", "num_threads")
+            if key in request_fields
+        },
+    }
+    device, max_bin, num_threads = resolve_gbm_execution_config(execution_config)
     effective = _gbm_effective_params_by_fold(
         config,
         folds,

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -15,10 +15,19 @@ Usage:
 from __future__ import annotations
 
 import gc
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import subprocess
 import time
+import uuid
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # Import lightgbm before ml4t.diagnostic, which transitively loads
 # scikit-learn. Both scikit-learn and LightGBM ship their own OpenMP runtime
@@ -39,9 +48,48 @@ import polars as pl
 # torch first ensures its bundled CUDA runtime wins. Same pattern as in
 # `case_studies/utils/latent_factors/__init__.py` and `model_analysis.py`.
 import torch  # noqa: F401
+import yaml
 from ml4t.diagnostic.metrics import cross_sectional_ic
 
+from case_studies.research.cv import require_fold_scoped_temporal_compatibility
+from case_studies.research.identity import ResolvedSpec
+from case_studies.utils.artifact_digest import value_digest
 from utils.modeling import RANDOM_SEED, seed_everything
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+
+
+_GBM_PREVIEW_FIELDS = {
+    "checkpoint_interval",
+    "folds",
+    "max_iterations",
+    "max_symbols",
+    "train_sample_frac",
+}
+_GBM_REQUEST_FIELDS = {
+    "checkpoint_interval",
+    "device",
+    "huber_alpha_scale",
+    "max_bin",
+    "max_iterations",
+    "num_threads",
+}
+
+
+@dataclass(frozen=True)
+class GBMContext:
+    folds: tuple[dict[str, Any], ...]
+    feature_names: tuple[str, ...]
+    label_col: str
+    eval_label_col: str | None
+    date_col: str
+    entity_col: str
+    task_type: str
+    class_values: tuple[Any, ...]
+    expected_keys: pl.DataFrame
+    runtime_provenance: dict[str, Any]
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -199,9 +247,9 @@ def lightgbm_runtime_params(
     next to the portable training identity; they do not enter its hash.
     """
     normalized = device.lower()
+    if num_threads < 1:
+        raise ValueError("num_threads must be at least 1")
     if normalized == "cpu":
-        if num_threads < 1:
-            raise ValueError("num_threads must be at least 1")
         return {
             "device_type": "cpu",
             "deterministic": True,
@@ -222,7 +270,17 @@ def lightgbm_runtime_params(
                 "LightGBM CUDA was requested but is unavailable. "
                 "Use device='cpu' or install a CUDA-enabled LightGBM build."
             )
-        return {"device_type": gpu_device}
+        return {
+            "device_type": gpu_device,
+            "num_threads": int(num_threads),
+            "seed": int(seed),
+            "data_random_seed": int(seed),
+            "feature_fraction_seed": int(seed),
+            "bagging_seed": int(seed),
+            "drop_seed": int(seed),
+            "extra_seed": int(seed),
+            "objective_seed": int(seed),
+        }
     raise ValueError(f"Unsupported LightGBM device: {device!r}")
 
 
@@ -611,6 +669,9 @@ def prepare_gbm_folds(
         val_mask = (dates_series >= val_start) & (dates_series <= val_end)
 
         if has_fold_temporal:
+            assert temporal_by_fold is not None
+            assert temporal_keys is not None
+            assert temporal_feature_names is not None
             train_rows = replace_temporal_columns(
                 dataset_pd,
                 train_mask,
@@ -670,6 +731,7 @@ def prepare_gbm_folds(
 
         # Classification: remap labels to 0-indexed for LightGBM
         if is_classification:
+            assert class_values is not None
             y_train_lgb, _ = _remap_labels_for_lgb(y_train.astype(int), class_values)
             y_val_lgb, _ = _remap_labels_for_lgb(y_val.astype(int), class_values)
         else:
@@ -735,6 +797,23 @@ def _checkpoint_metrics_from_predictions(
             "ic_std": float(metric.get("ic_std", 0.0)),
         }
     return metrics
+
+
+def _learning_curves_from_predictions(
+    config_name: str,
+    predictions: list[dict[str, Any]],
+    checkpoints: list[int] | tuple[int, ...],
+) -> list[dict[str, Any]]:
+    metrics = _checkpoint_metrics_from_predictions(predictions, checkpoints)
+    return [
+        {
+            "config": config_name,
+            "iteration": checkpoint,
+            "ic_mean": metrics[checkpoint]["ic_mean"],
+            "ic_std": metrics[checkpoint]["ic_std"],
+        }
+        for checkpoint in checkpoints
+    ]
 
 
 def load_cached_gbm_config(
@@ -883,6 +962,7 @@ def train_gbm_config(
     task_type: str = "regression",
     class_values: list | None = None,
     save_dir: Path | None = None,
+    effective_params_by_fold: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Train a single GBM config across all CV folds.
 
@@ -927,20 +1007,33 @@ def train_gbm_config(
     is_classification = task_type == "classification" and class_values
 
     # Build LightGBM params from preset
-    params = dict(config["params"])
-    params["metric"] = "None"
-    params["verbosity"] = params.get("verbosity", -1)
+    base_params = dict(config["params"])
+    base_params["metric"] = "None"
+    base_params["verbosity"] = base_params.get("verbosity", -1)
 
     # Runtime settings are recorded as provenance by the caller. Numerical
     # model parameters such as max_bin are declared separately in the hashed
     # training spec and never inferred from this runtime backend.
-    params.update(lightgbm_runtime_params(device, num_threads=num_threads, seed=seed))
+    base_params.update(lightgbm_runtime_params(device, num_threads=num_threads, seed=seed))
     if max_bin is not None:
-        params["max_bin"] = max_bin
+        base_params["max_bin"] = max_bin
+    if (
+        base_params.get("objective") == "huber"
+        and "alpha" not in base_params
+        and effective_params_by_fold is None
+    ):
+        scale = config.get("huber_alpha_scale")
+        if scale is None:
+            raise ValueError("Huber GBM configs must declare huber_alpha_scale or alpha")
+        effective_params_by_fold = {}
+        for fold in fold_data:
+            params = dict(base_params)
+            params["alpha"] = _scaled_huber_alpha(float(scale), fold["y_train"])
+            effective_params_by_fold[str(int(fold["fold"]))] = params
 
     # Classification: ensure num_class for multiclass
     if is_classification and class_values and len(class_values) > 2:
-        params["num_class"] = len(class_values)
+        base_params["num_class"] = len(class_values)
 
     checkpoints = list(gbm_checkpoint_iterations(config))
 
@@ -955,6 +1048,12 @@ def train_gbm_config(
     for fd in fold_data:
         if fd["n_train"] == 0 or fd["n_val"] == 0:
             continue
+
+        params = (
+            dict(effective_params_by_fold[str(int(fd["fold"]))])
+            if effective_params_by_fold is not None
+            else dict(base_params)
+        )
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -999,7 +1098,8 @@ def train_gbm_config(
         for cp in checkpoints:
             raw_preds = model.predict(fd["X_val"], num_iteration=cp)
             if is_classification:
-                preds = _extract_gbm_score(raw_preds, class_values, len(fd["X_val"]))
+                assert class_values is not None
+                preds = _extract_gbm_score(np.asarray(raw_preds), class_values, len(fd["X_val"]))
             else:
                 preds = raw_preds
             ic_frame = pl.DataFrame(
@@ -1099,6 +1199,7 @@ def train_gbm_config(
         "predictions": all_preds,
         "fold_metrics": fold_metrics,
         "top_features": top_features,
+        "effective_params_by_fold": effective_params_by_fold,
     }
 
 
@@ -1291,3 +1392,562 @@ def register_gbm_result(
         fm_df.write_parquet(reg_dir / "fold_metrics.parquet")
 
     return t_hash
+
+
+def _gbm_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _gbm_source_identity() -> dict[str, str]:
+    from utils import modeling
+
+    assert modeling.__file__ is not None
+    paths = (Path(__file__), Path(modeling.__file__))
+    return {path.name: _gbm_sha256(path) for path in paths}
+
+
+def _gbm_runtime_identity() -> dict[str, str]:
+    return {
+        "lightgbm": importlib.metadata.version("lightgbm"),
+        "numpy": importlib.metadata.version("numpy"),
+    }
+
+
+def _gbm_runtime_provenance(study: Study, device: str) -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(study.release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = "unknown"
+    lock_path = study.release_root / "uv.lock"
+    record: dict[str, Any] = {
+        "device": device,
+        "entry_point": "case_studies.utils.gbm",
+        "lock_digest": _gbm_sha256(lock_path) if lock_path.is_file() else None,
+        "packages": _gbm_runtime_identity(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": commit,
+    }
+    if device == "cuda":
+        record["cuda_runtime"] = torch.version.cuda
+        record["gpu"] = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+    return record
+
+
+def _gbm_normalize_folds(splits: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+    return tuple(
+        {
+            key: int(split[key]) if key == "fold" else str(split[key])
+            for key in fields
+            if split.get(key) is not None
+        }
+        for split in splits
+    )
+
+
+def _gbm_select_splits(
+    mds,
+    request: dict[str, Any],
+    label_timeline: pl.DataFrame,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    cv = request.get("cv")
+    if cv is None:
+        splits = list(mds.splits)
+        normalized = _gbm_normalize_folds(splits)
+        cv_record = {
+            "request": {"source": "case_study_default"},
+            "folds": list(normalized),
+            "identity": value_digest(pl.DataFrame(list(normalized))),
+        }
+    else:
+        resolved = cv.resolve(label_timeline, date_col=mds.date_col)
+        splits = [dict(fold) for fold in resolved.normalized_folds]
+        cv_record = resolved.as_dict()
+    requested_folds = request["preview_reductions"].get("folds")
+    if requested_folds is not None:
+        selected = {int(fold) for fold in requested_folds}
+        splits = [split for split in splits if int(split["fold"]) in selected]
+        if {int(split["fold"]) for split in splits} != selected:
+            raise ValueError("preview fold reduction refers to an unavailable fold")
+        cv_record = {**cv_record, "preview_folds": sorted(selected)}
+    if not splits:
+        raise ValueError("GBM request resolved no cross-validation folds")
+    return splits, cv_record
+
+
+def _gbm_expected_keys(folds: list[dict[str, Any]], entity_col: str, date_col: str) -> pl.DataFrame:
+    frames = []
+    for fold in folds:
+        frame = pl.DataFrame(
+            {
+                "symbol": fold["entities"],
+                "timestamp": fold["dates"],
+                "fold": [int(fold["fold"])] * int(fold["n_val"]),
+            }
+        )
+        frames.append(frame)
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("GBM request produced duplicate expected prediction keys")
+    return expected
+
+
+def _validate_lightgbm_params(params: dict[str, Any]) -> None:
+    import lightgbm as lgb
+
+    aliases = lgb.basic._ConfigAliases  # noqa: SLF001
+    aliases.get("num_leaves")
+    valid = {alias for values in (aliases.aliases or {}).values() for alias in values}
+    unknown = set(params) - valid
+    if unknown:
+        raise ValueError(f"unsupported LightGBM parameters: {sorted(unknown)}")
+
+
+def _scaled_huber_alpha(scale: float, labels: np.ndarray) -> float:
+    """Resolve LightGBM's residual-unit Huber delta from one training fold."""
+    return max(scale * float(np.nanstd(labels)), float(np.finfo(np.float32).eps))
+
+
+def _gbm_effective_params_by_fold(
+    config: dict[str, Any],
+    folds: list[dict[str, Any]],
+    *,
+    device: str,
+    max_bin: int,
+    num_threads: int,
+    seed: int,
+    task_type: str = "regression",
+    class_values: list[Any] | tuple[Any, ...] = (),
+) -> dict[str, dict[str, Any]]:
+    base = dict(config["params"])
+    base["metric"] = "None"
+    base["verbosity"] = base.get("verbosity", -1)
+    base["max_bin"] = max_bin
+    base.update(lightgbm_runtime_params(device, num_threads=num_threads, seed=seed))
+    if task_type == "classification" and len(class_values) > 2:
+        base["num_class"] = len(class_values)
+    scale = config.get("huber_alpha_scale")
+    if base.get("objective") == "huber" and "alpha" not in base and scale is None:
+        raise ValueError("Huber GBM configs must declare huber_alpha_scale or alpha")
+    effective = {}
+    for fold in folds:
+        params = dict(base)
+        if params.get("objective") == "huber" and "alpha" not in params:
+            assert scale is not None
+            params["alpha"] = _scaled_huber_alpha(float(scale), fold["y_train"])
+        _validate_lightgbm_params(params)
+        effective[str(int(fold["fold"]))] = params
+    return effective
+
+
+def _load_gbm_request_config(
+    study: Study,
+    label: str,
+    config_name: str,
+    overrides: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    from utils.modeling import load_configs
+
+    configs = load_configs(study.case_study, label, family="gbm")
+    matches = [config for config in configs if config["config_name"] == config_name]
+    if len(matches) != 1:
+        raise ValueError(f"unknown GBM config {config_name!r}")
+    config = {**matches[0], "params": dict(matches[0]["params"])}
+    request_fields = {key: value for key, value in overrides.items() if key in _GBM_REQUEST_FIELDS}
+    config.update(
+        {
+            key: value
+            for key, value in request_fields.items()
+            if key in {"checkpoint_interval", "huber_alpha_scale", "max_iterations"}
+        }
+    )
+    config["params"].update(
+        {key: value for key, value in overrides.items() if key not in _GBM_REQUEST_FIELDS}
+    )
+    return config, request_fields
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    from case_studies.research.contracts import ExecutionTier
+    from utils.modeling import load_modeling_dataset
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _GBM_PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported GBM preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
+    max_symbols = int(reductions.get("max_symbols", 0))
+    train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
+    if not 0 < train_sample_frac <= 1:
+        raise ValueError("train_sample_frac must be in (0, 1]")
+    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("GBM runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+    if entity_col not in {"product", "symbol"}:
+        raise ValueError(f"GBM runner does not support entity key {entity_col!r}")
+    splits, cv_record = _gbm_select_splits(
+        mds,
+        request,
+        label_ref.load().select(mds.date_col).unique(),
+    )
+    if (
+        request.get("cv") is not None
+        and mds.temporal_by_fold is not None
+        and mds.temporal_keys
+        and mds.temporal_feature_names
+    ):
+        require_fold_scoped_temporal_compatibility(splits, mds.temporal_artifact_splits)
+    folds = prepare_gbm_folds(
+        mds.dataset.to_pandas(),
+        splits,
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        entity_col,
+        task_type=mds.task_type,
+        class_values=mds.class_values,
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=train_sample_frac,
+        eval_label_col=mds.eval_label_col,
+        seed=RANDOM_SEED,
+    )
+    if len(folds) != len(splits) or any(not fold["n_train"] or not fold["n_val"] for fold in folds):
+        raise ValueError("GBM request did not prepare every declared fold")
+    config, request_fields = _load_gbm_request_config(
+        study,
+        label_ref.name,
+        request["config_name"],
+        request["overrides"],
+    )
+    if tier is ExecutionTier.PREVIEW:
+        for field in ("max_iterations", "checkpoint_interval"):
+            if field in reductions:
+                config[field] = int(reductions[field])
+    setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
+    setup_gbm = (setup.get("modeling") or {}).get("gbm") or {}
+    device = str(request_fields.get("device", setup_gbm.get("device", "cpu"))).lower()
+    if device == "gpu":
+        device = "cuda"
+    max_bin = int(request_fields.get("max_bin", 63 if device == "cuda" else 255))
+    num_threads = int(request_fields.get("num_threads", DEFAULT_GBM_CPU_THREADS))
+    if device not in {"cpu", "cuda"} or max_bin < 2 or num_threads < 1:
+        raise ValueError("invalid GBM execution configuration")
+    effective = _gbm_effective_params_by_fold(
+        config,
+        folds,
+        device=device,
+        max_bin=max_bin,
+        num_threads=num_threads,
+        seed=RANDOM_SEED,
+        task_type=mds.task_type,
+        class_values=mds.class_values,
+    )
+    checkpoints = gbm_checkpoint_iterations(config)
+    expected = _gbm_expected_keys(folds, entity_col, mds.date_col)
+    input_lineage = mds.input_lineage
+    computation = {
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": input_lineage["artifacts"],
+        "feature_names": list(mds.feature_names),
+        "task": {
+            "type": mds.task_type,
+            "class_values": list(mds.class_values),
+            "continuous_eval_label": label_ref.definition.continuous_eval_label,
+        },
+        "cv": cv_record,
+        "model": {
+            "class": "lightgbm.Booster",
+            "implementation": "lightgbm",
+            "effective_params_by_fold": effective,
+            "huber_alpha_scale": config.get("huber_alpha_scale"),
+            "max_iterations": int(config["max_iterations"]),
+        },
+        "checkpoint_schedule": [
+            {"kind": "iteration", "value": checkpoint} for checkpoint in checkpoints
+        ],
+        "expected_prediction_keys": {
+            "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+            "n_rows": expected.height,
+            "n_folds": expected.get_column("fold").n_unique(),
+        },
+        "input_data_spec": input_lineage,
+        "sampling": {"train_sample_frac": train_sample_frac, "max_symbols": max_symbols},
+        "source_identity": _gbm_source_identity(),
+        "runtime_identity": _gbm_runtime_identity(),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        computation["preview_reductions"] = reductions
+    runtime_provenance = _gbm_runtime_provenance(study, device)
+    spec = ResolvedSpec.create(
+        family="gbm",
+        label=label_ref.name,
+        seed=RANDOM_SEED,
+        computation=computation,
+        provenance=runtime_provenance,
+        config_name=request["config_name"],
+        execution_tier=tier.value,
+    ).as_dict()
+    context = GBMContext(
+        folds=tuple(folds),
+        feature_names=tuple(mds.feature_names),
+        label_col=mds.label_col,
+        eval_label_col=mds.eval_label_col,
+        date_col=mds.date_col,
+        entity_col=entity_col,
+        task_type=mds.task_type,
+        class_values=tuple(mds.class_values),
+        expected_keys=expected,
+        runtime_provenance=runtime_provenance,
+    )
+    return spec, context
+
+
+def _gbm_manifest_files(model_dir: Path) -> dict[str, str]:
+    manifest = model_dir / "manifest.json"
+    if not manifest.is_file():
+        return {}
+    record = json.loads(manifest.read_text())
+    return dict(record.get("files") or {})
+
+
+def _valid_gbm_model_dir(model_dir: Path, context: GBMContext) -> bool:
+    files = _gbm_manifest_files(model_dir)
+    expected = {f"boosters/fold_{int(fold['fold'])}.txt" for fold in context.folds}
+    return set(files) == expected and all(
+        (model_dir / name).is_file() and _gbm_sha256(model_dir / name) == digest
+        for name, digest in files.items()
+    )
+
+
+def _valid_learning_curves(path: Path, spec: dict[str, Any]) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        curves = pl.read_parquet(path)
+    except (OSError, pl.exceptions.PolarsError):
+        return False
+    required = {"config", "iteration", "ic_mean", "ic_std"}
+    expected = {
+        int(checkpoint["value"]) for checkpoint in spec["computation"]["checkpoint_schedule"]
+    }
+    return required <= set(curves.columns) and set(curves["iteration"].to_list()) == expected
+
+
+def _cached_model_run(study: Study, spec: dict[str, Any], context: GBMContext):
+    from case_studies.research.models import ModelRun
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+    from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+
+    include_preview = spec["execution_tier"] == "preview"
+    training_hash = training_hash_from_spec(spec)
+    try:
+        training = Result.open(study, training_hash, include_preview=include_preview)
+        predictions = tuple(
+            Result.open(
+                study,
+                prediction_hash_from_parts(
+                    training_hash,
+                    checkpoint["value"],
+                    "validation",
+                    checkpoint_kind="iteration",
+                    identity_version=spec["identity_version"],
+                ),
+                include_preview=include_preview,
+            )
+            for checkpoint in spec["computation"]["checkpoint_schedule"]
+        )
+    except KeyError:
+        return None
+    if not isinstance(training, TrainingResult) or any(
+        not isinstance(result, PredictionResult) or not result.complete for result in predictions
+    ):
+        return None
+    prediction_results = tuple(
+        result for result in predictions if isinstance(result, PredictionResult)
+    )
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    curves_path = training.root / "run_log" / "training" / training.hash / "learning_curves.parquet"
+    if not _valid_gbm_model_dir(model_dir, context) or not _valid_learning_curves(
+        curves_path, spec
+    ):
+        return None
+    return ModelRun(training=training, predictions=prediction_results)
+
+
+def _gbm_prediction_frame(
+    entries: list[dict[str, Any]], checkpoint: int, context: GBMContext
+) -> pl.DataFrame:
+    frames = []
+    for entry in entries:
+        if int(entry["n_trees"]) != checkpoint:
+            continue
+        frame = pl.DataFrame(
+            {
+                "symbol": entry["entities"],
+                "timestamp": entry["dates"],
+                "fold": [int(entry["fold"])] * len(entry["y_pred"]),
+                "prediction": entry["y_pred"],
+                "actual": entry["y_true"],
+            }
+        )
+        if entry.get("y_eval") is not None:
+            frame = frame.with_columns(pl.Series("eval_actual", entry["y_eval"]))
+        frames.append(frame)
+    if len(frames) != len(context.folds):
+        raise ValueError(f"GBM checkpoint {checkpoint} is missing a declared fold")
+    return pl.concat(frames).sort("symbol", "timestamp", "fold")
+
+
+def _write_gbm_manifest(staging: Path, folds: tuple[dict[str, Any], ...]) -> None:
+    expected = [staging / "boosters" / f"fold_{int(fold['fold'])}.txt" for fold in folds]
+    missing = [path for path in expected if not path.is_file()]
+    if missing:
+        raise ValueError(f"GBM fit did not persist every fold booster: {missing}")
+    files = {str(path.relative_to(staging)): _gbm_sha256(path) for path in expected}
+    (staging / "manifest.json").write_text(
+        json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _predict_from_gbm_models(
+    model_dir: Path,
+    spec: dict[str, Any],
+    context: GBMContext,
+) -> dict[str, Any]:
+    import lightgbm as lgb
+
+    predictions = []
+    is_classification = context.task_type == "classification" and context.class_values
+    for fold in context.folds:
+        model = lgb.Booster(model_file=str(model_dir / "boosters" / f"fold_{fold['fold']}.txt"))
+        for checkpoint in spec["computation"]["checkpoint_schedule"]:
+            value = int(checkpoint["value"])
+            raw = np.asarray(model.predict(fold["X_val"], num_iteration=value))
+            score = (
+                _extract_gbm_score(raw, list(context.class_values), len(fold["X_val"]))
+                if is_classification
+                else raw
+            )
+            predictions.append(
+                {
+                    "dates": fold["dates"],
+                    "entities": fold["entities"],
+                    "y_true": fold["y_val"],
+                    "y_eval": fold.get("y_eval"),
+                    "y_pred": score,
+                    "fold": fold["fold"],
+                    "n_trees": value,
+                }
+            )
+    checkpoints = [
+        int(checkpoint["value"]) for checkpoint in spec["computation"]["checkpoint_schedule"]
+    ]
+    return {
+        "learning_curves": _learning_curves_from_predictions(
+            spec["config_name"],
+            predictions,
+            checkpoints,
+        ),
+        "predictions": predictions,
+    }
+
+
+def _write_learning_curves(path: Path, rows: list[dict[str, Any]]) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        pl.DataFrame(rows).write_parquet(temporary)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def run_resolved_request(study: Study, spec: dict[str, Any], context: GBMContext):
+    from case_studies.research.models import ModelRun
+
+    cached = _cached_model_run(study, spec, context)
+    if cached is not None:
+        return cached
+    started = time.perf_counter()
+    computation = spec["computation"]
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    train_dir = training.root / "run_log" / "training" / training.hash
+    model_dir = train_dir / "models"
+    if model_dir.exists():
+        if not _valid_gbm_model_dir(model_dir, context):
+            raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+        result = _predict_from_gbm_models(model_dir, spec, context)
+    else:
+        staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+        staging.mkdir(parents=True)
+        try:
+            result = train_gbm_config(
+                {
+                    "config_name": spec["config_name"],
+                    "max_iterations": computation["model"]["max_iterations"],
+                    "checkpoint_interval": computation["checkpoint_schedule"][0]["value"],
+                    "params": {},
+                },
+                list(context.folds),
+                feature_names=list(context.feature_names),
+                device="cpu",
+                entity_col=context.entity_col,
+                date_col=context.date_col,
+                task_type=context.task_type,
+                class_values=list(context.class_values) or None,
+                save_dir=staging,
+                effective_params_by_fold=computation["model"]["effective_params_by_fold"],
+            )
+            _write_gbm_manifest(staging, context.folds)
+            os.replace(staging, model_dir)
+        except Exception:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+    prediction_results = []
+    for checkpoint in computation["checkpoint_schedule"]:
+        value = int(checkpoint["value"])
+        frame = _gbm_prediction_frame(result["predictions"], value, context)
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="iteration",
+                checkpoint_value=value,
+                split="validation",
+                predictions=frame,
+                expected_keys=context.expected_keys,
+                task_type=context.task_type,
+                class_values=list(context.class_values) or None,
+                eval_col="eval_actual" if context.eval_label_col else None,
+                label=spec["label"],
+            )
+        )
+    curves_path = train_dir / "learning_curves.parquet"
+    if not curves_path.exists() and result["learning_curves"]:
+        _write_learning_curves(curves_path, result["learning_curves"])
+    runtime_path = train_dir / "runtime.json"
+    if runtime_path.exists():
+        runtime = json.loads(runtime_path.read_text())
+        runtime["elapsed_s"] = time.perf_counter() - started
+        temporary = runtime_path.with_name(f".{runtime_path.name}.{uuid.uuid4().hex}.tmp")
+        temporary.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, runtime_path)
+    return ModelRun(training=training, predictions=tuple(prediction_results))

--- a/case_studies/utils/latent_factors/__init__.py
+++ b/case_studies/utils/latent_factors/__init__.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 # torch first ensures its bundled cudart wins the resolution.
 import torch  # noqa: F401
 
+from case_studies.utils.latent_factors.adapter import (
+    LatentFactorContext,
+    resolve_model_request,
+    run_resolved_request,
+)
 from case_studies.utils.latent_factors.cae import run_cae_fold
 from case_studies.utils.latent_factors.cv import load_fold_extras, run_latent_factor_cv
 from case_studies.utils.latent_factors.ipca import run_ipca_fold
@@ -29,6 +34,7 @@ EXPENSIVE_MODELS = frozenset({"sdf", "cae", "sae"})
 
 __all__ = [
     "EXPENSIVE_MODELS",
+    "LatentFactorContext",
     "compute_managed_portfolios",
     "load_fold_extras",
     "prepare_panel_data",
@@ -40,4 +46,6 @@ __all__ = [
     "run_pca_fold",
     "run_sae_fold",
     "run_sdf_fold",
+    "resolve_model_request",
+    "run_resolved_request",
 ]

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -50,6 +50,13 @@ _PREVIEW_FIELDS = {
     "n_epochs_unc",
     "n_factors",
 }
+_MODEL_PREVIEW_FIELDS = {
+    "cae": {"folds", "max_symbols", "n_epochs", "n_factors"},
+    "ipca": {"folds", "max_iter", "max_symbols", "n_factors"},
+    "pca": {"folds", "max_symbols", "n_factors"},
+    "sae": {"folds", "max_symbols", "n_epochs"},
+    "sdf": {"folds", "max_symbols", "n_epochs_cond", "n_epochs_moment", "n_epochs_unc"},
+}
 _INTERFACE_FIELDS = {
     "deterministic_algorithms",
     "device",
@@ -209,6 +216,11 @@ def _resolve_model_configuration(
     overrides: dict[str, Any],
     reductions: dict[str, Any],
 ) -> tuple[dict[str, Any], int, int, int, dict[str, int]]:
+    unsupported_reductions = set(reductions) - _MODEL_PREVIEW_FIELDS[model_name]
+    if unsupported_reductions:
+        raise ValueError(
+            f"unsupported {model_name} preview reductions: {sorted(unsupported_reductions)}"
+        )
     interface = {key: value for key, value in overrides.items() if key in _INTERFACE_FIELDS}
     model_kwargs = dict(case.model_kwargs.get(model_name) or {})
     model_kwargs.update(

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -435,7 +435,6 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         model_name,
         n_epochs=n_epochs,
         model_kwargs=model_kwargs,
-        include_internal_aliases=True,
     )
     expected = _prepare_expected_keys(case, model_name)
     macro_context = None

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -1,0 +1,838 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import inspect
+import json
+import os
+import platform
+import shutil
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import polars as pl
+import torch
+
+from case_studies.research.cv import require_fold_scoped_temporal_compatibility
+from case_studies.research.identity import ResolvedSpec
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.latent_factors.cv import (
+    _build_prediction_frame,
+    _expected_latent_checkpoints,
+    _prepare_fold_inputs,
+    _save_fold_extras,
+    run_latent_factor_cv,
+)
+from case_studies.utils.latent_factors.library_bridge import (
+    predict_latent_fold_from_artifact,
+)
+from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+from utils.modeling import RANDOM_SEED
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+    from case_studies.utils.latent_factors.case_study import LatentFactorCaseStudyContext
+
+
+_LATENT_MODELS = {"cae", "ipca", "pca", "sae", "sdf"}
+_PREVIEW_FIELDS = {
+    "folds",
+    "max_iter",
+    "max_symbols",
+    "n_epochs",
+    "n_epochs_cond",
+    "n_epochs_moment",
+    "n_epochs_unc",
+    "n_factors",
+}
+_INTERFACE_FIELDS = {
+    "deterministic_algorithms",
+    "device",
+    "fold_workers",
+    "n_epochs",
+    "n_factors",
+    "num_threads",
+    "use_macro",
+}
+
+
+@dataclass(frozen=True)
+class LatentFactorContext:
+    case: LatentFactorCaseStudyContext
+    model_name: str
+    model_kwargs: dict[str, Any]
+    n_factors: int
+    n_epochs: int
+    fold_workers: int
+    expected_keys: pl.DataFrame
+    runtime_provenance: dict[str, Any]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).parent
+    release_root = root.parents[2]
+    files = [
+        root / "adapter.py",
+        root / "cae.py",
+        root / "case_study.py",
+        root / "common.py",
+        root / "cv.py",
+        root / "ipca.py",
+        root / "library_bridge.py",
+        root / "macro_context.py",
+        root / "panel.py",
+        root / "pca.py",
+        root / "sae.py",
+        root / "sdf.py",
+        release_root / "utils" / "artifact_specs.py",
+        release_root / "utils" / "modeling.py",
+    ]
+    return {path.relative_to(release_root).as_posix(): _sha256(path) for path in files}
+
+
+def _runtime_identity() -> dict[str, str | None]:
+    return {
+        "ml4t-models": _package_version("ml4t-models"),
+        "numpy": _package_version("numpy"),
+        "polars": _package_version("polars"),
+        "torch": _package_version("torch"),
+    }
+
+
+def _runtime_provenance(study: Study, device: str) -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(study.release_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = "unknown"
+    lock_path = study.release_root / "uv.lock"
+    record: dict[str, Any] = {
+        "device": device,
+        "entry_point": "case_studies.utils.latent_factors",
+        "lock_digest": _sha256(lock_path) if lock_path.is_file() else None,
+        "packages": _runtime_identity(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": commit,
+    }
+    if device == "cuda":
+        record["cuda_runtime"] = torch.version.cuda
+        record["gpu"] = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+    return record
+
+
+def _normalize_folds(splits: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    fields = ("fold", "train_start", "train_end", "val_start", "val_end")
+    return tuple(
+        {
+            key: int(split[key]) if key == "fold" else str(split[key])
+            for key in fields
+            if split.get(key) is not None
+        }
+        for split in splits
+    )
+
+
+def _select_splits(
+    case: LatentFactorCaseStudyContext,
+    request: dict[str, Any],
+    label_timeline: pl.DataFrame,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    cv = request.get("cv")
+    if cv is None:
+        splits = list(case.splits)
+        normalized = _normalize_folds(splits)
+        cv_record = {
+            "request": {"source": "case_study_default"},
+            "folds": list(normalized),
+            "identity": value_digest(pl.DataFrame(list(normalized))),
+        }
+    else:
+        resolved = cv.resolve(label_timeline, date_col=case.date_col)
+        splits = [dict(fold) for fold in resolved.normalized_folds]
+        cv_record = resolved.as_dict()
+    requested_folds = request["preview_reductions"].get("folds")
+    if requested_folds is not None:
+        selected = {int(fold) for fold in requested_folds}
+        splits = [split for split in splits if int(split["fold"]) in selected]
+        if {int(split["fold"]) for split in splits} != selected:
+            raise ValueError("preview fold reduction refers to an unavailable fold")
+        cv_record = {**cv_record, "preview_folds": sorted(selected)}
+    if not splits:
+        raise ValueError("latent-factor request resolved no cross-validation folds")
+    return splits, cv_record
+
+
+def _model_runner(model_name: str):
+    from case_studies.utils.latent_factors.cae import run_cae_fold
+    from case_studies.utils.latent_factors.ipca import run_ipca_fold
+    from case_studies.utils.latent_factors.pca import run_pca_fold
+    from case_studies.utils.latent_factors.sae import run_sae_fold
+    from case_studies.utils.latent_factors.sdf import run_sdf_fold
+
+    return {
+        "cae": run_cae_fold,
+        "ipca": run_ipca_fold,
+        "pca": run_pca_fold,
+        "sae": run_sae_fold,
+        "sdf": run_sdf_fold,
+    }[model_name]
+
+
+def _resolve_model_configuration(
+    case: LatentFactorCaseStudyContext,
+    model_name: str,
+    overrides: dict[str, Any],
+    reductions: dict[str, Any],
+) -> tuple[dict[str, Any], int, int, int, dict[str, int]]:
+    interface = {key: value for key, value in overrides.items() if key in _INTERFACE_FIELDS}
+    model_kwargs = dict(case.model_kwargs.get(model_name) or {})
+    model_kwargs.update(
+        {key: value for key, value in overrides.items() if key not in _INTERFACE_FIELDS}
+    )
+
+    n_factors = int(interface.get("n_factors", model_kwargs.pop("n_factors", 5)))
+    n_epochs = int(interface.get("n_epochs", model_kwargs.pop("n_epochs", 0)))
+    checkpoint_metadata: dict[str, int] = {}
+    if model_name in {"pca", "ipca"}:
+        checkpoint_interval = int(model_kwargs.pop("checkpoint_interval", 0))
+        if checkpoint_interval != 0:
+            raise ValueError(f"{model_name} checkpoint_interval must be 0")
+        checkpoint_metadata["checkpoint_interval"] = checkpoint_interval
+    if "n_factors" in reductions:
+        n_factors = int(reductions["n_factors"])
+    if "n_epochs" in reductions:
+        n_epochs = int(reductions["n_epochs"])
+    for field in ("max_iter", "n_epochs_cond", "n_epochs_moment", "n_epochs_unc"):
+        if field in reductions:
+            model_kwargs[field] = int(reductions[field])
+    if model_name == "sdf" and reductions:
+        reduced_budget = max(
+            int(model_kwargs.get("n_epochs_unc", 256)),
+            int(model_kwargs.get("n_epochs_cond", 1024)),
+        )
+        configured = model_kwargs.get("checkpoint_epochs")
+        if configured is not None:
+            compatible = sorted(
+                {int(epoch) for epoch in configured if 1 <= int(epoch) <= reduced_budget}
+            )
+            if reduced_budget not in compatible:
+                compatible.append(reduced_budget)
+            model_kwargs["checkpoint_epochs"] = compatible
+    if model_name == "sdf" and model_kwargs.get("expected_return_mapper", "linear") != "linear":
+        raise ValueError("SDF expected_return_mapper currently supports only 'linear'")
+    if n_factors < 1 or n_epochs < 0:
+        raise ValueError("latent-factor n_factors must be positive and n_epochs non-negative")
+
+    runner = _model_runner(model_name)
+    positional = {"chars_train", "returns_train", "chars_val", "returns_val"}
+    allowed = (
+        set(inspect.signature(runner).parameters)
+        - positional
+        - {
+            "artifact_dir",
+            "log_fn",
+            "n_factors",
+            "n_epochs",
+        }
+    )
+    unknown = set(model_kwargs) - allowed
+    if unknown:
+        raise ValueError(f"unsupported {model_name} parameters: {sorted(unknown)}")
+    fold_workers = int(interface.get("fold_workers", 1))
+    if fold_workers < 1 or (fold_workers > 1 and model_name != "ipca"):
+        raise ValueError("parallel latent folds are supported only for IPCA")
+    return model_kwargs, n_factors, n_epochs, fold_workers, checkpoint_metadata
+
+
+def _resolved_macro_digest(case: LatentFactorCaseStudyContext) -> str:
+    digest = hashlib.sha256()
+    resolved = 0
+    for split in case.splits:
+        fold_inputs = _prepare_fold_inputs(
+            dataset=case.dataset,
+            split=split,
+            feature_names=case.feature_names,
+            label_col=case.primary_label,
+            date_col=case.date_col,
+            entity_col=case.entity_col,
+            eval_label_col=case.eval_label_col,
+            macro_panel=case.macro_panel,
+            need_pca_inputs=False,
+            need_ragged_inputs=True,
+            temporal_by_fold=case.temporal_by_fold,
+            temporal_keys=case.temporal_keys,
+            temporal_feature_names=case.temporal_feature_names,
+        )
+        if fold_inputs is None:
+            raise ValueError(f"latent fold {split['fold']} has insufficient eligible periods")
+        model_input = fold_inputs["ragged"]
+        for segment in ("macro_train", "macro_val"):
+            values = model_input[segment]
+            if values is None:
+                raise ValueError("SDF request resolved no macro values")
+            array = np.ascontiguousarray(values)
+            metadata = json.dumps(
+                {
+                    "dtype": array.dtype.str,
+                    "fold": int(split["fold"]),
+                    "segment": segment,
+                    "shape": array.shape,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            digest.update(metadata.encode())
+            digest.update(array.tobytes())
+            resolved += array.size
+    if resolved == 0:
+        raise ValueError("SDF request resolved an empty macro surface")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _prepare_expected_keys(
+    case: LatentFactorCaseStudyContext,
+    model_name: str,
+) -> pl.DataFrame:
+    frames = []
+    for split in case.splits:
+        fold_inputs = _prepare_fold_inputs(
+            dataset=case.dataset,
+            split=split,
+            feature_names=case.feature_names,
+            label_col=case.primary_label,
+            date_col=case.date_col,
+            entity_col=case.entity_col,
+            eval_label_col=case.eval_label_col,
+            macro_panel=case.macro_panel,
+            need_pca_inputs=model_name == "pca",
+            need_ragged_inputs=model_name != "pca",
+            temporal_by_fold=case.temporal_by_fold,
+            temporal_keys=case.temporal_keys,
+            temporal_feature_names=case.temporal_feature_names,
+        )
+        if fold_inputs is None:
+            raise ValueError(f"latent fold {split['fold']} has insufficient eligible periods")
+        model_input = fold_inputs["pca"] if model_name == "pca" else fold_inputs["ragged"]
+        finite = np.isfinite(model_input["returns_val"])
+        if model_input.get("eval_returns_val") is not None:
+            finite &= np.isfinite(model_input["eval_returns_val"])
+        dummy = np.where(finite, 0.0, np.nan)
+        frame = _build_prediction_frame(
+            predictions=dummy,
+            returns_val=model_input["returns_val"],
+            eval_returns_val=model_input.get("eval_returns_val"),
+            val_dates=model_input["val_dates"],
+            val_entities=model_input["val_entities"],
+            fold_id=int(split["fold"]),
+            model_name=model_name,
+            epoch=0,
+        )
+        if frame is None:
+            raise ValueError(f"latent fold {split['fold']} has no eligible validation keys")
+        frames.append(frame.select("symbol", "timestamp", pl.col("fold_id").alias("fold")))
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("latent-factor request produced duplicate expected prediction keys")
+    return expected
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    from case_studies.research.contracts import ExecutionTier
+    from case_studies.utils.latent_factors.case_study import load_case_study_context
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(
+            f"unsupported latent-factor preview reductions: {sorted(unknown_reductions)}"
+        )
+    model_name = request["config_name"]
+    if model_name not in _LATENT_MODELS:
+        raise ValueError(f"unknown latent-factor config {model_name!r}")
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
+    max_symbols = int(reductions.get("max_symbols", 0))
+    interface = {
+        key: value for key, value in request["overrides"].items() if key in _INTERFACE_FIELDS
+    }
+    use_macro = bool(interface.get("use_macro", model_name == "sdf"))
+    if model_name != "sdf" and use_macro:
+        raise ValueError("only SDF accepts macro context")
+    case = load_case_study_context(
+        study.case_study,
+        primary_label=label_ref.name,
+        max_symbols=max_symbols,
+        use_macro=use_macro,
+    )
+    if case.date_col != "timestamp" or case.entity_col not in {"product", "symbol"}:
+        raise ValueError("latent-factor runner requires timestamp and symbol or product")
+    if model_name == "pca" and not case.persistent_entities:
+        raise ValueError("PCA requires persistent entity IDs")
+    splits, cv_record = _select_splits(
+        case,
+        request,
+        label_ref.load().select(case.date_col).unique(),
+    )
+    if (
+        request.get("cv") is not None
+        and case.temporal_by_fold is not None
+        and case.temporal_keys
+        and case.temporal_feature_names
+    ):
+        require_fold_scoped_temporal_compatibility(splits, case.temporal_artifact_splits)
+    case.splits = splits
+    (
+        model_kwargs,
+        n_factors,
+        n_epochs,
+        fold_workers,
+        checkpoint_metadata,
+    ) = _resolve_model_configuration(
+        case,
+        model_name,
+        request["overrides"],
+        reductions,
+    )
+    device = str(interface.get("device", case.device)).lower()
+    if device == "gpu":
+        device = "cuda"
+    num_threads = int(interface.get("num_threads", case.num_threads))
+    deterministic = bool(interface.get("deterministic_algorithms", case.deterministic_algorithms))
+    if device not in {"cpu", "cuda"} or num_threads < 1:
+        raise ValueError("invalid latent-factor runtime configuration")
+    case.device = device
+    case.num_threads = num_threads
+    case.deterministic_algorithms = deterministic
+
+    checkpoints = _expected_latent_checkpoints(
+        model_name,
+        n_epochs=n_epochs,
+        model_kwargs=model_kwargs,
+        include_internal_aliases=True,
+    )
+    expected = _prepare_expected_keys(case, model_name)
+    macro_context = None
+    if model_name == "sdf":
+        macro_context = dict(case.macro_context_spec or {"policy": "unspecified", "version": "v1"})
+        if case.macro_panel is not None:
+            macro_context["resolved_fold_digest"] = _resolved_macro_digest(case)
+    input_lineage = case.input_data_spec
+    computation = {
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": input_lineage["files"],
+        "feature_names": list(case.feature_names),
+        "task": {
+            "type": case.task_type,
+            "class_values": list(case.class_values),
+            "continuous_eval_label": label_ref.definition.continuous_eval_label,
+        },
+        "cv": cv_record,
+        "model": {
+            "class": model_name,
+            "implementation": "ml4t-models",
+            "n_epochs": n_epochs,
+            "n_factors": n_factors,
+            "params": model_kwargs,
+            **checkpoint_metadata,
+        },
+        "checkpoint_schedule": [
+            {"kind": "epoch", "value": checkpoint} for checkpoint in checkpoints
+        ],
+        "expected_prediction_keys": {
+            "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+            "n_rows": expected.height,
+            "n_folds": expected.get_column("fold").n_unique(),
+        },
+        "input_data_spec": input_lineage,
+        "macro_context": macro_context,
+        "runtime": {
+            "deterministic_algorithms": deterministic,
+            "device": device,
+            "fold_workers": fold_workers,
+            "num_threads": num_threads,
+        },
+        "numerical_runtime": {
+            "deterministic_algorithms": deterministic,
+            "device": device,
+            "fold_workers": fold_workers,
+            "num_threads": num_threads,
+        },
+        "sampling": {"max_symbols": max_symbols},
+        "source_identity": _source_identity(),
+        "runtime_identity": _runtime_identity(),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        computation["preview_reductions"] = reductions
+    runtime_provenance = _runtime_provenance(study, device)
+    spec = ResolvedSpec.create(
+        family="latent_factors",
+        label=label_ref.name,
+        seed=RANDOM_SEED,
+        computation=computation,
+        provenance=runtime_provenance,
+        config_name=model_name,
+        execution_tier=tier.value,
+    ).as_dict()
+    context = LatentFactorContext(
+        case=case,
+        model_name=model_name,
+        model_kwargs=model_kwargs,
+        n_factors=n_factors,
+        n_epochs=n_epochs,
+        fold_workers=fold_workers,
+        expected_keys=expected,
+        runtime_provenance=runtime_provenance,
+    )
+    return spec, context
+
+
+def _manifest_files(model_dir: Path) -> dict[str, str]:
+    path = model_dir / "manifest.json"
+    if not path.is_file():
+        return {}
+    return dict(json.loads(path.read_text()).get("files") or {})
+
+
+def _valid_model_dir(model_dir: Path, context: LatentFactorContext) -> bool:
+    files = _manifest_files(model_dir)
+    expected_models = {
+        f"{context.model_name}/artifacts/fold_{int(split['fold'])}/model.ml4t"
+        for split in context.case.splits
+    }
+    return (
+        bool(files)
+        and expected_models <= set(files)
+        and all(
+            (model_dir / name).is_file() and _sha256(model_dir / name) == digest
+            for name, digest in files.items()
+        )
+    )
+
+
+def _normalize_prediction_frame(frame: pl.DataFrame) -> pl.DataFrame:
+    rename = {
+        old: new
+        for old, new in {
+            "fold_id": "fold",
+            "y_score": "prediction",
+            "y_true": "actual",
+        }.items()
+        if old in frame.columns
+    }
+    columns = ["symbol", "timestamp", "fold", "prediction", "actual"]
+    normalized = frame.rename(rename)
+    if "eval_actual" in normalized.columns:
+        columns.append("eval_actual")
+    return normalized.select(columns).sort("symbol", "timestamp", "fold")
+
+
+def _reconstruct_predictions(
+    model_dir: Path,
+    context: LatentFactorContext,
+) -> dict[int, pl.DataFrame]:
+    case = context.case
+    frames: dict[int, list[pl.DataFrame]] = {
+        int(checkpoint): []
+        for checkpoint in _expected_latent_checkpoints(
+            context.model_name,
+            n_epochs=context.n_epochs,
+            model_kwargs=context.model_kwargs,
+            include_internal_aliases=True,
+        )
+    }
+    for split in case.splits:
+        fold_inputs = _prepare_fold_inputs(
+            dataset=case.dataset,
+            split=split,
+            feature_names=case.feature_names,
+            label_col=case.primary_label,
+            date_col=case.date_col,
+            entity_col=case.entity_col,
+            eval_label_col=case.eval_label_col,
+            macro_panel=case.macro_panel,
+            need_pca_inputs=context.model_name == "pca",
+            need_ragged_inputs=context.model_name != "pca",
+            temporal_by_fold=case.temporal_by_fold,
+            temporal_keys=case.temporal_keys,
+            temporal_feature_names=case.temporal_feature_names,
+        )
+        if fold_inputs is None:
+            raise ValueError(f"latent fold {split['fold']} no longer prepares from resolved inputs")
+        model_input = fold_inputs["pca"] if context.model_name == "pca" else fold_inputs["ragged"]
+        predictions = predict_latent_fold_from_artifact(
+            context.model_name,
+            artifact_dir=model_dir
+            / context.model_name
+            / "artifacts"
+            / f"fold_{int(split['fold'])}",
+            chars_train=model_input["chars_train"],
+            returns_train=model_input["returns_train"],
+            chars_val=model_input["chars_val"],
+            returns_val=model_input["returns_val"],
+            factor_returns_train=model_input.get("factor_returns_train"),
+            macro_train=model_input.get("macro_train"),
+            macro_val=model_input.get("macro_val"),
+            output_mode=str(context.model_kwargs.get("output_mode", "beta_network")),
+            device=case.device,
+        )
+        if set(predictions) != set(frames):
+            raise ValueError(
+                f"persisted {context.model_name} checkpoints {sorted(predictions)} do not match "
+                f"resolved request {sorted(frames)}"
+            )
+        for epoch, values in predictions.items():
+            frame = _build_prediction_frame(
+                predictions=values,
+                returns_val=model_input["returns_val"],
+                eval_returns_val=model_input.get("eval_returns_val"),
+                val_dates=model_input["val_dates"],
+                val_entities=model_input["val_entities"],
+                fold_id=int(split["fold"]),
+                model_name=context.model_name,
+                epoch=epoch,
+            )
+            if frame is None:
+                raise ValueError(f"persisted latent fold {split['fold']} produced no predictions")
+            frames[int(epoch)].append(frame)
+    return {
+        epoch: _normalize_prediction_frame(pl.concat(epoch_frames))
+        for epoch, epoch_frames in frames.items()
+    }
+
+
+def _same_predictions(left: pl.DataFrame, right: pl.DataFrame) -> bool:
+    if (
+        left.select("symbol", "timestamp", "fold").equals(
+            right.select("symbol", "timestamp", "fold")
+        )
+        is False
+    ):
+        return False
+    value_columns = ["prediction", "actual"]
+    if "eval_actual" in left.columns or "eval_actual" in right.columns:
+        if "eval_actual" not in left.columns or "eval_actual" not in right.columns:
+            return False
+        value_columns.append("eval_actual")
+    return np.allclose(
+        left.select(value_columns).to_numpy(),
+        right.select(value_columns).to_numpy(),
+        atol=1e-7,
+        rtol=1e-7,
+        equal_nan=False,
+    )
+
+
+def _cached_run(study: Study, spec: dict[str, Any], context: LatentFactorContext):
+    from case_studies.research.models import ModelRun
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+
+    include_preview = spec["execution_tier"] == "preview"
+    training_hash = training_hash_from_spec(spec)
+    try:
+        training = Result.open(study, training_hash, include_preview=include_preview)
+        predictions = tuple(
+            Result.open(
+                study,
+                prediction_hash_from_parts(
+                    training_hash,
+                    checkpoint["value"],
+                    "validation",
+                    checkpoint_kind="epoch",
+                    identity_version=spec["identity_version"],
+                ),
+                include_preview=include_preview,
+            )
+            for checkpoint in spec["computation"]["checkpoint_schedule"]
+        )
+    except KeyError:
+        return None
+    if not isinstance(training, TrainingResult) or any(
+        not isinstance(result, PredictionResult) or not result.complete for result in predictions
+    ):
+        return None
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    if not _valid_model_dir(model_dir, context):
+        return None
+    model_extras = model_dir / "fold_extras.json"
+    public_extras = model_dir.parent / "fold_extras.json"
+    if (
+        not model_extras.is_file()
+        or not public_extras.is_file()
+        or json.loads(public_extras.read_text()) != json.loads(model_extras.read_text())
+    ):
+        return None
+    reconstructed = _reconstruct_predictions(model_dir, context)
+    prediction_results = tuple(
+        result for result in predictions if isinstance(result, PredictionResult)
+    )
+    for result in prediction_results:
+        epoch = int(result.registry_record()["checkpoint_value"])
+        if not _same_predictions(_normalize_prediction_frame(result.load()), reconstructed[epoch]):
+            raise ValueError(f"persisted latent checkpoint {epoch} disagrees with registered data")
+    return ModelRun(training=training, predictions=prediction_results)
+
+
+def _write_manifest(staging: Path) -> None:
+    files = {
+        str(path.relative_to(staging)): _sha256(path)
+        for path in sorted(staging.rglob("*"))
+        if path.is_file() and path.name != "manifest.json"
+    }
+    if not files:
+        raise ValueError("latent fit produced no persisted artifacts")
+    (staging / "manifest.json").write_text(
+        json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _publish_fold_extras(model_dir: Path, train_dir: Path) -> None:
+    source = model_dir / "fold_extras.json"
+    serialized = source.read_text()
+    extras = json.loads(serialized)
+    if not isinstance(extras, list):
+        raise ValueError(f"invalid latent fold diagnostics: {source}")
+    target = train_dir / "fold_extras.json"
+    temporary = target.with_name(f".{target.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(serialized)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def run_resolved_request(study: Study, spec: dict[str, Any], context: LatentFactorContext):
+    from case_studies.research.models import ModelRun
+
+    cached = _cached_run(study, spec, context)
+    if cached is not None:
+        return cached
+    started = time.perf_counter()
+    computation = spec["computation"]
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    train_dir = training.root / "run_log" / "training" / training.hash
+    model_dir = train_dir / "models"
+    if model_dir.exists():
+        if not _valid_model_dir(model_dir, context):
+            raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+        prediction_frames = _reconstruct_predictions(model_dir, context)
+    else:
+        staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+        staging.mkdir(parents=True)
+        try:
+            result = run_latent_factor_cv(
+                panel_data=None,
+                splits=context.case.splits,
+                models=[context.model_name],
+                n_factors=context.n_factors,
+                n_epochs=context.n_epochs,
+                model_kwargs={context.model_name: context.model_kwargs},
+                save_dir=staging,
+                use_cache=False,
+                force_retrain=True,
+                random_state=RANDOM_SEED,
+                dataset=context.case.dataset,
+                feature_names=context.case.feature_names,
+                label_col=context.case.primary_label,
+                date_col=context.case.date_col,
+                entity_col=context.case.entity_col,
+                eval_label_col=context.case.eval_label_col,
+                task_type=context.case.task_type,
+                class_values=context.case.class_values or None,
+                macro_panel=context.case.macro_panel,
+                macro_context_spec=context.case.macro_context_spec,
+                input_data_spec=context.case.input_data_spec,
+                persistent_entities=context.case.persistent_entities,
+                checkpoint_selection_policy="fixed",
+                reporting_epoch=max(
+                    int(checkpoint["value"]) for checkpoint in computation["checkpoint_schedule"]
+                ),
+                device=context.case.device,
+                num_threads=context.case.num_threads,
+                deterministic_algorithms=context.case.deterministic_algorithms,
+                temporal_by_fold=context.case.temporal_by_fold,
+                temporal_keys=context.case.temporal_keys,
+                temporal_feature_names=context.case.temporal_feature_names,
+                fold_workers=context.fold_workers,
+                checkpoint_surface="fitted_state",
+            )
+            _save_fold_extras(
+                staging / "fold_extras.json",
+                result["fold_extras"][context.model_name],
+            )
+            model_stage = staging / context.model_name
+            shutil.rmtree(model_stage / "_incremental", ignore_errors=True)
+            fresh_frames = {
+                int(key[0]): _normalize_prediction_frame(frame)
+                for key, frame in result["all_predictions"][context.model_name]
+                .partition_by("epoch", as_dict=True)
+                .items()
+            }
+            prediction_frames = _reconstruct_predictions(staging, context)
+            if set(fresh_frames) != set(prediction_frames) or any(
+                not _same_predictions(fresh_frames[epoch], prediction_frames[epoch])
+                for epoch in fresh_frames
+            ):
+                raise ValueError("persisted latent state does not reproduce fresh predictions")
+            _write_manifest(staging)
+            os.replace(staging, model_dir)
+        except Exception:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+    _publish_fold_extras(model_dir, train_dir)
+
+    prediction_results = []
+    for checkpoint in computation["checkpoint_schedule"]:
+        value = int(checkpoint["value"])
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="epoch",
+                checkpoint_value=value,
+                split="validation",
+                predictions=prediction_frames[value],
+                expected_keys=context.expected_keys,
+                task_type=context.case.task_type,
+                class_values=context.case.class_values or None,
+                eval_col="eval_actual" if context.case.eval_label_col else None,
+                label=context.case.primary_label,
+            )
+        )
+    runtime_path = train_dir / "runtime.json"
+    if runtime_path.exists():
+        runtime = json.loads(runtime_path.read_text())
+        runtime["elapsed_s"] = time.perf_counter() - started
+        temporary = runtime_path.with_name(f".{runtime_path.name}.{uuid.uuid4().hex}.tmp")
+        temporary.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, runtime_path)
+    return ModelRun(training=training, predictions=tuple(prediction_results))

--- a/case_studies/utils/latent_factors/cae.py
+++ b/case_studies/utils/latent_factors/cae.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -30,6 +31,7 @@ def run_cae_fold(
     seed: int = 42,
     device: str = "cpu",
     log_fn=print,
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
     """Train the CAE and emit forecasts from the requested checkpoint grid."""
     del log_fn
@@ -51,4 +53,5 @@ def run_cae_fold(
         task_type=task_type,
         seed=seed,
         device=device,
+        artifact_dir=artifact_dir,
     )

--- a/case_studies/utils/latent_factors/case_study.py
+++ b/case_studies/utils/latent_factors/case_study.py
@@ -47,6 +47,7 @@ class LatentFactorCaseStudyContext:
     temporal_by_fold: pd.DataFrame | None
     temporal_keys: list[str]
     temporal_feature_names: list[str]
+    temporal_artifact_splits: list[dict[str, Any]]
     max_symbols: int = 0
     max_folds: int = 0
     device: str = "cpu"
@@ -96,7 +97,14 @@ def load_case_study_context(
     if use_macro and macro_context_config:
         macro_panel, macro_context_spec = load_configured_macro_context(macro_context_config)
     elif use_macro:
-        macro_panel, macro_context_spec = _load_macro_panel(lf_setup), None
+        macro_panel = _load_macro_panel(lf_setup)
+        macro_context_spec = {
+            "policy": "load_macro_fallback",
+            "version": "v1",
+            "series": [column for column in macro_panel.columns if column != "timestamp"],
+            "availability_lag_days": int(lf_setup.get("macro_availability_lag_days", 0)),
+            "alignment": "backward_asof",
+        }
     else:
         macro_panel, macro_context_spec = (
             None,
@@ -113,7 +121,11 @@ def load_case_study_context(
     modeling_dataset = load_modeling_dataset(
         case_study_id, resolved_primary, max_symbols=max_symbols
     )
-    input_data_spec = training_input_identity(case_study_id, resolved_primary)
+    input_data_spec = training_input_identity(
+        case_study_id,
+        resolved_primary,
+        eval_label=modeling_dataset.eval_label_col,
+    )
     splits = modeling_dataset.splits[:max_folds] if max_folds else modeling_dataset.splits
 
     return LatentFactorCaseStudyContext(
@@ -139,6 +151,7 @@ def load_case_study_context(
         temporal_by_fold=modeling_dataset.temporal_by_fold,
         temporal_keys=modeling_dataset.temporal_keys,
         temporal_feature_names=modeling_dataset.temporal_feature_names,
+        temporal_artifact_splits=modeling_dataset.temporal_artifact_splits,
         max_symbols=max_symbols,
         max_folds=max_folds,
         device=device,
@@ -263,7 +276,11 @@ def run_case_study_variants(
         modeling_dataset = load_modeling_dataset(
             context.case_study_id, variant_label, max_symbols=context.max_symbols
         )
-        input_data_spec = training_input_identity(context.case_study_id, variant_label)
+        input_data_spec = training_input_identity(
+            context.case_study_id,
+            variant_label,
+            eval_label=modeling_dataset.eval_label_col,
+        )
         # Honour the same max_folds truncation the primary run uses, so a
         # `max_folds=2` smoke test does not silently retrain variants on the
         # full split set.
@@ -317,7 +334,12 @@ def run_case_study_variants(
     return results
 
 
-def training_input_identity(case_study_id: str, label: str) -> dict[str, Any]:
+def training_input_identity(
+    case_study_id: str,
+    label: str,
+    *,
+    eval_label: str | None = None,
+) -> dict[str, Any]:
     """Return portable content identity for every materialized modeling input."""
     case_dir = get_case_study_dir(case_study_id)
     inputs = {
@@ -340,6 +362,12 @@ def training_input_identity(case_study_id: str, label: str) -> dict[str, Any]:
     )
     if temporal_path.exists():
         inputs["model_based"] = temporal_path
+    if eval_label is not None and eval_label != label:
+        inputs["evaluation_label"] = resolve_storage_path(
+            case_study_id,
+            load_label_spec(case_study_id, eval_label),
+            f"labels/{eval_label}.parquet",
+        )
 
     missing = [role for role, path in inputs.items() if not path.exists()]
     if missing:

--- a/case_studies/utils/latent_factors/cv.py
+++ b/case_studies/utils/latent_factors/cv.py
@@ -636,28 +636,44 @@ def run_latent_factor_cv(
         ):
             preds_df = pl.read_parquet(model_dir / "predictions.parquet")
             metrics_df = pl.read_parquet(model_dir / "fold_metrics.parquet")
-            best_epoch, mean_ic = _select_reporting_epoch(
-                metrics_df,
-                checkpoint_selection_policy=metric_policy["checkpoint_selection_policy"],
-                reporting_epoch=metric_policy["reporting_epoch"],
+            expected_cache_checkpoints = set(
+                _expected_latent_checkpoints(
+                    model_name,
+                    n_epochs=n_epochs,
+                    model_kwargs=model_kwargs.get(model_name, {}),
+                    include_internal_aliases=checkpoint_surface == "fitted_state",
+                )
             )
-            model_results.append(
-                {
-                    "model_name": model_name,
-                    "mean_ic": round(mean_ic, 4),
-                    "best_epoch": best_epoch,
-                    "n_folds": int(metrics_df["fold_id"].n_unique())
-                    if metrics_df.height > 0
-                    else 0,
-                    "elapsed_s": 0.0,
-                    "started_at": None,
-                }
-            )
-            all_predictions[model_name] = preds_df
-            fold_metrics[model_name] = metrics_df
-            all_extras[model_name] = []
-            log(f"  {model_name}: loaded cache (best IC={mean_ic:+.4f})")
-            continue
+            cached_prediction_checkpoints = set(preds_df.get_column("epoch").unique().to_list())
+            cached_metric_checkpoints = set(metrics_df.get_column("epoch").unique().to_list())
+            if (
+                cached_prediction_checkpoints != expected_cache_checkpoints
+                or cached_metric_checkpoints != expected_cache_checkpoints
+            ):
+                log(f"  {model_name}: cache checkpoint surface mismatch, retraining")
+            else:
+                best_epoch, mean_ic = _select_reporting_epoch(
+                    metrics_df,
+                    checkpoint_selection_policy=metric_policy["checkpoint_selection_policy"],
+                    reporting_epoch=metric_policy["reporting_epoch"],
+                )
+                model_results.append(
+                    {
+                        "model_name": model_name,
+                        "mean_ic": round(mean_ic, 4),
+                        "best_epoch": best_epoch,
+                        "n_folds": int(metrics_df["fold_id"].n_unique())
+                        if metrics_df.height > 0
+                        else 0,
+                        "elapsed_s": 0.0,
+                        "started_at": None,
+                    }
+                )
+                all_predictions[model_name] = preds_df
+                fold_metrics[model_name] = metrics_df
+                all_extras[model_name] = []
+                log(f"  {model_name}: loaded cache (best IC={mean_ic:+.4f})")
+                continue
 
         active_models.append(model_name)
         started_at[model_name] = datetime.now(UTC).isoformat()

--- a/case_studies/utils/latent_factors/cv.py
+++ b/case_studies/utils/latent_factors/cv.py
@@ -644,11 +644,18 @@ def run_latent_factor_cv(
                     include_internal_aliases=checkpoint_surface == "fitted_state",
                 )
             )
-            cached_prediction_checkpoints = set(preds_df.get_column("epoch").unique().to_list())
-            cached_metric_checkpoints = set(metrics_df.get_column("epoch").unique().to_list())
+            expected_cache_surface = {
+                (int(split["fold"]), checkpoint)
+                for split in splits
+                for checkpoint in expected_cache_checkpoints
+            }
+            cached_prediction_surface = set(
+                preds_df.select("fold_id", "epoch").unique().iter_rows()
+            )
+            cached_metric_surface = set(metrics_df.select("fold_id", "epoch").unique().iter_rows())
             if (
-                cached_prediction_checkpoints != expected_cache_checkpoints
-                or cached_metric_checkpoints != expected_cache_checkpoints
+                cached_prediction_surface != expected_cache_surface
+                or cached_metric_surface != expected_cache_surface
             ):
                 log(f"  {model_name}: cache checkpoint surface mismatch, retraining")
             else:

--- a/case_studies/utils/latent_factors/cv.py
+++ b/case_studies/utils/latent_factors/cv.py
@@ -107,8 +107,9 @@ def _expected_latent_checkpoints(
     *,
     n_epochs: int,
     model_kwargs: dict[str, Any],
+    include_internal_aliases: bool = False,
 ) -> tuple[int, ...]:
-    """Resolve the complete physical and library-defined checkpoint surface."""
+    """Resolve physical checkpoints and, when requested, fitted-state aliases."""
     from case_studies.utils.latent_factors.common import resolve_checkpoint_epochs
 
     if model_name in {"pca", "ipca"}:
@@ -119,6 +120,8 @@ def _expected_latent_checkpoints(
             checkpoint_interval=model_kwargs.get("checkpoint_interval", 5),
             checkpoint_epochs=model_kwargs.get("checkpoint_epochs"),
         )
+        if model_name == "cae" and include_internal_aliases:
+            return tuple(sorted({0, *physical}))
         return tuple(physical)
     if model_name == "sdf":
         n_epochs_unc = int(model_kwargs.get("n_epochs_unc", 256))
@@ -128,7 +131,7 @@ def _expected_latent_checkpoints(
             checkpoint_interval=model_kwargs.get("checkpoint_interval"),
             checkpoint_epochs=model_kwargs.get("checkpoint_epochs"),
         )
-        labels: set[int] = set()
+        labels: set[int] = {-3, -2, -1, 0} if include_internal_aliases else set()
         labels.update(epoch for epoch in physical if epoch <= n_epochs_unc)
         labels.update(n_epochs_unc + epoch for epoch in physical if epoch <= n_epochs_cond)
         return tuple(sorted(labels))
@@ -448,6 +451,7 @@ def run_latent_factor_cv(
     temporal_keys: list[str] | None = None,
     temporal_feature_names: list[str] | None = None,
     fold_workers: int = 1,
+    checkpoint_surface: str = "physical",
 ) -> dict[str, Any]:
     """Run walk-forward latent factor CV from the raw dated dataset."""
     del panel_data
@@ -460,6 +464,8 @@ def run_latent_factor_cv(
         raise ValueError("fold_workers must be a positive integer")
     if fold_workers > 1 and models != ["ipca"]:
         raise ValueError("parallel fold execution is currently supported only for IPCA-only runs")
+    if checkpoint_surface not in {"fitted_state", "physical"}:
+        raise ValueError("checkpoint_surface must be 'physical' or 'fitted_state'")
 
     model_kwargs = model_kwargs or {}
     runtime_spec = configure_latent_torch_runtime(
@@ -666,7 +672,11 @@ def run_latent_factor_cv(
     need_pca_inputs = "pca" in active_models
     need_ragged_inputs = any(model_name != "pca" for model_name in active_models)
 
-    def runner_kwargs(model_name: str, model_input: dict[str, Any]) -> dict[str, Any]:
+    def runner_kwargs(
+        model_name: str,
+        model_input: dict[str, Any],
+        fold_id: int,
+    ) -> dict[str, Any]:
         runner = _MODEL_RUNNERS[model_name]
         kwargs: dict[str, Any] = {"n_factors": n_factors}
         if model_name in {"cae", "sae"}:
@@ -684,6 +694,9 @@ def run_latent_factor_cv(
         if model_name == "sdf" and model_input.get("macro_train") is not None:
             kwargs["macro_train"] = model_input["macro_train"]
             kwargs["macro_val"] = model_input["macro_val"]
+        model_dir = model_dirs[model_name]
+        if model_dir is not None and "artifact_dir" in inspect.signature(runner).parameters:
+            kwargs["artifact_dir"] = model_dir / "artifacts" / f"fold_{fold_id}"
         if model_name in model_kwargs:
             merge_preset_into_runner_kwargs(
                 kwargs,
@@ -696,6 +709,7 @@ def run_latent_factor_cv(
     def fit_fold(
         model_name: str,
         model_input: dict[str, Any],
+        fold_id: int,
     ) -> tuple[dict[int, np.ndarray], dict[str, Any], float]:
         fold_started = time.perf_counter()
         result = _MODEL_RUNNERS[model_name](
@@ -703,7 +717,7 @@ def run_latent_factor_cv(
             model_input["returns_train"],
             model_input["chars_val"],
             model_input["returns_val"],
-            **runner_kwargs(model_name, model_input),
+            **runner_kwargs(model_name, model_input, fold_id),
         )
         if isinstance(result[0], dict):
             checkpoint_preds, extra = result
@@ -722,6 +736,21 @@ def run_latent_factor_cv(
         fold_elapsed: float,
     ) -> None:
         state[model_name]["fold_extras"].append({"fold_id": split["fold"], **extra})
+        if checkpoint_surface == "physical":
+            physical = set(
+                _expected_latent_checkpoints(
+                    model_name,
+                    n_epochs=n_epochs,
+                    model_kwargs=model_kwargs.get(model_name, {}),
+                )
+            )
+            checkpoint_preds = {
+                epoch: predictions
+                for epoch, predictions in checkpoint_preds.items()
+                if epoch in physical
+            }
+            if not checkpoint_preds:
+                raise ValueError(f"{model_name} produced no physical checkpoints")
         checkpoint_ics: dict[int, float] = {}
         for epoch, predictions in checkpoint_preds.items():
             frame = _build_prediction_frame(
@@ -811,7 +840,7 @@ def run_latent_factor_cv(
             ThreadPoolExecutor(max_workers=worker_count, thread_name_prefix="ipca-fold") as pool,
         ):
             futures = {
-                pool.submit(fit_fold, "ipca", model_input): int(split["fold"])
+                pool.submit(fit_fold, "ipca", model_input, int(split["fold"])): int(split["fold"])
                 for split, model_input in prepared_folds
             }
             for future in as_completed(futures):
@@ -871,7 +900,11 @@ def run_latent_factor_cv(
             )
             for model_name in active_models:
                 model_input = fold_inputs["pca"] if model_name == "pca" else fold_inputs["ragged"]
-                checkpoint_preds, extra, fold_elapsed = fit_fold(model_name, model_input)
+                checkpoint_preds, extra, fold_elapsed = fit_fold(
+                    model_name,
+                    model_input,
+                    int(split["fold"]),
+                )
                 record_fold(
                     split=split,
                     model_name=model_name,

--- a/case_studies/utils/latent_factors/ipca.py
+++ b/case_studies/utils/latent_factors/ipca.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -21,6 +22,7 @@ def run_ipca_fold(
     tol: float = 1e-6,
     factor_ridge: float = 1e-6,
     gamma_ridge: float = 1e-6,
+    artifact_dir: Path | None = None,
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Fit IPCA on unbalanced dated cross-sections and forecast with train premiums."""
     return run_ipca_fold_with_library(
@@ -33,4 +35,5 @@ def run_ipca_fold(
         tol=tol,
         factor_ridge=factor_ridge,
         gamma_ridge=gamma_ridge,
+        artifact_dir=artifact_dir,
     )

--- a/case_studies/utils/latent_factors/library_bridge.py
+++ b/case_studies/utils/latent_factors/library_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -76,6 +77,7 @@ def run_pca_fold_with_library(
     returns_val: np.ndarray,
     *,
     n_factors: int,
+    artifact_dir: Path | None = None,
 ) -> tuple[np.ndarray, dict[str, Any]]:
     _validate_persistent_returns(returns_train, returns_val)
     train_batch = PersistentPanelBatch(
@@ -94,6 +96,10 @@ def run_pca_fold_with_library(
     val_state = model.extract(val_batch)
     forecaster = ExpandingMeanFactorForecaster()
     forecaster.fit(train_state)
+    if artifact_dir is not None:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        model.save(artifact_dir / "model.ml4t")
+        forecaster.save(artifact_dir / "forecaster_0.ml4t")
     forecast = forecaster.predict(val_state)
     predictions = (
         BetaLambdaMapper().predict(val_state, forecast).expected_returns.astype(np.float32)
@@ -131,6 +137,7 @@ def run_ipca_fold_with_library(
     tol: float = 1e-6,
     factor_ridge: float = 1e-6,
     gamma_ridge: float = 1e-6,
+    artifact_dir: Path | None = None,
 ) -> tuple[np.ndarray, dict[str, Any]]:
     train_batch = _cross_section_batch(chars_train, returns=returns_train)
     val_batch = _cross_section_batch(chars_val)
@@ -149,6 +156,10 @@ def run_ipca_fold_with_library(
     val_state = model.extract(val_batch)
     forecaster = ExpandingMeanFactorForecaster()
     forecaster.fit(train_state)
+    if artifact_dir is not None:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        model.save(artifact_dir / "model.ml4t")
+        forecaster.save(artifact_dir / "forecaster_0.ml4t")
     forecast = forecaster.predict(val_state)
     predictions = (
         BetaLambdaMapper().predict(val_state, forecast).expected_returns.astype(np.float32)
@@ -193,6 +204,7 @@ def run_cae_fold_with_library(
     task_type: TaskType = "regression",
     seed: int = 42,
     device: str = "cpu",
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
     train_batch = _cross_section_batch(
         chars_train,
@@ -223,6 +235,7 @@ def run_cae_fold_with_library(
         val_batch=val_batch,
         returns_val=returns_val,
         task_type=task_type,
+        artifact_dir=artifact_dir,
     )
     extras["factor_source"] = (
         "continuous_returns" if factor_returns_train is not None else "label_column"
@@ -252,6 +265,7 @@ def run_sae_fold_with_library(
     task_type: TaskType = "regression",
     seed: int = 42,
     device: str = "cpu",
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
     train_batch = _cross_section_batch(
         chars_train,
@@ -284,6 +298,7 @@ def run_sae_fold_with_library(
         val_batch=val_batch,
         returns_val=returns_val,
         task_type=task_type,
+        artifact_dir=artifact_dir,
     )
     return extras.pop("checkpoint_predictions"), extras
 
@@ -317,7 +332,10 @@ def run_sdf_fold_with_library(
     weight_decay: float = 0.0,
     seed: int = 42,
     device: str = "cpu",
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
+    if expected_return_mapper != "linear":
+        raise ValueError("SDF expected_return_mapper currently supports only 'linear'")
     train_batch = _cross_section_batch(
         chars_train,
         returns=returns_train,
@@ -327,7 +345,6 @@ def run_sdf_fold_with_library(
 
     model = StochasticDiscountFactorModel(
         StochasticDiscountFactorConfig(
-            output_mode="weights",
             state_dim_sdf=state_dim_sdf,
             state_dim_moment=state_dim_moment,
             hidden_dim=hidden_dim,
@@ -342,7 +359,6 @@ def run_sdf_fold_with_library(
             beta_checkpoint_interval=beta_checkpoint_interval,
             beta_checkpoint_epochs=tuple(beta_checkpoint_epochs or ()),
             beta_default_checkpoint=beta_default_checkpoint,
-            expected_return_mapper=expected_return_mapper,
             burn_in_epochs=burn_in_epochs,
             lr=lr,
             weight_decay=weight_decay,
@@ -351,6 +367,9 @@ def run_sdf_fold_with_library(
         )
     )
     fit = model.fit(train_batch, validation_batch=val_batch)
+    if artifact_dir is not None:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        model.save(artifact_dir / "model.ml4t")
 
     checkpoint_predictions: dict[int, np.ndarray] = {}
     checkpoint_metrics: dict[str, dict[str, float | int | None]] = {}
@@ -368,11 +387,15 @@ def run_sdf_fold_with_library(
             beta_fit = beta_head.fit(train_state, train_batch)
             predictions = beta_head.predict(val_batch).signal_values.astype(np.float32)
             beta_head_epochs[str(checkpoint_label)] = beta_fit.best_epoch
+            if artifact_dir is not None:
+                beta_head.save(artifact_dir / f"beta_head_{checkpoint_label}.ml4t")
         elif output_mode == "expected_returns":
             mapper = LinearStochasticDiscountFactorReturnMapper()
             mapper.fit(train_state, train_batch)
             predictions = mapper.predict(val_state).expected_returns.astype(np.float32)
             beta_head_epochs[str(checkpoint_label)] = None
+            if artifact_dir is not None:
+                mapper.save(artifact_dir / f"return_mapper_{checkpoint_label}.ml4t")
         else:
             raise ValueError(f"Unsupported output_mode: {output_mode!r}")
         predictions[~np.isfinite(returns_val)] = np.nan
@@ -406,6 +429,143 @@ def run_sdf_fold_with_library(
     return checkpoint_predictions, extras
 
 
+def predict_latent_fold_from_artifact(
+    model_name: str,
+    *,
+    artifact_dir: Path,
+    chars_train: np.ndarray,
+    returns_train: np.ndarray,
+    chars_val: np.ndarray,
+    returns_val: np.ndarray,
+    factor_returns_train: np.ndarray | None = None,
+    macro_train: np.ndarray | None = None,
+    macro_val: np.ndarray | None = None,
+    output_mode: str = "beta_network",
+    device: str = "cpu",
+) -> dict[int, np.ndarray]:
+    """Reconstruct one fold's predictions from persisted fitted state."""
+    model_path = artifact_dir / "model.ml4t"
+    if not model_path.is_file():
+        raise FileNotFoundError(model_path)
+    if model_name == "pca":
+        model = PCAModel.load(model_path, device=device)
+        train_batch = PersistentPanelBatch(
+            returns=returns_train,
+            timestamps=tuple(range(returns_train.shape[0])),
+            asset_ids=_asset_ids(returns_train.shape[1]),
+        )
+        val_batch = PersistentPanelBatch(
+            timestamps=tuple(range(returns_val.shape[0])),
+            asset_ids=_asset_ids(returns_val.shape[1]),
+        )
+        train_state = model.extract(train_batch)
+        val_state = model.extract(val_batch)
+        forecaster = ExpandingMeanFactorForecaster.load(
+            artifact_dir / "forecaster_0.ml4t",
+            device=device,
+        )
+        predictions = (
+            BetaLambdaMapper()
+            .predict(
+                val_state,
+                forecaster.predict(val_state),
+            )
+            .expected_returns.astype(np.float32)
+        )
+        predictions[~np.isfinite(returns_val)] = np.nan
+        return {0: predictions}
+
+    train_batch = _cross_section_batch(
+        chars_train,
+        returns=returns_train,
+        factor_returns=factor_returns_train,
+        context_features=macro_train,
+    )
+    val_batch = _cross_section_batch(
+        chars_val,
+        returns=returns_val,
+        context_features=macro_val,
+    )
+    if model_name == "ipca":
+        model = IPCAModel.load(model_path, device=device)
+        train_state = model.extract(train_batch)
+        val_state = model.extract(val_batch)
+        forecaster = ExpandingMeanFactorForecaster.load(
+            artifact_dir / "forecaster_0.ml4t",
+            device=device,
+        )
+        predictions = (
+            BetaLambdaMapper()
+            .predict(
+                val_state,
+                forecaster.predict(val_state),
+            )
+            .expected_returns.astype(np.float32)
+        )
+        predictions[~np.isfinite(returns_val)] = np.nan
+        return {0: predictions}
+    if model_name == "cae":
+        model = CAEModel.load(model_path, device=device)
+        checkpoint_predictions: dict[int, np.ndarray] = {}
+        for epoch in model.available_checkpoints:
+            val_state = model.extract(val_batch, checkpoint=epoch)
+            forecaster = ExpandingMeanFactorForecaster.load(
+                artifact_dir / f"forecaster_{int(epoch)}.ml4t",
+                device=device,
+            )
+            predictions = (
+                BetaLambdaMapper()
+                .predict(
+                    val_state,
+                    forecaster.predict(val_state),
+                )
+                .expected_returns.astype(np.float32)
+            )
+            if model.config.task_type == "classification":
+                predictions = _sigmoid(predictions).astype(np.float32)
+            predictions[~np.isfinite(returns_val)] = np.nan
+            checkpoint_predictions[int(epoch)] = predictions
+        return checkpoint_predictions
+    if model_name == "sae":
+        model = SAEModel.load(model_path, device=device)
+        checkpoint_predictions = {}
+        for epoch in model.available_checkpoints:
+            predictions = model.predict(val_batch, checkpoint=epoch).signal_values.astype(
+                np.float32
+            )
+            predictions[~np.isfinite(returns_val)] = np.nan
+            checkpoint_predictions[int(epoch)] = predictions
+        return checkpoint_predictions
+    if model_name == "sdf":
+        model = StochasticDiscountFactorModel.load(model_path, device=device)
+        checkpoint_predictions = {}
+        for epoch in model.available_checkpoints:
+            checkpoint_label = _sdf_checkpoint_label(
+                epoch,
+                n_epochs_unc=model.config.n_epochs_unc,
+            )
+            val_state = model.extract(val_batch, checkpoint=epoch)
+            if output_mode == "weights":
+                predictions = val_state.asset_weights.astype(np.float32)
+            elif output_mode == "beta_network":
+                head = StochasticDiscountFactorBetaNetworkHead.load(
+                    artifact_dir / f"beta_head_{checkpoint_label}.ml4t",
+                    device=device,
+                )
+                predictions = head.predict(val_batch).signal_values.astype(np.float32)
+            elif output_mode == "expected_returns":
+                mapper = LinearStochasticDiscountFactorReturnMapper.load(
+                    artifact_dir / f"return_mapper_{checkpoint_label}.ml4t"
+                )
+                predictions = mapper.predict(val_state).expected_returns.astype(np.float32)
+            else:
+                raise ValueError(f"Unsupported output_mode: {output_mode!r}")
+            predictions[~np.isfinite(returns_val)] = np.nan
+            checkpoint_predictions[checkpoint_label] = predictions
+        return checkpoint_predictions
+    raise ValueError(f"Unsupported latent-factor model: {model_name!r}")
+
+
 def _run_checkpointed_latent_pipeline(
     *,
     model: CAEModel,
@@ -413,8 +573,12 @@ def _run_checkpointed_latent_pipeline(
     val_batch: CrossSectionBatch,
     returns_val: np.ndarray,
     task_type: TaskType,
+    artifact_dir: Path | None,
 ) -> dict[str, Any]:
     fit = model.fit(train_batch, validation_batch=val_batch)
+    if artifact_dir is not None:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        model.save(artifact_dir / "model.ml4t")
 
     checkpoint_predictions: dict[int, np.ndarray] = {}
     checkpoint_metrics: dict[str, dict[str, float | int | None]] = {}
@@ -424,6 +588,8 @@ def _run_checkpointed_latent_pipeline(
         val_state = model.extract(val_batch, checkpoint=epoch)
         forecaster = ExpandingMeanFactorForecaster()
         forecaster.fit(train_state)
+        if artifact_dir is not None:
+            forecaster.save(artifact_dir / f"forecaster_{int(epoch)}.ml4t")
         forecast = forecaster.predict(val_state)
         predictions = (
             BetaLambdaMapper().predict(val_state, forecast).expected_returns.astype(np.float32)
@@ -456,8 +622,12 @@ def _run_checkpointed_signal_pipeline(
     val_batch: CrossSectionBatch,
     returns_val: np.ndarray,
     task_type: TaskType,
+    artifact_dir: Path | None,
 ) -> dict[str, Any]:
     fit = model.fit(train_batch)
+    if artifact_dir is not None:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        model.save(artifact_dir / "model.ml4t")
 
     checkpoint_predictions: dict[int, np.ndarray] = {}
     checkpoint_metrics: dict[str, dict[str, float | int | None]] = {}

--- a/case_studies/utils/latent_factors/pca.py
+++ b/case_studies/utils/latent_factors/pca.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -15,6 +16,8 @@ def run_pca_fold(
     chars_val: np.ndarray,
     returns_val: np.ndarray,
     n_factors: int,
+    *,
+    artifact_dir: Path | None = None,
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Fit PCA on the training return panel and emit expected-return forecasts."""
     del chars_train, chars_val
@@ -22,4 +25,5 @@ def run_pca_fold(
         returns_train,
         returns_val,
         n_factors=n_factors,
+        artifact_dir=artifact_dir,
     )

--- a/case_studies/utils/latent_factors/sae.py
+++ b/case_studies/utils/latent_factors/sae.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -34,6 +35,7 @@ def run_sae_fold(
     seed: int = 42,
     device: str = "cpu",
     log_fn=print,
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
     """Train the SAE and emit predictions on the requested checkpoint grid."""
     # `n_factors` is part of the runner-API contract for parity with PCA/IPCA/CAE/SDF
@@ -60,4 +62,5 @@ def run_sae_fold(
         task_type=task_type,
         seed=seed,
         device=device,
+        artifact_dir=artifact_dir,
     )

--- a/case_studies/utils/latent_factors/sdf.py
+++ b/case_studies/utils/latent_factors/sdf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
@@ -42,6 +43,7 @@ def run_sdf_fold(
     log_fn=print,
     seed: int = 42,
     device: str = "cpu",
+    artifact_dir: Path | None = None,
 ) -> tuple[dict[int, np.ndarray], dict[str, Any]]:
     """Train the SDF network and emit checkpoint predictions."""
     del n_factors, log_fn
@@ -73,4 +75,5 @@ def run_sdf_fold(
         weight_decay=weight_decay,
         seed=seed,
         device=device,
+        artifact_dir=artifact_dir,
     )

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -18,6 +18,7 @@ import polars as pl
 from sklearn.linear_model import ElasticNet, Lasso, LinearRegression, LogisticRegression, Ridge
 
 from case_studies.research.contracts import ExecutionTier
+from case_studies.research.cv import require_fold_scoped_temporal_compatibility
 from case_studies.research.identity import ResolvedSpec
 from case_studies.research.models import ModelRun
 from case_studies.research.recovery import ExecutionLedger
@@ -207,7 +208,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     study.require_writable()
     study.activate(tier)
 
-    label_ref = study.labels.get(request["label"])
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
     max_symbols = int(reductions.get("max_symbols", 0))
     train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
     if not 0 < train_sample_frac <= 1:
@@ -220,6 +221,13 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         raise ValueError(f"linear runner does not support entity key {entity_col!r}")
     label_timeline = label_ref.load().select(mds.date_col).unique()
     splits, cv_record = _select_splits(mds, request, label_timeline)
+    if (
+        request.get("cv") is not None
+        and mds.temporal_by_fold is not None
+        and mds.temporal_keys
+        and mds.temporal_feature_names
+    ):
+        require_fold_scoped_temporal_compatibility(splits, mds.temporal_artifact_splits)
     folds = prepare_cv_folds(
         mds.dataset.to_pandas(),
         splits,
@@ -323,9 +331,11 @@ def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> M
     if not isinstance(training, TrainingResult) or not isinstance(prediction, PredictionResult):
         return None
     model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    if not prediction.complete:
+        return None
     manifest = model_dir / "manifest.json"
     expected_files = {f"fold_{int(fold['fold'])}.joblib" for fold in context.folds}
-    if not prediction.complete or not manifest.is_file():
+    if not manifest.is_file():
         return None
     record = json.loads(manifest.read_text())
     if set(record.get("files") or {}) != expected_files:
@@ -341,6 +351,48 @@ def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> M
             "fitted_folds": [],
         },
     )
+
+
+def _fold_predictions(model: Any, fold: dict[str, Any], context: LinearContext) -> np.ndarray:
+    if context.task_type == "classification":
+        predict_proba = getattr(model, "predict_proba", None)
+        if not callable(predict_proba):
+            raise ValueError("classification linear model must expose predict_proba")
+        probabilities = predict_proba(fold["X_val"])
+        predictions = probabilities @ np.asarray(sorted(context.class_values), dtype=np.float64)
+    else:
+        predictions = np.asarray(model.predict(fold["X_val"]), dtype=np.float64)
+    fold_id = int(fold["fold"])
+    if not np.isfinite(predictions).all() or np.nanstd(predictions) <= 1e-15:
+        raise ValueError(f"linear fold {fold_id} produced non-finite or constant predictions")
+    return predictions
+
+
+def _prediction_frame(
+    fold: dict[str, Any], predictions: np.ndarray, context: LinearContext
+) -> pl.DataFrame:
+    fold_id = int(fold["fold"])
+    frame = pl.from_pandas(fold["meta"][[context.entity_col, context.date_col]]).with_columns(
+        pl.lit(fold_id, dtype=pl.Int64).alias("fold"),
+        pl.Series("prediction", predictions),
+        pl.Series("actual", fold["y_val"]),
+    )
+    if fold.get("y_eval") is not None:
+        frame = frame.with_columns(pl.Series("eval_actual", fold["y_eval"]))
+    return frame.rename({context.entity_col: "symbol", context.date_col: "timestamp"})
+
+
+def _write_runtime_fields(runtime_path: Path, **fields: float) -> None:
+    if not runtime_path.exists():
+        return
+    runtime = json.loads(runtime_path.read_text())
+    runtime.update(fields)
+    temporary = runtime_path.with_name(f".{runtime_path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, runtime_path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _fit_or_reuse_predictions(
@@ -377,25 +429,8 @@ def _fit_or_reuse_predictions(
 
         model = cls(**params)
         model.fit(fold["X_train"], fold["y_train"])
-        if context.task_type == "classification":
-            predict_proba = getattr(model, "predict_proba", None)
-            if not callable(predict_proba):
-                raise ValueError("classification linear model must expose predict_proba")
-            probabilities = predict_proba(fold["X_val"])
-            predictions = probabilities @ np.asarray(sorted(context.class_values), dtype=np.float64)
-        else:
-            predictions = np.asarray(model.predict(fold["X_val"]), dtype=np.float64)
-        if not np.isfinite(predictions).all() or np.nanstd(predictions) <= 1e-15:
-            raise ValueError(f"linear fold {fold_id} produced non-finite or constant predictions")
-
-        frame = pl.from_pandas(fold["meta"][[context.entity_col, context.date_col]]).with_columns(
-            pl.lit(fold_id, dtype=pl.Int64).alias("fold"),
-            pl.Series("prediction", predictions),
-            pl.Series("actual", fold["y_val"]),
-        )
-        if fold.get("y_eval") is not None:
-            frame = frame.with_columns(pl.Series("eval_actual", fold["y_eval"]))
-        frame = frame.rename({context.entity_col: "symbol", context.date_col: "timestamp"})
+        predictions = _fold_predictions(model, fold, context)
+        frame = _prediction_frame(fold, predictions, context)
         artifact_temp = model_dir / f".{artifact.name}.{uuid.uuid4().hex}.tmp"
         shard_temp = shard_dir / f".{shard.name}.{uuid.uuid4().hex}.tmp"
         try:
@@ -479,8 +514,5 @@ def run_resolved_request(
         attempt.finish("failed", {"error_type": type(exc).__name__, "error": str(exc)})
         raise
     runtime_path = train_dir / "runtime.json"
-    if runtime_path.exists():
-        runtime = json.loads(runtime_path.read_text())
-        runtime["elapsed_s"] = time.perf_counter() - started
-        runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+    _write_runtime_fields(runtime_path, elapsed_s=time.perf_counter() - started)
     return ModelRun(training=training, predictions=(prediction,), diagnostics=diagnostics)

--- a/case_studies/utils/registry/specs.py
+++ b/case_studies/utils/registry/specs.py
@@ -375,6 +375,8 @@ def build_training_spec(
     if family == "gbm":
         spec["max_iterations"] = preset.get("max_iterations", 500)
         spec["checkpoint_interval"] = checkpoint_interval or preset.get("checkpoint_interval", 50)
+        if preset.get("huber_alpha_scale") is not None:
+            params["huber_alpha_scale"] = preset["huber_alpha_scale"]
         if max_bin is not None:
             params["max_bin"] = max_bin
         if num_class is not None and num_class > 2:

--- a/case_studies/utils/uncertainty.py
+++ b/case_studies/utils/uncertainty.py
@@ -42,7 +42,7 @@ import warnings
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 import numpy as np
 import polars as pl
@@ -122,6 +122,11 @@ def resolve_block_length(
 
     if rebalance_step and rebalance_step > 0:
         return max(rebalance_step, floor)
+
+    scale = float(np.std(returns))
+    scale_floor = np.finfo(float).eps * max(1.0, abs(float(np.mean(returns))))
+    if returns.size >= 10 and scale <= scale_floor:
+        return max(int(returns.size ** (1 / 3)), floor, 1)
 
     from ml4t.diagnostic.evaluation.stats import _optimal_block_size
 
@@ -232,16 +237,22 @@ def _sharpe_se_lo(returns: np.ndarray, periods_per_year: int) -> float:
         return float("nan")
     mu = float(np.mean(returns))
     sd = float(np.std(returns, ddof=1))
-    if sd == 0:
+    scale_floor = np.finfo(float).eps * max(1.0, abs(mu))
+    if sd <= scale_floor:
         return float("nan")
     sr = mu / sd  # native frequency
     centered = returns - mu
     m2 = float(np.mean(centered**2))
-    if m2 == 0:
+    if m2 <= scale_floor**2:
         return float("nan")
     skew = float(np.mean(centered**3) / m2**1.5)
     kurt = float(np.mean(centered**4) / m2**2)  # Pearson convention (normal=3)
-    rho = float(np.corrcoef(returns[:-1], returns[1:])[0, 1])
+    previous = returns[:-1]
+    following = returns[1:]
+    if float(np.std(previous)) == 0.0 or float(np.std(following)) == 0.0:
+        rho = 0.0
+    else:
+        rho = float(np.corrcoef(previous, following)[0, 1])
     if not np.isfinite(rho) or abs(rho) >= 0.999:
         rho = 0.0
     var = compute_sharpe_variance(
@@ -277,21 +288,16 @@ def _stationary_bootstrap_metrics(
     max_dds = np.empty(n_boot)
     calmars = np.empty(n_boot)
 
-    np_state = np.random.get_state()
-    np.random.seed(int(rng.integers(0, 2**31 - 1)))
-    try:
-        for i in range(n_boot):
-            idx = _stationary_bootstrap_indices(len(returns), float(block_length))
-            sample = returns[idx]
-            stats = _sample_stats(sample, periods_per_year)
-            sharpes[i] = stats.sharpe
-            sortinos[i] = stats.sortino
-            ann_rets[i] = stats.ann_return
-            vols[i] = stats.volatility
-            max_dds[i] = stats.max_drawdown
-            calmars[i] = stats.calmar
-    finally:
-        np.random.set_state(np_state)
+    for i in range(n_boot):
+        idx = _stationary_bootstrap_indices(len(returns), float(block_length), rng)
+        sample = returns[idx]
+        stats = _sample_stats(sample, periods_per_year)
+        sharpes[i] = stats.sharpe
+        sortinos[i] = stats.sortino
+        ann_rets[i] = stats.ann_return
+        vols[i] = stats.volatility
+        max_dds[i] = stats.max_drawdown
+        calmars[i] = stats.calmar
 
     return {
         "sharpe": sharpes,
@@ -458,25 +464,18 @@ def compute_paired_uncertainty(
     irs = np.empty(n_boot)
     wins = 0
 
-    np_state = np.random.get_state()
-    np.random.seed(int(rng.integers(0, 2**31 - 1)))
-    try:
-        for i in range(n_boot):
-            idx = _stationary_bootstrap_indices(c.size, float(block))
-            cs = _sample_stats(c[idx], periods_per_year)
-            bs = _sample_stats(b[idx], periods_per_year)
-            sharpe_diffs[i] = cs.sharpe - bs.sharpe
-            ret_diffs[i] = cs.ann_return - bs.ann_return
-            max_dd_diffs[i] = cs.max_drawdown - bs.max_drawdown
-            d = c[idx] - b[idx]
-            sd = float(np.std(d, ddof=1))
-            irs[i] = (
-                float(np.mean(d) / sd * np.sqrt(periods_per_year)) if sd > 1e-6 else float("nan")
-            )
-            if cs.sharpe > bs.sharpe:
-                wins += 1
-    finally:
-        np.random.set_state(np_state)
+    for i in range(n_boot):
+        idx = _stationary_bootstrap_indices(c.size, float(block), rng)
+        cs = _sample_stats(c[idx], periods_per_year)
+        bs = _sample_stats(b[idx], periods_per_year)
+        sharpe_diffs[i] = cs.sharpe - bs.sharpe
+        ret_diffs[i] = cs.ann_return - bs.ann_return
+        max_dd_diffs[i] = cs.max_drawdown - bs.max_drawdown
+        d = c[idx] - b[idx]
+        sd = float(np.std(d, ddof=1))
+        irs[i] = float(np.mean(d) / sd * np.sqrt(periods_per_year)) if sd > 1e-6 else float("nan")
+        if cs.sharpe > bs.sharpe:
+            wins += 1
 
     sd_lo, sd_hi = _percentile_ci(sharpe_diffs)
     rd_lo, rd_hi = _percentile_ci(ret_diffs)
@@ -559,22 +558,17 @@ def compute_independent_diff_uncertainty(
     mdds_c = np.empty(n_boot)
     mdds_b = np.empty(n_boot)
 
-    np_state = np.random.get_state()
-    np.random.seed(int(rng.integers(0, 2**31 - 1)))
-    try:
-        for i in range(n_boot):
-            idx_c = _stationary_bootstrap_indices(c.size, float(block_c))
-            idx_b = _stationary_bootstrap_indices(b.size, float(block_b))
-            cs = _sample_stats(c[idx_c], periods_per_year)
-            bs = _sample_stats(b[idx_b], periods_per_year)
-            sharpes_c[i] = cs.sharpe
-            sharpes_b[i] = bs.sharpe
-            rets_c[i] = cs.ann_return
-            rets_b[i] = bs.ann_return
-            mdds_c[i] = cs.max_drawdown
-            mdds_b[i] = bs.max_drawdown
-    finally:
-        np.random.set_state(np_state)
+    for i in range(n_boot):
+        idx_c = _stationary_bootstrap_indices(c.size, float(block_c), rng)
+        idx_b = _stationary_bootstrap_indices(b.size, float(block_b), rng)
+        cs = _sample_stats(c[idx_c], periods_per_year)
+        bs = _sample_stats(b[idx_b], periods_per_year)
+        sharpes_c[i] = cs.sharpe
+        sharpes_b[i] = bs.sharpe
+        rets_c[i] = cs.ann_return
+        rets_b[i] = bs.ann_return
+        mdds_c[i] = cs.max_drawdown
+        mdds_b[i] = bs.max_drawdown
 
     sharpe_diffs = sharpes_c - sharpes_b
     ret_diffs = rets_c - rets_b
@@ -667,7 +661,7 @@ def compute_selection_adjustment(
     names = list(arrays.keys())
     arr_list = [arrays[n] for n in names]
     sharpes = {n: _sample_stats(arrays[n], periods_per_year).sharpe for n in names}
-    leader = max(sharpes, key=sharpes.get)
+    leader = max(sharpes, key=lambda name: sharpes[name])
 
     out: dict[str, Any] = {
         "leader": leader,
@@ -702,12 +696,12 @@ def compute_selection_adjustment(
 
 def compute_reality_check(
     challenger_returns: dict[str, np.ndarray | pl.Series],
-    benchmark_returns: np.ndarray | pl.Series,
+    benchmark_returns: np.ndarray | pl.Series | pl.DataFrame,
     *,
     block_size: int | None = None,
     n_bootstrap: int = 2000,
     seed: int = 0,
-) -> dict[str, float]:
+) -> dict[str, Any]:
     """White's reality check: do any of K challengers beat the benchmark?
 
     Returns ``{p_value, test_statistic, best_strategy, k_strategies}``.
@@ -888,7 +882,7 @@ def _align_variants_on_timestamp(
 def compute_cohort_metrics(
     returns_by_hash: dict[str, pl.DataFrame],
     *,
-    periods_per_year: float,
+    periods_per_year: int,
     baseline_returns: pl.DataFrame | np.ndarray | None = None,
     fold_returns_by_hash: dict[str, np.ndarray] | None = None,
     rademacher_n_simulations: int = 2000,
@@ -942,6 +936,7 @@ def compute_cohort_metrics(
         variants must share fold cardinality. Skipped if not provided.
     """
     from ml4t.diagnostic.evaluation.stats import (
+        RASResult,
         compute_min_trl,
         deflated_sharpe_ratio,
         effective_number_of_trials,
@@ -1005,14 +1000,22 @@ def compute_cohort_metrics(
 
     # DSR — raw, MP, ER (three calls; library handles K correctly per method)
     arr_list = [matrix[:, i] for i in range(k_variants)]
-    for suffix, kwargs in (
-        ("raw", {}),
-        ("mp", {"correlation_method": "marchenko_pastur"}),
-        ("er", {"correlation_method": "effective_rank"}),
-    ):
+    methods: tuple[
+        tuple[str, Literal["marchenko_pastur", "effective_rank"] | None],
+        ...,
+    ] = (
+        ("raw", None),
+        ("mp", "marchenko_pastur"),
+        ("er", "effective_rank"),
+    )
+    for suffix, method in methods:
         try:
-            if "correlation_method" in kwargs:
-                dsr = deflated_sharpe_ratio(matrix, periods_per_year=periods_per_year, **kwargs)
+            if method is not None:
+                dsr = deflated_sharpe_ratio(
+                    matrix,
+                    periods_per_year=periods_per_year,
+                    correlation_method=method,
+                )
             else:
                 dsr = deflated_sharpe_ratio(arr_list, periods_per_year=periods_per_year)
             out[f"dsr_{suffix}"] = float(dsr.deflated_sharpe)
@@ -1034,12 +1037,15 @@ def compute_cohort_metrics(
             random_state=rademacher_seed,
         )
         annualized_sharpes = sharpes  # already annualized
-        ras_result = ras_sharpe_adjustment(
-            annualized_sharpes,
-            complexity=complexity,
-            n_samples=n_periods,
-            n_strategies=k_variants,
-            return_result=True,
+        ras_result = cast(
+            RASResult,
+            ras_sharpe_adjustment(
+                annualized_sharpes,
+                complexity=complexity,
+                n_samples=n_periods,
+                n_strategies=k_variants,
+                return_result=True,
+            ),
         )
         out["ras_complexity"] = float(complexity)
         out["ras_n_strategies"] = float(k_variants)

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1375,8 +1375,8 @@ case_studies/etfs/09_dl_lstm:
     BATCH_SIZE: 32
     LOOKBACK: 5
     MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 1
+    MAX_SYMBOLS: 6
+    N_EPOCHS: 6
   timeout: 180
 case_studies/etfs/10_dl_tsmixer:
   # LOOKBACK becomes the Darts input_chunk_length, which must exceed
@@ -1389,8 +1389,8 @@ case_studies/etfs/10_dl_tsmixer:
     BATCH_SIZE: 32
     LOOKBACK: 22
     MAX_FOLDS: 2
-    MAX_SYMBOLS: 5
-    N_EPOCHS: 1
+    MAX_SYMBOLS: 6
+    N_EPOCHS: 2
   timeout: 180
 case_studies/etfs/11a_pca:
   # MAX_SYMBOLS must match 04_model_based_features, which builds the temporal

--- a/tests/test_gbm_runtime.py
+++ b/tests/test_gbm_runtime.py
@@ -142,6 +142,28 @@ def test_us_firm_gbm_defaults_use_the_reproducible_reader_backend() -> None:
     )
 
 
+def test_every_case_study_gbm_setup_resolves_the_shared_execution_contract() -> None:
+    resolved = {}
+    for setup_path in sorted((REPO_ROOT / "case_studies").glob("*/config/setup.yaml")):
+        setup = yaml.safe_load(setup_path.read_text()) or {}
+        gbm_config = (setup.get("modeling") or {}).get("gbm")
+        if gbm_config is not None:
+            resolved[setup_path.parents[1].name] = gbm.resolve_gbm_execution_config(gbm_config)
+
+    assert set(resolved) == {
+        "cme_futures",
+        "crypto_perps_funding",
+        "etfs",
+        "fx_pairs",
+        "nasdaq100_microstructure",
+        "sp500_equity_option_analytics",
+        "sp500_options",
+        "us_equities_panel",
+        "us_firm_characteristics",
+    }
+    assert {max_bin for _, max_bin, _ in resolved.values()} == {gbm.GBM_DEFAULT_MAX_BIN}
+
+
 def test_prepare_gbm_folds_keeps_continuous_classification_target() -> None:
     frame = pd.DataFrame(
         {

--- a/tests/test_gbm_runtime.py
+++ b/tests/test_gbm_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 
 import numpy as np
 import pandas as pd
@@ -74,6 +75,8 @@ def test_cpu_runtime_params_are_explicit_and_deterministic() -> None:
 def test_cpu_runtime_params_reject_invalid_thread_count() -> None:
     with pytest.raises(ValueError, match="num_threads must be at least 1"):
         gbm.lightgbm_runtime_params("cpu", num_threads=0)
+    with pytest.raises(ValueError, match="num_threads must be at least 1"):
+        gbm.lightgbm_runtime_params("cuda", num_threads=0)
 
 
 def test_gpu_runtime_params_fail_when_cuda_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -86,7 +89,21 @@ def test_gpu_runtime_params_fail_when_cuda_is_unavailable(monkeypatch: pytest.Mo
 def test_gpu_runtime_params_record_cuda_device(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(gbm, "_best_gpu_device", lambda _library: "cuda")
 
-    assert gbm.lightgbm_runtime_params("cuda") == {"device_type": "cuda"}
+    params = gbm.lightgbm_runtime_params("cuda", num_threads=3)
+    assert params["device_type"] == "cuda"
+    assert params["num_threads"] == 3
+    assert {
+        params[key]
+        for key in (
+            "bagging_seed",
+            "data_random_seed",
+            "drop_seed",
+            "extra_seed",
+            "feature_fraction_seed",
+            "objective_seed",
+            "seed",
+        )
+    } == {42}
 
 
 def test_runtime_params_reject_unknown_device() -> None:
@@ -481,17 +498,58 @@ def test_training_registration_records_runtime_without_changing_hash(tmp_path) -
         json.loads((tmp_path / "run_log" / "training" / training_hash / "runtime.json").read_text())
         == runtime
     )
-    with sqlite3.connect(tmp_path / "run_log" / "registry.db") as db:
+    with closing(sqlite3.connect(tmp_path / "run_log" / "registry.db")) as db:
         [runtime_json] = db.execute(
             "SELECT runtime_json FROM training_runs WHERE training_hash = ?", (training_hash,)
         ).fetchone()
     assert json.loads(runtime_json) == runtime
 
 
+def test_legacy_huber_registration_hashes_declared_fold_scale(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    captured = {}
+
+    def capture_training(_case_study, *, spec, **_kwargs):
+        captured["spec"] = spec
+        return registry.training_hash_from_spec(spec)
+
+    monkeypatch.setattr(registry, "register_training_run", capture_training)
+    monkeypatch.setattr(registry, "get_training_dir", lambda *_args: tmp_path)
+    monkeypatch.setattr(registry, "register_prediction_set", lambda *_args, **_kwargs: "unused")
+    result = {
+        "best_iter": 50,
+        "best_ic": 0.0,
+        "best_ic_std": 0.0,
+        "config_name": "default_huber",
+        "elapsed_s": 0.1,
+        "fold_metrics": [],
+        "learning_curves": [],
+        "predictions": [],
+    }
+    config = {
+        "checkpoint_interval": 50,
+        "config_name": "default_huber",
+        "family": "gbm",
+    }
+
+    gbm.register_gbm_result(
+        "probe",
+        result,
+        config,
+        "fwd_ret_1m",
+        n_folds=2,
+        max_bin=63,
+    )
+
+    assert captured["spec"]["params"]["huber_alpha_scale"] == 0.5
+
+
 def test_runtime_provenance_migrates_a_training_only_registry(tmp_path) -> None:
     run_log = tmp_path / "run_log"
     run_log.mkdir()
-    with sqlite3.connect(run_log / "registry.db") as db:
+    with closing(sqlite3.connect(run_log / "registry.db")) as db:
         db.execute(
             """
             CREATE TABLE training_runs (

--- a/tests/test_latent_factors_no_leak.py
+++ b/tests/test_latent_factors_no_leak.py
@@ -789,6 +789,89 @@ def test_legacy_fresh_and_cached_outputs_share_physical_checkpoint_surface(
     assert fresh_metrics.equals(cached_metrics)
 
 
+def test_filesystem_cache_requires_each_checkpoint_for_each_fold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.utils.latent_factors import cv
+
+    dates = pl.date_range(datetime(2020, 1, 1), datetime(2020, 1, 25), "1d", eager=True)
+    dataset = pl.DataFrame(
+        [
+            {
+                "timestamp": timestamp,
+                "symbol": f"S{symbol}",
+                "value": float(symbol + date_index / 100),
+                "return": float(symbol + date_index / 100),
+            }
+            for date_index, timestamp in enumerate(dates)
+            for symbol in range(6)
+        ]
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": dates[0],
+            "train_end": dates[14],
+            "val_start": dates[15],
+            "val_end": dates[19],
+        },
+        {
+            "fold": 1,
+            "train_start": dates[0],
+            "train_end": dates[19],
+            "val_start": dates[20],
+            "val_end": dates[24],
+        },
+    ]
+    fit_calls = 0
+
+    def fake_cae(chars_train, returns_train, chars_val, returns_val, **_kwargs):
+        nonlocal fit_calls
+        del chars_train, returns_train, returns_val
+        fit_calls += 1
+        physical = chars_val[..., 0]
+        return {0: physical - 1.0, 5: physical}, {"checkpoint_epochs": [0, 5]}
+
+    monkeypatch.setitem(cv._MODEL_RUNNERS, "cae", fake_cae)
+    cache_dir = tmp_path / "cache"
+    kwargs = {
+        "panel_data": None,
+        "splits": splits,
+        "models": ["cae"],
+        "n_factors": 1,
+        "n_epochs": 5,
+        "model_kwargs": {"cae": {"checkpoint_interval": 5}},
+        "save_dir": cache_dir,
+        "dataset": dataset,
+        "feature_names": ["value"],
+        "label_col": "return",
+        "device": "cpu",
+        "num_threads": 1,
+        "checkpoint_surface": "fitted_state",
+    }
+
+    cv.run_latent_factor_cv(**kwargs, use_cache=False)
+    assert fit_calls == 2
+
+    for filename in ("predictions.parquet", "fold_metrics.parquet"):
+        path = cache_dir / "cae" / filename
+        corrupted = pl.read_parquet(path).filter(
+            ~((pl.col("fold_id") == 1) & (pl.col("epoch") == 5))
+        )
+        corrupted.write_parquet(path)
+
+    result = cv.run_latent_factor_cv(**kwargs, use_cache=True)
+
+    assert fit_calls == 4
+    assert set(result["fold_metrics"]["cae"].select("fold_id", "epoch").unique().iter_rows()) == {
+        (0, 0),
+        (0, 5),
+        (1, 0),
+        (1, 5),
+    }
+
+
 @pytest.mark.gpu
 def test_cae_predictions_independent_of_validation_returns() -> None:
     """End-to-end regression: perturbing validation returns must not change predictions.

--- a/tests/test_latent_factors_no_leak.py
+++ b/tests/test_latent_factors_no_leak.py
@@ -762,7 +762,12 @@ def test_legacy_fresh_and_cached_outputs_share_physical_checkpoint_surface(
         "num_threads": 1,
     }
 
-    fresh = cv.run_latent_factor_cv(**kwargs, use_cache=False)
+    fitted_state = cv.run_latent_factor_cv(
+        **kwargs,
+        use_cache=False,
+        checkpoint_surface="fitted_state",
+    )
+    fresh = cv.run_latent_factor_cv(**kwargs, use_cache=True)
     cached = cv.run_latent_factor_cv(**kwargs, use_cache=True)
 
     fresh_predictions = fresh["all_predictions"]["cae"].sort(
@@ -774,6 +779,10 @@ def test_legacy_fresh_and_cached_outputs_share_physical_checkpoint_surface(
     fresh_metrics = fresh["fold_metrics"]["cae"].sort("epoch", "fold_id")
     cached_metrics = cached["fold_metrics"]["cae"].sort("epoch", "fold_id")
 
+    assert fitted_state["all_predictions"]["cae"].get_column("epoch").unique().sort().to_list() == [
+        0,
+        5,
+    ]
     assert fresh_predictions.get_column("epoch").unique().to_list() == [5]
     assert fresh_metrics.get_column("epoch").unique().to_list() == [5]
     assert fresh_predictions.equals(cached_predictions)

--- a/tests/test_latent_factors_no_leak.py
+++ b/tests/test_latent_factors_no_leak.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import polars as pl
@@ -712,6 +713,71 @@ def test_latent_registration_builds_complete_training_identity(
     assert spec["checkpoint_epochs"] == [5]
     assert spec["params"]["input_digest"] == "input-a"
     assert captured["checkpoints"] == [5]
+
+
+def test_legacy_fresh_and_cached_outputs_share_physical_checkpoint_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.utils.latent_factors import cv
+
+    dates = pl.date_range(datetime(2020, 1, 1), datetime(2020, 1, 20), "1d", eager=True)
+    rows = [
+        {
+            "timestamp": timestamp,
+            "symbol": f"S{symbol}",
+            "value": float(symbol + date_index / 100),
+            "return": float(symbol + date_index / 100),
+        }
+        for date_index, timestamp in enumerate(dates)
+        for symbol in range(6)
+    ]
+    dataset = pl.DataFrame(rows)
+    split = {
+        "fold": 0,
+        "train_start": dates[0],
+        "train_end": dates[14],
+        "val_start": dates[15],
+        "val_end": dates[19],
+    }
+
+    def fake_cae(chars_train, returns_train, chars_val, returns_val, **_kwargs):
+        del chars_train, returns_train, returns_val
+        physical = chars_val[..., 0]
+        return {0: physical - 1.0, 5: physical}, {"checkpoint_epochs": [0, 5]}
+
+    monkeypatch.setitem(cv._MODEL_RUNNERS, "cae", fake_cae)
+    kwargs = {
+        "panel_data": None,
+        "splits": [split],
+        "models": ["cae"],
+        "n_factors": 1,
+        "n_epochs": 5,
+        "model_kwargs": {"cae": {"checkpoint_interval": 5}},
+        "save_dir": tmp_path / "legacy-cache",
+        "dataset": dataset,
+        "feature_names": ["value"],
+        "label_col": "return",
+        "device": "cpu",
+        "num_threads": 1,
+    }
+
+    fresh = cv.run_latent_factor_cv(**kwargs, use_cache=False)
+    cached = cv.run_latent_factor_cv(**kwargs, use_cache=True)
+
+    fresh_predictions = fresh["all_predictions"]["cae"].sort(
+        "epoch", "fold_id", "timestamp", "symbol"
+    )
+    cached_predictions = cached["all_predictions"]["cae"].sort(
+        "epoch", "fold_id", "timestamp", "symbol"
+    )
+    fresh_metrics = fresh["fold_metrics"]["cae"].sort("epoch", "fold_id")
+    cached_metrics = cached["fold_metrics"]["cae"].sort("epoch", "fold_id")
+
+    assert fresh_predictions.get_column("epoch").unique().to_list() == [5]
+    assert fresh_metrics.get_column("epoch").unique().to_list() == [5]
+    assert fresh_predictions.equals(cached_predictions)
+    assert fresh_metrics.equals(cached_metrics)
 
 
 @pytest.mark.gpu

--- a/tests/test_latent_input_identity.py
+++ b/tests/test_latent_input_identity.py
@@ -43,6 +43,50 @@ def test_feature_content_enters_latent_training_hash(tmp_path: Path, monkeypatch
     assert training_hash_from_spec(first_spec) != training_hash_from_spec(second_spec)
 
 
+def test_continuous_evaluation_label_enters_classification_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case_dir = tmp_path / "etfs"
+    (case_dir / "features").mkdir(parents=True)
+    (case_dir / "labels").mkdir()
+    (case_dir / "config").mkdir()
+    (case_dir / "features" / "financial.parquet").write_bytes(b"financial")
+    (case_dir / "labels" / "fwd_dir_21d.parquet").write_bytes(b"classes")
+    eval_path = case_dir / "labels" / "fwd_ret_21d.parquet"
+    eval_path.write_bytes(b"returns-v1")
+    (case_dir / "config" / "setup.yaml").write_text("version: 1\n")
+
+    monkeypatch.setattr(case_study, "get_case_study_dir", lambda _case_study_id: case_dir)
+    monkeypatch.setattr(case_study, "load_feature_spec", lambda *_args: None)
+    monkeypatch.setattr(case_study, "load_label_spec", lambda *_args: None)
+    monkeypatch.setattr(
+        case_study,
+        "resolve_storage_path",
+        lambda _case_study_id, _spec, fallback: case_dir / fallback,
+    )
+
+    first = case_study.training_input_identity(
+        "etfs",
+        "fwd_dir_21d",
+        eval_label="fwd_ret_21d",
+    )
+    eval_path.write_bytes(b"returns-v2")
+    second = case_study.training_input_identity(
+        "etfs",
+        "fwd_dir_21d",
+        eval_label="fwd_ret_21d",
+    )
+
+    assert {item["role"] for item in first["files"]} == {
+        "evaluation_label",
+        "financial",
+        "label",
+        "setup",
+    }
+    assert first["input_digest"] != second["input_digest"]
+
+
 def test_fold_extras_are_scoped_by_training_hash(tmp_path: Path, monkeypatch) -> None:
     case_dir = tmp_path / "etfs"
     first_path = case_dir / "run_log" / "training" / "training-a" / "fold_extras.json"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -139,6 +139,7 @@ _REGISTERING_SUFFIXES = frozenset(
         "dl_tsmixer",
         "dl_nlinear",
         "dl_tcn",
+        "dl_weekly",
         # NOTE: causal_dml notebooks register to ``causal_runs`` (DML effect
         # estimates), not ``training_runs`` — so they are intentionally NOT in
         # this set. Likewise ``NN_latent_factors`` is a thin index notebook that
@@ -160,18 +161,16 @@ _REGISTERING_SUFFIXES = frozenset(
 )
 
 
-# DL notebooks use entry_point = "dl_{model}" (e.g. "dl_lstm") instead of
-# the full filename stem (e.g. "09_dl_lstm"). Map stage stems to actual
-# entry_point values for these notebooks.
-def _expected_entry_point(stage: str) -> str:
-    """Return the entry_point value the notebook will use in the registry."""
+# DL notebooks register either their full stage name or ``dl_{model}``.
+def _expected_entry_points(stage: str) -> tuple[str, ...]:
+    """Return the allowed entry-point values for one model notebook."""
     match = _STAGE_RE.match(stage)
     suffix = stage[len(match.group(0)) :] if match else stage
     if suffix.startswith("dl_"):
-        return suffix
+        return tuple(sorted({stage, suffix}))
     if suffix in {"lstm", "patchtst"}:
-        return f"dl_{suffix}"
-    return stage
+        return tuple(sorted({stage, f"dl_{suffix}"}))
+    return (stage,)
 
 
 _STAGE_RE = re.compile(r"^(\d{2})[a-z]?_")
@@ -217,21 +216,23 @@ def test_etf_checkpoint_contract_parameters_come_from_notebook_overrides() -> No
 
 
 @pytest.mark.parametrize(
-    ("stage", "entry_point"),
+    ("stage", "entry_points"),
     [
-        ("09_dl_lstm", "dl_lstm"),
-        ("09a_lstm", "dl_lstm"),
-        ("09b_patchtst", "dl_patchtst"),
-        ("11b_ipca", "11b_ipca"),
-        ("11c_conditional_autoencoder", "11c_conditional_autoencoder"),
+        ("09_dl_lstm", ("09_dl_lstm", "dl_lstm")),
+        ("09a_lstm", ("09a_lstm", "dl_lstm")),
+        ("09b_patchtst", ("09b_patchtst", "dl_patchtst")),
+        ("11b_ipca", ("11b_ipca",)),
+        ("11c_conditional_autoencoder", ("11c_conditional_autoencoder",)),
     ],
 )
-def test_registering_stage_maps_to_its_actual_entry_point(stage: str, entry_point: str) -> None:
+def test_registering_stage_maps_to_its_actual_entry_points(
+    stage: str, entry_points: tuple[str, ...]
+) -> None:
     match = _STAGE_RE.match(stage)
     assert match is not None
     suffix = stage[len(match.group(0)) :]
     assert suffix in _REGISTERING_SUFFIXES
-    assert _expected_entry_point(stage) == entry_point
+    assert _expected_entry_points(stage) == entry_points
 
 
 # ---------------------------------------------------------------------------
@@ -469,11 +470,12 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
         # Some notebooks (e.g. 12_pca) re-register configs that were
         # already created by an earlier notebook (11_latent_factors),
         # resulting in upserts with 0 net new rows but updated entry_points.
-        expected_ep = _expected_entry_point(stage)
+        expected_entry_points = _expected_entry_points(stage)
+        entry_point_filter = ", ".join(f"'{entry}'" for entry in expected_entry_points)
         runs = _query_registry(
             registry_db,
             "training_runs",
-            f"entry_point = '{expected_ep}'",
+            f"entry_point IN ({entry_point_filter})",
         )
 
         if new_training > 0:
@@ -525,14 +527,14 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
         elif len(runs) > 0:
             print(
                 f"\n  Registry OK: {len(runs)} training_runs with "
-                f"entry_point='{expected_ep}' (upserted, no net new rows)"
+                f"entry_point in {expected_entry_points} (upserted, no net new rows)"
             )
         else:
             # Neither new entries nor matching entry_points — real failure
             msg = (
                 f"{case_study}::{stage} has register=True but created "
                 f"0 new training_runs and found 0 with "
-                f"entry_point='{expected_ep}' (total: {after['training_runs']})"
+                f"entry_point in {expected_entry_points} (total: {after['training_runs']})"
             )
             raise AssertionError(msg)
     else:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -150,21 +150,27 @@ _REGISTERING_SUFFIXES = frozenset(
         "sdf",
         "cae",
         "sae",
+        "lstm",
+        "patchtst",
+        "conditional_autoencoder",
+        "stochastic_discount_factor",
+        "supervised_autoencoder",
     }
 )
+
 
 # DL notebooks use entry_point = "dl_{model}" (e.g. "dl_lstm") instead of
 # the full filename stem (e.g. "09_dl_lstm"). Map stage stems to actual
 # entry_point values for these notebooks.
-_DL_RE = re.compile(r"^\d{2}_(dl_.+)$")
-
-
 def _expected_entry_point(stage: str) -> str:
     """Return the entry_point value the notebook will use in the registry."""
-    m = _DL_RE.match(stage)
-    if m:
-        return m.group(1)  # "09_dl_lstm" → "dl_lstm"
-    return stage  # "06_linear" → "06_linear"
+    match = _STAGE_RE.match(stage)
+    suffix = stage[len(match.group(0)) :] if match else stage
+    if suffix.startswith("dl_"):
+        return suffix
+    if suffix in {"lstm", "patchtst"}:
+        return f"dl_{suffix}"
+    return stage
 
 
 _STAGE_RE = re.compile(r"^(\d{2})[a-z]?_")
@@ -173,14 +179,9 @@ _STAGE_RE = re.compile(r"^(\d{2})[a-z]?_")
 def _quick_parameters(
     case_study: str,
     stage: str,
-    notebook_path: Path,
     override_params: dict,
 ) -> tuple[dict, str]:
     parameters = dict(_QUICK_PARAMS)
-    if case_study == "etfs" and notebook_path.stem == "09_dl_lstm":
-        parameters.update({"MAX_SYMBOLS": 6, "N_EPOCHS": 6})
-    if case_study == "etfs" and notebook_path.stem == "10_dl_tsmixer":
-        parameters.update({"MAX_SYMBOLS": 6, "N_EPOCHS": 2})
 
     stage_match = _STAGE_RE.match(stage)
     suffix = stage[len(stage_match.group(0)) :] if stage_match else stage
@@ -196,13 +197,40 @@ def test_notebook_override_parameters_have_final_precedence() -> None:
     parameters, suffix = _quick_parameters(
         "sp500_equity_option_analytics",
         "11b_ipca",
-        Path("case_studies/sp500_equity_option_analytics/11b_ipca.py"),
         {"MAX_SYMBOLS": 12, "N_FACTORS": 2},
     )
 
     assert suffix == "ipca"
     assert parameters["MAX_SYMBOLS"] == 12
     assert parameters["N_FACTORS"] == 2
+
+
+def test_etf_checkpoint_contract_parameters_come_from_notebook_overrides() -> None:
+    for stage, expected in {
+        "09_dl_lstm": {"MAX_SYMBOLS": 6, "N_EPOCHS": 6},
+        "10_dl_tsmixer": {"MAX_SYMBOLS": 6, "N_EPOCHS": 2},
+    }.items():
+        overrides = get_overrides(f"case_studies/etfs/{stage}")["parameters"]
+        parameters, _ = _quick_parameters("etfs", stage, overrides)
+        assert {key: parameters[key] for key in expected} == expected
+
+
+@pytest.mark.parametrize(
+    ("stage", "entry_point"),
+    [
+        ("09_dl_lstm", "dl_lstm"),
+        ("09a_lstm", "dl_lstm"),
+        ("09b_patchtst", "dl_patchtst"),
+        ("11b_ipca", "11b_ipca"),
+        ("11c_conditional_autoencoder", "11c_conditional_autoencoder"),
+    ],
+)
+def test_registering_stage_maps_to_its_actual_entry_point(stage: str, entry_point: str) -> None:
+    match = _STAGE_RE.match(stage)
+    assert match is not None
+    suffix = stage[len(match.group(0)) :]
+    assert suffix in _REGISTERING_SUFFIXES
+    assert _expected_entry_point(stage) == entry_point
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +422,6 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
     parameters, suffix_p = _quick_parameters(
         case_study,
         stage,
-        notebook_path,
         overrides.get("parameters", {}),
     )
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -161,16 +161,19 @@ _REGISTERING_SUFFIXES = frozenset(
 )
 
 
-# DL notebooks register either their full stage name or ``dl_{model}``.
-def _expected_entry_points(stage: str) -> tuple[str, ...]:
-    """Return the allowed entry-point values for one model notebook."""
-    match = _STAGE_RE.match(stage)
-    suffix = stage[len(match.group(0)) :] if match else stage
-    if suffix.startswith("dl_"):
-        return tuple(sorted({stage, suffix}))
-    if suffix in {"lstm", "patchtst"}:
-        return tuple(sorted({stage, f"dl_{suffix}"}))
-    return (stage,)
+_DL_FAMILY_ENTRY_POINTS = {
+    ("cme_futures", "09_dl_lstm"): "dl_lstm",
+    ("etfs", "10_dl_tsmixer"): "dl_tsmixer",
+    ("sp500_equity_option_analytics", "09_dl_lstm"): "dl_lstm",
+    ("sp500_equity_option_analytics", "10_dl_patchtst"): "dl_patchtst",
+    ("sp500_options", "09a_lstm"): "dl_lstm",
+    ("sp500_options", "09b_patchtst"): "dl_patchtst",
+}
+
+
+def _expected_entry_point(case_study: str, stage: str) -> str:
+    """Return the exact entry point declared by one model notebook."""
+    return _DL_FAMILY_ENTRY_POINTS.get((case_study, stage), stage)
 
 
 _STAGE_RE = re.compile(r"^(\d{2})[a-z]?_")
@@ -216,23 +219,24 @@ def test_etf_checkpoint_contract_parameters_come_from_notebook_overrides() -> No
 
 
 @pytest.mark.parametrize(
-    ("stage", "entry_points"),
+    ("case_study", "stage", "entry_point"),
     [
-        ("09_dl_lstm", ("09_dl_lstm", "dl_lstm")),
-        ("09a_lstm", ("09a_lstm", "dl_lstm")),
-        ("09b_patchtst", ("09b_patchtst", "dl_patchtst")),
-        ("11b_ipca", ("11b_ipca",)),
-        ("11c_conditional_autoencoder", ("11c_conditional_autoencoder",)),
+        ("etfs", "09_dl_lstm", "09_dl_lstm"),
+        ("etfs", "10_dl_tsmixer", "dl_tsmixer"),
+        ("sp500_options", "09a_lstm", "dl_lstm"),
+        ("sp500_options", "09b_patchtst", "dl_patchtst"),
+        ("etfs", "11b_ipca", "11b_ipca"),
+        ("etfs", "11c_conditional_autoencoder", "11c_conditional_autoencoder"),
     ],
 )
-def test_registering_stage_maps_to_its_actual_entry_points(
-    stage: str, entry_points: tuple[str, ...]
+def test_registering_stage_maps_to_its_actual_entry_point(
+    case_study: str, stage: str, entry_point: str
 ) -> None:
     match = _STAGE_RE.match(stage)
     assert match is not None
     suffix = stage[len(match.group(0)) :]
     assert suffix in _REGISTERING_SUFFIXES
-    assert _expected_entry_points(stage) == entry_points
+    assert _expected_entry_point(case_study, stage) == entry_point
 
 
 # ---------------------------------------------------------------------------
@@ -470,12 +474,11 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
         # Some notebooks (e.g. 12_pca) re-register configs that were
         # already created by an earlier notebook (11_latent_factors),
         # resulting in upserts with 0 net new rows but updated entry_points.
-        expected_entry_points = _expected_entry_points(stage)
-        entry_point_filter = ", ".join(f"'{entry}'" for entry in expected_entry_points)
+        expected_entry_point = _expected_entry_point(case_study, stage)
         runs = _query_registry(
             registry_db,
             "training_runs",
-            f"entry_point IN ({entry_point_filter})",
+            f"entry_point = '{expected_entry_point}'",
         )
 
         if new_training > 0:
@@ -527,14 +530,14 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
         elif len(runs) > 0:
             print(
                 f"\n  Registry OK: {len(runs)} training_runs with "
-                f"entry_point in {expected_entry_points} (upserted, no net new rows)"
+                f"entry_point='{expected_entry_point}' (upserted, no net new rows)"
             )
         else:
             # Neither new entries nor matching entry_points — real failure
             msg = (
                 f"{case_study}::{stage} has register=True but created "
                 f"0 new training_runs and found 0 with "
-                f"entry_point in {expected_entry_points} (total: {after['training_runs']})"
+                f"entry_point='{expected_entry_point}' (total: {after['training_runs']})"
             )
             raise AssertionError(msg)
     else:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -107,9 +107,8 @@ _LATENT_FACTOR_OVERRIDES = {
 _SPARSE_DATA_CASE_STUDIES = frozenset({"us_firm_characteristics"})
 _SPARSE_DATA_OVERRIDES = {"MAX_SYMBOLS": 20}
 
-# Minimal parameters for code-path coverage. Applied LAST so they
-# override anything from overrides.yaml — we want the absolute minimum
-# that still exercises the full train→register→predict loop.
+# Minimal parameters for code-path coverage. Family and sparse-data defaults
+# refine this base; notebook-specific overrides have final precedence.
 _QUICK_PARAMS = {
     "MAX_SYMBOLS": 5,
     "MAX_FOLDS": 2,
@@ -168,7 +167,42 @@ def _expected_entry_point(stage: str) -> str:
     return stage  # "06_linear" → "06_linear"
 
 
-_STAGE_RE = re.compile(r"^(\d{2})_")
+_STAGE_RE = re.compile(r"^(\d{2})[a-z]?_")
+
+
+def _quick_parameters(
+    case_study: str,
+    stage: str,
+    notebook_path: Path,
+    override_params: dict,
+) -> tuple[dict, str]:
+    parameters = dict(_QUICK_PARAMS)
+    if case_study == "etfs" and notebook_path.stem == "09_dl_lstm":
+        parameters.update({"MAX_SYMBOLS": 6, "N_EPOCHS": 6})
+    if case_study == "etfs" and notebook_path.stem == "10_dl_tsmixer":
+        parameters.update({"MAX_SYMBOLS": 6, "N_EPOCHS": 2})
+
+    stage_match = _STAGE_RE.match(stage)
+    suffix = stage[len(stage_match.group(0)) :] if stage_match else stage
+    if suffix in _LATENT_FACTOR_SUFFIXES:
+        parameters.update(_LATENT_FACTOR_OVERRIDES)
+    if case_study in _SPARSE_DATA_CASE_STUDIES:
+        parameters.update(_SPARSE_DATA_OVERRIDES)
+    parameters.update(override_params)
+    return parameters, suffix
+
+
+def test_notebook_override_parameters_have_final_precedence() -> None:
+    parameters, suffix = _quick_parameters(
+        "sp500_equity_option_analytics",
+        "11b_ipca",
+        Path("case_studies/sp500_equity_option_analytics/11b_ipca.py"),
+        {"MAX_SYMBOLS": 12, "N_FACTORS": 2},
+    )
+
+    assert suffix == "ipca"
+    assert parameters["MAX_SYMBOLS"] == 12
+    assert parameters["N_FACTORS"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +221,7 @@ def _collect_model_notebooks() -> list[tuple[str, str, Path]]:
         cs_dir = PROD_CS_DIR / cs
         if not cs_dir.exists():
             continue
-        for notebook in sorted(cs_dir.glob("[0-9][0-9]_*.py")):
+        for notebook in sorted(cs_dir.glob("[0-9][0-9]*_*.py")):
             if notebook.name.startswith("_"):
                 continue
             match = _STAGE_RE.match(notebook.name)
@@ -357,27 +391,12 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
     # reduced path to remain scientifically valid.
     # Papermill warns (but doesn't error) about unknown parameters, so it's
     # safe to inject all of them even if the notebook doesn't use them all.
-    override_params = overrides.get("parameters", {})
-    parameters = {**_QUICK_PARAMS, **override_params}
-
-    # Exercise the ETF LSTM's multi-checkpoint registration contract in the
-    # reduced E2E run. Epochs 5 and 6 must both become prediction sets.
-    if case_study == "etfs" and notebook_path.stem == "09_dl_lstm":
-        parameters["N_EPOCHS"] = 6
-        parameters["MAX_SYMBOLS"] = 6
-    if case_study == "etfs" and notebook_path.stem == "10_dl_tsmixer":
-        parameters["N_EPOCHS"] = 2
-        parameters["MAX_SYMBOLS"] = 6
-
-    # Latent factor models need a wider cross-section for factor extraction
-    stage_match_p = _STAGE_RE.match(stage)
-    suffix_p = stage[len(stage_match_p.group(0)) :] if stage_match_p else stage
-    if suffix_p in _LATENT_FACTOR_SUFFIXES:
-        parameters.update(_LATENT_FACTOR_OVERRIDES)
-
-    # Sparse-data case studies (monthly frequency) need more symbols
-    if case_study in _SPARSE_DATA_CASE_STUDIES:
-        parameters.update(_SPARSE_DATA_OVERRIDES)
+    parameters, suffix_p = _quick_parameters(
+        case_study,
+        stage,
+        notebook_path,
+        overrides.get("parameters", {}),
+    )
 
     default_timeout = 600 if suffix_p in _LATENT_FACTOR_SUFFIXES else 300
     timeout = overrides.get("timeout", default_timeout)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -480,6 +480,9 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
             "training_runs",
             f"entry_point = '{expected_entry_point}'",
         )
+        assert runs, (
+            f"{case_study}::{stage} found no training run with entry_point='{expected_entry_point}'"
+        )
 
         if new_training > 0:
             assert new_predictions > 0, (
@@ -527,19 +530,11 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
                 finally:
                     db.close()
                 assert {1, 2}.issubset(checkpoints), checkpoints
-        elif len(runs) > 0:
+        else:
             print(
                 f"\n  Registry OK: {len(runs)} training_runs with "
                 f"entry_point='{expected_entry_point}' (upserted, no net new rows)"
             )
-        else:
-            # Neither new entries nor matching entry_points — real failure
-            msg = (
-                f"{case_study}::{stage} has register=True but created "
-                f"0 new training_runs and found 0 with "
-                f"entry_point='{expected_entry_point}' (total: {after['training_runs']})"
-            )
-            raise AssertionError(msg)
     else:
         # Non-registering notebook — just report what happened
         new_training = after["training_runs"] - before["training_runs"]

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -13,8 +13,9 @@ Design:
     4. After each run, query the test registry.db for expected entries
 
 The goal is code-path coverage, not model quality. Params are set to the
-absolute minimum that still exercises the training→register→predict loop:
-MAX_SYMBOLS=3, MAX_FOLDS=2, N_EPOCHS=2, NUM_BOOST_ROUND=20.
+minimum that still exercises the training→register→predict loop and produces
+valid cross-sectional metrics: MAX_SYMBOLS=5, MAX_FOLDS=2, N_EPOCHS=2,
+NUM_BOOST_ROUND=20.
 
 Usage:
     # All model notebooks (~15-20 min)
@@ -110,7 +111,7 @@ _SPARSE_DATA_OVERRIDES = {"MAX_SYMBOLS": 20}
 # override anything from overrides.yaml — we want the absolute minimum
 # that still exercises the full train→register→predict loop.
 _QUICK_PARAMS = {
-    "MAX_SYMBOLS": 3,
+    "MAX_SYMBOLS": 5,
     "MAX_FOLDS": 2,
     "N_EPOCHS": 2,
     "NUM_BOOST_ROUND": 20,
@@ -351,12 +352,13 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
             pytest.skip("torch not installed")
 
     # --- Parameters ---
-    # Start with overrides.yaml, then apply ALL quick-test params on top.
-    # Quick params win — we want minimal runtime, not overrides.yaml scale.
+    # Start with quick defaults, then retain notebook-specific reduced settings.
+    # Some notebooks need wider cross-sections or longer windows for their
+    # reduced path to remain scientifically valid.
     # Papermill warns (but doesn't error) about unknown parameters, so it's
     # safe to inject all of them even if the notebook doesn't use them all.
     override_params = overrides.get("parameters", {})
-    parameters = {**override_params, **_QUICK_PARAMS}
+    parameters = {**_QUICK_PARAMS, **override_params}
 
     # Exercise the ETF LSTM's multi-checkpoint registration contract in the
     # reduced E2E run. Epochs 5 and 6 must both become prediction sets.

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -65,6 +65,7 @@ _READ_ONLY_DIRS = {"config", "features", "labels"}
 
 # Minimum stage number for model notebooks
 _MODEL_STAGE_MIN = 6
+_MODEL_STAGE_MIN_BY_CASE = {"us_firm_characteristics": 5}
 
 # Suffixes that are NOT model notebooks (backtest, strategy, diagnostics).
 # These depend on upstream predictions and should be tested separately.
@@ -256,7 +257,7 @@ def _collect_model_notebooks() -> list[tuple[str, str, Path]]:
             if not match:
                 continue
             stage_num = int(match.group(1))
-            if stage_num < _MODEL_STAGE_MIN:
+            if stage_num < _MODEL_STAGE_MIN_BY_CASE.get(cs, _MODEL_STAGE_MIN):
                 continue
             # Skip non-model notebooks (backtest, strategy, diagnostics)
             suffix = notebook.stem[len(match.group(0)) :]
@@ -267,6 +268,13 @@ def _collect_model_notebooks() -> list[tuple[str, str, Path]]:
 
 
 MODEL_TESTS = _collect_model_notebooks()
+
+
+def test_collection_includes_us_firm_linear_stage() -> None:
+    assert any(
+        case_study == "us_firm_characteristics" and stage == "05_linear"
+        for case_study, stage, _ in MODEL_TESTS
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import time
 from pathlib import Path
 
 import polars as pl
@@ -11,6 +12,7 @@ from case_studies.research import (
     CandidateSet,
     EligibilityManifest,
     OfficialPopulation,
+    PredictionResult,
     Result,
     Study,
     run_backtests,
@@ -74,6 +76,38 @@ def test_run_models_returns_catalog_rows_and_diagnostics(tmp_path: Path, monkeyp
     assert execution.catalog_rows.item(0, "complete") is True
     assert execution.diagnostics[0]["status"] == "completed"
     assert execution.diagnostics[0]["fitted_folds"] == [0, 1]
+
+
+def test_individual_and_batch_linear_execution_are_equivalent(tmp_path: Path, monkeypatch) -> None:
+    individual_study = _linear_study(tmp_path / "individual", monkeypatch)
+    individual_runs = []
+    for alpha in (1.0, 2.0):
+        request = individual_study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        individual_runs.append(run_models(individual_study, requests=[request]).runs[0])
+
+    batch_study = _linear_study(tmp_path / "batch", monkeypatch)
+    batch_requests = [
+        batch_study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        for alpha in (1.0, 2.0)
+    ]
+    batch_runs = run_models(batch_study, requests=batch_requests).runs
+
+    assert [run.training.hash for run in individual_runs] == [
+        run.training.hash for run in batch_runs
+    ]
+    for individual, batch in zip(individual_runs, batch_runs, strict=True):
+        assert individual.predictions[0].hash == batch.predictions[0].hash
+        assert individual.predictions[0].load().equals(batch.predictions[0].load())
 
 
 def test_backtest_selection_validation_fails_before_any_write(tmp_path: Path) -> None:
@@ -164,6 +198,72 @@ def test_n_catalog_rows_fan_out_to_n_independent_backtests(tmp_path: Path) -> No
     assert _backtest_count(study) == 2
 
 
+def test_strategy_change_creates_a_backtest_without_retraining(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    selected = study.predictions.table().filter(pl.col("prediction_hash") == prediction_hash)
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        before = {
+            table: db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in ("training_runs", "prediction_sets")
+        }
+
+    first = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    )
+    second = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 2},
+        prices=_prices(),
+    )
+
+    assert first.results[0].hash != second.results[0].hash
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        after = {
+            table: db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in ("training_runs", "prediction_sets")
+        }
+    assert after == before
+
+
+def test_preview_prediction_is_excluded_from_official_population(
+    tmp_path: Path, monkeypatch
+) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    preview = (
+        run_models(
+            study,
+            requests=[
+                study.model(
+                    family="linear",
+                    label="fwd_ret_1d",
+                    config_name="ridge",
+                    execution_tier="preview",
+                    preview_reductions={"folds": [0]},
+                )
+            ],
+        )
+        .runs[0]
+        .predictions[0]
+    )
+
+    assert study.predictions.table().is_empty()
+    assert study.predictions.table(include_preview=True).height == 1
+    with pytest.raises(ValueError, match="preview.*cannot enter"):
+        OfficialPopulation.create(
+            study,
+            name="preview-must-not-enter-official",
+            member_kind="prediction",
+            members=[preview.hash],
+        )
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert db.execute("SELECT COUNT(*) FROM official_populations").fetchone() == (0,)
+
+
 def test_backtest_immutability_uses_the_same_semantic_projection_as_hashing(
     tmp_path: Path,
 ) -> None:
@@ -237,8 +337,37 @@ def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Pat
     alternate_release = _seed_release(tmp_path / "alternate", marker="alternate")
     relocated = Study.open("etfs", workspace=tmp_path / "workspace", release_root=alternate_release)
     relocated_prediction = Result.open(relocated, prediction_hash)
+    assert isinstance(relocated_prediction, PredictionResult)
     assert relocated_prediction.root == release_case
     assert relocated_prediction.load().height == _predictions().height
+
+
+def test_quick_start_uses_human_fields_and_exposes_lineage_within_budget(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    release_case = release / "case_studies" / "etfs"
+    _publish(release_case, spec=_resolved_spec())
+    started = time.perf_counter()
+
+    study = Study.open("etfs", workspace=tmp_path / "reader-workspace", release_root=release)
+    selected = study.predictions.table().filter(
+        (pl.col("label") == "fwd_ret_21d")
+        & (pl.col("family") == "linear")
+        & (pl.col("config_name") == "ridge")
+        & (pl.col("split") == "validation")
+        & pl.col("complete")
+    )
+    backtest = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    ).results[0]
+    lineage = backtest.lineage()
+
+    assert selected.height == 1
+    assert lineage["prediction_hash"] == selected.item(0, "prediction_hash")
+    assert lineage["training_spec"]["config_name"] == "ridge"
+    assert time.perf_counter() - started < 15 * 60
 
 
 def test_unfinished_training_cannot_satisfy_an_official_population(tmp_path: Path) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -844,10 +844,6 @@ def test_real_sdf_preset_resolves_reduced_preview_schedule(tmp_path, monkeypatch
 
     assert resolved.spec["computation"]["model"]["params"]["checkpoint_epochs"] == [1]
     assert [item["value"] for item in resolved.spec["computation"]["checkpoint_schedule"]] == [
-        -3,
-        -2,
-        -1,
-        0,
         1,
         2,
     ]

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -849,6 +849,31 @@ def test_real_sdf_preset_resolves_reduced_preview_schedule(tmp_path, monkeypatch
     ]
 
 
+@pytest.mark.parametrize(
+    ("model_name", "reduction"),
+    [
+        ("pca", {"n_epochs": 1}),
+        ("sae", {"n_factors": 2}),
+        ("sdf", {"n_epochs": 1}),
+        ("sdf", {"n_factors": 2}),
+    ],
+)
+def test_latent_preview_rejects_model_specific_noop_reductions(
+    tmp_path, monkeypatch, model_name, reduction
+) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match=f"unsupported {model_name} preview reductions"):
+        study.model(
+            family="latent_factors",
+            label="fwd_ret_1d",
+            config_name=model_name,
+            overrides={"device": "cpu", "use_macro": False},
+            execution_tier="preview",
+            preview_reductions={"folds": [0], **reduction},
+        ).resolve()
+
+
 def test_sdf_rejects_unimplemented_expected_return_mapper() -> None:
     case = cast(
         LatentFactorCaseStudyContext,

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 from types import SimpleNamespace
+from typing import Any, cast
 
 import numpy as np
 import polars as pl
@@ -16,9 +18,23 @@ from case_studies.research import (
     register_adapter,
     registered_adapters,
 )
+from case_studies.research.results import ResultsCatalog
+from case_studies.utils import gbm as gbm_utils
 from case_studies.utils import linear
+from case_studies.utils.latent_factors import adapter as latent_adapter
+from case_studies.utils.latent_factors import case_study as latent_case_study
+from case_studies.utils.latent_factors.cae import run_cae_fold
+from case_studies.utils.latent_factors.case_study import LatentFactorCaseStudyContext
+from case_studies.utils.latent_factors.cv import _expected_latent_checkpoints, load_fold_extras
+from case_studies.utils.latent_factors.ipca import run_ipca_fold
+from case_studies.utils.latent_factors.library_bridge import (
+    predict_latent_fold_from_artifact,
+)
+from case_studies.utils.latent_factors.sae import run_sae_fold
+from case_studies.utils.latent_factors.sdf import run_sdf_fold
 from tests.test_research_registry import _predictions
 from tests.test_research_workspace import _seed_release
+from utils import modeling
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +101,7 @@ def _linear_study(tmp_path, monkeypatch):
         temporal_by_fold=None,
         temporal_keys=[],
         temporal_feature_names=[],
+        temporal_artifact_splits=[],
         eval_label_col=None,
         input_lineage={
             "artifacts": {
@@ -157,6 +174,68 @@ def test_linear_runner_persists_complete_reusable_result(tmp_path, monkeypatch) 
     ]
 
 
+def test_linear_runner_replays_valid_models_after_registration_interrupt(
+    tmp_path, monkeypatch
+) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    request = study.model(family="linear", label="fwd_ret_1d", config_name="ridge")
+    original_publish = ResultsCatalog.publish_predictions
+    attempted_predictions = None
+
+    def interrupt_registration(*args, **kwargs):
+        nonlocal attempted_predictions
+        attempted_predictions = kwargs["predictions"].clone()
+        raise RuntimeError("interrupted registration")
+
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", interrupt_registration)
+    with pytest.raises(RuntimeError, match="interrupted registration"):
+        request.run()
+    resolved = request.resolve()
+    training_hash = linear.training_hash_from_spec(resolved.spec)
+    model_dir = study.storage_root() / "run_log" / "training" / training_hash / "models"
+    fitted_digests = {
+        path.name: linear._sha256(path) for path in sorted(model_dir.glob("fold_*.joblib"))
+    }
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", original_publish)
+    monkeypatch.setattr(
+        linear.Ridge,
+        "fit",
+        lambda *args, **kwargs: pytest.fail("valid fitted state must not retrain"),
+    )
+
+    recovered = request.run()
+
+    assert recovered.predictions[0].complete
+    assert recovered.predictions[0].coverage()["n_expected"] == 12
+    assert attempted_predictions is not None
+    assert recovered.predictions[0].load().equals(attempted_predictions)
+    assert fitted_digests == {
+        path.name: linear._sha256(path) for path in sorted(model_dir.glob("fold_*.joblib"))
+    }
+    assert recovered.diagnostics == {
+        "cache_hit": False,
+        "reused_folds": [0, 1],
+        "fitted_folds": [],
+    }
+    runtime = json.loads((model_dir.parent / "runtime.json").read_text())
+    assert runtime["elapsed_s"] > 0
+
+
+def test_linear_runtime_update_is_atomic(tmp_path, monkeypatch) -> None:
+    runtime_path = tmp_path / "runtime.json"
+    runtime_path.write_text('{"status": "registered"}\n')
+
+    def interrupt_replace(*args, **kwargs):
+        raise RuntimeError("interrupted runtime update")
+
+    monkeypatch.setattr(linear.os, "replace", interrupt_replace)
+    with pytest.raises(RuntimeError, match="interrupted runtime update"):
+        linear._write_runtime_fields(runtime_path, elapsed_s=1.0)
+
+    assert json.loads(runtime_path.read_text()) == {"status": "registered"}
+    assert list(tmp_path.glob(".runtime.json.*.tmp")) == []
+
+
 def test_linear_override_changes_training_identity(tmp_path, monkeypatch) -> None:
     study = _linear_study(tmp_path, monkeypatch)
     base = study.model(family="linear", label="fwd_ret_1d", config_name="ridge").resolve()
@@ -205,6 +284,52 @@ def test_custom_cv_uses_label_timeline_not_feature_availability() -> None:
     assert full_record == reduced_record
 
 
+@pytest.mark.parametrize("family", ["linear", "gbm", "latent_factors"])
+def test_model_adapters_reject_custom_cv_for_fold_scoped_temporal_features(
+    family,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    cv = CVSpec.walk_forward(
+        training_window="2D",
+        validation_window="1D",
+        folds=(0,),
+    )
+    if family == "linear":
+        study = _linear_study(tmp_path / family, monkeypatch)
+        context = linear.load_modeling_dataset("etfs", "fwd_ret_1d")
+        selector = "case_studies.utils.linear._select_splits"
+        config_name = "ridge"
+    elif family == "gbm":
+        study = _gbm_study(tmp_path / family, monkeypatch)
+        context = modeling.load_modeling_dataset("etfs", "fwd_ret_1d")
+        selector = "case_studies.utils.gbm._gbm_select_splits"
+        config_name = "leaves_7_mse"
+    else:
+        study = _latent_study(tmp_path / family, monkeypatch)
+        context = latent_case_study.load_case_study_context("etfs")
+        selector = "case_studies.utils.latent_factors.adapter._select_splits"
+        config_name = "pca"
+    context.temporal_by_fold = pl.DataFrame({"fold": [0]}).to_pandas()
+    context.temporal_keys = ["symbol", "timestamp"]
+    context.temporal_feature_names = ["temporal_value"]
+    context.temporal_artifact_splits = [dict(context.splits[0])]
+    variant_splits = [{**context.splits[0], "train_end": "2024-01-01"}]
+    context.splits = variant_splits
+    monkeypatch.setattr(
+        selector, lambda *_args, **_kwargs: (variant_splits, {"identity": "variant-buffer"})
+    )
+
+    with pytest.raises(ValueError, match="incompatible with fold-scoped temporal features"):
+        study.model(
+            family=family,
+            label="fwd_ret_1d",
+            config_name=config_name,
+            cv=cv,
+            overrides={"device": "cpu", "max_bin": 63} if family == "gbm" else {},
+        ).resolve()
+
+
 def test_product_entity_is_normalized_at_prediction_boundary() -> None:
     meta = pl.DataFrame(
         {"product": ["ES", "NQ"], "timestamp": ["2024-01-01", "2024-01-01"]}
@@ -214,6 +339,836 @@ def test_product_entity_is_normalized_at_prediction_boundary() -> None:
 
     assert expected.columns == ["symbol", "timestamp", "fold"]
     assert expected.get_column("symbol").to_list() == ["ES", "NQ"]
+
+
+def _gbm_study(tmp_path, monkeypatch):
+    study = _linear_study(tmp_path, monkeypatch)
+    modeling_dataset = linear.load_modeling_dataset("etfs", "fwd_ret_1d")
+    monkeypatch.setattr(modeling, "load_modeling_dataset", lambda *args, **kwargs: modeling_dataset)
+    monkeypatch.setattr(
+        modeling,
+        "load_configs",
+        lambda *args, **kwargs: [
+            {
+                "checkpoint_interval": 2,
+                "config_name": "leaves_7_mse",
+                "family": "gbm",
+                "library": "lightgbm",
+                "max_iterations": 4,
+                "params": {
+                    "learning_rate": 0.1,
+                    "min_child_samples": 2,
+                    "num_leaves": 7,
+                    "objective": "regression",
+                    "seed": 42,
+                },
+            }
+        ],
+    )
+
+    def fake_train(config, fold_data, *, save_dir, **kwargs):
+        booster_dir = save_dir / "boosters"
+        booster_dir.mkdir(parents=True)
+        checkpoints = gbm_utils.gbm_checkpoint_iterations(config)
+        predictions = []
+        for fold in fold_data:
+            (booster_dir / f"fold_{fold['fold']}.txt").write_text(f"fold={fold['fold']}\n")
+            for checkpoint in checkpoints:
+                predictions.append(
+                    {
+                        "dates": fold["dates"],
+                        "entities": fold["entities"],
+                        "y_true": fold["y_val"],
+                        "y_eval": fold.get("y_eval"),
+                        "y_pred": fold["X_val"][:, 0] + checkpoint / 100,
+                        "fold": fold["fold"],
+                        "n_trees": checkpoint,
+                    }
+                )
+        return {
+            "learning_curves": [
+                {
+                    "config": config["config_name"],
+                    "iteration": checkpoint,
+                    "ic_mean": 0.01 * checkpoint,
+                    "ic_std": 0.0,
+                }
+                for checkpoint in checkpoints
+            ],
+            "predictions": predictions,
+        }
+
+    monkeypatch.setattr(gbm_utils, "train_gbm_config", fake_train)
+    return study
+
+
+def test_gbm_runner_persists_every_declared_checkpoint(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="gbm",
+        label="fwd_ret_1d",
+        config_name="leaves_7_mse",
+        overrides={"device": "cpu", "max_bin": 63},
+    )
+
+    resolved = request.resolve()
+    fresh = resolved.run()
+    cached = request.run()
+
+    assert resolved.spec["identity_version"] == 3
+    assert resolved.spec["resolved_spec_schema"] == "ml4t.resolved-spec/v1"
+    assert [item["value"] for item in resolved.spec["computation"]["checkpoint_schedule"]] == [2, 4]
+    assert len(fresh.predictions) == len(cached.predictions) == 2
+    assert [result.hash for result in fresh.predictions] == [
+        result.hash for result in cached.predictions
+    ]
+    assert all(result.complete for result in fresh.predictions)
+    assert all(result.coverage()["n_expected"] == 12 for result in fresh.predictions)
+    assert set(study.predictions.table()["identity_status"]) == {"current"}
+    model_dir = fresh.training.root / "run_log" / "training" / fresh.training.hash / "models"
+    assert sorted(path.name for path in (model_dir / "boosters").glob("*.txt")) == [
+        "fold_0.txt",
+        "fold_1.txt",
+    ]
+
+
+def test_gbm_runner_replays_valid_models_after_partial_registration(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="gbm",
+        label="fwd_ret_1d",
+        config_name="leaves_7_mse",
+        overrides={"device": "cpu", "max_bin": 63},
+    )
+    original_publish = ResultsCatalog.publish_predictions
+    calls = 0
+
+    def interrupt_after_first(catalog, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("interrupted registration")
+        return original_publish(catalog, *args, **kwargs)
+
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", interrupt_after_first)
+    with pytest.raises(RuntimeError, match="interrupted registration"):
+        request.run()
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", original_publish)
+
+    class ReplayBooster:
+        def __init__(self, *, model_file):
+            self.model_file = model_file
+
+        def predict(self, values, *, num_iteration):
+            return values[:, 0] + num_iteration / 100
+
+    monkeypatch.setattr("lightgbm.Booster", ReplayBooster)
+    monkeypatch.setattr(
+        gbm_utils,
+        "train_gbm_config",
+        lambda *args, **kwargs: pytest.fail("valid fitted state must not retrain"),
+    )
+
+    recovered = request.run()
+
+    assert len(recovered.predictions) == 2
+    assert all(result.complete for result in recovered.predictions)
+    curves = (
+        recovered.training.root
+        / "run_log"
+        / "training"
+        / recovered.training.hash
+        / "learning_curves.parquet"
+    )
+    assert pl.read_parquet(curves).get_column("iteration").to_list() == [2, 4]
+
+
+def test_gbm_runner_finalizes_curves_after_prediction_registration_interrupt(
+    tmp_path, monkeypatch
+) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="gbm",
+        label="fwd_ret_1d",
+        config_name="leaves_7_mse",
+        overrides={"device": "cpu", "max_bin": 63},
+    )
+    original_write = gbm_utils._write_learning_curves
+
+    def interrupt_curve_write(*args, **kwargs):
+        raise RuntimeError("interrupted curve finalization")
+
+    monkeypatch.setattr(gbm_utils, "_write_learning_curves", interrupt_curve_write)
+    with pytest.raises(RuntimeError, match="interrupted curve finalization"):
+        request.run()
+    monkeypatch.setattr(gbm_utils, "_write_learning_curves", original_write)
+
+    class ReplayBooster:
+        def __init__(self, *, model_file):
+            self.model_file = model_file
+
+        def predict(self, values, *, num_iteration):
+            return values[:, 0] + num_iteration / 100
+
+    monkeypatch.setattr("lightgbm.Booster", ReplayBooster)
+    monkeypatch.setattr(
+        gbm_utils,
+        "train_gbm_config",
+        lambda *args, **kwargs: pytest.fail("valid fitted state must not retrain"),
+    )
+
+    recovered = request.run()
+    curves_path = (
+        recovered.training.root
+        / "run_log"
+        / "training"
+        / recovered.training.hash
+        / "learning_curves.parquet"
+    )
+
+    assert [result.complete for result in recovered.predictions] == [True, True]
+    assert gbm_utils._valid_learning_curves(curves_path, request.resolve().spec)
+
+
+def test_huber_threshold_is_fold_scaled_and_hash_covered() -> None:
+    folds = [
+        {"fold": 0, "y_train": np.array([-0.02, 0.0, 0.02])},
+        {"fold": 1, "y_train": np.array([-0.2, 0.0, 0.2])},
+    ]
+    config = {
+        "huber_alpha_scale": 0.5,
+        "params": {"objective": "huber", "seed": 42},
+    }
+
+    effective = gbm_utils._gbm_effective_params_by_fold(
+        config,
+        folds,
+        device="cpu",
+        max_bin=63,
+        num_threads=1,
+        seed=42,
+    )
+
+    assert effective["0"]["alpha"] == pytest.approx(0.5 * np.std(folds[0]["y_train"]))
+    assert effective["1"]["alpha"] == pytest.approx(0.5 * np.std(folds[1]["y_train"]))
+    assert effective["0"]["alpha"] != effective["1"]["alpha"]
+
+
+def test_lightgbm_huber_alpha_is_a_residual_unit_threshold() -> None:
+    import lightgbm as lgb
+
+    rng = np.random.default_rng(7)
+    features = rng.normal(size=(200, 3))
+    labels = 0.02 * features[:, 0] + 0.01 * features[:, 1]
+    labels += rng.normal(scale=0.01, size=200)
+    labels[::20] += 0.15
+    common = {
+        "deterministic": True,
+        "force_col_wise": True,
+        "metric": "None",
+        "min_data_in_leaf": 5,
+        "num_leaves": 7,
+        "num_threads": 1,
+        "seed": 42,
+        "verbosity": -1,
+    }
+    data = lgb.Dataset(features, label=labels)
+    mse = lgb.train({**common, "objective": "regression"}, data, num_boost_round=20)
+    alpha = gbm_utils._scaled_huber_alpha(0.5, labels)
+    huber = lgb.train(
+        {**common, "alpha": alpha, "objective": "huber"},
+        data,
+        num_boost_round=20,
+    )
+    label_scale = 10.0
+    scaled_huber = lgb.train(
+        {**common, "alpha": label_scale * alpha, "objective": "huber"},
+        lgb.Dataset(features, label=label_scale * labels),
+        num_boost_round=20,
+    )
+
+    mse_predictions = np.asarray(mse.predict(features), dtype=np.float64)
+    huber_predictions = np.asarray(huber.predict(features), dtype=np.float64)
+    scaled_predictions = np.asarray(scaled_huber.predict(features), dtype=np.float64)
+    assert alpha == pytest.approx(0.5 * np.std(labels))
+    assert np.max(np.abs(mse_predictions - huber_predictions)) > 0.01
+    np.testing.assert_allclose(
+        scaled_predictions,
+        label_scale * huber_predictions,
+        rtol=1e-5,
+        atol=1e-7,
+    )
+
+
+def test_real_huber_preset_keeps_legacy_training_surface(monkeypatch) -> None:
+    config = next(
+        config
+        for config in modeling.load_configs("etfs", "fwd_ret_21d", "gbm")
+        if config["config_name"] == "default_huber"
+    )
+    captured = []
+
+    class Booster:
+        def predict(self, values, *, num_iteration):
+            del num_iteration
+            return values[:, 0]
+
+        def feature_importance(self, *, importance_type):
+            del importance_type
+            return np.array([1.0])
+
+    def fake_train(params, *_args, **_kwargs):
+        captured.append(dict(params))
+        return Booster()
+
+    monkeypatch.setattr("lightgbm.train", fake_train)
+    folds = []
+    for fold, scale in enumerate((0.01, 0.10)):
+        values = np.arange(6, dtype=float) * scale
+        folds.append(
+            {
+                "fold": fold,
+                "X_train": values[:, None],
+                "X_val": values[:, None],
+                "y_train": values,
+                "y_train_lgb": values,
+                "y_val": values,
+                "y_eval": None,
+                "dates": np.array([f"2024-01-0{fold + 1}"] * 6, dtype="datetime64[D]"),
+                "entities": np.array([f"S{index}" for index in range(6)]),
+                "n_train": 6,
+                "n_val": 6,
+            }
+        )
+
+    result = gbm_utils.train_gbm_config(
+        config,
+        folds,
+        feature_names=["value"],
+        device="cpu",
+        max_bin=63,
+        num_threads=1,
+    )
+
+    effective = result["effective_params_by_fold"]
+    assert [params["alpha"] for params in captured] == [
+        effective["0"]["alpha"],
+        effective["1"]["alpha"],
+    ]
+    assert effective["0"]["alpha"] != effective["1"]["alpha"]
+
+
+def test_multiclass_effective_params_use_resolved_class_count() -> None:
+    folds = [{"fold": 0, "y_train": np.array([0, 1, 2])}]
+    config = {
+        "params": {
+            "num_class": 5,
+            "objective": "multiclass",
+            "seed": 42,
+        }
+    }
+
+    effective = gbm_utils._gbm_effective_params_by_fold(
+        config,
+        folds,
+        device="cpu",
+        max_bin=63,
+        num_threads=1,
+        seed=42,
+        task_type="classification",
+        class_values=[-1, 0, 1],
+    )
+
+    assert effective["0"]["num_class"] == 3
+
+
+@pytest.mark.parametrize("model_name", ["pca", "ipca"])
+def test_real_pca_presets_resolve_checkpoint_metadata(model_name) -> None:
+    presets = latent_case_study._load_preset_model_kwargs("etfs", "fwd_ret_21d")
+    case = cast(LatentFactorCaseStudyContext, SimpleNamespace(model_kwargs=presets))
+
+    model_kwargs, _, _, _, checkpoint_metadata = latent_adapter._resolve_model_configuration(
+        case,
+        model_name,
+        {},
+        {},
+    )
+
+    assert checkpoint_metadata == {"checkpoint_interval": 0}
+    assert "checkpoint_interval" not in model_kwargs
+
+
+def test_legacy_latent_surface_excludes_internal_checkpoint_aliases() -> None:
+    presets = latent_case_study._load_preset_model_kwargs(
+        "us_firm_characteristics",
+        "fwd_ret_1m",
+    )
+
+    assert len(_expected_latent_checkpoints("cae", n_epochs=50, model_kwargs=presets["cae"])) == 10
+    assert len(_expected_latent_checkpoints("sdf", n_epochs=0, model_kwargs=presets["sdf"])) == 5
+    assert 0 in _expected_latent_checkpoints(
+        "cae",
+        n_epochs=50,
+        model_kwargs=presets["cae"],
+        include_internal_aliases=True,
+    )
+
+
+def test_sdf_identity_hashes_resolved_fallback_macro_values(tmp_path, monkeypatch) -> None:
+    _latent_study(tmp_path, monkeypatch)
+    context = latent_case_study.load_case_study_context("etfs")
+    dates = context.dataset.get_column("timestamp").unique().sort()
+    context.macro_panel = pl.DataFrame(
+        {
+            "timestamp": dates,
+            "market_state": np.linspace(0.0, 1.0, len(dates)),
+        }
+    )
+    context.macro_context_spec = {
+        "policy": "load_macro_fallback",
+        "version": "v1",
+    }
+
+    first = latent_adapter._resolved_macro_digest(context)
+    context.macro_panel = context.macro_panel.with_columns(pl.col("market_state") + 0.01)
+    second = latent_adapter._resolved_macro_digest(context)
+
+    assert first != second
+
+
+def test_macro_disabled_sdf_request_retains_disabled_identity(tmp_path, monkeypatch) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+    context = latent_case_study.load_case_study_context("etfs")
+    context.macro_context_spec = {
+        "alignment": "none",
+        "availability_lag_days": 0,
+        "input_digest": None,
+        "policy": "disabled",
+        "series": [],
+        "version": "v1",
+    }
+    context.model_kwargs["sdf"] = {
+        "beta_checkpoint_epochs": [1],
+        "beta_default_checkpoint": 1,
+        "beta_n_epochs": 1,
+        "checkpoint_epochs": [1],
+        "n_epochs_cond": 1,
+        "n_epochs_moment": 1,
+        "n_epochs_unc": 1,
+    }
+
+    resolved = study.model(
+        family="latent_factors",
+        label="fwd_ret_1d",
+        config_name="sdf",
+        overrides={"device": "cpu", "use_macro": False},
+    ).resolve()
+
+    assert resolved.spec["computation"]["macro_context"] == context.macro_context_spec
+
+
+def test_latent_numerical_runtime_changes_training_identity(tmp_path, monkeypatch) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+    requests = [
+        {"deterministic_algorithms": True, "device": "cpu", "num_threads": 1},
+        {"deterministic_algorithms": True, "device": "cuda", "num_threads": 1},
+        {"deterministic_algorithms": True, "device": "cpu", "num_threads": 2},
+        {"deterministic_algorithms": False, "device": "cpu", "num_threads": 1},
+    ]
+
+    identities = {
+        study.model(
+            family="latent_factors",
+            label="fwd_ret_1d",
+            config_name="pca",
+            overrides=runtime,
+        )
+        .resolve()
+        .identity
+        for runtime in requests
+    }
+
+    assert len(identities) == len(requests)
+
+
+def test_real_sdf_preset_resolves_reduced_preview_schedule(tmp_path, monkeypatch) -> None:
+    presets = latent_case_study._load_preset_model_kwargs("etfs", "fwd_ret_21d")
+    study = _latent_study(tmp_path, monkeypatch)
+    context = latent_case_study.load_case_study_context("etfs")
+    context.model_kwargs["sdf"] = presets["sdf"]
+    context.macro_context_spec = {
+        "alignment": "none",
+        "availability_lag_days": 0,
+        "input_digest": None,
+        "policy": "disabled",
+        "series": [],
+        "version": "v1",
+    }
+
+    resolved = study.model(
+        family="latent_factors",
+        label="fwd_ret_1d",
+        config_name="sdf",
+        overrides={"device": "cpu", "use_macro": False},
+        execution_tier="preview",
+        preview_reductions={
+            "n_epochs_cond": 1,
+            "n_epochs_moment": 1,
+            "n_epochs_unc": 1,
+        },
+    ).resolve()
+
+    assert resolved.spec["computation"]["model"]["params"]["checkpoint_epochs"] == [1]
+    assert [item["value"] for item in resolved.spec["computation"]["checkpoint_schedule"]] == [
+        -3,
+        -2,
+        -1,
+        0,
+        1,
+        2,
+    ]
+
+
+def test_sdf_rejects_unimplemented_expected_return_mapper() -> None:
+    case = cast(
+        LatentFactorCaseStudyContext,
+        SimpleNamespace(
+            model_kwargs={
+                "sdf": {
+                    "expected_return_mapper": "neural",
+                    "output_mode": "expected_returns",
+                }
+            }
+        ),
+    )
+
+    with pytest.raises(ValueError, match="supports only 'linear'"):
+        latent_adapter._resolve_model_configuration(case, "sdf", {}, {})
+
+
+def test_cae_fitted_artifact_reconstructs_every_checkpoint(tmp_path) -> None:
+    rng = np.random.default_rng(42)
+    chars_train = rng.normal(size=(4, 5, 3)).astype(np.float32)
+    chars_val = rng.normal(size=(2, 5, 3)).astype(np.float32)
+    returns_train = rng.normal(size=(4, 5)).astype(np.float32)
+    returns_val = rng.normal(size=(2, 5)).astype(np.float32)
+    artifact_dir = tmp_path / "cae"
+
+    fresh, _ = run_cae_fold(
+        chars_train,
+        returns_train,
+        chars_val,
+        returns_val,
+        n_factors=2,
+        n_epochs=2,
+        checkpoint_interval=1,
+        batch_size=20,
+        device="cpu",
+        artifact_dir=artifact_dir,
+    )
+    loaded = predict_latent_fold_from_artifact(
+        "cae",
+        artifact_dir=artifact_dir,
+        chars_train=chars_train,
+        returns_train=returns_train,
+        chars_val=chars_val,
+        returns_val=returns_val,
+        device="cpu",
+    )
+
+    assert sorted(fresh) == sorted(loaded) == [0, 1, 2]
+    assert all(np.array_equal(fresh[epoch], loaded[epoch]) for epoch in fresh)
+    assert sorted(path.name for path in artifact_dir.glob("*.ml4t")) == [
+        "forecaster_0.ml4t",
+        "forecaster_1.ml4t",
+        "forecaster_2.ml4t",
+        "model.ml4t",
+    ]
+
+
+def test_sdf_fitted_heads_reconstruct_every_checkpoint(tmp_path) -> None:
+    rng = np.random.default_rng(42)
+    chars_train = rng.normal(size=(10, 5, 3)).astype(np.float32)
+    chars_val = rng.normal(size=(3, 5, 3)).astype(np.float32)
+    returns_train = rng.normal(scale=0.05, size=(10, 5)).astype(np.float32)
+    returns_val = rng.normal(scale=0.05, size=(3, 5)).astype(np.float32)
+    macro_train = rng.normal(size=(10, 2)).astype(np.float32)
+    macro_val = rng.normal(size=(3, 2)).astype(np.float32)
+    artifact_dir = tmp_path / "sdf"
+    kwargs: dict[str, Any] = {
+        "state_dim_sdf": 2,
+        "state_dim_moment": 2,
+        "hidden_dim": 4,
+        "n_instruments": 2,
+        "n_epochs_unc": 1,
+        "n_epochs_moment": 1,
+        "n_epochs_cond": 1,
+        "checkpoint_epochs": [1],
+        "beta_n_epochs": 1,
+        "beta_checkpoint_epochs": [1],
+        "beta_default_checkpoint": 1,
+        "output_mode": "beta_network",
+        "device": "cpu",
+    }
+
+    fresh, _ = run_sdf_fold(
+        chars_train,
+        returns_train,
+        chars_val,
+        returns_val,
+        macro_train=macro_train,
+        macro_val=macro_val,
+        artifact_dir=artifact_dir,
+        **kwargs,
+    )
+    loaded = predict_latent_fold_from_artifact(
+        "sdf",
+        artifact_dir=artifact_dir,
+        chars_train=chars_train,
+        returns_train=returns_train,
+        chars_val=chars_val,
+        returns_val=returns_val,
+        macro_train=macro_train,
+        macro_val=macro_val,
+        output_mode="beta_network",
+        device="cpu",
+    )
+
+    expected = _expected_latent_checkpoints(
+        "sdf",
+        n_epochs=0,
+        model_kwargs=kwargs,
+        include_internal_aliases=True,
+    )
+    assert sorted(fresh) == sorted(loaded) == list(expected) == [-3, -2, -1, 0, 1, 2]
+    assert all(np.array_equal(fresh[checkpoint], loaded[checkpoint]) for checkpoint in fresh)
+
+
+@pytest.mark.parametrize("model_name", ["ipca", "sae"])
+def test_other_latent_fitted_artifacts_reconstruct_predictions(tmp_path, model_name) -> None:
+    rng = np.random.default_rng(42)
+    chars_train = rng.normal(size=(12, 5, 3)).astype(np.float32)
+    chars_val = rng.normal(size=(3, 5, 3)).astype(np.float32)
+    returns_train = rng.normal(scale=0.05, size=(12, 5)).astype(np.float32)
+    returns_val = rng.normal(scale=0.05, size=(3, 5)).astype(np.float32)
+    artifact_dir = tmp_path / model_name
+    if model_name == "ipca":
+        predictions, _ = run_ipca_fold(
+            chars_train,
+            returns_train,
+            chars_val,
+            returns_val,
+            n_factors=2,
+            max_iter=20,
+            tol=1.0,
+            artifact_dir=artifact_dir,
+        )
+        fresh = {0: predictions}
+    else:
+        fresh, _ = run_sae_fold(
+            chars_train,
+            returns_train,
+            chars_val,
+            returns_val,
+            n_factors=2,
+            n_epochs=2,
+            checkpoint_interval=1,
+            main_hidden_units=[4, 4, 4, 4],
+            aux_hidden_dim=4,
+            bottleneck_dim=2,
+            device="cpu",
+            artifact_dir=artifact_dir,
+        )
+    loaded = predict_latent_fold_from_artifact(
+        model_name,
+        artifact_dir=artifact_dir,
+        chars_train=chars_train,
+        returns_train=returns_train,
+        chars_val=chars_val,
+        returns_val=returns_val,
+        device="cpu",
+    )
+
+    assert sorted(fresh) == sorted(loaded)
+    assert all(np.array_equal(fresh[checkpoint], loaded[checkpoint]) for checkpoint in fresh)
+
+
+def _latent_study(tmp_path, monkeypatch):
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    dates = [f"2024-01-{day:02d}" for day in range(1, 17)]
+    symbols = [f"S{index}" for index in range(6)]
+    rows = []
+    for date_index, date in enumerate(dates):
+        for symbol_index, symbol in enumerate(symbols):
+            x1 = float(symbol_index - 2.5)
+            x2 = float(date_index) + x1 / 10
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "timestamp": date,
+                    "x1": x1,
+                    "x2": x2,
+                    "fwd_ret_1d": 0.03 * x1 + 0.002 * date_index * x1 + 0.01 * x2,
+                }
+            )
+    frame = pl.DataFrame(rows).with_columns(pl.col("timestamp").str.to_date())
+    study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-10",
+            "val_start": "2024-01-11",
+            "val_end": "2024-01-13",
+        },
+        {
+            "fold": 1,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-13",
+            "val_start": "2024-01-14",
+            "val_end": "2024-01-16",
+        },
+    ]
+    context = LatentFactorCaseStudyContext(
+        case_study_id="etfs",
+        case_dir=study.root,
+        setup={},
+        primary_label="fwd_ret_1d",
+        variant_labels=[],
+        model_kwargs={"pca": {"n_factors": 1}},
+        setup_model_kwargs={},
+        persistent_entities=True,
+        macro_panel=None,
+        macro_context_spec=None,
+        input_data_spec={
+            "version": "v1",
+            "files": [
+                {"role": "financial", "sha256": "sha256:features-v1"},
+                {"role": "label", "sha256": "sha256:label-v1"},
+            ],
+            "input_digest": "sha256:fixture-v1",
+        },
+        dataset=frame,
+        feature_names=["x1", "x2"],
+        task_type="regression",
+        class_values=[],
+        eval_label_col=None,
+        date_col="timestamp",
+        entity_col="symbol",
+        splits=splits,
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        temporal_artifact_splits=[],
+        device="cpu",
+        num_threads=1,
+    )
+    monkeypatch.setattr(
+        "case_studies.utils.latent_factors.case_study.load_case_study_context",
+        lambda *args, **kwargs: context,
+    )
+    monkeypatch.setattr(latent_adapter, "_source_identity", lambda: {"fixture": "v1"})
+    return study
+
+
+def test_latent_runner_persists_and_reconstructs_fitted_state(tmp_path, monkeypatch) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="latent_factors",
+        label="fwd_ret_1d",
+        config_name="pca",
+        overrides={"device": "cpu", "n_factors": 1},
+    )
+
+    resolved = request.resolve()
+    fresh = resolved.run()
+    cached = request.run()
+
+    assert resolved.spec["identity_version"] == 3
+    assert resolved.spec["resolved_spec_schema"] == "ml4t.resolved-spec/v1"
+    assert resolved.spec["computation"]["checkpoint_schedule"] == [{"kind": "epoch", "value": 0}]
+    assert fresh.training.hash == cached.training.hash
+    assert fresh.predictions[0].hash == cached.predictions[0].hash
+    assert fresh.predictions[0].complete
+    assert fresh.predictions[0].coverage()["n_expected"] == 36
+    assert set(study.predictions.table()["identity_status"]) == {"current"}
+    model_dir = fresh.training.root / "run_log" / "training" / fresh.training.hash / "models"
+    assert sorted(model_dir.glob("pca/artifacts/fold_*/model.ml4t")) == [
+        model_dir / "pca" / "artifacts" / "fold_0" / "model.ml4t",
+        model_dir / "pca" / "artifacts" / "fold_1" / "model.ml4t",
+    ]
+    extras = load_fold_extras("etfs", fresh.training.hash)
+    assert extras is not None
+    assert [int(row["fold_id"]) for row in extras] == [0, 1]
+
+
+def test_latent_runner_reuses_fitted_state_after_registration_interrupt(
+    tmp_path, monkeypatch
+) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="latent_factors",
+        label="fwd_ret_1d",
+        config_name="pca",
+        overrides={"device": "cpu", "n_factors": 1},
+    )
+    original_publish = ResultsCatalog.publish_predictions
+
+    def interrupt_registration(*args, **kwargs):
+        raise RuntimeError("interrupted registration")
+
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", interrupt_registration)
+    with pytest.raises(RuntimeError, match="interrupted registration"):
+        request.run()
+    monkeypatch.setattr(ResultsCatalog, "publish_predictions", original_publish)
+    monkeypatch.setattr(
+        latent_adapter,
+        "run_latent_factor_cv",
+        lambda *args, **kwargs: pytest.fail("valid fitted state must not retrain"),
+    )
+
+    recovered = request.run()
+
+    assert len(recovered.predictions) == 1
+    assert recovered.predictions[0].complete
+
+
+def test_latent_runner_recovers_interrupted_fold_diagnostics_publication(
+    tmp_path, monkeypatch
+) -> None:
+    study = _latent_study(tmp_path, monkeypatch)
+    request = study.model(
+        family="latent_factors",
+        label="fwd_ret_1d",
+        config_name="pca",
+        overrides={"device": "cpu", "n_factors": 1},
+    )
+    original_publish = latent_adapter._publish_fold_extras
+
+    def interrupt_publication(*args, **kwargs):
+        raise RuntimeError("interrupted diagnostics publication")
+
+    monkeypatch.setattr(latent_adapter, "_publish_fold_extras", interrupt_publication)
+    with pytest.raises(RuntimeError, match="interrupted diagnostics publication"):
+        request.run()
+    monkeypatch.setattr(latent_adapter, "_publish_fold_extras", original_publish)
+    monkeypatch.setattr(
+        latent_adapter,
+        "run_latent_factor_cv",
+        lambda *args, **kwargs: pytest.fail("valid fitted state must not retrain"),
+    )
+
+    recovered = request.run()
+
+    extras = load_fold_extras("etfs", recovered.training.hash)
+    assert extras is not None
+    assert [int(row["fold_id"]) for row in extras] == [0, 1]
+    assert recovered.predictions[0].complete
 
 
 def test_preview_request_requires_hash_covered_reductions(tmp_path) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import numpy as np
 import polars as pl
 import pytest
+import yaml
 
 from case_studies.research import (
     CVSpec,
@@ -430,6 +431,29 @@ def test_gbm_runner_persists_every_declared_checkpoint(tmp_path, monkeypatch) ->
         "fold_0.txt",
         "fold_1.txt",
     ]
+
+
+def test_gbm_request_uses_setup_execution_config_then_request_overrides(
+    tmp_path, monkeypatch
+) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    setup_path = study.root / "config" / "setup.yaml"
+    setup = yaml.safe_load(setup_path.read_text())
+    setup["modeling"] = {"gbm": {"device": "cpu", "max_bin": 127, "num_threads": 3}}
+    setup_path.write_text(yaml.safe_dump(setup, sort_keys=False))
+
+    configured = study.model(family="gbm", label="fwd_ret_1d", config_name="leaves_7_mse").resolve()
+    overridden = study.model(
+        family="gbm",
+        label="fwd_ret_1d",
+        config_name="leaves_7_mse",
+        overrides={"max_bin": 63, "num_threads": 1},
+    ).resolve()
+
+    configured_params = configured.spec["computation"]["model"]["effective_params_by_fold"]["0"]
+    overridden_params = overridden.spec["computation"]["model"]["effective_params_by_fold"]["0"]
+    assert (configured_params["max_bin"], configured_params["num_threads"]) == (127, 3)
+    assert (overridden_params["max_bin"], overridden_params["num_threads"]) == (63, 1)
 
 
 def test_gbm_runner_replays_valid_models_after_partial_registration(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from case_studies.research import CandidateSet, Result, Study
+from case_studies.research import CandidateSet, PredictionResult, Result, Study
 from case_studies.utils.registry import (
     backtest_hash_from_parts,
     prediction_hash_from_parts,
@@ -114,6 +114,7 @@ def test_legacy_result_reopens_without_being_inferred_complete(tmp_path: Path) -
 
     reopened = Result.open(study, "legacy-prediction")
 
+    assert isinstance(reopened, PredictionResult)
     assert reopened.hash == "legacy-prediction"
     assert reopened.identity_version is None
     assert not reopened.complete
@@ -321,6 +322,7 @@ def test_checkpoint_prediction_schema_must_match(tmp_path: Path) -> None:
 
 def test_preview_requires_identity_covered_reductions(tmp_path: Path) -> None:
     study = _study(tmp_path)
+    assert study.output_root is not None
 
     with pytest.raises(ValueError, match="identity-cover"):
         study.results.register_training(

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sqlite3
 from pathlib import Path
 
 import polars as pl
 import pytest
 
 from case_studies.research import CVSpec, LabelDefinition, Study
+from case_studies.research.contracts import ExecutionTier
+from case_studies.utils import linear
+from case_studies.utils.registry.store import _open_registry
+from utils import modeling
 from utils.artifact_specs import load_setup_config
+from utils.paths import get_case_study_dir
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +73,83 @@ def _seed_release(tmp_path: Path, *, marker: str = "release") -> Path:
     return release
 
 
+def _seed_regeneration_release(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
+    release = _seed_release(tmp_path)
+    case_dir = release / "case_studies" / "etfs"
+    generated_root = release / "generated" / "etfs"
+    targets = {name: generated_root / name for name in ("features", "labels", "run_log")}
+    generated_root.mkdir(parents=True)
+    (case_dir / "run_log").rename(targets["run_log"])
+    targets["features"].mkdir()
+    targets["labels"].mkdir()
+    for name, target in targets.items():
+        (case_dir / name).symlink_to(target, target_is_directory=True)
+
+    (case_dir / "config" / "setup.yaml").write_text(
+        "\n".join(
+            [
+                "labels:",
+                "  primary: fwd_ret_1d",
+                "  buffer: 0D",
+                "  horizons: {fwd_ret_1d: 0D}",
+                "evaluation:",
+                "  n_splits: 2",
+                "  train_size: 4D",
+                "  val_size: 2D",
+                "  holdout_start: '2024-01-11'",
+                "  holdout_end: '2024-01-12'",
+                "  calendar: crypto",
+                "decision:",
+                "  cadence: daily_close",
+                "  execution_delay: next_bar_open",
+                "mapping:",
+                "  position_state_space: long_only",
+                "costs:",
+                "  class: negligible",
+            ]
+        )
+        + "\n"
+    )
+    (release / "case_studies" / "config" / "linear" / "ridge.yaml").write_text(
+        "\n".join(
+            [
+                "config_name: ridge",
+                "family: linear",
+                "library: sklearn",
+                "model_class: Ridge",
+                "params:",
+                "  alpha: 1.0",
+            ]
+        )
+        + "\n"
+    )
+    rows = []
+    for date_index, timestamp in enumerate(
+        pl.date_range(pl.date(2024, 1, 1), pl.date(2024, 1, 10), eager=True)
+    ):
+        for symbol_index in range(6):
+            x1 = float(symbol_index - 2.5)
+            x2 = float(date_index) + x1 / 10
+            rows.append(
+                {
+                    "symbol": f"S{symbol_index}",
+                    "timestamp": timestamp,
+                    "x1": x1,
+                    "x2": x2,
+                    "fwd_ret_1d": 0.03 * x1 + 0.01 * x2,
+                }
+            )
+    frame = pl.DataFrame(rows)
+    frame.select("symbol", "timestamp", "x1", "x2").write_parquet(
+        targets["features"] / "financial.parquet"
+    )
+    frame.select("symbol", "timestamp", "fwd_ret_1d").write_parquet(
+        targets["labels"] / "fwd_ret_1d.parquet"
+    )
+    _open_registry(case_dir).close()
+    return release, targets
+
+
 def test_study_create_and_reopen_do_not_change_release_bytes(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     before = _tree_digest(release)
@@ -77,6 +160,124 @@ def test_study_create_and_reopen_do_not_change_release_bytes(tmp_path: Path) -> 
     assert study.root == reopened.root == tmp_path / "workspace" / "etfs"
     assert study.manifest == reopened.manifest
     assert _tree_digest(release) == before
+
+
+@pytest.mark.parametrize("regular_directory", ["features", "labels", "run_log"])
+def test_regeneration_rejects_regular_generated_artifact_directories(
+    tmp_path: Path, regular_directory: str
+) -> None:
+    release, _ = _seed_regeneration_release(tmp_path)
+    path = release / "case_studies" / "etfs" / regular_directory
+    path.unlink()
+    path.mkdir()
+
+    with pytest.raises(PermissionError, match=regular_directory):
+        Study.regenerate("etfs", release_root=release)
+
+
+def test_regeneration_writes_through_resolved_directory_symlinks(tmp_path: Path) -> None:
+    release, targets = _seed_regeneration_release(tmp_path)
+    study = Study.regenerate("etfs", release_root=release)
+
+    assert study.root == release / "case_studies" / "etfs"
+    assert study.root == get_case_study_dir("etfs")
+    assert all(
+        (study.root / name).resolve(strict=True) == target for name, target in targets.items()
+    )
+
+    feature_probe = pl.DataFrame(
+        {"symbol": ["S0"], "timestamp": ["2024-01-01"], "value": [1.0]}
+    ).with_columns(pl.col("timestamp").str.to_date())
+    feature_probe.write_parquet(get_case_study_dir("etfs") / "features" / "probe.parquet")
+    published = study.labels.publish(
+        LabelDefinition("probe", "regression", "1D"),
+        feature_probe.rename({"value": "probe"}),
+    )
+    training = study.results.register_training(
+        {
+            "identity_version": 2,
+            "execution_tier": "canonical",
+            "family": "linear",
+            "label": "probe",
+            "config_name": "ridge",
+            "seed": 42,
+        }
+    )
+
+    assert (targets["features"] / "probe.parquet").is_file()
+    assert published.path.resolve().parent == targets["labels"]
+    assert (targets["run_log"] / "training" / training.hash / "spec.json").is_file()
+
+
+def test_regeneration_preview_runs_real_model_without_changing_canonical_registry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    release, targets = _seed_regeneration_release(tmp_path)
+    study = Study.regenerate("etfs", release_root=release)
+    canonical_registry = targets["run_log"] / "registry.db"
+    canonical_bytes = canonical_registry.read_bytes()
+    with sqlite3.connect(canonical_registry) as db:
+        canonical_training_rows = db.execute("SELECT COUNT(*) FROM training_runs").fetchone()[0]
+    loaded_from = None
+    real_loader = modeling.load_modeling_dataset
+
+    def observed_loader(*args, **kwargs):
+        nonlocal loaded_from
+        loaded_from = get_case_study_dir("etfs", create=False)
+        return real_loader(*args, **kwargs)
+
+    monkeypatch.setattr(linear, "load_modeling_dataset", observed_loader)
+    run = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        execution_tier=ExecutionTier.PREVIEW,
+        preview_reductions={"folds": [0], "max_symbols": 3, "train_sample_frac": 1.0},
+    ).run()
+
+    preview_case = release / "case_studies" / ".preview" / "etfs"
+    assert loaded_from == preview_case
+    assert (preview_case / "config").is_symlink()
+    assert (preview_case / "config").resolve(strict=True) == study.root / "config"
+    preview_shared_config = release / "case_studies" / ".preview" / "config"
+    canonical_shared_config = release / "case_studies" / "config"
+    assert preview_shared_config.is_symlink()
+    assert preview_shared_config.resolve(strict=True) == canonical_shared_config
+    assert (preview_case / "features").is_symlink()
+    assert (preview_case / "features").resolve(strict=True) == targets["features"]
+    assert (preview_case / "labels").is_symlink()
+    assert (preview_case / "labels").resolve(strict=True) == targets["labels"]
+    assert run.training.root == preview_case
+    assert (
+        preview_case / "run_log" / "training" / run.training.hash / "models" / "manifest.json"
+    ).is_file()
+    assert run.predictions[0].complete
+    assert canonical_registry.read_bytes() == canonical_bytes
+    with sqlite3.connect(canonical_registry) as db:
+        assert (
+            db.execute("SELECT COUNT(*) FROM training_runs").fetchone()[0]
+            == canonical_training_rows
+        )
+    assert not (targets["run_log"] / "training").exists()
+    assert not (targets["run_log"] / "predictions").exists()
+    assert not (targets["run_log"] / "backtest").exists()
+
+    preview_request = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        execution_tier=ExecutionTier.PREVIEW,
+        preview_reductions={"folds": [0], "max_symbols": 3, "train_sample_frac": 1.0},
+    )
+    before_change = preview_request.resolve()
+    setup_path = study.root / "config" / "setup.yaml"
+    setup_path.write_text(setup_path.read_text().replace("train_size: 4D", "train_size: 3D"))
+    after_change = preview_request.resolve()
+
+    assert before_change.spec["computation"]["cv"] != after_change.spec["computation"]["cv"]
+    canonical_preset = canonical_shared_config / "linear" / "ridge.yaml"
+    canonical_preset.unlink()
+    assert not (preview_shared_config / "linear" / "ridge.yaml").exists()
 
 
 def test_release_study_is_read_only(tmp_path: Path) -> None:
@@ -112,6 +313,21 @@ def test_switching_workspaces_invalidates_root_sensitive_config_cache(tmp_path: 
     )
 
     assert load_setup_config("etfs")["marker"] == "second"
+
+
+def test_label_lookup_reactivates_its_owning_workspace(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    first = Study.open("etfs", workspace=tmp_path / "first", release_root=release)
+    frame = pl.DataFrame(
+        {"symbol": ["A"], "timestamp": ["2024-01-01"], "custom": [0.1]}
+    ).with_columns(pl.col("timestamp").str.to_date())
+    published = first.labels.publish(LabelDefinition("custom", "regression", "1D"), frame)
+    Study.open("etfs", workspace=tmp_path / "second", release_root=release)
+
+    resolved = first.labels.get("custom")
+
+    assert resolved.path == published.path
+    assert get_case_study_dir("etfs") == first.root
 
 
 def test_custom_classification_label_resolves_continuous_target(tmp_path: Path) -> None:
@@ -210,3 +426,29 @@ def test_cvspec_resolves_stable_exact_boundaries_and_changes_with_protocol() -> 
     assert first == second == reordered
     assert first.normalized_folds != changed.normalized_folds
     assert first.identity != changed.identity
+
+
+def test_custom_cv_cannot_relabel_fold_scoped_temporal_features() -> None:
+    from case_studies.research.cv import require_fold_scoped_temporal_compatibility
+
+    artifact = [
+        {
+            "fold": 0,
+            "train_start": "2020-01-01",
+            "train_end": "2020-12-31",
+            "val_start": "2021-01-01",
+            "val_end": "2021-03-31",
+        },
+        {
+            "fold": 1,
+            "train_start": "2020-04-01",
+            "train_end": "2021-03-31",
+            "val_start": "2021-04-01",
+            "val_end": "2021-06-30",
+        },
+    ]
+
+    require_fold_scoped_temporal_compatibility([artifact[1]], artifact)
+    changed = [{**artifact[1], "train_end": "2021-05-31"}]
+    with pytest.raises(ValueError, match="incompatible with fold-scoped temporal features"):
+        require_fold_scoped_temporal_compatibility(changed, artifact)

--- a/tests/test_sitecustomize_data_root.py
+++ b/tests/test_sitecustomize_data_root.py
@@ -218,12 +218,13 @@ def test_an_unpopulated_non_worktree_keeps_the_repo_default(clean_env, tmp_path)
     assert os.environ["ML4T_DATA_PATH"] == str(tmp_path / "data")
 
 
-def test_a_linked_worktree_falls_back_to_the_main_working_tree(clean_env):
+def test_a_linked_worktree_falls_back_to_the_main_working_tree(clean_env, monkeypatch):
     main_tree = sc._main_worktree(REPO_ROOT)
     if main_tree is None:
         pytest.skip("this checkout is the main working tree")
     if sc._has_datasets(REPO_ROOT / "data"):
         pytest.skip("this worktree has its own datasets")
+    monkeypatch.setattr(sc, "_data_root_from_dotenv", lambda _repo_root: None)
     sc._anchor_data_root(REPO_ROOT)
     assert os.environ["ML4T_DATA_PATH"] == str(main_tree / "data")
     assert os.environ["ML4T_DATA_PATH_IS_DEFAULT"] == "1"

--- a/tests/test_uncertainty_cscv.py
+++ b/tests/test_uncertainty_cscv.py
@@ -12,6 +12,7 @@ Covers two pieces P2.5 added:
 
 from __future__ import annotations
 
+import warnings
 from math import comb
 
 import numpy as np
@@ -91,7 +92,7 @@ def test_compute_cohort_metrics_populates_pbo_with_fold_returns() -> None:
 
     out = compute_cohort_metrics(
         returns_by_hash,
-        periods_per_year=252.0,
+        periods_per_year=252,
         fold_returns_by_hash=fold_returns_by_hash,
         rademacher_n_simulations=50,
         rademacher_seed=0,
@@ -108,3 +109,53 @@ def test_compute_cohort_metrics_populates_pbo_with_fold_returns() -> None:
     assert out["pbo_median_oos_rank"] is not None
     assert out["pbo_mean_degradation"] is not None
     assert out["pbo_n_folds"] == float(n_folds)
+
+
+def test_bootstrap_uncertainty_uses_seeded_generator() -> None:
+    from case_studies.utils.uncertainty import (
+        compute_backtest_uncertainty,
+        compute_independent_diff_uncertainty,
+        compute_paired_uncertainty,
+    )
+
+    rng = np.random.default_rng(17)
+    baseline = rng.normal(0.0002, 0.01, size=80)
+    challenger = baseline + rng.normal(0.0001, 0.002, size=80)
+
+    backtest = compute_backtest_uncertainty(challenger, n_boot=20, seed=41)
+    paired = compute_paired_uncertainty(challenger, baseline, n_boot=20, seed=41)
+    independent = compute_independent_diff_uncertainty(
+        challenger,
+        baseline[:60],
+        n_boot=20,
+        seed=41,
+    )
+
+    assert backtest["bootstrap_n"] == 20.0
+    assert paired["bootstrap_n"] == 20.0
+    assert independent["bootstrap_n"] == 20.0
+    assert backtest == compute_backtest_uncertainty(challenger, n_boot=20, seed=41)
+    assert paired == compute_paired_uncertainty(challenger, baseline, n_boot=20, seed=41)
+    repeated_independent = compute_independent_diff_uncertainty(
+        challenger,
+        baseline[:60],
+        n_boot=20,
+        seed=41,
+    )
+    assert independent.keys() == repeated_independent.keys()
+    np.testing.assert_allclose(
+        list(independent.values()),
+        list(repeated_independent.values()),
+        equal_nan=True,
+    )
+
+
+def test_sparse_bootstrap_samples_do_not_emit_correlation_warnings() -> None:
+    from case_studies.utils.uncertainty import compute_backtest_uncertainty
+
+    sparse_returns = np.r_[np.zeros(70), np.ones(10) * 0.01]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = compute_backtest_uncertainty(sparse_returns, n_boot=100, seed=0)
+
+    assert result["bootstrap_n"] == 100.0

--- a/tests/test_variant_fold_geometry.py
+++ b/tests/test_variant_fold_geometry.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 
 import case_studies.utils.cv_window as cv_window
+from case_studies.research.cv import require_fold_scoped_temporal_compatibility
 from case_studies.utils.cv_window import assert_variant_folds_are_out_of_sample
 
 
@@ -205,6 +206,13 @@ def _tiny_case_study(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, splits: li
         "_load_setup_yaml",
         lambda _cs: {"labels": {"primary": "primary", "variants": ["variant"]}},
     )
+    monkeypatch.setattr(
+        cv_window,
+        "temporal_artifact_fold_boundaries",
+        lambda case_study, primary_label, _artifact_path: cv_window.modeling_fold_boundaries(
+            case_study, primary_label
+        ),
+    )
     return modeling
 
 
@@ -234,10 +242,12 @@ def test_loading_a_variant_whose_validation_opens_inside_the_fit_is_refused(
 def test_loading_a_variant_whose_validation_opens_after_the_fit_is_allowed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    modeling = _tiny_case_study(tmp_path, monkeypatch, _WHOLE_YEAR)
+    primary_splits = _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")])
+    variant_splits = _splits([("2020-01-01", "2020-06-24", "2020-06-30", "2020-12-31")])
+    modeling = _tiny_case_study(tmp_path, monkeypatch, variant_splits)
     store = {
-        "primary": _splits([("2020-01-01", "2020-06-20", "2020-06-25", "2020-12-31")]),
-        "variant": _splits([("2020-01-01", "2020-06-24", "2020-06-30", "2020-12-31")]),
+        "primary": primary_splits,
+        "variant": variant_splits,
     }
     monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, lab: store.get(lab))
 
@@ -246,6 +256,50 @@ def test_loading_a_variant_whose_validation_opens_after_the_fit_is_allowed(
     # The check hangs off the fold-tagged artifact, so a fixture that loaded no
     # artifact would pass this file vacuously.
     assert mds.temporal_by_fold is not None
+    assert mds.splits == variant_splits
+    assert mds.temporal_artifact_splits == cv_window.modeling_fold_boundaries("cs", "primary")
+    requested = [
+        {
+            key: value.isoformat() if hasattr(value, "isoformat") else value
+            for key, value in primary_splits[0].items()
+        }
+    ]
+    require_fold_scoped_temporal_compatibility(requested, mds.temporal_artifact_splits)
+
+
+def test_loading_preserves_intraday_temporal_artifact_boundaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modeling = _tiny_case_study(tmp_path, monkeypatch, _WHOLE_YEAR)
+    artifact_splits = _splits(
+        [
+            (
+                "2020-01-02 09:32",
+                "2020-06-20 15:22",
+                "2020-06-25 09:31",
+                "2020-12-31 15:58",
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        cv_window,
+        "_derive_modeling_splits",
+        lambda _cs, label: artifact_splits if label == "primary" else None,
+    )
+
+    mds = modeling.load_modeling_dataset("cs", "primary")
+    requested = [
+        {
+            key: value.isoformat() if hasattr(value, "isoformat") else value
+            for key, value in artifact_splits[0].items()
+        }
+    ]
+
+    assert mds.temporal_artifact_splits == artifact_splits
+    require_fold_scoped_temporal_compatibility(requested, mds.temporal_artifact_splits)
+    changed = [{**requested[0], "train_end": "2020-06-20T15:23:00"}]
+    with pytest.raises(ValueError, match="incompatible with fold-scoped temporal features"):
+        require_fold_scoped_temporal_compatibility(changed, mds.temporal_artifact_splits)
 
 
 def test_loading_the_primary_label_does_not_check_itself(
@@ -265,3 +319,223 @@ def test_loading_the_primary_label_does_not_check_itself(
     monkeypatch.setattr(cv_window, "_derive_modeling_splits", lambda _cs, lab: store.get(lab))
 
     assert modeling.load_modeling_dataset("cs", "primary").label_col == "primary"
+
+
+@pytest.mark.parametrize(
+    ("case_study", "timeline_source", "include_outcome_horizon"),
+    [
+        ("cme_futures", "primary_label", False),
+        ("crypto_perps_funding", "primary_label", True),
+        ("etfs", "primary_label", True),
+        ("fx_pairs", "primary_label", False),
+        ("nasdaq100_microstructure", "primary_label", True),
+        ("sp500_equity_option_analytics", "primary_label", True),
+        ("sp500_options", "financial", False),
+        ("us_equities_panel", "primary_label", True),
+    ],
+)
+def test_legacy_temporal_fold_routes_match_locked_stage04_producers(
+    case_study: str,
+    timeline_source: str,
+    include_outcome_horizon: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import polars as pl
+
+    import utils.artifact_specs as artifact_specs
+    import utils.cv_splits as cv_splits
+
+    case_dir = tmp_path / case_study
+    (case_dir / "features").mkdir(parents=True)
+    (case_dir / "labels").mkdir()
+    pl.DataFrame({"timestamp": [datetime(2020, 1, 2)], "feature": [1.0]}).write_parquet(
+        case_dir / "features" / "financial.parquet"
+    )
+    pl.DataFrame({"timestamp": [datetime(2020, 1, 1)], "primary": [0.1]}).write_parquet(
+        case_dir / "labels" / "primary.parquet"
+    )
+    monkeypatch.setattr(
+        cv_window,
+        "_load_setup_yaml",
+        lambda _case_study: {"labels": {"primary": "primary", "buffer": "5D"}},
+    )
+    monkeypatch.setattr(artifact_specs, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(artifact_specs, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(artifact_specs, "resolve_label_buffer", lambda *_args: "5D")
+    monkeypatch.setattr(artifact_specs, "resolve_label_horizon", lambda *_args: "2D")
+    captured = {}
+    producer_folds = _splits(
+        [
+            (
+                "2020-01-02 09:32",
+                "2020-06-20 15:22",
+                "2020-06-25 09:31",
+                "2020-12-31 15:58",
+            )
+        ]
+    )
+
+    def fake_generate(timeline, **kwargs):
+        captured["timestamps"] = timeline.get_column("timestamp").to_list()
+        captured["kwargs"] = kwargs
+        return producer_folds
+
+    monkeypatch.setattr(cv_splits, "generate_cv_splits", fake_generate)
+
+    resolved = cv_window.temporal_artifact_fold_boundaries(
+        case_study,
+        "primary",
+        case_dir / "features" / "model_based.parquet",
+    )
+
+    expected_timestamp = (
+        datetime(2020, 1, 2) if timeline_source == "financial" else datetime(2020, 1, 1)
+    )
+    assert captured["timestamps"] == [expected_timestamp]
+    assert ("outcome_horizon" in captured["kwargs"]) is include_outcome_horizon
+    assert resolved == producer_folds
+
+
+def test_temporal_artifact_sidecar_fold_geometry_precedes_legacy_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    from case_studies.utils.artifact_digest import sidecar_path
+
+    artifact = tmp_path / "model_based.parquet"
+    artifact.write_bytes(b"artifact")
+    folds = [
+        {
+            "fold": 0,
+            "train_start": "2020-01-02T09:32:00",
+            "train_end": "2020-06-20T15:22:00",
+            "val_start": "2020-06-25T09:31:00",
+            "val_end": "2020-12-31T15:58:00",
+        }
+    ]
+    sidecar_path(artifact).write_text(json.dumps({"fold_geometry": folds}))
+    monkeypatch.setitem(cv_window._LEGACY_TEMPORAL_FOLD_ROUTES, "unknown", None)
+
+    assert cv_window.temporal_artifact_fold_boundaries("unknown", "primary", artifact) == folds
+
+
+def _available_corpus_artifact(case_study: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    candidates = (
+        repo_root / "case_studies" / case_study / "features" / "model_based.parquet",
+        repo_root.parent
+        / "code"
+        / "case_studies"
+        / case_study
+        / "features"
+        / "model_based.parquet",
+    )
+    artifact = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if artifact is None:
+        pytest.skip(f"canonical {case_study} model-based artifact is unavailable")
+    return artifact
+
+
+def _comparable_timestamp(value) -> pd.Timestamp:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is not None:
+        timestamp = timestamp.tz_convert("UTC").tz_localize(None)
+    return timestamp
+
+
+@pytest.mark.parametrize(
+    "case_study",
+    [
+        "cme_futures",
+        "crypto_perps_funding",
+        "etfs",
+        "fx_pairs",
+        "nasdaq100_microstructure",
+        "sp500_equity_option_analytics",
+        "sp500_options",
+        "us_equities_panel",
+    ],
+)
+def test_corpus_temporal_fold_geometry_covers_resolved_validation_windows(
+    case_study: str,
+) -> None:
+    import polars as pl
+
+    artifact = _available_corpus_artifact(case_study)
+    primary_label = cv_window.configured_labels(case_study)[0]
+    resolved = cv_window.temporal_artifact_fold_boundaries(
+        case_study,
+        primary_label,
+        artifact,
+    )
+    observed = (
+        pl.scan_parquet(artifact)
+        .select("fold", "timestamp")
+        .unique()
+        .collect()
+        .partition_by("fold", as_dict=True)
+    )
+
+    for split in resolved:
+        fold_rows = observed.get((split["fold"],))
+        assert fold_rows is not None, f"{case_study} has no artifact rows for fold {split['fold']}"
+        timestamps = [_comparable_timestamp(value) for value in fold_rows["timestamp"]]
+        val_start = _comparable_timestamp(split["val_start"])
+        val_end = _comparable_timestamp(split["val_end"])
+        assert min(timestamps) <= val_start <= val_end <= max(timestamps)
+        assert any(val_start <= timestamp <= val_end for timestamp in timestamps)
+
+
+def test_sp500_options_corpus_uses_financial_timeline_geometry() -> None:
+    import polars as pl
+    import yaml
+
+    from utils.artifact_specs import resolve_label_buffer, resolve_label_horizon
+    from utils.cv_splits import generate_cv_splits
+
+    case_study = "sp500_options"
+    primary_label = "ret_to_expiry"
+    artifact = _available_corpus_artifact(case_study)
+    case_dir = artifact.parent.parent
+    repo_root = Path(__file__).resolve().parents[1]
+    setup = yaml.safe_load(
+        (repo_root / "case_studies" / case_study / "config" / "setup.yaml").read_text()
+    )
+    resolved = cv_window.temporal_artifact_fold_boundaries(
+        case_study,
+        primary_label,
+        artifact,
+    )
+    label_timeline = (
+        pl.scan_parquet(case_dir / "labels" / f"{primary_label}.parquet")
+        .select("timestamp")
+        .unique()
+        .collect()
+    )
+    label_derived = generate_cv_splits(
+        label_timeline,
+        case_study_id=case_study,
+        label_buffer=resolve_label_buffer(case_study, primary_label, setup),
+        outcome_horizon=resolve_label_horizon(case_study, primary_label, setup),
+        date_col="timestamp",
+    )
+    observed_starts = (
+        pl.scan_parquet(artifact)
+        .group_by("fold")
+        .agg(pl.col("timestamp").min().alias("timestamp"))
+        .collect()
+    )
+
+    assert any(
+        _comparable_timestamp(actual["train_start"])
+        != _comparable_timestamp(from_label["train_start"])
+        for actual, from_label in zip(resolved, label_derived, strict=True)
+    )
+    for split in resolved:
+        observed_start = observed_starts.filter(pl.col("fold") == split["fold"]).item(
+            0, "timestamp"
+        )
+        assert _comparable_timestamp(split["train_start"]) == _comparable_timestamp(observed_start)

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -28,7 +28,7 @@ import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -123,6 +123,7 @@ class ModelingDataset:
     temporal_by_fold: pd.DataFrame | None = None  # Per-fold temporal features (has 'fold' column)
     temporal_keys: list[str] = field(default_factory=list)  # Join keys for temporal features
     temporal_feature_names: list[str] = field(default_factory=list)  # Temporal feature column names
+    temporal_artifact_splits: list[dict[str, Any]] = field(default_factory=list)
     # Continuous-return label that classification predictions are scored against.
     # None for regression labels. When set, the column lives in ``dataset`` and
     # downstream IC computation must use it instead of the binary ``label_col``.
@@ -498,7 +499,10 @@ def verify_artifact_sidecars(
             if rows is None:
                 continue
             try:
-                actual_rows = pl.scan_parquet(path).select(pl.len()).collect().item()
+                actual_rows = cast(
+                    pl.DataFrame,
+                    pl.scan_parquet(path).select(pl.len()).collect(),
+                ).item()
             except (OSError, pl.exceptions.PolarsError) as exc:
                 problems.append(f"{name}: {path.name} unreadable ({exc})")
                 continue
@@ -716,7 +720,9 @@ def load_modeling_dataset(
         outcome_horizon=resolve_label_horizon(case_study_id, primary_label, setup),
         date_col=date_col,
     )
+    temporal_artifact_splits: list[dict[str, Any]] = []
     if temporal_by_fold_pd is not None:
+        assert temporal is not None
         validate_temporal_fold_coverage(
             dataset,
             temporal,
@@ -735,9 +741,16 @@ def load_modeling_dataset(
         from case_studies.utils.cv_window import (
             assert_variant_folds_are_out_of_sample,
             configured_labels,
+            temporal_artifact_fold_boundaries,
         )
 
         configured = configured_labels(case_study_id)
+        artifact_label = configured[0] if configured else primary_label
+        temporal_artifact_splits = temporal_artifact_fold_boundaries(
+            case_study_id,
+            artifact_label,
+            temporal_path,
+        )
         if configured and primary_label != configured[0]:
             assert_variant_folds_are_out_of_sample(
                 case_study_id, configured[0], variants=[primary_label]
@@ -826,6 +839,7 @@ def load_modeling_dataset(
         temporal_by_fold=temporal_by_fold_pd,
         temporal_keys=_temporal_keys,
         temporal_feature_names=_temporal_feature_names,
+        temporal_artifact_splits=temporal_artifact_splits,
         eval_label_col=eval_label_col,
         lineage_inputs={
             "artifacts": input_artifacts,
@@ -1380,6 +1394,9 @@ def prepare_cv_folds(
         val_mask = (dates_series >= val_start) & (dates_series <= val_end)
 
         if has_fold_temporal:
+            assert temporal_by_fold is not None
+            assert temporal_keys is not None
+            assert temporal_feature_names is not None
             train_rows = replace_temporal_columns(
                 dataset_pd,
                 train_mask,
@@ -1540,6 +1557,9 @@ def prepare_single_fold(
 
         # Replace temporal columns with fold-specific values if available
         if _has_fold_temporal:
+            assert temporal_by_fold is not None
+            assert temporal_keys is not None
+            assert temporal_feature_names is not None
             fold_temp_pd = temporal_by_fold[temporal_by_fold["fold"] == fold_id].drop(
                 columns=["fold"]
             )
@@ -1583,6 +1603,9 @@ def prepare_single_fold(
         val_mask = (dates_series >= val_start) & (dates_series <= val_end)
 
         if _has_fold_temporal:
+            assert temporal_by_fold is not None
+            assert temporal_keys is not None
+            assert temporal_feature_names is not None
             train_rows = replace_temporal_columns(
                 dataset,
                 train_mask,


### PR DESCRIPTION
## Summary

- add reader-facing linear, gradient-boosting, latent-factor, catalog, and backtest execution boundaries
- make preview identities, eligible-key coverage, fitted-state recovery, checkpoint schedules, and restart behavior explicit
- prove the ETF reduced-scale path and tighten the executable notebook and registry contracts

## Validation

- `277 passed` in the focused contract, registry, model, backtest, latent-factor, and uncertainty suite
- `1941 passed, 17 skipped` in the configured non-notebook suite
- changed-path Ruff lint and format checks passed
- public-interface `ty` checks passed with six optional-library stub warnings
- all pre-commit hooks passed
- reduced real-data ETF proofs passed for exact coverage, catalog restart, backtest fan-out, strategy-only changes, GBM checkpoints, latent persistence, and preview exclusion
- RoboRev branch review completed with no blocking findings

This PR does not execute production notebooks, update the canonical registry, or generate official artifacts.