### PR TITLE
Prove crypto research execution contracts

### DIFF
--- a/case_studies/crypto_perps_funding/funding_backtest.py
+++ b/case_studies/crypto_perps_funding/funding_backtest.py
@@ -57,7 +57,7 @@ class FundingSettlementLedger:
             position = broker.positions.get(symbol)
             if position is None or float(position.quantity) == 0.0:
                 continue
-            mark = position.current_price
+            mark = broker.get_mark_price(symbol, quantity=position.quantity)
             if mark is None:
                 raise RuntimeError(f"funding settlement has no current mark for {symbol!r}")
             event_cash -= (

--- a/case_studies/crypto_perps_funding/funding_backtest.py
+++ b/case_studies/crypto_perps_funding/funding_backtest.py
@@ -1,0 +1,103 @@
+"""Funding-settlement accounting for perpetual-futures engine backtests."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Any
+
+import polars as pl
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def apply_funding_settlements(
+    engine_result: Any,
+    *,
+    prices: pl.DataFrame,
+    funding_rates: pl.DataFrame,
+    initial_cash: float,
+) -> dict[str, float]:
+    """Add position-signed funding cash before same-timestamp fills and update engine state."""
+    required = {"symbol", "timestamp", "funding_rate"}
+    missing = required - set(funding_rates.columns)
+    if missing:
+        raise ValueError(f"funding rates are missing columns: {sorted(missing)}")
+    if funding_rates.n_unique(["symbol", "timestamp"]) != funding_rates.height:
+        raise ValueError("funding settlement keys must be unique")
+
+    fills = defaultdict(list)
+    for fill in engine_result.fills:
+        fills[_as_utc(fill.timestamp)].append(fill)
+    rates = defaultdict(dict)
+    for row in funding_rates.select(*sorted(required)).iter_rows(named=True):
+        rates[_as_utc(row["timestamp"])][row["symbol"]] = float(row["funding_rate"])
+    marks = defaultdict(dict)
+    for row in prices.select("timestamp", "symbol", "close").iter_rows(named=True):
+        marks[_as_utc(row["timestamp"])][row["symbol"]] = float(row["close"])
+    engine_equity = {_as_utc(ts): float(value) for ts, value in engine_result.equity_curve}
+
+    cash = float(initial_cash)
+    positions = defaultdict(float)
+    last_marks: dict[str, float] = {}
+    cumulative_funding = 0.0
+    events = 0
+    adjusted = []
+    reconstructed = []
+    funding_by_equity_time: dict[datetime, float] = {}
+    for timestamp in sorted(set(engine_equity) | set(rates)):
+        last_marks.update(marks[timestamp])
+        event_cash = sum(
+            -(positions.get(symbol, 0.0) * last_marks[symbol]) * rate
+            for symbol, rate in rates.get(timestamp, {}).items()
+            if positions.get(symbol, 0.0) != 0 and symbol in last_marks
+        )
+        if event_cash:
+            cash += event_cash
+            cumulative_funding += event_cash
+            events += 1
+        for fill in fills.get(timestamp, []):
+            quantity = float(fill.quantity) if fill.side.value == "buy" else -float(fill.quantity)
+            cash -= quantity * float(fill.price) + float(fill.commission)
+            last_marks.setdefault(fill.asset, float(fill.price))
+            positions[fill.asset] += quantity
+            if abs(positions[fill.asset]) < 1e-12:
+                del positions[fill.asset]
+        if timestamp in engine_equity:
+            marked = sum(quantity * last_marks[symbol] for symbol, quantity in positions.items())
+            adjusted.append((timestamp, cash + marked))
+            reconstructed.append((timestamp, cash - cumulative_funding + marked))
+            funding_by_equity_time[timestamp] = cumulative_funding
+
+    reconstruction_error = max(
+        (abs(value - engine_equity[timestamp]) for timestamp, value in reconstructed),
+        default=0.0,
+    )
+    tolerance = max(1e-6, abs(initial_cash) * 1e-10)
+    if reconstruction_error > tolerance:
+        raise RuntimeError(
+            f"funding ledger cannot reconstruct engine equity: {reconstruction_error:.12g}"
+        )
+    if len(rates) and not adjusted:
+        raise RuntimeError("funding settlements did not overlap the engine equity timeline")
+
+    engine_result.equity_curve = adjusted
+    engine_result.portfolio_state = [
+        (
+            timestamp,
+            equity + funding_by_equity_time[_as_utc(timestamp)],
+            cash_value + funding_by_equity_time[_as_utc(timestamp)],
+            gross,
+            net,
+            count,
+        )
+        for timestamp, equity, cash_value, gross, net, count in engine_result.portfolio_state
+    ]
+    return {
+        "funding_pnl": cumulative_funding,
+        "funding_events": float(events),
+        "funding_settlements": float(funding_rates.height),
+        "funding_reconstruction_error": reconstruction_error,
+    }

--- a/case_studies/crypto_perps_funding/funding_backtest.py
+++ b/case_studies/crypto_perps_funding/funding_backtest.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
+import math
 from datetime import UTC, datetime
+from functools import wraps
 from typing import Any
 
 import polars as pl
@@ -13,91 +14,88 @@ def _as_utc(value: datetime) -> datetime:
     return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
 
 
-def apply_funding_settlements(
-    engine_result: Any,
-    *,
-    prices: pl.DataFrame,
-    funding_rates: pl.DataFrame,
-    initial_cash: float,
-) -> dict[str, float]:
-    """Add position-signed funding cash before same-timestamp fills and update engine state."""
-    required = {"symbol", "timestamp", "funding_rate"}
-    missing = required - set(funding_rates.columns)
-    if missing:
-        raise ValueError(f"funding rates are missing columns: {sorted(missing)}")
-    if funding_rates.n_unique(["symbol", "timestamp"]) != funding_rates.height:
-        raise ValueError("funding settlement keys must be unique")
+class FundingSettlementLedger:
+    """Apply position-signed funding during the engine's bar-time update."""
 
-    fills = defaultdict(list)
-    for fill in engine_result.fills:
-        fills[_as_utc(fill.timestamp)].append(fill)
-    rates = defaultdict(dict)
-    for row in funding_rates.select(*sorted(required)).iter_rows(named=True):
-        rates[_as_utc(row["timestamp"])][row["symbol"]] = float(row["funding_rate"])
-    marks = defaultdict(dict)
-    for row in prices.select("timestamp", "symbol", "close").iter_rows(named=True):
-        marks[_as_utc(row["timestamp"])][row["symbol"]] = float(row["close"])
-    engine_equity = {_as_utc(ts): float(value) for ts, value in engine_result.equity_curve}
+    def __init__(self, funding_rates: pl.DataFrame) -> None:
+        required = {"symbol", "timestamp", "funding_rate"}
+        missing = required - set(funding_rates.columns)
+        if missing:
+            raise ValueError(f"funding rates are missing columns: {sorted(missing)}")
+        selected = funding_rates.select("symbol", "timestamp", "funding_rate")
+        if selected.null_count().row(0) != (0, 0, 0):
+            raise ValueError("funding settlements cannot contain null keys or rates")
+        if selected.n_unique(["symbol", "timestamp"]) != selected.height:
+            raise ValueError("funding settlement keys must be unique")
 
-    cash = float(initial_cash)
-    positions = defaultdict(float)
-    last_marks: dict[str, float] = {}
-    cumulative_funding = 0.0
-    events = 0
-    adjusted = []
-    reconstructed = []
-    funding_by_equity_time: dict[datetime, float] = {}
-    for timestamp in sorted(set(engine_equity) | set(rates)):
-        last_marks.update(marks[timestamp])
-        event_cash = sum(
-            -(positions.get(symbol, 0.0) * last_marks[symbol]) * rate
-            for symbol, rate in rates.get(timestamp, {}).items()
-            if positions.get(symbol, 0.0) != 0 and symbol in last_marks
-        )
+        self._rates: dict[datetime, dict[str, float]] = {}
+        for row in selected.sort("timestamp", "symbol").iter_rows(named=True):
+            rate = float(row["funding_rate"])
+            if not math.isfinite(rate):
+                raise ValueError("funding rates must be finite")
+            self._rates.setdefault(_as_utc(row["timestamp"]), {})[str(row["symbol"])] = rate
+        self._rate_count = selected.height
+        self._settled_timestamps: set[datetime] = set()
+        self._funding_pnl = 0.0
+        self._funding_events = 0
+        self._funding_settlements = 0
+        self._installed = False
+
+    def settle(self, timestamp: datetime, broker: Any) -> float:
+        """Settle one timestamp exactly once against positions marked on that bar."""
+        normalized = _as_utc(timestamp)
+        if normalized in self._settled_timestamps:
+            return 0.0
+        rates = self._rates.get(normalized)
+        if rates is None:
+            return 0.0
+        self._settled_timestamps.add(normalized)
+        self._funding_settlements += len(rates)
+
+        event_cash = 0.0
+        for symbol, rate in rates.items():
+            position = broker.positions.get(symbol)
+            if position is None or float(position.quantity) == 0.0:
+                continue
+            mark = position.current_price
+            if mark is None:
+                raise RuntimeError(f"funding settlement has no current mark for {symbol!r}")
+            event_cash -= (
+                float(position.quantity)
+                * float(mark)
+                * float(getattr(position, "multiplier", 1.0))
+                * rate
+            )
         if event_cash:
-            cash += event_cash
-            cumulative_funding += event_cash
-            events += 1
-        for fill in fills.get(timestamp, []):
-            quantity = float(fill.quantity) if fill.side.value == "buy" else -float(fill.quantity)
-            cash -= quantity * float(fill.price) + float(fill.commission)
-            last_marks.setdefault(fill.asset, float(fill.price))
-            positions[fill.asset] += quantity
-            if abs(positions[fill.asset]) < 1e-12:
-                del positions[fill.asset]
-        if timestamp in engine_equity:
-            marked = sum(quantity * last_marks[symbol] for symbol, quantity in positions.items())
-            adjusted.append((timestamp, cash + marked))
-            reconstructed.append((timestamp, cash - cumulative_funding + marked))
-            funding_by_equity_time[timestamp] = cumulative_funding
+            broker.cash = float(broker.cash) + event_cash
+            self._funding_pnl += event_cash
+            self._funding_events += 1
+        return event_cash
 
-    reconstruction_error = max(
-        (abs(value - engine_equity[timestamp]) for timestamp, value in reconstructed),
-        default=0.0,
-    )
-    tolerance = max(1e-6, abs(initial_cash) * 1e-10)
-    if reconstruction_error > tolerance:
-        raise RuntimeError(
-            f"funding ledger cannot reconstruct engine equity: {reconstruction_error:.12g}"
-        )
-    if len(rates) and not adjusted:
-        raise RuntimeError("funding settlements did not overlap the engine equity timeline")
+    def install(self, broker: Any) -> None:
+        """Install settlement immediately after each engine mark update."""
+        if self._installed:
+            raise RuntimeError("funding settlement ledger is already installed")
+        original_update_time = broker._update_time
 
-    engine_result.equity_curve = adjusted
-    engine_result.portfolio_state = [
-        (
-            timestamp,
-            equity + funding_by_equity_time[_as_utc(timestamp)],
-            cash_value + funding_by_equity_time[_as_utc(timestamp)],
-            gross,
-            net,
-            count,
-        )
-        for timestamp, equity, cash_value, gross, net, count in engine_result.portfolio_state
-    ]
-    return {
-        "funding_pnl": cumulative_funding,
-        "funding_events": float(events),
-        "funding_settlements": float(funding_rates.height),
-        "funding_reconstruction_error": reconstruction_error,
-    }
+        @wraps(original_update_time)
+        def update_time_with_funding(timestamp, *args, **kwargs):
+            result = original_update_time(timestamp, *args, **kwargs)
+            self.settle(timestamp, broker)
+            return result
+
+        broker._update_time = update_time_with_funding
+        self._installed = True
+
+    def metrics(self) -> dict[str, float]:
+        """Return cashflows actually presented to the engine timeline."""
+        if self._funding_settlements != self._rate_count:
+            raise RuntimeError(
+                "funding settlement coverage is incomplete: "
+                f"{self._funding_settlements}/{self._rate_count} keys reached the engine timeline"
+            )
+        return {
+            "funding_pnl": self._funding_pnl,
+            "funding_events": float(self._funding_events),
+            "funding_settlements": float(self._funding_settlements),
+        }

--- a/case_studies/crypto_perps_funding/research_workflow.py
+++ b/case_studies/crypto_perps_funding/research_workflow.py
@@ -1,0 +1,223 @@
+"""Reader-facing workflow helpers for the crypto perpetual-funding case study."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from case_studies.research import (
+    DecisionArtifact,
+    StateTransitionPolicy,
+    Study,
+    run_models,
+)
+from case_studies.research.execution import ModelExecution
+from case_studies.utils.registry import prediction_hash_from_parts
+from utils.modeling import load_configs
+from utils.paths import REPO_ROOT
+
+CASE_STUDY = "crypto_perps_funding"
+ALL_LABELS = ("fwd_ret_8h", "fwd_ret_24h", "fwd_dir_8h", "fwd_dir_8h_3c")
+REGRESSION_LABELS = ("fwd_ret_8h", "fwd_ret_24h")
+
+
+def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> Study:
+    """Open canonical regeneration or an isolated reader preview."""
+    if execution_tier == "canonical":
+        return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+    if execution_tier != "preview":
+        raise ValueError("execution_tier must be canonical or preview")
+    if workspace is None:
+        raise ValueError("preview execution requires an explicit workspace")
+    workspace = Path(workspace).expanduser().resolve()
+    try:
+        return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
+    except ValueError as error:
+        generated = tuple(
+            REPO_ROOT / "case_studies" / CASE_STUDY / name
+            for name in ("features", "labels", "run_log")
+        )
+        if "artifact bundle" not in str(error) or not all(path.is_symlink() for path in generated):
+            raise
+        workspace.mkdir(parents=True, exist_ok=True)
+        shared_config = workspace / "config"
+        if not shared_config.exists():
+            shared_config.symlink_to(
+                REPO_ROOT / "case_studies" / "config", target_is_directory=True
+            )
+        return Study(
+            case_study=CASE_STUDY,
+            root=REPO_ROOT / "case_studies" / CASE_STUDY,
+            release_root=REPO_ROOT,
+            output_root=workspace,
+            read_only=False,
+            manifest={
+                "schema_version": 1,
+                "case_study": CASE_STUDY,
+                "baseline_source_commit": subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True
+                ).strip(),
+                "preview_only": True,
+            },
+        )
+
+
+def model_request_catalog(
+    family: str,
+    *,
+    labels: Iterable[str] = ALL_LABELS,
+    config_prefix: str | None = None,
+) -> pl.DataFrame:
+    """Return the declared label/config population as a Polars catalog."""
+    rows = []
+    for label in labels:
+        for config in load_configs(CASE_STUDY, label, family):
+            name = str(config["config_name"])
+            if config_prefix is None or name.startswith(config_prefix):
+                rows.append(
+                    {
+                        "family": family,
+                        "label": label,
+                        "config_name": name,
+                    }
+                )
+    if not rows:
+        raise ValueError(f"no declared requests for {family!r}")
+    return pl.DataFrame(rows).unique(maintain_order=True)
+
+
+def resolve_model_requests(
+    study: Study,
+    request_catalog: pl.DataFrame,
+    *,
+    execution_tier: str,
+    overrides: dict[str, Any] | None = None,
+    preview_reductions: dict[str, Any] | None = None,
+):
+    """Resolve every visible catalog row through the shared family boundary."""
+    required = {"family", "label", "config_name"}
+    missing = required - set(request_catalog.columns)
+    if missing:
+        raise ValueError(f"model request catalog is missing {sorted(missing)}")
+    return tuple(
+        study.model(
+            **row,
+            execution_tier=execution_tier,
+            overrides=dict(overrides or {}),
+            preview_reductions=dict(preview_reductions or {}),
+        ).resolve()
+        for row in request_catalog.select(*sorted(required)).iter_rows(named=True)
+    )
+
+
+def run_model_catalog(
+    study: Study,
+    request_catalog: pl.DataFrame,
+    *,
+    execution_tier: str,
+    overrides: dict[str, Any] | None = None,
+    preview_reductions: dict[str, Any] | None = None,
+) -> ModelExecution:
+    """Resolve and execute a complete declared population."""
+    resolved = resolve_model_requests(
+        study,
+        request_catalog,
+        execution_tier=execution_tier,
+        overrides=overrides,
+        preview_reductions=preview_reductions,
+    )
+    execution = run_models(study, requests=resolved)
+    if execution.catalog_rows.height != sum(len(run.predictions) for run in execution.runs):
+        raise RuntimeError("model execution did not return every checkpoint catalog row")
+    if execution.catalog_rows.filter(~pl.col("complete")).height:
+        raise RuntimeError("model execution returned incomplete prediction rows")
+    return execution
+
+
+def expected_prediction_hashes(resolved_requests) -> tuple[str, ...]:
+    """Project every declared checkpoint to its immutable validation prediction identity."""
+    hashes = []
+    for request in resolved_requests:
+        computation = request.spec.get("computation", request.spec)
+        checkpoints = computation["checkpoint_schedule"]
+        for checkpoint in checkpoints:
+            hashes.append(
+                prediction_hash_from_parts(
+                    request.identity,
+                    checkpoint["value"],
+                    "validation",
+                    checkpoint_kind=checkpoint["kind"],
+                    identity_version=request.spec["identity_version"],
+                )
+            )
+    if len(hashes) != len(set(hashes)):
+        raise ValueError("declared request population contains duplicate prediction identities")
+    return tuple(hashes)
+
+
+def target_positions(
+    predictions: pl.DataFrame,
+    *,
+    long_count: int = 1,
+    short_count: int = 1,
+) -> pl.DataFrame:
+    """Map scores to deterministic long/short target positions at each decision time."""
+    if long_count < 1 or short_count < 1:
+        raise ValueError("long_count and short_count must be positive")
+    ranked = predictions.with_columns(
+        pl.col("prediction").rank("ordinal").over("timestamp").alias("ascending_rank"),
+        pl.col("prediction")
+        .rank("ordinal", descending=True)
+        .over("timestamp")
+        .alias("descending_rank"),
+    )
+    return (
+        ranked.with_columns(
+            pl.when(pl.col("descending_rank") <= long_count)
+            .then(1.0)
+            .when(pl.col("ascending_rank") <= short_count)
+            .then(-1.0)
+            .otherwise(0.0)
+            .alias("position")
+        )
+        .select("symbol", "timestamp", "position")
+        .sort("timestamp", "symbol")
+    )
+
+
+def publish_exploratory_positions(
+    study: Study,
+    prediction_hash: str,
+    predictions: pl.DataFrame,
+    *,
+    long_count: int = 1,
+    short_count: int = 1,
+) -> DecisionArtifact:
+    """Publish an immediately backtestable, non-canonical Python decision."""
+    return DecisionArtifact.publish(
+        study,
+        kind="target_positions",
+        decisions=target_positions(
+            predictions,
+            long_count=long_count,
+            short_count=short_count,
+        ),
+        prediction_hashes=[prediction_hash],
+        parameters={"long_count": long_count, "short_count": short_count},
+        state_transition_policy=StateTransitionPolicy(
+            fold_boundary="liquidate",
+            temporal_gap="reset",
+        ),
+        canonical=False,
+    )
+
+
+def target_positions_source_digest() -> str:
+    """Return the digest used when this decision generator is promoted after replay."""
+    return hashlib.sha256(inspect.getsource(target_positions).encode()).hexdigest()

--- a/case_studies/crypto_perps_funding/research_workflow.py
+++ b/case_studies/crypto_perps_funding/research_workflow.py
@@ -177,7 +177,11 @@ def target_positions(
         .over("timestamp")
         .alias("descending_rank"),
     )
-    return (
+    fold_columns = [column for column in ("fold", "fold_id") if column in ranked.columns]
+    if len(fold_columns) > 1:
+        raise ValueError("predictions cannot contain both fold and fold_id")
+    selected_fold = fold_columns[:1]
+    result = (
         ranked.with_columns(
             pl.when(pl.col("descending_rank") <= long_count)
             .then(1.0)
@@ -186,9 +190,10 @@ def target_positions(
             .otherwise(0.0)
             .alias("position")
         )
-        .select("symbol", "timestamp", "position")
+        .select("symbol", "timestamp", "position", *selected_fold)
         .sort("timestamp", "symbol")
     )
+    return result.rename({"fold_id": "fold"}) if selected_fold == ["fold_id"] else result
 
 
 def publish_exploratory_positions(
@@ -198,6 +203,7 @@ def publish_exploratory_positions(
     *,
     long_count: int = 1,
     short_count: int = 1,
+    cadence: str = "8h",
 ) -> DecisionArtifact:
     """Publish an immediately backtestable, non-canonical Python decision."""
     return DecisionArtifact.publish(
@@ -209,7 +215,7 @@ def publish_exploratory_positions(
             short_count=short_count,
         ),
         prediction_hashes=[prediction_hash],
-        parameters={"long_count": long_count, "short_count": short_count},
+        parameters={"long_count": long_count, "short_count": short_count, "cadence": cadence},
         state_transition_policy=StateTransitionPolicy(
             fold_boundary="liquidate",
             temporal_gap="reset",

--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -1,4 +1,5 @@
 from .adapters import AdapterBinding, get_adapter, register_adapter, registered_adapters
+from .causal import CausalRequest, CausalResult, ResolvedCausalRequest
 from .comparison import CandidateSet
 from .contracts import ExecutionTier, LifecycleState
 from .cv import CVSpec, EligibilityManifest, ResolvedCVSpec
@@ -19,6 +20,8 @@ __all__ = [
     "BacktestExecution",
     "CVSpec",
     "CandidateSet",
+    "CausalRequest",
+    "CausalResult",
     "DecisionArtifact",
     "ExecutionTier",
     "EligibilityManifest",
@@ -32,6 +35,7 @@ __all__ = [
     "OfficialPopulation",
     "ResearchLock",
     "ResolvedModelRequest",
+    "ResolvedCausalRequest",
     "ResolvedSpec",
     "ResolvedCVSpec",
     "Result",

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.registry.specs import (
+    IDENTITY_VERSION,
+    SUPPORTED_IDENTITY_VERSIONS,
+    training_hash_from_spec,
+)
+
+from .adapters import get_adapter, registered_adapters
+from .contracts import ExecutionTier
+
+if TYPE_CHECKING:
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class CausalResult:
+    study: Study
+    hash: str
+    spec: dict[str, Any]
+    metrics: dict[str, Any]
+    execution_tier: str
+
+    @classmethod
+    def one(
+        cls,
+        study: Study,
+        *,
+        label: str,
+        execution_tier: str = "canonical",
+    ) -> CausalResult:
+        """Resolve one causal result by declared label and execution tier."""
+        tier = ExecutionTier(execution_tier)
+        root = study.storage_root(tier)
+        db_path = root / "run_log" / "registry.db"
+        if not db_path.is_file():
+            raise ValueError(f"causal selection for {label!r} resolved to 0 identities")
+        with sqlite3.connect(db_path) as db:
+            rows = db.execute(
+                "SELECT causal_hash, spec_json FROM causal_runs WHERE label = ? ORDER BY causal_hash",
+                (label,),
+            ).fetchall()
+        current = [
+            causal_hash
+            for causal_hash, spec_json in rows
+            if json.loads(spec_json or "{}").get("identity_version") == IDENTITY_VERSION
+            and json.loads(spec_json or "{}").get("execution_tier", tier.value) == tier.value
+        ]
+        if len(current) != 1:
+            raise ValueError(
+                f"causal selection for {label!r} resolved to {len(current)} identities"
+            )
+        return cls.open(
+            study,
+            current[0],
+            include_preview=tier is ExecutionTier.PREVIEW,
+        )
+
+    @classmethod
+    def open(
+        cls,
+        study: Study,
+        causal_hash: str,
+        *,
+        include_preview: bool = False,
+    ) -> CausalResult:
+        roots = [(study.root, ExecutionTier.CANONICAL.value)]
+        if include_preview and study.output_root is not None:
+            roots.insert(
+                0,
+                (
+                    study.output_root / ".preview" / study.case_study,
+                    ExecutionTier.PREVIEW.value,
+                ),
+            )
+        for root, namespace in roots:
+            db_path = root / "run_log" / "registry.db"
+            if not db_path.is_file():
+                continue
+            with sqlite3.connect(db_path) as db:
+                row = db.execute(
+                    "SELECT n_obs, dml_effect, dml_se_hac, p_value_hac, naive_effect, "
+                    "confounding_bias_pct, refutation_p, spec_json "
+                    "FROM causal_runs WHERE causal_hash = ?",
+                    (causal_hash,),
+                ).fetchone()
+            if row is None:
+                continue
+            spec = json.loads(row[7])
+            tier = str(spec.get("execution_tier", namespace))
+            return cls(
+                study=study,
+                hash=causal_hash,
+                spec=spec,
+                metrics={
+                    "n_obs": row[0],
+                    "dml_effect": row[1],
+                    "dml_se_hac": row[2],
+                    "p_value_hac": row[3],
+                    "naive_effect": row[4],
+                    "confounding_bias_pct": row[5],
+                    "refutation_p": row[6],
+                },
+                execution_tier=tier,
+            )
+        raise KeyError(f"unknown causal result {causal_hash!r}")
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.spec.get("identity_version") in SUPPORTED_IDENTITY_VERSIONS
+            and self.metrics.get("n_obs", 0) > 0
+            and self.metrics.get("dml_effect") is not None
+            and self.metrics.get("dml_se_hac") is not None
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedCausalRequest:
+    study: Study
+    method: str
+    spec: dict[str, Any]
+    _context: Any
+
+    @property
+    def identity(self) -> str:
+        return training_hash_from_spec(self.spec)
+
+    def run(self) -> CausalResult:
+        module = get_adapter("causal", self.method)
+        runner = getattr(module, "run_resolved_causal_request", None)
+        if runner is None:
+            raise NotImplementedError(f"{self.method!r} has no shared causal runner")
+        result = runner(self.study, self.spec, self._context)
+        if not isinstance(result, CausalResult):
+            raise TypeError(
+                f"{self.method!r} runner returned {type(result).__name__}, not CausalResult"
+            )
+        return result
+
+
+@dataclass(frozen=True)
+class CausalRequest:
+    study: Study
+    method: str
+    label: str
+    config_name: str
+    overrides: dict[str, Any]
+    execution_tier: ExecutionTier
+    preview_reductions: dict[str, Any]
+
+    @classmethod
+    def from_request(cls, study: Study, request: dict[str, Any]) -> CausalRequest:
+        supported = {
+            "method",
+            "label",
+            "config_name",
+            "overrides",
+            "execution_tier",
+            "preview_reductions",
+        }
+        unknown = set(request) - supported
+        if unknown:
+            raise ValueError(f"unsupported causal request fields: {sorted(unknown)}")
+        missing = {"method", "label"} - set(request)
+        if missing:
+            raise ValueError(f"causal request is missing fields: {sorted(missing)}")
+        method = str(request["method"])
+        available = {binding.name for binding in registered_adapters("causal")}
+        if method not in available:
+            raise ValueError(f"unsupported causal method {method!r}")
+        tier = ExecutionTier(request.get("execution_tier", ExecutionTier.CANONICAL))
+        reductions = dict(request.get("preview_reductions") or {})
+        if tier is ExecutionTier.PREVIEW and not reductions:
+            raise ValueError("preview causal requests must declare every reduction")
+        if tier is ExecutionTier.CANONICAL and reductions:
+            raise ValueError("canonical causal requests cannot declare preview reductions")
+        return cls(
+            study=study,
+            method=method,
+            label=str(request["label"]),
+            config_name=str(request.get("config_name", method)),
+            overrides=dict(request.get("overrides") or {}),
+            execution_tier=tier,
+            preview_reductions=reductions,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "method": self.method,
+            "label": self.label,
+            "config_name": self.config_name,
+            "overrides": dict(self.overrides),
+            "execution_tier": self.execution_tier.value,
+            "preview_reductions": dict(self.preview_reductions),
+        }
+
+    def resolve(self) -> ResolvedCausalRequest:
+        module = get_adapter("causal", self.method)
+        resolver = getattr(module, "resolve_causal_request", None)
+        if resolver is None:
+            raise NotImplementedError(f"{self.method!r} has no shared causal resolver")
+        spec, context = resolver(self.study, self.as_dict())
+        if spec.get("identity_version") != IDENTITY_VERSION:
+            raise ValueError("causal resolver did not produce the current identity version")
+        if spec.get("resolved_spec_schema") != "ml4t.resolved-spec/v1":
+            raise ValueError("causal resolver did not produce the resolved-spec schema")
+        if spec.get("execution_tier") != self.execution_tier.value:
+            raise ValueError("causal resolver changed the execution tier")
+        return ResolvedCausalRequest(self.study, self.method, spec, context)
+
+    def run(self) -> CausalResult:
+        return self.resolve().run()

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -49,6 +49,11 @@ class CandidateSet:
             raise ValueError("preview results cannot enter a canonical candidate set")
         if any(not member.complete for member in resolved):
             raise ValueError("partial results cannot enter a candidate set")
+        if member_kind == "backtest" and any(
+            (member.spec().get("decision_artifact") or {}).get("canonical") is False
+            for member in resolved
+        ):
+            raise ValueError("exploratory decision backtests cannot enter a candidate set")
         ordered = tuple(sorted(resolved, key=lambda member: member.hash))
         protocols = [member.protocol() for member in ordered]
         if any(protocol["split"] != "validation" for protocol in protocols):
@@ -114,6 +119,18 @@ class CandidateSet:
         return cls(study, set_hash, name, member_kind, member_hashes, contract)
 
     @classmethod
+    def one(cls, study: Study, *, name: str) -> CandidateSet:
+        """Resolve one immutable set by its reader-facing name without a hash handoff."""
+        with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
+            rows = db.execute(
+                "SELECT set_hash FROM candidate_sets WHERE name = ? ORDER BY set_hash",
+                (name,),
+            ).fetchall()
+        if len(rows) != 1:
+            raise ValueError(f"candidate set name {name!r} resolved to {len(rows)} identities")
+        return cls.open(study, rows[0][0])
+
+    @classmethod
     def open(cls, study: Study, set_hash: str) -> CandidateSet:
         db_path = study.root / "run_log" / "registry.db"
         with closing(sqlite3.connect(db_path)) as db:
@@ -170,3 +187,33 @@ class CandidateSet:
         if len(rows) != len(self.members):
             raise ValueError("candidate set contains an ineligible selection member")
         return Result.open(self.study, rows[0][0])
+
+    def ranked_validation_sharpe(self, *, limit: int | None = None) -> tuple[Result, ...]:
+        """Return complete members ordered by validation Sharpe and identity tie-break."""
+        if self.member_kind != "backtest":
+            raise ValueError("validation Sharpe ranking requires backtest members")
+        if limit is not None and limit < 1:
+            raise ValueError("validation Sharpe ranking limit must be positive")
+        placeholders = ",".join("?" for _ in self.members)
+        with closing(sqlite3.connect(self.study.root / "run_log" / "registry.db")) as db:
+            rows = db.execute(
+                f"""
+                SELECT m.backtest_hash
+                FROM backtest_metrics m
+                JOIN backtest_runs b ON b.backtest_hash = m.backtest_hash
+                JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
+                JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash
+                JOIN training_runs t ON t.training_hash = p.training_hash
+                WHERE m.backtest_hash IN ({placeholders})
+                  AND p.split = 'validation'
+                  AND c.status = 'complete'
+                  AND t.execution_tier = 'canonical'
+                  AND m.sharpe IS NOT NULL
+                ORDER BY m.sharpe DESC, m.backtest_hash ASC
+                """,
+                self.members,
+            ).fetchall()
+        if len(rows) != len(self.members):
+            raise ValueError("candidate set contains an ineligible selection member")
+        selected = rows[:limit] if limit is not None else rows
+        return tuple(Result.open(self.study, row[0]) for row in selected)

--- a/case_studies/research/decisions.py
+++ b/case_studies/research/decisions.py
@@ -64,7 +64,10 @@ def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
     return keys
 
 
-def _validate_promotion(source_identity: dict[str, Any]) -> None:
+def _validate_promotion(
+    source_identity: dict[str, Any],
+    prediction_hashes: tuple[str, ...],
+) -> None:
     required = {
         "module",
         "source_digest",
@@ -81,6 +84,13 @@ def _validate_promotion(source_identity: dict[str, Any]) -> None:
         raise ValueError("canonical decision promotion source module is not importable")
     if not source_identity["declared_inputs"]:
         raise ValueError("canonical decision promotion requires declared immutable inputs")
+    declared = source_identity["declared_inputs"]
+    if not isinstance(declared, dict) or declared.get("prediction_hashes") != list(
+        prediction_hashes
+    ):
+        raise ValueError(
+            "canonical decision promotion must disclose the exact prediction_hashes input"
+        )
     determinism = source_identity["determinism"]
     if not isinstance(determinism, dict) or not (
         determinism.get("deterministic") or determinism.get("seed") is not None
@@ -123,15 +133,25 @@ class DecisionArtifact:
         lineage = tuple(dict.fromkeys(prediction_hashes))
         if not lineage or len(lineage) != len(prediction_hashes):
             raise ValueError("decision prediction lineage must be non-empty and unique")
+        prediction_results = []
         for prediction_hash in lineage:
             result = Result.open(study, prediction_hash, include_preview=not canonical)
             if not isinstance(result, PredictionResult):
                 raise ValueError(f"decision lineage {prediction_hash!r} is not a prediction")
-            if canonical and (result.identity_version != IDENTITY_VERSION or not result.complete):
+            if canonical and (
+                result.identity_version != IDENTITY_VERSION
+                or not result.complete
+                or result.execution_tier != "canonical"
+            ):
                 raise ValueError("canonical decision lineage requires current complete predictions")
+            prediction_results.append(result)
+        tiers = {result.execution_tier for result in prediction_results}
+        if len(tiers) != 1:
+            raise ValueError("decision lineage cannot mix canonical and preview predictions")
+        execution_tier = tiers.pop()
         normalized_source = canonical_value(source_identity or {})
         if canonical:
-            _validate_promotion(normalized_source)
+            _validate_promotion(normalized_source, lineage)
         normalized_decisions = decisions.sort(list(key_columns))
         spec = {
             "schema_version": 1,
@@ -145,16 +165,18 @@ class DecisionArtifact:
             "decision_keys": list(key_columns),
             "artifact_digest": value_digest(normalized_decisions),
             "canonical": canonical,
+            "execution_tier": execution_tier,
         }
         if canonical and normalized_source["clean_replay_digest"] != spec["artifact_digest"]:
             raise ValueError("canonical decision clean replay does not match the artifact digest")
         decision_hash = compute_hash(canonical_json(spec))
-        artifact_dir = study.root / "run_log" / "decisions" / decision_hash
+        storage_root = study.storage_root(execution_tier)
+        artifact_dir = storage_root / "run_log" / "decisions" / decision_hash
         artifact = artifact_dir / "decisions.parquet"
         artifact_dir.mkdir(parents=True, exist_ok=True)
         temporary = artifact_dir / f".decisions.{uuid.uuid4().hex}.tmp"
         normalized_decisions.write_parquet(temporary)
-        db = _open_registry(study.root)
+        db = _open_registry(storage_root)
         created_artifact = False
         try:
             db.execute("BEGIN IMMEDIATE")
@@ -190,13 +212,15 @@ class DecisionArtifact:
         finally:
             temporary.unlink(missing_ok=True)
             db.close()
-        return cls(study, decision_hash, kind, spec, canonical, study.root)
+        return cls(study, decision_hash, kind, spec, canonical, storage_root)
 
     @classmethod
     def open(cls, study: Study, decision_hash: str) -> DecisionArtifact:
         roots = [study.root]
         if study.release_case_root != study.root:
             roots.append(study.release_case_root)
+        if study.output_root is not None:
+            roots.append(study.output_root / ".preview" / study.case_study)
         for root in roots:
             db_path = root / "run_log" / "registry.db"
             if not db_path.is_file():

--- a/case_studies/research/decisions.py
+++ b/case_studies/research/decisions.py
@@ -61,6 +61,11 @@ def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
     values = selected.get_column(value_column).cast(pl.Float64)
     if any(not math.isfinite(value) for value in values):
         raise ValueError("decision artifact values must be finite")
+    fold_columns = [column for column in ("fold", "fold_id") if column in decisions.columns]
+    if len(fold_columns) > 1:
+        raise ValueError("decision artifacts cannot contain both fold and fold_id")
+    if fold_columns and decisions.get_column(fold_columns[0]).null_count():
+        raise ValueError("decision artifact fold values cannot be null")
     return keys
 
 

--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -174,11 +174,14 @@ def run_backtests(
     costs: dict[str, Any] | None = None,
     chapter: str | None = None,
     execution_mode: str | None = None,
+    decision=None,
 ) -> BacktestExecution:
     study.require_writable()
     if not isinstance(predictions, pl.DataFrame):
         raise TypeError("run_backtests requires a Polars prediction catalog selection")
     resolved = _validate_selection(study, predictions)
+    if decision is not None and len(resolved) != 1:
+        raise ValueError("one decision artifact requires exactly one selected prediction")
     for prediction in resolved:
         _import_released_prediction(study, prediction)
 
@@ -188,6 +191,7 @@ def run_backtests(
         result = study.strategy(
             prediction=prediction,
             signal=signal,
+            decision=decision,
             allocation=allocation,
             risk=risk,
             costs=costs,

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -132,9 +132,14 @@ class Lifecycle:
         lock_hash = compute_hash(canonical_json(lock_record))
         db = _open_registry(self.study.root)
         try:
+            existing_lock = db.execute(
+                "SELECT lock_hash, state FROM research_locks LIMIT 1"
+            ).fetchone()
+            if existing_lock is not None:
+                if existing_lock[0] != lock_hash:
+                    raise ValueError("lifecycle already contains a different research lock")
+                return ResearchLock(self.study, lock_hash, existing_lock[1], lock_record)
             db.execute("BEGIN IMMEDIATE")
-            if db.execute("SELECT 1 FROM research_locks LIMIT 1").fetchone() is not None:
-                raise ValueError("lifecycle can lock only from DEVELOPMENT")
             db.execute(
                 "INSERT INTO research_locks (lock_hash, lock_json, state, created_at) "
                 "VALUES (?,?,?,?)",

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -48,6 +48,13 @@ class OfficialPopulation:
                 raise ValueError(
                     f"preview result {member_hash} cannot enter an official population"
                 )
+            if (
+                member_kind == "backtest"
+                and (result.spec().get("decision_artifact") or {}).get("canonical") is False
+            ):
+                raise ValueError(
+                    f"exploratory decision backtest {member_hash} cannot enter an official population"
+                )
         snapshot = {
             "schema_version": 1,
             "name": name,
@@ -102,6 +109,21 @@ class OfficialPopulation:
         finally:
             db.close()
         return cls(study, population_hash, name, member_kind, normalized, supersedes)
+
+    @classmethod
+    def one(cls, study: Study, *, name: str) -> OfficialPopulation:
+        """Resolve one immutable population by name without a hash handoff."""
+        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+            rows = db.execute(
+                "SELECT population_hash FROM official_populations WHERE name = ? "
+                "ORDER BY population_hash",
+                (name,),
+            ).fetchall()
+        if len(rows) != 1:
+            raise ValueError(
+                f"official population name {name!r} resolved to {len(rows)} identities"
+            )
+        return cls.open(study, rows[0][0])
 
     @classmethod
     def open(cls, study: Study, population_hash: str) -> OfficialPopulation:

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -103,7 +103,7 @@ def apply_state_transition_policy(
                 flat_frames.append(
                     weights.filter(pl.col("timestamp") == previous["timestamp"]).with_columns(
                         pl.lit(first_missing).cast(weights.schema["timestamp"]).alias("timestamp"),
-                        pl.lit(0.0).alias("weight"),
+                        pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
                     )
                 )
             else:

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -5,6 +5,7 @@ import sqlite3
 from contextlib import closing
 from copy import deepcopy
 from dataclasses import asdict, dataclass
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 import polars as pl
@@ -29,10 +30,19 @@ from .contracts import ExecutionTier
 from .results import BacktestResult, PredictionResult, Result
 
 if TYPE_CHECKING:
+    from .decisions import DecisionArtifact
     from .workspace import Study
 
 
 _MOMENT_ALLOCATORS = {"inverse_vol", "risk_parity", "hrp", "mvo", "mvo_ledoit_wolf"}
+
+
+def _date_string(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"expected a date-like timestamp, got {type(value).__name__}")
 
 
 def strategy_warmup_periods(strategy_spec: dict[str, Any]) -> int:
@@ -53,6 +63,7 @@ class Strategy:
     study: Study
     prediction: PredictionResult
     signal: dict[str, Any]
+    decision: DecisionArtifact | None = None
     allocation: dict[str, Any] | None = None
     risk: dict[str, Any] | None = None
     costs: dict[str, Any] | None = None
@@ -76,6 +87,11 @@ class Strategy:
             raise ValueError("prediction belongs to another study")
         if not self.prediction.complete:
             raise ValueError("partial predictions cannot enter strategy execution")
+        if self.decision is not None:
+            if self.decision.study != self.study:
+                raise ValueError("decision artifact belongs to another study")
+            if tuple(self.decision.spec["prediction_hashes"]) != (self.prediction.hash,):
+                raise ValueError("decision artifact must declare exactly the selected prediction")
         prediction_record = self.prediction.registry_record()
         split = prediction_record["split"]
         if split == "validation":
@@ -103,6 +119,7 @@ class Strategy:
         supported = {
             "prediction",
             "signal",
+            "decision",
             "allocation",
             "risk",
             "costs",
@@ -117,10 +134,17 @@ class Strategy:
         prediction = request.get("prediction")
         if not isinstance(prediction, PredictionResult):
             raise TypeError("strategy request requires one PredictionResult")
+        decision = request.get("decision")
+        if decision is not None:
+            from .decisions import DecisionArtifact
+
+            if not isinstance(decision, DecisionArtifact):
+                raise TypeError("strategy request decision must be a DecisionArtifact")
         return cls(
             study=study,
             prediction=prediction,
             signal=deepcopy(request.get("signal") or {}),
+            decision=decision,
             allocation=deepcopy(request.get("allocation")),
             risk=deepcopy(request.get("risk")),
             costs=deepcopy(request.get("costs")),
@@ -152,7 +176,7 @@ class Strategy:
         return strategy_warmup_periods({"allocation": allocation}) if allocation else 0
 
     def resolve(self, *, prices: pl.DataFrame | None = None) -> dict[str, Any]:
-        self.study.activate(ExecutionTier.CANONICAL)
+        self.study.activate(ExecutionTier(self.prediction.execution_tier))
         if self.split == "holdout" and prices is not None:
             raise ValueError("locked holdout strategy must load canonical holdout prices")
         case_config = get_backtest_config(self.study.case_study)
@@ -188,6 +212,20 @@ class Strategy:
         spec["identity_version"] = 2
         spec["execution_tier"] = self.prediction.execution_tier
         spec["input_identity"] = {"prices": value_digest(prices)}
+        if self.study.case_study == "crypto_perps_funding":
+            funding_rates = self._funding_rates(prices)
+            assert funding_rates is not None
+            spec["input_identity"]["funding_rates"] = value_digest(funding_rates)
+            spec["economic_cashflows"] = {"funding": "position_signed_before_same_timestamp_fills"}
+        if self.decision is not None:
+            spec["decision_artifact"] = {
+                "hash": self.decision.hash,
+                "kind": self.decision.kind,
+                "artifact_digest": self.decision.spec["artifact_digest"],
+                "canonical": self.decision.canonical,
+                "source_identity": self.decision.spec["source_identity"],
+                "state_transition_policy": self.decision.spec["state_transition_policy"],
+            }
         if contract_specs is not None:
             serialized = {
                 symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
@@ -202,6 +240,47 @@ class Strategy:
                 raise ValueError("holdout strategy does not match the locked validation strategy")
         return resolved
 
+    def _funding_rates(self, prices: pl.DataFrame) -> pl.DataFrame | None:
+        if self.study.case_study != "crypto_perps_funding":
+            return None
+        from case_studies.crypto_perps_funding.funding_data import load_funding_rates
+
+        symbols = prices.get_column("symbol").unique().to_list()
+        start = _date_string(prices.get_column("timestamp").min())
+        end = _date_string(prices.get_column("timestamp").max())
+        funding = load_funding_rates(symbols=symbols, start_date=start, end_date=end)
+        if funding.is_empty():
+            raise ValueError("crypto backtest resolved no official funding settlements")
+        return funding
+
+    def _decision_weights(self, prices: pl.DataFrame) -> pl.DataFrame | None:
+        if self.decision is None:
+            return None
+        decisions = self.decision.load()
+        if self.decision.kind == "target_weights":
+            weights = decisions.select("symbol", "timestamp", "weight")
+        elif self.decision.kind == "target_positions":
+            weights = decisions.select("symbol", "timestamp", "position").with_columns(
+                pl.col("position").abs().sum().over("timestamp").alias("gross")
+            )
+            weights = weights.with_columns(
+                pl.when(pl.col("gross") > 0)
+                .then(pl.col("position") / pl.col("gross"))
+                .otherwise(0.0)
+                .alias("weight")
+            ).select("symbol", "timestamp", "weight")
+        else:
+            raise ValueError("canonical backtesting does not support order decision artifacts")
+        price_keys = prices.select("symbol", "timestamp").unique()
+        weights = weights.with_columns(
+            pl.col("symbol").cast(price_keys.schema["symbol"]),
+            pl.col("timestamp").cast(price_keys.schema["timestamp"]),
+        )
+        missing = weights.join(price_keys, on=["symbol", "timestamp"], how="anti")
+        if not missing.is_empty():
+            raise ValueError("decision artifact contains keys outside the backtest price grid")
+        return weights
+
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:
         spec = self.resolve(prices=prices)
         return backtest_hash_from_parts(self.prediction.hash, spec, identity_version=2)
@@ -212,7 +291,7 @@ class Strategy:
             raise ValueError("locked holdout strategy must load canonical holdout prices")
         predictions = self.prediction.load()
         resolved_prices = prices
-        self.study.activate(ExecutionTier.CANONICAL)
+        self.study.activate(ExecutionTier(self.prediction.execution_tier))
         if resolved_prices is None:
             resolved_prices = load_backtest_prices_for(
                 self.study.case_study,
@@ -245,6 +324,8 @@ class Strategy:
             spec,
             prices=resolved_prices,
             predictions=predictions,
+            precomputed_weights=self._decision_weights(resolved_prices),
+            funding_rates=self._funding_rates(resolved_prices),
             label=self.label,
             initial_cash=float(spec["backtest_config"]["cash"]["initial"]),
             calendar=case_config.calendar,

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from contextlib import closing
 from copy import deepcopy
 from dataclasses import asdict, dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 import polars as pl
@@ -35,6 +36,71 @@ if TYPE_CHECKING:
 
 
 _MOMENT_ALLOCATORS = {"inverse_vol", "risk_parity", "hrp", "mvo", "mvo_ledoit_wolf"}
+
+
+def _cadence_delta(value: str) -> timedelta:
+    match = re.fullmatch(r"([1-9][0-9]*)(us|ms|s|m|h|d|w)", value.strip().lower())
+    if match is None:
+        raise ValueError(f"decision cadence must be a compact duration such as '8h', got {value!r}")
+    amount = int(match.group(1))
+    unit = match.group(2)
+    keyword = {
+        "us": "microseconds",
+        "ms": "milliseconds",
+        "s": "seconds",
+        "m": "minutes",
+        "h": "hours",
+        "d": "days",
+        "w": "weeks",
+    }[unit]
+    return timedelta(**{keyword: amount})
+
+
+def apply_state_transition_policy(
+    weights: pl.DataFrame,
+    *,
+    policy: dict[str, str],
+    cadence: str | None,
+) -> pl.DataFrame:
+    """Insert explicit flat targets before fold boundaries and temporal gaps."""
+    required = {"symbol", "timestamp", "weight"}
+    missing = required - set(weights.columns)
+    if missing:
+        raise ValueError(f"decision weights are missing columns: {sorted(missing)}")
+    if weights.is_empty():
+        return weights
+    fold_column = "fold" if "fold" in weights.columns else None
+    timeline_columns = ["timestamp", *([fold_column] if fold_column else [])]
+    timeline = weights.select(*timeline_columns).unique().sort("timestamp")
+    if fold_column and timeline.n_unique("timestamp") != timeline.height:
+        raise ValueError("each decision timestamp must belong to exactly one fold")
+
+    temporal_action = policy.get("temporal_gap", "continue")
+    expected = None
+    if temporal_action != "continue":
+        if cadence is None:
+            raise ValueError("non-continuing temporal-gap policy requires decision cadence")
+        expected = _cadence_delta(cadence)
+
+    flatten_at: set[object] = set()
+    rows = timeline.iter_rows(named=True)
+    previous = next(rows, None)
+    for current in rows:
+        assert previous is not None
+        fold_changed = fold_column is not None and current[fold_column] != previous[fold_column]
+        if fold_changed and policy.get("fold_boundary", "continue") != "continue":
+            flatten_at.add(previous["timestamp"])
+        if expected is not None and current["timestamp"] - previous["timestamp"] > expected:
+            flatten_at.add(previous["timestamp"])
+        previous = current
+    if not flatten_at:
+        return weights.sort("timestamp", "symbol")
+    return weights.with_columns(
+        pl.when(pl.col("timestamp").is_in(list(flatten_at)))
+        .then(0.0)
+        .otherwise(pl.col("weight"))
+        .alias("weight")
+    ).sort("timestamp", "symbol")
 
 
 def _date_string(value: object) -> str:
@@ -226,6 +292,11 @@ class Strategy:
                 "source_identity": self.decision.spec["source_identity"],
                 "state_transition_policy": self.decision.spec["state_transition_policy"],
             }
+            decision_weights = self._decision_weights(prices)
+            assert decision_weights is not None
+            spec["backtest_config"]["account"]["allow_short_selling"] = bool(
+                decision_weights.filter(pl.col("weight") < 0).height
+            )
         if contract_specs is not None:
             serialized = {
                 symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
@@ -245,32 +316,67 @@ class Strategy:
             return None
         from case_studies.crypto_perps_funding.funding_data import load_funding_rates
 
-        symbols = prices.get_column("symbol").unique().to_list()
-        start = _date_string(prices.get_column("timestamp").min())
-        end = _date_string(prices.get_column("timestamp").max())
+        prediction_timestamps = self.prediction.load().get_column("timestamp")
+        prediction_start = prediction_timestamps.min()
+        prediction_end = prediction_timestamps.max()
+        if prediction_start is None or prediction_end is None:
+            raise ValueError("crypto backtest prediction set has no timestamps")
+        timestamp_dtype = prices.schema["timestamp"]
+        price_keys = (
+            prices.filter(
+                pl.col("timestamp").is_between(
+                    pl.lit(prediction_start).cast(timestamp_dtype, strict=False),
+                    pl.lit(prediction_end).cast(timestamp_dtype, strict=False),
+                    closed="both",
+                )
+            )
+            .select("symbol", "timestamp")
+            .unique()
+        )
+        symbols = price_keys.get_column("symbol").unique().to_list()
+        start = _date_string(prediction_start)
+        end = _date_string(prediction_end)
         funding = load_funding_rates(symbols=symbols, start_date=start, end_date=end)
+        funding = funding.with_columns(
+            pl.col("symbol").cast(price_keys.schema["symbol"]),
+            pl.col("timestamp").cast(timestamp_dtype),
+        ).join(price_keys, on=["symbol", "timestamp"], how="semi")
         if funding.is_empty():
             raise ValueError("crypto backtest resolved no official funding settlements")
-        return funding
+        return funding.sort("timestamp", "symbol")
 
     def _decision_weights(self, prices: pl.DataFrame) -> pl.DataFrame | None:
         if self.decision is None:
             return None
         decisions = self.decision.load()
+        fold_columns = [column for column in ("fold", "fold_id") if column in decisions.columns]
+        if len(fold_columns) > 1:
+            raise ValueError("decision artifact cannot contain both fold and fold_id")
+        fold_column = fold_columns[0] if fold_columns else None
+        selected_fold = [fold_column] if fold_column else []
         if self.decision.kind == "target_weights":
-            weights = decisions.select("symbol", "timestamp", "weight")
+            weights = decisions.select("symbol", "timestamp", "weight", *selected_fold)
         elif self.decision.kind == "target_positions":
-            weights = decisions.select("symbol", "timestamp", "position").with_columns(
-                pl.col("position").abs().sum().over("timestamp").alias("gross")
-            )
+            weights = decisions.select(
+                "symbol", "timestamp", "position", *selected_fold
+            ).with_columns(pl.col("position").abs().sum().over("timestamp").alias("gross"))
             weights = weights.with_columns(
                 pl.when(pl.col("gross") > 0)
                 .then(pl.col("position") / pl.col("gross"))
                 .otherwise(0.0)
                 .alias("weight")
-            ).select("symbol", "timestamp", "weight")
+            ).select("symbol", "timestamp", "weight", *selected_fold)
         else:
             raise ValueError("canonical backtesting does not support order decision artifacts")
+        if fold_column == "fold_id":
+            weights = weights.rename({"fold_id": "fold"})
+        policy = self.decision.spec.get("state_transition_policy")
+        if policy is not None:
+            weights = apply_state_transition_policy(
+                weights,
+                policy=policy,
+                cadence=self.decision.spec.get("parameters", {}).get("cadence"),
+            )
         price_keys = prices.select("symbol", "timestamp").unique()
         weights = weights.with_columns(
             pl.col("symbol").cast(price_keys.schema["symbol"]),
@@ -279,7 +385,7 @@ class Strategy:
         missing = weights.join(price_keys, on=["symbol", "timestamp"], how="anti")
         if not missing.is_empty():
             raise ValueError("decision artifact contains keys outside the backtest price grid")
-        return weights
+        return weights.select("symbol", "timestamp", "weight")
 
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:
         spec = self.resolve(prices=prices)

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -61,8 +61,9 @@ def apply_state_transition_policy(
     *,
     policy: dict[str, str],
     cadence: str | None,
+    price_keys: pl.DataFrame | None = None,
 ) -> pl.DataFrame:
-    """Insert explicit flat targets before fold boundaries and temporal gaps."""
+    """Preserve targets while making fold and temporal state resets executable."""
     required = {"symbol", "timestamp", "weight"}
     missing = required - set(weights.columns)
     if missing:
@@ -82,25 +83,46 @@ def apply_state_transition_policy(
             raise ValueError("non-continuing temporal-gap policy requires decision cadence")
         expected = _cadence_delta(cadence)
 
-    flatten_at: set[object] = set()
+    transition_at: set[object] = set()
+    flat_frames: list[pl.DataFrame] = []
+    price_timestamps = (
+        set(price_keys.get_column("timestamp").unique().to_list())
+        if price_keys is not None
+        else set()
+    )
     rows = timeline.iter_rows(named=True)
     previous = next(rows, None)
     for current in rows:
         assert previous is not None
         fold_changed = fold_column is not None and current[fold_column] != previous[fold_column]
         if fold_changed and policy.get("fold_boundary", "continue") != "continue":
-            flatten_at.add(previous["timestamp"])
+            transition_at.add(current["timestamp"])
         if expected is not None and current["timestamp"] - previous["timestamp"] > expected:
-            flatten_at.add(previous["timestamp"])
+            first_missing = previous["timestamp"] + expected
+            if first_missing in price_timestamps:
+                flat_frames.append(
+                    weights.filter(pl.col("timestamp") == previous["timestamp"]).with_columns(
+                        pl.lit(first_missing).cast(weights.schema["timestamp"]).alias("timestamp"),
+                        pl.lit(0.0).alias("weight"),
+                    )
+                )
+            else:
+                transition_at.add(current["timestamp"])
         previous = current
-    if not flatten_at:
-        return weights.sort("timestamp", "symbol")
-    return weights.with_columns(
-        pl.when(pl.col("timestamp").is_in(list(flatten_at)))
-        .then(0.0)
-        .otherwise(pl.col("weight"))
-        .alias("weight")
-    ).sort("timestamp", "symbol")
+    result = weights.with_columns(
+        pl.col("timestamp").is_in(list(transition_at)).alias("_state_transition")
+    )
+    if flat_frames:
+        result = pl.concat(
+            [
+                result,
+                *[
+                    frame.with_columns(pl.lit(True).alias("_state_transition"))
+                    for frame in flat_frames
+                ],
+            ]
+        )
+    return result.sort("timestamp", "symbol")
 
 
 def _date_string(value: object) -> str:
@@ -316,26 +338,11 @@ class Strategy:
             return None
         from case_studies.crypto_perps_funding.funding_data import load_funding_rates
 
-        prediction_timestamps = self.prediction.load().get_column("timestamp")
-        prediction_start = prediction_timestamps.min()
-        prediction_end = prediction_timestamps.max()
-        if prediction_start is None or prediction_end is None:
-            raise ValueError("crypto backtest prediction set has no timestamps")
         timestamp_dtype = prices.schema["timestamp"]
-        price_keys = (
-            prices.filter(
-                pl.col("timestamp").is_between(
-                    pl.lit(prediction_start).cast(timestamp_dtype, strict=False),
-                    pl.lit(prediction_end).cast(timestamp_dtype, strict=False),
-                    closed="both",
-                )
-            )
-            .select("symbol", "timestamp")
-            .unique()
-        )
+        price_keys = prices.select("symbol", "timestamp").unique()
         symbols = price_keys.get_column("symbol").unique().to_list()
-        start = _date_string(prediction_start)
-        end = _date_string(prediction_end)
+        start = _date_string(price_keys.get_column("timestamp").min())
+        end = _date_string(price_keys.get_column("timestamp").max())
         funding = load_funding_rates(symbols=symbols, start_date=start, end_date=end)
         funding = funding.with_columns(
             pl.col("symbol").cast(price_keys.schema["symbol"]),
@@ -370,22 +377,26 @@ class Strategy:
             raise ValueError("canonical backtesting does not support order decision artifacts")
         if fold_column == "fold_id":
             weights = weights.rename({"fold_id": "fold"})
+        price_keys = prices.select("symbol", "timestamp").unique()
+        weights = weights.with_columns(
+            pl.col("symbol").cast(price_keys.schema["symbol"]),
+            pl.col("timestamp").cast(price_keys.schema["timestamp"]),
+        )
         policy = self.decision.spec.get("state_transition_policy")
         if policy is not None:
             weights = apply_state_transition_policy(
                 weights,
                 policy=policy,
                 cadence=self.decision.spec.get("parameters", {}).get("cadence"),
+                price_keys=price_keys,
             )
-        price_keys = prices.select("symbol", "timestamp").unique()
-        weights = weights.with_columns(
-            pl.col("symbol").cast(price_keys.schema["symbol"]),
-            pl.col("timestamp").cast(price_keys.schema["timestamp"]),
-        )
         missing = weights.join(price_keys, on=["symbol", "timestamp"], how="anti")
         if not missing.is_empty():
             raise ValueError("decision artifact contains keys outside the backtest price grid")
-        return weights.select("symbol", "timestamp", "weight")
+        selected = ["symbol", "timestamp", "weight"]
+        if "_state_transition" in weights.columns:
+            selected.append("_state_transition")
+        return weights.select(*selected)
 
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:
         spec = self.resolve(prices=prices)

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -18,6 +18,7 @@ from .contracts import ExecutionTier
 
 if TYPE_CHECKING:
     from .catalog import PredictionCatalog
+    from .causal import CausalRequest
     from .labels import LabelCatalog
     from .lifecycle import Lifecycle
     from .models import ModelRequest
@@ -320,3 +321,8 @@ class Study:
         from .models import ModelRequest
 
         return ModelRequest.from_request(self, request)
+
+    def causal(self, **request) -> CausalRequest:
+        from .causal import CausalRequest
+
+        return CausalRequest.from_request(self, request)

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -370,14 +370,16 @@ class BacktestRunResult:
     execution_mode: str = "engine"
 
 
-def _target_weights_by_timestamp(weights: pl.DataFrame) -> dict[datetime, dict[str, float]]:
+def _target_weights_by_timestamp(
+    weights: pl.DataFrame,
+) -> dict[date | datetime, dict[str, float]]:
     """Build deterministic timestamp and symbol ordered engine targets."""
     duplicate_count = weights.select(pl.struct("timestamp", "symbol").is_duplicated().sum()).item()
     if duplicate_count:
         raise ValueError(
             f"Target weights contain {duplicate_count} duplicate timestamp-symbol rows"
         )
-    targets: dict[datetime, dict[str, float]] = {}
+    targets: dict[date | datetime, dict[str, float]] = {}
     for row in weights.sort("timestamp", "symbol").iter_rows(named=True):
         timestamp = row["timestamp"]
         if timestamp not in targets:
@@ -389,9 +391,16 @@ def _target_weights_by_timestamp(weights: pl.DataFrame) -> dict[datetime, dict[s
 def _engine_timestamp(
     value: object,
     *,
+    feed_is_date: bool,
     feed_timezone: str | None,
     configured_timezone: str,
-) -> datetime:
+) -> date | datetime:
+    if feed_is_date:
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        raise TypeError(f"engine target timestamp must be date-like, got {type(value).__name__}")
     if isinstance(value, datetime):
         timestamp = value
     elif isinstance(value, date):
@@ -1110,6 +1119,11 @@ def run_backtest(
     if rebal_spec["mode"] == "vectorized":
         if funding_rates is not None:
             raise ValueError("vectorized backtests cannot execute funding cashflows")
+        if (
+            "_state_transition" in weights.columns
+            and weights.filter(pl.col("_state_transition")).height
+        ):
+            raise ValueError("vectorized backtests cannot sequence state transitions")
         # sp500_options HTM short-straddle uses a dedicated multi-cohort daily-MTM
         # backtest path: overlapping 5-cohort book, per-cohort daily premium + hedge
         # P&L, entry-spread + hedge-rebalance transaction costs. The simple
@@ -1266,6 +1280,7 @@ def _run_engine(
 
     # Pre-compute weight dict from DataFrame
     price_timestamp_dtype = prices.schema["timestamp"]
+    feed_is_date = price_timestamp_dtype == pl.Date
     feed_timezone = (
         price_timestamp_dtype.time_zone if isinstance(price_timestamp_dtype, pl.Datetime) else None
     )
@@ -1273,6 +1288,7 @@ def _run_engine(
     weight_dict = {
         _engine_timestamp(
             timestamp,
+            feed_is_date=feed_is_date,
             feed_timezone=feed_timezone,
             configured_timezone=config.resolved_timezone,
         ): targets
@@ -1309,11 +1325,28 @@ def _run_engine(
     rebalance_schedule = {
         _engine_timestamp(
             timestamp,
+            feed_is_date=feed_is_date,
             feed_timezone=feed_timezone,
             configured_timezone=config.resolved_timezone,
         )
         for timestamp in schedule_dates.to_list()
     }
+    transition_timestamps = {
+        _engine_timestamp(
+            timestamp,
+            feed_is_date=feed_is_date,
+            feed_timezone=feed_timezone,
+            configured_timezone=config.resolved_timezone,
+        )
+        for timestamp in (
+            weights.filter(pl.col("_state_transition")).get_column("timestamp").unique().to_list()
+            if "_state_transition" in weights.columns
+            else []
+        )
+    }
+    rebalance_schedule.update(transition_timestamps)
+    if transition_timestamps and config.execution_mode.value != "same_bar":
+        raise ValueError("state-transition sequencing requires same-bar engine execution")
 
     # Build risk components from spec (Ch19)
     position_rules = _build_position_rules(risk_spec)
@@ -1355,6 +1388,10 @@ def _run_engine(
                 if position_rules:
                     broker.set_position_rules(position_rules)
                 self._rules_set = True
+
+            if timestamp in transition_timestamps:
+                broker.flatten_all_positions(reason="declared state transition")
+                broker._process_orders()
 
             # Check portfolio-level limits (each bar)
             if risk_manager:

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1530,11 +1530,33 @@ def _run_engine(
     if weights.height > 0:
         turnover_weights = weights.with_columns(pl.lit(1).alias("_event_order"))
         if "_state_transition" in weights.columns:
-            flat_states = weights.filter(pl.col("_state_transition")).with_columns(
-                pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
-                pl.lit(0).alias("_event_order"),
+            flat_states = []
+            transition_timestamps = (
+                weights.filter(pl.col("_state_transition"))
+                .get_column("timestamp")
+                .unique()
+                .sort()
+                .to_list()
             )
-            turnover_weights = pl.concat([turnover_weights, flat_states])
+            for transition_timestamp in transition_timestamps:
+                previous_state = (
+                    weights.filter(pl.col("timestamp") < transition_timestamp)
+                    .sort("symbol", "timestamp")
+                    .group_by("symbol", maintain_order=True)
+                    .last()
+                )
+                if previous_state.height > 0:
+                    flat_states.append(
+                        previous_state.with_columns(
+                            pl.lit(transition_timestamp)
+                            .cast(weights.schema["timestamp"])
+                            .alias("timestamp"),
+                            pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
+                            pl.lit(0).alias("_event_order"),
+                        ).select(turnover_weights.columns)
+                    )
+            if flat_states:
+                turnover_weights = pl.concat([turnover_weights, *flat_states])
         weights_sorted = turnover_weights.sort("symbol", "timestamp", "_event_order").with_columns(
             abs_change=(
                 pl.col("weight") - pl.col("weight").shift(1).over("symbol").fill_null(0.0)

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1540,13 +1540,15 @@ def _run_engine(
                 pl.col("weight") - pl.col("weight").shift(1).over("symbol").fill_null(0.0)
             ).abs(),
         )
-        turnover_by_ts = weights_sorted.group_by("timestamp").agg(
-            turnover=pl.col("abs_change").sum()
+        turnover_by_ts = (
+            weights_sorted.with_columns(pl.col("timestamp").cast(daily_df.schema["timestamp"]))
+            .group_by("timestamp")
+            .agg(turnover=pl.col("abs_change").sum())
         )
         # Align to daily timeline so non-rebalance days contribute 0 to the mean
         # (matches port_ret.join(turnover) in the vectorized path).
         turnover_aligned = daily_df.join(
-            turnover_by_ts.with_columns(pl.col("timestamp").cast(daily_df.schema["timestamp"])),
+            turnover_by_ts,
             on="timestamp",
             how="left",
         ).with_columns(pl.col("turnover").fill_null(0.0))

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
-from typing import Any
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -1455,8 +1455,8 @@ def _run_engine(
         # weights. The daily_returns frame is sliced to [win_start, win_end]
         # below regardless of how wide the load was.
         prices_dates = prices["timestamp"].dt.date()
-        prices_min_date = prices_dates.min()
-        prices_max_date = prices_dates.max()
+        prices_min_date = cast(date | None, prices_dates.min())
+        prices_max_date = cast(date | None, prices_dates.max())
         if prices_min_date is None or prices_max_date is None:
             raise RuntimeError(
                 f"Empty prices frame for cs={case_study} label={label} "
@@ -1528,7 +1528,14 @@ def _run_engine(
     # for leveraged products (cme_futures multipliers inflate it 10⁴–10⁵×) and
     # mixes incompatibly with vectorized-path rows on the same column.
     if weights.height > 0:
-        weights_sorted = weights.sort("symbol", "timestamp").with_columns(
+        turnover_weights = weights.with_columns(pl.lit(1).alias("_event_order"))
+        if "_state_transition" in weights.columns:
+            flat_states = weights.filter(pl.col("_state_transition")).with_columns(
+                pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
+                pl.lit(0).alias("_event_order"),
+            )
+            turnover_weights = pl.concat([turnover_weights, flat_states])
+        weights_sorted = turnover_weights.sort("symbol", "timestamp", "_event_order").with_columns(
             abs_change=(
                 pl.col("weight") - pl.col("weight").shift(1).over("symbol").fill_null(0.0)
             ).abs(),
@@ -1543,7 +1550,7 @@ def _run_engine(
             on="timestamp",
             how="left",
         ).with_columns(pl.col("turnover").fill_null(0.0))
-        mean_turnover = turnover_aligned["turnover"].mean()
+        mean_turnover = cast(float | None, turnover_aligned["turnover"].mean())
         metrics["avg_turnover"] = float(mean_turnover) if mean_turnover is not None else 0.0
     else:
         metrics["avg_turnover"] = 0.0
@@ -1974,7 +1981,7 @@ def _run_vectorized(
     metrics = compute_portfolio_metrics(returns_arr, periods_per_year=periods_per_year or 252)
 
     # Vectorized-specific metrics (not derivable from returns alone)
-    avg_turnover = float(port_ret["turnover"].mean()) if n > 0 else 0.0
+    avg_turnover = cast(float, port_ret["turnover"].mean()) if n > 0 else 0.0
     metrics["avg_turnover"] = avg_turnover
     metrics["n_periods"] = n
 

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -862,6 +862,7 @@ def run_backtest(
     initial_cash: float = 1_000_000.0,
     calendar: str = "NYSE",
     precomputed_weights: pl.DataFrame | None = None,
+    funding_rates: pl.DataFrame | None = None,
     force_rebacktest: bool = False,
     contract_specs: dict | None = None,
 ) -> BacktestRunResult:
@@ -900,6 +901,8 @@ def run_backtest(
     contract_specs : dict, optional
         Per-asset contract specifications (futures multipliers, tick sizes).
         Pass for futures case studies to get correct P&L scaling.
+    funding_rates : pl.DataFrame, optional
+        Official position-signed perpetual-futures funding settlements.
 
     Returns
     -------
@@ -1118,6 +1121,7 @@ def run_backtest(
             contract_specs=contract_specs,
             case_study=case_study,
             label=label,
+            funding_rates=funding_rates,
         )
 
     # Build metrics dict
@@ -1209,6 +1213,7 @@ def _run_engine(
     *,
     case_study: str | None = None,
     label: str | None = None,
+    funding_rates: pl.DataFrame | None = None,
 ) -> dict:
     """Run backtest via ml4t-backtest Engine."""
     from ml4t.backtest import DataFeed, Engine, RebalanceConfig, Strategy, TargetWeightExecutor
@@ -1386,6 +1391,19 @@ def _run_engine(
     engine = Engine.from_config(feed, strategy, config, contract_specs=contract_specs)
     engine_result = engine.run()
 
+    funding_metrics = {}
+    if funding_rates is not None:
+        from case_studies.crypto_perps_funding.funding_backtest import (
+            apply_funding_settlements,
+        )
+
+        funding_metrics = apply_funding_settlements(
+            engine_result,
+            prices=prices,
+            funding_rates=funding_rates,
+            initial_cash=initial_cash,
+        )
+
     # Extract daily returns
     session_aligned = infer_session_alignment(calendar)
     daily_df = extract_daily_returns_frame(
@@ -1408,6 +1426,7 @@ def _run_engine(
 
     ppy = overall_periods_per_year(case_study, calendar, daily_df)
     metrics = compute_portfolio_metrics(returns_arr, periods_per_year=ppy, trim_leading_zeros=False)
+    metrics.update(funding_metrics)
 
     # Engine-specific metrics (execution details not derivable from returns)
     m = engine_result.metrics

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime, time
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import polars as pl
@@ -381,9 +382,32 @@ def _target_weights_by_timestamp(weights: pl.DataFrame) -> dict[datetime, dict[s
         timestamp = row["timestamp"]
         if timestamp not in targets:
             targets[timestamp] = {}
-        if row["weight"] != 0:
-            targets[timestamp][row["symbol"]] = row["weight"]
+        targets[timestamp][row["symbol"]] = row["weight"]
     return targets
+
+
+def _engine_timestamp(
+    value: object,
+    *,
+    feed_timezone: str | None,
+    configured_timezone: str,
+) -> datetime:
+    if isinstance(value, datetime):
+        timestamp = value
+    elif isinstance(value, date):
+        timestamp = datetime.combine(value, time.min)
+    else:
+        raise TypeError(f"engine target timestamp must be date-like, got {type(value).__name__}")
+    if feed_timezone is not None:
+        zone = ZoneInfo(feed_timezone)
+        return (
+            timestamp.replace(tzinfo=zone)
+            if timestamp.tzinfo is None
+            else timestamp.astimezone(zone)
+        )
+    if timestamp.tzinfo is not None:
+        timestamp = timestamp.astimezone(ZoneInfo(configured_timezone)).replace(tzinfo=None)
+    return timestamp
 
 
 # ---------------------------------------------------------------------------
@@ -942,6 +966,16 @@ def run_backtest(
     # spec ($100K) — halting the strategy before any trade is placed.
     initial_cash = float(strategy_spec["backtest_config"]["cash"]["initial"])
     strategy = strategy_view(strategy_spec)
+    signal_config = strategy["signal"]
+    allow_short = bool(
+        strategy_spec["backtest_config"]["account"].get("allow_short_selling", False)
+    ) or bool(signal_config.get("long_short", False))
+    allow_short = allow_short or (
+        str(signal_config.get("direction", "long_only")).strip().lower() == "short_only"
+    )
+    if precomputed_weights is not None:
+        allow_short = allow_short or bool(precomputed_weights.filter(pl.col("weight") < 0).height)
+    strategy_spec["backtest_config"]["account"]["allow_short_selling"] = allow_short
 
     # Apply spec-declared universe restriction (e.g., sp500_options rung-3
     # 'liquid' subset). Driven purely by strategy.signal.universe_filter so
@@ -997,7 +1031,6 @@ def run_backtest(
                     execution_mode=strategy.get("rebalance", {}).get("mode", "unknown"),
                 )
 
-    signal_config = strategy["signal"]
     rebal_spec = strategy.get("rebalance", {})
 
     if precomputed_weights is not None:
@@ -1075,6 +1108,8 @@ def run_backtest(
         }
 
     if rebal_spec["mode"] == "vectorized":
+        if funding_rates is not None:
+            raise ValueError("vectorized backtests cannot execute funding cashflows")
         # sp500_options HTM short-straddle uses a dedicated multi-cohort daily-MTM
         # backtest path: overlapping 5-cohort book, per-cohort daily premium + hedge
         # P&L, entry-spread + hedge-rebalance transaction costs. The simple
@@ -1105,9 +1140,6 @@ def run_backtest(
                 prediction_hash=prediction_hash,
             )
     else:
-        allow_short = signal_config.get("long_short", False) or (
-            str(signal_config.get("direction", "long_only")).strip().lower() == "short_only"
-        )
         result = _run_engine(
             weights=weights,
             prices=prices,
@@ -1233,7 +1265,19 @@ def _run_engine(
     apply_calendar_session_enforcement(config, calendar)
 
     # Pre-compute weight dict from DataFrame
-    weight_dict = _target_weights_by_timestamp(weights)
+    price_timestamp_dtype = prices.schema["timestamp"]
+    feed_timezone = (
+        price_timestamp_dtype.time_zone if isinstance(price_timestamp_dtype, pl.Datetime) else None
+    )
+    raw_weight_dict = _target_weights_by_timestamp(weights)
+    weight_dict = {
+        _engine_timestamp(
+            timestamp,
+            feed_timezone=feed_timezone,
+            configured_timezone=config.resolved_timezone,
+        ): targets
+        for timestamp, targets in raw_weight_dict.items()
+    }
 
     # Resolve calendar-aware rebalance schedule, then thin by the label's
     # non-overlapping step from setup.yaml::labels.rebalance_step. Mirrors
@@ -1262,7 +1306,14 @@ def _run_engine(
         step = get_rebalance_step(case_study, label)
         if step > 1:
             schedule_dates = schedule_dates.gather_every(step)
-    rebalance_schedule = set(schedule_dates.to_list())
+    rebalance_schedule = {
+        _engine_timestamp(
+            timestamp,
+            feed_timezone=feed_timezone,
+            configured_timezone=config.resolved_timezone,
+        )
+        for timestamp in schedule_dates.to_list()
+    }
 
     # Build risk components from spec (Ch19)
     position_rules = _build_position_rules(risk_spec)
@@ -1273,6 +1324,12 @@ def _run_engine(
     # ensure_backtest_spec()).
     min_weight_change = float(rebalance_spec["min_weight_change"])
     min_trade_value = float(rebalance_spec["min_trade_value"])
+
+    funding_ledger = None
+    if funding_rates is not None:
+        from case_studies.crypto_perps_funding.funding_backtest import FundingSettlementLedger
+
+        funding_ledger = FundingSettlementLedger(funding_rates)
 
     # Build strategy
     class _PrecomputedStrategy(Strategy):
@@ -1287,6 +1344,10 @@ def _run_engine(
                     rebalance_mode=profile_rebalance_mode,
                 )
             )
+
+        def on_start(self, broker):
+            if funding_ledger is not None:
+                funding_ledger.install(broker)
 
         def on_data(self, timestamp, data, context, broker):
             # Set position rules on broker (once, first bar)
@@ -1391,18 +1452,7 @@ def _run_engine(
     engine = Engine.from_config(feed, strategy, config, contract_specs=contract_specs)
     engine_result = engine.run()
 
-    funding_metrics = {}
-    if funding_rates is not None:
-        from case_studies.crypto_perps_funding.funding_backtest import (
-            apply_funding_settlements,
-        )
-
-        funding_metrics = apply_funding_settlements(
-            engine_result,
-            prices=prices,
-            funding_rates=funding_rates,
-            initial_cash=initial_cash,
-        )
+    funding_metrics = funding_ledger.metrics() if funding_ledger is not None else {}
 
     # Extract daily returns
     session_aligned = infer_session_alignment(calendar)

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -18,8 +18,15 @@ import os
 # is bit-reproducible across runs at the same seed/spec/data.
 os.environ.setdefault("OMP_NUM_THREADS", "1")
 
+import hashlib
+import importlib.metadata
+import json
+import platform
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -29,6 +36,31 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from statsmodels.regression.linear_model import OLS
 
 from utils.modeling import RANDOM_SEED, seed_everything
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+
+
+_DML_PREVIEW_FIELDS = {"max_samples", "max_symbols", "n_folds", "n_placebo"}
+
+
+@dataclass(frozen=True)
+class DMLResearchContext:
+    analysis: pd.DataFrame
+    treatment_col: str
+    outcome_col: str
+    confounder_cols: tuple[str, ...]
+    time_col: str
+    entity_col: str
+    n_folds: int
+    embargo: int
+    n_placebo: int
+    block_size: int
+    seed: int
+    horizon: int
+    expected_step: pd.Timedelta
+    nuisance_params: dict[str, Any]
+    runtime_provenance: dict[str, Any]
 
 
 def embargo_from_buffer(label_buffer: str, *, periods_per_year: int | None = None) -> int:
@@ -69,6 +101,7 @@ def block_permute(
     rng: np.random.Generator | None = None,
     groups: np.ndarray | None = None,
     units: np.ndarray | None = None,
+    expected_step: str | pd.Timedelta | None = None,
 ) -> np.ndarray:
     """Permute array in blocks to preserve autocorrelation structure.
 
@@ -114,7 +147,13 @@ def block_permute(
             unit_groups = group_arr[idx]
             if len(unit_groups) > 1 and np.any(unit_groups[1:] <= unit_groups[:-1]):
                 raise ValueError("groups must be strictly increasing within each unit")
-            result[idx] = block_permute(arr[idx], block_size, rng=rng)
+            result[idx] = block_permute(
+                arr[idx],
+                block_size,
+                rng=rng,
+                groups=unit_groups,
+                expected_step=expected_step,
+            )
         return result
 
     if groups is not None:
@@ -125,6 +164,21 @@ def block_permute(
             raise ValueError("units are required when decision times contain multiple rows")
         if n > 1 and np.any(group_arr[1:] <= group_arr[:-1]):
             raise ValueError("groups must be strictly increasing")
+        if expected_step is not None and n > 1:
+            cadence = pd.Timedelta(expected_step)
+            timestamps = pd.to_datetime(group_arr, utc=True)
+            boundaries = np.flatnonzero(np.asarray(timestamps[1:] - timestamps[:-1]) != cadence) + 1
+            if boundaries.size:
+                result = np.empty_like(arr)
+                starts = np.r_[0, boundaries]
+                stops = np.r_[boundaries, n]
+                for start, stop in zip(starts, stops, strict=True):
+                    result[start:stop] = block_permute(
+                        arr[start:stop],
+                        block_size,
+                        rng=rng,
+                    )
+                return result
 
     n_blocks = n // block_size
     if n_blocks < 2:
@@ -422,6 +476,9 @@ def run_dml_analysis(
     horizon: int | None = None,
     time_col: str | None = None,
     entity_col: str | None = None,
+    model_y=None,
+    model_t=None,
+    expected_step: str | pd.Timedelta | None = None,
 ) -> dict:
     """Full DML analysis pipeline: naive OLS, DML, and refutation tests.
 
@@ -518,6 +575,8 @@ def run_dml_analysis(
         hac_maxlags=hac_maxlags,
         horizon=horizon,
         groups=groups,
+        model_y=model_y,
+        model_t=model_t,
     )
 
     # Compare the adjusted estimate with naive OLS on the exact second-stage
@@ -538,7 +597,14 @@ def run_dml_analysis(
     placebo_effects = []
     placebo_n_obs = []
     for _ in range(n_placebo):
-        T_perm = block_permute(T, block_size, rng=rng, groups=groups, units=units)
+        T_perm = block_permute(
+            T,
+            block_size,
+            rng=rng,
+            groups=groups,
+            units=units,
+            expected_step=expected_step,
+        )
         perm_result = manual_dml_timeseries(
             Y,
             T_perm,
@@ -548,6 +614,8 @@ def run_dml_analysis(
             hac_maxlags=hac_maxlags,
             horizon=horizon,
             groups=groups,
+            model_y=model_y,
+            model_t=model_t,
         )
         if not np.isnan(perm_result["theta"]):
             if perm_result["n_obs"] != dml["n_obs"]:
@@ -563,7 +631,7 @@ def run_dml_analysis(
         p_mean = np.mean(placebo_arr)
         p_std = np.std(placebo_arr)
         z = (dml_effect - p_mean) / p_std if p_std > 0 else np.inf
-        emp_p = np.mean(np.abs(placebo_arr) >= np.abs(dml_effect))
+        emp_p = float(np.mean(np.abs(placebo_arr) >= np.abs(dml_effect)))
         ref_class = classify_refutation(emp_p)
         refutation = {
             "z_score": z,
@@ -632,6 +700,307 @@ def format_dml_summary(results: dict) -> str:
 
     lines.append("=" * 60)
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Reader-facing causal request adapter
+# ---------------------------------------------------------------------------
+
+
+def _causal_source_identity() -> dict[str, str]:
+    path = Path(__file__)
+    return {path.name: hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def _causal_runtime_identity() -> dict[str, str]:
+    return {
+        "numpy": importlib.metadata.version("numpy"),
+        "scikit-learn": importlib.metadata.version("scikit-learn"),
+        "statsmodels": importlib.metadata.version("statsmodels"),
+    }
+
+
+def _causal_runtime_provenance(study: Study) -> dict[str, Any]:
+    return {
+        "entry_point": "case_studies.utils.causal",
+        "packages": _causal_runtime_identity(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "source_commit": study.manifest.get("baseline_source_commit", "unknown"),
+    }
+
+
+def _whole_timestamp_tail(
+    frame,
+    *,
+    timestamp: str,
+    entity: str,
+    max_rows: int,
+):
+    import polars as pl
+
+    ordered = frame.sort([timestamp, entity])
+    if max_rows <= 0 or ordered.height <= max_rows:
+        return ordered
+    counts = ordered.group_by(timestamp).len().sort(timestamp)
+    counts = counts.with_columns(pl.col("len").reverse().cum_sum().reverse().alias("suffix_n"))
+    keep = counts.filter(pl.col("suffix_n") <= max_rows).select(timestamp)
+    if keep.is_empty():
+        raise ValueError("max_samples is smaller than the final timestamp panel")
+    return ordered.join(keep, on=timestamp, how="semi").sort([timestamp, entity])
+
+
+def _observed_cadence(frame, timestamp: str) -> pd.Timedelta:
+    values = pd.DatetimeIndex(frame.get_column(timestamp).unique().sort().to_list())
+    if len(values) < 2:
+        raise ValueError("causal analysis needs at least two decision timestamps")
+    differences = pd.Series(values[1:] - values[:-1])
+    cadence = differences.mode().iloc[0]
+    if cadence <= pd.Timedelta(0):
+        raise ValueError("causal observation cadence must be positive")
+    return pd.Timedelta(cadence)
+
+
+def _resolve_nuisance_params(config: dict[str, Any], overrides: dict[str, Any], seed: int):
+    configured = dict(config.get("params") or {})
+    supplied = dict(overrides.get("nuisance_params") or {})
+    estimator = HistGradientBoostingRegressor(random_state=seed)
+    unknown = (set(configured) | set(supplied)) - set(estimator.get_params(deep=True))
+    if unknown:
+        raise ValueError(f"unsupported DML nuisance parameters: {sorted(unknown)}")
+    estimator.set_params(**configured, **supplied)
+    return estimator.get_params(deep=True)
+
+
+def resolve_causal_request(study: Study, request: dict[str, Any]):
+    import polars as pl
+    import yaml
+
+    from case_studies.research.contracts import ExecutionTier
+    from case_studies.research.identity import ResolvedSpec
+    from case_studies.utils.artifact_digest import value_digest
+    from utils.modeling import load_configs, load_modeling_dataset
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _DML_PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported DML preview reductions: {sorted(unknown_reductions)}")
+    allowed_overrides = {"nuisance_params"}
+    unknown_overrides = set(request["overrides"]) - allowed_overrides
+    if unknown_overrides:
+        raise ValueError(f"unsupported DML overrides: {sorted(unknown_overrides)}")
+
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
+    mds = load_modeling_dataset(
+        study.case_study,
+        label_ref.name,
+        max_symbols=int(reductions.get("max_symbols", 0)),
+    )
+    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
+        raise ValueError("DML runner requires canonical symbol and timestamp keys")
+    configs = {
+        config["config_name"]: config
+        for config in load_configs(study.case_study, label_ref.name, "causal_dml")
+    }
+    try:
+        config = configs[request["config_name"]]
+    except KeyError as error:
+        raise ValueError(f"unknown DML configuration {request['config_name']!r}") from error
+
+    setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
+    causal = setup.get("causal") or {}
+    treatment = str(causal["treatment"])
+    confounders = tuple(str(value) for value in causal["confounders"])
+    seed = int(config.get("seed", RANDOM_SEED))
+    n_folds = int(reductions.get("n_folds", config.get("n_folds", 5)))
+    n_placebo = int(reductions.get("n_placebo", config.get("n_placebo", 100)))
+    max_samples = int(reductions.get("max_samples", config.get("max_samples", 0)))
+    if n_folds < 2 or n_placebo < 0 or max_samples < 0:
+        raise ValueError("DML folds, placebos, and sample cap are invalid")
+
+    columns = [mds.date_col, mds.entity_cols[0], treatment, mds.label_col, *confounders]
+    missing = sorted(set(columns) - set(mds.dataset.columns))
+    if missing:
+        raise ValueError(f"DML analysis columns are missing: {missing}")
+    holdout = pd.Timestamp(setup["evaluation"]["holdout_start"], tz="UTC")
+    horizon_delta = pd.Timedelta(str(mds.label_buffer).replace("H", "h"))
+    date_dtype = mds.dataset.schema[mds.date_col]
+    endpoint_cutoff = holdout - horizon_delta
+    analysis = (
+        mds.dataset.select(columns)
+        .drop_nulls()
+        .filter(
+            pl.col(mds.date_col)
+            < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False)
+        )
+    )
+    analysis = _whole_timestamp_tail(
+        analysis,
+        timestamp=mds.date_col,
+        entity=mds.entity_cols[0],
+        max_rows=max_samples,
+    )
+    if analysis.is_empty():
+        raise ValueError("DML request resolved an empty pre-holdout analysis frame")
+    cadence = _observed_cadence(analysis, mds.date_col)
+    horizon_steps = max(1, int(np.ceil(horizon_delta / cadence)))
+    embargo = embargo_from_buffer(mds.label_buffer)
+    nuisance_params = _resolve_nuisance_params(config, request["overrides"], seed)
+    key_frame = analysis.select(mds.entity_cols[0], mds.date_col)
+    if key_frame.n_unique([mds.entity_cols[0], mds.date_col]) != key_frame.height:
+        raise ValueError("DML analysis keys are not unique")
+
+    computation = {
+        "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
+        "feature_artifacts": mds.input_lineage["artifacts"],
+        "feature_names": list(mds.feature_names),
+        "estimand": {
+            "method": "walk_forward_dml",
+            "outcome": mds.label_col,
+            "treatment": treatment,
+            "confounders": list(confounders),
+            "treatment_observed_at": "decision_timestamp",
+            "outcome_horizon": str(horizon_delta),
+            "holdout_endpoint_cutoff": endpoint_cutoff.isoformat(),
+        },
+        "cv": {
+            "n_folds": n_folds,
+            "embargo_periods": embargo,
+            "fold_unit": "complete_timestamp_panel",
+        },
+        "model": {
+            "class": "sklearn.ensemble.HistGradientBoostingRegressor",
+            "implementation": "scikit-learn",
+            "nuisance_params": nuisance_params,
+        },
+        "refutation": {
+            "method": "within_symbol_contiguous_block_permutation",
+            "n_placebo": n_placebo,
+            "block_size": embargo,
+            "seed": seed,
+            "temporal_gap_policy": "reset",
+            "observation_cadence": str(cadence),
+        },
+        "analysis_population": {
+            "key_digest": value_digest(key_frame, (mds.entity_cols[0], mds.date_col)),
+            "n_rows": analysis.height,
+            "n_timestamps": analysis.get_column(mds.date_col).n_unique(),
+            "max_samples": max_samples,
+        },
+        "input_data_spec": mds.input_lineage,
+        "source_identity": _causal_source_identity(),
+        "runtime_identity": _causal_runtime_identity(),
+    }
+    if tier is ExecutionTier.PREVIEW:
+        computation["preview_reductions"] = reductions
+    provenance = _causal_runtime_provenance(study)
+    spec = ResolvedSpec.create(
+        family="causal_dml",
+        label=label_ref.name,
+        seed=seed,
+        computation=computation,
+        provenance=provenance,
+        config_name=config["config_name"],
+        execution_tier=tier.value,
+    ).as_dict()
+    context = DMLResearchContext(
+        analysis=analysis.to_pandas(),
+        treatment_col=treatment,
+        outcome_col=mds.label_col,
+        confounder_cols=confounders,
+        time_col=mds.date_col,
+        entity_col=mds.entity_cols[0],
+        n_folds=n_folds,
+        embargo=embargo,
+        n_placebo=n_placebo,
+        block_size=embargo,
+        seed=seed,
+        horizon=horizon_steps,
+        expected_step=cadence,
+        nuisance_params=nuisance_params,
+        runtime_provenance=provenance,
+    )
+    return spec, context
+
+
+def run_resolved_causal_request(
+    study: Study,
+    spec: dict[str, Any],
+    context: DMLResearchContext,
+):
+    import math
+
+    from case_studies.research.causal import CausalResult
+    from case_studies.utils.registry.registration import register_causal_run as register_record
+    from case_studies.utils.registry.specs import canonical_json, training_hash_from_spec
+
+    causal_hash = training_hash_from_spec(spec)
+    try:
+        cached = CausalResult.open(
+            study,
+            causal_hash,
+            include_preview=spec["execution_tier"] == "preview",
+        )
+    except KeyError:
+        cached = None
+    if cached is not None:
+        if cached.spec != spec or not cached.complete:
+            raise ValueError(f"causal cache is incomplete or conflicts with {causal_hash}")
+        return cached
+
+    nuisance_y = HistGradientBoostingRegressor(**context.nuisance_params)
+    nuisance_t = HistGradientBoostingRegressor(**context.nuisance_params)
+    results = run_dml_analysis(
+        context.analysis,
+        context.treatment_col,
+        context.outcome_col,
+        list(context.confounder_cols),
+        n_folds=context.n_folds,
+        embargo=context.embargo,
+        n_placebo=context.n_placebo,
+        block_size=context.block_size,
+        seed=context.seed,
+        horizon=context.horizon,
+        time_col=context.time_col,
+        entity_col=context.entity_col,
+        model_y=nuisance_y,
+        model_t=nuisance_t,
+        expected_step=context.expected_step,
+    )
+    dml = results["dml_result"]
+    if not all(math.isfinite(float(dml[name])) for name in ("theta", "se_hac")):
+        raise ValueError("DML fit did not produce a finite effect and HAC standard error")
+    refutation_p = results.get("refutation", {}).get("empirical_p")
+    case_dir = study.storage_root(spec["execution_tier"])
+    register_record(
+        study.case_study,
+        causal_hash,
+        label=context.outcome_col,
+        treatment=context.treatment_col,
+        confounders_json=json.dumps(list(context.confounder_cols)),
+        embargo=context.embargo,
+        n_folds=context.n_folds,
+        n_obs=int(dml["n_obs"]),
+        dml_effect=float(dml["theta"]),
+        dml_se_hac=float(dml["se_hac"]),
+        p_value_hac=float(results["p_value_hac"]),
+        naive_effect=float(results["naive_effect"]),
+        confounding_bias_pct=float(results["confounding_bias_pct"]),
+        refutation_p=float(refutation_p) if refutation_p is not None else None,
+        spec_json=canonical_json(spec),
+        notebook="case_studies.utils.causal",
+        started_at=results.get("started_at"),
+        elapsed_s=results.get("elapsed_s"),
+        case_dir=case_dir,
+    )
+    return CausalResult.open(
+        study,
+        causal_hash,
+        include_preview=spec["execution_tier"] == "preview",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -947,7 +947,7 @@ def run_resolved_causal_request(
     except KeyError:
         cached = None
     if cached is not None:
-        if cached.spec != spec or not cached.complete:
+        if training_hash_from_spec(cached.spec) != causal_hash or not cached.complete:
             raise ValueError(f"causal cache is incomplete or conflicts with {causal_hash}")
         return cached
 

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1466,8 +1466,38 @@ def register_causal_run(
     """
     if case_dir is None:
         case_dir = _case_dir(case_study)
+    import json
+
+    version = (json.loads(spec_json) or {}).get("identity_version")
+    immutable = version in SUPPORTED_IDENTITY_VERSIONS
     db = _open_registry(case_dir)
     try:
+        existing = db.execute(
+            "SELECT label, treatment, confounders_json, embargo, n_folds, n_obs, "
+            "dml_effect, dml_se_hac, p_value_hac, naive_effect, confounding_bias_pct, "
+            "refutation_p, spec_json, notebook FROM causal_runs WHERE causal_hash = ?",
+            (causal_hash,),
+        ).fetchone()
+        expected = (
+            label,
+            treatment,
+            confounders_json,
+            embargo,
+            n_folds,
+            n_obs,
+            dml_effect,
+            dml_se_hac,
+            p_value_hac,
+            naive_effect,
+            confounding_bias_pct,
+            refutation_p,
+            spec_json,
+            notebook,
+        )
+        if immutable and existing is not None:
+            if existing != expected:
+                raise ValueError(f"immutable causal result conflict for {causal_hash}")
+            return
         # ON CONFLICT DO UPDATE rather than INSERT OR REPLACE — consistent with
         # register_paired_metrics, avoids the implicit DELETE that triggers
         # FK cascades and loses the original created_at timestamp.

--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -419,6 +419,10 @@ def get_entry_schemes_for(
         # prediction-based portfolio; exclude it to match get_top_k_values_for.
         if k >= n_assets:
             continue
+        # Long and short selections must be disjoint. Keep the declared grid and
+        # exclude only members that the available cross-section cannot realize.
+        if long_short and 2 * k > n_assets:
+            continue
         schemes.append(
             {
                 "name": f"ew_top{k}",
@@ -703,6 +707,8 @@ def get_allocators(case_study: str) -> list[dict]:
         # Calendar-string overrides (``"3M"`` etc.) resolved against ppy.
         for key in _LOOKBACK_KEYS:
             if key in out and isinstance(out[key], str):
+                if ppy is None:
+                    raise RuntimeError("calendar lookback resolution requires periods_per_year")
                 out[key] = _resolve_calendar_lookback(out[key], ppy)
         resolved.append(out)
     return resolved

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -55,7 +55,8 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 from utils.modeling import RANDOM_SEED, seed_everything
 
-_TABM_PREVIEW_FIELDS = {"folds", "max_symbols"}
+_TABM_PREVIEW_FIELDS = {"checkpoint_interval", "folds", "max_symbols", "n_epochs"}
+_TABM_IMBALANCE_METHODS = {"balanced", "none"}
 
 
 @dataclass(frozen=True)
@@ -70,6 +71,7 @@ class TabMResearchContext:
     entity_col: str
     task_type: str
     class_values: tuple[Any, ...]
+    class_weights_by_fold: dict[int, tuple[float, ...]]
     temporal_by_fold: pd.DataFrame | None
     temporal_keys: tuple[str, ...]
     temporal_feature_names: tuple[str, ...]
@@ -88,9 +90,13 @@ def _sha256(path: Path) -> str:
 def _tabm_source_identity() -> dict[str, str]:
     from case_studies.utils import deep_model_state
 
+    deep_model_state_file = deep_model_state.__file__
+    if deep_model_state_file is None:
+        raise RuntimeError("deep_model_state has no source file")
+    deep_model_state_path = Path(deep_model_state_file)
     return {
         Path(__file__).name: _sha256(Path(__file__)),
-        Path(deep_model_state.__file__).name: _sha256(Path(deep_model_state.__file__)),
+        deep_model_state_path.name: _sha256(deep_model_state_path),
     }
 
 
@@ -165,18 +171,72 @@ def _tabm_splits(mds, request: dict[str, Any]) -> tuple[list[dict[str, Any]], di
 def _resolve_tabm_config(config: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
     resolved = {**config, "params": dict(config.get("params") or {})}
     top_level = {"batch_size", "checkpoint_interval", "n_epochs"}
-    unknown = set(overrides) - top_level - set(resolved["params"]) - {"device", "num_threads"}
+    unknown = (
+        set(overrides)
+        - top_level
+        - set(resolved["params"])
+        - {"class_weight", "device", "num_threads"}
+    )
     if unknown:
         raise ValueError(f"unsupported TabM overrides: {sorted(unknown)}")
     for key, value in overrides.items():
         if key in top_level:
             resolved[key] = value
-        elif key not in {"device", "num_threads"}:
+        elif key not in {"class_weight", "device", "num_threads"}:
             resolved["params"][key] = value
     if resolved.get("library") != "tabm" or str(resolved["config_name"]).startswith("tabpfn"):
         raise ValueError("the TabM research adapter requires a persisted TabM configuration")
     _tabm_checkpoint_epochs(resolved)
     return resolved
+
+
+def _balanced_class_weights(values: np.ndarray, class_values: tuple[Any, ...]) -> tuple[float, ...]:
+    """Return sklearn-style balanced weights in the declared class order."""
+    if not class_values:
+        return ()
+    counts = np.asarray([(values == value).sum() for value in class_values], dtype=np.float64)
+    if np.any(counts == 0):
+        missing = [value for value, count in zip(class_values, counts, strict=True) if count == 0]
+        raise ValueError(f"classification fold is missing declared classes: {missing}")
+    return tuple((len(values) / (len(class_values) * counts)).tolist())
+
+
+def _tabm_class_weights_by_fold(
+    mds,
+    splits: list[dict[str, Any]],
+    *,
+    method: str,
+) -> dict[int, tuple[float, ...]]:
+    if mds.task_type != "classification":
+        return {}
+    if method not in _TABM_IMBALANCE_METHODS:
+        raise ValueError(
+            f"unsupported TabM class_weight {method!r}; expected {sorted(_TABM_IMBALANCE_METHODS)}"
+        )
+    class_values = tuple(mds.class_values)
+    if not class_values:
+        raise ValueError("classification requires declared class values")
+    weights = {}
+    date_dtype = mds.dataset.schema[mds.date_col]
+    for split in splits:
+        labels = (
+            mds.dataset.filter(
+                pl.col(mds.date_col).is_between(
+                    pl.lit(split["train_start"]).cast(date_dtype, strict=False),
+                    pl.lit(split["train_end"]).cast(date_dtype, strict=False),
+                    closed="both",
+                )
+            )
+            .drop_nulls(mds.label_col)
+            .get_column(mds.label_col)
+            .to_numpy()
+        )
+        weights[int(split["fold"])] = (
+            _balanced_class_weights(labels, class_values)
+            if method == "balanced"
+            else tuple(1.0 for _ in class_values)
+        )
+    return weights
 
 
 def _tabm_expected_keys(mds, splits: list[dict[str, Any]]) -> pl.DataFrame:
@@ -204,6 +264,7 @@ def _tabm_expected_keys(mds, splits: list[dict[str, Any]]) -> pl.DataFrame:
 
 def resolve_model_request(study: Study, request: dict[str, Any]):
     from case_studies.research.contracts import ExecutionTier
+    from case_studies.research.identity import ResolvedSpec
     from utils.modeling import load_configs, load_modeling_dataset
 
     tier = ExecutionTier(request["execution_tier"])
@@ -213,7 +274,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         raise ValueError(f"unsupported TabM preview reductions: {sorted(unknown_reductions)}")
     study.require_writable()
     study.activate(tier)
-    label_ref = study.labels.get(request["label"])
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
     mds = load_modeling_dataset(
         study.case_study,
         label_ref.name,
@@ -231,27 +292,52 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     except KeyError as error:
         raise ValueError(f"unknown TabM configuration {request['config_name']!r}") from error
     config = _resolve_tabm_config(configured, request["overrides"])
+    if tier is ExecutionTier.PREVIEW:
+        for field in ("checkpoint_interval", "n_epochs"):
+            if field in reductions:
+                config[field] = int(reductions[field])
+        _tabm_checkpoint_epochs(config)
     device = str(request["overrides"].get("device", "cuda"))
     num_threads = int(request["overrides"].get("num_threads", 8))
     runtime = tabm_runtime_spec(device, num_threads=num_threads)
     expected = _tabm_expected_keys(mds, splits)
     input_lineage = mds.input_lineage
     checkpoints = _tabm_checkpoint_epochs(config)
-    spec = {
-        "identity_version": 2,
-        "execution_tier": tier.value,
-        "family": "tabular_dl",
-        "label": label_ref.name,
-        "seed": int(runtime["seed"]),
-        "config_name": config["config_name"],
+    class_weight_method = str(request["overrides"].get("class_weight", "balanced"))
+    class_weights_by_fold = _tabm_class_weights_by_fold(
+        mds,
+        splits,
+        method=class_weight_method,
+    )
+    task = {
+        "type": mds.task_type,
+        "class_values": list(mds.class_values),
+        "continuous_eval_label": label_ref.definition.continuous_eval_label,
+    }
+    if mds.task_type == "classification":
+        task.update(
+            {
+                "metrics": [
+                    "ic",
+                    "auc_roc",
+                    "log_loss",
+                    "accuracy",
+                    "balanced_accuracy",
+                ],
+                "imbalance": {
+                    "method": class_weight_method,
+                    "effective_class_weights_by_fold": {
+                        str(fold): list(weights)
+                        for fold, weights in sorted(class_weights_by_fold.items())
+                    },
+                },
+            }
+        )
+    computation = {
         "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
         "feature_artifacts": input_lineage["artifacts"],
         "feature_names": list(mds.feature_names),
-        "task": {
-            "type": mds.task_type,
-            "class_values": list(mds.class_values),
-            "continuous_eval_label": label_ref.definition.continuous_eval_label,
-        },
+        "task": task,
         "cv": cv_record,
         "model": {
             "class": "TabMModel",
@@ -282,8 +368,31 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         "source_identity": _tabm_source_identity(),
         "runtime_identity": _tabm_runtime_identity(),
     }
-    if tier is ExecutionTier.PREVIEW:
-        spec["preview_reductions"] = reductions
+    runtime_provenance = _tabm_runtime_provenance(study)
+    if mds.task_type == "classification":
+        if tier is ExecutionTier.PREVIEW:
+            computation["preview_reductions"] = reductions
+        spec = ResolvedSpec.create(
+            family="tabular_dl",
+            label=label_ref.name,
+            seed=int(runtime["seed"]),
+            computation=computation,
+            provenance=runtime_provenance,
+            config_name=config["config_name"],
+            execution_tier=tier.value,
+        ).as_dict()
+    else:
+        spec = {
+            "identity_version": 2,
+            "execution_tier": tier.value,
+            "family": "tabular_dl",
+            "label": label_ref.name,
+            "seed": int(runtime["seed"]),
+            "config_name": config["config_name"],
+            **computation,
+        }
+        if tier is ExecutionTier.PREVIEW:
+            spec["preview_reductions"] = reductions
     context = TabMResearchContext(
         dataset_pd=mds.dataset.to_pandas(),
         splits=tuple(splits),
@@ -295,11 +404,12 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         entity_col=mds.entity_cols[0],
         task_type=mds.task_type,
         class_values=tuple(mds.class_values),
+        class_weights_by_fold=class_weights_by_fold,
         temporal_by_fold=mds.temporal_by_fold,
         temporal_keys=tuple(mds.temporal_keys),
         temporal_feature_names=tuple(mds.temporal_feature_names),
         expected_keys=expected,
-        runtime_provenance=_tabm_runtime_provenance(study),
+        runtime_provenance=runtime_provenance,
     )
     return spec, context
 
@@ -311,7 +421,8 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
     from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
 
     training_hash = training_hash_from_spec(spec)
-    checkpoint_values = tuple(item["value"] for item in spec["checkpoint_schedule"])
+    computation = spec.get("computation", spec)
+    checkpoint_values = tuple(item["value"] for item in computation["checkpoint_schedule"])
     try:
         training = Result.open(
             study, training_hash, include_preview=spec["execution_tier"] == "preview"
@@ -324,7 +435,7 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
                     checkpoint,
                     "validation",
                     checkpoint_kind="epoch",
-                    identity_version=2,
+                    identity_version=spec["identity_version"],
                 ),
                 include_preview=spec["execution_tier"] == "preview",
             )
@@ -336,6 +447,9 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
         not isinstance(result, PredictionResult) or not result.complete for result in predictions
     ):
         return None
+    complete_predictions = tuple(
+        result for result in predictions if isinstance(result, PredictionResult)
+    )
     model_root = training.root / "run_log" / "training" / training.hash / "models"
     try:
         validate_deep_checkpoint_population(
@@ -347,7 +461,7 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
         )
     except ValueError:
         return None
-    return ModelRun(training=training, predictions=predictions)
+    return ModelRun(training=training, predictions=complete_predictions)
 
 
 def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResearchContext):
@@ -366,6 +480,7 @@ def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResear
     if model_dir.exists():
         raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
     staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+    computation = spec.get("computation", spec)
     try:
         result = run_tabm_cv(
             context.dataset_pd,
@@ -379,14 +494,15 @@ def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResear
             class_values=list(context.class_values) or None,
             date_col=context.date_col,
             entity_col=context.entity_col,
-            device=spec["numerics"]["device"],
+            device=computation["numerics"]["device"],
             save_dir=train_dir / "diagnostics",
             register=False,
             temporal_by_fold=context.temporal_by_fold,
             temporal_keys=list(context.temporal_keys),
             temporal_feature_names=list(context.temporal_feature_names),
+            class_weights_by_fold=context.class_weights_by_fold,
             seed=int(spec["seed"]),
-            num_threads=int(spec["numerics"]["num_threads"]),
+            num_threads=int(computation["numerics"]["num_threads"]),
             checkpoint_root=staging,
             strict=True,
         )
@@ -396,7 +512,7 @@ def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResear
         raise
 
     prediction_results = []
-    for checkpoint in (item["value"] for item in spec["checkpoint_schedule"]):
+    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
         predictions = (
             result["all_predictions"]
             .filter(
@@ -405,6 +521,11 @@ def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResear
             )
             .drop("config", "epoch")
             .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
+            .with_columns(
+                pl.col(context.date_col).cast(context.expected_keys.schema[context.date_col]),
+                pl.col(context.entity_col).cast(context.expected_keys.schema[context.entity_col]),
+                pl.col("fold").cast(context.expected_keys.schema["fold"]),
+            )
         )
         prediction_results.append(
             study.results.publish_predictions(
@@ -550,10 +671,10 @@ class TabMModel(nn.Module):
         n_features: int,
         hidden_dim: int = 64,
         n_members: int = 8,
+        output_dim: int = 1,
         dropout: float = 0.1,
     ):
         super().__init__()
-        self.n_members = n_members
 
         # Shared backbone
         self.backbone = nn.Sequential(
@@ -569,15 +690,16 @@ class TabMModel(nn.Module):
         self.adapters = nn.Parameter(torch.randn(n_members, hidden_dim) * 0.1)
 
         # Per-member output heads
-        self.heads = nn.ModuleList([nn.Linear(hidden_dim, 1) for _ in range(n_members)])
+        self.heads = nn.ModuleList([nn.Linear(hidden_dim, output_dim) for _ in range(n_members)])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         h = self.backbone(x)  # (batch, hidden)
         outputs = []
-        for i in range(self.n_members):
+        for i in range(len(self.heads)):
             h_adapted = h * self.adapters[i].unsqueeze(0)  # rank-1 scaling
             outputs.append(self.heads[i](h_adapted))
-        return torch.stack(outputs, dim=0).mean(dim=0).squeeze(-1)  # (batch,)
+        output = torch.stack(outputs, dim=0).mean(dim=0)
+        return output.squeeze(-1) if output.shape[-1] == 1 else output
 
 
 # ---------------------------------------------------------------------------
@@ -599,6 +721,15 @@ def _predict_in_chunks(
             batch = torch.FloatTensor(X[start : start + chunk_size]).to(device)
             preds.append(model(batch).cpu().numpy())
     return np.concatenate(preds)
+
+
+def _classification_scores(logits: np.ndarray, class_values: tuple[Any, ...]) -> np.ndarray:
+    shifted = logits - logits.max(axis=1, keepdims=True)
+    probabilities = np.exp(shifted)
+    probabilities /= probabilities.sum(axis=1, keepdims=True)
+    if len(class_values) == 2:
+        return probabilities[:, 1]
+    return probabilities @ np.asarray(class_values, dtype=np.float64)
 
 
 def _run_tabpfn_fold(
@@ -639,6 +770,9 @@ def _train_tabm_fold(
     batch_size: int,
     checkpoint_interval: int,
     device: torch.device,
+    task_type: str = "regression",
+    class_values: tuple[Any, ...] = (),
+    class_weights: tuple[float, ...] = (),
     state_callback: Callable[[int, nn.Module], None] | None = None,
 ) -> tuple[dict[int, float], dict[int, np.ndarray], dict[int, float]]:
     """Train TabM on one fold, storing predictions at ALL checkpoints.
@@ -650,7 +784,23 @@ def _train_tabm_fold(
     """
     model = model.to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
-    criterion = nn.MSELoss()
+    is_classification = task_type == "classification"
+    if is_classification:
+        if not class_values or len(class_weights) != len(class_values):
+            raise ValueError("classification training requires class values and aligned weights")
+        criterion = nn.CrossEntropyLoss(
+            weight=torch.tensor(class_weights, dtype=torch.float32, device=device)
+        )
+        class_to_index = {value: index for index, value in enumerate(class_values)}
+        try:
+            y_train_index = np.asarray([class_to_index[value] for value in y_train], dtype=np.int64)
+        except KeyError as error:
+            raise ValueError(
+                f"training label is outside declared classes: {error.args[0]!r}"
+            ) from error
+    else:
+        criterion = nn.MSELoss()
+        y_train_index = None
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs)
 
     n_train = len(X_train)
@@ -668,7 +818,12 @@ def _train_tabm_fold(
         for n_batches, start in enumerate(range(0, n_train, batch_size), 1):
             batch_idx = indices[start : start + batch_size]
             X_batch = torch.FloatTensor(X_train[batch_idx]).to(device)
-            y_batch = torch.FloatTensor(y_train[batch_idx]).to(device)
+            if is_classification:
+                if y_train_index is None:
+                    raise RuntimeError("classification target index was not initialized")
+                y_batch = torch.as_tensor(y_train_index[batch_idx], dtype=torch.long, device=device)
+            else:
+                y_batch = torch.as_tensor(y_train[batch_idx], dtype=torch.float32, device=device)
 
             pred = model(X_batch)
             loss = criterion(pred, y_batch)
@@ -686,7 +841,12 @@ def _train_tabm_fold(
 
         # Evaluate and store predictions at checkpoint epochs
         if epoch % checkpoint_interval == 0 or epoch == n_epochs:
-            val_preds = _predict_in_chunks(model, X_val, device)
+            raw_val_preds = _predict_in_chunks(model, X_val, device)
+            val_preds = (
+                _classification_scores(raw_val_preds, class_values)
+                if is_classification
+                else raw_val_preds
+            )
             if state_callback is not None:
                 state_callback(epoch, model)
             ic_frame = pl.DataFrame(
@@ -1161,6 +1321,7 @@ def run_tabm_cv(
     eval_label_col: str | None = None,
     task_type: str = "regression",
     class_values: list | None = None,
+    class_weights_by_fold: dict[int, tuple[float, ...]] | None = None,
     date_col: str,
     entity_col: str = "symbol",
     device: str = "cuda",
@@ -1228,6 +1389,8 @@ def run_tabm_cv(
         raise ValueError("classification requires eval_label_col for continuous-return IC")
     if task_type == "classification" and not class_values:
         raise ValueError("classification requires class_values")
+    if task_type == "classification" and class_weights_by_fold is None:
+        raise ValueError("classification requires identity-resolved class_weights_by_fold")
     if eval_label_col and eval_label_col not in dataset_pd.columns:
         raise ValueError(f"eval_label_col {eval_label_col!r} is absent from the dataset")
     if n_features != len(feature_names):
@@ -1388,14 +1551,19 @@ def run_tabm_cv(
     dates_series = dataset_pd[date_col]
 
     # Pre-build per-fold data: mask dates → extract numpy → impute + scale
-    has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
     print("Preparing fold data...")
     fold_data = []
     for split in splits:
         train_mask = (dates_series >= split["train_start"]) & (dates_series <= split["train_end"])
         val_mask = (dates_series >= split["val_start"]) & (dates_series <= split["val_end"])
 
-        if has_fold_temporal:
+        if (
+            temporal_by_fold is not None
+            and temporal_keys is not None
+            and temporal_feature_names is not None
+            and temporal_keys
+            and temporal_feature_names
+        ):
             from utils.modeling import replace_temporal_columns
 
             train_df = replace_temporal_columns(
@@ -1447,6 +1615,8 @@ def run_tabm_cv(
         scaler = StandardScaler()
         X_train = scaler.fit_transform(imputer.fit_transform(X_train))
         X_val = scaler.transform(imputer.transform(X_val))
+        if scaler.mean_ is None or scaler.scale_ is None:
+            raise RuntimeError("fitted standard scaler did not expose its state")
 
         fold_data.append(
             {
@@ -1463,8 +1633,8 @@ def run_tabm_cv(
                 "preprocessing": {
                     "feature_names": list(feature_names),
                     "imputer_statistics": imputer.statistics_.astype(np.float32),
-                    "scaler_mean": scaler.mean_.astype(np.float32),
-                    "scaler_scale": scaler.scale_.astype(np.float32),
+                    "scaler_mean": np.asarray(scaler.mean_, dtype=np.float32),
+                    "scaler_scale": np.asarray(scaler.scale_, dtype=np.float32),
                 },
             }
         )
@@ -1612,7 +1782,8 @@ def run_tabm_cv(
                     break
             else:
                 # TabM: train to completion, store ALL checkpoint predictions
-                tabm_kwargs = {"n_features": n_features, **cfg_params}
+                output_dim = len(class_values or []) if task_type == "classification" else 1
+                tabm_kwargs = {"n_features": n_features, "output_dim": output_dim, **cfg_params}
                 model = TabMModel(**tabm_kwargs)
                 train_kwargs: dict[str, Any] = {}
                 if checkpoint_root is not None:
@@ -1658,6 +1829,9 @@ def run_tabm_cv(
                     batch_size=cfg_batch_size,
                     checkpoint_interval=cfg_checkpoint,
                     device=torch_device,
+                    task_type=task_type,
+                    class_values=tuple(class_values or ()),
+                    class_weights=(class_weights_by_fold or {}).get(int(fd["fold"]), ()),
                     **train_kwargs,
                 )
 

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -315,15 +315,12 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         "continuous_eval_label": label_ref.definition.continuous_eval_label,
     }
     if mds.task_type == "classification":
+        metrics = ["ic", "accuracy", "balanced_accuracy"]
+        if len(mds.class_values) == 2:
+            metrics[1:1] = ["auc_roc", "log_loss"]
         task.update(
             {
-                "metrics": [
-                    "ic",
-                    "auc_roc",
-                    "log_loss",
-                    "accuracy",
-                    "balanced_accuracy",
-                ],
+                "metrics": metrics,
                 "imbalance": {
                     "method": class_weight_method,
                     "effective_class_weights_by_fold": {

--- a/scripts/prove_crypto_interface.py
+++ b/scripts/prove_crypto_interface.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 from datetime import timedelta
 from pathlib import Path
 
@@ -136,6 +137,7 @@ def prove(workspace: Path) -> dict[str, object]:
     positions = target_positions(prediction_frame)
     state_policy = StateTransitionPolicy(fold_boundary="liquidate", temporal_gap="reset")
     decision = publish_exploratory_positions(study, final_prediction.hash, prediction_frame)
+    assert decision.load().sort("timestamp", "symbol").equals(positions)
     prices = load_backtest_prices_for(
         CASE_STUDY,
         label="fwd_dir_8h",
@@ -154,6 +156,23 @@ def prove(workspace: Path) -> dict[str, object]:
         "fold_boundary": "liquidate",
         "temporal_gap": "reset",
     }
+    backtest_dir = backtest.root / "run_log" / "backtest" / backtest.hash
+    fills = pl.read_parquet(backtest_dir / "fills.parquet")
+    portfolio_state = pl.read_parquet(backtest_dir / "portfolio_state.parquet")
+    with sqlite3.connect(backtest.root / "run_log" / "registry.db") as db:
+        metrics = db.execute(
+            "SELECT num_trades, funding_pnl, funding_events, funding_settlements "
+            "FROM backtest_metrics WHERE backtest_hash = ?",
+            (backtest.hash,),
+        ).fetchone()
+    assert metrics is not None
+    num_trades, funding_pnl, funding_events, funding_settlements = metrics
+    assert fills.height > 0
+    assert portfolio_state.filter(pl.col("gross_exposure") > 0).height > 0
+    assert num_trades > 0
+    assert funding_pnl != 0
+    assert funding_events > 0
+    assert funding_settlements > 0
     try:
         CandidateSet.create(study, "exploratory-must-not-be-canonical", [backtest])
     except ValueError as error:
@@ -199,6 +218,11 @@ def prove(workspace: Path) -> dict[str, object]:
         "causal_hash": causal_result.hash,
         "checkpoint_prediction_hashes": [item.hash for item in run.predictions],
         "eligible_rows": expected.height,
+        "funding_events": int(funding_events),
+        "funding_pnl": float(funding_pnl),
+        "funding_settlements": int(funding_settlements),
+        "num_fills": fills.height,
+        "num_trades": int(num_trades),
         "training_hash": run.training.hash,
         "workspace": str(study.storage_root("preview")),
     }

--- a/scripts/prove_crypto_interface.py
+++ b/scripts/prove_crypto_interface.py
@@ -1,0 +1,215 @@
+"""Run the reduced real-data proof for the crypto research interface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import timedelta
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.crypto_perps_funding.research_workflow import (
+    model_request_catalog,
+    open_study,
+    publish_exploratory_positions,
+    resolve_model_requests,
+    target_positions,
+)
+from case_studies.research import CandidateSet, DecisionArtifact, OfficialPopulation, Study
+from case_studies.research.catalog import CATALOG_VERSION, RESERVED_COLUMNS
+from case_studies.research.decisions import StateTransitionPolicy
+from case_studies.research.execution import run_backtests
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import load_backtest_prices_for
+from utils.paths import REPO_ROOT
+
+CASE_STUDY = "crypto_perps_funding"
+
+
+def prove(workspace: Path) -> dict[str, object]:
+    assert CATALOG_VERSION == 1
+    assert {
+        "training_hash",
+        "prediction_hash",
+        "checkpoint_kind",
+        "checkpoint_value",
+        "execution_tier",
+        "complete",
+    } <= set(RESERVED_COLUMNS)
+    study = open_study(execution_tier="preview", workspace=workspace)
+    request_catalog = model_request_catalog(
+        "tabular_dl", labels=("fwd_dir_8h",), config_prefix="tabm"
+    ).filter(pl.col("config_name") == "tabm_s")
+    overrides = {"class_weight": "balanced", "device": "cuda"}
+    preview_reductions = {
+        "checkpoint_interval": 1,
+        "folds": [0],
+        "max_symbols": 6,
+        "n_epochs": 2,
+    }
+    resolved = resolve_model_requests(
+        study,
+        request_catalog,
+        execution_tier="preview",
+        overrides=overrides,
+        preview_reductions=preview_reductions,
+    )[0]
+    computation = resolved.spec["computation"]
+    task = computation["task"]
+    assert task["type"] == "classification"
+    assert task["continuous_eval_label"] == "fwd_ret_8h"
+    assert task["imbalance"]["method"] == "balanced"
+    assert task["metrics"] == [
+        "ic",
+        "auc_roc",
+        "log_loss",
+        "accuracy",
+        "balanced_accuracy",
+    ]
+    assert [item["value"] for item in computation["checkpoint_schedule"]] == [1, 2]
+
+    run = resolved.run()
+    assert len(run.predictions) == 2
+    final_prediction = run.predictions[-1]
+    prediction_frame = final_prediction.load()
+    expected = resolved._context.expected_keys
+    actual = prediction_frame.select("symbol", "timestamp", "fold")
+    assert actual.height == actual.n_unique(["symbol", "timestamp", "fold"])
+    assert actual.join(expected, on=["symbol", "timestamp", "fold"], how="anti").is_empty()
+    assert expected.join(actual, on=["symbol", "timestamp", "fold"], how="anti").is_empty()
+    timestamps = prediction_frame.get_column("timestamp").unique().sort()
+    observed_steps = timestamps.diff().drop_nulls().unique().to_list()
+    assert observed_steps == [timedelta(hours=8)]
+    assert prediction_frame.get_column("prediction").is_finite().all()
+
+    restarted = resolve_model_requests(
+        study,
+        request_catalog,
+        execution_tier="preview",
+        overrides=overrides,
+        preview_reductions=preview_reductions,
+    )[0].run()
+    assert restarted.training.hash == run.training.hash
+    assert tuple(item.hash for item in restarted.predictions) == tuple(
+        item.hash for item in run.predictions
+    )
+    assert value_digest(restarted.predictions[-1].load()) == value_digest(prediction_frame)
+
+    preview_catalog = study.predictions.table(include_preview=True)
+    canonical_catalog = study.predictions.table(include_preview=False)
+    assert final_prediction.hash in preview_catalog.get_column("prediction_hash").to_list()
+    if not canonical_catalog.is_empty():
+        assert (
+            final_prediction.hash not in canonical_catalog.get_column("prediction_hash").to_list()
+        )
+    try:
+        OfficialPopulation.create(
+            study,
+            name="preview-must-not-enter-official-population",
+            member_kind="prediction",
+            members=[final_prediction.hash],
+        )
+    except ValueError as error:
+        assert "preview" in str(error)
+    else:
+        raise AssertionError("preview prediction entered an official population")
+
+    causal = study.causal(
+        method="dml",
+        label="fwd_ret_8h",
+        execution_tier="preview",
+        preview_reductions={
+            "max_samples": 1200,
+            "max_symbols": 6,
+            "n_folds": 2,
+            "n_placebo": 10,
+        },
+        overrides={"nuisance_params": {"max_iter": 10}},
+    )
+    resolved_causal = causal.resolve()
+    assert resolved_causal.spec["computation"]["refutation"]["temporal_gap_policy"] == "reset"
+    causal_result = resolved_causal.run()
+    assert causal_result.complete
+    assert causal.resolve().run().hash == causal_result.hash
+
+    positions = target_positions(prediction_frame)
+    state_policy = StateTransitionPolicy(fold_boundary="liquidate", temporal_gap="reset")
+    decision = publish_exploratory_positions(study, final_prediction.hash, prediction_frame)
+    prices = load_backtest_prices_for(
+        CASE_STUDY,
+        label="fwd_dir_8h",
+        split="validation",
+    )
+    selected = preview_catalog.filter(pl.col("prediction_hash") == final_prediction.hash)
+    execution = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "precomputed_positions", "top_k": 1},
+        decision=decision,
+        prices=prices,
+    )
+    backtest = execution.results[0]
+    assert backtest.spec()["decision_artifact"]["state_transition_policy"] == {
+        "fold_boundary": "liquidate",
+        "temporal_gap": "reset",
+    }
+    try:
+        CandidateSet.create(study, "exploratory-must-not-be-canonical", [backtest])
+    except ValueError as error:
+        assert "preview" in str(error) or "exploratory" in str(error)
+    else:
+        raise AssertionError("exploratory decision backtest entered a candidate set")
+    try:
+        OfficialPopulation.create(
+            study,
+            name="exploratory-must-not-be-canonical",
+            member_kind="backtest",
+            members=[backtest.hash],
+        )
+    except ValueError as error:
+        assert "preview" in str(error) or "exploratory" in str(error)
+    else:
+        raise AssertionError("exploratory decision backtest entered an official population")
+
+    try:
+        DecisionArtifact.publish(
+            study,
+            kind="target_positions",
+            decisions=positions,
+            prediction_hashes=[final_prediction.hash],
+            parameters={"long_count": 1, "short_count": 1},
+            state_transition_policy=state_policy,
+            canonical=True,
+            source_identity={
+                "module": "scripts.prove_crypto_interface",
+                "source_digest": "undisclosed",
+                "declared_inputs": {},
+                "determinism": {"deterministic": True},
+                "clean_replay_digest": value_digest(positions),
+            },
+        )
+    except (KeyError, ValueError) as error:
+        assert "canonical decision" in str(error) or "Unknown result hash" in str(error)
+    else:
+        raise AssertionError("undisclosed decision generation was promoted")
+
+    return {
+        "backtest_hash": backtest.hash,
+        "causal_hash": causal_result.hash,
+        "checkpoint_prediction_hashes": [item.hash for item in run.predictions],
+        "eligible_rows": expected.height,
+        "training_hash": run.training.hash,
+        "workspace": str(study.storage_root("preview")),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workspace", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(prove(args.workspace), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.research import CausalResult, LabelDefinition, Study
+from case_studies.utils import causal
+from tests.test_research_workspace import _seed_release
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _causal_fixture(tmp_path, monkeypatch):
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    setup_path = study.root / "config" / "setup.yaml"
+    setup_path.write_text(
+        setup_path.read_text() + "causal:\n  treatment: treatment\n  confounders: [confounder]\n"
+    )
+    rows = []
+    for timestamp_index, timestamp in enumerate(
+        pl.datetime_range(
+            pl.datetime(2024, 1, 1),
+            pl.datetime(2024, 1, 9, 16),
+            interval="8h",
+            eager=True,
+            time_zone="UTC",
+        )
+    ):
+        for symbol_index in range(6):
+            rows.append(
+                {
+                    "symbol": f"S{symbol_index}",
+                    "timestamp": timestamp,
+                    "feature": float(symbol_index),
+                    "treatment": float(symbol_index) + timestamp_index / 100,
+                    "confounder": float(timestamp_index % 5),
+                    "fwd_ret_8h": (symbol_index - 2.5) / 100 + timestamp_index / 10000,
+                }
+            )
+    frame = pl.DataFrame(rows)
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_8h", "regression", "8H"),
+        frame.select("symbol", "timestamp", "fwd_ret_8h"),
+    )
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature", "treatment", "confounder"],
+        label_col="fwd_ret_8h",
+        label_buffer="8H",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "config_name": "dml",
+                "family": "causal_dml",
+                "max_samples": 50000,
+                "n_folds": 5,
+                "n_placebo": 100,
+                "params": {"max_depth": 3, "max_iter": 50},
+                "seed": 42,
+            }
+        ],
+    )
+    return study, label
+
+
+def test_causal_request_resolves_timing_gap_and_preview_identity(tmp_path, monkeypatch) -> None:
+    study, label = _causal_fixture(tmp_path, monkeypatch)
+
+    resolved = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={
+            "max_samples": 240,
+            "max_symbols": 6,
+            "n_folds": 2,
+            "n_placebo": 10,
+        },
+    ).resolve()
+    computation = resolved.spec["computation"]
+
+    assert resolved.spec["identity_version"] == 3
+    assert computation["estimand"]["outcome"] == "fwd_ret_8h"
+    assert computation["estimand"]["treatment"] == "treatment"
+    assert computation["estimand"]["treatment_observed_at"] == "decision_timestamp"
+    assert computation["refutation"]["temporal_gap_policy"] == "reset"
+    assert computation["refutation"]["observation_cadence"] == "0 days 08:00:00"
+    assert computation["analysis_population"]["n_rows"] <= 240
+    assert computation["model"]["nuisance_params"]["max_iter"] == 50
+    assert computation["preview_reductions"]["n_folds"] == 2
+
+
+def test_causal_run_registers_once_and_reopens_after_restart(tmp_path, monkeypatch) -> None:
+    study, label = _causal_fixture(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(
+        causal,
+        "run_dml_analysis",
+        lambda *args, **kwargs: {
+            "dml_result": {"theta": 0.02, "se_hac": 0.01, "n_obs": 120},
+            "p_value_hac": 0.04,
+            "naive_effect": 0.03,
+            "confounding_bias_pct": 50.0,
+            "refutation": {"empirical_p": 0.1},
+            "started_at": "2026-08-13T00:00:00+00:00",
+            "elapsed_s": 1.0,
+        },
+    )
+    request = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={
+            "max_samples": 240,
+            "max_symbols": 6,
+            "n_folds": 2,
+            "n_placebo": 10,
+        },
+    )
+
+    first = request.run()
+    reopened = CausalResult.open(study, first.hash, include_preview=True)
+    second = request.run()
+
+    assert first.complete
+    assert reopened.hash == first.hash == second.hash
+    assert CausalResult.one(study, label=label.name, execution_tier="preview").hash == first.hash
+    assert reopened.metrics["dml_effect"] == 0.02
+    assert json.loads(json.dumps(reopened.spec)) == reopened.spec
+
+
+def test_block_permutation_resets_at_temporal_gap() -> None:
+    values = np.arange(8)
+    timestamps = np.array(
+        [
+            "2024-01-01T00:00:00",
+            "2024-01-01T08:00:00",
+            "2024-01-01T16:00:00",
+            "2024-01-02T00:00:00",
+            "2024-01-04T00:00:00",
+            "2024-01-04T08:00:00",
+            "2024-01-04T16:00:00",
+            "2024-01-05T00:00:00",
+        ],
+        dtype="datetime64[s]",
+    )
+
+    permuted = causal.block_permute(
+        values,
+        block_size=2,
+        rng=np.random.default_rng(7),
+        groups=timestamps,
+        expected_step="8h",
+    )
+
+    assert set(permuted[:4]) == set(values[:4])
+    assert set(permuted[4:]) == set(values[4:])

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from copy import deepcopy
 from types import SimpleNamespace
 
 import numpy as np
@@ -10,6 +11,7 @@ import pytest
 
 from case_studies.research import CausalResult, LabelDefinition, Study
 from case_studies.utils import causal
+from case_studies.utils.registry.specs import training_hash_from_spec
 from tests.test_research_workspace import _seed_release
 
 
@@ -151,6 +153,44 @@ def test_causal_run_registers_once_and_reopens_after_restart(tmp_path, monkeypat
     assert CausalResult.one(study, label=label.name, execution_tier="preview").hash == first.hash
     assert reopened.metrics["dml_effect"] == 0.02
     assert json.loads(json.dumps(reopened.spec)) == reopened.spec
+
+
+def test_causal_cache_accepts_provenance_only_drift(tmp_path, monkeypatch) -> None:
+    study, label = _causal_fixture(tmp_path, monkeypatch)
+    calls = 0
+
+    def run_analysis(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "dml_result": {"theta": 0.02, "se_hac": 0.01, "n_obs": 120},
+            "p_value_hac": 0.04,
+            "naive_effect": 0.03,
+            "confounding_bias_pct": 50.0,
+            "refutation": {"empirical_p": 0.1},
+        }
+
+    monkeypatch.setattr(causal, "run_dml_analysis", run_analysis)
+    resolved = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={
+            "max_samples": 240,
+            "max_symbols": 6,
+            "n_folds": 2,
+            "n_placebo": 10,
+        },
+    ).resolve()
+    first = resolved.run()
+    provenance_only = deepcopy(resolved.spec)
+    provenance_only["provenance"]["baseline_commit"] = "new-provenance-only-commit"
+
+    assert training_hash_from_spec(provenance_only) == first.hash
+    second = causal.run_resolved_causal_request(study, provenance_only, resolved._context)
+
+    assert second.hash == first.hash
+    assert calls == 1
 
 
 def test_block_permutation_resets_at_temporal_gap() -> None:

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -369,8 +369,17 @@ def test_date_engine_targets_match_date_feed() -> None:
     assert result.engine_result.fills
 
 
-def test_contiguous_state_transition_flattens_then_reenters_at_boundary() -> None:
-    timestamps = [datetime(2024, 1, day, tzinfo=UTC) for day in (1, 2)]
+@pytest.mark.parametrize(
+    ("timestamps", "expected_avg_turnover"),
+    [
+        ([datetime(2024, 1, 1, hour=hour, tzinfo=UTC) for hour in (0, 8)], 1.5),
+        ([datetime(2024, 1, day, tzinfo=UTC) for day in (1, 2)], 0.75),
+    ],
+    ids=["intraday-events-summed", "daily-events-averaged"],
+)
+def test_contiguous_state_transition_flattens_then_reenters_at_boundary(
+    timestamps: list[datetime], expected_avg_turnover: float
+) -> None:
     prices = pl.DataFrame(
         {
             "timestamp": timestamps,
@@ -412,4 +421,4 @@ def test_contiguous_state_transition_flattens_then_reenters_at_boundary() -> Non
     assert [fill.side.value for fill in result.engine_result.fills] == ["buy", "sell", "buy"]
     assert result.engine_result.fills[1].timestamp == timestamps[1]
     assert result.engine_result.fills[2].timestamp == timestamps[1]
-    assert result.metrics["avg_turnover"] == pytest.approx(0.75)
+    assert result.metrics["avg_turnover"] == pytest.approx(expected_avg_turnover)

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -422,3 +422,54 @@ def test_contiguous_state_transition_flattens_then_reenters_at_boundary(
     assert result.engine_result.fills[1].timestamp == timestamps[1]
     assert result.engine_result.fills[2].timestamp == timestamps[1]
     assert result.metrics["avg_turnover"] == pytest.approx(expected_avg_turnover)
+
+
+def test_state_transition_turnover_includes_symbol_missing_from_new_target() -> None:
+    timestamps = [datetime(2024, 1, day, tzinfo=UTC) for day in (1, 2)]
+    price_keys = [(timestamp, symbol) for timestamp in timestamps for symbol in ("BTC", "ETH")]
+    prices = pl.DataFrame(
+        {
+            "timestamp": [timestamp for timestamp, _ in price_keys],
+            "symbol": [symbol for _, symbol in price_keys],
+            "open": [100.0] * 4,
+            "high": [100.0] * 4,
+            "low": [100.0] * 4,
+            "close": [100.0] * 4,
+            "volume": [1_000_000.0] * 4,
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": [timestamp for timestamp, _ in price_keys],
+            "symbol": [symbol for _, symbol in price_keys],
+            "y_score": [0.1] * 4,
+            "y_true": [0.0] * 4,
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": [timestamps[0], timestamps[0], timestamps[1]],
+            "symbol": ["BTC", "ETH", "BTC"],
+            "weight": [0.5, 0.5, 0.5],
+            "_state_transition": [False, False, True],
+        }
+    )
+
+    result = backtest_runner.run_backtest(
+        "crypto_perps_funding",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+
+    assert [fill.side.value for fill in result.engine_result.fills] == [
+        "buy",
+        "buy",
+        "sell",
+        "sell",
+        "buy",
+    ]
+    assert result.metrics["avg_turnover"] == pytest.approx(1.25)

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -4,46 +4,16 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import polars as pl
+import pytest
 
-from case_studies.crypto_perps_funding.funding_backtest import apply_funding_settlements
+from case_studies.crypto_perps_funding.funding_backtest import FundingSettlementLedger
+from case_studies.utils import backtest_runner
 
 
-def test_funding_is_position_signed_before_same_timestamp_fills() -> None:
+def test_funding_changes_broker_cash_before_same_timestamp_sizing() -> None:
     first = datetime(2024, 1, 1, tzinfo=UTC)
     settlement = datetime(2024, 1, 1, 8, tzinfo=UTC)
     last = datetime(2024, 1, 1, 16, tzinfo=UTC)
-    buy = SimpleNamespace(
-        timestamp=first,
-        quantity=1.0,
-        side=SimpleNamespace(value="buy"),
-        price=100.0,
-        commission=0.0,
-        asset="BTCUSDT",
-    )
-    sell = SimpleNamespace(
-        timestamp=settlement,
-        quantity=1.0,
-        side=SimpleNamespace(value="sell"),
-        price=100.0,
-        commission=0.0,
-        asset="BTCUSDT",
-    )
-    engine = SimpleNamespace(
-        fills=[buy, sell],
-        equity_curve=[(first, 1_000.0), (settlement, 1_000.0), (last, 1_000.0)],
-        portfolio_state=[
-            (first, 1_000.0, 900.0, 100.0, 100.0, 1),
-            (settlement, 1_000.0, 1_000.0, 0.0, 0.0, 0),
-            (last, 1_000.0, 1_000.0, 0.0, 0.0, 0),
-        ],
-    )
-    prices = pl.DataFrame(
-        {
-            "timestamp": [first, settlement, last],
-            "symbol": ["BTCUSDT"] * 3,
-            "close": [100.0] * 3,
-        }
-    )
     funding = pl.DataFrame(
         {
             "timestamp": [settlement],
@@ -52,21 +22,58 @@ def test_funding_is_position_signed_before_same_timestamp_fills() -> None:
         }
     )
 
-    metrics = apply_funding_settlements(
-        engine,
-        prices=prices,
-        funding_rates=funding,
-        initial_cash=1_000.0,
-    )
+    position = SimpleNamespace(quantity=1.0, current_price=100.0, multiplier=1.0)
+    broker = SimpleNamespace(cash=1_000.0, positions={"BTCUSDT": position})
 
-    assert metrics == {
+    def update_time(timestamp, prices, *_args, **_kwargs):
+        position.current_price = prices["BTCUSDT"]
+
+    broker._update_time = update_time
+    ledger = FundingSettlementLedger(funding)
+    ledger.install(broker)
+
+    broker._update_time(settlement, {"BTCUSDT": 100.0})
+    target_quantity = broker.cash / 100.0
+
+    assert broker.cash == 999.0
+    assert target_quantity == 9.99
+    assert ledger.metrics() == {
         "funding_pnl": -1.0,
         "funding_events": 1.0,
         "funding_settlements": 1.0,
-        "funding_reconstruction_error": 0.0,
     }
-    assert engine.equity_curve == [(first, 1_000.0), (settlement, 999.0), (last, 999.0)]
-    assert engine.portfolio_state[1][1:3] == (999.0, 999.0)
+
+    broker._update_time(settlement, {"BTCUSDT": 100.0})
+    assert broker.cash == 999.0
+
+    broker._update_time(last, {"BTCUSDT": 100.0})
+    assert ledger.metrics()["funding_pnl"] == -1.0
+
+
+def test_longs_pay_and_shorts_receive_the_same_funding_rate() -> None:
+    timestamp = datetime(2024, 1, 1, 8, tzinfo=UTC)
+    funding = pl.DataFrame(
+        {
+            "timestamp": [timestamp, timestamp],
+            "symbol": ["LONG", "SHORT"],
+            "funding_rate": [0.01, 0.01],
+        }
+    )
+    positions = {
+        "LONG": SimpleNamespace(quantity=2.0, current_price=100.0, multiplier=1.0),
+        "SHORT": SimpleNamespace(quantity=-1.0, current_price=100.0, multiplier=1.0),
+    }
+    broker = SimpleNamespace(cash=1_000.0, positions=positions)
+    ledger = FundingSettlementLedger(funding)
+
+    ledger.settle(timestamp, broker)
+
+    assert broker.cash == 999.0
+    assert ledger.metrics() == {
+        "funding_pnl": -1.0,
+        "funding_events": 1.0,
+        "funding_settlements": 2.0,
+    }
 
 
 def test_funding_rejects_duplicate_settlement_keys() -> None:
@@ -78,18 +85,234 @@ def test_funding_rejects_duplicate_settlement_keys() -> None:
             "funding_rate": [0.01, 0.01],
         }
     )
-    engine = SimpleNamespace(fills=[], equity_curve=[], portfolio_state=[])
-
     try:
-        apply_funding_settlements(
-            engine,
-            prices=pl.DataFrame(
-                {"timestamp": [timestamp], "symbol": ["BTCUSDT"], "close": [100.0]}
-            ),
-            funding_rates=funding,
-            initial_cash=1_000.0,
-        )
+        FundingSettlementLedger(funding)
     except ValueError as error:
         assert "unique" in str(error)
     else:
         raise AssertionError("duplicate funding settlements were accepted")
+
+
+def test_funding_rejects_incomplete_engine_timeline_coverage() -> None:
+    timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+    ledger = FundingSettlementLedger(
+        pl.DataFrame(
+            {
+                "timestamp": [timestamp],
+                "symbol": ["BTCUSDT"],
+                "funding_rate": [0.01],
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="0/1"):
+        ledger.metrics()
+
+
+def _backtest_frames(timestamp: datetime) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    prices = pl.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "symbol": ["BTCUSDT"],
+            "open": [100.0],
+            "high": [100.0],
+            "low": [100.0],
+            "close": [100.0],
+            "volume": [1_000.0],
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "symbol": ["BTCUSDT"],
+            "y_score": [0.1],
+            "y_true": [0.01],
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "symbol": ["BTCUSDT"],
+            "weight": [-1.0],
+        }
+    )
+    return prices, predictions, weights
+
+
+def _strategy_spec(mode: str) -> dict:
+    return {
+        "signal": {"method": "precomputed_positions"},
+        "execution": {
+            "mode": mode,
+            "cadence": "8_hour_funding",
+            "fill_timing": "AT_FUNDING_TIMESTAMP",
+            "min_weight_change": 0.0,
+            "min_trade_value": 0.0,
+        },
+        "costs": {"model": "percentage", "commission_bps": 0.0, "slippage_bps": 0.0},
+    }
+
+
+def test_negative_precomputed_weights_enable_shorting_in_resolved_engine_config(
+    monkeypatch,
+) -> None:
+    timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+    prices, predictions, weights = _backtest_frames(timestamp)
+    prices = prices.with_columns(pl.lit("A").alias("symbol"))
+    predictions = predictions.with_columns(pl.lit("A").alias("symbol"))
+    weights = weights.with_columns(pl.lit("A").alias("symbol"))
+    captured = {}
+
+    def fake_engine(**kwargs):
+        captured.update(kwargs)
+        return {
+            "metrics": {},
+            "daily_returns": pl.DataFrame({"timestamp": [timestamp], "daily_return": [0.0]}),
+        }
+
+    monkeypatch.setattr(backtest_runner, "_run_engine", fake_engine)
+
+    backtest_runner.run_backtest(
+        "etfs",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+
+    assert captured["allow_short"] is True
+    assert captured["strategy_spec"]["backtest_config"]["account"]["allow_short_selling"] is True
+
+
+def test_vectorized_backtest_rejects_funding_cashflows(monkeypatch) -> None:
+    timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+    prices, predictions, weights = _backtest_frames(timestamp)
+    funding = pl.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "symbol": ["BTCUSDT"],
+            "funding_rate": [0.01],
+        }
+    )
+    monkeypatch.setattr(
+        backtest_runner,
+        "_run_vectorized",
+        lambda **kwargs: pytest.fail("vectorized path ran with funding rates"),
+    )
+
+    with pytest.raises(ValueError, match="vectorized.*funding"):
+        backtest_runner.run_backtest(
+            "crypto_perps_funding",
+            "prediction-a",
+            _strategy_spec("vectorized"),
+            prices=prices,
+            predictions=predictions,
+            precomputed_weights=weights,
+            funding_rates=funding,
+            register=False,
+        )
+
+
+def test_live_funding_changes_the_next_engine_target_order() -> None:
+    timestamps = [datetime(2024, 1, 1, hour=hour, tzinfo=UTC) for hour in (0, 8, 16)]
+    prices = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 3,
+            "open": [100.0] * 3,
+            "high": [100.0] * 3,
+            "low": [100.0] * 3,
+            "close": [100.0] * 3,
+            "volume": [1_000_000.0] * 3,
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 3,
+            "y_score": [0.1] * 3,
+            "y_true": [0.0] * 3,
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 3,
+            "weight": [0.5] * 3,
+        }
+    )
+    funding = pl.DataFrame(
+        {
+            "timestamp": [timestamps[1]],
+            "symbol": ["BTCUSDT"],
+            "funding_rate": [0.1],
+        }
+    )
+
+    unfunded = backtest_runner.run_backtest(
+        "crypto_perps_funding",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+    funded = backtest_runner.run_backtest(
+        "crypto_perps_funding",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        funding_rates=funding,
+        register=False,
+    )
+
+    assert funded.metrics["funding_pnl"] < 0
+    assert len(funded.engine_result.fills) > len(unfunded.engine_result.fills)
+    assert any(fill.timestamp == timestamps[1] for fill in funded.engine_result.fills)
+
+
+def test_timezone_naive_engine_targets_match_timezone_naive_feed() -> None:
+    timestamps = [datetime(2024, 1, 1, hour=hour) for hour in (0, 8)]
+    prices = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "open": [100.0] * 2,
+            "high": [100.0] * 2,
+            "low": [100.0] * 2,
+            "close": [100.0] * 2,
+            "volume": [1_000_000.0] * 2,
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "y_score": [0.1] * 2,
+            "y_true": [0.0] * 2,
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "weight": [0.5] * 2,
+        }
+    )
+
+    result = backtest_runner.run_backtest(
+        "crypto_perps_funding",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+
+    assert result.engine_result.fills

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -22,11 +22,16 @@ def test_funding_changes_broker_cash_before_same_timestamp_sizing() -> None:
         }
     )
 
-    position = SimpleNamespace(quantity=1.0, current_price=100.0, multiplier=1.0)
-    broker = SimpleNamespace(cash=1_000.0, positions={"BTCUSDT": position})
+    position = SimpleNamespace(quantity=1.0, current_price=90.0, multiplier=1.0)
+    marks = {"BTCUSDT": 90.0}
+    broker = SimpleNamespace(
+        cash=1_000.0,
+        positions={"BTCUSDT": position},
+        get_mark_price=lambda symbol, **_kwargs: marks[symbol],
+    )
 
     def update_time(timestamp, prices, *_args, **_kwargs):
-        position.current_price = prices["BTCUSDT"]
+        marks.update(prices)
 
     broker._update_time = update_time
     ledger = FundingSettlementLedger(funding)
@@ -63,7 +68,11 @@ def test_longs_pay_and_shorts_receive_the_same_funding_rate() -> None:
         "LONG": SimpleNamespace(quantity=2.0, current_price=100.0, multiplier=1.0),
         "SHORT": SimpleNamespace(quantity=-1.0, current_price=100.0, multiplier=1.0),
     }
-    broker = SimpleNamespace(cash=1_000.0, positions=positions)
+    broker = SimpleNamespace(
+        cash=1_000.0,
+        positions=positions,
+        get_mark_price=lambda symbol, **_kwargs: positions[symbol].current_price,
+    )
     ledger = FundingSettlementLedger(funding)
 
     ledger.settle(timestamp, broker)
@@ -316,3 +325,90 @@ def test_timezone_naive_engine_targets_match_timezone_naive_feed() -> None:
     )
 
     assert result.engine_result.fills
+
+
+def test_date_engine_targets_match_date_feed() -> None:
+    timestamps = [datetime(2024, 1, day).date() for day in (2, 3)]
+    prices = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["A"] * 2,
+            "open": [100.0] * 2,
+            "high": [100.0] * 2,
+            "low": [100.0] * 2,
+            "close": [100.0] * 2,
+            "volume": [1_000_000.0] * 2,
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["A"] * 2,
+            "y_score": [0.1] * 2,
+            "y_true": [0.0] * 2,
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["A"] * 2,
+            "weight": [0.5] * 2,
+        }
+    )
+
+    result = backtest_runner.run_backtest(
+        "etfs",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+
+    assert result.engine_result.fills
+
+
+def test_contiguous_state_transition_flattens_then_reenters_at_boundary() -> None:
+    timestamps = [datetime(2024, 1, 1, hour=hour, tzinfo=UTC) for hour in (0, 8)]
+    prices = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "open": [100.0] * 2,
+            "high": [100.0] * 2,
+            "low": [100.0] * 2,
+            "close": [100.0] * 2,
+            "volume": [1_000_000.0] * 2,
+        }
+    )
+    predictions = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "y_score": [0.1] * 2,
+            "y_true": [0.0] * 2,
+        }
+    )
+    weights = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 2,
+            "weight": [0.5, 0.5],
+            "_state_transition": [False, True],
+        }
+    )
+
+    result = backtest_runner.run_backtest(
+        "crypto_perps_funding",
+        "prediction-a",
+        _strategy_spec("engine"),
+        prices=prices,
+        predictions=predictions,
+        precomputed_weights=weights,
+        register=False,
+    )
+
+    assert [fill.side.value for fill in result.engine_result.fills] == ["buy", "sell", "buy"]
+    assert result.engine_result.fills[1].timestamp == timestamps[1]
+    assert result.engine_result.fills[2].timestamp == timestamps[1]

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -370,7 +370,7 @@ def test_date_engine_targets_match_date_feed() -> None:
 
 
 def test_contiguous_state_transition_flattens_then_reenters_at_boundary() -> None:
-    timestamps = [datetime(2024, 1, 1, hour=hour, tzinfo=UTC) for hour in (0, 8)]
+    timestamps = [datetime(2024, 1, day, tzinfo=UTC) for day in (1, 2)]
     prices = pl.DataFrame(
         {
             "timestamp": timestamps,
@@ -412,3 +412,4 @@ def test_contiguous_state_transition_flattens_then_reenters_at_boundary() -> Non
     assert [fill.side.value for fill in result.engine_result.fills] == ["buy", "sell", "buy"]
     assert result.engine_result.fills[1].timestamp == timestamps[1]
     assert result.engine_result.fills[2].timestamp == timestamps[1]
+    assert result.metrics["avg_turnover"] == pytest.approx(0.75)

--- a/tests/test_crypto_funding_backtest.py
+++ b/tests/test_crypto_funding_backtest.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import polars as pl
+
+from case_studies.crypto_perps_funding.funding_backtest import apply_funding_settlements
+
+
+def test_funding_is_position_signed_before_same_timestamp_fills() -> None:
+    first = datetime(2024, 1, 1, tzinfo=UTC)
+    settlement = datetime(2024, 1, 1, 8, tzinfo=UTC)
+    last = datetime(2024, 1, 1, 16, tzinfo=UTC)
+    buy = SimpleNamespace(
+        timestamp=first,
+        quantity=1.0,
+        side=SimpleNamespace(value="buy"),
+        price=100.0,
+        commission=0.0,
+        asset="BTCUSDT",
+    )
+    sell = SimpleNamespace(
+        timestamp=settlement,
+        quantity=1.0,
+        side=SimpleNamespace(value="sell"),
+        price=100.0,
+        commission=0.0,
+        asset="BTCUSDT",
+    )
+    engine = SimpleNamespace(
+        fills=[buy, sell],
+        equity_curve=[(first, 1_000.0), (settlement, 1_000.0), (last, 1_000.0)],
+        portfolio_state=[
+            (first, 1_000.0, 900.0, 100.0, 100.0, 1),
+            (settlement, 1_000.0, 1_000.0, 0.0, 0.0, 0),
+            (last, 1_000.0, 1_000.0, 0.0, 0.0, 0),
+        ],
+    )
+    prices = pl.DataFrame(
+        {
+            "timestamp": [first, settlement, last],
+            "symbol": ["BTCUSDT"] * 3,
+            "close": [100.0] * 3,
+        }
+    )
+    funding = pl.DataFrame(
+        {
+            "timestamp": [settlement],
+            "symbol": ["BTCUSDT"],
+            "funding_rate": [0.01],
+        }
+    )
+
+    metrics = apply_funding_settlements(
+        engine,
+        prices=prices,
+        funding_rates=funding,
+        initial_cash=1_000.0,
+    )
+
+    assert metrics == {
+        "funding_pnl": -1.0,
+        "funding_events": 1.0,
+        "funding_settlements": 1.0,
+        "funding_reconstruction_error": 0.0,
+    }
+    assert engine.equity_curve == [(first, 1_000.0), (settlement, 999.0), (last, 999.0)]
+    assert engine.portfolio_state[1][1:3] == (999.0, 999.0)
+
+
+def test_funding_rejects_duplicate_settlement_keys() -> None:
+    timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+    funding = pl.DataFrame(
+        {
+            "timestamp": [timestamp, timestamp],
+            "symbol": ["BTCUSDT", "BTCUSDT"],
+            "funding_rate": [0.01, 0.01],
+        }
+    )
+    engine = SimpleNamespace(fills=[], equity_curve=[], portfolio_state=[])
+
+    try:
+        apply_funding_settlements(
+            engine,
+            prices=pl.DataFrame(
+                {"timestamp": [timestamp], "symbol": ["BTCUSDT"], "close": [100.0]}
+            ),
+            funding_rates=funding,
+            initial_cash=1_000.0,
+        )
+    except ValueError as error:
+        assert "unique" in str(error)
+    else:
+        raise AssertionError("duplicate funding settlements were accepted")

--- a/tests/test_cv_cached_results.py
+++ b/tests/test_cv_cached_results.py
@@ -107,6 +107,7 @@ def test_all_cached_dl_runner_returns_registered_result(
     result = deep_learning.run_dl_cv(
         pd.DataFrame(),
         [{"fold": 0}],
+        device="cpu",
         n_features=1,
         **common,
     )

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -10,10 +10,12 @@ import pytest
 
 from case_studies.research import (
     CandidateSet,
+    DecisionArtifact,
     EligibilityManifest,
     OfficialPopulation,
     PredictionResult,
     Result,
+    StateTransitionPolicy,
     Study,
     run_backtests,
     run_models,
@@ -196,6 +198,10 @@ def test_n_catalog_rows_fan_out_to_n_independent_backtests(tmp_path: Path) -> No
     assert len({result.hash for result in execution.results}) == 2
     assert {item["prediction_hash"] for item in execution.diagnostics} == {first, second}
     assert _backtest_count(study) == 2
+    candidate_set = CandidateSet.create(study, "two-backtests", execution.results)
+    assert CandidateSet.one(study, name="two-backtests").hash == candidate_set.hash
+    assert len(candidate_set.ranked_validation_sharpe()) == 2
+    assert len(candidate_set.ranked_validation_sharpe(limit=1)) == 1
 
 
 def test_strategy_change_creates_a_backtest_without_retraining(tmp_path: Path) -> None:
@@ -228,6 +234,55 @@ def test_strategy_change_creates_a_backtest_without_retraining(tmp_path: Path) -
             for table in ("training_runs", "prediction_sets")
         }
     assert after == before
+
+
+def test_custom_stateful_decision_backtests_but_requires_promotion_for_candidates(
+    tmp_path: Path,
+) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    selected = study.predictions.table().filter(pl.col("prediction_hash") == prediction_hash)
+    decisions = (
+        _predictions()
+        .select("symbol", "timestamp")
+        .with_columns(pl.Series("position", [1.0, -1.0]))
+    )
+    artifact = DecisionArtifact.publish(
+        study,
+        kind="target_positions",
+        decisions=decisions,
+        prediction_hashes=[prediction_hash],
+        parameters={"generator": "ordinary_python", "cadence": "1d"},
+        state_transition_policy=StateTransitionPolicy(
+            fold_boundary="liquidate",
+            temporal_gap="reset",
+        ),
+    )
+
+    execution = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+        execution_mode="vectorized",
+        decision=artifact,
+    )
+    result = execution.results[0]
+
+    assert result.spec()["decision_artifact"]["hash"] == artifact.hash
+    assert result.spec()["decision_artifact"]["state_transition_policy"] == {
+        "fold_boundary": "liquidate",
+        "temporal_gap": "reset",
+    }
+    with pytest.raises(ValueError, match="exploratory decision"):
+        CandidateSet.create(study, "exploratory-decision", [result])
+    with pytest.raises(ValueError, match="exploratory decision"):
+        OfficialPopulation.create(
+            study,
+            name="exploratory-decision",
+            member_kind="backtest",
+            members=[result.hash],
+        )
 
 
 def test_preview_prediction_is_excluded_from_official_population(
@@ -379,6 +434,7 @@ def test_unfinished_training_cannot_satisfy_an_official_population(tmp_path: Pat
         member_kind="training",
         members=[training.hash],
     )
+    assert OfficialPopulation.one(study, name="training-population").hash == population.hash
 
     assert training.complete is False
     with pytest.raises(ValueError, match="partial"):

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -58,7 +58,7 @@ def test_fold_boundary_liquidates_unchanged_positions_before_next_fold() -> None
                 date(2024, 1, 3),
             ],
             "fold": [0, 0, 1],
-            "weight": [1.0, 1.0, 1.0],
+            "weight": pl.Series([1.0, 1.0, 1.0], dtype=pl.Float32),
         }
     )
 
@@ -82,7 +82,7 @@ def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
                 date(2024, 1, 5),
             ],
             "fold": [0, 0, 0],
-            "weight": [1.0, 1.0, 1.0],
+            "weight": pl.Series([1.0, 1.0, 1.0], dtype=pl.Float32),
         }
     )
 
@@ -105,6 +105,7 @@ def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
         date(2024, 1, 5),
     ]
     assert transitioned.get_column("weight").to_list() == [1.0, 1.0, 0.0, 1.0]
+    assert transitioned.schema["weight"] == pl.Float32
     assert transitioned.get_column("_state_transition").to_list() == [
         False,
         False,

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -173,6 +173,24 @@ def test_canonical_decision_promotion_requires_replay_evidence(tmp_path: Path) -
             canonical=True,
         )
 
+    with pytest.raises(ValueError, match="exact prediction_hashes"):
+        DecisionArtifact.publish(
+            study,
+            kind="target_positions",
+            decisions=_decisions(),
+            prediction_hashes=[prediction_hash],
+            parameters={},
+            source_identity={
+                "module": "case_studies.research.decisions",
+                "source_digest": "source-a",
+                "declared_inputs": {"prediction_hashes": ["undisclosed-other-input"]},
+                "determinism": {"seed": 42},
+                "clean_replay_digest": "not-reached",
+            },
+            state_transition_policy=policy,
+            canonical=True,
+        )
+
     exploratory = DecisionArtifact.publish(
         study,
         kind="target_positions",
@@ -184,7 +202,7 @@ def test_canonical_decision_promotion_requires_replay_evidence(tmp_path: Path) -
     evidence = {
         "module": "case_studies.research.decisions",
         "source_digest": "source-a",
-        "declared_inputs": {"prediction": prediction_hash},
+        "declared_inputs": {"prediction_hashes": [prediction_hash]},
         "determinism": {"seed": 42},
         "clean_replay_digest": exploratory.spec["artifact_digest"],
     }
@@ -240,6 +258,15 @@ def test_holdout_stages_then_transitions_in_one_atomic_transaction(
         selected_backtest_hash=validation_backtest.hash,
         selection_evidence={"metric": "validation_backtest_sharpe"},
         holdout_training_spec=holdout_spec,
+    )
+    assert (
+        study.lifecycle.lock(
+            candidate_set_hash=candidates.hash,
+            selected_backtest_hash=validation_backtest.hash,
+            selection_evidence={"metric": "validation_backtest_sharpe"},
+            holdout_training_spec=holdout_spec,
+        ).hash
+        == lock.hash
     )
     holdout_training = study.results.register_training(holdout_spec)
     holdout_frame = frame.with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -15,6 +15,7 @@ from case_studies.research import (
     StateTransitionPolicy,
     Study,
 )
+from case_studies.research.strategy import apply_state_transition_policy
 from tests.test_research_contract_catalog import _publish, _resolved_spec
 from tests.test_research_flow import _patch_holdout_prices, _prices
 from tests.test_research_registry import _predictions
@@ -45,6 +46,52 @@ def _decisions() -> pl.DataFrame:
             "position": [1.0, 0.0],
         }
     )
+
+
+def test_fold_boundary_liquidates_unchanged_positions_before_next_fold() -> None:
+    decisions = pl.DataFrame(
+        {
+            "symbol": ["A", "A", "A"],
+            "timestamp": [
+                date(2024, 1, 1),
+                date(2024, 1, 2),
+                date(2024, 1, 3),
+            ],
+            "fold": [0, 0, 1],
+            "weight": [1.0, 1.0, 1.0],
+        }
+    )
+
+    transitioned = apply_state_transition_policy(
+        decisions,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "continue"},
+        cadence="1d",
+    )
+
+    assert transitioned.get_column("weight").to_list() == [1.0, 0.0, 1.0]
+
+
+def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
+    decisions = pl.DataFrame(
+        {
+            "symbol": ["A", "A", "A"],
+            "timestamp": [
+                date(2024, 1, 1),
+                date(2024, 1, 2),
+                date(2024, 1, 5),
+            ],
+            "fold": [0, 0, 0],
+            "weight": [1.0, 1.0, 1.0],
+        }
+    )
+
+    transitioned = apply_state_transition_policy(
+        decisions,
+        policy={"fold_boundary": "continue", "temporal_gap": "reset"},
+        cadence="1d",
+    )
+
+    assert transitioned.get_column("weight").to_list() == [1.0, 0.0, 1.0]
 
 
 def _prediction(study: Study) -> str:

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -68,7 +68,8 @@ def test_fold_boundary_liquidates_unchanged_positions_before_next_fold() -> None
         cadence="1d",
     )
 
-    assert transitioned.get_column("weight").to_list() == [1.0, 0.0, 1.0]
+    assert transitioned.get_column("weight").to_list() == [1.0, 1.0, 1.0]
+    assert transitioned.get_column("_state_transition").to_list() == [False, False, True]
 
 
 def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
@@ -89,9 +90,27 @@ def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
         decisions,
         policy={"fold_boundary": "continue", "temporal_gap": "reset"},
         cadence="1d",
+        price_keys=pl.DataFrame(
+            {
+                "symbol": ["A"] * 5,
+                "timestamp": [date(2024, 1, day) for day in range(1, 6)],
+            }
+        ),
     )
 
-    assert transitioned.get_column("weight").to_list() == [1.0, 0.0, 1.0]
+    assert transitioned.get_column("timestamp").to_list() == [
+        date(2024, 1, 1),
+        date(2024, 1, 2),
+        date(2024, 1, 3),
+        date(2024, 1, 5),
+    ]
+    assert transitioned.get_column("weight").to_list() == [1.0, 1.0, 0.0, 1.0]
+    assert transitioned.get_column("_state_transition").to_list() == [
+        False,
+        False,
+        True,
+        False,
+    ]
 
 
 def _prediction(study: Study) -> str:

--- a/tests/test_sweep_config_seam.py
+++ b/tests/test_sweep_config_seam.py
@@ -141,6 +141,19 @@ class TestQuarantinePolicy:
             )
 
 
+def test_crypto_long_short_grid_keeps_only_disjoint_selections() -> None:
+    schemes = get_entry_schemes_for(
+        "crypto_perps_funding",
+        "fwd_ret_8h",
+        n_assets=19,
+        long_short=True,
+    )
+
+    top_k = [scheme["top_k"] for scheme in schemes if scheme["method"] == "equal_weight_top_k"]
+    assert top_k == [5]
+    assert load_sweep("crypto_perps_funding")["top_k_grid"]["fwd_ret_8h"] == [5, 10]
+
+
 # ---------------------------------------------------------------------------
 # Registry reconciliation - declared sweep covers rank-1 per (CS, label)
 # ---------------------------------------------------------------------------

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -20,7 +20,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def test_tabm_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None:
+def test_tabm_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -> None:
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -93,6 +93,29 @@ def test_tabm_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None
     context = resolved._context
 
     assert spec["identity_version"] == 2
+    assert "resolved_spec_schema" not in spec
+    assert set(spec) == {
+        "identity_version",
+        "execution_tier",
+        "family",
+        "label",
+        "seed",
+        "config_name",
+        "label_artifact",
+        "feature_artifacts",
+        "feature_names",
+        "task",
+        "cv",
+        "model",
+        "preprocessing",
+        "checkpoint_schedule",
+        "expected_prediction_keys",
+        "input_data_spec",
+        "sampling",
+        "numerics",
+        "source_identity",
+        "runtime_identity",
+    }
     assert spec["label_artifact"]["digest"] == label.digest
     assert spec["model"]["params"]["n_epochs"] == 11
     assert [row["value"] for row in spec["checkpoint_schedule"]] == [5, 10, 11]
@@ -103,3 +126,105 @@ def test_tabm_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None
     }
     assert context.expected_keys.height == 12
     assert context.config["n_epochs"] == 11
+
+
+def test_tabm_classification_resolves_targets_imbalance_and_preview_checkpoints(
+    tmp_path, monkeypatch
+) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    symbols = [f"S{index}" for index in range(6)]
+    timestamps = [
+        date for date in ("2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04") for _ in symbols
+    ]
+    classes = [0, 0, 0, 0, 0, 1] * 4
+    frame = pl.DataFrame(
+        {
+            "symbol": symbols * 4,
+            "timestamp": timestamps,
+            "feature": [float(index) for index in range(24)],
+            "direction": classes,
+            "fwd_ret_1d": [float(index % 6 - 3) / 100 for index in range(24)],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    label = study.labels.publish(
+        LabelDefinition("direction", "classification", "1D", "fwd_ret_1d"),
+        frame.select("symbol", "timestamp", "direction", "fwd_ret_1d"),
+    )
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-02",
+            "val_start": "2024-01-03",
+            "val_end": "2024-01-04",
+        }
+    ]
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="direction",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        splits=splits,
+        task_type="classification",
+        class_values=[0, 1],
+        eval_label_col="fwd_ret_1d",
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "batch_size": 64,
+                "checkpoint_interval": 5,
+                "n_epochs": 10,
+                "params": {"dropout": 0.0, "hidden_dim": 4, "n_members": 2},
+                "config_name": "tabm_probe",
+                "family": "tabular_dl",
+                "library": "tabm",
+            }
+        ],
+    )
+
+    resolved = study.model(
+        family="tabular_dl",
+        label=label.name,
+        config_name="tabm_probe",
+        overrides={"device": "cpu", "class_weight": "balanced"},
+        execution_tier="preview",
+        preview_reductions={"folds": [0], "n_epochs": 2, "checkpoint_interval": 1},
+    ).resolve()
+    computation = resolved.spec["computation"]
+
+    assert computation["task"]["type"] == "classification"
+    assert computation["task"]["continuous_eval_label"] == "fwd_ret_1d"
+    assert computation["task"]["imbalance"] == {
+        "method": "balanced",
+        "effective_class_weights_by_fold": {"0": [0.6, 3.0]},
+    }
+    assert computation["task"]["metrics"] == [
+        "ic",
+        "auc_roc",
+        "log_loss",
+        "accuracy",
+        "balanced_accuracy",
+    ]
+    assert computation["preview_reductions"] == {
+        "checkpoint_interval": 1,
+        "folds": [0],
+        "n_epochs": 2,
+    }
+    assert computation["checkpoint_schedule"] == [
+        {"kind": "epoch", "value": 1},
+        {"kind": "epoch", "value": 2},
+    ]
+    assert resolved._context.class_weights_by_fold == {0: (0.6, 3.0)}

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -228,3 +228,20 @@ def test_tabm_classification_resolves_targets_imbalance_and_preview_checkpoints(
         {"kind": "epoch", "value": 2},
     ]
     assert resolved._context.class_weights_by_fold == {0: (0.6, 3.0)}
+
+    mds.dataset = frame.with_columns(pl.Series("direction", [0, 1, 2, 0, 1, 2] * 4))
+    mds.class_values = [0, 1, 2]
+    multiclass = study.model(
+        family="tabular_dl",
+        label=label.name,
+        config_name="tabm_probe",
+        overrides={"device": "cpu", "class_weight": "balanced"},
+        execution_tier="preview",
+        preview_reductions={"folds": [0], "n_epochs": 2, "checkpoint_interval": 1},
+    ).resolve()
+
+    assert multiclass.spec["computation"]["task"]["metrics"] == [
+        "ic",
+        "accuracy",
+        "balanced_accuracy",
+    ]

--- a/tests/test_tabular_dl_runtime.py
+++ b/tests/test_tabular_dl_runtime.py
@@ -111,6 +111,7 @@ def test_classification_cv_keeps_continuous_evaluation_target(
         eval_label_col="return",
         task_type="classification",
         class_values=[0, 1],
+        class_weights_by_fold={0: (1.0, 1.0)},
         date_col="timestamp",
         entity_col="symbol",
         device="cpu",


### PR DESCRIPTION
## What changed

- add explicit unbalanced-classification targets, continuous evaluation targets, fold class weights, metrics, checkpoint identity, and restart validation to the shared TabM adapter
- add the reader-facing causal request and result contract with preview isolation and immutable restart behavior
- add typed decision artifacts, state transition policy, named population lookup, and canonical-promotion checks to the shared strategy boundary
- integrate official crypto funding settlements into engine equity and registered P&L
- settle funding from the live broker mark before risk, sizing, and order processing
- execute fold and temporal-gap state transitions as explicit liquidation and re-entry events
- filter infeasible long-short selections from the declared sweep without changing its catalog identity
- add a bounded real-data proof script for the crypto-owned paths

## Why

The crypto stage-06 notebooks previously duplicated orchestration, model identity, causal execution, stateful decision handling, and funding accounting. The shared reader-facing boundary must resolve these semantics before the notebooks consume it.

## Validation

- 630 focused behavioral tests passed, 8 skipped
- configured non-notebook suite completed with 1,945 passed and 17 skipped before focused reconciliation of its 12 reported failures
- all 11 behavior and environment failures from that run now pass; the remaining notebook provenance check intentionally remains stale only in the unpushed case-study notebook worktree until official production execution
- Ruff and `ty` passed on the changed public surface
- configured pre-commit range passed
- 17 artifact sidecars verified, none missing or failed
- fresh and restarted real-data preview passed with 5,957 eligible 8-hour prediction keys, training hash `8b16bd434d28`, checkpoints `cd8fda88f0c4` and `6269f51f73d0`, causal hash `d4ce198d5edc`, and funded backtest hash `462632fbdae8`
- the funded path produced 38,530 settlements, 1,094 non-zero funding events, 2,916 fills, and 1,569 trades

No official production model or strategy population was started.
