### PR TITLE
Prove US equities fold-major execution

### DIFF
--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections import OrderedDict
 from collections.abc import Iterable
 from contextlib import closing
 from dataclasses import dataclass
@@ -11,6 +12,8 @@ import polars as pl
 
 from case_studies.utils.registry.store import _open_registry, _utc_now
 
+from .adapters import get_adapter
+from .contracts import ExecutionTier
 from .models import ModelRequest, ModelRun, ResolvedModelRequest
 from .results import BacktestResult, PredictionResult, Result
 from .workspace import Study
@@ -35,15 +38,45 @@ def run_models(
     *,
     requests: Iterable[ModelRequest | ResolvedModelRequest],
 ) -> ModelExecution:
-    resolved: list[ResolvedModelRequest] = []
-    for request in requests:
+    submitted = list(requests)
+    if not submitted:
+        raise ValueError("run_models requires at least one request")
+    for request in submitted:
         if request.study != study:
             raise ValueError("model request belongs to another study")
-        resolved.append(request.resolve() if isinstance(request, ModelRequest) else request)
-    if not resolved:
-        raise ValueError("run_models requires at least one request")
 
-    runs = tuple(request.run() for request in resolved)
+    ordered_runs: list[ModelRun | None] = [None] * len(submitted)
+    unresolved: OrderedDict[str, list[tuple[int, ModelRequest]]] = OrderedDict()
+    for index, request in enumerate(submitted):
+        if isinstance(request, ModelRequest):
+            unresolved.setdefault(request.family, []).append((index, request))
+            continue
+        study.activate(ExecutionTier(request.spec["execution_tier"]))
+        ordered_runs[index] = request.run()
+
+    for family, indexed_requests in unresolved.items():
+        module = get_adapter("model", family)
+        batch_runner = getattr(module, "run_model_requests", None)
+        if callable(batch_runner):
+            batch_runs = tuple(
+                batch_runner(study, [request.as_dict() for _, request in indexed_requests])
+            )
+            if len(batch_runs) != len(indexed_requests):
+                raise ValueError(
+                    f"{family!r} batch runner returned {len(batch_runs)} results for "
+                    f"{len(indexed_requests)} requests"
+                )
+            for (index, _), run in zip(indexed_requests, batch_runs, strict=True):
+                ordered_runs[index] = run
+            continue
+        for index, request in indexed_requests:
+            resolved = request.resolve()
+            study.activate(ExecutionTier(resolved.spec["execution_tier"]))
+            ordered_runs[index] = resolved.run()
+
+    if any(run is None for run in ordered_runs):
+        raise RuntimeError("model execution did not produce a result for every request")
+    runs = tuple(run for run in ordered_runs if run is not None)
     hashes = [prediction.hash for run in runs for prediction in run.predictions]
     catalog_rows = study.predictions.table(include_preview=True).filter(
         pl.col("prediction_hash").is_in(hashes)

--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sqlite3
-from collections import OrderedDict
 from collections.abc import Iterable
 from contextlib import closing
 from dataclasses import dataclass
@@ -46,7 +45,7 @@ def run_models(
             raise ValueError("model request belongs to another study")
 
     ordered_runs: list[ModelRun | None] = [None] * len(submitted)
-    unresolved: OrderedDict[str, list[tuple[int, ModelRequest]]] = OrderedDict()
+    unresolved: dict[str, list[tuple[int, ModelRequest]]] = {}
     for index, request in enumerate(submitted):
         if isinstance(request, ModelRequest):
             unresolved.setdefault(request.family, []).append((index, request))

--- a/case_studies/research/models.py
+++ b/case_studies/research/models.py
@@ -146,7 +146,9 @@ class ModelRequest:
         return ResolvedModelRequest(self.study, self.family, spec, context)
 
     def run(self) -> ModelRun:
-        return self.resolve().run()
+        from .execution import run_models
+
+        return run_models(self.study, requests=[self]).runs[0]
 
 
 def _family_module(family: str):

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -2050,26 +2050,51 @@ def _write_learning_curves(path: Path, rows: list[dict[str, Any]]) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _gbm_fixed_effective_params(
+def _gbm_sampled_training_labels(base: dict[str, Any], split: dict[str, Any]) -> np.ndarray:
+    mds = base["mds"]
+    dataset = base["dataset_pd"]
+    dates = dataset[mds.date_col]
+    mask = (dates >= split["train_start"]) & (dates <= split["train_end"])
+    labels = dataset.loc[mask, mds.label_col].values.astype(np.float32)
+    labels = labels[~np.isnan(labels)]
+    train_sample_frac = base["train_sample_frac"]
+    if 0.0 < train_sample_frac < 1.0 and len(labels) > 0:
+        n_keep = max(1, int(len(labels) * train_sample_frac))
+        rng = np.random.default_rng(RANDOM_SEED + int(split["fold"]))
+        keep_idx = rng.choice(len(labels), size=n_keep, replace=False)
+        keep_idx.sort()
+        labels = labels[keep_idx]
+    if not len(labels):
+        raise ValueError(f"GBM request has no training labels for fold {split['fold']}")
+    return labels
+
+
+def _gbm_effective_params_for_splits(
     config: dict[str, Any],
-    fold_ids: tuple[int, ...],
+    base: dict[str, Any],
     *,
     device: str,
     max_bin: int,
     num_threads: int,
     task_type: str,
     class_values: tuple[Any, ...],
-) -> dict[str, dict[str, Any]] | None:
+) -> dict[str, dict[str, Any]]:
     params = config["params"]
-    if (
+    fold_dependent = (
         params.get("objective") == "huber"
         and "alpha" not in params
         and config.get("huber_alpha_scale") is not None
-    ):
-        return None
+    )
+    folds = [
+        {
+            "fold": int(split["fold"]),
+            **({"y_train": _gbm_sampled_training_labels(base, split)} if fold_dependent else {}),
+        }
+        for split in base["splits"]
+    ]
     return _gbm_effective_params_by_fold(
         config,
-        [{"fold": fold_id} for fold_id in fold_ids],
+        folds,
         device=device,
         max_bin=max_bin,
         num_threads=num_threads,
@@ -2428,9 +2453,7 @@ def _run_gbm_batch_group(
     report_batch: bool,
 ) -> list[_GBMBatchCandidate]:
     mds = base["mds"]
-    fold_ids = tuple(int(split["fold"]) for split in base["splits"])
     candidates = []
-    dependent = []
     for index, request in indexed_requests:
         config, request_fields = _load_gbm_request_config(
             study,
@@ -2440,9 +2463,9 @@ def _run_gbm_batch_group(
         )
         _apply_gbm_preview_reductions(config, request)
         device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
-        effective = _gbm_fixed_effective_params(
+        effective = _gbm_effective_params_for_splits(
             config,
-            fold_ids,
+            base,
             device=device,
             max_bin=max_bin,
             num_threads=num_threads,
@@ -2453,33 +2476,28 @@ def _run_gbm_batch_group(
             index=index,
             request=request,
             config=config,
-            effective_params=effective or {},
+            effective_params=effective,
             device=device,
             max_bin=max_bin,
             num_threads=num_threads,
         )
         candidates.append(candidate)
-        if effective is None:
-            dependent.append(candidate)
-        else:
-            _resolve_gbm_batch_candidate(study, candidate, base)
-    dependent_indices = {candidate.index for candidate in dependent}
+        _resolve_gbm_batch_candidate(study, candidate, base)
 
     preparation_elapsed_s = 0.0
     preparation_count = 0
-    first_pass_needed = bool(dependent) or any(
+    execution_needed = any(
         candidate.result is None and candidate.error is None for candidate in candidates
     )
-    if first_pass_needed:
+    if execution_needed:
         for split in base["splits"]:
             fold_id = int(split["fold"])
-            fixed_pending = [
+            pending = [
                 candidate
                 for candidate in candidates
-                if candidate.index not in dependent_indices
-                and not _reuse_gbm_batch_fold(candidate, fold_id)
+                if not _reuse_gbm_batch_fold(candidate, fold_id)
             ]
-            if not dependent and not fixed_pending:
+            if not pending:
                 continue
             started = time.perf_counter()
             try:
@@ -2490,76 +2508,13 @@ def _run_gbm_batch_group(
                 break
             preparation_elapsed_s += time.perf_counter() - started
             preparation_count += 1
-            for candidate in dependent:
-                if candidate.error is not None:
-                    continue
-                try:
-                    candidate.effective_params.update(
-                        _gbm_effective_params_by_fold(
-                            candidate.config,
-                            [fold],
-                            device=candidate.device,
-                            max_bin=candidate.max_bin,
-                            num_threads=candidate.num_threads,
-                            seed=RANDOM_SEED,
-                            task_type=mds.task_type,
-                            class_values=tuple(mds.class_values),
-                        )
-                    )
-                except Exception as exc:
-                    _fail_gbm_batch_candidate(candidate, exc)
-            for candidate in fixed_pending:
+            for candidate in pending:
                 _run_gbm_batch_fold(candidate, fold)
             del fold
             gc.collect()
 
     for candidate in candidates:
-        if candidate.index not in dependent_indices:
-            _finish_gbm_batch_candidate(study, candidate)
-
-    active_dependent = []
-    for candidate in dependent:
-        if candidate.error is not None:
-            continue
-        if set(candidate.effective_params) != {str(fold_id) for fold_id in fold_ids}:
-            _fail_gbm_batch_candidate(
-                candidate,
-                RuntimeError("GBM candidate did not resolve parameters for every fold"),
-            )
-            continue
-        try:
-            _resolve_gbm_batch_candidate(study, candidate, base)
-        except Exception as exc:
-            _fail_gbm_batch_candidate(candidate, exc)
-            continue
-        if candidate.result is None:
-            active_dependent.append(candidate)
-
-    if active_dependent:
-        for split in base["splits"]:
-            fold_id = int(split["fold"])
-            pending = [
-                candidate
-                for candidate in active_dependent
-                if not _reuse_gbm_batch_fold(candidate, fold_id)
-            ]
-            if not pending:
-                continue
-            started = time.perf_counter()
-            try:
-                fold = _prepare_gbm_batch_fold(base, split)
-            except Exception as exc:
-                for candidate in active_dependent:
-                    _fail_gbm_batch_candidate(candidate, exc)
-                break
-            preparation_elapsed_s += time.perf_counter() - started
-            preparation_count += 1
-            for candidate in pending:
-                _run_gbm_batch_fold(candidate, fold)
-            del fold
-            gc.collect()
-        for candidate in active_dependent:
-            _finish_gbm_batch_candidate(study, candidate)
+        _finish_gbm_batch_candidate(study, candidate)
 
     group_digest = hashlib.sha256(compatibility_key.encode()).hexdigest()[:12]
     fit_elapsed_s = sum(candidate.fit_elapsed_s for candidate in candidates)

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -25,7 +25,7 @@ import subprocess
 import time
 import uuid
 import warnings
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -51,9 +51,15 @@ import torch  # noqa: F401
 import yaml
 from ml4t.diagnostic.metrics import cross_sectional_ic
 
+from case_studies.research.contracts import ExecutionTier
 from case_studies.research.cv import require_fold_scoped_temporal_compatibility
 from case_studies.research.identity import ResolvedSpec
+from case_studies.research.models import ModelRun
+from case_studies.research.recovery import ExecutionAttempt, ExecutionLedger
+from case_studies.research.results import PredictionResult, Result, TrainingResult
 from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+from case_studies.utils.registry.specs import canonical_json
 from utils.modeling import RANDOM_SEED, seed_everything
 
 if TYPE_CHECKING:
@@ -80,6 +86,7 @@ _GBM_REQUEST_FIELDS = {
 @dataclass(frozen=True)
 class GBMContext:
     folds: tuple[dict[str, Any], ...]
+    fold_ids: tuple[int, ...]
     feature_names: tuple[str, ...]
     label_col: str
     eval_label_col: str | None
@@ -89,6 +96,29 @@ class GBMContext:
     class_values: tuple[Any, ...]
     expected_keys: pl.DataFrame
     runtime_provenance: dict[str, Any]
+
+
+@dataclass
+class _GBMBatchCandidate:
+    index: int
+    request: dict[str, Any]
+    config: dict[str, Any]
+    effective_params: dict[str, dict[str, Any]]
+    device: str
+    max_bin: int
+    num_threads: int
+    spec: dict[str, Any] | None = None
+    context: GBMContext | None = None
+    training: TrainingResult | None = None
+    ledger: ExecutionLedger | None = None
+    attempt: ExecutionAttempt | None = None
+    frames: list[pl.DataFrame] = field(default_factory=list)
+    reused_folds: list[int] = field(default_factory=list)
+    fitted_folds: list[int] = field(default_factory=list)
+    fit_elapsed_s: float = 0.0
+    started_at_s: float = 0.0
+    result: ModelRun | None = None
+    error: Exception | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1577,8 +1607,45 @@ def _load_gbm_request_config(
     return config, request_fields
 
 
-def resolve_model_request(study: Study, request: dict[str, Any]):
-    from case_studies.research.contracts import ExecutionTier
+def _gbm_expected_keys_from_dataset(mds, splits: list[dict[str, Any]]) -> pl.DataFrame:
+    date_dtype = mds.dataset.schema[mds.date_col]
+    label_valid = pl.col(mds.label_col).is_not_null()
+    if mds.dataset.schema[mds.label_col] in {pl.Float32, pl.Float64}:
+        label_valid &= pl.col(mds.label_col).is_not_nan()
+    frames = []
+    for split in splits:
+        val_start = split.get("val_start", split.get("test_start"))
+        val_end = split.get("val_end", split.get("test_end"))
+        frame = (
+            mds.dataset.filter(
+                pl.col(mds.date_col).is_between(
+                    pl.lit(val_start).cast(date_dtype, strict=False),
+                    pl.lit(val_end).cast(date_dtype, strict=False),
+                    closed="both",
+                )
+                & label_valid
+            )
+            .select(
+                pl.col(mds.entity_cols[0]).alias("symbol"),
+                pl.col(mds.date_col).alias("timestamp"),
+            )
+            .with_columns(pl.lit(int(split["fold"]), dtype=pl.Int64).alias("fold"))
+        )
+        if frame.is_empty():
+            raise ValueError(f"GBM request produced no validation keys for fold {split['fold']}")
+        frames.append(frame)
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("GBM request produced duplicate expected prediction keys")
+    return expected
+
+
+def _load_gbm_batch_base(
+    study: Study,
+    request: dict[str, Any],
+    *,
+    inputs: tuple[Any, Any, Any] | None = None,
+) -> dict[str, Any]:
     from utils.modeling import load_modeling_dataset
 
     tier = ExecutionTier(request["execution_tier"])
@@ -1588,12 +1655,16 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         raise ValueError(f"unsupported GBM preview reductions: {sorted(unknown_reductions)}")
     study.require_writable()
     study.activate(tier)
-    label_ref = study.labels.get(request["label"], execution_tier=tier)
     max_symbols = int(reductions.get("max_symbols", 0))
     train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
     if not 0 < train_sample_frac <= 1:
         raise ValueError("train_sample_frac must be in (0, 1]")
-    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
+    if inputs is None:
+        label_ref = study.labels.get(request["label"], execution_tier=tier)
+        mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
+        dataset_pd = mds.dataset.to_pandas()
+    else:
+        label_ref, mds, dataset_pd = inputs
     if mds.date_col != "timestamp" or not mds.entity_cols:
         raise ValueError("GBM runner requires timestamp and an entity key")
     entity_col = mds.entity_cols[0]
@@ -1611,34 +1682,18 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         and mds.temporal_feature_names
     ):
         require_fold_scoped_temporal_compatibility(splits, mds.temporal_artifact_splits)
-    folds = prepare_gbm_folds(
-        mds.dataset.to_pandas(),
-        splits,
-        mds.feature_names,
-        mds.label_col,
-        mds.date_col,
-        entity_col,
-        task_type=mds.task_type,
-        class_values=mds.class_values,
-        temporal_by_fold=mds.temporal_by_fold,
-        temporal_keys=mds.temporal_keys,
-        temporal_feature_names=mds.temporal_feature_names,
-        train_sample_frac=train_sample_frac,
-        eval_label_col=mds.eval_label_col,
-        seed=RANDOM_SEED,
-    )
-    if len(folds) != len(splits) or any(not fold["n_train"] or not fold["n_val"] for fold in folds):
-        raise ValueError("GBM request did not prepare every declared fold")
-    config, request_fields = _load_gbm_request_config(
-        study,
-        label_ref.name,
-        request["config_name"],
-        request["overrides"],
-    )
-    if tier is ExecutionTier.PREVIEW:
-        for field in ("max_iterations", "checkpoint_interval"):
-            if field in reductions:
-                config[field] = int(reductions[field])
+    return {
+        "label_ref": label_ref,
+        "mds": mds,
+        "dataset_pd": dataset_pd,
+        "splits": splits,
+        "cv_record": cv_record,
+        "expected": _gbm_expected_keys_from_dataset(mds, splits),
+        "train_sample_frac": train_sample_frac,
+    }
+
+
+def _gbm_execution_settings(study: Study, request_fields: dict[str, Any]) -> tuple[str, int, int]:
     setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
     setup_gbm = (setup.get("modeling") or {}).get("gbm") or {}
     execution_config = {
@@ -1649,19 +1704,25 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             if key in request_fields
         },
     }
-    device, max_bin, num_threads = resolve_gbm_execution_config(execution_config)
-    effective = _gbm_effective_params_by_fold(
-        config,
-        folds,
-        device=device,
-        max_bin=max_bin,
-        num_threads=num_threads,
-        seed=RANDOM_SEED,
-        task_type=mds.task_type,
-        class_values=mds.class_values,
-    )
+    return resolve_gbm_execution_config(execution_config)
+
+
+def _build_gbm_resolved_request(
+    study: Study,
+    request: dict[str, Any],
+    *,
+    base: dict[str, Any],
+    config: dict[str, Any],
+    effective: dict[str, dict[str, Any]],
+    folds: tuple[dict[str, Any], ...],
+    device: str,
+) -> tuple[dict[str, Any], GBMContext]:
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    mds = base["mds"]
+    label_ref = base["label_ref"]
     checkpoints = gbm_checkpoint_iterations(config)
-    expected = _gbm_expected_keys(folds, entity_col, mds.date_col)
+    expected = base["expected"]
     input_lineage = mds.input_lineage
     computation = {
         "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
@@ -1672,7 +1733,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             "class_values": list(mds.class_values),
             "continuous_eval_label": label_ref.definition.continuous_eval_label,
         },
-        "cv": cv_record,
+        "cv": base["cv_record"],
         "model": {
             "class": "lightgbm.Booster",
             "implementation": "lightgbm",
@@ -1689,7 +1750,10 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             "n_folds": expected.get_column("fold").n_unique(),
         },
         "input_data_spec": input_lineage,
-        "sampling": {"train_sample_frac": train_sample_frac, "max_symbols": max_symbols},
+        "sampling": {
+            "train_sample_frac": base["train_sample_frac"],
+            "max_symbols": int(reductions.get("max_symbols", 0)),
+        },
         "source_identity": _gbm_source_identity(),
         "runtime_identity": _gbm_runtime_identity(),
     }
@@ -1706,18 +1770,115 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         execution_tier=tier.value,
     ).as_dict()
     context = GBMContext(
-        folds=tuple(folds),
+        folds=folds,
+        fold_ids=tuple(int(split["fold"]) for split in base["splits"]),
         feature_names=tuple(mds.feature_names),
         label_col=mds.label_col,
         eval_label_col=mds.eval_label_col,
         date_col=mds.date_col,
-        entity_col=entity_col,
+        entity_col=mds.entity_cols[0],
         task_type=mds.task_type,
         class_values=tuple(mds.class_values),
         expected_keys=expected,
         runtime_provenance=runtime_provenance,
     )
     return spec, context
+
+
+def _apply_gbm_preview_reductions(config: dict[str, Any], request: dict[str, Any]) -> None:
+    if ExecutionTier(request["execution_tier"]) is not ExecutionTier.PREVIEW:
+        return
+    reductions = request["preview_reductions"]
+    for name in ("max_iterations", "checkpoint_interval"):
+        if name in reductions:
+            config[name] = int(reductions[name])
+
+
+def _gbm_input_compatibility_key(request: dict[str, Any]) -> tuple[str, str, int]:
+    reductions = request["preview_reductions"]
+    return (
+        request["label"],
+        request["execution_tier"],
+        int(reductions.get("max_symbols", 0)),
+    )
+
+
+def _gbm_compatibility_key(study: Study, request: dict[str, Any]) -> str:
+    _, request_fields = _load_gbm_request_config(
+        study,
+        request["label"],
+        request["config_name"],
+        request["overrides"],
+    )
+    device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
+    cv = request.get("cv")
+    reductions = request["preview_reductions"]
+    return canonical_json(
+        {
+            "label": request["label"],
+            "execution_tier": request["execution_tier"],
+            "cv": asdict(cv) if cv is not None else None,
+            "folds": reductions.get("folds"),
+            "max_symbols": reductions.get("max_symbols", 0),
+            "train_sample_frac": reductions.get("train_sample_frac", 1.0),
+            "device": device,
+            "max_bin": max_bin,
+            "num_threads": num_threads,
+            "preprocessing": "lightgbm-native-float32/v1",
+        }
+    )
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    base = _load_gbm_batch_base(study, request)
+    mds = base["mds"]
+    folds = prepare_gbm_folds(
+        base["dataset_pd"],
+        base["splits"],
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        mds.entity_cols[0],
+        task_type=mds.task_type,
+        class_values=mds.class_values,
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=base["train_sample_frac"],
+        eval_label_col=mds.eval_label_col,
+        seed=RANDOM_SEED,
+    )
+    if len(folds) != len(base["splits"]) or any(
+        not fold["n_train"] or not fold["n_val"] for fold in folds
+    ):
+        raise ValueError("GBM request did not prepare every declared fold")
+    config, request_fields = _load_gbm_request_config(
+        study,
+        base["label_ref"].name,
+        request["config_name"],
+        request["overrides"],
+    )
+    _apply_gbm_preview_reductions(config, request)
+    device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
+    effective = _gbm_effective_params_by_fold(
+        config,
+        folds,
+        device=device,
+        max_bin=max_bin,
+        num_threads=num_threads,
+        seed=RANDOM_SEED,
+        task_type=mds.task_type,
+        class_values=mds.class_values,
+    )
+    return _build_gbm_resolved_request(
+        study,
+        request,
+        base=base,
+        config=config,
+        effective=effective,
+        folds=tuple(folds),
+        device=device,
+    )
 
 
 def _gbm_manifest_files(model_dir: Path) -> dict[str, str]:
@@ -1730,7 +1891,7 @@ def _gbm_manifest_files(model_dir: Path) -> dict[str, str]:
 
 def _valid_gbm_model_dir(model_dir: Path, context: GBMContext) -> bool:
     files = _gbm_manifest_files(model_dir)
-    expected = {f"boosters/fold_{int(fold['fold'])}.txt" for fold in context.folds}
+    expected = {f"boosters/fold_{fold_id}.txt" for fold_id in context.fold_ids}
     return set(files) == expected and all(
         (model_dir / name).is_file() and _gbm_sha256(model_dir / name) == digest
         for name, digest in files.items()
@@ -1789,7 +1950,15 @@ def _cached_model_run(study: Study, spec: dict[str, Any], context: GBMContext):
         curves_path, spec
     ):
         return None
-    return ModelRun(training=training, predictions=prediction_results)
+    return ModelRun(
+        training=training,
+        predictions=prediction_results,
+        diagnostics={
+            "cache_hit": True,
+            "reused_folds": sorted(context.fold_ids),
+            "fitted_folds": [],
+        },
+    )
 
 
 def _gbm_prediction_frame(
@@ -1810,7 +1979,9 @@ def _gbm_prediction_frame(
         )
         if entry.get("y_eval") is not None:
             frame = frame.with_columns(pl.Series("eval_actual", entry["y_eval"]))
-        frames.append(frame)
+        frames.append(
+            frame.with_columns(pl.col("timestamp").cast(context.expected_keys.schema["timestamp"]))
+        )
     if len(frames) != len(context.folds):
         raise ValueError(f"GBM checkpoint {checkpoint} is missing a declared fold")
     return pl.concat(frames).sort("symbol", "timestamp", "fold")
@@ -1877,6 +2048,578 @@ def _write_learning_curves(path: Path, rows: list[dict[str, Any]]) -> None:
         os.replace(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _gbm_fixed_effective_params(
+    config: dict[str, Any],
+    fold_ids: tuple[int, ...],
+    *,
+    device: str,
+    max_bin: int,
+    num_threads: int,
+    task_type: str,
+    class_values: tuple[Any, ...],
+) -> dict[str, dict[str, Any]] | None:
+    params = config["params"]
+    if (
+        params.get("objective") == "huber"
+        and "alpha" not in params
+        and config.get("huber_alpha_scale") is not None
+    ):
+        return None
+    return _gbm_effective_params_by_fold(
+        config,
+        [{"fold": fold_id} for fold_id in fold_ids],
+        device=device,
+        max_bin=max_bin,
+        num_threads=num_threads,
+        seed=RANDOM_SEED,
+        task_type=task_type,
+        class_values=class_values,
+    )
+
+
+def _prepare_gbm_batch_fold(base: dict[str, Any], split: dict[str, Any]) -> dict[str, Any]:
+    mds = base["mds"]
+    folds = prepare_gbm_folds(
+        base["dataset_pd"],
+        [split],
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        mds.entity_cols[0],
+        task_type=mds.task_type,
+        class_values=mds.class_values,
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=base["train_sample_frac"],
+        eval_label_col=mds.eval_label_col,
+        seed=RANDOM_SEED,
+    )
+    if len(folds) != 1 or not folds[0]["n_train"] or not folds[0]["n_val"]:
+        raise ValueError(f"GBM request could not prepare fold {split['fold']}")
+    return folds[0]
+
+
+def _gbm_fold_settings(candidate: _GBMBatchCandidate, fold_id: int) -> dict[str, Any]:
+    assert candidate.spec is not None
+    return {
+        "effective_params": candidate.spec["computation"]["model"]["effective_params_by_fold"][
+            str(fold_id)
+        ],
+        "checkpoint_schedule": candidate.spec["computation"]["checkpoint_schedule"],
+    }
+
+
+def _gbm_fold_prediction_shard(entries: list[dict[str, Any]], context: GBMContext) -> pl.DataFrame:
+    frames = []
+    timestamp_dtype = context.expected_keys.schema["timestamp"]
+    for entry in entries:
+        frame = pl.DataFrame(
+            {
+                "symbol": entry["entities"],
+                "timestamp": entry["dates"],
+                "fold": [int(entry["fold"])] * len(entry["y_pred"]),
+                "checkpoint": [int(entry["n_trees"])] * len(entry["y_pred"]),
+                "prediction": entry["y_pred"],
+                "actual": entry["y_true"],
+            }
+        ).with_columns(pl.col("timestamp").cast(timestamp_dtype))
+        if entry.get("y_eval") is not None:
+            frame = frame.with_columns(pl.Series("eval_actual", entry["y_eval"]))
+        frames.append(frame)
+    if not frames:
+        raise ValueError("GBM fold fit produced no checkpoint predictions")
+    return pl.concat(frames).sort("checkpoint", "symbol", "timestamp", "fold")
+
+
+def _fit_or_reuse_gbm_fold(
+    candidate: _GBMBatchCandidate,
+    fold: dict[str, Any],
+) -> tuple[pl.DataFrame, bool, float]:
+    assert candidate.spec is not None
+    assert candidate.context is not None
+    assert candidate.training is not None
+    assert candidate.ledger is not None
+    fold_id = int(fold["fold"])
+    training_dir = candidate.training.root / "run_log" / "training" / candidate.training.hash
+    artifact = training_dir / "models" / "boosters" / f"fold_{fold_id}.txt"
+    shard = training_dir / "prediction_folds" / f"fold_{fold_id}.parquet"
+    settings = _gbm_fold_settings(candidate, fold_id)
+    if candidate.ledger.reusable_fold(
+        training_hash=candidate.training.hash,
+        candidate_identity=candidate.training.hash,
+        fold_id=fold_id,
+        fitted_state=artifact,
+        prediction_shard=shard,
+        resolved_settings=settings,
+    ):
+        return pl.read_parquet(shard), True, 0.0
+
+    started = time.perf_counter()
+    staging = training_dir / f".fold_{fold_id}.{uuid.uuid4().hex}.tmp"
+    staging.mkdir(parents=True)
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    shard.parent.mkdir(parents=True, exist_ok=True)
+    shard_staging = staging / "predictions.parquet"
+    try:
+        result = train_gbm_config(
+            candidate.config,
+            [fold],
+            feature_names=list(candidate.context.feature_names),
+            device=candidate.device,
+            num_threads=candidate.num_threads,
+            max_bin=candidate.max_bin,
+            entity_col=candidate.context.entity_col,
+            date_col=candidate.context.date_col,
+            task_type=candidate.context.task_type,
+            class_values=list(candidate.context.class_values) or None,
+            save_dir=staging,
+            effective_params_by_fold={
+                str(fold_id): settings["effective_params"],
+            },
+        )
+        booster = staging / "boosters" / f"fold_{fold_id}.txt"
+        if not booster.is_file():
+            raise ValueError(f"GBM fit did not persist fold {fold_id} booster")
+        frame = _gbm_fold_prediction_shard(result["predictions"], candidate.context)
+        expected_checkpoints = {
+            int(item["value"]) for item in candidate.spec["computation"]["checkpoint_schedule"]
+        }
+        if set(frame.get_column("checkpoint").unique()) != expected_checkpoints:
+            raise ValueError(f"GBM fold {fold_id} did not produce every checkpoint")
+        expected_rows = candidate.context.expected_keys.filter(pl.col("fold") == fold_id).height
+        if frame.height != expected_rows * len(expected_checkpoints):
+            raise ValueError(f"GBM fold {fold_id} prediction coverage is incomplete")
+        frame.write_parquet(shard_staging)
+        os.replace(booster, artifact)
+        os.replace(shard_staging, shard)
+        candidate.ledger.complete_fold(
+            training_hash=candidate.training.hash,
+            candidate_identity=candidate.training.hash,
+            fold_id=fold_id,
+            fitted_state=artifact,
+            prediction_shard=shard,
+            resolved_settings=settings,
+        )
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return frame, False, time.perf_counter() - started
+
+
+def _write_gbm_training_manifest(training: TrainingResult, fold_ids: tuple[int, ...]) -> None:
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    expected = [model_dir / "boosters" / f"fold_{fold_id}.txt" for fold_id in fold_ids]
+    missing = [path for path in expected if not path.is_file()]
+    if missing:
+        raise ValueError(f"GBM fit did not persist every fold booster: {missing}")
+    files = {str(path.relative_to(model_dir)): _gbm_sha256(path) for path in expected}
+    manifest = model_dir / "manifest.json"
+    temporary = model_dir / f".manifest.{uuid.uuid4().hex}.tmp"
+    try:
+        temporary.write_text(
+            json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
+        )
+        os.replace(temporary, manifest)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _gbm_curves_from_shards(
+    config_name: str,
+    predictions: pl.DataFrame,
+    checkpoints: tuple[int, ...],
+) -> list[dict[str, Any]]:
+    target = "eval_actual" if "eval_actual" in predictions.columns else "actual"
+    curves = []
+    for checkpoint in checkpoints:
+        frame = predictions.filter(pl.col("checkpoint") == checkpoint)
+        metric = cross_sectional_ic(
+            frame,
+            frame,
+            pred_col="prediction",
+            ret_col=target,
+            date_col="timestamp",
+            entity_col="symbol",
+            min_obs=5,
+        )
+        curves.append(
+            {
+                "config": config_name,
+                "iteration": checkpoint,
+                "ic_mean": float(metric["ic_mean"]),
+                "ic_std": float(metric.get("ic_std", 0.0)),
+            }
+        )
+    return curves
+
+
+def _write_gbm_runtime_fields(path: Path, **fields: float) -> None:
+    if not path.exists():
+        return
+    runtime = json.loads(path.read_text())
+    runtime.update(fields)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _resolve_gbm_batch_candidate(
+    study: Study,
+    candidate: _GBMBatchCandidate,
+    base: dict[str, Any],
+) -> None:
+    placeholder_folds = tuple({"fold": int(split["fold"])} for split in base["splits"])
+    spec, context = _build_gbm_resolved_request(
+        study,
+        candidate.request,
+        base=base,
+        config=candidate.config,
+        effective=candidate.effective_params,
+        folds=placeholder_folds,
+        device=candidate.device,
+    )
+    candidate.spec = spec
+    candidate.context = context
+    cached = _cached_model_run(study, spec, context)
+    if cached is not None:
+        candidate.result = cached
+        return
+    candidate.started_at_s = time.perf_counter()
+    candidate.training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    candidate.ledger = ExecutionLedger(study, candidate.training.root)
+    candidate.attempt = candidate.ledger.start(candidate.training.hash)
+
+
+def _fail_gbm_batch_candidate(candidate: _GBMBatchCandidate, error: Exception) -> None:
+    if candidate.error is not None:
+        return
+    candidate.error = error
+    if candidate.attempt is not None:
+        candidate.attempt.finish(
+            "failed",
+            {
+                "error_type": type(error).__name__,
+                "error": str(error),
+                "reused_folds": candidate.reused_folds,
+                "fitted_folds": candidate.fitted_folds,
+            },
+        )
+        candidate.attempt = None
+
+
+def _reuse_gbm_batch_fold(candidate: _GBMBatchCandidate, fold_id: int) -> bool:
+    if candidate.result is not None or candidate.error is not None:
+        return True
+    assert candidate.training is not None
+    assert candidate.ledger is not None
+    training_dir = candidate.training.root / "run_log" / "training" / candidate.training.hash
+    artifact = training_dir / "models" / "boosters" / f"fold_{fold_id}.txt"
+    shard = training_dir / "prediction_folds" / f"fold_{fold_id}.parquet"
+    if not candidate.ledger.reusable_fold(
+        training_hash=candidate.training.hash,
+        candidate_identity=candidate.training.hash,
+        fold_id=fold_id,
+        fitted_state=artifact,
+        prediction_shard=shard,
+        resolved_settings=_gbm_fold_settings(candidate, fold_id),
+    ):
+        return False
+    candidate.frames.append(pl.read_parquet(shard))
+    candidate.reused_folds.append(fold_id)
+    return True
+
+
+def _run_gbm_batch_fold(candidate: _GBMBatchCandidate, fold: dict[str, Any]) -> None:
+    if candidate.result is not None or candidate.error is not None:
+        return
+    fold_id = int(fold["fold"])
+    if fold_id in candidate.reused_folds or fold_id in candidate.fitted_folds:
+        return
+    try:
+        frame, reused, elapsed = _fit_or_reuse_gbm_fold(candidate, fold)
+    except Exception as exc:
+        _fail_gbm_batch_candidate(candidate, exc)
+        return
+    candidate.frames.append(frame)
+    candidate.fit_elapsed_s += elapsed
+    (candidate.reused_folds if reused else candidate.fitted_folds).append(fold_id)
+
+
+def _finish_gbm_batch_candidate(study: Study, candidate: _GBMBatchCandidate) -> None:
+    if candidate.result is not None or candidate.error is not None:
+        return
+    assert candidate.spec is not None
+    assert candidate.context is not None
+    assert candidate.training is not None
+    assert candidate.attempt is not None
+    try:
+        if len(candidate.frames) != len(candidate.context.fold_ids):
+            raise RuntimeError(
+                f"GBM candidate produced {len(candidate.frames)} of "
+                f"{len(candidate.context.fold_ids)} fold shards"
+            )
+        _write_gbm_training_manifest(candidate.training, candidate.context.fold_ids)
+        predictions = pl.concat(candidate.frames).sort("checkpoint", "symbol", "timestamp", "fold")
+        prediction_results = []
+        checkpoints = tuple(
+            int(item["value"]) for item in candidate.spec["computation"]["checkpoint_schedule"]
+        )
+        for checkpoint in checkpoints:
+            frame = predictions.filter(pl.col("checkpoint") == checkpoint).drop("checkpoint")
+            prediction_results.append(
+                study.results.publish_predictions(
+                    candidate.training,
+                    checkpoint_kind="iteration",
+                    checkpoint_value=checkpoint,
+                    split="validation",
+                    predictions=frame,
+                    expected_keys=candidate.context.expected_keys,
+                    task_type=candidate.context.task_type,
+                    class_values=list(candidate.context.class_values) or None,
+                    eval_col="eval_actual" if candidate.context.eval_label_col else None,
+                    label=candidate.spec["label"],
+                )
+            )
+        curves_path = (
+            candidate.training.root
+            / "run_log"
+            / "training"
+            / candidate.training.hash
+            / "learning_curves.parquet"
+        )
+        curves = _gbm_curves_from_shards(candidate.spec["config_name"], predictions, checkpoints)
+        _write_learning_curves(curves_path, curves)
+        diagnostics = {
+            "cache_hit": False,
+            "reused_folds": candidate.reused_folds,
+            "fitted_folds": candidate.fitted_folds,
+        }
+        candidate.attempt.finish("completed", diagnostics)
+        candidate.attempt = None
+        runtime_path = curves_path.with_name("runtime.json")
+        _write_gbm_runtime_fields(
+            runtime_path,
+            elapsed_s=time.perf_counter() - candidate.started_at_s,
+        )
+        candidate.result = ModelRun(
+            candidate.training,
+            tuple(prediction_results),
+            diagnostics,
+        )
+    except Exception as exc:
+        _fail_gbm_batch_candidate(candidate, exc)
+
+
+def _run_gbm_batch_group(
+    study: Study,
+    indexed_requests: list[tuple[int, dict[str, Any]]],
+    compatibility_key: str,
+    base: dict[str, Any],
+    *,
+    report_batch: bool,
+) -> list[_GBMBatchCandidate]:
+    mds = base["mds"]
+    fold_ids = tuple(int(split["fold"]) for split in base["splits"])
+    candidates = []
+    dependent = []
+    for index, request in indexed_requests:
+        config, request_fields = _load_gbm_request_config(
+            study,
+            base["label_ref"].name,
+            request["config_name"],
+            request["overrides"],
+        )
+        _apply_gbm_preview_reductions(config, request)
+        device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
+        effective = _gbm_fixed_effective_params(
+            config,
+            fold_ids,
+            device=device,
+            max_bin=max_bin,
+            num_threads=num_threads,
+            task_type=mds.task_type,
+            class_values=tuple(mds.class_values),
+        )
+        candidate = _GBMBatchCandidate(
+            index=index,
+            request=request,
+            config=config,
+            effective_params=effective or {},
+            device=device,
+            max_bin=max_bin,
+            num_threads=num_threads,
+        )
+        candidates.append(candidate)
+        if effective is None:
+            dependent.append(candidate)
+        else:
+            _resolve_gbm_batch_candidate(study, candidate, base)
+    dependent_indices = {candidate.index for candidate in dependent}
+
+    preparation_elapsed_s = 0.0
+    preparation_count = 0
+    first_pass_needed = bool(dependent) or any(
+        candidate.result is None and candidate.error is None for candidate in candidates
+    )
+    if first_pass_needed:
+        for split in base["splits"]:
+            fold_id = int(split["fold"])
+            fixed_pending = [
+                candidate
+                for candidate in candidates
+                if candidate.index not in dependent_indices
+                and not _reuse_gbm_batch_fold(candidate, fold_id)
+            ]
+            if not dependent and not fixed_pending:
+                continue
+            started = time.perf_counter()
+            try:
+                fold = _prepare_gbm_batch_fold(base, split)
+            except Exception as exc:
+                for candidate in candidates:
+                    _fail_gbm_batch_candidate(candidate, exc)
+                break
+            preparation_elapsed_s += time.perf_counter() - started
+            preparation_count += 1
+            for candidate in dependent:
+                if candidate.error is not None:
+                    continue
+                try:
+                    candidate.effective_params.update(
+                        _gbm_effective_params_by_fold(
+                            candidate.config,
+                            [fold],
+                            device=candidate.device,
+                            max_bin=candidate.max_bin,
+                            num_threads=candidate.num_threads,
+                            seed=RANDOM_SEED,
+                            task_type=mds.task_type,
+                            class_values=tuple(mds.class_values),
+                        )
+                    )
+                except Exception as exc:
+                    _fail_gbm_batch_candidate(candidate, exc)
+            for candidate in fixed_pending:
+                _run_gbm_batch_fold(candidate, fold)
+            del fold
+            gc.collect()
+
+    for candidate in candidates:
+        if candidate.index not in dependent_indices:
+            _finish_gbm_batch_candidate(study, candidate)
+
+    active_dependent = []
+    for candidate in dependent:
+        if candidate.error is not None:
+            continue
+        if set(candidate.effective_params) != {str(fold_id) for fold_id in fold_ids}:
+            _fail_gbm_batch_candidate(
+                candidate,
+                RuntimeError("GBM candidate did not resolve parameters for every fold"),
+            )
+            continue
+        try:
+            _resolve_gbm_batch_candidate(study, candidate, base)
+        except Exception as exc:
+            _fail_gbm_batch_candidate(candidate, exc)
+            continue
+        if candidate.result is None:
+            active_dependent.append(candidate)
+
+    if active_dependent:
+        for split in base["splits"]:
+            fold_id = int(split["fold"])
+            pending = [
+                candidate
+                for candidate in active_dependent
+                if not _reuse_gbm_batch_fold(candidate, fold_id)
+            ]
+            if not pending:
+                continue
+            started = time.perf_counter()
+            try:
+                fold = _prepare_gbm_batch_fold(base, split)
+            except Exception as exc:
+                for candidate in active_dependent:
+                    _fail_gbm_batch_candidate(candidate, exc)
+                break
+            preparation_elapsed_s += time.perf_counter() - started
+            preparation_count += 1
+            for candidate in pending:
+                _run_gbm_batch_fold(candidate, fold)
+            del fold
+            gc.collect()
+        for candidate in active_dependent:
+            _finish_gbm_batch_candidate(study, candidate)
+
+    group_digest = hashlib.sha256(compatibility_key.encode()).hexdigest()[:12]
+    fit_elapsed_s = sum(candidate.fit_elapsed_s for candidate in candidates)
+    measured_s = preparation_elapsed_s + fit_elapsed_s
+    for candidate in candidates:
+        if candidate.result is None or not report_batch:
+            continue
+        candidate.result.diagnostics.update(
+            {
+                "execution_order": "fold_major",
+                "compatibility_group": group_digest,
+                "compatibility_group_size": len(candidates),
+                "base_fold_preparations": preparation_count,
+                "base_fold_preparation_s": preparation_elapsed_s,
+                "candidate_fit_s": candidate.fit_elapsed_s,
+                "preparation_fraction": (preparation_elapsed_s / measured_s if measured_s else 0.0),
+                "disk_fold_cache": False,
+            }
+        )
+    return candidates
+
+
+def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[ModelRun, ...]:
+    if not requests:
+        raise ValueError("GBM batch runner requires at least one request")
+    groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        groups.setdefault(_gbm_compatibility_key(study, request), []).append((index, request))
+
+    ordered: list[ModelRun | None] = [None] * len(requests)
+    failures = []
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any, Any]] = {}
+    for key, indexed_requests in groups.items():
+        input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
+        base = _load_gbm_batch_base(
+            study,
+            indexed_requests[0][1],
+            inputs=input_cache.get(input_key),
+        )
+        input_cache.setdefault(
+            input_key,
+            (base["label_ref"], base["mds"], base["dataset_pd"]),
+        )
+        candidates = _run_gbm_batch_group(
+            study,
+            indexed_requests,
+            key,
+            base,
+            report_batch=len(requests) > 1,
+        )
+        for candidate in candidates:
+            if candidate.error is not None:
+                failures.append(candidate.error)
+            elif candidate.result is not None:
+                ordered[candidate.index] = candidate.result
+    if failures:
+        raise failures[0]
+    if any(result is None for result in ordered):
+        raise RuntimeError("GBM batch did not produce every requested result")
+    return tuple(result for result in ordered if result is not None)
 
 
 def run_resolved_request(study: Study, spec: dict[str, Any], context: GBMContext):

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -8,7 +8,8 @@ import platform
 import subprocess
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -21,11 +22,17 @@ from case_studies.research.contracts import ExecutionTier
 from case_studies.research.cv import require_fold_scoped_temporal_compatibility
 from case_studies.research.identity import ResolvedSpec
 from case_studies.research.models import ModelRun
-from case_studies.research.recovery import ExecutionLedger
+from case_studies.research.recovery import ExecutionAttempt, ExecutionLedger
 from case_studies.research.results import PredictionResult, Result, TrainingResult
 from case_studies.utils.artifact_digest import value_digest
 from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
-from utils.modeling import load_modeling_dataset, prepare_cv_folds, resolve_linear_params
+from case_studies.utils.registry.specs import canonical_json
+from utils.modeling import (
+    load_modeling_dataset,
+    prepare_cv_folds,
+    prepare_single_fold,
+    resolve_linear_params,
+)
 
 if TYPE_CHECKING:
     from case_studies.research.workspace import Study
@@ -54,6 +61,7 @@ _SOURCE_FILES = (Path(__file__), _module_source("utils.modeling"))
 @dataclass(frozen=True)
 class LinearContext:
     folds: tuple[dict[str, Any], ...]
+    fold_ids: tuple[int, ...]
     feature_names: tuple[str, ...]
     label_col: str
     eval_label_col: str | None
@@ -63,6 +71,26 @@ class LinearContext:
     class_values: tuple[Any, ...]
     expected_keys: pl.DataFrame
     runtime_provenance: dict[str, Any]
+
+
+@dataclass
+class _BatchCandidate:
+    index: int
+    request: dict[str, Any]
+    config: dict[str, Any]
+    effective_params: dict[str, dict[str, Any]]
+    spec: dict[str, Any] | None = None
+    context: LinearContext | None = None
+    training: TrainingResult | None = None
+    ledger: ExecutionLedger | None = None
+    attempt: ExecutionAttempt | None = None
+    frames: list[pl.DataFrame] = field(default_factory=list)
+    reused_folds: list[int] = field(default_factory=list)
+    fitted_folds: list[int] = field(default_factory=list)
+    fit_elapsed_s: float = 0.0
+    started_at_s: float = 0.0
+    result: ModelRun | None = None
+    error: Exception | None = None
 
 
 def _sha256(path: Path) -> str:
@@ -148,6 +176,20 @@ def _select_splits(
     return splits, cv_record
 
 
+def _expected_keys(folds: list[dict[str, Any]], entity_col: str, date_col: str) -> pl.DataFrame:
+    frames = [
+        pl.from_pandas(fold["meta"][[entity_col, date_col]])
+        .with_columns(pl.lit(int(fold["fold"]), dtype=pl.Int64).alias("fold"))
+        .rename({entity_col: "symbol", date_col: "timestamp"})
+        .select("symbol", "timestamp", "fold")
+        for fold in folds
+    ]
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("linear request produced duplicate expected prediction keys")
+    return expected
+
+
 def _load_preset(config_name: str) -> dict[str, Any]:
     from case_studies.utils.registry.specs import load_preset
 
@@ -160,23 +202,6 @@ def _load_preset(config_name: str) -> dict[str, Any]:
             f"unsupported linear model class {model_class!r}; expected {sorted(_MODEL_CLASSES)}"
         )
     return config
-
-
-def _expected_keys(folds: list[dict[str, Any]], entity_col: str, date_col: str) -> pl.DataFrame:
-    frames = []
-    for fold in folds:
-        frame = pl.from_pandas(fold["meta"][[entity_col, date_col]]).with_columns(
-            pl.lit(int(fold["fold"]), dtype=pl.Int64).alias("fold")
-        )
-        frames.append(
-            frame.rename({entity_col: "symbol", date_col: "timestamp"}).select(
-                "symbol", "timestamp", "fold"
-            )
-        )
-    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
-    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
-        raise ValueError("linear request produced duplicate expected prediction keys")
-    return expected
 
 
 def _effective_params(config: dict[str, Any], overrides: dict[str, Any], folds) -> dict[str, dict]:
@@ -199,54 +224,95 @@ def _effective_params(config: dict[str, Any], overrides: dict[str, Any], folds) 
     return effective
 
 
-def resolve_model_request(study: Study, request: dict[str, Any]):
+def _fixed_effective_params(
+    config: dict[str, Any],
+    overrides: dict[str, Any],
+    fold_ids: tuple[int, ...],
+) -> dict[str, dict[str, Any]] | None:
+    merged = {**dict(config.get("params") or {}), **overrides}
+    if "alpha_frac" in merged:
+        return None
+    cls = _MODEL_CLASSES[config["model_class"]]
+    supported = cls().get_params(deep=True)
+    if "random_state" in supported and "random_state" not in merged:
+        merged["random_state"] = 42
+    try:
+        resolved = cls(**merged).get_params(deep=True)
+    except TypeError as exc:
+        raise ValueError(
+            f"invalid parameters for {config['model_class']}: {sorted(merged)}"
+        ) from exc
+    return {str(fold_id): dict(resolved) for fold_id in fold_ids}
+
+
+def _boundary_literal(dtype: pl.DataType, value: Any) -> pl.Expr:
+    raw = str(value)
+    if dtype == pl.Date:
+        return pl.lit(datetime.fromisoformat(raw[:10]).date())
+    if dtype.base_type() == pl.Datetime:
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            parsed = datetime.fromisoformat(f"{raw[:10]}T00:00:00")
+        return pl.lit(parsed).cast(dtype)
+    return pl.lit(value).cast(dtype)
+
+
+def _expected_keys_from_dataset(
+    dataset: pl.DataFrame,
+    splits: list[dict[str, Any]],
+    *,
+    entity_col: str,
+    date_col: str,
+    label_col: str,
+) -> pl.DataFrame:
+    dtype = dataset.schema[date_col]
+    label_valid = pl.col(label_col).is_not_null()
+    if dataset.schema[label_col] in {pl.Float32, pl.Float64}:
+        label_valid &= pl.col(label_col).is_not_nan()
+    frames = []
+    for split in splits:
+        val_start = split.get("val_start", split.get("test_start"))
+        val_end = split.get("val_end", split.get("test_end"))
+        frame = (
+            dataset.filter(
+                (pl.col(date_col) >= _boundary_literal(dtype, val_start))
+                & (pl.col(date_col) <= _boundary_literal(dtype, val_end))
+                & label_valid
+            )
+            .select(entity_col, date_col)
+            .with_columns(pl.lit(int(split["fold"]), dtype=pl.Int64).alias("fold"))
+            .rename({entity_col: "symbol", date_col: "timestamp"})
+            .select("symbol", "timestamp", "fold")
+        )
+        if frame.is_empty():
+            raise ValueError(f"linear request produced no validation keys for fold {split['fold']}")
+        frames.append(frame)
+    expected = pl.concat(frames).sort("symbol", "timestamp", "fold")
+    if expected.n_unique(["symbol", "timestamp", "fold"]) != expected.height:
+        raise ValueError("linear request produced duplicate expected prediction keys")
+    return expected
+
+
+def _build_resolved_request(
+    study: Study,
+    request: dict[str, Any],
+    *,
+    label_ref,
+    mds,
+    splits: list[dict[str, Any]],
+    cv_record: dict[str, Any],
+    config: dict[str, Any],
+    effective: dict[str, dict[str, Any]],
+    expected: pl.DataFrame,
+    folds: tuple[dict[str, Any], ...],
+    runtime_provenance: dict[str, Any],
+) -> tuple[dict[str, Any], LinearContext]:
     tier = ExecutionTier(request["execution_tier"])
     reductions = dict(request["preview_reductions"])
-    unknown_reductions = set(reductions) - _PREVIEW_FIELDS
-    if unknown_reductions:
-        raise ValueError(f"unsupported linear preview reductions: {sorted(unknown_reductions)}")
-    study.require_writable()
-    study.activate(tier)
-
-    label_ref = study.labels.get(request["label"], execution_tier=tier)
     max_symbols = int(reductions.get("max_symbols", 0))
     train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
-    if not 0 < train_sample_frac <= 1:
-        raise ValueError("train_sample_frac must be in (0, 1]")
-    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
-    if mds.date_col != "timestamp" or not mds.entity_cols:
-        raise ValueError("linear runner requires timestamp and an entity key")
     entity_col = mds.entity_cols[0]
-    if entity_col not in {"product", "symbol"}:
-        raise ValueError(f"linear runner does not support entity key {entity_col!r}")
-    label_timeline = label_ref.load().select(mds.date_col).unique()
-    splits, cv_record = _select_splits(mds, request, label_timeline)
-    if (
-        request.get("cv") is not None
-        and mds.temporal_by_fold is not None
-        and mds.temporal_keys
-        and mds.temporal_feature_names
-    ):
-        require_fold_scoped_temporal_compatibility(splits, mds.temporal_artifact_splits)
-    folds = prepare_cv_folds(
-        mds.dataset.to_pandas(),
-        splits,
-        mds.feature_names,
-        mds.label_col,
-        mds.date_col,
-        entity_col,
-        temporal_by_fold=mds.temporal_by_fold,
-        temporal_keys=mds.temporal_keys,
-        temporal_feature_names=mds.temporal_feature_names,
-        train_sample_frac=train_sample_frac,
-        eval_label_col=mds.eval_label_col,
-    )
-    if len(folds) != len(splits):
-        raise ValueError("linear request did not prepare every declared fold")
-
-    config = _load_preset(request["config_name"])
-    effective = _effective_params(config, request["overrides"], folds)
-    expected = _expected_keys(folds, entity_col, mds.date_col)
     input_lineage = mds.input_lineage
     computation = {
         "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
@@ -281,7 +347,6 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     }
     if tier is ExecutionTier.PREVIEW:
         computation["preview_reductions"] = reductions
-    runtime_provenance = _runtime_provenance(study)
     spec = ResolvedSpec.create(
         family="linear",
         label=label_ref.name,
@@ -292,7 +357,8 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         execution_tier=tier.value,
     ).as_dict()
     context = LinearContext(
-        folds=tuple(folds),
+        folds=folds,
+        fold_ids=tuple(int(split["fold"]) for split in splits),
         feature_names=tuple(mds.feature_names),
         label_col=mds.label_col,
         eval_label_col=mds.eval_label_col,
@@ -304,6 +370,122 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         runtime_provenance=runtime_provenance,
     )
     return spec, context
+
+
+def _load_batch_base(
+    study: Study,
+    request: dict[str, Any],
+    *,
+    inputs: tuple[Any, Any] | None = None,
+) -> dict[str, Any]:
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported linear preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+    max_symbols = int(reductions.get("max_symbols", 0))
+    train_sample_frac = float(reductions.get("train_sample_frac", 1.0))
+    if not 0 < train_sample_frac <= 1:
+        raise ValueError("train_sample_frac must be in (0, 1]")
+    if inputs is None:
+        label_ref = study.labels.get(request["label"], execution_tier=tier)
+        mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
+    else:
+        label_ref, mds = inputs
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("linear runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+    if entity_col not in {"product", "symbol"}:
+        raise ValueError(f"linear runner does not support entity key {entity_col!r}")
+    label_timeline = label_ref.load().select(mds.date_col).unique()
+    splits, cv_record = _select_splits(mds, request, label_timeline)
+    if (
+        request.get("cv") is not None
+        and mds.temporal_by_fold is not None
+        and mds.temporal_keys
+        and mds.temporal_feature_names
+    ):
+        require_fold_scoped_temporal_compatibility(splits, mds.temporal_artifact_splits)
+    expected = _expected_keys_from_dataset(
+        mds.dataset,
+        splits,
+        entity_col=entity_col,
+        date_col=mds.date_col,
+        label_col=mds.label_col,
+    )
+    return {
+        "train_sample_frac": train_sample_frac,
+        "label_ref": label_ref,
+        "mds": mds,
+        "splits": splits,
+        "cv_record": cv_record,
+        "expected": expected,
+        "runtime_provenance": _runtime_provenance(study),
+    }
+
+
+def _input_compatibility_key(request: dict[str, Any]) -> tuple[str, str, int]:
+    reductions = request["preview_reductions"]
+    return (
+        request["label"],
+        request["execution_tier"],
+        int(reductions.get("max_symbols", 0)),
+    )
+
+
+def _compatibility_key(request: dict[str, Any]) -> str:
+    cv = request.get("cv")
+    cv_value = asdict(cv) if cv is not None else None
+    reductions = request["preview_reductions"]
+    return canonical_json(
+        {
+            "label": request["label"],
+            "execution_tier": request["execution_tier"],
+            "cv": cv_value,
+            "folds": reductions.get("folds"),
+            "max_symbols": reductions.get("max_symbols", 0),
+            "train_sample_frac": reductions.get("train_sample_frac", 1.0),
+            "preprocessing": "median-imputer-standard-scaler/v1",
+        }
+    )
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    base = _load_batch_base(study, request)
+    mds = base["mds"]
+    folds = prepare_cv_folds(
+        mds.dataset.to_pandas(),
+        base["splits"],
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        mds.entity_cols[0],
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=base["train_sample_frac"],
+        eval_label_col=mds.eval_label_col,
+    )
+    if len(folds) != len(base["splits"]):
+        raise ValueError("linear request did not prepare every declared fold")
+
+    config = _load_preset(request["config_name"])
+    effective = _effective_params(config, request["overrides"], folds)
+    return _build_resolved_request(
+        study,
+        request,
+        label_ref=base["label_ref"],
+        mds=mds,
+        splits=base["splits"],
+        cv_record=base["cv_record"],
+        config=config,
+        effective=effective,
+        expected=base["expected"],
+        folds=tuple(folds),
+        runtime_provenance=base["runtime_provenance"],
+    )
 
 
 def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> ModelRun | None:
@@ -334,7 +516,7 @@ def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> M
     if not prediction.complete:
         return None
     manifest = model_dir / "manifest.json"
-    expected_files = {f"fold_{int(fold['fold'])}.joblib" for fold in context.folds}
+    expected_files = {f"fold_{fold_id}.joblib" for fold_id in context.fold_ids}
     if not manifest.is_file():
         return None
     record = json.loads(manifest.read_text())
@@ -347,7 +529,7 @@ def _cached_run(study: Study, spec: dict[str, Any], context: LinearContext) -> M
         predictions=(prediction,),
         diagnostics={
             "cache_hit": True,
-            "reused_folds": sorted(int(fold["fold"]) for fold in context.folds),
+            "reused_folds": sorted(context.fold_ids),
             "fitted_folds": [],
         },
     )
@@ -372,14 +554,21 @@ def _prediction_frame(
     fold: dict[str, Any], predictions: np.ndarray, context: LinearContext
 ) -> pl.DataFrame:
     fold_id = int(fold["fold"])
-    frame = pl.from_pandas(fold["meta"][[context.entity_col, context.date_col]]).with_columns(
+    metadata = fold.get("meta_pl")
+    if metadata is not None:
+        frame = metadata.select(context.entity_col, context.date_col)
+    else:
+        frame = pl.from_pandas(fold["meta"][[context.entity_col, context.date_col]])
+    frame = frame.with_columns(
         pl.lit(fold_id, dtype=pl.Int64).alias("fold"),
         pl.Series("prediction", predictions),
         pl.Series("actual", fold["y_val"]),
     )
     if fold.get("y_eval") is not None:
         frame = frame.with_columns(pl.Series("eval_actual", fold["y_eval"]))
-    return frame.rename({context.entity_col: "symbol", context.date_col: "timestamp"})
+    return frame.rename({context.entity_col: "symbol", context.date_col: "timestamp"}).with_columns(
+        pl.col("timestamp").cast(context.expected_keys.schema["timestamp"])
+    )
 
 
 def _write_runtime_fields(runtime_path: Path, **fields: float) -> None:
@@ -395,79 +584,385 @@ def _write_runtime_fields(runtime_path: Path, **fields: float) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _fit_or_reuse_predictions(
+def _fit_or_reuse_fold(
     spec: dict[str, Any],
     context: LinearContext,
     training: TrainingResult,
     ledger: ExecutionLedger,
-) -> tuple[pl.DataFrame, list[int], list[int]]:
-    computation = spec["computation"]
-    cls = _MODEL_CLASSES[computation["model"]["class"]]
-    prediction_frames = []
+    fold: dict[str, Any],
+) -> tuple[pl.DataFrame, bool, float]:
+    fold_id = int(fold["fold"])
+    params = spec["computation"]["model"]["effective_params_by_fold"][str(fold_id)]
     model_dir = training.root / "run_log" / "training" / training.hash / "models"
     shard_dir = training.root / "run_log" / "training" / training.hash / "prediction_folds"
     model_dir.mkdir(parents=True, exist_ok=True)
     shard_dir.mkdir(parents=True, exist_ok=True)
-    reused_folds = []
-    fitted_folds = []
-    for fold in context.folds:
-        fold_id = int(fold["fold"])
-        params = computation["model"]["effective_params_by_fold"][str(fold_id)]
-        artifact = model_dir / f"fold_{fold_id}.joblib"
-        shard = shard_dir / f"fold_{fold_id}.parquet"
-        if ledger.reusable_fold(
+    artifact = model_dir / f"fold_{fold_id}.joblib"
+    shard = shard_dir / f"fold_{fold_id}.parquet"
+    if ledger.reusable_fold(
+        training_hash=training.hash,
+        candidate_identity=training.hash,
+        fold_id=fold_id,
+        fitted_state=artifact,
+        prediction_shard=shard,
+        resolved_settings=params,
+    ):
+        return pl.read_parquet(shard), True, 0.0
+
+    started = time.perf_counter()
+    cls = _MODEL_CLASSES[spec["computation"]["model"]["class"]]
+    model = cls(**params)
+    model.fit(fold["X_train"], fold["y_train"])
+    predictions = _fold_predictions(model, fold, context)
+    frame = _prediction_frame(fold, predictions, context)
+    artifact_temp = model_dir / f".{artifact.name}.{uuid.uuid4().hex}.tmp"
+    shard_temp = shard_dir / f".{shard.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        joblib.dump(
+            {
+                "feature_names": context.feature_names,
+                "model": model,
+                "preprocessor": fold["preprocessor"],
+            },
+            artifact_temp,
+        )
+        frame.write_parquet(shard_temp)
+        os.replace(artifact_temp, artifact)
+        os.replace(shard_temp, shard)
+        ledger.complete_fold(
             training_hash=training.hash,
             candidate_identity=training.hash,
             fold_id=fold_id,
             fitted_state=artifact,
             prediction_shard=shard,
             resolved_settings=params,
-        ):
-            prediction_frames.append(pl.read_parquet(shard))
-            reused_folds.append(fold_id)
-            continue
+        )
+    finally:
+        artifact_temp.unlink(missing_ok=True)
+        shard_temp.unlink(missing_ok=True)
+    return frame, False, time.perf_counter() - started
 
-        model = cls(**params)
-        model.fit(fold["X_train"], fold["y_train"])
-        predictions = _fold_predictions(model, fold, context)
-        frame = _prediction_frame(fold, predictions, context)
-        artifact_temp = model_dir / f".{artifact.name}.{uuid.uuid4().hex}.tmp"
-        shard_temp = shard_dir / f".{shard.name}.{uuid.uuid4().hex}.tmp"
-        try:
-            joblib.dump(
-                {
-                    "feature_names": context.feature_names,
-                    "model": model,
-                    "preprocessor": fold["preprocessor"],
-                },
-                artifact_temp,
-            )
-            frame.write_parquet(shard_temp)
-            os.replace(artifact_temp, artifact)
-            os.replace(shard_temp, shard)
-            ledger.complete_fold(
-                training_hash=training.hash,
-                candidate_identity=training.hash,
-                fold_id=fold_id,
-                fitted_state=artifact,
-                prediction_shard=shard,
-                resolved_settings=params,
-            )
-        finally:
-            artifact_temp.unlink(missing_ok=True)
-            shard_temp.unlink(missing_ok=True)
-        prediction_frames.append(frame)
-        fitted_folds.append(fold_id)
 
+def _write_model_manifest(training: TrainingResult) -> None:
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
     files = {path.name: _sha256(path) for path in sorted(model_dir.glob("fold_*.joblib"))}
     manifest = model_dir / "manifest.json"
     manifest_temp = model_dir / f".manifest.{uuid.uuid4().hex}.tmp"
-    manifest_temp.write_text(
-        json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
-    )
-    os.replace(manifest_temp, manifest)
+    try:
+        manifest_temp.write_text(
+            json.dumps({"files": files, "schema_version": 1}, indent=2, sort_keys=True) + "\n"
+        )
+        os.replace(manifest_temp, manifest)
+    finally:
+        manifest_temp.unlink(missing_ok=True)
+
+
+def _fit_or_reuse_predictions(
+    spec: dict[str, Any],
+    context: LinearContext,
+    training: TrainingResult,
+    ledger: ExecutionLedger,
+) -> tuple[pl.DataFrame, list[int], list[int]]:
+    prediction_frames = []
+    reused_folds = []
+    fitted_folds = []
+    for fold in context.folds:
+        fold_id = int(fold["fold"])
+        frame, reused, _ = _fit_or_reuse_fold(spec, context, training, ledger, fold)
+        prediction_frames.append(frame)
+        if reused:
+            reused_folds.append(fold_id)
+        else:
+            fitted_folds.append(fold_id)
+
+    _write_model_manifest(training)
     predictions = pl.concat(prediction_frames).sort("symbol", "timestamp", "fold")
     return predictions, reused_folds, fitted_folds
+
+
+def _prepare_batch_fold(base: dict[str, Any], split: dict[str, Any]) -> dict[str, Any]:
+    mds = base["mds"]
+    fold = prepare_single_fold(
+        mds.dataset,
+        split,
+        mds.feature_names,
+        mds.label_col,
+        mds.date_col,
+        mds.entity_cols[0],
+        temporal_by_fold=mds.temporal_by_fold,
+        temporal_keys=mds.temporal_keys,
+        temporal_feature_names=mds.temporal_feature_names,
+        train_sample_frac=base["train_sample_frac"],
+        eval_label_col=mds.eval_label_col,
+    )
+    if fold is None:
+        raise ValueError(f"linear request could not prepare fold {split['fold']}")
+    return fold
+
+
+def _resolve_batch_candidate(
+    study: Study,
+    candidate: _BatchCandidate,
+    base: dict[str, Any],
+) -> None:
+    placeholder_folds = tuple({"fold": int(split["fold"])} for split in base["splits"])
+    spec, context = _build_resolved_request(
+        study,
+        candidate.request,
+        label_ref=base["label_ref"],
+        mds=base["mds"],
+        splits=base["splits"],
+        cv_record=base["cv_record"],
+        config=candidate.config,
+        effective=candidate.effective_params,
+        expected=base["expected"],
+        folds=placeholder_folds,
+        runtime_provenance=base["runtime_provenance"],
+    )
+    candidate.spec = spec
+    candidate.context = context
+    cached = _cached_run(study, spec, context)
+    if cached is not None:
+        candidate.result = cached
+        return
+    candidate.started_at_s = time.perf_counter()
+    training = study.results.register_training(
+        spec,
+        execution_tier=spec["execution_tier"],
+        runtime_provenance=context.runtime_provenance,
+    )
+    candidate.training = training
+    candidate.ledger = ExecutionLedger(study, training.root)
+    candidate.attempt = candidate.ledger.start(training.hash)
+
+
+def _fail_batch_candidate(candidate: _BatchCandidate, error: Exception) -> None:
+    if candidate.error is not None:
+        return
+    candidate.error = error
+    if candidate.attempt is not None:
+        candidate.attempt.finish(
+            "failed",
+            {
+                "error_type": type(error).__name__,
+                "error": str(error),
+                "reused_folds": candidate.reused_folds,
+                "fitted_folds": candidate.fitted_folds,
+            },
+        )
+        candidate.attempt = None
+
+
+def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) -> None:
+    if candidate.result is not None or candidate.error is not None:
+        return
+    assert candidate.spec is not None
+    assert candidate.context is not None
+    assert candidate.training is not None
+    assert candidate.ledger is not None
+    try:
+        frame, reused, elapsed = _fit_or_reuse_fold(
+            candidate.spec,
+            candidate.context,
+            candidate.training,
+            candidate.ledger,
+            fold,
+        )
+    except Exception as exc:
+        _fail_batch_candidate(candidate, exc)
+        return
+    candidate.frames.append(frame)
+    candidate.fit_elapsed_s += elapsed
+    fold_id = int(fold["fold"])
+    (candidate.reused_folds if reused else candidate.fitted_folds).append(fold_id)
+
+
+def _finish_batch_candidate(study: Study, candidate: _BatchCandidate) -> None:
+    if candidate.result is not None or candidate.error is not None:
+        return
+    assert candidate.spec is not None
+    assert candidate.context is not None
+    assert candidate.training is not None
+    assert candidate.attempt is not None
+    try:
+        if len(candidate.frames) != len(candidate.context.fold_ids):
+            raise RuntimeError(
+                f"linear candidate produced {len(candidate.frames)} of "
+                f"{len(candidate.context.fold_ids)} fold shards"
+            )
+        _write_model_manifest(candidate.training)
+        predictions = pl.concat(candidate.frames).sort("symbol", "timestamp", "fold")
+        prediction = study.results.publish_predictions(
+            candidate.training,
+            checkpoint_kind="final",
+            checkpoint_value=None,
+            split="validation",
+            predictions=predictions,
+            expected_keys=candidate.context.expected_keys,
+            task_type=candidate.context.task_type,
+            class_values=list(candidate.context.class_values) or None,
+            eval_col="eval_actual" if candidate.context.eval_label_col else None,
+            label=candidate.context.label_col,
+        )
+        diagnostics = {
+            "cache_hit": False,
+            "reused_folds": candidate.reused_folds,
+            "fitted_folds": candidate.fitted_folds,
+        }
+        candidate.attempt.finish("completed", diagnostics)
+        candidate.attempt = None
+        runtime_path = (
+            candidate.training.root
+            / "run_log"
+            / "training"
+            / candidate.training.hash
+            / "runtime.json"
+        )
+        _write_runtime_fields(runtime_path, elapsed_s=time.perf_counter() - candidate.started_at_s)
+        candidate.result = ModelRun(candidate.training, (prediction,), diagnostics)
+    except Exception as exc:
+        _fail_batch_candidate(candidate, exc)
+
+
+def _run_batch_group(
+    study: Study,
+    indexed_requests: list[tuple[int, dict[str, Any]]],
+    compatibility_key: str,
+    base: dict[str, Any],
+) -> tuple[list[_BatchCandidate], float, int]:
+    fold_ids = tuple(int(split["fold"]) for split in base["splits"])
+    candidates = []
+    dependent = []
+    for index, request in indexed_requests:
+        config = _load_preset(request["config_name"])
+        effective = _fixed_effective_params(config, request["overrides"], fold_ids)
+        candidate = _BatchCandidate(index, request, config, effective or {})
+        candidates.append(candidate)
+        if effective is None:
+            dependent.append(candidate)
+            continue
+        _resolve_batch_candidate(study, candidate, base)
+    dependent_indices = {candidate.index for candidate in dependent}
+
+    preparation_elapsed_s = 0.0
+    preparation_count = 0
+    first_pass_needed = bool(dependent) or any(
+        candidate.result is None and candidate.error is None for candidate in candidates
+    )
+    if first_pass_needed:
+        for split in base["splits"]:
+            started = time.perf_counter()
+            try:
+                fold = _prepare_batch_fold(base, split)
+            except Exception as exc:
+                for candidate in candidates:
+                    _fail_batch_candidate(candidate, exc)
+                break
+            preparation_elapsed_s += time.perf_counter() - started
+            preparation_count += 1
+            for candidate in dependent:
+                if candidate.error is not None:
+                    continue
+                try:
+                    candidate.effective_params.update(
+                        _effective_params(candidate.config, candidate.request["overrides"], [fold])
+                    )
+                except Exception as exc:
+                    _fail_batch_candidate(candidate, exc)
+            for candidate in candidates:
+                if candidate.index not in dependent_indices:
+                    _run_batch_candidate_fold(candidate, fold)
+            del fold
+
+    for candidate in candidates:
+        if candidate.index not in dependent_indices:
+            _finish_batch_candidate(study, candidate)
+
+    active_dependent = []
+    for candidate in dependent:
+        if candidate.error is not None:
+            continue
+        if set(candidate.effective_params) != {str(fold_id) for fold_id in fold_ids}:
+            _fail_batch_candidate(
+                candidate,
+                RuntimeError("linear candidate did not resolve parameters for every fold"),
+            )
+            continue
+        try:
+            _resolve_batch_candidate(study, candidate, base)
+        except Exception as exc:
+            _fail_batch_candidate(candidate, exc)
+            continue
+        if candidate.result is None:
+            active_dependent.append(candidate)
+
+    if active_dependent:
+        for split in base["splits"]:
+            started = time.perf_counter()
+            try:
+                fold = _prepare_batch_fold(base, split)
+            except Exception as exc:
+                for candidate in active_dependent:
+                    _fail_batch_candidate(candidate, exc)
+                break
+            preparation_elapsed_s += time.perf_counter() - started
+            preparation_count += 1
+            for candidate in active_dependent:
+                _run_batch_candidate_fold(candidate, fold)
+            del fold
+        for candidate in active_dependent:
+            _finish_batch_candidate(study, candidate)
+
+    group_digest = hashlib.sha256(compatibility_key.encode()).hexdigest()[:12]
+    fit_elapsed_s = sum(candidate.fit_elapsed_s for candidate in candidates)
+    measured_s = preparation_elapsed_s + fit_elapsed_s
+    for candidate in candidates:
+        if candidate.result is None or len(candidates) == 1:
+            continue
+        candidate.result.diagnostics.update(
+            {
+                "execution_order": "fold_major",
+                "compatibility_group": group_digest,
+                "compatibility_group_size": len(candidates),
+                "base_fold_preparations": preparation_count,
+                "base_fold_preparation_s": preparation_elapsed_s,
+                "candidate_fit_s": candidate.fit_elapsed_s,
+                "preparation_fraction": (preparation_elapsed_s / measured_s if measured_s else 0.0),
+                "disk_fold_cache": False,
+            }
+        )
+    return candidates, preparation_elapsed_s, preparation_count
+
+
+def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[ModelRun, ...]:
+    if not requests:
+        raise ValueError("linear batch runner requires at least one request")
+    groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        groups.setdefault(_compatibility_key(request), []).append((index, request))
+
+    ordered: list[ModelRun | None] = [None] * len(requests)
+    failures: list[Exception] = []
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    for key, indexed_requests in groups.items():
+        input_key = _input_compatibility_key(indexed_requests[0][1])
+        base = _load_batch_base(
+            study,
+            indexed_requests[0][1],
+            inputs=input_cache.get(input_key),
+        )
+        input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
+        candidates, _, _ = _run_batch_group(study, indexed_requests, key, base)
+        for candidate in candidates:
+            if candidate.error is not None:
+                failures.append(candidate.error)
+            elif candidate.result is not None:
+                ordered[candidate.index] = candidate.result
+    if failures:
+        raise failures[0]
+    if any(result is None for result in ordered):
+        raise RuntimeError("linear batch did not produce every requested result")
+    return tuple(result for result in ordered if result is not None)
 
 
 def run_resolved_request(

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -857,7 +857,7 @@ def _run_batch_group(
     base: dict[str, Any],
     *,
     report_batch: bool,
-) -> tuple[list[_BatchCandidate], float, int]:
+) -> list[_BatchCandidate]:
     fold_ids = tuple(int(split["fold"]) for split in base["splits"])
     candidates = []
     dependent = []
@@ -975,7 +975,7 @@ def _run_batch_group(
                 "disk_fold_cache": False,
             }
         )
-    return candidates, preparation_elapsed_s, preparation_count
+    return candidates
 
 
 def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[ModelRun, ...]:
@@ -996,7 +996,7 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
             inputs=input_cache.get(input_key),
         )
         input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
-        candidates, _, _ = _run_batch_group(
+        candidates = _run_batch_group(
             study,
             indexed_requests,
             key,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -760,6 +760,9 @@ def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) 
     assert candidate.context is not None
     assert candidate.training is not None
     assert candidate.ledger is not None
+    fold_id = int(fold["fold"])
+    if fold_id in candidate.reused_folds or fold_id in candidate.fitted_folds:
+        return
     try:
         frame, reused, elapsed = _fit_or_reuse_fold(
             candidate.spec,
@@ -773,8 +776,31 @@ def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) 
         return
     candidate.frames.append(frame)
     candidate.fit_elapsed_s += elapsed
-    fold_id = int(fold["fold"])
     (candidate.reused_folds if reused else candidate.fitted_folds).append(fold_id)
+
+
+def _reuse_batch_candidate_fold(candidate: _BatchCandidate, fold_id: int) -> bool:
+    if candidate.result is not None or candidate.error is not None:
+        return True
+    assert candidate.spec is not None
+    assert candidate.training is not None
+    assert candidate.ledger is not None
+    params = candidate.spec["computation"]["model"]["effective_params_by_fold"][str(fold_id)]
+    training_dir = candidate.training.root / "run_log" / "training" / candidate.training.hash
+    artifact = training_dir / "models" / f"fold_{fold_id}.joblib"
+    shard = training_dir / "prediction_folds" / f"fold_{fold_id}.parquet"
+    if not candidate.ledger.reusable_fold(
+        training_hash=candidate.training.hash,
+        candidate_identity=candidate.training.hash,
+        fold_id=fold_id,
+        fitted_state=artifact,
+        prediction_shard=shard,
+        resolved_settings=params,
+    ):
+        return False
+    candidate.frames.append(pl.read_parquet(shard))
+    candidate.reused_folds.append(fold_id)
+    return True
 
 
 def _finish_batch_candidate(study: Study, candidate: _BatchCandidate) -> None:
@@ -829,6 +855,8 @@ def _run_batch_group(
     indexed_requests: list[tuple[int, dict[str, Any]]],
     compatibility_key: str,
     base: dict[str, Any],
+    *,
+    report_batch: bool,
 ) -> tuple[list[_BatchCandidate], float, int]:
     fold_ids = tuple(int(split["fold"]) for split in base["splits"])
     candidates = []
@@ -851,6 +879,15 @@ def _run_batch_group(
     )
     if first_pass_needed:
         for split in base["splits"]:
+            fold_id = int(split["fold"])
+            fixed_pending = [
+                candidate
+                for candidate in candidates
+                if candidate.index not in dependent_indices
+                and not _reuse_batch_candidate_fold(candidate, fold_id)
+            ]
+            if not dependent and not fixed_pending:
+                continue
             started = time.perf_counter()
             try:
                 fold = _prepare_batch_fold(base, split)
@@ -869,9 +906,8 @@ def _run_batch_group(
                     )
                 except Exception as exc:
                     _fail_batch_candidate(candidate, exc)
-            for candidate in candidates:
-                if candidate.index not in dependent_indices:
-                    _run_batch_candidate_fold(candidate, fold)
+            for candidate in fixed_pending:
+                _run_batch_candidate_fold(candidate, fold)
             del fold
 
     for candidate in candidates:
@@ -898,6 +934,14 @@ def _run_batch_group(
 
     if active_dependent:
         for split in base["splits"]:
+            fold_id = int(split["fold"])
+            pending = [
+                candidate
+                for candidate in active_dependent
+                if not _reuse_batch_candidate_fold(candidate, fold_id)
+            ]
+            if not pending:
+                continue
             started = time.perf_counter()
             try:
                 fold = _prepare_batch_fold(base, split)
@@ -907,7 +951,7 @@ def _run_batch_group(
                 break
             preparation_elapsed_s += time.perf_counter() - started
             preparation_count += 1
-            for candidate in active_dependent:
+            for candidate in pending:
                 _run_batch_candidate_fold(candidate, fold)
             del fold
         for candidate in active_dependent:
@@ -917,7 +961,7 @@ def _run_batch_group(
     fit_elapsed_s = sum(candidate.fit_elapsed_s for candidate in candidates)
     measured_s = preparation_elapsed_s + fit_elapsed_s
     for candidate in candidates:
-        if candidate.result is None or len(candidates) == 1:
+        if candidate.result is None or not report_batch:
             continue
         candidate.result.diagnostics.update(
             {
@@ -952,7 +996,13 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
             inputs=input_cache.get(input_key),
         )
         input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
-        candidates, _, _ = _run_batch_group(study, indexed_requests, key, base)
+        candidates, _, _ = _run_batch_group(
+            study,
+            indexed_requests,
+            key,
+            base,
+            report_batch=len(requests) > 1,
+        )
         for candidate in candidates:
             if candidate.error is not None:
                 failures.append(candidate.error)

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import shutil
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -67,7 +68,7 @@ def _requests(
     ]
 
 
-def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, object]]:
+def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, Any]]:
     assert len(execution.runs) == 3
     assert execution.catalog_rows.height == 3
     assert set(execution.catalog_rows["execution_tier"]) == {"preview"}
@@ -86,9 +87,9 @@ def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, object]]
         assert sorted(keys["fold"].unique().to_list()) == folds
         assert frame["prediction"].is_finite().all()
         model_dir = run.training.root / "run_log" / "training" / run.training.hash / "models"
-        assert sorted(path.stem for path in model_dir.glob("fold_*.joblib")) == [
+        assert {path.stem for path in model_dir.glob("fold_*.joblib")} == {
             f"fold_{fold}" for fold in folds
-        ]
+        }
         diagnostics[config_name] = dict(run.diagnostics)
     assert (
         diagnostics["ridge_a1.0"]["compatibility_group"]
@@ -100,9 +101,13 @@ def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, object]]
         diagnostics["ridge_a1.0"]["compatibility_group"]
         != diagnostics["ridge_a100.0"]["compatibility_group"]
     )
+    groups: dict[str, list[dict[str, Any]]] = {}
     for item in diagnostics.values():
-        expected_preparations = 0 if item["cache_hit"] else len(folds)
-        assert item["base_fold_preparations"] == expected_preparations
+        groups.setdefault(str(item["compatibility_group"]), []).append(item)
+    for group in groups.values():
+        preparation_counts = {int(item["base_fold_preparations"]) for item in group}
+        prepared_folds = {int(fold) for item in group for fold in item.get("fitted_folds", [])}
+        assert preparation_counts == {len(prepared_folds)}
     assert all(item["disk_fold_cache"] is False for item in diagnostics.values())
     return diagnostics
 
@@ -154,14 +159,12 @@ def prove(
     assert restarted_hashes == first_hashes
     assert all(run.diagnostics["cache_hit"] is True for run in restarted.runs)
     assert all(run.diagnostics["base_fold_preparations"] == 0 for run in restarted.runs)
+    prediction_hashes = [record["prediction"] for record in first_hashes.values()]
     selected = restarted_study.predictions.table(include_preview=True).filter(
-        (pl.col("label") == LABEL)
-        & (pl.col("family") == "linear")
-        & pl.col("config_name").is_in(list(first_hashes))
-        & (pl.col("execution_tier") == "preview")
-        & pl.col("complete")
+        pl.col("prediction_hash").is_in(prediction_hashes)
     )
     assert selected.height == 3
+    assert set(selected["prediction_hash"]) == set(prediction_hashes)
 
     group_measurements = {}
     for item in diagnostics.values():

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -41,6 +41,7 @@ def _seed_worktree_workspace(workspace: Path) -> None:
 def _requests(
     study: Study,
     *,
+    family: str,
     folds: list[int],
     max_symbols: int,
     train_sample_frac: float,
@@ -50,56 +51,69 @@ def _requests(
         "max_symbols": max_symbols,
         "train_sample_frac": train_sample_frac,
     }
+    if family == "gbm":
+        common_reductions.update({"checkpoint_interval": 2, "max_iterations": 4})
     incompatible_reductions = {
         **common_reductions,
         "train_sample_frac": train_sample_frac / 2,
     }
+    config_names = (
+        ("ridge_a1.0", "ridge_a10.0", "ridge_a100.0")
+        if family == "linear"
+        else ("default_mse", "default_huber", "leaves_15_mse")
+    )
     return [
         study.model(
-            family="linear",
+            family=family,
             label=LABEL,
             config_name=config_name,
             execution_tier="preview",
             preview_reductions=(
-                common_reductions if config_name != "ridge_a100.0" else incompatible_reductions
+                common_reductions if config_name != config_names[-1] else incompatible_reductions
             ),
         )
-        for config_name in ("ridge_a1.0", "ridge_a10.0", "ridge_a100.0")
+        for config_name in config_names
     ]
 
 
-def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, Any]]:
+def _assert_results(execution, family: str, folds: list[int]) -> dict[str, dict[str, Any]]:
     assert len(execution.runs) == 3
-    assert execution.catalog_rows.height == 3
+    expected_predictions = 3 if family == "linear" else 6
+    assert execution.catalog_rows.height == expected_predictions
     assert set(execution.catalog_rows["execution_tier"]) == {"preview"}
     diagnostics = {}
     for run in execution.runs:
         spec = run.training.spec()
         config_name = spec["config_name"]
-        prediction = run.predictions[0]
-        frame = prediction.load()
-        coverage = prediction.coverage()
-        keys = frame.select("symbol", "timestamp", "fold")
-        assert prediction.complete
-        assert coverage["status"] == "complete"
-        assert coverage["n_expected"] == coverage["n_actual"] == frame.height
-        assert keys.n_unique(["symbol", "timestamp", "fold"]) == keys.height
-        assert sorted(keys["fold"].unique().to_list()) == folds
-        assert frame["prediction"].is_finite().all()
+        assert len(run.predictions) == (1 if family == "linear" else 2)
+        for prediction in run.predictions:
+            frame = prediction.load()
+            coverage = prediction.coverage()
+            keys = frame.select("symbol", "timestamp", "fold")
+            assert prediction.complete
+            assert coverage["status"] == "complete"
+            assert coverage["n_expected"] == coverage["n_actual"] == frame.height
+            assert keys.n_unique(["symbol", "timestamp", "fold"]) == keys.height
+            assert sorted(keys["fold"].unique().to_list()) == folds
+            assert frame["prediction"].is_finite().all()
         model_dir = run.training.root / "run_log" / "training" / run.training.hash / "models"
-        assert {path.stem for path in model_dir.glob("fold_*.joblib")} == {
-            f"fold_{fold}" for fold in folds
-        }
+        fitted = (
+            model_dir.glob("fold_*.joblib")
+            if family == "linear"
+            else (model_dir / "boosters").glob("fold_*.txt")
+        )
+        assert {path.stem for path in fitted} == {f"fold_{fold}" for fold in folds}
         diagnostics[config_name] = dict(run.diagnostics)
+    config_names = list(diagnostics)
     assert (
-        diagnostics["ridge_a1.0"]["compatibility_group"]
-        == diagnostics["ridge_a10.0"]["compatibility_group"]
+        diagnostics[config_names[0]]["compatibility_group"]
+        == diagnostics[config_names[1]]["compatibility_group"]
     )
-    assert diagnostics["ridge_a1.0"]["compatibility_group_size"] == 2
-    assert diagnostics["ridge_a100.0"]["compatibility_group_size"] == 1
+    assert diagnostics[config_names[0]]["compatibility_group_size"] == 2
+    assert diagnostics[config_names[2]]["compatibility_group_size"] == 1
     assert (
-        diagnostics["ridge_a1.0"]["compatibility_group"]
-        != diagnostics["ridge_a100.0"]["compatibility_group"]
+        diagnostics[config_names[0]]["compatibility_group"]
+        != diagnostics[config_names[2]]["compatibility_group"]
     )
     groups: dict[str, list[dict[str, Any]]] = {}
     for item in diagnostics.values():
@@ -115,6 +129,7 @@ def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, Any]]:
 def prove(
     workspace: Path,
     *,
+    family: str,
     folds: list[int],
     max_symbols: int,
     train_sample_frac: float,
@@ -125,16 +140,17 @@ def prove(
         study,
         requests=_requests(
             study,
+            family=family,
             folds=folds,
             max_symbols=max_symbols,
             train_sample_frac=train_sample_frac,
         ),
     )
-    diagnostics = _assert_results(execution, folds)
+    diagnostics = _assert_results(execution, family, folds)
     first_hashes = {
         run.training.spec()["config_name"]: {
             "training": run.training.hash,
-            "prediction": run.predictions[0].hash,
+            "predictions": [prediction.hash for prediction in run.predictions],
         }
         for run in execution.runs
     }
@@ -144,6 +160,7 @@ def prove(
         restarted_study,
         requests=_requests(
             restarted_study,
+            family=family,
             folds=folds,
             max_symbols=max_symbols,
             train_sample_frac=train_sample_frac,
@@ -152,18 +169,22 @@ def prove(
     restarted_hashes = {
         run.training.spec()["config_name"]: {
             "training": run.training.hash,
-            "prediction": run.predictions[0].hash,
+            "predictions": [prediction.hash for prediction in run.predictions],
         }
         for run in restarted.runs
     }
     assert restarted_hashes == first_hashes
     assert all(run.diagnostics["cache_hit"] is True for run in restarted.runs)
     assert all(run.diagnostics["base_fold_preparations"] == 0 for run in restarted.runs)
-    prediction_hashes = [record["prediction"] for record in first_hashes.values()]
+    prediction_hashes = [
+        prediction_hash
+        for record in first_hashes.values()
+        for prediction_hash in record["predictions"]
+    ]
     selected = restarted_study.predictions.table(include_preview=True).filter(
         pl.col("prediction_hash").is_in(prediction_hashes)
     )
-    assert selected.height == 3
+    assert selected.height == len(prediction_hashes)
     assert set(selected["prediction_hash"]) == set(prediction_hashes)
 
     group_measurements = {}
@@ -183,6 +204,7 @@ def prove(
         ]
 
     return {
+        "family": family,
         "folds": folds,
         "groups": group_measurements,
         "hashes": first_hashes,
@@ -196,6 +218,7 @@ def prove(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("workspace", type=Path)
+    parser.add_argument("--family", choices=("gbm", "linear"), default="linear")
     parser.add_argument("--folds", nargs="+", type=int, default=[0, 1])
     parser.add_argument("--max-symbols", type=int, default=50)
     parser.add_argument("--train-sample-frac", type=float, default=0.05)
@@ -204,6 +227,7 @@ def main() -> None:
         json.dumps(
             prove(
                 args.workspace,
+                family=args.family,
                 folds=sorted(set(args.folds)),
                 max_symbols=args.max_symbols,
                 train_sample_frac=args.train_sample_frac,

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -4,14 +4,37 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 
 import polars as pl
 
 from case_studies.research import Study, run_models
+from utils.paths import REPO_ROOT
 
 CASE_STUDY = "us_equities_panel"
 LABEL = "fwd_ret_1d"
+
+
+def _seed_worktree_workspace(workspace: Path) -> None:
+    target = workspace.resolve() / CASE_STUDY
+    if target.exists():
+        return
+    release_case = REPO_ROOT / "case_studies" / CASE_STUDY
+    if not (release_case / "run_log").is_symlink():
+        return
+    workspace.mkdir(parents=True, exist_ok=True)
+    target.mkdir()
+    (target / "run_log").mkdir()
+    shutil.copytree(release_case / "config", target / "config")
+    if not (workspace / "config").exists():
+        shutil.copytree(REPO_ROOT / "case_studies" / "config", workspace / "config")
+    for name in ("features", "labels"):
+        source = (release_case / name).resolve(strict=True)
+        (target / name).symlink_to(source, target_is_directory=True)
+    (target / ".study.json").write_text(
+        json.dumps({"schema_version": 1, "case_study": CASE_STUDY}, sort_keys=True) + "\n"
+    )
 
 
 def _requests(
@@ -77,8 +100,9 @@ def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, object]]
         diagnostics["ridge_a1.0"]["compatibility_group"]
         != diagnostics["ridge_a100.0"]["compatibility_group"]
     )
-    assert diagnostics["ridge_a1.0"]["base_fold_preparations"] == len(folds)
-    assert diagnostics["ridge_a100.0"]["base_fold_preparations"] == len(folds)
+    for item in diagnostics.values():
+        expected_preparations = 0 if item["cache_hit"] else len(folds)
+        assert item["base_fold_preparations"] == expected_preparations
     assert all(item["disk_fold_cache"] is False for item in diagnostics.values())
     return diagnostics
 
@@ -90,6 +114,7 @@ def prove(
     max_symbols: int,
     train_sample_frac: float,
 ) -> dict[str, object]:
+    _seed_worktree_workspace(workspace)
     study = Study.open(CASE_STUDY, workspace=workspace)
     execution = run_models(
         study,
@@ -128,6 +153,7 @@ def prove(
     }
     assert restarted_hashes == first_hashes
     assert all(run.diagnostics["cache_hit"] is True for run in restarted.runs)
+    assert all(run.diagnostics["base_fold_preparations"] == 0 for run in restarted.runs)
     selected = restarted_study.predictions.table(include_preview=True).filter(
         (pl.col("label") == LABEL)
         & (pl.col("family") == "linear")

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -1,0 +1,189 @@
+"""Run the reduced real-data proof for US-equities fold-major execution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.research import Study, run_models
+
+CASE_STUDY = "us_equities_panel"
+LABEL = "fwd_ret_1d"
+
+
+def _requests(
+    study: Study,
+    *,
+    folds: list[int],
+    max_symbols: int,
+    train_sample_frac: float,
+):
+    common_reductions = {
+        "folds": folds,
+        "max_symbols": max_symbols,
+        "train_sample_frac": train_sample_frac,
+    }
+    incompatible_reductions = {
+        **common_reductions,
+        "train_sample_frac": train_sample_frac / 2,
+    }
+    return [
+        study.model(
+            family="linear",
+            label=LABEL,
+            config_name=config_name,
+            execution_tier="preview",
+            preview_reductions=(
+                common_reductions if config_name != "ridge_a100.0" else incompatible_reductions
+            ),
+        )
+        for config_name in ("ridge_a1.0", "ridge_a10.0", "ridge_a100.0")
+    ]
+
+
+def _assert_results(execution, folds: list[int]) -> dict[str, dict[str, object]]:
+    assert len(execution.runs) == 3
+    assert execution.catalog_rows.height == 3
+    assert set(execution.catalog_rows["execution_tier"]) == {"preview"}
+    diagnostics = {}
+    for run in execution.runs:
+        spec = run.training.spec()
+        config_name = spec["config_name"]
+        prediction = run.predictions[0]
+        frame = prediction.load()
+        coverage = prediction.coverage()
+        keys = frame.select("symbol", "timestamp", "fold")
+        assert prediction.complete
+        assert coverage["status"] == "complete"
+        assert coverage["n_expected"] == coverage["n_actual"] == frame.height
+        assert keys.n_unique(["symbol", "timestamp", "fold"]) == keys.height
+        assert sorted(keys["fold"].unique().to_list()) == folds
+        assert frame["prediction"].is_finite().all()
+        model_dir = run.training.root / "run_log" / "training" / run.training.hash / "models"
+        assert sorted(path.stem for path in model_dir.glob("fold_*.joblib")) == [
+            f"fold_{fold}" for fold in folds
+        ]
+        diagnostics[config_name] = dict(run.diagnostics)
+    assert (
+        diagnostics["ridge_a1.0"]["compatibility_group"]
+        == diagnostics["ridge_a10.0"]["compatibility_group"]
+    )
+    assert diagnostics["ridge_a1.0"]["compatibility_group_size"] == 2
+    assert diagnostics["ridge_a100.0"]["compatibility_group_size"] == 1
+    assert (
+        diagnostics["ridge_a1.0"]["compatibility_group"]
+        != diagnostics["ridge_a100.0"]["compatibility_group"]
+    )
+    assert diagnostics["ridge_a1.0"]["base_fold_preparations"] == len(folds)
+    assert diagnostics["ridge_a100.0"]["base_fold_preparations"] == len(folds)
+    assert all(item["disk_fold_cache"] is False for item in diagnostics.values())
+    return diagnostics
+
+
+def prove(
+    workspace: Path,
+    *,
+    folds: list[int],
+    max_symbols: int,
+    train_sample_frac: float,
+) -> dict[str, object]:
+    study = Study.open(CASE_STUDY, workspace=workspace)
+    execution = run_models(
+        study,
+        requests=_requests(
+            study,
+            folds=folds,
+            max_symbols=max_symbols,
+            train_sample_frac=train_sample_frac,
+        ),
+    )
+    diagnostics = _assert_results(execution, folds)
+    first_hashes = {
+        run.training.spec()["config_name"]: {
+            "training": run.training.hash,
+            "prediction": run.predictions[0].hash,
+        }
+        for run in execution.runs
+    }
+
+    restarted_study = Study.open(CASE_STUDY, workspace=workspace)
+    restarted = run_models(
+        restarted_study,
+        requests=_requests(
+            restarted_study,
+            folds=folds,
+            max_symbols=max_symbols,
+            train_sample_frac=train_sample_frac,
+        ),
+    )
+    restarted_hashes = {
+        run.training.spec()["config_name"]: {
+            "training": run.training.hash,
+            "prediction": run.predictions[0].hash,
+        }
+        for run in restarted.runs
+    }
+    assert restarted_hashes == first_hashes
+    assert all(run.diagnostics["cache_hit"] is True for run in restarted.runs)
+    selected = restarted_study.predictions.table(include_preview=True).filter(
+        (pl.col("label") == LABEL)
+        & (pl.col("family") == "linear")
+        & pl.col("config_name").is_in(list(first_hashes))
+        & (pl.col("execution_tier") == "preview")
+        & pl.col("complete")
+    )
+    assert selected.height == 3
+
+    group_measurements = {}
+    for item in diagnostics.values():
+        group_measurements.setdefault(
+            item["compatibility_group"],
+            {
+                "base_fold_preparation_s": item["base_fold_preparation_s"],
+                "base_fold_preparations": item["base_fold_preparations"],
+                "candidate_fit_s": 0.0,
+                "group_size": item["compatibility_group_size"],
+                "preparation_fraction": item["preparation_fraction"],
+            },
+        )
+        group_measurements[item["compatibility_group"]]["candidate_fit_s"] += item[
+            "candidate_fit_s"
+        ]
+
+    return {
+        "folds": folds,
+        "groups": group_measurements,
+        "hashes": first_hashes,
+        "max_symbols": max_symbols,
+        "selected_catalog_rows": selected.height,
+        "train_sample_frac": train_sample_frac,
+        "workspace": str(study.storage_root("preview")),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workspace", type=Path)
+    parser.add_argument("--folds", nargs="+", type=int, default=[0, 1])
+    parser.add_argument("--max-symbols", type=int, default=50)
+    parser.add_argument("--train-sample-frac", type=float, default=0.05)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            prove(
+                args.workspace,
+                folds=sorted(set(args.folds)),
+                max_symbols=args.max_symbols,
+                train_sample_frac=args.train_sample_frac,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -413,6 +413,7 @@ def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
     assert recovered_by_alpha[2.0].diagnostics["reused_folds"] == [0]
     assert recovered_by_alpha[2.0].diagnostics["fitted_folds"] == [1]
     assert recovered_by_alpha[2.0].diagnostics["base_fold_preparations"] == 1
+    assert {run.diagnostics["base_fold_preparations"] for run in recovered.runs} == {1}
     assert study.predictions.table().filter(pl.col("complete")).height == 3
 
 

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -742,6 +742,283 @@ def test_gbm_runner_persists_every_declared_checkpoint(tmp_path, monkeypatch) ->
     ]
 
 
+def test_gbm_batch_is_fold_major_and_matches_individual_execution(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path / "batch", monkeypatch)
+    individual_study = _gbm_study(tmp_path / "individual", monkeypatch)
+    original_prepare = gbm_utils.prepare_gbm_folds
+    prepared: list[list[int]] = []
+    released_arrays: list[weakref.ReferenceType[np.ndarray]] = []
+
+    def observed_prepare(dataset, splits, *args, **kwargs):
+        gc.collect()
+        if released_arrays:
+            assert released_arrays[-1]() is None
+        prepared.append([int(split["fold"]) for split in splits])
+        folds = original_prepare(dataset, splits, *args, **kwargs)
+        released_arrays.append(weakref.ref(folds[0]["X_train"]))
+        return folds
+
+    monkeypatch.setattr(gbm_utils, "prepare_gbm_folds", observed_prepare)
+    requests = [
+        study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63, "learning_rate": learning_rate},
+        )
+        for learning_rate in (0.1, 0.2)
+    ]
+
+    batch = run_models(study, requests=requests)
+    batch_preparations = list(prepared)
+    monkeypatch.setattr(gbm_utils, "prepare_gbm_folds", original_prepare)
+    individual = (
+        individual_study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63, "learning_rate": 0.1},
+        )
+        .resolve()
+        .run()
+    )
+    gc.collect()
+
+    assert batch_preparations == [[0], [1]]
+    assert released_arrays[-1]() is None
+    assert batch.runs[0].training.hash == individual.training.hash
+    assert [prediction.hash for prediction in batch.runs[0].predictions] == [
+        prediction.hash for prediction in individual.predictions
+    ]
+    for batch_prediction, individual_prediction in zip(
+        batch.runs[0].predictions,
+        individual.predictions,
+        strict=True,
+    ):
+        assert batch_prediction.load().equals(individual_prediction.load())
+    assert all(run.diagnostics["execution_order"] == "fold_major" for run in batch.runs)
+    assert all(run.diagnostics["compatibility_group_size"] == 2 for run in batch.runs)
+    assert all(run.diagnostics["base_fold_preparations"] == 2 for run in batch.runs)
+    assert all(run.diagnostics["disk_fold_cache"] is False for run in batch.runs)
+
+
+def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    original_prepare = gbm_utils.prepare_gbm_folds
+    prepared: list[int] = []
+
+    def configs(*_args, **_kwargs):
+        common = {
+            "checkpoint_interval": 2,
+            "family": "gbm",
+            "library": "lightgbm",
+            "max_iterations": 4,
+        }
+        return [
+            {
+                **common,
+                "config_name": "mse",
+                "params": {"learning_rate": 0.1, "objective": "regression"},
+            },
+            {
+                **common,
+                "config_name": "huber",
+                "huber_alpha_scale": 0.5,
+                "params": {"learning_rate": 0.1, "objective": "huber"},
+            },
+        ]
+
+    def observed_prepare(*args, **kwargs):
+        folds = original_prepare(*args, **kwargs)
+        prepared.extend(int(fold["fold"]) for fold in folds)
+        return folds
+
+    monkeypatch.setattr(modeling, "load_configs", configs)
+    monkeypatch.setattr(gbm_utils, "prepare_gbm_folds", observed_prepare)
+
+    batch = run_models(
+        study,
+        requests=[
+            study.model(
+                family="gbm",
+                label="fwd_ret_1d",
+                config_name=config_name,
+                overrides={"device": "cpu", "max_bin": 63},
+            )
+            for config_name in ("mse", "huber")
+        ],
+    )
+
+    assert prepared == [0, 1, 0, 1]
+    params = batch.runs[1].training.spec()["computation"]["model"]["effective_params_by_fold"]
+    assert params["0"]["alpha"] > 0
+    assert params["1"]["alpha"] > 0
+    assert all(run.diagnostics["base_fold_preparations"] == 4 for run in batch.runs)
+
+
+def test_gbm_batch_separates_sampling_and_is_order_invariant(tmp_path, monkeypatch) -> None:
+    first = _gbm_study(tmp_path / "first", monkeypatch)
+    second = _gbm_study(tmp_path / "second", monkeypatch)
+    original_prepare = gbm_utils.prepare_gbm_folds
+    original_load = modeling.load_modeling_dataset
+    preparation: list[tuple[int, float]] = []
+    load_count = 0
+
+    def observed_load(*args, **kwargs):
+        nonlocal load_count
+        load_count += 1
+        return original_load(*args, **kwargs)
+
+    def observed_prepare(*args, **kwargs):
+        folds = original_prepare(*args, **kwargs)
+        preparation.extend(
+            (int(fold["fold"]), float(kwargs["train_sample_frac"])) for fold in folds
+        )
+        return folds
+
+    monkeypatch.setattr(modeling, "load_modeling_dataset", observed_load)
+    monkeypatch.setattr(gbm_utils, "prepare_gbm_folds", observed_prepare)
+
+    def requests(study, order):
+        return [
+            study.model(
+                family="gbm",
+                label="fwd_ret_1d",
+                config_name="leaves_7_mse",
+                overrides={
+                    "device": "cpu",
+                    "learning_rate": learning_rate,
+                    "max_bin": 63,
+                },
+                execution_tier="preview",
+                preview_reductions={
+                    "folds": [0, 1],
+                    "train_sample_frac": sample,
+                },
+            )
+            for learning_rate, sample in order
+        ]
+
+    forward = run_models(
+        first,
+        requests=requests(first, [(0.1, 0.75), (0.2, 0.75), (0.3, 0.5)]),
+    )
+    forward_preparation = list(preparation)
+    forward_load_count = load_count
+    preparation.clear()
+    load_count = 0
+    reverse = run_models(
+        second,
+        requests=requests(second, [(0.3, 0.5), (0.2, 0.75), (0.1, 0.75)]),
+    )
+
+    assert forward_preparation == [(0, 0.75), (1, 0.75), (0, 0.5), (1, 0.5)]
+    assert forward_load_count == 1
+    assert preparation == [(0, 0.5), (1, 0.5), (0, 0.75), (1, 0.75)]
+    assert load_count == 1
+    forward_by_rate = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"][
+            "learning_rate"
+        ]: run
+        for run in forward.runs
+    }
+    reverse_by_rate = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"][
+            "learning_rate"
+        ]: run
+        for run in reverse.runs
+    }
+    assert set(forward_by_rate) == set(reverse_by_rate) == {0.1, 0.2, 0.3}
+    for learning_rate in forward_by_rate:
+        assert (
+            forward_by_rate[learning_rate].training.hash
+            == reverse_by_rate[learning_rate].training.hash
+        )
+        for forward_prediction, reverse_prediction in zip(
+            forward_by_rate[learning_rate].predictions,
+            reverse_by_rate[learning_rate].predictions,
+            strict=True,
+        ):
+            assert forward_prediction.load().equals(reverse_prediction.load())
+
+
+def test_gbm_batch_failure_preserves_siblings_and_completed_folds(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    original_train = gbm_utils.train_gbm_config
+    rate_two_fits = 0
+
+    def interrupted_train(*args, **kwargs):
+        nonlocal rate_two_fits
+        params = next(iter(kwargs["effective_params_by_fold"].values()))
+        if params["learning_rate"] == 0.2:
+            rate_two_fits += 1
+            if rate_two_fits == 2:
+                raise RuntimeError("injected GBM candidate failure")
+        return original_train(*args, **kwargs)
+
+    monkeypatch.setattr(gbm_utils, "train_gbm_config", interrupted_train)
+    requests = [
+        study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63, "learning_rate": rate},
+        )
+        for rate in (0.1, 0.2, 0.3)
+    ]
+
+    with pytest.raises(RuntimeError, match="injected GBM candidate failure"):
+        run_models(study, requests=requests)
+
+    assert study.predictions.table().filter(pl.col("complete")).height == 4
+    monkeypatch.setattr(gbm_utils, "train_gbm_config", original_train)
+    recovered = run_models(study, requests=requests)
+    recovered_by_rate = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"][
+            "learning_rate"
+        ]: run
+        for run in recovered.runs
+    }
+
+    assert recovered_by_rate[0.1].diagnostics["cache_hit"] is True
+    assert recovered_by_rate[0.3].diagnostics["cache_hit"] is True
+    assert recovered_by_rate[0.2].diagnostics["reused_folds"] == [0]
+    assert recovered_by_rate[0.2].diagnostics["fitted_folds"] == [1]
+    assert {run.diagnostics["base_fold_preparations"] for run in recovered.runs} == {1}
+    assert study.predictions.table().filter(pl.col("complete")).height == 6
+
+
+def test_gbm_batch_rejects_a_modified_booster(tmp_path, monkeypatch) -> None:
+    study = _gbm_study(tmp_path, monkeypatch)
+    requests = [
+        study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63, "learning_rate": rate},
+        )
+        for rate in (0.1, 0.2)
+    ]
+    first = run_models(study, requests=requests)
+    artifact = (
+        first.runs[0].training.root
+        / "run_log"
+        / "training"
+        / first.runs[0].training.hash
+        / "models"
+        / "boosters"
+        / "fold_0.txt"
+    )
+    artifact.write_text("modified\n")
+
+    recovered = run_models(study, requests=requests)
+
+    assert recovered.runs[0].diagnostics["reused_folds"] == [1]
+    assert recovered.runs[0].diagnostics["fitted_folds"] == [0]
+    assert recovered.runs[0].diagnostics["base_fold_preparations"] == 1
+    assert recovered.runs[1].diagnostics["cache_hit"] is True
+
+
 def test_gbm_request_uses_setup_execution_config_then_request_overrides(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -236,6 +236,60 @@ def test_linear_batch_is_fold_major_and_matches_individual_execution(tmp_path, m
     assert all(run.diagnostics["disk_fold_cache"] is False for run in batch.runs)
 
 
+def test_linear_batch_resolves_fold_dependent_parameters_before_fitting(
+    tmp_path, monkeypatch
+) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    original_prepare = modeling.prepare_single_fold
+    prepared_folds: list[int] = []
+
+    def load_preset(config_name):
+        if config_name == "lasso":
+            return {
+                "config_name": config_name,
+                "family": "linear",
+                "library": "sklearn",
+                "model_class": "Lasso",
+                "params": {"alpha_frac": 0.5, "max_iter": 5000},
+            }
+        return {
+            "config_name": config_name,
+            "family": "linear",
+            "library": "sklearn",
+            "model_class": "Ridge",
+            "params": {"alpha": 1.0},
+        }
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        assert fold is not None
+        prepared_folds.append(int(fold["fold"]))
+        return fold
+
+    monkeypatch.setattr(linear, "_load_preset", load_preset)
+    monkeypatch.setattr(linear, "prepare_single_fold", observed_prepare, raising=False)
+
+    batch = run_models(
+        study,
+        requests=[
+            study.model(
+                family="linear",
+                label="fwd_ret_1d",
+                config_name=config_name,
+            )
+            for config_name in ("ridge", "lasso")
+        ],
+    )
+
+    assert prepared_folds == [0, 1, 0, 1]
+    assert all(run.predictions[0].complete for run in batch.runs)
+    lasso_params = batch.runs[1].training.spec()["computation"]["model"]["effective_params_by_fold"]
+    assert set(lasso_params) == {"0", "1"}
+    assert all(params["alpha"] > 0 for params in lasso_params.values())
+    assert all("alpha_frac" not in params for params in lasso_params.values())
+    assert all(run.diagnostics["base_fold_preparations"] == 4 for run in batch.runs)
+
+
 def test_linear_batch_separates_incompatible_sampling_and_is_order_invariant(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import gc
 import json
 import os
+import weakref
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -18,6 +20,7 @@ from case_studies.research import (
     get_adapter,
     register_adapter,
     registered_adapters,
+    run_models,
 )
 from case_studies.research.results import ResultsCatalog
 from case_studies.utils import gbm as gbm_utils
@@ -173,6 +176,251 @@ def test_linear_runner_persists_complete_reusable_result(tmp_path, monkeypatch) 
         "fold_0.joblib",
         "fold_1.joblib",
     ]
+
+
+def test_linear_batch_is_fold_major_and_matches_individual_execution(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path / "batch", monkeypatch)
+    individual_study = _linear_study(tmp_path / "individual", monkeypatch)
+    original_prepare = modeling.prepare_single_fold
+    prepared_folds: list[int] = []
+    released_arrays: list[weakref.ReferenceType[np.ndarray]] = []
+
+    def observed_prepare(*args, **kwargs):
+        gc.collect()
+        if released_arrays:
+            assert released_arrays[-1]() is None
+        fold = original_prepare(*args, **kwargs)
+        assert fold is not None
+        prepared_folds.append(int(fold["fold"]))
+        released_arrays.append(weakref.ref(fold["X_train"]))
+        return fold
+
+    monkeypatch.setattr(linear, "prepare_single_fold", observed_prepare, raising=False)
+    requests = [
+        study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        for alpha in (1.0, 2.0)
+    ]
+
+    batch = run_models(study, requests=requests)
+    batch_prepared_folds = list(prepared_folds)
+    monkeypatch.setattr(linear, "prepare_single_fold", original_prepare)
+    individual = individual_study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        overrides={"alpha": 1.0},
+    ).run()
+    gc.collect()
+
+    assert batch_prepared_folds == [0, 1]
+    assert released_arrays[-1]() is None
+    assert batch.runs[0].training.hash == individual.training.hash
+    batch_predictions = batch.runs[0].predictions[0].load()
+    individual_predictions = individual.predictions[0].load()
+    assert batch_predictions.select("symbol", "timestamp", "fold", "actual").equals(
+        individual_predictions.select("symbol", "timestamp", "fold", "actual")
+    )
+    np.testing.assert_allclose(
+        batch_predictions["prediction"],
+        individual_predictions["prediction"],
+        rtol=1e-12,
+        atol=1e-15,
+    )
+    assert all(run.diagnostics["execution_order"] == "fold_major" for run in batch.runs)
+    assert all(run.diagnostics["compatibility_group_size"] == 2 for run in batch.runs)
+    assert all(run.diagnostics["disk_fold_cache"] is False for run in batch.runs)
+
+
+def test_linear_batch_separates_incompatible_sampling_and_is_order_invariant(
+    tmp_path, monkeypatch
+) -> None:
+    first = _linear_study(tmp_path / "first", monkeypatch)
+    second = _linear_study(tmp_path / "second", monkeypatch)
+    original_prepare = modeling.prepare_single_fold
+    original_load = linear.load_modeling_dataset
+    preparation: list[tuple[int, float]] = []
+    load_count = 0
+
+    def observed_load(*args, **kwargs):
+        nonlocal load_count
+        load_count += 1
+        return original_load(*args, **kwargs)
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        assert fold is not None
+        preparation.append((int(fold["fold"]), float(kwargs["train_sample_frac"])))
+        return fold
+
+    monkeypatch.setattr(linear, "prepare_single_fold", observed_prepare, raising=False)
+    monkeypatch.setattr(linear, "load_modeling_dataset", observed_load)
+
+    def requests(study, order):
+        return [
+            study.model(
+                family="linear",
+                label="fwd_ret_1d",
+                config_name="ridge",
+                overrides={"alpha": alpha},
+                execution_tier="preview",
+                preview_reductions={
+                    "folds": [0, 1],
+                    "train_sample_frac": sample,
+                },
+            )
+            for alpha, sample in order
+        ]
+
+    forward = run_models(
+        first,
+        requests=requests(first, [(1.0, 0.75), (2.0, 0.75), (3.0, 0.5)]),
+    )
+    forward_preparation = list(preparation)
+    forward_load_count = load_count
+    preparation.clear()
+    load_count = 0
+    reverse = run_models(
+        second,
+        requests=requests(second, [(3.0, 0.5), (2.0, 0.75), (1.0, 0.75)]),
+    )
+
+    assert forward_preparation == [(0, 0.75), (1, 0.75), (0, 0.5), (1, 0.5)]
+    assert forward_load_count == 1
+    assert preparation == [(0, 0.5), (1, 0.5), (0, 0.75), (1, 0.75)]
+    assert load_count == 1
+    forward_by_alpha = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"]["alpha"]: run
+        for run in forward.runs
+    }
+    reverse_by_alpha = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"]["alpha"]: run
+        for run in reverse.runs
+    }
+    assert set(forward_by_alpha) == set(reverse_by_alpha) == {1.0, 2.0, 3.0}
+    for alpha in forward_by_alpha:
+        assert forward_by_alpha[alpha].training.hash == reverse_by_alpha[alpha].training.hash
+        assert (
+            forward_by_alpha[alpha]
+            .predictions[0]
+            .load()
+            .equals(reverse_by_alpha[alpha].predictions[0].load())
+        )
+
+
+def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
+    tmp_path, monkeypatch
+) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    original_fit = linear.Ridge.fit
+    alpha_two_fits = 0
+
+    def interrupted_fit(model, *args, **kwargs):
+        nonlocal alpha_two_fits
+        if model.alpha == 2.0:
+            alpha_two_fits += 1
+            if alpha_two_fits == 2:
+                raise RuntimeError("injected candidate failure")
+        return original_fit(model, *args, **kwargs)
+
+    monkeypatch.setattr(linear.Ridge, "fit", interrupted_fit)
+    requests = [
+        study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        for alpha in (1.0, 2.0, 3.0)
+    ]
+
+    with pytest.raises(RuntimeError, match="injected candidate failure"):
+        run_models(study, requests=requests)
+
+    completed = study.predictions.table().filter(pl.col("complete"))
+    assert completed.height == 2
+    monkeypatch.setattr(linear.Ridge, "fit", original_fit)
+    recovered = run_models(study, requests=requests)
+    recovered_by_alpha = {
+        run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"]["alpha"]: run
+        for run in recovered.runs
+    }
+
+    assert recovered_by_alpha[1.0].diagnostics["cache_hit"] is True
+    assert recovered_by_alpha[3.0].diagnostics["cache_hit"] is True
+    assert recovered_by_alpha[2.0].diagnostics["reused_folds"] == [0]
+    assert recovered_by_alpha[2.0].diagnostics["fitted_folds"] == [1]
+    assert study.predictions.table().filter(pl.col("complete")).height == 3
+
+
+def test_linear_batch_rejects_a_modified_fitted_preprocessor(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    requests = [
+        study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        for alpha in (1.0, 2.0)
+    ]
+    first = run_models(study, requests=requests)
+    artifact = (
+        first.runs[0].training.root
+        / "run_log"
+        / "training"
+        / first.runs[0].training.hash
+        / "models"
+        / "fold_0.joblib"
+    )
+    payload = linear.joblib.load(artifact)
+    payload["preprocessor"][-1].mean_[0] += 1.0
+    linear.joblib.dump(payload, artifact)
+
+    recovered = run_models(study, requests=requests)
+
+    assert recovered.runs[0].diagnostics["reused_folds"] == [1]
+    assert recovered.runs[0].diagnostics["fitted_folds"] == [0]
+    assert recovered.runs[1].diagnostics["cache_hit"] is True
+
+
+def test_linear_feature_order_and_random_state_are_identity_bearing(tmp_path, monkeypatch) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    original_load = linear.load_modeling_dataset
+    base = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+    ).resolve()
+    changed_seed = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+        overrides={"random_state": 7},
+    ).resolve()
+    modeling_dataset = original_load("etfs", "fwd_ret_1d")
+    reversed_lineage = dict(modeling_dataset.input_lineage)
+    reversed_lineage["feature_names"] = ["x2", "x1"]
+    reversed_features = SimpleNamespace(
+        **{
+            **vars(modeling_dataset),
+            "feature_names": ["x2", "x1"],
+            "input_lineage": reversed_lineage,
+        }
+    )
+    monkeypatch.setattr(linear, "load_modeling_dataset", lambda *args, **kwargs: reversed_features)
+    changed_order = study.model(
+        family="linear",
+        label="fwd_ret_1d",
+        config_name="ridge",
+    ).resolve()
+
+    assert base.identity != changed_seed.identity
+    assert base.identity != changed_order.identity
 
 
 def test_linear_runner_replays_valid_models_after_registration_interrupt(

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -354,6 +354,7 @@ def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
     assert recovered_by_alpha[3.0].diagnostics["cache_hit"] is True
     assert recovered_by_alpha[2.0].diagnostics["reused_folds"] == [0]
     assert recovered_by_alpha[2.0].diagnostics["fitted_folds"] == [1]
+    assert recovered_by_alpha[2.0].diagnostics["base_fold_preparations"] == 1
     assert study.predictions.table().filter(pl.col("complete")).height == 3
 
 
@@ -385,6 +386,7 @@ def test_linear_batch_rejects_a_modified_fitted_preprocessor(tmp_path, monkeypat
 
     assert recovered.runs[0].diagnostics["reused_folds"] == [1]
     assert recovered.runs[0].diagnostics["fitted_folds"] == [0]
+    assert recovered.runs[0].diagnostics["base_fold_preparations"] == 1
     assert recovered.runs[1].diagnostics["cache_hit"] is True
 
 

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -806,6 +806,7 @@ def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatc
     study = _gbm_study(tmp_path, monkeypatch)
     original_prepare = gbm_utils.prepare_gbm_folds
     prepared: list[int] = []
+    prepared_label_std: dict[str, float] = {}
 
     def configs(*_args, **_kwargs):
         common = {
@@ -831,6 +832,9 @@ def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatc
     def observed_prepare(*args, **kwargs):
         folds = original_prepare(*args, **kwargs)
         prepared.extend(int(fold["fold"]) for fold in folds)
+        prepared_label_std.update(
+            {str(int(fold["fold"])): float(np.std(fold["y_train"])) for fold in folds}
+        )
         return folds
 
     monkeypatch.setattr(modeling, "load_configs", configs)
@@ -849,11 +853,11 @@ def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatc
         ],
     )
 
-    assert prepared == [0, 1, 0, 1]
+    assert prepared == [0, 1]
     params = batch.runs[1].training.spec()["computation"]["model"]["effective_params_by_fold"]
-    assert params["0"]["alpha"] > 0
-    assert params["1"]["alpha"] > 0
-    assert all(run.diagnostics["base_fold_preparations"] == 4 for run in batch.runs)
+    assert params["0"]["alpha"] == pytest.approx(0.5 * prepared_label_std["0"])
+    assert params["1"]["alpha"] == pytest.approx(0.5 * prepared_label_std["1"])
+    assert all(run.diagnostics["base_fold_preparations"] == 2 for run in batch.runs)
 
 
 def test_gbm_batch_separates_sampling_and_is_order_invariant(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -209,12 +209,16 @@ def test_linear_batch_is_fold_major_and_matches_individual_execution(tmp_path, m
     batch = run_models(study, requests=requests)
     batch_prepared_folds = list(prepared_folds)
     monkeypatch.setattr(linear, "prepare_single_fold", original_prepare)
-    individual = individual_study.model(
-        family="linear",
-        label="fwd_ret_1d",
-        config_name="ridge",
-        overrides={"alpha": 1.0},
-    ).run()
+    individual = (
+        individual_study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": 1.0},
+        )
+        .resolve()
+        .run()
+    )
     gc.collect()
 
     assert batch_prepared_folds == [0, 1]

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1686,6 +1686,7 @@ def prepare_single_fold(
         "entities": entities,
         "n_train": n_train,
         "n_val": n_val,
+        "preprocessor": preprocessor,
     }
 
 


### PR DESCRIPTION
## Summary

- batch compatible linear and gradient-boosting requests by fold while preserving separate immutable identities and artifacts
- persist and digest-check every completed candidate/fold fit so retries reuse valid work and isolate failures
- preserve individual and batch equivalence, including fold-dependent linear parameters and GBM Huber thresholds
- avoid repeated feature-fold preparation when resolving sampled Huber thresholds
- add reduced real-data linear and GBM proofs and retain the evidence-based no-disk-cache decision

## Validation

- `52 passed` in the model-family test module
- `55 passed` in the research execution, catalog, registry, and workspace contract suite
- `1980 passed, 18 skipped` in the configured non-notebook suite
- changed-path Ruff lint and format checks passed
- `ty` reported only the six pre-existing optional-library attribute warnings outside the new paths
- all pre-commit hooks passed
- mandatory RoboRev review passed with no findings
- reduced real-data linear proof passed for two compatible Ridge candidates and one incompatible candidate across two folds
- reduced real-data GBM proof passed for compatible MSE and Huber candidates plus one sampling-incompatible candidate, two folds, two checkpoints, exact validation coverage, fitted-state persistence, Polars selection, and clean-process restart with zero repeated fold preparation

The GBM proof measured fold preparation at 83.9% of the compatible group's deliberately four-tree reduced run. The implementation removes the avoidable second Huber preparation pass. It does not add a disk cache because production prepares each compatible fold once, completed candidate/fold artifacts already make restart preparation zero, and a disk cache would add large overlapping panel artifacts without a demonstrated production benefit.

This PR does not execute production notebooks or write the canonical registry.
