### PR TITLE
Complete fold-major TabM execution and recovery

### DIFF
--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -481,6 +481,22 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
         )
     except ValueError:
         return None
+    diagnostics = training.root / "run_log" / "training" / training.hash / "diagnostics"
+    required = {
+        "all_predictions.parquet",
+        "learning_curves.parquet",
+        "predictions.parquet",
+        "result.json",
+        "training_log.parquet",
+    }
+    if not diagnostics.is_dir() or required - {path.name for path in diagnostics.iterdir()}:
+        return None
+    try:
+        for name in required - {"result.json"}:
+            pl.read_parquet(diagnostics / name)
+        json.loads((diagnostics / "result.json").read_text())
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
     return ModelRun(training=training, predictions=complete_predictions)
 
 
@@ -593,6 +609,10 @@ class _TabMRecovery:
         )
         return manifest, shard
 
+    def _diagnostic_path(self, candidate_key: str, fold_id: int) -> Path:
+        _, shard = self._paths(candidate_key, fold_id)
+        return shard.with_suffix(".json")
+
     def _settings(self, candidate_key: str, fold_id: int) -> dict[str, Any]:
         candidate = self.candidates[candidate_key]
         split = next(split for split in candidate.context.splits if int(split["fold"]) == fold_id)
@@ -638,6 +658,7 @@ class _TabMRecovery:
     def _quarantine(self, candidate_key: str, fold_id: int) -> None:
         candidate = self.candidates[candidate_key]
         manifest, shard = self._paths(candidate_key, fold_id)
+        diagnostic = self._diagnostic_path(candidate_key, fold_id)
         fold_dir = manifest.parent
         if not fold_dir.exists() and not shard.exists():
             return
@@ -648,18 +669,25 @@ class _TabMRecovery:
             os.replace(fold_dir, quarantine / "models")
         if shard.exists():
             os.replace(shard, quarantine / shard.name)
+        if diagnostic.exists():
+            os.replace(diagnostic, quarantine / diagnostic.name)
 
-    def reuse(self, candidate_key: str, fold_id: int) -> pl.DataFrame | None:
+    def reuse(self, candidate_key: str, fold_id: int) -> tuple[pl.DataFrame, dict[str, Any]] | None:
         candidate = self.candidates[candidate_key]
         manifest, shard = self._paths(candidate_key, fold_id)
-        if not candidate.ledger.reusable_fold(
-            training_hash=candidate.training.hash,
-            candidate_identity=candidate.training.hash,
-            fold_id=fold_id,
-            fitted_state=manifest,
-            prediction_shard=shard,
-            resolved_settings=self._settings(candidate_key, fold_id),
-        ) or not self._valid_manifest(candidate_key, fold_id, manifest):
+        diagnostic = self._diagnostic_path(candidate_key, fold_id)
+        if (
+            not candidate.ledger.reusable_fold(
+                training_hash=candidate.training.hash,
+                candidate_identity=candidate.training.hash,
+                fold_id=fold_id,
+                fitted_state=manifest,
+                prediction_shard=shard,
+                resolved_settings=self._settings(candidate_key, fold_id),
+            )
+            or not self._valid_manifest(candidate_key, fold_id, manifest)
+            or not diagnostic.is_file()
+        ):
             self._quarantine(candidate_key, fold_id)
             return None
         frame = pl.read_parquet(shard)
@@ -690,10 +718,21 @@ class _TabMRecovery:
         if frame.n_unique(keys) != frame.height:
             self._quarantine(candidate_key, fold_id)
             return None
+        try:
+            training_record = json.loads(diagnostic.read_text())
+        except (OSError, json.JSONDecodeError):
+            self._quarantine(candidate_key, fold_id)
+            return None
         candidate.reused_folds.append(fold_id)
-        return frame
+        return frame, training_record
 
-    def complete(self, candidate_key: str, fold_id: int, frame: pl.DataFrame) -> None:
+    def complete(
+        self,
+        candidate_key: str,
+        fold_id: int,
+        frame: pl.DataFrame,
+        training_record: dict[str, Any],
+    ) -> None:
         candidate = self.candidates[candidate_key]
         manifest, shard = self._paths(candidate_key, fold_id)
         files = self._checkpoint_files(candidate_key, fold_id)
@@ -704,6 +743,8 @@ class _TabMRecovery:
         manifest_tmp = manifest.with_name(f".{manifest.name}.{uuid.uuid4().hex}.tmp")
         shard.parent.mkdir(parents=True, exist_ok=True)
         shard_tmp = shard.with_name(f".{shard.name}.{uuid.uuid4().hex}.tmp")
+        diagnostic = self._diagnostic_path(candidate_key, fold_id)
+        diagnostic_tmp = diagnostic.with_name(f".{diagnostic.name}.{uuid.uuid4().hex}.tmp")
         try:
             record = {
                 "files": {
@@ -714,11 +755,14 @@ class _TabMRecovery:
             }
             manifest_tmp.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
             frame.write_parquet(shard_tmp)
+            diagnostic_tmp.write_text(json.dumps(training_record, indent=2, sort_keys=True) + "\n")
             os.replace(manifest_tmp, manifest)
             os.replace(shard_tmp, shard)
+            os.replace(diagnostic_tmp, diagnostic)
         finally:
             manifest_tmp.unlink(missing_ok=True)
             shard_tmp.unlink(missing_ok=True)
+            diagnostic_tmp.unlink(missing_ok=True)
         candidate.ledger.complete_fold(
             training_hash=candidate.training.hash,
             candidate_identity=candidate.training.hash,
@@ -887,6 +931,8 @@ def _run_tabm_compatible_group(study: Study, items):
                 )
                 candidate.attempt = None
                 continue
+            _record_tabm_runtime(train_dir, result, candidate_key)
+            _persist_tabm_diagnostics(train_dir, result, candidate_key)
             predictions = _publish_tabm_predictions(
                 study,
                 spec,
@@ -895,8 +941,6 @@ def _run_tabm_compatible_group(study: Study, items):
                 result,
                 candidate_key=candidate_key,
             )
-            _record_tabm_runtime(train_dir, result, candidate_key)
-            _persist_tabm_diagnostics(train_dir, result, candidate_key)
             verified = _cached_research_run(study, spec, context)
             if verified is None:
                 raise ValueError(
@@ -2125,7 +2169,9 @@ def run_tabm_cv(
             if _recovery is not None:
                 reused = _recovery.reuse(candidate_key, fold_id)
                 if reused is not None:
-                    state["prediction_frames"].append(reused)
+                    reused_predictions, reused_training_record = reused
+                    state["prediction_frames"].append(reused_predictions)
+                    training_log.append(reused_training_record)
                     print(f"  Fold {fold_id}: reused completed fitted state")
                     continue
             pending_states.append((candidate_key, state))
@@ -2159,6 +2205,7 @@ def run_tabm_cv(
             fold_t0 = time.perf_counter()
             seed_everything(seed + fd["fold"])
             fold_prediction_frame = None
+            fold_training_record = None
             if is_tabpfn:
                 try:
                     preds = _run_tabpfn_fold(
@@ -2218,17 +2265,16 @@ def run_tabm_cv(
                         state["prediction_frames"].append(fold_prediction_frame)
 
                     fold_elapsed = time.perf_counter() - fold_t0
-                    training_log.append(
-                        {
-                            "config": candidate_key,
-                            "fold": fd["fold"],
-                            "elapsed_s": round(fold_elapsed, 1),
-                            "n_train": fd["n_train"],
-                            "n_val": fd["n_val"],
-                            "best_ic": round(ic, 4),
-                            "n_checkpoints": 1,
-                        }
-                    )
+                    fold_training_record = {
+                        "config": candidate_key,
+                        "fold": fd["fold"],
+                        "elapsed_s": round(fold_elapsed, 1),
+                        "n_train": fd["n_train"],
+                        "n_val": fd["n_val"],
+                        "best_ic": round(ic, 4),
+                        "n_checkpoints": 1,
+                    }
+                    training_log.append(fold_training_record)
                     print(f"    Fold {fd['fold']}: IC={ic:+.4f} ({fold_elapsed:.1f}s)")
                 except ImportError:
                     if int(fd["fold"]) == int(splits[0]["fold"]):
@@ -2356,26 +2402,32 @@ def run_tabm_cv(
                     str(k): round(epoch_losses.get(k, 0.0), 6)
                     for k in sorted(checkpoint_ics.keys())
                 }
-                training_log.append(
-                    {
-                        "config": candidate_key,
-                        "fold": fd["fold"],
-                        "elapsed_s": round(fold_elapsed, 1),
-                        "n_train": fd["n_train"],
-                        "n_val": fd["n_val"],
-                        "best_ic": round(checkpoint_ics[best_ep], 4),
-                        "n_checkpoints": len(checkpoint_ics),
-                        "checkpoint_ics": {str(k): round(v, 4) for k, v in checkpoint_ics.items()},
-                        "checkpoint_losses": loss_at_checkpoints,
-                    }
-                )
+                fold_training_record = {
+                    "config": candidate_key,
+                    "fold": fd["fold"],
+                    "elapsed_s": round(fold_elapsed, 1),
+                    "n_train": fd["n_train"],
+                    "n_val": fd["n_val"],
+                    "best_ic": round(checkpoint_ics[best_ep], 4),
+                    "n_checkpoints": len(checkpoint_ics),
+                    "checkpoint_ics": {str(k): round(v, 4) for k, v in checkpoint_ics.items()},
+                    "checkpoint_losses": loss_at_checkpoints,
+                }
+                training_log.append(fold_training_record)
                 print(
                     f"    Fold {fd['fold']}: best_ep={best_ep}, "
                     f"IC={checkpoint_ics[best_ep]:+.4f} ({fold_elapsed:.1f}s)"
                 )
             if _recovery is not None and fold_prediction_frame is not None:
                 try:
-                    _recovery.complete(candidate_key, int(fd["fold"]), fold_prediction_frame)
+                    if fold_training_record is None:
+                        raise RuntimeError("TabM fold completed without a training record")
+                    _recovery.complete(
+                        candidate_key,
+                        int(fd["fold"]),
+                        fold_prediction_frame,
+                        fold_training_record,
+                    )
                 except Exception as error:
                     state["available"] = False
                     state["error"] = error

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -747,6 +747,7 @@ def _run_tabm_compatible_group(study: Study, items):
     from case_studies.research.models import ModelRun
     from case_studies.research.recovery import ExecutionLedger
 
+    compatibility_group = hashlib.sha256(_tabm_execution_key(items[0][1]).encode()).hexdigest()[:12]
     completed: dict[int, ModelRun] = {}
     pending = []
     for index, spec, context in items:
@@ -757,8 +758,15 @@ def _run_tabm_compatible_group(study: Study, items):
                 predictions=cached.predictions,
                 diagnostics={
                     "execution_order": "fold_major",
+                    "compatibility_group": compatibility_group,
+                    "compatibility_group_size": len(items),
                     "group_size": len(items),
                     "reused": True,
+                    "base_fold_preparations": 0,
+                    "base_fold_preparation_s": 0.0,
+                    "candidate_fit_s": 0.0,
+                    "preparation_fraction": 0.0,
+                    "disk_fold_cache": False,
                 },
             )
         else:
@@ -827,6 +835,12 @@ def _run_tabm_compatible_group(study: Study, items):
             strict=True,
             _recovery=recovery,
         )
+        execution_diagnostics = result["execution_diagnostics"]
+        preparation_elapsed_s = float(execution_diagnostics["base_fold_preparation_s"])
+        fit_elapsed_by_candidate = execution_diagnostics["candidate_fit_s"]
+        measured_s = preparation_elapsed_s + sum(
+            float(value) for value in fit_elapsed_by_candidate.values()
+        )
         for index, spec, context, training, train_dir, candidate_key, candidate in registered:
             failure = result.get("failures", {}).get(candidate_key)
             if failure is not None:
@@ -857,10 +871,17 @@ def _run_tabm_compatible_group(study: Study, items):
                 )
             diagnostics = {
                 "execution_order": "fold_major",
+                "compatibility_group": compatibility_group,
+                "compatibility_group_size": len(items),
                 "fitted_folds": candidate.fitted_folds,
                 "group_size": len(pending),
                 "reused": False,
                 "reused_folds": candidate.reused_folds,
+                "base_fold_preparations": int(execution_diagnostics["base_fold_preparations"]),
+                "base_fold_preparation_s": preparation_elapsed_s,
+                "candidate_fit_s": float(fit_elapsed_by_candidate[candidate_key]),
+                "preparation_fraction": (preparation_elapsed_s / measured_s if measured_s else 0.0),
+                "disk_fold_cache": False,
             }
             candidate.attempt.finish("completed", diagnostics)
             candidate.attempt = None
@@ -2059,8 +2080,25 @@ def run_tabm_cv(
             "started_at": datetime.now(UTC).isoformat(),
         }
 
+    preparation_elapsed_s = 0.0
+    preparation_count = 0
     print("Preparing and releasing folds...")
     for split in splits:
+        fold_id = int(split["fold"])
+        pending_states = []
+        for candidate_key, state in states.items():
+            if not state["available"]:
+                continue
+            if _recovery is not None:
+                reused = _recovery.reuse(candidate_key, fold_id)
+                if reused is not None:
+                    state["prediction_frames"].append(reused)
+                    print(f"  Fold {fold_id}: reused completed fitted state")
+                    continue
+            pending_states.append((candidate_key, state))
+        if not pending_states:
+            continue
+        preparation_started = time.perf_counter()
         fd = _prepare_tabm_fold(
             dataset_pd,
             split,
@@ -2073,10 +2111,10 @@ def run_tabm_cv(
             temporal_keys=temporal_keys,
             temporal_feature_names=temporal_feature_names,
         )
+        preparation_elapsed_s += time.perf_counter() - preparation_started
+        preparation_count += 1
         print(f"  Fold {fd['fold']}: train={fd['n_train']:,}  val={fd['n_val']:,}")
-        for candidate_key, state in states.items():
-            if not state["available"]:
-                continue
+        for candidate_key, state in pending_states:
             cfg = state["config"]
             artifact_name = cfg["config_name"]
             cfg_params = dict(cfg.get("params", {}))
@@ -2087,12 +2125,6 @@ def run_tabm_cv(
             fold_t0 = time.perf_counter()
             seed_everything(seed + fd["fold"])
             fold_prediction_frame = None
-            if _recovery is not None:
-                reused = _recovery.reuse(candidate_key, int(fd["fold"]))
-                if reused is not None:
-                    state["prediction_frames"].append(reused)
-                    print(f"    Fold {fd['fold']}: reused completed fitted state")
-                    continue
             if is_tabpfn:
                 try:
                     preds = _run_tabpfn_fold(
@@ -2509,6 +2541,13 @@ def run_tabm_cv(
             if frame.height:
                 prediction_frames.append(frame)
     all_predictions = pl.concat(prediction_frames) if prediction_frames else pl.DataFrame()
+    execution_diagnostics = {
+        "base_fold_preparation_s": preparation_elapsed_s,
+        "base_fold_preparations": preparation_count,
+        "candidate_fit_s": {
+            candidate_key: float(state["elapsed_s"]) for candidate_key, state in states.items()
+        },
+    }
     if not config_results:
         return {
             "all_learning_curves": pl.DataFrame(all_curves),
@@ -2518,6 +2557,7 @@ def run_tabm_cv(
             "grid_results": [],
             "predictions": pl.DataFrame(),
             "training_log": pl.DataFrame(training_log),
+            "execution_diagnostics": execution_diagnostics,
         }
     assembled = _assemble_tabm_results(
         config_results=config_results,
@@ -2530,4 +2570,5 @@ def run_tabm_cv(
         eval_col=eval_col,
     )
     assembled["failures"] = failures
+    assembled["execution_diagnostics"] = execution_diagnostics
     return assembled

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -565,7 +565,11 @@ def _persist_tabm_diagnostics(train_dir: Path, result: dict[str, Any], candidate
     if "config" in training_log.columns:
         training_log = training_log.filter(pl.col("config") == candidate_key)
     grid_row = next(row for row in result["grid_results"] if row["config_name"] == candidate_key)
-    best = predictions.filter(pl.col("epoch") == int(grid_row["best_epoch"]))
+    best = (
+        predictions.filter(pl.col("epoch") == int(grid_row["best_epoch"]))
+        .with_columns(pl.lit(candidate_key).alias("model_id"))
+        .drop("config", "epoch")
+    )
     predictions.write_parquet(diagnostics_dir / "all_predictions.parquet")
     best.write_parquet(diagnostics_dir / "predictions.parquet")
     curves.write_parquet(diagnostics_dir / "learning_curves.parquet")

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -1974,6 +1974,8 @@ def run_tabm_cv(
     runtime_spec = tabm_runtime_spec(device, seed=seed, num_threads=num_threads)
     torch_device = _configure_torch_runtime(runtime_spec)
     eval_col = "eval_actual" if eval_label_col else None
+    if not splits:
+        raise ValueError("TabM cross-validation requires at least one fold")
 
     dataset_pd = dataset_pd.sort_values([date_col, entity_col], kind="mergesort").reset_index(
         drop=True
@@ -2113,8 +2115,6 @@ def run_tabm_cv(
         configs = pending_configs
 
     # Train every compatible candidate while one prepared fold is resident.
-    if not splits:
-        raise ValueError("TabM cross-validation requires at least one fold")
     config_results: list[dict[str, Any]] = list(cached_results)
     all_curves: list[dict] = list(cached_curves)
     training_log: list[dict] = []

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -474,7 +474,7 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
     try:
         validate_deep_checkpoint_population(
             model_root,
-            config_name=context.config["config_name"],
+            config_name=training.hash,
             fold_ids=tuple(int(split["fold"]) for split in context.splits),
             checkpoints=checkpoint_values,
             architecture="tabm",
@@ -538,6 +538,27 @@ def _record_tabm_runtime(train_dir: Path, result: dict[str, Any], config_name: s
     runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
 
 
+def _persist_tabm_diagnostics(train_dir: Path, result: dict[str, Any], candidate_key: str) -> None:
+    diagnostics_dir = train_dir / "diagnostics"
+    diagnostics_dir.mkdir(parents=True, exist_ok=True)
+    predictions = result["all_predictions"].filter(pl.col("config") == candidate_key)
+    curves = result["all_learning_curves"]
+    if "config" in curves.columns:
+        curves = curves.filter(pl.col("config") == candidate_key)
+    training_log = result["training_log"]
+    if "config" in training_log.columns:
+        training_log = training_log.filter(pl.col("config") == candidate_key)
+    grid_row = next(row for row in result["grid_results"] if row["config_name"] == candidate_key)
+    best = predictions.filter(pl.col("epoch") == int(grid_row["best_epoch"]))
+    predictions.write_parquet(diagnostics_dir / "all_predictions.parquet")
+    best.write_parquet(diagnostics_dir / "predictions.parquet")
+    curves.write_parquet(diagnostics_dir / "learning_curves.parquet")
+    training_log.write_parquet(diagnostics_dir / "training_log.parquet")
+    (diagnostics_dir / "result.json").write_text(
+        json.dumps(grid_row, indent=2, sort_keys=True) + "\n"
+    )
+
+
 @dataclass
 class _TabMRecoveryCandidate:
     spec: dict[str, Any]
@@ -559,9 +580,8 @@ class _TabMRecovery:
 
     def _paths(self, candidate_key: str, fold_id: int) -> tuple[Path, Path]:
         candidate = self.candidates[candidate_key]
-        artifact_name = candidate.context.config["config_name"]
         manifest = (
-            self.model_root(candidate_key) / artifact_name / f"fold_{fold_id:02d}" / "manifest.json"
+            self.model_root(candidate_key) / candidate_key / f"fold_{fold_id:02d}" / "manifest.json"
         )
         shard = (
             candidate.training.root
@@ -587,13 +607,12 @@ class _TabMRecovery:
         from case_studies.utils.deep_model_state import checkpoint_sidecar, deep_checkpoint_path
 
         candidate = self.candidates[candidate_key]
-        artifact_name = candidate.context.config["config_name"]
         computation = candidate.spec.get("computation", candidate.spec)
         checkpoints = tuple(int(item["value"]) for item in computation["checkpoint_schedule"])
         files = []
         for checkpoint in checkpoints:
             path = deep_checkpoint_path(
-                self.model_root(candidate_key), artifact_name, fold_id, checkpoint
+                self.model_root(candidate_key), candidate_key, fold_id, checkpoint
             )
             files.extend((path, checkpoint_sidecar(path)))
         return tuple(files)
@@ -813,7 +832,11 @@ def _run_tabm_compatible_group(study: Study, items):
             first_context.dataset_pd,
             list(first_context.splits),
             configs=[
-                {**context.config, "_execution_key": candidate_key}
+                {
+                    **context.config,
+                    "_artifact_name": candidate_key,
+                    "_execution_key": candidate_key,
+                }
                 for _, _, context, _, _, candidate_key, _ in registered
             ],
             n_features=len(first_context.feature_names),
@@ -873,6 +896,7 @@ def _run_tabm_compatible_group(study: Study, items):
                 candidate_key=candidate_key,
             )
             _record_tabm_runtime(train_dir, result, candidate_key)
+            _persist_tabm_diagnostics(train_dir, result, candidate_key)
             verified = _cached_research_run(study, spec, context)
             if verified is None:
                 raise ValueError(
@@ -1888,6 +1912,8 @@ def run_tabm_cv(
         )
     if len(feature_names) != len(set(feature_names)):
         raise ValueError("feature_names contains duplicates")
+    if not splits:
+        raise ValueError("TabM cross-validation requires at least one fold")
     if register and save_dir is None:
         raise ValueError(
             "register=True requires save_dir for incremental prediction saves. "
@@ -2124,6 +2150,7 @@ def run_tabm_cv(
         for candidate_key, state in pending_states:
             cfg = state["config"]
             artifact_name = cfg["config_name"]
+            checkpoint_artifact_name = str(cfg.get("_artifact_name", artifact_name))
             cfg_params = dict(cfg.get("params", {}))
             cfg_n_epochs = cfg.get("n_epochs", 200)
             cfg_batch_size = cfg.get("batch_size", 4096)
@@ -2233,7 +2260,7 @@ def run_tabm_cv(
                         *,
                         _fold: int = int(fd["fold"]),
                         _preprocessing: dict[str, Any] = fd["preprocessing"],
-                        _config_name: str = artifact_name,
+                        _config_name: str = checkpoint_artifact_name,
                         _model_kwargs: dict[str, Any] = tabm_kwargs,
                         _checkpoint_root: Path = candidate_checkpoint_root,
                     ) -> None:
@@ -2367,6 +2394,7 @@ def run_tabm_cv(
             continue
         cfg = state["config"]
         artifact_name = cfg["config_name"]
+        checkpoint_artifact_name = str(cfg.get("_artifact_name", artifact_name))
         completed_candidate_keys.append(candidate_key)
         fold_checkpoint_ics = state["fold_checkpoint_ics"]
         config_prediction_frames = state["prediction_frames"]
@@ -2463,7 +2491,7 @@ def run_tabm_cv(
 
             validate_deep_checkpoint_population(
                 candidate_checkpoint_root,
-                config_name=artifact_name,
+                config_name=checkpoint_artifact_name,
                 fold_ids=tuple(int(split["fold"]) for split in splits),
                 checkpoints=_tabm_checkpoint_epochs(cfg),
                 architecture="tabm",

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -262,33 +262,29 @@ def _tabm_expected_keys(mds, splits: list[dict[str, Any]]) -> pl.DataFrame:
     return expected
 
 
-def resolve_model_request(study: Study, request: dict[str, Any]):
+def _resolve_model_request_from_materialized(
+    study: Study,
+    request: dict[str, Any],
+    *,
+    label_ref,
+    mds,
+    dataset_pd: pd.DataFrame | None,
+    configured_by_name: dict[str, dict[str, Any]],
+    runtime_provenance: dict[str, Any],
+):
     from case_studies.research.contracts import ExecutionTier
     from case_studies.research.identity import ResolvedSpec
-    from utils.modeling import load_configs, load_modeling_dataset
 
     tier = ExecutionTier(request["execution_tier"])
     reductions = dict(request["preview_reductions"])
     unknown_reductions = set(reductions) - _TABM_PREVIEW_FIELDS
     if unknown_reductions:
         raise ValueError(f"unsupported TabM preview reductions: {sorted(unknown_reductions)}")
-    study.require_writable()
-    study.activate(tier)
-    label_ref = study.labels.get(request["label"], execution_tier=tier)
-    mds = load_modeling_dataset(
-        study.case_study,
-        label_ref.name,
-        max_symbols=int(reductions.get("max_symbols", 0)),
-    )
     if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
         raise ValueError("TabM runner requires canonical symbol and timestamp keys")
     splits, cv_record = _tabm_splits(mds, request)
-    configs = {
-        config["config_name"]: config
-        for config in load_configs(study.case_study, label_ref.name, "tabular_dl")
-    }
     try:
-        configured = configs[request["config_name"]]
+        configured = configured_by_name[request["config_name"]]
     except KeyError as error:
         raise ValueError(f"unknown TabM configuration {request['config_name']!r}") from error
     config = _resolve_tabm_config(configured, request["overrides"])
@@ -365,7 +361,6 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         "source_identity": _tabm_source_identity(),
         "runtime_identity": _tabm_runtime_identity(),
     }
-    runtime_provenance = _tabm_runtime_provenance(study)
     if mds.task_type == "classification":
         if tier is ExecutionTier.PREVIEW:
             computation["preview_reductions"] = reductions
@@ -391,7 +386,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         if tier is ExecutionTier.PREVIEW:
             spec["preview_reductions"] = reductions
     context = TabMResearchContext(
-        dataset_pd=mds.dataset.to_pandas(),
+        dataset_pd=mds.dataset.to_pandas() if dataset_pd is None else dataset_pd,
         splits=tuple(splits),
         config=config,
         feature_names=tuple(mds.feature_names),
@@ -409,6 +404,48 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         runtime_provenance=runtime_provenance,
     )
     return spec, context
+
+
+def _materialize_tabm_request_group(study: Study, request: dict[str, Any]):
+    from case_studies.research.contracts import ExecutionTier
+    from utils.modeling import load_configs, load_modeling_dataset
+
+    tier = ExecutionTier(request["execution_tier"])
+    reductions = dict(request["preview_reductions"])
+    unknown_reductions = set(reductions) - _TABM_PREVIEW_FIELDS
+    if unknown_reductions:
+        raise ValueError(f"unsupported TabM preview reductions: {sorted(unknown_reductions)}")
+    study.require_writable()
+    study.activate(tier)
+    label_ref = study.labels.get(request["label"], execution_tier=tier)
+    mds = load_modeling_dataset(
+        study.case_study,
+        label_ref.name,
+        max_symbols=int(reductions.get("max_symbols", 0)),
+    )
+    configured_by_name = {
+        config["config_name"]: config
+        for config in load_configs(study.case_study, label_ref.name, "tabular_dl")
+    }
+    return (
+        label_ref,
+        mds,
+        configured_by_name,
+        _tabm_runtime_provenance(study),
+    )
+
+
+def resolve_model_request(study: Study, request: dict[str, Any]):
+    materialized = _materialize_tabm_request_group(study, request)
+    return _resolve_model_request_from_materialized(
+        study,
+        request,
+        label_ref=materialized[0],
+        mds=materialized[1],
+        dataset_pd=None,
+        configured_by_name=materialized[2],
+        runtime_provenance=materialized[3],
+    )
 
 
 def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResearchContext):
@@ -461,6 +498,60 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
     return ModelRun(training=training, predictions=complete_predictions)
 
 
+def _publish_tabm_predictions(
+    study: Study,
+    spec: dict[str, Any],
+    context: TabMResearchContext,
+    training,
+    result: dict[str, Any],
+):
+    computation = spec.get("computation", spec)
+    prediction_results = []
+    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
+        predictions = (
+            result["all_predictions"]
+            .filter(
+                (pl.col("config") == context.config["config_name"])
+                & (pl.col("epoch") == checkpoint)
+            )
+            .drop("config", "epoch")
+            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
+            .with_columns(
+                pl.col(context.date_col).cast(context.expected_keys.schema[context.date_col]),
+                pl.col(context.entity_col).cast(context.expected_keys.schema[context.entity_col]),
+                pl.col("fold").cast(context.expected_keys.schema["fold"]),
+            )
+        )
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="epoch",
+                checkpoint_value=int(checkpoint),
+                split="validation",
+                predictions=predictions,
+                expected_keys=context.expected_keys,
+                task_type=context.task_type,
+                class_values=list(context.class_values) or None,
+                eval_col="eval_actual" if context.eval_label_col else None,
+                label=context.label_col,
+            )
+        )
+    return tuple(prediction_results)
+
+
+def _record_tabm_runtime(train_dir: Path, result: dict[str, Any], config_name: str) -> None:
+    runtime_path = train_dir / "runtime.json"
+    if not runtime_path.exists():
+        return
+    runtime = json.loads(runtime_path.read_text())
+    runtime["elapsed_s"] = sum(
+        float(row.get("elapsed_s", 0.0))
+        for row in result["grid_results"]
+        if row["config_name"] == config_name
+    )
+    runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
+
+
 def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResearchContext):
     from case_studies.research.models import ModelRun
 
@@ -508,44 +599,190 @@ def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResear
         shutil.rmtree(staging, ignore_errors=True)
         raise
 
-    prediction_results = []
-    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
-        predictions = (
-            result["all_predictions"]
-            .filter(
-                (pl.col("config") == context.config["config_name"])
-                & (pl.col("epoch") == checkpoint)
-            )
-            .drop("config", "epoch")
-            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
-            .with_columns(
-                pl.col(context.date_col).cast(context.expected_keys.schema[context.date_col]),
-                pl.col(context.entity_col).cast(context.expected_keys.schema[context.entity_col]),
-                pl.col("fold").cast(context.expected_keys.schema["fold"]),
-            )
+    prediction_results = _publish_tabm_predictions(study, spec, context, training, result)
+    _record_tabm_runtime(train_dir, result, context.config["config_name"])
+    return ModelRun(training=training, predictions=prediction_results)
+
+
+def _tabm_materialization_key(request: dict[str, Any]) -> tuple[str, str, int]:
+    reductions = dict(request["preview_reductions"])
+    return (
+        str(request["label"]),
+        str(request["execution_tier"]),
+        int(reductions.get("max_symbols", 0)),
+    )
+
+
+def _tabm_execution_key(spec: dict[str, Any]) -> str:
+    from case_studies.utils.registry.specs import canonical_json
+
+    computation = spec.get("computation", spec)
+    shared = {
+        "execution_tier": spec["execution_tier"],
+        "cv": computation["cv"],
+        "feature_artifacts": computation["feature_artifacts"],
+        "feature_names": computation["feature_names"],
+        "input_data_spec": computation["input_data_spec"],
+        "label_artifact": computation["label_artifact"],
+        "numerics": computation["numerics"],
+        "preprocessing": computation["preprocessing"],
+        "sampling": computation["sampling"],
+        "task": computation["task"],
+    }
+    return canonical_json(shared)
+
+
+def _tabm_unique_name_batches(items):
+    batches: list[list[Any]] = []
+    for item in items:
+        config_name = item[2].config["config_name"]
+        target = next(
+            (
+                batch
+                for batch in batches
+                if config_name not in {member[2].config["config_name"] for member in batch}
+            ),
+            None,
         )
-        prediction_results.append(
-            study.results.publish_predictions(
-                training,
-                checkpoint_kind="epoch",
-                checkpoint_value=int(checkpoint),
-                split="validation",
+        if target is None:
+            target = []
+            batches.append(target)
+        target.append(item)
+    return batches
+
+
+def _run_tabm_compatible_group(study: Study, items):
+    from case_studies.research.models import ModelRun
+
+    completed: dict[int, ModelRun] = {}
+    pending = []
+    for index, spec, context in items:
+        cached = _cached_research_run(study, spec, context)
+        if cached is not None:
+            completed[index] = ModelRun(
+                training=cached.training,
+                predictions=cached.predictions,
+                diagnostics={
+                    "execution_order": "candidate_major_shared_preparation",
+                    "group_size": len(items),
+                    "reused": True,
+                },
+            )
+        else:
+            pending.append((index, spec, context))
+    if not pending:
+        return completed
+
+    registered = []
+    for index, spec, context in pending:
+        training = study.results.register_training(
+            spec,
+            execution_tier=spec["execution_tier"],
+            runtime_provenance=context.runtime_provenance,
+        )
+        train_dir = training.root / "run_log" / "training" / training.hash
+        model_dir = train_dir / "models"
+        if model_dir.exists():
+            raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
+        registered.append((index, spec, context, training, train_dir, model_dir))
+
+    first_context = pending[0][2]
+    first_computation = pending[0][1].get("computation", pending[0][1])
+    batch_root = registered[0][4].parent / f".tabm-batch.{uuid.uuid4().hex}.tmp"
+    checkpoint_root = batch_root / "models"
+    try:
+        result = run_tabm_cv(
+            first_context.dataset_pd,
+            list(first_context.splits),
+            configs=[context.config for _, _, context in pending],
+            n_features=len(first_context.feature_names),
+            feature_names=list(first_context.feature_names),
+            label_col=first_context.label_col,
+            eval_label_col=first_context.eval_label_col,
+            task_type=first_context.task_type,
+            class_values=list(first_context.class_values) or None,
+            date_col=first_context.date_col,
+            entity_col=first_context.entity_col,
+            device=str(first_computation["numerics"]["device"]),
+            save_dir=batch_root / "diagnostics",
+            register=False,
+            temporal_by_fold=first_context.temporal_by_fold,
+            temporal_keys=list(first_context.temporal_keys),
+            temporal_feature_names=list(first_context.temporal_feature_names),
+            class_weights_by_fold=first_context.class_weights_by_fold,
+            seed=int(pending[0][1]["seed"]),
+            num_threads=int(first_computation["numerics"]["num_threads"]),
+            checkpoint_root=checkpoint_root,
+            strict=True,
+        )
+        for index, spec, context, training, train_dir, model_dir in registered:
+            predictions = _publish_tabm_predictions(study, spec, context, training, result)
+            source = checkpoint_root / context.config["config_name"]
+            if not source.is_dir():
+                raise ValueError(
+                    f"TabM batch did not persist fitted state for {context.config['config_name']}"
+                )
+            staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
+            staging.mkdir()
+            try:
+                os.replace(source, staging / context.config["config_name"])
+                os.replace(staging, model_dir)
+            except Exception:
+                shutil.rmtree(staging, ignore_errors=True)
+                raise
+            _record_tabm_runtime(train_dir, result, context.config["config_name"])
+            verified = _cached_research_run(study, spec, context)
+            if verified is None:
+                raise ValueError(
+                    f"TabM batch result failed fitted-state validation for {context.config['config_name']}"
+                )
+            completed[index] = ModelRun(
+                training=verified.training,
                 predictions=predictions,
-                expected_keys=context.expected_keys,
-                task_type=context.task_type,
-                class_values=list(context.class_values) or None,
-                eval_col="eval_actual" if context.eval_label_col else None,
-                label=context.label_col,
+                diagnostics={
+                    "execution_order": "candidate_major_shared_preparation",
+                    "group_size": len(pending),
+                    "reused": False,
+                },
             )
+    finally:
+        shutil.rmtree(batch_root, ignore_errors=True)
+    return completed
+
+
+def run_model_requests(study: Study, requests: list[dict[str, Any]]):
+    if not requests:
+        return ()
+    resolved_by_index = []
+    materialization_groups: dict[tuple[str, str, int], list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        materialization_groups.setdefault(_tabm_materialization_key(request), []).append(
+            (index, request)
         )
-    runtime_path = train_dir / "runtime.json"
-    if runtime_path.exists():
-        runtime = json.loads(runtime_path.read_text())
-        runtime["elapsed_s"] = sum(
-            float(row.get("elapsed_s", 0.0)) for row in result["grid_results"]
-        )
-        runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
-    return ModelRun(training=training, predictions=tuple(prediction_results))
+    for group in materialization_groups.values():
+        materialized = _materialize_tabm_request_group(study, group[0][1])
+        dataset_pd = None
+        for index, request in group:
+            spec, context = _resolve_model_request_from_materialized(
+                study,
+                request,
+                label_ref=materialized[0],
+                mds=materialized[1],
+                dataset_pd=dataset_pd,
+                configured_by_name=materialized[2],
+                runtime_provenance=materialized[3],
+            )
+            dataset_pd = context.dataset_pd
+            resolved_by_index.append((index, spec, context))
+
+    execution_groups: dict[str, list[Any]] = {}
+    for item in resolved_by_index:
+        execution_groups.setdefault(_tabm_execution_key(item[1]), []).append(item)
+    completed = {}
+    for compatible in execution_groups.values():
+        for batch in _tabm_unique_name_batches(compatible):
+            completed.update(_run_tabm_compatible_group(study, batch))
+    return tuple(completed[index] for index in range(len(requests)))
 
 
 def resolve_torch_device(device: str) -> torch.device:

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -21,7 +21,6 @@ import importlib.metadata
 import json
 import os
 import platform
-import shutil
 import subprocess
 import time
 import uuid
@@ -361,30 +360,17 @@ def _resolve_model_request_from_materialized(
         "source_identity": _tabm_source_identity(),
         "runtime_identity": _tabm_runtime_identity(),
     }
-    if mds.task_type == "classification":
-        if tier is ExecutionTier.PREVIEW:
-            computation["preview_reductions"] = reductions
-        spec = ResolvedSpec.create(
-            family="tabular_dl",
-            label=label_ref.name,
-            seed=int(runtime["seed"]),
-            computation=computation,
-            provenance=runtime_provenance,
-            config_name=config["config_name"],
-            execution_tier=tier.value,
-        ).as_dict()
-    else:
-        spec = {
-            "identity_version": 2,
-            "execution_tier": tier.value,
-            "family": "tabular_dl",
-            "label": label_ref.name,
-            "seed": int(runtime["seed"]),
-            "config_name": config["config_name"],
-            **computation,
-        }
-        if tier is ExecutionTier.PREVIEW:
-            spec["preview_reductions"] = reductions
+    if tier is ExecutionTier.PREVIEW:
+        computation["preview_reductions"] = reductions
+    spec = ResolvedSpec.create(
+        family="tabular_dl",
+        label=label_ref.name,
+        seed=int(runtime["seed"]),
+        computation=computation,
+        provenance=runtime_provenance,
+        config_name=config["config_name"],
+        execution_tier=tier.value,
+    ).as_dict()
     context = TabMResearchContext(
         dataset_pd=mds.dataset.to_pandas() if dataset_pd is None else dataset_pd,
         splits=tuple(splits),
@@ -552,56 +538,179 @@ def _record_tabm_runtime(train_dir: Path, result: dict[str, Any], config_name: s
     runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
 
 
-def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResearchContext):
-    from case_studies.research.models import ModelRun
+@dataclass
+class _TabMRecoveryCandidate:
+    spec: dict[str, Any]
+    context: TabMResearchContext
+    training: Any
+    ledger: Any
+    attempt: Any
+    reused_folds: list[int]
+    fitted_folds: list[int]
 
-    cached = _cached_research_run(study, spec, context)
-    if cached is not None:
-        return cached
-    training = study.results.register_training(
-        spec,
-        execution_tier=spec["execution_tier"],
-        runtime_provenance=context.runtime_provenance,
-    )
-    train_dir = training.root / "run_log" / "training" / training.hash
-    model_dir = train_dir / "models"
-    if model_dir.exists():
-        raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
-    staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
-    computation = spec.get("computation", spec)
-    try:
-        result = run_tabm_cv(
-            context.dataset_pd,
-            list(context.splits),
-            configs=[context.config],
-            n_features=len(context.feature_names),
-            feature_names=list(context.feature_names),
-            label_col=context.label_col,
-            eval_label_col=context.eval_label_col,
-            task_type=context.task_type,
-            class_values=list(context.class_values) or None,
-            date_col=context.date_col,
-            entity_col=context.entity_col,
-            device=computation["numerics"]["device"],
-            save_dir=train_dir / "diagnostics",
-            register=False,
-            temporal_by_fold=context.temporal_by_fold,
-            temporal_keys=list(context.temporal_keys),
-            temporal_feature_names=list(context.temporal_feature_names),
-            class_weights_by_fold=context.class_weights_by_fold,
-            seed=int(spec["seed"]),
-            num_threads=int(computation["numerics"]["num_threads"]),
-            checkpoint_root=staging,
-            strict=True,
+
+class _TabMRecovery:
+    def __init__(self, candidates: dict[str, _TabMRecoveryCandidate]) -> None:
+        self.candidates = candidates
+
+    def model_root(self, config_name: str) -> Path:
+        candidate = self.candidates[config_name]
+        return candidate.training.root / "run_log" / "training" / candidate.training.hash / "models"
+
+    def _paths(self, config_name: str, fold_id: int) -> tuple[Path, Path]:
+        candidate = self.candidates[config_name]
+        manifest = (
+            self.model_root(config_name) / config_name / f"fold_{fold_id:02d}" / "manifest.json"
         )
-        os.replace(staging, model_dir)
-    except Exception:
-        shutil.rmtree(staging, ignore_errors=True)
-        raise
+        shard = (
+            candidate.training.root
+            / "run_log"
+            / "training"
+            / candidate.training.hash
+            / "prediction_folds"
+            / f"fold_{fold_id}.parquet"
+        )
+        return manifest, shard
 
-    prediction_results = _publish_tabm_predictions(study, spec, context, training, result)
-    _record_tabm_runtime(train_dir, result, context.config["config_name"])
-    return ModelRun(training=training, predictions=prediction_results)
+    def _settings(self, config_name: str, fold_id: int) -> dict[str, Any]:
+        candidate = self.candidates[config_name]
+        split = next(split for split in candidate.context.splits if int(split["fold"]) == fold_id)
+        computation = candidate.spec.get("computation", candidate.spec)
+        return {
+            "checkpoint_schedule": computation["checkpoint_schedule"],
+            "fold": _normalize_splits([split])[0],
+            "training_hash": candidate.training.hash,
+        }
+
+    def _checkpoint_files(self, config_name: str, fold_id: int) -> tuple[Path, ...]:
+        from case_studies.utils.deep_model_state import checkpoint_sidecar, deep_checkpoint_path
+
+        candidate = self.candidates[config_name]
+        computation = candidate.spec.get("computation", candidate.spec)
+        checkpoints = tuple(int(item["value"]) for item in computation["checkpoint_schedule"])
+        files = []
+        for checkpoint in checkpoints:
+            path = deep_checkpoint_path(
+                self.model_root(config_name), config_name, fold_id, checkpoint
+            )
+            files.extend((path, checkpoint_sidecar(path)))
+        return tuple(files)
+
+    def _valid_manifest(self, config_name: str, fold_id: int, manifest: Path) -> bool:
+        if not manifest.is_file():
+            return False
+        try:
+            record = json.loads(manifest.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        files = self._checkpoint_files(config_name, fold_id)
+        expected = {
+            str(path.relative_to(self.model_root(config_name))): _sha256(path)
+            for path in files
+            if path.is_file()
+        }
+        return len(expected) == len(files) and record == {
+            "files": expected,
+            "schema_version": 1,
+        }
+
+    def _quarantine(self, config_name: str, fold_id: int) -> None:
+        candidate = self.candidates[config_name]
+        manifest, shard = self._paths(config_name, fold_id)
+        fold_dir = manifest.parent
+        if not fold_dir.exists() and not shard.exists():
+            return
+        train_dir = candidate.training.root / "run_log" / "training" / candidate.training.hash
+        quarantine = train_dir / "invalid_folds" / f"fold_{fold_id}.{uuid.uuid4().hex}"
+        quarantine.mkdir(parents=True)
+        if fold_dir.exists():
+            os.replace(fold_dir, quarantine / "models")
+        if shard.exists():
+            os.replace(shard, quarantine / shard.name)
+
+    def reuse(self, config_name: str, fold_id: int) -> pl.DataFrame | None:
+        candidate = self.candidates[config_name]
+        manifest, shard = self._paths(config_name, fold_id)
+        if not candidate.ledger.reusable_fold(
+            training_hash=candidate.training.hash,
+            candidate_identity=candidate.training.hash,
+            fold_id=fold_id,
+            fitted_state=manifest,
+            prediction_shard=shard,
+            resolved_settings=self._settings(config_name, fold_id),
+        ) or not self._valid_manifest(config_name, fold_id, manifest):
+            self._quarantine(config_name, fold_id)
+            return None
+        frame = pl.read_parquet(shard)
+        checkpoints = {
+            int(item["value"])
+            for item in candidate.spec.get("computation", candidate.spec)["checkpoint_schedule"]
+        }
+        required = {
+            candidate.context.date_col,
+            candidate.context.entity_col,
+            "config",
+            "epoch",
+            "fold_id",
+            "y_score",
+            "y_true",
+        }
+        if required - set(frame.columns):
+            self._quarantine(config_name, fold_id)
+            return None
+        if (
+            set(frame["config"].unique().to_list()) != {config_name}
+            or set(frame["fold_id"].unique().to_list()) != {fold_id}
+            or {int(value) for value in frame["epoch"].unique().to_list()} != checkpoints
+        ):
+            self._quarantine(config_name, fold_id)
+            return None
+        keys = [candidate.context.date_col, candidate.context.entity_col, "fold_id", "epoch"]
+        if frame.n_unique(keys) != frame.height:
+            self._quarantine(config_name, fold_id)
+            return None
+        candidate.reused_folds.append(fold_id)
+        return frame
+
+    def complete(self, config_name: str, fold_id: int, frame: pl.DataFrame) -> None:
+        candidate = self.candidates[config_name]
+        manifest, shard = self._paths(config_name, fold_id)
+        files = self._checkpoint_files(config_name, fold_id)
+        missing = [str(path) for path in files if not path.is_file()]
+        if missing:
+            raise ValueError(f"TabM fold checkpoint population is incomplete: {missing}")
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest_tmp = manifest.with_name(f".{manifest.name}.{uuid.uuid4().hex}.tmp")
+        shard.parent.mkdir(parents=True, exist_ok=True)
+        shard_tmp = shard.with_name(f".{shard.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            record = {
+                "files": {
+                    str(path.relative_to(self.model_root(config_name))): _sha256(path)
+                    for path in files
+                },
+                "schema_version": 1,
+            }
+            manifest_tmp.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+            frame.write_parquet(shard_tmp)
+            os.replace(manifest_tmp, manifest)
+            os.replace(shard_tmp, shard)
+        finally:
+            manifest_tmp.unlink(missing_ok=True)
+            shard_tmp.unlink(missing_ok=True)
+        candidate.ledger.complete_fold(
+            training_hash=candidate.training.hash,
+            candidate_identity=candidate.training.hash,
+            fold_id=fold_id,
+            fitted_state=manifest,
+            prediction_shard=shard,
+            resolved_settings=self._settings(config_name, fold_id),
+        )
+        candidate.fitted_folds.append(fold_id)
+
+
+def run_resolved_request(study: Study, spec: dict[str, Any], context: TabMResearchContext):
+    return _run_tabm_compatible_group(study, [(0, spec, context)])[0]
 
 
 def _tabm_materialization_key(request: dict[str, Any]) -> tuple[str, str, int]:
@@ -653,6 +762,7 @@ def _tabm_unique_name_batches(items):
 
 def _run_tabm_compatible_group(study: Study, items):
     from case_studies.research.models import ModelRun
+    from case_studies.research.recovery import ExecutionLedger
 
     completed: dict[int, ModelRun] = {}
     pending = []
@@ -674,6 +784,7 @@ def _run_tabm_compatible_group(study: Study, items):
         return completed
 
     registered = []
+    recovery_candidates = {}
     for index, spec, context in pending:
         training = study.results.register_training(
             spec,
@@ -681,15 +792,22 @@ def _run_tabm_compatible_group(study: Study, items):
             runtime_provenance=context.runtime_provenance,
         )
         train_dir = training.root / "run_log" / "training" / training.hash
-        model_dir = train_dir / "models"
-        if model_dir.exists():
-            raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
-        registered.append((index, spec, context, training, train_dir, model_dir))
+        ledger = ExecutionLedger(study, training.root)
+        candidate = _TabMRecoveryCandidate(
+            spec=spec,
+            context=context,
+            training=training,
+            ledger=ledger,
+            attempt=ledger.start(training.hash),
+            reused_folds=[],
+            fitted_folds=[],
+        )
+        recovery_candidates[context.config["config_name"]] = candidate
+        registered.append((index, spec, context, training, train_dir, candidate))
 
     first_context = pending[0][2]
     first_computation = pending[0][1].get("computation", pending[0][1])
-    batch_root = registered[0][4].parent / f".tabm-batch.{uuid.uuid4().hex}.tmp"
-    checkpoint_root = batch_root / "models"
+    recovery = _TabMRecovery(recovery_candidates)
     try:
         result = run_tabm_cv(
             first_context.dataset_pd,
@@ -704,7 +822,7 @@ def _run_tabm_compatible_group(study: Study, items):
             date_col=first_context.date_col,
             entity_col=first_context.entity_col,
             device=str(first_computation["numerics"]["device"]),
-            save_dir=batch_root / "diagnostics",
+            save_dir=None,
             register=False,
             temporal_by_fold=first_context.temporal_by_fold,
             temporal_keys=list(first_context.temporal_keys),
@@ -712,41 +830,62 @@ def _run_tabm_compatible_group(study: Study, items):
             class_weights_by_fold=first_context.class_weights_by_fold,
             seed=int(pending[0][1]["seed"]),
             num_threads=int(first_computation["numerics"]["num_threads"]),
-            checkpoint_root=checkpoint_root,
+            checkpoint_root=None,
             strict=True,
+            _recovery=recovery,
         )
-        for index, spec, context, training, train_dir, model_dir in registered:
-            predictions = _publish_tabm_predictions(study, spec, context, training, result)
-            source = checkpoint_root / context.config["config_name"]
-            if not source.is_dir():
-                raise ValueError(
-                    f"TabM batch did not persist fitted state for {context.config['config_name']}"
+        for index, spec, context, training, train_dir, candidate in registered:
+            failure = result.get("failures", {}).get(context.config["config_name"])
+            if failure is not None:
+                candidate.attempt.finish(
+                    "failed",
+                    {
+                        "error": str(failure),
+                        "error_type": type(failure).__name__,
+                        "fitted_folds": candidate.fitted_folds,
+                        "reused_folds": candidate.reused_folds,
+                    },
                 )
-            staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
-            staging.mkdir()
-            try:
-                os.replace(source, staging / context.config["config_name"])
-                os.replace(staging, model_dir)
-            except Exception:
-                shutil.rmtree(staging, ignore_errors=True)
-                raise
+                candidate.attempt = None
+                continue
+            predictions = _publish_tabm_predictions(study, spec, context, training, result)
             _record_tabm_runtime(train_dir, result, context.config["config_name"])
             verified = _cached_research_run(study, spec, context)
             if verified is None:
                 raise ValueError(
                     f"TabM batch result failed fitted-state validation for {context.config['config_name']}"
                 )
+            diagnostics = {
+                "execution_order": "fold_major",
+                "fitted_folds": candidate.fitted_folds,
+                "group_size": len(pending),
+                "reused": False,
+                "reused_folds": candidate.reused_folds,
+            }
+            candidate.attempt.finish("completed", diagnostics)
+            candidate.attempt = None
             completed[index] = ModelRun(
                 training=verified.training,
                 predictions=predictions,
-                diagnostics={
-                    "execution_order": "fold_major",
-                    "group_size": len(pending),
-                    "reused": False,
-                },
+                diagnostics=diagnostics,
             )
-    finally:
-        shutil.rmtree(batch_root, ignore_errors=True)
+        failures = list(result.get("failures", {}).values())
+        if failures:
+            raise failures[0]
+    except Exception as error:
+        for candidate in recovery_candidates.values():
+            if candidate.attempt is not None:
+                candidate.attempt.finish(
+                    "failed",
+                    {
+                        "error": str(error),
+                        "error_type": type(error).__name__,
+                        "fitted_folds": candidate.fitted_folds,
+                        "reused_folds": candidate.reused_folds,
+                    },
+                )
+                candidate.attempt = None
+        raise
     return completed
 
 
@@ -1658,6 +1797,7 @@ def run_tabm_cv(
     identity_params: dict[str, Any] | None = None,
     checkpoint_root: Path | None = None,
     strict: bool = False,
+    _recovery: _TabMRecovery | None = None,
 ) -> dict[str, Any]:
     """Walk-forward tabular DL CV with epoch-checkpoint IC evaluation.
 
@@ -1881,7 +2021,9 @@ def run_tabm_cv(
         config_name = cfg["config_name"]
         if config_name in states:
             raise ValueError(f"TabM configuration names must be unique: {config_name}")
-        if checkpoint_root is not None and config_name.startswith("tabpfn"):
+        if (checkpoint_root is not None or _recovery is not None) and config_name.startswith(
+            "tabpfn"
+        ):
             raise ValueError("TabPFN fitted-state persistence is not implemented")
         if register and case_study and force_retrain:
             from case_studies.utils.registry import build_training_spec, training_hash_from_spec
@@ -1907,6 +2049,7 @@ def run_tabm_cv(
             "available": True,
             "config": cfg,
             "elapsed_s": 0.0,
+            "error": None,
             "fold_checkpoint_ics": {},
             "prediction_frames": [],
             "started_at": datetime.now(UTC).isoformat(),
@@ -1938,6 +2081,13 @@ def run_tabm_cv(
             is_tabpfn = config_name.startswith("tabpfn")
             fold_t0 = time.perf_counter()
             seed_everything(seed + fd["fold"])
+            fold_prediction_frame = None
+            if _recovery is not None:
+                reused = _recovery.reuse(config_name, int(fd["fold"]))
+                if reused is not None:
+                    state["prediction_frames"].append(reused)
+                    print(f"    Fold {fd['fold']}: reused completed fitted state")
+                    continue
             if is_tabpfn:
                 try:
                     preds = _run_tabpfn_fold(
@@ -1965,7 +2115,21 @@ def run_tabm_cv(
                         min_obs=5,
                     )["ic_mean"]
                     state["fold_checkpoint_ics"].setdefault(1, []).append(ic)
-                    if incr_dir is not None:
+                    fold_prediction_frame = _checkpoint_prediction_frame(
+                        config_name,
+                        fd["fold"],
+                        {1: preds},
+                        fd["val_dates"],
+                        fd["val_entities"],
+                        fd["y_val"],
+                        date_col,
+                        entity_col,
+                        eval_actual=fd["y_eval_val"] if eval_col else None,
+                        eval_col=eval_col or "eval_actual",
+                    )
+                    if _recovery is not None:
+                        state["prediction_frames"].append(fold_prediction_frame)
+                    elif incr_dir is not None:
                         flush_fold_predictions(
                             incr_dir,
                             config_name,
@@ -1980,20 +2144,7 @@ def run_tabm_cv(
                             eval_col=eval_col or "eval_actual",
                         )
                     else:
-                        state["prediction_frames"].append(
-                            _checkpoint_prediction_frame(
-                                config_name,
-                                fd["fold"],
-                                {1: preds},
-                                fd["val_dates"],
-                                fd["val_entities"],
-                                fd["y_val"],
-                                date_col,
-                                entity_col,
-                                eval_actual=fd["y_eval_val"] if eval_col else None,
-                                eval_col=eval_col or "eval_actual",
-                            )
-                        )
+                        state["prediction_frames"].append(fold_prediction_frame)
 
                     fold_elapsed = time.perf_counter() - fold_t0
                     training_log.append(
@@ -2021,7 +2172,10 @@ def run_tabm_cv(
                 tabm_kwargs = {"n_features": n_features, "output_dim": output_dim, **cfg_params}
                 model = TabMModel(**tabm_kwargs)
                 train_kwargs: dict[str, Any] = {}
-                if checkpoint_root is not None:
+                candidate_checkpoint_root = (
+                    _recovery.model_root(config_name) if _recovery is not None else checkpoint_root
+                )
+                if candidate_checkpoint_root is not None:
                     from case_studies.utils.deep_model_state import (
                         deep_checkpoint_path,
                         write_deep_checkpoint,
@@ -2035,9 +2189,15 @@ def run_tabm_cv(
                         _preprocessing: dict[str, Any] = fd["preprocessing"],
                         _config_name: str = config_name,
                         _model_kwargs: dict[str, Any] = tabm_kwargs,
+                        _checkpoint_root: Path = candidate_checkpoint_root,
                     ) -> None:
                         write_deep_checkpoint(
-                            deep_checkpoint_path(checkpoint_root, _config_name, _fold, epoch),
+                            deep_checkpoint_path(
+                                _checkpoint_root,
+                                _config_name,
+                                _fold,
+                                epoch,
+                            ),
                             model=fitted_model,
                             architecture="tabm",
                             model_kwargs=_model_kwargs,
@@ -2051,27 +2211,53 @@ def run_tabm_cv(
                         )
 
                     train_kwargs["state_callback"] = persist_state
-                checkpoint_ics, checkpoint_preds, epoch_losses = _train_tabm_fold(
-                    model=model,
-                    X_train=fd["X_train"],
-                    y_train=fd["y_train"],
-                    X_val=fd["X_val"],
-                    y_val=fd["y_val"],
-                    y_eval_val=fd["y_eval_val"],
-                    val_dates=fd["val_dates"],
-                    val_entities=fd["val_entities"],
-                    n_epochs=cfg_n_epochs,
-                    batch_size=cfg_batch_size,
-                    checkpoint_interval=cfg_checkpoint,
-                    device=torch_device,
-                    task_type=task_type,
-                    class_values=tuple(class_values or ()),
-                    class_weights=(class_weights_by_fold or {}).get(int(fd["fold"]), ()),
-                    **train_kwargs,
-                )
+                try:
+                    checkpoint_ics, checkpoint_preds, epoch_losses = _train_tabm_fold(
+                        model=model,
+                        X_train=fd["X_train"],
+                        y_train=fd["y_train"],
+                        X_val=fd["X_val"],
+                        y_val=fd["y_val"],
+                        y_eval_val=fd["y_eval_val"],
+                        val_dates=fd["val_dates"],
+                        val_entities=fd["val_entities"],
+                        n_epochs=cfg_n_epochs,
+                        batch_size=cfg_batch_size,
+                        checkpoint_interval=cfg_checkpoint,
+                        device=torch_device,
+                        task_type=task_type,
+                        class_values=tuple(class_values or ()),
+                        class_weights=(class_weights_by_fold or {}).get(int(fd["fold"]), ()),
+                        **train_kwargs,
+                    )
+                except Exception as error:
+                    del model
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    if _recovery is None:
+                        raise
+                    state["available"] = False
+                    state["error"] = error
+                    state["prediction_frames"].clear()
+                    print(f"    Fold {fd['fold']}: {config_name} failed: {error}")
+                    continue
                 for ep, ic in checkpoint_ics.items():
                     state["fold_checkpoint_ics"].setdefault(ep, []).append(ic)
-                if incr_dir is not None:
+                fold_prediction_frame = _checkpoint_prediction_frame(
+                    config_name,
+                    fd["fold"],
+                    checkpoint_preds,
+                    fd["val_dates"],
+                    fd["val_entities"],
+                    fd["y_val"],
+                    date_col,
+                    entity_col,
+                    eval_actual=fd["y_eval_val"] if eval_col else None,
+                    eval_col=eval_col or "eval_actual",
+                )
+                if _recovery is not None:
+                    state["prediction_frames"].append(fold_prediction_frame)
+                elif incr_dir is not None:
                     flush_fold_predictions(
                         incr_dir,
                         config_name,
@@ -2086,20 +2272,7 @@ def run_tabm_cv(
                         eval_col=eval_col or "eval_actual",
                     )
                 else:
-                    state["prediction_frames"].append(
-                        _checkpoint_prediction_frame(
-                            config_name,
-                            fd["fold"],
-                            checkpoint_preds,
-                            fd["val_dates"],
-                            fd["val_entities"],
-                            fd["y_val"],
-                            date_col,
-                            entity_col,
-                            eval_actual=fd["y_eval_val"] if eval_col else None,
-                            eval_col=eval_col or "eval_actual",
-                        )
-                    )
+                    state["prediction_frames"].append(fold_prediction_frame)
 
                 del model, checkpoint_preds
                 if torch.cuda.is_available():
@@ -2127,6 +2300,15 @@ def run_tabm_cv(
                     f"    Fold {fd['fold']}: best_ep={best_ep}, "
                     f"IC={checkpoint_ics[best_ep]:+.4f} ({fold_elapsed:.1f}s)"
                 )
+            if _recovery is not None and fold_prediction_frame is not None:
+                try:
+                    _recovery.complete(config_name, int(fd["fold"]), fold_prediction_frame)
+                except Exception as error:
+                    state["available"] = False
+                    state["error"] = error
+                    state["prediction_frames"].clear()
+                    print(f"    Fold {fd['fold']}: {config_name} persistence failed: {error}")
+                    continue
             state["elapsed_s"] += time.perf_counter() - fold_t0
         del fd
         if torch.cuda.is_available():
@@ -2141,14 +2323,13 @@ def run_tabm_cv(
         completed_config_names.append(config_name)
         fold_checkpoint_ics = state["fold_checkpoint_ics"]
         config_prediction_frames = state["prediction_frames"]
-        cfg_all_preds = (
-            _load_incremental_preds_for_config(incr_dir, config_name)
-            if incr_dir is not None
-            else (
-                pl.concat(config_prediction_frames) if config_prediction_frames else pl.DataFrame()
-            )
-        )
-        if incr_dir is None and cfg_all_preds.height:
+        prediction_parts = list(config_prediction_frames)
+        if incr_dir is not None:
+            incremental = _load_incremental_preds_for_config(incr_dir, config_name)
+            if incremental.height:
+                prediction_parts.append(incremental)
+        cfg_all_preds = pl.concat(prediction_parts) if prediction_parts else pl.DataFrame()
+        if (incr_dir is None or _recovery is not None) and cfg_all_preds.height:
             in_memory_prediction_frames.append(cfg_all_preds)
         checkpoint_metrics: dict[int, dict[str, float]] = {}
         if cfg_all_preds.height:
@@ -2227,11 +2408,14 @@ def run_tabm_cv(
             all_curves.append(entry)
             cfg_curves_list.append(entry)
         print(f"    → best_epoch={best_cp}, IC={best_ic_val:+.4f} ({elapsed:.1f}s)")
-        if checkpoint_root is not None:
+        candidate_checkpoint_root = (
+            _recovery.model_root(config_name) if _recovery is not None else checkpoint_root
+        )
+        if candidate_checkpoint_root is not None:
             from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
 
             validate_deep_checkpoint_population(
-                checkpoint_root,
+                candidate_checkpoint_root,
                 config_name=config_name,
                 fold_ids=tuple(int(split["fold"]) for split in splits),
                 checkpoints=_tabm_checkpoint_epochs(cfg),
@@ -2305,14 +2489,29 @@ def run_tabm_cv(
                 print(f"    WARN: incremental registration failed for {config_name}: {exc}")
         gc.collect()
 
+    failures = {
+        config_name: state["error"]
+        for config_name, state in states.items()
+        if state["error"] is not None
+    }
     prediction_frames = [*cached_prediction_frames, *in_memory_prediction_frames]
-    if incr_dir is not None:
+    if incr_dir is not None and _recovery is None:
         for config_name in completed_config_names:
             frame = _load_incremental_preds_for_config(incr_dir, config_name)
             if frame.height:
                 prediction_frames.append(frame)
     all_predictions = pl.concat(prediction_frames) if prediction_frames else pl.DataFrame()
-    return _assemble_tabm_results(
+    if not config_results:
+        return {
+            "all_learning_curves": pl.DataFrame(all_curves),
+            "all_predictions": all_predictions,
+            "failures": failures,
+            "fold_metrics": pl.DataFrame(),
+            "grid_results": [],
+            "predictions": pl.DataFrame(),
+            "training_log": pl.DataFrame(training_log),
+        }
+    assembled = _assemble_tabm_results(
         config_results=config_results,
         all_predictions=all_predictions,
         curve_rows=all_curves,
@@ -2322,3 +2521,5 @@ def run_tabm_cv(
         entity_col=entity_col,
         eval_col=eval_col,
     )
+    assembled["failures"] = failures
+    return assembled

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -749,6 +749,7 @@ def _run_tabm_compatible_group(study: Study, items):
 
     compatibility_group = hashlib.sha256(_tabm_execution_key(items[0][1]).encode()).hexdigest()[:12]
     completed: dict[int, ModelRun] = {}
+    cached_indices = []
     pending = []
     for index, spec, context in items:
         cached = _cached_research_run(study, spec, context)
@@ -769,6 +770,7 @@ def _run_tabm_compatible_group(study: Study, items):
                     "disk_fold_cache": False,
                 },
             )
+            cached_indices.append(index)
         else:
             pending.append((index, spec, context))
     if not pending:
@@ -841,6 +843,13 @@ def _run_tabm_compatible_group(study: Study, items):
         measured_s = preparation_elapsed_s + sum(
             float(value) for value in fit_elapsed_by_candidate.values()
         )
+        group_measurements = {
+            "base_fold_preparations": int(execution_diagnostics["base_fold_preparations"]),
+            "base_fold_preparation_s": preparation_elapsed_s,
+            "preparation_fraction": (preparation_elapsed_s / measured_s if measured_s else 0.0),
+        }
+        for index in cached_indices:
+            completed[index].diagnostics.update(group_measurements)
         for index, spec, context, training, train_dir, candidate_key, candidate in registered:
             failure = result.get("failures", {}).get(candidate_key)
             if failure is not None:
@@ -877,10 +886,8 @@ def _run_tabm_compatible_group(study: Study, items):
                 "group_size": len(pending),
                 "reused": False,
                 "reused_folds": candidate.reused_folds,
-                "base_fold_preparations": int(execution_diagnostics["base_fold_preparations"]),
-                "base_fold_preparation_s": preparation_elapsed_s,
+                **group_measurements,
                 "candidate_fit_s": float(fit_elapsed_by_candidate[candidate_key]),
-                "preparation_fraction": (preparation_elapsed_s / measured_s if measured_s else 0.0),
                 "disk_fold_cache": False,
             }
             candidate.attempt.finish("completed", diagnostics)

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -494,6 +494,9 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
     try:
         for name in required - {"result.json"}:
             pl.read_parquet(diagnostics / name)
+        selected = pl.read_parquet(diagnostics / "predictions.parquet")
+        if "model_id" not in selected.columns or {"config", "epoch"} & set(selected.columns):
+            return None
         json.loads((diagnostics / "result.json").read_text())
     except (OSError, ValueError, json.JSONDecodeError, pl.exceptions.PolarsError):
         return None

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -1963,8 +1963,6 @@ def run_tabm_cv(
         )
     if len(feature_names) != len(set(feature_names)):
         raise ValueError("feature_names contains duplicates")
-    if not splits:
-        raise ValueError("TabM cross-validation requires at least one fold")
     if register and save_dir is None:
         raise ValueError(
             "register=True requires save_dir for incremental prediction saves. "
@@ -2115,6 +2113,8 @@ def run_tabm_cv(
         configs = pending_configs
 
     # Train every compatible candidate while one prepared fold is resident.
+    if not splits:
+        raise ValueError("TabM cross-validation requires at least one fold")
     config_results: list[dict[str, Any]] = list(cached_results)
     all_curves: list[dict] = list(cached_curves)
     training_log: list[dict] = []

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -495,7 +495,7 @@ def _cached_research_run(study: Study, spec: dict[str, Any], context: TabMResear
         for name in required - {"result.json"}:
             pl.read_parquet(diagnostics / name)
         json.loads((diagnostics / "result.json").read_text())
-    except (OSError, ValueError, json.JSONDecodeError):
+    except (OSError, ValueError, json.JSONDecodeError, pl.exceptions.PolarsError):
         return None
     return ModelRun(training=training, predictions=complete_predictions)
 

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -490,16 +490,16 @@ def _publish_tabm_predictions(
     context: TabMResearchContext,
     training,
     result: dict[str, Any],
+    *,
+    candidate_key: str | None = None,
 ):
     computation = spec.get("computation", spec)
+    result_key = candidate_key or context.config["config_name"]
     prediction_results = []
     for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
         predictions = (
             result["all_predictions"]
-            .filter(
-                (pl.col("config") == context.config["config_name"])
-                & (pl.col("epoch") == checkpoint)
-            )
+            .filter((pl.col("config") == result_key) & (pl.col("epoch") == checkpoint))
             .drop("config", "epoch")
             .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
             .with_columns(
@@ -553,14 +553,15 @@ class _TabMRecovery:
     def __init__(self, candidates: dict[str, _TabMRecoveryCandidate]) -> None:
         self.candidates = candidates
 
-    def model_root(self, config_name: str) -> Path:
-        candidate = self.candidates[config_name]
+    def model_root(self, candidate_key: str) -> Path:
+        candidate = self.candidates[candidate_key]
         return candidate.training.root / "run_log" / "training" / candidate.training.hash / "models"
 
-    def _paths(self, config_name: str, fold_id: int) -> tuple[Path, Path]:
-        candidate = self.candidates[config_name]
+    def _paths(self, candidate_key: str, fold_id: int) -> tuple[Path, Path]:
+        candidate = self.candidates[candidate_key]
+        artifact_name = candidate.context.config["config_name"]
         manifest = (
-            self.model_root(config_name) / config_name / f"fold_{fold_id:02d}" / "manifest.json"
+            self.model_root(candidate_key) / artifact_name / f"fold_{fold_id:02d}" / "manifest.json"
         )
         shard = (
             candidate.training.root
@@ -572,8 +573,8 @@ class _TabMRecovery:
         )
         return manifest, shard
 
-    def _settings(self, config_name: str, fold_id: int) -> dict[str, Any]:
-        candidate = self.candidates[config_name]
+    def _settings(self, candidate_key: str, fold_id: int) -> dict[str, Any]:
+        candidate = self.candidates[candidate_key]
         split = next(split for split in candidate.context.splits if int(split["fold"]) == fold_id)
         computation = candidate.spec.get("computation", candidate.spec)
         return {
@@ -582,30 +583,31 @@ class _TabMRecovery:
             "training_hash": candidate.training.hash,
         }
 
-    def _checkpoint_files(self, config_name: str, fold_id: int) -> tuple[Path, ...]:
+    def _checkpoint_files(self, candidate_key: str, fold_id: int) -> tuple[Path, ...]:
         from case_studies.utils.deep_model_state import checkpoint_sidecar, deep_checkpoint_path
 
-        candidate = self.candidates[config_name]
+        candidate = self.candidates[candidate_key]
+        artifact_name = candidate.context.config["config_name"]
         computation = candidate.spec.get("computation", candidate.spec)
         checkpoints = tuple(int(item["value"]) for item in computation["checkpoint_schedule"])
         files = []
         for checkpoint in checkpoints:
             path = deep_checkpoint_path(
-                self.model_root(config_name), config_name, fold_id, checkpoint
+                self.model_root(candidate_key), artifact_name, fold_id, checkpoint
             )
             files.extend((path, checkpoint_sidecar(path)))
         return tuple(files)
 
-    def _valid_manifest(self, config_name: str, fold_id: int, manifest: Path) -> bool:
+    def _valid_manifest(self, candidate_key: str, fold_id: int, manifest: Path) -> bool:
         if not manifest.is_file():
             return False
         try:
             record = json.loads(manifest.read_text())
         except (OSError, json.JSONDecodeError):
             return False
-        files = self._checkpoint_files(config_name, fold_id)
+        files = self._checkpoint_files(candidate_key, fold_id)
         expected = {
-            str(path.relative_to(self.model_root(config_name))): _sha256(path)
+            str(path.relative_to(self.model_root(candidate_key))): _sha256(path)
             for path in files
             if path.is_file()
         }
@@ -614,9 +616,9 @@ class _TabMRecovery:
             "schema_version": 1,
         }
 
-    def _quarantine(self, config_name: str, fold_id: int) -> None:
-        candidate = self.candidates[config_name]
-        manifest, shard = self._paths(config_name, fold_id)
+    def _quarantine(self, candidate_key: str, fold_id: int) -> None:
+        candidate = self.candidates[candidate_key]
+        manifest, shard = self._paths(candidate_key, fold_id)
         fold_dir = manifest.parent
         if not fold_dir.exists() and not shard.exists():
             return
@@ -628,18 +630,18 @@ class _TabMRecovery:
         if shard.exists():
             os.replace(shard, quarantine / shard.name)
 
-    def reuse(self, config_name: str, fold_id: int) -> pl.DataFrame | None:
-        candidate = self.candidates[config_name]
-        manifest, shard = self._paths(config_name, fold_id)
+    def reuse(self, candidate_key: str, fold_id: int) -> pl.DataFrame | None:
+        candidate = self.candidates[candidate_key]
+        manifest, shard = self._paths(candidate_key, fold_id)
         if not candidate.ledger.reusable_fold(
             training_hash=candidate.training.hash,
             candidate_identity=candidate.training.hash,
             fold_id=fold_id,
             fitted_state=manifest,
             prediction_shard=shard,
-            resolved_settings=self._settings(config_name, fold_id),
-        ) or not self._valid_manifest(config_name, fold_id, manifest):
-            self._quarantine(config_name, fold_id)
+            resolved_settings=self._settings(candidate_key, fold_id),
+        ) or not self._valid_manifest(candidate_key, fold_id, manifest):
+            self._quarantine(candidate_key, fold_id)
             return None
         frame = pl.read_parquet(shard)
         checkpoints = {
@@ -656,26 +658,26 @@ class _TabMRecovery:
             "y_true",
         }
         if required - set(frame.columns):
-            self._quarantine(config_name, fold_id)
+            self._quarantine(candidate_key, fold_id)
             return None
         if (
-            set(frame["config"].unique().to_list()) != {config_name}
+            set(frame["config"].unique().to_list()) != {candidate_key}
             or set(frame["fold_id"].unique().to_list()) != {fold_id}
             or {int(value) for value in frame["epoch"].unique().to_list()} != checkpoints
         ):
-            self._quarantine(config_name, fold_id)
+            self._quarantine(candidate_key, fold_id)
             return None
         keys = [candidate.context.date_col, candidate.context.entity_col, "fold_id", "epoch"]
         if frame.n_unique(keys) != frame.height:
-            self._quarantine(config_name, fold_id)
+            self._quarantine(candidate_key, fold_id)
             return None
         candidate.reused_folds.append(fold_id)
         return frame
 
-    def complete(self, config_name: str, fold_id: int, frame: pl.DataFrame) -> None:
-        candidate = self.candidates[config_name]
-        manifest, shard = self._paths(config_name, fold_id)
-        files = self._checkpoint_files(config_name, fold_id)
+    def complete(self, candidate_key: str, fold_id: int, frame: pl.DataFrame) -> None:
+        candidate = self.candidates[candidate_key]
+        manifest, shard = self._paths(candidate_key, fold_id)
+        files = self._checkpoint_files(candidate_key, fold_id)
         missing = [str(path) for path in files if not path.is_file()]
         if missing:
             raise ValueError(f"TabM fold checkpoint population is incomplete: {missing}")
@@ -686,7 +688,7 @@ class _TabMRecovery:
         try:
             record = {
                 "files": {
-                    str(path.relative_to(self.model_root(config_name))): _sha256(path)
+                    str(path.relative_to(self.model_root(candidate_key))): _sha256(path)
                     for path in files
                 },
                 "schema_version": 1,
@@ -704,7 +706,7 @@ class _TabMRecovery:
             fold_id=fold_id,
             fitted_state=manifest,
             prediction_shard=shard,
-            resolved_settings=self._settings(config_name, fold_id),
+            resolved_settings=self._settings(candidate_key, fold_id),
         )
         candidate.fitted_folds.append(fold_id)
 
@@ -741,25 +743,6 @@ def _tabm_execution_key(spec: dict[str, Any]) -> str:
     return canonical_json(shared)
 
 
-def _tabm_unique_name_batches(items):
-    batches: list[list[Any]] = []
-    for item in items:
-        config_name = item[2].config["config_name"]
-        target = next(
-            (
-                batch
-                for batch in batches
-                if config_name not in {member[2].config["config_name"] for member in batch}
-            ),
-            None,
-        )
-        if target is None:
-            target = []
-            batches.append(target)
-        target.append(item)
-    return batches
-
-
 def _run_tabm_compatible_group(study: Study, items):
     from case_studies.research.models import ModelRun
     from case_studies.research.recovery import ExecutionLedger
@@ -785,12 +768,18 @@ def _run_tabm_compatible_group(study: Study, items):
 
     registered = []
     recovery_candidates = {}
+    primary_index_by_key = {}
+    duplicate_indices: dict[str, list[int]] = {}
     for index, spec, context in pending:
         training = study.results.register_training(
             spec,
             execution_tier=spec["execution_tier"],
             runtime_provenance=context.runtime_provenance,
         )
+        candidate_key = training.hash
+        if candidate_key in recovery_candidates:
+            duplicate_indices.setdefault(candidate_key, []).append(index)
+            continue
         train_dir = training.root / "run_log" / "training" / training.hash
         ledger = ExecutionLedger(study, training.root)
         candidate = _TabMRecoveryCandidate(
@@ -802,8 +791,9 @@ def _run_tabm_compatible_group(study: Study, items):
             reused_folds=[],
             fitted_folds=[],
         )
-        recovery_candidates[context.config["config_name"]] = candidate
-        registered.append((index, spec, context, training, train_dir, candidate))
+        recovery_candidates[candidate_key] = candidate
+        primary_index_by_key[candidate_key] = index
+        registered.append((index, spec, context, training, train_dir, candidate_key, candidate))
 
     first_context = pending[0][2]
     first_computation = pending[0][1].get("computation", pending[0][1])
@@ -812,7 +802,10 @@ def _run_tabm_compatible_group(study: Study, items):
         result = run_tabm_cv(
             first_context.dataset_pd,
             list(first_context.splits),
-            configs=[context.config for _, _, context in pending],
+            configs=[
+                {**context.config, "_execution_key": candidate_key}
+                for _, _, context, _, _, candidate_key, _ in registered
+            ],
             n_features=len(first_context.feature_names),
             feature_names=list(first_context.feature_names),
             label_col=first_context.label_col,
@@ -834,8 +827,8 @@ def _run_tabm_compatible_group(study: Study, items):
             strict=True,
             _recovery=recovery,
         )
-        for index, spec, context, training, train_dir, candidate in registered:
-            failure = result.get("failures", {}).get(context.config["config_name"])
+        for index, spec, context, training, train_dir, candidate_key, candidate in registered:
+            failure = result.get("failures", {}).get(candidate_key)
             if failure is not None:
                 candidate.attempt.finish(
                     "failed",
@@ -848,8 +841,15 @@ def _run_tabm_compatible_group(study: Study, items):
                 )
                 candidate.attempt = None
                 continue
-            predictions = _publish_tabm_predictions(study, spec, context, training, result)
-            _record_tabm_runtime(train_dir, result, context.config["config_name"])
+            predictions = _publish_tabm_predictions(
+                study,
+                spec,
+                context,
+                training,
+                result,
+                candidate_key=candidate_key,
+            )
+            _record_tabm_runtime(train_dir, result, candidate_key)
             verified = _cached_research_run(study, spec, context)
             if verified is None:
                 raise ValueError(
@@ -872,6 +872,10 @@ def _run_tabm_compatible_group(study: Study, items):
         failures = list(result.get("failures", {}).values())
         if failures:
             raise failures[0]
+        for candidate_key, indices in duplicate_indices.items():
+            primary = completed[primary_index_by_key[candidate_key]]
+            for index in indices:
+                completed[index] = primary
     except Exception as error:
         for candidate in recovery_candidates.values():
             if candidate.attempt is not None:
@@ -919,8 +923,7 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]):
         execution_groups.setdefault(_tabm_execution_key(item[1]), []).append(item)
     completed = {}
     for compatible in execution_groups.values():
-        for batch in _tabm_unique_name_batches(compatible):
-            completed.update(_run_tabm_compatible_group(study, batch))
+        completed.update(_run_tabm_compatible_group(study, compatible))
     return tuple(completed[index] for index in range(len(requests)))
 
 
@@ -2018,10 +2021,11 @@ def run_tabm_cv(
 
     states: dict[str, dict[str, Any]] = {}
     for cfg in configs:
-        config_name = cfg["config_name"]
-        if config_name in states:
-            raise ValueError(f"TabM configuration names must be unique: {config_name}")
-        if (checkpoint_root is not None or _recovery is not None) and config_name.startswith(
+        artifact_name = cfg["config_name"]
+        candidate_key = str(cfg.get("_execution_key", artifact_name))
+        if candidate_key in states:
+            raise ValueError(f"TabM execution keys must be unique: {candidate_key}")
+        if (checkpoint_root is not None or _recovery is not None) and artifact_name.startswith(
             "tabpfn"
         ):
             raise ValueError("TabPFN fitted-state persistence is not implemented")
@@ -2030,7 +2034,7 @@ def run_tabm_cv(
 
             spec = build_training_spec(
                 cfg["family"],
-                config_name,
+                artifact_name,
                 label_col,
                 n_folds=len(splits),
                 n_epochs=cfg.get("n_epochs"),
@@ -2043,9 +2047,9 @@ def run_tabm_cv(
             if removed["prediction_sets"]:
                 print(
                     f"  cleared {removed['prediction_sets']} prior {prediction_split} "
-                    f"checkpoint(s) for {config_name}"
+                    f"checkpoint(s) for {artifact_name}"
                 )
-        states[config_name] = {
+        states[candidate_key] = {
             "available": True,
             "config": cfg,
             "elapsed_s": 0.0,
@@ -2070,20 +2074,21 @@ def run_tabm_cv(
             temporal_feature_names=temporal_feature_names,
         )
         print(f"  Fold {fd['fold']}: train={fd['n_train']:,}  val={fd['n_val']:,}")
-        for config_name, state in states.items():
+        for candidate_key, state in states.items():
             if not state["available"]:
                 continue
             cfg = state["config"]
+            artifact_name = cfg["config_name"]
             cfg_params = dict(cfg.get("params", {}))
             cfg_n_epochs = cfg.get("n_epochs", 200)
             cfg_batch_size = cfg.get("batch_size", 4096)
             cfg_checkpoint = cfg.get("checkpoint_interval", 25)
-            is_tabpfn = config_name.startswith("tabpfn")
+            is_tabpfn = artifact_name.startswith("tabpfn")
             fold_t0 = time.perf_counter()
             seed_everything(seed + fd["fold"])
             fold_prediction_frame = None
             if _recovery is not None:
-                reused = _recovery.reuse(config_name, int(fd["fold"]))
+                reused = _recovery.reuse(candidate_key, int(fd["fold"]))
                 if reused is not None:
                     state["prediction_frames"].append(reused)
                     print(f"    Fold {fd['fold']}: reused completed fitted state")
@@ -2116,7 +2121,7 @@ def run_tabm_cv(
                     )["ic_mean"]
                     state["fold_checkpoint_ics"].setdefault(1, []).append(ic)
                     fold_prediction_frame = _checkpoint_prediction_frame(
-                        config_name,
+                        candidate_key,
                         fd["fold"],
                         {1: preds},
                         fd["val_dates"],
@@ -2132,7 +2137,7 @@ def run_tabm_cv(
                     elif incr_dir is not None:
                         flush_fold_predictions(
                             incr_dir,
-                            config_name,
+                            candidate_key,
                             fd["fold"],
                             {1: preds},
                             fd["val_dates"],
@@ -2149,7 +2154,7 @@ def run_tabm_cv(
                     fold_elapsed = time.perf_counter() - fold_t0
                     training_log.append(
                         {
-                            "config": config_name,
+                            "config": candidate_key,
                             "fold": fd["fold"],
                             "elapsed_s": round(fold_elapsed, 1),
                             "n_train": fd["n_train"],
@@ -2173,7 +2178,9 @@ def run_tabm_cv(
                 model = TabMModel(**tabm_kwargs)
                 train_kwargs: dict[str, Any] = {}
                 candidate_checkpoint_root = (
-                    _recovery.model_root(config_name) if _recovery is not None else checkpoint_root
+                    _recovery.model_root(candidate_key)
+                    if _recovery is not None
+                    else checkpoint_root
                 )
                 if candidate_checkpoint_root is not None:
                     from case_studies.utils.deep_model_state import (
@@ -2187,7 +2194,7 @@ def run_tabm_cv(
                         *,
                         _fold: int = int(fd["fold"]),
                         _preprocessing: dict[str, Any] = fd["preprocessing"],
-                        _config_name: str = config_name,
+                        _config_name: str = artifact_name,
                         _model_kwargs: dict[str, Any] = tabm_kwargs,
                         _checkpoint_root: Path = candidate_checkpoint_root,
                     ) -> None:
@@ -2239,12 +2246,12 @@ def run_tabm_cv(
                     state["available"] = False
                     state["error"] = error
                     state["prediction_frames"].clear()
-                    print(f"    Fold {fd['fold']}: {config_name} failed: {error}")
+                    print(f"    Fold {fd['fold']}: {artifact_name} failed: {error}")
                     continue
                 for ep, ic in checkpoint_ics.items():
                     state["fold_checkpoint_ics"].setdefault(ep, []).append(ic)
                 fold_prediction_frame = _checkpoint_prediction_frame(
-                    config_name,
+                    candidate_key,
                     fd["fold"],
                     checkpoint_preds,
                     fd["val_dates"],
@@ -2260,7 +2267,7 @@ def run_tabm_cv(
                 elif incr_dir is not None:
                     flush_fold_predictions(
                         incr_dir,
-                        config_name,
+                        candidate_key,
                         fd["fold"],
                         checkpoint_preds,
                         fd["val_dates"],
@@ -2285,7 +2292,7 @@ def run_tabm_cv(
                 }
                 training_log.append(
                     {
-                        "config": config_name,
+                        "config": candidate_key,
                         "fold": fd["fold"],
                         "elapsed_s": round(fold_elapsed, 1),
                         "n_train": fd["n_train"],
@@ -2302,12 +2309,12 @@ def run_tabm_cv(
                 )
             if _recovery is not None and fold_prediction_frame is not None:
                 try:
-                    _recovery.complete(config_name, int(fd["fold"]), fold_prediction_frame)
+                    _recovery.complete(candidate_key, int(fd["fold"]), fold_prediction_frame)
                 except Exception as error:
                     state["available"] = False
                     state["error"] = error
                     state["prediction_frames"].clear()
-                    print(f"    Fold {fd['fold']}: {config_name} persistence failed: {error}")
+                    print(f"    Fold {fd['fold']}: {artifact_name} persistence failed: {error}")
                     continue
             state["elapsed_s"] += time.perf_counter() - fold_t0
         del fd
@@ -2315,17 +2322,18 @@ def run_tabm_cv(
             torch.cuda.empty_cache()
         gc.collect()
 
-    completed_config_names: list[str] = []
-    for config_name, state in states.items():
+    completed_candidate_keys: list[str] = []
+    for candidate_key, state in states.items():
         if not state["available"]:
             continue
         cfg = state["config"]
-        completed_config_names.append(config_name)
+        artifact_name = cfg["config_name"]
+        completed_candidate_keys.append(candidate_key)
         fold_checkpoint_ics = state["fold_checkpoint_ics"]
         config_prediction_frames = state["prediction_frames"]
         prediction_parts = list(config_prediction_frames)
         if incr_dir is not None:
-            incremental = _load_incremental_preds_for_config(incr_dir, config_name)
+            incremental = _load_incremental_preds_for_config(incr_dir, candidate_key)
             if incremental.height:
                 prediction_parts.append(incremental)
         cfg_all_preds = pl.concat(prediction_parts) if prediction_parts else pl.DataFrame()
@@ -2369,7 +2377,7 @@ def run_tabm_cv(
                 and (full_days is None or int(metric.get("ic_n_days", 0)) == full_days)
             ]
             if not eligible_checkpoints:
-                raise ValueError(f"No selectable checkpoint completed for {config_name}")
+                raise ValueError(f"No selectable checkpoint completed for {artifact_name}")
             best_cp = max(
                 eligible_checkpoints,
                 key=lambda epoch: checkpoint_metrics[epoch]["ic_mean"],
@@ -2386,7 +2394,7 @@ def run_tabm_cv(
         config_started_at = state["started_at"]
         config_results.append(
             {
-                "config_name": config_name,
+                "config_name": candidate_key,
                 "best_epoch": best_cp,
                 "best_ic": best_ic_val,
                 "ic_n_days": best_ic_n_days,
@@ -2398,7 +2406,7 @@ def run_tabm_cv(
         cfg_curves_list = []
         for ep, metric in sorted(checkpoint_metrics.items()):
             entry = {
-                "config": config_name,
+                "config": candidate_key,
                 "epoch": ep,
                 "ic_mean": float(metric["ic_mean"]),
                 "ic_std": float(metric.get("ic_std", 0.0)),
@@ -2409,14 +2417,14 @@ def run_tabm_cv(
             cfg_curves_list.append(entry)
         print(f"    → best_epoch={best_cp}, IC={best_ic_val:+.4f} ({elapsed:.1f}s)")
         candidate_checkpoint_root = (
-            _recovery.model_root(config_name) if _recovery is not None else checkpoint_root
+            _recovery.model_root(candidate_key) if _recovery is not None else checkpoint_root
         )
         if candidate_checkpoint_root is not None:
             from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
 
             validate_deep_checkpoint_population(
                 candidate_checkpoint_root,
-                config_name=config_name,
+                config_name=artifact_name,
                 fold_ids=tuple(int(split["fold"]) for split in splits),
                 checkpoints=_tabm_checkpoint_epochs(cfg),
                 architecture="tabm",
@@ -2441,7 +2449,7 @@ def run_tabm_cv(
                     t_hash = _register_tabm_config(
                         case_study=case_study,
                         label=label_col,
-                        config_name=config_name,
+                        config_name=artifact_name,
                         n_epochs=cfg.get("n_epochs"),
                         best_epoch=int(first_ep),
                         n_folds=len(splits),
@@ -2457,7 +2465,7 @@ def run_tabm_cv(
                         task_type=task_type,
                         class_values=class_values,
                         eval_col=eval_col,
-                        training_spec=training_specs[config_name],
+                        training_spec=training_specs[artifact_name],
                     )
 
                     # Remaining epochs: just register prediction_sets
@@ -2481,23 +2489,23 @@ def run_tabm_cv(
                             label=label_col,
                         )
                     print(
-                        f"    registered {config_name} incrementally ({len(epochs)} per-epoch slices)"
+                        f"    registered {artifact_name} incrementally ({len(epochs)} per-epoch slices)"
                     )
             except Exception as exc:
                 if strict:
                     raise
-                print(f"    WARN: incremental registration failed for {config_name}: {exc}")
+                print(f"    WARN: incremental registration failed for {artifact_name}: {exc}")
         gc.collect()
 
     failures = {
-        config_name: state["error"]
-        for config_name, state in states.items()
+        candidate_key: state["error"]
+        for candidate_key, state in states.items()
         if state["error"] is not None
     }
     prediction_frames = [*cached_prediction_frames, *in_memory_prediction_frames]
     if incr_dir is not None and _recovery is None:
-        for config_name in completed_config_names:
-            frame = _load_incremental_preds_for_config(incr_dir, config_name)
+        for candidate_key in completed_candidate_keys:
+            frame = _load_incremental_preds_for_config(incr_dir, candidate_key)
             if frame.height:
                 prediction_frames.append(frame)
     all_predictions = pl.concat(prediction_frames) if prediction_frames else pl.DataFrame()

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -663,7 +663,7 @@ def _run_tabm_compatible_group(study: Study, items):
                 training=cached.training,
                 predictions=cached.predictions,
                 diagnostics={
-                    "execution_order": "candidate_major_shared_preparation",
+                    "execution_order": "fold_major",
                     "group_size": len(items),
                     "reused": True,
                 },
@@ -740,7 +740,7 @@ def _run_tabm_compatible_group(study: Study, items):
                 training=verified.training,
                 predictions=predictions,
                 diagnostics={
-                    "execution_order": "candidate_major_shared_preparation",
+                    "execution_order": "fold_major",
                     "group_size": len(pending),
                     "reused": False,
                 },
@@ -1544,6 +1544,90 @@ def _register_tabm_config(
 # ---------------------------------------------------------------------------
 
 
+def _prepare_tabm_fold(
+    dataset_pd: pd.DataFrame,
+    split: dict[str, Any],
+    *,
+    feature_names: list[str],
+    label_col: str,
+    eval_label_col: str | None,
+    date_col: str,
+    entity_col: str,
+    temporal_by_fold,
+    temporal_keys: list[str] | None,
+    temporal_feature_names: list[str] | None,
+) -> dict[str, Any]:
+    dates = dataset_pd[date_col]
+    train_mask = (dates >= split["train_start"]) & (dates <= split["train_end"])
+    val_mask = (dates >= split["val_start"]) & (dates <= split["val_end"])
+    if temporal_by_fold is not None and temporal_keys and temporal_feature_names:
+        from utils.modeling import replace_temporal_columns
+
+        train_df = replace_temporal_columns(
+            dataset_pd,
+            train_mask,
+            temporal_by_fold,
+            temporal_keys,
+            temporal_feature_names,
+            split["fold"],
+        )
+        val_df = replace_temporal_columns(
+            dataset_pd,
+            val_mask,
+            temporal_by_fold,
+            temporal_keys,
+            temporal_feature_names,
+            split["fold"],
+        )
+    else:
+        train_df = dataset_pd.loc[train_mask]
+        val_df = dataset_pd.loc[val_mask]
+
+    train_valid = train_df[label_col].notna()
+    val_valid = val_df[label_col].notna()
+    if eval_label_col:
+        train_valid &= train_df[eval_label_col].notna()
+        val_valid &= val_df[eval_label_col].notna()
+    train_df = train_df.loc[train_valid]
+    val_df = val_df.loc[val_valid]
+    if len(train_df) < 100 or len(val_df) < 50:
+        raise ValueError(
+            f"Fold {split['fold']} is too small: train={len(train_df)}, val={len(val_df)}"
+        )
+
+    X_train = train_df[feature_names].values.astype(np.float32)
+    y_train = train_df[label_col].values.astype(np.float32)
+    X_val = val_df[feature_names].values.astype(np.float32)
+    y_val = val_df[label_col].values.astype(np.float32)
+    y_eval_val = (
+        val_df[eval_label_col].values.astype(np.float32) if eval_label_col else y_val.copy()
+    )
+    imputer = SimpleImputer(strategy="median", keep_empty_features=True)
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(imputer.fit_transform(X_train))
+    X_val = scaler.transform(imputer.transform(X_val))
+    if scaler.mean_ is None or scaler.scale_ is None:
+        raise RuntimeError("fitted standard scaler did not expose its state")
+    return {
+        "fold": split["fold"],
+        "X_train": X_train,
+        "y_train": y_train,
+        "X_val": X_val,
+        "y_val": y_val,
+        "y_eval_val": y_eval_val,
+        "val_dates": val_df[date_col].values,
+        "val_entities": val_df[entity_col].values,
+        "n_train": len(X_train),
+        "n_val": len(X_val),
+        "preprocessing": {
+            "feature_names": list(feature_names),
+            "imputer_statistics": imputer.statistics_.astype(np.float32),
+            "scaler_mean": np.asarray(scaler.mean_, dtype=np.float32),
+            "scaler_scale": np.asarray(scaler.scale_, dtype=np.float32),
+        },
+    }
+
+
 def run_tabm_cv(
     dataset_pd: pd.DataFrame,
     splits: list[dict[str, Any]],
@@ -1782,116 +1866,21 @@ def run_tabm_cv(
             )
         configs = pending_configs
 
-    dates_series = dataset_pd[date_col]
-
-    # Pre-build per-fold data: mask dates → extract numpy → impute + scale
-    print("Preparing fold data...")
-    fold_data = []
-    for split in splits:
-        train_mask = (dates_series >= split["train_start"]) & (dates_series <= split["train_end"])
-        val_mask = (dates_series >= split["val_start"]) & (dates_series <= split["val_end"])
-
-        if (
-            temporal_by_fold is not None
-            and temporal_keys is not None
-            and temporal_feature_names is not None
-            and temporal_keys
-            and temporal_feature_names
-        ):
-            from utils.modeling import replace_temporal_columns
-
-            train_df = replace_temporal_columns(
-                dataset_pd,
-                train_mask,
-                temporal_by_fold,
-                temporal_keys,
-                temporal_feature_names,
-                split["fold"],
-            )
-            val_df = replace_temporal_columns(
-                dataset_pd,
-                val_mask,
-                temporal_by_fold,
-                temporal_keys,
-                temporal_feature_names,
-                split["fold"],
-            )
-        else:
-            train_df = dataset_pd.loc[train_mask]
-            val_df = dataset_pd.loc[val_mask]
-
-        # Drop rows without a fit target or declared evaluation target.
-        train_valid = train_df[label_col].notna()
-        val_valid = val_df[label_col].notna()
-        if eval_label_col:
-            train_valid &= train_df[eval_label_col].notna()
-            val_valid &= val_df[eval_label_col].notna()
-        train_df = train_df.loc[train_valid]
-        val_df = val_df.loc[val_valid]
-
-        if len(train_df) < 100 or len(val_df) < 50:
-            raise ValueError(
-                f"Fold {split['fold']} is too small: train={len(train_df)}, val={len(val_df)}"
-            )
-
-        X_train = train_df[feature_names].values.astype(np.float32)
-        y_train = train_df[label_col].values.astype(np.float32)
-        X_val = val_df[feature_names].values.astype(np.float32)
-        y_val = val_df[label_col].values.astype(np.float32)
-        y_eval_val = (
-            val_df[eval_label_col].values.astype(np.float32) if eval_label_col else y_val.copy()
-        )
-        val_dates = val_df[date_col].values
-        val_entities = val_df[entity_col].values
-
-        # Impute + scale per fold
-        imputer = SimpleImputer(strategy="median", keep_empty_features=True)
-        scaler = StandardScaler()
-        X_train = scaler.fit_transform(imputer.fit_transform(X_train))
-        X_val = scaler.transform(imputer.transform(X_val))
-        if scaler.mean_ is None or scaler.scale_ is None:
-            raise RuntimeError("fitted standard scaler did not expose its state")
-
-        fold_data.append(
-            {
-                "fold": split["fold"],
-                "X_train": X_train,
-                "y_train": y_train,
-                "X_val": X_val,
-                "y_val": y_val,
-                "y_eval_val": y_eval_val,
-                "val_dates": val_dates,
-                "val_entities": val_entities,
-                "n_train": len(X_train),
-                "n_val": len(X_val),
-                "preprocessing": {
-                    "feature_names": list(feature_names),
-                    "imputer_statistics": imputer.statistics_.astype(np.float32),
-                    "scaler_mean": np.asarray(scaler.mean_, dtype=np.float32),
-                    "scaler_scale": np.asarray(scaler.scale_, dtype=np.float32),
-                },
-            }
-        )
-        print(f"  Fold {split['fold']}: train={len(X_train):,}  val={len(X_val):,}")
-
-    if not fold_data:
-        raise ValueError("No valid folds created. Check data size.")
-
-    # Grid search — train each config, evaluate at checkpoints, store ALL predictions.
-    # Incremental save: flush predictions to disk after each fold × config.
+    # Train every compatible candidate while one prepared fold is resident.
     config_results: list[dict[str, Any]] = list(cached_results)
     all_curves: list[dict] = list(cached_curves)
     training_log: list[dict] = []
     in_memory_prediction_frames: list[pl.DataFrame] = []
-
-    # Set up incremental save directory
     run_save_dir = save_dir / label_col if save_dir is not None else None
     incr_dir = run_save_dir / "_incremental" if run_save_dir is not None else None
     if incr_dir is not None:
         incr_dir.mkdir(parents=True, exist_ok=True)
 
+    states: dict[str, dict[str, Any]] = {}
     for cfg in configs:
         config_name = cfg["config_name"]
+        if config_name in states:
+            raise ValueError(f"TabM configuration names must be unique: {config_name}")
         if checkpoint_root is not None and config_name.startswith("tabpfn"):
             raise ValueError("TabPFN fitted-state persistence is not implemented")
         if register and case_study and force_retrain:
@@ -1914,24 +1903,41 @@ def run_tabm_cv(
                     f"  cleared {removed['prediction_sets']} prior {prediction_split} "
                     f"checkpoint(s) for {config_name}"
                 )
-        cfg_params = dict(cfg.get("params", {}))
-        cfg_n_epochs = cfg.get("n_epochs", 200)
-        cfg_batch_size = cfg.get("batch_size", 4096)
-        cfg_checkpoint = cfg.get("checkpoint_interval", 25)
-        is_tabpfn = config_name.startswith("tabpfn")
+        states[config_name] = {
+            "available": True,
+            "config": cfg,
+            "elapsed_s": 0.0,
+            "fold_checkpoint_ics": {},
+            "prediction_frames": [],
+            "started_at": datetime.now(UTC).isoformat(),
+        }
 
-        config_started_at = datetime.now(UTC).isoformat()
-        t0 = time.perf_counter()
-        print(f"\n  {config_name}:")
-
-        fold_checkpoint_ics: dict[int, list[float]] = {}
-        config_prediction_frames: list[pl.DataFrame] = []
-        tabpfn_available = True
-
-        for fd in fold_data:
+    print("Preparing and releasing folds...")
+    for split in splits:
+        fd = _prepare_tabm_fold(
+            dataset_pd,
+            split,
+            feature_names=feature_names,
+            label_col=label_col,
+            eval_label_col=eval_label_col,
+            date_col=date_col,
+            entity_col=entity_col,
+            temporal_by_fold=temporal_by_fold,
+            temporal_keys=temporal_keys,
+            temporal_feature_names=temporal_feature_names,
+        )
+        print(f"  Fold {fd['fold']}: train={fd['n_train']:,}  val={fd['n_val']:,}")
+        for config_name, state in states.items():
+            if not state["available"]:
+                continue
+            cfg = state["config"]
+            cfg_params = dict(cfg.get("params", {}))
+            cfg_n_epochs = cfg.get("n_epochs", 200)
+            cfg_batch_size = cfg.get("batch_size", 4096)
+            cfg_checkpoint = cfg.get("checkpoint_interval", 25)
+            is_tabpfn = config_name.startswith("tabpfn")
             fold_t0 = time.perf_counter()
             seed_everything(seed + fd["fold"])
-
             if is_tabpfn:
                 try:
                     preds = _run_tabpfn_fold(
@@ -1958,9 +1964,7 @@ def run_tabm_cv(
                         entity_col="symbol",
                         min_obs=5,
                     )["ic_mean"]
-                    fold_checkpoint_ics.setdefault(1, []).append(ic)
-
-                    # Incremental save: flush this fold's predictions to disk
+                    state["fold_checkpoint_ics"].setdefault(1, []).append(ic)
                     if incr_dir is not None:
                         flush_fold_predictions(
                             incr_dir,
@@ -1976,7 +1980,7 @@ def run_tabm_cv(
                             eval_col=eval_col or "eval_actual",
                         )
                     else:
-                        config_prediction_frames.append(
+                        state["prediction_frames"].append(
                             _checkpoint_prediction_frame(
                                 config_name,
                                 fd["fold"],
@@ -2005,17 +2009,14 @@ def run_tabm_cv(
                     )
                     print(f"    Fold {fd['fold']}: IC={ic:+.4f} ({fold_elapsed:.1f}s)")
                 except ImportError:
-                    if fd == fold_data[0]:
+                    if int(fd["fold"]) == int(splits[0]["fold"]):
                         print("    TabPFN not installed — skipping")
-                    tabpfn_available = False
-                    break
+                    state["available"] = False
                 except (RuntimeError, ValueError) as e:
-                    if fd == fold_data[0]:
+                    if int(fd["fold"]) == int(splits[0]["fold"]):
                         print(f"    TabPFN failed: {e}")
-                    tabpfn_available = False
-                    break
+                    state["available"] = False
             else:
-                # TabM: train to completion, store ALL checkpoint predictions
                 output_dim = len(class_values or []) if task_type == "classification" else 1
                 tabm_kwargs = {"n_features": n_features, "output_dim": output_dim, **cfg_params}
                 model = TabMModel(**tabm_kwargs)
@@ -2068,11 +2069,8 @@ def run_tabm_cv(
                     class_weights=(class_weights_by_fold or {}).get(int(fd["fold"]), ()),
                     **train_kwargs,
                 )
-
                 for ep, ic in checkpoint_ics.items():
-                    fold_checkpoint_ics.setdefault(ep, []).append(ic)
-
-                # Incremental save: flush ALL checkpoint predictions for this fold
+                    state["fold_checkpoint_ics"].setdefault(ep, []).append(ic)
                 if incr_dir is not None:
                     flush_fold_predictions(
                         incr_dir,
@@ -2088,7 +2086,7 @@ def run_tabm_cv(
                         eval_col=eval_col or "eval_actual",
                     )
                 else:
-                    config_prediction_frames.append(
+                    state["prediction_frames"].append(
                         _checkpoint_prediction_frame(
                             config_name,
                             fd["fold"],
@@ -2106,10 +2104,8 @@ def run_tabm_cv(
                 del model, checkpoint_preds
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
-
                 best_ep = max(checkpoint_ics, key=lambda e: checkpoint_ics[e])
                 fold_elapsed = time.perf_counter() - fold_t0
-                # Sample losses at checkpoint epochs for the log
                 loss_at_checkpoints = {
                     str(k): round(epoch_losses.get(k, 0.0), 6)
                     for k in sorted(checkpoint_ics.keys())
@@ -2131,10 +2127,20 @@ def run_tabm_cv(
                     f"    Fold {fd['fold']}: best_ep={best_ep}, "
                     f"IC={checkpoint_ics[best_ep]:+.4f} ({fold_elapsed:.1f}s)"
                 )
+            state["elapsed_s"] += time.perf_counter() - fold_t0
+        del fd
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
 
-        if is_tabpfn and not tabpfn_available:
+    completed_config_names: list[str] = []
+    for config_name, state in states.items():
+        if not state["available"]:
             continue
-
+        cfg = state["config"]
+        completed_config_names.append(config_name)
+        fold_checkpoint_ics = state["fold_checkpoint_ics"]
+        config_prediction_frames = state["prediction_frames"]
         cfg_all_preds = (
             _load_incremental_preds_for_config(incr_dir, config_name)
             if incr_dir is not None
@@ -2195,8 +2201,8 @@ def run_tabm_cv(
             best_ic_val = float("nan")
             best_ic_n_days = 0
             best_n_invalid = 0
-
-        elapsed = time.perf_counter() - t0
+        elapsed = float(state["elapsed_s"])
+        config_started_at = state["started_at"]
         config_results.append(
             {
                 "config_name": config_name,
@@ -2208,7 +2214,6 @@ def run_tabm_cv(
                 "started_at": config_started_at,
             }
         )
-
         cfg_curves_list = []
         for ep, metric in sorted(checkpoint_metrics.items()):
             entry = {
@@ -2221,28 +2226,17 @@ def run_tabm_cv(
             }
             all_curves.append(entry)
             cfg_curves_list.append(entry)
-
         print(f"    → best_epoch={best_cp}, IC={best_ic_val:+.4f} ({elapsed:.1f}s)")
-
         if checkpoint_root is not None:
             from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
 
             validate_deep_checkpoint_population(
                 checkpoint_root,
                 config_name=config_name,
-                fold_ids=tuple(int(fd["fold"]) for fd in fold_data),
+                fold_ids=tuple(int(split["fold"]) for split in splits),
                 checkpoints=_tabm_checkpoint_epochs(cfg),
                 architecture="tabm",
             )
-
-        # Incremental registration: persist this config immediately so a later
-        # interruption or re-run doesn't lose work. Safe because config-major
-        # loop: this config's folds are all complete at this point.
-        # Registers ONE prediction_set per epoch checkpoint (each parquet contains
-        # exactly one epoch's predictions). The training_run is registered once on
-        # the first epoch slice via _register_tabm_config; subsequent epochs go
-        # through register_prediction_set directly so we don't re-register the
-        # training_run each time.
         if register and case_study and incr_dir is not None:
             try:
                 if cfg_all_preds.height > 0:
@@ -2266,7 +2260,7 @@ def run_tabm_cv(
                         config_name=config_name,
                         n_epochs=cfg.get("n_epochs"),
                         best_epoch=int(first_ep),
-                        n_folds=len(fold_data),
+                        n_folds=len(splits),
                         ic_mean=epoch_ics.get(first_ep, best_ic_val),
                         predictions=first_slice,
                         notebook=notebook,
@@ -2309,12 +2303,11 @@ def run_tabm_cv(
                 if strict:
                     raise
                 print(f"    WARN: incremental registration failed for {config_name}: {exc}")
-
         gc.collect()
 
     prediction_frames = [*cached_prediction_frames, *in_memory_prediction_frames]
     if incr_dir is not None:
-        for config_name in [cfg["config_name"] for cfg in configs]:
+        for config_name in completed_config_names:
             frame = _load_incremental_preds_for_config(incr_dir, config_name)
             if frame.height:
                 prediction_frames.append(frame)

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -2360,7 +2360,7 @@ def run_tabm_cv(
                     del model
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()
-                    if _recovery is None:
+                    if _recovery is None and not (register and case_study):
                         raise
                     state["available"] = False
                     state["error"] = error
@@ -2628,6 +2628,7 @@ def run_tabm_cv(
         for candidate_key, state in states.items()
         if state["error"] is not None
     }
+    direct_failure = next(iter(failures.values()), None) if _recovery is None else None
     prediction_frames = [*cached_prediction_frames, *in_memory_prediction_frames]
     if incr_dir is not None and _recovery is None:
         for candidate_key in completed_candidate_keys:
@@ -2643,6 +2644,8 @@ def run_tabm_cv(
         },
     }
     if not config_results:
+        if direct_failure is not None:
+            raise direct_failure
         return {
             "all_learning_curves": pl.DataFrame(all_curves),
             "all_predictions": all_predictions,
@@ -2665,4 +2668,6 @@ def run_tabm_cv(
     )
     assembled["failures"] = failures
     assembled["execution_diagnostics"] = execution_diagnostics
+    if direct_failure is not None:
+        raise direct_failure
     return assembled

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -123,7 +123,8 @@ def _assert_results(execution, family: str, folds: list[int]) -> dict[str, dict[
             fitted_folds = {path.stem for path in (model_dir / "boosters").glob("fold_*.txt")}
         else:
             fitted_folds = {
-                path.parent.name for path in (model_dir / config_name).glob("fold_*/epoch_0001.pt")
+                path.parent.name
+                for path in (model_dir / run.training.hash).glob("fold_*/epoch_0001.pt")
             }
         expected_fitted_folds = {
             f"fold_{fold:02d}" if family == "tabular_dl" else f"fold_{fold}" for fold in folds

--- a/scripts/prove_us_equities_fold_major.py
+++ b/scripts/prove_us_equities_fold_major.py
@@ -45,12 +45,24 @@ def _requests(
     folds: list[int],
     max_symbols: int,
     train_sample_frac: float,
+    device: str,
 ):
-    common_reductions = {
-        "folds": folds,
-        "max_symbols": max_symbols,
-        "train_sample_frac": train_sample_frac,
-    }
+    common_reductions = {"folds": folds, "max_symbols": max_symbols}
+    if family == "tabular_dl":
+        common_reductions.update({"checkpoint_interval": 1, "n_epochs": 1})
+        variants = ((64, max_symbols), (80, max_symbols), (96, max(1, max_symbols // 2)))
+        return [
+            study.model(
+                family=family,
+                label=LABEL,
+                config_name="tabm_s",
+                overrides={"device": device, "hidden_dim": hidden_dim, "num_threads": 8},
+                execution_tier="preview",
+                preview_reductions={**common_reductions, "max_symbols": symbols},
+            )
+            for hidden_dim, symbols in variants
+        ]
+    common_reductions["train_sample_frac"] = train_sample_frac
     if family == "gbm":
         common_reductions.update({"checkpoint_interval": 2, "max_iterations": 4})
     incompatible_reductions = {
@@ -76,16 +88,24 @@ def _requests(
     ]
 
 
+def _run_key(run, family: str) -> str:
+    spec = run.training.spec()
+    if family != "tabular_dl":
+        return str(spec["config_name"])
+    hidden_dim = spec["computation"]["model"]["params"]["hidden_dim"]
+    return f"{spec['config_name']}-h{hidden_dim}"
+
+
 def _assert_results(execution, family: str, folds: list[int]) -> dict[str, dict[str, Any]]:
     assert len(execution.runs) == 3
-    expected_predictions = 3 if family == "linear" else 6
+    expected_predictions = 6 if family == "gbm" else 3
     assert execution.catalog_rows.height == expected_predictions
     assert set(execution.catalog_rows["execution_tier"]) == {"preview"}
     diagnostics = {}
     for run in execution.runs:
         spec = run.training.spec()
         config_name = spec["config_name"]
-        assert len(run.predictions) == (1 if family == "linear" else 2)
+        assert len(run.predictions) == (2 if family == "gbm" else 1)
         for prediction in run.predictions:
             frame = prediction.load()
             coverage = prediction.coverage()
@@ -97,13 +117,19 @@ def _assert_results(execution, family: str, folds: list[int]) -> dict[str, dict[
             assert sorted(keys["fold"].unique().to_list()) == folds
             assert frame["prediction"].is_finite().all()
         model_dir = run.training.root / "run_log" / "training" / run.training.hash / "models"
-        fitted = (
-            model_dir.glob("fold_*.joblib")
-            if family == "linear"
-            else (model_dir / "boosters").glob("fold_*.txt")
-        )
-        assert {path.stem for path in fitted} == {f"fold_{fold}" for fold in folds}
-        diagnostics[config_name] = dict(run.diagnostics)
+        if family == "linear":
+            fitted_folds = {path.stem for path in model_dir.glob("fold_*.joblib")}
+        elif family == "gbm":
+            fitted_folds = {path.stem for path in (model_dir / "boosters").glob("fold_*.txt")}
+        else:
+            fitted_folds = {
+                path.parent.name for path in (model_dir / config_name).glob("fold_*/epoch_0001.pt")
+            }
+        expected_fitted_folds = {
+            f"fold_{fold:02d}" if family == "tabular_dl" else f"fold_{fold}" for fold in folds
+        }
+        assert fitted_folds == expected_fitted_folds
+        diagnostics[_run_key(run, family)] = dict(run.diagnostics)
     config_names = list(diagnostics)
     assert (
         diagnostics[config_names[0]]["compatibility_group"]
@@ -133,6 +159,7 @@ def prove(
     folds: list[int],
     max_symbols: int,
     train_sample_frac: float,
+    device: str,
 ) -> dict[str, object]:
     _seed_worktree_workspace(workspace)
     study = Study.open(CASE_STUDY, workspace=workspace)
@@ -144,11 +171,12 @@ def prove(
             folds=folds,
             max_symbols=max_symbols,
             train_sample_frac=train_sample_frac,
+            device=device,
         ),
     )
     diagnostics = _assert_results(execution, family, folds)
     first_hashes = {
-        run.training.spec()["config_name"]: {
+        _run_key(run, family): {
             "training": run.training.hash,
             "predictions": [prediction.hash for prediction in run.predictions],
         }
@@ -164,17 +192,19 @@ def prove(
             folds=folds,
             max_symbols=max_symbols,
             train_sample_frac=train_sample_frac,
+            device=device,
         ),
     )
     restarted_hashes = {
-        run.training.spec()["config_name"]: {
+        _run_key(run, family): {
             "training": run.training.hash,
             "predictions": [prediction.hash for prediction in run.predictions],
         }
         for run in restarted.runs
     }
     assert restarted_hashes == first_hashes
-    assert all(run.diagnostics["cache_hit"] is True for run in restarted.runs)
+    reuse_field = "reused" if family == "tabular_dl" else "cache_hit"
+    assert all(run.diagnostics[reuse_field] is True for run in restarted.runs)
     assert all(run.diagnostics["base_fold_preparations"] == 0 for run in restarted.runs)
     prediction_hashes = [
         prediction_hash
@@ -210,7 +240,7 @@ def prove(
         "hashes": first_hashes,
         "max_symbols": max_symbols,
         "selected_catalog_rows": selected.height,
-        "train_sample_frac": train_sample_frac,
+        "train_sample_frac": train_sample_frac if family != "tabular_dl" else None,
         "workspace": str(study.storage_root("preview")),
     }
 
@@ -218,7 +248,8 @@ def prove(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("workspace", type=Path)
-    parser.add_argument("--family", choices=("gbm", "linear"), default="linear")
+    parser.add_argument("--family", choices=("gbm", "linear", "tabular_dl"), default="linear")
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
     parser.add_argument("--folds", nargs="+", type=int, default=[0, 1])
     parser.add_argument("--max-symbols", type=int, default=50)
     parser.add_argument("--train-sample-frac", type=float, default=0.05)
@@ -231,6 +262,7 @@ def main() -> None:
                 folds=sorted(set(args.folds)),
                 max_symbols=args.max_symbols,
                 train_sample_frac=args.train_sample_frac,
+                device=args.device,
             ),
             indent=2,
             sort_keys=True,

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -401,6 +401,9 @@ def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatc
         (4, "2024-01-04"),
     ]
     assert recovered.runs[1].diagnostics["reused"] is True
+    assert {run.diagnostics["base_fold_preparations"] for run in recovered.runs} == {2}
+    assert len({run.diagnostics["preparation_fraction"] for run in recovered.runs}) == 1
+    assert recovered.runs[1].diagnostics["candidate_fit_s"] == 0.0
     assert all(run.predictions[0].complete for run in recovered.runs)
 
 

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -187,9 +187,10 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
         prediction_frames = []
         for config_index, config in enumerate(configs):
             config_name = config["config_name"]
+            candidate_key = config.get("_execution_key", config_name)
             for split in splits:
                 fold = int(split["fold"])
-                root = _recovery.model_root(config_name) if _recovery else checkpoint_root
+                root = _recovery.model_root(candidate_key) if _recovery else checkpoint_root
                 checkpoint = root / config_name / f"fold_{fold:02d}" / "epoch_0001.pt"
                 checkpoint.parent.mkdir(parents=True, exist_ok=True)
                 checkpoint.write_text("fixture\n")
@@ -205,7 +206,7 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
                             "y_true": frame["fwd_ret_1d"],
                             "y_score": frame["x1"] + config_index / 100,
                             "fold_id": [fold] * len(frame),
-                            "config": [config_name] * len(frame),
+                            "config": [candidate_key] * len(frame),
                             "epoch": [1] * len(frame),
                         }
                     )
@@ -219,7 +220,7 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
                 {
                     "best_epoch": 1,
                     "best_ic": 0.0,
-                    "config_name": config["config_name"],
+                    "config_name": config.get("_execution_key", config["config_name"]),
                     "elapsed_s": 0.0,
                 }
                 for config in configs
@@ -566,6 +567,13 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
     monkeypatch,
 ) -> None:
     study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    prepared_folds: list[int] = []
+    original_prepare = tabular_dl._prepare_tabm_fold
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        prepared_folds.append(int(fold["fold"]))
+        return fold
 
     def deterministic_train(*, model, X_val, state_callback=None, **kwargs):
         if state_callback is not None:
@@ -575,6 +583,7 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
         return {1: 0.1}, {1: predictions}, {1: 0.01}
 
     monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+    monkeypatch.setattr(tabular_dl, "_prepare_tabm_fold", observed_prepare)
     result = run_models(
         study,
         requests=[
@@ -590,6 +599,7 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
 
     assert len({run.training.hash for run in result.runs}) == 2
     assert len({run.predictions[0].hash for run in result.runs}) == 2
+    assert prepared_folds == [0, 1]
     assert {run.training.spec()["identity_version"] for run in result.runs} == {3}
     assert {run.training.spec()["resolved_spec_schema"] for run in result.runs} == {
         "ml4t.resolved-spec/v1"
@@ -597,6 +607,39 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
     assert [
         run.training.spec()["computation"]["model"]["params"]["hidden_dim"] for run in result.runs
     ] == [5, 6]
+
+
+def test_tabm_duplicate_requests_share_one_execution(tmp_path, monkeypatch) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    prepared_folds: list[int] = []
+    original_prepare = tabular_dl._prepare_tabm_fold
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        prepared_folds.append(int(fold["fold"]))
+        return fold
+
+    def deterministic_train(*, model, X_val, state_callback=None, **kwargs):
+        if state_callback is not None:
+            state_callback(1, model)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64)
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+    monkeypatch.setattr(tabular_dl, "_prepare_tabm_fold", observed_prepare)
+    request = study.model(
+        family="tabular_dl",
+        label="fwd_ret_1d",
+        config_name="tabm_s",
+        overrides={"device": "cpu", "num_threads": 1},
+    )
+
+    result = run_models(study, requests=[request, request])
+
+    assert len(result.runs) == 2
+    assert result.runs[0].training.hash == result.runs[1].training.hash
+    assert result.runs[0].predictions[0].hash == result.runs[1].predictions[0].hash
+    assert prepared_folds == [0, 1]
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -606,6 +606,23 @@ def test_tabm_corrupt_diagnostics_are_rebuilt_from_completed_folds(tmp_path, mon
     assert prepared_folds == [0, 1]
     assert set(pl.read_parquet(training_log)["fold"]) == {0, 1}
 
+    selected_path = training_log.parent / "predictions.parquet"
+    obsolete = (
+        pl.read_parquet(selected_path)
+        .drop("model_id")
+        .with_columns(
+            pl.lit("tabm_s").alias("config"),
+            pl.lit(1, dtype=pl.Int32).alias("epoch"),
+        )
+    )
+    obsolete.write_parquet(selected_path)
+
+    request.run()
+
+    selected = pl.read_parquet(selected_path)
+    assert "model_id" in selected.columns
+    assert {"config", "epoch"}.isdisjoint(selected.columns)
+
 
 def test_tabm_candidate_order_does_not_change_identities_or_predictions(
     tmp_path,

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -242,10 +242,61 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
     assert len(result.runs) == 2
     assert len({run.training.hash for run in result.runs}) == 2
     assert all(run.predictions[0].complete for run in result.runs)
-    assert all(
-        run.diagnostics["execution_order"] == "candidate_major_shared_preparation"
-        for run in result.runs
+    assert all(run.diagnostics["execution_order"] == "fold_major" for run in result.runs)
+
+
+def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _, modeling_dataset, _ = _tabm_study(tmp_path, monkeypatch)
+    configs = modeling.load_configs("etfs", "fwd_ret_1d", "tabular_dl")
+    original_prepare = tabular_dl._prepare_tabm_fold
+    released_arrays: list[weakref.ReferenceType[np.ndarray]] = []
+    prepared_folds: list[int] = []
+    training_order: list[tuple[str, int]] = []
+
+    def observed_prepare(*args, **kwargs):
+        gc.collect()
+        if released_arrays:
+            assert released_arrays[-1]() is None
+        fold = original_prepare(*args, **kwargs)
+        prepared_folds.append(int(fold["fold"]))
+        released_arrays.append(weakref.ref(fold["X_train"]))
+        return fold
+
+    def fake_train_tabm_fold(*, model, X_val, val_dates, **kwargs):
+        hidden_dim = int(model.backbone[0].out_features)
+        training_order.append((str(val_dates[0])[:10], hidden_dim))
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64)
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_prepare_tabm_fold", observed_prepare)
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", fake_train_tabm_fold)
+
+    result = tabular_dl.run_tabm_cv(
+        modeling_dataset.dataset.to_pandas(),
+        modeling_dataset.splits,
+        configs=configs,
+        n_features=len(modeling_dataset.feature_names),
+        feature_names=modeling_dataset.feature_names,
+        label_col=modeling_dataset.label_col,
+        date_col=modeling_dataset.date_col,
+        entity_col=modeling_dataset.entity_cols[0],
+        device="cpu",
+        seed=42,
+        num_threads=1,
+        strict=True,
     )
+
+    assert prepared_folds == [0, 1]
+    assert training_order == [
+        ("2024-01-03", 4),
+        ("2024-01-03", 8),
+        ("2024-01-04", 4),
+        ("2024-01-04", 8),
+    ]
+    assert result["all_predictions"].height == 240
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -321,6 +321,22 @@ def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
     assert result["execution_diagnostics"]["base_fold_preparations"] == 2
 
 
+def test_tabm_cv_rejects_empty_fold_population(tmp_path, monkeypatch) -> None:
+    _, modeling_dataset, _ = _tabm_study(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="at least one fold"):
+        tabular_dl.run_tabm_cv(
+            modeling_dataset.dataset.to_pandas(),
+            [],
+            configs=modeling.load_configs("etfs", "fwd_ret_1d", "tabular_dl")[:1],
+            n_features=len(modeling_dataset.feature_names),
+            feature_names=modeling_dataset.feature_names,
+            label_col=modeling_dataset.label_col,
+            date_col=modeling_dataset.date_col,
+            device="cpu",
+        )
+
+
 def test_tabm_batch_reuses_completed_fold_after_interruption(tmp_path, monkeypatch) -> None:
     study, _, _ = _tabm_study(tmp_path, monkeypatch)
     calls: list[str] = []
@@ -470,7 +486,7 @@ def test_tabm_batch_rejects_corrupt_checkpoint_and_refits_only_its_fold(
     )
     original = request.run()
     model_root = original.training.root / "run_log" / "training" / original.training.hash / "models"
-    checkpoint = model_root / "tabm_s" / "fold_00" / "epoch_0001.pt"
+    checkpoint = model_root / original.training.hash / "fold_00" / "epoch_0001.pt"
     checkpoint.write_bytes(checkpoint.read_bytes() + b"corrupt")
 
     recovered = request.run()
@@ -500,7 +516,7 @@ def test_tabm_saved_weight_checkpoint_replays_validation_predictions(
         overrides={"device": "cpu", "num_threads": 1},
     ).run()
     model_root = run.training.root / "run_log" / "training" / run.training.hash / "models"
-    checkpoint = model_root / "tabm_s" / "fold_00" / "epoch_0001.pt"
+    checkpoint = model_root / run.training.hash / "fold_00" / "epoch_0001.pt"
     model, preprocessing, metadata = restore_deep_model(
         checkpoint,
         lambda architecture, kwargs: tabular_dl.TabMModel(**kwargs),
@@ -624,6 +640,15 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
     assert [
         run.training.spec()["computation"]["model"]["params"]["hidden_dim"] for run in result.runs
     ] == [5, 6]
+    for run in result.runs:
+        diagnostics = run.training.root / "run_log" / "training" / run.training.hash / "diagnostics"
+        assert {path.name for path in diagnostics.iterdir()} == {
+            "all_predictions.parquet",
+            "learning_curves.parquet",
+            "predictions.parquet",
+            "result.json",
+            "training_log.parquet",
+        }
 
 
 def test_tabm_duplicate_requests_share_one_execution(tmp_path, monkeypatch) -> None:
@@ -658,6 +683,49 @@ def test_tabm_duplicate_requests_share_one_execution(tmp_path, monkeypatch) -> N
     assert result.runs[0].predictions[0].hash == result.runs[1].predictions[0].hash
     assert prepared_folds == [0, 1]
     assert {run.diagnostics["base_fold_preparations"] for run in result.runs} == {2}
+
+
+def test_tabm_equivalent_named_presets_share_identity_stable_checkpoints(
+    tmp_path, monkeypatch
+) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    prepared_folds: list[int] = []
+    original_prepare = tabular_dl._prepare_tabm_fold
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        prepared_folds.append(int(fold["fold"]))
+        return fold
+
+    monkeypatch.setattr(tabular_dl, "_prepare_tabm_fold", observed_prepare)
+    requests = [
+        study.model(
+            family="tabular_dl",
+            label="fwd_ret_1d",
+            config_name=name,
+            overrides={"device": "cpu", "hidden_dim": 6, "num_threads": 1},
+        )
+        for name in ("tabm_s", "tabm_m")
+    ]
+
+    result = run_models(study, requests=requests)
+    replay = requests[1].run()
+
+    assert result.runs[0].training.hash == result.runs[1].training.hash == replay.training.hash
+    assert result.runs[0].predictions[0].hash == result.runs[1].predictions[0].hash
+    assert prepared_folds == [0, 1]
+    checkpoint_root = (
+        replay.training.root
+        / "run_log"
+        / "training"
+        / replay.training.hash
+        / "models"
+        / replay.training.hash
+    )
+    assert {path.parent.name for path in checkpoint_root.glob("fold_*/epoch_0001.pt")} == {
+        "fold_00",
+        "fold_01",
+    }
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -703,6 +703,9 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
             "result.json",
             "training_log.parquet",
         }
+        selected = pl.read_parquet(diagnostics / "predictions.parquet")
+        assert "model_id" in selected.columns
+        assert {"config", "epoch"}.isdisjoint(selected.columns)
 
 
 def test_tabm_duplicate_requests_share_one_execution(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -24,7 +24,7 @@ from case_studies.research import (
 )
 from case_studies.research.results import ResultsCatalog
 from case_studies.utils import gbm as gbm_utils
-from case_studies.utils import linear
+from case_studies.utils import linear, tabular_dl
 from case_studies.utils.latent_factors import adapter as latent_adapter
 from case_studies.utils.latent_factors import case_study as latent_case_study
 from case_studies.utils.latent_factors.cae import run_cae_fold
@@ -51,12 +51,12 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def _linear_study(tmp_path, monkeypatch):
+def _linear_study(tmp_path, monkeypatch, *, n_symbols: int = 6):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
     dates = ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
-    symbols = [f"S{index}" for index in range(6)]
+    symbols = [f"S{index}" for index in range(n_symbols)]
     rows = []
     for date_index, date in enumerate(dates):
         for symbol_index, symbol in enumerate(symbols):
@@ -130,6 +130,122 @@ def _linear_study(tmp_path, monkeypatch):
         },
     )
     return study
+
+
+def _tabm_study(tmp_path, monkeypatch):
+    study = _linear_study(tmp_path, monkeypatch, n_symbols=60)
+    modeling_dataset = linear.load_modeling_dataset("etfs", "fwd_ret_1d")
+    loads: list[tuple[str, str, int]] = []
+
+    def load_dataset(case_study, label, *, max_symbols=0):
+        loads.append((case_study, label, max_symbols))
+        return modeling_dataset
+
+    configs = [
+        {
+            "batch_size": 64,
+            "checkpoint_interval": 1,
+            "config_name": name,
+            "family": "tabular_dl",
+            "library": "tabm",
+            "n_epochs": 1,
+            "params": {"dropout": 0.0, "hidden_dim": hidden, "n_members": 2},
+        }
+        for name, hidden in (("tabm_s", 4), ("tabm_m", 8))
+    ]
+    monkeypatch.setattr(modeling, "load_modeling_dataset", load_dataset)
+    monkeypatch.setattr(modeling, "load_configs", lambda *args, **kwargs: configs)
+    return study, modeling_dataset, loads
+
+
+def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    study, modeling_dataset, loads = _tabm_study(tmp_path, monkeypatch)
+    conversions = 0
+    executions: list[tuple[str, ...]] = []
+    original_to_pandas = pl.DataFrame.to_pandas
+
+    def counted_to_pandas(frame, *args, **kwargs):
+        nonlocal conversions
+        if frame is modeling_dataset.dataset:
+            conversions += 1
+        return original_to_pandas(frame, *args, **kwargs)
+
+    def fake_run_tabm_cv(dataset_pd, splits, *, configs, checkpoint_root, **kwargs):
+        executions.append(tuple(config["config_name"] for config in configs))
+        prediction_frames = []
+        for config_index, config in enumerate(configs):
+            config_name = config["config_name"]
+            for split in splits:
+                fold = int(split["fold"])
+                checkpoint = checkpoint_root / config_name / f"fold_{fold:02d}" / "epoch_0001.pt"
+                checkpoint.parent.mkdir(parents=True, exist_ok=True)
+                checkpoint.write_text("fixture\n")
+                valid = dataset_pd["timestamp"].between(
+                    split["val_start"], split["val_end"], inclusive="both"
+                )
+                frame = dataset_pd.loc[valid]
+                prediction_frames.append(
+                    pl.DataFrame(
+                        {
+                            "timestamp": frame["timestamp"],
+                            "symbol": frame["symbol"],
+                            "y_true": frame["fwd_ret_1d"],
+                            "y_score": frame["x1"] + config_index / 100,
+                            "fold_id": [fold] * len(frame),
+                            "config": [config_name] * len(frame),
+                            "epoch": [1] * len(frame),
+                        }
+                    )
+                )
+        all_predictions = pl.concat(prediction_frames)
+        return {
+            "all_learning_curves": pl.DataFrame(),
+            "all_predictions": all_predictions,
+            "fold_metrics": pl.DataFrame(),
+            "grid_results": [
+                {
+                    "best_epoch": 1,
+                    "best_ic": 0.0,
+                    "config_name": config["config_name"],
+                    "elapsed_s": 0.0,
+                }
+                for config in configs
+            ],
+            "predictions": all_predictions,
+            "training_log": pl.DataFrame(),
+        }
+
+    monkeypatch.setattr(pl.DataFrame, "to_pandas", counted_to_pandas)
+    monkeypatch.setattr(tabular_dl, "run_tabm_cv", fake_run_tabm_cv)
+    monkeypatch.setattr(
+        "case_studies.utils.deep_model_state.validate_deep_checkpoint_population",
+        lambda *args, **kwargs: (),
+    )
+    requests = [
+        study.model(
+            family="tabular_dl",
+            label="fwd_ret_1d",
+            config_name=config_name,
+            overrides={"device": "cpu", "num_threads": 1},
+        )
+        for config_name in ("tabm_s", "tabm_m")
+    ]
+
+    result = run_models(study, requests=requests)
+
+    assert loads == [("etfs", "fwd_ret_1d", 0)]
+    assert conversions == 1
+    assert executions == [("tabm_s", "tabm_m")]
+    assert len(result.runs) == 2
+    assert len({run.training.hash for run in result.runs}) == 2
+    assert all(run.predictions[0].complete for run in result.runs)
+    assert all(
+        run.diagnostics["execution_order"] == "candidate_major_shared_preparation"
+        for run in result.runs
+    )
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -571,6 +571,42 @@ def test_tabm_saved_weight_checkpoint_replays_validation_predictions(
     np.testing.assert_allclose(replay, stored, rtol=0.0, atol=1e-7)
 
 
+def test_tabm_corrupt_diagnostics_are_rebuilt_from_completed_folds(tmp_path, monkeypatch) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    prepared_folds: list[int] = []
+    original_prepare = tabular_dl._prepare_tabm_fold
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        prepared_folds.append(int(fold["fold"]))
+        return fold
+
+    monkeypatch.setattr(tabular_dl, "_prepare_tabm_fold", observed_prepare)
+    request = study.model(
+        family="tabular_dl",
+        label="fwd_ret_1d",
+        config_name="tabm_s",
+        overrides={"device": "cpu", "num_threads": 1},
+    )
+    original = request.run()
+    training_log = (
+        original.training.root
+        / "run_log"
+        / "training"
+        / original.training.hash
+        / "diagnostics"
+        / "training_log.parquet"
+    )
+    training_log.write_bytes(b"truncated")
+
+    repaired = request.run()
+
+    assert repaired.training.hash == original.training.hash
+    assert repaired.diagnostics["base_fold_preparations"] == 0
+    assert prepared_folds == [0, 1]
+    assert set(pl.read_parquet(training_log)["fold"]) == {0, 1}
+
+
 def test_tabm_candidate_order_does_not_change_identities_or_predictions(
     tmp_path,
     monkeypatch,

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -372,6 +372,15 @@ def test_tabm_batch_reuses_completed_fold_after_interruption(tmp_path, monkeypat
     assert recovered.diagnostics["base_fold_preparations"] == 1
     assert recovered.predictions[0].complete
     assert recovered.predictions[0].coverage()["n_expected"] == 120
+    training_log = pl.read_parquet(
+        recovered.training.root
+        / "run_log"
+        / "training"
+        / recovered.training.hash
+        / "diagnostics"
+        / "training_log.parquet"
+    )
+    assert set(training_log["fold"]) == {0, 1}
 
 
 def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatch) -> None:
@@ -496,6 +505,15 @@ def test_tabm_batch_rejects_corrupt_checkpoint_and_refits_only_its_fold(
     assert recovered.diagnostics["fitted_folds"] == [0]
     assert recovered.diagnostics["reused_folds"] == [1]
     assert recovered.diagnostics["base_fold_preparations"] == 1
+    training_log = pl.read_parquet(
+        recovered.training.root
+        / "run_log"
+        / "training"
+        / recovered.training.hash
+        / "diagnostics"
+        / "training_log.parquet"
+    )
+    assert set(training_log["fold"]) == {0, 1}
     invalid = (
         original.training.root / "run_log" / "training" / original.training.hash / "invalid_folds"
     )

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -215,6 +215,13 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
         return {
             "all_learning_curves": pl.DataFrame(),
             "all_predictions": all_predictions,
+            "execution_diagnostics": {
+                "base_fold_preparation_s": 0.2,
+                "base_fold_preparations": len(splits),
+                "candidate_fit_s": {
+                    config.get("_execution_key", config["config_name"]): 0.1 for config in configs
+                },
+            },
             "fold_metrics": pl.DataFrame(),
             "grid_results": [
                 {
@@ -254,6 +261,9 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
     assert len({run.training.hash for run in result.runs}) == 2
     assert all(run.predictions[0].complete for run in result.runs)
     assert all(run.diagnostics["execution_order"] == "fold_major" for run in result.runs)
+    assert all(run.diagnostics["base_fold_preparations"] == 2 for run in result.runs)
+    assert all(run.diagnostics["compatibility_group_size"] == 2 for run in result.runs)
+    assert all(run.diagnostics["disk_fold_cache"] is False for run in result.runs)
 
 
 def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
@@ -308,6 +318,7 @@ def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
         ("2024-01-04", 8),
     ]
     assert result["all_predictions"].height == 240
+    assert result["execution_diagnostics"]["base_fold_preparations"] == 2
 
 
 def test_tabm_batch_reuses_completed_fold_after_interruption(tmp_path, monkeypatch) -> None:
@@ -342,6 +353,7 @@ def test_tabm_batch_reuses_completed_fold_after_interruption(tmp_path, monkeypat
     assert calls == ["2024-01-03", "2024-01-04", "2024-01-04"]
     assert recovered.diagnostics["reused_folds"] == [0]
     assert recovered.diagnostics["fitted_folds"] == [1]
+    assert recovered.diagnostics["base_fold_preparations"] == 1
     assert recovered.predictions[0].complete
     assert recovered.predictions[0].coverage()["n_expected"] == 120
 
@@ -464,6 +476,7 @@ def test_tabm_batch_rejects_corrupt_checkpoint_and_refits_only_its_fold(
     assert recovered.training.hash == original.training.hash
     assert recovered.diagnostics["fitted_folds"] == [0]
     assert recovered.diagnostics["reused_folds"] == [1]
+    assert recovered.diagnostics["base_fold_preparations"] == 1
     invalid = (
         original.training.root / "run_log" / "training" / original.training.hash / "invalid_folds"
     )
@@ -600,6 +613,7 @@ def test_tabm_variants_from_one_named_preset_keep_separate_identities(
     assert len({run.training.hash for run in result.runs}) == 2
     assert len({run.predictions[0].hash for run in result.runs}) == 2
     assert prepared_folds == [0, 1]
+    assert {run.diagnostics["base_fold_preparations"] for run in result.runs} == {2}
     assert {run.training.spec()["identity_version"] for run in result.runs} == {3}
     assert {run.training.spec()["resolved_spec_schema"] for run in result.runs} == {
         "ml4t.resolved-spec/v1"
@@ -640,6 +654,7 @@ def test_tabm_duplicate_requests_share_one_execution(tmp_path, monkeypatch) -> N
     assert result.runs[0].training.hash == result.runs[1].training.hash
     assert result.runs[0].predictions[0].hash == result.runs[1].predictions[0].hash
     assert prepared_folds == [0, 1]
+    assert {run.diagnostics["base_fold_preparations"] for run in result.runs} == {2}
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 import numpy as np
 import polars as pl
 import pytest
+import torch
 import yaml
 
 from case_studies.research import (
@@ -173,14 +174,23 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
             conversions += 1
         return original_to_pandas(frame, *args, **kwargs)
 
-    def fake_run_tabm_cv(dataset_pd, splits, *, configs, checkpoint_root, **kwargs):
+    def fake_run_tabm_cv(
+        dataset_pd,
+        splits,
+        *,
+        configs,
+        checkpoint_root,
+        _recovery=None,
+        **kwargs,
+    ):
         executions.append(tuple(config["config_name"] for config in configs))
         prediction_frames = []
         for config_index, config in enumerate(configs):
             config_name = config["config_name"]
             for split in splits:
                 fold = int(split["fold"])
-                checkpoint = checkpoint_root / config_name / f"fold_{fold:02d}" / "epoch_0001.pt"
+                root = _recovery.model_root(config_name) if _recovery else checkpoint_root
+                checkpoint = root / config_name / f"fold_{fold:02d}" / "epoch_0001.pt"
                 checkpoint.parent.mkdir(parents=True, exist_ok=True)
                 checkpoint.write_text("fixture\n")
                 valid = dataset_pd["timestamp"].between(
@@ -297,6 +307,296 @@ def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
         ("2024-01-04", 8),
     ]
     assert result["all_predictions"].height == 240
+
+
+def test_tabm_batch_reuses_completed_fold_after_interruption(tmp_path, monkeypatch) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    calls: list[str] = []
+    fail_second_fold = True
+
+    def interrupted_train(*, model, X_val, val_dates, state_callback=None, **kwargs):
+        nonlocal fail_second_fold
+        validation_date = str(val_dates[0])[:10]
+        calls.append(validation_date)
+        if validation_date == "2024-01-04" and fail_second_fold:
+            fail_second_fold = False
+            raise RuntimeError("injected TabM interruption")
+        if state_callback is not None:
+            state_callback(1, model)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64)
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", interrupted_train)
+    request = study.model(
+        family="tabular_dl",
+        label="fwd_ret_1d",
+        config_name="tabm_s",
+        overrides={"device": "cpu", "num_threads": 1},
+    )
+
+    with pytest.raises(RuntimeError, match="injected TabM interruption"):
+        request.run()
+    recovered = request.run()
+
+    assert calls == ["2024-01-03", "2024-01-04", "2024-01-04"]
+    assert recovered.diagnostics["reused_folds"] == [0]
+    assert recovered.diagnostics["fitted_folds"] == [1]
+    assert recovered.predictions[0].complete
+    assert recovered.predictions[0].coverage()["n_expected"] == 120
+
+
+def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatch) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    calls: list[tuple[int, str]] = []
+    fail_small = True
+
+    def candidate_train(*, model, X_val, val_dates, state_callback=None, **kwargs):
+        hidden_dim = int(model.backbone[0].out_features)
+        validation_date = str(val_dates[0])[:10]
+        calls.append((hidden_dim, validation_date))
+        if hidden_dim == 4 and fail_small:
+            raise RuntimeError("injected TabM candidate failure")
+        if state_callback is not None:
+            state_callback(1, model)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64) + hidden_dim / 100
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", candidate_train)
+    requests = [
+        study.model(
+            family="tabular_dl",
+            label="fwd_ret_1d",
+            config_name=config_name,
+            overrides={"device": "cpu", "num_threads": 1},
+        )
+        for config_name in ("tabm_s", "tabm_m")
+    ]
+
+    with pytest.raises(RuntimeError, match="injected TabM candidate failure"):
+        run_models(study, requests=requests)
+    first_calls = list(calls)
+    fail_small = False
+    recovered = run_models(study, requests=requests)
+
+    assert first_calls == [
+        (4, "2024-01-03"),
+        (8, "2024-01-03"),
+        (8, "2024-01-04"),
+    ]
+    assert calls[len(first_calls) :] == [
+        (4, "2024-01-03"),
+        (4, "2024-01-04"),
+    ]
+    assert recovered.runs[1].diagnostics["reused"] is True
+    assert all(run.predictions[0].complete for run in recovered.runs)
+
+
+def test_tabm_batch_matches_individual_resolved_execution(tmp_path, monkeypatch) -> None:
+    batch_study, _, _ = _tabm_study(tmp_path / "batch", monkeypatch)
+    individual_study, _, _ = _tabm_study(tmp_path / "individual", monkeypatch)
+
+    def deterministic_train(*, model, X_val, state_callback=None, **kwargs):
+        if state_callback is not None:
+            state_callback(1, model)
+        hidden_dim = int(model.backbone[0].out_features)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64) + hidden_dim / 100
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+    batch = run_models(
+        batch_study,
+        requests=[
+            batch_study.model(
+                family="tabular_dl",
+                label="fwd_ret_1d",
+                config_name=config_name,
+                overrides={"device": "cpu", "num_threads": 1},
+            )
+            for config_name in ("tabm_s", "tabm_m")
+        ],
+    )
+    individual = (
+        individual_study.model(
+            family="tabular_dl",
+            label="fwd_ret_1d",
+            config_name="tabm_s",
+            overrides={"device": "cpu", "num_threads": 1},
+        )
+        .resolve()
+        .run()
+    )
+
+    assert batch.runs[0].training.hash == individual.training.hash
+    assert batch.runs[0].predictions[0].hash == individual.predictions[0].hash
+    assert batch.runs[0].predictions[0].load().equals(individual.predictions[0].load())
+
+
+def test_tabm_batch_rejects_corrupt_checkpoint_and_refits_only_its_fold(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+    calls: list[str] = []
+
+    def deterministic_train(*, model, X_val, val_dates, state_callback=None, **kwargs):
+        calls.append(str(val_dates[0])[:10])
+        if state_callback is not None:
+            state_callback(1, model)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64)
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+    request = study.model(
+        family="tabular_dl",
+        label="fwd_ret_1d",
+        config_name="tabm_s",
+        overrides={"device": "cpu", "num_threads": 1},
+    )
+    original = request.run()
+    model_root = original.training.root / "run_log" / "training" / original.training.hash / "models"
+    checkpoint = model_root / "tabm_s" / "fold_00" / "epoch_0001.pt"
+    checkpoint.write_bytes(checkpoint.read_bytes() + b"corrupt")
+
+    recovered = request.run()
+
+    assert calls == ["2024-01-03", "2024-01-04", "2024-01-03"]
+    assert recovered.training.hash == original.training.hash
+    assert recovered.diagnostics["fitted_folds"] == [0]
+    assert recovered.diagnostics["reused_folds"] == [1]
+    invalid = (
+        original.training.root / "run_log" / "training" / original.training.hash / "invalid_folds"
+    )
+    assert len(list(invalid.glob("fold_0.*"))) == 1
+
+
+def test_tabm_saved_weight_checkpoint_replays_validation_predictions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from case_studies.utils.deep_model_state import restore_deep_model
+
+    study, modeling_dataset, _ = _tabm_study(tmp_path, monkeypatch)
+    run = study.model(
+        family="tabular_dl",
+        label="fwd_ret_1d",
+        config_name="tabm_s",
+        overrides={"device": "cpu", "num_threads": 1},
+    ).run()
+    model_root = run.training.root / "run_log" / "training" / run.training.hash / "models"
+    checkpoint = model_root / "tabm_s" / "fold_00" / "epoch_0001.pt"
+    model, preprocessing, metadata = restore_deep_model(
+        checkpoint,
+        lambda architecture, kwargs: tabular_dl.TabMModel(**kwargs),
+    )
+    sorted_dataset = (
+        modeling_dataset.dataset.to_pandas()
+        .sort_values(["timestamp", "symbol"], kind="mergesort")
+        .reset_index(drop=True)
+    )
+    fold = tabular_dl._prepare_tabm_fold(
+        sorted_dataset,
+        modeling_dataset.splits[0],
+        feature_names=modeling_dataset.feature_names,
+        label_col=modeling_dataset.label_col,
+        eval_label_col=None,
+        date_col=modeling_dataset.date_col,
+        entity_col=modeling_dataset.entity_cols[0],
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+    )
+    replay = tabular_dl._predict_in_chunks(model, fold["X_val"], torch.device("cpu"))
+    stored = (
+        run.predictions[0]
+        .load()
+        .filter(pl.col("fold") == 0)
+        .sort("timestamp", "symbol")
+        .get_column("prediction")
+        .to_numpy()
+    )
+
+    assert metadata["fold"] == 0
+    assert preprocessing["feature_names"] == modeling_dataset.feature_names
+    np.testing.assert_allclose(replay, stored, rtol=0.0, atol=1e-7)
+
+
+def test_tabm_candidate_order_does_not_change_identities_or_predictions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    forward_study, _, _ = _tabm_study(tmp_path / "forward", monkeypatch)
+    reverse_study, _, _ = _tabm_study(tmp_path / "reverse", monkeypatch)
+
+    def deterministic_train(*, model, X_val, state_callback=None, **kwargs):
+        if state_callback is not None:
+            state_callback(1, model)
+        hidden_dim = int(model.backbone[0].out_features)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64) + hidden_dim / 100
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+
+    def execute(study, names):
+        result = run_models(
+            study,
+            requests=[
+                study.model(
+                    family="tabular_dl",
+                    label="fwd_ret_1d",
+                    config_name=name,
+                    overrides={"device": "cpu", "num_threads": 1},
+                )
+                for name in names
+            ],
+        )
+        return {run.training.spec()["config_name"]: run for run in result.runs}
+
+    forward = execute(forward_study, ("tabm_s", "tabm_m"))
+    reverse = execute(reverse_study, ("tabm_m", "tabm_s"))
+
+    assert set(forward) == set(reverse)
+    for name in forward:
+        assert forward[name].training.hash == reverse[name].training.hash
+        assert forward[name].predictions[0].hash == reverse[name].predictions[0].hash
+        assert forward[name].predictions[0].load().equals(reverse[name].predictions[0].load())
+
+
+def test_tabm_variants_from_one_named_preset_keep_separate_identities(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    study, _, _ = _tabm_study(tmp_path, monkeypatch)
+
+    def deterministic_train(*, model, X_val, state_callback=None, **kwargs):
+        if state_callback is not None:
+            state_callback(1, model)
+        hidden_dim = int(model.backbone[0].out_features)
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64) + hidden_dim / 100
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", deterministic_train)
+    result = run_models(
+        study,
+        requests=[
+            study.model(
+                family="tabular_dl",
+                label="fwd_ret_1d",
+                config_name="tabm_s",
+                overrides={"device": "cpu", "hidden_dim": hidden, "num_threads": 1},
+            )
+            for hidden in (5, 6)
+        ],
+    )
+
+    assert len({run.training.hash for run in result.runs}) == 2
+    assert len({run.predictions[0].hash for run in result.runs}) == 2
+    assert {run.training.spec()["identity_version"] for run in result.runs} == {3}
+    assert {run.training.spec()["resolved_spec_schema"] for run in result.runs} == {
+        "ml4t.resolved-spec/v1"
+    }
+    assert [
+        run.training.spec()["computation"]["model"]["params"]["hidden_dim"] for run in result.runs
+    ] == [5, 6]
 
 
 def test_linear_notebook_and_public_request_resolve_identically(tmp_path, monkeypatch) -> None:

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -92,15 +92,21 @@ def test_tabm_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -
     spec = resolved.spec
     context = resolved._context
 
-    assert spec["identity_version"] == 2
-    assert "resolved_spec_schema" not in spec
+    assert spec["identity_version"] == 3
+    assert spec["resolved_spec_schema"] == "ml4t.resolved-spec/v1"
     assert set(spec) == {
         "identity_version",
+        "resolved_spec_schema",
         "execution_tier",
         "family",
         "label",
         "seed",
         "config_name",
+        "computation",
+        "provenance",
+    }
+    computation = spec["computation"]
+    assert set(computation) == {
         "label_artifact",
         "feature_artifacts",
         "feature_names",
@@ -116,11 +122,11 @@ def test_tabm_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -
         "source_identity",
         "runtime_identity",
     }
-    assert spec["label_artifact"]["digest"] == label.digest
-    assert spec["model"]["params"]["n_epochs"] == 11
-    assert [row["value"] for row in spec["checkpoint_schedule"]] == [5, 10, 11]
-    assert spec["expected_prediction_keys"] == {
-        "digest": spec["expected_prediction_keys"]["digest"],
+    assert computation["label_artifact"]["digest"] == label.digest
+    assert computation["model"]["params"]["n_epochs"] == 11
+    assert [row["value"] for row in computation["checkpoint_schedule"]] == [5, 10, 11]
+    assert computation["expected_prediction_keys"] == {
+        "digest": computation["expected_prediction_keys"]["digest"],
         "n_rows": 12,
         "n_folds": 1,
     }

--- a/tests/test_tabular_dl_runtime.py
+++ b/tests/test_tabular_dl_runtime.py
@@ -663,6 +663,78 @@ def test_complete_registry_replays_predictions_instead_of_returning_empty(
     assert result["grid_results"][0]["cached"] is True
 
 
+def test_direct_registered_batch_preserves_completed_sibling_on_later_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class MissingStatus:
+        complete = False
+        partial = False
+
+    registered: list[str] = []
+
+    def train_candidate(*, model, X_val, **_kwargs):
+        hidden_dim = int(model.backbone[0].out_features)
+        if hidden_dim == 8:
+            raise RuntimeError("injected later candidate failure")
+        predictions = np.asarray(X_val[:, 0], dtype=np.float64) + hidden_dim / 100
+        return {1: 0.1}, {1: predictions}, {1: 0.01}
+
+    monkeypatch.setattr(tabular_dl, "_train_tabm_fold", train_candidate)
+    monkeypatch.setattr(registry, "training_run_status", lambda *_args: MissingStatus())
+    monkeypatch.setattr(registry, "load_prediction_sets", lambda *_args, **_kwargs: pl.DataFrame())
+    monkeypatch.setattr(registry, "training_hash_from_spec", lambda _spec: "training")
+    monkeypatch.setattr(
+        tabular_dl,
+        "_register_tabm_config",
+        lambda **kwargs: registered.append(kwargs["config_name"]) or "training",
+    )
+
+    with pytest.raises(RuntimeError, match="injected later candidate failure"):
+        tabular_dl.run_tabm_cv(
+            _classification_frame(),
+            [
+                {
+                    "fold": 0,
+                    "train_start": pd.Timestamp("2020-01-01"),
+                    "train_end": pd.Timestamp("2020-03-01"),
+                    "val_start": pd.Timestamp("2020-04-01"),
+                    "val_end": pd.Timestamp("2020-05-01"),
+                }
+            ],
+            configs=[
+                {
+                    "family": "tabular_dl",
+                    "config_name": "tabm_s",
+                    "params": {"hidden_dim": 4, "n_members": 2, "dropout": 0.0},
+                    "n_epochs": 1,
+                    "batch_size": 32,
+                    "checkpoint_interval": 1,
+                },
+                {
+                    "family": "tabular_dl",
+                    "config_name": "tabm_m",
+                    "params": {"hidden_dim": 8, "n_members": 2, "dropout": 0.0},
+                    "n_epochs": 1,
+                    "batch_size": 32,
+                    "checkpoint_interval": 1,
+                },
+            ],
+            n_features=1,
+            feature_names=["feature"],
+            label_col="return",
+            date_col="timestamp",
+            entity_col="symbol",
+            device="cpu",
+            save_dir=tmp_path,
+            register=True,
+            case_study="probe",
+        )
+
+    assert registered == ["tabm_s"]
+    assert (tmp_path / "return" / "_incremental" / "tabm_s_fold0.parquet").exists()
+
+
 def test_saved_artifact_message_does_not_leak_absolute_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/test_tabular_dl_runtime.py
+++ b/tests/test_tabular_dl_runtime.py
@@ -566,13 +566,13 @@ def test_complete_registry_replays_predictions_instead_of_returning_empty(
 
     cached_predictions = pl.DataFrame(
         {
-            "timestamp": [pd.Timestamp("2020-04-01")] * 5,
-            "symbol": list(range(5)),
-            "y_true": np.arange(5, dtype=float),
-            "y_score": np.arange(5, dtype=float),
-            "fold_id": [0] * 5,
-            "config": ["tabm_probe"] * 5,
-            "epoch": [25] * 5,
+            "timestamp": [pd.Timestamp("2020-04-01")] * 50,
+            "symbol": list(range(50)),
+            "y_true": np.arange(50, dtype=float),
+            "y_score": np.arange(50, dtype=float),
+            "fold_id": [0] * 50,
+            "config": ["tabm_probe"] * 50,
+            "epoch": [25] * 50,
         }
     )
     cached_result = {
@@ -605,7 +605,15 @@ def test_complete_registry_replays_predictions_instead_of_returning_empty(
 
     result = tabular_dl.run_tabm_cv(
         _classification_frame(),
-        [],
+        [
+            {
+                "fold": 0,
+                "train_start": "2020-01-01",
+                "train_end": "2020-03-01",
+                "val_start": "2020-04-01",
+                "val_end": "2020-04-01",
+            }
+        ],
         configs=[
             {
                 "family": "tabular_dl",
@@ -627,7 +635,7 @@ def test_complete_registry_replays_predictions_instead_of_returning_empty(
     )
 
     assert result["best_config_name"] == "tabm_probe"
-    assert result["predictions"].height == 5
+    assert result["predictions"].height == 50
     assert result["grid_results"][0]["cached"] is True
 
 

--- a/tests/test_tabular_dl_runtime.py
+++ b/tests/test_tabular_dl_runtime.py
@@ -636,6 +636,30 @@ def test_complete_registry_replays_predictions_instead_of_returning_empty(
 
     assert result["best_config_name"] == "tabm_probe"
     assert result["predictions"].height == 50
+
+    with pytest.raises(ValueError, match="at least one fold"):
+        tabular_dl.run_tabm_cv(
+            _classification_frame(),
+            [],
+            configs=[
+                {
+                    "family": "tabular_dl",
+                    "config_name": "tabm_probe",
+                    "params": {"hidden_dim": 4, "n_members": 2, "dropout": 0.0},
+                    "n_epochs": 25,
+                    "checkpoint_interval": 25,
+                }
+            ],
+            n_features=1,
+            feature_names=["feature"],
+            label_col="return",
+            date_col="timestamp",
+            entity_col="symbol",
+            device="cpu",
+            save_dir=tmp_path,
+            register=True,
+            case_study="probe",
+        )
     assert result["grid_results"][0]["cached"] is True
 
 


### PR DESCRIPTION
## Summary

- execute compatible TabM candidates fold-major with shared panel preparation and separate scientific identities
- persist and validate completed-fold checkpoints, prediction shards, and training diagnostics for restart
- recover incomplete or corrupt diagnostic artifacts without repeating fold preparation
- preserve individual and batch equivalence, candidate failure isolation, and order invariance

## Verification

- reduced real US-equities panel proof with two compatible candidates and one incompatible candidate
- cached replay reused exact identities with zero fold preparation
- 1993 passed, 18 skipped in the complete non-notebook suite
- ruff, ty, pre-commit hooks, and focused RoboRev checks passed

The proof evidence remains local under .workspace/proofs and is intentionally not committed.