### PR TITLE
Add shared backtest population planning bridge

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -1,10 +1,19 @@
 from .adapters import AdapterBinding, get_adapter, register_adapter, registered_adapters
+from .catalog import BacktestCatalog, PredictionCatalog
 from .causal import CausalRequest, CausalResult, ResolvedCausalRequest
 from .comparison import CandidateSet
 from .contracts import ExecutionTier, LifecycleState
 from .cv import CVSpec, EligibilityManifest, ResolvedCVSpec
 from .decisions import DecisionArtifact, StateTransitionPolicy
-from .execution import BacktestExecution, ModelExecution, run_backtests, run_models
+from .execution import (
+    BacktestExecution,
+    BacktestPlan,
+    ModelExecution,
+    PlannedBacktest,
+    plan_backtests,
+    run_backtests,
+    run_models,
+)
 from .identity import ResolvedSpec
 from .labels import LabelDefinition, LabelRef
 from .lifecycle import ResearchLock
@@ -17,7 +26,9 @@ from .workspace import Study
 __all__ = [
     "AdapterBinding",
     "BacktestResult",
+    "BacktestCatalog",
     "BacktestExecution",
+    "BacktestPlan",
     "CVSpec",
     "CandidateSet",
     "CausalRequest",
@@ -32,6 +43,8 @@ __all__ = [
     "ModelExecution",
     "ModelRun",
     "PredictionResult",
+    "PredictionCatalog",
+    "PlannedBacktest",
     "OfficialPopulation",
     "ResearchLock",
     "ResolvedModelRequest",
@@ -46,6 +59,7 @@ __all__ = [
     "get_adapter",
     "register_adapter",
     "registered_adapters",
+    "plan_backtests",
     "run_backtests",
     "run_models",
 ]

--- a/case_studies/research/catalog.py
+++ b/case_studies/research/catalog.py
@@ -11,6 +11,7 @@ import polars as pl
 from case_studies.utils.registry.specs import IDENTITY_VERSION, canonical_json
 
 if TYPE_CHECKING:
+    from .comparison import CandidateSet
     from .workspace import Study
 
 
@@ -52,6 +53,59 @@ RESERVED_COLUMNS: dict[str, Any] = {
     "provenance_json": pl.String,
     "training_hash": pl.String,
     "prediction_hash": pl.String,
+    "spec_json": pl.String,
+}
+
+_BACKTEST_METRIC_COLUMNS = (
+    "sharpe",
+    "sortino",
+    "total_return",
+    "max_drawdown",
+    "cagr",
+    "volatility",
+    "calmar",
+    "omega",
+    "stability",
+    "tail_ratio",
+    "win_rate",
+    "kurtosis",
+    "skewness",
+    "var_95",
+    "cvar_95",
+    "n_periods",
+    "num_trades",
+    "total_commission",
+    "total_slippage",
+    "avg_turnover",
+)
+BACKTEST_RESERVED_COLUMNS: dict[str, Any] = {
+    "catalog_version": pl.Int64,
+    "origin": pl.String,
+    "identity_status": pl.String,
+    "family": pl.String,
+    "config_name": pl.String,
+    "label": pl.String,
+    "split": pl.String,
+    "checkpoint_kind": pl.String,
+    "checkpoint_value": pl.Int64,
+    "stage": pl.String,
+    "execution_tier": pl.String,
+    "approval": pl.String,
+    "completion_state": pl.String,
+    "complete": pl.Boolean,
+    "created_at": pl.String,
+    "metrics_computed_at": pl.String,
+    "artifact_available": pl.Boolean,
+    "signal_method": pl.String,
+    "allocation_method": pl.String,
+    "risk_method": pl.String,
+    "decision_artifact_hash": pl.String,
+    **{metric: pl.Float64 for metric in _BACKTEST_METRIC_COLUMNS},
+    "metrics_json": pl.String,
+    "training_hash": pl.String,
+    "prediction_hash": pl.String,
+    "backtest_hash": pl.String,
+    "training_spec_json": pl.String,
     "spec_json": pl.String,
 }
 
@@ -293,12 +347,15 @@ def _dtype(values: list[Any]) -> Any:
     return pl.String
 
 
-def _frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
+def _frame(
+    rows: list[dict[str, Any]],
+    reserved_columns: dict[str, Any] = RESERVED_COLUMNS,
+) -> pl.DataFrame:
     if not rows:
-        return pl.DataFrame(schema=RESERVED_COLUMNS)
-    columns = list(RESERVED_COLUMNS)
+        return pl.DataFrame(schema=reserved_columns)
+    columns = list(reserved_columns)
     columns.extend(sorted(set().union(*(row.keys() for row in rows)) - set(columns)))
-    schema = dict(RESERVED_COLUMNS)
+    schema = dict(reserved_columns)
     for column in columns:
         if column not in schema:
             schema[column] = _dtype([row.get(column) for row in rows])
@@ -318,6 +375,257 @@ def _frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
             values[column] = value
         normalized.append(values)
     return pl.DataFrame(normalized, schema=schema).select(columns)
+
+
+def _backtest_registry_rows(root: Path, origin: str) -> list[dict[str, Any]]:
+    db_path = root / "run_log" / "registry.db"
+    if not db_path.is_file() or db_path.stat().st_size == 0:
+        return []
+    query = f"file:{db_path}?mode=ro"
+    if origin == "released":
+        query += "&immutable=1"
+    with closing(sqlite3.connect(query, uri=True)) as db:
+        tables = _tables(db)
+        if not {"training_runs", "prediction_sets", "backtest_runs"} <= tables:
+            return []
+        training_columns = _columns(db, "training_runs")
+        prediction_columns = _columns(db, "prediction_sets")
+        backtest_columns = _columns(db, "backtest_runs")
+        coverage_columns = (
+            _columns(db, "prediction_coverage") if "prediction_coverage" in tables else set()
+        )
+        prediction_metric_columns = (
+            _columns(db, "prediction_metrics") if "prediction_metrics" in tables else set()
+        )
+        backtest_metric_columns = (
+            _columns(db, "backtest_metrics") if "backtest_metrics" in tables else set()
+        )
+        expressions = [
+            _select("training_hash", training_columns, "t"),
+            _select("family", training_columns, "t"),
+            _select("label", training_columns, "t"),
+            _select("config_name", training_columns, "t"),
+            _select("spec_json", training_columns, "t", "'{}'"),
+            _select("identity_version", training_columns, "t"),
+            _select("execution_tier", training_columns, "t"),
+            _select("prediction_hash", prediction_columns, "p"),
+            _select("checkpoint_kind", prediction_columns, "p"),
+            _select("checkpoint_value", prediction_columns, "p"),
+            _select("split", prediction_columns, "p"),
+            _select("backtest_hash", backtest_columns, "b"),
+            _select("spec_json", backtest_columns, "b", "'{}'"),
+            _select("stage", backtest_columns, "b"),
+            _select("created_at", backtest_columns, "b"),
+            _select("status", coverage_columns, "c"),
+            _select("n_folds_expected", coverage_columns, "c"),
+            _select("prediction_hash", prediction_metric_columns, "pm"),
+            _select("backtest_hash", backtest_metric_columns, "bm"),
+            _select("computed_at", backtest_metric_columns, "bm"),
+            *[
+                _select(metric, backtest_metric_columns, "bm")
+                for metric in _BACKTEST_METRIC_COLUMNS
+            ],
+        ]
+        expressions.append(
+            "(SELECT COUNT(*) FROM fold_metrics fm "
+            "WHERE fm.prediction_hash = p.prediction_hash) AS prediction_fold_metric_count"
+            if "fold_metrics" in tables
+            else "0 AS prediction_fold_metric_count"
+        )
+        coverage_join = (
+            "LEFT JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash"
+            if coverage_columns
+            else "LEFT JOIN (SELECT NULL AS prediction_hash) c ON 0"
+        )
+        prediction_metrics_join = (
+            "LEFT JOIN prediction_metrics pm ON pm.prediction_hash = p.prediction_hash"
+            if prediction_metric_columns
+            else "LEFT JOIN (SELECT NULL AS prediction_hash) pm ON 0"
+        )
+        backtest_metrics_join = (
+            "LEFT JOIN backtest_metrics bm ON bm.backtest_hash = b.backtest_hash"
+            if backtest_metric_columns
+            else "LEFT JOIN (SELECT NULL AS backtest_hash) bm ON 0"
+        )
+        cursor = db.execute(
+            f"SELECT {', '.join(expressions)} FROM backtest_runs b "
+            "JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash "
+            "JOIN training_runs t ON t.training_hash = p.training_hash "
+            f"{coverage_join} {prediction_metrics_join} {backtest_metrics_join}"
+        )
+        columns = [description[0] for description in cursor.description]
+        records = [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]
+        prediction_roots = (
+            {
+                row[0]: Path(row[1])
+                for row in db.execute(
+                    "SELECT result_hash, source_root FROM overlay_references "
+                    "WHERE result_kind = 'prediction'"
+                ).fetchall()
+            }
+            if "overlay_references" in tables
+            else {}
+        )
+
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        try:
+            training_spec = json.loads(record["t_spec_json"] or "{}")
+        except json.JSONDecodeError:
+            training_spec = {}
+        try:
+            backtest_spec = json.loads(record["b_spec_json"] or "{}")
+        except json.JSONDecodeError:
+            backtest_spec = {}
+        computation = _computation(training_spec)
+        model_value = computation.get("model")
+        model = dict(model_value) if isinstance(model_value, dict) else {}
+        cv_value = computation.get("cv")
+        cv = dict(cv_value) if isinstance(cv_value, dict) else {}
+        strategy_value = backtest_spec.get("strategy")
+        strategy = dict(strategy_value) if isinstance(strategy_value, dict) else {}
+        identity_version = record["t_identity_version"]
+        identity_status = (
+            "current"
+            if identity_version == IDENTITY_VERSION
+            else ("legacy-v2" if identity_version == 2 else "legacy")
+        )
+        prediction_root = prediction_roots.get(record["p_prediction_hash"], root)
+        prediction_artifact = (
+            prediction_root
+            / "run_log"
+            / "predictions"
+            / record["p_prediction_hash"]
+            / "predictions.parquet"
+        )
+        returns_artifact = (
+            root / "run_log" / "backtest" / record["b_backtest_hash"] / "daily_returns.parquet"
+        )
+        complete = (
+            identity_status == "current"
+            and record["c_status"] == "complete"
+            and record["pm_prediction_hash"] is not None
+            and record["prediction_fold_metric_count"] == record["c_n_folds_expected"]
+            and prediction_artifact.is_file()
+            and record["bm_backtest_hash"] is not None
+            and returns_artifact.is_file()
+        )
+        metrics = {
+            metric: record[f"bm_{metric}"]
+            for metric in _BACKTEST_METRIC_COLUMNS
+            if record[f"bm_{metric}"] is not None
+        }
+        signal_value = strategy.get("signal")
+        signal: dict[str, Any] = dict(signal_value) if isinstance(signal_value, dict) else {}
+        allocation_value = strategy.get("allocation")
+        allocation: dict[str, Any] = (
+            dict(allocation_value) if isinstance(allocation_value, dict) else {}
+        )
+        risk_value = strategy.get("risk")
+        risk: dict[str, Any] = dict(risk_value) if isinstance(risk_value, dict) else {}
+        decision_value = backtest_spec.get("decision_artifact")
+        decision: dict[str, Any] = dict(decision_value) if isinstance(decision_value, dict) else {}
+        row: dict[str, Any] = {
+            "catalog_version": CATALOG_VERSION,
+            "origin": origin,
+            "identity_status": identity_status,
+            "family": record["t_family"],
+            "config_name": record["t_config_name"],
+            "label": record["t_label"],
+            "split": record["p_split"],
+            "checkpoint_kind": record["p_checkpoint_kind"],
+            "checkpoint_value": record["p_checkpoint_value"],
+            "stage": record["b_stage"],
+            "execution_tier": record["t_execution_tier"]
+            or backtest_spec.get("execution_tier")
+            or "canonical",
+            "approval": "unapproved",
+            "completion_state": "complete" if complete else "partial",
+            "complete": complete,
+            "created_at": record["b_created_at"],
+            "metrics_computed_at": record["bm_computed_at"],
+            "artifact_available": returns_artifact.is_file(),
+            "signal_method": signal.get("method"),
+            "allocation_method": allocation.get("method"),
+            "risk_method": risk.get("method"),
+            "decision_artifact_hash": decision.get("hash"),
+            **{metric: record[f"bm_{metric}"] for metric in _BACKTEST_METRIC_COLUMNS},
+            "metrics_json": canonical_json(metrics),
+            "training_hash": record["t_training_hash"],
+            "prediction_hash": record["p_prediction_hash"],
+            "backtest_hash": record["b_backtest_hash"],
+            "training_spec_json": canonical_json(training_spec),
+            "spec_json": canonical_json(backtest_spec),
+        }
+        open_fields: dict[str, Any] = {}
+        _flatten("model", model, open_fields)
+        _flatten("preprocessing", computation.get("preprocessing", {}), open_fields)
+        _flatten("cv", cv.get("request", {}), open_fields)
+        _flatten("strategy", strategy, open_fields)
+        row.update({key: _open_value(value) for key, value in open_fields.items()})
+        rows.append(row)
+    return rows
+
+
+def _resolve_authoritative_selection(
+    study: Study,
+    selection: pl.DataFrame,
+    *,
+    kind: str,
+    canonical: bool = True,
+) -> tuple[Any, ...]:
+    if not isinstance(selection, pl.DataFrame):
+        raise TypeError(f"{kind} selection must be a Polars DataFrame")
+    identity_columns = (
+        ("training_hash", "prediction_hash")
+        if kind == "prediction"
+        else ("training_hash", "prediction_hash", "backtest_hash")
+    )
+    missing = set(identity_columns) - set(selection.columns)
+    if missing:
+        raise ValueError(
+            f"{kind} catalog selection is missing required identity columns: {sorted(missing)}"
+        )
+    if selection.is_empty():
+        raise ValueError(f"{kind} catalog selection is empty")
+    result_column = identity_columns[-1]
+    if selection.get_column(result_column).n_unique() != selection.height:
+        raise ValueError(f"duplicate {kind} identities make the selection ambiguous")
+    authoritative = (
+        study.predictions.table(include_preview=True)
+        if kind == "prediction"
+        else study.backtests.table(include_preview=True)
+    )
+    from .results import Result
+
+    resolved = []
+    for selected in selection.select(*identity_columns).iter_rows(named=True):
+        match = authoritative.filter(pl.col(result_column) == selected[result_column])
+        if match.height != 1:
+            raise ValueError(
+                f"{kind} identity {selected[result_column]!r} resolved to {match.height} rows"
+            )
+        row = match.row(0, named=True)
+        altered = {
+            column: (selected[column], row[column])
+            for column in identity_columns
+            if selected[column] != row[column]
+        }
+        if altered:
+            details = ", ".join(
+                f"{column}={actual!r}, not {supplied!r}"
+                for column, (supplied, actual) in altered.items()
+            )
+            raise ValueError(f"{kind} selection has altered lineage: {details}")
+        if canonical and row["execution_tier"] == "preview":
+            raise ValueError(f"preview {kind} results cannot enter a canonical candidate set")
+        if not row["complete"]:
+            raise ValueError(f"{kind} {selected[result_column]} is partial")
+        result = Result.open(study, str(selected[result_column]), include_preview=True)
+        if result.kind != kind:
+            raise ValueError(f"catalog identity {selected[result_column]} is not a {kind}")
+        resolved.append(result)
+    return tuple(resolved)
 
 
 class PredictionCatalog:
@@ -368,3 +676,101 @@ class PredictionCatalog:
                 f"prediction selection matched {table.height} rows; disambiguate with {varying}"
             )
         return table.row(0, named=True)
+
+    def freeze(
+        self,
+        selection: pl.DataFrame,
+        *,
+        name: str,
+        comparison_contract: dict[str, Any] | None = None,
+    ) -> CandidateSet:
+        """Freeze exact authoritative prediction members selected with Polars."""
+        from .comparison import CandidateSet
+
+        members = _resolve_authoritative_selection(
+            self.study,
+            selection,
+            kind="prediction",
+        )
+        return CandidateSet.create(
+            self.study,
+            name,
+            members,
+            comparison_contract=comparison_contract,
+        )
+
+
+class BacktestCatalog:
+    def __init__(self, study: Study) -> None:
+        self.study = study
+
+    def table(self, *, include_preview: bool = False) -> pl.DataFrame:
+        released = _backtest_registry_rows(self.study.release_case_root, "released")
+        if self.study.read_only:
+            return _frame(released, BACKTEST_RESERVED_COLUMNS).sort("backtest_hash")
+        workspace = _backtest_registry_rows(self.study.root, "workspace")
+        preview: list[dict[str, Any]] = []
+        if include_preview and self.study.output_root is not None:
+            preview = _backtest_registry_rows(
+                self.study.output_root / ".preview" / self.study.case_study,
+                "workspace",
+            )
+        seen = {row["backtest_hash"] for row in [*workspace, *preview]}
+        overlaid = [
+            *workspace,
+            *preview,
+            *(row for row in released if row["backtest_hash"] not in seen),
+        ]
+        return _frame(overlaid, BACKTEST_RESERVED_COLUMNS).sort("backtest_hash")
+
+    def one(self, **filters: Any) -> dict[str, Any]:
+        table = self.table()
+        for field, value in filters.items():
+            if field not in table.columns:
+                raise ValueError(f"unknown backtest catalog field {field!r}")
+            predicate = pl.col(field).is_null() if value is None else pl.col(field) == value
+            table = table.filter(predicate)
+        if table.height != 1:
+            varying = [
+                column
+                for column in (
+                    "label",
+                    "split",
+                    "checkpoint_kind",
+                    "checkpoint_value",
+                    "stage",
+                    "signal_method",
+                    "allocation_method",
+                    "risk_method",
+                    "training_hash",
+                    "prediction_hash",
+                    "backtest_hash",
+                )
+                if column in table.columns and table.get_column(column).n_unique() > 1
+            ]
+            raise ValueError(
+                f"backtest selection matched {table.height} rows; disambiguate with {varying}"
+            )
+        return table.row(0, named=True)
+
+    def freeze(
+        self,
+        selection: pl.DataFrame,
+        *,
+        name: str,
+        comparison_contract: dict[str, Any] | None = None,
+    ) -> CandidateSet:
+        """Freeze exact authoritative backtest members selected with Polars."""
+        from .comparison import CandidateSet
+
+        members = _resolve_authoritative_selection(
+            self.study,
+            selection,
+            kind="backtest",
+        )
+        return CandidateSet.create(
+            self.study,
+            name,
+            members,
+            comparison_contract=comparison_contract,
+        )

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -7,6 +7,8 @@ from contextlib import closing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import polars as pl
+
 from case_studies.utils.registry.specs import canonical_json, compute_hash
 from case_studies.utils.registry.store import _git_hash, _open_registry, _utc_now
 
@@ -162,58 +164,33 @@ class CandidateSet:
 
     def best_validation_sharpe(self) -> Result:
         """Select deterministically within this immutable backtest set."""
-        if self.member_kind != "backtest":
-            raise ValueError("validation Sharpe selection requires backtest members")
-        placeholders = ",".join("?" for _ in self.members)
-        with closing(sqlite3.connect(self.study.root / "run_log" / "registry.db")) as db:
-            rows = db.execute(
-                f"""
-                SELECT m.backtest_hash, m.sharpe
-                FROM backtest_metrics m
-                JOIN backtest_runs b ON b.backtest_hash = m.backtest_hash
-                JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
-                JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash
-                JOIN training_runs t ON t.training_hash = p.training_hash
-                WHERE m.backtest_hash IN ({placeholders})
-                  AND p.split = 'validation'
-                  AND c.status = 'complete'
-                  AND t.execution_tier = 'canonical'
-                  AND b.stage IN ('signal', 'allocation', 'risk_overlay')
-                  AND m.sharpe IS NOT NULL
-                ORDER BY m.sharpe DESC, m.backtest_hash ASC
-                """,
-                self.members,
-            ).fetchall()
-        if len(rows) != len(self.members):
-            raise ValueError("candidate set contains an ineligible selection member")
-        return Result.open(self.study, rows[0][0])
+        hashes = self._ranked_validation_hashes()
+        return Result.open(self.study, hashes[0])
 
     def ranked_validation_sharpe(self, *, limit: int | None = None) -> tuple[Result, ...]:
         """Return complete members ordered by validation Sharpe and identity tie-break."""
-        if self.member_kind != "backtest":
-            raise ValueError("validation Sharpe ranking requires backtest members")
         if limit is not None and limit < 1:
             raise ValueError("validation Sharpe ranking limit must be positive")
-        placeholders = ",".join("?" for _ in self.members)
-        with closing(sqlite3.connect(self.study.root / "run_log" / "registry.db")) as db:
-            rows = db.execute(
-                f"""
-                SELECT m.backtest_hash
-                FROM backtest_metrics m
-                JOIN backtest_runs b ON b.backtest_hash = m.backtest_hash
-                JOIN prediction_sets p ON p.prediction_hash = b.prediction_hash
-                JOIN prediction_coverage c ON c.prediction_hash = p.prediction_hash
-                JOIN training_runs t ON t.training_hash = p.training_hash
-                WHERE m.backtest_hash IN ({placeholders})
-                  AND p.split = 'validation'
-                  AND c.status = 'complete'
-                  AND t.execution_tier = 'canonical'
-                  AND m.sharpe IS NOT NULL
-                ORDER BY m.sharpe DESC, m.backtest_hash ASC
-                """,
-                self.members,
-            ).fetchall()
-        if len(rows) != len(self.members):
+        hashes = self._ranked_validation_hashes()
+        selected = hashes[:limit] if limit is not None else hashes
+        return tuple(Result.open(self.study, result_hash) for result_hash in selected)
+
+    def _ranked_validation_hashes(self) -> tuple[str, ...]:
+        if self.member_kind != "backtest":
+            raise ValueError("validation Sharpe ranking requires backtest members")
+        rows = (
+            self.study.backtests.table()
+            .filter(
+                pl.col("backtest_hash").is_in(self.members)
+                & (pl.col("split") == "validation")
+                & (pl.col("execution_tier") == "canonical")
+                & pl.col("stage").is_in(["signal", "allocation", "risk_overlay"])
+                & pl.col("sharpe").is_not_null()
+            )
+            .sort("sharpe", "backtest_hash", descending=[True, False])
+        )
+        if rows.height != len(self.members):
             raise ValueError("candidate set contains an ineligible selection member")
-        selected = rows[:limit] if limit is not None else rows
-        return tuple(Result.open(self.study, row[0]) for row in selected)
+        if any(not Result.open(self.study, member_hash).complete for member_hash in self.members):
+            raise ValueError("candidate set contains an incomplete selection member")
+        return tuple(rows.get_column("backtest_hash"))

--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -320,7 +320,8 @@ def run_backtests(
         decision=decision,
     )
     population = None
-    if plan.execution_tier is ExecutionTier.CANONICAL:
+    canonical_decision = decision is None or decision.canonical
+    if plan.execution_tier is ExecutionTier.CANONICAL and canonical_decision:
         ordered_hashes = tuple(sorted(plan.expected_hashes))
         if population_name is None:
             suffix = compute_hash(canonical_json({"members": list(ordered_hashes)}))
@@ -332,7 +333,8 @@ def run_backtests(
             members=ordered_hashes,
         )
     elif population_name is not None:
-        raise ValueError("preview backtests cannot create an official population")
+        ancestry = "preview" if plan.execution_tier is ExecutionTier.PREVIEW else "exploratory"
+        raise ValueError(f"{ancestry} backtests cannot create an official population")
     for item in resolved:
         _import_released_prediction(study, item.prediction)
 

--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -5,17 +5,25 @@ from collections.abc import Iterable
 from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
+from case_studies.utils.backtest_presets import serializable_backtest_spec
+from case_studies.utils.registry.specs import backtest_hash_from_parts, canonical_json, compute_hash
 from case_studies.utils.registry.store import _open_registry, _utc_now
 
 from .adapters import get_adapter
+from .catalog import _resolve_authoritative_selection
 from .contracts import ExecutionTier
 from .models import ModelRequest, ModelRun, ResolvedModelRequest
+from .population import OfficialPopulation
 from .results import BacktestResult, PredictionResult, Result
+from .strategy import Strategy
 from .workspace import Study
+
+if TYPE_CHECKING:
+    from .decisions import DecisionArtifact
 
 
 @dataclass(frozen=True)
@@ -30,6 +38,36 @@ class BacktestExecution:
     results: tuple[BacktestResult, ...]
     catalog_rows: pl.DataFrame
     diagnostics: tuple[dict[str, Any], ...]
+    population: OfficialPopulation | None
+
+    @property
+    def population_hash(self) -> str | None:
+        return self.population.hash if self.population is not None else None
+
+
+@dataclass(frozen=True)
+class PlannedBacktest:
+    training_hash: str
+    prediction_hash: str
+    backtest_hash: str
+    spec_json: str
+
+
+@dataclass(frozen=True)
+class BacktestPlan:
+    members: tuple[PlannedBacktest, ...]
+    execution_tier: ExecutionTier
+
+    @property
+    def expected_hashes(self) -> tuple[str, ...]:
+        return tuple(member.backtest_hash for member in self.members)
+
+
+@dataclass(frozen=True)
+class _ResolvedBacktest:
+    member: PlannedBacktest
+    prediction: PredictionResult
+    strategy: Strategy
 
 
 def run_models(
@@ -162,37 +200,94 @@ def _import_released_prediction(study: Study, prediction: PredictionResult) -> N
 
 
 def _validate_selection(study: Study, predictions: pl.DataFrame) -> list[PredictionResult]:
-    required = {"training_hash", "prediction_hash"}
-    missing = required - set(predictions.columns)
-    if missing:
-        raise ValueError(
-            f"prediction catalog selection is missing required identity columns: {sorted(missing)}"
+    resolved = _resolve_authoritative_selection(
+        study,
+        predictions,
+        kind="prediction",
+        canonical=False,
+    )
+    if not all(isinstance(result, PredictionResult) for result in resolved):
+        raise RuntimeError("prediction selection resolved a non-prediction result")
+    return list(resolved)
+
+
+def _resolve_backtest_plan(
+    study: Study,
+    *,
+    predictions: pl.DataFrame,
+    signal: dict[str, Any],
+    prices: pl.DataFrame | None,
+    allocation: dict[str, Any] | None,
+    risk: dict[str, Any] | None,
+    costs: dict[str, Any] | None,
+    chapter: str | None,
+    execution_mode: str | None,
+    decision: DecisionArtifact | None,
+) -> tuple[BacktestPlan, tuple[_ResolvedBacktest, ...]]:
+    resolved_predictions = _validate_selection(study, predictions)
+    if decision is not None and len(resolved_predictions) != 1:
+        raise ValueError("one decision artifact requires exactly one selected prediction")
+    tiers = {ExecutionTier(prediction.execution_tier) for prediction in resolved_predictions}
+    if len(tiers) != 1:
+        raise ValueError("one backtest plan cannot mix canonical and preview predictions")
+    tier = tiers.pop()
+    resolved: list[_ResolvedBacktest] = []
+    for prediction in resolved_predictions:
+        strategy = study.strategy(
+            prediction=prediction,
+            signal=signal,
+            decision=decision,
+            allocation=allocation,
+            risk=risk,
+            costs=costs,
+            chapter=chapter,
+            execution_mode=execution_mode,
         )
-    if predictions.is_empty():
-        raise ValueError("prediction catalog selection is empty")
-    if predictions.get_column("prediction_hash").n_unique() != predictions.height:
-        raise ValueError("duplicate prediction identities make the selection ambiguous")
-    catalog = study.predictions.table(include_preview=True)
-    resolved = []
-    for row in predictions.select("training_hash", "prediction_hash").iter_rows(named=True):
-        match = catalog.filter(pl.col("prediction_hash") == row["prediction_hash"])
-        if match.height != 1:
-            raise ValueError(
-                f"prediction identity {row['prediction_hash']!r} resolved to {match.height} rows"
-            )
-        authoritative = match.row(0, named=True)
-        if authoritative["training_hash"] != row["training_hash"]:
-            raise ValueError(
-                f"prediction {row['prediction_hash']} has training_hash "
-                f"{authoritative['training_hash']}, not {row['training_hash']}"
-            )
-        if not authoritative["complete"]:
-            raise ValueError(f"prediction {row['prediction_hash']} is partial")
-        result = Result.open(study, str(row["prediction_hash"]), include_preview=True)
-        if not isinstance(result, PredictionResult):
-            raise ValueError(f"catalog identity {row['prediction_hash']} is not a prediction")
-        resolved.append(result)
-    return resolved
+        spec = strategy.resolve(prices=prices)
+        serializable = serializable_backtest_spec(spec)
+        backtest_hash = backtest_hash_from_parts(
+            prediction.hash,
+            serializable,
+            identity_version=spec.get("identity_version"),
+        )
+        member = PlannedBacktest(
+            training_hash=str(prediction.registry_record()["training_hash"]),
+            prediction_hash=prediction.hash,
+            backtest_hash=backtest_hash,
+            spec_json=canonical_json(serializable),
+        )
+        resolved.append(_ResolvedBacktest(member, prediction, strategy))
+    plan = BacktestPlan(tuple(item.member for item in resolved), tier)
+    return plan, tuple(resolved)
+
+
+def plan_backtests(
+    study: Study,
+    *,
+    predictions: pl.DataFrame,
+    signal: dict[str, Any],
+    prices: pl.DataFrame | None = None,
+    allocation: dict[str, Any] | None = None,
+    risk: dict[str, Any] | None = None,
+    costs: dict[str, Any] | None = None,
+    chapter: str | None = None,
+    execution_mode: str | None = None,
+    decision: DecisionArtifact | None = None,
+) -> BacktestPlan:
+    """Resolve every expected backtest identity without executing or writing one."""
+    plan, _ = _resolve_backtest_plan(
+        study,
+        predictions=predictions,
+        signal=signal,
+        prices=prices,
+        allocation=allocation,
+        risk=risk,
+        costs=costs,
+        chapter=chapter,
+        execution_mode=execution_mode,
+        decision=decision,
+    )
+    return plan
 
 
 def run_backtests(
@@ -206,36 +301,75 @@ def run_backtests(
     costs: dict[str, Any] | None = None,
     chapter: str | None = None,
     execution_mode: str | None = None,
-    decision=None,
+    decision: DecisionArtifact | None = None,
+    population_name: str | None = None,
 ) -> BacktestExecution:
     study.require_writable()
     if not isinstance(predictions, pl.DataFrame):
         raise TypeError("run_backtests requires a Polars prediction catalog selection")
-    resolved = _validate_selection(study, predictions)
-    if decision is not None and len(resolved) != 1:
-        raise ValueError("one decision artifact requires exactly one selected prediction")
-    for prediction in resolved:
-        _import_released_prediction(study, prediction)
+    plan, resolved = _resolve_backtest_plan(
+        study,
+        predictions=predictions,
+        signal=signal,
+        prices=prices,
+        allocation=allocation,
+        risk=risk,
+        costs=costs,
+        chapter=chapter,
+        execution_mode=execution_mode,
+        decision=decision,
+    )
+    population = None
+    if plan.execution_tier is ExecutionTier.CANONICAL:
+        ordered_hashes = tuple(sorted(plan.expected_hashes))
+        if population_name is None:
+            suffix = compute_hash(canonical_json({"members": list(ordered_hashes)}))
+            population_name = f"backtests-{suffix}"
+        population = OfficialPopulation.create(
+            study,
+            name=population_name,
+            member_kind="backtest",
+            members=ordered_hashes,
+        )
+    elif population_name is not None:
+        raise ValueError("preview backtests cannot create an official population")
+    for item in resolved:
+        _import_released_prediction(study, item.prediction)
 
     results = []
     diagnostics = []
-    for prediction in resolved:
-        result = study.strategy(
-            prediction=prediction,
-            signal=signal,
-            decision=decision,
-            allocation=allocation,
-            risk=risk,
-            costs=costs,
-            chapter=chapter,
-            execution_mode=execution_mode,
-        ).run(prices=prices)
+    for item in resolved:
+        try:
+            existing = Result.open(
+                study,
+                item.member.backtest_hash,
+                include_preview=plan.execution_tier is ExecutionTier.PREVIEW,
+            )
+        except KeyError:
+            existing = None
+        if isinstance(existing, BacktestResult) and existing.complete:
+            result = existing
+            status = "reused"
+        else:
+            result = item.strategy.run(prices=prices)
+            status = "completed"
+        if result.hash != item.member.backtest_hash:
+            raise RuntimeError(
+                "backtest execution returned an identity different from its plan: "
+                f"{item.member.backtest_hash} -> {result.hash}"
+            )
         results.append(result)
         diagnostics.append(
             {
-                "status": "completed",
-                "prediction_hash": prediction.hash,
+                "status": status,
+                "prediction_hash": item.prediction.hash,
                 "backtest_hash": result.hash,
             }
         )
-    return BacktestExecution(tuple(results), predictions.clone(), tuple(diagnostics))
+    if population is not None:
+        population.require_complete()
+    result_hashes = [result.hash for result in results]
+    catalog_rows = study.backtests.table(include_preview=True).filter(
+        pl.col("backtest_hash").is_in(result_hashes)
+    )
+    return BacktestExecution(tuple(results), catalog_rows, tuple(diagnostics), population)

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -44,6 +44,11 @@ class OfficialPopulation:
                 result = Result.open(study, member_hash, include_preview=True)
             except KeyError:
                 continue
+            if result.kind != member_kind:
+                raise ValueError(
+                    f"official population member {member_hash} has kind {result.kind}, "
+                    f"not {member_kind}"
+                )
             if result.execution_tier == "preview":
                 raise ValueError(
                     f"preview result {member_hash} cannot enter an official population"

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -17,7 +17,7 @@ from utils.paths import REPO_ROOT
 from .contracts import ExecutionTier
 
 if TYPE_CHECKING:
-    from .catalog import PredictionCatalog
+    from .catalog import BacktestCatalog, PredictionCatalog
     from .causal import CausalRequest
     from .labels import LabelCatalog
     from .lifecycle import Lifecycle
@@ -164,8 +164,26 @@ class Study:
         manifest_path = target / ".study.json"
         if target.exists():
             if not manifest_path.is_file():
-                raise ValueError(f"Existing workspace has no .study.json manifest: {target}")
-            manifest = json.loads(manifest_path.read_text())
+                isolated_root = os.environ.get("ML4T_OUTPUT_DIR")
+                may_adopt = (
+                    isolated_root is not None
+                    and Path(isolated_root).expanduser().resolve() == output_root
+                    and not target.is_symlink()
+                    and (target / "config").is_dir()
+                )
+                if not may_adopt:
+                    raise ValueError(f"Existing workspace has no .study.json manifest: {target}")
+                manifest = {
+                    "schema_version": 1,
+                    "case_study": case_study,
+                    "baseline_source_commit": _source_commit(release_root),
+                    "baseline_manifest_sha256": _release_manifest_digest(release_case_dir),
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "adopted_output_root": True,
+                }
+                manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+            else:
+                manifest = json.loads(manifest_path.read_text())
             if manifest.get("schema_version") != 1 or manifest.get("case_study") != case_study:
                 raise ValueError(f"Invalid workspace manifest: {manifest_path}")
         else:
@@ -295,6 +313,12 @@ class Study:
         from .catalog import PredictionCatalog
 
         return PredictionCatalog(self)
+
+    @property
+    def backtests(self) -> BacktestCatalog:
+        from .catalog import BacktestCatalog
+
+        return BacktestCatalog(self)
 
     @property
     def release_case_root(self) -> Path:

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1045,7 +1045,11 @@ def register_backtest_run(
             ) != value_digest(new_frame):
                 raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
         existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
-        if existing_returns.exists() and existing[2]:
+        if (
+            identity_version in SUPPORTED_IDENTITY_VERSIONS
+            and existing_returns.exists()
+            and existing[2]
+        ):
             return b_hash
 
     # Write spec.json

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1133,12 +1133,10 @@ def register_backtest_run(
                 n = returns.height if hasattr(returns, "height") else len(returns)
                 metrics["n_periods"] = float(n)
 
-    # Insert into DB — clean child tables first to avoid FK violations
-    # on INSERT OR REPLACE (which is DELETE + INSERT under the hood)
+    # Insert into DB without replacing an existing parent row. Metric UPSERTs
+    # below update only supplied columns and preserve prior headline and fold data.
     db = _open_registry(case_dir)
     try:
-        db.execute("DELETE FROM backtest_fold_metrics WHERE backtest_hash = ?", (b_hash,))
-        db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = ?", (b_hash,))
         if identity_version in SUPPORTED_IDENTITY_VERSIONS:
             existing = db.execute(
                 "SELECT prediction_hash, spec_json FROM backtest_runs WHERE backtest_hash = ?",
@@ -1151,43 +1149,24 @@ def register_backtest_run(
                 ) == canonical_json(_hashable_strategy_spec(strategy_spec))
                 if existing[0] != prediction_hash or not same_identity:
                     raise ValueError(f"immutable backtest identity conflict for {b_hash}")
-            db.execute(
-                """
-                INSERT OR IGNORE INTO backtest_runs
-                (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
-                 started_at, elapsed_s)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    b_hash,
-                    prediction_hash,
-                    spec_json_str,
-                    stage,
-                    _utc_now(),
-                    _git_hash(),
-                    started_at,
-                    elapsed_s,
-                ),
-            )
-        else:
-            db.execute(
-                """
-                INSERT OR REPLACE INTO backtest_runs
-                (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
-                 started_at, elapsed_s)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    b_hash,
-                    prediction_hash,
-                    spec_json_str,
-                    stage,
-                    _utc_now(),
-                    _git_hash(),
-                    started_at,
-                    elapsed_s,
-                ),
-            )
+        db.execute(
+            """
+            INSERT OR IGNORE INTO backtest_runs
+            (backtest_hash, prediction_hash, spec_json, stage, created_at, git_commit,
+             started_at, elapsed_s)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                b_hash,
+                prediction_hash,
+                spec_json_str,
+                stage,
+                _utc_now(),
+                _git_hash(),
+                started_at,
+                elapsed_s,
+            ),
+        )
 
         if metrics:
             _upsert_wide_metrics(db, "backtest_metrics", {"backtest_hash": b_hash}, metrics)

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1003,50 +1003,50 @@ def register_backtest_run(
     existing_strategy_spec: dict | None = None
     existing_backtest = False
 
-    if identity_version in SUPPORTED_IDENTITY_VERSIONS:
-        db = _open_registry(case_dir)
-        try:
-            existing = db.execute(
-                "SELECT prediction_hash, spec_json, "
-                "EXISTS(SELECT 1 FROM backtest_metrics m WHERE m.backtest_hash = ?) "
-                "FROM backtest_runs WHERE backtest_hash = ?",
-                (b_hash, b_hash),
-            ).fetchone()
-        finally:
-            db.close()
-        if existing is not None:
-            existing_backtest = True
-            existing_spec = json.loads(existing[1] or "{}")
+    db = _open_registry(case_dir)
+    try:
+        existing = db.execute(
+            "SELECT prediction_hash, spec_json, "
+            "EXISTS(SELECT 1 FROM backtest_metrics m WHERE m.backtest_hash = ?) "
+            "FROM backtest_runs WHERE backtest_hash = ?",
+            (b_hash, b_hash),
+        ).fetchone()
+    finally:
+        db.close()
+    if existing is not None:
+        existing_backtest = True
+        existing_spec = json.loads(existing[1] or "{}")
+        if identity_version in SUPPORTED_IDENTITY_VERSIONS:
             same_identity = canonical_json(
                 _hashable_strategy_spec(existing_spec)
             ) == canonical_json(_hashable_strategy_spec(strategy_spec))
             if existing[0] != prediction_hash or not same_identity:
                 raise ValueError(f"immutable backtest identity conflict for {b_hash}")
-            existing_strategy_spec = existing_spec
-            import polars as pl
+        existing_strategy_spec = existing_spec
+        import polars as pl
 
-            from case_studies.utils.artifact_digest import value_digest
+        from case_studies.utils.artifact_digest import value_digest
 
-            artifact_values = {
-                "daily_returns.parquet": returns,
-                "trades.parquet": trades,
-                "fills.parquet": fills,
-                "equity.parquet": equity,
-                "portfolio_state.parquet": portfolio_state,
-                "weights.parquet": weights,
-            }
-            for filename, value in artifact_values.items():
-                if value is None:
-                    continue
-                new_frame = value if isinstance(value, pl.DataFrame) else pl.from_pandas(value)
-                existing_path = _backtest_dir(case_dir, b_hash) / filename
-                if existing_path.exists() and value_digest(
-                    pl.read_parquet(existing_path)
-                ) != value_digest(new_frame):
-                    raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
-            existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
-            if existing_returns.exists() and existing[2]:
-                return b_hash
+        artifact_values = {
+            "daily_returns.parquet": returns,
+            "trades.parquet": trades,
+            "fills.parquet": fills,
+            "equity.parquet": equity,
+            "portfolio_state.parquet": portfolio_state,
+            "weights.parquet": weights,
+        }
+        for filename, value in artifact_values.items():
+            if value is None:
+                continue
+            new_frame = value if isinstance(value, pl.DataFrame) else pl.from_pandas(value)
+            existing_path = _backtest_dir(case_dir, b_hash) / filename
+            if existing_path.exists() and value_digest(
+                pl.read_parquet(existing_path)
+            ) != value_digest(new_frame):
+                raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
+        existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
+        if existing_returns.exists() and existing[2]:
+            return b_hash
 
     # Write spec.json
     bt_dir = _backtest_dir(case_dir, b_hash)

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1005,8 +1005,10 @@ def register_backtest_run(
         db = _open_registry(case_dir)
         try:
             existing = db.execute(
-                "SELECT prediction_hash, spec_json FROM backtest_runs WHERE backtest_hash = ?",
-                (b_hash,),
+                "SELECT prediction_hash, spec_json, "
+                "EXISTS(SELECT 1 FROM backtest_metrics m WHERE m.backtest_hash = ?) "
+                "FROM backtest_runs WHERE backtest_hash = ?",
+                (b_hash, b_hash),
             ).fetchone()
         finally:
             db.close()
@@ -1026,11 +1028,12 @@ def register_backtest_run(
                 new_returns = (
                     returns if isinstance(returns, pl.DataFrame) else pl.from_pandas(returns)
                 )
-                if not existing_returns.exists() or value_digest(
+                if existing_returns.exists() and value_digest(
                     pl.read_parquet(existing_returns)
                 ) != value_digest(new_returns):
                     raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
-            return b_hash
+            if existing_returns.exists() and existing[2]:
+                return b_hash
 
     # Write spec.json
     bt_dir = _backtest_dir(case_dir, b_hash)

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1000,6 +1000,7 @@ def register_backtest_run(
     stored_strategy_spec = dict(strategy_spec)
     stored_strategy_spec.pop("_runtime_backtest_config", None)
     spec_json_str = canonical_json(stored_strategy_spec)
+    existing_strategy_spec: dict | None = None
 
     if identity_version in SUPPORTED_IDENTITY_VERSIONS:
         db = _open_registry(case_dir)
@@ -1019,6 +1020,7 @@ def register_backtest_run(
             ) == canonical_json(_hashable_strategy_spec(strategy_spec))
             if existing[0] != prediction_hash or not same_identity:
                 raise ValueError(f"immutable backtest identity conflict for {b_hash}")
+            existing_strategy_spec = existing_spec
             import polars as pl
 
             from case_studies.utils.artifact_digest import value_digest
@@ -1037,7 +1039,10 @@ def register_backtest_run(
 
     # Write spec.json
     bt_dir = _backtest_dir(case_dir, b_hash)
-    _save_json(bt_dir / "spec.json", strategy_spec)
+    _save_json(
+        bt_dir / "spec.json",
+        existing_strategy_spec if existing_strategy_spec is not None else strategy_spec,
+    )
 
     # Save returns
     if returns is not None:
@@ -1119,8 +1124,13 @@ def register_backtest_run(
                 "SELECT prediction_hash, spec_json FROM backtest_runs WHERE backtest_hash = ?",
                 (b_hash,),
             ).fetchone()
-            if existing is not None and existing != (prediction_hash, spec_json_str):
-                raise ValueError(f"immutable backtest identity conflict for {b_hash}")
+            if existing is not None:
+                existing_spec = json.loads(existing[1] or "{}")
+                same_identity = canonical_json(
+                    _hashable_strategy_spec(existing_spec)
+                ) == canonical_json(_hashable_strategy_spec(strategy_spec))
+                if existing[0] != prediction_hash or not same_identity:
+                    raise ValueError(f"immutable backtest identity conflict for {b_hash}")
             db.execute(
                 """
                 INSERT OR IGNORE INTO backtest_runs

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1001,6 +1001,7 @@ def register_backtest_run(
     stored_strategy_spec.pop("_runtime_backtest_config", None)
     spec_json_str = canonical_json(stored_strategy_spec)
     existing_strategy_spec: dict | None = None
+    existing_backtest = False
 
     if identity_version in SUPPORTED_IDENTITY_VERSIONS:
         db = _open_registry(case_dir)
@@ -1014,6 +1015,7 @@ def register_backtest_run(
         finally:
             db.close()
         if existing is not None:
+            existing_backtest = True
             existing_spec = json.loads(existing[1] or "{}")
             same_identity = canonical_json(
                 _hashable_strategy_spec(existing_spec)
@@ -1025,47 +1027,61 @@ def register_backtest_run(
 
             from case_studies.utils.artifact_digest import value_digest
 
-            existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
-            if returns is not None:
-                new_returns = (
-                    returns if isinstance(returns, pl.DataFrame) else pl.from_pandas(returns)
-                )
-                if existing_returns.exists() and value_digest(
-                    pl.read_parquet(existing_returns)
-                ) != value_digest(new_returns):
+            artifact_values = {
+                "daily_returns.parquet": returns,
+                "trades.parquet": trades,
+                "fills.parquet": fills,
+                "equity.parquet": equity,
+                "portfolio_state.parquet": portfolio_state,
+                "weights.parquet": weights,
+            }
+            for filename, value in artifact_values.items():
+                if value is None:
+                    continue
+                new_frame = value if isinstance(value, pl.DataFrame) else pl.from_pandas(value)
+                existing_path = _backtest_dir(case_dir, b_hash) / filename
+                if existing_path.exists() and value_digest(
+                    pl.read_parquet(existing_path)
+                ) != value_digest(new_frame):
                     raise ValueError(f"immutable backtest artifact conflict for {b_hash}")
+            existing_returns = _backtest_dir(case_dir, b_hash) / "daily_returns.parquet"
             if existing_returns.exists() and existing[2]:
                 return b_hash
 
     # Write spec.json
     bt_dir = _backtest_dir(case_dir, b_hash)
-    _save_json(
-        bt_dir / "spec.json",
-        existing_strategy_spec if existing_strategy_spec is not None else strategy_spec,
-    )
+    if not (bt_dir / "spec.json").exists():
+        _save_json(
+            bt_dir / "spec.json",
+            existing_strategy_spec if existing_strategy_spec is not None else strategy_spec,
+        )
 
     # Save returns
-    if returns is not None:
+    if returns is not None and not (
+        existing_backtest and (bt_dir / "daily_returns.parquet").exists()
+    ):
         _save_parquet(bt_dir / "daily_returns.parquet", returns)
 
     # Save trade log
-    if trades is not None:
+    if trades is not None and not (existing_backtest and (bt_dir / "trades.parquet").exists()):
         _save_parquet(bt_dir / "trades.parquet", trades)
 
     # Save fill-level execution records
-    if fills is not None:
+    if fills is not None and not (existing_backtest and (bt_dir / "fills.parquet").exists()):
         _save_parquet(bt_dir / "fills.parquet", fills)
 
     # Save bar-level equity curve
-    if equity is not None:
+    if equity is not None and not (existing_backtest and (bt_dir / "equity.parquet").exists()):
         _save_parquet(bt_dir / "equity.parquet", equity)
 
     # Save bar-level portfolio state
-    if portfolio_state is not None:
+    if portfolio_state is not None and not (
+        existing_backtest and (bt_dir / "portfolio_state.parquet").exists()
+    ):
         _save_parquet(bt_dir / "portfolio_state.parquet", portfolio_state)
 
     # Save target weights
-    if weights is not None:
+    if weights is not None and not (existing_backtest and (bt_dir / "weights.parquet").exists()):
         _save_parquet(bt_dir / "weights.parquet", weights)
 
     # Defensive: compute per-backtest uncertainty inline from daily

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -227,6 +227,7 @@ def main():
                 parameters=parameters,
                 timeout=timeout,
                 output_dir=output_dir,
+                research_preview=False,
             )
 
             elapsed = time.time() - start

--- a/tests/notebook_worker.py
+++ b/tests/notebook_worker.py
@@ -176,6 +176,7 @@ def main() -> None:
             output_dir=output_dir,
             data_dir=data_dir,
             extra_env=extra_env,
+            research_preview=True,
         )
     elapsed = time.perf_counter() - started
 

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -853,6 +853,35 @@ def register_kernelspec(python_exe: str, launcher: Path | None = None) -> tuple[
     return kernel_name, root
 
 
+def research_preview_parameters(
+    py_path: Path,
+    parameters: dict | None,
+    output_dir: Path | None,
+) -> dict:
+    """Route migrated Study notebooks to the isolated reduced-run workspace."""
+    resolved = dict(parameters or {})
+    if output_dir is None:
+        return resolved
+    source = py_path.read_text(encoding="utf-8")
+    parameter_bounds = next(
+        (
+            (first_line, last_line)
+            for header, first_line, last_line in _percent_cell_bounds(source)
+            if PARAMETERS_CELL_MARKER in header
+        ),
+        None,
+    )
+    if parameter_bounds is None:
+        return resolved
+    first_line, last_line = parameter_bounds
+    tree = ast.parse(source, filename=str(py_path))
+    declared = {name for name, line in _top_level_bindings(tree) if first_line <= line <= last_line}
+    if {"EXECUTION_TIER", "WORKSPACE"} <= declared:
+        resolved["EXECUTION_TIER"] = "preview"
+        resolved["WORKSPACE"] = str(output_dir.resolve())
+    return resolved
+
+
 def run_notebook(
     py_path: Path,
     parameters: dict | None = None,
@@ -895,6 +924,7 @@ def run_notebook(
 
     start = time.time()
     nb_name = py_path.stem
+    parameters = research_preview_parameters(py_path, parameters, output_dir)
 
     def _log(msg: str) -> None:
         if log_path:

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -893,6 +893,7 @@ def run_notebook(
     cwd: Path | None = None,
     kernel_python: str | None = None,
     kernel_launcher: Path | None = None,
+    research_preview: bool = False,
 ) -> dict:
     """Execute a notebook via Papermill with parameter injection.
 
@@ -913,6 +914,7 @@ def run_notebook(
         kernel_python: Interpreter to execute with, when the notebook needs an
             environment other than the one running pytest
         kernel_launcher: Optional launcher script for that interpreter
+        research_preview: Inject preview tier and workspace for migrated Study notebooks
 
     Returns:
         Dict with keys: status ("ok" or "error"), error (str if failed),
@@ -924,7 +926,8 @@ def run_notebook(
 
     start = time.time()
     nb_name = py_path.stem
-    parameters = research_preview_parameters(py_path, parameters, output_dir)
+    if research_preview:
+        parameters = research_preview_parameters(py_path, parameters, output_dir)
 
     def _log(msg: str) -> None:
         if log_path:

--- a/tests/test_case_studies.py
+++ b/tests/test_case_studies.py
@@ -144,6 +144,7 @@ def test_case_study_pipeline(
         timeout=timeout,
         output_dir=seeded_output_dir,
         data_dir=populated_data_dir,
+        research_preview=True,
     )
 
     if result["status"] == "error":

--- a/tests/test_docker_notebooks.py
+++ b/tests/test_docker_notebooks.py
@@ -96,6 +96,7 @@ def test_docker_notebook(notebook_path, populated_data_dir, seeded_output_dir):
         data_dir=populated_data_dir,
         kernel_python=routing.python,
         kernel_launcher=routing.launcher,
+        research_preview=True,
     )
 
     if result["status"] == "error":

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -452,6 +452,7 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
         timeout=timeout,
         output_dir=isolated_model_output,
         log_path=LOG_PATH,
+        research_preview=True,
     )
 
     assert result["status"] == "ok", (

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1000,6 +1000,35 @@ def test_reduced_harness_injects_only_migrated_study_preview_parameters(
     assert legacy_parameters == {"MAX_FOLDS": 1}
 
 
+def test_run_notebook_requires_explicit_research_preview_opt_in(
+    tmp_path: Path, monkeypatch
+) -> None:
+    py = tmp_path / "06_model.py"
+    py.write_text(
+        '# %% tags=["parameters"]\nEXECUTION_TIER = "canonical"\nWORKSPACE = None\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pm_helpers, "sync_notebook", lambda path: path.with_suffix(".ipynb"))
+    _fake_papermill(monkeypatch)
+    calls: list[Path] = []
+
+    def inject(py_path: Path, parameters: dict | None, output_dir: Path | None) -> dict:
+        calls.append(py_path)
+        return dict(parameters or {})
+
+    monkeypatch.setattr(pm_helpers, "research_preview_parameters", inject)
+
+    pm_helpers.run_notebook(py, output_dir=tmp_path / "canonical")
+    assert calls == []
+
+    pm_helpers.run_notebook(
+        py,
+        output_dir=tmp_path / "preview",
+        research_preview=True,
+    )
+    assert calls == [py]
+
+
 def test_notebook_worker_caps_the_same_pools(tmp_path: Path, monkeypatch) -> None:
     """The full-execution path builds its own env table, so it can drift from
     run_notebook's. Both read one table, and this is what notices if they stop."""

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -21,6 +21,7 @@ from tests.pm_helpers import (
     get_reruns,
     get_tier,
     missing_required_env,
+    research_preview_parameters,
     unusable_parameters,
 )
 
@@ -962,6 +963,41 @@ def test_run_notebook_caps_the_kernel_thread_pools(tmp_path: Path, monkeypatch) 
     assert seen == dict.fromkeys(pm_helpers.KERNEL_THREAD_CAPS, pm_helpers.KERNEL_THREAD_CAP)
     # ...and restored afterwards, so the caps do not leak into the pytest process.
     assert os.environ["OMP_NUM_THREADS"] == "24"
+
+
+def test_reduced_harness_injects_only_migrated_study_preview_parameters(
+    tmp_path: Path,
+) -> None:
+    migrated = tmp_path / "06_model.py"
+    migrated.write_text(
+        '# %% tags=["parameters"]\n'
+        'EXECUTION_TIER = "canonical"\n'
+        'WORKSPACE = "experiments/unrelated"\n'
+        "MAX_FOLDS = 8\n"
+        "# %%\n"
+        "print(EXECUTION_TIER, WORKSPACE, MAX_FOLDS)\n",
+        encoding="utf-8",
+    )
+    legacy = tmp_path / "05_legacy.py"
+    legacy.write_text(
+        '# %% tags=["parameters"]\nMAX_FOLDS = 8\n# %%\nprint(MAX_FOLDS)\n',
+        encoding="utf-8",
+    )
+    isolated = tmp_path / "isolated"
+
+    migrated_parameters = research_preview_parameters(
+        migrated,
+        {"MAX_FOLDS": 1, "WORKSPACE": "experiments/unrelated"},
+        isolated,
+    )
+    legacy_parameters = research_preview_parameters(legacy, {"MAX_FOLDS": 1}, isolated)
+
+    assert migrated_parameters == {
+        "EXECUTION_TIER": "preview",
+        "MAX_FOLDS": 1,
+        "WORKSPACE": str(isolated.resolve()),
+    }
+    assert legacy_parameters == {"MAX_FOLDS": 1}
 
 
 def test_notebook_worker_caps_the_same_pools(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -681,6 +681,52 @@ def test_backtest_immutability_uses_the_same_semantic_projection_as_hashing(
         )
 
 
+def test_backtest_retry_rejects_changed_existing_execution_artifacts(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
+        pl.col("timestamp").str.to_date()
+    )
+    original_trades = pl.DataFrame({"symbol": ["SPY"], "pnl": [1.0]})
+    changed_trades = pl.DataFrame({"symbol": ["SPY"], "pnl": [2.0]})
+    strategy = {
+        "identity_version": 3,
+        "execution_tier": "canonical",
+        "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
+    }
+
+    backtest_hash = register_backtest_run(
+        "etfs",
+        prediction_hash,
+        strategy,
+        stage="signal",
+        returns=returns,
+        trades=original_trades,
+        metrics={"sharpe": 1.0},
+        case_dir=study.root,
+    )
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = ?", (backtest_hash,))
+        db.commit()
+
+    with pytest.raises(ValueError, match="immutable backtest artifact conflict"):
+        register_backtest_run(
+            "etfs",
+            prediction_hash,
+            strategy,
+            stage="signal",
+            returns=returns,
+            trades=changed_trades,
+            metrics={"sharpe": 1.0},
+            case_dir=study.root,
+        )
+
+    stored_trades = pl.read_parquet(
+        study.root / "run_log" / "backtest" / backtest_hash / "trades.parquet"
+    )
+    assert stored_trades.equals(original_trades)
+
+
 def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     release_case = release / "case_studies" / "etfs"

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -17,6 +17,7 @@ from case_studies.research import (
     Result,
     StateTransitionPolicy,
     Study,
+    plan_backtests,
     run_backtests,
     run_models,
 )
@@ -168,6 +169,39 @@ def test_catalog_one_reports_fields_that_disambiguate_matches(tmp_path: Path) ->
         study.predictions.one(config_name="ridge")
 
 
+def test_prediction_catalog_freezes_only_authoritative_polars_rows(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    first = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    second = _publish_prediction(study, alpha=2.0, checkpoint=2)
+    selected = study.predictions.table().filter(pl.col("prediction_hash").is_in([first, second]))
+
+    frozen = study.predictions.freeze(selected, name="visible-model-selection")
+
+    assert frozen.member_kind == "prediction"
+    assert frozen.members == tuple(sorted((first, second)))
+    assert CandidateSet.one(study, name="visible-model-selection").hash == frozen.hash
+    altered = selected.with_columns(pl.lit("altered-training").alias("training_hash"))
+    with pytest.raises(ValueError, match="altered lineage.*training_hash"):
+        study.predictions.freeze(altered, name="altered")
+    with pytest.raises(ValueError, match="duplicate.*ambiguous"):
+        study.predictions.freeze(pl.concat([selected, selected]), name="duplicate")
+
+    training = study.results.register_training(_resolved_spec(alpha=3.0))
+    frame = _predictions()
+    partial = study.results.publish_predictions(
+        training,
+        checkpoint_kind="epoch",
+        checkpoint_value=3,
+        split="validation",
+        predictions=frame.head(1),
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+        allow_partial=True,
+    )
+    partial_selection = study.predictions.table().filter(pl.col("prediction_hash") == partial.hash)
+    with pytest.raises(ValueError, match="partial"):
+        study.predictions.freeze(partial_selection, name="partial")
+
+
 def test_version_3_candidate_protocol_uses_computation_cv_identity(tmp_path: Path) -> None:
     study = _study(tmp_path)
     first_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
@@ -198,10 +232,203 @@ def test_n_catalog_rows_fan_out_to_n_independent_backtests(tmp_path: Path) -> No
     assert len({result.hash for result in execution.results}) == 2
     assert {item["prediction_hash"] for item in execution.diagnostics} == {first, second}
     assert _backtest_count(study) == 2
-    candidate_set = CandidateSet.create(study, "two-backtests", execution.results)
+    assert execution.population is not None
+    assert execution.population.require_complete() == tuple(
+        sorted(result.hash for result in execution.results)
+    )
+    assert "backtest_hash" in execution.catalog_rows.columns
+    assert execution.catalog_rows.height == 2
+    assert set(execution.catalog_rows["prediction_hash"]) == {first, second}
+    candidate_set = study.backtests.freeze(
+        execution.catalog_rows,
+        name="two-backtests",
+    )
+    with pytest.raises(ValueError, match="disambiguate.*checkpoint_value"):
+        study.backtests.one(config_name="ridge")
+    with pytest.raises(ValueError, match="required identity columns"):
+        study.backtests.freeze(
+            execution.catalog_rows.drop("training_hash"),
+            name="missing-backtest-lineage",
+        )
     assert CandidateSet.one(study, name="two-backtests").hash == candidate_set.hash
     assert len(candidate_set.ranked_validation_sharpe()) == 2
     assert len(candidate_set.ranked_validation_sharpe(limit=1)) == 1
+
+
+def test_backtest_catalog_is_typed_and_filters_nested_model_and_strategy_fields(
+    tmp_path: Path,
+) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    selected = study.predictions.table().filter(pl.col("prediction_hash") == prediction_hash)
+
+    execution = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+        allocation={"method": "equal_weight"},
+    )
+    catalog = study.backtests.table()
+    filtered = catalog.filter(
+        (pl.col("model__params__alpha") == 1.0)
+        & (pl.col("strategy__signal__top_k") == 1)
+        & (pl.col("strategy__allocation__method") == "equal_weight")
+    )
+
+    assert filtered.height == 1
+    assert filtered.item(0, "backtest_hash") == execution.results[0].hash
+    assert filtered.item(0, "completion_state") == "complete"
+    assert filtered.item(0, "complete") is True
+    assert filtered.schema["model__params__alpha"] == pl.Float64
+    assert filtered.schema["strategy__signal__top_k"] == pl.Int64
+    assert filtered.schema["sharpe"] == pl.Float64
+    assert filtered.item(0, "spec_json") == execution.results[0].registry_record()["spec_json"]
+    altered = filtered.with_columns(pl.lit("wrong-prediction").alias("prediction_hash"))
+    with pytest.raises(ValueError, match="altered lineage.*prediction_hash"):
+        study.backtests.freeze(altered, name="altered-backtest")
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        db.execute(
+            "DELETE FROM backtest_metrics WHERE backtest_hash = ?",
+            (execution.results[0].hash,),
+        )
+        db.commit()
+    partial = study.backtests.table().filter(pl.col("backtest_hash") == execution.results[0].hash)
+    with pytest.raises(ValueError, match="partial"):
+        study.backtests.freeze(partial, name="partial-backtest")
+
+
+def test_backtest_planning_resolves_every_identity_without_writes(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    first = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    second = _publish_prediction(study, alpha=2.0, checkpoint=2)
+    selected = study.predictions.table().filter(pl.col("prediction_hash").is_in([first, second]))
+
+    plan = plan_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    )
+
+    assert len(plan.members) == 2
+    assert len(set(plan.expected_hashes)) == 2
+    assert {member.prediction_hash for member in plan.members} == {first, second}
+    assert _backtest_count(study) == 0
+
+
+def test_explicit_backtest_bridge_preserves_strategy_identity_and_returns(tmp_path: Path) -> None:
+    direct_study = _study(tmp_path / "direct")
+    direct_prediction_hash = _publish_prediction(
+        direct_study,
+        alpha=1.0,
+        checkpoint=1,
+    )
+    direct_prediction = Result.open(direct_study, direct_prediction_hash)
+    assert isinstance(direct_prediction, PredictionResult)
+    direct_strategy = direct_study.strategy(
+        prediction=direct_prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+    )
+    expected_identity = direct_strategy.identity(prices=_prices())
+    direct_result = direct_strategy.run(prices=_prices())
+
+    explicit_study = _study(tmp_path / "explicit")
+    explicit_prediction_hash = _publish_prediction(
+        explicit_study,
+        alpha=1.0,
+        checkpoint=1,
+    )
+    selected = explicit_study.predictions.table().filter(
+        pl.col("prediction_hash") == explicit_prediction_hash
+    )
+    plan = plan_backtests(
+        explicit_study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    )
+    explicit_result = run_backtests(
+        explicit_study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    ).results[0]
+
+    assert plan.expected_hashes == (expected_identity,)
+    assert direct_result.hash == explicit_result.hash == expected_identity
+    direct_returns = (
+        direct_result.root / "run_log" / "backtest" / direct_result.hash / "daily_returns.parquet"
+    )
+    explicit_returns = (
+        explicit_result.root
+        / "run_log"
+        / "backtest"
+        / explicit_result.hash
+        / "daily_returns.parquet"
+    )
+    assert pl.read_parquet(direct_returns).equals(pl.read_parquet(explicit_returns))
+
+
+def test_backtest_population_precedes_writes_and_retry_reuses_completed_results(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from case_studies.research.strategy import Strategy
+
+    study = _study(tmp_path)
+    first = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    second = _publish_prediction(study, alpha=2.0, checkpoint=2)
+    selected = study.predictions.table().filter(pl.col("prediction_hash").is_in([first, second]))
+    planned = plan_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+    )
+    original_run = Strategy.run
+    calls = 0
+    observed_population_hash = None
+
+    def fail_second(self, *, prices=None):
+        nonlocal calls, observed_population_hash
+        calls += 1
+        population = OfficialPopulation.one(study, name="planned-backtests")
+        observed_population_hash = population.hash
+        assert population.members == tuple(sorted(planned.expected_hashes))
+        if calls == 1:
+            assert _backtest_count(study) == 0
+            return original_run(self, prices=prices)
+        raise RuntimeError("induced second backtest failure")
+
+    monkeypatch.setattr(Strategy, "run", fail_second)
+    with pytest.raises(RuntimeError, match="induced second backtest failure"):
+        run_backtests(
+            study,
+            predictions=selected,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            prices=_prices(),
+            population_name="planned-backtests",
+        )
+
+    population = OfficialPopulation.open(study, str(observed_population_hash))
+    with pytest.raises(ValueError, match="missing"):
+        population.require_complete()
+    assert _backtest_count(study) == 1
+
+    monkeypatch.setattr(Strategy, "run", original_run)
+    retried = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+        population_name="planned-backtests",
+    )
+
+    assert retried.population_hash == observed_population_hash
+    assert [item["status"] for item in retried.diagnostics] == ["reused", "completed"]
+    assert retried.population is not None
+    assert retried.population.require_complete() == tuple(sorted(planned.expected_hashes))
+    assert [result.hash for result in retried.results] == list(planned.expected_hashes)
 
 
 def test_strategy_change_creates_a_backtest_without_retraining(tmp_path: Path) -> None:
@@ -307,13 +534,50 @@ def test_preview_prediction_is_excluded_from_official_population(
     )
 
     assert study.predictions.table().is_empty()
-    assert study.predictions.table(include_preview=True).height == 1
+    preview_selection = study.predictions.table(include_preview=True)
+    assert preview_selection.height == 1
+    with pytest.raises(ValueError, match="preview.*candidate set"):
+        study.predictions.freeze(preview_selection, name="preview-must-not-freeze")
     with pytest.raises(ValueError, match="preview.*cannot enter"):
         OfficialPopulation.create(
             study,
             name="preview-must-not-enter-official",
             member_kind="prediction",
             members=[preview.hash],
+        )
+    preview_returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
+        pl.col("timestamp").str.to_date()
+    )
+    preview_backtest_hash = register_backtest_run(
+        "etfs",
+        preview.hash,
+        {
+            "identity_version": 2,
+            "execution_tier": "preview",
+            "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
+        },
+        stage="signal",
+        returns=preview_returns,
+        metrics={"sharpe": 1.0},
+        case_dir=preview.root,
+    )
+    preview_backtest_rows = study.backtests.table(include_preview=True).filter(
+        pl.col("backtest_hash") == preview_backtest_hash
+    )
+    assert preview_backtest_rows.item(0, "complete") is True
+    with pytest.raises(ValueError, match="preview.*candidate set"):
+        study.backtests.freeze(
+            preview_backtest_rows,
+            name="preview-backtest-must-not-freeze",
+        )
+    with pytest.raises(ValueError, match="preview.*official population"):
+        run_backtests(
+            study,
+            predictions=preview_selection,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            prices=_prices(),
+            execution_mode="vectorized",
+            population_name="preview-not-official",
         )
     with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
         assert db.execute("SELECT COUNT(*) FROM official_populations").fetchone() == (0,)
@@ -385,7 +649,10 @@ def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Pat
     reopened = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
 
     assert len(execution.results) == 1
+    assert execution.catalog_rows.item(0, "complete") is True
+    assert execution.catalog_rows.item(0, "origin") == "workspace"
     assert _backtest_count(reopened) == 1
+    assert reopened.backtests.table().item(0, "complete") is True
     assert reopened.predictions.table().item(0, "origin") == "released"
     assert _tree_digest(release_case) == before
 

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -681,7 +681,10 @@ def test_backtest_immutability_uses_the_same_semantic_projection_as_hashing(
         )
 
 
-def test_backtest_retry_rejects_changed_existing_execution_artifacts(tmp_path: Path) -> None:
+@pytest.mark.parametrize("identity_version", [3, None], ids=["versioned", "unversioned"])
+def test_backtest_retry_rejects_changed_existing_execution_artifacts(
+    tmp_path: Path, identity_version: int | None
+) -> None:
     study = _study(tmp_path)
     prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
     returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
@@ -689,11 +692,12 @@ def test_backtest_retry_rejects_changed_existing_execution_artifacts(tmp_path: P
     )
     original_trades = pl.DataFrame({"symbol": ["SPY"], "pnl": [1.0]})
     changed_trades = pl.DataFrame({"symbol": ["SPY"], "pnl": [2.0]})
-    strategy = {
-        "identity_version": 3,
+    strategy: dict = {
         "execution_tier": "canonical",
         "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
     }
+    if identity_version is not None:
+        strategy["identity_version"] = identity_version
 
     backtest_hash = register_backtest_run(
         "etfs",

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -731,6 +731,61 @@ def test_backtest_retry_rejects_changed_existing_execution_artifacts(
     assert stored_trades.equals(original_trades)
 
 
+@pytest.mark.parametrize("existing_sharpe", [1.0, None], ids=["stale", "partial"])
+def test_unversioned_backtest_retry_updates_metrics_without_rewriting_artifacts(
+    tmp_path: Path, existing_sharpe: float | None
+) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
+        pl.col("timestamp").str.to_date()
+    )
+    trades = pl.DataFrame({"symbol": ["SPY"], "pnl": [1.0]})
+    strategy = {
+        "execution_tier": "canonical",
+        "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
+    }
+    backtest_hash = register_backtest_run(
+        "etfs",
+        prediction_hash,
+        strategy,
+        stage="signal",
+        returns=returns,
+        trades=trades,
+        metrics={"sharpe": 1.0},
+        case_dir=study.root,
+    )
+    if existing_sharpe is None:
+        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+            db.execute(
+                "UPDATE backtest_metrics SET sharpe = NULL WHERE backtest_hash = ?",
+                (backtest_hash,),
+            )
+            db.commit()
+
+    retried_hash = register_backtest_run(
+        "etfs",
+        prediction_hash,
+        strategy,
+        stage="signal",
+        returns=returns,
+        trades=trades,
+        metrics={"sharpe": 2.0},
+        case_dir=study.root,
+    )
+
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        stored_sharpe = db.execute(
+            "SELECT sharpe FROM backtest_metrics WHERE backtest_hash = ?",
+            (backtest_hash,),
+        ).fetchone()[0]
+    assert retried_hash == backtest_hash
+    assert stored_sharpe == 2.0
+    assert pl.read_parquet(
+        study.root / "run_log" / "backtest" / backtest_hash / "trades.parquet"
+    ).equals(trades)
+
+
 def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Path) -> None:
     release = _seed_release(tmp_path)
     release_case = release / "case_studies" / "etfs"

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -430,6 +430,28 @@ def test_backtest_population_precedes_writes_and_retry_reuses_completed_results(
     assert retried.population.require_complete() == tuple(sorted(planned.expected_hashes))
     assert [result.hash for result in retried.results] == list(planned.expected_hashes)
 
+    interrupted_hash = retried.results[0].hash
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        db.execute(
+            "DELETE FROM backtest_metrics WHERE backtest_hash = ?",
+            (interrupted_hash,),
+        )
+        db.commit()
+    with pytest.raises(ValueError, match="partial"):
+        retried.population.require_complete()
+
+    repaired = run_backtests(
+        study,
+        predictions=selected,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        prices=_prices(),
+        population_name="planned-backtests",
+    )
+
+    assert [item["status"] for item in repaired.diagnostics] == ["completed", "reused"]
+    assert repaired.population is not None
+    assert repaired.population.require_complete() == tuple(sorted(planned.expected_hashes))
+
 
 def test_strategy_change_creates_a_backtest_without_retraining(tmp_path: Path) -> None:
     study = _study(tmp_path)
@@ -496,6 +518,7 @@ def test_custom_stateful_decision_backtests_but_requires_promotion_for_candidate
     )
     result = execution.results[0]
 
+    assert execution.population is None
     assert result.spec()["decision_artifact"]["hash"] == artifact.hash
     assert result.spec()["decision_artifact"]["state_transition_policy"] == {
         "fold_boundary": "liquidate",
@@ -509,6 +532,16 @@ def test_custom_stateful_decision_backtests_but_requires_promotion_for_candidate
             name="exploratory-decision",
             member_kind="backtest",
             members=[result.hash],
+        )
+    with pytest.raises(ValueError, match="exploratory.*official population"):
+        run_backtests(
+            study,
+            predictions=selected,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            prices=_prices(),
+            execution_mode="vectorized",
+            decision=artifact,
+            population_name="exploratory-must-not-be-official",
         )
 
 
@@ -662,6 +695,37 @@ def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Pat
     assert isinstance(relocated_prediction, PredictionResult)
     assert relocated_prediction.root == release_case
     assert relocated_prediction.load().height == _predictions().height
+
+
+def test_workspace_can_freeze_and_rank_a_released_backtest(tmp_path: Path) -> None:
+    release = _seed_release(tmp_path)
+    release_case = release / "case_studies" / "etfs"
+    prediction_hash = _publish(release_case, spec=_resolved_spec())
+    returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
+        pl.col("timestamp").str.to_date()
+    )
+    backtest_hash = register_backtest_run(
+        "etfs",
+        prediction_hash,
+        {
+            "identity_version": 2,
+            "execution_tier": "canonical",
+            "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
+        },
+        stage="signal",
+        returns=returns,
+        metrics={"sharpe": 1.0},
+        case_dir=release_case,
+    )
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    selected = study.backtests.table().filter(pl.col("backtest_hash") == backtest_hash)
+
+    frozen = study.backtests.freeze(selected, name="released-backtest")
+    ranked = frozen.ranked_validation_sharpe()
+
+    assert selected.item(0, "origin") == "released"
+    assert ranked[0].hash == backtest_hash
+    assert ranked[0].origin == "released"
 
 
 def test_quick_start_uses_human_fields_and_exposes_lineage_within_budget(tmp_path: Path) -> None:

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -23,7 +23,11 @@ from case_studies.research import (
 )
 from case_studies.utils import linear
 from case_studies.utils.registry import metrics as registry_metrics
-from case_studies.utils.registry import prediction_hash_from_parts, register_backtest_run
+from case_studies.utils.registry import (
+    prediction_hash_from_parts,
+    register_backtest_fold_metrics,
+    register_backtest_run,
+)
 from tests.test_research_contract_catalog import _publish, _resolved_spec, _tree_digest
 from tests.test_research_flow import _prices
 from tests.test_research_models import _linear_study
@@ -784,6 +788,56 @@ def test_unversioned_backtest_retry_updates_metrics_without_rewriting_artifacts(
     assert pl.read_parquet(
         study.root / "run_log" / "backtest" / backtest_hash / "trades.parquet"
     ).equals(trades)
+
+
+def test_unversioned_metric_retry_preserves_unsupplied_and_fold_metrics(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction_hash = _publish_prediction(study, alpha=1.0, checkpoint=1)
+    returns = pl.DataFrame({"timestamp": ["2024-01-05"], "return": [0.01]}).with_columns(
+        pl.col("timestamp").str.to_date()
+    )
+    strategy = {
+        "execution_tier": "canonical",
+        "strategy": {"signal": {"method": "equal_weight_top_k", "top_k": 1}},
+    }
+    backtest_hash = register_backtest_run(
+        "etfs",
+        prediction_hash,
+        strategy,
+        stage="signal",
+        returns=returns,
+        metrics={"sharpe": 1.0, "max_drawdown": -0.1},
+        case_dir=study.root,
+    )
+    register_backtest_fold_metrics(
+        "etfs",
+        backtest_hash,
+        {0: {"sharpe": 0.5, "max_drawdown": -0.2}},
+        case_dir=study.root,
+    )
+
+    register_backtest_run(
+        "etfs",
+        prediction_hash,
+        strategy,
+        stage="signal",
+        returns=returns,
+        metrics={"sharpe": 2.0},
+        case_dir=study.root,
+    )
+
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        headline = db.execute(
+            "SELECT sharpe, max_drawdown FROM backtest_metrics WHERE backtest_hash = ?",
+            (backtest_hash,),
+        ).fetchone()
+        fold = db.execute(
+            "SELECT sharpe, max_drawdown FROM backtest_fold_metrics "
+            "WHERE backtest_hash = ? AND fold_id = 0",
+            (backtest_hash,),
+        ).fetchone()
+    assert headline == (2.0, -0.1)
+    assert fold == (0.5, -0.2)
 
 
 def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Path) -> None:

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -652,6 +652,13 @@ def test_backtest_immutability_uses_the_same_semantic_projection_as_hashing(
         metrics={"sharpe": 1.0},
         case_dir=study.root,
     )
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        first_spec_json = db.execute(
+            "SELECT spec_json FROM backtest_runs WHERE backtest_hash = ?",
+            (first_hash,),
+        ).fetchone()[0]
+        db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = ?", (first_hash,))
+        db.commit()
     second_hash = register_backtest_run(
         "etfs",
         prediction_hash,
@@ -663,6 +670,15 @@ def test_backtest_immutability_uses_the_same_semantic_projection_as_hashing(
     )
 
     assert first_hash == second_hash
+    assert Result.open(study, second_hash).complete
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        assert (
+            db.execute(
+                "SELECT spec_json FROM backtest_runs WHERE backtest_hash = ?",
+                (second_hash,),
+            ).fetchone()[0]
+            == first_spec_json
+        )
 
 
 def test_released_catalog_prediction_backtests_into_workspace_only(tmp_path: Path) -> None:

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -162,6 +162,44 @@ def test_study_create_and_reopen_do_not_change_release_bytes(tmp_path: Path) -> 
     assert _tree_digest(release) == before
 
 
+def test_seeded_output_root_becomes_the_explicit_isolated_preview_workspace(
+    tmp_path: Path, monkeypatch
+) -> None:
+    release = _seed_release(tmp_path)
+    release_before = _tree_digest(release)
+    isolated = tmp_path / "isolated"
+    seeded_case = isolated / "etfs"
+    (seeded_case / "config").mkdir(parents=True)
+    (seeded_case / "config" / "setup.yaml").write_text("marker: seeded\n")
+    _open_registry(seeded_case).close()
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(isolated))
+
+    study = Study.open("etfs", workspace=isolated, release_root=release)
+    training = study.results.register_training(
+        {
+            "identity_version": 2,
+            "execution_tier": "preview",
+            "family": "linear",
+            "label": "fwd_ret_21d",
+            "config_name": "ridge",
+            "seed": 42,
+            "preview_reductions": {"folds": [0]},
+        },
+        execution_tier="preview",
+    )
+
+    preview_case = isolated / ".preview" / "etfs"
+    assert study.root == seeded_case
+    assert study.manifest["adopted_output_root"] is True
+    assert training.root == preview_case
+    assert (seeded_case / ".study.json").is_file()
+    assert (seeded_case / "run_log" / "registry.db").is_file()
+    assert (preview_case / "run_log" / "registry.db").is_file()
+    assert (preview_case / "run_log" / "training" / training.hash / "spec.json").is_file()
+    assert _tree_digest(release) == release_before
+    assert not (tmp_path / "experiments").exists()
+
+
 @pytest.mark.parametrize("regular_directory", ["features", "labels", "run_log"])
 def test_regeneration_rejects_regular_generated_artifact_directories(
     tmp_path: Path, regular_directory: str


### PR DESCRIPTION
## Summary

- add authoritative Polars selection freezing for prediction and backtest catalogs
- add typed backtest catalog rows, shared N-row planning, and pre-write official populations
- preserve completed results and immutable artifacts across failure and retry
- route migrated reduced notebook runs into an explicit isolated preview workspace

## Behavior

Phase 1 notebooks can freeze human-readable prediction selections and complete expected backtest populations without handling the temporary fluent Strategy object. Successful backtest identities and numerical outputs remain unchanged.

## Evidence

- focused research contract and workspace suites
- registry completeness, lineage, metrics, and retry suites
- Ruff check and format
- ty checks for changed public interfaces
- commit hooks and RoboRev branch review

No notebook, model, or production backtest was executed for this change.