### PR TITLE
Fix typed S&P 500 option strategy accounting

### DIFF
--- a/case_studies/research/decisions.py
+++ b/case_studies/research/decisions.py
@@ -45,6 +45,7 @@ def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
         "target_weights": "weight",
         "target_positions": "position",
         "orders": "quantity",
+        "short_straddles": "weight",
     }.get(kind)
     if value_column is None:
         raise ValueError("unsupported decision artifact kind")
@@ -66,6 +67,47 @@ def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
         raise ValueError("decision artifacts cannot contain both fold and fold_id")
     if fold_columns and decisions.get_column(fold_columns[0]).null_count():
         raise ValueError("decision artifact fold values cannot be null")
+    if kind == "short_straddles":
+        contract_columns = {
+            "strike",
+            "expiration",
+            "entry_date",
+            "entry_straddle_mid",
+            "entry_call_mid",
+            "entry_call_bid",
+            "entry_call_ask",
+            "entry_put_mid",
+            "entry_put_bid",
+            "entry_put_ask",
+        }
+        missing_contract = contract_columns - set(decisions.columns)
+        if missing_contract:
+            raise ValueError(
+                f"short-straddle decisions are missing columns: {sorted(missing_contract)}"
+            )
+        if decisions.select(*sorted(contract_columns)).null_count().sum_horizontal().item():
+            raise ValueError("short-straddle decisions cannot contain null contract fields")
+        invalid_dates = decisions.filter(
+            (pl.col("entry_date").cast(pl.Date) <= pl.col("timestamp").cast(pl.Date))
+            | (pl.col("expiration").cast(pl.Date) < pl.col("entry_date").cast(pl.Date))
+        )
+        if not invalid_dates.is_empty():
+            raise ValueError("short-straddle entry and expiration dates are invalid")
+        if decisions.filter(
+            (pl.col("strike") <= 0)
+            | (pl.col("entry_straddle_mid") <= 0)
+            | (pl.col("entry_call_mid") <= 0)
+            | (pl.col("entry_put_mid") <= 0)
+            | (pl.col("entry_call_bid") < 0)
+            | (pl.col("entry_put_bid") < 0)
+            | (pl.col("entry_call_ask") < pl.col("entry_call_bid"))
+            | (pl.col("entry_put_ask") < pl.col("entry_put_bid"))
+            | (pl.col("weight") <= 0)
+        ).height:
+            raise ValueError("short-straddle decisions contain invalid quotes, strike, or weight")
+        weight_sums = decisions.group_by("timestamp").agg(pl.col("weight").sum().alias("weight"))
+        if weight_sums.filter((pl.col("weight") - 1.0).abs() > 1e-10).height:
+            raise ValueError("short-straddle weights must sum to one per decision timestamp")
     return keys
 
 

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -300,6 +300,42 @@ class Strategy:
         spec["identity_version"] = 2
         spec["execution_tier"] = self.prediction.execution_tier
         spec["input_identity"] = {"prices": value_digest(prices)}
+        if self.study.case_study == "sp500_options" and self.label == "ret_to_expiry":
+            from case_studies.sp500_options._htm_backtest import (
+                option_accounting_parameters,
+                option_data_paths,
+                option_source_identity,
+            )
+
+            if self.risk is not None:
+                raise ValueError("the specialized option path does not support risk overlays")
+            if self.costs is not None:
+                raise ValueError(
+                    "option cost variants use signal.option_spread_fraction; generic costs are unsupported"
+                )
+
+            labels_dir, raw_options_dir = option_data_paths()
+            option_inputs = option_source_identity(labels_dir, raw_options_dir)
+            spec["input_identity"]["option_contract_returns"] = option_inputs["contract_returns"]
+            spec["input_identity"]["option_lifecycle"] = compute_hash(
+                canonical_json(option_inputs["raw_lifecycle"])
+            )
+            accounting = option_accounting_parameters(self.signal)
+            if (
+                self.decision is not None
+                and self.decision.kind == "short_straddles"
+                and accounting["exit_at_max_days"] is not None
+            ):
+                raise ValueError("hold-to-expiry decisions cannot declare an earlier option exit")
+            spec["options_market"] = {
+                "decision_timestamp": "feature_session_close",
+                "entry": "next_session_close",
+                "position": "short_atm_call_and_put",
+                "marking": "paired_daily_midpoint",
+                "settlement": accounting["settlement"],
+                "hedge": "retained_underlying_delta_with_threshold",
+            }
+            spec["options_accounting"] = accounting
         if self.study.case_study == "crypto_perps_funding":
             funding_rates = self._funding_rates(prices)
             assert funding_rates is not None
@@ -314,6 +350,9 @@ class Strategy:
                 "source_identity": self.decision.spec["source_identity"],
                 "state_transition_policy": self.decision.spec["state_transition_policy"],
             }
+            if self.decision.kind == "short_straddles":
+                spec["decision_artifact"]["decision_keys"] = self.decision.spec["decision_keys"]
+                spec["decision_artifact"]["parameters"] = self.decision.spec["parameters"]
             decision_weights = self._decision_weights(prices)
             assert decision_weights is not None
             spec["backtest_config"]["account"]["allow_short_selling"] = bool(
@@ -373,6 +412,25 @@ class Strategy:
                 .otherwise(0.0)
                 .alias("weight")
             ).select("symbol", "timestamp", "weight", *selected_fold)
+        elif self.decision.kind == "short_straddles":
+            if self.study.case_study != "sp500_options" or self.label != "ret_to_expiry":
+                raise ValueError("short-straddle decisions require sp500_options and ret_to_expiry")
+            parameters = self.decision.spec.get("parameters") or {}
+            expected = {
+                "decision_cadence": "weekly_friday",
+                "entry_policy": "next_session_close",
+                "exit_policy": "hold_to_expiry",
+                "settlement_policy": "cash_intrinsic_at_expiration",
+                "hedge_policy": "retained_underlying_delta_with_threshold",
+            }
+            mismatched = {
+                key: (parameters.get(key), value)
+                for key, value in expected.items()
+                if parameters.get(key) != value
+            }
+            if mismatched:
+                raise ValueError(f"short-straddle decision parameters are invalid: {mismatched}")
+            weights = decisions
         else:
             raise ValueError("canonical backtesting does not support order decision artifacts")
         if fold_column == "fold_id":
@@ -393,6 +451,8 @@ class Strategy:
         missing = weights.join(price_keys, on=["symbol", "timestamp"], how="anti")
         if not missing.is_empty():
             raise ValueError("decision artifact contains keys outside the backtest price grid")
+        if self.decision.kind == "short_straddles":
+            return weights.sort("timestamp", "symbol")
         selected = ["symbol", "timestamp", "weight"]
         if "_state_transition" in weights.columns:
             selected.append("_state_transition")
@@ -402,7 +462,12 @@ class Strategy:
         spec = self.resolve(prices=prices)
         return backtest_hash_from_parts(self.prediction.hash, spec, identity_version=2)
 
-    def run(self, *, prices: pl.DataFrame | None = None) -> BacktestResult:
+    def run(
+        self,
+        *,
+        prices: pl.DataFrame | None = None,
+        option_lifecycle: pl.DataFrame | None = None,
+    ) -> BacktestResult:
         self.study.require_writable()
         if self.split == "holdout" and prices is not None:
             raise ValueError("locked holdout strategy must load canonical holdout prices")
@@ -447,6 +512,7 @@ class Strategy:
             initial_cash=float(spec["backtest_config"]["cash"]["initial"]),
             calendar=case_config.calendar,
             contract_specs=contract_specs,
+            option_lifecycle=option_lifecycle,
         )
         expected_hash = backtest_hash_from_parts(
             self.prediction.hash,

--- a/case_studies/sp500_options/_htm_backtest.py
+++ b/case_studies/sp500_options/_htm_backtest.py
@@ -28,13 +28,12 @@ so at steady state 5 cohorts are open simultaneously. Each cohort is sized at
 ``1/n_roll`` of capital so the book is fully invested.
 
 Inputs:
-- ``labels/contract_returns.parquet`` — one row per (feature_date, symbol, strike,
+- ``labels/contract_returns.parquet`` - one row per (feature_date, symbol, strike,
   expiration) with entry call/put mid, bid, ask and expiration date.
-- ``labels/hedge_path.parquet`` — per-cohort per-holding-day call_delta, put_delta,
-  instr_delta, underlying_price.
 - Raw daily option chain at ``data/equities/market/sp500/options_straddles_raw/year=YYYY.parquet``
-  for tracking same-contract mids through the holding period. This is the
-  reader-distributed slim — a lifecycle-preserving superset of every contract
+  for tracking same-contract quotes, deltas, underlying prices, and settlement
+  inputs through expiration. This is the reader-distributed slim dataset, a
+  lifecycle-preserving superset of every contract
   the ATM-band candidate filter (DTE 25-35, |delta| 0.35-0.65, converged IV,
   bid >= 0.01, relative spread <= 0.30) ever picks, with every daily observation
   from first listing through expiration. Backtest results are byte-identical
@@ -47,8 +46,12 @@ backtest.
 
 from __future__ import annotations
 
+import hashlib
 import math
+from datetime import date, datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
 import polars as pl
@@ -65,6 +68,94 @@ DELTA_THRESHOLD_DEFAULT = 0.10  # setup.yaml hedging_protocol.delta_threshold
 HEDGE_SPREAD_BPS_DEFAULT = 0.5  # 0.5 bps of hedge-trade notional
 EQUITY_COMMISSION_PER_SHARE_DEFAULT = 0.0035  # USD / share, IBKR Pro Tiered top
 OPTION_COMMISSION_PER_CONTRACT_DEFAULT = 1.00  # USD / contract incl. exchange/clearing/regulatory
+OPTION_CONTRACT_MULTIPLIER_DEFAULT = 100
+
+
+def option_accounting_parameters(signal: dict[str, Any]) -> dict[str, Any]:
+    """Resolve every identity-bearing input used by the specialized option engine."""
+    import yaml
+
+    from utils.paths import get_case_study_dir
+
+    setup_path = get_case_study_dir(CASE_STUDY_ID) / "config" / "setup.yaml"
+    setup = yaml.safe_load(setup_path.read_text())
+    costs = setup["costs"]["components"]
+    exit_at_max_days = signal.get("exit_at_max_days")
+    if exit_at_max_days is not None:
+        exit_at_max_days = int(exit_at_max_days)
+        if exit_at_max_days < 1:
+            raise ValueError("exit_at_max_days must be positive")
+    n_roll = int(signal.get("n_roll", N_ROLL_DEFAULT))
+    if n_roll < 1:
+        raise ValueError("n_roll must be positive")
+    option_spread_fraction = float(signal.get("option_spread_fraction", 1.0))
+    if not 0 <= option_spread_fraction <= 1:
+        raise ValueError("option_spread_fraction must be between zero and one")
+    delta_threshold = float(setup["hedging_protocol"]["delta_threshold"])
+    if delta_threshold < 0:
+        raise ValueError("delta_threshold cannot be negative")
+    return {
+        "schema_version": 1,
+        "n_roll": n_roll,
+        "portfolio_sizing": "equal_premium_within_cohort_and_fixed_cohort_fraction",
+        "delta_hedge": True,
+        "delta_threshold": delta_threshold,
+        "hedge_spread_bps": float(costs["hedge_spread"]["estimate_bps_of_notional"]),
+        "equity_commission_per_share": float(costs["commission"]["equity_per_share"]),
+        "option_commission_per_contract": float(costs["commission"]["option_per_contract"]),
+        "option_contract_multiplier": OPTION_CONTRACT_MULTIPLIER_DEFAULT,
+        "option_spread_fraction": option_spread_fraction,
+        "exit_at_max_days": exit_at_max_days,
+        "entry_quote": "bid_for_short_call_and_put",
+        "daily_mark": "paired_midpoint",
+        "settlement": (
+            "cash_intrinsic_at_expiration"
+            if exit_at_max_days is None
+            else "ask_for_buy_to_close_at_holding_limit"
+        ),
+        "hedge_liquidation": "final_observation_close",
+    }
+
+
+def option_data_paths() -> tuple[Path, Path]:
+    """Resolve the canonical option artifact and raw lifecycle roots."""
+    from utils import ML4T_DATA_PATH
+    from utils.paths import get_case_study_dir
+
+    labels_dir = get_case_study_dir(CASE_STUDY_ID) / "labels"
+    raw_options_dir = ML4T_DATA_PATH / "equities" / "market" / "sp500" / "options_straddles_raw"
+    if not (labels_dir / "contract_returns.parquet").is_file():
+        raise FileNotFoundError("sp500_options contract_returns.parquet is missing")
+    if not raw_options_dir.is_dir():
+        raise FileNotFoundError(f"raw option lifecycle directory is missing: {raw_options_dir}")
+    return labels_dir, raw_options_dir
+
+
+@lru_cache(maxsize=64)
+def _file_sha256(path_string: str, size: int, modified_ns: int) -> str:
+    del size, modified_ns
+    digest = hashlib.sha256()
+    with Path(path_string).open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _digest_file(path: Path) -> str:
+    stat = path.stat()
+    return _file_sha256(str(path.resolve()), stat.st_size, stat.st_mtime_ns)
+
+
+def option_source_identity(labels_dir: Path, raw_options_dir: Path) -> dict[str, Any]:
+    """Bind the specialized engine to exact contract and lifecycle files."""
+    contract_returns = labels_dir / "contract_returns.parquet"
+    raw_files = sorted(raw_options_dir.glob("year=*.parquet"))
+    if not raw_files:
+        raise FileNotFoundError(f"raw option lifecycle directory is empty: {raw_options_dir}")
+    return {
+        "contract_returns": _digest_file(contract_returns),
+        "raw_lifecycle": {path.name: _digest_file(path) for path in raw_files},
+    }
 
 
 def _select_cohorts(
@@ -123,7 +214,7 @@ def _select_cohorts(
             f"equal_weight_top_k, score_weighted_top_k, cross_sectional_percentile."
         )
 
-    cr = contract_returns.filter(pl.col("exit_found_10d")).select(
+    cr = contract_returns.select(
         pl.col("feature_date").alias("timestamp"),
         "symbol",
         "strike",
@@ -137,7 +228,43 @@ def _select_cohorts(
         "entry_put_bid",
         "entry_put_ask",
     )
+    if cr.n_unique(["timestamp", "symbol"]) != cr.height:
+        raise ValueError("contract-return rows are not unique by decision timestamp and symbol")
+    invalid_contracts = cr.filter(
+        pl.any_horizontal(
+            [
+                pl.col(column).is_null()
+                for column in (
+                    "strike",
+                    "expiration",
+                    "entry_date",
+                    "entry_straddle_mid",
+                    "entry_call_mid",
+                    "entry_call_bid",
+                    "entry_call_ask",
+                    "entry_put_mid",
+                    "entry_put_bid",
+                    "entry_put_ask",
+                )
+            ]
+        )
+    )
+    if not invalid_contracts.is_empty():
+        cr = cr.join(
+            invalid_contracts.select("timestamp", "symbol"),
+            on=["timestamp", "symbol"],
+            how="anti",
+        )
     cohorts = ranked.join(cr, on=["timestamp", "symbol"], how="inner")
+    missing = ranked.join(
+        cohorts.select("timestamp", "symbol"),
+        on=["timestamp", "symbol"],
+        how="anti",
+    )
+    if not missing.is_empty():
+        raise ValueError(
+            f"selected option decisions have no complete entry contract: {missing.height} rows"
+        )
 
     if method == "score_weighted_top_k":
         cohorts = (
@@ -169,26 +296,26 @@ def _select_cohorts(
     return cohorts
 
 
-def _load_daily_contract_mids(
+def _load_option_lifecycle(
     cohorts: pl.DataFrame,
     raw_options_dir: Path,
 ) -> pl.DataFrame:
-    """Pull daily call_mid + put_mid + underlying_price for every contract in
-    cohorts, for every trading day in the union of cohorts' holding windows.
-
-    Returns [date, symbol, strike, expiration, instr_mid, underlying_price].
-    """
+    """Load paired option quotes, deltas, and explicit cash settlement through expiry."""
     contracts = cohorts.select(["symbol", "strike", "expiration"]).unique()
     entry_min = cohorts["entry_date"].min()
     exp_max = cohorts["expiration"].max()
+    if not isinstance(entry_min, (date, datetime)) or not isinstance(exp_max, (date, datetime)):
+        raise TypeError("option cohort entry and expiration columns must contain dates")
     years = list(range(entry_min.year, exp_max.year + 1))
     parts = []
+    calendars = []
+    symbols = cohorts.get_column("symbol").unique().to_list()
     for year in years:
         parquet_path = raw_options_dir / f"year={year}.parquet"
         if not parquet_path.exists():
             continue
         raw = pl.scan_parquet(parquet_path)
-        filt = (
+        selected = (
             raw.select(
                 [
                     "date",
@@ -199,17 +326,44 @@ def _load_daily_contract_mids(
                     "mid_price",
                     "bid",
                     "ask",
+                    "delta",
                     "underlying_price",
                 ]
             )
-            .filter(pl.col("mid_price") > 0)
+            .filter(pl.col("symbol").is_in(symbols))
+            .filter(pl.col("date").is_between(entry_min, exp_max, closed="both"))
+            .join(contracts.lazy(), on=["symbol", "strike", "expiration"], how="semi")
             .collect()
         )
-        matched = filt.join(contracts, on=["symbol", "strike", "expiration"], how="semi")
-        parts.append(matched)
+        calendar = (
+            raw.select("date")
+            .filter(pl.col("date").is_between(entry_min, exp_max, closed="both"))
+            .unique()
+            .collect()
+        )
+        parts.append(selected)
+        calendars.append(calendar)
     if not parts:
         raise FileNotFoundError(f"No raw option data in {raw_options_dir}")
     raw_lookup = pl.concat(parts)
+    key_columns = ["date", "symbol", "strike", "expiration", "call_put"]
+    if raw_lookup.n_unique(key_columns) != raw_lookup.height:
+        raise ValueError("raw option lifecycle contains duplicate contract-leg dates")
+    required_values = ["mid_price", "bid", "ask", "delta", "underlying_price"]
+    invalid = raw_lookup.filter(
+        pl.any_horizontal(
+            [
+                pl.col(column).is_null() | ~pl.col(column).cast(pl.Float64).is_finite()
+                for column in required_values
+            ]
+        )
+        | (pl.col("mid_price") < 0)
+        | (pl.col("bid") < 0)
+        | (pl.col("ask") < pl.col("bid"))
+        | (pl.col("underlying_price") <= 0)
+    )
+    if not invalid.is_empty():
+        raise ValueError(f"raw option lifecycle contains {invalid.height} invalid quote rows")
     calls = raw_lookup.filter(pl.col("call_put") == "C").select(
         [
             "date",
@@ -219,6 +373,7 @@ def _load_daily_contract_mids(
             pl.col("mid_price").alias("call_mid"),
             pl.col("bid").alias("call_bid"),
             pl.col("ask").alias("call_ask"),
+            pl.col("delta").alias("call_delta"),
             "underlying_price",
         ]
     )
@@ -231,10 +386,24 @@ def _load_daily_contract_mids(
             pl.col("mid_price").alias("put_mid"),
             pl.col("bid").alias("put_bid"),
             pl.col("ask").alias("put_ask"),
+            pl.col("delta").alias("put_delta"),
+            pl.col("underlying_price").alias("put_underlying_price"),
         ]
     )
-    mids = (
+    lifecycle = (
         calls.join(puts, on=["date", "symbol", "strike", "expiration"], how="inner")
+        .with_columns(
+            cash_settled=pl.col("date") == pl.col("expiration"),
+            instr_delta=pl.col("call_delta") + pl.col("put_delta"),
+        )
+        .with_columns(
+            call_mid=pl.when(pl.col("cash_settled"))
+            .then((pl.col("underlying_price") - pl.col("strike")).clip(lower_bound=0.0))
+            .otherwise(pl.col("call_mid")),
+            put_mid=pl.when(pl.col("cash_settled"))
+            .then((pl.col("strike") - pl.col("underlying_price")).clip(lower_bound=0.0))
+            .otherwise(pl.col("put_mid")),
+        )
         .with_columns(instr_mid=pl.col("call_mid") + pl.col("put_mid"))
         .select(
             [
@@ -249,39 +418,93 @@ def _load_daily_contract_mids(
                 "put_mid",
                 "put_bid",
                 "put_ask",
+                "call_delta",
+                "put_delta",
+                "instr_delta",
                 "underlying_price",
+                "put_underlying_price",
+                "cash_settled",
             ]
         )
     )
-    return mids
+    if lifecycle.filter(
+        (pl.col("underlying_price") - pl.col("put_underlying_price")).abs() > 1e-10
+    ).height:
+        raise ValueError("call and put rows disagree on the underlying settlement price")
+
+    cohort_keys = cohorts.select(
+        pl.col("timestamp").alias("cohort_feature_date"),
+        "symbol",
+        "strike",
+        "expiration",
+        "entry_date",
+        "entry_call_mid",
+        "entry_put_mid",
+    ).unique()
+    calendar = pl.concat(calendars).unique()
+    expected = (
+        cohort_keys.join(calendar, how="cross")
+        .filter(pl.col("date").is_between(pl.col("entry_date"), pl.col("expiration")))
+        .select(
+            "cohort_feature_date",
+            "symbol",
+            "strike",
+            "expiration",
+            "entry_date",
+            "date",
+        )
+    )
+    observed = (
+        cohort_keys.join(lifecycle, on=["symbol", "strike", "expiration"], how="inner")
+        .filter(pl.col("date").is_between(pl.col("entry_date"), pl.col("expiration")))
+        .select(expected.columns)
+    )
+    missing = expected.join(observed, on=expected.columns, how="anti")
+    if not missing.is_empty():
+        raise ValueError(f"selected option contracts are missing {missing.height} lifecycle dates")
+    endpoints = cohort_keys.join(
+        lifecycle, on=["symbol", "strike", "expiration"], how="inner"
+    ).filter(pl.col("date") == pl.col("entry_date"))
+    if endpoints.height != cohort_keys.height:
+        raise ValueError("selected option contracts do not all have an entry observation")
+    if endpoints.filter(
+        ((pl.col("call_mid") - pl.col("entry_call_mid")).abs() > 1e-10)
+        | ((pl.col("put_mid") - pl.col("entry_put_mid")).abs() > 1e-10)
+    ).height:
+        raise ValueError("contract-return entry quotes disagree with the raw option lifecycle")
+    expiry_keys = cohort_keys.select("cohort_feature_date", "symbol", "strike", "expiration").join(
+        lifecycle.filter(pl.col("cash_settled")).select("symbol", "strike", "expiration"),
+        on=["symbol", "strike", "expiration"],
+        how="semi",
+    )
+    if expiry_keys.height != cohort_keys.height:
+        raise ValueError("selected option contracts do not all have cash-settlement inputs")
+    return lifecycle.drop("put_underlying_price").sort(["symbol", "strike", "expiration", "date"])
+
+
+_load_daily_contract_mids = _load_option_lifecycle
 
 
 def _compute_cohort_daily_pnl(
     cohorts: pl.DataFrame,
     contract_mids: pl.DataFrame,
-    hedge_path: pl.DataFrame,
     *,
     delta_hedge: bool,
     hedge_spread_bps: float,
     equity_commission_per_share: float,
     option_commission_per_contract: float,
+    option_contract_multiplier: int = OPTION_CONTRACT_MULTIPLIER_DEFAULT,
     delta_threshold: float,
     exit_at_max_days: int | None = None,
+    option_spread_fraction: float = 1.0,
 ) -> pl.DataFrame:
-    """Per (cohort, contract, day) premium P&L + hedge P&L (with costs).
-
-    When ``exit_at_max_days`` is None (default), each cohort is held to expiry
-    and settles at intrinsic — no exit bid-ask. When set (e.g. 10), cohorts are
-    closed at t + ``exit_at_max_days`` trading days and the full round-trip is
-    charged: entry half-spread on both legs on day 1 PLUS exit half-spread on
-    both legs on the final holding day. This is the "naive" rung of the cost-
-    mitigation cascade — same strategy, same delta hedge, but no expiry
-    settlement benefit.
-
-    Returns [cohort_feature_date, symbol, strike, expiration, date,
-             premium_pnl_norm, hedge_pnl_norm, hedge_cost_norm,
-             entry_cost_norm, exit_cost_norm].
-    """
+    """Compute daily option and retained-hedge P&L for every selected contract."""
+    if not 0 <= option_spread_fraction <= 1:
+        raise ValueError("option_spread_fraction must be between zero and one")
+    if delta_threshold < 0:
+        raise ValueError("delta_threshold cannot be negative")
+    if option_contract_multiplier < 1:
+        raise ValueError("option_contract_multiplier must be positive")
     cohort_keys = cohorts.select(
         [
             pl.col("timestamp").alias("cohort_feature_date"),
@@ -304,6 +527,26 @@ def _compute_cohort_daily_pnl(
         .filter(pl.col("date") <= pl.col("expiration"))
         .sort(["cohort_feature_date", "symbol", "strike", "expiration", "date"])
     )
+    partition = ["cohort_feature_date", "symbol", "strike", "expiration"]
+    expected_cohorts = cohort_keys.n_unique(partition)
+    if daily.n_unique(partition) != expected_cohorts:
+        raise ValueError("option lifecycle silently dropped one or more selected cohorts")
+    entry_coverage = daily.group_by(partition).agg(pl.col("date").min().alias("first_date"))
+    if (
+        entry_coverage.join(cohort_keys.select(*partition, "entry_date"), on=partition, how="left")
+        .filter(pl.col("first_date") != pl.col("entry_date"))
+        .height
+    ):
+        raise ValueError("option lifecycle does not begin on every selected entry date")
+    if exit_at_max_days is None:
+        settlement_coverage = daily.group_by(partition).agg(
+            pl.col("date").max().alias("last_date"),
+            pl.col("cash_settled").last().alias("cash_settled"),
+        )
+        if settlement_coverage.filter(
+            (pl.col("last_date") != pl.col("expiration")) | ~pl.col("cash_settled")
+        ).height:
+            raise ValueError("option lifecycle does not cash-settle every selected contract")
 
     # Round-trip mode: cap the holding window at entry + exit_at_max_days
     # trading days (day 1 = entry, so we keep ranks 1 .. exit_at_max_days+1).
@@ -314,92 +557,66 @@ def _compute_cohort_daily_pnl(
         )
         daily = daily.filter(pl.col("_pre_rank") <= int(exit_at_max_days) + 1).drop("_pre_rank")
 
-    partition = ["cohort_feature_date", "symbol", "strike", "expiration"]
-
-    # Premium leg: −(mid_d − mid_{d−1}) / entry_mid (short straddle P&L)
     daily = daily.with_columns(
         dmid=pl.col("instr_mid") - pl.col("instr_mid").shift(1).over(partition),
         dS=pl.col("underlying_price") - pl.col("underlying_price").shift(1).over(partition),
         _day_rank=pl.col("date").rank("ordinal").over(partition),
+        _last_rank=pl.len().over(partition),
     )
     daily = daily.with_columns(
         premium_pnl_norm=(-pl.col("dmid") / pl.col("entry_straddle_mid")).fill_null(0.0),
     )
-
-    # Hedge leg from hedge_path.instr_delta (pre-computed call_delta + put_delta)
-    if delta_hedge:
-        hedge = (
-            hedge_path.select(
-                pl.col("feature_date").alias("cohort_feature_date"),
-                "symbol",
-                "strike",
-                "expiration",
-                pl.col("holding_date").alias("date"),
-                "instr_delta",
+    day_rank = daily.get_column("_day_rank").to_numpy()
+    last_rank = daily.get_column("_last_rank").to_numpy()
+    deltas = daily.get_column("instr_delta").cast(pl.Float64).to_numpy()
+    underlying_moves = daily.get_column("dS").fill_null(0.0).cast(pl.Float64).to_numpy()
+    entry_mids = daily.get_column("entry_straddle_mid").cast(pl.Float64).to_numpy()
+    underlying_prices = daily.get_column("underlying_price").cast(pl.Float64).to_numpy()
+    hedge_positions = np.zeros(daily.height, dtype=np.float64)
+    hedge_trades = np.zeros(daily.height, dtype=np.float64)
+    hedge_pnl = np.zeros(daily.height, dtype=np.float64)
+    hedge_cost = np.zeros(daily.height, dtype=np.float64)
+    retained_position = 0.0
+    hedge_spread_rate = hedge_spread_bps / 10_000.0
+    for index in range(daily.height):
+        if day_rank[index] == 1:
+            retained_position = 0.0
+        hedge_pnl[index] = retained_position * underlying_moves[index] / entry_mids[index]
+        if delta_hedge:
+            final_observation = day_rank[index] == last_rank[index]
+            if final_observation:
+                next_position = 0.0
+            elif abs(deltas[index] - retained_position) > delta_threshold:
+                next_position = deltas[index]
+            else:
+                next_position = retained_position
+            trade = next_position - retained_position
+            hedge_trades[index] = trade
+            retained_position = next_position
+            hedge_cost[index] = (
+                abs(trade)
+                * (underlying_prices[index] * hedge_spread_rate + equity_commission_per_share)
+                / entry_mids[index]
             )
-            .sort(["cohort_feature_date", "symbol", "strike", "expiration", "date"])
-            .with_columns(delta_lag=pl.col("instr_delta").shift(1).over(partition))
-        )
-        daily = daily.join(
-            hedge.select(
-                [
-                    "cohort_feature_date",
-                    "symbol",
-                    "strike",
-                    "expiration",
-                    "date",
-                    "instr_delta",
-                    "delta_lag",
-                ]
-            ),
-            on=["cohort_feature_date", "symbol", "strike", "expiration", "date"],
-            how="left",
-        )
-        # Hedge P&L from carry: held delta_lag shares into today's dS
-        daily = daily.with_columns(
-            hedge_pnl_norm=(
-                pl.col("delta_lag").fill_null(0.0) * pl.col("dS") / pl.col("entry_straddle_mid")
-            ).fill_null(0.0),
-        )
-        # Hedge transaction cost: applied on days where |delta_change| > threshold.
-        # Trade size (shares) = |dδ| × 100. Per-trade cost per straddle =
-        # trade_shares × (S × spread_rate + commission_per_share). Normalized by
-        # entry straddle $ notional (entry_mid × 100), the 100 factor cancels.
-        hedge_spread_rate = hedge_spread_bps / 10_000.0
-        daily = daily.with_columns(
-            _delta_change=(pl.col("instr_delta") - pl.col("delta_lag")).abs().fill_null(0.0),
-        ).with_columns(
-            _hedge_triggered=pl.col("_delta_change") > delta_threshold,
-        )
-        daily = daily.with_columns(
-            hedge_cost_norm=(
-                pl.when(pl.col("_hedge_triggered"))
-                .then(
-                    pl.col("_delta_change")
-                    * (pl.col("underlying_price") * hedge_spread_rate + equity_commission_per_share)
-                    / pl.col("entry_straddle_mid")
-                )
-                .otherwise(0.0)
-            ).fill_null(0.0),
-        )
-    else:
-        daily = daily.with_columns(
-            hedge_pnl_norm=pl.lit(0.0),
-            hedge_cost_norm=pl.lit(0.0),
-        )
+        hedge_positions[index] = retained_position
+    daily = daily.with_columns(
+        pl.Series("hedge_position", hedge_positions),
+        pl.Series("hedge_trade", hedge_trades),
+        pl.Series("hedge_pnl_norm", hedge_pnl),
+        pl.Series("hedge_cost_norm", hedge_cost),
+    )
 
-    # Entry option cost (day_rank == 1 only): bid-ask half-spread on both legs
-    # plus per-contract commission on both legs. A straddle = 1 call contract +
-    # 1 put contract, each covering 100 shares (multiplier cancels with the
-    # *100 in the dollar-to-norm scaling of the commission term).
     daily = daily.with_columns(
         entry_cost_norm=(
             pl.when(pl.col("_day_rank") == 1)
             .then(
                 (
-                    (pl.col("entry_call_mid") - pl.col("entry_call_bid"))
-                    + (pl.col("entry_put_mid") - pl.col("entry_put_bid"))
-                    + (2.0 * option_commission_per_contract / 100.0)
+                    option_spread_fraction
+                    * (
+                        (pl.col("entry_call_mid") - pl.col("entry_call_bid"))
+                        + (pl.col("entry_put_mid") - pl.col("entry_put_bid"))
+                    )
+                    + (2.0 * option_commission_per_contract / option_contract_multiplier)
                 )
                 / pl.col("entry_straddle_mid")
             )
@@ -407,24 +624,18 @@ def _compute_cohort_daily_pnl(
         ).fill_null(0.0),
     )
 
-    # Exit option cost (round-trip mode only, charged on the last held day):
-    # we buy back the short straddle by crossing to the ask on both legs.
-    # Half-spread on ask side = (ask - mid); plus per-contract commission on
-    # both legs (entry commission already covers the entry leg, this is the
-    # second leg of the round trip).
     if exit_at_max_days is not None:
-        partition = ["cohort_feature_date", "symbol", "strike", "expiration"]
-        daily = daily.with_columns(
-            _last_rank=pl.col("_day_rank").max().over(partition),
-        )
         daily = daily.with_columns(
             exit_cost_norm=(
                 pl.when(pl.col("_day_rank") == pl.col("_last_rank"))
                 .then(
                     (
-                        (pl.col("call_ask") - pl.col("call_mid"))
-                        + (pl.col("put_ask") - pl.col("put_mid"))
-                        + (2.0 * option_commission_per_contract / 100.0)
+                        option_spread_fraction
+                        * (
+                            (pl.col("call_ask") - pl.col("call_mid"))
+                            + (pl.col("put_ask") - pl.col("put_mid"))
+                        )
+                        + (2.0 * option_commission_per_contract / option_contract_multiplier)
                     )
                     / pl.col("entry_straddle_mid")
                 )
@@ -443,6 +654,9 @@ def _compute_cohort_daily_pnl(
             "entry_date",
             "date",
             "weight",
+            "cash_settled",
+            "hedge_position",
+            "hedge_trade",
             "premium_pnl_norm",
             "hedge_pnl_norm",
             "hedge_cost_norm",
@@ -622,14 +836,11 @@ def _apply_cohort_allocator(
     date_min = preds["timestamp"].min()
     date_max = preds["timestamp"].max()
     # Backfill window for covariance estimation: 2× the longest lookback used.
-    if hasattr(date_min, "replace"):
-        # Pull ~1 year prior to earliest cohort to ensure rolling-window coverage.
-        backfill_days = max(vol_window, lookback) * 2
-        from datetime import timedelta
-
-        panel_start = date_min - timedelta(days=backfill_days + 30)
-    else:
-        panel_start = date_min
+    if not isinstance(date_min, (date, datetime)) or not isinstance(date_max, (date, datetime)):
+        raise TypeError("option allocation timestamps must contain dates")
+    # Pull ~1 year prior to earliest cohort to ensure rolling-window coverage.
+    backfill_days = max(vol_window, lookback) * 2
+    panel_start = date_min - timedelta(days=backfill_days + 30)
 
     prices = _load_underlying_price_panel(raw_options_dir, symbols, panel_start, date_max)
     if prices.is_empty():
@@ -648,9 +859,8 @@ def _apply_cohort_allocator(
     if prices["timestamp"].dtype != preds["timestamp"].dtype:
         prices = prices.cast({"timestamp": preds["timestamp"].dtype})
 
-    top_k_for_alloc = max(
-        int(allocation_spec.get("top_k", 0)), preds.group_by("timestamp").len()["len"].max() or 0
-    )
+    max_cohort_size = cast(int, preds.group_by("timestamp").len()["len"].max())
+    top_k_for_alloc = max(int(allocation_spec.get("top_k", 0)), max_cohort_size)
 
     if method == "inverse_vol":
         weights = compute_inverse_vol_weights(
@@ -738,8 +948,12 @@ def run_htm_daily_mtm(
     hedge_spread_bps: float = HEDGE_SPREAD_BPS_DEFAULT,
     equity_commission_per_share: float = EQUITY_COMMISSION_PER_SHARE_DEFAULT,
     option_commission_per_contract: float = OPTION_COMMISSION_PER_CONTRACT_DEFAULT,
+    option_contract_multiplier: int = OPTION_CONTRACT_MULTIPLIER_DEFAULT,
     exit_at_max_days: int | None = None,
     allocation_spec: dict | None = None,
+    decisions: pl.DataFrame | None = None,
+    option_lifecycle: pl.DataFrame | None = None,
+    option_spread_fraction: float = 1.0,
 ) -> dict:
     """Run the HTM daily-MTM short-straddle backtest and return a result dict.
 
@@ -756,17 +970,38 @@ def run_htm_daily_mtm(
         n_periods, win_rate, mean_daily_return
     """
     assert case_study == CASE_STUDY_ID, f"htm_daily_mtm is sp500_options only, got {case_study!r}"
+    if n_roll < 1:
+        raise ValueError("n_roll must be positive")
 
-    contract_returns = pl.read_parquet(labels_dir / "contract_returns.parquet")
-    hedge_path = pl.read_parquet(labels_dir / "hedge_path.parquet")
-
-    cohorts = _select_cohorts(
-        predictions,
-        contract_returns,
-        method=method,
-        top_k=top_k,
-        percentile=percentile,
-    )
+    if decisions is None:
+        contract_returns = pl.read_parquet(labels_dir / "contract_returns.parquet")
+        cohorts = _select_cohorts(
+            predictions,
+            contract_returns,
+            method=method,
+            top_k=top_k,
+            percentile=percentile,
+        )
+    else:
+        required = {
+            "timestamp",
+            "symbol",
+            "strike",
+            "expiration",
+            "entry_date",
+            "entry_straddle_mid",
+            "entry_call_mid",
+            "entry_call_bid",
+            "entry_call_ask",
+            "entry_put_mid",
+            "entry_put_bid",
+            "entry_put_ask",
+            "weight",
+        }
+        missing = required - set(decisions.columns)
+        if missing:
+            raise ValueError(f"typed option decisions are missing columns: {sorted(missing)}")
+        cohorts = decisions
     if cohorts.is_empty():
         raise ValueError("No cohorts selected from predictions")
 
@@ -777,21 +1012,26 @@ def run_htm_daily_mtm(
     # entry date is a separate allocation problem — we delegate to the
     # standard `case_studies.utils.allocation` helpers, which already
     # implement covariance-shrinkage MVO, hierarchical risk parity, etc.
-    if allocation_spec:
+    if allocation_spec and decisions is None:
         cohorts = _apply_cohort_allocator(cohorts, raw_options_dir, allocation_spec)
 
-    contract_mids = _load_daily_contract_mids(cohorts, raw_options_dir)
+    contract_mids = (
+        option_lifecycle
+        if option_lifecycle is not None
+        else _load_option_lifecycle(cohorts, raw_options_dir)
+    )
 
     daily_cohort = _compute_cohort_daily_pnl(
         cohorts,
         contract_mids,
-        hedge_path,
         delta_hedge=delta_hedge,
         hedge_spread_bps=hedge_spread_bps,
         equity_commission_per_share=equity_commission_per_share,
         option_commission_per_contract=option_commission_per_contract,
+        option_contract_multiplier=option_contract_multiplier,
         delta_threshold=delta_threshold,
         exit_at_max_days=exit_at_max_days,
+        option_spread_fraction=option_spread_fraction,
     )
 
     port = _aggregate_portfolio(daily_cohort, n_roll=n_roll)

--- a/case_studies/sp500_options/_htm_backtest.py
+++ b/case_studies/sp500_options/_htm_backtest.py
@@ -146,14 +146,21 @@ def _digest_file(path: Path) -> str:
     return _file_sha256(str(path.resolve()), stat.st_size, stat.st_mtime_ns)
 
 
+def option_contract_source_identity(labels_dir: Path) -> str:
+    """Return the exact contract-selection artifact identity."""
+    contract_returns = labels_dir / "contract_returns.parquet"
+    if not contract_returns.is_file():
+        raise FileNotFoundError(f"option contract artifact is missing: {contract_returns}")
+    return _digest_file(contract_returns)
+
+
 def option_source_identity(labels_dir: Path, raw_options_dir: Path) -> dict[str, Any]:
     """Bind the specialized engine to exact contract and lifecycle files."""
-    contract_returns = labels_dir / "contract_returns.parquet"
     raw_files = sorted(raw_options_dir.glob("year=*.parquet"))
     if not raw_files:
         raise FileNotFoundError(f"raw option lifecycle directory is empty: {raw_options_dir}")
     return {
-        "contract_returns": _digest_file(contract_returns),
+        "contract_returns": option_contract_source_identity(labels_dir),
         "raw_lifecycle": {path.name: _digest_file(path) for path in raw_files},
     }
 

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -61,7 +61,9 @@ mapping:
   class: systematic_straddle_sell
   position_state_space: short_straddle_hedged
   entry_logic: sell_atm_straddle_weekly
-  sizing: fixed_vega_notional
+  # Equal premium capital within each cohort, then 1/n_roll of portfolio capital
+  # per concurrent cohort. The specialized path does not target a fixed vega.
+  sizing: equal_premium_capital_with_fixed_cohort_fraction
 
 costs:
   class: dominant

--- a/case_studies/sp500_options/research_workflow.py
+++ b/case_studies/sp500_options/research_workflow.py
@@ -28,8 +28,8 @@ from case_studies.sp500_options._htm_backtest import (
     _apply_cohort_allocator,
     _load_option_lifecycle,
     _select_cohorts,
+    option_contract_source_identity,
     option_data_paths,
-    option_source_identity,
 )
 from case_studies.utils.artifact_digest import value_digest
 from case_studies.utils.backtest_loaders import load_backtest_prices_for
@@ -193,8 +193,8 @@ def _publish_resolved_short_straddle_decisions(
 ) -> DecisionArtifact:
     if canonical and clean_replay_digest is None:
         raise ValueError("canonical option decisions require a clean-process replay digest")
-    labels_dir, raw_options_dir = option_data_paths()
-    inputs = option_source_identity(labels_dir, raw_options_dir)
+    labels_dir, _ = option_data_paths()
+    contract_identity = option_contract_source_identity(labels_dir)
     source_identity: dict[str, Any] | None = None
     if canonical:
         source_identity = {
@@ -205,7 +205,7 @@ def _publish_resolved_short_straddle_decisions(
             "declared_inputs": {
                 "prediction_hashes": [prediction.hash],
                 "prices": value_digest(prices),
-                "option_sources": inputs,
+                "option_contract_returns": contract_identity,
                 "signal": signal,
                 "allocation": allocation,
             },

--- a/case_studies/sp500_options/research_workflow.py
+++ b/case_studies/sp500_options/research_workflow.py
@@ -59,15 +59,10 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
     if workspace is None:
         raise ValueError("preview execution requires an explicit workspace")
     workspace = Path(workspace).expanduser().resolve()
-    try:
-        return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
-    except ValueError as error:
-        generated = tuple(
-            REPO_ROOT / "case_studies" / CASE_STUDY / name
-            for name in ("features", "labels", "run_log")
-        )
-        if "artifact bundle" not in str(error) or not all(path.is_symlink() for path in generated):
-            raise
+    generated = tuple(
+        REPO_ROOT / "case_studies" / CASE_STUDY / name for name in ("features", "labels", "run_log")
+    )
+    if all(path.is_symlink() for path in generated):
         workspace.mkdir(parents=True, exist_ok=True)
         shared_config = workspace / "config"
         if not shared_config.exists():
@@ -89,6 +84,7 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
                 "preview_only": True,
             },
         )
+    return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
 
 
 def selected_prediction(study: Study, catalog_row: dict[str, Any]) -> PredictionResult:
@@ -236,6 +232,9 @@ def _clean_replay_digests(
     requests: list[dict[str, Any]],
 ) -> dict[str, str]:
     """Replay a complete decision request set in a fresh interpreter."""
+    tiers = {str(request["execution_tier"]) for request in requests}
+    if len(tiers) != 1:
+        raise ValueError("clean option decision replay cannot mix execution tiers")
     payload = {
         "study": {
             "case_study": study.case_study,
@@ -244,6 +243,7 @@ def _clean_replay_digests(
             "output_root": str(study.output_root) if study.output_root is not None else None,
             "manifest": study.manifest,
         },
+        "execution_tier": tiers.pop(),
         "requests": requests,
     }
     completed = subprocess.run(
@@ -346,6 +346,7 @@ def run_official_backtest_requests(
                 "label": row["label"],
                 "signal": row["signal"],
                 "allocation": allocation,
+                "execution_tier": prediction.execution_tier,
             }
         )
     replay_digests = _clean_replay_digests(study, replay_requests)
@@ -444,7 +445,7 @@ def _replay_from_stdin() -> None:
         read_only=False,
         manifest=descriptor["manifest"],
     )
-    study.activate()
+    study.activate(payload["execution_tier"])
     catalog = study.predictions.table(include_preview=True)
     price_cache: dict[tuple[str, int], pl.DataFrame] = {}
     replayed = []

--- a/case_studies/sp500_options/research_workflow.py
+++ b/case_studies/sp500_options/research_workflow.py
@@ -1,0 +1,484 @@
+"""Reader-facing S&P 500 option decision and backtest workflow."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import inspect
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from case_studies.research import (
+    BacktestResult,
+    DecisionArtifact,
+    OfficialPopulation,
+    PredictionResult,
+    Result,
+    Study,
+    plan_backtests,
+)
+from case_studies.research.strategy import strategy_warmup_periods
+from case_studies.sp500_options._htm_backtest import (
+    _apply_cohort_allocator,
+    _load_option_lifecycle,
+    _select_cohorts,
+    option_data_paths,
+    option_source_identity,
+)
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import load_backtest_prices_for
+from case_studies.utils.backtest_runner import (
+    apply_universe_filter,
+    normalize_prediction_columns,
+)
+from utils.paths import REPO_ROOT
+
+CASE_STUDY = "sp500_options"
+PRIMARY_LABEL = "ret_to_expiry"
+
+
+@dataclass(frozen=True)
+class OptionBacktestExecution:
+    results: tuple[BacktestResult, ...]
+    catalog_rows: pl.DataFrame
+    population: OfficialPopulation
+
+
+def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> Study:
+    """Open canonical regeneration or an isolated reader preview."""
+    if execution_tier == "canonical":
+        return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+    if execution_tier != "preview":
+        raise ValueError("execution_tier must be canonical or preview")
+    if workspace is None:
+        raise ValueError("preview execution requires an explicit workspace")
+    workspace = Path(workspace).expanduser().resolve()
+    try:
+        return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
+    except ValueError as error:
+        generated = tuple(
+            REPO_ROOT / "case_studies" / CASE_STUDY / name
+            for name in ("features", "labels", "run_log")
+        )
+        if "artifact bundle" not in str(error) or not all(path.is_symlink() for path in generated):
+            raise
+        workspace.mkdir(parents=True, exist_ok=True)
+        shared_config = workspace / "config"
+        if not shared_config.exists():
+            shared_config.symlink_to(
+                REPO_ROOT / "case_studies" / "config", target_is_directory=True
+            )
+        return Study(
+            case_study=CASE_STUDY,
+            root=REPO_ROOT / "case_studies" / CASE_STUDY,
+            release_root=REPO_ROOT,
+            output_root=workspace,
+            read_only=False,
+            manifest={
+                "schema_version": 1,
+                "case_study": CASE_STUDY,
+                "baseline_source_commit": subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True
+                ).strip(),
+                "preview_only": True,
+            },
+        )
+
+
+def selected_prediction(study: Study, catalog_row: dict[str, Any]) -> PredictionResult:
+    """Resolve one complete selected prediction row."""
+    result = Result.open(
+        study,
+        str(catalog_row["prediction_hash"]),
+        include_preview=catalog_row.get("execution_tier") == "preview",
+    )
+    if not isinstance(result, PredictionResult) or not result.complete:
+        raise ValueError("selected catalog row does not identify a complete prediction")
+    return result
+
+
+def resolve_short_straddle_decisions(
+    prediction: PredictionResult,
+    *,
+    prices: pl.DataFrame,
+    signal: dict[str, Any],
+    allocation: dict[str, Any] | None = None,
+) -> pl.DataFrame:
+    """Resolve ranked predictions to exact option contracts and cohort weights."""
+    if prediction.lineage()["training_spec"]["label"] != PRIMARY_LABEL:
+        raise ValueError("short-straddle decisions require ret_to_expiry predictions")
+    predictions = normalize_prediction_columns(prediction.load())
+    predictions = apply_universe_filter(
+        predictions,
+        prices,
+        CASE_STUDY,
+        signal,
+        prediction_hash=prediction.hash,
+    )
+    labels_dir, raw_options_dir = option_data_paths()
+    contract_returns = pl.read_parquet(labels_dir / "contract_returns.parquet")
+    decisions = _select_cohorts(
+        predictions,
+        contract_returns,
+        method=str(signal.get("method", "equal_weight_top_k")),
+        top_k=int(signal.get("top_k", 20)),
+        percentile=float(signal.get("percentile", 90.0)),
+    )
+    if allocation:
+        decisions = _apply_cohort_allocator(decisions, raw_options_dir, allocation)
+    fold_columns = [column for column in ("fold", "fold_id") if column in predictions.columns]
+    if len(fold_columns) != 1:
+        raise ValueError("option predictions require exactly one fold column")
+    fold = fold_columns[0]
+    fold_by_time = (
+        predictions.select("timestamp", fold)
+        .unique()
+        .group_by("timestamp")
+        .agg(pl.col(fold).n_unique().alias("n_folds"), pl.col(fold).first().alias("fold"))
+    )
+    if fold_by_time.filter(pl.col("n_folds") != 1).height:
+        raise ValueError("each option decision timestamp must belong to exactly one fold")
+    decisions = decisions.with_columns(
+        pl.col("timestamp").cast(fold_by_time.schema["timestamp"])
+    ).join(fold_by_time.select("timestamp", "fold"), on="timestamp", how="left")
+    if decisions.get_column("fold").null_count():
+        raise ValueError("option decisions contain timestamps outside prediction eligibility")
+    return decisions.drop("y_score").sort("timestamp", "symbol")
+
+
+def publish_short_straddle_decisions(
+    prediction: PredictionResult,
+    *,
+    prices: pl.DataFrame,
+    signal: dict[str, Any],
+    allocation: dict[str, Any] | None = None,
+    canonical: bool = False,
+    clean_replay_digest: str | None = None,
+) -> DecisionArtifact:
+    """Publish exact short-straddle contracts with settlement and hedge policy."""
+    if signal.get("exit_at_max_days") is not None:
+        raise ValueError("short-straddle decisions are hold-to-expiry and cannot declare an exit")
+    decisions = resolve_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+        allocation=allocation,
+    )
+    return _publish_resolved_short_straddle_decisions(
+        prediction,
+        decisions=decisions,
+        prices=prices,
+        signal=signal,
+        allocation=allocation,
+        canonical=canonical,
+        clean_replay_digest=clean_replay_digest,
+    )
+
+
+def _publish_resolved_short_straddle_decisions(
+    prediction: PredictionResult,
+    *,
+    decisions: pl.DataFrame,
+    prices: pl.DataFrame,
+    signal: dict[str, Any],
+    allocation: dict[str, Any] | None,
+    canonical: bool,
+    clean_replay_digest: str | None,
+) -> DecisionArtifact:
+    if canonical and clean_replay_digest is None:
+        raise ValueError("canonical option decisions require a clean-process replay digest")
+    labels_dir, raw_options_dir = option_data_paths()
+    inputs = option_source_identity(labels_dir, raw_options_dir)
+    source_identity: dict[str, Any] | None = None
+    if canonical:
+        source_identity = {
+            "module": "case_studies.sp500_options.research_workflow",
+            "source_digest": hashlib.sha256(
+                inspect.getsource(resolve_short_straddle_decisions).encode()
+            ).hexdigest(),
+            "declared_inputs": {
+                "prediction_hashes": [prediction.hash],
+                "prices": value_digest(prices),
+                "option_sources": inputs,
+                "signal": signal,
+                "allocation": allocation,
+            },
+            "determinism": {"deterministic": True},
+            "clean_replay_digest": clean_replay_digest,
+        }
+    return DecisionArtifact.publish(
+        prediction.study,
+        kind="short_straddles",
+        decisions=decisions,
+        prediction_hashes=[prediction.hash],
+        parameters={
+            "decision_cadence": "weekly_friday",
+            "entry_policy": "next_session_close",
+            "exit_policy": "hold_to_expiry",
+            "settlement_policy": "cash_intrinsic_at_expiration",
+            "hedge_policy": "retained_underlying_delta_with_threshold",
+            "signal": signal,
+            "allocation": allocation,
+        },
+        source_identity=source_identity,
+        canonical=canonical,
+    )
+
+
+def _clean_replay_digests(
+    study: Study,
+    requests: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Replay a complete decision request set in a fresh interpreter."""
+    payload = {
+        "study": {
+            "case_study": study.case_study,
+            "root": str(study.root),
+            "release_root": str(study.release_root),
+            "output_root": str(study.output_root) if study.output_root is not None else None,
+            "manifest": study.manifest,
+        },
+        "requests": requests,
+    }
+    completed = subprocess.run(
+        [sys.executable, "-m", "case_studies.sp500_options.research_workflow", "--replay"],
+        cwd=REPO_ROOT,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            "clean option decision replay failed: "
+            + (completed.stderr.strip() or completed.stdout.strip())
+        )
+    marker = "OPTION_DECISION_REPLAY="
+    lines = [line for line in completed.stdout.splitlines() if line.startswith(marker)]
+    if len(lines) != 1:
+        raise RuntimeError("clean option decision replay did not return one digest set")
+    replayed = json.loads(lines[0].removeprefix(marker))
+    return {str(row["request_name"]): str(row["decision_digest"]) for row in replayed}
+
+
+def strategy_request_frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
+    """Build visible option strategy rows while retaining nested request fields."""
+    if not rows:
+        raise ValueError("strategy request rows cannot be empty")
+    nested = ("signal", "allocation", "risk", "costs")
+    scalar_rows = [{key: value for key, value in row.items() if key not in nested} for row in rows]
+    frame = pl.DataFrame(scalar_rows)
+    return frame.with_columns(
+        *(pl.Series(name, [row.get(name) for row in rows], dtype=pl.Object) for name in nested)
+    )
+
+
+def run_official_backtest_requests(
+    study: Study,
+    requests: pl.DataFrame,
+    *,
+    population_name: str,
+    supersedes: str | None = None,
+) -> OptionBacktestExecution:
+    """Resolve, snapshot, and execute a complete typed option request population."""
+    required = {"request_name", "prediction_hash", "label", "signal"}
+    missing = required - set(requests.columns)
+    if missing:
+        raise ValueError(f"strategy requests are missing columns: {sorted(missing)}")
+    if (
+        requests.is_empty()
+        or requests.get_column("request_name").null_count()
+        or requests.get_column("request_name").n_unique() != requests.height
+        or any(not str(value).strip() for value in requests.get_column("request_name"))
+    ):
+        raise ValueError("strategy request names must be non-empty and unique")
+    request_rows = list(requests.iter_rows(named=True))
+    for row in request_rows:
+        if row.get("risk") is not None:
+            raise ValueError("the specialized option path does not support risk overlays")
+        if row.get("costs") is not None:
+            raise ValueError(
+                "option cost variants use signal.option_spread_fraction; generic costs are unsupported"
+            )
+        if row["signal"].get("exit_at_max_days") is not None:
+            raise ValueError("official short-straddle requests must hold to expiration")
+    catalog = study.predictions.table()
+    price_cache: dict[tuple[str, int], pl.DataFrame] = {}
+    resolved = []
+    replay_requests = []
+    for row in request_rows:
+        selected = catalog.filter(pl.col("prediction_hash") == row["prediction_hash"])
+        if selected.height != 1 or not selected.item(0, "complete"):
+            raise ValueError(
+                f"prediction {row['prediction_hash']!r} is absent, ambiguous, or incomplete"
+            )
+        if selected.item(0, "label") != row["label"] or row["label"] != PRIMARY_LABEL:
+            raise ValueError("option request label does not match its prediction catalog row")
+        prediction = selected_prediction(study, selected.row(0, named=True))
+        allocation = row.get("allocation")
+        warmup = strategy_warmup_periods({"strategy": {"allocation": allocation}})
+        cache_key = (str(row["label"]), warmup)
+        if cache_key not in price_cache:
+            price_cache[cache_key] = load_backtest_prices_for(
+                CASE_STUDY,
+                str(row["label"]),
+                split="validation",
+                warmup_periods=warmup,
+            )
+        prices = price_cache[cache_key]
+        decisions = resolve_short_straddle_decisions(
+            prediction,
+            prices=prices,
+            signal=row["signal"],
+            allocation=allocation,
+        )
+        resolved.append((row, prediction, prices, decisions))
+        replay_requests.append(
+            {
+                "request_name": row["request_name"],
+                "prediction_hash": prediction.hash,
+                "label": row["label"],
+                "signal": row["signal"],
+                "allocation": allocation,
+            }
+        )
+    replay_digests = _clean_replay_digests(study, replay_requests)
+    local_digests = {
+        row["request_name"]: value_digest(decisions)
+        for row, _prediction, _prices, decisions in resolved
+    }
+    if replay_digests != local_digests:
+        raise RuntimeError("clean option decision replay differs from the prepared request set")
+
+    prepared = []
+    expected = []
+    all_decisions = []
+    for row, prediction, prices, decisions in resolved:
+        allocation = row.get("allocation")
+        decision = _publish_resolved_short_straddle_decisions(
+            prediction,
+            decisions=decisions,
+            prices=prices,
+            signal=row["signal"],
+            allocation=allocation,
+            canonical=True,
+            clean_replay_digest=replay_digests[row["request_name"]],
+        )
+        plan = plan_backtests(
+            study,
+            predictions=selected,
+            signal=row["signal"],
+            prices=prices,
+            allocation=allocation,
+            risk=row.get("risk"),
+            costs=row.get("costs"),
+            chapter=row.get("chapter"),
+            decision=decision,
+        )
+        if len(plan.members) != 1:
+            raise RuntimeError("one option strategy request must resolve to one backtest")
+        expected_hash = plan.expected_hashes[0]
+        expected.append(expected_hash)
+        all_decisions.append(decision.load())
+        prepared.append((row, prediction, prices, decision, expected_hash))
+    if len(expected) != len(set(expected)):
+        raise ValueError("strategy requests resolve to duplicate backtest identities")
+    population = OfficialPopulation.create(
+        study,
+        name=population_name,
+        member_kind="backtest",
+        members=expected,
+        supersedes=supersedes,
+    )
+    labels_dir, raw_options_dir = option_data_paths()
+    del labels_dir
+    lifecycle = _load_option_lifecycle(pl.concat(all_decisions), raw_options_dir)
+    results = []
+    rows = []
+    for row, prediction, prices, decision, expected_hash in prepared:
+        strategy = study.strategy(
+            prediction=prediction,
+            signal=row["signal"],
+            allocation=row.get("allocation"),
+            risk=row.get("risk"),
+            costs=row.get("costs"),
+            chapter=row.get("chapter"),
+            decision=decision,
+        )
+        result = strategy.run(prices=prices, option_lifecycle=lifecycle)
+        if result.hash != expected_hash:
+            raise RuntimeError(f"backtest identity changed: {expected_hash} -> {result.hash}")
+        results.append(result)
+        rows.append(
+            {
+                "request_name": row["request_name"],
+                "label": row["label"],
+                "prediction_hash": prediction.hash,
+                "decision_hash": decision.hash,
+                "backtest_hash": result.hash,
+                "complete": result.complete,
+            }
+        )
+    if tuple(result.hash for result in results) != tuple(expected):
+        raise RuntimeError("backtest execution did not preserve declared request order")
+    population.require_complete()
+    return OptionBacktestExecution(tuple(results), pl.DataFrame(rows), population)
+
+
+def _replay_from_stdin() -> None:
+    payload = json.load(sys.stdin)
+    descriptor = payload["study"]
+    study = Study(
+        case_study=str(descriptor["case_study"]),
+        root=Path(descriptor["root"]),
+        release_root=Path(descriptor["release_root"]),
+        output_root=(
+            Path(descriptor["output_root"]) if descriptor["output_root"] is not None else None
+        ),
+        read_only=False,
+        manifest=descriptor["manifest"],
+    )
+    study.activate()
+    catalog = study.predictions.table(include_preview=True)
+    price_cache: dict[tuple[str, int], pl.DataFrame] = {}
+    replayed = []
+    for row in payload["requests"]:
+        selected = catalog.filter(pl.col("prediction_hash") == row["prediction_hash"])
+        if selected.height != 1 or not selected.item(0, "complete"):
+            raise ValueError("clean replay prediction is absent, ambiguous, or incomplete")
+        prediction = selected_prediction(study, selected.row(0, named=True))
+        allocation = row.get("allocation")
+        warmup = strategy_warmup_periods({"strategy": {"allocation": allocation}})
+        cache_key = (str(row["label"]), warmup)
+        if cache_key not in price_cache:
+            price_cache[cache_key] = load_backtest_prices_for(
+                CASE_STUDY,
+                str(row["label"]),
+                split="validation",
+                warmup_periods=warmup,
+            )
+        decisions = resolve_short_straddle_decisions(
+            prediction,
+            prices=price_cache[cache_key],
+            signal=row["signal"],
+            allocation=allocation,
+        )
+        replayed.append(
+            {"request_name": row["request_name"], "decision_digest": value_digest(decisions)}
+        )
+    print("OPTION_DECISION_REPLAY=" + json.dumps(replayed, sort_keys=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--replay", action="store_true")
+    arguments = parser.parse_args()
+    if not arguments.replay:
+        parser.error("--replay is required")
+    _replay_from_stdin()

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -898,6 +898,7 @@ def run_backtest(
     funding_rates: pl.DataFrame | None = None,
     force_rebacktest: bool = False,
     contract_specs: dict | None = None,
+    option_lifecycle: pl.DataFrame | None = None,
 ) -> BacktestRunResult:
     """Core backtest: predictions -> weights -> engine/vectorized -> result.
 
@@ -1130,6 +1131,7 @@ def run_backtest(
         # weights × y_true vectorized path cannot express this strategy because
         # y_true is a single 30-day return, not a daily P&L series.
         if case_study == "sp500_options" and label == "ret_to_expiry":
+            decision_kind = (strategy_spec.get("decision_artifact") or {}).get("kind")
             result = _run_htm_daily_mtm(
                 case_study=case_study,
                 predictions=predictions,
@@ -1139,6 +1141,9 @@ def run_backtest(
                 allocation_spec=strategy.get("allocation", {}),
                 label=label,
                 prediction_hash=prediction_hash,
+                option_decisions=weights if decision_kind == "short_straddles" else None,
+                option_lifecycle=option_lifecycle,
+                option_accounting=strategy_spec.get("options_accounting"),
             )
         else:
             result = _run_vectorized(
@@ -1635,6 +1640,9 @@ def _run_htm_daily_mtm(
     allocation_spec: dict | None = None,
     label: str | None = None,
     prediction_hash: str | None = None,
+    option_decisions: pl.DataFrame | None = None,
+    option_lifecycle: pl.DataFrame | None = None,
+    option_accounting: dict | None = None,
 ) -> dict:
     """Dispatch wrapper for the hold-to-expiry daily-MTM short-straddle backtest.
 
@@ -1656,44 +1664,35 @@ def _run_htm_daily_mtm(
     where ``daily_returns`` has columns ``[timestamp, daily_return]`` so the
     registry write path treats it identically to any other backtest.
     """
-    from pathlib import Path
-
-    import yaml
-
     from case_studies.sp500_options._htm_backtest import run_htm_daily_mtm
-    from utils import CASE_STUDIES_DIR
-    from utils.paths import REPO_ROOT
+    from utils import CASE_STUDIES_DIR, ML4T_DATA_PATH
 
     cs_dir = CASE_STUDIES_DIR / case_study
     labels_dir = cs_dir / "labels"
-    # Anchor on REPO_ROOT — same convention as every other case-study data
-    # path. Resolving relative to cwd masked real "data missing" errors as
-    # cwd-mismatch fallbacks pointing at a different (also-missing) path.
-    raw_options_dir = REPO_ROOT / "data" / "equities" / "market" / "sp500" / "options_straddles_raw"
+    raw_options_dir = ML4T_DATA_PATH / "equities" / "market" / "sp500" / "options_straddles_raw"
 
     method = str(signal_config.get("method", "equal_weight_top_k"))
     top_k = int(signal_config.get("top_k", 20))
     percentile = float(signal_config.get("percentile", 90.0))
-    exit_at_max_days = signal_config.get("exit_at_max_days")
-    if exit_at_max_days is not None:
-        exit_at_max_days = int(exit_at_max_days)
-
-    # For round-trip mode (exit_at_max_days set), weekly entry with a 10-day
-    # hold yields ~2 concurrent cohorts, not 5. Caller can override via
-    # signal_config.n_roll; default is the HTM-expiry value (5).
-    from case_studies.sp500_options._htm_backtest import N_ROLL_DEFAULT
-
-    n_roll = int(signal_config.get("n_roll", N_ROLL_DEFAULT))
-
-    # Read cost/risk parameters from setup.yaml so the wrapper does not
-    # silently drop them. Required keys raise KeyError; missing optional keys
-    # fall through to run_htm_daily_mtm's defaults.
-    setup = yaml.safe_load((cs_dir / "config" / "setup.yaml").read_text())
-    cost_components = setup["costs"]["components"]
-    delta_threshold = float(setup["hedging_protocol"]["delta_threshold"])
-    hedge_spread_bps = float(cost_components["hedge_spread"]["estimate_bps_of_notional"])
-    equity_commission_per_share = float(cost_components["commission"]["equity_per_share"])
-    option_commission_per_contract = float(cost_components["commission"]["option_per_contract"])
+    if risk_spec:
+        raise ValueError("the specialized option path does not support risk overlays")
+    required_accounting = {
+        "n_roll",
+        "delta_hedge",
+        "delta_threshold",
+        "hedge_spread_bps",
+        "equity_commission_per_share",
+        "option_commission_per_contract",
+        "option_contract_multiplier",
+        "option_spread_fraction",
+        "exit_at_max_days",
+    }
+    missing_accounting = required_accounting - set(option_accounting or {})
+    if missing_accounting:
+        raise ValueError(
+            f"specialized option accounting is missing fields: {sorted(missing_accounting)}"
+        )
+    assert option_accounting is not None
 
     result = run_htm_daily_mtm(
         case_study=case_study,
@@ -1703,13 +1702,18 @@ def _run_htm_daily_mtm(
         method=method,
         top_k=top_k,
         percentile=percentile,
-        exit_at_max_days=exit_at_max_days,
-        n_roll=n_roll,
-        delta_threshold=delta_threshold,
-        hedge_spread_bps=hedge_spread_bps,
-        equity_commission_per_share=equity_commission_per_share,
-        option_commission_per_contract=option_commission_per_contract,
+        exit_at_max_days=option_accounting["exit_at_max_days"],
+        n_roll=int(option_accounting["n_roll"]),
+        delta_hedge=bool(option_accounting["delta_hedge"]),
+        delta_threshold=float(option_accounting["delta_threshold"]),
+        hedge_spread_bps=float(option_accounting["hedge_spread_bps"]),
+        equity_commission_per_share=float(option_accounting["equity_commission_per_share"]),
+        option_commission_per_contract=float(option_accounting["option_commission_per_contract"]),
+        option_contract_multiplier=int(option_accounting["option_contract_multiplier"]),
         allocation_spec=allocation_spec,
+        decisions=option_decisions,
+        option_lifecycle=option_lifecycle,
+        option_spread_fraction=float(option_accounting["option_spread_fraction"]),
     )
     port = result["daily_returns"]
     metrics = result["metrics"]
@@ -1759,21 +1763,6 @@ def _run_htm_daily_mtm(
         from case_studies.sp500_options._htm_backtest import _compute_metrics
 
         metrics.update(_compute_metrics(port))
-
-    # Optional portfolio-level risk overlay (Ch19). Same mechanism as vectorized
-    # path: operates on the daily return series post-hoc.
-    if risk_spec:
-        from case_studies.sp500_options._htm_backtest import _compute_metrics
-
-        port_for_risk = daily_returns.rename({"daily_return": "net_ret"})
-        port_for_risk = _apply_vectorized_risk(port_for_risk, risk_spec)
-        daily_returns = port_for_risk.select(
-            pl.col("timestamp"), pl.col("net_ret").alias("daily_return")
-        )
-        # Recompute the full metric set from the post-overlay return series so
-        # cagr/max_drawdown/volatility/etc. reflect the same series as Sharpe.
-        post = daily_returns.rename({"daily_return": "portfolio_ret"})
-        metrics.update(_compute_metrics(post))
 
     # Final unified metric pass: replace HTM-internal Sharpe/Sortino/etc. with
     # the canonical ml4t.diagnostic.PortfolioAnalysis values so HTM metrics are

--- a/scripts/prove_sp500_options_interface.py
+++ b/scripts/prove_sp500_options_interface.py
@@ -146,6 +146,7 @@ def main() -> None:
         "preview_excluded": True,
     }
     print(json.dumps(report, indent=2, sort_keys=True))
+    print("OPTION_GATE_REPORT=" + json.dumps(report, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/scripts/prove_sp500_options_interface.py
+++ b/scripts/prove_sp500_options_interface.py
@@ -182,6 +182,7 @@ def main() -> None:
                 "label": "ret_to_expiry",
                 "signal": signal,
                 "allocation": None,
+                "execution_tier": prediction.execution_tier,
             }
         ],
     )

--- a/scripts/prove_sp500_options_interface.py
+++ b/scripts/prove_sp500_options_interface.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import polars as pl
 
-from case_studies.research import OfficialPopulation
+from case_studies.research import OfficialPopulation, PredictionResult, ResolvedSpec, Study
 from case_studies.sp500_options._htm_backtest import (
     _load_option_lifecycle,
     option_data_paths,
@@ -30,22 +30,133 @@ from case_studies.utils.backtest_runner import apply_universe_filter, normalize_
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", type=Path, required=True)
-    parser.add_argument("--prediction-hash", required=True)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--prediction-hash")
+    source.add_argument("--source-prediction-hash")
     parser.add_argument("--top-k", type=int, default=1)
+    parser.add_argument("--max-symbols", type=int, default=20)
+    parser.add_argument("--max-sessions", type=int, default=65)
     return parser.parse_args()
+
+
+def _seed_real_preview_prediction(
+    study: Study,
+    *,
+    source_prediction_hash: str,
+    max_symbols: int,
+    max_sessions: int,
+) -> PredictionResult:
+    if max_symbols < 2 or max_sessions < 5:
+        raise ValueError("the real preview fixture requires at least two symbols and five sessions")
+    source_path = (
+        study.release_root
+        / "case_studies"
+        / "sp500_options"
+        / "run_log"
+        / "predictions"
+        / source_prediction_hash
+        / "predictions.parquet"
+    )
+    if not source_path.is_file():
+        raise FileNotFoundError(f"released source prediction is missing: {source_path}")
+    source = pl.read_parquet(source_path)
+    required = {"symbol", "timestamp", "fold", "prediction", "actual"}
+    missing = required - set(source.columns)
+    if missing:
+        raise ValueError(f"released source prediction is missing columns: {sorted(missing)}")
+    fold_value = source.get_column("fold").min()
+    if not isinstance(fold_value, int):
+        raise TypeError("released source prediction fold values must be integers")
+    fold = fold_value
+    folded = source.filter(pl.col("fold") == fold)
+    symbols = (
+        folded.group_by("symbol")
+        .len()
+        .sort(["len", "symbol"], descending=[True, False])
+        .head(max_symbols)
+        .get_column("symbol")
+    )
+    sessions = folded.get_column("timestamp").unique().sort().head(max_sessions)
+    preview = (
+        folded.filter(
+            pl.col("symbol").is_in(symbols.implode()),
+            pl.col("timestamp").is_in(sessions.implode()),
+        )
+        .select("symbol", "timestamp", "fold", "prediction", "actual")
+        .sort("timestamp", "symbol")
+    )
+    if preview.get_column("symbol").n_unique() != max_symbols:
+        raise ValueError("real preview fixture did not retain the declared symbol population")
+    if preview.get_column("timestamp").n_unique() != max_sessions:
+        raise ValueError("real preview fixture did not retain the declared session population")
+    expected_keys = preview.select("symbol", "timestamp", "fold")
+    reductions = {
+        "source_prediction_hash": source_prediction_hash,
+        "folds": [fold],
+        "max_symbols": max_symbols,
+        "max_sessions": max_sessions,
+        "date_start": str(preview.get_column("timestamp").min()),
+        "date_end": str(preview.get_column("timestamp").max()),
+    }
+    spec = ResolvedSpec.create(
+        family="options_interface_fixture",
+        label="ret_to_expiry",
+        seed=0,
+        computation={
+            "model": {
+                "class": "released_prediction_subset",
+                "source_prediction_hash": source_prediction_hash,
+            },
+            "cv": {"identity": "released-validation-fold-subset", "request": {"folds": [fold]}},
+            "checkpoint_schedule": [{"kind": "final", "value": None}],
+            "expected_prediction_keys": {
+                "digest": value_digest(expected_keys),
+                "n_rows": expected_keys.height,
+                "n_folds": 1,
+            },
+            "input_data_spec": {
+                "source_prediction_hash": source_prediction_hash,
+                "source_prediction_digest": value_digest(source),
+            },
+            "preview_reductions": reductions,
+        },
+        provenance={"purpose": "reduced-real-options-interface-proof"},
+        config_name=f"released-{source_prediction_hash}",
+        execution_tier="preview",
+    ).as_dict()
+    training = study.results.register_training(spec, execution_tier="preview")
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=preview,
+        expected_keys=expected_keys,
+    )
+    if not prediction.complete:
+        raise RuntimeError("real preview prediction fixture is incomplete")
+    return prediction
 
 
 def main() -> None:
     args = parse_args()
     study = open_study(execution_tier="preview", workspace=args.workspace)
-    catalog = study.predictions.table(include_preview=True).filter(
-        pl.col("prediction_hash") == args.prediction_hash
-    )
-    if catalog.height != 1 or not catalog.item(0, "complete"):
-        raise ValueError("proof prediction is absent, ambiguous, or incomplete")
-    if catalog.item(0, "execution_tier") != "preview":
-        raise ValueError("the reduced proof requires a preview prediction")
-    prediction = selected_prediction(study, catalog.row(0, named=True))
+    if args.source_prediction_hash is not None:
+        prediction = _seed_real_preview_prediction(
+            study,
+            source_prediction_hash=args.source_prediction_hash,
+            max_symbols=args.max_symbols,
+            max_sessions=args.max_sessions,
+        )
+    else:
+        catalog = study.predictions.table(include_preview=True).filter(
+            pl.col("prediction_hash") == args.prediction_hash
+        )
+        if catalog.height != 1 or not catalog.item(0, "complete"):
+            raise ValueError("proof prediction is absent, ambiguous, or incomplete")
+        if catalog.item(0, "execution_tier") != "preview":
+            raise ValueError("the reduced proof requires a preview prediction")
+        prediction = selected_prediction(study, catalog.row(0, named=True))
     signal = {
         "method": "equal_weight_top_k",
         "top_k": args.top_k,

--- a/scripts/prove_sp500_options_interface.py
+++ b/scripts/prove_sp500_options_interface.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Prove the typed S&P 500 option path on a reduced real prediction set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.research import OfficialPopulation
+from case_studies.sp500_options._htm_backtest import (
+    _load_option_lifecycle,
+    option_data_paths,
+    run_htm_daily_mtm,
+)
+from case_studies.sp500_options.research_workflow import (
+    _clean_replay_digests,
+    open_study,
+    publish_short_straddle_decisions,
+    resolve_short_straddle_decisions,
+    selected_prediction,
+)
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import load_backtest_prices_for
+from case_studies.utils.backtest_runner import apply_universe_filter, normalize_prediction_columns
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--prediction-hash", required=True)
+    parser.add_argument("--top-k", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    study = open_study(execution_tier="preview", workspace=args.workspace)
+    catalog = study.predictions.table(include_preview=True).filter(
+        pl.col("prediction_hash") == args.prediction_hash
+    )
+    if catalog.height != 1 or not catalog.item(0, "complete"):
+        raise ValueError("proof prediction is absent, ambiguous, or incomplete")
+    if catalog.item(0, "execution_tier") != "preview":
+        raise ValueError("the reduced proof requires a preview prediction")
+    prediction = selected_prediction(study, catalog.row(0, named=True))
+    signal = {
+        "method": "equal_weight_top_k",
+        "top_k": args.top_k,
+        "universe_filter": "liquid",
+    }
+    prices = load_backtest_prices_for(
+        "sp500_options",
+        "ret_to_expiry",
+        split="validation",
+    )
+    prepared_decisions = resolve_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+    )
+    local_decision_digest = value_digest(prepared_decisions)
+    clean_replay = _clean_replay_digests(
+        study,
+        [
+            {
+                "request_name": "reduced-liquid-option-proof",
+                "prediction_hash": prediction.hash,
+                "label": "ret_to_expiry",
+                "signal": signal,
+                "allocation": None,
+            }
+        ],
+    )
+    if clean_replay != {"reduced-liquid-option-proof": local_decision_digest}:
+        raise RuntimeError("clean-process option decisions differ from the prepared proof")
+    decision = publish_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+        canonical=False,
+    )
+    labels_dir, raw_options_dir = option_data_paths()
+    decisions = decision.load()
+    lifecycle = _load_option_lifecycle(decisions, raw_options_dir)
+    raw_predictions = normalize_prediction_columns(prediction.load())
+    filtered_predictions = apply_universe_filter(
+        raw_predictions,
+        prices,
+        "sp500_options",
+        signal,
+        prediction_hash=prediction.hash,
+    )
+    direct = run_htm_daily_mtm(
+        "sp500_options",
+        filtered_predictions,
+        labels_dir,
+        raw_options_dir,
+        top_k=args.top_k,
+        option_lifecycle=lifecycle,
+    )
+    typed = run_htm_daily_mtm(
+        "sp500_options",
+        filtered_predictions,
+        labels_dir,
+        raw_options_dir,
+        top_k=args.top_k,
+        decisions=decisions,
+        option_lifecycle=lifecycle,
+    )
+    if not typed["daily_returns"].equals(direct["daily_returns"]):
+        raise RuntimeError("typed and direct option returns differ")
+    strategy = study.strategy(prediction=prediction, signal=signal, decision=decision)
+    result = strategy.run(prices=prices, option_lifecycle=lifecycle)
+    replay = strategy.run(prices=prices, option_lifecycle=lifecycle)
+    if replay.hash != result.hash:
+        raise RuntimeError("option backtest replay changed identity")
+    try:
+        OfficialPopulation.create(
+            study,
+            name="sp500-options-preview-must-fail",
+            member_kind="backtest",
+            members=[result.hash],
+        )
+    except ValueError as error:
+        if "preview" not in str(error):
+            raise
+    else:
+        raise RuntimeError("preview option result entered an official population")
+    expiry_rows = lifecycle.filter(pl.col("cash_settled"))
+    report = {
+        "prediction_hash": prediction.hash,
+        "decision_hash": decision.hash,
+        "backtest_hash": result.hash,
+        "decision_rows": decisions.height,
+        "decision_dates": decisions.get_column("timestamp").n_unique(),
+        "contracts": decisions.n_unique(["symbol", "strike", "expiration"]),
+        "lifecycle_rows": lifecycle.height,
+        "settlement_rows": expiry_rows.height,
+        "return_rows": typed["daily_returns"].height,
+        "replay_hash": replay.hash,
+        "typed_direct_equal": True,
+        "clean_decision_replay": True,
+        "preview_excluded": True,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sp500_options_research.py
+++ b/tests/test_sp500_options_research.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import DecisionArtifact, OfficialPopulation, Study
+from case_studies.sp500_options._htm_backtest import (
+    _compute_cohort_daily_pnl,
+    _load_option_lifecycle,
+    _select_cohorts,
+    run_htm_daily_mtm,
+)
+from case_studies.sp500_options.research_workflow import (
+    publish_short_straddle_decisions,
+    run_official_backtest_requests,
+    strategy_request_frame,
+)
+from case_studies.utils.registry.store import _open_registry
+from tests.test_research_contract_catalog import _resolved_spec
+from utils.paths import REPO_ROOT
+
+
+def _study(tmp_path: Path) -> Study:
+    output_root = tmp_path / "workspace"
+    root = output_root / "sp500_options"
+    root.mkdir(parents=True)
+    (root / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "sp500_options" / "config",
+        target_is_directory=True,
+    )
+    (output_root / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "config",
+        target_is_directory=True,
+    )
+    _open_registry(root).close()
+    return Study(
+        case_study="sp500_options",
+        root=root,
+        release_root=tmp_path / "release",
+        output_root=output_root,
+        read_only=False,
+        manifest={"schema_version": 1, "case_study": "sp500_options"},
+    )
+
+
+def _prediction(study: Study):
+    spec = _resolved_spec()
+    spec["label"] = "ret_to_expiry"
+    training = study.results.register_training(spec)
+    frame = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": [datetime(2024, 1, 5)],
+            "fold": [0],
+            "actual": [0.01],
+            "prediction": [0.02],
+        }
+    )
+    return study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold"),
+    )
+
+
+def _contract_returns() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "feature_date": [date(2024, 1, 5)],
+            "symbol": ["A"],
+            "strike": [100.0],
+            "expiration": [date(2024, 1, 10)],
+            "entry_date": [date(2024, 1, 8)],
+            "entry_straddle_mid": [10.0],
+            "entry_call_mid": [6.0],
+            "entry_call_bid": [5.5],
+            "entry_call_ask": [6.5],
+            "entry_put_mid": [4.0],
+            "entry_put_bid": [3.5],
+            "entry_put_ask": [4.5],
+            "exit_found_10d": [False],
+        }
+    )
+
+
+def _predictions() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "timestamp": [date(2024, 1, 5)],
+            "symbol": ["A"],
+            "y_score": [0.3],
+            "y_true": [0.1],
+        }
+    )
+
+
+def _write_raw_options(raw_dir: Path) -> None:
+    raw_dir.mkdir(parents=True)
+    rows = []
+    observations = (
+        (date(2024, 1, 8), 100.0, 6.0, 4.0, 0.6, -0.4),
+        (date(2024, 1, 9), 102.0, 5.5, 3.5, 0.7, -0.35),
+        # The quoted expiry midpoint is deliberately not intrinsic. The lifecycle
+        # loader must replace it with cash settlement: max(101-100, 0) + 0 = 1.
+        (date(2024, 1, 10), 101.0, 3.0, 2.0, 0.8, -0.1),
+    )
+    for timestamp, underlying, call_mid, put_mid, call_delta, put_delta in observations:
+        rows.extend(
+            [
+                {
+                    "date": timestamp,
+                    "symbol": "A",
+                    "strike": 100.0,
+                    "expiration": date(2024, 1, 10),
+                    "call_put": "C",
+                    "mid_price": call_mid,
+                    "bid": max(call_mid - 0.5, 0.0),
+                    "ask": call_mid + 0.5,
+                    "delta": call_delta,
+                    "underlying_price": underlying,
+                },
+                {
+                    "date": timestamp,
+                    "symbol": "A",
+                    "strike": 100.0,
+                    "expiration": date(2024, 1, 10),
+                    "call_put": "P",
+                    "mid_price": put_mid,
+                    "bid": max(put_mid - 0.5, 0.0),
+                    "ask": put_mid + 0.5,
+                    "delta": put_delta,
+                    "underlying_price": underlying,
+                },
+            ]
+        )
+    pl.DataFrame(rows).write_parquet(raw_dir / "year=2024.parquet")
+
+
+def test_hold_to_expiry_selection_does_not_require_a_ten_day_exit_quote() -> None:
+    cohorts = _select_cohorts(_predictions(), _contract_returns(), top_k=1)
+
+    assert cohorts.height == 1
+    assert cohorts.select("symbol", "timestamp", "strike", "expiration").row(0) == (
+        "A",
+        date(2024, 1, 5),
+        100.0,
+        date(2024, 1, 10),
+    )
+
+
+def test_cash_settlement_and_stateful_delta_hedge(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    _write_raw_options(raw_dir)
+    cohorts = _select_cohorts(_predictions(), _contract_returns(), top_k=1)
+    lifecycle = _load_option_lifecycle(cohorts, raw_dir)
+
+    expiry = lifecycle.filter(pl.col("date") == pl.col("expiration")).row(0, named=True)
+    assert expiry["call_mid"] == pytest.approx(1.0)
+    assert expiry["put_mid"] == pytest.approx(0.0)
+    assert expiry["instr_mid"] == pytest.approx(1.0)
+    assert expiry["cash_settled"] is True
+
+    daily = _compute_cohort_daily_pnl(
+        cohorts,
+        lifecycle,
+        delta_hedge=True,
+        hedge_spread_bps=0.0,
+        equity_commission_per_share=1.0,
+        option_commission_per_contract=0.0,
+        delta_threshold=0.10,
+        option_spread_fraction=1.0,
+    )
+
+    assert daily.get_column("hedge_position").to_list() == pytest.approx([0.2, 0.35, 0.0])
+    assert daily.get_column("hedge_trade").to_list() == pytest.approx([0.2, 0.15, -0.35])
+    assert daily.get_column("hedge_pnl_norm").to_list() == pytest.approx([0.0, 0.04, -0.035])
+    assert daily.get_column("hedge_cost_norm").to_list() == pytest.approx([0.02, 0.015, 0.035])
+    assert daily.get_column("premium_pnl_norm").to_list() == pytest.approx([0.0, 0.1, 0.8])
+
+
+def test_lifecycle_rejects_a_missing_contract_leg_date(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    _write_raw_options(raw_dir)
+    raw_path = raw_dir / "year=2024.parquet"
+    pl.read_parquet(raw_path).filter(
+        ~((pl.col("date") == date(2024, 1, 9)) & (pl.col("call_put") == "P"))
+    ).write_parquet(raw_path)
+    cohorts = _select_cohorts(_predictions(), _contract_returns(), top_k=1)
+
+    with pytest.raises(ValueError, match="missing 1 lifecycle dates"):
+        _load_option_lifecycle(cohorts, raw_dir)
+
+
+def test_supplied_lifecycle_cannot_drop_cash_settlement(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    _write_raw_options(raw_dir)
+    cohorts = _select_cohorts(_predictions(), _contract_returns(), top_k=1)
+    lifecycle = _load_option_lifecycle(cohorts, raw_dir).filter(
+        pl.col("date") < pl.col("expiration")
+    )
+
+    with pytest.raises(ValueError, match="cash-settle every selected contract"):
+        _compute_cohort_daily_pnl(
+            cohorts,
+            lifecycle,
+            delta_hedge=True,
+            hedge_spread_bps=0.0,
+            equity_commission_per_share=0.0,
+            option_commission_per_contract=0.0,
+            delta_threshold=0.1,
+        )
+
+
+def test_typed_contract_rows_match_direct_option_selection(tmp_path: Path) -> None:
+    labels_dir = tmp_path / "labels"
+    raw_dir = tmp_path / "raw"
+    labels_dir.mkdir()
+    _contract_returns().write_parquet(labels_dir / "contract_returns.parquet")
+    _write_raw_options(raw_dir)
+    predictions = _predictions()
+    decisions = _select_cohorts(predictions, _contract_returns(), top_k=1)
+
+    direct = run_htm_daily_mtm(
+        "sp500_options",
+        predictions,
+        labels_dir,
+        raw_dir,
+        top_k=1,
+        delta_threshold=0.10,
+        hedge_spread_bps=0.0,
+        equity_commission_per_share=0.0,
+        option_commission_per_contract=0.0,
+    )
+    typed = run_htm_daily_mtm(
+        "sp500_options",
+        predictions,
+        labels_dir,
+        raw_dir,
+        decisions=decisions,
+        top_k=1,
+        delta_threshold=0.10,
+        hedge_spread_bps=0.0,
+        equity_commission_per_share=0.0,
+        option_commission_per_contract=0.0,
+    )
+
+    assert typed["daily_returns"].equals(direct["daily_returns"])
+    assert typed["metrics"] == direct["metrics"]
+
+
+def test_short_straddle_decision_artifact_keeps_contract_identity(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    decisions = _select_cohorts(_predictions(), _contract_returns(), top_k=1).drop("y_score")
+
+    artifact = DecisionArtifact.publish(
+        study,
+        kind="short_straddles",
+        decisions=decisions,
+        prediction_hashes=[prediction.hash],
+        parameters={
+            "decision_cadence": "weekly_friday",
+            "entry_policy": "next_session_close",
+            "exit_policy": "hold_to_expiry",
+            "settlement_policy": "cash_intrinsic_at_expiration",
+        },
+    )
+
+    assert artifact.spec["decision_keys"] == ["symbol", "timestamp"]
+    assert (
+        artifact.load()
+        .select("symbol", "timestamp", "strike", "expiration", "entry_date", "weight")
+        .equals(
+            decisions.select("symbol", "timestamp", "strike", "expiration", "entry_date", "weight")
+        )
+    )
+
+    with pytest.raises(ValueError, match="expiration"):
+        DecisionArtifact.publish(
+            study,
+            kind="short_straddles",
+            decisions=decisions.drop("expiration"),
+            prediction_hashes=[prediction.hash],
+            parameters={"exit_policy": "hold_to_expiry"},
+        )
+
+
+def test_reader_boundary_publishes_contracts_consumed_by_strategy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.sp500_options import research_workflow
+
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    labels_dir = tmp_path / "labels"
+    raw_dir = tmp_path / "raw"
+    labels_dir.mkdir()
+    _contract_returns().write_parquet(labels_dir / "contract_returns.parquet")
+    _write_raw_options(raw_dir)
+    monkeypatch.setattr(research_workflow, "option_data_paths", lambda: (labels_dir, raw_dir))
+    prices = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": [datetime(2024, 1, 5)],
+            "open": [100.0],
+            "high": [101.0],
+            "low": [99.0],
+            "close": [100.0],
+            "volume": [1000],
+        }
+    )
+    signal = {"method": "equal_weight_top_k", "top_k": 1}
+
+    decision = publish_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+    )
+    strategy = study.strategy(prediction=prediction, signal=signal, decision=decision)
+    consumed = strategy._decision_weights(prices)
+
+    assert decision.kind == "short_straddles"
+    assert consumed is not None
+    assert consumed.select(
+        "symbol", "timestamp", "strike", "expiration", "entry_date", "weight", "fold"
+    ).equals(
+        decision.load().select(
+            "symbol", "timestamp", "strike", "expiration", "entry_date", "weight", "fold"
+        )
+    )
+    with pytest.raises(ValueError, match="clean-process replay digest"):
+        publish_short_straddle_decisions(
+            prediction,
+            prices=prices,
+            signal=signal,
+            canonical=True,
+        )
+
+
+def test_typed_decision_runs_through_registered_option_backtest_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.sp500_options import _htm_backtest, research_workflow
+    from case_studies.utils import cv_window
+
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    labels_dir = tmp_path / "labels"
+    raw_dir = tmp_path / "raw"
+    labels_dir.mkdir()
+    _contract_returns().write_parquet(labels_dir / "contract_returns.parquet")
+    _write_raw_options(raw_dir)
+    monkeypatch.setattr(research_workflow, "option_data_paths", lambda: (labels_dir, raw_dir))
+    monkeypatch.setattr(_htm_backtest, "option_data_paths", lambda: (labels_dir, raw_dir))
+    monkeypatch.setattr(cv_window, "canonical_window", lambda *args, **kwargs: None)
+    prices = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": [datetime(2024, 1, 5)],
+            "open": [100.0],
+            "high": [101.0],
+            "low": [99.0],
+            "close": [100.0],
+            "volume": [1000],
+        }
+    )
+    signal = {"method": "equal_weight_top_k", "top_k": 1}
+    decision = publish_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+    )
+    lifecycle = _load_option_lifecycle(decision.load(), raw_dir)
+
+    result = study.strategy(
+        prediction=prediction,
+        signal=signal,
+        decision=decision,
+    ).run(prices=prices, option_lifecycle=lifecycle)
+    spec = result.spec()
+
+    assert result.complete
+    assert spec["decision_artifact"]["kind"] == "short_straddles"
+    assert spec["decision_artifact"]["hash"] == decision.hash
+    assert spec["input_identity"]["option_contract_returns"]
+    assert spec["input_identity"]["option_lifecycle"]
+    assert spec["options_market"]["settlement"] == "cash_intrinsic_at_expiration"
+    assert spec["options_accounting"]["delta_threshold"] == pytest.approx(0.1)
+    assert spec["options_accounting"]["option_commission_per_contract"] == pytest.approx(0.65)
+    assert spec["options_accounting"]["equity_commission_per_share"] == pytest.approx(0.005)
+    assert spec["options_accounting"]["option_contract_multiplier"] == 100
+
+
+def test_unsupported_option_overrides_fail_before_backtesting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.sp500_options import _htm_backtest, research_workflow
+
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    labels_dir = tmp_path / "labels"
+    raw_dir = tmp_path / "raw"
+    labels_dir.mkdir()
+    _contract_returns().write_parquet(labels_dir / "contract_returns.parquet")
+    _write_raw_options(raw_dir)
+    monkeypatch.setattr(research_workflow, "option_data_paths", lambda: (labels_dir, raw_dir))
+    monkeypatch.setattr(_htm_backtest, "option_data_paths", lambda: (labels_dir, raw_dir))
+    prices = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": [datetime(2024, 1, 5)],
+            "open": [100.0],
+            "high": [101.0],
+            "low": [99.0],
+            "close": [100.0],
+            "volume": [1000],
+        }
+    )
+    signal = {"method": "equal_weight_top_k", "top_k": 1}
+    decision = publish_short_straddle_decisions(prediction, prices=prices, signal=signal)
+
+    with pytest.raises(ValueError, match="does not support risk overlays"):
+        study.strategy(
+            prediction=prediction,
+            signal=signal,
+            risk={"method": "vol_target"},
+            decision=decision,
+        ).resolve(prices=prices)
+    with pytest.raises(ValueError, match="generic costs are unsupported"):
+        study.strategy(
+            prediction=prediction,
+            signal=signal,
+            costs={"model": "percentage", "commission_bps": 1.0, "slippage_bps": 1.0},
+            decision=decision,
+        ).resolve(prices=prices)
+
+    assert study.backtests.table(include_preview=True).is_empty()
+
+
+def test_official_population_is_snapshotted_before_option_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.research.strategy import Strategy
+    from case_studies.sp500_options import _htm_backtest, research_workflow
+    from case_studies.utils import cv_window
+
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    labels_dir = study.root / "labels"
+    raw_dir = tmp_path / "raw"
+    labels_dir.mkdir()
+    _contract_returns().write_parquet(labels_dir / "contract_returns.parquet")
+    _write_raw_options(raw_dir)
+    monkeypatch.setattr(research_workflow, "option_data_paths", lambda: (labels_dir, raw_dir))
+    monkeypatch.setattr(_htm_backtest, "option_data_paths", lambda: (labels_dir, raw_dir))
+    monkeypatch.setattr(cv_window, "canonical_window", lambda *args, **kwargs: None)
+    prices = pl.DataFrame(
+        {
+            "symbol": ["A"],
+            "timestamp": [datetime(2024, 1, 5)],
+            "open": [100.0],
+            "high": [101.0],
+            "low": [99.0],
+            "close": [100.0],
+            "volume": [1000],
+        }
+    )
+    monkeypatch.setattr(research_workflow, "load_backtest_prices_for", lambda *a, **k: prices)
+    population_name = "sp500-options-test-population"
+
+    def fail_after_snapshot(self, **kwargs):
+        del self, kwargs
+        population = OfficialPopulation.one(study, name=population_name)
+        assert len(population.members) == 1
+        raise RuntimeError("injected option execution failure")
+
+    monkeypatch.setattr(Strategy, "run", fail_after_snapshot)
+    requests = strategy_request_frame(
+        [
+            {
+                "request_name": "liquid-top-1",
+                "prediction_hash": prediction.hash,
+                "label": "ret_to_expiry",
+                "signal": {"method": "equal_weight_top_k", "top_k": 1},
+                "allocation": None,
+                "risk": None,
+                "costs": None,
+            }
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="injected option execution failure"):
+        run_official_backtest_requests(study, requests, population_name=population_name)
+
+    population = OfficialPopulation.one(study, name=population_name)
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()

--- a/tests/test_sp500_options_research.py
+++ b/tests/test_sp500_options_research.py
@@ -19,6 +19,7 @@ from case_studies.sp500_options.research_workflow import (
     strategy_request_frame,
 )
 from case_studies.utils.registry.store import _open_registry
+from scripts.prove_sp500_options_interface import _seed_real_preview_prediction
 from tests.test_research_contract_catalog import _resolved_spec
 from utils.paths import REPO_ROOT
 
@@ -152,6 +153,59 @@ def test_hold_to_expiry_selection_does_not_require_a_ten_day_exit_quote() -> Non
         100.0,
         date(2024, 1, 10),
     )
+
+
+def test_real_prediction_subset_is_identity_covered_and_preview_only(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    source_hash = "released-source"
+    source_path = (
+        study.release_root
+        / "case_studies"
+        / "sp500_options"
+        / "run_log"
+        / "predictions"
+        / source_hash
+        / "predictions.parquet"
+    )
+    source_path.parent.mkdir(parents=True)
+    timestamps = [datetime(2024, 1, day) for day in range(2, 7)]
+    pl.DataFrame(
+        {
+            "symbol": [symbol for timestamp in timestamps for symbol in ("A", "B", "C")],
+            "timestamp": [timestamp for timestamp in timestamps for _ in range(3)],
+            "fold": [0] * 15,
+            "prediction": [float(index) / 100 for index in range(15)],
+            "actual": [float(index) / 200 for index in range(15)],
+        }
+    ).write_parquet(source_path)
+
+    prediction = _seed_real_preview_prediction(
+        study,
+        source_prediction_hash=source_hash,
+        max_symbols=2,
+        max_sessions=5,
+    )
+    computation = prediction.lineage()["training_spec"]["computation"]
+
+    assert prediction.complete
+    assert prediction.execution_tier == "preview"
+    assert prediction.load().shape == (10, 5)
+    assert computation["input_data_spec"]["source_prediction_hash"] == source_hash
+    assert computation["preview_reductions"] == {
+        "source_prediction_hash": source_hash,
+        "folds": [0],
+        "max_symbols": 2,
+        "max_sessions": 5,
+        "date_start": "2024-01-02 00:00:00",
+        "date_end": "2024-01-06 00:00:00",
+    }
+    with pytest.raises(ValueError, match="preview.*cannot enter"):
+        OfficialPopulation.create(
+            study,
+            name="real-preview-fixture-must-not-enter",
+            member_kind="prediction",
+            members=[prediction.hash],
+        )
 
 
 def test_cash_settlement_and_stateful_delta_hedge(tmp_path: Path) -> None:

--- a/tests/test_sp500_options_research.py
+++ b/tests/test_sp500_options_research.py
@@ -18,6 +18,7 @@ from case_studies.sp500_options.research_workflow import (
     run_official_backtest_requests,
     strategy_request_frame,
 )
+from case_studies.utils.artifact_digest import value_digest
 from case_studies.utils.registry.store import _open_registry
 from scripts.prove_sp500_options_interface import _seed_real_preview_prediction
 from tests.test_research_contract_catalog import _resolved_spec
@@ -403,6 +404,16 @@ def test_reader_boundary_publishes_contracts_consumed_by_strategy(
             signal=signal,
             canonical=True,
         )
+    canonical = publish_short_straddle_decisions(
+        prediction,
+        prices=prices,
+        signal=signal,
+        canonical=True,
+        clean_replay_digest=value_digest(decision.load()),
+    )
+    declared_inputs = canonical.spec["source_identity"]["declared_inputs"]
+    assert declared_inputs["option_contract_returns"]
+    assert "option_sources" not in declared_inputs
 
 
 def test_typed_decision_runs_through_registered_option_backtest_path(

--- a/tests/test_sp500_options_research.py
+++ b/tests/test_sp500_options_research.py
@@ -185,9 +185,16 @@ def test_real_prediction_subset_is_identity_covered_and_preview_only(tmp_path: P
         max_symbols=2,
         max_sessions=5,
     )
+    replayed = _seed_real_preview_prediction(
+        study,
+        source_prediction_hash=source_hash,
+        max_symbols=2,
+        max_sessions=5,
+    )
     computation = prediction.lineage()["training_spec"]["computation"]
 
     assert prediction.complete
+    assert replayed.hash == prediction.hash
     assert prediction.execution_tier == "preview"
     assert prediction.load().shape == (10, 5)
     assert computation["input_data_spec"]["source_prediction_hash"] == source_hash


### PR DESCRIPTION
## Summary

- add a typed short-straddle decision artifact and reader-facing option workflow
- validate paired contract lifecycles through intrinsic cash settlement
- retain and liquidate delta hedges with identity-bound option and equity costs
- snapshot complete official option backtest populations before execution
- bind clean-process decision replay and exact raw lifecycle inputs

## Reduced real proof

Two fresh processes produced the same report from one released linear configuration reduced to one fold, 20 symbols, and 65 sessions:

- prediction: `f6f5dfbc8d82`
- decision: `f3656015d13d`
- backtest: `2c6bb6e842a4`
- 14 decision dates and 14 cash-settled contracts
- 466 paired lifecycle rows and 82 daily return rows
- typed/direct equality and preview official-population exclusion

Command:

`bash .workspace/proofs/run_option_gate.sh`

## Tests

`uv run pytest -q tests/test_sp500_options_research.py tests/test_research_flow.py tests/test_strategy_gates.py tests/test_backtest_runner_helpers.py tests/test_research_contract_execution.py tests/test_research_workspace.py tests/test_research_models.py`

162 passed.
