### PR TITLE
Allow fresh workspaces from case-study worktrees

### DIFF
--- a/scripts/create_experiment.py
+++ b/scripts/create_experiment.py
@@ -30,7 +30,9 @@ def create_experiment(
     """Copy available generated state into a new ML4T_OUTPUT_DIR."""
     source = repo_root / "case_studies" / case_study
     source_run_log = source / "run_log"
-    if not source.is_dir() or not source_run_log.is_dir() or source_run_log.is_symlink():
+    if not source.is_dir() or (
+        include_release_run_log and (not source_run_log.is_dir() or source_run_log.is_symlink())
+    ):
         raise ValueError(f"Install the {case_study} artifact bundle before creating an experiment")
     source_config = source / "config"
     if not source_config.is_dir():
@@ -54,11 +56,11 @@ def create_experiment(
     try:
         staging.mkdir()
         for name in GENERATED_DIRS:
+            if name == "run_log" and not include_release_run_log:
+                (staging / name).mkdir()
+                continue
             candidate = source / name
             if candidate.is_dir():
-                if name == "run_log" and not include_release_run_log:
-                    (staging / name).mkdir()
-                    continue
                 shutil.copytree(candidate, staging / name)
 
         # config/ is a version-controlled input, not a generated artifact, but the

--- a/tests/test_create_experiment.py
+++ b/tests/test_create_experiment.py
@@ -89,6 +89,30 @@ def test_create_experiment_seeds_editable_config_and_shared_presets(tmp_path: Pa
     assert (tmp_path / "repo/case_studies/etfs/config/setup.yaml").exists()
 
 
+def test_create_experiment_without_baseline_accepts_a_linked_release_run_log(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    source = _seed_source(tmp_path)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    linked_run_log = artifact_root / "run_log"
+    (source / "run_log").rename(linked_run_log)
+    (source / "run_log").symlink_to(linked_run_log, target_is_directory=True)
+
+    output_root = tmp_path / "experiments/etf-test"
+    result = module.create_experiment(
+        "etfs",
+        output_root,
+        repo_root=tmp_path / "repo",
+        include_release_run_log=False,
+    )
+
+    assert (source / "run_log").is_symlink()
+    assert (result / "run_log").is_dir()
+    assert not (result / "run_log/registry.db").exists()
+
+
 def test_create_experiment_requires_config_tree(tmp_path: Path) -> None:
     """A case study with artifacts but no config/ cannot form a runnable experiment."""
     module = _load_module()


### PR DESCRIPTION
## Summary

- permit workspace creation without copying a released run log when the case-study worktree links canonical artifacts
- always create the empty writable run-log directory for this path
- cover the case-study symlink layout with a behavioral regression

## Verification

- `uv run pytest -q tests/test_create_experiment.py tests/test_us_firm_research_workflow.py --override-ini=addopts=` - 6 passed
- pre-commit hooks passed on commit `d808c6f4`