### PR TITLE
Plan complete model populations before fitting

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -17,6 +17,7 @@ from .execution import (
 from .identity import ResolvedSpec
 from .labels import LabelDefinition, LabelRef
 from .lifecycle import ResearchLock
+from .model_planning import ModelPlan, PlannedModel, plan_models
 from .models import ModelRequest, ModelRun, ResolvedModelRequest
 from .population import OfficialPopulation
 from .results import BacktestResult, PredictionResult, Result, TrainingResult
@@ -41,10 +42,12 @@ __all__ = [
     "LifecycleState",
     "ModelRequest",
     "ModelExecution",
+    "ModelPlan",
     "ModelRun",
     "PredictionResult",
     "PredictionCatalog",
     "PlannedBacktest",
+    "PlannedModel",
     "OfficialPopulation",
     "ResearchLock",
     "ResolvedModelRequest",
@@ -60,6 +63,7 @@ __all__ = [
     "register_adapter",
     "registered_adapters",
     "plan_backtests",
+    "plan_models",
     "run_backtests",
     "run_models",
 ]

--- a/case_studies/research/model_planning.py
+++ b/case_studies/research/model_planning.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+from case_studies.utils.registry.specs import (
+    canonical_json,
+    prediction_hash_from_parts,
+    training_hash_from_spec,
+)
+
+from .adapters import get_adapter
+from .contracts import ExecutionTier
+from .models import ModelRequest
+
+if TYPE_CHECKING:
+    from .execution import ModelExecution
+    from .workspace import Study
+
+
+@dataclass(frozen=True)
+class PlannedModel:
+    family: str
+    label: str
+    config_name: str
+    training_hash: str
+    checkpoint_kind: str
+    checkpoint_value: int | None
+    prediction_hash: str
+    spec_json: str
+
+
+@dataclass(frozen=True)
+class _FamilyPlan:
+    family: str
+    indexes: tuple[int, ...]
+    payload: Any
+
+
+@dataclass(frozen=True)
+class ModelPlan:
+    study: Study
+    requests: tuple[ModelRequest, ...]
+    members: tuple[PlannedModel, ...]
+    execution_tier: ExecutionTier
+    _family_plans: tuple[_FamilyPlan, ...] = field(repr=False)
+
+    @property
+    def expected_training_hashes(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(member.training_hash for member in self.members))
+
+    @property
+    def expected_prediction_hashes(self) -> tuple[str, ...]:
+        return tuple(member.prediction_hash for member in self.members)
+
+    def run(self) -> ModelExecution:
+        from .execution import ModelExecution
+
+        ordered_runs: list[Any | None] = [None] * len(self.requests)
+        failures = []
+        for family_plan in self._family_plans:
+            module = get_adapter("model", family_plan.family)
+            batch_runner = getattr(module, "run_model_plan", None)
+            if callable(batch_runner):
+                try:
+                    runs = tuple(batch_runner(self.study, family_plan.payload))
+                except Exception as error:
+                    failures.append(error)
+                    continue
+            else:
+                completed = []
+                for request in family_plan.payload:
+                    try:
+                        completed.append(request.run())
+                    except Exception as error:
+                        failures.append(error)
+                        completed.append(None)
+                runs = tuple(completed)
+            if len(runs) != len(family_plan.indexes):
+                raise RuntimeError(
+                    f"{family_plan.family!r} planned runner returned {len(runs)} results for "
+                    f"{len(family_plan.indexes)} requests"
+                )
+            for index, run in zip(family_plan.indexes, runs, strict=True):
+                if run is not None:
+                    ordered_runs[index] = run
+        if failures:
+            raise failures[0]
+        if any(run is None for run in ordered_runs):
+            raise RuntimeError("planned model execution did not produce every result")
+        runs = tuple(run for run in ordered_runs if run is not None)
+        actual_predictions = tuple(
+            prediction.hash for run in runs for prediction in run.predictions
+        )
+        actual_training = tuple(run.training.hash for run in runs)
+        if actual_training != self.expected_training_hashes:
+            raise RuntimeError("model execution changed its planned training population")
+        if actual_predictions != self.expected_prediction_hashes:
+            raise RuntimeError("model execution changed its planned checkpoint population")
+        catalog_rows = self.study.predictions.table(include_preview=True).filter(
+            pl.col("prediction_hash").is_in(actual_predictions)
+        )
+        diagnostics = tuple(
+            {"status": "completed", "training_hash": run.training.hash, **run.diagnostics}
+            for run in runs
+        )
+        return ModelExecution(runs, catalog_rows, diagnostics)
+
+
+def _planned_members(spec: dict[str, Any]) -> tuple[PlannedModel, ...]:
+    computation = spec.get("computation", spec)
+    schedule = computation.get("checkpoint_schedule")
+    if not isinstance(schedule, list) or not schedule:
+        raise ValueError("resolved model request has no checkpoint schedule")
+    training_hash = training_hash_from_spec(spec)
+    spec_json = canonical_json(spec)
+    members = []
+    for checkpoint in schedule:
+        kind = checkpoint.get("kind")
+        value = checkpoint.get("value")
+        if not isinstance(kind, str) or not kind:
+            raise ValueError("resolved model checkpoint has no kind")
+        if value is not None and not isinstance(value, int):
+            raise TypeError("resolved model checkpoint value must be an integer or null")
+        members.append(
+            PlannedModel(
+                family=str(spec["family"]),
+                label=str(spec["label"]),
+                config_name=str(spec["config_name"]),
+                training_hash=training_hash,
+                checkpoint_kind=kind,
+                checkpoint_value=value,
+                prediction_hash=prediction_hash_from_parts(
+                    training_hash,
+                    value,
+                    "validation",
+                    checkpoint_kind=kind,
+                    identity_version=spec["identity_version"],
+                ),
+                spec_json=spec_json,
+            )
+        )
+    return tuple(members)
+
+
+def plan_models(
+    study: Study, *, requests: tuple[ModelRequest, ...] | list[ModelRequest]
+) -> ModelPlan:
+    """Resolve every training and checkpoint identity without fitting a model."""
+    submitted = tuple(requests)
+    if not submitted:
+        raise ValueError("plan_models requires at least one request")
+    if any(not isinstance(request, ModelRequest) for request in submitted):
+        raise TypeError("plan_models requires unresolved ModelRequest objects")
+    if any(request.study != study for request in submitted):
+        raise ValueError("model request belongs to another study")
+    tiers = {request.execution_tier for request in submitted}
+    if len(tiers) != 1:
+        raise ValueError("one model plan cannot mix canonical and preview requests")
+
+    ordered_specs: list[dict[str, Any] | None] = [None] * len(submitted)
+    family_plans = []
+    grouped: dict[str, list[tuple[int, ModelRequest]]] = {}
+    for index, request in enumerate(submitted):
+        grouped.setdefault(request.family, []).append((index, request))
+    for family, indexed_requests in grouped.items():
+        module = get_adapter("model", family)
+        batch_planner = getattr(module, "plan_model_requests", None)
+        if callable(batch_planner):
+            planned = batch_planner(
+                study,
+                [request.as_dict() for _, request in indexed_requests],
+            )
+            if not isinstance(planned, tuple) or len(planned) != 2:
+                raise TypeError(f"{family!r} planner must return specifications and a payload")
+            specs = tuple(planned[0])
+            payload = planned[1]
+        else:
+            resolved = tuple(request.resolve() for _, request in indexed_requests)
+            specs = tuple(request.spec for request in resolved)
+            payload = resolved
+        if len(specs) != len(indexed_requests):
+            raise ValueError(
+                f"{family!r} planner returned {len(specs)} specifications for "
+                f"{len(indexed_requests)} requests"
+            )
+        for (index, request), spec in zip(indexed_requests, specs, strict=True):
+            if spec.get("family") != request.family or spec.get("label") != request.label:
+                raise ValueError("family planner changed the requested family or label")
+            if spec.get("execution_tier") != request.execution_tier.value:
+                raise ValueError("family planner changed the execution tier")
+            ordered_specs[index] = spec
+        family_plans.append(
+            _FamilyPlan(
+                family,
+                tuple(index for index, _ in indexed_requests),
+                payload,
+            )
+        )
+    if any(spec is None for spec in ordered_specs):
+        raise RuntimeError("model planning did not resolve every request")
+
+    members = tuple(
+        member for spec in ordered_specs if spec is not None for member in _planned_members(spec)
+    )
+    training_hashes = [member.training_hash for member in members]
+    expected_training_count = len(submitted)
+    if len(set(training_hashes)) != expected_training_count:
+        raise ValueError("model plan contains duplicate training identities")
+    prediction_hashes = [member.prediction_hash for member in members]
+    if len(set(prediction_hashes)) != len(prediction_hashes):
+        raise ValueError("model plan contains duplicate checkpoint identities")
+    return ModelPlan(study, submitted, members, tiers.pop(), tuple(family_plans))

--- a/case_studies/research/model_planning.py
+++ b/case_studies/research/model_planning.py
@@ -17,6 +17,7 @@ from .models import ModelRequest
 
 if TYPE_CHECKING:
     from .execution import ModelExecution
+    from .population import OfficialPopulation
     from .workspace import Study
 
 
@@ -54,6 +55,25 @@ class ModelPlan:
     @property
     def expected_prediction_hashes(self) -> tuple[str, ...]:
         return tuple(member.prediction_hash for member in self.members)
+
+    def create_population(
+        self,
+        *,
+        name: str,
+        supersedes: str | None = None,
+    ) -> OfficialPopulation:
+        """Persist the complete canonical checkpoint population before execution."""
+        from .population import OfficialPopulation
+
+        if self.execution_tier is not ExecutionTier.CANONICAL:
+            raise ValueError("preview model plans cannot create an official population")
+        return OfficialPopulation.create(
+            self.study,
+            name=name,
+            member_kind="prediction",
+            members=self.expected_prediction_hashes,
+            supersedes=supersedes,
+        )
 
     def run(self) -> ModelExecution:
         from .execution import ModelExecution

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -2451,27 +2451,35 @@ def _run_gbm_batch_group(
     base: dict[str, Any],
     *,
     report_batch: bool,
+    planned_candidates: dict[
+        int,
+        tuple[dict[str, Any], dict[str, dict[str, Any]], str, int, int],
+    ]
+    | None = None,
 ) -> list[_GBMBatchCandidate]:
     mds = base["mds"]
     candidates = []
     for index, request in indexed_requests:
-        config, request_fields = _load_gbm_request_config(
-            study,
-            base["label_ref"].name,
-            request["config_name"],
-            request["overrides"],
-        )
-        _apply_gbm_preview_reductions(config, request)
-        device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
-        effective = _gbm_effective_params_for_splits(
-            config,
-            base,
-            device=device,
-            max_bin=max_bin,
-            num_threads=num_threads,
-            task_type=mds.task_type,
-            class_values=tuple(mds.class_values),
-        )
+        if planned_candidates is None:
+            config, request_fields = _load_gbm_request_config(
+                study,
+                base["label_ref"].name,
+                request["config_name"],
+                request["overrides"],
+            )
+            _apply_gbm_preview_reductions(config, request)
+            device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
+            effective = _gbm_effective_params_for_splits(
+                config,
+                base,
+                device=device,
+                max_bin=max_bin,
+                num_threads=num_threads,
+                task_type=mds.task_type,
+                class_values=tuple(mds.class_values),
+            )
+        else:
+            config, effective, device, max_bin, num_threads = planned_candidates[index]
         candidate = _GBMBatchCandidate(
             index=index,
             request=request,
@@ -2535,6 +2543,99 @@ def _run_gbm_batch_group(
             }
         )
     return candidates
+
+
+def plan_model_requests(
+    study: Study,
+    requests: list[dict[str, Any]],
+) -> tuple[tuple[dict[str, Any], ...], tuple[Any, ...]]:
+    """Resolve a request batch once without fitting or writing result rows."""
+    if not requests:
+        raise ValueError("GBM batch planner requires at least one request")
+    groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        groups.setdefault(_gbm_compatibility_key(study, request), []).append((index, request))
+
+    ordered: list[dict[str, Any] | None] = [None] * len(requests)
+    planned_groups = []
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any, Any]] = {}
+    for key, indexed_requests in groups.items():
+        input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
+        base = _load_gbm_batch_base(
+            study,
+            indexed_requests[0][1],
+            inputs=input_cache.get(input_key),
+        )
+        input_cache.setdefault(
+            input_key,
+            (base["label_ref"], base["mds"], base["dataset_pd"]),
+        )
+        mds = base["mds"]
+        placeholder_folds = tuple({"fold": int(split["fold"])} for split in base["splits"])
+        planned_candidates = {}
+        for index, request in indexed_requests:
+            config, request_fields = _load_gbm_request_config(
+                study,
+                base["label_ref"].name,
+                request["config_name"],
+                request["overrides"],
+            )
+            _apply_gbm_preview_reductions(config, request)
+            device, max_bin, num_threads = _gbm_execution_settings(study, request_fields)
+            effective = _gbm_effective_params_for_splits(
+                config,
+                base,
+                device=device,
+                max_bin=max_bin,
+                num_threads=num_threads,
+                task_type=mds.task_type,
+                class_values=tuple(mds.class_values),
+            )
+            spec, _ = _build_gbm_resolved_request(
+                study,
+                request,
+                base=base,
+                config=config,
+                effective=effective,
+                folds=placeholder_folds,
+                device=device,
+            )
+            ordered[index] = spec
+            planned_candidates[index] = (config, effective, device, max_bin, num_threads)
+        planned_groups.append((key, indexed_requests, base, planned_candidates))
+    if any(spec is None for spec in ordered):
+        raise RuntimeError("GBM batch planner did not resolve every request")
+    return tuple(spec for spec in ordered if spec is not None), tuple(planned_groups)
+
+
+def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ...]:
+    ordered: list[ModelRun | None] = [
+        None for _ in range(sum(len(indexed) for _, indexed, _, _ in payload))
+    ]
+    failures = []
+    for key, indexed_requests, base, planned_candidates in payload:
+        try:
+            candidates = _run_gbm_batch_group(
+                study,
+                indexed_requests,
+                key,
+                base,
+                report_batch=len(ordered) > 1,
+                planned_candidates=planned_candidates,
+            )
+        except Exception as error:
+            failures.append(error)
+            continue
+        for candidate in candidates:
+            if candidate.error is not None:
+                failures.append(candidate.error)
+            elif candidate.result is not None:
+                ordered[candidate.index] = candidate.result
+    if failures:
+        raise failures[0]
+    if any(result is None for result in ordered):
+        raise RuntimeError("GBM planned batch did not produce every requested result")
+    return tuple(result for result in ordered if result is not None)
 
 
 def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[ModelRun, ...]:

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -857,13 +857,18 @@ def _run_batch_group(
     base: dict[str, Any],
     *,
     report_batch: bool,
+    planned_effective: dict[int, dict[str, dict[str, Any]]] | None = None,
 ) -> list[_BatchCandidate]:
     fold_ids = tuple(int(split["fold"]) for split in base["splits"])
     candidates = []
     dependent = []
     for index, request in indexed_requests:
         config = _load_preset(request["config_name"])
-        effective = _fixed_effective_params(config, request["overrides"], fold_ids)
+        effective = (
+            planned_effective[index]
+            if planned_effective is not None
+            else _fixed_effective_params(config, request["overrides"], fold_ids)
+        )
         candidate = _BatchCandidate(index, request, config, effective or {})
         candidates.append(candidate)
         if effective is None:
@@ -976,6 +981,118 @@ def _run_batch_group(
             }
         )
     return candidates
+
+
+def plan_model_requests(
+    study: Study,
+    requests: list[dict[str, Any]],
+) -> tuple[tuple[dict[str, Any], ...], tuple[Any, ...]]:
+    """Resolve a request batch once without fitting or writing result rows."""
+    if not requests:
+        raise ValueError("linear batch planner requires at least one request")
+    groups: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        groups.setdefault(_compatibility_key(request), []).append((index, request))
+
+    ordered: list[dict[str, Any] | None] = [None] * len(requests)
+    planned_groups = []
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    for key, indexed_requests in groups.items():
+        input_key = _input_compatibility_key(indexed_requests[0][1])
+        base = _load_batch_base(
+            study,
+            indexed_requests[0][1],
+            inputs=input_cache.get(input_key),
+        )
+        input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
+        fold_ids = tuple(int(split["fold"]) for split in base["splits"])
+        candidates = []
+        dependent = []
+        for index, request in indexed_requests:
+            config = _load_preset(request["config_name"])
+            effective = _fixed_effective_params(config, request["overrides"], fold_ids)
+            candidate = _BatchCandidate(index, request, config, effective or {})
+            candidates.append(candidate)
+            if effective is None:
+                dependent.append(candidate)
+
+        if dependent:
+            for split in base["splits"]:
+                fold = _prepare_batch_fold(base, split)
+                try:
+                    for candidate in dependent:
+                        candidate.effective_params.update(
+                            _effective_params(
+                                candidate.config,
+                                candidate.request["overrides"],
+                                [fold],
+                            )
+                        )
+                finally:
+                    del fold
+
+        placeholder_folds = tuple({"fold": fold_id} for fold_id in fold_ids)
+        for candidate in candidates:
+            if set(candidate.effective_params) != {str(fold_id) for fold_id in fold_ids}:
+                raise RuntimeError(
+                    f"linear planner did not resolve every fold for "
+                    f"{candidate.request['config_name']}"
+                )
+            spec, _ = _build_resolved_request(
+                study,
+                candidate.request,
+                label_ref=base["label_ref"],
+                mds=base["mds"],
+                splits=base["splits"],
+                cv_record=base["cv_record"],
+                config=candidate.config,
+                effective=candidate.effective_params,
+                expected=base["expected"],
+                folds=placeholder_folds,
+                runtime_provenance=base["runtime_provenance"],
+            )
+            ordered[candidate.index] = spec
+        planned_groups.append(
+            (
+                key,
+                indexed_requests,
+                base,
+                {candidate.index: candidate.effective_params for candidate in candidates},
+            )
+        )
+    if any(spec is None for spec in ordered):
+        raise RuntimeError("linear batch planner did not resolve every request")
+    return tuple(spec for spec in ordered if spec is not None), tuple(planned_groups)
+
+
+def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ...]:
+    ordered: list[ModelRun | None] = [
+        None for _ in range(sum(len(indexed) for _, indexed, _, _ in payload))
+    ]
+    failures = []
+    for key, indexed_requests, base, planned_effective in payload:
+        try:
+            candidates = _run_batch_group(
+                study,
+                indexed_requests,
+                key,
+                base,
+                report_batch=len(ordered) > 1,
+                planned_effective=planned_effective,
+            )
+        except Exception as error:
+            failures.append(error)
+            continue
+        for candidate in candidates:
+            if candidate.error is not None:
+                failures.append(candidate.error)
+            elif candidate.result is not None:
+                ordered[candidate.index] = candidate.result
+    if failures:
+        raise failures[0]
+    if any(result is None for result in ordered):
+        raise RuntimeError("linear planned batch did not produce every requested result")
+    return tuple(result for result in ordered if result is not None)
 
 
 def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[ModelRun, ...]:

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -996,6 +996,57 @@ def _run_tabm_compatible_group(study: Study, items):
     return completed
 
 
+def plan_model_requests(
+    study: Study,
+    requests: list[dict[str, Any]],
+) -> tuple[tuple[dict[str, Any], ...], tuple[Any, ...]]:
+    """Resolve compatible TabM requests once without fitting or result writes."""
+    if not requests:
+        raise ValueError("TabM batch planner requires at least one request")
+    ordered: list[dict[str, Any] | None] = [None] * len(requests)
+    resolved_by_index = []
+    materialization_groups: dict[tuple[str, str, int], list[tuple[int, dict[str, Any]]]] = {}
+    for index, request in enumerate(requests):
+        materialization_groups.setdefault(_tabm_materialization_key(request), []).append(
+            (index, request)
+        )
+    for group in materialization_groups.values():
+        materialized = _materialize_tabm_request_group(study, group[0][1])
+        dataset_pd = None
+        for index, request in group:
+            spec, context = _resolve_model_request_from_materialized(
+                study,
+                request,
+                label_ref=materialized[0],
+                mds=materialized[1],
+                dataset_pd=dataset_pd,
+                configured_by_name=materialized[2],
+                runtime_provenance=materialized[3],
+            )
+            dataset_pd = context.dataset_pd
+            ordered[index] = spec
+            resolved_by_index.append((index, spec, context))
+    if any(spec is None for spec in ordered):
+        raise RuntimeError("TabM batch planner did not resolve every request")
+    return tuple(spec for spec in ordered if spec is not None), tuple(resolved_by_index)
+
+
+def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[Any, ...]:
+    execution_groups: dict[str, list[Any]] = {}
+    for item in payload:
+        execution_groups.setdefault(_tabm_execution_key(item[1]), []).append(item)
+    completed = {}
+    failures = []
+    for compatible in execution_groups.values():
+        try:
+            completed.update(_run_tabm_compatible_group(study, compatible))
+        except Exception as error:
+            failures.append(error)
+    if failures:
+        raise failures[0]
+    return tuple(completed[index] for index in range(len(payload)))
+
+
 def run_model_requests(study: Study, requests: list[dict[str, Any]]):
     if not requests:
         return ()

--- a/tests/test_research_model_planning.py
+++ b/tests/test_research_model_planning.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+
+import pytest
+
+from case_studies.research.contracts import ExecutionTier
+from case_studies.research.identity import ResolvedSpec
+from case_studies.research.model_planning import plan_models
+from case_studies.research.models import ModelRequest
+from case_studies.utils import gbm, linear, tabular_dl
+
+
+def _request(study, config_name: str) -> ModelRequest:
+    return ModelRequest(
+        study=study,
+        family="planned_family",
+        label="target",
+        config_name=config_name,
+        overrides={},
+        cv=None,
+        execution_tier=ExecutionTier.CANONICAL,
+        preview_reductions={},
+    )
+
+
+def _spec(config_name: str) -> dict:
+    return ResolvedSpec.create(
+        family="planned_family",
+        label="target",
+        seed=7,
+        computation={
+            "checkpoint_schedule": [
+                {"kind": "epoch", "value": 5},
+                {"kind": "epoch", "value": 10},
+            ],
+            "cv": {"folds": [0, 1]},
+            "feature_artifacts": {"features": "digest"},
+            "label_artifact": {"name": "target", "digest": "label-digest"},
+            "model": {"class": "FixtureModel", "params": {"variant": config_name}},
+        },
+        provenance={"device": "cpu"},
+        config_name=config_name,
+        execution_tier="canonical",
+    ).as_dict()
+
+
+def test_plan_models_resolves_one_family_batch_and_declares_every_checkpoint(monkeypatch) -> None:
+    study = SimpleNamespace()
+    requests = [_request(study, "first"), _request(study, "second")]
+    calls = []
+
+    def batch_planner(received_study, request_dicts):
+        calls.append((received_study, request_dicts))
+        specs = tuple(_spec(request["config_name"]) for request in request_dicts)
+        return specs, request_dicts
+
+    monkeypatch.setattr(
+        "case_studies.research.model_planning.get_adapter",
+        lambda kind, family: SimpleNamespace(plan_model_requests=batch_planner),
+    )
+
+    plan = plan_models(study, requests=requests)
+
+    assert len(calls) == 1
+    assert calls[0][0] is study
+    assert [request["config_name"] for request in calls[0][1]] == ["first", "second"]
+    assert len(plan.expected_training_hashes) == 2
+    assert len(plan.expected_prediction_hashes) == 4
+    assert [(member.config_name, member.checkpoint_value) for member in plan.members] == [
+        ("first", 5),
+        ("first", 10),
+        ("second", 5),
+        ("second", 10),
+    ]
+
+
+def test_model_plan_rejects_execution_identity_drift(monkeypatch) -> None:
+    study = SimpleNamespace()
+    request = _request(study, "first")
+
+    def run_model_plan(received_study, payload):
+        return (
+            SimpleNamespace(
+                training=SimpleNamespace(hash=plan.expected_training_hashes[0]),
+                predictions=(SimpleNamespace(hash="wrong-checkpoint"),),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "case_studies.research.model_planning.get_adapter",
+        lambda kind, family: SimpleNamespace(
+            plan_model_requests=lambda received_study, request_dicts: (
+                (_spec("first"),),
+                request_dicts,
+            ),
+            run_model_plan=run_model_plan,
+        ),
+    )
+    plan = plan_models(study, requests=[request])
+
+    with pytest.raises(RuntimeError, match="planned checkpoint population"):
+        plan.run()
+
+
+@pytest.mark.parametrize(
+    ("module", "batch_name"),
+    [(linear, "_run_batch_group"), (gbm, "_run_gbm_batch_group")],
+)
+def test_planned_fold_major_runner_attempts_later_group_after_failure(
+    monkeypatch, module, batch_name
+) -> None:
+    calls = []
+
+    def observed_batch(study, indexed_requests, key, base, **kwargs):
+        calls.append(key)
+        if key == "first":
+            raise RuntimeError("injected compatibility-group failure")
+        return [SimpleNamespace(index=1, error=None, result=object())]
+
+    monkeypatch.setattr(module, batch_name, observed_batch)
+    payload = (
+        ("first", [(0, {})], object(), {}),
+        ("second", [(1, {})], object(), {}),
+    )
+
+    with pytest.raises(RuntimeError, match="injected compatibility-group failure"):
+        module.run_model_plan(SimpleNamespace(), payload)
+
+    assert calls == ["first", "second"]
+
+
+def test_planned_tabm_runner_attempts_later_group_after_failure(monkeypatch) -> None:
+    calls = []
+
+    def observed_batch(study, items):
+        key = items[0][1]
+        calls.append(key)
+        if key == "first":
+            raise RuntimeError("injected compatibility-group failure")
+        return {1: object()}
+
+    monkeypatch.setattr(tabular_dl, "_tabm_execution_key", lambda spec: spec)
+    monkeypatch.setattr(tabular_dl, "_run_tabm_compatible_group", observed_batch)
+    payload = ((0, "first", object()), (1, "second", object()))
+
+    with pytest.raises(RuntimeError, match="injected compatibility-group failure"):
+        tabular_dl.run_model_plan(SimpleNamespace(), payload)
+
+    assert calls == ["first", "second"]

--- a/tests/test_research_model_planning.py
+++ b/tests/test_research_model_planning.py
@@ -9,7 +9,12 @@ from case_studies.research.models import ModelRequest
 from case_studies.utils import gbm, linear, tabular_dl
 
 
-def _request(study, config_name: str) -> ModelRequest:
+def _request(
+    study,
+    config_name: str,
+    *,
+    execution_tier: ExecutionTier = ExecutionTier.CANONICAL,
+) -> ModelRequest:
     return ModelRequest(
         study=study,
         family="planned_family",
@@ -17,8 +22,8 @@ def _request(study, config_name: str) -> ModelRequest:
         config_name=config_name,
         overrides={},
         cv=None,
-        execution_tier=ExecutionTier.CANONICAL,
-        preview_reductions={},
+        execution_tier=execution_tier,
+        preview_reductions={"folds": [0]} if execution_tier is ExecutionTier.PREVIEW else {},
     )
 
 
@@ -99,6 +104,29 @@ def test_model_plan_rejects_execution_identity_drift(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="planned checkpoint population"):
         plan.run()
+
+
+def test_preview_model_plan_rejects_official_population_before_registry_write(
+    monkeypatch,
+) -> None:
+    study = SimpleNamespace()
+    request = _request(study, "first", execution_tier=ExecutionTier.PREVIEW)
+    preview_spec = _spec("first")
+    preview_spec["execution_tier"] = "preview"
+    monkeypatch.setattr(
+        "case_studies.research.model_planning.get_adapter",
+        lambda kind, family: SimpleNamespace(
+            plan_model_requests=lambda received_study, request_dicts: (
+                (preview_spec,),
+                request_dicts,
+            )
+        ),
+    )
+
+    plan = plan_models(study, requests=[request])
+
+    with pytest.raises(ValueError, match="preview model plans"):
+        plan.create_population(name="invalid-preview-population")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_research_model_planning.py
+++ b/tests/test_research_model_planning.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -6,6 +7,7 @@ from case_studies.research.contracts import ExecutionTier
 from case_studies.research.identity import ResolvedSpec
 from case_studies.research.model_planning import plan_models
 from case_studies.research.models import ModelRequest
+from case_studies.research.workspace import Study
 from case_studies.utils import gbm, linear, tabular_dl
 
 
@@ -49,7 +51,7 @@ def _spec(config_name: str) -> dict:
 
 
 def test_plan_models_resolves_one_family_batch_and_declares_every_checkpoint(monkeypatch) -> None:
-    study = SimpleNamespace()
+    study = cast(Study, SimpleNamespace())
     requests = [_request(study, "first"), _request(study, "second")]
     calls = []
 
@@ -79,7 +81,7 @@ def test_plan_models_resolves_one_family_batch_and_declares_every_checkpoint(mon
 
 
 def test_model_plan_rejects_execution_identity_drift(monkeypatch) -> None:
-    study = SimpleNamespace()
+    study = cast(Study, SimpleNamespace())
     request = _request(study, "first")
 
     def run_model_plan(received_study, payload):
@@ -109,7 +111,7 @@ def test_model_plan_rejects_execution_identity_drift(monkeypatch) -> None:
 def test_preview_model_plan_rejects_official_population_before_registry_write(
     monkeypatch,
 ) -> None:
-    study = SimpleNamespace()
+    study = cast(Study, SimpleNamespace())
     request = _request(study, "first", execution_tier=ExecutionTier.PREVIEW)
     preview_spec = _spec("first")
     preview_spec["execution_tier"] = "preview"
@@ -171,6 +173,6 @@ def test_planned_tabm_runner_attempts_later_group_after_failure(monkeypatch) -> 
     payload = ((0, "first", object()), (1, "second", object()))
 
     with pytest.raises(RuntimeError, match="injected compatibility-group failure"):
-        tabular_dl.run_model_plan(SimpleNamespace(), payload)
+        tabular_dl.run_model_plan(cast(Study, SimpleNamespace()), payload)
 
     assert calls == ["first", "second"]

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -17,8 +17,10 @@ from case_studies.research import (
     CVSpec,
     LabelDefinition,
     ModelRun,
+    OfficialPopulation,
     Study,
     get_adapter,
+    plan_models,
     register_adapter,
     registered_adapters,
     run_models,
@@ -252,7 +254,19 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
         for config_name in ("tabm_s", "tabm_m")
     ]
 
-    result = run_models(study, requests=requests)
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-tabm-checkpoints",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
+    assert loads == [("etfs", "fwd_ret_1d", 0)]
+    assert conversions == 1
+    assert executions == []
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
+    result = plan.run()
 
     assert loads == [("etfs", "fwd_ret_1d", 0)]
     assert conversions == 1
@@ -264,6 +278,7 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
     assert all(run.diagnostics["base_fold_preparations"] == 2 for run in result.runs)
     assert all(run.diagnostics["compatibility_group_size"] == 2 for run in result.runs)
     assert all(run.diagnostics["disk_fold_cache"] is False for run in result.runs)
+    assert population.require_complete() == plan.expected_prediction_hashes
 
 
 def test_tabm_cv_releases_each_prepared_fold_after_all_candidates(
@@ -409,12 +424,23 @@ def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatc
         )
         for config_name in ("tabm_s", "tabm_m")
     ]
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-tabm-recovery",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
 
     with pytest.raises(RuntimeError, match="injected TabM candidate failure"):
-        run_models(study, requests=requests)
+        plan.run()
     first_calls = list(calls)
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
     fail_small = False
-    recovered = run_models(study, requests=requests)
+    recovered_plan = plan_models(study, requests=requests)
+    assert recovered_plan.expected_prediction_hashes == plan.expected_prediction_hashes
+    recovered = recovered_plan.run()
 
     assert first_calls == [
         (4, "2024-01-03"),
@@ -430,6 +456,7 @@ def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatc
     assert len({run.diagnostics["preparation_fraction"] for run in recovered.runs}) == 1
     assert recovered.runs[1].diagnostics["candidate_fit_s"] == 0.0
     assert all(run.predictions[0].complete for run in recovered.runs)
+    assert population.require_complete() == plan.expected_prediction_hashes
 
 
 def test_tabm_batch_matches_individual_resolved_execution(tmp_path, monkeypatch) -> None:
@@ -964,6 +991,73 @@ def test_linear_batch_resolves_fold_dependent_parameters_before_fitting(
     assert all(run.diagnostics["base_fold_preparations"] == 4 for run in batch.runs)
 
 
+def test_linear_model_plan_reuses_one_materialization_and_one_execution_fold_pass(
+    tmp_path, monkeypatch
+) -> None:
+    study = _linear_study(tmp_path, monkeypatch)
+    original_load = linear.load_modeling_dataset
+    original_prepare = modeling.prepare_single_fold
+    loads = 0
+    prepared_folds = []
+
+    def observed_load(*args, **kwargs):
+        nonlocal loads
+        loads += 1
+        return original_load(*args, **kwargs)
+
+    def load_preset(config_name):
+        if config_name == "lasso":
+            return {
+                "config_name": config_name,
+                "family": "linear",
+                "library": "sklearn",
+                "model_class": "Lasso",
+                "params": {"alpha_frac": 0.5, "max_iter": 5000},
+            }
+        return {
+            "config_name": config_name,
+            "family": "linear",
+            "library": "sklearn",
+            "model_class": "Ridge",
+            "params": {"alpha": 1.0},
+        }
+
+    def observed_prepare(*args, **kwargs):
+        fold = original_prepare(*args, **kwargs)
+        assert fold is not None
+        prepared_folds.append(int(fold["fold"]))
+        return fold
+
+    monkeypatch.setattr(linear, "load_modeling_dataset", observed_load)
+    monkeypatch.setattr(linear, "_load_preset", load_preset)
+    monkeypatch.setattr(linear, "prepare_single_fold", observed_prepare, raising=False)
+    requests = [
+        study.model(family="linear", label="fwd_ret_1d", config_name=config_name)
+        for config_name in ("ridge", "lasso")
+    ]
+
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-linear-checkpoints",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
+    execution = plan.run()
+
+    assert loads == 1
+    assert prepared_folds == [0, 1, 0, 1]
+    assert tuple(run.training.hash for run in execution.runs) == plan.expected_training_hashes
+    assert (
+        tuple(prediction.hash for run in execution.runs for prediction in run.predictions)
+        == plan.expected_prediction_hashes
+    )
+    assert all(run.diagnostics["base_fold_preparations"] == 2 for run in execution.runs)
+    assert population.require_complete() == plan.expected_prediction_hashes
+
+
 def test_linear_batch_separates_incompatible_sampling_and_is_order_invariant(
     tmp_path, monkeypatch
 ) -> None:
@@ -1065,14 +1159,25 @@ def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
         )
         for alpha in (1.0, 2.0, 3.0)
     ]
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-linear-recovery",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
 
     with pytest.raises(RuntimeError, match="injected candidate failure"):
-        run_models(study, requests=requests)
+        plan.run()
 
     completed = study.predictions.table().filter(pl.col("complete"))
     assert completed.height == 2
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
     monkeypatch.setattr(linear.Ridge, "fit", original_fit)
-    recovered = run_models(study, requests=requests)
+    recovered_plan = plan_models(study, requests=requests)
+    assert recovered_plan.expected_prediction_hashes == plan.expected_prediction_hashes
+    recovered = recovered_plan.run()
     recovered_by_alpha = {
         run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"]["alpha"]: run
         for run in recovered.runs
@@ -1085,6 +1190,7 @@ def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
     assert recovered_by_alpha[2.0].diagnostics["base_fold_preparations"] == 1
     assert {run.diagnostics["base_fold_preparations"] for run in recovered.runs} == {1}
     assert study.predictions.table().filter(pl.col("complete")).height == 3
+    assert population.require_complete() == plan.expected_prediction_hashes
 
 
 def test_linear_batch_rejects_a_modified_fitted_preprocessor(tmp_path, monkeypatch) -> None:
@@ -1439,7 +1545,16 @@ def test_gbm_batch_is_fold_major_and_matches_individual_execution(tmp_path, monk
         for learning_rate in (0.1, 0.2)
     ]
 
-    batch = run_models(study, requests=requests)
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-gbm-checkpoints",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
+    batch = plan.run()
     batch_preparations = list(prepared)
     monkeypatch.setattr(gbm_utils, "prepare_gbm_folds", original_prepare)
     individual = (
@@ -1470,6 +1585,7 @@ def test_gbm_batch_is_fold_major_and_matches_individual_execution(tmp_path, monk
     assert all(run.diagnostics["compatibility_group_size"] == 2 for run in batch.runs)
     assert all(run.diagnostics["base_fold_preparations"] == 2 for run in batch.runs)
     assert all(run.diagnostics["disk_fold_cache"] is False for run in batch.runs)
+    assert population.require_complete() == plan.expected_prediction_hashes
 
 
 def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatch) -> None:
@@ -1640,13 +1756,24 @@ def test_gbm_batch_failure_preserves_siblings_and_completed_folds(tmp_path, monk
         )
         for rate in (0.1, 0.2, 0.3)
     ]
+    plan = plan_models(study, requests=requests)
+    population = OfficialPopulation.create(
+        study,
+        name="planned-gbm-recovery",
+        member_kind="prediction",
+        members=plan.expected_prediction_hashes,
+    )
 
     with pytest.raises(RuntimeError, match="injected GBM candidate failure"):
-        run_models(study, requests=requests)
+        plan.run()
 
     assert study.predictions.table().filter(pl.col("complete")).height == 4
+    with pytest.raises(ValueError, match="incomplete"):
+        population.require_complete()
     monkeypatch.setattr(gbm_utils, "train_gbm_config", original_train)
-    recovered = run_models(study, requests=requests)
+    recovered_plan = plan_models(study, requests=requests)
+    assert recovered_plan.expected_prediction_hashes == plan.expected_prediction_hashes
+    recovered = recovered_plan.run()
     recovered_by_rate = {
         run.training.spec()["computation"]["model"]["effective_params_by_fold"]["0"][
             "learning_rate"
@@ -1660,6 +1787,7 @@ def test_gbm_batch_failure_preserves_siblings_and_completed_folds(tmp_path, monk
     assert recovered_by_rate[0.2].diagnostics["fitted_folds"] == [1]
     assert {run.diagnostics["base_fold_preparations"] for run in recovered.runs} == {1}
     assert study.predictions.table().filter(pl.col("complete")).height == 6
+    assert population.require_complete() == plan.expected_prediction_hashes
 
 
 def test_gbm_batch_rejects_a_modified_booster(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -17,7 +17,6 @@ from case_studies.research import (
     CVSpec,
     LabelDefinition,
     ModelRun,
-    OfficialPopulation,
     Study,
     get_adapter,
     plan_models,
@@ -255,11 +254,8 @@ def test_tabm_public_batch_materializes_and_prepares_compatible_panel_once(
     ]
 
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-tabm-checkpoints",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
     assert loads == [("etfs", "fwd_ret_1d", 0)]
     assert conversions == 1
@@ -425,11 +421,8 @@ def test_tabm_candidate_failure_preserves_completed_sibling(tmp_path, monkeypatc
         for config_name in ("tabm_s", "tabm_m")
     ]
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-tabm-recovery",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
 
     with pytest.raises(RuntimeError, match="injected TabM candidate failure"):
@@ -1037,11 +1030,8 @@ def test_linear_model_plan_reuses_one_materialization_and_one_execution_fold_pas
     ]
 
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-linear-checkpoints",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
     with pytest.raises(ValueError, match="incomplete"):
         population.require_complete()
@@ -1160,11 +1150,8 @@ def test_linear_batch_failure_preserves_and_reuses_completed_candidate_folds(
         for alpha in (1.0, 2.0, 3.0)
     ]
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-linear-recovery",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
 
     with pytest.raises(RuntimeError, match="injected candidate failure"):
@@ -1546,11 +1533,8 @@ def test_gbm_batch_is_fold_major_and_matches_individual_execution(tmp_path, monk
     ]
 
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-gbm-checkpoints",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
     with pytest.raises(ValueError, match="incomplete"):
         population.require_complete()
@@ -1757,11 +1741,8 @@ def test_gbm_batch_failure_preserves_siblings_and_completed_folds(tmp_path, monk
         for rate in (0.1, 0.2, 0.3)
     ]
     plan = plan_models(study, requests=requests)
-    population = OfficialPopulation.create(
-        study,
+    population = plan.create_population(
         name="planned-gbm-recovery",
-        member_kind="prediction",
-        members=plan.expected_prediction_hashes,
     )
 
     with pytest.raises(RuntimeError, match="injected GBM candidate failure"):


### PR DESCRIPTION
## Scope

- Declare each complete training and checkpoint identity before fitting through the shared model plan.
- Preserve the existing linear, GBM, and TabM family implementations while reusing one compatible materialization and fold-major execution payload.
- Keep failed members visible in the official population, attempt later compatibility groups after a sibling group fails, and reuse completed candidate-fold work on restart.
- Return the completed prediction rows through the existing catalog. Preview plans cannot create official populations.
- Preserve the backtest-planning and catalog exports already on main. No disk cache is added.

This PR contains only the seven model-planning files named in the integration brief. It does not include a notebook or case-study source change.

## Verification

- Focused planner plus linear, GBM, and TabM planning, failure-isolation, and restart cases: 12 passed.
- Complete research model and contract modules: 120 passed.
- Configured non-notebook boundary: 2,013 passed, 21 skipped across isolated module invocations. The artifact-contract module used temporary read-only hard-linked staging because this worktree intentionally has no artifact symlinks. The current-main S&P 500 options module was run separately because it leaves its temporary output root process-active; all 11 tests passed.
- Changed-path Ruff format and lint: passed.
- Changed-path ty: exit 0, with six existing optional LightGBM/XGBoost stub warnings.
- Commit hooks and the pre-push RoboRev gate: passed.

No production notebook, model, backtest, render, or GPU job was run.