### PR TITLE
Validate the shared CME futures research gate

### DIFF
--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -449,6 +449,14 @@ def _resolved_signal(signal: dict[str, Any]) -> dict[str, Any]:
     return resolved
 
 
+def _resolved_allocation(allocation: dict[str, Any] | None) -> dict[str, Any] | None:
+    if allocation is None:
+        return None
+    resolved = dict(allocation)
+    resolved.setdefault("long_short", get_backtest_config(CASE_STUDY).long_short)
+    return resolved
+
+
 def resolve_product_weights(
     prediction: PredictionResult,
     *,
@@ -463,6 +471,7 @@ def resolve_product_weights(
         raise ValueError("reader-facing CME prices require product and cannot contain symbol")
     study = prediction.study
     signal = _resolved_signal(signal)
+    allocation = _resolved_allocation(allocation)
     unresolved = study.strategy(
         prediction=prediction,
         signal=signal,
@@ -530,6 +539,7 @@ def publish_product_weights(
 ) -> DecisionArtifact:
     """Publish validated CME weights with product, roll, expiry, and fold lineage."""
     signal = _resolved_signal(signal)
+    allocation = _resolved_allocation(allocation)
     weights = resolve_product_weights(
         prediction,
         prices=prices,
@@ -636,7 +646,7 @@ def run_official_backtest_requests(
         if selected.item(0, "label") != row["label"]:
             raise ValueError("strategy request label does not match its prediction catalog row")
         prediction = selected_prediction(study, selected.row(0, named=True))
-        allocation = row.get("allocation")
+        allocation = _resolved_allocation(row.get("allocation"))
         risk = row.get("risk")
         costs = row.get("costs")
         warmup = strategy_warmup_periods({"strategy": {"allocation": allocation}})

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -1,0 +1,667 @@
+"""Reader-facing model and futures-strategy workflow for CME futures."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import polars as pl
+import yaml
+
+from case_studies.research import (
+    BacktestResult,
+    CandidateSet,
+    DecisionArtifact,
+    OfficialPopulation,
+    PredictionResult,
+    Result,
+    StateTransitionPolicy,
+    Study,
+    run_backtests,
+    run_models,
+)
+from case_studies.research.execution import ModelExecution
+from case_studies.research.strategy import strategy_warmup_periods
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.backtest_loaders import load_backtest_prices_for
+from case_studies.utils.backtest_runner import precompute_weights
+from case_studies.utils.registry import prediction_hash_from_parts
+from data import load_cme_futures
+from utils.modeling import load_configs
+from utils.paths import REPO_ROOT
+
+CASE_STUDY = "cme_futures"
+ALL_LABELS = ("fwd_ret_5d", "fwd_ret_21d")
+FRONT_CONTRACT_POSITION = 0
+ROLL_POLICY = "volume_rolled_multiplicative_back_adjustment"
+EXPIRY_POLICY = "continuous_front_contract_rolls_before_delivery"
+MODEL_POPULATION_NAMES = (
+    "cme-linear-validation-v1",
+    "cme-gbm-validation-v1",
+    "cme-tabular-dl-validation-v1",
+    "cme-sequence-validation-v1",
+    "cme-pca-validation-v1",
+    "cme-sdf-validation-v1",
+)
+
+
+@dataclass(frozen=True)
+class FuturesPricePath:
+    """Reader-facing prices and the rows that establish their roll lineage."""
+
+    prices: pl.DataFrame
+    audit: pl.DataFrame
+    roll_transitions: pl.DataFrame
+    expiry_rules: pl.DataFrame
+
+
+@dataclass(frozen=True)
+class FuturesBacktestExecution:
+    results: tuple[BacktestResult, ...]
+    catalog_rows: pl.DataFrame
+    population: OfficialPopulation
+
+
+def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> Study:
+    """Open canonical regeneration or an isolated reader preview."""
+    if execution_tier == "canonical":
+        return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+    if execution_tier != "preview":
+        raise ValueError("execution_tier must be canonical or preview")
+    if workspace is None:
+        raise ValueError("preview execution requires an explicit workspace")
+    workspace = Path(workspace).expanduser().resolve()
+    try:
+        return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
+    except ValueError as error:
+        generated = tuple(
+            REPO_ROOT / "case_studies" / CASE_STUDY / name
+            for name in ("features", "labels", "run_log")
+        )
+        if "artifact bundle" not in str(error) or not all(path.is_symlink() for path in generated):
+            raise
+        workspace.mkdir(parents=True, exist_ok=True)
+        shared_config = workspace / "config"
+        if not shared_config.exists():
+            shared_config.symlink_to(
+                REPO_ROOT / "case_studies" / "config", target_is_directory=True
+            )
+        return Study(
+            case_study=CASE_STUDY,
+            root=REPO_ROOT / "case_studies" / CASE_STUDY,
+            release_root=REPO_ROOT,
+            output_root=workspace,
+            read_only=False,
+            manifest={
+                "schema_version": 1,
+                "case_study": CASE_STUDY,
+                "baseline_source_commit": subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True
+                ).strip(),
+                "preview_only": True,
+            },
+        )
+
+
+def model_request_catalog(
+    family: str,
+    *,
+    labels: Iterable[str] = ALL_LABELS,
+    config_names: Iterable[str] | None = None,
+) -> pl.DataFrame:
+    """Return the declared model population as visible Polars rows."""
+    selected = set(config_names) if config_names is not None else None
+    rows = []
+    for label in labels:
+        for config in load_configs(CASE_STUDY, label, family):
+            name = str(config["config_name"])
+            if selected is None or name in selected:
+                rows.append({"family": family, "label": label, "config_name": name})
+    if not rows:
+        raise ValueError(f"no declared requests for {family!r}")
+    return pl.DataFrame(rows).unique(maintain_order=True)
+
+
+def resolve_model_requests(
+    study: Study,
+    request_catalog: pl.DataFrame,
+    *,
+    execution_tier: str,
+    overrides: dict[str, Any] | None = None,
+    preview_reductions: dict[str, Any] | None = None,
+):
+    """Resolve visible catalog rows through the shared family boundary."""
+    required = {"family", "label", "config_name"}
+    missing = required - set(request_catalog.columns)
+    if missing:
+        raise ValueError(f"model request catalog is missing {sorted(missing)}")
+    return tuple(
+        study.model(
+            **row,
+            execution_tier=execution_tier,
+            overrides=dict(overrides or {}),
+            preview_reductions=dict(preview_reductions or {}),
+        ).resolve()
+        for row in request_catalog.select(*sorted(required)).iter_rows(named=True)
+    )
+
+
+def run_model_catalog(
+    study: Study,
+    request_catalog: pl.DataFrame,
+    *,
+    execution_tier: str,
+    overrides: dict[str, Any] | None = None,
+    preview_reductions: dict[str, Any] | None = None,
+) -> ModelExecution:
+    """Execute every visible model request and require complete catalog output."""
+    resolved = resolve_model_requests(
+        study,
+        request_catalog,
+        execution_tier=execution_tier,
+        overrides=overrides,
+        preview_reductions=preview_reductions,
+    )
+    execution = run_models(study, requests=resolved)
+    expected_rows = sum(len(run.predictions) for run in execution.runs)
+    if execution.catalog_rows.height != expected_rows:
+        raise RuntimeError("model execution did not return every checkpoint catalog row")
+    if execution.catalog_rows.filter(~pl.col("complete")).height:
+        raise RuntimeError("model execution returned incomplete prediction rows")
+    return execution
+
+
+def run_official_model_catalog(
+    study: Study,
+    request_catalog: pl.DataFrame,
+    *,
+    population_name: str,
+) -> tuple[ModelExecution, OfficialPopulation]:
+    """Snapshot and execute one complete canonical model population."""
+    resolved = resolve_model_requests(study, request_catalog, execution_tier="canonical")
+    expected = expected_prediction_hashes(resolved)
+    population = OfficialPopulation.create(
+        study,
+        name=population_name,
+        member_kind="prediction",
+        members=expected,
+    )
+    execution = run_models(study, requests=resolved)
+    actual = tuple(prediction.hash for run in execution.runs for prediction in run.predictions)
+    if set(actual) != set(expected) or len(actual) != len(expected):
+        missing = sorted(set(expected) - set(actual))
+        extra = sorted(set(actual) - set(expected))
+        raise RuntimeError(f"model population mismatch: missing={missing}, extra={extra}")
+    population.require_complete()
+    return execution, population
+
+
+def official_prediction_catalog(
+    study: Study,
+    population_names: Iterable[str],
+) -> pl.DataFrame:
+    """Return the exact complete catalog rows from declared official populations."""
+    members = []
+    for name in population_names:
+        population = OfficialPopulation.one(study, name=name)
+        if population.member_kind != "prediction":
+            raise ValueError(f"official population {name!r} does not contain predictions")
+        members.extend(population.require_complete())
+    if len(members) != len(set(members)):
+        raise ValueError("official prediction populations overlap")
+    catalog = study.predictions.table().filter(pl.col("prediction_hash").is_in(members))
+    if catalog.height != len(members) or catalog.filter(~pl.col("complete")).height:
+        raise ValueError("official prediction catalog is incomplete")
+    return catalog.sort("label", "family", "config_name", "checkpoint_kind", "checkpoint_value")
+
+
+def expected_prediction_hashes(resolved_requests) -> tuple[str, ...]:
+    """Project the declared checkpoint population to immutable prediction identities."""
+    hashes = []
+    for request in resolved_requests:
+        computation = request.spec.get("computation", request.spec)
+        for checkpoint in computation["checkpoint_schedule"]:
+            hashes.append(
+                prediction_hash_from_parts(
+                    request.identity,
+                    checkpoint["value"],
+                    "validation",
+                    checkpoint_kind=checkpoint["kind"],
+                    identity_version=request.spec["identity_version"],
+                )
+            )
+    if len(hashes) != len(set(hashes)):
+        raise ValueError("declared request population contains duplicate prediction identities")
+    return tuple(hashes)
+
+
+def _expiry_rules(products: list[str]) -> pl.DataFrame:
+    path = REPO_ROOT / "data" / "futures" / "market" / "futures_specs.yaml"
+    configured = yaml.safe_load(path.read_text())["products"]
+    missing = sorted(set(products) - set(configured))
+    if missing:
+        raise ValueError(f"products have no contract specification: {missing}")
+    rows = []
+    for product in products:
+        spec = configured[product]
+        if not spec.get("expiry_rule") or not spec.get("contract_months"):
+            raise ValueError(f"{product} has an incomplete expiry specification")
+        rows.append(
+            {
+                "product": product,
+                "expiry_rule": str(spec["expiry_rule"]),
+                "contract_months": ",".join(str(value) for value in spec["contract_months"]),
+            }
+        )
+    return pl.DataFrame(rows).sort("product")
+
+
+def load_futures_price_path(
+    label: str,
+    *,
+    split: Literal["validation", "holdout"] = "validation",
+    max_products: int = 0,
+    warmup_periods: int = 0,
+) -> FuturesPricePath:
+    """Load front-contract prices while retaining the rows that prove each roll."""
+    engine_prices = load_backtest_prices_for(
+        CASE_STUDY,
+        label,
+        split=split,
+        max_symbols=max_products,
+        warmup_periods=warmup_periods,
+    ).rename({"symbol": "product"})
+    price_keys = engine_prices.select("product", "timestamp").unique()
+    start = str(price_keys.get_column("timestamp").min())[:10]
+    end = str(price_keys.get_column("timestamp").max())[:10]
+    loaded_audit = load_cme_futures(
+        max_symbols=max_products,
+        start_date=start,
+        end_date=end,
+    )
+    audit = (
+        cast(pl.DataFrame, loaded_audit.collect())
+        if isinstance(loaded_audit, pl.LazyFrame)
+        else loaded_audit
+    )
+    audit = audit.rename({"session_date": "timestamp", "tenor": "position"})
+    required = {
+        "product",
+        "position",
+        "timestamp",
+        "adj_open",
+        "adj_high",
+        "adj_low",
+        "adj_close",
+        "raw_close",
+        "cum_ratio",
+    }
+    missing = required - set(audit.columns)
+    if missing:
+        raise ValueError(f"CME price source is missing columns: {sorted(missing)}")
+    audit = audit.filter(pl.col("position") == FRONT_CONTRACT_POSITION).with_columns(
+        pl.col("timestamp").cast(price_keys.schema["timestamp"]),
+        pl.col("product").cast(price_keys.schema["product"]),
+    )
+    audit = audit.join(price_keys, on=["product", "timestamp"], how="semi").sort(
+        "product", "timestamp"
+    )
+    if audit.n_unique(["product", "position", "timestamp"]) != audit.height:
+        raise ValueError("front-contract roll audit contains duplicate keys")
+    missing_audit = price_keys.join(
+        audit.select("product", "timestamp"), on=["product", "timestamp"], how="anti"
+    )
+    if not missing_audit.is_empty():
+        raise ValueError("backtest price keys are missing from the front-contract roll audit")
+    if (
+        audit.select(pl.col("cum_ratio").is_null().any()).item()
+        or audit.filter(pl.col("cum_ratio") <= 0).height
+    ):
+        raise ValueError("front-contract roll ratios must be finite positive values")
+    scale = pl.max_horizontal(pl.col("adj_close").abs(), pl.lit(1.0))
+    inconsistent = audit.filter(
+        (pl.col("adj_close") - pl.col("raw_close") * pl.col("cum_ratio")).abs() > scale * 1e-10
+    )
+    if not inconsistent.is_empty():
+        raise ValueError("roll-adjusted prices do not equal raw prices times the roll ratio")
+    previous_ratio = pl.col("cum_ratio").shift(1).over("product")
+    audit = audit.with_columns(
+        previous_ratio.alias("previous_cum_ratio"),
+        (previous_ratio.is_not_null() & (pl.col("cum_ratio") != previous_ratio)).alias(
+            "roll_transition"
+        ),
+    )
+    transitions = audit.filter(pl.col("roll_transition")).select(
+        "product",
+        "timestamp",
+        "raw_close",
+        "adj_close",
+        "previous_cum_ratio",
+        "cum_ratio",
+        (pl.col("cum_ratio") / pl.col("previous_cum_ratio")).alias("roll_adjustment_factor"),
+    )
+    products = sorted(audit.get_column("product").unique().to_list())
+    return FuturesPricePath(
+        prices=engine_prices.sort("timestamp", "product"),
+        audit=audit,
+        roll_transitions=transitions,
+        expiry_rules=_expiry_rules(products),
+    )
+
+
+def resolve_product_weights(
+    prediction: PredictionResult,
+    *,
+    prices: pl.DataFrame,
+    signal: dict[str, Any],
+    allocation: dict[str, Any] | None = None,
+    risk: dict[str, Any] | None = None,
+    costs: dict[str, Any] | None = None,
+) -> pl.DataFrame:
+    """Resolve built-in research decisions and return canonical product weights."""
+    if "product" not in prices.columns or "symbol" in prices.columns:
+        raise ValueError("reader-facing CME prices require product and cannot contain symbol")
+    study = prediction.study
+    unresolved = study.strategy(
+        prediction=prediction,
+        signal=signal,
+        allocation=allocation,
+        risk=risk,
+        costs=costs,
+    )
+    spec = unresolved.resolve(prices=prices)
+    engine_prices = prices.rename({"product": "symbol"})
+    weights = precompute_weights(
+        prediction.load(),
+        spec,
+        engine_prices,
+        label=unresolved.label,
+        case_study=CASE_STUDY,
+        prediction_hash=prediction.hash,
+    ).rename({"symbol": "product"})
+    prediction_frame = prediction.load()
+    entity_columns = [
+        column for column in ("symbol", "product") if column in prediction_frame.columns
+    ]
+    if len(entity_columns) != 1:
+        raise ValueError("CME predictions require exactly one entity key: symbol or product")
+    fold_columns = [column for column in ("fold", "fold_id") if column in prediction_frame.columns]
+    if len(fold_columns) != 1:
+        raise ValueError("CME predictions require exactly one fold key: fold or fold_id")
+    entity = entity_columns[0]
+    fold = fold_columns[0]
+    if entity == "symbol":
+        prediction_frame = prediction_frame.rename({"symbol": "product"})
+    prediction_frame = prediction_frame.with_columns(
+        pl.col("product").cast(weights.schema["product"]),
+        pl.col("timestamp").cast(weights.schema["timestamp"]),
+    )
+    fold_by_time = (
+        prediction_frame.select("timestamp", fold)
+        .unique()
+        .group_by("timestamp")
+        .agg(pl.col(fold).n_unique().alias("n_folds"), pl.col(fold).first().alias("fold"))
+    )
+    if fold_by_time.filter(pl.col("n_folds") != 1).height:
+        raise ValueError("each CME decision timestamp must belong to exactly one fold")
+    eligible = prediction_frame.select("product", "timestamp").unique()
+    missing = weights.select("product", "timestamp").join(
+        eligible, on=["product", "timestamp"], how="anti"
+    )
+    if not missing.is_empty():
+        raise ValueError("resolved CME decisions contain keys outside prediction eligibility")
+    return (
+        weights.join(fold_by_time.select("timestamp", "fold"), on="timestamp", how="left")
+        .select("product", "timestamp", "weight", "fold")
+        .sort("timestamp", "product")
+    )
+
+
+def publish_product_weights(
+    prediction: PredictionResult,
+    *,
+    prices: pl.DataFrame,
+    signal: dict[str, Any],
+    allocation: dict[str, Any] | None = None,
+    risk: dict[str, Any] | None = None,
+    costs: dict[str, Any] | None = None,
+    canonical: bool = False,
+) -> DecisionArtifact:
+    """Publish validated CME weights with product, roll, expiry, and fold lineage."""
+    weights = resolve_product_weights(
+        prediction,
+        prices=prices,
+        signal=signal,
+        allocation=allocation,
+        risk=risk,
+        costs=costs,
+    )
+    source_identity: dict[str, Any] | None = None
+    if canonical:
+        source_identity = {
+            "module": "case_studies.cme_futures.research_workflow",
+            "source_digest": hashlib.sha256(
+                inspect.getsource(resolve_product_weights).encode()
+            ).hexdigest(),
+            "declared_inputs": {
+                "prediction_hashes": [prediction.hash],
+                "prices": value_digest(prices),
+            },
+            "determinism": {"deterministic": True},
+            "clean_replay_digest": value_digest(weights),
+        }
+    return DecisionArtifact.publish(
+        prediction.study,
+        kind="target_weights",
+        decisions=weights,
+        prediction_hashes=[prediction.hash],
+        parameters={
+            "signal": signal,
+            "allocation": allocation,
+            "risk": risk,
+            "costs": costs,
+            "cadence": "7d",
+            "contract_position": FRONT_CONTRACT_POSITION,
+            "roll_policy": ROLL_POLICY,
+            "expiry_policy": EXPIRY_POLICY,
+        },
+        source_identity=source_identity,
+        state_transition_policy=StateTransitionPolicy(
+            fold_boundary="liquidate",
+            temporal_gap="continue",
+        ),
+        canonical=canonical,
+    )
+
+
+def selected_prediction(study: Study, catalog_row: dict[str, Any]) -> PredictionResult:
+    """Resolve one selected catalog row without exposing its hash to notebook control flow."""
+    result = Result.open(
+        study,
+        str(catalog_row["prediction_hash"]),
+        include_preview=catalog_row.get("execution_tier") == "preview",
+    )
+    if not isinstance(result, PredictionResult):
+        raise ValueError("selected catalog row does not identify a prediction")
+    return result
+
+
+def strategy_request_frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
+    """Build visible request rows while preserving each nested strategy dictionary."""
+    if not rows:
+        raise ValueError("strategy request rows cannot be empty")
+    nested = ("signal", "allocation", "risk", "costs")
+    scalar_rows = [{key: value for key, value in row.items() if key not in nested} for row in rows]
+    frame = pl.DataFrame(scalar_rows)
+    return frame.with_columns(
+        *(pl.Series(name, [row.get(name) for row in rows], dtype=pl.Object) for name in nested)
+    )
+
+
+def run_official_backtest_requests(
+    study: Study,
+    requests: pl.DataFrame,
+    *,
+    population_name: str,
+) -> FuturesBacktestExecution:
+    """Resolve, snapshot, and execute visible canonical futures strategy requests."""
+    required = {"request_name", "prediction_hash", "label", "signal"}
+    missing = required - set(requests.columns)
+    if missing:
+        raise ValueError(f"strategy requests are missing columns: {sorted(missing)}")
+    if requests.is_empty() or requests.get_column("request_name").n_unique() != requests.height:
+        raise ValueError("strategy request names must be non-empty and unique")
+    catalog = study.predictions.table()
+    price_cache: dict[tuple[str, int], FuturesPricePath] = {}
+    prepared = []
+    expected = []
+    for row in requests.iter_rows(named=True):
+        selected = catalog.filter(pl.col("prediction_hash") == row["prediction_hash"])
+        if selected.height != 1 or not selected.item(0, "complete"):
+            raise ValueError(
+                f"prediction {row['prediction_hash']!r} is absent, ambiguous, or incomplete"
+            )
+        if selected.item(0, "label") != row["label"]:
+            raise ValueError("strategy request label does not match its prediction catalog row")
+        prediction = selected_prediction(study, selected.row(0, named=True))
+        allocation = row.get("allocation")
+        risk = row.get("risk")
+        costs = row.get("costs")
+        warmup = strategy_warmup_periods({"strategy": {"allocation": allocation}})
+        cache_key = (str(row["label"]), warmup)
+        if cache_key not in price_cache:
+            price_cache[cache_key] = load_futures_price_path(
+                str(row["label"]),
+                split="validation",
+                warmup_periods=warmup,
+            )
+        price_path = price_cache[cache_key]
+        decision = publish_product_weights(
+            prediction,
+            prices=price_path.prices,
+            signal=row["signal"],
+            allocation=allocation,
+            risk=risk,
+            costs=costs,
+            canonical=True,
+        )
+        strategy = study.strategy(
+            prediction=prediction,
+            signal=row["signal"],
+            decision=decision,
+            allocation=allocation,
+            risk=risk,
+            costs=costs,
+            chapter=row.get("chapter"),
+        )
+        expected_hash = strategy.identity(prices=price_path.prices)
+        expected.append(expected_hash)
+        prepared.append((row, selected, price_path, decision, expected_hash))
+    if len(expected) != len(set(expected)):
+        raise ValueError("strategy requests resolve to duplicate backtest identities")
+    population = OfficialPopulation.create(
+        study,
+        name=population_name,
+        member_kind="backtest",
+        members=expected,
+    )
+    results = []
+    rows = []
+    for row, selected, price_path, decision, expected_hash in prepared:
+        result = run_backtests(
+            study,
+            predictions=selected,
+            signal=row["signal"],
+            prices=price_path.prices,
+            allocation=row.get("allocation"),
+            risk=row.get("risk"),
+            costs=row.get("costs"),
+            chapter=row.get("chapter"),
+            decision=decision,
+        ).results[0]
+        if result.hash != expected_hash:
+            raise RuntimeError(f"backtest identity changed: {expected_hash} -> {result.hash}")
+        results.append(result)
+        rows.append(
+            {
+                "request_name": row["request_name"],
+                "label": row["label"],
+                "prediction_hash": row["prediction_hash"],
+                "decision_hash": decision.hash,
+                "backtest_hash": result.hash,
+                "complete": result.complete,
+            }
+        )
+    if tuple(result.hash for result in results) != tuple(expected):
+        raise RuntimeError("backtest execution did not preserve declared request order")
+    population.require_complete()
+    return FuturesBacktestExecution(tuple(results), pl.DataFrame(rows), population)
+
+
+def create_label_candidate_sets(
+    study: Study,
+    execution: FuturesBacktestExecution,
+    *,
+    name_prefix: str,
+) -> dict[str, CandidateSet]:
+    """Create one immutable comparable backtest set per label."""
+    labels = execution.catalog_rows.get_column("label").unique().sort().to_list()
+    output = {}
+    for label in labels:
+        hashes = execution.catalog_rows.filter(pl.col("label") == label).get_column("backtest_hash")
+        members_by_hash = {result.hash: result for result in execution.results}
+        members = [members_by_hash[value] for value in hashes]
+        output[label] = CandidateSet.create(
+            study,
+            f"{name_prefix}-{label}-v1",
+            members,
+        )
+    return output
+
+
+def shortlist_signal_configurations(
+    study: Study,
+    *,
+    label: str,
+    limit: int,
+) -> tuple[BacktestResult, ...]:
+    """Select the strongest signal result for each distinct model configuration."""
+    candidates = CandidateSet.one(study, name=f"cme-signal-{label}-v1")
+    selected = []
+    configurations = set()
+    for result in candidates.ranked_validation_sharpe():
+        assert isinstance(result, BacktestResult)
+        training = result.lineage()["training_spec"]
+        key = (training["family"], training.get("config_name"))
+        if key in configurations:
+            continue
+        configurations.add(key)
+        selected.append(result)
+        if len(selected) == limit:
+            break
+    if len(selected) != limit:
+        raise ValueError(
+            f"signal population has {len(selected)} distinct configurations, expected {limit}"
+        )
+    return tuple(selected)
+
+
+def pre_overlay_candidate_set(study: Study, *, label: str) -> CandidateSet:
+    """Return the immutable union of signal and allocation validation results."""
+    signal = CandidateSet.one(study, name=f"cme-signal-{label}-v1")
+    allocation = CandidateSet.one(study, name=f"cme-allocation-{label}-v1")
+    members = [Result.open(study, value) for value in (*signal.members, *allocation.members)]
+    return CandidateSet.create(study, f"cme-pre-overlay-{label}-v1", members)
+
+
+def final_validation_candidate_set(study: Study, *, label: str) -> CandidateSet:
+    """Return the selection pool across signal, allocation, and risk-overlay stages."""
+    pre_overlay = pre_overlay_candidate_set(study, label=label)
+    risk = CandidateSet.one(study, name=f"cme-risk-{label}-v1")
+    members = [Result.open(study, value) for value in (*pre_overlay.members, *risk.members)]
+    return CandidateSet.create(study, f"cme-final-validation-{label}-v1", members)

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -30,7 +30,7 @@ from case_studies.research import (
 from case_studies.research.execution import ModelExecution
 from case_studies.research.strategy import strategy_warmup_periods
 from case_studies.utils.artifact_digest import value_digest
-from case_studies.utils.backtest_loaders import load_backtest_prices_for
+from case_studies.utils.backtest_loaders import get_backtest_config, load_backtest_prices_for
 from case_studies.utils.backtest_runner import precompute_weights
 from case_studies.utils.registry import prediction_hash_from_parts
 from data import load_cme_futures
@@ -119,11 +119,19 @@ def model_request_catalog(
     """Return the declared model population as visible Polars rows."""
     selected = set(config_names) if config_names is not None else None
     rows = []
+    missing_by_label = {}
     for label in labels:
-        for config in load_configs(CASE_STUDY, label, family):
+        configs = load_configs(CASE_STUDY, label, family)
+        available = {str(config["config_name"]) for config in configs}
+        missing = sorted((selected or set()) - available)
+        if missing:
+            missing_by_label[label] = missing
+        for config in configs:
             name = str(config["config_name"])
             if selected is None or name in selected:
                 rows.append({"family": family, "label": label, "config_name": name})
+    if missing_by_label:
+        raise ValueError(f"unknown {family!r} configurations by label: {missing_by_label}")
     if not rows:
         raise ValueError(f"no declared requests for {family!r}")
     return pl.DataFrame(rows).unique(maintain_order=True)
@@ -223,7 +231,7 @@ def resolved_model_plan(resolved_requests: Iterable[ResolvedModelRequest]) -> pl
     """Show the data, folds, checkpoints, and eligibility each request will use."""
     rows = []
     for request in resolved_requests:
-        computation = request.spec["computation"]
+        computation = request.spec.get("computation", request.spec)
         expected = request._context.expected_keys
         entity = next(
             (column for column in ("product", "symbol") if column in expected.columns),
@@ -424,6 +432,12 @@ def load_futures_price_path(
     )
 
 
+def _resolved_signal(signal: dict[str, Any]) -> dict[str, Any]:
+    resolved = dict(signal)
+    resolved.setdefault("long_short", get_backtest_config(CASE_STUDY).long_short)
+    return resolved
+
+
 def resolve_product_weights(
     prediction: PredictionResult,
     *,
@@ -437,6 +451,7 @@ def resolve_product_weights(
     if "product" not in prices.columns or "symbol" in prices.columns:
         raise ValueError("reader-facing CME prices require product and cannot contain symbol")
     study = prediction.study
+    signal = _resolved_signal(signal)
     unresolved = study.strategy(
         prediction=prediction,
         signal=signal,
@@ -503,6 +518,7 @@ def publish_product_weights(
     canonical: bool = False,
 ) -> DecisionArtifact:
     """Publish validated CME weights with product, roll, expiry, and fold lineage."""
+    signal = _resolved_signal(signal)
     weights = resolve_product_weights(
         prediction,
         prices=prices,
@@ -513,6 +529,16 @@ def publish_product_weights(
     )
     source_identity: dict[str, Any] | None = None
     if canonical:
+        replay = resolve_product_weights(
+            prediction,
+            prices=prices,
+            signal=signal,
+            allocation=allocation,
+            risk=risk,
+            costs=costs,
+        )
+        if value_digest(replay) != value_digest(weights):
+            raise RuntimeError("canonical CME decision replay was not deterministic")
         source_identity = {
             "module": "case_studies.cme_futures.research_workflow",
             "source_digest": hashlib.sha256(
@@ -523,7 +549,7 @@ def publish_product_weights(
                 "prices": value_digest(prices),
             },
             "determinism": {"deterministic": True},
-            "clean_replay_digest": value_digest(weights),
+            "clean_replay_digest": value_digest(replay),
         }
     return DecisionArtifact.publish(
         prediction.study,
@@ -611,10 +637,11 @@ def run_official_backtest_requests(
                 warmup_periods=warmup,
             )
         price_path = price_cache[cache_key]
+        signal = _resolved_signal(row["signal"])
         decision = publish_product_weights(
             prediction,
             prices=price_path.prices,
-            signal=row["signal"],
+            signal=signal,
             allocation=allocation,
             risk=risk,
             costs=costs,
@@ -623,7 +650,7 @@ def run_official_backtest_requests(
         plan = plan_backtests(
             study,
             predictions=selected,
-            signal=row["signal"],
+            signal=signal,
             decision=decision,
             prices=price_path.prices,
             allocation=allocation,
@@ -635,7 +662,7 @@ def run_official_backtest_requests(
             raise RuntimeError("one futures strategy request must resolve to one backtest")
         expected_hash = plan.expected_hashes[0]
         expected.append(expected_hash)
-        prepared.append((row, selected, price_path, decision, expected_hash))
+        prepared.append((row, selected, price_path, signal, decision, expected_hash))
     if len(expected) != len(set(expected)):
         raise ValueError("strategy requests resolve to duplicate backtest identities")
     population = OfficialPopulation.create(
@@ -646,11 +673,11 @@ def run_official_backtest_requests(
     )
     results = []
     rows = []
-    for row, selected, price_path, decision, expected_hash in prepared:
+    for row, selected, price_path, signal, decision, expected_hash in prepared:
         result = run_backtests(
             study,
             predictions=selected,
-            signal=row["signal"],
+            signal=signal,
             prices=price_path.prices,
             allocation=row.get("allocation"),
             risk=row.get("risk"),

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -344,9 +344,13 @@ def load_futures_price_path(
     *,
     split: Literal["validation", "holdout"] = "validation",
     max_products: int = 0,
+    products: Iterable[str] | None = None,
     warmup_periods: int = 0,
 ) -> FuturesPricePath:
     """Load front-contract prices while retaining the rows that prove each roll."""
+    selected_products = sorted(set(products or ()))
+    if max_products and selected_products:
+        raise ValueError("select CME prices by max_products or products, not both")
     engine_prices = load_backtest_prices_for(
         CASE_STUDY,
         label,
@@ -354,10 +358,17 @@ def load_futures_price_path(
         max_symbols=max_products,
         warmup_periods=warmup_periods,
     ).rename({"symbol": "product"})
+    if selected_products:
+        engine_prices = engine_prices.filter(pl.col("product").is_in(selected_products))
+        loaded_products = set(engine_prices.get_column("product"))
+        missing_products = sorted(set(selected_products) - loaded_products)
+        if missing_products:
+            raise ValueError(f"selected CME products have no backtest prices: {missing_products}")
     price_keys = engine_prices.select("product", "timestamp").unique()
     start = str(price_keys.get_column("timestamp").min())[:10]
     end = str(price_keys.get_column("timestamp").max())[:10]
     loaded_audit = load_cme_futures(
+        products=selected_products or None,
         max_symbols=max_products,
         start_date=start,
         end_date=end,

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -19,6 +19,7 @@ from case_studies.research import (
     DecisionArtifact,
     OfficialPopulation,
     PredictionResult,
+    ResolvedModelRequest,
     Result,
     StateTransitionPolicy,
     Study,
@@ -134,7 +135,7 @@ def resolve_model_requests(
     execution_tier: str,
     overrides: dict[str, Any] | None = None,
     preview_reductions: dict[str, Any] | None = None,
-):
+) -> tuple[ResolvedModelRequest, ...]:
     """Resolve visible catalog rows through the shared family boundary."""
     required = {"family", "label", "config_name"}
     missing = required - set(request_catalog.columns)
@@ -167,6 +168,17 @@ def run_model_catalog(
         overrides=overrides,
         preview_reductions=preview_reductions,
     )
+    return run_resolved_model_requests(study, resolved)
+
+
+def run_resolved_model_requests(
+    study: Study,
+    resolved_requests: Iterable[ResolvedModelRequest],
+) -> ModelExecution:
+    """Execute already-resolved requests without loading their input artifacts again."""
+    resolved = tuple(resolved_requests)
+    if not resolved:
+        raise ValueError("resolved model requests cannot be empty")
     execution = run_models(study, requests=resolved)
     expected_rows = sum(len(run.predictions) for run in execution.runs)
     if execution.catalog_rows.height != expected_rows:
@@ -181,9 +193,14 @@ def run_official_model_catalog(
     request_catalog: pl.DataFrame,
     *,
     population_name: str,
+    resolved_requests: Iterable[ResolvedModelRequest] | None = None,
 ) -> tuple[ModelExecution, OfficialPopulation]:
     """Snapshot and execute one complete canonical model population."""
-    resolved = resolve_model_requests(study, request_catalog, execution_tier="canonical")
+    resolved = tuple(resolved_requests or ())
+    if not resolved:
+        resolved = resolve_model_requests(study, request_catalog, execution_tier="canonical")
+    if any(request.spec["execution_tier"] != "canonical" for request in resolved):
+        raise ValueError("official model populations require canonical requests")
     expected = expected_prediction_hashes(resolved)
     population = OfficialPopulation.create(
         study,
@@ -191,7 +208,7 @@ def run_official_model_catalog(
         member_kind="prediction",
         members=expected,
     )
-    execution = run_models(study, requests=resolved)
+    execution = run_resolved_model_requests(study, resolved)
     actual = tuple(prediction.hash for run in execution.runs for prediction in run.predictions)
     if set(actual) != set(expected) or len(actual) != len(expected):
         missing = sorted(set(expected) - set(actual))
@@ -199,6 +216,58 @@ def run_official_model_catalog(
         raise RuntimeError(f"model population mismatch: missing={missing}, extra={extra}")
     population.require_complete()
     return execution, population
+
+
+def resolved_model_plan(resolved_requests: Iterable[ResolvedModelRequest]) -> pl.DataFrame:
+    """Show the data, folds, checkpoints, and eligibility each request will use."""
+    rows = []
+    for request in resolved_requests:
+        computation = request.spec["computation"]
+        expected = request._context.expected_keys
+        entity = next(
+            (column for column in ("product", "symbol") if column in expected.columns),
+            None,
+        )
+        fold = next((column for column in ("fold", "fold_id") if column in expected.columns), None)
+        if entity is None or fold is None:
+            raise ValueError("resolved model eligibility has no entity or fold key")
+        timestamps = expected.get_column("timestamp")
+        rows.append(
+            {
+                "family": request.family,
+                "label": request.spec["label"],
+                "config_name": request.spec.get("config_name"),
+                "task": (computation.get("task") or {}).get("type", "regression"),
+                "feature_count": len(computation.get("feature_names") or []),
+                "eligible_entities": expected.get_column(entity).n_unique(),
+                "eligible_rows": expected.height,
+                "folds": expected.get_column(fold).n_unique(),
+                "validation_start": timestamps.min(),
+                "validation_end": timestamps.max(),
+                "checkpoints": len(computation["checkpoint_schedule"]),
+                "execution_tier": request.spec["execution_tier"],
+                "training_hash": request.identity,
+            }
+        )
+    return pl.DataFrame(rows).sort("label", "family", "config_name")
+
+
+def product_universe_table() -> pl.DataFrame:
+    """Return the configured CME product groups with expiry references."""
+    setup = yaml.safe_load(
+        (REPO_ROOT / "case_studies" / CASE_STUDY / "config" / "setup.yaml").read_text()
+    )
+    rows = [
+        {"sector": sector, "product": product}
+        for sector, products in setup["universe"]["product_groups"].items()
+        for product in products
+    ]
+    universe = pl.DataFrame(rows)
+    return universe.join(
+        _expiry_rules(universe.get_column("product").to_list()),
+        on="product",
+        how="left",
+    ).sort("sector", "product")
 
 
 def official_prediction_catalog(

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -23,6 +23,7 @@ from case_studies.research import (
     Result,
     StateTransitionPolicy,
     Study,
+    plan_backtests,
     run_backtests,
     run_models,
 )
@@ -619,16 +620,20 @@ def run_official_backtest_requests(
             costs=costs,
             canonical=True,
         )
-        strategy = study.strategy(
-            prediction=prediction,
+        plan = plan_backtests(
+            study,
+            predictions=selected,
             signal=row["signal"],
             decision=decision,
+            prices=price_path.prices,
             allocation=allocation,
             risk=risk,
             costs=costs,
             chapter=row.get("chapter"),
         )
-        expected_hash = strategy.identity(prices=price_path.prices)
+        if len(plan.members) != 1:
+            raise RuntimeError("one futures strategy request must resolve to one backtest")
+        expected_hash = plan.expected_hashes[0]
         expected.append(expected_hash)
         prepared.append((row, selected, price_path, decision, expected_hash))
     if len(expected) != len(set(expected)):

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -683,7 +683,7 @@ def run_official_backtest_requests(
             raise RuntimeError("one futures strategy request must resolve to one backtest")
         expected_hash = plan.expected_hashes[0]
         expected.append(expected_hash)
-        prepared.append((row, selected, price_path, signal, decision, expected_hash))
+        prepared.append((row, selected, price_path, signal, allocation, decision, expected_hash))
     if len(expected) != len(set(expected)):
         raise ValueError("strategy requests resolve to duplicate backtest identities")
     population = OfficialPopulation.create(
@@ -694,13 +694,13 @@ def run_official_backtest_requests(
     )
     results = []
     rows = []
-    for row, selected, price_path, signal, decision, expected_hash in prepared:
+    for row, selected, price_path, signal, allocation, decision, expected_hash in prepared:
         result = run_backtests(
             study,
             predictions=selected,
             signal=signal,
             prices=price_path.prices,
-            allocation=row.get("allocation"),
+            allocation=allocation,
             risk=row.get("risk"),
             costs=row.get("costs"),
             chapter=row.get("chapter"),

--- a/case_studies/research/decisions.py
+++ b/case_studies/research/decisions.py
@@ -40,6 +40,13 @@ class StateTransitionPolicy:
             raise ValueError(f"state transitions must be one of {sorted(allowed)}")
 
 
+def _decision_entity_key(decisions: pl.DataFrame) -> str:
+    entity_keys = [column for column in ("symbol", "product") if column in decisions.columns]
+    if len(entity_keys) != 1:
+        raise ValueError("decision artifacts require exactly one entity key: symbol or product")
+    return entity_keys[0]
+
+
 def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
     value_column = {
         "target_weights": "weight",
@@ -49,7 +56,7 @@ def _validate_frame(kind: str, decisions: pl.DataFrame) -> tuple[str, ...]:
     }.get(kind)
     if value_column is None:
         raise ValueError("unsupported decision artifact kind")
-    keys = ("symbol", "timestamp")
+    keys = (_decision_entity_key(decisions), "timestamp")
     required = {*keys, value_column}
     missing = required - set(decisions.columns)
     if missing:

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -16,6 +16,7 @@ from case_studies.utils.backtest_loaders import (
     get_backtest_config,
     load_backtest_prices_for,
     load_contract_specs_from_yaml,
+    load_futures_market_contract,
 )
 from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
 from case_studies.utils.backtest_runner import run_backtest
@@ -263,19 +264,41 @@ class Strategy:
         allocation = self._resolved_allocation()
         return strategy_warmup_periods({"allocation": allocation}) if allocation else 0
 
+    def _engine_prices(
+        self,
+        prices: pl.DataFrame,
+        *,
+        reader_supplied: bool,
+    ) -> pl.DataFrame:
+        if self.study.case_study != "cme_futures":
+            return prices
+        if "product" in prices.columns and "symbol" in prices.columns:
+            raise ValueError("CME prices cannot contain both product and symbol")
+        if "product" in prices.columns:
+            return prices.rename({"product": "symbol"})
+        if reader_supplied or "symbol" not in prices.columns:
+            raise ValueError("CME prices require the canonical product entity key")
+        return prices
+
     def resolve(self, *, prices: pl.DataFrame | None = None) -> dict[str, Any]:
         self.study.activate(ExecutionTier(self.prediction.execution_tier))
         if self.split == "holdout" and prices is not None:
             raise ValueError("locked holdout strategy must load canonical holdout prices")
         case_config = get_backtest_config(self.study.case_study)
+        reader_supplied = prices is not None
         resolved_prices = prices
-        if resolved_prices is None:
+        if not reader_supplied:
             resolved_prices = load_backtest_prices_for(
                 self.study.case_study,
                 self.label,
                 split=self.split,
                 warmup_periods=self._warmup_periods(),
             )
+        assert resolved_prices is not None
+        resolved_prices = self._engine_prices(
+            resolved_prices,
+            reader_supplied=reader_supplied,
+        )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
         )
@@ -345,6 +368,8 @@ class Strategy:
             spec["decision_artifact"] = {
                 "hash": self.decision.hash,
                 "kind": self.decision.kind,
+                "decision_keys": self.decision.spec["decision_keys"],
+                "parameters": self.decision.spec["parameters"],
                 "artifact_digest": self.decision.spec["artifact_digest"],
                 "canonical": self.decision.canonical,
                 "source_identity": self.decision.spec["source_identity"],
@@ -363,6 +388,15 @@ class Strategy:
                 symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
             }
             spec["input_identity"]["contract_specs"] = compute_hash(canonical_json(serialized))
+            products = prices.get_column("symbol").unique().sort().to_list()
+            futures_market = load_futures_market_contract(products)
+            spec["input_identity"]["futures_market"] = compute_hash(canonical_json(futures_market))
+            spec["futures_market"] = futures_market
+            spec["entity_contract"] = {
+                "reader_key": "product",
+                "engine_key": "symbol",
+                "mapping": "one_to_one_at_backtest_boundary",
+            }
         resolved = ensure_conformal_calibration_identity(spec)
         if self.split == "holdout":
             from .lifecycle import _locked_strategy_projection
@@ -395,23 +429,35 @@ class Strategy:
         if self.decision is None:
             return None
         decisions = self.decision.load()
+        decision_keys = tuple(self.decision.spec.get("decision_keys") or ())
+        if len(decision_keys) != 2 or decision_keys[1] != "timestamp":
+            raise ValueError("decision artifact has an invalid key contract")
+        entity_key = decision_keys[0]
+        if entity_key not in {"symbol", "product"}:
+            raise ValueError(f"unsupported decision entity key {entity_key!r}")
+        if self.study.case_study == "cme_futures" and entity_key != "product":
+            raise ValueError("CME futures decisions require the canonical product entity key")
+        if self.study.case_study != "cme_futures" and entity_key != "symbol":
+            raise ValueError(
+                f"{self.study.case_study} decisions require the canonical symbol entity key"
+            )
         fold_columns = [column for column in ("fold", "fold_id") if column in decisions.columns]
         if len(fold_columns) > 1:
             raise ValueError("decision artifact cannot contain both fold and fold_id")
         fold_column = fold_columns[0] if fold_columns else None
         selected_fold = [fold_column] if fold_column else []
         if self.decision.kind == "target_weights":
-            weights = decisions.select("symbol", "timestamp", "weight", *selected_fold)
+            weights = decisions.select(entity_key, "timestamp", "weight", *selected_fold)
         elif self.decision.kind == "target_positions":
             weights = decisions.select(
-                "symbol", "timestamp", "position", *selected_fold
+                entity_key, "timestamp", "position", *selected_fold
             ).with_columns(pl.col("position").abs().sum().over("timestamp").alias("gross"))
             weights = weights.with_columns(
                 pl.when(pl.col("gross") > 0)
                 .then(pl.col("position") / pl.col("gross"))
                 .otherwise(0.0)
                 .alias("weight")
-            ).select("symbol", "timestamp", "weight", *selected_fold)
+            ).select(entity_key, "timestamp", "weight", *selected_fold)
         elif self.decision.kind == "short_straddles":
             if self.study.case_study != "sp500_options" or self.label != "ret_to_expiry":
                 raise ValueError("short-straddle decisions require sp500_options and ret_to_expiry")
@@ -433,6 +479,8 @@ class Strategy:
             weights = decisions
         else:
             raise ValueError("canonical backtesting does not support order decision artifacts")
+        if entity_key == "product":
+            weights = weights.rename({"product": "symbol"})
         if fold_column == "fold_id":
             weights = weights.rename({"fold_id": "fold"})
         price_keys = prices.select("symbol", "timestamp").unique()
@@ -472,15 +520,21 @@ class Strategy:
         if self.split == "holdout" and prices is not None:
             raise ValueError("locked holdout strategy must load canonical holdout prices")
         predictions = self.prediction.load()
+        reader_supplied = prices is not None
         resolved_prices = prices
         self.study.activate(ExecutionTier(self.prediction.execution_tier))
-        if resolved_prices is None:
+        if not reader_supplied:
             resolved_prices = load_backtest_prices_for(
                 self.study.case_study,
                 self.label,
                 split=self.split,
                 warmup_periods=self._warmup_periods(),
             )
+        assert resolved_prices is not None
+        resolved_prices = self._engine_prices(
+            resolved_prices,
+            reader_supplied=reader_supplied,
+        )
         contract_specs = (
             load_contract_specs_from_yaml() if self.study.case_study == "cme_futures" else None
         )

--- a/case_studies/utils/backtest_loaders.py
+++ b/case_studies/utils/backtest_loaders.py
@@ -183,6 +183,45 @@ def load_contract_specs_from_yaml(yaml_path: Path | None = None):
     return specs
 
 
+def load_futures_market_contract(products: list[str]) -> dict:
+    """Resolve the reader-visible roll and expiry contract for CME products."""
+    repo_root = Path(__file__).resolve().parents[2]
+    market_config = yaml.safe_load(
+        (repo_root / "data" / "futures" / "market" / "config.yaml").read_text()
+    )
+    product_specs = yaml.safe_load(
+        (repo_root / "data" / "futures" / "market" / "futures_specs.yaml").read_text()
+    )["products"]
+    if market_config.get("roll_type") != "v":
+        raise ValueError("CME backtesting requires the volume-rolled continuous series")
+    missing = sorted(set(products) - set(product_specs))
+    if missing:
+        raise ValueError(f"CME products have no expiry specification: {missing}")
+    expiry = {}
+    for product in sorted(set(products)):
+        spec = product_specs[product]
+        if not spec.get("expiry_rule") or not spec.get("contract_months"):
+            raise ValueError(f"{product} has an incomplete expiry specification")
+        expiry[product] = {
+            "contract_months": list(spec["contract_months"]),
+            "expiry_rule": str(spec["expiry_rule"]),
+        }
+    return {
+        "entity_key": "product",
+        "contract_position": 0,
+        "roll": {
+            "type": "volume",
+            "decision_information": "previous_session_volume",
+            "adjustment": "multiplicative_ratio",
+            "price_identity": "adj_close=raw_close*cum_ratio",
+        },
+        "expiry": {
+            "engine_behavior": "continuous_front_contract_has_no_delivery_event",
+            "products": expiry,
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # Prediction loading
 # ---------------------------------------------------------------------------

--- a/scripts/prove_cme_futures_interface.py
+++ b/scripts/prove_cme_futures_interface.py
@@ -124,12 +124,12 @@ def prove(workspace: Path) -> dict[str, object]:
         assert prediction.hash not in canonical_catalog.get_column("prediction_hash").to_list()
     _reject_preview_population(study, member_kind="prediction", member_hash=prediction.hash)
 
+    products = set(actual.get_column("product"))
     price_path = load_futures_price_path(
         "fwd_ret_5d",
         split="validation",
-        max_products=6,
+        products=sorted(products),
     )
-    products = set(actual.get_column("product"))
     assert set(price_path.prices.get_column("product")) == products
     assert "symbol" not in price_path.prices.columns
     assert price_path.audit.get_column("position").unique().to_list() == [0]

--- a/scripts/prove_cme_futures_interface.py
+++ b/scripts/prove_cme_futures_interface.py
@@ -1,0 +1,216 @@
+"""Run the reduced real-data proof for the CME futures research interface."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.cme_futures.research_workflow import (
+    load_futures_price_path,
+    model_request_catalog,
+    open_study,
+    publish_product_weights,
+    resolve_model_requests,
+    run_model_catalog,
+)
+from case_studies.research import CandidateSet, OfficialPopulation
+from case_studies.research.execution import run_backtests
+from case_studies.utils.artifact_digest import value_digest
+
+CASE_STUDY = "cme_futures"
+
+
+def _product_keys(frame: pl.DataFrame) -> pl.DataFrame:
+    entity_columns = [column for column in ("symbol", "product") if column in frame.columns]
+    fold_columns = [column for column in ("fold", "fold_id") if column in frame.columns]
+    if len(entity_columns) != 1 or len(fold_columns) != 1:
+        raise ValueError("prediction eligibility requires one entity key and one fold key")
+    result = frame.select(entity_columns[0], "timestamp", fold_columns[0])
+    return result.rename({entity_columns[0]: "product", fold_columns[0]: "fold"})
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fitted_state_rows(study, training_hash: str) -> list[tuple]:
+    root = study.storage_root("preview")
+    with sqlite3.connect(root / "run_log" / "registry.db") as db:
+        rows = db.execute(
+            "SELECT fold_id, fitted_state_path, fitted_state_digest, "
+            "prediction_shard_path, prediction_shard_digest "
+            "FROM candidate_fold_completions WHERE training_hash = ? ORDER BY fold_id",
+            (training_hash,),
+        ).fetchall()
+    if not rows:
+        raise AssertionError("reduced model run persisted no fitted-state rows")
+    for _, fitted_path, fitted_digest, shard_path, shard_digest in rows:
+        fitted = root / fitted_path
+        shard = root / shard_path
+        assert fitted.is_file() and _sha256(fitted) == fitted_digest
+        assert shard.is_file() and _sha256(shard) == shard_digest
+    return rows
+
+
+def _returns(result) -> pl.DataFrame:
+    path = result.root / "run_log" / "backtest" / result.hash / "daily_returns.parquet"
+    return pl.read_parquet(path)
+
+
+def _reject_preview_population(study, *, member_kind: str, member_hash: str) -> None:
+    try:
+        OfficialPopulation.create(
+            study,
+            name=f"preview-{member_kind}-must-not-enter-official",
+            member_kind=member_kind,
+            members=[member_hash],
+        )
+    except ValueError as error:
+        assert "preview" in str(error) or "exploratory" in str(error)
+    else:
+        raise AssertionError(f"preview {member_kind} entered an official population")
+
+
+def prove(workspace: Path) -> dict[str, object]:
+    study = open_study(execution_tier="preview", workspace=workspace)
+    request_catalog = model_request_catalog(
+        "linear",
+        labels=("fwd_ret_5d",),
+        config_names=("ols",),
+    )
+    preview_reductions = {"folds": [0], "max_symbols": 6}
+    resolved = resolve_model_requests(
+        study,
+        request_catalog,
+        execution_tier="preview",
+        preview_reductions=preview_reductions,
+    )[0]
+    assert resolved.spec["computation"]["preview_reductions"] == preview_reductions
+
+    execution = run_model_catalog(
+        study,
+        request_catalog,
+        execution_tier="preview",
+        preview_reductions=preview_reductions,
+    )
+    run = execution.runs[0]
+    prediction = run.predictions[-1]
+    prediction_frame = prediction.load()
+    expected = _product_keys(resolved._context.expected_keys)
+    actual = _product_keys(prediction_frame)
+    key_columns = ["product", "timestamp", "fold"]
+    assert actual.height == actual.n_unique(key_columns)
+    assert actual.join(expected, on=key_columns, how="anti").is_empty()
+    assert expected.join(actual, on=key_columns, how="anti").is_empty()
+    assert actual.get_column("fold").unique().to_list() == [0]
+    assert 1 < actual.get_column("product").n_unique() <= 6
+    coverage = prediction.coverage()
+    assert coverage is not None and coverage["status"] == "complete"
+    assert coverage["n_expected"] == coverage["n_actual"] == actual.height
+    state_rows = _fitted_state_rows(study, run.training.hash)
+
+    restarted = run_model_catalog(
+        study,
+        request_catalog,
+        execution_tier="preview",
+        preview_reductions=preview_reductions,
+    ).runs[0]
+    assert restarted.training.hash == run.training.hash
+    assert [item.hash for item in restarted.predictions] == [item.hash for item in run.predictions]
+    assert value_digest(restarted.predictions[-1].load()) == value_digest(prediction_frame)
+    assert _fitted_state_rows(study, restarted.training.hash) == state_rows
+
+    preview_catalog = study.predictions.table(include_preview=True)
+    canonical_catalog = study.predictions.table(include_preview=False)
+    selected = preview_catalog.filter(pl.col("prediction_hash") == prediction.hash)
+    assert selected.height == 1 and selected.item(0, "complete") is True
+    if not canonical_catalog.is_empty():
+        assert prediction.hash not in canonical_catalog.get_column("prediction_hash").to_list()
+    _reject_preview_population(study, member_kind="prediction", member_hash=prediction.hash)
+
+    price_path = load_futures_price_path(
+        "fwd_ret_5d",
+        split="validation",
+        max_products=6,
+    )
+    products = set(actual.get_column("product"))
+    assert set(price_path.prices.get_column("product")) == products
+    assert "symbol" not in price_path.prices.columns
+    assert price_path.audit.get_column("position").unique().to_list() == [0]
+    assert price_path.roll_transitions.height > 0
+    assert price_path.roll_transitions.get_column("roll_adjustment_factor").is_finite().all()
+    assert set(price_path.expiry_rules.get_column("product")) == products
+
+    signal = {"method": "equal_weight_top_k", "top_k": 2}
+    decision = publish_product_weights(
+        prediction,
+        prices=price_path.prices,
+        signal=signal,
+    )
+    assert decision.spec["decision_keys"] == ["product", "timestamp"]
+    typed = run_backtests(
+        study,
+        predictions=selected,
+        signal=signal,
+        decision=decision,
+        prices=price_path.prices,
+    ).results[0]
+    direct = study.strategy(prediction=prediction, signal=signal).run(prices=price_path.prices)
+    assert _returns(typed).equals(_returns(direct))
+    typed_spec = typed.spec()
+    assert typed_spec["entity_contract"]["reader_key"] == "product"
+    assert typed_spec["decision_artifact"]["hash"] == decision.hash
+    assert typed_spec["decision_artifact"]["decision_keys"] == ["product", "timestamp"]
+    assert typed_spec["futures_market"]["roll"]["type"] == "volume"
+    assert typed_spec["futures_market"]["contract_position"] == 0
+    assert set(typed_spec["futures_market"]["expiry"]["products"]) == products
+    assert typed.lineage()["prediction_hash"] == prediction.hash
+    backtest_dir = typed.root / "run_log" / "backtest" / typed.hash
+    fills = pl.read_parquet(backtest_dir / "fills.parquet")
+    assert fills.height > 0
+    with sqlite3.connect(typed.root / "run_log" / "registry.db") as db:
+        metrics = db.execute(
+            "SELECT sharpe, num_trades FROM backtest_metrics WHERE backtest_hash = ?",
+            (typed.hash,),
+        ).fetchone()
+    assert metrics is not None
+    sharpe, num_trades = metrics
+    assert math.isfinite(sharpe) and num_trades > 0
+    try:
+        CandidateSet.create(study, "preview-backtest-must-not-rank", [typed])
+    except ValueError as error:
+        assert "preview" in str(error) or "exploratory" in str(error)
+    else:
+        raise AssertionError("preview backtest entered a candidate set")
+    _reject_preview_population(study, member_kind="backtest", member_hash=typed.hash)
+
+    return {
+        "backtest_hash": typed.hash,
+        "eligible_rows": actual.height,
+        "fitted_state_rows": len(state_rows),
+        "num_fills": fills.height,
+        "num_products": len(products),
+        "num_trades": int(num_trades),
+        "prediction_hash": prediction.hash,
+        "roll_transitions": price_path.roll_transitions.height,
+        "sharpe": float(sharpe),
+        "training_hash": run.training.hash,
+        "workspace": str(study.storage_root("preview")),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workspace", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(prove(args.workspace), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prove_cme_futures_interface.py
+++ b/scripts/prove_cme_futures_interface.py
@@ -144,14 +144,20 @@ def prove(workspace: Path) -> dict[str, object]:
         signal=signal,
     )
     assert decision.spec["decision_keys"] == ["product", "timestamp"]
+    resolved_signal = decision.spec["parameters"]["signal"]
+    assert resolved_signal["long_short"] is True
+    assert decision.load().filter(pl.col("weight") < 0).height > 0
+    assert decision.load().filter(pl.col("weight") > 0).height > 0
     typed = run_backtests(
         study,
         predictions=selected,
-        signal=signal,
+        signal=resolved_signal,
         decision=decision,
         prices=price_path.prices,
     ).results[0]
-    direct = study.strategy(prediction=prediction, signal=signal).run(prices=price_path.prices)
+    direct = study.strategy(prediction=prediction, signal=resolved_signal).run(
+        prices=price_path.prices
+    )
     assert _returns(typed).equals(_returns(direct))
     typed_spec = typed.spec()
     assert typed_spec["entity_contract"]["reader_key"] == "product"

--- a/scripts/prove_cme_futures_interface.py
+++ b/scripts/prove_cme_futures_interface.py
@@ -138,26 +138,33 @@ def prove(workspace: Path) -> dict[str, object]:
     assert set(price_path.expiry_rules.get_column("product")) == products
 
     signal = {"method": "equal_weight_top_k", "top_k": 2}
+    allocation = {"method": "inverse_vol", "vol_window": 20}
     decision = publish_product_weights(
         prediction,
         prices=price_path.prices,
         signal=signal,
+        allocation=allocation,
     )
     assert decision.spec["decision_keys"] == ["product", "timestamp"]
     resolved_signal = decision.spec["parameters"]["signal"]
+    resolved_allocation = decision.spec["parameters"]["allocation"]
     assert resolved_signal["long_short"] is True
+    assert resolved_allocation["long_short"] is True
     assert decision.load().filter(pl.col("weight") < 0).height > 0
     assert decision.load().filter(pl.col("weight") > 0).height > 0
     typed = run_backtests(
         study,
         predictions=selected,
         signal=resolved_signal,
+        allocation=resolved_allocation,
         decision=decision,
         prices=price_path.prices,
     ).results[0]
-    direct = study.strategy(prediction=prediction, signal=resolved_signal).run(
-        prices=price_path.prices
-    )
+    direct = study.strategy(
+        prediction=prediction,
+        signal=resolved_signal,
+        allocation=resolved_allocation,
+    ).run(prices=price_path.prices)
     assert _returns(typed).equals(_returns(direct))
     typed_spec = typed.spec()
     assert typed_spec["entity_contract"]["reader_key"] == "product"

--- a/scripts/prove_cme_futures_interface.py
+++ b/scripts/prove_cme_futures_interface.py
@@ -17,7 +17,7 @@ from case_studies.cme_futures.research_workflow import (
     open_study,
     publish_product_weights,
     resolve_model_requests,
-    run_model_catalog,
+    run_resolved_model_requests,
 )
 from case_studies.research import CandidateSet, OfficialPopulation
 from case_studies.research.execution import run_backtests
@@ -93,12 +93,7 @@ def prove(workspace: Path) -> dict[str, object]:
     )[0]
     assert resolved.spec["computation"]["preview_reductions"] == preview_reductions
 
-    execution = run_model_catalog(
-        study,
-        request_catalog,
-        execution_tier="preview",
-        preview_reductions=preview_reductions,
-    )
+    execution = run_resolved_model_requests(study, [resolved])
     run = execution.runs[0]
     prediction = run.predictions[-1]
     prediction_frame = prediction.load()
@@ -115,12 +110,7 @@ def prove(workspace: Path) -> dict[str, object]:
     assert coverage["n_expected"] == coverage["n_actual"] == actual.height
     state_rows = _fitted_state_rows(study, run.training.hash)
 
-    restarted = run_model_catalog(
-        study,
-        request_catalog,
-        execution_tier="preview",
-        preview_reductions=preview_reductions,
-    ).runs[0]
+    restarted = run_resolved_model_requests(study, [resolved]).runs[0]
     assert restarted.training.hash == run.training.hash
     assert [item.hash for item in restarted.predictions] == [item.hash for item in run.predictions]
     assert value_digest(restarted.predictions[-1].load()) == value_digest(prediction_frame)

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -13,6 +13,7 @@ from case_studies.cme_futures.research_workflow import (
     FuturesPricePath,
     _expiry_rules,
     create_label_candidate_sets,
+    model_request_catalog,
     product_universe_table,
     publish_product_weights,
     resolved_model_plan,
@@ -132,20 +133,24 @@ def test_product_decision_matches_existing_futures_engine_path(tmp_path: Path) -
     prices = _product_prices()
     signal = {"method": "equal_weight_top_k", "top_k": 1}
 
-    direct = study.strategy(prediction=prediction, signal=signal).run(prices=prices)
     decision = publish_product_weights(
         prediction,
         prices=prices,
         signal=signal,
     )
+    resolved_signal = decision.spec["parameters"]["signal"]
+    direct = study.strategy(prediction=prediction, signal=resolved_signal).run(prices=prices)
     typed = study.strategy(
         prediction=prediction,
-        signal=signal,
+        signal=resolved_signal,
         decision=decision,
     ).run(prices=prices)
 
     assert decision.spec["decision_keys"] == ["product", "timestamp"]
     assert decision.load().columns == ["product", "timestamp", "weight", "fold"]
+    assert decision.spec["parameters"]["signal"]["long_short"] is True
+    assert decision.load().filter(pl.col("weight") < 0).height > 0
+    assert decision.load().filter(pl.col("weight") > 0).height > 0
     assert typed.spec()["entity_contract"] == {
         "reader_key": "product",
         "engine_key": "symbol",
@@ -272,6 +277,77 @@ def test_reader_plan_exposes_resolved_population_and_product_contract(tmp_path: 
     assert universe.get_column("product").n_unique() == 30
     assert universe.select(pl.col("expiry_rule").is_null().any()).item() is False
     assert universe.select(pl.col("contract_months").is_null().any()).item() is False
+
+
+def test_reader_plan_accepts_flat_family_spec(tmp_path: Path) -> None:
+    expected = pl.DataFrame(
+        {
+            "symbol": ["ES", "NQ"],
+            "timestamp": [datetime(2024, 1, 2), datetime(2024, 1, 2)],
+            "fold": [0, 0],
+        }
+    )
+    nested = _resolved_spec()
+    computation = nested.pop("computation")
+    spec = {**nested, **computation}
+    spec.update(
+        {
+            "identity_version": 2,
+            "label": "fwd_ret_5d",
+            "execution_tier": "preview",
+            "checkpoint_schedule": [{"kind": "epoch", "value": 2}],
+        }
+    )
+    request = ResolvedModelRequest(
+        study=_study(tmp_path),
+        family="deep_learning",
+        spec=spec,
+        _context=SimpleNamespace(expected_keys=expected),
+    )
+
+    plan = resolved_model_plan([request])
+
+    assert plan.item(0, "family") == "deep_learning"
+    assert plan.item(0, "checkpoints") == len(spec["checkpoint_schedule"])
+
+
+def test_model_request_catalog_rejects_each_unknown_requested_config() -> None:
+    with pytest.raises(ValueError, match="missing"):
+        model_request_catalog(
+            "linear",
+            labels=("fwd_ret_5d",),
+            config_names=("ols", "missing"),
+        )
+
+
+def test_canonical_decision_rejects_divergent_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from case_studies.cme_futures import research_workflow
+
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    prices = _product_prices()
+    original = research_workflow.resolve_product_weights
+    calls = 0
+
+    def divergent_replay(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        weights = original(*args, **kwargs)
+        if calls == 2:
+            weights = weights.with_columns((pl.col("weight") + 0.01).alias("weight"))
+        return weights
+
+    monkeypatch.setattr(research_workflow, "resolve_product_weights", divergent_replay)
+
+    with pytest.raises(RuntimeError, match="not deterministic"):
+        research_workflow.publish_product_weights(
+            prediction,
+            prices=prices,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            canonical=True,
+        )
 
 
 def test_visible_requests_snapshot_complete_canonical_backtests(

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -296,6 +297,24 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
         expiry_rules=_expiry_rules(["ES", "NQ"]),
     )
     monkeypatch.setattr(research_workflow, "load_futures_price_path", lambda *args, **kwargs: path)
+    original_run_backtests = research_workflow.run_backtests
+    backtest_calls = 0
+
+    def run_after_population_snapshot(*args, **kwargs):
+        nonlocal backtest_calls
+        population = research_workflow.OfficialPopulation.one(
+            study,
+            name="test-cme-signal",
+        )
+        assert len(population.members) == 2
+        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+            completed = db.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0]
+        assert completed == backtest_calls
+        result = original_run_backtests(*args, **kwargs)
+        backtest_calls += 1
+        return result
+
+    monkeypatch.setattr(research_workflow, "run_backtests", run_after_population_snapshot)
     requests = strategy_request_frame(
         [
             {
@@ -328,6 +347,7 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
     )
 
     assert execution.catalog_rows.get_column("complete").to_list() == [True, True]
+    assert backtest_calls == 2
     assert execution.population.require_complete() == tuple(
         execution.catalog_rows.get_column("backtest_hash")
     )

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -11,6 +11,7 @@ import pytest
 from case_studies.cme_futures.research_workflow import (
     FuturesPricePath,
     _expiry_rules,
+    create_label_candidate_sets,
     product_universe_table,
     publish_product_weights,
     resolved_model_plan,
@@ -82,8 +83,8 @@ def _prediction(study: Study):
     )
 
 
-def _current_prediction(study: Study):
-    training = study.results.register_training(_resolved_spec())
+def _current_prediction(study: Study, *, alpha: float = 1.0):
+    training = study.results.register_training(_resolved_spec(alpha=alpha))
     dates = pl.date_range(pl.date(2024, 1, 2), pl.date(2024, 1, 5), eager=True)
     frame = pl.DataFrame(
         {
@@ -279,6 +280,7 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
 
     study = _study(tmp_path)
     prediction = _current_prediction(study)
+    second_prediction = _current_prediction(study, alpha=2.0)
     prices = _product_prices()
     path = FuturesPricePath(
         prices=prices,
@@ -305,7 +307,17 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
                 "risk": None,
                 "costs": None,
                 "chapter": "ch16",
-            }
+            },
+            {
+                "request_name": "ridge-alpha2-equal-weight-k1",
+                "prediction_hash": second_prediction.hash,
+                "label": "fwd_ret_21d",
+                "signal": {"method": "equal_weight_top_k", "top_k": 1},
+                "allocation": None,
+                "risk": None,
+                "costs": None,
+                "chapter": "ch16",
+            },
         ]
     )
 
@@ -315,8 +327,17 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
         population_name="test-cme-signal",
     )
 
-    assert execution.catalog_rows.get_column("complete").to_list() == [True]
+    assert execution.catalog_rows.get_column("complete").to_list() == [True, True]
     assert execution.population.require_complete() == tuple(
         execution.catalog_rows.get_column("backtest_hash")
     )
     assert execution.results[0].spec()["decision_artifact"]["canonical"] is True
+    candidate_sets = create_label_candidate_sets(
+        study,
+        execution,
+        name_prefix="test-cme-signal",
+    )
+    assert set(candidate_sets) == {"fwd_ret_21d"}
+    assert set(candidate_sets["fwd_ret_21d"].members) == set(
+        execution.catalog_rows.get_column("backtest_hash")
+    )

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.cme_futures.research_workflow import (
+    FuturesPricePath,
+    _expiry_rules,
+    publish_product_weights,
+    run_official_backtest_requests,
+    strategy_request_frame,
+)
+from case_studies.research import DecisionArtifact, StateTransitionPolicy, Study
+from case_studies.utils.registry.store import _open_registry
+from tests.test_research_contract_catalog import _resolved_spec
+from tests.test_research_registry import _training_spec
+from utils.paths import REPO_ROOT
+
+
+@pytest.fixture(autouse=True)
+def _restore_output_root():
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+    from case_studies.research import workspace
+
+    workspace._ACTIVE_OUTPUT_ROOT = None
+    workspace._clear_root_sensitive_caches()
+
+
+def _study(tmp_path: Path) -> Study:
+    output_root = tmp_path / "workspace"
+    root = output_root / "cme_futures"
+    root.mkdir(parents=True)
+    (root / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "cme_futures" / "config", target_is_directory=True
+    )
+    (output_root / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "config", target_is_directory=True
+    )
+    _open_registry(root).close()
+    return Study(
+        case_study="cme_futures",
+        root=root,
+        release_root=tmp_path / "release",
+        output_root=output_root,
+        read_only=False,
+        manifest={"schema_version": 1, "case_study": "cme_futures"},
+    )
+
+
+def _prediction(study: Study):
+    training = study.results.register_training(_training_spec(label="fwd_ret_5d"))
+    dates = pl.date_range(pl.date(2024, 1, 2), pl.date(2024, 1, 5), eager=True)
+    frame = pl.DataFrame(
+        {
+            "symbol": [product for timestamp in dates for product in ("ES", "NQ")],
+            "timestamp": [timestamp for timestamp in dates for _ in range(2)],
+            "fold_id": [0] * (2 * len(dates)),
+            "y_true": [0.01, -0.01] * len(dates),
+            "y_score": [0.02, -0.02] * len(dates),
+        }
+    )
+    return study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+
+
+def _current_prediction(study: Study):
+    training = study.results.register_training(_resolved_spec())
+    dates = pl.date_range(pl.date(2024, 1, 2), pl.date(2024, 1, 5), eager=True)
+    frame = pl.DataFrame(
+        {
+            "symbol": [product for timestamp in dates for product in ("ES", "NQ")],
+            "timestamp": [timestamp for timestamp in dates for _ in range(2)],
+            "fold": [0] * (2 * len(dates)),
+            "actual": [0.01, -0.01] * len(dates),
+            "prediction": [0.02, -0.02] * len(dates),
+        }
+    )
+    return study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold"),
+    )
+
+
+def _product_prices() -> pl.DataFrame:
+    dates = pl.date_range(pl.date(2024, 1, 2), pl.date(2024, 1, 5), eager=True)
+    return pl.DataFrame(
+        {
+            "product": [product for timestamp in dates for product in ("ES", "NQ")],
+            "timestamp": [timestamp for timestamp in dates for _ in range(2)],
+            "open": [4_800.0, 16_800.0, 4_810.0, 16_820.0] * 2,
+            "high": [4_820.0, 16_850.0, 4_830.0, 16_870.0] * 2,
+            "low": [4_780.0, 16_750.0, 4_790.0, 16_770.0] * 2,
+            "close": [4_810.0, 16_820.0, 4_820.0, 16_840.0] * 2,
+            "volume": [1_000] * (2 * len(dates)),
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("ms")))
+
+
+def _returns(result) -> pl.DataFrame:
+    path = result.root / "run_log" / "backtest" / result.hash / "daily_returns.parquet"
+    return pl.read_parquet(path)
+
+
+def test_product_decision_matches_existing_futures_engine_path(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    prices = _product_prices()
+    signal = {"method": "equal_weight_top_k", "top_k": 1}
+
+    direct = study.strategy(prediction=prediction, signal=signal).run(prices=prices)
+    decision = publish_product_weights(
+        prediction,
+        prices=prices,
+        signal=signal,
+    )
+    typed = study.strategy(
+        prediction=prediction,
+        signal=signal,
+        decision=decision,
+    ).run(prices=prices)
+
+    assert decision.spec["decision_keys"] == ["product", "timestamp"]
+    assert decision.load().columns == ["product", "timestamp", "weight", "fold"]
+    assert typed.spec()["entity_contract"] == {
+        "reader_key": "product",
+        "engine_key": "symbol",
+        "mapping": "one_to_one_at_backtest_boundary",
+    }
+    assert typed.spec()["decision_artifact"]["decision_keys"] == ["product", "timestamp"]
+    assert typed.spec()["decision_artifact"]["parameters"]["contract_position"] == 0
+    assert typed.spec()["futures_market"]["roll"]["type"] == "volume"
+    assert typed.spec()["futures_market"]["expiry"]["products"] == {
+        "ES": {"contract_months": ["H", "M", "U", "Z"], "expiry_rule": "3rd_friday"},
+        "NQ": {"contract_months": ["H", "M", "U", "Z"], "expiry_rule": "3rd_friday"},
+    }
+    assert _returns(typed).equals(_returns(direct))
+
+
+def test_cme_strategy_rejects_symbol_decisions(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+    prices = _product_prices()
+    decisions = (
+        prediction.load().select("symbol", "timestamp").with_columns(pl.lit(0.5).alias("weight"))
+    )
+    artifact = DecisionArtifact.publish(
+        study,
+        kind="target_weights",
+        decisions=decisions,
+        prediction_hashes=[prediction.hash],
+        parameters={"cadence": "7d"},
+        state_transition_policy=StateTransitionPolicy(
+            fold_boundary="liquidate",
+            temporal_gap="continue",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="canonical product entity key"):
+        study.strategy(
+            prediction=prediction,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+            decision=artifact,
+        ).resolve(prices=prices)
+
+
+def test_cme_strategy_rejects_reader_supplied_symbol_prices(tmp_path: Path) -> None:
+    study = _study(tmp_path)
+    prediction = _prediction(study)
+
+    with pytest.raises(ValueError, match="canonical product entity key"):
+        study.strategy(
+            prediction=prediction,
+            signal={"method": "equal_weight_top_k", "top_k": 1},
+        ).resolve(prices=_product_prices().rename({"product": "symbol"}))
+
+
+def test_expiry_rules_are_complete_for_requested_products() -> None:
+    rules = _expiry_rules(["ES", "CL"])
+
+    assert rules.get_column("product").to_list() == ["CL", "ES"]
+    assert all(rules.get_column("expiry_rule").str.len_chars() > 0)
+    assert all(rules.get_column("contract_months").str.len_chars() > 0)
+
+
+def test_visible_requests_snapshot_complete_canonical_backtests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from case_studies.cme_futures import research_workflow
+
+    study = _study(tmp_path)
+    prediction = _current_prediction(study)
+    prices = _product_prices()
+    path = FuturesPricePath(
+        prices=prices,
+        audit=pl.DataFrame(
+            {
+                "product": ["ES", "NQ"],
+                "position": [0, 0],
+                "timestamp": [prices.item(0, "timestamp"), prices.item(1, "timestamp")],
+                "cum_ratio": [1.0, 1.0],
+            }
+        ),
+        roll_transitions=pl.DataFrame(),
+        expiry_rules=_expiry_rules(["ES", "NQ"]),
+    )
+    monkeypatch.setattr(research_workflow, "load_futures_price_path", lambda *args, **kwargs: path)
+    requests = strategy_request_frame(
+        [
+            {
+                "request_name": "ridge-equal-weight-k1",
+                "prediction_hash": prediction.hash,
+                "label": "fwd_ret_21d",
+                "signal": {"method": "equal_weight_top_k", "top_k": 1},
+                "allocation": None,
+                "risk": None,
+                "costs": None,
+                "chapter": "ch16",
+            }
+        ]
+    )
+
+    execution = run_official_backtest_requests(
+        study,
+        requests,
+        population_name="test-cme-signal",
+    )
+
+    assert execution.catalog_rows.get_column("complete").to_list() == [True]
+    assert execution.population.require_complete() == tuple(
+        execution.catalog_rows.get_column("backtest_hash")
+    )
+    assert execution.results[0].spec()["decision_artifact"]["canonical"] is True

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -407,7 +407,7 @@ def test_visible_requests_snapshot_complete_canonical_backtests(
                 "prediction_hash": prediction.hash,
                 "label": "fwd_ret_21d",
                 "signal": {"method": "equal_weight_top_k", "top_k": 1},
-                "allocation": None,
+                "allocation": {"method": "inverse_vol", "vol_window": 2},
                 "risk": None,
                 "costs": None,
                 "chapter": "ch16",

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -132,23 +132,32 @@ def test_product_decision_matches_existing_futures_engine_path(tmp_path: Path) -
     prediction = _prediction(study)
     prices = _product_prices()
     signal = {"method": "equal_weight_top_k", "top_k": 1}
+    allocation = {"method": "inverse_vol", "vol_window": 2}
 
     decision = publish_product_weights(
         prediction,
         prices=prices,
         signal=signal,
+        allocation=allocation,
     )
     resolved_signal = decision.spec["parameters"]["signal"]
-    direct = study.strategy(prediction=prediction, signal=resolved_signal).run(prices=prices)
+    resolved_allocation = decision.spec["parameters"]["allocation"]
+    direct = study.strategy(
+        prediction=prediction,
+        signal=resolved_signal,
+        allocation=resolved_allocation,
+    ).run(prices=prices)
     typed = study.strategy(
         prediction=prediction,
         signal=resolved_signal,
+        allocation=resolved_allocation,
         decision=decision,
     ).run(prices=prices)
 
     assert decision.spec["decision_keys"] == ["product", "timestamp"]
     assert decision.load().columns == ["product", "timestamp", "weight", "fold"]
     assert decision.spec["parameters"]["signal"]["long_short"] is True
+    assert decision.spec["parameters"]["allocation"]["long_short"] is True
     assert decision.load().filter(pl.col("weight") < 0).height > 0
     assert decision.load().filter(pl.col("weight") > 0).height > 0
     assert typed.spec()["entity_contract"] == {

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
 import pytest
@@ -9,11 +11,18 @@ import pytest
 from case_studies.cme_futures.research_workflow import (
     FuturesPricePath,
     _expiry_rules,
+    product_universe_table,
     publish_product_weights,
+    resolved_model_plan,
     run_official_backtest_requests,
     strategy_request_frame,
 )
-from case_studies.research import DecisionArtifact, StateTransitionPolicy, Study
+from case_studies.research import (
+    DecisionArtifact,
+    ResolvedModelRequest,
+    StateTransitionPolicy,
+    Study,
+)
 from case_studies.utils.registry.store import _open_registry
 from tests.test_research_contract_catalog import _resolved_spec
 from tests.test_research_registry import _training_spec
@@ -194,6 +203,73 @@ def test_expiry_rules_are_complete_for_requested_products() -> None:
     assert rules.get_column("product").to_list() == ["CL", "ES"]
     assert all(rules.get_column("expiry_rule").str.len_chars() > 0)
     assert all(rules.get_column("contract_months").str.len_chars() > 0)
+
+
+def test_reader_plan_exposes_resolved_population_and_product_contract(tmp_path: Path) -> None:
+    expected = pl.DataFrame(
+        {
+            "symbol": ["ES", "NQ", "ES", "NQ"],
+            "timestamp": [
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 2),
+                datetime(2024, 2, 2),
+                datetime(2024, 2, 2),
+            ],
+            "fold": [0, 0, 1, 1],
+        }
+    )
+    spec = _resolved_spec()
+    spec["label"] = "fwd_ret_5d"
+    spec["execution_tier"] = "preview"
+    spec["computation"].update(
+        {
+            "task": {"type": "regression"},
+            "feature_names": ["carry", "momentum"],
+            "checkpoint_schedule": [
+                {"kind": "final", "value": None},
+                {"kind": "epoch", "value": 10},
+            ],
+        }
+    )
+    request = ResolvedModelRequest(
+        study=_study(tmp_path),
+        family="linear",
+        spec=spec,
+        _context=SimpleNamespace(expected_keys=expected),
+    )
+
+    plan = resolved_model_plan([request])
+    universe = product_universe_table()
+
+    assert plan.select(
+        "family",
+        "label",
+        "config_name",
+        "task",
+        "feature_count",
+        "eligible_entities",
+        "eligible_rows",
+        "folds",
+        "checkpoints",
+        "execution_tier",
+        "training_hash",
+    ).row(0) == (
+        "linear",
+        "fwd_ret_5d",
+        "ridge",
+        "regression",
+        2,
+        2,
+        4,
+        2,
+        2,
+        "preview",
+        request.identity,
+    )
+    assert universe.height == 30
+    assert universe.get_column("product").n_unique() == 30
+    assert universe.select(pl.col("expiry_rule").is_null().any()).item() is False
+    assert universe.select(pl.col("contract_months").is_null().any()).item() is False
 
 
 def test_visible_requests_snapshot_complete_canonical_backtests(


### PR DESCRIPTION
## What changed

- Add the reader-facing CME research workflow and reduced real-data proof.
- Preserve canonical `product` keys through typed decisions and convert to `symbol` only at the existing engine boundary.
- Materialize the configured long-short state through signal selection, allocation, population planning, and execution.
- Validate expiry rules, front-contract roll transitions, decision replay, prediction eligibility, catalog selection, population completeness, and restart reuse.
- Support visible nested and flat model-family plans and reject partial named model populations.

## Root cause

The existing futures path exposed engine-facing symbol keys and implicit defaults to notebooks. Independent preview truncations could select different products, canonical replay evidence reused the published frame, and official allocation execution could diverge from its planned identity.

## Validation

- 48 research contract, CME futures, and S&P 500 options tests pass.
- Ruff and ty pass for the changed research boundary and proof.
- Automated commit review reports no issues on `e8c603da`.
- Reduced real-data OLS proof: 1,512 eligible rows, six products, one fitted-state fold, 327 roll transitions, 243 fills, and 125 trades.
- Initial run: 7.70 seconds wall time and 2,040,816 KiB maximum RSS.
- Separate restart process: 5.31 seconds wall time and 2,038,588 KiB maximum RSS.
- Both processes produced training `873b30cef90b`, prediction `06fb93fa0c46`, decision `c1544839c96c`, and typed backtest `5bc2cfe48871` with matching metrics and fitted-state digests.
- Preview proof artifacts were excluded from official populations and candidate sets.
