### PR TITLE
Sample CME futures products once and guard roll ratios

### DIFF
--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -364,12 +364,14 @@ def load_futures_price_path(
         missing_products = sorted(set(selected_products) - loaded_products)
         if missing_products:
             raise ValueError(f"selected CME products have no backtest prices: {missing_products}")
+    resolved_products = sorted(engine_prices.get_column("product").unique().to_list())
+    if not resolved_products:
+        raise ValueError(f"CME backtest prices for {label!r} resolved to no products")
     price_keys = engine_prices.select("product", "timestamp").unique()
     start = str(price_keys.get_column("timestamp").min())[:10]
     end = str(price_keys.get_column("timestamp").max())[:10]
     loaded_audit = load_cme_futures(
-        products=selected_products or None,
-        max_symbols=max_products,
+        products=resolved_products,
         start_date=start,
         end_date=end,
     )
@@ -407,10 +409,11 @@ def load_futures_price_path(
     )
     if not missing_audit.is_empty():
         raise ValueError("backtest price keys are missing from the front-contract roll audit")
-    if (
-        audit.select(pl.col("cum_ratio").is_null().any()).item()
-        or audit.filter(pl.col("cum_ratio") <= 0).height
-    ):
+    ratio = pl.col("cum_ratio").cast(pl.Float64)
+    invalid_ratio = audit.filter(
+        ratio.is_null() | ratio.is_nan() | ratio.is_infinite() | (ratio <= 0)
+    )
+    if not invalid_ratio.is_empty():
         raise ValueError("front-contract roll ratios must be finite positive values")
     scale = pl.max_horizontal(pl.col("adj_close").abs(), pl.lit(1.0))
     inconsistent = audit.filter(
@@ -434,12 +437,11 @@ def load_futures_price_path(
         "cum_ratio",
         (pl.col("cum_ratio") / pl.col("previous_cum_ratio")).alias("roll_adjustment_factor"),
     )
-    products = sorted(audit.get_column("product").unique().to_list())
     return FuturesPricePath(
         prices=engine_prices.sort("timestamp", "product"),
         audit=audit,
         roll_transitions=transitions,
-        expiry_rules=_expiry_rules(products),
+        expiry_rules=_expiry_rules(resolved_products),
     )
 
 

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -284,10 +284,12 @@ def _stub_price_loaders(
     *,
     engine_products: list[str],
     cum_ratio: float = 1.0,
-) -> list[dict[str, object]]:
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    engine_calls: list[dict[str, object]] = []
     audit_calls: list[dict[str, object]] = []
 
     def fake_backtest_prices(case_study, label, **kwargs):
+        engine_calls.append(kwargs)
         return _engine_price_frame(engine_products)
 
     def fake_load_cme_futures(**kwargs):
@@ -297,16 +299,17 @@ def _stub_price_loaders(
 
     monkeypatch.setattr(research_workflow, "load_backtest_prices_for", fake_backtest_prices)
     monkeypatch.setattr(research_workflow, "load_cme_futures", fake_load_cme_futures)
-    return audit_calls
+    return engine_calls, audit_calls
 
 
 def test_price_path_audits_exactly_the_products_the_engine_load_sampled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    audit_calls = _stub_price_loaders(monkeypatch, engine_products=["GC", "NQ"])
+    engine_calls, audit_calls = _stub_price_loaders(monkeypatch, engine_products=["GC", "NQ"])
 
     path = research_workflow.load_futures_price_path("fwd_ret_5d", max_products=2)
 
+    assert [call["max_symbols"] for call in engine_calls] == [2]
     assert len(audit_calls) == 1
     assert audit_calls[0]["products"] == ["GC", "NQ"]
     assert not audit_calls[0].get("max_symbols")
@@ -395,6 +398,7 @@ def test_reader_plan_exposes_resolved_population_and_product_contract(tmp_path: 
         (sector, product) for sector, products in grouped.items() for product in products
     )
 
+    assert universe.height == 30
     assert universe.height == len(expected_universe)
     assert universe.get_column("product").n_unique() == universe.height
     assert list(zip(universe.get_column("sector"), universe.get_column("product"))) == [

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -8,7 +8,9 @@ from types import SimpleNamespace
 
 import polars as pl
 import pytest
+import yaml
 
+from case_studies.cme_futures import research_workflow
 from case_studies.cme_futures.research_workflow import (
     FuturesPricePath,
     _expiry_rules,
@@ -213,12 +215,113 @@ def test_cme_strategy_rejects_reader_supplied_symbol_prices(tmp_path: Path) -> N
         ).resolve(prices=_product_prices().rename({"product": "symbol"}))
 
 
-def test_expiry_rules_are_complete_for_requested_products() -> None:
+def test_expiry_rules_carry_the_configured_contract_terms() -> None:
     rules = _expiry_rules(["ES", "CL"])
 
     assert rules.get_column("product").to_list() == ["CL", "ES"]
-    assert all(rules.get_column("expiry_rule").str.len_chars() > 0)
-    assert all(rules.get_column("contract_months").str.len_chars() > 0)
+    assert rules.rows() == [
+        ("CL", "3bd_before_25th_prior_month", "F,G,H,J,K,M,N,Q,U,V,X,Z"),
+        ("ES", "3rd_friday", "H,M,U,Z"),
+    ]
+
+
+def test_expiry_rules_reject_unknown_and_incomplete_specifications(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(ValueError, match="no contract specification"):
+        _expiry_rules(["ES", "NOT_A_PRODUCT"])
+
+    market = tmp_path / "data" / "futures" / "market"
+    market.mkdir(parents=True)
+    (market / "futures_specs.yaml").write_text(
+        "products:\n"
+        "  ES:\n"
+        "    expiry_rule: 3rd_friday\n"
+        "    contract_months: []\n"
+        "  NQ:\n"
+        "    contract_months: [H, M, U, Z]\n"
+    )
+    monkeypatch.setattr(research_workflow, "REPO_ROOT", tmp_path)
+
+    with pytest.raises(ValueError, match="ES has an incomplete expiry specification"):
+        _expiry_rules(["ES"])
+    with pytest.raises(ValueError, match="NQ has an incomplete expiry specification"):
+        _expiry_rules(["NQ"])
+
+
+_PRICE_DATES = [datetime(2024, 1, 2), datetime(2024, 1, 3)]
+
+
+def _engine_price_frame(products: list[str]) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": [product for product in products for _ in _PRICE_DATES],
+            "timestamp": [timestamp for _ in products for timestamp in _PRICE_DATES],
+            "close": [100.0 for _ in products for _ in _PRICE_DATES],
+        }
+    )
+
+
+def _audit_frame(products: list[str], cum_ratio: float = 1.0) -> pl.DataFrame:
+    rows = len(products) * len(_PRICE_DATES)
+    return pl.DataFrame(
+        {
+            "product": [product for product in products for _ in _PRICE_DATES],
+            "session_date": [timestamp for _ in products for timestamp in _PRICE_DATES],
+            "tenor": [0] * rows,
+            "adj_open": [100.0 * cum_ratio] * rows,
+            "adj_high": [100.0 * cum_ratio] * rows,
+            "adj_low": [100.0 * cum_ratio] * rows,
+            "adj_close": [100.0 * cum_ratio] * rows,
+            "raw_close": [100.0] * rows,
+            "cum_ratio": [cum_ratio] * rows,
+        }
+    )
+
+
+def _stub_price_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    engine_products: list[str],
+    cum_ratio: float = 1.0,
+) -> list[dict[str, object]]:
+    audit_calls: list[dict[str, object]] = []
+
+    def fake_backtest_prices(case_study, label, **kwargs):
+        return _engine_price_frame(engine_products)
+
+    def fake_load_cme_futures(**kwargs):
+        audit_calls.append(kwargs)
+        requested = kwargs.get("products") or engine_products
+        return _audit_frame(list(requested), cum_ratio=cum_ratio)
+
+    monkeypatch.setattr(research_workflow, "load_backtest_prices_for", fake_backtest_prices)
+    monkeypatch.setattr(research_workflow, "load_cme_futures", fake_load_cme_futures)
+    return audit_calls
+
+
+def test_price_path_audits_exactly_the_products_the_engine_load_sampled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_calls = _stub_price_loaders(monkeypatch, engine_products=["GC", "NQ"])
+
+    path = research_workflow.load_futures_price_path("fwd_ret_5d", max_products=2)
+
+    assert len(audit_calls) == 1
+    assert audit_calls[0]["products"] == ["GC", "NQ"]
+    assert not audit_calls[0].get("max_symbols")
+    assert path.audit.get_column("product").unique().sort().to_list() == ["GC", "NQ"]
+    assert path.expiry_rules.get_column("product").to_list() == ["GC", "NQ"]
+
+
+@pytest.mark.parametrize("cum_ratio", [float("nan"), float("inf"), 0.0, -1.0])
+def test_price_path_rejects_non_finite_or_non_positive_roll_ratios(
+    monkeypatch: pytest.MonkeyPatch, cum_ratio: float
+) -> None:
+    _stub_price_loaders(monkeypatch, engine_products=["ES"], cum_ratio=cum_ratio)
+
+    with pytest.raises(ValueError, match="finite positive"):
+        research_workflow.load_futures_price_path("fwd_ret_5d", products=["ES"])
 
 
 def test_reader_plan_exposes_resolved_population_and_product_contract(tmp_path: Path) -> None:
@@ -282,10 +385,27 @@ def test_reader_plan_exposes_resolved_population_and_product_contract(tmp_path: 
         "preview",
         request.identity,
     )
-    assert universe.height == 30
-    assert universe.get_column("product").n_unique() == 30
-    assert universe.select(pl.col("expiry_rule").is_null().any()).item() is False
-    assert universe.select(pl.col("contract_months").is_null().any()).item() is False
+    configured = yaml.safe_load(
+        (REPO_ROOT / "data" / "futures" / "market" / "futures_specs.yaml").read_text()
+    )["products"]
+    grouped = yaml.safe_load(
+        (REPO_ROOT / "case_studies" / "cme_futures" / "config" / "setup.yaml").read_text()
+    )["universe"]["product_groups"]
+    expected_universe = sorted(
+        (sector, product) for sector, products in grouped.items() for product in products
+    )
+
+    assert universe.height == len(expected_universe)
+    assert universe.get_column("product").n_unique() == universe.height
+    assert list(zip(universe.get_column("sector"), universe.get_column("product"))) == [
+        tuple(row) for row in expected_universe
+    ]
+    assert universe.get_column("expiry_rule").to_list() == [
+        configured[product]["expiry_rule"] for _, product in expected_universe
+    ]
+    assert universe.get_column("contract_months").to_list() == [
+        ",".join(configured[product]["contract_months"]) for _, product in expected_universe
+    ]
 
 
 def test_reader_plan_accepts_flat_family_spec(tmp_path: Path) -> None:


### PR DESCRIPTION
Three defects in the CME futures research gate, found by the review of the branch that introduced it.

### The audit sampled a second, different set of products

`load_futures_price_path` drew two independent random product samples whenever it was called with
`max_products`. The engine load applied `max_symbols` over the backtest price universe; the roll
audit then re-applied the same `max_symbols` over the raw daily store restricted to the date window
the engine prices happened to span. `apply_max_symbols` samples from whichever universe it is handed,
so the two draws diverge and the roll audit describes products the engine never priced.

The engine load now samples once. The products it returned are passed to the audit load explicitly,
and the expiry rules are built from that same list.

### The roll-ratio guard could not detect what its message named

The guard rejected null and non-positive `cum_ratio` values but not NaN or infinity, while its
message says the ratios must be finite positive values. It now rejects null, NaN, infinity and
non-positive ratios.

### Two assertions could not fail

`test_reader_plan_exposes_resolved_population_and_product_contract` asserted that `expiry_rule` and
`contract_months` are not null after a join whose right side is built by `_expiry_rules`, which
raises before it can emit either as null. The assertions now compare the product universe against the
contract terms configured in `data/futures/market/futures_specs.yaml`, and a new test covers the
rejection of unknown and incomplete specifications that makes a null impossible.

### Verification

New tests for the first two defects fail against the pre-fix code and pass after it.

```
uv run pytest -q tests/test_cme_futures_research.py \
  tests/test_research_contract_execution.py \
  tests/test_research_model_planning.py \
  tests/test_research_models.py
115 passed
```

The reduced real-data CME proof passes on this tree: 6 products, 1,512 eligible rows, 327 roll
transitions, 243 fills, 125 trades. Its identities are unchanged from the same proof run on `main`
without these commits, which confirms the fix does not move model, prediction or backtest identity.
