### PR TITLE
Build the sequence family on the shared resolved specification

### DIFF
--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -499,7 +499,7 @@ def _cached_sequence_run(study: Study, spec: dict[str, Any], context: SequenceRe
                     checkpoint,
                     "validation",
                     checkpoint_kind="epoch",
-                    identity_version=2,
+                    identity_version=spec["identity_version"],
                 ),
                 include_preview=spec["execution_tier"] == "preview",
             )

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -291,6 +291,7 @@ def _configure_sequence_runtime(spec: dict[str, Any]) -> None:
 
 def resolve_model_request(study: Study, request: dict[str, Any]):
     from case_studies.research.contracts import ExecutionTier
+    from case_studies.research.identity import ResolvedSpec
     from case_studies.utils.artifact_digest import value_digest
     from case_studies.utils.deep_model_state import declared_epoch_checkpoints
     from utils.cv_splits import make_walk_forward_config
@@ -408,17 +409,15 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     checkpoints = declared_epoch_checkpoints(
         int(config.get("n_epochs", 100)), int(config.get("checkpoint_interval", 5))
     )
-    spec = {
-        "identity_version": 2,
-        "execution_tier": tier.value,
-        "family": "deep_learning",
-        "label": label_ref.name,
-        "seed": seed,
-        "config_name": config["config_name"],
+    computation = {
         "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
         "feature_artifacts": mds.input_lineage["artifacts"],
         "feature_names": list(mds.feature_names),
-        "task": {"type": "regression", "class_values": []},
+        "task": {
+            "type": "regression",
+            "class_values": [],
+            "continuous_eval_label": label_ref.definition.continuous_eval_label,
+        },
         "cv": cv_record,
         "model": {
             "class": config["params"]["architecture"],
@@ -450,7 +449,17 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         "runtime_identity": _sequence_runtime_identity(config),
     }
     if tier is ExecutionTier.PREVIEW:
-        spec["preview_reductions"] = reductions
+        computation["preview_reductions"] = reductions
+    runtime_provenance = _sequence_runtime_provenance(study, config)
+    spec = ResolvedSpec.create(
+        family="deep_learning",
+        label=label_ref.name,
+        seed=seed,
+        computation=computation,
+        provenance=runtime_provenance,
+        config_name=config["config_name"],
+        execution_tier=tier.value,
+    ).as_dict()
     context = SequenceResearchContext(
         dataset_pd=dataset_pd,
         splits=tuple(splits),
@@ -466,7 +475,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         temporal_feature_names=tuple(mds.temporal_feature_names),
         expected_keys=expected,
         max_train_sequences=max_train_sequences,
-        runtime_provenance=_sequence_runtime_provenance(study, config),
+        runtime_provenance=runtime_provenance,
     )
     return spec, context
 
@@ -477,7 +486,7 @@ def _cached_sequence_run(study: Study, spec: dict[str, Any], context: SequenceRe
     from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
 
     training_hash = training_hash_from_spec(spec)
-    checkpoint_values = tuple(item["value"] for item in spec["checkpoint_schedule"])
+    checkpoint_values = tuple(item["value"] for item in spec["computation"]["checkpoint_schedule"])
     try:
         training = Result.open(
             study, training_hash, include_preview=spec["execution_tier"] == "preview"
@@ -552,7 +561,8 @@ def run_resolved_request(
     if model_dir.exists():
         raise ValueError(f"partial fitted-state directory requires inspection: {model_dir}")
     staging = train_dir / f".models.{uuid.uuid4().hex}.tmp"
-    _configure_sequence_runtime(spec["numerics"])
+    computation = spec["computation"]
+    _configure_sequence_runtime(computation["numerics"])
     try:
         result = run_dl_cv(
             context.dataset_pd,
@@ -563,7 +573,7 @@ def run_resolved_request(
             label_col=context.label_col,
             date_col=context.date_col,
             entity_col=context.entity_col,
-            device=spec["numerics"]["device"],
+            device=computation["numerics"]["device"],
             save_dir=train_dir / "diagnostics",
             max_train_sequences=context.max_train_sequences,
             register=False,
@@ -574,7 +584,7 @@ def run_resolved_request(
             checkpoint_root=staging,
             strict=True,
             seed=int(spec["seed"]),
-            num_threads=int(spec["numerics"]["num_threads"]),
+            num_threads=int(computation["numerics"]["num_threads"]),
         )
         os.replace(staging, model_dir)
     except Exception:
@@ -582,7 +592,7 @@ def run_resolved_request(
         raise
 
     prediction_results = []
-    for checkpoint in (item["value"] for item in spec["checkpoint_schedule"]):
+    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
         predictions = (
             result["all_predictions"]
             .filter(

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -23,7 +23,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def test_sequence_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> None:
+def test_sequence_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -> None:
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -100,12 +100,13 @@ def test_sequence_resolver_builds_complete_v2_request(tmp_path, monkeypatch) -> 
     spec = resolved.spec
     context = resolved._context
 
-    assert spec["identity_version"] == 2
-    assert spec["label_artifact"]["digest"] == label.digest
-    assert spec["model"]["params"]["n_epochs"] == 3
-    assert [row["value"] for row in spec["checkpoint_schedule"]] == [2, 3]
-    assert spec["expected_prediction_keys"]["n_rows"] == 12
-    assert spec["sampling"] == {"max_symbols": 0, "max_train_sequences": 0}
+    computation = spec["computation"]
+    assert spec["identity_version"] == 3
+    assert computation["label_artifact"]["digest"] == label.digest
+    assert computation["model"]["params"]["n_epochs"] == 3
+    assert [row["value"] for row in computation["checkpoint_schedule"]] == [2, 3]
+    assert computation["expected_prediction_keys"]["n_rows"] == 12
+    assert computation["sampling"] == {"max_symbols": 0, "max_train_sequences": 0}
     assert context.expected_keys.height == 12
     assert context.config["n_epochs"] == 3
 
@@ -200,8 +201,9 @@ def test_darts_request_resolves_installed_runtime_identity(tmp_path, monkeypatch
         overrides={"device": "cpu"},
     ).resolve()
 
-    assert resolved.spec["runtime_identity"]["darts"] == version("darts")
-    assert resolved.spec["model"]["implementation"] == "darts"
+    computation = resolved.spec["computation"]
+    assert computation["runtime_identity"]["darts"] == version("darts")
+    assert computation["model"]["implementation"] == "darts"
 
 
 def test_weekly_nbeats_request_applies_identity_cadence_before_cv(tmp_path, monkeypatch) -> None:
@@ -301,10 +303,11 @@ def test_weekly_nbeats_request_applies_identity_cadence_before_cv(tmp_path, monk
     assert all(timestamp.weekday() == 4 for timestamp in observed_timestamps)
     assert list(context.splits) == canonical_folds
     assert pd.Timestamp(split["val_start"]) - pd.Timestamp(split["train_end"]) >= pd.Timedelta("5D")
-    assert resolved.spec["cv"]["request"]["decision_cadence"] is None
-    assert resolved.spec["cv"]["request"]["gap"] == "5D"
-    assert resolved.spec["model"]["params"]["decision_cadence"] == "weekly_friday"
-    assert resolved.spec["preprocessing"]["decision_cadence"] == "weekly_friday"
+    computation = resolved.spec["computation"]
+    assert computation["cv"]["request"]["decision_cadence"] is None
+    assert computation["cv"]["request"]["gap"] == "5D"
+    assert computation["model"]["params"]["decision_cadence"] == "weekly_friday"
+    assert computation["preprocessing"]["decision_cadence"] == "weekly_friday"
     eligible_timestamps = [
         timestamp
         for timestamp in observed_timestamps
@@ -318,7 +321,7 @@ def test_weekly_nbeats_request_applies_identity_cadence_before_cv(tmp_path, monk
         }
     ).sort("symbol", "timestamp", "fold")
     assert context.expected_keys.equals(expected)
-    assert resolved.spec["expected_prediction_keys"]["n_rows"] == expected.height
+    assert computation["expected_prediction_keys"]["n_rows"] == expected.height
 
 
 def test_run_dl_cv_applies_preset_cadence_before_backend(monkeypatch) -> None:

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -23,7 +23,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def test_sequence_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -> None:
+def _resolve_nlinear_request(tmp_path, monkeypatch):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -97,6 +97,11 @@ def test_sequence_resolver_builds_complete_resolved_request(tmp_path, monkeypatc
         config_name="nlinear_probe",
         overrides={"device": "cpu", "n_epochs": 3},
     ).resolve()
+    return study, label, resolved
+
+
+def test_sequence_resolver_builds_complete_resolved_request(tmp_path, monkeypatch) -> None:
+    _study, label, resolved = _resolve_nlinear_request(tmp_path, monkeypatch)
     spec = resolved.spec
     context = resolved._context
 
@@ -109,6 +114,39 @@ def test_sequence_resolver_builds_complete_resolved_request(tmp_path, monkeypatc
     assert computation["sampling"] == {"max_symbols": 0, "max_train_sequences": 0}
     assert context.expected_keys.height == 12
     assert context.config["n_epochs"] == 3
+
+
+def test_cached_sequence_run_resolves_predictions_at_the_published_identity(
+    tmp_path, monkeypatch
+) -> None:
+    from case_studies.research.results import Result
+    from case_studies.utils.registry import prediction_hash_from_parts, training_hash_from_spec
+
+    study, _label, resolved = _resolve_nlinear_request(tmp_path, monkeypatch)
+    spec = resolved.spec
+    requested: list[str] = []
+
+    @classmethod
+    def _record(cls, study_arg, result_hash, **kwargs):
+        requested.append(result_hash)
+        return SimpleNamespace(hash=result_hash)
+
+    monkeypatch.setattr(Result, "open", _record)
+
+    assert deep_learning._cached_sequence_run(study, spec, resolved._context) is None
+
+    training_hash = training_hash_from_spec(spec)
+    expected = [
+        prediction_hash_from_parts(
+            training_hash,
+            row["value"],
+            "validation",
+            checkpoint_kind="epoch",
+            identity_version=spec["identity_version"],
+        )
+        for row in spec["computation"]["checkpoint_schedule"]
+    ]
+    assert requested == [training_hash, *expected]
 
 
 def test_darts_request_resolves_installed_runtime_identity(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Moves the sequence family onto the shared resolved specification, so all five predictive families now build their training identity the same way.

## Why

`resolve_model_request` for `deep_learning` hand-built its training spec as a flat dict stamped `identity_version: 2`. It was the last family doing so; `linear`, `gbm`, `tabular_dl` and `latent_factors` all go through `ResolvedSpec`.

The stamp had a downstream consequence. `catalog.py` maps `identity_version == 2` to `identity_status "legacy-v2"` and requires `"current"` before a prediction row can be `complete`, so no sequence prediction could ever be complete, and any notebook filtering on `identity_status == "current"` silently dropped sequence predictions from the signal population.

## What changed

- `resolve_model_request` builds a `computation` block and calls `ResolvedSpec.create`, which stamps `IDENTITY_VERSION`. `cv`, `model`, `preprocessing`, `checkpoint_schedule`, `expected_prediction_keys`, `numerics`, `sampling`, `source_identity` and `runtime_identity` move under `computation`, matching the other four families.
- `_cached_sequence_run` and `run_resolved_request` read the moved keys from `spec["computation"]`.
- `task.continuous_eval_label` is now recorded. `linear`, `gbm` and `tabular_dl` already carry it; the sequence family omitted it.
- `_cached_sequence_run` derives cached prediction hashes from `spec["identity_version"]` rather than a hardcoded `2`.

The second commit is a defect the pre-push review caught in the first. With the spec at version 3 and the cache lookup pinned to 2, re-running an already-trained sequence model missed its published predictions, fell through to registration, found the existing `models` directory and raised `partial fitted-state directory requires inspection`. `tests/test_deep_learning_adapter.py::test_cached_sequence_run_resolves_predictions_at_the_published_identity` pins the requested hash sequence and fails against the hardcoded version.

## Identity impact

Sequence training and prediction hashes change. Every stage-06 result is being regenerated, so no stored artifact depends on the old identity.

`tests/test_research_contract_catalog.py:305-306` is deliberately unchanged: its hand-seeded legacy row is family `linear`, and a legacy v2 row must stay readable without being granted completeness.

## Verification

```
uv run pytest tests/test_deep_learning_adapter.py tests/test_deep_learning_state.py \
  tests/test_darts_state.py tests/test_cv_cached_results.py tests/test_research_models.py \
  tests/test_research_registry.py tests/test_research_contract_catalog.py \
  tests/test_model_analysis_selection.py tests/test_registry_cleanup.py \
  tests/test_latent_input_identity.py tests/test_carrier_routing_contract.py
```

145 passed. Ruff, formatting and pre-commit hooks green; RoboRev pre-push gate reports no blocking findings.

This lands ahead of the locked-holdout producer, which builds on the `computation` block to reconstruct locked sequence models.
