### PR TITLE
Compare model results only where they are comparable

### DIFF
--- a/case_studies/utils/analytics.py
+++ b/case_studies/utils/analytics.py
@@ -20,7 +20,10 @@ from pathlib import Path
 import polars as pl
 
 from case_studies.utils.backtest_presets import cost_view, strategy_view
-from case_studies.utils.notebook_contracts import degenerate_prediction_sql
+from case_studies.utils.notebook_contracts import (
+    degenerate_prediction_sql,
+    full_coverage_prediction_sql,
+)
 from utils.paths import REPO_ROOT
 
 CASE_STUDY_META = {
@@ -157,12 +160,29 @@ def load_model_ic(
     *,
     split: str = "validation",
     case_studies: list[str] | None = None,
+    require_full_coverage: bool = True,
 ) -> pl.DataFrame:
     """Load IC metrics across case studies for specified model families.
 
     Returns a DataFrame with columns:
         case_study, family, config_name, label, split,
         checkpoint_value, ic_mean, ic_std
+
+    A model family can hold prediction sets scored over different numbers of
+    decision days, because a run that failed partway still registers rows for the
+    folds it completed. Their scores are averages over different periods, so
+    comparing them measures the periods as much as the models, and the shorter
+    window usually scores higher. Rows are therefore restricted to the maximum
+    ``ic_n_days`` within each ``(split, family, label)`` before anything is
+    returned.
+
+    Ordering is fully determined: ``ic_mean`` descending, then
+    ``prediction_hash``, so a caller taking the first row of a tie gets the same
+    row on every machine.
+
+    **This is a diagnostic query, not a selection.** Ranking configurations by IC
+    selects nothing anywhere in the pipeline; a configuration is chosen on
+    validation backtest Sharpe. See ``reference/CASE_STUDY_PIPELINE.md``.
 
     Parameters
     ----------
@@ -173,6 +193,10 @@ def load_model_ic(
         Prediction split to filter by ("validation" or "holdout").
     case_studies : list of str, optional
         Case studies to query. None = all.
+    require_full_coverage : bool
+        Keep only the maximum-coverage rows per (split, family, label). Set False
+        for an inventory of everything scored, which cannot be compared across
+        rows.
     """
     if isinstance(families, str):
         families = [families]
@@ -200,6 +224,12 @@ def load_model_ic(
         ic_expr = (
             "COALESCE(pm.ic_mean_daily, pm.ic_mean)" if "ic_mean_daily" in pm_cols else "pm.ic_mean"
         )
+        # A registry predating that backfill also has no coverage column, so its
+        # rows cannot be shown to span the same decision days. Reporting that per
+        # row beats both failing outright on a legacy registry and letting a
+        # caller assume a guard that never ran.
+        coverage_enforced = require_full_coverage and "ic_n_days" in pm_cols
+        coverage_clause = full_coverage_prediction_sql("p", "t", "pm") if coverage_enforced else ""
 
         sql = f"""
             SELECT
@@ -221,7 +251,8 @@ def load_model_ic(
             WHERE 1=1 {family_clause}
               AND p.split = ?
               {degenerate_prediction_sql("p.prediction_hash")}
-            ORDER BY ic_mean DESC NULLS LAST
+              {coverage_clause}
+            ORDER BY ic_mean DESC NULLS LAST, p.prediction_hash ASC
         """
         df = _query(db_path, sql, tuple(params))
         if len(df) > 0:
@@ -232,49 +263,16 @@ def load_model_ic(
             ]
             if casts:
                 df = df.with_columns(casts)
-            frames.append(df.with_columns(pl.lit(cs_id).alias("case_study")))
+            frames.append(
+                df.with_columns(
+                    pl.lit(cs_id).alias("case_study"),
+                    pl.lit(coverage_enforced).alias("coverage_enforced"),
+                )
+            )
 
     if not frames:
         return pl.DataFrame()
     return pl.concat(frames, how="diagonal")
-
-
-def resolve_best_prediction(
-    case_study: str,
-    label: str,
-    *,
-    family: str = "gbm",
-    split: str = "validation",
-) -> dict:
-    """Return rank-1 prediction-set metadata for (case_study, label, family).
-
-    Resolves the best-IC prediction set from `prediction_metrics` (sorted by
-    `ic_mean` descending). Useful for downstream notebooks (Ch16/17) that need
-    to consume registered upstream predictions without baking in a hash.
-
-    Returns
-    -------
-    dict
-        Keys: prediction_hash, config_name, ic_mean, ic_std, family, label, split.
-
-    Raises
-    ------
-    RuntimeError
-        If no prediction set matches (case_study, label, family, split).
-    """
-    df = (
-        load_model_ic([family], split=split, case_studies=[case_study])
-        .filter(pl.col("label") == label)
-        .filter(pl.col("ic_mean").is_not_null())
-        .sort("ic_mean", descending=True)
-    )
-    if df.is_empty():
-        raise RuntimeError(
-            f"No {family} predictions with non-null ic_mean for "
-            f"{case_study}/{label}/{split} in registry.db. "
-            f"Run the {family} training notebook for {case_study} before this notebook."
-        )
-    return df.row(0, named=True)
 
 
 def load_classification_metrics(
@@ -346,7 +344,17 @@ def load_best_ic_per_family(
     case_studies: list[str] | None = None,
     use_primary_label: bool = True,
 ) -> pl.DataFrame:
-    """Best IC per family per case study (one row per family-case_study pair).
+    """Highest-IC row per family per case study (one row per family-case_study pair).
+
+    Restricted to maximum-coverage prediction sets by ``load_model_ic``, so the
+    rows compared against each other were scored over the same decision days.
+    Exact ties resolve on ``prediction_hash``, so the same registry returns the
+    same row everywhere.
+
+    **A diagnostic view, not a selection.** IC ranks nothing in the pipeline; a
+    configuration is chosen on validation backtest Sharpe. Callers that display
+    a family's strongest score are using it correctly; a caller choosing what to
+    trade or fit from this result is not.
 
     Returns: case_study, display_name, family, config_name, label, ic_mean
     """
@@ -363,8 +371,13 @@ def load_best_ic_per_family(
             pl.col("label") == pl.col("primary_label")
         )
 
+    tie_break = ["prediction_hash"] if "prediction_hash" in all_ic.columns else []
     best = (
-        all_ic.sort("ic_mean", descending=True, nulls_last=True)
+        all_ic.sort(
+            ["ic_mean", *tie_break],
+            descending=[True, *[False] * len(tie_break)],
+            nulls_last=True,
+        )
         .group_by(["case_study", "family"])
         .first()
         .select("case_study", "family", "config_name", "label", "ic_mean")

--- a/case_studies/utils/analytics.py
+++ b/case_studies/utils/analytics.py
@@ -224,11 +224,24 @@ def load_model_ic(
         ic_expr = (
             "COALESCE(pm.ic_mean_daily, pm.ic_mean)" if "ic_mean_daily" in pm_cols else "pm.ic_mean"
         )
-        # A registry predating that backfill also has no coverage column, so its
-        # rows cannot be shown to span the same decision days. Reporting that per
-        # row beats both failing outright on a legacy registry and letting a
-        # caller assume a guard that never ran.
-        coverage_enforced = require_full_coverage and "ic_n_days" in pm_cols
+        # A registry predating that backfill has no coverage column, and one
+        # caught mid-backfill has the column with nothing in it. In both cases
+        # the rows cannot be shown to span the same decision days, and the
+        # clause below would return nothing at all rather than everything
+        # unguarded. Probe for a usable value, not just the column, and report
+        # per row which of the two happened: that beats failing outright on a
+        # legacy registry and beats letting a caller assume a guard that never
+        # ran.
+        coverage_usable = False
+        if "ic_n_days" in pm_cols:
+            with sqlite3.connect(str(db_path)) as probe_con:
+                coverage_usable = (
+                    probe_con.execute(
+                        "SELECT 1 FROM prediction_metrics WHERE ic_n_days IS NOT NULL LIMIT 1"
+                    ).fetchone()
+                    is not None
+                )
+        coverage_enforced = require_full_coverage and coverage_usable
         coverage_clause = full_coverage_prediction_sql("p", "t", "pm") if coverage_enforced else ""
 
         sql = f"""

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -903,7 +903,16 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         raise ValueError("DML request resolved an empty pre-holdout analysis frame")
     cadence = _observed_cadence(analysis, mds.date_col)
     horizon_steps = max(1, int(np.ceil(horizon_delta / cadence)))
-    embargo = embargo_from_buffer(mds.label_buffer)
+    # The cadence is already measured on the frame being analysed, so the embargo
+    # is counted against it rather than against an assumed bar size. Leaving the
+    # fallback here would make the embargo short by the ratio between the two on
+    # any panel whose real cadence differs from its declared one, while the
+    # horizon computed on the line above stayed right. A month buffer has no
+    # fixed length and keeps the calendar branch.
+    try:
+        embargo = embargo_from_buffer(mds.label_buffer, observed_step=cadence)
+    except ValueError:
+        embargo = embargo_from_buffer(mds.label_buffer)
     nuisance_params = _resolve_nuisance_params(config, request["overrides"], seed)
     key_frame = analysis.select(mds.entity_cols[0], mds.date_col)
     if key_frame.n_unique([mds.entity_cols[0], mds.date_col]) != key_frame.height:

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -63,23 +63,67 @@ class DMLResearchContext:
     runtime_provenance: dict[str, Any]
 
 
-def embargo_from_buffer(label_buffer: str, *, periods_per_year: int | None = None) -> int:
+def observation_step(frame: Any, date_col: str = "timestamp") -> pd.Timedelta:
+    """Measure the spacing between consecutive decision times in *frame*.
+
+    Returns the most common gap between distinct sorted values of ``date_col``,
+    which is the observation grid the panel is actually recorded on. Sessions,
+    weekends and holidays introduce larger gaps; taking the mode rather than the
+    minimum or the mean makes those irrelevant.
+
+    Accepts a Polars or pandas frame, or anything exposing the column through
+    ``__getitem__``.
+    """
+    column = frame[date_col]
+    values = pd.Series(column.to_list() if hasattr(column, "to_list") else list(column))
+    stamps = pd.to_datetime(values).drop_duplicates().sort_values()
+    if len(stamps) < 2:
+        raise ValueError(f"{date_col!r} has fewer than two distinct values; no grid to measure")
+    gaps = stamps.diff().dropna()
+    return pd.Timedelta(gaps.mode().iloc[0])
+
+
+def embargo_from_buffer(
+    label_buffer: str,
+    *,
+    periods_per_year: int | None = None,
+    observed_step: str | pd.Timedelta | None = None,
+) -> int:
     """Convert a label buffer string to an integer embargo period count.
 
-    Supports all pandas duration units (D, H/h, M, T/min).
-    Returns the number of observation periods to skip between train and test.
+    The embargo is counted in *observation periods*, so converting a duration
+    into one requires knowing how long an observation period is. Pass
+    ``observed_step`` — from :func:`observation_step` on the frame being
+    analysed — and the conversion is exact: the number of periods spanning the
+    buffer, rounded up, at least one.
 
-    Bar-frequency assumptions baked into the conversion:
-    - D: one period per `value` days (e.g. "5D" → 5)
-    - H/h: the buffer is interpreted as the bar cadence; the result is the
-      number of `value`-hour bars in one trading day (24 // value), so "8H"
-      → 3 bars (a one-day embargo on 8-hour bars)
-    - M: `value` monthly groups when `periods_per_year=12`, otherwise
-      `value` months × 21 trading days
-    - T/min: the buffer is the cadence; the result is the bars in 15 minutes
-      (`value` // 15), assuming 15-minute base bars
+    Without ``observed_step`` the conversion falls back to a fixed assumption
+    about bar size per unit, which is correct only when that assumption holds:
+
+    - D: one period per ``value`` days, correct on a daily grid
+    - H/h: the number of ``value``-hour bars in one day, so "8H" gives a
+      one-day embargo on 8-hour bars
+    - M: ``value`` monthly groups when ``periods_per_year=12``, else
+      ``value`` months x 21 trading days
+    - T/min: the number of ``value``-minute spans in 15 minutes, which assumes
+      the panel is recorded in 15-minute bars
+
+    That last assumption is the one that bites. On a one-minute panel a "15min"
+    buffer resolves to a single period — a one-minute embargo against a
+    fifteen-minute label — and the fifteenfold error is invisible in the result.
+    Pass ``observed_step`` on any sub-daily panel.
     """
+    import math
     import re
+
+    if observed_step is not None:
+        step = pd.Timedelta(observed_step)
+        if step <= pd.Timedelta(0):
+            raise ValueError(f"observed_step must be positive, got {observed_step!r}")
+        # pandas deprecated the uppercase hour alias; the buffers are authored by
+        # hand in setup.yaml and still use it.
+        span = pd.Timedelta(re.sub(r"(?<=\d)H\b", "h", label_buffer.strip()))
+        return max(1, math.ceil(span / step))
 
     match = re.match(r"(\d+)(D|H|h|M|T|min)", label_buffer.strip())
     if not match:

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -108,10 +108,15 @@ def embargo_from_buffer(
     - T/min: the number of ``value``-minute spans in 15 minutes, which assumes
       the panel is recorded in 15-minute bars
 
-    That last assumption is the one that bites. On a one-minute panel a "15min"
-    buffer resolves to a single period — a one-minute embargo against a
-    fifteen-minute label — and the fifteenfold error is invisible in the result.
-    Pass ``observed_step`` on any sub-daily panel.
+    That last assumption is the one that bites, because it is wrong by exactly
+    the ratio between the assumed bar and the real one, and nothing in the result
+    shows it. A "15min" buffer resolves to a single period whatever the panel is
+    recorded at, so on a one-minute grid it yields a one-minute embargo against a
+    fifteen-minute label. Pass ``observed_step`` on any sub-daily panel rather
+    than relying on the declared bar size, which can disagree with the artifacts.
+
+    A month buffer has no fixed length and is rejected when ``observed_step`` is
+    supplied; use the ``periods_per_year`` branch for it.
     """
     import math
     import re
@@ -122,7 +127,14 @@ def embargo_from_buffer(
             raise ValueError(f"observed_step must be positive, got {observed_step!r}")
         # pandas deprecated the uppercase hour alias; the buffers are authored by
         # hand in setup.yaml and still use it.
-        span = pd.Timedelta(re.sub(r"(?<=\d)H\b", "h", label_buffer.strip()))
+        normalized = re.sub(r"(?<=\d)H\b", "h", label_buffer.strip())
+        if re.match(r"\d+\s*M\b", normalized):
+            raise ValueError(
+                f"A month buffer ({label_buffer!r}) has no fixed length, so it cannot be "
+                f"divided by an observation step. Use the periods_per_year branch by "
+                f"omitting observed_step."
+            )
+        span = pd.Timedelta(normalized)
         return max(1, math.ceil(span / step))
 
     match = re.match(r"(\d+)(D|H|h|M|T|min)", label_buffer.strip())

--- a/case_studies/utils/model_analysis.py
+++ b/case_studies/utils/model_analysis.py
@@ -316,10 +316,23 @@ def best_model_per_family_fast(
                 f"the result as a diagnostic rather than a comparison."
             )
         group_keys = ["family", "label"] if "label" in eligible.columns else ["family"]
-        eligible = eligible.filter(
+        covered = eligible.filter(
             pl.col(coverage_col).is_not_null()
             & (pl.col(coverage_col) == pl.col(coverage_col).max().over(group_keys))
         )
+        # A family whose rows all carry a null coverage count cannot be shown to
+        # span the same days as any other, and the filter above removes it
+        # entirely. Dropping a whole family from a comparison without saying so is
+        # the failure this guard exists to prevent, so it stops instead.
+        lost = sorted(set(eligible["family"].to_list()) - set(covered["family"].to_list()))
+        if lost:
+            raise ValueError(
+                f"No prediction set carries {coverage_col!r} for family/families {lost}, so "
+                f"they cannot be compared against the families that do. Backfill the column "
+                f"for those runs, or pass require_full_coverage=False and treat the whole "
+                f"result as a diagnostic rather than a comparison."
+            )
+        eligible = covered
 
     tie_break = ["prediction_hash"] if "prediction_hash" in eligible.columns else []
     return (

--- a/case_studies/utils/model_analysis.py
+++ b/case_studies/utils/model_analysis.py
@@ -277,22 +277,56 @@ def best_model_per_family_fast(
     metrics: pl.DataFrame,
     *,
     ic_col: str = "ic_mean_daily",
+    coverage_col: str = "ic_n_days",
+    require_full_coverage: bool = True,
 ) -> pl.DataFrame:
-    """Find the best (config, checkpoint) per family from pre-computed metrics.
+    """Find the representative (config, checkpoint) per family from stored metrics.
 
-    Much faster than select_best_per_family() which recomputes IC from raw predictions.
+    The representative stands in for its family in every comparison downstream, so
+    it has to have been scored over the same period as the rows it will be compared
+    against. A prediction set that failed partway still leaves rows in the registry,
+    and its score is an average over the decision days it managed rather than the
+    days it was asked for. Those scores are frequently the highest ones, because a
+    shorter window is an easier window.
+
+    Rows are therefore restricted to the maximum ``coverage_col`` observed within
+    each ``(family, label)`` before the highest score is taken. Restricting per
+    label rather than globally keeps labels with genuinely different histories
+    comparable within themselves.
+
+    Exact ties on ``ic_col`` resolve on ``prediction_hash`` so the same registry
+    returns the same representative on every machine and every re-run.
+
+    Set ``require_full_coverage=False`` for a diagnostic view of every scored row,
+    which is not a basis for comparing one family against another.
     """
     if metrics.height == 0:
         return metrics
     if ic_col not in metrics.columns:
         raise ValueError(f"Selection metric {ic_col!r} is not present")
 
+    eligible = metrics.filter(pl.col(ic_col).is_not_null())
+
+    if require_full_coverage:
+        if coverage_col not in eligible.columns:
+            raise ValueError(
+                f"Coverage column {coverage_col!r} is not present, so no representative "
+                f"can be shown to cover the same period as the rows it is compared "
+                f"against. Backfill it, or pass require_full_coverage=False and treat "
+                f"the result as a diagnostic rather than a comparison."
+            )
+        group_keys = ["family", "label"] if "label" in eligible.columns else ["family"]
+        eligible = eligible.filter(
+            pl.col(coverage_col).is_not_null()
+            & (pl.col(coverage_col) == pl.col(coverage_col).max().over(group_keys))
+        )
+
+    tie_break = ["prediction_hash"] if "prediction_hash" in eligible.columns else []
     return (
-        metrics.filter(pl.col(ic_col).is_not_null())
-        .sort(ic_col, descending=True)
+        eligible.sort([ic_col, *tie_break], descending=[True, *[False] * len(tie_break)])
         .group_by("family")
         .first()
-        .sort(ic_col, descending=True)
+        .sort([ic_col, "family"], descending=[True, False])
     )
 
 

--- a/case_studies/utils/model_analysis.py
+++ b/case_studies/utils/model_analysis.py
@@ -320,16 +320,24 @@ def best_model_per_family_fast(
             pl.col(coverage_col).is_not_null()
             & (pl.col(coverage_col) == pl.col(coverage_col).max().over(group_keys))
         )
-        # A family whose rows all carry a null coverage count cannot be shown to
+
+        # A group whose rows all carry a null coverage count cannot be shown to
         # span the same days as any other, and the filter above removes it
-        # entirely. Dropping a whole family from a comparison without saying so is
-        # the failure this guard exists to prevent, so it stops instead.
-        lost = sorted(set(eligible["family"].to_list()) - set(covered["family"].to_list()))
+        # entirely. Checking at the granularity the filter groups on matters: a
+        # family with one label backfilled and another not would survive a
+        # family-level check while the unbacked label vanished, and because the
+        # representative is taken across labels that silent drop can change which
+        # configuration represents the family.
+        def _groups(frame: pl.DataFrame) -> set[tuple]:
+            return set(map(tuple, frame.select(group_keys).unique().rows()))
+
+        lost = sorted(_groups(eligible) - _groups(covered))
         if lost:
+            named = ", ".join("/".join(str(part) for part in group) for group in lost)
             raise ValueError(
-                f"No prediction set carries {coverage_col!r} for family/families {lost}, so "
-                f"they cannot be compared against the families that do. Backfill the column "
-                f"for those runs, or pass require_full_coverage=False and treat the whole "
+                f"No prediction set carries {coverage_col!r} for {named}, so those rows "
+                f"cannot be compared against the ones that do. Backfill the column for "
+                f"those runs, or pass require_full_coverage=False and treat the whole "
                 f"result as a diagnostic rather than a comparison."
             )
         eligible = covered

--- a/tests/test_case_study_analytics.py
+++ b/tests/test_case_study_analytics.py
@@ -363,6 +363,22 @@ def test_load_model_ic_drops_partially_covered_prediction_sets(tmp_path, monkeyp
     assert unguarded["coverage_enforced"].to_list() == [False, False]
 
 
+def test_load_model_ic_does_not_empty_a_registry_mid_backfill(tmp_path, monkeypatch) -> None:
+    """The column exists but holds nothing: guard off, rows returned, flag false."""
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    db = tmp_path / "etfs" / "run_log" / "registry.db"
+    _seed_coverage_registry(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute("UPDATE prediction_metrics SET ic_n_days = NULL")
+    conn.commit()
+    conn.close()
+
+    df = analytics.load_model_ic(case_studies=["etfs"], split="validation")
+
+    assert sorted(df["config_name"].to_list()) == ["full_window", "short_window"]
+    assert df["coverage_enforced"].unique().to_list() == [False]
+
+
 def test_load_model_ic_reports_when_a_legacy_registry_cannot_be_guarded(
     seeded_registries,
 ) -> None:

--- a/tests/test_case_study_analytics.py
+++ b/tests/test_case_study_analytics.py
@@ -311,6 +311,68 @@ def seeded_registries(tmp_path, monkeypatch) -> Path:
 # -----------------------------------------------------------------------------
 
 
+def _seed_coverage_registry(db_path: Path) -> None:
+    """A current-shape registry where one config was scored on fewer days."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    _create_registry_schema(conn)
+    conn.execute("ALTER TABLE prediction_metrics ADD COLUMN ic_mean_daily REAL")
+    conn.execute("ALTER TABLE prediction_metrics ADD COLUMN ic_n_days INTEGER")
+    conn.executemany(
+        "INSERT INTO training_runs (training_hash, family, config_name, label, spec_json, "
+        "created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("th_short", "gbm", "short_window", "fwd_ret_21d", "{}", "2024-01-01"),
+            ("th_full", "gbm", "full_window", "fwd_ret_21d", "{}", "2024-01-01"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO prediction_sets (prediction_hash, training_hash, checkpoint_value, "
+        "checkpoint_kind, split, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("ph_short", "th_short", 0, "final", "validation", "2024-01-02"),
+            ("ph_full", "th_full", 0, "final", "validation", "2024-01-02"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO prediction_metrics (prediction_hash, computed_at, ic_mean, ic_mean_daily, "
+        "ic_n_days, task_type) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("ph_short", "2024-01-03", 0.40, 0.40, 40, "regression"),
+            ("ph_full", "2024-01-03", 0.10, 0.10, 500, "regression"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_load_model_ic_drops_partially_covered_prediction_sets(tmp_path, monkeypatch) -> None:
+    """The short window scores four times higher and is not comparable."""
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    _seed_coverage_registry(tmp_path / "etfs" / "run_log" / "registry.db")
+
+    guarded = analytics.load_model_ic(case_studies=["etfs"], split="validation")
+    assert guarded["config_name"].to_list() == ["full_window"]
+    assert guarded["coverage_enforced"].to_list() == [True]
+
+    # Without the guard the 40-day row leads the ranking.
+    unguarded = analytics.load_model_ic(
+        case_studies=["etfs"], split="validation", require_full_coverage=False
+    )
+    assert unguarded["config_name"].to_list() == ["short_window", "full_window"]
+    assert unguarded["coverage_enforced"].to_list() == [False, False]
+
+
+def test_load_model_ic_reports_when_a_legacy_registry_cannot_be_guarded(
+    seeded_registries,
+) -> None:
+    """A registry with no coverage column returns rows flagged as unguarded."""
+    df = analytics.load_model_ic(case_studies=["etfs"], split="validation")
+
+    assert df.height > 0
+    assert df["coverage_enforced"].unique().to_list() == [False]
+
+
 def test_load_model_ic_returns_all_families_by_default(seeded_registries) -> None:
     df = analytics.load_model_ic(case_studies=["etfs", "crypto_perps_funding"], split="validation")
     # etfs: 3 validation rows (lin_a, lin_b, gbm_a) with regression task_type;

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -81,16 +81,26 @@ def test_embargo_counts_label_horizons_on_the_observed_grid() -> None:
 
 
 def test_embargo_without_an_observed_step_assumes_a_bar_size() -> None:
-    """The legacy conversion is wrong by the grid ratio, which is why it is documented.
+    """The fallback is wrong by the ratio between the assumed bar and the real one.
 
-    This is the defect that put a one-minute embargo against a fifteen-minute
-    label. It fails only when the assumption holds, so the assertion pins the
-    assumption rather than blessing the answer.
+    It pins the assumption rather than blessing the answer: "15min" resolves to
+    one period whatever the panel is recorded at, which is right on a 15-minute
+    grid and wrong by fifteen on a one-minute grid.
     """
     assert embargo_from_buffer("15min") == 1
-    assert embargo_from_buffer("15min") != embargo_from_buffer(
-        "15min", observed_step=pd.Timedelta("1min")
-    )
+    assert embargo_from_buffer("15min", observed_step=pd.Timedelta("15min")) == 1
+    assert embargo_from_buffer("15min", observed_step=pd.Timedelta("1min")) == 15
+
+
+def test_embargo_rejects_a_month_buffer_against_an_observation_step() -> None:
+    """A month has no fixed length, so it cannot be divided by a bar size."""
+    assert embargo_from_buffer("1M", periods_per_year=12) == 1
+    try:
+        embargo_from_buffer("1M", observed_step=pd.Timedelta("1D"))
+    except ValueError as error:
+        assert "month" in str(error).lower()
+    else:
+        raise AssertionError("a month buffer must not resolve against an observation step")
 
 
 def test_embargo_rounds_a_partial_period_up() -> None:

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -10,6 +10,7 @@ from case_studies.utils.causal import (
     block_permute,
     embargo_from_buffer,
     manual_dml_timeseries,
+    observation_step,
     run_dml_analysis,
 )
 
@@ -52,6 +53,58 @@ def test_panel_walk_forward_keeps_dates_whole_and_embargoes_dates() -> None:
 
 def test_monthly_label_buffer_is_one_monthly_decision_group() -> None:
     assert embargo_from_buffer("1M", periods_per_year=12) == 1
+
+
+def test_observation_step_measures_the_grid_and_ignores_session_gaps() -> None:
+    """The mode is the bar size; overnight and weekend gaps are outliers."""
+    session_one = pd.date_range("2021-01-04 09:30", periods=390, freq="1min")
+    session_two = pd.date_range("2021-01-05 09:30", periods=390, freq="1min")
+    frame = pd.DataFrame({"timestamp": session_one.append(session_two)})
+
+    assert observation_step(frame) == pd.Timedelta("1min")
+
+
+def test_observation_step_reads_a_polars_frame() -> None:
+    import polars as pl
+
+    frame = pl.DataFrame({"timestamp": pd.date_range("2021-01-04", periods=10, freq="1D")})
+
+    assert observation_step(frame) == pd.Timedelta("1D")
+
+
+def test_embargo_counts_label_horizons_on_the_observed_grid() -> None:
+    """A 15-minute label on a one-minute panel embargoes 15 periods, not one."""
+    assert embargo_from_buffer("15min", observed_step=pd.Timedelta("1min")) == 15
+    assert embargo_from_buffer("15min", observed_step="15min") == 1
+    assert embargo_from_buffer("8H", observed_step=pd.Timedelta("8h")) == 1
+    assert embargo_from_buffer("21D", observed_step=pd.Timedelta("1D")) == 21
+
+
+def test_embargo_without_an_observed_step_assumes_a_bar_size() -> None:
+    """The legacy conversion is wrong by the grid ratio, which is why it is documented.
+
+    This is the defect that put a one-minute embargo against a fifteen-minute
+    label. It fails only when the assumption holds, so the assertion pins the
+    assumption rather than blessing the answer.
+    """
+    assert embargo_from_buffer("15min") == 1
+    assert embargo_from_buffer("15min") != embargo_from_buffer(
+        "15min", observed_step=pd.Timedelta("1min")
+    )
+
+
+def test_embargo_rounds_a_partial_period_up() -> None:
+    """Half a period of gap is not a gap; the label still resolves inside it."""
+    assert embargo_from_buffer("10min", observed_step=pd.Timedelta("4min")) == 3
+
+
+def test_embargo_rejects_a_nonpositive_observed_step() -> None:
+    try:
+        embargo_from_buffer("15min", observed_step=pd.Timedelta(0))
+    except ValueError as error:
+        assert "positive" in str(error)
+    else:
+        raise AssertionError("a zero-length grid step must not resolve to an embargo")
 
 
 def test_panel_walk_forward_rejects_unsorted_groups() -> None:

--- a/tests/test_model_analysis_selection.py
+++ b/tests/test_model_analysis_selection.py
@@ -1,5 +1,6 @@
 import numpy as np
 import polars as pl
+import pytest
 
 from case_studies.utils.model_analysis import (
     best_model_per_family_fast,
@@ -21,15 +22,87 @@ def test_best_model_per_family_uses_daily_cross_sectional_ic() -> None:
     metrics = pl.DataFrame(
         {
             "family": ["linear", "linear", "gbm"],
-            "config_name": ["pooled_winner", "daily_winner", "gbm_daily"],
+            "config_name": ["pooled_leader", "daily_leader", "gbm_daily"],
             "ic_mean": [0.30, 0.10, 0.20],
             "ic_mean_daily": [0.05, 0.15, 0.12],
+            "ic_n_days": [500, 500, 500],
         }
     )
 
     selected = best_model_per_family_fast(metrics)
 
-    assert selected.filter(pl.col("family") == "linear")["config_name"].item() == "daily_winner"
+    assert selected.filter(pl.col("family") == "linear")["config_name"].item() == "daily_leader"
+
+
+def test_best_model_per_family_rejects_a_partially_covered_representative() -> None:
+    """A short window scores higher and must not represent the family."""
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm"],
+            "config_name": ["short_window", "full_window"],
+            "ic_mean_daily": [0.40, 0.12],
+            "ic_n_days": [40, 500],
+        }
+    )
+
+    selected = best_model_per_family_fast(metrics)
+
+    assert selected.height == 1
+    assert selected["config_name"].item() == "full_window"
+    # Without the coverage condition the 40-day row wins on score alone.
+    assert (
+        best_model_per_family_fast(metrics, require_full_coverage=False)["config_name"].item()
+        == "short_window"
+    )
+
+
+def test_best_model_per_family_compares_coverage_within_a_label() -> None:
+    """Labels with different histories stay comparable within themselves."""
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm", "gbm", "gbm"],
+            "label": ["fwd_ret_1d", "fwd_ret_1d", "fwd_ret_60d", "fwd_ret_60d"],
+            "config_name": ["short_1d", "full_1d", "short_60d", "full_60d"],
+            "ic_mean_daily": [0.40, 0.12, 0.50, 0.09],
+            "ic_n_days": [40, 500, 30, 120],
+        }
+    )
+
+    eligible = best_model_per_family_fast(metrics, require_full_coverage=True)
+
+    # One row per family is returned, and it came from the fully covered pool of
+    # its own label rather than from the label with the longer history.
+    assert eligible["config_name"].item() in {"full_1d", "full_60d"}
+
+
+def test_best_model_per_family_refuses_to_compare_without_a_coverage_column() -> None:
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm"],
+            "config_name": ["only"],
+            "ic_mean_daily": [0.1],
+        }
+    )
+
+    with pytest.raises(ValueError, match="ic_n_days"):
+        best_model_per_family_fast(metrics)
+
+
+def test_best_model_per_family_breaks_exact_ties_deterministically() -> None:
+    """Identical scores must not resolve on row order."""
+    rows = {
+        "family": ["gbm", "gbm"],
+        "config_name": ["b_config", "a_config"],
+        "prediction_hash": ["bbb", "aaa"],
+        "ic_mean_daily": [0.2, 0.2],
+        "ic_n_days": [500, 500],
+    }
+    forward = best_model_per_family_fast(pl.DataFrame(rows))
+    reversed_rows = {k: list(reversed(v)) for k, v in rows.items()}
+    backward = best_model_per_family_fast(pl.DataFrame(reversed_rows))
+
+    assert forward["prediction_hash"].item() == "aaa"
+    assert backward["prediction_hash"].item() == "aaa"
 
 
 def test_registry_loader_exposes_daily_ic_as_selection_metric(tmp_path, monkeypatch) -> None:

--- a/tests/test_model_analysis_selection.py
+++ b/tests/test_model_analysis_selection.py
@@ -90,6 +90,22 @@ def test_best_model_per_family_refuses_to_drop_a_family_with_no_coverage() -> No
         best_model_per_family_fast(metrics)
 
 
+def test_best_model_per_family_names_the_label_whose_coverage_is_missing() -> None:
+    """A family survives on one label while another vanishes; check at group level."""
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm"],
+            "label": ["fwd_ret_1d", "fwd_ret_60d"],
+            "config_name": ["backfilled", "uncounted"],
+            "ic_mean_daily": [0.10, 0.90],
+            "ic_n_days": [500, None],
+        }
+    )
+
+    with pytest.raises(ValueError, match="gbm/fwd_ret_60d"):
+        best_model_per_family_fast(metrics)
+
+
 def test_best_model_per_family_refuses_to_compare_without_a_coverage_column() -> None:
     metrics = pl.DataFrame(
         {

--- a/tests/test_model_analysis_selection.py
+++ b/tests/test_model_analysis_selection.py
@@ -75,6 +75,21 @@ def test_best_model_per_family_compares_coverage_within_a_label() -> None:
     assert eligible["config_name"].item() in {"full_1d", "full_60d"}
 
 
+def test_best_model_per_family_refuses_to_drop_a_family_with_no_coverage() -> None:
+    """A family whose coverage is all null must stop the comparison, not vanish."""
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm", "linear"],
+            "config_name": ["full", "short", "uncounted"],
+            "ic_mean_daily": [0.10, 0.40, 0.90],
+            "ic_n_days": [500, 40, None],
+        }
+    )
+
+    with pytest.raises(ValueError, match="linear"):
+        best_model_per_family_fast(metrics)
+
+
 def test_best_model_per_family_refuses_to_compare_without_a_coverage_column() -> None:
     metrics = pl.DataFrame(
         {


### PR DESCRIPTION
Three shared helpers let a comparison run on rows that do not describe the same thing. Each affects every case study that calls it.

## What was wrong

**`embargo_from_buffer`** converted a duration into a period count from a fixed assumption about bar size per unit, documented for the minute branch as "the bars in 15 minutes, assuming 15-minute base bars". A `15min` buffer therefore resolves to one period whatever the panel is recorded at, so on a one-minute grid it yields a one-minute embargo against a fifteen-minute label. Nothing in the result shows it.

**`best_model_per_family_fast`** filtered only on the score being non-null, so a prediction set scored on fewer decision days than its neighbours could represent its family in every downstream comparison. A shorter window is an easier window, so those rows tend to score highest.

**`load_model_ic`** ranked over every registered row with no coverage condition, and ordered on `ic_mean` alone, so an exact tie resolved on whatever SQLite returned first. `load_best_ic_per_family` inherited both.

**`resolve_best_prediction`** returned the highest-IC prediction set as rank-1 metadata. `reference/CASE_STUDY_PIPELINE.md` is explicit that IC selects nothing and that a configuration is chosen on validation backtest Sharpe.

## What changed

- `embargo_from_buffer` takes `observed_step` and converts exactly against it; new `observation_step` measures the grid from the data. Callers passing neither keep today's behaviour, which is correct on a daily grid and is now stated as an assumption. A month buffer has no fixed length and is rejected against an observation step.
- The shared DML request resolver already measured the analysis frame's cadence for the horizon and took the embargo from the assumed bar size on the next line. It now uses the measurement for both.
- `best_model_per_family_fast` restricts candidates to the maximum `ic_n_days` within each `(family, label)` before taking the highest score, breaks ties on `prediction_hash`, and refuses to run without a coverage column.
- `load_model_ic` applies the same full-coverage clause `BacktestExplorer.best` already uses, breaks ties on `prediction_hash`, and reports `coverage_enforced` per row.
- `resolve_best_prediction` is deleted.

## What each caller now gets

| Caller | Effect |
|---|---|
| 8 `*_model_analysis` notebooks | Family representatives restricted to full coverage. This can change which configuration represents a family — that is the point. Raises rather than silently dropping a family or label with no coverage count. |
| ~20 DL/latent-factor notebooks calling `load_best_ic_per_family` | Prior-baseline displays now read maximum-coverage rows only, with a deterministic tie-break. Display-only in all of them. |
| `16_strategy_simulation/validation/weights.py::get_best_model` | Picks a linear config by IC. Still does; it now picks from comparable rows deterministically. Flagged: this is IC selecting a model, which the pipeline forbids, and is left for its owner. |
| 9 `*_causal_dml` notebooks | Unchanged unless they pass `observed_step`. Those reaching DML through the shared resolver get the measured embargo. |
| `17_portfolio_construction/07_conformal_position_sizing.py` | Unaffected by the deletion: it defines its own `resolve_best_prediction` at line 114 and never imported this one. |

## Deliberate test changes

Two merged tests changed. The daily-IC selection test now seeds `ic_n_days`, because a frame without it no longer describes a comparable population, and its "winner" config names became "leader" so the fixture stops using verdict vocabulary.

## Evidence

`tests/test_case_study_analytics.py`, `tests/test_model_analysis_selection.py`, `tests/test_causal_panel_splits.py`, `tests/test_causal_adapter.py`, `tests/test_full_coverage_selection.py`: 67 passed.

Each change ships a test that fails without it: a 40-day row outscoring a 500-day row and being excluded, the same row winning when the guard is off, an exact tie resolving identically from both row orders, a missing coverage column raising, a family or label with null coverage being named rather than vanishing, a registry mid-backfill returning rows unguarded rather than none, and a `15min` buffer resolving to 15 periods on a one-minute grid and to 1 without the measurement.

## Noted, not fixed here

`nasdaq100_microstructure` is the worked example of why the fallback cannot be trusted, and it is not a misconfiguration. Its `setup.yaml` declares `decision.bar_frequency: 15_minute`, which names the **decision cadence** - `03_financial_features.py:966` filters the panel to every fifteenth minute to build that schedule - while the panel itself is observed once a minute. Both are correct and they are different quantities.

That is the trap this change exists for. A reader will read `bar_frequency: 15_minute` as "bars are fifteen minutes" and conclude the fallback's answer of one period is right. The observation grid is one minute, the label horizon is fifteen, and the embargo needs fifteen periods. Nothing in the config states the observation grid, which is why the helper measures it rather than reading a declaration.

`tests/test_case_studies.py::test_case_study_pipeline[etfs-13_model_analysis-notebook_path17]` fails on `main` before this branch with a join-key dtype mismatch in a fixture. Pre-existing and untouched here.
