### PR TITLE
Accept the canonical product entity key across the model adapters

### DIFF
--- a/case_studies/cme_futures/config/setup.yaml
+++ b/case_studies/cme_futures/config/setup.yaml
@@ -334,7 +334,7 @@ modeling:
   gbm:
     libraries: [lightgbm]
     preset: default
-    device: gpu
+    device: cpu
     max_bin: 63
   latent_factors:
     persistent_entities: true

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -855,8 +855,10 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         label_ref.name,
         max_symbols=int(reductions.get("max_symbols", 0)),
     )
-    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
-        raise ValueError("DML runner requires canonical symbol and timestamp keys")
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("DML runner requires timestamp and an entity key")
+    if mds.entity_cols[0] not in {"product", "symbol"}:
+        raise ValueError(f"DML runner does not support entity key {mds.entity_cols[0]!r}")
     configs = {
         config["config_name"]: config
         for config in load_configs(study.case_study, label_ref.name, "causal_dml")

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -362,6 +362,14 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             darts_validation_keys,
         )
 
+        # darts_validation_keys names its keys after the entity column and adds
+        # `position` where the panel has one, unlike the three key builders that
+        # emit `symbol`. No product-keyed case study configures a Darts preset,
+        # so that combination has never been exercised; refuse it here rather
+        # than fail later on a key that is missing from the digest.
+        if entity_col != "symbol":
+            raise ValueError(f"Darts presets require the symbol entity key, not {entity_col!r}")
+
         expected = darts_validation_keys(
             dataset_pd,
             splits,

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -310,8 +310,11 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         label_ref.name,
         max_symbols=int(reductions.get("max_symbols", 0)),
     )
-    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
-        raise ValueError("sequence runner requires canonical symbol and timestamp keys")
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("sequence runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+    if entity_col not in {"product", "symbol"}:
+        raise ValueError(f"sequence runner does not support entity key {entity_col!r}")
     if mds.task_type != "regression":
         raise ValueError("sequence runner currently supports regression labels only")
     cv = request.get("cv")
@@ -366,7 +369,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             feature_names=list(mds.feature_names),
             label_col=mds.label_col,
             date_col=mds.date_col,
-            entity_col=mds.entity_cols[0],
+            entity_col=entity_col,
             case_study=study.case_study,
             temporal_by_fold=mds.temporal_by_fold,
             temporal_keys=list(mds.temporal_keys),
@@ -392,7 +395,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             splits,
             label_col=mds.label_col,
             date_col=mds.date_col,
-            entity_col=mds.entity_cols[0],
+            entity_col=entity_col,
             lookback=lookback,
             calendar_id=calendar_id,
         )
@@ -467,7 +470,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         feature_names=tuple(mds.feature_names),
         label_col=mds.label_col,
         date_col=mds.date_col,
-        entity_col=mds.entity_cols[0],
+        entity_col=entity_col,
         task_type=mds.task_type,
         class_values=tuple(mds.class_values),
         temporal_by_fold=mds.temporal_by_fold,

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -552,6 +552,45 @@ def _cached_sequence_run(study: Study, spec: dict[str, Any], context: SequenceRe
     return ModelRun(training=training, predictions=predictions)
 
 
+def _publish_sequence_predictions(
+    study: Study,
+    computation: dict[str, Any],
+    context: SequenceResearchContext,
+    training,
+    result: dict[str, Any],
+) -> tuple:
+    """Register one prediction set per declared checkpoint under the expected key names."""
+    prediction_results = []
+    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
+        predictions = (
+            result["all_predictions"]
+            .filter(
+                (pl.col("config") == context.config["config_name"])
+                & (pl.col("epoch") == checkpoint)
+            )
+            .drop("config", "epoch")
+            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
+        )
+        # The expected keys are the internal contract and always name the entity
+        # `symbol`; the runner emits the reader-facing key the case study uses.
+        if context.entity_col != "symbol":
+            predictions = predictions.rename({context.entity_col: "symbol"})
+        prediction_results.append(
+            study.results.publish_predictions(
+                training,
+                checkpoint_kind="epoch",
+                checkpoint_value=int(checkpoint),
+                split="validation",
+                predictions=predictions,
+                expected_keys=context.expected_keys,
+                task_type="regression",
+                class_values=None,
+                label=context.label_col,
+            )
+        )
+    return tuple(prediction_results)
+
+
 def run_resolved_request(
     study: Study,
     spec: dict[str, Any],
@@ -602,34 +641,9 @@ def run_resolved_request(
         shutil.rmtree(staging, ignore_errors=True)
         raise
 
-    prediction_results = []
-    for checkpoint in (item["value"] for item in computation["checkpoint_schedule"]):
-        predictions = (
-            result["all_predictions"]
-            .filter(
-                (pl.col("config") == context.config["config_name"])
-                & (pl.col("epoch") == checkpoint)
-            )
-            .drop("config", "epoch")
-            .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
-        )
-        # The expected keys are the internal contract and always name the entity
-        # `symbol`; the runner emits the reader-facing key the case study uses.
-        if context.entity_col != "symbol" and context.entity_col in predictions.columns:
-            predictions = predictions.rename({context.entity_col: "symbol"})
-        prediction_results.append(
-            study.results.publish_predictions(
-                training,
-                checkpoint_kind="epoch",
-                checkpoint_value=int(checkpoint),
-                split="validation",
-                predictions=predictions,
-                expected_keys=context.expected_keys,
-                task_type="regression",
-                class_values=None,
-                label=context.label_col,
-            )
-        )
+    prediction_results = _publish_sequence_predictions(
+        study, computation, context, training, result
+    )
     runtime_path = train_dir / "runtime.json"
     if runtime_path.exists():
         runtime = json.loads(runtime_path.read_text())
@@ -637,7 +651,7 @@ def run_resolved_request(
             float(row.get("elapsed_s", 0.0)) for row in result["grid_results"]
         )
         runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n")
-    return ModelRun(training=training, predictions=tuple(prediction_results))
+    return ModelRun(training=training, predictions=prediction_results)
 
 
 # ---------------------------------------------------------------------------

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -605,6 +605,10 @@ def run_resolved_request(
             .drop("config", "epoch")
             .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
         )
+        # The expected keys are the internal contract and always name the entity
+        # `symbol`; the runner emits the reader-facing key the case study uses.
+        if context.entity_col != "symbol" and context.entity_col in predictions.columns:
+            predictions = predictions.rename({context.entity_col: "symbol"})
         prediction_results.append(
             study.results.publish_predictions(
                 training,

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -524,11 +524,15 @@ def _publish_tabm_predictions(
             .filter((pl.col("config") == result_key) & (pl.col("epoch") == checkpoint))
             .drop("config", "epoch")
             .rename({"fold_id": "fold", "y_true": "actual", "y_score": "prediction"})
-            .with_columns(
-                pl.col(context.date_col).cast(context.expected_keys.schema[context.date_col]),
-                pl.col(context.entity_col).cast(context.expected_keys.schema[context.entity_col]),
-                pl.col("fold").cast(context.expected_keys.schema["fold"]),
-            )
+        )
+        # The expected keys are the internal contract and always name the entity
+        # `symbol`; the runner emits the reader-facing key the case study uses.
+        if context.entity_col != "symbol":
+            predictions = predictions.rename({context.entity_col: "symbol"})
+        predictions = predictions.with_columns(
+            pl.col(context.date_col).cast(context.expected_keys.schema[context.date_col]),
+            pl.col("symbol").cast(context.expected_keys.schema["symbol"]),
+            pl.col("fold").cast(context.expected_keys.schema["fold"]),
         )
         prediction_results.append(
             study.results.publish_predictions(

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -279,8 +279,11 @@ def _resolve_model_request_from_materialized(
     unknown_reductions = set(reductions) - _TABM_PREVIEW_FIELDS
     if unknown_reductions:
         raise ValueError(f"unsupported TabM preview reductions: {sorted(unknown_reductions)}")
-    if mds.date_col != "timestamp" or mds.entity_cols[:1] != ["symbol"]:
-        raise ValueError("TabM runner requires canonical symbol and timestamp keys")
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("TabM runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+    if entity_col not in {"product", "symbol"}:
+        raise ValueError(f"TabM runner does not support entity key {entity_col!r}")
     splits, cv_record = _tabm_splits(mds, request)
     try:
         configured = configured_by_name[request["config_name"]]
@@ -379,7 +382,7 @@ def _resolve_model_request_from_materialized(
         label_col=mds.label_col,
         eval_label_col=mds.eval_label_col,
         date_col=mds.date_col,
-        entity_col=mds.entity_cols[0],
+        entity_col=entity_col,
         task_type=mds.task_type,
         class_values=tuple(mds.class_values),
         class_weights_by_fold=class_weights_by_fold,

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -25,7 +25,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def _causal_fixture(tmp_path, monkeypatch):
+def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol"):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -46,7 +46,7 @@ def _causal_fixture(tmp_path, monkeypatch):
         for symbol_index in range(6):
             rows.append(
                 {
-                    "symbol": f"S{symbol_index}",
+                    entity: f"S{symbol_index}",
                     "timestamp": timestamp,
                     "feature": float(symbol_index),
                     "treatment": float(symbol_index) + timestamp_index / 100,
@@ -57,7 +57,7 @@ def _causal_fixture(tmp_path, monkeypatch):
     frame = pl.DataFrame(rows)
     label = study.labels.publish(
         LabelDefinition("fwd_ret_8h", "regression", "8H"),
-        frame.select("symbol", "timestamp", "fwd_ret_8h"),
+        frame.rename({entity: "symbol"}).select("symbol", "timestamp", "fwd_ret_8h"),
     )
     mds = SimpleNamespace(
         dataset=frame,
@@ -65,7 +65,7 @@ def _causal_fixture(tmp_path, monkeypatch):
         label_col="fwd_ret_8h",
         label_buffer="8H",
         date_col="timestamp",
-        entity_cols=["symbol"],
+        entity_cols=[entity],
         input_lineage={
             "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
             "fingerprint": "fixture-v1",
@@ -219,3 +219,34 @@ def test_block_permutation_resets_at_temporal_gap() -> None:
 
     assert set(permuted[:4]) == set(values[:4])
     assert set(permuted[4:]) == set(values[4:])
+
+
+@pytest.mark.parametrize("entity", ["symbol", "product"])
+def test_causal_resolver_accepts_either_canonical_entity_key(tmp_path, monkeypatch, entity) -> None:
+    study, label = _causal_fixture(tmp_path, monkeypatch, entity=entity)
+
+    resolved = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={"max_samples": 240, "max_symbols": 6, "n_folds": 2, "n_placebo": 10},
+    ).resolve()
+
+    assert resolved.spec["computation"]["analysis_population"]["n_rows"] > 0
+
+
+def test_causal_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:
+    study, label = _causal_fixture(tmp_path, monkeypatch, entity="ticker")
+
+    with pytest.raises(ValueError, match="does not support entity key 'ticker'"):
+        study.causal(
+            method="dml",
+            label=label.name,
+            execution_tier="preview",
+            preview_reductions={
+                "max_samples": 240,
+                "max_symbols": 6,
+                "n_folds": 2,
+                "n_placebo": 10,
+            },
+        ).resolve()

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from importlib.metadata import version
 from types import SimpleNamespace
 
@@ -494,3 +495,56 @@ def test_darts_presets_refuse_a_non_symbol_entity_key(tmp_path, monkeypatch) -> 
     """The Darts key builder names its keys after the entity column, unlike the other three."""
     with pytest.raises(ValueError, match="Darts presets require the symbol entity key"):
         _resolve_nlinear_request(tmp_path, monkeypatch, entity="product", library="darts")
+
+
+@pytest.mark.parametrize("entity", ["symbol", "product"])
+def test_sequence_publishes_predictions_under_the_expected_key_names(entity) -> None:
+    """The runner emits the reader-facing entity key; the registry contract expects `symbol`."""
+    from case_studies.utils import deep_learning
+
+    expected_keys = pl.DataFrame(
+        {
+            "symbol": ["ES", "NQ"],
+            "timestamp": [datetime(2024, 1, 8), datetime(2024, 1, 8)],
+            "fold": [0, 0],
+        }
+    )
+    all_predictions = pl.DataFrame(
+        {
+            "config": ["nlinear_probe"] * 2,
+            "epoch": [2, 2],
+            entity: ["ES", "NQ"],
+            "timestamp": [datetime(2024, 1, 8), datetime(2024, 1, 8)],
+            "fold_id": [0, 0],
+            "y_true": [0.01, -0.01],
+            "y_score": [0.02, -0.02],
+        }
+    )
+    context = SimpleNamespace(
+        config={"config_name": "nlinear_probe"},
+        entity_col=entity,
+        expected_keys=expected_keys,
+        label_col="fwd_ret_1d",
+    )
+    published = []
+
+    def capture(_training, **kwargs):
+        published.append(kwargs["predictions"])
+        return kwargs["predictions"]
+
+    study = SimpleNamespace(results=SimpleNamespace(publish_predictions=capture))
+    computation = {"checkpoint_schedule": [{"kind": "epoch", "value": 2}]}
+
+    results = deep_learning._publish_sequence_predictions(
+        study, computation, context, object(), {"all_predictions": all_predictions}
+    )
+
+    assert len(results) == 1 and len(published) == 1
+    frame = published[0]
+    assert "symbol" in frame.columns
+    assert entity not in set(frame.columns) - {"symbol"}
+    assert (
+        frame.select("symbol", "timestamp", "fold")
+        .sort("symbol")
+        .equals(expected_keys.sort("symbol"))
+    )

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -23,7 +23,9 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def _resolve_nlinear_request(tmp_path, monkeypatch, entity: str = "symbol"):
+def _resolve_nlinear_request(
+    tmp_path, monkeypatch, entity: str = "symbol", library: str = "pytorch"
+):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -83,10 +85,14 @@ def _resolve_nlinear_request(tmp_path, monkeypatch, entity: str = "symbol"):
                 "batch_size": 64,
                 "checkpoint_interval": 2,
                 "n_epochs": 4,
-                "params": {"architecture": "nlinear", "dropout": 0.0, "lookback": 2},
+                "params": {
+                    "architecture": "tsmixer" if library == "darts" else "nlinear",
+                    "dropout": 0.0,
+                    "lookback": 2,
+                },
                 "config_name": "nlinear_probe",
                 "family": "deep_learning",
-                "library": "pytorch",
+                "library": library,
             }
         ],
     )
@@ -482,3 +488,9 @@ def test_sequence_resolver_accepts_either_canonical_entity_key(
 def test_sequence_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:
     with pytest.raises(ValueError, match="does not support entity key 'ticker'"):
         _resolve_nlinear_request(tmp_path, monkeypatch, entity="ticker")
+
+
+def test_darts_presets_refuse_a_non_symbol_entity_key(tmp_path, monkeypatch) -> None:
+    """The Darts key builder names its keys after the entity column, unlike the other three."""
+    with pytest.raises(ValueError, match="Darts presets require the symbol entity key"):
+        _resolve_nlinear_request(tmp_path, monkeypatch, entity="product", library="darts")

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -23,7 +23,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def _resolve_nlinear_request(tmp_path, monkeypatch):
+def _resolve_nlinear_request(tmp_path, monkeypatch, entity: str = "symbol"):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -39,7 +39,7 @@ def _resolve_nlinear_request(tmp_path, monkeypatch):
     ]
     frame = pl.DataFrame(
         {
-            "symbol": [f"S{symbol}" for symbol in range(3) for _ in dates],
+            entity: [f"S{symbol}" for symbol in range(3) for _ in dates],
             "timestamp": dates * 3,
             "feature": [float(index) for index in range(24)],
             "fwd_ret_1d": [float(index % 3) / 100 for index in range(24)],
@@ -47,7 +47,7 @@ def _resolve_nlinear_request(tmp_path, monkeypatch):
     ).with_columns(pl.col("timestamp").str.to_date())
     label = study.labels.publish(
         LabelDefinition("fwd_ret_1d", "regression", "1D"),
-        frame.select("symbol", "timestamp", "fwd_ret_1d"),
+        frame.rename({entity: "symbol"}).select("symbol", "timestamp", "fwd_ret_1d"),
     )
     splits = [
         {
@@ -63,7 +63,7 @@ def _resolve_nlinear_request(tmp_path, monkeypatch):
         feature_names=["feature"],
         label_col="fwd_ret_1d",
         date_col="timestamp",
-        entity_cols=["symbol"],
+        entity_cols=[entity],
         splits=splits,
         task_type="regression",
         class_values=[],
@@ -466,3 +466,19 @@ def test_deep_adapters_reject_custom_cv_with_stale_temporal_geometry(split_resol
 
     with pytest.raises(ValueError, match="Custom CV cannot reuse fold-specific temporal features"):
         split_resolver(mds, {"cv": cv, "preview_reductions": {}})
+
+
+@pytest.mark.parametrize("entity", ["symbol", "product"])
+def test_sequence_resolver_accepts_either_canonical_entity_key(
+    tmp_path, monkeypatch, entity
+) -> None:
+    _study, _label, resolved = _resolve_nlinear_request(tmp_path, monkeypatch, entity=entity)
+
+    assert resolved._context.entity_col == entity
+    assert resolved._context.expected_keys.columns == ["symbol", "timestamp", "fold"]
+    assert resolved._context.expected_keys.height > 0
+
+
+def test_sequence_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:
+    with pytest.raises(ValueError, match="does not support entity key 'ticker'"):
+        _resolve_nlinear_request(tmp_path, monkeypatch, entity="ticker")

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from types import SimpleNamespace
 
 import polars as pl
@@ -355,3 +356,62 @@ def test_tabm_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) 
             config_name="tabm_probe",
             overrides={"device": "cpu"},
         ).resolve()
+
+
+@pytest.mark.parametrize("entity", ["symbol", "product"])
+def test_tabm_publishes_predictions_under_the_expected_key_names(monkeypatch, entity) -> None:
+    """The runner emits the reader-facing entity key; the registry contract expects `symbol`."""
+    from case_studies.utils import tabular_dl
+
+    expected_keys = pl.DataFrame(
+        {
+            "symbol": ["ES", "NQ"],
+            "timestamp": [datetime(2024, 1, 3), datetime(2024, 1, 3)],
+            "fold": [0, 0],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("ms")))
+    all_predictions = pl.DataFrame(
+        {
+            "config": ["tabm_probe"] * 2,
+            "epoch": [2, 2],
+            entity: ["ES", "NQ"],
+            "timestamp": [datetime(2024, 1, 3), datetime(2024, 1, 3)],
+            "fold_id": [0, 0],
+            "y_true": [0.01, -0.01],
+            "y_score": [0.02, -0.02],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us")))
+    context = SimpleNamespace(
+        config={"config_name": "tabm_probe"},
+        date_col="timestamp",
+        entity_col=entity,
+        expected_keys=expected_keys,
+        task_type="regression",
+        class_values=(),
+        eval_label_col=None,
+        label_col="fwd_ret_1d",
+    )
+    published = []
+
+    def capture(_training, **kwargs):
+        published.append(kwargs["predictions"])
+        return kwargs["predictions"]
+
+    study = SimpleNamespace(results=SimpleNamespace(publish_predictions=capture))
+    spec = {"computation": {"checkpoint_schedule": [{"kind": "epoch", "value": 2}]}}
+
+    tabular_dl._publish_tabm_predictions(
+        study, spec, context, object(), {"all_predictions": all_predictions}
+    )
+
+    assert len(published) == 1
+    frame = published[0]
+    assert "symbol" in frame.columns and entity not in set(frame.columns) - {"symbol"}
+    assert frame.schema["symbol"] == expected_keys.schema["symbol"]
+    assert frame.schema["timestamp"] == expected_keys.schema["timestamp"]
+    assert frame.schema["fold"] == expected_keys.schema["fold"]
+    assert (
+        frame.select("symbol", "timestamp", "fold")
+        .sort("symbol")
+        .equals(expected_keys.sort("symbol"))
+    )

--- a/tests/test_tabular_dl_adapter.py
+++ b/tests/test_tabular_dl_adapter.py
@@ -251,3 +251,107 @@ def test_tabm_classification_resolves_targets_imbalance_and_preview_checkpoints(
         "accuracy",
         "balanced_accuracy",
     ]
+
+
+def _entity_keyed_dataset(entity: str) -> tuple[pl.DataFrame, SimpleNamespace, list[dict]]:
+    """Build a four-session panel whose entity column carries the given canonical name."""
+    frame = pl.DataFrame(
+        {
+            entity: [f"S{index}" for index in range(6)] * 4,
+            "timestamp": [
+                date
+                for date in ("2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04")
+                for _ in range(6)
+            ],
+            "feature": [float(index) for index in range(24)],
+            "fwd_ret_1d": [float(index % 6) / 100 for index in range(24)],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    splits = [
+        {
+            "fold": 0,
+            "train_start": "2024-01-01",
+            "train_end": "2024-01-02",
+            "val_start": "2024-01-03",
+            "val_end": "2024-01-04",
+        }
+    ]
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_cols=[entity],
+        splits=splits,
+        task_type="regression",
+        class_values=[],
+        eval_label_col=None,
+        temporal_by_fold=None,
+        temporal_keys=[],
+        temporal_feature_names=[],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    return frame, mds, splits
+
+
+def _tabm_config() -> list[dict]:
+    return [
+        {
+            "batch_size": 64,
+            "checkpoint_interval": 5,
+            "n_epochs": 10,
+            "params": {"dropout": 0.0, "hidden_dim": 4, "n_members": 2},
+            "config_name": "tabm_probe",
+            "family": "tabular_dl",
+            "library": "tabm",
+        }
+    ]
+
+
+@pytest.mark.parametrize("entity", ["symbol", "product"])
+def test_tabm_resolver_accepts_either_canonical_entity_key(tmp_path, monkeypatch, entity) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    frame, mds, _ = _entity_keyed_dataset(entity)
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.rename({entity: "symbol"}).select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: mds)
+    monkeypatch.setattr("utils.modeling.load_configs", lambda *a, **k: _tabm_config())
+
+    resolved = study.model(
+        family="tabular_dl",
+        label=label.name,
+        config_name="tabm_probe",
+        overrides={"device": "cpu"},
+    ).resolve()
+
+    assert resolved._context.entity_col == entity
+    assert resolved._context.expected_keys.columns == ["symbol", "timestamp", "fold"]
+    assert resolved._context.expected_keys.height == 12
+
+
+def test_tabm_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    frame, mds, _ = _entity_keyed_dataset("ticker")
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_1d", "regression", "1D"),
+        frame.rename({"ticker": "symbol"}).select("symbol", "timestamp", "fwd_ret_1d"),
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: mds)
+    monkeypatch.setattr("utils.modeling.load_configs", lambda *a, **k: _tabm_config())
+
+    with pytest.raises(ValueError, match="does not support entity key 'ticker'"):
+        study.model(
+            family="tabular_dl",
+            label=label.name,
+            config_name="tabm_probe",
+            overrides={"device": "cpu"},
+        ).resolve()


### PR DESCRIPTION
Three of the six model-family adapters refused any panel whose entity key is not literally `symbol`, and `cme_futures` is the one case study whose canonical entity key is `product`. Three of its nine phase-1 notebooks could not run at all.

### The guard

`tabular_dl.py`, `deep_learning.py` and `causal.py` each tested `mds.entity_cols[:1] != ["symbol"]`. `linear.py`, `gbm.py` and `latent_factors/adapter.py` already accept `{"product", "symbol"}`. The three now use the same two-step check as their three siblings, and the resolved `entity_col` is threaded through instead of `mds.entity_cols[0]` being read again at each call site.

### The publish boundary

Fixing the guard was not fixing the path. With the guards aligned, `08_tabular_dl` raised `KeyError: 'product'` and `09_dl_lstm` raised `prediction coverage requires columns ['fold_id', 'symbol', 'timestamp']; missing {'symbol'}`, both after resolution and before any prediction reached the registry. The expected-key frames are the internal contract and always name the entity `symbol`; the runner emits the reader-facing key. `linear.py` already renamed at that boundary, TabM and the sequence path did not, and they do now. The rename is a no-op for the eight case studies keyed on `symbol`.

The sequence publish loop is extracted as `_publish_sequence_predictions` so it can be tested in the same shape as `_publish_tabm_predictions`.

### Darts

`darts_validation_keys` names its keys after the entity column and adds `position` where the panel has one, unlike the three builders that emit `symbol`. No product-keyed case study configures a Darts preset, so the combination has never run. It is refused with a reason rather than claimed as supported.

### GBM device

`case_studies/cme_futures/config/setup.yaml` declared `modeling.gbm.device: gpu` against a LightGBM 4.6.0 wheel with no CUDA tree learner, so resolving any CME GBM request raised before a model was planned. Third instance of the same defect and fix, after `crypto_perps_funding` in ce91dfac (#533) and `fx_pairs`.

`old -> new -> cause`: CME GBM planning raised `RuntimeError` -> resolves and fits the declared population, 30 configurations and 300 checkpoint prediction sets at preview width -> the declared device named a LightGBM build that was never installed, not a model change.

### Verification

```
uv run pytest -q tests/test_tabular_dl_adapter.py tests/test_tabular_dl.py \
  tests/test_tabular_dl_runtime.py tests/test_deep_learning_adapter.py \
  tests/test_deep_learning_state.py tests/test_darts_state.py \
  tests/test_causal_adapter.py tests/test_causal_panel_splits.py \
  tests/test_causal_registry_registration.py tests/test_research_models.py
146 passed
```

The tests parametrize the entity key over `symbol` and `product`, assert that an unsupported key is named in the refusal, and pin both publish boundaries. Each new test fails against the code it covers: the TabM pair on the old guard message, both publish tests with the entity column still named `product`.

Reduced real-data previews on `cme_futures`, preview execution tier, isolated preview root, one fold, six products, thread pools capped at 4:

| notebook | before | after |
|---|---|---|
| `07_gbm` | raised at resolve | 1:40.95 cold, 0:35.43 on the restart that reused persisted fitted state, 4.0 GB |
| `08_tabular_dl` | raised at resolve, then `KeyError: 'product'` | 18.9 s, 4.4 GB |
| `09_dl_lstm` | coverage error on the published frame | 32.9 s, 4.0 GB |
| `11_causal_dml` | raised at resolve | 7.3 s, 2.5 GB |
