### PR TITLE
Pin the linear and causal thread pool and use the full canonical DML population

### DIFF
--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -12,11 +12,23 @@ from __future__ import annotations
 
 import os
 
-# Pin OpenMP threading before sklearn imports. HistGradientBoostingRegressor
-# uses OMP-parallel histogram construction whose floating-point reduction order
-# is non-deterministic across threads. With OMP_NUM_THREADS=1 the placebo loop
-# is bit-reproducible across runs at the same seed/spec/data.
+# HistGradientBoostingRegressor uses OMP-parallel histogram construction whose
+# floating-point reduction order is non-deterministic across threads, so the placebo
+# loop is only bit-reproducible at a fixed thread count.
+#
+# Setting OMP_NUM_THREADS here does NOT achieve that on its own. Every notebook imports
+# case_studies.research (and through it sklearn) before this module, so the OpenMP and
+# OpenBLAS runtimes have already read the variable by the time this line runs: measured
+# with threadpoolctl, the notebook import order leaves the openmp pool at 16 and openblas
+# at 24 despite os.environ reporting 1. The env pin is kept because it does work when this
+# module is imported first, but DML_THREAD_LIMIT below is the mechanism that holds, and the
+# limit is recorded in the resolved specification so two runs at different counts cannot
+# share an identity.
 os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+# Fixed rather than derived from the host: a value like -1 varies with the machine, so a
+# result would not be identity-stable across the readers' hardware.
+DML_THREAD_LIMIT = 1
 
 import hashlib
 import importlib.metadata
@@ -34,6 +46,7 @@ import statsmodels.api as sm
 from scipy import stats
 from sklearn.ensemble import HistGradientBoostingRegressor
 from statsmodels.regression.linear_model import OLS
+from threadpoolctl import threadpool_limits
 
 from utils.modeling import RANDOM_SEED, seed_everything
 
@@ -311,6 +324,7 @@ def manual_dml_timeseries(
     hac_maxlags: int | None = None,
     horizon: int | None = None,
     groups: np.ndarray | None = None,
+    thread_limit: int = DML_THREAD_LIMIT,
 ) -> dict:
     """Walk-forward DML with embargo for temporal data.
 
@@ -359,132 +373,138 @@ def manual_dml_timeseries(
         n_obs, n_periods, hac_maxlags, covariance_type. If return_residuals:
         also Y_res, T_res.
     """
-    seed_everything(RANDOM_SEED)
+    # Pinned here, where the nuisance models are actually fitted, so that every caller is
+    # covered: run_dml_analysis, the six case-study DML stages that call it directly, and
+    # the chapter-15 notebooks that call this function themselves and rely on the default
+    # HistGradientBoostingRegressor. The module-level OMP_NUM_THREADS setdefault does not
+    # bind for any of them, because sklearn is imported first.
+    with threadpool_limits(limits=thread_limit):
+        seed_everything(RANDOM_SEED)
 
-    n = len(Y)
+        n = len(Y)
 
-    # Initialize residual arrays
-    Y_res = np.full(n, np.nan)
-    T_res = np.full(n, np.nan)
+        # Initialize residual arrays
+        Y_res = np.full(n, np.nan)
+        T_res = np.full(n, np.nan)
 
-    folds = _walk_forward_indices(n, n_folds, embargo, groups=groups)
+        folds = _walk_forward_indices(n, n_folds, embargo, groups=groups)
 
-    for train_idx, test_idx in folds:
-        if len(test_idx) == 0:
-            continue
+        for train_idx, test_idx in folds:
+            if len(test_idx) == 0:
+                continue
 
-        if len(train_idx) < 50 or len(test_idx) < 10:
-            continue
+            if len(train_idx) < 50 or len(test_idx) < 10:
+                continue
 
-        # Fit nuisance models on training data (clone to avoid mutation)
-        from sklearn.base import clone
+            # Fit nuisance models on training data (clone to avoid mutation)
+            from sklearn.base import clone
 
-        _default_y = HistGradientBoostingRegressor(max_iter=50, max_depth=3, random_state=42)
-        _default_t = HistGradientBoostingRegressor(max_iter=50, max_depth=3, random_state=42)
-        my = clone(model_y) if model_y is not None else _default_y
-        mt = clone(model_t) if model_t is not None else _default_t
+            _default_y = HistGradientBoostingRegressor(max_iter=50, max_depth=3, random_state=42)
+            _default_t = HistGradientBoostingRegressor(max_iter=50, max_depth=3, random_state=42)
+            my = clone(model_y) if model_y is not None else _default_y
+            mt = clone(model_t) if model_t is not None else _default_t
 
-        my.fit(X[train_idx], Y[train_idx])
-        mt.fit(X[train_idx], T[train_idx])
+            my.fit(X[train_idx], Y[train_idx])
+            mt.fit(X[train_idx], T[train_idx])
 
-        Y_res[test_idx] = Y[test_idx] - my.predict(X[test_idx])
-        T_res[test_idx] = T[test_idx] - mt.predict(X[test_idx])
+            Y_res[test_idx] = Y[test_idx] - my.predict(X[test_idx])
+            T_res[test_idx] = T[test_idx] - mt.predict(X[test_idx])
 
-    # Drop observations without residuals
-    valid = ~np.isnan(Y_res) & ~np.isnan(T_res)
-    Y_v = Y_res[valid]
-    T_v = T_res[valid]
-    n_valid = len(Y_v)
-    valid_groups = np.asarray(groups)[valid] if groups is not None else None
-    n_periods = len(np.unique(valid_groups)) if valid_groups is not None else n_valid
+        # Drop observations without residuals
+        valid = ~np.isnan(Y_res) & ~np.isnan(T_res)
+        Y_v = Y_res[valid]
+        T_v = T_res[valid]
+        n_valid = len(Y_v)
+        valid_groups = np.asarray(groups)[valid] if groups is not None else None
+        n_periods = len(np.unique(valid_groups)) if valid_groups is not None else n_valid
 
-    empty = {
-        "theta": np.nan,
-        "se_iid": np.nan,
-        "se_hac": np.nan,
-        "t_stat_iid": np.nan,
-        "t_stat_hac": np.nan,
-        "p_value_hac": np.nan,
-        "n_obs": n_valid,
-        "n_periods": n_periods,
-        "hac_maxlags": 0,
-        "covariance_type": "driscoll_kraay" if groups is not None else "newey_west",
-    }
-    if n_valid < 50:
+        empty = {
+            "theta": np.nan,
+            "se_iid": np.nan,
+            "se_hac": np.nan,
+            "t_stat_iid": np.nan,
+            "t_stat_hac": np.nan,
+            "p_value_hac": np.nan,
+            "n_obs": n_valid,
+            "n_periods": n_periods,
+            "hac_maxlags": 0,
+            "covariance_type": "driscoll_kraay" if groups is not None else "newey_west",
+        }
+        if n_valid < 50:
+            if return_residuals:
+                empty["Y_res"] = Y_res
+                empty["T_res"] = T_res
+            return empty
+
+        # Final stage: Y_res = alpha + theta * T_res + epsilon
+        # Must include intercept: cross-fitting residuals may have non-zero mean
+        # when training data varies across folds (expanding window).
+        if hac_maxlags is None:
+            auto = max(1, int(n_periods ** (1 / 3)))
+            # Overlapping h-period labels need L >= h-1; the cube-root rule is
+            # horizon-blind and under-lags long-horizon overlapping returns.
+            hac_maxlags = max(horizon - 1, auto) if horizon else auto
+            hac_maxlags = min(hac_maxlags, max(1, n_periods // 2))
+
+        T_const = sm.add_constant(T_v)
+        ols_iid = OLS(Y_v, T_const).fit()
+        theta = ols_iid.params[1]
+
+        # HC0 standard error
+        se_iid = np.sqrt(ols_iid.cov_HC0[1, 1])
+
+        # Serial-correlation-robust standard error with frequency-adaptive bandwidth.
+        # Panel rows share decision times, so ordinary row-wise Newey-West treats
+        # cross-sectional observations as extra time periods and understates risk.
+        # Driscoll-Kraay aggregates the score by decision time and remains robust to
+        # general cross-sectional dependence.
+        se_hac = se_iid
+        try:
+            if valid_groups is not None:
+                time_codes = pd.factorize(valid_groups, sort=False)[0]
+                robust = ols_iid.get_robustcov_results(
+                    cov_type="hac-groupsum",
+                    time=time_codes,
+                    maxlags=hac_maxlags,
+                    use_correction="hac",
+                    df_correction=False,
+                )
+            else:
+                robust = ols_iid.get_robustcov_results(
+                    cov_type="HAC",
+                    maxlags=hac_maxlags,
+                    use_correction=True,
+                )
+            cov = robust.cov_params()
+            se_hac = np.sqrt(cov.iloc[1, 1] if hasattr(cov, "iloc") else cov[1, 1])
+        except Exception:
+            pass  # Fall back to HC0 standard errors on numerical failure
+
+        t_stat_hac = theta / se_hac if se_hac > 0 else np.nan
+        p_value_hac = (
+            2 * stats.t.sf(abs(t_stat_hac), df=max(n_periods - 2, 1))
+            if not np.isnan(t_stat_hac)
+            else np.nan
+        )
+
+        result = {
+            "theta": theta,
+            "se_iid": se_iid,
+            "se_hac": se_hac,
+            "t_stat_iid": theta / se_iid if se_iid > 0 else np.nan,
+            "t_stat_hac": t_stat_hac,
+            "p_value_hac": p_value_hac,
+            "n_obs": n_valid,
+            "n_periods": n_periods,
+            "hac_maxlags": hac_maxlags,
+            "covariance_type": "driscoll_kraay" if groups is not None else "newey_west",
+        }
+
         if return_residuals:
-            empty["Y_res"] = Y_res
-            empty["T_res"] = T_res
-        return empty
+            result["Y_res"] = Y_res
+            result["T_res"] = T_res
 
-    # Final stage: Y_res = alpha + theta * T_res + epsilon
-    # Must include intercept: cross-fitting residuals may have non-zero mean
-    # when training data varies across folds (expanding window).
-    if hac_maxlags is None:
-        auto = max(1, int(n_periods ** (1 / 3)))
-        # Overlapping h-period labels need L >= h-1; the cube-root rule is
-        # horizon-blind and under-lags long-horizon overlapping returns.
-        hac_maxlags = max(horizon - 1, auto) if horizon else auto
-        hac_maxlags = min(hac_maxlags, max(1, n_periods // 2))
-
-    T_const = sm.add_constant(T_v)
-    ols_iid = OLS(Y_v, T_const).fit()
-    theta = ols_iid.params[1]
-
-    # HC0 standard error
-    se_iid = np.sqrt(ols_iid.cov_HC0[1, 1])
-
-    # Serial-correlation-robust standard error with frequency-adaptive bandwidth.
-    # Panel rows share decision times, so ordinary row-wise Newey-West treats
-    # cross-sectional observations as extra time periods and understates risk.
-    # Driscoll-Kraay aggregates the score by decision time and remains robust to
-    # general cross-sectional dependence.
-    se_hac = se_iid
-    try:
-        if valid_groups is not None:
-            time_codes = pd.factorize(valid_groups, sort=False)[0]
-            robust = ols_iid.get_robustcov_results(
-                cov_type="hac-groupsum",
-                time=time_codes,
-                maxlags=hac_maxlags,
-                use_correction="hac",
-                df_correction=False,
-            )
-        else:
-            robust = ols_iid.get_robustcov_results(
-                cov_type="HAC",
-                maxlags=hac_maxlags,
-                use_correction=True,
-            )
-        cov = robust.cov_params()
-        se_hac = np.sqrt(cov.iloc[1, 1] if hasattr(cov, "iloc") else cov[1, 1])
-    except Exception:
-        pass  # Fall back to HC0 standard errors on numerical failure
-
-    t_stat_hac = theta / se_hac if se_hac > 0 else np.nan
-    p_value_hac = (
-        2 * stats.t.sf(abs(t_stat_hac), df=max(n_periods - 2, 1))
-        if not np.isnan(t_stat_hac)
-        else np.nan
-    )
-
-    result = {
-        "theta": theta,
-        "se_iid": se_iid,
-        "se_hac": se_hac,
-        "t_stat_iid": theta / se_iid if se_iid > 0 else np.nan,
-        "t_stat_hac": t_stat_hac,
-        "p_value_hac": p_value_hac,
-        "n_obs": n_valid,
-        "n_periods": n_periods,
-        "hac_maxlags": hac_maxlags,
-        "covariance_type": "driscoll_kraay" if groups is not None else "newey_west",
-    }
-
-    if return_residuals:
-        result["Y_res"] = Y_res
-        result["T_res"] = T_res
-
-    return result
+        return result
 
 
 REFUTATION_ALPHA = 0.05
@@ -535,6 +555,7 @@ def run_dml_analysis(
     model_y=None,
     model_t=None,
     expected_step: str | pd.Timedelta | None = None,
+    thread_limit: int = DML_THREAD_LIMIT,
 ) -> dict:
     """Full DML analysis pipeline: naive OLS, DML, and refutation tests.
 
@@ -585,135 +606,144 @@ def run_dml_analysis(
         empirical_p, placebo_mean, placebo_std, placebo_effects,
         refutation_class), p_value_hac, hac_maxlags, and n_obs.
     """
-    # Input validation
-    time_col, entity_col = _resolve_panel_columns(df, time_col, entity_col)
-    n = len(df)
-    min_rows = (n_folds + 1) * 50 + n_folds * embargo
-    if n < min_rows:
-        raise ValueError(
-            f"Need at least {min_rows} rows for {n_folds}-fold CV with embargo={embargo}, got {n}"
-        )
-    if df[treatment_col].std() < 1e-10:
-        raise ValueError(f"Treatment '{treatment_col}' has near-zero variance")
-    if df[outcome_col].std() < 1e-10:
-        raise ValueError(f"Outcome '{outcome_col}' has near-zero variance")
+    # Also wrapped here, not only inside manual_dml_timeseries. The naive-OLS comparison
+    # below runs np.linalg.lstsq after that call returns, and LAPACK's dgelsd reaches
+    # threaded BLAS on a tall design - so naive_effect, and confounding_bias_pct which is a
+    # difference between it and the pinned theta, would otherwise vary with the ambient
+    # pool while the spec records deterministic_reduction: True. The inner context nests
+    # harmlessly and still covers callers that use manual_dml_timeseries directly.
+    with threadpool_limits(limits=thread_limit):
+        # Input validation
+        time_col, entity_col = _resolve_panel_columns(df, time_col, entity_col)
+        n = len(df)
+        min_rows = (n_folds + 1) * 50 + n_folds * embargo
+        if n < min_rows:
+            raise ValueError(
+                f"Need at least {min_rows} rows for {n_folds}-fold CV with embargo={embargo}, got {n}"
+            )
+        if df[treatment_col].std() < 1e-10:
+            raise ValueError(f"Treatment '{treatment_col}' has near-zero variance")
+        if df[outcome_col].std() < 1e-10:
+            raise ValueError(f"Outcome '{outcome_col}' has near-zero variance")
 
-    if hac_maxlags is None and horizon is None:
-        import warnings
+        if hac_maxlags is None and horizon is None:
+            import warnings
 
-        warnings.warn(
-            "run_dml_analysis: no horizon or hac_maxlags given; the second-stage "
-            "HAC bandwidth falls back to the horizon-blind cube-root rule, which "
-            "under-lags overlapping labels of horizon >= ~10 and overstates the "
-            "t-statistic. Pass horizon=embargo_from_buffer(mds.label_buffer).",
-            stacklevel=2,
-        )
+            warnings.warn(
+                "run_dml_analysis: no horizon or hac_maxlags given; the second-stage "
+                "HAC bandwidth falls back to the horizon-blind cube-root rule, which "
+                "under-lags overlapping labels of horizon >= ~10 and overstates the "
+                "t-statistic. Pass horizon=embargo_from_buffer(mds.label_buffer).",
+                stacklevel=2,
+            )
 
-    _dml_started_at = datetime.now(UTC).isoformat()
-    _dml_t0 = time.perf_counter()
+        _dml_started_at = datetime.now(UTC).isoformat()
+        _dml_t0 = time.perf_counter()
 
-    rng = np.random.default_rng(seed)
+        rng = np.random.default_rng(seed)
 
-    T = df[treatment_col].values
-    Y = df[outcome_col].values
-    X = df[confounder_cols].values
-    groups = df[time_col].values if time_col is not None else None
-    units = df[entity_col].values if entity_col is not None else None
+        T = df[treatment_col].values
+        Y = df[outcome_col].values
+        X = df[confounder_cols].values
+        groups = df[time_col].values if time_col is not None else None
+        units = df[entity_col].values if entity_col is not None else None
 
-    # DML estimate
-    dml = manual_dml_timeseries(
-        Y,
-        T,
-        X,
-        n_folds=n_folds,
-        embargo=embargo,
-        return_residuals=True,
-        hac_maxlags=hac_maxlags,
-        horizon=horizon,
-        groups=groups,
-        model_y=model_y,
-        model_t=model_t,
-    )
-
-    # Compare the adjusted estimate with naive OLS on the exact second-stage
-    # population. Earlier walk-forward dates have no out-of-fold residuals and
-    # cannot enter only one side of the comparison.
-    valid = np.isfinite(dml["Y_res"]) & np.isfinite(dml["T_res"])
-    naive_n_obs = int(valid.sum())
-    T_const = np.column_stack([np.ones(naive_n_obs), T[valid]])
-    naive_coef = np.linalg.lstsq(T_const, Y[valid], rcond=None)[0]
-    naive_effect = naive_coef[1]
-
-    # Confounding bias
-    dml_effect = dml["theta"]
-    bias = naive_effect - dml_effect
-    bias_pct = bias / abs(dml_effect) * 100 if dml_effect != 0 else 0.0
-
-    # Block permutation refutation
-    placebo_effects = []
-    placebo_n_obs = []
-    for _ in range(n_placebo):
-        T_perm = block_permute(
-            T,
-            block_size,
-            rng=rng,
-            groups=groups,
-            units=units,
-            expected_step=expected_step,
-        )
-        perm_result = manual_dml_timeseries(
+        # DML estimate
+        dml = manual_dml_timeseries(
             Y,
-            T_perm,
+            T,
             X,
             n_folds=n_folds,
             embargo=embargo,
+            return_residuals=True,
             hac_maxlags=hac_maxlags,
             horizon=horizon,
             groups=groups,
             model_y=model_y,
             model_t=model_t,
+            thread_limit=thread_limit,
         )
-        if not np.isnan(perm_result["theta"]):
-            if perm_result["n_obs"] != dml["n_obs"]:
-                raise RuntimeError(
-                    "Observed and placebo DML statistics use different second-stage samples"
-                )
-            placebo_effects.append(perm_result["theta"])
-            placebo_n_obs.append(int(perm_result["n_obs"]))
 
-    refutation = {}
-    if len(placebo_effects) >= 10:
-        placebo_arr = np.array(placebo_effects)
-        p_mean = np.mean(placebo_arr)
-        p_std = np.std(placebo_arr)
-        z = (dml_effect - p_mean) / p_std if p_std > 0 else np.inf
-        emp_p = float(np.mean(np.abs(placebo_arr) >= np.abs(dml_effect)))
-        ref_class = classify_refutation(emp_p)
-        refutation = {
-            "z_score": z,
-            "empirical_p": emp_p,
-            "placebo_mean": p_mean,
-            "placebo_std": p_std,
-            "n_successful": len(placebo_effects),
-            "n_folds": n_folds,
-            "placebo_n_obs": placebo_n_obs,
-            "placebo_effects": placebo_effects,
-            "refutation_class": ref_class,
+        # Compare the adjusted estimate with naive OLS on the exact second-stage
+        # population. Earlier walk-forward dates have no out-of-fold residuals and
+        # cannot enter only one side of the comparison.
+        valid = np.isfinite(dml["Y_res"]) & np.isfinite(dml["T_res"])
+        naive_n_obs = int(valid.sum())
+        T_const = np.column_stack([np.ones(naive_n_obs), T[valid]])
+        naive_coef = np.linalg.lstsq(T_const, Y[valid], rcond=None)[0]
+        naive_effect = naive_coef[1]
+
+        # Confounding bias
+        dml_effect = dml["theta"]
+        bias = naive_effect - dml_effect
+        bias_pct = bias / abs(dml_effect) * 100 if dml_effect != 0 else 0.0
+
+        # Block permutation refutation
+        placebo_effects = []
+        placebo_n_obs = []
+        for _ in range(n_placebo):
+            T_perm = block_permute(
+                T,
+                block_size,
+                rng=rng,
+                groups=groups,
+                units=units,
+                expected_step=expected_step,
+            )
+            perm_result = manual_dml_timeseries(
+                Y,
+                T_perm,
+                X,
+                n_folds=n_folds,
+                embargo=embargo,
+                hac_maxlags=hac_maxlags,
+                horizon=horizon,
+                groups=groups,
+                model_y=model_y,
+                model_t=model_t,
+                thread_limit=thread_limit,
+            )
+            if not np.isnan(perm_result["theta"]):
+                if perm_result["n_obs"] != dml["n_obs"]:
+                    raise RuntimeError(
+                        "Observed and placebo DML statistics use different second-stage samples"
+                    )
+                placebo_effects.append(perm_result["theta"])
+                placebo_n_obs.append(int(perm_result["n_obs"]))
+
+        refutation = {}
+        if len(placebo_effects) >= 10:
+            placebo_arr = np.array(placebo_effects)
+            p_mean = np.mean(placebo_arr)
+            p_std = np.std(placebo_arr)
+            z = (dml_effect - p_mean) / p_std if p_std > 0 else np.inf
+            emp_p = float(np.mean(np.abs(placebo_arr) >= np.abs(dml_effect)))
+            ref_class = classify_refutation(emp_p)
+            refutation = {
+                "z_score": z,
+                "empirical_p": emp_p,
+                "placebo_mean": p_mean,
+                "placebo_std": p_std,
+                "n_successful": len(placebo_effects),
+                "n_folds": n_folds,
+                "placebo_n_obs": placebo_n_obs,
+                "placebo_effects": placebo_effects,
+                "refutation_class": ref_class,
+            }
+
+        return {
+            "naive_effect": naive_effect,
+            "naive_n_obs": naive_n_obs,
+            "dml_result": dml,
+            "confounding_bias": bias,
+            "confounding_bias_pct": bias_pct,
+            "refutation": refutation,
+            "p_value_hac": dml.get("p_value_hac", np.nan),
+            "hac_maxlags": dml.get("hac_maxlags", 0),
+            "n_obs": len(df),
+            "started_at": _dml_started_at,
+            "elapsed_s": time.perf_counter() - _dml_t0,
         }
-
-    return {
-        "naive_effect": naive_effect,
-        "naive_n_obs": naive_n_obs,
-        "dml_result": dml,
-        "confounding_bias": bias,
-        "confounding_bias_pct": bias_pct,
-        "refutation": refutation,
-        "p_value_hac": dml.get("p_value_hac", np.nan),
-        "hac_maxlags": dml.get("hac_maxlags", 0),
-        "n_obs": len(df),
-        "started_at": _dml_started_at,
-        "elapsed_s": time.perf_counter() - _dml_t0,
-    }
 
 
 def format_dml_summary(results: dict) -> str:
@@ -842,6 +872,16 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     unknown_reductions = set(reductions) - _DML_PREVIEW_FIELDS
     if unknown_reductions:
         raise ValueError(f"unsupported DML preview reductions: {sorted(unknown_reductions)}")
+    # Every field, not merely a non-empty dict. This path no longer falls back to the shared
+    # preset's max_samples, so a preview that omits it would silently resolve the full
+    # population - an uncapped preview, which is the opposite of what the tier is for.
+    if tier is ExecutionTier.PREVIEW:
+        missing_reductions = _DML_PREVIEW_FIELDS - set(reductions)
+        if missing_reductions:
+            raise ValueError(
+                "preview causal requests must declare every reduction; missing "
+                f"{sorted(missing_reductions)}"
+            )
     allowed_overrides = {"nuisance_params"}
     unknown_overrides = set(request["overrides"]) - allowed_overrides
     if unknown_overrides:
@@ -867,7 +907,6 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         config = configs[request["config_name"]]
     except KeyError as error:
         raise ValueError(f"unknown DML configuration {request['config_name']!r}") from error
-
     setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
     causal = setup.get("causal") or {}
     treatment = str(causal["treatment"])
@@ -875,7 +914,12 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     seed = int(config.get("seed", RANDOM_SEED))
     n_folds = int(reductions.get("n_folds", config.get("n_folds", 5)))
     n_placebo = int(reductions.get("n_placebo", config.get("n_placebo", 100)))
-    max_samples = int(reductions.get("max_samples", config.get("max_samples", 0)))
+    # The shared preset still declares max_samples for the six case-study DML stages that have
+    # not migrated to this path and read it as their own default. This path ignores it: a
+    # canonical run uses the full declared population, and a reduction reaches it only through
+    # preview_reductions, which research/causal.py refuses for a canonical request. So the
+    # preset cannot cap a canonical sample, and the resolved spec records max_samples: 0.
+    max_samples = int(reductions.get("max_samples", 0))
     if n_folds < 2 or n_placebo < 0 or max_samples < 0:
         raise ValueError("DML folds, placebos, and sample cap are invalid")
 
@@ -942,6 +986,10 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
             "class": "sklearn.ensemble.HistGradientBoostingRegressor",
             "implementation": "scikit-learn",
             "nuisance_params": nuisance_params,
+        },
+        "numerics": {
+            "thread_limit": DML_THREAD_LIMIT,
+            "deterministic_reduction": True,
         },
         "refutation": {
             "method": "within_symbol_contiguous_block_permutation",
@@ -1020,6 +1068,9 @@ def run_resolved_causal_request(
 
     nuisance_y = HistGradientBoostingRegressor(**context.nuisance_params)
     nuisance_t = HistGradientBoostingRegressor(**context.nuisance_params)
+    thread_limit = int(
+        spec["computation"].get("numerics", {}).get("thread_limit", DML_THREAD_LIMIT)
+    )
     results = run_dml_analysis(
         context.analysis,
         context.treatment_col,
@@ -1036,6 +1087,7 @@ def run_resolved_causal_request(
         model_y=nuisance_y,
         model_t=nuisance_t,
         expected_step=context.expected_step,
+        thread_limit=thread_limit,
     )
     dml = results["dml_result"]
     if not all(math.isfinite(float(dml[name])) for name in ("theta", "se_hac")):

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -17,6 +17,7 @@ import joblib
 import numpy as np
 import polars as pl
 from sklearn.linear_model import ElasticNet, Lasso, LinearRegression, LogisticRegression, Ridge
+from threadpoolctl import threadpool_limits
 
 from case_studies.research.contracts import ExecutionTier
 from case_studies.research.cv import require_fold_scoped_temporal_compatibility
@@ -37,6 +38,14 @@ from utils.modeling import (
 if TYPE_CHECKING:
     from case_studies.research.workspace import Study
 
+
+# Coordinate descent and the BLAS kernels behind these fits reduce in thread-order, so a fit is
+# a deterministic function of the pool rather than of the data alone. Measured on
+# crypto_perps_funding lasso_f0.08: identical training_hash 51c3b31a83a2 under both arms, with
+# prediction digests 37352b2ff14a4b6a uncapped (pools 16/24) against c81ca6b5302e1dc2 capped.
+# Fixed rather than derived: a value like -1 varies with the host, so a result would not be
+# identity-stable across the readers' hardware.
+LINEAR_THREAD_LIMIT = 1
 
 _MODEL_CLASSES = {
     "LinearRegression": LinearRegression,
@@ -334,6 +343,10 @@ def _build_resolved_request(
             "imputer": {"class": "SimpleImputer", "strategy": "median"},
             "scaler": {"class": "StandardScaler", "with_mean": True, "with_std": True},
         },
+        "numerics": {
+            "thread_limit": LINEAR_THREAD_LIMIT,
+            "deterministic_reduction": True,
+        },
         "checkpoint_schedule": [{"kind": "final", "value": None}],
         "expected_prediction_keys": {
             "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
@@ -612,8 +625,12 @@ def _fit_or_reuse_fold(
     started = time.perf_counter()
     cls = _MODEL_CLASSES[spec["computation"]["model"]["class"]]
     model = cls(**params)
-    model.fit(fold["X_train"], fold["y_train"])
-    predictions = _fold_predictions(model, fold, context)
+    thread_limit = int(
+        spec["computation"].get("numerics", {}).get("thread_limit", LINEAR_THREAD_LIMIT)
+    )
+    with threadpool_limits(limits=thread_limit):
+        model.fit(fold["X_train"], fold["y_train"])
+        predictions = _fold_predictions(model, fold, context)
     frame = _prediction_frame(fold, predictions, context)
     artifact_temp = model_dir / f".{artifact.name}.{uuid.uuid4().hex}.tmp"
     shard_temp = shard_dir / f".{shard.name}.{uuid.uuid4().hex}.tmp"

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from copy import deepcopy
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import numpy as np
+import pandas as pd
 import polars as pl
 import pytest
 
@@ -78,7 +81,6 @@ def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol"):
             {
                 "config_name": "dml",
                 "family": "causal_dml",
-                "max_samples": 50000,
                 "n_folds": 5,
                 "n_placebo": 100,
                 "params": {"max_depth": 3, "max_iter": 50},
@@ -86,11 +88,11 @@ def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol"):
             }
         ],
     )
-    return study, label
+    return study, label, frame
 
 
 def test_causal_request_resolves_timing_gap_and_preview_identity(tmp_path, monkeypatch) -> None:
-    study, label = _causal_fixture(tmp_path, monkeypatch)
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
 
     resolved = study.causal(
         method="dml",
@@ -116,8 +118,271 @@ def test_causal_request_resolves_timing_gap_and_preview_identity(tmp_path, monke
     assert computation["preview_reductions"]["n_folds"] == 2
 
 
+def test_canonical_causal_uses_the_full_declared_population(tmp_path, monkeypatch) -> None:
+    study, label, frame = _causal_fixture(tmp_path, monkeypatch)
+
+    canonical = study.causal(method="dml", label=label.name).resolve()
+    preview = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={
+            "max_samples": 60,
+            "max_symbols": 6,
+            "n_folds": 2,
+            "n_placebo": 10,
+        },
+    ).resolve()
+
+    canonical_population = canonical.spec["computation"]["analysis_population"]
+    preview_population = preview.spec["computation"]["analysis_population"]
+    assert canonical_population["n_rows"] == frame.height
+    assert canonical_population["max_samples"] == 0
+    assert "preview_reductions" not in canonical.spec["computation"]
+    assert preview_population["n_rows"] == 60
+    assert preview_population["max_samples"] == 60
+    assert canonical.identity != preview.identity
+
+
+def _set_holdout_start(setup_path, value: str) -> None:
+    setup_path.write_text(
+        re.sub(
+            r"holdout_start: *'?[^'\n]+'?",
+            f"holdout_start: '{value}'",
+            setup_path.read_text(),
+        )
+    )
+
+
+def test_canonical_causal_population_stops_before_the_holdout_endpoint(
+    tmp_path, monkeypatch
+) -> None:
+    """The DML sample must end one outcome horizon before the holdout, and fail closed."""
+    study, label, frame = _causal_fixture(tmp_path, monkeypatch)
+    setup_path = study.root / "config" / "setup.yaml"
+
+    # The seeded holdout_start (2024-01-11) is past the fixture's last row, so the seal never
+    # binds there. Move it inside the fixture's own span to exercise the cutoff itself.
+    _set_holdout_start(setup_path, "2024-01-05")
+    resolved = study.causal(method="dml", label=label.name).resolve()
+    computation = resolved.spec["computation"]
+
+    cutoff = datetime(2024, 1, 5, tzinfo=UTC) - timedelta(hours=8)
+    expected = frame.filter(pl.col("timestamp") < cutoff)
+    assert computation["estimand"]["holdout_endpoint_cutoff"] == cutoff.isoformat()
+    assert computation["analysis_population"]["n_rows"] == expected.height
+    # The seal must actually remove rows here, or this test would pass on a no-op filter.
+    assert 0 < expected.height < frame.height
+
+    # An empty pre-holdout frame fails closed rather than estimating on whatever is left.
+    _set_holdout_start(setup_path, "2023-12-01")
+    with pytest.raises(ValueError, match="empty pre-holdout analysis frame"):
+        study.causal(method="dml", label=label.name).resolve()
+
+
+def test_causal_pins_the_thread_pool_and_records_it_in_identity(tmp_path, monkeypatch) -> None:
+    """The placebo loop is only bit-reproducible at a fixed thread count.
+
+    `os.environ.setdefault("OMP_NUM_THREADS", "1")` at import does not achieve that: every
+    notebook imports sklearn through case_studies.research first, so the pools are already
+    built. Measured that way the openmp pool stays at 16. The limit therefore has to be
+    applied at run time, and recorded, so two runs at different counts cannot share a hash.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    resolved = study.causal(method="dml", label=label.name).resolve()
+
+    numerics = resolved.spec["computation"]["numerics"]
+    assert numerics["thread_limit"] == causal.DML_THREAD_LIMIT
+    assert numerics["deterministic_reduction"] is True
+
+    # The limit must be identity-bearing: a different count is a different result, not the
+    # same result computed differently.
+    other = deepcopy(resolved.spec)
+    other["computation"]["numerics"]["thread_limit"] = causal.DML_THREAD_LIMIT + 1
+    assert training_hash_from_spec(other) != training_hash_from_spec(resolved.spec)
+
+    # The resolver's job is to pass the recorded limit down; binding the pool is
+    # run_dml_analysis's, so that direct callers get it too - see
+    # test_run_dml_analysis_pins_the_pool_for_direct_callers.
+    passed: list[int] = []
+
+    def capture(*args, **kwargs):
+        passed.append(kwargs["thread_limit"])
+        return {
+            "dml_result": {"theta": 0.02, "se_hac": 0.01, "n_obs": 120},
+            "p_value_hac": 0.04,
+            "naive_effect": 0.03,
+            "confounding_bias_pct": 50.0,
+            "refutation": {"empirical_p": 0.1},
+            "started_at": "2026-08-15T00:00:00+00:00",
+            "elapsed_s": 1.0,
+        }
+
+    monkeypatch.setattr(causal, "run_dml_analysis", capture)
+    study.causal(method="dml", label=label.name).run()
+
+    assert passed == [causal.DML_THREAD_LIMIT], (
+        f"resolver passed thread_limit={passed}, not [{causal.DML_THREAD_LIMIT}]"
+    )
+
+
+def test_manual_dml_timeseries_pins_the_pool_for_every_caller(monkeypatch) -> None:
+    """The pin lives where the nuisance models are fitted, so no caller can bypass it.
+
+    Six case-study DML stages call run_dml_analysis directly, and the chapter-15 notebooks
+    15_causal_estimation/03_econml_dml.py and 04_dml_crypto_regime.py call
+    manual_dml_timeseries themselves at nine sites, with model_y/model_t unset so they fit the
+    default HistGradientBoostingRegressor. All of them import sklearn before this module, so
+    the OMP_NUM_THREADS setdefault is inert for every one - while
+    cme_futures/12_model_analysis.py:1190 and sp500_options/11_model_analysis.py:992 tell the
+    reader the nuisance models are pinned.
+    """
+    import threadpoolctl
+
+    observed: list[int] = []
+    original = causal._walk_forward_indices
+
+    def record(*args, **kwargs):
+        observed.extend(
+            info["num_threads"]
+            for info in threadpoolctl.threadpool_info()
+            if info["user_api"] in {"openmp", "blas"}
+        )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(causal, "_walk_forward_indices", record)
+
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=(n, 1))
+    t = x[:, 0] * 0.5 + rng.normal(scale=0.1, size=n)
+    y = t * 0.3 + rng.normal(scale=0.1, size=n)
+    causal.manual_dml_timeseries(y, t, x, n_folds=2, embargo=1)
+
+    assert observed, "no thread pool was observed inside manual_dml_timeseries"
+    assert set(observed) == {causal.DML_THREAD_LIMIT}, (
+        f"manual_dml_timeseries ran with pools at {sorted(set(observed))}, "
+        f"not {causal.DML_THREAD_LIMIT}"
+    )
+
+
+def test_run_dml_analysis_pins_the_naive_ols_too(monkeypatch) -> None:
+    """The naive-OLS comparison runs after manual_dml_timeseries returns.
+
+    np.linalg.lstsq on a tall design reaches threaded BLAS, so naive_effect - and
+    confounding_bias_pct, which is a difference between it and the pinned theta - would vary
+    with the ambient pool while the resolved spec records deterministic_reduction: True.
+    Observed with manual_dml_timeseries stubbed, so only the outer pin can be in effect.
+    """
+    import threadpoolctl
+
+    observed: list[int] = []
+    n = 200
+
+    def stub(Y, T, X, **kwargs):
+        observed.extend(
+            info["num_threads"]
+            for info in threadpoolctl.threadpool_info()
+            if info["user_api"] in {"openmp", "blas"}
+        )
+        rng = np.random.default_rng(1)
+        return {
+            "Y_res": rng.normal(size=n),
+            "T_res": rng.normal(size=n),
+            "theta": 0.02,
+            "se_hac": 0.01,
+            "n_obs": n,
+            "t_stat": 2.0,
+            "p_value_hac": 0.04,
+            "hac_lags": 1,
+            "n_entities": 1,
+            "n_periods": n,
+            "hac_maxlags": 1,
+            "covariance_type": "newey_west",
+        }
+
+    monkeypatch.setattr(causal, "manual_dml_timeseries", stub)
+
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(n, 1))
+    t = x[:, 0] * 0.5 + rng.normal(scale=0.1, size=n)
+    y = t * 0.3 + rng.normal(scale=0.1, size=n)
+    causal.run_dml_analysis(
+        pd.DataFrame({"y": y, "t": t, "x": x[:, 0]}),
+        "t",
+        "y",
+        ["x"],
+        n_folds=2,
+        embargo=1,
+        n_placebo=0,
+    )
+
+    assert observed, "manual_dml_timeseries was not reached"
+    assert set(observed) == {causal.DML_THREAD_LIMIT}, (
+        f"run_dml_analysis ran with pools at {sorted(set(observed))}, not {causal.DML_THREAD_LIMIT}"
+    )
+
+
+def test_preview_causal_requires_every_reduction(tmp_path, monkeypatch) -> None:
+    """A preview that omits max_samples would resolve the full population.
+
+    This path no longer falls back to the shared preset's max_samples, so a partial
+    reduction set is an uncapped preview - the opposite of what the tier is for. The
+    guard's message already claimed every reduction; now it enforces it.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+
+    with pytest.raises(
+        ValueError, match=r"must declare every reduction; missing \['max_samples'\]"
+    ):
+        study.causal(
+            method="dml",
+            label=label.name,
+            execution_tier="preview",
+            preview_reductions={"max_symbols": 6, "n_folds": 2, "n_placebo": 10},
+        ).resolve()
+
+
+def test_canonical_causal_ignores_a_sample_cap_declared_in_the_preset(
+    tmp_path, monkeypatch
+) -> None:
+    """The shared preset cannot cap a canonical sample.
+
+    config/dml/dml.yaml still declares max_samples for the six case-study DML stages that read
+    it as their own default and have not migrated to this path. This resolver must ignore it:
+    a canonical run uses the full declared population, and a reduction reaches it only through
+    preview_reductions, which a canonical request refuses.
+    """
+    study, label, frame = _causal_fixture(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "config_name": "dml",
+                "family": "causal_dml",
+                "max_samples": 50_000,
+                "n_folds": 5,
+                "n_placebo": 100,
+                "params": {},
+                "seed": 42,
+            }
+        ],
+    )
+
+    resolved = study.causal(method="dml", label=label.name).resolve()
+    population = resolved.spec["computation"]["analysis_population"]
+
+    assert population["max_samples"] == 0
+    assert population["n_rows"] == frame.height
+
+    with pytest.raises(ValueError, match="canonical causal requests cannot declare preview"):
+        study.causal(
+            method="dml", label=label.name, preview_reductions={"max_samples": 60}
+        ).resolve()
+
+
 def test_causal_run_registers_once_and_reopens_after_restart(tmp_path, monkeypatch) -> None:
-    study, label = _causal_fixture(tmp_path, monkeypatch)
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
 
     monkeypatch.setattr(
         causal,
@@ -156,7 +421,7 @@ def test_causal_run_registers_once_and_reopens_after_restart(tmp_path, monkeypat
 
 
 def test_causal_cache_accepts_provenance_only_drift(tmp_path, monkeypatch) -> None:
-    study, label = _causal_fixture(tmp_path, monkeypatch)
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
     calls = 0
 
     def run_analysis(*args, **kwargs):
@@ -223,7 +488,7 @@ def test_block_permutation_resets_at_temporal_gap() -> None:
 
 @pytest.mark.parametrize("entity", ["symbol", "product"])
 def test_causal_resolver_accepts_either_canonical_entity_key(tmp_path, monkeypatch, entity) -> None:
-    study, label = _causal_fixture(tmp_path, monkeypatch, entity=entity)
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, entity=entity)
 
     resolved = study.causal(
         method="dml",
@@ -236,7 +501,7 @@ def test_causal_resolver_accepts_either_canonical_entity_key(tmp_path, monkeypat
 
 
 def test_causal_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:
-    study, label = _causal_fixture(tmp_path, monkeypatch, entity="ticker")
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, entity="ticker")
 
     with pytest.raises(ValueError, match="does not support entity key 'ticker'"):
         study.causal(

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -4,6 +4,7 @@ import gc
 import json
 import os
 import weakref
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -866,6 +867,117 @@ def test_linear_runner_persists_complete_reusable_result(tmp_path, monkeypatch) 
         "fold_0.joblib",
         "fold_1.joblib",
     ]
+
+
+def test_thread_limit_does_not_leak_into_families_that_already_record_threads(
+    tmp_path, monkeypatch
+) -> None:
+    """gbm, tabular_dl and deep_learning must be byte-identical before and after this change.
+
+    They already record thread state - gbm carries num_threads in _GBM_REQUEST_FIELDS,
+    tabular_dl and deep_learning carry numerics blocks. Adding a second thread field to a
+    family that already has one moves its training identities and buys nothing. The pinning
+    helper is shared; the `numerics.thread_limit` field is applied to linear and causal only.
+    """
+    gbm_study = _gbm_study(tmp_path / "gbm", monkeypatch)
+    gbm_spec = (
+        gbm_study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63},
+        )
+        .resolve()
+        .spec
+    )
+    gbm_numerics = gbm_spec["computation"].get("numerics", {})
+    assert "thread_limit" not in gbm_numerics, (
+        "thread_limit leaked into gbm, which already records num_threads; "
+        "this moves every gbm training identity"
+    )
+
+    tabm_study, *_ = _tabm_study(tmp_path / "tabm", monkeypatch)
+    tabm_spec = (
+        tabm_study.model(family="tabular_dl", label="fwd_ret_1d", config_name="tabm_s")
+        .resolve()
+        .spec
+    )
+    assert "thread_limit" not in tabm_spec["computation"].get("numerics", {}), (
+        "thread_limit leaked into tabular_dl, which already carries a numerics block"
+    )
+
+    # deep_learning builds its own numerics block at utils/deep_learning.py, so it is the third
+    # family this scope protects and equally likely to be caught by a future widening.
+    from tests.test_deep_learning_adapter import _resolve_nlinear_request
+
+    _, _, sequence_resolved = _resolve_nlinear_request(tmp_path / "sequence", monkeypatch)
+    sequence_spec = sequence_resolved.spec
+    assert "thread_limit" not in sequence_spec["computation"].get("numerics", {}), (
+        "thread_limit leaked into deep_learning, which already carries a numerics block"
+    )
+    assert sequence_spec["computation"]["numerics"]["num_threads"]
+
+    # latent_factors records num_threads too (utils/latent_factors/adapter.py), so it is the
+    # fourth family this scope protects and equally exposed to a future widening.
+    latent_study = _latent_study(tmp_path / "latent", monkeypatch)
+    latent_spec = (
+        latent_study.model(
+            family="latent_factors",
+            label="fwd_ret_1d",
+            config_name="pca",
+            overrides={"device": "cpu"},
+        )
+        .resolve()
+        .spec
+    )
+    assert "thread_limit" not in latent_spec["computation"].get("numerics", {}), (
+        "thread_limit leaked into latent_factors, which already records num_threads"
+    )
+
+
+def test_linear_pins_the_thread_pool_and_records_it_in_identity(tmp_path, monkeypatch) -> None:
+    """A linear fit is a deterministic function of the thread pool, not of the data alone.
+
+    Coordinate descent and the BLAS kernels reduce in thread order, so two runs can agree on
+    training_hash and prediction_hash and still differ in the coefficients. Measured on real
+    crypto data: lasso_f0.08 at identical training_hash produced prediction digests
+    37352b2ff14a4b6a uncapped (pools 16/24) against c81ca6b5302e1dc2 capped. Recording the
+    limit is what makes the identity cover the computation.
+    """
+    import threadpoolctl
+
+    study = _linear_study(tmp_path, monkeypatch)
+    request = study.model(family="linear", label="fwd_ret_1d", config_name="ridge")
+    resolved = request.resolve()
+
+    numerics = resolved.spec["computation"]["numerics"]
+    assert numerics["thread_limit"] == linear.LINEAR_THREAD_LIMIT
+    assert numerics["deterministic_reduction"] is True
+
+    other = deepcopy(resolved.spec)
+    other["computation"]["numerics"]["thread_limit"] = linear.LINEAR_THREAD_LIMIT + 1
+    assert linear.training_hash_from_spec(other) != linear.training_hash_from_spec(resolved.spec)
+
+    # Observed from inside the limited block rather than by trusting the source: the runner
+    # calls _fold_predictions immediately after model.fit, within the same context manager.
+    observed: list[int] = []
+    original_predictions = linear._fold_predictions
+
+    def recording_predictions(model, fold, context):
+        observed.extend(
+            info["num_threads"]
+            for info in threadpoolctl.threadpool_info()
+            if info["user_api"] in {"openmp", "blas"}
+        )
+        return original_predictions(model, fold, context)
+
+    monkeypatch.setattr(linear, "_fold_predictions", recording_predictions)
+    request.run()
+
+    assert observed, "no thread pool was observed during the linear fit"
+    assert set(observed) == {linear.LINEAR_THREAD_LIMIT}, (
+        f"linear fitted with pools at {sorted(set(observed))}, not {linear.LINEAR_THREAD_LIMIT}"
+    )
 
 
 def test_linear_batch_is_fold_major_and_matches_individual_execution(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Two corrections to the canonical causal path, plus the same thread fix for linear.

The canonical DML sample is the full declared population
--------------------------------------------------------
resolve_causal_request read max_samples from the shared preset for canonical runs
as well as previews. A sample cap on a time-ordered panel is not a cost control:
taken as a tail it lands inside the sealed holdout, and taken anywhere it makes
the canonical estimate a sample of the declared population without saying so.

This path now ignores the preset's max_samples entirely. A reduction reaches it
only through preview_reductions, and a preview must declare every field of
_DML_PREVIEW_FIELDS rather than merely a non-empty dict - without the preset
fallback, a preview omitting max_samples would resolve the full population, which
is the opposite of what the tier is for.

config/dml/dml.yaml keeps the key. Six case-study DML stages have not migrated to
this path and read it as their own default via
`MAX_SAMPLES = dml_cfg.get("max_samples", 50000)` after a merge loop that only
writes when the preset and the parameter differ. Removing it would make that loop
a no-op and silently discard their Papermill override - falling back to 50000, and
in etfs to 0, where the guard is `if MAX_SAMPLES > 0` and the cap disappears
entirely. fx_pairs and us_firm_characteristics are unaffected; the latter already
assigns unconditionally, which is the pattern the other five should adopt.

crypto_perps_funding: 50,000 -> 58,975 rows, measured at 1m44s. The cost is ~101
DML fits, one plus n_placebo=100, each over the population at n_folds=5. Other
case studies are unmeasured; nasdaq100_microstructure at 16.1M rows should be
measured, not extrapolated from this.

The thread pool is bound at run time and recorded in identity
--------------------------------------------------------------
causal.py set OMP_NUM_THREADS=1 via os.environ.setdefault at import, with a
comment explaining that HistGradientBoostingRegressor's OMP-parallel histogram
construction reduces in thread order, so the placebo loop is bit-reproducible
only at a fixed thread count. That did not work: every notebook imports
case_studies.research, and through it sklearn, before this module, so the
runtimes have already read the variable. Measured with threadpoolctl in the
notebook import order the openmp pool is 16 and openblas 24, while os.environ
reports 1.

linear had no thread record at all. Measured on crypto lasso_f0.08: identical
training_hash 51c3b31a83a2 with prediction digests 37352b2ff14a4b6a uncapped
against c81ca6b5302e1dc2 capped. Identical identity, different numbers.

That is the reason this blocks production rather than improving it. Everything else
found in this review round was a run that failed loudly; this is a run that
succeeds and is wrong.

Three gaps close: the pool is bound with threadpool_limits at run time, matching
the seven existing call sites in this repository; the declaration states what is
true; and the effective limit is identity-bearing under computation.numerics.
Without the third, a 16-thread run and a 1-thread run are indistinguishable by
hash.

The pin is applied at two levels, and both are load-bearing.

manual_dml_timeseries wraps the nuisance fits and the second-stage HAC regression,
so no caller can bypass it: run_dml_analysis, the six case-study DML stages that
call it directly, and the chapter-15 notebooks 03_econml_dml.py (5 calls) and
04_dml_crypto_regime.py (4 calls), which call it themselves with model_y/model_t
unset and so fit the default HistGradientBoostingRegressor. All of them import
sklearn before this module, so the setdefault is inert for every one.

run_dml_analysis wraps its own body as well, because the naive-OLS comparison runs
np.linalg.lstsq after that call returns and LAPACK's dgelsd reaches threaded BLAS
on a tall design. naive_effect and confounding_bias_pct are both registered in
causal_runs, and confounding_bias_pct is a difference between an unpinned quantity
and the pinned theta - so without this the spec would record
deterministic_reduction: True over a computation that is only partly deterministic.
The inner context nests harmlessly.

This reaches lane:teaching, not only stage 06+. cme_futures/12_model_analysis.py:1190
and sp500_options/11_model_analysis.py:992 tell the reader the nuisance models are
pinned, which was false for those paths; and 04_dml_crypto_regime.py:490 prints an
empirical p-value from a permutation loop that a reader re-running the published
chapter would get differently depending on their thread count. The diff touches
only case_studies/utils/, so that consequence is not visible from the files changed.

The resolver passes the identity-bearing value down through run_dml_analysis.

Capping happens inside the runner, so an uncapped caller gets the capped result
and reproducibility does not depend on every caller setting four environment
variables.

Scope: applied to linear and causal only. gbm carries num_threads in
_GBM_REQUEST_FIELDS; tabular_dl, deep_learning and latent_factors carry numerics
blocks. Adding a second thread field to a family that already records one moves
596 identities and buys nothing. Asserted for all four by
test_thread_limit_does_not_leak_into_families_that_already_record_threads.

Identity consequence: this supersedes every existing linear and causal hash.
crypto's canonical causal hash moves 345a838c2116 -> 6b3858478e72, which confirms
the field binds rather than nominally carrying.

Why `numerics.thread_limit` rather than the `num_threads` that latent_factors,
tabular_dl and deep_learning already record: they are different knobs, and
measurably so. Those three set it through torch.set_num_threads from their
resolved spec, which bounds the OpenMP pool and leaves OpenBLAS alone - measured,
torch.set_num_threads(3) gives openmp 3 and openblas 24. threadpool_limits caps
both. Naming this field num_threads would invite a reader comparing two specs to
conclude the same guarantee holds in each, when only one of them bounds BLAS.

That said, this brings linear and causal up to a standard those three families
already meet: the thread setting comes from the resolved specification rather than
from the ambient environment, and it is a fixed value rather than one derived from
the host. Whoever wrote latent_factors/case_study.py:94 chose a fixed 8 for the
same reason this chooses a fixed 1.

thread_limit = 1 is fixed rather than derived. A value like -1 varies with the
host, so a result would not be identity-stable across readers' hardware. 1 is not
the only reproducible choice - with OMP_DYNAMIC off a pinned 4 binds identically
everywhere - but nothing here sets OMP_DYNAMIC, determinism above one thread is
untested, and the measured 1m44s leaves no runtime problem for a higher limit to
solve. Raising it is a versioned identity change and needs a determinism
measurement on a quiet machine, not a wall-clock one.

There is no library-level enforcement to add for these paths, and that is worth
stating rather than leaving to inference. latent_factors, tabular_dl and
deep_learning call torch.use_deterministic_algorithms(warn_only=False), which makes
a nondeterministic op raise instead of varying quietly. That governs torch ops.
These paths are sklearn Lasso/ElasticNet coordinate descent, LAPACK dgelsd through
np.linalg.lstsq, and sklearn HistGradientBoostingRegressor - none of which torch
sees, so adding the call here would be a no-op that reads like a guarantee.

For these families determinism therefore rests on the pool being bound, with no
library-level assertion behind it. The property is demonstrated against real data
rather than in the unit suite: .workspace/proofs/measure_linear_threads.py resolves
one configuration twice under different ambient pools and compares prediction
digests. A unit-fixture version of that test would be vacuous - measured, the
12-row fixture produces digest 383e454cc1155c7f under both an ambient pool of
16/24 and a cap of 1, because the panel is too small for BLAS to thread at all, so
the assertion would pass with the pin removed.

What the evidence covers: the mechanism is measured. A metric-level demonstration
was not reproduced - two fresh-workspace preview runs matched before and after, on
769 observations with 10 placebos, likely too small for OMP to parallelise at all,
and a nondeterministic reduction can agree by chance.

The source-text guard in test_holdout_boundary.py is left alone here. It reads
crypto notebook text, and the notebook it guards is unchanged by this commit, so
its replacement lands with the notebook rewrite rather than ahead of it.

