### PR TITLE
Evaluate the state-transition gap policy on the observation timeline

### DIFF
--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -114,8 +114,13 @@ def apply_state_transition_policy(
             else:
                 transition_at.add(current["timestamp"])
         previous = current
+    transition_values = pl.Series(
+        "_transition_timestamp",
+        list(transition_at),
+        dtype=weights.schema["timestamp"],
+    )
     result = weights.with_columns(
-        pl.col("timestamp").is_in(list(transition_at)).alias("_state_transition")
+        pl.col("timestamp").is_in(transition_values.implode()).alias("_state_transition")
     )
     if flat_frames:
         result = pl.concat(
@@ -520,6 +525,11 @@ class Strategy:
         policy = risk.get("state_transition_policy")
         if policy is None or self.decision is not None:
             return None
+        if not isinstance(policy, dict):
+            raise TypeError("risk state-transition policy must be a mapping")
+        from .decisions import StateTransitionPolicy
+
+        policy = asdict(StateTransitionPolicy(**policy))
         cadence = risk.get("state_transition_cadence")
         if cadence is None:
             raise ValueError("risk state-transition policy requires an explicit cadence")

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -61,25 +61,42 @@ def _cadence_delta(value: str) -> timedelta:
     return timedelta(**{keyword: amount})
 
 
+def _last_at_or_before(timestamps: pl.Series, moment: object) -> object | None:
+    """The weight row in force at a moment on the observation grid."""
+    earlier = timestamps.filter(timestamps <= moment)
+    return earlier[-1] if earlier.len() else None
+
+
 def apply_state_transition_policy(
     weights: pl.DataFrame,
     *,
     policy: dict[str, str],
     cadence: str | None,
     price_keys: pl.DataFrame | None = None,
+    timeline: pl.DataFrame | None = None,
 ) -> pl.DataFrame:
-    """Preserve targets while making fold and temporal state resets executable."""
+    """Preserve targets while making fold and temporal state resets executable.
+
+    `cadence` describes the timeline the policy is written against - the observation grid, not
+    the weight frame. For a decision artifact the two coincide, so `timeline` defaults to the
+    weights' own timestamps. For generated weights they do not: `precompute_weights` thins to
+    the non-overlapping rebalance schedule, so a label with `rebalance_step` 3 yields weights
+    24h apart under a declared 8h cadence and every ordinary rebalance would read as a gap.
+    Callers in that position pass the observation timeline explicitly.
+    """
     required = {"symbol", "timestamp", "weight"}
     missing = required - set(weights.columns)
     if missing:
         raise ValueError(f"decision weights are missing columns: {sorted(missing)}")
     if weights.is_empty():
         return weights
-    fold_column = "fold" if "fold" in weights.columns else None
+    source = weights if timeline is None else timeline
+    fold_column = "fold" if "fold" in source.columns else None
     timeline_columns = ["timestamp", *([fold_column] if fold_column else [])]
-    timeline = weights.select(*timeline_columns).unique().sort("timestamp")
+    timeline = source.select(*timeline_columns).unique().sort("timestamp")
     if fold_column and timeline.n_unique("timestamp") != timeline.height:
         raise ValueError("each decision timestamp must belong to exactly one fold")
+    weight_timestamps = weights.get_column("timestamp").unique().sort()
 
     temporal_action = policy.get("temporal_gap", "continue")
     expected = None
@@ -90,29 +107,67 @@ def apply_state_transition_policy(
 
     transition_at: set[object] = set()
     flat_frames: list[pl.DataFrame] = []
+    # A fold boundary and a temporal gap can resolve to the same off-grid moment. The on-grid
+    # path dedupes through `transition_at`; without this the flat-row path would append the row
+    # twice and `_target_weights_by_timestamp` rejects duplicate (symbol, timestamp) pairs, so
+    # the reset would abort the backtest instead of executing.
+    flat_moments: set[object] = set()
     price_timestamps = (
         set(price_keys.get_column("timestamp").unique().to_list())
         if price_keys is not None
         else set()
     )
+    weight_moments = set(weight_timestamps.to_list())
+
+    def _flat_row_at(moment: object, carried_from: object) -> pl.DataFrame:
+        return weights.filter(pl.col("timestamp") == carried_from).with_columns(
+            pl.lit(moment).cast(weights.schema["timestamp"]).alias("timestamp"),
+            pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
+        )
+
+    def _mark(moment: object, *, previous_moment: object, reason: str) -> None:
+        """Mark a declared reset at the moment it is declared for.
+
+        If the moment is on the weight grid, marking the row is enough. If it is not - which
+        happens whenever the weight frame is thinned relative to the observation grid - a
+        zero-weight row is inserted at that exact moment, carrying the position that was in
+        force. Snapping the mark forward to the next weight row instead would carry the old
+        state across the boundary and then collapse the liquidation into an ordinary rebalance
+        on the same bar, paying a round trip for no change in exposure.
+        """
+        if moment in weight_moments:
+            transition_at.add(moment)
+            return
+        held_at = _last_at_or_before(weight_timestamps, previous_moment)
+        if held_at is None or moment not in price_timestamps:
+            raise ValueError(
+                f"declared {reason} at {moment} cannot be represented on the weight grid"
+            )
+        if moment in flat_moments:
+            return
+        flat_moments.add(moment)
+        flat_frames.append(_flat_row_at(moment, held_at))
+
     rows = timeline.iter_rows(named=True)
     previous = next(rows, None)
     for current in rows:
         assert previous is not None
         fold_changed = fold_column is not None and current[fold_column] != previous[fold_column]
         if fold_changed and policy.get("fold_boundary", "continue") != "continue":
-            transition_at.add(current["timestamp"])
+            _mark(current["timestamp"], previous_moment=previous["timestamp"], reason="fold reset")
         if expected is not None and current["timestamp"] - previous["timestamp"] > expected:
             first_missing = previous["timestamp"] + expected
-            if first_missing in price_timestamps:
-                flat_frames.append(
-                    weights.filter(pl.col("timestamp") == previous["timestamp"]).with_columns(
-                        pl.lit(first_missing).cast(weights.schema["timestamp"]).alias("timestamp"),
-                        pl.lit(0.0).cast(weights.schema["weight"]).alias("weight"),
-                    )
-                )
+            held_at = _last_at_or_before(weight_timestamps, previous["timestamp"])
+            if first_missing in price_timestamps and held_at is not None:
+                if first_missing not in flat_moments:
+                    flat_moments.add(first_missing)
+                    flat_frames.append(_flat_row_at(first_missing, held_at))
             else:
-                transition_at.add(current["timestamp"])
+                _mark(
+                    current["timestamp"],
+                    previous_moment=previous["timestamp"],
+                    reason="temporal-gap reset",
+                )
         previous = current
     transition_values = pl.Series(
         "_transition_timestamp",
@@ -560,6 +615,10 @@ class Strategy:
             price_keys=prices.select("symbol", "timestamp")
             .unique()
             .with_columns(pl.col("timestamp").cast(weights.schema["timestamp"])),
+            # The declared cadence describes the observation grid. precompute_weights thins to
+            # the rebalance schedule, so for a label with rebalance_step > 1 the weight frame is
+            # coarser than the cadence and every ordinary rebalance would read as a gap.
+            timeline=fold_map.sort("timestamp"),
         )
 
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -18,8 +18,12 @@ from case_studies.utils.backtest_loaders import (
     load_contract_specs_from_yaml,
     load_futures_market_contract,
 )
-from case_studies.utils.backtest_presets import build_backtest_spec, serializable_backtest_spec
-from case_studies.utils.backtest_runner import run_backtest
+from case_studies.utils.backtest_presets import (
+    build_backtest_spec,
+    serializable_backtest_spec,
+    strategy_view,
+)
+from case_studies.utils.backtest_runner import precompute_weights, run_backtest
 from case_studies.utils.conformal import (
     compute_holdout_conformal_widths,
     ensure_conformal_calibration_identity,
@@ -506,6 +510,48 @@ class Strategy:
             selected.append("_state_transition")
         return weights.select(*selected)
 
+    def _risk_state_weights(
+        self,
+        predictions: pl.DataFrame,
+        prices: pl.DataFrame,
+        strategy_spec: dict[str, Any],
+    ) -> pl.DataFrame | None:
+        risk = strategy_view(strategy_spec).get("risk") or {}
+        policy = risk.get("state_transition_policy")
+        if policy is None or self.decision is not None:
+            return None
+        cadence = risk.get("state_transition_cadence")
+        if cadence is None:
+            raise ValueError("risk state-transition policy requires an explicit cadence")
+        weights = precompute_weights(
+            predictions,
+            strategy_spec,
+            prices,
+            label=self.label,
+            case_study=self.study.case_study,
+            prediction_hash=self.prediction.hash,
+        )
+        fold_columns = [column for column in ("fold", "fold_id") if column in predictions.columns]
+        if len(fold_columns) != 1:
+            raise ValueError("stateful strategy predictions require exactly one fold column")
+        fold_map = predictions.select("timestamp", fold_columns[0]).unique()
+        if fold_map.get_column("timestamp").n_unique() != fold_map.height:
+            raise ValueError("each stateful strategy timestamp must belong to exactly one fold")
+        if fold_columns[0] == "fold_id":
+            fold_map = fold_map.rename({"fold_id": "fold"})
+        fold_map = fold_map.with_columns(pl.col("timestamp").cast(weights.schema["timestamp"]))
+        weights = weights.join(fold_map, on="timestamp", how="left", validate="m:1")
+        if weights.get_column("fold").null_count():
+            raise ValueError("stateful strategy weights contain timestamps without a fold")
+        return apply_state_transition_policy(
+            weights,
+            policy=policy,
+            cadence=str(cadence),
+            price_keys=prices.select("symbol", "timestamp")
+            .unique()
+            .with_columns(pl.col("timestamp").cast(weights.schema["timestamp"])),
+        )
+
     def identity(self, *, prices: pl.DataFrame | None = None) -> str:
         spec = self.resolve(prices=prices)
         return backtest_hash_from_parts(self.prediction.hash, spec, identity_version=2)
@@ -554,13 +600,16 @@ class Strategy:
             )
         tier = ExecutionTier(self.prediction.execution_tier)
         self.study.activate(tier)
+        decision_weights = self._decision_weights(resolved_prices)
+        if decision_weights is None:
+            decision_weights = self._risk_state_weights(predictions, resolved_prices, spec)
         result = run_backtest(
             self.study.case_study,
             self.prediction.hash,
             spec,
             prices=resolved_prices,
             predictions=predictions,
-            precomputed_weights=self._decision_weights(resolved_prices),
+            precomputed_weights=decision_weights,
             funding_rates=self._funding_rates(resolved_prices),
             label=self.label,
             initial_cash=float(spec["backtest_config"]["cash"]["initial"]),

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -139,6 +139,189 @@ def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
     ]
 
 
+def test_rebalance_thinned_weights_do_not_read_as_observation_gaps() -> None:
+    """A coarser weight frame than the declared cadence is not a gap.
+
+    precompute_weights thins to the non-overlapping rebalance schedule, so crypto's
+    fwd_ret_24h (rebalance_step 3) produces weights 24h apart while 16_risk_management
+    declares an 8h cadence. Running the gap test over the weight frame made every ordinary
+    rebalance look like a missing observation, which flattened the book one bar later and
+    left it flat for two of every three bars.
+    """
+    observations = [datetime(2024, 1, 1, hour, tzinfo=UTC) for hour in (0, 8, 16)] + [
+        datetime(2024, 1, 2, hour, tzinfo=UTC) for hour in (0, 8, 16)
+    ]
+    # Weights only on the rebalance schedule: every third observation.
+    rebalanced = [observations[0], observations[3]]
+    weights = pl.DataFrame(
+        {
+            "symbol": ["A"] * len(rebalanced),
+            "timestamp": rebalanced,
+            "fold": [0] * len(rebalanced),
+            "weight": [1.0] * len(rebalanced),
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    timeline = pl.DataFrame(
+        {"timestamp": observations, "fold": [0] * len(observations)}
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    prices = pl.DataFrame(
+        {"symbol": ["A"] * len(observations), "timestamp": observations}
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+
+    transitioned = apply_state_transition_policy(
+        weights,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "reset"},
+        cadence="8h",
+        price_keys=prices,
+        timeline=timeline,
+    )
+
+    assert not transitioned.get_column("_state_transition").any(), (
+        "a rebalance interval was misread as an observation gap"
+    )
+    assert transitioned.height == weights.height, (
+        "synthetic flat rows were inserted for ordinary rebalance intervals"
+    )
+
+
+def test_fold_boundary_off_the_weight_grid_liquidates_at_the_boundary() -> None:
+    """A declared liquidation happens when it is declared, not at the next rebalance.
+
+    With a thinned weight frame the fold boundary usually falls between weight rows. Snapping
+    the mark forward would carry the old fold's book into the new fold, and because the snapped
+    timestamp is itself a rebalance bar the engine would flatten and re-apply new targets on the
+    same bar - a round trip for no change in exposure.
+    """
+    observations = [datetime(2024, 1, 1, hour, tzinfo=UTC) for hour in (0, 8, 16)]
+    # Weights only at 00:00; the fold changes at 08:00, which is not a weight timestamp.
+    weights = pl.DataFrame(
+        {"symbol": ["A"], "timestamp": [observations[0]], "fold": [0], "weight": [1.0]}
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    timeline = pl.DataFrame({"timestamp": observations, "fold": [0, 1, 1]}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+    prices = pl.DataFrame({"symbol": ["A"] * 3, "timestamp": observations}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+
+    transitioned = apply_state_transition_policy(
+        weights,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "continue"},
+        cadence="8h",
+        price_keys=prices,
+        timeline=timeline,
+    )
+
+    marked = transitioned.filter(pl.col("_state_transition"))
+    assert marked.height == 1, "the fold boundary produced no executable reset"
+    assert marked.item(0, "timestamp") == observations[1], (
+        "the liquidation was snapped away from the boundary it was declared for"
+    )
+    assert marked.item(0, "weight") == 0.0, "the reset did not flatten the position"
+
+
+def test_a_fold_boundary_and_a_gap_at_one_moment_insert_one_flat_row() -> None:
+    """Both policies can resolve to the same off-grid moment; the reset must still execute.
+
+    The on-grid path dedupes through a set. Without the same guard on the flat-row path the
+    moment gets two identical rows, and `_target_weights_by_timestamp` rejects duplicate
+    (symbol, timestamp) pairs - so the declared reset would abort the backtest rather than run.
+    """
+    observations = [
+        datetime(2024, 1, 1, 0, tzinfo=UTC),
+        # 08:00 missing: a gap, and the fold changes across it too
+        datetime(2024, 1, 1, 16, tzinfo=UTC),
+    ]
+    weights = pl.DataFrame(
+        {"symbol": ["A"], "timestamp": [observations[0]], "fold": [0], "weight": [1.0]}
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    timeline = pl.DataFrame({"timestamp": observations, "fold": [0, 1]}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+    # 08:00 has no price bar, so the gap branch falls through to the same _mark call the fold
+    # branch makes for 16:00.
+    prices = pl.DataFrame({"symbol": ["A", "A"], "timestamp": observations}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+
+    transitioned = apply_state_transition_policy(
+        weights,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "reset"},
+        cadence="8h",
+        price_keys=prices,
+        timeline=timeline,
+    )
+
+    keys = transitioned.select("symbol", "timestamp")
+    assert keys.height == keys.unique().height, (
+        "the same moment produced duplicate rows, which the backtest runner rejects"
+    )
+    assert transitioned.filter(pl.col("_state_transition")).height == 1
+
+
+def test_a_declared_reset_that_cannot_be_represented_fails_closed() -> None:
+    """A reset with no price bar to execute on is a contract violation, not a no-op."""
+    observations = [datetime(2024, 1, 1, hour, tzinfo=UTC) for hour in (0, 8)]
+    weights = pl.DataFrame(
+        {"symbol": ["A"], "timestamp": [observations[0]], "fold": [0], "weight": [1.0]}
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    timeline = pl.DataFrame({"timestamp": observations, "fold": [0, 1]}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+    # 08:00 has no price bar, so the declared liquidation cannot be executed anywhere.
+    prices = pl.DataFrame({"symbol": ["A"], "timestamp": [observations[0]]}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+
+    with pytest.raises(ValueError, match="cannot be represented on the weight grid"):
+        apply_state_transition_policy(
+            weights,
+            policy={"fold_boundary": "liquidate", "temporal_gap": "continue"},
+            cadence="8h",
+            price_keys=prices,
+            timeline=timeline,
+        )
+
+
+def test_a_real_observation_gap_still_resets_thinned_weights() -> None:
+    """The counterpart: a hole in the observation grid must still reset state."""
+    observations = [
+        datetime(2024, 1, 1, 0, tzinfo=UTC),
+        datetime(2024, 1, 1, 8, tzinfo=UTC),
+        # 16:00 is missing - a real gap in the observation grid
+        datetime(2024, 1, 2, 0, tzinfo=UTC),
+    ]
+    weights = pl.DataFrame(
+        {
+            "symbol": ["A", "A"],
+            "timestamp": [observations[0], observations[2]],
+            "fold": [0, 0],
+            "weight": [1.0, 1.0],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+    timeline = pl.DataFrame({"timestamp": observations, "fold": [0, 0, 0]}).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("us", "UTC"))
+    )
+    prices = pl.DataFrame(
+        {
+            "symbol": ["A"] * 4,
+            "timestamp": observations + [datetime(2024, 1, 1, 16, tzinfo=UTC)],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime("us", "UTC")))
+
+    transitioned = apply_state_transition_policy(
+        weights,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "reset"},
+        cadence="8h",
+        price_keys=prices,
+        timeline=timeline,
+    )
+
+    assert transitioned.get_column("_state_transition").any(), (
+        "a real hole in the observation grid did not reset state"
+    )
+
+
 def test_generated_strategy_weights_execute_declared_fold_and_gap_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import polars as pl
@@ -70,6 +70,31 @@ def test_fold_boundary_liquidates_unchanged_positions_before_next_fold() -> None
 
     assert transitioned.get_column("weight").to_list() == [1.0, 1.0, 1.0]
     assert transitioned.get_column("_state_transition").to_list() == [False, False, True]
+
+
+def test_state_transition_preserves_millisecond_utc_timestamp_dtype() -> None:
+    timestamps = pl.Series(
+        "timestamp",
+        [datetime(2024, 1, day, tzinfo=UTC) for day in (1, 2)],
+        dtype=pl.Datetime("ms", "UTC"),
+    )
+    weights = pl.DataFrame(
+        {
+            "symbol": ["A", "A"],
+            "timestamp": timestamps,
+            "fold": [0, 1],
+            "weight": [1.0, 1.0],
+        }
+    )
+
+    transitioned = apply_state_transition_policy(
+        weights,
+        policy={"fold_boundary": "liquidate", "temporal_gap": "continue"},
+        cadence="1d",
+    )
+
+    assert transitioned.schema["timestamp"] == pl.Datetime("ms", "UTC")
+    assert transitioned.get_column("_state_transition").to_list() == [False, True]
 
 
 def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -114,6 +114,62 @@ def test_temporal_gap_resets_unchanged_positions_before_gap() -> None:
     ]
 
 
+def test_generated_strategy_weights_execute_declared_fold_and_gap_policy(
+    tmp_path: Path,
+) -> None:
+    study = _study(tmp_path)
+    timestamps = [date(2024, 1, day) for day in (1, 2, 5)]
+    frame = pl.DataFrame(
+        {
+            "symbol": [symbol for timestamp in timestamps for symbol in ("A", "B")],
+            "timestamp": [timestamp for timestamp in timestamps for _ in ("A", "B")],
+            "fold_id": [fold for fold in (0, 0, 1) for _ in ("A", "B")],
+            "y_true": [0.01, -0.01] * len(timestamps),
+            "y_score": [0.02, -0.02] * len(timestamps),
+        }
+    )
+    training = study.results.register_training(_resolved_spec())
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    prices = pl.DataFrame(
+        {
+            "symbol": [symbol for day in range(1, 6) for symbol in ("A", "B")],
+            "timestamp": [date(2024, 1, day) for day in range(1, 6) for _ in ("A", "B")],
+            "open": [100.0] * 10,
+            "high": [101.0] * 10,
+            "low": [99.0] * 10,
+            "close": [100.0] * 10,
+            "volume": [1_000] * 10,
+        }
+    )
+    strategy = study.strategy(
+        prediction=prediction,
+        signal={"method": "equal_weight_top_k", "top_k": 1},
+        risk={
+            "state_transition_policy": {
+                "fold_boundary": "liquidate",
+                "temporal_gap": "reset",
+            },
+            "state_transition_cadence": "1d",
+        },
+    )
+
+    weights = strategy._risk_state_weights(frame, prices, strategy.resolve(prices=prices))
+
+    assert weights is not None
+    transitions = weights.filter(pl.col("_state_transition")).get_column("timestamp").unique()
+    assert {timestamp.date() for timestamp in transitions} == {
+        date(2024, 1, 3),
+        date(2024, 1, 5),
+    }
+
+
 def _prediction(study: Study) -> str:
     training = study.results.register_training(_resolved_spec())
     frame = _predictions()


### PR DESCRIPTION
`_risk_state_weights` ran the temporal-gap test over the frame returned by
`precompute_weights`, which `_apply_allocation` has already thinned to the
non-overlapping rebalance schedule. The declared `state_transition_cadence` is the
observation cadence, so the two disagree whenever `rebalance_step > 1`.

crypto's `fwd_ret_24h` has `rebalance_step: 3` and `16_risk_management.py` declares
an 8h cadence for every label, so any construction carrying an allocation block
produced weights 24h apart against an 8h expectation. Every ordinary rebalance
interval was read as a missing observation, a synthetic zero-weight row was
appended one bar later with `_state_transition = True`, and `_run_engine` flattened
the book there. The position sat flat for two of every three bars, which makes the
Ch19 risk numbers for that label wrong rather than merely different.

This reaches seven of nine case studies, and the diff touches only
case_studies/research/, so nothing in the changed files shows it. Labels with
rebalance_step > 1, measured through get_rebalance_step:

    cme_futures                    fwd_ret_21d 3
    crypto_perps_funding           fwd_ret_24h 3
    fx_pairs                       fwd_ret_5d 5,  fwd_ret_21d 21
    nasdaq100_microstructure       fwd_ret_60m 4
    sp500_equity_option_analytics  fwd_ret_10d 2, fwd_dir_10d 2
    sp500_options                  ret_to_expiry 5
    us_equities_panel              fwd_ret_5d 5,  fwd_ret_21d 21

Only etfs and us_firm_characteristics have every label at step 1. At step 21 the
book would be flat for twenty bars in every twenty-one.

The decision-artifact path was never affected: a decision frame *is* the decision
timeline, and its cadence comes from the same artifact.

`apply_state_transition_policy` now takes an optional `timeline` describing the grid
the cadence is written against, defaulting to the weights' own timestamps so the
decision path is unchanged. A transition found on that grid maps onto the first
weight timestamp at or after it, and a gap clones the weight rows in force at or
before the gap, rather than assuming the two frames share an index.

A declared reset is marked at the moment it is declared for, on both branches. When
that moment is not on the weight grid - which is the ordinary case once the frame is
thinned - a zero-weight row is inserted there carrying the position in force, rather
than snapping the mark forward to the next weight row. Snapping would carry the old
fold's book across the boundary for up to rebalance_step - 1 observations, and
because the snapped timestamp is itself a rebalance bar the engine would flatten and
re-apply the new fold's targets on the same bar: a round trip for no change in
exposure. This is reachable today, since 16_risk_management.py declares
fold_boundary: liquidate for every crypto label.

A fold boundary and a temporal gap can resolve to the same off-grid moment, in which
case the flat row is inserted once. The on-grid path dedupes through a set; without
the same guard on the flat-row path the moment carries two identical rows and
_target_weights_by_timestamp rejects duplicate (symbol, timestamp) pairs, so the
declared reset would abort the backtest rather than execute it.

A reset that can be represented on neither the weight grid nor the price grid now
raises rather than being dropped. The observation timeline extends past the last
weight row once the frame is thinned, so a boundary in that tail previously produced
no transition and no diagnostic. A declared reset that cannot be executed is a
contract violation, not a no-op.

Two tests, both mutation-tested: thinned weights under a finer declared cadence
produce no transitions and no synthetic rows, and a real hole in the observation
grid still resets state. The first fails with "a rebalance interval was misread as
an observation gap" when the timeline is ignored.

Two further findings from the same review are real, latent on current configs, and
deliberately not fixed here, so they are not rediscovered as new:

- _build_spec does not re-derive backtest_config.account.allow_short_selling from
  generated weights the way the decision branch does at strategy.py:390-394.
  allow_short_selling is hash input, so a long_only signal whose allocator emits
  negative weights would abort with "backtest identity changed during execution".
  Current crypto Ch19 constructions carry long_short=True, so the flag is already
  True.
- precompute_weights does not apply apply_universe_filter or dispatch
  slot_persistent_signal_exit, both of which run_backtest does, so enabling a risk
  state-transition policy would change which weights are produced for a strategy
  using either. No current config combines them; universe filters are sp500_options
  and nasdaq100 only.

Both belong with the precompute path rather than the gap timeline, and this branch
is what seven case studies are waiting on.

