### PR TITLE
Address ledger artifacts in the study's space, not the filesystem's

### DIFF
--- a/case_studies/research/recovery.py
+++ b/case_studies/research/recovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 import uuid
 from dataclasses import dataclass
@@ -24,10 +25,30 @@ def _sha256(path: Path) -> str:
 
 
 def _relative(root: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(root.resolve()))
-    except ValueError as exc:
-        raise ValueError(f"completed-fold artifact is outside the study root: {path}") from exc
+    """Return the artifact's path within the study's own address space.
+
+    Deliberately does not resolve symlinks. A study whose ``run_log`` is a symlink into
+    a shared artifact store resolves its artifacts out of the study root, so resolving
+    rejects a file that is inside the study as the study addresses it. A study whose
+    ``run_log`` is a real directory - one driven through ``ML4T_OUTPUT_DIR`` - never
+    leaves the root and never saw this, which is the whole of why it survived earlier
+    runs. The trigger is the layout, not the execution tier.
+
+    Resolving was also wrong for the value's purpose. The result is a study-relative
+    label: ``reusable_fold`` compares it against the stored row, and where it is joined
+    back to open the artifact - ``scripts/prove_cme_futures_interface.py`` does exactly
+    this - it is joined onto the study root, so it has to address the artifact the way
+    the study does. A resolved label does not survive that join, and it silently
+    depends on where the symlink pointed when it was written, so re-pointing the store
+    would stop a completed fold from matching and re-run work that was already done.
+
+    ``..`` is still normalized away, without following symlinks, so a path that climbs
+    out of the study root is rejected rather than recorded as a label containing ``..``.
+    """
+    relative = os.path.relpath(os.path.abspath(path), os.path.abspath(root))
+    if relative == os.pardir or relative.startswith(f"{os.pardir}{os.sep}"):
+        raise ValueError(f"completed-fold artifact is outside the study root: {path}")
+    return relative
 
 
 @dataclass(frozen=True)

--- a/tests/test_execution_ledger_paths.py
+++ b/tests/test_execution_ledger_paths.py
@@ -1,0 +1,137 @@
+"""The execution ledger addresses artifacts as the study does, not as the filesystem does.
+
+A study whose ``run_log`` is a symlink into a shared artifact store resolves its
+artifacts out of the study root; a study whose ``run_log`` is a real directory does not.
+So a containment check that resolved symlinks passed in one layout and failed in the
+other, on the same code and the same execution tier. These tests build the symlinked
+layout, because a fix exercised only against a real directory cannot fail.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from case_studies.research.recovery import ExecutionLedger, _relative
+
+
+def _case_study_layout(tmp_path: Path) -> tuple[Path, Path]:
+    """A study root whose run_log points at a shared store outside it."""
+    root = tmp_path / "worktree" / "case_studies" / "fx_pairs"
+    store = tmp_path / "code" / "case_studies" / "fx_pairs" / "run_log"
+    (store / "training" / "abc123").mkdir(parents=True)
+    root.mkdir(parents=True)
+    (root / "run_log").symlink_to(store, target_is_directory=True)
+    artifact = root / "run_log" / "training" / "abc123" / "fold_0.bin"
+    artifact.write_bytes(b"fitted-state")
+    return root, artifact
+
+
+def test_symlinked_run_log_artifact_is_inside_the_study(tmp_path: Path) -> None:
+    root, artifact = _case_study_layout(tmp_path)
+
+    # The precondition that made this fail: the artifact resolves out of the study root.
+    assert artifact.is_file()
+    assert not str(artifact.resolve()).startswith(str(root.resolve()))
+
+    assert _relative(root, artifact) == os.path.join("run_log", "training", "abc123", "fold_0.bin")
+
+
+def test_label_is_stable_when_the_shared_store_moves(tmp_path: Path) -> None:
+    """A relabelled store must not invalidate a completed fold.
+
+    Resolving made the recorded label depend on where the symlink pointed when it was
+    written, so re-pointing the store stopped a completed fold from matching and re-ran
+    work that was already done.
+    """
+    root, artifact = _case_study_layout(tmp_path)
+    before = _relative(root, artifact)
+
+    moved = tmp_path / "relocated-code" / "case_studies" / "fx_pairs" / "run_log"
+    moved.parent.mkdir(parents=True)
+    (tmp_path / "code" / "case_studies" / "fx_pairs" / "run_log").rename(moved)
+    (root / "run_log").unlink()
+    (root / "run_log").symlink_to(moved, target_is_directory=True)
+
+    assert artifact.is_file()
+    assert _relative(root, artifact) == before
+
+
+def test_artifact_outside_the_study_is_still_rejected(tmp_path: Path) -> None:
+    root, _ = _case_study_layout(tmp_path)
+
+    with pytest.raises(ValueError, match="outside the study root"):
+        _relative(root, tmp_path / "elsewhere" / "fold_0.bin")
+
+
+def test_parent_traversal_is_rejected_rather_than_recorded(tmp_path: Path) -> None:
+    """Dropping resolve() must not drop the containment guard with it.
+
+    ``relative_to`` alone accepts this lexically and returns a label containing ``..``.
+    """
+    root, _ = _case_study_layout(tmp_path)
+    climbing = root / "run_log" / ".." / ".." / ".." / "etc" / "passwd"
+
+    with pytest.raises(ValueError, match="outside the study root"):
+        _relative(root, climbing)
+
+
+def test_complete_and_reuse_a_fold_under_a_symlinked_run_log(tmp_path: Path) -> None:
+    """The end-to-end path that actually failed: record a fold, then reuse it.
+
+    The unit tests above pin the labelling rule; this one drives ExecutionLedger the
+    way a canonical 06/07/08 run does, so the regression is caught at the surface where
+    it was reported rather than only at the helper it came from.
+    """
+    root, fitted_state = _case_study_layout(tmp_path)
+    shard = fitted_state.parent / "shard_0.parquet"
+    shard.write_bytes(b"prediction-shard")
+
+    # candidate_fold_completions references training_runs, so seed the parent row.
+    from case_studies.utils.registry.store import _open_registry, _utc_now
+
+    training_hash = "t" * 8
+    db = _open_registry(root)
+    try:
+        db.execute(
+            "INSERT INTO training_runs (training_hash, family, label, created_at) VALUES (?,?,?,?)",
+            (training_hash, "linear", "fwd_ret_1d", _utc_now()),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    ledger = ExecutionLedger(study=SimpleNamespace(), root=root)
+    fold = {
+        "training_hash": training_hash,
+        "candidate_identity": "ridge",
+        "fold_id": 0,
+    }
+    settings = {"alpha": 1.0}
+
+    ledger.complete_fold(
+        **fold,
+        fitted_state=fitted_state,
+        prediction_shard=shard,
+        resolved_settings=settings,
+    )
+
+    assert ledger.fold_completion_exists(**fold)
+    assert ledger.reusable_fold(
+        **fold,
+        fitted_state=fitted_state,
+        prediction_shard=shard,
+        resolved_settings=settings,
+    )
+
+    # The recorded label addresses the artifact from the study root, so it opens.
+    with sqlite3.connect(root / "run_log" / "registry.db") as db:
+        stored = db.execute(
+            "SELECT fitted_state_path, prediction_shard_path FROM candidate_fold_completions"
+        ).fetchone()
+    assert (root / stored[0]).read_bytes() == b"fitted-state"
+    assert (root / stored[1]).read_bytes() == b"prediction-shard"


### PR DESCRIPTION
Unblocks `06`, `07` and `08` for every study whose `run_log` is a symlink into a shared artifact store. Found by `fx_pairs` on the first canonical run of the rebuild.

```
ValueError: completed-fold artifact is outside the study root
  recovery.py:30, via ExecutionLedger.complete_fold
```

## The trigger is layout, not tier

`_relative` resolved symlinks before checking containment:

```python
str(path.resolve().relative_to(root.resolve()))
```

A study whose `run_log` is a symlink into a shared store resolves its artifacts *out* of the study root, so the check rejected a file that is inside the study as the study addresses it.

This is not a canonical-vs-preview distinction, and reading it that way would justify a test that cannot fail. `crypto_perps_funding` completed canonical `06` and `07` through the same `linear.py` and `gbm.py` without raising, because it drives production through `ML4T_OUTPUT_DIR` where `run_log` is a real directory. `cme_futures` isolated it to two cases differing only in the layout: symlinked `run_log` raises, real `run_log` returns `run_log/training/x`. Preview runs survived for the same reason, not because they are previews.

## Resolving was wrong for the value's purpose too

The stored path is a study-relative **label**. `reusable_fold` compares it against the recorded row, and `scripts/prove_cme_futures_interface.py:53-57` joins it back onto the study root to open the artifact and re-digest it. So it has to address the artifact the way the study does — and a resolved label does not survive that join, since `root / <resolved path>` opens nothing.

It also made the label depend on where the symlink pointed when it was written. Re-pointing the store stops a completed fold from matching, and the work re-runs silently. That half is layout-independent: it was never correct, and canonical production on a symlinked layout is just the first thing that made it fail loudly instead of quietly.

## The fix, and why not the obvious one

`os.path.relpath` over `os.path.abspath`, which collapses `..` without following symlinks, rejecting a result that climbs out of the root.

Dropping `resolve()` altogether fixes the crash and takes the containment guard with it: `relative_to` accepts `run_log/../../../etc/passwd` lexically and records it as a label.

## Tests

Five, over the real symlinked layout rather than a mocked check. Four pin the labelling rule and discriminate all three candidates:

| | symlinked artifact | stable label | out of root | `..` traversal |
|---|---|---|---|---|
| `resolve()` (old) | ✗ | ✗ | ✓ | ✓ |
| bare `relative_to` | ✓ | ✓ | ✓ | ✗ |
| this | ✓ | ✓ | ✓ | ✓ |

The stable-label test renames the store and re-points the symlink — both the silent-re-run case and the only test that separates the two layouts by construction rather than by naming a tier.

The fifth drives `ExecutionLedger` end to end the way a `06`/`07`/`08` run does: `complete_fold`, then `fold_completion_exists` and `reusable_fold`, then opening both artifacts through the recorded label. Against the old code it raises fx's exact error from `complete_fold`.

## Compatibility

Labels are unchanged for artifacts already inside the root, so rows written by earlier runs still match and no migration is needed.

## Verification

`628 passed` across the research, registry and adapter suites with `ML4T_DATA_PATH` pointed at the populated checkout. Ruff, formatting and pre-commit hooks green; RoboRev pre-push gate reports no blocking findings.
