### PR TITLE
Let a production run declare the population it supersedes

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -34,6 +34,13 @@ So the executor states the parameters and the stamp records that statement:
 ``--production`` for an unparameterized run, or ``--parameters '<json>'``. One of
 the two is required; this tool never infers.
 
+That choice is about what the run carried, not about what tier it was. ``production``
+is computed from the parameters, not from their absence: a run whose every override is
+in ``PRODUCTION_SAFE_PARAMETERS`` stamps as production too. A canonical run that must
+carry an override - ``SUPERSEDES_POPULATION`` on a re-run into a changed population -
+declares it with ``--parameters`` and is still production. ``--production`` is
+shorthand for the empty set, not a claim the tool would otherwise have to weigh.
+
 Where the notebook *does* carry evidence of its own execution — papermill's
 ``injected-parameters`` cell, which lives in the cell list and is rewritten by
 every parameterized run — ``stamp`` cross-checks the declaration against it and
@@ -79,10 +86,46 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SKIP_PARTS = {"_reference", ".venv", ".git", ".ipynb_checkpoints"}
 STAMP_KEY = "ml4t_provenance"
 INJECTED_TAG = "injected-parameters"
-PRODUCTION_SAFE_PARAMETERS = {
+
+
+class _ValidatedByConsumer:
+    """An override whose value this gate deliberately does not check.
+
+    The allowlist otherwise pins each name to the one value that preserves the
+    production surface, because nothing downstream would catch the other one -
+    ``FORCE_RETRAIN=False`` silently reuses a cached fit and no later check notices.
+
+    This is a second kind of allowlist entry, not a second entry. Adding a name with a
+    pinned value says "this override is harmless at this value"; marking one with this
+    says "this gate is the wrong place to check this override at all". A parameter
+    earns the marker only when BOTH hold:
+
+    1. No value of it can reduce the execution surface. It adds a declaration rather
+       than removing work, which is what separates it from ``FORCE_RETRAIN=False``.
+    2. The code that consumes it rejects a wrong value outright, so nothing is left
+       unchecked - merely moved to where the check can actually be made. For an
+       identity-bearing value the gate could not make it anyway: the correct one
+       depends on registry state at run time, which a commit hook does not have.
+
+    Both conditions, not either. A future exemption citing this precedent has to show
+    both, and a name that fails the first is a reduced run wearing a declaration.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return "<validated by the consumer>"
+
+
+VALIDATED_BY_CONSUMER = _ValidatedByConsumer()
+
+PRODUCTION_SAFE_PARAMETERS: dict[str, object] = {
     "FORCE_REBACKTEST": True,
     "FORCE_RETRAIN": True,
     "USE_CACHE": False,
+    # Names the population this run supersedes, which research/population.py requires
+    # on a re-run into a changed population and which a person sets deliberately. It
+    # adds a declaration rather than removing work, so it cannot reduce the run, and
+    # population.py raises unless it equals the current population hash exactly.
+    "SUPERSEDES_POPULATION": VALIDATED_BY_CONSUMER,
 }
 
 
@@ -110,12 +153,21 @@ def _coerce_bool(value: object) -> bool | None:
 
 
 def production_parameters(parameters: dict[str, object]) -> bool:
-    """Whether overrides preserve the full production execution surface."""
-    return all(
-        name in PRODUCTION_SAFE_PARAMETERS
-        and _coerce_bool(value) is PRODUCTION_SAFE_PARAMETERS[name]
-        for name, value in parameters.items()
-    )
+    """Whether overrides preserve the full production execution surface.
+
+    Note that this is not "carries no overrides". A canonical run may legitimately be
+    parameterized; what makes it production is that every override is one the surface
+    survives. An unlisted name is never production, whatever its value.
+    """
+    for name, value in parameters.items():
+        if name not in PRODUCTION_SAFE_PARAMETERS:
+            return False
+        expected = PRODUCTION_SAFE_PARAMETERS[name]
+        if expected is VALIDATED_BY_CONSUMER:
+            continue
+        if _coerce_bool(value) is not expected:
+            return False
+    return True
 
 
 def _normalize_value(value: object) -> tuple[str, object]:

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -74,6 +74,29 @@ def test_production_parameters_allow_only_full_run_cache_bypasses():
     assert not production_parameters({"USE_CACHE": True})
 
 
+def test_an_identity_bearing_override_is_production() -> None:
+    """A canonical run may be required to carry a parameter.
+
+    research/population.py refuses a re-run into a changed population unless it names
+    the population it supersedes, and that value is set deliberately by a person. Such
+    a run is production: the override adds a declaration rather than removing work.
+    """
+    assert production_parameters({"SUPERSEDES_POPULATION": "342446006141"})
+    assert production_parameters({"SUPERSEDES_POPULATION": "342446006141", "FORCE_RETRAIN": True})
+
+
+def test_waiving_the_value_check_does_not_admit_a_reduced_run() -> None:
+    """The waiver is per name, not a general relaxation.
+
+    Only the value of an identity-bearing override goes unchecked - its correctness is
+    enforced where it is consumed. A name that is not on the list is still not
+    production, including alongside one that is.
+    """
+    assert not production_parameters({"SUPERSEDES_POPULATION": "abc", "MAX_SYMBOLS": 8})
+    assert not production_parameters({"SUPERSEDES_POPULATION": "abc", "FORCE_RETRAIN": False})
+    assert not production_parameters({"SUPERSEDES_ARTIFACT": "abc"})
+
+
 def test_numeric_and_string_bools_are_the_same_override() -> None:
     """``1`` from a JSON declaration and ``"1"`` from ``papermill -p`` are one run."""
     assert production_parameters({"FORCE_REBACKTEST": 1})


### PR DESCRIPTION
Unblocks `fx_pairs`' `06_linear` commit. **This changes what the fleet-wide commit gate accepts, so the reasoning is here rather than only in the commit message.**

## The contradiction

`research/population.py` refuses a re-run into a changed population unless the run names the population it supersedes, and that value is deliberately not inferred — auto-filling it would turn the guard into a formality. So `fx_pairs`' `06_linear` must carry `SUPERSEDES_POPULATION`.

The commit gate then rejected it:

```
TEST-MODE (committed a run with papermill parameter overrides — must be production):
  06_linear.ipynb (params={'SUPERSEDES_POPULATION': '342446006141'})
```

A canonical run classified as TEST-MODE for carrying a parameter it is required to carry. The artifacts were complete — 681 prediction sets, population 84 of 84. Only the commit was blocked.

## What was already true

The gate does **not** treat tier and parameterization as one axis, and it never did. `production` is computed by `production_parameters` against `PRODUCTION_SAFE_PARAMETERS`, an allowlist of overrides the production surface survives:

| parameters | `production` |
|---|---|
| `{}` | True |
| `{"FORCE_RETRAIN": True}` | **True** |
| `{"USE_CACHE": False}` | **True** |
| `{"FORCE_RETRAIN": False}` | False |
| `{"MAX_SYMBOLS": 8}` | False |

A parameterized canonical run already stamps as production. `--production` is shorthand for the empty set, not a claim the tool weighs. `SUPERSEDES_POPULATION` was simply not on the list. The module docstring described the CLI choice in terms that read as the semantic model; it now says which one it is.

## A new entry *kind*, not a new entry

The existing entries pin a name to the one value that preserves the surface, because nothing downstream catches the other one — `FORCE_RETRAIN=False` silently reuses a cached fit and no later check notices. `SUPERSEDES_POPULATION` has no fixed value: it is a population hash that differs per run.

So the value check is waived for it, and the bar for doing that is recorded on the sentinel, because the next request for an exemption will cite this one. **Both conditions, not either:**

1. **No value of it can reduce the execution surface.** It adds a declaration rather than removing work. This is what separates it from `FORCE_RETRAIN=False`, and a name failing it is a reduced run wearing a declaration.
2. **The consumer rejects a wrong value outright.** `population.py:81` raises unless it equals the current population hash exactly. The value is not unchecked — it is checked where the check can be made. The gate could not make it: the correct hash depends on registry state at run time, which a commit hook does not have.

## What this deliberately does not do

Allow `--production` together with arbitrary `--parameters`. That was the proposed fix and it is worse than the problem: it replaces a value-checked allowlist with an unchecked executor declaration, and would admit `--production --parameters '{"MAX_SYMBOLS": 8}'`. The guarantee the gate makes — *every override in a committed run is one the production surface survives* — is unchanged here; only its allowlist grew by one name whose value is enforced elsewhere.

## Scope

`SUPERSEDES_POPULATION` is the only identity-bearing notebook parameter in the fleet; a sweep of every `public-s6-*` worktree found `fx_pairs/06_linear.py` as the sole hit. The PR covers one name and does not try to anticipate others.

## Tests

`tests/test_notebook_sync.py`, 39 passing. The two new ones fail without the allowlist entry:

- the identity-bearing override is production, alone and beside `FORCE_RETRAIN=True`
- the waiver is per name, not a relaxation: `MAX_SYMBOLS=8` is still rejected beside it, `FORCE_RETRAIN=False` still is, and an unlisted name still is
