### PR TITLE
Write every SDF checkpoint schedule in the scheme its consumer reads

### DIFF
--- a/case_studies/cme_futures/config/setup.yaml
+++ b/case_studies/cme_futures/config/setup.yaml
@@ -340,7 +340,7 @@ modeling:
     persistent_entities: true
     model_kwargs:
       sdf:
-        checkpoint_epochs: [256, 512, 768, 1024, 1280]
+        checkpoint_epochs: [256, 512, 768, 1024]  # conditional-relative; publishes global 256..1280
         beta_checkpoint_epochs: [256]
         beta_default_checkpoint: 256
 

--- a/case_studies/config/sdf/sdf.yaml
+++ b/case_studies/config/sdf/sdf.yaml
@@ -2,7 +2,7 @@ n_epochs_unc: 256
 n_epochs_moment: 64
 n_epochs_cond: 1024
 burn_in_epochs: 0
-checkpoint_epochs: [256, 512, 768, 1024, 1280]
+checkpoint_epochs: [256, 512, 768, 1024]
 beta_n_epochs: 256
 beta_checkpoint_epochs: [256]
 beta_default_checkpoint: 256

--- a/case_studies/etfs/config/setup.yaml
+++ b/case_studies/etfs/config/setup.yaml
@@ -301,7 +301,7 @@ modeling:
         factor_ridge: 0.01
         gamma_ridge: 0.01
       sdf:
-        checkpoint_epochs: [256, 512, 768, 1024, 1280]
+        checkpoint_epochs: [256, 512, 768, 1024]  # conditional-relative; publishes global 256..1280
         beta_checkpoint_epochs: [256]
         beta_default_checkpoint: 256
 

--- a/case_studies/sp500_equity_option_analytics/config/setup.yaml
+++ b/case_studies/sp500_equity_option_analytics/config/setup.yaml
@@ -320,7 +320,7 @@ modeling:
         factor_ridge: 0.01
         gamma_ridge: 0.01
       sdf:
-        checkpoint_epochs: [256, 512, 768, 1024, 1280]
+        checkpoint_epochs: [256, 512, 768, 1024]  # conditional-relative; publishes global 256..1280
         beta_checkpoint_epochs: [256]
         beta_default_checkpoint: 256
 

--- a/case_studies/us_equities_panel/config/setup.yaml
+++ b/case_studies/us_equities_panel/config/setup.yaml
@@ -188,7 +188,7 @@ modeling:
         n_epochs_moment: 32
         n_epochs_cond: 512
         burn_in_epochs: 32
-        checkpoint_epochs: [128, 256, 384, 512, 640]
+        checkpoint_epochs: [128, 256, 384, 512]  # conditional-relative; publishes global 128..640
         beta_checkpoint_epochs: [256]
         beta_default_checkpoint: 256
 

--- a/case_studies/us_firm_characteristics/config/setup.yaml
+++ b/case_studies/us_firm_characteristics/config/setup.yaml
@@ -396,7 +396,7 @@ modeling:
         factor_ridge: 0.01
         gamma_ridge: 0.01
       sdf:
-        checkpoint_epochs: [256, 512, 768, 1024, 1280]
+        checkpoint_epochs: [256, 512, 768, 1024]  # conditional-relative; publishes global 256..1280
         beta_checkpoint_epochs: [256]
         beta_default_checkpoint: 256
 

--- a/case_studies/utils/latent_factors/common.py
+++ b/case_studies/utils/latent_factors/common.py
@@ -24,7 +24,18 @@ def resolve_checkpoint_epochs(
         raise ValueError(f"max_epoch must be positive; got {max_epoch}")
 
     if checkpoint_epochs is not None:
-        epochs = sorted({int(epoch) for epoch in checkpoint_epochs if 1 <= int(epoch) <= max_epoch})
+        # Refuse an out-of-range entry rather than dropping it. Silently filtering is
+        # how a schedule written in global epochs (unconditional offset plus conditional
+        # epoch) survived being consumed as conditional-relative: the one entry that
+        # exposed the mismatch was removed here, so the canonical path's ValueError from
+        # the model config was the only detector, and the preview path never saw one.
+        requested = [int(epoch) for epoch in checkpoint_epochs]
+        out_of_range = [epoch for epoch in requested if not 1 <= epoch <= max_epoch]
+        if out_of_range:
+            raise ValueError(
+                f"checkpoint_epochs entries must be within 1..{max_epoch}; got {out_of_range}"
+            )
+        epochs = sorted(set(requested))
         if not epochs:
             raise ValueError("checkpoint_epochs did not contain a valid epoch")
     elif checkpoint_interval is None or checkpoint_interval <= 0:

--- a/scripts/probe_latent_identities.py
+++ b/scripts/probe_latent_identities.py
@@ -1,0 +1,39 @@
+"""Resolve latent-factor training identities without executing anything.
+
+Used to measure which identities a config edit moves, by running it before and after
+the edit and diffing. Resolve-only: no training, no artifact written.
+
+    uv run python -m scripts.probe_latent_identities cme_futures fwd_ret_5d pca sdf
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 4:
+        print(__doc__)
+        return 2
+    case_study, label, *config_names = argv[1:]
+
+    from case_studies.research.workspace import Study
+
+    study = Study.regenerate(case_study, release_root=REPO)
+    for config_name in config_names:
+        request = study.model(
+            family="latent_factors",
+            label=label,
+            config_name=config_name,
+            execution_tier="canonical",
+        )
+        resolved = request.resolve()
+        print(f"{config_name:8s} {resolved.identity}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_latent_factors_no_leak.py
+++ b/tests/test_latent_factors_no_leak.py
@@ -583,7 +583,9 @@ def test_sdf_expected_spec_includes_library_output_defaults() -> None:
         "n_epochs_unc": 256,
         "n_epochs_moment": 64,
         "n_epochs_cond": 1024,
-        "checkpoint_epochs": [256, 512, 768, 1024, 1280],
+        # Conditional-relative, as every preset in the corpus now is. The published
+        # labels below are global and unchanged by the renumbering.
+        "checkpoint_epochs": [256, 512, 768, 1024],
         "beta_n_epochs": 256,
         "beta_checkpoint_epochs": [256],
         "beta_default_checkpoint": 256,

--- a/tests/test_sdf_checkpoint_numbering.py
+++ b/tests/test_sdf_checkpoint_numbering.py
@@ -1,0 +1,132 @@
+"""Contracts for the SDF checkpoint schedule and the two numbering schemes around it.
+
+The preset field `checkpoint_epochs` is CONDITIONAL-RELATIVE: the model config validates
+it against `n_epochs_cond` alone. The checkpoint labels the run publishes are GLOBAL:
+`n_epochs_unc` plus the conditional epoch. Every preset in the corpus was written in the
+global scheme, and the canonical path refused it while the preview path passed because
+`resolve_checkpoint_epochs` silently dropped the entry that exposed the mismatch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from case_studies.utils.latent_factors.common import resolve_checkpoint_epochs
+
+REPO = Path(__file__).resolve().parents[1]
+SHARED_PRESET = REPO / "case_studies" / "config" / "sdf" / "sdf.yaml"
+CASE_STUDIES = (
+    "cme_futures",
+    "etfs",
+    "sp500_equity_option_analytics",
+    "us_equities_panel",
+    "us_firm_characteristics",
+)
+
+
+def _shared_defaults() -> dict:
+    return yaml.safe_load(SHARED_PRESET.read_text())
+
+
+def _case_study_preset(case_study: str) -> dict:
+    document = yaml.safe_load(
+        (REPO / "case_studies" / case_study / "config" / "setup.yaml").read_text()
+    )
+    block = document["modeling"]["latent_factors"]["model_kwargs"]["sdf"]
+    return {**_shared_defaults(), **block}
+
+
+def _presets() -> list[tuple[str, dict]]:
+    return [("config/sdf/sdf.yaml", _shared_defaults())] + [
+        (case_study, _case_study_preset(case_study)) for case_study in CASE_STUDIES
+    ]
+
+
+def _published_labels(preset: dict) -> list[int]:
+    """Reproduce `_resolve_latent_checkpoints` for the SDF branch."""
+    unc = int(preset["n_epochs_unc"])
+    cond = int(preset["n_epochs_cond"])
+    physical = resolve_checkpoint_epochs(
+        max(unc, cond),
+        checkpoint_interval=None,
+        checkpoint_epochs=[int(epoch) for epoch in preset["checkpoint_epochs"]],
+    )
+    labels = {epoch for epoch in physical if epoch <= unc}
+    labels |= {unc + epoch for epoch in physical if epoch <= cond}
+    return sorted(labels)
+
+
+@pytest.mark.parametrize(
+    "name,preset", _presets(), ids=lambda value: value if isinstance(value, str) else ""
+)
+def test_every_sdf_preset_is_within_its_conditional_budget(name: str, preset: dict) -> None:
+    """The canonical path hands the raw preset to the model config, which validates it
+    against `n_epochs_cond`. A preset above that budget fails production, not review."""
+    cond = int(preset["n_epochs_cond"])
+    declared = [int(epoch) for epoch in preset["checkpoint_epochs"]]
+    assert max(declared) <= cond, f"{name}: {max(declared)} exceeds n_epochs_cond {cond}"
+
+
+@pytest.mark.parametrize(
+    "name,preset", _presets(), ids=lambda value: value if isinstance(value, str) else ""
+)
+def test_every_sdf_preset_declares_exactly_the_schedule_that_runs(name: str, preset: dict) -> None:
+    """The declared list must equal the resolved physical list.
+
+    Asserting on the published labels instead does not work, and the reason is the trap
+    worth naming: `include_final` appends `max_epoch`, so `[256,512,768]`,
+    `[256,512,768,1024]` and `[256,512,768,1024,1280]` all publish the same labels. A
+    truncated preset is invisible in the schedule and still moves the training identity,
+    because the declared list is what enters the spec.
+    """
+    unc = int(preset["n_epochs_unc"])
+    cond = int(preset["n_epochs_cond"])
+    declared = [int(epoch) for epoch in preset["checkpoint_epochs"]]
+    physical = resolve_checkpoint_epochs(
+        max(unc, cond), checkpoint_interval=None, checkpoint_epochs=declared
+    )
+    assert declared == physical, name
+
+
+@pytest.mark.parametrize(
+    "name,preset", _presets(), ids=lambda value: value if isinstance(value, str) else ""
+)
+def test_every_sdf_preset_publishes_the_full_conditional_horizon(name: str, preset: dict) -> None:
+    """The final published label is the end of the conditional stage in global numbering.
+    This is the property the renumbering had to preserve."""
+    unc = int(preset["n_epochs_unc"])
+    cond = int(preset["n_epochs_cond"])
+    assert _published_labels(preset)[-1] == unc + cond, name
+
+
+def test_out_of_range_checkpoint_is_refused_not_dropped() -> None:
+    """Filtering silently is what let a globally numbered preset survive review."""
+    with pytest.raises(ValueError, match=r"must be within 1\.\.1024"):
+        resolve_checkpoint_epochs(
+            1024, checkpoint_interval=None, checkpoint_epochs=[256, 512, 768, 1024, 1280]
+        )
+
+
+def test_in_range_checkpoints_resolve_unchanged() -> None:
+    assert resolve_checkpoint_epochs(
+        1024, checkpoint_interval=None, checkpoint_epochs=[256, 512, 768, 1024]
+    ) == [256, 512, 768, 1024]
+
+
+def test_beta_schedule_is_a_separate_budget_and_is_left_alone() -> None:
+    """`beta_checkpoint_epochs` validates against `beta_n_epochs`, not `n_epochs_cond`,
+    and is already exactly at its budget. The 256 it shares with `n_epochs_unc` is a
+    coincidence of value; renumbering it would break it."""
+    for name, preset in _presets():
+        beta_total = int(preset["beta_n_epochs"])
+        beta_epochs = [int(epoch) for epoch in preset["beta_checkpoint_epochs"]]
+        assert max(beta_epochs) == beta_total, name
+        assert (
+            resolve_checkpoint_epochs(
+                beta_total, checkpoint_interval=None, checkpoint_epochs=beta_epochs
+            )
+            == beta_epochs
+        ), name


### PR DESCRIPTION
`checkpoint_epochs` is consumed as **conditional-relative** - the model config validates it against
`n_epochs_cond` alone. Every preset in the corpus was written in the **global** scheme, where a label
is `n_epochs_unc` plus the conditional epoch, so the last entry was `n_epochs_unc + n_epochs_cond`
and out of range by construction. All six had `max == n_epochs_unc + n_epochs_cond`, and
`us_equities_panel` scales the same pattern to 128/512, so the global scheme was deliberate at
authoring time rather than a typo.

It survived because `resolve_checkpoint_epochs` filtered the out-of-range entry silently. The preview
path handed the library the filtered list and passed; the canonical path handed it the raw preset and
was refused. **A preview could therefore clear a cohort the canonical run could not execute**, which
is how `cme_futures` `10b` failed production at `checkpoint_epochs entries must be <= 1024; got 1280`
after a green preview. Five case studies had the same failure queued.

The filter is not the bug and 1280 is not spurious - it is the global label of the final conditional
checkpoint. What was wrong is that two numbering schemes met in one field with nothing saying which
it was.

## Order within the commit

The presets are renumbered first and `resolve_checkpoint_epochs` is hardened second, in that
dependency order. Hardening alone would break all six presets at resolve time rather than at
production, converting five latent failures into immediate ones. Hardening reveals a data problem; it
does not fix one.

## Published schedule is unchanged, measured rather than assumed

| case studies | preset before | preset after | published labels |
|---|---|---|---|
| `cme_futures`, `etfs`, `sp500_equity_option_analytics`, `us_firm_characteristics` | `[256,512,768,1024,1280]` | `[256,512,768,1024]` | `[256,512,768,1024,1280]` |
| `us_equities_panel` | `[128,256,384,512,640]` | `[128,256,384,512]` | `[128,256,384,512,640]` |

`tests/test_latent_factors_no_leak.py::test_sdf_expected_spec_includes_library_output_defaults`
witnesses this directly: its input preset is renumbered and its assertion on the published labels is
unchanged.

## Identities move, and wider than the SDF family

Resolved canonically for `cme_futures` `fwd_ret_5d`, before and after, on a clean tree:

```
pca  e3b09eb3c4f8 -> b3e5d0cb8fe8
sdf  bc28d2791106 -> 42058803119e
```

`pca` moves although its own `model_kwargs` carry no `checkpoint_epochs`, because the case-wide
`latent_factors` block reaches the resolved computation. **So every case study with a `pca`
population needs it re-produced, not only the ones with an `sdf`.** `cme_futures` is the only case
study that has produced one, at `e3b09eb3c4f8`.

## Tests

`tests/test_sdf_checkpoint_numbering.py` is new: 21 cases, both mutations verified failing.
`tests/test_sdf_checkpoint_numbering.py` and `tests/test_latent_factors_no_leak.py` are 59 passed at
`6725b3c6`.

`scripts/probe_latent_identities.py` is a resolve-only identity probe, added so the before/after
above can be re-measured rather than trusted.