### PR TITLE
Pin the holdout replay to the validation carrier's checkpoint

### DIFF
--- a/case_studies/utils/paired_metrics.py
+++ b/case_studies/utils/paired_metrics.py
@@ -382,7 +382,7 @@ def _holdout_lineage_for(
     *,
     label_restriction: frozenset[str] | None,
     rung: dict | None,
-    prefer_training_hash: str | None = None,
+    prefer_prediction_hash: str | None = None,
 ) -> dict | None:
     """Return ``{backtest_hash, prediction_hash, family, config_name, label}``
     for the highest-Sharpe holdout backtest registered in this case study,
@@ -429,28 +429,49 @@ def _holdout_lineage_for(
     db = sqlite3.connect(str(db_path))
     db.row_factory = sqlite3.Row
     try:
-        # Same-lineage preference: when the caller knows the validation rank-1's
-        # training_hash, prefer a holdout that shares it — pins val→holdout
-        # decay to the same trained model rather than a same-spec but
-        # different-lineage holdout that happens to have a higher Sharpe.
-        if prefer_training_hash is not None:
-            row = db.execute(
-                f"""
-                SELECT t.family, t.config_name, t.label,
-                       p.prediction_hash, b.backtest_hash
-                FROM prediction_sets p
-                JOIN training_runs t ON p.training_hash = t.training_hash
-                JOIN backtest_runs b ON p.prediction_hash = b.prediction_hash
-                                     AND b.stage IN ('signal','allocation','risk_overlay','holdout')
-                JOIN backtest_metrics bm ON b.backtest_hash = bm.backtest_hash
-                WHERE {where_sql} AND p.training_hash = ?
-                ORDER BY bm.sharpe DESC NULLS LAST
-                LIMIT 1
+        # Same-lineage preference: given the validation rank-1's own prediction
+        # set, prefer a holdout sharing its trained model AND its checkpoint.
+        # Both are read from that one row here rather than accepted as separate
+        # arguments, because a caller that passes the training hash and forgets
+        # the checkpoint reintroduces the defect while looking correct.
+        #
+        # The checkpoint has to be pinned because a trained model registers one
+        # prediction set per declared checkpoint and they share a strategy spec,
+        # so the training hash alone leaves one indistinguishable candidate per
+        # checkpoint. This branch writes the hash the ``val_rank1_self`` pair is
+        # stored under and ``select_holdout_self_backtest`` reads it back, so the
+        # two must agree. Ordering by ``backtest_hash`` rather than by Sharpe
+        # keeps the choice off holdout performance either way.
+        if prefer_prediction_hash is not None:
+            carrier = db.execute(
+                """
+                SELECT training_hash, checkpoint_value, checkpoint_kind
+                FROM prediction_sets WHERE prediction_hash = ?
                 """,
-                params + [prefer_training_hash],
+                (prefer_prediction_hash,),
             ).fetchone()
-            if row:
-                return dict(row)
+            if carrier is not None:
+                row = db.execute(
+                    f"""
+                    SELECT t.family, t.config_name, t.label,
+                           p.prediction_hash, b.backtest_hash
+                    FROM prediction_sets p
+                    JOIN training_runs t ON p.training_hash = t.training_hash
+                    JOIN backtest_runs b ON p.prediction_hash = b.prediction_hash
+                                         AND b.stage IN
+                                             ('signal','allocation','risk_overlay','holdout')
+                    JOIN backtest_metrics bm ON b.backtest_hash = bm.backtest_hash
+                    WHERE {where_sql}
+                      AND p.training_hash = ?
+                      AND p.checkpoint_value IS ?
+                      AND p.checkpoint_kind IS ?
+                    ORDER BY b.backtest_hash
+                    LIMIT 1
+                    """,
+                    params + [carrier[0], carrier[1], carrier[2]],
+                ).fetchone()
+                if row:
+                    return dict(row)
 
         row = db.execute(
             f"""
@@ -784,29 +805,16 @@ def populate_paired_metrics(
         rung=rung,
         carrier_pin_predicate=carrier_pin_predicate,
     )
-    _val_training_hash: str | None = None
-    try:
-        _case_db = get_case_study_dir(cs) / "run_log" / "registry.db"
-        with sqlite3.connect(str(_case_db)) as _con:
-            _row = _con.execute(
-                "SELECT training_hash FROM prediction_sets WHERE prediction_hash = ?",
-                (leader_phash,),
-            ).fetchone()
-            if _row:
-                _val_training_hash = _row[0]
-    except (sqlite3.Error, OSError) as exc:
-        print(
-            f"[warn] {cs}: failed to resolve val_training_hash from "
-            f"prediction_hash={leader_phash}: {type(exc).__name__}: {exc}"
-        )
-        _val_training_hash = None
+    # The carrier's training hash and checkpoint are both resolved inside
+    # ``_holdout_lineage_for`` from this one prediction hash, so the same-lineage
+    # preference cannot be half-applied by a caller.
     ho_lineage = _holdout_lineage_for(
         cs,
         leader_label,
         strategy_spec=val_spec,
         label_restriction=label_restriction,
         rung=rung,
-        prefer_training_hash=_val_training_hash,
+        prefer_prediction_hash=leader_phash,
     )
     ho_hash = ho_lineage["backtest_hash"] if ho_lineage else None
     ho_label = ho_lineage["label"] if ho_lineage else leader_label

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -169,7 +169,19 @@ def select_holdout_self_backtest(
     ``val_rank1_self`` pair (written against the canonical lineage's
     holdout hash) goes unfound by the reader.
 
-    Returns ``None`` when no matching holdout backtest exists.
+    The checkpoint is part of the model configuration, so the replay is
+    pinned to the validation prediction set's own ``checkpoint_value`` and
+    ``checkpoint_kind`` as well as its ``training_hash``. One trained model
+    registers one prediction set per declared checkpoint, and the strategy
+    spec is identical across them, so ``training_hash`` alone leaves several
+    indistinguishable holdout candidates. Resolving those by holdout Sharpe -
+    which the previous ``ORDER BY bm.sharpe DESC`` did - reads the holdout to
+    choose among configurations, the one thing
+    ``reference/CASE_STUDY_PIPELINE.md`` §6 forbids outright. Exposure is a
+    function of how many checkpoints per configuration a case study advances.
+
+    Returns ``None`` when no matching holdout backtest exists. Raises when the
+    pinned lineage is still ambiguous, rather than picking one.
     """
     import sqlite3
 
@@ -187,30 +199,47 @@ def select_holdout_self_backtest(
         val_strategy = json.loads(val_spec_json).get("strategy", {})
 
         train_row = db.execute(
-            "SELECT training_hash FROM prediction_sets WHERE prediction_hash = ?",
+            """
+            SELECT training_hash, checkpoint_value, checkpoint_kind
+            FROM prediction_sets WHERE prediction_hash = ?
+            """,
             (val_pred_hash,),
         ).fetchone()
         if train_row is None:
             return None
-        training_hash = train_row[0]
+        training_hash, checkpoint_value, checkpoint_kind = train_row
 
+        # ``IS`` is SQLite's null-safe equality: a configuration with no
+        # checkpoint dimension stores NULL on both sides and must still match,
+        # while ``=`` would drop it.
         candidates = db.execute(
             """
             SELECT b.backtest_hash, b.spec_json
             FROM backtest_runs b
             JOIN prediction_sets p ON b.prediction_hash = p.prediction_hash
-            LEFT JOIN backtest_metrics bm ON bm.backtest_hash = b.backtest_hash
-            WHERE p.training_hash = ? AND p.split = 'holdout'
-            ORDER BY bm.sharpe DESC NULLS LAST
+            WHERE p.training_hash = ?
+              AND p.split = 'holdout'
+              AND p.checkpoint_value IS ?
+              AND p.checkpoint_kind IS ?
+            ORDER BY b.backtest_hash
             """,
-            (training_hash,),
+            (training_hash, checkpoint_value, checkpoint_kind),
         ).fetchall()
 
-    for bh, spec_json in candidates:
-        candidate_strategy = json.loads(spec_json).get("strategy", {})
-        if candidate_strategy == val_strategy:
-            return bh
-    return None
+    matched = [
+        bh
+        for bh, spec_json in candidates
+        if json.loads(spec_json).get("strategy", {}) == val_strategy
+    ]
+    if not matched:
+        return None
+    if len(set(matched)) > 1:
+        raise ValueError(
+            f"holdout replay for {val_backtest_hash} is ambiguous: "
+            f"{sorted(set(matched))} share training_hash {training_hash}, "
+            f"checkpoint {checkpoint_kind}={checkpoint_value} and one strategy spec"
+        )
+    return matched[0]
 
 
 def resolve_canonical_rank1_lineage(case_study: str) -> dict[str, Any]:

--- a/tests/test_holdout_checkpoint_identity.py
+++ b/tests/test_holdout_checkpoint_identity.py
@@ -34,9 +34,11 @@ def _build_registry(case_dir, *, checkpoints=(200, 400), holdout_sharpes=(0.4, 1
     """One training run, one prediction set per checkpoint per split.
 
     The strategy spec is identical across checkpoints, which is what makes the
-    candidates indistinguishable without the checkpoint pin. The second
-    checkpoint is given the better holdout Sharpe so that a lookup ordering on
-    Sharpe picks it.
+    candidates indistinguishable without the checkpoint pin. By default the
+    second checkpoint is given the better holdout Sharpe, so a lookup ordering on
+    Sharpe picks it; a caller can invert `holdout_sharpes` to point Sharpe order
+    at the first checkpoint instead, which is how a case makes its carrier win
+    neither the `backtest_hash` nor the `sharpe` tiebreak.
     """
     run_log = case_dir / "run_log"
     run_log.mkdir(parents=True, exist_ok=True)

--- a/tests/test_holdout_checkpoint_identity.py
+++ b/tests/test_holdout_checkpoint_identity.py
@@ -17,6 +17,7 @@ import sqlite3
 
 import pytest
 
+from case_studies.utils.paired_metrics import _holdout_lineage_for
 from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
 from case_studies.utils.strategy_analysis import select_holdout_self_backtest
 
@@ -47,14 +48,19 @@ def _build_registry(case_dir, *, checkpoints=(200, 400), holdout_sharpes=(0.4, 1
         (TRAINING_HASH,),
     )
     for checkpoint, holdout_sharpe in zip(checkpoints, holdout_sharpes, strict=True):
+        # A configuration with no checkpoint dimension stores NULL in *both*
+        # columns, which is what the linear and GBM holdout rows look like. Binding
+        # the kind to the value is what makes the `checkpoint_kind IS ?` half of the
+        # guard fail when it is written as `=`.
+        checkpoint_kind = "iteration" if checkpoint is not None else None
         for split in ("validation", "holdout"):
             pred = f"p_{split}_{checkpoint}"
             backtest = f"b_{split}_{checkpoint}"
             db.execute(
                 "INSERT INTO prediction_sets (prediction_hash, training_hash,"
                 " checkpoint_value, checkpoint_kind, split, created_at)"
-                " VALUES (?, ?, ?, 'iteration', ?, '2026-08-16T00:00:00+00:00')",
-                (pred, TRAINING_HASH, checkpoint, split),
+                " VALUES (?, ?, ?, ?, ?, '2026-08-16T00:00:00+00:00')",
+                (pred, TRAINING_HASH, checkpoint, checkpoint_kind, split),
             )
             db.execute(
                 "INSERT INTO backtest_runs (backtest_hash, prediction_hash, spec_json,"
@@ -73,8 +79,16 @@ def _build_registry(case_dir, *, checkpoints=(200, 400), holdout_sharpes=(0.4, 1
 
 @pytest.fixture
 def case_study(tmp_path, monkeypatch):
+    """Redirect both resolvers, which are bound differently.
+
+    ``strategy_analysis`` imports ``get_case_study_dir`` inside the function, so
+    patching ``utils.paths`` reaches it; ``paired_metrics`` binds it at module
+    import, so it needs its own patch or the test silently reads the real
+    registry instead of the fixture.
+    """
     case_dir = tmp_path / "etfs"
     monkeypatch.setattr("utils.paths.get_case_study_dir", lambda _: case_dir)
+    monkeypatch.setattr("case_studies.utils.paired_metrics.get_case_study_dir", lambda _: case_dir)
     return case_dir
 
 
@@ -111,6 +125,40 @@ def test_a_diverging_strategy_spec_is_not_a_replay(case_study):
     db.close()
 
     assert select_holdout_self_backtest("etfs", "b_validation_200") is None
+
+
+def test_both_resolvers_agree_on_one_hash_for_the_same_carrier(case_study):
+    """Given the same carrier prediction set, writer and reader return one hash.
+
+    `_holdout_lineage_for` picks the holdout the `val_rank1_self` pair is stored
+    against; `select_holdout_self_backtest` is what the strategy-analysis
+    notebooks pass to `load_paired_metrics` to find it again. Pinning one side
+    only makes them disagree exactly where a training run has holdout backtests
+    at more than one checkpoint, and the pair lookup then returns empty: `etfs`
+    reports NaN val-to-holdout decay and `us_firm_characteristics` raises.
+
+    Scope, stated because the name would otherwise overclaim: this covers the two
+    resolvers, not the wiring that hands `_holdout_lineage_for` its carrier.
+    Mutating that call site does not fail this test. What removes that class of
+    error is the signature rather than this assertion - the function takes one
+    prediction hash and derives both the training hash and the checkpoint from
+    it, so a caller cannot supply half a pin; it can only omit the preference
+    entirely and fall back.
+    """
+    _build_registry(case_study)
+
+    writer = _holdout_lineage_for(
+        "etfs",
+        "fwd_ret_21d",
+        strategy_spec=None,
+        label_restriction=None,
+        rung=None,
+        prefer_prediction_hash="p_validation_200",
+    )
+    reader = select_holdout_self_backtest("etfs", "b_validation_200")
+
+    assert writer is not None
+    assert writer["backtest_hash"] == reader == "b_holdout_200"
 
 
 def test_an_ambiguous_pinned_lineage_raises_rather_than_choosing(case_study):

--- a/tests/test_holdout_checkpoint_identity.py
+++ b/tests/test_holdout_checkpoint_identity.py
@@ -1,0 +1,130 @@
+"""The holdout replay is pinned to the validation set's checkpoint.
+
+``reference/CASE_STUDY_PIPELINE.md`` §5 makes the checkpoint part of the model
+configuration and §6 allows the holdout exactly one use, on the selected
+configuration. A lookup keyed on ``training_hash`` alone leaves one holdout
+candidate per declared checkpoint, all carrying the same strategy spec, and
+resolving them by holdout Sharpe reads the holdout to choose among
+configurations.
+
+Exposure scales with ``backtest.sweep.checkpoints_per_config``: ``etfs``
+advances two checkpoints per configuration, so it registers two
+indistinguishable holdout candidates for every carrier.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
+from case_studies.utils.strategy_analysis import select_holdout_self_backtest
+
+TRAINING_HASH = "t_gbm_leaves_7_mae"
+STRATEGY = {"signal": {"method": "score_weighted_top_k", "top_k": 10}}
+OTHER_STRATEGY = {"signal": {"method": "score_weighted_top_k", "top_k": 20}}
+
+
+def _spec(strategy: dict) -> str:
+    return json.dumps({"strategy": strategy})
+
+
+def _build_registry(case_dir, *, checkpoints=(200, 400), holdout_sharpes=(0.4, 1.9)):
+    """One training run, one prediction set per checkpoint per split.
+
+    The strategy spec is identical across checkpoints, which is what makes the
+    candidates indistinguishable without the checkpoint pin. The second
+    checkpoint is given the better holdout Sharpe so that a lookup ordering on
+    Sharpe picks it.
+    """
+    run_log = case_dir / "run_log"
+    run_log.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(str(run_log / "registry.db"))
+    db.executescript(REGISTRY_SCHEMA_SQL)
+    db.execute(
+        "INSERT INTO training_runs (training_hash, family, label, config_name, created_at)"
+        " VALUES (?, 'gbm', 'fwd_ret_21d', 'leaves_7_mae', '2026-08-16T00:00:00+00:00')",
+        (TRAINING_HASH,),
+    )
+    for checkpoint, holdout_sharpe in zip(checkpoints, holdout_sharpes, strict=True):
+        for split in ("validation", "holdout"):
+            pred = f"p_{split}_{checkpoint}"
+            backtest = f"b_{split}_{checkpoint}"
+            db.execute(
+                "INSERT INTO prediction_sets (prediction_hash, training_hash,"
+                " checkpoint_value, checkpoint_kind, split, created_at)"
+                " VALUES (?, ?, ?, 'iteration', ?, '2026-08-16T00:00:00+00:00')",
+                (pred, TRAINING_HASH, checkpoint, split),
+            )
+            db.execute(
+                "INSERT INTO backtest_runs (backtest_hash, prediction_hash, spec_json,"
+                " stage, created_at) VALUES (?, ?, ?, 'signal', '2026-08-16T00:00:00+00:00')",
+                (backtest, pred, _spec(STRATEGY)),
+            )
+            sharpe = holdout_sharpe if split == "holdout" else 1.0
+            db.execute(
+                "INSERT INTO backtest_metrics (backtest_hash, computed_at, sharpe)"
+                " VALUES (?, '2026-08-16T00:00:00+00:00', ?)",
+                (backtest, sharpe),
+            )
+    db.commit()
+    db.close()
+
+
+@pytest.fixture
+def case_study(tmp_path, monkeypatch):
+    case_dir = tmp_path / "etfs"
+    monkeypatch.setattr("utils.paths.get_case_study_dir", lambda _: case_dir)
+    return case_dir
+
+
+def test_holdout_replay_uses_the_validation_checkpoint_not_the_better_one(case_study):
+    """The carrier is checkpoint 200; checkpoint 400 has the higher holdout Sharpe."""
+    _build_registry(case_study)
+
+    assert select_holdout_self_backtest("etfs", "b_validation_200") == "b_holdout_200"
+
+
+def test_each_checkpoint_replays_onto_its_own_holdout(case_study):
+    """Both directions, so the pin is not satisfied by always returning the first row."""
+    _build_registry(case_study)
+
+    assert select_holdout_self_backtest("etfs", "b_validation_400") == "b_holdout_400"
+
+
+def test_a_configuration_without_checkpoints_still_matches(case_study):
+    """``IS`` is null-safe; ``=`` would drop a linear run storing NULL on both sides."""
+    _build_registry(case_study, checkpoints=(None,), holdout_sharpes=(0.7,))
+
+    assert select_holdout_self_backtest("etfs", "b_validation_None") == "b_holdout_None"
+
+
+def test_a_diverging_strategy_spec_is_not_a_replay(case_study):
+    """The existing allocator-variant guard survives the checkpoint pin."""
+    _build_registry(case_study, checkpoints=(200,), holdout_sharpes=(0.4,))
+    db = sqlite3.connect(str(case_study / "run_log" / "registry.db"))
+    db.execute(
+        "UPDATE backtest_runs SET spec_json = ? WHERE backtest_hash = 'b_holdout_200'",
+        (_spec(OTHER_STRATEGY),),
+    )
+    db.commit()
+    db.close()
+
+    assert select_holdout_self_backtest("etfs", "b_validation_200") is None
+
+
+def test_an_ambiguous_pinned_lineage_raises_rather_than_choosing(case_study):
+    """Two holdout backtests on one checkpoint and one spec is unresolvable."""
+    _build_registry(case_study, checkpoints=(200,), holdout_sharpes=(0.4,))
+    db = sqlite3.connect(str(case_study / "run_log" / "registry.db"))
+    db.execute(
+        "INSERT INTO backtest_runs (backtest_hash, prediction_hash, spec_json, stage, created_at)"
+        " VALUES ('b_holdout_200_dup', 'p_holdout_200', ?, 'signal',"
+        " '2026-08-16T00:00:00+00:00')",
+        (_spec(STRATEGY),),
+    )
+    db.commit()
+    db.close()
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        select_holdout_self_backtest("etfs", "b_validation_200")

--- a/tests/test_holdout_checkpoint_identity.py
+++ b/tests/test_holdout_checkpoint_identity.py
@@ -137,6 +137,13 @@ def test_both_resolvers_agree_on_one_hash_for_the_same_carrier(case_study):
     at more than one checkpoint, and the pair lookup then returns empty: `etfs`
     reports NaN val-to-holdout decay and `us_firm_characteristics` raises.
 
+    The carrier is checkpoint 400 rather than 200 deliberately. The pinned query
+    orders by `backtest_hash`, so with carrier 200 it returns `b_holdout_200`
+    whether or not the checkpoint clauses are there, and the case would only
+    discriminate against the older `ORDER BY bm.sharpe DESC` form. Asking for the
+    checkpoint that does *not* sort first means deleting the pin yields
+    `b_holdout_200` and this fails.
+
     Scope, stated because the name would otherwise overclaim: this covers the two
     resolvers, not the wiring that hands `_holdout_lineage_for` its carrier.
     Mutating that call site does not fail this test. What removes that class of
@@ -153,12 +160,12 @@ def test_both_resolvers_agree_on_one_hash_for_the_same_carrier(case_study):
         strategy_spec=None,
         label_restriction=None,
         rung=None,
-        prefer_prediction_hash="p_validation_200",
+        prefer_prediction_hash="p_validation_400",
     )
-    reader = select_holdout_self_backtest("etfs", "b_validation_200")
+    reader = select_holdout_self_backtest("etfs", "b_validation_400")
 
     assert writer is not None
-    assert writer["backtest_hash"] == reader == "b_holdout_200"
+    assert writer["backtest_hash"] == reader == "b_holdout_400"
 
 
 def test_an_ambiguous_pinned_lineage_raises_rather_than_choosing(case_study):

--- a/tests/test_holdout_checkpoint_identity.py
+++ b/tests/test_holdout_checkpoint_identity.py
@@ -137,12 +137,18 @@ def test_both_resolvers_agree_on_one_hash_for_the_same_carrier(case_study):
     at more than one checkpoint, and the pair lookup then returns empty: `etfs`
     reports NaN val-to-holdout decay and `us_firm_characteristics` raises.
 
-    The carrier is checkpoint 400 rather than 200 deliberately. The pinned query
-    orders by `backtest_hash`, so with carrier 200 it returns `b_holdout_200`
-    whether or not the checkpoint clauses are there, and the case would only
-    discriminate against the older `ORDER BY bm.sharpe DESC` form. Asking for the
-    checkpoint that does *not* sort first means deleting the pin yields
-    `b_holdout_200` and this fails.
+    The carrier is the checkpoint that wins neither tiebreak, which is what makes
+    the case discriminate against both ways of losing the pin. `_holdout_lineage_for`
+    reaches its pinned query only inside the `prefer_prediction_hash` branch and
+    otherwise falls through to an unpinned `ORDER BY bm.sharpe DESC`. So carrier
+    400 with the Sharpes inverted for this case is neither hash-first (200 sorts
+    before 400) nor Sharpe-best (200 is given 1.9 here): dropping the checkpoint
+    clauses yields `b_holdout_200` by hash order, and dropping the whole
+    preference branch yields `b_holdout_200` by Sharpe order. Both fail.
+
+    The default Sharpes are left alone because
+    `test_holdout_replay_uses_the_validation_checkpoint_not_the_better_one` needs
+    checkpoint 400 to be the better one for its own assertion to mean anything.
 
     Scope, stated because the name would otherwise overclaim: this covers the two
     resolvers, not the wiring that hands `_holdout_lineage_for` its carrier.
@@ -152,7 +158,7 @@ def test_both_resolvers_agree_on_one_hash_for_the_same_carrier(case_study):
     it, so a caller cannot supply half a pin; it can only omit the preference
     entirely and fall back.
     """
-    _build_registry(case_study)
+    _build_registry(case_study, holdout_sharpes=(1.9, 0.4))
 
     writer = _holdout_lineage_for(
         "etfs",


### PR DESCRIPTION
## Summary

The holdout replay is pinned to the validation carrier's checkpoint, on both the
side that writes the `val_rank1_self` pair and the side that reads it back.

`reference/CASE_STUDY_PIPELINE.md` section 5 makes the checkpoint part of the
model configuration, so one trained model registers one prediction set per
declared checkpoint and the strategy spec is identical across them. Both
resolvers keyed on `training_hash` and the full strategy spec, ordered
`bm.sharpe DESC`, and neither constrained `checkpoint_value`. That left one
indistinguishable holdout candidate per checkpoint and resolved them by holdout
Sharpe - reading the holdout to choose among configurations, which section 6
forbids. Section 5 records the same omission as the us_firm +1.771 against
+2.613 pair, one trained model read at cp200 and cp50.

## Changes

- `select_holdout_self_backtest` pins `checkpoint_value` and `checkpoint_kind`
  to the validation prediction set's own values, using SQLite `IS` so a
  configuration with no checkpoint dimension still matches where `=` would drop
  it, and raises on a lineage that is still ambiguous rather than returning one.
- `_holdout_lineage_for` takes the carrier's `prediction_hash` and derives the
  training hash and the checkpoint from that one row, replacing
  `prefer_training_hash`. A caller that passed the training hash and forgot the
  checkpoint would reintroduce the defect while looking correct; with one
  argument it can only omit the preference entirely and fall back. Its pinned
  branch orders by `backtest_hash`, so it never chooses on holdout performance.

## Validation

- `tests/test_holdout_checkpoint_identity.py` is new, 6 cases, and every guard
  it adds was mutation-tested rather than assumed:

  | mutation | result |
  |---|---|
  | pre-fix reader implementation | 2 of 6 fail; carrier cp200 replays onto `b_holdout_400`, the better holdout Sharpe |
  | `checkpoint_kind IS ?` written as `= ?` | the no-checkpoint case fails |
  | writer's two checkpoint clauses deleted | the agreement case fails on hash order |
  | writer's whole preference branch disabled | the agreement case fails on Sharpe order |

- `84 passed, 1 skipped` across `test_holdout_checkpoint_identity.py`,
  `test_holdout_boundary.py` and `test_locked_holdout_execution.py`.
- Changed-path Ruff lint and format clean; all pre-commit hooks pass.

## Scope and limits

Consumers enumerated rather than assumed: `etfs/18_strategy_analysis`,
`cme_futures/17_strategy_analysis` and `us_firm_characteristics/15_strategy_analysis`
are the three call sites, and `select_holdout_self_backtest`'s signature is
unchanged.

Exposure is a function of `backtest.sweep.checkpoints_per_config`. `etfs` is the
only case study that advances two, so it registers two indistinguishable holdout
candidates for every carrier; the other two consumers advance one and were
latent.

The agreement test covers the two resolvers, not the wiring that supplies the
carrier - mutating that call site leaves it green, and the test says so. What
removes that class of error is the single-argument signature.

No committed result moves: no case study has produced a stage-06+ holdout under
the rebuild, so this corrects the path before it is first used.

This PR executes no notebook, writes no registry row and generates no artifact.
