### PR TITLE
Mark equity-option positions on the price series the labels use

### DIFF
--- a/case_studies/sp500_options/_underlying_returns.py
+++ b/case_studies/sp500_options/_underlying_returns.py
@@ -1,64 +1,15 @@
-"""Point-in-time S&P 500 returns that respect security identity boundaries."""
+"""Point-in-time S&P 500 returns that respect security identity boundaries.
+
+The lineage rule is shared with `sp500_equity_option_analytics`, which reads the
+same bars into a backtest price panel; it lives in
+`case_studies/utils/sp500_price_lineage.py` so the boundary is defined once.
+"""
 
 from __future__ import annotations
 
-import polars as pl
+from case_studies.utils.sp500_price_lineage import (
+    reconcile_underlying_log_returns,
+    validate_reconciled_returns,
+)
 
-
-def validate_reconciled_returns(frame: pl.DataFrame) -> None:
-    """Fail if a return crosses a security identity or violates adjusted-price arithmetic."""
-    required = {
-        "sec_id",
-        "adjusted_close",
-        "clean_log_return",
-        "identity_boundary",
-    }
-    missing = required - set(frame.columns)
-    if missing:
-        raise ValueError(f"Reconciled returns missing columns: {sorted(missing)}")
-    if frame.filter(pl.col("identity_boundary") & pl.col("clean_log_return").is_not_null()).height:
-        raise ValueError("A return crosses a security identity boundary")
-
-    expected = pl.col("adjusted_close").log().diff().over(["symbol", "sec_id"])
-    checked = frame.with_columns(expected.alias("expected_log_return"))
-    violations = checked.filter(
-        ~(
-            pl.col("clean_log_return").eq_missing(pl.col("expected_log_return"))
-            | ((pl.col("clean_log_return") - pl.col("expected_log_return")).abs() <= 1e-12)
-        )
-    )
-    if not violations.is_empty():
-        raise ValueError(f"Adjusted-return identity violations: {violations.height}")
-
-
-def reconcile_underlying_log_returns(prices: pl.DataFrame) -> pl.DataFrame:
-    """Compute adjusted daily log returns within stable ``sec_id`` segments."""
-    required = {"timestamp", "symbol", "sec_id", "close", "adj_factor"}
-    missing = required - set(prices.columns)
-    if missing:
-        raise ValueError(f"Underlying bars missing columns: {sorted(missing)}")
-    if prices.select(pl.struct("timestamp", "symbol").is_duplicated().any()).item():
-        raise ValueError("Underlying bars contain duplicate timestamp-symbol keys")
-    if prices["sec_id"].null_count():
-        raise ValueError("Underlying bars contain null sec_id values")
-    invalid_levels = prices.filter(
-        ((pl.col("close").is_not_null()) & (pl.col("close") <= 0))
-        | ((pl.col("adj_factor").is_not_null()) & (pl.col("adj_factor") <= 0))
-    )
-    if not invalid_levels.is_empty():
-        raise ValueError(
-            f"Underlying bars contain nonpositive price/factor rows: {invalid_levels.height}"
-        )
-
-    frame = prices.sort(["symbol", "timestamp"]).with_columns(
-        (pl.col("close") * pl.col("adj_factor")).alias("adjusted_close"),
-        (
-            pl.col("sec_id").shift(1).over("symbol").is_not_null()
-            & (pl.col("sec_id") != pl.col("sec_id").shift(1).over("symbol"))
-        ).alias("identity_boundary"),
-    )
-    frame = frame.with_columns(
-        pl.col("adjusted_close").log().diff().over(["symbol", "sec_id"]).alias("clean_log_return")
-    )
-    validate_reconciled_returns(frame)
-    return frame
+__all__ = ["reconcile_underlying_log_returns", "validate_reconciled_returns"]

--- a/case_studies/utils/backtest_loaders.py
+++ b/case_studies/utils/backtest_loaders.py
@@ -42,7 +42,7 @@ import yaml
 from case_studies.utils.notebook_contracts import degenerate_prediction_sql
 from case_studies.utils.registry import model_source
 from case_studies.utils.signals import build_target_weights
-from case_studies.utils.sp500_price_lineage import continuous_adjusted_panel
+from case_studies.utils.sp500_price_lineage import adjustment_scale, continuous_adjusted_panel
 from utils.artifact_specs import resolve_market_runtime, resolve_market_semantics
 from utils.paths import get_case_study_dir
 
@@ -755,9 +755,27 @@ _PRICE_CONFIG = {
 }
 
 
+@cache
+def _sp500_daily_bars_scale() -> pl.DataFrame:
+    """Resolve the back-adjustment scale once, over the complete bar history.
+
+    The panel handed to the rule is already narrowed by the ``start_date`` /
+    ``end_date`` pushdown, and the scale must not be: it depends on every segment
+    a ticker has and on which row is its last, so deriving it from the window
+    would make the same session's price depend on the query that asked for it.
+    """
+    from data import load_sp500_daily_bars
+
+    return adjustment_scale(load_sp500_daily_bars())
+
+
+def _sp500_daily_bars_lineage(df: pl.DataFrame) -> pl.DataFrame:
+    return continuous_adjusted_panel(df, scale=_sp500_daily_bars_scale())
+
+
 # Named price-lineage rules a panel spec may request, applied before any column
 # the rule reads can be dropped.
-_PRICE_LINEAGE = {"sp500_daily_bars": continuous_adjusted_panel}
+_PRICE_LINEAGE = {"sp500_daily_bars": _sp500_daily_bars_lineage}
 
 
 def _load_via_canonical(

--- a/case_studies/utils/backtest_loaders.py
+++ b/case_studies/utils/backtest_loaders.py
@@ -42,6 +42,7 @@ import yaml
 from case_studies.utils.notebook_contracts import degenerate_prediction_sql
 from case_studies.utils.registry import model_source
 from case_studies.utils.signals import build_target_weights
+from case_studies.utils.sp500_price_lineage import continuous_adjusted_panel
 from utils.artifact_specs import resolve_market_runtime, resolve_market_semantics
 from utils.paths import get_case_study_dir
 
@@ -660,6 +661,13 @@ _PRICE_CONFIG = {
         "close_col": "close",
         "ohlcv": True,
         "loader": "sp500_daily_bars",
+        # Backtest fills ride the same split- and dividend-adjusted series that
+        # 02_labels builds every label from (``close * adj_factor`` within a
+        # ``sec_id``). On the printed close 92 sessions in 2017-2021 carry a move
+        # above 30% that is a corporate action rather than a price change - GE
+        # +677% on its 1-for-8 reverse split, NVDA -75% and NEE -75% on 4-for-1
+        # subdivisions - and each one books as P&L.
+        "price_lineage": "sp500_daily_bars",
         "drop_cols": [
             "sec_id",
             "adj_factor",
@@ -745,6 +753,11 @@ _PRICE_CONFIG = {
         ],
     },
 }
+
+
+# Named price-lineage rules a panel spec may request, applied before any column
+# the rule reads can be dropped.
+_PRICE_LINEAGE = {"sp500_daily_bars": continuous_adjusted_panel}
 
 
 def _load_via_canonical(
@@ -929,6 +942,10 @@ def load_backtest_prices(
                         end_lit = end_lit.dt.replace_time_zone(tz)
                     lf = lf.filter(pl.col(ts_col) < end_lit + pl.duration(days=1))
         df = lf.collect()
+
+    # Resolve the price lineage before drop_cols removes what the rule reads
+    if "price_lineage" in config:
+        df = _PRICE_LINEAGE[config["price_lineage"]](df)
 
     # Drop unwanted columns
     drop = [c for c in config.get("drop_cols", []) if c in df.columns]

--- a/case_studies/utils/sp500_price_lineage.py
+++ b/case_studies/utils/sp500_price_lineage.py
@@ -1,0 +1,152 @@
+"""Point-in-time S&P 500 prices that respect security identity boundaries.
+
+``load_sp500_daily_bars`` returns the close as it printed plus ``adj_factor``, a
+cumulative price factor. ``close * adj_factor`` is the series in which a split, a
+reverse split or a cash dividend is no longer a price move, and it is what
+``sp500_equity_option_analytics/02_labels`` builds every label from.
+
+The factor restarts at 1.0 when the exchange reassigns a ticker to a new
+security, so a series taken across that boundary carries a jump that is neither a
+price move nor a corporate action on the security being held. Both consumers of
+these bars need that boundary, and they need it in different shapes: a return
+series can leave it null, a backtest price panel cannot. Both shapes are here so
+the boundary is defined once.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+PRICE_COLS = ("open", "high", "low", "close")
+
+
+def validate_reconciled_returns(frame: pl.DataFrame) -> None:
+    """Fail if a return crosses a security identity or violates adjusted-price arithmetic."""
+    required = {
+        "sec_id",
+        "adjusted_close",
+        "clean_log_return",
+        "identity_boundary",
+    }
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Reconciled returns missing columns: {sorted(missing)}")
+    if frame.filter(pl.col("identity_boundary") & pl.col("clean_log_return").is_not_null()).height:
+        raise ValueError("A return crosses a security identity boundary")
+
+    expected = pl.col("adjusted_close").log().diff().over(["symbol", "sec_id"])
+    checked = frame.with_columns(expected.alias("expected_log_return"))
+    violations = checked.filter(
+        ~(
+            pl.col("clean_log_return").eq_missing(pl.col("expected_log_return"))
+            | ((pl.col("clean_log_return") - pl.col("expected_log_return")).abs() <= 1e-12)
+        )
+    )
+    if not violations.is_empty():
+        raise ValueError(f"Adjusted-return identity violations: {violations.height}")
+
+
+def _validated(prices: pl.DataFrame) -> pl.DataFrame:
+    """Check the bar columns both shapes depend on, and mark each identity boundary."""
+    required = {"timestamp", "symbol", "sec_id", "close", "adj_factor"}
+    missing = required - set(prices.columns)
+    if missing:
+        raise ValueError(f"Underlying bars missing columns: {sorted(missing)}")
+    if prices.select(pl.struct("timestamp", "symbol").is_duplicated().any()).item():
+        raise ValueError("Underlying bars contain duplicate timestamp-symbol keys")
+    if prices["sec_id"].null_count():
+        raise ValueError("Underlying bars contain null sec_id values")
+    invalid_levels = prices.filter(
+        ((pl.col("close").is_not_null()) & (pl.col("close") <= 0))
+        | ((pl.col("adj_factor").is_not_null()) & (pl.col("adj_factor") <= 0))
+    )
+    if not invalid_levels.is_empty():
+        raise ValueError(
+            f"Underlying bars contain nonpositive price/factor rows: {invalid_levels.height}"
+        )
+    return prices.sort(["symbol", "timestamp"]).with_columns(
+        (pl.col("close") * pl.col("adj_factor")).alias("adjusted_close"),
+        (
+            pl.col("sec_id").shift(1).over("symbol").is_not_null()
+            & (pl.col("sec_id") != pl.col("sec_id").shift(1).over("symbol"))
+        ).alias("identity_boundary"),
+    )
+
+
+def reconcile_underlying_log_returns(prices: pl.DataFrame) -> pl.DataFrame:
+    """Compute adjusted daily log returns within stable ``sec_id`` segments."""
+    frame = _validated(prices).with_columns(
+        pl.col("adjusted_close").log().diff().over(["symbol", "sec_id"]).alias("clean_log_return")
+    )
+    validate_reconciled_returns(frame)
+    return frame
+
+
+def continuous_adjusted_panel(
+    prices: pl.DataFrame,
+    *,
+    price_cols: tuple[str, ...] = PRICE_COLS,
+    volume_col: str | None = "volume",
+) -> pl.DataFrame:
+    """Back-adjust every price column and splice at each security identity boundary.
+
+    A backtest feed reads a level, so it has no way to say that a return does not
+    exist. Each ``sec_id`` segment after a ticker's first is rescaled to meet the
+    level the previous segment closed at: the two securities keep their own
+    returns, and the changeover contributes zero instead of the jump the
+    restarting factor would otherwise produce. It is the treatment ``cme_futures``
+    gives a contract roll, applied to a ticker reassignment.
+
+    The series is then anchored so each ticker's **last** row equals the close
+    that printed, which is what makes it a back-adjusted price rather than an
+    index. The level matters: this case study sizes positions in whole shares
+    against a fixed cash budget, so a series carried on the factor's own scale
+    would put AAPL near 4000 instead of near 130 and turn integer rounding into
+    a material allocation error. History before the anchor is the split- and
+    dividend-adjusted equivalent, exactly as ``us_equities_panel``'s stored
+    ``adj_close`` is.
+
+    ``volume_col`` is divided by the same total factor each row's price is
+    multiplied by, so ``price * volume`` stays the dollar volume that printed.
+    """
+    frame = _validated(prices)
+    columns = [column for column in price_cols if column in frame.columns]
+    if "close" not in columns:
+        raise ValueError("the adjusted panel requires a close column")
+
+    frame = frame.with_columns(pl.col("identity_boundary").cum_sum().over("symbol").alias("_seg"))
+    splice = (
+        frame.group_by("symbol", "_seg")
+        .agg(
+            pl.col("adjusted_close").first().alias("_open"),
+            pl.col("adjusted_close").last().alias("_close"),
+        )
+        .sort("symbol", "_seg")
+        .with_columns(
+            (pl.col("_close").shift(1) / pl.col("_open")).over("symbol").fill_null(1.0).alias("_st")
+        )
+        .with_columns(pl.col("_st").cum_prod().over("symbol").alias("_splice"))
+        .select("symbol", "_seg", "_splice")
+    )
+    frame = frame.join(splice, on=["symbol", "_seg"], how="left").with_columns(
+        (pl.col("adj_factor") * pl.col("_splice")).alias("_scale")
+    )
+    # Anchor: each ticker's last row keeps the close that printed, so the level a
+    # position is sized against is the one the market quoted.
+    frame = frame.with_columns(
+        (pl.col("_scale") / pl.col("_scale").last().over("symbol", order_by="timestamp")).alias(
+            "_scale"
+        )
+    )
+    volume = (
+        [(pl.col(volume_col) / pl.col("_scale")).alias(volume_col)]
+        if _has(frame, volume_col)
+        else []
+    )
+    return frame.with_columns(
+        [(pl.col(column) * pl.col("_scale")).alias(column) for column in columns] + volume
+    ).drop("_seg", "_splice", "_scale", "adjusted_close", "identity_boundary")
+
+
+def _has(frame: pl.DataFrame, column: str | None) -> bool:
+    return bool(column) and column in frame.columns

--- a/case_studies/utils/sp500_price_lineage.py
+++ b/case_studies/utils/sp500_price_lineage.py
@@ -82,39 +82,37 @@ def reconcile_underlying_log_returns(prices: pl.DataFrame) -> pl.DataFrame:
     return frame
 
 
-def continuous_adjusted_panel(
-    prices: pl.DataFrame,
-    *,
-    price_cols: tuple[str, ...] = PRICE_COLS,
-    volume_col: str | None = "volume",
-) -> pl.DataFrame:
-    """Back-adjust every price column and splice at each security identity boundary.
+def adjustment_scale(bars: pl.DataFrame) -> pl.DataFrame:
+    """Return the per ``(symbol, timestamp)`` multiplier that back-adjusts a printed price.
 
-    A backtest feed reads a level, so it has no way to say that a return does not
-    exist. Each ``sec_id`` segment after a ticker's first is rescaled to meet the
-    level the previous segment closed at: the two securities keep their own
-    returns, and the changeover contributes zero instead of the jump the
-    restarting factor would otherwise produce. It is the treatment ``cme_futures``
-    gives a contract roll, applied to a ticker reassignment.
+    Two things go into it. ``adj_factor`` removes the corporate action. Then each
+    ``sec_id`` segment after a ticker's first is rescaled to meet the level the
+    previous segment closed at, so the two securities keep their own returns and
+    the changeover contributes zero rather than the jump a factor restarting at
+    1.0 would produce - the treatment ``cme_futures`` gives a contract roll,
+    applied to a ticker reassignment. A backtest feed reads a level, so unlike
+    :func:`reconcile_underlying_log_returns` it cannot say that a return does not
+    exist.
 
-    The series is then anchored so each ticker's **last** row equals the close
+    Finally the series is anchored so each ticker's **last** row equals the close
     that printed, which is what makes it a back-adjusted price rather than an
-    index. The level matters: this case study sizes positions in whole shares
-    against a fixed cash budget, so a series carried on the factor's own scale
-    would put AAPL near 4000 instead of near 130 and turn integer rounding into
-    a material allocation error. History before the anchor is the split- and
-    dividend-adjusted equivalent, exactly as ``us_equities_panel``'s stored
-    ``adj_close`` is.
+    index. The level is not cosmetic: this case study sizes positions in whole
+    shares against a fixed cash budget, and on the factor's own scale AAPL sits
+    near 4000 instead of near 130, which turns integer rounding into a material
+    allocation error.
 
-    ``volume_col`` is divided by the same total factor each row's price is
-    multiplied by, so ``price * volume`` stays the dollar volume that printed.
+    **Pass the complete bar history.** Both halves depend on every segment a
+    ticker has and on which row is its last, so a scale derived from a
+    date-filtered frame is a function of the window as well as the session, and
+    two windows would disagree about the same date. That is not hypothetical:
+    the holdout path concatenates a validation load and a holdout load to give
+    the rolling-volatility allocators their burn-in, and a window-dependent
+    scale puts a fabricated return on the seam - 8x for GE, whose 1-for-8 falls
+    inside the holdout year.
     """
-    frame = _validated(prices)
-    columns = [column for column in price_cols if column in frame.columns]
-    if "close" not in columns:
-        raise ValueError("the adjusted panel requires a close column")
-
-    frame = frame.with_columns(pl.col("identity_boundary").cum_sum().over("symbol").alias("_seg"))
+    frame = _validated(bars).with_columns(
+        pl.col("identity_boundary").cum_sum().over("symbol").alias("_seg")
+    )
     splice = (
         frame.group_by("symbol", "_seg")
         .agg(
@@ -122,30 +120,77 @@ def continuous_adjusted_panel(
             pl.col("adjusted_close").last().alias("_close"),
         )
         .sort("symbol", "_seg")
-        .with_columns(
-            (pl.col("_close").shift(1) / pl.col("_open")).over("symbol").fill_null(1.0).alias("_st")
+        .with_columns((pl.col("_close").shift(1) / pl.col("_open")).over("symbol").alias("_step"))
+    )
+    # The null `_step` belongs to a ticker's first segment, where there is nothing
+    # to splice onto. A null anywhere else means a null close reached the ratio -
+    # `_validated` tolerates those - and filling it would silently drop the splice
+    # and carry a wrong offset into every later segment, visible only as P&L.
+    unspliceable = splice.filter((pl.col("_seg") > 0) & pl.col("_step").is_null())
+    if not unspliceable.is_empty():
+        raise ValueError(
+            "cannot splice a security identity boundary whose adjusted close is null: "
+            f"{unspliceable.select('symbol', '_seg').rows()}"
         )
-        .with_columns(pl.col("_st").cum_prod().over("symbol").alias("_splice"))
+    splice = (
+        splice.with_columns(pl.col("_step").fill_null(1.0))
+        .with_columns(pl.col("_step").cum_prod().over("symbol").alias("_splice"))
         .select("symbol", "_seg", "_splice")
     )
-    frame = frame.join(splice, on=["symbol", "_seg"], how="left").with_columns(
-        (pl.col("adj_factor") * pl.col("_splice")).alias("_scale")
-    )
-    # Anchor: each ticker's last row keeps the close that printed, so the level a
-    # position is sized against is the one the market quoted.
-    frame = frame.with_columns(
-        (pl.col("_scale") / pl.col("_scale").last().over("symbol", order_by="timestamp")).alias(
-            "_scale"
+    return (
+        frame.join(splice, on=["symbol", "_seg"], how="inner")
+        .with_columns((pl.col("adj_factor") * pl.col("_splice")).alias("price_scale"))
+        .with_columns(
+            (
+                pl.col("price_scale")
+                / pl.col("price_scale").last().over("symbol", order_by="timestamp")
+            ).alias("price_scale")
         )
+        .select("symbol", "timestamp", "price_scale")
     )
+
+
+def continuous_adjusted_panel(
+    prices: pl.DataFrame,
+    *,
+    scale: pl.DataFrame,
+    price_cols: tuple[str, ...] = PRICE_COLS,
+    volume_col: str | None = "volume",
+) -> pl.DataFrame:
+    """Apply a full-history :func:`adjustment_scale` to a panel that may be one window of it.
+
+    Keeping the scale a separate argument is what makes the result a function of
+    ``(symbol, timestamp)`` alone: the caller resolves it once over the whole
+    series, and every window of that series then agrees about every date it
+    contains.
+
+    ``volume_col`` is divided by the same factor its row's price is multiplied
+    by, so ``price * volume`` stays the dollar volume that printed. Note that the
+    share **count** moves with the level, so a per-share cost schedule evaluated
+    on this panel is charged on adjusted share counts and is not comparable to a
+    live per-share commission.
+    """
+    columns = [column for column in price_cols if column in prices.columns]
+    if "close" not in columns:
+        raise ValueError("the adjusted panel requires a close column")
+    if "price_scale" in prices.columns:
+        raise ValueError("the panel already carries a price_scale column")
+
+    frame = prices.join(scale, on=["symbol", "timestamp"], how="left")
+    unscaled = frame.filter(pl.col("price_scale").is_null())
+    if not unscaled.is_empty():
+        raise ValueError(
+            "the adjustment scale does not cover every panel row; it must be resolved "
+            f"over the complete bar history. First uncovered: {unscaled.head(3).rows()}"
+        )
     volume = (
-        [(pl.col(volume_col) / pl.col("_scale")).alias(volume_col)]
+        [(pl.col(volume_col) / pl.col("price_scale")).alias(volume_col)]
         if _has(frame, volume_col)
         else []
     )
     return frame.with_columns(
-        [(pl.col(column) * pl.col("_scale")).alias(column) for column in columns] + volume
-    ).drop("_seg", "_splice", "_scale", "adjusted_close", "identity_boundary")
+        [(pl.col(column) * pl.col("price_scale")).alias(column) for column in columns] + volume
+    ).drop("price_scale")
 
 
 def _has(frame: pl.DataFrame, column: str | None) -> bool:

--- a/tests/test_sp500_eoa_backtest_price_basis.py
+++ b/tests/test_sp500_eoa_backtest_price_basis.py
@@ -13,7 +13,7 @@ import polars as pl
 import pytest
 
 from case_studies.utils.backtest_loaders import load_backtest_prices
-from case_studies.utils.sp500_price_lineage import continuous_adjusted_panel
+from case_studies.utils.sp500_price_lineage import adjustment_scale, continuous_adjusted_panel
 from data import load_sp500_daily_bars
 from data.exceptions import DataNotFoundError
 
@@ -33,6 +33,11 @@ def _bars(rows: list[tuple[str, int, str, float, float, int]]) -> pl.DataFrame:
     )
 
 
+def _adjusted(bars: pl.DataFrame) -> pl.DataFrame:
+    """Adjust a frame that IS the complete history for the tickers it holds."""
+    return continuous_adjusted_panel(bars, scale=adjustment_scale(bars))
+
+
 def _returns(frame: pl.DataFrame, symbol: str) -> list[float]:
     series = frame.filter(pl.col("symbol") == symbol).sort("timestamp")["close"]
     return (series / series.shift(1) - 1).drop_nulls().to_list()
@@ -41,7 +46,7 @@ def _returns(frame: pl.DataFrame, symbol: str) -> list[float]:
 def test_a_subdivision_is_not_a_price_move():
     # AAPL's 4-for-1 on 2020-08-31: the printed close falls 499.23 -> 129.04
     # while adj_factor rises by the same 4x, so the adjusted move is +3.4%.
-    panel = continuous_adjusted_panel(
+    panel = _adjusted(
         _bars(
             [
                 ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
@@ -55,7 +60,7 @@ def test_a_subdivision_is_not_a_price_move():
 
 def test_a_reverse_split_is_not_a_price_move():
     # GE's 1-for-8 on 2021-08-02: the printed close rises 12.96 -> 100.60.
-    panel = continuous_adjusted_panel(
+    panel = _adjusted(
         _bars(
             [
                 ("GE", 33645, "2021-07-30", 12.96, 8.0, 80_000_000),
@@ -70,7 +75,7 @@ def test_a_reverse_split_is_not_a_price_move():
 def test_a_ticker_reassignment_contributes_no_return():
     # The factor restarts at 1.0 with the new security, so multiplying without
     # splicing would fabricate a jump where the ticker changed hands.
-    panel = continuous_adjusted_panel(
+    panel = _adjusted(
         _bars(
             [
                 ("XRX", 44733, "2019-07-30", 30.00, 1.853437, 1_000_000),
@@ -94,7 +99,7 @@ def test_each_security_keeps_its_own_returns_across_a_reassignment():
         ("IR", 6285863, "2020-03-03", 32.80, 1.0, 1_000_000),
         ("IR", 6285863, "2020-03-04", 33.00, 1.0, 1_000_000),
     ]
-    panel = continuous_adjusted_panel(_bars(rows))
+    panel = _adjusted(_bars(rows))
     within = _returns(panel, "IR")
     assert within[0] == pytest.approx(130.00 / 129.04 - 1, abs=1e-9)
     assert within[2] == pytest.approx(33.00 / 32.80 - 1, abs=1e-9)
@@ -105,7 +110,7 @@ def test_dollar_volume_survives_the_adjustment():
         ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
         ("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 210_249_674),
     ]
-    panel = continuous_adjusted_panel(_bars(rows)).sort("timestamp")
+    panel = _adjusted(_bars(rows)).sort("timestamp")
     dollars = (panel["close"] * panel["volume"]).to_list()
     assert dollars == [
         pytest.approx(499.23 * 44_260_263),
@@ -120,7 +125,7 @@ def test_the_anchor_is_the_close_that_printed():
         ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
         ("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 210_249_674),
     ]
-    panel = continuous_adjusted_panel(_bars(rows)).sort("timestamp")
+    panel = _adjusted(_bars(rows)).sort("timestamp")
     assert panel["close"].to_list()[-1] == pytest.approx(129.04)
     # ...and the session before it is 499.23 carried through the ratio of the two
     # factors, which is the 4-for-1 plus the dividend that accrued with it.
@@ -130,9 +135,87 @@ def test_the_anchor_is_the_close_that_printed():
 
 def test_a_restarting_factor_without_a_lineage_column_is_refused():
     with pytest.raises(ValueError, match="missing columns"):
-        continuous_adjusted_panel(
-            _bars([("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 1)]).drop("sec_id")
-        )
+        _adjusted(_bars([("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 1)]).drop("sec_id"))
+
+
+def test_a_scale_that_does_not_cover_the_panel_is_refused():
+    # The failure mode this guards is a scale resolved over a narrower frame than
+    # the panel it is applied to, which is how the window dependence got in.
+    bars = _bars(
+        [
+            ("GE", 33645, "2021-07-30", 12.96, 8.0, 80_000_000),
+            ("GE", 33645, "2021-08-02", 100.60, 1.0, 10_000_000),
+        ]
+    )
+    partial = adjustment_scale(bars.head(1))
+    with pytest.raises(ValueError, match="complete bar history"):
+        continuous_adjusted_panel(bars, scale=partial)
+
+
+def test_two_windows_of_one_series_agree_about_the_dates_they_share():
+    """The regression guard for a scale anchored on the frame it was handed.
+
+    The holdout path concatenates a validation load and a holdout load to give the
+    rolling-volatility allocators their burn-in. If the anchor is the last row of
+    each *window*, the two halves are on different scales and the seam carries a
+    fabricated return. GE is the case that makes it unmissable: its 1-for-8 falls
+    inside the holdout year, so the two windows would disagree by a factor of 8.
+    """
+    history = _bars(
+        [
+            ("GE", 33645, "2020-11-30", 10.00, 8.0, 1_000_000),
+            ("GE", 33645, "2020-12-31", 11.00, 8.0, 1_000_000),
+            ("GE", 33645, "2021-06-30", 12.96, 8.0, 1_000_000),
+            ("GE", 33645, "2021-08-02", 100.60, 1.0, 1_000_000),
+            ("GE", 33645, "2021-12-31", 104.00, 1.0, 1_000_000),
+        ]
+    )
+    scale = adjustment_scale(history)
+    validation = continuous_adjusted_panel(
+        history.filter(pl.col("timestamp") <= pl.date(2020, 12, 31)), scale=scale
+    )
+    holdout = continuous_adjusted_panel(
+        history.filter(pl.col("timestamp") >= pl.date(2020, 12, 31)), scale=scale
+    )
+    shared = validation.join(holdout, on=["symbol", "timestamp"], suffix="_holdout")
+    assert shared.height == 1
+    assert shared["close"][0] == pytest.approx(shared["close_holdout"][0], abs=1e-12)
+
+    # And the seam itself: concatenating the two halves must reproduce the return
+    # the whole series gives, not an 8x step.
+    seam = pl.concat([validation, holdout]).unique(subset=["symbol", "timestamp"]).sort("timestamp")
+    whole = continuous_adjusted_panel(history, scale=scale).sort("timestamp")
+    assert seam["close"].to_list() == pytest.approx(whole["close"].to_list(), abs=1e-12)
+    assert max(abs(r) for r in _returns(seam, "GE")) < 0.20
+
+
+def test_two_real_loads_agree_about_the_dates_they_share():
+    """The same guard through `load_backtest_prices`, on the windows holdout actually uses.
+
+    `20_strategy_synthesis/holdout.py` concatenates a validation load and a
+    holdout load, so these are the two frames whose seam has to hold. GE's
+    1-for-8 on 2021-08-02 sits inside the holdout window.
+    """
+    try:
+        load_sp500_daily_bars(symbols=["GE"])
+    except DataNotFoundError:
+        pytest.skip("Licensed S&P 500 data is unavailable")
+
+    validation = load_backtest_prices(CASE_STUDY, start_date="2019-01-01", end_date="2020-12-31")
+    holdout = load_backtest_prices(CASE_STUDY, start_date="2020-06-01", end_date="2021-12-31")
+    shared = validation.join(holdout, on=["symbol", "timestamp"], suffix="_holdout")
+    assert shared.height > 50_000
+    drift = (shared["close"] - shared["close_holdout"]).abs().max()
+    assert drift == pytest.approx(0.0, abs=1e-9)
+
+    seam = (
+        pl.concat([validation, holdout])
+        .unique(subset=["symbol", "timestamp"])
+        .sort("symbol", "timestamp")
+        .with_columns((pl.col("close") / pl.col("close").shift(1).over("symbol") - 1).alias("r"))
+        .drop_nulls("r")
+    )
+    assert seam.filter(pl.col("r").abs() > 0.60).is_empty()
 
 
 def test_the_real_panel_carries_no_corporate_action_as_a_price_move():

--- a/tests/test_sp500_eoa_backtest_price_basis.py
+++ b/tests/test_sp500_eoa_backtest_price_basis.py
@@ -1,0 +1,224 @@
+"""The equity-option backtest panel marks positions on the series the labels use.
+
+`load_sp500_daily_bars` prints the close as it traded and carries the cumulative
+price factor separately, so a panel built on the printed close books every split,
+reverse split and cash dividend as P&L. `02_labels` builds every label from
+`close * adj_factor` inside a `sec_id`, which left the label and the backtest
+measuring returns on two different price series.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from case_studies.utils.backtest_loaders import load_backtest_prices
+from case_studies.utils.sp500_price_lineage import continuous_adjusted_panel
+from data import load_sp500_daily_bars
+from data.exceptions import DataNotFoundError
+
+CASE_STUDY = "sp500_equity_option_analytics"
+
+
+def _bars(rows: list[tuple[str, int, str, float, float, int]]) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": [r[0] for r in rows],
+            "sec_id": [r[1] for r in rows],
+            "timestamp": [pl.Series([r[2]]).str.to_date().item() for r in rows],
+            "close": [r[3] for r in rows],
+            "adj_factor": [r[4] for r in rows],
+            "volume": [float(r[5]) for r in rows],
+        }
+    )
+
+
+def _returns(frame: pl.DataFrame, symbol: str) -> list[float]:
+    series = frame.filter(pl.col("symbol") == symbol).sort("timestamp")["close"]
+    return (series / series.shift(1) - 1).drop_nulls().to_list()
+
+
+def test_a_subdivision_is_not_a_price_move():
+    # AAPL's 4-for-1 on 2020-08-31: the printed close falls 499.23 -> 129.04
+    # while adj_factor rises by the same 4x, so the adjusted move is +3.4%.
+    panel = continuous_adjusted_panel(
+        _bars(
+            [
+                ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
+                ("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 210_249_674),
+            ]
+        )
+    )
+    (change,) = _returns(panel, "AAPL")
+    assert change == pytest.approx(0.03383, abs=1e-4)
+
+
+def test_a_reverse_split_is_not_a_price_move():
+    # GE's 1-for-8 on 2021-08-02: the printed close rises 12.96 -> 100.60.
+    panel = continuous_adjusted_panel(
+        _bars(
+            [
+                ("GE", 33645, "2021-07-30", 12.96, 8.0, 80_000_000),
+                ("GE", 33645, "2021-08-02", 100.60, 1.0, 10_000_000),
+            ]
+        )
+    )
+    (change,) = _returns(panel, "GE")
+    assert change == pytest.approx(-0.02970, abs=1e-4)
+
+
+def test_a_ticker_reassignment_contributes_no_return():
+    # The factor restarts at 1.0 with the new security, so multiplying without
+    # splicing would fabricate a jump where the ticker changed hands.
+    panel = continuous_adjusted_panel(
+        _bars(
+            [
+                ("XRX", 44733, "2019-07-30", 30.00, 1.853437, 1_000_000),
+                ("XRX", 44733, "2019-07-31", 31.00, 1.853437, 1_000_000),
+                ("XRX", 5888027, "2019-08-01", 31.64, 1.0, 1_000_000),
+                ("XRX", 5888027, "2019-08-02", 32.00, 1.0, 1_000_000),
+            ]
+        )
+    )
+    first, boundary, second = _returns(panel, "XRX")
+    assert first == pytest.approx(1 / 30, abs=1e-9)
+    assert boundary == pytest.approx(0.0, abs=1e-12)
+    assert second == pytest.approx(32.00 / 31.64 - 1, abs=1e-9)
+
+
+def test_each_security_keeps_its_own_returns_across_a_reassignment():
+    # Splicing rescales a segment; it must not change any return inside one.
+    rows = [
+        ("IR", 5122670, "2020-02-28", 129.04, 1.578133, 1_000_000),
+        ("IR", 5122670, "2020-03-02", 130.00, 1.578133, 1_000_000),
+        ("IR", 6285863, "2020-03-03", 32.80, 1.0, 1_000_000),
+        ("IR", 6285863, "2020-03-04", 33.00, 1.0, 1_000_000),
+    ]
+    panel = continuous_adjusted_panel(_bars(rows))
+    within = _returns(panel, "IR")
+    assert within[0] == pytest.approx(130.00 / 129.04 - 1, abs=1e-9)
+    assert within[2] == pytest.approx(33.00 / 32.80 - 1, abs=1e-9)
+
+
+def test_dollar_volume_survives_the_adjustment():
+    rows = [
+        ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
+        ("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 210_249_674),
+    ]
+    panel = continuous_adjusted_panel(_bars(rows)).sort("timestamp")
+    dollars = (panel["close"] * panel["volume"]).to_list()
+    assert dollars == [
+        pytest.approx(499.23 * 44_260_263),
+        pytest.approx(129.04 * 210_249_674),
+    ]
+
+
+def test_the_anchor_is_the_close_that_printed():
+    # The series is back-adjusted, not an index: the last row a ticker has keeps
+    # its quoted level, so whole-share sizing sees the price the market showed.
+    rows = [
+        ("AAPL", 33449, "2020-08-28", 499.23, 8.100549, 44_260_263),
+        ("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 210_249_674),
+    ]
+    panel = continuous_adjusted_panel(_bars(rows)).sort("timestamp")
+    assert panel["close"].to_list()[-1] == pytest.approx(129.04)
+    # ...and the session before it is 499.23 carried through the ratio of the two
+    # factors, which is the 4-for-1 plus the dividend that accrued with it.
+    assert panel["close"].to_list()[0] == pytest.approx(499.23 * 8.100549 / 32.402197, abs=1e-12)
+    assert panel["close"].to_list()[0] == pytest.approx(499.23 / 4.0, rel=1e-4)
+
+
+def test_a_restarting_factor_without_a_lineage_column_is_refused():
+    with pytest.raises(ValueError, match="missing columns"):
+        continuous_adjusted_panel(
+            _bars([("AAPL", 33449, "2020-08-31", 129.04, 32.402197, 1)]).drop("sec_id")
+        )
+
+
+def test_the_real_panel_carries_no_corporate_action_as_a_price_move():
+    """The shipped 2017-2021 extract, through the loader the backtest calls."""
+    try:
+        load_sp500_daily_bars(symbols=["AAPL"])
+    except DataNotFoundError:
+        pytest.skip("Licensed S&P 500 data is unavailable")
+
+    panel = load_backtest_prices(CASE_STUDY, start_date="2017-01-01", end_date="2021-12-31")
+    assert {"open", "high", "low", "close", "volume"} <= set(panel.columns)
+    assert not {"adj_factor", "sec_id", "adjustment_reason"} & set(panel.columns)
+
+    moves = (
+        panel.sort("symbol", "timestamp")
+        .with_columns((pl.col("close") / pl.col("close").shift(1).over("symbol") - 1).alias("r"))
+        .drop_nulls("r")
+    )
+    # On the printed close, 92 sessions move more than 30% on a corporate action
+    # alone. What survives here is the market, not the adjustment: the largest
+    # single-session move in the extract is a real one.
+    extreme = moves.filter(pl.col("r").abs() > 0.60)
+    assert extreme.height == 0, extreme.sort(pl.col("r").abs(), descending=True).head(10)
+
+    # The 15 ticker reassignments contribute no return rather than a spliced-in jump.
+    boundaries = (
+        load_sp500_daily_bars(start_date="2017-01-01", end_date="2021-12-31")
+        .sort("symbol", "timestamp")
+        .with_columns(
+            (pl.col("sec_id") != pl.col("sec_id").shift(1).over("symbol")).alias("boundary")
+        )
+        .filter(pl.col("boundary").fill_null(False))
+        .select("symbol", "timestamp")
+    )
+    assert boundaries.height == 15
+    crossed = moves.join(
+        boundaries.with_columns(pl.col("timestamp").cast(moves.schema["timestamp"])),
+        on=["symbol", "timestamp"],
+    )
+    assert crossed.height == 15
+    assert crossed["r"].abs().max() == pytest.approx(0.0, abs=1e-12)
+
+
+def test_the_real_panel_keeps_prices_at_the_level_positions_are_sized_against():
+    """`execution.share_type` is `integer`, so the level is not cosmetic."""
+    try:
+        bars = load_sp500_daily_bars(start_date="2017-01-01", end_date="2021-12-31")
+    except DataNotFoundError:
+        pytest.skip("Licensed S&P 500 data is unavailable")
+
+    panel = load_backtest_prices(CASE_STUDY, start_date="2017-01-01", end_date="2021-12-31")
+    last_printed = (
+        bars.sort("timestamp").group_by("symbol").last().select("symbol", "close").sort("symbol")
+    )
+    last_panel = (
+        panel.sort("timestamp").group_by("symbol").last().select("symbol", "close").sort("symbol")
+    )
+    joined = last_printed.join(last_panel, on="symbol", suffix="_panel")
+    assert joined.height == last_printed.height
+    drift = (joined["close_panel"] - joined["close"]).abs().max()
+    assert drift == pytest.approx(0.0, abs=1e-9)
+
+
+def test_the_real_panel_matches_the_price_basis_the_labels_use():
+    """`02_labels` builds every label from `close * adj_factor` within a `sec_id`."""
+    try:
+        bars = load_sp500_daily_bars(start_date="2019-01-01", end_date="2019-12-31")
+    except DataNotFoundError:
+        pytest.skip("Licensed S&P 500 data is unavailable")
+
+    panel = load_backtest_prices(CASE_STUDY, start_date="2019-01-01", end_date="2019-12-31")
+    label_basis = (
+        bars.sort("symbol", "timestamp")
+        .with_columns((pl.col("close") * pl.col("adj_factor")).alias("p"))
+        .with_columns((pl.col("p").log().diff().over("symbol", "sec_id")).alias("label_r"))
+        .drop_nulls("label_r")
+        .select("symbol", "timestamp", "label_r")
+    )
+    backtest_basis = (
+        panel.sort("symbol", "timestamp")
+        .with_columns(pl.col("close").log().diff().over("symbol").alias("backtest_r"))
+        .drop_nulls("backtest_r")
+        .with_columns(pl.col("timestamp").dt.date())
+        .select("symbol", "timestamp", "backtest_r")
+    )
+    joined = label_basis.join(backtest_basis, on=["symbol", "timestamp"], how="inner")
+    assert joined.height > 100_000
+    disagreement = joined.filter((pl.col("label_r") - pl.col("backtest_r")).abs() > 1e-10)
+    assert disagreement.is_empty(), disagreement.head(10)

--- a/tests/test_sp500_eoa_backtest_price_basis.py
+++ b/tests/test_sp500_eoa_backtest_price_basis.py
@@ -152,6 +152,52 @@ def test_a_scale_that_does_not_cover_the_panel_is_refused():
         continuous_adjusted_panel(bars, scale=partial)
 
 
+def test_a_null_close_at_a_segment_boundary_is_refused():
+    """The splice ratio reads the previous segment's last close, which may be null.
+
+    Filling that null the way a first segment's is filled would drop the splice and
+    carry a wrong offset into every later segment, visible only as P&L. The scale is
+    resolved over the whole history, so this must fail loudly rather than quietly.
+    """
+    bars = _bars(
+        [
+            ("XRX", 44733, "2019-07-30", 30.00, 1.853437, 1_000_000),
+            ("XRX", 44733, "2019-07-31", 31.00, 1.853437, 1_000_000),
+            ("XRX", 5888027, "2019-08-01", 31.64, 1.0, 1_000_000),
+        ]
+    ).with_columns(
+        pl.when(pl.col("timestamp") == pl.date(2019, 7, 31))
+        .then(None)
+        .otherwise(pl.col("close"))
+        .alias("close")
+    )
+    with pytest.raises(ValueError, match="cannot splice"):
+        adjustment_scale(bars)
+
+
+def test_a_null_close_that_ends_a_ticker_is_not_refused():
+    """The 10 in the shipped extract are all of this shape and must keep working.
+
+    Measured on `daily_bars.parquet`: 10 segments carry a null close, every one the
+    terminal row of a delisted ticker that has a single `sec_id`, and none at a
+    segment boundary. Nothing splices onto them, so the guard above must not fire.
+    """
+    bars = _bars(
+        [
+            ("WFM", 40001, "2017-08-25", 41.00, 1.0, 1_000_000),
+            ("WFM", 40001, "2017-08-28", 30.89, 1.0, 1_000_000),
+        ]
+    ).with_columns(
+        pl.when(pl.col("timestamp") == pl.date(2017, 8, 28))
+        .then(None)
+        .otherwise(pl.col("close"))
+        .alias("close")
+    )
+    scale = adjustment_scale(bars)
+    assert scale.height == 2
+    assert scale["price_scale"].null_count() == 0
+
+
 def test_two_windows_of_one_series_agree_about_the_dates_they_share():
     """The regression guard for a scale anchored on the frame it was handed.
 


### PR DESCRIPTION
`backtest_loaders` built the `sp500_equity_option_analytics` price panel from the printed close and
dropped `adj_factor`, while `02_labels` builds every label from `close * adj_factor` inside a
`sec_id`. The label and the backtest were measuring returns on two different series, and the
backtest's booked every corporate action as P&L.

Measured on the shipped 2017-2021 extract, 92 same-security sessions carry a printed-close move above
30% that is a corporate action rather than a price change: GE +677% on its 1-for-8 reverse split,
XRX +301%, NVDA -75% and NEE -75% on 4-for-1 subdivisions. 8,098 rows carry a cash-dividend
adjustment a holder would have collected.

## Why it is three commits

Multiplying by the factor alone replaces one fabricated jump with another. `adj_factor` restarts at
1.0 when the exchange reassigns a ticker, and the extract has 15 such reassignments; taken naively
they book XRX +94.6%, IR -83.9% and FTI -76.6% on the changeover session. `sp500_options` already had
that boundary rule and a test asserting the same 15 reassignments, so the first commit promotes
`_underlying_returns.py` to `case_studies/utils/sp500_price_lineage.py` rather than writing a second
one. `_underlying_returns.py` re-exports, so every `sp500_options` consumer is unchanged.

The second commit fixes what the push review caught in the first and its tests did not. The anchor
that keeps the panel at a tradable level was the symbol's last row *in the frame it was handed*, and
`load_backtest_prices` applies the lineage after the date pushdown - so the panel was a function of
`(symbol, date, query window)`. `20_strategy_synthesis/holdout.py` concatenates a validation load and
a holdout load to give the rolling-volatility allocators their burn-in, so the seam carried a
fabricated return for every symbol, and 8x for GE, whose 1-for-8 falls inside the holdout window.
Measured on the real extract: $545.40 of drift on a shared date. `adjustment_scale(bars)` now returns
the `(symbol, timestamp)` multiplier and requires the complete history; `continuous_adjusted_panel`
applies it and raises rather than left-joining nulls when the scale does not cover every row.

The third adds the tests for the null-splice guard, with the measurement behind it: the shipped
extract carries 10 segments with a null close, every one the terminal row of a delisted ticker with a
single `sec_id`, and none at a segment boundary. The guard is correct and dormant.

## Why the level is anchored at all

The series is back-adjusted, not an index: each ticker's last row equals the close that printed.
`execution.share_type` is `integer` against a fixed cash budget, and `setup.yaml` already records
that dropping that budget to $100k made this case study nearly stop trading through integer rounding
on the S&P high-priced tail. On the factor's own scale AAPL sits near 4000 instead of near 130.

## Tests

`tests/test_sp500_eoa_backtest_price_basis.py`, 15 cases - 11 on the transform, 4 on the real bundled
extract. The four real-data cases assert that the panel's log returns equal the label price basis to
1e-10 across 2019, that all 15 reassignment sessions contribute exactly zero, that two overlapping
`load_backtest_prices` windows agree on every shared date, and that every ticker's last close still
equals the one the market quoted.

The ten tests in the first commit all passed through the window-dependence defect, four of them on
real data, because every one loaded a single window. Each case added since was therefore verified to
fail against a deliberately reintroduced defect before being believed.

## Consequences

Every `backtest_runs` row for this case study is invalidated and the case study is re-swept, which
the stage 06+ regeneration was going to do regardless. Notebooks 14-18 have never been produced under
this lineage; when they are, confirm that `16_costs.py`'s per-share Sharpe-versus-cost narrative
still matches, since back-adjusting the level moves the share count a per-share schedule is charged
on. `continuous_adjusted_panel`'s docstring records that.
