### PR TITLE
Ignore the artifact directories when they arrive as symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,15 +133,29 @@ tests/notebook_catalog.db
 # from the wrong cwd can drop an empty one at this repo root. Never track it.
 test_status.db
 
-# Pipeline artifacts (case study outputs — generated, not tracked)
+# Pipeline artifacts (case study outputs - generated, not tracked)
+#
+# Each name is listed twice, with and without the trailing slash, and both forms are
+# needed. The slashed form matches a directory; a symlink to a directory is a symlink,
+# not a directory, so it does not match. Several of these arrive as symlinks to a shared
+# artifact store outside the repository, and without the bare form git offers to commit
+# an absolute machine-specific path.
 case_studies/*/features/
+case_studies/*/features
 case_studies/*/labels/
+case_studies/*/labels
 case_studies/*/models/
+case_studies/*/models
 case_studies/*/synthesis/
+case_studies/*/synthesis
 case_studies/*/backtest/
+case_studies/*/backtest
 case_studies/*/strategy/
+case_studies/*/strategy
 case_studies/*/evaluation/
+case_studies/*/evaluation
 case_studies/*/exploration/
+case_studies/*/exploration
 case_studies/*/registry.db
 case_studies/*/results/
 case_studies/*/*_v1_contaminated/


### PR DESCRIPTION
## What

Each of the eight case-study artifact directory names in `.gitignore` was listed only with a trailing slash. `run_log` already carried both forms; this gives the other eight the same treatment.

## Why

A trailing slash matches a directory. A symlink to a directory is a symlink, not a directory, so the slashed pattern does not match one.

The case-study artifact store (registries, labels, features) is too large to live in the repository and each working tree reaches it through per-directory symlinks. On the machine where that setup exists, the gap had been patched in `.git/info/exclude`, which is machine-local and does not travel with a clone. So on a fresh checkout with the same layout the symlinks show as untracked, and `git add -A` would commit an absolute machine-specific path into the repository.

## Verification

`git check-ignore -v` now names `.gitignore` rather than `.git/info/exclude` for all nine:

```
labels       .gitignore:146:case_studies/*/labels        case_studies/fx_pairs/labels
features     .gitignore:144:case_studies/*/features      case_studies/fx_pairs/features
evaluation   .gitignore:156:case_studies/*/evaluation    case_studies/fx_pairs/evaluation
models       .gitignore:148:case_studies/*/models        case_studies/fx_pairs/models
backtest     .gitignore:152:case_studies/*/backtest      case_studies/fx_pairs/backtest
strategy     .gitignore:154:case_studies/*/strategy      case_studies/fx_pairs/strategy
synthesis    .gitignore:150:case_studies/*/synthesis     case_studies/fx_pairs/synthesis
exploration  .gitignore:158:case_studies/*/exploration   case_studies/fx_pairs/exploration
run_log      .gitignore:170:case_studies/*/run_log       case_studies/fx_pairs/run_log
```

No tracked file changes state: nothing matching these patterns is in the index.