### PR TITLE
Ignore .env backups, not only .env itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Environment and secrets
 .env
+.env.*
 .env.local
 .env.*.local
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # Environment and secrets
 .env
 .env.*
+# .env.example is tracked and documents the variables; keep it out of the sweep above.
+!.env.example
 .env.local
 .env.*.local
 


### PR DESCRIPTION
`.gitignore` covered `.env`, `.env.local` and `.env.*.local`. A rotation on 2026-08-21 left `.env.bak-20260821-161214` in this checkout and in four case-study worktrees, matching none of those, so `git add -A` would have staged a credentials file.

`.env.*` covers every backup, sample and per-environment variant, with `!.env.example` keeping the tracked one that documents the variables. Verified with `git check-ignore`: the backup is ignored, `.env.example` is not.