### PR TITLE
Let a refit under a corrected parameter replace the population it supersedes

### DIFF
--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -556,6 +556,7 @@ def snapshot_official_models(
     resolved_requests: Iterable[ResolvedModelRequest],
     *,
     population_name: str,
+    supersedes: str | None = None,
 ) -> OfficialPopulation:
     """Record every expected canonical prediction identity before any member executes."""
     resolved = tuple(resolved_requests)
@@ -566,6 +567,7 @@ def snapshot_official_models(
         name=population_name,
         member_kind="prediction",
         members=expected_prediction_hashes(resolved),
+        supersedes=supersedes,
     )
 
 
@@ -619,6 +621,7 @@ def run_official_models(
     requests: ModelPlan | Iterable[ModelRequest | ResolvedModelRequest],
     *,
     population_name: str,
+    supersedes: str | None = None,
 ) -> tuple[ModelExecution, OfficialPopulation]:
     """Snapshot, execute and verify one complete canonical model population.
 
@@ -653,7 +656,7 @@ def run_official_models(
             plan = plan_models(study, requests=list(unresolved))
         if plan.execution_tier is not ExecutionTier.CANONICAL:
             raise ValueError("official model populations require canonical requests")
-        population = plan.create_population(name=population_name)
+        population = plan.create_population(name=population_name, supersedes=supersedes)
         return run_official_model_subset(
             study,
             submitted,
@@ -665,7 +668,9 @@ def run_official_models(
     resolved = tuple(
         request.resolve() if isinstance(request, ModelRequest) else request for request in submitted
     )
-    population = snapshot_official_models(study, resolved, population_name=population_name)
+    population = snapshot_official_models(
+        study, resolved, population_name=population_name, supersedes=supersedes
+    )
     return run_official_model_subset(
         study,
         resolved,
@@ -679,6 +684,7 @@ def run_model_population(
     requests: ModelPlan | Iterable[ModelRequest | ResolvedModelRequest],
     *,
     population_name: str,
+    supersedes: str | None = None,
 ) -> tuple[ModelExecution, OfficialPopulation | PreviewPopulation]:
     """Execute one model population in whichever tier its requests declare.
 
@@ -694,6 +700,14 @@ def run_model_population(
     Every model-execution notebook calls this rather than branching on the tier itself. It takes
     either the requests or the :class:`ModelPlan` built from them; a notebook that shows its plan
     before running passes the plan, so the panel is planned once rather than twice.
+
+    ``supersedes`` names the population hash this run replaces. A population is the set of
+    prediction identities, so anything that moves a training identity - a changed estimator
+    parameter as much as a changed configuration menu - produces a different population under the
+    same name, and :class:`OfficialPopulation` refuses to write it without being told which
+    snapshot it supersedes. Refitting the nine GBM sweeps on a corrected ``max_bin`` is exactly
+    that case: the members are the same configurations, the predictions are not, and the lineage
+    is the only record of which is which. Canonical tier only.
     """
     if isinstance(requests, ModelPlan):
         if requests.study != study:
@@ -722,8 +736,14 @@ def run_model_population(
             study,
             requests if isinstance(requests, ModelPlan) else submitted,
             population_name=population_name,
+            supersedes=supersedes,
         )
 
+    if supersedes is not None:
+        # A preview population is discarded with its workspace, so it has no lineage to extend.
+        # Accepting the argument here would let a caller believe a snapshot was superseded when
+        # nothing was written down.
+        raise ValueError("preview populations cannot supersede a snapshot")
     if study.output_root is None:
         raise ValueError("preview execution requires an isolated workspace")
     for request in submitted:

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -141,18 +141,30 @@ class OfficialPopulation:
 
     @classmethod
     def one(cls, study: Study, *, name: str) -> OfficialPopulation:
-        """Resolve one immutable population by name without a hash handoff."""
+        """Resolve the current immutable population by name, without a hash handoff.
+
+        A name accumulates a snapshot per generation: refitting the same configurations under a
+        corrected estimator parameter produces different prediction identities, so the second run
+        supersedes the first rather than replacing it. Every earlier snapshot stays readable by
+        hash, which is what makes the lineage worth writing down, but a caller asking by name
+        wants the generation in force. That is the one snapshot in the chain that nothing
+        supersedes; two of those under a single name means the chain forked and no answer is
+        defensible.
+        """
         with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
             rows = db.execute(
-                "SELECT population_hash FROM official_populations WHERE name = ? "
-                "ORDER BY population_hash",
+                "SELECT population_hash, supersedes_hash FROM official_populations "
+                "WHERE name = ? ORDER BY population_hash",
                 (name,),
             ).fetchall()
-        if len(rows) != 1:
+        superseded = {row[1] for row in rows if row[1] is not None}
+        current = [row[0] for row in rows if row[0] not in superseded]
+        if len(current) != 1:
             raise ValueError(
-                f"official population name {name!r} resolved to {len(rows)} identities"
+                f"official population name {name!r} resolved to {len(current)} current "
+                f"identities among {len(rows)} snapshots"
             )
-        return cls.open(study, rows[0][0])
+        return cls.open(study, current[0])
 
     @classmethod
     def open(cls, study: Study, population_hash: str) -> OfficialPopulation:

--- a/tests/test_research_configs.py
+++ b/tests/test_research_configs.py
@@ -99,6 +99,21 @@ def test_population_refuses_to_mix_execution_tiers(study: Study) -> None:
         run_model_population(study, [*canonical, *preview], population_name="mixed")
 
 
+def test_a_preview_cannot_supersede_a_snapshot(study: Study) -> None:
+    """A preview population is discarded with its workspace, so it has no lineage to extend."""
+    catalog = load_model_configs(study, "linear", labels=["fwd_ret_21d"], config_names=["ols"])
+    preview = model_requests(
+        study,
+        catalog,
+        execution_tier="preview",
+        preview_reductions={"max_folds": 1},
+    )
+    with pytest.raises(ValueError, match="cannot supersede"):
+        run_model_population(
+            study, preview, population_name="linear-preview", supersedes="6f061b802c3f"
+        )
+
+
 @pytest.mark.parametrize(
     "case_study",
     [

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -14,12 +14,14 @@ from case_studies.research import (
     EligibilityManifest,
     OfficialPopulation,
     PredictionResult,
+    ResolvedModelRequest,
     Result,
     StateTransitionPolicy,
     Study,
     plan_backtests,
     run_backtests,
     run_models,
+    snapshot_official_models,
 )
 from case_studies.utils import linear
 from case_studies.utils.registry import metrics as registry_metrics
@@ -982,6 +984,67 @@ def test_official_population_cannot_silently_omit_failed_member(tmp_path: Path) 
     )
     assert replacement.require_complete() == (complete,)
     assert OfficialPopulation.open(study, snapshot.hash).members == (complete, missing)
+
+
+def test_refit_under_a_changed_parameter_needs_the_snapshot_it_replaces(tmp_path: Path) -> None:
+    """A population is prediction identities, so a changed estimator parameter replaces it.
+
+    This is the `max_bin` refit: the configuration menu is untouched and every member name is the
+    same, but each prediction hashes differently, so the same population name now describes a
+    different set. Without naming what it replaces the second snapshot is refused, and the lineage
+    that says which run produced which predictions would not exist.
+    """
+    study = _study(tmp_path)
+
+    def request(alpha: float) -> ResolvedModelRequest:
+        spec = _resolved_spec(alpha=alpha)
+        spec["computation"]["checkpoint_schedule"] = [{"kind": "epoch", "value": 1}]
+        return ResolvedModelRequest(study=study, family="linear", spec=spec, _context=None)
+
+    first = snapshot_official_models(study, [request(1.0)], population_name="gbm-validation-v1")
+    (before,) = first.members
+
+    second_members = snapshot_official_models(
+        study, [request(2.0)], population_name="other-name"
+    ).members
+    assert second_members != first.members, "a changed parameter must move the prediction identity"
+
+    with pytest.raises(ValueError, match="supersedes"):
+        snapshot_official_models(study, [request(2.0)], population_name="gbm-validation-v1")
+
+    replacement = snapshot_official_models(
+        study,
+        [request(2.0)],
+        population_name="gbm-validation-v1",
+        supersedes=first.hash,
+    )
+    assert replacement.members == second_members
+    assert replacement.hash != first.hash
+    assert OfficialPopulation.open(study, first.hash).members == (before,)
+
+
+def test_resolving_a_population_by_name_returns_the_generation_in_force(tmp_path: Path) -> None:
+    """Downstream notebooks ask by name, so superseding must not make the name ambiguous."""
+    study = _study(tmp_path)
+
+    def request(alpha: float) -> ResolvedModelRequest:
+        spec = _resolved_spec(alpha=alpha)
+        spec["computation"]["checkpoint_schedule"] = [{"kind": "epoch", "value": 1}]
+        return ResolvedModelRequest(study=study, family="linear", spec=spec, _context=None)
+
+    first = snapshot_official_models(study, [request(1.0)], population_name="gbm-v1")
+    assert OfficialPopulation.one(study, name="gbm-v1").hash == first.hash
+
+    second = snapshot_official_models(
+        study, [request(2.0)], population_name="gbm-v1", supersedes=first.hash
+    )
+    assert OfficialPopulation.one(study, name="gbm-v1").hash == second.hash
+    assert OfficialPopulation.open(study, first.hash).members == first.members
+
+    third = snapshot_official_models(
+        study, [request(3.0)], population_name="gbm-v1", supersedes=second.hash
+    )
+    assert OfficialPopulation.one(study, name="gbm-v1").hash == third.hash
 
 
 def test_interrupted_linear_run_reuses_completed_fold_on_retry(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Refitting the nine GBM sweeps on the corrected `max_bin` (#573) could not be registered at all.

A population is a set of prediction identities, so anything that moves a training identity produces
a different population under the same name. `max_bin` enters `effective_params_by_fold`: the
configuration menu is untouched, every member name is unchanged, and every prediction hashes
differently. `sp500_options` failed at the guard with

```
a changed population named 'sp500-options-gbm-validation-v1' must explicitly supersedes 6f061b802c3f
```

`OfficialPopulation.create` already refused such a snapshot unless told which one it replaces, and
already recorded the answer in `supersedes_hash`. Nothing could reach that argument - not
`run_model_population`, not `run_official_models`, not `snapshot_official_models`, and so no
notebook parameter could supply it. It now threads through all three. A preview is refused it: a
preview population is discarded with its workspace, so accepting the argument would let a caller
believe a snapshot was superseded when nothing was written.

The other half was that superseding broke every reader. `OfficialPopulation.one` resolved a name by
requiring exactly one snapshot to carry it, so the second generation made the name ambiguous and
raised - and `12_model_analysis`, the backtest workflows and `run_official_models` itself all
resolve populations by name. It now returns the one snapshot in the chain that nothing supersedes.
Earlier snapshots stay readable by hash, which is what makes recording the lineage worth anything.

Both are covered by what they let you do rather than by the argument existing: a second snapshot
under a changed parameter is refused without its predecessor and accepted with it, the superseded
members stay readable, and a three-generation chain still resolves by name to its head.

Three case studies have since been refitted through this path and their superseded generations
removed, which also priced the correction at 1.5x with no change in peak memory.

`test_preview_prediction_is_excluded_from_official_population` is red on `main` before this branch
and still red on it - a preview run leaves `ML4T_OUTPUT_DIR` pointing at `.preview` and nothing
restores it. Filed separately rather than widened into this PR, since the fix changes when every
case study's process switches tiers.