### PR TITLE
Point the shared max_bin constant at the value all nine case studies declare

### DIFF
--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -243,7 +243,10 @@ _SKIP_PARAMS: dict[str, set[str]] = {
 _BEST_GPU: dict[str, str | None] = {}
 
 DEFAULT_GBM_CPU_THREADS = 8
-GBM_DEFAULT_MAX_BIN = 63
+# What every case study's setup.yaml declares under modeling.gbm.max_bin. It is LightGBM's own
+# default; the 63 that preceded it was inherited from a device branch rather than declared, and
+# the populations fitted under it are superseded.
+GBM_DEFAULT_MAX_BIN = 255
 
 # Declared behaviour of this runner. Bump when a change here would change a fitted result: the
 # libraries it dispatches to, how a parameter is derived, the fitting procedure, the checkpoint

--- a/tests/test_gbm_runtime.py
+++ b/tests/test_gbm_runtime.py
@@ -312,9 +312,9 @@ def test_cpu_training_repeats_bit_exactly() -> None:
 def test_max_bin_changes_the_fitted_model() -> None:
     """max_bin is not cosmetic: it must be declared, never inherited from a device branch.
 
-    Every published GBM number was produced with max_bin=63 (recorded inside the saved
-    boosters). Swapping to LightGBM's 255 default silently moves every result, so this
-    pins the empirical consequence that
+    Changing it moves every fitted result, which is why the correction from 63 to 255
+    supersedes the populations fitted before it rather than adding to them. This pins the
+    empirical consequence that
     ``test_gbm_training_identity_covers_every_declared_numerical_input`` pins for the hash.
     """
     n_dates, n_entities, n_features = 60, 20, 6


### PR DESCRIPTION
`GBM_DEFAULT_MAX_BIN` in `case_studies/utils/gbm.py` stayed at 63 when 5b19cf0b raised `modeling.gbm.max_bin` to 255 in every `config/setup.yaml`, so the two tests that check the declared value against the constant have been red on main since. The constant is read only by those tests, so nothing fitted changes.

`test_max_bin_changes_the_fitted_model`'s docstring still described 63 as what every published number was produced with. That is exactly what the correction supersedes, so it now says so.

```
uv run pytest tests/test_gbm_runtime.py -q   # 24 passed (2 failed before)
```