### PR TITLE
Say which sibling a regression AUC was scored against, and read folds in fold order

### DIFF
--- a/case_studies/research/catalog.py
+++ b/case_studies/research/catalog.py
@@ -50,6 +50,7 @@ RESERVED_COLUMNS: dict[str, Any] = {
     "config_name": pl.String,
     "label": pl.String,
     "task": pl.String,
+    "direction_label": pl.String,
     "split": pl.String,
     "checkpoint_kind": pl.String,
     "checkpoint_value": pl.Int64,
@@ -211,6 +212,11 @@ def _registry_rows(root: Path, origin: str) -> list[dict[str, Any]]:
             _select("prediction_hash", metric_columns, "m"),
             _select("computed_at", metric_columns, "m"),
             _select("task_type", metric_columns, "m"),
+            # Which sibling label an `auc_*` block was scored against. A classification row
+            # scores its own label and leaves this null; a regression row has no classes, so
+            # the AUC it carries is against a declared direction sibling and is meaningless
+            # without knowing which. A regression label with no sibling carries no AUC.
+            _select("direction_label", metric_columns, "m"),
             *[_select(metric, metric_columns, "m") for metric in _METRIC_COLUMNS],
         ]
         fold_metric_count = (
@@ -314,6 +320,7 @@ def _registry_rows(root: Path, origin: str) -> list[dict[str, Any]]:
             "config_name": record["t_config_name"],
             "label": record["t_label"],
             "task": task,
+            "direction_label": record["m_direction_label"],
             "split": record["p_split"],
             "checkpoint_kind": record["p_checkpoint_kind"],
             "checkpoint_value": record["p_checkpoint_value"],

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -317,7 +317,9 @@ class TrainingResult(Result):
         import joblib
 
         models = self.root / "run_log" / "training" / self.hash / "models"
-        paths = sorted(models.glob("fold_*.joblib"))
+        # Fold order, not filename order: a lexicographic sort puts fold_10 before fold_2, and
+        # `us_equities_panel` declares sixteen splits.
+        paths = sorted(models.glob("fold_*.joblib"), key=lambda path: int(path.stem.split("_")[1]))
         if not paths:
             raise FileNotFoundError(
                 f"training run {self.hash} stored no fitted state under {models}"

--- a/case_studies/utils/runtime.py
+++ b/case_studies/utils/runtime.py
@@ -16,6 +16,7 @@ import os
 import platform
 import resource
 import subprocess
+import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -84,9 +85,15 @@ def peak_rss_bytes() -> int:
     the peak of the notebook rather than of the run that just finished. That is the number the
     concurrency policy needs - whether this notebook can share the machine - and it is recorded
     under a name that says so.
+
+    ``ru_maxrss`` carries no portable unit: Linux reports kilobytes and macOS reports bytes, so
+    the scale is read off the platform rather than assumed. Reading it as kilobytes on macOS
+    reports a peak 1024 times too large, and `scripts/pre_run_gate.py` prints that figure in GB
+    as a check it passes on.
     """
     usage = resource.getrusage(resource.RUSAGE_SELF)
-    return int(usage.ru_maxrss) * 1024
+    scale = 1 if sys.platform == "darwin" else 1024
+    return int(usage.ru_maxrss) * scale
 
 
 def cpu_seconds() -> float:

--- a/tests/test_research_contract_catalog.py
+++ b/tests/test_research_contract_catalog.py
@@ -334,3 +334,31 @@ def test_catalog_reads_legacy_rows_without_claiming_current_contract(tmp_path: P
     assert row["prediction_hash"] == "legacy-prediction"
     assert row["identity_status"] == "legacy"
     assert row["complete"] is False
+
+
+def test_catalog_says_which_sibling_a_regression_auc_was_scored_against(tmp_path: Path) -> None:
+    """A regression row's AUC is scored against a declared direction label, not its own classes.
+
+    Without ``direction_label`` the column reads as the classification path's AUC on a row that
+    has no classes, and the two are not the same quantity.
+    """
+    release = _seed_release(tmp_path)
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=release)
+    scored = _publish(study.root, spec=_resolved_spec(alpha=1.0))
+    unscored = _publish(study.root, spec=_resolved_spec(alpha=2))
+
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        # The metric writer adds this column the first time a regression AUC is recorded, the
+        # same way it adds any other metric name it has not seen.
+        db.execute("ALTER TABLE prediction_metrics ADD COLUMN direction_label TEXT")
+        for prediction_hash, direction in ((scored, "fwd_dir_21d"), (unscored, None)):
+            db.execute(
+                "UPDATE prediction_metrics SET auc_mean_daily = 0.53, direction_label = ? "
+                "WHERE prediction_hash = ?",
+                (direction, prediction_hash),
+            )
+
+    rows = {row["prediction_hash"]: row for row in study.predictions.table().iter_rows(named=True)}
+    assert rows[scored]["direction_label"] == "fwd_dir_21d"
+    assert rows[unscored]["direction_label"] is None
+    assert study.predictions.table().schema["direction_label"] == pl.String

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -2917,3 +2917,15 @@ def test_published_logistic_presets_resolve_to_the_model_their_name_claims() -> 
         if sum(sig == signature for sig in effective.values()) > 1
     }
     assert not duplicates, f"published logistic presets resolve to one model: {duplicates}"
+
+
+def test_peak_rss_is_read_in_the_unit_the_platform_reports(monkeypatch) -> None:
+    """Linux reports ru_maxrss in kilobytes and macOS in bytes; the same reading is not both."""
+    from case_studies.utils import runtime
+
+    monkeypatch.setattr(runtime, "sys", type("_S", (), {"platform": "linux"}))
+    on_linux = runtime.peak_rss_bytes()
+    monkeypatch.setattr(runtime, "sys", type("_S", (), {"platform": "darwin"}))
+    on_macos = runtime.peak_rss_bytes()
+
+    assert on_linux == on_macos * 1024

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -597,3 +597,32 @@ def test_partial_and_preview_results_are_rejected_from_canonical_sets(tmp_path: 
     with pytest.raises(KeyError):
         Result.open(study, preview.hash)
     assert Result.open(study, preview.hash, include_preview=True).hash == preview.hash
+
+
+def test_fitted_states_come_back_in_fold_order_not_filename_order(tmp_path: Path) -> None:
+    """A lexicographic sort puts fold_10 before fold_2, and one case study declares 16 splits."""
+    import joblib
+
+    from case_studies.research import TrainingResult
+
+    study = _study(tmp_path)
+    db = _open_registry(study.root)
+    try:
+        db.execute(
+            "INSERT INTO training_runs "
+            "(training_hash, family, label, spec_json, created_at) VALUES (?,?,?,?,?)",
+            ("many-folds", "linear", "fwd_ret_21d", "{}", "2024-01-01"),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    models = study.root / "run_log" / "training" / "many-folds" / "models"
+    models.mkdir(parents=True)
+    for fold in range(12):
+        joblib.dump({"fold": fold}, models / f"fold_{fold}.joblib")
+
+    reopened = Result.open(study, "many-folds")
+
+    assert isinstance(reopened, TrainingResult)
+    assert [state["fold"] for state in reopened.fitted_states()] == list(range(12))

--- a/tests/test_temporal_artifact_is_read_by_fold.py
+++ b/tests/test_temporal_artifact_is_read_by_fold.py
@@ -13,11 +13,11 @@ who cannot allocate 80 GB is the reason both properties matter.
 from __future__ import annotations
 
 import gc
-import resource
 
 import polars as pl
 import pytest
 
+from case_studies.utils.runtime import peak_rss_bytes
 from utils.modeling import fold_temporal_frame, temporal_fold_index
 
 N_FOLDS = 8
@@ -131,19 +131,19 @@ class TestTheArtifactIsNotMaterialised:
     def test_selecting_a_fold_costs_a_fold_not_the_table(self, artifact_path):
         """The regression guard. Re-adding a ``.to_pandas()`` on the artifact fails here.
 
-        ``ru_maxrss`` is a high-water mark that never falls, so the baseline is taken before
+        ``peak_rss_bytes`` is a high-water mark that never falls, so the baseline is taken before
         anything in this test has read the artifact whole - reading it first would pay the peak
         up front and leave the assertion unable to fail. The budget is derived from one fold,
         not from the table, for the same reason.
         """
         gc.collect()
-        before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        before = peak_rss_bytes()
 
         one_at_a_time = None
         for fold_id in range(N_FOLDS):
             one_at_a_time = fold_temporal_frame(pl.scan_parquet(artifact_path), fold_id)
         gc.collect()
-        after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        after = peak_rss_bytes()
         assert one_at_a_time is not None
         growth = after - before
 


### PR DESCRIPTION
Three fixes to the shared research boundary plus a test-side unit fix. None changes a fitted result.

**`direction_label` on the catalog.** A regression prediction carries no classes of its own, so the `auc_*` block on its row is computed against a declared direction sibling - `fwd_ret_5d` against `fwd_dir_5d` - and the registry has always recorded which one. The catalog dropped that column, so a reader comparing `auc_mean_daily` across a mixed frame saw a classifier's AUC on its own label beside a regression's AUC on a sibling label with nothing distinguishing them, and could not tell a null apart from a label that declares no sibling. Five case-study notebooks assert "it is null on the regression labels, which have no classes to separate", which their own printed frames contradict; carrying the column is what lets them say the real rule.

**Fold order.** `TrainingResult.fitted_states()` promised fold order and sorted filenames, so `fold_10` came back before `fold_2`. `us_equities_panel` declares sixteen splits. The only current caller indexes `[0]` and otherwise averages, so nothing published is wrong.

**`ru_maxrss` units.** Read as kilobytes unconditionally; macOS reports bytes. A run recorded there would report a peak 1024x too large, which `scripts/pre_run_gate.py` prints in GB as a check it passes on. The fold-materialisation guard in `tests/` scaled it the same way, so its assertion would fail on a Mac wherever the predicate was working.

```
uv run pytest tests/test_research_contract_catalog.py tests/test_research_registry.py \
  tests/test_temporal_artifact_is_read_by_fold.py -q   # 47 passed
```
The fold-order test fails on the old sort; the platform test fails on the old constant.