### PR TITLE
Observe the fold path the batch runs actually take

### DIFF
--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -1010,14 +1010,17 @@ def _observe_fold_sets(monkeypatch) -> list[tuple[int, float]]:
 
     folds_module.clear_memo()
     built: list[tuple[int, float]] = []
-    original = folds_module.prepare_raw_folds
+    original = folds_module.iter_raw_folds
 
+    # `iter_raw_folds`, not `prepare_raw_folds`: the batch paths stream folds so that only one is
+    # alive at a time, and `prepare_raw_folds` is now the list() wrapper no consumer calls.
+    # Observing the wrapper recorded nothing while the run underneath prepared every fold.
     def observed(mds, splits, *, train_sample_frac=1.0, **kwargs):
-        prepared = original(mds, splits, train_sample_frac=train_sample_frac, **kwargs)
-        built.extend((int(fold.fold), float(train_sample_frac)) for fold in prepared)
-        return prepared
+        for fold in original(mds, splits, train_sample_frac=train_sample_frac, **kwargs):
+            built.append((int(fold.fold), float(train_sample_frac)))
+            yield fold
 
-    monkeypatch.setattr(folds_module, "prepare_raw_folds", observed)
+    monkeypatch.setattr(folds_module, "iter_raw_folds", observed)
     return built
 
 


### PR DESCRIPTION
Closes the second reading in ml4t/agent-workspace#874, which turns out to be the benign one: a test defect, not a production one.

`test_linear_batch_separates_incompatible_sampling_and_is_order_invariant` asserted against an empty list, so it pinned nothing - the two orderings it compares were never observed at all.

The batch paths were changed to stream folds so only one is alive at a time (`case_studies/utils/folds.py:728,772`), which left `prepare_raw_folds` as the `list()` wrapper no consumer calls. The test patched the wrapper, so every fold the run prepared went unrecorded while the assertion compared `[]` against the expected order. Patching `iter_raw_folds` records them as they are yielded, and keeps the one-fold-alive bound the streaming change bought.

The batch path is taken and does separate incompatible `train_sample_frac` values. Nothing was watching it.

```
uv run pytest tests/test_research_models.py -q   # 73 passed (1 failed before)
```