### PR TITLE
Scope the provenance gate to the files being committed

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -654,8 +654,11 @@ def stamp_reference(base_branch: str = "main") -> str:
     return "HEAD"
 
 
-def destamped(ref: str | None = None) -> list[str]:
+def destamped(ref: str | None = None, only: set[str] | None = None) -> list[str]:
     """Notebooks stamped at *ref* and unstamped now.
+
+    ``only`` restricts the answer to those paths, so the pre-commit gate reports a
+    stamp this commit is dropping rather than one another commit dropped earlier.
 
     The gate says nothing about a notebook with no stamp, which is deliberate - the
     corpus is being stamped as notebooks are re-run, and failing the ones that have
@@ -668,7 +671,8 @@ def destamped(ref: str | None = None) -> list[str]:
     return sorted(
         rel
         for rel in stamped_at(ref or stamp_reference())
-        if (REPO_ROOT / rel).exists()
+        if (only is None or rel in only)
+        and (REPO_ROOT / rel).exists()
         and not json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
         .get("metadata", {})
         .get(STAMP_KEY)
@@ -677,12 +681,20 @@ def destamped(ref: str | None = None) -> list[str]:
 
 def check_all(
     strict: bool = False,
+    only: set[str] | None = None,
 ) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
     """Return (stale, testmode, contradicted, unverified, alt_only) repo-relative rows.
 
     Only the first four fail. ``alt_only`` is reported so that forgiving a drift is
     never silent: a notebook in that list has a ``.py`` that no longer matches its
     stamp, and the reason it is allowed is printed rather than assumed.
+
+    ``only`` restricts the scan to the notebooks whose ``.ipynb`` or paired ``.py``
+    is in that set of repo-relative paths. The pre-commit gate passes the staged
+    files, so a notebook someone else left dirty in the working tree no longer
+    blocks an unrelated commit; nothing unstaged can reach main, so the narrower
+    scan gives up no protection. CI calls it with no ``only`` and still scans the
+    whole tree.
     """
     stale: list[str] = []
     testmode: list[str] = []
@@ -694,6 +706,8 @@ def check_all(
         py = paired_py(nb_path)
         if py is None:
             continue  # un-paired notebooks have no .py to drift from
+        if only is not None and rel not in only and str(py.relative_to(REPO_ROOT)) not in only:
+            continue
         try:
             nb = json.loads(nb_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
@@ -737,8 +751,9 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
-    stale, testmode, contradicted, unverified, alt_only = check_all(strict=args.strict)
-    lost = destamped()
+    only = {str(Path(p)) for p in args.paths} or None
+    stale, testmode, contradicted, unverified, alt_only = check_all(strict=args.strict, only=only)
+    lost = destamped(only=only)
     fail = bool(stale or testmode or contradicted or lost) or (args.strict and bool(unverified))
     if lost:
         print("DE-STAMPED (carried a provenance stamp where this branch forked, and does not now):")
@@ -811,6 +826,12 @@ def main() -> int:
 
     cp = sub.add_parser("check", help="gate: fail on stale or test-mode stamped notebooks")
     cp.add_argument("--strict", action="store_true", help="also fail on unstamped notebooks")
+    cp.add_argument(
+        "paths",
+        nargs="*",
+        help="restrict the scan to these files (the pre-commit gate passes the staged ones); "
+        "with none given, the whole tree is scanned",
+    )
     cp.set_defaults(func=_cmd_check)
 
     args = ap.parse_args()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,12 +55,18 @@ repos:
       # paired .py changed since execution) or was committed from a TEST-mode
       # run. Unstamped notebooks are advisory only (gradual adoption). See
       # .github/scripts/notebook_provenance.py.
+      # Scoped to the staged files since 2026-08-22. It used to scan the whole tree
+      # on every commit, so one notebook another session had left dirty blocked every
+      # unrelated commit in that worktree - three worktrees were stuck that way in a
+      # single day, and the cme_futures one could not commit anything for six days.
+      # Nothing unstaged can reach main, so the narrower scan gives up no protection,
+      # and CI still calls `check` with no arguments and scans everything.
       - id: notebook-sync
         name: notebook provenance sync gate
         language: system
         entry: python3 .github/scripts/notebook_provenance.py check
-        pass_filenames: false
-        always_run: true
+        files: \.(py|ipynb)$
+        pass_filenames: true
 
       # Verification gate: a notebook whose verifier signed off on one exact
       # version may not be silently changed. `.verified-notebooks.tsv` records

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -565,3 +565,41 @@ def test_a_computed_alt_the_output_does_not_carry_is_stale(tmp_path, monkeypatch
         ],
     }
     assert not _drift(tmp_path, monkeypatch, old, new, _notebook([cell]))
+
+
+def test_every_row_the_scan_returns_is_one_of_the_files_it_was_given() -> None:
+    """The gate must answer for the files it is given, not for the working tree.
+
+    `check_all` scanning everything is what let one session's dirty notebook block
+    every unrelated commit in a shared worktree. This is the contract that fixes it,
+    and it holds whatever state the tree is in: no category may name a notebook
+    outside `only`. Nothing unstaged can reach main, so the narrower scan gives up
+    no protection.
+    """
+    everything = check_all()
+    all_rows = sorted({r for category in everything for r in category})
+    assert all_rows, "no notebook in this tree for the scan to report on"
+
+    chosen = {all_rows[0]}
+    for category in check_all(only=chosen):
+        assert set(category) <= chosen
+
+    excluded = set(all_rows[1:])
+    if excluded:
+        for category in check_all(only=excluded):
+            assert all_rows[0] not in category
+
+
+def test_the_paired_py_selects_its_notebook() -> None:
+    """pre-commit stages the `.py`, so naming it has to reach the `.ipynb` beside it."""
+    everything = check_all()
+    all_rows = sorted({r for category in everything for r in category})
+    assert all_rows, "no notebook in this tree for the scan to report on"
+    nb = all_rows[0]
+    by_py = check_all(only={nb.removesuffix(".ipynb") + ".py"})
+    assert sorted({r for category in by_py for r in category}) == [nb]
+
+
+def test_an_empty_restriction_still_scans_everything() -> None:
+    """`only=None` is the whole tree, which is what CI calls and must not change."""
+    assert check_all(only=None) == check_all()


### PR DESCRIPTION
The `notebook-sync` pre-commit hook ran with `pass_filenames: false` and `always_run: true`, so every commit was checked against the whole working tree rather than against what it contained. One notebook left dirty by another session therefore blocked every unrelated commit in that worktree.

That is what has been happening. On 2026-08-22 three worktrees were stuck at once:

- one could not commit anything because six notebooks in it are de-stamped, and had been unable to since 2026-08-16;
- two others each hold uncommitted work from a session that has since exited, and a correction to a third file in each was refused on account of it.

Two extra worktrees had to be cut from branch tips purely to get one-line fixes committed.

**The change.** The gate now takes the staged paths and answers for those. Naming a `.py` selects the `.ipynb` beside it, which is what pre-commit stages. `check` with no arguments still walks the whole tree, so the CI invocation is unchanged.

Nothing unstaged can reach `main`, so the narrower scan gives up no protection. It stops the gate reporting on files the commit does not contain.

**Tests.** Three in `tests/test_notebook_sync.py`: every row returned is one of the files given, naming the paired `.py` reaches its notebook, and an empty restriction is still the whole tree. The first two fail against the previous code, verified by reverting the filter and re-running.