### PR TITLE
Give the provenance gate a legal way to commit an edited notebook

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -56,6 +56,22 @@ Gate (``check``): for every tracked ``.ipynb`` that HAS a stamp,
 * the stamp must not contradict a committed ``injected-parameters`` cell (else the
   notebook was re-executed with overrides after it was stamped).
 
+Two states are legal at commit time, and the second is what keeps the workflow
+linear:
+
+1. **Stamped and in sync** — the notebook is its current ``.py``, executed in
+   production. The checks above apply.
+2. **Cleared** — no stamp and no outputs. It makes no claim about a run, so there
+   is nothing to be stale. ``clear`` puts a notebook in this state. Edit the
+   ``.py``, ``jupytext --sync``, ``clear``, commit; execute later and the stamp and
+   the checks come back. Without this the gate has no legal path for a correction
+   to an already-executed notebook, because clearing the stale stamp read as
+   DE-STAMPED and keeping it read as STALE.
+
+The state the gate must still reject is the one that looks like (2) but claims (1):
+a stamp over an empty output set — a render rebuilt from the ``.py`` and re-stamped
+without a run behind it. That is HOLLOW and it fails.
+
 Notebooks WITHOUT a stamp are reported as "unverified" but do not fail unless
 ``--strict`` is passed. This is deliberate: adoption is gradual — stamp notebooks
 as they are re-run through the canonical path, and the gate enforces only where
@@ -66,6 +82,7 @@ Usage::
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --production
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --parameters '{"MAX_SYMBOLS": 5}'
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --production --notes "..."
+    uv run python .github/scripts/notebook_provenance.py clear <nb.ipynb>  # commit it unexecuted
     uv run python .github/scripts/notebook_provenance.py check          # gate (stamped-only)
     uv run python .github/scripts/notebook_provenance.py check --strict  # also fail on unverified
 """
@@ -654,6 +671,47 @@ def stamp_reference(base_branch: str = "main") -> str:
     return "HEAD"
 
 
+def has_outputs(nb: dict) -> bool:
+    """True if any non-empty code cell in *nb* carries an output.
+
+    A notebook with code and no outputs anywhere has not been executed (or has been
+    deliberately cleared). The distinction matters twice below: a CLEARED notebook
+    claims nothing and may be committed, and a STAMPED one claims a production run
+    that left no outputs, which no real run does.
+    """
+    saw_code = False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source") or []
+        if not "".join(source).strip():
+            continue
+        saw_code = True
+        if cell.get("outputs"):
+            return True
+    return not saw_code
+
+
+def is_cleared(nb_path: Path) -> bool:
+    """True if *nb_path* carries neither a provenance stamp nor any output.
+
+    This is the state an edited-but-not-yet-executed notebook is committed in, and
+    it is the one state that makes the workflow linear: edit the ``.py``, sync,
+    clear the ``.ipynb``, commit. The notebook then asserts nothing about a run, so
+    there is nothing for the gate to catch it lying about. Execution restores the
+    outputs and the stamp, and the gate resumes checking them.
+
+    It is precisely distinguishable from the render the gate exists to reject. A
+    hollow render carries ``production: True`` over an empty output set - it claims
+    a run that did not happen. A cleared notebook carries no stamp at all.
+    """
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    return not nb.get("metadata", {}).get(STAMP_KEY) and not has_outputs(nb)
+
+
 def destamped(ref: str | None = None, only: set[str] | None = None) -> list[str]:
     """Notebooks stamped at *ref* and unstamped now.
 
@@ -676,16 +734,20 @@ def destamped(ref: str | None = None, only: set[str] | None = None) -> list[str]
         and not json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
         .get("metadata", {})
         .get(STAMP_KEY)
+        # Dropping the stamp AND the outputs together is the documented way to
+        # commit an edited notebook before it is re-executed; only dropping the
+        # stamp while outputs stay is the regression this looks for.
+        and not is_cleared(REPO_ROOT / rel)
     )
 
 
 def check_all(
     strict: bool = False,
     only: set[str] | None = None,
-) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
-    """Return (stale, testmode, contradicted, unverified, alt_only) repo-relative rows.
+) -> tuple[list[str], list[str], list[str], list[str], list[str], list[str]]:
+    """Return (stale, testmode, contradicted, unverified, alt_only, hollow) rows.
 
-    Only the first four fail. ``alt_only`` is reported so that forgiving a drift is
+    ``stale``, ``testmode``, ``contradicted`` and ``hollow`` fail. ``alt_only`` is reported so that forgiving a drift is
     never silent: a notebook in that list has a ``.py`` that no longer matches its
     stamp, and the reason it is allowed is printed rather than assumed.
 
@@ -701,6 +763,7 @@ def check_all(
     contradicted: list[str] = []
     unverified: list[str] = []
     alt_only: list[str] = []
+    hollow: list[str] = []
     for nb_path in iter_notebooks():
         rel = str(nb_path.relative_to(REPO_ROOT))
         py = paired_py(nb_path)
@@ -727,7 +790,9 @@ def check_all(
         conflict = contradicts_injected_cell(nb, stamp.get("parameters") or {})
         if conflict:
             contradicted.append(f"{rel} ({conflict})")
-    return stale, testmode, contradicted, unverified, alt_only
+        if not has_outputs(nb):
+            hollow.append(rel)
+    return stale, testmode, contradicted, unverified, alt_only, hollow
 
 
 def _cmd_stamp(args: argparse.Namespace) -> int:
@@ -750,11 +815,58 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_clear(args: argparse.Namespace) -> int:
+    """Strip outputs, execution counts and the provenance stamp from a notebook.
+
+    The result is committable: it claims no run, so nothing about it can be stale.
+    Use it after editing a ``.py`` and before the notebook is re-executed, so the
+    correction lands on ``main`` in one commit instead of waiting on a run.
+    """
+    cleared = 0
+    for name in args.notebooks:
+        nb_path = Path(name).resolve()
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+        nb.get("metadata", {}).pop(STAMP_KEY, None)
+        nb.get("metadata", {}).pop("papermill", None)
+        kept = []
+        for cell in nb.get("cells", []):
+            if cell.get("cell_type") == "code":
+                cell["outputs"] = []
+                cell["execution_count"] = None
+                cell.get("metadata", {}).pop("papermill", None)
+                cell.get("metadata", {}).pop("execution", None)
+                if "injected-parameters" in (cell.get("metadata", {}).get("tags") or []):
+                    continue
+            kept.append(cell)
+        nb["cells"] = kept
+        nb_path.write_text(json.dumps(nb, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+        try:
+            shown = nb_path.relative_to(REPO_ROOT)
+        except ValueError:
+            shown = nb_path
+        print(f"cleared {shown}")
+        cleared += 1
+    if not cleared:
+        print("nothing to clear")
+    return 0
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
     only = {str(Path(p)) for p in args.paths} or None
-    stale, testmode, contradicted, unverified, alt_only = check_all(strict=args.strict, only=only)
+    stale, testmode, contradicted, unverified, alt_only, hollow = check_all(
+        strict=args.strict, only=only
+    )
     lost = destamped(only=only)
-    fail = bool(stale or testmode or contradicted or lost) or (args.strict and bool(unverified))
+    fail = bool(stale or testmode or contradicted or lost or hollow) or (
+        args.strict and bool(unverified)
+    )
+    if hollow:
+        print(
+            "HOLLOW (carries a provenance stamp over an empty output set — the stamp claims "
+            "a run that left nothing behind; clear the notebook or re-execute it):"
+        )
+        for r in hollow:
+            print(f"  {r}")
     if lost:
         print("DE-STAMPED (carried a provenance stamp where this branch forked, and does not now):")
         for r in lost:
@@ -833,6 +945,13 @@ def main() -> int:
         "with none given, the whole tree is scanned",
     )
     cp.set_defaults(func=_cmd_check)
+
+    lp = sub.add_parser(
+        "clear",
+        help="strip outputs and the stamp so an edited notebook can be committed unexecuted",
+    )
+    lp.add_argument("notebooks", nargs="+")
+    lp.set_defaults(func=_cmd_clear)
 
     args = ap.parse_args()
     return args.func(args)

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -52,7 +52,9 @@ Gate (``check``): for every tracked ``.ipynb`` that HAS a stamp,
 
 * ``source_py_blob`` must equal ``git hash-object`` of the current paired ``.py``
   (else the ``.py`` changed since the notebook was executed — STALE),
-* ``production`` must be True (else a TEST-mode run was committed), and
+* ``production`` must be True (else a TEST-mode run was committed),
+* some code cell must show it ran - an output or an execution count (else the stamp
+  is over a render nothing produced — HOLLOW), and
 * the stamp must not contradict a committed ``injected-parameters`` cell (else the
   notebook was re-executed with overrides after it was stamped).
 
@@ -69,8 +71,8 @@ linear:
    DE-STAMPED and keeping it read as STALE.
 
 The state the gate must still reject is the one that looks like (2) but claims (1):
-a stamp over an empty output set — a render rebuilt from the ``.py`` and re-stamped
-without a run behind it. That is HOLLOW and it fails.
+a stamp over a notebook showing no trace of execution — a render rebuilt from the
+``.py`` and re-stamped without a run behind it. That is HOLLOW and it fails.
 
 Notebooks WITHOUT a stamp are reported as "unverified" but do not fail unless
 ``--strict`` is passed. This is deliberate: adoption is gradual — stamp notebooks
@@ -671,23 +673,28 @@ def stamp_reference(base_branch: str = "main") -> str:
     return "HEAD"
 
 
-def has_outputs(nb: dict) -> bool:
-    """True if any non-empty code cell in *nb* carries an output.
+def was_executed(nb: dict) -> bool:
+    """True if any non-empty code cell in *nb* shows evidence of having been run.
 
-    A notebook with code and no outputs anywhere has not been executed (or has been
-    deliberately cleared). The distinction matters twice below: a CLEARED notebook
-    claims nothing and may be committed, and a STAMPED one claims a production run
-    that left no outputs, which no real run does.
+    Evidence is an output OR a non-null ``execution_count``. Outputs alone are not
+    enough to ask about: a cell that only assigns, writes a file or logs somewhere
+    else runs successfully and displays nothing, and a notebook made entirely of
+    those would otherwise read as never executed. The counter is written by the
+    kernel on every execution and cleared only deliberately, so the two together
+    separate "ran and said little" from "did not run".
+
+    The distinction matters twice below: a CLEARED notebook shows no evidence and so
+    claims nothing, and a STAMPED one claims a production run that left no evidence
+    at all, which no real run does.
     """
     saw_code = False
     for cell in nb.get("cells", []):
         if cell.get("cell_type") != "code":
             continue
-        source = cell.get("source") or []
-        if not "".join(source).strip():
+        if not "".join(cell.get("source") or []).strip():
             continue
         saw_code = True
-        if cell.get("outputs"):
+        if cell.get("outputs") or cell.get("execution_count") is not None:
             return True
     return not saw_code
 
@@ -709,7 +716,7 @@ def is_cleared(nb_path: Path) -> bool:
         nb = json.loads(nb_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return False
-    return not nb.get("metadata", {}).get(STAMP_KEY) and not has_outputs(nb)
+    return not nb.get("metadata", {}).get(STAMP_KEY) and not was_executed(nb)
 
 
 def destamped(ref: str | None = None, only: set[str] | None = None) -> list[str]:
@@ -790,7 +797,7 @@ def check_all(
         conflict = contradicts_injected_cell(nb, stamp.get("parameters") or {})
         if conflict:
             contradicted.append(f"{rel} ({conflict})")
-        if not has_outputs(nb):
+        if not was_executed(nb):
             hollow.append(rel)
     return stale, testmode, contradicted, unverified, alt_only, hollow
 
@@ -862,7 +869,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
     )
     if hollow:
         print(
-            "HOLLOW (carries a provenance stamp over an empty output set — the stamp claims "
+            "HOLLOW (carries a provenance stamp over a notebook with no trace of a run — "
             "a run that left nothing behind; clear the notebook or re-execute it):"
         )
         for r in hollow:

--- a/case_studies/us_firm_characteristics/12_portfolio_management.ipynb
+++ b/case_studies/us_firm_characteristics/12_portfolio_management.ipynb
@@ -391,13 +391,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-07-22T09:18:52.654460+00:00",
-   "executor": "local-script-production",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "993a75286773149960dcb25bc4b5a7a16d77c26e"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_firm_characteristics/13_costs.ipynb
+++ b/case_studies/us_firm_characteristics/13_costs.ipynb
@@ -326,13 +326,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-07-22T09:24:39.236078+00:00",
-   "executor": "local-script-production",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "767530397e4a3f99260619e357d3951102bf4468"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_firm_characteristics/14_risk_management.ipynb
+++ b/case_studies/us_firm_characteristics/14_risk_management.ipynb
@@ -422,13 +422,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-07-22T09:28:17.505053+00:00",
-   "executor": "local-script-production",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "d2555f4cc37b8c41351c0a295e562c9545ce4115"
   }
  },
  "nbformat": 4,

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -37,7 +37,9 @@ from notebook_provenance import (  # noqa: E402
     check_all,
     contradicts_injected_cell,
     destamped,
+    has_outputs,
     injected_parameters,
+    is_cleared,
     production_parameters,
     stamp_notebook,
 )
@@ -258,8 +260,8 @@ def test_stamp_records_declared_overrides_as_test_mode(tmp_path, monkeypatch) ->
 
 
 def test_stamped_notebooks_are_current_and_production() -> None:
-    stale, testmode, contradicted, _unverified, _alt_only = check_all(strict=False)
-    assert not stale and not testmode and not contradicted, (
+    stale, testmode, contradicted, _unverified, _alt_only, hollow = check_all(strict=False)
+    assert not stale and not testmode and not contradicted and not hollow, (
         "Committed notebooks are out of sync with their source .py:\n"
         + (
             "  STALE (re-run in the canonical env):\n    " + "\n    ".join(stale) + "\n"
@@ -275,6 +277,11 @@ def test_stamped_notebooks_are_current_and_production() -> None:
             "  CONTRADICTED (stamp disagrees with the injected-parameters cell):\n    "
             + "\n    ".join(contradicted)
             if contradicted
+            else ""
+        )
+        + (
+            "  HOLLOW (stamped over an empty output set):\n    " + "\n    ".join(hollow)
+            if hollow
             else ""
         )
     )
@@ -603,3 +610,104 @@ def test_the_paired_py_selects_its_notebook() -> None:
 def test_an_empty_restriction_still_scans_everything() -> None:
     """`only=None` is the whole tree, which is what CI calls and must not change."""
     assert check_all(only=None) == check_all()
+
+
+# -----------------------------------------------------------------------------
+# The cleared state
+#
+# Before this existed the gate had no legal way to land a correction to a notebook
+# that had already been executed: keeping the stale stamp read as STALE and dropping
+# it read as DE-STAMPED, and clearing either one needed the production run that the
+# uncommitted correction was a prerequisite for. Work accumulated in worktrees
+# instead - 177 uncommitted files across 24 of them on 2026-08-23.
+#
+# A cleared notebook (no stamp, no outputs) asserts nothing about a run, so there is
+# nothing for the gate to catch it lying about. What still fails is the render that
+# looks cleared but claims a run: a stamp over an empty output set.
+# -----------------------------------------------------------------------------
+
+
+def _code(source: str, outputs: list | None = None) -> dict:
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "source": source,
+        "outputs": outputs if outputs is not None else [],
+        "execution_count": None,
+    }
+
+
+def _stdout(text: str) -> dict:
+    return {"output_type": "stream", "name": "stdout", "text": text}
+
+
+def test_a_notebook_with_outputs_has_outputs() -> None:
+    assert has_outputs(_notebook([_code("print(1)", [_stdout("1")])]))
+
+
+def test_a_notebook_whose_code_ran_nothing_has_no_outputs() -> None:
+    assert not has_outputs(_notebook([_code("print(1)")]))
+
+
+def test_a_blank_code_cell_does_not_count_as_unexecuted_code() -> None:
+    """jupytext leaves empty trailing cells; they must not make a live notebook hollow."""
+    assert has_outputs(_notebook([_code("print(1)", [_stdout("1")]), _code("   ")]))
+
+
+def test_a_markdown_only_notebook_is_not_hollow() -> None:
+    assert has_outputs(_notebook([{"cell_type": "markdown", "source": "# hi", "metadata": {}}]))
+
+
+def test_cleared_is_no_stamp_and_no_outputs(tmp_path) -> None:
+    nb = tmp_path / "cleared.ipynb"
+    nb.write_text(json.dumps(_notebook([_code("print(1)")])), encoding="utf-8")
+    assert is_cleared(nb)
+
+
+def test_a_notebook_keeping_its_outputs_is_not_cleared(tmp_path) -> None:
+    nb = tmp_path / "live.ipynb"
+    nb.write_text(json.dumps(_notebook([_code("print(1)", [_stdout("1")])])), encoding="utf-8")
+    assert not is_cleared(nb)
+
+
+def test_a_stamped_notebook_is_not_cleared_even_with_no_outputs(tmp_path) -> None:
+    """The hollow render: it claims a production run and has nothing to show for it."""
+    nb = tmp_path / "hollow.ipynb"
+    nb.write_text(
+        json.dumps(
+            _notebook(
+                [_code("print(1)")],
+                metadata={notebook_provenance.STAMP_KEY: {"production": True}},
+            )
+        ),
+        encoding="utf-8",
+    )
+    assert not is_cleared(nb)
+
+
+def test_clearing_a_notebook_makes_it_committable(tmp_path) -> None:
+    """End to end on the state that used to be unreachable: stamped, edited, cleared."""
+    nb = tmp_path / "nb.ipynb"
+    nb.write_text(
+        json.dumps(
+            _notebook(
+                [
+                    _injected_cell("MAX_SYMBOLS = 5"),
+                    _code("print(1)", [_stdout("1")]),
+                ],
+                metadata={
+                    notebook_provenance.STAMP_KEY: {"production": True, "source_py_blob": "abc"},
+                    "papermill": {"parameters": {"MAX_SYMBOLS": 5}},
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+    notebook_provenance._cmd_clear(__import__("argparse").Namespace(notebooks=[str(nb)]))
+    written = json.loads(nb.read_text(encoding="utf-8"))
+    assert notebook_provenance.STAMP_KEY not in written["metadata"]
+    assert "papermill" not in written["metadata"]
+    assert not any(
+        "injected-parameters" in (c.get("metadata", {}).get("tags") or []) for c in written["cells"]
+    )
+    assert is_cleared(nb)

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -37,11 +37,11 @@ from notebook_provenance import (  # noqa: E402
     check_all,
     contradicts_injected_cell,
     destamped,
-    has_outputs,
     injected_parameters,
     is_cleared,
     production_parameters,
     stamp_notebook,
+    was_executed,
 )
 
 
@@ -641,21 +641,31 @@ def _stdout(text: str) -> dict:
     return {"output_type": "stream", "name": "stdout", "text": text}
 
 
-def test_a_notebook_with_outputs_has_outputs() -> None:
-    assert has_outputs(_notebook([_code("print(1)", [_stdout("1")])]))
+def test_a_notebook_with_outputs_was_executed() -> None:
+    assert was_executed(_notebook([_code("print(1)", [_stdout("1")])]))
 
 
-def test_a_notebook_whose_code_ran_nothing_has_no_outputs() -> None:
-    assert not has_outputs(_notebook([_code("print(1)")]))
+def test_a_notebook_whose_code_never_ran_was_not_executed() -> None:
+    assert not was_executed(_notebook([_code("print(1)")]))
+
+
+def test_a_silent_cell_with_an_execution_count_was_executed() -> None:
+    """A cell that only assigns or writes a file runs fine and displays nothing.
+
+    The kernel still stamps ``execution_count``, so the notebook is not hollow.
+    """
+    cell = _code("x = 1")
+    cell["execution_count"] = 3
+    assert was_executed(_notebook([cell]))
 
 
 def test_a_blank_code_cell_does_not_count_as_unexecuted_code() -> None:
     """jupytext leaves empty trailing cells; they must not make a live notebook hollow."""
-    assert has_outputs(_notebook([_code("print(1)", [_stdout("1")]), _code("   ")]))
+    assert was_executed(_notebook([_code("print(1)", [_stdout("1")]), _code("   ")]))
 
 
 def test_a_markdown_only_notebook_is_not_hollow() -> None:
-    assert has_outputs(_notebook([{"cell_type": "markdown", "source": "# hi", "metadata": {}}]))
+    assert was_executed(_notebook([{"cell_type": "markdown", "source": "# hi", "metadata": {}}]))
 
 
 def test_cleared_is_no_stamp_and_no_outputs(tmp_path) -> None:


### PR DESCRIPTION
The gate had no state in which a correction to an already-executed notebook could land. Editing the `.py` moved the source blob, so the committed `.ipynb` read STALE; dropping the stale stamp read DE-STAMPED; and clearing either one needed the production run that the uncommitted correction was itself a prerequisite for. Work therefore stopped at the commit and stayed in the worktree.

## What changes

Two states are legal at commit time.

- **Stamped and in sync** - checked exactly as before.
- **Cleared** - no stamp and no outputs. It asserts nothing about a run, so there is nothing for the gate to catch it lying about. `notebook_provenance.py clear <nb.ipynb>` puts a notebook in that state.

The loop is then linear: edit the `.py`, `jupytext --sync`, `clear`, commit, execute later, and the stamp and the checks come back with the outputs.

## What is now caught that was not

A stamp over a notebook showing no trace of a run - the render rebuilt from the `.py` and re-stamped without executing. That is HOLLOW and it fails. Evidence of a run is an output **or** a non-null `execution_count`, so a notebook whose cells only assign or write files is not mistaken for an empty one.

Three notebooks on `main` were already hollow: `us_firm_characteristics` 12, 13 and 14, stamped `production: True` on 2026-07-22 with no outputs and no execution counts across 28 code cells. Readers have been served empty notebooks that claim a production run. Cleared here - they are `todo` for execution either way, and now they do not claim otherwise.

Behaviour is unchanged for every notebook that keeps its outputs. `tests/test_notebook_sync.py`: 54 passed.