### PR TITLE
ci: stop enrolling us_equities_panel in the case-study matrix while its rebuild is descheduled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,8 +328,24 @@ jobs:
           if [[ "$all" == "true" ]] || [[ "${{ steps.filter.outputs.cs-sp500opt }}" == "true" ]]; then
             add_cs "sp500_options"
           fi
+          # us_equities_panel is DEFERRED and does not enroll, even on a push to
+          # main. It is the most expensive case study in the corpus - the runtime
+          # reference puts one tabular_dl configuration at 4.1 hours - and its
+          # rebuild is scheduled after the other eight complete. Until then its
+          # notebooks fail CI for reasons nobody is working on, which trains
+          # readers of this workflow to expect a red job and to stop reading it.
+          #
+          # A deferred case study must not also be a permanently red one. Enroll
+          # it again by deleting CS_DEFERRED below; nothing else needs changing,
+          # and the notice in the log names the condition so the skip cannot be
+          # forgotten silently.
+          CS_DEFERRED="us_equities_panel"
           if [[ "$all" == "true" ]] || [[ "${{ steps.filter.outputs.cs-usequity }}" == "true" ]]; then
-            add_cs "us_equities_panel"
+            if [[ " $CS_DEFERRED " == *" us_equities_panel "* ]]; then
+              echo "::notice title=us_equities_panel deferred::case-study job skipped by design while its rebuild is descheduled; re-enroll by clearing CS_DEFERRED in .github/workflows/test.yml"
+            else
+              add_cs "us_equities_panel"
+            fi
           fi
 
           echo "case_matrix=$cases" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`us_equities_panel` is descheduled: its rebuild costs more machine time than the
remaining eight case studies combined, and nobody is assigned to it. Its
case-study job has been red since the registry rebuild for that reason - it has
no rows - and it reports that failure on every push, on work that has nothing to
do with it.

This stops the job from being enrolled. It does not touch a test, a notebook or a
fixture: the defects stay exactly where they are, CI just stops reporting them
until someone is working on them again.

The skip is explicit rather than silent. `CS_DEFERRED` names the case study in
one place, and the matrix builder emits a GitHub notice saying the job was
skipped by design and how to reverse it, so a reader who wonders where the job
went finds the answer in the run itself:

    ::notice title=us_equities_panel deferred::case-study job skipped by design
    while its rebuild is descheduled; re-enroll by clearing CS_DEFERRED in
    .github/workflows/test.yml

Re-enrolling is deleting one word.