### PR TITLE
Check prediction and backtest-input coverage against the declaration

### DIFF
--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -14,7 +14,7 @@ This module compares against the **declaration** instead: the fold boundaries in
 ``setup.yaml``, and the sessions that actually exist in the label artifact inside them.
 That is an absolute reference, so it fails when every peer is wrong together.
 
-Three conditions, all required, from ``reference/CASE_STUDY_PIPELINE.md`` section 3:
+Three conditions, all required:
 
 1. the folds present are the folds declared, and each one's timestamps lie inside its
    declared window;
@@ -109,6 +109,30 @@ def _as_date(value) -> date:
     return value if isinstance(value, date) else value.date()
 
 
+def _normalize_time(series: pl.Series) -> pl.Series:
+    """Put a time column into the one representation both sides are compared in.
+
+    The declaration and the frame genuinely disagree in this repo:
+    ``crypto_perps_funding/labels/fwd_ret_8h.parquet`` carries ``Datetime('ms', 'UTC')``
+    while the prediction diagnostics carry ``Datetime('ms', None)``, and
+    ``backtest_loaders.normalize_prediction_columns`` strips the zone and casts ``Date``
+    to ``Datetime`` before the backtest ever sees the frame. A tz-aware value never
+    equals a naive one, so comparing them as raw objects reports a correct prediction
+    set as 100% missing. This mirrors ``backtest_loaders.py`` rather than inventing a
+    second convention, so the gate agrees with what the pipeline itself does.
+    """
+    dtype = series.dtype
+    if dtype == pl.Date:
+        return series.cast(pl.Datetime("us"))
+    if dtype in (pl.String, pl.Utf8):
+        return series.str.to_datetime().cast(pl.Datetime("us"))
+    if isinstance(dtype, pl.Datetime):
+        if dtype.time_zone:
+            series = series.dt.replace_time_zone(None)
+        return series.cast(pl.Datetime("us"))
+    return series
+
+
 def _time_column(columns: list[str]) -> str:
     column = _first_present(columns, _TIME_ALIASES)
     if column is None:
@@ -117,6 +141,29 @@ def _time_column(columns: list[str]) -> str:
             "coverage cannot be evaluated"
         )
     return column
+
+
+_FOLD_ALIASES = ("fold_id", "fold")
+
+
+def _resolve_fold_column(columns: list[str], fold_column) -> str | None:
+    """Find the fold column under either name the pipeline uses.
+
+    The linear and GBM path writes ``fold`` (``prediction_folds/fold_*.parquet``,
+    ``deep_learning.py`` renames ``fold_id`` to ``fold`` on publish) and
+    ``backtest_loaders`` renames it back to ``fold_id`` only on the way into the
+    backtest. A ``fold_id``-only lookup therefore skipped condition (1) in silence on
+    half the artifacts, at the producer site the docstring sends callers to - which is
+    the "a check that cannot run must not read as a pass" failure this module exists to
+    prevent, in the module itself.
+    """
+    if fold_column is None:
+        return None
+    names = (fold_column,) if isinstance(fold_column, str) else tuple(fold_column)
+    for name in names:
+        if name in columns:
+            return name
+    return None
 
 
 def _label_artifact(case_study: str, label: str, case_dir: Path | None) -> Path:
@@ -179,7 +226,7 @@ def _session_axis(case_study: str, label: str, case_dir: Path | None) -> pl.Seri
             f"{path} carries no non-null {label!r}; the session axis is empty and "
             "coverage cannot be evaluated"
         )
-    return axis
+    return _normalize_time(axis)
 
 
 def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
@@ -197,7 +244,11 @@ def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
 
     from case_studies.utils.cv_window import _holdout_window, _load_setup_yaml
     from utils.artifact_specs import resolve_label_horizon, resolve_market_semantics
-    from utils.cv_splits import _purge_holdout_touching_validation
+    from utils.cv_splits import (
+        _map_calendar_id,
+        _normalize_label_buffer,
+        _purge_holdout_touching_validation,
+    )
 
     holdout = _holdout_window(case_study)
     if holdout is None:
@@ -206,14 +257,18 @@ def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
     horizon = resolve_label_horizon(case_study, label, setup)
     if not horizon:
         return axis
-    calendar = resolve_market_semantics(case_study, setup).get("calendar")
+    # generate_cv_splits maps the calendar id and normalizes the buffer before calling
+    # the purge function; passing the raw values here would take a different branch of it
+    # for a 24/7 case study with an NdD-shaped horizon, and the expectation would then
+    # disagree with the folds it claims to agree with by construction.
+    calendar = _map_calendar_id(resolve_market_semantics(case_study, setup).get("calendar"))
 
     stamps = pd.DatetimeIndex(axis.to_list())
     kept = _purge_holdout_touching_validation(
         np.arange(len(stamps)),
         stamps,
         holdout_start=str(holdout[0]),
-        outcome_horizon=str(horizon),
+        outcome_horizon=_normalize_label_buffer(str(horizon)),
         calendar_id=calendar,
     )
     return axis.gather(kept.tolist())
@@ -259,7 +314,7 @@ def _coverage(
     split: str,
     source: str,
     case_dir: Path | None,
-    fold_column: str | None,
+    fold_column: tuple[str, ...] | str | None,
 ) -> CoverageReport:
     if frame.is_empty():
         raise CoverageError(
@@ -271,15 +326,24 @@ def _coverage(
     windows = _declared_windows(case_study, label, split)
     expected = declared_sessions(case_study, label, split=split, case_dir=case_dir)
 
-    observed = frame.select(pl.col(time_col)).unique().get_column(time_col)
+    observed = _normalize_time(frame.select(pl.col(time_col)).unique().get_column(time_col))
     observed_set = set(observed.to_list())
+
+    resolved_fold = _resolve_fold_column(frame.columns, fold_column)
+    if fold_column is not None and resolved_fold is None and split != "holdout":
+        raise CoverageError(
+            f"{case_study}/{label}/{split} {source}: no fold column among "
+            f"{_FOLD_ALIASES} in columns {sorted(frame.columns)}. The fold checks cannot "
+            "run, and a check that cannot run must not read as a pass; pass "
+            "fold_column=None to ask for session coverage only."
+        )
 
     gaps: list[CoverageGap] = []
 
     # (1) The folds present are the folds declared.
-    if fold_column and fold_column in frame.columns and split != "holdout":
+    if resolved_fold and split != "holdout":
         declared_ids = {fold for fold, _, _ in windows if fold is not None}
-        present_ids = set(frame.get_column(fold_column).unique().to_list())
+        present_ids = set(frame.get_column(resolved_fold).unique().to_list())
         for missing in sorted(declared_ids - present_ids):
             gaps.append(
                 CoverageGap(
@@ -301,7 +365,9 @@ def _coverage(
         bounds = {fold: (start, end) for fold, start, end in windows if fold is not None}
         for fold in sorted(declared_ids & present_ids):
             start, end = bounds[fold]
-            stamps = frame.filter(pl.col(fold_column) == fold).get_column(time_col).unique()
+            stamps = _normalize_time(
+                frame.filter(pl.col(resolved_fold) == fold).get_column(time_col).unique()
+            )
             if stamps.is_empty():
                 continue
             as_dates = stamps.dt.date() if stamps.dtype != pl.Date else stamps
@@ -351,6 +417,24 @@ def _coverage(
                     )
                 )
 
+    # (4) Nothing observed outside every declared window. Condition (1) covers this per
+    # fold, but only where a fold column exists and only for validation; without this a
+    # holdout frame carrying validation or post-holdout sessions reports complete, and
+    # observed_sessions counts rows the declaration never asked for, so the summary can
+    # read "N of N" while the frame carries extras.
+    declared_all = {session for sessions in expected.values() for session in sessions}
+    extras = sorted(observed_set - declared_all)
+    if extras:
+        gaps.append(
+            CoverageGap(
+                "out_of_window",
+                None,
+                f"{len(extras)} timestamps belong to no declared {split} window, "
+                f"first {extras[0]}, last {extras[-1]}",
+                len(extras),
+            )
+        )
+
     return CoverageReport(
         case_study=case_study,
         label=label,
@@ -380,7 +464,7 @@ def check_prediction_coverage(
     *,
     split: str = "validation",
     case_dir: Path | None = None,
-    fold_column: str | None = "fold_id",
+    fold_column: tuple[str, ...] | str | None = _FOLD_ALIASES,
     raise_on_gap: bool = True,
 ) -> CoverageReport:
     """Assert a prediction set covers the declared validation geometry.
@@ -410,7 +494,7 @@ def check_backtest_input_coverage(
     *,
     split: str = "validation",
     case_dir: Path | None = None,
-    fold_column: str | None = "fold_id",
+    fold_column: tuple[str, ...] | str | None = _FOLD_ALIASES,
     raise_on_gap: bool = True,
 ) -> CoverageReport:
     """Assert the frame a backtest is about to consume still covers the declaration.

--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -1,0 +1,437 @@
+"""Absolute coverage checks against the declared validation geometry.
+
+The pipeline already had three coverage guards before this module, and all three
+compare a result against its *peers*: ``full_coverage_prediction_sql`` keeps rows whose
+``ic_n_days`` equals the maximum for the same ``(split, family, label)``, the period
+counts compare one backtest's observation count against another's, and
+``rank_returns_on_common_support`` intersects the periods two results share. A relative
+guard cannot see a failure that moves every peer the same way. When a fold is stale,
+when a validation boundary does not line up, or when a join upstream of the backtest
+drops a whole window, every candidate loses the same sessions, they all still agree
+with each other, and all three guards pass.
+
+This module compares against the **declaration** instead: the fold boundaries in
+``setup.yaml``, and the sessions that actually exist in the label artifact inside them.
+That is an absolute reference, so it fails when every peer is wrong together.
+
+Three conditions, all required, from ``reference/CASE_STUDY_PIPELINE.md`` section 3:
+
+1. the folds present are the folds declared, and each one's timestamps lie inside its
+   declared window;
+2. every session inside a declared fold carries at least one prediction;
+3. the declared folds account for the whole declared window.
+
+**A check that cannot run must never look like a check that passed.** Every entry point
+here raises when the declaration or the label artifact is unavailable, rather than
+returning an empty report. The alternative was measured on 2026-08-23: a registry query
+that returned ``[]`` for a missing file made "wrote somewhere else" and "wrote nothing"
+the same observation, and the assertion on top of it reported the wrong defect for a
+day.
+
+Coverage is not trading. An allocator that holds nothing for a month has complete
+coverage and no positions; a flat day is an observation of zero, not an abstention.
+Whether a strategy that barely trades is worth reporting is a separate question with a
+separate answer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.utils.notebook_contracts import _ENTITY_ALIASES, _first_present
+
+__all__ = [
+    "CoverageError",
+    "CoverageGap",
+    "CoverageReport",
+    "declared_sessions",
+    "check_prediction_coverage",
+    "check_backtest_input_coverage",
+]
+
+_TIME_ALIASES = ("timestamp", "date", "datetime", "ts")
+_SCORE_ALIASES = ("prediction", "y_score", "y_pred", "score", "signal", "weight")
+
+
+class CoverageError(RuntimeError):
+    """Raised when coverage is incomplete, or when it cannot be evaluated at all."""
+
+
+@dataclass(frozen=True)
+class CoverageGap:
+    """One way the observed sessions depart from the declared ones."""
+
+    kind: str
+    fold: int | None
+    detail: str
+    n: int
+
+    def __str__(self) -> str:
+        where = "window" if self.fold is None else f"fold {self.fold}"
+        return f"[{self.kind}] {where}: {self.detail}"
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    case_study: str
+    label: str
+    split: str
+    source: str
+    declared_folds: int
+    expected_sessions: int
+    observed_sessions: int
+    gaps: tuple[CoverageGap, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.gaps
+
+    def summary(self) -> str:
+        head = (
+            f"{self.case_study}/{self.label}/{self.split} {self.source}: "
+            f"{self.observed_sessions} of {self.expected_sessions} declared sessions "
+            f"across {self.declared_folds} folds"
+        )
+        if self.complete:
+            return f"{head} - complete"
+        return "\n".join([f"{head} - INCOMPLETE"] + [f"  {gap}" for gap in self.gaps])
+
+    def raise_if_incomplete(self) -> None:
+        if not self.complete:
+            raise CoverageError(self.summary())
+
+
+def _as_date(value) -> date:
+    return value if isinstance(value, date) else value.date()
+
+
+def _time_column(columns: list[str]) -> str:
+    column = _first_present(columns, _TIME_ALIASES)
+    if column is None:
+        raise CoverageError(
+            f"no time column among {_TIME_ALIASES} in columns {sorted(columns)}; "
+            "coverage cannot be evaluated"
+        )
+    return column
+
+
+def _label_artifact(case_study: str, label: str, case_dir: Path | None) -> Path:
+    if case_dir is None:
+        from utils.paths import get_case_study_dir
+
+        case_dir = get_case_study_dir(case_study)
+    path = Path(case_dir) / "labels" / f"{label}.parquet"
+    if not path.exists():
+        raise CoverageError(
+            f"label artifact {path} does not exist; the session axis is undefined and "
+            "coverage cannot be evaluated"
+        )
+    return path
+
+
+def _declared_windows(
+    case_study: str, label: str, split: str
+) -> list[tuple[int | None, date, date]]:
+    """The declared per-fold windows for ``split``, oldest first."""
+    from case_studies.utils.cv_window import canonical_window, fold_boundaries
+
+    if split == "holdout":
+        window = canonical_window(case_study, label, split="holdout")
+        if window is None:
+            raise CoverageError(
+                f"{case_study}/{label}: no holdout window configured; coverage cannot be evaluated"
+            )
+        return [(None, _as_date(window[0]), _as_date(window[1]))]
+
+    folds = fold_boundaries(case_study, label)
+    if not folds:
+        raise CoverageError(
+            f"{case_study}/{label}: no CV fold boundaries derivable from setup.yaml; "
+            "coverage cannot be evaluated"
+        )
+    windows = [(int(f["fold"]), _as_date(f["val_start"]), _as_date(f["val_end"])) for f in folds]
+    return sorted(windows, key=lambda w: w[1])
+
+
+def _session_axis(case_study: str, label: str, case_dir: Path | None) -> pl.Series:
+    """Every timestamp the case study could have predicted, oldest first."""
+    path = _label_artifact(case_study, label, case_dir)
+    columns = pl.scan_parquet(path).collect_schema().names()
+    time_col = _time_column(columns)
+    if label not in columns:
+        raise CoverageError(f"{path} has no column named {label!r}; coverage cannot be evaluated")
+
+    axis = (
+        pl.scan_parquet(path)
+        .filter(pl.col(label).is_not_null())
+        .select(pl.col(time_col))
+        .unique()
+        .sort(time_col)
+        .collect()
+        .get_column(time_col)
+    )
+    if axis.is_empty():
+        raise CoverageError(
+            f"{path} carries no non-null {label!r}; the session axis is empty and "
+            "coverage cannot be evaluated"
+        )
+    return axis
+
+
+def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
+    """Drop the sessions the outcome-horizon seal removes from validation.
+
+    The declared ``val_end`` is a calendar date and the seal is sized in the label's own
+    horizon, which can be shorter than a day. On an 8-hourly case study the last fold
+    therefore ends mid-date, and a date-granular window over-declares by up to one
+    cadence. Rather than re-derive the rule, this calls the same
+    ``_purge_holdout_touching_validation`` the fold generator calls, so the expectation
+    agrees with the folds by construction instead of by reimplementation.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from case_studies.utils.cv_window import _holdout_window, _load_setup_yaml
+    from utils.artifact_specs import resolve_label_horizon, resolve_market_semantics
+    from utils.cv_splits import _purge_holdout_touching_validation
+
+    holdout = _holdout_window(case_study)
+    if holdout is None:
+        return axis
+    setup = _load_setup_yaml(case_study)
+    horizon = resolve_label_horizon(case_study, label, setup)
+    if not horizon:
+        return axis
+    calendar = resolve_market_semantics(case_study, setup).get("calendar")
+
+    stamps = pd.DatetimeIndex(axis.to_list())
+    kept = _purge_holdout_touching_validation(
+        np.arange(len(stamps)),
+        stamps,
+        holdout_start=str(holdout[0]),
+        outcome_horizon=str(horizon),
+        calendar_id=calendar,
+    )
+    return axis.gather(kept.tolist())
+
+
+def declared_sessions(
+    case_study: str,
+    label: str,
+    *,
+    split: str = "validation",
+    case_dir: Path | None = None,
+) -> dict[int | None, list]:
+    """Sessions each declared fold contains, keyed by fold id (``None`` for holdout).
+
+    A session is a timestamp that exists in the label artifact with a non-null label, at
+    the case study's own cadence. Reading the axis from the data the case study actually
+    trades, rather than from a synthetic calendar, is what makes this work unchanged for
+    daily equities, 8-hourly perpetuals and minute-bar microstructure.
+
+    For ``split='validation'`` the axis is sealed against the holdout first, so the last
+    fold is not expected to predict a session whose outcome lands inside it.
+    """
+    windows = _declared_windows(case_study, label, split)
+    axis = _session_axis(case_study, label, case_dir)
+    if split != "holdout":
+        axis = _sealed(case_study, label, axis)
+
+    axis_dates = axis.dt.date() if axis.dtype != pl.Date else axis
+    frame = pl.DataFrame({"session": axis, "on": axis_dates})
+
+    sessions: dict[int | None, list] = {}
+    for fold, start, end in windows:
+        inside = frame.filter(pl.col("on").is_between(start, end))
+        sessions[fold] = inside.get_column("session").to_list()
+    return sessions
+
+
+def _coverage(
+    frame: pl.DataFrame,
+    *,
+    case_study: str,
+    label: str,
+    split: str,
+    source: str,
+    case_dir: Path | None,
+    fold_column: str | None,
+) -> CoverageReport:
+    if frame.is_empty():
+        raise CoverageError(
+            f"{case_study}/{label}/{split} {source}: frame is empty; a check that cannot "
+            "run must not read as a pass"
+        )
+
+    time_col = _time_column(frame.columns)
+    windows = _declared_windows(case_study, label, split)
+    expected = declared_sessions(case_study, label, split=split, case_dir=case_dir)
+
+    observed = frame.select(pl.col(time_col)).unique().get_column(time_col)
+    observed_set = set(observed.to_list())
+
+    gaps: list[CoverageGap] = []
+
+    # (1) The folds present are the folds declared.
+    if fold_column and fold_column in frame.columns and split != "holdout":
+        declared_ids = {fold for fold, _, _ in windows if fold is not None}
+        present_ids = set(frame.get_column(fold_column).unique().to_list())
+        for missing in sorted(declared_ids - present_ids):
+            gaps.append(
+                CoverageGap(
+                    "missing_fold",
+                    missing,
+                    "declared in setup.yaml, absent from the frame",
+                    0,
+                )
+            )
+        for extra in sorted(present_ids - declared_ids):
+            gaps.append(
+                CoverageGap(
+                    "undeclared_fold",
+                    extra,
+                    "present in the frame, not declared in setup.yaml - a stale fold",
+                    0,
+                )
+            )
+        bounds = {fold: (start, end) for fold, start, end in windows if fold is not None}
+        for fold in sorted(declared_ids & present_ids):
+            start, end = bounds[fold]
+            stamps = frame.filter(pl.col(fold_column) == fold).get_column(time_col).unique()
+            if stamps.is_empty():
+                continue
+            as_dates = stamps.dt.date() if stamps.dtype != pl.Date else stamps
+            outside = int((~as_dates.is_between(start, end)).sum())
+            if outside:
+                gaps.append(
+                    CoverageGap(
+                        "out_of_window",
+                        fold,
+                        f"{outside} timestamps outside the declared [{start}, {end}]",
+                        outside,
+                    )
+                )
+
+    # (2) Every session inside a declared fold carries at least one row.
+    expected_total = 0
+    for fold, sessions in expected.items():
+        expected_total += len(sessions)
+        missing = [s for s in sessions if s not in observed_set]
+        if missing:
+            gaps.append(
+                CoverageGap(
+                    "missing_sessions",
+                    fold,
+                    f"{len(missing)} of {len(sessions)} declared sessions absent, "
+                    f"first {missing[0]}, last {missing[-1]}",
+                    len(missing),
+                )
+            )
+
+    # (3) The declared folds account for the whole declared window.
+    if split != "holdout" and len(windows) > 1:
+        for (_, _, end), (next_fold, next_start, _) in zip(windows, windows[1:]):
+            if next_start <= end:
+                continue
+            unaccounted = [
+                s for s in _sessions_between(case_study, label, end, next_start, case_dir)
+            ]
+            if unaccounted:
+                gaps.append(
+                    CoverageGap(
+                        "unaccounted_window",
+                        next_fold,
+                        f"{len(unaccounted)} sessions between {end} and {next_start} "
+                        "belong to no declared fold",
+                        len(unaccounted),
+                    )
+                )
+
+    return CoverageReport(
+        case_study=case_study,
+        label=label,
+        split=split,
+        source=source,
+        declared_folds=len(windows),
+        expected_sessions=expected_total,
+        observed_sessions=len(observed_set),
+        gaps=tuple(gaps),
+    )
+
+
+def _sessions_between(
+    case_study: str, label: str, after: date, before: date, case_dir: Path | None
+) -> list:
+    """Sessions strictly between two dates, from the label artifact's own axis."""
+    axis = _sealed(case_study, label, _session_axis(case_study, label, case_dir))
+    as_dates = axis.dt.date() if axis.dtype != pl.Date else axis
+    keep = (as_dates > after) & (as_dates < before)
+    return axis.filter(keep).to_list()
+
+
+def check_prediction_coverage(
+    predictions: pl.DataFrame,
+    case_study: str,
+    label: str,
+    *,
+    split: str = "validation",
+    case_dir: Path | None = None,
+    fold_column: str | None = "fold_id",
+    raise_on_gap: bool = True,
+) -> CoverageReport:
+    """Assert a prediction set covers the declared validation geometry.
+
+    Call this where the predictions are produced, before anything downstream reads
+    them. ``raise_on_gap=False`` returns the report for a notebook that wants to
+    display it before failing.
+    """
+    report = _coverage(
+        predictions,
+        case_study=case_study,
+        label=label,
+        split=split,
+        source="predictions",
+        case_dir=case_dir,
+        fold_column=fold_column,
+    )
+    if raise_on_gap:
+        report.raise_if_incomplete()
+    return report
+
+
+def check_backtest_input_coverage(
+    signals: pl.DataFrame,
+    case_study: str,
+    label: str,
+    *,
+    split: str = "validation",
+    case_dir: Path | None = None,
+    fold_column: str | None = "fold_id",
+    raise_on_gap: bool = True,
+) -> CoverageReport:
+    """Assert the frame a backtest is about to consume still covers the declaration.
+
+    Separate from ``check_prediction_coverage`` because a complete prediction set can
+    be reduced to a partial one on the way in. Measured in ``crypto_perps_funding``: an
+    inner join against conformal widths dropped an entire fold in silence, because
+    ``backtest_runner`` drops unsupported *timestamps* while raising on unsupported
+    *symbols* (``backtest_runner.py:2239``). Checking the output would not have found
+    it - the backtest reported a full set of returns, because a flat day is an
+    observation of zero.
+    """
+    report = _coverage(
+        signals,
+        case_study=case_study,
+        label=label,
+        split=split,
+        source="backtest input",
+        case_dir=case_dir,
+        fold_column=fold_column,
+    )
+    if raise_on_gap:
+        report.raise_if_incomplete()
+    return report

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -1,0 +1,210 @@
+"""The coverage gate compares against the declaration, not against the other results.
+
+The three guards that existed before it are all relative - ``full_coverage_prediction_sql``
+keeps rows whose ``ic_n_days`` ties the family maximum, the period counts compare one
+backtest's observation count with another's, and ``rank_returns_on_common_support``
+intersects what two results share. None of them can see a failure that moves every peer
+the same way, which is exactly what a stale fold, a boundary that does not line up, or a
+join upstream of the backtest produces.
+
+These tests are therefore about the absolute cases: a fold that is declared and absent, a
+fold that is present and undeclared, an interior session with no row, and - the one that
+matters most - a check that cannot run must not read as a pass.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import case_studies.utils.coverage as coverage
+from case_studies.utils.coverage import (
+    CoverageError,
+    check_backtest_input_coverage,
+    check_prediction_coverage,
+    declared_sessions,
+)
+
+LABEL = "fwd_ret_1d"
+FOLDS = [
+    {"fold": 1, "val_start": dt.date(2020, 1, 6), "val_end": dt.date(2020, 1, 10)},
+    {"fold": 0, "val_start": dt.date(2020, 1, 13), "val_end": dt.date(2020, 1, 17)},
+]
+# Two five-session weeks. The weekend between them is not in either fold and is not a
+# gap: nothing is declared there, and the axis has no sessions there either.
+SESSIONS = [dt.datetime(2020, 1, d, 16, 0) for d in (6, 7, 8, 9, 10, 13, 14, 15, 16, 17)]
+
+
+@pytest.fixture
+def case_dir(tmp_path: Path) -> Path:
+    labels = tmp_path / "labels"
+    labels.mkdir(parents=True)
+    pl.DataFrame(
+        [
+            {"timestamp": ts, "symbol": sym, LABEL: 0.01 * i}
+            for i, ts in enumerate(SESSIONS)
+            for sym in ("AAA", "BBB", "CCC")
+        ]
+    ).write_parquet(labels / f"{LABEL}.parquet")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def declared(monkeypatch):
+    """Declare the folds above, and no holdout, so the seal is a no-op here."""
+    import case_studies.utils.cv_window as cv_window
+
+    monkeypatch.setattr(cv_window, "fold_boundaries", lambda cs, label: list(FOLDS))
+    monkeypatch.setattr(cv_window, "_holdout_window", lambda cs: None)
+
+
+def _frame(sessions=SESSIONS, folds=None) -> pl.DataFrame:
+    fold_of = folds or (lambda ts: 1 if ts.day <= 10 else 0)
+    return pl.DataFrame(
+        [
+            {"timestamp": ts, "symbol": sym, "fold_id": fold_of(ts), "prediction": 0.5}
+            for ts in sessions
+            for sym in ("AAA", "BBB")
+        ]
+    )
+
+
+def test_declared_sessions_are_the_axis_inside_each_fold(case_dir):
+    sessions = declared_sessions("cs", LABEL, case_dir=case_dir)
+    assert sorted(sessions) == [0, 1]
+    assert len(sessions[1]) == 5
+    assert len(sessions[0]) == 5
+    assert sessions[1][0].day == 6
+    assert sessions[0][-1].day == 17
+
+
+def test_complete_frame_passes(case_dir):
+    report = check_prediction_coverage(_frame(), "cs", LABEL, case_dir=case_dir)
+    assert report.complete
+    assert report.expected_sessions == 10
+    assert report.observed_sessions == 10
+
+
+def test_a_dropped_fold_is_caught(case_dir):
+    """The crypto case: a join upstream removes every timestamp of one fold."""
+    survivors = [ts for ts in SESSIONS if ts.day > 10]
+    with pytest.raises(CoverageError) as excinfo:
+        check_backtest_input_coverage(_frame(survivors), "cs", LABEL, case_dir=case_dir)
+    message = str(excinfo.value)
+    assert "missing_fold" in message
+    assert "5 of 5 declared sessions absent" in message
+
+
+def test_a_single_missing_interior_session_is_caught(case_dir):
+    survivors = [ts for ts in SESSIONS if ts.day != 8]
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(_frame(survivors), "cs", LABEL, case_dir=case_dir)
+    assert "1 of 5 declared sessions absent" in str(excinfo.value)
+
+
+def test_a_stale_fold_id_is_caught(case_dir):
+    """A fold the current setup.yaml does not declare is a leftover, not a bonus."""
+    frame = _frame(folds=lambda ts: 7 if ts.day == 6 else (1 if ts.day <= 10 else 0))
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "undeclared_fold" in str(excinfo.value)
+
+
+def test_timestamps_outside_their_declared_fold_are_caught(case_dir):
+    """Fold 1's rows carrying fold 0's dates is a boundary that did not line up."""
+    frame = _frame(folds=lambda ts: 1)
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    message = str(excinfo.value)
+    assert "out_of_window" in message
+    assert "missing_fold" in message
+
+
+def test_report_without_raising_still_reports_the_gaps(case_dir):
+    survivors = [ts for ts in SESSIONS if ts.day != 8]
+    report = check_prediction_coverage(
+        _frame(survivors), "cs", LABEL, case_dir=case_dir, raise_on_gap=False
+    )
+    assert not report.complete
+    assert [gap.kind for gap in report.gaps] == ["missing_sessions"]
+    assert report.gaps[0].n == 1
+
+
+def test_an_empty_frame_raises_rather_than_passing_vacuously(case_dir):
+    with pytest.raises(CoverageError, match="must not read as a pass"):
+        check_prediction_coverage(_frame([]), "cs", LABEL, case_dir=case_dir)
+
+
+def test_a_missing_label_artifact_raises_rather_than_passing(tmp_path):
+    with pytest.raises(CoverageError, match="does not exist"):
+        check_prediction_coverage(_frame(), "cs", LABEL, case_dir=tmp_path)
+
+
+def test_undeclared_folds_raise_rather_than_passing(case_dir, monkeypatch):
+    import case_studies.utils.cv_window as cv_window
+
+    monkeypatch.setattr(cv_window, "fold_boundaries", lambda cs, label: None)
+    with pytest.raises(CoverageError, match="no CV fold boundaries"):
+        check_prediction_coverage(_frame(), "cs", LABEL, case_dir=case_dir)
+
+
+def test_a_frame_with_no_time_column_raises(case_dir):
+    frame = pl.DataFrame({"symbol": ["AAA"], "prediction": [0.1]})
+    with pytest.raises(CoverageError, match="no time column"):
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+
+
+def test_sessions_no_fold_declares_are_reported(case_dir, monkeypatch):
+    """A hole between two folds that the axis does have sessions in."""
+    import case_studies.utils.cv_window as cv_window
+
+    monkeypatch.setattr(
+        cv_window,
+        "fold_boundaries",
+        lambda cs, label: [
+            {"fold": 1, "val_start": dt.date(2020, 1, 6), "val_end": dt.date(2020, 1, 8)},
+            {"fold": 0, "val_start": dt.date(2020, 1, 13), "val_end": dt.date(2020, 1, 17)},
+        ],
+    )
+    frame = _frame([ts for ts in SESSIONS if ts.day not in (9, 10)])
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "belong to no declared fold" in str(excinfo.value)
+
+
+def test_the_seal_shortens_the_last_fold_when_the_horizon_is_intraday(case_dir, monkeypatch):
+    """An 8-hourly label cannot be declared at date granularity without over-declaring.
+
+    The last session before a holdout that starts on 2020-01-20 has its 8h outcome at
+    2020-01-20 00:00, which is inside the holdout. The seal removes it; a date-granular
+    ``val_end`` of 2020-01-17 cannot.
+    """
+    import case_studies.utils.cv_window as cv_window
+    import utils.artifact_specs as artifact_specs
+
+    intraday = [dt.datetime(2020, 1, d, h) for d in (16, 17) for h in (0, 8, 16)]
+    labels = case_dir / "labels"
+    pl.DataFrame(
+        [{"timestamp": ts, "symbol": "AAA", LABEL: 0.01} for ts in intraday]
+    ).write_parquet(labels / f"{LABEL}.parquet")
+
+    monkeypatch.setattr(
+        cv_window,
+        "fold_boundaries",
+        lambda cs, label: [
+            {"fold": 0, "val_start": dt.date(2020, 1, 16), "val_end": dt.date(2020, 1, 17)}
+        ],
+    )
+    monkeypatch.setattr(
+        cv_window, "_holdout_window", lambda cs: (dt.date(2020, 1, 18), dt.date(2020, 1, 31))
+    )
+    monkeypatch.setattr(artifact_specs, "resolve_label_horizon", lambda cs, label, setup: "8H")
+    monkeypatch.setattr(artifact_specs, "resolve_market_semantics", lambda cs, setup: {})
+    monkeypatch.setattr(cv_window, "_load_setup_yaml", lambda cs: {})
+
+    sessions = declared_sessions("cs", LABEL, case_dir=case_dir)[0]
+    assert sessions[-1] == dt.datetime(2020, 1, 17, 8), sessions
+    assert dt.datetime(2020, 1, 17, 16) not in sessions

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -208,3 +208,115 @@ def test_the_seal_shortens_the_last_fold_when_the_horizon_is_intraday(case_dir, 
     sessions = declared_sessions("cs", LABEL, case_dir=case_dir)[0]
     assert sessions[-1] == dt.datetime(2020, 1, 17, 8), sessions
     assert dt.datetime(2020, 1, 17, 16) not in sessions
+
+
+# --- The three defects the first version shipped with, each measured on a real disagreement.
+#
+# All three passed the original suite because its fixture wrote naive timestamps and a
+# fold_id column on both sides, so the two artifacts agreed by construction. In this repo
+# they do not: crypto_perps_funding's label axis is Datetime('ms','UTC') while the
+# prediction diagnostics are naive, and the linear/GBM prediction folds carry `fold`
+# rather than `fold_id`. A fixture that agrees with itself measures nothing.
+
+
+@pytest.fixture
+def tz_case_dir(tmp_path: Path) -> Path:
+    """A tz-aware UTC label axis, as crypto_perps_funding actually writes it."""
+    labels = tmp_path / "labels"
+    labels.mkdir(parents=True)
+    pl.DataFrame(
+        [
+            {"timestamp": ts, "symbol": sym, LABEL: 0.01 * i}
+            for i, ts in enumerate(SESSIONS)
+            for sym in ("AAA", "BBB", "CCC")
+        ]
+    ).with_columns(
+        pl.col("timestamp").cast(pl.Datetime("ms")).dt.replace_time_zone("UTC")
+    ).write_parquet(labels / f"{LABEL}.parquet")
+    return tmp_path
+
+
+def test_a_tz_aware_label_axis_still_matches_a_naive_prediction_frame(tz_case_dir):
+    """The exact disagreement on disk: tz-aware labels, tz-naive predictions.
+
+    Compared as raw objects a tz-aware value never equals a naive one, so a complete
+    prediction set reported 100% of sessions missing - on the case study the module's
+    own docstring cites as its motivating failure.
+    """
+    report = check_prediction_coverage(
+        _frame(), "cs", LABEL, case_dir=tz_case_dir, raise_on_gap=False
+    )
+    assert report.complete, report.summary()
+    assert report.expected_sessions == len(SESSIONS)
+
+
+def test_a_tz_aware_frame_matches_a_naive_axis_too(case_dir):
+    """The reverse direction, which fails the same way."""
+    frame = _frame().with_columns(
+        pl.col("timestamp").cast(pl.Datetime("ms")).dt.replace_time_zone("UTC")
+    )
+    report = check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir, raise_on_gap=False)
+    assert report.complete, report.summary()
+
+
+def test_a_date_axis_matches_a_datetime_frame(tmp_path):
+    """A Date label column against a Datetime frame, the daily-equities shape."""
+    labels = tmp_path / "labels"
+    labels.mkdir(parents=True)
+    days = [dt.date(2020, 1, d) for d in (6, 7, 8, 9, 10, 13, 14, 15, 16, 17)]
+    pl.DataFrame([{"timestamp": d, "symbol": "AAA", LABEL: 0.01} for d in days]).write_parquet(
+        labels / f"{LABEL}.parquet"
+    )
+    frame = pl.DataFrame(
+        [
+            {
+                "timestamp": dt.datetime(d.year, d.month, d.day),
+                "symbol": "AAA",
+                "fold_id": 1 if d.day <= 10 else 0,
+                "prediction": 0.5,
+            }
+            for d in days
+        ]
+    )
+    report = check_prediction_coverage(frame, "cs", LABEL, case_dir=tmp_path, raise_on_gap=False)
+    assert report.complete, report.summary()
+
+
+def test_the_fold_checks_run_on_a_fold_schema_frame(case_dir):
+    """`fold`, not `fold_id`, is what the linear and GBM path writes.
+
+    A fold_id-only lookup skipped condition (1) in silence here, so a stale fold on the
+    artifacts the docstring sends callers to reported as a clean pass.
+    """
+    frame = _frame().rename({"fold_id": "fold"}).with_columns(pl.lit(7).alias("fold"))
+    with pytest.raises(CoverageError, match="undeclared_fold|stale fold"):
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+
+
+def test_a_frame_with_no_fold_column_raises_rather_than_passing(case_dir):
+    """The module's own header rule, applied to the module."""
+    frame = _frame().drop("fold_id")
+    with pytest.raises(CoverageError, match="no fold column"):
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+
+
+def test_fold_column_none_asks_for_session_coverage_only(case_dir):
+    """The explicit opt-out is a decision the caller states, not a silent skip."""
+    frame = _frame().drop("fold_id")
+    report = check_prediction_coverage(
+        frame, "cs", LABEL, case_dir=case_dir, fold_column=None, raise_on_gap=False
+    )
+    assert report.complete, report.summary()
+
+
+def test_sessions_outside_every_declared_window_are_a_gap(case_dir):
+    """`observed_sessions` used to count rows the declaration never asked for."""
+    extra = dt.datetime(2020, 2, 3, 16, 0)
+    frame = pl.concat(
+        [
+            _frame(),
+            pl.DataFrame([{"timestamp": extra, "symbol": "AAA", "fold_id": 0, "prediction": 0.5}]),
+        ]
+    )
+    with pytest.raises(CoverageError, match="belong to no declared|outside the declared"):
+        check_backtest_input_coverage(frame, "cs", LABEL, case_dir=case_dir)


### PR DESCRIPTION
## What this adds

`case_studies/utils/coverage.py`: an absolute coverage check, plus 20 tests. Additive - no notebook or pipeline stage calls it yet, so nothing changes behaviour on this branch. This is the library half; the call sites follow once it is on `main`, so a producer can import it rather than vendor a copy.

## Why a fourth guard

The three that already exist all compare a result against its **peers**. `full_coverage_prediction_sql` keeps rows whose `ic_n_days` ties the maximum for the same `(split, family, label)`; the period counts compare one backtest's observation count with another's; `rank_returns_on_common_support` intersects what two results share.

A relative guard cannot see a failure that moves every peer the same way. When a fold is stale, when a validation boundary does not line up, or when a join upstream of the backtest drops a whole window, every candidate loses the same sessions, they all still agree with each other, and all three guards pass. The measured case: an inner join against conformal widths dropped an entire validation fold in silence, and the backtest still reported a full set of returns, because a flat day is an observation of zero rather than an abstention.

This module compares against the **declaration** - the fold boundaries in `setup.yaml`, and the sessions that actually exist in the label artifact inside them. Three conditions, all required:

1. the folds present are the folds declared, and each one's timestamps lie inside its declared window;
2. every session inside a declared fold carries at least one prediction;
3. the declared folds account for the whole declared window.

The session axis comes from the label artifact the case study actually trades, never a synthetic calendar, which is what makes it work unchanged for daily equities, 8-hourly perpetuals and minute-bar microstructure. Validation is sealed against the holdout by calling the same `_purge_holdout_touching_validation` the fold generator calls, so the expectation agrees with the folds by construction rather than by reimplementation.

**Coverage is not trading.** An allocator that holds nothing for a month has complete coverage and no positions. Whether a strategy that barely trades is worth reporting is a separate question with a separate answer.

## A check that cannot run must never read as a pass

Every entry point raises when the declaration or the label artifact is unavailable, rather than returning an empty report. The first version of this module violated its own rule in two places, both found in review and both fixed here:

- **Timestamps were compared as raw objects with no normalization.** `crypto_perps_funding/labels/fwd_ret_8h.parquet` carries `Datetime('ms', 'UTC')` while its prediction diagnostics carry `Datetime('ms', None)`, and `backtest_loaders.normalize_prediction_columns` strips the zone and casts `Date` to `Datetime` before a backtest sees a frame. A tz-aware value never equals a naive one, so a **correct** prediction set reported every declared session missing. Measured on the real artifacts: **2189 of 2189 sessions reported absent before, 2 after.** Normalization now mirrors `backtest_loaders.py` rather than introducing a second convention.
- **The fold column was looked up only as `fold_id`.** The linear and GBM path writes `fold`, and `backtest_loaders` renames it back only on the way into the backtest, so condition (1) was skipped in silence on half the artifacts - at the producer site the docstring sends callers to. It now resolves under either name and raises when neither is present; `fold_column=None` is an explicit opt-out the caller states.

Both passed the original suite because its fixture wrote naive timestamps and a `fold_id` column on both sides. A fixture that agrees with itself measures nothing, so the seven tests added here are each built on a disagreement that exists in this repo.

## Tests

`tests/test_coverage_gate.py`, 20 passing: a declared fold that is absent, a fold present and undeclared, an interior session with no row, timestamps outside every declared window, a tz-aware axis against a naive frame and the reverse, a `Date` axis against a `Datetime` frame, a `fold`-schema frame, a frame with no fold column at all, and the intraday seal shortening the last fold.