### PR TITLE
fix: scripts folder was not reachable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["utils", "data", "case_studies"]
+include = ["utils", "data", "case_studies", "scripts"]
 namespaces = false
 
 # Auto-loaded at interpreter startup to put numbered chapter dirs on sys.path


### PR DESCRIPTION
`pyproject.toml` contains the line

[tool.setuptools.packages.find]
include = ["utils", "data", "case_studies", "scripts"]

and `scripts` folder has an `__init__.py` file.

Referring to this [issue](https://github.com/stefan-jansen/machine-learning-for-trading/issues/593)