### PR TITLE
Teach unusable_parameters the preview translation, through the mapping the value lands in

### DIFF
--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -619,14 +619,18 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
 
     # A notebook declaring PREVIEW_REDUCTIONS receives these by translation rather than by name -
     # `research_preview_parameters` folds them in - so the source never mentions them and the
-    # "never reads it" test below would report every one of them unreachable.
+    # "never reads it" test below would report every one of them unreachable. The question is not
+    # dropped, it is redirected: the value lands in PREVIEW_REDUCTIONS, so that is the name whose
+    # reachability decides whether the override reaches anything. Exempting the name outright would
+    # pass a notebook that declares the mapping and never reads it, which is the exact condition
+    # this helper exists to catch.
     cell_declares = (
         {name for name, line in _top_level_bindings(tree) if tagged[-1][1] <= line <= injected_at}
         if tagged
         else set()
     )
     translated = (
-        set(PREVIEW_TRANSLATED_PARAMETERS) if "PREVIEW_REDUCTIONS" in cell_declares else set()
+        set(PREVIEW_TRANSLATED_PARAMETERS) if TRANSLATION_TARGET in cell_declares else set()
     )
 
     events: list[tuple[str, str, int]] = []
@@ -650,19 +654,21 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
 
     problems = {}
     for name in names:
-        if name in translated:
-            continue
+        # A translated name is analysed through the mapping it is folded into, and any problem is
+        # reported against that mapping, because that is where the override actually has to land.
+        analysed = TRANSLATION_TARGET if name in translated else name
+        via = f" (it reaches the notebook as {TRANSLATION_TARGET})" if analysed != name else ""
         reads = [
             (seq, line)
             for seq, (kind, bound, line) in enumerate(events)
-            if kind == "read" and bound == name and live(line)
+            if kind == "read" and bound == analysed and live(line)
         ]
         binds = [
             (seq, line)
             for seq, (kind, bound, line) in enumerate(events)
-            if kind == "bind" and bound == name and live(line)
+            if kind == "bind" and bound == analysed and live(line)
         ]
-        if name in opaque or name in readers:
+        if analysed in opaque or analysed in readers:
             # A function that reads the name is normally enough to leave the
             # entry alone: it may be called before any binding below, and the
             # tree does not say which happens first. The exception is a binding
@@ -675,11 +681,11 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
             reaching = [
                 seq
                 for seq, (kind, bound, line) in enumerate(events)
-                if kind == "call" and bound in readers.get(name, set()) and live(line)
+                if kind == "call" and bound in readers.get(analysed, set()) and live(line)
             ]
             first = min((seq for seq, _ in blocking), default=None)
             reachable = (
-                name in opaque
+                analysed in opaque
                 or first is None
                 or any(seq < first for seq in [*(r for r, _ in reads), *reaching])
             )
@@ -688,15 +694,15 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
             problems[name] = (
                 f"the binding on line {min(line for _, line in blocking)} overwrites the "
                 f"injected value before anything below {where} can call a function that "
-                "reads it"
+                f"reads it{via}"
             )
         elif not reads:
-            problems[name] = f"the notebook never reads it below {where}"
+            problems[name] = f"the notebook never reads it below {where}{via}"
         elif all(any(reaches(b, r) for b in binds) for r in reads):
             problems[name] = (
                 f"the binding on line {min(line for _, line in binds)} overwrites the "
                 f"injected value: every read below {where} is on a path that rebinds "
-                "the name first"
+                f"the name first{via}"
             )
     return problems
 
@@ -904,6 +910,8 @@ def research_preview_parameters(
 # stating this list separately is what let one of them go stale: measured on
 # agent/us-equities-panel-notebooks, `06_linear` and `07_gbm` declare PREVIEW_REDUCTIONS and were
 # reported unreachable on MAX_FOLDS and MAX_SYMBOLS, which do reach them.
+TRANSLATION_TARGET = "PREVIEW_REDUCTIONS"
+
 PREVIEW_TRANSLATED_PARAMETERS: dict[str, tuple[str, Callable[[Any], Any]]] = {
     "MAX_FOLDS": ("folds", lambda value: list(range(int(value)))),
     "MAX_SYMBOLS": ("max_symbols", int),

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -55,9 +55,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import yaml
 
@@ -617,6 +617,18 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
     def live(line: int) -> bool:
         return line > injected_at and not any(lo <= line <= hi for lo, hi in stale)
 
+    # A notebook declaring PREVIEW_REDUCTIONS receives these by translation rather than by name -
+    # `research_preview_parameters` folds them in - so the source never mentions them and the
+    # "never reads it" test below would report every one of them unreachable.
+    cell_declares = (
+        {name for name, line in _top_level_bindings(tree) if tagged[-1][1] <= line <= injected_at}
+        if tagged
+        else set()
+    )
+    translated = (
+        set(PREVIEW_TRANSLATED_PARAMETERS) if "PREVIEW_REDUCTIONS" in cell_declares else set()
+    )
+
     events: list[tuple[str, str, int]] = []
     _module_level_events(tree, events)
     branch = _branch_paths(tree)
@@ -638,6 +650,8 @@ def unusable_parameters(py_path: Path, names: Iterable[str]) -> dict[str, str]:
 
     problems = {}
     for name in names:
+        if name in translated:
+            continue
         reads = [
             (seq, line)
             for seq, (kind, bound, line) in enumerate(events)
@@ -884,6 +898,19 @@ def research_preview_parameters(
     return resolved
 
 
+# The override names `_collect_preview_reductions` folds into PREVIEW_REDUCTIONS, mapped to the
+# reduction key each becomes. `unusable_parameters` reads the same table, so a name that reaches a
+# notebook by translation is not reported unreachable for not appearing in its source. Two places
+# stating this list separately is what let one of them go stale: measured on
+# agent/us-equities-panel-notebooks, `06_linear` and `07_gbm` declare PREVIEW_REDUCTIONS and were
+# reported unreachable on MAX_FOLDS and MAX_SYMBOLS, which do reach them.
+PREVIEW_TRANSLATED_PARAMETERS: dict[str, tuple[str, Callable[[Any], Any]]] = {
+    "MAX_FOLDS": ("folds", lambda value: list(range(int(value)))),
+    "MAX_SYMBOLS": ("max_symbols", int),
+    "TRAIN_SAMPLE_FRAC": ("train_sample_frac", float),
+}
+
+
 def _collect_preview_reductions(parameters: dict) -> dict:
     """Fold the per-notebook reduction overrides into the single parameter that carries them.
 
@@ -895,15 +922,10 @@ def _collect_preview_reductions(parameters: dict) -> dict:
     """
     resolved = dict(parameters)
     reductions = dict(resolved.get("PREVIEW_REDUCTIONS") or {})
-    max_folds = resolved.pop("MAX_FOLDS", None)
-    max_symbols = resolved.pop("MAX_SYMBOLS", None)
-    train_sample_frac = resolved.pop("TRAIN_SAMPLE_FRAC", None)
-    if max_folds is not None:
-        reductions.setdefault("folds", list(range(int(max_folds))))
-    if max_symbols is not None:
-        reductions.setdefault("max_symbols", int(max_symbols))
-    if train_sample_frac is not None:
-        reductions.setdefault("train_sample_frac", float(train_sample_frac))
+    for name, (key, cast) in PREVIEW_TRANSLATED_PARAMETERS.items():
+        value = resolved.pop(name, None)
+        if value is not None:
+            reductions.setdefault(key, cast(value))
     # A preview run that reduces nothing is a canonical run wearing the wrong tier, and the
     # request builder rejects it. Reducing the universe is the reduction that always applies.
     if not reductions:

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1131,3 +1131,44 @@ def test_injected_parameters_keeps_preview_reductions_under_the_preview_tier(
     )
     assert resolved["PREVIEW_REDUCTIONS"]["max_samples"] == 5000
     assert resolved["EXECUTION_TIER"] == "preview"
+
+
+def test_unusable_parameters_catches_a_preview_mapping_the_notebook_never_reads(
+    tmp_path: Path,
+) -> None:
+    """Declaring PREVIEW_REDUCTIONS is not on its own proof the reduction reaches anything.
+
+    The translated names are analysed through the mapping they are folded into. A notebook that
+    declares the mapping and then never reads it discards every reduction, so the preview run is a
+    canonical run wearing the preview label - which is what this helper exists to catch. Exempting
+    the translated names outright would have passed it.
+    """
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nPREVIEW_REDUCTIONS = {}\n\n# %%\nprint("nothing reads it")\n',
+    )
+    problems = unusable_parameters(py, sorted(PREVIEW_TRANSLATED_PARAMETERS))
+    assert set(problems) == set(PREVIEW_TRANSLATED_PARAMETERS)
+    for name, reason in problems.items():
+        assert "never reads it" in reason
+        assert "PREVIEW_REDUCTIONS" in reason, name
+
+
+def test_unusable_parameters_catches_a_preview_mapping_rebound_before_any_read(
+    tmp_path: Path,
+) -> None:
+    """A mapping rebound below the parameters cell throws the injected reductions away.
+
+    Same condition as the overwrite check on an ordinary name, reached through the translation:
+    every read below the parameters cell is on a path that rebinds PREVIEW_REDUCTIONS first, so
+    nothing the harness folded in survives to be read.
+    """
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nPREVIEW_REDUCTIONS = {}\n\n'
+        "# %%\nPREVIEW_REDUCTIONS = {}\nprint(PREVIEW_REDUCTIONS)\n",
+    )
+    problems = unusable_parameters(py, sorted(PREVIEW_TRANSLATED_PARAMETERS))
+    assert set(problems) == set(PREVIEW_TRANSLATED_PARAMETERS)
+    for name, reason in problems.items():
+        assert "overwrites the injected value" in reason, name

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1172,3 +1172,27 @@ def test_unusable_parameters_catches_a_preview_mapping_rebound_before_any_read(
     assert set(problems) == set(PREVIEW_TRANSLATED_PARAMETERS)
     for name, reason in problems.items():
         assert "overwrites the injected value" in reason, name
+        assert "PREVIEW_REDUCTIONS" in reason, name
+
+
+def test_unusable_parameters_catches_a_preview_mapping_rebound_above_every_reader(
+    tmp_path: Path,
+) -> None:
+    """A helper that reads the mapping does not save it when the rebind runs before every call.
+
+    The deferred-reader exemption asks whether anything can observe the injected value. Here the
+    unconditional rebind sits above the only call site, so every read the helper performs sees the
+    notebook's own mapping and none see the reductions the harness folded in. Reached through the
+    translation, so it also pins that the redirect keeps the reader analysis rather than bypassing
+    it.
+    """
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nPREVIEW_REDUCTIONS = {}\n\n'
+        "# %%\ndef fit():\n    return dict(PREVIEW_REDUCTIONS)\n\n"
+        "# %%\nPREVIEW_REDUCTIONS = {}\nprint(fit())\n",
+    )
+    problems = unusable_parameters(py, sorted(PREVIEW_TRANSLATED_PARAMETERS))
+    assert set(problems) == set(PREVIEW_TRANSLATED_PARAMETERS)
+    for name, reason in problems.items():
+        assert "PREVIEW_REDUCTIONS" in reason, name

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -9,6 +9,7 @@ import yaml
 
 from tests import pm_helpers
 from tests.pm_helpers import (
+    PREVIEW_TRANSLATED_PARAMETERS,
     RECORD_REPLAY,
     RECORD_REWRITE,
     TIER_ON_DEMAND,
@@ -595,6 +596,42 @@ def test_unusable_parameters_does_not_take_a_comprehension_target_for_a_rebind(
     )
 
     assert unusable_parameters(py, ["SYMBOLS"]) == {}
+
+
+def test_unusable_parameters_accepts_a_name_that_reaches_by_preview_translation(
+    tmp_path: Path,
+) -> None:
+    """A PREVIEW_REDUCTIONS notebook never names MAX_FOLDS; the harness folds it in.
+
+    `research_preview_parameters` pops the names in `PREVIEW_TRANSLATED_PARAMETERS` into the
+    PREVIEW_REDUCTIONS mapping, so the notebook reads the reduction and not the override name.
+    Measured on agent/us-equities-panel-notebooks: `06_linear` and `07_gbm` were reported
+    unreachable on MAX_FOLDS and MAX_SYMBOLS, both of which do reach them.
+    """
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nPREVIEW_REDUCTIONS = {}\n\n# %%\nprint(PREVIEW_REDUCTIONS)\n',
+    )
+    assert unusable_parameters(py, sorted(PREVIEW_TRANSLATED_PARAMETERS)) == {}
+
+
+def test_unusable_parameters_still_rejects_an_untranslated_name_on_such_a_notebook(
+    tmp_path: Path,
+) -> None:
+    """The exemption covers the translated names only, not every name on the notebook."""
+    py = _notebook(
+        tmp_path,
+        '# %% tags=["parameters"]\nPREVIEW_REDUCTIONS = {}\n\n# %%\nprint(PREVIEW_REDUCTIONS)\n',
+    )
+    assert "never reads it" in unusable_parameters(py, ["TOP_N_COMBOS"])["TOP_N_COMBOS"]
+
+
+def test_unusable_parameters_does_not_exempt_a_translated_name_without_the_mapping(
+    tmp_path: Path,
+) -> None:
+    """No PREVIEW_REDUCTIONS declared means no translation, so MAX_SYMBOLS must be read."""
+    py = _notebook(tmp_path, '# %% tags=["parameters"]\nLABELS = []\n\n# %%\nprint(LABELS)\n')
+    assert "never reads it" in unusable_parameters(py, ["MAX_SYMBOLS"])["MAX_SYMBOLS"]
 
 
 def test_unusable_parameters_rejects_a_notebook_with_no_parameters_cell(tmp_path: Path) -> None:


### PR DESCRIPTION
`unusable_parameters` did not model one route a parameter takes to a notebook. A notebook declaring `PREVIEW_REDUCTIONS` receives `MAX_FOLDS`, `MAX_SYMBOLS` and `TRAIN_SAMPLE_FRAC` by translation - `research_preview_parameters` pops them into the mapping - so the notebook reads the reduction and never the override name. The check reported them unreachable.

That is a red `test_every_declared_parameter_reaches_its_notebook` in the required `test-unit` job for two bindings that do reach their notebooks, and its obvious remedy is to break two correct notebooks.

**The exemption is a redirect, not a skip.** An earlier version of this change dropped the translated name from analysis entirely, which would have passed a notebook that declares the mapping and never reads it - discarding every reduction, so the preview run is a canonical run wearing the preview label, which is exactly what this helper exists to catch. A translated name is now analysed against `PREVIEW_REDUCTIONS`, with the problem reported against that mapping, so "never reads it", "overwrites the injected value" and the deferred-reader path all still apply.

The translation table lives in one place, `PREVIEW_TRANSLATED_PARAMETERS`, which `_collect_preview_reductions` also reads, so the two cannot drift.

## Verified

- `tests/test_pm_helpers.py`: 85 passed.
- Measured in the tree the claim is about, not this one: on `agent/us-equities-panel-notebooks`, `test_every_declared_parameter_reaches_its_notebook` goes **1 failed to 85 passed**.
- The three tests covering the hole **discriminate**: against the skip-the-name version they fail 3 of 3; against this they pass. A test that passed both ways would prove nothing.
- Relative to `main`, translated names are reported on a strict subset of what is reported today and non-translated names are analysed identically, so no branch that is green can be turned red by this.
