### PR TITLE
Fix the fixture registry identity chain, and split the preview tier from workspace isolation

### DIFF
--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -446,7 +446,13 @@ def _upgrade_seeded_registry(cs_dir: Path) -> None:
                     n_folds,
                     n_folds,
                     json.dumps({"symbol": "String", "timestamp": "Date"}),
-                    _make_hash(f"artifact/{p_hash}"),
+                    # Empty, not NULL: prediction_coverage.artifact_digest is NOT NULL, and
+                    # under INSERT OR IGNORE a NULL silently drops the whole row rather
+                    # than raising - which is how the first version of this wrote zero
+                    # coverage rows and still passed a test asserting 23 of them.
+                    # `results.py:419` guards with `if recorded_digest:`, so "" reads as
+                    # "not recorded, backfill it" until the pass below fills it in.
+                    "",
                     "complete",
                 ),
             )
@@ -653,7 +659,13 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
                         2,
                         2,
                         json.dumps({"symbol": "String", "timestamp": "Date"}),
-                        _make_hash(f"artifact/{p_hash}"),
+                        # Empty, not NULL: prediction_coverage.artifact_digest is NOT NULL, and
+                        # under INSERT OR IGNORE a NULL silently drops the whole row rather
+                        # than raising - which is how the first version of this wrote zero
+                        # coverage rows and still passed a test asserting 23 of them.
+                        # `results.py:419` guards with `if recorded_digest:`, so "" reads as
+                        # "not recorded, backfill it" until the pass below fills it in.
+                        "",
                         "complete",
                     ),
                 )
@@ -863,6 +875,53 @@ def _subsampled_panel(frame, entity: str, entity_col: str, _pl):
         fold.alias("fold"),
         _pl.col("actual"),
     )
+
+
+def _record_prediction_artifact_digests(cs_dir: Path) -> None:
+    """Record the digest the artifact actually has, once the artifact exists.
+
+    `PredictionResult.complete` verifies `value_digest(...)` of the parquet against
+    `prediction_coverage.artifact_digest` (`research/results.py:419-423`), and that check is
+    stricter than the catalog's `complete` column - which reads `coverage.status` and stops
+    there. So a population can freeze cleanly from the catalog and be rejected by
+    `require_complete` one line later, which is what happened here: the fixture wrote a
+    fabricated 12-character `_make_hash` value where `value_digest` produces 16, so no
+    seeded prediction could ever match and every path reaching the stricter definition saw
+    `complete=False`.
+
+    Recording the real digest is better than recording none. `results.py:412-418` treats a
+    NULL as "legacy, backfill it" rather than as a conflict, so NULL would also have worked -
+    but it makes the fixture silent about its artifacts where it can be truthful about them,
+    and a later change that starts requiring the digest would find nothing recorded.
+
+    Runs after `_backfill_all_prediction_parquets`, because the digest cannot be computed
+    before the file it describes exists.
+    """
+    db_path = cs_dir / "run_log" / "registry.db"
+    if not db_path.exists():
+        return
+    import polars as pl
+
+    from case_studies.utils.artifact_digest import value_digest
+
+    with sqlite3.connect(str(db_path)) as db:
+        rows = db.execute(
+            "SELECT prediction_hash FROM prediction_coverage "
+            "WHERE artifact_digest IS NULL OR artifact_digest = ''"
+        ).fetchall()
+        for (p_hash,) in rows:
+            artifact = cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet"
+            if not artifact.is_file():
+                continue
+            try:
+                digest = value_digest(pl.read_parquet(artifact))
+            except Exception:
+                continue
+            db.execute(
+                "UPDATE prediction_coverage SET artifact_digest = ? WHERE prediction_hash = ?",
+                (digest, p_hash),
+            )
+        db.commit()
 
 
 def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
@@ -1436,6 +1495,7 @@ def seed_results(output_dir: Path, case_study_ids: list[str]) -> None:
         # Backfill prediction parquets for ALL hashes in registry
         # (must run AFTER _seed_registry_db, and also when registry was pre-seeded)
         _backfill_all_prediction_parquets(cs_dir, cs_id)
+        _record_prediction_artifact_digests(cs_dir)
 
         # Backfill daily_returns.parquet for ALL backtest hashes in registry
         # so downstream notebooks (e.g., 17/01_portfolio_metrics) that resolve a

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 import yaml
 
+from case_studies.utils.registry.specs import IDENTITY_VERSION
+from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
+
 REPO_ROOT = Path(__file__).parent.parent.parent
 CS_ROOT = REPO_ROOT / "case_studies"
 
@@ -391,7 +394,7 @@ def _add_cohort_metrics_table(db_path: Path) -> None:
 def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
     """Create a minimal registry.db with entries for all families and stages.
 
-    Schema matches utils/registry.py REGISTRY_SCHEMA_SQL exactly.
+    The schema IS REGISTRY_SCHEMA_SQL, executed directly, so it cannot drift from it.
     Creates entries that utils.case_study_analytics and utils.model_analysis
     can query without crashing.
     """
@@ -452,118 +455,13 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
     db = sqlite3.connect(str(db_path))
-    db.executescript("""
-        CREATE TABLE IF NOT EXISTS training_runs (
-            training_hash TEXT PRIMARY KEY, family TEXT NOT NULL,
-            label TEXT NOT NULL, config_name TEXT,
-            spec_json TEXT, created_at TEXT NOT NULL,
-            git_commit TEXT, entry_point TEXT
-        );
-        CREATE TABLE IF NOT EXISTS prediction_sets (
-            prediction_hash TEXT PRIMARY KEY,
-            training_hash TEXT NOT NULL REFERENCES training_runs(training_hash),
-            checkpoint_value INTEGER, checkpoint_kind TEXT,
-            split TEXT NOT NULL, created_at TEXT NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS prediction_metrics (
-            prediction_hash TEXT PRIMARY KEY REFERENCES prediction_sets(prediction_hash),
-            computed_at TEXT NOT NULL,
-            ic_mean REAL, ic_std REAL, ic_t REAL, n_folds REAL, n_obs REAL,
-            n_periods REAL, pct_positive REAL, task_type REAL,
-            accuracy REAL, balanced_accuracy REAL, auc_roc REAL, auc_pr REAL,
-            log_loss REAL, brier_score REAL
-        );
-        CREATE TABLE IF NOT EXISTS fold_metrics (
-            prediction_hash TEXT NOT NULL REFERENCES prediction_sets(prediction_hash),
-            fold_id INTEGER NOT NULL,
-            computed_at TEXT NOT NULL,
-            ic REAL, ic_std REAL, n_periods REAL, n_obs REAL, n_entities REAL,
-            rmse REAL, mae REAL,
-            accuracy REAL, balanced_accuracy REAL, auc_roc REAL, auc_pr REAL,
-            log_loss REAL, brier_score REAL,
-            PRIMARY KEY (prediction_hash, fold_id)
-        );
-        CREATE TABLE IF NOT EXISTS backtest_runs (
-            backtest_hash TEXT PRIMARY KEY,
-            prediction_hash TEXT NOT NULL REFERENCES prediction_sets(prediction_hash),
-            spec_json TEXT, stage TEXT, created_at TEXT NOT NULL, git_commit TEXT
-        );
-        CREATE TABLE IF NOT EXISTS backtest_metrics (
-            backtest_hash TEXT PRIMARY KEY REFERENCES backtest_runs(backtest_hash),
-            computed_at TEXT NOT NULL,
-            sharpe REAL, sortino REAL, total_return REAL, max_drawdown REAL,
-            cagr REAL, volatility REAL, calmar REAL, omega REAL, stability REAL,
-            tail_ratio REAL, win_rate REAL, kurtosis REAL, skewness REAL,
-            var_95 REAL, cvar_95 REAL, n_periods REAL,
-            num_trades REAL, total_commission REAL, total_slippage REAL, avg_turnover REAL
-        );
-        CREATE TABLE IF NOT EXISTS backtest_fold_metrics (
-            backtest_hash TEXT NOT NULL REFERENCES backtest_runs(backtest_hash),
-            fold_id INTEGER NOT NULL, metric TEXT NOT NULL,
-            value REAL, computed_at TEXT NOT NULL,
-            PRIMARY KEY (backtest_hash, fold_id, metric)
-        );
-        CREATE TABLE IF NOT EXISTS cohort_metrics (
-            cohort_type   TEXT NOT NULL,
-            stage         TEXT,
-            label         TEXT NOT NULL,
-            family        TEXT,
-            leader_hash   TEXT NOT NULL REFERENCES backtest_runs(backtest_hash),
-            k_variants                  INTEGER NOT NULL,
-            periods_per_year            REAL NOT NULL,
-            computed_at                 TEXT NOT NULL,
-            n_trials_effective_mp       REAL,
-            n_trials_effective_er       REAL,
-            dsr_raw                     REAL, dsr_raw_pvalue REAL,
-            expected_max_sharpe_raw     REAL, min_trl_periods_raw REAL,
-            dsr_mp                      REAL, dsr_mp_pvalue  REAL,
-            expected_max_sharpe_mp      REAL, min_trl_periods_mp  REAL,
-            dsr_er                      REAL, dsr_er_pvalue  REAL,
-            expected_max_sharpe_er      REAL, min_trl_periods_er  REAL,
-            ras_leader                  REAL,
-            ras_complexity              REAL,
-            ras_n_strategies            REAL,
-            ras_pvalue                  REAL,
-            reality_check_pvalue        REAL,
-            reality_check_statistic     REAL,
-            reality_check_k             REAL,
-            pbo                         REAL,
-            pbo_n_combinations          REAL,
-            pbo_median_oos_rank         REAL,
-            pbo_mean_degradation        REAL,
-            pbo_n_folds                 REAL,
-            leader_sharpe               REAL,
-            leader_sortino              REAL,
-            leader_min_trl              REAL
-        );
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_cohort_unique
-            ON cohort_metrics(cohort_type, COALESCE(stage, ''), label, COALESCE(family, ''));
-        CREATE INDEX IF NOT EXISTS idx_cohort_leader ON cohort_metrics(leader_hash);
-        CREATE TABLE IF NOT EXISTS backtest_paired_metrics (
-            challenger_hash       TEXT NOT NULL REFERENCES backtest_runs(backtest_hash),
-            benchmark_hash        TEXT NOT NULL,
-            benchmark_kind        TEXT,
-            periods_per_year      INTEGER,
-            bootstrap_block_length INTEGER,
-            bootstrap_n           INTEGER,
-            sharpe_diff           REAL,
-            sharpe_diff_ci95_lo   REAL,
-            sharpe_diff_ci95_hi   REAL,
-            ret_diff              REAL,
-            ret_diff_ci95_lo      REAL,
-            ret_diff_ci95_hi      REAL,
-            max_dd_diff           REAL,
-            max_dd_diff_ci95_lo   REAL,
-            max_dd_diff_ci95_hi   REAL,
-            info_ratio            REAL,
-            info_ratio_ci95_lo    REAL,
-            info_ratio_ci95_hi    REAL,
-            prob_challenger_wins  REAL,
-            p_value               REAL,
-            computed_at           TEXT NOT NULL,
-            PRIMARY KEY (challenger_hash, benchmark_hash)
-        );
-    """)
+    # The canonical schema itself, not a restatement of it. This block used to repeat
+    # nine CREATE TABLE statements under a docstring promising they matched
+    # REGISTRY_SCHEMA_SQL "exactly", with nothing checking that promise. They had
+    # drifted by thirteen tables - every research-boundary table, prediction_coverage
+    # among them - and by training_runs.identity_version, so a notebook on the research
+    # API resolved an empty catalog from a fixture that looked fully populated (#893).
+    db.executescript(REGISTRY_SCHEMA_SQL)
 
     # IC values per family (realistic ordering: gbm > linear > dl > others)
     ic_values = {
@@ -604,8 +502,9 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
                 spec = {"family": family, "config_name": config_name, "label": label}
                 db.execute(
                     """INSERT OR IGNORE INTO training_runs
-                       (training_hash, family, label, config_name, spec_json, created_at, git_commit, entry_point)
-                       VALUES (?,?,?,?,?,?,?,?)""",
+                       (training_hash, family, label, config_name, spec_json, created_at,
+                        git_commit, entry_point, identity_version, execution_tier)
+                       VALUES (?,?,?,?,?,?,?,?,?,?)""",
                     (
                         t_hash,
                         family,
@@ -615,6 +514,13 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
                         FIXTURE_TS,
                         "fixture",
                         "fixture",
+                        # Without this the catalog resolves every seeded row as "legacy"
+                        # and therefore incomplete, so a notebook that filters on the
+                        # current identity sees nothing. Reading IDENTITY_VERSION rather
+                        # than writing 3 means the fixture follows the next bump instead
+                        # of silently going legacy again the day it lands.
+                        IDENTITY_VERSION,
+                        "canonical",
                     ),
                 )
                 db.execute(
@@ -625,30 +531,61 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
                 )
                 db.execute(
                     """INSERT OR IGNORE INTO prediction_metrics
-                       (prediction_hash, computed_at, ic_mean, ic_std, n_folds, n_obs)
+                       (prediction_hash, computed_at, ic_mean, ic_std, ic_t, n_folds)
                        VALUES (?,?,?,?,?,?)""",
-                    (p_hash, FIXTURE_TS, ic, ic * 0.3, 2, 100),
+                    (p_hash, FIXTURE_TS, ic, ic * 0.3, ic / (ic * 0.3), 2),
                 )
                 # Fold metrics (2 folds) — wide format matching production schema
                 for fold_id in range(2):
                     fold_ic = ic + (0.002 if fold_id == 0 else -0.002)
                     db.execute(
                         """INSERT OR IGNORE INTO fold_metrics
-                           (prediction_hash, fold_id, computed_at, ic, ic_std, n_periods, n_obs, n_entities, rmse, mae)
-                           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                           (prediction_hash, fold_id, computed_at, ic, ic_std, n_entities, rmse, mae)
+                           VALUES (?,?,?,?,?,?,?,?)""",
                         (
                             p_hash,
                             fold_id,
                             FIXTURE_TS,
                             fold_ic,
                             fold_ic * 0.3,
-                            50,
-                            100,
                             5,
                             0.05,
                             0.03,
                         ),
                     )
+
+                # `complete` is a conjunction (research/catalog.py:308-313): current
+                # identity, a coverage row saying complete, a prediction_metrics row,
+                # fold_metrics matching n_folds_expected, and the artifact on disk. The
+                # fixture supplied three of the five, so every row read as partial. The
+                # two fold_metrics rows above are what n_folds_expected must equal; the
+                # digest is filled by _backfill_all_prediction_parquets, which writes
+                # the artifact.
+                db.execute(
+                    """INSERT OR IGNORE INTO prediction_coverage
+                       (prediction_hash, expected_key_digest, actual_key_digest,
+                        n_expected, n_actual, n_duplicates, n_missing, n_extra,
+                        n_null, n_non_finite, n_folds_expected, n_folds_actual,
+                        schema_json, artifact_digest, status)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (
+                        p_hash,
+                        _make_hash(f"keys/{p_hash}"),
+                        _make_hash(f"keys/{p_hash}"),
+                        100,
+                        100,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        2,
+                        2,
+                        json.dumps({"symbol": "String", "timestamp": "Date"}),
+                        _make_hash(f"artifact/{p_hash}"),
+                        "complete",
+                    ),
+                )
 
                 if label == primary_label and ic > best_ic:
                     best_ic = ic

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import yaml
 
 from case_studies.utils.registry.specs import IDENTITY_VERSION
-from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
+from case_studies.utils.registry.store import _open_registry
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 CS_ROOT = REPO_ROOT / "case_studies"
@@ -391,10 +391,75 @@ def _add_cohort_metrics_table(db_path: Path) -> None:
     db.close()
 
 
+def _upgrade_seeded_registry(cs_dir: Path) -> None:
+    """Bring a registry copied out of test-data up to the canonical schema and identity.
+
+    `_open_registry` is the function production uses to open any registry: it migrates
+    an old one, then runs REGISTRY_SCHEMA_SQL, then declares the uncertainty columns. So
+    the tables and columns a shipped registry lacks are added by the same code that
+    would add them in a real run, rather than by a copy of it that can drift.
+
+    What the schema cannot supply is the values. A registry written before
+    `identity_version` existed carries NULL there, which the catalog reads as "legacy"
+    and therefore never complete, and it has no coverage row at all. Both are backfilled
+    here for rows that lack them, and only for those - a row that already records its
+    identity is left alone.
+    """
+    db = _open_registry(cs_dir)
+    try:
+        db.execute(
+            "UPDATE training_runs SET identity_version = ? WHERE identity_version IS NULL",
+            (IDENTITY_VERSION,),
+        )
+        db.execute(
+            "UPDATE training_runs SET execution_tier = 'canonical' WHERE execution_tier IS NULL"
+        )
+        uncovered = db.execute(
+            """SELECT p.prediction_hash, COUNT(f.fold_id)
+               FROM prediction_sets p
+               LEFT JOIN fold_metrics f ON f.prediction_hash = p.prediction_hash
+               WHERE p.prediction_hash NOT IN (SELECT prediction_hash FROM prediction_coverage)
+               GROUP BY p.prediction_hash"""
+        ).fetchall()
+        for p_hash, n_folds in uncovered:
+            # n_folds_expected must equal the fold_metrics rows actually present: the
+            # catalog compares the two, so a constant here would mark a row incomplete
+            # for the opposite reason.
+            db.execute(
+                """INSERT OR IGNORE INTO prediction_coverage
+                   (prediction_hash, expected_key_digest, actual_key_digest,
+                    n_expected, n_actual, n_duplicates, n_missing, n_extra,
+                    n_null, n_non_finite, n_folds_expected, n_folds_actual,
+                    schema_json, artifact_digest, status)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    p_hash,
+                    _make_hash(f"keys/{p_hash}"),
+                    _make_hash(f"keys/{p_hash}"),
+                    100,
+                    100,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    n_folds,
+                    n_folds,
+                    json.dumps({"symbol": "String", "timestamp": "Date"}),
+                    _make_hash(f"artifact/{p_hash}"),
+                    "complete",
+                ),
+            )
+        db.commit()
+    finally:
+        db.close()
+
+
 def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
     """Create a minimal registry.db with entries for all families and stages.
 
-    The schema IS REGISTRY_SCHEMA_SQL, executed directly, so it cannot drift from it.
+    The schema comes from `_open_registry`, the function production uses, so it cannot
+    drift from the canonical one.
     Creates entries that utils.case_study_analytics and utils.model_analysis
     can query without crashing.
     """
@@ -427,7 +492,14 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
             )
 
             if has_core and has_all_tables and bm_wide and fm_wide and pm_wide:
-                return  # Fully current schema — don't overwrite
+                # NOT a return. "Fully current" here is five hand-picked columns, and
+                # every one of the nine registries shipped in test-data satisfies all
+                # five while missing thirteen tables and two columns. Returning on that
+                # check is why #893's first fix changed nothing: the canonical DDL below
+                # is only reached when no registry was copied in, which is not the path
+                # conftest takes. Bring the copied registry up to schema instead.
+                _upgrade_seeded_registry(cs_dir)
+                return
 
             # Schema present but missing cohort_metrics — add it without
             # rebuilding the entire registry (preserves seeded rows).
@@ -454,14 +526,13 @@ def _seed_registry_db(cs_dir: Path, cs_id: str, primary_label: str) -> None:
             db_path.unlink(missing_ok=True)
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    db = sqlite3.connect(str(db_path))
+    db = _open_registry(cs_dir)
     # The canonical schema itself, not a restatement of it. This block used to repeat
     # nine CREATE TABLE statements under a docstring promising they matched
     # REGISTRY_SCHEMA_SQL "exactly", with nothing checking that promise. They had
     # drifted by thirteen tables - every research-boundary table, prediction_coverage
     # among them - and by training_runs.identity_version, so a notebook on the research
     # API resolved an empty catalog from a fixture that looked fully populated (#893).
-    db.executescript(REGISTRY_SCHEMA_SQL)
 
     # IC values per family (realistic ordering: gbm > linear > dl > others)
     ic_values = {

--- a/tests/notebook_worker.py
+++ b/tests/notebook_worker.py
@@ -167,7 +167,7 @@ def main() -> None:
             sync_policy=args.sync_policy,
         )
     else:
-        from tests.pm_helpers import run_notebook
+        from tests.pm_helpers import REPO_ROOT, get_overrides, run_notebook
 
         result = run_notebook(
             py_path=path,
@@ -176,7 +176,12 @@ def main() -> None:
             output_dir=output_dir,
             data_dir=data_dir,
             extra_env=extra_env,
-            research_preview=True,
+            # Same rule as tests/test_case_studies.py: a notebook that only READS at
+            # the tier it is handed cannot run preview in a fresh workspace, because
+            # nothing wrote preview rows there. overrides.yaml decides per notebook.
+            research_preview=get_overrides(str(path.relative_to(REPO_ROOT).with_suffix(""))).get(
+                "research_preview", True
+            ),
         )
     elapsed = time.perf_counter() - started
 

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -23,8 +23,11 @@ overrides.yaml schema (per-notebook, all optional):
         way the test runs at production scale while this file states a reduction.
         ``unusable_parameters`` is the detector and tests/test_pm_helpers.py
         fails the build on what it finds, with no allowlist.
-    research_preview: bool — default true. The harness runs a notebook that declares
-        both EXECUTION_TIER and WORKSPACE at the preview tier in a fresh workspace,
+    research_preview: bool — default true. Chooses the TIER only; the isolated
+        workspace is injected either way, and there is deliberately no way to ask the
+        harness for the in-place production path. The harness runs a notebook that
+        declares both EXECUTION_TIER and WORKSPACE at the preview tier in a fresh
+        workspace,
         because that pair means "this notebook can run self-contained at reduced
         scale". That is exact for a notebook that WRITES at the tier it is given: a
         model notebook fits something small and registers it into the workspace it
@@ -32,9 +35,12 @@ overrides.yaml schema (per-notebook, all optional):
         that only READS at that tier - it is self-contained only if its producer ran
         into the same workspace, and the per-notebook suite runs each notebook alone,
         so it filters for preview rows nobody wrote and stops at its first cell. Set
-        this false for a reader, and it runs against the canonical rows the fixture
-        seeds, which is real coverage rather than a skip. Do NOT instead seed
-        preview-tier rows: that fabricates predictions at a tier nothing fitted.
+        this false for a reader, and it runs at its declared tier, in an isolated
+        workspace, against the canonical rows the fixture seeds - the third combination
+        `open_study`'s docstring names, "the same computation at full scale writing to an
+        isolated registry ... without being able to damage" the published one. Real
+        coverage rather than a skip. Do NOT instead seed preview-tier rows: that
+        fabricates predictions at a tier nothing fitted.
     skip: bool — hard skip in uv-native run (Docker tests ignore)
     skip_reason: str
     requires_import: str | list[str]
@@ -885,6 +891,30 @@ def register_kernelspec(python_exe: str, launcher: Path | None = None) -> tuple[
     return kernel_name, root
 
 
+def _declares_tier_and_workspace(py_path: Path) -> bool:
+    """Whether a notebook's parameters cell declares both EXECUTION_TIER and WORKSPACE.
+
+    The pair is what makes a notebook addressable by tier and workspace at all. It is read
+    here rather than inside `research_preview_parameters` because both the preview path and
+    the canonical-with-a-workspace path need the same answer.
+    """
+    source = py_path.read_text(encoding="utf-8")
+    bounds = next(
+        (
+            (first_line, last_line)
+            for header, first_line, last_line in _percent_cell_bounds(source)
+            if PARAMETERS_CELL_MARKER in header
+        ),
+        None,
+    )
+    if bounds is None:
+        return False
+    first_line, last_line = bounds
+    tree = ast.parse(source, filename=str(py_path))
+    declared = {name for name, line in _top_level_bindings(tree) if first_line <= line <= last_line}
+    return {"EXECUTION_TIER", "WORKSPACE"} <= declared
+
+
 def research_preview_parameters(
     py_path: Path,
     parameters: dict | None,
@@ -971,9 +1001,25 @@ def injected_parameters(
     """
     if research_preview:
         return research_preview_parameters(py_path, parameters, output_dir)
-    if parameters and "PREVIEW_REDUCTIONS" in parameters:
-        return {k: v for k, v in parameters.items() if k != "PREVIEW_REDUCTIONS"}
-    return parameters
+    resolved = dict(parameters or {})
+    resolved.pop("PREVIEW_REDUCTIONS", None)
+    # Declining the preview tier must NOT decline the isolated workspace. They are two
+    # decisions and this flag used to collapse them: false left WORKSPACE at the
+    # notebook's declared "", `open_study` took the `workspace=None` branch
+    # (workspace.py:374) into `Study.regenerate`, and that is the in-place production
+    # path - which in a maintainer worktree, where case_studies/*/run_log links to the
+    # shared artifacts, writes to the real registry. It also calls activate(), resetting
+    # ML4T_OUTPUT_DIR for everything after it. Measured 2026-08-24: a test run of
+    # fx_pairs 13-16 wrote 13 official populations, 1 candidate set and 269 backtest runs
+    # into the published fx_pairs registry, and froze one population incomplete.
+    #
+    # Canonical-tier-with-a-workspace is the third combination `open_study`'s own
+    # docstring names: the same computation at full scale against an isolated registry,
+    # unable to damage the published one. That is what a reader under test needs, and the
+    # harness must never be able to reach the in-place path.
+    if output_dir is not None and _declares_tier_and_workspace(py_path):
+        resolved["WORKSPACE"] = str(output_dir.resolve())
+    return resolved or None
 
 
 def run_notebook(

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -23,6 +23,18 @@ overrides.yaml schema (per-notebook, all optional):
         way the test runs at production scale while this file states a reduction.
         ``unusable_parameters`` is the detector and tests/test_pm_helpers.py
         fails the build on what it finds, with no allowlist.
+    research_preview: bool — default true. The harness runs a notebook that declares
+        both EXECUTION_TIER and WORKSPACE at the preview tier in a fresh workspace,
+        because that pair means "this notebook can run self-contained at reduced
+        scale". That is exact for a notebook that WRITES at the tier it is given: a
+        model notebook fits something small and registers it into the workspace it
+        was handed, so it needs nothing else to be there. It is wrong for a notebook
+        that only READS at that tier - it is self-contained only if its producer ran
+        into the same workspace, and the per-notebook suite runs each notebook alone,
+        so it filters for preview rows nobody wrote and stops at its first cell. Set
+        this false for a reader, and it runs against the canonical rows the fixture
+        seeds, which is real coverage rather than a skip. Do NOT instead seed
+        preview-tier rows: that fabricates predictions at a tier nothing fitted.
     skip: bool — hard skip in uv-native run (Docker tests ignore)
     skip_reason: str
     requires_import: str | list[str]

--- a/tests/test_case_studies.py
+++ b/tests/test_case_studies.py
@@ -152,7 +152,7 @@ def test_case_study_pipeline(
         timeout=timeout,
         output_dir=seeded_output_dir,
         data_dir=populated_data_dir,
-        research_preview=True,
+        research_preview=overrides.get("research_preview", True),
     )
 
     if result["status"] == "error":

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -84,3 +84,44 @@ def test_training_runs_follow_the_current_identity_version(seeded: Path) -> None
     with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
         versions = {r[0] for r in db.execute("SELECT identity_version FROM training_runs")}
     assert versions == {IDENTITY_VERSION}
+
+
+def test_declining_the_preview_tier_suppresses_the_injection(tmp_path) -> None:
+    """`research_preview=False` must suppress the tier injection, not merely be accepted.
+
+    This covers the helper contract only. It passes with or without the two call sites
+    that read `overrides["research_preview"]`, which was true when it was first written
+    under a name claiming otherwise - the same vacuity this branch exists to remove. The
+    call sites are a one-line pass-through whose effect shows up as fx_pairs 13-16
+    executing; there is no seam to assert it at without running a notebook.
+
+    The harness injects the preview tier for any notebook declaring both
+    `EXECUTION_TIER` and `WORKSPACE`. That pair means "this runs self-contained at
+    reduced scale", which is true of a notebook that WRITES at the tier it is handed
+    and false of one that only READS at it: the reader is self-contained only if its
+    producer ran into the same workspace, and the per-notebook suite runs each
+    notebook alone. Without the opt-out such a notebook filters for preview rows
+    nothing wrote and stops at its first cell.
+    """
+    from tests.pm_helpers import injected_parameters
+
+    py_path = tmp_path / "13_backtest.py"
+    py_path.write_text(
+        '# %% tags=["parameters"]\n'
+        'CASE_STUDY_ID = "fx_pairs"\n'
+        'EXECUTION_TIER = "canonical"\n'
+        'WORKSPACE: str = ""\n'
+        "\n"
+        "# %%\n"
+        "print(EXECUTION_TIER)\n"
+    )
+
+    injected = injected_parameters(py_path, {}, tmp_path, research_preview=True)
+    assert injected["EXECUTION_TIER"] == "preview", (
+        "the pair must still opt a producer into the preview tier; if this stops "
+        "holding, the opt-out below is measuring nothing"
+    )
+
+    declined = injected_parameters(py_path, {}, tmp_path, research_preview=False) or {}
+    assert "EXECUTION_TIER" not in declined
+    assert "WORKSPACE" not in declined

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -1,18 +1,26 @@
-"""The seeded registry must be usable by a notebook on the research API.
+"""A seeded registry must be usable by a notebook on the research API.
 
-Before #893 the fixture wrote its own nine-table copy of the registry schema under a
-docstring promising it matched `REGISTRY_SCHEMA_SQL` "exactly". Nothing checked that
-promise, and it had drifted by thirteen tables and two columns. Every seeded prediction
-resolved as `identity_status="legacy"` and `complete=False`, so any rebuilt notebook
-filtering on the current identity read an empty catalog and stopped at its first cell -
-against a fixture that looked fully populated.
+Two defects, one behind the other, both invisible.
 
-These tests fail against that fixture and pass against the canonical schema.
+The seeder wrote its own nine-table copy of the registry DDL under a docstring
+promising it matched `REGISTRY_SCHEMA_SQL` "exactly". Nothing checked that promise and
+it had drifted by thirteen tables and two columns.
+
+Fixing that alone changed nothing on the path the suite takes, because `conftest` copies
+a registry out of `test-data` before `seed_results` runs, and `_seed_registry_db` then
+returned early on a five-column "fully current schema" check. All nine shipped
+registries satisfy those five columns while missing the same thirteen tables, so the
+corrected DDL was never reached.
+
+**These tests therefore exercise the copied registry, not a fresh one.** A test that
+seeds into an empty directory passes against both the broken and the fixed seeder, which
+is how the first fix was measured as working when it was not.
 """
 
 from __future__ import annotations
 
 import re
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -24,36 +32,55 @@ from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
 from tests.fixtures.seed_results import seed_results
 
 CASE_STUDY = "fx_pairs"
+SHIPPED = Path.home() / "ml4t" / "test-data" / "intermediates"
 
 
 @pytest.fixture(scope="module")
 def seeded(tmp_path_factory) -> Path:
+    """Reproduce conftest's order: copy the shipped intermediates, then seed."""
+    src = SHIPPED / CASE_STUDY
+    if not (src / "run_log" / "registry.db").is_file():
+        pytest.skip(f"no shipped registry at {src}")
     root = tmp_path_factory.mktemp("seed893")
+    shutil.copytree(src, root / CASE_STUDY)
     seed_results(root, [CASE_STUDY])
     return root / CASE_STUDY
 
 
-def test_seeded_predictions_are_usable_by_the_research_catalog(seeded: Path) -> None:
-    """The end-to-end symptom: a rebuilt notebook resolves rows it can actually use."""
-    frame = _frame(_registry_rows(seeded, "workspace"))
-    assert frame.height > 0, "the fixture seeded no prediction rows at all"
-    assert frame["identity_status"].unique().to_list() == ["current"]
-    assert frame.filter(frame["complete"]).height == frame.height, (
-        "every seeded row must be complete; a partial row is what made the catalog "
-        "look empty to a notebook filtering on it"
+def test_the_shipped_registry_is_the_one_under_test(seeded: Path) -> None:
+    """Guard the guard: if this stops being the copied registry, the rest proves nothing."""
+    with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
+        n_folds = db.execute("SELECT COUNT(*) FROM fold_metrics").fetchone()[0]
+    # fold_metrics is what separates the two registries. The shipped fx_pairs one holds
+    # 2099 rows; a fresh seed writes exactly two per prediction, so a few dozen. Row
+    # counts in training_runs do not separate them - the shipped registry has 19 - which
+    # is why this asserts on the table that does.
+    assert n_folds > 1000, (
+        f"only {n_folds} fold_metrics rows: this is a freshly seeded registry, not the "
+        "one shipped in test-data, so these tests are measuring the wrong path"
     )
 
 
-def test_the_fixture_registry_carries_every_canonical_table(seeded: Path) -> None:
-    """Drift is what caused #893, so the test is on the schema, not on one column."""
+def test_seeded_predictions_are_usable_by_the_research_catalog(seeded: Path) -> None:
+    """The end-to-end symptom a rebuilt notebook hits at its first executable cell."""
+    frame = _frame(_registry_rows(seeded, "workspace"))
+    assert frame.height > 0, "the registry resolved no prediction rows at all"
+    assert frame["identity_status"].unique().to_list() == ["current"]
+    assert frame.filter(frame["complete"]).height == frame.height, (
+        "every row must be complete; a partial row is what made the catalog look empty"
+    )
+
+
+def test_the_registry_carries_every_canonical_table(seeded: Path) -> None:
+    """Drift caused this, so the assertion is on the schema, not on one column."""
     expected = set(re.findall(r"CREATE TABLE IF NOT EXISTS (\w+)", REGISTRY_SCHEMA_SQL))
     with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
         actual = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-    assert expected <= actual, f"missing from the seeded registry: {sorted(expected - actual)}"
+    assert expected <= actual, f"missing: {sorted(expected - actual)}"
 
 
-def test_seeded_training_runs_follow_the_current_identity_version(seeded: Path) -> None:
+def test_training_runs_follow_the_current_identity_version(seeded: Path) -> None:
     """Reading the constant is what makes the fixture survive the next bump."""
     with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
-        versions = {row[0] for row in db.execute("SELECT identity_version FROM training_runs")}
+        versions = {r[0] for r in db.execute("SELECT identity_version FROM training_runs")}
     assert versions == {IDENTITY_VERSION}

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -1,0 +1,59 @@
+"""The seeded registry must be usable by a notebook on the research API.
+
+Before #893 the fixture wrote its own nine-table copy of the registry schema under a
+docstring promising it matched `REGISTRY_SCHEMA_SQL` "exactly". Nothing checked that
+promise, and it had drifted by thirteen tables and two columns. Every seeded prediction
+resolved as `identity_status="legacy"` and `complete=False`, so any rebuilt notebook
+filtering on the current identity read an empty catalog and stopped at its first cell -
+against a fixture that looked fully populated.
+
+These tests fail against that fixture and pass against the canonical schema.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from case_studies.research.catalog import _frame, _registry_rows
+from case_studies.utils.registry.specs import IDENTITY_VERSION
+from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
+from tests.fixtures.seed_results import seed_results
+
+CASE_STUDY = "fx_pairs"
+
+
+@pytest.fixture(scope="module")
+def seeded(tmp_path_factory) -> Path:
+    root = tmp_path_factory.mktemp("seed893")
+    seed_results(root, [CASE_STUDY])
+    return root / CASE_STUDY
+
+
+def test_seeded_predictions_are_usable_by_the_research_catalog(seeded: Path) -> None:
+    """The end-to-end symptom: a rebuilt notebook resolves rows it can actually use."""
+    frame = _frame(_registry_rows(seeded, "workspace"))
+    assert frame.height > 0, "the fixture seeded no prediction rows at all"
+    assert frame["identity_status"].unique().to_list() == ["current"]
+    assert frame.filter(frame["complete"]).height == frame.height, (
+        "every seeded row must be complete; a partial row is what made the catalog "
+        "look empty to a notebook filtering on it"
+    )
+
+
+def test_the_fixture_registry_carries_every_canonical_table(seeded: Path) -> None:
+    """Drift is what caused #893, so the test is on the schema, not on one column."""
+    expected = set(re.findall(r"CREATE TABLE IF NOT EXISTS (\w+)", REGISTRY_SCHEMA_SQL))
+    with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
+        actual = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert expected <= actual, f"missing from the seeded registry: {sorted(expected - actual)}"
+
+
+def test_seeded_training_runs_follow_the_current_identity_version(seeded: Path) -> None:
+    """Reading the constant is what makes the fixture survive the next bump."""
+    with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
+        versions = {row[0] for row in db.execute("SELECT identity_version FROM training_runs")}
+    assert versions == {IDENTITY_VERSION}

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -123,5 +123,14 @@ def test_declining_the_preview_tier_suppresses_the_injection(tmp_path) -> None:
     )
 
     declined = injected_parameters(py_path, {}, tmp_path, research_preview=False) or {}
-    assert "EXECUTION_TIER" not in declined
-    assert "WORKSPACE" not in declined
+    assert "EXECUTION_TIER" not in declined, "declining must leave the declared tier alone"
+    # But it must NOT decline the isolated workspace. Leaving WORKSPACE empty sends
+    # open_study down the workspace=None branch into Study.regenerate, which is the
+    # in-place production path: in a maintainer worktree that writes the published
+    # registry. Measured 2026-08-24 - a test run put 13 official populations, 1 candidate
+    # set and 269 backtest runs into the real fx_pairs registry and froze one population
+    # incomplete. The harness must not be able to reach that path at all.
+    assert declined.get("WORKSPACE") == str(tmp_path.resolve()), (
+        "declining the preview tier must still isolate the workspace, or the run writes "
+        "to the maintainer's published artifacts"
+    )

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -134,3 +134,49 @@ def test_declining_the_preview_tier_suppresses_the_injection(tmp_path) -> None:
         "declining the preview tier must still isolate the workspace, or the run writes "
         "to the maintainer's published artifacts"
     )
+
+
+def test_every_prediction_has_a_coverage_row(seeded: Path) -> None:
+    """The count, because `INSERT OR IGNORE` turns a constraint violation into silence.
+
+    `prediction_coverage.artifact_digest` is `TEXT NOT NULL`. An earlier version of the
+    seeder inserted NULL there intending to fill it later; under `INSERT OR IGNORE` every
+    row was dropped without error, and the catalog test above still passed because it
+    asserts on the rows that exist rather than on how many there are.
+    """
+    with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
+        n_pred = db.execute("SELECT COUNT(*) FROM prediction_sets").fetchone()[0]
+        n_cov = db.execute("SELECT COUNT(*) FROM prediction_coverage").fetchone()[0]
+    assert n_pred > 0
+    assert n_cov == n_pred, f"{n_pred} predictions but {n_cov} coverage rows"
+
+
+def test_recorded_artifact_digests_match_the_artifacts(seeded: Path) -> None:
+    """`PredictionResult.complete` is stricter than the catalog's `complete` column.
+
+    The catalog reads `coverage.status` and stops; `results.py:419-423` additionally
+    verifies `value_digest` of the parquet against the recorded digest. The fixture used to
+    record a fabricated 12-character `_make_hash` value where `value_digest` produces 16, so
+    no seeded prediction could satisfy the stricter check and a population would freeze
+    cleanly from the catalog and then fail its own `require_complete`.
+    """
+    import polars as pl
+
+    from case_studies.utils.artifact_digest import value_digest
+
+    with sqlite3.connect(seeded / "run_log" / "registry.db") as db:
+        rows = db.execute(
+            "SELECT prediction_hash, artifact_digest FROM prediction_coverage"
+        ).fetchall()
+
+    checked = 0
+    for p_hash, recorded in rows:
+        artifact = seeded / "run_log" / "predictions" / p_hash / "predictions.parquet"
+        if not artifact.is_file():
+            continue
+        assert recorded, f"{p_hash} has an artifact but no recorded digest"
+        assert value_digest(pl.read_parquet(artifact)) == recorded, (
+            f"{p_hash}: recorded {recorded!r} does not describe the artifact on disk"
+        )
+        checked += 1
+    assert checked > 0, "no seeded prediction had an artifact to check"


### PR DESCRIPTION
Fixes the test fixture registry so a rebuilt case-study notebook resolves its own
predictions, and separates the preview execution tier from workspace isolation.

Four defects, in the order they were found. **Each is necessary and none is
sufficient alone**, which is why the first two measurements each looked complete
and were not. Two of the four were introduced by the fix for the first.

### 1. The seeder built its own schema, and it had drifted

`tests/fixtures/seed_results.py` carried a hand-rolled 9-table DDL. Production's
`REGISTRY_SCHEMA_SQL` has 13 tables, plus `identity_version` and
`execution_tier`, and had dropped three columns the seeder still wrote
(`prediction_metrics.n_obs`, `fold_metrics.n_periods`, `fold_metrics.n_obs`).
A notebook rebuilt against the fixture could not resolve a prediction the
fixture claimed to hold. Replaced with the canonical schema.

### 2. The upgrade skipped the path the suite actually takes

The suite copies the shipped registry rather than seeding a fresh one, so the
schema fix never reached it. `_upgrade_seeded_registry(cs_dir)` now runs the
copied registry through `_open_registry`, production's own opener (migrate,
schema, uncertainty columns), backfills `identity_version`, and writes one
`prediction_coverage` row per prediction with `n_folds_expected` taken from the
actual `fold_metrics`. The tests were rewritten to seed from the shipped
registry, which is what CI uses.

### 3. Declining the preview tier also declined the workspace

`research_preview: false` left `WORKSPACE` unset, which routes `open_study` down
the **in-place production path**. On one run that wrote 13 populations, 1
candidate set and 269 backtest runs into the published `fx_pairs` registry. The
flag now chooses the tier only; the isolated workspace is always injected.
`_declares_tier_and_workspace(py_path)` checks the notebook declares both.

### 4. The recorded artifact digest was fabricated

Coverage rows carried a 12-hex `_make_hash` value while `value_digest` produces
16 hex, so `PredictionResult.complete` failed on every seeded prediction.
`_record_prediction_artifact_digests(cs_dir)` now computes the real digest.
Rows insert `""` first because the column is `TEXT NOT NULL`, then get updated.

An earlier attempt inserted `NULL`; `INSERT OR IGNORE` swallowed the constraint
violation, **zero coverage rows were written, and the existing test still
passed**. There is now a count assertion.

### Scope

Every commit is under `tests/`. No notebook and no identity-bearing file is
touched, so nothing here moves a training or causal identity digest.

### Blocks

`cs6/fx_pairs` is red in CI until this merges: `research_preview` is an inert
key on that branch because both call-site wirings live here. fx deliberately did
not cherry-pick these commits, which would have duplicated two of them and
guaranteed a conflict.

### Known gaps, from the pre-push review

- `tests/test_fixture_registry_identity.py` resolves the intermediates root from
  `$HOME`, so it skips in CI, and no workflow step names the file. The
  regression coverage currently exists only locally.
- `_upgrade_seeded_registry` is called inside a `try` whose handler unlinks the
  copied registry, so a failure there silently falls back to the minimal
  fixture.

Both are follow-ups, not regressions from this branch. Neither changes what the
four fixes do.
