### PR TITLE
Make the causal refutation a test that can fail, and carry its verdict through the registry

### DIFF
--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -84,9 +84,25 @@ class CausalResult:
             if not db_path.is_file():
                 continue
             with sqlite3.connect(db_path) as db:
+                # `refutation_n_successful` arrived with a migration, and this read does
+                # not go through the migrating opener - deliberately, because a read that
+                # rewrites the schema of a registry it was only asked to look at is a
+                # write. Naming the column unconditionally instead raises
+                # OperationalError on any registry written before it existed, and the
+                # cache probe in `run_resolved_causal_request` catches only KeyError, so
+                # the error escapes, the registering write that would have migrated the
+                # database never happens, and re-running the notebook fails identically.
+                columns = {
+                    row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
+                }
+                draws_column = (
+                    "refutation_n_successful"
+                    if "refutation_n_successful" in columns
+                    else "NULL AS refutation_n_successful"
+                )
                 row = db.execute(
                     "SELECT n_obs, dml_effect, dml_se_hac, p_value_hac, naive_effect, "
-                    "confounding_bias_pct, refutation_p, refutation_n_successful, spec_json "
+                    f"confounding_bias_pct, refutation_p, {draws_column}, spec_json "
                     "FROM causal_runs WHERE causal_hash = ?",
                     (causal_hash,),
                 ).fetchone()
@@ -110,9 +126,15 @@ class CausalResult:
                     # Derived here so every reader gets the same verdict from the same
                     # rule. A p-value alone cannot say whether the draws could have
                     # rejected at all, so a caller that re-applies a bare threshold
-                    # publishes "Fails" for runs that were merely underpowered.
+                    # publishes "Fails" for runs that were merely underpowered. An
+                    # unknown draw count is the same problem one step back: a row written
+                    # before the column existed carries NULL there, and classifying it on
+                    # the p-value alone reports exactly the verdict this derivation is
+                    # here to prevent. No count, no verdict.
                     "refutation_class": (
-                        classify_refutation(row[6], row[7]) if row[6] is not None else None
+                        classify_refutation(row[6], row[7])
+                        if row[6] is not None and row[7] is not None
+                        else None
                     ),
                 },
                 execution_tier=tier,

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -5,6 +5,7 @@ import sqlite3
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from case_studies.utils.causal import classify_refutation
 from case_studies.utils.registry.specs import (
     IDENTITY_VERSION,
     SUPPORTED_IDENTITY_VERSIONS,
@@ -85,13 +86,13 @@ class CausalResult:
             with sqlite3.connect(db_path) as db:
                 row = db.execute(
                     "SELECT n_obs, dml_effect, dml_se_hac, p_value_hac, naive_effect, "
-                    "confounding_bias_pct, refutation_p, spec_json "
+                    "confounding_bias_pct, refutation_p, refutation_n_successful, spec_json "
                     "FROM causal_runs WHERE causal_hash = ?",
                     (causal_hash,),
                 ).fetchone()
             if row is None:
                 continue
-            spec = json.loads(row[7])
+            spec = json.loads(row[8])
             tier = str(spec.get("execution_tier", namespace))
             return cls(
                 study=study,
@@ -105,6 +106,14 @@ class CausalResult:
                     "naive_effect": row[4],
                     "confounding_bias_pct": row[5],
                     "refutation_p": row[6],
+                    "refutation_n_successful": row[7],
+                    # Derived here so every reader gets the same verdict from the same
+                    # rule. A p-value alone cannot say whether the draws could have
+                    # rejected at all, so a caller that re-applies a bare threshold
+                    # publishes "Fails" for runs that were merely underpowered.
+                    "refutation_class": (
+                        classify_refutation(row[6], row[7]) if row[6] is not None else None
+                    ),
                 },
                 execution_tier=tier,
             )

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -164,6 +164,15 @@ def embargo_from_buffer(
     }[unit]
 
 
+# A segment boundary is a hole in the observation series, not a step the calendar
+# always takes. Splitting wherever the gap differs from the cadence at all cut a
+# daily series at every weekend, leaving five-row segments that could not hold two
+# blocks of any useful size; the short-segment path then shuffled them. Four
+# cadences clears a weekend (three) and a long weekend (four) on a daily series and
+# still catches a real hole.
+GAP_TOLERANCE_CADENCES = 4
+
+
 def block_permute(
     arr: np.ndarray,
     block_size: int,
@@ -171,6 +180,7 @@ def block_permute(
     groups: np.ndarray | None = None,
     units: np.ndarray | None = None,
     expected_step: str | pd.Timedelta | None = None,
+    gap_tolerance: str | pd.Timedelta | None = None,
 ) -> np.ndarray:
     """Permute array in blocks to preserve autocorrelation structure.
 
@@ -222,6 +232,7 @@ def block_permute(
                 rng=rng,
                 groups=unit_groups,
                 expected_step=expected_step,
+                gap_tolerance=gap_tolerance,
             )
         return result
 
@@ -235,8 +246,14 @@ def block_permute(
             raise ValueError("groups must be strictly increasing")
         if expected_step is not None and n > 1:
             cadence = pd.Timedelta(expected_step)
+            tolerance = (
+                pd.Timedelta(gap_tolerance)
+                if gap_tolerance is not None
+                else GAP_TOLERANCE_CADENCES * cadence
+            )
             timestamps = pd.to_datetime(group_arr, utc=True)
-            boundaries = np.flatnonzero(np.asarray(timestamps[1:] - timestamps[:-1]) != cadence) + 1
+            steps = np.asarray(timestamps[1:] - timestamps[:-1])
+            boundaries = np.flatnonzero(steps > tolerance) + 1
             if boundaries.size:
                 result = np.empty_like(arr)
                 starts = np.r_[0, boundaries]
@@ -251,7 +268,14 @@ def block_permute(
 
     n_blocks = n // block_size
     if n_blocks < 2:
-        return rng.permutation(arr)
+        # Not enough room for two blocks, so there is no permutation to make at this
+        # block size. Returning the segment intact preserves the dependence the
+        # caller asked to keep; shuffling it would destroy exactly that, which is
+        # what the old `rng.permutation(arr)` did to every weekend-bounded segment
+        # of a daily series. A caller that permutes nothing at all is caught by
+        # `_assert_placebo_permutation_possible`, not here: inside a panel, one short unit staying
+        # put while the others move is correct.
+        return np.array(arr, copy=True)
 
     block_indices = rng.permutation(n_blocks)
 
@@ -510,6 +534,84 @@ def manual_dml_timeseries(
 REFUTATION_ALPHA = 0.05
 
 
+def _placebo_is_unchanged(original: np.ndarray, permuted: np.ndarray) -> bool:
+    """Whether a placebo draw returned the observed treatment.
+
+    ``np.array_equal`` calls two arrays different wherever either holds a NaN, so a
+    frame the resolver's ``drop_nulls()`` never touched - which is every frame the
+    case-study notebooks pass to ``run_dml_analysis`` directly - would report every
+    identity draw as a real permutation. Compare the non-null positions and require
+    the null positions to agree.
+    """
+    original = np.asarray(original)
+    permuted = np.asarray(permuted)
+    if original.shape != permuted.shape:
+        return False
+    if not np.issubdtype(original.dtype, np.floating):
+        return bool(np.array_equal(original, permuted))
+    missing = np.isnan(original)
+    if not np.array_equal(missing, np.isnan(permuted)):
+        return False
+    return bool(np.array_equal(original[~missing], permuted[~missing]))
+
+
+def _assert_placebo_permutation_possible(
+    unchanged_draws: int, n_draws: int, block_size: int
+) -> None:
+    """A refutation whose every placebo equals the observed treatment measures nothing.
+
+    ``block_permute`` leaves a segment intact when it cannot hold two blocks of the
+    requested size, which is the right thing to do to one short unit in a panel. If it
+    happens to *every* segment - the block is larger than the longest uninterrupted
+    stretch of observations - then the "permuted" treatment is the observed treatment,
+    every placebo effect equals the observed effect, and the refutation reports p = 1
+    while looking like it ran. Fail instead of publishing that.
+
+    The test is over the whole set of draws, not each one. ``rng.permutation(n_blocks)``
+    can return the identity by chance - one time in two at two blocks, one in six at
+    three - so failing on a single unchanged draw aborts runs that are structurally
+    fine, with a message asserting something false about the data. Every draw coming
+    back unchanged is the structural condition; the chance of that happening to a
+    series that can be permuted falls off as the draws multiply.
+    """
+    if n_draws and unchanged_draws == n_draws:
+        raise ValueError(
+            f"block permutation with block_size={block_size} left the treatment "
+            f"unchanged on all {n_draws} placebo draws: no uninterrupted segment of "
+            "the series holds two blocks of that size. Either the block size exceeds "
+            "the data's contiguous runs or the gap tolerance is splitting the series "
+            "too finely."
+        )
+
+
+def empirical_permutation_p(placebo_effects: np.ndarray, observed_effect: float) -> float:
+    """Two-sided Monte Carlo p-value for the block-permutation refutation.
+
+    The observed statistic is itself one draw the permutation distribution can
+    produce, so both the count and the denominator take the plus-one correction
+    (Davison and Hinkley 1997; Phipson and Smyth 2010). Without it, a run in
+    which no placebo reaches the observed effect reports ``p = 0.000`` - a claim
+    no finite number of permutations can support. With ``n`` placebo draws the
+    smallest p-value the test can report is ``1 / (n + 1)``.
+
+    Parameters
+    ----------
+    placebo_effects : np.ndarray
+        Treatment effects from the successful placebo permutations.
+    observed_effect : float
+        The treatment effect estimated on the unpermuted data.
+
+    Returns
+    -------
+    float
+        The fraction of the permutation distribution at least as extreme as the
+        observed effect in absolute value, in ``(0, 1]``.
+    """
+    placebo = np.asarray(placebo_effects, dtype=float)
+    at_least_as_extreme = int(np.sum(np.abs(placebo) >= abs(observed_effect)))
+    return (1.0 + at_least_as_extreme) / (1.0 + placebo.size)
+
+
 def classify_refutation(empirical_p: float) -> str:
     """Binary pass/fail of the block-permutation refutation test at 5 %.
 
@@ -681,6 +783,7 @@ def run_dml_analysis(
         # Block permutation refutation
         placebo_effects = []
         placebo_n_obs = []
+        unchanged_draws = 0
         for _ in range(n_placebo):
             T_perm = block_permute(
                 T,
@@ -690,6 +793,7 @@ def run_dml_analysis(
                 units=units,
                 expected_step=expected_step,
             )
+            unchanged_draws += _placebo_is_unchanged(T, T_perm)
             perm_result = manual_dml_timeseries(
                 Y,
                 T_perm,
@@ -711,13 +815,15 @@ def run_dml_analysis(
                 placebo_effects.append(perm_result["theta"])
                 placebo_n_obs.append(int(perm_result["n_obs"]))
 
+        _assert_placebo_permutation_possible(unchanged_draws, n_placebo, block_size)
+
         refutation = {}
         if len(placebo_effects) >= 10:
             placebo_arr = np.array(placebo_effects)
             p_mean = np.mean(placebo_arr)
             p_std = np.std(placebo_arr)
             z = (dml_effect - p_mean) / p_std if p_std > 0 else np.inf
-            emp_p = float(np.mean(np.abs(placebo_arr) >= np.abs(dml_effect)))
+            emp_p = empirical_permutation_p(placebo_arr, dml_effect)
             ref_class = classify_refutation(emp_p)
             refutation = {
                 "z_score": z,
@@ -994,7 +1100,7 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         "refutation": {
             "method": "within_symbol_contiguous_block_permutation",
             "n_placebo": n_placebo,
-            "block_size": embargo,
+            "block_size": horizon_steps,
             "seed": seed,
             "temporal_gap_policy": "reset",
             "observation_cadence": str(cadence),
@@ -1031,7 +1137,19 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         n_folds=n_folds,
         embargo=embargo,
         n_placebo=n_placebo,
-        block_size=embargo,
+        # The block spans the label horizon, because the overlapping labels are
+        # what create the serial dependence the permutation exists to preserve -
+        # the same scale the second-stage HAC bandwidth uses (L >= h - 1).
+        #
+        # It is named `horizon_steps` rather than `embargo` even though the two
+        # are equal here: `embargo` is `embargo_from_buffer(mds.label_buffer,
+        # observed_step=cadence)`, which is `horizon_steps` by construction, so
+        # this is a rename and no result moves. Naming it for the horizon is what
+        # keeps it correct if the embargo ever stops being derived from the label
+        # buffer. The five case-study notebooks that call `run_dml_analysis`
+        # directly take `BLOCK_SIZE = EMBARGO_PERIODS` from the *fallback*
+        # conversion, with no `observed_step`, and there the two can diverge.
+        block_size=horizon_steps,
         seed=seed,
         horizon=horizon_steps,
         expected_step=cadence,

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -35,6 +35,7 @@ import importlib.metadata
 import json
 import platform
 import time
+import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -543,20 +544,33 @@ def _placebo_is_unchanged(original: np.ndarray, permuted: np.ndarray) -> bool:
     identity draw as a real permutation. Compare the non-null positions and require
     the null positions to agree.
     """
+    return not _placebo_moved_mask(original, permuted).any()
+
+
+def _placebo_moved_mask(original: np.ndarray, permuted: np.ndarray) -> np.ndarray:
+    """Which comparable rows the permutation actually moved.
+
+    ``True`` where the row differs, ``False`` where it sits still. Rows whose original
+    value is missing are never comparable, so they are reported as unmoved rather than
+    counted as evidence either way. A shape or null-position mismatch means the two are
+    not the same series at all, so every row counts as moved.
+    """
     original = np.asarray(original)
     permuted = np.asarray(permuted)
     if original.shape != permuted.shape:
-        return False
+        return np.ones(original.shape, dtype=bool)
     if not np.issubdtype(original.dtype, np.floating):
-        return bool(np.array_equal(original, permuted))
+        return original != permuted
     missing = np.isnan(original)
     if not np.array_equal(missing, np.isnan(permuted)):
-        return False
-    return bool(np.array_equal(original[~missing], permuted[~missing]))
+        return np.ones(original.shape, dtype=bool)
+    moved = np.zeros(original.shape, dtype=bool)
+    moved[~missing] = original[~missing] != permuted[~missing]
+    return moved
 
 
 def _assert_placebo_permutation_possible(
-    unchanged_draws: int, n_draws: int, block_size: int
+    unchanged_draws: int, n_draws: int, block_size: int, frozen_fraction: float = 0.0
 ) -> None:
     """A refutation whose every placebo equals the observed treatment measures nothing.
 
@@ -581,6 +595,18 @@ def _assert_placebo_permutation_possible(
             "the series holds two blocks of that size. Either the block size exceeds "
             "the data's contiguous runs or the gap tolerance is splitting the series "
             "too finely."
+        )
+    if n_draws and frozen_fraction > 0:
+        warnings.warn(
+            f"block permutation with block_size={block_size} never moved "
+            f"{frozen_fraction:.1%} of the treatment rows in any of {n_draws} placebo "
+            "draws: those rows sit in segments too short to hold two blocks, so the "
+            "placebo distribution holds them at their observed values and the "
+            "refutation p-value is biased toward 1. Read placebo_frozen_fraction "
+            "alongside the p-value, and lower block_size or widen gap_tolerance if "
+            "the frozen share is large.",
+            UserWarning,
+            stacklevel=3,
         )
 
 
@@ -612,14 +638,25 @@ def empirical_permutation_p(placebo_effects: np.ndarray, observed_effect: float)
     return (1.0 + at_least_as_extreme) / (1.0 + placebo.size)
 
 
-def classify_refutation(empirical_p: float) -> str:
-    """Binary pass/fail of the block-permutation refutation test at 5 %.
+def classify_refutation(empirical_p: float, n_successful: int | None = None) -> str:
+    """Pass, fail, or too few draws to tell, at the 5 % level.
 
-    Returns "Passes" if the empirical placebo p-value is below 5 %
-    (the observed effect cannot be reproduced by permutation in
-    most placebo runs); "Fails" otherwise. Always read the raw
-    `empirical_p` alongside the label.
+    Returns "Passes" if the empirical placebo p-value is below 5 % (the observed effect
+    cannot be reproduced by permutation in most placebo runs), and "Fails" otherwise.
+
+    "Underpowered" is the third answer, and it is the honest one whenever the number of
+    successful draws puts "Passes" out of reach. The plus-one correction floors the
+    reported p-value at ``1 / (n + 1)``, so at 19 successful draws or fewer the smallest
+    value the test can produce is already at or above 5 % and "Fails" would be published
+    whatever the data said - untrue by construction in the same way ``p = 0.000`` was at
+    the other end. The preview tier runs ten draws, so this is the ordinary case there,
+    not an exotic one.
+
+    ``n_successful`` is optional so that a caller holding only a p-value keeps the
+    two-way answer; pass it wherever the draw count is known.
     """
+    if n_successful is not None and 1.0 / (n_successful + 1) >= REFUTATION_ALPHA:
+        return "Underpowered"
     return "Passes" if empirical_p < REFUTATION_ALPHA else "Fails"
 
 
@@ -784,6 +821,8 @@ def run_dml_analysis(
         placebo_effects = []
         placebo_n_obs = []
         unchanged_draws = 0
+        ever_moved = np.zeros(np.shape(T), dtype=bool)
+        moved_fractions: list[float] = []
         for _ in range(n_placebo):
             T_perm = block_permute(
                 T,
@@ -793,7 +832,10 @@ def run_dml_analysis(
                 units=units,
                 expected_step=expected_step,
             )
-            unchanged_draws += _placebo_is_unchanged(T, T_perm)
+            moved = _placebo_moved_mask(T, T_perm)
+            ever_moved |= moved
+            moved_fractions.append(float(moved.mean()))
+            unchanged_draws += not moved.any()
             perm_result = manual_dml_timeseries(
                 Y,
                 T_perm,
@@ -815,7 +857,14 @@ def run_dml_analysis(
                 placebo_effects.append(perm_result["theta"])
                 placebo_n_obs.append(int(perm_result["n_obs"]))
 
-        _assert_placebo_permutation_possible(unchanged_draws, n_placebo, block_size)
+        # A row that can move will have moved in at least one of the draws; one that
+        # never moves sits in a segment too short to hold two blocks. Reading it off the
+        # draws rather than re-deriving the segmentation keeps one implementation of
+        # where a series is cut.
+        frozen_fraction = float(1.0 - ever_moved.mean()) if ever_moved.size else 0.0
+        _assert_placebo_permutation_possible(
+            unchanged_draws, n_placebo, block_size, frozen_fraction
+        )
 
         refutation = {}
         if len(placebo_effects) >= 10:
@@ -824,13 +873,17 @@ def run_dml_analysis(
             p_std = np.std(placebo_arr)
             z = (dml_effect - p_mean) / p_std if p_std > 0 else np.inf
             emp_p = empirical_permutation_p(placebo_arr, dml_effect)
-            ref_class = classify_refutation(emp_p)
+            ref_class = classify_refutation(emp_p, len(placebo_effects))
             refutation = {
                 "z_score": z,
                 "empirical_p": emp_p,
                 "placebo_mean": p_mean,
                 "placebo_std": p_std,
                 "n_successful": len(placebo_effects),
+                "placebo_frozen_fraction": frozen_fraction,
+                "placebo_moved_fraction": float(np.mean(moved_fractions))
+                if moved_fractions
+                else 0.0,
                 "n_folds": n_folds,
                 "placebo_n_obs": placebo_n_obs,
                 "placebo_effects": placebo_effects,

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -210,10 +210,33 @@ def block_permute(
         Block-permuted array.
     """
     arr = np.asarray(arr)
-    n = len(arr)
     if rng is None:
         rng = np.random.default_rng()
 
+    segments = _permutation_segments(len(arr), groups, units, expected_step, gap_tolerance)
+    result = np.array(arr, copy=True)
+    for idx in segments:
+        result[idx] = _permute_one_segment(arr[idx], block_size, rng)
+    return result
+
+
+def _permutation_segments(
+    n: int,
+    groups: np.ndarray | None,
+    units: np.ndarray | None,
+    expected_step: str | pd.Timedelta | None,
+    gap_tolerance: str | pd.Timedelta | None,
+) -> list[np.ndarray]:
+    """The maximal stretches of rows a block permutation may reorder within.
+
+    One entity's uninterrupted run of decision times is one segment. Blocks never cross
+    a segment boundary, because the rows on either side are not adjacent in time - they
+    belong to different entities, or to the same entity either side of a gap.
+
+    This is the single definition of where the series is cut. ``block_permute`` permutes
+    within these segments and ``_immobile_masks`` counts what they leave standing, so
+    the two can never disagree about the segmentation.
+    """
     if units is not None:
         if groups is None:
             raise ValueError("groups are required when units are supplied")
@@ -221,21 +244,17 @@ def block_permute(
         unit_arr = np.asarray(units)
         if len(group_arr) != n or len(unit_arr) != n:
             raise ValueError("groups and units must have the same length as arr")
-        result = np.empty_like(arr)
+        segments: list[np.ndarray] = []
         for unit in pd.unique(unit_arr):
             idx = np.flatnonzero(unit_arr == unit)
             unit_groups = group_arr[idx]
             if len(unit_groups) > 1 and np.any(unit_groups[1:] <= unit_groups[:-1]):
                 raise ValueError("groups must be strictly increasing within each unit")
-            result[idx] = block_permute(
-                arr[idx],
-                block_size,
-                rng=rng,
-                groups=unit_groups,
-                expected_step=expected_step,
-                gap_tolerance=gap_tolerance,
+            segments.extend(
+                idx[bounds]
+                for bounds in _contiguous_runs(unit_groups, expected_step, gap_tolerance)
             )
-        return result
+        return segments
 
     if groups is not None:
         group_arr = np.asarray(groups)
@@ -245,28 +264,45 @@ def block_permute(
             raise ValueError("units are required when decision times contain multiple rows")
         if n > 1 and np.any(group_arr[1:] <= group_arr[:-1]):
             raise ValueError("groups must be strictly increasing")
-        if expected_step is not None and n > 1:
-            cadence = pd.Timedelta(expected_step)
-            tolerance = (
-                pd.Timedelta(gap_tolerance)
-                if gap_tolerance is not None
-                else GAP_TOLERANCE_CADENCES * cadence
-            )
-            timestamps = pd.to_datetime(group_arr, utc=True)
-            steps = np.asarray(timestamps[1:] - timestamps[:-1])
-            boundaries = np.flatnonzero(steps > tolerance) + 1
-            if boundaries.size:
-                result = np.empty_like(arr)
-                starts = np.r_[0, boundaries]
-                stops = np.r_[boundaries, n]
-                for start, stop in zip(starts, stops, strict=True):
-                    result[start:stop] = block_permute(
-                        arr[start:stop],
-                        block_size,
-                        rng=rng,
-                    )
-                return result
+        positions = np.arange(n)
+        return [
+            positions[bounds]
+            for bounds in _contiguous_runs(group_arr, expected_step, gap_tolerance)
+        ]
 
+    return [np.arange(n)]
+
+
+def _contiguous_runs(
+    group_arr: np.ndarray,
+    expected_step: str | pd.Timedelta | None,
+    gap_tolerance: str | pd.Timedelta | None,
+) -> list[slice]:
+    """Split one entity's ordered decision times wherever the gap exceeds the tolerance."""
+    n = len(group_arr)
+    if expected_step is None or n <= 1:
+        return [slice(0, n)]
+    cadence = pd.Timedelta(expected_step)
+    tolerance = (
+        pd.Timedelta(gap_tolerance)
+        if gap_tolerance is not None
+        else GAP_TOLERANCE_CADENCES * cadence
+    )
+    timestamps = pd.to_datetime(group_arr, utc=True)
+    steps = np.asarray(timestamps[1:] - timestamps[:-1])
+    boundaries = np.flatnonzero(steps > tolerance) + 1
+    if not boundaries.size:
+        return [slice(0, n)]
+    starts = np.r_[0, boundaries]
+    stops = np.r_[boundaries, n]
+    return [slice(int(a), int(b)) for a, b in zip(starts, stops, strict=True)]
+
+
+def _permute_one_segment(
+    values: np.ndarray, block_size: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Reorder whole blocks within one uninterrupted stretch."""
+    n = len(values)
     n_blocks = n // block_size
     if n_blocks < 2:
         # Not enough room for two blocks, so there is no permutation to make at this
@@ -276,21 +312,46 @@ def block_permute(
         # of a daily series. A caller that permutes nothing at all is caught by
         # `_assert_placebo_permutation_possible`, not here: inside a panel, one short unit staying
         # put while the others move is correct.
-        return np.array(arr, copy=True)
+        return np.array(values, copy=True)
 
-    block_indices = rng.permutation(n_blocks)
+    pieces = [
+        values[idx * block_size : (idx + 1) * block_size] for idx in rng.permutation(n_blocks)
+    ]
 
-    result = []
-    for idx in block_indices:
-        start = idx * block_size
-        result.append(arr[start : start + block_size])
-
-    # Handle remainder
+    # The trailing rows that do not fill a whole block stay where they are. This is a
+    # property of block permutation itself, not of the data: it happens to any segment
+    # whose length is not a multiple of the block size, however long the segment is.
     remainder_start = n_blocks * block_size
     if remainder_start < n:
-        result.append(arr[remainder_start:])
+        pieces.append(values[remainder_start:])
 
-    return np.concatenate(result)
+    return np.concatenate(pieces)
+
+
+def _immobile_masks(
+    n: int, block_size: int, segments: list[np.ndarray]
+) -> tuple[np.ndarray, np.ndarray]:
+    """Which rows no draw can move, split by the two unrelated reasons.
+
+    The first mask is rows in a segment too short to hold two blocks. Those are frozen
+    because of how the data is shaped against the block size, they carry their observed
+    values into every placebo, and a large share of them makes the refutation
+    uninformative - which is worth telling the caller about.
+
+    The second is the trailing remainder of a segment whose length is not a multiple of
+    the block size. Those rows also never move, but for a reason intrinsic to block
+    permutation that no choice of gap tolerance can remove, and shrinking the block size
+    to chase them is the wrong response. They are reported, not warned about.
+    """
+    short = np.zeros(n, dtype=bool)
+    remainder = np.zeros(n, dtype=bool)
+    for idx in segments:
+        n_blocks = len(idx) // block_size
+        if n_blocks < 2:
+            short[idx] = True
+        elif n_blocks * block_size < len(idx):
+            remainder[idx[n_blocks * block_size :]] = True
+    return short, remainder
 
 
 def _walk_forward_indices(
@@ -547,6 +608,28 @@ def _placebo_is_unchanged(original: np.ndarray, permuted: np.ndarray) -> bool:
     return not _placebo_moved_mask(original, permuted).any()
 
 
+def _placebo_moved_fraction(original: np.ndarray, permuted: np.ndarray) -> float:
+    """The share of comparable rows this draw actually moved.
+
+    Separate from `_placebo_moved_mask` on purpose. That one answers "are these the same
+    series at all", so a disagreement in null positions means every row counts as moved;
+    here that convention would report a frozen panel as fully permuted the moment one
+    draw shifted a missing value. Rows that are null on either side are simply not
+    comparable, so they are left out of both the count and the denominator.
+    """
+    original = np.asarray(original)
+    permuted = np.asarray(permuted)
+    if original.shape != permuted.shape:
+        return 0.0
+    if not np.issubdtype(original.dtype, np.floating):
+        comparable = np.ones(original.shape, dtype=bool)
+    else:
+        comparable = ~np.isnan(original) & ~np.isnan(permuted)
+    if not comparable.any():
+        return 0.0
+    return float(np.mean(original[comparable] != permuted[comparable]))
+
+
 def _placebo_moved_mask(original: np.ndarray, permuted: np.ndarray) -> np.ndarray:
     """Which comparable rows the permutation actually moved.
 
@@ -570,7 +653,7 @@ def _placebo_moved_mask(original: np.ndarray, permuted: np.ndarray) -> np.ndarra
 
 
 def _assert_placebo_permutation_possible(
-    unchanged_draws: int, n_draws: int, block_size: int, frozen_fraction: float = 0.0
+    unchanged_draws: int, n_draws: int, block_size: int, short_segment_fraction: float = 0.0
 ) -> None:
     """A refutation whose every placebo equals the observed treatment measures nothing.
 
@@ -596,15 +679,14 @@ def _assert_placebo_permutation_possible(
             "the data's contiguous runs or the gap tolerance is splitting the series "
             "too finely."
         )
-    if n_draws and frozen_fraction > 0:
+    if n_draws and short_segment_fraction > 0:
         warnings.warn(
-            f"block permutation with block_size={block_size} never moved "
-            f"{frozen_fraction:.1%} of the treatment rows in any of {n_draws} placebo "
-            "draws: those rows sit in segments too short to hold two blocks, so the "
-            "placebo distribution holds them at their observed values and the "
-            "refutation p-value is biased toward 1. Read placebo_frozen_fraction "
-            "alongside the p-value, and lower block_size or widen gap_tolerance if "
-            "the frozen share is large.",
+            f"block permutation with block_size={block_size} cannot move "
+            f"{short_segment_fraction:.1%} of the treatment rows: they sit in segments "
+            "too short to hold two blocks, so the placebo distribution holds them at "
+            "their observed values and the refutation p-value is biased toward 1. Read "
+            "placebo_frozen_fraction alongside the p-value, and lower block_size or "
+            "widen gap_tolerance if the frozen share is large.",
             UserWarning,
             stacklevel=3,
         )
@@ -821,8 +903,16 @@ def run_dml_analysis(
         placebo_effects = []
         placebo_n_obs = []
         unchanged_draws = 0
-        ever_moved = np.zeros(np.shape(T), dtype=bool)
         moved_fractions: list[float] = []
+        # What no draw can move is a property of the segmentation and the block size, so
+        # it is computed from them rather than inferred from what the draws happened to
+        # do. The two reasons a row never moves are unrelated and only one of them is
+        # worth a warning: see `_immobile_masks`.
+        short_frozen, remainder_frozen = _immobile_masks(
+            len(T),
+            block_size,
+            _permutation_segments(len(T), groups, units, expected_step, None),
+        )
         for _ in range(n_placebo):
             T_perm = block_permute(
                 T,
@@ -832,10 +922,8 @@ def run_dml_analysis(
                 units=units,
                 expected_step=expected_step,
             )
-            moved = _placebo_moved_mask(T, T_perm)
-            ever_moved |= moved
-            moved_fractions.append(float(moved.mean()))
-            unchanged_draws += not moved.any()
+            moved_fractions.append(_placebo_moved_fraction(T, T_perm))
+            unchanged_draws += _placebo_is_unchanged(T, T_perm)
             perm_result = manual_dml_timeseries(
                 Y,
                 T_perm,
@@ -857,11 +945,8 @@ def run_dml_analysis(
                 placebo_effects.append(perm_result["theta"])
                 placebo_n_obs.append(int(perm_result["n_obs"]))
 
-        # A row that can move will have moved in at least one of the draws; one that
-        # never moves sits in a segment too short to hold two blocks. Reading it off the
-        # draws rather than re-deriving the segmentation keeps one implementation of
-        # where a series is cut.
-        frozen_fraction = float(1.0 - ever_moved.mean()) if ever_moved.size else 0.0
+        frozen_fraction = float(short_frozen.mean()) if short_frozen.size else 0.0
+        remainder_fraction = float(remainder_frozen.mean()) if remainder_frozen.size else 0.0
         _assert_placebo_permutation_possible(
             unchanged_draws, n_placebo, block_size, frozen_fraction
         )
@@ -881,6 +966,7 @@ def run_dml_analysis(
                 "placebo_std": p_std,
                 "n_successful": len(placebo_effects),
                 "placebo_frozen_fraction": frozen_fraction,
+                "placebo_remainder_fraction": remainder_fraction,
                 "placebo_moved_fraction": float(np.mean(moved_fractions))
                 if moved_fractions
                 else 0.0,
@@ -1263,7 +1349,9 @@ def run_resolved_causal_request(
     dml = results["dml_result"]
     if not all(math.isfinite(float(dml[name])) for name in ("theta", "se_hac")):
         raise ValueError("DML fit did not produce a finite effect and HAC standard error")
-    refutation_p = results.get("refutation", {}).get("empirical_p")
+    refutation = results.get("refutation", {})
+    refutation_p = refutation.get("empirical_p")
+    refutation_n = refutation.get("n_successful")
     case_dir = study.storage_root(spec["execution_tier"])
     register_record(
         study.case_study,
@@ -1280,6 +1368,7 @@ def run_resolved_causal_request(
         naive_effect=float(results["naive_effect"]),
         confounding_bias_pct=float(results["confounding_bias_pct"]),
         refutation_p=float(refutation_p) if refutation_p is not None else None,
+        refutation_n_successful=int(refutation_n) if refutation_n is not None else None,
         spec_json=canonical_json(spec),
         notebook="case_studies.utils.causal",
         started_at=results.get("started_at"),
@@ -1379,6 +1468,7 @@ def register_causal_run(
     # significant result, and ``or 1.0`` would flip its meaning.
     p_value_hac = results.get("p_value_hac")
     refutation_p = ref.get("empirical_p")
+    refutation_n = ref.get("n_successful")
 
     _register_causal_run(
         case_study_id,
@@ -1395,6 +1485,7 @@ def register_causal_run(
         naive_effect=float(results.get("naive_effect", 0.0)),
         confounding_bias_pct=float(results.get("confounding_bias_pct", 0.0)),
         refutation_p=float(refutation_p) if refutation_p is not None else None,
+        refutation_n_successful=int(refutation_n) if refutation_n is not None else None,
         spec_json=canonical_json(spec),
         notebook=notebook,
         started_at=started_at or results.get("started_at"),

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1738,11 +1738,25 @@ def register_causal_run(
     immutable = version in SUPPORTED_IDENTITY_VERSIONS
     db = _open_registry(case_dir)
     try:
+        comparable_columns = (
+            "label",
+            "treatment",
+            "confounders_json",
+            "embargo",
+            "n_folds",
+            "n_obs",
+            "dml_effect",
+            "dml_se_hac",
+            "p_value_hac",
+            "naive_effect",
+            "confounding_bias_pct",
+            "refutation_p",
+            "refutation_n_successful",
+            "spec_json",
+            "notebook",
+        )
         existing = db.execute(
-            "SELECT label, treatment, confounders_json, embargo, n_folds, n_obs, "
-            "dml_effect, dml_se_hac, p_value_hac, naive_effect, confounding_bias_pct, "
-            "refutation_p, refutation_n_successful, spec_json, notebook "
-            "FROM causal_runs WHERE causal_hash = ?",
+            f"SELECT {', '.join(comparable_columns)} FROM causal_runs WHERE causal_hash = ?",
             (causal_hash,),
         ).fetchone()
         expected = (
@@ -1763,9 +1777,29 @@ def register_causal_run(
             notebook,
         )
         if immutable and existing is not None:
-            if existing != expected:
-                raise ValueError(f"immutable causal result conflict for {causal_hash}")
-            return
+            # A row written before a column existed carries NULL there, and filling it in
+            # is not a conflict: nothing about the run changed, the registry simply had no
+            # place to record that fact yet. Treating it as one would make an upgrade break
+            # re-registration of results that are identical - the same shape as a fix that
+            # forces a refit without changing a number.
+            stored = list(existing)
+            backfilled = False
+            for position, value in enumerate(expected):
+                if stored[position] is None and value is not None:
+                    stored[position] = value
+                    backfilled = True
+            if tuple(stored) != expected:
+                conflicting = [
+                    name
+                    for name, was, now in zip(comparable_columns, existing, expected, strict=True)
+                    if was != now and was is not None
+                ]
+                raise ValueError(
+                    f"immutable causal result conflict for {causal_hash}: "
+                    f"{', '.join(conflicting)} would change"
+                )
+            if not backfilled:
+                return
         # ON CONFLICT DO UPDATE rather than INSERT OR REPLACE — consistent with
         # register_paired_metrics, avoids the implicit DELETE that triggers
         # FK cascades and loses the original created_at timestamp.

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1795,18 +1795,27 @@ def register_causal_run(
             # still conflict. Filling on NULL alone would write that over an immutable row
             # and refresh its execution provenance on the way through.
             stored = list(existing)
-            backfilled = False
+            backfilled_positions: set[int] = set()
             for position, value in enumerate(expected):
                 if comparable_columns[position] not in MIGRATION_BACKFILLED_COLUMNS:
                     continue
                 if stored[position] is None and value is not None:
                     stored[position] = value
-                    backfilled = True
+                    backfilled_positions.add(position)
+            backfilled = bool(backfilled_positions)
             if tuple(stored) != expected:
+                # Excluded because it was filled, not because of its name. A migrated
+                # column whose stored value is not NULL - a recording convention that
+                # changes 1000 to 998, or a re-registration passing None where 10 was
+                # stored - is a genuine difference, and excluding it by name would raise
+                # naming nothing. That empty message is the same defect this branch
+                # already fixed once, reached from the other side.
                 conflicting = [
                     name
-                    for name, was, now in zip(comparable_columns, existing, expected, strict=True)
-                    if was != now and name not in MIGRATION_BACKFILLED_COLUMNS
+                    for position, (name, was, now) in enumerate(
+                        zip(comparable_columns, existing, expected, strict=True)
+                    )
+                    if was != now and position not in backfilled_positions
                 ]
                 raise ValueError(
                     f"immutable causal result conflict for {causal_hash}: "

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1716,6 +1716,7 @@ def register_causal_run(
     naive_effect: float | None,
     confounding_bias_pct: float | None,
     refutation_p: float | None,
+    refutation_n_successful: int | None = None,
     spec_json: str,
     notebook: str | None,
     started_at: str | None,
@@ -1740,7 +1741,8 @@ def register_causal_run(
         existing = db.execute(
             "SELECT label, treatment, confounders_json, embargo, n_folds, n_obs, "
             "dml_effect, dml_se_hac, p_value_hac, naive_effect, confounding_bias_pct, "
-            "refutation_p, spec_json, notebook FROM causal_runs WHERE causal_hash = ?",
+            "refutation_p, refutation_n_successful, spec_json, notebook "
+            "FROM causal_runs WHERE causal_hash = ?",
             (causal_hash,),
         ).fetchone()
         expected = (
@@ -1756,6 +1758,7 @@ def register_causal_run(
             naive_effect,
             confounding_bias_pct,
             refutation_p,
+            refutation_n_successful,
             spec_json,
             notebook,
         )
@@ -1772,8 +1775,9 @@ def register_causal_run(
                 causal_hash, label, treatment, confounders_json, embargo,
                 n_folds, n_obs, dml_effect, dml_se_hac, p_value_hac,
                 naive_effect, confounding_bias_pct, refutation_p,
+                refutation_n_successful,
                 spec_json, notebook, started_at, elapsed_s, git_commit, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(causal_hash) DO UPDATE SET
                 label=excluded.label,
                 treatment=excluded.treatment,
@@ -1787,6 +1791,7 @@ def register_causal_run(
                 naive_effect=excluded.naive_effect,
                 confounding_bias_pct=excluded.confounding_bias_pct,
                 refutation_p=excluded.refutation_p,
+                refutation_n_successful=excluded.refutation_n_successful,
                 spec_json=excluded.spec_json,
                 notebook=excluded.notebook,
                 started_at=excluded.started_at,
@@ -1804,6 +1809,7 @@ def register_causal_run(
                OR causal_runs.naive_effect IS NOT excluded.naive_effect
                OR causal_runs.confounding_bias_pct IS NOT excluded.confounding_bias_pct
                OR causal_runs.refutation_p IS NOT excluded.refutation_p
+               OR causal_runs.refutation_n_successful IS NOT excluded.refutation_n_successful
                OR causal_runs.spec_json IS NOT excluded.spec_json
                OR causal_runs.notebook IS NOT excluded.notebook
             """,
@@ -1821,6 +1827,7 @@ def register_causal_run(
                 naive_effect,
                 confounding_bias_pct,
                 refutation_p,
+                refutation_n_successful,
                 spec_json,
                 notebook,
                 started_at,

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -38,6 +38,11 @@ from .store import (
 logger = logging.getLogger(__name__)
 
 VALID_PREDICTION_SPLITS = frozenset({"validation", "holdout"})
+
+# Columns a schema migration added, which an immutable row may therefore be missing
+# through no change of its own. Nothing else is filled on NULL: see the comment at the
+# backfill itself for why a nullable column is not the same as a migrated one.
+MIGRATION_BACKFILLED_COLUMNS = frozenset({"refutation_n_successful"})
 MAX_PREDICTION_STD_RATIO = 100.0
 
 
@@ -1782,9 +1787,18 @@ def register_causal_run(
             # place to record that fact yet. Treating it as one would make an upgrade break
             # re-registration of results that are identical - the same shape as a fix that
             # forces a refit without changing a number.
+            #
+            # Only a column a migration added is filled this way. The other comparable
+            # columns are nullable for reasons that have nothing to do with the schema:
+            # refutation_p is None whenever the refutation produced too few successful
+            # placebos, so a later run that does produce one has genuinely changed and must
+            # still conflict. Filling on NULL alone would write that over an immutable row
+            # and refresh its execution provenance on the way through.
             stored = list(existing)
             backfilled = False
             for position, value in enumerate(expected):
+                if comparable_columns[position] not in MIGRATION_BACKFILLED_COLUMNS:
+                    continue
                 if stored[position] is None and value is not None:
                     stored[position] = value
                     backfilled = True
@@ -1792,7 +1806,7 @@ def register_causal_run(
                 conflicting = [
                     name
                     for name, was, now in zip(comparable_columns, existing, expected, strict=True)
-                    if was != now and was is not None
+                    if was != now and name not in MIGRATION_BACKFILLED_COLUMNS
                 ]
                 raise ValueError(
                     f"immutable causal result conflict for {causal_hash}: "

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -148,6 +148,7 @@ CREATE TABLE IF NOT EXISTS causal_runs (
     naive_effect     REAL,
     confounding_bias_pct REAL,
     refutation_p     REAL,
+    refutation_n_successful INTEGER,
     spec_json        TEXT,
     notebook         TEXT,
     started_at       TEXT,
@@ -649,6 +650,15 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
     for table in ("holdout_staging", "holdout_evaluations"):
         if table in tables and not _table_has_column(db, table, "fitted_state_digest"):
             db.execute(f"ALTER TABLE {table} ADD COLUMN fitted_state_digest TEXT")
+
+    # The number of successful placebo draws decides whether the refutation could have
+    # rejected at all: the plus-one correction floors the p-value at 1 / (n + 1), so at
+    # 19 or fewer no data could produce a pass. Without it a reader holding only
+    # refutation_p cannot tell an underpowered run from a failed one.
+    if "causal_runs" in tables and not _table_has_column(
+        db, "causal_runs", "refutation_n_successful"
+    ):
+        db.execute("ALTER TABLE causal_runs ADD COLUMN refutation_n_successful INTEGER")
 
     # Migration 3: tall → wide metric tables
     if "prediction_metrics" in tables:

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -28,7 +28,7 @@ def _restore_output_root():
     workspace._clear_root_sensitive_caches()
 
 
-def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol"):
+def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol", label_buffer: str = "8H"):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
@@ -59,14 +59,14 @@ def _causal_fixture(tmp_path, monkeypatch, entity: str = "symbol"):
             )
     frame = pl.DataFrame(rows)
     label = study.labels.publish(
-        LabelDefinition("fwd_ret_8h", "regression", "8H"),
+        LabelDefinition("fwd_ret_8h", "regression", label_buffer),
         frame.rename({entity: "symbol"}).select("symbol", "timestamp", "fwd_ret_8h"),
     )
     mds = SimpleNamespace(
         dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_8h",
-        label_buffer="8H",
+        label_buffer=label_buffer,
         date_col="timestamp",
         entity_cols=[entity],
         input_lineage={
@@ -498,6 +498,32 @@ def test_causal_resolver_accepts_either_canonical_entity_key(tmp_path, monkeypat
     ).resolve()
 
     assert resolved.spec["computation"]["analysis_population"]["n_rows"] > 0
+
+
+@pytest.mark.parametrize(
+    ("label_buffer", "expected_block"),
+    [("8H", 1), ("24H", 3), ("48H", 6)],
+)
+def test_the_placebo_block_spans_the_label_horizon(
+    tmp_path, monkeypatch, label_buffer, expected_block
+) -> None:
+    """The resolved spec's block size is the label horizon in bars, not the embargo.
+
+    On 8-hour bars a 24-hour label overlaps three observations, so a block of one
+    would leave the placebo free to break exactly the dependence the overlap
+    creates. Reverting the resolver to `block_size=embargo` passes only while the
+    embargo happens to be derived from the same buffer; this pins the horizon.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, label_buffer=label_buffer)
+
+    resolved = study.causal(
+        method="dml",
+        label=label.name,
+        execution_tier="preview",
+        preview_reductions={"max_samples": 240, "max_symbols": 6, "n_folds": 2, "n_placebo": 10},
+    ).resolve()
+
+    assert resolved.spec["computation"]["refutation"]["block_size"] == expected_block
 
 
 def test_causal_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch) -> None:

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -4,7 +4,9 @@ import numpy as np
 import pandas as pd
 from sklearn.dummy import DummyRegressor
 
+from case_studies.utils import causal
 from case_studies.utils.causal import (
+    _placebo_is_unchanged,
     _resolve_panel_columns,
     _walk_forward_indices,
     block_permute,
@@ -158,13 +160,16 @@ def test_panel_cross_fitting_residualizes_complete_dates() -> None:
 
 
 def test_panel_block_permutation_preserves_each_entity_history() -> None:
-    dates = np.array([1, 1, 2, 2, 3, 3, 4, 5])
-    units = np.array(["a", "b", "a", "b", "a", "b", "a", "a"])
-    treatment = np.array([11, 21, 12, 22, 13, 23, 14, 15])
+    """Treatment moves within an entity's own history and never across entities."""
+    dates = np.concatenate([np.arange(1, 13), np.arange(1, 13)])
+    units = np.array(["a"] * 12 + ["b"] * 12)
+    treatment = np.concatenate([np.arange(11, 23), np.arange(101, 113)])
+    order = np.argsort(dates, kind="stable")
+    dates, units, treatment = dates[order], units[order], treatment[order]
 
     permuted = block_permute(
         treatment,
-        block_size=2,
+        block_size=3,
         rng=np.random.default_rng(7),
         groups=dates,
         units=units,
@@ -173,6 +178,82 @@ def test_panel_block_permutation_preserves_each_entity_history() -> None:
     for unit in np.unique(units):
         assert sorted(permuted[units == unit]) == sorted(treatment[units == unit])
     assert not np.array_equal(permuted, treatment)
+
+
+def test_a_segment_too_short_for_two_blocks_is_left_intact() -> None:
+    """It is not shuffled: shuffling destroys the dependence the blocks preserve.
+
+    One entity in a panel can be shorter than two blocks while the others are not,
+    so this is per-segment behaviour rather than an error. The case where it happens
+    to every segment is caught by `_assert_placebo_permutation_possible`.
+    """
+    dates = np.concatenate([np.arange(1, 13), np.arange(1, 5)])
+    units = np.array(["long"] * 12 + ["short"] * 4)
+    treatment = np.concatenate([np.arange(11, 23), np.arange(101, 105)])
+    order = np.argsort(dates, kind="stable")
+    dates, units, treatment = dates[order], units[order], treatment[order]
+
+    permuted = block_permute(
+        treatment,
+        block_size=3,
+        rng=np.random.default_rng(7),
+        groups=dates,
+        units=units,
+    )
+
+    short = units == "short"
+    assert np.array_equal(permuted[short], treatment[short])
+    assert not np.array_equal(permuted[~short], treatment[~short])
+
+
+def test_a_weekend_is_not_a_gap_in_a_daily_series() -> None:
+    """The defect this pins: splitting at every diff != cadence cut a daily series
+    into five-row weeks, none of which could hold two blocks of a useful size."""
+    dates = pd.bdate_range("2024-01-01", periods=30).to_numpy()
+    treatment = np.arange(30, dtype=float)
+
+    permuted = block_permute(
+        treatment,
+        block_size=5,
+        rng=np.random.default_rng(3),
+        groups=dates,
+        expected_step="1D",
+    )
+
+    assert sorted(permuted) == sorted(treatment)
+    assert not np.array_equal(permuted, treatment)
+    # Whole weeks moved: four of every five steps stay contiguous.
+    assert np.sum(np.diff(permuted) == 1.0) >= 30 - 30 // 5 - 1
+
+
+def test_a_real_hole_in_the_series_is_still_a_gap() -> None:
+    """Six cadences apart is past the four-cadence tolerance, so the two runs of
+    observations are permuted independently and nothing crosses between them."""
+    dates = np.array(
+        [
+            "2024-01-01T00:00:00",
+            "2024-01-01T08:00:00",
+            "2024-01-01T16:00:00",
+            "2024-01-02T00:00:00",
+            "2024-01-04T00:00:00",
+            "2024-01-04T08:00:00",
+            "2024-01-04T16:00:00",
+            "2024-01-05T00:00:00",
+        ],
+        dtype="datetime64[s]",
+    )
+    treatment = np.arange(8)
+
+    permuted = block_permute(
+        treatment,
+        block_size=2,
+        rng=np.random.default_rng(7),
+        groups=dates,
+        expected_step="8h",
+    )
+
+    assert set(permuted[:4]) == set(treatment[:4])
+    assert set(permuted[4:]) == set(treatment[4:])
 
 
 def test_panel_block_permutation_requires_entity_column() -> None:
@@ -233,3 +314,126 @@ def test_dml_comparisons_use_the_observed_second_stage_sample_and_folds() -> Non
     assert result["naive_n_obs"] == residuals["n_obs"]
     assert result["refutation"]["n_folds"] == 2
     assert set(result["refutation"]["placebo_n_obs"]) == {residuals["n_obs"]}
+
+
+def _two_entity_panel(n_dates: int, seed: int = 19) -> pd.DataFrame:
+    """A small balanced daily panel that DML can residualize."""
+    rng = np.random.default_rng(seed)
+    dates = np.repeat(pd.date_range("2020-01-01", periods=n_dates, freq="B"), 2)
+    confounder = rng.normal(size=len(dates))
+    treatment = 0.4 * confounder + rng.normal(size=len(dates))
+    return pd.DataFrame(
+        {
+            "timestamp": dates,
+            "symbol": np.tile(["A", "B"], n_dates),
+            "treatment": treatment,
+            "outcome": 0.3 * treatment + 0.2 * confounder + rng.normal(size=len(dates)),
+            "confounder": confounder,
+        }
+    )
+
+
+def test_a_block_longer_than_every_contiguous_run_fails_the_refutation() -> None:
+    """The guard the short-segment path depends on: if no segment can hold two
+    blocks, every placebo IS the observed treatment and p = 1 is an artefact."""
+    frame = _two_entity_panel(n_dates=100)
+
+    try:
+        run_dml_analysis(
+            frame,
+            treatment_col="treatment",
+            outcome_col="outcome",
+            confounder_cols=["confounder"],
+            n_folds=2,
+            embargo=1,
+            n_placebo=10,
+            block_size=101,
+            seed=7,
+            horizon=1,
+            time_col="timestamp",
+            entity_col="symbol",
+        )
+    except ValueError as error:
+        assert "block_size=101" in str(error)
+        assert "all 10 placebo draws" in str(error)
+    else:
+        raise AssertionError("a block longer than every contiguous run must fail")
+
+
+def test_one_identity_draw_does_not_abort_a_permutable_series() -> None:
+    """`rng.permutation` returns the identity by chance - one time in two at two
+    blocks. Failing on a single unchanged draw aborts runs that are structurally
+    fine, with a message asserting something false about the data. The condition is
+    every draw coming back unchanged, not any of them."""
+    frame = _two_entity_panel(n_dates=100)
+    n_placebo = 30
+
+    unchanged = 0
+    real_is_unchanged = causal._placebo_is_unchanged
+
+    def counting_is_unchanged(original, permuted):
+        nonlocal unchanged
+        verdict = real_is_unchanged(original, permuted)
+        unchanged += bool(verdict)
+        return verdict
+
+    causal._placebo_is_unchanged = counting_is_unchanged
+    try:
+        result = run_dml_analysis(
+            frame,
+            treatment_col="treatment",
+            outcome_col="outcome",
+            confounder_cols=["confounder"],
+            n_folds=2,
+            embargo=1,
+            n_placebo=n_placebo,
+            block_size=50,
+            seed=3,
+            horizon=1,
+            time_col="timestamp",
+            entity_col="symbol",
+        )
+    finally:
+        causal._placebo_is_unchanged = real_is_unchanged
+
+    # Without a draw that came back unchanged the run says nothing about the guard:
+    # it would pass under the per-draw abort this replaces.
+    assert 0 < unchanged < n_placebo, f"{unchanged} of {n_placebo} draws were the identity"
+    assert result["refutation"]["n_successful"] >= 10
+
+
+def test_the_placebo_guard_sees_through_missing_treatment_values() -> None:
+    """`np.array_equal` calls two arrays different wherever either holds a NaN, so
+    comparing raw would report every identity draw as a real permutation on any
+    frame the resolver's drop_nulls() never touched."""
+    treatment = np.array([1.0, np.nan, 3.0, 4.0])
+
+    assert _placebo_is_unchanged(treatment, treatment.copy())
+    assert not _placebo_is_unchanged(treatment, np.array([3.0, np.nan, 1.0, 4.0]))
+    assert not _placebo_is_unchanged(treatment, np.array([1.0, 2.0, 3.0, 4.0]))
+
+
+def test_an_explicit_gap_tolerance_moves_the_boundary() -> None:
+    """The default clears a weekend at four cadences. A caller that passes its own
+    tolerance decides where a series stops being contiguous."""
+    dates = pd.bdate_range("2024-01-01", periods=20).to_numpy()
+    treatment = np.arange(20, dtype=float)
+
+    tolerant = block_permute(
+        treatment,
+        block_size=8,
+        rng=np.random.default_rng(5),
+        groups=dates,
+        expected_step="1D",
+    )
+    strict = block_permute(
+        treatment,
+        block_size=8,
+        rng=np.random.default_rng(5),
+        groups=dates,
+        expected_step="1D",
+        gap_tolerance="1D",
+    )
+
+    assert not np.array_equal(tolerant, treatment)
+    assert np.array_equal(strict, treatment)

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -440,17 +442,11 @@ def test_an_explicit_gap_tolerance_moves_the_boundary() -> None:
     assert np.array_equal(strict, treatment)
 
 
-def test_a_partly_frozen_panel_reports_how_much_never_moved() -> None:
-    """A unit too short to hold two blocks is returned intact, which is right for that
-    unit and invisible in the result unless it is measured. Those rows sit at their
-    observed values in every placebo, so the placebo effects cluster on the observed
-    effect and the p-value is pulled toward 1 - a "Fails" that looks measured. The
-    all-draws-unchanged guard does not fire, because most of the panel does move."""
-    rng = np.random.default_rng(11)
-    long_dates = pd.date_range("2020-01-01", periods=200, freq="B")
-    short_dates = long_dates[:10]
+def _panel_of(spec: dict[str, pd.DatetimeIndex], seed: int = 11) -> pd.DataFrame:
+    """A panel whose entities carry the given decision times."""
+    rng = np.random.default_rng(seed)
     frames = []
-    for symbol, dates in (("LONG", long_dates), ("SHORT", short_dates)):
+    for symbol, dates in spec.items():
         confounder = rng.normal(size=len(dates))
         treatment = 0.4 * confounder + rng.normal(size=len(dates))
         frames.append(
@@ -464,25 +460,84 @@ def test_a_partly_frozen_panel_reports_how_much_never_moved() -> None:
                 }
             )
         )
-    frame = pd.concat(frames, ignore_index=True).sort_values(["timestamp", "symbol"])
+    return pd.concat(frames, ignore_index=True).sort_values(["timestamp", "symbol"])
 
-    with pytest.warns(UserWarning, match="never moved"):
-        result = run_dml_analysis(
-            frame,
-            treatment_col="treatment",
-            outcome_col="outcome",
-            confounder_cols=["confounder"],
-            n_folds=2,
-            embargo=1,
-            n_placebo=20,
-            block_size=20,
-            seed=5,
-            horizon=1,
-            time_col="timestamp",
-            entity_col="symbol",
-        )
+
+def _refute(frame: pd.DataFrame, **kwargs):
+    defaults = dict(
+        treatment_col="treatment",
+        outcome_col="outcome",
+        confounder_cols=["confounder"],
+        n_folds=2,
+        embargo=1,
+        n_placebo=20,
+        seed=5,
+        horizon=1,
+        time_col="timestamp",
+        entity_col="symbol",
+        expected_step=pd.Timedelta(days=1),
+    )
+    return run_dml_analysis(frame, **{**defaults, **kwargs})
+
+
+def test_the_block_remainder_is_not_reported_as_a_frozen_series() -> None:
+    """Every segment whose length is not a multiple of the block size leaves a trailing
+    remainder in place, on every draw. That is a property of block permutation, not of
+    the data: no gap tolerance can remove it and shrinking the block size to chase it is
+    the wrong response. Counting it as frozen fires the warning on essentially every
+    real run - the resolver passes a cadence, so entities split into several segments
+    and each contributes a remainder - and tells the author a false cause."""
+    # 105 rows is five whole blocks and a remainder of five; 55 is two and a remainder
+    # of fifteen. Neither segment is short: both hold at least two blocks.
+    early = pd.bdate_range("2020-01-01", periods=105)
+    late = pd.bdate_range("2020-08-01", periods=55)
+    dates = early.append(late)
+    frame = _panel_of({"A": dates, "B": dates})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _refute(frame, block_size=20)
 
     refutation = result["refutation"]
-    # The ten SHORT rows cannot hold two blocks of twenty; the two hundred LONG ones can.
-    assert refutation["placebo_frozen_fraction"] == pytest.approx(10 / 210, abs=1e-9)
+    assert refutation["placebo_frozen_fraction"] == 0.0
+    assert refutation["placebo_remainder_fraction"] == pytest.approx(40 / 320, abs=1e-9)
+    assert not [w for w in caught if "cannot move" in str(w.message)]
+
+
+def test_a_partly_frozen_panel_reports_how_much_never_moved() -> None:
+    """A unit too short to hold two blocks is returned intact, which is right for that
+    unit and invisible in the result unless it is measured. Those rows sit at their
+    observed values in every placebo, so the placebo effects cluster on the observed
+    effect and the p-value is pulled toward 1 - a "Fails" that looks measured. The
+    all-draws-unchanged guard does not fire, because most of the panel does move.
+
+    The long entity here is deliberately not a multiple of the block size, so the two
+    reasons a row never moves are both present and the test pins that they are counted
+    apart."""
+    frame = _panel_of(
+        {
+            "LONG": pd.bdate_range("2020-01-01", periods=205),
+            "SHORT": pd.bdate_range("2020-01-01", periods=10),
+        }
+    )
+
+    with pytest.warns(UserWarning, match="cannot move"):
+        result = _refute(frame, block_size=20)
+
+    refutation = result["refutation"]
+    # Ten SHORT rows cannot hold two blocks; five LONG rows are the block remainder.
+    assert refutation["placebo_frozen_fraction"] == pytest.approx(10 / 215, abs=1e-9)
+    assert refutation["placebo_remainder_fraction"] == pytest.approx(5 / 215, abs=1e-9)
     assert 0 < refutation["placebo_moved_fraction"] < 1
+
+
+def test_movement_accounting_does_not_treat_a_shifted_null_as_a_moved_panel() -> None:
+    """`_placebo_moved_mask` answers "are these the same series at all", so a
+    disagreement in null positions makes every row count as moved. Reusing that for the
+    movement accounting would report a panel that barely moved as fully permuted the
+    moment one draw shifted a missing value."""
+    original = np.array([1.0, np.nan, 3.0, 4.0])
+    shifted_null = np.array([1.0, 2.0, 3.0, 4.0])
+
+    assert causal._placebo_moved_mask(original, shifted_null).all()
+    assert causal._placebo_moved_fraction(original, shifted_null) == 0.0

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.dummy import DummyRegressor
 
 from case_studies.utils import causal
@@ -369,15 +370,15 @@ def test_one_identity_draw_does_not_abort_a_permutable_series() -> None:
     n_placebo = 30
 
     unchanged = 0
-    real_is_unchanged = causal._placebo_is_unchanged
+    real_moved_mask = causal._placebo_moved_mask
 
-    def counting_is_unchanged(original, permuted):
+    def counting_moved_mask(original, permuted):
         nonlocal unchanged
-        verdict = real_is_unchanged(original, permuted)
-        unchanged += bool(verdict)
-        return verdict
+        moved = real_moved_mask(original, permuted)
+        unchanged += not moved.any()
+        return moved
 
-    causal._placebo_is_unchanged = counting_is_unchanged
+    causal._placebo_moved_mask = counting_moved_mask
     try:
         result = run_dml_analysis(
             frame,
@@ -394,7 +395,7 @@ def test_one_identity_draw_does_not_abort_a_permutable_series() -> None:
             entity_col="symbol",
         )
     finally:
-        causal._placebo_is_unchanged = real_is_unchanged
+        causal._placebo_moved_mask = real_moved_mask
 
     # Without a draw that came back unchanged the run says nothing about the guard:
     # it would pass under the per-draw abort this replaces.
@@ -437,3 +438,51 @@ def test_an_explicit_gap_tolerance_moves_the_boundary() -> None:
 
     assert not np.array_equal(tolerant, treatment)
     assert np.array_equal(strict, treatment)
+
+
+def test_a_partly_frozen_panel_reports_how_much_never_moved() -> None:
+    """A unit too short to hold two blocks is returned intact, which is right for that
+    unit and invisible in the result unless it is measured. Those rows sit at their
+    observed values in every placebo, so the placebo effects cluster on the observed
+    effect and the p-value is pulled toward 1 - a "Fails" that looks measured. The
+    all-draws-unchanged guard does not fire, because most of the panel does move."""
+    rng = np.random.default_rng(11)
+    long_dates = pd.date_range("2020-01-01", periods=200, freq="B")
+    short_dates = long_dates[:10]
+    frames = []
+    for symbol, dates in (("LONG", long_dates), ("SHORT", short_dates)):
+        confounder = rng.normal(size=len(dates))
+        treatment = 0.4 * confounder + rng.normal(size=len(dates))
+        frames.append(
+            pd.DataFrame(
+                {
+                    "timestamp": dates,
+                    "symbol": symbol,
+                    "treatment": treatment,
+                    "outcome": 0.3 * treatment + 0.2 * confounder + rng.normal(size=len(dates)),
+                    "confounder": confounder,
+                }
+            )
+        )
+    frame = pd.concat(frames, ignore_index=True).sort_values(["timestamp", "symbol"])
+
+    with pytest.warns(UserWarning, match="never moved"):
+        result = run_dml_analysis(
+            frame,
+            treatment_col="treatment",
+            outcome_col="outcome",
+            confounder_cols=["confounder"],
+            n_folds=2,
+            embargo=1,
+            n_placebo=20,
+            block_size=20,
+            seed=5,
+            horizon=1,
+            time_col="timestamp",
+            entity_col="symbol",
+        )
+
+    refutation = result["refutation"]
+    # The ten SHORT rows cannot hold two blocks of twenty; the two hundred LONG ones can.
+    assert refutation["placebo_frozen_fraction"] == pytest.approx(10 / 210, abs=1e-9)
+    assert 0 < refutation["placebo_moved_fraction"] < 1

--- a/tests/test_causal_refutation_pvalue.py
+++ b/tests/test_causal_refutation_pvalue.py
@@ -1,0 +1,99 @@
+"""The two properties the block-permutation refutation rests on.
+
+Both were broken together, and the pair is what made the test easy to pass and
+its result impossible: `block_size` was taken from `embargo_periods`, so at the
+common `embargo_periods = 1` the "block" permutation was an iid shuffle that
+destroys exactly the serial dependence the placebo is supposed to keep; and the
+p-value omitted the plus-one correction, so a run in which no placebo reached
+the observed effect published `p = 0.000`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from case_studies.utils.causal import block_permute, empirical_permutation_p
+
+
+class TestEmpiricalPermutationP:
+    def test_no_placebo_reaches_the_effect_reports_the_resolution_not_zero(self) -> None:
+        """100 permutations cannot establish p = 0; they can establish p <= 1/101."""
+        placebo = np.full(100, 0.01)
+
+        p = empirical_permutation_p(placebo, observed_effect=5.0)
+
+        assert p == pytest.approx(1.0 / 101.0)
+        assert p > 0.0
+
+    def test_the_floor_is_set_by_how_many_permutations_were_run(self) -> None:
+        few = empirical_permutation_p(np.full(10, 0.01), observed_effect=5.0)
+        many = empirical_permutation_p(np.full(1000, 0.01), observed_effect=5.0)
+
+        assert few == pytest.approx(1.0 / 11.0)
+        assert many == pytest.approx(1.0 / 1001.0)
+        assert many < few
+
+    def test_every_placebo_reaching_the_effect_reports_one(self) -> None:
+        """An effect the permutation reproduces every time is not evidence."""
+        assert empirical_permutation_p(np.full(20, 1.0), observed_effect=0.5) == 1.0
+
+    def test_the_count_is_two_sided(self) -> None:
+        """A negative placebo of the same magnitude is as extreme as a positive one."""
+        placebo = np.array([-2.0, -2.0, 0.0, 0.0])
+
+        assert empirical_permutation_p(placebo, observed_effect=1.0) == pytest.approx(3.0 / 5.0)
+        assert empirical_permutation_p(placebo, observed_effect=-1.0) == pytest.approx(3.0 / 5.0)
+
+    def test_the_fraction_is_otherwise_the_plain_one(self) -> None:
+        """Away from the boundary the correction is the only difference."""
+        placebo = np.array([3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+        assert empirical_permutation_p(placebo, observed_effect=1.0) == pytest.approx(4.0 / 10.0)
+
+
+class TestBlockSizePreservesDependence:
+    """Why taking block_size from a unit embargo emptied the refutation."""
+
+    @staticmethod
+    def _one_symbol(n: int = 24):
+        dates = pd.to_datetime([f"2024-01-{d + 1:02d}" for d in range(n)]).to_numpy()
+        units = np.array(["BTC"] * n)
+        return np.arange(n, dtype=float), dates, units
+
+    def test_block_size_one_leaves_no_contiguous_pair(self) -> None:
+        """The degenerate case: block_size = 1 is an iid shuffle."""
+        arr, dates, units = self._one_symbol()
+
+        permuted = block_permute(
+            arr,
+            block_size=1,
+            rng=np.random.default_rng(0),
+            groups=dates,
+            units=units,
+            expected_step="1D",
+        )
+
+        adjacent = np.sum(np.diff(permuted) == 1.0)
+        assert sorted(permuted) == sorted(arr)
+        assert adjacent <= 2, "a unit block size left the series essentially in order"
+
+    def test_a_horizon_sized_block_keeps_the_series_locally_intact(self) -> None:
+        """What the permutation is for: shuffle position, keep local structure."""
+        arr, dates, units = self._one_symbol()
+        block = 6
+
+        permuted = block_permute(
+            arr,
+            block_size=block,
+            rng=np.random.default_rng(0),
+            groups=dates,
+            units=units,
+            expected_step="1D",
+        )
+
+        adjacent = np.sum(np.diff(permuted) == 1.0)
+        assert sorted(permuted) == sorted(arr)
+        # Four blocks of six: five of every six steps stay contiguous.
+        assert adjacent >= len(arr) - len(arr) // block - 1

--- a/tests/test_causal_refutation_pvalue.py
+++ b/tests/test_causal_refutation_pvalue.py
@@ -14,7 +14,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from case_studies.utils.causal import block_permute, empirical_permutation_p
+from case_studies.utils.causal import (
+    REFUTATION_ALPHA,
+    block_permute,
+    classify_refutation,
+    empirical_permutation_p,
+)
 
 
 class TestEmpiricalPermutationP:
@@ -97,3 +102,29 @@ class TestBlockSizePreservesDependence:
         assert sorted(permuted) == sorted(arr)
         # Four blocks of six: five of every six steps stay contiguous.
         assert adjacent >= len(arr) - len(arr) // block - 1
+
+
+class TestUnderpoweredRefutation:
+    """The plus-one correction floors the p-value, so few draws cannot reject."""
+
+    def test_nineteen_draws_cannot_reach_the_alpha_the_classifier_tests(self) -> None:
+        # The most extreme result 19 draws can produce: no placebo reaches the observed
+        # effect. Even then the reported p-value is at the threshold, not below it.
+        strongest = empirical_permutation_p(np.zeros(19), observed_effect=1.0)
+
+        assert strongest == 1 / 20
+        assert not strongest < REFUTATION_ALPHA
+
+    def test_a_draw_count_that_cannot_reject_is_reported_as_underpowered(self) -> None:
+        # "Fails" here would be untrue by construction - the same defect as p = 0.000
+        # at the other end of the range - because no data could have produced "Passes".
+        assert classify_refutation(1 / 20, n_successful=19) == "Underpowered"
+        assert classify_refutation(1.0, n_successful=10) == "Underpowered"
+
+    def test_twenty_draws_are_enough_to_answer(self) -> None:
+        assert classify_refutation(1 / 21, n_successful=20) == "Passes"
+        assert classify_refutation(0.9, n_successful=20) == "Fails"
+
+    def test_a_caller_without_the_draw_count_keeps_the_two_way_answer(self) -> None:
+        assert classify_refutation(0.01) == "Passes"
+        assert classify_refutation(0.9) == "Fails"

--- a/tests/test_causal_registry_registration.py
+++ b/tests/test_causal_registry_registration.py
@@ -59,67 +59,13 @@ def test_identical_causal_result_does_not_refresh_execution_provenance(tmp_path)
     assert changed[4] == first[4]
 
 
-def test_the_draw_count_is_persisted_so_the_verdict_can_be_recomputed(tmp_path) -> None:
-    """A reader holding only `refutation_p` cannot tell a run that failed from one whose
-    draws could never have rejected. The plus-one correction floors the p-value at
-    1 / (n + 1), so a preview run of ten draws reports 0.09 at best and any bare
-    threshold republishes it as "Fails". Persisting the count is what lets every reader
-    reach the same verdict from the same rule."""
-    case_dir = tmp_path / "test_case"
-    register_causal_run(
-        "test_case",
-        "causal_underpowered",
-        label="fwd_ret_5d",
-        treatment="ivrv_spread",
-        confounders_json='["rv_20"]',
-        embargo=10,
-        n_folds=5,
-        n_obs=100,
-        dml_effect=-0.02,
-        dml_se_hac=0.02,
-        p_value_hac=0.25,
-        naive_effect=-0.02,
-        confounding_bias_pct=-0.5,
-        refutation_p=1 / 11,
-        refutation_n_successful=10,
-        spec_json='{"family":"causal_dml"}',
-        notebook="12_causal_dml",
-        started_at="first",
-        elapsed_s=1.0,
-        case_dir=case_dir,
-    )
-
-    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
-        stored = db.execute(
-            "SELECT refutation_p, refutation_n_successful FROM causal_runs "
-            "WHERE causal_hash='causal_underpowered'"
-        ).fetchone()
-
-    assert stored[1] == 10
-    assert classify_refutation(stored[0], stored[1]) == "Underpowered"
-    # The two-way rule a reader would otherwise apply to the same p-value.
-    assert ("Passes" if stored[0] < REFUTATION_ALPHA else "Fails") == "Fails"
-
-
-def test_a_registry_written_before_the_draw_count_existed_gains_the_column(tmp_path) -> None:
-    case_dir = tmp_path / "test_case"
-    _register(case_dir, effect=-0.0228, started_at="first", elapsed_s=10.0)
-    db_path = case_dir / "run_log" / "registry.db"
-    with sqlite3.connect(db_path) as db:
-        db.execute("ALTER TABLE causal_runs DROP COLUMN refutation_n_successful")
-        assert "refutation_n_successful" not in {
-            row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
-        }
-
-    _register(case_dir, effect=-0.0228, started_at="second", elapsed_s=11.0)
-
-    with sqlite3.connect(db_path) as db:
-        assert "refutation_n_successful" in {
-            row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
-        }
-
-
 def _register_immutable(case_dir, **overrides) -> None:
+    """Registers through the immutable path, which `_register` above does not reach.
+    `register_causal_run` enforces immutability only when the spec carries an
+    `identity_version` it recognises, so a spec without one is accepted and silently
+    overwritten. A test built on such a spec passes whatever the check does, including
+    nothing. Every assertion about a conflict, or about a conflict correctly not being
+    raised, has to come through here."""
     fields = dict(
         label="fwd_ret_5d",
         treatment="ivrv_spread",

--- a/tests/test_causal_registry_registration.py
+++ b/tests/test_causal_registry_registration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 
+from case_studies.utils.causal import REFUTATION_ALPHA, classify_refutation
 from case_studies.utils.registry.registration import register_causal_run
 
 
@@ -51,3 +52,63 @@ def test_identical_causal_result_does_not_refresh_execution_provenance(tmp_path)
     changed = _row(case_dir)
     assert changed[0:3] == (-0.0230, "third", 30.0)
     assert changed[4] == first[4]
+
+
+def test_the_draw_count_is_persisted_so_the_verdict_can_be_recomputed(tmp_path) -> None:
+    """A reader holding only `refutation_p` cannot tell a run that failed from one whose
+    draws could never have rejected. The plus-one correction floors the p-value at
+    1 / (n + 1), so a preview run of ten draws reports 0.09 at best and any bare
+    threshold republishes it as "Fails". Persisting the count is what lets every reader
+    reach the same verdict from the same rule."""
+    case_dir = tmp_path / "test_case"
+    register_causal_run(
+        "test_case",
+        "causal_underpowered",
+        label="fwd_ret_5d",
+        treatment="ivrv_spread",
+        confounders_json='["rv_20"]',
+        embargo=10,
+        n_folds=5,
+        n_obs=100,
+        dml_effect=-0.02,
+        dml_se_hac=0.02,
+        p_value_hac=0.25,
+        naive_effect=-0.02,
+        confounding_bias_pct=-0.5,
+        refutation_p=1 / 11,
+        refutation_n_successful=10,
+        spec_json='{"family":"causal_dml"}',
+        notebook="12_causal_dml",
+        started_at="first",
+        elapsed_s=1.0,
+        case_dir=case_dir,
+    )
+
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        stored = db.execute(
+            "SELECT refutation_p, refutation_n_successful FROM causal_runs "
+            "WHERE causal_hash='causal_underpowered'"
+        ).fetchone()
+
+    assert stored[1] == 10
+    assert classify_refutation(stored[0], stored[1]) == "Underpowered"
+    # The two-way rule a reader would otherwise apply to the same p-value.
+    assert ("Passes" if stored[0] < REFUTATION_ALPHA else "Fails") == "Fails"
+
+
+def test_a_registry_written_before_the_draw_count_existed_gains_the_column(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, effect=-0.0228, started_at="first", elapsed_s=10.0)
+    db_path = case_dir / "run_log" / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("ALTER TABLE causal_runs DROP COLUMN refutation_n_successful")
+        assert "refutation_n_successful" not in {
+            row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
+        }
+
+    _register(case_dir, effect=-0.0228, started_at="second", elapsed_s=11.0)
+
+    with sqlite3.connect(db_path) as db:
+        assert "refutation_n_successful" in {
+            row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
+        }

--- a/tests/test_causal_registry_registration.py
+++ b/tests/test_causal_registry_registration.py
@@ -169,3 +169,20 @@ def test_a_nullable_column_gaining_a_value_is_still_a_conflict(tmp_path) -> None
         assert "refutation_p" in str(error)
     else:
         raise AssertionError("a refutation p-value appearing where there was none is a change")
+
+
+def test_a_migrated_column_that_changes_from_a_stored_value_names_itself(tmp_path) -> None:
+    """The backfill exists for NULL, not for the column. A migrated column whose stored
+    value is present and different - a recording convention that changes the count, or a
+    re-registration passing None where a number was stored - is a real difference, and
+    excluding it from the message by name raises naming nothing. That empty message is
+    what this file already fixed once from the NULL side."""
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir, refutation_n_successful=1000)
+
+    try:
+        _register_immutable(case_dir, refutation_n_successful=998, started_at="second")
+    except ValueError as error:
+        assert "refutation_n_successful" in str(error), f"the conflict named nothing: {error}"
+    else:
+        raise AssertionError("a changed draw count on an immutable row must not be accepted")

--- a/tests/test_causal_registry_registration.py
+++ b/tests/test_causal_registry_registration.py
@@ -152,3 +152,20 @@ def test_a_registry_written_before_the_draw_count_existed_gains_the_column(tmp_p
         assert "refutation_n_successful" in {
             row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
         }
+
+
+def test_a_nullable_column_gaining_a_value_is_still_a_conflict(tmp_path) -> None:
+    """`refutation_p` is NULL whenever the refutation produced too few successful
+    placebos, so a stored NULL there means "this run could not answer", not "the registry
+    had nowhere to put it". A later run that does produce a p-value has changed. Only a
+    column a migration added may be filled on NULL; widening that to every nullable column
+    writes a changed result onto an immutable row."""
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir, refutation_p=None)
+
+    try:
+        _register_immutable(case_dir, refutation_p=0.01, started_at="second")
+    except ValueError as error:
+        assert "refutation_p" in str(error)
+    else:
+        raise AssertionError("a refutation p-value appearing where there was none is a change")

--- a/tests/test_causal_registry_registration.py
+++ b/tests/test_causal_registry_registration.py
@@ -7,6 +7,11 @@ import sqlite3
 from case_studies.utils.causal import REFUTATION_ALPHA, classify_refutation
 from case_studies.utils.registry.registration import register_causal_run
 
+# A spec whose identity_version is supported is what puts a row on the immutable path;
+# without one, register_causal_run overwrites freely and an immutability test proves
+# nothing.
+IMMUTABLE_SPEC = '{"family":"causal_dml","identity_version":3}'
+
 
 def _register(case_dir, *, effect: float, started_at: str, elapsed_s: float) -> None:
     register_causal_run(
@@ -107,6 +112,95 @@ def test_a_registry_written_before_the_draw_count_existed_gains_the_column(tmp_p
         }
 
     _register(case_dir, effect=-0.0228, started_at="second", elapsed_s=11.0)
+
+    with sqlite3.connect(db_path) as db:
+        assert "refutation_n_successful" in {
+            row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()
+        }
+
+
+def _register_immutable(case_dir, **overrides) -> None:
+    fields = dict(
+        label="fwd_ret_5d",
+        treatment="ivrv_spread",
+        confounders_json='["rv_20"]',
+        embargo=10,
+        n_folds=5,
+        n_obs=100,
+        dml_effect=-0.02,
+        dml_se_hac=0.02,
+        p_value_hac=0.25,
+        naive_effect=-0.02,
+        confounding_bias_pct=-0.5,
+        refutation_p=1 / 11,
+        refutation_n_successful=10,
+        spec_json=IMMUTABLE_SPEC,
+        notebook="12_causal_dml",
+        started_at="first",
+        elapsed_s=1.0,
+        case_dir=case_dir,
+    )
+    fields.update(overrides)
+    register_causal_run("test_case", "causal_immutable", **fields)
+
+
+def _stored(case_dir, column: str):
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        return db.execute(
+            f"SELECT {column} FROM causal_runs WHERE causal_hash='causal_immutable'"
+        ).fetchone()[0]
+
+
+def test_the_draw_count_is_persisted_so_the_verdict_can_be_recomputed(tmp_path) -> None:
+    """A reader holding only `refutation_p` cannot tell a run that failed from one whose
+    draws could never have rejected. The plus-one correction floors the p-value at
+    1 / (n + 1), so a preview run of ten draws reports 0.09 at best and any bare
+    threshold republishes it as a verdict the data never supported. Persisting the count
+    is what lets every reader reach the same verdict from the same rule."""
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir)
+
+    assert _stored(case_dir, "refutation_n_successful") == 10
+    assert classify_refutation(_stored(case_dir, "refutation_p"), 10) == "Underpowered"
+    # The two-way rule a reader would otherwise apply to the same p-value.
+    assert (_stored(case_dir, "refutation_p") < REFUTATION_ALPHA) is False
+
+
+def test_filling_a_column_that_did_not_exist_yet_is_not_a_conflict(tmp_path) -> None:
+    """Rows written before `refutation_n_successful` existed carry NULL there. Recording
+    the count on a re-registration of the identical result must not read as the result
+    having changed: an upgrade that breaks re-registration of unchanged results is the
+    same shape as a fix that forces a refit without moving a number."""
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("UPDATE causal_runs SET refutation_n_successful = NULL")
+
+    _register_immutable(case_dir, refutation_n_successful=100, started_at="second")
+
+    assert _stored(case_dir, "refutation_n_successful") == 100
+
+
+def test_a_value_that_actually_changes_is_still_a_conflict(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir)
+
+    try:
+        _register_immutable(case_dir, dml_effect=-0.9999)
+    except ValueError as error:
+        assert "dml_effect" in str(error)
+    else:
+        raise AssertionError("a changed effect must not be accepted onto an immutable row")
+
+
+def test_a_registry_written_before_the_draw_count_existed_gains_the_column(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register_immutable(case_dir)
+    db_path = case_dir / "run_log" / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("ALTER TABLE causal_runs DROP COLUMN refutation_n_successful")
+
+    _register_immutable(case_dir, started_at="second")
 
     with sqlite3.connect(db_path) as db:
         assert "refutation_n_successful" in {

--- a/tests/test_causal_result_read.py
+++ b/tests/test_causal_result_read.py
@@ -1,0 +1,105 @@
+"""Reading a causal result must survive a registry written before the column existed.
+
+`refutation_n_successful` arrived with a migration. `CausalResult.open` reads through a
+plain connection rather than the migrating opener - on purpose, since a read that
+rewrites the schema of a registry it was only asked to look at is a write - so naming the
+column unconditionally raised OperationalError on every pre-migration registry. The cache
+probe in `run_resolved_causal_request` catches only KeyError, so that error escaped past
+the probe, the registering write that would have migrated the database never ran, and the
+next attempt failed the same way.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from case_studies.research.causal import CausalResult
+from case_studies.utils.registry.registration import register_causal_run
+
+SPEC = '{"family":"causal_dml","identity_version":3}'
+
+
+def _register(case_dir, *, refutation_p, n_successful) -> None:
+    register_causal_run(
+        "test_case",
+        "causal_read",
+        label="fwd_ret_5d",
+        treatment="ivrv_spread",
+        confounders_json='["rv_20"]',
+        embargo=10,
+        n_folds=5,
+        n_obs=100,
+        dml_effect=-0.02,
+        dml_se_hac=0.02,
+        p_value_hac=0.25,
+        naive_effect=-0.02,
+        confounding_bias_pct=-0.5,
+        refutation_p=refutation_p,
+        refutation_n_successful=n_successful,
+        spec_json=SPEC,
+        notebook="12_causal_dml",
+        started_at="first",
+        elapsed_s=1.0,
+        case_dir=case_dir,
+    )
+
+
+def _study(case_dir):
+    return SimpleNamespace(root=case_dir, output_root=None)
+
+
+def _drop_the_column(case_dir) -> None:
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("ALTER TABLE causal_runs DROP COLUMN refutation_n_successful")
+
+
+def test_a_registry_without_the_draw_count_can_still_be_read(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, refutation_p=1 / 11, n_successful=10)
+    _drop_the_column(case_dir)
+
+    result = CausalResult.open(_study(case_dir), "causal_read")
+
+    assert result.metrics["refutation_p"] == pytest.approx(1 / 11)
+    assert result.metrics["refutation_n_successful"] is None
+
+
+def test_an_unknown_draw_count_yields_no_verdict(tmp_path) -> None:
+    """A p-value of 0.09 is "Fails" under a bare threshold and "Underpowered" under ten
+    draws. With the count unknown the reader cannot tell which, and reporting the first is
+    exactly the mistake deriving the class centrally exists to prevent."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, refutation_p=1 / 11, n_successful=10)
+    _drop_the_column(case_dir)
+
+    result = CausalResult.open(_study(case_dir), "causal_read")
+
+    assert result.metrics["refutation_class"] is None
+
+
+def test_a_known_draw_count_still_yields_its_verdict(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, refutation_p=1 / 11, n_successful=10)
+
+    result = CausalResult.open(_study(case_dir), "causal_read")
+
+    assert result.metrics["refutation_n_successful"] == 10
+    assert result.metrics["refutation_class"] == "Underpowered"
+
+
+def test_a_null_draw_count_in_a_present_column_also_yields_no_verdict(tmp_path) -> None:
+    """The column present and NULL is a different state from the column absent, and only
+    this one isolates the classification. With the column dropped both tests above fail on
+    the read, so neither of them can tell whether the verdict rule was fixed."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, refutation_p=1 / 11, n_successful=10)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("UPDATE causal_runs SET refutation_n_successful = NULL")
+
+    result = CausalResult.open(_study(case_dir), "causal_read")
+
+    assert result.metrics["refutation_n_successful"] is None
+    assert result.metrics["refutation_class"] is None


### PR DESCRIPTION
## What this is

The shared causal refutation in `case_studies/utils/causal.py` published numbers
it had not measured. Nine commits fix the measurement, the registry column that
carries its verdict, and the reads of that column. 65 tests pass across five
files, 1133 insertions.

## The refutation was not a test that could fail

**`p = 0.000` from 100 draws.** The p-value omitted the plus-one correction, so
a run where no placebo drew an effect as large as the observed one published a
number 100 draws cannot support. The floor 100 draws can report is 1/101.
`empirical_permutation_p` now counts the observed effect among the draws.

**The block permutation was an iid shuffle wherever the embargo was 1.**
`block_size` came from `embargo_periods`. It destroyed the serial dependence it
exists to preserve, so the null it compared against was not the null the
markdown describes. It now comes from the label horizon.

**`block_permute` treated a flattened panel as one series**, permuting blocks
across the boundary between entities and across gaps in time. It now takes
groups and units, splits on both, and leaves a segment shorter than one block
intact. `gap_tolerance` defaults to four cadences so a weekend does not split a
daily series.

**The guard on that path aborted runs that were fine.** `rng.permutation`
returns the identity by chance - one time in two at two blocks, one in six at
three - and aborting on any single unchanged draw gives two units at three
blocks a 94% chance of at least one abort over 100 placebos, with a message
asserting something false about the data. The condition worth refusing is every
draw coming back unchanged, which means no segment can hold two blocks. The
comparison is NaN-aware: `np.array_equal` calls two arrays different wherever
either holds a NaN, which is every frame the case-study notebooks pass in.

## What the placebo left standing, and when it cannot answer

**A frozen panel reported "Fails".** A segment too short to hold two blocks is
returned intact, which is right for one short unit in a panel and invisible in
the result: those rows sit at their observed values in every draw, the placebo
effects cluster on the observed effect, and the p-value is pulled toward 1.
`run_dml_analysis` now records `placebo_frozen_fraction` and
`placebo_moved_fraction` and warns whenever anything is frozen.

**The frozen share was counted off the draws, which conflated two causes.**
`block_permute` re-appends a segment's trailing `n % block_size` rows at their
original position with their original values - a property of block permutation
that no gap tolerance can remove - so the warning would have fired on
essentially every real run, naming a cause that was not the cause and
recommending a remedy that cannot work. `_permutation_segments` is now the
single definition of where a series is cut, used by `block_permute` to permute
and `_immobile_masks` to count what it leaves standing, so the two cannot
disagree. Short segments warn as `placebo_frozen_fraction`; the remainder is
`placebo_remainder_fraction` and does not.

**Twenty draws or fewer could not report a pass.** The plus-one correction
floors the p-value at 1/(n+1), so at 19 successful draws the smallest value the
test can produce is already at or above the 5% threshold and "Fails" was
published whatever the data said. That is the ordinary case in the preview tier,
which runs ten draws. `classify_refutation` takes the draw count and returns
"Underpowered" there.

## The verdict has to survive the registry

`refutation_class` never left `run_dml_analysis`: only `refutation_p` was
persisted, so any reader re-deriving a verdict with a bare threshold turns an
underpowered run into a pass or a fail. `causal_runs` gains
`refutation_n_successful`, with a migration, and `CausalResult.metrics` exposes
both the count and the class.

That column then had to be added without breaking what was already stored, and
the first three attempts each broke something:

1. **Adding the column broke re-registration of an unchanged result.** A row
   written before the column carries NULL there, so re-registering the identical
   result compared a supplied count against NULL and raised. A stored NULL is
   now filled rather than compared.
2. **Filling any NULL was wider than the reason the fill exists.**
   `refutation_p` is NULL whenever the refutation produced too few successful
   placebos - that records that the run could not answer, not that the registry
   had nowhere to put the answer. A later re-registration under the same
   `causal_hash` that did produce a p-value was written straight onto the
   immutable row, refreshing `started_at`, `elapsed_s` and `git_commit` on the
   way. The backfill is now restricted to `MIGRATION_BACKFILLED_COLUMNS`.
3. **The conflict message named nothing, twice, from opposite sides.** It first
   filtered out any column whose stored value was NULL, which is precisely a
   NULL-to-value change; the fix for that excluded the backfillable columns by
   name, which is wrong for a migrated column whose stored value is present and
   different. It now excludes the positions the backfill actually filled.

**A read must not migrate.** `CausalResult.open` named
`refutation_n_successful` on a plain `sqlite3` connection, which never runs
`_migrate_registry` - only `_open_registry` does - so against any registry
written before this branch the read raised `OperationalError`. That escaped
further than it looks: the cache probe in `run_resolved_causal_request` catches
`KeyError` only, so the error propagated out, the registering write that would
have migrated the database never happened, and re-running the notebook failed
identically. The reader keeps its plain connection deliberately - migrating on
read would mean a process asked to look at a registry rewrites its schema - and
now asks `PRAGMA table_info` first, selecting NULL under the column's name when
it is absent. `refutation_class` returns `None` without a count.

## Tests

65 pass across `test_causal_adapter.py`, `test_causal_panel_splits.py`,
`test_causal_refutation_pvalue.py`, `test_causal_registry_registration.py` and
`test_causal_result_read.py`. Each fix's test was checked to fail against the
version before it; two of them fail in two distinct ways across two commits,
which is how the incomplete first fix was caught.

`test_causal_registry_registration.py` also lost two test bodies Python never
ran. The file defined seven top-level tests and pytest collected five: two names
were defined twice, and Python binds the later definition. No coverage was lost -
the running five were the correct ones - but a file that reads as seven and runs
five gives the reader no way to tell which five. `_register_immutable` now
carries the reason it exists: `register_causal_run` enforces immutability only
for a spec whose `identity_version` it recognises, so a conflict test built on
the older helper asserts nothing.

## Deliberately not in this PR

The two chapter-15 notebooks that call this code, `03_econml_dml` and
`04_dml_crypto_regime`. Both block-permute a flattened panel with no groups or
units, so a block spans about a fifth of one cross-section in the first and
about 1.1 cross-sections in the second, not the seven days their labels claim;
both also label a raw tail fraction as an FDR and publish it from 100 draws.
Fixing the call sites without re-executing would leave the checked-in outputs
claiming the old numbers, and the next reader could not tell which half was
true. They belong to the teaching lane, notebooks and prose re-executed once.
