### PR TITLE
Model-analysis figures publish alt text, computed from what they just plotted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -497,6 +497,21 @@ jobs:
             tests/test_download_coverage.py \
             tests/test_plotly_renderer.py \
             -v --tb=short
+      # model_viz.py rendered the model-analysis figures for seven case studies
+      # through fig.show(), which emits an <img> with no alternative text, so all
+      # seven published figures a screen reader cannot describe. Alt text lives in
+      # output metadata, so it only reaches a notebook by executing it, and these
+      # notebooks execute rarely - which is exactly why the plumbing has to be
+      # gated rather than checked by eye. The tests require the alt text to change
+      # when the plotted data changes, so a canned sentence fails them.
+      - name: Run model-analysis figure alt-text tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          MPLBACKEND: Agg
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_model_viz_alt_text.py \
+            -v --tb=short
       # The Chapter 21 environments reached readers as broken imports partly
       # because no job ran the tests that name them: test_import_coverage.py
       # listed both notebooks while nothing invoked it. These two files pin the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -507,19 +507,17 @@ jobs:
       - name: Run model-analysis figure alt-text tests
         env:
           PYTHONPATH: ${{ github.workspace }}
-          # Agg because the job has no display; without it matplotlib picks an
-          # interactive backend and the import fails.
           MPLBACKEND: Agg
           # Importing case_studies.utils pulls in utils.config, which hard-fails at
-          # import when ML4T_DATA_PATH does not exist. This job checks out no
-          # test-data, so the workflow default points at a directory that is not
-          # there. These tests build every frame inline and read nothing from it.
+          # import when ML4T_DATA_PATH does not exist. The workflow-level default
+          # points at test-data this job does not check out. `data/` is tracked and
+          # the unconditional download-logic step above already writes the `.env`
+          # that utils.config also requires, so pointing at the repo's own `data/`
+          # is all this needs. These tests build every frame inline and read
+          # nothing from disk.
           ML4T_PATH: ${{ github.workspace }}
           ML4T_DATA_PATH: ${{ github.workspace }}/data
         run: |
-          printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
-            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
-          mkdir -p "$GITHUB_WORKSPACE/data"
           .venv/bin/python -m pytest \
             tests/test_model_viz_alt_text.py \
             -v --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -507,8 +507,19 @@ jobs:
       - name: Run model-analysis figure alt-text tests
         env:
           PYTHONPATH: ${{ github.workspace }}
+          # Agg because the job has no display; without it matplotlib picks an
+          # interactive backend and the import fails.
           MPLBACKEND: Agg
+          # Importing case_studies.utils pulls in utils.config, which hard-fails at
+          # import when ML4T_DATA_PATH does not exist. This job checks out no
+          # test-data, so the workflow default points at a directory that is not
+          # there. These tests build every frame inline and read nothing from it.
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
         run: |
+          printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
+          mkdir -p "$GITHUB_WORKSPACE/data"
           .venv/bin/python -m pytest \
             tests/test_model_viz_alt_text.py \
             -v --tb=short

--- a/case_studies/utils/model_viz.py
+++ b/case_studies/utils/model_viz.py
@@ -21,6 +21,7 @@ from utils.style import (
     add_message_title,
     ml4t_diverging,
     ml4t_palette,
+    show_with_alt,
 )
 
 ML4T_DIVERGING_CMAP = LinearSegmentedColormap.from_list("ml4t_diverging", ml4t_diverging())
@@ -43,6 +44,21 @@ FAMILY_COLORS = {
     "causal_dml": COLORS["neutral"],
     "benchmark": COLORS["slate"],
 }
+
+
+def _span(values, fmt: str = "{:+.3f}") -> str:
+    """Describe the range of the finite values a figure actually plots.
+
+    Alt text here is computed from the plotted data rather than written as prose,
+    so it cannot drift from the figure and cannot describe a chart nobody saw.
+    """
+    arr = np.asarray(list(values), dtype=float).ravel()
+    arr = arr[np.isfinite(arr)]
+    if arr.size == 0:
+        return "no finite values"
+    if arr.size == 1:
+        return fmt.format(float(arr[0]))
+    return f"{fmt.format(float(arr.min()))} to {fmt.format(float(arr.max()))}"
 
 
 def _family_color(label: str, i: int = 0) -> str:
@@ -112,7 +128,15 @@ def plot_cv_timeline(
         loc="lower right",
     )
     fig.tight_layout()
-    fig.show()
+    starts = fold_ranges["val_start"].to_list()
+    ends = fold_ranges["val_end"].to_list()
+    alt = (
+        f"Horizontal bar chart of {n_splits} walk-forward validation windows, one bar per fold, "
+        f"covering {min(starts)} to {max(ends)}."
+    )
+    if holdout_start:
+        alt += f" A dashed vertical line marks the holdout start at {holdout_start}."
+    show_with_alt(fig, alt)
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +195,13 @@ def plot_fold_heatmap(
     ax.text(n_folds + 0.3, -0.7, "Mean", ha="left", va="center", fontsize=9, fontweight="bold")
 
     fig.colorbar(im, ax=ax, label="IC", shrink=0.8)
-    fig.show()
+    show_with_alt(
+        fig,
+        f"Heatmap of information coefficient for {n_models} models down the rows and "
+        f"{n_folds} validation folds across the columns, each cell annotated with its value. "
+        f"Cell values span {_span(matrix)}; the per-model means printed at the right span "
+        f"{_span(row_means)}.",
+    )
 
     return model_labels, fold_cols, matrix
 
@@ -231,7 +261,14 @@ def plot_fold_boxplot(
     ax.set_ylabel("Mean IC per Fold")
     add_message_title(ax, title)
     fig.tight_layout()
-    fig.show()
+    n_folds = fold_ic["fold_id"].n_unique()
+    show_with_alt(
+        fig,
+        f"Box plot of mean IC per fold for {n_families} model families, with each fold's value "
+        f"overlaid as a jittered point and the mean marked by a diamond. Across "
+        f"{n_folds} folds the plotted values span {_span(np.concatenate(bp_data))}, "
+        f"against a dashed line at zero.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -274,7 +311,15 @@ def plot_bucket_monotonicity(
     add_message_title(ax, title)
     ax.legend(loc="upper left", fontsize=8)
     fig.tight_layout()
-    fig.show()
+    plotted = np.concatenate([b["mean_return"].to_numpy() for b in bucket_results.values()])
+    alt = (
+        f"Line chart of mean realized {label_name.lower()} against prediction bucket, one line per "
+        f"model family, for {len(bucket_results)} families over {n_buckets} buckets ordered lowest "
+        f"to highest score. Plotted means span {_span(plotted, '{:+.4f}')}."
+    )
+    if unconditional_mean is not None:
+        alt += f" A dashed line marks the unconditional mean at {unconditional_mean:+.4f}."
+    show_with_alt(fig, alt)
 
     # Cost context
     if cost_range:
@@ -325,9 +370,15 @@ def plot_correlation_matrix(
     ax.set_yticklabels(short_labels)
     add_message_title(ax, title)
     fig.colorbar(im, ax=ax, shrink=0.8)
-    fig.show()
-
     off_diag = corr_matrix[np.triu_indices(n, k=1)]
+    show_with_alt(
+        fig,
+        f"Heatmap of pairwise prediction correlation between {n} models, symmetric about the "
+        f"diagonal and annotated with each value. The {off_diag.size} distinct off-diagonal "
+        f"correlations span {_span(off_diag, '{:.2f}')} and average "
+        f"{float(np.nanmean(off_diag)):.2f}.",
+    )
+
     print(f"\nAverage pairwise correlation: {off_diag.mean():.2f}")
     print(f"Range: {off_diag.min():.2f} to {off_diag.max():.2f}")
 
@@ -347,6 +398,7 @@ def plot_learning_curves(
         return
 
     n_panels = len(cp_families)
+    plotted_ic: list[np.ndarray] = []
     fig, axes = plt.subplots(n_panels, 1, figsize=(12, 4 * n_panels), squeeze=False)
 
     for idx, family in enumerate(sorted(cp_families)):
@@ -359,6 +411,7 @@ def plot_learning_curves(
             y = cfg_data["ic_mean_daily"].to_numpy()
 
             ax.plot(x, y, marker=".", label=config, linewidth=1.5)
+            plotted_ic.append(y)
 
             if "ic_std" in cfg_data.columns:
                 y_std = cfg_data["ic_std"].to_numpy()
@@ -374,7 +427,15 @@ def plot_learning_curves(
         ax.legend(fontsize=7, loc="lower right")
 
     fig.tight_layout()
-    fig.show()
+    n_configs = cp_data["config_name"].n_unique()
+    show_with_alt(
+        fig,
+        f"{n_panels} stacked line charts, one per model family "
+        f"({', '.join(sorted(cp_families))}), plotting mean IC across folds against the training "
+        f"checkpoint for {n_configs} configurations in total, each against a dashed line at zero. "
+        f"Plotted IC spans "
+        f"{_span(np.concatenate(plotted_ic) if plotted_ic else np.array([]))}.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -422,7 +483,13 @@ def plot_feature_importance_heatmap(
     ax.set_yticklabels(features_sorted)
     add_message_title(ax, title)
     fig.colorbar(im, ax=ax, shrink=0.8)
-    fig.show()
+    show_with_alt(
+        fig,
+        f"Heatmap of normalized feature importance for the {n_show} features with the highest mean "
+        f"importance, down the rows, across {len(fold_cols)} folds along the columns, each cell "
+        f"annotated with its value. Plotted importances span {_span(matrix_sorted, '{:.2f}')}, on a "
+        f"scale from 0 to 1.",
+    )
 
     # Recurrence summary
     n_total_folds = importance_df["fold_id"].n_unique()
@@ -461,6 +528,7 @@ def plot_regime_bars(
     fig, ax = plt.subplots(figsize=(max(8, n_fam * 2), 5))
 
     x = np.arange(n_fam)
+    plotted_ic: list[float] = []
     width = 0.35
     colors_regime = {
         "low_vol": COLORS.get("blue", "#3B82F6"),
@@ -494,6 +562,7 @@ def plot_regime_bars(
                 ics.append(0)
                 ses.append(0)
 
+        plotted_ic.extend(ics)
         offset = (i - 0.5) * width
         bars = ax.bar(
             x + offset,
@@ -523,7 +592,12 @@ def plot_regime_bars(
     add_message_title(ax, title)
     ax.legend()
     fig.tight_layout()
-    fig.show()
+    show_with_alt(
+        fig,
+        f"Grouped bar chart of mean IC for {n_fam} model families along the x-axis, one bar per "
+        f"volatility regime ({', '.join(r.replace('_', ' ') for r in regimes)}), with error bars "
+        f"and a dashed line at zero. Plotted IC spans {_span(plotted_ic)}.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -637,7 +711,26 @@ def plot_hac_ci_leaderboard(
     ax.set_title(title)
     ax.grid(axis="x", alpha=0.3, zorder=0)
     fig.tight_layout()
-    fig.show()
+    ics = df[ic_col].to_numpy()
+    if {lo_col, hi_col}.issubset(df.columns):
+        los = df[lo_col].to_numpy().astype(float)
+        his = df[hi_col].to_numpy().astype(float)
+        finite = np.isfinite(los) & np.isfinite(his)
+        excludes_zero = int(np.sum(finite & ((los > 0) | (his < 0))))
+        ci_clause = (
+            f" {excludes_zero} of the {int(finite.sum())} intervals drawn exclude zero, "
+            f"which a dashed vertical line marks."
+        )
+    else:
+        ci_clause = " A dashed vertical line marks zero."
+    show_with_alt(
+        fig,
+        f"Dot plot of {n} model configurations, one row each, ordered by daily-pooled IC with the "
+        f"highest at the top. The dot is the point estimate and the bar is its HAC 95% confidence "
+        f"interval"
+        f"{', with a fainter bootstrap interval behind it' if has_boot else ''}. "
+        f"Point estimates span {_span(ics, '{:+.4f}')}.{ci_clause}",
+    )
 
 
 def plot_label_horizon_forest(
@@ -700,6 +793,9 @@ def plot_label_horizon_forest(
         axes = [axes]
 
     y_pos = np.arange(n_fam)
+    plotted_ic: list[float] = []
+    n_drawn = 0
+    n_excludes_zero = 0
     for ax, lbl in zip(axes, lbls):
         sub = metrics.filter(pl.col(label_col) == lbl)
         sub_map = {r[family_col]: r for r in sub.iter_rows(named=True)}
@@ -722,6 +818,9 @@ def plot_label_horizon_forest(
             hi = row.get(hi_col)
             ci_valid = lo is not None and hi is not None and np.isfinite(lo) and np.isfinite(hi)
             crosses_zero = bool(ci_valid and lo <= 0 <= hi)
+            plotted_ic.append(ic)
+            n_drawn += 1
+            n_excludes_zero += int(ci_valid and not crosses_zero)
             color = (
                 "#999999" if (not ci_valid or crosses_zero) else family_palette.get(fam, "#444444")
             )
@@ -742,7 +841,16 @@ def plot_label_horizon_forest(
     fig.supxlabel("Information Coefficient (daily-pooled, 95% HAC CI)", fontsize=9)
     if title:
         fig.suptitle(title, fontsize=11)
-    fig.show()
+    show_with_alt(
+        fig,
+        f"Forest plot in {n_lab} side-by-side panels, one per label "
+        f"({', '.join(label_display.get(l, l) for l in lbls)}), each showing daily-pooled IC with "
+        f"its 95% HAC confidence interval for {n_fam} model families on a shared y-axis. "
+        f"{n_drawn} of the {n_lab * n_fam} family-label pairs have a run, the rest marked "
+        f"'no run'; {n_excludes_zero} of the drawn intervals exclude zero and are shown in the "
+        f"family colour, the remainder in grey. Point estimates span "
+        f"{_span(plotted_ic, '{:+.4f}')}.",
+    )
 
 
 def plot_rolling_daily_ic(
@@ -789,4 +897,10 @@ def plot_rolling_daily_ic(
     ax.set_title(f"Daily IC time series{(' - ' + label) if label else ''}")
     ax.legend(loc="best", fontsize=8)
     fig.tight_layout()
-    fig.show()
+    alt = (
+        f"Line chart of daily cross-sectional IC over {df.height} days from {dates.min()} to "
+        f"{dates.max()}, against a dashed line at zero. Daily values span {_span(ic)}"
+    )
+    if window > 1 and df.height >= window:
+        alt += f", and a {window}-day rolling mean drawn over them spans {_span(roll_mean)}"
+    show_with_alt(fig, alt + ".")

--- a/case_studies/utils/model_viz.py
+++ b/case_studies/utils/model_viz.py
@@ -399,6 +399,7 @@ def plot_learning_curves(
 
     n_panels = len(cp_families)
     plotted_ic: list[np.ndarray] = []
+    n_configs = 0
     fig, axes = plt.subplots(n_panels, 1, figsize=(12, 4 * n_panels), squeeze=False)
 
     for idx, family in enumerate(sorted(cp_families)):
@@ -412,6 +413,7 @@ def plot_learning_curves(
 
             ax.plot(x, y, marker=".", label=config, linewidth=1.5)
             plotted_ic.append(y)
+            n_configs += 1
 
             if "ic_std" in cfg_data.columns:
                 y_std = cfg_data["ic_std"].to_numpy()
@@ -427,7 +429,6 @@ def plot_learning_curves(
         ax.legend(fontsize=7, loc="lower right")
 
     fig.tight_layout()
-    n_configs = cp_data["config_name"].n_unique()
     show_with_alt(
         fig,
         f"{n_panels} stacked line charts, one per model family "
@@ -711,11 +712,14 @@ def plot_hac_ci_leaderboard(
     ax.set_title(title)
     ax.grid(axis="x", alpha=0.3, zorder=0)
     fig.tight_layout()
-    ics = df[ic_col].to_numpy()
+    ics = df[ic_col].to_numpy().astype(float)
     if {lo_col, hi_col}.issubset(df.columns):
         los = df[lo_col].to_numpy().astype(float)
         his = df[hi_col].to_numpy().astype(float)
-        finite = np.isfinite(los) & np.isfinite(his)
+        # The drawing loop above skips any row whose point estimate is missing or
+        # non-finite, so a row with a valid interval and no `ic` is never drawn.
+        # Counting it here would describe a bar that is not on the chart.
+        finite = np.isfinite(los) & np.isfinite(his) & np.isfinite(ics)
         excludes_zero = int(np.sum(finite & ((los > 0) | (his < 0))))
         ci_clause = (
             f" {excludes_zero} of the {int(finite.sum())} intervals drawn exclude zero, "
@@ -869,6 +873,11 @@ def plot_rolling_daily_ic(
         return
 
     df = defined_ic(daily_metrics).sort("date")
+    if df.height == 0:
+        # The guard above tests the input; `defined_ic` is what drops undefined days,
+        # and it can drop all of them. Reducing over the empty date array raises, so
+        # this returns where the pre-alt-text version rendered an empty figure.
+        return
     if df.height < window:
         window = max(5, df.height // 4)
 

--- a/tests/test_model_viz_alt_text.py
+++ b/tests/test_model_viz_alt_text.py
@@ -257,6 +257,72 @@ def test_feature_importance_alt_counts_rows_shown_not_rows_available(captured):
     assert "0.75 to 0.95" in alt
 
 
+# ---------------------------------------------------------------------------
+# Regressions from the first version of the alt-text change. Each of these three
+# was a defect the computed description introduced: a count that did not match
+# what was drawn, or a reduction over an array the drawing code never reaches.
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_daily_ic_returns_when_every_day_is_undefined(captured):
+    """`defined_ic` can empty a frame that passed the height guard above it."""
+    n = 12
+    daily = pl.DataFrame(
+        {
+            "fold_id": [0] * n,
+            "date": pl.date_range(
+                pl.date(2024, 1, 1), pl.date(2024, 1, 12), interval="1d", eager=True
+            ),
+            "ic": [None] * n,
+            "n_obs": [100] * n,
+        },
+        schema_overrides={"ic": pl.Float64},
+    )
+
+    # Reducing over the empty date array raises; the pre-alt-text version rendered
+    # an empty figure, so raising here would be a regression in the notebook cell.
+    model_viz.plot_rolling_daily_ic(daily, window=5)
+
+    assert captured == []
+
+
+def test_hac_leaderboard_does_not_count_an_interval_it_did_not_draw(captured):
+    """A row with a valid CI and no point estimate is skipped by the drawing loop."""
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "linear"],
+            "config_name": ["a", "b"],
+            "ic_mean_daily": [0.05, None],
+            "ic_ci_lo": [0.03, 0.01],
+            "ic_ci_hi": [0.07, 0.09],
+        },
+        schema_overrides={"ic_mean_daily": pl.Float64},
+    )
+    model_viz.plot_hac_ci_leaderboard(metrics)
+
+    # Both rows have finite intervals, but only the first is drawn.
+    assert "1 of the 1 intervals drawn exclude zero" in captured[0]
+
+
+def test_learning_curves_counts_only_configs_in_the_plotted_families(captured):
+    """`cp_data` may carry families the caller did not ask to plot."""
+    cp = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm", "linear", "linear"],
+            "config_name": ["a", "a", "b", "b"],
+            "checkpoint_value": [10, 20, 10, 20],
+            "ic_mean_daily": [0.01, 0.02, 0.30, 0.40],
+        }
+    )
+    model_viz.plot_learning_curves(cp, ["gbm"])
+
+    alt = captured[0]
+    # One panel, one config drawn - `linear` is in the frame and not on the chart.
+    assert "1 configurations" in alt
+    assert "+0.010 to +0.020" in alt
+    assert "0.400" not in alt
+
+
 def test_no_helper_still_calls_fig_show():
     """The defect was `fig.show()`; a new helper must not reintroduce it."""
     from pathlib import Path

--- a/tests/test_model_viz_alt_text.py
+++ b/tests/test_model_viz_alt_text.py
@@ -1,0 +1,271 @@
+"""Every model-analysis figure publishes alt text, and that text is computed.
+
+`case_studies/utils/model_viz.py` renders the model-analysis figures for seven case
+studies. It called ``fig.show()`` for every one of them, which emits an ``<img>`` with
+no alternative text, so all seven notebooks published figures a screen reader cannot
+describe (ml4t/agent-workspace#899).
+
+These tests assert two separate things, and the second is the one that matters:
+
+1. Every helper publishes alt text at all.
+2. The alt text is **derived from the data just plotted**, not a fixed sentence. Each
+   test changes the input and requires the alt text to change with it. A canned string
+   would pass (1) and fail (2), which is the failure mode worth protecting against -
+   a wrong figure description is a worse defect than a missing one.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.utils import model_viz
+
+
+@pytest.fixture
+def captured(monkeypatch) -> list[str]:
+    """Record the alt text of every figure a helper publishes, and close the figure."""
+    import matplotlib.pyplot as plt
+
+    alts: list[str] = []
+
+    def _record(fig: object, alt: str) -> None:
+        alts.append(alt)
+        plt.close(fig)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(model_viz, "show_with_alt", _record)
+    return alts
+
+
+def _fold_ic(scale: float = 1.0) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "model_label": ["linear/a", "linear/a", "gbm/b", "gbm/b"],
+            "fold_id": [0, 1, 0, 1],
+            "ic_mean": [0.01 * scale, 0.03 * scale, 0.02 * scale, 0.04 * scale],
+        }
+    )
+
+
+def test_fold_heatmap_publishes_alt_carrying_the_plotted_range(captured):
+    model_viz.plot_fold_heatmap(_fold_ic())
+
+    assert len(captured) == 1
+    alt = captured[0]
+    assert "Heatmap" in alt
+    assert "2 models" in alt and "2 validation folds" in alt
+    # The extremes of the matrix actually drawn.
+    assert "+0.010" in alt and "+0.040" in alt
+
+
+def test_fold_heatmap_alt_tracks_the_data(captured):
+    model_viz.plot_fold_heatmap(_fold_ic(scale=1.0))
+    model_viz.plot_fold_heatmap(_fold_ic(scale=10.0))
+
+    assert len(captured) == 2
+    assert captured[0] != captured[1], "alt text is fixed prose, not computed from the data"
+    assert "+0.400" in captured[1]
+
+
+def test_fold_boxplot_publishes_alt(captured):
+    model_viz.plot_fold_boxplot(_fold_ic())
+
+    assert len(captured) == 1
+    assert "Box plot" in captured[0]
+    assert "2 model families" in captured[0]
+    assert "2 folds" in captured[0]
+
+
+def test_correlation_matrix_alt_reports_the_off_diagonal(captured):
+    corr = np.array([[1.0, 0.42, 0.10], [0.42, 1.0, 0.80], [0.10, 0.80, 1.0]])
+    model_viz.plot_correlation_matrix(corr, ["linear/a", "gbm/b", "dl/c"])
+
+    assert len(captured) == 1
+    alt = captured[0]
+    assert "3 models" in alt
+    assert "3 distinct off-diagonal" in alt
+    assert "0.10 to 0.80" in alt
+    assert "0.44" in alt  # mean of 0.42, 0.10, 0.80
+
+
+def test_bucket_monotonicity_alt_names_the_unconditional_mean(captured):
+    buckets = {
+        "gbm/b": pl.DataFrame({"bucket": [1, 2, 3], "mean_return": [-0.002, 0.0, 0.003]}),
+    }
+    model_viz.plot_bucket_monotonicity(buckets, n_buckets=3, unconditional_mean=0.0005)
+
+    assert len(captured) == 1
+    alt = captured[0]
+    assert "3 buckets" in alt
+    assert "-0.0020 to +0.0030" in alt
+    assert "+0.0005" in alt
+
+
+def test_bucket_monotonicity_omits_the_mean_clause_when_absent(captured):
+    buckets = {"gbm/b": pl.DataFrame({"bucket": [1, 2], "mean_return": [-0.001, 0.001]})}
+    model_viz.plot_bucket_monotonicity(buckets, n_buckets=2)
+
+    assert "unconditional mean" not in captured[0]
+
+
+def test_hac_leaderboard_alt_counts_intervals_excluding_zero(captured):
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "linear", "dl"],
+            "config_name": ["a", "b", "c"],
+            "ic_mean_daily": [0.05, 0.02, -0.01],
+            "ic_ci_lo": [0.03, -0.01, -0.04],
+            "ic_ci_hi": [0.07, 0.05, 0.02],
+        }
+    )
+    model_viz.plot_hac_ci_leaderboard(metrics)
+
+    alt = captured[0]
+    assert "3 model configurations" in alt
+    # Only the first interval (0.03, 0.07) excludes zero.
+    assert "1 of the 3 intervals drawn exclude zero" in alt
+    assert "-0.0100 to +0.0500" in alt
+
+
+def test_label_horizon_forest_alt_counts_missing_pairs(captured):
+    metrics = pl.DataFrame(
+        {
+            "family": ["gbm", "linear"],
+            "label": ["fwd_ret_1d", "fwd_ret_1d"],
+            "ic_mean_daily": [0.04, 0.01],
+            "ic_ci_lo": [0.02, -0.02],
+            "ic_ci_hi": [0.06, 0.04],
+        }
+    )
+    model_viz.plot_label_horizon_forest(
+        metrics, families=["gbm", "linear", "dl"], labels=["fwd_ret_1d"]
+    )
+
+    alt = captured[0]
+    # Three families x one label = three tiles, but only two have a run.
+    assert "2 of the 3 family-label pairs have a run" in alt
+    assert "1 of the drawn intervals exclude zero" in alt
+
+
+def test_rolling_daily_ic_alt_reports_the_window_and_span(captured):
+    n = 40
+    daily = pl.DataFrame(
+        {
+            "fold_id": [0] * n,
+            "date": pl.date_range(
+                pl.date(2024, 1, 1), pl.date(2024, 2, 9), interval="1d", eager=True
+            ),
+            "ic": np.linspace(-0.05, 0.05, n),
+            "n_obs": [100] * n,
+        }
+    )
+    model_viz.plot_rolling_daily_ic(daily, window=10)
+
+    alt = captured[0]
+    assert "40 days" in alt
+    assert "-0.050 to +0.050" in alt
+    assert "10-day rolling mean" in alt
+
+
+def test_regime_bars_publishes_alt_naming_both_regimes(captured):
+    regime = pl.DataFrame(
+        {
+            "regime": ["low_vol", "high_vol", "low_vol", "high_vol"],
+            "family": ["gbm", "gbm", "linear", "linear"],
+            "ic_mean": [0.03, -0.01, 0.02, 0.00],
+            "ic_std": [0.01, 0.01, 0.01, 0.01],
+            "n_periods": [100, 100, 100, 100],
+        }
+    )
+    model_viz.plot_regime_bars(regime)
+
+    alt = captured[0]
+    assert "2 model families" in alt
+    assert "high vol" in alt and "low vol" in alt
+    assert "-0.010 to +0.030" in alt
+
+
+def test_learning_curves_alt_counts_panels_and_configs(captured):
+    cp = pl.DataFrame(
+        {
+            "family": ["gbm", "gbm", "gbm", "gbm"],
+            "config_name": ["a", "a", "b", "b"],
+            "checkpoint_value": [10, 20, 10, 20],
+            "ic_mean_daily": [0.01, 0.02, 0.00, 0.03],
+        }
+    )
+    model_viz.plot_learning_curves(cp, ["gbm"])
+
+    alt = captured[0]
+    assert "1 stacked line chart" in alt or "1 stacked line charts" in alt
+    assert "2 configurations" in alt
+    assert "+0.000 to +0.030" in alt
+
+
+def test_cv_timeline_alt_reports_the_span_and_holdout(captured):
+    import datetime as dt
+
+    folds = pl.DataFrame(
+        {
+            "fold_id": [0, 1],
+            "val_start": [dt.datetime(2024, 1, 1), dt.datetime(2024, 3, 1)],
+            "val_end": [dt.datetime(2024, 2, 29), dt.datetime(2024, 4, 30)],
+        }
+    )
+    model_viz.plot_cv_timeline(folds, n_splits=2, holdout_start="2024-05-01")
+
+    alt = captured[0]
+    assert "2 walk-forward validation windows" in alt
+    assert "2024-01-01" in alt and "2024-04-30" in alt
+    assert "2024-05-01" in alt
+
+
+def test_cv_timeline_omits_the_holdout_clause_when_absent(captured):
+    import datetime as dt
+
+    folds = pl.DataFrame(
+        {
+            "fold_id": [0],
+            "val_start": [dt.datetime(2024, 1, 1)],
+            "val_end": [dt.datetime(2024, 2, 29)],
+        }
+    )
+    model_viz.plot_cv_timeline(folds, n_splits=1)
+
+    assert "holdout" not in captured[0]
+
+
+def test_feature_importance_alt_counts_rows_shown_not_rows_available(captured):
+    rows = []
+    for feature_i in range(20):
+        for fold in range(3):
+            rows.append(
+                {
+                    "feature": f"f{feature_i:02d}",
+                    "fold_id": fold,
+                    "importance_norm": feature_i / 20.0,
+                }
+            )
+    importance = pl.DataFrame(rows)
+    model_viz.plot_feature_importance_heatmap(importance, top_n=5)
+
+    alt = captured[0]
+    # 20 features exist; the figure draws the top 5, and the alt must say 5.
+    assert "5 features" in alt
+    assert "3 folds" in alt
+    assert "0.75 to 0.95" in alt
+
+
+def test_no_helper_still_calls_fig_show():
+    """The defect was `fig.show()`; a new helper must not reintroduce it."""
+    from pathlib import Path
+
+    source = Path(model_viz.__file__).read_text()
+    assert "fig.show()" not in source
+
+
+def test_span_describes_only_finite_values():
+    assert model_viz._span([np.nan, 0.5, np.inf, -0.25]) == "-0.250 to +0.500"
+    assert model_viz._span([np.nan, np.nan]) == "no finite values"
+    assert model_viz._span([0.25]) == "+0.250"


### PR DESCRIPTION
Seven case studies published model-analysis figures that a screen reader cannot
describe. This adds the plumbing to the one module they all render through.

### The defect

`case_studies/utils/model_viz.py` has 11 `plot_*` helpers and every one called
`fig.show()`, which emits an `<img>` with no alternative text. The figures in
`cme_futures/12`, `etfs/13`, `nasdaq100_microstructure/13`,
`sp500_equity_option_analytics/13`, `sp500_options/11`, `us_equities_panel/15`
and `us_firm_characteristics/10` all reach the page described as "No description
has been provided for this image".

`crypto_perps_funding/12` is the only model-analysis notebook with alt text and
the only one that does not use these helpers. That is the tell: this is not seven
notebooks that forgot, it is one boundary that never had the plumbing, inherited
seven times. The same case studies meet the standard elsewhere -
`nasdaq100_microstructure/05_evaluation` renders eight figures with alt text.

### The alt text is computed, not written

Each helper now calls `show_with_alt` with a description built from the data it
just plotted: the chart type, what is on each axis, how many series, and the
range the plotted values actually span. Nothing is authored as prose.

A generic plotter cannot describe a figure it has not seen, and hand-written alt
has a poor record here - three of four were wrong the last time it was attempted.
What a plotter *can* do is state what it just drew, and that cannot drift from
the figure. `_span()` reports only the finite values, so a NaN column cannot be
described as a plotted one.

The module is matplotlib throughout, so the helper is `show_with_alt`, not
`show_plotly_with_alt`.

### Tests

`tests/test_model_viz_alt_text.py`, 19 tests covering all 11 helpers, asserting
two separate things:

1. Alt text is published at all.
2. **It tracks the data.** Each test changes an input and requires the text to
   change with it. A canned sentence passes the first and fails the second.

Proven by mutation rather than asserted: replacing one computed description with
a fixed sentence and reverting one helper to `fig.show()` fails 4 of 19;
restoring passes all 19.

Wired into `test-unit`, which is a required check. Alt text lives in output
metadata and only reaches a notebook by executing it, and these notebooks execute
rarely - so this has to be gated rather than checked by eye. An ungated test
would be the defect in #871, not a fix for this one.

### Three defects the first version of this change introduced

All three were found by the pre-push review and are fixed here, each with a
regression test that fails on its own defect:

- **`plot_rolling_daily_ic` raised where it used to render.** The guard tests
  `daily_metrics.height`, but `defined_ic` is what drops undefined days and it
  can drop all of them. `dates.min()` over the resulting empty array raises, so a
  cell that previously produced an empty figure now failed. Returns after the
  filter as well as before it.
- **`plot_hac_ci_leaderboard` could count intervals the chart does not hold.**
  The drawing loop skips rows with a missing or non-finite point estimate, and
  `sort(nulls_last=True)` shows those are expected. The count now uses the same
  condition as the loop.
- **`plot_learning_curves` counted configs it did not draw**, including families
  the caller did not ask to plot.

The CI step was also wrong in a way that would have made it silently useless:
importing `case_studies.utils` pulls in `utils.config`, which hard-fails when
`ML4T_DATA_PATH` does not exist, and this job checks out no test-data.
Reproduced locally as a collection error and verified fixed under the same
condition.

### Scope

Nothing here is hashed into a training or causal identity, so it lands inside the
execution freeze.

**It has a deadline rather than a priority.** All nine model-analysis notebooks
re-execute as part of the stage 06+ production runs. Landing before those runs
costs nothing beyond the run everyone is doing anyway; landing after costs nine
re-executions of notebooks that read every model population in their case study.
