### PR TITLE
causal: count the pre-holdout buffer in observations, not calendar days

### DIFF
--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -930,14 +930,46 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     holdout = pd.Timestamp(setup["evaluation"]["holdout_start"], tz="UTC")
     horizon_delta = pd.Timedelta(str(mds.label_buffer).replace("H", "h"))
     date_dtype = mds.dataset.schema[mds.date_col]
-    endpoint_cutoff = holdout - horizon_delta
-    analysis = (
-        mds.dataset.select(columns)
-        .drop_nulls()
-        .filter(
-            pl.col(mds.date_col)
-            < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False)
+    # The cutoff steps back a count of observations, not a calendar duration. The horizons
+    # these buffers describe are counted in the panel's own observations, so subtracting the
+    # buffer as calendar time answers a different question on any gapped calendar. A 21D
+    # buffer is roughly fifteen sessions on a five-session week, which left the last few
+    # retained rows resolving their returns inside the holdout, silently. The two
+    # constructions agree only on a continuous panel, which is why this held wherever anyone
+    # had checked it.
+    #
+    # The cadence therefore has to be measured before the cutoff rather than after it, and on
+    # the pre-holdout observations alone: `_observed_cadence` takes the mode of the gaps, so a
+    # panel whose spacing changes across the holdout boundary would otherwise size the buffer
+    # and the embargo from rows the analysis never touches.
+    populated = mds.dataset.select(columns).drop_nulls()
+    pre_holdout = (
+        populated.filter(
+            pl.col(mds.date_col) < pl.lit(holdout.to_pydatetime()).cast(date_dtype, strict=False)
         )
+        .select(mds.date_col)
+        .unique()
+        .sort(mds.date_col)
+    )
+    if pre_holdout.is_empty():
+        raise ValueError("DML request resolved an empty pre-holdout analysis frame")
+    cadence = _observed_cadence(pre_holdout, mds.date_col)
+    horizon_steps = max(1, int(np.ceil(horizon_delta / cadence)))
+    # The trim is unconditional. Making it depend on whether the panel reaches the holdout
+    # would rest on the last populated row's window resolving inside the panel, which is a
+    # property of how a label was built rather than anything this function can see: a label
+    # column that is non-null through the final observation resolves past it.
+    if pre_holdout.height <= horizon_steps:
+        raise ValueError(
+            f"the panel holds {pre_holdout.height} observations before {holdout.date()}, which "
+            f"cannot absorb a {horizon_steps}-observation buffer and leave anything to analyse"
+        )
+    endpoint_cutoff = pd.Timestamp(
+        pre_holdout.get_column(mds.date_col)[pre_holdout.height - horizon_steps]
+    )
+    analysis = populated.filter(
+        pl.col(mds.date_col)
+        < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False)
     )
     analysis = _whole_timestamp_tail(
         analysis,
@@ -947,13 +979,11 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     )
     if analysis.is_empty():
         raise ValueError("DML request resolved an empty pre-holdout analysis frame")
-    cadence = _observed_cadence(analysis, mds.date_col)
-    horizon_steps = max(1, int(np.ceil(horizon_delta / cadence)))
-    # The cadence is already measured on the frame being analysed, so the embargo
+    # The cadence is measured on the pre-holdout observations above, so the embargo
     # is counted against it rather than against an assumed bar size. Leaving the
     # fallback here would make the embargo short by the ratio between the two on
     # any panel whose real cadence differs from its declared one, while the
-    # horizon computed on the line above stayed right. A month buffer has no
+    # horizon computed from that same cadence stayed right. A month buffer has no
     # fixed length and keeps the calendar branch.
     try:
         embargo = embargo_from_buffer(mds.label_buffer, observed_step=cadence)

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -958,11 +958,15 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     # resolving inside the holdout. The panel-wide count is only correct when every entity
     # trades every session, which is a property of the data rather than of this function.
     #
+    # Each entity is then sealed against its own cutoff rather than against a panel-wide
+    # collapse of them. Taking the earliest and applying it everywhere would let one
+    # entity whose history ends early - a delisted firm, a contract that stopped trading -
+    # drag the boundary back to its own exit date and silently truncate every other
+    # entity to an early slice of the panel.
+    #
     # An entity that does not hold more than `horizon_steps` observations before the
     # holdout has no row whose outcome resolves before it, so it contributes no cutoff and
-    # drops out entirely. Taking the earliest surviving cutoff and applying it panel-wide
-    # keeps one scalar boundary, which is what the estimand records, and is at least as
-    # tight as every entity's own.
+    # drops out entirely.
     per_entity = (
         pre_holdout.unique()
         .sort(entity_col, mds.date_col)
@@ -983,13 +987,17 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
             f"no entity holds more than {horizon_steps} observations before "
             f"{holdout.date()}, so none can absorb the buffer and leave anything to analyse"
         )
-    endpoint_cutoff = pd.Timestamp(per_entity.get_column("entity_cutoff").min())
-    retained_entities = per_entity.get_column(entity_col).implode()
-    analysis = populated.filter(
-        pl.col(mds.date_col)
-        < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False),
-        pl.col(entity_col).is_in(retained_entities),
+    analysis = (
+        populated.join(per_entity.select(entity_col, "entity_cutoff"), on=entity_col, how="inner")
+        .filter(pl.col(mds.date_col) < pl.col("entity_cutoff"))
+        .select(columns)
     )
+    if analysis.is_empty():
+        raise ValueError("DML request resolved an empty pre-holdout analysis frame")
+    # The estimand records one boundary, and with a per-entity seal the honest scalar is
+    # the loosest of them: no entity retains a row at or after its own cutoff, and none
+    # of those cutoffs is later than this one.
+    endpoint_cutoff = pd.Timestamp(per_entity.get_column("entity_cutoff").max())
     analysis = _whole_timestamp_tail(
         analysis,
         timestamp=mds.date_col,

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -942,34 +942,53 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     # the pre-holdout observations alone: `_observed_cadence` takes the mode of the gaps, so a
     # panel whose spacing changes across the holdout boundary would otherwise size the buffer
     # and the embargo from rows the analysis never touches.
+    entity_col = mds.entity_cols[0]
     populated = mds.dataset.select(columns).drop_nulls()
-    pre_holdout = (
-        populated.filter(
-            pl.col(mds.date_col) < pl.lit(holdout.to_pydatetime()).cast(date_dtype, strict=False)
-        )
-        .select(mds.date_col)
-        .unique()
-        .sort(mds.date_col)
-    )
+    pre_holdout = populated.filter(
+        pl.col(mds.date_col) < pl.lit(holdout.to_pydatetime()).cast(date_dtype, strict=False)
+    ).select(entity_col, mds.date_col)
     if pre_holdout.is_empty():
         raise ValueError("DML request resolved an empty pre-holdout analysis frame")
     cadence = _observed_cadence(pre_holdout, mds.date_col)
     horizon_steps = max(1, int(np.ceil(horizon_delta / cadence)))
-    # The trim is unconditional. Making it depend on whether the panel reaches the holdout
-    # would rest on the last populated row's window resolving inside the panel, which is a
-    # property of how a label was built rather than anything this function can see: a label
-    # column that is non-null through the final observation resolves past it.
-    if pre_holdout.height <= horizon_steps:
-        raise ValueError(
-            f"the panel holds {pre_holdout.height} observations before {holdout.date()}, which "
-            f"cannot absorb a {horizon_steps}-observation buffer and leave anything to analyse"
+    # The step-back is counted within each entity, not across the panel's distinct
+    # timestamps. A label advances by that entity's own observations, so on a panel where
+    # one product is missing some of the final sessions, a global count reaches back fewer
+    # of that product's observations than the buffer names and leaves its last rows
+    # resolving inside the holdout. The panel-wide count is only correct when every entity
+    # trades every session, which is a property of the data rather than of this function.
+    #
+    # An entity that does not hold more than `horizon_steps` observations before the
+    # holdout has no row whose outcome resolves before it, so it contributes no cutoff and
+    # drops out entirely. Taking the earliest surviving cutoff and applying it panel-wide
+    # keeps one scalar boundary, which is what the estimand records, and is at least as
+    # tight as every entity's own.
+    per_entity = (
+        pre_holdout.unique()
+        .sort(entity_col, mds.date_col)
+        .group_by(entity_col)
+        .agg(
+            pl.col(mds.date_col).len().alias("observations"),
+            pl.col(mds.date_col).alias("timestamps"),
         )
-    endpoint_cutoff = pd.Timestamp(
-        pre_holdout.get_column(mds.date_col)[pre_holdout.height - horizon_steps]
+        .filter(pl.col("observations") > horizon_steps)
+        .with_columns(
+            pl.col("timestamps")
+            .list.get(pl.col("observations") - horizon_steps)
+            .alias("entity_cutoff")
+        )
     )
+    if per_entity.is_empty():
+        raise ValueError(
+            f"no entity holds more than {horizon_steps} observations before "
+            f"{holdout.date()}, so none can absorb the buffer and leave anything to analyse"
+        )
+    endpoint_cutoff = pd.Timestamp(per_entity.get_column("entity_cutoff").min())
+    retained_entities = per_entity.get_column(entity_col).implode()
     analysis = populated.filter(
         pl.col(mds.date_col)
-        < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False)
+        < pl.lit(endpoint_cutoff.to_pydatetime()).cast(date_dtype, strict=False),
+        pl.col(entity_col).is_in(retained_entities),
     )
     analysis = _whole_timestamp_tail(
         analysis,

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -136,7 +136,12 @@ def test_canonical_causal_uses_the_full_declared_population(tmp_path, monkeypatc
 
     canonical_population = canonical.spec["computation"]["analysis_population"]
     preview_population = preview.spec["computation"]["analysis_population"]
-    assert canonical_population["n_rows"] == frame.height
+    # "Full" means the declared panel less the buffer the endpoint cutoff removes, which at
+    # an 8H buffer on 8-hour bars is one observation across the fixture's symbols. It does
+    # not mean every row: asserting `frame.height` would encode this fixture's labels being
+    # non-null through its final bar, which a forward return never is.
+    trimmed = frame.get_column("symbol").n_unique()
+    assert canonical_population["n_rows"] == frame.height - trimmed
     assert canonical_population["max_samples"] == 0
     assert "preview_reductions" not in canonical.spec["computation"]
     assert preview_population["n_rows"] == 60
@@ -373,7 +378,7 @@ def test_canonical_causal_ignores_a_sample_cap_declared_in_the_preset(
     population = resolved.spec["computation"]["analysis_population"]
 
     assert population["max_samples"] == 0
-    assert population["n_rows"] == frame.height
+    assert population["n_rows"] == frame.height - frame.get_column("symbol").n_unique()
 
     with pytest.raises(ValueError, match="canonical causal requests cannot declare preview"):
         study.causal(
@@ -515,3 +520,95 @@ def test_causal_resolver_rejects_an_unsupported_entity_key(tmp_path, monkeypatch
                 "n_placebo": 10,
             },
         ).resolve()
+
+
+def _session_causal_fixture(tmp_path, monkeypatch):
+    """A weekday-only panel, where a calendar buffer and a session buffer disagree."""
+    study = Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+    setup_path = study.root / "config" / "setup.yaml"
+    setup_path.write_text(
+        setup_path.read_text() + "causal:\n  treatment: treatment\n  confounders: [confounder]\n"
+    )
+    sessions = [
+        timestamp
+        for timestamp in pd.date_range("2024-01-01", "2024-03-01", freq="D", tz="UTC")
+        if timestamp.weekday() < 5
+    ]
+    rows = []
+    for session_index, timestamp in enumerate(sessions):
+        for symbol_index in range(6):
+            rows.append(
+                {
+                    "symbol": f"S{symbol_index}",
+                    "timestamp": timestamp.to_pydatetime(),
+                    "feature": float(symbol_index),
+                    "treatment": float(symbol_index) + session_index / 100,
+                    "confounder": float(session_index % 5),
+                    "fwd_ret_5d": (symbol_index - 2.5) / 100 + session_index / 10000,
+                }
+            )
+    frame = pl.DataFrame(rows).with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
+    label = study.labels.publish(
+        LabelDefinition("fwd_ret_5d", "regression", "5D"),
+        frame.select("symbol", "timestamp", "fwd_ret_5d"),
+    )
+    mds = SimpleNamespace(
+        dataset=frame,
+        feature_names=["feature", "treatment", "confounder"],
+        label_col="fwd_ret_5d",
+        label_buffer="5D",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *args, **kwargs: mds)
+    monkeypatch.setattr(
+        "utils.modeling.load_configs",
+        lambda *args, **kwargs: [
+            {
+                "config_name": "dml",
+                "family": "causal_dml",
+                "n_folds": 5,
+                "n_placebo": 100,
+                "params": {"max_depth": 3, "max_iter": 50},
+                "seed": 42,
+            }
+        ],
+    )
+    return study, label, frame, sessions
+
+
+def test_holdout_seal_counts_sessions_not_calendar_days(tmp_path, monkeypatch) -> None:
+    """A 5D buffer means five observations, and on a gapped calendar those differ.
+
+    The panel trades Monday to Friday, so five calendar days back from a Monday holdout
+    reaches the Wednesday before, while five observations back reaches the Monday before
+    that. The two sessions between them carry outcomes that resolve inside the holdout.
+    """
+    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    _set_holdout_start(study.root / "config" / "setup.yaml", "2024-02-19")
+
+    computation = study.causal(method="dml", label=label.name).resolve().spec["computation"]
+
+    holdout = pd.Timestamp("2024-02-19", tz="UTC")
+    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
+    session_cutoff = pre_holdout[-5]
+    calendar_cutoff = holdout - pd.Timedelta("5D")
+    # The fixture is only meaningful while the two constructions actually disagree.
+    assert session_cutoff < calendar_cutoff
+
+    assert computation["estimand"]["holdout_endpoint_cutoff"] == session_cutoff.isoformat()
+    retained = frame.filter(pl.col("timestamp") < session_cutoff)
+    assert computation["analysis_population"]["n_rows"] == retained.height
+    # Rows the calendar cutoff would have kept, whose own five-session outcome resolves
+    # inside the holdout. This is the difference the seal exists to remove.
+    leaked = frame.filter(
+        (pl.col("timestamp") >= session_cutoff) & (pl.col("timestamp") < calendar_cutoff)
+    )
+    assert leaked.height > 0
+    assert computation["analysis_population"]["n_rows"] < retained.height + leaked.height

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -712,10 +712,10 @@ def test_holdout_seal_fails_closed_on_a_panel_shorter_than_its_buffer(
         study.causal(method="dml", label=label.name).resolve()
 
 
-def test_holdout_seal_holds_a_one_session_horizon_over_a_holiday_boundary(
+def test_holdout_seal_holds_a_one_session_horizon_over_a_weekend_boundary(
     tmp_path, monkeypatch
 ) -> None:
-    """A one-session horizon leaks too, whenever the holdout opens on a non-session.
+    """A one-session horizon leaks too, whenever a non-session gap precedes the boundary.
 
     This is a boundary problem rather than a long-horizon one. The holdout opens on a
     Monday, so the two weekend days sit between the last session and the boundary: the

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -611,4 +611,58 @@ def test_holdout_seal_counts_sessions_not_calendar_days(tmp_path, monkeypatch) -
         (pl.col("timestamp") >= session_cutoff) & (pl.col("timestamp") < calendar_cutoff)
     )
     assert leaked.height > 0
-    assert computation["analysis_population"]["n_rows"] < retained.height + leaked.height
+    # The population the calendar construction would have produced, less exactly the rows
+    # whose outcomes reach past the holdout. Stated independently of the assertion above.
+    assert (
+        computation["analysis_population"]["n_rows"]
+        == frame.filter(pl.col("timestamp") < calendar_cutoff).height - leaked.height
+    )
+
+
+def test_holdout_seal_counts_each_entity_own_observations(tmp_path, monkeypatch) -> None:
+    """A product missing late sessions needs an earlier cutoff than the panel's.
+
+    The buffer advances by the entity's own observations. Counting distinct timestamps
+    across the panel reaches back five panel sessions, which is fewer than five of a
+    sparse product's own, so that product keeps rows resolving inside the holdout.
+    """
+    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    holdout = pd.Timestamp("2024-02-19", tz="UTC")
+    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
+    # S0 stops trading four sessions before the holdout; every other product runs through.
+    absent = set(pre_holdout[-4:])
+    sparse = frame.filter(~((pl.col("symbol") == "S0") & pl.col("timestamp").is_in(absent)))
+    sparse_mds = SimpleNamespace(
+        dataset=sparse,
+        feature_names=["feature", "treatment", "confounder"],
+        label_col="fwd_ret_5d",
+        label_buffer="5D",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        input_lineage={
+            "artifacts": {"financial": {"sha256": "features-v1", "size": 1}},
+            "fingerprint": "fixture-v1",
+        },
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: sparse_mds)
+    _set_holdout_start(study.root / "config" / "setup.yaml", "2024-02-19")
+
+    computation = study.causal(method="dml", label=label.name).resolve().spec["computation"]
+
+    # S0's own five-observations-back lands four sessions earlier than the panel's.
+    sparse_sessions = [timestamp for timestamp in pre_holdout if timestamp not in absent]
+    expected = sparse_sessions[-5]
+    panel_cutoff = pre_holdout[-5]
+    assert expected < panel_cutoff
+    assert computation["estimand"]["holdout_endpoint_cutoff"] == expected.isoformat()
+
+
+def test_holdout_seal_fails_closed_on_a_panel_shorter_than_its_buffer(
+    tmp_path, monkeypatch
+) -> None:
+    """No entity can absorb the buffer, so the request refuses rather than estimating."""
+    study, label, _frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    # Three sessions precede this holdout, against a five-observation buffer.
+    _set_holdout_start(study.root / "config" / "setup.yaml", "2024-01-04")
+    with pytest.raises(ValueError, match="none can absorb the buffer"):
+        study.causal(method="dml", label=label.name).resolve()

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -611,29 +611,17 @@ def test_holdout_seal_counts_sessions_not_calendar_days(tmp_path, monkeypatch) -
         (pl.col("timestamp") >= session_cutoff) & (pl.col("timestamp") < calendar_cutoff)
     )
     assert leaked.height > 0
-    # The population the calendar construction would have produced, less exactly the rows
-    # whose outcomes reach past the holdout. Stated independently of the assertion above.
-    assert (
-        computation["analysis_population"]["n_rows"]
-        == frame.filter(pl.col("timestamp") < calendar_cutoff).height - leaked.height
-    )
+    # Counted from the session list rather than derived from the frame filters above, so it
+    # can disagree with them: every session strictly before the cutoff, times every symbol.
+    symbols = frame.get_column("symbol").n_unique()
+    admissible = len([timestamp for timestamp in sessions if timestamp < session_cutoff])
+    assert computation["analysis_population"]["n_rows"] == admissible * symbols
 
 
-def test_holdout_seal_counts_each_entity_own_observations(tmp_path, monkeypatch) -> None:
-    """A product missing late sessions needs an earlier cutoff than the panel's.
-
-    The buffer advances by the entity's own observations. Counting distinct timestamps
-    across the panel reaches back five panel sessions, which is fewer than five of a
-    sparse product's own, so that product keeps rows resolving inside the holdout.
-    """
-    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
-    holdout = pd.Timestamp("2024-02-19", tz="UTC")
-    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
-    # S0 stops trading four sessions before the holdout; every other product runs through.
-    absent = set(pre_holdout[-4:])
-    sparse = frame.filter(~((pl.col("symbol") == "S0") & pl.col("timestamp").is_in(absent)))
-    sparse_mds = SimpleNamespace(
-        dataset=sparse,
+def _patch_modeling_dataset(monkeypatch, frame) -> None:
+    """Re-point the resolver at a modified panel, keeping the fixture's label metadata."""
+    mds = SimpleNamespace(
+        dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_5d",
         label_buffer="5D",
@@ -644,17 +632,73 @@ def test_holdout_seal_counts_each_entity_own_observations(tmp_path, monkeypatch)
             "fingerprint": "fixture-v1",
         },
     )
-    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: sparse_mds)
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: mds)
+
+
+def _retained_rows(frame, cutoffs: dict) -> int:
+    """Rows each symbol keeps when sealed against its own cutoff."""
+    return sum(
+        frame.filter((pl.col("symbol") == symbol) & (pl.col("timestamp") < cutoff)).height
+        for symbol, cutoff in cutoffs.items()
+    )
+
+
+def test_holdout_seal_counts_each_entity_own_observations(tmp_path, monkeypatch) -> None:
+    """A product missing late sessions is sealed earlier, and only that product is.
+
+    The buffer advances by the entity's own observations. Counting distinct timestamps
+    across the panel reaches back five panel sessions, which is fewer than five of a
+    sparse product's own, so that product would keep rows resolving inside the holdout.
+    """
+    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    holdout = pd.Timestamp("2024-02-19", tz="UTC")
+    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
+    # S0 stops trading four sessions before the holdout; every other product runs through.
+    absent = set(pre_holdout[-4:])
+    sparse = frame.filter(~((pl.col("symbol") == "S0") & pl.col("timestamp").is_in(absent)))
+    _patch_modeling_dataset(monkeypatch, sparse)
     _set_holdout_start(study.root / "config" / "setup.yaml", "2024-02-19")
 
     computation = study.causal(method="dml", label=label.name).resolve().spec["computation"]
 
-    # S0's own five-observations-back lands four sessions earlier than the panel's.
-    sparse_sessions = [timestamp for timestamp in pre_holdout if timestamp not in absent]
-    expected = sparse_sessions[-5]
-    panel_cutoff = pre_holdout[-5]
-    assert expected < panel_cutoff
-    assert computation["estimand"]["holdout_endpoint_cutoff"] == expected.isoformat()
+    sparse_cutoff = [t for t in pre_holdout if t not in absent][-5]
+    dense_cutoff = pre_holdout[-5]
+    assert sparse_cutoff < dense_cutoff
+
+    cutoffs = {"S0": sparse_cutoff} | {f"S{i}": dense_cutoff for i in range(1, 6)}
+    assert computation["analysis_population"]["n_rows"] == _retained_rows(sparse, cutoffs)
+    # Sealing every symbol at the earliest cutoff would keep strictly fewer rows, so the
+    # count above distinguishes a per-entity seal from a panel-wide collapse of them.
+    collapsed = {symbol: sparse_cutoff for symbol in cutoffs}
+    assert _retained_rows(sparse, collapsed) < _retained_rows(sparse, cutoffs)
+    assert computation["estimand"]["holdout_endpoint_cutoff"] == dense_cutoff.isoformat()
+
+
+def test_one_entity_exiting_early_does_not_truncate_the_others(tmp_path, monkeypatch) -> None:
+    """A product that stops trading long before the holdout seals only itself.
+
+    Collapsing the per-entity cutoffs to their minimum and applying it panel-wide would
+    drag every other product back to this one's exit date, which is a much larger loss
+    than the leak the seal exists to prevent.
+    """
+    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    holdout = pd.Timestamp("2024-02-19", tz="UTC")
+    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
+    # S0 exits early but still holds well more than the five observations the buffer needs.
+    exit_after = pre_holdout[15]
+    early = frame.filter(~((pl.col("symbol") == "S0") & (pl.col("timestamp") > exit_after)))
+    _patch_modeling_dataset(monkeypatch, early)
+    _set_holdout_start(study.root / "config" / "setup.yaml", "2024-02-19")
+
+    computation = study.causal(method="dml", label=label.name).resolve().spec["computation"]
+
+    dense_cutoff = pre_holdout[-5]
+    cutoffs = {"S0": pre_holdout[11]} | {f"S{i}": dense_cutoff for i in range(1, 6)}
+    assert computation["analysis_population"]["n_rows"] == _retained_rows(early, cutoffs)
+    # Sealing every symbol at S0's exit instead keeps strictly fewer rows, which is the
+    # truncation this test exists to rule out.
+    collapsed = {symbol: pre_holdout[11] for symbol in cutoffs}
+    assert _retained_rows(early, collapsed) < _retained_rows(early, cutoffs)
 
 
 def test_holdout_seal_fails_closed_on_a_panel_shorter_than_its_buffer(

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -618,13 +618,13 @@ def test_holdout_seal_counts_sessions_not_calendar_days(tmp_path, monkeypatch) -
     assert computation["analysis_population"]["n_rows"] == admissible * symbols
 
 
-def _patch_modeling_dataset(monkeypatch, frame) -> None:
+def _patch_modeling_dataset(monkeypatch, frame, buffer: str = "5D") -> None:
     """Re-point the resolver at a modified panel, keeping the fixture's label metadata."""
     mds = SimpleNamespace(
         dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_5d",
-        label_buffer="5D",
+        label_buffer=buffer,
         date_col="timestamp",
         entity_cols=["symbol"],
         input_lineage={
@@ -710,3 +710,32 @@ def test_holdout_seal_fails_closed_on_a_panel_shorter_than_its_buffer(
     _set_holdout_start(study.root / "config" / "setup.yaml", "2024-01-04")
     with pytest.raises(ValueError, match="none can absorb the buffer"):
         study.causal(method="dml", label=label.name).resolve()
+
+
+def test_holdout_seal_holds_a_one_session_horizon_over_a_holiday_boundary(
+    tmp_path, monkeypatch
+) -> None:
+    """A one-session horizon leaks too, whenever the holdout opens on a non-session.
+
+    This is a boundary problem rather than a long-horizon one. The holdout opens on a
+    Monday, so the two weekend days sit between the last session and the boundary: the
+    calendar cutoff lands on the Sunday, a strict `<` still admits the Friday, and that
+    Friday's one-session-forward outcome resolves on the first session of the holdout.
+    A test that only pins a multi-session buffer passes on a panel that still leaks here.
+    """
+    study, label, frame, sessions = _session_causal_fixture(tmp_path, monkeypatch)
+    _patch_modeling_dataset(monkeypatch, frame, buffer="1D")
+    _set_holdout_start(study.root / "config" / "setup.yaml", "2024-02-19")
+
+    computation = study.causal(method="dml", label=label.name).resolve().spec["computation"]
+
+    holdout = pd.Timestamp("2024-02-19", tz="UTC")
+    pre_holdout = [timestamp for timestamp in sessions if timestamp < holdout]
+    last_session = pre_holdout[-1]
+    # The Friday sits strictly before the calendar cutoff, so the old construction kept it.
+    assert last_session < holdout - pd.Timedelta("1D")
+    # Counting one observation instead seals at that Friday, so the last row retained is
+    # the Thursday, whose next session is the Friday and therefore still outside.
+    assert computation["estimand"]["holdout_endpoint_cutoff"] == last_session.isoformat()
+    symbols = frame.get_column("symbol").n_unique()
+    assert computation["analysis_population"]["n_rows"] == (len(pre_holdout) - 1) * symbols


### PR DESCRIPTION
Fixes the pre-holdout seal in `resolve_causal_request`, which seals the analysis
window in calendar time while the horizons those buffers describe are counted in
the panel's own observations. Tracked as ml4t/agent-workspace#906 and #908.

## The leak

`endpoint_cutoff = holdout - label_buffer` subtracts a calendar `Timedelta`. A
21D buffer is roughly fifteen sessions on a five-session week, so the rows
between the calendar cutoff and the observation cutoff were retained even though
their outcomes resolve inside the holdout.

Measured on the cme_futures panel with `holdout_start` 2024-01-01:

| label | calendar cutoff | observation cutoff | leaking sessions |
|---|---|---|---|
| `fwd_ret_21d` | 2023-12-11 | 2023-11-30 | 7 |
| `fwd_ret_5d`  | 2023-12-27 | 2023-12-22 | 2 |

The five calendar days before that holdout contain the Christmas holiday and
hold three sessions, which is why even the shorter horizon is exposed.

## Three revisions, two of them wrong

The first version counted distinct panel timestamps. The second computed a
cutoff per entity and collapsed them with `min()` to keep one scalar. Both were
caught by review, and both are recorded here because the second is the more
instructive: it traded correctness for a stable spec shape and would have let a
single delisted firm truncate an entire panel.

## Two counts, not one

The first version of this fix counted distinct panel timestamps. That is still
wrong on an unbalanced panel: a label advances by each entity's own
observations, so where one product is missing some of the final sessions,
stepping back N panel timestamps reaches back fewer than N of that product's
observations and leaves its last rows resolving inside the holdout. Review
caught this; a balanced fixture cannot.

The step-back is now counted within each entity. An entity holding no more than
`horizon_steps` pre-holdout observations has no row that resolves before the
boundary and drops out entirely. The earliest surviving cutoff applies
panel-wide, so the single scalar the estimand records still describes the filter
actually applied, and no new field enters the recorded spec shape.

The cadence is measured on the pre-holdout rows rather than on the already
trimmed analysis frame, so a panel whose spacing changes across the boundary
cannot size the buffer or the embargo from rows the analysis never touches.

## Behavior change beyond the leak

The trim is unconditional: it also removes the final observation when the panel
stops short of the holdout. Whether that row's outcome resolves inside the panel
depends on how the label was built, which this function cannot see, so the
conditional version encodes a property of the fixture rather than of the data.

Two existing tests asserted the old no-op and now assert the panel less the
buffer. They were asserting a property of their continuous 8-hour fixture, not
anything about the seal. Anyone landing this fix without those two updates sees
failures that look unrelated to what they changed.

## Verification

Each new test was run against the unfixed code to confirm it fails:

| test | without the fix |
|---|---|
| `test_holdout_seal_counts_sessions_not_calendar_days` | seals 2024-02-14, expected 2024-02-12 |
| `test_holdout_seal_counts_each_entity_own_observations` | 156 rows retained, expected 176 |
| `test_one_entity_exiting_early_does_not_truncate_the_others` | 66 rows retained, expected 161 |

`test_holdout_seal_fails_closed_on_a_panel_shorter_than_its_buffer` covers the
refusal path, which had no coverage.

168 passed, 2 skipped across `test_causal_adapter`, `test_causal_registry_registration`,
`test_causal_panel_splits`, `test_holdout_boundary`, `test_leakage_detectors`,
`test_pvalue_tail_precision`, `test_research_models` and
`test_us_firm_research_workflow`. One failure in the last of these,
`test_open_study_writes_canonical_results_to_output_dir`, is pre-existing and
environmental: it asserts produced artifacts that CI seeds and a local worktree
does not have, and it fails identically on a tree whose `causal.py` matches
main. Lint and format clean.

## Known, not addressed here

The code treats every buffer as an observation count, but `sp500_options`
declares `buffer: 35D` for `ret_to_expiry`, a calendar horizon to option expiry.
Converting it to 35 daily observations trims about seven weeks instead of five.
That over-trims, so it loses data rather than leaking it, and a real fix needs
label metadata separating calendar-anchored horizons from session-counted ones
rather than a change at this call site. Tracked as ml4t/agent-workspace#909.

## Three notebooks stop reproducing

Three committed causal notebooks store seal-dependent numbers computed under
the old construction, so a reader on a clean clone will not reproduce them once
this lands:

| notebook | stored values |
|---|---|
| `fx_pairs/11_causal_dml.ipynb` | `analysis_rows` 59280/59500/59560, `analysis_timestamps` 2964/2975, three `analysis_key_digest`s, three printed endpoints |
| `cme_futures/11_causal_dml.ipynb` | `analysis_rows` 88320/88695, `analysis_timestamps` 3089/3100 |
| `crypto_perps_funding/11_causal_dml.ipynb` | `embargo_periods` 1 |

The remaining five store none. `crypto`'s value comes from
`embargo_from_buffer`, which this branch does not touch, so it should survive a
rerun unchanged; the other two will not.

Each needs one re-execution after this lands, on the land-first-then-re-execute-
once rule rather than once per merge. I have not run them here.

A note on how this was counted, because the obvious method under-reports it. A
text search of a `.ipynb` finds numbers a notebook *prints*, but these
notebooks mostly *display polars frames*, which render into `text/html`. There
the column name matches a `<th>` header while the value sits in a later `<td>`,
so a naive scan reports a hit with no value, or misses the notebook entirely.
My first pass searched only `text/plain`, `text/markdown` and stream text and
found one notebook of the three. The table above comes from parsing the HTML
cells.

## Blast radius

`_causal_source_identity` sha256s `causal.py` whole, so this moves every identity
resolved through it and every causal run needs recomputing, not merely
re-identifying. The affected estimates are cheap: on cme_futures, 11_causal_dml
is 6:46 and 12_model_analysis is 0:11, and nothing downstream reads a causal row.
