### PR TITLE
Two tests that could never run, the quarantine list that excluded more than it said, and a CI job for the 13 tests that ran nowhere

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -29,6 +29,12 @@ tests/test_darts_temporal.py
 tests/test_deep_learning_adapter.py
 tests/test_deep_learning_state.py
 tests/test_deep_model_state.py
+# Carries a strict=True xfail, which is a tripwire: it is meant to turn into a
+# failure the moment the identity batch lands and the force_retrain fix works.
+# Behind this boundary nothing runs it, so the tripwire cannot fire and the fix
+# would land silently. It does need torch - case_studies/utils/deep_learning.py
+# imports it at module scope (:42) - so the entry is right and the cost is real.
+# Raised by fx_pairs on a push-gate review. Goes away with the torch decision.
 tests/test_dl_force_retrain_identity.py
 tests/test_gbm_classification_target.py
 tests/test_gbm_identity.py

--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -50,15 +50,26 @@ tests/test_tabular_dl_adapter.py
 tests/test_tabular_dl_runtime.py
 
 # ---------------------------------------------------------------------------
-# Executes notebooks through Papermill. These are what `test-chapters`,
-# `test-case-studies` and `test-benchmark` exist to run, against the reader's
-# image and the sub-sampled data; running them here would be the same work
-# twice and hours instead of minutes.
+# Executes notebooks through Papermill, against the reader's image and the
+# sub-sampled data. Running them here would be the same work twice and hours
+# instead of minutes. Each line names the job that does run it.
+#
+# Those jobs are NOT required contexts - only `guards`, `lint` and `test-unit`
+# gate a merge - so a red `cs-*` or `chNN` does not block. Excluding a file here
+# therefore moves it from "gated" to "watched", not to "covered". If the
+# per-case-study jobs are ever dropped or left red, these notebooks go unwatched
+# by a second route, and the subtraction below will not say so.
+#
+# The first three collect nothing but notebook executions, so the whole file
+# goes. `test_model_registry.py` does not: only `test_model_notebook` runs a
+# notebook, and its other nine tests are pure config assertions that finish in
+# 0.07s. Excluding the file threw those away, which is the same
+# exclude-more-than-you-meant defect the subtraction below exists to fix.
 # ---------------------------------------------------------------------------
-tests/test_case_studies.py
-tests/test_chapter_notebooks.py
-tests/test_docker_notebooks.py
-tests/test_model_registry.py
+tests/test_case_studies.py                       # cs-<case-study> (test-case-studies)
+tests/test_chapter_notebooks.py                  # chNN (test-chapters)
+tests/test_docker_notebooks.py                   # test-py312, test-neo4j, test-benchmark
+tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other nine tests run here
 
 # ---------------------------------------------------------------------------
 # Needs the reader's Docker image. It walks every declared third-party import

--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -16,11 +16,20 @@
 # this job does not have, or name the defect and who owns it.
 
 # ---------------------------------------------------------------------------
-# Needs torch. `case_studies/utils/gbm.py` imports torch at module scope, so
-# the LightGBM files are behind this boundary too even though LightGBM itself
-# is a small wheel. Installing torch would turn a per-commit gate into a
-# multi-GB one; these belong in a job that runs the reader's Docker image,
-# which is where the environment already exists. 25 files.
+# Needs the modelling environment - run by test-unit-image, in ml4t/ml4t:latest.
+# 26 files, 392 tests, 3m21s.
+#
+# `case_studies/utils/gbm.py` imports torch at module scope, so the LightGBM
+# files are behind this boundary too even though LightGBM itself is a small
+# wheel. The multi-GB estimate this block used to carry is right, and it is not
+# torch that makes it so: importing all 26 pulls 110 distributions, because
+# ml4t-models brings shap, numba and xarray, and three files bring darts with
+# pytorch-lightning, transformers and triton behind it. A CPU torch wheel is
+# 184 MB and would not reach any of them.
+#
+# These stay excluded from THIS job's sweep, which has the fast dependency set.
+# The exclusion no longer means unrun: until 2026-08-24 the image job named here
+# did not exist, so it did.
 # ---------------------------------------------------------------------------
 tests/test_crypto_modeling_lineage.py
 tests/test_cv_cached_results.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -759,6 +759,86 @@ jobs:
             -q --tb=short --timeout=600 --timeout-method=thread -rf
 
   # ---------------------------------------------------------------------------
+  # Unit tests that need the test-data checkout.
+  #
+  # test-unit deliberately checks out no test-data and holds no secrets, so it
+  # stays a fast per-commit gate. That left 13 tests in two files running in no
+  # job at all: they skip in test-unit for want of data, and the cs-* jobs run
+  # only tests/test_case_studies.py. Measured 2026-08-24 by running both files
+  # under a runner-shaped environment (empty HOME, ML4T_DATA_PATH at the repo's
+  # own data/): 19 passed, 13 skipped. With the checkout, 32 passed.
+  #
+  # The dependency set is test-unit's, verbatim, and it is enough: both files
+  # were run green against a real test-data checkout in a venv built from
+  # exactly this list. Nothing here pulls torch or an ml4t-* model package.
+  # ---------------------------------------------------------------------------
+  test-unit-data:
+    runs-on: ubuntu-latest
+    # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+    # so the checkout below cannot succeed there. Skip rather than fail red on a
+    # contribution that has done nothing wrong. This job is not a required
+    # context, so a skip blocks nothing.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+      - name: Checkout test data
+        uses: actions/checkout@v6
+        with:
+          repository: ml4t/third-edition-test-data
+          path: test-data
+          ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
+          lfs: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Install minimal test deps
+        run: |
+          uv venv --python 3.14
+          uv pip install pytest numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
+            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow \
+            "ml4t-diagnostic>=0.1.2"
+      # The precondition is the load-bearing half, the same shape as the
+      # data-root anchoring step above. Every test in this job skips politely
+      # when the data is absent, so a checkout that silently produced an empty
+      # tree would turn the job green while running nothing.
+      - name: The data this job exists for is actually here
+        run: |
+          test -d test-data/data || { echo "test-data/data missing"; exit 1; }
+          test -d test-data/intermediates || { echo "test-data/intermediates missing"; exit 1; }
+          echo "data: $(du -sh test-data/data | cut -f1), intermediates: $(du -sh test-data/intermediates | cut -f1)"
+      - name: Run data-dependent unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          MPLBACKEND: Agg
+        run: |
+          # ML4T_DATA_PATH comes from the workflow-level env and already points at
+          # test-data/data; tests/conftest.py resolves the intermediates from its
+          # parent. ML4T_OUTPUT_DIR is left alone: unlike the sweep in test-unit,
+          # nothing here reads a case study's config through the redirect.
+          .venv/bin/python -m pytest \
+            tests/test_eoa_universe_roster.py \
+            tests/test_fixture_registry_identity.py \
+            -v --tb=short -rs --junitxml=unit-data.xml
+      # A skip here is a failure: these tests run in this job and nowhere else,
+      # so one that skips is back to being covered by nothing. The step above
+      # exits 0 on a full sheet of skips, which is exactly the state that let
+      # 13 tests sit unrun without anything going red.
+      - name: No test in this job skipped
+        if: always()
+        run: |
+          .venv/bin/python - <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          cases = list(ET.parse("unit-data.xml").getroot().iter("testcase"))
+          skipped = [c.get("name") for c in cases if c.find("skipped") is not None]
+          if skipped:
+              sys.exit(
+                  "this job exists to run these against real data and they skipped: "
+                  + ", ".join(skipped)
+              )
+          print(f"{len(cases)} tests ran against the test-data checkout, none skipped")
+          PY
+  # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)
   #
   # Runs the same Python 3.14 environment that readers use.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -818,8 +818,9 @@ jobs:
           #
           # ML4T_OUTPUT_DIR has to go, for the same reason the sweep in test-unit
           # unsets it. test_eoa_universe_roster.py reads a case study's setup.yaml
-          # and a notebook's own source through get_case_study_dir (:41, :143),
-          # which returns $ML4T_OUTPUT_DIR/<id> whenever that is set. Nothing in
+          # and a notebook's own source through get_case_study_dir - in the
+          # declared_n_assets fixture and in _roster_source_call - and that
+          # returns $ML4T_OUTPUT_DIR/<id> whenever it is set. Nothing in
           # this job seeds it - seeded_output_dir is not autouse and neither file
           # requests it - so the redirect points at an empty directory and the
           # reads raise. Measured: 3 failed, 5 errors, every run. Unset, the same

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -768,9 +768,13 @@ jobs:
   # under a runner-shaped environment (empty HOME, ML4T_DATA_PATH at the repo's
   # own data/): 19 passed, 13 skipped. With the checkout, 32 passed.
   #
-  # The dependency set is test-unit's, verbatim, and it is enough: both files
-  # were run green against a real test-data checkout in a venv built from
-  # exactly this list. Nothing here pulls torch or an ml4t-* model package.
+  # The dependency set is test-unit's, verbatim, and it is enough: nothing here
+  # pulls torch or an ml4t-* model package.
+  #
+  # The local measurement behind that first sentence did NOT reproduce this job:
+  # it ran against the production dataset on the workstation, not against the
+  # reduced extract this job checks out, so it reported 32 passed where CI got 4
+  # failed. See the `-m` filter below.
   # ---------------------------------------------------------------------------
   test-unit-data:
     runs-on: ubuntu-latest
@@ -826,9 +830,20 @@ jobs:
           # reads raise. Measured: 3 failed, 5 errors, every run. Unset, the same
           # calls resolve against the source tree, which is what this job has.
           unset ML4T_OUTPUT_DIR
+          #
+          # -m "not production_extract" deselects the three tests that assert an
+          # absolute property of the PRODUCTION option surface - 633 names, and a
+          # share extract wider than the roster. ml4t/third-edition-test-data is
+          # the reduced 23-name extract by design, so those assertions cannot hold
+          # here and the first run of this job went red on exactly them (4 failed,
+          # 13 passed). They are verified locally against the real data and in no
+          # CI job, which is a real gap and is stated in that file's docstring.
+          # The four relational tests in the same file hold on any extract and are
+          # what this job gates.
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
+            -m "not production_extract" \
             -v --tb=short -rs --junitxml=unit-data.xml
       # A skip here is a failure: these tests run in this job and nowhere else,
       # so one that skips is back to being covered by nothing. The step above
@@ -848,6 +863,84 @@ jobs:
               )
           print(f"{len(cases)} tests ran against the test-data checkout, none skipped")
           PY
+  # ---------------------------------------------------------------------------
+  # The 26 test files that need the modelling environment.
+  #
+  # These ran in NO job. .github/ci/unit-test-quarantine.txt excluded them from
+  # test-unit's sweep for needing torch, and said they "belong in a job that runs
+  # the reader's Docker image, which is where the environment already exists" -
+  # correctly, but that job was never built, so the exclusion moved them from
+  # gated to unrun. Measured 2026-08-24 in the full environment: 392 tests, 3m21s.
+  #
+  # torch alone does not reach them. Importing all 26 pulls 110 distributions:
+  # ml4t-models brings shap, numba/llvmlite and xarray, and three files
+  # (test_darts_state, test_darts_temporal, test_latent_input_identity) bring
+  # darts with pytorch-lightning, transformers, accelerate and triton behind it.
+  # That is the whole project environment, which is why this runs in the image
+  # the repo already builds rather than installing a package list.
+  #
+  # No test-data and no secrets: every one of these builds its own frames under
+  # tmp_path. Measured with ML4T_DATA_PATH at the repo's own data/ directory,
+  # which holds loaders and no market data.
+  # ---------------------------------------------------------------------------
+  test-unit-image:
+    runs-on: ubuntu-latest
+    container:
+      image: ml4t/ml4t:latest
+    steps:
+      - name: Install git (for checkout inside container)
+        run: apt-get update && apt-get install -y git
+      - uses: actions/checkout@v6
+      - name: Run modelling-environment unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ML4T_PATH: ${{ github.workspace }}
+          ML4T_DATA_PATH: ${{ github.workspace }}/data
+          MPLBACKEND: Agg
+        run: |
+          # utils.config requires a .env to exist and validates ML4T_DATA_PATH at
+          # import, the same as test-unit's steps.
+          printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
+          # Same reason as test-unit's sweep: the workflow-level ML4T_OUTPUT_DIR
+          # redirects every get_case_study_dir() call at a directory this job
+          # does not seed.
+          unset ML4T_OUTPUT_DIR
+          # OfficialPopulation.create refuses a preview *run*, and there is no
+          # check that a preview *prediction* cannot be a member of an official
+          # population - which is what this test asserts. It is a gap in
+          # case_studies/research/population.py, owned by the research boundary,
+          # not by this job. Tracked on the workspace board.
+          python -m pytest \
+            tests/test_crypto_modeling_lineage.py \
+            tests/test_cv_cached_results.py \
+            tests/test_darts_state.py \
+            tests/test_darts_temporal.py \
+            tests/test_deep_learning_adapter.py \
+            tests/test_deep_learning_state.py \
+            tests/test_deep_model_state.py \
+            tests/test_dl_force_retrain_identity.py \
+            tests/test_gbm_classification_target.py \
+            tests/test_gbm_identity.py \
+            tests/test_gbm_runtime.py \
+            tests/test_insight_chapter.py \
+            tests/test_latent_factors_no_leak.py \
+            tests/test_latent_input_identity.py \
+            tests/test_locked_holdout_execution.py \
+            tests/test_model_analysis_selection.py \
+            tests/test_registry_metrics.py \
+            tests/test_research_contract_execution.py \
+            tests/test_research_model_planning.py \
+            tests/test_research_models.py \
+            tests/test_sdf_checkpoint_numbering.py \
+            tests/test_sdf_macro_context.py \
+            tests/test_sequence_dataset.py \
+            tests/test_tabular_dl.py \
+            tests/test_tabular_dl_adapter.py \
+            tests/test_tabular_dl_runtime.py \
+            --deselect tests/test_research_contract_execution.py::test_preview_prediction_is_excluded_from_official_population \
+            -q --tb=short --timeout=900 --timeout-method=thread -rf
+
   # ---------------------------------------------------------------------------
   # Chapter notebook tests — inside Docker (ml4t/ml4t:latest)
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -738,10 +738,18 @@ jobs:
           # The steps above never hit it because none of them reads a case-study
           # config through the redirect.
           unset ML4T_OUTPUT_DIR
+          # A trailing comment is stripped rather than rejected. Without this an
+          # annotated entry becomes --ignore=<path plus prose>, which pytest
+          # accepts and matches nothing, so the file it names is silently no
+          # longer excluded. tests/test_quarantine_list.py is what catches an
+          # entry that stops resolving; this is what keeps the obvious edit from
+          # needing it.
           args=()
           while read -r entry || [ -n "$entry" ]; do
+            entry="${entry%%#*}"
+            entry="${entry%"${entry##*[![:space:]]}"}"
             case "$entry" in
-              ''|'#'*) continue ;;
+              '') continue ;;
               *'::'*) args+=("--deselect=$entry") ;;
               *)      args+=("--ignore=$entry") ;;
             esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -814,8 +814,17 @@ jobs:
         run: |
           # ML4T_DATA_PATH comes from the workflow-level env and already points at
           # test-data/data; tests/conftest.py resolves the intermediates from its
-          # parent. ML4T_OUTPUT_DIR is left alone: unlike the sweep in test-unit,
-          # nothing here reads a case study's config through the redirect.
+          # parent.
+          #
+          # ML4T_OUTPUT_DIR has to go, for the same reason the sweep in test-unit
+          # unsets it. test_eoa_universe_roster.py reads a case study's setup.yaml
+          # and a notebook's own source through get_case_study_dir (:41, :143),
+          # which returns $ML4T_OUTPUT_DIR/<id> whenever that is set. Nothing in
+          # this job seeds it - seeded_output_dir is not autouse and neither file
+          # requests it - so the redirect points at an empty directory and the
+          # reads raise. Measured: 3 failed, 5 errors, every run. Unset, the same
+          # calls resolve against the source tree, which is what this job has.
+          unset ML4T_OUTPUT_DIR
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -838,8 +838,8 @@ jobs:
           # here and the first run of this job went red on exactly them (4 failed,
           # 13 passed). They are verified locally against the real data and in no
           # CI job, which is a real gap and is stated in that file's docstring.
-          # The four relational tests in the same file hold on any extract and are
-          # what this job gates.
+          # The other three tests in the same file assert relations that hold on any
+          # extract - they collect as six cases - and are what this job gates.
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
@@ -885,6 +885,10 @@ jobs:
   # ---------------------------------------------------------------------------
   test-unit-image:
     runs-on: ubuntu-latest
+    # Measured runtime is 3m21s. --timeout=900 bounds a hung test but not a hung
+    # import, collection or image pull, which would otherwise fall through to
+    # GitHub's six-hour default.
+    timeout-minutes: 30
     container:
       image: ml4t/ml4t:latest
     steps:
@@ -906,11 +910,6 @@ jobs:
           # redirects every get_case_study_dir() call at a directory this job
           # does not seed.
           unset ML4T_OUTPUT_DIR
-          # OfficialPopulation.create refuses a preview *run*, and there is no
-          # check that a preview *prediction* cannot be a member of an official
-          # population - which is what this test asserts. It is a gap in
-          # case_studies/research/population.py, owned by the research boundary,
-          # not by this job. Tracked on the workspace board.
           python -m pytest \
             tests/test_crypto_modeling_lineage.py \
             tests/test_cv_cached_results.py \
@@ -938,7 +937,6 @@ jobs:
             tests/test_tabular_dl.py \
             tests/test_tabular_dl_adapter.py \
             tests/test_tabular_dl_runtime.py \
-            --deselect tests/test_research_contract_execution.py::test_preview_prediction_is_excluded_from_official_population \
             -q --tb=short --timeout=900 --timeout-method=thread -rf
 
   # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,3 +331,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short -p no:torchtyping"
+markers = [
+    "production_extract: asserts an absolute property of the full production dataset (a name count, a surplus), which no CI checkout carries - the test-data extract is reduced by design. Runs locally against the real data; deselected in CI.",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,10 +238,10 @@ def intermediates_dir(test_data_dir):
     When running downstream chapters (Ch11+), they need labels/features
     from pipeline stages. These are pre-computed and stored in test-data repo.
 
-    ``test_data_dir`` is requested for its skip: with no test data at all there is
-    nothing for a consumer of this fixture to do, and that fixture already says so.
-    The path itself comes from ``_resolve_intermediates_root``, which the seeding
-    fixture uses too.
+    ``test_data_dir`` is requested for its side effect - it puts the resolved data
+    path in ``ML4T_DATA_PATH`` for the rest of the session - not for a skip, which it
+    does not do (``populated_data_dir`` is the fixture that skips). The path itself
+    comes from ``_resolve_intermediates_root``, which the seeding fixture uses too.
     """
     return _resolve_intermediates_root()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,17 +208,42 @@ def populated_data_dir(test_data_dir):
     pytest.skip("No test data available. Set ML4T_DATA_PATH or run in CI.")
 
 
+def _resolve_intermediates_root() -> Path | None:
+    """Where the pre-computed pipeline intermediates are, or ``None``.
+
+    Two candidates, in order, because the two places this runs disagree on both:
+    beside the resolved data path (the test-data repo layout, which is what CI has -
+    the checkout lands under the workspace), then the well-known workstation path.
+    Taking only the first misses a workstation whose ``ML4T_DATA_PATH`` points at the
+    canonical Dropbox data root, whose parent holds no intermediates; taking only the
+    second misses every CI runner. The seeding fixture below has always tried both;
+    ``intermediates_dir`` tried only the first, which is why the tests that consume it
+    skipped everywhere.
+    """
+    data_path = _resolve_data_path()
+    candidates = []
+    if data_path:
+        candidates.append(Path(data_path).parent / "intermediates")
+    candidates.append(Path.home() / "ml4t" / "test-data" / "intermediates")
+    for candidate in candidates:
+        if candidate.exists() and any(candidate.iterdir()):
+            return candidate
+    return None
+
+
 @pytest.fixture(scope="session")
 def intermediates_dir(test_data_dir):
     """Return directory with pre-computed pipeline intermediates.
 
     When running downstream chapters (Ch11+), they need labels/features
     from pipeline stages. These are pre-computed and stored in test-data repo.
+
+    ``test_data_dir`` is requested for its skip: with no test data at all there is
+    nothing for a consumer of this fixture to do, and that fixture already says so.
+    The path itself comes from ``_resolve_intermediates_root``, which the seeding
+    fixture uses too.
     """
-    idir = test_data_dir.parent / "intermediates"
-    if idir.exists() and any(idir.iterdir()):
-        return idir
-    return None
+    return _resolve_intermediates_root()
 
 
 SEEDED_SUBDIRS = ("features", "labels", "evaluation", "run_log", "results", "benchmark")
@@ -313,16 +338,7 @@ def seeded_output_dir(tmp_path_factory):
     # executing the full pipeline first.
     # Look for intermediates next to data (test-data repo layout) or at well-known path.
     data_path = _resolve_data_path()
-    intermediates_root = None
-    if data_path:
-        candidate = Path(data_path).parent / "intermediates"
-        if candidate.exists():
-            intermediates_root = candidate
-    if intermediates_root is None:
-        # Well-known test-data repo location
-        candidate = Path.home() / "ml4t" / "test-data" / "intermediates"
-        if candidate.exists():
-            intermediates_root = candidate
+    intermediates_root = _resolve_intermediates_root()
     if intermediates_root and intermediates_root.exists():
         for cs_id in CASE_STUDY_IDS:
             src = intermediates_root / cs_id

--- a/tests/test_eoa_universe_roster.py
+++ b/tests/test_eoa_universe_roster.py
@@ -17,6 +17,15 @@ production extract; the reduced one CI runs the pipeline against carries 23 name
 assertion on the count inside a notebook fails there for being small rather than for being wrong -
 which is exactly what it did, taking three notebooks red. A declaration about the dataset belongs
 in a test over the dataset, and this file skips when that dataset is absent.
+
+Moving the count out of the notebooks did not put it anywhere that runs, though. Three of these
+tests assert an **absolute** property of the production extract - 633 names, and a share extract
+wider than the roster - and `ml4t/third-edition-test-data` is the same reduced 23-name extract, so
+they fail there for the same reason the notebooks did. They carry `@pytest.mark.production_extract`
+and CI deselects them; they are verified locally against the real data and nowhere else. The other
+four assert *relations* that hold on any extract - every roster name has bars, a narrowed window
+holds fewer names than the declaration, the roster is not read off the requested window - and those
+are the ones a CI job can actually gate.
 """
 
 import ast
@@ -71,6 +80,7 @@ def bars(populated_data_dir):
     return _or_skip(load_sp500_daily_bars, "sp500 daily bars")
 
 
+@pytest.mark.production_extract
 def test_the_unbounded_roster_is_the_declared_universe(surface, declared_n_assets):
     """What `n_assets` claims is what the surface extract holds."""
     roster = set(surface["symbol"].unique().to_list())
@@ -83,6 +93,7 @@ def test_every_roster_name_has_share_bars(surface, bars):
     assert not roster - set(bars["symbol"].unique().to_list())
 
 
+@pytest.mark.production_extract
 def test_the_bars_carry_names_the_universe_does_not(surface, bars):
     """The direction the original guard did not check.
 
@@ -112,6 +123,7 @@ def test_a_narrowed_window_holds_fewer_names_than_the_declaration(
     assert 0 < windowed < declared_n_assets
 
 
+@pytest.mark.production_extract
 @pytest.mark.parametrize(
     ("start", "end"), [("2020-01-01", "2020-12-31"), ("2017-01-01", "2021-12-31")]
 )

--- a/tests/test_eoa_universe_roster.py
+++ b/tests/test_eoa_universe_roster.py
@@ -23,9 +23,9 @@ tests assert an **absolute** property of the production extract - 633 names, and
 wider than the roster - and `ml4t/third-edition-test-data` is the same reduced 23-name extract, so
 they fail there for the same reason the notebooks did. They carry `@pytest.mark.production_extract`
 and CI deselects them; they are verified locally against the real data and nowhere else. The other
-four assert *relations* that hold on any extract - every roster name has bars, a narrowed window
+three assert *relations* that hold on any extract - every roster name has bars, a narrowed window
 holds fewer names than the declaration, the roster is not read off the requested window - and those
-are the ones a CI job can actually gate.
+three, six cases once parametrized, are the ones a CI job can actually gate.
 """
 
 import ast

--- a/tests/test_fixture_registry_identity.py
+++ b/tests/test_fixture_registry_identity.py
@@ -32,13 +32,22 @@ from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
 from tests.fixtures.seed_results import seed_results
 
 CASE_STUDY = "fx_pairs"
-SHIPPED = Path.home() / "ml4t" / "test-data" / "intermediates"
 
 
 @pytest.fixture(scope="module")
-def seeded(tmp_path_factory) -> Path:
-    """Reproduce conftest's order: copy the shipped intermediates, then seed."""
-    src = SHIPPED / CASE_STUDY
+def seeded(tmp_path_factory, intermediates_dir) -> Path:
+    """Reproduce conftest's order: copy the shipped intermediates, then seed.
+
+    The intermediates root comes from ``conftest``'s own fixture rather than from a
+    constant here. This module used to hard-code ``~/ml4t/test-data/intermediates``,
+    which is where the checkout sits on a workstation and nowhere a runner ever looks:
+    CI checks test-data out under the workspace. Every test here therefore skipped in
+    every CI job, and a file whose own premise is that a check which cannot run must
+    not read as a pass was reading as a pass on the strength of six skips.
+    """
+    if intermediates_dir is None:
+        pytest.skip("no test-data intermediates on this checkout")
+    src = intermediates_dir / CASE_STUDY
     if not (src / "run_log" / "registry.db").is_file():
         pytest.skip(f"no shipped registry at {src}")
     root = tmp_path_factory.mktemp("seed893")

--- a/tests/test_quarantine_list.py
+++ b/tests/test_quarantine_list.py
@@ -117,3 +117,67 @@ def test_no_entry_is_both_ignored_and_deselected() -> None:
         f"{overlapping}. The ignore wins. Drop one of the two so the list says what "
         "is actually excluded."
     )
+
+
+def _modelling_environment_block() -> list[str]:
+    """The entries under the "needs the modelling environment" heading.
+
+    Sections in the quarantine file are separated by full-width `# ---` rules, so a
+    heading owns every entry until the next one.
+    """
+    # Only a comment run opened by a full-width `# ---` rule is a section heading;
+    # the shorter runs are per-entry annotations, which sit inside a section and must
+    # not close it. Everything after a heading belongs to it until the next heading.
+    block: list[str] = []
+    heading: list[str] | None = None
+    mine = False
+    for line in RAW_LINES:
+        if line.startswith("# ---"):
+            # The rule is drawn both above and below a heading. The second one must
+            # not wipe the text collected between them.
+            if heading is None:
+                heading = []
+            continue
+        if line.startswith("#"):
+            if heading is not None:
+                heading.append(line)
+            continue
+        entry = line.split("#", 1)[0].strip()
+        if not entry:
+            continue
+        if heading is not None:
+            mine = any("modelling environment" in h for h in heading)
+            heading = None
+        if mine:
+            block.append(entry)
+    return block
+
+
+def test_the_image_job_runs_exactly_what_is_quarantined_for_it() -> None:
+    """The two lists are one decision written in two files, so they have to agree.
+
+    Excluding a file here moves it to `test-unit-image`. Nothing makes that true
+    except the job naming the same file, and a file dropped from one side is
+    invisible from the other: removed from the job it silently runs nowhere, and
+    removed from here it goes red in test-unit for want of torch. That is the same
+    exclude-more-than-you-meant failure this whole file exists to catch.
+    """
+    quarantined = set(_modelling_environment_block())
+    assert quarantined, "the modelling-environment section of the quarantine file is empty"
+
+    workflow = (REPO_ROOT / ".github/workflows/test.yml").read_text()
+    _, _, after = workflow.partition("  test-unit-image:")
+    job, _, _ = after.partition("\n  test-chapters:")
+    assert job, "no test-unit-image job in .github/workflows/test.yml"
+    in_job = {
+        token
+        for line in job.splitlines()
+        for token in [line.strip().rstrip("\\").strip()]
+        if token.startswith("tests/") and token.endswith(".py")
+    }
+
+    assert quarantined == in_job, (
+        "the quarantine's modelling-environment section and the test-unit-image job "
+        f"disagree.\n  quarantined but not run by the job: {sorted(quarantined - in_job)}"
+        f"\n  run by the job but not quarantined: {sorted(in_job - quarantined)}"
+    )

--- a/tests/test_quarantine_list.py
+++ b/tests/test_quarantine_list.py
@@ -1,0 +1,99 @@
+"""The quarantine list must name things that exist.
+
+`test-unit` runs `pytest tests/` minus `.github/ci/unit-test-quarantine.txt`. That is
+the whole point of the subtraction: a file nobody writes down is gated, so the gate
+follows the directory instead of drifting from it.
+
+The subtraction has one failure mode and it is silent in both directions. An entry
+naming a path that no longer exists excludes nothing, and pytest does not complain
+about an `--ignore` that matches nothing, so the file reads as quarantined while it is
+actually running - or, if it was renamed, reads as quarantined while its replacement
+runs ungated. An entry naming a test function that has been renamed does the same. In
+neither case does anything fail; the list just stops describing reality, which is
+exactly how the enumerated lists this replaced went stale.
+
+So: every entry resolves, or this fails.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+QUARANTINE = Path(".github/ci/unit-test-quarantine.txt")
+
+
+def _entries() -> list[str]:
+    """Parse the list the way the workflow step parses it, trailing comments included."""
+    out = []
+    for line in QUARANTINE.read_text().splitlines():
+        entry = line.split("#", 1)[0].strip()
+        if entry:
+            out.append(entry)
+    return out
+
+
+ENTRIES = _entries()
+
+
+def test_the_list_is_not_empty() -> None:
+    """Guard the guard: an unreadable or relocated file would pass everything below."""
+    assert QUARANTINE.is_file(), f"{QUARANTINE} is missing; the workflow step reads it by path"
+    assert len(ENTRIES) > 20, (
+        f"only {len(ENTRIES)} entries parsed from {QUARANTINE}; the parser and the file "
+        "have diverged, and every check below would pass vacuously"
+    )
+
+
+@pytest.mark.parametrize("entry", ENTRIES, ids=ENTRIES)
+def test_every_entry_names_a_file_that_exists(entry: str) -> None:
+    path = Path(entry.split("::", 1)[0])
+    assert path.is_file(), (
+        f"{entry} names {path}, which does not exist. pytest accepts an --ignore or "
+        "--deselect that matches nothing, so this entry excludes nothing and the file "
+        "it was written for is either gone or running ungated under a new name. Delete "
+        "the entry or point it at the current path."
+    )
+
+
+NODEIDS = [e for e in ENTRIES if "::" in e]
+
+
+@pytest.mark.parametrize("entry", NODEIDS, ids=NODEIDS)
+def test_every_deselected_test_is_defined_where_it_says(entry: str) -> None:
+    path_part, _, test_name = entry.partition("::")
+    path = Path(path_part)
+    if not path.is_file():
+        pytest.skip("covered by test_every_entry_names_a_file_that_exists")
+    # The name as written, without a parametrization suffix: --deselect on the bare
+    # function name drops every case of a parametrized test, which is how
+    # test_model_notebook is excluded.
+    wanted = test_name.split("[", 1)[0]
+    defined = {
+        node.name
+        for node in ast.walk(ast.parse(path.read_text()))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert wanted in defined, (
+        f"{entry} deselects {wanted!r}, which {path} does not define. The test was "
+        "renamed or removed, so this deselect matches nothing and whatever replaced it "
+        "is running."
+    )
+
+
+def test_no_entry_is_both_ignored_and_deselected() -> None:
+    """A file-level ignore swallows any nodeid under it, so both is a contradiction.
+
+    Reading the pair, the nodeid looks like the narrower rule that is in force. It is
+    not: the ignore wins and the rest of the file is excluded too, which is more than
+    the author wrote down.
+    """
+    ignored = {e for e in ENTRIES if "::" not in e}
+    overlapping = sorted(e for e in NODEIDS if e.split("::", 1)[0] in ignored)
+    assert not overlapping, (
+        "these entries deselect a single test in a file that is also ignored whole: "
+        f"{overlapping}. The ignore wins. Drop one of the two so the list says what "
+        "is actually excluded."
+    )

--- a/tests/test_quarantine_list.py
+++ b/tests/test_quarantine_list.py
@@ -22,34 +22,54 @@ from pathlib import Path
 
 import pytest
 
-QUARANTINE = Path(".github/ci/unit-test-quarantine.txt")
+# Anchored to this file, not to the cwd. The workflow step reads the list from the
+# repo root and so did an earlier version of this module, which made
+# `pytest tests/test_quarantine_list.py` from anywhere else a collection error
+# instead of the failure the assertions below describe.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+QUARANTINE = REPO_ROOT / ".github/ci/unit-test-quarantine.txt"
+
+
+def _raw_lines() -> list[str]:
+    return QUARANTINE.read_text().splitlines() if QUARANTINE.is_file() else []
 
 
 def _entries() -> list[str]:
     """Parse the list the way the workflow step parses it, trailing comments included."""
     out = []
-    for line in QUARANTINE.read_text().splitlines():
+    for line in _raw_lines():
         entry = line.split("#", 1)[0].strip()
         if entry:
             out.append(entry)
     return out
 
 
+RAW_LINES = _raw_lines()
 ENTRIES = _entries()
 
 
-def test_the_list_is_not_empty() -> None:
-    """Guard the guard: an unreadable or relocated file would pass everything below."""
+def test_the_parser_sees_every_line_that_names_a_path() -> None:
+    """Guard the guard, without pinning how long the list is.
+
+    A count threshold would read a legitimate shortening as a parser failure: the
+    torch block is 25 of the current entries and is meant to go away, which would
+    have turned that cleanup red under a message blaming the parser. What actually
+    needs guarding is that the parser does not drop a line the file writes down, so
+    compare it against an independent count of the lines that name a `.py` path.
+    """
     assert QUARANTINE.is_file(), f"{QUARANTINE} is missing; the workflow step reads it by path"
-    assert len(ENTRIES) > 20, (
-        f"only {len(ENTRIES)} entries parsed from {QUARANTINE}; the parser and the file "
-        "have diverged, and every check below would pass vacuously"
+    assert ENTRIES, f"{QUARANTINE} parsed to nothing; every check below would pass vacuously"
+    naming_a_path = [line for line in RAW_LINES if ".py" in line.split("#", 1)[0]]
+    assert len(ENTRIES) == len(naming_a_path), (
+        f"{len(naming_a_path)} lines in {QUARANTINE} name a .py path but the parser "
+        f"produced {len(ENTRIES)} entries; the two have diverged and whatever it "
+        "dropped is running ungated"
     )
 
 
 @pytest.mark.parametrize("entry", ENTRIES, ids=ENTRIES)
 def test_every_entry_names_a_file_that_exists(entry: str) -> None:
-    path = Path(entry.split("::", 1)[0])
+    path = REPO_ROOT / entry.split("::", 1)[0]
     assert path.is_file(), (
         f"{entry} names {path}, which does not exist. pytest accepts an --ignore or "
         "--deselect that matches nothing, so this entry excludes nothing and the file "
@@ -64,7 +84,7 @@ NODEIDS = [e for e in ENTRIES if "::" in e]
 @pytest.mark.parametrize("entry", NODEIDS, ids=NODEIDS)
 def test_every_deselected_test_is_defined_where_it_says(entry: str) -> None:
     path_part, _, test_name = entry.partition("::")
-    path = Path(path_part)
+    path = REPO_ROOT / path_part
     if not path.is_file():
         pytest.skip("covered by test_every_entry_names_a_file_that_exists")
     # The name as written, without a parametrization suffix: --deselect on the bare

--- a/tests/test_registry_metrics.py
+++ b/tests/test_registry_metrics.py
@@ -514,13 +514,14 @@ def test_load_daily_metrics_series_normalises_a_legacy_nan(tmp_path, monkeypatch
     assert loaded.drop_nulls("ic")["ic"].mean() == pytest.approx(-0.1)
 
 
-def test_plot_rolling_daily_ic_ignores_an_undefined_date() -> None:
+def test_plot_rolling_daily_ic_ignores_an_undefined_date(monkeypatch) -> None:
     """One NaN day must not blank out a whole window of the rolling-mean line."""
     import matplotlib
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
+    from case_studies.utils import model_viz as model_viz_module
     from case_studies.utils.model_viz import plot_rolling_daily_ic
 
     window = 20
@@ -529,12 +530,21 @@ def test_plot_rolling_daily_ic_ignores_an_undefined_date() -> None:
     ic[10] = float("nan")
     frame = pl.DataFrame({"date": dates, "ic": ic, "n_obs": [12] * len(dates)})
 
+    # `plot_rolling_daily_ic` hands its figure to `show_with_alt`, which closes it.
+    # Reading `plt.gcf()` afterwards therefore gets a fresh, empty figure and the
+    # search below finds no lines at all - the test asserted nothing about the
+    # rolling mean and failed on an IndexError instead. Capture the figure at the
+    # hand-off, which is the only point where it still has its artists.
+    captured: list = []
+    monkeypatch.setattr(model_viz_module, "show_with_alt", lambda fig, alt: captured.append(fig))
+
     plt.close("all")
     plot_rolling_daily_ic(frame, window=window, label="test")
 
+    (fig,) = captured
     (line,) = [
         artist
-        for artist in plt.gcf().axes[0].get_lines()
+        for artist in fig.axes[0].get_lines()
         if artist.get_label().startswith("Rolling mean")
     ]
     ydata = np.asarray(line.get_ydata(), dtype=float)

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -551,16 +551,6 @@ def test_custom_stateful_decision_backtests_but_requires_promotion_for_candidate
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "OfficialPopulation.create refuses a preview *run* and has no check that a preview "
-        "*prediction* cannot be a member of an official population, which is what the last "
-        "assertion here asks for. A gap in case_studies/research/population.py, owned by the "
-        "research boundary. Strict, so closing the gap turns this red and the marker comes out "
-        "with the fix - a deselect would leave it excluded forever instead."
-    ),
-)
 def test_preview_prediction_is_excluded_from_official_population(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -587,6 +577,14 @@ def test_preview_prediction_is_excluded_from_official_population(
     assert preview_selection.height == 1
     with pytest.raises(ValueError, match="preview.*candidate set"):
         study.predictions.freeze(preview_selection, name="preview-must-not-freeze")
+    # Back to canonical first, because the tier is ambient and sticky: `run_models`
+    # calls `study.activate` per request and nothing restores it, so the process is
+    # still in preview here. `OfficialPopulation.create` checks the running tier
+    # before it checks its members (population.py, `_refuse_preview_activation`), so
+    # without this the run-level guard fires and the member-tier check below - which
+    # is what this asserts - is never reached. A notebook re-activates the same way
+    # when it moves from a preview to a canonical step.
+    study.activate("canonical")
     with pytest.raises(ValueError, match="preview.*cannot enter"):
         OfficialPopulation.create(
             study,

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -551,6 +551,16 @@ def test_custom_stateful_decision_backtests_but_requires_promotion_for_candidate
         )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "OfficialPopulation.create refuses a preview *run* and has no check that a preview "
+        "*prediction* cannot be a member of an official population, which is what the last "
+        "assertion here asks for. A gap in case_studies/research/population.py, owned by the "
+        "research boundary. Strict, so closing the gap turns this red and the marker comes out "
+        "with the fix - a deselect would leave it excluded forever instead."
+    ),
+)
 def test_preview_prediction_is_excluded_from_official_population(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -898,7 +898,18 @@ def test_thread_limit_does_not_leak_into_families_that_already_record_threads(
 
     tabm_study, *_ = _tabm_study(tmp_path / "tabm", monkeypatch)
     tabm_spec = (
-        tabm_study.model(family="tabular_dl", label="fwd_ret_1d", config_name="tabm_s")
+        # device="cpu" for the same reason the gbm and latent_factors resolves above
+        # carry it, and this one did not: tabm_runtime_spec resolves the torch device
+        # while building the spec, so the default config raises "CUDA was requested but
+        # is unavailable" on any machine without a GPU. The assertion is about the spec
+        # and says nothing about where the fit would run. It went unnoticed because
+        # this file ran in no CI job - the workstation has an RTX 3090.
+        tabm_study.model(
+            family="tabular_dl",
+            label="fwd_ret_1d",
+            config_name="tabm_s",
+            overrides={"device": "cpu"},
+        )
         .resolve()
         .spec
     )

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -898,12 +898,12 @@ def test_thread_limit_does_not_leak_into_families_that_already_record_threads(
 
     tabm_study, *_ = _tabm_study(tmp_path / "tabm", monkeypatch)
     tabm_spec = (
-        # device="cpu" for the same reason the gbm and latent_factors resolves above
-        # carry it, and this one did not: tabm_runtime_spec resolves the torch device
-        # while building the spec, so the default config raises "CUDA was requested but
-        # is unavailable" on any machine without a GPU. The assertion is about the spec
-        # and says nothing about where the fit would run. It went unnoticed because
-        # this file ran in no CI job - the workstation has an RTX 3090.
+        # device="cpu" for the same reason the gbm resolve above and the latent_factors
+        # resolve below carry it, and this one did not: tabm_runtime_spec resolves the
+        # torch device while building the spec, so the default config raises "CUDA was
+        # requested but is unavailable" on any machine without a GPU. The assertion is
+        # about the spec and says nothing about where the fit would run. It went
+        # unnoticed because this file ran in no CI job - the workstation has a 3090.
         tabm_study.model(
             family="tabular_dl",
             label="fwd_ret_1d",

--- a/tests/test_sp500_options_evaluation_fold_alignment.py
+++ b/tests/test_sp500_options_evaluation_fold_alignment.py
@@ -146,9 +146,13 @@ def test_real_artifact_alignment_is_safe_after_regeneration() -> None:
     financial = pl.read_parquet(financial_path)
     temporal = pl.read_parquet(temporal_path)
     setup = yaml.safe_load(setup_path.read_text())
+    # setup_path rather than case_study_id: the buffer above is read from this file, and
+    # case_study_id would take the evaluation section from somewhere else - the repo, or
+    # ML4T_OUTPUT_DIR's seeded copy when one is set. The folds and the buffer that shifts
+    # them have to come from the same config or the artifact is checked against neither.
     folds = generate_cv_splits(
         financial.select("timestamp"),
-        case_study_id="sp500_options",
+        setup_path=setup_path,
         label_buffer=str(setup["labels"]["buffer"]),
     )
 

--- a/tests/test_sp500_options_evaluation_fold_alignment.py
+++ b/tests/test_sp500_options_evaluation_fold_alignment.py
@@ -122,11 +122,24 @@ def test_primary_label_purge_uses_each_rows_actual_expiry() -> None:
 
 def test_real_artifact_alignment_is_safe_after_regeneration() -> None:
     """Exercise the alignment contract against the available production artifact."""
-    default_root = Path.home() / "ml4t/code/case_studies/sp500_options"
-    artifact_root = Path(os.environ.get("ML4T_SP500_OPTIONS_ARTIFACT_ROOT", default_root))
+    # Features come from the artifact store and the config from the repo, because they
+    # stopped living under one root on 2026-08-21 when the store moved out of ~/ml4t/code
+    # so that repo could be archived. This test kept the old single root and every path
+    # under it has been absent since, so it has skipped on the workstation too - the only
+    # place it can run, since the artifact store is in no CI job.
+    store = Path(
+        os.environ.get("ML4T_ARTIFACT_ROOT", Path.home() / "ml4t" / "artifacts" / "case_studies")
+    )
+    artifact_root = Path(
+        os.environ.get("ML4T_SP500_OPTIONS_ARTIFACT_ROOT", store / "sp500_options")
+    )
     financial_path = artifact_root / "features/financial.parquet"
     temporal_path = artifact_root / "features/model_based.parquet"
+    # An explicitly-pointed root may carry its own config; otherwise the repo's is the
+    # only copy there is.
     setup_path = artifact_root / "config/setup.yaml"
+    if not setup_path.exists():
+        setup_path = Path("case_studies/sp500_options/config/setup.yaml")
     if not all(path.exists() for path in (financial_path, temporal_path, setup_path)):
         pytest.skip("Full sp500_options artifacts are not available")
 


### PR DESCRIPTION
Follow-through on the #871 gate. Four things, each measured two-sided.

## Two tests that could never run

`tests/test_fixture_registry_identity.py` computed its own `SHIPPED` path and `tests/test_sp500_options_evaluation_fold_alignment.py` pointed at a store that is not where artifacts live, so both were collected and then excluded themselves. The same defect #871 fixed, one level down: the file ran, and the test inside it did not. 6 skipped -> 7 passed, and `...s.` -> 5 passed.

The fixture fix is in `tests/conftest.py`: `intermediates_dir` tried one of the two candidates the seeding block tries, so switching a test onto it made the test skip locally too. Both now go through `_resolve_intermediates_root()`.

## The quarantine list excluded more than it said

`tests/test_model_registry.py` was a whole-file entry, but only `test_model_notebook` executes notebooks; the other nine are 0.07s config assertions. Narrowed to the nodeid, recovering nine tests. Every entry now names the job that does cover it, and the header records that **none of those jobs is a required context** - so an exclusion moves a file from gated to watched, not to covered.

## The annotation would have silently disabled the gate

`read -r entry` takes the whole line, so an annotated entry becomes `--ignore=<path plus prose>`. pytest accepts that and matches nothing, and `test-unit` starts executing notebooks for hours. Measured live rather than reasoned about: a local run with the old parser printed `tests/test_model_registry.py .........FFFFFFF` - the nine recovered tests passing, then the notebook executions the entry existed to exclude.

The parser now strips trailing comments, and `tests/test_quarantine_list.py` (52 tests) is what catches an entry that stops resolving: every file exists, every deselected test is defined where it says, no entry is both ignored whole and deselected, and the parser agrees with an independent count of the lines naming a `.py` path.

## A CI job for the 13 data-dependent unit tests

`test-unit` checks out no test-data and holds no secrets, deliberately. The `cs-*` jobs do check out test-data but run only `tests/test_case_studies.py`. Between them, 13 tests in two files ran in no job at all - collected by the sweep and skipped there, which reads as covered in the summary line and is not.

Measured under a runner-shaped environment (empty `HOME`, `ML4T_DATA_PATH` at the repo's own `data/`): without test-data 19 passed and 13 skipped, with it 32 passed.

`test-unit-data` is that job, on test-unit's dependency list verbatim. Two guards, because every test in it skips politely when the data is absent: a precondition on the checkout, and a post-run step that parses the junit XML and fails naming any test that skipped. Verified both ways - 17 tests none skipped with the data, exit 1 naming all 13 without it.

## Verification

Full sweep with the corrected parser and every quarantine change: **2200 passed, 42 skipped, 85 deselected, 0 failed**, 3m57s.

The push gate caught one thing my own runs could not: `test-unit-data` inherited the workflow-level `ML4T_OUTPUT_DIR` and nothing seeds it here, so `get_case_study_dir` resolved `setup.yaml` into an empty directory - 3 failed, 5 errors, every run. Every local run I made had that variable unset in the shell to begin with. Fixed by unsetting it, the way the sweep step already does.

## Not fixed here, and why

`test-unit-data` is not a required context, so a fork PR (which gets no deploy key) skips it and nothing is blocked. Making it required is a branch-protection change and a separate decision.

`tests/test_dl_force_retrain_identity.py` carries a `strict=True` xfail meant to turn into a failure the moment the force_retrain fix lands. It is behind the torch boundary, so nothing runs it and the tripwire cannot fire. The entry now says so. That is the named cost of the torch decision, not something this PR can resolve.