### PR TITLE
A causal refit had no way to retire what it replaced

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -145,6 +145,11 @@ PRODUCTION_SAFE_PARAMETERS: dict[str, object] = {
     # adds a declaration rather than removing work, so it cannot reduce the run, and
     # population.py raises unless it equals the current population hash exactly.
     "SUPERSEDES_POPULATION": VALIDATED_BY_CONSUMER,
+    # The causal identity this run retires. Same shape as SUPERSEDES_POPULATION and
+    # for the same reason: it adds a declaration rather than removing work, so it
+    # cannot reduce the run, and register_causal_run refuses a hash that is not a
+    # current canonical identity for the same label.
+    "SUPERSEDES_CAUSAL": VALIDATED_BY_CONSUMER,
 }
 
 

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -42,19 +42,41 @@ class CausalResult:
         if not db_path.is_file():
             raise ValueError(f"causal selection for {label!r} resolved to 0 identities")
         with sqlite3.connect(db_path) as db:
+            # Same reason `open` below probes rather than naming the column: this read
+            # does not go through the migrating opener, and a registry written before
+            # supersedes_hash existed would raise OperationalError instead of
+            # resolving the single identity it does hold.
+            columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
+            supersedes_column = (
+                "supersedes_hash" if "supersedes_hash" in columns else "NULL AS supersedes_hash"
+            )
             rows = db.execute(
-                "SELECT causal_hash, spec_json FROM causal_runs WHERE label = ? ORDER BY causal_hash",
+                f"SELECT causal_hash, spec_json, {supersedes_column} FROM causal_runs "
+                "WHERE label = ? ORDER BY causal_hash",
                 (label,),
             ).fetchall()
+        # A refit produces a second canonical identity for the same label. Which one is
+        # live is declared, not inferred: `created_at` ties on a fast refit, and a
+        # recency rule would be the only one in a registry that is otherwise entirely
+        # spec-addressed. A row another row names as superseded is retired.
+        retired = {row[2] for row in rows if row[2]}
         current = [
             causal_hash
-            for causal_hash, spec_json in rows
+            for causal_hash, spec_json, _ in rows
             if json.loads(spec_json or "{}").get("identity_version") == IDENTITY_VERSION
             and json.loads(spec_json or "{}").get("execution_tier", tier.value) == tier.value
+            and causal_hash not in retired
         ]
         if len(current) != 1:
+            hint = ""
+            if len(current) > 1:
+                hint = (
+                    f" ({', '.join(current)}). A refit left more than one live, and none of "
+                    "them says which it retires - re-register the newer with SUPERSEDES_CAUSAL "
+                    "naming the older."
+                )
             raise ValueError(
-                f"causal selection for {label!r} resolved to {len(current)} identities"
+                f"causal selection for {label!r} resolved to {len(current)} identities{hint}"
             )
         return cls.open(
             study,

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -11,6 +11,7 @@ from case_studies.utils.registry.specs import (
     SUPPORTED_IDENTITY_VERSIONS,
     training_hash_from_spec,
 )
+from case_studies.utils.registry.store import current_causal_identities
 
 from .adapters import get_adapter, registered_adapters
 from .contracts import ExecutionTier
@@ -42,31 +43,12 @@ class CausalResult:
         if not db_path.is_file():
             raise ValueError(f"causal selection for {label!r} resolved to 0 identities")
         with sqlite3.connect(db_path) as db:
-            # Same reason `open` below probes rather than naming the column: this read
-            # does not go through the migrating opener, and a registry written before
-            # supersedes_hash existed would raise OperationalError instead of
-            # resolving the single identity it does hold.
-            columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
-            supersedes_column = (
-                "supersedes_hash" if "supersedes_hash" in columns else "NULL AS supersedes_hash"
-            )
-            rows = db.execute(
-                f"SELECT causal_hash, spec_json, {supersedes_column} FROM causal_runs "
-                "WHERE label = ? ORDER BY causal_hash",
-                (label,),
-            ).fetchall()
-        # A refit produces a second canonical identity for the same label. Which one is
-        # live is declared, not inferred: `created_at` ties on a fast refit, and a
-        # recency rule would be the only one in a registry that is otherwise entirely
-        # spec-addressed. A row another row names as superseded is retired.
-        retired = {row[2] for row in rows if row[2]}
-        current = [
-            causal_hash
-            for causal_hash, spec_json, _ in rows
-            if json.loads(spec_json or "{}").get("identity_version") == IDENTITY_VERSION
-            and json.loads(spec_json or "{}").get("execution_tier", tier.value) == tier.value
-            and causal_hash not in retired
-        ]
+            # One derivation, shared with register_causal_run's write-time check. Two
+            # copies of this disagreed within an hour of being written, and the shape
+            # of that disagreement is a refusal to register for an ambiguity the
+            # reader never sees. It also probes for supersedes_hash rather than naming
+            # it, because this read does not go through the migrating opener.
+            current = current_causal_identities(db, label=label, tier=tier.value)
         if len(current) != 1:
             hint = ""
             if len(current) > 1:
@@ -179,6 +161,11 @@ class ResolvedCausalRequest:
     method: str
     spec: dict[str, Any]
     _context: Any
+    # Alongside the spec and deliberately not in it: the identity is what was fitted,
+    # and which earlier identity this run retires is a statement about the registry.
+    # Putting it in the spec would change the hash of every run that declares one, so
+    # a refit would supersede a row and then not be the row it claimed to be.
+    supersedes: str | None = None
 
     @property
     def identity(self) -> str:
@@ -189,7 +176,7 @@ class ResolvedCausalRequest:
         runner = getattr(module, "run_resolved_causal_request", None)
         if runner is None:
             raise NotImplementedError(f"{self.method!r} has no shared causal runner")
-        result = runner(self.study, self.spec, self._context)
+        result = runner(self.study, self.spec, self._context, supersedes=self.supersedes)
         if not isinstance(result, CausalResult):
             raise TypeError(
                 f"{self.method!r} runner returned {type(result).__name__}, not CausalResult"
@@ -206,6 +193,7 @@ class CausalRequest:
     overrides: dict[str, Any]
     execution_tier: ExecutionTier
     preview_reductions: dict[str, Any]
+    supersedes: str | None = None
 
     @classmethod
     def from_request(cls, study: Study, request: dict[str, Any]) -> CausalRequest:
@@ -216,6 +204,7 @@ class CausalRequest:
             "overrides",
             "execution_tier",
             "preview_reductions",
+            "supersedes",
         }
         unknown = set(request) - supported
         if unknown:
@@ -241,6 +230,7 @@ class CausalRequest:
             overrides=dict(request.get("overrides") or {}),
             execution_tier=tier,
             preview_reductions=reductions,
+            supersedes=(str(request["supersedes"]) if request.get("supersedes") else None),
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -252,6 +242,8 @@ class CausalRequest:
             "execution_tier": self.execution_tier.value,
             "preview_reductions": dict(self.preview_reductions),
         }
+        # `supersedes` is absent on purpose: this dict is what the resolver turns into
+        # the spec, and the spec is hashed.
 
     def resolve(self) -> ResolvedCausalRequest:
         module = get_adapter("causal", self.method)
@@ -265,7 +257,7 @@ class CausalRequest:
             raise ValueError("causal resolver did not produce the resolved-spec schema")
         if spec.get("execution_tier") != self.execution_tier.value:
             raise ValueError("causal resolver changed the execution tier")
-        return ResolvedCausalRequest(self.study, self.method, spec, context)
+        return ResolvedCausalRequest(self.study, self.method, spec, context, self.supersedes)
 
     def run(self) -> CausalResult:
         return self.resolve().run()

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1466,6 +1466,7 @@ def register_causal_run(
     case_dir=None,
     started_at: str | None = None,
     elapsed_s: float | None = None,
+    supersedes_hash: str | None = None,
 ) -> str:
     """Register a causal DML run in the dedicated `causal_runs` table.
 
@@ -1550,6 +1551,11 @@ def register_causal_run(
         notebook=notebook,
         started_at=started_at or results.get("started_at"),
         elapsed_s=elapsed_s if elapsed_s is not None else results.get("elapsed_s"),
+        # The causal identity this run retires. A refit produces a second canonical
+        # identity for the same label and `CausalResult.one` resolves a label to exactly
+        # one, so the chain is declared here rather than guessed from `created_at`.
+        # Notebooks pass their SUPERSEDES_CAUSAL parameter through.
+        supersedes_hash=supersedes_hash,
         case_dir=case_dir,
     )
 

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1359,6 +1359,8 @@ def run_resolved_causal_request(
     study: Study,
     spec: dict[str, Any],
     context: DMLResearchContext,
+    *,
+    supersedes: str | None = None,
 ):
     import math
 
@@ -1413,6 +1415,11 @@ def run_resolved_causal_request(
     register_record(
         study.case_study,
         causal_hash,
+        # The identity this run retires, from the notebook's SUPERSEDES_CAUSAL. A refit
+        # under a changed version of this file produces a second canonical identity for
+        # the same label, and a reader resolves a label to exactly one; register_record
+        # refuses the second without a declaration.
+        supersedes_hash=supersedes,
         label=context.outcome_col,
         treatment=context.treatment_col,
         confounders_json=json.dumps(list(context.confounder_cols)),

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1365,6 +1365,9 @@ def run_resolved_causal_request(
     import math
 
     from case_studies.research.causal import CausalResult
+    from case_studies.utils.registry.registration import (
+        declare_causal_supersedes,
+    )
     from case_studies.utils.registry.registration import register_causal_run as register_record
     from case_studies.utils.registry.specs import canonical_json, training_hash_from_spec
 
@@ -1380,6 +1383,23 @@ def run_resolved_causal_request(
     if cached is not None:
         if training_hash_from_spec(cached.spec) != causal_hash or not cached.complete:
             raise ValueError(f"causal cache is incomplete or conflicts with {causal_hash}")
+        if supersedes is not None:
+            # The declaration has to land even when the fit does not re-run, because
+            # that is the shape of the repair. A registry already holding two
+            # undeclared identities tells the author to re-register the newer one
+            # naming the older; doing so reproduces the same causal_hash, so the cache
+            # answers and the fit is skipped. Returning here without writing would drop
+            # the declaration silently and leave the label unresolvable, with the
+            # notebook reporting success. register_causal_run fills the column
+            # once and validates what it is given.
+            declare_causal_supersedes(
+                study.case_study,
+                causal_hash,
+                supersedes_hash=supersedes,
+                label=context.outcome_col,
+                tier=str(spec["execution_tier"]),
+                case_dir=study.storage_root(spec["execution_tier"]),
+            )
         return cached
 
     nuisance_y = HistGradientBoostingRegressor(**context.nuisance_params)

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -652,6 +652,36 @@ def _placebo_moved_mask(original: np.ndarray, permuted: np.ndarray) -> np.ndarra
     return moved
 
 
+# Below this many successful placebo draws the permutation test is not computed at all:
+# the plus-one correction floors the empirical p at 1/(n+1), so under ten draws no data
+# could produce a pass and a number would be reported that no test earned. When it is not
+# computed, `refutation` stays empty and `refutation_p` is registered NULL - a missing
+# measurement, which is what it is.
+MIN_PLACEBO_DRAWS = 10
+
+
+def placebo_request_is_on_the_boundary(n_placebo: int) -> bool:
+    """Would one failed draw take the whole refutation with it?
+
+    This is not enforced at run time, and the attempt to do so is worth recording. Nine
+    tests in tests/test_causal_adapter.py request two to six draws on purpose, to
+    exercise the block-span and permutation-feasibility logic without paying for a
+    refutation they never read; refusing every small request turned all nine red for a
+    property they are not about. The boundary is a property of a *declared reduction* -
+    a config that says how a real run should be made cheap - not of every call.
+
+    Zero means "do not refute", which is a different statement from "refute with too
+    few draws to say anything".
+    """
+    return 0 < n_placebo < MIN_PLACEBO_DRAWS + PLACEBO_REQUEST_MARGIN
+
+
+# Enough that one draw failing does not take the whole test with it. Small on purpose:
+# a placebo draw is a full nuisance refit, so this is the least that makes the boundary
+# unreachable by a single failure rather than a comfortable cushion.
+PLACEBO_REQUEST_MARGIN = 5
+
+
 def _assert_placebo_permutation_possible(
     unchanged_draws: int, n_draws: int, block_size: int, short_segment_fraction: float = 0.0
 ) -> None:
@@ -952,7 +982,7 @@ def run_dml_analysis(
         )
 
         refutation = {}
-        if len(placebo_effects) >= 10:
+        if len(placebo_effects) >= MIN_PLACEBO_DRAWS:
             placebo_arr = np.array(placebo_effects)
             p_mean = np.mean(placebo_arr)
             p_std = np.std(placebo_arr)

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1747,6 +1747,7 @@ def declare_causal_supersedes(
             label=label,
             tier=tier,
             supersedes_hash=supersedes_hash,
+            is_repair=True,
         )
         db.execute(
             "UPDATE causal_runs SET supersedes_hash = ? WHERE causal_hash = ?",
@@ -1758,7 +1759,13 @@ def declare_causal_supersedes(
 
 
 def _enforce_causal_supersedes(
-    db, *, causal_hash: str, label: str, tier: str, supersedes_hash: str | None
+    db,
+    *,
+    causal_hash: str,
+    label: str,
+    tier: str,
+    supersedes_hash: str | None,
+    is_repair: bool = False,
 ) -> None:
     """A second canonical identity for a label must say which one it retires.
 
@@ -1771,6 +1778,14 @@ def _enforce_causal_supersedes(
     Refusing here rather than at read time is what makes it fixable. The read happens
     in a downstream notebook, hours later, with no idea which run introduced the
     ambiguity.
+
+    ``is_repair`` is what lets an already-broken registry be fixed. A new fit must
+    leave exactly one identity current, because that is the state it is responsible
+    for. Chaining rows that already exist cannot: with three stranded identities,
+    every single declaration leaves two current, so requiring one at every step
+    deadlocks - the middle row is refused because the newest is live and the newest is
+    refused because the middle is. A repair step is allowed to reduce the count
+    without finishing the job, and the reader's error still names what is left.
     """
     stored = (
         db.execute(
@@ -1808,17 +1823,18 @@ def _enforce_causal_supersedes(
                 f"not a current {tier} identity for {label!r}. Current: {others or 'none'}"
             )
         remaining = [other for other in others if other != supersedes_hash]
-        if remaining:
+        if remaining and not is_repair:
             # One column holds one edge, so a single declaration retires a single row.
-            # Accepting it while others stay live would let the write succeed and leave
-            # the label exactly as unresolvable as before, with nothing saying so - the
-            # failure moves back to the downstream notebook, which is what declaring
-            # the chain at the write is here to prevent.
+            # A *new* identity that retires one of several would let the write succeed
+            # and leave the label exactly as unresolvable as before, with nothing
+            # saying so - the failure moves back to the downstream notebook, which is
+            # what declaring the chain at the write is here to prevent. Repair first,
+            # then fit.
             raise ValueError(
                 f"causal run {causal_hash} retires {supersedes_hash}, but {remaining} would "
                 f"still be current for {label!r}, so a reader still resolves to "
-                f"{len(remaining) + 1}. Chain those first: each identity declares the one "
-                "before it, oldest to newest."
+                f"{len(remaining) + 1}. Chain the rows that already exist first: each "
+                "declares the one before it, oldest to newest."
             )
         return
     if others:
@@ -1884,6 +1900,13 @@ def register_causal_run(
             label=label,
             tier=str(spec.get("execution_tier", "canonical")),
             supersedes_hash=supersedes_hash,
+            # A row that already exists is not a new fit, so this call is a step in
+            # chaining what is already there rather than the write that must leave the
+            # label resolvable.
+            is_repair=db.execute(
+                "SELECT 1 FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+            ).fetchone()
+            is not None,
         )
         comparable_columns = (
             "label",

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1707,6 +1707,56 @@ def register_cohort_metrics(
 # ---------------------------------------------------------------------------
 
 
+def declare_causal_supersedes(
+    case_study: str,
+    causal_hash: str,
+    *,
+    supersedes_hash: str,
+    label: str,
+    tier: str = "canonical",
+    case_dir: Path | None = None,
+) -> None:
+    """Record which identity *causal_hash* retires, without re-running the fit.
+
+    The repair path needs this. A registry holding two undeclared identities is fixed
+    by re-registering the newer one naming the older, and re-registering reproduces the
+    same hash - so the fit is served from cache and never reaches the write. Fill-once,
+    and validated the same way the registering path is: a predecessor that is not
+    itself current is refused rather than recorded.
+    """
+    if case_dir is None:
+        case_dir = _case_dir(case_study)
+    db = _open_registry(case_dir)
+    try:
+        stored = (
+            db.execute(
+                "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+            ).fetchone()
+            or (None,)
+        )[0]
+        if stored is not None:
+            if stored != supersedes_hash:
+                raise ValueError(
+                    f"causal run {causal_hash} already declares it supersedes {stored}; "
+                    f"it cannot also supersede {supersedes_hash}"
+                )
+            return
+        _enforce_causal_supersedes(
+            db,
+            causal_hash=causal_hash,
+            label=label,
+            tier=tier,
+            supersedes_hash=supersedes_hash,
+        )
+        db.execute(
+            "UPDATE causal_runs SET supersedes_hash = ? WHERE causal_hash = ?",
+            (supersedes_hash, causal_hash),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
 def _enforce_causal_supersedes(
     db, *, causal_hash: str, label: str, tier: str, supersedes_hash: str | None
 ) -> None:
@@ -1723,6 +1773,23 @@ def _enforce_causal_supersedes(
     ambiguity.
     """
     if causal_hash in causal_identities_retired(db, label=label):
+        # Reproducing a retired identity is a no-op, but the declaration it carries is
+        # not exempt from being checked. An author reproducing A from an older checkout
+        # with SUPERSEDES_CAUSAL still pointing at B - the run that retired A - would
+        # otherwise make both rows retired, and the reader would resolve to zero with
+        # no hint at all. Worse than the two-identity state this exists to prevent.
+        stored = (
+            db.execute(
+                "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+            ).fetchone()
+            or (None,)
+        )[0]
+        if supersedes_hash is not None and supersedes_hash != stored:
+            raise ValueError(
+                f"causal run {causal_hash} is already retired by a later identity, and "
+                f"declaring that it supersedes {supersedes_hash} would retire that one too. "
+                f"It carries {stored or 'no declaration'}; re-register without SUPERSEDES_CAUSAL."
+            )
         # Re-registering a row some later run already retired changes nothing about
         # what a reader resolves - reproducing a published number from an older
         # checkout does exactly this. Refusing it would also hand the author the

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1705,6 +1705,74 @@ def register_cohort_metrics(
 # ---------------------------------------------------------------------------
 
 
+def current_causal_identities(
+    db, *, label: str, tier: str = "canonical", exclude: str | None = None
+) -> list[str]:
+    """The causal identities a reader would currently resolve for *label*.
+
+    A row is current when its spec carries a supported ``identity_version``, its
+    ``execution_tier`` is the one asked for, and no other row declares that it
+    supersedes it. That is the same set ``CausalResult.one`` counts, and keeping the
+    two derivations in one function is the point: they disagreed once already, which
+    is how a refit came to fail at read time in a different notebook from the one
+    that caused it.
+    """
+    columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
+    supersedes_column = (
+        "supersedes_hash" if "supersedes_hash" in columns else "NULL AS supersedes_hash"
+    )
+    rows = db.execute(
+        f"SELECT causal_hash, spec_json, {supersedes_column} FROM causal_runs "
+        "WHERE label = ? ORDER BY causal_hash",
+        (label,),
+    ).fetchall()
+    retired = {row[2] for row in rows if row[2]}
+    current = []
+    for causal_hash, spec_json, _ in rows:
+        spec = json.loads(spec_json or "{}")
+        if spec.get("identity_version") not in SUPPORTED_IDENTITY_VERSIONS:
+            continue
+        if str(spec.get("execution_tier", tier)) != tier:
+            continue
+        if causal_hash in retired or causal_hash == exclude:
+            continue
+        current.append(causal_hash)
+    return current
+
+
+def _enforce_causal_supersedes(
+    db, *, causal_hash: str, label: str, tier: str, supersedes_hash: str | None
+) -> None:
+    """A second canonical identity for a label must say which one it retires.
+
+    Without the declaration the registry ends up holding two rows a reader cannot
+    choose between, and ``CausalResult.one`` refuses forever. Recency is not the
+    fallback: ``created_at`` ties on a fast refit, and a recency rule would be the
+    only one in a registry that is otherwise entirely spec-addressed. So the chain is
+    declared by a person, the way a changed population is.
+
+    Refusing here rather than at read time is what makes it fixable. The read happens
+    in a downstream notebook, hours later, with no idea which run introduced the
+    ambiguity.
+    """
+    others = current_causal_identities(db, label=label, tier=tier, exclude=causal_hash)
+    if supersedes_hash is not None:
+        if supersedes_hash == causal_hash:
+            raise ValueError(f"causal run {causal_hash} cannot supersede itself")
+        if supersedes_hash not in others:
+            raise ValueError(
+                f"causal run {causal_hash} declares it supersedes {supersedes_hash}, which is "
+                f"not a current {tier} identity for {label!r}. Current: {others or 'none'}"
+            )
+        return
+    if others:
+        raise ValueError(
+            f"registering {causal_hash} would leave {len(others) + 1} current {tier} causal "
+            f"identities for {label!r}, and a reader resolves a label to exactly one. Name the "
+            f"one this run retires: set SUPERSEDES_CAUSAL to {others[0] if len(others) == 1 else others}"
+        )
+
+
 def register_causal_run(
     case_study: str,
     causal_hash: str,
@@ -1726,6 +1794,7 @@ def register_causal_run(
     notebook: str | None,
     started_at: str | None,
     elapsed_s: float | None,
+    supersedes_hash: str | None = None,
     case_dir: Path | None = None,
 ) -> None:
     """Persist one causal-DML run to ``causal_runs``.
@@ -1734,15 +1803,31 @@ def register_causal_run(
     completeness contract (``ic_mean`` non-null, etc.) does not apply to
     treatment-effect estimates. Callers compute the spec and result fields
     upstream; this function owns the SQL row write.
+
+    ``supersedes_hash`` names the canonical identity this run retires, and a second
+    canonical identity for a label is refused without one. That refusal is the point:
+    ``CausalResult.one`` requires exactly one current identity per label, so an
+    undeclared refit leaves the registry in a state no reader can resolve, and it does
+    so silently at write time and loudly at read time in a different notebook. Mirrors
+    ``official_populations``, where a changed population under an existing name must
+    name the hash it supersedes.
     """
     if case_dir is None:
         case_dir = _case_dir(case_study)
     import json
 
-    version = (json.loads(spec_json) or {}).get("identity_version")
+    spec = json.loads(spec_json) or {}
+    version = spec.get("identity_version")
     immutable = version in SUPPORTED_IDENTITY_VERSIONS
     db = _open_registry(case_dir)
     try:
+        _enforce_causal_supersedes(
+            db,
+            causal_hash=causal_hash,
+            label=label,
+            tier=str(spec.get("execution_tier", "canonical")),
+            supersedes_hash=supersedes_hash,
+        )
         comparable_columns = (
             "label",
             "treatment",
@@ -1764,6 +1849,12 @@ def register_causal_run(
             f"SELECT {', '.join(comparable_columns)} FROM causal_runs WHERE causal_hash = ?",
             (causal_hash,),
         ).fetchone()
+        existing_supersedes = (
+            db.execute(
+                "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+            ).fetchone()
+            or (None,)
+        )[0]
         expected = (
             label,
             treatment,
@@ -1821,6 +1912,12 @@ def register_causal_run(
                     f"immutable causal result conflict for {causal_hash}: "
                     f"{', '.join(conflicting)} would change"
                 )
+            if supersedes_hash is not None and existing_supersedes is None:
+                db.execute(
+                    "UPDATE causal_runs SET supersedes_hash = ? WHERE causal_hash = ?",
+                    (supersedes_hash, causal_hash),
+                )
+                db.commit()
             if not backfilled:
                 return
         # ON CONFLICT DO UPDATE rather than INSERT OR REPLACE — consistent with
@@ -1833,8 +1930,9 @@ def register_causal_run(
                 n_folds, n_obs, dml_effect, dml_se_hac, p_value_hac,
                 naive_effect, confounding_bias_pct, refutation_p,
                 refutation_n_successful,
-                spec_json, notebook, started_at, elapsed_s, git_commit, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                spec_json, notebook, started_at, elapsed_s, git_commit,
+                supersedes_hash, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(causal_hash) DO UPDATE SET
                 label=excluded.label,
                 treatment=excluded.treatment,
@@ -1853,7 +1951,8 @@ def register_causal_run(
                 notebook=excluded.notebook,
                 started_at=excluded.started_at,
                 elapsed_s=excluded.elapsed_s,
-                git_commit=excluded.git_commit
+                git_commit=excluded.git_commit,
+                supersedes_hash=excluded.supersedes_hash
             WHERE causal_runs.label IS NOT excluded.label
                OR causal_runs.treatment IS NOT excluded.treatment
                OR causal_runs.confounders_json IS NOT excluded.confounders_json
@@ -1869,6 +1968,7 @@ def register_causal_run(
                OR causal_runs.refutation_n_successful IS NOT excluded.refutation_n_successful
                OR causal_runs.spec_json IS NOT excluded.spec_json
                OR causal_runs.notebook IS NOT excluded.notebook
+               OR causal_runs.supersedes_hash IS NOT excluded.supersedes_hash
             """,
             (
                 causal_hash,
@@ -1890,6 +1990,7 @@ def register_causal_run(
                 started_at,
                 elapsed_s,
                 _git_hash(),
+                supersedes_hash,
                 _utc_now(),
             ),
         )

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1764,37 +1764,39 @@ def _enforce_causal_supersedes(
 
     Without the declaration the registry ends up holding two rows a reader cannot
     choose between, and ``CausalResult.one`` refuses forever. Recency is not the
-    fallback: ``created_at`` ties on a fast refit, and a recency rule would be the
-    only one in a registry that is otherwise entirely spec-addressed. So the chain is
+    fallback: ``created_at`` ties on a fast refit, and it would be the only recency
+    rule in a registry that is otherwise entirely spec-addressed. So the chain is
     declared by a person, the way a changed population is.
 
     Refusing here rather than at read time is what makes it fixable. The read happens
     in a downstream notebook, hours later, with no idea which run introduced the
     ambiguity.
     """
+    stored = (
+        db.execute(
+            "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+        ).fetchone()
+        or (None,)
+    )[0]
+    if supersedes_hash is not None and stored == supersedes_hash:
+        # Re-registering a row that already carries this exact declaration changes
+        # nothing, and it has to be allowed or a wired notebook is not idempotent on
+        # its second run. The check below would reject it: the predecessor is retired
+        # by this row's own edge, so it is no longer in the current set and reads as
+        # "not a current identity ... Current: none".
+        return
     if causal_hash in causal_identities_retired(db, label=label):
         # Reproducing a retired identity is a no-op, but the declaration it carries is
         # not exempt from being checked. An author reproducing A from an older checkout
         # with SUPERSEDES_CAUSAL still pointing at B - the run that retired A - would
         # otherwise make both rows retired, and the reader would resolve to zero with
         # no hint at all. Worse than the two-identity state this exists to prevent.
-        stored = (
-            db.execute(
-                "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
-            ).fetchone()
-            or (None,)
-        )[0]
         if supersedes_hash is not None and supersedes_hash != stored:
             raise ValueError(
                 f"causal run {causal_hash} is already retired by a later identity, and "
                 f"declaring that it supersedes {supersedes_hash} would retire that one too. "
                 f"It carries {stored or 'no declaration'}; re-register without SUPERSEDES_CAUSAL."
             )
-        # Re-registering a row some later run already retired changes nothing about
-        # what a reader resolves - reproducing a published number from an older
-        # checkout does exactly this. Refusing it would also hand the author the
-        # wrong instruction: the only current identity is the tip, and superseding
-        # that would invert the chain and retire the newer result.
         return
     others = current_causal_identities(db, label=label, tier=tier, exclude=causal_hash)
     if supersedes_hash is not None:
@@ -1805,12 +1807,26 @@ def _enforce_causal_supersedes(
                 f"causal run {causal_hash} declares it supersedes {supersedes_hash}, which is "
                 f"not a current {tier} identity for {label!r}. Current: {others or 'none'}"
             )
+        remaining = [other for other in others if other != supersedes_hash]
+        if remaining:
+            # One column holds one edge, so a single declaration retires a single row.
+            # Accepting it while others stay live would let the write succeed and leave
+            # the label exactly as unresolvable as before, with nothing saying so - the
+            # failure moves back to the downstream notebook, which is what declaring
+            # the chain at the write is here to prevent.
+            raise ValueError(
+                f"causal run {causal_hash} retires {supersedes_hash}, but {remaining} would "
+                f"still be current for {label!r}, so a reader still resolves to "
+                f"{len(remaining) + 1}. Chain those first: each identity declares the one "
+                "before it, oldest to newest."
+            )
         return
     if others:
         raise ValueError(
             f"registering {causal_hash} would leave {len(others) + 1} current {tier} causal "
             f"identities for {label!r}, and a reader resolves a label to exactly one. Name the "
-            f"one this run retires: set SUPERSEDES_CAUSAL to {others[0] if len(others) == 1 else others}"
+            f"one this run retires: set SUPERSEDES_CAUSAL to "
+            f"{others[0] if len(others) == 1 else others}"
         )
 
 

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -33,6 +33,8 @@ from .store import (
     _training_dir,
     _upsert_wide_metrics,
     _utc_now,
+    causal_identities_retired,
+    current_causal_identities,
 )
 
 logger = logging.getLogger(__name__)
@@ -1705,41 +1707,6 @@ def register_cohort_metrics(
 # ---------------------------------------------------------------------------
 
 
-def current_causal_identities(
-    db, *, label: str, tier: str = "canonical", exclude: str | None = None
-) -> list[str]:
-    """The causal identities a reader would currently resolve for *label*.
-
-    A row is current when its spec carries a supported ``identity_version``, its
-    ``execution_tier`` is the one asked for, and no other row declares that it
-    supersedes it. That is the same set ``CausalResult.one`` counts, and keeping the
-    two derivations in one function is the point: they disagreed once already, which
-    is how a refit came to fail at read time in a different notebook from the one
-    that caused it.
-    """
-    columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
-    supersedes_column = (
-        "supersedes_hash" if "supersedes_hash" in columns else "NULL AS supersedes_hash"
-    )
-    rows = db.execute(
-        f"SELECT causal_hash, spec_json, {supersedes_column} FROM causal_runs "
-        "WHERE label = ? ORDER BY causal_hash",
-        (label,),
-    ).fetchall()
-    retired = {row[2] for row in rows if row[2]}
-    current = []
-    for causal_hash, spec_json, _ in rows:
-        spec = json.loads(spec_json or "{}")
-        if spec.get("identity_version") not in SUPPORTED_IDENTITY_VERSIONS:
-            continue
-        if str(spec.get("execution_tier", tier)) != tier:
-            continue
-        if causal_hash in retired or causal_hash == exclude:
-            continue
-        current.append(causal_hash)
-    return current
-
-
 def _enforce_causal_supersedes(
     db, *, causal_hash: str, label: str, tier: str, supersedes_hash: str | None
 ) -> None:
@@ -1755,6 +1722,13 @@ def _enforce_causal_supersedes(
     in a downstream notebook, hours later, with no idea which run introduced the
     ambiguity.
     """
+    if causal_hash in causal_identities_retired(db, label=label):
+        # Re-registering a row some later run already retired changes nothing about
+        # what a reader resolves - reproducing a published number from an older
+        # checkout does exactly this. Refusing it would also hand the author the
+        # wrong instruction: the only current identity is the tip, and superseding
+        # that would invert the chain and retire the newer result.
+        return
     others = current_causal_identities(db, label=label, tier=tier, exclude=causal_hash)
     if supersedes_hash is not None:
         if supersedes_hash == causal_hash:
@@ -1952,7 +1926,12 @@ def register_causal_run(
                 started_at=excluded.started_at,
                 elapsed_s=excluded.elapsed_s,
                 git_commit=excluded.git_commit,
-                supersedes_hash=excluded.supersedes_hash
+                -- Fill-once, matching the UPDATE above. A re-registration that
+                -- passes no declaration must not clobber one that was made: the row
+                -- it retired would go live again and the reader would see two.
+                -- Reachable through the migration backfill path, which skips the
+                -- early return.
+                supersedes_hash=COALESCE(excluded.supersedes_hash, causal_runs.supersedes_hash)
             WHERE causal_runs.label IS NOT excluded.label
                OR causal_runs.treatment IS NOT excluded.treatment
                OR causal_runs.confounders_json IS NOT excluded.confounders_json
@@ -1968,7 +1947,8 @@ def register_causal_run(
                OR causal_runs.refutation_n_successful IS NOT excluded.refutation_n_successful
                OR causal_runs.spec_json IS NOT excluded.spec_json
                OR causal_runs.notebook IS NOT excluded.notebook
-               OR causal_runs.supersedes_hash IS NOT excluded.supersedes_hash
+               OR (excluded.supersedes_hash IS NOT NULL
+                   AND causal_runs.supersedes_hash IS NOT excluded.supersedes_hash)
             """,
             (
                 causal_hash,

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -11,7 +11,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .specs import _validate_spec, canonical_json, training_hash_from_spec
+from .specs import (
+    IDENTITY_VERSION,
+    _validate_spec,
+    canonical_json,
+    training_hash_from_spec,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -584,6 +589,61 @@ def _declare_uncertainty_columns(db: sqlite3.Connection) -> None:
 def _table_has_column(db: sqlite3.Connection, table: str, column: str) -> bool:
     """Check if a table has a specific column."""
     return column in {row[1] for row in db.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def current_causal_identities(
+    db, *, label: str, tier: str = "canonical", exclude: str | None = None
+) -> list[str]:
+    """The causal identities a reader would currently resolve for *label*.
+
+    A row is current when its spec carries the current ``identity_version``, its
+    ``execution_tier`` is the one asked for, and no other row declares that it
+    supersedes it.
+
+    This lives here, and not beside either caller, because it has to be one derivation.
+    ``CausalResult.one`` decides what a reader resolves and ``register_causal_run``
+    decides what may be written; if those two sets differ, a registration is refused
+    for an ambiguity the reader never sees, or permitted into one it cannot resolve.
+    The first draft duplicated the logic and the copies disagreed within the hour -
+    one counted every SUPPORTED_IDENTITY_VERSION, the other only the current one, so a
+    legacy row made the first v3 registration for its label impossible to satisfy.
+    The reader's rule is the authority, because it is the one a person hits.
+    """
+    columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
+    supersedes_column = (
+        "supersedes_hash" if "supersedes_hash" in columns else "NULL AS supersedes_hash"
+    )
+    rows = db.execute(
+        f"SELECT causal_hash, spec_json, {supersedes_column} FROM causal_runs "
+        "WHERE label = ? ORDER BY causal_hash",
+        (label,),
+    ).fetchall()
+    retired = {row[2] for row in rows if row[2]}
+    current = []
+    for causal_hash, spec_json, _ in rows:
+        spec = json.loads(spec_json or "{}")
+        if spec.get("identity_version") != IDENTITY_VERSION:
+            continue
+        if str(spec.get("execution_tier", tier)) != tier:
+            continue
+        if causal_hash in retired or causal_hash == exclude:
+            continue
+        current.append(causal_hash)
+    return current
+
+
+def causal_identities_retired(db, *, label: str) -> set[str]:
+    """Every causal hash some other row declares it supersedes."""
+    columns = {row[1] for row in db.execute("PRAGMA table_info(causal_runs)").fetchall()}
+    if "supersedes_hash" not in columns:
+        return set()
+    return {
+        row[0]
+        for row in db.execute(
+            "SELECT supersedes_hash FROM causal_runs WHERE label = ? AND supersedes_hash IS NOT NULL",
+            (label,),
+        ).fetchall()
+    }
 
 
 def _migrate_registry(db: sqlite3.Connection) -> None:

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -154,6 +154,13 @@ CREATE TABLE IF NOT EXISTS causal_runs (
     started_at       TEXT,
     elapsed_s        REAL,
     git_commit       TEXT,
+    -- The causal identity this run retires, mirroring official_populations. A causal
+    -- refit produces a second canonical identity for the same label, and without a
+    -- declared chain CausalResult.one sees two and refuses forever - there is no
+    -- recency rule to fall back on, and there should not be one in a registry that is
+    -- otherwise entirely spec-addressed. Declared by a person through the notebook's
+    -- SUPERSEDES_CAUSAL parameter, never inferred from created_at.
+    supersedes_hash  TEXT REFERENCES causal_runs(causal_hash),
     created_at       TEXT NOT NULL
 );
 
@@ -659,6 +666,12 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
         db, "causal_runs", "refutation_n_successful"
     ):
         db.execute("ALTER TABLE causal_runs ADD COLUMN refutation_n_successful INTEGER")
+
+    # Additive, and it costs no recompute: _causal_source_identity hashes
+    # case_studies/utils/causal.py and nothing else, so a column outside the spec
+    # moves no causal_hash and invalidates no registered row.
+    if "causal_runs" in tables and not _table_has_column(db, "causal_runs", "supersedes_hash"):
+        db.execute("ALTER TABLE causal_runs ADD COLUMN supersedes_hash TEXT")
 
     # Migration 3: tall → wide metric tables
     if "prediction_metrics" in tables:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1448,7 +1448,7 @@ case_studies/etfs/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 3000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 5
+    N_PLACEBO: 15
   timeout: 120
 case_studies/etfs/13_model_analysis:
   timeout: 300
@@ -1521,7 +1521,7 @@ case_studies/fx_pairs/11_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 10
+    N_PLACEBO: 15
   timeout: 120
 case_studies/fx_pairs/12_model_analysis:
   timeout: 300
@@ -1624,7 +1624,7 @@ case_studies/nasdaq100_microstructure/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 900
     MAX_SYMBOLS: 5
-    N_PLACEBO: 10
+    N_PLACEBO: 15
   timeout: 120
 case_studies/nasdaq100_microstructure/13_model_analysis:
   timeout: 300
@@ -1754,7 +1754,7 @@ case_studies/sp500_equity_option_analytics/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 3000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 5
+    N_PLACEBO: 15
   timeout: 120
 case_studies/sp500_equity_option_analytics/13_model_analysis:
   timeout: 300
@@ -1849,7 +1849,7 @@ case_studies/sp500_options/10_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 10
+    N_PLACEBO: 15
   timeout: 120
 case_studies/sp500_options/11_model_analysis:
   timeout: 300
@@ -2026,7 +2026,7 @@ case_studies/us_equities_panel/14_causal_dml:
     MAX_SYMBOLS: 5
     PREVIEW_N_FOLDS: 2
     PREVIEW_MAX_SAMPLES: 5000
-    PREVIEW_N_PLACEBO: 10
+    PREVIEW_N_PLACEBO: 15
   timeout: 120
 case_studies/us_equities_panel/15_model_analysis:
   # 15 declares EXECUTION_TIER and WORKSPACE, so research_preview_parameters routes it to the
@@ -2176,7 +2176,7 @@ case_studies/us_firm_characteristics/09_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 10
+    N_PLACEBO: 15
   timeout: 120
 case_studies/us_firm_characteristics/10_model_analysis:
   timeout: 300

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1236,7 +1236,7 @@ case_studies/cme_futures/11_causal_dml:
       max_samples: 5000
       max_symbols: 5
       n_folds: 2
-      n_placebo: 10
+      n_placebo: 15
   timeout: 300
 case_studies/cme_futures/12_model_analysis:
   timeout: 300
@@ -1324,7 +1324,7 @@ case_studies/crypto_perps_funding/11_causal_dml:
       max_samples: 5000
       max_symbols: 5
       n_folds: 2
-      n_placebo: 10
+      n_placebo: 15
   timeout: 300
 case_studies/crypto_perps_funding/12_model_analysis:
   timeout: 300

--- a/tests/test_causal_refutation_pvalue.py
+++ b/tests/test_causal_refutation_pvalue.py
@@ -10,6 +10,8 @@ the observed effect published `p = 0.000`.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -128,3 +130,59 @@ class TestUnderpoweredRefutation:
     def test_a_caller_without_the_draw_count_keeps_the_two_way_answer(self) -> None:
         assert classify_refutation(0.01) == "Passes"
         assert classify_refutation(0.9) == "Fails"
+
+
+# ---------------------------------------------------------------------------
+# The margin between what a run requests and what the test needs.
+# ---------------------------------------------------------------------------
+
+
+def test_the_boundary_is_where_one_failed_draw_costs_the_whole_test() -> None:
+    from case_studies.utils.causal import (
+        MIN_PLACEBO_DRAWS,
+        PLACEBO_REQUEST_MARGIN,
+        placebo_request_is_on_the_boundary,
+    )
+
+    assert placebo_request_is_on_the_boundary(MIN_PLACEBO_DRAWS)
+    assert not placebo_request_is_on_the_boundary(0)
+    assert not placebo_request_is_on_the_boundary(MIN_PLACEBO_DRAWS + PLACEBO_REQUEST_MARGIN)
+    assert not placebo_request_is_on_the_boundary(100)
+
+
+def test_every_declared_test_reduction_can_produce_a_refutation() -> None:
+    """The reduction file is the environment this defect was reachable in.
+
+    Pinning the constant alone would leave `tests/overrides.yaml` free to drift back
+    onto the boundary, which is exactly how it got there.
+    """
+    import yaml
+
+    from case_studies.utils.causal import (
+        MIN_PLACEBO_DRAWS,
+        PLACEBO_REQUEST_MARGIN,
+        placebo_request_is_on_the_boundary,
+    )
+
+    overrides = yaml.safe_load((Path(__file__).resolve().parent / "overrides.yaml").read_text())
+
+    def walk(node):
+        if isinstance(node, dict):
+            if "n_placebo" in node:
+                yield int(node["n_placebo"])
+            for value in node.values():
+                yield from walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from walk(value)
+
+    declared = sorted(set(walk(overrides)))
+    assert declared, "no n_placebo reduction is declared, so this test measures nothing"
+    on_the_boundary = [value for value in declared if placebo_request_is_on_the_boundary(value)]
+    assert not on_the_boundary, (
+        f"these declared reductions request {on_the_boundary} placebo draws, and the "
+        f"permutation test needs {MIN_PLACEBO_DRAWS} successful ones. One failed draw "
+        "then produces no refutation at all, silently - and a notebook reading the "
+        f"p-value with a default publishes a number no test computed. Ask for at least "
+        f"{MIN_PLACEBO_DRAWS + PLACEBO_REQUEST_MARGIN}, or 0 to declare no refutation."
+    )

--- a/tests/test_causal_refutation_pvalue.py
+++ b/tests/test_causal_refutation_pvalue.py
@@ -167,10 +167,20 @@ def test_every_declared_test_reduction_can_produce_a_refutation() -> None:
     overrides = yaml.safe_load((Path(__file__).resolve().parent / "overrides.yaml").read_text())
 
     def walk(node):
+        # Case-insensitive, and by suffix, because the same quantity is declared under
+        # three names: `n_placebo` inside PREVIEW_REDUCTIONS, and the Papermill
+        # parameters `N_PLACEBO` and `PREVIEW_N_PLACEBO` for the stages that have not
+        # migrated. Matching only the lowercase key found two declarations and missed
+        # nine, five of which requested fewer draws than the test needs at all.
+        #
+        # N_PLACEBO_PERMUTATIONS is deliberately not matched: the chapter-15 notebooks
+        # run their own permutation loop and never reach run_dml_analysis's threshold,
+        # so the boundary this checks is not theirs.
         if isinstance(node, dict):
-            if "n_placebo" in node:
-                yield int(node["n_placebo"])
-            for value in node.values():
+            for key, value in node.items():
+                lowered = str(key).lower()
+                if lowered == "n_placebo" or lowered.endswith("_n_placebo"):
+                    yield int(value)
                 yield from walk(value)
         elif isinstance(node, list):
             for value in node:

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -160,6 +160,61 @@ def test_two_undeclared_identities_say_what_to_do(tmp_path) -> None:
     assert "causal_first" in str(raised.value)
 
 
+def test_reproducing_a_retired_identity_leaves_the_tip_alone(tmp_path) -> None:
+    """An older checkout reproducing a published number must not disturb the chain."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+
+    _register(case_dir, "causal_first")
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_second"
+
+
+def test_a_retired_identity_cannot_declare_it_retires_its_own_successor(tmp_path) -> None:
+    """Otherwise both rows end up retired and the reader resolves to zero.
+
+    Reachable by reproducing an older run with SUPERSEDES_CAUSAL still set to the value
+    the *newer* run used - the parameter is sticky in a notebook, the hash is not. A
+    worse state than the two-identity one, because the error names no candidates.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+
+    with pytest.raises(ValueError, match="already retired"):
+        _register(case_dir, "causal_first", supersedes="causal_second")
+
+
+def test_a_re_registration_without_a_declaration_does_not_clear_one(tmp_path) -> None:
+    """Fill-once has to hold on the ON CONFLICT path too, not only the UPDATE.
+
+    The route in is the migration backfill: a row stored with a NULL
+    refutation_n_successful is re-registered with a real one, which skips the early
+    return and reaches the insert. If that insert wrote NULL over the declaration, the
+    row it retired would go live again and the reader would see two.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute(
+            "UPDATE causal_runs SET refutation_n_successful = NULL WHERE causal_hash = ?",
+            ("causal_second",),
+        )
+
+    _register(case_dir, "causal_second", effect=-0.03)
+
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        stored = db.execute(
+            "SELECT supersedes_hash, refutation_n_successful FROM causal_runs "
+            "WHERE causal_hash = ?",
+            ("causal_second",),
+        ).fetchone()
+    assert stored == ("causal_first", 100)
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_second"
+
+
 # ---------------------------------------------------------------------------
 # The path that actually produces the rows a reader resolves.
 #
@@ -243,3 +298,34 @@ def test_the_declaration_stays_out_of_the_identity(tmp_path, monkeypatch) -> Non
 
     assert declaring.identity == plain.identity
     assert "supersedes" not in declaring.spec
+
+
+def test_the_repair_lands_even_though_the_fit_is_served_from_cache(tmp_path, monkeypatch) -> None:
+    """The recovery path for the rows that already exist, end to end.
+
+    A registry holding two undeclared identities is repaired by re-running the newer
+    one with SUPERSEDES_CAUSAL naming the older. That reproduces the same causal_hash,
+    so `run_resolved_causal_request` serves it from cache and never reaches the
+    registering write - and before this the declaration was dropped there in silence,
+    leaving the label unresolvable while the notebook reported success.
+    """
+    from tests.test_causal_adapter import _causal_fixture
+
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    _refit_under_a_changed_causal_module(monkeypatch, "a" * 64)
+    first = study.causal(method="dml", label=label.name).run()
+    _refit_under_a_changed_causal_module(monkeypatch, "b" * 64)
+    second = study.causal(method="dml", label=label.name, supersedes=first.hash).run()
+
+    # Strand them, which is the state cme_futures is in: two identities, no chain.
+    db_path = study.root / "run_log" / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("UPDATE causal_runs SET supersedes_hash = NULL")
+    with pytest.raises(ValueError, match="resolved to 2 identities"):
+        CausalResult.one(study, label=label.name)
+
+    # The documented repair, which recomputes an identity that is already stored.
+    repaired = study.causal(method="dml", label=label.name, supersedes=first.hash).run()
+
+    assert repaired.hash == second.hash
+    assert CausalResult.one(study, label=label.name).hash == second.hash

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -1,0 +1,160 @@
+"""A causal refit has to be recoverable, and nothing tested that it was.
+
+`CausalResult.one` resolves a label to exactly one current identity. A refit under a
+changed `case_studies/utils/causal.py` produces a second, and before this the registry
+had no way to say which one is live: no supersedes column, no tiebreak, no recency rule.
+`cme_futures` reached that state after re-running `11_causal_dml` - four canonical rows
+for two labels - and `12_model_analysis` exited 1 with no way forward but hand-editing
+the registry.
+
+The mechanism mirrors `official_populations`, where a changed population under an
+existing name must name the hash it supersedes. Recency is deliberately not the fallback:
+`created_at` ties on a fast refit, and it would be the only recency rule in a registry
+that is otherwise entirely spec-addressed.
+
+Not one of the four tests in `tests/test_causal_result_read.py` covers two identities;
+they are all about the refutation draw count. That absence is why this shipped.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from case_studies.research.causal import CausalResult
+from case_studies.utils.registry.registration import register_causal_run
+
+SPEC = '{"family":"causal_dml","identity_version":3}'
+LABEL = "fwd_ret_5d"
+
+
+def _register(case_dir, causal_hash, *, effect=-0.02, supersedes=None) -> None:
+    register_causal_run(
+        "test_case",
+        causal_hash,
+        label=LABEL,
+        treatment="ivrv_spread",
+        confounders_json='["rv_20"]',
+        embargo=10,
+        n_folds=5,
+        n_obs=100,
+        dml_effect=effect,
+        dml_se_hac=0.02,
+        p_value_hac=0.25,
+        naive_effect=-0.02,
+        confounding_bias_pct=-0.5,
+        refutation_p=1 / 101,
+        refutation_n_successful=100,
+        spec_json=SPEC,
+        notebook="11_causal_dml",
+        started_at="first",
+        elapsed_s=1.0,
+        supersedes_hash=supersedes,
+        case_dir=case_dir,
+    )
+
+
+def _study(case_dir):
+    return SimpleNamespace(
+        root=case_dir,
+        output_root=None,
+        storage_root=lambda _tier: case_dir,
+    )
+
+
+def test_one_identity_resolves(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_first"
+
+
+def test_a_second_identity_is_refused_at_the_write(tmp_path) -> None:
+    """Where the failure belongs: the run that caused it, not a downstream notebook.
+
+    Registering freely and failing at read time is what actually happened, and it puts
+    the error hours away from its cause and in a different notebook.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+
+    with pytest.raises(ValueError, match="SUPERSEDES_CAUSAL"):
+        _register(case_dir, "causal_second", effect=-0.03)
+
+
+def test_a_declared_refit_retires_its_predecessor(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+
+    resolved = CausalResult.one(_study(case_dir), label=LABEL)
+    assert resolved.hash == "causal_second"
+    assert resolved.metrics["dml_effect"] == pytest.approx(-0.03)
+
+
+def test_a_chain_of_two_refits_resolves_to_the_tip(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+    _register(case_dir, "causal_third", effect=-0.04, supersedes="causal_second")
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_third"
+
+
+def test_superseding_something_that_is_not_current_is_refused(tmp_path) -> None:
+    """The declaration is checked, not just recorded.
+
+    A typo'd or already-retired predecessor would otherwise leave the newer run live and
+    the older one live too, which is the state this whole mechanism exists to prevent -
+    reached by the one route that looks like it was handled.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+
+    with pytest.raises(ValueError, match="not a current canonical identity"):
+        _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_typo")
+
+
+def test_a_run_cannot_supersede_itself(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    with pytest.raises(ValueError, match="cannot supersede itself"):
+        _register(case_dir, "causal_first", supersedes="causal_first")
+
+
+def test_a_registry_written_before_the_column_can_still_be_read(tmp_path) -> None:
+    """`CausalResult.one` reads through a plain connection, not the migrating opener.
+
+    Naming `supersedes_hash` unconditionally would raise OperationalError on every
+    registry written before it existed - the same defect `refutation_n_successful`
+    caused once already, and the reason that read probes rather than assumes.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("ALTER TABLE causal_runs DROP COLUMN supersedes_hash")
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_first"
+
+
+def test_two_undeclared_identities_say_what_to_do(tmp_path) -> None:
+    """The state cme_futures was left in, and what a reader gets out of it.
+
+    The write-time refusal above stops this arising from here on, but four rows already
+    exist in a production registry. The message has to name the candidates and the
+    parameter, because the person reading it is in the downstream notebook.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute(
+            "INSERT INTO causal_runs (causal_hash, label, spec_json, created_at) "
+            "VALUES ('causal_second', ?, ?, 'now')",
+            (LABEL, SPEC),
+        )
+
+    with pytest.raises(ValueError, match="resolved to 2 identities") as raised:
+        CausalResult.one(_study(case_dir), label=LABEL)
+    assert "SUPERSEDES_CAUSAL" in str(raised.value)
+    assert "causal_first" in str(raised.value)

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -158,3 +158,88 @@ def test_two_undeclared_identities_say_what_to_do(tmp_path) -> None:
         CausalResult.one(_study(case_dir), label=LABEL)
     assert "SUPERSEDES_CAUSAL" in str(raised.value)
     assert "causal_first" in str(raised.value)
+
+
+# ---------------------------------------------------------------------------
+# The path that actually produces the rows a reader resolves.
+#
+# Everything above drives `register_causal_run` directly. Notebooks do not: they call
+# `study.causal(...).run()`, which goes through `run_resolved_causal_request`. Wiring
+# the enforcement to the low-level function while leaving that path unable to supply a
+# declaration would turn a recoverable read-time failure into a write-time one that
+# discards the fit - the fit runs, then the registration raises, and the only exit is
+# hand-editing the registry. Caught on review, so the coverage goes here.
+# ---------------------------------------------------------------------------
+
+_CANNED = {
+    "dml_result": {"theta": 0.02, "se_hac": 0.01, "n_obs": 120},
+    "p_value_hac": 0.04,
+    "naive_effect": 0.03,
+    "confounding_bias_pct": 50.0,
+    "refutation": {"empirical_p": 0.1, "n_successful": 100},
+    "started_at": "2026-08-15T00:00:00+00:00",
+    "elapsed_s": 1.0,
+}
+
+
+def _refit_under_a_changed_causal_module(monkeypatch, digest: str) -> None:
+    """What a refit is: the same request against a changed case_studies/utils/causal.py.
+
+    `_causal_source_identity` hashes that file, so editing it is what produces a second
+    identity for the same label. Simulating it here keeps the test about the chain
+    rather than about which edit was made.
+    """
+    from case_studies.utils import causal as causal_module
+
+    monkeypatch.setattr(causal_module, "run_dml_analysis", lambda *a, **k: dict(_CANNED))
+    monkeypatch.setattr(causal_module, "_causal_source_identity", lambda: {"causal.py": digest})
+
+
+def test_a_refit_through_the_request_path_is_refused_without_a_declaration(
+    tmp_path, monkeypatch
+) -> None:
+    from tests.test_causal_adapter import _causal_fixture
+
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    _refit_under_a_changed_causal_module(monkeypatch, "a" * 64)
+    first = study.causal(method="dml", label=label.name).run()
+
+    _refit_under_a_changed_causal_module(monkeypatch, "b" * 64)
+    with pytest.raises(ValueError, match="SUPERSEDES_CAUSAL"):
+        study.causal(method="dml", label=label.name).run()
+
+    assert CausalResult.one(study, label=label.name).hash == first.hash
+
+
+def test_a_refit_through_the_request_path_can_declare_what_it_retires(
+    tmp_path, monkeypatch
+) -> None:
+    from tests.test_causal_adapter import _causal_fixture
+
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    _refit_under_a_changed_causal_module(monkeypatch, "a" * 64)
+    first = study.causal(method="dml", label=label.name).run()
+
+    _refit_under_a_changed_causal_module(monkeypatch, "b" * 64)
+    second = study.causal(method="dml", label=label.name, supersedes=first.hash).run()
+
+    assert second.hash != first.hash
+    assert CausalResult.one(study, label=label.name).hash == second.hash
+
+
+def test_the_declaration_stays_out_of_the_identity(tmp_path, monkeypatch) -> None:
+    """A run that retires another must still be the run it says it is.
+
+    If `supersedes` reached the spec it would change the hash of every run that carries
+    one, so the row would supersede its predecessor and then not be the identity the
+    notebook computed.
+    """
+    from tests.test_causal_adapter import _causal_fixture
+
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    _refit_under_a_changed_causal_module(monkeypatch, "a" * 64)
+    plain = study.causal(method="dml", label=label.name).resolve()
+    declaring = study.causal(method="dml", label=label.name, supersedes="c" * 12).resolve()
+
+    assert declaring.identity == plain.identity
+    assert "supersedes" not in declaring.spec

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -24,7 +24,10 @@ from types import SimpleNamespace
 import pytest
 
 from case_studies.research.causal import CausalResult
-from case_studies.utils.registry.registration import register_causal_run
+from case_studies.utils.registry.registration import (
+    declare_causal_supersedes,
+    register_causal_run,
+)
 
 SPEC = '{"family":"causal_dml","identity_version":3}'
 LABEL = "fwd_ret_5d"
@@ -329,3 +332,52 @@ def test_the_repair_lands_even_though_the_fit_is_served_from_cache(tmp_path, mon
 
     assert repaired.hash == second.hash
     assert CausalResult.one(study, label=label.name).hash == second.hash
+
+
+def test_re_registering_an_unchanged_declaration_is_accepted(tmp_path) -> None:
+    """A wired notebook has to be idempotent on its second run.
+
+    Once `causal_second` declares it retires `causal_first`, that predecessor is no
+    longer current - its own successor's edge retired it - so validating the same
+    declaration against the current set reads as "not a current identity ... Current:
+    none". The declaration is unchanged, so nothing about it needs re-checking.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+
+    _register(case_dir, "causal_second", effect=-0.03, supersedes="causal_first")
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_second"
+
+
+def test_retiring_one_of_several_is_refused(tmp_path) -> None:
+    """One column holds one edge, so one declaration retires one row.
+
+    Accepting it while another stays current would let the write succeed and leave the
+    label exactly as unresolvable as before - the failure moves back to the downstream
+    notebook, which is what declaring the chain at the write is here to prevent.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute(
+            "INSERT INTO causal_runs (causal_hash, label, spec_json, created_at) "
+            "VALUES ('causal_other', ?, ?, 'now')",
+            (LABEL, SPEC),
+        )
+
+    with pytest.raises(ValueError, match="would still be current"):
+        _register(case_dir, "causal_third", effect=-0.04, supersedes="causal_first")
+
+    # Chained oldest to newest, the same registry resolves. `declare_causal_supersedes`
+    # is the repair write for a row that already exists and must not be re-fitted.
+    declare_causal_supersedes(
+        "test_case",
+        "causal_other",
+        supersedes_hash="causal_first",
+        label=LABEL,
+        case_dir=case_dir,
+    )
+    _register(case_dir, "causal_third", effect=-0.04, supersedes="causal_other")
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_third"

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -381,3 +381,47 @@ def test_retiring_one_of_several_is_refused(tmp_path) -> None:
     )
     _register(case_dir, "causal_third", effect=-0.04, supersedes="causal_other")
     assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_third"
+
+
+def test_three_stranded_identities_can_be_chained_back_to_one(tmp_path) -> None:
+    """The state a registry is actually found in, and the way out of it.
+
+    Requiring every declaration to leave exactly one current deadlocks here: with three
+    live rows, chaining the middle one is refused because the newest is still current,
+    and chaining the newest is refused because the middle still is. So a repair step -
+    a declaration on a row that already exists - is allowed to reduce the count without
+    finishing, while a new fit is not.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_a")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        for name in ("causal_b", "causal_c"):
+            db.execute(
+                "INSERT INTO causal_runs (causal_hash, label, spec_json, created_at) "
+                "VALUES (?, ?, ?, 'now')",
+                (name, LABEL, SPEC),
+            )
+    with pytest.raises(ValueError, match="resolved to 3 identities"):
+        CausalResult.one(_study(case_dir), label=LABEL)
+
+    for newer, older in (("causal_b", "causal_a"), ("causal_c", "causal_b")):
+        declare_causal_supersedes(
+            "test_case", newer, supersedes_hash=older, label=LABEL, case_dir=case_dir
+        )
+
+    assert CausalResult.one(_study(case_dir), label=LABEL).hash == "causal_c"
+
+
+def test_a_new_fit_into_a_broken_registry_is_still_refused(tmp_path) -> None:
+    """Repair first, then fit. A new identity owns the state it leaves behind."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_a")
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute(
+            "INSERT INTO causal_runs (causal_hash, label, spec_json, created_at) "
+            "VALUES ('causal_b', ?, ?, 'now')",
+            (LABEL, SPEC),
+        )
+
+    with pytest.raises(ValueError, match="would still be current"):
+        _register(case_dir, "causal_new", effect=-0.05, supersedes="causal_a")


### PR DESCRIPTION
`CausalResult.one` resolves a label to exactly one current identity, and a refit under a changed `case_studies/utils/causal.py` produces a second. `causal_runs` had no supersedes column, no tiebreak and no recency rule, so the registry ended up holding two rows no reader could choose between - and the failure surfaced hours later, in a different notebook, with nothing saying which run caused it. `cme_futures` reached that state after re-running `11_causal_dml`: four canonical rows for two labels, and `12_model_analysis` exiting 1 with nothing to do but hand-edit the registry.

This mirrors `official_populations`, where a changed population under an existing name must name the hash it supersedes. Recency is deliberately not the fallback: `created_at` ties on a fast refit, it would be the only recency rule in a registry that is otherwise entirely spec-addressed, and it would hide the failure rather than surface it.

## What is here

- `causal_runs.supersedes_hash`, nullable, with a migration. Both reads probe for the column rather than naming it - neither goes through the migrating opener, so naming it would raise `OperationalError` on every registry written before today.
- `current_causal_identities` in `store.py`, used by the write-time check and by `CausalResult.one`, so the two cannot drift. The first draft had two copies and they disagreed within the hour.
- A new fit that would leave a label with more than one current identity is refused at the write, naming the one to retire. A repair step - a declaration on a row that already exists - may reduce the count without finishing, because chaining three stranded rows is incremental and requiring one at every step deadlocks.
- `declare_causal_supersedes`, the narrow fill-once write for the repair path. It is needed because re-running the newer identity reproduces its hash, so the fit is served from cache and never reaches the registering write.
- `supersedes` travels `study.causal(...)` -> `CausalRequest` -> `ResolvedCausalRequest` -> `run_resolved_causal_request` -> `register_causal_run`, alongside the spec and never inside it: the spec is hashed, so a declaration in it would change the identity of every run that carries one.
- `SUPERSEDES_CAUSAL` joins `SUPERSEDES_POPULATION` in `PRODUCTION_SAFE_PARAMETERS`.

## Cost

Threading the parameter through the notebook-facing wrapper edits `case_studies/utils/causal.py`, and `_causal_source_identity` hashes that file, so every `causal_hash` moves. Measured: **12 rows across four case studies** - `cme_futures` 4 (2 labels), `us_firm_characteristics` 3 (1 label), `fx_pairs` 3 (3 labels), `crypto_perps_funding` and `etfs` 1 each. The first two are already holding more identities per label than a reader can resolve, so they refit either way, and all five are inside the stage 06+ rebuild.

## Tests

`tests/test_causal_supersedes.py`, 19 tests. Nothing covered the two-identity path before - the four in `test_causal_result_read.py` are all about the refutation draw count, which is why this shipped. Both sides are covered: the write-time refusals, the reader's subtraction, an unchanged declaration re-registering cleanly, a retired row that cannot retire its own successor, fill-once surviving the migration backfill, the repair landing from cache, three stranded identities chained back to one, and a new fit into that same broken registry still refused. 54 passed across the causal and registry surface.

## Not here

No causal notebook declares `SUPERSEDES_CAUSAL` yet. Four need `SUPERSEDES_CAUSAL: str = ""` in the parameters cell and `supersedes=SUPERSEDES_CAUSAL or None` at the `study.causal(...)` call: `cme_futures/11_causal_dml`, `fx_pairs/11_causal_dml`, `crypto_perps_funding/11_causal_dml` and `us_equities_panel/14_causal_dml`. Each sits on its own `cs6` branch with a different version of that file, so the edit belongs to the case study that owns it, with its refit.