### PR TITLE
Give the causal supersedes refusal a way to be answered, and take two spec shapes

### DIFF
--- a/case_studies/cme_futures/11_causal_dml.ipynb
+++ b/case_studies/cme_futures/11_causal_dml.ipynb
@@ -29,23 +29,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "e0ae501d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:55:22.732322Z",
-     "iopub.status.busy": "2026-08-15T20:55:22.732202Z",
-     "iopub.status.idle": "2026-08-15T20:55:24.228228Z",
-     "shell.execute_reply": "2026-08-15T20:55:24.227699Z"
-    },
-    "papermill": {
-     "duration": 1.498518,
-     "end_time": "2026-08-15T20:55:24.228882+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:55:22.730364+00:00",
-     "status": "completed"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared CME futures double-machine-learning requests.\"\"\"\n",
@@ -56,27 +42,15 @@
     "    ALL_LABELS,\n",
     "    open_study,\n",
     "    product_universe_table,\n",
-    ")"
+    ")\n",
+    "from case_studies.research import supersedes_for"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "eb596eed",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:55:24.232292Z",
-     "iopub.status.busy": "2026-08-15T20:55:24.232127Z",
-     "iopub.status.idle": "2026-08-15T20:55:24.234290Z",
-     "shell.execute_reply": "2026-08-15T20:55:24.233841Z"
-    },
-    "papermill": {
-     "duration": 0.004684,
-     "end_time": "2026-08-15T20:55:24.234670+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:55:24.229986+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -85,7 +59,8 @@
    "source": [
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE: str | None = None\n",
-    "PREVIEW_REDUCTIONS: dict = {}"
+    "PREVIEW_REDUCTIONS: dict = {}\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
@@ -109,62 +84,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "271bff70",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:55:24.238646Z",
-     "iopub.status.busy": "2026-08-15T20:55:24.238570Z",
-     "iopub.status.idle": "2026-08-15T20:55:24.288754Z",
-     "shell.execute_reply": "2026-08-15T20:55:24.288278Z"
-    },
-    "papermill": {
-     "duration": 0.051911,
-     "end_time": "2026-08-15T20:55:24.289164+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:55:24.237253+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (30, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sector</th><th>product</th><th>expiry_rule</th><th>contract_months</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;agriculture&quot;</td><td>&quot;ZC&quot;</td><td>&quot;business_day_before_15th&quot;</td><td>&quot;H,K,N,U,Z&quot;</td></tr><tr><td>&quot;agriculture&quot;</td><td>&quot;ZL&quot;</td><td>&quot;business_day_before_15th&quot;</td><td>&quot;F,H,K,N,Q,U,V,Z&quot;</td></tr><tr><td>&quot;agriculture&quot;</td><td>&quot;ZM&quot;</td><td>&quot;business_day_before_15th&quot;</td><td>&quot;F,H,K,N,Q,U,V,Z&quot;</td></tr><tr><td>&quot;agriculture&quot;</td><td>&quot;ZS&quot;</td><td>&quot;business_day_before_15th&quot;</td><td>&quot;F,H,K,N,Q,U,X&quot;</td></tr><tr><td>&quot;agriculture&quot;</td><td>&quot;ZW&quot;</td><td>&quot;business_day_before_15th&quot;</td><td>&quot;H,K,N,U,Z&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;metals&quot;</td><td>&quot;SI&quot;</td><td>&quot;3rd_last_business_day&quot;</td><td>&quot;H,K,N,U,Z&quot;</td></tr><tr><td>&quot;treasuries&quot;</td><td>&quot;ZB&quot;</td><td>&quot;last_business_day&quot;</td><td>&quot;H,M,U,Z&quot;</td></tr><tr><td>&quot;treasuries&quot;</td><td>&quot;ZF&quot;</td><td>&quot;last_business_day&quot;</td><td>&quot;H,M,U,Z&quot;</td></tr><tr><td>&quot;treasuries&quot;</td><td>&quot;ZN&quot;</td><td>&quot;last_business_day&quot;</td><td>&quot;H,M,U,Z&quot;</td></tr><tr><td>&quot;treasuries&quot;</td><td>&quot;ZT&quot;</td><td>&quot;last_business_day&quot;</td><td>&quot;H,M,U,Z&quot;</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (30, 4)\n",
-       "┌─────────────┬─────────┬──────────────────────────┬─────────────────┐\n",
-       "│ sector      ┆ product ┆ expiry_rule              ┆ contract_months │\n",
-       "│ ---         ┆ ---     ┆ ---                      ┆ ---             │\n",
-       "│ str         ┆ str     ┆ str                      ┆ str             │\n",
-       "╞═════════════╪═════════╪══════════════════════════╪═════════════════╡\n",
-       "│ agriculture ┆ ZC      ┆ business_day_before_15th ┆ H,K,N,U,Z       │\n",
-       "│ agriculture ┆ ZL      ┆ business_day_before_15th ┆ F,H,K,N,Q,U,V,Z │\n",
-       "│ agriculture ┆ ZM      ┆ business_day_before_15th ┆ F,H,K,N,Q,U,V,Z │\n",
-       "│ agriculture ┆ ZS      ┆ business_day_before_15th ┆ F,H,K,N,Q,U,X   │\n",
-       "│ agriculture ┆ ZW      ┆ business_day_before_15th ┆ H,K,N,U,Z       │\n",
-       "│ …           ┆ …       ┆ …                        ┆ …               │\n",
-       "│ metals      ┆ SI      ┆ 3rd_last_business_day    ┆ H,K,N,U,Z       │\n",
-       "│ treasuries  ┆ ZB      ┆ last_business_day        ┆ H,M,U,Z         │\n",
-       "│ treasuries  ┆ ZF      ┆ last_business_day        ┆ H,M,U,Z         │\n",
-       "│ treasuries  ┆ ZN      ┆ last_business_day        ┆ H,M,U,Z         │\n",
-       "│ treasuries  ┆ ZT      ┆ last_business_day        ┆ H,M,U,Z         │\n",
-       "└─────────────┴─────────┴──────────────────────────┴─────────────────┘"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "study = open_study(execution_tier=EXECUTION_TIER, workspace=WORKSPACE)\n",
     "if EXECUTION_TIER == \"preview\" and (WORKSPACE is None or not PREVIEW_REDUCTIONS):\n",
@@ -175,61 +98,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "4b112f55",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:55:24.292085Z",
-     "iopub.status.busy": "2026-08-15T20:55:24.291968Z",
-     "iopub.status.idle": "2026-08-15T20:55:26.901436Z",
-     "shell.execute_reply": "2026-08-15T20:55:26.900946Z"
-    },
-    "papermill": {
-     "duration": 2.611691,
-     "end_time": "2026-08-15T20:55:26.902124+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:55:24.290433+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (2, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>treatment</th><th>outcome</th><th>outcome_horizon</th><th>confounders</th><th>analysis_rows</th><th>analysis_timestamps</th><th>request_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;carry_pct&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;5 days 00:00:00&quot;</td><td>&quot;vol_21d, momentum_composite, c…</td><td>88695</td><td>3100</td><td>&quot;05b4cdb8a2f2&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;carry_pct&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;21 days 00:00:00&quot;</td><td>&quot;vol_21d, momentum_composite, c…</td><td>88320</td><td>3089</td><td>&quot;f78daa857772&quot;</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (2, 8)\n",
-       "┌────────────┬───────────┬────────────┬────────────┬───────────┬───────────┬───────────┬───────────┐\n",
-       "│ label      ┆ treatment ┆ outcome    ┆ outcome_ho ┆ confounde ┆ analysis_ ┆ analysis_ ┆ request_h │\n",
-       "│ ---        ┆ ---       ┆ ---        ┆ rizon      ┆ rs        ┆ rows      ┆ timestamp ┆ ash       │\n",
-       "│ str        ┆ str       ┆ str        ┆ ---        ┆ ---       ┆ ---       ┆ s         ┆ ---       │\n",
-       "│            ┆           ┆            ┆ str        ┆ str       ┆ i64       ┆ ---       ┆ str       │\n",
-       "│            ┆           ┆            ┆            ┆           ┆           ┆ i64       ┆           │\n",
-       "╞════════════╪═══════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ fwd_ret_5d ┆ carry_pct ┆ fwd_ret_5d ┆ 5 days     ┆ vol_21d,  ┆ 88695     ┆ 3100      ┆ 05b4cdb8a │\n",
-       "│            ┆           ┆            ┆ 00:00:00   ┆ momentum_ ┆           ┆           ┆ 2f2       │\n",
-       "│            ┆           ┆            ┆            ┆ composite ┆           ┆           ┆           │\n",
-       "│            ┆           ┆            ┆            ┆ , c…      ┆           ┆           ┆           │\n",
-       "│ fwd_ret_21 ┆ carry_pct ┆ fwd_ret_21 ┆ 21 days    ┆ vol_21d,  ┆ 88320     ┆ 3089      ┆ f78daa857 │\n",
-       "│ d          ┆           ┆ d          ┆ 00:00:00   ┆ momentum_ ┆           ┆           ┆ 772       │\n",
-       "│            ┆           ┆            ┆            ┆ composite ┆           ┆           ┆           │\n",
-       "│            ┆           ┆            ┆            ┆ , c…      ┆           ┆           ┆           │\n",
-       "└────────────┴───────────┴────────────┴────────────┴───────────┴───────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "requests = tuple(\n",
     "    study.causal(\n",
@@ -237,6 +109,7 @@
     "        label=label,\n",
     "        execution_tier=EXECUTION_TIER,\n",
     "        preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "        supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=list(ALL_LABELS)),\n",
     "    ).resolve()\n",
     "    for label in ALL_LABELS\n",
     ")\n",
@@ -282,23 +155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "d1e82d3c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:55:26.907707Z",
-     "iopub.status.busy": "2026-08-15T20:55:26.907615Z",
-     "iopub.status.idle": "2026-08-15T20:59:38.200808Z",
-     "shell.execute_reply": "2026-08-15T20:59:38.200370Z"
-    },
-    "papermill": {
-     "duration": 251.295466,
-     "end_time": "2026-08-15T20:59:38.201550+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:55:26.906084+00:00",
-     "status": "completed"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results = []\n",
@@ -320,56 +179,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "612ccf15",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T20:59:38.203561Z",
-     "iopub.status.busy": "2026-08-15T20:59:38.203480Z",
-     "iopub.status.idle": "2026-08-15T20:59:38.206862Z",
-     "shell.execute_reply": "2026-08-15T20:59:38.206415Z"
-    },
-    "papermill": {
-     "duration": 0.004845,
-     "end_time": "2026-08-15T20:59:38.207169+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T20:59:38.202324+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (2, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>execution_tier</th><th>complete</th><th>causal_hash</th></tr><tr><td>str</td><td>str</td><td>bool</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f78daa857772&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;05b4cdb8a2f2&quot;</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (2, 4)\n",
-       "┌─────────────┬────────────────┬──────────┬──────────────┐\n",
-       "│ label       ┆ execution_tier ┆ complete ┆ causal_hash  │\n",
-       "│ ---         ┆ ---            ┆ ---      ┆ ---          │\n",
-       "│ str         ┆ str            ┆ bool     ┆ str          │\n",
-       "╞═════════════╪════════════════╪══════════╪══════════════╡\n",
-       "│ fwd_ret_21d ┆ canonical      ┆ true     ┆ f78daa857772 │\n",
-       "│ fwd_ret_5d  ┆ canonical      ┆ true     ┆ 05b4cdb8a2f2 │\n",
-       "└─────────────┴────────────────┴──────────┴──────────────┘"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl.DataFrame(results).sort(\"label\")"
    ]
@@ -395,25 +212,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-08-15T20:59:43.618553+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "6db4407a8e66c2c236b17ebbb344999fc5262d18"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 257.435137,
-   "end_time": "2026-08-15T20:59:39.523567+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/11_causal_dml.ipynb",
-   "output_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/11_causal_dml.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-15T20:55:22.088430+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/cme_futures/11_causal_dml.py
+++ b/case_studies/cme_futures/11_causal_dml.py
@@ -37,11 +37,13 @@ from case_studies.cme_futures.research_workflow import (
     open_study,
     product_universe_table,
 )
+from case_studies.research import supersedes_for
 
 # %% tags=["parameters"]
 EXECUTION_TIER = "canonical"
 WORKSPACE: str | None = None
 PREVIEW_REDUCTIONS: dict = {}
+SUPERSEDES_CAUSAL: str = ""
 
 # %% [markdown]
 # ## Resolve the estimands
@@ -63,6 +65,7 @@ requests = tuple(
         label=label,
         execution_tier=EXECUTION_TIER,
         preview_reductions=PREVIEW_REDUCTIONS,
+        supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=list(ALL_LABELS)),
     ).resolve()
     for label in ALL_LABELS
 )

--- a/case_studies/crypto_perps_funding/11_causal_dml.ipynb
+++ b/case_studies/crypto_perps_funding/11_causal_dml.ipynb
@@ -32,50 +32,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a1beca76",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T18:16:18.970813Z",
-     "iopub.status.busy": "2026-08-15T18:16:18.970623Z",
-     "iopub.status.idle": "2026-08-15T18:16:20.775418Z",
-     "shell.execute_reply": "2026-08-15T18:16:20.774615Z"
-    },
-    "papermill": {
-     "duration": 1.807436,
-     "end_time": "2026-08-15T18:16:20.776229+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T18:16:18.968793+00:00",
-     "status": "completed"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "import polars as pl\n",
     "\n",
-    "from case_studies.crypto_perps_funding.research_workflow import open_study"
+    "from case_studies.crypto_perps_funding.research_workflow import open_study\n",
+    "from case_studies.research import supersedes_for"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f733ded3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T18:16:20.779328Z",
-     "iopub.status.busy": "2026-08-15T18:16:20.779082Z",
-     "iopub.status.idle": "2026-08-15T18:16:20.781523Z",
-     "shell.execute_reply": "2026-08-15T18:16:20.781082Z"
-    },
-    "papermill": {
-     "duration": 0.00467,
-     "end_time": "2026-08-15T18:16:20.782136+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T18:16:20.777466+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -87,7 +61,8 @@
     "LABEL = \"fwd_ret_8h\"\n",
     "CONFIG_NAME = \"dml\"\n",
     "PREVIEW_REDUCTIONS = {}\n",
-    "OVERRIDES = {}"
+    "OVERRIDES = {}\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
@@ -108,57 +83,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ec79caaf",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T18:16:20.788657Z",
-     "iopub.status.busy": "2026-08-15T18:16:20.788402Z",
-     "iopub.status.idle": "2026-08-15T18:16:22.386411Z",
-     "shell.execute_reply": "2026-08-15T18:16:22.385885Z"
-    },
-    "papermill": {
-     "duration": 1.601971,
-     "end_time": "2026-08-15T18:16:22.387127+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T18:16:20.785156+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (1, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>causal_hash</th><th>outcome</th><th>treatment</th><th>outcome_horizon</th><th>n_folds</th><th>embargo_periods</th><th>gap_policy</th><th>eligible_rows</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;828ab65131b1&quot;</td><td>&quot;fwd_ret_8h&quot;</td><td>&quot;premium_zscore_14d&quot;</td><td>&quot;0 days 08:00:00&quot;</td><td>5</td><td>1</td><td>&quot;reset&quot;</td><td>58975</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (1, 8)\n",
-       "┌────────────┬────────────┬────────────┬────────────┬─────────┬────────────┬───────────┬───────────┐\n",
-       "│ causal_has ┆ outcome    ┆ treatment  ┆ outcome_ho ┆ n_folds ┆ embargo_pe ┆ gap_polic ┆ eligible_ │\n",
-       "│ h          ┆ ---        ┆ ---        ┆ rizon      ┆ ---     ┆ riods      ┆ y         ┆ rows      │\n",
-       "│ ---        ┆ str        ┆ str        ┆ ---        ┆ i64     ┆ ---        ┆ ---       ┆ ---       │\n",
-       "│ str        ┆            ┆            ┆ str        ┆         ┆ i64        ┆ str       ┆ i64       │\n",
-       "╞════════════╪════════════╪════════════╪════════════╪═════════╪════════════╪═══════════╪═══════════╡\n",
-       "│ 828ab65131 ┆ fwd_ret_8h ┆ premium_zs ┆ 0 days     ┆ 5       ┆ 1          ┆ reset     ┆ 58975     │\n",
-       "│ b1         ┆            ┆ core_14d   ┆ 08:00:00   ┆         ┆            ┆           ┆           │\n",
-       "└────────────┴────────────┴────────────┴────────────┴─────────┴────────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "study = open_study(execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)\n",
     "request = study.causal(\n",
@@ -168,6 +100,7 @@
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
     "    overrides=OVERRIDES,\n",
+    "    supersedes=supersedes_for(SUPERSEDES_CAUSAL, LABEL, labels=[LABEL]),\n",
     ")\n",
     "resolved = request.resolve()\n",
     "computation = resolved.spec[\"computation\"]\n",
@@ -203,55 +136,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2657e0db",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-15T18:16:22.392632Z",
-     "iopub.status.busy": "2026-08-15T18:16:22.392505Z",
-     "iopub.status.idle": "2026-08-15T18:17:14.326483Z",
-     "shell.execute_reply": "2026-08-15T18:17:14.325815Z"
-    },
-    "papermill": {
-     "duration": 51.936899,
-     "end_time": "2026-08-15T18:17:14.327767+00:00",
-     "exception": false,
-     "start_time": "2026-08-15T18:16:22.390868+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (1, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>causal_hash</th><th>n_obs</th><th>complete</th><th>execution_tier</th></tr><tr><td>str</td><td>i64</td><td>bool</td><td>str</td></tr></thead><tbody><tr><td>&quot;828ab65131b1&quot;</td><td>54314</td><td>true</td><td>&quot;canonical&quot;</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (1, 4)\n",
-       "┌──────────────┬───────┬──────────┬────────────────┐\n",
-       "│ causal_hash  ┆ n_obs ┆ complete ┆ execution_tier │\n",
-       "│ ---          ┆ ---   ┆ ---      ┆ ---            │\n",
-       "│ str          ┆ i64   ┆ bool     ┆ str            │\n",
-       "╞══════════════╪═══════╪══════════╪════════════════╡\n",
-       "│ 828ab65131b1 ┆ 54314 ┆ true     ┆ canonical      │\n",
-       "└──────────────┴───────┴──────────┴────────────────┘"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = resolved.run()\n",
     "if not result.complete or result.spec != resolved.spec:\n",
@@ -309,25 +201,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 57.847246,
-   "end_time": "2026-08-15T18:17:16.148143+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "~/ml4t/public-s6-crypto_perps_funding/case_studies/crypto_perps_funding/11_causal_dml.ipynb",
-   "output_path": "~/ml4t/public-s6-crypto_perps_funding/case_studies/crypto_perps_funding/11_causal_dml.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-15T18:16:18.300897+00:00",
-   "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "5762bb2b91bb3b4199b2793b843b2b6a12e9934d",
-   "executed_at": "2026-08-15T18:17:21.745044+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/crypto_perps_funding/11_causal_dml.py
+++ b/case_studies/crypto_perps_funding/11_causal_dml.py
@@ -36,6 +36,7 @@ import os
 import polars as pl
 
 from case_studies.crypto_perps_funding.research_workflow import open_study
+from case_studies.research import supersedes_for
 
 # %% tags=["parameters"]
 EXECUTION_TIER = "canonical"
@@ -44,6 +45,7 @@ LABEL = "fwd_ret_8h"
 CONFIG_NAME = "dml"
 PREVIEW_REDUCTIONS = {}
 OVERRIDES = {}
+SUPERSEDES_CAUSAL: str = ""
 
 # %% [markdown]
 # ## Resolve the estimand and refutation contract
@@ -57,6 +59,7 @@ request = study.causal(
     execution_tier=EXECUTION_TIER,
     preview_reductions=PREVIEW_REDUCTIONS,
     overrides=OVERRIDES,
+    supersedes=supersedes_for(SUPERSEDES_CAUSAL, LABEL, labels=[LABEL]),
 )
 resolved = request.resolve()
 computation = resolved.spec["computation"]

--- a/case_studies/etfs/14_backtest.ipynb
+++ b/case_studies/etfs/14_backtest.ipynb
@@ -38,16 +38,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "129bf603",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:48.039230Z",
-     "iopub.status.busy": "2026-04-28T14:41:48.038935Z",
-     "iopub.status.idle": "2026-04-28T14:41:49.410491Z",
-     "shell.execute_reply": "2026-04-28T14:41:49.410120Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Ch16 Backtest & Signal Evaluation — ETF rotation case study.\"\"\"\n",
@@ -82,15 +75,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3a20ed2d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:49.417283Z",
-     "iopub.status.busy": "2026-04-28T14:41:49.417113Z",
-     "iopub.status.idle": "2026-04-28T14:41:49.419061Z",
-     "shell.execute_reply": "2026-04-28T14:41:49.418702Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -124,34 +111,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e28c6848",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:49.424342Z",
-     "iopub.status.busy": "2026-04-28T14:41:49.424273Z",
-     "iopub.status.idle": "2026-04-28T14:41:49.429965Z",
-     "shell.execute_reply": "2026-04-28T14:41:49.429559Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Protocol Term Sheet ===\n",
-      "  Case study:    etfs\n",
-      "  Label:         fwd_ret_21d\n",
-      "  Calendar:      NYSE\n",
-      "  Cadence:       monthly_month_end\n",
-      "  Commission:    6.0 bps\n",
-      "  Slippage:      4.0 bps\n",
-      "  Total cost:    10.0 bps/leg\n",
-      "  Long/short:    False\n",
-      "\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
     "bt_config = get_backtest_config(CASE_STUDY_ID)\n",
@@ -177,25 +140,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e364c3f9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:49.433175Z",
-     "iopub.status.busy": "2026-04-28T14:41:49.433115Z",
-     "iopub.status.idle": "2026-04-28T14:41:49.496964Z",
-     "shell.execute_reply": "2026-04-28T14:41:49.496526Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prices: 470,662 rows, 100 assets\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "prices = load_backtest_prices_for(CASE_STUDY_ID, LABEL, split=\"validation\", max_symbols=MAX_SYMBOLS)\n",
     "n_assets = prices[\"symbol\"].n_unique()\n",
@@ -212,25 +160,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "31b25447",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:49.500365Z",
-     "iopub.status.busy": "2026-04-28T14:41:49.500282Z",
-     "iopub.status.idle": "2026-04-28T14:41:50.337276Z",
-     "shell.execute_reply": "2026-04-28T14:41:50.336783Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Random signal Sharpe: 0.401  [PASS]\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "strategy_spec = build_backtest_spec(\n",
     "    CASE_STUDY_ID,\n",
@@ -283,26 +216,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "564dd2d6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:50.343435Z",
-     "iopub.status.busy": "2026-04-28T14:41:50.343284Z",
-     "iopub.status.idle": "2026-04-28T14:41:50.348232Z",
-     "shell.execute_reply": "2026-04-28T14:41:50.347881Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predictions to sweep: 84\n",
-      "  IC range: -0.0147 — 0.0858\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pred_index = load_prediction_index(\n",
     "    CASE_STUDY_ID,\n",
@@ -328,36 +245,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "f80f59fc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:50.353273Z",
-     "iopub.status.busy": "2026-04-28T14:41:50.353204Z",
-     "iopub.status.idle": "2026-04-28T14:41:50.355276Z",
-     "shell.execute_reply": "2026-04-28T14:41:50.354983Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Entry schemes (8):\n",
-      "  ew_top5: equal_weight_top_k (top_k=5)\n",
-      "  ew_top10: equal_weight_top_k (top_k=10)\n",
-      "  ew_top20: equal_weight_top_k (top_k=20)\n",
-      "  sw_top10: score_weighted_top_k (top_k=10)\n",
-      "  sw_top20: score_weighted_top_k (top_k=20)\n",
-      "  cs_pct80: cross_sectional_percentile (top_k=-)\n",
-      "  cs_pct90: cross_sectional_percentile (top_k=-)\n",
-      "  cs_pct95: cross_sectional_percentile (top_k=-)\n",
-      "\n",
-      "Total grid: 84 predictions × 8 schemes = 672 backtests\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "entry_schemes = get_entry_schemes_for(\n",
     "    CASE_STUDY_ID, LABEL, n_assets, long_short=bt_config.long_short\n",
@@ -376,1001 +267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0d21a3cc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:41:50.360727Z",
-     "iopub.status.busy": "2026-04-28T14:41:50.360635Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.687522Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.687132Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Existing signal-stage hashes in registry: 521\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 38s (1.1 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 39s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 40s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 41s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 42s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 43s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 44s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [40/672] 45s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 81s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 82s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 83s (1.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 85s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 86s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 87s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 88s (0.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/672] 89s (0.9 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=22367b425a10)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=24ae26cf85b4)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8ad3f7384cd4)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4a970d6162e7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7765f88d5366)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0716ed3dc15e)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6205d6171815)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0e17a0b33c1d)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=08eeda7d1c5f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5fa9d7d37550)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f4ae9e394915)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f3e54275757b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b109b812ff20)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ae0fb554b5cd)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=21e0a5bc2cde)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ab4c5649ff56)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=fca0764c4be9)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ac4ab5e1f353)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=024c526dee2d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c41bbf3678bf)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=12d1822f91a2)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=2d9fd1c84869)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f206b53d2e71)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7b56efe250c2)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=2a2f840d2500)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=86b9d39430e0)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=e1595a3f5432)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=f7206378e2d8)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=99c8f20ffbd3)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=a37b93c28a99)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=2b1ab719e6d8)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=7e366acd0dbf)) — reusing cached result\n",
-      "  [120/672] 98s (1.2 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=14444d85ebcf)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8f6ab4e17b6d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4e16d00a71b4)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0e4780b97e36)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c280bff0f6f5)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=229597542f50)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c2052cfaf907)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=2cc5fc5d3c06)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0b0e7b35f07d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=96670dd9eb61)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=94c8e312e56e)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8316b49f20ab)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6469a5b82e87)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ab4a7a8651fa)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ba30441951e3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4bfad577691f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=59c9f4c73bc0)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=dd8a677b5a26)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=1c87ec2c778e)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=be0978bb4510)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0eb400ad7152)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d653ce2cc12a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5ed09a0c89fb)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b85b670aee96)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7241ee4e09ef)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=835dc1263892)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=776e4f54a92c)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=3c989a44dfbb)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0d18e6666100)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=20b483bd1db2)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a00ba2b765e1)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6951b5031866)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=20699aaaf4db)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=6ce0edbc0c29)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=dad2a6363ac8)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=9058b83c2ddb)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=1851ec4b29d3)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=448796824ac2)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=21d8fc1f04f2)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=0695068b7a57)) — reusing cached result\n",
-      "  [160/672] 98s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=16a6360a5e9b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=25623edb9190)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7ff4855f03cd)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b94906fde58d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=47edcb592c0b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a42fb87e62f4)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=e744579b9b92)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=35f888cd1d67)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7cb76f0a0af8)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=00e0833a27d9)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4e0936a9c7a8)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=eddec9e2c8be)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6f7e57e7e63c)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=63cb59ab6b0b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6f616a82607e)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0ef6329c779a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=80d218dbf09b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=61c3e12afe1a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b88c9432117a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f4af975b1f1b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=96a048a4d3a0)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=3517ff2926a1)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d33d00250c72)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=3853df93e761)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=829653e06a5e)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=901de6afa784)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6b0dcdd12f80)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c9f43fda8614)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b9c31ec161d4)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5825ef42d160)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=27d6a731b7f7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ec39d55ffb38)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 99s (2.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 100s (2.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 101s (2.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 102s (2.0 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 104s (1.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 105s (1.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 106s (1.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [200/672] 107s (1.9 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=56c6a30adfd9)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=dc86ade4c1a7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=61e8c96737d3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c1f2c2454dcb)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ec633bfb85ef)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=103aabdc3132)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=630273b1e040)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=389906416cbd)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 134s (1.8 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 135s (1.8 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 136s (1.8 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 137s (1.8 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 138s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 139s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 140s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [240/672] 141s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=adf40fb14759)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6aec11363e85)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7a1f1a7accca)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f582ef3ff4a9)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=9179eb693e25)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=e3a82bbae7a3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6ceb08c767d7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f4388350ce21)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=465c6d8fe8f7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=477ce90d64e2)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7c008402abaa)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f239e5f6a74b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=bc79a75391b6)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=49e9835f0842)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f20ec065c74f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=52bca8d554ba)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 159s (1.8 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 160s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 161s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 162s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 164s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 165s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 166s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [280/672] 167s (1.7 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 202s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 204s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 205s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 206s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 207s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 208s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 209s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [320/672] 210s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=70c95004672c)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f2699cff3498)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=89b890aac534)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=3251ef5da823)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=afc0b6c82853)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d454835a68de)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=9d96945d90b7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=666f587da881)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=fdadacc4e864)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=13e9cd17d774)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=3954a20cb0e2)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=66f39e271e8f)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=3258b360148c)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=172a68822293)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=2942c1d2079c)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=8091cb1de67b)) — reusing cached result\n",
-      "  [360/672] 236s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=d507aa0e35b6)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8695b1ea9340)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ffd000b5fbb2)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=e0ebb0869222)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6610652fab71)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=bb1f30a4f981)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a1476769dd72)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a2eb7db989f2)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=98af82ef005d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a7a6ffbc6dfb)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ddde0285c68f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5943ffb34e94)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=537722b45400)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d01c9d8ce4bd)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a734b4b823de)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=54056c81b9b0)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 254s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 255s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 256s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 257s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 258s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 259s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 260s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [400/672] 262s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=4bcf9d260cd1)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=9930efdc12cb)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c04472c4d0c3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0dce31517abf)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d15ca5d0ddc3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5aebf71e2d5c)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0ea723ede413)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=854255bbfb52)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=cfd05cb0d8c3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4bb5243d779b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5d7f215e89d6)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c18708aaf90b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=816bf34494af)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5db04acaa9f7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=add5acd41448)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=bfbc3b887105)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=97eeffcf74db)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=b3a86268dc9d)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=885d02f77867)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=034831b1a252)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=3ea373cafa13)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=56bd7de364c9)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=6a57ae971673)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=4229aab0739e)) — reusing cached result\n",
-      "  [440/672] 279s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=b84200435329)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=fa6fc67d34bc)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=7c1ff19a3aa3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=82be70bd1fa3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=2bceb59da7ca)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=334efa82d16f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c73076afeb8d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=eb63e4d3ff1b)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=6ec9549b0b16)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=bd3b3e8144d9)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=82c6289da5e5)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=32b19c0e39bd)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=7f05331b82e9)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=b401ea819613)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=8f38fcdf0eb0)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=115523f871c2)) — reusing cached result\n",
-      "  [480/672] 305s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=59ca4125dd61)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=3df586d658b7)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b10726bef091)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=b6cfbc65639c)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=499f93dd3416)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=bb51d47dd5b3)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8e991395b28f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=c47e3ab48628)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=1a77c5dd8a5a)) — reusing cached result\n",
-      "  [520/672] 329s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=b3d2dab6f9b9)) — reusing cached result\n",
-      "  [520/672] 329s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=a2f39c7b746f)) — reusing cached result\n",
-      "  [520/672] 329s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=5f324a02e16f)) — reusing cached result\n",
-      "  [520/672] 329s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=2892c7295ff1)) — reusing cached result\n",
-      "  [520/672] 330s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=6aa964971b8a)) — reusing cached result\n",
-      "  [520/672] 330s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=38a86081b4d7)) — reusing cached result\n",
-      "  [520/672] 330s (1.6 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=c7594f5f370c)) — reusing cached result\n",
-      "  [520/672] 330s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=9c3736a29f58)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=60aab452babf)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=e386f4e870bd)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0baab098f9fc)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=159ca9bc91ee)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f2c688fd5b01)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=5d3513e90124)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a3010b3e5b6c)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=82a612fcc7b0)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=23afc755f9b8)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=4892c2be668a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=f98a8d5c5d1b)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=8a1202a35b4f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=0128f7ead861)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=a595493756fe)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ce9f0a6c6500)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 347s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 348s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 349s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 350s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 351s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 352s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 353s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [560/672] 354s (1.6 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 389s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 390s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 391s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 393s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 394s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 395s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 396s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [600/672] 397s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=40b73d304f60)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=6c24f878fb26)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=19b698bac650)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=08d726e061bc)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=e0fcd9f1ba14)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=13e4f885a5a1)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=38be45ddb50a)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=71181d46e680)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=96c5854de0d8)) — reusing cached result\n",
-      "  [640/672] 422s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=e4bfc8fb8882)) — reusing cached result\n",
-      "  [640/672] 422s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=219e05e443d4)) — reusing cached result\n",
-      "  [640/672] 422s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=32389fbcbabb)) — reusing cached result\n",
-      "  [640/672] 422s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=476900016711)) — reusing cached result\n",
-      "  [640/672] 423s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=8be8207b1ffa)) — reusing cached result\n",
-      "  [640/672] 423s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=aca35bfa3be1)) — reusing cached result\n",
-      "  [640/672] 423s (1.5 bt/s) | failed: 0\n",
-      "  SKIP backtest (complete (hash=7173a9976120)) — reusing cached result\n",
-      "  [640/672] 423s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SKIP backtest (complete (hash=df154ce3b6db)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=54836ebaf42f)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=ddb43902544d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=3a6fcf71c1ad)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=aee209c1034d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=006cd1141e6d)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=56ab9cc8d900)) — reusing cached result\n",
-      "  SKIP backtest (complete (hash=d3364cb75bff)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 441s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 442s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 443s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 444s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 445s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 446s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 447s (1.5 bt/s) | failed: 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [672/672] 448s (1.5 bt/s) | failed: 0\n",
-      "\n",
-      "Sweep complete: 672 backtests in 448s (0 failed, 0 skipped)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "results = []\n",
     "t0 = time.time()\n",
@@ -1497,25 +397,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "b0e82fa4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.698731Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.698634Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.701828Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.701455Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BacktestExplorer('etfs', 1329 runs: allocation=240, cost_sensitivity=44, risk_overlay=108, signal=937)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from case_studies.utils.backtest_explorer import BacktestExplorer\n",
     "\n",
@@ -1537,41 +422,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "41fc0cec",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.712390Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.712318Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.716924Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.716612Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (10, 5)\n",
-      "┌────────────────────────┬────────────────────────────┬──────────┬──────────┬──────────────┐\n",
-      "│ source                 ┆ signal_method              ┆ sharpe   ┆ cagr     ┆ max_drawdown │\n",
-      "│ ---                    ┆ ---                        ┆ ---      ┆ ---      ┆ ---          │\n",
-      "│ str                    ┆ str                        ┆ f64      ┆ f64      ┆ f64          │\n",
-      "╞════════════════════════╪════════════════════════════╪══════════╪══════════╪══════════════╡\n",
-      "│ benchmark/equal_weight ┆ full_universe_equal_weight ┆ 0.72343  ┆ 0.091891 ┆ -0.192609    │\n",
-      "│ tabular_dl/tabm_l      ┆ cross_sectional_percentile ┆ 0.687288 ┆ 0.093351 ┆ -0.41919     │\n",
-      "│ tabular_dl/tabm_l      ┆ cross_sectional_percentile ┆ 0.663353 ┆ 0.087866 ┆ -0.407064    │\n",
-      "│ tabular_dl/tabm_l      ┆ equal_weight_top_k         ┆ 0.663211 ┆ 0.091434 ┆ -0.396086    │\n",
-      "│ tabular_dl/tabm_l      ┆ cross_sectional_percentile ┆ 0.660968 ┆ 0.087894 ┆ -0.408286    │\n",
-      "│ deep_learning/lstm_h64 ┆ equal_weight_top_k         ┆ 0.656524 ┆ 0.067775 ┆ -0.170979    │\n",
-      "│ deep_learning/lstm_h64 ┆ equal_weight_top_k         ┆ 0.656524 ┆ 0.067775 ┆ -0.170979    │\n",
-      "│ tabular_dl/tabm_l      ┆ equal_weight_top_k         ┆ 0.65501  ┆ 0.079536 ┆ -0.401632    │\n",
-      "│ tabular_dl/tabm_l      ┆ cross_sectional_percentile ┆ 0.65501  ┆ 0.079536 ┆ -0.401632    │\n",
-      "│ deep_learning/lstm_h64 ┆ cross_sectional_percentile ┆ 0.654153 ┆ 0.067776 ┆ -0.170979    │\n",
-      "└────────────────────────┴────────────────────────────┴──────────┴──────────┴──────────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "top = explorer.best(stage=\"signal\", top_n=10)\n",
     "print(top.select(\"source\", \"signal_method\", \"sharpe\", \"cagr\", \"max_drawdown\"))"
@@ -1592,37 +446,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "8ade6fdd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.727794Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.727710Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.732969Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.732424Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (6, 6)\n",
-      "┌────────────────┬─────┬───────────────┬────────────┬────────────┬──────────────┐\n",
-      "│ family         ┆ n   ┆ sharpe_median ┆ sharpe_max ┆ sharpe_q75 ┆ pct_positive │\n",
-      "│ ---            ┆ --- ┆ ---           ┆ ---        ┆ ---        ┆ ---          │\n",
-      "│ str            ┆ u32 ┆ f64           ┆ f64        ┆ f64        ┆ f64          │\n",
-      "╞════════════════╪═════╪═══════════════╪════════════╪════════════╪══════════════╡\n",
-      "│ benchmark      ┆ 1   ┆ 0.72343       ┆ 0.72343    ┆ 0.72343    ┆ 100.0        │\n",
-      "│ latent_factors ┆ 216 ┆ 0.460904      ┆ 0.610929   ┆ 0.504029   ┆ 100.0        │\n",
-      "│ deep_learning  ┆ 38  ┆ 0.43608       ┆ 0.656524   ┆ 0.490002   ┆ 100.0        │\n",
-      "│ tabular_dl     ┆ 192 ┆ 0.404204      ┆ 0.687288   ┆ 0.482609   ┆ 100.0        │\n",
-      "│ gbm            ┆ 264 ┆ 0.355135      ┆ 0.547426   ┆ 0.415404   ┆ 100.0        │\n",
-      "│ linear         ┆ 215 ┆ 0.323738      ┆ 0.603297   ┆ 0.392497   ┆ 100.0        │\n",
-      "└────────────────┴─────┴───────────────┴────────────┴────────────┴──────────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "families = explorer.compare_families(stage=\"signal\")\n",
     "print(families)"
@@ -1630,16 +457,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "71c4bf9e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.739002Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.738926Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.819278Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.818619Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -1712,47 +532,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1e468596",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.835752Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.835657Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.851402Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.850845Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (5, 8)\n",
-      "┌─────────────┬────────┬────────────┬─────────────┬────────────┬────────────┬────────────┬─────────┐\n",
-      "│ source      ┆ sharpe ┆ psr_pvalue ┆ deflated_sh ┆ expected_m ┆ dsr_pvalue ┆ significan ┆ is_best │\n",
-      "│ ---         ┆ ---    ┆ ---        ┆ arpe        ┆ ax_sharpe  ┆ ---        ┆ t          ┆ ---     │\n",
-      "│ str         ┆ f64    ┆ f64        ┆ ---         ┆ ---        ┆ f64        ┆ ---        ┆ bool    │\n",
-      "│             ┆        ┆            ┆ f64         ┆ f64        ┆            ┆ bool       ┆         │\n",
-      "╞═════════════╪════════╪════════════╪═════════════╪════════════╪════════════╪════════════╪═════════╡\n",
-      "│ benchmark/e ┆ 3.3152 ┆ 0.0116     ┆ 0.1188      ┆ 0.09       ┆ 0.03       ┆ true       ┆ true    │\n",
-      "│ qual_weight ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ _full_un…   ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ deep_learni ┆ 0.6565 ┆ 0.0015     ┆ null        ┆ null       ┆ null       ┆ null       ┆ false   │\n",
-      "│ ng/lstm_h64 ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ _equal_w…   ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ deep_learni ┆ 0.6542 ┆ 0.0015     ┆ null        ┆ null       ┆ null       ┆ null       ┆ false   │\n",
-      "│ ng/lstm_h64 ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ _cross_s…   ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ tabular_dl/ ┆ 0.6181 ┆ 0.0013     ┆ null        ┆ null       ┆ null       ┆ null       ┆ false   │\n",
-      "│ tabm_l_equa ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ l_weight…   ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ tabular_dl/ ┆ 0.6157 ┆ 0.0024     ┆ null        ┆ null       ┆ null       ┆ null       ┆ false   │\n",
-      "│ tabm_l_cros ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "│ s_sectio…   ┆        ┆            ┆             ┆            ┆            ┆            ┆         │\n",
-      "└─────────────┴────────┴────────────┴─────────────┴────────────┴────────────┴────────────┴─────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from case_studies.utils.backtest_loaders import print_stage_dsr_summary\n",
     "\n",
@@ -1775,35 +558,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "d924cc32",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:18.862816Z",
-     "iopub.status.busy": "2026-04-28T14:49:18.862677Z",
-     "iopub.status.idle": "2026-04-28T14:49:18.867606Z",
-     "shell.execute_reply": "2026-04-28T14:49:18.867137Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Sharpe progression for best prediction (benchmark/equal_weight):\n",
-      "shape: (2, 4)\n",
-      "┌────────────┬──────────┬──────────┬──────────────┐\n",
-      "│ stage      ┆ sharpe   ┆ cagr     ┆ max_drawdown │\n",
-      "│ ---        ┆ ---      ┆ ---      ┆ ---          │\n",
-      "│ str        ┆ f64      ┆ f64      ┆ f64          │\n",
-      "╞════════════╪══════════╪══════════╪══════════════╡\n",
-      "│ signal     ┆ 0.72343  ┆ 0.091891 ┆ -0.192609    │\n",
-      "│ allocation ┆ 0.594003 ┆ 0.032936 ┆ -0.196737    │\n",
-      "└────────────┴──────────┴──────────┴──────────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if not top.is_empty():\n",
     "    best_pred = top[\"prediction_hash\"][0]\n",
@@ -1862,18 +620,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 452.812987,
-   "end_time": "2026-04-28T14:49:20.191064+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/etfs/14_backtest.ipynb",
-   "output_path": "~/scratch/ch16_19_runs/etfs_14_backtest.ipynb",
-   "parameters": {},
-   "start_time": "2026-04-28T14:41:47.378077+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/15_portfolio_management.ipynb
+++ b/case_studies/etfs/15_portfolio_management.ipynb
@@ -36,16 +36,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f85b0a47",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:21.747768Z",
-     "iopub.status.busy": "2026-04-28T14:49:21.747655Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.135447Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.134987Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"ETF Portfolio Construction: Allocator Sweep.\"\"\"\n",
@@ -72,15 +65,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "197e72f7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.141810Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.141659Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.143379Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.143087Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -95,25 +82,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0d94cf2f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.145932Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.145869Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.151122Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.150823Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Case study: etfs, label: fwd_ret_21d\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
     "bt_config = get_backtest_config(CASE_STUDY_ID)\n",
@@ -139,42 +111,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5ea462bc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.155188Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.155125Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.177422Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.177115Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Top 10 prediction sources by signal-stage Sharpe:\n",
-      "shape: (10, 2)\n",
-      "┌────────────────────────┬──────────┐\n",
-      "│ source                 ┆ sharpe   │\n",
-      "│ ---                    ┆ ---      │\n",
-      "│ str                    ┆ f64      │\n",
-      "╞════════════════════════╪══════════╡\n",
-      "│ benchmark/equal_weight ┆ 0.72343  │\n",
-      "│ tabular_dl/tabm_l      ┆ 0.687288 │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.656524 │\n",
-      "│ latent_factors/sdf     ┆ 0.610929 │\n",
-      "│ linear/enet_a0.01      ┆ 0.603297 │\n",
-      "│ latent_factors/sae     ┆ 0.5761   │\n",
-      "│ gbm/leaves_7_huber     ┆ 0.547426 │\n",
-      "│ latent_factors/cae     ┆ 0.532568 │\n",
-      "│ deep_learning/tsmixer  ┆ 0.521803 │\n",
-      "│ gbm/leaves_7_mse       ┆ 0.514759 │\n",
-      "└────────────────────────┴──────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "top_preds = resolve_best_predictions(\n",
     "    CASE_STUDY_ID,\n",
@@ -190,25 +130,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "28c75738",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.180341Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.180265Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.222347Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.221888Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prices: 470,662 rows, 100 assets\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "prices = load_backtest_prices_for(CASE_STUDY_ID, LABEL, split=\"validation\", max_symbols=MAX_SYMBOLS)\n",
     "n_assets = prices[\"symbol\"].n_unique()\n",
@@ -236,26 +161,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "16bd4eed",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.228707Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.228623Z",
-     "iopub.status.idle": "2026-04-28T14:49:23.230895Z",
-     "shell.execute_reply": "2026-04-28T14:49:23.230609Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TOP_K grid: [10, 20, 50] (universe: 100 assets)\n",
-      "Total backtests: 10 preds × 3 top_k × 6 allocs = 180\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "TOP_K_VALUES = get_top_k_values_for(CASE_STUDY_ID, LABEL, n_assets)\n",
     "print(f\"TOP_K grid: {TOP_K_VALUES} (universe: {n_assets} assets)\")\n",
@@ -271,752 +180,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "88e3817c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:49:23.233500Z",
-     "iopub.status.busy": "2026-04-28T14:49:23.233424Z",
-     "iopub.status.idle": "2026-04-28T14:52:32.548724Z",
-     "shell.execute_reply": "2026-04-28T14:52:32.548390Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "--- TOP_K = 10 ---\n",
-      "  SKIP backtest (complete (hash=57c5fb9a3221)) — reusing cached result\n",
-      "  [1/180] k=10 benchmark/equal_weight × equal_weight: Sharpe=0.588\n",
-      "  SKIP backtest (complete (hash=691ac940ee74)) — reusing cached result\n",
-      "  [2/180] k=10 benchmark/equal_weight × score_weighted: Sharpe=0.588\n",
-      "  SKIP backtest (complete (hash=f08d04e65809)) — reusing cached result\n",
-      "  [3/180] k=10 benchmark/equal_weight × inverse_vol: Sharpe=0.628\n",
-      "  SKIP backtest (complete (hash=9856f0b19db1)) — reusing cached result\n",
-      "  [4/180] k=10 benchmark/equal_weight × risk_parity: Sharpe=0.618\n",
-      "  SKIP backtest (complete (hash=475c480cbad0)) — reusing cached result\n",
-      "  [5/180] k=10 benchmark/equal_weight × mvo_ledoit_wolf: Sharpe=0.594\n",
-      "  SKIP backtest (complete (hash=301dc80f6c05)) — reusing cached result\n",
-      "  [6/180] k=10 benchmark/equal_weight × hrp: Sharpe=0.611\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [7/180] k=10 tabular_dl/tabm_l × equal_weight: Sharpe=0.575\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [8/180] k=10 tabular_dl/tabm_l × score_weighted: Sharpe=0.269\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [9/180] k=10 tabular_dl/tabm_l × inverse_vol: Sharpe=0.536\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [10/180] k=10 tabular_dl/tabm_l × risk_parity: Sharpe=0.527\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [11/180] k=10 tabular_dl/tabm_l × mvo_ledoit_wolf: Sharpe=0.564\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [12/180] k=10 tabular_dl/tabm_l × hrp: Sharpe=0.506\n",
-      "  SKIP backtest (complete (hash=1dcc42ee996d)) — reusing cached result\n",
-      "  [13/180] k=10 deep_learning/lstm_h64 × equal_weight: Sharpe=0.579\n",
-      "  SKIP backtest (complete (hash=57d9bcca8e5d)) — reusing cached result\n",
-      "  [14/180] k=10 deep_learning/lstm_h64 × score_weighted: Sharpe=0.438\n",
-      "  SKIP backtest (complete (hash=79ff48cf0caf)) — reusing cached result\n",
-      "  [15/180] k=10 deep_learning/lstm_h64 × inverse_vol: Sharpe=0.565\n",
-      "  SKIP backtest (complete (hash=553d1a9b2bbd)) — reusing cached result\n",
-      "  [16/180] k=10 deep_learning/lstm_h64 × risk_parity: Sharpe=0.569\n",
-      "  SKIP backtest (complete (hash=29d9f98ec34d)) — reusing cached result\n",
-      "  [17/180] k=10 deep_learning/lstm_h64 × mvo_ledoit_wolf: Sharpe=0.508\n",
-      "  SKIP backtest (complete (hash=0e9fde7704db)) — reusing cached result\n",
-      "  [18/180] k=10 deep_learning/lstm_h64 × hrp: Sharpe=0.560\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [19/180] k=10 latent_factors/sdf × equal_weight: Sharpe=0.611\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [20/180] k=10 latent_factors/sdf × score_weighted: Sharpe=0.574\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [21/180] k=10 latent_factors/sdf × inverse_vol: Sharpe=0.576\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [22/180] k=10 latent_factors/sdf × risk_parity: Sharpe=0.557\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [23/180] k=10 latent_factors/sdf × mvo_ledoit_wolf: Sharpe=0.557\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [24/180] k=10 latent_factors/sdf × hrp: Sharpe=0.551\n",
-      "  SKIP backtest (complete (hash=08165a8d94a9)) — reusing cached result\n",
-      "  [25/180] k=10 linear/enet_a0.01 × equal_weight: Sharpe=0.603\n",
-      "  SKIP backtest (complete (hash=282f0f46b99b)) — reusing cached result\n",
-      "  [26/180] k=10 linear/enet_a0.01 × score_weighted: Sharpe=0.505\n",
-      "  SKIP backtest (complete (hash=ca3207f16e14)) — reusing cached result\n",
-      "  [27/180] k=10 linear/enet_a0.01 × inverse_vol: Sharpe=0.647\n",
-      "  SKIP backtest (complete (hash=b14e0c5224ed)) — reusing cached result\n",
-      "  [28/180] k=10 linear/enet_a0.01 × risk_parity: Sharpe=0.644\n",
-      "  SKIP backtest (complete (hash=07d93cb70ce5)) — reusing cached result\n",
-      "  [29/180] k=10 linear/enet_a0.01 × mvo_ledoit_wolf: Sharpe=0.489\n",
-      "  SKIP backtest (complete (hash=63510e6f6af7)) — reusing cached result\n",
-      "  [30/180] k=10 linear/enet_a0.01 × hrp: Sharpe=0.667\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [31/180] k=10 latent_factors/sae × equal_weight: Sharpe=0.570\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [32/180] k=10 latent_factors/sae × score_weighted: Sharpe=0.576\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [33/180] k=10 latent_factors/sae × inverse_vol: Sharpe=0.584\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [34/180] k=10 latent_factors/sae × risk_parity: Sharpe=0.576\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [35/180] k=10 latent_factors/sae × mvo_ledoit_wolf: Sharpe=0.516\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [36/180] k=10 latent_factors/sae × hrp: Sharpe=0.573\n",
-      "  SKIP backtest (complete (hash=890fde288922)) — reusing cached result\n",
-      "  [37/180] k=10 gbm/leaves_7_huber × equal_weight: Sharpe=0.543\n",
-      "  SKIP backtest (complete (hash=b9d15eb3d156)) — reusing cached result\n",
-      "  [38/180] k=10 gbm/leaves_7_huber × score_weighted: Sharpe=0.444\n",
-      "  SKIP backtest (complete (hash=c246494f7405)) — reusing cached result\n",
-      "  [39/180] k=10 gbm/leaves_7_huber × inverse_vol: Sharpe=0.542\n",
-      "  SKIP backtest (complete (hash=8233552e8eb5)) — reusing cached result\n",
-      "  [40/180] k=10 gbm/leaves_7_huber × risk_parity: Sharpe=0.549\n",
-      "  SKIP backtest (complete (hash=222b687abb73)) — reusing cached result\n",
-      "  [41/180] k=10 gbm/leaves_7_huber × mvo_ledoit_wolf: Sharpe=0.422\n",
-      "  SKIP backtest (complete (hash=f7ebb4194157)) — reusing cached result\n",
-      "  [42/180] k=10 gbm/leaves_7_huber × hrp: Sharpe=0.502\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [43/180] k=10 latent_factors/cae × equal_weight: Sharpe=0.409\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [44/180] k=10 latent_factors/cae × score_weighted: Sharpe=0.429\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [45/180] k=10 latent_factors/cae × inverse_vol: Sharpe=0.391\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [46/180] k=10 latent_factors/cae × risk_parity: Sharpe=0.362\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [47/180] k=10 latent_factors/cae × mvo_ledoit_wolf: Sharpe=0.420\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [48/180] k=10 latent_factors/cae × hrp: Sharpe=0.295\n",
-      "  SKIP backtest (complete (hash=264ce2cfd2ec)) — reusing cached result\n",
-      "  [49/180] k=10 deep_learning/tsmixer × equal_weight: Sharpe=0.458\n",
-      "  SKIP backtest (complete (hash=4773514e0dbf)) — reusing cached result\n",
-      "  [50/180] k=10 deep_learning/tsmixer × score_weighted: Sharpe=0.256\n",
-      "  SKIP backtest (complete (hash=e05cb3e73b49)) — reusing cached result\n",
-      "  [51/180] k=10 deep_learning/tsmixer × inverse_vol: Sharpe=0.436\n",
-      "  SKIP backtest (complete (hash=d2a33860a20f)) — reusing cached result\n",
-      "  [52/180] k=10 deep_learning/tsmixer × risk_parity: Sharpe=0.428\n",
-      "  SKIP backtest (complete (hash=cd14e7356b63)) — reusing cached result\n",
-      "  [53/180] k=10 deep_learning/tsmixer × mvo_ledoit_wolf: Sharpe=0.383\n",
-      "  SKIP backtest (complete (hash=8323d01d93f8)) — reusing cached result\n",
-      "  [54/180] k=10 deep_learning/tsmixer × hrp: Sharpe=0.392\n",
-      "  SKIP backtest (complete (hash=423f50944daf)) — reusing cached result\n",
-      "  [55/180] k=10 gbm/leaves_7_mse × equal_weight: Sharpe=0.509\n",
-      "  SKIP backtest (complete (hash=2f7ea6cfdd3e)) — reusing cached result\n",
-      "  [56/180] k=10 gbm/leaves_7_mse × score_weighted: Sharpe=0.409\n",
-      "  SKIP backtest (complete (hash=d32571710078)) — reusing cached result\n",
-      "  [57/180] k=10 gbm/leaves_7_mse × inverse_vol: Sharpe=0.504\n",
-      "  SKIP backtest (complete (hash=3c07ee8e4e0c)) — reusing cached result\n",
-      "  [58/180] k=10 gbm/leaves_7_mse × risk_parity: Sharpe=0.518\n",
-      "  SKIP backtest (complete (hash=5285e9bd16f9)) — reusing cached result\n",
-      "  [59/180] k=10 gbm/leaves_7_mse × mvo_ledoit_wolf: Sharpe=0.375\n",
-      "  SKIP backtest (complete (hash=d0320ddbbafe)) — reusing cached result\n",
-      "  [60/180] k=10 gbm/leaves_7_mse × hrp: Sharpe=0.511\n",
-      "\n",
-      "--- TOP_K = 20 ---\n",
-      "  SKIP backtest (complete (hash=9bbcabeb322f)) — reusing cached result\n",
-      "  [61/180] k=20 benchmark/equal_weight × equal_weight: Sharpe=0.478\n",
-      "  SKIP backtest (complete (hash=0581c920a119)) — reusing cached result\n",
-      "  [62/180] k=20 benchmark/equal_weight × score_weighted: Sharpe=0.478\n",
-      "  SKIP backtest (complete (hash=b54642554613)) — reusing cached result\n",
-      "  [63/180] k=20 benchmark/equal_weight × inverse_vol: Sharpe=0.528\n",
-      "  SKIP backtest (complete (hash=f713b4dcb352)) — reusing cached result\n",
-      "  [64/180] k=20 benchmark/equal_weight × risk_parity: Sharpe=0.518\n",
-      "  SKIP backtest (complete (hash=9f86943d8bdb)) — reusing cached result\n",
-      "  [65/180] k=20 benchmark/equal_weight × mvo_ledoit_wolf: Sharpe=0.389\n",
-      "  SKIP backtest (complete (hash=80ddf7a347b4)) — reusing cached result\n",
-      "  [66/180] k=20 benchmark/equal_weight × hrp: Sharpe=0.509\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [67/180] k=20 tabular_dl/tabm_l × equal_weight: Sharpe=0.561\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [68/180] k=20 tabular_dl/tabm_l × score_weighted: Sharpe=0.346\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [69/180] k=20 tabular_dl/tabm_l × inverse_vol: Sharpe=0.511\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [70/180] k=20 tabular_dl/tabm_l × risk_parity: Sharpe=0.484\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [71/180] k=20 tabular_dl/tabm_l × mvo_ledoit_wolf: Sharpe=0.566\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [72/180] k=20 tabular_dl/tabm_l × hrp: Sharpe=0.465\n",
-      "  SKIP backtest (complete (hash=3371b0070646)) — reusing cached result\n",
-      "  [73/180] k=20 deep_learning/lstm_h64 × equal_weight: Sharpe=0.657\n",
-      "  SKIP backtest (complete (hash=caf089366179)) — reusing cached result\n",
-      "  [74/180] k=20 deep_learning/lstm_h64 × score_weighted: Sharpe=0.521\n",
-      "  SKIP backtest (complete (hash=f7547f65b3a8)) — reusing cached result\n",
-      "  [75/180] k=20 deep_learning/lstm_h64 × inverse_vol: Sharpe=0.685\n",
-      "  SKIP backtest (complete (hash=22867e5d12d1)) — reusing cached result\n",
-      "  [76/180] k=20 deep_learning/lstm_h64 × risk_parity: Sharpe=0.679\n",
-      "  SKIP backtest (complete (hash=6fe1dfa84a54)) — reusing cached result\n",
-      "  [77/180] k=20 deep_learning/lstm_h64 × mvo_ledoit_wolf: Sharpe=0.620\n",
-      "  SKIP backtest (complete (hash=bbc8a5618a77)) — reusing cached result\n",
-      "  [78/180] k=20 deep_learning/lstm_h64 × hrp: Sharpe=0.632\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [79/180] k=20 latent_factors/sdf × equal_weight: Sharpe=0.563\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [80/180] k=20 latent_factors/sdf × score_weighted: Sharpe=0.557\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [81/180] k=20 latent_factors/sdf × inverse_vol: Sharpe=0.566\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [82/180] k=20 latent_factors/sdf × risk_parity: Sharpe=0.549\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [83/180] k=20 latent_factors/sdf × mvo_ledoit_wolf: Sharpe=0.567\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [84/180] k=20 latent_factors/sdf × hrp: Sharpe=0.554\n",
-      "  SKIP backtest (complete (hash=e991647887a2)) — reusing cached result\n",
-      "  [85/180] k=20 linear/enet_a0.01 × equal_weight: Sharpe=0.526\n",
-      "  SKIP backtest (complete (hash=4d465632d1c2)) — reusing cached result\n",
-      "  [86/180] k=20 linear/enet_a0.01 × score_weighted: Sharpe=0.500\n",
-      "  SKIP backtest (complete (hash=dd16479ed016)) — reusing cached result\n",
-      "  [87/180] k=20 linear/enet_a0.01 × inverse_vol: Sharpe=0.539\n",
-      "  SKIP backtest (complete (hash=1759bd52a410)) — reusing cached result\n",
-      "  [88/180] k=20 linear/enet_a0.01 × risk_parity: Sharpe=0.539\n",
-      "  SKIP backtest (complete (hash=faca4261eddb)) — reusing cached result\n",
-      "  [89/180] k=20 linear/enet_a0.01 × mvo_ledoit_wolf: Sharpe=0.523\n",
-      "  SKIP backtest (complete (hash=4161ba243350)) — reusing cached result\n",
-      "  [90/180] k=20 linear/enet_a0.01 × hrp: Sharpe=0.529\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [91/180] k=20 latent_factors/sae × equal_weight: Sharpe=0.561\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [92/180] k=20 latent_factors/sae × score_weighted: Sharpe=0.559\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [93/180] k=20 latent_factors/sae × inverse_vol: Sharpe=0.563\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [94/180] k=20 latent_factors/sae × risk_parity: Sharpe=0.517\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [95/180] k=20 latent_factors/sae × mvo_ledoit_wolf: Sharpe=0.534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [96/180] k=20 latent_factors/sae × hrp: Sharpe=0.494\n",
-      "  SKIP backtest (complete (hash=661136824b80)) — reusing cached result\n",
-      "  [97/180] k=20 gbm/leaves_7_huber × equal_weight: Sharpe=0.547\n",
-      "  SKIP backtest (complete (hash=554009154dbb)) — reusing cached result\n",
-      "  [98/180] k=20 gbm/leaves_7_huber × score_weighted: Sharpe=0.509\n",
-      "  SKIP backtest (complete (hash=1bc6263fc581)) — reusing cached result\n",
-      "  [99/180] k=20 gbm/leaves_7_huber × inverse_vol: Sharpe=0.539\n",
-      "  SKIP backtest (complete (hash=371a1a9892f5)) — reusing cached result\n",
-      "  [100/180] k=20 gbm/leaves_7_huber × risk_parity: Sharpe=0.521\n",
-      "  SKIP backtest (complete (hash=3f3357f384e2)) — reusing cached result\n",
-      "  [101/180] k=20 gbm/leaves_7_huber × mvo_ledoit_wolf: Sharpe=0.479\n",
-      "  SKIP backtest (complete (hash=c94b7dab41bd)) — reusing cached result\n",
-      "  [102/180] k=20 gbm/leaves_7_huber × hrp: Sharpe=0.522\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [103/180] k=20 latent_factors/cae × equal_weight: Sharpe=0.533\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [104/180] k=20 latent_factors/cae × score_weighted: Sharpe=0.516\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [105/180] k=20 latent_factors/cae × inverse_vol: Sharpe=0.518\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [106/180] k=20 latent_factors/cae × risk_parity: Sharpe=0.527\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [107/180] k=20 latent_factors/cae × mvo_ledoit_wolf: Sharpe=0.407\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [108/180] k=20 latent_factors/cae × hrp: Sharpe=0.526\n",
-      "  SKIP backtest (complete (hash=9b5dd63a2337)) — reusing cached result\n",
-      "  [109/180] k=20 deep_learning/tsmixer × equal_weight: Sharpe=0.480\n",
-      "  SKIP backtest (complete (hash=974f6b954681)) — reusing cached result\n",
-      "  [110/180] k=20 deep_learning/tsmixer × score_weighted: Sharpe=0.363\n",
-      "  SKIP backtest (complete (hash=2785e78400f8)) — reusing cached result\n",
-      "  [111/180] k=20 deep_learning/tsmixer × inverse_vol: Sharpe=0.448\n",
-      "  SKIP backtest (complete (hash=28e3d826b97e)) — reusing cached result\n",
-      "  [112/180] k=20 deep_learning/tsmixer × risk_parity: Sharpe=0.428\n",
-      "  SKIP backtest (complete (hash=5514b91fb4ca)) — reusing cached result\n",
-      "  [113/180] k=20 deep_learning/tsmixer × mvo_ledoit_wolf: Sharpe=0.332\n",
-      "  SKIP backtest (complete (hash=7f4cba20330f)) — reusing cached result\n",
-      "  [114/180] k=20 deep_learning/tsmixer × hrp: Sharpe=0.405\n",
-      "  SKIP backtest (complete (hash=75d7bdeb328a)) — reusing cached result\n",
-      "  [115/180] k=20 gbm/leaves_7_mse × equal_weight: Sharpe=0.481\n",
-      "  SKIP backtest (complete (hash=c468a6bf6099)) — reusing cached result\n",
-      "  [116/180] k=20 gbm/leaves_7_mse × score_weighted: Sharpe=0.444\n",
-      "  SKIP backtest (complete (hash=ff9e763948eb)) — reusing cached result\n",
-      "  [117/180] k=20 gbm/leaves_7_mse × inverse_vol: Sharpe=0.509\n",
-      "  SKIP backtest (complete (hash=081f9ff270ed)) — reusing cached result\n",
-      "  [118/180] k=20 gbm/leaves_7_mse × risk_parity: Sharpe=0.502\n",
-      "  SKIP backtest (complete (hash=e2788cd0bac8)) — reusing cached result\n",
-      "  [119/180] k=20 gbm/leaves_7_mse × mvo_ledoit_wolf: Sharpe=0.441\n",
-      "  SKIP backtest (complete (hash=c018e0afc088)) — reusing cached result\n",
-      "  [120/180] k=20 gbm/leaves_7_mse × hrp: Sharpe=0.475\n",
-      "\n",
-      "--- TOP_K = 50 ---\n",
-      "  SKIP backtest (complete (hash=03ae518f546f)) — reusing cached result\n",
-      "  [121/180] k=50 benchmark/equal_weight × equal_weight: Sharpe=0.490\n",
-      "  SKIP backtest (complete (hash=2680e82f0222)) — reusing cached result\n",
-      "  [122/180] k=50 benchmark/equal_weight × score_weighted: Sharpe=0.490\n",
-      "  SKIP backtest (complete (hash=9b35dc583a4e)) — reusing cached result\n",
-      "  [123/180] k=50 benchmark/equal_weight × inverse_vol: Sharpe=0.565\n",
-      "  SKIP backtest (complete (hash=ca5c3c07fc07)) — reusing cached result\n",
-      "  [124/180] k=50 benchmark/equal_weight × risk_parity: Sharpe=0.532\n",
-      "  SKIP backtest (complete (hash=d100bbb02f94)) — reusing cached result\n",
-      "  [125/180] k=50 benchmark/equal_weight × mvo_ledoit_wolf: Sharpe=0.490\n",
-      "  SKIP backtest (complete (hash=811268293519)) — reusing cached result\n",
-      "  [126/180] k=50 benchmark/equal_weight × hrp: Sharpe=0.533\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [127/180] k=50 tabular_dl/tabm_l × equal_weight: Sharpe=0.534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [128/180] k=50 tabular_dl/tabm_l × score_weighted: Sharpe=0.451\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [129/180] k=50 tabular_dl/tabm_l × inverse_vol: Sharpe=0.483\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [130/180] k=50 tabular_dl/tabm_l × risk_parity: Sharpe=0.472\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [131/180] k=50 tabular_dl/tabm_l × mvo_ledoit_wolf: Sharpe=0.529\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [132/180] k=50 tabular_dl/tabm_l × hrp: Sharpe=0.487\n",
-      "  SKIP backtest (complete (hash=832007f072ed)) — reusing cached result\n",
-      "  [133/180] k=50 deep_learning/lstm_h64 × equal_weight: Sharpe=0.599\n",
-      "  SKIP backtest (complete (hash=e4448c401ed6)) — reusing cached result\n",
-      "  [134/180] k=50 deep_learning/lstm_h64 × score_weighted: Sharpe=0.481\n",
-      "  SKIP backtest (complete (hash=daae7797a195)) — reusing cached result\n",
-      "  [135/180] k=50 deep_learning/lstm_h64 × inverse_vol: Sharpe=0.630\n",
-      "  SKIP backtest (complete (hash=b0e670250312)) — reusing cached result\n",
-      "  [136/180] k=50 deep_learning/lstm_h64 × risk_parity: Sharpe=0.616\n",
-      "  SKIP backtest (complete (hash=f66dee24afcb)) — reusing cached result\n",
-      "  [137/180] k=50 deep_learning/lstm_h64 × mvo_ledoit_wolf: Sharpe=0.522\n",
-      "  SKIP backtest (complete (hash=916f4bdc1273)) — reusing cached result\n",
-      "  [138/180] k=50 deep_learning/lstm_h64 × hrp: Sharpe=0.588\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [139/180] k=50 latent_factors/sdf × equal_weight: Sharpe=0.522\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [140/180] k=50 latent_factors/sdf × score_weighted: Sharpe=0.561\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [141/180] k=50 latent_factors/sdf × inverse_vol: Sharpe=0.607\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [142/180] k=50 latent_factors/sdf × risk_parity: Sharpe=0.603\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [143/180] k=50 latent_factors/sdf × mvo_ledoit_wolf: Sharpe=0.570\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [144/180] k=50 latent_factors/sdf × hrp: Sharpe=0.608\n",
-      "  SKIP backtest (complete (hash=71d00a0cc269)) — reusing cached result\n",
-      "  [145/180] k=50 linear/enet_a0.01 × equal_weight: Sharpe=0.536\n",
-      "  SKIP backtest (complete (hash=e51f8be74f08)) — reusing cached result\n",
-      "  [146/180] k=50 linear/enet_a0.01 × score_weighted: Sharpe=0.528\n",
-      "  SKIP backtest (complete (hash=44397f038639)) — reusing cached result\n",
-      "  [147/180] k=50 linear/enet_a0.01 × inverse_vol: Sharpe=0.565\n",
-      "  SKIP backtest (complete (hash=ed858fbdf847)) — reusing cached result\n",
-      "  [148/180] k=50 linear/enet_a0.01 × risk_parity: Sharpe=0.541\n",
-      "  SKIP backtest (complete (hash=f93a333e0abf)) — reusing cached result\n",
-      "  [149/180] k=50 linear/enet_a0.01 × mvo_ledoit_wolf: Sharpe=0.567\n",
-      "  SKIP backtest (complete (hash=668eca9c06ea)) — reusing cached result\n",
-      "  [150/180] k=50 linear/enet_a0.01 × hrp: Sharpe=0.552\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [151/180] k=50 latent_factors/sae × equal_weight: Sharpe=0.568\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [152/180] k=50 latent_factors/sae × score_weighted: Sharpe=0.568\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [153/180] k=50 latent_factors/sae × inverse_vol: Sharpe=0.579\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [154/180] k=50 latent_factors/sae × risk_parity: Sharpe=0.544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [155/180] k=50 latent_factors/sae × mvo_ledoit_wolf: Sharpe=0.575\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [156/180] k=50 latent_factors/sae × hrp: Sharpe=0.485\n",
-      "  SKIP backtest (complete (hash=4048f0cd34c7)) — reusing cached result\n",
-      "  [157/180] k=50 gbm/leaves_7_huber × equal_weight: Sharpe=0.499\n",
-      "  SKIP backtest (complete (hash=af8b1d7f6bc3)) — reusing cached result\n",
-      "  [158/180] k=50 gbm/leaves_7_huber × score_weighted: Sharpe=0.486\n",
-      "  SKIP backtest (complete (hash=190ad1ce8b6a)) — reusing cached result\n",
-      "  [159/180] k=50 gbm/leaves_7_huber × inverse_vol: Sharpe=0.525\n",
-      "  SKIP backtest (complete (hash=642b959cee90)) — reusing cached result\n",
-      "  [160/180] k=50 gbm/leaves_7_huber × risk_parity: Sharpe=0.535\n",
-      "  SKIP backtest (complete (hash=8b49a2758f07)) — reusing cached result\n",
-      "  [161/180] k=50 gbm/leaves_7_huber × mvo_ledoit_wolf: Sharpe=0.494\n",
-      "  SKIP backtest (complete (hash=761ca6c3926e)) — reusing cached result\n",
-      "  [162/180] k=50 gbm/leaves_7_huber × hrp: Sharpe=0.530\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [163/180] k=50 latent_factors/cae × equal_weight: Sharpe=0.540\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [164/180] k=50 latent_factors/cae × score_weighted: Sharpe=0.529\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [165/180] k=50 latent_factors/cae × inverse_vol: Sharpe=0.551\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [166/180] k=50 latent_factors/cae × risk_parity: Sharpe=0.568\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [167/180] k=50 latent_factors/cae × mvo_ledoit_wolf: Sharpe=0.537\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [168/180] k=50 latent_factors/cae × hrp: Sharpe=0.595\n",
-      "  SKIP backtest (complete (hash=74107b0a6539)) — reusing cached result\n",
-      "  [169/180] k=50 deep_learning/tsmixer × equal_weight: Sharpe=0.522\n",
-      "  SKIP backtest (complete (hash=5cbecf2d06f0)) — reusing cached result\n",
-      "  [170/180] k=50 deep_learning/tsmixer × score_weighted: Sharpe=0.488\n",
-      "  SKIP backtest (complete (hash=3ee211d1971c)) — reusing cached result\n",
-      "  [171/180] k=50 deep_learning/tsmixer × inverse_vol: Sharpe=0.546\n",
-      "  SKIP backtest (complete (hash=bc1477c23fe2)) — reusing cached result\n",
-      "  [172/180] k=50 deep_learning/tsmixer × risk_parity: Sharpe=0.528\n",
-      "  SKIP backtest (complete (hash=e2949f1d6091)) — reusing cached result\n",
-      "  [173/180] k=50 deep_learning/tsmixer × mvo_ledoit_wolf: Sharpe=0.445\n",
-      "  SKIP backtest (complete (hash=046847fd5a95)) — reusing cached result\n",
-      "  [174/180] k=50 deep_learning/tsmixer × hrp: Sharpe=0.507\n",
-      "  SKIP backtest (complete (hash=883e3c72ab17)) — reusing cached result\n",
-      "  [175/180] k=50 gbm/leaves_7_mse × equal_weight: Sharpe=0.487\n",
-      "  SKIP backtest (complete (hash=5beca0232d01)) — reusing cached result\n",
-      "  [176/180] k=50 gbm/leaves_7_mse × score_weighted: Sharpe=0.459\n",
-      "  SKIP backtest (complete (hash=d6a1ce787bdd)) — reusing cached result\n",
-      "  [177/180] k=50 gbm/leaves_7_mse × inverse_vol: Sharpe=0.512\n",
-      "  SKIP backtest (complete (hash=f38e05791e33)) — reusing cached result\n",
-      "  [178/180] k=50 gbm/leaves_7_mse × risk_parity: Sharpe=0.522\n",
-      "  SKIP backtest (complete (hash=aa3f47968679)) — reusing cached result\n",
-      "  [179/180] k=50 gbm/leaves_7_mse × mvo_ledoit_wolf: Sharpe=0.496\n",
-      "  SKIP backtest (complete (hash=a811f94d0f1b)) — reusing cached result\n",
-      "  [180/180] k=50 gbm/leaves_7_mse × hrp: Sharpe=0.520\n",
-      "\n",
-      "Sweep completed in 3.2 minutes (0 failed)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "n_done = 0\n",
     "n_failed = 0\n",
@@ -1110,16 +277,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0803f868",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:52:32.558253Z",
-     "iopub.status.busy": "2026-04-28T14:52:32.558134Z",
-     "iopub.status.idle": "2026-04-28T14:52:32.560816Z",
-     "shell.execute_reply": "2026-04-28T14:52:32.560462Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from case_studies.utils.backtest_explorer import BacktestExplorer\n",
@@ -1144,36 +304,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "327283a3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:52:32.577323Z",
-     "iopub.status.busy": "2026-04-28T14:52:32.577210Z",
-     "iopub.status.idle": "2026-04-28T14:52:32.585371Z",
-     "shell.execute_reply": "2026-04-28T14:52:32.584844Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (5, 5)\n",
-      "┌─────────────────┬─────┬────────────┬─────────────┬────────────┐\n",
-      "│ allocator       ┆ n   ┆ avg_sharpe ┆ best_sharpe ┆ avg_max_dd │\n",
-      "│ ---             ┆ --- ┆ ---        ┆ ---         ┆ ---        │\n",
-      "│ str             ┆ u32 ┆ f64        ┆ f64         ┆ f64        │\n",
-      "╞═════════════════╪═════╪════════════╪═════════════╪════════════╡\n",
-      "│ inverse_vol     ┆ 57  ┆ 0.482987   ┆ 0.685162    ┆ -0.335834  │\n",
-      "│ risk_parity     ┆ 57  ┆ 0.477318   ┆ 0.678971    ┆ -0.334029  │\n",
-      "│ hrp             ┆ 57  ┆ 0.461615   ┆ 0.666526    ┆ -0.332183  │\n",
-      "│ mvo_ledoit_wolf ┆ 59  ┆ 0.456972   ┆ 0.619565    ┆ -0.350766  │\n",
-      "│ score_weighted  ┆ 57  ┆ 0.370207   ┆ 0.5761      ┆ -0.374766  │\n",
-      "└─────────────────┴─────┴────────────┴─────────────┴────────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "alloc_comparison = explorer.compare_allocators()\n",
     "print(alloc_comparison)"
@@ -1181,16 +315,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "9e87b2b6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:52:32.590893Z",
-     "iopub.status.busy": "2026-04-28T14:52:32.590792Z",
-     "iopub.status.idle": "2026-04-28T14:52:32.619568Z",
-     "shell.execute_reply": "2026-04-28T14:52:32.618764Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -1234,41 +361,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "f328dbfd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T14:52:32.636325Z",
-     "iopub.status.busy": "2026-04-28T14:52:32.636098Z",
-     "iopub.status.idle": "2026-04-28T14:52:32.642771Z",
-     "shell.execute_reply": "2026-04-28T14:52:32.642258Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (10, 4)\n",
-      "┌────────────────────────┬──────────┬──────────┬──────────────┐\n",
-      "│ source                 ┆ sharpe   ┆ cagr     ┆ max_drawdown │\n",
-      "│ ---                    ┆ ---      ┆ ---      ┆ ---          │\n",
-      "│ str                    ┆ f64      ┆ f64      ┆ f64          │\n",
-      "╞════════════════════════╪══════════╪══════════╪══════════════╡\n",
-      "│ deep_learning/lstm_h64 ┆ 0.685162 ┆ 0.06301  ┆ -0.175275    │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.678971 ┆ 0.060824 ┆ -0.177936    │\n",
-      "│ linear/enet_a0.01      ┆ 0.666526 ┆ 0.076009 ┆ -0.206288    │\n",
-      "│ linear/enet_a0.01      ┆ 0.646579 ┆ 0.073314 ┆ -0.18382     │\n",
-      "│ linear/enet_a0.01      ┆ 0.643615 ┆ 0.073323 ┆ -0.185078    │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.631602 ┆ 0.053339 ┆ -0.168794    │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.629925 ┆ 0.047447 ┆ -0.163136    │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.619565 ┆ 0.067033 ┆ -0.200959    │\n",
-      "│ deep_learning/lstm_h64 ┆ 0.615978 ┆ 0.045778 ┆ -0.169223    │\n",
-      "│ latent_factors/sdf     ┆ 0.607875 ┆ 0.037907 ┆ -0.195839    │\n",
-      "└────────────────────────┴──────────┴──────────┴──────────────┘\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "top10 = explorer.best(stage=\"allocation\", top_n=10)\n",
     "print(top10.select(\"source\", \"sharpe\", \"cagr\", \"max_drawdown\"))"
@@ -1323,18 +419,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 193.260361,
-   "end_time": "2026-04-28T14:52:34.368527+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/etfs/15_portfolio_management.ipynb",
-   "output_path": "~/scratch/ch16_19_runs/etfs_15_portfolio_management.ipynb",
-   "parameters": {},
-   "start_time": "2026-04-28T14:49:21.108166+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/11_causal_dml.ipynb
+++ b/case_studies/fx_pairs/11_causal_dml.ipynb
@@ -37,23 +37,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "195730de",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T22:13:25.107745Z",
-     "iopub.status.busy": "2026-08-21T22:13:25.107331Z",
-     "iopub.status.idle": "2026-08-21T22:13:26.553258Z",
-     "shell.execute_reply": "2026-08-21T22:13:26.552677Z"
-    },
-    "papermill": {
-     "duration": 1.452429,
-     "end_time": "2026-08-21T22:13:26.554093+00:00",
-     "exception": false,
-     "start_time": "2026-08-21T22:13:25.101664+00:00",
-     "status": "completed"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Estimate and register the configured FX causal DML specification.\"\"\"\n",
@@ -61,29 +47,16 @@
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import ExecutionTier, Study\n",
+    "from case_studies.research import ExecutionTier, Study, supersedes_for\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6eadebf1",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T22:13:26.557063Z",
-     "iopub.status.busy": "2026-08-21T22:13:26.556898Z",
-     "iopub.status.idle": "2026-08-21T22:13:26.558709Z",
-     "shell.execute_reply": "2026-08-21T22:13:26.558403Z"
-    },
-    "papermill": {
-     "duration": 0.004094,
-     "end_time": "2026-08-21T22:13:26.559034+00:00",
-     "exception": false,
-     "start_time": "2026-08-21T22:13:26.554940+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -97,7 +70,8 @@
     "CV_FOLDS = 0\n",
     "MAX_SAMPLES = 0\n",
     "N_PLACEBO = 0\n",
-    "FORCE_RETRAIN = False"
+    "FORCE_RETRAIN = False\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
@@ -121,38 +95,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "1a9b2c2c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T22:13:26.561953Z",
-     "iopub.status.busy": "2026-08-21T22:13:26.561890Z",
-     "iopub.status.idle": "2026-08-21T22:13:29.735749Z",
-     "shell.execute_reply": "2026-08-21T22:13:29.735394Z"
-    },
-    "papermill": {
-     "duration": 3.175487,
-     "end_time": "2026-08-21T22:13:29.736216+00:00",
-     "exception": false,
-     "start_time": "2026-08-21T22:13:26.560729+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Labels: fwd_ret_1d, fwd_ret_5d, fwd_ret_21d\n",
-      "Treatment: mom_skip_recent\n",
-      "Confounders: vol_gk_21d, vol_gk_63d, zscore_21d\n",
-      "Execution tier: canonical\n",
-      "  fwd_ret_1d: outcome horizon 1 days 00:00:00, last admissible endpoint 2023-12-31T00:00:00+00:00\n",
-      "  fwd_ret_5d: outcome horizon 5 days 00:00:00, last admissible endpoint 2023-12-27T00:00:00+00:00\n",
-      "  fwd_ret_21d: outcome horizon 21 days 00:00:00, last admissible endpoint 2023-12-11T00:00:00+00:00\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "set_global_seeds(RANDOM_SEED)\n",
     "case_dir = get_case_study_dir(CASE_STUDY_ID)\n",
@@ -182,6 +128,7 @@
     "        execution_tier=tier,\n",
     "        preview_reductions=reductions,\n",
     "        overrides={},\n",
+    "        supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=list(labels)),\n",
     "    )\n",
     "    for label in labels\n",
     "}\n",
@@ -223,62 +170,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "1818f82c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T22:13:29.740889Z",
-     "iopub.status.busy": "2026-08-21T22:13:29.740790Z",
-     "iopub.status.idle": "2026-08-21T22:13:29.745426Z",
-     "shell.execute_reply": "2026-08-21T22:13:29.745095Z"
-    },
-    "papermill": {
-     "duration": 0.005979,
-     "end_time": "2026-08-21T22:13:29.745701+00:00",
-     "exception": false,
-     "start_time": "2026-08-21T22:13:29.739722+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>cross_fitting_folds</th><th>embargo_periods</th><th>fold_unit</th><th>placebo_method</th><th>placebo_block_size</th><th>analysis_rows</th><th>analysis_timestamps</th><th>analysis_key_digest</th></tr><tr><td>str</td><td>i64</td><td>i64</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>1</td><td>&quot;complete_timestamp_panel&quot;</td><td>&quot;within_symbol_contiguous_block…</td><td>1</td><td>59560</td><td>2978</td><td>&quot;df4c721cbb1520aa&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>5</td><td>5</td><td>&quot;complete_timestamp_panel&quot;</td><td>&quot;within_symbol_contiguous_block…</td><td>5</td><td>59500</td><td>2975</td><td>&quot;d34db595e46c335e&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>5</td><td>21</td><td>&quot;complete_timestamp_panel&quot;</td><td>&quot;within_symbol_contiguous_block…</td><td>21</td><td>59280</td><td>2964</td><td>&quot;b8bfa85cb38e90d0&quot;</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (3, 9)\n",
-       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
-       "│ label     ┆ cross_fit ┆ embargo_p ┆ fold_unit ┆ … ┆ placebo_b ┆ analysis_ ┆ analysis_ ┆ analysis │\n",
-       "│ ---       ┆ ting_fold ┆ eriods    ┆ ---       ┆   ┆ lock_size ┆ rows      ┆ timestamp ┆ _key_dig │\n",
-       "│ str       ┆ s         ┆ ---       ┆ str       ┆   ┆ ---       ┆ ---       ┆ s         ┆ est      │\n",
-       "│           ┆ ---       ┆ i64       ┆           ┆   ┆ i64       ┆ i64       ┆ ---       ┆ ---      │\n",
-       "│           ┆ i64       ┆           ┆           ┆   ┆           ┆           ┆ i64       ┆ str      │\n",
-       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ fwd_ret_1 ┆ 5         ┆ 1         ┆ complete_ ┆ … ┆ 1         ┆ 59560     ┆ 2978      ┆ df4c721c │\n",
-       "│ d         ┆           ┆           ┆ timestamp ┆   ┆           ┆           ┆           ┆ bb1520aa │\n",
-       "│           ┆           ┆           ┆ _panel    ┆   ┆           ┆           ┆           ┆          │\n",
-       "│ fwd_ret_5 ┆ 5         ┆ 5         ┆ complete_ ┆ … ┆ 5         ┆ 59500     ┆ 2975      ┆ d34db595 │\n",
-       "│ d         ┆           ┆           ┆ timestamp ┆   ┆           ┆           ┆           ┆ e46c335e │\n",
-       "│           ┆           ┆           ┆ _panel    ┆   ┆           ┆           ┆           ┆          │\n",
-       "│ fwd_ret_2 ┆ 5         ┆ 21        ┆ complete_ ┆ … ┆ 21        ┆ 59280     ┆ 2964      ┆ b8bfa85c │\n",
-       "│ 1d        ┆           ┆           ┆ timestamp ┆   ┆           ┆           ┆           ┆ b38e90d0 │\n",
-       "│           ┆           ┆           ┆ _panel    ┆   ┆           ┆           ┆           ┆          │\n",
-       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pl.DataFrame(\n",
     "    {\n",
@@ -320,38 +215,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "e294bb1d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-21T22:13:29.748668Z",
-     "iopub.status.busy": "2026-08-21T22:13:29.748599Z",
-     "iopub.status.idle": "2026-08-21T22:18:56.352905Z",
-     "shell.execute_reply": "2026-08-21T22:18:56.352583Z"
-    },
-    "papermill": {
-     "duration": 326.605999,
-     "end_time": "2026-08-21T22:18:56.353631+00:00",
-     "exception": false,
-     "start_time": "2026-08-21T22:13:29.747632+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Registered causal identity, fwd_ret_1d: 6e17a9b4644c\n",
-      "Registered causal identity, fwd_ret_5d: e9623aa44d9a\n",
-      "Registered causal identity, fwd_ret_21d: f53540351b6b\n",
-      "Effect estimates and their interpretation are reported in 12_model_analysis.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results = {}\n",
     "for label, resolved in resolutions.items():\n",
@@ -418,25 +289,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-08-21T22:19:03.282272+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "c5b1ebaf5b1bee551d72e6131c97ceed5f464cbf"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 334.206473,
-   "end_time": "2026-08-21T22:18:58.649147+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/11_causal_dml.ipynb",
-   "output_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/11_causal_dml.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-21T22:13:24.442674+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/11_causal_dml.py
+++ b/case_studies/fx_pairs/11_causal_dml.py
@@ -41,7 +41,7 @@
 import polars as pl
 import yaml
 
-from case_studies.research import ExecutionTier, Study
+from case_studies.research import ExecutionTier, Study, supersedes_for
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
 
@@ -54,6 +54,7 @@ CV_FOLDS = 0
 MAX_SAMPLES = 0
 N_PLACEBO = 0
 FORCE_RETRAIN = False
+SUPERSEDES_CAUSAL: str = ""
 
 # %% [markdown]
 # ## Resolve the estimand and analysis population
@@ -90,6 +91,7 @@ requests = {
         execution_tier=tier,
         preview_reductions=reductions,
         overrides={},
+        supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=list(labels)),
     )
     for label in labels
 }

--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -1,6 +1,6 @@
 from .adapters import AdapterBinding, get_adapter, register_adapter, registered_adapters
 from .catalog import BacktestCatalog, PredictionCatalog
-from .causal import CausalRequest, CausalResult, ResolvedCausalRequest
+from .causal import CausalRequest, CausalResult, ResolvedCausalRequest, supersedes_for
 from .comparison import CandidateSet
 from .configs import (
     declared_labels,
@@ -48,6 +48,7 @@ from .strategy import Strategy
 from .workspace import Study, open_study
 
 __all__ = [
+    "supersedes_for",
     "AdapterBinding",
     "BacktestResult",
     "BacktestCatalog",

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -261,3 +261,52 @@ class CausalRequest:
 
     def run(self) -> CausalResult:
         return self.resolve().run()
+
+
+def supersedes_for(
+    declaration: str | None, label: str, *, labels: list[str] | None = None
+) -> str | None:
+    """Read one label's superseded causal identity out of a notebook parameter.
+
+    A refit produces a second canonical identity for the same label and
+    ``CausalResult.one`` resolves a label to exactly one, so the run has to say which
+    identity it retires. Papermill passes parameters as strings, so the declaration is
+    one of three things: empty, meaning nothing is being retired and the fit must leave
+    a single current identity on its own; a bare causal hash, for a notebook that fits
+    one label; or a JSON object mapping label to hash, for one that fits several.
+
+    A hash declared for a label the notebook does not fit is a typo rather than a
+    no-op - the run would proceed, retire nothing, and fail at registration - so it
+    raises here, before the fit is paid for.
+    """
+    text = (declaration or "").strip()
+    if not text:
+        return None
+    if text.startswith("{"):
+        try:
+            mapping = json.loads(text)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"SUPERSEDES_CAUSAL is not valid JSON: {text!r}. Give a bare causal hash "
+                f'for a single-label notebook, or {{"<label>": "<hash>"}} for several.'
+            ) from error
+        if not isinstance(mapping, dict):
+            raise ValueError(
+                f"SUPERSEDES_CAUSAL must be an object mapping label to hash, got {text!r}"
+            )
+        known = set(labels) if labels is not None else None
+        if known is not None:
+            unknown = sorted(set(mapping) - known)
+            if unknown:
+                raise ValueError(
+                    f"SUPERSEDES_CAUSAL names {unknown}, which this notebook does not fit. "
+                    f"It fits {sorted(known)}."
+                )
+        value = mapping.get(label)
+        return str(value) if value else None
+    if labels is not None and len(labels) > 1:
+        raise ValueError(
+            f"SUPERSEDES_CAUSAL is a bare hash but this notebook fits {sorted(labels)}. "
+            f'Use {{"<label>": "<hash>"}} so each label retires its own identity.'
+        )
+    return text

--- a/case_studies/us_equities_panel/14_causal_dml.ipynb
+++ b/case_studies/us_equities_panel/14_causal_dml.ipynb
@@ -43,7 +43,7 @@
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import Study, open_study\n",
+    "from case_studies.research import Study, open_study, supersedes_for\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import REPO_ROOT, get_case_study_dir"
    ]
@@ -87,7 +87,8 @@
     "MAX_SYMBOLS = 0\n",
     "PREVIEW_MAX_SAMPLES = 0\n",
     "PREVIEW_N_FOLDS = 0\n",
-    "PREVIEW_N_PLACEBO = 0"
+    "PREVIEW_N_PLACEBO = 0\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
@@ -108,16 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "302f5a01",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-02T19:17:49.611586Z",
-     "iopub.status.busy": "2026-05-02T19:17:49.611426Z",
-     "iopub.status.idle": "2026-05-02T19:17:51.658754Z",
-     "shell.execute_reply": "2026-05-02T19:17:51.658221Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "case_dir = get_case_study_dir(CASE_STUDY_ID)\n",
@@ -150,16 +144,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "31c1b021",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-02T19:17:51.663338Z",
-     "iopub.status.busy": "2026-05-02T19:17:51.663252Z",
-     "iopub.status.idle": "2026-05-02T19:17:51.664891Z",
-     "shell.execute_reply": "2026-05-02T19:17:51.664638Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
@@ -201,6 +188,7 @@
     "    overrides={\"nuisance_params\": dict(NUISANCE_OVERRIDES)} if NUISANCE_OVERRIDES else {},\n",
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=preview_reductions,\n",
+    "    supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=[label]),\n",
     ")\n",
     "resolved = request.resolve()"
    ]
@@ -271,32 +259,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "359317d9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-02T19:17:51.669898Z",
-     "iopub.status.busy": "2026-05-02T19:17:51.669832Z",
-     "iopub.status.idle": "2026-05-02T19:17:51.677828Z",
-     "shell.execute_reply": "2026-05-02T19:17:51.677531Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DML config: dml\n",
-      "Causal DML Configuration:\n",
-      "  Case study: us_equities_panel\n",
-      "  Treatment: past_ret_12m_skip\n",
-      "  Outcome: fwd_ret_1d\n",
-      "  Confounders: ['vol_21d', 'amihud_illiq', 'volume_ratio']\n",
-      "  CV folds: 5\n",
-      "  Placebo reps: 100\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "result = resolved.run()\n",
     "if not result.complete:\n",
@@ -386,18 +352,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 29.142943,
-   "end_time": "2026-05-02T19:18:18.106177+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/14_causal_dml.ipynb",
-   "output_path": "case_studies/us_equities_panel/14_causal_dml.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-02T19:17:48.963234+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/14_causal_dml.py
+++ b/case_studies/us_equities_panel/14_causal_dml.py
@@ -45,7 +45,7 @@ from pathlib import Path
 import polars as pl
 import yaml
 
-from case_studies.research import Study, open_study
+from case_studies.research import Study, open_study, supersedes_for
 from utils.modeling import load_configs
 from utils.paths import REPO_ROOT, get_case_study_dir
 
@@ -74,6 +74,7 @@ MAX_SYMBOLS = 0
 PREVIEW_MAX_SAMPLES = 0
 PREVIEW_N_FOLDS = 0
 PREVIEW_N_PLACEBO = 0
+SUPERSEDES_CAUSAL: str = ""
 
 # %% [markdown]
 # ## Configure the estimand and execution
@@ -154,6 +155,7 @@ request = study.causal(
     overrides={"nuisance_params": dict(NUISANCE_OVERRIDES)} if NUISANCE_OVERRIDES else {},
     execution_tier=EXECUTION_TIER,
     preview_reductions=preview_reductions,
+    supersedes=supersedes_for(SUPERSEDES_CAUSAL, label, labels=[label]),
 )
 resolved = request.resolve()
 

--- a/case_studies/utils/insight_chapter.py
+++ b/case_studies/utils/insight_chapter.py
@@ -352,7 +352,17 @@ def conformal_coverage_for_selected_prediction(
 
     spec = json.loads(selected["spec_json"])
     computation = spec.get("computation") or {}
-    n_folds = int((computation.get("expected_prediction_keys") or {}).get("n_folds", 0))
+    # Two spec shapes are live. Identity v3 nests the fold count under
+    # `computation.expected_prediction_keys`; the v2 shape that `build_training_spec`
+    # still emits - `run_dl_cv` uses it, and LEGACY_IDENTITY_VERSION is still supported -
+    # carries `n_folds` at the top level and has no `computation` key at all. Reading only
+    # the v3 location answered 0 for every v2 row and raised "requires at least two
+    # declared folds" against a row declaring five.
+    n_folds = int(
+        (computation.get("expected_prediction_keys") or {}).get("n_folds")
+        or spec.get("n_folds")
+        or 0
+    )
     if n_folds < 2:
         raise RegistrySelectionError(
             f"{selected['case_study']}/{selected['prediction_hash']}: "

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1728,12 +1728,20 @@ def declare_causal_supersedes(
         case_dir = _case_dir(case_study)
     db = _open_registry(case_dir)
     try:
-        stored = (
-            db.execute(
-                "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
-            ).fetchone()
-            or (None,)
-        )[0]
+        row = db.execute(
+            "SELECT supersedes_hash FROM causal_runs WHERE causal_hash = ?", (causal_hash,)
+        ).fetchone()
+        # This is the one function an author calls by hand, typing a hash copied out of
+        # the `CausalResult.one` error text. Without this check a truncated or mistyped
+        # hash makes the UPDATE below match zero rows, commit, and return None - so the
+        # repair reports success and the label still resolves to two identities.
+        if row is None:
+            raise ValueError(
+                f"no causal run {causal_hash!r} in {case_study}'s registry, so there is "
+                f"nothing to declare a predecessor for. Check the hash against "
+                f"`SELECT causal_hash FROM causal_runs WHERE label = '{label}'`."
+            )
+        stored = row[0]
         if stored is not None:
             if stored != supersedes_hash:
                 raise ValueError(
@@ -1800,6 +1808,16 @@ def _enforce_causal_supersedes(
         # by this row's own edge, so it is no longer in the current set and reads as
         # "not a current identity ... Current: none".
         return
+    if stored is not None and supersedes_hash is not None:
+        # One column holds one edge, so a row cannot retire two identities. The INSERT
+        # this guards uses COALESCE, which keeps the stored value and drops the new one
+        # in silence; declare_causal_supersedes refuses the same case. Both paths answer
+        # the same question and must answer it the same way, or which one an author
+        # happened to call decides whether a contradiction is reported.
+        raise ValueError(
+            f"causal run {causal_hash} already declares it supersedes {stored}; "
+            f"it cannot also supersede {supersedes_hash}"
+        )
     if causal_hash in causal_identities_retired(db, label=label):
         # Reproducing a retired identity is a no-op, but the declaration it carries is
         # not exempt from being checked. An author reproducing A from an older checkout

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1236,7 +1236,7 @@ case_studies/cme_futures/11_causal_dml:
       max_samples: 5000
       max_symbols: 5
       n_folds: 2
-      n_placebo: 15
+      n_placebo: 25
   timeout: 300
 case_studies/cme_futures/12_model_analysis:
   timeout: 300
@@ -1324,7 +1324,7 @@ case_studies/crypto_perps_funding/11_causal_dml:
       max_samples: 5000
       max_symbols: 5
       n_folds: 2
-      n_placebo: 15
+      n_placebo: 25
   timeout: 300
 case_studies/crypto_perps_funding/12_model_analysis:
   timeout: 300
@@ -1448,7 +1448,7 @@ case_studies/etfs/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 3000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/etfs/13_model_analysis:
   timeout: 300
@@ -1521,7 +1521,7 @@ case_studies/fx_pairs/11_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/fx_pairs/12_model_analysis:
   timeout: 300
@@ -1624,7 +1624,7 @@ case_studies/nasdaq100_microstructure/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 900
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/nasdaq100_microstructure/13_model_analysis:
   timeout: 300
@@ -1754,7 +1754,7 @@ case_studies/sp500_equity_option_analytics/12_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 3000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/sp500_equity_option_analytics/13_model_analysis:
   timeout: 300
@@ -1849,7 +1849,7 @@ case_studies/sp500_options/10_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/sp500_options/11_model_analysis:
   timeout: 300
@@ -2026,7 +2026,7 @@ case_studies/us_equities_panel/14_causal_dml:
     MAX_SYMBOLS: 5
     PREVIEW_N_FOLDS: 2
     PREVIEW_MAX_SAMPLES: 5000
-    PREVIEW_N_PLACEBO: 15
+    PREVIEW_N_PLACEBO: 25
   timeout: 120
 case_studies/us_equities_panel/15_model_analysis:
   # 15 declares EXECUTION_TIER and WORKSPACE, so research_preview_parameters routes it to the
@@ -2176,7 +2176,7 @@ case_studies/us_firm_characteristics/09_causal_dml:
     CV_FOLDS: 2
     MAX_SAMPLES: 5000
     MAX_SYMBOLS: 5
-    N_PLACEBO: 15
+    N_PLACEBO: 25
   timeout: 120
 case_studies/us_firm_characteristics/10_model_analysis:
   timeout: 300

--- a/tests/test_causal_refutation_pvalue.py
+++ b/tests/test_causal_refutation_pvalue.py
@@ -156,6 +156,8 @@ def test_every_declared_test_reduction_can_produce_a_refutation() -> None:
     Pinning the constant alone would leave `tests/overrides.yaml` free to drift back
     onto the boundary, which is exactly how it got there.
     """
+    import math
+
     import yaml
 
     from case_studies.utils.causal import (
@@ -195,4 +197,20 @@ def test_every_declared_test_reduction_can_produce_a_refutation() -> None:
         "then produces no refutation at all, silently - and a notebook reading the "
         f"p-value with a default publishes a number no test computed. Ask for at least "
         f"{MIN_PLACEBO_DRAWS + PLACEBO_REQUEST_MARGIN}, or 0 to declare no refutation."
+    )
+
+    # Above the boundary the refutation is computed; that is a lower bar than being able
+    # to answer. The plus-one correction floors the empirical p at 1/(n+1), so a verdict
+    # below alpha needs ceil(1/alpha) successful draws - twenty at alpha = 0.05, and
+    # classify_refutation returns "Underpowered" for anything less whatever the data
+    # showed. Nine declarations sat at 5, 10 and 15 and none of them could ever have
+    # passed. The margin is the same one: one draw may fail without taking the verdict.
+    answerable = math.ceil(1.0 / REFUTATION_ALPHA)
+    unanswerable = [value for value in declared if 0 < value < answerable + PLACEBO_REQUEST_MARGIN]
+    assert not unanswerable, (
+        f"these declared reductions request {unanswerable} placebo draws. The smallest "
+        f"p-value attainable at n draws is 1/(n+1), so below {answerable} the refutation "
+        f"cannot reach alpha = {REFUTATION_ALPHA} and the verdict is 'Underpowered' by "
+        f"construction - the draws are paid for and answer nothing. Ask for at least "
+        f"{answerable + PLACEBO_REQUEST_MARGIN}, or 0 to declare no refutation."
     )

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -425,3 +425,48 @@ def test_a_new_fit_into_a_broken_registry_is_still_refused(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="would still be current"):
         _register(case_dir, "causal_new", effect=-0.05, supersedes="causal_a")
+
+
+def test_declaring_a_predecessor_for_a_hash_no_row_carries_is_refused(tmp_path) -> None:
+    """The repair is typed by hand from an error message, so a typo must not report success.
+
+    `_enforce_causal_supersedes` validates the predecessor against the current set and
+    never that `causal_hash` itself exists, so before this check the UPDATE matched zero
+    rows, committed, and returned None - the author saw success and the label still
+    resolved to two identities.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+
+    with pytest.raises(ValueError, match="nothing to declare a predecessor for"):
+        declare_causal_supersedes(
+            "test_case",
+            "deadbeefdeadbeef",  # no row carries this
+            supersedes_hash="causal_first",
+            label=LABEL,
+            case_dir=case_dir,
+        )
+
+    # And the registry is untouched: the refusal happens before the UPDATE.
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        stored = db.execute("SELECT causal_hash, supersedes_hash FROM causal_runs").fetchall()
+    assert stored == [("causal_first", None)]
+
+
+def test_a_conflicting_declaration_is_refused_on_the_register_path_too(tmp_path) -> None:
+    """One column holds one edge, so both paths must answer a contradiction the same way.
+
+    The INSERT uses COALESCE, which keeps the stored value and drops the new one without
+    a word, while `declare_causal_supersedes` raises for the same case. Which function
+    the author happened to call decided whether the contradiction was reported.
+    """
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, "causal_first")
+    _register(case_dir, "causal_second", supersedes="causal_first")
+
+    with pytest.raises(ValueError, match="cannot also supersede"):
+        _register(case_dir, "causal_second", supersedes="causal_other")
+
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        stored = dict(db.execute("SELECT causal_hash, supersedes_hash FROM causal_runs"))
+    assert stored == {"causal_first": None, "causal_second": "causal_first"}

--- a/tests/test_insight_chapter.py
+++ b/tests/test_insight_chapter.py
@@ -166,3 +166,65 @@ def test_selected_prediction_conformal_coverage_rejects_non_finite_rows(
             },
             levels=(0.80,),
         )
+
+
+def test_selected_prediction_conformal_coverage_reads_the_legacy_spec_shape(
+    tmp_path, monkeypatch
+) -> None:
+    """Two spec shapes are live, and the older one is still written.
+
+    `build_training_spec` puts `n_folds` at the top level and emits no `computation`
+    key at all; `run_dl_cv` still uses it and LEGACY_IDENTITY_VERSION is still
+    supported. Reading only the identity-v3 location answered 0 for every such row, so
+    a row declaring five folds raised "requires at least two declared folds" and
+    12_case_study_insights, which tolerates only "fewer than 30 rows", aborted the
+    chapter rather than degrading.
+    """
+    case_dir = tmp_path / "case_studies" / "probe"
+    prediction_dir = case_dir / "run_log" / "predictions" / "prediction-legacy"
+    prediction_dir.mkdir(parents=True)
+    calibration = [0.1] * 33 + [5.0] * 7
+    evaluation = [1.0] * 40
+    pl.DataFrame(
+        {
+            "timestamp": ["2019-01-02"] * 40 + ["2020-01-02"] * 40,
+            "y_true": calibration + evaluation,
+            "y_score": [0.0] * 80,
+            "fold_id": [1] * 40 + [0] * 40,
+        }
+    ).write_parquet(prediction_dir / "predictions.parquet")
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    legacy = insight_chapter.conformal_coverage_for_selected_prediction(
+        {
+            "case_study": "probe",
+            "family": "deep_learning",
+            "config_name": "probe-config",
+            "prediction_hash": "prediction-legacy",
+            "spec_json": json.dumps({"family": "deep_learning", "n_folds": 2}),
+        },
+        levels=(0.80,),
+    )
+
+    assert legacy["empirical_coverage"].to_list() == [0.0]
+
+
+def test_selected_prediction_conformal_coverage_still_rejects_a_single_fold(
+    tmp_path, monkeypatch
+) -> None:
+    """The fallback must not turn the real one-fold refusal into a pass."""
+    case_dir = tmp_path / "case_studies" / "probe"
+    (case_dir / "run_log" / "predictions" / "prediction-one").mkdir(parents=True)
+    monkeypatch.setattr(insight_chapter, "get_case_study_dir", lambda _case_study: case_dir)
+
+    with pytest.raises(insight_chapter.RegistrySelectionError, match="at least two declared folds"):
+        insight_chapter.conformal_coverage_for_selected_prediction(
+            {
+                "case_study": "probe",
+                "family": "deep_learning",
+                "config_name": "probe-config",
+                "prediction_hash": "prediction-one",
+                "spec_json": json.dumps({"family": "deep_learning", "n_folds": 1}),
+            },
+            levels=(0.80,),
+        )

--- a/tests/test_supersedes_declaration.py
+++ b/tests/test_supersedes_declaration.py
@@ -1,0 +1,98 @@
+"""The notebook parameter that says which causal identity a refit retires.
+
+`_enforce_causal_supersedes` refuses to register a second current identity for a
+label, and refuses at write time - after the DML fit and every placebo refit have
+been paid for. The only way a notebook can satisfy that refusal is to declare the
+predecessor, so the parameter has to exist, reach the request, and reject a
+declaration that names nothing the notebook fits before the fit starts.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from case_studies.research import supersedes_for
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Every notebook that opens a causal request. A notebook here without the parameter
+# cannot answer the write-time refusal and would lose its fit to it.
+CAUSAL_NOTEBOOKS = [
+    "case_studies/cme_futures/11_causal_dml.py",
+    "case_studies/crypto_perps_funding/11_causal_dml.py",
+    "case_studies/fx_pairs/11_causal_dml.py",
+    "case_studies/us_equities_panel/14_causal_dml.py",
+]
+
+
+class TestTheDeclarationParser:
+    def test_an_empty_declaration_retires_nothing(self) -> None:
+        assert supersedes_for("", "fwd_ret_5d") is None
+        assert supersedes_for(None, "fwd_ret_5d") is None
+        assert supersedes_for("   ", "fwd_ret_5d") is None
+
+    def test_a_bare_hash_is_the_single_label_form(self) -> None:
+        assert supersedes_for("ab12cd34", "fwd_ret_5d", labels=["fwd_ret_5d"]) == "ab12cd34"
+
+    def test_a_bare_hash_is_refused_when_the_notebook_fits_several(self) -> None:
+        # One hash cannot say which of three identities is being retired, and guessing
+        # would retire the wrong one.
+        with pytest.raises(ValueError, match="bare hash"):
+            supersedes_for("ab12cd34", "a", labels=["a", "b", "c"])
+
+    def test_a_mapping_selects_this_label(self) -> None:
+        text = '{"a": "hash_a", "b": "hash_b"}'
+        assert supersedes_for(text, "a", labels=["a", "b"]) == "hash_a"
+        assert supersedes_for(text, "b", labels=["a", "b"]) == "hash_b"
+
+    def test_a_label_absent_from_the_mapping_retires_nothing(self) -> None:
+        assert supersedes_for('{"a": "hash_a"}', "b", labels=["a", "b"]) is None
+
+    def test_a_label_the_notebook_does_not_fit_is_a_typo_not_a_no_op(self) -> None:
+        # Silently ignoring it means the run pays for the fit and then fails at
+        # registration for the identity it meant to retire.
+        with pytest.raises(ValueError, match="does not fit"):
+            supersedes_for('{"typo": "hash"}', "a", labels=["a", "b"])
+
+    def test_malformed_json_names_itself(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            supersedes_for('{"a": ', "a", labels=["a"])
+
+
+@pytest.mark.parametrize("path", CAUSAL_NOTEBOOKS)
+def test_the_notebook_declares_the_parameter(path: str) -> None:
+    source = (REPO / path).read_text()
+    assert "SUPERSEDES_CAUSAL" in source, f"{path} cannot answer the write-time refusal"
+
+
+@pytest.mark.parametrize("path", CAUSAL_NOTEBOOKS)
+def test_the_parameter_reaches_the_request(path: str) -> None:
+    """Declaring it and not passing it is the same as not declaring it."""
+    source = (REPO / path).read_text()
+    tree = ast.parse(source)
+    passed = [
+        keyword
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "causal"
+        for keyword in node.keywords
+        if keyword.arg == "supersedes"
+    ]
+    assert passed, f"{path} declares SUPERSEDES_CAUSAL but no study.causal() call takes it"
+
+
+@pytest.mark.parametrize("path", CAUSAL_NOTEBOOKS)
+def test_the_parameter_is_in_the_parameters_cell(path: str) -> None:
+    """Papermill only overrides names in the tagged cell; elsewhere it is a constant."""
+    source = (REPO / path).read_text()
+    cells = source.split("\n# %%")
+    tagged = [cell for cell in cells if cell.startswith(' tags=["parameters"]')]
+    assert tagged, f"{path} has no parameters cell"
+    assert any("SUPERSEDES_CAUSAL" in cell for cell in tagged), (
+        f"{path} declares SUPERSEDES_CAUSAL outside the parameters cell, so papermill "
+        "cannot set it and the declaration can never be supplied"
+    )


### PR DESCRIPTION
#609 made a second canonical causal identity refuse at the write instead of at the read, and told the author to "set SUPERSEDES_CAUSAL". No notebook had that parameter. The refusal fires after the DML fit and every placebo refit are paid for, and #609 also edits `case_studies/utils/causal.py`, which is hashed into every causal identity - so the next canonical run of any of the four causal notebooks would compute a new identity, run the fit, and throw the result away with no route to satisfy the message. The pre-push review flagged it on three separate branches before this landed.

The four notebooks now declare `SUPERSEDES_CAUSAL` in their parameters cell and pass it to `study.causal()`. Two of them fit several labels and one hash cannot say which identity is retired, so the declaration is either empty, a bare hash for a single-label notebook, or a JSON object mapping label to hash. `supersedes_for()` in `case_studies/research/causal.py` parses it - that module is the reader and is in no identity, so wiring this moves no hash. A hash naming a label the notebook does not fit raises before the fit rather than being ignored.

Three defects found in the same review:

- `declare_causal_supersedes` succeeded silently when its `causal_hash` named no row. It is the one function typed by hand, from a hash copied out of the `CausalResult.one` error text, and the UPDATE matched zero rows, committed and returned `None` - so a truncated hash reported success and left the label still resolving to two identities.
- `_enforce_causal_supersedes` dropped a conflicting declaration in silence where `declare_causal_supersedes` refuses it. The INSERT uses `COALESCE`, so re-registering a row that already retires X while declaring Y kept X and discarded Y. Both paths now answer the same way.
- `conformal_coverage_for_selected_prediction` read the fold count only from the identity-v3 location. `build_training_spec` still emits the v2 shape - `run_dl_cv` uses it and `LEGACY_IDENTITY_VERSION` is still supported - which carries `n_folds` at the top level and has no `computation` key at all. Every such row answered 0 and raised "requires at least two declared folds" against a row declaring five, and `12_case_study_insights` tolerates only "fewer than 30 rows", so the chapter notebook aborted rather than degrading.

Every declared placebo reduction goes to 25, derived rather than chosen. The plus-one correction floors the empirical p at 1/(n+1), so a verdict below alpha needs ceil(1/0.05) = 20 successful draws; below that `classify_refutation` returns "Underpowered" whatever the data showed. Nine declarations sat at 5, 10 and 15 - the five at 5 were below the threshold at which a refutation is computed at all, so those notebooks published the `.get("empirical_p", 1.0)` default as a measured p-value. 25 is 20 plus the same one-failed-draw margin that already justified 15 over 10, and the test now computes both bars from `REFUTATION_ALPHA` rather than pinning a literal.

`etfs/14_backtest` and `etfs/15_portfolio_management` are cleared. #597 changed the etfs sweep config - `top_k_grid` from `[10, 20]` to `[5, 10, 20]`, `checkpoints_per_config` from 2 to 1 - and neither was re-executed, so both display numbers the config beside them cannot produce. `notebook_provenance.py check` passes them: staleness is measured against the stamp's `source_py_blob`, and an unstamped notebook has nothing to compare, so it can never be reported stale however far its source moves.

## Tests

- 19 new in `tests/test_supersedes_declaration.py`: the parser, and per notebook that the parameter exists, sits in the parameters cell where papermill can reach it, and is passed to `study.causal()`. Proven two-sided - deleting the `supersedes=` argument from `cme_futures/11` fails the AST check and restoring it passes.
- `tests/test_causal_supersedes.py` 21 passed, `tests/test_insight_chapter.py` 7 passed, both refusals and both spec shapes pinned.
- Full quarantine-adjusted sweep: **2243 passed, 42 skipped, 85 deselected, 0 failed**.