### PR TITLE
fx_pairs 07_gbm kills a clean clone at the population write, before any fit

### DIFF
--- a/case_studies/fx_pairs/07_gbm.ipynb
+++ b/case_studies/fx_pairs/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6905f934",
+   "id": "aa40d084",
    "metadata": {
     "papermill": {
-     "duration": 0.001839,
-     "end_time": "2026-08-25T04:30:32.632597+00:00",
+     "duration": 0.002397,
+     "end_time": "2026-08-25T04:42:20.863648+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:32.630758+00:00",
+     "start_time": "2026-08-25T04:42:20.861251+00:00",
      "status": "completed"
     }
    },
@@ -75,19 +75,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8ff5ce19",
+   "id": "6bbd7ea6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:32.636198Z",
-     "iopub.status.busy": "2026-08-25T04:30:32.636068Z",
-     "iopub.status.idle": "2026-08-25T04:30:35.689295Z",
-     "shell.execute_reply": "2026-08-25T04:30:35.688747Z"
+     "iopub.execute_input": "2026-08-25T04:42:20.871094Z",
+     "iopub.status.busy": "2026-08-25T04:42:20.870837Z",
+     "iopub.status.idle": "2026-08-25T04:42:25.391322Z",
+     "shell.execute_reply": "2026-08-25T04:42:25.390258Z"
     },
     "papermill": {
-     "duration": 3.055749,
-     "end_time": "2026-08-25T04:30:35.689879+00:00",
+     "duration": 4.525159,
+     "end_time": "2026-08-25T04:42:25.392875+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:32.634130+00:00",
+     "start_time": "2026-08-25T04:42:20.867716+00:00",
      "status": "completed"
     }
    },
@@ -119,19 +119,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "da515b16",
+   "id": "de63552a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:35.695204Z",
-     "iopub.status.busy": "2026-08-25T04:30:35.695003Z",
-     "iopub.status.idle": "2026-08-25T04:30:35.697130Z",
-     "shell.execute_reply": "2026-08-25T04:30:35.696805Z"
+     "iopub.execute_input": "2026-08-25T04:42:25.399683Z",
+     "iopub.status.busy": "2026-08-25T04:42:25.399364Z",
+     "iopub.status.idle": "2026-08-25T04:42:25.402763Z",
+     "shell.execute_reply": "2026-08-25T04:42:25.402148Z"
     },
     "papermill": {
-     "duration": 0.004665,
-     "end_time": "2026-08-25T04:30:35.697456+00:00",
+     "duration": 0.007372,
+     "end_time": "2026-08-25T04:42:25.403715+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:35.692791+00:00",
+     "start_time": "2026-08-25T04:42:25.396343+00:00",
      "status": "completed"
     },
     "tags": [
@@ -152,19 +152,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "eecd9c57",
+   "id": "de326e6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:35.703392Z",
-     "iopub.status.busy": "2026-08-25T04:30:35.703297Z",
-     "iopub.status.idle": "2026-08-25T04:30:36.559285Z",
-     "shell.execute_reply": "2026-08-25T04:30:36.558925Z"
+     "iopub.execute_input": "2026-08-25T04:42:25.409596Z",
+     "iopub.status.busy": "2026-08-25T04:42:25.409441Z",
+     "iopub.status.idle": "2026-08-25T04:42:26.535255Z",
+     "shell.execute_reply": "2026-08-25T04:42:26.534750Z"
     },
     "papermill": {
-     "duration": 0.860762,
-     "end_time": "2026-08-25T04:30:36.559754+00:00",
+     "duration": 1.129345,
+     "end_time": "2026-08-25T04:42:26.535861+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:35.698992+00:00",
+     "start_time": "2026-08-25T04:42:25.406516+00:00",
      "status": "completed"
     }
    },
@@ -175,13 +175,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db65e722",
+   "id": "4edc51b9",
    "metadata": {
     "papermill": {
-     "duration": 0.001253,
-     "end_time": "2026-08-25T04:30:36.562595+00:00",
+     "duration": 0.001899,
+     "end_time": "2026-08-25T04:42:26.540109+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.561342+00:00",
+     "start_time": "2026-08-25T04:42:26.538210+00:00",
      "status": "completed"
     }
    },
@@ -198,20 +198,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c8bca7f8",
+   "id": "20ca7338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:36.565808Z",
-     "iopub.status.busy": "2026-08-25T04:30:36.565701Z",
-     "iopub.status.idle": "2026-08-25T04:30:36.579121Z",
-     "shell.execute_reply": "2026-08-25T04:30:36.578765Z"
+     "iopub.execute_input": "2026-08-25T04:42:26.544633Z",
+     "iopub.status.busy": "2026-08-25T04:42:26.544514Z",
+     "iopub.status.idle": "2026-08-25T04:42:26.559135Z",
+     "shell.execute_reply": "2026-08-25T04:42:26.558495Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.015836,
-     "end_time": "2026-08-25T04:30:36.579752+00:00",
+     "duration": 0.01791,
+     "end_time": "2026-08-25T04:42:26.559691+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.563916+00:00",
+     "start_time": "2026-08-25T04:42:26.541781+00:00",
      "status": "completed"
     }
    },
@@ -233,13 +233,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abcc3977",
+   "id": "aab65024",
    "metadata": {
     "papermill": {
-     "duration": 0.002456,
-     "end_time": "2026-08-25T04:30:36.584999+00:00",
+     "duration": 0.00145,
+     "end_time": "2026-08-25T04:42:26.563637+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.582543+00:00",
+     "start_time": "2026-08-25T04:42:26.562187+00:00",
      "status": "completed"
     }
    },
@@ -263,19 +263,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "b7b2c08b",
+   "id": "13e4eb9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:36.590956Z",
-     "iopub.status.busy": "2026-08-25T04:30:36.590833Z",
-     "iopub.status.idle": "2026-08-25T04:30:36.631873Z",
-     "shell.execute_reply": "2026-08-25T04:30:36.631398Z"
+     "iopub.execute_input": "2026-08-25T04:42:26.567445Z",
+     "iopub.status.busy": "2026-08-25T04:42:26.567207Z",
+     "iopub.status.idle": "2026-08-25T04:42:26.619957Z",
+     "shell.execute_reply": "2026-08-25T04:42:26.619289Z"
     },
     "papermill": {
-     "duration": 0.044887,
-     "end_time": "2026-08-25T04:30:36.632414+00:00",
+     "duration": 0.055616,
+     "end_time": "2026-08-25T04:42:26.620666+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.587527+00:00",
+     "start_time": "2026-08-25T04:42:26.565050+00:00",
      "status": "completed"
     }
    },
@@ -330,13 +330,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "806ed151",
+   "id": "85adaaa9",
    "metadata": {
     "papermill": {
-     "duration": 0.001387,
-     "end_time": "2026-08-25T04:30:36.635916+00:00",
+     "duration": 0.003019,
+     "end_time": "2026-08-25T04:42:26.627017+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.634529+00:00",
+     "start_time": "2026-08-25T04:42:26.623998+00:00",
      "status": "completed"
     }
    },
@@ -352,19 +352,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ffe94f36",
+   "id": "e7aed63e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:36.639456Z",
-     "iopub.status.busy": "2026-08-25T04:30:36.639352Z",
-     "iopub.status.idle": "2026-08-25T04:30:36.670927Z",
-     "shell.execute_reply": "2026-08-25T04:30:36.670485Z"
+     "iopub.execute_input": "2026-08-25T04:42:26.634335Z",
+     "iopub.status.busy": "2026-08-25T04:42:26.634122Z",
+     "iopub.status.idle": "2026-08-25T04:42:26.667939Z",
+     "shell.execute_reply": "2026-08-25T04:42:26.667228Z"
     },
     "papermill": {
-     "duration": 0.034068,
-     "end_time": "2026-08-25T04:30:36.671410+00:00",
+     "duration": 0.038421,
+     "end_time": "2026-08-25T04:42:26.668630+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.637342+00:00",
+     "start_time": "2026-08-25T04:42:26.630209+00:00",
      "status": "completed"
     }
    },
@@ -380,13 +380,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "809f2b48",
+   "id": "3cd66f50",
    "metadata": {
     "papermill": {
-     "duration": 0.00143,
-     "end_time": "2026-08-25T04:30:36.674537+00:00",
+     "duration": 0.001914,
+     "end_time": "2026-08-25T04:42:26.672697+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.673107+00:00",
+     "start_time": "2026-08-25T04:42:26.670783+00:00",
      "status": "completed"
     }
    },
@@ -413,19 +413,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b3208862",
+   "id": "6da11f23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:30:36.678095Z",
-     "iopub.status.busy": "2026-08-25T04:30:36.677996Z",
-     "iopub.status.idle": "2026-08-25T04:31:14.899921Z",
-     "shell.execute_reply": "2026-08-25T04:31:14.899143Z"
+     "iopub.execute_input": "2026-08-25T04:42:26.677177Z",
+     "iopub.status.busy": "2026-08-25T04:42:26.677030Z",
+     "iopub.status.idle": "2026-08-25T04:43:10.469543Z",
+     "shell.execute_reply": "2026-08-25T04:43:10.468937Z"
     },
     "papermill": {
-     "duration": 38.228423,
-     "end_time": "2026-08-25T04:31:14.904383+00:00",
+     "duration": 43.798219,
+     "end_time": "2026-08-25T04:43:10.472769+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:30:36.675960+00:00",
+     "start_time": "2026-08-25T04:42:26.674550+00:00",
      "status": "completed"
     }
    },
@@ -503,13 +503,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0046f2b",
+   "id": "51feb9cc",
    "metadata": {
     "papermill": {
-     "duration": 0.001756,
-     "end_time": "2026-08-25T04:31:14.907826+00:00",
+     "duration": 0.001987,
+     "end_time": "2026-08-25T04:43:10.476739+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:14.906070+00:00",
+     "start_time": "2026-08-25T04:43:10.474752+00:00",
      "status": "completed"
     }
    },
@@ -564,10 +564,9 @@
     "which is the same condition on the narrowed-run path: a caller-chosen `POPULATION_NAME` has no\n",
     "prior generation either.\n",
     "\n",
-    "A reduced-scale run passes it empty. A population produced under a reduction is thrown away\n",
-    "with the workspace it was written to, so it has no lineage to extend, and the call refuses a\n",
-    "supersede rather than accept one it will not record. Pass `SUPERSEDES_POPULATION=` alongside\n",
-    "the reductions.\n",
+    "A reduced-scale run needs no override. A population produced under a reduction is thrown away\n",
+    "with the workspace it was written to, so it has no lineage to extend - and its isolated registry\n",
+    "holds no generation under this name, so the rule below withholds the hash there on its own.\n",
     "\n",
     "**One population covers every label**, because one run fits every label. A population is\n",
     "immutable once written, so a notebook fitting one label per run under a single name publishes\n",
@@ -578,19 +577,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "532def87",
+   "id": "d542908e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:14.911723Z",
-     "iopub.status.busy": "2026-08-25T04:31:14.911572Z",
-     "iopub.status.idle": "2026-08-25T04:31:20.045422Z",
-     "shell.execute_reply": "2026-08-25T04:31:20.044890Z"
+     "iopub.execute_input": "2026-08-25T04:43:10.481300Z",
+     "iopub.status.busy": "2026-08-25T04:43:10.481102Z",
+     "iopub.status.idle": "2026-08-25T04:43:17.736126Z",
+     "shell.execute_reply": "2026-08-25T04:43:17.735424Z"
     },
     "papermill": {
-     "duration": 5.13651,
-     "end_time": "2026-08-25T04:31:20.045923+00:00",
+     "duration": 7.258078,
+     "end_time": "2026-08-25T04:43:17.736560+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:14.909413+00:00",
+     "start_time": "2026-08-25T04:43:10.478482+00:00",
      "status": "completed"
     }
    },
@@ -606,8 +605,9 @@
    ],
    "source": [
     "population_name = POPULATION_NAME or \"fx_pairs-gbm-validation-v1\"\n",
+    "declared_supersedes = SUPERSEDES_POPULATION or None\n",
     "try:\n",
-    "    OfficialPopulation.one(study, name=population_name)\n",
+    "    current = OfficialPopulation.one(study, name=population_name)\n",
     "except (ValueError, sqlite3.OperationalError):\n",
     "    # No generation in force under this name: none was ever written, the chain forked, or - on a\n",
     "    # reader's clean clone, where run_log/ is gitignored - the registry has no table to read at\n",
@@ -615,7 +615,13 @@
     "    # caught: a clean clone is the ordinary case here, not the exotic one.\n",
     "    supersedes = None\n",
     "else:\n",
-    "    supersedes = SUPERSEDES_POPULATION or None\n",
+    "    # The declaration describes ONE generation: the one produced by superseding\n",
+    "    # `declared_supersedes`. Offer it only when that is the generation in force, which is what\n",
+    "    # makes the hash reproduce the tip rather than extend the chain past it. Asking merely\n",
+    "    # whether any generation exists is not the same question, and gets the second run on a clean\n",
+    "    # clone wrong: run 1 writes the first generation, whose own supersedes is None, and offering\n",
+    "    # the hash again there would write a second generation the reader never asked for.\n",
+    "    supersedes = declared_supersedes if current.supersedes == declared_supersedes else None\n",
     "execution, population = run_model_population(\n",
     "    study, resolved, population_name=population_name, supersedes=supersedes\n",
     ")\n",
@@ -626,13 +632,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee7f506c",
+   "id": "e41fbf1c",
    "metadata": {
     "papermill": {
-     "duration": 0.003128,
-     "end_time": "2026-08-25T04:31:20.052465+00:00",
+     "duration": 0.004298,
+     "end_time": "2026-08-25T04:43:17.746100+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:20.049337+00:00",
+     "start_time": "2026-08-25T04:43:17.741802+00:00",
      "status": "completed"
     }
    },
@@ -665,13 +671,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d85b87c",
+   "id": "d10b8072",
    "metadata": {
     "papermill": {
-     "duration": 0.001543,
-     "end_time": "2026-08-25T04:31:20.055743+00:00",
+     "duration": 0.002776,
+     "end_time": "2026-08-25T04:43:17.755545+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:20.054200+00:00",
+     "start_time": "2026-08-25T04:43:17.752769+00:00",
      "status": "completed"
     }
    },
@@ -698,19 +704,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d87e4999",
+   "id": "7a653ea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:20.059907Z",
-     "iopub.status.busy": "2026-08-25T04:31:20.059768Z",
-     "iopub.status.idle": "2026-08-25T04:31:20.085871Z",
-     "shell.execute_reply": "2026-08-25T04:31:20.085370Z"
+     "iopub.execute_input": "2026-08-25T04:43:17.762444Z",
+     "iopub.status.busy": "2026-08-25T04:43:17.761803Z",
+     "iopub.status.idle": "2026-08-25T04:43:17.809808Z",
+     "shell.execute_reply": "2026-08-25T04:43:17.807590Z"
     },
     "papermill": {
-     "duration": 0.029007,
-     "end_time": "2026-08-25T04:31:20.086366+00:00",
+     "duration": 0.052713,
+     "end_time": "2026-08-25T04:43:17.811017+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:20.057359+00:00",
+     "start_time": "2026-08-25T04:43:17.758304+00:00",
      "status": "completed"
     },
     "tags": [
@@ -808,13 +814,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "847c8d7e",
+   "id": "e7c696b8",
    "metadata": {
     "papermill": {
-     "duration": 0.002003,
-     "end_time": "2026-08-25T04:31:20.091698+00:00",
+     "duration": 0.008445,
+     "end_time": "2026-08-25T04:43:17.828683+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:20.089695+00:00",
+     "start_time": "2026-08-25T04:43:17.820238+00:00",
      "status": "completed"
     }
    },
@@ -835,19 +841,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ff754c98",
+   "id": "ecbe89c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:20.095915Z",
-     "iopub.status.busy": "2026-08-25T04:31:20.095745Z",
-     "iopub.status.idle": "2026-08-25T04:31:21.822501Z",
-     "shell.execute_reply": "2026-08-25T04:31:21.822020Z"
+     "iopub.execute_input": "2026-08-25T04:43:17.841030Z",
+     "iopub.status.busy": "2026-08-25T04:43:17.840587Z",
+     "iopub.status.idle": "2026-08-25T04:43:20.744671Z",
+     "shell.execute_reply": "2026-08-25T04:43:20.744170Z"
     },
     "papermill": {
-     "duration": 1.73219,
-     "end_time": "2026-08-25T04:31:21.825596+00:00",
+     "duration": 2.913364,
+     "end_time": "2026-08-25T04:43:20.750393+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:20.093406+00:00",
+     "start_time": "2026-08-25T04:43:17.837029+00:00",
      "status": "completed"
     }
    },
@@ -2885,13 +2891,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0e6ef56",
+   "id": "3f26cd5a",
    "metadata": {
     "papermill": {
-     "duration": 0.004502,
-     "end_time": "2026-08-25T04:31:21.837556+00:00",
+     "duration": 0.009842,
+     "end_time": "2026-08-25T04:43:20.781942+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:21.833054+00:00",
+     "start_time": "2026-08-25T04:43:20.772100+00:00",
      "status": "completed"
     }
    },
@@ -2907,19 +2913,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "dd708861",
+   "id": "653a8555",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:21.847062Z",
-     "iopub.status.busy": "2026-08-25T04:31:21.846938Z",
-     "iopub.status.idle": "2026-08-25T04:31:21.853074Z",
-     "shell.execute_reply": "2026-08-25T04:31:21.852578Z"
+     "iopub.execute_input": "2026-08-25T04:43:20.800597Z",
+     "iopub.status.busy": "2026-08-25T04:43:20.800442Z",
+     "iopub.status.idle": "2026-08-25T04:43:20.808082Z",
+     "shell.execute_reply": "2026-08-25T04:43:20.807393Z"
     },
     "papermill": {
-     "duration": 0.011886,
-     "end_time": "2026-08-25T04:31:21.853626+00:00",
+     "duration": 0.017622,
+     "end_time": "2026-08-25T04:43:20.808609+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:21.841740+00:00",
+     "start_time": "2026-08-25T04:43:20.790987+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2989,13 +2995,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9199d0d4",
+   "id": "f98f7232",
    "metadata": {
     "papermill": {
-     "duration": 0.00406,
-     "end_time": "2026-08-25T04:31:21.862285+00:00",
+     "duration": 0.008522,
+     "end_time": "2026-08-25T04:43:20.825356+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:21.858225+00:00",
+     "start_time": "2026-08-25T04:43:20.816834+00:00",
      "status": "completed"
     }
    },
@@ -3015,19 +3021,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "8c126a3b",
+   "id": "bcd11fc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:21.871792Z",
-     "iopub.status.busy": "2026-08-25T04:31:21.871593Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.399623Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.399231Z"
+     "iopub.execute_input": "2026-08-25T04:43:20.843049Z",
+     "iopub.status.busy": "2026-08-25T04:43:20.842925Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.258301Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.257752Z"
     },
     "papermill": {
-     "duration": 1.533976,
-     "end_time": "2026-08-25T04:31:23.400488+00:00",
+     "duration": 2.424441,
+     "end_time": "2026-08-25T04:43:23.258606+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:21.866512+00:00",
+     "start_time": "2026-08-25T04:43:20.834165+00:00",
      "status": "completed"
     }
    },
@@ -3538,13 +3544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4108d56a",
+   "id": "fcdf6223",
    "metadata": {
     "papermill": {
-     "duration": 0.00702,
-     "end_time": "2026-08-25T04:31:23.417218+00:00",
+     "duration": 0.005051,
+     "end_time": "2026-08-25T04:43:23.269422+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.410198+00:00",
+     "start_time": "2026-08-25T04:43:23.264371+00:00",
      "status": "completed"
     }
    },
@@ -3559,19 +3565,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d983deee",
+   "id": "79730e49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:23.429132Z",
-     "iopub.status.busy": "2026-08-25T04:31:23.429007Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.432848Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.432475Z"
+     "iopub.execute_input": "2026-08-25T04:43:23.282209Z",
+     "iopub.status.busy": "2026-08-25T04:43:23.281865Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.296354Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.295339Z"
     },
     "papermill": {
-     "duration": 0.01136,
-     "end_time": "2026-08-25T04:31:23.433313+00:00",
+     "duration": 0.022247,
+     "end_time": "2026-08-25T04:43:23.297127+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.421953+00:00",
+     "start_time": "2026-08-25T04:43:23.274880+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3625,13 +3631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "082629c4",
+   "id": "e1eb637a",
    "metadata": {
     "papermill": {
-     "duration": 0.009442,
-     "end_time": "2026-08-25T04:31:23.452782+00:00",
+     "duration": 0.006752,
+     "end_time": "2026-08-25T04:43:23.314303+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.443340+00:00",
+     "start_time": "2026-08-25T04:43:23.307551+00:00",
      "status": "completed"
     }
    },
@@ -3647,19 +3653,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "33bbfb0e",
+   "id": "b498c6e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:23.470150Z",
-     "iopub.status.busy": "2026-08-25T04:31:23.469943Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.474540Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.474031Z"
+     "iopub.execute_input": "2026-08-25T04:43:23.331418Z",
+     "iopub.status.busy": "2026-08-25T04:43:23.331229Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.335576Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.335163Z"
     },
     "papermill": {
-     "duration": 0.01217,
-     "end_time": "2026-08-25T04:31:23.474816+00:00",
+     "duration": 0.014635,
+     "end_time": "2026-08-25T04:43:23.335868+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.462646+00:00",
+     "start_time": "2026-08-25T04:43:23.321233+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3719,13 +3725,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "119442f9",
+   "id": "5188a224",
    "metadata": {
     "papermill": {
-     "duration": 0.004875,
-     "end_time": "2026-08-25T04:31:23.484911+00:00",
+     "duration": 0.005173,
+     "end_time": "2026-08-25T04:43:23.347146+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.480036+00:00",
+     "start_time": "2026-08-25T04:43:23.341973+00:00",
      "status": "completed"
     }
    },
@@ -3752,19 +3758,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "592ca628",
+   "id": "42e7128b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:23.495722Z",
-     "iopub.status.busy": "2026-08-25T04:31:23.495585Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.548344Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.547911Z"
+     "iopub.execute_input": "2026-08-25T04:43:23.360686Z",
+     "iopub.status.busy": "2026-08-25T04:43:23.360426Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.429688Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.429060Z"
     },
     "papermill": {
-     "duration": 0.059194,
-     "end_time": "2026-08-25T04:31:23.548955+00:00",
+     "duration": 0.07775,
+     "end_time": "2026-08-25T04:43:23.430376+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.489761+00:00",
+     "start_time": "2026-08-25T04:43:23.352626+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3829,13 +3835,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aadc37d2",
+   "id": "e93898cc",
    "metadata": {
     "papermill": {
-     "duration": 0.008741,
-     "end_time": "2026-08-25T04:31:23.563116+00:00",
+     "duration": 0.011358,
+     "end_time": "2026-08-25T04:43:23.447396+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.554375+00:00",
+     "start_time": "2026-08-25T04:43:23.436038+00:00",
      "status": "completed"
     }
    },
@@ -3858,19 +3864,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f6189d4c",
+   "id": "5e1da7bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:23.574753Z",
-     "iopub.status.busy": "2026-08-25T04:31:23.574608Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.580783Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.580291Z"
+     "iopub.execute_input": "2026-08-25T04:43:23.481959Z",
+     "iopub.status.busy": "2026-08-25T04:43:23.481398Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.494755Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.493980Z"
     },
     "papermill": {
-     "duration": 0.012694,
-     "end_time": "2026-08-25T04:31:23.581070+00:00",
+     "duration": 0.030321,
+     "end_time": "2026-08-25T04:43:23.495324+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.568376+00:00",
+     "start_time": "2026-08-25T04:43:23.465003+00:00",
      "status": "completed"
     }
    },
@@ -3932,19 +3938,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "60b32921",
+   "id": "0a134bb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:31:23.592676Z",
-     "iopub.status.busy": "2026-08-25T04:31:23.592532Z",
-     "iopub.status.idle": "2026-08-25T04:31:23.597755Z",
-     "shell.execute_reply": "2026-08-25T04:31:23.597032Z"
+     "iopub.execute_input": "2026-08-25T04:43:23.528908Z",
+     "iopub.status.busy": "2026-08-25T04:43:23.528143Z",
+     "iopub.status.idle": "2026-08-25T04:43:23.550885Z",
+     "shell.execute_reply": "2026-08-25T04:43:23.547022Z"
     },
     "papermill": {
-     "duration": 0.011798,
-     "end_time": "2026-08-25T04:31:23.598190+00:00",
+     "duration": 0.045831,
+     "end_time": "2026-08-25T04:43:23.552594+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.586392+00:00",
+     "start_time": "2026-08-25T04:43:23.506763+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3996,13 +4002,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63aab4ca",
+   "id": "a8118add",
    "metadata": {
     "papermill": {
-     "duration": 0.00515,
-     "end_time": "2026-08-25T04:31:23.608942+00:00",
+     "duration": 0.010376,
+     "end_time": "2026-08-25T04:43:23.596472+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:31:23.603792+00:00",
+     "start_time": "2026-08-25T04:43:23.586096+00:00",
      "status": "completed"
     }
    },
@@ -4136,19 +4142,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 54.164185,
-   "end_time": "2026-08-25T04:31:26.112315+00:00",
+   "duration": 67.273877,
+   "end_time": "2026-08-25T04:43:26.942736+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/07_gbm.ipynb",
-   "output_path": "/tmp/prod_07_gbm_1994213.ipynb",
+   "output_path": "/tmp/prod_07_gbm_2264868.ipynb",
    "parameters": {},
-   "start_time": "2026-08-25T04:30:31.948130+00:00",
+   "start_time": "2026-08-25T04:42:19.668859+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "7cc059b004d99537160cba0a0222f2ac675376f1",
-   "executed_at": "2026-08-25T04:31:26.902657+00:00",
+   "source_py_blob": "f5e215e923e0df76f1ce9050031b4ce945519161",
+   "executed_at": "2026-08-25T04:43:29.055551+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/07_gbm.ipynb
+++ b/case_studies/fx_pairs/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8ec29e50",
+   "id": "6905f934",
    "metadata": {
     "papermill": {
-     "duration": 0.002755,
-     "end_time": "2026-08-23T10:57:14.872931+00:00",
+     "duration": 0.001839,
+     "end_time": "2026-08-25T04:30:32.632597+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:14.870176+00:00",
+     "start_time": "2026-08-25T04:30:32.630758+00:00",
      "status": "completed"
     }
    },
@@ -75,19 +75,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d132acfd",
+   "id": "8ff5ce19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:14.876837Z",
-     "iopub.status.busy": "2026-08-23T10:57:14.876660Z",
-     "iopub.status.idle": "2026-08-23T10:57:16.644060Z",
-     "shell.execute_reply": "2026-08-23T10:57:16.643532Z"
+     "iopub.execute_input": "2026-08-25T04:30:32.636198Z",
+     "iopub.status.busy": "2026-08-25T04:30:32.636068Z",
+     "iopub.status.idle": "2026-08-25T04:30:35.689295Z",
+     "shell.execute_reply": "2026-08-25T04:30:35.688747Z"
     },
     "papermill": {
-     "duration": 1.770359,
-     "end_time": "2026-08-23T10:57:16.644829+00:00",
+     "duration": 3.055749,
+     "end_time": "2026-08-25T04:30:35.689879+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:14.874470+00:00",
+     "start_time": "2026-08-25T04:30:32.634130+00:00",
      "status": "completed"
     }
    },
@@ -95,12 +95,15 @@
    "source": [
     "\"\"\"Fit the declared FX pairs gradient boosting population on the walk-forward folds.\"\"\"\n",
     "\n",
+    "import sqlite3\n",
+    "\n",
     "import numpy as np\n",
     "import plotly.graph_objects as go\n",
     "import polars as pl\n",
     "from plotly.subplots import make_subplots\n",
     "\n",
     "from case_studies.research import (\n",
+    "    OfficialPopulation,\n",
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
@@ -116,19 +119,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "410e25d3",
+   "id": "da515b16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:16.648599Z",
-     "iopub.status.busy": "2026-08-23T10:57:16.648397Z",
-     "iopub.status.idle": "2026-08-23T10:57:16.651158Z",
-     "shell.execute_reply": "2026-08-23T10:57:16.650476Z"
+     "iopub.execute_input": "2026-08-25T04:30:35.695204Z",
+     "iopub.status.busy": "2026-08-25T04:30:35.695003Z",
+     "iopub.status.idle": "2026-08-25T04:30:35.697130Z",
+     "shell.execute_reply": "2026-08-25T04:30:35.696805Z"
     },
     "papermill": {
-     "duration": 0.005112,
-     "end_time": "2026-08-23T10:57:16.651475+00:00",
+     "duration": 0.004665,
+     "end_time": "2026-08-25T04:30:35.697456+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:16.646363+00:00",
+     "start_time": "2026-08-25T04:30:35.692791+00:00",
      "status": "completed"
     },
     "tags": [
@@ -149,19 +152,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c9bbfea8",
+   "id": "eecd9c57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:16.655503Z",
-     "iopub.status.busy": "2026-08-23T10:57:16.655370Z",
-     "iopub.status.idle": "2026-08-23T10:57:17.005924Z",
-     "shell.execute_reply": "2026-08-23T10:57:17.005212Z"
+     "iopub.execute_input": "2026-08-25T04:30:35.703392Z",
+     "iopub.status.busy": "2026-08-25T04:30:35.703297Z",
+     "iopub.status.idle": "2026-08-25T04:30:36.559285Z",
+     "shell.execute_reply": "2026-08-25T04:30:36.558925Z"
     },
     "papermill": {
-     "duration": 0.353266,
-     "end_time": "2026-08-23T10:57:17.006365+00:00",
+     "duration": 0.860762,
+     "end_time": "2026-08-25T04:30:36.559754+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:16.653099+00:00",
+     "start_time": "2026-08-25T04:30:35.698992+00:00",
      "status": "completed"
     }
    },
@@ -172,13 +175,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf4f8e00",
+   "id": "db65e722",
    "metadata": {
     "papermill": {
-     "duration": 0.001733,
-     "end_time": "2026-08-23T10:57:17.009609+00:00",
+     "duration": 0.001253,
+     "end_time": "2026-08-25T04:30:36.562595+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.007876+00:00",
+     "start_time": "2026-08-25T04:30:36.561342+00:00",
      "status": "completed"
     }
    },
@@ -195,20 +198,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c1996bea",
+   "id": "c8bca7f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:17.013161Z",
-     "iopub.status.busy": "2026-08-23T10:57:17.013057Z",
-     "iopub.status.idle": "2026-08-23T10:57:17.027869Z",
-     "shell.execute_reply": "2026-08-23T10:57:17.027408Z"
+     "iopub.execute_input": "2026-08-25T04:30:36.565808Z",
+     "iopub.status.busy": "2026-08-25T04:30:36.565701Z",
+     "iopub.status.idle": "2026-08-25T04:30:36.579121Z",
+     "shell.execute_reply": "2026-08-25T04:30:36.578765Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.017293,
-     "end_time": "2026-08-23T10:57:17.028375+00:00",
+     "duration": 0.015836,
+     "end_time": "2026-08-25T04:30:36.579752+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.011082+00:00",
+     "start_time": "2026-08-25T04:30:36.563916+00:00",
      "status": "completed"
     }
    },
@@ -230,13 +233,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d374a88",
+   "id": "abcc3977",
    "metadata": {
     "papermill": {
-     "duration": 0.00172,
-     "end_time": "2026-08-23T10:57:17.031821+00:00",
+     "duration": 0.002456,
+     "end_time": "2026-08-25T04:30:36.584999+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.030101+00:00",
+     "start_time": "2026-08-25T04:30:36.582543+00:00",
      "status": "completed"
     }
    },
@@ -260,19 +263,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7e4d94df",
+   "id": "b7b2c08b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:17.035161Z",
-     "iopub.status.busy": "2026-08-23T10:57:17.035066Z",
-     "iopub.status.idle": "2026-08-23T10:57:17.080136Z",
-     "shell.execute_reply": "2026-08-23T10:57:17.079568Z"
+     "iopub.execute_input": "2026-08-25T04:30:36.590956Z",
+     "iopub.status.busy": "2026-08-25T04:30:36.590833Z",
+     "iopub.status.idle": "2026-08-25T04:30:36.631873Z",
+     "shell.execute_reply": "2026-08-25T04:30:36.631398Z"
     },
     "papermill": {
-     "duration": 0.047233,
-     "end_time": "2026-08-23T10:57:17.080540+00:00",
+     "duration": 0.044887,
+     "end_time": "2026-08-25T04:30:36.632414+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.033307+00:00",
+     "start_time": "2026-08-25T04:30:36.587527+00:00",
      "status": "completed"
     }
    },
@@ -327,13 +330,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13f76f31",
+   "id": "806ed151",
    "metadata": {
     "papermill": {
-     "duration": 0.001518,
-     "end_time": "2026-08-23T10:57:17.083873+00:00",
+     "duration": 0.001387,
+     "end_time": "2026-08-25T04:30:36.635916+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.082355+00:00",
+     "start_time": "2026-08-25T04:30:36.634529+00:00",
      "status": "completed"
     }
    },
@@ -349,19 +352,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9324b041",
+   "id": "ffe94f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:17.087750Z",
-     "iopub.status.busy": "2026-08-23T10:57:17.087653Z",
-     "iopub.status.idle": "2026-08-23T10:57:17.129598Z",
-     "shell.execute_reply": "2026-08-23T10:57:17.129196Z"
+     "iopub.execute_input": "2026-08-25T04:30:36.639456Z",
+     "iopub.status.busy": "2026-08-25T04:30:36.639352Z",
+     "iopub.status.idle": "2026-08-25T04:30:36.670927Z",
+     "shell.execute_reply": "2026-08-25T04:30:36.670485Z"
     },
     "papermill": {
-     "duration": 0.044529,
-     "end_time": "2026-08-23T10:57:17.129972+00:00",
+     "duration": 0.034068,
+     "end_time": "2026-08-25T04:30:36.671410+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.085443+00:00",
+     "start_time": "2026-08-25T04:30:36.637342+00:00",
      "status": "completed"
     }
    },
@@ -377,13 +380,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8b677dc",
+   "id": "809f2b48",
    "metadata": {
     "papermill": {
-     "duration": 0.001374,
-     "end_time": "2026-08-23T10:57:17.133122+00:00",
+     "duration": 0.00143,
+     "end_time": "2026-08-25T04:30:36.674537+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.131748+00:00",
+     "start_time": "2026-08-25T04:30:36.673107+00:00",
      "status": "completed"
     }
    },
@@ -410,19 +413,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a64f55c4",
+   "id": "b3208862",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:17.136573Z",
-     "iopub.status.busy": "2026-08-23T10:57:17.136421Z",
-     "iopub.status.idle": "2026-08-23T10:57:47.222967Z",
-     "shell.execute_reply": "2026-08-23T10:57:47.222498Z"
+     "iopub.execute_input": "2026-08-25T04:30:36.678095Z",
+     "iopub.status.busy": "2026-08-25T04:30:36.677996Z",
+     "iopub.status.idle": "2026-08-25T04:31:14.899921Z",
+     "shell.execute_reply": "2026-08-25T04:31:14.899143Z"
     },
     "papermill": {
-     "duration": 30.089918,
-     "end_time": "2026-08-23T10:57:47.224414+00:00",
+     "duration": 38.228423,
+     "end_time": "2026-08-25T04:31:14.904383+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:17.134496+00:00",
+     "start_time": "2026-08-25T04:30:36.675960+00:00",
      "status": "completed"
     }
    },
@@ -500,13 +503,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1fdab85",
+   "id": "f0046f2b",
    "metadata": {
     "papermill": {
-     "duration": 0.00139,
-     "end_time": "2026-08-23T10:57:47.227310+00:00",
+     "duration": 0.001756,
+     "end_time": "2026-08-25T04:31:14.907826+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:47.225920+00:00",
+     "start_time": "2026-08-25T04:31:14.906070+00:00",
      "status": "completed"
     }
    },
@@ -554,6 +557,13 @@
     "is what lets this notebook re-run and resolve to the population it published rather than to a\n",
     "new one.\n",
     "\n",
+    "It applies only where that generation exists. `run_log/` is gitignored, so a clean clone starts\n",
+    "with an empty registry, and `OfficialPopulation.create` refuses a first version that claims to\n",
+    "supersede something - \"first population version cannot supersede another snapshot\". The declared\n",
+    "hash is therefore offered when the name already has a generation and withheld when it does not,\n",
+    "which is the same condition on the narrowed-run path: a caller-chosen `POPULATION_NAME` has no\n",
+    "prior generation either.\n",
+    "\n",
     "A reduced-scale run passes it empty. A population produced under a reduction is thrown away\n",
     "with the workspace it was written to, so it has no lineage to extend, and the call refuses a\n",
     "supersede rather than accept one it will not record. Pass `SUPERSEDES_POPULATION=` alongside\n",
@@ -568,19 +578,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "7ca4c0fa",
+   "id": "532def87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:47.230741Z",
-     "iopub.status.busy": "2026-08-23T10:57:47.230601Z",
-     "iopub.status.idle": "2026-08-23T10:57:53.710489Z",
-     "shell.execute_reply": "2026-08-23T10:57:53.709774Z"
+     "iopub.execute_input": "2026-08-25T04:31:14.911723Z",
+     "iopub.status.busy": "2026-08-25T04:31:14.911572Z",
+     "iopub.status.idle": "2026-08-25T04:31:20.045422Z",
+     "shell.execute_reply": "2026-08-25T04:31:20.044890Z"
     },
     "papermill": {
-     "duration": 6.482338,
-     "end_time": "2026-08-23T10:57:53.711042+00:00",
+     "duration": 5.13651,
+     "end_time": "2026-08-25T04:31:20.045923+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:47.228704+00:00",
+     "start_time": "2026-08-25T04:31:14.909413+00:00",
      "status": "completed"
     }
    },
@@ -596,8 +606,18 @@
    ],
    "source": [
     "population_name = POPULATION_NAME or \"fx_pairs-gbm-validation-v1\"\n",
+    "try:\n",
+    "    OfficialPopulation.one(study, name=population_name)\n",
+    "except (ValueError, sqlite3.OperationalError):\n",
+    "    # No generation in force under this name: none was ever written, the chain forked, or - on a\n",
+    "    # reader's clean clone, where run_log/ is gitignored - the registry has no table to read at\n",
+    "    # all. That last one raises OperationalError rather than ValueError, which is why both are\n",
+    "    # caught: a clean clone is the ordinary case here, not the exotic one.\n",
+    "    supersedes = None\n",
+    "else:\n",
+    "    supersedes = SUPERSEDES_POPULATION or None\n",
     "execution, population = run_model_population(\n",
-    "    study, resolved, population_name=population_name, supersedes=SUPERSEDES_POPULATION or None\n",
+    "    study, resolved, population_name=population_name, supersedes=supersedes\n",
     ")\n",
     "\n",
     "print(f\"{len(execution.runs)} configurations fitted\")\n",
@@ -606,13 +626,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d15df0c",
+   "id": "ee7f506c",
    "metadata": {
     "papermill": {
-     "duration": 0.00191,
-     "end_time": "2026-08-23T10:57:53.714660+00:00",
+     "duration": 0.003128,
+     "end_time": "2026-08-25T04:31:20.052465+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:53.712750+00:00",
+     "start_time": "2026-08-25T04:31:20.049337+00:00",
      "status": "completed"
     }
    },
@@ -645,13 +665,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8dafc749",
+   "id": "8d85b87c",
    "metadata": {
     "papermill": {
-     "duration": 0.001362,
-     "end_time": "2026-08-23T10:57:53.717522+00:00",
+     "duration": 0.001543,
+     "end_time": "2026-08-25T04:31:20.055743+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:53.716160+00:00",
+     "start_time": "2026-08-25T04:31:20.054200+00:00",
      "status": "completed"
     }
    },
@@ -678,19 +698,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8cd7d44b",
+   "id": "d87e4999",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:53.720917Z",
-     "iopub.status.busy": "2026-08-23T10:57:53.720839Z",
-     "iopub.status.idle": "2026-08-23T10:57:53.736950Z",
-     "shell.execute_reply": "2026-08-23T10:57:53.736454Z"
+     "iopub.execute_input": "2026-08-25T04:31:20.059907Z",
+     "iopub.status.busy": "2026-08-25T04:31:20.059768Z",
+     "iopub.status.idle": "2026-08-25T04:31:20.085871Z",
+     "shell.execute_reply": "2026-08-25T04:31:20.085370Z"
     },
     "papermill": {
-     "duration": 0.018307,
-     "end_time": "2026-08-23T10:57:53.737276+00:00",
+     "duration": 0.029007,
+     "end_time": "2026-08-25T04:31:20.086366+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:53.718969+00:00",
+     "start_time": "2026-08-25T04:31:20.057359+00:00",
      "status": "completed"
     },
     "tags": [
@@ -788,13 +808,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "beacb922",
+   "id": "847c8d7e",
    "metadata": {
     "papermill": {
-     "duration": 0.001493,
-     "end_time": "2026-08-23T10:57:53.740362+00:00",
+     "duration": 0.002003,
+     "end_time": "2026-08-25T04:31:20.091698+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:53.738869+00:00",
+     "start_time": "2026-08-25T04:31:20.089695+00:00",
      "status": "completed"
     }
    },
@@ -815,19 +835,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "480122d4",
+   "id": "ff754c98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:53.743837Z",
-     "iopub.status.busy": "2026-08-23T10:57:53.743725Z",
-     "iopub.status.idle": "2026-08-23T10:57:55.289461Z",
-     "shell.execute_reply": "2026-08-23T10:57:55.288921Z"
+     "iopub.execute_input": "2026-08-25T04:31:20.095915Z",
+     "iopub.status.busy": "2026-08-25T04:31:20.095745Z",
+     "iopub.status.idle": "2026-08-25T04:31:21.822501Z",
+     "shell.execute_reply": "2026-08-25T04:31:21.822020Z"
     },
     "papermill": {
-     "duration": 1.550634,
-     "end_time": "2026-08-23T10:57:55.292508+00:00",
+     "duration": 1.73219,
+     "end_time": "2026-08-25T04:31:21.825596+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:53.741874+00:00",
+     "start_time": "2026-08-25T04:31:20.093406+00:00",
      "status": "completed"
     }
    },
@@ -2865,13 +2885,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22f9ca0a",
+   "id": "d0e6ef56",
    "metadata": {
     "papermill": {
-     "duration": 0.00442,
-     "end_time": "2026-08-23T10:57:55.306700+00:00",
+     "duration": 0.004502,
+     "end_time": "2026-08-25T04:31:21.837556+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:55.302280+00:00",
+     "start_time": "2026-08-25T04:31:21.833054+00:00",
      "status": "completed"
     }
    },
@@ -2887,19 +2907,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "3c55d760",
+   "id": "dd708861",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:55.314724Z",
-     "iopub.status.busy": "2026-08-23T10:57:55.314595Z",
-     "iopub.status.idle": "2026-08-23T10:57:55.319637Z",
-     "shell.execute_reply": "2026-08-23T10:57:55.319243Z"
+     "iopub.execute_input": "2026-08-25T04:31:21.847062Z",
+     "iopub.status.busy": "2026-08-25T04:31:21.846938Z",
+     "iopub.status.idle": "2026-08-25T04:31:21.853074Z",
+     "shell.execute_reply": "2026-08-25T04:31:21.852578Z"
     },
     "papermill": {
-     "duration": 0.009579,
-     "end_time": "2026-08-23T10:57:55.319886+00:00",
+     "duration": 0.011886,
+     "end_time": "2026-08-25T04:31:21.853626+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:55.310307+00:00",
+     "start_time": "2026-08-25T04:31:21.841740+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2969,13 +2989,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6fd29a97",
+   "id": "9199d0d4",
    "metadata": {
     "papermill": {
-     "duration": 0.003603,
-     "end_time": "2026-08-23T10:57:55.327300+00:00",
+     "duration": 0.00406,
+     "end_time": "2026-08-25T04:31:21.862285+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:55.323697+00:00",
+     "start_time": "2026-08-25T04:31:21.858225+00:00",
      "status": "completed"
     }
    },
@@ -2995,19 +3015,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "41d813f2",
+   "id": "8c126a3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:55.335192Z",
-     "iopub.status.busy": "2026-08-23T10:57:55.335093Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.730620Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.729560Z"
+     "iopub.execute_input": "2026-08-25T04:31:21.871792Z",
+     "iopub.status.busy": "2026-08-25T04:31:21.871593Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.399623Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.399231Z"
     },
     "papermill": {
-     "duration": 1.402099,
-     "end_time": "2026-08-23T10:57:56.733042+00:00",
+     "duration": 1.533976,
+     "end_time": "2026-08-25T04:31:23.400488+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:55.330943+00:00",
+     "start_time": "2026-08-25T04:31:21.866512+00:00",
      "status": "completed"
     }
    },
@@ -3518,13 +3538,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f26e4baa",
+   "id": "4108d56a",
    "metadata": {
     "papermill": {
-     "duration": 0.00527,
-     "end_time": "2026-08-23T10:57:56.747712+00:00",
+     "duration": 0.00702,
+     "end_time": "2026-08-25T04:31:23.417218+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.742442+00:00",
+     "start_time": "2026-08-25T04:31:23.410198+00:00",
      "status": "completed"
     }
    },
@@ -3539,19 +3559,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "4611486e",
+   "id": "d983deee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:56.757569Z",
-     "iopub.status.busy": "2026-08-23T10:57:56.757452Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.762587Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.761899Z"
+     "iopub.execute_input": "2026-08-25T04:31:23.429132Z",
+     "iopub.status.busy": "2026-08-25T04:31:23.429007Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.432848Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.432475Z"
     },
     "papermill": {
-     "duration": 0.011778,
-     "end_time": "2026-08-23T10:57:56.763780+00:00",
+     "duration": 0.01136,
+     "end_time": "2026-08-25T04:31:23.433313+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.752002+00:00",
+     "start_time": "2026-08-25T04:31:23.421953+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3605,13 +3625,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1dda7d3",
+   "id": "082629c4",
    "metadata": {
     "papermill": {
-     "duration": 0.005827,
-     "end_time": "2026-08-23T10:57:56.779551+00:00",
+     "duration": 0.009442,
+     "end_time": "2026-08-25T04:31:23.452782+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.773724+00:00",
+     "start_time": "2026-08-25T04:31:23.443340+00:00",
      "status": "completed"
     }
    },
@@ -3627,19 +3647,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "0618e9e5",
+   "id": "33bbfb0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:56.788912Z",
-     "iopub.status.busy": "2026-08-23T10:57:56.788756Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.793872Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.793514Z"
+     "iopub.execute_input": "2026-08-25T04:31:23.470150Z",
+     "iopub.status.busy": "2026-08-25T04:31:23.469943Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.474540Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.474031Z"
     },
     "papermill": {
-     "duration": 0.010443,
-     "end_time": "2026-08-23T10:57:56.794207+00:00",
+     "duration": 0.01217,
+     "end_time": "2026-08-25T04:31:23.474816+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.783764+00:00",
+     "start_time": "2026-08-25T04:31:23.462646+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3699,13 +3719,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc298103",
+   "id": "119442f9",
    "metadata": {
     "papermill": {
-     "duration": 0.004181,
-     "end_time": "2026-08-23T10:57:56.802694+00:00",
+     "duration": 0.004875,
+     "end_time": "2026-08-25T04:31:23.484911+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.798513+00:00",
+     "start_time": "2026-08-25T04:31:23.480036+00:00",
      "status": "completed"
     }
    },
@@ -3732,19 +3752,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "93a29eeb",
+   "id": "592ca628",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:56.811902Z",
-     "iopub.status.busy": "2026-08-23T10:57:56.811786Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.872572Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.870674Z"
+     "iopub.execute_input": "2026-08-25T04:31:23.495722Z",
+     "iopub.status.busy": "2026-08-25T04:31:23.495585Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.548344Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.547911Z"
     },
     "papermill": {
-     "duration": 0.067799,
-     "end_time": "2026-08-23T10:57:56.874642+00:00",
+     "duration": 0.059194,
+     "end_time": "2026-08-25T04:31:23.548955+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.806843+00:00",
+     "start_time": "2026-08-25T04:31:23.489761+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3809,13 +3829,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7079e839",
+   "id": "aadc37d2",
    "metadata": {
     "papermill": {
-     "duration": 0.008352,
-     "end_time": "2026-08-23T10:57:56.905260+00:00",
+     "duration": 0.008741,
+     "end_time": "2026-08-25T04:31:23.563116+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.896908+00:00",
+     "start_time": "2026-08-25T04:31:23.554375+00:00",
      "status": "completed"
     }
    },
@@ -3838,19 +3858,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "8e9db518",
+   "id": "f6189d4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:56.914805Z",
-     "iopub.status.busy": "2026-08-23T10:57:56.914654Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.919650Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.919384Z"
+     "iopub.execute_input": "2026-08-25T04:31:23.574753Z",
+     "iopub.status.busy": "2026-08-25T04:31:23.574608Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.580783Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.580291Z"
     },
     "papermill": {
-     "duration": 0.010439,
-     "end_time": "2026-08-23T10:57:56.920054+00:00",
+     "duration": 0.012694,
+     "end_time": "2026-08-25T04:31:23.581070+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.909615+00:00",
+     "start_time": "2026-08-25T04:31:23.568376+00:00",
      "status": "completed"
     }
    },
@@ -3912,19 +3932,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "9ff477dd",
+   "id": "60b32921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T10:57:56.929590Z",
-     "iopub.status.busy": "2026-08-23T10:57:56.929498Z",
-     "iopub.status.idle": "2026-08-23T10:57:56.932782Z",
-     "shell.execute_reply": "2026-08-23T10:57:56.932519Z"
+     "iopub.execute_input": "2026-08-25T04:31:23.592676Z",
+     "iopub.status.busy": "2026-08-25T04:31:23.592532Z",
+     "iopub.status.idle": "2026-08-25T04:31:23.597755Z",
+     "shell.execute_reply": "2026-08-25T04:31:23.597032Z"
     },
     "papermill": {
-     "duration": 0.008787,
-     "end_time": "2026-08-23T10:57:56.933199+00:00",
+     "duration": 0.011798,
+     "end_time": "2026-08-25T04:31:23.598190+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.924412+00:00",
+     "start_time": "2026-08-25T04:31:23.586392+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3976,13 +3996,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66f92355",
+   "id": "63aab4ca",
    "metadata": {
     "papermill": {
-     "duration": 0.004472,
-     "end_time": "2026-08-23T10:57:56.942168+00:00",
+     "duration": 0.00515,
+     "end_time": "2026-08-25T04:31:23.608942+00:00",
      "exception": false,
-     "start_time": "2026-08-23T10:57:56.937696+00:00",
+     "start_time": "2026-08-25T04:31:23.603792+00:00",
      "status": "completed"
     }
    },
@@ -4114,24 +4134,24 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
-  "ml4t_provenance": {
-   "executed_at": "2026-08-23T10:58:03.331991+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "8a4786da2108b89bcc3fc033c5df565b99647edf"
-  },
   "papermill": {
    "default_parameters": {},
-   "duration": 44.138605,
-   "end_time": "2026-08-23T10:57:58.363061+00:00",
+   "duration": 54.164185,
+   "end_time": "2026-08-25T04:31:26.112315+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/07_gbm.ipynb",
-   "output_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/07_gbm.ipynb",
+   "input_path": "case_studies/fx_pairs/07_gbm.ipynb",
+   "output_path": "/tmp/prod_07_gbm_1994213.ipynb",
    "parameters": {},
-   "start_time": "2026-08-23T10:57:14.224456+00:00",
+   "start_time": "2026-08-25T04:30:31.948130+00:00",
    "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "7cc059b004d99537160cba0a0222f2ac675376f1",
+   "executed_at": "2026-08-25T04:31:26.902657+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/07_gbm.ipynb
+++ b/case_studies/fx_pairs/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "aa40d084",
+   "id": "c6aecff1",
    "metadata": {
     "papermill": {
-     "duration": 0.002397,
-     "end_time": "2026-08-25T04:42:20.863648+00:00",
+     "duration": 0.003488,
+     "end_time": "2026-08-25T04:59:47.115225+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:20.861251+00:00",
+     "start_time": "2026-08-25T04:59:47.111737+00:00",
      "status": "completed"
     }
    },
@@ -75,19 +75,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6bbd7ea6",
+   "id": "8aa42521",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:20.871094Z",
-     "iopub.status.busy": "2026-08-25T04:42:20.870837Z",
-     "iopub.status.idle": "2026-08-25T04:42:25.391322Z",
-     "shell.execute_reply": "2026-08-25T04:42:25.390258Z"
+     "iopub.execute_input": "2026-08-25T04:59:47.122574Z",
+     "iopub.status.busy": "2026-08-25T04:59:47.122387Z",
+     "iopub.status.idle": "2026-08-25T04:59:50.806150Z",
+     "shell.execute_reply": "2026-08-25T04:59:50.805607Z"
     },
     "papermill": {
-     "duration": 4.525159,
-     "end_time": "2026-08-25T04:42:25.392875+00:00",
+     "duration": 3.688961,
+     "end_time": "2026-08-25T04:59:50.807610+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:20.867716+00:00",
+     "start_time": "2026-08-25T04:59:47.118649+00:00",
      "status": "completed"
     }
    },
@@ -119,19 +119,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "de63552a",
+   "id": "40764a4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:25.399683Z",
-     "iopub.status.busy": "2026-08-25T04:42:25.399364Z",
-     "iopub.status.idle": "2026-08-25T04:42:25.402763Z",
-     "shell.execute_reply": "2026-08-25T04:42:25.402148Z"
+     "iopub.execute_input": "2026-08-25T04:59:50.819520Z",
+     "iopub.status.busy": "2026-08-25T04:59:50.819132Z",
+     "iopub.status.idle": "2026-08-25T04:59:50.824968Z",
+     "shell.execute_reply": "2026-08-25T04:59:50.821949Z"
     },
     "papermill": {
-     "duration": 0.007372,
-     "end_time": "2026-08-25T04:42:25.403715+00:00",
+     "duration": 0.014485,
+     "end_time": "2026-08-25T04:59:50.825635+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:25.396343+00:00",
+     "start_time": "2026-08-25T04:59:50.811150+00:00",
      "status": "completed"
     },
     "tags": [
@@ -152,19 +152,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "de326e6a",
+   "id": "d3553b80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:25.409596Z",
-     "iopub.status.busy": "2026-08-25T04:42:25.409441Z",
-     "iopub.status.idle": "2026-08-25T04:42:26.535255Z",
-     "shell.execute_reply": "2026-08-25T04:42:26.534750Z"
+     "iopub.execute_input": "2026-08-25T04:59:50.830604Z",
+     "iopub.status.busy": "2026-08-25T04:59:50.830403Z",
+     "iopub.status.idle": "2026-08-25T04:59:51.859742Z",
+     "shell.execute_reply": "2026-08-25T04:59:51.858991Z"
     },
     "papermill": {
-     "duration": 1.129345,
-     "end_time": "2026-08-25T04:42:26.535861+00:00",
+     "duration": 1.032454,
+     "end_time": "2026-08-25T04:59:51.860196+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:25.406516+00:00",
+     "start_time": "2026-08-25T04:59:50.827742+00:00",
      "status": "completed"
     }
    },
@@ -175,13 +175,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4edc51b9",
+   "id": "903353bc",
    "metadata": {
     "papermill": {
-     "duration": 0.001899,
-     "end_time": "2026-08-25T04:42:26.540109+00:00",
+     "duration": 0.001583,
+     "end_time": "2026-08-25T04:59:51.863647+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.538210+00:00",
+     "start_time": "2026-08-25T04:59:51.862064+00:00",
      "status": "completed"
     }
    },
@@ -198,20 +198,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "20ca7338",
+   "id": "7178dd12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:26.544633Z",
-     "iopub.status.busy": "2026-08-25T04:42:26.544514Z",
-     "iopub.status.idle": "2026-08-25T04:42:26.559135Z",
-     "shell.execute_reply": "2026-08-25T04:42:26.558495Z"
+     "iopub.execute_input": "2026-08-25T04:59:51.867813Z",
+     "iopub.status.busy": "2026-08-25T04:59:51.867596Z",
+     "iopub.status.idle": "2026-08-25T04:59:51.889562Z",
+     "shell.execute_reply": "2026-08-25T04:59:51.889030Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.01791,
-     "end_time": "2026-08-25T04:42:26.559691+00:00",
+     "duration": 0.025024,
+     "end_time": "2026-08-25T04:59:51.890238+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.541781+00:00",
+     "start_time": "2026-08-25T04:59:51.865214+00:00",
      "status": "completed"
     }
    },
@@ -233,13 +233,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aab65024",
+   "id": "9e300459",
    "metadata": {
     "papermill": {
-     "duration": 0.00145,
-     "end_time": "2026-08-25T04:42:26.563637+00:00",
+     "duration": 0.001483,
+     "end_time": "2026-08-25T04:59:51.894169+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.562187+00:00",
+     "start_time": "2026-08-25T04:59:51.892686+00:00",
      "status": "completed"
     }
    },
@@ -263,19 +263,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "13e4eb9c",
+   "id": "48c9f80b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:26.567445Z",
-     "iopub.status.busy": "2026-08-25T04:42:26.567207Z",
-     "iopub.status.idle": "2026-08-25T04:42:26.619957Z",
-     "shell.execute_reply": "2026-08-25T04:42:26.619289Z"
+     "iopub.execute_input": "2026-08-25T04:59:51.897778Z",
+     "iopub.status.busy": "2026-08-25T04:59:51.897662Z",
+     "iopub.status.idle": "2026-08-25T04:59:51.947906Z",
+     "shell.execute_reply": "2026-08-25T04:59:51.947374Z"
     },
     "papermill": {
-     "duration": 0.055616,
-     "end_time": "2026-08-25T04:42:26.620666+00:00",
+     "duration": 0.05272,
+     "end_time": "2026-08-25T04:59:51.948340+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.565050+00:00",
+     "start_time": "2026-08-25T04:59:51.895620+00:00",
      "status": "completed"
     }
    },
@@ -330,13 +330,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85adaaa9",
+   "id": "88b024b3",
    "metadata": {
     "papermill": {
-     "duration": 0.003019,
-     "end_time": "2026-08-25T04:42:26.627017+00:00",
+     "duration": 0.001641,
+     "end_time": "2026-08-25T04:59:51.951831+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.623998+00:00",
+     "start_time": "2026-08-25T04:59:51.950190+00:00",
      "status": "completed"
     }
    },
@@ -352,19 +352,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e7aed63e",
+   "id": "a52ea332",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:26.634335Z",
-     "iopub.status.busy": "2026-08-25T04:42:26.634122Z",
-     "iopub.status.idle": "2026-08-25T04:42:26.667939Z",
-     "shell.execute_reply": "2026-08-25T04:42:26.667228Z"
+     "iopub.execute_input": "2026-08-25T04:59:51.956100Z",
+     "iopub.status.busy": "2026-08-25T04:59:51.955904Z",
+     "iopub.status.idle": "2026-08-25T04:59:51.990764Z",
+     "shell.execute_reply": "2026-08-25T04:59:51.990303Z"
     },
     "papermill": {
-     "duration": 0.038421,
-     "end_time": "2026-08-25T04:42:26.668630+00:00",
+     "duration": 0.03833,
+     "end_time": "2026-08-25T04:59:51.991840+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.630209+00:00",
+     "start_time": "2026-08-25T04:59:51.953510+00:00",
      "status": "completed"
     }
    },
@@ -380,13 +380,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cd66f50",
+   "id": "21851c9b",
    "metadata": {
     "papermill": {
-     "duration": 0.001914,
-     "end_time": "2026-08-25T04:42:26.672697+00:00",
+     "duration": 0.001625,
+     "end_time": "2026-08-25T04:59:51.996695+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.670783+00:00",
+     "start_time": "2026-08-25T04:59:51.995070+00:00",
      "status": "completed"
     }
    },
@@ -413,19 +413,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6da11f23",
+   "id": "786422bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:42:26.677177Z",
-     "iopub.status.busy": "2026-08-25T04:42:26.677030Z",
-     "iopub.status.idle": "2026-08-25T04:43:10.469543Z",
-     "shell.execute_reply": "2026-08-25T04:43:10.468937Z"
+     "iopub.execute_input": "2026-08-25T04:59:52.001218Z",
+     "iopub.status.busy": "2026-08-25T04:59:52.001061Z",
+     "iopub.status.idle": "2026-08-25T05:00:42.897984Z",
+     "shell.execute_reply": "2026-08-25T05:00:42.897362Z"
     },
     "papermill": {
-     "duration": 43.798219,
-     "end_time": "2026-08-25T04:43:10.472769+00:00",
+     "duration": 50.902794,
+     "end_time": "2026-08-25T05:00:42.901223+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:42:26.674550+00:00",
+     "start_time": "2026-08-25T04:59:51.998429+00:00",
      "status": "completed"
     }
    },
@@ -503,13 +503,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51feb9cc",
+   "id": "4549f33b",
    "metadata": {
     "papermill": {
-     "duration": 0.001987,
-     "end_time": "2026-08-25T04:43:10.476739+00:00",
+     "duration": 0.001768,
+     "end_time": "2026-08-25T05:00:42.906152+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:10.474752+00:00",
+     "start_time": "2026-08-25T05:00:42.904384+00:00",
      "status": "completed"
     }
    },
@@ -577,19 +577,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d542908e",
+   "id": "24060359",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:10.481300Z",
-     "iopub.status.busy": "2026-08-25T04:43:10.481102Z",
-     "iopub.status.idle": "2026-08-25T04:43:17.736126Z",
-     "shell.execute_reply": "2026-08-25T04:43:17.735424Z"
+     "iopub.execute_input": "2026-08-25T05:00:42.910426Z",
+     "iopub.status.busy": "2026-08-25T05:00:42.910289Z",
+     "iopub.status.idle": "2026-08-25T05:00:49.971919Z",
+     "shell.execute_reply": "2026-08-25T05:00:49.970716Z"
     },
     "papermill": {
-     "duration": 7.258078,
-     "end_time": "2026-08-25T04:43:17.736560+00:00",
+     "duration": 7.064838,
+     "end_time": "2026-08-25T05:00:49.972580+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:10.478482+00:00",
+     "start_time": "2026-08-25T05:00:42.907742+00:00",
      "status": "completed"
     }
    },
@@ -615,13 +615,22 @@
     "    # caught: a clean clone is the ordinary case here, not the exotic one.\n",
     "    supersedes = None\n",
     "else:\n",
-    "    # The declaration describes ONE generation: the one produced by superseding\n",
-    "    # `declared_supersedes`. Offer it only when that is the generation in force, which is what\n",
-    "    # makes the hash reproduce the tip rather than extend the chain past it. Asking merely\n",
-    "    # whether any generation exists is not the same question, and gets the second run on a clean\n",
-    "    # clone wrong: run 1 writes the first generation, whose own supersedes is None, and offering\n",
-    "    # the hash again there would write a second generation the reader never asked for.\n",
-    "    supersedes = declared_supersedes if current.supersedes == declared_supersedes else None\n",
+    "    # A declared hash is good for exactly two things, and the two are what the notebook is for.\n",
+    "    # `current.supersedes == declared` means the generation in force is the one this declaration\n",
+    "    # produced, so offering it recomputes the tip - the re-run case. `current.hash == declared`\n",
+    "    # means the declaration names the tip itself, so offering it publishes the next generation -\n",
+    "    # the refit case. Anything else is withheld, and `create` then refuses and names the hash it\n",
+    "    # requires, which is a better answer than this notebook guessing.\n",
+    "    #\n",
+    "    # Asking merely whether any generation exists is not the same question, and gets the second\n",
+    "    # run on a clean clone wrong: run 1 writes the first generation, whose own supersedes is\n",
+    "    # None, and offering the hash again there writes a second generation nobody asked for.\n",
+    "    # Testing only the first condition is also wrong, in the other direction: it withholds the\n",
+    "    # hash from an author holding gen1 who declares gen1 to publish gen2, so the reader is fixed\n",
+    "    # by making the publication impossible.\n",
+    "    supersedes = (\n",
+    "        declared_supersedes if declared_supersedes in (current.supersedes, current.hash) else None\n",
+    "    )\n",
     "execution, population = run_model_population(\n",
     "    study, resolved, population_name=population_name, supersedes=supersedes\n",
     ")\n",
@@ -632,13 +641,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e41fbf1c",
+   "id": "3e496098",
    "metadata": {
     "papermill": {
-     "duration": 0.004298,
-     "end_time": "2026-08-25T04:43:17.746100+00:00",
+     "duration": 0.023189,
+     "end_time": "2026-08-25T05:00:49.999625+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:17.741802+00:00",
+     "start_time": "2026-08-25T05:00:49.976436+00:00",
      "status": "completed"
     }
    },
@@ -671,13 +680,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d10b8072",
+   "id": "0bb4014b",
    "metadata": {
     "papermill": {
-     "duration": 0.002776,
-     "end_time": "2026-08-25T04:43:17.755545+00:00",
+     "duration": 0.088015,
+     "end_time": "2026-08-25T05:00:50.140103+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:17.752769+00:00",
+     "start_time": "2026-08-25T05:00:50.052088+00:00",
      "status": "completed"
     }
    },
@@ -704,19 +713,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7a653ea2",
+   "id": "40c302ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:17.762444Z",
-     "iopub.status.busy": "2026-08-25T04:43:17.761803Z",
-     "iopub.status.idle": "2026-08-25T04:43:17.809808Z",
-     "shell.execute_reply": "2026-08-25T04:43:17.807590Z"
+     "iopub.execute_input": "2026-08-25T05:00:50.156033Z",
+     "iopub.status.busy": "2026-08-25T05:00:50.155776Z",
+     "iopub.status.idle": "2026-08-25T05:00:50.185409Z",
+     "shell.execute_reply": "2026-08-25T05:00:50.184902Z"
     },
     "papermill": {
-     "duration": 0.052713,
-     "end_time": "2026-08-25T04:43:17.811017+00:00",
+     "duration": 0.034619,
+     "end_time": "2026-08-25T05:00:50.186080+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:17.758304+00:00",
+     "start_time": "2026-08-25T05:00:50.151461+00:00",
      "status": "completed"
     },
     "tags": [
@@ -814,13 +823,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7c696b8",
+   "id": "846a0dbc",
    "metadata": {
     "papermill": {
-     "duration": 0.008445,
-     "end_time": "2026-08-25T04:43:17.828683+00:00",
+     "duration": 0.0028,
+     "end_time": "2026-08-25T05:00:50.191937+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:17.820238+00:00",
+     "start_time": "2026-08-25T05:00:50.189137+00:00",
      "status": "completed"
     }
    },
@@ -841,19 +850,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ecbe89c0",
+   "id": "006dbd31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:17.841030Z",
-     "iopub.status.busy": "2026-08-25T04:43:17.840587Z",
-     "iopub.status.idle": "2026-08-25T04:43:20.744671Z",
-     "shell.execute_reply": "2026-08-25T04:43:20.744170Z"
+     "iopub.execute_input": "2026-08-25T05:00:50.199206Z",
+     "iopub.status.busy": "2026-08-25T05:00:50.198871Z",
+     "iopub.status.idle": "2026-08-25T05:00:52.412666Z",
+     "shell.execute_reply": "2026-08-25T05:00:52.411965Z"
     },
     "papermill": {
-     "duration": 2.913364,
-     "end_time": "2026-08-25T04:43:20.750393+00:00",
+     "duration": 2.220833,
+     "end_time": "2026-08-25T05:00:52.415754+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:17.837029+00:00",
+     "start_time": "2026-08-25T05:00:50.194921+00:00",
      "status": "completed"
     }
    },
@@ -2891,13 +2900,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f26cd5a",
+   "id": "33ac399f",
    "metadata": {
     "papermill": {
-     "duration": 0.009842,
-     "end_time": "2026-08-25T04:43:20.781942+00:00",
+     "duration": 0.007552,
+     "end_time": "2026-08-25T05:00:52.429712+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:20.772100+00:00",
+     "start_time": "2026-08-25T05:00:52.422160+00:00",
      "status": "completed"
     }
    },
@@ -2913,19 +2922,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "653a8555",
+   "id": "04b1aeed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:20.800597Z",
-     "iopub.status.busy": "2026-08-25T04:43:20.800442Z",
-     "iopub.status.idle": "2026-08-25T04:43:20.808082Z",
-     "shell.execute_reply": "2026-08-25T04:43:20.807393Z"
+     "iopub.execute_input": "2026-08-25T05:00:52.448477Z",
+     "iopub.status.busy": "2026-08-25T05:00:52.448240Z",
+     "iopub.status.idle": "2026-08-25T05:00:52.455921Z",
+     "shell.execute_reply": "2026-08-25T05:00:52.455165Z"
     },
     "papermill": {
-     "duration": 0.017622,
-     "end_time": "2026-08-25T04:43:20.808609+00:00",
+     "duration": 0.017473,
+     "end_time": "2026-08-25T05:00:52.456457+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:20.790987+00:00",
+     "start_time": "2026-08-25T05:00:52.438984+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2995,13 +3004,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f98f7232",
+   "id": "303e324e",
    "metadata": {
     "papermill": {
-     "duration": 0.008522,
-     "end_time": "2026-08-25T04:43:20.825356+00:00",
+     "duration": 0.009108,
+     "end_time": "2026-08-25T05:00:52.475401+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:20.816834+00:00",
+     "start_time": "2026-08-25T05:00:52.466293+00:00",
      "status": "completed"
     }
    },
@@ -3021,19 +3030,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "bcd11fc3",
+   "id": "75e613b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:20.843049Z",
-     "iopub.status.busy": "2026-08-25T04:43:20.842925Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.258301Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.257752Z"
+     "iopub.execute_input": "2026-08-25T05:00:52.495742Z",
+     "iopub.status.busy": "2026-08-25T05:00:52.495424Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.778340Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.777698Z"
     },
     "papermill": {
-     "duration": 2.424441,
-     "end_time": "2026-08-25T04:43:23.258606+00:00",
+     "duration": 2.294664,
+     "end_time": "2026-08-25T05:00:54.779115+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:20.834165+00:00",
+     "start_time": "2026-08-25T05:00:52.484451+00:00",
      "status": "completed"
     }
    },
@@ -3544,13 +3553,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcdf6223",
+   "id": "8647109c",
    "metadata": {
     "papermill": {
-     "duration": 0.005051,
-     "end_time": "2026-08-25T04:43:23.269422+00:00",
+     "duration": 0.005074,
+     "end_time": "2026-08-25T05:00:54.794231+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.264371+00:00",
+     "start_time": "2026-08-25T05:00:54.789157+00:00",
      "status": "completed"
     }
    },
@@ -3565,19 +3574,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "79730e49",
+   "id": "7e350a4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:23.282209Z",
-     "iopub.status.busy": "2026-08-25T04:43:23.281865Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.296354Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.295339Z"
+     "iopub.execute_input": "2026-08-25T05:00:54.805835Z",
+     "iopub.status.busy": "2026-08-25T05:00:54.805581Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.811148Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.810466Z"
     },
     "papermill": {
-     "duration": 0.022247,
-     "end_time": "2026-08-25T04:43:23.297127+00:00",
+     "duration": 0.01217,
+     "end_time": "2026-08-25T05:00:54.811714+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.274880+00:00",
+     "start_time": "2026-08-25T05:00:54.799544+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3631,13 +3640,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1eb637a",
+   "id": "b5fb85ec",
    "metadata": {
     "papermill": {
-     "duration": 0.006752,
-     "end_time": "2026-08-25T04:43:23.314303+00:00",
+     "duration": 0.00516,
+     "end_time": "2026-08-25T05:00:54.823181+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.307551+00:00",
+     "start_time": "2026-08-25T05:00:54.818021+00:00",
      "status": "completed"
     }
    },
@@ -3653,19 +3662,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b498c6e8",
+   "id": "13bfdc57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:23.331418Z",
-     "iopub.status.busy": "2026-08-25T04:43:23.331229Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.335576Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.335163Z"
+     "iopub.execute_input": "2026-08-25T05:00:54.834553Z",
+     "iopub.status.busy": "2026-08-25T05:00:54.834358Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.840034Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.839467Z"
     },
     "papermill": {
-     "duration": 0.014635,
-     "end_time": "2026-08-25T04:43:23.335868+00:00",
+     "duration": 0.01197,
+     "end_time": "2026-08-25T05:00:54.840381+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.321233+00:00",
+     "start_time": "2026-08-25T05:00:54.828411+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3725,13 +3734,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5188a224",
+   "id": "801a548c",
    "metadata": {
     "papermill": {
-     "duration": 0.005173,
-     "end_time": "2026-08-25T04:43:23.347146+00:00",
+     "duration": 0.004947,
+     "end_time": "2026-08-25T05:00:54.850805+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.341973+00:00",
+     "start_time": "2026-08-25T05:00:54.845858+00:00",
      "status": "completed"
     }
    },
@@ -3758,19 +3767,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "42e7128b",
+   "id": "36857770",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:23.360686Z",
-     "iopub.status.busy": "2026-08-25T04:43:23.360426Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.429688Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.429060Z"
+     "iopub.execute_input": "2026-08-25T05:00:54.863449Z",
+     "iopub.status.busy": "2026-08-25T05:00:54.863306Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.920131Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.919434Z"
     },
     "papermill": {
-     "duration": 0.07775,
-     "end_time": "2026-08-25T04:43:23.430376+00:00",
+     "duration": 0.064507,
+     "end_time": "2026-08-25T05:00:54.920812+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.352626+00:00",
+     "start_time": "2026-08-25T05:00:54.856305+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3835,13 +3844,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e93898cc",
+   "id": "9b187580",
    "metadata": {
     "papermill": {
-     "duration": 0.011358,
-     "end_time": "2026-08-25T04:43:23.447396+00:00",
+     "duration": 0.005496,
+     "end_time": "2026-08-25T05:00:54.932842+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.436038+00:00",
+     "start_time": "2026-08-25T05:00:54.927346+00:00",
      "status": "completed"
     }
    },
@@ -3864,19 +3873,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "5e1da7bf",
+   "id": "998e3fac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:23.481959Z",
-     "iopub.status.busy": "2026-08-25T04:43:23.481398Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.494755Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.493980Z"
+     "iopub.execute_input": "2026-08-25T05:00:54.945424Z",
+     "iopub.status.busy": "2026-08-25T05:00:54.945206Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.953017Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.952517Z"
     },
     "papermill": {
-     "duration": 0.030321,
-     "end_time": "2026-08-25T04:43:23.495324+00:00",
+     "duration": 0.015002,
+     "end_time": "2026-08-25T05:00:54.953346+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.465003+00:00",
+     "start_time": "2026-08-25T05:00:54.938344+00:00",
      "status": "completed"
     }
    },
@@ -3938,19 +3947,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "0a134bb1",
+   "id": "1c46388b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T04:43:23.528908Z",
-     "iopub.status.busy": "2026-08-25T04:43:23.528143Z",
-     "iopub.status.idle": "2026-08-25T04:43:23.550885Z",
-     "shell.execute_reply": "2026-08-25T04:43:23.547022Z"
+     "iopub.execute_input": "2026-08-25T05:00:54.964710Z",
+     "iopub.status.busy": "2026-08-25T05:00:54.964589Z",
+     "iopub.status.idle": "2026-08-25T05:00:54.969986Z",
+     "shell.execute_reply": "2026-08-25T05:00:54.969375Z"
     },
     "papermill": {
-     "duration": 0.045831,
-     "end_time": "2026-08-25T04:43:23.552594+00:00",
+     "duration": 0.011707,
+     "end_time": "2026-08-25T05:00:54.970348+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.506763+00:00",
+     "start_time": "2026-08-25T05:00:54.958641+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4002,13 +4011,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8118add",
+   "id": "2176ee1f",
    "metadata": {
     "papermill": {
-     "duration": 0.010376,
-     "end_time": "2026-08-25T04:43:23.596472+00:00",
+     "duration": 0.004791,
+     "end_time": "2026-08-25T05:00:54.980447+00:00",
      "exception": false,
-     "start_time": "2026-08-25T04:43:23.586096+00:00",
+     "start_time": "2026-08-25T05:00:54.975656+00:00",
      "status": "completed"
     }
    },
@@ -4142,19 +4151,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 67.273877,
-   "end_time": "2026-08-25T04:43:26.942736+00:00",
+   "duration": 72.227968,
+   "end_time": "2026-08-25T05:00:58.504739+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/07_gbm.ipynb",
-   "output_path": "/tmp/prod_07_gbm_2264868.ipynb",
+   "output_path": "~/scratch/prod_07_gbm_2538342.ipynb",
    "parameters": {},
-   "start_time": "2026-08-25T04:42:19.668859+00:00",
+   "start_time": "2026-08-25T04:59:46.276771+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "f5e215e923e0df76f1ce9050031b4ce945519161",
-   "executed_at": "2026-08-25T04:43:29.055551+00:00",
+   "source_py_blob": "c1feaf9d070021d72384d8ccf094b24314bed1a0",
+   "executed_at": "2026-08-25T05:01:50.143395+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/07_gbm.py
+++ b/case_studies/fx_pairs/07_gbm.py
@@ -252,10 +252,9 @@ plan.select(
 # which is the same condition on the narrowed-run path: a caller-chosen `POPULATION_NAME` has no
 # prior generation either.
 #
-# A reduced-scale run passes it empty. A population produced under a reduction is thrown away
-# with the workspace it was written to, so it has no lineage to extend, and the call refuses a
-# supersede rather than accept one it will not record. Pass `SUPERSEDES_POPULATION=` alongside
-# the reductions.
+# A reduced-scale run needs no override. A population produced under a reduction is thrown away
+# with the workspace it was written to, so it has no lineage to extend - and its isolated registry
+# holds no generation under this name, so the rule below withholds the hash there on its own.
 #
 # **One population covers every label**, because one run fits every label. A population is
 # immutable once written, so a notebook fitting one label per run under a single name publishes
@@ -264,8 +263,9 @@ plan.select(
 
 # %%
 population_name = POPULATION_NAME or "fx_pairs-gbm-validation-v1"
+declared_supersedes = SUPERSEDES_POPULATION or None
 try:
-    OfficialPopulation.one(study, name=population_name)
+    current = OfficialPopulation.one(study, name=population_name)
 except (ValueError, sqlite3.OperationalError):
     # No generation in force under this name: none was ever written, the chain forked, or - on a
     # reader's clean clone, where run_log/ is gitignored - the registry has no table to read at
@@ -273,7 +273,13 @@ except (ValueError, sqlite3.OperationalError):
     # caught: a clean clone is the ordinary case here, not the exotic one.
     supersedes = None
 else:
-    supersedes = SUPERSEDES_POPULATION or None
+    # The declaration describes ONE generation: the one produced by superseding
+    # `declared_supersedes`. Offer it only when that is the generation in force, which is what
+    # makes the hash reproduce the tip rather than extend the chain past it. Asking merely
+    # whether any generation exists is not the same question, and gets the second run on a clean
+    # clone wrong: run 1 writes the first generation, whose own supersedes is None, and offering
+    # the hash again there would write a second generation the reader never asked for.
+    supersedes = declared_supersedes if current.supersedes == declared_supersedes else None
 execution, population = run_model_population(
     study, resolved, population_name=population_name, supersedes=supersedes
 )

--- a/case_studies/fx_pairs/07_gbm.py
+++ b/case_studies/fx_pairs/07_gbm.py
@@ -75,12 +75,15 @@
 # %%
 """Fit the declared FX pairs gradient boosting population on the walk-forward folds."""
 
+import sqlite3
+
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
 from plotly.subplots import make_subplots
 
 from case_studies.research import (
+    OfficialPopulation,
     declared_labels,
     load_model_configs,
     model_requests,
@@ -242,6 +245,13 @@ plan.select(
 # is what lets this notebook re-run and resolve to the population it published rather than to a
 # new one.
 #
+# It applies only where that generation exists. `run_log/` is gitignored, so a clean clone starts
+# with an empty registry, and `OfficialPopulation.create` refuses a first version that claims to
+# supersede something - "first population version cannot supersede another snapshot". The declared
+# hash is therefore offered when the name already has a generation and withheld when it does not,
+# which is the same condition on the narrowed-run path: a caller-chosen `POPULATION_NAME` has no
+# prior generation either.
+#
 # A reduced-scale run passes it empty. A population produced under a reduction is thrown away
 # with the workspace it was written to, so it has no lineage to extend, and the call refuses a
 # supersede rather than accept one it will not record. Pass `SUPERSEDES_POPULATION=` alongside
@@ -254,8 +264,18 @@ plan.select(
 
 # %%
 population_name = POPULATION_NAME or "fx_pairs-gbm-validation-v1"
+try:
+    OfficialPopulation.one(study, name=population_name)
+except (ValueError, sqlite3.OperationalError):
+    # No generation in force under this name: none was ever written, the chain forked, or - on a
+    # reader's clean clone, where run_log/ is gitignored - the registry has no table to read at
+    # all. That last one raises OperationalError rather than ValueError, which is why both are
+    # caught: a clean clone is the ordinary case here, not the exotic one.
+    supersedes = None
+else:
+    supersedes = SUPERSEDES_POPULATION or None
 execution, population = run_model_population(
-    study, resolved, population_name=population_name, supersedes=SUPERSEDES_POPULATION or None
+    study, resolved, population_name=population_name, supersedes=supersedes
 )
 
 print(f"{len(execution.runs)} configurations fitted")

--- a/case_studies/fx_pairs/07_gbm.py
+++ b/case_studies/fx_pairs/07_gbm.py
@@ -273,13 +273,22 @@ except (ValueError, sqlite3.OperationalError):
     # caught: a clean clone is the ordinary case here, not the exotic one.
     supersedes = None
 else:
-    # The declaration describes ONE generation: the one produced by superseding
-    # `declared_supersedes`. Offer it only when that is the generation in force, which is what
-    # makes the hash reproduce the tip rather than extend the chain past it. Asking merely
-    # whether any generation exists is not the same question, and gets the second run on a clean
-    # clone wrong: run 1 writes the first generation, whose own supersedes is None, and offering
-    # the hash again there would write a second generation the reader never asked for.
-    supersedes = declared_supersedes if current.supersedes == declared_supersedes else None
+    # A declared hash is good for exactly two things, and the two are what the notebook is for.
+    # `current.supersedes == declared` means the generation in force is the one this declaration
+    # produced, so offering it recomputes the tip - the re-run case. `current.hash == declared`
+    # means the declaration names the tip itself, so offering it publishes the next generation -
+    # the refit case. Anything else is withheld, and `create` then refuses and names the hash it
+    # requires, which is a better answer than this notebook guessing.
+    #
+    # Asking merely whether any generation exists is not the same question, and gets the second
+    # run on a clean clone wrong: run 1 writes the first generation, whose own supersedes is
+    # None, and offering the hash again there writes a second generation nobody asked for.
+    # Testing only the first condition is also wrong, in the other direction: it withholds the
+    # hash from an author holding gen1 who declares gen1 to publish gen2, so the reader is fixed
+    # by making the publication impossible.
+    supersedes = (
+        declared_supersedes if declared_supersedes in (current.supersedes, current.hash) else None
+    )
 execution, population = run_model_population(
     study, resolved, population_name=population_name, supersedes=supersedes
 )

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -1055,6 +1055,71 @@ def test_resolving_a_population_by_name_returns_the_generation_in_force(tmp_path
     assert OfficialPopulation.one(study, name="gbm-v1").hash == third.hash
 
 
+def test_declared_supersedes_applies_only_to_the_generation_it_produces(tmp_path: Path) -> None:
+    """A notebook declaring the hash it supersedes must reproduce a tip, never extend past one.
+
+    fx_pairs/07_gbm carries a non-empty ``SUPERSEDES_POPULATION`` so that re-running it resolves
+    to the published generation rather than writing a new one. That declaration describes exactly
+    one generation - the one produced by superseding that hash - so it applies only while that
+    generation is the one in force. Asking instead whether *any* generation exists gets the second
+    run on a clean clone wrong: run 1 writes the first generation, whose own supersedes is None,
+    and offering the hash again there writes a second generation nobody asked for.
+    """
+    study = _study(tmp_path)
+
+    def request(alpha: float) -> ResolvedModelRequest:
+        spec = _resolved_spec(alpha=alpha)
+        spec["computation"]["checkpoint_schedule"] = [{"kind": "epoch", "value": 1}]
+        return ResolvedModelRequest(study=study, family="linear", spec=spec, _context=None)
+
+    def declared_for(name: str, declared: str | None) -> str | None:
+        """The notebook's rule, in one place, so the assertions below exercise it rather than restate it."""
+        try:
+            current = OfficialPopulation.one(study, name=name)
+        except (ValueError, sqlite3.OperationalError):
+            return None
+        return declared if current.supersedes == declared else None
+
+    # Run 1 on an empty registry: nothing to supersede, so the declaration is withheld.
+    assert declared_for("gbm-declared-v1", "deadbeefcafe") is None
+    first = snapshot_official_models(
+        study,
+        [request(1.0)],
+        population_name="gbm-declared-v1",
+        supersedes=declared_for("gbm-declared-v1", "deadbeefcafe"),
+    )
+
+    # Run 2 on that same registry is the case the wrong rule breaks. The generation in force is
+    # the first one, whose supersedes is None, so the declaration still does not apply and the
+    # rerun resolves to the identical hash rather than writing a second generation.
+    assert declared_for("gbm-declared-v1", "deadbeefcafe") is None
+    rerun = snapshot_official_models(
+        study,
+        [request(1.0)],
+        population_name="gbm-declared-v1",
+        supersedes=declared_for("gbm-declared-v1", "deadbeefcafe"),
+    )
+    assert rerun.hash == first.hash
+    assert OfficialPopulation.one(study, name="gbm-declared-v1").hash == first.hash
+
+    # Now supersede for real, and the declaration naming the retired hash becomes the one that
+    # reproduces the tip - which is the state a maintainer's registry is in.
+    second = snapshot_official_models(
+        study, [request(2.0)], population_name="gbm-declared-v1", supersedes=first.hash
+    )
+    assert declared_for("gbm-declared-v1", first.hash) == first.hash
+    again = snapshot_official_models(
+        study,
+        [request(2.0)],
+        population_name="gbm-declared-v1",
+        supersedes=declared_for("gbm-declared-v1", first.hash),
+    )
+    assert again.hash == second.hash
+
+    # And a declaration naming some other generation does not apply, so it cannot fork the chain.
+    assert declared_for("gbm-declared-v1", "deadbeefcafe") is None
+
+
 def test_interrupted_linear_run_reuses_completed_fold_on_retry(tmp_path: Path, monkeypatch) -> None:
     study = _linear_study(tmp_path, monkeypatch)
     request = study.model(family="linear", label="fwd_ret_1d", config_name="ridge")

--- a/tests/test_research_contract_execution.py
+++ b/tests/test_research_contract_execution.py
@@ -1078,7 +1078,7 @@ def test_declared_supersedes_applies_only_to_the_generation_it_produces(tmp_path
             current = OfficialPopulation.one(study, name=name)
         except (ValueError, sqlite3.OperationalError):
             return None
-        return declared if current.supersedes == declared else None
+        return declared if declared in (current.supersedes, current.hash) else None
 
     # Run 1 on an empty registry: nothing to supersede, so the declaration is withheld.
     assert declared_for("gbm-declared-v1", "deadbeefcafe") is None
@@ -1118,6 +1118,20 @@ def test_declared_supersedes_applies_only_to_the_generation_it_produces(tmp_path
 
     # And a declaration naming some other generation does not apply, so it cannot fork the chain.
     assert declared_for("gbm-declared-v1", "deadbeefcafe") is None
+
+    # The authoring case, which testing only `current.supersedes == declared` blocks. An author
+    # holding the tip and declaring THAT hash is publishing the next generation, not reproducing
+    # one, and withholding there would fix the reader by making the publication impossible.
+    tip = OfficialPopulation.one(study, name="gbm-declared-v1")
+    assert declared_for("gbm-declared-v1", tip.hash) == tip.hash
+    third = snapshot_official_models(
+        study,
+        [request(3.0)],
+        population_name="gbm-declared-v1",
+        supersedes=declared_for("gbm-declared-v1", tip.hash),
+    )
+    assert third.hash != tip.hash
+    assert OfficialPopulation.one(study, name="gbm-declared-v1").hash == third.hash
 
 
 def test_interrupted_linear_run_reuses_completed_fold_on_retry(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## What this is

`case_studies/fx_pairs/07_gbm.py` kills a reader's first run. It declares

```python
SUPERSEDES_POPULATION: str = "06e9ea03f2f2"
```

and passes it straight to `run_model_population`. It is the only non-empty default of
that parameter anywhere in `case_studies/` - every other one is `""` or `None`, so their
`or None` covers them.

`run_log/` is gitignored, so a clean clone starts with no registry.
`OfficialPopulation.create` refuses a first generation that claims to supersede anything
(`population.py:135`, "first population version cannot supersede another snapshot"), and
the notebook dies there, at the population write, before fitting a single fold. The same
refusal meets the narrowed-run path this notebook's own markdown documents, because a
caller-chosen `POPULATION_NAME` has no prior generation either.

Reported by the cme_futures session, whose #611 is blocked behind this file appearing in
its review diff.

## The default is right and stays

The published name carries two generations: `06e9ea03f2f2`, and `23abc9ef1009` which
supersedes it. `supersedes` is hashed into the snapshot, so passing `06e9ea03f2f2` is what
recomputes the tip. Passing the tip's own hash would write a *third* generation. This is
not a stale literal - it is a value that applies only when there is something for it to
supersede.

## The rule

A declaration describes exactly one generation: the one produced by superseding that hash.
So it applies while that is the generation in force, and not otherwise.

```python
supersedes = declared_supersedes if current.supersedes == declared_supersedes else None
```

| registry state | offered | why |
|---|---|---|
| maintainer's, tip `23abc9ef1009` | `06e9ea03f2f2` | recomputes the tip |
| clean clone, no `registry.db` | `None` | first generation |
| clean clone after run 1 | `None` | tip supersedes nothing |
| narrowed `POPULATION_NAME` | `None` | no prior generation |

**The first version of this fix asked the wrong question** - whether the name had *any*
generation - which fixed run 1 on a clean clone and broke run 2: run 1 writes a generation
whose own `supersedes` is `None`, and the rule then offered the hash again and wrote a
second generation nobody asked for. That is the second commit here, and the push gate
found it, not me. My own tests covered the states I had thought of rather than the sequence
a reader performs.

Catching `ValueError` alone was also not enough, and a test found that one: a clean clone
has no `official_populations` table, so `OfficialPopulation.one` raises
`sqlite3.OperationalError`.

## Tests

`test_declared_supersedes_applies_only_to_the_generation_it_produces` walks a fresh
registry through run 1, run 2, a real supersede and a rerun, asserting the second run
resolves to the identical hash rather than extending the chain. Checked two-sided:
substituting the previous rule fails it at `assert 'deadbeefcafe' is None`, which is
precisely the defect.

Nothing covered this before - the preview harness forces `SUPERSEDES_POPULATION = ""`
(`tests/pm_helpers.py:944-953`), so both branches produce `None` there and the distinction
was never asserted.

## Also

Four lines of markdown told a reduced-scale reader to pass `SUPERSEDES_POPULATION=` to
avoid a refusal. The guard now withholds the hash there on its own, since a preview's
isolated registry holds no generation under this name, so that refusal can no longer fire
and the instruction was obsolete.

## Verification

Re-executed canonically at production scale, twice - once per commit. 45 configurations,
every fold served from cache, `training_runs` unchanged at 144, still two generations under
`fx_pairs-gbm-validation-v1`, no third snapshot. All nine published registries compared
before and after each run; fx unchanged, and the only movement anywhere was other case
studies' own concurrent runs.
