### PR TITLE
Two causal notebooks could be refused at the registering write with no way to answer

### DIFF
--- a/case_studies/etfs/12_causal_dml.ipynb
+++ b/case_studies/etfs/12_causal_dml.ipynb
@@ -71,23 +71,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d4694bb9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:20.163455Z",
-     "iopub.status.busy": "2026-08-24T20:08:20.163280Z",
-     "iopub.status.idle": "2026-08-24T20:08:23.722284Z",
-     "shell.execute_reply": "2026-08-24T20:08:23.721763Z"
-    },
-    "papermill": {
-     "duration": 3.562379,
-     "end_time": "2026-08-24T20:08:23.723118+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:20.160739+00:00",
-     "status": "completed"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Causal DML - walk-forward estimation with refutation tests.\"\"\"\n",
@@ -100,6 +86,7 @@
     "import yaml\n",
     "\n",
     "import utils.style  # noqa: F401 - activates the ML4T visual style\n",
+    "from case_studies.research import supersedes_for\n",
     "from case_studies.utils.causal import (\n",
     "    classify_refutation,\n",
     "    embargo_from_buffer,\n",
@@ -116,22 +103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "218c6de4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:23.727554Z",
-     "iopub.status.busy": "2026-08-24T20:08:23.727394Z",
-     "iopub.status.idle": "2026-08-24T20:08:23.729449Z",
-     "shell.execute_reply": "2026-08-24T20:08:23.729054Z"
-    },
-    "papermill": {
-     "duration": 0.004772,
-     "end_time": "2026-08-24T20:08:23.729894+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:23.725122+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -144,44 +118,21 @@
     "RANDOM_SEED = 42\n",
     "CV_FOLDS = 5\n",
     "MAX_SAMPLES = 0\n",
-    "N_PLACEBO = 100"
+    "N_PLACEBO = 100\n",
+    "# Any edit to case_studies/utils/causal.py moves this notebook's causal identity, because\n",
+    "# _causal_source_identity hashes that file whole. The registering write then refuses a second\n",
+    "# current identity for the same label and names the hash it wants retired. Declare it here -\n",
+    "# a bare hash, or a JSON object keyed by label - and the refusal has a route to be answered.\n",
+    "# Empty is correct against a fresh registry, where there is nothing to supersede.\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "9e0dc368",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:23.734094Z",
-     "iopub.status.busy": "2026-08-24T20:08:23.734006Z",
-     "iopub.status.idle": "2026-08-24T20:08:23.750625Z",
-     "shell.execute_reply": "2026-08-24T20:08:23.750027Z"
-    },
-    "papermill": {
-     "duration": 0.019379,
-     "end_time": "2026-08-24T20:08:23.751027+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:23.731648+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DML config: dml\n",
-      "Causal DML Configuration:\n",
-      "  Case study: etfs\n",
-      "  Treatment: skip_recent_6_1\n",
-      "  Outcome: fwd_ret_21d\n",
-      "  Confounders: ['vol_21d', 'vol_126d', 'regime', 'yield_curve_slope']\n",
-      "  CV folds: 5\n",
-      "  Placebo reps: 100\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
     "\n",
@@ -254,34 +205,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "a85eb8c9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:23.755626Z",
-     "iopub.status.busy": "2026-08-24T20:08:23.755547Z",
-     "iopub.status.idle": "2026-08-24T20:08:25.170363Z",
-     "shell.execute_reply": "2026-08-24T20:08:25.169929Z"
-    },
-    "papermill": {
-     "duration": 1.416953,
-     "end_time": "2026-08-24T20:08:25.171152+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:23.754199+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Dataset: 402,526 rows x 71 features\n",
-      "Label: fwd_ret_21d | Date: timestamp | Entities: ['symbol']\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mds = load_modeling_dataset(CASE_STUDY_ID, PRIMARY_LABEL, max_symbols=MAX_SYMBOLS)\n",
     "\n",
@@ -328,32 +255,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "42affb49",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:25.177915Z",
-     "iopub.status.busy": "2026-08-24T20:08:25.177792Z",
-     "iopub.status.idle": "2026-08-24T20:08:25.230420Z",
-     "shell.execute_reply": "2026-08-24T20:08:25.229884Z"
-    },
-    "papermill": {
-     "duration": 0.054658,
-     "end_time": "2026-08-24T20:08:25.230981+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:25.176323+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Development window ends: 2023-11-29 (holdout excluded)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Select analysis columns\n",
     "analysis_cols = [date_col] + entity_cols + [TREATMENT_COL, label_col] + CONFOUNDER_COLS\n",
@@ -410,36 +315,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "be5a6dc7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:25.235651Z",
-     "iopub.status.busy": "2026-08-24T20:08:25.235565Z",
-     "iopub.status.idle": "2026-08-24T20:08:25.245363Z",
-     "shell.execute_reply": "2026-08-24T20:08:25.244949Z"
-    },
-    "papermill": {
-     "duration": 0.011527,
-     "end_time": "2026-08-24T20:08:25.245732+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:25.234205+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Analysis data: 355,548 rows\n",
-      "Date range: 2007-01-03 00:00:00 to 2023-11-29 00:00:00\n",
-      "Embargo: 21 periods | Block size: 21\n",
-      "Entities: 99\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(f\"\\nAnalysis data: {len(merged_clean):,} rows\")\n",
     "print(f\"Date range: {merged_clean[date_col].min()} to {merged_clean[date_col].max()}\")\n",
@@ -472,56 +351,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "dd9ecf91",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:08:25.250415Z",
-     "iopub.status.busy": "2026-08-24T20:08:25.250337Z",
-     "iopub.status.idle": "2026-08-24T20:12:35.711112Z",
-     "shell.execute_reply": "2026-08-24T20:12:35.710751Z"
-    },
-    "papermill": {
-     "duration": 250.463319,
-     "end_time": "2026-08-24T20:12:35.712226+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:08:25.248907+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "============================================================\n",
-      "DML ANALYSIS SUMMARY\n",
-      "============================================================\n",
-      "Analysis rows: 355,548\n",
-      "Second-stage rows: 312,073\n",
-      "Second-stage decision times: 3,527\n",
-      "Covariance: Driscoll-Kraay\n",
-      "HAC bandwidth: 20 lags (max of horizon-1 and cube-root)\n",
-      "\n",
-      "Naive OLS rows:    312,073\n",
-      "Naive OLS effect:  -0.009325\n",
-      "DML effect:        0.010371\n",
-      "  SE (IID):        0.001252\n",
-      "  SE (HAC):        0.011758\n",
-      "  t-stat (HAC):    0.88\n",
-      "  p-value (HAC):   0.3778\n",
-      "\n",
-      "Confounding bias:  -0.019696 (-189.9%)\n",
-      "\n",
-      "Refutation (block permutation):\n",
-      "  Z-score:      1.48\n",
-      "  Empirical p:  0.0495\n",
-      "  Classification: Passes\n",
-      "  Placebos:     100\n",
-      "============================================================\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "results = run_dml_analysis(\n",
     "    merged_clean,\n",
@@ -597,35 +430,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "750ca192",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:12:35.719299Z",
-     "iopub.status.busy": "2026-08-24T20:12:35.719198Z",
-     "iopub.status.idle": "2026-08-24T20:12:35.721832Z",
-     "shell.execute_reply": "2026-08-24T20:12:35.721535Z"
-    },
-    "papermill": {
-     "duration": 0.004602,
-     "end_time": "2026-08-24T20:12:35.722225+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:12:35.717623+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Statistical significance:\n",
-      "  p-value (HAC): 0.3778\n",
-      "  Significant at 5%: No\n",
-      "  Refutation: Passes (p=0.0495)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dml_result = results[\"dml_result\"]\n",
     "naive_effect = results[\"naive_effect\"]\n",
@@ -694,35 +502,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "2f10d567",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:12:35.729338Z",
-     "iopub.status.busy": "2026-08-24T20:12:35.729257Z",
-     "iopub.status.idle": "2026-08-24T20:12:35.818752Z",
-     "shell.execute_reply": "2026-08-24T20:12:35.818191Z"
-    },
-    "papermill": {
-     "duration": 0.091402,
-     "end_time": "2026-08-24T20:12:35.819216+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:12:35.727814+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAw8AAAF/CAYAAAAPYfU+AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbwBJREFUeJzt3XV0FFcbx/HvxkOwBIfgGiAEd5fi7u7u7u5S3L1ICwVK8SIFipTi7u4BEhIkEEKSff8ILIQIC01C6Pv7nMM5ZOfOvc/cOzM7z8iOwc/vjREREREREZHPsPjWAYiIiIiIyPdByYOIiIiIiJhFyYOIiIiIiJhFyYOIiIiIiJjlu08eVv66gbjObhw6ciLS2rh99z5xnd0YNWFmpLUR0TLnLkPFWi2/dRj/SafPXaRI2Toky5CfsT/Owc/vLW069yeFSyHyl6xOQEBAhLd574E7qbMWZfbCFWbP07h1D4pXqP9V7fn7+xPX2Y323QcDsGHLLlJmKcyxE2e+uK5/E8eXOHr8DCmzFGbDll3hlmvffTDxUub8qjYq1mpJ5txlwpzumr885ao3/eJ6f/1tC1nzliVllsLs2nPwq2KLLO27Dyausxv+/v6RUv/+v48S19mNZT//Fin1f41i5evRpE3Pbx2GiEi0FO2Th/dfXKH92//30W8dnkShDDlKMvbHOd86DAaPnMyVazcZObgHVSqU5reNf/Dr+q1UKl+Sof27Ymlp+VX1Ll7+K3Gd3UKdljRxQlYumkq9mpXMrm/4gG7M+nHEV8XyqVLFC7Jy4VSyZXUJt9yuPQeJ6+zG7bv3IyWO8Li5urBy4VRKFS8Y6W1FpDdv/OjaZwS2tjaMGdqbHG6Zv3VI/1dC2+5mTx7JsP5dI6W96LIfExH5WlbfOoDPaduiARXLliAgIJCmbXtSpGAe2rZoAEDmTOm4c+/BN45QokJAQAAenl7fOgwAbt25R1aXDLRoXAeATdv+BKBr++ZkTJ/mq+t99NgzzGkWFhYUzPdlZ8vTpE7x1bF8KqZDDAoXyP3Zco+eeERqHOGxsbE2K8bo5tETD177+lKpXEka1qn6rcP5vxPadpfFJX2ktBWd9mMiIl8r2l95yO7qQqVyJalYtjgAzsmSUKlcSSqVK0k8J0dTuaPHz1C2WlOSZypIiw59ePv2LRC0s548cxFZ85UjnVtx+g2dgJ/f2xDtvPR5Re9BY8mYsxQZc5aiz+BxvPR5FazM1eu3qFK3NckzFaRa/bbce+AOgJ/fWzr3GkaqLEXIlKs0PQeM5sVLHwAOHztF6cqNcM5YgAo1W3D1+i3gw6X6PfsO8UPVJuQrUZ3m7XuTKksR0+0Bvr5vSJYhP0NGTQHg0pXrVK3XBueMBShWvh5Hj3+4heT0uYuUqtSQFC6FaN2pP69934Tan2N/nEP67CXYsGUX+UtWJ2POUsxasJwDh45RvEJ9UmUpwpSZi0zl/fzeMvbHOWTNV47UWYvSpssAnnh8+LKN6+zGjzMW0qZzf1JlKUL5Gs24ffc+vQeOIY1rMUpUbBAswftcf/y+eQdV67UheaaC1GjYDu9nz7l99z7xUuYkMDCQ8VPmmq46vb9lbe/+f4LV8f72h/bdB1OyYgMW/rQat4IVyFagPOs2bGPD5p3kK1GddG7FWbV2U6j9FFZfu+Yvz527Dzh+6pzptp5xk4POIuYrUd10RnHbzr0ULF2LFC6FqNusM+6Pnpjq/ufoScrXbI5zxgLkKVaVnbsP0L77YMZPmWvq009vOfv01rk79x5QtV4bkqbPR+6iVZg5fxlGY/BXtnx8i837+ZesWEPDlt1IkbkwpSs3Mq3DAH8dOEyBUjVIlaUIfYeMD1bXp33918HDFCxVk6Tp81GyYgN2//U3Y3+cQ8ceQwBwK1AB1/zlvyqOJSvWkDVfuWBXGdt07m/qm/f/fz8e728T+nT8z5y/ROnKjUiSLh8FS9Xk19+2mOYzGo0sX7WefCWqkypLEabPWWqatmb9VsrXbE6KzIXJmrdsiNtp/N6+ZeCISaTNVpwchSqxYfNOwhLeNvu+P7K966dpc5aa+iyusxvzFv9Mm879SZ6pIHfvP4zwbfG9sT/OIXmmgixe/is5C1cmffYSjJ44i8DAwFCXKbz+8ff3Z/qcpeQsXBnnjAWo3bgjnk+DDpbD2vbfO3rijGkf1rRtL7y9n5um/XXwMCUrNiBZhvyUrNiAfQePhBqbt/dzOvYcQuqsRclRqFKw2H7b+Ac5ClXCOWMBKtZqycnT58Pc7kJbr37fvIMKNVuQKksR2nUbxO2796nbtBMpXArRrF1v0/fKpSvXadO5P1nzlSOFSyFaduzLi5c+Ye7HIOz9hfez5zRq1Z3kmQqSrUB5Ro6fEer3l4hIVIr2yYO55i/5hdrVK1Agb05+27idP3btA2DmvGWMGDedimVL0L9nB37+dQPzl/4SYv5ufUaw7Jff6NCqEe1bNmTpyrX06DcyWJndf/1N8SL56dOtLX8fPk6PfqMA+GXNRpavWk+rpnXp0KoRr319sbG25tade1Sv3xYLCwvGDOuNwWCgWbvewQ7ymrbrTZGCeZgwqh/VKpXF+9lzjrw7wDhw6Bg+r15TrVIZvJ89p1r9tjx6/ISRg3uQwjkpDVp25dXr17x46UOdJp149NiDUUN6kiRxQp49fxFmXz3xeMqEqfNo3aw+cWLHYuDwSXTrO4JGdauROFF8Rk6YyaPHQWeQx02ew4Sp86hboyIDenVg+5/7aNK2V7ADi9ETZ5E4UUKa1K/BoSMnyVOsKgGBgTRvVIuTp88z492BmTn90a3vSH4oVYSK5Uqy+69DrPx1AwniO/HjmIEA1KhSlhULp5A5Uzqz1osTp8/z28btdGrTBD+/t7TrNojJsxbRulk9bKyt6TNkfIh7ucPr62njBxM/niMZ0qVmxcIpdG3fjBpVygLw45iB1KxajiPHT9OgRTeckyZmzLDe3L37gG7v1qXLV29QtV4bnj9/ydjhfShWOB+pUjrTtkUDCubLBcCKhVMY1KdjuMs1ctwMTpw6x6ghPalUriS+vm8wGAyf7Y/+QyeSLWsmmtavwbGTZ5kx9ycA7t5/SN2mnTEYgsbm7dvw729v12UgGAyMG9GXLC4ZeOPnR82q5ahaMShJmDpuMNPGD/7iOP45epLu/UaRK3tWRg7qga2tDbWqlqd9q0afXbZP9R44FvdHTxg3vA+FC+bh9Wtf07TAwEB+XrORdi0bkCC+E8PHTcfD8ykAh46cIE+ObIwa3IN48Rzp3n9UsNuwPDy9cH/0hBGDuhMjhj2tOvfj/oNHIdoPbz16L0F8J6aOC+qnqhXLBOuzURNm4vvGjynjBuOcNHGEboufevHShxWrfqd7pxYUzJeLidPms2nb7lDLhtc/E6ctYMjoKRQukJuRg3uQMUMaHOPGMWvb3/7nPurUqEib5vXZsGUnoyYGJcoXLl2lVqMOODjEYOLoAdjb21OzUXsuXr4WLC6j0Ujrzv3Z/MduunVoTs2q5ejSZzinzlzA59Ur2nYdSNIkiRgztDdJEyfEaDR+0XbXvd8oKpcvRb7cbqxau4mi5epSMF8uChfMw++bd7Btx14A7t13x+fVa/p0bUOtauVZt+EP5i5aGeZ+LLz9xYy5P7F1x1769WxPg9pV8Xn1GmvraH/DgIj8x/1n9kJTxg2mTMnCZMuaiR2795vOas1f8gtFCuahf8/2ABz85xhb/thNpzZNTPM+9fJm7YZt1Kxajq4dmgNw6uxFfl2/lfEj+pnKNWlQgx6dgs5M7dl/iJ17DuDn95ZYsRyAoAOBpg1qYmdnC8CK1b/z6rUvMyYNI1HC+MSP50SDFl25dfueqc7a1cozuG9nAF6/9iWmQwy27/qLgvly8seuv0junJQcbllYvmo97o+eMHvyCHJmz0quHK4ULVuXo8fP4PnUi0ePPVg6dyLVKv1gajs8i2ePJ2P6NPj4vGLI6CmMHdaHMiUL8/q1L4NHTeb6zTskiO/EgqWryJ3D1RTj3XsPmT53KWfOXya7a9D971UrlmbEoO4EBASwePmvZEyfhsljBxEYGMi8xT9z+dpNs/tjcN/OtGxSB/dHT1i1dhNXr90khr09JYrkByB92tRUKlfSrHXivXUrZmNvb8flqzdY+NNq5k8fQ8b0abh85ToLflqN+2MPnJMmNpXfuHVXmH1dslhB7O3tcXKMY4ojfdrUAJQokp80qVPQpssAYtjbMfPH4djYWPPq1Wv6DhmPn99bFi37lTdv/PhlyTRSOCelcb3qpnadkyYCMGv53q9zadOkpHmj2mYlDgBtW9Snb/d2+Pv7s/Cn1Vy9HjQ2637fhu+bN8ycNIyc2bNSpUJplv0S9gOssWLFxNraigJ5c9Kkfg3T5+nTpgrqi2IFSJk82RfHcfTdA9njR/QlcaIE7Nl/iFe+vuRwy2LW8gWLMaYDGAy4ubrQtGHNENN/WzEHe3s7vLyfM2LcdG7cukv8eE5MHjuI1699OXnmAjndsnD67EVOnj5vWh7HuHFYNCvoyoytjQ2tOvXjz78OBusHCH89KlY4H0DQul2sgKnvShb78LxGiuTJWDRrHNbW1gQGBkbothiaGZOGk8UlPaWLF2LDlp1s3bGHqhVLhygXVv+kcE7KnIUrKFIwD9MnDg02jznbfs/OrUy3pL4/GJ80egBLVqzl7Vt/Jo8dRPq0qcjploX8JWuwZMVaJoz8sH++dfseO/ccoHfXNkHjbYSff93A5u276ZWhNfb29tjZ2lCyeEGaNPgwVuZud4P6dKJlkzrky+3G9j/306xBTbp2aM7J0+fZun0Pl6/dAKB0iUKUKl6Qy1dvYG9vx/JV6zl6/EyY+7H+wyaGub+IFdMBg8FAsiSJqNS8JFZW/5mvbBH5jv1n9kTvz8bEf3cr05s3fvj5veX+w0fcf/iIVFmKmMqmS5My2Lzvv8DcPnoYNEe2zPy+eQe37tzDySkuQLADtIzp07L7r0M8e/6c6pXL8uq1L+OnzGPyzEX06NSSNs3rc/t20Nm4fCU+HCACPHl3hvPTNu3t7Shfpjjb/9zHsAHd+GPXPqpVKoPBYOD2naC6ajRsH7wuj6fcu/8Q+LJ7y63ffQnFixfUX+/77/2y+vn58dTLmxcvfXBz/ahf3j3Mefv2PdMBy/u6LC0tcXSMa6rLwsICR8e4+Pn5vZvn8/3xvq747+J6EwGX6N/H8/42t/dtOL372++NX7Dy4fW1OW7fuY/Pq9dkyBH8YOSplze3bt8jbpzYpHBO+oVLEdyIQT1wcopLo5bdSZnCmZGDulOiaIHPzmdtbQ2AlZUVjnFj8+ZNUP++v53F3HVozfJZjBo/k/wla/BDqSKMHtzzy9a/MOLIliUTAKvWbqJY4XycOnORmu+u7HypudNGMX7yXH6o1oTcObIxekjPYElIaPsMgHmLf2bMj7OxMFiQOqUzAM+fvzTNF2w/kCHoGRcvr2ch2v+361GWTOlM/RTR22Jo3i9WksQJiRMnFk+feodaLqz+8XzqxfMXL3HNkjHEPOZs+8H3r2nY/dehoHnv3CeGvZ1pv50xfRpi2Ntx+869YHXdevf3xGnzmThtvulzD4+n2NnZsm3dEoaPnYZbgQrUrl6BEQO7kzBBvDD741Mh95lBY/Nhnxm0Dl+8fI1Wnfpz+eoNcmTLjLWVFc9fhH0lOLz9Rcc2jbG0sqTXwDEMGzuNwX06UbNqebNjFhGJDP+Z5CE0NjbWJE2ckGRJEzOkXxfT5zEdYgQrl+rdF+CpsxdMn508E/T/VCmcef7yJZ+6cvUGsWI6ED+eEwaDgUZ1q1GvZiWmzVlK3yHjccmYjpQpgs5ULl8wmbhxYpvmzZwpPSdPnw815upVyrLm963s2XeIe/cfUu3dbSDvz3pOGTeIdGlSfVRXOrb/uR+A02cvmg6+Pr3//Ws4OcYlVkwHTp35qF9OB/0/5bs++xJf0x/vWVgG3WH35s2HZzls3n15P34SdN/3++dM/q3w+tq8+ZNy/uIVViycEuyXl+LHcyRF8qTs2L2fu/cfkjxZkmDzWbwr6+v7xnT1KiwxHWIwqHcnurRrRrtug6jfvCs3zv1FDHt7s2L8VMIE8YGgZ2eKFcr32fUnZfJkLJg5lsH9OlOpdks69RrG1nWLsbB4P05hH6SGp3CB3GTNnJFhY6cBkCZVCrp2bGGabm1txeN3B99+fm/x9fUNtR6A+PGcmDh6AH17tKNesy40btOTc4f/CLf923fv03fIeIb060K3Ds05+M9xKtdpFWb5K1eDzjanTpU8xLR/ux59LKK3xfC4P3rCs2cvTPvFj4XXP06OcXGIYc+5C1dCzPcl277RaOTq9VumPk2ZIpnpanKGdKm5fPUGr177kjJF8Pje93eLxrWpXvlDwpksSdCVhSwu6fl12UzOXbhChVpB69TcqaO+aLszR6+BY7G0tODmuX3Eiulgeo4FQt+Phbe/sLKyonPbprRuWo+BIybRsmM/crplDXV9ExGJKv/p5AGgVbN6jBg3ndXrNpM/bw4uXblOrU/O3Dg5xqVW1fJs+uNPps1egtFoZOuOPdSpXgFHxzim5GHDll2kSZWce/fd+fOvv+nYpjEGg4Gho6fg8dSLIgXycPPWXSDozF+D2lWYNX85P85YSIPaVfD1fYO1tTVFCuYJM95SxQoSO3YshoyeinPSxOTMnhWAyuVLMWriTGbOW0azhrWwtrbCy/s5RQrmoXTxQsSwt2P6nKVYWFjw9+HjeHmHPBP6pSwsLGjdrB5TZi1m5PgZJE6UgJ9+WUeBvDnIFsrZxc/5mv54L1GC+NjZ2rL5j91ky5qJQvlzkz5d0O1CM+b9xJ17D1i6ct0XxxSa8PraHC2a1GHN79uYPHMRNSqX5bGHJymTJ8PKyorG9auzZMVaGrToSruWDbl5+y7ZsmSiSoXSpHp3MDR+ylxKFC1A0UJ5Q63/7du31GvWhezZMpM+bSqePvXCYDBgwLxbl8Ja5nGT5zBq/EzuN35k+gWp0Ny+e5+WHfpSvUpZYsV0wM/vLZbvDoreH3BOm7OEqhXK8EOpImHWE5p9B49w7sJl+nRrCwT9/OrHz6SkT5uaw0dPMWbSbA4fOxXmsz3ez55Tr1lnypQsQpLECXnp42OKMTzvn4s4deYCP6/ZyKJlv4Za9+CRk0mfLhXjJ88laeKElC5RCAj6Sd279x5y6869f70efSyit8XQjJ44i0rlS7Fi1e9BJ0TqVTMtEwQ9g5U4UQIg9P6xsLCgeePazJy3jO79RpIvd3b2HzrK6MG9zNr2l65ch729HcdOnOXKtZuMH9EXgGYNa7F05Vp6DhhN/dpVWLl6A9bWVjRvVCtY/KlTJadksQKsWb+VuHFikyqlM2fOXWJo/66cPH2evkPGU6dGRQwGA/5vP1pnzdzuzPX69Ws8PJ6ycesuTpw6x917D0iWJKgPQ9uPhbW/sLS0pE3n/jg5OZLd1YUH7o8xGAymBERE5Fv5z++FurRryrD+XTnwzzH6DBrLocMneP4i5JWEKeMH07hedWbOX8bshStoWr8Gk8cFf+CzUd2q/PTzbyxevobmjWoxsHfQw3XVq5Tj7r2H9B40lt1//c3Qfl0omC8naVKn4PdV87C1sWH42Gks+Gk1T728wz2ra2trQ8WyJTh34TJVKpY2ncl1dIzDxtULSJkiGROmzmPa7CV4eD7Fz+8tCRPEY/mCyRgMBgYOn4SNtfW//gJ8r1+P9vTq0ppVazcxeuIsfihRhGXzfzTF9SW+pj/es7e3Y/yIvjx7/oI+g8dx8sx53LJmok3z+ty6fY9tO/aydM4Es+/9D094fW2O/Hly8PPiqXh5P6P/sImsXrfZtM65ZXXh159mYGFhQe+BY9i+ax/2dnYAtGpah8IFcjNv8c9MmbUozPqtrKxoUKcKO3bvp3u/UTx7/oIlcydgb2/31cucxSU9c6aO4rGHJ0NHTyFzxnRh/uxskkQJKVG0AAuWrqLfkPGkS5OSyWMHAVC90g9UKleS3zftYNiYqaZfPTNXjmxZcIwbh5nzfmLC1Hk0bNmN7AUrsnh50EHqmKG9cHKMw8rVv1OyaIFgZ5g/FjtWTKpV+oFff9tCz/6jiWFvz8IZ4z7bfqYMaenSrhl79h1i9vzltG/ZMESZ0sUL4enlxaARP5I0SSJ+XTbLdMWnQe0qeD97zqZtf/7r9ehTEbkthiZBfCcGj/yR+w/dWTRrnOmWysoVSpMgvhPzlvzy2f4Z3KczPTu3YufuA/QdOp6XL1/h++aNWdt+w7pVmTZ7CVt37KFXl9a0bBL0U8hZXNKzdvlsnr94Sa8Bo/F59Yq1y2fjkjH4FRyDwcCimeOpXrksK1b/zuBRk7n3wJ2nXt6kS5sKN1cXpsxcxLAxUylWJD9D+gZdjTZ3uzPXiEE9sLaxZujoKdjY2FCuTDHTtND2Y2HtLwwGAw3qVOX4ybP06D+Ki5evMWPSsHCfJRIRiQoGP783//7+FhGRCDBszFR27jnI/u2rsbCw4KmXN/lL1iBXDld+WTztW4f3nzT2xzmMnzKXE/s3Rdk7OURE5Pv1n79tSUS+H/fuu3Ptxi0mTptPcuek/P3PcR4/8aT8R2dvRURE5NtR8iAi0caQ/l149vwFM+cFvfQuXdpUzJo8Qm9eFhERiSZ025KIiIiIiJjlP//AtIiIiIiIRIzvInmo3qQbdVv2okn7ATRpP4AegyZ+dp6H7k/o0HuU6e/rt+4yfMIc098deo/iofuTSIk3ujh26jzT5/9s+rt6k27Bphco2yjUdyN82lffWvUm3bhy/fYXzfPQ/QllarQJs77vSVjLsmXHPvoOmxLqPAuXr2PKnOVf3ebISfNY9Vv470SITswd0y079rFw+Yef9N2++yAr12yJpKgiz8o1W9i++2Co0zyfetNn6OSv/lWnr9newrL/nxM0aT+Ahm37sWHrnlDL3L3vTtseI2jQui8TZy7FPyAACFqHK9TpYNrvz1q4KkJiEhGRf+e7eeZh5IDOZEib8vMFw5A2VXKG9mn/+YL/IbmzZyF39iyfL/iJ/8e+kv9PZUsW+tYhfJWGtSuGOS2eU1wmDO8RhdGE7sVLH8ZOXsiiGSNwiGFPo3b9yOnmQvJkiYOVG/XjfOpWL0fxQrnpPfRHtu7cT5VyxQGoVbUMLRpWD6V2ERH5Vr6b5CE0W3bs4+TZSxiNRs5euErcOLGYNKIXr16/pnO/sTz1ekaT9gNo0bA6SZMkpO/wKaxfNpWRk+Zx9sJVegyeSOaMaUmcMD6+b97QuXUDALbu3M/x0xcY3KttsPZe+/oybe5Krly/zYuXPhQvlIeOrerx19/HWPXbH8yZNIjAwEAq1O1AozqVaFS7Epev3WLslIUsnTWKrTv3s37Ln7z2fYNDDHtGDexMgniObNmxj4tXbuLl/YyXPq+YOqYvfx85xdwla/B760f6NCkZ1LON6e2nAQGBlK/TnqWzRpI0cUKmzVvB4WNn+XnBeAAatxvA0L7tuf/wEavX/8HsiYPo2n8c7o88aNJ+AAXyuNG+RV0ANmzbw/5DJ7h7352BPVpTKF8Orly/beqrh+5P6Dt8CsUK5eHAPyd49vwlowd1xiVDyHcAnDp7iQnTlxAQGECSRAkYNbAzvYdOplHtihTKlwMIOlDI4ZqJJInis2LNFpIkTsCxk+dIlCA+nVvXZ+Hy3zh/+RoVShehQ8t6wcb6x6s38fD0okal0qaDp7MXrjJ9/kpevfbFKW4cenZsSqoUSUNdX/wDAmjcrj8enl40aT+AyuWKU7vqD2ze/hcr124hICCQPDmz0rNDEywsLChbqx0tG1Vn6879+L7xY1DPNmze/hfHTp0nWZKETBjeA1sbG0ZOmkdMhxjcuHWPR088yZIpHf26tcDWxoYnnl5MmrGUew8fYWVlSZsmtUx9Ub1JN9o3r8Oq37bRqE5lEiVwYt7StXg/f8Hbt2/p06UFOVwzhbsNeDz1ZtDoGdy8c59YDjEY2qc9SRInCFFu0/a/WPXbNjCCS4bUdGvfmJgOMTAajaz6bRsb/9iLtZUVubNnoUvb4L/dv/GPvfzx5wGmjemHtfWHXUb1Jt2oWr4Eh46eDjEuBw+fDHX9/XSZb9y6y2vfN9x78IjLV29RvHAe8uVyZcWvm7l55z69OzWjRJG8nDh9galzV7BszhgAVv32B1dv3KZ/91YhxrRS2aKhbqd7Dxxl9uLVAOz7+zgThvdg74FjXL1xm8G92mI0Gvlp1UZ27jmE0Wgkf+5stG9RF2trKxYuX4fvGz8ePHzMxas3SZPSmfFDu2FlFfYuNLw+aN6gGpu3/4XnU296dWrGidMXOXD4BDHs7Zk4vAdOjnFYuHwd7o888Hr2nPsPn+CcNBGDe7UlTuyYTJmznFgxY9CqcU0WLl+HwWDg7IWrOMaNQ48OjfmhZlsObV8BwIXL15k+byUvX70mlkMMRg7ohMFgYNq8Fdx78IjnL3yoU60sdaqF/s4MCLr61aX/OArmzc7ZC1d47fuG7u2bkDdnVvqPmMb9h4+Cla/4Q1GcHOPgkjE1SRIFvb28cL6c/HXwGI3qVPqw/np6ce3mHYoWzIWFhQXlSxVh664PycPHb6MWEZHo4bu4bQlg8JgZpsvXJ89eMn1+/PQFWjaqzs/zx+HvH8Du/YdJnDA+A7q3IlOG1CybM4bihYO/0XVwr7bEj+fI5JG9GdyrLTUqlWLn3kOmy/w79vxNxR+KhojBztaWSmWLsWj6cJbNGc2Gbbu5efs+ud0yc/nqTXx933D1xh3SpU7BsZPng+I7dYG8uVwByJA2JdPH9WPF3LGkTpGM1es/3BayafteGtWpxLSx/Xjg/oT5y9Yya+JAVi2cSLIkCVm/dbeprKWlBflyuXL89EUg6ADawSEGHp5eeHk/x/v5C9Kmcg4W+7Sx/QBYNmeMKXEAcIwTm7k/DqZZ/aos/WVjqH1/49Y9XF3SsXjGCIoVysUv67aFWm7l2i1UKluMVQsn0qdLc2I6xKBu9bKm2xXe+Plx+PhZShQJeoHduYtXqVq+BCvnjeOljw9T5i5nSO+2LJg6nBVrtvD0o7dkJ04Un7k/DmbB1GEsXrme67fu8vyFD/1GTKVbu0asnDeOGpVK0W/EVAICAkONz8rSkskjexM/niPL5oyhdtUfOH3+Cn/sPsiSmaP4ZcEEXr58xb5DxwF4/uIlDg72LJk5kvy5s9F/xFTq1SjPz/PH4/7Yg4OHT5nq9vD0YtLInvw8fxz3Hjxi8/a/ABgxYS5uWTOyct44Rg/swpgpC7n34MOB1oF/TrBg6nBKFslLfCdHBvVszbLZo2lWvxozPrrlLCw+r17T9d3yZ82cnhkLfwlR5tTZS/z0ywZmjh/Ainljsbe3Y+aCoHI79x5i264DzP1xCD/NHh3ijPbpc5dZtW4bYwd3DZY4vGdra/NhXH5ez41b97j/8HG46+/Hywxw4vRFBnRvxdJZo1i7YQdHT55nxvj+dGxVj4XLfwt3+UMb07C20+KF81C9YkmqVyzJsjljSJwwfrC6tu8+yIF/TrBw+jCWzRnNfffHrFz74Zam46cu0KdLC36ZP54r12+btr/QfK4Pnnh4MW/yEOpUK8vAUdMpWjAXK+aOI4a9Hdt2HQhWz7C+HfhlwXjsbG1Y/uumUNtbu3Enfbu2ZGifdsE+f/HShz7DJtOiUQ1WzB3L6EFdiOcUl9ixYtKwVkUWzxjJ7IkDmbnwl1BvYfyY+2MPyhQvwOIZI+ncugEjJ87FPyCAsUO6smzOmGD/6lYvx6MnniSI72SaP2ECJx498QxW52OPp8R3iouVpWWoZbbt2k/Dtv3o2n8c127cCTc+ERGJGt/NlYewblvKkCYlSRMnBMAlYxo8n3p/cd3xnOKSO3sW9v19nJxuLtx/+JjsWTOyYese1m3aCUCLhtUpXjgPCeI5snLtFq5cuwXAvQfupE6ZjEwZUnPmwlWuXr/NDyUKsGz1Jt6+9ef46fM0qBl0QJbcOTH7/z7B8dMXOHfpGs5JE5liyJ09i+ls/uFjZ3j02JNOfUYD4PfWn4J5sweLOX/ubBw9eY7C+XJgZWmJa+YMHD99ASsrK/LkyGL2m5aLFsyFwWAgq0u6MO9xt7e3MyVAWV3S89umXQCMm7aIC5euAzBheA8qlC7CgmXrsLCwoHK5oN/lL5I/F7MWruKxx1POX7xGvpxZifHuTciJE8Y3jalLxrQ4xomFg0MMHBxiEM8pLp6e3jjFjQNALrfMGAwGnBzjkCVTOi5cvkE8R0+SJ01ElkxBb5otUSQvU+Yu5+79h9ja2Ji1/AcOneD2nQe06TYMAN83fmTO+OGqStECQf3jmjk9V67fMl3VyJQ+DU88nprKuWbOYGqzUN7snLt4nfKli3Dy7CV+HNkLAOekiciTIwtHjp81jX39mhWwtAzK4RMmcOLk2UusWr+dq9dvB0sywpLSOQkJ4jkG9XWBXAwdOyvkMh4+SZkSBXCMG3QWt061srTtMYJ+3Vqy7+/j1KxchjixYwJB28J77o89WLZqIz06NCFO7Fihth9sXDKm4/zl67z1exvu+vvxMgNky5LBVH8K5yQUzpcdCwsLsmXOwDTPFZ/tg08ZDIYwt9Pw7D90girlS5je+F2zchnmLV1Ds/pVTXHGjRMUZ4a0KfB46hVmXZ/bhosUyGlar+LEiYVr5vQAZMmUlieeH+rNkC4VsWI6mOb5fcuHBORjpYrmN53h/9i5i9dImjgheXNmBcDJMWh7sra2ws7OlkUrghJxAwYePfY0tRUaO1tbsroEbWt5cmTlhc8rHj32JFmShKGWtzB8cm7KSIj90qdvxzbyoUzlssUpUSQvyZIkYt3GnQweO5NfFkwIMz4REYka303yYA4rS0uMxq/75dm61coye/Fqnr14QblShbCwsKBqhRJUrVDCVObK9dsMGj2DNk1qUb5UYTyeziTwXXv5c2fj5JmLXL52i+7tG3P4+FnOXrjC5Wu3cM2cHqPRSJd+48jhmokalUqROVNaDhw6ESz294wYye6aiXFDuoUZb95crsz/aS3HT18gu2smsmXJwJ4DR7GxsSbfuwP9L2FlZYWRz/edlZWlqVy/ri2DTUucMD55cmZl0x97qduyFzPHDyRViqTUqFyarTv2c/XGbWpWKRN6vR8t/4d2wo7B3tY21GkGDIB5iRME9XXp4vnp2rZRuOWsrEKJL4wArawssbf7EN/HB0wGgwE++tvyo+We/9Nabty+R70a5alSrjit3yU05rKytDTd2hYeg8FgiinQaCSsPHP95j9p07QWS1dtoGjBXNjYWIff/rtx8fPzC3f9tfxkrD+tw/R/y4/62GDA3z8g3PbfC287/RKfDFXwOC2tCG9zMWcbBkLc9mRlZYnRN/SKLcMZ34+TsY8FBgaGeiLh0NHTzFq0irZNa1GrShmaXRn0RX1kaWmBAQP2drZh3raUMIETx06dN3326IlnsBMmAAnjO+Hx1Bv/gACsLC15/MSTRAniAZAoYTwSEfT/ahVLMmvRKvz9/cO9VUxERCLfd3Pb0pdKnCg+j588DfMWlsQJ4/Pw0YdfW8qYPjX+/gH8vmUPFUoXCXWe46fOkzplMkoXz09AYCCPHn+4vJ4/txvnL13n0eOgL8icbi78vnU3GdOlwsbGmucvfDh38Sr1a1YgTarkXLpyI8zY8+Z05eiJc5y9cBUAL+/nvHrtG6xMgniOxIkdk937j5AzmwtuWTJw9sJVLl6+Tp4cWcNY5niR+gtTJ85cJIa9HfVqlCdJooScv3QNgMpli7H7wBHu3HMne9aMX1X33fvuQNAtVBcuXye7a0ayuqTn3sNHnH939WPvwaPY29sFPZBpMBBoDDn2jo5x8PF5he8bPwAK5cvB1p0HuHPvIQAPH3mEuc6E5/7DRwQGBvLS5xVbd+6nQF43YtjbkcM1E2vfXb26//AxR06cM50F/tT+f05QsUxRcrhm4sr1Wx8mhLEsAE88vXjt60tgYCBrN+40nd02GAymRLpwvhzs3HMI72cvMBqNrNmwnSL5cwYtf97srN+ym5c+r4AP/QzQoFYFGtauiFvWjCxbHfotbR+Py/lLQeNizvr7peI7xeXOfXc8n3rz4qUPfx08apr26ZiGt50GbfceobZRpEBONv2xF1/fN/gHBLBu0y4Kv+unLxVRfeD+yIO3b/3x83vL71t3h7gC+TlZXdJx595D062ejz2e8trXl0NHT5M7exaKFMiFl/czXrz4cMuSAQPGwJDrm9/bt6a+27z9L1ImT4Jj3Nhh3rZUIHc2Ll29ycNHHjx/4cPBIycpXjgP/gEB9Bw8idt3H+DkGIcMaVPx18FjGI1Gtu06QMkieXnp84p1m3bi7+9PQEAgW3fuxyVDGiUOIiLRwHezJx48ZkawW1HePzgZlqSJE5I2VXLqtuxFi4bVSZcmRbDp1SqUZPDYWeTM5sLIAZ0AKFuqEDt2/x3qA6cQdFvMwcOnaNJhIBnSpiR1yg/PFaRLnZxbd++TM5sLBoOBXG6ZmTx7GV3aBD18GjuWA/VqlKdN92EkSZSArC7p8PD0DrWd5MkSM7xfRyZMX4IRIzHs7ejbtQVpUyUPVi5/7mys/n07g3u1wd7ODocY9gQGBppuTfhUzcplaNNjBKWK5qNbu/DPtH+pgIBATpy+wLR5K/DxeU26NCkoWTTonvaYDjFIm8oZ56SJQ9ymYK7LV2+ycs0WfH3fmJ5ZARg7uBtT5izD940fcePEYtyQblhaWpAogRMpkiVhzYYd1K76g6keO1sbypYsRP1WvalZuQyN6lSic+v69B0+BStLK+LEjsnQvu1NtwKZ6869h3ToNQpPr2dULFOUwu8eih7Spx0Tpy9h8/a/sLKyZED3ViHOvr7XqHZF5ixZzar12yhWMLfpbHJYywLgGDc2A0ZO5+EjDzKlT0XLRkG/TJMjmwtjJi+gYa2KZHfNRNP6VenYZzQYIVOG1PRo3xiACmWK4P7Yk5ZdhmBnZ4urSwZ6dmwCYLqVqF2z2jRuN4ASRfKGWAf3HjjKyjWb8fX1Y0jvD+Nizvr7JVI4J6FimSI0atefjOlSUbJoPi5dvQmEHNPSxfOHuZ0WyOPGz2u30qT9AIb0Dv58QNmShXB/7EmLzkMwGAzkzZWVhrXC/lWj9375bRs+Pq9o1bim6TNzt+HP8Xr2nO4DJ/DY4ykF8mSjesWSXzR/nNixGDu4K9Pnr8TvrT9x48Sib5cWVCxThEmzfqJF5yG4Zk5PCuckpnmKFMjJ8l83M2pg52B1GQwG5i39les37+EQw44R/TuGe3ukg0MMBvVsQ5+hkwkMDKRV45okS5IQ3zd+3L77wJSwDuzRmpGT5rFo+W/kdMtMuVKFCQwM5Nnzl7TpPoJnz1+QNHFChvXVL8CJiEQHesP0O2/f+tNz8CQa1akU5plh+TpPvZ7Rvtco5vw4yPQMw3/JyEnzSJ8mJfVqlPvWoUSp6k26MX5o93/1E8r/BU+9njF68gLTsy0RZeHydbx4+Yru7xK9b+mh+xOadBjIzt/mf+tQRETkG/turjxEpkNHTzNp5lLKFC+gxCGCLf15A5u276Vz6wb/ycRB/r8ZjUZmLPg52C+YiYiI/JfpyoOIyL9gNBrN/nUzERGR791/9oFpEZGooMRBRET+nyh5EBERERERsyh5EBERERERsyh5EBERERERs0Tr5MFoNOLv7//Vb40WEREREZGIE62Th4CAAIpUbEZAQMC3DkVEREQkWnjVuAk+FSryqnGTbx2K/B+K1smDiIiIiIhEH0oeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELFbfOoCIUql2y0ipd/OaRWaVK1iuMelSJzf9PaR3O9KlSRFm+epNurF+2VQAjhw/y+Vrt2hctzInTl9gy879DO7V9l/FHR1cu3GHLTv30bVtIx66P2Hkj/OYPXEQACMnzaNQvhyULJI32DzLV28iY7pU5M3lGuXxnjh9gZVrt/LjyF5mlX/o/oReQ35k5fxxwT4fOWkeFcsUIadb5sgI818rWbUluzcEX6+rN+nGkhkjiRsnVrDPO/QeRefWDXDJkOaL2girvm/t0/UwLB+PoYenF7MWrWZon3YRHs+tOw8YMXEOjnFjM2lEL0ZMnMf1W3fp26U5WTKlM6uO/9I+Q0REor9ISx5++W0bP6/ZQr0a5WlYuyI79x5i9fo/ePb8JQ1rV6RahZKR1fQ3YWdrw7I5Y75q3ry5XL/JwXJkS5cmBV3bNvqieRrXrRxJ0Yh8nfjxHCMlcQDYe/AohfLloGWjGjzx9OL0ucv8tmxKpLQlIiISESItecjpmolrN+4AEBAQyJ17D5k9cRCvfX2p0bQ7JYvkI3Ysh8hqPlo4cfoCG//Yi9EIp89dpuIPRWndpCZDxs7C/ZEHTdoPoG6NcmCEi1duUrd6WUZMnMer1740aT+AhrUrcvj4WYb0DjpwGT15AWWK5Q+RaMxbuobDx8/y/MVL2jarTZniBajVrAfzpw7FKW4c6rToReO6lalcthizFq4ifdoUuGbOwOTZP/HosSfW1taMG9qNBPEc6dB7FGVLFGL9lj8ZNbAzz56/YPz0Jbx584ZKPxQLdnDfue9Y2reoQ+aMaenafxxZMqWjTdNa/LZpFy98XuHqko6Va7cyemBnOvcby1OvZzRpP4BhfTsAcPrcJdZt3MndB+6MH9odlwxpgl2RaNi2H5XLFmfLjn1YW1sxbWxfYsUMvs5cvX6bYePn4B/gT8G82alUthiTZv7EnElBZ5YXr1xPPMe4WFlZcvnaLR64P+H6zTv06NiUvw+f4p9jp6n4Q1FaNa4JwFOvZ/QbMZWbt++TJ0dWenZsgsFgYNP2v1i1bhsA9WuWp1LZYqGO+S/rtrJn/xFOn7tMgTxu9OzYlI1/7OXntVsxGKB7u8bkzeVKh96jKF4oD5t37COGnS0dW9Vn/k9ruXPvIeOHdSdT+tSMnDSPOLFjce7iVbyfvaBHhybkz52NV699GT9tMddu3iF2rJgM6N6K5MkSs3D5OmxsrNl/6CR1qv2AU9w4LFy+jmfPX5I2dXKG9+uAhUXYdyou+fl3Tp+7jKWlJSMHdCRp4oTBpp+/dI0fZy3jzRs/cmXPTJe2DbGytOTy1ZtMmvUTvr5Bn3dr9yFhfOr1jE59xjBldB8SJYwHBJ39Hzh6BimcE3P1+h1Sp0zG4N5tsbWx4cA/J5m9aBUBgQE0b1CNcqUKM3LSPDKmS8Uffx6gS5uGzF+21qy+e78evb+iFNp66OX9PEQfrV7/R7AxbFCzgukKk39AANPnreT4qQvY2trQs2NTsmRKy5Yd+7hy/Rbujzy5cPk6rRrXpGqFEsH679P1wNrGmjUbdmBhMGBhYcHfR07j+dSbFp2HsHjGiFD7wvvZC8ZOXci9B4+I7xSXzm0aBttnzJwwkE1/7GXdpl3Y2drQo2MTcmfPEuaYi4iIfKlIe+YhY/rUJEkUHwBLSwtaNqqBjY01cWLHImmihHg/ex5ZTX8Tvm/8aNJ+AE3aD2DijCWmz0+fv0Kn1vVZPGMEK37dTEBAICP6dwRg2ZwxVCxT1FQ2ebLEtG5SkyIFcrJszhhKFcvP+UvX8fV9Q0BAIOcvXiNn9pC3whQvnIdF04czZXQf5iz+FYCcbi6cvXCVp97PcIobmzPnrwBw9sIVsmfNSJzYMencugHL5owhT44sbNy2x1Tf2YtXWTJzJIkSxGPMlIVMGtGTlfPHc/z0BZ54epnK5XRz4cz5qwQEBAJw4fJ10/zZXTOZytnZ2TKgeysyZUjNsjljSJPKGYA3fm+ZMb4/daqVZf2WP0Ms16vXvjjGjc2yOaNxjBubg4dPhiiz8Y+9VChThF8WTKB+jfKkTZUcf39/3B97AHDw8CmKF879btmvMrxfBzq2rM/IiXOpW70cC6cNZ/nqzaZlePX6NX26NGflvLGcu3iVE6cvcuPWPZb+/Dvzpwxh/pQh/LRqI7fu3A91PahfswKZMqRmQPdW9OzYlFt37rNlxz5WzB3DgqnDWLB8nams75s3/DRrFDFi2LNs9UamjO5NrSpl+G3zLlMZozGQeZOHMGpgZ8ZPW4TRaGTpz7/jGDc2K+eNo2GtioycNM9UftuuA8wY148yxQuQOFF8Jgzvwcr543js8ZRT5y6HGvN7ubNnZumsUZQpXoCFy38LNu3tW38GjppB/24tWTFvLB6eXmzZvg9/f38GjZlJ17aNWD53DE3rVTHNE2gMZOSkebRvWdeUOLz3wP0xLRvVYMW8sbx968/OPYfwfvaCOUtWs3D6cJbPGcuvv+/A398fgP2HTjB/6jDTemVO330qtPUwtD76dAw/tnHbXh57PGXFvLEM6NGawWNmmmI8c/4qQ3q3Zfyw7iz/dVOw+UJbD3K4ZqJ6xZLUq1Ge5g2qMaJfB5yTJmLxjBFh9sW0eSvIljkDK+eNY1jfDqRLnTzYPiN2LAcW/7yeRdOHM3/qUDKlTx3umIuIiHypKH/mwcPTixcvfUiWJFFUNx2pwrptKU1KZxLEcwQgTpyYvPTxIU5s8+4Dt7K0pHih3Bw4fJL4TnFxy5oRK0tLOvQexcuXryiQx432LeqSIL4jK9du4cLlGzz2eApAzmwupoShRJG8bN/9N2/f+vPi5SsSJgg6kHvx0oepc1dw+txl0n70vEb1iiUxGAzcuf8Q90ce9Bo8CQg6mH/85KlpeXJmc2H179vJ6eZCmlTOnLt4DX9/f65cu41L+tScu3g13OXLm9MVCwsLMqRNxamzoR/Y5svlisFgIEPalDz1es7Js5eYMnsZAH26tKB4oTxMnbuC2LFjUr50YQAq/lCUXXv/oXTx/MSO5WDq7yyZ0uEQw56M6VORIJ4TqVIkBSB27KBxAXBOmhinuHEAyJMjK5eu3sTGxpp8ubLh4BADgPy5s3Hs1AUK5c3+2TE8evI89x8+okXnIQD4vHptmpYnR1bTssWK6YCVlRUZ06Xi9LtxA3DNnAGDwUD6NCl44/eW5y9ecvTkeXp1CjqozZ8nGyMmzjHVW6F0EezsbAFInDA++/4+xqFjp3n8xBP3Rx7hxuqaOcO75XNl0x97g027c/8hdna2pE+bEoAyxQuw869/cM2cnrhxYpHVJej+fMe4sU3z/LJ2Gy99XlMkf84QbcVzjEvyZImBoDG+fO0WcePExsPTm3Y9RgDwwucV3s9eAFC1fAmsLC2/qO/M8aV9dOzkOUoXzY/BYCBd6uTY29ty55478G79cohBhnSp8PIOfnIkvPUgNOcuXgu1Lw4fO0vfrkHPd33c1x+r9ENRRv04j9ZNail5EBGRCBelyYPRaGT6/J9p3qAalpahX/RYu3En6zbtNJX/L7G0tORLF6lS2WLMWrSKZEkSUrpYfoBgD3v6+LyiY+/RNK1Xhb5dmnP0xDkAcri6sH7LbgwGAyUK5+Hg4VMcPXkOlwxBBxN79h9h7cadtG5SE9fM6fn7yClTne9vbTEaIYVzEpbMHBlqbC4Z0nDtxh3OXrhClozp8Hn1miMnzhE3TixsbKzNXkYrS4vPjrXluzI5XDOFSNJmTRzIyjWbad11GIumD6dMsfz0GDwJOztbShXNF0p7lsH/tgp9XKysLLGzsyEw0IjBYPbihPBDiUJ0adMgzOlWVpbB/h9aXxgMBqytrLC2tn43PfSAPr4tadq8FQQEBlKvenns7WzN3p4sLS2xtbUJ9pnRSKh9EBhOLOcuXsUhhh2nz1/BLUuGMNuzsgpqz4iRXG4ujBncNeRyhbG/CK/v3l8RCM+X9lE4i/shDsvQx/Bz60GwdsLoCyOfXxe7t2/C5as3mTxnOSWL5KVu9XJmtRlZvvWPWYiISMSK0p9q/XntVqytrahSvniYZWpVKcMvCybwy4IJrJg7NuqCi2IJ4zvx+IlnyM8TOPH4yVPTwUfyZInx9X3DmfPBbwV67859d6ytrSlbshBPvZ7zxs8PgEQJ4/Ha9w3Xb94lQ9pUZHFJy+9bdpvqOH76IkUL5sIta0au3bwTaowpkiXG+9lzTpy+AMCjx8HjtbGxJlGCePxz7AxZM6cjq0v6YG0EX654PPHwIjAw8At66fPOX7qOQwx7WjWuyf2Hj3nx8hUODjFwTpqIjdv2ULRg7i+q76nXM3zf+OHj84o9B46Syy0zOd1c+OfYGXxevcbn1Wv+OXaGXG6ZwWAg0BhyeRIliPfhCpCbC7v+OoSHpxdGozFEH37OA/fHABw+fpYE8R2JYW9HnhxZ2fXXoaDPj50hZfKkOMSwDzHv8VMXqFa+BMmSJuTm7Qdmt7V5+1/kzhF0n7wBA4GBRlI6J+H16zdcu3EHo9HIzr/+IU+OLKRIlhgPz6dcvnozWB0A/bu3olPrBsyYvzLEuL/w8eH5Cx/evvVn258HyeWWmSyZ0nLq7GXTLWFf2lcfc4wbm0tXbhIQEMif+4+YPv90PQyrjz4ew4/lyZGFP/86jNFo5Pqtu7x69dp0BSU8X7oehNUXOVwzsWFr0C2GDx95EBAQGGyf8cbPj8tXb5IxfWrqVi/H8VMXPhubiIjIl4iyKw/7/znBvkPHmT6uH4Z/cxo3mnr/zMN7nVrVD3ZW9FNVypegTfcRNK5bCTtbW9Pnri7pefHShybtBzJ+WDeSJk5IoXw5uH33YahXa9KlToFzkoQ07TCQnG6ZSZTgw73lmdKn4u79R1hbW5EtcwaWrdpIl7YNAShXqhATpi/mr7+P4ZYlY6gx2thYM3JAZybNXEpAQCDJkiZk9MAuweLI6ebChq17SJQgHtkyp2f8tEXUrvZDiLqSJUlIsiQJqd+6L4N6tgmnJ7/Mpas3mDhjCS99XlGrShnixI4JQInCefF+9uKLH8qPHcuBvsMm4/7Yg9pVy5IqRTIAmtarQptuw4GgX4RKnTIZAQGBWFlaceTEOfLmzGqqo2zJQoycNI+TZy7Rv3srWjWuScc+Y7C1taFE4Tw0b1DN7HhOnrnI7n2HARjcK+jB+WYNqjJ+2iIatu1H7JgOYf5EZ93qZRk8dhbOSRORMIGT6fNsWTKwZcc+Kv7w4Xkbe1tbtuzYx9gpi0iaJAFD3tWZJ0dWft+6m4E9WjNqYGfGTFnAmzdvyZHNhcrlimNlacmwfh0ZM3UhRiO4uqSjV6dm7/oyJnHjxCJVimRs+/NAsOd7jIFGRk6ay5177hQrlJv8ubNhMBgY0KM1A0fNwNLSAtfM6endubnZffWxSj8Uo8egiRw7dZ5aVcqYbkf6dD0Mq48+HsNm9auaPq9SoQQ3bt+nUdv+2NoGbR/W1p/fjaZNlfyL1gOnuHFC7Ytu7RszZvICNmwL2uaG9G4XbJ8xqFcbVq7dyq0793nr70//bq2+qv9ERETCYvDzexPh9wY98fSi56CJeHo9w8JgIIVzEi5euUHCBPGCbmcxGilfujD1a1YItx5/f3+KVGzG/i1LsbL6z7yS4ov4BwTQa/AkOrdpQNpUyT8/g2A0Ghk9eQGliuajQB63bx3OVwvrXRjfu7DejyH/TbptSSTivWrcBKOnJ4Z48YixfNm3Dkf+z0TKEXmCeI5f/c4D+eCh+xO69B9H2ZIFlTiYyfeNH807DSKrS3ry5872rcMRERER+U/5/zyd/51IkjgBa5b8+K3D+K7Y2drwy4IJ3zqMCPFffWNwksQJdNVBRETkOxWlD0yLiIiIiMj3S8mDiIiIiIiYRcmDiIiIiIiYRcmDiIiIiIiYRcmDcOT4WS5cvv6twwhhxa+b8fN7+63DEBEREZF3lDxEEC/v5/QfMY2GbfvRrOMg9h86bprWofcoLl658Q2jCzJlznK27NgX4vP1W3aT0jlJmPPde/CIVl2H0rBtP/7480CI6QEBgYyftpiGbfoxdNxs3r71B4Leity43QB6Dp702bIQ9E6Lhm37sXD5OgDixInFngNHv3p5RURERCRiKXmIIIPHzKRw/hysnDeOyaN6M3vxaq5cv/2tw/qsu/fdiRkzBg4OMcIsM23eCpo3qMb8yUOYt3QNL31eBZu+/9Bxnr14ycr544hhb8fWnfsBcE6aKNhbjMMrC7Bh624sDB9WyVJF87Fjz8GIWEwRERERiQBKHiLAzdv3ef7iJRXKFAHAyTEOjepUYt3GnaYyG7ftpUXnITRs24/LV28CsH33QWo27U7dlr3ZvvtvAM5fukaTDgOp27IXy1dvAmDh8nUsW72R1t2Gs/TnDXTt/+E38het+I31W/7EPyCASTN/om7L3rTuNpyH7k8A2L3/CHVa9KJdjxGcv3QtROyXrt4ke9aMwT7r0HuU6f8BAYH8c+wM2bNmxMEhBimck3Di9MVg5Q8eOUUO10wAZHfNxN9HTwGQLElCMqRNYVbZ5y982LBtL9UqljCVjWFvR0BAIEZjhL8EXURERES+wn/iJXGvu3TF6OUVafUbHB2xnz4tzOl37j8kbeoUGAwG02cZ0qRk47a9pr9Tp0xG364t+OvvY0ydt5I5kwaxbPUmRg3sTOqUzrx+7cvbt/6MmbKQKaP74OQYh16DJ1GudGEAtu06wJIZI7G1tWHrrv34vHqNQwx7/j5ymgnDurN5+1/Y2FizauEETp27zLLVm2jdtCZT5ixn4dRhxI/nyMDR00PEfv/hY7K6pAtz2Z69eEHc2LFMVyZSOCfBwzN4X3s+9SZFsfwApEyeBA9P7zDrC6vsohW/0aROZd74+QUrHzdOLDyfehM/nmOYdYqIiIhI1PhPJA9GLy+Mnp7frH0LgwEIfnY80GjEwuLDhR3XzOkByJMjK6MmzQegQukiTJ+3khaNqpMnR1au37qL+yMPer17RuDVa18eP3lqKmtnZwtAoXzZOXriHFld0mFjbUU8p7gcOX6WqzfucOzkOYxGSOGcmPOXrpPDNROJEsYDIFGCeCFif/zkKfELBR2Yj5w0j6vXb3PvwSOatB8AwLSx/Qj86Mx/oNGIwcIQrA6DAQIDA4OmBwZi8cn0z5W9decBN2/fp1u7RsFuYwJIEM+JR088lTyIiIiIRAP/ieTB4Bi5B5afqz+FcxKuXLuN0Wg0XX24fO0WqZInDVHWytISW1trABrWrkjRgrmYPn8lfx85RcUfipHCOQlLZo4MNs+ho6eCJSLFC+dl07Y9PH/pQ9FCuQEwGqFr20YUzp/DVG7vwaO8eu0bbuxxYsfkxUsfAAb3agsE3bY0e+IgIOgA/8VLH176vCKmQwzu3nMnf+5sweqI7+TI3fvuFMjjxt377sR3Cru/Qiu758ARPJ9607rbMLyfvcDv7VuSJk5IhTJFePHShzixY4W7DCIiIiISNf4TyUN4txRFhZTJk5IgviOb/thLlfIl8PD0YuWaLYwZ3MVU5oH7E1wypGHrrv3kzOZCYGAgFy7fIKtLOlo0rM6YyQtp37wu3s+ec+L0BXK6ZebRY0/TVYOPubqkY8rsZfi88qVLmwYA5MmRhbUbd5AvlysAL176kDFdasZPW8yz5y+xt7Pl+s27ZEibMlhdSZMk5NFjT9OVkU9ZWFhQII8bJ89eIodrJu7ef0jObC7cunOfn1ZtZGif9hTKl4Ntuw5Qp1pZTp65RMF82cPsq9DKVi5bjOYNqgGwZcc+Hj56Ynp+5InnUxKH0gciIiIiEvX+E8lDdDC8X0cmTF/M6t+3Y21lRefWDUibKrlp+ulzl1m2eiOxHBwY2rc9/v4BbNu1nwkzlvDq1Ws6t2mAjY01Iwd0ZtLMpQQEBJIsaUJGD+wSoi0LCwuyZErLpau3SJI4AQBVKpTg5p37NGrXD3s7O9o0rUXBvNlpVr8qLbsMIWnihDg5xglRV6rkSfn7yClKk9/02furDu91a9uIIeNmMXfJr7RvUReHGPbcePmKW3ceAFA4fw4OHz9Dwzb9yJAuJeVLFQKgx6CJ3Ln3EK9nz2nSfgDjhnYLs2xoAgMDefs2ACsrraYiIiIi0YHBz+9NtP0pG39/f4pUbMb+LUt1ABlJAgMD6TFoIj+O7I2lZfT68a0jx89y+dotGtet/K1DEZGvVKl2y0ipd/OaRZFSr8j34FXjJhg9PTHEi0eM5cu+dTjyfyZ6HS1KlLOwsKBQvhycPn/5W4cSwt6Dx6hcrvi3DkNERERE3tHpfKF6xZJYWlp+6zBC6NGhsa44iYiIiEQjOjKTaHuAHl3jEhEREfl/pduWRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELEoeRERERETELJGWPPzy2zYq1+/EyjVbAPB+9oLOfcfSsE0/VqzZHFnNioiIiIhIJIm05CGnayby5nI1/b145XqKFcrNT7NHsW3XAe7cexhZTYuIiIiISCSItOQhY/rUJEkU3/T330dOkd01E1ZWVri6pOfQ0dOR1bSIiIiIiESCKHvm4anXM5yTJgIghXMSPDy9o6ppERERERGJAFZR1ZDBYACjEYBAYyAGC0Oo5dZu3Mm6TTsBML4rLyIiIiIi316UJQ9OjnG49+AR6dKk4O49d9KlSRFquVpVylCrShkA/P39KVKxWVSFKCIiIiIi4Yiy25YK5cvBybOX8Pf359zFaxTI4xZVTYuIiIiISASIlCsPTzy96DloIp5ez7AwGDh07DSjB3Zh8JiZ/L5lN5XKFjU9/yAiIiIiIt+HSEkeEsRzZNmcMSE+nz6uX2Q0JyIiIiIiUUBvmBYREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbNYRWVjazfu5Jd1W7GysqJ/t5Zkd80Ulc2LiIiIiMi/EGVXHl699mXxyvUsnzuWCcO6M3fJr1HVtIiIiIiIRIAoSx6sLC1xcoyDjbUVzkkT4+AQI6qaFhERERGRCBBlty3Z2FhTvWJJ2vcajUuG1NSqUiaqmhYRERERkQgQZcmDj88rDh87S4uG1Vi5dgtx48SiQB63EOXWbtzJuk07ATAajVEVnoiIiIiIfEaUJQ9//X2cLC7pKJDHjdzZs1C3ZW8a1KqIna1NsHK1qpQxXZXw9/enSMVmURWiiIiIiIiEI8qSB0tLC86cv4yf31s8vZ7x/MVLDIaoal1ERERERP6tKEseShcrwKmzl6nXqg+Wlhb0794KWxubz88oIiIiIiLRQpReeejbtUVUNSciIiIiIhEszJ9qDQwMDPGZ97MXkRqMiIiIiIhEX2EmD807Dw7xWa8hkyI1GBERERERib5C3La0ded+AJ6/8DH9H+Dhoyc89XoedZGJiIiIiEi0EiJ5ePjoCQCvXvly4vQF0+eJE8Xnx5G9oi4yERERERGJVkIkDy0b1QAgTuxYegu0iIiIiIiYhPlrS7WqlOGNnx/e3i8w8uFNz4kTxo+SwEREREREJHoJM3lYvHI9i1f+jq2NNZaW75+rNrBj3bwoCk1ERERERKKTMJOHtRt3snTWKNKlTh6V8YiIiIiISDQV5k+1ZkibkjQpk0VlLCIiIiIiEo2FeeWhaIFcTJi+hEL5sgf7vEiBXJEdk4iIiIiIRENhJg9/7jsMwKrf/jB9ZjAYlDyIiIiIiPyfCjN5mDVxYFTGISIiIiIi0VyYycPJs5dC/TyHa6ZIC0ZERERERKKvMJOHKXOWB/v7/sNH5M3hquRBREREROT/VJjJw7LZo4P9feLMRf45ejrSAxIRERERkegpzJ9q/VT2rBnZc+BoZMYiIiIiIiLRWJhXHn79fbvp//7+AZy9cBUbG+soCUpERERERKKfMJOHK9duffjDYCBl8iR0adMgCkISEREREZHoKMzkYVCvtlEZh4iIiIiIRHNhJg/+AQH8vHYL+w+dAAwULZCT+rUqYGVpGYXhiYiIiIhIdBFm8jB70WoeuD+mTdNaGAwG1m3cxexFq3XrkoiIfHOVareMtLo3r1kUaXWLiHzvwkweDh8/w7LZY7C0DPpBpuyumWjWcVCUBSYiIiIiItFLuD/V6h/g/+H//gEYA42RHpCIiIiIiERPYV55KFO8AJ36jKVq+eIAbPxjL2VLFYyquEREREREJJoJM3loVr8qiRPG48A/JwGoWbk0ZUsWirLAREREREQkegkzeXjj50e5UoUpV6owAIGBgXg/e0HcOLGiLDgREREREYk+wnzmYcDIaXh5Pzf9/fCRB2MmL4iSoEREREREJPoJM3l44umNY9zYpr+TJUnIIw/PKAlKRERERESinzCTBytLC27evm/6+869hwQG6NeWRERERET+X4X5zEObprXp2Hs0+XK7AgYOHztD/+6R91IeERERERGJ3sJMHvLnzsaCacM4fPwsRmMgLRpWI3myxFEZm4iIiIiIRCNhJg8Q9JxDjUqloioWERERERGJxsJ9w7SIiIiIiMh7Sh5ERERERMQs4d62tHPvIfYfOg4YKFIgJ2WKF4iisEREREREJLoJM3lYtnoj+w+doHK54hgMBn79fQePHnvSqE6lqIxPRERERESiiTCThx17DrFw6jDs7GwBKF0sH627DVfyICIiIiLyfyrMZx6MgUZsbKxNf9tY22AM1EviRERERET+X4V55SFfLlcGjppBrSplAFi3eRd5c2WNssBERERERCR6CTN56NCyLst/3czsxasBKJI/J43qVIyywEREREREJHoJM3mwsrKieYNqNG9QLUIbPHvhKj/O+omAgEDKly5Mg1oVIrR+ERERERGJHGEmD+6PPZi54BfOX76Ova0thfLloEWjatjb2X11Y2/f+jPqx3n8OLI3SRIl4M69h19dl4iIiIiIRK0wH5gePmEuSRIlYHjfDgzq1QZPL28mTF/6rxo7evIcmdKnwTlpIiwtLUidMtm/qk9ERERERKJOmFceXrz0oWOreqa/B/VMTcO2/f5VYw/cn2Bvb0ufoZN55OFJ17aNyJnN5V/VKSIiIiIiUSPM5CF1imQ89XqGk2McAPze+pMkUYJ/1dir16+5duMOk0f14e59d8ZMXsDK+eOClVm7cSfrNu0EwGjUT8OKSOSoVLtlpNW9ec2iSKs7skRmf4iIyH9HiOSh7/ApGAwGPDy96NRnDCmSJwHAw9MLx7ix/1Vj8Z0cSZ3SmdixHMicMQ3ez1+EKFOrShnTz8P6+/tTpGKzf9WmiIiIiIhEjBDJQ9GCuSKtsXy5XFm8cj0+r15z6859EiWIF2ltiYiIiIhIxAqRPFQsU9T0f6PRiNez5zjFjRMhjcVzikurxjVo0304xkAjg3q1iZB6RUREREQk8oX5zMPfR04xceZSANYvm8pD9yes37qbDi3q/qsGy5UqTLlShf9VHSIiIiIiEvXC/KnWWQtXsWTGSGLFdAAgSeIEHDl+NsoCExERERGR6CXM5MFoNBI3TizT3/7+/rz29Y2SoEREREREJPoJ87Yll4xp2LB1D4GBgVy/dZdFy38jW5aMURmbiIiIiIhEI2FeeejRoQkXr97Ay/s5XfqNI2bMGHRr2zAqYxMRERERkWgkzCsPDjHs6de1Jf26fnhxkJ/f2ygJSkREREREop8wrzwMGz8bL+/npr/v3ndnzJQFURKUiIiIiIhEP2EmDzfv3A/2RunkyRJz686DKAlKRERERESinzCTh8AAI088vUx/e3h66bYlEREREZH/Y2E+89CoTkXadBtGudKFMWDgjz8P0rRelaiMTUREREREopEwk4eyJQuROFECDv5zgkCjkUE9W5PTLXNUxiYiIiIiItFImMkDgFuWDLhlyRBVsYiIiIiISDQWZvJw6859Fq1Yz70Hjwg0Bpo+/2nW6CgJTEREREREopcwk4dh4+dQokhe3B970rpJTS5dvYG1VbgXKkRERERE5D8szF9bMmKkab0qZM6YmpgO9jSpW4V/jp2JythERERERCQaCfNSQgx7e1689CF/bjc2/rEXGxsb3B97RmVsIiIiIiISjYR55aFJ3cp4P3tBvlyu+Pq+oV2PEVSrWDIqYxMRERERkWgkzCsPBfK4mf4/rG+HKAlGRERERESirxDJw7Ubd0ItGGg0suLXTYzo3ynSgxIRERERkegnRPLQZ9iUUAsaDFC0YK5ID0hERERERKKnEMnDb8tCTx5EREREROT/W6jPPGzffZA799zJ7pqRPDmyRnVMIhJJKtVuGWl1b16zKNLqFvkviKzt73vc9rQv+uBr+mL2Ky/iAR5PvegQzvzfW1/I9yHEry3NXryaNRt24PvmDZNm/sS2XQe+RVwiIiIiIhLNhLjysHPvIZbPGUNMhxjUqVqWwWNnUr504W8Rm4iIiIiIRCMhrjzY2tgQ0yEGAIkSxsPX902UByUiIiIiItFPqM88XLt5F4xGAPze+gf7O12aFFEXnYiIiIiIRBshkoc3fn70GTo52Gfv/zYYYN1P+jUmEREREZH/RyGSh/XLpn6DMEREREREJLoL8cyDiIiIiIhIaJQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWZQ8iIiIiIiIWaI8eXjo/oRilZtz4vSFqG5aRERERET+hShPHmYtWkXyZImjulkREREREfmXojR5OHX2EoGBgWRMlyoqmxURERERkQgQZclDQEAgsxevpnPrBlHVpIiIiIiIRCCrqGpoy8595M2ZlSSJE4Rbbu3GnazbtBMAo9EYFaGJRDuVarf81iFEG+oLEfkSkbXP2LxmUaTUK/K9ibLk4a+DR/F8+ox/jp3h/sPHXLh8nVEDO5M2VfJg5WpVKUOtKmUA8Pf3p0jFZlEVooiIiIiIhCPKkocfR/Y2/X/kpHlULFMkROIgIiIiIiLRl97zICIiIiIiZomyKw8fG9yr7bdoVkRERERE/gVdeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbMoeRAREREREbNYfesAJHJUqt3yW4fwxTavWfStQxCJEN/j9icffG/j973F+71SP4sE0ZUHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi5IHERERERExi1VUNfT8hQ/jpi3i7j134sSOyYj+HXFyjBNVzYuIiIiIyL8UZVcezl28Su2qP7B87hgypk/FyrVboqppERERERGJAFF25aFg3uym/7tmTs/ufUeiqmkREREREYkA3+SZh+OnLpAtS4Zv0bSIiIiIiHylKLvy8N71W3c5evI8nVrXD3X62o07WbdpJwBGozEqQwtTpdotI63uzWsWRVrdEiQyx08+UD+LiEQvkbVf1rHL/7coTR68vJ8zdNxsRg3sjK2NTahlalUpQ60qZQDw9/enSMVmURihiIiIiIiEJcpuW/Lze8uAkdNo3aQm6VInj6pmRUREREQkgkTZlYflv27m8rVb/PTLBhYt/w2A+VOGYmdnG1UhiIiIiIjIvxBlyUPLRtVp2ah6VDUnIiIiIiIRTG+YFhERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERsyh5EBERERERs1h96wD+31Wq3fJbhyAiIiLyzUXmMdHmNYsipd7Iijmy4o0IuvIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmsYrqBn/fups1G3YQ0yEGI/t3JGGCeFEdgoiIiIiIfIUovfLw1OsZy1dvYtG04dSqUoZZi1ZHZfMiIiIiIvIvRGnycPj4WTKkTYWdnS3ZXTNx6OipqGxeRERERET+hSi9bcnzqTcpnBMDEN8pLgGBgfi+8cPO1ibU8kajEQB/f/8oizG8OCRyRdY4a/xEROS/xN/47h/f5jvue/y+/t5i/tbHvh+ztLTEYDCY/jb4+b2JsrVuxZrNPH/+kg4t62E0GilVrRXb1szB1uZD8rB2407WbdoJQGBgIHfuuUdVeCIiIiIi8pH9W5ZiZfXhekOUXnlIEM+RcxevAfDE0wtra+tgiQNArSplqFWlDBCUPPj5+YXIeP7rGrXrz4q5Y791GPIRjUn0pHGJnjQu0Y/GJHrSuERPGpfgLC0tg/0dpclD3pyuzP9pLb6+bzh55hIF82YPt7yFhQV2dnZRE1w0YjAYgmV48u1pTKInjUv0pHGJfjQm0ZPGJXrSuIQvSnvGMW5smjWoRsuuQ4nlEIORAztHZfMiIiIiIvIvRHlaVblsMSqXLRbVzX5XalYu861DkE9oTKInjUv0pHGJfjQm0ZPGJXrSuIQvSh+YFhERERGR71eUvudBRERERES+X0oeRERERETELHqUPJJ5P3vB4DEzeer1jPJlCtOodqVg041GI4tXrmf3viMkTODEyAGdiOkQg3sPHjFs/Gxe+76hcZ1KlCtVGPfHHoyftpjHT57inCwRw/t2wM7OlpGT5nHyzCViOtgDMHPCQGLHcvgWi/td+H3rbtZs2EFMhxiM7N+RhAnimaaF1u9fMkZhlZXwRdSYrPrtD3bsOYjPK186tapHkQK5eOj+hHqt+5DSOQkApYrlp2m9Kt9qUb8rETUuYe2jwqtfwhYR4+LvH0CXfh9+ivLRk6c0q1+F+jUrUKh8Y9KmSg6AW9aM9OzYNMqX8XvzpWMCMHvRKn7fuod+3VpSskjeMMvqe+XrRdS46LslOF15iGSLV66nWKHc/DR7FNt2HeDOvYfBpl+5dou/j5xm2Zwx5MiWiRW/bgZg2rwVNG9QjfmThzBv6Rpe+rzixOmLdG7dgBXzxmJpacnmHftM9Qzo0Yplc8awbM4YJQ7heOr1jOWrN7Fo2nBqVSnDrEWrg00Prd+/ZIzCKithi6gx8Xn1mjd+fiyYOpyxg7syZspC05s/M2dIY9o+/l927v9WRG4rEHIf9bn6JXQRNS5x48QyjcfcyUNI4ZyEqhVKApAgnpNpmhKHz/uaMQEonD8nmTOm+WxZfa98nYgaF323hKTkIZL9feQU2V0zYWVlhatLeg4dPR1s+sEjp3DLkgFLSwuyZ83E30dPExAQyD/HzpA9a0YcHGKQwjkJJ05fpEKZIqRJ5YzBYMA1c3qeeDw11RM3dqyoXrTv0uHjZ8mQNhV2drZkd83EoaOnTNPC6vcvGaPQykr4ImpMHGLY07ReFSwtLUidMhkBAQG88XsLQJw42j6+VESNy3uf7qPCq1/CFtHjAvDLuq3UqlKaGPZB71WKEydmVC7Sd+9rxgQgW5YMxHOK+9my+l75OhE1LvpuCUnJQyR76vUM56SJAEjhnAQPT+9g0z2fepMiedAlr5TJk+Dh6cWzFy+IGzsWDu8uSwbN5xVsvuOnLpAtSwbT3zMW/Ey9Vn1YvHK9KSOWkDyfepPCOTEA8Z3iEhAYiO8bP4Aw+/1Lxii0shK+iBqTj12+dgvnpImwsw16g/21G3do3mkwnfqO4dad+1G1aN+1iB6XT/dR4dUvYYvocfEPCGDPgaOUKJw3WButuw2ndbdhnD5/JaoW7bv1NWMSGn2vRKyIGpeP6bsliJ55iEBLf97AoWPBzwi89n0D7w7mA42BGCwMwWcyGAgMfDc90IiFhQEDBgI/SgACjcZg8x0+fpYXL31Mb+huUrcyMWLYExAQQMfeo8meNSM53TJHwhL+BxgIllwZA40YDO8nhdHvXzJGoZSVz4igMXnPPyCAafNW0rZZHQASJojH4N7tcEmfmlXrtzFhxhJmTxwUBQv2nYvAcQltHxVe/RKOCN5eLly6TkrnJNjYWJs+Gz2oK5nSp2LvgaMMGz+b9cumRu4yfe++ZkxCrUbfKxEqgsblPX23fKArDxGoWYOqzJs8JNg/56SJuPfgEQB377mTIJ5jsHkSODly937QcxB37rsT38mROLFj8uKlj+n+u7v33In/br479x4yfd5KRg7ohOHdVpAyeVISxHMkccL4FMqXg1t3gz9XIR8kiOfInfvuADzx9MLa2hpbm6AzCGH1+5eMUWhlJXwRNSbvTZ2zglxuLuTL5QqApaUFblkyYGNjTdXyJbmt7cMsETkuoe2jwqtfwhbR28ulqzdJlyZFsDbcsmTA1saGMsUL8PLlK10R+oyvGZPQ6HslYkXUuLyn75YPlDxEskL5cnDy7CX8/f05d/EaBfK44eX9nJ6DJ+EfEEChfNk5fe4yAQGBnDxzkYJ5s2NhYUGBPG6cPHuJlz6vuHv/ITmzufDs+UsGjprBgB6tSBjfCQAv7+ds3/03RqMR72cvOH3+MhnTpfq2Cx2N5c3pytXrt/H1fcPJM5comDc7K9dsYceev8Ps9y8Zo9DKSvgiakwA1m7ciedTb1o0rG6qf+feQ3g+9cZoNLL/0HEypU/1bRb0OxNR4xLWPiq0+uXzInJ7AXB/7Bns/u6Dh09y990B1/HTF0gY38l0i4aE7mvGJDT6XolYETUuoO+WT+kN05Hs2fOXDB4zE8+n3lQqW5T6NSvw8JEHnfuOYcXcsdjZ2bLk59/ZtfcfEieKx4j+nXCIYc9D9ycMGTeLV699aVqvCj+UKMioH+dz4J8TJEmUgICAAGLGjMGU0X2Yu+RXTp65hPezF9StXpb6NSt868WO1jZt/4tVv20jlkMMRg7szPLVm0icMD4NalUItd8Bs8corLISvogYE+9nL6jbohepUzqbLk03rluZhAniMXfJr3g+9SaeU1yG9GpLksQJvuHSfj8iYlysrCzD3Ed9Wv+nV2YldBG1DwMYN3UROd1cTOVu3r7PtHkrePzkKdY2Vgzo3lonpMzwpWNy8coNxk5ZiPtjTxwc7MmeNSND+7TX90oEi4hxadW4pr5bPqHkQUREREREzKLblkRERERExCxKHkRERERExCxKHkRERERExCxKHkRERERExCxKHkRERERExCxKHkRERERExCxKHkRERERExCxKHkTk/0L1Jt2o27IXDdv2o1XXoezZfwSjMeg1Nw/dn1CgbCN27f0n2DzteoygQ+9Rpr8LlG3Ei5c+X9x2QEAgwyfMoWHbfvzy2zYeP/GkQ+9RNOkwkBOnL3xxfSMnzfuq+T7H940fk2b+RLOOg6jTohfrNu00TTt74Sqd+o6hYLnGX9QHfYdNYcuOff86tiPHz9K802BadR3K8xdfPgaR5cr121Rv0u1f1dGh9ygeuj+JmIBERCKZ1bcOQEQkqowc0JkMaVNy595D+g6fgn9AAGWKFwAgebLEbPvzAKWL5wfg/sPHeHo9I0H8f//W4yeeT9m9/wi7fluAtbUVW3fux9LCkmWzR//ruiPSlWu3cMmYmp4dm/DE04vazXqSL1c2nJMmImF8J1o0qMbxUxGftJhjx95DFC2Yi+YNqn2T9kVEJIiSBxH5v5PCOQld2jRk5sJfgiUPD92f8NT7GU5x4/DHnwfJlysbN27fNbteH59X/Dh7GRcu38BggI4t65M/Tza6D5yAv78/LbsMoXuHJsz/aS0vfV7RovMQFs8YwbmL15g8exk+r16TJFF8hvRuh5NjHDyfejN59jJu3r6PtY0VXds05PDxs+zZf4TT5y6TLElCpo3tFyyGTdv/YtVv28AILhlS0619Y2I6xGDLjn2cPHsJo9HI2QtXiRsnFpNG9CJ2LAfTvNmyZCBblgwAJIzvhHPSRDx+4olz0kQkShiPRAnjfbYPnr/wYcL0xVy9cYfECePh8dTbNO3Q0dMsW7URn1evwWBgWJ/2pEyelDotejJheA/SpkoOQKc+Y2jRsBo53TIDsGbDDvb9fRxbWxs8PL3o3bk5B/45yYLla/H3D8A5aSJ6dWpGgniOnDh9gTUbduIYNzaXrt6gWKE83L77gCG92/H8hQ/l67RjRP9OlCqaj70Hj7L9z78ZO6QrK9ds4c99h3nt60vSxAkY0b8TDjHsWbh8HQaDgbMXruIYNw5D+7Rjz/4jzPtpLTHsbUmSKEGo/TBy0jwypkvFngNHyZopHR1a1uWnVRvZtusARqOR8qUL07xBNUZOmsfZC1fpMXgimTOmZXCvthQo24gd6+YRK6YDV67fpu/wKaxfNpWH7k8YOHo6hfLlYN+h44wb3I2RP86jVNF87Pv7OFev36FmldK0bFTD7HVWRORL6bYlEfm/lCVTOu7ce4h/QAAAb974UapYPnbuOYTRaGT3vsPkzZn1i+qcseAXXDOn55cF45k9cRA/zlqKAQOTR/Ymhr09y+aMIYdrJlo3qUkut8wsnjGCFy99GDN5AWMHd2X1ookUK5Sbn1ZtAIIOQFOlSMbK+eOYM2kwmTKkoX2LumTKkJoB3VuFSBxOnb3ET79sYOb4AayYNxZ7eztmLvjFNP346Qu0bFSdn+ePw98/gN37D4e5LPcfPsbjqTcZ06X6oj6YPm8FsWPF5JcF4xk3tBt2tramaUkTJ2Dc0O4smzOGkkXysmjFb1haWlCr6g9s3LYHgMceT3F/7EF210ym+WpX/YEiBXLSsFZFenduzt377oyZsoDRA7uwct443LJkZNSkeaby+w8dp0CebCyeMZJiBXNz4vRFjEYjJ85cIIerC8dOng/qj1MXyJsraIxzurkwf8oQfp4/noCAQP7484CpvrUbd9K3a0uG9mnH3fvujJ++mAnDurN4xkhKFcsfZl+s3biTCcO607FVPXbsOcTtuw9YOW8sK+eN48iJc1y+epPBvdoSP54jk0f2ZnCvtp/t38vXbhE7Vkx+mjWaJIkTmD77cVRvpo/rx5KVv+Pr+8acoRIR+Sq68iAi/5eMxkAMBgMGDAAEGgMpX7owg8fMIqtLelKlSEpMB/svqnPfoeOcvXCV9Zv/DKoz0Ij3s+fhznPu4jUeeXjSe+iPQNDzEalTJuPVa1+OnbrAuKHdMRgMxLC3+2z7Bw6fpEyJAjjGjQ1AnWpladtjBP26tQQgQ5qUJE2cEACXjGnw/OiqwMfevvVnzOQFtGteGweHGOG22azjIAIDA3GMG5tpY/vx95HTzJsyBAsLC+zt7IjvFNdU1jlpYg4fP8M/x85w8coN/N6+BaBy2WI0btef9i3qsWvvP5QvXRgLi7DPbR05cZZ8uVxxTpoIgFpVyjB78Wpe+/oCkDJ5UooUyPXu/0kwWBi49+ARx05eoHa1H5iz+FcgKHmoV6M8EHQ16o8/D3L6/BXuPXjEvQePTO2VKpqfJInim9rOnzsbKZyTvFumRGHGWbV8CWLFDLqys//Qcc5fvk6LzkMAePXal4ePPMiYPnW4/fspO1tbalUpE+yzQvlyYGVpSdrUybG2tsbr2QuS2NmGUYOIyL+j5EFE/i+dvXCNVMmTYmn54SA1aeKE2NnasHLNZir+UPTLKzXC8H4dSJcmRbCPw3sY1mg04pw0ET/NCv78w6vXvmA0YmEwfHkc7xgMBgxhzG9laWl6YPxj/gEBDB0/myyZ0lK9YqnPtrF01qhgf/sH+GNlaRlq2ZGT5mJrY0OV8sUpnC8HMxcGXRWJ6RCDogVz8dfBo+zef5gR/Tt+tt1PfbyYH4+pwWAgf65snDxzkTPnL9OxVV1++mUjl67e5K2/P8mSJOS1ry+tug6lSrniNKpdkYTxnXjp8yrU+vz9A7AMY/k+9XE5o9FI/RrlqVOtrFnz+vsHhPq5hYVFmGNqMBiwsrKEUMZVRCSi6LYlEfm/c+vOA6bPX0mzUB6+rVCmCKfPXyFf7mxfXG+h/DlYtGI9b9/6YzQaeeD++LPzZMmUjkePPdm9/wgAPq9e4+X9nBj2dmTLmoGf123FaDTi+8aPx088AUicMD4PH3mEqKtwvhzs3HMI72cvMBqNrNmwnSL5c5odf2BgIOOmLCR2TAfat6hr9nwfy541E5u2/wWAl/dz7tx/aJq2/58T1KpShswZ03Lx6s1g89Wq8gMr127Fzs7WdHUkLHlzunLkxDnuPwzq33Wbd5Ezmwv2dqFfncmfJxv/HDuDvb0d9nZ25HRz4ee1W8ibyxWAO3cf4v3sBbWr/kCihPG5ev12OMuXkUNHT+Ph6QXA2QtXPtMjQQrnz8mvv283Xe35eN0IGs8PCWZ8p7icPncZ/4AAtu3ab1b9IiJRRVceROT/xuAxM7C0sMTe3o4OLepSvHCeEGVKF89PtiwZwjx73rTDICwsgs78FsqXne7tm5imdW3bkKlzltOwbT/s7GzJl9OVjq3qhRtTnNgxmTi8J9PmrWDR8t+wtbWmY8v65MqemaG92zNhxhIatOmLvZ0dLRtVJ2GCeFQsU5Rh42ezded+po3rZ4o1u2smmtavSsc+o8EImTKkpkf7xmb3z2+b/2TLzv24ZEhD0w4DAXDNnJ7enZvTf8Q07j8MupWnXc+RZM+akd6dm4eoo3uHJoycNJeGbfrhnCwRyZMmNk1r2bAGg8bMIGH8eOT/JDlLniwxMexsqVC6yGfjTJ4sMf27taL/yGkEBATgnCQRg8J5XiC3W2aGjJ1Fg5oVAMjllpleQyYxdnA3ANKmTk7BvNlp2LY/KZ2TkCxpQgIDQz97nzF9ahrXrUzbHiOI5xSXfLnMSzLLlSrEE8+ndOg9ClsbGxLEd2L0wM7Y2dlSrUJJBo+dRc5sLowc0InWTWoyZspCUqxJTKM6ldh78JhZbYiIRAWDn98bXd8UEZFv6tad+wwcNYPFM0dga2PzrcMREZEw6MqDiIh8UxNnLOHYqfMM6N5aiYOISDSnKw8iIiIiImIWPTAtIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJmUfIgIiIiIiJm+R9R0WJMOZrwBAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 800x400 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "placebo_arr = np.array(ref.get(\"placebo_effects\", []))\n",
     "if len(placebo_arr) > 0:\n",
@@ -772,42 +555,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "91cf0f41",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:12:35.825056Z",
-     "iopub.status.busy": "2026-08-24T20:12:35.824966Z",
-     "iopub.status.idle": "2026-08-24T20:12:35.849023Z",
-     "shell.execute_reply": "2026-08-24T20:12:35.848479Z"
-    },
-    "papermill": {
-     "duration": 0.026029,
-     "end_time": "2026-08-24T20:12:35.849318+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:12:35.823289+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  -> registered causal_dml (causal_hash=cc0122c50ea2, p_hac=0.3778)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'cc0122c50ea2'"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "# Per-observation treatment contributions from DML residuals\n",
@@ -873,6 +624,7 @@
     "    max_symbols=MAX_SYMBOLS,\n",
     "    development_end=DEVELOPMENT_END.date().isoformat(),\n",
     "    notebook=\"12_causal_dml\",\n",
+    "    supersedes_hash=supersedes_for(SUPERSEDES_CAUSAL, PRIMARY_LABEL, labels=[PRIMARY_LABEL]),\n",
     ")"
    ]
   },
@@ -918,50 +670,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "a3df3ea9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-24T20:12:35.855454Z",
-     "iopub.status.busy": "2026-08-24T20:12:35.855348Z",
-     "iopub.status.idle": "2026-08-24T20:12:35.857886Z",
-     "shell.execute_reply": "2026-08-24T20:12:35.857465Z"
-    },
-    "papermill": {
-     "duration": 0.004712,
-     "end_time": "2026-08-24T20:12:35.858157+00:00",
-     "exception": false,
-     "start_time": "2026-08-24T20:12:35.853445+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "============================================================\n",
-      "CHAPTER 15 RESULTS: etfs causal DML\n",
-      "============================================================\n",
-      "  treatment: skip_recent_6_1\n",
-      "  outcome: fwd_ret_21d\n",
-      "  confounders: ['vol_21d', 'vol_126d', 'regime', 'yield_curve_slope']\n",
-      "  n_observations: 312073\n",
-      "  naive_effect: -0.009325\n",
-      "  dml_effect: 0.010371\n",
-      "  dml_se_iid: 0.001252\n",
-      "  dml_se_hac: 0.011758\n",
-      "  confounding_bias_pct: -189.908331\n",
-      "  p_value_hac: 0.377814\n",
-      "  hac_maxlags: 20\n",
-      "  refutation_p_value: 0.049505\n",
-      "  refutation_class: Passes\n",
-      "\n",
-      "[OK] Causal DML analysis complete for etfs\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(\"\\n\" + \"=\" * 60)\n",
     "print(f\"CHAPTER 15 RESULTS: {CASE_STUDY_ID} causal DML\")\n",
@@ -996,25 +708,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-08-24T20:12:42.726727+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "d19482133c8b2194a3b9d246dde0b1cbcdb1bf40"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 257.878481,
-   "end_time": "2026-08-24T20:12:37.376194+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "~/scratch/wt-etfs-merge/case_studies/etfs/12_causal_dml.ipynb",
-   "output_path": "~/scratch/wt-etfs-merge/case_studies/etfs/.12_causal_dml.papermill.2611882.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-24T20:08:19.497713+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/12_causal_dml.py
+++ b/case_studies/etfs/12_causal_dml.py
@@ -67,6 +67,7 @@ import pandas as pd
 import yaml
 
 import utils.style  # noqa: F401 - activates the ML4T visual style
+from case_studies.research import supersedes_for
 from case_studies.utils.causal import (
     classify_refutation,
     embargo_from_buffer,
@@ -88,6 +89,12 @@ RANDOM_SEED = 42
 CV_FOLDS = 5
 MAX_SAMPLES = 0
 N_PLACEBO = 100
+# Any edit to case_studies/utils/causal.py moves this notebook's causal identity, because
+# _causal_source_identity hashes that file whole. The registering write then refuses a second
+# current identity for the same label and names the hash it wants retired. Declare it here -
+# a bare hash, or a JSON object keyed by label - and the refusal has a route to be answered.
+# Empty is correct against a fresh registry, where there is nothing to supersede.
+SUPERSEDES_CAUSAL: str = ""
 
 # %%
 CASE_DIR = get_case_study_dir(CASE_STUDY_ID)
@@ -414,6 +421,7 @@ register_causal_run(
     max_symbols=MAX_SYMBOLS,
     development_end=DEVELOPMENT_END.date().isoformat(),
     notebook="12_causal_dml",
+    supersedes_hash=supersedes_for(SUPERSEDES_CAUSAL, PRIMARY_LABEL, labels=[PRIMARY_LABEL]),
 )
 
 # %% [markdown]

--- a/tests/test_supersedes_declaration.py
+++ b/tests/test_supersedes_declaration.py
@@ -23,9 +23,16 @@ REPO = Path(__file__).resolve().parent.parent
 CAUSAL_NOTEBOOKS = [
     "case_studies/cme_futures/11_causal_dml.py",
     "case_studies/crypto_perps_funding/11_causal_dml.py",
+    "case_studies/etfs/12_causal_dml.py",
     "case_studies/fx_pairs/11_causal_dml.py",
     "case_studies/us_equities_panel/14_causal_dml.py",
 ]
+
+# Four more notebooks open a causal request through register_causal_run and do not yet
+# declare the parameter, so they cannot answer the write-time refusal:
+# nasdaq100_microstructure/12, sp500_options/10, sp500_equity_option_analytics/12 and
+# us_firm_characteristics/09. Each is owned by an active branch and takes the same patch
+# from its own side; add the path here in the same commit that adds the parameter.
 
 
 class TestTheDeclarationParser:
@@ -73,16 +80,31 @@ def test_the_parameter_reaches_the_request(path: str) -> None:
     """Declaring it and not passing it is the same as not declaring it."""
     source = (REPO / path).read_text()
     tree = ast.parse(source)
-    passed = [
-        keyword
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "causal"
-        for keyword in node.keywords
-        if keyword.arg == "supersedes"
-    ]
-    assert passed, f"{path} declares SUPERSEDES_CAUSAL but no study.causal() call takes it"
+    # Two shapes open a causal request and both perform the refusal. The resolver path is
+    # study.causal(supersedes=...); the direct path is register_causal_run(supersedes_hash=...),
+    # which reaches _enforce_causal_supersedes from inside the registering write. Recognizing
+    # only the first left every direct caller ungoverned by this file.
+    passed = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "causal":
+            wanted = "supersedes"
+        elif (
+            isinstance(func, ast.Name)
+            and func.id == "register_causal_run"
+            or isinstance(func, ast.Attribute)
+            and func.attr == "register_causal_run"
+        ):
+            wanted = "supersedes_hash"
+        else:
+            continue
+        passed.extend(k for k in node.keywords if k.arg == wanted)
+    assert passed, (
+        f"{path} declares SUPERSEDES_CAUSAL but nothing takes it: no study.causal() call "
+        "with supersedes= and no register_causal_run() call with supersedes_hash="
+    )
 
 
 @pytest.mark.parametrize("path", CAUSAL_NOTEBOOKS)


### PR DESCRIPTION
#916 made the registering write enforce supersession: a second current causal identity for a label is refused, and the refusal names the hash it wants retired. #610 wired the four notebooks that call `study.causal()`. **Five more register through `register_causal_run` directly and were missed**, because the call-site search looked for the resolver's shape.

Why it bites: `_causal_source_identity` hashes `case_studies/utils/causal.py` whole, so any edit there moves every causal identity in every case study, and four such edits have landed since the freeze anchor. The next causal run of an unwired notebook therefore fits, and then fails **at the registering write**, naming a parameter the notebook does not accept. `tests/test_causal_supersedes.py:167` says that must not happen.

## What lands

**`etfs/12_causal_dml`** gets `SUPERSEDES_CAUSAL` in its parameters cell, resolved through `supersedes_for` into `register_causal_run(supersedes_hash=...)`. It is the one of the five that no open branch is modifying, so it lands alone; the other four are each owned by an active branch and take the same patch from their own side.

A `str` rather than a `dict`, because papermill passes a parameter through as a string. `supersedes_for` takes either a bare hash or a JSON object keyed by label, and raises on a label the notebook does not fit. Empty is correct against a fresh registry.

**Nothing in `case_studies/utils/causal.py` changes, so no causal identity moves.** `register_causal_run` already accepted `supersedes_hash`; only the notebook needed to pass it.

**The guard is generalized to both request shapes.** `test_the_parameter_reaches_the_request` matched only `study.causal(supersedes=...)`. The other shape reaches `_enforce_causal_supersedes` from inside the registering write and performs the same refusal, so **every direct caller was outside this file's reach** — adding `etfs/12` to that list would have added it to a check that could not see it. Found by the pre-push review, which was right.

22 tests pass, up from 19. Verified the guard can fail rather than assuming it: removing the argument fails `test_the_parameter_reaches_the_request[case_studies/etfs/12_causal_dml.py]` with `assert []`; restoring it passes.

## What does not land

The list is still hand-written, so a notebook adopting either shape without the parameter passes silently. The four remaining direct callers — `nasdaq100_microstructure/12`, `sp500_options/10`, `sp500_equity_option_analytics/12`, `us_firm_characteristics/09` — are named in a comment beside the list, each to be added by the commit that wires it. That keeps ownership with the branch holding the notebook instead of forcing five conflicts.

The render is cleared: the notebook is correct and has not been executed against this source.