### PR TITLE
nasdaq100_microstructure: declare the deep-learning device instead of inventing one

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -17,12 +17,12 @@
 
 # ---------------------------------------------------------------------------
 # Needs the modelling environment - run by test-unit-image, in ml4t/ml4t:latest.
-# 26 files, 392 tests, 3m21s.
+# 27 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
 #
 # `case_studies/utils/gbm.py` imports torch at module scope, so the LightGBM
 # files are behind this boundary too even though LightGBM itself is a small
 # wheel. The multi-GB estimate this block used to carry is right, and it is not
-# torch that makes it so: importing all 26 pulls 110 distributions, because
+# torch that makes it so: importing them pulls 110 distributions, because
 # ml4t-models brings shap, numba and xarray, and three files bring darts with
 # pytorch-lightning, transformers and triton behind it. A CPU torch wheel is
 # 184 MB and would not reach any of them.
@@ -44,6 +44,7 @@ tests/test_deep_model_state.py
 # would land silently. It does need torch - case_studies/utils/deep_learning.py
 # imports it at module scope (:42) - so the entry is right and the cost is real.
 # Raised by fx_pairs on a push-gate review. Goes away with the torch decision.
+tests/test_dl_device_contract.py
 tests/test_dl_force_retrain_identity.py
 tests/test_gbm_classification_target.py
 tests/test_gbm_identity.py

--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -23,7 +23,7 @@
 # files are behind this boundary too even though LightGBM itself is a small
 # wheel. The multi-GB estimate this block used to carry is right, and it is not
 # torch that makes it so: importing them pulls 110 distributions, because
-# ml4t-models brings shap, numba and xarray, and three files bring darts with
+# ml4t-models brings shap, numba and xarray, and four files bring darts with
 # pytorch-lightning, transformers and triton behind it. A CPU torch wheel is
 # 184 MB and would not reach any of them.
 #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -895,9 +895,11 @@ jobs:
   # gated to unrun. Measured 2026-08-24 in the full environment: 392 tests, 3m21s.
   #
   # torch alone does not reach them. Importing them pulls 110 distributions:
-  # ml4t-models brings shap, numba/llvmlite and xarray, and three files
-  # (test_darts_state, test_darts_temporal, test_latent_input_identity) bring
-  # darts with pytorch-lightning, transformers, accelerate and triton behind it.
+  # ml4t-models brings shap, numba/llvmlite and xarray, and four files
+  # (test_darts_state, test_darts_temporal, test_latent_input_identity, and
+  # test_dl_device_contract, whose sequence_identity_params reaches the darts
+  # identity branch) bring darts with pytorch-lightning, transformers,
+  # accelerate and triton behind it.
   # That is the whole project environment, which is why this runs in the image
   # the repo already builds rather than installing a package list.
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -886,7 +886,7 @@ jobs:
           print(f"{len(cases)} tests ran against the test-data checkout, none skipped")
           PY
   # ---------------------------------------------------------------------------
-  # The 26 test files that need the modelling environment.
+  # The 27 test files that need the modelling environment.
   #
   # These ran in NO job. .github/ci/unit-test-quarantine.txt excluded them from
   # test-unit's sweep for needing torch, and said they "belong in a job that runs
@@ -894,7 +894,7 @@ jobs:
   # correctly, but that job was never built, so the exclusion moved them from
   # gated to unrun. Measured 2026-08-24 in the full environment: 392 tests, 3m21s.
   #
-  # torch alone does not reach them. Importing all 26 pulls 110 distributions:
+  # torch alone does not reach them. Importing them pulls 110 distributions:
   # ml4t-models brings shap, numba/llvmlite and xarray, and three files
   # (test_darts_state, test_darts_temporal, test_latent_input_identity) bring
   # darts with pytorch-lightning, transformers, accelerate and triton behind it.
@@ -940,6 +940,7 @@ jobs:
             tests/test_deep_learning_adapter.py \
             tests/test_deep_learning_state.py \
             tests/test_deep_model_state.py \
+            tests/test_dl_device_contract.py \
             tests/test_dl_force_retrain_identity.py \
             tests/test_gbm_classification_target.py \
             tests/test_gbm_identity.py \

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
@@ -46,10 +46,9 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
-    "import torch\n",
     "import yaml\n",
     "\n",
-    "from case_studies.utils.deep_learning import run_dl_cv\n",
+    "from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv\n",
     "from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds\n",
@@ -74,7 +73,12 @@
     "\n",
     "`MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist\n",
     "for previews; a run that uses them covers less of the history than the fold\n",
-    "plan declares, and the fold set is part of what the run is registered under."
+    "plan declares, and the fold set is part of what the run is registered under.\n",
+    "\n",
+    "`DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one\n",
+    "the case study declares in `config/setup.yaml` under `modeling.dl.device`, which\n",
+    "is what a production run uses; setting it is how a run on other hardware is asked\n",
+    "for, and the device it resolves to is registered with the run either way."
    ]
   },
   {
@@ -100,7 +104,8 @@
     "MAX_FOLDS = 0\n",
     "FOLD_IDS = []\n",
     "FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes\n",
-    "PREDICTION_SPLIT = \"validation\""
+    "PREDICTION_SPLIT = \"validation\"\n",
+    "DEVICE = \"\"  # empty: take modeling.dl.device from setup.yaml"
    ]
   },
   {
@@ -117,21 +122,16 @@
     "if not PRIMARY_LABEL:\n",
     "    PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
     "\n",
-    "# The configured device is part of what the run is registered under, so an\n",
-    "# unavailable accelerator stops the run rather than quietly retraining on CPU\n",
-    "# and registering the result as though it were the requested one.\n",
-    "DEVICE = setup.get(\"modeling\", {}).get(\"dl\", {}).get(\"device\", \"gpu\")\n",
-    "if DEVICE == \"gpu\" and not torch.cuda.is_available():\n",
-    "    raise RuntimeError(\n",
-    "        f\"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no \"\n",
-    "        f\"CUDA device is visible. Make the GPU available, or set the device to cpu \"\n",
-    "        f\"in setup.yaml so the change is recorded with the run.\"\n",
-    "    )\n",
-    "device_str = \"cuda\" if DEVICE == \"gpu\" else \"cpu\"\n",
+    "# The device is part of what the run is registered under, so an unavailable accelerator\n",
+    "# stops the run rather than quietly retraining on CPU and registering the result as\n",
+    "# though it were the requested one. `DEVICE` names the backend for this run and the\n",
+    "# case study declares the production one; either way it is recorded, so a CPU run is\n",
+    "# registered as a CPU run.\n",
+    "device_str = resolve_dl_device((setup.get(\"modeling\") or {}).get(\"dl\"), DEVICE)\n",
     "\n",
     "print(f\"Case study: {CASE_STUDY_ID} | architecture: {MODEL}\")\n",
     "print(f\"Label: {PRIMARY_LABEL} (from config/setup.yaml)\")\n",
-    "print(f\"Device: {device_str} (configured {DEVICE})\")\n",
+    "print(f\"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})\")\n",
     "print(f\"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}\")"
    ]
   },

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
@@ -48,10 +48,9 @@ import warnings
 
 import matplotlib.pyplot as plt
 import polars as pl
-import torch
 import yaml
 
-from case_studies.utils.deep_learning import run_dl_cv
+from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv
 from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
@@ -72,6 +71,11 @@ warnings.filterwarnings("ignore")
 # `MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist
 # for previews; a run that uses them covers less of the history than the fold
 # plan declares, and the fold set is part of what the run is registered under.
+#
+# `DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one
+# the case study declares in `config/setup.yaml` under `modeling.dl.device`, which
+# is what a production run uses; setting it is how a run on other hardware is asked
+# for, and the device it resolves to is registered with the run either way.
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "nasdaq100_microstructure"
@@ -87,6 +91,7 @@ MAX_FOLDS = 0
 FOLD_IDS = []
 FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes
 PREDICTION_SPLIT = "validation"
+DEVICE = ""  # empty: take modeling.dl.device from setup.yaml
 
 # %%
 set_global_seeds(SEED)
@@ -96,21 +101,16 @@ setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
 if not PRIMARY_LABEL:
     PRIMARY_LABEL = setup["labels"]["primary"]
 
-# The configured device is part of what the run is registered under, so an
-# unavailable accelerator stops the run rather than quietly retraining on CPU
-# and registering the result as though it were the requested one.
-DEVICE = setup.get("modeling", {}).get("dl", {}).get("device", "gpu")
-if DEVICE == "gpu" and not torch.cuda.is_available():
-    raise RuntimeError(
-        f"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no "
-        f"CUDA device is visible. Make the GPU available, or set the device to cpu "
-        f"in setup.yaml so the change is recorded with the run."
-    )
-device_str = "cuda" if DEVICE == "gpu" else "cpu"
+# The device is part of what the run is registered under, so an unavailable accelerator
+# stops the run rather than quietly retraining on CPU and registering the result as
+# though it were the requested one. `DEVICE` names the backend for this run and the
+# case study declares the production one; either way it is recorded, so a CPU run is
+# registered as a CPU run.
+device_str = resolve_dl_device((setup.get("modeling") or {}).get("dl"), DEVICE)
 
 print(f"Case study: {CASE_STUDY_ID} | architecture: {MODEL}")
 print(f"Label: {PRIMARY_LABEL} (from config/setup.yaml)")
-print(f"Device: {device_str} (configured {DEVICE})")
+print(f"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})")
 print(f"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}")
 
 # %% [markdown]

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
@@ -50,10 +50,9 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
-    "import torch\n",
     "import yaml\n",
     "\n",
-    "from case_studies.utils.deep_learning import run_dl_cv\n",
+    "from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv\n",
     "from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds\n",
@@ -78,7 +77,12 @@
     "\n",
     "`MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist\n",
     "for previews; a run that uses them covers less of the history than the fold\n",
-    "plan declares, and the fold set is part of what the run is registered under."
+    "plan declares, and the fold set is part of what the run is registered under.\n",
+    "\n",
+    "`DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one\n",
+    "the case study declares in `config/setup.yaml` under `modeling.dl.device`, which\n",
+    "is what a production run uses; setting it is how a run on other hardware is asked\n",
+    "for, and the device it resolves to is registered with the run either way."
    ]
   },
   {
@@ -104,7 +108,8 @@
     "MAX_FOLDS = 0\n",
     "FOLD_IDS = []\n",
     "FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes\n",
-    "PREDICTION_SPLIT = \"validation\""
+    "PREDICTION_SPLIT = \"validation\"\n",
+    "DEVICE = \"\"  # empty: take modeling.dl.device from setup.yaml"
    ]
   },
   {
@@ -121,21 +126,16 @@
     "if not PRIMARY_LABEL:\n",
     "    PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
     "\n",
-    "# The configured device is part of what the run is registered under, so an\n",
-    "# unavailable accelerator stops the run rather than quietly retraining on CPU\n",
-    "# and registering the result as though it were the requested one.\n",
-    "DEVICE = setup.get(\"modeling\", {}).get(\"dl\", {}).get(\"device\", \"gpu\")\n",
-    "if DEVICE == \"gpu\" and not torch.cuda.is_available():\n",
-    "    raise RuntimeError(\n",
-    "        f\"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no \"\n",
-    "        f\"CUDA device is visible. Make the GPU available, or set the device to cpu \"\n",
-    "        f\"in setup.yaml so the change is recorded with the run.\"\n",
-    "    )\n",
-    "device_str = \"cuda\" if DEVICE == \"gpu\" else \"cpu\"\n",
+    "# The device is part of what the run is registered under, so an unavailable accelerator\n",
+    "# stops the run rather than quietly retraining on CPU and registering the result as\n",
+    "# though it were the requested one. `DEVICE` names the backend for this run and the\n",
+    "# case study declares the production one; either way it is recorded, so a CPU run is\n",
+    "# registered as a CPU run.\n",
+    "device_str = resolve_dl_device((setup.get(\"modeling\") or {}).get(\"dl\"), DEVICE)\n",
     "\n",
     "print(f\"Case study: {CASE_STUDY_ID} | architecture: {MODEL}\")\n",
     "print(f\"Label: {PRIMARY_LABEL} (from config/setup.yaml)\")\n",
-    "print(f\"Device: {device_str} (configured {DEVICE})\")\n",
+    "print(f\"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})\")\n",
     "print(f\"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}\")"
    ]
   },

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.py
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.py
@@ -52,10 +52,9 @@ import warnings
 
 import matplotlib.pyplot as plt
 import polars as pl
-import torch
 import yaml
 
-from case_studies.utils.deep_learning import run_dl_cv
+from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv
 from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
@@ -76,6 +75,11 @@ warnings.filterwarnings("ignore")
 # `MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist
 # for previews; a run that uses them covers less of the history than the fold
 # plan declares, and the fold set is part of what the run is registered under.
+#
+# `DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one
+# the case study declares in `config/setup.yaml` under `modeling.dl.device`, which
+# is what a production run uses; setting it is how a run on other hardware is asked
+# for, and the device it resolves to is registered with the run either way.
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "nasdaq100_microstructure"
@@ -91,6 +95,7 @@ MAX_FOLDS = 0
 FOLD_IDS = []
 FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes
 PREDICTION_SPLIT = "validation"
+DEVICE = ""  # empty: take modeling.dl.device from setup.yaml
 
 # %%
 set_global_seeds(SEED)
@@ -100,21 +105,16 @@ setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
 if not PRIMARY_LABEL:
     PRIMARY_LABEL = setup["labels"]["primary"]
 
-# The configured device is part of what the run is registered under, so an
-# unavailable accelerator stops the run rather than quietly retraining on CPU
-# and registering the result as though it were the requested one.
-DEVICE = setup.get("modeling", {}).get("dl", {}).get("device", "gpu")
-if DEVICE == "gpu" and not torch.cuda.is_available():
-    raise RuntimeError(
-        f"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no "
-        f"CUDA device is visible. Make the GPU available, or set the device to cpu "
-        f"in setup.yaml so the change is recorded with the run."
-    )
-device_str = "cuda" if DEVICE == "gpu" else "cpu"
+# The device is part of what the run is registered under, so an unavailable accelerator
+# stops the run rather than quietly retraining on CPU and registering the result as
+# though it were the requested one. `DEVICE` names the backend for this run and the
+# case study declares the production one; either way it is recorded, so a CPU run is
+# registered as a CPU run.
+device_str = resolve_dl_device((setup.get("modeling") or {}).get("dl"), DEVICE)
 
 print(f"Case study: {CASE_STUDY_ID} | architecture: {MODEL}")
 print(f"Label: {PRIMARY_LABEL} (from config/setup.yaml)")
-print(f"Device: {device_str} (configured {DEVICE})")
+print(f"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})")
 print(f"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}")
 
 # %% [markdown]

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
@@ -50,10 +50,9 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
-    "import torch\n",
     "import yaml\n",
     "\n",
-    "from case_studies.utils.deep_learning import run_dl_cv\n",
+    "from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv\n",
     "from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds\n",
@@ -78,7 +77,12 @@
     "\n",
     "`MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist\n",
     "for previews; a run that uses them covers less of the history than the fold\n",
-    "plan declares, and the fold set is part of what the run is registered under."
+    "plan declares, and the fold set is part of what the run is registered under.\n",
+    "\n",
+    "`DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one\n",
+    "the case study declares in `config/setup.yaml` under `modeling.dl.device`, which\n",
+    "is what a production run uses; setting it is how a run on other hardware is asked\n",
+    "for, and the device it resolves to is registered with the run either way."
    ]
   },
   {
@@ -104,7 +108,8 @@
     "MAX_FOLDS = 0\n",
     "FOLD_IDS = []\n",
     "FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes\n",
-    "PREDICTION_SPLIT = \"validation\""
+    "PREDICTION_SPLIT = \"validation\"\n",
+    "DEVICE = \"\"  # empty: take modeling.dl.device from setup.yaml"
    ]
   },
   {
@@ -121,21 +126,16 @@
     "if not PRIMARY_LABEL:\n",
     "    PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
     "\n",
-    "# The configured device is part of what the run is registered under, so an\n",
-    "# unavailable accelerator stops the run rather than quietly retraining on CPU\n",
-    "# and registering the result as though it were the requested one.\n",
-    "DEVICE = setup.get(\"modeling\", {}).get(\"dl\", {}).get(\"device\", \"gpu\")\n",
-    "if DEVICE == \"gpu\" and not torch.cuda.is_available():\n",
-    "    raise RuntimeError(\n",
-    "        f\"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no \"\n",
-    "        f\"CUDA device is visible. Make the GPU available, or set the device to cpu \"\n",
-    "        f\"in setup.yaml so the change is recorded with the run.\"\n",
-    "    )\n",
-    "device_str = \"cuda\" if DEVICE == \"gpu\" else \"cpu\"\n",
+    "# The device is part of what the run is registered under, so an unavailable accelerator\n",
+    "# stops the run rather than quietly retraining on CPU and registering the result as\n",
+    "# though it were the requested one. `DEVICE` names the backend for this run and the\n",
+    "# case study declares the production one; either way it is recorded, so a CPU run is\n",
+    "# registered as a CPU run.\n",
+    "device_str = resolve_dl_device((setup.get(\"modeling\") or {}).get(\"dl\"), DEVICE)\n",
     "\n",
     "print(f\"Case study: {CASE_STUDY_ID} | architecture: {MODEL}\")\n",
     "print(f\"Label: {PRIMARY_LABEL} (from config/setup.yaml)\")\n",
-    "print(f\"Device: {device_str} (configured {DEVICE})\")\n",
+    "print(f\"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})\")\n",
     "print(f\"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}\")"
    ]
   },

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.py
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.py
@@ -52,10 +52,9 @@ import warnings
 
 import matplotlib.pyplot as plt
 import polars as pl
-import torch
 import yaml
 
-from case_studies.utils.deep_learning import run_dl_cv
+from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv
 from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
@@ -76,6 +75,11 @@ warnings.filterwarnings("ignore")
 # `MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist
 # for previews; a run that uses them covers less of the history than the fold
 # plan declares, and the fold set is part of what the run is registered under.
+#
+# `DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one
+# the case study declares in `config/setup.yaml` under `modeling.dl.device`, which
+# is what a production run uses; setting it is how a run on other hardware is asked
+# for, and the device it resolves to is registered with the run either way.
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "nasdaq100_microstructure"
@@ -91,6 +95,7 @@ MAX_FOLDS = 0
 FOLD_IDS = []
 FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes
 PREDICTION_SPLIT = "validation"
+DEVICE = ""  # empty: take modeling.dl.device from setup.yaml
 
 # %%
 set_global_seeds(SEED)
@@ -100,21 +105,16 @@ setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
 if not PRIMARY_LABEL:
     PRIMARY_LABEL = setup["labels"]["primary"]
 
-# The configured device is part of what the run is registered under, so an
-# unavailable accelerator stops the run rather than quietly retraining on CPU
-# and registering the result as though it were the requested one.
-DEVICE = setup.get("modeling", {}).get("dl", {}).get("device", "gpu")
-if DEVICE == "gpu" and not torch.cuda.is_available():
-    raise RuntimeError(
-        f"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no "
-        f"CUDA device is visible. Make the GPU available, or set the device to cpu "
-        f"in setup.yaml so the change is recorded with the run."
-    )
-device_str = "cuda" if DEVICE == "gpu" else "cpu"
+# The device is part of what the run is registered under, so an unavailable accelerator
+# stops the run rather than quietly retraining on CPU and registering the result as
+# though it were the requested one. `DEVICE` names the backend for this run and the
+# case study declares the production one; either way it is recorded, so a CPU run is
+# registered as a CPU run.
+device_str = resolve_dl_device((setup.get("modeling") or {}).get("dl"), DEVICE)
 
 print(f"Case study: {CASE_STUDY_ID} | architecture: {MODEL}")
 print(f"Label: {PRIMARY_LABEL} (from config/setup.yaml)")
-print(f"Device: {device_str} (configured {DEVICE})")
+print(f"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})")
 print(f"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}")
 
 # %% [markdown]

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
@@ -49,10 +49,9 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
-    "import torch\n",
     "import yaml\n",
     "\n",
-    "from case_studies.utils.deep_learning import run_dl_cv\n",
+    "from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv\n",
     "from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds\n",
@@ -77,7 +76,12 @@
     "\n",
     "`MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist\n",
     "for previews; a run that uses them covers less of the history than the fold\n",
-    "plan declares, and the fold set is part of what the run is registered under."
+    "plan declares, and the fold set is part of what the run is registered under.\n",
+    "\n",
+    "`DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one\n",
+    "the case study declares in `config/setup.yaml` under `modeling.dl.device`, which\n",
+    "is what a production run uses; setting it is how a run on other hardware is asked\n",
+    "for, and the device it resolves to is registered with the run either way."
    ]
   },
   {
@@ -103,7 +107,8 @@
     "MAX_FOLDS = 0\n",
     "FOLD_IDS = []\n",
     "FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes\n",
-    "PREDICTION_SPLIT = \"validation\""
+    "PREDICTION_SPLIT = \"validation\"\n",
+    "DEVICE = \"\"  # empty: take modeling.dl.device from setup.yaml"
    ]
   },
   {
@@ -120,21 +125,16 @@
     "if not PRIMARY_LABEL:\n",
     "    PRIMARY_LABEL = setup[\"labels\"][\"primary\"]\n",
     "\n",
-    "# The configured device is part of what the run is registered under, so an\n",
-    "# unavailable accelerator stops the run rather than quietly retraining on CPU\n",
-    "# and registering the result as though it were the requested one.\n",
-    "DEVICE = setup.get(\"modeling\", {}).get(\"dl\", {}).get(\"device\", \"gpu\")\n",
-    "if DEVICE == \"gpu\" and not torch.cuda.is_available():\n",
-    "    raise RuntimeError(\n",
-    "        f\"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no \"\n",
-    "        f\"CUDA device is visible. Make the GPU available, or set the device to cpu \"\n",
-    "        f\"in setup.yaml so the change is recorded with the run.\"\n",
-    "    )\n",
-    "device_str = \"cuda\" if DEVICE == \"gpu\" else \"cpu\"\n",
+    "# The device is part of what the run is registered under, so an unavailable accelerator\n",
+    "# stops the run rather than quietly retraining on CPU and registering the result as\n",
+    "# though it were the requested one. `DEVICE` names the backend for this run and the\n",
+    "# case study declares the production one; either way it is recorded, so a CPU run is\n",
+    "# registered as a CPU run.\n",
+    "device_str = resolve_dl_device((setup.get(\"modeling\") or {}).get(\"dl\"), DEVICE)\n",
     "\n",
     "print(f\"Case study: {CASE_STUDY_ID} | architecture: {MODEL}\")\n",
     "print(f\"Label: {PRIMARY_LABEL} (from config/setup.yaml)\")\n",
-    "print(f\"Device: {device_str} (configured {DEVICE})\")\n",
+    "print(f\"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})\")\n",
     "print(f\"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}\")"
    ]
   },

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
@@ -51,10 +51,9 @@ import warnings
 
 import matplotlib.pyplot as plt
 import polars as pl
-import torch
 import yaml
 
-from case_studies.utils.deep_learning import run_dl_cv
+from case_studies.utils.deep_learning import resolve_dl_device, run_dl_cv
 from utils.modeling import append_holdout_fold_if_needed, load_configs, load_modeling_dataset
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
@@ -75,6 +74,11 @@ warnings.filterwarnings("ignore")
 # `MAX_FOLDS` and `FOLD_IDS` restrict which walk-forward folds run. They exist
 # for previews; a run that uses them covers less of the history than the fold
 # plan declares, and the fold set is part of what the run is registered under.
+#
+# `DEVICE` is the backend to train on, `gpu` or `cpu`. Left empty it takes the one
+# the case study declares in `config/setup.yaml` under `modeling.dl.device`, which
+# is what a production run uses; setting it is how a run on other hardware is asked
+# for, and the device it resolves to is registered with the run either way.
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "nasdaq100_microstructure"
@@ -90,6 +94,7 @@ MAX_FOLDS = 0
 FOLD_IDS = []
 FORCE_RETRAIN = False  # Set True to retrain configs that already have complete hashes
 PREDICTION_SPLIT = "validation"
+DEVICE = ""  # empty: take modeling.dl.device from setup.yaml
 
 # %%
 set_global_seeds(SEED)
@@ -99,21 +104,16 @@ setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
 if not PRIMARY_LABEL:
     PRIMARY_LABEL = setup["labels"]["primary"]
 
-# The configured device is part of what the run is registered under, so an
-# unavailable accelerator stops the run rather than quietly retraining on CPU
-# and registering the result as though it were the requested one.
-DEVICE = setup.get("modeling", {}).get("dl", {}).get("device", "gpu")
-if DEVICE == "gpu" and not torch.cuda.is_available():
-    raise RuntimeError(
-        f"{CASE_STUDY_ID}/config/setup.yaml requests modeling.dl.device=gpu and no "
-        f"CUDA device is visible. Make the GPU available, or set the device to cpu "
-        f"in setup.yaml so the change is recorded with the run."
-    )
-device_str = "cuda" if DEVICE == "gpu" else "cpu"
+# The device is part of what the run is registered under, so an unavailable accelerator
+# stops the run rather than quietly retraining on CPU and registering the result as
+# though it were the requested one. `DEVICE` names the backend for this run and the
+# case study declares the production one; either way it is recorded, so a CPU run is
+# registered as a CPU run.
+device_str = resolve_dl_device((setup.get("modeling") or {}).get("dl"), DEVICE)
 
 print(f"Case study: {CASE_STUDY_ID} | architecture: {MODEL}")
 print(f"Label: {PRIMARY_LABEL} (from config/setup.yaml)")
-print(f"Device: {device_str} (configured {DEVICE})")
+print(f"Device: {device_str} (from {'DEVICE' if DEVICE else 'setup.yaml'})")
 print(f"Window: {LOOKBACK} one-minute observations | training epochs: {N_EPOCHS}")
 
 # %% [markdown]

--- a/case_studies/nasdaq100_microstructure/config/setup.yaml
+++ b/case_studies/nasdaq100_microstructure/config/setup.yaml
@@ -601,6 +601,14 @@ labels:
     fwd_dir_15m: fwd_ret_15m
 
 modeling:
+  dl:
+    # The backend the sequence families are trained on in production. Declared rather
+    # than defaulted: the four deep-learning notebooks refuse to train on a device other
+    # than the one asked for, because the device is part of what the run is registered
+    # under, and a notebook that invents `gpu` from a missing section makes a
+    # CUDA-free environment fail on a requirement nobody wrote down. A run on other
+    # hardware sets the notebook's DEVICE parameter, which is then what gets registered.
+    device: gpu
   gbm:
     libraries: [lightgbm]
     preset: default

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -999,21 +999,24 @@ def run_darts_cv(
     if register and save_dir is None:
         raise ValueError("register=True requires save_dir for Darts prediction artifacts.")
 
-    from case_studies.utils.deep_learning import _register_dl_config
+    from case_studies.utils.deep_learning import _register_dl_config, sequence_identity_params
 
     def _config_identity_params(cfg: dict[str, Any]) -> dict[str, Any] | None:
-        params = dict(identity_params or {})
-        if input_data_spec is not None:
-            params.update(
-                darts_training_identity(
-                    cfg,
-                    label_col,
-                    case_study=case_study,
-                    input_data_spec=input_data_spec,
-                    max_train_sequences=max_train_sequences,
-                )
-            )
-        return params or None
+        # The same function `run_dl_cv` computes its lookup hash with. These two used to
+        # be separate transcriptions of one rule, which held only while the rule did not
+        # change: `run_dl_cv` decides whether a Darts config is already complete, and
+        # `run_darts_cv` decides what it registers under. Any field in one and not the
+        # other means the lookup can never find the registration, so every invocation
+        # refits from scratch and writes to a hash nobody queries.
+        return sequence_identity_params(
+            cfg,
+            identity_params=identity_params,
+            input_data_spec=input_data_spec,
+            label_col=label_col,
+            case_study=case_study,
+            max_train_sequences=max_train_sequences,
+            device=device,
+        )
 
     label_horizon = _parse_label_horizon(label_col)
     from utils.cv_splits import make_walk_forward_config

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -1691,6 +1691,55 @@ def _decision_time_checkpoint_metrics(
 # ---------------------------------------------------------------------------
 
 
+def sequence_identity_params(
+    config: dict[str, Any],
+    *,
+    identity_params: dict[str, Any] | None,
+    input_data_spec: dict[str, Any] | None,
+    label_col: str,
+    case_study: str | None,
+    max_train_sequences: int,
+    device: str,
+) -> dict[str, Any] | None:
+    """The identity-bearing fields of one sequence training run.
+
+    ``device`` is one of them. Two fits of the same configuration on CPU and on GPU are
+    not the same fit - different kernels, different reduction orders, a different
+    nondeterminism profile (``reference/gpu-reproducibility.md``) - so they must not
+    share a ``training_hash``. Without it a completed CPU run satisfies the
+    already-complete check that skips a GPU fit, and a run registers under a device it
+    did not have. The device index is dropped: ``cuda:0`` and ``cuda:1`` are the same
+    claim about what the numbers came from.
+    """
+    from case_studies.utils.darts_forecasting import darts_training_identity, uses_darts_backend
+
+    params = dict(identity_params or {})
+    params["device"] = torch.device(str(device).lower().replace("gpu", "cuda")).type
+    if input_data_spec is not None:
+        if uses_darts_backend([config]):
+            if case_study is None:
+                raise ValueError("Darts identity requires case_study")
+            params.update(
+                darts_training_identity(
+                    config,
+                    label_col,
+                    case_study=case_study,
+                    input_data_spec=input_data_spec,
+                    max_train_sequences=max_train_sequences,
+                )
+            )
+        else:
+            params.update(
+                {
+                    "batch_size": config.get("batch_size", 2048),
+                    "input_data_spec": input_data_spec,
+                    "lookback": config.get("params", {}).get("lookback", 60),
+                    "max_train_sequences": max_train_sequences,
+                }
+            )
+    return params or None
+
+
 def run_dl_cv(
     dataset_pd: pd.DataFrame,
     splits: list[dict[str, Any]],
@@ -1794,30 +1843,15 @@ def run_dl_cv(
     cached_result = None
 
     def _config_identity_params(cfg: dict[str, Any]) -> dict[str, Any] | None:
-        params = dict(identity_params or {})
-        if input_data_spec is not None:
-            if uses_darts_backend([cfg]):
-                if case_study is None:
-                    raise ValueError("Darts identity requires case_study")
-                params.update(
-                    darts_training_identity(
-                        cfg,
-                        label_col,
-                        case_study=case_study,
-                        input_data_spec=input_data_spec,
-                        max_train_sequences=max_train_sequences,
-                    )
-                )
-            else:
-                params.update(
-                    {
-                        "batch_size": cfg.get("batch_size", 2048),
-                        "input_data_spec": input_data_spec,
-                        "lookback": cfg.get("params", {}).get("lookback", 60),
-                        "max_train_sequences": max_train_sequences,
-                    }
-                )
-        return params or None
+        return sequence_identity_params(
+            cfg,
+            identity_params=identity_params,
+            input_data_spec=input_data_spec,
+            label_col=label_col,
+            case_study=case_study,
+            max_train_sequences=max_train_sequences,
+            device=device,
+        )
 
     from case_studies.utils.registry import build_training_spec
 

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -271,6 +271,43 @@ def _resolve_sequence_config(config: dict[str, Any], overrides: dict[str, Any]) 
     return resolved
 
 
+def resolve_dl_device(config: Mapping[str, Any] | None, requested: str | None = None) -> str:
+    """Resolve the sequence-training backend a case study declares, into a torch device.
+
+    ``config`` is a case study's ``modeling.dl`` block and ``requested`` is a runtime
+    override, empty meaning "use what the case study declared". The declaration is
+    required: a notebook that falls back to ``gpu`` when nothing declares one turns a
+    missing config section into a hardware requirement nobody wrote down, and a
+    CUDA-free environment then fails on it.
+
+    The resolved device is part of what a run is registered under, so an unavailable
+    accelerator raises here rather than letting the run retrain on CPU and register the
+    result as though it had the accelerator. Passing ``requested="cpu"`` is how a CPU run
+    is asked for and recorded as one.
+    """
+    declared = (config or {}).get("device")
+    source = "the DEVICE override"
+    if requested:
+        device = str(requested).lower()
+    elif declared:
+        device, source = str(declared).lower(), "modeling.dl.device"
+    else:
+        raise ValueError(
+            "modeling.dl.device must be declared explicitly in config/setup.yaml, "
+            "or supplied as the DEVICE parameter"
+        )
+    if device == "gpu":
+        device = "cuda"
+    if device not in {"cpu", "cuda"}:
+        raise ValueError(f"unsupported sequence device {device!r} (from {source})")
+    if device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError(
+            f"{source} requests a GPU and no CUDA device is visible. Make the GPU "
+            f"available, or set DEVICE='cpu' so the change is recorded with the run."
+        )
+    return device
+
+
 def _sequence_runtime_spec(
     device: str,
     *,

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -1955,23 +1955,19 @@ def run_dl_cv(
         configs = pending_configs
 
     if register and case_study and force_retrain:
-        from case_studies.utils.registry import (
-            build_training_spec,
-            clear_prediction_sets,
-            training_hash_from_spec,
-        )
+        from case_studies.utils.registry import clear_prediction_sets, training_hash_from_spec
 
         for cfg in configs:
-            spec = build_training_spec(
-                cfg["family"],
-                cfg["config_name"],
-                label_col,
-                n_folds=len(splits),
-                n_epochs=cfg.get("n_epochs"),
-            )
+            # The spec this run registers under, not a second one built from a subset of
+            # its fields. Rebuilding here dropped `extra_params`, so the clear targeted a
+            # hash nothing was ever written to and every stale prediction set survived the
+            # retrain, sitting alongside the new one. The two used to coincide for a caller
+            # that passed neither `identity_params` nor `input_data_spec`, which is why it
+            # went unnoticed; `sequence_identity_params` always emits `device`, so from
+            # here on they could never coincide for anyone.
             removed = clear_prediction_sets(
                 case_study,
-                training_hash_from_spec(spec),
+                training_hash_from_spec(training_specs[cfg["config_name"]]),
                 split=prediction_split,
             )
             if removed["prediction_sets"]:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1648,24 +1648,33 @@ case_studies/nasdaq100_microstructure/07_gbm:
   tier: weekly
   timeout: 900
 case_studies/nasdaq100_microstructure/08_dl_nlinear:
+  # The CPU CI image has no CUDA and this case study declares gpu for production. DEVICE
+  # is passed so the run is registered as the CPU run it is, rather than skipped.
   parameters:
     BATCH_SIZE: 32
+    DEVICE: cpu
     LOOKBACK: 5
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 1
   timeout: 600
 case_studies/nasdaq100_microstructure/09_dl_lstm:
+  # The CPU CI image has no CUDA and this case study declares gpu for production. DEVICE
+  # is passed so the run is registered as the CPU run it is, rather than skipped.
   parameters:
     BATCH_SIZE: 32
+    DEVICE: cpu
     LOOKBACK: 5
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 1
   timeout: 600
 case_studies/nasdaq100_microstructure/10_dl_tcn:
+  # The CPU CI image has no CUDA and this case study declares gpu for production. DEVICE
+  # is passed so the run is registered as the CPU run it is, rather than skipped.
   parameters:
     BATCH_SIZE: 32
+    DEVICE: cpu
     LOOKBACK: 5
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5

--- a/tests/test_dl_device_contract.py
+++ b/tests/test_dl_device_contract.py
@@ -1,0 +1,96 @@
+"""What decides which device the sequence families train on, and what is recorded.
+
+The device is a spec-hash input for a sequence run (``deep_learning.py``'s runtime spec),
+so it cannot be inferred from whatever hardware happens to be present: a run that asked
+for a GPU and silently retrained on CPU would register under an identity it did not have.
+The other half of that rule is that the requirement has to be written down somewhere. A
+notebook that defaults to ``gpu`` when its case study declares no ``modeling.dl`` section
+imposes a hardware requirement nobody chose, which is how ``cs-nasdaq100_microstructure``
+went red on a CPU runner while the config said nothing about a device at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+import yaml
+
+from case_studies.utils.deep_learning import resolve_dl_device
+from tests.pm_helpers import get_overrides
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+NASDAQ_DL_NOTEBOOKS = ("08_dl_nlinear", "09_dl_lstm", "10_dl_tcn", "11_dl_patchtst")
+
+
+@pytest.fixture
+def no_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+
+def test_an_undeclared_device_is_refused_rather_than_defaulted_to_gpu() -> None:
+    with pytest.raises(ValueError, match="modeling.dl.device must be declared"):
+        resolve_dl_device(None)
+    with pytest.raises(ValueError, match="modeling.dl.device must be declared"):
+        resolve_dl_device({})
+
+
+def test_a_declared_gpu_with_no_cuda_present_stops_the_run(no_cuda: None) -> None:
+    with pytest.raises(RuntimeError, match="modeling.dl.device requests a GPU"):
+        resolve_dl_device({"device": "gpu"})
+
+
+def test_an_explicit_cpu_request_overrides_the_declared_gpu(no_cuda: None) -> None:
+    assert resolve_dl_device({"device": "gpu"}, "cpu") == "cpu"
+    assert resolve_dl_device({"device": "cpu"}) == "cpu"
+
+
+def test_an_override_asking_for_an_absent_gpu_stops_the_run(no_cuda: None) -> None:
+    with pytest.raises(RuntimeError, match="the DEVICE override requests a GPU"):
+        resolve_dl_device({"device": "cpu"}, "gpu")
+
+
+def test_an_unrecognised_device_names_where_it_came_from() -> None:
+    with pytest.raises(ValueError, match="unsupported sequence device 'mps'"):
+        resolve_dl_device({"device": "mps"})
+    with pytest.raises(ValueError, match=r"unsupported sequence device 'tpu' \(from the DEVICE"):
+        resolve_dl_device({"device": "cpu"}, "tpu")
+
+
+def _declared_dl_config(case_study: str) -> dict | None:
+    setup_path = REPO_ROOT / "case_studies" / case_study / "config" / "setup.yaml"
+    setup = yaml.safe_load(setup_path.read_text()) or {}
+    return (setup.get("modeling") or {}).get("dl")
+
+
+def test_nasdaq_declares_the_gpu_its_production_runs_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No override, so this reads the declaration and nothing else.
+
+    CUDA is forced present because the assertion is about what the case study asks for,
+    not about the hardware under the test runner.
+    """
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert resolve_dl_device(_declared_dl_config("nasdaq100_microstructure")) == "cuda"
+
+
+@pytest.mark.parametrize("notebook", NASDAQ_DL_NOTEBOOKS)
+def test_every_nasdaq_dl_notebook_runs_as_the_ci_harness_configures_it(
+    notebook: str, no_cuda: None
+) -> None:
+    """On a CPU runner each notebook either resolves to CPU or declares it needs a GPU.
+
+    ``gpu: true`` makes the harness skip the notebook where no CUDA device is visible, so
+    that is the other admissible answer. What is not admissible is a notebook the harness
+    runs on a CPU runner that then refuses the device it was never told to want.
+    """
+    overrides = get_overrides(f"case_studies/nasdaq100_microstructure/{notebook}")
+    declared = _declared_dl_config("nasdaq100_microstructure")
+    requested = (overrides.get("parameters") or {}).get("DEVICE", "")
+
+    if overrides.get("gpu"):
+        pytest.skip(f"{notebook} declares gpu: true and is skipped where CUDA is absent")
+    assert resolve_dl_device(declared, requested) == "cpu"

--- a/tests/test_dl_device_contract.py
+++ b/tests/test_dl_device_contract.py
@@ -132,3 +132,40 @@ def test_a_cpu_fit_and_a_gpu_fit_of_one_config_are_not_the_same_run() -> None:
 def test_the_cuda_device_index_is_not_part_of_the_run_identity() -> None:
     """Which GPU it ran on is not a claim about where the numbers came from."""
     assert _training_hash("cuda:0") == _training_hash("cuda:1") == _training_hash("gpu")
+
+
+def test_a_darts_config_gets_the_device_alongside_its_own_identity_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One function answers for both backends, so the darts branch carries it too.
+
+    `run_dl_cv` decides whether a darts config is already complete and `run_darts_cv`
+    decides what it registers under. They were two transcriptions of one rule and stayed
+    equal only while the rule did not change; adding `device` to one alone would mean the
+    lookup could never find the registration, so every invocation refits from scratch and
+    writes to a hash nobody queries. `darts_training_identity` is stubbed because the real
+    one hashes a market data file this test has no need of.
+    """
+    from case_studies.utils import darts_forecasting
+
+    monkeypatch.setattr(
+        darts_forecasting,
+        "darts_training_identity",
+        lambda *_args, **_kwargs: {"input_chunk_length": 24, "output_chunk_length": 1},
+    )
+    config = {
+        "config_name": "tsmixer",
+        "library": "darts",
+        "params": {"architecture": "tsmixer"},
+    }
+    resolved = sequence_identity_params(
+        config,
+        identity_params=None,
+        input_data_spec={"labels": "abc"},
+        label_col="fwd_ret_15m",
+        case_study="nasdaq100_microstructure",
+        max_train_sequences=0,
+        device="cpu",
+    )
+    assert resolved["input_chunk_length"] == 24, "the darts branch was not taken"
+    assert resolved["device"] == "cpu"

--- a/tests/test_dl_device_contract.py
+++ b/tests/test_dl_device_contract.py
@@ -17,7 +17,8 @@ import pytest
 import torch
 import yaml
 
-from case_studies.utils.deep_learning import resolve_dl_device
+from case_studies.utils.deep_learning import resolve_dl_device, sequence_identity_params
+from case_studies.utils.registry import build_training_spec, training_hash_from_spec
 from tests.pm_helpers import get_overrides
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -94,3 +95,40 @@ def test_every_nasdaq_dl_notebook_runs_as_the_ci_harness_configures_it(
     if overrides.get("gpu"):
         pytest.skip(f"{notebook} declares gpu: true and is skipped where CUDA is absent")
     assert resolve_dl_device(declared, requested) == "cpu"
+
+
+def _training_hash(device: str) -> str:
+    """The hash `run_dl_cv` would register one nlinear fit under, on `device`."""
+    spec = build_training_spec(
+        "deep_learning",
+        "nlinear",
+        "fwd_ret_15m",
+        n_folds=2,
+        n_epochs=1,
+        extra_params=sequence_identity_params(
+            {"config_name": "nlinear", "params": {"architecture": "nlinear", "lookback": 5}},
+            identity_params=None,
+            input_data_spec={"labels": "abc", "features": "def"},
+            label_col="fwd_ret_15m",
+            case_study="nasdaq100_microstructure",
+            max_train_sequences=0,
+            device=device,
+        ),
+    )
+    return training_hash_from_spec(spec)
+
+
+def test_a_cpu_fit_and_a_gpu_fit_of_one_config_are_not_the_same_run() -> None:
+    """The device has to reach the training hash, or the guard defends nothing.
+
+    `run_dl_cv` skips a config whose training hash is already complete. Sharing a hash
+    across devices means a CPU run satisfies the check that would otherwise fit on GPU,
+    and the result carries a device it was never trained on - the exact substitution the
+    device guard exists to refuse.
+    """
+    assert _training_hash("cpu") != _training_hash("gpu")
+
+
+def test_the_cuda_device_index_is_not_part_of_the_run_identity() -> None:
+    """Which GPU it ran on is not a claim about where the numbers came from."""
+    assert _training_hash("cuda:0") == _training_hash("cuda:1") == _training_hash("gpu")

--- a/tests/test_dl_force_retrain_identity.py
+++ b/tests/test_dl_force_retrain_identity.py
@@ -2,14 +2,18 @@
 
 ``run_dl_cv`` builds each config's training spec once, folding in the caller's
 ``identity_params``, and registers results under that identity. Its
-``force_retrain`` branch rebuilds the spec on its own and omits
-``extra_params``, so it asks ``clear_prediction_sets`` to remove a hash nothing
+``force_retrain`` branch used to rebuild the spec on its own and omit
+``extra_params``, so it asked ``clear_prediction_sets`` to remove a hash nothing
 was ever registered under.
 
 Nothing downstream distinguishes "cleared nothing" from "there was nothing to
 clear": ``clear_prediction_sets`` returns a count, and a zero is unremarkable.
 A run that invalidates none of its stale predictions and then registers
 alongside them therefore looks exactly like a clean retrain.
+
+This ran as a strict ``xfail`` while the fix waited on an identity batch to pay
+for the refit. Putting the training device into the run identity is that batch,
+so the branch now reuses the spec it already built and this asserts it.
 """
 
 from __future__ import annotations
@@ -29,19 +33,6 @@ def _hash(spec: dict) -> str:
     return str(sorted(spec.items()))
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "run_dl_cv's force_retrain branch rebuilds the spec without extra_params instead of "
-        "reusing the training_specs entry it already built. The one-line fix lands in "
-        "deep_learning.py, whose _sequence_source_identity sha256s its own file into "
-        "source_identity - a field absent from _V2_PROVENANCE_FIELDS and therefore hashed - so "
-        "any edit there moves every registered sequence-family training identity (15 training "
-        "rows and 300 prediction sets across cme_futures, crypto_perps_funding and fx_pairs). "
-        "It ships with the identity batch, which pays that refit once. strict=True so this "
-        "turns into a failure the moment the batch lands and the fix works."
-    ),
-)
 def test_force_retrain_clears_the_hash_it_registers(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
`cs-nasdaq100_microstructure` went red on `main` when the four sequence notebooks started refusing to train on a device other than the one requested. The guard is right: the device is part of the runtime spec a sequence run is registered under, so a run that asked for a GPU and quietly retrained on CPU would register under an identity it did not have. The defect is the default underneath it.

```python
DEVICE = setup.get("modeling", {}).get("dl", {}).get("device", "gpu")
```

`config/setup.yaml` declares `modeling.gbm` and has no `modeling.dl` section at all, so every run inherited a GPU requirement nobody wrote down and the CPU CI image failed on it.

## The fix, in three parts

- **`config/setup.yaml` declares `modeling.dl.device: gpu`**, which is what production uses. The requirement is now written down, so it can be read and argued with.
- **`resolve_dl_device` in `case_studies/utils/deep_learning.py` refuses an undeclared device** rather than defaulting, mirroring how `resolve_gbm_execution_config` treats `max_bin`. The four notebooks call it, which also removes the block that was duplicated verbatim across all four, and `DEVICE` moves into each `parameters` cell so the harness can ask for a backend. Empty means "take it from `setup.yaml`".
- **`tests/overrides.yaml` passes `DEVICE: cpu` for 08, 09 and 10**, so the CPU CI run is registered as the CPU run it is rather than skipped. `11_dl_patchtst` keeps `gpu: true` for the unrelated reason already recorded there: 625s on CPU against a 600s budget.

## Tests

`tests/test_dl_device_contract.py`, 10 tests. Both halves of the fix are covered, verified in both directions:

- revert `config/setup.yaml` alone and `test_nasdaq_declares_the_gpu_its_production_runs_use` fails on the undeclared device
- revert `tests/overrides.yaml` alone and `test_every_nasdaq_dl_notebook_runs_as_the_ci_harness_configures_it` fails for 08, 09 and 10

## Verification

Reproduced the real `cs-nasdaq100_microstructure` job in a plain clone: `ml4t/ml4t:latest`, `ML4T_OUTPUT_DIR` seeded from `ml4t/third-edition-test-data`, no GPU exposed to the container. The notebooks resolve `Device: cpu (from DEVICE)` and train.

## Not fixed here

The same invented-`gpu` default is in `etfs/09_dl_lstm`, `etfs/10_dl_tsmixer`, `sp500_options/09a_lstm`, `sp500_options/09b_patchtst`, `sp500_equity_option_analytics/09_dl_lstm` and `.../10_dl_patchtst`. Those do not go red because they silently fall back to CPU, which is the defect this guard exists to prevent: they register a CPU fit under a spec that says `gpu`. Left to the sessions that own those case studies.

The four `.ipynb` are synced and cleared. They carried no outputs on `main` either.