### PR TITLE
A superseded prediction generation stays "current", so a backtest sweeps both

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -42,7 +42,12 @@ from .model_planning import (
     require_declared_menu_coverage,
 )
 from .models import ModelRequest, ModelRun, ResolvedModelRequest
-from .population import OfficialPopulation, research_name
+from .population import (
+    OfficialPopulation,
+    population_supersedes,
+    research_name,
+    superseded_members,
+)
 from .results import BacktestResult, PredictionResult, Result, TrainingResult
 from .strategy import Strategy, strategy_warmup_periods
 from .workspace import Study, open_study
@@ -101,11 +106,13 @@ __all__ = [
     "expected_prediction_hashes",
     "planned_model_plan",
     "primary_label",
+    "population_supersedes",
     "research_name",
     "resolved_model_plan",
     "run_backtests",
     "run_locked_holdout",
     "run_model_population",
+    "superseded_members",
     "run_models",
     "run_official_model_subset",
     "run_official_models",

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from case_studies.utils.registry.specs import canonical_json, compute_hash
@@ -285,6 +286,49 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
     return declared if declared in (current.supersedes, current.hash) else None
 
 
+def _lineage(
+    case_dir: Path, member_kind: str
+) -> tuple[list[tuple[str, str, str | None]], dict[str, set[str]]]:
+    """One registry's population lineage: its generations, and what each one lists.
+
+    Opened with the timeouts ``_open_registry`` applies, because concurrent writers are the
+    expected case for a registry and a momentary lock would otherwise raise instantly - and the
+    caller turns any failure here into "nothing is retired", which is the silent wrong answer
+    this whole module exists to prevent. Opening through ``_open_registry`` itself would create
+    the database and its schema as a side effect, which is wrong for a read against a release
+    root that may legitimately not exist.
+
+    A missing file or a missing table means no generation was ever written and is answered with
+    nothing, which is the ordinary state of a reader's clean clone. Every other
+    ``OperationalError`` propagates: a lock timeout, an I/O error and a half-migrated schema are
+    not evidence that nothing has been retired.
+    """
+    db_path = case_dir / "run_log" / "registry.db"
+    if not db_path.exists():
+        return [], {}
+    db = sqlite3.connect(str(db_path), timeout=120.0)
+    try:
+        db.execute("PRAGMA busy_timeout = 60000")
+        try:
+            rows = db.execute(
+                "SELECT population_hash, name, supersedes_hash FROM official_populations "
+                "WHERE member_kind = ?",
+                (member_kind,),
+            ).fetchall()
+        except sqlite3.OperationalError as error:
+            if "no such table" not in str(error):
+                raise
+            return [], {}
+        members: dict[str, set[str]] = {}
+        for population_hash, member_hash in db.execute(
+            "SELECT population_hash, member_hash FROM official_population_members"
+        ):
+            members.setdefault(population_hash, set()).add(member_hash)
+    finally:
+        db.close()
+    return rows, members
+
+
 def superseded_members(study: Study, *, member_kind: str = "prediction") -> frozenset[str]:
     """Identities whose own publisher has moved past them.
 
@@ -320,24 +364,31 @@ def superseded_members(study: Study, *, member_kind: str = "prediction") -> froz
     all 72 - so the global form returned nothing retired and the sweep would have run over both
     generations exactly as if the check were absent. A stale snapshot under an unrelated name
     cannot un-retire another name's superseded generation.
+
+    Both registries are read, in the order :class:`PredictionCatalog` overlays them. A workspace
+    study offers released rows the workspace registry does not hold, and their lineage lives in
+    the released registry - which ``Study.open`` never copies. Reading only ``study.root`` there
+    returns nothing retired, because the workspace's ``official_populations`` table is created
+    schema-complete and empty, and the filter is a no-op again by a different route. A population
+    hash is content-addressed, so the same generation seen in both is the same generation and the
+    merge is a union rather than a precedence rule.
     """
-    try:
-        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
-            rows = db.execute(
-                "SELECT population_hash, name, supersedes_hash FROM official_populations "
-                "WHERE member_kind = ?",
-                (member_kind,),
-            ).fetchall()
-            if not any(row[2] is not None for row in rows):
-                return frozenset()
-            members: dict[str, set[str]] = {}
-            for population_hash, member_hash in db.execute(
-                "SELECT population_hash, member_hash FROM official_population_members"
-            ):
-                members.setdefault(population_hash, set()).add(member_hash)
-    except sqlite3.OperationalError:
-        # A clean clone has no `official_populations` table at all, so nothing has been
-        # retired. Same reasoning as `population_supersedes`.
+    rows: list[tuple[str, str, str | None]] = []
+    members: dict[str, set[str]] = {}
+    roots = [study.release_case_root]
+    if not study.read_only and study.root != study.release_case_root:
+        roots.append(study.root)
+    seen_populations: set[str] = set()
+    for root in roots:
+        root_rows, root_members = _lineage(root, member_kind)
+        for row in root_rows:
+            if row[0] in seen_populations:
+                continue
+            seen_populations.add(row[0])
+            rows.append(row)
+        for population_hash, member_hashes in root_members.items():
+            members.setdefault(population_hash, set()).update(member_hashes)
+    if not any(row[2] is not None for row in rows):
         return frozenset()
 
     by_name: dict[str, list[tuple[str, str | None]]] = {}

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -372,39 +372,51 @@ def superseded_members(study: Study, *, member_kind: str = "prediction") -> froz
     schema-complete and empty, and the filter is a no-op again by a different route. A population
     hash is content-addressed, so the same generation seen in both is the same generation and the
     merge is a union rather than a precedence rule.
+
+    That union covers the ``supersedes`` edges too, and it has to. The two roots disagree in the
+    ordinary case rather than the exotic one: an author who copies a workspace registry into the
+    release root and then refits leaves the release root holding generation A as an unsuperseded
+    tip while the workspace holds A -> B. **A stale root is not independent evidence that A is
+    still published.** It is an older copy of the same content-addressed chain, and supersession
+    is monotone - an edge is only ever added, never retracted - so a hash superseded in either
+    root is superseded. Deciding tip-ness per root and keeping any root's tip alive instead lets
+    the lagging root veto every retirement it knows a name for, which is the state right after
+    every release, and the catalog goes on overlaying generation A's rows into that workspace.
     """
+    rows: list[tuple[str, str, str | None]] = []
+    members: dict[str, set[str]] = {}
     roots = [study.release_case_root]
     if not study.read_only and study.root != study.release_case_root:
         roots.append(study.root)
-    per_root = [_lineage(root, member_kind) for root in roots]
-
-    members: dict[str, set[str]] = {}
-    for _, root_members in per_root:
+    seen_populations: set[str] = set()
+    for root in roots:
+        root_rows, root_members = _lineage(root, member_kind)
+        for row in root_rows:
+            if row[0] in seen_populations:
+                continue
+            seen_populations.add(row[0])
+            rows.append(row)
         for population_hash, member_hashes in root_members.items():
             members.setdefault(population_hash, set()).update(member_hashes)
-    names = {name for rows, _ in per_root for _, name, _ in rows}
-    if not any(supersedes is not None for rows, _ in per_root for *_, supersedes in rows):
+    if not any(row[2] is not None for row in rows):
         return frozenset()
 
+    by_name: dict[str, list[tuple[str, str | None]]] = {}
+    for population_hash, name, supersedes in rows:
+        by_name.setdefault(name, []).append((population_hash, supersedes))
+
     retired: set[str] = set()
-    for name in names:
-        superseded: set[str] = set()
+    for generations in by_name.values():
+        superseded = {supersedes for _, supersedes in generations if supersedes is not None}
+        if not superseded:
+            continue
+        # The generations this name still stands behind. Normally one; a forked chain leaves
+        # more, and taking the union is the conservative reading - a member any surviving tip
+        # still lists is not retired, so a fork can only under-report.
         in_force: set[str] = set()
-        # Whether a generation is a tip is decided **within the registry that holds it**, then
-        # unioned. Flattening both chains first and asking afterwards gets a lagging registry
-        # wrong: a generation the workspace has refit past is superseded there and still an
-        # unsuperseded tip in the release registry, and the flattened form would retire its
-        # members on the strength of the other root's chain. Under-retiring is the safe
-        # direction - a member wrongly kept is backtested and its result is verified, a member
-        # wrongly dropped silently narrows the sweep - so a disagreement between the two roots
-        # resolves in favour of keeping.
-        for rows, _ in per_root:
-            generations = [row for row in rows if row[1] == name]
-            root_superseded = {row[2] for row in generations if row[2] is not None}
-            superseded |= root_superseded
-            for population_hash, _, _ in generations:
-                if population_hash not in root_superseded:
-                    in_force |= members.get(population_hash, set())
+        for population_hash, _ in generations:
+            if population_hash not in superseded:
+                in_force |= members.get(population_hash, set())
         for population_hash in superseded:
             retired |= members.get(population_hash, set()) - in_force
     return frozenset(retired)

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -373,40 +373,38 @@ def superseded_members(study: Study, *, member_kind: str = "prediction") -> froz
     hash is content-addressed, so the same generation seen in both is the same generation and the
     merge is a union rather than a precedence rule.
     """
-    rows: list[tuple[str, str, str | None]] = []
-    members: dict[str, set[str]] = {}
     roots = [study.release_case_root]
     if not study.read_only and study.root != study.release_case_root:
         roots.append(study.root)
-    seen_populations: set[str] = set()
-    for root in roots:
-        root_rows, root_members = _lineage(root, member_kind)
-        for row in root_rows:
-            if row[0] in seen_populations:
-                continue
-            seen_populations.add(row[0])
-            rows.append(row)
+    per_root = [_lineage(root, member_kind) for root in roots]
+
+    members: dict[str, set[str]] = {}
+    for _, root_members in per_root:
         for population_hash, member_hashes in root_members.items():
             members.setdefault(population_hash, set()).update(member_hashes)
-    if not any(row[2] is not None for row in rows):
+    names = {name for rows, _ in per_root for _, name, _ in rows}
+    if not any(supersedes is not None for rows, _ in per_root for *_, supersedes in rows):
         return frozenset()
 
-    by_name: dict[str, list[tuple[str, str | None]]] = {}
-    for population_hash, name, supersedes in rows:
-        by_name.setdefault(name, []).append((population_hash, supersedes))
-
     retired: set[str] = set()
-    for generations in by_name.values():
-        superseded = {supersedes for _, supersedes in generations if supersedes is not None}
-        if not superseded:
-            continue
-        # The generations this name still stands behind. Normally one; a forked chain leaves
-        # more, and taking the union is the conservative reading - a member any surviving tip
-        # still lists is not retired, so a fork can only under-report.
+    for name in names:
+        superseded: set[str] = set()
         in_force: set[str] = set()
-        for population_hash, _ in generations:
-            if population_hash not in superseded:
-                in_force |= members.get(population_hash, set())
+        # Whether a generation is a tip is decided **within the registry that holds it**, then
+        # unioned. Flattening both chains first and asking afterwards gets a lagging registry
+        # wrong: a generation the workspace has refit past is superseded there and still an
+        # unsuperseded tip in the release registry, and the flattened form would retire its
+        # members on the strength of the other root's chain. Under-retiring is the safe
+        # direction - a member wrongly kept is backtested and its result is verified, a member
+        # wrongly dropped silently narrows the sweep - so a disagreement between the two roots
+        # resolves in favour of keeping.
+        for rows, _ in per_root:
+            generations = [row for row in rows if row[1] == name]
+            root_superseded = {row[2] for row in generations if row[2] is not None}
+            superseded |= root_superseded
+            for population_hash, _, _ in generations:
+                if population_hash not in root_superseded:
+                    in_force |= members.get(population_hash, set())
         for population_hash in superseded:
             retired |= members.get(population_hash, set()) - in_force
     return frozenset(retired)

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -243,3 +243,119 @@ class OfficialPopulation:
                 f"official population {self.hash} is incomplete: {', '.join(failures)}"
             )
         return self.members
+
+
+def population_supersedes(study: Study, *, name: str, declared: str | None) -> str | None:
+    """Decide whether a declared population hash may be offered to :meth:`OfficialPopulation.create`.
+
+    A notebook that has published a population and then moved a training identity has to name the
+    snapshot it replaces, or ``create`` refuses the write. The hash it names is committed source,
+    so the same declaration has to be right in three situations the notebook cannot tell apart on
+    its own, and offering it unconditionally is wrong in two of them.
+
+    - **A clean clone.** ``run_log/`` is gitignored, so a reader starts with an empty registry -
+      often with no ``official_populations`` table at all, which raises ``OperationalError``
+      rather than ``ValueError``. ``create`` refuses a first version that claims to supersede
+      something, so the declared hash must be withheld and the reader's run publishes generation
+      one. This is the ordinary case for anyone who is not the author.
+    - **The re-run.** The generation in force is the one this declaration produced, which is
+      ``current.supersedes == declared``. Offering the hash recomputes the same snapshot, so the
+      notebook resolves to the population it published instead of writing a new one.
+    - **The refit.** The declaration names the tip itself, ``current.hash == declared``, and
+      offering it publishes the next generation over that tip.
+
+    Anything else is withheld, and ``create`` then refuses and names the hash it requires - a
+    better answer than this function guessing. Note that the two matching conditions are both
+    needed: testing only the first withholds the hash from an author holding generation one who
+    declares it in order to publish generation two, and testing only whether any generation exists
+    gets the second run on a clean clone wrong, because run 1 writes a generation whose own
+    ``supersedes`` is ``None`` and offering the hash again there writes a generation nobody asked
+    for.
+
+    A narrowed run passes here too and needs no special case: a caller-chosen ``POPULATION_NAME``
+    has no prior generation, so the lookup fails and the hash is withheld. So does a preview,
+    whose isolated registry holds no generation under this name either.
+    """
+    if not declared:
+        return None
+    try:
+        current = OfficialPopulation.one(study, name=name)
+    except (ValueError, sqlite3.OperationalError, KeyError):
+        return None
+    return declared if declared in (current.supersedes, current.hash) else None
+
+
+def superseded_members(study: Study, *, member_kind: str = "prediction") -> frozenset[str]:
+    """Identities whose own publisher has moved past them.
+
+    A downstream stage asks the registry which results it should consume, and the obvious
+    answer - every row that is ``complete`` and whose ``identity_status`` is ``"current"`` -
+    does not answer it. ``identity_status`` is derived from ``identity_version``
+    (``catalog.py``), which is the schema number the row was written under. It says the
+    registry still understands the row. It says nothing about whether the row is the one its
+    producer publishes, because that is a property of the population lineage and is recorded
+    in a different table.
+
+    The two agree until a model notebook refits. Then the notebook publishes a second
+    generation under the same name, the first generation's members stay in the registry -
+    complete, and current under a schema version that has not moved - and a stage selecting on
+    the catalog alone sweeps both. It does not fail: it succeeds over twice the population,
+    freezes the retired generation into whatever it publishes, and everything downstream
+    inherits a set that mixes two answers to the same question. That is worse than a refusal,
+    because nothing about the run looks wrong.
+
+    So ask the lineage instead. **The question is asked per name, and the name is the whole
+    point.** A name is one publisher's answer to one question, and its chain of generations is
+    that publisher changing its mind; a member is retired when the name that published it has
+    moved past it. Within a name, the comparison is member-wise rather than whole-generation:
+    a refit that moves three of ten identities retires three, and the seven that did not move
+    are still what that name publishes.
+
+    Asking it globally instead - "retired by someone, and listed by nobody in force" - is the
+    version that looks equivalent and is not, because the same identity is legitimately listed
+    under several names. A narrowed or preview run freezes its own snapshot of whatever the
+    catalog held on the day it ran, and that snapshot stays in force under its own name
+    forever. Measured on ``fx_pairs`` 2026-08-25: refitting ``tabular_dl`` retired 72
+    prediction sets, and ``fx_pairs:preflight-baselines``, frozen the day before, still listed
+    all 72 - so the global form returned nothing retired and the sweep would have run over both
+    generations exactly as if the check were absent. A stale snapshot under an unrelated name
+    cannot un-retire another name's superseded generation.
+    """
+    try:
+        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+            rows = db.execute(
+                "SELECT population_hash, name, supersedes_hash FROM official_populations "
+                "WHERE member_kind = ?",
+                (member_kind,),
+            ).fetchall()
+            if not any(row[2] is not None for row in rows):
+                return frozenset()
+            members: dict[str, set[str]] = {}
+            for population_hash, member_hash in db.execute(
+                "SELECT population_hash, member_hash FROM official_population_members"
+            ):
+                members.setdefault(population_hash, set()).add(member_hash)
+    except sqlite3.OperationalError:
+        # A clean clone has no `official_populations` table at all, so nothing has been
+        # retired. Same reasoning as `population_supersedes`.
+        return frozenset()
+
+    by_name: dict[str, list[tuple[str, str | None]]] = {}
+    for population_hash, name, supersedes in rows:
+        by_name.setdefault(name, []).append((population_hash, supersedes))
+
+    retired: set[str] = set()
+    for generations in by_name.values():
+        superseded = {supersedes for _, supersedes in generations if supersedes is not None}
+        if not superseded:
+            continue
+        # The generations this name still stands behind. Normally one; a forked chain leaves
+        # more, and taking the union is the conservative reading - a member any surviving tip
+        # still lists is not retired, so a fork can only under-report.
+        in_force: set[str] = set()
+        for population_hash, _ in generations:
+            if population_hash not in superseded:
+                in_force |= members.get(population_hash, set())
+        for population_hash in superseded:
+            retired |= members.get(population_hash, set()) - in_force
+    return frozenset(retired)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -266,3 +266,29 @@ class TestWhatALaterGenerationRetires:
             db.execute("ALTER TABLE official_populations RENAME COLUMN supersedes_hash TO gone")
         with pytest.raises(sqlite3.OperationalError, match="supersedes_hash"):
             superseded_members(study)
+    def test_a_generation_still_a_tip_in_the_other_registry_is_kept(self, tmp_path: Path) -> None:
+        """Whether a generation is a tip is decided within the registry that holds it.
+
+        The release registry lags: it holds generation one as an unsuperseded tip, because it
+        never saw the refit the author made in a workspace. Flattening both chains before
+        asking makes generation one a superseded hash on the strength of the workspace's chain
+        alone, and its members are retired out of a sweep the release registry still publishes
+        them for.
+
+        Under-retiring is the safe direction. A member wrongly kept is backtested and its
+        result verified; a member wrongly dropped silently narrows the sweep, which is the
+        failure this whole function exists to prevent.
+        """
+        release_root = _seed_release(tmp_path)
+        author = Study.open("etfs", release_root=release_root, workspace=tmp_path / "author")
+        first = _publish(author, MEMBERS_ONE)
+        released_db = author.release_case_root / "run_log" / "registry.db"
+        released_db.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(author.root / "run_log" / "registry.db", released_db)
+
+        # The refit happens in a workspace that carries generation one forward, so the
+        # workspace chain reads A -> B while the release registry still holds A as its tip.
+        refitter = Study.open("etfs", release_root=release_root, workspace=tmp_path / "refit")
+        shutil.copy(released_db, refitter.root / "run_log" / "registry.db")
+        _publish(refitter, MEMBERS_TWO, supersedes=first.hash)
+        assert superseded_members(refitter) == frozenset()

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -10,6 +10,8 @@ every case below is one that has already broken a notebook when it was decided b
 
 from __future__ import annotations
 
+import shutil
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -129,12 +131,47 @@ class TestWhatALaterGenerationRetires:
         _publish(study, MEMBERS_ONE)
         assert superseded_members(study) == frozenset()
 
-    def test_a_clean_clone_retires_nothing(self, tmp_path: Path) -> None:
-        # No `official_populations` table at all, which raises rather than returning no rows.
+    def test_a_registry_with_no_population_table_retires_nothing(self, tmp_path: Path) -> None:
+        """A reader's clean clone, and the branch a schema-complete workspace cannot reach.
+
+        `Study.open(workspace=...)` runs `_open_registry`, which creates
+        `official_populations` empty, so a study built that way exits through the
+        no-generations return and never touches the missing-table handler. Dropping the table
+        from both registries is what puts that handler under test.
+        """
         fresh = Study.open(
             "etfs", workspace=tmp_path / "fresh", release_root=_seed_release(tmp_path)
         )
+        for root in (fresh.root, fresh.release_case_root):
+            db_path = root / "run_log" / "registry.db"
+            if not db_path.exists():
+                continue
+            with sqlite3.connect(db_path) as db:
+                db.execute("DROP TABLE IF EXISTS official_populations")
+                db.execute("DROP TABLE IF EXISTS official_population_members")
         assert superseded_members(fresh) == frozenset()
+
+    def test_a_workspace_reads_the_released_registry_s_lineage(self, tmp_path: Path) -> None:
+        """The overlay, which is where reading only `study.root` gets it wrong.
+
+        `PredictionCatalog.table()` offers released rows the workspace registry does not hold,
+        and their lineage lives in the released registry - which `Study.open` never copies. A
+        workspace gets its own `official_populations`, created schema-complete and empty, so
+        reading only `study.root` returns nothing retired and the filter is a no-op. Same
+        failure mode as the global form, by a different route.
+        """
+        release_root = _seed_release(tmp_path)
+        published = Study.open("etfs", release_root=release_root, workspace=tmp_path / "author")
+        first = _publish(published, MEMBERS_ONE)
+        _publish(published, MEMBERS_TWO, supersedes=first.hash)
+        # Move what the author published into the release root, which is what a reader sees.
+        released_db = published.release_case_root / "run_log" / "registry.db"
+        released_db.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(published.root / "run_log" / "registry.db", released_db)
+
+        reader = Study.open("etfs", release_root=release_root, workspace=tmp_path / "reader")
+        assert reader.root != reader.release_case_root
+        assert superseded_members(reader) == frozenset(MEMBERS_ONE)
 
     def test_a_refit_retires_the_generation_it_replaced(self, study: Study) -> None:
         first = _publish(study, MEMBERS_ONE)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -248,3 +248,21 @@ class TestWhatALaterGenerationRetires:
         )
         _publish(study, MEMBERS_TWO, supersedes=first.hash)
         assert superseded_members(study) == frozenset(MEMBERS_ONE)
+
+    def test_a_registry_error_that_is_not_a_missing_table_propagates(self, tmp_path: Path) -> None:
+        """The blanket catch this replaced turned every failure into "nothing is retired".
+
+        A lock timeout, an I/O error and a half-migrated schema are not evidence that no
+        generation has been superseded, and answering them with an empty set is the silent
+        wrong answer the whole module exists to prevent - the sweep runs over both generations
+        and reports every member complete. Only a missing file or a missing table means
+        nothing was ever written.
+        """
+        study = Study.open(
+            "etfs", workspace=tmp_path / "broken", release_root=_seed_release(tmp_path)
+        )
+        _publish(study, MEMBERS_ONE)
+        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+            db.execute("ALTER TABLE official_populations RENAME COLUMN supersedes_hash TO gone")
+        with pytest.raises(sqlite3.OperationalError, match="supersedes_hash"):
+            superseded_members(study)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -1,0 +1,213 @@
+"""When a notebook's declared population hash may be offered to the registry.
+
+A modelling notebook that has published a population and then moves a training identity
+must name the snapshot it replaces, or ``OfficialPopulation.create`` refuses the write.
+The hash it names is committed source, so one declaration has to be right for the author
+refitting, for the author re-running, and for a reader on a clean clone whose ``run_log/``
+is gitignored and therefore empty. ``population_supersedes`` is the single decision, and
+every case below is one that has already broken a notebook when it was decided by hand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from case_studies.research import (
+    OfficialPopulation,
+    population_supersedes,
+    superseded_members,
+)
+from case_studies.research.workspace import Study
+from tests.test_research_workspace import _seed_release
+
+MEMBERS_ONE = ("aaaa11112222", "bbbb11112222")
+MEMBERS_TWO = ("cccc33334444", "dddd33334444")
+
+
+@pytest.fixture
+def study(tmp_path: Path) -> Study:
+    return Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+
+
+def _publish(study: Study, members, *, supersedes: str | None = None) -> OfficialPopulation:
+    return OfficialPopulation.create(
+        study,
+        name="etfs-linear-validation-v1",
+        member_kind="prediction",
+        members=list(members),
+        supersedes=supersedes,
+    )
+
+
+class TestWhatTheHelperDecides:
+    def test_an_empty_declaration_is_never_offered(self, study: Study) -> None:
+        assert population_supersedes(study, name="etfs-linear-validation-v1", declared="") is None
+        assert population_supersedes(study, name="etfs-linear-validation-v1", declared=None) is None
+
+    def test_a_clean_clone_withholds_the_declared_hash(self, study: Study) -> None:
+        # Nothing has been published under this name, which is what a reader sees: `run_log/`
+        # is gitignored, so the registry has no generation to supersede. Offering the hash
+        # here makes `create` refuse a first version that claims to supersede something, and
+        # the reader's run dies at the population write before any fit.
+        assert (
+            population_supersedes(study, name="etfs-linear-validation-v1", declared="feedfacefeed")
+            is None
+        )
+
+    def test_the_refit_offers_the_hash_of_the_generation_in_force(self, study: Study) -> None:
+        # The author holds generation one and declares it in order to publish generation two.
+        first = _publish(study, MEMBERS_ONE)
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+
+    def test_the_re_run_offers_the_hash_the_generation_in_force_superseded(
+        self, study: Study
+    ) -> None:
+        # Generation two is in force and its own `supersedes` is generation one, which is what
+        # the notebook still declares. Offering it recomputes the same snapshot, so the
+        # notebook resolves to the population it published instead of writing a third.
+        first = _publish(study, MEMBERS_ONE)
+        second = _publish(study, MEMBERS_TWO, supersedes=first.hash)
+        assert second.hash != first.hash
+        assert population_supersedes(study, name=second.name, declared=first.hash) == first.hash
+
+    def test_a_hash_that_names_neither_is_withheld(self, study: Study) -> None:
+        # `create` then refuses and names the hash it requires, which is a better answer than
+        # this helper guessing at a lineage the declaration does not describe.
+        _publish(study, MEMBERS_ONE)
+        assert (
+            population_supersedes(study, name="etfs-linear-validation-v1", declared="0123456789ab")
+            is None
+        )
+
+    def test_a_narrowed_run_under_its_own_name_is_withheld(self, study: Study) -> None:
+        # A caller-chosen POPULATION_NAME has no prior generation, so the declaration that is
+        # correct for the canonical name must not be carried onto it.
+        first = _publish(study, MEMBERS_ONE)
+        assert population_supersedes(study, name="etfs-linear-scratch", declared=first.hash) is None
+
+
+class TestTheDecisionsItReplaces:
+    """Each of these is how the decision was made by hand, and each is wrong somewhere."""
+
+    def test_offering_the_hash_whenever_any_generation_exists_is_not_the_rule(
+        self, study: Study
+    ) -> None:
+        # The second run on a clean clone: run 1 wrote generation one, whose own `supersedes`
+        # is None and whose hash is not what the notebook declares. "A generation exists" is
+        # true, so that rule offers the declared hash and writes a generation nobody asked
+        # for. The helper withholds it.
+        _publish(study, MEMBERS_ONE)
+        assert (
+            population_supersedes(study, name="etfs-linear-validation-v1", declared="feedfacefeed")
+            is None
+        )
+
+    def test_matching_only_the_supersedes_column_blocks_the_refit(self, study: Study) -> None:
+        # Testing `current.supersedes == declared` alone withholds the hash from an author
+        # holding generation one who declares it to publish generation two, so the clean-clone
+        # reader is fixed by making the publication impossible. The helper offers it.
+        first = _publish(study, MEMBERS_ONE)
+        assert first.supersedes is None
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+
+
+class TestWhatALaterGenerationRetires:
+    """`superseded_members` is what a downstream stage must consume instead of the catalog.
+
+    `identity_status` is the schema version a row was written under. It cannot distinguish the
+    generation a producer publishes from the one it replaced, so a backtest selecting on it
+    sweeps both and succeeds - over twice the population, with the retired half frozen into
+    whatever it publishes next.
+    """
+
+    def test_nothing_is_retired_before_anything_is_superseded(self, study: Study) -> None:
+        assert superseded_members(study) == frozenset()
+        _publish(study, MEMBERS_ONE)
+        assert superseded_members(study) == frozenset()
+
+    def test_a_clean_clone_retires_nothing(self, tmp_path: Path) -> None:
+        # No `official_populations` table at all, which raises rather than returning no rows.
+        fresh = Study.open(
+            "etfs", workspace=tmp_path / "fresh", release_root=_seed_release(tmp_path)
+        )
+        assert superseded_members(fresh) == frozenset()
+
+    def test_a_refit_retires_the_generation_it_replaced(self, study: Study) -> None:
+        first = _publish(study, MEMBERS_ONE)
+        _publish(study, MEMBERS_TWO, supersedes=first.hash)
+        assert superseded_members(study) == frozenset(MEMBERS_ONE)
+
+    def test_an_identity_the_refit_still_lists_is_not_retired(self, study: Study) -> None:
+        # The case that makes this member-wise rather than population-wise: a refit that moves
+        # one of two identities retires one. Retiring the whole predecessor would drop a
+        # prediction set that is still exactly what its producer publishes.
+        kept, moved = MEMBERS_ONE
+        first = _publish(study, (kept, moved))
+        _publish(study, (kept, "eeee55556666"), supersedes=first.hash)
+        assert superseded_members(study) == frozenset({moved})
+
+    def test_the_whole_chain_is_retired_not_only_the_last_step(self, study: Study) -> None:
+        first = _publish(study, MEMBERS_ONE)
+        second = _publish(study, MEMBERS_TWO, supersedes=first.hash)
+        third = ("eeee55556666", "ffff55556666")
+        _publish(study, third, supersedes=second.hash)
+        assert superseded_members(study) == frozenset(MEMBERS_ONE) | frozenset(MEMBERS_TWO)
+
+    def test_another_name_s_lineage_is_independent(self, study: Study) -> None:
+        # Populations are not named to a convention, so the answer must come from the lineage
+        # and not from the name. A narrowed run's own chain retires its own predecessors only.
+        first = _publish(study, MEMBERS_ONE)
+        _publish(study, MEMBERS_TWO, supersedes=first.hash)
+        scratch = OfficialPopulation.create(
+            study,
+            name="etfs-linear-scratch",
+            member_kind="prediction",
+            members=["9999aaaabbbb"],
+        )
+        assert scratch.hash not in superseded_members(study)
+        assert superseded_members(study) == frozenset(MEMBERS_ONE)
+
+    def test_a_backtest_lineage_does_not_retire_a_prediction(self, study: Study) -> None:
+        # Kinds are separate chains: a re-backtest supersedes backtest identities and must not
+        # be read as retiring the prediction sets they were run over.
+        first = OfficialPopulation.create(
+            study, name="etfs-baselines", member_kind="backtest", members=["1111bbbb2222"]
+        )
+        OfficialPopulation.create(
+            study,
+            name="etfs-baselines",
+            member_kind="backtest",
+            members=["3333bbbb4444"],
+            supersedes=first.hash,
+        )
+        assert superseded_members(study, member_kind="prediction") == frozenset()
+        assert superseded_members(study, member_kind="backtest") == frozenset({"1111bbbb2222"})
+
+    def test_a_stale_snapshot_under_another_name_cannot_un_retire_a_generation(
+        self, study: Study
+    ) -> None:
+        """The case that made the global form wrong on real data.
+
+        A narrowed or preview run freezes its own snapshot of whatever the catalog held on
+        the day it ran, and that snapshot stays in force under its own name forever. Asking
+        "retired by someone, listed by nobody in force" then answers no: the stale snapshot
+        lists the retired members, so the refit reads as though it never happened.
+
+        Measured on `fx_pairs` 2026-08-25. Refitting `tabular_dl` retired 72 prediction sets;
+        `fx_pairs:preflight-baselines`, frozen the previous day, still listed all 72; the
+        global form returned zero retired and the backtest sweep would have run over both
+        generations exactly as if the filter were absent. Every unit test passed.
+        """
+        first = _publish(study, MEMBERS_ONE)
+        OfficialPopulation.create(
+            study,
+            name="fx-preflight-baselines",
+            member_kind="prediction",
+            members=list(MEMBERS_ONE),
+        )
+        _publish(study, MEMBERS_TWO, supersedes=first.hash)
+        assert superseded_members(study) == frozenset(MEMBERS_ONE)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -266,18 +266,22 @@ class TestWhatALaterGenerationRetires:
             db.execute("ALTER TABLE official_populations RENAME COLUMN supersedes_hash TO gone")
         with pytest.raises(sqlite3.OperationalError, match="supersedes_hash"):
             superseded_members(study)
-    def test_a_generation_still_a_tip_in_the_other_registry_is_kept(self, tmp_path: Path) -> None:
-        """Whether a generation is a tip is decided within the registry that holds it.
 
-        The release registry lags: it holds generation one as an unsuperseded tip, because it
-        never saw the refit the author made in a workspace. Flattening both chains before
-        asking makes generation one a superseded hash on the strength of the workspace's chain
-        alone, and its members are retired out of a sweep the release registry still publishes
-        them for.
+    def test_a_hash_superseded_in_either_registry_is_superseded(self, tmp_path: Path) -> None:
+        """Supersession is monotone, so the union of edges across both roots is the merge.
 
-        Under-retiring is the safe direction. A member wrongly kept is backtested and its
-        result verified; a member wrongly dropped silently narrows the sweep, which is the
-        failure this whole function exists to prevent.
+        The two roots disagree in the ordinary case, not the exotic one. An author copies a
+        workspace registry into the release root - what `test_a_workspace_reads_the_released_
+        registry_s_lineage` calls what a reader sees - and then refits, which leaves the release
+        root holding generation A as an unsuperseded tip while the workspace holds A -> B. That
+        is the state right after every release.
+
+        A stale root is not independent evidence that A is still published; it is an older copy
+        of the same content-addressed chain. Reading tip-ness per root and keeping any root's
+        tip alive lets the lagging root veto every retirement for the names it holds, while
+        `PredictionCatalog.table()` goes on overlaying generation A's rows into that workspace -
+        so the sweep runs over both generations, which is the failure this function exists to
+        stop.
         """
         release_root = _seed_release(tmp_path)
         author = Study.open("etfs", release_root=release_root, workspace=tmp_path / "author")
@@ -286,9 +290,7 @@ class TestWhatALaterGenerationRetires:
         released_db.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(author.root / "run_log" / "registry.db", released_db)
 
-        # The refit happens in a workspace that carries generation one forward, so the
-        # workspace chain reads A -> B while the release registry still holds A as its tip.
         refitter = Study.open("etfs", release_root=release_root, workspace=tmp_path / "refit")
         shutil.copy(released_db, refitter.root / "run_log" / "registry.db")
         _publish(refitter, MEMBERS_TWO, supersedes=first.hash)
-        assert superseded_members(refitter) == frozenset()
+        assert superseded_members(refitter) == frozenset(MEMBERS_ONE)

--- a/tests/test_superseded_members_registries.py
+++ b/tests/test_superseded_members_registries.py
@@ -1,0 +1,103 @@
+"""`superseded_members` against real registries, at four shapes a fixture does not reach.
+
+The unit suite in `test_population_supersedes.py` builds its own populations, and five
+successive forms of this function passed it while being wrong - three returning an empty
+set, one over-retiring, one under-retiring systematically. Every one was caught by a real
+registry or by review, none by the unit suite alone. These are the four registries the
+fleet measured on 2026-08-25, each chosen for a shape the others do not test:
+
+| case study | retired | what it catches |
+|---|---|---|
+| `etfs` | 324 | Transitive closure. `etfs-gbm-validation-v1` runs four generations, `linear` and `ipca` three each, so a form that finds the first edge and stops under-reports. |
+| `us_firm_characteristics` | 135 | Four independent single-hop chains with uneven counts (30/3/30/72), so a form that stops at one chain misses the rest and an over-retiring form cannot coincidentally match. |
+| `sp500_equity_option_analytics` | 123 | A doubled catalog, visible directly: 915 prediction rows = 792 live + 123 retired, zero overlap. |
+| `crypto_perps_funding` | 400 | The edge outlives the rows. Its refit deleted generation A's `prediction_sets` rows and only the `official_population_members` record survives, so a form reading supersession out of `prediction_sets` returns empty here and correct on the other three. |
+
+The last one is why this file exists rather than a single spot check. Three of the four
+registries would let a wrong implementation look right, and `crypto_perps_funding` reading
+clean is not evidence the filter is unnecessary there - exposure is decided by whether a
+refit deleted or layered, never by the notebook.
+
+Skipped where the artifacts are not present, which is every CI runner: these read the
+canonical production registries under `~/ml4t/artifacts`, not the test fixture.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from case_studies.research.population import superseded_members
+
+ARTIFACTS = Path.home() / "ml4t" / "artifacts" / "case_studies"
+
+# Measured 2026-08-25, each by the pane that owns that case study.
+RETIRED_PREDICTIONS = {
+    "etfs": 324,
+    "us_firm_characteristics": 135,
+    "sp500_equity_option_analytics": 123,
+    "crypto_perps_funding": 400,
+}
+
+
+class _SingleRootStudy:
+    """The shape `superseded_members` needs, pointed at one registry root.
+
+    A production case study has no workspace: `study.root` and `study.release_case_root`
+    are the same directory, which is the configuration these registries are in.
+    """
+
+    read_only = False
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    @property
+    def release_case_root(self) -> Path:
+        return self.root
+
+
+def _study(case_study: str) -> _SingleRootStudy:
+    root = ARTIFACTS / case_study
+    if not (root / "run_log" / "registry.db").exists():
+        pytest.skip(f"no production registry for {case_study} on this machine")
+    return _SingleRootStudy(root)
+
+
+@pytest.mark.parametrize(("case_study", "expected"), sorted(RETIRED_PREDICTIONS.items()))
+def test_retired_prediction_count(case_study: str, expected: int) -> None:
+    assert len(superseded_members(_study(case_study), member_kind="prediction")) == expected
+
+
+def test_a_retired_generation_and_the_live_catalog_do_not_overlap() -> None:
+    """What the doubling looks like from the catalog's side.
+
+    `sp500_equity_option_analytics` holds both generations as complete, current rows, so
+    the count a backtest would sweep is the sum. Asserting the disjointness rather than
+    the totals is what says the retired set is a clean second generation and not an
+    arbitrary subset.
+    """
+    study = _study("sp500_equity_option_analytics")
+    retired = superseded_members(study, member_kind="prediction")
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        registered = {row[0] for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
+    assert retired <= registered
+    assert len(registered - retired) == len(registered) - len(retired)
+
+
+def test_an_edge_outlives_the_rows_it_retired() -> None:
+    """`crypto_perps_funding` deleted the rows and kept the membership record.
+
+    Nothing of generation A is left in `prediction_sets`; only
+    `official_population_members` still lists it, which is what keeps the edge readable as
+    history. A form that derives supersession from the prediction rows returns empty here
+    and correct everywhere else, which is the failure this case exists to catch.
+    """
+    study = _study("crypto_perps_funding")
+    retired = superseded_members(study, member_kind="prediction")
+    assert retired
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        registered = {row[0] for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
+    assert not (retired & registered)


### PR DESCRIPTION
Every backtest notebook in the fleet selects its prediction sets with `identity_status == "current" & complete`. That reads as "what should I trade" and answers "what does this registry still understand".

`identity_status` is derived from `identity_version` (`case_studies/research/catalog.py:274`), the schema number a row was written under. It carries no information about population lineage, which lives in a different table. The two agree until a model notebook refits — and then the notebook publishes a second generation under the same name, generation one's prediction sets stay in the registry complete and current under a schema version that has not moved, and the sweep runs over both.

**It does not fail.** It reports every member complete, over twice the population, and freezes the retired generation into whatever it publishes next, so everything downstream inherits a set that mixes two answers to one question. Nothing about the run looks wrong, which is why no case study has caught it. `nasdaq100_microstructure/14_backtest.py:232` carries the same filter with a comment reasoning that `complete` is the whole test.

## Measured on fx_pairs

`case_studies/utils/tabular_dl.py` gained 64 lines in #597 that record `elapsed_s` against the registry row. They change nothing the model computes, but the file's sha256 is part of `computation.source_identity`, so all 72 TabM prediction identities moved. After the refit the registry holds 144 canonical `tabular_dl` validation prediction sets where 72 are the generation `08_tabular_dl` publishes — and the catalog filter selects all 144.

With the fix: 798 complete canonical validation predictions in, 726 out, and the survivors are set-equal to the members of the three in-force populations (gbm 450, linear 84, tabular_dl 72, deep_learning 120) — checked for set equality, not counted.

## `superseded_members`

Returns the identities whose own publisher has moved past them. Two things about it are load-bearing, and both are what a reimplementation gets wrong:

**It is asked per name.** A name is one publisher's answer to one question; its chain of generations is that publisher changing its mind. The global form — "retired by someone, listed by nobody in force" — looks equivalent and is not, because the same identity is legitimately listed under several names. A narrowed or preview run freezes its own snapshot of whatever the catalog held that day, and it stays in force under its own name forever. `fx_pairs:preflight-baselines`, frozen 2026-08-24, still lists all 72 retired members, so the global form returns nothing retired and the filter becomes a silent no-op.

That version passed every unit test I had written. The real registry is what caught it, and `test_a_stale_snapshot_under_another_name_cannot_un_retire_a_generation` is that case turned into a test.

**It is member-wise within a name, and per `member_kind` across them.** A refit that moves three of ten identities retires three; the seven that did not move are still what that name publishes. Prediction and backtest lineages are separate chains in one table, so a re-backtest must not read as retiring the prediction sets it ran over.

## `population_supersedes`

The decision about whether a notebook's committed `SUPERSEDES_POPULATION` hash may be offered to `OfficialPopulation.create`. `07_gbm` inlines this after #615 and `08`, `09` and `10` need it, so it moves to one place. Offered when the declared hash names the generation in force (the refit) or the one that generation superseded (the re-run); withheld otherwise, including on a reader's clean clone where `run_log/` is gitignored and the lookup raises `OperationalError` rather than returning nothing.

## Verification

16 tests. Each fails against the specific wrong rule it exists to exclude, confirmed by substituting that rule and re-running:

| Wrong rule | Tests that fail |
|---|---|
| offer whenever any generation exists | 2 |
| match only `current.supersedes` | 2 |
| retire the whole predecessor | 1 |
| ignore `member_kind` | 1 |
| the global (not per-name) form | 1 |

**No notebook changes here.** The other eight case studies carry the same filter, and this lands on its own so they can take it without waiting on any case study's notebook work.