### PR TITLE
Size the placebo block by the treatment, and register the horizon the bandwidth uses

### DIFF
--- a/case_studies/cme_futures/config/setup.yaml
+++ b/case_studies/cme_futures/config/setup.yaml
@@ -351,5 +351,15 @@ modeling:
 
 causal:
   treatment: carry_pct
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting carry_pct in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `(c0_price - c1_price) / c0_price * 12` in 04_model_based_features, from two prices at
+  # the same timestamp. Nothing rolls, so the column carries no dependence of its own.
+  treatment_window: 1
   confounders: [vol_21d, momentum_composite, carry_rank]
   method: walk_forward_dml

--- a/case_studies/etfs/config/setup.yaml
+++ b/case_studies/etfs/config/setup.yaml
@@ -333,6 +333,16 @@ modeling:
 
 causal:
   treatment: skip_recent_6_1
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting skip_recent_6_1 in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `close.shift(21) / close.shift(6 * 21) - 1` in 03_financial_features: the six-month
+  # return that stops a month short. The oldest price it reads is 126 sessions back.
+  treatment_window: 126
   confounders: [vol_21d, vol_126d, regime, yield_curve_slope]
   method: walk_forward_dml
 

--- a/case_studies/fx_pairs/config/setup.yaml
+++ b/case_studies/fx_pairs/config/setup.yaml
@@ -296,7 +296,12 @@ causal:
   # one. Derived from the construction, not chosen:
   #
   # `close.shift(skip_recent) / close.shift(momentum[-1]) - 1` in 03_financial_features,
-  # which is 21 and 252. The oldest price it reads is 252 sessions back.
+  # which is 21 and 252. Three different numbers live in that one expression and conflating them
+  # is easy, so all three are stated: the LOOKBACK is 252 sessions, the oldest price it reads;
+  # the RETURN INTERVAL is 231 sessions, from t-252 to t-21, which is what the value measures;
+  # and consecutive values OVERLAP in 230 of those 231. The declaration takes the lookback
+  # because it is the larger, so a block of this length spans the 231-session dependence
+  # whichever way the arithmetic is read.
   treatment_window: 252
   confounders: [vol_gk_21d, vol_gk_63d, zscore_21d]
   method: walk_forward_dml

--- a/case_studies/fx_pairs/config/setup.yaml
+++ b/case_studies/fx_pairs/config/setup.yaml
@@ -288,5 +288,15 @@ modeling:
 
 causal:
   treatment: mom_skip_recent
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting mom_skip_recent in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `close.shift(skip_recent) / close.shift(momentum[-1]) - 1` in 03_financial_features,
+  # which is 21 and 252. The oldest price it reads is 252 sessions back.
+  treatment_window: 252
   confounders: [vol_gk_21d, vol_gk_63d, zscore_21d]
   method: walk_forward_dml

--- a/case_studies/nasdaq100_microstructure/config/setup.yaml
+++ b/case_studies/nasdaq100_microstructure/config/setup.yaml
@@ -614,5 +614,15 @@ modeling:
 
 causal:
   treatment: signed_vol_share
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting signed_vol_share in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `signed / TRADED_VOLUME` in 03_financial_features, both from the same bar. The smoothed
+  # versions this feeds are separate columns; the treatment itself spans one bar.
+  treatment_window: 1
   confounders: [rel_spread_close, rv_5m, r1m]
   method: walk_forward_dml

--- a/case_studies/sp500_equity_option_analytics/config/setup.yaml
+++ b/case_studies/sp500_equity_option_analytics/config/setup.yaml
@@ -347,5 +347,16 @@ modeling:
 
 causal:
   treatment: ivrv_spread
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting ivrv_spread in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `iv_30_atm - rv_{realized_vol[0]}` in 03_financial_features, and features.windows
+  # declares realized_vol as [20, 63]. The implied leg is a quote and rolls nothing; the
+  # realized leg is what makes the spread autocorrelated, over its own 20 sessions.
+  treatment_window: 20
   confounders: [rv_20, mom_21d, skew_rr_30_25d]
   method: walk_forward_dml

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -366,5 +366,14 @@ modeling:
 
 causal:
   treatment: vrp_21d
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting vrp_21d in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `iv_atm - rv_21d` in 03_financial_features. The realized leg spans 21 sessions.
+  treatment_window: 21
   confounders: [rv_21d, vrp_mom_5d, spread_pctl]
   method: walk_forward_dml

--- a/case_studies/us_equities_panel/config/setup.yaml
+++ b/case_studies/us_equities_panel/config/setup.yaml
@@ -199,6 +199,17 @@ modeling:
 
 causal:
   treatment: past_ret_12m_skip
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting past_ret_12m_skip in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # `close.shift(MOMENTUM_SKIP) / close.shift(MOMENTUM_LOOKBACK) - 1` in 02_labels, where
+  # those are 21 and 252 trading sessions. 03_financial_features recomputes it as
+  # `ret_12m_skip`; the oldest price either reads is 252 sessions back.
+  treatment_window: 252
   confounders: [vol_21d, illiq_rank, volume_ratio]
   method: walk_forward_dml
 

--- a/case_studies/us_firm_characteristics/config/setup.yaml
+++ b/case_studies/us_firm_characteristics/config/setup.yaml
@@ -407,5 +407,15 @@ modeling:
 
 causal:
   treatment: r12_2
+  # Bars the treatment's own construction window spans, which is what the placebo block has
+  # to cover: permuting r12_2 in blocks shorter than this destroys the serial
+  # dependence the refutation exists to preserve, and the resulting p-value reads like a
+  # refutation without being one. Declared here rather than inferred, because guessing which
+  # element of a window list a column was built from puts a wrong number behind a right-looking
+  # one. Derived from the construction, not chosen:
+  #
+  # cumulative return from twelve months back to two months back, on a monthly panel
+  # (03_financial_features). Twelve rows, because a row here is a month.
+  treatment_window: 12
   confounders: [Beta, IdioVol, LME, Variance]
   method: walk_forward_dml

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1440,12 +1440,13 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
             "block_size": block_size,
             "block_size_basis": block_size_basis,
             "label_buffer_steps": buffer_steps,
-            # The quantity the second-stage HAC bandwidth is sized by, which until now was
-            # computed here, passed to run_dml_analysis and then discarded. A notebook reasoning
-            # about bandwidth against block size had no registered number to read, so it either
-            # recomputed one or printed a value it could not read back - crypto's 12_model_analysis
-            # did the latter, against a key that had never existed. It is not the buffer: the
-            # buffer is the CV gap and can be deliberately longer than the outcome it seals.
+            # The quantity the second-stage HAC bandwidth is sized by, restored here after the
+            # treatment-window work dropped it. It was emitted through e71730e4 and replaced by
+            # label_buffer_steps in e5604dff - not renamed, replaced: these are two different
+            # quantities, and the buffer is the CV gap, which is declared deliberately longer
+            # than the outcome it seals. Both are recorded now because a notebook comparing a
+            # block size against a bandwidth needs to name which scale it means. They coincide
+            # at 1 on crypto_perps_funding, which is why the substitution looked harmless.
             "label_horizon_steps": outcome_horizon_steps,
             "treatment_window_steps": treatment_window_steps,
             "seed": seed,

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1128,6 +1128,46 @@ def _observed_cadence(frame, timestamp: str) -> pd.Timedelta:
     return pd.Timedelta(cadence)
 
 
+def _treatment_persistence_steps(setup: dict[str, Any], treatment: str) -> int | None:
+    """Bars the treatment's own construction window spans, from `features.windows`.
+
+    A 14-day z-score is autocorrelated over its whole window whatever the label
+    horizon is, so a placebo that permutes in blocks shorter than that window
+    destroys the dependence the permutation exists to preserve. `setup.yaml`
+    already declares every window once, keyed by the suffix the emitted column
+    carries, so the number is read from there rather than parsed out of the
+    column name. Returns None when the register declares no window for this
+    treatment, which the caller records rather than papers over.
+    """
+    # An explicit declaration in the causal block wins. The feature register below can only
+    # answer for a column whose family is suffix-keyed, and eight of the nine treatments are
+    # not: cme's `carry_pct` has no `carry` family, etfs' `skip_recent_6_1` sits under a family
+    # that is a bare int, us_firm and us_equities_panel declare no windows at all. Contorting
+    # the register to reach them would have meant renaming keys the feature code reads by name.
+    # Declared next to `treatment` and `confounders`, which is where a reader looks for what
+    # the treatment is, and where the derivation can be written down beside it.
+    declared = (setup.get("causal") or {}).get("treatment_window")
+    if declared is not None:
+        return max(1, int(declared))
+    windows = (setup.get("features") or {}).get("windows") or {}
+    for family, suffixes in windows.items():
+        prefix = f"{family}_"
+        if not treatment.startswith(prefix):
+            continue
+        # Only the suffix-keyed mapping says which window *this* column carries.
+        # The register also holds bare ints and lists of bar counts for families
+        # whose columns are named some other way (etfs `skip_recent: 21`, and
+        # `momentum: [5, 10, 21, ...]`), and guessing which element a treatment
+        # was built from would put a wrong block size behind a right-looking
+        # number. Those return None, and the caller warns.
+        if not isinstance(suffixes, dict):
+            continue
+        declared = suffixes.get(treatment[len(prefix) :])
+        if declared is not None:
+            return max(1, int(declared))
+    return None
+
+
 def _resolve_nuisance_params(config: dict[str, Any], overrides: dict[str, Any], seed: int):
     configured = dict(config.get("params") or {})
     supplied = dict(overrides.get("nuisance_params") or {})
@@ -1325,6 +1365,43 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         embargo = embargo_from_buffer(mds.label_buffer, observed_step=cadence)
     except ValueError:
         embargo = embargo_from_buffer(mds.label_buffer)
+    # Two separate scales create the serial dependence the placebo has to preserve, and the
+    # block spans the longer of them: the overlapping labels span the label horizon, and the
+    # treatment's own construction window spans itself. Sizing by the horizon alone permutes
+    # a 126-session momentum column in blocks of 21, which is close enough to an independent
+    # shuffle that the p-value it produces does not mean what it reads as.
+    treatment_window_steps = _treatment_persistence_steps(setup, treatment)
+    if treatment_window_steps is None:
+        # A canonical run refuses rather than warns. A warning still leaves a registered
+        # result whose refutation is weaker than it reads, and nothing downstream can tell
+        # it from one whose block was sized correctly.
+        #
+        # Preview keeps the warning. That tier exists to run reduced and be thrown away, so
+        # failing it would block CI on every case study that has not declared a window yet
+        # without protecting any registered number.
+        if tier is not ExecutionTier.PREVIEW:
+            raise ValueError(
+                f"{study.case_study}: no construction window is declared for treatment "
+                f"{treatment!r}, so the placebo block would span only the label buffer "
+                f"({buffer_steps} bars). Set `causal.treatment_window` in setup.yaml to the "
+                "number of bars the treatment's own construction spans, read off the code "
+                "that builds the column rather than its name. A canonical refutation will "
+                "not be registered against a block that cannot be shown to span the "
+                "treatment. One bar is a valid answer for a column built from quantities "
+                "carrying the row's own timestamp, and is how it is said."
+            )
+        warnings.warn(
+            f"{study.case_study}: no construction window is declared for treatment "
+            f"{treatment!r}, so the placebo block spans only the label buffer "
+            f"({buffer_steps} bars). If the treatment is a rolling statistic, set "
+            "`causal.treatment_window` in setup.yaml so the block can span it.",
+            UserWarning,
+            stacklevel=2,
+        )
+    block_size = max(buffer_steps, treatment_window_steps or 1)
+    block_size_basis = (
+        "treatment_window" if block_size == treatment_window_steps else "label_buffer"
+    )
     nuisance_params = _resolve_nuisance_params(config, request["overrides"], seed)
     key_frame = analysis.select(mds.entity_cols[0], mds.date_col)
     if key_frame.n_unique([mds.entity_cols[0], mds.date_col]) != key_frame.height:
@@ -1360,7 +1437,10 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         "refutation": {
             "method": "within_symbol_contiguous_block_permutation",
             "n_placebo": n_placebo,
-            "block_size": buffer_steps,
+            "block_size": block_size,
+            "block_size_basis": block_size_basis,
+            "label_buffer_steps": buffer_steps,
+            "treatment_window_steps": treatment_window_steps,
             "seed": seed,
             "temporal_gap_policy": "reset",
             "observation_cadence": str(cadence),
@@ -1397,16 +1477,20 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         n_folds=n_folds,
         embargo=embargo,
         n_placebo=n_placebo,
-        # The block takes the buffer and the bandwidth takes the outcome horizon.
-        # The block holds fixed the dependence the fold structure already keeps
-        # clear, which the buffer measures; the bandwidth corrects for outcomes
-        # that overlap, and how far one outcome reaches is the horizon. The two
-        # are equal wherever a case study declares them equal, which is most of
-        # them here, so the split changes no result until one of them declares a
-        # horizon shorter than its buffer. Newey-West is not monotonic in the
-        # bandwidth, so a bandwidth taken from the wrong quantity is not a known
-        # direction of error.
-        block_size=buffer_steps,
+        # The block takes the longer of the buffer and the treatment's construction
+        # window; the bandwidth takes the outcome horizon. The block holds fixed the
+        # dependence the permutation must preserve, and there are two sources of it:
+        # the fold structure keeps the overlapping labels clear, which the buffer
+        # measures, and the treatment's own rolling window carries dependence of its
+        # own for as long as it spans. The bandwidth corrects for outcomes that
+        # overlap, and how far one outcome reaches is the horizon. Newey-West is not
+        # monotonic in the bandwidth, so a bandwidth taken from the wrong quantity is
+        # not a known direction of error.
+        #
+        # This is the same number the spec registers above. They are derived once and
+        # passed to both, because a spec that records a block the analysis did not use
+        # is worse than either value alone.
+        block_size=block_size,
         seed=seed,
         horizon=outcome_horizon_steps,
         expected_step=cadence,
@@ -1603,6 +1687,22 @@ def register_causal_run(
     if development_end is not None:
         causal_params["development_end"] = development_end
 
+    # NOTE: this spec carries no `identity_version`, and `current_causal_identities` skips
+    # every row that lacks one. A run registered through this wrapper therefore lands in
+    # `causal_runs` and resolves to nothing - the label's current identity set comes back
+    # empty, and the notebook that reads it shows no result rather than an error.
+    #
+    # It cannot be fixed by stamping version 3 here: `project_training_identity` refuses a
+    # version-3 identity whose payload is not `ml4t.resolved-spec/v1`, which only
+    # `resolve_causal_request` produces. The fix is per notebook, converting it to the
+    # resolver, and `tests/test_causal_rows_are_resolvable.py` names the ones still to go.
+    #
+    # Measured across the nine registries on 2026-08-25: crypto 2/2 rows visible, cme 6/6
+    # and fx 3/3, all resolver-written; us_firm 0/3 and etfs 0/1, both wrapper-written.
+    # sp500_options' single row IS visible, but it was written before that notebook moved
+    # to this wrapper, so the row describes a path the notebook no longer takes and its
+    # next run registers an invisible one. Five notebooks call this; do not delete it when
+    # the first two convert.
     spec = build_training_spec(
         "causal_dml",
         "dml",

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1440,6 +1440,13 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
             "block_size": block_size,
             "block_size_basis": block_size_basis,
             "label_buffer_steps": buffer_steps,
+            # The quantity the second-stage HAC bandwidth is sized by, which until now was
+            # computed here, passed to run_dml_analysis and then discarded. A notebook reasoning
+            # about bandwidth against block size had no registered number to read, so it either
+            # recomputed one or printed a value it could not read back - crypto's 12_model_analysis
+            # did the latter, against a key that had never existed. It is not the buffer: the
+            # buffer is the CV gap and can be deliberately longer than the outcome it seals.
+            "label_horizon_steps": outcome_horizon_steps,
             "treatment_window_steps": treatment_window_steps,
             "seed": seed,
             "temporal_gap_policy": "reset",

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -891,3 +891,32 @@ def test_the_block_spans_the_treatment_when_it_outlasts_the_buffer(tmp_path, mon
     assert refutation["block_size_basis"] == "treatment_window"
     assert refutation["treatment_window_steps"] == 21
     assert refutation["label_buffer_steps"] < 21
+
+
+def test_the_outcome_horizon_is_registered_and_is_not_the_buffer(tmp_path, monkeypatch) -> None:
+    """The bandwidth the second stage is HAC-corrected at has to be readable from the spec.
+
+    ``run_dml_analysis`` is already given the outcome horizon in observation periods, and until
+    now the resolver computed it and threw it away. A notebook comparing bandwidth against block
+    size then had nothing registered to read: crypto's ``12_model_analysis`` printed a value it
+    derived from a key that had never existed under any version of the resolver.
+
+    The assertion that carries this is the second one. ``label_buffer_steps`` is the CV gap and
+    may be deliberately longer than the outcome it seals, so a horizon read off the buffer is
+    wrong in exactly the case where the two differ - which is the fixture here.
+    """
+    # A buffer three cadences long over an eight-hour panel, sealing a one-cadence outcome.
+    # That gap is the case the two quantities are told apart in: a horizon read off the
+    # buffer would report 3 where the label resolves in 1.
+    study, label, _frame = _causal_fixture(
+        tmp_path, monkeypatch, treatment_window=21, label_buffer="24H", label_horizon="8H"
+    )
+
+    refutation = (
+        study.causal(method="dml", label=label.name, execution_tier="canonical")
+        .resolve()
+        .spec["computation"]["refutation"]
+    )
+
+    assert refutation["label_buffer_steps"] == 3
+    assert refutation["label_horizon_steps"] == 1

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -35,14 +35,20 @@ def _causal_fixture(
     entity: str = "symbol",
     label_buffer: str = "8H",
     label_horizon: str | None = None,
+    treatment_window: int | None = 1,
 ):
     study = Study.open(
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
     setup_path = study.root / "config" / "setup.yaml"
-    setup_path.write_text(
-        setup_path.read_text() + "causal:\n  treatment: treatment\n  confounders: [confounder]\n"
-    )
+    # `treatment` here is a per-row column carrying its own timestamp, so one bar is
+    # the honest window. It is declared rather than omitted because a canonical run now
+    # refuses an undeclared window, and every test below that is not about that refusal
+    # would otherwise fail on it. Pass treatment_window=None to exercise the refusal.
+    causal_block = "causal:\n  treatment: treatment\n  confounders: [confounder]\n"
+    if treatment_window is not None:
+        causal_block += f"  treatment_window: {treatment_window}\n"
+    setup_path.write_text(setup_path.read_text() + causal_block)
     if label_horizon is not None:
         # Merged through a yaml round-trip rather than appended. `labels` already exists in
         # this setup, and a second top-level `labels:` key would replace it outright rather
@@ -568,8 +574,11 @@ def _session_causal_fixture(tmp_path, monkeypatch):
         "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
     )
     setup_path = study.root / "config" / "setup.yaml"
+    # One bar: `treatment` carries the row's own timestamp. Declared because a canonical
+    # run refuses an undeclared window, and this fixture is about the holdout seal.
     setup_path.write_text(
-        setup_path.read_text() + "causal:\n  treatment: treatment\n  confounders: [confounder]\n"
+        setup_path.read_text()
+        + "causal:\n  treatment: treatment\n  confounders: [confounder]\n  treatment_window: 1\n"
     )
     sessions = [
         timestamp
@@ -834,3 +843,51 @@ def test_a_horizon_longer_than_its_buffer_is_refused(tmp_path, monkeypatch) -> N
                 "n_placebo": 10,
             },
         ).resolve()
+
+
+def test_a_canonical_run_refuses_an_undeclared_treatment_window(tmp_path, monkeypatch) -> None:
+    """A block that cannot be shown to span the treatment must not reach the registry.
+
+    Preview warns and proceeds - that tier exists to run reduced and be thrown away. Canonical
+    refuses, because the alternative is a registered refutation whose p-value reads stronger
+    than it is and that nothing downstream can distinguish from a correctly sized one.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, treatment_window=None)
+
+    with pytest.raises(ValueError, match="no construction window is declared"):
+        study.causal(method="dml", label=label.name, execution_tier="canonical").resolve()
+
+
+def test_preview_warns_on_an_undeclared_window_rather_than_failing(tmp_path, monkeypatch) -> None:
+    """Failing preview would block CI on every case study that had not declared one yet."""
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, treatment_window=None)
+
+    with pytest.warns(UserWarning, match="no construction window is declared"):
+        study.causal(
+            method="dml",
+            label=label.name,
+            execution_tier="preview",
+            preview_reductions={
+                "max_samples": 240,
+                "max_symbols": 6,
+                "n_folds": 2,
+                "n_placebo": 10,
+            },
+        ).resolve()
+
+
+def test_the_block_spans_the_treatment_when_it_outlasts_the_buffer(tmp_path, monkeypatch) -> None:
+    """The case the defect produced: a wide treatment permuted in blocks sized by the label.
+
+    ETFs permuted a six-month momentum column in blocks of 21 sessions this way. The spec must
+    also record which of the two scales bound it, so a reader can tell the two apart.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch, treatment_window=21)
+
+    resolved = study.causal(method="dml", label=label.name, execution_tier="canonical").resolve()
+
+    refutation = resolved.spec["computation"]["refutation"]
+    assert refutation["block_size"] == 21
+    assert refutation["block_size_basis"] == "treatment_window"
+    assert refutation["treatment_window_steps"] == 21
+    assert refutation["label_buffer_steps"] < 21

--- a/tests/test_causal_treatment_window.py
+++ b/tests/test_causal_treatment_window.py
@@ -1,0 +1,63 @@
+"""Every configured treatment must resolve to a construction window.
+
+A placebo that permutes in blocks shorter than the treatment's own construction window
+destroys the serial dependence the refutation exists to preserve, and the p-value it
+produces reads like a refutation without being one. `resolve_causal_request` therefore
+sizes the block by `max(label_buffer, treatment_window)` and a canonical run refuses when
+the window is undeclared.
+
+The feature register can only answer for a family that is suffix-keyed, and eight of the
+nine treatments are not: `carry_pct`, `skip_recent_6_1`, `mom_skip_recent`, `r12_2`,
+`past_ret_12m_skip`, `vrp_21d`, `ivrv_spread` and `signed_vol_share`. That is why the
+window is declared explicitly under `causal.treatment_window`, beside the treatment it
+describes. Only crypto_perps_funding still resolves through the register.
+
+This reads configuration and nothing else, so it costs no data and runs everywhere. The
+refusal itself is exercised against a real resolve in tests/test_causal_adapter.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from case_studies.utils.causal import _treatment_persistence_steps
+
+REPO = Path(__file__).resolve().parent.parent
+SETUPS = sorted(REPO.glob("case_studies/*/config/setup.yaml"))
+
+
+def _configured() -> list[tuple[str, dict]]:
+    out = []
+    for path in SETUPS:
+        setup = yaml.safe_load(path.read_text()) or {}
+        if (setup.get("causal") or {}).get("treatment"):
+            out.append((path.parent.parent.name, setup))
+    return out
+
+
+CONFIGURED = _configured()
+
+
+def test_every_case_study_configures_a_causal_treatment() -> None:
+    """Nine case studies, nine causal stages - so nine is what the parametrization covers.
+
+    Without this a setup.yaml that lost its `causal` block would silently drop out of the
+    check below rather than fail it.
+    """
+    assert len(CONFIGURED) == 9, [name for name, _ in CONFIGURED]
+
+
+@pytest.mark.parametrize("case_study,setup", CONFIGURED, ids=[n for n, _ in CONFIGURED])
+def test_treatment_window_resolves(case_study: str, setup: dict) -> None:
+    treatment = setup["causal"]["treatment"]
+    steps = _treatment_persistence_steps(setup, treatment)
+    assert steps is not None, (
+        f"{case_study} declares treatment {treatment!r} and no construction window for it, so "
+        "its placebo block would span the label buffer alone. Declare `causal.treatment_window` "
+        "as the number of bars the treatment's own construction spans, derived from the code "
+        "that builds the column - not from the name."
+    )
+    assert steps >= 1


### PR DESCRIPTION
Three commits, all in the causal path, extracted from crypto's PR so the eight case studies waiting on them do not each wait for that branch.

## The placebo block was sized by the label alone

`run_dml_analysis`'s block permutation used `block_size=buffer_steps`. A block has to span whatever makes an observation dependent on its neighbours, and that is the longer of the label buffer and the window the treatment itself is constructed over. ETFs permuted a six-month momentum column in blocks of 21 sessions.

`causal.treatment_window` is now declared under `causal.treatment` in eight `config/setup.yaml` files, each with its derivation in a comment: `cme_futures` 1, `nasdaq100_microstructure` 1, `us_firm_characteristics` 12, `sp500_equity_option_analytics` 20, `sp500_options` 21, `etfs` 126, `fx_pairs` 252, `us_equities_panel` 252. crypto is unchanged and resolves to 42 through `features.windows`.

Canonical runs refuse an undeclared window; preview warns. The spec records `block_size`, `block_size_basis`, `label_buffer_steps` and `treatment_window_steps`, so a reader can tell which of the two scales bound the block.

The change that matters most is one line: the analysis call moved from `block_size=buffer_steps` to `block_size=block_size`. Without it the spec would have recorded a block the analysis never used.

## The outcome horizon is registered again

`label_horizon_steps` was emitted through `e71730e4` and **replaced** by `label_buffer_steps` in `e5604dff` - not renamed, replaced. They are two quantities: the buffer is the CV gap and is declared deliberately longer than the outcome it seals. So the horizon, which is what the second-stage HAC bandwidth is sized by, has been registered nowhere since, and `crypto_perps_funding/12_model_analysis` has been printing a value it cannot read back.

It goes back as a second field beside the buffer. The test builds the case where the two differ - a 24H buffer over an eight-hour panel sealing an 8H outcome, giving 3 and 1 - because a fixture where they coincide passes on code that reads the buffer, which is the substitution the test exists to catch.

## Verification

72 passed across `test_causal_adapter.py`, `test_causal_treatment_window.py`, `test_causal_supersedes.py`, `test_causal_refutation_pvalue.py`. Deleting `treatment_window` from `etfs/config/setup.yaml` fails two tests; restoring it passes 21.

A NOTE above `build_training_spec` records the wrapper hazard measured on crypto: rows written through `register_causal_run` carry no `identity_version`, so `current_causal_identities` skips them and the label resolves to nothing. Five notebooks still call it. That is not fixed here - it is per-notebook work in the owning units.