### PR TITLE
Chapter 20: read the ledgers where they are written, and drop a stale carrier pin

### DIFF
--- a/20_strategy_synthesis/01_aggregate_synthesis.ipynb
+++ b/20_strategy_synthesis/01_aggregate_synthesis.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a4fb7f3f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.011026,
-     "end_time": "2026-08-20T08:34:04.295205+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:04.284179+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "609b349b",
+   "metadata": {},
    "source": [
     "# Aggregate Synthesis\n",
     "\n",
@@ -34,23 +26,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "868609d7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:04.301725Z",
-     "iopub.status.busy": "2026-08-20T08:34:04.301606Z",
-     "iopub.status.idle": "2026-08-20T08:34:05.822696Z",
-     "shell.execute_reply": "2026-08-20T08:34:05.822180Z"
-    },
-    "papermill": {
-     "duration": 1.525307,
-     "end_time": "2026-08-20T08:34:05.823349+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:04.298042+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "311d341f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Ch20 Aggregate Synthesis — query registries and compare all 9 case studies.\"\"\"\n",
@@ -73,22 +51,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "9d265150",
+   "execution_count": null,
+   "id": "5a204fd3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:05.829906Z",
-     "iopub.status.busy": "2026-08-20T08:34:05.829767Z",
-     "iopub.status.idle": "2026-08-20T08:34:05.831601Z",
-     "shell.execute_reply": "2026-08-20T08:34:05.831336Z"
-    },
-    "papermill": {
-     "duration": 0.005745,
-     "end_time": "2026-08-20T08:34:05.832087+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.826342+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -110,23 +75,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "e4632cef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:05.838115Z",
-     "iopub.status.busy": "2026-08-20T08:34:05.838047Z",
-     "iopub.status.idle": "2026-08-20T08:34:05.840451Z",
-     "shell.execute_reply": "2026-08-20T08:34:05.840141Z"
-    },
-    "papermill": {
-     "duration": 0.005905,
-     "end_time": "2026-08-20T08:34:05.840756+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.834851+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "f047b157",
+   "metadata": {},
    "outputs": [],
    "source": [
     "OUTPUT_DIR = get_chapter_dir(20) / \"output\"\n",
@@ -167,23 +118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "895d99e4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:05.846755Z",
-     "iopub.status.busy": "2026-08-20T08:34:05.846685Z",
-     "iopub.status.idle": "2026-08-20T08:34:05.848351Z",
-     "shell.execute_reply": "2026-08-20T08:34:05.848101Z"
-    },
-    "papermill": {
-     "duration": 0.005239,
-     "end_time": "2026-08-20T08:34:05.848715+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.843476+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "4b1479f0",
+   "metadata": {},
    "outputs": [],
    "source": [
     "ASSET_CLASS_MAP = {\n",
@@ -213,16 +150,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72f3dfaa",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002704,
-     "end_time": "2026-08-20T08:34:05.854178+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.851474+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5d76533c",
+   "metadata": {},
    "source": [
     "## Load Registries\n",
     "\n",
@@ -231,42 +160,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "78674ebb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:05.860250Z",
-     "iopub.status.busy": "2026-08-20T08:34:05.860171Z",
-     "iopub.status.idle": "2026-08-20T08:34:05.952007Z",
-     "shell.execute_reply": "2026-08-20T08:34:05.951676Z"
-    },
-    "papermill": {
-     "duration": 0.095475,
-     "end_time": "2026-08-20T08:34:05.952361+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.856886+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [OK] etfs: 0 backtests ({})\n",
-      "  [OK] crypto_perps_funding: 0 backtests ({})\n",
-      "  [OK] nasdaq100_microstructure: 0 backtests ({})\n",
-      "  [OK] sp500_equity_option_analytics: 2933 backtests ({'allocation': 2014, 'signal': 726, 'risk_overlay': 105, 'cost_sensitivity': 85, 'holdout': 3})\n",
-      "  [OK] us_firm_characteristics: 2538 backtests ({'allocation': 1361, 'signal': 1164, 'cost_sensitivity': 11, 'holdout': 2})\n",
-      "  [OK] fx_pairs: 728 backtests ({'allocation': 360, 'signal': 292, 'risk_overlay': 42, 'cost_sensitivity': 33, 'holdout': 1})\n",
-      "  [OK] cme_futures: 698 backtests ({'signal': 302, 'allocation': 289, 'risk_overlay': 61, 'cost_sensitivity': 44, 'holdout': 2})\n",
-      "  [OK] sp500_options: 867 backtests ({'signal': 684, 'allocation': 150, 'htm_cost_cascade': 32, 'holdout': 1})\n",
-      "  [OK] us_equities_panel: 0 backtests ({})\n",
-      "\n",
-      "Loaded: 9/9 case studies\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "18220e3f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "explorers: dict[str, BacktestExplorer] = {}\n",
     "configs: dict[str, dict] = {}\n",
@@ -290,16 +187,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "833d32e7",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002774,
-     "end_time": "2026-08-20T08:34:05.958146+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.955372+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "a6949de3",
+   "metadata": {},
    "source": [
     "## Rank-1 Cluster Diagnostics\n",
     "\n",
@@ -333,23 +222,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "55c08186",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:05.964572Z",
-     "iopub.status.busy": "2026-08-20T08:34:05.964495Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.011909Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.011375Z"
-    },
-    "papermill": {
-     "duration": 1.051524,
-     "end_time": "2026-08-20T08:34:07.012409+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:05.960885+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "f07eee28",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Label restrictions that align the cluster-diagnostics rank-1 with the\n",
@@ -430,20 +305,26 @@
     "    return df.filter(rung[\"predicate\"])\n",
     "\n",
     "\n",
-    "# Carrier pin (validation-time a-priori tie-break) — distinct from the rung\n",
-    "# restrictions above. It selects the deployed MODEL carrier when the cross-stage\n",
-    "# val rank-1 is statistically tied with a more diversified / more precisely-\n",
-    "# estimated config. us_firm_characteristics: default_huber (signal-stage rank-1,\n",
-    "# val 2.754, block-bootstrap Sharpe CI [2.33,3.37] width 1.04) is pinned over\n",
-    "# leaves_7_mae (cross-stage rank-1, val 2.759, CI [2.10,3.57] width 1.46) — same\n",
-    "# point estimate, narrower CI, far more diversified deployment (50 equal-weight\n",
-    "# names vs 10 score-weighted; holdout MaxDD -8.6% vs -34%). Pinning on\n",
-    "# config_name (NOT allocator) keeps both equal_weight and score_weighted in the\n",
-    "# §20.5 allocator comparison on the carrier's prediction. Mirrors\n",
-    "# case_studies.utils.strategy_analysis.CARRIER_PINS — keep in sync.\n",
-    "_CARRIER_PIN_PREDICATES: dict[str, pl.Expr] = {\n",
-    "    \"us_firm_characteristics\": pl.col(\"config_name\") == \"default_huber\",\n",
-    "}\n",
+    "# Carrier pin: a validation-time a-priori tie-break, distinct from the rung restrictions\n",
+    "# above. EMPTY, and that is the normal state. It held\n",
+    "# `\"us_firm_characteristics\": pl.col(\"config_name\") == \"default_huber\"` until 2026-08-25,\n",
+    "# copied from case_studies.utils.strategy_analysis.CARRIER_PINS and translated into a\n",
+    "# config-name predicate, under a \"keep in sync\" comment doing the job a mechanism should.\n",
+    "#\n",
+    "# It had not been in sync for a rebuild. Against the current registry `default_huber` is the\n",
+    "# WEAKEST of the ten configs that reached the allocation stage (48 validation backtests, best\n",
+    "# Sharpe 2.128, 2.075 average - tenth of ten), while the documented rule selects `leaves_63_mse`\n",
+    "# (59 backtests, 3.116). So this restricted one case study to its worst advanced configuration\n",
+    "# while every notebook inside that case study reported its best.\n",
+    "#\n",
+    "# Worse than the hash pin removed from CARRIER_PINS the same day, because a hash pin dies loudly:\n",
+    "# every hash changes when a sweep is rebuilt, so it resolves to nothing and stops. A config-name\n",
+    "# predicate survives the rebuild and keeps selecting, silently and wrongly.\n",
+    "#\n",
+    "# If a carrier restriction is ever needed here again, call `carrier_pins.carrier_config_name(cs)`,\n",
+    "# which resolves a pin to its config through the registry - the thing this copy existed to avoid\n",
+    "# and the thing that would have failed loudly instead of filtering to the wrong config.\n",
+    "_CARRIER_PIN_PREDICATES: dict[str, pl.Expr] = {}\n",
     "\n",
     "\n",
     "def _apply_carrier_pin(df: pl.DataFrame, cs: str) -> pl.DataFrame:\n",
@@ -523,50 +404,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "977763f8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.021013Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.020816Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.486458Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.486098Z"
-    },
-    "papermill": {
-     "duration": 0.469903,
-     "end_time": "2026-08-20T08:34:07.487000+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.017097+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Rank-1 Cluster Diagnostics (validation) ===\n",
-      "shape: (5, 9)\n",
-      "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬─────────┬───────────┐\n",
-      "│ case_study ┆ rank1_sha ┆ rank10_sh ┆ rank1_ran ┆ … ┆ fold_shar ┆ n_folds_p ┆ n_folds ┆ n_configs │\n",
-      "│ ---        ┆ rpe       ┆ arpe      ┆ k10_sprea ┆   ┆ pe_se     ┆ os        ┆ ---     ┆ ---       │\n",
-      "│ str        ┆ ---       ┆ ---       ┆ d         ┆   ┆ ---       ┆ ---       ┆ i64     ┆ i64       │\n",
-      "│            ┆ f64       ┆ f64       ┆ ---       ┆   ┆ f64       ┆ i64       ┆         ┆           │\n",
-      "│            ┆           ┆           ┆ f64       ┆   ┆           ┆           ┆         ┆           │\n",
-      "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═════════╪═══════════╡\n",
-      "│ S&P 500    ┆ 1.482389  ┆ 1.006782  ┆ 0.475608  ┆ … ┆ 0.104766  ┆ 2         ┆ 2       ┆ 200       │\n",
-      "│ Eq+Opt     ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
-      "│ US Firms   ┆ 2.746176  ┆ 2.65441   ┆ 0.091765  ┆ … ┆ 2.376608  ┆ 10        ┆ 10      ┆ 200       │\n",
-      "│ FX Pairs   ┆ -0.004311 ┆ -0.085029 ┆ 0.080718  ┆ … ┆ 0.270165  ┆ 3         ┆ 8       ┆ 200       │\n",
-      "│ CME        ┆ 1.126253  ┆ 0.779805  ┆ 0.346448  ┆ … ┆ 0.273758  ┆ 3         ┆ 5       ┆ 200       │\n",
-      "│ Futures    ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
-      "│ S&P 500    ┆ 0.001681  ┆ -0.117699 ┆ 0.11938   ┆ … ┆ 0.043902  ┆ 1         ┆ 2       ┆ 342       │\n",
-      "│ Options    ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
-      "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴─────────┴───────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "6aab06d3",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "cluster_rows = []\n",
     "for cs, explorer in explorers.items():\n",
@@ -637,16 +478,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6133616",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002876,
-     "end_time": "2026-08-20T08:34:07.494192+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.491316+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "79c71796",
+   "metadata": {},
    "source": [
     "Read the table as a tuple: (rank1 Sharpe, rank10 Sharpe, spread, fold-SE,\n",
     "folds-positive). A small rank1→rank10 spread relative to the fold-SE signals\n",
@@ -657,16 +490,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4628dc5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002917,
-     "end_time": "2026-08-20T08:34:07.500115+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.497198+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "bfc62581",
+   "metadata": {},
    "source": [
     "## Overview Table\n",
     "\n",
@@ -678,60 +503,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "a206af57",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.506569Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.506481Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.917108Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.916700Z"
-    },
-    "papermill": {
-     "duration": 0.414685,
-     "end_time": "2026-08-20T08:34:07.917739+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.503054+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (9, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>asset_class</th><th>frequency</th><th>universe</th><th>cost_bps</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;ETFs&quot;</td><td>&quot;equity_etf&quot;</td><td>&quot;daily&quot;</td><td>100</td><td>10.0</td></tr><tr><td>&quot;Crypto&quot;</td><td>&quot;crypto&quot;</td><td>&quot;8h&quot;</td><td>19</td><td>3.0</td></tr><tr><td>&quot;NASDAQ-100&quot;</td><td>&quot;equity_micro&quot;</td><td>&quot;15min&quot;</td><td>115</td><td>10.0</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>&quot;equity_options&quot;</td><td>&quot;daily&quot;</td><td>633</td><td>6.5</td></tr><tr><td>&quot;US Firms&quot;</td><td>&quot;equity_firm&quot;</td><td>&quot;monthly&quot;</td><td>2500</td><td>12.5</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>&quot;fx&quot;</td><td>&quot;daily&quot;</td><td>20</td><td>10.0</td></tr><tr><td>&quot;CME Futures&quot;</td><td>&quot;futures&quot;</td><td>&quot;daily&quot;</td><td>30</td><td>10.0</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>&quot;options&quot;</td><td>&quot;daily&quot;</td><td>627</td><td>10.0</td></tr><tr><td>&quot;US Equities&quot;</td><td>&quot;equity_panel&quot;</td><td>&quot;daily&quot;</td><td>3199</td><td>12.5</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (9, 5)\n",
-       "┌─────────────────┬────────────────┬───────────┬──────────┬──────────┐\n",
-       "│ case_study      ┆ asset_class    ┆ frequency ┆ universe ┆ cost_bps │\n",
-       "│ ---             ┆ ---            ┆ ---       ┆ ---      ┆ ---      │\n",
-       "│ str             ┆ str            ┆ str       ┆ i64      ┆ f64      │\n",
-       "╞═════════════════╪════════════════╪═══════════╪══════════╪══════════╡\n",
-       "│ ETFs            ┆ equity_etf     ┆ daily     ┆ 100      ┆ 10.0     │\n",
-       "│ Crypto          ┆ crypto         ┆ 8h        ┆ 19       ┆ 3.0      │\n",
-       "│ NASDAQ-100      ┆ equity_micro   ┆ 15min     ┆ 115      ┆ 10.0     │\n",
-       "│ S&P 500 Eq+Opt  ┆ equity_options ┆ daily     ┆ 633      ┆ 6.5      │\n",
-       "│ US Firms        ┆ equity_firm    ┆ monthly   ┆ 2500     ┆ 12.5     │\n",
-       "│ FX Pairs        ┆ fx             ┆ daily     ┆ 20       ┆ 10.0     │\n",
-       "│ CME Futures     ┆ futures        ┆ daily     ┆ 30       ┆ 10.0     │\n",
-       "│ S&P 500 Options ┆ options        ┆ daily     ┆ 627      ┆ 10.0     │\n",
-       "│ US Equities     ┆ equity_panel   ┆ daily     ┆ 3199     ┆ 12.5     │\n",
-       "└─────────────────┴────────────────┴───────────┴──────────┴──────────┘"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "c1958182",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "overview_rows = []\n",
     "for cs, explorer in explorers.items():\n",
@@ -770,16 +545,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f44a2f3f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003129,
-     "end_time": "2026-08-20T08:34:07.924042+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.920913+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "e7aaa13d",
+   "metadata": {},
    "source": [
     "The test bed covers equity ETFs, crypto perpetuals, intraday microstructure,\n",
     "equity+options, firm characteristics, FX, futures, pure options, and a broad\n",
@@ -790,16 +557,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e262d5a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002875,
-     "end_time": "2026-08-20T08:34:07.929928+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.927053+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f3920af5",
+   "metadata": {},
    "source": [
     "## Model IC Comparison\n",
     "\n",
@@ -810,23 +569,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "7cb43def",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.936304Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.936229Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.943933Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.943642Z"
-    },
-    "papermill": {
-     "duration": 0.011676,
-     "end_time": "2026-08-20T08:34:07.944528+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.932852+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "561fbc67",
+   "metadata": {},
    "outputs": [],
    "source": [
     "ic_rows = []\n",
@@ -882,23 +627,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "eba9359d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.951098Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.951031Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.953660Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.953357Z"
-    },
-    "papermill": {
-     "duration": 0.006415,
-     "end_time": "2026-08-20T08:34:07.954134+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.947719+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "075d3a41",
+   "metadata": {},
    "outputs": [],
    "source": [
     "if not ic_df.is_empty():\n",
@@ -909,92 +640,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d4fcfa8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002834,
-     "end_time": "2026-08-20T08:34:07.959992+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.957158+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "7b79bdff",
+   "metadata": {},
    "source": [
     "### Mean IC by Model Family"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f37524bc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.966198Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.966125Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.968332Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.968112Z"
-    },
-    "papermill": {
-     "duration": 0.005814,
-     "end_time": "2026-08-20T08:34:07.968636+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.962822+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (9, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>gbm</th><th>linear</th><th>deep_learning</th><th>latent_factors</th><th>tabular_dl</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;CME Futures&quot;</td><td>0.015521</td><td>-0.009466</td><td>-0.014893</td><td>0.018133</td><td>-0.007905</td></tr><tr><td>&quot;Crypto&quot;</td><td>0.017063</td><td>-0.0178</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;ETFs&quot;</td><td>0.026285</td><td>0.033106</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>-0.004202</td><td>-0.001396</td><td>0.008934</td><td>null</td><td>-0.000892</td></tr><tr><td>&quot;NASDAQ-100&quot;</td><td>null</td><td>0.002387</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>-0.003597</td><td>-0.006396</td><td>0.00649</td><td>0.002445</td><td>0.006562</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>0.000091</td><td>-0.009068</td><td>0.004082</td><td>null</td><td>0.003241</td></tr><tr><td>&quot;US Equities&quot;</td><td>0.025116</td><td>0.01163</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;US Firms&quot;</td><td>0.060253</td><td>-0.008456</td><td>null</td><td>-0.008372</td><td>0.027168</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (9, 6)\n",
-       "┌─────────────────┬───────────┬───────────┬───────────────┬────────────────┬────────────┐\n",
-       "│ case_study      ┆ gbm       ┆ linear    ┆ deep_learning ┆ latent_factors ┆ tabular_dl │\n",
-       "│ ---             ┆ ---       ┆ ---       ┆ ---           ┆ ---            ┆ ---        │\n",
-       "│ str             ┆ f64       ┆ f64       ┆ f64           ┆ f64            ┆ f64        │\n",
-       "╞═════════════════╪═══════════╪═══════════╪═══════════════╪════════════════╪════════════╡\n",
-       "│ CME Futures     ┆ 0.015521  ┆ -0.009466 ┆ -0.014893     ┆ 0.018133       ┆ -0.007905  │\n",
-       "│ Crypto          ┆ 0.017063  ┆ -0.0178   ┆ null          ┆ null           ┆ null       │\n",
-       "│ ETFs            ┆ 0.026285  ┆ 0.033106  ┆ null          ┆ null           ┆ null       │\n",
-       "│ FX Pairs        ┆ -0.004202 ┆ -0.001396 ┆ 0.008934      ┆ null           ┆ -0.000892  │\n",
-       "│ NASDAQ-100      ┆ null      ┆ 0.002387  ┆ null          ┆ null           ┆ null       │\n",
-       "│ S&P 500 Eq+Opt  ┆ -0.003597 ┆ -0.006396 ┆ 0.00649       ┆ 0.002445       ┆ 0.006562   │\n",
-       "│ S&P 500 Options ┆ 0.000091  ┆ -0.009068 ┆ 0.004082      ┆ null           ┆ 0.003241   │\n",
-       "│ US Equities     ┆ 0.025116  ┆ 0.01163   ┆ null          ┆ null           ┆ null       │\n",
-       "│ US Firms        ┆ 0.060253  ┆ -0.008456 ┆ null          ┆ -0.008372      ┆ 0.027168   │\n",
-       "└─────────────────┴───────────┴───────────┴───────────────┴────────────────┴────────────┘"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "fc5bce0d",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ic_pivot"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "91419fb6",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002887,
-     "end_time": "2026-08-20T08:34:07.974634+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.971747+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "1a054cab",
+   "metadata": {},
    "source": [
     "No single model family dominates across all nine case studies. GBM tends\n",
     "to produce the best or near-best IC in most datasets (especially futures\n",
@@ -1007,16 +672,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23aaaa47",
+   "id": "396c25b2",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003372,
-     "end_time": "2026-08-20T08:34:07.981093+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.977721+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## Backtest Comparison\n",
@@ -1028,23 +686,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "4a0c0c96",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.987671Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.987608Z",
-     "iopub.status.idle": "2026-08-20T08:34:07.992804Z",
-     "shell.execute_reply": "2026-08-20T08:34:07.992499Z"
-    },
-    "papermill": {
-     "duration": 0.009136,
-     "end_time": "2026-08-20T08:34:07.993241+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.984105+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "c966adad",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def build_backtest_rows():\n",
@@ -1188,23 +832,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "498f1de3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:07.999779Z",
-     "iopub.status.busy": "2026-08-20T08:34:07.999713Z",
-     "iopub.status.idle": "2026-08-20T08:34:11.018715Z",
-     "shell.execute_reply": "2026-08-20T08:34:11.018170Z"
-    },
-    "papermill": {
-     "duration": 3.022827,
-     "end_time": "2026-08-20T08:34:11.019061+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:07.996234+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "e501e738",
+   "metadata": {},
    "outputs": [],
    "source": [
     "bt_rows = build_backtest_rows()"
@@ -1212,49 +842,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "099f6162",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:11.025979Z",
-     "iopub.status.busy": "2026-08-20T08:34:11.025834Z",
-     "iopub.status.idle": "2026-08-20T08:34:11.028689Z",
-     "shell.execute_reply": "2026-08-20T08:34:11.028263Z"
-    },
-    "papermill": {
-     "duration": 0.006608,
-     "end_time": "2026-08-20T08:34:11.028923+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:11.022315+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Pipeline Comparison:\n",
-      "shape: (9, 5)\n",
-      "┌─────────────────┬───────────────┬──────────────┬────────────────┬────────────────┐\n",
-      "│ case_study      ┆ signal_sharpe ┆ alloc_sharpe ┆ survives_costs ┆ managed_sharpe │\n",
-      "│ ---             ┆ ---           ┆ ---          ┆ ---            ┆ ---            │\n",
-      "│ str             ┆ f64           ┆ f64          ┆ bool           ┆ f64            │\n",
-      "╞═════════════════╪═══════════════╪══════════════╪════════════════╪════════════════╡\n",
-      "│ ETFs            ┆ null          ┆ null         ┆ null           ┆ null           │\n",
-      "│ Crypto          ┆ null          ┆ null         ┆ null           ┆ null           │\n",
-      "│ NASDAQ-100      ┆ null          ┆ null         ┆ null           ┆ null           │\n",
-      "│ S&P 500 Eq+Opt  ┆ 1.482389      ┆ 1.587153     ┆ true           ┆ 2.391868       │\n",
-      "│ US Firms        ┆ 1.7254        ┆ null         ┆ true           ┆ null           │\n",
-      "│ FX Pairs        ┆ -0.004311     ┆ 0.046721     ┆ true           ┆ 0.027212       │\n",
-      "│ CME Futures     ┆ 1.126253      ┆ 1.189192     ┆ true           ┆ 1.264021       │\n",
-      "│ S&P 500 Options ┆ 0.001681      ┆ 0.001681     ┆ null           ┆ null           │\n",
-      "│ US Equities     ┆ null          ┆ null         ┆ null           ┆ null           │\n",
-      "└─────────────────┴───────────────┴──────────────┴────────────────┴────────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "99b6ea4d",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "bt_df = pl.DataFrame(bt_rows)\n",
     "print(\"\\nPipeline Comparison:\")\n",
@@ -1271,16 +862,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86673541",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002915,
-     "end_time": "2026-08-20T08:34:11.034778+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:11.031863+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f4f98a8c",
+   "metadata": {},
    "source": [
     "Eight of nine case studies produce positive signal-stage Sharpe; only\n",
     "FX Pairs enters the pipeline negative (-0.00) and stays marginal through\n",
@@ -1296,16 +879,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9946830c",
+   "id": "7e3863ef",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003357,
-     "end_time": "2026-08-20T08:34:11.041300+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:11.037943+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## Paired-Bootstrap Comparison vs Equal-Weight Benchmark\n",
@@ -1333,23 +909,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "c47c0d40",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:11.048509Z",
-     "iopub.status.busy": "2026-08-20T08:34:11.048390Z",
-     "iopub.status.idle": "2026-08-20T08:34:11.054496Z",
-     "shell.execute_reply": "2026-08-20T08:34:11.053982Z"
-    },
-    "papermill": {
-     "duration": 0.010525,
-     "end_time": "2026-08-20T08:34:11.054831+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:11.044306+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "b852de2c",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _benchmark_returns_from_artifact(\n",
@@ -1428,60 +990,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "7c609f51",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:11.062009Z",
-     "iopub.status.busy": "2026-08-20T08:34:11.061901Z",
-     "iopub.status.idle": "2026-08-20T08:34:15.247793Z",
-     "shell.execute_reply": "2026-08-20T08:34:15.246555Z"
-    },
-    "papermill": {
-     "duration": 4.189811,
-     "end_time": "2026-08-20T08:34:15.248365+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:11.058554+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Paired Bootstrap: rank-1 vs equal-weight ===\n",
-      "shape: (5, 9)\n",
-      "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬─────────┐\n",
-      "│ case_study ┆ label     ┆ benchmark ┆ sharpe_di ┆ … ┆ sharpe_di ┆ info_rati ┆ prob_wins ┆ p_value │\n",
-      "│ ---        ┆ ---       ┆ _label    ┆ ff        ┆   ┆ ff_ci_hi  ┆ o         ┆ ---       ┆ ---     │\n",
-      "│ str        ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ f64       ┆ f64     │\n",
-      "│            ┆           ┆ str       ┆ f64       ┆   ┆ f64       ┆ f64       ┆           ┆         │\n",
-      "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═════════╡\n",
-      "│ S&P 500    ┆ fwd_ret_r ┆ fwd_ret_r ┆ 1.759621  ┆ … ┆ 2.8199    ┆ 1.026232  ┆ 0.9965    ┆ 0.003   │\n",
-      "│ Eq+Opt     ┆ isk_adj_5 ┆ isk_adj_5 ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "│            ┆ d         ┆ d         ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "│ US Firms   ┆ fwd_ret_1 ┆ fwd_ret_1 ┆ 2.398494  ┆ … ┆ 3.428543  ┆ 2.019403  ┆ 1.0       ┆ 0.0     │\n",
-      "│            ┆ m_win     ┆ m_win     ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "│ FX Pairs   ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ -0.128052 ┆ … ┆ 0.695079  ┆ -0.117171 ┆ 0.381     ┆ 0.7675  │\n",
-      "│            ┆ 1d        ┆ 1d        ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "│ CME        ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ 0.674617  ┆ … ┆ 1.846019  ┆ 0.965434  ┆ 0.858     ┆ 0.2605  │\n",
-      "│ Futures    ┆ d         ┆ d         ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "│ S&P 500    ┆ ret_to_ex ┆ ret_to_ex ┆ -0.705173 ┆ … ┆ 0.912071  ┆ -0.1548   ┆ 0.205     ┆ 0.4385  │\n",
-      "│ Options    ┆ piry      ┆ piry      ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-      "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴─────────┘\n",
-      "\n",
-      "Skipped case studies:\n",
-      "  - etfs                              no_signal_stage_candidates\n",
-      "  - crypto_perps_funding              no_signal_stage_candidates\n",
-      "  - nasdaq100_microstructure          no_signal_stage_candidates\n",
-      "  - us_equities_panel                 no_signal_stage_candidates\n",
-      "\n",
-      "paired=5/9, skipped=4/9\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "73c225af",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -1657,16 +1169,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f106d95",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002952,
-     "end_time": "2026-08-20T08:34:15.254571+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:15.251619+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "38474498",
+   "metadata": {},
    "source": [
     "Read each row as: rank-1 challenger annualized Sharpe **minus** equal-weight\n",
     "benchmark Sharpe, with a 95 % CI from the paired stationary block bootstrap\n",
@@ -1682,16 +1186,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5587d61a",
+   "id": "fb43d511",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.002878,
-     "end_time": "2026-08-20T08:34:15.260331+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:15.257453+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## Paired metrics — full coverage for strategy-analysis notebook\n",
@@ -1722,23 +1219,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "60da6349",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:15.266992Z",
-     "iopub.status.busy": "2026-08-20T08:34:15.266859Z",
-     "iopub.status.idle": "2026-08-20T08:34:15.276620Z",
-     "shell.execute_reply": "2026-08-20T08:34:15.276171Z"
-    },
-    "papermill": {
-     "duration": 0.013885,
-     "end_time": "2026-08-20T08:34:15.277072+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:15.263187+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "4999758b",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _full_strategy_spec_from_backtest(db: sqlite3.Connection, bt_hash: str) -> dict | None:\n",
@@ -2097,23 +1580,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "861fae81",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:15.283546Z",
-     "iopub.status.busy": "2026-08-20T08:34:15.283452Z",
-     "iopub.status.idle": "2026-08-20T08:34:15.287850Z",
-     "shell.execute_reply": "2026-08-20T08:34:15.287272Z"
-    },
-    "papermill": {
-     "duration": 0.008359,
-     "end_time": "2026-08-20T08:34:15.288384+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:15.280025+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "f1e5f4ce",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _populate_pair(\n",
@@ -2233,23 +1702,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "9f702350",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:15.294785Z",
-     "iopub.status.busy": "2026-08-20T08:34:15.294716Z",
-     "iopub.status.idle": "2026-08-20T08:34:29.690293Z",
-     "shell.execute_reply": "2026-08-20T08:34:29.689738Z"
-    },
-    "papermill": {
-     "duration": 14.399929,
-     "end_time": "2026-08-20T08:34:29.691244+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:15.291315+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "9bc9b98d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "extra_paired_rows: list[dict] = []\n",
@@ -2452,33 +1907,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "6292d519",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:29.701850Z",
-     "iopub.status.busy": "2026-08-20T08:34:29.701719Z",
-     "iopub.status.idle": "2026-08-20T08:34:29.704832Z",
-     "shell.execute_reply": "2026-08-20T08:34:29.704395Z"
-    },
-    "papermill": {
-     "duration": 0.008558,
-     "end_time": "2026-08-20T08:34:29.705188+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.696630+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "extra_paired=21 rows across 5 case studies\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5a22cd5e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "extra_paired_df = pl.DataFrame(extra_paired_rows)\n",
     "if extra_paired_df.is_empty():\n",
@@ -2493,114 +1925,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "044b9a4e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004324,
-     "end_time": "2026-08-20T08:34:29.715325+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.711001+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "8257671b",
+   "metadata": {},
    "source": [
     "### Extended Paired-Bootstrap Coverage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "d203aff0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:29.721886Z",
-     "iopub.status.busy": "2026-08-20T08:34:29.721822Z",
-     "iopub.status.idle": "2026-08-20T08:34:29.724481Z",
-     "shell.execute_reply": "2026-08-20T08:34:29.724144Z"
-    },
-    "papermill": {
-     "duration": 0.006471,
-     "end_time": "2026-08-20T08:34:29.724856+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.718385+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (21, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>cs</th><th>kind</th><th>label</th><th>benchmark_label</th><th>n_overlap</th><th>sharpe_diff</th><th>sharpe_diff_ci_lo</th><th>sharpe_diff_ci_hi</th><th>info_ratio</th><th>p_value</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;equal_weight_holdout_side_arti…</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>242</td><td>-2.401451</td><td>-4.06315</td><td>-0.783935</td><td>-2.691758</td><td>0.0085</td></tr><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;val_rank1_self&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>242</td><td>-3.139415</td><td>-5.278208</td><td>-1.021425</td><td>NaN</td><td>0.0065</td></tr><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;signal_leader&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>497</td><td>0.0</td><td>0.0</td><td>0.0</td><td>NaN</td><td>1.0</td></tr><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;allocation_leader&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>497</td><td>0.197167</td><td>0.144714</td><td>0.287969</td><td>7.909009</td><td>0.0</td></tr><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;cost_sensitivity_leader&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>497</td><td>0.954119</td><td>-0.453653</td><td>2.123493</td><td>0.055207</td><td>0.1555</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;cme_futures&quot;</td><td>&quot;allocation_leader&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>1289</td><td>0.048035</td><td>0.034035</td><td>0.064634</td><td>2.550234</td><td>0.0</td></tr><tr><td>&quot;cme_futures&quot;</td><td>&quot;cost_sensitivity_leader&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>1289</td><td>0.37539</td><td>-0.252267</td><td>1.004101</td><td>-0.021609</td><td>0.237</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;equal_weight_holdout_side_arti…</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>247</td><td>-1.452696</td><td>-3.518484</td><td>0.778201</td><td>0.552341</td><td>0.1905</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;val_rank1_self&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>247</td><td>1.093054</td><td>-1.303685</td><td>3.349853</td><td>NaN</td><td>0.34</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;signal_leader&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>497</td><td>0.0</td><td>0.0</td><td>0.0</td><td>NaN</td><td>1.0</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (21, 10)\n",
-       "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬─────────┐\n",
-       "│ cs         ┆ kind      ┆ label     ┆ benchmark ┆ … ┆ sharpe_di ┆ sharpe_di ┆ info_rati ┆ p_value │\n",
-       "│ ---        ┆ ---       ┆ ---       ┆ _label    ┆   ┆ ff_ci_lo  ┆ ff_ci_hi  ┆ o         ┆ ---     │\n",
-       "│ str        ┆ str       ┆ str       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ f64     │\n",
-       "│            ┆           ┆           ┆ str       ┆   ┆ f64       ┆ f64       ┆ f64       ┆         │\n",
-       "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═════════╡\n",
-       "│ sp500_equi ┆ equal_wei ┆ fwd_ret_r ┆ fwd_ret_r ┆ … ┆ -4.06315  ┆ -0.783935 ┆ -2.691758 ┆ 0.0085  │\n",
-       "│ ty_option_ ┆ ght_holdo ┆ isk_adj_5 ┆ isk_adj_5 ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ analytics  ┆ ut_side_a ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│            ┆ rti…      ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_equi ┆ val_rank1 ┆ fwd_ret_r ┆ fwd_ret_r ┆ … ┆ -5.278208 ┆ -1.021425 ┆ NaN       ┆ 0.0065  │\n",
-       "│ ty_option_ ┆ _self     ┆ isk_adj_5 ┆ isk_adj_5 ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ analytics  ┆           ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_equi ┆ signal_le ┆ fwd_ret_r ┆ fwd_ret_r ┆ … ┆ 0.0       ┆ 0.0       ┆ NaN       ┆ 1.0     │\n",
-       "│ ty_option_ ┆ ader      ┆ isk_adj_5 ┆ isk_adj_5 ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ analytics  ┆           ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_equi ┆ allocatio ┆ fwd_ret_r ┆ fwd_ret_r ┆ … ┆ 0.144714  ┆ 0.287969  ┆ 7.909009  ┆ 0.0     │\n",
-       "│ ty_option_ ┆ n_leader  ┆ isk_adj_5 ┆ isk_adj_5 ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ analytics  ┆           ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_equi ┆ cost_sens ┆ fwd_ret_r ┆ fwd_ret_r ┆ … ┆ -0.453653 ┆ 2.123493  ┆ 0.055207  ┆ 0.1555  │\n",
-       "│ ty_option_ ┆ itivity_l ┆ isk_adj_5 ┆ isk_adj_5 ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ analytics  ┆ eader     ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ …          ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …       │\n",
-       "│ cme_future ┆ allocatio ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ 0.034035  ┆ 0.064634  ┆ 2.550234  ┆ 0.0     │\n",
-       "│ s          ┆ n_leader  ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ cme_future ┆ cost_sens ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ -0.252267 ┆ 1.004101  ┆ -0.021609 ┆ 0.237   │\n",
-       "│ s          ┆ itivity_l ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
-       "│            ┆ eader     ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_opti ┆ equal_wei ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ -3.518484 ┆ 0.778201  ┆ 0.552341  ┆ 0.1905  │\n",
-       "│ ons        ┆ ght_holdo ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
-       "│            ┆ ut_side_a ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-       "│            ┆ rti…      ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_opti ┆ val_rank1 ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ -1.303685 ┆ 3.349853  ┆ NaN       ┆ 0.34    │\n",
-       "│ ons        ┆ _self     ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
-       "│ sp500_opti ┆ signal_le ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ 0.0       ┆ 0.0       ┆ NaN       ┆ 1.0     │\n",
-       "│ ons        ┆ ader      ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
-       "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴─────────┘"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "36de9ca9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "extra_paired_df"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f2aa6c8f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004449,
-     "end_time": "2026-08-20T08:34:29.732750+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.728301+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "1c9b6cb5",
+   "metadata": {},
    "source": [
     "Summary by `benchmark_kind` shows which extension pair types landed for\n",
     "which CSs. ``equal_weight_holdout_side_artifact`` and ``val_rank1_self``\n",
@@ -2612,16 +1956,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66b69348",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003016,
-     "end_time": "2026-08-20T08:34:29.739359+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.736343+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "91f34790",
+   "metadata": {},
    "source": [
     "## Sharpe Progression\n",
     "\n",
@@ -2633,23 +1969,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "cf765b5f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:29.746014Z",
-     "iopub.status.busy": "2026-08-20T08:34:29.745942Z",
-     "iopub.status.idle": "2026-08-20T08:34:30.200331Z",
-     "shell.execute_reply": "2026-08-20T08:34:30.199871Z"
-    },
-    "papermill": {
-     "duration": 0.45855,
-     "end_time": "2026-08-20T08:34:30.200887+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:29.742337+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "6b2db63c",
+   "metadata": {},
    "outputs": [],
    "source": [
     "prog_rows = []\n",
@@ -2707,88 +2029,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2194419c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003073,
-     "end_time": "2026-08-20T08:34:30.207354+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.204281+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "85790725",
+   "metadata": {},
    "source": [
     "### Sharpe Progression (best prediction per CS)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "13fac9a9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:30.214465Z",
-     "iopub.status.busy": "2026-08-20T08:34:30.214388Z",
-     "iopub.status.idle": "2026-08-20T08:34:30.216567Z",
-     "shell.execute_reply": "2026-08-20T08:34:30.216281Z"
-    },
-    "papermill": {
-     "duration": 0.006474,
-     "end_time": "2026-08-20T08:34:30.216841+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.210367+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (5, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>signal</th><th>allocation</th><th>cost_sensitivity</th><th>risk_overlay</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;CME Futures&quot;</td><td>1.126253</td><td>1.189192</td><td>1.236469</td><td>1.232756</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>-0.004311</td><td>0.015739</td><td>null</td><td>null</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>1.482389</td><td>1.587153</td><td>null</td><td>null</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>0.001681</td><td>0.001681</td><td>null</td><td>null</td></tr><tr><td>&quot;US Firms&quot;</td><td>2.746176</td><td>2.758884</td><td>null</td><td>null</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (5, 5)\n",
-       "┌─────────────────┬───────────┬────────────┬──────────────────┬──────────────┐\n",
-       "│ case_study      ┆ signal    ┆ allocation ┆ cost_sensitivity ┆ risk_overlay │\n",
-       "│ ---             ┆ ---       ┆ ---        ┆ ---              ┆ ---          │\n",
-       "│ str             ┆ f64       ┆ f64        ┆ f64              ┆ f64          │\n",
-       "╞═════════════════╪═══════════╪════════════╪══════════════════╪══════════════╡\n",
-       "│ CME Futures     ┆ 1.126253  ┆ 1.189192   ┆ 1.236469         ┆ 1.232756     │\n",
-       "│ FX Pairs        ┆ -0.004311 ┆ 0.015739   ┆ null             ┆ null         │\n",
-       "│ S&P 500 Eq+Opt  ┆ 1.482389  ┆ 1.587153   ┆ null             ┆ null         │\n",
-       "│ S&P 500 Options ┆ 0.001681  ┆ 0.001681   ┆ null             ┆ null         │\n",
-       "│ US Firms        ┆ 2.746176  ┆ 2.758884   ┆ null             ┆ null         │\n",
-       "└─────────────────┴───────────┴────────────┴──────────────────┴──────────────┘"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "150ca2cd",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "prog_pivot"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d4e2450a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003155,
-     "end_time": "2026-08-20T08:34:30.223218+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.220063+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "9c77204f",
+   "metadata": {},
    "source": [
     "Most case studies only have complete data through the signal and allocation\n",
     "stages for their best prediction hash. Where the full pipeline is available\n",
@@ -2801,16 +2061,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a76be9a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00316,
-     "end_time": "2026-08-20T08:34:30.229553+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.226393+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "14222c6e",
+   "metadata": {},
    "source": [
     "## Rank-1 Lineage\n",
     "\n",
@@ -2827,23 +2079,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "05361b3d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:30.236477Z",
-     "iopub.status.busy": "2026-08-20T08:34:30.236367Z",
-     "iopub.status.idle": "2026-08-20T08:34:30.689063Z",
-     "shell.execute_reply": "2026-08-20T08:34:30.688703Z"
-    },
-    "papermill": {
-     "duration": 0.457144,
-     "end_time": "2026-08-20T08:34:30.689748+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.232604+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "3fac7841",
+   "metadata": {},
    "outputs": [],
    "source": [
     "lineage_rows = []\n",
@@ -2903,51 +2141,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "e9d55c9a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:30.696862Z",
-     "iopub.status.busy": "2026-08-20T08:34:30.696783Z",
-     "iopub.status.idle": "2026-08-20T08:34:30.698843Z",
-     "shell.execute_reply": "2026-08-20T08:34:30.698588Z"
-    },
-    "papermill": {
-     "duration": 0.005965,
-     "end_time": "2026-08-20T08:34:30.699137+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.693172+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Rank-1 Lineage (locked stage path per CS) ===\n",
-      "shape: (5, 6)\n",
-      "┌────────────────┬────────────────┬───────────────┬────────────────┬───────────────┬───────────────┐\n",
-      "│ case_study     ┆ signal_source  ┆ signal_sharpe ┆ allocation_sha ┆ cost_sensitiv ┆ risk_overlay_ │\n",
-      "│ ---            ┆ ---            ┆ ---           ┆ rpe            ┆ ity_sharpe    ┆ sharpe        │\n",
-      "│ str            ┆ str            ┆ f64           ┆ ---            ┆ ---           ┆ ---           │\n",
-      "│                ┆                ┆               ┆ f64            ┆ f64           ┆ f64           │\n",
-      "╞════════════════╪════════════════╪═══════════════╪════════════════╪═══════════════╪═══════════════╡\n",
-      "│ S&P 500 Eq+Opt ┆ latent_factors ┆ 1.482         ┆ 1.587          ┆ null          ┆ null          │\n",
-      "│                ┆ /pca           ┆               ┆                ┆               ┆               │\n",
-      "│ US Firms       ┆ gbm/leaves_7_m ┆ 2.746         ┆ 2.759          ┆ null          ┆ null          │\n",
-      "│                ┆ ae             ┆               ┆                ┆               ┆               │\n",
-      "│ FX Pairs       ┆ linear/ridge_a ┆ -0.004        ┆ 0.016          ┆ null          ┆ null          │\n",
-      "│                ┆ 10000000.0     ┆               ┆                ┆               ┆               │\n",
-      "│ CME Futures    ┆ latent_factors ┆ 1.126         ┆ 1.189          ┆ 1.236         ┆ 1.233         │\n",
-      "│                ┆ /sdf           ┆               ┆                ┆               ┆               │\n",
-      "│ S&P 500        ┆ linear/ridge_a ┆ 0.002         ┆ 0.002          ┆ null          ┆ null          │\n",
-      "│ Options        ┆ 10000000.0     ┆               ┆                ┆               ┆               │\n",
-      "└────────────────┴────────────────┴───────────────┴────────────────┴───────────────┴───────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "12cb7fbe",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "lineage_df = pl.DataFrame(lineage_rows)\n",
     "if not lineage_df.is_empty():\n",
@@ -2966,16 +2163,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee0a54f1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003071,
-     "end_time": "2026-08-20T08:34:30.705283+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.702212+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "6ec7b150",
+   "metadata": {},
    "source": [
     "The lineage table shows how the rank-1 signal's Sharpe moves stage by\n",
     "stage. Case studies with blanks in later stages haven't run downstream\n",
@@ -2987,16 +2176,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "605516e1",
+   "id": "093e6f15",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003058,
-     "end_time": "2026-08-20T08:34:30.711516+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.708458+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## Holdout Integration\n",
@@ -3009,23 +2191,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "940a26f2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:30.718558Z",
-     "iopub.status.busy": "2026-08-20T08:34:30.718495Z",
-     "iopub.status.idle": "2026-08-20T08:34:30.723215Z",
-     "shell.execute_reply": "2026-08-20T08:34:30.722919Z"
-    },
-    "papermill": {
-     "duration": 0.008818,
-     "end_time": "2026-08-20T08:34:30.723520+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.714702+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "6be4a347",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _optional_metric(db: sqlite3.Connection, table: str, column: str, alias: str) -> str:\n",
@@ -3165,23 +2333,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "b4dfbde3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:30.730678Z",
-     "iopub.status.busy": "2026-08-20T08:34:30.730592Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.058839Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.058384Z"
-    },
-    "papermill": {
-     "duration": 1.332592,
-     "end_time": "2026-08-20T08:34:32.059398+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:30.726806+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "b820af02",
+   "metadata": {},
    "outputs": [],
    "source": [
     "holdout_rows = query_holdout_rows()"
@@ -3189,45 +2343,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "9852e075",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.066925Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.066847Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.068863Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.068620Z"
-    },
-    "papermill": {
-     "duration": 0.006332,
-     "end_time": "2026-08-20T08:34:32.069349+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.063017+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Holdout Results (5 entries) ===\n",
-      "shape: (5, 5)\n",
-      "┌─────────────────┬────────────────┬────────────┬────────────────┬────────────────┐\n",
-      "│ case_study      ┆ family         ┆ holdout_ic ┆ holdout_sharpe ┆ holdout_max_dd │\n",
-      "│ ---             ┆ ---            ┆ ---        ┆ ---            ┆ ---            │\n",
-      "│ str             ┆ str            ┆ f64        ┆ f64            ┆ f64            │\n",
-      "╞═════════════════╪════════════════╪════════════╪════════════════╪════════════════╡\n",
-      "│ S&P 500 Eq+Opt  ┆ latent_factors ┆ 0.035666   ┆ -0.727829      ┆ -0.118632      │\n",
-      "│ US Firms        ┆ gbm            ┆ 0.061034   ┆ 2.612811       ┆ -0.051978      │\n",
-      "│ FX Pairs        ┆ linear         ┆ 0.040025   ┆ -0.157475      ┆ -0.021188      │\n",
-      "│ CME Futures     ┆ gbm            ┆ 0.063839   ┆ 1.14181        ┆ -0.231299      │\n",
-      "│ S&P 500 Options ┆ linear         ┆ -0.004298  ┆ 1.094734       ┆ -0.364809      │\n",
-      "└─────────────────┴────────────────┴────────────┴────────────────┴────────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "c38d518e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "holdout_df = pl.DataFrame(holdout_rows)\n",
     "if not holdout_df.is_empty():\n",
@@ -3239,16 +2358,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c48a538b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003105,
-     "end_time": "2026-08-20T08:34:32.075726+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.072621+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "8c610ff0",
+   "metadata": {},
    "source": [
     "Six of nine holdout backtests are positive: US Firms (+1.77), CME Futures\n",
     "(+1.11), ETFs (+1.00), sp500_options Rung-3 HTM+liquid (+0.97), NASDAQ-100\n",
@@ -3273,16 +2384,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2224031",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00323,
-     "end_time": "2026-08-20T08:34:32.082202+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.078972+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "12985247",
+   "metadata": {},
    "source": [
     "## Stage Attrition Funnel\n",
     "\n",
@@ -3303,38 +2406,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "0394ed34",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.089723Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.089648Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.096625Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.096255Z"
-    },
-    "papermill": {
-     "duration": 0.011491,
-     "end_time": "2026-08-20T08:34:32.097292+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.085801+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Stage Attrition Funnel ===\n",
-      "  good_predictor        █████████  9/9\n",
-      "  tradable_gross        ████░░░░░  4/9\n",
-      "  cost_surviving        ████░░░░░  4/9\n",
-      "  risk_tolerable        ███░░░░░░  3/9\n",
-      "  holdout_valid         ███░░░░░░  3/9\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "562fe1f7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "attrition = {\n",
     "    \"good_predictor\": 0,  # positive IC\n",
@@ -3387,16 +2462,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cd2732d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005423,
-     "end_time": "2026-08-20T08:34:32.109096+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.103673+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "b74bd089",
+   "metadata": {},
    "source": [
     "The funnel reads top-down with per-stage independent counts: 9 of 9\n",
     "case studies produce positive IC, 8 of 9 produce positive signal-stage\n",
@@ -3413,16 +2480,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17491cb2",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005581,
-     "end_time": "2026-08-20T08:34:32.118655+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.113074+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5da47d39",
+   "metadata": {},
    "source": [
     "## Measurement Quality Disclosures\n",
     "\n",
@@ -3439,55 +2498,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "c738a98f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.126924Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.126807Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.134395Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.133981Z"
-    },
-    "papermill": {
-     "duration": 0.011768,
-     "end_time": "2026-08-20T08:34:32.134718+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.122950+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Measurement Quality Disclosures ===\n",
-      "shape: (9, 8)\n",
-      "┌────────────┬────────────┬────────────┬────────────┬────────────┬─────────┬───────────┬───────────┐\n",
-      "│ case_study ┆ rank1_val_ ┆ rank1_rank ┆ fold_sharp ┆ n_folds_po ┆ n_folds ┆ holdout_s ┆ validatio │\n",
-      "│ ---        ┆ sharpe     ┆ 10_spread  ┆ e_se       ┆ sitive     ┆ ---     ┆ harpe     ┆ n_holdout │\n",
-      "│ str        ┆ ---        ┆ ---        ┆ ---        ┆ ---        ┆ i64     ┆ ---       ┆ _decay    │\n",
-      "│            ┆ f64        ┆ f64        ┆ f64        ┆ i64        ┆         ┆ f64       ┆ ---       │\n",
-      "│            ┆            ┆            ┆            ┆            ┆         ┆           ┆ f64       │\n",
-      "╞════════════╪════════════╪════════════╪════════════╪════════════╪═════════╪═══════════╪═══════════╡\n",
-      "│ ETFs       ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
-      "│ Crypto     ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
-      "│ NASDAQ-100 ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
-      "│ S&P 500    ┆ 1.482389   ┆ 0.475608   ┆ 0.104766   ┆ 2          ┆ 2       ┆ -0.727829 ┆ 2.210218  │\n",
-      "│ Eq+Opt     ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
-      "│ US Firms   ┆ 2.746176   ┆ 0.091765   ┆ 2.376608   ┆ 10         ┆ 10      ┆ 2.612811  ┆ 0.133365  │\n",
-      "│ FX Pairs   ┆ -0.004311  ┆ 0.080718   ┆ 0.270165   ┆ 3          ┆ 8       ┆ -0.157475 ┆ 0.153164  │\n",
-      "│ CME        ┆ 1.126253   ┆ 0.346448   ┆ 0.273758   ┆ 3          ┆ 5       ┆ 1.14181   ┆ -0.015557 │\n",
-      "│ Futures    ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
-      "│ S&P 500    ┆ 0.001681   ┆ 0.11938    ┆ 0.043902   ┆ 1          ┆ 2       ┆ 1.094734  ┆ -1.093054 │\n",
-      "│ Options    ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
-      "│ US         ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
-      "│ Equities   ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
-      "└────────────┴────────────┴────────────┴────────────┴────────────┴─────────┴───────────┴───────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "cd1442a1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "measurement_rows = []\n",
     "for cs in ALL_CASE_STUDIES:\n",
@@ -3541,16 +2555,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbafb471",
+   "id": "3f1b4ccf",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003237,
-     "end_time": "2026-08-20T08:34:32.141668+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.138431+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## Variant Analysis\n",
@@ -3562,23 +2569,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "7f4c6f59",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.148837Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.148770Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.151401Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.151132Z"
-    },
-    "papermill": {
-     "duration": 0.006682,
-     "end_time": "2026-08-20T08:34:32.151642+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.144960+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "bda38edb",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def build_variant_rows():\n",
@@ -3634,16 +2627,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa59b9cb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003164,
-     "end_time": "2026-08-20T08:34:32.158112+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.154948+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "c537e90c",
+   "metadata": {},
    "source": [
     "The schema is declared rather than inferred. Polars reads the leading rows to guess a column's\n",
     "type, and a registry that has no metrics yet contributes rows whose `ic` and `sharpe` are all\n",
@@ -3654,23 +2639,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "706c30b3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.165242Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.165174Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.231075Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.230495Z"
-    },
-    "papermill": {
-     "duration": 0.070207,
-     "end_time": "2026-08-20T08:34:32.231607+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.161400+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "58ef2898",
+   "metadata": {},
    "outputs": [],
    "source": [
     "variant_rows = build_variant_rows()"
@@ -3678,49 +2649,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "f875e502",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.239209Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.239129Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.242803Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.242452Z"
-    },
-    "papermill": {
-     "duration": 0.007946,
-     "end_time": "2026-08-20T08:34:32.243134+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.235188+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Variant Analysis: 385 variants ===\n",
-      "shape: (9, 3)\n",
-      "┌─────────────────┬─────┬──────────────┐\n",
-      "│ case_study      ┆ n   ┆ pct_positive │\n",
-      "│ ---             ┆ --- ┆ ---          │\n",
-      "│ str             ┆ u32 ┆ f64          │\n",
-      "╞═════════════════╪═════╪══════════════╡\n",
-      "│ CME Futures     ┆ 50  ┆ 54.0         │\n",
-      "│ Crypto          ┆ 43  ┆ 0.0          │\n",
-      "│ ETFs            ┆ 43  ┆ 0.0          │\n",
-      "│ FX Pairs        ┆ 49  ┆ 0.0          │\n",
-      "│ NASDAQ-100      ┆ 16  ┆ 0.0          │\n",
-      "│ S&P 500 Eq+Opt  ┆ 54  ┆ 100.0        │\n",
-      "│ S&P 500 Options ┆ 49  ┆ 4.081633     │\n",
-      "│ US Equities     ┆ 31  ┆ 0.0          │\n",
-      "│ US Firms        ┆ 50  ┆ 100.0        │\n",
-      "└─────────────────┴─────┴──────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "2451f6bc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "variant_df = pl.DataFrame(\n",
     "    variant_rows,\n",
@@ -3746,16 +2678,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74203a65",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003303,
-     "end_time": "2026-08-20T08:34:32.251463+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.248160+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "931338a1",
+   "metadata": {},
    "source": [
     "The `pct_positive` column reveals a stark divide: ETFs, S&P 500 Eq+Opt,\n",
     "S&P 500 Options, and US Equities have 96%+ variants with positive\n",
@@ -3772,16 +2696,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8aa0be0",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00326,
-     "end_time": "2026-08-20T08:34:32.258046+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.254786+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "28a02b3d",
+   "metadata": {},
    "source": [
     "## Synthesis JSON\n",
     "\n",
@@ -3792,16 +2708,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b66ed050",
-   "metadata": {
-    "papermill": {
-     "duration": 0.0031,
-     "end_time": "2026-08-20T08:34:32.264422+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.261322+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "dab0d91e",
+   "metadata": {},
    "source": [
     "Pinning a case study to its spine prediction stops cost and risk figures being\n",
     "pooled out of full-universe rows when the selected strategy runs on a\n",
@@ -3815,42 +2723,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "4d0ff60e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.271748Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.271615Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.453504Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.453095Z"
-    },
-    "papermill": {
-     "duration": 0.186237,
-     "end_time": "2026-08-20T08:34:32.453817+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.267580+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Built synthesis JSON for 9 case studies\n",
-      "  etfs: 2 families, best IC=0.0661\n",
-      "  crypto_perps_funding: 2 families, best IC=0.0321\n",
-      "  nasdaq100_microstructure: 1 families, best IC=0.0046\n",
-      "  sp500_equity_option_analytics: 5 families, best IC=0.0114\n",
-      "  us_firm_characteristics: 4 families, best IC=0.0834\n",
-      "  fx_pairs: 4 families, best IC=0.0204\n",
-      "  cme_futures: 5 families, best IC=0.0419\n",
-      "  sp500_options: 4 families, best IC=0.0247\n",
-      "  us_equities_panel: 2 families, best IC=0.0343\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "0e4f21e5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "_PINNED_WITH_EVIDENCE = frozenset(\n",
     "    row[\"case_study_id\"]\n",
@@ -3934,16 +2810,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "822ea979",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00324,
-     "end_time": "2026-08-20T08:34:32.460626+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.457386+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "bb7691c7",
+   "metadata": {},
    "source": [
     "## Save Aggregated DataFrames\n",
     "\n",
@@ -3952,44 +2820,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "26892ec5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.467719Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.467635Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.476942Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.476669Z"
-    },
-    "papermill": {
-     "duration": 0.013343,
-     "end_time": "2026-08-20T08:34:32.477332+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.463989+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Saved aggregated data to 20_strategy_synthesis/output\n",
-      "  backtest_comparison.parquet: 5.9 KB\n",
-      "  holdout_results.parquet: 8.1 KB\n",
-      "  ic_comparison.parquet: 3.1 KB\n",
-      "  lineage.parquet: 6.7 KB\n",
-      "  measurement_quality.parquet: 3.9 KB\n",
-      "  overview.parquet: 3.5 KB\n",
-      "  rank1_cluster_diagnostics.parquet: 4.0 KB\n",
-      "  sharpe_progression.parquet: 2.2 KB\n",
-      "  variant_analysis.parquet: 8.5 KB\n",
-      "  all_synthesis.json: 26.7 KB\n",
-      "  stage_attrition.json: 0.2 KB\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "36a76be7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "overview_df.write_parquet(OUTPUT_DIR / \"overview.parquet\")\n",
     "if not ic_df.is_empty():\n",
@@ -4022,16 +2856,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2f9c930",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003386,
-     "end_time": "2026-08-20T08:34:32.484405+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.481019+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5d9a770b",
+   "metadata": {},
    "source": [
     "## What the Empty Cells Mean\n",
     "\n",
@@ -4047,40 +2873,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "8227402b",
+   "execution_count": null,
+   "id": "8561724f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T08:34:32.491642Z",
-     "iopub.status.busy": "2026-08-20T08:34:32.491548Z",
-     "iopub.status.idle": "2026-08-20T08:34:32.493930Z",
-     "shell.execute_reply": "2026-08-20T08:34:32.493711Z"
-    },
-    "papermill": {
-     "duration": 0.006793,
-     "end_time": "2026-08-20T08:34:32.494443+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.487650+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "**4 of 9 case studies have no registered backtests**: ETFs, Crypto, NASDAQ-100, US Equities. Every backtest-derived column is null for these, and the stage attrition counts above treat them as not reaching the tradable stage."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "_empty = [\n",
     "    row[\"case_study\"]\n",
@@ -4099,16 +2899,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "edef8e2e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003447,
-     "end_time": "2026-08-20T08:34:32.502382+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T08:34:32.498935+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "8236ac7f",
+   "metadata": {},
    "source": [
     "## Artifacts Produced\n",
     "\n",
@@ -4162,37 +2954,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "d09624362fdffeb173359378ee2a58e9e342cbce",
-   "executed_at": "2026-08-20T08:34:46.982050+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 31.136208,
-   "end_time": "2026-08-20T08:34:34.770922+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "20_strategy_synthesis/01_aggregate_synthesis.ipynb",
-   "output_path": "20_strategy_synthesis/01_aggregate_synthesis.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-20T08:34:03.634714+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/20_strategy_synthesis/01_aggregate_synthesis.py
+++ b/20_strategy_synthesis/01_aggregate_synthesis.py
@@ -258,20 +258,26 @@ def _apply_rung_restriction(df: pl.DataFrame, cs: str) -> pl.DataFrame:
     return df.filter(rung["predicate"])
 
 
-# Carrier pin (validation-time a-priori tie-break) — distinct from the rung
-# restrictions above. It selects the deployed MODEL carrier when the cross-stage
-# val rank-1 is statistically tied with a more diversified / more precisely-
-# estimated config. us_firm_characteristics: default_huber (signal-stage rank-1,
-# val 2.754, block-bootstrap Sharpe CI [2.33,3.37] width 1.04) is pinned over
-# leaves_7_mae (cross-stage rank-1, val 2.759, CI [2.10,3.57] width 1.46) — same
-# point estimate, narrower CI, far more diversified deployment (50 equal-weight
-# names vs 10 score-weighted; holdout MaxDD -8.6% vs -34%). Pinning on
-# config_name (NOT allocator) keeps both equal_weight and score_weighted in the
-# §20.5 allocator comparison on the carrier's prediction. Mirrors
-# case_studies.utils.strategy_analysis.CARRIER_PINS — keep in sync.
-_CARRIER_PIN_PREDICATES: dict[str, pl.Expr] = {
-    "us_firm_characteristics": pl.col("config_name") == "default_huber",
-}
+# Carrier pin: a validation-time a-priori tie-break, distinct from the rung restrictions
+# above. EMPTY, and that is the normal state. It held
+# `"us_firm_characteristics": pl.col("config_name") == "default_huber"` until 2026-08-25,
+# copied from case_studies.utils.strategy_analysis.CARRIER_PINS and translated into a
+# config-name predicate, under a "keep in sync" comment doing the job a mechanism should.
+#
+# It had not been in sync for a rebuild. Against the current registry `default_huber` is the
+# WEAKEST of the ten configs that reached the allocation stage (48 validation backtests, best
+# Sharpe 2.128, 2.075 average - tenth of ten), while the documented rule selects `leaves_63_mse`
+# (59 backtests, 3.116). So this restricted one case study to its worst advanced configuration
+# while every notebook inside that case study reported its best.
+#
+# Worse than the hash pin removed from CARRIER_PINS the same day, because a hash pin dies loudly:
+# every hash changes when a sweep is rebuilt, so it resolves to nothing and stops. A config-name
+# predicate survives the rebuild and keeps selecting, silently and wrongly.
+#
+# If a carrier restriction is ever needed here again, call `carrier_pins.carrier_config_name(cs)`,
+# which resolves a pin to its config through the registry - the thing this copy existed to avoid
+# and the thing that would have failed loudly instead of filtering to the wrong config.
+_CARRIER_PIN_PREDICATES: dict[str, pl.Expr] = {}
 
 
 def _apply_carrier_pin(df: pl.DataFrame, cs: str) -> pl.DataFrame:

--- a/20_strategy_synthesis/02_feature_evaluation.ipynb
+++ b/20_strategy_synthesis/02_feature_evaluation.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "90748c0a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001255,
-     "end_time": "2026-08-20T07:52:26.036102+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:26.034847+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "87c82f3f",
+   "metadata": {},
    "source": [
     "# Feature Evaluation Across Case Studies\n",
     "\n",
@@ -35,23 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "6493023a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:26.039996Z",
-     "iopub.status.busy": "2026-08-20T07:52:26.039838Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.666771Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.666148Z"
-    },
-    "papermill": {
-     "duration": 1.629699,
-     "end_time": "2026-08-20T07:52:27.667544+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:26.037845+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "55dc53a5",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Ch20 Feature Evaluation — cross-case-study triage ledger comparison.\"\"\"\n",
@@ -65,29 +43,16 @@
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
-    "from case_studies.utils.analytics import CASE_STUDY_IDS, SHORT_NAMES\n",
+    "from case_studies.utils.analytics import CASE_STUDY_IDS, SHORT_NAMES, load_triage_ledger\n",
     "from utils.paths import REPO_ROOT, get_chapter_dir\n",
     "from utils.style import show_with_alt"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "47858925",
+   "execution_count": null,
+   "id": "0f8c0913",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.671865Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.671668Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.673501Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.673172Z"
-    },
-    "papermill": {
-     "duration": 0.005394,
-     "end_time": "2026-08-20T07:52:27.674074+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.668680+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -103,23 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "8e2bfdc4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.676523Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.676436Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.678188Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.677866Z"
-    },
-    "papermill": {
-     "duration": 0.003801,
-     "end_time": "2026-08-20T07:52:27.678753+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.674952+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "09da1def",
+   "metadata": {},
    "outputs": [],
    "source": [
     "OUTPUT_DIR = get_chapter_dir(20) / \"output\"\n",
@@ -129,16 +80,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bce396e",
+   "id": "c15798ad",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.000888,
-     "end_time": "2026-08-20T07:52:27.681431+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.680543+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "## 1. Load Triage Ledgers\n",
@@ -156,41 +100,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "19ee3f8e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.683971Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.683861Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.721071Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.720587Z"
-    },
-    "papermill": {
-     "duration": 0.039193,
-     "end_time": "2026-08-20T07:52:27.721440+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.682247+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 9/9 ledgers\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5d229904",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "def _load_ledger(cs: str) -> pl.DataFrame | None:\n",
-    "    p = REPO_ROOT / \"case_studies\" / cs / \"evaluation\" / \"triage_ledger.parquet\"\n",
-    "    if not p.exists():\n",
-    "        return None\n",
-    "    return pl.read_parquet(p).with_columns(case_study=pl.lit(cs))\n",
-    "\n",
-    "\n",
-    "ledgers = {cs: _load_ledger(cs) for cs in CS_LIST}\n",
+    "ledgers = {cs: load_triage_ledger(cs) for cs in CS_LIST}\n",
     "available = [cs for cs, df in ledgers.items() if df is not None]\n",
     "missing = [cs for cs in CS_LIST if cs not in available]\n",
     "print(f\"Loaded {len(available)}/{len(CS_LIST)} ledgers\")\n",
@@ -221,16 +136,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fca364e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000901,
-     "end_time": "2026-08-20T07:52:27.723428+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.722527+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "2e4cc42d",
+   "metadata": {},
    "source": [
     "## 2. Two Routes to PROCEED\n",
     "\n",
@@ -250,66 +157,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "167bdea8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.726011Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.725868Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.732210Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.731768Z"
-    },
-    "papermill": {
-     "duration": 0.008223,
-     "end_time": "2026-08-20T07:52:27.732512+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.724289+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (9, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>cs_short</th><th>n_candidate</th><th>n_fdr_sig</th><th>n_proceed</th><th>n_proceed_by_fdr</th><th>n_proceed_by_stability</th><th>pct_fdr_sig</th><th>pct_proceed</th></tr><tr><td>str</td><td>u32</td><td>u32</td><td>u32</td><td>u32</td><td>u32</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;US Firms&quot;</td><td>57</td><td>38</td><td>40</td><td>38</td><td>2</td><td>66.7</td><td>70.2</td></tr><tr><td>&quot;Crypto&quot;</td><td>44</td><td>8</td><td>24</td><td>8</td><td>16</td><td>18.2</td><td>54.5</td></tr><tr><td>&quot;FX&quot;</td><td>63</td><td>0</td><td>27</td><td>0</td><td>27</td><td>0.0</td><td>42.9</td></tr><tr><td>&quot;ETFs&quot;</td><td>71</td><td>1</td><td>17</td><td>1</td><td>16</td><td>1.4</td><td>23.9</td></tr><tr><td>&quot;SP500 Options&quot;</td><td>51</td><td>8</td><td>9</td><td>8</td><td>1</td><td>15.7</td><td>17.6</td></tr><tr><td>&quot;CME Futures&quot;</td><td>69</td><td>0</td><td>12</td><td>0</td><td>12</td><td>0.0</td><td>17.4</td></tr><tr><td>&quot;NQ100&quot;</td><td>88</td><td>4</td><td>14</td><td>4</td><td>10</td><td>4.5</td><td>15.9</td></tr><tr><td>&quot;SP500 Eq+Opt&quot;</td><td>48</td><td>0</td><td>4</td><td>0</td><td>4</td><td>0.0</td><td>8.3</td></tr><tr><td>&quot;US Equities&quot;</td><td>73</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (9, 8)\n",
-       "┌────────────┬────────────┬───────────┬───────────┬────────────┬───────────┬───────────┬───────────┐\n",
-       "│ cs_short   ┆ n_candidat ┆ n_fdr_sig ┆ n_proceed ┆ n_proceed_ ┆ n_proceed ┆ pct_fdr_s ┆ pct_proce │\n",
-       "│ ---        ┆ e          ┆ ---       ┆ ---       ┆ by_fdr     ┆ _by_stabi ┆ ig        ┆ ed        │\n",
-       "│ str        ┆ ---        ┆ u32       ┆ u32       ┆ ---        ┆ lity      ┆ ---       ┆ ---       │\n",
-       "│            ┆ u32        ┆           ┆           ┆ u32        ┆ ---       ┆ f64       ┆ f64       │\n",
-       "│            ┆            ┆           ┆           ┆            ┆ u32       ┆           ┆           │\n",
-       "╞════════════╪════════════╪═══════════╪═══════════╪════════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ US Firms   ┆ 57         ┆ 38        ┆ 40        ┆ 38         ┆ 2         ┆ 66.7      ┆ 70.2      │\n",
-       "│ Crypto     ┆ 44         ┆ 8         ┆ 24        ┆ 8          ┆ 16        ┆ 18.2      ┆ 54.5      │\n",
-       "│ FX         ┆ 63         ┆ 0         ┆ 27        ┆ 0          ┆ 27        ┆ 0.0       ┆ 42.9      │\n",
-       "│ ETFs       ┆ 71         ┆ 1         ┆ 17        ┆ 1          ┆ 16        ┆ 1.4       ┆ 23.9      │\n",
-       "│ SP500      ┆ 51         ┆ 8         ┆ 9         ┆ 8          ┆ 1         ┆ 15.7      ┆ 17.6      │\n",
-       "│ Options    ┆            ┆           ┆           ┆            ┆           ┆           ┆           │\n",
-       "│ CME        ┆ 69         ┆ 0         ┆ 12        ┆ 0          ┆ 12        ┆ 0.0       ┆ 17.4      │\n",
-       "│ Futures    ┆            ┆           ┆           ┆            ┆           ┆           ┆           │\n",
-       "│ NQ100      ┆ 88         ┆ 4         ┆ 14        ┆ 4          ┆ 10        ┆ 4.5       ┆ 15.9      │\n",
-       "│ SP500      ┆ 48         ┆ 0         ┆ 4         ┆ 0          ┆ 4         ┆ 0.0       ┆ 8.3       │\n",
-       "│ Eq+Opt     ┆            ┆           ┆           ┆            ┆           ┆           ┆           │\n",
-       "│ US         ┆ 73         ┆ 0         ┆ 0         ┆ 0          ┆ 0         ┆ 0.0       ┆ 0.0       │\n",
-       "│ Equities   ┆            ┆           ┆           ┆            ┆           ┆           ┆           │\n",
-       "└────────────┴────────────┴───────────┴───────────┴────────────┴───────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "82da0e49",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "funnel = (\n",
     "    panel.group_by(\"case_study\")\n",
@@ -341,39 +192,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "65a93b45",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.735196Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.735121Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.808128Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.807462Z"
-    },
-    "papermill": {
-     "duration": 0.074949,
-     "end_time": "2026-08-20T07:52:27.808563+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.733614+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3MAAAHjCAYAAACJsEYQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYuVJREFUeJzt3WdgFFUbhuFns5sCIYSEEAgQeu+9I4I0BUGKIlKkS/3oXUGKdER6L9KUrhQVKSqIIiC9905oCSGF1N3vR2QlhiqBzeB9/XJnzpx5ZzKseXLOzJiioiJtAgAAAAAYipOjCwAAAAAAPDvCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYM6AqdVvr5JkLkqQ1G7ZoyJgZj2zb85Nx+nr1Dy+0nmMnz6pR616q0bC9Dh45+UL39V8zc8EKzVyw4rn7+ed18s+fWee+I7Tjj33PvZ+kZsmKDer76QRHl5GkdOw9/IV/JxjJy/iOBADgRbE4uoBXyYEjJzVrwQqdPndJqTw99OYbFdS0UW1ZzOYXts96td5QvVpvJE5fzbtp2piB8kuX5pm2W7RsnfLkzKaPe7aTk9O///tAx97D1aZpfRUrnO9f95GYytZoKhcXZ5kfOKZRg7rJP0M61f+wu9xcXeXsbFGmjOlUr9YbeqtaRZlMJknSsHEztXHrb3JxtijWalX6dGn0fr03Vfetys9Uw0ct3k2UY/nndfLPn9mU0QMSZT+PU7ZGU/2+cfEL38/TuBZw0/4ztNqsSuGeXKWKFVS39k3kmdJDew8cVac+I5TMzVWxsVa5uydTuZKF1a1DM6VwTy5Junk7SJNmLtH+Q8clk0lFC+bR/9p9IJ/UXvb9xMTGasmKDfrxp99081agsmfx10ct3lWRgnni1fDXZSNJmj9lmDL7p1fH3sN16OgpOVv+/pp+v/6bavdhQ234cZs++3y2XF1c5O7upuxZ/NWmWQMVzJfzpZ3DpOLffm8BAPAqIMwlkp17DmrQyKnq06WlKpQpqruhYVq5dpMiIiLtv/y9qu7cDVHFssXl7PzqXU6zv/hUubJnjrfsWsBNSdLapZPkbLHowJGTGjt5vi5evqYOrRrZ2zV4u6q6d2imsLBw7Tt0Qh+PmKwc2fyVP0+Ol3oMD/Mq/8yexdqlk5QsmZsuXrqmafOW6fNpizSkX0dJUgr35Nq0epZiYmN14dJVjZ/6pabPW6beXVoqNCxcrTp/ojerVlCvzqMk2bRk5Xdq9b9B+mrWaLn/9W9++LiZuhpwU8P6d1amjOl08MhJnTxzQUUK5olXg0cK94fW16l1Y71fv+ZD1+XI6q+F00co+G6ofvp1l7oNHK3hA7qobMnCiXuSAABAkvXf/k0ukdhsNk2YvlDtW76nqq+XkSS5ubmq4wO/2G/Z9oeWf7NR5y5cVmrvVOrfrY0K5c8lKe4vy706faiVazfpyPHTKpgvp4YP7KJkbm6SpM2/7NSsL1cqNDRcVV8vo1ir1d7vim9/1E+/7tK0sR9Lkk6duaAxkxfo/MUrKlwgtwKDgu1tQ8PC9eVXa7V9517dDryjkkXza2DPdnJPnkxV6rbWvYhINW7XVx4p3LVu6WTFxMZq/pJvtG7jzzLJpEb1auqDhm/FO/buA8fowOETOnT0lDb8uE2LZ4zUtYCbGjtlgQ4fO6WM6dOqb9fWyp0ji6KiovXV6u+1+eedunb9pvLmyqbBfdrLJ7WXGrfto/MXr6r7x2NldnLSt0smadmaH3TqzEWN/rS7JOnXnfs0ftqXWrPwC/t569e1teYsWq3kyVw1cWQ/nTpzQeOnfqkz5y8rd44sGtCjjdKn81VgULCGjp2hQ8dOKU1qb7VuWk/VXi/73D97NzdXlS5eUEP7d1L7nsPUoE41+fp4x2vj7p5cFcoUVaaMfjpz7tJDw9yho6c0ZtJ8Xb1+QzmyZlKPjs2VO0cWTZq1VMF3Q/RJr48kSd9v/lWzF65SwI1bstlscnN1VdP3auutqhXUtvunGtijnWYvXKlLV66rXq0q6tj6/QTXycN+Zi07f6KGdaqpVvXXJEmbfv5dC5Z+qxu3ApU/T3Z90usjeXt5as36LVr/4y+6eDlAmTL6aVDv9sqSKb2kuJG3GeM/0Yz5y3Xq7EVVLFtcn/Rqp+s3A9W4bR9JcVOEs2f11+wvPn3kOb11O0hzF6/R7n2HdTckVFVeK61enVvIYjZrw4/btHPPQeXJmVVrNmxRRGSkenb8UJUrlpIk3QkO0bgpC7Rr72GlT5dG6Z9itMZiNitbloyq9npZLVq+7qHrs2fxV6VyJbR1+y5J0tKV38k/Yzr7+ZWkjq0a6ejxM/p6zQ9q3bS+Dh09pe2/79WKBePlncpTklSscL5EH3n2TJlC77xVRWFh9zR51tKnCnOXrgao+8AxOnL8tHJmy6yPe7aTb5rUavBhdw3o3kaliheUFDcdt/fg8fp28WSZzX+PUAcGBWvizCXatfeQkrm5qVmj2qpX6w1duhKguYtX68DhE7oXEan6tauq3YcNJT36Gr8XEaEpc77WT9t3KXkyN7Vt3kA1qpSPV29ERKSGj5+lP/48JI8U7nrvnRp6v37Nh35vDRs3Uynck6t7h2aSnv47MiwsXLUbd9GX04YrU0Y/SdLW7bu0ZMUGzZ005Dl/SgAAvBjcM5cIAoOCdfFygN54rdQj20RGRqlHx+b6btk0vV6hpEZPnBdv/dzFa9StfVOtmD9ex06c06afd0qSjp44o2HjZqp7h2b6dskkFS6QW1FR0Q/dR1j4PfX4eKzKlSqsDV9PVeum9eKFOScnJ6X2TqVp4wZq9cIJOn/xqr7ZsFWStPXbuZKkr2aN1rqlkyVJi5ev1669h7RgynDNnzJM323eHjel7AETPuujwgVyq1Prxlo8Y6Sio2PU85NxKpQ/l75bNk1tmzfUoJFTFBtrldlslouLs8YO7aH1X0+VTTYt+Gpt3H5nj1G6tD6aMLy3tn4795EjFf80fuqX6tetlSZ81kd3Q8LUdcBo1X2rir5fMV1VXy+jERPmSJKWrNwgk8mktUsma+KIvsqUId1T9f+08uXOrtRenjr1172MDwq6c1cbNm3ThYtXlT/vw0flJkxfqErli+uH5TPUrX1TeXt5Jmhz/uJVffb5bA3o0UZrl0xSvtzZ1avzh2rdtJ4k6XZgsLZs+0OfD++jcUN7atHy9bp0JSDhvv7xM/un33cf0JhJ89W9YzN9v3yaGjd4S54pU8hkMskmmwb36aDvl09X1swZNHn20njbLly2VkP6ddSi6SP040879OeBo/JL66OvZo2WFHedPS7ISZLVZlPunFk0b/IwLZ45Sr/s2KNtv/1pX//zjt2yWMxaPHOUGrxdTV/M+Hvq5vDxsxQZFaVVX36uMUN66G5o2GP3JUlRUdE6cvyM1m38WYUL5E6wPjo6RgeOnNT3m39V4b/+AHPo6Cm9VrZEgravlSuuQ0dPSZL2HTqmooXy2oPci1a5Ykmdu3hF4fcintj28LFT6ty2sb5dMkm+abw1auJcmc1OqlX9Nf3402/2dtt++1NVKpaOF+RiY63qO+QLOTmZtHzeOM2aMEi5smeRFBe6KpQupiWzRmvG+E+08Ou1OnbyrKRHX+MTZyzRrVtBWjFvnL4Y0Vcz5i/XlWs34tW7/sdtunDpmlbMH695k4cqb+5skh7+vfU4j/uOdHdPrsoVS2rTz78/cPx7VLVS6Sf2CwCAoxDmEkHAjdtydrYopUeKR7Z5q1pF5ciaSRcuX5N7smQ6e+FyvFDW/P23ldk/vTxTeih/3uy6ePmaJGn9xm2qVqmMypYsLGdni954rXS8e7ge9PuuA3JxcdaH79eRi4uz8ubKZv8LsyQlT+am9+vXlKuzs86evyyf1F46cfr8I2tevX6z2jZvKG8vT3l7eeqtqhX1++4Djz0X+w4dV2h4uD58v44sFovKliwsi8WiK9euy2x2UuP6bypVSg+dOXdRPt6pHrv/p/F+vZrKnsVfTk5O+vnXXfLPkE5vVq0gi9msum9W1olT5xUZFaW0aVLrasBNXb9xW2l9Uyt3zqxP1X+HnsNUrX47VavfTsPHz3psW2+vVLpxK9D+ec2GLapWv51qvd9JS5Zv0PCPuyh7Fv+HbuubJrXOnLuskNAw5c2VTWkeuO/qvvMXryiDn69KFMkvn9Reeq1ccR07eS5em/+1a6JUnh4qmC+n3JMne2iYe5KVazepYd1qKlEkvywWi0oXLyjLX/dtNXi7mtKn89XZC5eV0sNdJ//x82v34bvyTZNafunSKGvmjPbr+Fn4+njrnbeqyGaz6tLlAKVJ7aUTp/4+ziz+GdSoXk25ubqoXMnCunErUBERkQoMCtaOP/apR8cP5ZHCXb4+3ir+hFGwes266c1GHTR41FTlypZZXdo0tq8LDQtXtfrtVLVeW3UfMFqlihdU62b1JcXdL+ftlTJBf6m9U+n6zduSpOs3bssndaonHm+9Zt3s19j8pd/EWzd9/jL7uvujm4/i7RW3r5sPXIOP8uYbFZU9i7+SubmpeaM62r3viKKjY1SrekX98tufioiMkiRt+/1PvfFa/DBz8sx5nTxzXr06t5BHCnf5pPZS/jzZJUk5s2dW1dfLKDz8ngJu3JaXl6f93/jDrvHIqCit3/iLOrdtLHf35MqYPq0qlCmm3fsOx9tn2jTeuhUYpMtXryuVp4c9VD+rJ31H1q5RSRu3/iabzaaYmBj9vvugfdQXAICkiGmWiSCdb2pFR8fobkioPFN6PLTNxq07NGfRaqXx8VKOrJkkSZFRUXJxcZYk+4MzJCmlRwpFR8dIkq5dv6mihfIk7PAhrl2/Kf8M6R75EJLIqCiNn/qldu89bH9QQuRfv7T9U3R0jG7eClL/YV/IyRTXX2xsrN6sWuGxNVwNuKHAwGBVb/CRfVlUdLSC74bKarVqxvzl2vTz78qVPYvMZidFRkY+1bE9SuoHflm+cu2Gjp44o2r12/2976ho3Q0JU8M61ZTSw10DP5uk9Ol81an1+8qWJeMT+58+/pME98w9ys3bgUrn62P/XK/WG+reoZmmzVumE6fOqULpopLiQt7kWXEjWgXy5tSkUf30Sa+PtPybjWrR+WNVLFtc7Zo3lGfK+H8cKJA3h27dDtLvuw8oa+YM+mn7Lr33To14be5fRk5OTvLwcFd0TMxT1f6gqwE3VL1yuYeu+2r191rxzY/KlDGdfFJ72X/p/3v/D17H7oqOjn3m/QffDdXIL+bo9NmLKlIgtywWc7z9PPiwkPt/QImOidG16zfl4uysdL6pn3pfaxZ98chR4Pv3zJ09f1mt/jdI77xVWa4uLpLi/s3fun0nwTY3bv19DaT1Ta2DR049Vw0dWjZ65D1z/3Q/xKVN8/THL0mpPD1ks9kUEham9Ol8lSdnVu34Y5/y5MyquyFhCR6qcuXaDaVNk1ruyZMl6OtawE199vls3bwdpOKF88nVxVkREXE/u4dd48F3QxRrtapl50/s105MTKxaNXknXr8VyxbXQJOTJkxfJIvFrI6t3/9Xge5J35FFC+aR1WrVsZNnFX4vQpky+sX7Nw0AQFJDmEsE3l6eyuDnqy2//KH6b1dNsP7GrUANHTtDS2aOUpZMGXQt4KZWfPvjU/Wd2stT128++S/tkuTt7akbj2n79eofdPGvqUoWi0VzFq3SqTMX47Wx2mySJGdni3y8U2nYgM7xHtbwJH5p0yhdWh+tmD8+3i/2kvTjT7/pp193a8ms0UqezE0bftymZWv+fiS4SSb7/iXJYrHobkio/XOs9fHBwC9dGhUukPuRT2as+UYFVa9cTsvW/KC+QyZoxfzxT31cT3LwyEkF3w19aPBr9l5tNfiwh3buOaiyJQs/9Amk7smTqeUH76hx/Tc1fPwsTZv7tfp3bxOvjbeXp/LmyqaZC1boVmCQqr9eTjXfiH9vUWJI5+ujy1cTjugdOnpK8xav0bK5Y+Xt5am9B47qlx17nq7Tv64Fq9X6xCeeTp+/TC7OzvZraNi4mU+1C2+vVIqKjtad4BB5pUo4avZv3b+fbtrcZRo+sIskqVD+XPrp191q3OBN+3Vus9n00/ZdKleqSFybfLm0YOm3CrpzN1HreZQt2/5QzuyZ5ebm+kzbXbx8TcmTucnLM67G2jUqacsvOxUYFKwqFUsl+Hn5pfXRzVtBioiITLCv0ZPmKV+e7Pb7hTv2Hm5f97BrvHvH5nJyMmnJzFFK+4QQXqFMUZUvXUQ//7pb3QeM1vcrptvD9YPfG84Wi+6G/D29Njb273uMn/QdaTKZVLtGJW3+5Q/JZkswKgkAQFLDNMtEYDKZ1K19M81YsFybf9mpiMgo3Q68o3FTvtSxk2d1NyRMVqtNEZFRCgkN09drnv6dRq9XKKUft/6mI8fPKCIiUotXrI/3AJQHlS1RWNeu39LaH35WdHSMdvyxT8cfmJ4WHByiWKtN0TExOn32on7Z8We87VN7e+rP/UcUGRX3l/R3ar2hiTOX6PLV64qIiNTvuw888X6cogXzyGw2a+aCFYqIiNT1G7e1Z/+RuP3fDVVMTIxiYmJ15doNfb/514T7P3BUUVHRio21yj9DOp04fV7Xrt/SyTMXNHfxmsefq/IldfbcZa1at0nR0TG6dCXAfv/S16t/0Jnzl2S1WmWxWOxTXH/ffUB9h0xQzL8YwZKkiMgo/fHnIQ0ePU3N3qut1N6pErTxSOGuFo3ravKspYqJTRhIw+9F6Muv1+p24B1ZbTZZLGZFRSe8L/LshSu6eOWapo4dqPVfTdX/PmryXK+CeJS6b1bW8m9+1IHDJxQTE3cd3bgVqDt3QxQTE6vo6BgFBgVrzV/3Wz4Nz5QpZHZy0p79R+3X14Kl32rWlysTtA0ODlVMbKyioqO1/9Bx7T1w9Kn2kc43tfLmyqrp85cpIiJSZ89f1ua/7j19Xm2a1tf2nXvt71FsVK+mbty8rcmzv1Lw3VAF3w3VlDlf6eatQPtoaZGCeVS2ZGH1HTJB5y5cUUxsrA4fO60hY6bHCxjPK/huqFav36JFy9ap81/TRO9FRKjbgNGPfO/j7n2HdDvwjoLu3NX0ectUu0YleyitVL6EDh07rS2/7FTVSmUSbJs7Z1b5Z0yn8dMWKiwsXIFBwfrprwfD3AkOUXR0tKKiorV9516dPhv3x6JHXeNuri56s2pFjZo4V7cD7yg0LFzbd+5NcH7WbfxFh4+dVmxsrMxms2JiY2X963vwn99bGTOk1f7DxxV05672HjymFd9utPfzpO9IKW5K/Lbf9uj3PQdU5TH3QQMAkBQwMpdIKpQpqhGfdNWchas0ZtI8eXulUvXKZZUrexY5OZnUsE41der9mTJmSKtWTerZHzzyJOVLF1GzRrXVb+gXsljMalC7qjL7p39oW28vT4345H+aOHOJps39Wq+VK67ypYvY179bt7r2HTquuk3+pxJF8qtGlXL2sCNJH7V4T1Nmf6XFKzZo3uSh+vD9t2WzWdWl7wiFhd9TvtzZldnfT8mTuT2yXhcXZ034rLcmTF+kOk3inshZvXI5FS+cTzXfKK9fduxR/ebdVCBvDlWvXFYr126yb9uqST2N+Hy2vt/0qyaN6qeKZYqpZLECatq+nwrmzakubRvbH2jyMKk8PTRxZF9NmLFI0+ctl2fKFHq3bg0VzJdTful8NGzsTF26EiC/dGk0uE97SXH3Pv26c6/OnLv01PfR3Vfng//JbHZSpox+atO0vt6qVvGRbRvUqarl32zU2u9/Vv3a8UflXFycZbPZ1KHXcN0OuqP8uXNoQI82CfrInNFPri4uqtvkf/ZQmi1zBvXr1kauf03XTQyVypfQnbshGj5+loLvhqhgvlzq1bmFyhQvpLKlCuuDdn2VI1smvfdODe3cc/Cp+kyezE2tmtbTgGETlSVTes2aMFiXrgbolx177E87vK9F4zoaNGqa3mnaVRXKFFOV10orJubJ0zVNJpOG9OukERPm6O0Puihf7myq+noZHf/HfYX/Rlrf1Hqvbg1Nnr1UsyYMlnvyZJo3eagmzlysph/1kyQVLZRXcycNjffvY0i/jvry67XqP2yibgfeUfYsGfVRy/fiPVCkzgf/izd19LOP/2d/IuXUuV9p1pd/vzT+tXLF9WnfuFcnnD53SZXrtFYyN1flyJZJE0f2U4G/HrATGRmt46fOafMvO+1PzX1Q7hxZ1fOTcbp2/ZZeL19CHVq+Z1/n5uqi18oV146d++z3wj3IYjZr7Kc9NH7ql6rXvLtSerjr/fpvSpLat3xPIyfM0eZf/lC118uq/F9Tix93jffs1FzT5y3Xh50GKjbWqqIF86hQvlzxphlnypBOk2cv1Zm/3uE5uE8H+9N+//m99XaNSvpt136916qXShcvqA6tGmn1+s2SnvwdKcXds5nZ309hYfcSPJkWAICkxhQVFWl7cjPg1dX6f4M1enC3eC97Toq+3/yrDh8/rd6dW0iKG5EZ+NkkZc+SUd07NHdscf9C8N1Qdek7Qgunj3B0Ka+kFd/+qMjIKDV9r/Yzbzt59lI5mZzUqc37T278ChowfJJKFM730GnzAAAkJUyzxH/alDlfqUjB3Ek+yEnS2fOXFRgYrGsBNxUZFaXTZy/qyrUbKpjv3z3Zz5GioqLVf9gXatOsgaNLeSXdf5XC2zVff6btrFarjhw/ox+3/pbgnZL/BVarVdt37tWJU+dUu0YlR5cDAMATMTKH/7SLl6/JP0O6BA9rSYqC74Zo7OQF2rX3kGJjrcqQPq0a1auhWtVec3Rpz8xms+ni5WuPnDKM53PzdpCSu7nK3T35M203ZMwM7dl/RF0/avLQ++VedR16DtPN20Ea0L1Nor/cHQCAF4EwBwAAAAAGxDRLAAAAADAgwhwAAAAAGBBhDgAAAAAMiDD3nGw2m2JiYmSzceshAAAAgJeHMPecYmNjVbFWC8XGPvmlxgAAAACQWAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCCLowt4VXTt2lUmk8nRZQAAgEfw8PDQyJEjHV0GACQawlwi6dipsyxms6PLAAAAjzB58iRHlwAAiYpplgAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZEmAMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgi6MLeFV06NFPJpOjqwCApMUaeU+F8+VydBmAJMnDw8PRJQBAokoSYa5K3dba+u1c++e+n05Qo3o1VKxwPp0+d0kjPp+tiIhIeaVKqe4dmilHtkz2tnMWrdK33/0kr1QpJUkF8+VUyw/e0dS5yzS4T/uXdgytP5sms9n80vYHAEaweeZITZky0dFlAADwSkoSYe5xJkxbqJYf1FXFssV17sKVh45+vV//TTV5t1a8ZS8zyAEAAADAy5bkw9y9iAiFht2TJGXNnOGptrkWcFO9Bo3XklmjtOHHbbpw+ZqOnjij8qWKKCz8nmKtVh06ckoBN25pQI+2+mbDVu07eExtmzdQnTcr69SZC/p09HTFxMaoXKki6vpR0xd5iAAAAADwzJL8A1C6tGuiaXO/1oDhk3T2/OV/1cf6jb9oaL9OatzgLUnSydMX9MWIPqr7ZmUNHzdLXT9qolGDu2nhsnWSpLU//Ky3qlXUV7PHqHH9NxPtWAAAAAAgsSTJkTmrzSqTU1zOLFowj76aM0Yrv92kjr2Hq0fH5qpeuVy89l+v/l4bt+6QJA3q3V7uyZPFW/96+ZLy9vK0fy5WKK8sFoty58iirJkzKLV3KnmmTKGgO3ft7b+YsVgpU6bQm1UrJKhv5dpNWrVukyTJZrMl3oEDAAAAwFNKEmHO3T25IiIi5ebmKkm6ExwiH+9U9vUp3JOrxQd1lT2bvxZ+vTZBmPvnPXPXAm7GW+/k9PABSIvF/MB/W+zBrHiRfJo6dqCWrFivtl0/1dxJQ+L10bBONTWsU02SFBMTo4q1Wjz7QQMAAADAc0gS0yyLFsyj77f8Kkk6fe6Sgu7clV9aH4WF39PML1foXkSEbDabrt+4rXS+Pi+8niPHz8g9eTK1adZAV67dUEho+AvfJwAAAAA8iyQxMte5bWON+Hy2Vq/bIiezSR/3bCeLxSKz2azUXqnUvucwRUREKp2vjwZ0b/vC6zl+6qzGTp6v0LBwNaxTTZ4pU7zwfQIAAADAszBFRUVy09dzuD/Nsv2I0bxnDgD+YfPMkVownffMAQDwIiSJaZYAAAAAgGfDyNxzuj8ydzP45pMbA8B/jMVsVpZM/s/Vh7+vp2ZPHJNIFQEA8OpIEvfMvQpS1xkgOTHNEgD+Keh5OziwKDHKAADglcM0SwAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIIujC3hVpDq4RCaTydFlAMArx9/X09ElAACQJBHmEsmGxdNksXA6AQAAALwcTLMEAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGxFuuE0nXrl1lMpkcXQYA4AXy8PDQyJEjHV0GAACSCHOJpmOnzrKYzY4uAwDwAk2ePMnRJQAAYMc0SwAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIIujC3hVdOjRTyaTo6tIOqyR91Q4Xy5HlwEAicrDw8PRJQAAYEeYSyStP5sms9ns6DKSjM0zR2rKlImOLgMAAAB4ZRlqmmVYWLiGj5+lpu37q0Wnj7Vx62/P1d+1gJvq2Ht4IlUHAAAAAC+PoUbmho6dqWKF82pgj7aKiIzU8VPnHV0SAAAAADiEYcLcpSsBunQlQKMGd5PJZFIyNzcVLZhHHXsPV43K5bVmwxbVrlFJQXfuqm3zBpKkzn1HqO//WmnBV9/KM6WHDh87pTvBIerRsbmKFMitLv1GKjAoWM07DNCnfTvKM2UKjZgwRwE3bimdr48G9mgrby9PBx85AAAAACRkmGmW5y9eUe6cWWR6yFNGDh07pflThql65XL6ecdu2Ww2Bd8NVXh4hPwzpJMk2WxWzfx8kIYP7KLRE+fK1dVFA7q3UZ5cWbVw+ghly5JRX8xYrFLFCmjJzFEqU6KQJs5c8rIPEwAAAACeimFG5h6nXq0qMplMSunhruxZ/HX0xFldvHxNr1coYW9TMF8umUwm5cyWSZFR0bobEpqgnz37j6hb+6aSpKqVymj+km8eur+Vazdp1bpNkiSbzZb4BwQAAAAAT2CYMJfZP71OnDovm82WYHTOyenvAca3a1bSpp9/181bgerY+v0E/ZhMJjlbLHJ2dk6w7mF9P0zDOtXUsE41SVJMTIwq1mrxjEcDAAAAAM/HMNMsM2X0k186H61cu0k2m01RUdH69ruf9M+BseKF8+nYybMKCQ1XBj9f+/KrATckSX/8eUhpfLyUPJmbfNOk1s1bQbJarZKkEkXya/MvOyVJW7b9oRJF872cgwMAAACAZ2SYkTlJGtyno8ZP/VJr1m+Rq6uL3q9fM8GLup2cnJQ/Tw6l/seDS/YdPKat2/6QJH3Sq70kKYOfrzL4+apx2776uGc7de/QTJ99Plvffv+T0qZJrYE92r6U4wIAAACAZ2WoMJfSw11D+nWMt6xGlfLxPkdERmn/oeMaN6xnvOW1qldSlYql4i0zmUz6YkTfeMs+H947ESsGAAAAgBfDMNMsn8aho6fUpF1f1X2zsrxT8UoBAAAAAK8uU1RUJI9jfA73H4ByM/imo0tJUixms7Jk8nd0GUji/H09NXviGEeXAQAAYEiGmmaZlKWuM0ByMju6jCQlyNEFIOk7sMjRFQAAABjWKzXNEgAAAAD+KwhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgCyOLuBVkergEplMJkeXARiKv6+no0sAAAAwLMJcItmweJosFk4nAAAAgJeDaZYAAAAAYECEOQAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAMizAEAAACAARHmAAAAAMCAeMt1IunatatMJpOjywAAAP8RHh4eGjlypKPLAOBAhLlE0rFTZ1nMZkeXAQAA/iMmT57k6BIAOBjTLAEAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgCyOLuBVMW3qFJlMJkeXAQAA/iM8PDwcXQIAByPMJZKJEyfKYuF0AgAAAHg5/tPpo1zNZsqR1d/++ZNeH6nf0C80ffwn8vXx1s87dmvrtj80tH9nB1YJAAAAAAn9p8Ocm6uLFk4fEW9Z4wZvacmKDerWvqmWrNiggT3aOag6AAAAAHg0HoDyD3Vqvq6dew5qy7Y/5J8hnbJkSu/okgAAAAAgAcLcP7i4OOv9+jX12fjZavnBO44uBwAAAAAe6j89zTIiMkrNOwyQJBXMl1O9u7SUJF29dlMpPdx1NyTsodutXLtJq9ZtkiTZbLaXUywAAAAAPOA/HeYeds/c7cA72rXvkD77+H+a9eUKTRzZL8F2DetUU8M61SRJMTExqlirxcsoFwAAAADsmGb5DwuXrdN7dWuoQN4cMplM2nvgqKNLAgAAAIAECHMPuHErULv2HlKNKuUkSS0/eEczFqxgKiUAAACAJMcUFRVJUnkO96dZbt+wgJeGAwAAAHhpSB+JpFbTjjKZTI4uA8BD+Pt6avbEMY4uAwAAIFER5hLJnUJNJCezo8sA8DAHFjm6AgAAgETHPXMAAAAAYECEOQAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIIujC3hVpDq4RCaTydFlAHgIf19PR5cAAACQ6AhziWTD4mmyWDidAAAAAF4OplkCAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABsSL0RJJ165deWk4AACAg3h4eGjkyJGOLgN4qQhziaRjp86ymM2OLgMAAOA/afLkSY4uAXjpmGYJAAAAAAZEmAMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZkcXQBr4oOPfrJZHr0emvkPRXOl+vlFQQAAPAf4uHh4egSgJeOMJdIWn82TWaz+ZHrN88cqSlTJr7EigAAAAC8yl65MFeuZjPlyOpv/zyod3vNXbxGV65dV8CN23J3TyYP9+R6u+brqlC6qN5v00eZ/f3s7SeN6q9UnvxlBwAAAEDS9sqFOTdXFy2cPiLespGDukqSho2bqfKli6pKxVKSpGsBN5UxfdoE7QEAAAAgqXvlwlxiWLJig1at2yw3Vxf16NRcJYrkd3RJAAAAABDPKxfmIiKj1LzDAElSwXw51btLy2fuY97SNVo5/3M5O79ypwcAAADAK+KVSysPm2b5OJevXreHv8oVS6nlB++odvXXNHz8TLVt3lB5cmZNsM3KtZu0at0mSZLNZkucwgEAAADgGbxyYe5ZPeyeue4dmuvEqXP6fPoiValYSo3q1Yy3vmGdampYp5okKSYmRhVrtXhZ5QIAAACAJF4ankBkVJROnDqn3DmzqlG9mvpz/1FHlwQAAAAACbxyI3MP3jMnSZ3bNFap4gWfevvIyGgtWfmdzl+8ouiYGPXv1uZFlAkAAAAAz8UUFRXJTV/P4f40y/YjRj/xpeELpvPScAAAAACJg2mWAAAAAGBAjMw9p/sjczeDbz62ncVsVpZM/i+pKhiVv6+nZk8c4+gyAAAAYACv3D1zjpK6zgDJ6dHTLCUp6CXVAgM7sMjRFQAAAMAgmGYJAAAAAAZEmAMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZkcXQBr4pUB5fIZDI5ugwYnL+vp6NLAAAAgEEQ5hLJhsXTZLFwOgEAAAC8HEyzBAAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABsRbrhNJ165dZTKZHF0GAACJxsPDQyNHjnR0GQCARyDMJZKOnTrLYjY7ugwAABLN5MmTHF0CAOAxmGYJAAAAAAZEmAMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZkcXQBr4oOPfrJZHJ0FUmHNfKeCufL5egyAADPwcPDw9ElAAAegzCXSFp/Nk1ms9nRZSQZm2eO1JQpEx1dBgAAAPDKemSY27LtD836coUsFouyZ/FXz07N5ZnSQ+VqNlP2LP4KCQ1TZn8/9e/eRul8fdSx93DdDrwjVxcXubq6aPYXn8pms2nekjXaum2XfNN4a9iAzkrhnlyXr17Xp6On6V5EpJq9V1s136gQb9/3IiI0YfoiHTl+RmYnJ9V/u6reeavKYw/kWsBNDRs/U9PGfixJWrRsnXLnyKJSxQsmwmkCAAAAgKTloWEuMipKYybN19JZo5TaO5V27jkoFxdnSZKbq4sWzRghq9WqVes2a9rcZRrav5Mk6fPhfZTBz9fez8nT5/XbrgNaOH2Elqxcr8XL16t9y/c0ceZitfzgHRUpkFtN2/dXhTLFlMI9uX278VMXyi+tj/p3a6N7EZHqMXCMUnt5qmLZ4k99YM0avf2vTggAAAAAGMFDH4ASEx2jiMhIhd+LkCSVKVFIydzc4m/o5KTihfPpasAN+7JUKVPEa7Nj134Vzp9LZrOTihTIo992H1BsrFU79xxUkQK55e6eXJky+mnvgWP2bcLCwrVzzwE1b1RHJpNJyZO5qV2Ld7Xi202SpGHjZmrSrKVq132I3mvVSzv3HFRERKS69Bup4yfPqXmHATp7/rKGjZuprdt3SZKOHD+tVl0GqUm7fvp82kLFxMZKkpp81E9fr/5BzdoPUKsugxQSGiabzaYvZixWgw+7q3nHgTp97tLznmMAAAAASHQPDXPu7snVuU1jtf7fYE2atVR3gkMStImNtWrj1h3Klzu7fdmgUdPUuG0frf3+J0nS7cA7yuTvJ0nK7O+nW7eDFBwSolQpPeT+10hcpoxxy++7EnBT/unTydn570HDXNkz6/ylK/bPNptVMz8fpOEDu2j0xLlydXXRgO5tlCdXVi2cPkLZsmS0t42OjtHA4ZPVv1trLZ45UrduB2nDxm2SpPB7EfJKlVILp38mr1QpteOPfbobEqoNP27Tsnnj9MWIPvLPkPbZzyoAAAAAvGCPvGfu3brVVa5UEc1f+o2adRigiSP6KluWjIqIjFLzDgNktdlUIE8OdW7bWJLUvX0z+aZJraA7wWrbbYiKFc4nmUyyWm2SJKvVJicnk0wyyWqz2fdjtdlkcvr7MZBOJpNsD6y/v63Z6e/cWTBfLplMJuXMlkmRUdG6GxL6yAO8eOWa3NxclTN7ZklStdfLatMvO1X3rcqSpNLFC8pkMilX9swKDLqrlB4pVKxwXg0fN1Otm9aXdyrPBH2uXLtJq9bFjRT+s1YAAAAAeBke+zTLDH6++rhnO02auUQ/bN2hjq0ayc3VRQunj0jQ9n5Y8kyZQkUK5talKwFK4+2lS1euSZIuXgmQj7eXPFOmUEhomELDwpXCPbkuXQ5QmRKF7P2k9/PVpavXFRUVbb9P78Tpc8rsnz7BPk0mk5wtFjk7Oz/yGGw2PdUrA8xmJ9lsNplMJo0e3F1/7j+qAcMmqXXTenq9Qsl4bRvWqaaGdapJkmJiYlSxVosn7wAAAAAAEtFDp1mePHNBq9dtltVqVUxsrG7eDlI6X59HdnLh0lX9vvuAbDabrt+4rbPnLyt7Vn+VL11EBw6fUGysVfsOHlO5UkXk5OSksiULa9+h4woNC9elK9dUrFBee1/Jk7mpYtlimv/VN7LZbAoLv6dZX67Se+/UsLe5f5/eH38eUhofLyVP5ibfNKl181aQrFZrvNoyZ/TTvXuROn32omw2mzb9slMli+Z/5LEE3w3RhUtXVbxIPtV8o7z2HTr2yLYAAAAA4CgPHZnzz5BW6zf+ouYdByoiIlIliuRXnZqVHtmJt5enFi1fr+nzlys0NFztW74rXx9v+fp4q2LZ4mreYYDSpU2tof07S5K6fdRUg0ZN1Yz5y9WhVSO5J08Wr79u7ZvpixmL1LR9fzmZnPTuO3FTPu/bd/CYtm77Q5L0Sa/2kuJGETP4+apx2776uGc7e1tnZ4uGD+yiERNmKzIyWkUL5dXbNV9/5LFERERp8uyvFHDjlsxmJw3t1+nxZxAAAAAAHMAUFRVpqJu+ho2bqfKli6pKxVKOLkXS39Ms248YzUvDH7B55kgtmM5LwwEAAIAX5bH3zOHpDevUytElJCkWs1k1G3/02Db+vp6aPXHMS6oIAAAAeLUYLsx90uvxAcFRUtcZIDkxMvegoCc1OLDoZZQBAAAAvJIe+gAUAAAAAEDSRpgDAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIMIcAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAOyOLqAV0Wqg0tkMpkcXYah+Pt6OroEAAAAwLAIc4lkw+Jpslg4nQAAAABeDqZZAgAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAbEi9ESSdeuXXlpOAAAwL/g4eGhkSNHOroMwHAIc4mkY6fOspjNji4DAADAcCZPnuToEgBDYpolAAAAABgQYQ4AAAAADIgwBwAAAAAGRJgDAAAAAAMizAEAAACAARHmAAAAAMCACHMAAAAAYECEOQAAAAAwIMIcAAAAABgQYQ4AAAAADMji6AJeFdOmTpHJZHJ0GQAAAIbj4eHh6BIAQ3ruMBcWFq4JMxbr+KlzspjNatzgLdWoUk7Dxs1UdHS0hvbvLEmy2Wxq3LavqlYqrTbNGmjOolX69ruf5JUqpSSpYL6c6t2lpb3fDT9u0+TZS+Xr4y1J8kubRqM/7f7IOuYsWiW/tGlUq/prz3tI/8rEiRNlsZCNAQAAALwcz50+ho6dqWKF82pgj7aKiIzU8VPn7evOX7yqiMgoubm66NyFK4qKio637fv131STd2s9su+qlcqqV+cPn7dEAAAAAHjlPNc9c5euBOjSlQC9904NmUwmJXNzU9GCeezr8+XJrp17DkiSfvp1l4oVyvOorp5albqt7f89bNxMbd2+S5t+/l3Lv/lRsxeuUv+hEx/ZTpKatR+g5d9sVMvOn+heRIR+3blPH7Ttq0ate+mHLb9KkjZu3aEGH3ZXo9a9tXHrb89dMwAAAAAktucamTt/8Ypy58zyyHvFypQopK3bdun18iW1c89BvVm1ogKD7tjXf736e23cukOSNKh3e+XIlulf1VHt9bLaueegihXK+8RplqHh4bobEqp5k4cq+G6ops9fpjmThshiNqt9z2GqWqmMFi5bp+EDuyhr5oy6dy/iX9UEAAAAAC/SC73JK1f2zJq35Budu3BFfml95OriHG/9k6ZZbv7ldx08ckKS1KFVI5UtWThR6qpfu6pMJpMOHzutW7fvqH2PoZKkkLBw3QkO0VtVK2rSzCVq1bSeShYtkGD7lWs3adW6TZLi7gUEAAAAgJftucJcZv/0OnHqvGw220NH50wyqUyJQpo692u9XbOSQkPDn6n/h90zF2u1PnJ/T9vOySludqlNNhUvnFcjPukab32Td2vptXLFNWnWEv22a7+6ftQ03vqGdaqpYZ1qkqSYmBhVrNXimY4LAAAAAJ7Xc90zlymjn/zS+Wjl2k2y2WyKiorWt9/9FG+06o3XSmvfoWMqU6LQcxcrSe7JkunMuUu6cStQBw6fsC/3TeOtG7cCn9juQfnzZNf+Qyd0/uIVSdL1G7dltVp1+Nhp+WdIp1ZN6mnPvqOJUjcAAAAAJKbnnmY5uE9HjZ/6pdas3yJXVxe9X79mvNGwXNkza+7EoXJ1cUmw7YP3zGXwS6uRg7omaPNPzd5/W//rN0qFCuRSuVJF7MsrVyilXoPG6dDRUxo/rNcj2z3IO5WnBvRoq4HDJ8tsdlLBfDnV9aOm+n7zdo2ZPF/h4ffUpd0Hz3ZCAAAAAOAlMEVFRXLT13O4P81y+4YFvGcOAAAAwEvzXNMsAQAAAACOwVBSIqnVtOMTH8oCx/D39dTsiWMcXQYAAACQqAhzieROoSaSk9nRZeBhDixydAUAAABAomOaJQAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYkMXRBbwqUh1cIpPJ5Ogy8BD+vp6OLgEAAABIdIS5RLJh8TRZLJxOAAAAAC8H0ywBAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZEmAMAAAAAAyLMAQAAAIAB8ZbrRNK1a1eZTCZHlwEAAADgOXh4eGjkyJGOLuOpEOYSScdOnWUxmx1dBgAAAIDnMHnyJEeX8NSYZgkAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABmRxdAGvig49+slkcnQVkjXyngrny+XoMgAAAABD8vDwcHQJT40wl0hafzZNZrPZ0WVo88yRmjJloqPLAAAAAPCCMc0SAAAAAAzIUGGubI2m2rp9l/1zx97DdezkWUlSTGysps1bpqbt+6tp+/5asPRbWa1WSVLw3VANHD5JFWt9qDvBIfbtt+/cq6bt+6tFp491+uxFSVJEZJQGDJuoJu366YsZi2Wz2V7iEQIAAADA0zFUmPP28tTi5evsIe1Bi5atU2DgHX059TMtmDJMJ8+c1+r1WyRJri7OavB2VaX0SGFvHx0do/FTvtSkUf3Uq3MLjZk8X5K0Zv1m+aVLo8UzR+r8xSvavffwyzk4AAAAAHgGhgpzLs4W5ciWST/9ujvBujUbtqhTm8Yym51ksVjUpe0HWvHtRkmSm5urihXOJxcXZ3v7I8dPK5Wnh7xTeSpvrmw6cfq8QkLDtGPXfhUpmEcmk0lFCubRb7sPvLTjAwAAAICnZagHoISG3VPTd2vr488mq3KFkg8sD5eTyUleqVLal/mlS6Pgu6GKjo6Rs3PCw7wVeEeZMvpJksxmJ2VMn1a3A+/oduAdZf5reeaMfvbplw9auXaTVq3bJElMwwQAAADgEIYKc7GxscqU0U85smXS1u27ZHYy/7U84bRLSbJabY8MWyaTKd46m9Umk8kkk0yyWuOWW202OTklfN9AwzrV1LBONUlSTEyMKtZq8TyHBQAAAADPzFDTLO9r+cE7WrryOyVP5iZJSunhrqjo6HgPNwm4cUseKZLHm1r5IJ/UXrp45ZqkuDB4JeCGfLxTySe1ly79tfzS5QD5eHu94KMBAAAAgGdnyDDnnyGdsmXOoOOnzkmKG2WrVe01zVm0WjabTVarVTMXrFDdtyo/so/8ubPpbkiYAoOCdeT4aeXLlU3u7slVvnQR7Tt4XDabTfsPH1e50kVe0lEBAAAAwNMzZJiTpBYfvKPbgXfsn9s2b6Dwe/fUuG1fNW7bR8mTJ1OThrUlSavXb1HzDgN063aQOvX+TMvW/CCLxaLenVvof/1HacL0RerdpaUk6Z1aVXT95m01/ai/smXxV/HC+RxxeAAAAADwWKaoqMhX6gkeJ06d09BxMzV6cHdl8POVFDdy96Lcv2eu/YjRMpvNL2w/T2vzzJFaMH2io8sAAAAA8IK9cmFOkn7+dbfmLf1GsTGx+nx4b6X1Tf3C9nU/zN0MvvnC9vEsLGazsmTyd3QZrxx/X0/NnjjG0WUAAAAAdoZ6muXTer1CSb3+wKsLXobUdQZITo4fmZOkIEcX8Co6sMjRFQAAAADxGPaeOQAAAAD4LyPMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZEmAMAAAAAA7I4uoBXRaqDS2QymRxdBl4Qf19PR5cAAAAAxEOYSyQbFk+TxcLpBAAAAPByMM0SAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCBejJZIunbtykvDAQAvhYeHh0aOHOnoMgAADkaYSyQdO3WWxWx2dBkAgP+AyZMnOboEAEASwDRLAAAAADAgwhwAAAAAGBBhDgAAAAAMiDAHAAAAAAZEmAMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgwhwAAAAAGJDF0QW8KqZNnSKTyeToMgAA/wEeHh6OLgEAkAQ8Mcxt2faHZn25QhaLRdmz+Ktnp+byTOmhcjWbKXsWf4WEhimzv5/6d2+jdL4+6th7uG4H3pGri4tcXV00+4tPZbPZNG/JGm3dtku+abw1bEBnpXBPrstXr+vT0dN0LyJSzd6rrZpvVIi373rNuym5m5vM5rgBxA6tGqlsycLPfJC7/jyk6fOXKyo6WunTpVGf/7VSmtRej91m2LiZqlWtoooVzvdU+5g4caIsFrIxAAAAgJfjsekjMipKYybN19JZo5TaO5V27jkoFxdnSZKbq4sWzRghq9WqVes2a9rcZRrav5Mk6fPhfZTBz9fez8nT5/XbrgNaOH2Elqxcr8XL16t9y/c0ceZitfzgHRUpkFtN2/dXhTLFlMI9ebwapo4dqFSe//4vkJevXteYyfM1efQA+aX10S+/7VGfwZ9r3uShjKQBAAAAMKzH3jMXEx2jiMhIhd+LkCSVKVFIydzc4nfg5KTihfPpasAN+7JUKVPEa7Nj134Vzp9LZrOTihTIo992H1BsrFU79xxUkQK55e6eXJky+mnvgWNPVfTKtZv0Xqte6tBzmDr0HKa9B47a181ZtCre52++26qGdarLL62PJKlSuRJKnsxNB4+e0rWAm2rVZZA+HT1NTdr108efTVZkVJS+WvWdftq+SyMmzNH4qV8+VU0AAAAA8DI9Nsy5uydX5zaN1fp/gzVp1lLdCQ5J0CY21qqNW3coX+7s9mWDRk1T47Z9tPb7nyRJtwPvKJO/nyQps7+fbt0OUnBIiFKl9JD7XyNxmTLGLf+nTr0/U/MOA9T30wmSpNPnLmn5Nxs1d9IQfTGyr6KiYx57gJcuByhHNv94y3Jmz6wLF69Ikq4G3FDrpvW1eOZIRUfHaNNPv6txg7eUJ1dWDejeRj07ffjY/gEAAADAEZ54k9e7daurXKkimr/0GzXrMEATR/RVtiwZFREZpeYdBshqs6lAnhzq3LaxJKl7+2byTZNaQXeC1bbbkLh7zkwmWa02SZLVapOTk0kmmWS12ez7sdpsMjklnPb4z2mW+w4eU+UKJeWRwl2S5OOdSpK04tsfte6Hn3U7KFg/bNmh5Mnc1Od/rWRyMsn2wH4kyWazyskpLsem9kol/wzpJEmlixfUidPnVbtGpceek5VrN2nVuk1/9WV7bFsAAAAAeBGe6okdGfx89XHPdpo0c4l+2LpDHVs1kpurixZOH5Ggbc7smSVJnilTqEjB3Lp0JUBpvL106co1SdLFKwHy8faSZ8oUCgkNU2hYuFK4J9elywEqU6LQE2uJiY21T/t80Lt1q+vdutU1Z9EqFSuU1/7gkkwZ/XTy9AWVLFrA3vbEqfOq9nq5hCfDYparq8sTa2hYp5oa1qkWV09MjCrWavHEbQAAAAAgMT12muXJMxe0et1mWa1WxcTG6ubtIKXz9Xlk+wuXrur33Qdks9l0/cZtnT1/Wdmz+qt86SI6cPiEYmOt2nfwmMqVKiInJyeVLVlY+w4dV2hYuC5duaZihfI+seD8ubNr195DioyKUkhomC5dCXhs+3pvVdGaDVt0LeCmJGnr9l2KjolV/jxx00JDwsJ0NyRM0dEx+n7LDhX/KwSmTZNaN24FPrEeAAAAAHCEx47M+WdIq/Ubf1HzjgMVERGpEkXyq07NR09B9Pby1KLl6zV9/nKFhoarfct35evjLV8fb1UsW1zNOwxQurSpNbR/Z0lSt4+aatCoqZoxf7k6tGok9+TJEvTZqfdn9lcTNKpfU29VraiKZYur6Uf9lS1zRrm5ucZr36ZZg3if/dKlUb9urTXws0mKjIp7NcGYT7vbn2Rps9o0bNwMXbwcoErlS9hHB2tUKa9h42Zq38Hj6t+9zZPOIwAAAAC8VKaoqEhD3/TV99MJalSvxlO/D+5B1wJuqteg8Voya9S/3v/9aZbbNyzgPXMAAAAAXprHTrMEAAAAACRNhh+Zc7T7I3MpvZIniZeQ+/t6avbEMY4uAwAAAMALxrzARHKnUBPJyezoMqQDixxdAQAAAICXgGmWAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAFkcX8KpIdXCJTCaTo8uQv6+no0sAAAAA8BIQ5hLJhsXTZLFwOgEAAAC8HEyzBAAAAAADIswBAAAAgAER5gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABsRbrhNJ165dZTKZHF0GAAAAnoOHh4dGjhzp6DKAp0KYSyQdO3WWxWx2dBkAAAB4DpMnT3J0CcBTI8wBAAAADtC/f3+FhIQker8ve3QxJDRMzTsO1JqFX2jXn4d04vR5NWv0drw2J89c0BczFmna2I8f2c+cRavklzaNalV/7UWX/MogzAEAAAAOEBISoi5d/pfo/TpydLFU8YIqVbygw/b/X0OYAwAAAP6DNm79TQu/XisnJye936CmDh09pZOnzys07J76dW2lYoXzac6iVbLZpCPHT+vU2Ysa0L2NypcuqtCwcA0bO1OXr11X9iwZ7X1u+HGbjp08p16dP9SNm7c1ZMwMhYSGKb2fr73NqTMXNGnWUgUF35V3Kk+NGtxNO/7Yp+Xf/Kjkydz06859Gjmoq37duU/T5n6tWGusWn7wjmq+UUEbt+7QrC9XymKxqFWTeqpRpZwjTl2SQZgDAAAA/mPOX7yqOYtWadaEwUrpkUKhYWHKkcVfuXNm1a4/D2nu4jUqVjifJOn4qbMaO6Sntv3+p75e/YPKly6q+Uu/UYb0aTX60+46eeaC+g6ZkGAfX8xcotcrlNS7davrl9/2aNmaHyRJ3l6eGtSnvdKk9tLgUdP006+7VKvaa9q556CKFcqrWtVf053gEE2fv0xzJg2RxWxW+57DVLVSGS1ctk7DB3ZR1swZde9exEs9Z0kRryYAAAAA/mP27D+iyhVLyStVSpnNTvJM6aGUKT00d/FqLftmowJu3LK3LVYon5ydLcqVPbMC7wRLkv7cf1TvvFVZkuSX1ueh+9h38JjqvPn6X23S2Jd7e3nq7PnLGjt5vk6cPq+A67cTbHv42Gndun1H7XsMVZuugxUUfFd3gkP0VtWKmjRziQ4dPSmvVCkT63QYFiNzAAAAwH+MzWbTgy/VuhpwQz0/GacOLRupdvVKat9rWIJtLGazZIv779hYq8KfMDIWExOre/ci5eriEm/516u/16Fjp9XsvdrKmD6twsLvJaxPNhUvnFcjPukab3mTd2vptXLFNWnWEv22a7+6ftT06Q74FcXIHAAAAPAfU7RgHm3dvkvBd0NltVr10/bdypTRT6+VK66LV649cfv8ebJr++97JUnHTp57aJt8ubPp151xbY6fPGtfvmf/UdWsUl65smfR6XOX7Mt903jrxq1Ae//7D53Q+YtXJEnXb9yW1WrV4WOn5Z8hnVo1qac9+47+u4N/hTAyBwAAAPzH5MiWSY0bvKV23YcomZuralQpp/DwCLXq8onKly6mZK6uj92+VdN6GjRiin79Y69KFysoF2fnBG26ftRUn46ZrtXrN6tEkfz25e/UqqJpc7/WqnWblCVTBvvyyhVKqdegcTp09JTGD+ulAT3aauDwyTKbnVQwX051/aipvt+8XWMmz1d4+D11afdB4p0QgzJFRUXaHF2EkcXExKhirRaaM2EgLw0HAAAwuMmTJ2nKlCkvZV+vynvm4DiMzCWSaVOnyGQyPbkhAAAAkiwPD4+Xti8CF54XYS6RTJw4URYLpxMAAADAy/FCHoBSpW7reJ/7fjpBew/E3aB4+twlteoySB+07atOvT/T6bMX47Wds2iV3m7cWc07DFDzDgM0dvL8f1XDd5u267tN2yXFvbxwzqJV9nVDxkzXrdtB/6pfAAAAAEgKXvpQ0oRpC9Xyg7qqWLa4zl24oofNTHy//ptq8m6t59rPW9UqPnLd4D4dnqtvAAAAAHC0lx7m7kVEKDQs7l0SWTNneELrv527cEXDxs1UTGyssvj7ydnZWZ/0+kjDxs1U+dJFVaViKe09cFRLVn6n8cN6ac6iVUrm5qZ8ebJr2rxlkqQ//jyk2V98qnrNu2n+5GFK5emhtT/8rKUrv5PJJHVv30ylihfUkhUbtGrdZrm5uqhHp+bxnr4DAAAAAEnBSw9zXdo10aARU7R95161aVpf2bJkTNDm69Xfa+PWHZKkQb3bK0e2TBo2bqZaNamnCmWK6uvVP+jU2QtPtb+iBfOoXq0qkqQ2zRrEW3f+4hVt+HGbFs8YoYjIKHUfOEalihfUvKVrtHL+53J25h44AAAAAEnTS0krVptVJqe42/OKFsyjr+aM0cpvN6lj7+Hq0bG5qlcuF6/9P6dZhoWF6+btIFUoU1SS5JfO56nD3OPs3ndEV65dV6sug+L289fb52tXf03Dx89U2+YNlSdn1gTbrVy7SavWbZIk2Wy82QEAAADAy/dCwpy7e3JFRETKzS3uZYN3gkPk453Kvj6Fe3K1+KCusmfz18Kv1yYIc/8Ua7Xp3r0IxcZaZTYnfGZLTEzMv661euXy+t8/XjjYvUNznTh1Tp9PX6QqFUupUb2a8dY3rFNNDetUs++7Yq0W/3r/AAAA+G/q0XegAu+GJnq/3ilT6PPRnz3zdtcCbqrXoPFaMmtUotd0394DR9X708+VPq2v7oaEqmC+nBrQo62SJ3OLd/uUJP3y2x5t++1PfdLrowT91GveTcnd3OzZoEOrRgoMCtbk2Uvlk9pLLs4WNW9UR69XKCkp7iGL3373k1J6pFBoWLjee6fGUz2j41rATQ0bP1PTxn4cb3lsrFXjpizQwSMnlSNbJn3cs12CWX3bd+7VzAUrZDGb9XHPdsqRLZM2/LhNU+Z8pTSpvSRJnds0VqniBZ/9RP7lhYS5ogXz6Pstv6perTd0+twlBd25K7+0PgoLv6fFK9areaO35ebqqus3biudr88T+/NIkVzeXp7af+i4ihfJp+Mnz9nXeaVKqeMnz+mN18poy/ZdD93eN01qHT52KsHyYoXzqvvAMfqgwZtK7Z1KN24GKlUqD52/cEW5c2ZVo3o19cPmXxOEOQAAAOB5Bd4NVdWP+id6v5tnJu331xUpkEfjh/VSbKxVg0ZO0U/bd6lW9deeuZ+pYwcqleff7wXc8OM2Va1UVr06f6gbN2+rxyfjlMrTQ0UK5pH09+y/4LuhatN1sMqXLqosmdL/q2PY/vufCg4J1ZJZozR64jx9t2m76r5V2b4+OjpG46d8qXlThurqtZsaM3m+Zk0YLEmqV+sNtfuw4b/a7z+9kDDXuW1jjfh8tlav2yIns0kf92wni8Uis9ms1F6p1L7nMEVERCqdr48GdG+bYPsH75nL4JdWIwd1Vb9urTV64jyl9EihjOnTyskp7jGYtatXUo+Px2rP/iNqWKeaAq7fStBfmRKFtGjZOrXqMkhTxw6wL8+exV9tmjVQpz4j5OrqosoVSqrB29W0ZOV3On/xiqJjYtS/W5sXcYoAAAAAh9q49Tct/HqtnJyc1PS92iqUL2e89fOWrNGPP/0uF2eLBvZsp9w5smjFtz/q+82/KiQ0TPVrv6HGDd7S3gNH9eNPvyvozl1lzJBWNauU16ejpysmNkblShVR14+aPnT/d0NCdeNWoDL4+Sb6sfmmSa12zRtqxbc/2sPcfZ4pUyhn9sy6GnDDHuZiYmI0buqXOnn6vELD7qlf11bKlzu7uvQbqcCgYDXvMECf9u1of97Hjl37VfSvfosUzKOt2/+IF+aOHD+tVJ4e8k7lKU8PD504fV4hoWGSFC+APq8XEuZ8fbz1xYi+CZabTKZ4UxQfpk2zBgkeVCJJxQrl1bK5YyX9PeQqSVkypdfqhRPs7eq8Wdnez4P1rJg/3v55zcIv/m5f83XVqfl6vH0N7d/pMUcHAAAAGNv5i1c1Z9EqzZow+K+ph2EKD4+wr//jz0M6fe6Sls4apYAbtzR+6pcaP6x33MMFa7+hyIhI1WveTfXfripJ+mHrDs2fPExZM2fQ+Klf6q1qFdW4wZsPfbfz/sPH1bR9f52/cEXlShVRvtzZ7esmz16qBUu/kSSFht1T0UJ5Emz/tHJmzxzvXdP3XQu4qUNHT6lruyb2ZRaLRfXeqqLcObNq15+HNHfxGk0dO1ADurfRnMWrE0yzvB14R5kqlZEkZfb3063bd+KtvxV4R5ky+kmSzGYnZUyfVrcD49r8sGWHvv3uJ+XKkVm9OreQe/Jk//oYeVwjAAAA8B+zZ/8RVa5YSl6pUkqSPFN6JAhzx06cUYtOcSEmWTI3SZJfWh99s2GrDh45odhYq4Lu3JUUd5vV/deOvV6+pL6YsVgpU6bQm1UrJNj3/WmWIaFhWv7NRk2evVQ9O30oSerS9oME98xJUsfewxUaGq6yJQurQ6tGkqROvT+T2ewkv7RpNPrT7gn2Y7Va5eT09/M2vl79vdb+8LNCw8I1rH8npfVNHa99ypQemrt4tY6eOKuAGwln+z3IZIrr/+/9mP6x3hTvQYk2q00mk0kVyhRV7pxZ5eebWsPGz9JXq7576EDW0zJkmKtUroQqlSvh6DIAAAAAQ7LZbDI9voE+aFhL79atHm+bTn1GqHaNSurSronOX7wqmzUusDwYmooXyaepYwdqyYr1atv1U82dNCTe+vs8Urjr7RqV1POT8QnW/dM/R8akhPfM/dPxU+eUKWM6++f367+pBm9X1YedBir9P6Z2Xg24oZ6fjFOHlo1Uu3olte817LH1+Hh76dKVAJUtWViXrgTIx9sr/vrUXrp45ZqkuIelXAm4IR/vVHJ3Ty7PlHE116xSXlu2/fH4A3+ChGcVAAAAwCutaME82rp9l4LvhspqtepawE3JZJLVFjfaVLJYAa39/meFhYXLarXqxq1ABd8NVcCNW3qnVhXZrFYF3gl+aN9Hjp+Re/JkatOsga5cu6GQ0PCHtrPZbNqyfZdyZPNP9OMLuHFLcxatUsM61eMtd3Nz1Yfv19WU2V/FW3781Hllyuin18oVt4cwKe7eu5u3guyjcPeVL11U+w4elyTtO3hc5UoXkSQNGTNd5y9eUf7c2XQ3JEyBQcE6cvy08uXKpmTJ3LR6/RZFRUUrKipav+8+oNw5szzXcRpyZA4AAADAv5cjWyY1bvCW2nUfomRurmpQp5reqlpRFrNFu/YeVpkShXT81Dm17DJIbm6uerduddWu/preeK20PuwwUHlzZ1MGv7QP7fv4qbMaO3m+QsPC1bBONXmmTBFv/f7Dx9Ws/QDFxMbIP3069evWOtGOa/Mvv2vfoWNytlj0UYt3VSh/rgRtar5RXsu++UH7Dh23P8SkeOF8WrN+i1p1+UTlSxdTMte4V6xl8PNVBj9fNW7bVx/3bKeCfz0kpkKZovrjz4Nq0q6fcuXIrDffKC8p7l7EkNBwWSwW9e7cQv/rP0rOFos+6fWRTCaTnJxM6tBruILu3FWRgrn1Xt0az3W8pqioSN56/Rzuv2du+4YFsljIxgAAAHg6Se09czAe0gcAAADgAAQuPC/umQMAAAAAAyLMAQAAAIABEeYAAAAAwIAIcwAAAABgQIQ5AAAAADAgnmYJAAAAOEDbrn106cbDX7z9PPx9PTV74pgntitXs5myZ/FXSGiYMvv7qX/3Nkrn66OOvYfr1u07kiQnJyd1a99UZUoUkiT9sOVXLV31vWJjY5Ure2b17PShUrgnlyTdDryjsVMW6PLV63Jxdlb7lu+pVLEC9v7cXF0kSe++U0Nv16ikes27Kbmbm8zmuPGlDq0aqWzJwva6rDarShTJrw4t35Obm2uin6dXAWEOAAAAcIBLN4IVVLhZ4nd8YNFTNXNzddGiGSNktVq1at1mTZu7TEP7d5IkDenXUXlzZdPJMxfU85NxWrtkkvYfPqGvVn+vyaP6K6WHu5Z/s1HDx8/SqEHdZLVa1fOTcWrxQV29Xr6k7gSH6GrADfu+7vf3T1PHDlQqT4+H1hUba9W0eV9r/LSFGtij7XOckFcX0ywBAACA/zAnJycVL5wvXvi6L1f2zIqJiVFkZJRWfvujWjWpJ8+UKWQymfRu3eo6ffaibty8rT37j8rby1Ovly8pSUrl6aF8ubM/V11ms5Pat3hPO3cfUFhY+HP19apiZA4AAAD4D4uNtWrj1h0PDV+/7dovz5QecnNz1aUrAcqRNZN9nZOTk7Jn9df5S9d0/uIV5c6Z5ZH7GDxqmtxcXWSxWDRv8lD78k69P5PZ7CS/tGk0+tPuCbZzdrYoU0Y/XQm4qVzZMz/fgb6CCHMAAADAf1BEZJSadxggq82mAnlyqHPbxvZ1g0dNU2RklHxSe2nC8N6SJJOTSTabLV4fNqtNZqcnT/Z7lmmW/2S1WuX0FPv4LyLMAQAAAP9Bbq4uWjh9xEPXDenXURazWcPGz5JvmtSSpMwZ/XTyzAVlTJ9WUtyI3ulzl5TJ308xsbHauedgotcYGRWli1cClD5dmkTv+1VAxAUAAACQQM7smZUre2Z9+91WSVLDOtU1f8k3Cr4bKpvNpmVrflC+3NmUJrWXShTJr5u3grTttz8lSaFh4fp+86/Ptf+Y2FhNnfO1KpYppuTJ3J77eF5FjMwBAAAAeKh2HzZUu25D9EalMiqUP5eav/+2uvQb+derCbKof/c2kuIeVjJ+WE+NnjRPM79coWRurmrXvKG9n/v3zEnSG5XK6MP360j6+545SWpUv6ZqVXtNEZFRatZ+gGJjY1WyWH516/ACnvj5ijBFRUXantwMjxITE6OKtVpo+4YFsljIxgAAAHg6jn7PHIyP9AEAAAA4AIELz4t75gAAAADAgAhzAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAAADAgCyOLsDobDabJCkmJsbBlQAAAAB4lZnNZplMJvtnwtxzio2NlSRVrtvGwZUAAAAAeJVt37BAFsvfEY4w95xcXFyUKWM6LZ4xMl5KBpKypu37a/GMkY4uA3gqXK8wGq5ZGAnXq7GYzeZ4nwlzz8nJyUlOTk5ydnZ2dCnAUzOZTPH+qgMkZVyvMBquWRgJ16ux8QAUAAAAADAgwlwiaPB2NUeXADwTrlkYCdcrjIZrFkbC9WpspqioSJujiwAAAAAAPBtG5gAAAADAgAhzAAAAAGBAPLrmOX3z3Vat+PZHpXBPrmH9O8k3TWpHlwTEczckTKMmztWlywHyTJlCQ/t3kpOTkz4ZMUWBQcF6s1oFNX23tqPLBOK5FnBT77ftownDeytbFn+uVyRph46e0vipXyo21qo3q1bQW9Uqcs0iyVq5dpO+WvWdLBaL+ndrrTy5smnomOm6cOmaShYroK4fNeF1WwbCyNxzCAwK1qJl6zR34hA1rFNNU+cuc3RJQAKHj53Su3Wra9GMEcqdM4uWrNygeUvWqFL5Evpy2nB9v/lXXbx8zdFlAvFMnfu1/DOkkySuVyRp0dExGj5+poYP7KIFU4erbMnCXLNIssLvRWjekjVaNGOkxnzaXTPmL9ea9Zvlly6NFs8cqfMXr2j33sOOLhPPgDD3HP7485ByZc8iNzdXFSmYR7/v3u/okoAEypUqoqIF80iSCubLqZu3gvTbrv0qUjCPLBaLCubNqd93H3BwlcDf9h86LqvVqtw5skgS1yuStN37DitPzmzKmD6tzGYnZc2cgWsWSZbFbJa3l6dcnC3KmD6d3N2Ta8df16vJZFKRgnn0G9eroRDmnsPtwDvKlDHuL8c+3qkUa7UqIjLKwVUBj/bn/qMqlD+XAoOClTF9WklSpox+unX7jmMLA/4SG2vVtHnL1KXtB/ZlXK9Iyq4G3FSyZK7qM/hzfdhpoPYePMY1iyTLxcVZ9WpVUYden2nizMVqWKeabgfeUeaMfpKkzBn9dOt2kIOrxLMgzD0Pk2Sz/f1mB5vVJqYYI6k6c/6Sdu87ordrVoqbC//XtWu1WWVy4sJF0rBh0zaVKlZAfunS2JdxvSIpC793T6fPXtTHvT5Sny6tNH7Kl1yzSLLCwsL1x55DatXkHZ29cFnHTp6VSSZZrfevV5ucuF4NhQegPIc0qb10+NhpSdLN20FydnaWq4uLg6sCEgq6c1eDR03T8IFd5OriIm8vT12+el05smXSpcsBypEtk6NLBCRJv+zYrduBwdq556CuXLuhoyfOKPxeBNcrkiwfby9lzZxRKT3clS93Nt25G8J3LJKsX377U/nz5lDZkoVVokh+NWrdWxnTp9WlK9eUJVN6XbocIB9vL0eXiWfAyNxzKFWsoE6duaCIiEjtO3hc5UoVcXRJQAJRUdEaMGyi2jZvoBxZ/SVJ5UsX1b5DxxUTE6PDx06rbMnCDq4SiDN+WG8tmDpccyYOUblSRdS7cws1qleT6xVJVuniBbXv4DGFhd/T0RNnlDZNar5jkWSZzU46eOSEoqKidSvwju6GhKp86SLad/C4bDab9h8+rnKlizi6TDwDU1RUpO3JzfAo6zb+oq9Xfy8P9+QaNrCL0qTmrxlIWuYuXqMlK9YrS6b0iomJlSSNH95bw8bO1O3AO6pd4zU1bvCWg6sEEho2bqZqVauo7Fkz6ZMRU7hekWT9sOVXLVq+XjarTR/3aqcMfmm5ZpEkxcZaNW7KAv3x5yGZzU5q3/I9VShTVEPHzND5i1dVukQhdWnbmFcTGAhhDgAAAAAMiGmWAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAADIswBAAAAgAER5gAAhlKveTd99vls++eQ0DCVrdE0UffRsfdw/fLbnkTt81F+2PKrmncYoP/1G6XYWKt9+ckzF9S22xC16vKJzl+8+sz9Xgu4qY69hydmqQCAJMbi6AIAAHhW+w8d14lT55Q7Z1ZHl/Lc1m/cpg8avqWab1SIt3z773uVNXN6Deje1kGVAQCSOsIcAMBw3nunhr6YsVjTxn2cYF3ZGk3146qZ8kjhrpNnLqjvkAlas/ALXQu4qb5DJqh8maLa9tufcnVxVv9ubbRo+TodPHJKRQrm1uA+HWQymSRJv+86oGVrftCNm4GqWLaY/teuiUwmkw4fO63Ppy1UWPg9+aX10aDe7eXt5amOvYfrzaoVtfb7n1S1Uhk1qlfTXtP5i1c1buoCBd25q+TJkqnrR01UIG8OTZ+3TEdPnNHVgJu6dv2WWn7wjiTp5193a/X6zbJareobPEGjP+2uHX/s04z5KxQVHaWc2TLr457t5ObmqiUrNmjLtj90LyJC6dOl0dD+nRUSGqYu/UYqMChYzTsMUKsm9RQWfk/bfvtToz/tLkmaMH2RPFIkV5tmDTRn0SqZTCYdOnpKXqk8NbhPe63f+IuWrNyg2FirShYroJ4dmysyKkqfjpquM+cvycXZWV3bN1Xp4gVf/A8cAPBQhDkAgOEUK5xXG7fu0JZtfzxTmDh7/rI6t/1AbZs10IDhkzR41DRNGtVPyZK5qc4HXXT81DnlzZVNkpQsmasmjxqgyKgoNWvfXyWK5Feh/Lk04vPZmvBZH6X1Ta01G7boy6+/VfcOzSVJGzb+oqljBsrFxdm+z5jYWPUd8rnat3hPlSuW0pHjp9V3yAR9NXuMOrRqpEPHTqlRvZqqVK6EfZvXK5TU6XMXFRIaru4dmunKtRuatXClpo4dKI8UyTVj/nKt+W6rGtd/U8UK51WjejVkNpvVfeAY/bDlVzV4u5oGdG+jOYtXa9rYuMC74cdtjz03K9du0rzJw+SX1kcHjpzUD1t3aP6U4XK2WDR07Axt+/1PySZdvnZdK+aP192QMJnN3K0BAI5EmAMAGE5srFXd2jfToJFTVaJI/qfeLlkyN5UqVkCSVCBvDrknTyaf1F6SpOxZ/XXzVpDy5oprW6RgHpnNTkqezE0liuTXkeNn5OTkpOu3bqv34PH2OrJmzmDv/716NeMFOUm6dDlAERFRqlyxlCQpf54cyuCXVoePnVbZkoWfqu4/9hzU9Ru31bnPZ5KkqOgYlStVRJKUKaOfftiyQweOnNTlq9d1+er1pz4fD3rjtTLyS+sjSfr19726cPGq2nX7VJIUERmlfLmzqVrlsnJxdtboifP0fv2aypIpw2N6BAC8aIQ5AIAhFcibQ4UL5NL3m7fLyckUb11MTOwTt7eY4/8v0GIxyybbw9tazErm5iqbzaaM6dPqy6mfPbTd045UmZ7cJB6bbCpSMI9GDeoWb/m9iAi16TpYdWq+rqbv1pKvj7dCw8IfudOY2JhH7uPB2m2yqerrZdT1o4QPlpk3eah27jmoQSOnqtrrZdWs0dvPeDQAgMTC/AgAgGF1aPmeVq3bLGfnv0fDfLxT6cDhE4qJjdX3m7f/674vXQmQzWbTjVuB+uW3PSpTopDy58mh6zdua+v2XZKksPB7Crpz97H9+GdMJzc3F/28Y7ck6cjxM7py7YYK5M3x1LWUKlZQu/ce1qGjpyRJQXfuKvxehC5euqY7wSF6t251pfX10akzF+zbpEvroxs3A+1PyPTx9tLJMxcVFn5PN27e1q69hx65v/Kli+q7Tb/q4uVrkqRr128pNtaqs+cvKyj4rsqWLKx6td/Q73sOPPUxAAASHyNzAADD8k2TWm9Wrag5i1bZl7Vt3kAjJsxRphXp1PS92vp5x797xcDNW0Fq132I7oaE6qMW7yln9sySpLFDemrizMWau2i1XF2d1al1YxUvku+R/VjMZo0e3EPjpizQ7IWrlDyZm0YO6iaPFO5PXYt/hnQa0q+TxkyaL5tsSp7MTX27tlL2rP4qV6qImnzUX5kz+ilDel9ZrXGji+nT+Sp7Fn81at1LrZrUU/XKZZUre2Y1at1LhfLlUtVKZWSzPXwksmjBPOrStrH6Dpkgi9kiz5QpNLhvB925G6Ixk+Yp5K/Rvz5dWj71MQAAEp8pKiry4d/kAAAAAIAki2mWAAAAAGBAhDkAAAAAMCDCHAAAAAAYEGEOAAAAAAyIMAcAAAAABkSYAwAAAAAD+j9XzVC6hiP/kQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 900x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "image/png": {
-       "alt": "Grouped horizontal bars per case study giving the candidate feature count, the number clearing Benjamini-Hochberg, and the number reaching PROCEED. The PROCEED bar exceeds the FDR-significant bar in most case studies, because the stability route to PROCEED does not require BH significance."
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "7aa636fe",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(9, 5))\n",
     "y = np.arange(funnel.height)\n",
@@ -411,16 +233,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d689359",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001044,
-     "end_time": "2026-08-20T07:52:27.810878+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.809834+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5053164f",
+   "metadata": {},
    "source": [
     "The same triage protocol, applied to nine different markets, produces very\n",
     "different survival rates. The summary below is computed from the table above\n",
@@ -429,40 +243,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "8b2fdfa1",
+   "execution_count": null,
+   "id": "89d645eb",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.813676Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.813598Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.817598Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.817254Z"
-    },
-    "papermill": {
-     "duration": 0.006487,
-     "end_time": "2026-08-20T07:52:27.818355+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.811868+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "Across 9 case studies, the share of candidate features clearing BH-FDR at 0.05 runs from 0.0 to 66.7 percent (US Firms highest). 4 clear it for none of their candidates: FX, CME Futures, SP500 Eq+Opt, US Equities. PROCEED rates run from 0.0 percent (US Equities, 0 of 73) to 70.2 percent (US Firms, 40 of 57). Of 147 PROCEED decisions in total, 88 were reached on effect size and fold stability without clearing BH, which is why the PROCEED bars are not contained inside the FDR bars."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "_f = funnel.sort(\"pct_fdr_sig\", descending=True)\n",
     "_none = _f.filter(pl.col(\"n_fdr_sig\") == 0)[\"cs_short\"].to_list()\n",
@@ -494,16 +282,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78f0472c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001848,
-     "end_time": "2026-08-20T07:52:27.822188+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.820340+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "eafd40ca",
+   "metadata": {},
    "source": [
     "A case study can reach zero surviving features and still support a trained\n",
     "model. Univariate IC asks whether one feature predicts on its own; the model\n",
@@ -514,16 +294,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e908ea86",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001839,
-     "end_time": "2026-08-20T07:52:27.825897+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.824058+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f48f9187",
+   "metadata": {},
    "source": [
     "## 3. Forward Link: Feature Survival vs Strategy Survival\n",
     "\n",
@@ -542,60 +314,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "d510dacb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.830258Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.830178Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.834773Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.834362Z"
-    },
-    "papermill": {
-     "duration": 0.007597,
-     "end_time": "2026-08-20T07:52:27.835351+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.827754+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (9, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>cs_short</th><th>pct_proceed</th><th>rank1_val_sharpe</th><th>holdout_sharpe</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;us_firm_characteristics&quot;</td><td>&quot;US Firms&quot;</td><td>70.2</td><td>2.746176</td><td>2.612811</td></tr><tr><td>&quot;crypto_perps_funding&quot;</td><td>&quot;Crypto&quot;</td><td>54.5</td><td>null</td><td>null</td></tr><tr><td>&quot;fx_pairs&quot;</td><td>&quot;FX&quot;</td><td>42.9</td><td>-0.004311</td><td>-0.157475</td></tr><tr><td>&quot;etfs&quot;</td><td>&quot;ETFs&quot;</td><td>23.9</td><td>null</td><td>null</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;SP500 Options&quot;</td><td>17.6</td><td>0.001681</td><td>1.094734</td></tr><tr><td>&quot;cme_futures&quot;</td><td>&quot;CME Futures&quot;</td><td>17.4</td><td>1.126253</td><td>1.14181</td></tr><tr><td>&quot;nasdaq100_microstructure&quot;</td><td>&quot;NQ100&quot;</td><td>15.9</td><td>null</td><td>null</td></tr><tr><td>&quot;sp500_equity_option_analytics&quot;</td><td>&quot;SP500 Eq+Opt&quot;</td><td>8.3</td><td>1.482389</td><td>-0.727829</td></tr><tr><td>&quot;us_equities_panel&quot;</td><td>&quot;US Equities&quot;</td><td>0.0</td><td>null</td><td>null</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (9, 5)\n",
-       "┌───────────────────────────────┬───────────────┬─────────────┬──────────────────┬────────────────┐\n",
-       "│ case_study                    ┆ cs_short      ┆ pct_proceed ┆ rank1_val_sharpe ┆ holdout_sharpe │\n",
-       "│ ---                           ┆ ---           ┆ ---         ┆ ---              ┆ ---            │\n",
-       "│ str                           ┆ str           ┆ f64         ┆ f64              ┆ f64            │\n",
-       "╞═══════════════════════════════╪═══════════════╪═════════════╪══════════════════╪════════════════╡\n",
-       "│ us_firm_characteristics       ┆ US Firms      ┆ 70.2        ┆ 2.746176         ┆ 2.612811       │\n",
-       "│ crypto_perps_funding          ┆ Crypto        ┆ 54.5        ┆ null             ┆ null           │\n",
-       "│ fx_pairs                      ┆ FX            ┆ 42.9        ┆ -0.004311        ┆ -0.157475      │\n",
-       "│ etfs                          ┆ ETFs          ┆ 23.9        ┆ null             ┆ null           │\n",
-       "│ sp500_options                 ┆ SP500 Options ┆ 17.6        ┆ 0.001681         ┆ 1.094734       │\n",
-       "│ cme_futures                   ┆ CME Futures   ┆ 17.4        ┆ 1.126253         ┆ 1.14181        │\n",
-       "│ nasdaq100_microstructure      ┆ NQ100         ┆ 15.9        ┆ null             ┆ null           │\n",
-       "│ sp500_equity_option_analytics ┆ SP500 Eq+Opt  ┆ 8.3         ┆ 1.482389         ┆ -0.727829      │\n",
-       "│ us_equities_panel             ┆ US Equities   ┆ 0.0         ┆ null             ┆ null           │\n",
-       "└───────────────────────────────┴───────────────┴─────────────┴──────────────────┴────────────────┘"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "d3b124f1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mq = pl.read_parquet(OUTPUT_DIR / \"measurement_quality.parquet\")\n",
     "forward = (\n",
@@ -616,39 +338,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a9303f3e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.838789Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.838725Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.935554Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.934987Z"
-    },
-    "papermill": {
-     "duration": 0.098926,
-     "end_time": "2026-08-20T07:52:27.935966+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.837040+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABDcAAAGYCAYAAABWPwlLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAia9JREFUeJzs3XdUVEcbx/HvAiICYlewYu+992hs0di7sZfYY9dYYtdYYy9YY++JPbZo1Nh774odO0UQENj3D+IqL6LGAOvC73OO57Bz75377OzKHZ47M9cQGBhgRERERERERETEQlmZOwARERERERERkf9CyQ0RERERERERsWhKboiIiIiIiIiIRVNyQ0REREREREQsmpIbIiIxwIgJbhSv3DTcP08vn/9cd6c+I9myY18kRPnl2XfwBPVa9iQgMPA/11W8clMOHTsTCVF9ujUbdtC225BIqetzP+ctO/bRqc/I/3z+eUvWMWKC23+u59/ye+XPxBmLqN64C1UbdKLf0Encun3ftL128+4W8/1/6PGE4pWb4n7ngblDiTIjJrgxb8m6/1RHbGgnEZHYyMbcAYiISOQoXawA/bq1DlPmFN/BTNFYhvjxHUiTyhlra2tzh/JZEiV0Ik0qZ3OHYdGmzF7KlevuDOjZjsQJndi+5xBui9YwZnB3c4cmIiIi/4KSGyIiMUTcuLYkSZzQ3GFYlPy5s5E/dzZzh/HZKpQtRoWyxcwdhkXb8/cx+v7QiuKF8wKQNXN6QkJCzByViIiI/FtKboiIxALXbtzml5mLuXrjNhlcU9O7cwuyZk4PwNkLV1m6ejPnL1/HxsaaJnWr0ahOFSB0qgXAqbOXGTlxDjPGDQCgc9/R/LVpAXFtbYHQoeKBga8ZMaALEDqUf0CPtmz84y8OHz/L2l8n4hTfkbUbd7Lq92289PWjbIlCdOvQFPt4dmFiDQ4OYdrc5ezYfRArawNflSxCx9YNcLCPR+3m3WnWoDp1vv0agJNnLoaJZd6SdTx97km2zOlZsOx3vqtXjcmzl7Jh6RSSJ0sCgLePL1UbdmLxzFE8evKMnoPGc2j7UmYtWMWlq7eYOuZHUyxrN+5k6859LJg2gpvu9/h1xQbOXrhKQGAg1SuXpUOrBlhZfXiG5+vXQazfupttfx7A/c590qVxYUCPdmTKkNYUz4Tpv3Lw6Gl8/V6ZjmvTtDatv6vNzr8OsX7Lbq7dvEOypIno3bklBfPlAOC3zX+yZPUmfl88GQidWlKtYhnu3HvItj8PYGVloO8PrU1/uN+978HPk+dx+eotUrokp3nD6lQqV+K9n3OBvDk++pn8MnMxW3fuN31XqlYszU+929Opz0hqVPmK85dusGPPQWaMG0D8+A78unwDJ85cxMvbh7IlC9O7Swvi2trSqc9ITp29DMDWnftp07Q2bZvVxd8/gGnzVrBn31Hs7OJSr0ZFGtf9BoPBQGDga6bMWcafew/j5f3SFGvViqV5+OgJ+XNnp13zuqbyn0ZPJ0XyJHRp2zjM5xPPLi7HT1+gfOkips/y/z9Tv1f+jJ+2kD1/HyO+owND+3Uke5YMAB/9XhSv3JTFM0cxY/5Kbt6+x++Lp9D1x9GUKV6I23cfsPfAcRIkcKRzm8aUKpbfdM4Tpy8yfd4K7tx/SM6smej7QytSp0zxwe/aG1eu32Ls1AVcv3mHPDkzM7Dn9yROlIARE9wwGo0M7tPBtO/M+Su5//Axowb9EKaOkJAQ1m7cybpNu3j+wovC+XPSu2tLEiVw4tCxM6z6fRuXrt4ivqM9HVs1pMJXoUk2f/8Axk5dwIEjp3B0cKDK1yVp1aQWceLYfPDzfNfzF178PHkeJ89cImmShNT5tgINalWmToseeDx6CsD8pb8zqNf3FMiTnToterBi7jhc06YEQqc4HT5+lnlThgEQFBTE7F/X8Meuv7GPZ0fViqVN5zp55iI9f5rA1lUzTb+L3O88oFnH/mxdNZP4jhr9JiJiKbTmhohIDPf02Qs69x1F8SJ5mT91GOVLF6H3kF9M60z8ffgkRQvlZsa4gbRvUZ8pbku54X4XgM0rppMwQXy6d2jK5hXTyZ0jyyefd+yUBWTN5MrC6SNI4BSfdZt2sXbjTrp+34QZ4wfywOMJ85b8Fu64XXsPs2vvIYYP6MyUn38k6b8cjXL0xHn++vsY44f14ttKZciYPg1/Hzlt2n74+BlSuSQjfbpUYY4rX7oIp85dwtfXz1T29+GTfFWqMABHTpwlU4Y0TBjei4E9v2fFb39w8OjH19jwe+XPqbOXaNO0NvOnDid5siSM+mWuafvUOct47unF5NH9GNG/C44O9kwa1Zcm9aoRHBzC34dP0aBWZeZPHUaBvDkYOnYmr18HRXi+KW5LsbOLy5Sf+5Ere2bGTV2A0WgEYML0X0mcMAFzpwzlh++/49WrAODjn3NEn0mPjs2oW70iubJnZvOK6fTo2Mx0zLwlv2FjY82cSUNI75qaM+ev4uTkyPD+nRk3tCf7D51g4x9/AfDzT90pXawAX5cpyuYV02lSrxoAwye44fHoCT8P6c6g3t+zev12DvzzWS5ZvZlzF64yetAPTBjei+RJEzOgZzt6dGxGtUpl2PnXIdP7Dgx8zcFjpylfuki49mrZpCYbtu6hXfdhHD1xznTMu+YsWksG19TMHD+IxAmdmOq2zLTtU74Xg0ZPp0LZYsyZNARr69Cul9uva0iXJiUzJwykbIlC/Dh8Mo+fPANCk5H9hk2iepWvmD9lOJkzpuWn0dPfG9v7LF29hVZNajFtbH9eeHozfPxsAKpVKsPeg8fxD3i7xszegycoX6Zo+DrWbGb+0t9p17wucycPJWvm9FhbhU7f+uvAMSqXL8ncyUOoXvkrRkx044WnNwArf9/G1eu3+WVkX0b/9AO2ceJgsApNXnzo8/z/9vbz82fmhEEM7Pk9wcGhI2kWTB1OlkzpaFy3KptXTOfrTxy15PbrWrb9+TeDen3P6EE/cP3mHdO2fLmzkSRRAvYfOmkq23foOEUK5FJiQ0TEwmjkhohIDLFn/1HK12xjet29Q1NqfFOOFb/9QYki+WjesAYArmlTseGPv7hw6ToF8uagU5tGpmNc06Zk9q9rOHX2Mhld05AkcUKsrKxwdLD/11NesmRypWmDbwEwGo0sWPo7Q3/sRJECuQDo0Ko+g0ZP54fvm4Q57qWvLwkTOJE/d3asra3I6JrmX53Xy8eHgb0GkyxJIgDKlSrCgSMnTaM9/j58iq9KFg53tzhLJleSJ03M4RPn+LpMUXz9XnHy7CV6dmoOQOO6VU37ZsqQluxZMnDq3KUwd9vfJ4GTI6N/6mZ6Xafa13QbMJZX/v7Es7PjyjV3vm9Zj1zZM5EreyZ27TvMTfd7FCuUB8A0GgagUe0q/LZpF3fve5DBNfV7z1fxq+K0alILgErlS7Br72F8XvrhFN8Bn5d+FC6Qi4yuacK068c+5w99Jvbx4hInjnW44xI4xadruyamP+Yrly8RZnvRgnk4de4y9WtWIoGTI3Hj2mJrG8dUz033exw4fIqtq2fiYB8PgLrVK7Dn76OUKpafK9duUb3KV6YRJuXLXODqdXeqVy5L+dJF+GXGYq5cdydb5vScPHsJp/iOptEW76pd7WtSOSdn4sxFdBswlsL5c/FTn/am7w9Ai0Y1qFu94j/nKYrbr2tM2z7le1GqWH6+rVw2zHnrVP/aNEKqfcv67PzrELv2HqFJvaosXLGB+jUrmb6zHVs3pFKd7/F49BQX52Th3sP/G/ZjJ9P3o+v339Gp90heeHqTL1fW0JEXR09TrnQRbt99wKMnzyhRJG+Y41+/DmLhsg306tzcNO3JNW0N0/YBPdqZfm5Upwrzlv7GxSs3KFk0Py99/XBOkZSc2TJiMBjI9s8IsY99nu/yeemLa7pUZM3kCkCenKHJtkQJnYhjY4N9vLif/PsoIDCQ1eu3M7BXO9MIpnbN67F7/1EgdJRO1YqhybA339H9h05Sq2r5T6pfRES+HEpuiIjEEEUL5aZ7h7d3zhMldALg2o07nDp3iX0HT5i2+QcE8uSZJxDa+d+55xC79h7mxq27vPD0xtPL+z/HUyhfTtPPT5694IWXN32H/oLVP0mFEKOR4ODgcMd9U6E0h46dpcn3/Wja4Fu++bokNjaffrlKnzZVmD9My5cuwuKVG3nl708cGxsOHTvDtLH9wx1nMBgoV7oIfx8+yddlinLkxDnSpHImbWoXIHRqxt6Dx9n+5wGu3nDn6XPPT17M86HHE37f8ifHT1/k7n0PADw9fYjnbEeRgrnY/ucBcmbNyMNHTzl7/io1vylnOvb5Cy82/LGHw8fPcvtu6NMdPvT5vPnDESC1S+g0Bl/f0ORG1++bMHKCG+cvXadl45qmPzw/5nM+k4J5s5sSGxCa4Dpy4hxbduzj8rVbPHryjFzZM0V4/LWbtwl8/Zrqjd8md4KCg01rpBQpmJvd+49QqlgBAgICOHTsLA1qVgIgnp0dX5ctyo7dB8mWOT37D52gXKki4RJabxQpmJvlc8axa+8hps1dTvsew1k5bxy2tnEAsH+nTVO5JA8zfehTvhfv/l94w/qdqS8Gg4H06VLzwONJ6Hu/cZu/D59k1e/bTPu88g/gybMXn5TceHdaTYZ/Rih5PH5KooROVKtUhh17DlGudBH2HzpJicJ5iWcXdmrY3fse+AcEUPSfBNv/e+nrx5Yd+9h38AS37twnJCTE9GSmRrWrMGDkVFp3HUyLRjUoU6IgVlZWH/0839W2WV0GjZpGl36jadm4JgXz5ojws/uYu/cfEfj6NQXyZI9wn6oVS7N45Ua8vH0ICgrmynV3ShUr8FnnExER81FyQ0QkhrCPF++9f2wbjUa+rVSWJvWqhilPkjghISEh9Bo0gcDXr6lbvSKF8+ek79BfPul8xpBPGyL/TxAAjB3Sg5Tv/HH2vj9Y7OPZMWF4L85fus6ilRtYsmoTsyYMMt2pNRr/3WKP6dOlIqVLMo6ePI+jvT2OjvamO8L/r1ypIvQcNJ6g4ODQKSklC5u2/TxpLhev3KRxvar06NSMGfNWftL5r924Tac+o6hasTRd2jYivqMDzTsNNG2vV70iLbv8RM2mPxASEkLD2t+YRm08fvKMtt2HUihfTlo2rkmOrBmoUr/jJ7/3/2/f/LmzsWLuOLbu2s+gUdMoXjgvvTq3+Gg9H/tMPsWCZb+z4Y89NG9Yg7bN6rB5+z4uXLke4f5Go5GECeIzZ1LYR93a2cUF4JuvS7Jk1SaatOuHf0AAlcqVoMY3X5n2q1apLD+NnkaXdo05cOQ0owZ1/WB81tZWVC5fkoyuaWjWcQDXbt4mZ7bwyZf/b9PP/V78v4CAQOzjhb43o9FIy8Y1qfhV8TD7JE+W+LPqBUwJjG8qlGLRyo34+r3iwJFTphEp73qzoOr70gm+fq9o33M4LimSUb9WJQrmzUGjtn1N25MmSYTbL4M5cuIcvy5fz9I1m5k2tv9HP893pU+XisWzRrNn/1GmzF5GSudkjP6pW5hk2f+LaMpOcFDoFK4PPRHJJUVS8ubKyl9/H8fK2oqCeXOQwMkxwv1FROTLpOSGiEgMlzF9Gk6fu0wql+ThFkq84X6XE2cusn7JFFIkD11wM+T/khbW1lamP5Dg7ciAew8fkyl9GoxGI8+ee35wfnqypImJ7+iA+537FC2Y+5PizpU9E+OH9aJLv9H8ue8IDWpVxsE+HvcfPDbt82b0yceETk05RXxHB74qWSjCu8A5smYgnl1czl28xuHjZ5n6c+jior6+fmzd9Tczxw8k3z93mj/1iRp//HmArJldTetR3Lp9P8z2Ras20qNjU0oXK4C1tXWYP/b2HjyBbZw4/NS7PQaDAX//gE8654fY2sahVtXyFC+Ul1rNutG+ZX0cHezDfc7v877PxNramoCA1x8975oNO+jWvinfVCgFgJEPf88yuqbB08sHf/8AMmdMF66+tZt2UataeRrX+Ybg4GAcHOzDbM+TIzN2ceOy5Z8FT983JSUkJIQ79zxMC1ECpoRN3Ljh/+j+f//le/Euv1f+XLl+i2qVQhe6zJg+DVeuu9P6u9r/uq7/d+rcFeLGtTUlFZ2TJyVvzizs2HOQqzdvU6JovnDHpE7ljI2NNSfOXKRy+ZJh6zt7mbv3PVg0YyQ2NjYYjcZwiU6DwUCxQnkoUiAXDdv04fipCx/9PP+ftbUVFb4qRqniBfimfkdu3b5Hpgxpw33f7E2/jx6Z1tF5+s7vBRfn5BgMBi5fu2WalvK+z6hapTL8sWs/DvbxKPeetVlEROTLpwVFRURiuMZ1vuHOvYeMmTKfm+73uHjlBotWbsRoNGL/z93c7XsOcMP9LlPdlnH1xu0wx6dyTs7eg8e5dfs+3j6+pE6ZAru4cfl98y4uXL7B2CkLwv3B/v8MBgOtv6vNnEVr2bJzH/cePOKvv4+x/9CJcPv+MnMxK3/bxk33exw6doar12/jnDwpAJkzpGP/4ZNcuHydzdv38uuK9Z/UBuVLF+HQ0TMcOnomzGiM98VZrnRhFi5bj308OzKmD11bIk6cOMSxsWH3/qPcun2fX1ds4MDR02GOtY9nx+Mnz8PV6WBvx9Xrt7lw+TonTl9k9KS5Ybb7+flz+twVnnt64+v3Cl9fP9NdaHt7OzwePeXYyfOcv3SdASOnfvbw/Bee3vQYOI4DR05x++4D1m/dTQInR1My5f8/53d96DNJ6ZKc67fucOrcZR54PA533rftE4/9h09y6/Z9ftu0i41/7AmzPaVzcs5evMqlqzd59PgZmTOmo0zxggwaPZ1jp85z595D1mzYwZ17D/9pt1dcunITj8dP8Q8IxOelb5i79waDgW8rl2HGvBWUK134vU+1OXfpOi27DGL+0t+5dPUm12/eYcyU+WTN5Bom4RGRT/leRGTnX4f468AxbrrfY/Qvc3Gwj0f50qELe7ZsXJO/D5/E7dc13L77gNPnLrNmww4gdITCT6Ons2XHvgjrdvt1DVeuu3P05Hmmz1tBg1qVTVNsAL6tXBa3X9dQOH+ucE8rArCLa0uj2t8wZfYy9h48jvudB8xf+hvnL13H3t6O16+D2PnXYa5cd2f4+Nl4+7w0xTb45+ls2r4X9zsP2L3/KA8fPSVF8qQf/TzfCAx8Ta+fxrNr72Fu333A5u17CQ4JJnHiBEDo9+TIibNcv3WX5y+8cIrvgHPyJGzZsY9LV2/i9usaDh17u6CrU3wHypUqzOTZSzl38RpnL1wN938QoGzJQly9fpvjpy9StkTBT/oMRUTky6LkhohIDJcieRJm/zKY+w8e0677UAaNmo6f3yuCQ0JwcU5Gh1YNWLp6MwNGTCVF8iR8W6lMmOM7tGrAvQeP6Nx3FOcuXsXBwZ7eXVqw9+BxhoyZQfp0qUwLI35Iw9qV6dCqAYtXbqJ5xwEsWb35ves21Pm2AkdPnqNDr+GM/mUuDWpVonTx0Pnv7ZrXwSm+Iz0GjuPIiXOMG9rzk9ogY/o02NnFxcvnJbmyZ/7gvuVKFeHYqfNh1miwtY1D326t2LX3MD0HjSMw8DXNGlQPc1zFcsWZMX+l6ckOb9SrUYmsmVzp2u9nFq5YT6/OLYgT5+37rv3t12zffZDG7frxbeMuVKjzPfVa9uTKtVtULFucsiVDn6QxefYSGtWuQppUn/Y40P+XMEF802KYLToP4uCx0/w8uDs2/wzX///P+V0f+ky+LlOUQvly0PunCSxeuSnC8/fp2pJLV27Qpd9obt6+T+c2YR/JWrd6BVIkS0rXfj+zecdeAIb+2JEiBXIxYoIbbbsN5ciJc6b9q1f5ihNnLtKi0yC+bdyFSnXbU71JlzB/2Fb8qgRe3i8pV+r9d+Lz5szClNH9uHjlBr1+msAP/ccQ19aW8cN7mdrlQz7lexGRXNkzs2nbXtr1GMoLT2+mjulvSkBkz5KBqT/35+jJ87Ts/BM/T55H0D/TK0JCjNy6c59V67e/t944cWyoWK44g3+ewdAxM6lYthjfv/NIXIAyJQry6lVAhO0C0L5VferWqMBUt2V832MY7ncekNIlGflzZ6Nu9YpMmPEroybOoXjhvBTKH7qmiMFgoEGtKqGP8+02mBnzV9KzU3Oy/DNS40Of57ttWrtaBVas+4OWnX9izYYdDO/fmcQJQ5MbLRpVJzgkhE69R/L34ZMYDKGPO75y3Z2+QydhNBrp1qFpmDr7dWtDpvRp6DloPJNnL6Fjq4Zh/g9CaEKnRJG8ZMvsSgKn+BG2i4iIfLkMgYEB/2LStIiIiESWkJAQGrXty7ihPXBNm8o0xafrjz9TpEAuenRsbu4Qv1hd+/1Mk3pVKV44L0ajES/vlwz+eQZ2cW0ZNyw06bV7/1Hcfl3Nirnj3jtyw1w69RlJrmyZwjyp6N+46X6PCTN+Zeb4QZ91/KWrN+nWfyy/L5kcZgHa2CwkJIRmHQfQvGGNcE/2ERERy6A1N0RERMzEPyCQBx5P2LX3MKWKFcBgMHD63GUeP3lOkQKftjZJbOV+5z5/Hz6Jo4M9DvbxOH/5Ojfc79Lmu9r4vPTl6vXbzJy/kk5tGn1RiY3/6oWnNxNm/EqDmpX/9bF+r/y5dfseE2csokWjGkps/OPeg0f8vuVPANOjb0VExPIouSEiImIm9vHsGDmwCwuXr2fpmi3EtbUlY/rUDPuxMyWL5jd3eF+0EQO6MHPBKv7YNQYrKyvSpUlJpzYNqVqhNItWbmT52i1Uq1SGcqUiXmPFEnl5v6RW1fJ89Rnva/+hE4ybtpAyxQtRt0b4p6TERv4BgbTuOhjn5EkY3KfDB5/IIiIiXzZNSxERERERERERi6b0tIiIiIiIiIhYNCU3RERERERERMSiKbkhIiIiIiIiIhZNyQ0RERERERERsWhKboiIiIiIiIiIRVNyQ0REREREREQsmpIbIiIiIiIiImLRlNwQEREREREREYum5IaIiIiIiIiIWDQlN0RERERERETEoim5ISIiIiIiIiIWTckNEREREREREbFoSm6IiIiIiIiIiEVTckNERERERERELJqSGyIiIiIiIiJi0ZTcEBERERERERGLpuSGiIiIiIiIiFg0i0luGI1GgoKCMBqN5g5FREREYhn1Q0RERL5sFpPcCA4OpnS1lgQHB5s7FBEREYll1A8RERH5sllMckNERERERERE5H2U3BARERERERERi2Zj7gBEREQkvPI127B7w3zT635DJ9GwdmUK5M3B9Vt3Gf3LXPz9A0iU0IkeHZuRKUNa077zlqxjw9Y9JEroBEDuHJlp1aQWM+avYkjfDtH+XkRERMSyWGI/RMkNERERCzNp5mJaNalJ6eIFuXX7PgZD+H0a1fmG7+pXC1OmxIaIiIj8V19qP0TJDREREQvzyt+fl76vAEifLtUnHfPQ4wm9B09k2ZwxbNmxj9v3HnLxyg1KFsmHr98rgkNCOHfhGh6PnzKgZzvWb9nNqbOXaNe8LjW+Kce1G7cZOnYWQcFBlCiSj27tm0blWxQREZEv1JfaD9GaGyIiIham6/ffMXP+SgaMnMpN93ufVcfm7XsZ/mNnGtetCsDV67eZPLovNb8px8gJc+jW/jvGDOnO4lWbANi47S+qVizNirnjaFznm0h7LyIiImJZvtR+iJIbIiIiFiDEGILBKvSynT93NlbMG0eWDOno1GckO/YcDLf/yt/+oHnHATTvOIDrN++E2/5VycIkTpTA9LpAnuzY2NiQNZMr6dOlIknihGTN5MoLT2/T/tv+PMCWnftJnDhh1LxJERER+SJZQj9EyQ0REZEvkIODPf7+AabXnl4+JH3nYu7oYE/LJjUZ2Ot71mzYEe74RnW+YfGs0SyeNTrMIl9vWFm9vwtgY2P9zs82GI1GAArmy8GM8QO5d9+Ddt2GEhIS8rlvTURERL5wltgPUXJDRETkC5Q/dzb++PNvAK7fussLT29cUiTF1+8VbovW8MrfH6PRyKPHz3BOnjTK47lw+QYO9vFo26wu9x8+xuelX5SfU0RERMzDEvshWlBURETETNzd3Xn48CEuLi64urqG2dalXWNG/zKX3zb9iZW1gUG9vsfGxgZra2uSJEpIh14j8PcPwDl5Ugb0aBflsV6+dpPx0xby0tePejUqksDJMcrPKSIiIlEnpvVDDIGBAcYojyQSBAUFUbpaS/Zv+RUbG+VkRETEch07fpxu/YbgjQM4OYO3B074MmXsMAoXKmTu8OQ91A8REZGYIqb2Q3R1FhERiUbHjh/nu059iV+lNw72TqbyAD9vvuvUl2Uzx1l0x0JERES+XDG5H6I1N0RERKJRt35DiF+lNzbvdCgAbOydiF+lF936DTFTZCIiIhLTxeR+iJIbIiIi0cTd3R1vHMJ1KN6wsU+ANw64u7tHb2AiIiIS48X0foiSGyIiItHk4cOHoXNbP8QpBR4eHtETkIiIiMQaMb0fouSGiIhINHFxcQHvj3QYvB/h7PyRjoeIiIjIvxTT+yFKboiIiEQTV1dXnPAlyM/7vduD/Lxwwjfc49hERERE/quY3g9RckNERCQaTRk7DJ9tE8J1LIL8vPDZNpEpY4eZKTIRERGJ6WJyP0SPghUREYlGhQsVYtnMce88Xz4FeD8igcGX2Rb8+DURERH58sXkfoiSGyIiItGscKFCHPxzC+7u7nh4eODs7GyxQ0BFRETEssTUfoiSGyIiImbi6uoaIzoTXxpvH1/GTJnP3XseJHByZHj/ziROlMC0fcQEN06dvYyjQzwApo8biFN8B3OFKyIiYhYxrR+i5IaIiIjEKOcvXaN+zUrkz52NaXOXs2ztFrq2axJmnwE921IoX04zRSgiIiKRTckNERERiVFKFMln+jl3jszs3nc03D4JneJHY0QiIiIS1ZTcEBERkRjrxOmL5MmZJVz5tLnLefTkOZXKFadVk1oYDAYzRCciIiKRRckNERERiZFuuN/l2KkLdGnXOEx584bVsbePR3BwMJ37jCJfrqwUyJsj3PFrN+5k3aadABiNxmiJWURERD6PkhsiIiIS47zw9GbImJmMHNiVuLa2YbalS5PS9HPJovlxv/vwvcmNejUqUq9GRQCCgoIoXa1llMYsIiIin8/K3AGIiIiIRKbAwNcMGDGFds3rkil9GgCWrdnCjj0HeeHpzfbdBzEajXh6+XDmwhWyZnI1b8AiIiLyn2nkhoiIiMQoS1Zv5sp1dxat2MD8Jb8BkCNrRgwGA/b2dly+dpMV67bi6eVDw9qVyZkto5kjFhERkf9KyQ0RERGJUdo0rU2bprUj3N6tfdNojEZERESig6aliIiIiIiIiIhFU3JDRERERERERCyakhsiIiIiIiIiYtGU3BARERERERERi6bkhoiIiIiIiIhYNCU3RERERERERMSiKbkhIiIiIiIiIhZNyQ0RERERERERsWg2UVGpt48vY6bM5+49DxI4OTK8f2cSJ0pg2j5ighunzl7G0SEeANPHDcQpvkNUhCIiIiIiIiIiMVyUJDfOX7pG/ZqVyJ87G9PmLmfZ2i10bdckzD4DeralUL6cUXF6EREREREREYlFoiS5UaJIPtPPuXNkZve+o+H2SegUPypOLSIiIiIiIiKxTJQkN9514vRF8uTMEq582tzlPHrynErlitOqSS0MBkNUhyIiIiIiIiIiMVCUJjduuN/l2KkLdGnXOEx584bVsbePR3BwMJ37jCJfrqwUyJsj3PFrN+5k3aadABiNxqgMVUREREREREQsVJQlN154ejNkzExGDuxKXFvbMNvSpUlp+rlk0fy433343uRGvRoVqVejIgBBQUGUrtYyqsIVEREREREREQsVJY+CDQx8zYARU2jXvC6Z0qcBYNmaLezYc5AXnt5s330Qo9GIp5cPZy5cIWsm16gIQ0RERERERERigSgZubFk9WauXHdn0YoNzF/yGwA5smbEYDBgb2/H5Ws3WbFuK55ePjSsXZmc2TJGRRgiIiIiIiIiEgtESXKjTdPatGlaO8Lt3do3jYrTioiIiIiIiEgsFCXTUkREREREREREoouSGyIiIiIiIiJi0ZTcEBERERERERGLpuSGiIiIiIiIiFg0JTdERERERERExKIpuSEiIiIiIiIiFk3JDRERERERERGxaEpuiIiIiIiIiIhFU3JDRERERERERCyakhsiIiIiIiIiYtGU3BARERERERERi6bkhoiIiIiIiIhYNCU3RERERERERMSiKbkhIiIiIiIiIhZNyQ0RERERERERsWhKboiIiIiIiIiIRVNyQ0REREREREQsmpIbIiIiIiIiImLRlNwQEREREREREYtmY+4ARERERCKTt48vY6bM5+49DxI4OTK8f2cSJ0pg2n7vwSOGjp3JK/8AmjX4lipflzJjtCIiIhIZNHJDREREYpTzl65Rv2YllsweTdbMrixbuyXM9iluS2nVpBZzfhmM269reOnrZ6ZIRUREJLIouSEiIiIxSoki+cifOxsAuXNk5snTF6ZtwcEhHD5+lny5suLgYE/a1C6cPHPJXKGKiIhIJFFyQ0RERGKsE6cvkidnFtNrLx8fEjrFx8HBHoC0qV14+uxFRIeLiIiIhdCaGyIiIhIj3XC/y7FTF+jSrrGpzICBEKPR9DrEaMRgZXjv8Ws37mTdpp0AGN85RkRERL48Sm6IiIhIjPPC05shY2YycmBX4tramsoTODni89KXl75+ODrYc/eeB8UK5XlvHfVqVKRejYoABAUFUbpay+gIXURERD6DpqWIiIhIjBIY+JoBI6bQrnldMqVPA8CyNVvYsecgVlZWFC+cl1PnLvPS14+79x9SIE92M0csIiIi/5VGboiIiEiMsmT1Zq5cd2fRig3MX/IbADmyZsRgCJ1+0r19UwaPmcHshavp2LohDvbxzBmuiIiIRAIlN0RERCRGadO0Nm2a1o5wu4tzMuZOHhp9AYmIiEiU07QUEREREREREbFoSm6IiIiIiIiIiEVTckNERERERERELJqSGyIiIiIiIiJi0ZTcEBERERERERGLpuSGiIiIiIiIiFg0JTdERERERERExKIpuSEiIiIiIiIiFk3JDRERERERERGxaEpuiIiIiIiIiIhFU3JDRERERERERCyakhsiIiIiIiIiYtGU3BARERERERERi6bkhoiIiIiIiIhYNCU3RERERERERMSiKbkhIiIiIiIiIhZNyQ0RERERERERsWg2UVGpt48vY6bM5+49DxI4OTK8f2cSJ0pg2n7vwSOGjp3JK/8AmjX4lipfl4qKMEREREREREQkFoiSkRvnL12jfs1KLJk9mqyZXVm2dkuY7VPcltKqSS3m/DIYt1/X8NLXLyrCEBEREREREZFYIEqSGyWK5CN/7mwA5M6RmSdPX5i2BQeHcPj4WfLlyoqDgz1pU7tw8sylqAhDRERERERERGKBKF9z48Tpi+TJmcX02svHh4RO8XFwsAcgbWoXnj57EdHhIiIiIiIiIiIfFCVrbrxxw/0ux05doEu7xqYyAwZCjEbT6xCjEYOV4b3Hr924k3WbdgJgfOcYEREREREREZE3oiy58cLTmyFjZjJyYFfi2tqayhM4OeLz0peXvn44Othz954HxQrleW8d9WpUpF6NigAEBQVRulrLqApXRERERERERCxUlExLCQx8zYARU2jXvC6Z0qcBYNmaLezYcxArKyuKF87LqXOXeenrx937DymQJ3tUhCEiIiIiIiIisUCUjNxYsnozV667s2jFBuYv+Q2AHFkzYjCETj/p3r4pg8fMYPbC1XRs3RAH+3hREYaIiIiIiIiIxAJRktxo07Q2bZrWjnC7i3My5k4eGhWnFhEREREREZFYJsJpKQGBgaz8bRvT560A4JW/P7du34+2wEREREREREREPkWEyY1RE+fg6eXNwSOnAQgIeM3YKfOjKy4RERERERERkU8SYXLj6o07dGjVAJs4oTNXEiaIj98r/2gLTERERERERETkU0SY3LCNY8NLXz/+WQOU85euR1dMIiIiIiIiIiKfLMIFRTu0akCXvqN5/OQ5A0ZM4ejJ8wzv3zk6YxMRERERERER+agIkxsliuTDNW1KDh8/B0YjHVs3JE0q5+iMTURERGKJF57ePHryjGyZ05s7FBEREbFAEU5LAQgMfE1c2zgkSBAfB/t40RWTiIiIxCKbt++lY++RDBw5FYCHHk8YPn62maMSERERSxJhcmP52q207TaUnX8dYuvOfXzX/kcOHTsTnbGJiIhILLBk9WZ+nTESBwd7AFyck3HT/Z6ZoxIRERFLEuG0lN8272L1wgkkTpgAgJvu9/jp5+kUL5w32oITERGRmM/KyoBdXFvTa1+/V7zy1xPaRERE5NNFmNxImjihKbEBkME1NXFtbSPaXUREROSzFCuUB7df1xAQEMjfh0+xZPUmShUrYO6wRERExIJEmNwoXiQfq37fRsG8OQC4e9+D1ClTcP3mHQAyZUgbPRGKiIhIjNa5TSOWrd1KfEd7Fi5fT6li+WnW4Nv/VOeK3/5g+ZotNKrzDd/VrxZm24gJbpw6exlHh9D1xKaPG4hTfIf/dD4RERExrwiTGxu27gFg1e/bw5T3HToJgwHWLZoUtZGJiIhIrGBjY0OLRjVoWv9brK0/uNb5JyuQO5vphsz7DOjZlkL5ckbKuURERMT8IkxurJg3VtNQREREJMpdv3mHnyfP58p1d2zj2FC8cF56dWkRZnrsv5U1c3pcUiSNcHtCp/ifXbeIiIh8eSK8PdKp96jojENERERiqVG/zKVaxdL8vmQyaxf9QtrULoz+ZV6UnnPa3OU0atuXBct+x2g0Rum5REREJOpFOHIjW2ZXDhw5Rcmi+aMzHhEREYllQowh1KlewfS6fcv6fNf+xyg7X/OG1bG3j0dwcDCd+4wiX66sFPhnjbF3rd24k3WbdgIoASIiIvKFizC58cLTm37DJuOaNmWY+a+LZmhEh4iIiESezBnScfe+B2lSOQPg5f2StKlcoux86dKkNP1csmh+3O8+fG9yo16NitSrURGAoKAgSldrGWUxiYiIyH8TYXKjXs1K1KtZKTpjERERkVjo7n0POvQaQdIkCQHw8fEjODiYFp0HApFzY2XZmi0kS5qIwvlzcfTkeSqVK46X90vOXLhC5fIl/3P9IiIiYl4RJjcK5MkenXGIiIhILNW+Zf1Ire/Jsxf0GjSeZy+8sDIYOHT8DBnSpcZgMGBvb8flazdZsW4rnl4+NKxdmZzZMkbq+UVERCT6RZjccL9zn/lLf+feg0eEGENM5ZqWIiIiIpHp8PGzdGrdMNLqS5YkEYtnjY5we7f2TSPtXCIiIvJliDC5MXTsLMqVLoLH42e0a16Xy9duEscmwt1FREREPsv5S9fw9XuFg308c4ciIiIiFirCbIURIy0a1eD5C08cHeLRvGENuvUfQ+O6VaMzPhEREYnhypUqQuuug6lVtRzW1tam8ga1KpsxKhEREbEkESY37OPFw+elL8UK5WXjtr+wtbXF4/Gz6IxNREREYoEr126RO3smbty6+7bQYDBfQCIiImJxIkxuNG9YHU8vH4oWzM323Qfo0HM4bZrVic7YREREJBYY1Lu9uUMQERERCxdhcqN44bymn4f26xQtwYiIiEjsYzQaOXz8LPcePMJoNJrKNS1FREREPlWEyY2Xvn7s3neEp889eaefQZumtaMjLhEREYklRk6cw6UrN3np50eR/Llwv/sA17SpzB2WiIiIWJAIkxs9B40nODiE7FkyYGNjHdFuIiIiIv/Jhcs3WOY2hlG/zKFd83rEi2fHhOkLzR2WiIiIWJAIkxte3i9ZPmcs1tZW0RmPiIiIxDL28eywtrYiR9aMHD99gWqVynDz9n1zhyUiIiIWJMLMRb5cWXny7Hl0xiIiIiKxUMG8Obh45QYVvyrGopUbadl5EKmck5s7LBEREbEg4UZu9Bs2CYPBgI+PL537jCJzxnRhto8Z3D26YhMREZFYoFObhhj+efTr9HEDuHjlBoXz5TRzVCIiImJJwiU3ypQoaI44REREJJYyGAwEBAbi6emDESPZMqfHx9cPBwd7c4cmIiIiFiJccqNaxTLhdvJ56YuDfTysrLT+hoiIiESu+Ut/Y+HyDcS1jfPOWl8GdqxzM2tcIiIiYjnCJTf2HzqBg308CuTNAcDk2UtZs2E7CZziM35YT3JmyxTtQYqIiEjMtW7jLn6dMZJM6dOYOxQRERGxUOGGYixetdn0bPkzF66yY89BVs4bz7AfOzFp1pJoD1BERERitqyZXcmQLpW5wxARERELFm7kxit/fxInSgDAynV/0KhOFdKkciZNKmcmzlgc7QGKiIhIzLT/0AkAMqVPy7ipCylZNF+Y7aWLax0wERER+TThkhtWBgNXb9zG2+clJ85c4MfurQEICgrC1jZOtAcoIiIiMdPK37ZF+NpgMCi5EQv5+voxafZSLl+7hY21NY3rVqVy+RKMmODG69evGd6/CwBGo5HG7fpRoWxR2jary7wl69iwdQ+JEjoBkDtHZvp0bWWqd8uOfUybu5zkSRMD4JIiGWOH9ogwjnlL1uGSIhnVKoVfi05ERL5M4ZIbndo0olPvkQS+fs2P3dqQwCk+AKt+307RArmjPUARERGJmWaMH2juEOQLM3y8GwXyZmdgz3b4BwRw+Zq7aZv7nQf4BwRiF9eWW7fvExj4Osyxjep8w3f1q0VYd4WyxendpUVUhS4iImYWbs2NYoXy8MfqWWxfO5uqFUubygvmy0GbprWjNTgRERGJuR49fsYLT2/T6xOnL9Jv6CSmzV2O3yt/M0Ym5nD3vgd373vQoFZlDAYD8ezsyJ87m2l7jmwZOXz8DAB7/j5KgTzZIqrqk5Wv2cb084gJbuzef5Sdfx1i9fodzF28jv7Dp0S4H0CzDgNYvX47rbr8xCt/f/4+fIom7frRsE1vtv35NwDbdx+gboseNGzTh+27D/7nmEVE5P3e+2zXOHFsiGdnF6YsW+b02NnFjZagREREJOabNnc5N9zvAvDc04tBo6eRMX0avLxfMnHGIjNHJ9HN/c59smZ2xWAwvHd7sUJ52L0vNKlw+PhZcvzfE/xW/vYHzTsOoHnHAVy/eeez46j4VXFKFy9Au+Z1+Xlwtw/u+9LPD2+flyyYNpyAgNfMWriKeVOHsWTWz6xev4OgoCAWr9rEyIFdWTRzFEUK5PrsuERE5MPCTUsRERERiQ537ntQKF9OANas30GRArn5vkU9goKDady2r5mjky9NlozpWLBsPbdu38clRVLi/t9acB+blrJr7yHOXrgCQMfWDSleOG+kxFXn2woYDAbOX7rO02eedOg5HAAfXz88vXyoWqE0U92W0bppbQrnV3JDRCSqKLkhIiIiZuHn94qg4GACA1/z+5Y/mTy6HwA21tbEjWtr5ugkuqVLk5Ir19zZtfcwcxevxcbGhoyuaejVuTkAdVv0JGECJ1p2GUS61C5ky5wegE59RnLj1l1s48ThrwPHmDt5KEajkQXLfmf3vqMkT5aYUsUKUKFscRrVqcLQsTOZPm8FXt4+BIeEYDQaTaNFAgMDGT1pLvsOnuDE6Qu8DgqiVtXy4fZ715Onzxk0ehqN61alYN7sZM+SgayZXClSMHStuu/qV6NMiYJMnbOMg0dP061902hqURGR2CXC5MZLXz927zvC0+eeGI1vy2PLuht/7jvCnEVrwlxYEzjFp0SVZmR0TYPPS1/SpXGhf4+2OCdPSqc+I3n23JO4trbEjWv73gvriAFdcHSw596DRwwdO5NX/gE0a/AtVb4uFebctZt3x97ODmvr0FlDn3t34eiJc8xauJrA169J6ZyMvj+0JlmSRB88ZsQEN6pVLE2BvDn+9flERET+ja9KFaZ9j+G8euVPkQK5TH+snrlwFefkSc0cnUS3tKldSJE8CaMmzmHNwok4xXdkxvyVxIkT2l2Na2vL5NF96dR7JN9UKM2few9TrHAeACqXL0mKZElMIzeuXnfn4NEzLJ41mmVrN3Po6GmcUyRjittSWjWpRb5cWWnaoT/2dnbcuHUXJydHzpy/gsejpxTIm516NSpiMBjYtutvkiRKgEO8eGH2K1k0f7j4c2bLyM+/zOP7FvVwTZuKR4+fkSxpIi5euUmu7Jlo/V1tRv8yL/oaVEQklokwudH7pwm8Dgome5YM2NhYR2dMZhcQGMi4qQtZPmcMSRIn5PDxs6bH4NrFtWXJ7NGEhISwbtMuZs5fxfD+nQH4ZWRfUrkkN9Xz/xfWpas306FVg3AX1lLFCuDoYB8mhhnjB5IwQfzPfg/3Hjxi3LSFTBs7AJcUSdl78Dh9h/zCgmnDI5zLKiIiEp06t2nEjj2H8Hv1Kswi5hcvX6dDqwZmjEyiiru7Ow8fPsTFxQVXV9dw2/v90Iq6LXvSsfdIHB3saVSnCvbx4pm2Z8mYjvlThxMSEsLajTtM5XZxbVn52x9s330AgNdBQRQvlBdrayvy5crGb5v+JEXypBw+fpahfTvi4GBP2tQuJE+ahB9+HEOeXFkonD8Xu/YdZvLofty6c5/egyeQLGliVq/fQbNG1WnzwxCSJ0uMf0AAv8xcjH08O4xGIz+OmIKXlw/d+4+lddPatOs+DEdHe0oUzkvFcsXpP3wqfn6viGNrw4Ae7QD4rv2PVK/8FVt27CNOHBum/NwPRwd7prgtY/+hEzg42DO4TwcypU8TtR+IiEgMEmFy44WXN8vnjDONHohNgl4H4R8QgN8rf5IQuoDV/7OysqJg3hymiyhAQifHMPscOHqavDmzmC6sE2Ysol3zeuEurCfPXKJMiYIfjWvtxp2sXr+dJIkSANCueV3TCIt5S9ZRIE920+v1W3dTr0YlXFKE3vkqW6IQq3/fztmL10ieJBEDR00jbWpnrt24Q/p0qfipT3t+27SLPfuPcub8FYoXzkuvznpcmoiIRB2DwUDl8iXClTeuW9UM0UhUOnb8ON36DcEbB3ByBm8PnPBlythhFC5UyLSfc4pkdO/QjLmL11G6eEGKFgztg/3Uuz179h/FYDCQJpUzcxatoWTR/LRtVjd0Wor7PRwd7alXoyI1vinH+GkLSZvGBYB0aVwIfP2aNs1qs+/gcRz+uaGUNrUL6dOmYmCv0ITD1Ru3cb9znzhxbMiSMR0bl03jpa8fTb7vx7Sx/bl+8w5O8R344fvvuHbzDv2G/sLviydz6uwl5i39jZnjBwFw6epNShbNT+liBajfqhdTf+5HpgxpGThyKj4+vgD4vfInUUInFs8aRe/BEzlw5BTFC+dly459/LFmFt4+L3Gwf5vUERGRj4swc5E7e2aePHsenbF8MRwc7OnStjFtfhjC1DnL8fTyCbdPcHAI23cfIEfWjKaywWNm0rhdXzb+sQeAZ889w1xYnz57gZePDwmd4oe5sD599iJc/Z37jKJ5xwH0GzoJgOu37rJ6/XbmTx3G5J/7Efg66IPv4e49DzJlCJvtz5wxHbfv3Afggcdj2jStw1K3n3n9Ooidew7RuG5VsmVJz4AebZXYEBERkUhx7PhxvuvUl4CSnXGo+AMORRvgUPEHAkp25rtOfTl2/HiY/evXrMTC6SPw9nlJs44DuOl+DwD/gECadxxAi84D8fJ+yfct6gHQo0MzBvfpwM8/dWPa3BXce/AIDAZCQkLnVYeEGLGyMmDAQMg7c61DjEYMVm9Hs1oZDBjfnYv9z7HWVm+7y7lzZMFgMJA5Q1oCAl/j7fMywvd95/5D7OzikjljOgwGAxW/Ks6Rk+dM24sWzI3BYCBLxnQ8f+GNU3xHCuTNzsgJbvj6viKurdadERH5NyIcuWGwsqJzn1FkzpguTPmYwd2jOqYvQv2alShRJB8Ll6+nWccBTBndjwyuqU0X1hCjkVzZMtGlXWMg9MKaPFkSXnh60a77sNARFJ9xYX3j/6elnDp7iXKlChPf0QGApIkTArBmww42bfuLZy+82PbnAezj2dH3h9YYrMJfoI3GEKz+uUAnSZSQNKmcgdCL65Xr7nxbuWwktZ6IiIhIqG79hhC/Sm9s7J3ClNvYOxG/Si+69RvCwT+3hNmWyiU5g3p9z1S3ZWzbfYBOrRtiF9eWxbNGh6v/TV81gZMj+XJn5e59D5IlTsTd+w+B0KfyJE2ciAROjvi89OWlrx+ODvbcvecRZnRuSpfk3H3wiMDA16bpyFeu3yJdmpThzmkwGIhjY0OcOHHCbXvDaIRPmQlsbW1lWqx07JAenDh9kQEjptKmaW2+KlX44xWIiAjwgZEb+XJnpXXT2pQuXiDMv9jkzYW1YtlibPtn+smbC+vS2T/zY/c2prUyMmdMRwInR1zTpvrkCyuEjrBI+pFFPgGCgoPxe+Ufrrx+zUosnjWa2tXKM6BHWxbPGk2u7JlIm9qFq9dvh9n3yjV3XNOmCleHjY1WpRcREfMZOXFOuLLBP88wQyQS2dzd3fHGIVxi4w0b+wR444C7uzsQOjXkt027CAkJISg4mCfPXnxwcdnbdx9w6NgZjEYjjx4/46b7PTKmT0PJovk4c/4KwcEhnDp7iRJF8mFlZUXxwnk5de4yL339uHv/IQXyZDfVZR/PjtLFC7BwxXqMRiO+fq+Ys2gdDWpVNu3zwOMxAEdOnCNZ0kTYx7MjebIkPHn6gpCQkDCxpUvtwqtXAVy/eQej0cjOvYcpnD9nhO/Fy9uH23cfUDBfDqp8XZJT5y59tH1FROStCEduVKtY5j9VvOK3P1i+Zst7nzk+YoIbp85extEhdC7h9HEDcYrv8J/OF5mu3rjN+YvXqFWtPCFGI0+evSD/Oxe//3f77gMeeDyhWKE8PH7y3HRhTZo4IT9PnhfhhTV/7mzhLqwRyZk1I+u3/ElAYCCBga+5e9/jg/vXrlqerj/+TPnSRXBxTsbu/Ud5HRRMzmwZ8Xj0FB9fX7x9fIlnF5c//jxA84bVAUiRLAmPn8bO6UgiIhK9PB4/xWiES1du8ujxM4yEjjh84PGEk2cvmjk6iQwPHz4MXWPjQ5xS4OHhgaurK2lSpWDz9r007zQQf/8ACuXLSY0qEY8sTZwoAUtWb2bWwtW8fOlHh1b1SZ40McmTJqZ08YI07zgA5xRJGN6/CwDd2zdl8JgZzF64mo6tG4Zb16J7h2ZMnr2Eph36Y2Wwon6t0JG8b5w6e4nd+44A8FPvDkDozbBULslp3K4fg3p9b9o3ThwbRg7syuhJcwkIeE3+PNmpXuWrCN+Lv38g0+auwOPxU6ytrRj+Y+cPt5uIiIRhCAwMML5vg6/fK6bNXc7fh09iwEDp4gXp0q4x9vHsPqniK9dusXrDDjKkS/3e5MY3FUpRKF/E2ev/FxQUROlqLdm/5VdsbCLMyfwrEa3Y/crfn1kLVnPy7CXThbV3lxbY2NhQvmYbdm+YH6Yen5e+THFbxtUbt00X1krlQhdIW7h8Pbv+Omy6sDrYx+OhxxMGj5mB3yt/WjSqYdr3jf9/FGzDOlWoWqE0M+avZO+B42RIl5onz17QpW2jDz6y9fjpC8ycv5KAwNBHwf7YrQ1JEifkoccTvu8xjGxZ0nPnngdlSxaiY6sGGAwGDh8/y4gJbpQqmp/+PdpGSjuLiIi8T+c+owA4d+kayZIkMj163iVFUmpWLRfu+mhOUdEPiQ3c3d35tk1fHCr+EOE+d1YPxW1YN2pUrx6Nkf17Iya4UbJofsqXLmLuUERE5D0iTG6M+mUu8ezimobirdmwA1+/V2Ey0h8zb8k64tnZvTe50bjON2TKkPaT64rMTsWnrtj9Jes3dBINa1f+YHIjIg89ntB78ESWzRkTBZGJiIj8OyMnuDGod3tzh/FBSm58vhJfVyOgZOf3Tk0J8vPCfe3PJHG0ZdnMcV90P0zJDRGRL1uEV+dLV2+ydPbPptfdOzSlWccBkXbiaXOX8+jJcyqVK06rJrUwfMqKS5HgzYrd8av0xuGdi2yAnzffder7xV9YRUREYpovPbEh/82UscNMfa93ExxvEhspv26FbSLn9y4s+iX5Sd9TEZEv2gdvPXh5vySBkyMA3v88lzsyNG9YHXv7eAQHB9O5zyjy5cr63hEIazfuZN2mnQDhnvzxuT5nxe4v0dihPT77WBfnZBq1ISIiX4w6zXu896kS6xZNiv5gJNIVLlSI8YO606prb+K6ZME2kQuBLx7y2teTlF+3wj5VVgDTwqLvThUWERH5VBEmNxrWrkLbbkNM8113/nWIFo1qRMpJ332kVsmi+XG/+/C9yY16NSpSr0ZF4O1w0P/izYrdDp+wYrcurCIiItFj7JDuYV7/setv8uXOZp5gJEokT5aMlAUqYJOlDEE+z7DJ8zVxE/3fQqPvLCwqIiLyb0WY3KheuSxpUqbgwJHTAAzs2Y68ubJ+9omWrdlCsqSJKJw/F0dPnqdSueJ4eb/kzIUrVC5f8rPr/Tf+7YrdIiIiEvUyZ0wX5nUG1zR06DWCMiUKmikiiWwuLi7g7UHcRM7hkxpveD/C2fkj/TQREZEIfHBaSr7c2T7rzsmTZy/oNWg8z154YWUwcOj4GTKkS43BYMDe3o7L126yYt1WPL18aFi7MjmzZfzsN/BvvLmwfpAurCIiItHK19fP9HNQcDCnz1/hzr2HZoxIIpurqytO+BLg5x3hwqJO+OrmkoiIfLZwyY3p81bQpW1jOvcZ9d5FPqeP+/iiosmSJGLxrNERbu/Wvum/DDNy6MIqIiLy5alYtz0GA6ZHwSZNkpDObRuZNyiJdB9aWNRn20RmzxxnxuhERMTShUtuFC+UFwhdcyMm0oVVRETky3Jw25IoqXfFb3+wfM0WGtX5Jtxj6e89eMTQsTN55R9AswbfUuXrUlESg7xVuFAhls0cR7d+Q/DGAZxSgPcjEhh8ma2n1YmIyH8ULrlRMF/owp5JEicMN13k6Mnz0RNVFNKFVURE5MvzwOMxR06cw2AwULRAblyck/3nOgvkzsb1m3feu22K21JaNalFvlxZadqhP6WKFcDRwf4/n1M+rHChQhz8cwvu7u54eHjg7OysEbMiIhIprCLaMG7agnBlU2YvjdJgosubC+vm+eOY1+87Ns8fx4FdW5TYEBERMYODR0/zfY9hnL1wlTPnr/J9j2EcOnbmP9ebNXN6XFIkDVceHBzC4eNnyZcrKw4O9qRN7cLJM5f+8/nk07m6ulKsWDElNkREJNKEG7kxcoIbGAw8evyMkRPnmMo9Hj3F3j5etAYX1VxdXXVRFRERMbO5i9fh9ssQUrkkB+D+w8cMGjWN4oXzRsn5vHx8SOgUH4d/RmqkTe3C02cvouRcIiIiEj3CJTeqVioDwInTF8if5+2TUlySJyV3jizRF5mIiIjECq+DgkyJDYBULsl5HRQUZeczYCDkzeqlQIjRiMEq/CLqazfuZN2mnQAY39lfREREvjzhkhsF8mQHYOTAruTMlinaAxIREZHYJZVLclb+to16NSqAwcC6jTtJ5Zz84wd+pgROjvi89OWlrx+ODvbcvedBsUJ5wu1Xr0ZF6tWoCEBQUBClq7WMsphERETkvwmX3HgjR9aMHDp2hnsPHoW5W9GgVuVoCUxERERihz5dWjJ8vBsz5q/AYDCQP3c2furdPtLPs2zNFpIlTUSlciUoXjgvp85dJn/ubNy9/9B0c0dEREQsU4TJjZET53Dpyk1e+vlRJH8u3O8+wDVtquiMTURERGKBpEkSMXXMj7zy9wcgnp3df67zybMX9Bo0nmcvvLAyGDh0/AwZ0qXGYAidftK9fVMGj5nB7IWr6di6IQ4xbF0xERGR2CbC5MaFyzdY5jaGUb/MoV3zesSLZ8eE6QujMzYRERGJwU6du/zB7flzZ/vg9g9JliQRi2eNjnC7i3My5k4e+tn1i4iIyJclwuSGfTw7rK2tyJE1I8dPX6BapTLcvH0/OmMTERGRGGzSrCUAeHu/xGBlIL6jAwDPnnuSNpUzsyb+ZM7wRERExIJEmNwomDcHF6/coOJXxWjXfRhrNuwIs5K5iIiIyH+xeOYoAPoNncSAnu1I4OQIwAOPx8xb8ps5QxMRERELE2Fyo1ObhqZ5qdPHDeDilRsUzpcz2gITERGR2OG+x2NTYgMgpXNybrjfNWNEIiIiYmmsItrwJrEBkDxpYr4qWRgHB/toCUpERERij6SJE7J0zWZevw4iJCSEzdv3Ym0VYRdFREREJJxwIzdKVGnGO3mNMOLZ2bHr97lRHZOIiIjEIv27t2XEBDdmL1yDwQDp06Xmp17fmzssERERsSDhkhs71rlhNBr5ZeYSGtauTOqUKQA4e+Eq5y9dj/YARUREJGZLkTwJ08cN4JW/PyHBIRopKiIiIv9auDGfjg72xHd0wP3OfbJlTo+jgz2ODvaUKJKPY6fOmyNGERERiYF8ff3C/AsJDgHA56UvM+atNHN0IiIiYkkiXFA0OCSEcxevkTtHZgBu332At8/LaAtMREREYraKddtjMIDRGLbcYICyJQqZJygRERGxSBEmN7p3aEq/YZNIl9oFa2trrt5wp2/X1tEZm4iIiMRgB7ctMXcIIiIiEkNEmNwokCc7q+aP5/yl6wQFBZE9SwaSJkkUnbGJiIhILOHr68e5S9cxGAzkyp4JB/t45g5JRERELEi45EZQUBA2NqHF8R0dKF44b7QHJSIiIrHHhcvX+XHYZFK5JMdgMHDf4zFjBncnR9aM5g5NRERELES45MbAUdMYO6RHuEfCGo2hc2AP/KEhpCIiIhJ5ps5ZzpghPciZLTSZceHyDSbPXsqcSUPMHJmIiIhYinDJjX4/hK6rsWOdW7QHIyIiIrGPr98rU2IDIGe2jPi98jdjRCIiImJpwj0KNnGiBACmR8C+++/ufY9oD1BERERitkQJnNh78Ljp9b6DJ0iYIL4ZIxIRERFLE37kxrBJGN6dj/IPY4iRm7fvsWbhxGgJTERERGKH3l1a0HfoJCbPCp36GjduXMYN7WHmqERERMSShEtulClR8L07GjDQuW2jKA9IzMvX149Js5dy+dotbKytaVy3KpXLl2DEBDdev37N8P5dADAajTRu148KZYvStlld5i1Zx4ate0iU0AmA3Dky06drK1O9W3bsY9rc5SRPmhgAlxTJGPuBjuu8JetwSZGMapXKROG7FRGRL0G6NClZPmcsd+8/BCBNKhesrcMNLhURERGJULjkRrWK+mMyNhs+3o0CebMzsGc7/AMCuHzN3bTN/c4D/AMCsYtry63b9wkMfB3m2EZ1vuG7+tUirLtC2eL07tIiqkIXEREL9sDjMZ5ePhiBF14+AOTPnc28QYmIiIjFCJfceOPZc09W/b6New8eEWI0msrHDO4eHXGJGdy978Hd+x6MGdIdg8FAPDu7MB3LHNkycvj4Gb4qWZg9fx+lQJ7/3uksX7MNuzfMB2DEBDdKFs1PcHAwq9fvwD6eHX8fPsXPg7u9d7/ypYvQrMMAqlcpyx+7/mbmhIGcOH2JmfNXEhwSTKsmtajydSm27z7AnEVrsbGxofV3talcvsR/jltERCLP6Elz+WPX36RN5YK1jTUQ+oS2RTNGmTkyERERsRQRJjcGjZpGurQpuffgEQ1qVebStVskTpggOmOTaOZ+5z5ZM7u+d80VgGKF8rB731G+KlmYw8fP8k2F0jx/4WnavvK3P9i++wAAg/t0IFOGtJ8VR8WvinP4+FkK5Mn+0WkpL/388PZ5yYJpw/HyfsmshauYN3UYNtbWdOg1ggpli7F41SZGDuxK+nSpeaXV90VEvjiHjp1l84rpJHDSIqIiIiLyeSJMbvj6veLHbm0YN3Uh2bJkoGrF0vQerMVEY7MsGdOxYNl6bt2+j0uKpMS1jRNm+8empezae4izF64A0LF1Q4oXzhspcdX5tgIGg4Hzl67z9JknHXoOB8DH1w9PLx+qVijNVLdltG5am8L5c0XKOUVEJPJkz5yeeHZ25g5DRERELFiEyY24cePiHxBIgbzZ+XPfYVLUrcr9h4+jMzaJZunSpOTKNXeMRuN7R28YMFCsUB5mzF9J9SplefnS71/V/741N4JDQiI836fuZ2UVuuicESMF82Zn9E/dwmz/rn41ypQoyNQ5yzh49DTd2jf9V3GLiEjUWL1+OwBJEiek/4gpFC2YO8z2BrUqmyMsERERsUARLkVe59uvuf/wEWWKF+TkmUt806ATZYq//0kqEjOkTe2Ci3NS1m7cidFoJDDwNRu27sH4zporX5cpyqlzlyhWKE+knNMhXjxu3LrL46fPOXP+iqk8ebLEPH76/KP7vStntoycPncF9zv3AXj0+BkhISGcv3SdNKmcaf1dbY6fuhgpcYuIyH939bo7V6+78/r1axIliG96ffW6O1dv3DZ3eCIiImJBIhy58U2FUqaf3X4ZjLePL07xHaIlKIk67u7uPHz4EBcXF1xdXcNtH9K3ExNnLOL3zX8SN64tjepUCTNaIkvGdMyfMpy4trbhjn13zY1ULin4eXC3cPv8v2aNqvPDj2PIkysLJYrkM5WXK1WE3oMncO7iNSaO6B3hfu9KnDABA3q2Y+DIaVhbW5E7R2a6tW/KH7v2M27aQvz8XtH1+yYfjUlERKLHoN7tzR2CiIiIxBCGwMAA4/s21Gneg8rlS1C5fAlc06aK7rjCCQoKonS1luzf8is2NhHmZCQCx44fp1u/IXjjAE7O4O2BE75MGTuMwoUKmTs8ERGRL5r6ISIiIl+2CK/OM8YPZPe+Iwwf74bRaKRy+ZJU/KoYSRInjMbwJDIcO36c7zr1JX6V3jjYO5nKA/y8+a5TX5bNHKcEh4iIiIiIiFisCNfccEmRlO/qV2PBtOGMHvQDz194UqdFj+iMTSJJt35DiF+lNzbvJDYAbOydiF+lF936DTFTZCIiIjBigpu5QxAREREL98FxlU+fvWDP38f4c+9hXvq9ol2zutEVl0QSd3d3vHEIM2LjXTb2CfDGAXd39/euwSEiIhLVnr/w4vGTZyRPlsTcoYiIiIiFijC50bHXCO49fEzFssXo0ak5WTO5RmNYElkePnwYusbGhzilwMPDQ8kNERExi1zZM9Oyy09UKFsMa+u3g0r16G4RERH5VBEmN5o3qkGRArnDdDLE8ri4uIC3x4d38n6Es/NHEiAiIiJRxkjd6hXMHYSIiIhYsAiTG8UL543OOCSKuLq64oQvAX7e4dbcAAjy88IJX43aEBERs2nTtI65QxARERELp2EZscCUscPw2TaBID/vMOVBfl74bJvIlLHDzBSZiIgIXLh8gxadB1L3n4XLPR4/Zc2GHWaOSkRERCxJhMkNrVwecxQuVIhlM8cR98AMfHdOxffIKnx3TsXu4Ew9BlZERMxu/LSFDOvXGQcHewCSJ03M5h17zRyViIiIWJIIp6Vo5fKYpXChQhz8cwvu7u54eHjg7OysqSgiIvJFCAx8jWvalKbXBoOBgIDXZoxIRERELE2EyQ2tXB4zubq6KqkhIiJflDSpnDl64hwGA/j6+jFn8dowyQ4RERGRj/nAmhuhK5cncHLE0cHe9E9EREQkMvX9oRXL123lxq17VK7fkVu3H9C7cwtzhyUiIiIWJMKRG1q5XERERKJDksQJmTy6H6/8/QGIZ2dn5ohERETE0kSY3Lhw+Qbjpi3g5Us/1i2ahMfjp+w/dJL6NStFZ3wiIiISQ508c5ECeXOwdef+926vWrH0Z9e9futu1mzYgaODPSP6dw6zhtiICW6cOnsZR4d4AEwfNxCn+A6ffS4RERExvwiTG29WLh88ZgbwduXyf5PcWPHbHyxfs4VGdb7hu/rVwmy79+ARQ8fO5JV/AM0afEuVr0t95lsQERERS3Tg6GkK5M3B3oPHw20zGAyfndx4/sKLJas2scxtDPsPn2TG/FUM+7FTmH0G9GxLoXw5P6t+ERER+fJEmNyIjJXLC+TOxvWbd967bYrbUlo1qUW+XFlp2qE/pYoV0JoeIiIisUjXdk0A6NGxGc7Jk0ZavUdOnCNLRlfs7OKSL3c2xk9bGG6fhE7xI+18IiIiYn4RLij6/yuXT5695F+vXJ41c3pcUoTvrAQHh3D4+Fny5cqKg4M9aVO7cPLMpX8fvYiIiFi8/sOnRGp9z557kja1MwBJEyckOCQE/4DAMPtMm7ucRm37smDZ7xiNxkg9v4iIiES/CEdu9P2hFSMmuJlWLi+QJzuD+7SPlJN6+fiQ0Ck+Dv+M1Eib2oWnz15ESt0iIiJiWUoVK8C6TTupW71i5FRoIEzCwhhixGB4u7l5w+rY28cjODiYzn1GkS9XVgrkzRGumrUbd7Ju087QOpQAERER+aJFmNyIypXLDRgIeaeTEGI0YrAyhNtPnQoREZGY78CRU1y97s6sBauxsrICjICBHevcPqu+ZEkScf7SdQCePHtBnDhxiGtra9qeLs3bkagli+bH/e7D9yY36tWoSL0aoQmXoKAgSldr+VnxiIiISNQLl9yIypXL30jg5IjPS19e+vrh6GDP3XseFCuUJ9x+6lSIiIjEfKMG/RCp9RUpkJs5i9bi7x/AqbOXKVEkH8vWbCFZ0kQUzp+LoyfPU6lccby8X3LmwhUqly8ZqecXERGR6BcuuRFVK5cDpo5FpXIlKF44L6fOXSZ/7mzcvf+QAnmyf3a9IiIiYrnmLVnHT70jZ+orQKKETrRsUos23YYQ38GeEQO7smTVJgwGA/b2dly+dpMV67bi6eVDw9qVyZktY6SdW0RERMzDEBgY8N75Hh6Pn/6nlcufPHtBr0HjefbCCyuDgXRpU5IhXWqckyelSb2qPPR4wuAxM/B75U+LRjWoVK7EB+t7M3Jj/5ZfsbGJcDaNiIiIWJgeA8fRv3sbkidLYu5QIqR+iIiIyJctwqtz/+FTWDh9xGdXnCxJIhbPGh3hdhfnZMydPPSz6xcREZGYIVf2zLTs8hMVyhbD2vrtg9y6tW9qxqhERETEkkT4KNg3K5eLiIiIRC0jdatXIIGTI44O9qZ/IiIiIp8qwpEbkb1yuYiIiMj7tGlax9whiIiIiIWLMLkR2SuXi4iIiLzPK39//th1gHsPHmE0hpjKNS1FREREPlWE01LmLVmHS4qk4f6JiIiIRKafRs9g38Hj/H34JA728Xjw8AkGQ4RdFBEREZFwIuw5PH/hxeMnz6IzFhEREYmFHno8YfLofuTLnZXK5UsyrH9n7j98ZO6wRERExIJEOC1FK5eLiIhIdLCzi0twcAh5c2bl4NHT1KtRiTv3Hpo7LBEREbEgHxjzqZXLRUREJOp9XaYo12/eplzpImzYuofqTbqQM1smc4clIiIiFiTCkRtauVxERESiQ5N6VU0/L5g2nNv3HpIxfRozRiQiIiKWJsLkhlYuFxERkaj08NFT4saNQ+KECUxldnZx8fLy4cmT57g4JzNjdCIiImJJIpyWopXLRUREJCpNmrmYBw+fhCtP4OTIpFlLzBCRiIiIWKoIsxVauVxERESikseTZ+TKHn5tjayZ0/P46XMzRCQiIiKWKsLkxv+vXB7HxkYrl4uIiEikCgoODlf2+nUQr4OCzBCNiIiIWKoIkxtauVxERESiUtkSBRkzeT7+AYGmMn//AMZOXUDJovnNGJmIiIhYmggXFNXK5SIiIhKVWjSqwYTpi6jdrBsZ0qXGiJGb7vcoXbwg3zeva+7wRERExIKES25o5XIRERGJDjY2NvzYvQ2tmtTi+q07AGRMnwbn5EnNHJmIiIhYmnDTUrRyuYiIiESnFMmTULJofkoWza/EhoiIiHyWcMkNrVwuIiIiIiIiIpbkvQuKauVyEREREREREbEU4ZIbWrlcRERERERERCxJuAVFtXK5iIiIiIiIiFiScMkNrVwuIiIiIiIiIpYkXHLjjRTJk5AieZLojEVERERERERE5F9774KiIiIiIiIiIiKWQskNEREREREREbFoSm6IiIiIiIiIiEVTckNERERERERELJqSGyIiIiIiIiJi0ZTcEBERERERERGLpuSGiIiIiIiIiFg0JTdERERERERExKIpuSEiIiIiIiIiFk3JDRERERERERGxaEpuiIiIiIiIiIhFU3JDRERERERERCyakhsiIiIiIiIiYtFszB2AiIiISGRbv3U3azbswNHBnhH9O5M8WRLTtnsPHjF07Exe+QfQrMG3VPm6lBkjFRERkcigkRsiIiISozx/4cWSVZuYP2UY9WpUZMb8VWG2T3FbSqsmtZjzy2Dcfl3DS18/M0UqIiIikUXJDREREYlRjpw4R5aMrtjZxSVf7mwcOnbatC04OITDx8+SL1dWHBzsSZvahZNnLpkvWBEREYkUSm6IiIhIjPLsuSdpUzsDkDRxQoJDQvAPCATAy8eHhE7xcXCwByBtaheePnthtlhFREQkcmjNDREREYlZDGA0Gk0vjSFGDIY3mwyEvLMtxGjEYGV4bzVrN+5k3aadoXX8c8z48ROx+mf/zp07cefOHTZt2mw6pnHjRtja2rJo0WJTWeXKlciRIweTJk02lRUuXIjy5cszc+YsfHx8AMiYMQP16tVj5cpV3L59G4CECRPSvv337Nixk1OnTpmO79OnNydPnuLPP/80lbVu3ZqXL31YvXqNqaxWrVo4O6dg9mw3U1mZMmUoXrwYEyZMJDg4GIDcuXNRtWpVFixYyJMnTwBImTIlzZo1Zf36DVy5cgUAOzs7unX7gX379nPo0CFTnV26dMHd/RabN28xlTVp0gQbG2sWL15iKqtSpQrZsmVl8uQpprIiRYpQrtxXzJgxk5cvXwKQKVMm6tatw4oVK7hz5y4AiRMnpl27tmzbtp0zZ86Yju/Xry9Hjx5jz549prK2bdvg6enJ2rXrTGV16tQmadKkzJkz11T21VdfUbRoEcaPn0BISAgAefLk4ZtvqjB//gKePn0KQOrUqfnuuyb8/vt6rl69CoC9vT1du3Zh7969HD58xFTnDz905fr162zd+oeprGnT7wBYunSZqaxq1W/IlCkTU6dOM5UVK1aUsmXLMm3adPz8QqdLZcmShdq1a7Fs2XLu3bsHQNKkSWnTpjV//LGNs2fPAmBlZUWfPr05cuQof/31l6nO779vx9OnT/ntt99NZfXq1SVhwoTMmzffVFauXDmKFCnM2LHjTGV58+alSpXKzJ07j+fPnwOQNm0aGjduzLp1v3H9+nUAHB0d6dy5E3v2/MXRo0dNx3fv3o3Ll6+wbds2U1nz5s0ICgpm+fLlprJvv62Gq2t6pk+fbiorXrw4ZcqUZsqUqfj7+wOQNWtWatWqyZIlS3nw4AEAyZIlo3XrVmzdupVz584DYG1tTe/evTh06DD79u0z1dmhQ3s8PB6xfv16U1mDBvVxdIzPggULTGVff/01BQrkZ/z4Caay/PnzU6lSRdzc5uDp6QlAunTpaNSoIWvXruXGjZsAxI8fn06dOrJ7926OHTtuOr5Hj+5cvHiR7dt3mMpatGhOYGAgK1asNJVVr/4tadOmZcaMmaaykiVLUqpUSSZNmkxgYGiiNnv27NSoUZ3Fixfz8KEHAClSpKBlyxZs3ryZCxcuAhAnThx69uzBwYMH2b//b1OdHTt24MGDB2zYsNFU1rBhA+zt7Vm48FdTWcWKFciTJw8TJ/5iKitYsAAVKlRg9mw3vLy8AEif3pUGDRqwevVqbt1yByBBggR06NCeXbt2ceLESdPxvXr15OzZs+zcuctU1qpVS/z8/Fi1arWprGbNGqRMmZJZs2abykqXLkWJEiX45ZdJvH79GoCcOXPw7bff8uuvi3j06BEALi7ONG/enI0bN3HpUujoPFtbW3r06M7ffx/gwIEDpjr1uzzyf5d37twJczAEBgYYP76b+QUFBVG6Wkv2b/kVGxvlZEREROT9tu8+wJ6/jzFmcHceP31Osw4D2L42tHMcEhLCVzVas3XVTBwd7PnhxzHUr1WJ0sUKfLBO9UNERES+bJqWIiIiIjFKkQK5uXbjNv7+AZw6e5kSRfKxbM0Wduw5iJWVFcUL5+XUucu89PXj7v2HFMiT3dwhi4iIyH+k5IaIiIjEKIkSOtGySS3adBvC75t30alNQx49ecbTZ54AdG/flMUrN9K+53A6tm6Ig3088wYsIhapRJVmNO84wPTv2o3b1G3Rg8dPQ6fw/HXgGIN/nv6RWkQksmhaioiIiMhHqB8iIv+vfM027N4wP0zZ2o07uXvfg+4dmvJ9j2EM7Pk9rmlTmilCkdhFIzdEREREREQiQY0qX3H4+Fn+3HeENKmcldgQiUZKboiIiIiIiEQCW9s4NKpThVET59KqSS1zhyMSq0TZuMr1W3ezZsMOHB3sGdG/M8mTJTFtGzHBjVNnL+PoEDrHdfq4gTjFd4iqUERERERERCKVf0AgzTsOACB3jsz06doKgAcPn+AU3wFvH19zhicS60RJcuP5Cy+WrNrEMrcx7D98khnzVzHsx7DPuh3Qsy2F8uWMitOLiIiIiIhEKbu4tiyeNTpM2bPnnhw9dY5Rg35gzqI1TPn5RzNFJxL7RMm0lCMnzpEloyt2dnHJlzsbh46dDrdPQqf4UXFqERERERERs1i8ahMNalYmV/ZMGAwGTp65aO6QRGKNKEluPHvuSdrUzgAkTZyQ4JAQ/AMCw+wzbe5yGrXty4Jlv2M0WsQDW0REREREJJZwd3fn0KFDuLu7f9L+j58+5+jJc1QuXwKAVk1qMfvXNfpbRySaRM2aGwbC/Cc2hhgxGN5ubt6wOvb28QgODqZzn1Hky5WVAnlzhKtm7cadrNu0M7QO/VIQEREREZEoduz4cbr1G4I3DuDkDN4eOOHLlLHDKFyokGm//38MbPKkiVkxd5zpdd5cWZkzaUi0xS0S20VJciNZkkScv3QdgCfPXhAnThzi2tqatqdL8/aRSCWL5sf97sP3Jjfq1ahIvRoVgbfPlxcREREREYkKx44f57tOfYlfpTcO9k6m8gA/b77r1JdlM8eFSXCIyJcjSqalFCmQm2s3buPvH8Cps5cpUSQfy9ZsYceeg7zw9Gb77oMYjUY8vXw4c+EKWTO5RkUYIiIiIiIin6xbvyHEr9Ibm3cSGwA29k7Er9KLbv00EkPkSxUlIzcSJXSiZZNatOk2hPgO9owY2JUlqzZhMBiwt7fj8rWbrFi3FU8vHxrWrkzObBmjIgwREREREZFP4u7ujjcOYUZsvMvGPgHeOODu7o6rq2v0BiciHxU1a24A1SuXpXrlsqbXPTs1N/3crX3TqDqtiIiIiIjIv/bw4cPQNTY+xCkFHh4eSm6IfIGiZFqKiIiIiIiIJXFxcQFvjw/v5P0IZ+ePJEBExCyU3BARERERkVjP1dUVJ3wJ8vN+7/YgPy+c8NWoDZEvlJIbIiIiIiIiwJSxw/DZNiFcgiPIzwufbROZMnaYmSITkY+JsjU3RERERERELEnhQoVYNnMc3foNwRsHcEoB3o9IYPBlth4DK/JFU3JDRERERETkH4ULFeLgn1twd3fHw8MDZ2dnTUURsQBKboiIiIiIiPwfV1dXJTVELIjW3BARERERERERi6bkhoiIiIiIiIhYNCU3RERERERERMSiKbkhIiIiIiIiIhZNyQ0RERERERERsWhKboiIiIiIiIiIRVNyQ0REREREREQsmpIbIiIiIiIiImLRlNwQEREREREREYum5IaIiIiIiIiIWDQlN0RERERERETEoim5ISIiIiIiIiIWTckNEREREREREbFoSm6IiIiIiIiIiEVTckNERERERERELJqSGyIiIiIiIiJi0ZTcEBERERERERGLpuSGiIiIiIiIiFg0JTdERERERERExKIpuSEiIiIiIiIiFs3G3AGIiIiIRBZPLx9+Gj2d5y+8+KZiKZrW/zbM9oceT2jUri/pUrsA8HXZYrRoVMMcoYqIiEgkUnJDREREYowFy36nbMlC1KpajhadB1GmeEHS/pPIeCNHlgzMmviTmSIUERGRqKBpKSIiIhJjHDx6mny5s2FjY0Pu7Jk5dOxMuH0SJIhvhshEREQkKmnkhoiIiMQYz194kTplCgDSpnbh6TPPcPtcv3mHVl1+wsEhHr07t8A1bar31rV2407WbdoJgNFojLKYRURE5L9TckNEREQs0q/LN3DoeNiRGa/8A+CfRESIMQSDlSHM9uTJkvBTnw5kz5yelb//wbhpC5k5ftB7669XoyL1alQEICgoiNLVWkb+mxAREZFIoeSGiIiIWKSWTWrSsknNMGX1W/Xi3oNHZMqQlrv3PMiUIW2Y7dbWVuTNmQWAmt+UZ9Xv26MtXhEREYk6WnNDREREYoySRfNz6txlgoKCOH/pOsUL5+WFpze9fppAUHAwO/86xLPnnhiNRvYfOkG2zK7mDllEREQigUZuiIiISIzRqkktfho9nfVbdvNt5TKkTpmCh4+ecvvuA4JeB5E8WRIGjZ7Os+eeJEmckMG925s7ZBEREYkEhsDAAItYIevNXNf9W37FxkY5GREREYk+6oeIiIh82TQtRUREREREREQsmpIbIiIiIiIiImLRNK5Swvlz3xHmLFqDjY0NGV3T0KtzcxI4xadElWZkdE2Dz0tf0qVxoX+PtjgnT0qnPiN59tyTuLa2xI1ry9zJQzEajSxY9ju79x0lebLEjBjQBUcHe+49eMTQsTN55R9AswbfUuXrUmHO/crfn0mzlnDh8g2srayoU70CtaqW/2C8Dz2eMGKim+lRfktWbSJrJleKFMwdZW0kIiIiIiIiXw4lNySMgMBAxk1dyPI5Y0iSOCGHj5/F1jYOAHZxbVkyezQhISGs27SLmfNXMbx/ZwB+GdmXVC7JTfVcve7OwaNnWDxrNMvWbmbp6s10aNWAKW5LadWkFvlyZaVph/6UKlYARwd703ETZyzGJUVS+ndvyyv/AHoOHEeSRAkoXbzgJ7+HZg2rR1JryJeuRJVmZEqfxvT6p97t+XH4ZGZN/InkSRPz14Fj7N53hOH9u5gxShGRf8+cNxpqN++OvZ0d1tahA3w7tm5I8cJ5//V7OHriHLMWribw9WtSOiej7w+tSZYk0QePGTHBjWoVS1Mgb45/fT4REYndlNyQMIJeB+EfEIDfK3+SAMUK5Qm3j5WVFQXz5mD77gOmsoROjmH2OXD0NHlzZsHa2op8ubIxYcYi2jWvx+HjZxnatyMODvakTe3CyTOXKFMiNHHh6+vH4eNn+H3xFAwGA/bx7Pi+ZX1+Xb6B0sULMmKCGwmc4nP+0jU8vXzo2ak5+XJlpeuPP/P8hRfNOw5gaL9OLFu7hZJF81O+dBEuXL7OxBmLCQgIpGC+HPzQ/jtsrK35rv2PVK/8FVt27CNOHBum/NwPRwd7prgtY/+hEzg42DO4T4cwfzjLl8curi2LZ40OU9a4blWWrdlC9w5NWbZmCwN7fm+m6EREPo+5bzQAzBg/kIQJ4n/2e7j34BHjpi1k2tgBuKRIyt6Dx+k75BcWTBuOwWD47HpFREQiojU3JAwHB3u6tG1Mmx+GMHXOcjy9fMLtExwcwvbdB8iRNaOpbPCYmTRu15eNf+wB4NlzT9KmcQEgXRoXnj57gZePDwmd4uPwTwcqberQ8jfuezwhTUpn4sR5m3PLkjEd7nfvm14bjSG4/TKYkQO7MnbKfOLGtWVAj7Zky5KexbNGk8E1tWnf16+DGDhyGv27t2Gp2888ffaCLdv3AeD3yp9ECZ1YPGsUiRI6ceDIKbx9XrJlxz5WLZjA5NF9SZMqRWQ0qUSzGlW+4vDxs/y57whpUjnjmjaluUMSEflX3r3RAKE3GuLZ2YXZ582Nhgcej01lH7vRcPDYGYKDQzh8/Cz5cmUNc6PhU6zduJMGrXvTsdcIOvYawckzF03b5i1ZF+b1+q27qVejEi4pkgJQtkQh7OPZcfbiNR56PKF118EMHTuT777/kUGjphEQGMiKdVvZs/8ooyfNY+KMRf+u0UREJNZTckPCqV+zEgunj8Db5yXNOg7gpvs9APwDAmnecQAtOg/Ey/sl37eoB0CPDs0Y3KcDP//UjWlzV3DvwSMwGAgJCX3KcEiIESsrAwYMhBjfPnk4xGjEYPX27o2VwYDRGPbJxCEhRqyt3n5Nc+fIgsFgIHOGtAQEvsbb52WE7+PO/YfY2cUlc8Z0GAwGKn5VnCMnz5m2Fy2YG4PBQJaM6Xj+whun+I4UyJudkRPc8PV9RVxb2//QimIutrZxaFSnCqMmzqVVk1rmDkdE5F8z542GNzr3GUXzjgPoN3QSANdv3WX1+u3MnzqMyT/3I/B10Affw917HmTKEHb0Y+aM6bh9J/SGxQOPx7RpWoelbj/z+nUQO/cconHdqmTLkp4BPdrSq3OLT20uERERQNNSJAKpXJIzqNf3THVbxrbdB+jUuuF7pwBAaGcFIIGTI/lyZ+XufQ+SJU7E3fsPAbhz34OkiRORwMkRn5e+vPT1w9HBnrv3PMJMe0npkpy7Dx4RGPjaNPz2yvVbpEsT/s67wWAgjo0NceLEifA9GI3wKSNfra2tMBqNGAwGxg7pwYnTFxkwYiptmtbmq1KFP16BmM2bhBtA7hyZ6dO1FQAPHj7BKb4D3j6+5gxPROSz1a9ZiRJF8rFw+XqadRzAlNH9yOCa2vR7L8RoJFe2THRp1xgIvdGQPFkSXnh60a77sNA1Kz7jRsMb/z8t5dTZS5QrVZj4jg4AJE2cEIA1G3awadtfPHvhxbY/D2Afz46+P7TGYBX+hoXRGILVPzcskiRKSJpUzkDozYYr1935tnLZSGo9ERGJjTRyQ8K4euM2v23aRUhICEHBwTx59gLn5Ekj3P/23QccOnYGo9HIo8fPuOl+j4zp01CyaD7OnL9CcHAIp85eokSRfFhZWVG8cF5OnbvMS18/7t5/SIE82U112cezo3TxAixcsR6j0Yiv3yvmLFpHg1qVTfu8GX575MQ5kiVNhH08O5InS8KTpy8ICQkJE1u61C68ehXA9Zt3MBqN7Nx7mML5c0b4Xry8fbh99wEF8+WgytclOXXu04bpivm8SbgtnjXalNh49tyTo6fOMWrQD8xZtMbMEYqIfL43Nxoqli3Gtn/WuXrze2/p7J/5sXsb01oZmTOmI4GTI65pU33yjQYIHWGR9COLfAIEBQebpsm8q37NSiyeNZra1cozoEdbFs8aTa7smUib2oWr12+H2ffKNXdc06YKV4eNjTVx42q0pIiI/DdKbsRS7u7uHDp0CHd39zDlaVKlwP3uA5p3GkijNn1wsI9HjSoR30lJnCgBf+47QovOg+jYeyTtW9YnedLEZM6YjtLFC9K84wDOXbzKd/WrAdC9fVMWr9xI+57D6di6IQ728cLU171DM154etO0Q3869BxB9SplKVEkn2n7qbOXaN31J9x+XW1aKDKVS3JSuSSncbt+nLt4zbRvnDg2jBzYldGT5tK0fX8SJ0xA9SpfRfhe/P0DmTZ3BU079GfHXwep822FT2xN+ZIsXrWJBjUrkyt7JgwGQ5g54CIilsCcNxoikjNrRo6ePEdAYCA+L325e9/jg/vXrlqe37f8yUOPJwDs3n+U10HB5MwWOo3Gx9cXbx9fXr8O4o8/D1Dwn6ejpEiWhMdPn39qU4mIiJgYAgMDjB/fzfyCgoIoXa0l+7f8io2NZtN8rmPHj9Ot3xC8cQAnZ/D2wAlfpowdRuFChcwd3geNmOBmegqKxA7u7u48fPgQFxcXXF1dw20vX7MNuzfMN71+/PQ53fqPYcms0djY2HDm/BVmzF+J2y+DtTq/iPwnUdEPieh33Ct/f2YtWM3Js5fw9w+gUL6c9O7SAhsbm3C/9wB8XvoyxW0ZV2/c5uVLPzq0qk+lciUAWLh8Pbv+OoxziiQM798FB/t4PPR4wuAxM/B75U+LRjVM+77x/4+CbVinClUrlGbG/JXsPXCcDOlS8+TZC7q0bfTBR7YeP32BmfNXEhAY+ijYH7u1IUnihDz0eML3PYaRLUt67tzzoGzJQnRs1QCDwcDh42cZMcGNUkXz079H20hpZxERiR2iLLmxfutu1mzYgaODPSP6dyZ5siSmbR97vvr7KLnx3x07fpzvOvUlfpXe2Ng7mcqD/Lzx2TaBZTPHfdEJDiU3Yg9LTsKJSMwUmf2QmPA7rt/QSTSsXfmDyY2IPPR4Qu/BE1k2Z0wURCYiIrFVlGQJnr/wYsmqTSxzG8P+wyeZMX8Vw37sZNr+Kc9Xl8jXrd+QcIkNABt7J+JX6UW3fkM4+OcWM0X3cT/1bm/uECQavJuEc3jnuxrg5813nfp+8Uk4EZEP0e84ERGRqBEla24cOXGOLBldsbOLS77c2Th07LRp2395vrp8Pnd3d7xxCJfYeMPGPgHeOIRbg0Mkun1KEk5ExFLFlN9xY4f2+KxRGwAuzsk0akNERCJdlCQ3nj33JG3q0Md7JU2ckOCQEPwDAgE++fnqErkePnwYOvT1Q5xS4OHx4QXCRKKSknAiEpPpd5yIiEjUiZrFKwyEeba5McTIm7X8PvX56gBrN+5k3aadoXX8c8z48ROx+mf/zp07cefOHTZt2mw6pnHjRtja2rJo0WJTWeXKlciRIweTJk02lRUuXIjy5cszc+YsfHx8AMiYMQP16tVj5cpV3L4d+viyhAkT0r799+zYsZNTp06Zju/TpzcnT57izz//NJW1bt2aly99WL367eMna9WqhbNzCmbPdjOVlSlThuLFizFhwkSCg4MByJ07F1WrVmXBgoU8eRK6snjKlClp1qwp69dv4MqVKwDY2dnRrdsP7Nu3n0OHDpnq7NKlC+7ut9i8+e20kiZNmmBjY83ixUswGo00LJCCs0YPHpCUKsbDpv1ukIpLVumpkSsJf/21l71795EpUybq1q3DihUruHPnLgCJEyemXbu2bNu2nTNnzpiO79evL0ePHmPPnj2msrZt2+Dp6cnatetMZXXq1CZp0qTMmTPXVPbVV19RtGgRxo+fYHqUa548efjmmyrMn7+Ap0+fApA6dWq++64Jv/++nqtXrwJgb29P165d2Lt3L4cPHzHV+cMPXbl+/Tpbt/5hKmva9DsAli5dZiqrWvUbMmXKxNSp00xlxYoVpWzZskybNh0/v9DH5GXJkoXatWuxbNly7t27B0DSpElp06Y1f/yxjbNnzwJgZWVFnz69OXLkKH/99Zepzu+/b8fTp0/57bffTWX16tUlYcKEzJv3dlG4cuXKUaRIYcaOHWcqy5s3L1WqVGbu3Hk8fx66enzatGlo3Lgx69b9xvXr1wFwdHSkc+dO7NnzF0ePHjUd3717Ny5fvsK2bdtMZc2bNyMoKJjly5ebyr79thqurumZPn26qax48eKUKVOaKVOm4u8f+vi/rFmzUqtWTZYsWcqDBw8ASJYsGa1bt2Lr1q2cO3ceAGtra3r37sWhQ4fZt2+fqc4OHdrj4fGI9evXm8oaNKiPo2N8FixYgNEYQsNy+bhgfIA7LlQzHjDt544L560yUq1ELlauXIXBYCBdunQ0atSQtWvXcuPGTQDix49Pp04d2b17N8eOHTcd36NHdy5evMj27TtMZS1aNCcwMJAVK1aayqpX/5a0adMyY8ZMU1nJkiUpVaokkyZNJjAwNFGbPXt2atSozuLFi3n4MDQpmCJFClq2bMHmzZu5cCH0KS1x4sShZ88eHDx4kP37/zbV2bFjBx48eMCGDRtNZQ0bNsDe3p6FC381lVWsWIE8efIwceIvprKCBQtQoUIFZs92w8vLC4D06V1p0KABq1ev5tYtdwASJEhAhw7t2bVrFydOnDQd36tXT86ePcvOnbtMZa1atcTPz49Vq1abymrWrEHKlCmZNWu2qax06VKUKFGCX36ZxOvXrwHImTMH3377Lb/+uohHjx4B4OLiTPPmzdm4cROXLoWOzrO1taVHj+78/fcBDhx4+9nqd/mn/y5/o0qVKmTLlpXJk6eYyooUKUK5cl8xY8ZMOnd+OxVUvhz/5kbD+xZRFhERkYhFyYKi23cfYM/fxxgzuDuPnz6nWYcBbF8b2jkOCQnhqxqt2bpqJo4O9vzw4xjq16pE6WIFPlinFhT970p8XY2Akp3fe8coyM+LuAdmftFrbkjM5+7uzrdt+uJQ8YcI9/HdOZXN88ep4y8i0Soy+iH6HSciIhJ1omRaSpECubl24zb+/gGcOnuZEkXysWzNFnbsOfjZz1eX/27K2GH4bJtAkJ93mPIgPy98tk1kythhZopMJJSrqytO+Ib7jr4R5OeFE77q9IuIRdLvOBERkagTJcmNRAmdaNmkFm26DeH3zbvo1KYhj5484+kzTwC6t2/K4pUbad9zOB1bN8TBPl5UhCH/p3ChQiybOY64B2bgu3MqvkdW4btzKnYHZ2p1dvliKAknIjGZfseJiIhEjSiZlhIVNC0lcrm7u+Ph4YGzs7PuEMkX59jx43TrNwRvHMApBXg/IoHBl8ljhikJJyJmEZn9EP2OExERiXzKEsRSrq6uSmrIF6twoUIc/HOLknAiEiPpd5yIiEjkU3JDRL5YSsKJSEym33EiIiKRJ0rW3BARERERERERiS5KboiIiIiIiIiIRVNyQ0REREREREQsmpIbIiIiIiIiImLRlNwQEREREREREYum5IaIiIiIiIiIWDQlN0RERERERETEotmYO4BPZTQaAQgKCjJzJCIiIl8+a2trDAaDucOIMdQPERER+XTm6IdYTHIjODgYgHI125o5EhERkS/f/i2/YmNjMZf5L576ISIiIp/OHP0QQ2BggDFaz/iZQkJCCAwMNOudqKYd+rN09s9mOfeXSO3xltoiLLXHW2qLsNQeb0V1W2jkRuRSP+TLo/Z4S20RltrjLbVFWGqPt2JiP8RibulYWVlhZ2dn1hgMBoPugr1D7fGW2iIstcdbaouw1B5vqS0si/ohXx61x1tqi7DUHm+pLcJSe7wVE9tCC4qKiIiIiIiIiEVTcuNfqFu9orlD+KKoPd5SW4Sl9nhLbRGW2uMttYX8W/rOhKX2eEttEZba4y21RVhqj7diYltYzJobIiIiIiIiIiLvo5EbIiIiIiIiImLRlNwQEREREREREYum5IaIiIiIiIiIWLSY9eyXKLDitz9YvmYLjep8w3f1q+Hp5cNPo6fz/IUX31QsRdP635o7xGjh7ePLmCnzuXvPgwROjgzv3xkrK6tY2RaPnz5n4oxF3L3nQRxbGwb36UCSRAljZVu88dDjCY3a9WXSyD5kcE0Tq9ui5DfNyOiaBoC8ubLSuW1jho+bxe27DylcIBfd2n8X7c/8NqdzF68xccYigoND+KZCKapWLB0rvx+btu9lzfrtABiNcOvOfdYsnMi0Octi7XdDPo36IaHUD3lL/ZDw1A95S/2QsNQPCRVb+iFKbnxEgdzZuH7zjun1gmW/U7ZkIWpVLUeLzoMoU7wgaVO7mDHC6HH+0jXq16xE/tzZmDZ3OcvWbuH166BY2RYGg4F2zeqSKUNa1mzYwbI1W3B0sI+VbfHGjPkrSZPKGYi9/0feSJYkMYtnjTa9XrFuKy7OyRg16Ad6DBzHsZPnKVIwtxkjjD6vXwcxcqIbE0f0wSVFMu7cexhrvx/VK5eleuWyAOw9eJwz567w199HY+13Qz6d+iGh1A95S/2Q8NQPeUv9kLfUD3krtvRDNC3lI7JmTo9LiqSm1wePniZf7mzY2NiQO3tmDh07Y8book+JIvnInzsbALlzZObJ0xexti2SJUlEpgxpeeHpzb0HHmTJ6Bpr2wLg9LnLhISEkDWTKxB7/4+8kSCBY5jXB/5pD4PBQL7c2TgYi9rj2KnzZMucgdQpU2BtbUX6dKli/fcjODiERSs20LZ53Vj93ZBPp35IKPVD3lI/JCz1Q8JSP+Qt9UPCi+n9ECU3/qXnL7xInTIFAGlTu/D0mad5AzKDE6cvkidnlljdFmcuXKV64y7cuv2A+jUrxdq2CA4OYeaCVXRt18RUFlvb4o1nzz1p130Y7boP5cyFqzx77km6f+4IpEvtwtNnL8wcYfR54PGEePHi0nfIL7ToPJCTZy/F+u/H0ZPnyJE1E/bx7GL1d0M+X2z/PwTqh4D6IW+oHxKe+iFvqR8SXkzvhyi58S8ZDIbQiUpAiDEEg5Vlz0v6t2643+XYqQtUr1I2VrdF3pxZ2LNxAXlzZeHnSXNjbVts2bmPIgVy4eKczFQWW9vijVGDujF9XH/q1ajI0LEzMWAgJORNexixikXt4ffqFddv3mFQ7/b07dqaidMXxfrvx94DxylRJC9ArP5uyOeL7f+H1A8JpX5IKPVDwlM/5C31Q8KL6f0QJTf+pcSJEnDvwSMA7t7zIFmSRGaOKPq88PRmyJiZjBzYlbi2trG6LQDixLGhQa3KHDx2Jta2xd4Dx/j78CnadhvCwaOnGT/9V/xe+cfKtngjb84sxLW1peJXxXn50o+kSRJx9/5DILQ9kiaOPe2RNHEi0qdLjVN8B3JkzYCnt0+s/b/yxqVrN8mUPnSht9j83ZDPF5v/D6kfEpb6IeqHvI/6IW+pHxJeTO+HKLnxL5Usmp9T5y4TFBTE+UvXKV44r7lDihaBga8ZMGIK7ZrXNf2HiK1t8fuW/7V353FVVXsfxz8I54ADg4A4i0qO5FQYqTgkqKjkHI45Zk6J1xQrRcvxmuJTPg7pVbtFkpqWQ86mdc0hJxQHTAkVSxEURREHlLOfP7SjXMCsxyHk+/4P9t5rLdZr89rf12+vdc5mjsWexDAMvt+2B8/SJfLsXEwbH8pnsyYwf/pY6r5Uk9C3etKxbWCenAuA7bv28+uZcwDsi47Bw92Ver412X/wZwzD4MDhn6nrW/PpDvIJ8n2xGvsPHiXt2nVijsVRtIhbnv1f+V1iUjKuri4AefrekL8ur/4PKYfcoxxyj3JIZsohmSmHZPWs5xCb9PSbxtMexN/V+eRLDAubSvKly+SzscGzTAkmjgph9KSZJF9MIahZAzq3b/G0h/lELFi4nMilqylbpgS3b2cAMG1CKOOnzs1zc3Hq9Fk++iSCc0nJFCzgwOjh/XEt7Jwn74v7jQ+fS8sm9fEqVybPzsXJ+DNMn7uQpPMXMZntGDm0L2XLlGDclDmcOn0WX5/qDO7bOdd/zdafsX7zNr74ajWGxSBs+JuULF40z94fAP5t3mDzivkA3ExPz9P3hvwx5ZB7lEPuUQ7JnnKIckh2lEMye9ZziIobIiIiIiIiIpKraVuKiIiIiIiIiORqKm6IiIiIiIiISK6m4oaIiIiIiIiI5GoqboiIiIiIiIhIrqbihoiIiIiIiIjkaipuiIiIiIiIiEiuZve0ByDyOKVcTuWdsR+RfDGFbsFBtGnRGIDd+w4R/1sCr7Vu+kTHs/ib9cSeiGf08H7sPXCEHbujCXmzS5bz/rNjL0uWr2f21LAHtjf/i68pXrQILZs2eOgxrN+8jS+XrcXF2YmPJo7A1vbP1TjXbNxKQuJ53ni9/Z+67v9jw5btXEhOoetrLR/6mrbd/4HZZAfYcPNmOk1fqUP/XsHky5ePgaETOJeYTP789ly+korvi9UJfasnDg72GIbBirVbWL5mCxaLhUIF8jOwTyeqe1e0tn08Lp4Z//qSS5evYGdrS/MAPzq2DSQqOoahYVPxLFXcem6blv60C/JnfPhcdkcdprCzo/XYtAmhFHErTJ1m3ShfthQY4ORUiL6vt+OFGlUfydyJiMjToxySlXKIcojI46LihjzTVqzdQrPG9WjRpD59QsYQ1LQBNjb5WLHue8a9O/Cpjs2npjc+Nb2feL+rN2ylS4cWBPr7PfG+/6pmjev9pevGjxxMRS9PrqSmMXTUFDZs2UHzgDt/95D+XWlY14frN24wfupcIpetpU+3tqxYu4W1m35kxuR3cXZyJDYunrdHhzNj8ruULVOS384mMmx0OJPCQqhWtQI3bqaz/+BRa5+epYoT8cmkbMfTtUNLOrULzPbYnGmjcSxUkCM/x/HuuI+ZOGpwpiAjIiK5j3JIVsohyiEij4uKG/JMS0xKpk7tGjjYmylZzIPLV67y409RBDauh51d9re/YRgs/mYdq9b/gMnODp+a3oT068rOPdFELF5F2rXrYGPDByMGUL5sKaKiY1i4dA2lSxZl7/4YsIGpY9+mRDEPLBYL8yK+ZtMPO3FzdcHebKaIe2Eg61uRZas2sWT5epydClHYxck6nuSLKUyfu5DfziZyJTWN4DbNCG7TjKUrN/LVio0UyO/AkuXr+XTmeFJSrjDlf//N6TPnMJtNjBjci+erPGdt65NPlxBzLI6z586TkHiBnp1b8/niVaz7bhuGYdA8wI9eXdpw/cYNps+J5HhcPKlX02hUrzaD3ujED9v2MPvTJQBs3bGPKWPfZl7E11Qo72l9WHYfMJJ/9O/GCzWqMjB0As0D6rNq3fcENHyZdkEBzFqwmJ17ojEMg27BQbQKbMSp02cYO2UOadeu4+LsyNh3B1G8qLt13Pe/aVqzcSv7D/2MYRgcionFxdmR8HHDcXIsmON94ORYkBrPV+L0mYQsx/I7OFCrehUOH/0FgIjFq5gYFoKz0503GxW8PAlu3ZSFX60mbHg/Ipasov2rAVSrWgEAB3szdWrX+IM78eF5V/aiV5c2RCz5lvBxwx5ZuyIi8uQphyiHgHKIyJOi4oY808qUKsaO3Qco4l6YMwlJmM0m9u4/woDeHfngw9mYTCbeeqOT9QECsOmHnaz7bhtzpo3BybEgFy9dBqBEsSJMfn8ozk6F+GzRShYs/IaJYSEAHD4aS7+erzGkXzdGTZjByrXfM6B3R9Zt3sZPew/y+eyJ5Hew56NPvuDa9RtZxhl18CiRy9Yw/+MPcHN1IXLpGrbv3g+Ak2MhunZoSaUK5Ug6n0yHXsNoHuDHa62b8nPsSV6oXsW6HHTCtH/RqV1zXvapzqnTZxgzeTYRsyda+xnQuyOHjsbSsW0gDev6sGHLDuJ/PUvk3H9iGBDy3mTq1q5BxefKEtSsId6Vvbhx8yatu4bQokl9GvnV5peTpwEeejnomg3/YdaUUZjNJj5btBJ7s4lF8z4kPf0WPQaF4edbi29Wb+b5Ks8xbFAPEhIvULSI6wPb3Bcdw6wpI/Fwd+XNoePY8uMu61Lf7CQmJbN9VxRvD+yR5djlK6ls+mEnTRrVIS3tGucvXKLic2UznVO1khebt+4CIDbuNM1eyfkNTvxvCXQfMBKAQoUKZFrSG7lsDWs3bQWgeYAfndu3yLYN78peRC5dnWMfIiKSOyiHKIeAcojIk6LihjzTWgU2Ylz4XL4b8RO9u7UlcukaugUHMWPelwzq04mExAt8vvjbTPtNt+7YR/tXm+DsVAgAN1cXAEqVKMaufQf5ae9Bjh4/QfqtW9Zrinm4U+nug8i7ihen4s8AsGPXAdq2bEzBAvkBKFm8KLEn4rOMc8fuAwQ2rnevr5JFrcdMJjscHOxZsHA5cad+xQYbEpOScSyU+Q3Btes32Lv/CBcvXWb2gsUApF5Ne+D8/LhzH0eOxdF78BhrGwmJF6hUoRxF3AoTuWwNx385BcBvZ89RzrPkA9vLTnDbQMxm093+oki9msbOPdEApN+6xbmkC/g38GXy9AUsWLicdkH+5Mv34P23Fct7UqKYBwBVKpUn+WJKtueNnjQDk8lEfgd7undshe+L1azHps+J5JNPvyIh8Tw9OrWiXVAAN27cDXyGkakdi2EhXz4b688GmY/f768uB72fYRh/OAciIvL3pxyiHKIcIvLkqLghz7SCBQvw4ftDAUg4d549UYepXKEcyRdTKF2yGC7Ojiz6em2mayyGgY1N1rbGh8/B3mymVfNG+PnWYub8Rdn2aWdrZ33k3M7IwNbW9g/Heft2Bg725myP7dwTzawFi+nXowMdWjWh5/EwLEb2DzUDg1lTR2UJHDkxDIPO7ZoT3KZZpt8fj4snbOIM3uzegeb+fly4ODPHPm2A2xm3c+zj/g8KMwyDwX07U7/Oi1nO+2zWBDZs3k6PQaP44J2BvFC9ykP9DXa2thg5jO33va7ZGdK/K3Vr16TnoDAqVyiHrW0+ChYsgEcRN2KOnci0z/TI0Ti8ypUBwKtcaQ7FxD7WfcqHYmIp71nqsbUvIiJPhnLIgymHKIeIPEoqyUmesSByOb26tAHA3t7MqdNnOXz0FzzcMy89rPdSTZav2cLVtGsA/HrmHAA//hRFh1ZNqFrJi6OxJx+qz5rVKrNu8zZu3brN7YwMYo7F5XBeJbZs3U1a2jXrHs7f7dwTjU9Nb+rXeZFLKZdJTb33FqSYhzsJiecBKJD/zp7NeRFfY7FYyMiwkJB44YHj83v5Bb5ascH6xuHsuSQA9h04QjnPkgQ0epkMi4XEpOT/6vNeu26uLhyKiSUjw0LUwaOcSUh6QH+1iFiymrS7c/t7fwePHMcGG14NbETN5ysRFR3zwHE/KiaTHe8M6c3UGf+2jqlnl9Z8PGchKZdTATgWe5Jl326k291PSH89OIhlqzZZ98beunWbpSs3cjM9/ZGM6VBMLJ8vXkn3Tq0eSXsiIvL3oBySlXKIcojIo6SVG5InHIqJpYh7YYp6uAHQ9/X2hL4/DbPJxKTRIZnObdGkPueSkukTMgYHB3uqVanIsEHd6dO1HWGTZuDh7sbLPtUfqt92Qf7EnThN574jKObhTvmype58ENh/aVjXh0MxsXQfOAoPd1eq3Vetb9mkPuGzPqf34DFUq1qBMvd9vZd/A1+GjQlnx+5owscP4/0RAwif+Rmd+76DvdlEy6YN6Ng25+WHgf71OJ98kYGhE+5+yJgrE0cN5pX6L7F91wG6DxxFRS9Pyt1Xva9TuwZfLltL9wEjGRPan9YtXiF0zP/Qsc9wGvnVxqdWzm8SXg9+latXr9Fr8J259SpbijGh/Yk9EX93H/B1iri5MqRft4ea30ehundF6vrWYub8xbwzpDevNmuIYTEIeW8yGRkZFCpYgH+O/geepUsA4Fm6BFM+GMrMeYu4cjUNs8lEoH89zKY7S17v3+sKd4Lbmz06AJn3ugK8N/QNqlQsD0D/YeOxWCy4ODky7r238K7s9aSmQEREHjPlkOwphyiHiDxKNunpN3PetCUiIiIiIiIi8jenbSkiIiIiIiIikqupuCEiIiIiIiIiuZqKGyIiIiIiIiKSq6m4ISIiIiIiIiK5moobIiIiIiIiIpKrqbghIiIiIiIiIrna/wHhFgV+5VSmPQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1100x420 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "image/png": {
-       "alt": "Two scatter panels plotting each case study's percentage of PROCEED features against its validation Sharpe on the left and its holdout Sharpe on the right, points labelled by case study. Only case studies with registered backtests appear, and they are too few to show a trend."
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "269ccb17",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, axes = plt.subplots(1, 2, figsize=(11, 4.2), sharey=False)\n",
     "for ax, ycol, ylabel in zip(\n",
@@ -684,40 +377,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "420092bd",
+   "execution_count": null,
+   "id": "66f08b68",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T07:52:27.939657Z",
-     "iopub.status.busy": "2026-08-20T07:52:27.939500Z",
-     "iopub.status.idle": "2026-08-20T07:52:27.944154Z",
-     "shell.execute_reply": "2026-08-20T07:52:27.943671Z"
-    },
-    "papermill": {
-     "duration": 0.00714,
-     "end_time": "2026-08-20T07:52:27.944599+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.937459+00:00",
-     "status": "completed"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "5 of 9 case studies carry a holdout Sharpe; the rest have no registered backtests (Crypto, ETFs, NQ100, US Equities). Among those that do, the highest holdout Sharpe is +2.61 (US Firms, 70.2 percent PROCEED). With this many points, no ordering of PROCEED rate against holdout Sharpe is distinguishable from chance, and none is claimed here."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "_paired = forward.filter(pl.col(\"holdout_sharpe\").is_not_null())\n",
     "_absent = forward.filter(pl.col(\"holdout_sharpe\").is_null())[\"cs_short\"].to_list()\n",
@@ -745,16 +412,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ba0dadb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001222,
-     "end_time": "2026-08-20T07:52:27.947087+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.945865+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "c55178e3",
+   "metadata": {},
    "source": [
     "What the count of surviving features cannot tell you is how large those\n",
     "features are relative to the frictions of the market they trade in, or how\n",
@@ -765,16 +424,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b66d65a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001177,
-     "end_time": "2026-08-20T07:52:27.949500+00:00",
-     "exception": false,
-     "start_time": "2026-08-20T07:52:27.948323+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "b7ded287",
+   "metadata": {},
    "source": [
     "## Takeaways\n",
     "\n",
@@ -817,37 +468,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "94e02fc0cadc7d7018cd578edaf710f735aef966",
-   "executed_at": "2026-08-20T07:52:33.375367+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 3.368612,
-   "end_time": "2026-08-20T07:52:28.765552+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "20_strategy_synthesis/02_feature_evaluation.ipynb",
-   "output_path": "20_strategy_synthesis/02_feature_evaluation.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-20T07:52:25.396940+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/20_strategy_synthesis/02_feature_evaluation.py
+++ b/20_strategy_synthesis/02_feature_evaluation.py
@@ -45,7 +45,7 @@ from IPython.display import Markdown, display
 
 warnings.filterwarnings("ignore")
 
-from case_studies.utils.analytics import CASE_STUDY_IDS, SHORT_NAMES
+from case_studies.utils.analytics import CASE_STUDY_IDS, SHORT_NAMES, load_triage_ledger
 from utils.paths import REPO_ROOT, get_chapter_dir
 from utils.style import show_with_alt
 
@@ -76,14 +76,7 @@ CS_LIST = CASE_STUDY_IDS[:MAX_CASE_STUDIES] if MAX_CASE_STUDIES else CASE_STUDY_
 
 
 # %%
-def _load_ledger(cs: str) -> pl.DataFrame | None:
-    p = REPO_ROOT / "case_studies" / cs / "evaluation" / "triage_ledger.parquet"
-    if not p.exists():
-        return None
-    return pl.read_parquet(p).with_columns(case_study=pl.lit(cs))
-
-
-ledgers = {cs: _load_ledger(cs) for cs in CS_LIST}
+ledgers = {cs: load_triage_ledger(cs) for cs in CS_LIST}
 available = [cs for cs, df in ledgers.items() if df is not None]
 missing = [cs for cs in CS_LIST if cs not in available]
 print(f"Loaded {len(available)}/{len(CS_LIST)} ledgers")

--- a/case_studies/utils/analytics.py
+++ b/case_studies/utils/analytics.py
@@ -24,7 +24,7 @@ from case_studies.utils.notebook_contracts import (
     degenerate_prediction_sql,
     full_coverage_prediction_sql,
 )
-from utils.paths import REPO_ROOT
+from utils.paths import REPO_ROOT, get_case_study_dir
 
 CASE_STUDY_META = {
     "etfs": {"display_name": "ETFs", "chapter_track": "Ch6 to Ch21"},
@@ -686,3 +686,26 @@ def load_carrier_cost_curves(case_studies: list[str] | None = None) -> pl.DataFr
 # cross-module interface and is now public. The aliases keep those callers working until
 # each notebook is re-executed with the public name, and go when the last one moves.
 _registry_path = registry_path
+
+
+def triage_ledger_path(case_study: str) -> Path:
+    """Where a case study's stage-05 triage ledger actually is.
+
+    ``05_evaluation`` writes it through ``get_case_study_dir``, which honours
+    ``ML4T_OUTPUT_DIR``. A reader that builds the same path from ``REPO_ROOT`` instead resolves
+    somewhere else whenever that variable is set, which is every CI job: the fixture seeds
+    ``/tmp/ml4t-test-output/<cs>/evaluation/triage_ledger.parquet`` and the reader looks under the
+    checkout, finds nothing, and reports the ledger missing. ``ch18-20`` failed that way while all
+    nine ledgers were present in ``ml4t/third-edition-test-data``.
+
+    One function so the writer's path and the reader's path cannot drift again.
+    """
+    return get_case_study_dir(case_study, create=False) / "evaluation" / "triage_ledger.parquet"
+
+
+def load_triage_ledger(case_study: str) -> pl.DataFrame | None:
+    """Read one case study's triage ledger, or None when that stage has not run."""
+    path = triage_ledger_path(case_study)
+    if not path.exists():
+        return None
+    return pl.read_parquet(path).with_columns(case_study=pl.lit(case_study))

--- a/tests/test_triage_ledger_location.py
+++ b/tests/test_triage_ledger_location.py
@@ -1,0 +1,83 @@
+"""The chapter-20 reader and the stage-05 writer resolve one path.
+
+``case_studies/<cs>/05_evaluation`` writes ``evaluation/triage_ledger.parquet`` through
+``get_case_study_dir``, which honours ``ML4T_OUTPUT_DIR``. Chapter 20 read it from ``REPO_ROOT``,
+which does not - so in every CI job the fixture was seeded at
+``/tmp/ml4t-test-output/<cs>/evaluation/`` and the reader looked under the checkout. ``ch18-20``
+reported "No triage ledger for [...]" while all nine ledgers were present in the test-data repo.
+
+The bug was invisible locally, where ``ML4T_OUTPUT_DIR`` is unset and the two paths coincide, so
+the test that matters is the one that sets it.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+
+def _reloaded_analytics():
+    import utils.paths
+
+    importlib.reload(utils.paths)
+    import case_studies.utils.analytics as analytics
+
+    return importlib.reload(analytics)
+
+
+@pytest.fixture
+def restore_modules():
+    yield
+    _reloaded_analytics()
+
+
+def test_the_ledger_is_read_from_the_output_root_the_writer_wrote_to(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, restore_modules: None
+) -> None:
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    analytics = _reloaded_analytics()
+
+    seeded = tmp_path / "etfs" / "evaluation"
+    seeded.mkdir(parents=True)
+    pl.DataFrame({"feature": ["mom_21"], "verdict": ["advance"]}).write_parquet(
+        seeded / "triage_ledger.parquet"
+    )
+
+    assert analytics.triage_ledger_path("etfs") == seeded / "triage_ledger.parquet"
+
+    ledger = analytics.load_triage_ledger("etfs")
+    assert ledger is not None, "the reader did not find the ledger the writer's path produced"
+    assert ledger.get_column("case_study").to_list() == ["etfs"]
+    assert ledger.get_column("feature").to_list() == ["mom_21"]
+
+
+def test_a_repo_relative_path_would_not_have_found_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, restore_modules: None
+) -> None:
+    """The failure direction, stated as the thing the old code did.
+
+    Without this, the test above passes on a reader that happens to resolve to the same place for
+    another reason. This pins that the redirect actually moves the path off the checkout.
+    """
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    analytics = _reloaded_analytics()
+
+    from utils.paths import REPO_ROOT
+
+    resolved = analytics.triage_ledger_path("etfs")
+    old_path = REPO_ROOT / "case_studies" / "etfs" / "evaluation" / "triage_ledger.parquet"
+
+    assert resolved != old_path
+    assert not resolved.is_relative_to(REPO_ROOT)
+
+
+def test_an_absent_ledger_reads_as_absent_rather_than_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, restore_modules: None
+) -> None:
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    analytics = _reloaded_analytics()
+
+    assert analytics.load_triage_ledger("etfs") is None


### PR DESCRIPTION
Two defects in `20_strategy_synthesis`, both the same shape: a value or a path stated in one place and derived in another, agreeing when written and not since.

## `ch18-20` is red with the data already shipped

`02_feature_evaluation` read `case_studies/<cs>/evaluation/triage_ledger.parquet` from `REPO_ROOT`. Each case study's `05_evaluation` **writes** it through `get_case_study_dir`, which honours `ML4T_OUTPUT_DIR`. Those are the same path only when that variable is unset - true on a workstation, false in every CI job.

So CI seeds the fixture at `/tmp/ml4t-test-output/<cs>/evaluation/` and the reader looks under the checkout, finds nothing, and raises `No triage ledger for [...]` - with all nine ledgers present in `ml4t/third-edition-test-data` the whole time. A path bug reported as missing data.

Fixed by giving the reader and the writer one derivation: `analytics.triage_ledger_path` and `analytics.load_triage_ledger`.

Three tests. The one that matters sets `ML4T_OUTPUT_DIR`, because with it unset the two paths coincide and any test passes on the broken code. Reverting to the `REPO_ROOT` form fails two of the three.

## Chapter 20 pinned `us_firm_characteristics` to its weakest advanced config

`_CARRIER_PIN_PREDICATES` held `"us_firm_characteristics": pl.col("config_name") == "default_huber"`, hand-copied from `case_studies.utils.strategy_analysis.CARRIER_PINS` and translated into a config-name predicate, under a `keep in sync` comment doing the job a mechanism should. Measured against the current registry:

| | validation backtests | best Sharpe |
|---|---|---|
| `default_huber` | 48 | 2.128 - tenth of ten advanced configs |
| `leaves_63_mse` | 59 | 3.116 - what the documented rule selects |

So chapter 20 restricted that case study to its weakest advanced configuration while every notebook inside it reported its strongest.

Worse than the hash pin removed from `CARRIER_PINS` the same day, and the difference is the point: a hash pin dies loudly, because every backtest hash changes when a sweep is rebuilt - which is how the other one was caught. A config-name predicate survives the rebuild and keeps selecting.

The entry is gone; the mechanism stays empty, which is its normal state. The comment now records the measurement and points at `carrier_pins.carrier_config_name`, which resolves a pin through the registry and would have failed loudly instead of filtering to the wrong config.

**Not fixed here, deliberately.** `test_carrier_pins_are_single_sourced_and_well_formed` walks these files for assignments named `CARRIER_PINS` and passed straight over a mapping called `_CARRIER_PIN_PREDICATES` - a check aimed at exactly this duplication that could not see it. Widening it belongs with whoever next touches that test; the `us_firm_characteristics` pane has offered to assert the predicate mapping's keys are a subset of `CARRIER_PINS`.

Both notebooks are rebuilt from their `.py` and cleared, so they claim nothing until the chapter-20 synthesis is re-executed - which cannot happen usefully yet, since it aggregates across nine case studies holding almost no backtest rows between them.