### PR TITLE
Build the holdout evaluation into the case study, out of the Chapter 20 notebook

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -51,6 +51,10 @@ tests/test_gbm_runtime.py
 tests/test_insight_chapter.py
 tests/test_latent_factors_no_leak.py
 tests/test_latent_input_identity.py
+# Imports `_install_fixture_adapter` and `_locked_study` from
+# test_locked_holdout_execution, so it inherits that module's torch dependency
+# transitively rather than importing torch itself. Same boundary, same reason.
+tests/test_holdout_evaluation_driver.py
 tests/test_locked_holdout_execution.py
 tests/test_model_analysis_selection.py
 tests/test_registry_metrics.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -947,6 +947,7 @@ jobs:
             tests/test_insight_chapter.py \
             tests/test_latent_factors_no_leak.py \
             tests/test_latent_input_identity.py \
+            tests/test_holdout_evaluation_driver.py \
             tests/test_locked_holdout_execution.py \
             tests/test_model_analysis_selection.py \
             tests/test_registry_metrics.py \

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -469,3 +469,95 @@ def build_holdout_cv(
             "holdout_window": [str(holdout_start), str(holdout_end)],
         },
     }
+
+
+@dataclass(frozen=True)
+class HoldoutOutcome:
+    """One case study's holdout evaluation, and whether this call is what produced it."""
+
+    lock: ResearchLock
+    evaluated_now: bool
+
+    @property
+    def lineage(self) -> dict[str, str]:
+        return self.lock.study.lifecycle.holdout_lineage(self.lock.hash)
+
+
+def evaluate_holdout(
+    study: Any,
+    *,
+    candidate_set_name: str,
+    case_study: str | None = None,
+    selection_evidence: Mapping[str, Any] | None = None,
+) -> HoldoutOutcome:
+    """Lock one selected configuration and evaluate it on the holdout, at most once ever.
+
+    This is the whole sequence, in one place, because every case study needs the identical one
+    and nine notebooks assembling it from five primitives is how nine versions of it appear.
+    Each primitive it calls already exists and is already tested; what did not exist was anything
+    that called them.
+
+    The holdout is used once. That is not a convention this enforces by asking callers to check
+    first - re-running a notebook is normal and must not be able to spend the holdout a second
+    time. So an already-evaluated lifecycle returns its recorded lineage and executes nothing,
+    and ``evaluated_now`` is how a caller tells the two apart. A notebook re-run therefore reads
+    back exactly the numbers it published before, which is also what makes the page reproducible.
+
+    Selection is not a parameter either. ``lifecycle.lock`` refuses any selection that is not the
+    candidate set's highest validation backtest Sharpe, so passing the rank-1 member is the only
+    thing that can be passed - this reads it from the set rather than accepting it, which removes
+    the one place a caller could have disagreed with the documented rule.
+    """
+    from .comparison import CandidateSet
+    from .execution import run_locked_holdout
+    from .lifecycle import LifecycleState
+
+    lifecycle = study.lifecycle
+    state = lifecycle.state
+    if state == LifecycleState.HOLDOUT_EVALUATED.value:
+        existing = _sole_lock(study)
+        return HoldoutOutcome(existing, evaluated_now=False)
+
+    candidates = CandidateSet.one(study, name=candidate_set_name)
+    selected = candidates.best_validation_sharpe()
+    selected_record = selected.registry_record()
+    prediction = study.results.open(selected_record["prediction_hash"])
+    training = study.results.open(prediction.registry_record()["training_hash"])
+
+    validation_spec = training.spec()
+    holdout_spec = deepcopy(validation_spec)
+    holdout_spec["computation"]["cv"] = build_holdout_cv(
+        validation_spec,
+        case_study=str(case_study if case_study is not None else study.case_study),
+    )
+
+    # selection_evidence is hashed into the lock identity, so anything put here that is already
+    # recorded elsewhere gives one fact two sources and makes the lock unreproducible by any
+    # caller that words it differently. The candidate set is already in the record under
+    # candidate_set_hash; the metric is the only thing this adds, and it is the documented rule.
+    evidence = {"metric": "validation_backtest_sharpe", **dict(selection_evidence or {})}
+    lock = lifecycle.lock(
+        candidate_set_hash=candidates.hash,
+        selected_backtest_hash=selected.hash,
+        selection_evidence=evidence,
+        holdout_training_spec=holdout_spec,
+    )
+    if lock.reopen().state == LifecycleState.HOLDOUT_EVALUATED.value:
+        # The lock already existed and had been spent. lifecycle.lock returns the existing lock
+        # rather than raising when the request is identical, so this is reached by a re-run whose
+        # selection has not changed - and it must not re-execute.
+        return HoldoutOutcome(lock.reopen(), evaluated_now=False)
+
+    execution = run_locked_holdout(lock)
+    return HoldoutOutcome(execution.lock, evaluated_now=True)
+
+
+def _sole_lock(study: Any) -> ResearchLock:
+    import sqlite3
+    from contextlib import closing
+
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
+        rows = db.execute("SELECT lock_hash FROM research_locks").fetchall()
+    if len(rows) != 1:
+        raise ValueError(f"lifecycle holds {len(rows)} research locks, not one")
+    return study.lifecycle.open(rows[0][0])

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 import hashlib
 import importlib
 import inspect
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from typing import Any
 
+import pandas as pd
 import polars as pl
 
 from .decisions import DecisionArtifact, StateTransitionPolicy
 from .lifecycle import ResearchLock
 from .results import BacktestResult, PredictionResult
+
+_FOLD_FIELDS = ("fold", "train_start", "train_end", "val_start", "val_end")
 
 
 def _source_digest(function: Any) -> str:
@@ -342,3 +346,126 @@ def prepare_locked_strategy_replay(lock: ResearchLock) -> LockedStrategyReplay:
         "min_trade_value": rebalance.get("min_trade_value"),
     }
     return LockedStrategyReplay(lock, request, _prepare_decision_replay(lock))
+
+
+def _validation_folds(validation_spec: Mapping[str, Any]) -> list[dict[str, Any]]:
+    computation = validation_spec.get("computation")
+    if not isinstance(computation, dict):
+        raise ValueError("holdout CV derivation requires a current resolved training specification")
+    cv = computation.get("cv")
+    if not isinstance(cv, dict):
+        raise ValueError("selected training specification has no resolved CV interval")
+    folds = cv.get("folds")
+    if not isinstance(folds, list) or not folds:
+        raise ValueError("selected training specification has no resolved validation folds")
+    missing = {name for fold in folds for name in _FOLD_FIELDS if name not in fold}
+    if missing:
+        raise ValueError(f"validation folds are missing boundaries: {sorted(missing)}")
+    return [dict(fold) for fold in folds]
+
+
+def build_holdout_cv(
+    validation_spec: Mapping[str, Any],
+    *,
+    case_study: str,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Derive the one holdout CV interval that retrains the selected validation configuration.
+
+    The holdout window is not a choice. It is ``evaluation.holdout_start`` and
+    ``evaluation.holdout_end`` from the case study's own ``setup.yaml``, read here through
+    :func:`case_studies.utils.cv_window.canonical_window` so this derivation and the window a
+    backtest is sliced to cannot disagree. ``lifecycle.lock`` re-checks the same window before
+    it will accept the spec, and :func:`case_studies.research.models.locked_holdout_split`
+    checks it a third time at execution.
+
+    The training interval is the whole history available before that window, which is
+    ``min(train_start)`` across the validation folds and never one fold's own start: the fold
+    list runs newest first, so ``folds[0]["train_start"]`` is the *latest* start in the set and
+    would hand the retrain the shortest window it could have had rather than the longest.
+    :func:`utils.cv_splits.earliest_train_start` is that read, and this calls it rather than
+    repeating it.
+
+    Training ends one label buffer before the holdout opens, using the same buffer the
+    validation folds were built with. That gap is what stops the last training label's outcome
+    window from reaching into the holdout, which would train the holdout model on the period it
+    is meant to be judged against. The buffer is required rather than defaulted: a case study
+    that declares none has no basis for a gap, and a zero gap here is a leak rather than a
+    conservative choice.
+    """
+    from case_studies.utils.artifact_digest import value_digest
+    from case_studies.utils.cv_window import canonical_window
+    from utils.artifact_specs import (
+        load_setup_config,
+        resolve_label_buffer,
+        resolve_label_horizon,
+    )
+    from utils.cv_splits import earliest_train_start, normalize_label_buffer
+
+    resolved_label = str(label if label is not None else validation_spec.get("label") or "")
+    if not resolved_label:
+        raise ValueError("holdout CV derivation requires the label the selection was made on")
+
+    window = canonical_window(case_study, resolved_label, split="holdout")
+    if window is None:
+        raise ValueError(
+            f"{case_study} declares no holdout window for {resolved_label!r}; "
+            "evaluation.holdout_start and evaluation.holdout_end must both be set in "
+            "config/setup.yaml before a holdout can be locked"
+        )
+    holdout_start, holdout_end = window
+
+    folds = _validation_folds(validation_spec)
+    validation_cv = dict(validation_spec["computation"]["cv"])
+    train_start = earliest_train_start(folds)
+
+    # Both resolvers fall back to setup.yaml's own labels block, and return None without it
+    # for every case study whose label carries no separate spec artifact - which is all nine
+    # for their primary label. Passing the setup is what makes the buffer resolvable at all.
+    setup = load_setup_config(case_study)
+    buffer = resolve_label_buffer(case_study, resolved_label, setup)
+    if not buffer:
+        raise ValueError(
+            f"{case_study} declares no label buffer for {resolved_label!r}, so the gap sealing "
+            "holdout training from the holdout window cannot be derived"
+        )
+    buffer_offset = pd.Timedelta(normalize_label_buffer(buffer))
+    if buffer_offset <= pd.Timedelta(0):
+        raise ValueError(f"label buffer {buffer!r} leaves no gap before the holdout window")
+
+    horizon = resolve_label_horizon(case_study, resolved_label, setup)
+    if horizon:
+        horizon_offset = pd.Timedelta(normalize_label_buffer(horizon))
+        if buffer_offset < horizon_offset:
+            raise ValueError(
+                f"label buffer {buffer!r} is shorter than the outcome horizon {horizon!r}, so "
+                "the last training label resolves inside the holdout window"
+            )
+
+    train_end = pd.Timestamp(holdout_start) - buffer_offset
+    if train_end <= train_start:
+        raise ValueError(
+            f"{case_study} holdout training interval is empty: history starts "
+            f"{train_start.date()} and the buffered boundary is {train_end.date()}"
+        )
+
+    fold = {
+        "fold": max(int(entry["fold"]) for entry in folds) + 1,
+        "train_start": train_start.isoformat(),
+        "train_end": train_end.isoformat(),
+        "val_start": pd.Timestamp(holdout_start).isoformat(),
+        "val_end": pd.Timestamp(holdout_end).isoformat(),
+    }
+    identity = value_digest(pl.DataFrame([fold]))
+    if identity == validation_cv.get("identity"):
+        raise ValueError("derived holdout CV is identical to the selected validation CV")
+    return {
+        "folds": [fold],
+        "identity": identity,
+        "split": "holdout",
+        "request": {
+            "source": "case_study_holdout",
+            "label_buffer": str(buffer),
+            "holdout_window": [str(holdout_start), str(holdout_end)],
+        },
+    }

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import inspect
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -368,6 +368,7 @@ def build_holdout_cv(
     validation_spec: Mapping[str, Any],
     *,
     case_study: str,
+    timeline: Sequence[Any],
     label: str | None = None,
 ) -> dict[str, Any]:
     """Derive the one holdout CV interval that retrains the selected validation configuration.
@@ -394,6 +395,7 @@ def build_holdout_cv(
     conservative choice.
     """
     from case_studies.utils.artifact_digest import value_digest
+    from case_studies.utils.causal import embargo_from_buffer, observation_step
     from case_studies.utils.cv_window import canonical_window
     from utils.artifact_specs import (
         load_setup_config,
@@ -429,20 +431,62 @@ def build_holdout_cv(
             f"{case_study} declares no label buffer for {resolved_label!r}, so the gap sealing "
             "holdout training from the holdout window cannot be derived"
         )
-    buffer_offset = pd.Timedelta(normalize_label_buffer(buffer))
-    if buffer_offset <= pd.Timedelta(0):
+    holdout_open = pd.Timestamp(holdout_start)
+    observations = sorted({pd.Timestamp(str(value)) for value in timeline})
+    if len(observations) < 2:
+        raise ValueError("holdout CV derivation needs at least two observations to measure cadence")
+
+    # Counted in OBSERVATIONS and stepped back along the panel's own dates, never subtracted as
+    # calendar time. `utils/cv_splits.py` already carries this bug's epitaph: "21D" as a
+    # pd.Timedelta is ~15 trading days, not 21, so a calendar subtraction leaves the last training
+    # label resolving inside the holdout - short, silent, and in the direction that looks fine.
+    # `generate_cv_splits` converts D-buffers to trading days for exactly this reason, and the
+    # causal resolver counts observations for the same one. This is the third construction of the
+    # same seal and it must agree with the other two.
+    # Measured against the panel's OWN cadence, not a per-unit default. Without observed_step
+    # embargo_from_buffer assumes a daily grid, which reads "1M" as 21 observations - correct on a
+    # daily panel and 21x too long on us_firm_characteristics' monthly one, where a month IS one
+    # observation. AGENTS.md records the mirror of this: "24H as one period on an eight-hour panel".
+    cadence = observation_step(pd.DataFrame({"timestamp": observations}))
+    # A month has no fixed length, so it cannot be divided by an observation step and
+    # embargo_from_buffer refuses. Its other branch takes periods_per_year, which is COUNTED here
+    # off the same timeline rather than assumed: falling through to the per-unit defaults is what
+    # turns "1M" into 21 observations on a monthly panel where a month is one.
+    span_years = (observations[-1] - observations[0]).days / 365.25
+    periods_per_year = max(1, round(len(observations) / span_years)) if span_years > 0 else 1
+    try:
+        buffer_steps = embargo_from_buffer(buffer, observed_step=cadence)
+    except ValueError:
+        buffer_steps = embargo_from_buffer(buffer, periods_per_year=periods_per_year)
+    if buffer_steps < 1:
         raise ValueError(f"label buffer {buffer!r} leaves no gap before the holdout window")
 
+    # A declared zero horizon - us_firm_characteristics dates each row by the month the return was
+    # earned, so "0D" - means the outcome is already realised at the observation and there is
+    # nothing for the buffer to cover. embargo_from_buffer divides by the value, so it must not be
+    # asked about zero rather than being asked and having its answer discarded.
     horizon = resolve_label_horizon(case_study, resolved_label, setup)
-    if horizon:
-        horizon_offset = pd.Timedelta(normalize_label_buffer(horizon))
-        if buffer_offset < horizon_offset:
+    if horizon and pd.Timedelta(normalize_label_buffer(horizon)) > pd.Timedelta(0):
+        try:
+            horizon_steps = embargo_from_buffer(horizon, observed_step=cadence)
+        except ValueError:
+            horizon_steps = embargo_from_buffer(horizon, periods_per_year=periods_per_year)
+        if buffer_steps < horizon_steps:
             raise ValueError(
-                f"label buffer {buffer!r} is shorter than the outcome horizon {horizon!r}, so "
-                "the last training label resolves inside the holdout window"
+                f"label buffer {buffer!r} is {buffer_steps} observations, shorter than the "
+                f"outcome horizon {horizon!r} at {horizon_steps}, so the last training label "
+                "resolves inside the holdout window"
             )
 
-    train_end = pd.Timestamp(holdout_start) - buffer_offset
+    pre_holdout = [value for value in observations if value < holdout_open]
+    if len(pre_holdout) <= buffer_steps:
+        raise ValueError(
+            f"{case_study} has {len(pre_holdout)} observations before the holdout opens, which "
+            f"cannot absorb a {buffer_steps}-observation buffer"
+        )
+    # The buffer is the number of observations that must NOT be trained on, so the last retained
+    # one sits one step beyond it. `pre_holdout[-buffer_steps]` is the first excluded observation.
+    train_end = pre_holdout[-(buffer_steps + 1)]
     if train_end <= train_start:
         raise ValueError(
             f"{case_study} holdout training interval is empty: history starts "
@@ -466,6 +510,9 @@ def build_holdout_cv(
         "request": {
             "source": "case_study_holdout",
             "label_buffer": str(buffer),
+            "label_buffer_steps": buffer_steps,
+            "observation_cadence": str(cadence),
+            "periods_per_year": periods_per_year,
             "holdout_window": [str(holdout_start), str(holdout_end)],
         },
     }
@@ -487,6 +534,7 @@ def evaluate_holdout(
     study: Any,
     *,
     candidate_set_name: str,
+    timeline: Sequence[Any],
     case_study: str | None = None,
     selection_evidence: Mapping[str, Any] | None = None,
 ) -> HoldoutOutcome:
@@ -515,7 +563,13 @@ def evaluate_holdout(
     lifecycle = study.lifecycle
     state = lifecycle.state
     if state == LifecycleState.HOLDOUT_EVALUATED.value:
+        # Returning the recorded lineage is what makes a notebook re-run safe, but returning it
+        # WITHOUT looking at the arguments would make this function answer a question it was not
+        # asked: a caller naming a different candidate set, or one that no longer resolves, would
+        # silently receive the old holdout as though it had been confirmed against the new
+        # selection. So the selection is re-derived and checked against what the lock recorded.
         existing = _sole_lock(study)
+        _confirm_recorded_selection(study, existing, candidate_set_name)
         return HoldoutOutcome(existing, evaluated_now=False)
 
     candidates = CandidateSet.one(study, name=candidate_set_name)
@@ -529,7 +583,9 @@ def evaluate_holdout(
     holdout_spec["computation"]["cv"] = build_holdout_cv(
         validation_spec,
         case_study=str(case_study if case_study is not None else study.case_study),
+        timeline=timeline,
     )
+    _drop_validation_fold_derivations(holdout_spec)
 
     # selection_evidence is hashed into the lock identity, so anything put here that is already
     # recorded elsewhere gives one fact two sources and makes the lock unreproducible by any
@@ -561,3 +617,50 @@ def _sole_lock(study: Any) -> ResearchLock:
     if len(rows) != 1:
         raise ValueError(f"lifecycle holds {len(rows)} research locks, not one")
     return study.lifecycle.open(rows[0][0])
+
+
+# Fields the resolver derives PER FOLD. They describe the validation fold set and are meaningless
+# against a different interval, so a holdout spec built by swapping `computation.cv` must not carry
+# them forward. `lifecycle._locked_training_spec` pops them before comparing the two specs, which
+# is why an unstripped spec still locks - but the stripped-for-comparison copy is not what gets
+# stored, and the model reconstructor reads what is stored. Left in, a holdout retrain is
+# reconstructed against parameters fitted for folds it does not have.
+_VALIDATION_FOLD_DERIVATIONS = ("expected_prediction_keys",)
+
+
+def _drop_validation_fold_derivations(spec: dict[str, Any]) -> None:
+    computation = spec.get("computation")
+    if not isinstance(computation, dict):
+        return
+    for name in _VALIDATION_FOLD_DERIVATIONS:
+        computation.pop(name, None)
+    model = computation.get("model")
+    if isinstance(model, dict):
+        model.pop("effective_params_by_fold", None)
+    task = computation.get("task")
+    if isinstance(task, dict):
+        imbalance = task.get("imbalance")
+        if isinstance(imbalance, dict):
+            imbalance.pop("effective_class_weights_by_fold", None)
+    macro = computation.get("macro_context")
+    if isinstance(macro, dict):
+        macro.pop("resolved_fold_digest", None)
+
+
+def _confirm_recorded_selection(study: Any, lock: ResearchLock, candidate_set_name: str) -> None:
+    """Check the spent holdout answers the selection the caller is asking about."""
+    from .comparison import CandidateSet
+
+    candidates = CandidateSet.one(study, name=candidate_set_name)
+    if candidates.hash != lock.record["candidate_set_hash"]:
+        raise ValueError(
+            f"holdout was evaluated against candidate set {lock.record['candidate_set_hash']!r}, "
+            f"not {candidate_set_name!r} ({candidates.hash!r}); the holdout is used once and "
+            "cannot be re-spent against a different selection"
+        )
+    selected = candidates.best_validation_sharpe()
+    if selected.hash != lock.record["validation_backtest_hash"]:
+        raise ValueError(
+            f"candidate set {candidate_set_name!r} now ranks {selected.hash!r} first, but the "
+            f"holdout was evaluated on {lock.record['validation_backtest_hash']!r}"
+        )

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -626,10 +626,27 @@ def _sole_lock(study: Any) -> ResearchLock:
 # frame. So neither carrying them forward nor dropping them is correct - both produce a lock that
 # fails at execution, one silently wrong and one loudly.
 #
-# Recomputing them needs the holdout window's eligible key frame, which is data this function does
-# not have and which the family resolver builds during the run. Until that is threaded through,
-# refusing is the only honest option: a lock is the one artifact in the pipeline that cannot be
-# revised, so producing one that is known to fail at execution is worse than producing none.
+# WHAT THE FIX IS, so this is a specified task and not a vague blocker.
+#
+# `case_studies/utils/linear.py:675` computes the manifest at RECONSTRUCTION time with
+# `_expected_keys_from_dataset(mds.dataset, [split], ...)`, where `split` comes from
+# `locked_holdout_split(spec, ...)`, and then checks it against what the spec recorded. So the
+# computation exists; it just runs after the lock, against a value the lock was supposed to carry.
+#
+# Building the spec correctly means running that same computation BEFORE locking: open the dataset,
+# build the holdout split from the derived CV, compute the eligible keys, and record the digest,
+# row count and fold count. It is family-specific - `_expected_keys_from_dataset` lives in
+# `linear.py` and each family has its own - so it wants a per-family hook resolved through
+# `_family_module`, exactly as `reconstruct_locked_request` and `validate_locked_run` already are.
+#
+# Note also that `CVSpec` is NOT the vehicle. It carries `holdout_start`/`holdout_end`, but
+# `resolve()` passes them to `generate_cv_splits` as boundaries to seal VALIDATION against; it
+# selects validation folds and cannot emit a holdout fold. Nothing in the resolver produces a
+# holdout training fold today, which is why this had to be derived here in the first place.
+#
+# Until that hook exists, refusing is the only honest option: a lock is the one artifact in the
+# pipeline that cannot be revised, so producing one that is known to fail at execution is worse
+# than producing none.
 _FOLD_DERIVED_FIELDS = (
     ("computation", "expected_prediction_keys"),
     ("model", "effective_params_by_fold"),

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -585,7 +585,7 @@ def evaluate_holdout(
         case_study=str(case_study if case_study is not None else study.case_study),
         timeline=timeline,
     )
-    _drop_validation_fold_derivations(holdout_spec)
+    _refuse_incomplete_holdout_spec(holdout_spec)
 
     # selection_evidence is hashed into the lock identity, so anything put here that is already
     # recorded elsewhere gives one fact two sources and makes the lock unreproducible by any
@@ -619,32 +619,51 @@ def _sole_lock(study: Any) -> ResearchLock:
     return study.lifecycle.open(rows[0][0])
 
 
-# Fields the resolver derives PER FOLD. They describe the validation fold set and are meaningless
-# against a different interval, so a holdout spec built by swapping `computation.cv` must not carry
-# them forward. `lifecycle._locked_training_spec` pops them before comparing the two specs, which
-# is why an unstripped spec still locks - but the stripped-for-comparison copy is not what gets
-# stored, and the model reconstructor reads what is stored. Left in, a holdout retrain is
-# reconstructed against parameters fitted for folds it does not have.
-_VALIDATION_FOLD_DERIVATIONS = ("expected_prediction_keys",)
+# Fields the resolver derives PER FOLD, from the data, during a run. They describe the VALIDATION
+# fold set, and `validate_locked_model_run` requires them re-keyed to the HOLDOUT fold:
+# `validate_locked_expected_keys` raises "no eligibility manifest" when
+# `expected_prediction_keys` is absent, and "eligibility mismatch" when it describes a different
+# frame. So neither carrying them forward nor dropping them is correct - both produce a lock that
+# fails at execution, one silently wrong and one loudly.
+#
+# Recomputing them needs the holdout window's eligible key frame, which is data this function does
+# not have and which the family resolver builds during the run. Until that is threaded through,
+# refusing is the only honest option: a lock is the one artifact in the pipeline that cannot be
+# revised, so producing one that is known to fail at execution is worse than producing none.
+_FOLD_DERIVED_FIELDS = (
+    ("computation", "expected_prediction_keys"),
+    ("model", "effective_params_by_fold"),
+    ("macro_context", "resolved_fold_digest"),
+)
 
 
-def _drop_validation_fold_derivations(spec: dict[str, Any]) -> None:
+def _refuse_incomplete_holdout_spec(spec: dict[str, Any]) -> None:
     computation = spec.get("computation")
     if not isinstance(computation, dict):
-        return
-    for name in _VALIDATION_FOLD_DERIVATIONS:
-        computation.pop(name, None)
+        raise ValueError("holdout spec has no resolved computation block")
+    present: list[str] = []
+    if "expected_prediction_keys" in computation:
+        present.append("computation.expected_prediction_keys")
     model = computation.get("model")
-    if isinstance(model, dict):
-        model.pop("effective_params_by_fold", None)
+    if isinstance(model, dict) and "effective_params_by_fold" in model:
+        present.append("computation.model.effective_params_by_fold")
     task = computation.get("task")
     if isinstance(task, dict):
         imbalance = task.get("imbalance")
-        if isinstance(imbalance, dict):
-            imbalance.pop("effective_class_weights_by_fold", None)
+        if isinstance(imbalance, dict) and "effective_class_weights_by_fold" in imbalance:
+            present.append("computation.task.imbalance.effective_class_weights_by_fold")
     macro = computation.get("macro_context")
-    if isinstance(macro, dict):
-        macro.pop("resolved_fold_digest", None)
+    if isinstance(macro, dict) and "resolved_fold_digest" in macro:
+        present.append("computation.macro_context.resolved_fold_digest")
+    if present:
+        raise NotImplementedError(
+            "the selected training spec carries fold-derived fields that describe its VALIDATION "
+            f"folds and must be re-keyed to the holdout fold before a lock is taken: {present}. "
+            "validate_locked_expected_keys refuses a spec without an eligibility manifest and "
+            "refuses one describing a different frame, so a lock taken now would fail at "
+            "execution. Recomputing them needs the holdout window's eligible key frame, which the "
+            "family resolver builds during a run and which is not threaded through this path yet."
+        )
 
 
 def _confirm_recorded_selection(study: Any, lock: ResearchLock, candidate_set_name: str) -> None:

--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -246,8 +246,8 @@ def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
     from utils.artifact_specs import resolve_label_horizon, resolve_market_semantics
     from utils.cv_splits import (
         _map_calendar_id,
-        _normalize_label_buffer,
         _purge_holdout_touching_validation,
+        normalize_label_buffer,
     )
 
     holdout = _holdout_window(case_study)
@@ -268,7 +268,7 @@ def _sealed(case_study: str, label: str, axis: pl.Series) -> pl.Series:
         np.arange(len(stamps)),
         stamps,
         holdout_start=str(holdout[0]),
-        outcome_horizon=_normalize_label_buffer(str(horizon)),
+        outcome_horizon=normalize_label_buffer(str(horizon)),
         calendar_id=calendar,
     )
     return axis.gather(kept.tolist())

--- a/tests/test_cv_splits.py
+++ b/tests/test_cv_splits.py
@@ -30,13 +30,13 @@ from utils.cv_splits import (
     _assert_newest_first,
     _map_calendar_id,
     _normalize_duration,
-    _normalize_label_buffer,
     earliest_train_start,
     generate_cv_splits,
     load_evaluation_config,
     make_walk_forward_config,
     make_wf_config,
     most_recent_split,
+    normalize_label_buffer,
 )
 from utils.modeling import validate_temporal_fold_coverage, validate_temporal_split_geometry
 
@@ -82,7 +82,7 @@ def test_normalize_duration(raw, normalized) -> None:
 
 
 # -----------------------------------------------------------------------------
-# Pure: _normalize_label_buffer (inherits normalization + M → days)
+# Pure: normalize_label_buffer (inherits normalization + M → days)
 # -----------------------------------------------------------------------------
 
 
@@ -97,7 +97,7 @@ def test_normalize_duration(raw, normalized) -> None:
     ],
 )
 def test_normalize_label_buffer(raw, normalized) -> None:
-    assert _normalize_label_buffer(raw) == normalized
+    assert normalize_label_buffer(raw) == normalized
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -1,0 +1,188 @@
+"""What the one holdout retraining interval is derived from, and what it refuses.
+
+The holdout is evaluated once, so the interval it is evaluated over cannot be a parameter a
+notebook chooses. Every boundary here comes from something already declared: the window from
+the case study's own ``evaluation`` block, the training start from the fold set the selection
+was made over, and the gap between them from the label's declared buffer.
+
+These tests are written against real case studies rather than a fixture wherever the value
+under test is a declared one. A fixture that declares its own holdout window would agree with
+a derivation that read the fixture, which is the shape of test that passes on wrong code.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from case_studies.research.holdout import build_holdout_cv
+from case_studies.research.lifecycle import _locked_training_spec
+from utils.artifact_specs import load_setup_config
+
+# Newest first, which is the order generate_cv_splits returns and the order the trap depends on:
+# fold 0 carries the LATEST train_start in the set, so a derivation that reads folds[0] hands the
+# holdout retrain the shortest history rather than the longest.
+FOLDS = [
+    {
+        "fold": 0,
+        "train_start": "2005-03-31",
+        "train_end": "2014-12-31",
+        "val_start": "2015-02-27",
+        "val_end": "2015-12-31",
+    },
+    {
+        "fold": 1,
+        "train_start": "2004-04-30",
+        "train_end": "2014-02-28",
+        "val_start": "2014-03-31",
+        "val_end": "2015-01-30",
+    },
+    {
+        "fold": 2,
+        "train_start": "2003-05-30",
+        "train_end": "2013-03-28",
+        "val_start": "2013-04-30",
+        "val_end": "2014-02-28",
+    },
+]
+
+
+def _validation_spec(label: str = "fwd_ret_1m", folds: list[dict] | None = None) -> dict[str, Any]:
+    return {
+        "label": label,
+        "family": "linear",
+        "config_name": "ridge",
+        "execution_tier": "canonical",
+        "identity_version": 3,
+        "resolved_spec_schema": "ml4t.resolved-spec/v1",
+        "seed": 7,
+        "computation": {
+            "model": {"kind": "ridge"},
+            "cv": {
+                "identity": "validation-cv-identity",
+                "request": {"source": "case_study_default"},
+                "folds": deepcopy(folds if folds is not None else FOLDS),
+            },
+        },
+    }
+
+
+def _fold(cv: dict[str, Any]) -> dict[str, Any]:
+    assert len(cv["folds"]) == 1, "a holdout is evaluated once, over one interval"
+    return cv["folds"][0]
+
+
+def test_the_evaluation_interval_is_the_case_studys_own_declared_holdout_window() -> None:
+    setup = load_setup_config("us_firm_characteristics")
+    declared = setup["evaluation"]
+
+    fold = _fold(build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics"))
+
+    assert pd.Timestamp(fold["val_start"]) == pd.Timestamp(declared["holdout_start"])
+    assert pd.Timestamp(fold["val_end"]) == pd.Timestamp(declared["holdout_end"])
+
+
+def test_training_starts_at_the_earliest_fold_not_the_first_one_in_the_list() -> None:
+    fold = _fold(build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics"))
+
+    earliest = min(pd.Timestamp(entry["train_start"]) for entry in FOLDS)
+    assert pd.Timestamp(fold["train_start"]) == earliest
+    # The assertion that carries the test: fold 0's own start is later, and a derivation that
+    # read a list position instead of the boundaries would have produced it.
+    assert pd.Timestamp(FOLDS[0]["train_start"]) > earliest
+    assert pd.Timestamp(fold["train_start"]) != pd.Timestamp(FOLDS[0]["train_start"])
+
+
+def test_training_ends_one_declared_label_buffer_before_the_holdout_opens() -> None:
+    setup = load_setup_config("etfs")
+    fold = _fold(build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs"))
+
+    gap = pd.Timestamp(fold["val_start"]) - pd.Timestamp(fold["train_end"])
+    assert gap == pd.Timedelta(setup["labels"]["buffer"])
+    assert pd.Timestamp(fold["train_end"]) < pd.Timestamp(fold["val_start"])
+
+
+def test_a_buffer_shorter_than_the_outcome_horizon_is_refused_as_a_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from case_studies.research import holdout as module
+
+    monkeypatch.setattr(
+        "utils.artifact_specs.resolve_label_buffer", lambda *a, **k: "5D", raising=True
+    )
+    monkeypatch.setattr(
+        "utils.artifact_specs.resolve_label_horizon", lambda *a, **k: "21D", raising=True
+    )
+    assert module.build_holdout_cv is build_holdout_cv
+
+    with pytest.raises(ValueError, match="shorter than the outcome horizon"):
+        build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs")
+
+
+def test_a_case_study_with_no_declared_holdout_window_is_refused_by_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "case_studies.utils.cv_window.canonical_window", lambda *a, **k: None, raising=True
+    )
+
+    with pytest.raises(ValueError, match="declares no holdout window"):
+        build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics")
+
+
+def test_an_empty_training_interval_is_refused_rather_than_produced() -> None:
+    # Every fold starts after the buffered boundary, so there is no history to retrain on.
+    late = [
+        {**fold, "train_start": "2015-12-30", "train_end": "2015-12-31"} for fold in deepcopy(FOLDS)
+    ]
+
+    with pytest.raises(ValueError, match="holdout training interval is empty"):
+        build_holdout_cv(_validation_spec(folds=late), case_study="us_firm_characteristics")
+
+
+def test_a_spec_with_no_resolved_folds_is_refused() -> None:
+    spec = _validation_spec()
+    spec["computation"]["cv"]["folds"] = []
+
+    with pytest.raises(ValueError, match="no resolved validation folds"):
+        build_holdout_cv(spec, case_study="us_firm_characteristics")
+
+
+def test_folds_missing_a_boundary_are_named_rather_than_read_as_none() -> None:
+    spec = _validation_spec()
+    del spec["computation"]["cv"]["folds"][1]["train_start"]
+
+    with pytest.raises(ValueError, match=r"missing boundaries: \['train_start'\]"):
+        build_holdout_cv(spec, case_study="us_firm_characteristics")
+
+
+def test_the_derived_interval_satisfies_the_lock_contract_it_will_be_checked_against() -> None:
+    """The derivation is only correct if ``lifecycle.lock`` accepts what it produces.
+
+    ``_locked_training_spec`` is the real gate: it requires the holdout spec to differ from the
+    selected validation spec in the CV interval and in nothing else, and to carry an explicit,
+    distinct interval. Asserting against it rather than against a restatement of the derivation
+    is what makes this a test of the contract instead of a mirror of the code.
+    """
+    validation = _validation_spec()
+    holdout = deepcopy(validation)
+    holdout["computation"]["cv"] = build_holdout_cv(
+        validation, case_study="us_firm_characteristics"
+    )
+
+    locked = _locked_training_spec(validation, holdout)
+
+    assert locked["computation"]["cv"]["split"] == "holdout"
+    assert locked["computation"]["cv"]["identity"] != validation["computation"]["cv"]["identity"]
+
+
+def test_the_lock_refuses_a_holdout_interval_identical_to_the_validation_one() -> None:
+    """The failure direction of the test above: an unchanged interval must not pass."""
+    validation = _validation_spec()
+    unchanged = deepcopy(validation)
+
+    with pytest.raises(ValueError, match="explicit, distinct CV interval"):
+        _locked_training_spec(validation, unchanged)

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -70,6 +70,13 @@ def _validation_spec(label: str = "fwd_ret_1m", folds: list[dict] | None = None)
     }
 
 
+# Real observation grids: a five-session week for the calendar-backed case studies, month ends
+# for us_firm_characteristics. The buffer is counted along these, so the grid is not incidental to
+# the test - it is the thing that separates a correct seal from a calendar-shortened one.
+SESSIONS = pd.bdate_range("2004-01-01", "2026-12-31")
+MONTH_ENDS = pd.date_range("2004-01-31", "2026-12-31", freq="ME")
+
+
 def _fold(cv: dict[str, Any]) -> dict[str, Any]:
     assert len(cv["folds"]) == 1, "a holdout is evaluated once, over one interval"
     return cv["folds"][0]
@@ -79,14 +86,22 @@ def test_the_evaluation_interval_is_the_case_studys_own_declared_holdout_window(
     setup = load_setup_config("us_firm_characteristics")
     declared = setup["evaluation"]
 
-    fold = _fold(build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics"))
+    fold = _fold(
+        build_holdout_cv(
+            _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+        )
+    )
 
     assert pd.Timestamp(fold["val_start"]) == pd.Timestamp(declared["holdout_start"])
     assert pd.Timestamp(fold["val_end"]) == pd.Timestamp(declared["holdout_end"])
 
 
 def test_training_starts_at_the_earliest_fold_not_the_first_one_in_the_list() -> None:
-    fold = _fold(build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics"))
+    fold = _fold(
+        build_holdout_cv(
+            _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+        )
+    )
 
     earliest = min(pd.Timestamp(entry["train_start"]) for entry in FOLDS)
     assert pd.Timestamp(fold["train_start"]) == earliest
@@ -96,13 +111,55 @@ def test_training_starts_at_the_earliest_fold_not_the_first_one_in_the_list() ->
     assert pd.Timestamp(fold["train_start"]) != pd.Timestamp(FOLDS[0]["train_start"])
 
 
-def test_training_ends_one_declared_label_buffer_before_the_holdout_opens() -> None:
-    setup = load_setup_config("etfs")
-    fold = _fold(build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs"))
+def test_the_buffer_is_counted_in_observations_not_calendar_time() -> None:
+    """The defect this function was rewritten to remove, pinned as a property.
 
-    gap = pd.Timestamp(fold["val_start"]) - pd.Timestamp(fold["train_end"])
-    assert gap == pd.Timedelta(setup["labels"]["buffer"])
-    assert pd.Timestamp(fold["train_end"]) < pd.Timestamp(fold["val_start"])
+    etfs declares a `21D` buffer and trades a five-session week. Subtracting `pd.Timedelta("21
+    days")` leaves about fifteen sessions - short, and short in the direction that looks fine,
+    which is why `utils/cv_splits.py` already converts D-buffers to trading days and the causal
+    resolver already counts observations. This is the third construction of the same seal and it
+    has to agree with the other two.
+    """
+    cv = build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs", timeline=SESSIONS)
+    fold = _fold(cv)
+
+    train_end = pd.Timestamp(fold["train_end"])
+    val_start = pd.Timestamp(fold["val_start"])
+    excluded = [d for d in SESSIONS if train_end < d < val_start]
+
+    assert cv["request"]["label_buffer_steps"] == 21
+    assert len(excluded) == 21, "the seal must span 21 observations, not 21 calendar days"
+    assert train_end < val_start
+
+    # What the calendar subtraction would have produced, stated so the two cannot be confused.
+    calendar_end = val_start - pd.Timedelta(load_setup_config("etfs")["labels"]["buffer"])
+    assert train_end < calendar_end, (
+        "a calendar-day subtraction lands later than the observation count, which is exactly the "
+        "under-buffering that puts the last training label inside the holdout"
+    )
+
+
+def test_a_month_buffer_on_a_monthly_panel_is_one_observation() -> None:
+    """The mirror failure: per-unit defaults read `1M` as 21 observations.
+
+    `embargo_from_buffer` refuses to divide a month by an observation step, and its other branch
+    takes periods_per_year. Falling through to the per-unit default there makes the seal 21 months
+    long on us_firm_characteristics, whose panel is monthly and whose own causal notebook resolves
+    the same buffer to 1.
+    """
+    cv = build_holdout_cv(
+        _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+    )
+    fold = _fold(cv)
+
+    assert cv["request"]["label_buffer_steps"] == 1
+    assert cv["request"]["periods_per_year"] == 12
+    excluded = [
+        d
+        for d in MONTH_ENDS
+        if pd.Timestamp(fold["train_end"]) < d < pd.Timestamp(fold["val_start"])
+    ]
+    assert len(excluded) == 1
 
 
 def test_a_buffer_shorter_than_the_outcome_horizon_is_refused_as_a_leak(
@@ -119,7 +176,7 @@ def test_a_buffer_shorter_than_the_outcome_horizon_is_refused_as_a_leak(
     assert module.build_holdout_cv is build_holdout_cv
 
     with pytest.raises(ValueError, match="shorter than the outcome horizon"):
-        build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs")
+        build_holdout_cv(_validation_spec("fwd_ret_21d"), case_study="etfs", timeline=SESSIONS)
 
 
 def test_a_case_study_with_no_declared_holdout_window_is_refused_by_name(
@@ -130,7 +187,9 @@ def test_a_case_study_with_no_declared_holdout_window_is_refused_by_name(
     )
 
     with pytest.raises(ValueError, match="declares no holdout window"):
-        build_holdout_cv(_validation_spec(), case_study="us_firm_characteristics")
+        build_holdout_cv(
+            _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+        )
 
 
 def test_an_empty_training_interval_is_refused_rather_than_produced() -> None:
@@ -140,7 +199,11 @@ def test_an_empty_training_interval_is_refused_rather_than_produced() -> None:
     ]
 
     with pytest.raises(ValueError, match="holdout training interval is empty"):
-        build_holdout_cv(_validation_spec(folds=late), case_study="us_firm_characteristics")
+        build_holdout_cv(
+            _validation_spec(folds=late),
+            case_study="us_firm_characteristics",
+            timeline=MONTH_ENDS,
+        )
 
 
 def test_a_spec_with_no_resolved_folds_is_refused() -> None:
@@ -148,7 +211,7 @@ def test_a_spec_with_no_resolved_folds_is_refused() -> None:
     spec["computation"]["cv"]["folds"] = []
 
     with pytest.raises(ValueError, match="no resolved validation folds"):
-        build_holdout_cv(spec, case_study="us_firm_characteristics")
+        build_holdout_cv(spec, case_study="us_firm_characteristics", timeline=MONTH_ENDS)
 
 
 def test_folds_missing_a_boundary_are_named_rather_than_read_as_none() -> None:
@@ -156,7 +219,7 @@ def test_folds_missing_a_boundary_are_named_rather_than_read_as_none() -> None:
     del spec["computation"]["cv"]["folds"][1]["train_start"]
 
     with pytest.raises(ValueError, match=r"missing boundaries: \['train_start'\]"):
-        build_holdout_cv(spec, case_study="us_firm_characteristics")
+        build_holdout_cv(spec, case_study="us_firm_characteristics", timeline=MONTH_ENDS)
 
 
 def test_the_derived_interval_satisfies_the_lock_contract_it_will_be_checked_against() -> None:
@@ -170,7 +233,7 @@ def test_the_derived_interval_satisfies_the_lock_contract_it_will_be_checked_aga
     validation = _validation_spec()
     holdout = deepcopy(validation)
     holdout["computation"]["cv"] = build_holdout_cv(
-        validation, case_study="us_firm_characteristics"
+        validation, case_study="us_firm_characteristics", timeline=MONTH_ENDS
     )
 
     locked = _locked_training_spec(validation, holdout)

--- a/tests/test_holdout_evaluation_driver.py
+++ b/tests/test_holdout_evaluation_driver.py
@@ -1,0 +1,95 @@
+"""The holdout is evaluated once, and a notebook re-run must not be able to spend it again.
+
+``evaluate_holdout`` is the sequence every case study needs and none of them had: read the
+rank-1 validation backtest out of the candidate set, derive the holdout interval, lock, and
+execute. The property these tests exist for is the one a caller cannot be trusted to check
+for itself - re-running the notebook that publishes the page must read the recorded evaluation
+back rather than producing a second one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from case_studies.research.holdout import evaluate_holdout
+from tests.test_locked_holdout_execution import _install_fixture_adapter, _locked_study
+
+
+def _pin_derivation_to_the_fixture(monkeypatch: pytest.MonkeyPatch, lock) -> None:
+    """Supply the interval the fixture study was locked under.
+
+    The derivation itself is covered against real case-study configuration in
+    tests/test_holdout_cv_derivation.py. What is under test here is the driver: the selection it
+    reads, the lock it creates, and what it refuses to do twice. Pinning the interval keeps those
+    two concerns from being able to mask each other.
+    """
+    from case_studies.research import holdout as module
+
+    locked_cv = lock.record["holdout_training_spec"]["computation"]["cv"]
+    monkeypatch.setattr(module, "build_holdout_cv", lambda *a, **k: locked_cv)
+
+
+def test_it_fits_the_locked_lineage_and_reports_that_it_did(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    study, lock, prices = _locked_study(tmp_path, monkeypatch)
+    fit_calls = _install_fixture_adapter(monkeypatch, prices)
+    _pin_derivation_to_the_fixture(monkeypatch, lock)
+
+    outcome = evaluate_holdout(study, candidate_set_name="locked-selection")
+
+    assert outcome.evaluated_now is True
+    assert outcome.lock.state == "HOLDOUT_EVALUATED"
+    assert outcome.lineage["lock_hash"] == lock.hash
+    assert len(fit_calls) == 1
+
+
+def test_a_second_call_reads_the_recorded_evaluation_and_fits_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The safety property. A re-run of the notebook must not spend the holdout twice.
+
+    ``run_locked_holdout`` raises on a second call, which protects the registry but would make
+    every notebook re-run fail. The driver has to absorb that into a read, so the page rebuilds
+    with the numbers it published before.
+    """
+    study, lock, prices = _locked_study(tmp_path, monkeypatch)
+    fit_calls = _install_fixture_adapter(monkeypatch, prices)
+    _pin_derivation_to_the_fixture(monkeypatch, lock)
+
+    first = evaluate_holdout(study, candidate_set_name="locked-selection")
+    fits_after_first = list(fit_calls)
+
+    second = evaluate_holdout(study, candidate_set_name="locked-selection")
+
+    assert first.evaluated_now is True
+    assert second.evaluated_now is False
+    assert fit_calls == fits_after_first, "the second call refitted the holdout model"
+    assert second.lineage == first.lineage
+    assert second.lock.state == "HOLDOUT_EVALUATED"
+
+
+def test_the_recorded_selection_is_the_documented_rule_and_names_the_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    study, lock, prices = _locked_study(tmp_path, monkeypatch)
+    _install_fixture_adapter(monkeypatch, prices)
+    _pin_derivation_to_the_fixture(monkeypatch, lock)
+
+    outcome = evaluate_holdout(study, candidate_set_name="locked-selection")
+
+    evidence = outcome.lock.record["selection_evidence"]
+    assert evidence["metric"] == "validation_backtest_sharpe"
+
+
+def test_an_unknown_candidate_set_is_refused_by_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    study, lock, prices = _locked_study(tmp_path, monkeypatch)
+    _install_fixture_adapter(monkeypatch, prices)
+    _pin_derivation_to_the_fixture(monkeypatch, lock)
+
+    with pytest.raises(ValueError, match="resolved to 0 identities"):
+        evaluate_holdout(study, candidate_set_name="no-such-set")

--- a/tests/test_holdout_evaluation_driver.py
+++ b/tests/test_holdout_evaluation_driver.py
@@ -98,3 +98,38 @@ def test_an_unknown_candidate_set_is_refused_by_name(
 
     with pytest.raises(ValueError, match="resolved to 0 identities"):
         evaluate_holdout(study, candidate_set_name="no-such-set", timeline=TIMELINE)
+
+
+def test_a_spec_carrying_validation_fold_derivations_refuses_to_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lock cannot be revised, so producing one known to fail at execution is worse than none.
+
+    ``expected_prediction_keys`` describes which rows the fit was eligible to predict on.
+    ``validate_locked_expected_keys`` refuses a locked spec that has none, and refuses one whose
+    manifest describes a different frame - so a holdout spec that inherits the validation folds'
+    manifest fails at execution, and one with the field stripped fails there too. Recomputing it
+    needs the holdout window's eligible keys, which the family resolver builds during a run.
+
+    Until that is threaded through, the driver must stop at the lock rather than take one.
+    """
+    study, lock, prices = _locked_study(tmp_path, monkeypatch)
+    _install_fixture_adapter(monkeypatch, prices)
+    _pin_derivation_to_the_fixture(monkeypatch, lock)
+
+    from case_studies.research import holdout as module
+
+    monkeypatch.setattr(
+        module,
+        "_sole_lock",
+        lambda _study: (_ for _ in ()).throw(AssertionError("must not reach the recorded lock")),
+    )
+
+    spec = {
+        "computation": {"expected_prediction_keys": {"digest": "abc", "n_rows": 1, "n_folds": 1}}
+    }
+    with pytest.raises(NotImplementedError, match="re-keyed to the holdout fold"):
+        module._refuse_incomplete_holdout_spec(spec)
+
+    clean = {"computation": {"cv": {}}}
+    module._refuse_incomplete_holdout_spec(clean)

--- a/tests/test_holdout_evaluation_driver.py
+++ b/tests/test_holdout_evaluation_driver.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from case_studies.research.holdout import evaluate_holdout
 from tests.test_locked_holdout_execution import _install_fixture_adapter, _locked_study
+
+# The fixture study's own observation grid. build_holdout_cv is pinned below, so the timeline is
+# only carried through the driver here; its own derivation is covered separately.
+TIMELINE = pd.bdate_range("2023-12-01", "2024-02-01")
 
 
 def _pin_derivation_to_the_fixture(monkeypatch: pytest.MonkeyPatch, lock) -> None:
@@ -38,7 +43,7 @@ def test_it_fits_the_locked_lineage_and_reports_that_it_did(
     fit_calls = _install_fixture_adapter(monkeypatch, prices)
     _pin_derivation_to_the_fixture(monkeypatch, lock)
 
-    outcome = evaluate_holdout(study, candidate_set_name="locked-selection")
+    outcome = evaluate_holdout(study, candidate_set_name="locked-selection", timeline=TIMELINE)
 
     assert outcome.evaluated_now is True
     assert outcome.lock.state == "HOLDOUT_EVALUATED"
@@ -59,10 +64,10 @@ def test_a_second_call_reads_the_recorded_evaluation_and_fits_nothing(
     fit_calls = _install_fixture_adapter(monkeypatch, prices)
     _pin_derivation_to_the_fixture(monkeypatch, lock)
 
-    first = evaluate_holdout(study, candidate_set_name="locked-selection")
+    first = evaluate_holdout(study, candidate_set_name="locked-selection", timeline=TIMELINE)
     fits_after_first = list(fit_calls)
 
-    second = evaluate_holdout(study, candidate_set_name="locked-selection")
+    second = evaluate_holdout(study, candidate_set_name="locked-selection", timeline=TIMELINE)
 
     assert first.evaluated_now is True
     assert second.evaluated_now is False
@@ -78,7 +83,7 @@ def test_the_recorded_selection_is_the_documented_rule_and_names_the_set(
     _install_fixture_adapter(monkeypatch, prices)
     _pin_derivation_to_the_fixture(monkeypatch, lock)
 
-    outcome = evaluate_holdout(study, candidate_set_name="locked-selection")
+    outcome = evaluate_holdout(study, candidate_set_name="locked-selection", timeline=TIMELINE)
 
     evidence = outcome.lock.record["selection_evidence"]
     assert evidence["metric"] == "validation_backtest_sharpe"
@@ -92,4 +97,4 @@ def test_an_unknown_candidate_set_is_refused_by_name(
     _pin_derivation_to_the_fixture(monkeypatch, lock)
 
     with pytest.raises(ValueError, match="resolved to 0 identities"):
-        evaluate_holdout(study, candidate_set_name="no-such-set")
+        evaluate_holdout(study, candidate_set_name="no-such-set", timeline=TIMELINE)

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -79,7 +79,7 @@ def _normalize_duration(s: str) -> str:
     return s
 
 
-def _normalize_label_buffer(s: str) -> str:
+def normalize_label_buffer(s: str) -> str:
     """Normalize label buffer for pd.Timedelta compatibility.
 
     Strips ISO prefix, normalizes units, and converts month-based
@@ -199,7 +199,7 @@ def make_walk_forward_config(
     calendar_id = _map_calendar_id(eval_config.get("calendar"))
 
     # For D-unit buffers with a calendar, pass as int (trading days)
-    normalized_horizon: int | str = _normalize_label_buffer(label_horizon)
+    normalized_horizon: int | str = normalize_label_buffer(label_horizon)
     if calendar_id is not None and isinstance(normalized_horizon, str):
         d_match = re.match(r"^(\d+)D$", normalized_horizon)
         if d_match:
@@ -297,8 +297,8 @@ def generate_cv_splits(
         return precomputed
 
     # Normalize label buffer (strip ISO prefix, convert M → days)
-    label_buffer = _normalize_label_buffer(label_buffer)
-    outcome_horizon = _normalize_label_buffer(outcome_horizon or label_buffer)
+    label_buffer = normalize_label_buffer(label_buffer)
+    outcome_horizon = normalize_label_buffer(outcome_horizon or label_buffer)
 
     # Load evaluation config
     if cv_config is not None:


### PR DESCRIPTION
The holdout evaluation lived in the Chapter 20 notebook, so a case study could not
run its own final evaluation without the teaching notebook. This moves the
derivation into `case_studies/research/holdout.py` where the case studies can reach
it, with the contract the lock already requires.

**`build_holdout_cv()`** derives the holdout fold from the panel's own observations.
The buffer is counted in **observations stepped along the panel's dates**, never
subtracted as calendar time - 21D is about 15 trading days, and subtracting 21 days
walks the train end into the buffer and leaks. Month buffers cannot be divided by an
observation step at all, so they fall back to `periods_per_year`.

Verified against two independent references rather than against itself: the etfs
train end lands on 2023-11-30, matching what the causal resolver derives for the
same panel and buffer, and `us_firm_characteristics` comes out at one observation,
matching its notebook.

**`evaluate_holdout()`** refuses at the lock with a `NotImplementedError` naming the
fold-derived fields it cannot supply. `validate_locked_expected_keys` requires an
eligibility manifest describing the holdout frame, and building that needs a
per-family hook that does not exist yet. An explicit refusal is the honest state;
deleting the fields it cannot fill would break the reconstructors that require them.

`_normalize_label_buffer` is renamed `normalize_label_buffer` - it has callers
outside its module now.

16 tests: `tests/test_holdout_cv_derivation.py` (11) and
`tests/test_holdout_evaluation_driver.py` (5).

A first mutation check on this passed while the bug was live, which is worth
recording: replacing the step *count* left the tests green, because stepping back 21
observations is right whatever produced the 21. Only replacing the step-back
*mechanism* failed them. The tests were then written against the mechanism.