### PR TITLE
Ten notebooks record no entry_point, and their test asserts one

### DIFF
--- a/case_studies/sp500_equity_option_analytics/06_linear.ipynb
+++ b/case_studies/sp500_equity_option_analytics/06_linear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "42fcd074",
+   "id": "95e14279",
    "metadata": {
     "papermill": {
-     "duration": 0.003902,
-     "end_time": "2026-08-23T15:20:32.266665+00:00",
+     "duration": 0.001417,
+     "end_time": "2026-08-25T22:41:52.113040+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:32.262763+00:00",
+     "start_time": "2026-08-25T22:41:52.111623+00:00",
      "status": "completed"
     }
    },
@@ -73,19 +73,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "939ac028",
+   "id": "758e447f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:32.280799Z",
-     "iopub.status.busy": "2026-08-23T15:20:32.280245Z",
-     "iopub.status.idle": "2026-08-23T15:20:33.969385Z",
-     "shell.execute_reply": "2026-08-23T15:20:33.968718Z"
+     "iopub.execute_input": "2026-08-25T22:41:52.116403Z",
+     "iopub.status.busy": "2026-08-25T22:41:52.116221Z",
+     "iopub.status.idle": "2026-08-25T22:41:54.848976Z",
+     "shell.execute_reply": "2026-08-25T22:41:54.848303Z"
     },
     "papermill": {
-     "duration": 1.696658,
-     "end_time": "2026-08-23T15:20:33.970193+00:00",
+     "duration": 2.73506,
+     "end_time": "2026-08-25T22:41:54.849370+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:32.273535+00:00",
+     "start_time": "2026-08-25T22:41:52.114310+00:00",
      "status": "completed"
     }
    },
@@ -115,19 +115,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f00e626d",
+   "id": "e73cd4a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:33.973325Z",
-     "iopub.status.busy": "2026-08-23T15:20:33.973144Z",
-     "iopub.status.idle": "2026-08-23T15:20:33.975130Z",
-     "shell.execute_reply": "2026-08-23T15:20:33.974888Z"
+     "iopub.execute_input": "2026-08-25T22:41:54.852642Z",
+     "iopub.status.busy": "2026-08-25T22:41:54.852465Z",
+     "iopub.status.idle": "2026-08-25T22:41:54.854720Z",
+     "shell.execute_reply": "2026-08-25T22:41:54.854355Z"
     },
     "papermill": {
-     "duration": 0.004058,
-     "end_time": "2026-08-23T15:20:33.975559+00:00",
+     "duration": 0.004197,
+     "end_time": "2026-08-25T22:41:54.854996+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:33.971501+00:00",
+     "start_time": "2026-08-25T22:41:54.850799+00:00",
      "status": "completed"
     },
     "tags": [
@@ -148,38 +148,41 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fc5691b7",
+   "id": "c562978d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:33.978124Z",
-     "iopub.status.busy": "2026-08-23T15:20:33.978054Z",
-     "iopub.status.idle": "2026-08-23T15:20:34.869316Z",
-     "shell.execute_reply": "2026-08-23T15:20:34.868784Z"
+     "iopub.execute_input": "2026-08-25T22:41:54.857699Z",
+     "iopub.status.busy": "2026-08-25T22:41:54.857627Z",
+     "iopub.status.idle": "2026-08-25T22:41:56.656545Z",
+     "shell.execute_reply": "2026-08-25T22:41:56.655890Z"
     },
     "papermill": {
-     "duration": 0.893149,
-     "end_time": "2026-08-23T15:20:34.869802+00:00",
+     "duration": 1.800899,
+     "end_time": "2026-08-25T22:41:56.657080+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:33.976653+00:00",
+     "start_time": "2026-08-25T22:41:54.856181+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"06_linear\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "84f2c32d",
+   "id": "c731fb25",
    "metadata": {
     "papermill": {
-     "duration": 0.001032,
-     "end_time": "2026-08-23T15:20:34.872078+00:00",
+     "duration": 0.001874,
+     "end_time": "2026-08-25T22:41:56.660487+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.871046+00:00",
+     "start_time": "2026-08-25T22:41:56.658613+00:00",
      "status": "completed"
     }
    },
@@ -203,19 +206,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a6d2c981",
+   "id": "991961bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:34.874779Z",
-     "iopub.status.busy": "2026-08-23T15:20:34.874710Z",
-     "iopub.status.idle": "2026-08-23T15:20:34.889737Z",
-     "shell.execute_reply": "2026-08-23T15:20:34.889408Z"
+     "iopub.execute_input": "2026-08-25T22:41:56.663867Z",
+     "iopub.status.busy": "2026-08-25T22:41:56.663689Z",
+     "iopub.status.idle": "2026-08-25T22:41:56.693640Z",
+     "shell.execute_reply": "2026-08-25T22:41:56.693065Z"
     },
     "papermill": {
-     "duration": 0.016892,
-     "end_time": "2026-08-23T15:20:34.890007+00:00",
+     "duration": 0.032494,
+     "end_time": "2026-08-25T22:41:56.694180+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.873115+00:00",
+     "start_time": "2026-08-25T22:41:56.661686+00:00",
      "status": "completed"
     }
    },
@@ -241,13 +244,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47f1e3af",
+   "id": "b256ba33",
    "metadata": {
     "papermill": {
-     "duration": 0.001107,
-     "end_time": "2026-08-23T15:20:34.892246+00:00",
+     "duration": 0.00196,
+     "end_time": "2026-08-25T22:41:56.698631+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.891139+00:00",
+     "start_time": "2026-08-25T22:41:56.696671+00:00",
      "status": "completed"
     }
    },
@@ -277,19 +280,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4ff9b8fb",
+   "id": "bafe66da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:34.894998Z",
-     "iopub.status.busy": "2026-08-23T15:20:34.894937Z",
-     "iopub.status.idle": "2026-08-23T15:20:34.934776Z",
-     "shell.execute_reply": "2026-08-23T15:20:34.934423Z"
+     "iopub.execute_input": "2026-08-25T22:41:56.703606Z",
+     "iopub.status.busy": "2026-08-25T22:41:56.703452Z",
+     "iopub.status.idle": "2026-08-25T22:41:56.757158Z",
+     "shell.execute_reply": "2026-08-25T22:41:56.756518Z"
     },
     "papermill": {
-     "duration": 0.041875,
-     "end_time": "2026-08-23T15:20:34.935204+00:00",
+     "duration": 0.057022,
+     "end_time": "2026-08-25T22:41:56.757674+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.893329+00:00",
+     "start_time": "2026-08-25T22:41:56.700652+00:00",
      "status": "completed"
     }
    },
@@ -354,13 +357,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1f75bad",
+   "id": "f832bea6",
    "metadata": {
     "papermill": {
-     "duration": 0.001152,
-     "end_time": "2026-08-23T15:20:34.937693+00:00",
+     "duration": 0.0018,
+     "end_time": "2026-08-25T22:41:56.762003+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.936541+00:00",
+     "start_time": "2026-08-25T22:41:56.760203+00:00",
      "status": "completed"
     }
    },
@@ -376,20 +379,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "30dbe81b",
+   "id": "40b39dfa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:34.940549Z",
-     "iopub.status.busy": "2026-08-23T15:20:34.940474Z",
-     "iopub.status.idle": "2026-08-23T15:20:34.976737Z",
-     "shell.execute_reply": "2026-08-23T15:20:34.976151Z"
+     "iopub.execute_input": "2026-08-25T22:41:56.765486Z",
+     "iopub.status.busy": "2026-08-25T22:41:56.765321Z",
+     "iopub.status.idle": "2026-08-25T22:41:56.821185Z",
+     "shell.execute_reply": "2026-08-25T22:41:56.820714Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.038149,
-     "end_time": "2026-08-23T15:20:34.977024+00:00",
+     "duration": 0.0587,
+     "end_time": "2026-08-25T22:41:56.821974+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.938875+00:00",
+     "start_time": "2026-08-25T22:41:56.763274+00:00",
      "status": "completed"
     }
    },
@@ -404,13 +407,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "932c3e75",
+   "id": "58445859",
    "metadata": {
     "papermill": {
-     "duration": 0.001169,
-     "end_time": "2026-08-23T15:20:34.979567+00:00",
+     "duration": 0.001306,
+     "end_time": "2026-08-25T22:41:56.824908+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.978398+00:00",
+     "start_time": "2026-08-25T22:41:56.823602+00:00",
      "status": "completed"
     }
    },
@@ -447,19 +450,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4851032c",
+   "id": "1c142ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:34.982512Z",
-     "iopub.status.busy": "2026-08-23T15:20:34.982445Z",
-     "iopub.status.idle": "2026-08-23T15:20:53.554139Z",
-     "shell.execute_reply": "2026-08-23T15:20:53.553580Z"
+     "iopub.execute_input": "2026-08-25T22:41:56.828010Z",
+     "iopub.status.busy": "2026-08-25T22:41:56.827927Z",
+     "iopub.status.idle": "2026-08-25T22:42:27.276771Z",
+     "shell.execute_reply": "2026-08-25T22:42:27.276063Z"
     },
     "papermill": {
-     "duration": 18.573995,
-     "end_time": "2026-08-23T15:20:53.554754+00:00",
+     "duration": 30.452211,
+     "end_time": "2026-08-25T22:42:27.278409+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:34.980759+00:00",
+     "start_time": "2026-08-25T22:41:56.826198+00:00",
      "status": "completed"
     }
    },
@@ -535,13 +538,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b329588",
+   "id": "1566894a",
    "metadata": {
     "papermill": {
-     "duration": 0.002142,
-     "end_time": "2026-08-23T15:20:53.559560+00:00",
+     "duration": 0.001234,
+     "end_time": "2026-08-25T22:42:27.281103+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:53.557418+00:00",
+     "start_time": "2026-08-25T22:42:27.279869+00:00",
      "status": "completed"
     }
    },
@@ -583,19 +586,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "53756c49",
+   "id": "308d2519",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:53.562587Z",
-     "iopub.status.busy": "2026-08-23T15:20:53.562478Z",
-     "iopub.status.idle": "2026-08-23T15:20:55.648508Z",
-     "shell.execute_reply": "2026-08-23T15:20:55.647969Z"
+     "iopub.execute_input": "2026-08-25T22:42:27.284513Z",
+     "iopub.status.busy": "2026-08-25T22:42:27.284390Z",
+     "iopub.status.idle": "2026-08-25T22:42:30.164693Z",
+     "shell.execute_reply": "2026-08-25T22:42:30.163889Z"
     },
     "papermill": {
-     "duration": 2.088161,
-     "end_time": "2026-08-23T15:20:55.648978+00:00",
+     "duration": 2.885887,
+     "end_time": "2026-08-25T22:42:30.168276+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:53.560817+00:00",
+     "start_time": "2026-08-25T22:42:27.282389+00:00",
      "status": "completed"
     }
    },
@@ -623,13 +626,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebcb8836",
+   "id": "546b5e25",
    "metadata": {
     "papermill": {
-     "duration": 0.001674,
-     "end_time": "2026-08-23T15:20:55.652518+00:00",
+     "duration": 0.003617,
+     "end_time": "2026-08-25T22:42:30.177968+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.650844+00:00",
+     "start_time": "2026-08-25T22:42:30.174351+00:00",
      "status": "completed"
     }
    },
@@ -669,13 +672,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9405010d",
+   "id": "eb5e88a6",
    "metadata": {
     "papermill": {
-     "duration": 0.001164,
-     "end_time": "2026-08-23T15:20:55.654937+00:00",
+     "duration": 0.003203,
+     "end_time": "2026-08-25T22:42:30.184644+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.653773+00:00",
+     "start_time": "2026-08-25T22:42:30.181441+00:00",
      "status": "completed"
     }
    },
@@ -707,19 +710,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "48eb0973",
+   "id": "55f4edf6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:55.658718Z",
-     "iopub.status.busy": "2026-08-23T15:20:55.658444Z",
-     "iopub.status.idle": "2026-08-23T15:20:55.681508Z",
-     "shell.execute_reply": "2026-08-23T15:20:55.681122Z"
+     "iopub.execute_input": "2026-08-25T22:42:30.201534Z",
+     "iopub.status.busy": "2026-08-25T22:42:30.200945Z",
+     "iopub.status.idle": "2026-08-25T22:42:30.237163Z",
+     "shell.execute_reply": "2026-08-25T22:42:30.236181Z"
     },
     "papermill": {
-     "duration": 0.025766,
-     "end_time": "2026-08-23T15:20:55.681961+00:00",
+     "duration": 0.047512,
+     "end_time": "2026-08-25T22:42:30.237768+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.656195+00:00",
+     "start_time": "2026-08-25T22:42:30.190256+00:00",
      "status": "completed"
     },
     "tags": [
@@ -846,13 +849,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7276b220",
+   "id": "aaca7e56",
    "metadata": {
     "papermill": {
-     "duration": 0.001327,
-     "end_time": "2026-08-23T15:20:55.684821+00:00",
+     "duration": 0.004533,
+     "end_time": "2026-08-25T22:42:30.245995+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.683494+00:00",
+     "start_time": "2026-08-25T22:42:30.241462+00:00",
      "status": "completed"
     }
    },
@@ -886,19 +889,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "6b2701b8",
+   "id": "0b1b8620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:55.689519Z",
-     "iopub.status.busy": "2026-08-23T15:20:55.689340Z",
-     "iopub.status.idle": "2026-08-23T15:20:55.699824Z",
-     "shell.execute_reply": "2026-08-23T15:20:55.698342Z"
+     "iopub.execute_input": "2026-08-25T22:42:30.257797Z",
+     "iopub.status.busy": "2026-08-25T22:42:30.257479Z",
+     "iopub.status.idle": "2026-08-25T22:42:30.267521Z",
+     "shell.execute_reply": "2026-08-25T22:42:30.266759Z"
     },
     "papermill": {
-     "duration": 0.015067,
-     "end_time": "2026-08-23T15:20:55.701453+00:00",
+     "duration": 0.017242,
+     "end_time": "2026-08-25T22:42:30.268046+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.686386+00:00",
+     "start_time": "2026-08-25T22:42:30.250804+00:00",
      "status": "completed"
     },
     "tags": [
@@ -967,14 +970,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05ea2fd1",
+   "id": "64dc9357",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001502,
-     "end_time": "2026-08-23T15:20:55.704928+00:00",
+     "duration": 0.008054,
+     "end_time": "2026-08-25T22:42:30.280462+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.703426+00:00",
+     "start_time": "2026-08-25T22:42:30.272408+00:00",
      "status": "completed"
     }
    },
@@ -993,19 +996,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "3a3dbb28",
+   "id": "47cd86f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:55.708621Z",
-     "iopub.status.busy": "2026-08-23T15:20:55.708514Z",
-     "iopub.status.idle": "2026-08-23T15:20:57.196289Z",
-     "shell.execute_reply": "2026-08-23T15:20:57.195540Z"
+     "iopub.execute_input": "2026-08-25T22:42:30.295273Z",
+     "iopub.status.busy": "2026-08-25T22:42:30.295141Z",
+     "iopub.status.idle": "2026-08-25T22:42:32.283197Z",
+     "shell.execute_reply": "2026-08-25T22:42:32.282673Z"
     },
     "papermill": {
-     "duration": 1.491627,
-     "end_time": "2026-08-23T15:20:57.197991+00:00",
+     "duration": 1.995517,
+     "end_time": "2026-08-25T22:42:32.284819+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:55.706364+00:00",
+     "start_time": "2026-08-25T22:42:30.289302+00:00",
      "status": "completed"
     }
    },
@@ -1846,13 +1849,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "860d2a47",
+   "id": "99587394",
    "metadata": {
     "papermill": {
-     "duration": 0.004733,
-     "end_time": "2026-08-23T15:20:57.209901+00:00",
+     "duration": 0.004955,
+     "end_time": "2026-08-25T22:42:32.295691+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:57.205168+00:00",
+     "start_time": "2026-08-25T22:42:32.290736+00:00",
      "status": "completed"
     }
    },
@@ -1869,19 +1872,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f680e842",
+   "id": "233a3c62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:20:57.216255Z",
-     "iopub.status.busy": "2026-08-23T15:20:57.216147Z",
-     "iopub.status.idle": "2026-08-23T15:20:58.633104Z",
-     "shell.execute_reply": "2026-08-23T15:20:58.632239Z"
+     "iopub.execute_input": "2026-08-25T22:42:32.308609Z",
+     "iopub.status.busy": "2026-08-25T22:42:32.308306Z",
+     "iopub.status.idle": "2026-08-25T22:42:34.248813Z",
+     "shell.execute_reply": "2026-08-25T22:42:34.247741Z"
     },
     "papermill": {
-     "duration": 1.421554,
-     "end_time": "2026-08-23T15:20:58.634718+00:00",
+     "duration": 1.948501,
+     "end_time": "2026-08-25T22:42:34.249463+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:57.213164+00:00",
+     "start_time": "2026-08-25T22:42:32.300962+00:00",
      "status": "completed"
     }
    },
@@ -2255,13 +2258,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4188351e",
+   "id": "b171ca86",
    "metadata": {
     "papermill": {
-     "duration": 0.004809,
-     "end_time": "2026-08-23T15:20:58.650835+00:00",
+     "duration": 0.003092,
+     "end_time": "2026-08-25T22:42:34.258002+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:20:58.646026+00:00",
+     "start_time": "2026-08-25T22:42:34.254910+00:00",
      "status": "completed"
     }
    },
@@ -2349,22 +2352,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-23T15:21:05.210713+00:00",
+   "executed_at": "2026-08-25T22:42:45.104678+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "ca9e1e255264afc21bbcdaf3bd6f962207b49867"
+   "source_py_blob": "c3c9edc7b538dc31298dc27027f4232e19d60f00"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 28.550158,
-   "end_time": "2026-08-23T15:21:00.170189+00:00",
+   "duration": 46.181945,
+   "end_time": "2026-08-25T22:42:37.635614+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/06_linear.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/06_linear.ipynb",
+   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.06_linear.papermill.3993382.ipynb",
    "parameters": {},
-   "start_time": "2026-08-23T15:20:31.620031+00:00",
+   "start_time": "2026-08-25T22:41:51.453669+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/06_linear.py
+++ b/case_studies/sp500_equity_option_analytics/06_linear.py
@@ -102,7 +102,10 @@ SUPERSEDES_POPULATION: str = ""
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="06_linear",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/07_gbm.ipynb
+++ b/case_studies/sp500_equity_option_analytics/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b3f6b4ef",
+   "id": "93ecf0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002676,
-     "end_time": "2026-08-23T15:21:07.878239+00:00",
+     "duration": 0.002493,
+     "end_time": "2026-08-25T22:41:53.241648+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:07.875563+00:00",
+     "start_time": "2026-08-25T22:41:53.239155+00:00",
      "status": "completed"
     }
    },
@@ -78,19 +78,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "14be645d",
+   "id": "c0dcbad9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:07.883884Z",
-     "iopub.status.busy": "2026-08-23T15:21:07.883598Z",
-     "iopub.status.idle": "2026-08-23T15:21:09.753534Z",
-     "shell.execute_reply": "2026-08-23T15:21:09.753106Z"
+     "iopub.execute_input": "2026-08-25T22:41:53.246820Z",
+     "iopub.status.busy": "2026-08-25T22:41:53.246705Z",
+     "iopub.status.idle": "2026-08-25T22:41:55.889356Z",
+     "shell.execute_reply": "2026-08-25T22:41:55.888767Z"
     },
     "papermill": {
-     "duration": 1.873904,
-     "end_time": "2026-08-23T15:21:09.754357+00:00",
+     "duration": 2.646391,
+     "end_time": "2026-08-25T22:41:55.890195+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:07.880453+00:00",
+     "start_time": "2026-08-25T22:41:53.243804+00:00",
      "status": "completed"
     }
    },
@@ -118,19 +118,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a63229fa",
+   "id": "679fb070",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:09.759197Z",
-     "iopub.status.busy": "2026-08-23T15:21:09.759015Z",
-     "iopub.status.idle": "2026-08-23T15:21:09.761204Z",
-     "shell.execute_reply": "2026-08-23T15:21:09.760848Z"
+     "iopub.execute_input": "2026-08-25T22:41:55.896662Z",
+     "iopub.status.busy": "2026-08-25T22:41:55.896322Z",
+     "iopub.status.idle": "2026-08-25T22:41:55.899347Z",
+     "shell.execute_reply": "2026-08-25T22:41:55.898831Z"
     },
     "papermill": {
-     "duration": 0.005028,
-     "end_time": "2026-08-23T15:21:09.761584+00:00",
+     "duration": 0.00828,
+     "end_time": "2026-08-25T22:41:55.901352+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:09.756556+00:00",
+     "start_time": "2026-08-25T22:41:55.893072+00:00",
      "status": "completed"
     },
     "tags": [
@@ -151,38 +151,41 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ab125a25",
+   "id": "195b0b2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:09.764301Z",
-     "iopub.status.busy": "2026-08-23T15:21:09.764221Z",
-     "iopub.status.idle": "2026-08-23T15:21:10.684014Z",
-     "shell.execute_reply": "2026-08-23T15:21:10.683584Z"
+     "iopub.execute_input": "2026-08-25T22:41:55.907611Z",
+     "iopub.status.busy": "2026-08-25T22:41:55.907467Z",
+     "iopub.status.idle": "2026-08-25T22:41:57.690822Z",
+     "shell.execute_reply": "2026-08-25T22:41:57.690370Z"
     },
     "papermill": {
-     "duration": 0.921856,
-     "end_time": "2026-08-23T15:21:10.684564+00:00",
+     "duration": 1.787407,
+     "end_time": "2026-08-25T22:41:57.691766+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:09.762708+00:00",
+     "start_time": "2026-08-25T22:41:55.904359+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"07_gbm\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f7581dd9",
+   "id": "14202a33",
    "metadata": {
     "papermill": {
-     "duration": 0.001046,
-     "end_time": "2026-08-23T15:21:10.686980+00:00",
+     "duration": 0.002024,
+     "end_time": "2026-08-25T22:41:57.696288+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.685934+00:00",
+     "start_time": "2026-08-25T22:41:57.694264+00:00",
      "status": "completed"
     }
    },
@@ -199,19 +202,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ba118db0",
+   "id": "bfd259fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:10.689737Z",
-     "iopub.status.busy": "2026-08-23T15:21:10.689636Z",
-     "iopub.status.idle": "2026-08-23T15:21:10.705839Z",
-     "shell.execute_reply": "2026-08-23T15:21:10.705369Z"
+     "iopub.execute_input": "2026-08-25T22:41:57.701762Z",
+     "iopub.status.busy": "2026-08-25T22:41:57.701412Z",
+     "iopub.status.idle": "2026-08-25T22:41:57.729981Z",
+     "shell.execute_reply": "2026-08-25T22:41:57.729533Z"
     },
     "papermill": {
-     "duration": 0.018444,
-     "end_time": "2026-08-23T15:21:10.706504+00:00",
+     "duration": 0.03209,
+     "end_time": "2026-08-25T22:41:57.730500+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.688060+00:00",
+     "start_time": "2026-08-25T22:41:57.698410+00:00",
      "status": "completed"
     }
    },
@@ -237,13 +240,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ffcb79",
+   "id": "52d76b6f",
    "metadata": {
     "papermill": {
-     "duration": 0.001128,
-     "end_time": "2026-08-23T15:21:10.709157+00:00",
+     "duration": 0.002068,
+     "end_time": "2026-08-25T22:41:57.735010+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.708029+00:00",
+     "start_time": "2026-08-25T22:41:57.732942+00:00",
      "status": "completed"
     }
    },
@@ -268,19 +271,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "910fee9a",
+   "id": "8b6cfbcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:10.712177Z",
-     "iopub.status.busy": "2026-08-23T15:21:10.712072Z",
-     "iopub.status.idle": "2026-08-23T15:21:10.753280Z",
-     "shell.execute_reply": "2026-08-23T15:21:10.752841Z"
+     "iopub.execute_input": "2026-08-25T22:41:57.740104Z",
+     "iopub.status.busy": "2026-08-25T22:41:57.740011Z",
+     "iopub.status.idle": "2026-08-25T22:41:57.794227Z",
+     "shell.execute_reply": "2026-08-25T22:41:57.793727Z"
     },
     "papermill": {
-     "duration": 0.043313,
-     "end_time": "2026-08-23T15:21:10.753571+00:00",
+     "duration": 0.057768,
+     "end_time": "2026-08-25T22:41:57.794898+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.710258+00:00",
+     "start_time": "2026-08-25T22:41:57.737130+00:00",
      "status": "completed"
     }
    },
@@ -335,13 +338,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6381388",
+   "id": "12cb82b1",
    "metadata": {
     "papermill": {
-     "duration": 0.001185,
-     "end_time": "2026-08-23T15:21:10.756130+00:00",
+     "duration": 0.002133,
+     "end_time": "2026-08-25T22:41:57.799611+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.754945+00:00",
+     "start_time": "2026-08-25T22:41:57.797478+00:00",
      "status": "completed"
     }
    },
@@ -357,20 +360,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4218d64d",
+   "id": "cbea4120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:10.759209Z",
-     "iopub.status.busy": "2026-08-23T15:21:10.759070Z",
-     "iopub.status.idle": "2026-08-23T15:21:10.797869Z",
-     "shell.execute_reply": "2026-08-23T15:21:10.797321Z"
+     "iopub.execute_input": "2026-08-25T22:41:57.804990Z",
+     "iopub.status.busy": "2026-08-25T22:41:57.804841Z",
+     "iopub.status.idle": "2026-08-25T22:41:57.860200Z",
+     "shell.execute_reply": "2026-08-25T22:41:57.859308Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.041163,
-     "end_time": "2026-08-23T15:21:10.798488+00:00",
+     "duration": 0.05915,
+     "end_time": "2026-08-25T22:41:57.860992+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.757325+00:00",
+     "start_time": "2026-08-25T22:41:57.801842+00:00",
      "status": "completed"
     }
    },
@@ -385,13 +388,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5265f724",
+   "id": "7ecad63d",
    "metadata": {
     "papermill": {
-     "duration": 0.001207,
-     "end_time": "2026-08-23T15:21:10.801145+00:00",
+     "duration": 0.002206,
+     "end_time": "2026-08-25T22:41:57.865928+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.799938+00:00",
+     "start_time": "2026-08-25T22:41:57.863722+00:00",
      "status": "completed"
     }
    },
@@ -418,19 +421,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7c8d6129",
+   "id": "a0303236",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:10.804419Z",
-     "iopub.status.busy": "2026-08-23T15:21:10.804319Z",
-     "iopub.status.idle": "2026-08-23T15:21:53.880995Z",
-     "shell.execute_reply": "2026-08-23T15:21:53.880362Z"
+     "iopub.execute_input": "2026-08-25T22:41:57.872044Z",
+     "iopub.status.busy": "2026-08-25T22:41:57.871861Z",
+     "iopub.status.idle": "2026-08-25T22:43:13.077666Z",
+     "shell.execute_reply": "2026-08-25T22:43:13.076755Z"
     },
     "papermill": {
-     "duration": 43.079812,
-     "end_time": "2026-08-23T15:21:53.882213+00:00",
+     "duration": 75.213151,
+     "end_time": "2026-08-25T22:43:13.081497+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:10.802401+00:00",
+     "start_time": "2026-08-25T22:41:57.868346+00:00",
      "status": "completed"
     }
    },
@@ -508,13 +511,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cb4d76b",
+   "id": "62750b65",
    "metadata": {
     "papermill": {
-     "duration": 0.00121,
-     "end_time": "2026-08-23T15:21:53.884765+00:00",
+     "duration": 0.002442,
+     "end_time": "2026-08-25T22:43:13.086500+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:53.883555+00:00",
+     "start_time": "2026-08-25T22:43:13.084058+00:00",
      "status": "completed"
     }
    },
@@ -555,19 +558,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "dfae08cb",
+   "id": "95bc11f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:21:53.887962Z",
-     "iopub.status.busy": "2026-08-23T15:21:53.887817Z",
-     "iopub.status.idle": "2026-08-23T15:22:03.393424Z",
-     "shell.execute_reply": "2026-08-23T15:22:03.392822Z"
+     "iopub.execute_input": "2026-08-25T22:43:13.091190Z",
+     "iopub.status.busy": "2026-08-25T22:43:13.091067Z",
+     "iopub.status.idle": "2026-08-25T22:43:22.549703Z",
+     "shell.execute_reply": "2026-08-25T22:43:22.549372Z"
     },
     "papermill": {
-     "duration": 9.508056,
-     "end_time": "2026-08-23T15:22:03.394049+00:00",
+     "duration": 9.461336,
+     "end_time": "2026-08-25T22:43:22.550227+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:21:53.885993+00:00",
+     "start_time": "2026-08-25T22:43:13.088891+00:00",
      "status": "completed"
     }
    },
@@ -593,13 +596,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f02b4bb2",
+   "id": "7ebdd81e",
    "metadata": {
     "papermill": {
-     "duration": 0.00127,
-     "end_time": "2026-08-23T15:22:03.396767+00:00",
+     "duration": 0.0015,
+     "end_time": "2026-08-25T22:43:22.553461+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.395497+00:00",
+     "start_time": "2026-08-25T22:43:22.551961+00:00",
      "status": "completed"
     }
    },
@@ -632,13 +635,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7f4af5c",
+   "id": "874dae3d",
    "metadata": {
     "papermill": {
-     "duration": 0.001185,
-     "end_time": "2026-08-23T15:22:03.399199+00:00",
+     "duration": 0.001265,
+     "end_time": "2026-08-25T22:43:22.556206+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.398014+00:00",
+     "start_time": "2026-08-25T22:43:22.554941+00:00",
      "status": "completed"
     }
    },
@@ -672,19 +675,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "cc0e44f5",
+   "id": "3e5c2878",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:03.402502Z",
-     "iopub.status.busy": "2026-08-23T15:22:03.402420Z",
-     "iopub.status.idle": "2026-08-23T15:22:03.418757Z",
-     "shell.execute_reply": "2026-08-23T15:22:03.418389Z"
+     "iopub.execute_input": "2026-08-25T22:43:22.560870Z",
+     "iopub.status.busy": "2026-08-25T22:43:22.560641Z",
+     "iopub.status.idle": "2026-08-25T22:43:22.587171Z",
+     "shell.execute_reply": "2026-08-25T22:43:22.586660Z"
     },
     "papermill": {
-     "duration": 0.01869,
-     "end_time": "2026-08-23T15:22:03.419137+00:00",
+     "duration": 0.029485,
+     "end_time": "2026-08-25T22:43:22.587582+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.400447+00:00",
+     "start_time": "2026-08-25T22:43:22.558097+00:00",
      "status": "completed"
     },
     "tags": [
@@ -792,13 +795,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a966fb1",
+   "id": "ecebfa81",
    "metadata": {
     "papermill": {
-     "duration": 0.001291,
-     "end_time": "2026-08-23T15:22:03.421854+00:00",
+     "duration": 0.001493,
+     "end_time": "2026-08-25T22:43:22.590797+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.420563+00:00",
+     "start_time": "2026-08-25T22:43:22.589304+00:00",
      "status": "completed"
     }
    },
@@ -826,19 +829,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a31acfb5",
+   "id": "afb4547d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:03.425208Z",
-     "iopub.status.busy": "2026-08-23T15:22:03.425140Z",
-     "iopub.status.idle": "2026-08-23T15:22:03.429131Z",
-     "shell.execute_reply": "2026-08-23T15:22:03.428824Z"
+     "iopub.execute_input": "2026-08-25T22:43:22.594696Z",
+     "iopub.status.busy": "2026-08-25T22:43:22.594538Z",
+     "iopub.status.idle": "2026-08-25T22:43:22.600162Z",
+     "shell.execute_reply": "2026-08-25T22:43:22.599659Z"
     },
     "papermill": {
-     "duration": 0.006376,
-     "end_time": "2026-08-23T15:22:03.429571+00:00",
+     "duration": 0.008399,
+     "end_time": "2026-08-25T22:43:22.600764+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.423195+00:00",
+     "start_time": "2026-08-25T22:43:22.592365+00:00",
      "status": "completed"
     },
     "tags": [
@@ -908,13 +911,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "feaadf36",
+   "id": "1ea759a4",
    "metadata": {
     "papermill": {
-     "duration": 0.001747,
-     "end_time": "2026-08-23T15:22:03.432962+00:00",
+     "duration": 0.002778,
+     "end_time": "2026-08-25T22:43:22.606733+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.431215+00:00",
+     "start_time": "2026-08-25T22:43:22.603955+00:00",
      "status": "completed"
     }
    },
@@ -935,19 +938,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "edd53bf1",
+   "id": "63274c8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:03.437980Z",
-     "iopub.status.busy": "2026-08-23T15:22:03.437894Z",
-     "iopub.status.idle": "2026-08-23T15:22:04.852524Z",
-     "shell.execute_reply": "2026-08-23T15:22:04.852044Z"
+     "iopub.execute_input": "2026-08-25T22:43:22.613108Z",
+     "iopub.status.busy": "2026-08-25T22:43:22.612934Z",
+     "iopub.status.idle": "2026-08-25T22:43:24.590021Z",
+     "shell.execute_reply": "2026-08-25T22:43:24.589244Z"
     },
     "papermill": {
-     "duration": 1.419351,
-     "end_time": "2026-08-23T15:22:04.854466+00:00",
+     "duration": 1.985912,
+     "end_time": "2026-08-25T22:43:24.595429+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:03.435115+00:00",
+     "start_time": "2026-08-25T22:43:22.609517+00:00",
      "status": "completed"
     }
    },
@@ -3472,13 +3475,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "faeb6f73",
+   "id": "d3b9e730",
    "metadata": {
     "papermill": {
-     "duration": 0.003901,
-     "end_time": "2026-08-23T15:22:04.863123+00:00",
+     "duration": 0.013064,
+     "end_time": "2026-08-25T22:43:24.625869+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:04.859222+00:00",
+     "start_time": "2026-08-25T22:43:24.612805+00:00",
      "status": "completed"
     }
    },
@@ -3500,19 +3503,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ab4307de",
+   "id": "deb5a951",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:04.871955Z",
-     "iopub.status.busy": "2026-08-23T15:22:04.871851Z",
-     "iopub.status.idle": "2026-08-23T15:22:06.195784Z",
-     "shell.execute_reply": "2026-08-23T15:22:06.195059Z"
+     "iopub.execute_input": "2026-08-25T22:43:24.657310Z",
+     "iopub.status.busy": "2026-08-25T22:43:24.657077Z",
+     "iopub.status.idle": "2026-08-25T22:43:26.980289Z",
+     "shell.execute_reply": "2026-08-25T22:43:26.979713Z"
     },
     "papermill": {
-     "duration": 1.329093,
-     "end_time": "2026-08-23T15:22:06.196280+00:00",
+     "duration": 2.341323,
+     "end_time": "2026-08-25T22:43:26.982793+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:04.867187+00:00",
+     "start_time": "2026-08-25T22:43:24.641470+00:00",
      "status": "completed"
     }
    },
@@ -4185,13 +4188,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc9315e9",
+   "id": "c0d2e896",
    "metadata": {
     "papermill": {
-     "duration": 0.004512,
-     "end_time": "2026-08-23T15:22:06.206542+00:00",
+     "duration": 0.016093,
+     "end_time": "2026-08-25T22:43:27.015333+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:06.202030+00:00",
+     "start_time": "2026-08-25T22:43:26.999240+00:00",
      "status": "completed"
     }
    },
@@ -4209,19 +4212,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "ec42e0cf",
+   "id": "30fad792",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:06.218554Z",
-     "iopub.status.busy": "2026-08-23T15:22:06.218438Z",
-     "iopub.status.idle": "2026-08-23T15:22:06.226679Z",
-     "shell.execute_reply": "2026-08-23T15:22:06.226351Z"
+     "iopub.execute_input": "2026-08-25T22:43:27.045436Z",
+     "iopub.status.busy": "2026-08-25T22:43:27.045231Z",
+     "iopub.status.idle": "2026-08-25T22:43:27.054863Z",
+     "shell.execute_reply": "2026-08-25T22:43:27.053771Z"
     },
     "papermill": {
-     "duration": 0.016238,
-     "end_time": "2026-08-23T15:22:06.227390+00:00",
+     "duration": 0.025486,
+     "end_time": "2026-08-25T22:43:27.055994+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:06.211152+00:00",
+     "start_time": "2026-08-25T22:43:27.030508+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4299,13 +4302,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81716f74",
+   "id": "3c87d121",
    "metadata": {
     "papermill": {
-     "duration": 0.007432,
-     "end_time": "2026-08-23T15:22:06.242106+00:00",
+     "duration": 0.013384,
+     "end_time": "2026-08-25T22:43:27.083073+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:06.234674+00:00",
+     "start_time": "2026-08-25T22:43:27.069689+00:00",
      "status": "completed"
     }
    },
@@ -4391,22 +4394,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-23T15:22:13.401959+00:00",
+   "executed_at": "2026-08-25T22:43:36.724869+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "e548e68bfe7995bd87ef407343b110906b954047"
+   "source_py_blob": "2d613f870a2a8d0f905d3b58758babe82d32b075"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 60.642272,
-   "end_time": "2026-08-23T15:22:07.867069+00:00",
+   "duration": 98.24294,
+   "end_time": "2026-08-25T22:43:30.813848+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/07_gbm.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/07_gbm.ipynb",
+   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.07_gbm.papermill.3993495.ipynb",
    "parameters": {},
-   "start_time": "2026-08-23T15:21:07.224797+00:00",
+   "start_time": "2026-08-25T22:41:52.570908+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/07_gbm.py
+++ b/case_studies/sp500_equity_option_analytics/07_gbm.py
@@ -105,7 +105,10 @@ SUPERSEDES_POPULATION: str = ""
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="07_gbm",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/08_tabular_dl.ipynb
+++ b/case_studies/sp500_equity_option_analytics/08_tabular_dl.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5688afed",
+   "id": "d15c4d4a",
    "metadata": {
     "papermill": {
-     "duration": 0.001873,
-     "end_time": "2026-08-23T15:22:16.186759+00:00",
+     "duration": 0.003809,
+     "end_time": "2026-08-25T20:14:14.999870+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:16.184886+00:00",
+     "start_time": "2026-08-25T20:14:14.996061+00:00",
      "status": "completed"
     }
    },
@@ -85,19 +85,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ab32d1f9",
+   "id": "8515badd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:16.193469Z",
-     "iopub.status.busy": "2026-08-23T15:22:16.193042Z",
-     "iopub.status.idle": "2026-08-23T15:22:17.954678Z",
-     "shell.execute_reply": "2026-08-23T15:22:17.954336Z"
+     "iopub.execute_input": "2026-08-25T20:14:15.007037Z",
+     "iopub.status.busy": "2026-08-25T20:14:15.006795Z",
+     "iopub.status.idle": "2026-08-25T20:14:18.796162Z",
+     "shell.execute_reply": "2026-08-25T20:14:18.795507Z"
     },
     "papermill": {
-     "duration": 1.765524,
-     "end_time": "2026-08-23T15:22:17.955314+00:00",
+     "duration": 3.793858,
+     "end_time": "2026-08-25T20:14:18.796796+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:16.189790+00:00",
+     "start_time": "2026-08-25T20:14:15.002938+00:00",
      "status": "completed"
     }
    },
@@ -125,19 +125,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5db2d7c2",
+   "id": "67f98acb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:17.958389Z",
-     "iopub.status.busy": "2026-08-23T15:22:17.958221Z",
-     "iopub.status.idle": "2026-08-23T15:22:17.960226Z",
-     "shell.execute_reply": "2026-08-23T15:22:17.960004Z"
+     "iopub.execute_input": "2026-08-25T20:14:18.802086Z",
+     "iopub.status.busy": "2026-08-25T20:14:18.801732Z",
+     "iopub.status.idle": "2026-08-25T20:14:18.805319Z",
+     "shell.execute_reply": "2026-08-25T20:14:18.804641Z"
     },
     "papermill": {
-     "duration": 0.00403,
-     "end_time": "2026-08-23T15:22:17.960660+00:00",
+     "duration": 0.0062,
+     "end_time": "2026-08-25T20:14:18.805701+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:17.956630+00:00",
+     "start_time": "2026-08-25T20:14:18.799501+00:00",
      "status": "completed"
     },
     "tags": [
@@ -158,39 +158,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "4564598e",
+   "execution_count": 4,
+   "id": "4cfbd4bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:17.963219Z",
-     "iopub.status.busy": "2026-08-23T15:22:17.963151Z",
-     "iopub.status.idle": "2026-08-23T15:22:18.894247Z",
-     "shell.execute_reply": "2026-08-23T15:22:18.893839Z"
+     "iopub.execute_input": "2026-08-25T20:14:18.815726Z",
+     "iopub.status.busy": "2026-08-25T20:14:18.815517Z",
+     "iopub.status.idle": "2026-08-25T20:14:20.639003Z",
+     "shell.execute_reply": "2026-08-25T20:14:20.638321Z"
     },
     "papermill": {
-     "duration": 0.933199,
-     "end_time": "2026-08-23T15:22:18.894971+00:00",
+     "duration": 1.826166,
+     "end_time": "2026-08-25T20:14:20.639587+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:17.961772+00:00",
+     "start_time": "2026-08-25T20:14:18.813421+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"08_tabular_dl\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5ecb7265",
+   "id": "804efc5e",
    "metadata": {
     "papermill": {
-     "duration": 0.001932,
-     "end_time": "2026-08-23T15:22:18.899231+00:00",
+     "duration": 0.001232,
+     "end_time": "2026-08-25T20:14:20.642380+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.897299+00:00",
+     "start_time": "2026-08-25T20:14:20.641148+00:00",
      "status": "completed"
     }
    },
@@ -208,20 +211,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "14cb5722",
+   "execution_count": 5,
+   "id": "df3caf9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:18.902971Z",
-     "iopub.status.busy": "2026-08-23T15:22:18.902889Z",
-     "iopub.status.idle": "2026-08-23T15:22:18.917728Z",
-     "shell.execute_reply": "2026-08-23T15:22:18.917439Z"
+     "iopub.execute_input": "2026-08-25T20:14:20.645867Z",
+     "iopub.status.busy": "2026-08-25T20:14:20.645702Z",
+     "iopub.status.idle": "2026-08-25T20:14:20.676286Z",
+     "shell.execute_reply": "2026-08-25T20:14:20.675584Z"
     },
     "papermill": {
-     "duration": 0.016907,
-     "end_time": "2026-08-23T15:22:18.918094+00:00",
+     "duration": 0.033043,
+     "end_time": "2026-08-25T20:14:20.676668+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.901187+00:00",
+     "start_time": "2026-08-25T20:14:20.643625+00:00",
      "status": "completed"
     }
    },
@@ -232,7 +235,7 @@
        "('fwd_ret_10d', 'fwd_ret_5d', 'fwd_ret_risk_adj_5d')"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -243,13 +246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e0cb350",
+   "id": "89fcef25",
    "metadata": {
     "papermill": {
-     "duration": 0.001084,
-     "end_time": "2026-08-23T15:22:18.920392+00:00",
+     "duration": 0.001334,
+     "end_time": "2026-08-25T20:14:20.679590+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.919308+00:00",
+     "start_time": "2026-08-25T20:14:20.678256+00:00",
      "status": "completed"
     }
    },
@@ -270,20 +273,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "e158b180",
+   "execution_count": 6,
+   "id": "448300d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:18.923101Z",
-     "iopub.status.busy": "2026-08-23T15:22:18.923031Z",
-     "iopub.status.idle": "2026-08-23T15:22:18.945387Z",
-     "shell.execute_reply": "2026-08-23T15:22:18.944959Z"
+     "iopub.execute_input": "2026-08-25T20:14:20.683386Z",
+     "iopub.status.busy": "2026-08-25T20:14:20.683217Z",
+     "iopub.status.idle": "2026-08-25T20:14:20.730693Z",
+     "shell.execute_reply": "2026-08-25T20:14:20.730068Z"
     },
     "papermill": {
-     "duration": 0.024194,
-     "end_time": "2026-08-23T15:22:18.945713+00:00",
+     "duration": 0.051063,
+     "end_time": "2026-08-25T20:14:20.732126+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.921519+00:00",
+     "start_time": "2026-08-25T20:14:20.681063+00:00",
      "status": "completed"
     }
    },
@@ -319,7 +322,7 @@
        "└────────────┴─────────────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -336,13 +339,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a713e47",
+   "id": "9dacbd80",
    "metadata": {
     "papermill": {
-     "duration": 0.001139,
-     "end_time": "2026-08-23T15:22:18.948118+00:00",
+     "duration": 0.002831,
+     "end_time": "2026-08-25T20:14:20.738960+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.946979+00:00",
+     "start_time": "2026-08-25T20:14:20.736129+00:00",
      "status": "completed"
     }
    },
@@ -365,20 +368,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "808d741c",
+   "execution_count": 7,
+   "id": "0a0be300",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:18.950868Z",
-     "iopub.status.busy": "2026-08-23T15:22:18.950801Z",
-     "iopub.status.idle": "2026-08-23T15:22:18.969722Z",
-     "shell.execute_reply": "2026-08-23T15:22:18.969317Z"
+     "iopub.execute_input": "2026-08-25T20:14:20.745063Z",
+     "iopub.status.busy": "2026-08-25T20:14:20.744910Z",
+     "iopub.status.idle": "2026-08-25T20:14:20.785301Z",
+     "shell.execute_reply": "2026-08-25T20:14:20.784608Z"
     },
     "papermill": {
-     "duration": 0.020672,
-     "end_time": "2026-08-23T15:22:18.969990+00:00",
+     "duration": 0.043761,
+     "end_time": "2026-08-25T20:14:20.785730+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.949318+00:00",
+     "start_time": "2026-08-25T20:14:20.741969+00:00",
      "status": "completed"
     }
    },
@@ -408,13 +411,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98d66c32",
+   "id": "7e9d61d0",
    "metadata": {
     "papermill": {
-     "duration": 0.001241,
-     "end_time": "2026-08-23T15:22:18.972494+00:00",
+     "duration": 0.001451,
+     "end_time": "2026-08-25T20:14:20.788856+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.971253+00:00",
+     "start_time": "2026-08-25T20:14:20.787405+00:00",
      "status": "completed"
     }
    },
@@ -450,20 +453,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "6ba2138c",
+   "execution_count": 8,
+   "id": "045c6bf0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:18.975360Z",
-     "iopub.status.busy": "2026-08-23T15:22:18.975296Z",
-     "iopub.status.idle": "2026-08-23T15:22:27.300102Z",
-     "shell.execute_reply": "2026-08-23T15:22:27.299652Z"
+     "iopub.execute_input": "2026-08-25T20:14:20.793208Z",
+     "iopub.status.busy": "2026-08-25T20:14:20.792984Z",
+     "iopub.status.idle": "2026-08-25T20:14:32.506101Z",
+     "shell.execute_reply": "2026-08-25T20:14:32.505439Z"
     },
     "papermill": {
-     "duration": 8.326896,
-     "end_time": "2026-08-23T15:22:27.300605+00:00",
+     "duration": 11.716138,
+     "end_time": "2026-08-25T20:14:32.506498+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:18.973709+00:00",
+     "start_time": "2026-08-25T20:14:20.790360+00:00",
      "status": "completed"
     }
    },
@@ -509,7 +512,7 @@
        "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -540,13 +543,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b296d3e",
+   "id": "bd5242d9",
    "metadata": {
     "papermill": {
-     "duration": 0.001409,
-     "end_time": "2026-08-23T15:22:27.303598+00:00",
+     "duration": 0.001648,
+     "end_time": "2026-08-25T20:14:32.510026+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:27.302189+00:00",
+     "start_time": "2026-08-25T20:14:32.508378+00:00",
      "status": "completed"
     }
    },
@@ -611,20 +614,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c998159f",
+   "execution_count": 9,
+   "id": "4ead628d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:22:27.307282Z",
-     "iopub.status.busy": "2026-08-23T15:22:27.307169Z",
-     "iopub.status.idle": "2026-08-23T15:43:30.625215Z",
-     "shell.execute_reply": "2026-08-23T15:43:30.624420Z"
+     "iopub.execute_input": "2026-08-25T20:14:32.514163Z",
+     "iopub.status.busy": "2026-08-25T20:14:32.513963Z",
+     "iopub.status.idle": "2026-08-25T20:49:11.228903Z",
+     "shell.execute_reply": "2026-08-25T20:49:11.228064Z"
     },
     "papermill": {
-     "duration": 1263.329066,
-     "end_time": "2026-08-23T15:43:30.634106+00:00",
+     "duration": 2078.727437,
+     "end_time": "2026-08-25T20:49:11.239033+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:22:27.305040+00:00",
+     "start_time": "2026-08-25T20:14:32.511596+00:00",
      "status": "completed"
     }
    },
@@ -703,7 +706,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=50, IC=+0.0381 (51.8s)\n"
+      "    Fold 0: best_ep=50, IC=+0.0381 (104.0s)\n"
      ]
     },
     {
@@ -773,14 +776,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=25, IC=+0.0129 (43.1s)\n"
+      "    Fold 1: best_ep=25, IC=+0.0129 (74.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=175, IC=+0.0208 (94.9s)\n"
+      "    → best_epoch=175, IC=+0.0208 (178.4s)\n"
      ]
     },
     {
@@ -788,7 +791,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 729bce90b233 @ epoch 175 (IC=+0.0208)\n"
+      "  Best: 639b7ee5835c @ epoch 175 (IC=+0.0208)\n"
      ]
     },
     {
@@ -865,7 +868,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=25, IC=+0.0236 (68.0s)\n"
+      "    Fold 0: best_ep=25, IC=+0.0236 (143.4s)\n"
      ]
     },
     {
@@ -935,14 +938,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=150, IC=+0.0184 (60.8s)\n"
+      "    Fold 1: best_ep=150, IC=+0.0184 (142.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=125, IC=+0.0183 (128.9s)\n"
+      "    → best_epoch=125, IC=+0.0183 (285.9s)\n"
      ]
     },
     {
@@ -950,7 +953,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 61d82fbfe4ac @ epoch 125 (IC=+0.0183)\n"
+      "  Best: fda129978af8 @ epoch 125 (IC=+0.0183)\n"
      ]
     },
     {
@@ -1027,7 +1030,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=125, IC=+0.0053 (90.7s)\n"
+      "    Fold 0: best_ep=125, IC=+0.0053 (195.9s)\n"
      ]
     },
     {
@@ -1097,14 +1100,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=75, IC=+0.0088 (81.1s)\n"
+      "    Fold 1: best_ep=75, IC=+0.0088 (160.9s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=125, IC=+0.0050 (171.9s)\n"
+      "    → best_epoch=125, IC=+0.0050 (357.0s)\n"
      ]
     },
     {
@@ -1112,7 +1115,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: f9a64e188ab5 @ epoch 125 (IC=+0.0050)\n"
+      "  Best: 8c2ee6c20cf3 @ epoch 125 (IC=+0.0050)\n"
      ]
     },
     {
@@ -1189,7 +1192,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=25, IC=+0.0173 (38.2s)\n"
+      "    Fold 0: best_ep=25, IC=+0.0173 (90.5s)\n"
      ]
     },
     {
@@ -1259,14 +1262,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=75, IC=+0.0074 (36.8s)\n"
+      "    Fold 1: best_ep=75, IC=+0.0074 (87.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=25, IC=+0.0095 (75.1s)\n"
+      "    → best_epoch=25, IC=+0.0095 (178.0s)\n"
      ]
     },
     {
@@ -1274,7 +1277,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: d365ed8c39d2 @ epoch 25 (IC=+0.0095)\n"
+      "  Best: 3c7055832449 @ epoch 25 (IC=+0.0095)\n"
      ]
     },
     {
@@ -1351,7 +1354,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=150, IC=+0.0304 (44.2s)\n"
+      "    Fold 0: best_ep=150, IC=+0.0304 (97.3s)\n"
      ]
     },
     {
@@ -1421,14 +1424,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=100, IC=+0.0018 (41.8s)\n"
+      "    Fold 1: best_ep=100, IC=+0.0018 (95.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=150, IC=+0.0155 (86.1s)\n"
+      "    → best_epoch=150, IC=+0.0155 (192.7s)\n"
      ]
     },
     {
@@ -1436,7 +1439,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 9c95ab125a3e @ epoch 150 (IC=+0.0155)\n"
+      "  Best: 503cb8c47478 @ epoch 150 (IC=+0.0155)\n"
      ]
     },
     {
@@ -1513,7 +1516,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=50, IC=+0.0198 (90.5s)\n"
+      "    Fold 0: best_ep=50, IC=+0.0198 (121.6s)\n"
      ]
     },
     {
@@ -1583,14 +1586,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=50, IC=+0.0092 (91.7s)\n"
+      "    Fold 1: best_ep=50, IC=+0.0092 (112.5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=50, IC=+0.0144 (182.4s)\n"
+      "    → best_epoch=50, IC=+0.0144 (234.4s)\n"
      ]
     },
     {
@@ -1598,7 +1601,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 403df27c8464 @ epoch 50 (IC=+0.0144)\n"
+      "  Best: 8c3b00c4e64c @ epoch 50 (IC=+0.0144)\n"
      ]
     },
     {
@@ -1675,7 +1678,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=200, IC=+0.0190 (64.9s)\n"
+      "    Fold 0: best_ep=200, IC=+0.0190 (59.8s)\n"
      ]
     },
     {
@@ -1745,14 +1748,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=25, IC=+0.0231 (54.6s)\n"
+      "    Fold 1: best_ep=25, IC=+0.0231 (57.8s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=175, IC=+0.0199 (119.7s)\n"
+      "    → best_epoch=175, IC=+0.0199 (117.9s)\n"
      ]
     },
     {
@@ -1760,7 +1763,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 3a6c58ccd091 @ epoch 175 (IC=+0.0199)\n"
+      "  Best: 1c56fb523d94 @ epoch 175 (IC=+0.0199)\n"
      ]
     },
     {
@@ -1837,7 +1840,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=25, IC=+0.0112 (81.4s)\n"
+      "    Fold 0: best_ep=25, IC=+0.0112 (76.7s)\n"
      ]
     },
     {
@@ -1907,14 +1910,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=75, IC=+0.0149 (75.1s)\n"
+      "    Fold 1: best_ep=75, IC=+0.0149 (86.7s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=100, IC=+0.0123 (156.6s)\n"
+      "    → best_epoch=100, IC=+0.0123 (163.6s)\n"
      ]
     },
     {
@@ -1922,7 +1925,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: ea6ebdb80df8 @ epoch 100 (IC=+0.0123)\n"
+      "  Best: 3d9714ac9894 @ epoch 100 (IC=+0.0123)\n"
      ]
     },
     {
@@ -1999,7 +2002,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 0: best_ep=25, IC=+0.0187 (90.5s)\n"
+      "    Fold 0: best_ep=25, IC=+0.0187 (133.5s)\n"
      ]
     },
     {
@@ -2069,14 +2072,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fold 1: best_ep=100, IC=+0.0174 (78.7s)\n"
+      "    Fold 1: best_ep=100, IC=+0.0174 (117.5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    → best_epoch=25, IC=+0.0163 (169.3s)\n"
+      "    → best_epoch=25, IC=+0.0163 (251.3s)\n"
      ]
     },
     {
@@ -2084,7 +2087,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: 386ec2d262e6 @ epoch 25 (IC=+0.0163)\n"
+      "  Best: dc34b767fe7f @ epoch 25 (IC=+0.0163)\n"
      ]
     },
     {
@@ -2114,13 +2117,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "426c6200",
+   "id": "bcf413c8",
    "metadata": {
     "papermill": {
-     "duration": 0.008568,
-     "end_time": "2026-08-23T15:43:30.658863+00:00",
+     "duration": 0.013037,
+     "end_time": "2026-08-25T20:49:11.272230+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.650295+00:00",
+     "start_time": "2026-08-25T20:49:11.259193+00:00",
      "status": "completed"
     }
    },
@@ -2162,13 +2165,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "279bbd24",
+   "id": "5881cca9",
    "metadata": {
     "papermill": {
-     "duration": 0.00385,
-     "end_time": "2026-08-23T15:43:30.666937+00:00",
+     "duration": 0.011072,
+     "end_time": "2026-08-25T20:49:11.294680+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.663087+00:00",
+     "start_time": "2026-08-25T20:49:11.283608+00:00",
      "status": "completed"
     }
    },
@@ -2200,20 +2203,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "eb9a7207",
+   "execution_count": 10,
+   "id": "6df687ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:43:30.683886Z",
-     "iopub.status.busy": "2026-08-23T15:43:30.683738Z",
-     "iopub.status.idle": "2026-08-23T15:43:30.702240Z",
-     "shell.execute_reply": "2026-08-23T15:43:30.701813Z"
+     "iopub.execute_input": "2026-08-25T20:49:11.330567Z",
+     "iopub.status.busy": "2026-08-25T20:49:11.330303Z",
+     "iopub.status.idle": "2026-08-25T20:49:11.375652Z",
+     "shell.execute_reply": "2026-08-25T20:49:11.374912Z"
     },
     "papermill": {
-     "duration": 0.03543,
-     "end_time": "2026-08-23T15:43:30.706389+00:00",
+     "duration": 0.069952,
+     "end_time": "2026-08-25T20:49:11.379282+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.670959+00:00",
+     "start_time": "2026-08-25T20:49:11.309330+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2293,7 +2296,7 @@
        "└────────────┴────────────┴────────────┴────────────┴──────────┴──────────┴───────────┴────────────┘"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2350,13 +2353,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4949c9b",
+   "id": "b522e309",
    "metadata": {
     "papermill": {
-     "duration": 0.004173,
-     "end_time": "2026-08-23T15:43:30.716309+00:00",
+     "duration": 0.011536,
+     "end_time": "2026-08-25T20:49:11.403448+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.712136+00:00",
+     "start_time": "2026-08-25T20:49:11.391912+00:00",
      "status": "completed"
     }
    },
@@ -2380,20 +2383,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "bd1aeca9",
+   "execution_count": 11,
+   "id": "582e6fbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:43:30.726059Z",
-     "iopub.status.busy": "2026-08-23T15:43:30.725900Z",
-     "iopub.status.idle": "2026-08-23T15:43:30.730211Z",
-     "shell.execute_reply": "2026-08-23T15:43:30.729925Z"
+     "iopub.execute_input": "2026-08-25T20:49:11.431441Z",
+     "iopub.status.busy": "2026-08-25T20:49:11.431189Z",
+     "iopub.status.idle": "2026-08-25T20:49:11.438235Z",
+     "shell.execute_reply": "2026-08-25T20:49:11.437616Z"
     },
     "papermill": {
-     "duration": 0.009904,
-     "end_time": "2026-08-23T15:43:30.730795+00:00",
+     "duration": 0.023641,
+     "end_time": "2026-08-25T20:49:11.438859+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.720891+00:00",
+     "start_time": "2026-08-25T20:49:11.415218+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2432,7 +2435,7 @@
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2459,13 +2462,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f38225b",
+   "id": "be3e57ff",
    "metadata": {
     "papermill": {
-     "duration": 0.003979,
-     "end_time": "2026-08-23T15:43:30.741833+00:00",
+     "duration": 0.011462,
+     "end_time": "2026-08-25T20:49:11.462385+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.737854+00:00",
+     "start_time": "2026-08-25T20:49:11.450923+00:00",
      "status": "completed"
     }
    },
@@ -2488,20 +2491,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "acdc0b59",
+   "execution_count": 12,
+   "id": "e19eec0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:43:30.750948Z",
-     "iopub.status.busy": "2026-08-23T15:43:30.750857Z",
-     "iopub.status.idle": "2026-08-23T15:43:32.134132Z",
-     "shell.execute_reply": "2026-08-23T15:43:32.133655Z"
+     "iopub.execute_input": "2026-08-25T20:49:11.490561Z",
+     "iopub.status.busy": "2026-08-25T20:49:11.490356Z",
+     "iopub.status.idle": "2026-08-25T20:49:13.775884Z",
+     "shell.execute_reply": "2026-08-25T20:49:13.775264Z"
     },
     "papermill": {
-     "duration": 1.391105,
-     "end_time": "2026-08-23T15:43:32.137109+00:00",
+     "duration": 2.299954,
+     "end_time": "2026-08-25T20:49:13.777419+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:30.746004+00:00",
+     "start_time": "2026-08-25T20:49:11.477465+00:00",
      "status": "completed"
     }
    },
@@ -3189,13 +3192,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5db9ac2c",
+   "id": "5b220dae",
    "metadata": {
     "papermill": {
-     "duration": 0.004947,
-     "end_time": "2026-08-23T15:43:32.149969+00:00",
+     "duration": 0.011395,
+     "end_time": "2026-08-25T20:49:13.803232+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:32.145022+00:00",
+     "start_time": "2026-08-25T20:49:13.791837+00:00",
      "status": "completed"
     }
    },
@@ -3213,20 +3216,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "464db521",
+   "execution_count": 13,
+   "id": "a8061ae0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:43:32.161304Z",
-     "iopub.status.busy": "2026-08-23T15:43:32.161153Z",
-     "iopub.status.idle": "2026-08-23T15:43:33.481965Z",
-     "shell.execute_reply": "2026-08-23T15:43:33.481502Z"
+     "iopub.execute_input": "2026-08-25T20:49:13.829264Z",
+     "iopub.status.busy": "2026-08-25T20:49:13.829116Z",
+     "iopub.status.idle": "2026-08-25T20:49:15.971024Z",
+     "shell.execute_reply": "2026-08-25T20:49:15.970486Z"
     },
     "papermill": {
-     "duration": 1.327549,
-     "end_time": "2026-08-23T15:43:33.482642+00:00",
+     "duration": 2.155685,
+     "end_time": "2026-08-25T20:49:15.972371+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:32.155093+00:00",
+     "start_time": "2026-08-25T20:49:13.816686+00:00",
      "status": "completed"
     }
    },
@@ -3615,13 +3618,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6530088",
+   "id": "d2718b1d",
    "metadata": {
     "papermill": {
-     "duration": 0.005495,
-     "end_time": "2026-08-23T15:43:33.496386+00:00",
+     "duration": 0.012157,
+     "end_time": "2026-08-25T20:49:15.997631+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:33.490891+00:00",
+     "start_time": "2026-08-25T20:49:15.985474+00:00",
      "status": "completed"
     }
    },
@@ -3640,20 +3643,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "f3ec06e9",
+   "execution_count": 14,
+   "id": "6b47b1b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T15:43:33.509913Z",
-     "iopub.status.busy": "2026-08-23T15:43:33.509754Z",
-     "iopub.status.idle": "2026-08-23T15:43:33.515323Z",
-     "shell.execute_reply": "2026-08-23T15:43:33.514841Z"
+     "iopub.execute_input": "2026-08-25T20:49:16.026795Z",
+     "iopub.status.busy": "2026-08-25T20:49:16.026657Z",
+     "iopub.status.idle": "2026-08-25T20:49:16.032647Z",
+     "shell.execute_reply": "2026-08-25T20:49:16.032174Z"
     },
     "papermill": {
-     "duration": 0.013623,
-     "end_time": "2026-08-23T15:43:33.515745+00:00",
+     "duration": 0.026876,
+     "end_time": "2026-08-25T20:49:16.036808+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:33.502122+00:00",
+     "start_time": "2026-08-25T20:49:16.009932+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3687,7 +3690,7 @@
        "└─────────────────────┴────────────────┴────────────────┴─────────────────────┴────────────────────┘"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3719,13 +3722,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd7ea150",
+   "id": "ae328a34",
    "metadata": {
     "papermill": {
-     "duration": 0.005509,
-     "end_time": "2026-08-23T15:43:33.527897+00:00",
+     "duration": 0.011718,
+     "end_time": "2026-08-25T20:49:16.060938+00:00",
      "exception": false,
-     "start_time": "2026-08-23T15:43:33.522388+00:00",
+     "start_time": "2026-08-25T20:49:16.049220+00:00",
      "status": "completed"
     }
    },
@@ -3819,22 +3822,26 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-23T15:43:42.604020+00:00",
+   "executed_at": "2026-08-25T20:49:34.359419+00:00",
    "executor": "local-uv",
-   "parameters": {},
+   "parameters": {
+    "SUPERSEDES_POPULATION": "faa6952f1819"
+   },
    "production": true,
-   "source_py_blob": "b00a67c7d3d06cee08d45ab2eb85f2f42408aeec"
+   "source_py_blob": "03bc049ea045611e72abd4d572018fa4ca2c0d0e"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1280.769106,
-   "end_time": "2026-08-23T15:43:36.289517+00:00",
+   "duration": 2105.3546,
+   "end_time": "2026-08-25T20:49:19.645602+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/08_tabular_dl.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/08_tabular_dl.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-23T15:22:15.520411+00:00",
+   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.08_tabular_dl.papermill.3279591.ipynb",
+   "parameters": {
+    "SUPERSEDES_POPULATION": "faa6952f1819"
+   },
+   "start_time": "2026-08-25T20:14:14.291002+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/08_tabular_dl.py
+++ b/case_studies/sp500_equity_option_analytics/08_tabular_dl.py
@@ -113,7 +113,10 @@ DEVICE: str = ""
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="08_tabular_dl",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/09_dl_lstm.ipynb
+++ b/case_studies/sp500_equity_option_analytics/09_dl_lstm.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bf9524cb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002728,
-     "end_time": "2026-07-22T07:04:01.158517+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:01.155789+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "d86dd047",
+   "metadata": {},
    "source": [
     "# S&P 500 Equity+Options: Sequence Models\n",
     "\n",
@@ -69,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f61c3a18",
+   "id": "1a79fbe9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c774e1d9",
+   "id": "986936e5",
    "metadata": {
     "tags": [
      "parameters"
@@ -115,27 +107,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f1c1bf4",
+   "id": "986e972b",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"09_dl_lstm\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8861b22d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001624,
-     "end_time": "2026-07-22T07:04:06.084225+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:06.082601+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "47441661",
+   "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
     "\n",
@@ -151,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67db9463",
+   "id": "abfd9c33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,16 +147,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39dc5923",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002285,
-     "end_time": "2026-07-22T07:04:06.982490+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:06.980205+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "add3a5ee",
+   "metadata": {},
    "source": [
     "`SEQUENCE_CONFIGS` is this notebook's slice of the declared family. The menu declares three\n",
     "architectures; the third, `patchtst`, is declared on one label only and is published by\n",
@@ -192,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a3e8851",
+   "id": "6af05399",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,16 +188,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d075a313",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00175,
-     "end_time": "2026-07-22T07:04:07.007181+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:07.005431+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "e5f59431",
+   "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
     "declares a different set of members than the published population does. A population is immutable\n",
@@ -238,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82caf2d3",
+   "id": "2987b335",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90b8aecf",
+   "id": "7a97c506",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -297,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29630768",
+   "id": "f83c706d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b2f58a0",
+   "id": "b5730464",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -373,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd485de2",
+   "id": "902453e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,16 +365,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "593c32fc",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00136,
-     "end_time": "2026-07-22T07:04:08.812372+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:08.811012+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ac2357e1",
+   "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
     "already holds the matching rows and the saved weights, and the runner returns the stored result\n",
@@ -412,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1d461cd",
+   "id": "5f1c22f4",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -438,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea6745fa",
+   "id": "29ec5d94",
    "metadata": {
     "tags": [
      "results"
@@ -499,16 +462,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1169dbc",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001414,
-     "end_time": "2026-07-22T07:04:08.827057+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:08.825643+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "86893c26",
+   "metadata": {},
    "source": [
     "### Memory against no memory, on each label\n",
     "\n",
@@ -527,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a138ba93",
+   "id": "09d398a7",
    "metadata": {
     "tags": [
      "results"
@@ -554,16 +509,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "705deece",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-07-22T07:04:10.317016+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:10.314299+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "aa17283f",
+   "metadata": {},
    "source": [
     "**`epoch_at_high` is a diagnostic and not a result.** It says where on its own curve each\n",
     "configuration happened to peak, and reading the two `ic_high` values as a contest between the\n",
@@ -577,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57540ccf",
+   "id": "4f53b0a6",
    "metadata": {},
    "source": [
     "### What more training does\n",
@@ -599,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1da89a18",
+   "id": "3f421e98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,16 +646,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4034e40a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003125,
-     "end_time": "2026-07-22T07:04:10.337133+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:10.334008+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ad709d92",
+   "metadata": {},
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -742,18 +681,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/09_dl_lstm.py
+++ b/case_studies/sp500_equity_option_analytics/09_dl_lstm.py
@@ -96,7 +96,10 @@ DEVICE: str = ""
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="09_dl_lstm",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/10_dl_patchtst.ipynb
+++ b/case_studies/sp500_equity_option_analytics/10_dl_patchtst.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8c552c8c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002688,
-     "end_time": "2026-07-22T07:04:18.667454+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:18.664766+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "d6adc1fd",
+   "metadata": {},
    "source": [
     "# S&P 500 Equity+Options: Patched Attention\n",
     "\n",
@@ -65,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "310a38fd",
+   "id": "eae53910",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f12c10d",
+   "id": "7e1fbb49",
    "metadata": {
     "tags": [
      "parameters"
@@ -109,27 +101,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f2c72b4",
+   "id": "10c2bdee",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"10_dl_patchtst\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "96e2f9c6",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002442,
-     "end_time": "2026-07-22T07:04:24.074114+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:24.071672+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5dabc9ff",
+   "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
     "\n",
@@ -152,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50bc4dfd",
+   "id": "b9c1af45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f806b902",
+   "id": "b19f4f7b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,16 +167,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65d15c95",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001384,
-     "end_time": "2026-07-22T07:04:24.690376+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:24.688992+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ffb14e89",
+   "metadata": {},
    "source": [
     "`LABELS` narrows the run below what the menu declares, and a narrowed run declares a different set\n",
     "of members than the published population does. A population is immutable once written, so such a\n",
@@ -207,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78439af3",
+   "id": "07c9f18f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,16 +207,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17c8589e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001309,
-     "end_time": "2026-07-22T07:04:24.714148+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:24.712839+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "677e162a",
+   "metadata": {},
    "source": [
     "## 2. Binding the declaration to the data\n",
     "\n",
@@ -267,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11d95862",
+   "id": "991d06bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4938694",
+   "id": "bbacd7cb",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -329,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e2edba4",
+   "id": "31809dbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8c26578",
+   "id": "807ade00",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -370,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "379ecf6c",
+   "id": "b0ef5163",
    "metadata": {
     "tags": [
      "results"
@@ -425,16 +396,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c786396",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001243,
-     "end_time": "2026-07-22T07:04:26.221335+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:26.220092+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "86c1cfc3",
+   "metadata": {},
    "source": [
     "### What more training does\n",
     "\n",
@@ -452,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2412b7f7",
+   "id": "2f646380",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,16 +467,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "859c024d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001509,
-     "end_time": "2026-07-22T07:04:26.233459+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:04:26.231950+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "93a0455b",
+   "metadata": {},
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -544,18 +499,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/10_dl_patchtst.py
+++ b/case_studies/sp500_equity_option_analytics/10_dl_patchtst.py
@@ -90,7 +90,10 @@ DEVICE: str = ""
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="10_dl_patchtst",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/11a_pca.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11a_pca.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "621f7f6e",
+   "id": "df76d685",
    "metadata": {
     "papermill": {
-     "duration": 0.00178,
-     "end_time": "2026-07-22T07:04:42.944732+00:00",
+     "duration": 0.001723,
+     "end_time": "2026-08-25T20:04:15.023203+00:00",
      "exception": false,
-     "start_time": "2026-07-22T07:04:42.942952+00:00",
+     "start_time": "2026-08-25T20:04:15.021480+00:00",
      "status": "completed"
     }
    },
@@ -74,9 +74,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "455e0526",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "d4074888",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:15.026843Z",
+     "iopub.status.busy": "2026-08-25T20:04:15.026682Z",
+     "iopub.status.idle": "2026-08-25T20:04:17.998649Z",
+     "shell.execute_reply": "2026-08-25T20:04:17.998054Z"
+    },
+    "papermill": {
+     "duration": 2.974589,
+     "end_time": "2026-08-25T20:04:17.999229+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:15.024640+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared option-analytics PCA population on the walk-forward folds.\"\"\"\n",
@@ -99,9 +113,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a52b8aa1",
+   "execution_count": 2,
+   "id": "6587d6d4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:18.003543Z",
+     "iopub.status.busy": "2026-08-25T20:04:18.003154Z",
+     "iopub.status.idle": "2026-08-25T20:04:18.006203Z",
+     "shell.execute_reply": "2026-08-25T20:04:18.005724Z"
+    },
+    "papermill": {
+     "duration": 0.005576,
+     "end_time": "2026-08-25T20:04:18.006617+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:18.001041+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -120,25 +147,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eb45e819",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "22be023e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:18.010010Z",
+     "iopub.status.busy": "2026-08-25T20:04:18.009857Z",
+     "iopub.status.idle": "2026-08-25T20:04:19.159308Z",
+     "shell.execute_reply": "2026-08-25T20:04:19.158687Z"
+    },
+    "papermill": {
+     "duration": 1.151999,
+     "end_time": "2026-08-25T20:04:19.160109+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:18.008110+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"11a_pca\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8588ca1e",
+   "id": "d3541f0c",
    "metadata": {
     "papermill": {
-     "duration": 0.001634,
-     "end_time": "2026-07-22T07:04:48.005619+00:00",
+     "duration": 0.002118,
+     "end_time": "2026-08-25T20:04:19.164658+00:00",
      "exception": false,
-     "start_time": "2026-07-22T07:04:48.003985+00:00",
+     "start_time": "2026-08-25T20:04:19.162540+00:00",
      "status": "completed"
     }
    },
@@ -154,23 +198,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "54278eea",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "0ee6af8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:19.170032Z",
+     "iopub.status.busy": "2026-08-25T20:04:19.169822Z",
+     "iopub.status.idle": "2026-08-25T20:04:19.197076Z",
+     "shell.execute_reply": "2026-08-25T20:04:19.196505Z"
+    },
+    "papermill": {
+     "duration": 0.030471,
+     "end_time": "2026-08-25T20:04:19.197450+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.166979+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_10d', 'fwd_ret_5d', 'fwd_ret_risk_adj_5d')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"latent_factors\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "380e849e",
+   "id": "de237396",
    "metadata": {
     "papermill": {
-     "duration": 0.001843,
-     "end_time": "2026-07-22T07:04:55.026093+00:00",
+     "duration": 0.001145,
+     "end_time": "2026-08-25T20:04:19.199982+00:00",
      "exception": false,
-     "start_time": "2026-07-22T07:04:55.024250+00:00",
+     "start_time": "2026-08-25T20:04:19.198837+00:00",
      "status": "completed"
     }
    },
@@ -190,10 +259,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "32f85f3f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "427f665f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:19.203222Z",
+     "iopub.status.busy": "2026-08-25T20:04:19.203066Z",
+     "iopub.status.idle": "2026-08-25T20:04:19.235278Z",
+     "shell.execute_reply": "2026-08-25T20:04:19.234594Z"
+    },
+    "papermill": {
+     "duration": 0.034889,
+     "end_time": "2026-08-25T20:04:19.236065+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.201176+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>&quot;pca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;pca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;pca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 5)\n",
+       "┌────────────────┬─────────────────────┬─────────────┬─────────────┬─────────────┐\n",
+       "│ family         ┆ label               ┆ config_name ┆ model_class ┆ params      │\n",
+       "│ ---            ┆ ---                 ┆ ---         ┆ ---         ┆ ---         │\n",
+       "│ str            ┆ str                 ┆ str         ┆ str         ┆ str         │\n",
+       "╞════════════════╪═════════════════════╪═════════════╪═════════════╪═════════════╡\n",
+       "│ latent_factors ┆ fwd_ret_10d         ┆ pca         ┆             ┆ n_factors=5 │\n",
+       "│ latent_factors ┆ fwd_ret_5d          ┆ pca         ┆             ┆ n_factors=5 │\n",
+       "│ latent_factors ┆ fwd_ret_risk_adj_5d ┆ pca         ┆             ┆ n_factors=5 │\n",
+       "└────────────────┴─────────────────────┴─────────────┴─────────────┴─────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "configs = load_model_configs(\n",
     "    study,\n",
@@ -206,13 +319,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afa75c18",
+   "id": "49c91cb6",
    "metadata": {
     "papermill": {
-     "duration": 0.000916,
-     "end_time": "2026-07-22T07:05:08.499788+00:00",
+     "duration": 0.002589,
+     "end_time": "2026-08-25T20:04:19.241528+00:00",
      "exception": false,
-     "start_time": "2026-07-22T07:05:08.498872+00:00",
+     "start_time": "2026-08-25T20:04:19.238939+00:00",
      "status": "completed"
     }
    },
@@ -230,9 +343,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36c6b9e1",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "4a4aaf52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:19.248379Z",
+     "iopub.status.busy": "2026-08-25T20:04:19.248060Z",
+     "iopub.status.idle": "2026-08-25T20:04:19.276540Z",
+     "shell.execute_reply": "2026-08-25T20:04:19.276008Z"
+    },
+    "papermill": {
+     "duration": 0.033261,
+     "end_time": "2026-08-25T20:04:19.277757+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.244496+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "declared = load_model_configs(study, \"latent_factors\", config_names=[MODEL_NAME])\n",
@@ -245,13 +372,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e455c09d",
+   "id": "9eb07481",
    "metadata": {
     "papermill": {
-     "duration": 0.000897,
-     "end_time": "2026-07-22T07:05:08.514593+00:00",
+     "duration": 0.00216,
+     "end_time": "2026-08-25T20:04:19.282715+00:00",
      "exception": false,
-     "start_time": "2026-07-22T07:05:08.513696+00:00",
+     "start_time": "2026-08-25T20:04:19.280555+00:00",
      "status": "completed"
     }
    },
@@ -268,10 +395,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c03af89c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "dddd9004",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:19.288110Z",
+     "iopub.status.busy": "2026-08-25T20:04:19.287942Z",
+     "iopub.status.idle": "2026-08-25T20:04:19.290962Z",
+     "shell.execute_reply": "2026-08-25T20:04:19.290296Z"
+    },
+    "papermill": {
+     "duration": 0.006737,
+     "end_time": "2026-08-25T20:04:19.291651+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.284914+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cpu\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cpu\"\n",
     "overrides = {\"device\": PUBLISHED_DEVICE}\n",
@@ -280,8 +429,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da4e9fb0",
-   "metadata": {},
+   "id": "c551e2fa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002297,
+     "end_time": "2026-08-25T20:04:19.296826+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.294529+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -307,10 +464,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f7fcbc38",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "09342ff8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:19.302302Z",
+     "iopub.status.busy": "2026-08-25T20:04:19.302178Z",
+     "iopub.status.idle": "2026-08-25T20:04:27.175490Z",
+     "shell.execute_reply": "2026-08-25T20:04:27.174813Z"
+    },
+    "papermill": {
+     "duration": 7.87694,
+     "end_time": "2026-08-25T20:04:27.176074+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:19.299134+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;pca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>175360</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-16 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;pca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>177682</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;pca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>177769</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-23 00:00:00&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ task       ┆ feature_c ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ ---        ┆ ount      ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ str        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆            ┆ i64       ┆   ┆       ┆ i64       ┆ str       ┆ str       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_10 ┆ pca        ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-1 │\n",
+       "│ d          ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 6         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ pca        ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-2 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_ri ┆ pca        ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-2 │\n",
+       "│ sk_adj_5d  ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -336,8 +544,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a83674ef",
-   "metadata": {},
+   "id": "fcc9d89d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00134,
+     "end_time": "2026-08-25T20:04:27.179663+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:27.178323+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
     "menu declares would still print an IC table and still register its rows; what it would not do is\n",
@@ -346,10 +562,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a8711b15",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "9089dc39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:27.183683Z",
+     "iopub.status.busy": "2026-08-25T20:04:27.183480Z",
+     "iopub.status.idle": "2026-08-25T20:04:27.187415Z",
+     "shell.execute_reply": "2026-08-25T20:04:27.186823Z"
+    },
+    "papermill": {
+     "duration": 0.006785,
+     "end_time": "2026-08-25T20:04:27.187877+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:27.181092+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 label-configuration pairs\n",
+      "3 training identities\n",
+      "3 validation prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "planned_pairs = {(member.label, member.config_name) for member in plan.members}\n",
     "requested_pairs = set(zip(configs[\"label\"], configs[\"config_name\"], strict=True))\n",
@@ -366,9 +606,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fc7a8f1",
+   "id": "351dbf73",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001364,
+     "end_time": "2026-08-25T20:04:27.191306+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:27.189942+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 3. Fitting the population\n",
@@ -404,10 +651,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f1925d43",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "25390e28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:27.195404Z",
+     "iopub.status.busy": "2026-08-25T20:04:27.195204Z",
+     "iopub.status.idle": "2026-08-25T20:04:37.233566Z",
+     "shell.execute_reply": "2026-08-25T20:04:37.233057Z"
+    },
+    "papermill": {
+     "duration": 10.041413,
+     "end_time": "2026-08-25T20:04:37.234227+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:27.192814+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 training runs across 3 labels\n",
+      "population sp500_equity_option_analytics-pca-validation-v1: 3 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "def catalog_labels(execution) -> int:\n",
     "    \"\"\"Number of distinct labels the execution published, read from its catalog rows.\"\"\"\n",
@@ -426,8 +696,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afb30284",
-   "metadata": {},
+   "id": "2c86db6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002303,
+     "end_time": "2026-08-25T20:04:37.239349+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.237046+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
     "already holds the matching rows, and the runner returns the stored result rather than fitting\n",
@@ -458,8 +736,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a01a8c2",
-   "metadata": {},
+   "id": "739babf6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002259,
+     "end_time": "2026-08-25T20:04:37.243972+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.241713+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -481,14 +767,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "334096e2",
+   "execution_count": 11,
+   "id": "d91af1ca",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:37.248774Z",
+     "iopub.status.busy": "2026-08-25T20:04:37.248633Z",
+     "iopub.status.idle": "2026-08-25T20:04:37.268817Z",
+     "shell.execute_reply": "2026-08-25T20:04:37.268301Z"
+    },
+    "papermill": {
+     "duration": 0.022828,
+     "end_time": "2026-08-25T20:04:37.269232+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.246404+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 candidate models across 3 labels\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>task</th><th>checkpoint_value</th><th>ic_mean</th><th>ic_std</th><th>ic_t</th><th>ic_n_days</th><th>auc_mean_daily</th><th>auc_scored_against</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>-0.004988</td><td>0.013</td><td>-0.542577</td><td>492.0</td><td>0.501488</td><td>&quot;fwd_dir_10d&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>0.009975</td><td>0.004982</td><td>2.831869</td><td>497.0</td><td>0.497546</td><td>&quot;fwd_dir_5d&quot;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>-0.032333</td><td>0.009544</td><td>-4.791035</td><td>497.0</td><td>null</td><td>null</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 9)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ label     ┆ task      ┆ checkpoin ┆ ic_mean   ┆ … ┆ ic_t      ┆ ic_n_days ┆ auc_mean_ ┆ auc_scor │\n",
+       "│ ---       ┆ ---       ┆ t_value   ┆ ---       ┆   ┆ ---       ┆ ---       ┆ daily     ┆ ed_again │\n",
+       "│ str       ┆ str       ┆ ---       ┆ f64       ┆   ┆ f64       ┆ f64       ┆ ---       ┆ st       │\n",
+       "│           ┆           ┆ i64       ┆           ┆   ┆           ┆           ┆ f64       ┆ ---      │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆ str      │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_1 ┆ regressio ┆ 0         ┆ -0.004988 ┆ … ┆ -0.542577 ┆ 492.0     ┆ 0.501488  ┆ fwd_dir_ │\n",
+       "│ 0d        ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆ 10d      │\n",
+       "│ fwd_ret_5 ┆ regressio ┆ 0         ┆ 0.009975  ┆ … ┆ 2.831869  ┆ 497.0     ┆ 0.497546  ┆ fwd_dir_ │\n",
+       "│ d         ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆ 5d       │\n",
+       "│ fwd_ret_r ┆ regressio ┆ 0         ┆ -0.032333 ┆ … ┆ -4.791035 ┆ 497.0     ┆ null      ┆ null     │\n",
+       "│ isk_adj_5 ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆          │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆          │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = execution.catalog_rows.select(\n",
     "    \"config_name\",\n",
@@ -538,8 +880,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd196125",
-   "metadata": {},
+   "id": "d216e805",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001501,
+     "end_time": "2026-08-25T20:04:37.272388+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.270887+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### One decomposition, three targets\n",
     "\n",
@@ -555,14 +905,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7056ddd9",
+   "execution_count": 12,
+   "id": "69df8142",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:37.276466Z",
+     "iopub.status.busy": "2026-08-25T20:04:37.276347Z",
+     "iopub.status.idle": "2026-08-25T20:04:37.280767Z",
+     "shell.execute_reply": "2026-08-25T20:04:37.280118Z"
+    },
+    "papermill": {
+     "duration": 0.007289,
+     "end_time": "2026-08-25T20:04:37.281118+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.273829+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>task</th><th>ic_mean</th><th>ic_t</th><th>scored_dates</th><th>full_coverage</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;regression&quot;</td><td>0.009975</td><td>2.831869</td><td>497.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;regression&quot;</td><td>-0.004988</td><td>-0.542577</td><td>492.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;regression&quot;</td><td>-0.032333</td><td>-4.791035</td><td>497.0</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 6)\n",
+       "┌─────────────────────┬────────────┬───────────┬───────────┬──────────────┬───────────────┐\n",
+       "│ label               ┆ task       ┆ ic_mean   ┆ ic_t      ┆ scored_dates ┆ full_coverage │\n",
+       "│ ---                 ┆ ---        ┆ ---       ┆ ---       ┆ ---          ┆ ---           │\n",
+       "│ str                 ┆ str        ┆ f64       ┆ f64       ┆ f64          ┆ bool          │\n",
+       "╞═════════════════════╪════════════╪═══════════╪═══════════╪══════════════╪═══════════════╡\n",
+       "│ fwd_ret_5d          ┆ regression ┆ 0.009975  ┆ 2.831869  ┆ 497.0        ┆ true          │\n",
+       "│ fwd_ret_10d         ┆ regression ┆ -0.004988 ┆ -0.542577 ┆ 492.0        ┆ false         │\n",
+       "│ fwd_ret_risk_adj_5d ┆ regression ┆ -0.032333 ┆ -4.791035 ┆ 497.0        ┆ true          │\n",
+       "└─────────────────────┴────────────┴───────────┴───────────┴──────────────┴───────────────┘"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "by_label = catalog.select(\n",
     "    \"label\",\n",
@@ -577,8 +970,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "828be0a1",
-   "metadata": {},
+   "id": "82a24e10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00147,
+     "end_time": "2026-08-25T20:04:37.284276+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.282806+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The same decomposition against each target\n",
     "\n",
@@ -589,10 +990,170 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "60243d19",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "dfe344c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T20:04:37.287954Z",
+     "iopub.status.busy": "2026-08-25T20:04:37.287858Z",
+     "iopub.status.idle": "2026-08-25T20:04:39.018939Z",
+     "shell.execute_reply": "2026-08-25T20:04:39.018274Z"
+    },
+    "papermill": {
+     "duration": 1.734357,
+     "end_time": "2026-08-25T20:04:39.020179+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:37.285822+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#1a2d4a",
+           "#1a2d4a"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "fwd_ret_5d",
+          "fwd_ret_10d",
+          "fwd_ret_risk_adj_5d"
+         ],
+         "y": [
+          0.009975139928306714,
+          -0.004987771048982855,
+          -0.03233275760923918
+         ]
+        }
+       ],
+       "layout": {
+        "height": 420,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "What the return factors rank depends on which forward return is asked for"
+        },
+        "width": 800,
+        "xaxis": {
+         "title": {
+          "text": "Label, primary target first"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAGkCAYAAADJzkGPAAAQAElEQVR4AezdCbxM5RvA8WeufUmyR0IbJVtkFxH+JUpR2YsIyV72Ldm3bNkVEVFUSila7FvIVlpIUsqusi//87zXjLlj7p25987ce2bmdz/eM2d5z3ve9/uec+Y8c86MqPPnz10hYcA+wD7APsA+wD7APsA+wD7APsA+kBT7QJTwhwACySTAZhFAAAEEEEAAgcgTIACJvD6nxQgggAACCCCAAAIIJJsAAUiy0bNhBBBAAAEEEEAg8gRoMQIEIOwDCCCAAAIIIIAAAgggkGQCBCBJRu25IaYRQAABBBBAAAEEEIg8AQKQyOtzWowAAggggAACCCCAQLIJEIAkGz0bRgABBBBAIPIEaDECCCBAAMI+gAACCCCAAAIIIIBA+AvYpoUEILbpCiqCAAIIIIAAAggggED4CxCAhH8f00JPAaYRQAABBBBAAAEEkk2AACTZ6NkwAgggEHkCtBgBBBBAAAECEPYBBBBAAAEEEEAg/AVoIQK2ESAAsU1XUBEEEEAAAQQQQAABBMJfIPICkPDvU1qIAAIIIIAAAggggIBtBQhAbNs1VAyB8BOgRQgggAACCCCAAAEI+wACCCCAAALhL0ALEUAAAdsIEIDYpiuoCAIIIIAAAggggED4CdAiTwECEE8RphFAAAEEEEAAAQQQQCBoAgQgQaOlYE8BphFAAAEEEEAAAQQQIABhH0AAAQTCX4AWIoAAAgggYBsBAhDbdAUVQQABBBBAAIHwE6BFCCDgKUAA4inCNAIIIIAAAggggAACCARNIMkCkKC1gIIRQAABBBBAAAEEEEAgZAQIQEKmq6goAgkWYEUEEEAAAQQQQMA2AgQgtukKKoIAAgggEH4CtAgBBBBAwFOAAMRThGkEEEAAAQQQQACB0BegBbYVIACxbddQMQQQQAABBBBAAAEEwk+AACT8+tSzRUwjgAACCCCAAAIIIGAbAQIQ23QFFUEAgfAToEUIIIAAAggg4ClAAOIpwjQCCCCAAAIIhL4ALUAAAdsKEIDYtmuoGAIIIIAAAggggAACoSfgq8YEIL6EWI4AAggggAACCCCAAAIBEyAACRglBSHgKcA0AggggAACCCCAgKcAAYinCNNBEajXuK0MHDYuKGX7W2i2/CVl+ddr/M0eEfkuXLggHbsPlGLlH5HMtxSTrd/tioh2J7SRgdiPf9m331gf/ONQQquRpOuFWn1dOG4j6zZuMeZnz55zmxtzdPKMd+SBmk/HnBnHVELPJ29MmyOV//eMqc+EKbPj2IJ9F7Xp2MecN+xbw4TXbPuuH0zfHDl6POGFJGLNQJxjPDf/9vzFUubBxz1nx5je++tv0uj5jnJbkcpy690VYixjAoFgCBCABEM1TMt8a+57cvOdZeTixYuuFuq4zvN843ZetHyzeoMrb2JH9OJYL5JPnDwVZ1H6pv5grYZx5rHDQj3Jf/LZV8lalY+t7X/0yXL5cN5UOfH7d1KiWOFE1ydU/BPdUAoIK4Gbc+WQ4kXvCWqb/j58VHoOGCEvd2glx37bKu1eaBrU7YVa4XY4d2RIn06qVCorqVKlDDW+RNV38oy5cvr0Wdm88kP57fvEf1CXqMqwckQIEIBERDcHppGVyt8vZ86clU1btrsK1PEc2bPK7j0/y+Ejx1zz127YIilTppQypYq75jFiPwH9FP62ArdK/ny32K9y1AiBJBR4rNZDMm5Ev6BuUY833UDlSmUkKoq3X7WwW7q9QD75YN4UuTHTDXarWlDrc/DPv6TIPXdJlpsyB3U7FI6AU4AzoFMi4K/hV6CemHPfnFPWrN/iatzaDVulcoUyUrFcKWv+t675a9Z9KxqwpE2bxjXv0qXL0qnHa3J3qepSpOzD8urQcTHupkx7a57Ua9xW8heuJKUeqCODRkxwLd//20Fx3tXQ5XonpFX7nq6ynSPvLPxIeg8cZR4l0jya3prznnOx/PX3EanfpK25xVyxen159/2PXct05PiJk9K11xC5r+KjkrdQeXmiYRvZ+f2PuijWlC1/SZn1zvsmr9Zt2JgpJu/nX66S/9V9VvLdU9G0Z+joyXLp0iWzrGSl2nLqn3/NLW+t4z331zDze7060swzE1cHWn/32+ejxs+Qh594TvTTwtJVHpOb8kYHeVoPvdUeV/uuFmlemrftZqw2WwGl1sG5jc+WrxS11ToVLFHNjHs+jqC365u90FU0T6H7HpIXO/eV7/f8InH5/3X4iClL+//O4g/Kc21ekd8P/mnqooPY2vXR0uXGVh21nlUeaSB/WG+Wuo63pA6e/fHvf6flteHjpcbjTU2/ahmLPvosxuq67/V5bVSc+2iMFayJlWs2iva5Z1nWIte/L1euNfvuLQXLyUN1msjO3T+5ljlHfvhxrzRu2UnUUm30ERf3O31at47dBkrDFh1El+vx03/w667jQ8vRfWv85Nmi+3Weu8qZbaqdLtPkfAzJWR/dv2s/9bx8u3WHLnYl5/LY6qvHg7PvtT8Kl64pX69a71rfc+T8+QvG/v7KdYz9o/Wfl7Ubrp0r/K2Xe7nLv15jjquLV+/G6v6oddFj15lv6OhJ5nzinNbX9Zu2Ghdvbff2CNaKb9aKGundSj0+9O7F6dNntCiTfJ1PTKarg+mz5ptt66RuX+urAYkvH83vbZ/Wc8Drb7ypi01q26mvaJmH/j5spvVxs+wFSon66gxfx7Xm0/U1nx4fue4oLavWbhI9dvQxzbtKVDXnbTXQ8uJKsR3LcZ1fYzt36HGg9dI74O7b1HPPgkWfuGZ5M3LWY+qb80T3v9uKVJbn23UXp5FrZbcRz0ewTPutY6/8Q08aXz22xk2e5bZGzNHdP/wsr/QZImUerGveZx57ppV8t/P7GJlGjJ1mzkU5b79ftG16LoyRwW3C8xwTl6FzNX1v0PdQPTfpOePkyX+ci7y+6nle78Zru7Q+2t+aUc8Njzd4wRxr+p6o7636IaQu06TnJX3P0vO/ngc0r84nIeCPQJQ/mciDgFOgSsWyss794sEaL1u6hJS9v7j1RnftomLVuk1SvkxJ52rmdb51sX/xwkUZPrC71H/8YdGT3fsffibOv1P/nJYu7Z+X7es/leGvdRcNdIaMesMszndrHvnqk3fM+K+7VpnHhaaOG2ym3QcN69eR1/p0MY8S6SNFmp5tXM+VZewbM6VYkbvljdED5a47b5PWHXvLr/t/dy1v0rKL/PPvvzJt/BDZtnapPPrwg9bFb2vRCwVXJi8jGnQ816Se/PDtcmnzfCPRR8/adx0gzzZ+Ur5dtUQmjRkoGzd/JwOGjDVr67xMN2SUudNfN23ZvelzM9/fwbYdu+XbbTtlwayJsn/3atdq096cL62fbyzfrVsqDZ967Lr2uTJaIzPfGCb9e3aU+0sWM3XY8NUH1lyREydPyuO1asjqzxfIu7PHS5rUqaVpqy5y5coVs1wfI6nxWFPJkD69vD9nkqxd8Z5UsALQU//8I7H567pPN31JfrCClEVzJ8sXH75tgognGrUW/R6KKdgaeLbrn3//kxYvdpdn6j1q2rRtzSfybMMnxeFwWLlj/zfMCgLd++P8+fOSJk1aGTOkjynnxZZNpOeAkdd9J2juux/J/fcVlTVfLJTRQ3rJzLcXyvtu+6j7Fpd8ukKatOwsMycNkyfq/M99kWt83/4D8nSz9nJfsXvNft2t0wvSd9Bo13IdUc/Hnm4pxe69R5YsnCGffzhbbrwxozzVrJ1cvnxZs5g0d8GHUrpkcdn0zYfy+rA+8q518TVy3HSzTAfDX58iH326XAb07iS7N38u3Tq2Fg1S9IJSlzvT7HcWy6hBPWXj1x9I3jy5rX2kl6tv/alvtz7D5JY8uWTZ4rdk386V5nhLly6ts/jrXvsNHiPT3npXhlnHve6Xhe66XR575gX56Zf9MfLGVa8YGa2JsveXkP+sQMB5UbrWuuOaPVsWK7DZbC2N/rdu41YpV6Zk9MTV4fDXp8oTtf8nY4b2kTNnz8Vo+9Usrhc9hvUCq3rVSrJ55UfyzsyxkjVLFrlwNejRjL7OJ5rHmZ5v9oy130d/5+P3PetEz015cucSf308zzHly5SQ9RuvfRi0ev1mMQbrvzWb3LB5m6RJncrszzrD13GteTSNGj9dRr7WQ37/Ya05j/ayjpMl1ocAb00eISuWzLE+xDkqX1qBmeaNK3key5q3SRzn19jOHbqev8nTSNfTeugHFgtnvyEfzJ8ie389IENHTdZFfiXt419/+12mTxgmB39cJ/PeHCt5bs4R67onT52SIoULWefmCeY8UrVyefMe4gx6NMCfZn3YNrB3Z9m3Y6WsXPaulLbOwd4K9HaOictQy5j//hLzwVKHts/J1jUfS7n7S8r4OAImXWfP1hXyv4cekA5tnjX75evW8aHveXWebiW5cmQ372ETRg2QedYHfF17xXzf1XPk7bflk1VWO2ZPHaXFkRDwS4AAxC8mMjkFype9T9Zab3r6yaOmNVYAUr70fVLWuiDQux6aTy8s9ORVsVzMN/+ihQvK+JH9pfbD1aRv9/byUJXysvHb7bqKSV1eaiHlrLL0wrzqA+VFL9bmLvjILAvU4Jl6daT3Ky9ZgUVVmTpukOi2vt22wxSvnzTpBc1E60RbskQR62IjszRv8pTcV7ywvP/RMpMntkHD+rVNu9Jad3y0zDETZ0rL5xrIM0/WlmxZbxK9yO/ZtY25oI2tjPjO14tQfXRKt+dct3nT+lLNesO7KfON0rZlY8mRLats+W6nc7Ffr1rnR2pWMbfiixe5x1yI68WMfkqvBbxp3VHSxxPGjegrdxe83eTTi4e4HrfTizm9EBg3sp9ZR+s9bkR/+fHnX2Xp599osa7k3q6jR4+bAKWiFeBkvjGT6HrPWgGlPq/vWsHLiGd/6GMFL3doKYXvvtPUt37dR+TZRvVk/ntLxP3voQcrmCBK81d/sKJUq1JBNm2J3j80n8Y9DodD5r33kXR45VV5d9Z40X1Vl3lLc+YvNheFQwe8bLarZTas/1iMrPoGXvTegqL1u/P2fFIgX14Z0v8V2WXdKdH90Zm5lLVPdrQuKtRB+1iDKP1eli4/d+686KfhA63gQ5dp//yv+gPSzGrjrHfe0yyu1LPri9Y+fa+o4Uutm5pAQO9OaQZ/6vvnob9E94u8t+SWm6z9rG7tGrE+aqmflk6ftUC6tm9lnNRVLXLfnENmzJ6vm3SluOrlynR1JGOG9KKB4uqrF9vrrABEL/D13KMXemet4EKDEr1Iv7qKeenXo71om+s9/rAM6dc1uu3WXVGz0GOgx3AD63zRvnUzyZE9q+gdYD1Hqa0z6zPW8tjOJ848cb3Gx8dzn9bg6hvrDpyehzVwPHzkqLVPP2kFYVvNJtdZ52k9L+ujsDrD13GteTR179xaSllBuHO92fMWSY8ubUQ/UFIHPT7/O31as8aanAs0rx6zeo5KzPnVWZ6vV08jza/7qH7QovUoagUG8ikC8wAAEABJREFUjZ6qY73vbNNFfqU/Dx2WAvnzyj2F7jAfujxQobQ8+djDsa6r72FNnqkr+qGZHiN6UX/vPQVl6bKvzDpanh4HGnSkT59OtE76oZVZaA2s04v5gMXbOcYfw1lzF5kPRLQO2nbd3++26m4VHa9/2u96nI0Z2tu8h2n/9+n2kugHIe6PW5coWlg6t2thzm/az/HaCJkjWiAqoltP4+MtULFsKdE3Tb0g1aQnUj2x6xvdnp/3id4eXrths+gnonqB4L6Buwve4T5pTtBHjh5zzdPHIxq26CCFSj5kbks/Zt26PvTXYTltfdLpypTIkXsK3ekqQd9gb7Uuoo5YF7k685e9+61PVU9Ltvwlzfb1VrSmz75YKe53STSvZypepHCMWXt+2iv6q1+6vjPp4zd6O//PQ3/HyJuQiYLW3Rv3CyFnGblvzukcNa85c2SL8d0cM9PH4MDvf4g+7qO38LXu2QuUMo+OHTj4h1nz572/igZo6mdm+DHY++tvkitndiluBTTO7AXvLCCa9AcLrs27TdzbpftWBWufq27dcdFHP6ZZnxzq43jO/LG9FvfoD82nb+i16rUwj0Vou/QRnQO//6mLXCmPh1/2bDdZfkddy/UmkD7W1P7lV0U/TdX93rXQy8i+/QfNo4ipUqVyLa36QFnXuI5o+7/4ak2MfU4fq9OLvH1ud+eKFL5Ls7uS3slzHh+aT4MQfeRP2+ZM/QaNkX2//u5aR0duyX1tH8luBag6z3lBsc+P+tazLt51/9DHLsZOeku2WHfitAxv6dffDpoAUgM753Ldbx58oJzs3febc5Z5jateJoPHQIOLddYHIDr769UbrACnrHWRfJ+sXrtZ9NyU2jL3PAcVvvuaYX4r0NN1D7udg3TamfQYLl2yqHPS62tc5xOvK3jMjI+P5z6t+97Fi5fMndA1ViBW2bowrljufllt3X3Wzay1gjINUnRc0wEfx7Xm0XSf2w9R/HbgD3N3rHLFcrrIpBsyZjCP3JqJOAae56jEnF/j2EyMRZ5GujBvnpv1xZWyZc0qetfRNcPHSN06NWX2O4usO5ntRB+d+tT6wETv6Ma2mr5f6eO2VR5uIHru1GNRP4A5cPVcox9CaLD44CMNzaOJesdCH8d1lhfXOcYfQz2uKlcs7SzOvOqX6s1IPAa/WMdnpQr3m/dy52padx3X87m+aipe9G59IdlHIGRqQgASMl1lj4rmz3eL9UngreZTtjXrt0iVimVMxdJan/yXtm4jf71qg+ib4QPl7zdfQjcLrw5SpkxxdSz6xeFwWCPRj/XoRVj9Ji/K00/UlmWLZ8nR/Vtk6fszreUi5y9cMK+BGHirg57wtWyHw2E+6dRHIzyTPo6jeWJLadOlibHI4XDIqME9xbMcndZPnmNkdptwONTEbYY1evHSRWsY81+6tGljzrg65e2Lrc72Xc0S54u+sepjUXrhPXfGWPnrl02iv9ajF9AXzl9fjzgL81ioZXjMkhQpYu4T3tr1/pw3pE+3dpI2TRrrzsPHUqZqXesia7NnUTGmPftDv+ujj2f07f6SefRI+0E/ufbct6KirvcXid5HdQPaPaVKFJN8eXOL3i3Qeb5SSo826gW4+zoOh8N8oqp18kx6se+e19u4tsHhiK73uhXvX7fPrf9yUYzVvO8j19roq756p2LmpOFya948snb9ZqlWu7GMnxz9aFGMDblNeLY5ZYqUbkujR33VKzrXtWF5KzBdtW6zuYvx77//mceF9NPndRu3yjrr0/9ypUtcfw5y6wuHI9pM9/lrpXqMRWfxmHltMq7zybVcvsf88fHcp/XTaQ2wNNBYa52Ly5a+z9yJ1gtHDdLXWQ4VrDvWunVto7/HtbdjMGXKKC3GlVJ4nMtdC9xGPMtxOBJ2fnU4vHfCJSv4ctucGfU00pnx3a90HfekdxS//GSuaDCnH7680KGn+S6Wex73cX20c9uOXTJ+VH/5cesKczxqGXqcaj69i7Rq2QJpaN2J+c/6cG3IqElS5eFnXEGRNje2c4zD4Z+h53nV85jWeviTPMvx1u/prPd+f8oiDwKeAjHPKp5LmUbAi4B+yrbO+nRtnb7Jl7nPlaNc6eLWG/+3JgDRiwPXAj9GtmzbZd3mzSL6SzR661pPfDt27YmxZhrrAlRnuD8Xr9OeKW3a1HLl8rULKs/lsU0XvOs28ybg/thLbHl9zb/Hutvz5cp1cWbTN+jLV64946+Zs2XNIseOndRRV/rhx32u8WCP6N0ZfYyl4VOPmbsTadKkll0//GQ+xXZu+47b8ptPvS+6PQvvXKavab3435b/VvOFcy1f82jSO096saSPtuh0bCmt9Qanj4/07d5evvx4rpQsXkQ+Wx7zsa3Y1nXOX795m1QoU1L0MbFc1p0Ynb9j1w/6Eu+U++bs8uH8qfL5l6vNl03jKqBAvjyyfWfM7Xy34/sYqxS883brmNls7izGWOAxsWPXjzHmaDk5s2cTfSTr9gJ5zSeVK75eGyNPfCf8qa+WWbNaJdFHJN+dNUG6tn9eFn+8TGdfl/LfmscEmdt37o6xTB8LvK3ArTHmxXdC+/KidRE6cdps0UdD9SK+QtmSxlIvyvWCMb5luucvaN1l3OT2iKj7skCNJ9anfJkS5jt536zZIJXKlRI9XtVgzBszRe8A6WN7Wlc97nwd15rPM91qBdoOh8Pah6+di/XHDrZ+F7M/PdfzNu3P+TWtl3OHPtajd9SPHj/hKlYfs3M+NuiaGcSRYvfeLfr445Sxg+StKSNE74KcPOX9i936vvjo/6pJkXsKmkcU9c6knkPdq6d3qls918A8arlu+fvym3V3ZLPbo56xnWP8MdTjaufua/2l292egHPd7dbx6Xnu2rotut/1fK7lkhBIjAABSGL0InRdfYPb+O020Uem9JEsJ0OZ+0vIhx8vN1/Y1jdD53x/XvXRiD8O/SU7rp44nb/I4b5u3ltuNm+wO3fHvBBzz6PjBayL3d9+/0P011N02t+kn57qJ1UvdukrX65cK/ocub7RTZgy27TV33I0n36ZXtswZNQboo9vadCkt+H1U3hdrkm/uLfr+5i/iFS6ZFGzLWcQtPuHn+WTZV9q9iRJ+shWnty5ZMXXa8z2dPv6uI0GhGaGNXiucT1j2/7lV80vXx2zLgz0F2z0sRdrsXjz1+emixW5Wzq8MkD2/LTPmHTu8Zq5k/Bw9cq6mtf0/Z6fZdT4GSZ40Qxq+cve/VLAuhOn0/6mIvfcZR5V0brql95HT5hhBRCr/F39unxq9OG8qVbffB1nENLo6cflh5/2ivb7RStg27xlu0yaMTdGec2b1DPTLdv3EL1Q0H1F262/Eud+kaPfodFHnnS/XvHNWpk47W15rkl9s65efOv3LLRd2hfaTn1U8r0PPpU570b/uIDJ6GPgT331l3C2XH3sSn8kQL8jU+Dq40xavHvSC8dWzz0jQ6xPeddYd0u0XsNfnyo7rA8XWj77jHvWeI/rHQC9wNYvxlYoU8qsr3cEft673zyCpRfnZmYCB51ebG5+1W3c5Fnmgwm9S6v7onufJLBo12qJ9Slr3fXQ74H8999pcf4fJnoeU5NybneA/DmuXZVyG1Hjpg2ekMEjJ5pjXc+JfV4bbR61dcvm16jWy9f51du5w+FwiH7P8O15i0Tv5GgANHLsdPF2R9WvisQz08Spb8uyFavMY6i67ZWrN4p+iKGBkbeiihQuKPpdDT3e9UOWNp36iPs+8+Eny0V/rVAfx9X1V67ZZH7NrkD+W3TSlbydY/wxbNboCZn77oei7z9i/emjp59b9bdG4/VPv0Oij+DpeUjboT+iMnD4OGlkfTiVPVuWeJVFZgS8CRCAeFNhXpwClSuVET15Or//4cysJ8cjx46bZ/hLuD1H7Fwe1+s9he6QiaNelbYd+4j+fOGoCdPl1V4dY6yizx7rRUGdp1ua5+X1p2JjZLg68WClslL03kKSv3Alk09/xvbqIp8vs6aOkhpVK0nP/iPl9qJVpMFzHaw3kw2SMWMGic+fWixZMF30S/ZVH20kd5esbl1IT5fz58+5innphWYyceps0WeE9ScldYF+0a9fjw7SyroY1fmvjRgvbZ5vrIuSJGmgMXf6GNE3yXLVnpRnnmsvr3R8QfQ/53JWQB8h+HjhTPNrYXUbvmD+59wxVn/pFyo1jzd/fQxi/pvjLMeM8niDVlL9sSbmi5bvvT1JUqdOpat5TenTpZNvVq+Xe8v8zziVfKCO1HzoAdEvkHtdIZaZmr9WzSpS7dHGUrpKXdEgttOLLWLJHftsfZxNL4I0h96p++jdqfLR0hWxBiG3WcHwwtkTzB2b0lUel9Yde5s7B7q+M92U+Ubz2KG2tUnLzqL7beceg0TvDqVKee1RpeZWsLHD+iRTl2tQ+MyTj0qXl661oXO75qKPmOmX2ouUeVgq1XzKBB/ufefcZmyv/tRXf3r2kXrNRfdP/TlZDZg8j1X38gf07CSPP1pdOnZ7VYqVe8Q6njZad5CmyO0F8rlnS9B4eesOgH7CrB+KaAFp06Yx30/QR7w0GNF5CU2VK5aRBVbfffr516LfhypZqY7ZF937JKFlu6+XGB/9Hshl625vhXIlzZ0mLbe8dVdaTcpZd/x0WpM/x7Xm85YG9esq5axAp26DF6RstSfMhXidRx7yltXnPF/nV2/nDi106Kvd5dz583JLwfLmO4La30l1EXzp8mVpZ30olTXffaJJPxDSX0l0OLw/Gja438vm1+v0Z3sf+N/TonfSqla+9h2ajBnTW+f9t622lDPHUOuOvWTEa93F+R1JX+cYH4bmh0+6dWptfl2teIVasmDRUunU7tp5Qj39SbfkuVk+XjhdNm/dYX6WXutZrUp5GTmopz+rkwcBnwIEID6JyOApoI996LPquzbGfOxCPy3T727oz8I6HDFPzu+Z5/jbxyhq6IBuMmvKKNe8eo8/LKs+XyAbvlos+qiN/tKIbkcfMXFm6t65jeg8Td5+hlfz6cXuB/OmuPLprybp/CO/fisPVamgo660ctm70rpFQ9e0tkF/MUWfmz/44zr56pN3rIuQiXKv25dXXZmvjngrVxdVKn+/LH5nsuzd8Y3ozxx+9O406dPtmsHDNSrLgR/Wmnq6/wxvx7bPyaZvPjLz35kxVvRXeJw/kavl6kXnp4ve1NEYyVs9PNsXYwVrQrf1xYcxn9/XT1I1eNLvE2xft1T0cZvfvl8jtf73oLVG9L9Cd90mb08bbX52WPtC61vknoJmYWz+uXJmF/3p3+83fyE/bfvK6vuRoo94mJWsgbd2RV/kTzMWuh3dv8YO7+u62LJWu+6fNwetk9rrz1Jq0nq80rGV6V9nAf7so5559CJaf3p5+MAezmKue9UvgOp+tGX1x+bnXPUne7Ut+gmnM7O2U/fn79YuFbXW/p01ZaQ4gzrNlzZNapk+Yaix2LH+U9FA1f1TYIfDIRgc7gUAABAASURBVBpoLf/obfNzofrTsXoc1K1dU1cXvYjU7epFuplhDfQX2nSe/hKPNWn++aqvXnwd+nmjqYeuq/u1e1tMIW4DDTD1+za6j+j+rhc15d0ujv2tl1uRrlHtU62D+wce2mY9dvWukDOjP9vQ84AeL8519FW/dKt9oX2i29G2OvvE236m62s5uq63pL+Gp+Xoeca53JeP5vO2LZ2v5Rzet9n8nLdOa9Lzjm5DjyeddiZfx7U3I11Xt6G/ZvXDluWiP4M9zAoG9FEk/alWXe4t6bbVzXOZlhXX+VWPU+0/rb+mZ627rVqG/jrc/DfHm/1azx11a9cQPWc+9UQtXWySNyNv9dDHfH/ZHvsjnHos6Lb12NCC9fyr29R5mnQ/VmNd5i3pBzR6nG78+kNTR31UUX9ufVDfriZ7tcrlRd9ftCxNv+5aJS2fbWCW6cDXOcaXoZbR7oWm5lyj/aXvQR3aPCvu7yGaxzPNf2u8DOjVKcZsPa50n9f9X89fA3t3MY96OjN51tU5n1cE/BEIvwDEn1aTBwEEEEAAAQQQQAABBJJFgAAkWdjZKALhKUCrEEAAAQQQQAABXwIEIL6EWI4AAggkswCPOiRzB4TG5qklAgggEDICBCAh01VUFAEEEEAAAQQQQMB+AtQovgIEIPEVIz8CCCCAAAIIIIAAAggkWIAAJMF0rOgpwDQCCCCAAAIIIIAAAr4ECEB8CbEcAQQQsL8ANUQAAQQQQCBkBAhAQqarqCgCCCCAAAII2E+AGiGAQHwFCEDiK0Z+BBBAAAEEEEAAAQQQSLBAwAKQBNeAFRFAAAEEEEAAAQQQQCBiBAhAIqaraWgYC9A0BBBAAAEEEEAgZAQIQEKmq6goAggggID9BKgRAggggEB8BQhA4itGfgQQQAABBBBAAIHkF6AGIStAABKyXUfFEUAAAQQQQAABBBAIPQECkNDrM88aM40AAggggAACCCCAQMgIEICETFdRUQQQsJ8ANUIAAQQQQACB+AoQgMRXjPwIIIAAAgggkPwC1AABBEJWgAAkZLuOiiOAAAIIIIAAAgggkPQCid0iAUhiBVkfAQQQQAABBBBAAAEE/BYgAPGbiowIeAowjQACCCCAAAIIIBBfAQKQ+IqRHwEEEEAg+QWoAQIIIIBAyAoQgIRs11FxBBBAAAEEEEAg6QXYIgKJFSAASawg6yOAAAIIIIAAAggggIDfAgQgflN5ZmQaAQQQQAABBBBAAAEE4itAABJfMfIjgEDyC1ADBBBAAAEEEAhZAQKQkO06Ko4AAggggEDSC7BFBBBAILECBCCJFWR9BBBAAAEEEEAAAQSCLxA2WyAACZuupCEIIIAAAggggAACCNhfgADE/n1EDT0FmEYAAQQQQAABBBAIWQECkJDtOiqOAAIIJL0AW0QAAQQQQCCxAgQgiRVkfQQQQAABBBBAIPgCbAGBsBEgAAmbrqQhCCCAAAIIIIAAAgjYXyD0AhD7m1JDBBBAAAEEEEAAAQQQiEWAACQWGGYjgMD1AsxBAAEEEEAAAQQSK0AAklhB1kcAAQQQQCD4AmwBAQQQCBsBApCw6UoaggACCCCAAAIIIBB4AUoMtAABSKBFKQ8BBBBAAAEEEEAAAQRiFSAAiZWGBZ4CTCOAAAIIIIAAAgggkFgBApDECrI+AgggEHwBtoAAAggggEDYCBCAhE1X0hAEEEAAAQQQCLwAJSKAQKAFCEACLUp5CCCAAAIIIIAAAgggEKuA3wFIrCWwAAEEEEAAAQQQQAABBBDwU4AAxE8osiGQjAJsGgEEEEAAAQQQCBsBApCw6UoaggACCCAQeAFKRAABBBAItAABSCJFU6VKLST7G1y4cFFSpEhJX7G/sg8EaB9wnjo5/9n//EcfhUYf6XvUxYsXOUe5n6NsPO48B/KaMAECkIS5sRYCCCCAAAIIIIAAAggkQIAAJAFoSbwKm0MAAQQQQAABBBBAIGwECEDCpitpCAIIBF6AEhFAAAEEEEAg0AIEIIEWpTwEEEAAAQQQSLwAJSCAQNgKEICEbdfSMAQQQAABBBBAAAEE4i8Q7DUIQIItTPkIIIAAAggggAACCCDgEiAAcVEwgoCnANMIIIAAAggggAACgRaImABkwQfLpHHrHtK0TS9ZuW6LV8cjR49Lu1cGS/OX+krPgWPlzNmzJt/xE6eka5+R8uBjLWT4uDfNPAYIIIAAAkEUoGgEEEAAgbAViIgAZP+BP2X2/CUyZXRfGd6/kwwaNVXOnjt/XaeOnTJXypYqJjPHvyqZMt0gcxcudeV5pMYD0rLJk65pRhBAAAEEEEAAgXAUoE0IBFsgIgKQ1eu3SOUKpSRD+nSSK2c2KXRnAdm0Zad4/q3ZsE1q1ahkZteqXklWb9hqxm/KnEmqViot6dKlMdMMEEAAAQQQQAABBBBAIGECERGAHD56THLnyu4SuiV3Tvn7yFHXtI78d/qMOBwiGmzodN48OeXwkWM6Gme6fPmykAJvcOXKFSEF1oD9lP2UYyqwx1QwPDlOOU6DsV8Fo8xI31fjvDhkoU+BiAhAVMERda2pDocVaehMjxQVI8+1/B7ZYkyeO3dWAp3eff8jGThsbESnAUNel0CmoaMnGc9AlhlqZQVjnwr0vu8qLwjHVTDKPnPmtERqOnfunHXuOxex7Q9Wv58LkX0/lOoZrL4KdLlnz56RCxcuhMwxFUr7QDDqGuNikIl4C/h3lR3vYu21QvasWeTEiZOuSh07fkJyZMvqmtYRfTzr0qXLct46+HX6qJUne7YsOhpnSpcuvQQ6ffzZVzL89akRnUaMnSqBTKMnzLDKm2alwJYbyDoGu6xg7FOB3vdDrbz06TNIpKa0adOKpkhtf7DabYdjINzqEKy+CnS56p46deqQOadofSM5xXlxyEKfAhERgFQse5+sWr9Fzp0/L8eOn5Tde/ZKmVJFDM7W7d9bnzhcNOPlSxeX5V+vM+Off7VWKpYpbsYZIIAAAggggAACCCAQZIGIKT4iApB8eW+WurWqSYv2/aRjz+HSqW1TSZ0qlenkV/qPkZOn/jHjHVs3kiXLVpqf4f3twJ/SqH4tM//ipUtSrmZj8xO8iz9ZYcb3/LTPLGOAAAIIIIAAAggggAAC/gtE+Z81tHM+9XhNmTN5iMyeNEgqly/paswXi6ZKtqw3mWl9nTSyt/kZ3sF9Oki6tGnN/JQpUsi6ZXNipIJ3FjDLGARBgCIRQAABBBBAAAEEwlYgYgKQsO1BGoYAAggEUICiEEAAAQQQCLYAAUiwhSkfAQQQQAABBBDwLUAOBCJGgAAkYrqahiKAAAIIIIAAAgggkPwC9gtAkt+EGiCAAAIIIIAAAggggECQBAhAggRLsQiEogB1RgABBBBAAAEEgi1AABJsYcpHAAEEEEDAtwA5EEAAgYgRIACJmK6moQgggAACCCCAAALXCzAnqQUIQJJanO0hgAACCCCAAAIIIBDBAgQgEdz5nk1nGgEEEEAAAQQQQACBYAsQgARbmPIRQAAB3wLkQAABBBBAIGIECEAipqtpKAIIIIAAAghcL8AcBBBIagECkKQWZ3sIIIAAAggggAACCESwgCsAiWADmo4AAggggAACCCCAAAJJJEAAkkTQbAaBOARYhAACCCCAAAIIRIwAAUjEdDUNRQABBBC4XoA5CCCAAAJJLUAAktTibA8BBBBAAAEEEEBABIOIFSAAidiup+EIIIAAAggggAACCCS9AAFI0pt7bpFpBBBAAAEEEEAAAQQiRoAAJGK6moYigMD1AsxBAAEEEEAAgaQWIABJanG2hwACCCCAAAIiGCCAQMQKEIBEbNfTcAQQQAABBBBAAIFIFEjuNhOAJHcPsH0EEEAAAQQQQAABBCJIgAAkgjqbpnoKMI0AAggggAACCCCQ1AIEIEktzvYQQAABBEQwQAABBBCIWAECkIjtehqOAAIIIIAAApEoQJsRSG4BApDk7gG2jwACCCCAAAIIIIBABAlEcAASQb1MUxFAAAEEEEAAAQQQsIkAAYhNOoJqIBBRAjQWAQQQQAABBCJWgAAkYruehiOAAAIIRKIAbUYAAQSSW4AAJLl7gO0jgAACCCCAAAIIRIIAbbwqQAByFYIXBBBAAAEEEEAAAQQQCL4AAUjwjdmCpwDTCCCAAAIIIIAAAhErQAASsV1PwxFAIBIFaDMCCCCAAALJLUAAktw9wPYRQAABBBBAIBIEaCMCCFwVIAC5CsELAggggAACCCCAAAIIBF8g6QOQ4LeJLSCAAAIIIIAAAggggIBNBQhAbNoxVAuBYAhQJgIIIIAAAgggkNwCBCDJ3QNsHwEEEEAgEgRoIwIIIIDAVQECkKsQvCCAAAIIIIAAAgiEowBtspsAAYjdeoT6IIAAAggggAACCCAQxgIEIGHcuZ5NYxoBBBBAAAEEEEAAgeQWIABJ7h5g+wggEAkCtBEBBBBAAAEErgoQgFyF4AUBBBBAAAEEwlGANiGAgN0ECEDs1iPUBwEEEEAAAQQQQACBcBCIpQ0EILHAeM5e8MEyady6hzRt00tWrtviuZhpBBBAAAEEEEAAAQQQ8EOAAMQPpP0H/pTZ85fIlNF9ZXj/TjJo1FQ5e+68H2uSBQEjwAABBBBAAAEEEEDgqgAByFWIuF5Wr98ilSuUkgzp00munNmk0J0FZNOWncIfAggggIDdBagfAggggIDdBAhA/OiRw0ePSe5c2V05b8mdU/4+ctQ1zQgCCCCAAAIIIICAhwCTCMQiQAASC4znbEfUNSqHw+FaXOrB+uIr1a5dW3wl9zJ++OUPKXR34etSgTxZxFfytp7nPF9l6HLPdbxNaz5fydt6nvO8lZE/903injzX8Tbtnj+2cW/rec6LbV33+Z7reJt2zx/buLf1POfFtq77fM91vE27549t3Nt6nvPc161Vq5Z4S+77c2zj3tbznBfbuu7zPdfxNq35S1apL3GmirWkpK/kqwxr+X0VHhFfKc56WGXocl9l6HLN5ytpPl/JVxm63LOMMlUeF03u8zWfr+SeP7ZxX2Xo8tjWdZ+v+Xwl9/yxjfsqQ5fHtq77fM3nK1Wt/ojXY8p9v9b92Vdyzx/buK8ydHls6+p81/FydZ+Ns22+ji1dHuHl3P9AbalY3TpPqYW3ZDcf6/qnpI9UqtKj4iv5KkOX+ypDl2u+2JLuy5p8XYvpcs3nK2k+14UgIwkSiErQWhG2UvasWeTEiZOuVh87fkJyZMtqppe9P1V8JFmwYIHP5F7G54umyueLpl2XNq1ZLr6St/U85/kqQ5d7ruNtWvP5St7W85znrYxv130p7umLxdPFV3LP7zm++stPjJ2vMnS557repjWfr+RtPc95vsrQ5Z7reJvWfL7SlvVfia+0/IMZ4iu5l7Fo0SLxlnzVRZd7W89znubzlTzX8Tbdpf3zcujY6bjTKZFDvpKvMqzlf/3jEF/JZ10oJ+6+CmOflzq+7PWYct9Rvo2gAAAQAElEQVSvfR0Tutw9f2zjms9Xim1dne86Xqz+8LlP+zq2dDnlxH0OspvPUeuc6iP9efKK+EqHfJShy32Vocs1n7dUtMi9ruu0+F6PuV+buY9rOeYikEGCBQhA/KCrWPY+WbV+i5w7f16OHT8pu/fslTKlipg1s2a5SXyldOnSia/kqwxd7qsMXa75fCXN5yv5KkOX+ypDl2s+X0nzeaa0adOKe8pyU2bxldzze46nSZPGlOerDF3uua63ac3nK3lbz3OerzJ0uec63qY1n6+kBr7STZlvFF/JVxm63FcZulzz+Uqaz1eKu4w0osszZkhvjlcGCNhdIFWqVGaf1f02tuTrmNDlsa3rPl/z+Uru+T3H7W5J/RBQgdSpU7uu0zyvNbxN+7pm0eW6npZNSrgAAYgfdvny3ix1a1WTFu37Sceew6VT26aS2nqT8GNVsiCAAAIIIBCZArQaAQQQiEWAACQWGM/ZTz1eU+ZMHiKzJw2SyuVLei5mGgEEEEAAAQQQQAABWwjYvRK2DEAuXb4sf/51WL7btUd+3vubnDz1r90dqR8CCCCAAAIIIIAAAgj4IWCrAOSvw0dl4Mip8lDdltK680AZP/Ud6TN4vNR7trM81byLLF2+yo8mkQUBpwCvCCCAAAIIIIAAAnYTsFUA0r77ECle5C5Z9t5k+XDuOJk+doDMmz5Cvlg0VYb16ywbv90pcxZ8YjdD6oMAAggg4CnANAIIIIAAArEI2CoAmTl+oNSuWcXrF7wL5Msj/bu1kbqPVo2lKcxGAAEEEEAAAQQQQAABuwvYKgDJkD6dTy9/8vgshAwIIIAAAggggAACCCCQLAK2CkCcAqvXb5WWHQdIpUeaSbmajV3Judy/V3IhgAACCCCAAAIIIICA3QRsGYDMmLNIurZrJl9//KasWzbHleyGR30QQCAWAWYjgAACCCCAAAKxCNgyAMmZI6sUvCO/pIiyZfWEPwQQQAABBOwqQL0QQAABuwvY8go/a5bMsujj5fLvf6ft7kf9EEAAAQQQQAABBBBQAZKfArYMQBYtWS4jxr8l1Z9o5fr+h34XxM82kQ0BBBBAAAEEEEAAAQRsKmDLAMT9ex/u4zY1pFqeAkwjgAACCCCAAAIIIBCLgC0DEK3rlStXZO+vB03ScZ1HQgABBBCIW4ClCCCAAAII2F3AlgHIh0u/NI9fte8+RDTVePIF+eizr+1uSf0QQAABBBBAIHIFaDkCCPgpYMsAZM7CT6R/t7ayZN54k/q+3FrefneJn00iGwIIIIAAAggggAACCNhVIPABSABamjJlSqlYtoQ4HA6TKpW7T6KiHAEomSIQQAABBBBAAAEEEEAgOQVsGYCkSBEl6zZ953JZvX6rpE6d2jXNCAIIeBdgLgIIIIAAAgggYHcBWwYg3Ts0l5ETZrl+gvf1yW+LzrM7JvVDAAEEEIhYARqOAAIIIOCngC0DkHvvvlPee2uUzJ0yzKSFb46SwoXu8LNJZEMAAQQQQAABBBCIHAFaGmoCtgpANm3dKf/+d1r0dfO2XXL0+HGTdFznhRou9UUAAQQQQAABBBBAAIGYArYKQGbMWSx/HT4q+uotxaw6U54CTCOAAAIIIIAAAgggYHcBWwUgk0f1kdvz5xV99Zbsjkn9EEAgYgVoOAIIIIAAAgj4KWCrAMRZ59ZdBjpHXa+NX+jhGmcEAQQQQAABBBCIFmCIAAKhJmDLAMQT8b/TZ+Tc+fOes5lGAAEE/BKoXaOSHNz+CSmABr9+u1g04RrY/erRGhX92qfJhAACCNhCIIGVsFUAMnXWQvPTu9/t3GNey9VsbF4bt+4hTzz6UAKbyGoIIIAAAggggAACCCBgFwFbBSCtmtWXdcvmSL06NcyrjmtaPPt1afDkw3Yxox4IeAowjQACCCCAAAIIIOCngK0CEGedu7zY1DnKKwIIIIAAAnEIsAgBBBBAINQEbBmA/Pb7IenYc5hUqd3cPILlfBQr1HCpLwIIIIAAAgggELYCNAyBBArYMgB5dcRkqf2/B6XQXQVkyTvjpd3zDaRF47oJbCKrIYAAAggggAACCCCAgF0EbBmAnD17Tqo9UFouX74s2bLeJI3q15K9v/5uFzPPejCNAAIIIIAAAggggAACfgrYMgBJnz6tqb7D4ZADBw/J2XPn5djxU2YeAwQQQOCaAGMIIIAAAgggEGoCtgxAit9bUE6c+kcaPPGINGzZTR6s01yqP1g21GypLwIIIIAAAuErQMsQQACBBArYMgBp2+IZyZzpBqlSsZSsWjrL/CTvk7WrJ7CJrIYAAggggAACCCCAQPgIhHpLbBWAbNq6U+JKoY5N/RFAAAEEEEAAAQQQiHQBWwUgM+YsFk3jp86T9t2HSu9BE2Tw6OlmfPQbsyO9r2j/dQLMQAABBBBAAAEEEAg1AVsFIJNH9RFN2bNllhEDushnCyfJ4rdfl+lj+0u+W24ONVvqiwACCISvAC1DAAEEEEAggQK2CkCcbfjr72NSsWwJcTgcZlbhQneYVwYIIIAAAggggECkC9B+BEJdwJYBiCPKIes3f+ey3fPTPjlx6l/XNCMIIIAAAggggAACCCAQmgK2DEB6dW4poybOlkeebiv1n+sifYZMkE6tG3sIM4kAAggggAACCCCAAAKhJmDLAKTQnQVkwcyRMmFYLxnWr7M1PkoKWvNCDZf6IhC2AjQMAQQQQAABBBBIoICtAhD9Cd5//zttfop387ZdcvT4cZN0vqYEtpHVEEAAAQQQCBsBGoIAAgiEuoCtAhD9Cd6/Dh81P8Wr454p1LGpPwIIIIAAAggggEDIClDxAAnYKgDRn+C9PX9e81O8Ou6ZAtRmikEAAQQQQAABBBBAAIFkErBVAJJMBmw2vgLkRwABBBBAAAEEEEAggQK2CkAqP/qcxJUS2EZWQwABBMJGgIYggAACCCAQ6gK2CkC++fhNiSslBnvBB8ukcese0rRNL1m5bovXoo4cPS7tXhkszV/qKz0HjpUzZ8+afMdPnJKufUbKg4+1kOHj3jTzGCCAAAIIIIBARAnQWAQQCJCArQIQ9zZduHBRdn7/k/lFLP0FLE3uy+Mzvv/AnzJ7/hKZMrqvDO/fSQaNmipnz52/roixU+ZK2VLFZOb4VyVTphtk7sKlrjyP1HhAWjZ50jXNCAIIIIAAAggggAACCMRfIP4BSPy3Ee81Vq/fKk807Sgdew6XEePflPbdh8qEafPiXY5zhdXrt0jlCqUkQ/p0kitnNtH/Z2TTlp3i+bdmwzapVaOSmV2reiVZvWGrGb8pcyapWqm0pEuXxkwzQAABBBBAAAEEEEAAgYQJ2DIAmThjvkwb21/uuO1W858QvjlhoDWeL2EttNY6fPSY5M6V3RqL/ndL7pzy95Gj0RNXh/+dPiMOh4gGGzorb56ccvjIMR0lIWAbASqCAAIIIIAAAgiEuoAtA5CUKVNIrhzZRB/DUmC9Y3H6zGkd9ZomzpgnrToNuC7NX/SZK78j6lpTHQ4r0nAtuTYSFSPPtfzXclw/dsaqF+m02N3gwoXzcvbsGdvX0+6O1M/++3pS9dG5c2dFU1Jtzwbb4fzh8X53/TsicxCwn8ClS5eCcuzar6WhVSP/rrKTuE3p06U1W8x8Y0b5cOmXsnr9Vjl+4h8zz9ugeaO6Mmpg1+tS3UermuzZs2aREydOmnEdHDt+QnJky6qjrqSPZ126dFnOX7hg5h218mTPlsWMxzVInTqNkOxvkCJFSkmVKjV9xf7KPhCgfSBlylSiKXWAyqMc+59HPfsorvdGliEQWIGEl6YfLnvuu4GYTniNWFMFbBmA1H+shpw49Y+0bfGMLP9mg8xZ+LG80Kye1tdrSpc2rdyQMcN1KU3q1CZ/xbL3yar1W+Tc+fNy7PhJ2b1nr5QpVcQs27r9e9edlvKli8vyr9eZ+Z9/tVYqliluxuMapEiRQkj2N9ATEP1k/36ij+gj9oHQ2Qfiem9kGQJ2EXA4HEG5ThP+EiUQlai1g7TyQ5XLSuZMN8jt+fPK+GE9zP+MXqLo3QneWr68N0vdWtWkRft+ol9s79S2qaROlcqU90r/MXLSCnZ0omPrRrJk2UrzM7y/HfhTGtWvpbPlonX7rlzNxuYneBd/skJ0fM9P+8yypBywLQQQQAABBBBAAAEEQl0gyo4NaPxCD3nnvaXmLkig6vfU4zVlzuQhMnvSIKlcvqSr2C8WTZVsWW8y0/o6aWRv8zO8g/t0EL2zogtSWnc51i2bI+6p4J0FdBEJAQQiQ4BWIoAAAggggECABGwZgPTp2kr2H/hDnnquq3TtO1K+XLVR9C5EgNpMMQgggAACCCAQMgJUFAEEwk3AlgGI3l3o0el5+XDuWKlQpoTMfneJ1H6mXbjZ0x4EEEAAAQQQQAABBOwrEKSa2TIAcW9rlMP7T+a652EcAQQQQAABBBBAAAEEQkPAlgGIfsF7yJjp8lijDubXq5o+XVuWzJ8QGqLUMhwFaBMCCCCAAAIIIIBAgARsGYAMHDlV8uXNLQveHCkjX+0qVSuVFv0ieIDaTDEIIIAAAiEjQEURQAABBMJNwJYByJwpQ6RhvUfMT/GGGzjtQQABBBBAAAEEQkKASiIQJAFbBSD6i1d/HPrba1NPnvpXRk6YJW8v+NjrcmYigAACCCCAAAIIIICA/QVsFYA8WqOKdOgxTF58eZBMnDFPps5aaNKrIyZLo1bd5czZc1K75gNJrcr2EEAAAQQQQAABBBBAIEACtgpAqlQsJQtmjpTnGj0u6dKmczWx+L0F5c0Jr4r+/yCZb8zkms8IAgiEuwDtQwABBBBAAIFwE7BVAKK4DodDShUvLM2tIKRVs/qiqc7DD0r2bFl0MQkBBBBAAAEEkkKAbSCAAAJBErBdABKkdlIsAggggAACCCCAAAIhIRDulSQACfcepn0IIIAAAggggAACCNhIgADERp1BVTwFmEYAAQQQQAABBBAINwFbBSA7dv8kX63edJ3xipUbZfeeX66bzwwEEEAAgSAJUCwCCCCAAAJBErBVADJm0ttS4NY81zX1tnx5ZPKbC6+bzwwEEEAAAQQQQCDcBGgPAuEuYKsARP+zwfy35r7OvIAVgPz51+Hr5jMDAQQQQAABBBBAAAEEQkvAVgHIlStX3PRijl68dCnmDKYQQAABBBBAAAEEEEAg5ARsFYDcdfutsmbjtusQV63bIgVvz3fdfGYggECQBCgWAQQQQAABBBAIkoCtApD2LzSSwaOnyZDXZ8iKbzbIZytWW9PTrenp0q5lgyARUCwCCCCAAAL2EaAmCCCAQLgL2CoAyZ0rh8ydMkQyZkgnE2bMkxlzFsuNN2aQd6YNk1ty5wr3vqB9CCCAAAIIIIAAAsknwJaTSMBWAYi2OfONmeSllg1l8ezXZeGbo+TFFg0kc6YbdBEJAQQQQAABBBBAAAEEQlzAVgHIgg+WSVwpxK1Dp/rUFAEEEEAAAQQQy/dlqQAAEABJREFUQACBIAnYKgDZsv17iSsFyYBiEUAAAdsIUBEEEEAAAQTCXcBWAcjQvh0lrhTunUH7EEAAAQQQQCDZBNgwAggkkYCtApAkajObQQABBBBAAAEEEEAAgWQSuD4ASaaKsFkEEEAAAQQQQAABBBAIfwECkPDvY1oYQgJUFQEEEEAAAQQQCHcBApBw72HahwACCCDgjwB5EEAAAQSSSMCWAciBg4dk0sx35aVuQ6R1l4GulEQmbAYBBBBAAAEEEEAgyQTYUKQJ2DIAeW3UVLnxxkzS+Kla0qJxXVeKtM6hvQgggAACCCCAAAIIhJuALQOQTDdkkIZPPixlShaV+0vc60rhhu/ZHqYRQAABBBBAAAEEEAh3AVsGIKlTpZJff/sj3O1pHwII2EeAmiCAAAIIIIBAEgnYMgDZu/+gNGj5ijRp09P1/Q/9LkgSmbAZBBBAAAEEEEgyATaEAAKRJmDLAKRz2yYybmh3ad+qoev7H/pdkEjrHNqLAAIIIIAAAggggEDQBJKpYFsGIO7f+3AfTyYjNosAAggggAACCCCAAAIBErBlAHLu/HmZNe8j6dhzGI9gBaijKSZOARYigAACCCCAAAIIJJGALQOQV4dPlsNHj8uRoyekbq2qkjF9Oil0Z/4kImEzCCCAAAJJJ8CWEEAAAQQiTcCWAcjeXw9I13bNJEOGdFKzagUZObCr/P7HX5HWN7QXAQQQQAABBBAIngAlI5BMArYMQDJkSG84Ll68JKfPnDXjFy5cMq8MEEAAAQQQQAABBBBAIHQFbBmAZMyQQU6c+kcqlC4uz7XrbaU+kitHVgnSH8UigAACCCCAAAIIIIBAEgnYMgB5ffArkjnTDdK8cV3p2amltG3xtLzSoXkSkbAZBBBIOgG2hAACCCCAAAKRJmDLAEQ7YfuuH2XBB8uk2L0FpcCteeTA74d0NgkBBBBAAAEEAiFAGQgggEAyCdgyANGf4B3y+gz5cOlXhuXKlSsyaPQ0M84AAQQQQAABBBBAAIFQFoj0utsyAPlsxSqZ/cYgueGGDKZ/smfLIv+dPm3GGSCAAAIIIIAAAggggEDoCtgyAEmTNq2kSpUyhqpDHDGm4zux4INl0rh1D2nappesXLfF6+pHjh6Xdq8MluYv9ZWeA8fKmbPRv8C1dfv30v3V1+Whui3l+Q795Zu133pdn5nxFSA/AggggAACCCCAQKQJ2DIAuenGTLJ7zy+mL/TxqxlzFssdt91qphMy2H/gT5k9f4lMGd1XhvfvJINGTZWz585fV9TYKXOlbKliMnP8q5Ip0w0yd+FSkyd9urTStd2zsuz9KdLsmTpmfbOAAQIIIBCqAtQbAQQQQACBZBKwZQDSr1trWfTxCtn1wy/yQK1n5cDBQ9KpTeMEE61ev0UqVyglGdKnk1w5s0mhOwvIpi07xfNvzYZtUqtGJTO7VvVKsnrDVjNe0MqfLUtmSREVJRXLlpALFy647o6YDAwQQAABBBBAAAE/BciGQKQL2DIA0Z/g7d2llSx9d6IsnjNW+ndrI5mtuyIJ7azDR49J7lzZXavfkjun/H3kqGtaR/47fUYcDpGbMmfSScmbJ6ccPnLMjLsPFluB0R235ZN0adO6z2YcAQQQQAABBBBAAAEE/BBIxgDk+tpt2rpT3NMPP+2Tfft/d827fo3oORNnzJNWnQZcl+Yv+iw6gzV0WHcvrBfzz+GwIg0zFnMQFSPP9TT608Bz31sqfV9+wbXiuXPnhGR/g4sXL9JP7KvsAwHcB86fvyCaOP/Z//wXrD5yvREygoCNBS5fvhyUc7+NmxwSVbv+KjsZq92++1CJK8VWteaN6sqogV2vS3UfrWpWyZ41i5w4cdKM6+DY8ROSI1tWHXUlfTzr0qXLcv7CBTPvqJVHf33LTFgDvRsyYfo8mTC8h3V3JJc1J/qfBi2kKLG7gcPhsH0dk9TQCrbZnv33W3v3kR5TmnC0dz8Fr3+EPwRCRCAYx2iINN221bRVAFK5fEnR71u0bfGMfDx/gqxbNidGik1RH4e6IWMG8UxpUqc2q1Qse5+sWr9Fzp0/L8eOn5Tde/ZKmVJFzDL9hasLFy6a8fKli8vyr9eZ8c+/WisVyxQ34/rrWL0GjZeenVrKzTmvPcqlC1OlSiUk+xukSJGCfmJfZR8I4D6QMmVK0cT5L/7nv3Ax0/dAEgJ2F9DgIxjHnN3bbff6RdmpgkP7dZKxg7tJmtSppFv/16VDj2Hy6fLVXn+xKj71zpf3Zqlbq5q0aN9POvYcLp3aNpXU1huxlvFK/zFy8tQ/OiodWzeSJctWmp/h/e3An9Kofi0zf+GHn8uO3T9Jg5avSLmajU069PcRs4wBAggggAACCCCAQEgIUEmbCETZpB6uatyYKaM89XhNmT62v9SrU11GTZwl897/1LU8oSNa5pzJQ2T2pEGid1qc5XyxaKpky3qTmdTXSSN7m5/hHdyng+uL5m2aPx3jTozemcmVI5tZhwECCCCAAAIIIIAAAgj4L2C7AOTkqX9F/9NA/c8Ap85+T9q2eFqerlvT/xaR07cAORBAAAEEEEAAAQQQSCYBWwUg3QeMkcebdJA9P/0qndo0kbcnDZYnHn1I9D8CTCYfNosAAggEVIDCEEAAAQQQiHQBWwUg36z9VvLkyiEHD/0tE2fMl9ZdBsZIkd5ZtB8BBBBAAAEEEizAigggYBMBWwUg44Z2lw6tG0mLxnW9JpuYUQ0EEEAAAQQQQAABBBDwWyBmRlsFIPeXuFfiSjGrzhQCCCCAAAIIIIAAAgiEmoCtApBQw6O+CMRXgPwIIIAAAggggECkCxCARPoeQPsRQACByBCglQgggAACNhEgALFJR1ANBBBAAAEEEEAgPAVoFQIxBQhAYnowhQACCCCAAAIIIIAAAkEUIAAJIq5n0UwjgAACCCCAAAIIIBDpAgQgkb4H0H4EIkOAViKAAAIIIICATQQIQGzSEVQDAQQQQACB8BSgVQgggEBMAQKQmB5MIYAAAggggAACCCAQHgI2bQUBiE07hmohgAACCCCAAAIIIBCOAgQg4dirtMlTgGkEEEAAAQQQQAABmwgQgNikI6gGAgggEJ4CtAoBBBBAAIGYAgQgMT2YQgABBBBAAAEEwkOAViBgUwECEJt2DNVCAAEEEEAAAQQQQCAcBSIhAAnHfqNNCCCAAAIIIIAAAgiEpAABSEh2G5VGIFQEqCcCCCCAAAIIIBBTgAAkpgdTCCCAAAIIhIcArUAAAQRsKkAAYtOOoVoIIIAAAggggAACoSlAreMWIACJ24elCCCAAAIIIIAAAgggEEABApAAYlKUpwDTCCCAAAIIIIAAAgjEFCAAienBFAIIIBAeArQCAQQQQAABmwoQgNi0Y6gWAggggAACCISmALVGAIG4BQhA4vZhKQIIIIAAAggggAACCARQIIgBSABrSVEIIIAAAggggAACCCAQFgIEIGHRjTQCAQ8BJhFAAAEEEEAAAZsKEIDYtGOoFgIIIIBAaApQawQQQACBuAUIQOL2YSkCCCCAAAIIIIBAaAhQyxARIAAJkY6imggggAACCCCAAAIIhIMAAUg49KJnG5hGAAEEEEAAAQQQQMCmAgQgNu0YqoUAAqEpQK0RQAABBBBAIG4BApC4fViKAAIIIIAAAqEhQC0RQCBEBAhAQqSjqCYCCCCAAAIIIIAAAvYUiF+tCEDi50VuBBBAAAEEEEAAAQQQSIQAAUgi8FgVAU8BphFAAAEEEEAAAQTiFiAAiduHpQgggAACoSFALRFAAAEEQkSAACREOopqIoAAAggggAAC9hSgVgjET4AAJH5e5EYAAQQQQAABBBBAAIFECBCAJALPc1WmEUAAAQQQQAABBBBAIG4BApC4fViKAAKhIUAtEUAAAQQQQCBEBAhAQqSjqCYCCCCAAAL2FKBWCCCAQPwECEDi50VuBBBAAAEEEEAAAQTsIRCitYiYAGTBB8ukcese0rRNL1m5bovX7jpy9Li0e2WwNH+pr/QcOFbOnD1r8u364Rep/kQrKVezsTRr20s+Xb7azGeAAAIIIIAAAggggAAC8ROIiABk/4E/Zfb8JTJldF8Z3r+TDBo1Vc6eO3+d1Ngpc6VsqWIyc/yrkinTDTJ34VKTJ2+enLJo9hhZ/els6druWRk7ZY4rODEZGCS3ANtHAAEEEEAAAQQQCBGBiAhAVq/fIpUrlJIM6dNJrpzZpNCdBWTTlp3i+bdmwzapVaOSmV2reiVZvWGrGc90Q0a5IWMGSREVJTdagYnDESWXL18xyxgggAACkS1A6xFAAAEEEIifQEQEIIePHpPcubK7ZG7JnVP+PnLUNa0j/50+Iw6HyE2ZM+mk6F2Pw0eOmXEdbN3+vXkEq0HLV2RQ75dMMKPzL1y4IKTAG1y8eEECmS5fvmSVd9FKgS03kHUMdlnsp4HfTyPZ9NKli6Ipkg0ive36HkhKZgE271Pg8uXLQblO87lhMsQpEBYByMQZ86RVpwHXpfmLPnM13mHdvXBOOBxWpOGccHuNipEnJk2JonebR7BmjBsgI8bNlGPHT5o1r1y5LKTAG1y6dNm6uAlcumzdsdIgJNDlhlJ57KeB308vW29skZuumDvBkdv+y1b7A59C6Tg1b4IMEAgBgWAcVyHQbFtXMeZVtq2rGmvlpHmjujJqYNfrUt1Hq5qVsmfNIidORAcMOuPY8ROSI1tWHXUlfTxLLybPW3c0dOZRK0/2bFl01JVSREWZx7dy5sgme37+1cxPnTqNkAJvkCZNGglkSpkypemnQJYZamWxn6Yx+0AgHUJtHwhkfVOlSiWaAlkmZQV+Hw3k/u5ZlnkTZICAzQX0w2XPfTcQ0zZvtu2rFxYBSLq0ac13NPR7Gu4pTerUpgMqlr1PVq3fIufOnzd3Lnbv2StlShUxy/TRqgsXLprx8qWLy/Kv15nxz79aKxXLFDfjP+/9TU6fif5FrN//OCR79x+UO2+71SxjgEBkC9B6BBBAAAEEEEAgfgJhEYD4anK+vDdL3VrVpEX7ftKx53Dp1LappLY+vdP1Xuk/Rk6e+kdHpWPrRrJk2UrzM7y/HfhTGtWvZeYfPHRYHmvU3nwHpGGr7vLMEw9Ltqw3mWUMEEAAAQQQSBYBNooAAgiEqEBUiNY73tV+6vGaMmfyEJk9aZBULl/Stf4Xi6a6ggkNKiaN7G1+hndwnw6id1Y0o+bXfOuWzZGVH78lDZ98WGeTEEAAAQQQQAABBCJQgCYnTiBiApDEMbE2AggggAACCCCAAAIIBEKAACQQihFbBg1HAAEEEEAAAQQQQCB+AgQg8fMiNwIIIGAPAWqBAAIIIIBAiAoQgIRox1FtBBBAAAEEEEgeAbaKAAKJEyAASZwfayOAAAIIIIAAAggggEA8BBIRgMRjK2RFAAEEEEAAAQQQQAABBCwBAhALgX8IhJwAFUYAAQQQQAABBEJUgAAkRDuOaiOAAOSYxawAABAASURBVAIIJI8AW40W6Ny6oZACZ9DphQbS/vn6mAZ4v3q0RsXoHZahrQQIQGzVHVQGAQQQQACB0BDo0raRkAJn0LlNQ2nf8ilM496v4u1Tu0al0DigIqyWBCAR1uE0FwEEEEAAAQQQQACB5BQgAElO/YRum/UQQAABBBBAAAEEEAhRAQKQEO04qo0AAskjwFYRQAABBBBAIHECBCCJ82NtBBBAAAEEEEgaAbaCAAJhIkAAEiYdSTMQQAABBBBAAAEEEAiOQGBLJQAJrCelIYAAAggggAACCCCAQBwCBCBx4LAIAU8BphFAAAEEEEAAAQQSJ0AAkjg/1kYAAQQQSBoBtoIAAgggECYCBCBh0pE0AwEEEEAAAQQQCI4ApSIQWAECkMB6UhoCCCCAAAIIIIAAAgjEIUAAEgeO5yKmEUAAAQQQQAABBBBAIHECBCCJ85MLF86TQsAgVaqUcunSRfoqBPoqlmOKvrNZ3zlPnfQX7wHsA4HZB/Q9KmXKlJzrbHaui23/dp4DeU2YAAFIwtxYCwEEEEAAgQgRoJkIIIBAYAUIQALrSWkIIIAAAggggAACCARGIExLIQAJ044NlWadPPWv9B40QVp3GSi//HogXtWe/e4Seee9pfFax1vmBR8skzNnz3pb5JrXfcAYKVezsSvt+uEX1zL3kdoNX3KfZByBJBGww3G0at0Wn8fwd7v2SKtOA6TCw01l+Tfrxf1Pj8PGrXtI0za9ZKVVlvsy53igjnlnebyGn0CoHAue8qMmzpZlX67xnO2aHjJmuny5aqNrOrEj+h7Wte9IU4yWq+WbCS+Ddxcvc7336fugHodeskmnXiNkz0/7vC1iHgLXCRCAXEfCjKQUWLlus+TMkUUmj+ojt+fPG9umgzp/8Scr5OzZ8z638caIXrJu2RyTChe63Wd+MiCQVAJ2OI7WbfpO9u0/GGeT06ZJIy80qydVKpSKkW//gT9l9vwlMmV0Xxnev5MMGjVVzp7zfUzGKIQJBCyBUDkWrKrG+FevTnUpVaJwjHlJNVGiSCFp8OQjcW6uReMnzHufvgc2fbp2nHlZiIA/AgQg/iiRJygCu/f8Yi46vly5UV7qNkQ69hwuP/6y32yrSZueMu3t9834lLcWyqKPl5tx/eSl/nNdpN0rg31+0vJU8y4yZtJsaWeV/dXqTfL9j3vNnRYtu2ufkXL0+An55POVcuivI/Jyv9Hm0xuzkXgMfv/jL2nT9TV5vkM/GTZ2ZjzWJCsCgRHwPI70Qn7e+5+awnX/b/vyIDO+ccsOc7dRJ+JzHA0ZM11eHTHZHEfTZr/n9Tj6ae9+WbXuW5lhHbN6N1MDCt2OZyp4R34pWbywREXFfOtZvX6LVLaCkgzp00munNmk0J0FZNOWnaJ/8amr5idFroDnsZAc7yn+Hgue70/vffSFbN66y3TezDmLzfvKY43ai94ZMTPdBmOnzJGBI6bIlStX3OZeG500813Ru/FPt+gq061j0rlEPyRo1Kq7tOw4QD5e9o1ztmzd8YPMe3+pa9rfkXPnz0u/oW+I3rns3Hu4/PvfaX9XJR8CEvNdABAEklDgnoK3y9N1a8rDD1WQ8cN6SNHCd8k260SoJ7E0qVPLjl0/mdps3/WjFL/3btm7/3d53zpJTxvbX4b07SC79+w1y+Ma5M2TSyZYZT9QvqQMGD5JOrzQSN6eNFiqP1hOxk6eK7VqPGAueEYM6CxjBr0cV1HSpc8oebh+Gxk5YZZcuHDR5J0wfZ6Uu7+YTB87QG7JnVPOnIn7US6zEgMEAijgeRwVK3KXbN+9x2zh+x/3yTnrTsLFS5fEHEfWsoQcR+fOX5BxQ7pJc+tTUG/H0Z235ZNK5UpKiyZPmruZ+fLebLbv7+Dw0WOSO1d2V3Y9lv4+cjRBx7yrEEYiTsDzWEiO95T4HAvO96cHK97v6qtD1gdiazZuk0kje8uHc8dJk6cfjV7mcJjX/sMmySXreO7z8gvicETPMwvcBjWrVpQl74yXWW8Mlp3f/yLfbtsleg4YNGqa9OjUQqaO6St6zLmt4nNUH3d+8LEW8kr/0fL3kWMm/4dLv5JT//wns98YJM9bx/7O76Pfs81CBgj4EIjysZzFCCSZwH1FC8l3VrChF0p6Uf/f6TPmpPnb73/KbfnzyHc798iDle6XzJlukBsyZpBqlcv4rFuViqVNnj8P/S1/HT4mY6fMNXdB3l+yXH74yXcAY1a2Bp1fbCZffjhdhvXvZK23T95e8LHonz5H+2Tth3RUnqxT3bwyQCA5BQoXukN27v5ZzlmfTqa2Avl7775DfrDu/m23AvoSRe9O0HFU2Qrg9a5FYo+juFwcbndFHI7oC6uEHPNxbYNlkSVg5/cU7Qnn+5OOO1PWLJnNhwYTZ8yTBR8sk0w3ZIxeZN3tmDh9vnnv69y2WfS8WIbnzp8zd/879x4hB//8S37e97sc/ONvyZrlRrn37jtN4FL30ej3rViKiDG7epWy8vn7k82HdzdkzCivjZxqlu/Y/ZM8XququaOpwZ8ms4ABAn4IhEIA4kczyBIOAvfec6d14fST6BdVi997l9x9123y4dIvxf37FilSpHA1NWXKa+OumR4jqVOlvDrHITfnzGY+ndXvm0wd008WzBx1dZnvlxzZsphM+olak6cele9//MVMW/fAJU3qVGY8pVUfhyP6wsnMYIBAMgiktI6RvLfcLJ8sWynFrOOoaOGCsuW7H+TAwUOu71nF9zjS/5sguimJO46iy7h+mD1rFjlx4qRrwbHjJyRHtqxmOr51NSsxQMASsPN7ilU9ufb+pFPRSf/PqrfeeE3K319cft57QPoNmRC9wHpvqVCmmGy27macOHkqep6Xod6d7zN4glR7oKy5q1+zagU5ffXOfIxjyTpPeFnd66wsN90oeg7QO5Od2jS23v+ufXin5xvnSvoe6BznFQFfAgQgvoRYnmQCeiLT57+/WrVR9I1DL57mvf+pFL23kKlDEeuTm2+37ZbLly9b1/1XZNOWXWa+PwN9vOPixYuy7Ms1JruepLdbd1t0Il3atKK/nKLjsSV9LEyXaRmr1m+xgqPoL6EXtj5dXrPxO10kGzbvMPUyE2EzoCGhKFC08J3yzvtLpeg9d0nxInfJR599JXfcltc0JWjHUbo0curUv2Yb8R1ULHuf6HGld22OHT9pHq8sU6qIJKau8a0D+cNPINneUxJxLJhgwbrboXcrX3iunux0+8XFEkXvkdbPPSXtuw+L9fsWGpykSpVKiha+ywpwUol+70N7Nk/uHKLH1vET0cGLfidM5/uTnO9/mvfLlRus97/bdFSKWB8abtq6w4zrdvf89KsZZ4CAPwIEIP4okSfJBPTCSW8563dAit1bUA7++beUKFLQbP+O226VqpXKmC+sd+49Ml4X+/r4yKDe7WXpF6ulWdteUqfhS64Te8N6j8j4aXPj/BL6k806m58h1NcbM2WUps9E/wpIu+cbyBLr4u7FlwfJ0uWrJE2a1MIfAsktoIGHPkte3Dp2st6U2TxyUaxwdCAfrOPokYcqybrN34l+6T22L6Gvt5brz3jqT/Dqp7QP1W1pqPQ7I3VrVZMW7fuJfnG4U9um5uIpMXU1BYf6gPonWiA53lP8ORZia9ihv4/Ig3VaiP5YyuiJs6Vru2djZNXHIRvWe9gcJxqwx1hoTWS37tbro1D6xfCX+44SvWthzRYNxvT7H/odkg49hskv+w7obL/SayOnmPe/ao8/Lxu+3SF9urYS/XvskQfl+Il/rIBoqAwYPkVy5Yy+a6nLSAj4EiAA8SXE8qAK1KtTQ1o1q+/axostGpgvdOuMHNaJVH/yTx/F0mlNeuE/cUQvc2t55vhXRYMHne8t6SNWGsw4l915Wz4ZO6SbzHpjkHy6cJI0fPJhs+ihymVl1MCXTZlmhpfBsvcmm58g1C8FvtSyoTmZazY9uY98tatonQb1ekk+mT9RZ5MQSFIBz+OofOnisvrT2aKBvFZk4ZujpPFTtXTUpPgcRz06PW8F/qXNejqI7Ti6vUBeGTGgi+jPVWtAoXk9U9lSxcxxpMe1puWLp7myPPV4TZkzeYjMnjRI9CLLuSA+dXWuw2vkCngeC8nxnuLPseD5/tTlxaaij0vdlu8WWbV0lrw9abDoh2YPXv2Ceo+OLcQ5/r9qFa33yf6u49uztzVA0GNp5MCuMqB7W3mu4WMmS5mSRc17oL4Pvj64m+h7ly44e+6cZMyQTke9pqH9OpnjdsUH002dNMjRjHp+0fLHDe1u3j/nTx8hBe8soIvCItGI4AoQgATXl9IRQAABBBBAAAFbCujdSP3Z35pWUGPLClKpsBUgAAnbrg1Ew0KjDP0dcv2/ONxTfJ5vdW9lIMtyL5dxBOwuMHfhJ+b/HnA/jnReQuqt67mXo+M6LyFlsQ4CSS0QyPeBQJbl6RCIsvUJgPfeGi133Z5P9BjVY9U96TzP7TKNQCAECEACoUgZySqgt4D1N9PdU+n7iiSoToEsK0EVYCUEnAJJ/Nqofi3zfw+4H0c6TxLwp+u5l6PjOi8BRbEKAkkuEMj3gUCW5QkR6LL1GNVj1T3pPM/tMo1AIAQIQAKhSBkIIIAAAgggEDYCNAQBBIIrQAASXF9KRwABBBBAAAEEEEAAATeBOAIQt1yMIoAAAggggAACCCCAAAIBECAACQAiRSAQcAEKRAABBBBAAAEEwlSAACRMO5ZmIYAAAggkTIC1EEAAAQSCK0AAElxfSkcAAQQQQAABBBDwT4BcESJAABIhHU0zEUAAAQQQQAABBBCwgwABiB16wbMOTCOAAAIIIIAAAgggEKYCBCBh2rE0CwEEEibAWggggAACCCAQXAECkOD6UjoCCCCAAAII+CdALgQQiBABApAI6WiaiQACCCCAAAIIIICAd4GknUsAkrTebA0BBBBAAAEEEEAAgYgWIACJ6O6n8Z4CTCOAAAIIIIAAAggEV4AAJLi+lI4AAggg4J8AuRBAAAEEIkSAACRCOppmIoAAAggggAAC3gWYi0DSChCAJK03W0MAAQQQQAABBBBAIKIFCEDcup9RBBBAAAEEEEAAAQQQCK4AAUhwfSkdAQT8EyAXAggggAACCESIAAFIhHQ0zUQAAQQQQMC7AHMRQACBpBUgAElab7aGAAIIIIAAAggggEC0QIQOCUAitONpNgII+C/QfcAYeXfxMv9XsHKWq9nYGsbv3/ZdP0qL9v3it5IfuTv0GCZrNmzzI2fws3y7bZds+HZH8DfktgVf2/z9j0PStc9Iad1loGy26vdU8y6y/8CfbiX4HvW1Dd8lkAMBBBCIHAECkMjpazu3lLohgEAQBV58/hkpfPftQdyC/0Vv3bFHtny32/8VApDT1zaXfrFK7il0h0we1UdKFS8sfV9uLTlzZI3Xln1tI16FkRkBBBAIcwECkDDvYJqHAALBE5i/6DN5+Km20rBVN+nYc5gcOHhkYN6RAAALmElEQVQoxsbGT50rrToNkAbPvyxffL3OtWzjlh3yQudXpVnbXuZ1955fXMv8Gdm0dac8266PvNxvlLlj0rLjANnz869mVecyvWvTrtsQ84n+xOnzZdf30duYOmuh9Bw4Vtq9MljqPdtZ+gyeIHt+2mc+/X+yWWeZ9/6nphwd9B40QWo3aCfPWPUfNHqanDl7VmeL5zbWbf7OOBw5etws18HICbNk5twPdNSV9u0/KJ98sVKWfbnWbG/hh5/LseMnpUmbnsbw6RZdZc6CT1z5ta49Br5u6vp8h/5y/sIFGWeZ6h2KF18eJCMmvGWWOVdY8MEyU5aWp208evyEeNumM7++fvTZ1/Lx56tkqVWv1tYdEE3tXhkif/19VBebeg4f96bZzsARU+TPvw6Lumj/1azXWibNfNfnNkxBDBBAAAEEXAIEIC4KRhBAAIH4CZS+r4gseWecvDN1mNSoWl6GvD4jRgEpU6WUqWP6Sb9ubWWwdQGvF8SaXhs1TV5u96zMemOQdG7bVHq8OlYuXroUY11fE7/s/U3aNn9GZowbIM2eqSMDR05xrfLTL/ul9XNPy4RhPcwn+q4FV0cOWRfXwwd0ljlThsreX3+X2e8ukXFDu8ubE16Vd977RP4+cszkbPpMbVkyb4LJlzJFCpmz8BMzXwfu2yhXqpg88lAFWfzJCl1kApUV36yXJ2pXM9POQYF8eaRW9QekpmWldxvqP1ZD0qVLI4N7tzeG08cOkC9XbZAt2793riK//vaHDOvfSaaP7S9fr94k6zZuk5njB8rYId3kZ8vAmXGNNV8Dm/FWm9+eNFiKFykkw8fOFG/bdK6jr3X+V0WqVrpfnnj0IXMHROuVI/tNusiVzpw9Z3z6vPyCvLv4M7n37jtkyui+8umCN+TJOtV9bsNVECMIeAowjUCEChCARGjH02wEEEi8QFSKKJk+Z5F06DFMPvr0a/nx6l0IZ8kNnnzEjBa6s4B10Xqn7Nz9s3y380c5a13Qjpw4y3y6PmbS23Ly1L/y2+9/mrz+DvJbF/N6ca35K5YtIb8f/EvOnjuvk3LX7fkk/625zbi3wX3F7pb06dJK2jSp5a478kuxewtK6lSpJNMNGSXfrXmsT/R/N6ud+udfGf3GLOnQfajs2P2TuVNiFlgDz23Uf6ymMbh8+bJ88vlKKV2yiGTOdIOVM+5/adOkka07fpABwydbd3RGy/ETp+SHH/e5Vip/fzHJkD6dmd62Y488UqOyZMyQXlKmTClP1n7IzNfB+k3b5cTJf6T7gNeN6+dfrZXtlrcuS2yq9kAZiYqKMsUUufsu0bs4enfm0+WrJWuWzGY+AwQQQAAB/wWiz6j+5w9GTspEAAEEQlKgc6/h1sV+funfrY0Mtz6l10/K3Ruidw2c03rBfOWKiMPhkIJ35Hd92q6fuH+9ZKbclu8WSezfxYsXTRFprMDCjMQySG3dmXEu0gvrVG7TKaKi5OLFy6Jfwn5t5FTrbkUFGfXay9K8cV05ezY6wNF1PbeRK2c2KXRXAesOxkZ5/6MvpMGTD4s/fx9//o18uXKDNHmqtkwY3lMqlr1PTp+JftRL1/fcjqep5tHkcFyx7q5UcrlOt+6m6B0KXZbYlCZNKlcR1SqXse4s9bTaerusWLle9LEs10JGEEAAAQT8EiAA8YuJTAiEqwDtSqjAmbNn5fjJU9YFcwm5KXMmWf7N+uuK0u+I6Ez9jsWO3T9KkcJ3SHHrboN+X2PFNxt0kUnrNn1nXj0HM+csFn1ky3O+Tv+y74D5LoaOL/p4ueS9JZe5M6DTgUj6fZZb8uSSwoXuMHdKVlhBgq9y69WpLmOnzJW0adOK3vXxll/vXpyw7vg4l/26/6AUuecuuS1/HivwuSTrNm1zLrrutXiRgrJ+83bXfPdf9ipfurgsXvql7N0fffdGvy/ifJTLc5uuAhIwonerbsyUUR4od580b1RXdn7/kyklkNswBTJAAAEEwliAACSMO5emIYBA4ARen/y26E/rOtO6TdulUb1a0uD5bqKPYB09duK6jZ0+c8Z8ubr/sDekW4fmkvWmzCZYGdqvo2jQoF8k/1/91q7vTrgXoAHO2ws/lhQpUrjPdo3ro1P6he1GrbrLp8vXSO8urVzLAjFSuuS9kiIqSpq26SWdew+Xm27M5LPYMiWLmke56j9WPda8VR8oLcdPnDRm+iX0uo8+JJ+tWC2tOw8UddJHu2Jb+aHKZeX2AreYdbv2GSkpU0SJBgOav2ypYtLCukvz6ogp8uyLvaXW0y/Kjl3RwYHnNjV/QtOkNxfIA48+K226vma+sN/lxWamqARtw6zJAAEEEIg8gajIazItRgABBOInMLRfJ1m3bE6MVLVSaXm+yRPy/qzR5gvRLZvWkzWfznYVrPnbt2pkvlw9b/oIqV6lnGvZfUXvlokjeslbEwbKZwsny/D+nc2yooXvMl8q14mt23+Qxx6uIrF9jyJtmtRmu3OnDpVpr/cTfaxL17u/xL3mMSQddyb9wnaFMsXNZKtm9UWTmbAGfbq2krq1qllj0f+ceVOnSmXKnz1pkIx+7RXp2q6ZeURKc3nbhs7/6/BRiYpyWG0tr5NeU45sWUx7dTv1H6sht+TOKQvfHCWTR/eRoX07yuA+HYyrrqz11KTjmqKiosxdB113iJX38pUrot9f0WWaHn+kqjF9a+Jr8sWiqdKsQR2dLZ7bNDPdBh1bN5GG9R5xzVkwc5Tky3uzmdZH5LS9ZsIadLcCyZUfvyWTRvaWQb3bS7n7i1lzxec2TCYGCCBgGwEqkrwCBCDJ68/WEUAAAa8C+kiRXhh7XWjDmW++86G01p+xfa6+pHL7Tkmgq6p3ZJ5q3kWatOkhaVKnlsdrVQ30JigPAQQQQCDIAgQgQQa2d/HUDgEEQlFAP5HXT+btVPfnGj4mi2e/LtUeKBvUai2aPUb0DsV8666S3pXROzVB3SCFI4AAAggEXIAAJOCkFIgAAgj4IUAWBBBAAAEEIlSAACRCO55mI4AAAgggEKkCtBsBBJJXgAAkef3ZOgIIIIAAAggggAACkSJg2kkAYhgYIIAAAggggAACCCCAQFIIEIAkhTLbQMBTgGkEEEAAAQQQQCBCBQhAIrTjaTYCCCAQqQK0GwEEEEAgeQUIQJLXn60jgAACCCCAAAKRIkA7ETACBCCGgQECCCCAAAIIIIAAAggkhQABSFIoe26DaQQQQAABBBBAAAEEIlSAACRCO55mIxCpArQbAQQQQAABBJJXgAAkef3ZOgIIIIAAApEiQDsRQAABI0AAYhgYIIAAAggggAACCCAQrgL2ahcBiL36g9oggAACCCCAAAIIIBDWAgQgYd29NM5TgGkEEEAAAQQQQACB5BUgAElef7aOAAIIRIoA7UQAAQQQQMAIEIAYBgYIIIAAAggggEC4CtAuBOwlQABir/6gNggggAACCCCAAAIIhLVARAUgYd2TNA4BBBBAAAEEEEAAgRAQIAAJgU6iigiEgQBNQAABBBBAAAEEjAABiGFggAACCCCAQLgK0C4EEEDAXgIEIPbqD2qDAAIIIIAAAgggEC4CtMOrAAGIVxZmIoAAAggggAACCCCAQDAECECCoUqZngJMI4AAAggggAACCCBgBAhADAMDBBBAIFwFaBcCCCCAAAL2EiAAsVd/UBsEEEAAAQQQCBcB2oEAAl4FCEC8sjATAQQQQAABBBBAAAEEgiGQFAFIMOpNmQgggAACCCCAAAIIIBCCAgQgIdhpVBkB/wXIiQACCCCAAAII2EuAAMRe/UFtEEAAAQTCRYB2IIAAAgh4FSAA8crCTAQQQAABBBBAAIFQFaDe9hYgALF3/1A7BBBAAAEEEEAAAQTCSoAAJKy607MxTCOAAAIIIIAAAgggYC8BAhB79Qe1QQCBcBGgHQgggAACCCDgVYAAxCsLMxFAAAEEEEAgVAWoNwII2Fvg/wAAAP//dZocwwAAAAZJREFUAwBPc/947ljxcAAAAABJRU5ErkJggg=="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Bar chart of mean validation information coefficient, one bar per label on one axis, with the primary target in dark navy first and the two variants in slate, and a dashed zero line. Counted from the frame: fwd_ret_5d above zero; fwd_ret_10d below zero; fwd_ret_risk_adj_5d below zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "panel = catalog.with_columns(\n",
     "    rank=pl.col(\"label\").replace_strict(\n",
@@ -635,8 +1196,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "292cb0b4",
-   "metadata": {},
+   "id": "c1e3ffba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003443,
+     "end_time": "2026-08-25T20:04:39.027244+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T20:04:39.023801+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -709,6 +1278,25 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-08-25T20:04:48.945034+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "9fbac9d0bfedcd2522073b68ce0a2d7b85c35be6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 28.175026,
+   "end_time": "2026-08-25T20:04:42.516598+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/11a_pca.ipynb",
+   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.11a_pca.papermill.2873915.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-25T20:04:14.341572+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/11a_pca.py
+++ b/case_studies/sp500_equity_option_analytics/11a_pca.py
@@ -102,7 +102,10 @@ MODEL_NAME = "pca"
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="11a_pca",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/11b_ipca.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11b_ipca.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6b96be85",
-   "metadata": {},
+   "id": "d47f8f65",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005916,
+     "end_time": "2026-08-25T22:35:11.955944+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:11.950028+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Option analytics: letting the option surface choose the exposures\n",
     "\n",
@@ -68,9 +76,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0c2c6409",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "80f8a819",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:11.978334Z",
+     "iopub.status.busy": "2026-08-25T22:35:11.977948Z",
+     "iopub.status.idle": "2026-08-25T22:35:17.745799Z",
+     "shell.execute_reply": "2026-08-25T22:35:17.745218Z"
+    },
+    "papermill": {
+     "duration": 5.771756,
+     "end_time": "2026-08-25T22:35:17.746319+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:11.974563+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared option-analytics IPCA population on the walk-forward folds.\"\"\"\n",
@@ -93,9 +115,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ce71a732",
+   "execution_count": 2,
+   "id": "712413df",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:17.753882Z",
+     "iopub.status.busy": "2026-08-25T22:35:17.753525Z",
+     "iopub.status.idle": "2026-08-25T22:35:17.756602Z",
+     "shell.execute_reply": "2026-08-25T22:35:17.756187Z"
+    },
+    "papermill": {
+     "duration": 0.00817,
+     "end_time": "2026-08-25T22:35:17.757016+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:17.748846+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -114,9 +149,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9814b76a",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "b7cf5ecd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:17.761790Z",
+     "iopub.status.busy": "2026-08-25T22:35:17.761608Z",
+     "iopub.status.idle": "2026-08-25T22:35:23.118750Z",
+     "shell.execute_reply": "2026-08-25T22:35:23.118368Z"
+    },
+    "papermill": {
+     "duration": 5.360618,
+     "end_time": "2026-08-25T22:35:23.119911+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:17.759293+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -129,8 +178,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a432c9fb",
-   "metadata": {},
+   "id": "fb224bf1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002182,
+     "end_time": "2026-08-25T22:35:23.124597+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.122415+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which labels, and what the configuration says\n",
     "\n",
@@ -143,18 +200,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c022992f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "db33a1e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:23.129824Z",
+     "iopub.status.busy": "2026-08-25T22:35:23.129659Z",
+     "iopub.status.idle": "2026-08-25T22:35:23.162604Z",
+     "shell.execute_reply": "2026-08-25T22:35:23.162259Z"
+    },
+    "papermill": {
+     "duration": 0.036743,
+     "end_time": "2026-08-25T22:35:23.163535+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.126792+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_10d', 'fwd_ret_5d', 'fwd_ret_risk_adj_5d')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"latent_factors\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "af30cba4",
-   "metadata": {},
+   "id": "d2cdb643",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002213,
+     "end_time": "2026-08-25T22:35:23.168336+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.166123+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`case_studies/config/ipca/ipca.yaml` declares `n_factors`, how many common factors to extract,\n",
     "and `checkpoint_interval: 0` for the reason given above. `config/setup.yaml` adds three more\n",
@@ -172,10 +262,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ed2ad622",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "e4740d0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:23.175755Z",
+     "iopub.status.busy": "2026-08-25T22:35:23.175592Z",
+     "iopub.status.idle": "2026-08-25T22:35:23.260521Z",
+     "shell.execute_reply": "2026-08-25T22:35:23.259353Z"
+    },
+    "papermill": {
+     "duration": 0.090022,
+     "end_time": "2026-08-25T22:35:23.260997+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.170975+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;&quot;</td><td>&quot;n_factors=5&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 5)\n",
+       "┌────────────────┬─────────────────────┬─────────────┬─────────────┬─────────────┐\n",
+       "│ family         ┆ label               ┆ config_name ┆ model_class ┆ params      │\n",
+       "│ ---            ┆ ---                 ┆ ---         ┆ ---         ┆ ---         │\n",
+       "│ str            ┆ str                 ┆ str         ┆ str         ┆ str         │\n",
+       "╞════════════════╪═════════════════════╪═════════════╪═════════════╪═════════════╡\n",
+       "│ latent_factors ┆ fwd_ret_10d         ┆ ipca        ┆             ┆ n_factors=5 │\n",
+       "│ latent_factors ┆ fwd_ret_5d          ┆ ipca        ┆             ┆ n_factors=5 │\n",
+       "│ latent_factors ┆ fwd_ret_risk_adj_5d ┆ ipca        ┆             ┆ n_factors=5 │\n",
+       "└────────────────┴─────────────────────┴─────────────┴─────────────┴─────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "configs = load_model_configs(\n",
     "    study,\n",
@@ -188,8 +322,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65339c3d",
-   "metadata": {},
+   "id": "e96561df",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00254,
+     "end_time": "2026-08-25T22:35:23.269944+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.267404+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
     "canonical population does. A population is immutable once written, so such a run must publish\n",
@@ -204,9 +346,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5ba9eb54",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "4aca1ee6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:23.285688Z",
+     "iopub.status.busy": "2026-08-25T22:35:23.285517Z",
+     "iopub.status.idle": "2026-08-25T22:35:23.349634Z",
+     "shell.execute_reply": "2026-08-25T22:35:23.344084Z"
+    },
+    "papermill": {
+     "duration": 0.071978,
+     "end_time": "2026-08-25T22:35:23.350364+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.278386+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "declared = load_model_configs(study, \"latent_factors\", config_names=[MODEL_NAME])\n",
@@ -219,8 +375,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a0b38c6",
-   "metadata": {},
+   "id": "97349b09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002549,
+     "end_time": "2026-08-25T22:35:23.355692+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.353143+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Where this one runs, and why it is not the family's device\n",
     "\n",
@@ -234,10 +398,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "babc0a80",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "93addfa6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:23.363101Z",
+     "iopub.status.busy": "2026-08-25T22:35:23.362263Z",
+     "iopub.status.idle": "2026-08-25T22:35:23.370168Z",
+     "shell.execute_reply": "2026-08-25T22:35:23.369469Z"
+    },
+    "papermill": {
+     "duration": 0.013286,
+     "end_time": "2026-08-25T22:35:23.371583+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.358297+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cpu\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cpu\"\n",
     "overrides = {\"device\": PUBLISHED_DEVICE}\n",
@@ -246,8 +432,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc5ad965",
-   "metadata": {},
+   "id": "fc5ec51f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00233,
+     "end_time": "2026-08-25T22:35:23.376632+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.374302+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -275,10 +469,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "af49e969",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "d0352bed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:35:23.383479Z",
+     "iopub.status.busy": "2026-08-25T22:35:23.383329Z",
+     "iopub.status.idle": "2026-08-25T22:36:05.067241Z",
+     "shell.execute_reply": "2026-08-25T22:36:05.066320Z"
+    },
+    "papermill": {
+     "duration": 41.693778,
+     "end_time": "2026-08-25T22:36:05.072905+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:35:23.379127+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>192139</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-16 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>194813</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;ipca&quot;</td><td>&quot;regression&quot;</td><td>48</td><td>194748</td><td>2</td><td>1</td><td>&quot;2019-01-07 00:00:00&quot;</td><td>&quot;2020-12-23 00:00:00&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ task       ┆ feature_c ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ ---        ┆ ount      ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ str        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆            ┆ i64       ┆   ┆       ┆ i64       ┆ str       ┆ str       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_10 ┆ ipca       ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-1 │\n",
+       "│ d          ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 6         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ ipca       ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-2 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_ri ┆ ipca       ┆ regression ┆ 48        ┆ … ┆ 2     ┆ 1         ┆ 2019-01-0 ┆ 2020-12-2 │\n",
+       "│ sk_adj_5d  ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -304,8 +549,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59baea6d",
-   "metadata": {},
+   "id": "7b662815",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001809,
+     "end_time": "2026-08-25T22:36:05.076762+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:36:05.074953+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
     "menu declares would still print an IC table and still register its rows; what it would not do is\n",
@@ -314,10 +567,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "87328cd4",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "48e73730",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:36:05.082072Z",
+     "iopub.status.busy": "2026-08-25T22:36:05.081776Z",
+     "iopub.status.idle": "2026-08-25T22:36:05.087342Z",
+     "shell.execute_reply": "2026-08-25T22:36:05.086556Z"
+    },
+    "papermill": {
+     "duration": 0.009251,
+     "end_time": "2026-08-25T22:36:05.087916+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:36:05.078665+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 label-configuration pairs\n",
+      "3 training identities\n",
+      "3 validation prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "planned_pairs = {(member.label, member.config_name) for member in plan.members}\n",
     "requested_pairs = set(zip(configs[\"label\"], configs[\"config_name\"], strict=True))\n",
@@ -334,9 +611,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1362a5ee",
+   "id": "5015fa92",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001849,
+     "end_time": "2026-08-25T22:36:05.091904+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:36:05.090055+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 3. Fitting the population\n",
@@ -381,10 +665,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4e32dc67",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "f843ed57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:36:05.096673Z",
+     "iopub.status.busy": "2026-08-25T22:36:05.096544Z",
+     "iopub.status.idle": "2026-08-25T22:37:15.103578Z",
+     "shell.execute_reply": "2026-08-25T22:37:15.102723Z"
+    },
+    "papermill": {
+     "duration": 70.024499,
+     "end_time": "2026-08-25T22:37:15.118330+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:36:05.093831+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 training runs across 3 labels\n",
+      "population sp500_equity_option_analytics-ipca-validation-v1: 3 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "def catalog_labels(execution) -> int:\n",
     "    \"\"\"Number of distinct labels the execution published, read from its catalog rows.\"\"\"\n",
@@ -403,8 +710,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b2b7603",
-   "metadata": {},
+   "id": "3f03ffaa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011709,
+     "end_time": "2026-08-25T22:37:15.133614+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.121905+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
     "already holds the matching rows, and the runner returns the stored result rather than fitting\n",
@@ -435,8 +750,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f11ca8bc",
-   "metadata": {},
+   "id": "7a26d1f8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009859,
+     "end_time": "2026-08-25T22:37:15.148049+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.138190+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -458,14 +781,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d9d0c470",
+   "execution_count": 11,
+   "id": "247fbc34",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:37:15.163099Z",
+     "iopub.status.busy": "2026-08-25T22:37:15.162872Z",
+     "iopub.status.idle": "2026-08-25T22:37:15.208517Z",
+     "shell.execute_reply": "2026-08-25T22:37:15.203252Z"
+    },
+    "papermill": {
+     "duration": 0.054297,
+     "end_time": "2026-08-25T22:37:15.209632+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.155335+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 candidate models across 3 labels\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>task</th><th>checkpoint_value</th><th>ic_mean</th><th>ic_std</th><th>ic_t</th><th>ic_n_days</th><th>auc_mean_daily</th><th>auc_scored_against</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>-0.008197</td><td>0.019054</td><td>-0.608413</td><td>492.0</td><td>0.511589</td><td>&quot;fwd_dir_10d&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>0.001611</td><td>0.008735</td><td>0.260787</td><td>497.0</td><td>0.511944</td><td>&quot;fwd_dir_5d&quot;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;regression&quot;</td><td>0</td><td>0.014003</td><td>0.006981</td><td>2.836809</td><td>497.0</td><td>null</td><td>null</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 9)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ label     ┆ task      ┆ checkpoin ┆ ic_mean   ┆ … ┆ ic_t      ┆ ic_n_days ┆ auc_mean_ ┆ auc_scor │\n",
+       "│ ---       ┆ ---       ┆ t_value   ┆ ---       ┆   ┆ ---       ┆ ---       ┆ daily     ┆ ed_again │\n",
+       "│ str       ┆ str       ┆ ---       ┆ f64       ┆   ┆ f64       ┆ f64       ┆ ---       ┆ st       │\n",
+       "│           ┆           ┆ i64       ┆           ┆   ┆           ┆           ┆ f64       ┆ ---      │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆ str      │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_1 ┆ regressio ┆ 0         ┆ -0.008197 ┆ … ┆ -0.608413 ┆ 492.0     ┆ 0.511589  ┆ fwd_dir_ │\n",
+       "│ 0d        ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆ 10d      │\n",
+       "│ fwd_ret_5 ┆ regressio ┆ 0         ┆ 0.001611  ┆ … ┆ 0.260787  ┆ 497.0     ┆ 0.511944  ┆ fwd_dir_ │\n",
+       "│ d         ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆ 5d       │\n",
+       "│ fwd_ret_r ┆ regressio ┆ 0         ┆ 0.014003  ┆ … ┆ 2.836809  ┆ 497.0     ┆ null      ┆ null     │\n",
+       "│ isk_adj_5 ┆ n         ┆           ┆           ┆   ┆           ┆           ┆           ┆          │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆          │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = execution.catalog_rows.select(\n",
     "    \"config_name\",\n",
@@ -515,8 +894,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fe303ef",
-   "metadata": {},
+   "id": "4389690c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011362,
+     "end_time": "2026-08-25T22:37:15.227731+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.216369+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### One map, three targets\n",
     "\n",
@@ -534,14 +921,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6265ac83",
+   "execution_count": 12,
+   "id": "1bcbef73",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:37:15.249336Z",
+     "iopub.status.busy": "2026-08-25T22:37:15.249093Z",
+     "iopub.status.idle": "2026-08-25T22:37:15.256690Z",
+     "shell.execute_reply": "2026-08-25T22:37:15.256006Z"
+    },
+    "papermill": {
+     "duration": 0.023506,
+     "end_time": "2026-08-25T22:37:15.260151+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.236645+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>task</th><th>ic_mean</th><th>ic_t</th><th>scored_dates</th><th>full_coverage</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;regression&quot;</td><td>0.014003</td><td>2.836809</td><td>497.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;regression&quot;</td><td>0.001611</td><td>0.260787</td><td>497.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_10d&quot;</td><td>&quot;regression&quot;</td><td>-0.008197</td><td>-0.608413</td><td>492.0</td><td>false</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 6)\n",
+       "┌─────────────────────┬────────────┬───────────┬───────────┬──────────────┬───────────────┐\n",
+       "│ label               ┆ task       ┆ ic_mean   ┆ ic_t      ┆ scored_dates ┆ full_coverage │\n",
+       "│ ---                 ┆ ---        ┆ ---       ┆ ---       ┆ ---          ┆ ---           │\n",
+       "│ str                 ┆ str        ┆ f64       ┆ f64       ┆ f64          ┆ bool          │\n",
+       "╞═════════════════════╪════════════╪═══════════╪═══════════╪══════════════╪═══════════════╡\n",
+       "│ fwd_ret_risk_adj_5d ┆ regression ┆ 0.014003  ┆ 2.836809  ┆ 497.0        ┆ true          │\n",
+       "│ fwd_ret_5d          ┆ regression ┆ 0.001611  ┆ 0.260787  ┆ 497.0        ┆ true          │\n",
+       "│ fwd_ret_10d         ┆ regression ┆ -0.008197 ┆ -0.608413 ┆ 492.0        ┆ false         │\n",
+       "└─────────────────────┴────────────┴───────────┴───────────┴──────────────┴───────────────┘"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "by_label = catalog.select(\n",
     "    \"label\",\n",
@@ -556,8 +986,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2530b82f",
-   "metadata": {},
+   "id": "c7302743",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006917,
+     "end_time": "2026-08-25T22:37:15.273706+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.266789+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The same map against each target\n",
     "\n",
@@ -568,10 +1006,170 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0c5263f9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "f938489c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T22:37:15.287606Z",
+     "iopub.status.busy": "2026-08-25T22:37:15.286692Z",
+     "iopub.status.idle": "2026-08-25T22:37:17.097044Z",
+     "shell.execute_reply": "2026-08-25T22:37:17.096243Z"
+    },
+    "papermill": {
+     "duration": 1.815788,
+     "end_time": "2026-08-25T22:37:17.097727+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:15.281939+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#1a2d4a",
+           "#1a2d4a"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "fwd_ret_5d",
+          "fwd_ret_10d",
+          "fwd_ret_risk_adj_5d"
+         ],
+         "y": [
+          0.0016107269715182424,
+          -0.008197255687239478,
+          0.014003431352138006
+         ]
+        }
+       ],
+       "layout": {
+        "height": 420,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "What the exposures are fitted against changes what they rank"
+        },
+        "width": 800,
+        "xaxis": {
+         "title": {
+          "text": "Label, primary target first"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAGkCAYAAADJzkGPAAAQAElEQVR4AezdCbxM5RvA8WeunVLZS0LIvsuWJUr+UkpIdlFC9pQlu+yu7FtSWVJUKlEKZctWyJIkZGmRLKnsy/88LzPNHTN35rpz7z0z87sf75mzvO973vf7njMzz5wzI+r8+XNXSBhwDHAMcAxwDHAMcAxwDHAMcAxwDCTGMRAl/CGAQBIJsFsEEEAAAQQQQCDyBAhAIm/M6TECCCCAAAIIIIAAAkkmQACSZPTsGAEEEEAAAQQQiDwBeowAAQjHAAIIIIAAAggggAACCCSaAAFIolF77ohlBBBAAAEEEEAAAQQiT4AAJPLGnB4jgAACCCCAAAIIIJBkAgQgSUbPjhFAAAEEEIg8AXqMAAIIEIBwDCCAAAIIIIAAAgggEP4CtukhAYhthoKGIIAAAggggAACCCAQ/gIEIOE/xvTQU4BlBBBAAAEEEEAAgSQTIABJMnp2jAACCESeAD1GAAEEEECAAIRjAAEEEEAAAQQQCH8BeoiAbQQIQGwzFDQEAQQQQAABBBBAAIHwF4i8ACT8x5QeIoAAAggggAACCCBgWwECENsODQ1DIPwE6BECCCCAAAIIIEAAwjGAAAIIIIBA+AvQQwQQQMA2AgQgthkKGoIAAggggAACCCAQfgL0yFOAAMRThGUEEEAAAQQQQAABBBBIMAECkASjpWJPAZYRQAABBBBAAAEEECAA4RhAAAEEwl+AHiKAAAIIIGAbAQIQ2wwFDUEAAQQQQACB8BOgRwgg4ClAAOIpwjICCCCAAAIIIIAAAggkmECiBSAJ1gMqRgABBBBAAAEEEEAAgZARIAAJmaGioQjcsAAFEUAAAQQQQAAB2wgQgNhmKGgIAggggED4CdAjBBBAAAFPAQIQTxGWEUAAAQQQQAABBEJfgB7YVoAAxLZDQ8MQQAABBBBAAAEEEAg/AQKQ8BtTzx6xjAACCCCAAAIIIICAbQQIQGwzFDQEAQTCT4AeIYAAAggggICnAAGIpwjLCCCAAAIIIBD6AvQAAQRsK0AAYtuhoWEIIIAAAggggAACCISegL8WE4D4E2I7AggggAACCCCAAAIIBE2AACRolFSEgKcAywgggAACCCCAAAKeAgQgniIsR6zAuo2b5dY7i8vZs+eSzCB6wutS64mnk2z/7DhpBL74co3Urt9aMucuI02e6SJfrV5vjsXEbE3xig/L/A8WJ+Yuve5r6utvS5WaDb1ui9PKIGeu37S9DB4xPsi1hmZ1drDIlKu0LPtqbWgC+mg1z/8+YFgdlgIEIGE5rJHdqUL3PiT6RC5uf7qswcVHi5e5rRVp16Wv1Gn4bIx18V3QN5AvDxrtt5q7Ct4niz/70m8+MoS/wMCh46Rs6WJyaNdamTtjrNx6S3q5v3J5V8cnTpsl1Wo3di07Z8LxGLo9WxYpUayQs4vxfvRlF++KqSBeAlu+2yn6nHzyr1Ox1sP4xcpj2400DAF/AgQg/oTYHnICVe8rJ+s2fBuj3bqcP19uWbcx5vo167+R+8qXiZGXBQQSW+Dg4V+lXJmSkjp1KrNrfQP+4bxpZj7SJo/VflDGj+ofad2mvwgggEBECRCAJNhwU3FSCVQoV1LWWgHIxYsXTRP0UZe7PN9Kvl6/2azTyU/7Dsgh643ffeVL66Irrd+0RfTT5hwFKsqjTz4j327Z7tr2/Q8/yUt9h0m5anVFP31+7Kk28t2OXa7tHbsPMFc1Jk2fLfrpnqbde/a7tjtnSld+VE79/Y+53Ubz6FUb5zZ9nPHWO3Jv1Tpyd9Gq8kyHnvL7H0d1tSt9vmK1/K9uS8lZqJKUqVJHho+ZKpcuXXJt9zYTW5m1ViCWKVdpWblmg6vozNnzTR/3/XzQrNPbLrr0GCyNW3eWfCWqSdHytWTA0LGiviaDNTly9E9p06m3FCxTw+R5ut1LcviX36wtV//t2PWjtHiuu2h/td+Fy9YUvd1It+onobpOPxnVZWfSvM5bg5y3yX22bJXc/3AjyZa3rKz+epPp+4Sps6RSjQaS/Z4KZvw+XrLMWYX88+9p0bZXfLCeGRfNM37qW67tnjP+xlnzq4de6Xq+Wz/Rfjze6DldLbE5mwxuE92P9lmPhaee7mjapsvOpFnfXvCx9BkcLeriXP/mnPcktmPIXxt+PnBYGrboYMZXj+V33l+ku4o1aVtjO/a18N79B6RBs/Yx6vW8teu1N+eJ2uUqXNkcu0NGTYxxDHnegqV5+74SLV17vWKOKz3uBg0fH6OMjvUTjduZ80GN9Nj49bcj4stO2+otLV/5teg5r+d2uWqPS++Bo+T06TOurJcuXY61Hf765jx+V6z62hyj3p5jrly5IuOmvGnGV430fNOrANoeV0OsGX9jPGrca/LQ480la557zXH1tHUuWsW8/qv1xNMydvIbrm3tu/YzZZzPO3pbqt4eqO13ZoqPxYGDv5j+a13aRx0zfd7QZffkb/yO/PGn63jTc//d9z9xLy4nTv4l3V8eJqUqPSJqrceIPgdppoOHfpXbcpSQbTt/0EVX0nOrQKkH5cKFC6517jN6PHo774Mx9u770Xl97tTn9269hogeF7qOhEC4CESFS0foBwJOgUoVysiZM2dl47ffmVWbNm+TDLfdKnUfqSm7ftxrXpR0w9dWkJImTWopf28JXXSlkWOnyxOP/k9eHd5Xzpw9J227vOx68v/r1CkpWriAzH9roqz9YoFUr1pRnmjc1hUgTBg9QGr/r5o836aZnDz8nUl65cVV+bWZb1cvkvQ332Rut9F832/6/NoWkX37D8onn30pXZ5vLS91eU7Wrv9WhkdPdW3XIKFT94HSsmk90XqmvDpYNn7znQwcNs6Vx3PGXxm9CtS907PyXKeX5c9jJ2TX7p+sN1+jZXDfbnJ3rrtc1c2d/5GULV1CNq38SMaO6CvvfrBYRo+fYbbrC2TD5h3lh9175YO5U+WLj2aLvgl8oklb14t5j74j5M7s2WTpwjdl/45V8krfF0THwFQQh0n0hBky+pVecviHr6Vk8cIycuw0+fjTZTKwT1f5/pvPpUeXtiY4+swKVLTacZNnys8HD8uMiSPklx/Xybw3xkn227PoJq/J3zg7C82cvUDy3J1TVi99V2ZNjzYBXFzGplCBvOYYUYN33pxg5vV4cL/60bhBHeOk/dRtmlo2rW/G3tsx5G+sL1mBasOWHeXEX6dk1WfvyptTR4u+6T95MvZbYfyZ6Bu2p6x6U1lXca7WO0o+WvyFeNZ76u/T8kKnZ2Tb+k9l5Cs9reN7swyLnuwk9fo4992P5d5Sxcw5N2bYy6Lu73/0mcn79z//Suvne8pT9R+R79Ytka1rF0vLxvXE4XCILztT0GOibvrmskb1yvLNqo/l7ZnjJGOGDHLh2gcZmv0d6w3uxQsXZeTgntLg8VqiQayzHWL9Bdq3WW8vlOghvWXjVx9Kjux3SFu35xg9x0aPmy59XuogW79eLA8/VE2mv/mOVft//7StsR1nGuDoG+LBfbrJ/u2rZJV1fJYtXfy/CjzmKlof2qzfuNm1Vq8MZ86UwfrA5luzbsM3WyVVyhRmDMwKaxIfi5x3ZZcvF79t1SLy887V5rifPn6oWXaf+Bs/Pa+LFy0ok8cMlnvy3W059hENrp11NHv2Bfn7n3/ktQnDLMsl8kitaub5+pdff5e7ctwhNardJ++8t8iZ3TzOs5b1WEqRIoVZ9jbR48/9vNc8wRh7rceZ9IOrWvVaSX3rONNj3uFwODfxiEBYCBCAhMUw0gl3gbutN8x33J5V1l672rFm3bdSrXJ50dtbyt9bQr5affVTfn1jf1+50pI8eXL34tK/Vyfp2La5eeIf1r+77Nl7QPSTNs1UoWwpafZUXdEX0Bx33iGd27WUIoXyy5Klwfsuh77hmWe9+Wny5GPStnVjea5VY9E3ALp/Ta9OminPPt1Inqr3qGTKeJvca72x6N29nXlTptu9pUDKvNSljfUinlvaWW+GWrXvIQ/cX1FaWG/k3OsrU7KodGn/tOh3FB6oWlGef7aZvDn3PZNF3xRt3f69jB/dXwrmzyO5ct4p40cNkB9/+lmWfL7S5Pnt9yNSomghUbvbbr1F6j76kJQrEzMANBn9THp2aytlrDekOnYprPHTT28HW8GHtumW9DfL/2pUkRZN6stbb19t22+/H5XcuXJIoQJ5JV3atFLlvrJS77FaPvcS6DiXLFZYunVobQJcDQYCcfa50yBt8NeGL1evl9179sm4Ef3NGOlY6RvVv079HWsL/Jlovft+PiyvDut7rd68JnDyrPeFjq1F61Kv6lUqSo+uz8nc+R/Huu8HrTeK+mZUP0ioUa2SdWzeJ5s2bzdljlkBswY/+sGDHpd63GmAdnu2LGZ7oBN1a1S/jnRq20KyZM4oeXLnFG2rHk/OOooVzi/6IcOjtR6Qfj07yYP3V5SN325zbjb5A+lb7+7PS6kSRUTbqM815jnGunqoFc2et1CaNHzMOjdqmvOsacPHRZ+ndJszaVtjew7Q412tNOhImzaNFLM+NGn3TBNn8eseK1jPgyvXbjRXlfYfOCRH/zwmLZvUk683bDF59cpH+XtLxniujM1CC6ldIBaa90bTU9Z49XmpoxVYVJfp44eYD3W+3Xr1uFhl9UevGk6KHiilreetjBlulVbNnrTcC8v7Hy81u2zSsK7oVRM9fnSFPlfpc62u12VfyfO813yB9je2sdd6HA6H6FX1Rxq0sl5fWkjPbu10NQmBsBOICrse0SEELIHqVSrIug1XP9HTxwrlSllrxXrjU1Kc3wNZs+4bqWC98JoNbpPCBe9xLeXKmcPMHz123DyePn3G3O50f61G5heL9NYBfeN96PBvZnswJvrJmn4i7qwr1113mjcEzmV986i/xqP7dqYH6zQztxn99vsfzmwxHgMpExUVZX2SOEhWrFovf1r9HTOsT4w6dKFo4f9sdFk/ffz9yFFzm8q+nw9KtqyZRQMM3aYpf77coklvzdFl/TSvS4/Borct6W0mm7fu0NVxTqWsqx7OQvsPHJZz586bW9KcHvrYf8irst96Q6z56tapKbPe/sDcdqS3pnxqBUR6xUa3eUuBjnOJYgVjFA/EOUaBBFjw14afrTeYGgAWzJ/HtffKFe/1eyXKn8kB6wrTXVZQrp+cOyvWN/E335TOuWge9RbHxq07S4HSD5rbfPQ2RucxZDJ4mWS3PlBwX505022ucyKXFejqFbwajzUXvWVKP/k/cPAX9+wBzatb2dLFYs1bMH/eGNv1gwg9V5wrA+3bnXdkdRaRzJkymvmjfx43jxoAFLE+1DAL1yZFrcDn2qx50LbG9hygQZoGEdUebiyvjJwgeoud3uZnCnuZaHBx8eIl+dY6H/WDmapWgF6pwr2yZt0mk/tr67nU87kyWBZmBzc4KVQgn6ukfhihx9+fVkCqK/fuOyD/nj4tmXKVNseZPido+uyLVeK8SvLwQ1UlRfIUolecrTtnNwAAEABJREFUtczsd9433wnMlyenLvpMnue9ZgzG2Gs9eqX20QbPyMtWkPpMi6d0FQmBuAiETF4CkJAZKhoaF4H7KpSWdZs2y9mz58yj8xPE8mVLytfWlRH9pEsvw1euUOa6apMnS+Za53A4zLzzzWrvgaNl6/adMiHa+mR/y3LR22H0U/fzPu4XNoXjOHHfvxZ1OByuW8Ccy9FDe5t96/7dk36iqnk8k8PhkEDKrFi1Tm5Kl9YUv3L5inkMZOLsv7fbFpK5eeqnfzOnjJS7cmS3xuEbeeDRpjJh6iyzC4fjqrVZcJtcst4YuS2a2TSpU5tHnTgcV8utW/7+dSbrV3ygWUTHaMXiuSbg/Gnfz/Jc597muyxmo5dJoOOcJnWqGKUdjsCcYxQK8oLD4b8NnseYNiFZVJQ++EyBmnhW4Dx3dL0Gog2aPS8Nn3hUli58S44d2CxL3p+pm8R5DJkFj0lU1NUxjrn6v+Pz/TmTpW+PDpI6VSqZ994nUq56XevN8zcxswey5G03buWSJ//vuUFXOxxa4Go74tI3Dfa1vHtyd3Jf723e4Yh9jPUKzuql86Xxk3WsN+FnZFj0FLm/1lPyx9Fj3qoz57ze4qaBhj4/li9bSjQo2bv/oGgwt27jFuuNeakYZYNlEaPSOC54a8OVq8NhbsFTB/fnR+e83tKku9Lnq6ZPPSbvfrDI3Ca64INPza18ui225HneB3Ps9ep9xfKlrDYtNh8qxdYOtiEQygKxv+KEcs9oe+QKWD3X72bo90AmvTbH3B6jn5Jaq6Vi2dLmeyCffvGV6K0VpUoU1tUBp3UbN8sj/3tAilqfUN526y3mk/edP+yJUT5VylQxAoYYG90W9E305SuX3dYENlvI+hRWA4XAcl/NFUgZ/eS1z6BoGTuir/zvwarStksfuXw5Zvu27/zxaoXXpt9t3yVZM2cSvfXl7lx3mS+cu1+F0U8j9U2MfhJ+rYjUfKCy6G037741Ubp3ekYWfrLUbNJbcvTKz7ETJ82yTvRLsPrFdp33lfLkzmE+vV/+1de+spj1xYsUlC7tn5Zp44bIm9NGiV4F8bw9yGS0JoGMs5Xtun+FbmBsrqvEy4rUqVOKt4DQ2zHkrw25rKt6+qtbzk/cdXe79+z3+2bHn0lO60qdZ736xkx/AED3oWnz1p2SKWMG0V+60qsHGpxu37lbN8UrpbYCQb0lsV/PTrLik7lSukRR+WzZSlNnah92ZqPbJH++u2WT2+1UbpsCmg1W33Jb47Pj+5gmnkb+xlgbrG9k2zzdSIYNeEnWLXtfDlpXab+5dtuabvdMFcuVtK4afysr124Q/WAmVaqUVtBRWl6dPFNSpkghevulZxlfy4FYpLKCRS3v+Ryj69xToOPnXkbn899ztwm49DYsXfaVmjeqJ1+sWCuz5n0gp8+ckSesq6W+8vpaH0h/fZX1XK/Ws6aNkbRpUosG6+7nj2delhEIZQECkFAePdruU0DfFOutP9Nnvm2+/+HMmNp6o6Kf9E2ePlv0KoletnduC+RRb4XQe4svXrwo+ua6Xde+4vkm9u5cd8qu3Xuve/PuWb/earVzV8zgxTOPt2X9Aq/+/yHDoiebWwn0BVxvAxvxqu+fbfVXRut4tmNvqValvLn3fEj/7qKBw5iJVz+ddrZDv+Oht07pL1YtX/m1THpttjzdrIHZrN+rKF60oHR+aaDoG1q9zaFbr1ckZ447pFaNqiaP/prT5q1Xb7v6+59/zX38+oZLNzocDitALCWzrTcC+mmwfll69LgZop9S6nZfScewe6c2Mmbi66K/mnPcCmA0+Hzvw09lzrsfmmL6q2RLl682v5al9a5as1GyZc1s7hk3GTwmgYyzRxGz6M/ZZLqBSW4ruDt4+FdRd/fi3o4hf224v1I5yXv3XdK5x0BRKw0Ye/QbLqmsN5zudXvO+zPR71npWGu9Ova7dv9kfoHIvV69vfHX34/I9mtvsPU4Hh/Lr5F5tsHbsu4nesLrJvjV7brvvfsOSO6cd+qi+LIzG90mXZ9vZY4fbY9eKdDgSev1PL/disSYDVbfmjWqK3Pf/UgWLlpqxluP6aXLV8XYl78x1v/vaPY7C11B5aq1m8z3O3Jbz00xKnJb0Kse+j2Qf/89Lfoz0LqpgnUlZN6Cj6WCdeVYzzNdF0gKxCLHnbebY27H9zE/1PCsP9Dx8yynbdcrn8+/0E9WrPraXA3XDzQmTpsleruUM/9d1vNTdet5r8/gMfLEY/8z3xFzbgv0MZD+BlqX5kuZMoXMfX2s9dyXnCBEQUhhKUAAEpbDSqdUQO9Z1k/Py91bQhddqby1rOv1aohrZYAzQ/u/aAIL/TnXKv9rKPqpafWqFWKUbtLwcTlw8LBkuKuk6D3H+mY8RoZrCx2fayGTps8yefSnZq+t9vugL6yL5s8wX36t/kgTKVi6hkRPmCHnz5/zWdZfmehrb+DGjuhn6tCrEZPHDBINcr7ZvM2s00krK9jYvvMHyVW4suh3OZ6q94joly91m95W8s4b4+Wmm26Sxxu1kRqPNTO3Qbw3e4roC6rm0S/zP1y/lemz/iymBj6DXu6im0waPqinnDt/Xu7MX9F8R+C+8qUlc6YMZltsk24dWkm/nh3NF/GLlqsllWs+aYKPdGnTmGKXrCs5Haw3IhlzlhJNi5euEP1lHIdDb6ExWWJMAhnnGAWuLfhzvpYtzg/65r5YkQLGXY8p/alQrcTbMeSvDfpG8p03J8iF8xekaq1G5ja4+o/XMgGZ1ukr+TPRQHHB7Ely9sx5ua9GA/OdnHrWGzq90pg+/c2m2kIF8sqk6EHSvktfKVetrkRPnCHu428yxXGSNk0aWblmvRQp9z9zXJWuUkdqPlhFWjapb2ryZWc2uk2qWoHZ/FkTrStjX5mfBy5duY6pN0Xy5G65fM8Gq2/64xPdO7eRV0ZONOO9YOES0R+iSJ8+vWvn/sb4ppvSWs8ts63zqILo8dK2y8sy6pWe4vm9DVeF1kz5e0taz21XzAczemXKWiUVy5UyV3krePmunG73lQKx0O8GadBXp+Gzpo3efoZX6w90/DSvZ3prerQ8VL2y9B4wWvIUu18aPd1ZVq3dYD1HpRP3v6fqP2p+ObGR9ei+PtD5QPobaF364YvmTZ06lejzqc7rlZDTp8/orL/EdgRCRoAAJGSGiobGVWDs8L7mOwH6q1XuZQf07mLWd3iuuftq61O+Uma9PvE7N+ivTOl9w8UKFzCr9J7iGROHy8avPhL96Vy9lWjujLEypF93s10nuXPmkM1rPjF1aVm9EqPrPVOth6rKoR++Nvm0Lt3+QsfW8ukHb+isK+ntKnu3rXQt60zlivfKwrenyr7tK2X3luXy8buvSd8enXSTzxRbmRc7Pys/fLtM9LYyZwWaX+/R11+bcq5LbX1Krv3Xfm1f/6n079XZ+pQuhXOzZLOuKsycPEJ2ffOF7Nn6pbw1bbToJ4zODPqm//efNpo+ax3a7ux3ZHNuFv3y5ztvTDA/lavl9Vey1ObJJ2qbPPrGS8ultl6czYprE4fDYd5wLvt4timrP6OqP2Vb99GaJof+spHWp2U1bVr5sWj/zEYvk0DG+T3zvYPrzbXeuI7Nb3s2yP+sN83Optxfubwxci5rcKf90bZr0l950m3ejiFd768NeowumD1ZdAzVV39p6buvl4jTWevwTIGY6K12H7w9xYzBge/XSPUqFcxtMLo/Z30a7Kz+fL5s+HKhuV2q3mO1TF/1Nj7No7/8tmrpuzprkjfn4QN7WMdWtNmut3LpcaQumvSYHTeynzjfRPuyM4U9JvrlbT3/Du5aa9qk9eqvSGk2f+3QPP765u349XyOcTgc0rldS/Mzy9ofPZZ+O/KH64qO7kdTbGP8QNWKot9/0vKa9Kdun23ZSIv5TPrdr6P7vxF9PnNm0n1oeX1ecq7Tx2BYaD36C09avyZvP8OreXyN358/fysP3n+fZnElPW70+HGu0D7p871a/PLjOvly8dsyf9YkKVIw5o9p/HzwVylwTx4J5Bf5vPVd9xeMsVdnPf60Pk167OmyJp3XdSQEwkUg/AKQcBkZ+oEAAgiEmIDeNvTFl2vE3F737XeiP+dczQpCfAXhIda9RGmu3j44cux08/Pfx46flCkz5srseQvl6aZXr+gkSiMiaCdq/Nob86R18wYR1Gu6ikDSCxCAJP0Y0AIEwkaAjiDwfLd+orfXte7QS/LkvktenzQclDgI6JUb/cL/vVXrSJFyNWXBh0tk5uSR5gptHKohawAC7br0lXurPiZPPFbTCvAIQAIgIwsCQRMgAAkaJRUhEN4Cvm49CO9e07u4COgtbz9uWWFuX9q2bolMGjPI/ApdXOqI9Lz6fSm97UpvS9Jb8/RXvfQ2zABcyBJHgSljB5vbWPX7TfrdqDgWJzsCCMRDgAAkHngURQABBBBAAAEEEIh0AfofVwECkLiKkR8BBBBAAAEEEEAAAQRuWIAA5IbpKOgpwDICCCCAAAIIIIAAAv4ECED8CbEdAQQQsL8ALUQAAQQQQCBkBAhAQmaoaCgCCCCAAAII2E+AFiGAQFwFCEDiKkZ+BBBAAAEEEEAAAQQQuGGBoAUgN9wCCiKAAAIIIIAAAggggEDECBCARMxQ09EwFqBrCCCAAAIIIIBAyAgQgITMUNFQBBBAAAH7CdAiBBBAAIG4ChCAxFWM/AgggAACCCCAAAJJL0ALQlaAACRkh46GI4AAAggggAACCCAQegIEIKE3Zp4tZhkBBBBAAAEEEEAAgZARIAAJmaGioQggYD8BWoQAAggggAACcRUgAImrGPkRQAABBBBAIOkFaAECCISsAAFIyA4dDUcAAQQQQAABBBBAIPEF4rtHApD4ClIeAQQQQAABBBBAAAEEAhYgAAmYiowIeAqwjAACCCCAAAIIIBBXAQKQuIqRHwEEEEAg6QVoAQIIIIBAyAoQgITs0NFwBBBAAAEEEEAg8QXYIwLxFSAAia8g5RFAAAEEEEAAAQQQQCBgAQKQgKk8M7KMAAIIIIAAAggggAACcRUgAImrGPkRQCDpBWgBAggggAACCISsAAFIyA4dDUcAAQQQQCDxBdgjAgggEF8BApD4ClIeAQQQQAABBBBAAIGEFwibPRCAhM1Q0hEEEEAAAQQQQAABBOwvQABi/zGihZ4CLCOAAAIIIIAAAgiErAABSMgOHQ1HAAEEEl+APSKAAAIIIBBfAQKQ+ApSHgEEEEAAAQQQSHgB9oBA2AgQgITNUNIRBBBAAAEEEEAAAQTsLxB6AYj9TWkhAggggAACCCCAAAII+BAgAPEBw2oEELhegDUIIIAAAggggEB8BQhA4itIeQQQQAABBBJegD0ggAACYSNAABI2Q0lHEEAAAQQQQAABBIIvQI3BFiAACbYo9SGAAAIIIIAAAggggIBPAQIQnzRs8BRgGQEEEEAAAQQQQACB+AoQgMRXkPIIIMJ0F98AABAASURBVIBAwguwBwQQQAABBMJGgAAkbIaSjiCAAAIIIIBA8AWoEQEEgi1AABJsUepDAAEEEEAAAQQQQAABnwIBByA+a2ADAggggAACCCCAAAIIIBCgQFgFIH8eOyEdXhoqrTr2k96Dx8mZs2e9Mny3Y7e07NBXmrXrLTNmv+/K8+GSFdLomRelQs2mcuLkKdf6n/YdNOt0vaauL49ybWMGgUQQYBcIIIAAAggggEDYCIRVADJu2lwpX6a4zJwwSNKnv1nmLlhy3UBduXJF+g2bJC91bClvTBwsK1ZvlC3bdpl8WTNnlEG9O0imjLeZZfdJ6eKFZN3SOSa9OuRF903MI4AAAgiErQAdQwABBBAItkBYBSBrN2yV2g9VNka1a1SWNRu2mHn3ye6ffpa0adNIofx5JHmyZPJQtYqyev1mk6XCvcUl3905zXygkxQpUgrJ/gYXLlyUZMmSM1YcrxwDQToGnM+RPP/Z//mPMQqNMdLXqIsXL/Ic5f4cZeN553MgjzcmEDYByL+nz4jDIXLbremNRI7sWeXon8fNvPvkyNHjkj1bZtcqzXfkj2OuZV8zO3fvlUq1mssznQfItp0/urLpFRXSFbG7gQ6Y3duY8O27bI0T6cqVYBrY/9i/Yl31JYXSOAXz+KSuK+Z8D53x57UqtMZKx4t0YwJhE4Bo96Oi/uuOw/HfvG5zT44oK1JxrfCdz5nljtuzyMdzx8unC6ZI9SrlpHu/aDl95ur3S86cOS0JnKg/CMbnz5+Ts2fPRLil9p905kwwDSL3/D937pxoOhOE85M63I+jYB6f1HXGnO/uvvad19cofa06wzkVEq/VzveIPN6YgP933zdWb6KXSpc2jVy6dFnOX7hg9n3sxEnJnCmDmXefZM2cQU6c/Nu16riVL2uWjK5lbzNp06SWm29KZ1LjerUkW5ZMcuiX303WtGnTCcn+BilTppI0adIyVhyvcTwG7H9sJ9XzT+rUqUVTUu2f/XJshtsxoK9R+loVbv0K1/6YN4FMblggbAIQFahYtoQs+2qdzsrnX34tlcqVMPN6e9aOXXvMfP68uUR/LUsDiEuXL8vylRukUvlSZpuvyT//nnZt0l/EOvHXKcmRPZtrHTMIIIAAAgggEGQBqkMAgbAVCKsApEvbJrJo6SrzM7wHD/0mTRrUNgN32LpaMXj0NDPvcDhkYM/20nfoRGn5fB8pXbKQlCpW0GybMvNd83O7GqA83LC9dO832qxf8sVqs75y7ZYSPXmWDO3TSfSqiNnIBAEEEEAAAQQQQACBMBJI6K5EJfQOErN+/fncKaP7iP4M79C+nSVN6tRm9/nz5ZZ3X78aTOiK4kXyy5uTXpHZU4bKs83q6SqT2rVqaH5m1/lzu6MHdTfrn3y8plm/evGbovUXLZTPrGeCAAIIIIAAAggggAACcRMIqwAkbl0nNwL+BNiOAAIIIIAAAgggEGwBApBgi1IfAggggED8BagBAQQQQCBsBQhAwnZo6RgCCCCAAAIIIBB3AUogkNACBCAJLUz9CCCAAAIIIIAAAggg4BIgAHFReM6wjAACCCCAAAIIIIAAAsEWIAAJtij1IYBA/AWoAQEEbC8QPXmukIJnMGbK2zL+tfmYBvm4WvT5atufS5HYQAKQSBx1+owAAggggIAPgUBXj5n6tpCCZ/DqtHkyfsYCTIN8XH3y+ZpAD2nyJaIAAUgiYrMrBBBAAAEEEEAAAQR8CETMagKQiBlqOooAAggggAACCCCAQNILEIAk/RjQAk8BlhFAAAEEEEAAAQTCVoAAJGyHlo4hgAACcRegBAIIIIAAAgktQACS0MLUjwACCCCAAAII+BcgBwIRI0AAEjFDTUcRQAABBBBAAAEEEEh6AfsFIElvQgsQQAABBBBAAAEEEEAggQQIQBIIlmoRCEUB2owAAggggAACCCS0AAFIQgtTPwIIIIAAAv4FyIEAAghEjAABSMQMNR1FAAEEEEAAAQQQuF6ANYktQACS2OLsDwEEEEAAAQQQQACBCBYgAIngwffsOssIIIAAAggggAACCCS0AAFIQgtTPwIIIOBfgBwIIIAAAghEjAABSMQMNR1FAAEEEEAAgesFWIMAAoktQACS2OLsDwEEEEAAAQQQQACBCBZwBSARbEDXEUAAAQQQQAABBBBAIJEECEASCZrdIBCLAJsQQAABBBBAAIGIESAAiZihpqMIIIAAAtcLsAYBBBBAILEFCEASW5z9IYAAAggggAACCIhgELECBCARO/R0HAEEEEAAAQQQQACBxBcgAEl8c889sowAAggggAACCCCAQMQIEIBEzFDTUQQQuF6ANQgggAACCCCQ2AIEIIktzv4QQAABBBBAQAQDBBCIWAECkIgdejqOAAIIIIAAAgggEIkCSd1nApCkHgH2jwACCCCAAAIIIIBABAkQgETQYNNVTwGWEUAAAQQQQAABBBJbgAAkscXZHwIIIICACAYIIIAAAhErQAASsUNPxxFAAAEEEEAgEgXoMwJJLUAAktQjwP4RQAABBBBAAAEEEIgggQgOQCJolOkqAggggAACCCCAAAI2ESAAsclA0AwEIkqAziKAAAIIIIBAxAoQgETs0NNxBBBAAIFIFKDPCCCAQFILEIAk9QiwfwQQQAABBBBAAIFIEKCP1wQIQK5B8IAAAggggAACCCCAAAIJL0AAkvDG7MFTgGUEEEAAAQQQQACBiBWImABk/odLpWnbXtK83cuyat1mrwP+57ET0uGlodKqYz/pPXicnDl71uQ7cfKUdO87Wqo91lpGjn/DrGOCAAIIhKIAbUYAAQQQQCCpBSIiADlw6DeZ9c4imTamn4wc0FWGRE+Xs+fOX2c/btpcKV+muMycMEjSp79Z5i5Y4srz8ENV5Nlm9VzLzCCAAAIIIIAAAnEQICsCCFwTiIgAZM36zVL1vjKSLm0ayZY1kxTIl1s2bd4hnn9rN2yV2g9VNqtr16gsazZsMfO33ZpeqlcuK2nSpDLLTBBAAAEEEEAAAQQQQODGBBI/ALmxdsar1NFjx+WObJldddx5R1b5489jrmWd+ff0GXE4RDTY0OUc2bPK0T+P62ys6cKFC0Kyv8GlS5cYJ45VjoEgHgMXL14UTTz/2f/5L6HGKNYXRzYiYBOBy5cvJ8hzv026F7LNiIgAREfHEfVfVx0OK9LQlR4pKkae//J7ZIuxeOXKFSHZ30AHjXG6IhjY/1hljBijUDkG9HmVhEAoCCTEORUK/bZzGwN7l23nHgTQtswZM8jJk3+5ch4/cVKyZMroWtYZvT3r0qXLct76hFCXj1l5MmfKoLOxppQpUwrJ/gbJkiVjnDhWOQaCeAykSJFCNPH8F/DzX9gdf8IfAiEgoB8uJ8TzVAh03dZNjIgApFL5UrJ6/WY5d/68HD/xl3y/e5+UK1PUDMyWbbusS3MXzXzFsiVk2VfrzPznX34tlcqVMPNMEEAAAQQQQAABBEJVgHbbTSAiApCcOW6XurUfkNad+kuX3iOla/vmktL69E4H46UBr8pfp/7WWenStoksWrrK/AzvwUO/SZMGtc36i5cuSYWaTc1P8C5cvNzM796z32xjggACCCCAAAIIIIAAAoELRAWeNbRzPvl4TZkzdZjMmjJEqlYs7erMFx9Ml0wZbzPL+jhldB/zM7xD+3aWNKlTm/XJkyWTdUvnxEj58+U220JpQlsRQAABBBBAAAEEEEhqgYgJQJIamv0jgEBEC9B5BBBAAAEEELgmQAByDYIHBBBAAAEEEAhHAfqEAAJ2EyAAsduI0B4EEEAAAQQQQAABBMJBwEcfCEB8wLAaAQQQQAABBBBAAAEEgi9AABJ8U2pEwFOAZQQQQAABBBBAAIFrAgQg1yB4QAABBBAIRwH6hAACCCBgNwECELuNCO1BAAEEEEAAAQTCQYA+IOBDgADEBwyrEUAAAQQQQAABBBBAIPgCBCDBN/WskWUEEEAAAQQQQAABBBC4JkAAcg2CBwQQCEcB+oQAAggggAACdhMgALHbiNAeBBBAAAEEwkGAPiCAAAI+BAhAfMCwGgEEEEAAAQQQQACBUBSwe5ttHYBcunxZfjtyVL7buVt+2ndQ/jr1j909aR8CCCCAAAIIIIAAAgjEImDLAOTI0WMyePR0ebDus9K222CZMP1t6Tt0gtRv2U2ebPWCLFm2OpYusQkBpwCPCCCAAAIIIIAAAnYTsGUA0qnnMClR9B5Z+t5U+WjueJkxbqDMmzFKvvhguozo3002frtD5sxfbDdL2oMAAggg4BTgEQEEEEAAAR8CtgxAZk4YLI/WvF9SpkhxXbNz58wuA3q0k7qPVL9uGysQQAABBBBAAIFIF6D/CNhdwJYBSLq0afy6BZLHbyVkQAABBBBAAAEEEEAAgUQVsGUA4hRYs36LPNtloFR+uIVUqNnUlZzbY39kKwIIIIAAAggggAACCNhNwNYByOtzPpDuHVrIV5+8IeuWznEluyHSHgQQ8BBgEQEEEEAAAQQQ8CFg6wAka5aMkj9vLkkWZetmCn8IIIAAAgjYRYB2IIAAAnYXsPU7+4wZbpUPPlkm//x72u6OtA8BBBBAAAEEEEAgsgXofYACtg5APli0TEZNeFNqPNHG9f0P/S5IgH0jGwIIIIAAAggggAACCNhMwNYBiPv3PtznbWZIczwFWEYAAQQQQAABBBBAwIeArQMQbfOVK1dk38+/mKTzuo6EAAIIIOBdgLUIIIAAAgjYXcDWAchHS1aY26869Rwmmh6q95x8/NlXdjelfQgggAACCCAQeQL0GAEEAhSwdQAyZ8FiGdCjvSyaN8Gkfi+2ldnvLgqwa2RDAAEEEEAAAQQQQAABuwkEPwAJYg+TJ08ulcqXFIfDYVLlCqUkKsoRxD1QFQIIIIAAAggggAACCCSmgK0DkGTJomTdpu9cHmvWb5GUKVO6lplBAIGYAiwhgAACCCCAAAJ2F7B1ANKzcysZPfEt10/wjp06W3Sd3VFpHwIIIIBAxAnQYQQQQACBAAVsHYAUKZhP3nszWuZOG2HSgjeipXCBvAF2jWwIIIAAAggggAAC4S9AD0NNwJYByKYtO+Sff0+LPn6zdaccO3HCJJ3XdaGGTHsRQAABBBBAAAEEEEDgqoAtA5DX5yyUI0ePiT56S1ebztRTgGUEEEAAAQQQQAABBOwuYMsAZGp0X8mTK4foo7dkd1TahwACESdAhxFAAAEEEEAgQAFbBiDOtrd9YbBz1vXY9LlernlmEEAAAQQQQCDSBeg/AgiEmoCtAxBPzH9Pn5Fz5897rmYZAQQQQAABBBBAAAEEElvgBvdnywBk+lsLzE/vfrdjt3msULOpeWzatpc88ciDN9hViiGAAAIIIIAAAggggEBSC9gyAGnTooGsWzpH6td5yDzqvKaFs8ZKo3q1ktqM/SPgKcAyAggggAACCCCAQIACtgxAnG1/4fnmzlkeEUAAAQQQ8CLAKgRUt4NbAAAQAElEQVQQQACBUBOwdQBy8PDv0qX3CLn/0VbmFiznrVihhkx7EUAAAQQQQACBsBOgQwjcoICtA5BBo6bKo/+rJgXuyS2L3p4gHZ5pJK2b1r3BrlIMAQQQQAABBBBAAAEEklrA1gHI2bPn5IEqZeXy5cuSKeNt0qRBbdn38+GkNvPcP8sIIIAAAggggAACCCAQoICtA5C0aVObbjgcDjn0y+9y9tx5OX7ilFnnbfLnsRPS4aWh0qpjP+k9eJycOXvWWzbRX9dq2aGvNGvXW2bMft+Vx1f5n/YdjHELWNeXR7nKMIMAAkkpwL4RQAABBBBAINQEbB2AlCiSX06e+lsaPfGwNH62h1Sr00pqVCvv03jctLlSvkxxmTlhkKRPf7PMXbDkurxXrlyRfsMmyUsdW8obEwfLitUbZcu2XSZfbOVLFy/k+kWuV4e8aPIzQQABBBBAIGIF6DgCCCBwgwK2DkDat35KbrUCifsrlZHVS94yAUC9R2v47OraDVul9kOVzfbaNSrLmg1bzLz7ZPdPP0vatGmkUP48kjxZMnmoWkVZvX6zyRJIeZORCQIIIIAAAggggAACSSQQ6ru1ZQCyacsOiS15Q//39BlxOERuuzW92Zwje1Y5+udxM+8+OXL0uGTPltm1SvMd+eOY+Cu/c/deqVSruTzTeYBs2/mjqzwzCCCAAAIIIIAAAgggELiALQOQ1+csFE0Tps+TTj2HS58hE2XomBlmfszkWT57FxX1X3ccjv/mPQs4oqxIxbXyv3y+yt9xexb5eO54+XTBFKlepZx07xctp89c/X7J2bNnhJRUBoHv9+LFC3Lu3FnGiuOVYyBIx8D58+dEE89/gT8PhZuV62WUGQRsLHDp0qUEed63cZdDomn/vfu2UXOnRvcVTZkz3SqjBr4gn1lv/BfOHiszxg2QnHfe7rWl6dKmkUuXLsv5CxfM9mMnTkrmTBnMvPska+YMcuLk365Vx618WbNklNjKp02TWm6+KZ1JjevVkmxZMpkvxWslKVKkFJL9DaKikkny5CkYK45XjoEgHQPJkiWXZFbi+c/+z38JNUb6GkhCwO4CUdaH0wlxDti933Zvny0DECfakT+OS6XyJcXhcJhVhQvkNY++JhXLlpBlX60zmz//8mupVK6Emdfbq3bs2mPm8+fNJfprV/qrWpcuX5blKzdY+yhltvkq/8+/p812negvYp3465TkyJ5NFyVZsmSkEDDQJyDGimOVY4BjgGMgeMeAeRFkkiQC7DRwAYfDkSDv04S/eAlExat0AhfWW6XWf/Oday+79+yXk6f+cS17znRp20QWLV1lfob34KHfzP8bonkO//K7DB49TWdNMDOwZ3vpO3SitHy+j5QuWUhKFStotvkqv+SL1eZneCvXbinRk2fJ0D6dRK+KmEJMEEAAAQQQQAABBBBAIGCBqIBzJkHGl7s9K9GTZsnDDdtLg6dfkL7DJkrXtk2vteT6h0wZb5Mpo/uI/gzv0L6dJU3q1CZT/ny55d3XR5t5nRQvkl/enPSKzJ4yVJ5tVk9XmeSr/JOP1zS/wLV68Zum/qKF8pn8TBBAAAEEEEAAAQQQQCBuArYOQApYgcP8maNl4oiXZUT/bjJ/ZrRoMBG3LpIbAQSCLkCFCCCAAAIIIIDADQrYMgDRn+DV713o4zdbd8qxEydM0mVNN9hXiiGAAAIIIBDyAnQAAQQQCHUBWwYg+hO8R44eMz/Fq/OeKdTRaT8CCCCAAAIIIIBAyAnQ4CAJ2DIA0Z/gzZMrh/kpXp33TEHqO9UggAACCCCAAAIIIIBAIgvYMgBJZAN2F1cB8iOAAAIIIIAAAgggcIMCtgxAqj7ytMSWbrCvFEMAAQRCXoAOIIAAAgggEOoCtgxAVn7yhsSWQh2d9iOAAAIIIIBAyAnQYAQQCJKALQMQ975duHBRduzaI/rrV87kvp15BBBAAAEEEEAAAQQQCB2BuAcgidi3Neu3yBPNu0iX3iNl1IQ3pFPP4TLxtXmJ2AJ2hQACCCCAAAIIIIAAAsEUsHUAMun1d+S1cQMk7913mf+E8I2Jg635nMHsP3UhEFICNBYBBBBAAAEEEAh1AVsHIMmTJ5NsWTKJ3oal0AXy5ZbTZ07rLAkBBBBAAIHEFGBfCCCAAAJBErB1AJI2TWrTzVtvuUk+WrJC9JasEyf/NuuYIIAAAggggAACCESCAH0MNwFbByANHntITp76W9q3fkqWrdwgcxZ8Is+1qB9uY0B/EEAAAQQQQAABBBCIGAFbByAPVi0vt6a/WfR/RZ8wopf5n9FLFisYMYPj2VGWEUAAAQQQQAABBBAIdQFbByBNn+slb7+3xFwFCXVo2o8AAiEtQOMRQAABBBBAIEgCtg5A+nZvIwcO/SpPPt1duvcbLStWb5SLly4FqetUgwACCCCAAAL2F6CFCCAQbgK2DkDy58stvbo+Ix/NHSf3lSsps95dJI8+1SHcxoD+IIAAAggggAACCCBgP4EEapGtAxD3Pkc5HO6LzCOAAAIIIIAAAggggEAICtg6ANm9Z78Me3WGPNaks6xev1maN3xUFr0zMQSZaXKIC9B8BBBAAAEEEEAAgSAJ2DoAGTx6uuTMcYfMf2O0jB7UXapXLivJkyULUtepBgEEEEDA/gK0EAEEEEAg3ARsHYDMmTZMGtd/2PwUb7jB0x8EEEAAAQQQQMDWAjQOgQQSsGUAor949evvf3jt8l+n/pHRE9+S2fM/8bqdlQgggAACCCCAAAIIIGBfAVsGII88dL907jVCnn9xiEx6fZ5Mf2uBSYNGTZUmbXrKmbPn5NGaVRJLlf0ggAACCCCAAAIIIIBAkARsGYDcX6mMzJ85Wp5u8rikSZ3G1dUSRfLLGxMHif7/ILfekt61nhkEEAhXAfqFAAIIIIAAAuEmYMsARJEdDoeUKVFYWllBSJsWDURTnVrVJHOmDLqZhAACCCCAAAIJKUDdCCCAQAIJ2DYASaD+Ui0CCCCAAAIIIIAAArYWCPfGEYCE+wjTPwQQQAABBBBAAAEEbCRAAGKjwaApngIsI4AAAggggAACCISbgC0DkO3f75Ev12y6znr5qo3y/e69161nBQIIIIBAkAWoDgEEEEAAgQQSsGUA8uqU2ZL7ruzXdfnunNll6hsLrlvPCgQQQAABBBBAIFwE6AcC4S5gywBE/7PBXHfdcZ19bisA+e3I0evWh9uKJq07S7qsBUlBNMicu7TcfHthTINoqsdouJ179AcBBBBAAAEEEl7AlgHIlStXRMR75y9euuR9A2sRQAABBBBAAAEEEEDA9gK2DEDuyXOXrN249Tq81es2S/48Oa9bzwoEEAiyANUhgAACCCCAAAIJJGDLAKTTc01k6JjXZNjY12X5yg3y2fI11vIMa3mGdHi2UQJRUC0CCCCAAAJJL0ALEEAAgXAXsGUAcke2LDJ32jC5KV0amfj6PHl9zkK55ZZ08vZrI+TOO7KF+5jQPwQQQAABBBBAAIHEF2CPiSRgywBE+37rLeml47ONZeGssbLgjWh5vnUjuTX9zbqJhAACCCCAAAIIIIAAAiEqYMsAZP6HSyW2FKLWodNsWooAAggggAACCCCAQAIJ2DIA2bxtl8SWEsiCahFAAIEkF6ABCCCAAAIIhLuALQOQ4f26SGwp3AeF/iGAAAIIIIBAoguwQwQQSCQBWwYgidR3doMAAggggAACCCCAAAKJLHB9AJLIDWB3CCCAAAIIIIAAAgggEDkCBCCRM9b0NAQEaCICCCCAAAIIIBDuAgQgAY6w/ipX07a9pHm7l2XVus0BliIbAggggECICNBMBBBAAIFEErB1AHLol99lysx3pWOPYdL2hcGulEg2rt0cOPSbzHpnkUwb009GDugqQ6Kny9lz513bmUEAAQQQQAABBBC4UQHKRZqArQOQV6w3+rfckl6aPllbWjet60qJPUhr1m+WqveVkXRp00i2rJmkQL7csmnzDuEPAQQQQAABBBBAAAEE4iZg6wAk/c3ppHG9WlKudDG5t2QRV4pbF+Of++ix43JHtsyuiu68I6v88ecxs7x3/8/iL504cUL8Ja3Dmc6cPSvJkie7Lpkd+pl4K+e5zk8VZrNnGW/LJqOfibdynuv8VGE2e5bxtmwy+pl4K+e5zk8VZrNnGW/LJqOfibdynuv8VGE2e5bxtmwy+pl4K+e5zr0KX8e181iO7dFXWff1sZV3bnPP72vemTe2R19l3dfHVt65zT2/r3ln3tgefZV1Xx9beec29/y+5p15Y3v0VdZ9fWzlndvc8/uad+aN7dFXWff1sZV3bnPP72vemTe2R19l3dfHVt65zT2/r3ln3tgefZV1Xx9beec29/ye887nAodDxF+SAP781aHbA6jGb1uoR/waSQB/6ugvBVCN37boPuJTz7+n/3W9T/M8hr0tO4/92B61XCBtIo9vgSjfm5J+S8oUKeTng78mfUOsFjii/qNyOKxnW2ud/mv0zIviL7Vp00b8Jfc6Dv56TPLly399yplF8vlL3sp5rvNXh273LONtWfP5S97Kea7zV4du9yzjbVnz+Uh578p81c5bOc91PuqIYe9ZxttyBNTj67h2P559zfsq677eV1n39e75fc0/ZZ2nDVu/KLEkqfXE035TbOWd2yKlnjoNnxNN7v11GsT26J7f13xs5Z3bfJV1X+/MG9uje35f87GVd27zVdZ9vTNvbI9NWzwTp9cL93PBfd7XueC+3j2/r3n3/J7zOTKmEE3ZMqYVf0nz+Uv+6tDt/urQ7ZrPX9J8/pK/OnS7vzp0u+bzlzTf1ZTcmF6dv+rrnPdXh2535o3tUfP5S7GVd27zV4dud+aN7VHz+UuxlXdu81XH7h92u96neR7D3pZ9nQvu67Wcvgck3bjAf++qb7yOBCu578Av0ujZl6RZu96u73/od0ESbIc+Ks6cMYOcPPmXa+vxEyclS6aMZnnj8gXiLy1YsED8Jfc6vvnyPfn2q/evS1s3rhR/yVs5z3X+6tDtnmW8LWs+f8lbOc91/urQ7Z5lvC1rPl9p3crPZPP6L68zjWs9zvq9lfNc58wb26NnGW/LsZV3bvNWznOdM29sj55lvC27l/d1XLsfz77mfZV1X++rrPt69/y+5vv16CS//Xk61nTo2AXxl/zVodv91aHbNZ+/pPn8JX916HZ/deh2zecvaT5/yV8dut1fHbpd8/lLms9f8leHbvdXh27XfP6S5vOX/NWh29t16Bqn1wv3c8F93te54L7ePb+veff8nvPrv/xQNH2zYoH4S5rPd6Ietfl6+Qfy5ZJ5xlSXPZM/Y93uWcbbsubzl7yV81znrw7d7lnG27Lm85e8lfNc56uOTdbx6Ty+PY9hb8vOvLE9ajnzJpDJDQvYOgDp1r6ZjB/eUzq1aez6/od+F+SGe3uDBSuVLyWr12+Wc+fPy/ETf8n3u/dJuTJFb7A2iiGAAAIIIIAAAgggy168EAAAEABJREFUYAOBJGqCrQMQ9+99uM8ntlXOHLdL3doPSOtO/aVL75HStX1z0dvDErsd7A8BBBBAAAEEEEAAgVAXsHUAolcc3pr3sfWmf0SS3oKlg/zk4zVlztRhMmvKEKlasbSuIoWPAD1BAAEEEEAAAQQQSCQBWwcgg0ZOlaPHTsifx05aVyCqy01p00iBfLkSiYbdIIAAAggkvAB7QAABBBCINAFbByD7fj4k3Tu0kHTp0kjN6vfJ6MHd5fCvRyJtjOgvAggggAACCCAQfAFqRCCJBGwdgKRLl9awXLx4SU6fOWvmL1y4ZB6ZIIAAAggggAACCCCAQOgJ2DoAuSldOjl56m+5r2wJebpDHyv1lWxZrv78rQTvj5oQQAABBBBAAAEEEEAgkQRsHYCMHfqS3Jr+ZmnVtK707vqstG/dUF7q3CqRaNgNAggkvAB7QAABBBBAAIFIE7B1AKKDsW3njzL/w6VSvEh+yX1Xdjl0+HddTUIAAQQQQACB+AhQFgEEEEgiAVsHIPoTvMPGvi4fLfnS8Fy5ckWGjHnNzDNBAAEEEEAAAQQQQCAUBSK9zbYOQD5bvlpmTR4iN9+czoxT5kwZ5N/Tp808EwQQQAABBBBAAAEEEAg9AVsHIKlSp5YUKZLHUHWII8YyC6EsQNsRQAABBBBAAAEEIk3A1gHIbbekl+937zVjordfvT5noeS9+y6zzAQBBBBAIB4CFEUAAQQQQCCJBGwdgPTv0VY++GS57Pxhr1Sp3VIO/fK7dG3XNImo2C0CCCCAAAIIIBB/AWpAINIFbB2A6E/w9nmhjSx5d5IsnDNOBvRoJ7daV0UifdDoPwIIIIAAAggggAACoSqQhAGIb7JNW3aIe/phz37Zf+Cwa53vkmxBAAEEEEAAAQQQQAABOwvYMgDp1HO4xJbsDErbEAgJARqJAAIIIIAAAggkkYAtA5CqFUtL/ny5pX3rp+STdybKuqVzYqQksmK3CCCAAAIIxFuAChBAAIFIF4iyI8Dw/l1l3NAekiplCukxYKx07jVCPl22Rs6eO2/H5tImBBBAAAEEEEAAAfsL0EKbCNgyAFGbW9LfJE8+XlNmjBsg9evUkOhJb8m89z/VTSQEEEAAAQQQQAABBBAIUQHbBiB/nfpH5n+4VFp17CfTZ70n7Vs3lIZ1a4Yos82aTXMQQAABBBBAAAEEEEgiAVsGID0HviqPN+ssu/f8LF3bNZPZU4bKE488KGnTpE4iJnaLAAIIBEeAWhBAAAEEEIh0AVsGICu//layZ8siv/z+h0x6/R1p+8LgGCnSB43+I4AAAggggECcBSiAAAI2EbBlADJ+eE/p3LaJtG5a12uyiR3NQAABBBBAAAEEEEAAAb8CMTPYMgC5t2QRiS3F7AJLCCCAAAIIIIAAAgggECoCtgxAQgWPdiIQVwHyI4AAAggggAACkS5AABLpRwD9RwABBCJDgF4igAACCNhEgADEJgNBMxBAAAEEEEAAgfAUoFcIxBQgAInpwRICCCCAAAIIIIAAAggkoAABSALielbNMgIIIIAAAggggAACkS5AABLpRwD9RyAyBOglAggggAACCNhEgADEJgNBMxBAAAEEEAhPAXqFAAIIxBQgAInpwRICCCCAAAIIIIAAAuEhYNNeEIDYdGBoFgIIIIAAAggggAAC4ShAABKOo0qfPAVYRgABBBBAAAEEELCJAAGITQaCZiCAAALhKUCvEEAAAQQQiClAABLTgyUEEEAAAQQQQCA8BOgFAjYVIACx6cDQLAQQQAABBBBAAAEEwlEgEgKQcBw3+oQAAggggAACCCCAQEgKEICE5LDRaARCRYB2IoAAAggggAACMQUIQGJ6sIQAAggggEB4CNALBBBAwKYCBCA2HRiahQACCCCAAAIIIBCaArQ6dgECkNh92IoAAggggAACCCCAAAJBFCAACSImVXkKsIwAAggggAACCCCAQEwBApCYHiwhgAAC4SFALxBAAAEEELCpQFgFIH8eOyEdXhoqrTr2k96Dx8mZs2e9sn+3Y7e07NBXmrXrLTNmv+/K46v8T/sOSoWaTV2p68ujXGWYQQABBBBAAAEE3AWYRwCB2AXCKgAZN22ulC9TXGZOGCTp098scxcsua73V65ckX7DJslLHVvKGxMHy4rVG2XLtl0mX2zlSxcvJOuWzjHp1SEvmvxMEEAAAQQQQAABBBBAIG4CCRiAxK0hwci9dsNWqf1QZVNV7RqVZc2GLWbefbL7p58lbdo0Uih/HkmeLJk8VK2irF6/2WQJpLzJyAQBBBBAAAEEEEAAAQRuSCBsApB/T58Rh0PktlvTG4gc2bPK0T+Pm3n3yZGjxyV7tsyuVZrvyB/HxF/5nbv3SqVazeWZzgNk284fXeUvXrwgJPsbXL58KbLGieMyxnhfunTRdc4yg4CdBfRY5TXF/q8pCTVGly7xWpVQtsGu187PI6HQtpAKQDr3GiFtug68Lm2+dgtVVNR/3XE4/pv3HAhHlBWpuFb+l89X+TtuzyIfzx0vny6YItWrlJPu/aLl9Jmr3y+5fPmykOxvoLfeMU72H6eEGiMdf9cpzwwCCSwQn+r1WE2o84B67f8cyPjbf4yc51F8znPKivz37jsENIb06SjRg7tfl0oVKyjp0qaRS5cuy/kLF0xPjp04KZkzZTDz7pOsmTPIiZN/u1Ydt/JlzZIx1vJp06SWm29KZ1LjerUkW5ZMcuiX300dKVOmEpL9DZIlS844RfCxmjx5CnO+MkHA7gJ6rPKaYv/XlIQao+TJea2Kp22ivdbb/bnE7u0LqQDkpnRpTRDgDAacj07kimVLyLKv1pnFz7/8WiqVK2Hm9faqHbv2mPn8eXOJ/tqVBhCXrKsXy1dukErlS5ltvsr/8+9ps10n+otYJ/46JTmyZ9NFEgIIIIAAAggggAACCMRBIKQCEH/96tK2iSxausr8DO/BQ79Jkwa1TZHD1tWKwaOnmXmHwyEDe7aXvkMnSsvn+0jpkoVEr6DoRl/ll3yx2vwEb+XaLSV68iwZ2qeT6FURLWPLRKMQQAABBBBAAAEEELCpQJRN23VDzcqU8TaZMrqP6M/wDu3bWdKkTm3qyZ8vt7z7+mgzr5PiRfLLm5NekdlThsqzzerpKpN8lX/y8Zrm53dXL37T1F+0UD6TnwkCCCDgKcAyAggggAACCMQuEFYBSOxdZSsCCCCAAAIIhLEAXUMAgRARIAAJkYGimQgggAACCCCAAAII2FMgbq0iAImbF7kRQAABBBBAAAEEEEAgHgIEIPHAoygCngIsI4AAAggggAACCMQuQAASuw9bEUAAAQRCQ4BWIoAAAgiEiAABSIgMFM1EAAEEEEAAAQTsKUCrEIibAAFI3LzIjQACCCCAAAIIIIAAAvEQIACJB55nUZYRQAABBBBAAAEEEEAgdgECkNh92IoAAqEhQCsRQAABBBBAIEQECEBCZKBoJgIIIIAAAvYUoFUIIIBA3AQIQOLmRW4EEEAAAQQQQAABBOwhEKKtIAAJ0YGj2QgggAACCCCAAAIIhKIAAUgojhpt9hRgGQEEEEAAAQQQQCBEBAhAQmSgaCYCCCBgTwFahQACCCCAQNwECEDi5kVuBBBAAAEEEEDAHgK0AoEQFSAACdGBo9kIIIAAAggggAACCISiQDgEIKHoTpsRQAABBBBAAAEEEIhIAQKQiBx2Oo1AsASoBwEEEEAAAQQQiJsAAUjcvMiNAAIIIICAPQRoBQIIIBCiAgQgITpwNBsBBBBAAAEEEEAgaQTYa/wECEDi50dpBBBAAAEEEEAAAQQQiIMAAUgcsMjqKcAyAggggAACCCCAAAJxEyAAiZsXuRFAAAF7CNAKBBBAAAEEQlSAACREB45mI4AAAggggEDSCLBXBBCInwABSPz8KI0AAggggAACCCCAAAJxEIhHABKHvZAVAQQQQAABBBBAAAEEELAECEAsBP4hEHICNBgBBBBAAAEEEAhRAQKQEB04mo0AAoEL5M+TU7q1bUwKokGXNg1FUyS6JmSf78lzV+AHNjkRQACBEBUgAAnRgaPZCCAQuIC+qXuhfRMhBc+gy3NPiSZMg2eqlnqsBn5kkxOBiBOgw2EiQAASJgNJNxBAAAEEEEAAAQQQCAUBApBQGCXPNrKMAAIIIIAAAggggECIChCAhOjA0WwEEEgaAfaKAAIIIIAAAvETIACJnx+lEUAAAQQQQCBxBNgLAgiEiQABSJgMJN1AAAEEEEAAAQQQQCBhBIJbKwFIcD2pDQEEEEAAAQQQQAABBGIRIACJBYdNCHgKsIwAAggggAACCCAQPwECkPj5URoBBBBAIHEE2AsCCCCAQJgIEICEyUDSDQQQQAABBBBAIGEEqBWB4AoQgATXk9oQQAABBBBAAAEEEEAgFgECkFhwPDexjAACCCCAAAIIIIAAAvETIACJn59cuHCeFAIGKVIkl0uXLjJWITBWPs4pxs5mY+d86mS8eA3gGAjOMaCvUcmTJ+e5zmbPdb6Ob+dzII83JkAAcmNulEIAAQQQQCBCBOgmAgggEFwBApDgelIbAggggAACCCCAAALBEQjTWghAwnRgQ6Vbf536R/oMmShtXxgse38+FKdmz3p3kbz93pI4lfGWef6HS+XM2bPeNrnW9Rz4qlSo2dSVdv6w17XNfebRxh3dF5lHIFEE7HAerV632e85/N3O3dKm60C5r1ZzWbZyvbj/6XnYtG0vad7uZVll1eW+zTkfrHPeWR+P4ScQKueCp3z0pFmydMVaz9Wu5WGvzpAVqze6luM7o69h3fuNNtVovVq/WfAyeXfhUtdrn74O6nnoJZt0fXmU7N6z39sm1iFwnQAByHUkrEhMgVXrvpGsWTLI1Oi+kidXDl+7TtD1Cxcvl7Nnz/vdx+RRL8u6pXNMKlwgj9/8ZEAgsQTscB6t2/Sd7D/wS6xdTp0qlTzXor7cf1+ZGPkOHPpNZr2zSKaN6ScjB3SVIdHT5ew5/+dkjEpYQMASCJVzwWpqjH/169SQMiULx1iXWAslixaQRvUejnV3rZs+YV779DWwecNHY83LRgQCESAACUSJPAki8P3uveZNx4pVG6Vjj2HSpfdI+XHvAbOvZu16y2uz3zfz095cIB98sszM6ycvDZ5+QTq8NNTvJy1PtnpBXp0ySzpYdX+5ZpPs+nGfudKidXfvO1qOnTgpiz9fJb8f+VNe7D/GfHpjdhKHyeFfj0i77q/IM537y4hxM+NQkqwIBEfA8zzSN/Lz3v/UVK7Hf/sXh5j5jZu3m6uNuhCX82jYqzNk0Kip5jx6bdZ7Xs+jPfsOyOp138rr1jmrVzM1oND9eKb8eXNJ6RKFJSoq5kvPmvWbpaoVlKRLm0ayZc0kBfLllk2bd4j+xaWtmp8UuQKe50JSvKYEei54vj699/EX8s2WnWbwZs5ZaF5XHmvSSfTKiFnpNhk3bY4MHjVNrly54rb2v9kpM/n0jVEAABAASURBVN8VvRrfsHV3mWGdk84t+iFBkzY95dkuA+WTpSudq2XL9h9k3vtLXMuBzpw7f176D58seuWyW5+R8s+/pwMtSj4EJOarACAIJKJAofx5pGHdmlLrwftkwoheUqzwPbLVeiLUJ7FUKVPK9p17TGu27fxRShQpKPsOHJb3rSfp18YNkGH9Osv3u/eZ7bFNcmTPJhOtuqtULC0DR06Rzs81kdlThkqNahVk3NS5UvuhKuYNz6iB3eTVIS/GVpW80DdaajVoJ6MnviUXLlw0eSfOmCcV7i0uM8YNlDvvyCpnzsR+K5cpxASBIAp4nkfFi94j277fbfaw68f9cs66knDx0iUx55G17UbOo3PnL8j4YT2klfUpqLfzKN/dOaVyhdLSulk9czUzZ47bzf4DnRw9dlzuyJbZlV3PpT/+PHZD57yrEmYiTsDzXEiK15S4nAvO16dqle51jdXv1gdiazdulSmj+8hHc8dLs4aPXN3mcJjHASOmyCXrfO774nPicFxdZza4TWpWrySL3p4gb00eKjt27ZVvt+4UfQ4YEv2a9OraWqa/2k/0nHMr4ndWb3eu9lhreWnAGPnjz+Mm/0dLvpRTf/8rsyYPkWesc3/Hrquv2WYjEwT8CET52c5mBBJNoFSxAvKdFWzoGyV9U//v6TPmSfPg4d/k7lzZ5bsdu6Va5Xvl1vQ3y803pZMHqpbz27b7K5U1eX77/Q85cvS4jJs211wFeX/RMvlhj/8AxhS2Jt2ebyErPpohIwZ0tcrtl9nzPxH90/to6z36oM5KvTo1zCMTBJJSoHCBvLLj+5/knPXpZEorkC9SMK/8YF3922YF9CWLFbyh86iqFcDrVYv4nkexuTjcroo4HFffWN3IOR/bPtgWWQJ2fk3RkXC+Pum8M2XMcKv50GDS6/Nk/odLJf3NN13dZF3tmDTjHfPa1619i6vrfEzPnT9nrv536zNKfvntiPy0/7D88usfkjHDLVKkYD4TuNR95Orrlo8qYqyucX95+fz9qebDu5tvukleGT3dbN/+/R55vHZ1c0VTgz9NZgMTBAIQCIUAJIBukCUcBIoUyme9cdoj+kXVEkXukYL33C0fLVkh7t+3SJYsmauryZP/N+9a6TGTMkXya2sccnvWTObTWf2+yfRX+8v8mdHXtvl/yJIpg8mkn6g1e/IR2fXjXrNsXQOXVClTmPnkVnscjqtvnMwKJggkgUBy6xzJceftsnjpKilunUfFCueXzd/9IId++d31Pau4nkf6fxNc7Ur8zqOrdVw/zZwxg5w8+Zdrw/ETJyVLpoxmOa5tNYWYIGAJ2Pk1xWqe/Pf6pEtXk/6fVW9OfkUq3ltCftp3SPoPm3h1g/Xacl+54vKNdTXj5F+nrq7zMtWr832HTpQHqpQ3V/VrVr9PTl+7Mh/jXLKeJ7wU97oqw223iD4H6JXJru2aWq9//314p883zkL6Guic5xEBfwIEIP6E2J5oAvpEpvd/f7l6o+gLh755mvf+p1KsSAHThqLWJzffbv1eLl++bL3vvyKbNu806wOZ6O0dFy9elKUr1prs+iS9zbraogtpUqcW/eUUnfeV9LYw3aZ1rF6/2QqOrn4JvbD16fLajd/pJtnwzXbTLrMQNhM6EooCxQrnk7ffXyLFCt0jJYreIx9/9qXkvTuH6UqCnUdpUsmpU/+YfcR1Uql8KdHzSq/aHD/xl7m9slyZohKftsa1DeQPP4Eke02Jx7lgggXraoderXzu6fqyw+0XF0sWKyRtn35SOvUc4fP7FhqcpEiRQooVvscKcFKIfu9DRzb7HVlEz60TJ68GL/qdMF0fSHK+/mneFas2WK9/d+usFLU+NNy0ZbuZ1/3u3vOzmWeCQCACBCCBKJEn0QT0jZNectbvgBQvkl9++e0PKVk0v9l/3rvvkuqVy5kvrHfrMzpOb/b19pEhfTrJki/WSIv2L0udxh1dT+yN6z8sE16bG+uX0Ou16GZ+hlAfb0l/kzR/6uqvgHR4ppEsst7cPf/iEFmybLWkSpVS+EMgqQU08NB7yUtY507G2241t1wUL3w1kE+o8+jhByvLum++E/3Su68voa+3tuvPeOpP8OqntA/WfdZQ6XdG6tZ+QFp36i/6xeGu7ZubN0/xaaupONQntD/eAknxmhLIueCrY7//8adUq9Na9MdSxkyaJd07tIyRVW+HbFy/ljlPNGCPsdFayGxdrddbofSL4S/2ixa9amGtFg3G9Psf+h2Szr1GyN79h3R1QOmV0dPM698Djz8jG77dLn27txH9e+zhanLi5N9WQDRcBo6cJtmyXr1qqdtICPgTIADxJ8T2BBWoX+chadOigWsfz7duZL7QrSuyWE+k+pN/eiuWLmvSN/6TRr1sLi3PnDBINHjQ9d6S3mKlwYxzW767c8q4YT3krclD5NMFU6RxvVpm04NVy0v04BdNnWaFl8nS96aanyDULwV2fLaxeTLXbPrkPnpQd9E2DXm5oyx+Z5KuJiGQqAKe51HFsiVkzaezRAN5bciCN6Kl6ZO1ddakuJxHvbo+YwX+ZU05nfg6j/LkziGjBr4g+nPVGlBoXs9Uvkxxcx7pea1p2cLXXFmefLymzJk6TGZNGSL6Jsu5IS5tdZbhMXIFPM+FpHhNCeRc8Hx9euH55qK3S92d805ZveQtmT1lqOiHZtWufUG9V5fW4pz/3wOVrNfJAa7z23O0NUDQc2n04O4ysGd7ebrxYyZLudLFzGugvg6OHdpD9LVLN5w9d05uSpdGZ72m4f27mvN2+YczTJs0yNGM+vyi9Y8f3tO8fr4zY5Tkz5dbN4VFohMJK0AAkrC+1I4AAggggAACCNhSQK9G6s/+1rSCGls2kEaFrQABSNgObTA6Fhp16O+Q6//F4Z7icn+rey+DWZd7vcwjYHeBuQsWm/97wP080nU30m4t516Pzuu6G6mLMggktkAwXweCWZenQzDq1jsA3ntzjNyTJ6foOarnqnvSdZ77ZRmBYAgQgARDkTqSVEAvAetvprunsqWK3lCbglnXDTWAQgg4BRL5sUmD2ub/HnA/j3Sd3MCflnOvR+d13Q1URREEEl0gmK8DwazLEyLYdes5queqe9J1nvtlGYFgCBCABEOROhBAAAEEEEAgbAToCAIIJKwAAUjC+lI7AggggAACCCCAAAIIuAnEEoC45WIWAQQQQAABBBBAAAEEEAiCAAFIEBCpAoGgC1AhAggggAACCCAQpgIEIGE6sHQLAQQQQODGBCiFAAIIIJCwAgQgCetL7QgggAACCCCAAAKBCZArQgQIQCJkoOkmAggggAACCCCAAAJ2ECAAscMoeLaBZQQQQAABBBBAAAEEwlSAACRMB5ZuIYDAjQlQCgEEEEAAAQQSVoAAJGF9qR0BBBBAAAEEAhMgFwIIRIgAAUiEDDTdRAABBBBAAAEEEEDAu0DiriUASVxv9oYAAggggAACCCCAQEQLEIBE9PDTeU8BlhFAAAEEEEAAAQQSVoAAJGF9qR0BBBBAIDABciGAAAIIRIgAAUiEDDTdRAABBBBAAAEEvAuwFoHEFSAASVxv9oYAAggggAACCCCAQEQLEIC4DT+zCCCAAAIIIIAAAgggkLACBCAJ60vtCCAQmAC5EEAAAQQQQCBCBAhAImSg6SYCCCCAAALeBViLAAIIJK4AAUjierM3BBBAAAEEEEAAAQSuCkTolAAkQgeebiOAQOACPQe+Ku8uXBp4AStnhZpNrWnc/m3b+aO07tQ/boUCyN251whZu2FrADkTPsu3W3fKhm+3J/yO3Pbgb5+Hf/1duvcdLW1fGCzfWO17stULcuDQb241+J/1tw//NZADAQQQiBwBApDIGWs795S2IYBAAgo8/8xTUrhgngTcQ+BVb9m+WzZ/933gBYKQ098+l3yxWgoVyCtTo/tKmRKFpd+LbSVrloxx2rO/fcSpMjIjgAACYS5AABLmA0z3EEAg4QTe+eAzqfVke2ncpod06T1CDv3ye4ydTZg+V9p0HSiNnnlRvvhqnWvbxs3b5blug6RF+5fN4/e797q2BTKzacsOadmhr7zYP9pcMXm2y0DZ/dPPpqhzm1616dBjmPlEf9KMd2Tnrqv7mP7WAuk9eJx0eGmo1G/ZTfoOnSi79+w3n/7Xa9FN5r3/qalHJ32GTJRHG3WQp6z2Dxnzmpw5e1ZXi+c+1n3znXH489gJs10noye+JTPnfqizrrT/wC+y+ItVsnTF12Z/Cz76XI6f+EuatettDBu27i5z5i925de29ho81rT1mc4D5PyFCzLeMtUrFM+/OERGTXzTbHMWmP/hUlOX1qd9PHbipHjbpzO/Pn782VfyyeerZYnVrrbWFRBNHV4aJkf+OKabTTtHjn/D7GfwqGny25Gjoi46fjXrt5UpM9/1uw9TERMEEEAAAZcAAYiLghkEEEAgbgJlSxWVRW+Pl7enj5CHqleUYWNfj1FB8hTJZfqr/aV/j/Yy1HoDr2+INb0S/Zq82KGlvDV5iHRr31x6DRonFy9dilHW38LefQelfaun5PXxA6XFU3Vk8OhpriJ79h6Qtk83lIkjeplP9F0brs38br25Hjmwm8yZNlz2/XxYZr27SMYP7ylvTBwkb7+3WP7487jJ2fypR2XRvIkmX/JkyWTOgsVmvU7c91GhTHF5+MH7ZOHi5brJBCrLV66XJx59wCw7J7lzZpfaNapITctKrzY0eOwhSZMmlQzt08kYzhg3UFas3iCbt+1yFpGfD/4qIwZ0lRnjBshXazbJuo1bZeaEwTJuWA/5yTJwZlxrrdfAZoLV59lThkqJogVk5LiZ4m2fzjL6WOd/90v1yvfKE488aK6AaLuyZL5NN7nSmbPnjE/fF5+Tdxd+JkUK5pVpY/rJp/MnS706Nfzuw1URMwh4CrCMQIQKEIBE6MDTbQQQiL9AVLIomTHnA+nca4R8/OlX8uO1qxDOmhvVe9jMFsiX23rTmk92fP+TfLfjRzlrvaEdPekt8+n6q1Nmy1+n/pGDh38zeQOd5LLezOuba81fqXxJOfzLETl77rwuyj15ckquu+4w894mpYoXlLRpUkvqVCnlnry5pHiR/JIyRQpJf/NNkvOu7NYn+odNsVN//yNjJr8lnXsOl+3f7zFXSswGa+K5jwaP1TQGly9flsWfr5KypYvKrelvtnLG/i91qlSyZfsPMnDkVOuKzhg5cfKU/PDjflehivcWl3Rp05jlrdt3y8MPVZWb0qWV5MmTS71HHzTrdbJ+0zY5+dff0nPgWOP6+ZdfyzbLW7fFNz1QpZxERUWZaooWvEf0Ko5enfl02RrJmOFWs54JAggggEDgAlefUQPPnxA5qRMBBBAISYFuL4+03uznkgE92slI61N6/aTcvSN61cC5rG+Yr1wRcTgckj9vLten7fqJ+1eLZsrdOe+U+P5dvHjRVJHKCizMjI9JSuvKjHOTvrFO4bacLCqE8pK9AAAHSklEQVRKLl68LPol7FdGT7euVtwn0a+8KK2a1pWzZ68GOFrWcx/ZsmaSAvfktq5gbJT3P/5CGtWrJYH8ffL5SlmxaoM0e/JRmTiyt1QqX0pOn7l6q5eW99yPp6nm0eRwXLGurlR2uc6wrqboFQrdFt+UKlUKVxUPVC1nXVnqbfU1jyxftV70tizXRmYQQAABBAISIAAJiIlMCISrAP26UYEzZ8/Kib9OWW+YS8ptt6aXZSvXX1eVfkdEV+p3LLZ//6MULZxXSlhXG/T7GstXbtBNJq3b9J159JzMnLNQ9JYtz/W6vHf/IfNdDJ3/4JNlkuPObObKgC4HI+n3We7Mnk0KF8hrrpQst4IEf/XWr1NDxk2bK6lTpxa96uMtv169OGld8XFu+/nAL1K00D1yd67sVuBzSdZt2urcdN1jiaL5Zf0321zr3X/Zq2LZErJwyQrZd+Dq1Rv9vojzVi7PfboquIEZvVp1S/qbpEqFUtKqSV3ZsWuPqSWY+zAVMkEAAQTCWIAAJIwHl64hgEDwBMZOnS3607rOtG7TNmlSv7Y0eqaH6C1Yx46fvG5np8+cMV+uHjBisvTo3Eoy3narCVaG9+8iGjToF8n/16Ct67sT7hVogDN7wSeSLFky99Wueb11Sr+w3aRNT/l02Vrp80Ib17ZgzJQtXUSSRUVJ83YvS7c+I+W2W9L7rbZc6WLmVq4Gj9Xwmbd6lbJy4uRfxky/hF73kQfls+VrpG23waJOemuXr8IPVi0veXLfacp27ztakieLEg0GNH/5MsWltXWVZtCoadLy+T5Su+Hzsn3n1eDAc5+a/0bTlDfmS5VHWkq77q+YL+y/8HwLU9UN7cOUZIIAAghEnkBU5HWZHiOAAAJxExjev6usWzonRqpeuaw80+wJef+tMeYL0c82ry9rP53lqljzd2rTxHy5et6MUVLj/gqubaWKFZRJo16WNycOls8WTJWRA7qZbcUK32O+VK4LW7b9II/Vul98fY8idaqUZr9zpw+X18b2F72tS8vdW7KIuQ1J551Jv7B9X7kSZrFNiwaiySxYk77d20jd2g9Yc1f/OfOmTJHC1D9ryhAZ88pL0r1DC3OLlObytg9df+ToMYmKclh9raiLXlOWTBlMf3U/DR57SO68I6sseCNapo7pK8P7dZGhfTsbVy2s7dSk85qioqLMVQctO8zKe/nKFdHvr+g2TY8/XN2YvjnpFfnig+nSolEdXS2e+zQr3SZd2jaTxvUfdq2ZPzNacua43SzrLXLaX7NgTXpageSqT96UKaP7yJA+naTCvcWtteJ3HyYTEwQQsI0ADUlaAQKQpPVn7wgggIBXAb2lSN8Ye91ow5VvvP2RtNWfsX26gaRw+05JsJuqV2SebPWCNGvXS1KlTCmP164e7F1QHwIIIIBAAgsQgCQwsL2rp3UIIBCKAvqJvH4yb6e2P934MVk4a6w8UKV8gjbrg1mvil6heMe6qqRXZfRKTYLukMoRQAABBIIuQAASdFIqRAABBAIQIAsCCCCAAAIRKkAAEqEDT7cRQAABBBCIVAH6jQACSStAAJK0/uwdAQQQQAABBBBAAIFIETD9JAAxDEwQQAABBBBAAAEEEEAgMQQIQBJDmX0g4CnAMgIIIIAAAgggEKECBCAROvB0GwEEEIhUAfqNAAIIIJC0AgQgSevP3hFAAAEEEEAAgUgRoJ8IGAECEMPABAEEEEAAAQQQQAABBBJDgAAkMZQ998EyAggggAACCCCAAAIRKkAAEqEDT7cRiFQB+o0AAggggAACSStAAJK0/uwdAQQQQACBSBGgnwgggIARIAAxDEwQQAABBBBAAAEEEAhXAXv1iwDEXuNBaxBAAAEEEEAAAQQQCGsBApCwHl465ynAMgIIIIAAAggggEDSChCAJK0/e0cAAQQiRYB+IoAAAgggYAQIQAwDEwQQQAABBBBAIFwF6BcC9hIgALHXeNAaBBBAAAEEEEAAAQTCWiCiApCwHkk6hwACCCCAAAIIIIBACAgQgITAINFEBMJAgC4ggAACCCCAAAJGgADEMDBBAAEEEEAgXAXoFwIIIGAvAQIQe40HrUEAAQQQQAABBBAIFwH64VWAAMQrCysRQAABBBBAAAEEEEAgIQQIQBJClTo9BVhGAAEEEEAAAQQQQMAIEIAYBiYIIIBAuArQLwQQQAABBOwlQABir/GgNQgggAACCCAQLgL0AwEEvAoQgHhlYSUCCCCAAAIIIIAAAggkhEBiBCAJ0W7qRAABBBBAAAEEEEAAgRAUIAAJwUGjyQgELkBOBBBAAAEEEEDAXgIEIPYaD1qDAAIIIBAuAvQDAQQQQMCrAAGIVxZWIoAAAggggAACCISqAO22twABiL3Hh9YhgAACCCCAAAIIIBBWAgQgYTWcnp1hGQEEEEAAAQQQQAABewkQgNhrPGgNAgiEiwD9QAABBBBAAAGvAgQgXllYiQACCCCAAAKhKkC7EUDA3gL/BwAA//+4s+k9AAAABklEQVQDALcHGw59Bu1VAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Bar chart of mean validation information coefficient, one bar per label on one axis, with the primary target in dark navy first and the two variants in slate, and a dashed zero line. Counted from the frame: fwd_ret_5d above zero; fwd_ret_10d below zero; fwd_ret_risk_adj_5d above zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "panel = catalog.with_columns(\n",
     "    rank=pl.col(\"label\").replace_strict(\n",
@@ -614,8 +1212,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d6f25f6",
-   "metadata": {},
+   "id": "cea114bd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002872,
+     "end_time": "2026-08-25T22:37:17.104435+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T22:37:17.101563+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -692,6 +1298,37 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-08-25T22:37:28.155802+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "0a488b10fa0bad51a32e01799b14df31fc380e2d"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 129.509304,
+   "end_time": "2026-08-25T22:37:20.209439+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/11b_ipca.ipynb",
+   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.11b_ipca.papermill.3868574.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-25T22:35:10.700135+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/11b_ipca.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11b_ipca.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cb7b9b81",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001738,
-     "end_time": "2026-07-22T07:05:15.447008+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:05:15.445270+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "6b96be85",
+   "metadata": {},
    "source": [
     "# Option analytics: letting the option surface choose the exposures\n",
     "\n",
@@ -31,7 +23,9 @@
     "\n",
     "- **The features finally reach the factor structure.** In PCA they reached nothing. The distance\n",
     "  between the two notebooks is what conditioning on the surface buys, measured rather than\n",
-    "  assumed, with the folds, the factor count and the scoring identical on both sides.\n",
+    "  assumed, with the folds, the factor count and the scoring identical on both sides - though not\n",
+    "  the sample, for the reason the next point gives, which is why section 5 reads that distance as\n",
+    "  a bound rather than an estimate.\n",
     "- **The panel no longer has to stay balanced.** PCA needs a stock to be the same stock with a\n",
     "  usable return history across the training window. IPCA needs only that a stock have features on\n",
     "  a date, because the exposure is computed from them rather than estimated from its past. On a\n",
@@ -75,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93efae0a",
+   "id": "0c2c6409",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9f966a9",
+   "id": "ce71a732",
    "metadata": {
     "tags": [
      "parameters"
@@ -121,27 +115,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e00f70a3",
+   "id": "9814b76a",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"11b_ipca\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1e8c4cf4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001919,
-     "end_time": "2026-07-22T07:05:19.719397+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:05:19.717478+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "a432c9fb",
+   "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
     "\n",
@@ -155,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8375218b",
+   "id": "c022992f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,16 +153,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf663798",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000727,
-     "end_time": "2026-07-22T07:05:27.242929+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:05:27.242202+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "af30cba4",
+   "metadata": {},
    "source": [
     "`case_studies/config/ipca/ipca.yaml` declares `n_factors`, how many common factors to extract,\n",
     "and `checkpoint_interval: 0` for the reason given above. `config/setup.yaml` adds three more\n",
@@ -192,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6fcc571",
+   "id": "ed2ad622",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,16 +188,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf5d5d07",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001441,
-     "end_time": "2026-07-22T07:05:41.897465+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:05:41.896024+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "65339c3d",
+   "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
     "canonical population does. A population is immutable once written, so such a run must publish\n",
@@ -232,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16b74a3e",
+   "id": "5ba9eb54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,16 +219,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd39334a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00103,
-     "end_time": "2026-07-22T07:05:41.916847+00:00",
-     "exception": false,
-     "start_time": "2026-07-22T07:05:41.915817+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5a0b38c6",
+   "metadata": {},
    "source": [
     "### Where this one runs, and why it is not the family's device\n",
     "\n",
@@ -270,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b529ec3d",
+   "id": "babc0a80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8fa9349",
+   "id": "fc5ad965",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -311,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cf4a17d",
+   "id": "af49e969",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53552404",
+   "id": "59baea6d",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -350,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cef16df",
+   "id": "87328cd4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21916b11",
+   "id": "1362a5ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -417,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9a36f27",
+   "id": "4e32dc67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5afad46c",
+   "id": "1b2b7603",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -470,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6a6ab32",
+   "id": "f11ca8bc",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -494,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ed115de",
+   "id": "d9d0c470",
    "metadata": {
     "tags": [
      "results"
@@ -550,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12670afd",
+   "id": "4fe303ef",
    "metadata": {},
    "source": [
     "### One map, three targets\n",
@@ -570,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c65348f",
+   "id": "6265ac83",
    "metadata": {
     "tags": [
      "results"
@@ -591,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74d2327a",
+   "id": "2530b82f",
    "metadata": {},
    "source": [
     "### The same map against each target\n",
@@ -604,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b773470",
+   "id": "0c5263f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +614,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aedef2c",
+   "id": "7d6f25f6",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",
@@ -660,13 +625,24 @@
     "measure of its own dispersion - so a gap between those two rows is a statement about scaling by\n",
     "width and nothing else.\n",
     "\n",
-    "**This notebook and [`11a_pca`](11a_pca.ipynb) differ by one thing, which is the comparison to\n",
-    "make.** Same folds, same factor count, same scoring, same three labels. PCA estimates each\n",
-    "stock's loading from its own return history and never sees an option-surface column; IPCA\n",
-    "requires the loading to be a linear function of exactly those columns. The distance between the\n",
-    "two populations is therefore what conditioning on the surface buys, measured rather than argued -\n",
-    "and it is a distance in both directions, because a constraint that is wrong costs more than no\n",
-    "constraint at all.\n",
+    "**This notebook and [`11a_pca`](11a_pca.ipynb) differ in two things, not one, and the second one\n",
+    "limits what the comparison can say.** Same folds, same factor count, same scoring, same three\n",
+    "labels. PCA estimates each stock's loading from its own return history and never sees an\n",
+    "option-surface column; IPCA requires the loading to be a linear function of exactly those\n",
+    "columns. That is the difference the comparison is for.\n",
+    "\n",
+    "The second difference is the sample. The section above is explicit that IPCA does not need a\n",
+    "balanced panel and PCA does, and the consequence is that the two populations are not scored on\n",
+    "the same rows: IPCA covers about a tenth more of the panel on every label - 192,139 against\n",
+    "175,360 on `fwd_ret_10d`, 194,813 against 177,682 on `fwd_ret_5d`, 194,748 against 177,769 on\n",
+    "`fwd_ret_risk_adj_5d`. The extra rows are the names PCA had to drop for want of a complete return\n",
+    "history, which are systematically the shorter-lived and less liquid ones.\n",
+    "\n",
+    "So the gap between the two ICs is what conditioning buys **plus** whatever those rows contribute,\n",
+    "and this notebook cannot separate them. Read it as a bound rather than an estimate, and read it\n",
+    "in both directions, because a constraint that is wrong costs more than no constraint at all.\n",
+    "Making it an estimate would mean scoring IPCA on PCA's balanced subset, which is a different\n",
+    "notebook and would throw away the tolerance that is IPCA's main practical advantage.\n",
     "\n",
     "**A model with no epochs still has a checkpoint, and the checkpoint is not a formality.** The\n",
     "registry keys a prediction set on `(training identity, checkpoint)`, so a family whose members\n",
@@ -716,18 +692,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/11b_ipca.py
+++ b/case_studies/sp500_equity_option_analytics/11b_ipca.py
@@ -32,7 +32,9 @@
 #
 # - **The features finally reach the factor structure.** In PCA they reached nothing. The distance
 #   between the two notebooks is what conditioning on the surface buys, measured rather than
-#   assumed, with the folds, the factor count and the scoring identical on both sides.
+#   assumed, with the folds, the factor count and the scoring identical on both sides - though not
+#   the sample, for the reason the next point gives, which is why section 5 reads that distance as
+#   a bound rather than an estimate.
 # - **The panel no longer has to stay balanced.** PCA needs a stock to be the same stock with a
 #   usable return history across the training window. IPCA needs only that a stock have features on
 #   a date, because the exposure is computed from them rather than estimated from its past. On a
@@ -102,7 +104,10 @@ MODEL_NAME = "ipca"
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="11b_ipca",
 )
 
 # %% [markdown]
@@ -465,13 +470,24 @@ show_plotly_with_alt(
 # measure of its own dispersion - so a gap between those two rows is a statement about scaling by
 # width and nothing else.
 #
-# **This notebook and [`11a_pca`](11a_pca.ipynb) differ by one thing, which is the comparison to
-# make.** Same folds, same factor count, same scoring, same three labels. PCA estimates each
-# stock's loading from its own return history and never sees an option-surface column; IPCA
-# requires the loading to be a linear function of exactly those columns. The distance between the
-# two populations is therefore what conditioning on the surface buys, measured rather than argued -
-# and it is a distance in both directions, because a constraint that is wrong costs more than no
-# constraint at all.
+# **This notebook and [`11a_pca`](11a_pca.ipynb) differ in two things, not one, and the second one
+# limits what the comparison can say.** Same folds, same factor count, same scoring, same three
+# labels. PCA estimates each stock's loading from its own return history and never sees an
+# option-surface column; IPCA requires the loading to be a linear function of exactly those
+# columns. That is the difference the comparison is for.
+#
+# The second difference is the sample. The section above is explicit that IPCA does not need a
+# balanced panel and PCA does, and the consequence is that the two populations are not scored on
+# the same rows: IPCA covers about a tenth more of the panel on every label - 192,139 against
+# 175,360 on `fwd_ret_10d`, 194,813 against 177,682 on `fwd_ret_5d`, 194,748 against 177,769 on
+# `fwd_ret_risk_adj_5d`. The extra rows are the names PCA had to drop for want of a complete return
+# history, which are systematically the shorter-lived and less liquid ones.
+#
+# So the gap between the two ICs is what conditioning buys **plus** whatever those rows contribute,
+# and this notebook cannot separate them. Read it as a bound rather than an estimate, and read it
+# in both directions, because a constraint that is wrong costs more than no constraint at all.
+# Making it an estimate would mean scoring IPCA on PCA's balanced subset, which is a different
+# notebook and would throw away the tolerance that is IPCA's main practical advantage.
 #
 # **A model with no epochs still has a checkpoint, and the checkpoint is not a formality.** The
 # registry keys a prediction set on `(training identity, checkpoint)`, so a family whose members

--- a/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eddaf200",
+   "id": "7ba0bf15",
    "metadata": {},
    "source": [
     "# Option analytics: letting a network decide what the exposures depend on\n",
@@ -20,12 +20,21 @@
     "available here and is not available there. Everything else - the factors, the folds, the labels,\n",
     "the way a forecast is formed - is unchanged.\n",
     "\n",
-    "**It is fitted by reconstruction, not by prediction.** The objective is to reproduce the returns\n",
-    "the panel actually realized from a small number of factors, and nothing in that objective mentions\n",
-    "the forward return the notebook is scored on. The model is not asked to order next week's returns;\n",
-    "it is trying to describe the cross-section compactly, and the IC below asks whether a compact\n",
-    "description of co-movement happens to order the forward return as well. That is a real question\n",
-    "with an unfavourable prior, and *Chapter 14*, Section 14.5 is where the book sets out why.\n",
+    "**It is fitted by reconstruction, not by prediction, and the difference is narrower than that\n",
+    "sentence usually implies.** The panel this model reconstructs is the label panel: the runner fills\n",
+    "its return matrix from the configured label column, so what the objective reproduces is\n",
+    "`fwd_ret_5d` itself, the same quantity section 4 scores the IC on. The objective is therefore not\n",
+    "blind to the target, and a positive IC is less surprising than it would be if it were.\n",
+    "\n",
+    "What still separates reconstruction from forecasting is *which* returns and *how*. The fit sees\n",
+    "the training window's forward returns beside the characteristics of the same dates and compresses\n",
+    "both into a handful of factors; it is never shown a date it must then order. The forecast in step\n",
+    "4 below applies fixed factor means to a validation date's own exposures, which is an\n",
+    "extrapolation the objective never optimized and could not have. So the IC below asks whether a\n",
+    "compact description of one window's cross-section transfers to the next one - a real question\n",
+    "with an unfavourable prior, and *Chapter 14*, Section 14.5 is where the book sets out why: the\n",
+    "directions a cross-section co-moves along are the directions it is *risky* along, and a risk\n",
+    "factor is not obliged to be a return factor.\n",
     "\n",
     "**This is the first member of the family with a genuine stopping point.** PCA and IPCA are solved:\n",
     "one fold produces one answer. This one is trained, so `config/cae/cae.yaml` declares\n",
@@ -36,7 +45,8 @@
     "**Learning objectives.** By the end of this notebook you will be able to:\n",
     "\n",
     "- State what a conditional autoencoder changes relative to IPCA, and what it leaves alone.\n",
-    "- Explain why a reconstruction objective is not a forecasting objective, and what that predicts\n",
+    "- Explain why reconstructing one window is not forecasting the next, given that both are\n",
+    "  measured on the same label column, and what that predicts\n",
     "  about the IC.\n",
     "- Read a checkpoint schedule as a property of the estimator rather than as a tuning knob.\n",
     "- Say why the epoch with the highest validation IC is not thereby selected.\n",
@@ -63,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "491fd250",
+   "id": "7a8e35c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cd0feaf",
+   "id": "93efbca4",
    "metadata": {
     "tags": [
      "parameters"
@@ -110,18 +120,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbe3d9a8",
+   "id": "f24250bb",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"11c_conditional_autoencoder\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "538cc925",
+   "id": "891c4119",
    "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
@@ -136,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ee1e05b",
+   "id": "fed6f436",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18352e0a",
+   "id": "d7051398",
    "metadata": {},
    "source": [
     "`case_studies/config/cae/cae.yaml` declares three values. `n_factors` is the width of the\n",
@@ -168,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a7373da",
+   "id": "a564be56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea0983d6",
+   "id": "b282eb59",
    "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
@@ -200,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7f5edf6",
+   "id": "3989f0b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2325fa6e",
+   "id": "71b19aea",
    "metadata": {},
    "source": [
     "### Where this one runs, and why the family's declaration is the right one here\n",
@@ -240,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f1eef5b",
+   "id": "4eb520a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "631067da",
+   "id": "f53d6187",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -279,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "268299f6",
+   "id": "13844f24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f08338c",
+   "id": "31979be2",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -318,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8e48373",
+   "id": "8c9a5d64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56d03555",
+   "id": "09ec7658",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -349,8 +362,8 @@
     "\n",
     "1. takes the characteristics of every stock in that fold's training window and passes them\n",
     "   through a network that outputs `n_factors` exposures per stock,\n",
-    "2. solves for the factor returns that, applied to those exposures, best reproduce the realized\n",
-    "   returns of the training window,\n",
+    "2. solves for the factor returns that, applied to those exposures, best reproduce that window's\n",
+    "   label values - `fwd_ret_5d`, the same column section 4 scores against,\n",
     "3. backpropagates the reconstruction error into the network, repeating for the declared number of\n",
     "   epochs and publishing whenever the checkpoint schedule says so,\n",
     "4. forecasts each validation date by applying the fitted network to that date's characteristics\n",
@@ -378,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d80a17e",
+   "id": "9770790c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +412,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51b158ba",
+   "id": "ecfc7995",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -432,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ffd308c",
+   "id": "9224e215",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -456,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0971c693",
+   "id": "7799bc76",
    "metadata": {
     "tags": [
      "results"
@@ -513,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "736f032f",
+   "id": "7dc920df",
    "metadata": {},
    "source": [
     "### Where each label's schedule reached its highest IC\n",
@@ -535,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85dc0419",
+   "id": "5faea06a",
    "metadata": {
     "tags": [
      "results"
@@ -561,7 +574,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a25cbd4d",
+   "id": "a05b9e30",
    "metadata": {},
    "source": [
     "### What training longer does to the ranking\n",
@@ -576,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4482df1c",
+   "id": "b9864869",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4c4db57",
+   "id": "9e1fb157",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",
@@ -633,18 +646,19 @@
     "nothing else, which is a rarer thing than it sounds and is the reason the family is split this\n",
     "way.\n",
     "\n",
-    "**A reconstruction objective is not a forecasting objective, and the epoch chart is where that\n",
+    "**Reconstructing a window is not forecasting the next one, and the epoch chart is where that\n",
     "stops being a caveat and becomes a measurement.** Training reduces reconstruction error on the\n",
-    "training window by construction. Whether the IC follows is an empirical question the schedule\n",
-    "answers directly, and *Chapter 14*, Section 14.5 sets out why the answer is often no: the\n",
-    "directions along which a cross-section co-moves are the directions along which it is *risky*, and\n",
-    "a risk factor is not obliged to be a return factor.\n",
+    "training window by construction, and it reduces it against the very column the IC is computed on -\n",
+    "so this is not a case of two unrelated quantities happening to agree. Whether driving that error\n",
+    "down on one window raises the IC on the next is the empirical question, and the schedule answers\n",
+    "it directly. *Chapter 14*, Section 14.5 sets out why the answer is often no.\n",
     "\n",
     "**More capacity than IPCA is not more information than IPCA.** The network sees exactly the\n",
     "characteristics the linear map saw. It can represent more functions of them, which helps only if\n",
     "the true relation is one of the functions IPCA could not reach. Where it is not, the extra\n",
     "capacity finds structure in the training window that does not survive into the validation one -\n",
-    "the standard bargain, made here against a target the objective never mentions.\n",
+    "the standard bargain, and one the shared target makes easier to lose rather than harder, because\n",
+    "the extra capacity is spent fitting the training window's own forward returns more exactly.\n",
     "\n",
     "**Ten checkpoints are ten observations of one fit, not ten candidates.** They are published so\n",
     "that [`14_backtest`](14_backtest.ipynb) can carry the entire schedule into its own sweep and\n",

--- a/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7ba0bf15",
+   "id": "7e49bea2",
    "metadata": {},
    "source": [
     "# Option analytics: letting a network decide what the exposures depend on\n",
@@ -22,9 +22,11 @@
     "\n",
     "**It is fitted by reconstruction, not by prediction, and the difference is narrower than that\n",
     "sentence usually implies.** The panel this model reconstructs is the label panel: the runner fills\n",
-    "its return matrix from the configured label column, so what the objective reproduces is\n",
-    "`fwd_ret_5d` itself, the same quantity section 4 scores the IC on. The objective is therefore not\n",
-    "blind to the target, and a positive IC is less surprising than it would be if it were.\n",
+    "its return matrix from the label column that member was configured with, so what the objective\n",
+    "reproduces is that member's own label - `fwd_ret_5d` for the primary one, and `fwd_ret_10d` or\n",
+    "`fwd_ret_risk_adj_5d` for the other two rows of the table in section 4. Whichever it is, it is\n",
+    "the same column that member's IC is then scored on. The objective is therefore not blind to the\n",
+    "target, and a positive IC is less surprising than it would be if it were.\n",
     "\n",
     "What still separates reconstruction from forecasting is *which* returns and *how*. The fit sees\n",
     "the training window's forward returns beside the characteristics of the same dates and compresses\n",
@@ -73,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a8e35c4",
+   "id": "ebc2a043",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93efbca4",
+   "id": "8e942e83",
    "metadata": {
     "tags": [
      "parameters"
@@ -120,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f24250bb",
+   "id": "2aa17bff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "891c4119",
+   "id": "d2b4e3fd",
    "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
@@ -149,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fed6f436",
+   "id": "6fc8e03a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7051398",
+   "id": "3efd046d",
    "metadata": {},
    "source": [
     "`case_studies/config/cae/cae.yaml` declares three values. `n_factors` is the width of the\n",
@@ -181,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a564be56",
+   "id": "212c70d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b282eb59",
+   "id": "0db442ba",
    "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
@@ -213,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3989f0b1",
+   "id": "9f540b01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71b19aea",
+   "id": "763e03d9",
    "metadata": {},
    "source": [
     "### Where this one runs, and why the family's declaration is the right one here\n",
@@ -253,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4eb520a0",
+   "id": "c4bd52a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f53d6187",
+   "id": "52d47b77",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -292,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13844f24",
+   "id": "0f702943",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31979be2",
+   "id": "6f6609d4",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -331,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c9a5d64",
+   "id": "33ef8b6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09ec7658",
+   "id": "b4e389e8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -363,7 +365,7 @@
     "1. takes the characteristics of every stock in that fold's training window and passes them\n",
     "   through a network that outputs `n_factors` exposures per stock,\n",
     "2. solves for the factor returns that, applied to those exposures, best reproduce that window's\n",
-    "   label values - `fwd_ret_5d`, the same column section 4 scores against,\n",
+    "   values of this member's own label column - the same column section 4 then scores it against,\n",
     "3. backpropagates the reconstruction error into the network, repeating for the declared number of\n",
     "   epochs and publishing whenever the checkpoint schedule says so,\n",
     "4. forecasts each validation date by applying the fitted network to that date's characteristics\n",
@@ -391,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9770790c",
+   "id": "f4c0a716",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecfc7995",
+   "id": "21082aa6",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -445,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9224e215",
+   "id": "b7f41ace",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -469,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7799bc76",
+   "id": "7612e9e7",
    "metadata": {
     "tags": [
      "results"
@@ -526,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dc920df",
+   "id": "f2b9870b",
    "metadata": {},
    "source": [
     "### Where each label's schedule reached its highest IC\n",
@@ -548,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5faea06a",
+   "id": "d03952a2",
    "metadata": {
     "tags": [
      "results"
@@ -574,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a05b9e30",
+   "id": "17baf29c",
    "metadata": {},
    "source": [
     "### What training longer does to the ranking\n",
@@ -589,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9864869",
+   "id": "db7b0589",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e1fb157",
+   "id": "42c46620",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.py
+++ b/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.py
@@ -29,12 +29,21 @@
 # available here and is not available there. Everything else - the factors, the folds, the labels,
 # the way a forecast is formed - is unchanged.
 #
-# **It is fitted by reconstruction, not by prediction.** The objective is to reproduce the returns
-# the panel actually realized from a small number of factors, and nothing in that objective mentions
-# the forward return the notebook is scored on. The model is not asked to order next week's returns;
-# it is trying to describe the cross-section compactly, and the IC below asks whether a compact
-# description of co-movement happens to order the forward return as well. That is a real question
-# with an unfavourable prior, and *Chapter 14*, Section 14.5 is where the book sets out why.
+# **It is fitted by reconstruction, not by prediction, and the difference is narrower than that
+# sentence usually implies.** The panel this model reconstructs is the label panel: the runner fills
+# its return matrix from the configured label column, so what the objective reproduces is
+# `fwd_ret_5d` itself, the same quantity section 4 scores the IC on. The objective is therefore not
+# blind to the target, and a positive IC is less surprising than it would be if it were.
+#
+# What still separates reconstruction from forecasting is *which* returns and *how*. The fit sees
+# the training window's forward returns beside the characteristics of the same dates and compresses
+# both into a handful of factors; it is never shown a date it must then order. The forecast in step
+# 4 below applies fixed factor means to a validation date's own exposures, which is an
+# extrapolation the objective never optimized and could not have. So the IC below asks whether a
+# compact description of one window's cross-section transfers to the next one - a real question
+# with an unfavourable prior, and *Chapter 14*, Section 14.5 is where the book sets out why: the
+# directions a cross-section co-moves along are the directions it is *risky* along, and a risk
+# factor is not obliged to be a return factor.
 #
 # **This is the first member of the family with a genuine stopping point.** PCA and IPCA are solved:
 # one fold produces one answer. This one is trained, so `config/cae/cae.yaml` declares
@@ -45,7 +54,8 @@
 # **Learning objectives.** By the end of this notebook you will be able to:
 #
 # - State what a conditional autoencoder changes relative to IPCA, and what it leaves alone.
-# - Explain why a reconstruction objective is not a forecasting objective, and what that predicts
+# - Explain why reconstructing one window is not forecasting the next, given that both are
+#   measured on the same label column, and what that predicts
 #   about the IC.
 # - Read a checkpoint schedule as a property of the estimator rather than as a tuning knob.
 # - Say why the epoch with the highest validation IC is not thereby selected.
@@ -99,7 +109,10 @@ MODEL_NAME = "cae"
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="11c_conditional_autoencoder",
 )
 
 # %% [markdown]
@@ -254,8 +267,8 @@ print(f"{len(plan.expected_prediction_hashes)} validation prediction sets")
 #
 # 1. takes the characteristics of every stock in that fold's training window and passes them
 #    through a network that outputs `n_factors` exposures per stock,
-# 2. solves for the factor returns that, applied to those exposures, best reproduce the realized
-#    returns of the training window,
+# 2. solves for the factor returns that, applied to those exposures, best reproduce that window's
+#    label values - `fwd_ret_5d`, the same column section 4 scores against,
 # 3. backpropagates the reconstruction error into the network, repeating for the declared number of
 #    epochs and publishing whenever the checkpoint schedule says so,
 # 4. forecasts each validation date by applying the fitted network to that date's characteristics
@@ -478,18 +491,19 @@ show_plotly_with_alt(
 # nothing else, which is a rarer thing than it sounds and is the reason the family is split this
 # way.
 #
-# **A reconstruction objective is not a forecasting objective, and the epoch chart is where that
+# **Reconstructing a window is not forecasting the next one, and the epoch chart is where that
 # stops being a caveat and becomes a measurement.** Training reduces reconstruction error on the
-# training window by construction. Whether the IC follows is an empirical question the schedule
-# answers directly, and *Chapter 14*, Section 14.5 sets out why the answer is often no: the
-# directions along which a cross-section co-moves are the directions along which it is *risky*, and
-# a risk factor is not obliged to be a return factor.
+# training window by construction, and it reduces it against the very column the IC is computed on -
+# so this is not a case of two unrelated quantities happening to agree. Whether driving that error
+# down on one window raises the IC on the next is the empirical question, and the schedule answers
+# it directly. *Chapter 14*, Section 14.5 sets out why the answer is often no.
 #
 # **More capacity than IPCA is not more information than IPCA.** The network sees exactly the
 # characteristics the linear map saw. It can represent more functions of them, which helps only if
 # the true relation is one of the functions IPCA could not reach. Where it is not, the extra
 # capacity finds structure in the training window that does not survive into the validation one -
-# the standard bargain, made here against a target the objective never mentions.
+# the standard bargain, and one the shared target makes easier to lose rather than harder, because
+# the extra capacity is spent fitting the training window's own forward returns more exactly.
 #
 # **Ten checkpoints are ten observations of one fit, not ten candidates.** They are published so
 # that [`14_backtest`](14_backtest.ipynb) can carry the entire schedule into its own sweep and

--- a/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.py
+++ b/case_studies/sp500_equity_option_analytics/11c_conditional_autoencoder.py
@@ -31,9 +31,11 @@
 #
 # **It is fitted by reconstruction, not by prediction, and the difference is narrower than that
 # sentence usually implies.** The panel this model reconstructs is the label panel: the runner fills
-# its return matrix from the configured label column, so what the objective reproduces is
-# `fwd_ret_5d` itself, the same quantity section 4 scores the IC on. The objective is therefore not
-# blind to the target, and a positive IC is less surprising than it would be if it were.
+# its return matrix from the label column that member was configured with, so what the objective
+# reproduces is that member's own label - `fwd_ret_5d` for the primary one, and `fwd_ret_10d` or
+# `fwd_ret_risk_adj_5d` for the other two rows of the table in section 4. Whichever it is, it is
+# the same column that member's IC is then scored on. The objective is therefore not blind to the
+# target, and a positive IC is less surprising than it would be if it were.
 #
 # What still separates reconstruction from forecasting is *which* returns and *how*. The fit sees
 # the training window's forward returns beside the characteristics of the same dates and compresses
@@ -268,7 +270,7 @@ print(f"{len(plan.expected_prediction_hashes)} validation prediction sets")
 # 1. takes the characteristics of every stock in that fold's training window and passes them
 #    through a network that outputs `n_factors` exposures per stock,
 # 2. solves for the factor returns that, applied to those exposures, best reproduce that window's
-#    label values - `fwd_ret_5d`, the same column section 4 scores against,
+#    values of this member's own label column - the same column section 4 then scores it against,
 # 3. backpropagates the reconstruction error into the network, repeating for the declared number of
 #    epochs and publishing whenever the checkpoint schedule says so,
 # 4. forecasts each validation date by applying the fitted network to that date's characteristics

--- a/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c77cfd82",
+   "id": "d66ec6f5",
    "metadata": {},
    "source": [
     "# Option analytics: pricing the cross-section instead of describing it\n",
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19cbd4c5",
+   "id": "ea613d66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9deab661",
+   "id": "94909bfb",
    "metadata": {
     "tags": [
      "parameters"
@@ -109,18 +109,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c47129a",
+   "id": "595600cf",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"11d_stochastic_discount_factor\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a0e9c40c",
+   "id": "6a30804f",
    "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
@@ -135,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3eb7624",
+   "id": "5f899e37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f6f1779",
+   "id": "2d5c9fea",
    "metadata": {},
    "source": [
     "### Three budgets, and one checkpoint axis across two phases\n",
@@ -175,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b8fce79",
+   "id": "850c5daa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c63264a3",
+   "id": "53abaadd",
    "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
@@ -207,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d28c478d",
+   "id": "9f500836",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83a25f69",
+   "id": "d7d15b60",
    "metadata": {},
    "source": [
     "### The device, and the one input that comes from outside the cross-section\n",
@@ -248,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d099e37",
+   "id": "8c6d773a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf80b1c0",
+   "id": "8cb32a64",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -284,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3520d36b",
+   "id": "8df01726",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9facd5b3",
+   "id": "bd2d2bda",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -323,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94a61f6b",
+   "id": "e81fa6b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "557ecd8e",
+   "id": "d3b2184a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -383,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6b93a7b",
+   "id": "e233c8ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f66f4715",
+   "id": "9908883c",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -438,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbd7ba85",
+   "id": "71d153ba",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -474,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11eabb8e",
+   "id": "7edda771",
    "metadata": {
     "tags": [
      "results"
@@ -532,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c56e344c",
+   "id": "01b85a3d",
    "metadata": {},
    "source": [
     "### Where the schedule went\n",
@@ -547,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1c90323",
+   "id": "48287b6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0d21985",
+   "id": "6afa5a3e",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d66ec6f5",
+   "id": "3dd4a775",
    "metadata": {},
    "source": [
     "# Option analytics: pricing the cross-section instead of describing it\n",
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea613d66",
+   "id": "d4e14b22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94909bfb",
+   "id": "81b87089",
    "metadata": {
     "tags": [
      "parameters"
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "595600cf",
+   "id": "22c5bf31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a30804f",
+   "id": "1a050b3d",
    "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
@@ -138,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f899e37",
+   "id": "d58c5789",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d5c9fea",
+   "id": "b8c93885",
    "metadata": {},
    "source": [
     "### Three budgets, and one checkpoint axis across two phases\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "850c5daa",
+   "id": "967dd1c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53abaadd",
+   "id": "24d82202",
    "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
@@ -210,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f500836",
+   "id": "651ec654",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7d15b60",
+   "id": "7525e30e",
    "metadata": {},
    "source": [
     "### The device, and the one input that comes from outside the cross-section\n",
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c6d773a",
+   "id": "926e953b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cb32a64",
+   "id": "ca3c45d2",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -287,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8df01726",
+   "id": "91d9c0a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd2d2bda",
+   "id": "31f7b93b",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e81fa6b2",
+   "id": "7e402c5b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3b2184a",
+   "id": "5a7519b5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -386,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e233c8ef",
+   "id": "47629032",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9908883c",
+   "id": "46f7d09d",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71d153ba",
+   "id": "5eb9d04c",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -477,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7edda771",
+   "id": "8794ac9c",
    "metadata": {
     "tags": [
      "results"
@@ -535,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01b85a3d",
+   "id": "b0e4bdb9",
    "metadata": {},
    "source": [
     "### Where the schedule went\n",
@@ -550,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48287b6b",
+   "id": "69af30b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6afa5a3e",
+   "id": "c6fb48d2",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.py
+++ b/case_studies/sp500_equity_option_analytics/11d_stochastic_discount_factor.py
@@ -98,7 +98,10 @@ MODEL_NAME = "sdf"
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="11d_stochastic_discount_factor",
 )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/11e_supervised_autoencoder.ipynb
+++ b/case_studies/sp500_equity_option_analytics/11e_supervised_autoencoder.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8a74da6e",
+   "id": "357eefea",
    "metadata": {},
    "source": [
     "# Option analytics: the factor model that is allowed to see the target\n",
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d220babd",
+   "id": "247c843c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f39ce6e9",
+   "id": "6d7d0407",
    "metadata": {
     "tags": [
      "parameters"
@@ -106,18 +106,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13c32024",
+   "id": "11545cf5",
    "metadata": {},
    "outputs": [],
    "source": [
     "study = open_study(\n",
-    "    \"sp500_equity_option_analytics\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None\n",
+    "    \"sp500_equity_option_analytics\",\n",
+    "    execution_tier=EXECUTION_TIER,\n",
+    "    workspace=WORKSPACE or None,\n",
+    "    entry_point=\"11e_supervised_autoencoder\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e594f8a1",
+   "id": "bf1dfe83",
    "metadata": {},
    "source": [
     "## 1. Which labels, and what the configuration says\n",
@@ -137,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "946e34ea",
+   "id": "ea77dfbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b5d1ac7",
+   "id": "a2e763ee",
    "metadata": {},
    "source": [
     "`case_studies/config/sae/sae.yaml` declares `n_factors: 5`, `n_epochs: 50` and\n",
@@ -164,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "031cf513",
+   "id": "a0bc8faf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f98e3a3",
+   "id": "b10f4a5b",
    "metadata": {},
    "source": [
     "`LABELS` narrows what is fitted, and a narrowed run declares a different set of members than the\n",
@@ -196,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5f86739",
+   "id": "ac11df81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7883317",
+   "id": "f9f5143c",
    "metadata": {},
    "source": [
     "### Where this one runs\n",
@@ -233,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "314d59e5",
+   "id": "90f9d39d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e5cf646",
+   "id": "186a94b8",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -268,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "291564a2",
+   "id": "9eae378c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd2f696d",
+   "id": "bdbf5621",
    "metadata": {},
    "source": [
     "The plan is also where a short population is visible. A run that fitted fewer labels than the\n",
@@ -307,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0f6e4ee",
+   "id": "04c18c06",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aef4a13b",
+   "id": "fb5573cc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -364,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2527bf1",
+   "id": "81148558",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6400bc59",
+   "id": "7753032d",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -419,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73435798",
+   "id": "1c246186",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -443,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f4068ea",
+   "id": "4fcdbc56",
    "metadata": {
     "tags": [
      "results"
@@ -498,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26237a63",
+   "id": "7b9dec10",
    "metadata": {},
    "source": [
     "### Where each label's schedule reached its highest IC\n",
@@ -521,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cc03aa8",
+   "id": "f7368193",
    "metadata": {
     "tags": [
      "results"
@@ -547,7 +550,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e986da3b",
+   "id": "d8a215e1",
    "metadata": {},
    "source": [
     "### What supervision does to the schedule\n",
@@ -562,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f95bcf92",
+   "id": "82ba07df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3267836",
+   "id": "0553f5ff",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/sp500_equity_option_analytics/11e_supervised_autoencoder.py
+++ b/case_studies/sp500_equity_option_analytics/11e_supervised_autoencoder.py
@@ -95,7 +95,10 @@ MODEL_NAME = "sae"
 
 # %%
 study = open_study(
-    "sp500_equity_option_analytics", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None
+    "sp500_equity_option_analytics",
+    execution_tier=EXECUTION_TIER,
+    workspace=WORKSPACE or None,
+    entry_point="11e_supervised_autoencoder",
 )
 
 # %% [markdown]

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -161,11 +161,18 @@ _REGISTERING_SUFFIXES = frozenset(
 )
 
 
+# Notebooks whose recorded entry point is the MODEL name rather than their own stem, which is
+# what the pre-migration `run_case_study_model(..., notebook=f"dl_{MODEL}")` wrote.
+#
+# `sp500_equity_option_analytics` is not in this map: its ten registering notebooks all record
+# their stem, which is the value that answers the question the column exists for - which
+# notebook produced this row. `dl_lstm` names a model, and two notebooks in different case
+# studies can fit the same one. The remaining four entries are other case studies' to settle,
+# and until they do, the fleet has both conventions in circulation - measured 2026-08-25, when
+# the only two non-NULL rows in all nine registries were `09_dl_lstm` and `dl_tsmixer`.
 _DL_FAMILY_ENTRY_POINTS = {
     ("cme_futures", "09_dl_lstm"): "dl_lstm",
     ("etfs", "10_dl_tsmixer"): "dl_tsmixer",
-    ("sp500_equity_option_analytics", "09_dl_lstm"): "dl_lstm",
-    ("sp500_equity_option_analytics", "10_dl_patchtst"): "dl_patchtst",
     ("sp500_options", "09a_lstm"): "dl_lstm",
     ("sp500_options", "09b_patchtst"): "dl_patchtst",
 }

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -161,8 +161,16 @@ _REGISTERING_SUFFIXES = frozenset(
 )
 
 
-# Notebooks whose recorded entry point is the MODEL name rather than their own stem, which is
-# what the pre-migration `run_case_study_model(..., notebook=f"dl_{MODEL}")` wrote.
+# Notebooks whose expected entry point is the MODEL name rather than their own stem.
+#
+# For `etfs/10_dl_tsmixer`, `sp500_options/09a_lstm` and `sp500_options/09b_patchtst` that is
+# what the notebook still writes: all three call `run_case_study_model(..., notebook=f"dl_{MODEL}")`.
+#
+# `cme_futures/09_dl_lstm` is a fourth case and this map is wrong about it. That notebook has
+# already been migrated - it reaches `open_study` through
+# `case_studies/cme_futures/research_workflow.py:82`, which forwards no `entry_point`, so its rows
+# record NULL and this entry expects a value nothing writes. It is the same defect as the two
+# removed below, in a case study this branch does not own; ml4t/agent-workspace#929 carries it.
 #
 # `sp500_equity_option_analytics` is not in this map: its ten registering notebooks all record
 # their stem, which is the value that answers the question the column exists for - which

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -163,21 +163,23 @@ _REGISTERING_SUFFIXES = frozenset(
 
 # Notebooks whose expected entry point is the MODEL name rather than their own stem.
 #
-# For `etfs/10_dl_tsmixer`, `sp500_options/09a_lstm` and `sp500_options/09b_patchtst` that is
-# what the notebook still writes: all three call `run_case_study_model(..., notebook=f"dl_{MODEL}")`.
+# Three of the four entries describe what the notebook still writes: `etfs/10_dl_tsmixer`,
+# `sp500_options/09a_lstm` and `sp500_options/09b_patchtst` all call
+# `run_dl_cv(..., notebook=f"dl_{MODEL}")`, and `deep_learning.py:1658` passes that straight
+# through as `entry_point=notebook`, so the expectation matches the value written.
 #
-# `cme_futures/09_dl_lstm` is a fourth case and this map is wrong about it. That notebook has
-# already been migrated - it reaches `open_study` through
-# `case_studies/cme_futures/research_workflow.py:82`, which forwards no `entry_point`, so its rows
-# record NULL and this entry expects a value nothing writes. It is the same defect as the two
-# removed below, in a case study this branch does not own; ml4t/agent-workspace#929 carries it.
+# The `cme_futures/09_dl_lstm` entry expects a value nothing writes. That notebook has been
+# migrated onto `open_study`, reaching it through
+# `case_studies/cme_futures/research_workflow.py:82`, which forwards no `entry_point`, so
+# `results.py` records `study.entry_point` and its rows carry NULL. Tracked as
+# ml4t/agent-workspace#930, which belongs to that case study rather than to this file.
 #
-# `sp500_equity_option_analytics` is not in this map: its ten registering notebooks all record
-# their stem, which is the value that answers the question the column exists for - which
-# notebook produced this row. `dl_lstm` names a model, and two notebooks in different case
-# studies can fit the same one. The remaining four entries are other case studies' to settle,
-# and until they do, the fleet has both conventions in circulation - measured 2026-08-25, when
-# the only two non-NULL rows in all nine registries were `09_dl_lstm` and `dl_tsmixer`.
+# `sp500_equity_option_analytics` has no entry here: all ten of its registering notebooks pass
+# their own stem. That is the value which answers the question the column exists for - which
+# notebook produced this row - where `dl_lstm` names a model that more than one case study
+# fits. The fleet currently has both conventions in circulation: on 2026-08-25 the only two
+# non-NULL `entry_point` values in all nine registries were `09_dl_lstm` and `dl_tsmixer`, one
+# a stem and one a model name.
 _DL_FAMILY_ENTRY_POINTS = {
     ("cme_futures", "09_dl_lstm"): "dl_lstm",
     ("etfs", "10_dl_tsmixer"): "dl_tsmixer",


### PR DESCRIPTION
Ten notebooks in `sp500_equity_option_analytics` stopped recording which notebook produced
each of their training rows, so `training_runs.entry_point` is NULL for all of them and
`tests/test_model_registry.py::test_model_notebook` asserts a value nothing writes.

Eight of them were migrated by #604 from `run_case_study_model(..., notebook="...")`, which
passed the stage name through to `register_training_run(entry_point=...)`, onto
`open_study(...)` called without the `entry_point=` argument the same range introduced.
`ResultsCatalog.register_training` then records `entry_point=self.study.entry_point`, which
is None. The other two, `06_linear` and `07_gbm`, were migrated the same way by #560.

## Why this is separate from the case-study branch

The push gate refuses HIGH findings in the files a push changes, and a merge commit counts
main's files as changed. A pane that merges main to resolve a conflict therefore inherits
this finding and cannot push, from a branch touching none of these files. It has already
held one push carrying seven notebooks' work. This branch is based on main so its checks run
for real.

## What it does not change

`entry_point` is provenance, not identity. `training_hash_from_spec(spec)` never sees it - it
is a separate column in the INSERT, beside `git_commit` and `started_at`. Verified by
resolving the `tabular_dl` population with and without it and getting the same 72 prediction
hashes, so no refit is owed and no registered result moves.

Nor does it repair existing rows. Identity is unchanged, so a re-run identity-skips and the
old rows keep their NULL: 1,060 of the 1,062 training rows across all nine registries carry
NULL today, so no case study can attribute a row to a notebook, and each one's run-log reset
is what fills the column. Rows written after this change carry the value, and in CI the
fixture registry is fresh so the assertion sees it.

## Which value

The notebook's own stem, which is what answers the question the column exists for. The two
`sp500_equity_option_analytics` entries in `_DL_FAMILY_ENTRY_POINTS` are removed rather than
matched, because `dl_lstm` names a *model* and more than one case study fits it. The four
entries belonging to `cme_futures`, `etfs` and `sp500_options` are left alone with a comment
recording which of them still reflect a live `run_dl_cv(..., notebook=...)` call - three do;
`cme_futures/09_dl_lstm` has already been migrated and writes nothing, which is
ml4t/agent-workspace#930 and belongs to that case study.

The fleet has both conventions in circulation: on 2026-08-25 the only two non-NULL
`entry_point` values in all nine registries were `09_dl_lstm` and `dl_tsmixer`, one a stem
and one a model name.

## Also here

Two prose corrections RoboRev raised against the same files, both replacing a claim about
the code with what the code does:

- `11c_conditional_autoencoder` said its reconstruction objective "never mentions the forward
  return the notebook is scored on". `panel.py:52` fills the return matrix from the
  configured label column, so the objective reproduces that member's own label - the same
  column its IC is then computed on. The narrower true distinction is kept: reconstructing
  one window is not forecasting the next.
- `11b_ipca` said it differs from `11a_pca` by one thing. It differs by two, and the notebook
  already said so elsewhere: IPCA tolerates a ragged panel, so it is scored on about a tenth
  more rows - 192,139 against 175,360 on `fwd_ret_10d`. The IC gap is now read as a bound
  rather than an estimate.

`08_tabular_dl` and `11a_pca` are committed executed against production data. `08` needed
`SUPERSEDES_POPULATION` because #597 changed `case_studies/utils/tabular_dl.py`, which is
recorded in `computation.source_identity`, so its registered population could no longer be
reproduced - all 72 resolved hashes differed from all 72 stored. That refit was owed
regardless of this change.
