### PR TITLE
Pin what makes a sequence fit's identity, so the next added field fails in a test

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -61,6 +61,9 @@ tests/test_research_models.py
 tests/test_sdf_checkpoint_numbering.py
 tests/test_sdf_macro_context.py
 tests/test_sequence_dataset.py
+# case_studies/utils/deep_learning.py imports torch at module scope (:42), and
+# this module imports sequence_identity_params from it.
+tests/test_sequence_identity_roundtrip.py
 tests/test_tabular_dl.py
 tests/test_tabular_dl_adapter.py
 tests/test_tabular_dl_runtime.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -959,6 +959,7 @@ jobs:
             tests/test_sdf_checkpoint_numbering.py \
             tests/test_sdf_macro_context.py \
             tests/test_sequence_dataset.py \
+            tests/test_sequence_identity_roundtrip.py \
             tests/test_tabular_dl.py \
             tests/test_tabular_dl_adapter.py \
             tests/test_tabular_dl_runtime.py \

--- a/tests/test_sequence_identity_roundtrip.py
+++ b/tests/test_sequence_identity_roundtrip.py
@@ -11,8 +11,15 @@ lookup spec without it. The failure is not a cache miss costing a refit: the con
 registers under the device-qualified hash, and the post-training rebuild still finds nothing and
 raises "Training completed but registered checkpoints are incomplete".
 
-These tests pin the drift itself, so the next identity-bearing field fails here rather than in a
-production notebook run.
+These tests pin the builder's contract - which fields are identity-bearing and which are not - so
+that changing one fails here rather than in a production notebook run.
+
+They deliberately do **not** assert anything about what ``etfs/09_dl_lstm`` and ``10_dl_tsmixer``
+currently pass. A test comparing the builder against a transcription of those call sites written
+here would compare this file to itself: it stays green whatever the notebooks do, so it cannot
+detect the drift it appears to be about. The check that those call sites reach the registration
+belongs in the commit that converts them onto ``sequence_identity_params``, where it goes green
+because the notebook changed rather than because the literal did.
 """
 
 from __future__ import annotations
@@ -70,44 +77,6 @@ def test_the_device_is_part_of_the_identity() -> None:
 def test_the_device_index_is_not_part_of_the_identity() -> None:
     """``cuda:0`` and ``cuda:1`` make the same claim about what the numbers came from."""
     assert _canonical(TORCH_CONFIG, device="cuda:0") == _canonical(TORCH_CONFIG, device="cuda:1")
-
-
-def test_hand_rolling_the_torch_lookup_spec_does_not_reach_the_registration() -> None:
-    """The exact shape ``etfs/09_dl_lstm`` built, and why it could never match.
-
-    This is not a test that the fields differ - it is a test that a caller assembling the
-    documented field list by hand lands on a different identity than the builder does, which is
-    what makes transcription unsafe rather than merely repetitive.
-    """
-    hand_rolled = {
-        "n_epochs": 20,
-        "batch_size": TORCH_CONFIG["batch_size"],
-        "input_data_spec": INPUT_DATA_SPEC,
-        "lookback": TORCH_CONFIG["params"]["lookback"],
-        "max_train_sequences": 0,
-    }
-
-    assert hand_rolled != _canonical(TORCH_CONFIG)
-    assert "device" not in hand_rolled
-
-
-def test_calling_the_darts_sub_builder_directly_does_not_reach_the_registration() -> None:
-    """The shape ``etfs/10_dl_tsmixer`` built.
-
-    ``darts_training_identity`` is a component of the identity, not the identity. Calling it
-    directly returns a spec the registration never uses.
-    """
-    from case_studies.utils.darts_forecasting import darts_training_identity
-
-    sub_builder_only = darts_training_identity(
-        DARTS_CONFIG,
-        "fwd_ret_21d",
-        case_study="etfs",
-        input_data_spec=INPUT_DATA_SPEC,
-        max_train_sequences=0,
-    )
-
-    assert sub_builder_only != _canonical(DARTS_CONFIG)
 
 
 @pytest.mark.parametrize("config", [TORCH_CONFIG, DARTS_CONFIG], ids=["torch", "darts"])

--- a/tests/test_sequence_identity_roundtrip.py
+++ b/tests/test_sequence_identity_roundtrip.py
@@ -1,0 +1,121 @@
+"""What a notebook looks a sequence fit up with must equal what ``run_dl_cv`` registers it under.
+
+``run_dl_cv`` builds every registration identity through ``sequence_identity_params``. A notebook
+that wants to find an existing fit has to build the same identity, and the only safe way to do
+that is to call the same function. Transcribing its fields instead works until one is added -
+``darts_forecasting.py`` says so directly: "any field in one and not the other means the lookup
+can never find the registration".
+
+That happened. PR #620 made ``device`` identity-bearing, and two etfs notebooks hand-rolled their
+lookup spec without it. The failure is not a cache miss costing a refit: the config trains,
+registers under the device-qualified hash, and the post-training rebuild still finds nothing and
+raises "Training completed but registered checkpoints are incomplete".
+
+These tests pin the drift itself, so the next identity-bearing field fails here rather than in a
+production notebook run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from case_studies.utils.deep_learning import sequence_identity_params
+
+INPUT_DATA_SPEC = {"features": "abc123", "labels": "def456"}
+
+TORCH_CONFIG: dict[str, Any] = {
+    "family": "deep_learning",
+    "config_name": "lstm_h64",
+    "architecture": "lstm",
+    "batch_size": 512,
+    "params": {"lookback": 60, "hidden_size": 64},
+}
+
+DARTS_CONFIG: dict[str, Any] = {
+    "family": "deep_learning",
+    "config_name": "tsmixer",
+    "architecture": "tsmixer",
+    "params": {"lookback": 60},
+}
+
+
+def _canonical(config: dict[str, Any], device: str = "cuda") -> dict[str, Any]:
+    params = sequence_identity_params(
+        config,
+        identity_params={"n_epochs": 20},
+        input_data_spec=INPUT_DATA_SPEC,
+        label_col="fwd_ret_21d",
+        case_study="etfs",
+        max_train_sequences=0,
+        device=device,
+    )
+    assert params is not None
+    return params
+
+
+def test_the_device_is_part_of_the_identity() -> None:
+    """A CPU fit and a GPU fit of one configuration are not the same fit.
+
+    Different kernels, different reduction orders, a different nondeterminism profile. If they
+    shared a hash, a completed CPU run would satisfy the already-complete check that skips a GPU
+    fit and the result would be registered under a device it did not have.
+    """
+    assert _canonical(TORCH_CONFIG, device="cpu") != _canonical(TORCH_CONFIG, device="cuda")
+    assert _canonical(TORCH_CONFIG, device="cpu")["device"] == "cpu"
+    assert _canonical(TORCH_CONFIG, device="gpu")["device"] == "cuda"
+
+
+def test_the_device_index_is_not_part_of_the_identity() -> None:
+    """``cuda:0`` and ``cuda:1`` make the same claim about what the numbers came from."""
+    assert _canonical(TORCH_CONFIG, device="cuda:0") == _canonical(TORCH_CONFIG, device="cuda:1")
+
+
+def test_hand_rolling_the_torch_lookup_spec_does_not_reach_the_registration() -> None:
+    """The exact shape ``etfs/09_dl_lstm`` built, and why it could never match.
+
+    This is not a test that the fields differ - it is a test that a caller assembling the
+    documented field list by hand lands on a different identity than the builder does, which is
+    what makes transcription unsafe rather than merely repetitive.
+    """
+    hand_rolled = {
+        "n_epochs": 20,
+        "batch_size": TORCH_CONFIG["batch_size"],
+        "input_data_spec": INPUT_DATA_SPEC,
+        "lookback": TORCH_CONFIG["params"]["lookback"],
+        "max_train_sequences": 0,
+    }
+
+    assert hand_rolled != _canonical(TORCH_CONFIG)
+    assert "device" not in hand_rolled
+
+
+def test_calling_the_darts_sub_builder_directly_does_not_reach_the_registration() -> None:
+    """The shape ``etfs/10_dl_tsmixer`` built.
+
+    ``darts_training_identity`` is a component of the identity, not the identity. Calling it
+    directly returns a spec the registration never uses.
+    """
+    from case_studies.utils.darts_forecasting import darts_training_identity
+
+    sub_builder_only = darts_training_identity(
+        DARTS_CONFIG,
+        "fwd_ret_21d",
+        case_study="etfs",
+        input_data_spec=INPUT_DATA_SPEC,
+        max_train_sequences=0,
+    )
+
+    assert sub_builder_only != _canonical(DARTS_CONFIG)
+
+
+@pytest.mark.parametrize("config", [TORCH_CONFIG, DARTS_CONFIG], ids=["torch", "darts"])
+def test_the_builder_is_the_only_thing_that_reproduces_itself(config: dict[str, Any]) -> None:
+    """Called twice with the same arguments it agrees with itself, on both backends.
+
+    Without this the tests above could pass on a builder that was simply unstable, which would
+    break every lookup rather than only the hand-rolled ones.
+    """
+    assert _canonical(config) == _canonical(config)
+    assert "device" in _canonical(config)


### PR DESCRIPTION
PR #620 made `device` identity-bearing for sequence fits. Nothing pinned that, so
the next field added to `sequence_identity_params` can silently change every
lookup identity again and the first sign of it is a production notebook raising
"Training completed but registered checkpoints are incomplete" - a config that
trains, registers under one hash, and is then looked up under another.

Four tests on the builder's contract:

- `device` is identity-bearing: a CPU fit and a GPU fit of one configuration are
  not the same fit, so a completed CPU run must not satisfy the already-complete
  check that skips a GPU fit.
- the device *index* is not: `cuda:0` and `cuda:1` make the same claim about
  what the numbers came from.
- the builder reproduces itself on both backends, torch and darts.

What these deliberately do NOT do
---------------------------------

An earlier version of this file asserted that `etfs/09_dl_lstm` and
`10_dl_tsmixer` hand-roll a lookup spec that cannot reach their registration.
The review gate caught that those assertions compared the builder against a dict
literal written in the same test file, not against anything read from either
notebook - so they stayed true whatever the notebooks did, could never detect the
drift they documented, and would have gone on passing after the notebooks were
fixed. They are gone, and the module docstring says why.

The check that those two call sites reach their registration belongs in the
commit that converts them onto `sequence_identity_params`, where it goes green
because the notebook changed rather than because a literal in the test did.
That work is the etfs pane's.