### PR TITLE
Scope result selection to immutable prediction populations

### DIFF
--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -201,6 +201,8 @@ class BacktestExplorer:
         """
         filter_sql = ""
         filter_params: list[str] = []
+        coverage_params: list[str] = []
+        coverage_sql = full_coverage_prediction_sql("p", "t", "pm")
         if label:
             filter_sql += " AND t.label = ?"
             filter_params.append(label)
@@ -208,6 +210,13 @@ class BacktestExplorer:
             placeholders = ", ".join("?" for _ in prediction_hashes)
             filter_sql += f" AND p.prediction_hash IN ({placeholders})"
             filter_params.extend(prediction_hashes)
+            coverage_sql = full_coverage_prediction_sql(
+                "p",
+                "t",
+                "pm",
+                population_subquery="SELECT value FROM json_each(?)",
+            )
+            coverage_params.append(json.dumps(list(prediction_hashes)))
 
         df = self._query(
             f"""
@@ -237,7 +246,7 @@ class BacktestExplorer:
             WHERE b.stage = ?
               AND p.split != 'holdout'
               {excluded_family_sql(self.case_study, "t.family")[0]}
-              {full_coverage_prediction_sql("p", "t", "pm")}
+              {coverage_sql}
               AND bm.sharpe IS NOT NULL
               AND (bm.num_trades IS NULL OR bm.num_trades > 0)
               {filter_sql}
@@ -247,6 +256,7 @@ class BacktestExplorer:
             (
                 stage,
                 *excluded_family_sql(self.case_study, "t.family")[1],
+                *coverage_params,
                 *filter_params,
                 top_n,
             ),
@@ -404,6 +414,16 @@ class BacktestExplorer:
         if not stages:
             return pl.DataFrame()
         placeholders = ", ".join("?" for _ in stages)
+        coverage_params: tuple[str, ...] = ()
+        coverage_sql = full_coverage_prediction_sql("p", "t", "pm")
+        if prediction_hashes:
+            coverage_sql = full_coverage_prediction_sql(
+                "p",
+                "t",
+                "pm",
+                population_subquery="SELECT value FROM json_each(?)",
+            )
+            coverage_params = (json.dumps(list(prediction_hashes)),)
         sql = f"""
             SELECT
                 b.spec_json,
@@ -419,11 +439,15 @@ class BacktestExplorer:
             WHERE b.stage IN ({placeholders})
               AND p.split != 'holdout'
               {excluded_family_sql(self.case_study, "t.family")[0]}
-              {full_coverage_prediction_sql("p", "t", "pm")}
+              {coverage_sql}
               AND bm.sharpe IS NOT NULL
               AND (bm.num_trades IS NULL OR bm.num_trades > 0)
         """
-        params: tuple = (*stages, *excluded_family_sql(self.case_study, "t.family")[1])
+        params: tuple = (
+            *stages,
+            *excluded_family_sql(self.case_study, "t.family")[1],
+            *coverage_params,
+        )
         if prediction_hash:
             sql += " AND b.prediction_hash LIKE ?"
             params = (*params, prediction_hash + "%")

--- a/case_studies/utils/notebook_contracts.py
+++ b/case_studies/utils/notebook_contracts.py
@@ -99,6 +99,7 @@ def full_coverage_prediction_sql(
     prediction_set_alias: str = "p",
     training_run_alias: str = "t",
     prediction_metric_alias: str = "pm",
+    population_subquery: str | None = None,
 ) -> str:
     """SQL clause retaining the maximum-coverage rows for each family and label.
 
@@ -106,12 +107,18 @@ def full_coverage_prediction_sql(
     its peers even when no fold-level IC is NULL. Comparing or selecting those
     rows against full-coverage checkpoints changes the evaluation sample. The
     eligible surface therefore keeps rows whose ``ic_n_days`` equals the maximum
-    for the same ``(split, family, label)``.
+    for the same ``(split, family, label)``. When ``population_subquery`` is
+    supplied, that maximum is computed within the explicitly locked prediction
+    population rather than across retired identities.
 
     The surrounding query must join ``prediction_sets``, ``training_runs``, and
     ``prediction_metrics`` under the supplied aliases. The returned fragment
-    begins with ``" AND "`` and takes no bound parameters.
+    begins with ``" AND "``. Any bound parameters required by
+    ``population_subquery`` belong to the surrounding query.
     """
+    population_clause = ""
+    if population_subquery is not None:
+        population_clause = f" AND p_full.prediction_hash IN ({population_subquery})"
     return f"""
         AND {prediction_metric_alias}.ic_n_days IS NOT NULL
         AND {prediction_metric_alias}.ic_n_days = (
@@ -124,6 +131,7 @@ def full_coverage_prediction_sql(
             WHERE p_full.split = {prediction_set_alias}.split
               AND t_full.family = {training_run_alias}.family
               AND t_full.label = {training_run_alias}.label
+              {population_clause}
         )
     """
 

--- a/case_studies/utils/registry/queries.py
+++ b/case_studies/utils/registry/queries.py
@@ -788,15 +788,17 @@ def _canonical_family_coverage_bar(
     case_dir: Path,
     prediction_hashes: set[str] | None = None,
 ) -> dict[str, int]:
-    """Max in-window coverage per family, over EVERY prediction set for the label.
+    """Max in-window coverage per family over the eligible prediction population.
 
     The eligibility bar has to be the family's best coverage, not the best among the
     rows that happen to carry a backtest at the stage being resolved. Taking the max
     after a stage filter lowers the bar whenever the family's full-coverage prediction
     was never backtested at that stage, and a partial-coverage prediction then
     qualifies - which is exactly what ``full_coverage_prediction_sql`` prevents on the
-    raw path, where the ``MAX(ic_n_days)`` subquery ranges over all of
-    ``(split, family, label)`` with no stage restriction.
+    raw path, where the ``MAX(ic_n_days)`` subquery ranges over all eligible members
+    of ``(split, family, label)`` with no stage restriction. An explicit immutable
+    population is a deliberate eligibility boundary, so retired identities outside
+    it do not set the comparison bar.
 
     Requires a ``prediction_metrics`` row, matching the raw path's implicit
     requirement (``full_coverage_prediction_sql`` joins ``pm``): a prediction set
@@ -1076,23 +1078,12 @@ def resolve_best_predictions(
         population_clause = (
             "AND p.prediction_hash IN (SELECT prediction_hash FROM population_members)"
         )
-        coverage_clause = """
-            AND pm.ic_n_days IS NOT NULL
-            AND pm.ic_n_days = (
-                SELECT MAX(pm_full.ic_n_days)
-                FROM prediction_sets p_full
-                JOIN training_runs t_full
-                  ON p_full.training_hash = t_full.training_hash
-                JOIN prediction_metrics pm_full
-                  ON p_full.prediction_hash = pm_full.prediction_hash
-                WHERE p_full.split = p.split
-                  AND t_full.family = t.family
-                  AND t_full.label = t.label
-                  AND p_full.prediction_hash IN (
-                      SELECT prediction_hash FROM population_members
-                  )
-            )
-        """
+        coverage_clause = full_coverage_prediction_sql(
+            "p",
+            "t",
+            "pm",
+            population_subquery="SELECT prediction_hash FROM population_members",
+        )
         params.append(json.dumps(sorted(prediction_hashes)))
     params.extend([label, *stage_params, *exclude_params])
     if split:
@@ -1384,23 +1375,12 @@ def resolve_best_backtest_runs(
         population_clause = (
             "AND p.prediction_hash IN (SELECT prediction_hash FROM population_members)"
         )
-        coverage_clause = """
-            AND pm.ic_n_days IS NOT NULL
-            AND pm.ic_n_days = (
-                SELECT MAX(pm_full.ic_n_days)
-                FROM prediction_sets p_full
-                JOIN training_runs t_full
-                  ON p_full.training_hash = t_full.training_hash
-                JOIN prediction_metrics pm_full
-                  ON p_full.prediction_hash = pm_full.prediction_hash
-                WHERE p_full.split = p.split
-                  AND t_full.family = t.family
-                  AND t_full.label = t.label
-                  AND p_full.prediction_hash IN (
-                      SELECT prediction_hash FROM population_members
-                  )
-            )
-        """
+        coverage_clause = full_coverage_prediction_sql(
+            "p",
+            "t",
+            "pm",
+            population_subquery="SELECT prediction_hash FROM population_members",
+        )
         params.append(json.dumps(sorted(prediction_hashes)))
     params.extend([label, *exclude_params, *stage_params, *split_params, str(top_n)])
 

--- a/case_studies/utils/registry/queries.py
+++ b/case_studies/utils/registry/queries.py
@@ -786,6 +786,7 @@ def _canonical_family_coverage_bar(
     label: str,
     split: str,
     case_dir: Path,
+    prediction_hashes: set[str] | None = None,
 ) -> dict[str, int]:
     """Max in-window coverage per family, over EVERY prediction set for the label.
 
@@ -817,6 +818,10 @@ def _canonical_family_coverage_bar(
     bar: dict[str, int] = {}
     if universe.is_empty():
         return bar
+    if prediction_hashes is not None:
+        universe = universe.filter(pl.col("prediction_hash").is_in(prediction_hashes))
+        if universe.is_empty():
+            return bar
     for prediction_hash, family in universe.select("prediction_hash", "family").iter_rows():
         days = canonical_coverage_days(case_study, label, split, prediction_hash, case_dir)
         if days is None:
@@ -837,6 +842,7 @@ def _resolve_best_predictions_canonical(
     universe_filter: str | None,
     case_dir: Path | None,
     checkpoints_per_config: int,
+    prediction_hashes: set[str] | None,
 ):
     """``resolve_best_predictions(coverage_window="canonical")``.
 
@@ -895,12 +901,22 @@ def _resolve_best_predictions_canonical(
     per_prediction = _query_table(case_dir, query, tuple(params))
     if per_prediction.is_empty():
         return pl.DataFrame(schema=_BEST_PREDICTIONS_SCHEMA)
+    if prediction_hashes is not None:
+        per_prediction = per_prediction.filter(pl.col("prediction_hash").is_in(prediction_hashes))
+        if per_prediction.is_empty():
+            return pl.DataFrame(schema=_BEST_PREDICTIONS_SCHEMA)
 
     in_window = {
         h: canonical_coverage_days(case_study, label, split, h, case_dir)
         for h in per_prediction["prediction_hash"].unique().to_list()
     }
-    bar = _canonical_family_coverage_bar(case_study, label, split, case_dir)
+    bar = _canonical_family_coverage_bar(
+        case_study,
+        label,
+        split,
+        case_dir,
+        prediction_hashes=prediction_hashes,
+    )
     per_prediction = per_prediction.with_columns(
         pl.col("prediction_hash").replace_strict(in_window, default=None).alias("_in_window_days"),
         pl.col("family").replace_strict(bar, default=None).alias("_family_bar"),
@@ -959,6 +975,7 @@ def resolve_best_predictions(
     case_dir: Path | None = None,
     checkpoints_per_config: int = 1,
     coverage_window: str = "raw",
+    prediction_hashes: set[str] | None = None,
 ):
     """Return top-N prediction hashes ranked by backtest Sharpe at a given stage.
 
@@ -998,6 +1015,9 @@ def resolve_best_predictions(
         study's prediction sets predate a canonical-window change and raw
         ``ic_n_days`` differs across peers only by out-of-window dates.
         Requires ``split``.
+    prediction_hashes : set[str], optional
+        Restrict eligibility to these prediction identities before ranking
+        configurations and checkpoints.
 
     Returns
     -------
@@ -1018,6 +1038,7 @@ def resolve_best_predictions(
             universe_filter=universe_filter,
             case_dir=case_dir,
             checkpoints_per_config=checkpoints_per_config,
+            prediction_hashes=prediction_hashes,
         )
 
     if case_dir is None:
@@ -1044,9 +1065,36 @@ def resolve_best_predictions(
     stage_clause, stage_params = _stage_filter_clause(stage, chapter_filter)
     exclude_clause, exclude_params = excluded_family_sql(case_study, "t.family")
     degenerate_clause = degenerate_prediction_sql("p.prediction_hash")
+    population_cte = ""
+    population_clause = ""
+    coverage_clause = full_coverage_prediction_sql("p", "t", "pm")
 
     split_clause = ""
-    params: list[str] = [label] + stage_params + exclude_params
+    params: list[str] = []
+    if prediction_hashes is not None:
+        population_cte = "population_members(prediction_hash) AS (SELECT value FROM json_each(?)),"
+        population_clause = (
+            "AND p.prediction_hash IN (SELECT prediction_hash FROM population_members)"
+        )
+        coverage_clause = """
+            AND pm.ic_n_days IS NOT NULL
+            AND pm.ic_n_days = (
+                SELECT MAX(pm_full.ic_n_days)
+                FROM prediction_sets p_full
+                JOIN training_runs t_full
+                  ON p_full.training_hash = t_full.training_hash
+                JOIN prediction_metrics pm_full
+                  ON p_full.prediction_hash = pm_full.prediction_hash
+                WHERE p_full.split = p.split
+                  AND t_full.family = t.family
+                  AND t_full.label = t.label
+                  AND p_full.prediction_hash IN (
+                      SELECT prediction_hash FROM population_members
+                  )
+            )
+        """
+        params.append(json.dumps(sorted(prediction_hashes)))
+    params.extend([label, *stage_params, *exclude_params])
     if split:
         split_clause = "AND p.split = ?"
         params.append(split)
@@ -1058,7 +1106,8 @@ def resolve_best_predictions(
     params.append(str(max(1, int(checkpoints_per_config))))
 
     query = f"""
-        WITH per_prediction AS (
+        WITH {population_cte}
+        per_prediction AS (
             -- Best backtest Sharpe per prediction_hash (a prediction may have
             -- been backtested with multiple signal methods)
             SELECT
@@ -1079,9 +1128,10 @@ def resolve_best_predictions(
               {stage_clause}
               {exclude_clause}
               {degenerate_clause}
-              {full_coverage_prediction_sql("p", "t", "pm")}
+              {coverage_clause}
               {split_clause}
               {universe_clause}
+              {population_clause}
             GROUP BY p.prediction_hash
         ),
         top_configs AS (
@@ -1137,6 +1187,7 @@ def _resolve_best_backtest_runs_canonical(
     chapter: str | None,
     top_n: int,
     case_dir: Path | None,
+    prediction_hashes: set[str] | None,
 ):
     """``resolve_best_backtest_runs(coverage_window="canonical")``.
 
@@ -1191,12 +1242,22 @@ def _resolve_best_backtest_runs_canonical(
     df = _query_table(case_dir, query, tuple([label] + exclude_params + stage_params + [split]))
     if df.is_empty():
         return df
+    if prediction_hashes is not None:
+        df = df.filter(pl.col("prediction_hash").is_in(prediction_hashes))
+        if df.is_empty():
+            return df
 
     in_window = {
         h: canonical_coverage_days(case_study, label, split, h, case_dir)
         for h in df["prediction_hash"].unique().to_list()
     }
-    bar = _canonical_family_coverage_bar(case_study, label, split, case_dir)
+    bar = _canonical_family_coverage_bar(
+        case_study,
+        label,
+        split,
+        case_dir,
+        prediction_hashes=prediction_hashes,
+    )
     df = df.with_columns(
         pl.col("prediction_hash").replace_strict(in_window, default=None).alias("_in_window_days"),
         pl.col("family").replace_strict(bar, default=None).alias("_family_bar"),
@@ -1229,6 +1290,7 @@ def resolve_best_backtest_runs(
     top_n: int = 3,
     case_dir: Path | None = None,
     coverage_window: str = "raw",
+    prediction_hashes: set[str] | None = None,
 ):
     """Return top-N backtest runs at a given stage, ranked by Sharpe.
 
@@ -1260,6 +1322,9 @@ def resolve_best_backtest_runs(
     coverage_window : str
         See ``resolve_best_predictions``. "raw" (default) is unchanged behavior;
         "canonical" requires an explicit ``split``.
+    prediction_hashes : set[str], optional
+        Restrict eligibility to these prediction identities before coverage filtering and
+        ranking.
 
     Returns
     -------
@@ -1277,6 +1342,7 @@ def resolve_best_backtest_runs(
             chapter=chapter,
             top_n=top_n,
             case_dir=case_dir,
+            prediction_hashes=prediction_hashes,
         )
 
     if case_dir is None:
@@ -1300,6 +1366,9 @@ def resolve_best_backtest_runs(
     stage_clause, stage_params = _stage_filter_clause(stage)
     exclude_clause, exclude_params = excluded_family_sql(case_study, "t.family")
     degenerate_clause = degenerate_prediction_sql("p.prediction_hash")
+    population_cte = ""
+    population_clause = ""
+    coverage_clause = full_coverage_prediction_sql("p", "t", "pm")
 
     split_clause = ""
     split_params: list[str] = []
@@ -1307,7 +1376,36 @@ def resolve_best_backtest_runs(
         split_clause = "AND p.split = ?"
         split_params = [split]
 
+    params: list[str] = []
+    if prediction_hashes is not None:
+        population_cte = (
+            "WITH population_members(prediction_hash) AS (SELECT value FROM json_each(?))"
+        )
+        population_clause = (
+            "AND p.prediction_hash IN (SELECT prediction_hash FROM population_members)"
+        )
+        coverage_clause = """
+            AND pm.ic_n_days IS NOT NULL
+            AND pm.ic_n_days = (
+                SELECT MAX(pm_full.ic_n_days)
+                FROM prediction_sets p_full
+                JOIN training_runs t_full
+                  ON p_full.training_hash = t_full.training_hash
+                JOIN prediction_metrics pm_full
+                  ON p_full.prediction_hash = pm_full.prediction_hash
+                WHERE p_full.split = p.split
+                  AND t_full.family = t.family
+                  AND t_full.label = t.label
+                  AND p_full.prediction_hash IN (
+                      SELECT prediction_hash FROM population_members
+                  )
+            )
+        """
+        params.append(json.dumps(sorted(prediction_hashes)))
+    params.extend([label, *exclude_params, *stage_params, *split_params, str(top_n)])
+
     query = f"""
+        {population_cte}
         SELECT
             b.backtest_hash,
             b.prediction_hash,
@@ -1324,15 +1422,16 @@ def resolve_best_backtest_runs(
           {exclude_clause}
           {stage_clause}
           {degenerate_clause}
-          {full_coverage_prediction_sql("p", "t", "pm")}
+          {coverage_clause}
           {split_clause}
+          {population_clause}
         ORDER BY bm.sharpe DESC
         LIMIT ?
     """
     df = _query_table(
         case_dir,
         query,
-        tuple([label] + exclude_params + stage_params + split_params + [str(top_n)]),
+        tuple(params),
     )
     if df.is_empty():
         return df

--- a/tests/test_canonical_coverage_bar.py
+++ b/tests/test_canonical_coverage_bar.py
@@ -62,6 +62,18 @@ def test_the_bar_is_the_family_best_across_every_prediction(case_dir: Path) -> N
     )
 
 
+def test_the_bar_is_scoped_to_an_explicit_population(case_dir: Path) -> None:
+    bar = queries._canonical_family_coverage_bar(
+        "fixture",
+        "fwd_ret_5d",
+        "validation",
+        case_dir,
+        prediction_hashes={"short"},
+    )
+
+    assert bar == {"gbm": 480}
+
+
 def test_a_prediction_that_cannot_be_evaluated_does_not_set_the_bar(
     case_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_full_coverage_selection.py
+++ b/tests/test_full_coverage_selection.py
@@ -126,11 +126,24 @@ def test_backtest_readers_exclude_partial_coverage(tmp_path) -> None:
     assert explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["partial"])[
         "prediction_hash"
     ].to_list() == ["partial"]
+    assert explorer.best(
+        top_n=10,
+        label="fwd_ret_5d",
+        prediction_hashes=["partial", "full_a"],
+    )["prediction_hash"].to_list() == ["full_a"]
     assert (
         explorer.compare_allocators(
             stages=("signal",),
             label="fwd_ret_5d",
             prediction_hashes=["partial"],
+        )["n"].item()
+        == 1
+    )
+    assert (
+        explorer.compare_allocators(
+            stages=("signal",),
+            label="fwd_ret_5d",
+            prediction_hashes=["partial", "full_a"],
         )["n"].item()
         == 1
     )
@@ -239,6 +252,18 @@ def test_backtest_population_sets_the_raw_coverage_bar(tmp_path) -> None:
 
     assert selected["prediction_hash"].to_list() == ["partial"]
 
+    selected_with_peer = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=10,
+        case_dir=case_dir,
+        prediction_hashes={"partial", "full_a"},
+    )
+
+    assert selected_with_peer["prediction_hash"].to_list() == ["full_a"]
+
 
 def test_canonical_backtest_population_is_filtered_before_run_ranking(
     tmp_path, monkeypatch
@@ -294,6 +319,19 @@ def test_canonical_backtest_population_sets_the_coverage_bar(tmp_path, monkeypat
     )
 
     assert selected["prediction_hash"].to_list() == ["partial"]
+
+    selected_with_peer = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=10,
+        case_dir=case_dir,
+        coverage_window="canonical",
+        prediction_hashes={"partial", "full_a"},
+    )
+
+    assert selected_with_peer["prediction_hash"].to_list() == ["full_a"]
 
 
 def test_canonical_prediction_population_sets_the_coverage_bar(tmp_path, monkeypatch) -> None:

--- a/tests/test_full_coverage_selection.py
+++ b/tests/test_full_coverage_selection.py
@@ -219,7 +219,12 @@ def test_canonical_backtest_population_is_filtered_before_run_ranking(
     _build_registry(case_dir)
     monkeypatch.setattr(
         "case_studies.utils.registry.queries.canonical_coverage_days",
-        lambda case_study, label, split, prediction_hash, case_dir: 4,
+        lambda case_study, label, split, prediction_hash, case_dir: {
+            "partial": 2,
+            "full_a": 4,
+            "full_b": 4,
+            "tabular": 2,
+        }[prediction_hash],
     )
 
     selected = resolve_best_backtest_runs(
@@ -230,10 +235,37 @@ def test_canonical_backtest_population_is_filtered_before_run_ranking(
         top_n=1,
         case_dir=case_dir,
         coverage_window="canonical",
-        prediction_hashes={"full_b"},
+        prediction_hashes={"partial"},
     )
 
-    assert selected["prediction_hash"].to_list() == ["full_b"]
+    assert selected["prediction_hash"].to_list() == ["partial"]
+
+
+def test_canonical_prediction_population_sets_the_coverage_bar(tmp_path, monkeypatch) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    monkeypatch.setattr(
+        "case_studies.utils.registry.queries.canonical_coverage_days",
+        lambda case_study, label, split, prediction_hash, case_dir: {
+            "partial": 2,
+            "full_a": 4,
+            "full_b": 4,
+            "tabular": 2,
+        }[prediction_hash],
+    )
+
+    selected = resolve_best_predictions(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=1,
+        case_dir=case_dir,
+        coverage_window="canonical",
+        prediction_hashes={"partial"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["partial"]
 
 
 def test_cohort_members_and_leader_exclude_partial_coverage(tmp_path) -> None:

--- a/tests/test_full_coverage_selection.py
+++ b/tests/test_full_coverage_selection.py
@@ -152,6 +152,90 @@ def test_downstream_resolution_excludes_partial_coverage(tmp_path) -> None:
     assert backtests["prediction_hash"].to_list() == ["tabular", "full_a", "full_b"]
 
 
+def test_prediction_population_is_filtered_before_checkpoint_ranking(tmp_path) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        for prediction_hash, sharpe, n_days in [
+            ("retired", 5.0, 5),
+            ("current", 0.75, 4),
+        ]:
+            training_hash = f"train_{prediction_hash}"
+            db.execute(
+                "INSERT INTO training_runs VALUES (?, 'gbm', 'shared', 'fwd_ret_5d')",
+                (training_hash,),
+            )
+            db.execute(
+                "INSERT INTO prediction_sets VALUES (?, ?, 'validation', 0)",
+                (prediction_hash, training_hash),
+            )
+            db.execute(
+                "INSERT INTO prediction_metrics VALUES (?, 0.1, 0.1, 0.0, 0.2, ?)",
+                (prediction_hash, n_days),
+            )
+            db.execute(
+                "INSERT INTO backtest_runs VALUES (?, ?, '{}', 'signal')",
+                (f"bt_{prediction_hash}", prediction_hash),
+            )
+            db.execute(
+                "INSERT INTO backtest_metrics VALUES (?, ?, 0.1, -0.1, 0.2, 0.1, 1)",
+                (f"bt_{prediction_hash}", sharpe),
+            )
+
+    selected = resolve_best_predictions(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=10,
+        case_dir=case_dir,
+        prediction_hashes={"current"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["current"]
+
+
+def test_backtest_population_is_filtered_before_run_ranking(tmp_path) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+
+    selected = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=1,
+        case_dir=case_dir,
+        prediction_hashes={"full_b"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["full_b"]
+
+
+def test_canonical_backtest_population_is_filtered_before_run_ranking(
+    tmp_path, monkeypatch
+) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    monkeypatch.setattr(
+        "case_studies.utils.registry.queries.canonical_coverage_days",
+        lambda case_study, label, split, prediction_hash, case_dir: 4,
+    )
+
+    selected = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=1,
+        case_dir=case_dir,
+        coverage_window="canonical",
+        prediction_hashes={"full_b"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["full_b"]
+
+
 def test_cohort_members_and_leader_exclude_partial_coverage(tmp_path) -> None:
     case_dir = tmp_path / "case"
     _build_registry(case_dir)

--- a/tests/test_full_coverage_selection.py
+++ b/tests/test_full_coverage_selection.py
@@ -123,6 +123,17 @@ def test_backtest_readers_exclude_partial_coverage(tmp_path) -> None:
     assert explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["full_a"])[
         "prediction_hash"
     ].to_list() == ["full_a"]
+    assert explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["partial"])[
+        "prediction_hash"
+    ].to_list() == ["partial"]
+    assert (
+        explorer.compare_allocators(
+            stages=("signal",),
+            label="fwd_ret_5d",
+            prediction_hashes=["partial"],
+        )["n"].item()
+        == 1
+    )
 
 
 def test_downstream_resolution_excludes_partial_coverage(tmp_path) -> None:
@@ -212,9 +223,53 @@ def test_backtest_population_is_filtered_before_run_ranking(tmp_path) -> None:
     assert selected["prediction_hash"].to_list() == ["full_b"]
 
 
+def test_backtest_population_sets_the_raw_coverage_bar(tmp_path) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+
+    selected = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=1,
+        case_dir=case_dir,
+        prediction_hashes={"partial"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["partial"]
+
+
 def test_canonical_backtest_population_is_filtered_before_run_ranking(
     tmp_path, monkeypatch
 ) -> None:
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    monkeypatch.setattr(
+        "case_studies.utils.registry.queries.canonical_coverage_days",
+        lambda case_study, label, split, prediction_hash, case_dir: {
+            "partial": 2,
+            "full_a": 4,
+            "full_b": 4,
+            "tabular": 2,
+        }[prediction_hash],
+    )
+
+    selected = resolve_best_backtest_runs(
+        "test",
+        "fwd_ret_5d",
+        split="validation",
+        stage="signal",
+        top_n=1,
+        case_dir=case_dir,
+        coverage_window="canonical",
+        prediction_hashes={"full_b"},
+    )
+
+    assert selected["prediction_hash"].to_list() == ["full_b"]
+
+
+def test_canonical_backtest_population_sets_the_coverage_bar(tmp_path, monkeypatch) -> None:
     case_dir = tmp_path / "case"
     _build_registry(case_dir)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- apply locked prediction populations before coverage bars, configuration ranking, checkpoint ranking, and result limits
- share the full-coverage SQL predicate across registry and explorer readers
- keep canonical and raw coverage behavior aligned with behavioral regressions

## Verification
- `uv run pytest -q tests/test_full_coverage_selection.py tests/test_canonical_coverage_bar.py` (17 passed)
- `uv run ruff check case_studies/utils/notebook_contracts.py case_studies/utils/registry/queries.py case_studies/utils/backtest_explorer.py tests/test_full_coverage_selection.py tests/test_canonical_coverage_bar.py`