### PR TITLE
Scope latent-factor identities to material inputs

### DIFF
--- a/case_studies/utils/latent_factors/case_study.py
+++ b/case_studies/utils/latent_factors/case_study.py
@@ -341,7 +341,6 @@ def training_input_identity(
     eval_label: str | None = None,
 ) -> dict[str, Any]:
     """Return portable content identity for every materialized modeling input."""
-    case_dir = get_case_study_dir(case_study_id)
     inputs = {
         "financial": resolve_storage_path(
             case_study_id,

--- a/case_studies/utils/latent_factors/case_study.py
+++ b/case_studies/utils/latent_factors/case_study.py
@@ -353,7 +353,6 @@ def training_input_identity(
             load_label_spec(case_study_id, label),
             f"labels/{label}.parquet",
         ),
-        "setup": case_dir / "config" / "setup.yaml",
     }
     temporal_path = resolve_storage_path(
         case_study_id,
@@ -380,7 +379,7 @@ def training_input_identity(
     aggregate = sha256(
         "\n".join(f"{item['role']}={item['sha256']}" for item in files).encode()
     ).hexdigest()
-    return {"version": "v1", "files": files, "input_digest": f"sha256:{aggregate}"}
+    return {"version": "v2", "files": files, "input_digest": f"sha256:{aggregate}"}
 
 
 def _sha256_file(path: Path) -> str:

--- a/tests/test_latent_input_identity.py
+++ b/tests/test_latent_input_identity.py
@@ -43,6 +43,37 @@ def test_feature_content_enters_latent_training_hash(tmp_path: Path, monkeypatch
     assert training_hash_from_spec(first_spec) != training_hash_from_spec(second_spec)
 
 
+def test_setup_content_does_not_duplicate_resolved_latent_training_spec(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case_dir = tmp_path / "etfs"
+    (case_dir / "features").mkdir(parents=True)
+    (case_dir / "labels").mkdir()
+    (case_dir / "config").mkdir()
+    (case_dir / "features" / "financial.parquet").write_bytes(b"financial")
+    (case_dir / "labels" / "fwd_ret_21d.parquet").write_bytes(b"labels")
+    setup_path = case_dir / "config" / "setup.yaml"
+    setup_path.write_text("causal:\n  treatment: first\n")
+
+    monkeypatch.setattr(case_study, "get_case_study_dir", lambda _case_study_id: case_dir)
+    monkeypatch.setattr(case_study, "load_feature_spec", lambda *_args: None)
+    monkeypatch.setattr(case_study, "load_label_spec", lambda *_args: None)
+    monkeypatch.setattr(
+        case_study,
+        "resolve_storage_path",
+        lambda _case_study_id, _spec, fallback: case_dir / fallback,
+    )
+
+    first = case_study.training_input_identity("etfs", "fwd_ret_21d")
+    setup_path.write_text("causal:\n  treatment: unrelated-change\n")
+    second = case_study.training_input_identity("etfs", "fwd_ret_21d")
+
+    assert first == second
+    assert first["version"] == "v2"
+    assert {item["role"] for item in first["files"]} == {"financial", "label"}
+
+
 def test_continuous_evaluation_label_enters_classification_identity(
     tmp_path: Path,
     monkeypatch,
@@ -82,7 +113,6 @@ def test_continuous_evaluation_label_enters_classification_identity(
         "evaluation_label",
         "financial",
         "label",
-        "setup",
     }
     assert first["input_digest"] != second["input_digest"]
 


### PR DESCRIPTION
## Summary

- remove the whole `setup.yaml` file from latent-factor material-input hashes
- version the narrower input identity as `v2`
- retain setup-derived model, solver, fold, runtime, and macro settings in the resolved training specification
- add a regression proving unrelated setup edits do not invalidate latent artifacts

## Verification

- `uv run pytest tests/test_latent_input_identity.py tests/test_latent_factors_no_leak.py tests/test_ipca_production_config.py tests/test_sdf_checkpoint_numbering.py tests/test_sdf_macro_context.py -q` (73 passed)
- `uv run ruff check case_studies/utils/latent_factors/case_study.py tests/test_latent_input_identity.py`
- pre-commit hooks
- RoboRev pre-push review: no blocking findings