### PR TITLE
Make notebook completion stable across non-semantic drift

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -17,7 +17,7 @@
 
 # ---------------------------------------------------------------------------
 # Needs the modelling environment - run by test-unit-image, in ml4t/ml4t:latest.
-# 30 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
+# 32 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
 #
 # `case_studies/utils/gbm.py` imports torch at module scope, so the LightGBM
 # files are behind this boundary too even though LightGBM itself is a small
@@ -58,6 +58,7 @@ tests/test_latent_input_identity.py
 tests/test_holdout_evaluation_driver.py
 tests/test_locked_holdout_execution.py
 tests/test_model_analysis_selection.py
+tests/test_model_source_identity_versions.py
 tests/test_registry_metrics.py
 tests/test_research_contract_execution.py
 tests/test_research_model_planning.py
@@ -72,6 +73,7 @@ tests/test_sequence_identity_roundtrip.py
 tests/test_tabular_dl.py
 tests/test_tabular_dl_adapter.py
 tests/test_tabular_dl_runtime.py
+tests/test_training_identity_migration.py
 
 # ---------------------------------------------------------------------------
 # Executes notebooks through Papermill, against the reader's image and the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -955,6 +955,7 @@ jobs:
             tests/test_holdout_evaluation_driver.py \
             tests/test_locked_holdout_execution.py \
             tests/test_model_analysis_selection.py \
+            tests/test_model_source_identity_versions.py \
             tests/test_registry_metrics.py \
             tests/test_research_contract_execution.py \
             tests/test_research_model_planning.py \
@@ -967,6 +968,7 @@ jobs:
             tests/test_tabular_dl.py \
             tests/test_tabular_dl_adapter.py \
             tests/test_tabular_dl_runtime.py \
+            tests/test_training_identity_migration.py \
             -q --tb=short --timeout=900 --timeout-method=thread -rf
 
   # ---------------------------------------------------------------------------

--- a/case_studies/RUN_LOG.md
+++ b/case_studies/RUN_LOG.md
@@ -291,43 +291,34 @@ identities and register as new rows. The old rows stay exactly where they were,
 still complete and still queryable, so an experiment accumulates alongside the
 published results rather than overwriting them.
 
-**What an edit to a runner costs depends on which runner.** Two schemes are in
-use, and they differ in what a change to the fitting code does to the results
-already registered.
-
-*Linear and GBM declare a version.* `LINEAR_RUNNER_VERSION`,
+**Every model family declares the implementation versions that enter its
+identity.** `LINEAR_RUNNER_VERSION`,
 `GBM_RUNNER_VERSION`, `FOLD_PREPARATION_VERSION` for the shared fold preparation,
 and `PREPROCESSING_ID` / `GBM_PREPROCESSING_ID` for the cast applied to a fold are
 what enter the identity. A comment, a log line or a refactoring that moves code
 without changing what it computes therefore leaves every registered result valid,
-and only bumping the version refits the family. The bump is the decision about
+and only incrementing a relevant version refits the family. The increment is the decision about
 compute, and it is required whenever the change would move the numbers, because a
 cache that survived such a change would be lying. What holds the declaration
 honest is `tests/test_linear_identity.py`, `tests/test_gbm_identity.py` and
 `tests/test_folds.py`: each pins the quantities its version claims to describe and
 fails when they move without a bump.
 
-*Tabular deep learning, sequence models, latent factors and causal inference
-digest their source.* The SHA-256 of each of a set of files is in the identity, so
-editing any file in that set - including a change that alters nothing a model
-computes - refits the configurations it covers on the next run. Only causal
-digests a single file; the others digest several, and latent factors digests
-fourteen, including `utils/modeling.py`. Read the set from the function that
-builds it rather than from a list here, which would drift:
+Tabular deep learning, sequence models, latent factors and causal inference use
+the following scoped declarations:
 
-| Family | Its digest set |
+| Family | Implementation identity |
 |---|---|
-| Tabular DL | `_tabm_source_identity` in `case_studies/utils/tabular_dl.py` |
-| Sequence models | `_sequence_source_identity` in `case_studies/utils/deep_learning.py` |
-| Latent factors | `_source_identity` in `case_studies/utils/latent_factors/adapter.py` |
-| Causal | `_causal_source_identity` in `case_studies/utils/causal.py` |
+| Tabular DL | runner and persisted-state versions in `case_studies/utils/tabular_dl.py` |
+| Sequence models | runner, preparation, state, backend and architecture versions in `case_studies/utils/deep_learning.py` |
+| Latent factors | shared adapter and per-model versions in `case_studies/utils/latent_factors/adapter.py` |
+| Causal | runner version in `case_studies/utils/causal.py` |
 
-Sequence models are the one case where the blast radius is narrower than the
-family: the set includes the selected architecture's own module, so editing that
-refits only the configurations that select it. Everywhere else, an edit inside the
-set refits the whole family, and is a decision about compute as well as about
-code. The declared-version scheme replaced this for linear and GBM first because
-those two are re-run most often; the remaining four have not been converted.
+Increment only the declaration whose computation changed. For example, a TCN-only
+change increments the TCN architecture version without invalidating LSTM results.
+`tests/test_model_source_identity_versions.py` pins the declared scopes and proves
+that changing a declaration changes the training identity; the model adapter tests
+cover their result-affecting behavior.
 
 The two identities downstream of a training run are built from it rather than
 from scratch; the next section gives their exact composition.

--- a/case_studies/etfs/12_causal_dml.ipynb
+++ b/case_studies/etfs/12_causal_dml.ipynb
@@ -119,10 +119,10 @@
     "CV_FOLDS = 5\n",
     "MAX_SAMPLES = 0\n",
     "N_PLACEBO = 100\n",
-    "# Any edit to case_studies/utils/causal.py moves this notebook's causal identity, because\n",
-    "# _causal_source_identity hashes that file whole. The registering write then refuses a second\n",
-    "# current identity for the same label and names the hash it wants retired. Declare it here -\n",
-    "# a bare hash, or a JSON object keyed by label - and the refusal has a route to be answered.\n",
+    "# Incrementing the causal runner's semantic version moves this notebook's causal identity.\n",
+    "# The registering write then refuses a second current identity for the same label and names\n",
+    "# the hash it wants retired. Declare it here - a bare hash, or a JSON object keyed by label -\n",
+    "# and the refusal has a route to be answered.\n",
     "# Empty is correct against a fresh registry, where there is nothing to supersede.\n",
     "SUPERSEDES_CAUSAL: str = \"\""
    ]

--- a/case_studies/etfs/12_causal_dml.py
+++ b/case_studies/etfs/12_causal_dml.py
@@ -89,10 +89,10 @@ RANDOM_SEED = 42
 CV_FOLDS = 5
 MAX_SAMPLES = 0
 N_PLACEBO = 100
-# Any edit to case_studies/utils/causal.py moves this notebook's causal identity, because
-# _causal_source_identity hashes that file whole. The registering write then refuses a second
-# current identity for the same label and names the hash it wants retired. Declare it here -
-# a bare hash, or a JSON object keyed by label - and the refusal has a route to be answered.
+# Incrementing the causal runner's semantic version moves this notebook's causal identity.
+# The registering write then refuses a second current identity for the same label and names
+# the hash it wants retired. Declare it here - a bare hash, or a JSON object keyed by label -
+# and the refusal has a route to be answered.
 # Empty is correct against a fresh registry, where there is nothing to supersede.
 SUPERSEDES_CAUSAL: str = ""
 

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -29,6 +29,7 @@ os.environ.setdefault("OMP_NUM_THREADS", "1")
 # Fixed rather than derived from the host: a value like -1 varies with the machine, so a
 # result would not be identity-stable across the readers' hardware.
 DML_THREAD_LIMIT = 1
+CAUSAL_RUNNER_VERSION = 1
 
 import hashlib
 import importlib.metadata
@@ -1074,9 +1075,9 @@ def format_dml_summary(results: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _causal_source_identity() -> dict[str, str]:
-    path = Path(__file__)
-    return {path.name: hashlib.sha256(path.read_bytes()).hexdigest()}
+def _causal_source_identity() -> dict[str, int]:
+    """Return the declared version of the result-affecting causal implementation."""
+    return {"causal_runner": CAUSAL_RUNNER_VERSION}
 
 
 def _causal_runtime_identity() -> dict[str, str]:

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -76,6 +76,19 @@ if TYPE_CHECKING:
 
 _SEQUENCE_PREVIEW_FIELDS = {"folds", "max_symbols", "max_train_sequences"}
 
+SEQUENCE_RUNNER_VERSION = 1
+SEQUENCE_PREPARATION_VERSION = 1
+SEQUENCE_STATE_VERSION = 1
+SEQUENCE_BACKEND_VERSIONS = {"darts": 1, "pytorch": 1}
+SEQUENCE_ARCHITECTURE_VERSIONS = {
+    "lstm": 1,
+    "nbeats": 1,
+    "nlinear": 1,
+    "patchtst": 1,
+    "tcn": 1,
+    "tsmixer": 1,
+}
+
 
 @dataclass(frozen=True)
 class SequenceResearchContext:
@@ -106,27 +119,22 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _module_path(module: Any) -> Path:
-    source_file = getattr(module, "__file__", None)
-    if not isinstance(source_file, str):
-        raise RuntimeError(f"{module.__name__} has no source file")
-    return Path(source_file)
-
-
-def _sequence_source_identity(config: dict[str, Any]) -> dict[str, str]:
-    from case_studies.utils import deep_model_state, sequence_dataset
-
-    paths = [Path(__file__), _module_path(deep_model_state), _module_path(sequence_dataset)]
-    if config.get("library") == "darts":
-        from case_studies.utils import darts_forecasting
-
-        paths.append(_module_path(darts_forecasting))
-    else:
-        architecture = str(config["params"]["architecture"])
-        model_class = _get_model_registry()[architecture]
-        module = __import__(model_class.__module__, fromlist=[model_class.__name__])
-        paths.append(_module_path(module))
-    return {path.name: _sha256(path) for path in paths}
+def _sequence_source_identity(config: dict[str, Any]) -> dict[str, int | str]:
+    """Return the declared implementation versions that can change sequence results."""
+    architecture = str(config["params"]["architecture"])
+    library = "darts" if config.get("library") == "darts" else "pytorch"
+    try:
+        architecture_version = SEQUENCE_ARCHITECTURE_VERSIONS[architecture]
+        backend_version = SEQUENCE_BACKEND_VERSIONS[library]
+    except KeyError as exc:
+        raise ValueError(f"no implementation version declared for {exc.args[0]!r}") from exc
+    return {
+        "sequence_runner": SEQUENCE_RUNNER_VERSION,
+        "sequence_preparation": SEQUENCE_PREPARATION_VERSION,
+        "sequence_state": SEQUENCE_STATE_VERSION,
+        "backend": f"{library}/v{backend_version}",
+        "architecture": f"{architecture}/v{architecture_version}",
+    }
 
 
 def _sequence_runtime_identity(config: dict[str, Any]) -> dict[str, str]:

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
 
 _LATENT_MODELS = {"cae", "ipca", "pca", "sae", "sdf"}
+LATENT_ADAPTER_VERSION = 1
+LATENT_MODEL_VERSIONS = {model: 1 for model in _LATENT_MODELS}
 _PREVIEW_FIELDS = {
     "folds",
     "max_iter",
@@ -99,26 +101,16 @@ def _package_version(name: str) -> str | None:
         return None
 
 
-def _source_identity() -> dict[str, str]:
-    root = Path(__file__).parent
-    release_root = root.parents[2]
-    files = [
-        root / "adapter.py",
-        root / "cae.py",
-        root / "case_study.py",
-        root / "common.py",
-        root / "cv.py",
-        root / "ipca.py",
-        root / "library_bridge.py",
-        root / "macro_context.py",
-        root / "panel.py",
-        root / "pca.py",
-        root / "sae.py",
-        root / "sdf.py",
-        release_root / "utils" / "artifact_specs.py",
-        release_root / "utils" / "modeling.py",
-    ]
-    return {path.relative_to(release_root).as_posix(): _sha256(path) for path in files}
+def _source_identity(model_name: str) -> dict[str, int | str]:
+    """Return the shared adapter version and the requested factor model version."""
+    try:
+        version = LATENT_MODEL_VERSIONS[model_name]
+    except KeyError as exc:
+        raise ValueError(f"no latent implementation version declared for {model_name!r}") from exc
+    return {
+        "latent_adapter": LATENT_ADAPTER_VERSION,
+        "latent_model": f"{model_name}/v{version}",
+    }
 
 
 def _runtime_identity() -> dict[str, str | None]:
@@ -500,7 +492,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             "num_threads": num_threads,
         },
         "sampling": {"max_symbols": max_symbols},
-        "source_identity": _source_identity(),
+        "source_identity": _source_identity(model_name),
         "runtime_identity": _runtime_identity(),
     }
     if tier is ExecutionTier.PREVIEW:
@@ -573,7 +565,7 @@ def reconstruct_locked_request(
         "feature_artifacts": case.input_data_spec["files"],
         "feature_names": list(case.feature_names),
         "input_data_spec": case.input_data_spec,
-        "source_identity": _source_identity(),
+        "source_identity": _source_identity(model_name),
         "runtime_identity": _runtime_identity(),
         "task": {
             "type": case.task_type,

--- a/case_studies/utils/registry/__init__.py
+++ b/case_studies/utils/registry/__init__.py
@@ -62,8 +62,10 @@ from .lineage import modeling_input_fingerprint
 # --- maintenance ---
 from .maintenance import (
     DuplicateBacktest,
+    TrainingIdentityMigration,
     deduplicate_semantic_backtests,
     find_semantic_backtest_duplicates,
+    migrate_equivalent_training_identity,
 )
 
 # --- metrics ---
@@ -190,8 +192,10 @@ __all__ = [
     "compute_cross_sectional_direction_auc",
     # maintenance
     "DuplicateBacktest",
+    "TrainingIdentityMigration",
     "find_semantic_backtest_duplicates",
     "deduplicate_semantic_backtests",
+    "migrate_equivalent_training_identity",
     # queries
     "load_training_runs",
     "load_prediction_sets",

--- a/case_studies/utils/registry/maintenance.py
+++ b/case_studies/utils/registry/maintenance.py
@@ -128,6 +128,88 @@ def _insert_record(db: sqlite3.Connection, table: str, record: dict[str, Any]) -
     )
 
 
+def _reconcile_table_schema(
+    source_db: sqlite3.Connection,
+    target_db: sqlite3.Connection,
+    table: str,
+) -> None:
+    source_columns = source_db.execute(f'PRAGMA table_info("{table}")').fetchall()
+    target_names = {row[1] for row in target_db.execute(f'PRAGMA table_info("{table}")').fetchall()}
+    for column in source_columns:
+        name = str(column[1])
+        if name in target_names:
+            continue
+        declared_type = str(column[2] or "TEXT")
+        target_db.execute(f'ALTER TABLE "{table}" ADD COLUMN "{name}" {declared_type}')
+
+
+def _validate_manifest_files(model_root: Path, manifest: Path) -> None:
+    try:
+        files = json.loads(manifest.read_text()).get("files")
+    except (OSError, json.JSONDecodeError, AttributeError) as exc:
+        raise ValueError(f"invalid fitted-state manifest: {manifest}") from exc
+    if not isinstance(files, dict) or not files:
+        raise ValueError(f"empty fitted-state manifest: {manifest}")
+    for relative, expected_digest in files.items():
+        artifact = model_root / relative
+        if (
+            not artifact.is_file()
+            or hashlib.sha256(artifact.read_bytes()).hexdigest() != expected_digest
+        ):
+            raise ValueError(f"fitted-state manifest mismatch: {artifact}")
+
+
+def _validate_fitted_state(source: Any, spec: dict[str, Any]) -> None:
+    computation = spec.get("computation", spec)
+    model = computation.get("model")
+    cv = computation.get("cv")
+    schedule = computation.get("checkpoint_schedule")
+    if not isinstance(model, dict) or not isinstance(cv, dict) or not isinstance(schedule, list):
+        raise ValueError("source training spec does not declare its fitted-state population")
+    folds = cv.get("folds")
+    if not isinstance(folds, list) or not folds:
+        raise ValueError("source training spec does not declare any folds")
+    fold_ids = tuple(int(fold["fold"]) for fold in folds)
+    checkpoints = tuple(int(item["value"]) for item in schedule)
+    config_name = spec.get("config_name")
+    if not isinstance(config_name, str) or not config_name:
+        raise ValueError("source training spec has no fitted-state config name")
+    model_root = source.root / "run_log" / "training" / source.hash / "models"
+    family = str(spec["family"])
+    if family == "deep_learning":
+        architecture = str(model.get("class"))
+        if model.get("implementation") == "darts":
+            from case_studies.utils.darts_forecasting import validate_darts_checkpoint_population
+
+            validate_darts_checkpoint_population(
+                model_root,
+                config_name=config_name,
+                fold_ids=fold_ids,
+                checkpoints=checkpoints,
+                architecture=architecture,
+            )
+        else:
+            from case_studies.utils.deep_model_state import validate_deep_checkpoint_population
+
+            validate_deep_checkpoint_population(
+                model_root,
+                config_name=config_name,
+                fold_ids=fold_ids,
+                checkpoints=checkpoints,
+                architecture=architecture,
+            )
+        return
+    if family == "tabular_dl":
+        manifests = tuple(
+            model_root / config_name / f"fold_{fold_id:02d}" / "manifest.json"
+            for fold_id in fold_ids
+        )
+    else:
+        manifests = (model_root / "manifest.json",)
+    for manifest in manifests:
+        _validate_manifest_files(model_root, manifest)
+
+
 def _clone_prediction_records(
     source_db: sqlite3.Connection,
     target_db: sqlite3.Connection,
@@ -231,6 +313,8 @@ def migrate_equivalent_training_identity(
     if not isinstance(source, TrainingResult) or not source.complete:
         raise ValueError(f"source {source_training_hash} is not a complete training result")
     source_spec = source.spec()
+    if source_spec.get("config_name") != target_spec.get("config_name"):
+        raise ValueError("training artifact config_name differs between source and target")
     source_identity = _normalized_training_identity(source_spec)
     target_identity = _normalized_training_identity(target_spec)
     for path in migrated_fields:
@@ -250,10 +334,9 @@ def migrate_equivalent_training_identity(
     if existing is not None:
         return existing
 
+    _validate_fitted_state(source, source_spec)
     source_training_dir = _training_dir(source.root, source_training_hash)
     source_manifest = _artifact_manifest(source_training_dir)
-    if not any(path.startswith("models/") for path in source_manifest):
-        raise ValueError(f"source {source_training_hash} has no persisted fitted state")
     with closing(sqlite3.connect(source.root / "run_log" / "registry.db")) as source_db:
         source_db.row_factory = sqlite3.Row
         training_record = _row(source_db, "training_runs", "training_hash", source_training_hash)
@@ -339,6 +422,14 @@ def migrate_equivalent_training_identity(
 
             with closing(_open_registry(target_root)) as target_db:
                 target_db.execute("BEGIN IMMEDIATE")
+                for table in (
+                    "training_runs",
+                    "prediction_sets",
+                    "prediction_coverage",
+                    "prediction_metrics",
+                    "fold_metrics",
+                ):
+                    _reconcile_table_schema(source_db, target_db, table)
                 if (
                     _row(target_db, "training_runs", "training_hash", target_training_hash)
                     is not None

--- a/case_studies/utils/registry/maintenance.py
+++ b/case_studies/utils/registry/maintenance.py
@@ -170,13 +170,16 @@ def _validate_fitted_state(source: Any, spec: dict[str, Any]) -> None:
     if not isinstance(folds, list) or not folds:
         raise ValueError("source training spec does not declare any folds")
     fold_ids = tuple(int(fold["fold"]) for fold in folds)
-    checkpoints = tuple(int(item["value"]) for item in schedule)
     config_name = spec.get("config_name")
     if not isinstance(config_name, str) or not config_name:
         raise ValueError("source training spec has no fitted-state config name")
     model_root = source.root / "run_log" / "training" / source.hash / "models"
     family = str(spec["family"])
     if family == "deep_learning":
+        try:
+            checkpoints = tuple(int(item["value"]) for item in schedule)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("deep-learning fitted state requires numeric checkpoints") from exc
         architecture = str(model.get("class"))
         if model.get("implementation") == "darts":
             from case_studies.utils.darts_forecasting import validate_darts_checkpoint_population

--- a/case_studies/utils/registry/maintenance.py
+++ b/case_studies/utils/registry/maintenance.py
@@ -3,19 +3,405 @@
 from __future__ import annotations
 
 import argparse
+import copy
+import hashlib
 import json
+import os
+import shutil
 import sqlite3
+import uuid
 from contextlib import closing
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-from .specs import backtest_hash_from_parts
+from .specs import (
+    IDENTITY_VERSION,
+    SUPPORTED_IDENTITY_VERSIONS,
+    backtest_hash_from_parts,
+    canonical_json,
+    prediction_hash_from_parts,
+    project_training_identity,
+    training_hash_from_spec,
+)
+from .store import _git_hash, _open_registry, _prediction_dir, _save_json, _training_dir, _utc_now
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
 
 
 @dataclass(frozen=True)
 class DuplicateBacktest:
     keep_hash: str
     drop_hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TrainingIdentityMigration:
+    source_training_hash: str
+    target_training_hash: str
+    prediction_map: dict[str, str]
+    migrated_fields: tuple[str, ...]
+    created: bool
+
+    def with_created(self, created: bool) -> TrainingIdentityMigration:
+        return replace(self, created=created)
+
+
+_MIGRATABLE_FIELDS = frozenset({"computation.source_identity"})
+
+
+def _normalized_training_identity(spec: dict[str, Any]) -> dict[str, Any]:
+    projection = project_training_identity(spec)
+    common = {
+        "family": projection["family"],
+        "label": projection["label"],
+        "seed": projection["seed"],
+        "execution_tier": projection["execution_tier"],
+    }
+    if spec["identity_version"] == IDENTITY_VERSION:
+        computation = projection["computation"]
+    else:
+        computation = {
+            key: value
+            for key, value in projection.items()
+            if key not in {*common, "identity_version", "resolved_spec_schema"}
+        }
+    return {**common, "computation": copy.deepcopy(computation)}
+
+
+def _remove_path(record: dict[str, Any], path: str) -> None:
+    parts = path.split(".")
+    parent: Any = record
+    for part in parts[:-1]:
+        if not isinstance(parent, dict) or part not in parent:
+            return
+        parent = parent[part]
+    if isinstance(parent, dict):
+        parent.pop(parts[-1], None)
+
+
+def _first_difference(left: Any, right: Any, prefix: str = "") -> str:
+    if isinstance(left, dict) and isinstance(right, dict):
+        for key in sorted(set(left) | set(right)):
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in left or key not in right:
+                return path
+            difference = _first_difference(left[key], right[key], path)
+            if difference:
+                return difference
+        return ""
+    if isinstance(left, list) and isinstance(right, list):
+        if len(left) != len(right):
+            return f"{prefix}.length"
+        for index, (left_item, right_item) in enumerate(zip(left, right, strict=True)):
+            difference = _first_difference(left_item, right_item, f"{prefix}[{index}]")
+            if difference:
+                return difference
+        return ""
+    return "" if left == right else prefix
+
+
+def _artifact_manifest(directory: Path) -> dict[str, str]:
+    return {
+        path.relative_to(directory).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(directory.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _row(db: sqlite3.Connection, table: str, key: str, value: str) -> dict[str, Any] | None:
+    cursor = db.execute(f'SELECT * FROM "{table}" WHERE "{key}" = ?', (value,))
+    values = cursor.fetchone()
+    if values is None:
+        return None
+    return dict(zip((column[0] for column in cursor.description), values, strict=True))
+
+
+def _insert_record(db: sqlite3.Connection, table: str, record: dict[str, Any]) -> None:
+    columns = tuple(record)
+    placeholders = ",".join("?" for _ in columns)
+    column_sql = ",".join(f'"{column}"' for column in columns)
+    db.execute(
+        f'INSERT INTO "{table}" ({column_sql}) VALUES ({placeholders})',
+        tuple(record[column] for column in columns),
+    )
+
+
+def _clone_prediction_records(
+    source_db: sqlite3.Connection,
+    target_db: sqlite3.Connection,
+    source_hash: str,
+    target_hash: str,
+    target_training_hash: str,
+) -> None:
+    prediction = _row(source_db, "prediction_sets", "prediction_hash", source_hash)
+    assert prediction is not None
+    prediction.update(
+        prediction_hash=target_hash,
+        training_hash=target_training_hash,
+        created_at=_utc_now(),
+    )
+    _insert_record(target_db, "prediction_sets", prediction)
+    for table in ("prediction_coverage", "prediction_metrics"):
+        record = _row(source_db, table, "prediction_hash", source_hash)
+        if record is not None:
+            record["prediction_hash"] = target_hash
+            _insert_record(target_db, table, record)
+    cursor = source_db.execute(
+        "SELECT * FROM fold_metrics WHERE prediction_hash = ?", (source_hash,)
+    )
+    columns = tuple(column[0] for column in cursor.description)
+    for values in cursor.fetchall():
+        record = dict(zip(columns, values, strict=True))
+        record["prediction_hash"] = target_hash
+        _insert_record(target_db, "fold_metrics", record)
+
+
+def _existing_migration(
+    study: Study,
+    source_training_hash: str,
+    target_training_hash: str,
+    target_spec: dict[str, Any],
+    migrated_fields: tuple[str, ...],
+) -> TrainingIdentityMigration | None:
+    target_root = study.storage_root(target_spec["execution_tier"])
+    with closing(_open_registry(target_root)) as db:
+        record = _row(
+            db,
+            "training_identity_migrations",
+            "target_training_hash",
+            target_training_hash,
+        )
+        target_exists = _row(db, "training_runs", "training_hash", target_training_hash)
+    if record is None:
+        if target_exists is not None:
+            raise ValueError(
+                f"target training identity {target_training_hash} already exists without an "
+                "equivalence record"
+            )
+        return None
+    if (
+        record["source_training_hash"] != source_training_hash
+        or json.loads(record["target_spec_json"]) != target_spec
+    ):
+        raise ValueError(f"target training identity {target_training_hash} has another migration")
+    proof = json.loads(record["proof_json"])
+    if proof.get("migrated_fields") != list(migrated_fields):
+        raise ValueError(f"target training identity {target_training_hash} has another proof scope")
+    prediction_map = json.loads(record["prediction_map_json"])
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+
+    training = Result.open(study, target_training_hash, include_preview=True)
+    if not isinstance(training, TrainingResult) or not training.complete:
+        raise ValueError(f"recorded target training identity {target_training_hash} is incomplete")
+    for prediction_hash in prediction_map.values():
+        prediction = Result.open(study, prediction_hash, include_preview=True)
+        if not isinstance(prediction, PredictionResult) or not prediction.complete:
+            raise ValueError(f"recorded target prediction {prediction_hash} is incomplete")
+    return TrainingIdentityMigration(
+        source_training_hash,
+        target_training_hash,
+        prediction_map,
+        migrated_fields,
+        False,
+    )
+
+
+def migrate_equivalent_training_identity(
+    study: Study,
+    source_training_hash: str,
+    target_spec: dict[str, Any],
+    *,
+    migrated_fields: tuple[str, ...] = ("computation.source_identity",),
+) -> TrainingIdentityMigration:
+    """Materialize a proven equivalent training identity without fitting again."""
+    from case_studies.research.results import PredictionResult, Result, TrainingResult
+
+    study.require_writable()
+    if target_spec.get("identity_version") not in SUPPORTED_IDENTITY_VERSIONS:
+        raise ValueError("target spec must use a supported identity version")
+    if not migrated_fields or not set(migrated_fields) <= _MIGRATABLE_FIELDS:
+        raise ValueError(f"unsupported migrated fields: {sorted(set(migrated_fields))}")
+    target_training_hash = training_hash_from_spec(target_spec)
+    if target_training_hash == source_training_hash:
+        raise ValueError("source and target already have the same training identity")
+
+    source = Result.open(study, source_training_hash, include_preview=True)
+    if not isinstance(source, TrainingResult) or not source.complete:
+        raise ValueError(f"source {source_training_hash} is not a complete training result")
+    source_spec = source.spec()
+    source_identity = _normalized_training_identity(source_spec)
+    target_identity = _normalized_training_identity(target_spec)
+    for path in migrated_fields:
+        _remove_path(source_identity, path)
+        _remove_path(target_identity, path)
+    difference = _first_difference(source_identity, target_identity)
+    if difference:
+        raise ValueError(f"training computations differ at {difference}")
+
+    existing = _existing_migration(
+        study,
+        source_training_hash,
+        target_training_hash,
+        target_spec,
+        migrated_fields,
+    )
+    if existing is not None:
+        return existing
+
+    source_training_dir = _training_dir(source.root, source_training_hash)
+    source_manifest = _artifact_manifest(source_training_dir)
+    if not any(path.startswith("models/") for path in source_manifest):
+        raise ValueError(f"source {source_training_hash} has no persisted fitted state")
+    with closing(sqlite3.connect(source.root / "run_log" / "registry.db")) as source_db:
+        source_db.row_factory = sqlite3.Row
+        training_record = _row(source_db, "training_runs", "training_hash", source_training_hash)
+        assert training_record is not None
+        prediction_rows = source_db.execute(
+            "SELECT prediction_hash, checkpoint_value, checkpoint_kind, split "
+            "FROM prediction_sets WHERE training_hash = ? ORDER BY prediction_hash",
+            (source_training_hash,),
+        ).fetchall()
+        if not prediction_rows:
+            raise ValueError(f"source {source_training_hash} has no prediction results")
+        prediction_map: dict[str, str] = {}
+        prediction_manifests: dict[str, dict[str, str]] = {}
+        for prediction_row in prediction_rows:
+            source_prediction_hash = str(prediction_row[0])
+            prediction = Result.open(study, source_prediction_hash, include_preview=True)
+            if not isinstance(prediction, PredictionResult) or not prediction.complete:
+                raise ValueError(f"source prediction {source_prediction_hash} is incomplete")
+            target_prediction_hash = prediction_hash_from_parts(
+                target_training_hash,
+                prediction_row[1],
+                prediction_row[3],
+                checkpoint_kind=prediction_row[2],
+                identity_version=target_spec["identity_version"],
+            )
+            if target_prediction_hash in prediction_map.values():
+                raise ValueError("source predictions collapse to one target identity")
+            prediction_map[source_prediction_hash] = target_prediction_hash
+            prediction_manifests[source_prediction_hash] = _artifact_manifest(
+                _prediction_dir(prediction.root, source_prediction_hash)
+            )
+
+        target_root = study.storage_root(target_spec["execution_tier"])
+        target_training_dir = _training_dir(target_root, target_training_hash)
+        target_prediction_dirs = {
+            source_hash: _prediction_dir(target_root, target_hash)
+            for source_hash, target_hash in prediction_map.items()
+        }
+        collisions = [
+            path
+            for path in (target_training_dir, *target_prediction_dirs.values())
+            if path.exists()
+        ]
+        if collisions:
+            raise ValueError(f"target artifact paths already exist: {collisions}")
+        with closing(_open_registry(target_root)) as target_db:
+            if any(
+                _row(target_db, "prediction_sets", "prediction_hash", target_hash) is not None
+                for target_hash in prediction_map.values()
+            ):
+                raise ValueError("a target prediction identity already exists")
+
+        token = uuid.uuid4().hex
+        staged_training = target_training_dir.with_name(f".{target_training_hash}.{token}.tmp")
+        staged_predictions = {
+            source_hash: target_dir.with_name(f".{target_dir.name}.{token}.tmp")
+            for source_hash, target_dir in target_prediction_dirs.items()
+        }
+        finalized: list[Path] = []
+        try:
+            shutil.copytree(source_training_dir, staged_training)
+            _save_json(staged_training / "spec.json", target_spec)
+            for source_hash, staged in staged_predictions.items():
+                shutil.copytree(_prediction_dir(source.root, source_hash), staged)
+            staged_source_manifest = dict(source_manifest)
+            staged_source_manifest.pop("spec.json", None)
+            staged_target_manifest = _artifact_manifest(staged_training)
+            staged_target_manifest.pop("spec.json", None)
+            if staged_target_manifest != staged_source_manifest:
+                raise RuntimeError("staged training artifacts differ from the proven source")
+            for source_hash, staged in staged_predictions.items():
+                if _artifact_manifest(staged) != prediction_manifests[source_hash]:
+                    raise RuntimeError(
+                        f"staged prediction artifacts differ from source {source_hash}"
+                    )
+            target_training_dir.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staged_training, target_training_dir)
+            finalized.append(target_training_dir)
+            for source_hash, target_dir in target_prediction_dirs.items():
+                target_dir.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(staged_predictions[source_hash], target_dir)
+                finalized.append(target_dir)
+
+            with closing(_open_registry(target_root)) as target_db:
+                target_db.execute("BEGIN IMMEDIATE")
+                if (
+                    _row(target_db, "training_runs", "training_hash", target_training_hash)
+                    is not None
+                ):
+                    raise ValueError(f"target training identity {target_training_hash} appeared")
+                migrated_training = dict(training_record)
+                migrated_training.update(
+                    training_hash=target_training_hash,
+                    family=target_spec["family"],
+                    label=target_spec["label"],
+                    config_name=target_spec.get("config_name"),
+                    spec_json=canonical_json(target_spec),
+                    created_at=_utc_now(),
+                    git_commit=_git_hash(),
+                    entry_point=f"identity-migration:{source_training_hash}",
+                    identity_version=target_spec["identity_version"],
+                    execution_tier=target_spec["execution_tier"],
+                )
+                _insert_record(target_db, "training_runs", migrated_training)
+                for source_hash, target_hash in prediction_map.items():
+                    _clone_prediction_records(
+                        source_db,
+                        target_db,
+                        source_hash,
+                        target_hash,
+                        target_training_hash,
+                    )
+                proof = {
+                    "migrated_fields": list(migrated_fields),
+                    "source_artifacts": source_manifest,
+                    "source_identity": project_training_identity(source_spec),
+                    "source_predictions": prediction_manifests,
+                    "target_identity": project_training_identity(target_spec),
+                }
+                _insert_record(
+                    target_db,
+                    "training_identity_migrations",
+                    {
+                        "target_training_hash": target_training_hash,
+                        "source_training_hash": source_training_hash,
+                        "target_spec_json": canonical_json(target_spec),
+                        "prediction_map_json": canonical_json(prediction_map),
+                        "proof_json": canonical_json(proof),
+                        "created_at": _utc_now(),
+                    },
+                )
+                target_db.commit()
+        except Exception:
+            for path in reversed(finalized):
+                shutil.rmtree(path, ignore_errors=True)
+            raise
+        finally:
+            shutil.rmtree(staged_training, ignore_errors=True)
+            for staged in staged_predictions.values():
+                shutil.rmtree(staged, ignore_errors=True)
+
+    return TrainingIdentityMigration(
+        source_training_hash,
+        target_training_hash,
+        prediction_map,
+        migrated_fields,
+        True,
+    )
 
 
 def find_semantic_backtest_duplicates(db_path: Path) -> list[DuplicateBacktest]:

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -727,9 +727,8 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
     ):
         db.execute("ALTER TABLE causal_runs ADD COLUMN refutation_n_successful INTEGER")
 
-    # Additive, and it costs no recompute: _causal_source_identity hashes
-    # case_studies/utils/causal.py and nothing else, so a column outside the spec
-    # moves no causal_hash and invalidates no registered row.
+    # Additive, and it costs no recompute: the column is outside the causal computation
+    # specification, so it moves no causal hash and invalidates no registered row.
     if "causal_runs" in tables and not _table_has_column(db, "causal_runs", "supersedes_hash"):
         db.execute("ALTER TABLE causal_runs ADD COLUMN supersedes_hash TEXT")
 

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -48,6 +48,18 @@ CREATE TABLE IF NOT EXISTS training_runs (
 CREATE INDEX IF NOT EXISTS idx_training_family_label ON training_runs(family, label);
 CREATE INDEX IF NOT EXISTS idx_training_config_name ON training_runs(config_name);
 
+CREATE TABLE IF NOT EXISTS training_identity_migrations (
+    target_training_hash TEXT PRIMARY KEY REFERENCES training_runs(training_hash),
+    source_training_hash TEXT NOT NULL,
+    target_spec_json     TEXT NOT NULL,
+    prediction_map_json TEXT NOT NULL,
+    proof_json          TEXT NOT NULL,
+    created_at          TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_training_migration_source
+    ON training_identity_migrations(source_training_hash);
+
 CREATE TABLE IF NOT EXISTS prediction_sets (
     prediction_hash     TEXT PRIMARY KEY,
     training_hash       TEXT NOT NULL REFERENCES training_runs(training_hash),

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -58,6 +58,8 @@ from utils.modeling import RANDOM_SEED, seed_everything
 
 _TABM_PREVIEW_FIELDS = {"checkpoint_interval", "folds", "max_symbols", "n_epochs"}
 _TABM_IMBALANCE_METHODS = {"balanced", "none"}
+TABM_RUNNER_VERSION = 1
+TABM_STATE_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -91,16 +93,11 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _tabm_source_identity() -> dict[str, str]:
-    from case_studies.utils import deep_model_state
-
-    deep_model_state_file = deep_model_state.__file__
-    if deep_model_state_file is None:
-        raise RuntimeError("deep_model_state has no source file")
-    deep_model_state_path = Path(deep_model_state_file)
+def _tabm_source_identity() -> dict[str, int]:
+    """Return declared versions for fitting TabM and persisting its state."""
     return {
-        Path(__file__).name: _sha256(Path(__file__)),
-        deep_model_state_path.name: _sha256(deep_model_state_path),
+        "tabm_runner": TABM_RUNNER_VERSION,
+        "tabm_state": TABM_STATE_VERSION,
     }
 
 

--- a/scripts/migrate_training_identity.py
+++ b/scripts/migrate_training_identity.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Reuse a complete model run after a non-computational identity migration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from case_studies.research import Study
+from case_studies.utils.registry import migrate_equivalent_training_identity
+from utils.paths import REPO_ROOT
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case-study", required=True)
+    parser.add_argument("--source-training-hash", required=True)
+    parser.add_argument("--target-spec", required=True, type=Path)
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--release-root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args()
+
+    target_spec = json.loads(args.target_spec.read_text())
+    if args.workspace is None:
+        study = Study.regenerate(args.case_study, release_root=args.release_root)
+    else:
+        study = Study.open(
+            args.case_study,
+            workspace=args.workspace,
+            release_root=args.release_root,
+        )
+    migration = migrate_equivalent_training_identity(
+        study,
+        args.source_training_hash,
+        target_spec,
+    )
+    print(
+        json.dumps(
+            {
+                "created": migration.created,
+                "prediction_map": migration.prediction_map,
+                "source_training_hash": migration.source_training_hash,
+                "target_training_hash": migration.target_training_hash,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_causal_supersedes.py
+++ b/tests/test_causal_supersedes.py
@@ -240,17 +240,14 @@ _CANNED = {
 }
 
 
-def _refit_under_a_changed_causal_module(monkeypatch, digest: str) -> None:
-    """What a refit is: the same request against a changed case_studies/utils/causal.py.
-
-    `_causal_source_identity` hashes that file, so editing it is what produces a second
-    identity for the same label. Simulating it here keeps the test about the chain
-    rather than about which edit was made.
-    """
+def _refit_under_a_changed_causal_module(monkeypatch, version: int) -> None:
+    """Run the same request against a new causal computation version."""
     from case_studies.utils import causal as causal_module
 
     monkeypatch.setattr(causal_module, "run_dml_analysis", lambda *a, **k: dict(_CANNED))
-    monkeypatch.setattr(causal_module, "_causal_source_identity", lambda: {"causal.py": digest})
+    monkeypatch.setattr(
+        causal_module, "_causal_source_identity", lambda: {"causal_runner": version}
+    )
 
 
 def test_a_refit_through_the_request_path_is_refused_without_a_declaration(
@@ -259,10 +256,10 @@ def test_a_refit_through_the_request_path_is_refused_without_a_declaration(
     from tests.test_causal_adapter import _causal_fixture
 
     study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
-    _refit_under_a_changed_causal_module(monkeypatch, "a" * 64)
+    _refit_under_a_changed_causal_module(monkeypatch, 1)
     first = study.causal(method="dml", label=label.name).run()
 
-    _refit_under_a_changed_causal_module(monkeypatch, "b" * 64)
+    _refit_under_a_changed_causal_module(monkeypatch, 2)
     with pytest.raises(ValueError, match="SUPERSEDES_CAUSAL"):
         study.causal(method="dml", label=label.name).run()
 

--- a/tests/test_model_source_identity_versions.py
+++ b/tests/test_model_source_identity_versions.py
@@ -1,0 +1,126 @@
+"""Semantic implementation versions for model families that used to hash source files."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from case_studies.utils import causal, deep_learning, tabular_dl
+from case_studies.utils.latent_factors import adapter as latent_adapter
+from case_studies.utils.registry import training_hash_from_spec
+
+PINNED_SEQUENCE_RUNNER = 1
+PINNED_SEQUENCE_PREPARATION = 1
+PINNED_SEQUENCE_STATE = 1
+PINNED_TABM_RUNNER = 1
+PINNED_TABM_STATE = 1
+PINNED_LATENT_ADAPTER = 1
+PINNED_CAUSAL_RUNNER = 1
+
+
+def _training_spec(source_identity: dict) -> dict:
+    return {
+        "identity_version": 3,
+        "resolved_spec_schema": "ml4t.resolved-spec/v1",
+        "execution_tier": "canonical",
+        "family": "fixture",
+        "label": "target",
+        "seed": 42,
+        "computation": {"source_identity": source_identity},
+        "provenance": {},
+    }
+
+
+def test_sequence_identity_is_declared_and_architecture_scoped() -> None:
+    assert deep_learning.SEQUENCE_RUNNER_VERSION == PINNED_SEQUENCE_RUNNER
+    assert deep_learning.SEQUENCE_PREPARATION_VERSION == PINNED_SEQUENCE_PREPARATION
+    assert deep_learning.SEQUENCE_STATE_VERSION == PINNED_SEQUENCE_STATE
+
+    nlinear = deep_learning._sequence_source_identity(
+        {"library": "pytorch", "params": {"architecture": "nlinear"}}
+    )
+    lstm = deep_learning._sequence_source_identity(
+        {"library": "pytorch", "params": {"architecture": "lstm"}}
+    )
+    darts = deep_learning._sequence_source_identity(
+        {"library": "darts", "params": {"architecture": "tsmixer"}}
+    )
+
+    assert nlinear == {
+        "sequence_runner": 1,
+        "sequence_preparation": 1,
+        "sequence_state": 1,
+        "backend": "pytorch/v1",
+        "architecture": "nlinear/v1",
+    }
+    assert nlinear != lstm
+    assert nlinear != darts
+
+
+def test_sequence_identity_rejects_an_unversioned_architecture() -> None:
+    with pytest.raises(ValueError, match="implementation version"):
+        deep_learning._sequence_source_identity(
+            {"library": "pytorch", "params": {"architecture": "unknown"}}
+        )
+
+
+def test_tabm_identity_is_declared() -> None:
+    assert tabular_dl.TABM_RUNNER_VERSION == PINNED_TABM_RUNNER
+    assert tabular_dl.TABM_STATE_VERSION == PINNED_TABM_STATE
+    assert tabular_dl._tabm_source_identity() == {
+        "tabm_runner": 1,
+        "tabm_state": 1,
+    }
+
+
+@pytest.mark.parametrize("model", ["pca", "ipca", "cae", "sae", "sdf"])
+def test_latent_identity_is_declared_and_model_scoped(model: str) -> None:
+    assert latent_adapter.LATENT_ADAPTER_VERSION == PINNED_LATENT_ADAPTER
+    assert latent_adapter._source_identity(model) == {
+        "latent_adapter": 1,
+        "latent_model": f"{model}/v1",
+    }
+
+
+def test_causal_identity_is_declared() -> None:
+    assert causal.CAUSAL_RUNNER_VERSION == PINNED_CAUSAL_RUNNER
+    assert causal._causal_source_identity() == {"causal_runner": 1}
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        lambda: deep_learning._sequence_source_identity(
+            {"library": "pytorch", "params": {"architecture": "nlinear"}}
+        ),
+        tabular_dl._tabm_source_identity,
+        lambda: latent_adapter._source_identity("pca"),
+        causal._causal_source_identity,
+    ],
+)
+def test_a_declared_version_change_moves_the_training_hash(identity) -> None:
+    original = identity()
+    changed = deepcopy(original)
+    first = next(iter(changed))
+    changed[first] = int(changed[first]) + 1
+
+    assert training_hash_from_spec(_training_spec(original)) != training_hash_from_spec(
+        _training_spec(changed)
+    )
+
+
+def test_active_source_identities_contain_no_file_digests() -> None:
+    identities = [
+        deep_learning._sequence_source_identity(
+            {"library": "pytorch", "params": {"architecture": "nlinear"}}
+        ),
+        tabular_dl._tabm_source_identity(),
+        latent_adapter._source_identity("pca"),
+        causal._causal_source_identity(),
+    ]
+    assert not any(
+        isinstance(value, str) and len(value) == 64
+        for identity in identities
+        for value in identity.values()
+    )

--- a/tests/test_model_source_identity_versions.py
+++ b/tests/test_model_source_identity_versions.py
@@ -1,10 +1,14 @@
 """Semantic implementation versions for model families that used to hash source files."""
 
+# ruff: noqa: E402  # pytest.importorskip must run before the torch-backed imports
+
 from __future__ import annotations
 
 from copy import deepcopy
 
 import pytest
+
+pytest.importorskip("torch")
 
 from case_studies.utils import causal, deep_learning, tabular_dl
 from case_studies.utils.latent_factors import adapter as latent_adapter

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -2724,7 +2724,9 @@ def _latent_study(tmp_path, monkeypatch):
         "case_studies.utils.latent_factors.case_study.load_case_study_context",
         lambda *args, **kwargs: context,
     )
-    monkeypatch.setattr(latent_adapter, "_source_identity", lambda: {"fixture": "v1"})
+    monkeypatch.setattr(
+        latent_adapter, "_source_identity", lambda model_name: {model_name: "fixture-v1"}
+    )
     return study
 
 

--- a/tests/test_training_identity_migration.py
+++ b/tests/test_training_identity_migration.py
@@ -1,0 +1,201 @@
+"""Verified reuse of complete training results across identity representation changes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from case_studies.research import OfficialPopulation, PredictionResult, Result, TrainingResult
+from case_studies.utils.registry import training_hash_from_spec
+from case_studies.utils.registry.completeness import skip_training_if_complete
+from case_studies.utils.registry.maintenance import migrate_equivalent_training_identity
+from tests.test_research_registry import _predictions, _study
+
+
+def _source_spec() -> dict:
+    return {
+        "identity_version": 3,
+        "resolved_spec_schema": "ml4t.resolved-spec/v1",
+        "family": "deep_learning",
+        "label": "fwd_ret_21d",
+        "seed": 42,
+        "execution_tier": "canonical",
+        "config_name": "nlinear",
+        "computation": {
+            "checkpoint_schedule": [{"kind": "epoch", "value": 5}],
+            "cv": {"folds": [{"fold": 0, "val_start": "2024-01-05"}]},
+            "feature_artifacts": {"financial": "features-a"},
+            "feature_names": ["momentum", "volatility"],
+            "label_artifact": "label-a",
+            "model": {"architecture": "nlinear", "width": 32},
+            "numerics": {"precision": "float32", "seed": 42},
+            "source_identity": {"deep_learning.py": "a" * 64},
+        },
+        "provenance": {"notebook": "09_dl_nlinear.ipynb"},
+    }
+
+
+def _target_spec(source: dict) -> dict:
+    target = copy.deepcopy(source)
+    target["computation"]["source_identity"] = {
+        "architecture": "nlinear/v1",
+        "backend": "pytorch/v1",
+        "sequence_preparation": 1,
+        "sequence_runner": 1,
+        "sequence_state": 1,
+    }
+    target["provenance"] = {"notebook": "09_dl_nlinear.py", "publication": "current"}
+    return target
+
+
+def _complete_source(study, spec: dict):
+    training = study.results.register_training(spec)
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    model_dir.mkdir(parents=True)
+    (model_dir / "fold_0.pt").write_bytes(b"immutable fitted state")
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="epoch",
+        checkpoint_value=5,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+        metrics={"ic_mean": 0.1},
+    )
+    assert training.complete and prediction.complete
+    return training, prediction
+
+
+def _registry_rows(db_path: Path) -> dict[str, list[tuple]]:
+    with sqlite3.connect(db_path) as db:
+        tables = (
+            "training_runs",
+            "prediction_sets",
+            "prediction_coverage",
+            "prediction_metrics",
+            "fold_metrics",
+            "training_identity_migrations",
+        )
+        return {
+            table: db.execute(f"SELECT * FROM {table} ORDER BY 1").fetchall() for table in tables
+        }
+
+
+def _artifact_bytes(root: Path) -> dict[str, bytes]:
+    run_log = root / "run_log"
+    return {
+        path.relative_to(run_log).as_posix(): path.read_bytes()
+        for path in sorted(run_log.rglob("*"))
+        if path.is_file() and path.name != "registry.db" and "registry.db-" not in path.name
+    }
+
+
+def test_equivalent_identity_migration_reuses_complete_training_and_predictions(tmp_path) -> None:
+    study = _study(tmp_path)
+    source_spec = _source_spec()
+    source, source_prediction = _complete_source(study, source_spec)
+    target_spec = _target_spec(source_spec)
+
+    migration = migrate_equivalent_training_identity(study, source.hash, target_spec)
+    target = Result.open(study, migration.target_training_hash)
+    target_prediction = Result.open(study, migration.prediction_map[source_prediction.hash])
+
+    assert isinstance(target, TrainingResult) and target.complete
+    assert isinstance(target_prediction, PredictionResult) and target_prediction.complete
+    assert target.hash == training_hash_from_spec(target_spec)
+    assert target.spec() == target_spec
+    assert target_prediction.load().equals(source_prediction.load())
+    assert (
+        target.root / "run_log" / "training" / target.hash / "models" / "fold_0.pt"
+    ).read_bytes() == b"immutable fitted state"
+    assert Result.open(study, source.hash).complete
+    assert migration.created
+    assert skip_training_if_complete(
+        study.case_study,
+        target_spec,
+        verbose=False,
+        case_dir=study.root,
+    ).complete
+
+    population = OfficialPopulation.create(
+        study,
+        name="equivalent-sequence-results",
+        member_kind="prediction",
+        members=[target_prediction.hash],
+    )
+    assert population.require_complete() == (target_prediction.hash,)
+
+    repeated = migrate_equivalent_training_identity(study, source.hash, target_spec)
+    assert repeated == migration.with_created(False)
+
+    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        proof = db.execute(
+            "SELECT proof_json FROM training_identity_migrations WHERE target_training_hash = ?",
+            (target.hash,),
+        ).fetchone()
+    assert proof is not None
+    record = json.loads(proof[0])
+    assert record["migrated_fields"] == ["computation.source_identity"]
+    assert record["source_artifacts"]
+
+
+def test_semantic_difference_refuses_before_registry_or_artifact_mutation(tmp_path) -> None:
+    study = _study(tmp_path)
+    source_spec = _source_spec()
+    source, _ = _complete_source(study, source_spec)
+    target_spec = _target_spec(source_spec)
+    target_spec["computation"]["model"]["width"] = 64
+    db_path = study.root / "run_log" / "registry.db"
+    before_rows = _registry_rows(db_path)
+    before_artifacts = _artifact_bytes(study.root)
+
+    with pytest.raises(ValueError, match="model.width"):
+        migrate_equivalent_training_identity(study, source.hash, target_spec)
+
+    assert _registry_rows(db_path) == before_rows
+    assert _artifact_bytes(study.root) == before_artifacts
+    assert not (study.root / "run_log" / "training" / training_hash_from_spec(target_spec)).exists()
+
+
+def test_version_2_result_remains_readable_after_migration_to_version_3(tmp_path) -> None:
+    study = _study(tmp_path)
+    version_3 = _source_spec()
+    source_spec = {
+        "identity_version": 2,
+        "family": version_3["family"],
+        "label": version_3["label"],
+        "seed": version_3["seed"],
+        "execution_tier": version_3["execution_tier"],
+        **copy.deepcopy(version_3["computation"]),
+    }
+    source, _ = _complete_source(study, source_spec)
+    target_spec = _target_spec(version_3)
+
+    migration = migrate_equivalent_training_identity(study, source.hash, target_spec)
+
+    assert Result.open(study, source.hash).identity_version == 2
+    assert Result.open(study, source.hash).complete
+    assert Result.open(study, migration.target_training_hash).identity_version == 3
+    assert Result.open(study, migration.target_training_hash).complete
+
+
+def test_incomplete_source_and_unrecorded_target_are_refused(tmp_path) -> None:
+    study = _study(tmp_path)
+    source_spec = _source_spec()
+    incomplete = study.results.register_training(source_spec)
+    target_spec = _target_spec(source_spec)
+
+    with pytest.raises(ValueError, match="complete training result"):
+        migrate_equivalent_training_identity(study, incomplete.hash, target_spec)
+
+    complete, _ = _complete_source(study, {**source_spec, "seed": 7})
+    occupied_spec = _target_spec({**source_spec, "seed": 7})
+    occupied = study.results.register_training(occupied_spec)
+    assert not occupied.complete
+    with pytest.raises(ValueError, match="already exists without an equivalence record"):
+        migrate_equivalent_training_identity(study, complete.hash, occupied_spec)

--- a/tests/test_training_identity_migration.py
+++ b/tests/test_training_identity_migration.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
+import joblib
 import pytest
 from torch import nn
 
@@ -90,6 +92,30 @@ def _complete_source(study, spec: dict):
         training,
         checkpoint_kind="epoch",
         checkpoint_value=5,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+        metrics={"ic_mean": 0.1},
+    )
+    assert training.complete and prediction.complete
+    return training, prediction
+
+
+def _complete_linear_source(study, spec: dict):
+    training = study.results.register_training(spec)
+    model_dir = training.root / "run_log" / "training" / training.hash / "models"
+    model_dir.mkdir(parents=True)
+    artifact = model_dir / "fold_0.joblib"
+    joblib.dump({"coefficient": [0.5]}, artifact)
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    (model_dir / "manifest.json").write_text(
+        json.dumps({"files": {artifact.name: digest}}, indent=2, sort_keys=True) + "\n"
+    )
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
         split="validation",
         predictions=frame,
         expected_keys=frame.select("symbol", "timestamp", "fold_id"),
@@ -232,6 +258,29 @@ def test_version_2_result_remains_readable_after_migration_to_version_3(tmp_path
     assert Result.open(study, source.hash).complete
     assert Result.open(study, migration.target_training_hash).identity_version == 3
     assert Result.open(study, migration.target_training_hash).complete
+
+
+def test_linear_final_checkpoint_migrates_through_its_manifest(tmp_path) -> None:
+    study = _study(tmp_path)
+    source_spec = {
+        **_source_spec(),
+        "family": "linear",
+        "config_name": "ridge",
+        "computation": {
+            **copy.deepcopy(_source_spec()["computation"]),
+            "checkpoint_schedule": [{"kind": "final", "value": None}],
+            "model": {"class": "Ridge", "params": {"alpha": 1.0}},
+            "source_identity": {"linear.py": "b" * 64},
+        },
+    }
+    source, source_prediction = _complete_linear_source(study, source_spec)
+    target_spec = copy.deepcopy(source_spec)
+    target_spec["computation"]["source_identity"] = {"linear_runner": 1}
+
+    migration = migrate_equivalent_training_identity(study, source.hash, target_spec)
+
+    assert Result.open(study, migration.target_training_hash).complete
+    assert Result.open(study, migration.prediction_map[source_prediction.hash]).complete
 
 
 def test_released_result_migration_reconciles_dynamic_metric_columns(tmp_path) -> None:

--- a/tests/test_training_identity_migration.py
+++ b/tests/test_training_identity_migration.py
@@ -6,14 +6,26 @@ import copy
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from torch import nn
 
-from case_studies.research import OfficialPopulation, PredictionResult, Result, TrainingResult
+from case_studies.research import (
+    OfficialPopulation,
+    PredictionResult,
+    Result,
+    Study,
+    TrainingResult,
+)
+from case_studies.utils import deep_learning
+from case_studies.utils.deep_model_state import deep_checkpoint_path, write_deep_checkpoint
 from case_studies.utils.registry import training_hash_from_spec
 from case_studies.utils.registry.completeness import skip_training_if_complete
 from case_studies.utils.registry.maintenance import migrate_equivalent_training_identity
+from case_studies.utils.registry.store import _open_registry
 from tests.test_research_registry import _predictions, _study
+from tests.test_research_workspace import _seed_release
 
 
 def _source_spec() -> dict:
@@ -31,7 +43,11 @@ def _source_spec() -> dict:
             "feature_artifacts": {"financial": "features-a"},
             "feature_names": ["momentum", "volatility"],
             "label_artifact": "label-a",
-            "model": {"architecture": "nlinear", "width": 32},
+            "model": {
+                "class": "nlinear",
+                "implementation": "pytorch",
+                "params": {"architecture": "nlinear", "width": 32},
+            },
             "numerics": {"precision": "float32", "seed": 42},
             "source_identity": {"deep_learning.py": "a" * 64},
         },
@@ -55,8 +71,20 @@ def _target_spec(source: dict) -> dict:
 def _complete_source(study, spec: dict):
     training = study.results.register_training(spec)
     model_dir = training.root / "run_log" / "training" / training.hash / "models"
-    model_dir.mkdir(parents=True)
-    (model_dir / "fold_0.pt").write_bytes(b"immutable fitted state")
+    checkpoint = deep_checkpoint_path(model_dir, spec["config_name"], 0, 5)
+    write_deep_checkpoint(
+        checkpoint,
+        model=nn.Linear(1, 1),
+        architecture="nlinear",
+        model_kwargs={"input_dim": 1},
+        preprocessing={"mean": [0.0], "scale": [1.0]},
+        metadata={
+            "checkpoint_kind": "epoch",
+            "checkpoint_value": 5,
+            "config_name": spec["config_name"],
+            "fold": 0,
+        },
+    )
     frame = _predictions()
     prediction = study.results.publish_predictions(
         training,
@@ -110,9 +138,13 @@ def test_equivalent_identity_migration_reuses_complete_training_and_predictions(
     assert target.hash == training_hash_from_spec(target_spec)
     assert target.spec() == target_spec
     assert target_prediction.load().equals(source_prediction.load())
-    assert (
-        target.root / "run_log" / "training" / target.hash / "models" / "fold_0.pt"
-    ).read_bytes() == b"immutable fitted state"
+    target_checkpoint = deep_checkpoint_path(
+        target.root / "run_log" / "training" / target.hash / "models", "nlinear", 0, 5
+    )
+    source_checkpoint = deep_checkpoint_path(
+        source.root / "run_log" / "training" / source.hash / "models", "nlinear", 0, 5
+    )
+    assert target_checkpoint.read_bytes() == source_checkpoint.read_bytes()
     assert Result.open(study, source.hash).complete
     assert migration.created
     assert skip_training_if_complete(
@@ -121,6 +153,23 @@ def test_equivalent_identity_migration_reuses_complete_training_and_predictions(
         verbose=False,
         case_dir=study.root,
     ).complete
+    cached = deep_learning._cached_sequence_run(
+        study,
+        target_spec,
+        SimpleNamespace(
+            config={
+                "config_name": "nlinear",
+                "library": "pytorch",
+                "params": {"architecture": "nlinear"},
+            },
+            prediction_split="validation",
+            published_checkpoints=(5,),
+            splits=({"fold": 0},),
+        ),
+    )
+    assert cached is not None
+    assert cached.training.hash == target.hash
+    assert cached.predictions == (target_prediction,)
 
     population = OfficialPopulation.create(
         study,
@@ -149,12 +198,12 @@ def test_semantic_difference_refuses_before_registry_or_artifact_mutation(tmp_pa
     source_spec = _source_spec()
     source, _ = _complete_source(study, source_spec)
     target_spec = _target_spec(source_spec)
-    target_spec["computation"]["model"]["width"] = 64
+    target_spec["computation"]["model"]["params"]["width"] = 64
     db_path = study.root / "run_log" / "registry.db"
     before_rows = _registry_rows(db_path)
     before_artifacts = _artifact_bytes(study.root)
 
-    with pytest.raises(ValueError, match="model.width"):
+    with pytest.raises(ValueError, match="model.params.width"):
         migrate_equivalent_training_identity(study, source.hash, target_spec)
 
     assert _registry_rows(db_path) == before_rows
@@ -171,6 +220,7 @@ def test_version_2_result_remains_readable_after_migration_to_version_3(tmp_path
         "label": version_3["label"],
         "seed": version_3["seed"],
         "execution_tier": version_3["execution_tier"],
+        "config_name": version_3["config_name"],
         **copy.deepcopy(version_3["computation"]),
     }
     source, _ = _complete_source(study, source_spec)
@@ -182,6 +232,49 @@ def test_version_2_result_remains_readable_after_migration_to_version_3(tmp_path
     assert Result.open(study, source.hash).complete
     assert Result.open(study, migration.target_training_hash).identity_version == 3
     assert Result.open(study, migration.target_training_hash).complete
+
+
+def test_released_result_migration_reconciles_dynamic_metric_columns(tmp_path) -> None:
+    release_root = _seed_release(tmp_path)
+    release_case = release_root / "case_studies" / "etfs"
+    _open_registry(release_case).close()
+    source_study = Study(
+        case_study="etfs",
+        root=release_case,
+        release_root=release_root,
+        output_root=release_root / "case_studies",
+        read_only=False,
+        manifest={"schema_version": 1, "case_study": "etfs"},
+    )
+    source_spec = _source_spec()
+    source, source_prediction = _complete_source(source_study, source_spec)
+    with sqlite3.connect(release_case / "run_log" / "registry.db") as db:
+        db.execute("ALTER TABLE prediction_metrics ADD COLUMN source_only_metric REAL")
+        db.execute(
+            "UPDATE prediction_metrics SET source_only_metric = 7.5 WHERE prediction_hash = ?",
+            (source_prediction.hash,),
+        )
+        db.commit()
+
+    target_study = Study.open(
+        "etfs",
+        workspace=tmp_path / "target-workspace",
+        release_root=release_root,
+    )
+    migration = migrate_equivalent_training_identity(
+        target_study,
+        source.hash,
+        _target_spec(source_spec),
+    )
+    target_prediction_hash = migration.prediction_map[source_prediction.hash]
+
+    with sqlite3.connect(target_study.root / "run_log" / "registry.db") as db:
+        row = db.execute(
+            "SELECT source_only_metric FROM prediction_metrics WHERE prediction_hash = ?",
+            (target_prediction_hash,),
+        ).fetchone()
+    assert row == (7.5,)
+    assert Result.open(target_study, target_prediction_hash).complete
 
 
 def test_incomplete_source_and_unrecorded_target_are_refused(tmp_path) -> None:

--- a/tests/test_training_identity_migration.py
+++ b/tests/test_training_identity_migration.py
@@ -1,5 +1,7 @@
 """Verified reuse of complete training results across identity representation changes."""
 
+# ruff: noqa: E402  # pytest.importorskip must run before the torch-backed imports
+
 from __future__ import annotations
 
 import copy
@@ -11,6 +13,9 @@ from types import SimpleNamespace
 
 import joblib
 import pytest
+
+pytest.importorskip("torch")
+
 from torch import nn
 
 from case_studies.research import (


### PR DESCRIPTION
Semantic model identity versions, a verified identity migration, migrated fitted-state and schema validation, and final-checkpoint support.

A documentation-only or output-presentation edit no longer invalidates a computational result when semantic identity and registered inputs are unchanged. Only identities whose computation changed are re-run; presentation and provenance update without discarding valid model fits.

Five commits: e3784bda, 0d7e6263, b86fd78c, f7108e55, c1e1ed14.
Tests at push time: 98 model-adapter, 135 research/registry, 38 focused, 6 migration.

This is shared infrastructure under `case_studies/utils/` that eight case-study panes execute against, so it should land before the phase PRs that build on it.