### PR TITLE
A preview reads the canonical registry in a maintainer worktree, and offered its hash

### DIFF
--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -40,6 +40,27 @@ def research_name(case_study_id: str, suffix: str, *, scope: str = "") -> str:
     return f"{scope}:{suffix}" if scope else f"{case_study_id}:{suffix}"
 
 
+def _preview_is_active() -> bool:
+    """Whether a preview tier is active, from the one signal that survives the read path.
+
+    `Study.activate` stamps `ML4T_OUTPUT_DIR` with a `.preview` root, and that is the only
+    marker a caller downstream can rely on. **`study.root` is not one.** In a maintainer
+    worktree `features`, `labels` and `run_log` are symlinks into the shared artifact store,
+    which `create_experiment` cannot copy, so `open_study(execution_tier="preview")` takes the
+    read-in-place branch (`workspace.py`) and hands back a study whose `root` *is* the canonical
+    case directory, with only its writes redirected. A preview there reads canonical rows.
+
+    That is invisible in CI, where a checkout has no symlinks and the isolated branch runs
+    instead - so a check that passes on a runner and fails on a maintainer's machine is the
+    expected shape of this bug rather than a surprising one.
+    """
+    import os
+    from pathlib import Path
+
+    active = os.environ.get("ML4T_OUTPUT_DIR")
+    return bool(active) and Path(active).name == ".preview"
+
+
 def _refuse_preview_activation() -> None:
     """A population is written to the canonical registry whatever tier is active.
 
@@ -52,11 +73,7 @@ def _refuse_preview_activation() -> None:
 
     Callers guard this too. This is the guard that does not depend on remembering.
     """
-    import os
-    from pathlib import Path
-
-    active = os.environ.get("ML4T_OUTPUT_DIR")
-    if active and Path(active).name == ".preview":
+    if _preview_is_active():
         raise ValueError(
             "a preview run cannot create an official population: it would be written to the "
             "canonical registry"
@@ -278,6 +295,14 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
     whose isolated registry holds no generation under this name either.
     """
     if not declared:
+        return None
+    if _preview_is_active():
+        # Decided before the registry is consulted, because in a maintainer worktree the
+        # registry a preview reads is the canonical one. Asking it first returns a real
+        # generation, this function offers the hash, and `run_model_population` then refuses
+        # the run outright - "preview populations cannot supersede a snapshot" - before the
+        # first fit. A preview never creates an official population, so there is never a
+        # snapshot for it to supersede and the answer does not depend on what is on disk.
         return None
     try:
         current = OfficialPopulation.one(study, name=name)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -294,3 +294,38 @@ class TestWhatALaterGenerationRetires:
         shutil.copy(released_db, refitter.root / "run_log" / "registry.db")
         _publish(refitter, MEMBERS_TWO, supersedes=first.hash)
         assert superseded_members(refitter) == frozenset(MEMBERS_ONE)
+
+
+class TestThePreviewTier:
+    """A preview never creates an official population, so it never supersedes one.
+
+    This has to be decided from the tier rather than from what the registry holds, because in a
+    maintainer worktree the registry a preview reads *is* the canonical one. `features`,
+    `labels` and `run_log` are symlinks into the shared artifact store, which `create_experiment`
+    cannot copy, so `open_study(execution_tier="preview")` takes the read-in-place branch and
+    returns a study whose `root` is the canonical case directory with only its writes redirected.
+
+    Asking the registry first then returns a real generation, the hash is offered, and
+    `run_model_population` refuses the whole run - "preview populations cannot supersede a
+    snapshot" - before the first fit. A CI checkout has no symlinks and never takes that branch,
+    so this fails only on a maintainer's machine.
+    """
+
+    def test_a_preview_is_never_offered_the_hash(
+        self, study: Study, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        first = _publish(study, MEMBERS_ONE)
+        # Canonical resolves it, which is what makes the preview answer a decision rather than
+        # an absence: the same registry, the same name, the same declaration.
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+
+        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.root / ".preview"))
+        assert population_supersedes(study, name=first.name, declared=first.hash) is None
+
+    def test_the_refusal_to_create_reads_the_same_signal(
+        self, study: Study, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One derivation for both, so they cannot drift into disagreeing about the tier."""
+        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.root / ".preview"))
+        with pytest.raises(ValueError, match="preview run cannot create an official population"):
+            _publish(study, MEMBERS_TWO)


### PR DESCRIPTION
`population_supersedes` asked the registry before it asked the tier. That is safe wherever a preview is genuinely isolated — and a maintainer worktree is not.

## The mechanism

`open_study(execution_tier="preview")` isolates a study only when `features`, `labels` and `run_log` are real directories (`case_studies/research/workspace.py`). Where they are **symlinks** into the shared artifact store — which is every maintainer worktree, because `create_experiment` cannot copy them — it takes the read-in-place branch:

```
root=case_dir          # the CANONICAL case directory
output_root=workspace  # writes only
```

So a preview *reads* canonical rows. `population_supersedes` resolves the canonical generation, offers the declared hash, and `run_model_population` then refuses the run outright — `preview populations cannot supersede a snapshot` — before the first fit.

## Reproduced

In `public-s6-fx_pairs`, against the real registry:

```
preview study.root        …/public-s6-fx_pairs/case_studies/fx_pairs
release_case_root         …/public-s6-fx_pairs/case_studies/fx_pairs
root IS the canonical dir True
population_supersedes ->  06e9ea03f2f2
```

`cme_futures` lost two preview runs to this and RoboRev blocked its push on it.

## Why the earlier evidence pointed the other way

**It is invisible in CI.** A checkout has no symlinks, so the isolated branch always runs there, and the pytest path sets `WORKSPACE` to a real throwaway directory. Both measure the case that works.

I had argued that preview isolation was structural, from `run_model_population` branching on tier before writing and `OfficialPopulation.create` refusing a preview member. Both are true. **Neither covers where a preview reads**, and I never asked.

`root == release_case_root` is the cheap test for it — one comparison, no fixture, and it distinguishes the two branches directly.

## The fix

The tier is decided **before** the registry is consulted. A preview never creates an official population, so there is never a snapshot for it to supersede, and the answer cannot depend on what is on disk.

`_preview_is_active` is one derivation shared with `_refuse_preview_activation`, which already read the same `.preview` marker, so the write refusal and the read guard cannot drift into disagreeing about what "preview" means.

Verified failing without the guard. Canonical behaviour is unchanged and still returns the hash.

## The general form

**Any code on a preview path that reads `study.root` expecting isolation has this bug**, and this will not be the only caller. That sentence is in the commit message so the next person to grep for it finds the reasoning rather than only the guard.