### PR TITLE
Narrow the registry reads that decide a superseded hash to the failure they can answer

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -86,14 +86,17 @@ tests/test_tabular_dl_runtime.py
 #
 # The first three collect nothing but notebook executions, so the whole file
 # goes. `test_model_registry.py` does not: only `test_model_notebook` runs a
-# notebook, and its other nine tests are pure config assertions that finish in
+# notebook, and its other ten tests are pure config assertions that finish in
 # 0.07s. Excluding the file threw those away, which is the same
 # exclude-more-than-you-meant defect the subtraction below exists to fix.
+# Ten, not nine: `test_registering_stage_maps_to_its_actual_entry_point` is
+# parametrized over five stages, so counting `def test_` undercounts what the
+# deselect leaves behind. Measured 2026-08-27: 88 collected, 78 deselected.
 # ---------------------------------------------------------------------------
 tests/test_case_studies.py                       # cs-<case-study> (test-case-studies)
 tests/test_chapter_notebooks.py                  # chNN (test-chapters)
 tests/test_docker_notebooks.py                   # test-py312, test-neo4j, test-benchmark
-tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other nine tests run here
+tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other ten tests run here
 
 # ---------------------------------------------------------------------------
 # Needs the reader's Docker image. It walks every declared third-party import

--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -301,13 +301,25 @@ def causal_supersedes(
     db_path = study.storage_root(tier) / "run_log" / "registry.db"
     if not db_path.is_file():
         return None
+    # The registry's own timeouts, as `population_supersedes` uses: five seconds is short
+    # enough that ordinary contention with a concurrent writer raises `database is locked`.
+    db = sqlite3.connect(str(db_path), timeout=120.0)
     try:
-        with sqlite3.connect(db_path) as db:
+        db.execute("PRAGMA busy_timeout = 60000")
+        try:
             current = current_causal_identities(db, label=label, tier=tier.value)
-    except sqlite3.OperationalError:
-        # No causal table at all, which is the ordinary state of a reader's clone rather than
-        # the exotic one. Same reasoning as `population_supersedes`.
-        return None
+        except sqlite3.OperationalError as error:
+            if "no such table" not in str(error):
+                # A lock timeout, an I/O error and a half-migrated schema are not evidence that
+                # this registry holds no causal identity. Reading them as a clean clone withholds
+                # the predecessor, and the notebook then pays for the DML fit and every placebo
+                # refit before registration refuses the write for naming none.
+                raise
+            # No causal table at all, which is the ordinary state of a reader's clone rather than
+            # the exotic one. Same reasoning as `population_supersedes`.
+            return None
+    finally:
+        db.close()
     return declared if declared in current else None
 
 

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -55,7 +55,7 @@ def research_name(case_study_id: str, suffix: str, *, scope: str = "") -> str:
     return f"{scope}:{suffix}" if scope else f"{case_study_id}:{suffix}"
 
 
-def _preview_is_active() -> bool:
+def _preview_is_active(study: Study | None = None) -> bool:
     """Whether a preview tier is active, from the one signal that survives the read path.
 
     `Study.activate` stamps `ML4T_OUTPUT_DIR` with a `.preview` root, and that is the only
@@ -68,12 +68,24 @@ def _preview_is_active() -> bool:
     That is invisible in CI, where a checkout has no symlinks and the isolated branch runs
     instead - so a check that passes on a runner and fails on a maintainer's machine is the
     expected shape of this bug rather than a surprising one.
+
+    The variable is process-global and `activate` never clears it, so "a preview is active"
+    and "*this* study is the preview" are different questions. Pass ``study`` to ask the
+    second. `activate` stamps ``study.output_root / ".preview"``, so a stamp whose parent is
+    some other study's output root says nothing about this one. Without the argument this
+    still answers the first question, which is what `_refuse_preview_activation` wants: a
+    population is written to whichever registry the active tier points at, so any active
+    preview is grounds to refuse the write.
     """
     import os
     from pathlib import Path
 
     active = os.environ.get("ML4T_OUTPUT_DIR")
-    return bool(active) and Path(active).name == ".preview"
+    if not active or Path(active).name != ".preview":
+        return False
+    if study is None or study.output_root is None:
+        return True
+    return Path(active).parent.resolve() == Path(study.output_root).resolve()
 
 
 def _refuse_preview_activation() -> None:
@@ -311,7 +323,7 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
     """
     if not declared:
         return None
-    if _preview_is_active():
+    if _preview_is_active(study):
         # Decided before the registry is consulted, because in a maintainer worktree the
         # registry a preview reads is the canonical one. Asking it first returns a real
         # generation, this function offers the hash, and `run_model_population` then refuses

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from .workspace import Study
 
 
+def _connect(case_dir: Path) -> sqlite3.Connection:
+    """Open one case study's registry for reading, with the timeouts every other reader uses.
+
+    A registry is written by notebooks, backfills and scripts that run at the same time, so a
+    read that takes SQLite's five-second default raises ``database is locked`` under nothing
+    worse than ordinary contention. ``_open_registry`` sets 120s on the driver and 60s
+    server-side for exactly that reason; a read here has the same contention and needs the same
+    patience. It cannot call ``_open_registry`` itself, which runs the schema DDL and would
+    create the tables a clean clone is being asked about.
+    """
+    db = sqlite3.connect(str(case_dir / "run_log" / "registry.db"), timeout=120.0)
+    db.execute("PRAGMA busy_timeout = 60000")
+    return db
+
+
 def research_name(case_study_id: str, suffix: str, *, scope: str = "") -> str:
     """Name one published artifact, isolated as a whole chain when a run is narrowed.
 
@@ -209,7 +224,7 @@ class OfficialPopulation:
         supersedes; two of those under a single name means the chain forked and no answer is
         defensible.
         """
-        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        with _connect(study.root) as db:
             rows = db.execute(
                 "SELECT population_hash, supersedes_hash FROM official_populations "
                 "WHERE name = ? ORDER BY population_hash",
@@ -226,7 +241,7 @@ class OfficialPopulation:
 
     @classmethod
     def open(cls, study: Study, population_hash: str) -> OfficialPopulation:
-        with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+        with _connect(study.root) as db:
             row = db.execute(
                 "SELECT name, member_kind, snapshot_json, supersedes_hash "
                 "FROM official_populations WHERE population_hash = ?",
@@ -306,7 +321,17 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
         return None
     try:
         current = OfficialPopulation.one(study, name=name)
-    except (ValueError, sqlite3.OperationalError, KeyError):
+    except (ValueError, KeyError):
+        # No generation under this name: `one` raises `ValueError` when the query returns no
+        # current snapshot, and `open` raises `KeyError` for a hash the table does not hold.
+        return None
+    except sqlite3.OperationalError as error:
+        if "no such table" not in str(error):
+            # A lock timeout, an I/O error and a half-migrated schema are not evidence that
+            # nothing has been published. Swallowing them withholds the hash, and the notebook
+            # then pays for a full refit before `create` refuses the write for naming no
+            # predecessor. Same rule as `_lineage`.
+            raise
         return None
     return declared if declared in (current.supersedes, current.hash) else None
 
@@ -331,9 +356,8 @@ def _lineage(
     db_path = case_dir / "run_log" / "registry.db"
     if not db_path.exists():
         return [], {}
-    db = sqlite3.connect(str(db_path), timeout=120.0)
+    db = _connect(case_dir)
     try:
-        db.execute("PRAGMA busy_timeout = 60000")
         try:
             rows = db.execute(
                 "SELECT population_hash, name, supersedes_hash FROM official_populations "

--- a/tests/test_causal_supersedes_resolution.py
+++ b/tests/test_causal_supersedes_resolution.py
@@ -114,3 +114,66 @@ class TestWhatItDoesNotChange:
         """
         with pytest.raises(ValueError, match="does not fit"):
             causal_supersedes(study, DECLARATION, "fwd_ret_1d", labels=["fwd_ret_1d", "other"])
+
+
+class TestWhenTheRegistryReadItselfFails:
+    """An operational error is not evidence that the registry holds nothing.
+
+    Answering every ``sqlite3.OperationalError`` with ``None`` reads a lock timeout, an I/O
+    error and a half-migrated schema as the clean clone. The notebook then withholds the
+    predecessor it does hold, pays for the DML fit and every placebo refit, and dies at
+    registration for naming none. Only the missing table means what the clean-clone branch
+    claims it means.
+    """
+
+    def _registry_without_the_causal_table(self, study: Study) -> None:
+        import sqlite3
+
+        db_path = study.root / "run_log" / "registry.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = sqlite3.connect(db_path)
+        db.execute("CREATE TABLE IF NOT EXISTS unrelated (x INTEGER)")
+        db.commit()
+        db.close()
+
+    def test_a_missing_causal_table_is_still_the_clean_clone(self, study: Study) -> None:
+        self._registry_without_the_causal_table(study)
+        assert causal_supersedes(study, DECLARATION, "fwd_ret_1d", labels=FITTED) is None
+
+    def test_a_lock_timeout_propagates(self, study: Study, monkeypatch) -> None:
+        import sqlite3
+
+        from case_studies.research import causal as causal_module
+
+        self._registry_without_the_causal_table(study)
+
+        def locked(*args: object, **kwargs: object) -> set[str]:
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(causal_module, "current_causal_identities", locked)
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            causal_supersedes(study, DECLARATION, "fwd_ret_1d", labels=FITTED)
+
+    def test_the_read_waits_as_long_as_every_other_reader_of_this_file(
+        self, study: Study, monkeypatch
+    ) -> None:
+        """120s on the driver and 60s server-side, the pair `_open_registry` sets.
+
+        A registry is written by notebooks, backfills and scripts at once, so SQLite's
+        five-second default is short enough that ordinary contention produced the very
+        error the branch above was swallowing.
+        """
+        import sqlite3
+
+        from case_studies.research import causal as causal_module
+
+        self._registry_without_the_causal_table(study)
+        seen: dict[str, object] = {}
+
+        def record(db: sqlite3.Connection, **kwargs: object) -> set[str]:
+            seen["busy_timeout"] = db.execute("PRAGMA busy_timeout").fetchone()[0]
+            return set()
+
+        monkeypatch.setattr(causal_module, "current_causal_identities", record)
+        causal_supersedes(study, DECLARATION, "fwd_ret_1d", labels=FITTED)
+        assert seen["busy_timeout"] == 60000

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -21,6 +21,7 @@ from case_studies.research import (
     population_supersedes,
     superseded_members,
 )
+from case_studies.research import population as population_module
 from case_studies.research.workspace import Study
 from tests.test_research_workspace import _seed_release
 
@@ -329,3 +330,59 @@ class TestThePreviewTier:
         monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.root / ".preview"))
         with pytest.raises(ValueError, match="preview run cannot create an official population"):
             _publish(study, MEMBERS_TWO)
+
+
+class TestWhenTheRegistryReadItselfFails:
+    """ "No generation is published here" is one operational error, not every one.
+
+    The clean clone raises ``no such table: official_populations``. A lock timeout, an I/O
+    error and a half-migrated schema raise from the same call and mean nothing of the sort.
+    Answering all four with ``None`` withholds a predecessor the author does hold, and the
+    notebook then refits every configuration before ``create`` refuses the write for naming
+    none - the exact expense the declaration exists to avoid.
+    """
+
+    def test_a_missing_table_is_still_the_clean_clone(self, study: Study) -> None:
+        db_path = study.root / "run_log" / "registry.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = sqlite3.connect(db_path)
+        db.execute("CREATE TABLE IF NOT EXISTS unrelated (x INTEGER)")
+        db.commit()
+        db.close()
+        assert (
+            population_supersedes(study, name="etfs-linear-validation-v1", declared="aaaa11112222")
+            is None
+        )
+
+    def test_a_lock_timeout_propagates(self, study: Study, monkeypatch: pytest.MonkeyPatch) -> None:
+        first = _publish(study, MEMBERS_ONE)
+
+        def locked(*args: object, **kwargs: object) -> OfficialPopulation:
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(OfficialPopulation, "one", classmethod(locked))
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            population_supersedes(study, name=first.name, declared=first.hash)
+
+    def test_the_read_waits_as_long_as_every_other_reader_of_this_file(
+        self, study: Study, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """120s on the driver and 60s server-side, the pair ``_open_registry`` sets.
+
+        These reads open the registry directly rather than through ``_open_registry``, which
+        would run the schema DDL and create the very tables a clean clone is being asked
+        about - so the timeouts have to be set here or they fall back to SQLite's five
+        seconds, which ordinary contention with a concurrent writer exceeds. Checked on the
+        connection ``population_supersedes`` actually opens, not on the helper in isolation.
+        """
+        first = _publish(study, MEMBERS_ONE)
+        opened: list[float | None] = []
+        real_connect = sqlite3.connect
+
+        def record(path, *args, **kwargs):
+            opened.append(kwargs.get("timeout"))
+            return real_connect(path, *args, **kwargs)
+
+        monkeypatch.setattr(population_module.sqlite3, "connect", record)
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+        assert opened and all(timeout == 120.0 for timeout in opened)

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -320,8 +320,27 @@ class TestThePreviewTier:
         # an absence: the same registry, the same name, the same declaration.
         assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
 
-        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.root / ".preview"))
+        # The value `Study.activate` writes, not merely some path ending in `.preview`: the
+        # guard asks whether the stamp belongs to *this* study, so a hand-made path that no
+        # activation would produce tests a signal the code never sees.
+        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.output_root / ".preview"))
         assert population_supersedes(study, name=first.name, declared=first.hash) is None
+
+    def test_another_study_s_preview_does_not_withhold_from_this_one(
+        self, study: Study, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`ML4T_OUTPUT_DIR` is process-global and `activate` never clears it.
+
+        So "a preview is active somewhere in this process" and "this study is that preview"
+        are different questions, and answering the first withholds the hash from a canonical
+        study that merely ran second. A notebook runs one tier and never notices; any process
+        that opens both - a test module, a backfill over several case studies - gets a
+        canonical declaration silently withheld and the run dies at `create` for naming no
+        predecessor, after paying for every fit.
+        """
+        first = _publish(study, MEMBERS_ONE)
+        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path / "elsewhere" / ".preview"))
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
 
     def test_the_refusal_to_create_reads_the_same_signal(
         self, study: Study, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Both guards that decide whether a notebook may offer a declared predecessor hash answered
every `sqlite3.OperationalError` with "nothing is published here". Only one operational
error means that: the missing table a clean clone has. A lock timeout, an I/O error and a
half-migrated schema reach the same `except` and get the same answer.

The consequence is not a wrong return value at the end of a cheap read. The predecessor is
withheld, the notebook refits every configuration - or, on the causal side, runs the DML fit
and every placebo refit - and then dies at registration for naming no predecessor. The
declaration exists precisely to avoid paying that twice.

The reads also took SQLite's five-second default, while every other reader of the same file
uses the 120s driver timeout and 60s `busy_timeout` that `_open_registry` sets. A registry is
written by notebooks, backfills and scripts at the same time, which is what makes a lock
timeout here an ordinary event rather than a hypothetical one - and it entered through the
`except` above without a trace.

`_connect` now sets those timeouts in one place for `OfficialPopulation.one`, `.open` and
`_lineage`. It cannot be `_open_registry` itself, which runs the schema DDL and would create
the very tables a clean clone is being asked about.

Filed by RoboRev as jobs #16098 and #16099 against `causal.py`; the same defect was in
`population.py`, which the reviews did not reach.

## Verification

Four new tests, each falsified against the reverted code with the revert confirmed present:

- reverting `population.py` fails `test_a_lock_timeout_propagates` and
  `test_the_read_waits_as_long_as_every_other_reader_of_this_file` (both connections opened
  with `timeout=None` pre-fix, asserted on the connection `population_supersedes` actually
  opens rather than on the helper in isolation)
- reverting `causal.py` fails its two counterparts (`busy_timeout` read back as 5000)
- the missing-table tests pass in both directions, which is the point: the clean clone is
  still answered with `None`

`tests/test_population_supersedes.py`, `tests/test_causal_supersedes_resolution.py`,
`tests/test_superseded_members_registries.py`, `tests/test_research_workspace.py`: 61 passed.
