### PR TITLE
The preview test asserted the defect #637 removed, and leaked its tier

### DIFF
--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -1273,8 +1273,12 @@ def test_preview_never_carries_a_supersedes_hash(tmp_path: Path):
     assert preview.root == case_dir
     assert (preview.root / "run_log").is_symlink()
 
-    # What the helper does on its own: it finds the canonical generation and offers the hash.
-    assert population_supersedes(preview, name=name, declared=first.hash) == first.hash
+    # What the helper does on its own. Until #637 it read the registry before the tier, found
+    # the canonical generation through the symlinks above and offered the hash - the defect this
+    # test was written against. #637 decides the tier first, so the library now withholds here
+    # on its own and the notebooks' `supersedes_declaration` is a second line rather than the
+    # only one. Asserted, not deleted: it is the guarantee the symlinked layout exists to check.
+    assert population_supersedes(preview, name=name, declared=first.hash) is None
 
     # What the notebooks pass. Both call `supersedes_declaration` with their own tier, so the
     # composition below is the expression they evaluate, not a restatement of it.
@@ -1288,6 +1292,13 @@ def test_preview_never_carries_a_supersedes_hash(tmp_path: Path):
 
     # And the canonical tier still reaches the registry, so this cannot be satisfied by a
     # declaration that is withheld everywhere.
+    #
+    # `activate` first, because #637 reads the tier from `ML4T_OUTPUT_DIR`, which `activate`
+    # stamps process-globally rather than per study. Opening the preview above stamped it, and
+    # without this the canonical half inherits that stamp and is withheld too - so the test
+    # would report a canonical failure that no notebook can hit, since a notebook runs one tier
+    # per process. This makes the process tier match the study each half is describing.
+    released.activate()
     assert supersedes_declaration("canonical", first.hash) == first.hash
     assert (
         population_supersedes(


### PR DESCRIPTION
`test_preview_never_carries_a_supersedes_hash` is red on `main` at `6f8f1e72`,
which takes the required `test-unit` check with it and stops every pane: a red
required check on `main` means no PR can show five green.

#637 and #611 landed two hours apart and neither ran its checks against the
other, so this composition was never tested by CI. Two independent causes, both
in the test. No library or notebook behaviour changes here.

## The premise assertion was obsolete

It asserted that `population_supersedes` offers a preview the canonical hash.
That is the defect itself, asserted on purpose: the test builds a real symlinked
release tree so the leak is demonstrated rather than described, after two earlier
versions of this test were vacuous against exactly that mistake.

#637 decides the tier before consulting the registry, so the library now
withholds on its own and the assertion is false by design. Inverted to `is None`
rather than deleted - it is the guarantee the symlinked fixture exists to check,
and the notebooks' `supersedes_declaration` is now a second line rather than the
only one.

## The canonical assertion failed for an unrelated reason

`None` is the wrong answer there, and the cause is not the wrapper.

`population_supersedes` takes a `study` but reads the tier from
`ML4T_OUTPUT_DIR`, which `Study.activate` stamps **process-globally**
(`workspace.py:299-301`) rather than per study. Opening the preview stamps
`.preview`, and every later call in that process is withheld whatever study it
is handed.

This test is what holds two tiers at once. A notebook runs one tier per process,
where the marker tracks its study exactly, so production is unaffected and this
is a test artifact rather than a regression. `released.activate()` before the
canonical half makes the process tier match the study each half describes.

## Verification

Mutation, not the green: with `_preview_is_active` forced to `return False` the
preview assertion fails with `assert 'd0a54df1a443' is None`, so the test still
catches the defect it names. `git diff` on `population.py` empty afterwards.

78 passed across `test_cme_futures_research.py`, `test_population_supersedes.py`,
`test_superseded_members_registries.py` and `test_causal_supersedes_resolution.py`.
RoboRev: no issues found.

Tests only, so no notebook `.py` changed and no provenance staleness.

## Not fixed here

`population_supersedes` ignoring its `study` argument when deciding the tier is
safe under one-tier-per-process and unsafe for anything holding a canonical and
a preview study at once - tooling, a fixture, a driver.
`manifest["preview_only"]` is set on the symlink branch (`workspace.py:432`) but
not the isolated one, so there is no study-scoped signal today. That needs
design rather than a fleet-blocking hotfix.

`06_linear` and `07_gbm` still call `supersedes_declaration`, which #637 makes
redundant. It only ever withholds, so it cannot produce the canonical `None` and
removing it would not have fixed this. Left as a follow-up because it costs two
notebook re-executions.
