### PR TITLE
fx_pairs 12: the analysis chapter rendered generations their producers had retired

### DIFF
--- a/case_studies/fx_pairs/12_model_analysis.ipynb
+++ b/case_studies/fx_pairs/12_model_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b634f5c9",
+   "id": "e91a371b",
    "metadata": {
     "papermill": {
-     "duration": 0.001594,
-     "end_time": "2026-08-27T22:48:36.348069+00:00",
+     "duration": 0.002068,
+     "end_time": "2026-08-28T00:29:34.758350+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:36.346475+00:00",
+     "start_time": "2026-08-28T00:29:34.756282+00:00",
      "status": "completed"
     }
    },
@@ -36,19 +36,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ca46c97c",
+   "id": "3f54f865",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:36.359054Z",
-     "iopub.status.busy": "2026-08-27T22:48:36.358841Z",
-     "iopub.status.idle": "2026-08-27T22:48:40.187146Z",
-     "shell.execute_reply": "2026-08-27T22:48:40.186681Z"
+     "iopub.execute_input": "2026-08-28T00:29:34.762465Z",
+     "iopub.status.busy": "2026-08-28T00:29:34.762239Z",
+     "iopub.status.idle": "2026-08-28T00:29:39.747622Z",
+     "shell.execute_reply": "2026-08-28T00:29:39.747240Z"
     },
     "papermill": {
-     "duration": 3.836856,
-     "end_time": "2026-08-27T22:48:40.188197+00:00",
+     "duration": 4.990821,
+     "end_time": "2026-08-28T00:29:39.750902+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:36.351341+00:00",
+     "start_time": "2026-08-28T00:29:34.760081+00:00",
      "status": "completed"
     }
    },
@@ -62,7 +62,7 @@
     "from ml4t.diagnostic.metrics import cross_sectional_ic\n",
     "\n",
     "import utils.style  # noqa: F401\n",
-    "from case_studies.research import CausalResult, Result, open_study\n",
+    "from case_studies.research import CausalResult, Result, open_study, superseded_members\n",
     "from case_studies.research.results import PredictionResult\n",
     "from case_studies.utils.conformal import split_conformal_coverage\n",
     "from utils.modeling import load_configs\n",
@@ -72,19 +72,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "bd9bd635",
+   "id": "cd92621b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:40.194143Z",
-     "iopub.status.busy": "2026-08-27T22:48:40.193854Z",
-     "iopub.status.idle": "2026-08-27T22:48:40.196090Z",
-     "shell.execute_reply": "2026-08-27T22:48:40.195827Z"
+     "iopub.execute_input": "2026-08-28T00:29:39.754367Z",
+     "iopub.status.busy": "2026-08-28T00:29:39.754131Z",
+     "iopub.status.idle": "2026-08-28T00:29:39.756131Z",
+     "shell.execute_reply": "2026-08-28T00:29:39.755897Z"
     },
     "papermill": {
-     "duration": 0.005698,
-     "end_time": "2026-08-27T22:48:40.196682+00:00",
+     "duration": 0.004115,
+     "end_time": "2026-08-28T00:29:39.756497+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:40.190984+00:00",
+     "start_time": "2026-08-28T00:29:39.752382+00:00",
      "status": "completed"
     },
     "tags": [
@@ -107,13 +107,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c78602d",
+   "id": "05df3df1",
    "metadata": {
     "papermill": {
-     "duration": 0.001787,
-     "end_time": "2026-08-27T22:48:40.200532+00:00",
+     "duration": 0.001118,
+     "end_time": "2026-08-28T00:29:39.758847+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:40.198745+00:00",
+     "start_time": "2026-08-28T00:29:39.757729+00:00",
      "status": "completed"
     }
    },
@@ -128,19 +128,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "813b2657",
+   "id": "88194d8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:40.205064Z",
-     "iopub.status.busy": "2026-08-27T22:48:40.204947Z",
-     "iopub.status.idle": "2026-08-27T22:48:42.789015Z",
-     "shell.execute_reply": "2026-08-27T22:48:42.788528Z"
+     "iopub.execute_input": "2026-08-28T00:29:39.761590Z",
+     "iopub.status.busy": "2026-08-28T00:29:39.761515Z",
+     "iopub.status.idle": "2026-08-28T00:29:41.569484Z",
+     "shell.execute_reply": "2026-08-28T00:29:41.569073Z"
     },
     "papermill": {
-     "duration": 2.587637,
-     "end_time": "2026-08-27T22:48:42.790105+00:00",
+     "duration": 1.809953,
+     "end_time": "2026-08-28T00:29:41.569990+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:40.202468+00:00",
+     "start_time": "2026-08-28T00:29:39.760037+00:00",
      "status": "completed"
     }
    },
@@ -155,6 +155,16 @@
     "    & (pl.col(\"execution_tier\") == \"canonical\")\n",
     "    & (pl.col(\"split\") == \"validation\")\n",
     ")\n",
+    "# `identity_status` names the schema version a row was written under. It says nothing about\n",
+    "# which generation the row's producer still publishes: a model notebook that refits leaves the\n",
+    "# generation it replaced in the registry, complete and current under that column, so the filter\n",
+    "# above carries retired prediction sets into the analysis. The lineage is what answers it, and\n",
+    "# `superseded_members` reads that - the same exclusion `13_backtest` applies before it freezes\n",
+    "# the baseline population, so the analysed catalog and the backtested one describe one set of\n",
+    "# models rather than two.\n",
+    "retired = superseded_members(study, member_kind=\"prediction\")\n",
+    "if retired:\n",
+    "    catalog = catalog.filter(~pl.col(\"prediction_hash\").is_in(list(retired)))\n",
     "\n",
     "if catalog.is_empty():\n",
     "    raise RuntimeError(\"no current canonical validation predictions are registered\")\n",
@@ -180,13 +190,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a20be4e1",
+   "id": "7362fb2b",
    "metadata": {
     "papermill": {
-     "duration": 0.001872,
-     "end_time": "2026-08-27T22:48:42.794523+00:00",
+     "duration": 0.001567,
+     "end_time": "2026-08-28T00:29:41.573216+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.792651+00:00",
+     "start_time": "2026-08-28T00:29:41.571649+00:00",
      "status": "completed"
     }
    },
@@ -208,19 +218,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "657da16a",
+   "id": "f1eaedf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:42.799833Z",
-     "iopub.status.busy": "2026-08-27T22:48:42.799687Z",
-     "iopub.status.idle": "2026-08-27T22:48:42.890584Z",
-     "shell.execute_reply": "2026-08-27T22:48:42.889907Z"
+     "iopub.execute_input": "2026-08-28T00:29:41.580810Z",
+     "iopub.status.busy": "2026-08-28T00:29:41.580704Z",
+     "iopub.status.idle": "2026-08-28T00:29:41.651594Z",
+     "shell.execute_reply": "2026-08-28T00:29:41.651189Z"
     },
     "papermill": {
-     "duration": 0.094506,
-     "end_time": "2026-08-27T22:48:42.891026+00:00",
+     "duration": 0.075867,
+     "end_time": "2026-08-28T00:29:41.652202+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.796520+00:00",
+     "start_time": "2026-08-28T00:29:41.576335+00:00",
      "status": "completed"
     },
     "tags": [
@@ -276,19 +286,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "db286649",
+   "id": "502c7fb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:42.896924Z",
-     "iopub.status.busy": "2026-08-27T22:48:42.896743Z",
-     "iopub.status.idle": "2026-08-27T22:48:42.902923Z",
-     "shell.execute_reply": "2026-08-27T22:48:42.902450Z"
+     "iopub.execute_input": "2026-08-28T00:29:41.656735Z",
+     "iopub.status.busy": "2026-08-28T00:29:41.656611Z",
+     "iopub.status.idle": "2026-08-28T00:29:41.663160Z",
+     "shell.execute_reply": "2026-08-28T00:29:41.662894Z"
     },
     "papermill": {
-     "duration": 0.009589,
-     "end_time": "2026-08-27T22:48:42.903342+00:00",
+     "duration": 0.010585,
+     "end_time": "2026-08-28T00:29:41.664529+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.893753+00:00",
+     "start_time": "2026-08-28T00:29:41.653944+00:00",
      "status": "completed"
     },
     "tags": [
@@ -306,7 +316,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (12, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>configurations</th><th>checkpoints</th><th>complete</th><th>diagnosed_checkpoints</th></tr><tr><td>str</td><td>str</td><td>u32</td><td>u32</td><td>bool</td><td>u32</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>80</td><td>true</td><td>80</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>15</td><td>150</td><td>true</td><td>150</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>28</td><td>28</td><td>true</td><td>28</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>48</td><td>true</td><td>48</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>80</td><td>true</td><td>80</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>48</td><td>true</td><td>48</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>80</td><td>true</td><td>80</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>15</td><td>150</td><td>true</td><td>150</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>28</td><td>28</td><td>true</td><td>28</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>48</td><td>true</td><td>48</td></tr></tbody></table></div>"
+       "<small>shape: (12, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>configurations</th><th>checkpoints</th><th>complete</th><th>diagnosed_checkpoints</th></tr><tr><td>str</td><td>str</td><td>u32</td><td>u32</td><td>bool</td><td>u32</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>40</td><td>true</td><td>40</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>15</td><td>150</td><td>true</td><td>150</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>28</td><td>28</td><td>true</td><td>28</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>24</td><td>true</td><td>24</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>40</td><td>true</td><td>40</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>24</td><td>true</td><td>24</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>2</td><td>40</td><td>true</td><td>40</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>15</td><td>150</td><td>true</td><td>150</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>28</td><td>28</td><td>true</td><td>28</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>3</td><td>24</td><td>true</td><td>24</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (12, 6)\n",
@@ -315,17 +325,17 @@
        "│ ---         ┆ ---           ┆ ---            ┆ ---         ┆ ---      ┆ ---                   │\n",
        "│ str         ┆ str           ┆ u32            ┆ u32         ┆ bool     ┆ u32                   │\n",
        "╞═════════════╪═══════════════╪════════════════╪═════════════╪══════════╪═══════════════════════╡\n",
-       "│ fwd_ret_1d  ┆ deep_learning ┆ 2              ┆ 80          ┆ true     ┆ 80                    │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ 2              ┆ 40          ┆ true     ┆ 40                    │\n",
        "│ fwd_ret_1d  ┆ gbm           ┆ 15             ┆ 150         ┆ true     ┆ 150                   │\n",
        "│ fwd_ret_1d  ┆ linear        ┆ 28             ┆ 28          ┆ true     ┆ 28                    │\n",
-       "│ fwd_ret_1d  ┆ tabular_dl    ┆ 3              ┆ 48          ┆ true     ┆ 48                    │\n",
-       "│ fwd_ret_21d ┆ deep_learning ┆ 2              ┆ 80          ┆ true     ┆ 80                    │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ 3              ┆ 24          ┆ true     ┆ 24                    │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ 2              ┆ 40          ┆ true     ┆ 40                    │\n",
        "│ …           ┆ …             ┆ …              ┆ …           ┆ …        ┆ …                     │\n",
-       "│ fwd_ret_21d ┆ tabular_dl    ┆ 3              ┆ 48          ┆ true     ┆ 48                    │\n",
-       "│ fwd_ret_5d  ┆ deep_learning ┆ 2              ┆ 80          ┆ true     ┆ 80                    │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ 3              ┆ 24          ┆ true     ┆ 24                    │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ 2              ┆ 40          ┆ true     ┆ 40                    │\n",
        "│ fwd_ret_5d  ┆ gbm           ┆ 15             ┆ 150         ┆ true     ┆ 150                   │\n",
        "│ fwd_ret_5d  ┆ linear        ┆ 28             ┆ 28          ┆ true     ┆ 28                    │\n",
-       "│ fwd_ret_5d  ┆ tabular_dl    ┆ 3              ┆ 48          ┆ true     ┆ 48                    │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ 3              ┆ 24          ┆ true     ┆ 24                    │\n",
        "└─────────────┴───────────────┴────────────────┴─────────────┴──────────┴───────────────────────┘"
       ]
      },
@@ -350,13 +360,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a5bbe6b",
+   "id": "1f587e62",
    "metadata": {
     "papermill": {
-     "duration": 0.002152,
-     "end_time": "2026-08-27T22:48:42.907965+00:00",
+     "duration": 0.001533,
+     "end_time": "2026-08-28T00:29:41.667771+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.905813+00:00",
+     "start_time": "2026-08-28T00:29:41.666238+00:00",
      "status": "completed"
     }
    },
@@ -371,19 +381,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3e569aa5",
+   "id": "70e86157",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:42.913484Z",
-     "iopub.status.busy": "2026-08-27T22:48:42.913351Z",
-     "iopub.status.idle": "2026-08-27T22:48:42.925357Z",
-     "shell.execute_reply": "2026-08-27T22:48:42.924948Z"
+     "iopub.execute_input": "2026-08-28T00:29:41.671994Z",
+     "iopub.status.busy": "2026-08-28T00:29:41.671890Z",
+     "iopub.status.idle": "2026-08-28T00:29:41.685433Z",
+     "shell.execute_reply": "2026-08-28T00:29:41.685024Z"
     },
     "papermill": {
-     "duration": 0.015619,
-     "end_time": "2026-08-27T22:48:42.926001+00:00",
+     "duration": 0.016014,
+     "end_time": "2026-08-28T00:29:41.685752+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.910382+00:00",
+     "start_time": "2026-08-28T00:29:41.669738+00:00",
      "status": "completed"
     },
     "tags": [
@@ -401,7 +411,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (12, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>ic_mean</th><th>ic_t</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.020448</td><td>2.837143</td><td>&quot;689e938f32ee&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>&quot;iteration&quot;</td><td>100</td><td>0.005035</td><td>0.541423</td><td>&quot;0cff45d5daf6&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>&quot;final&quot;</td><td>null</td><td>0.006462</td><td>0.439216</td><td>&quot;eeff2961026c&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>&quot;epoch&quot;</td><td>50</td><td>0.006267</td><td>0.924793</td><td>&quot;01e41111cb52&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.036</td><td>0.831955</td><td>&quot;06c0a15b6ba1&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>0.004256</td><td>0.113015</td><td>&quot;4bc7c8767ceb&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.028685</td><td>1.272266</td><td>&quot;b633f307a008&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>&quot;iteration&quot;</td><td>50</td><td>0.006415</td><td>0.442424</td><td>&quot;d4d6d17e5918&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>0.02817</td><td>1.177314</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>-0.002766</td><td>-0.216356</td><td>&quot;296531884fa8&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (12, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>ic_mean</th><th>ic_t</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.020448</td><td>2.837143</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>&quot;iteration&quot;</td><td>100</td><td>0.005035</td><td>0.541423</td><td>&quot;0cff45d5daf6&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>&quot;final&quot;</td><td>null</td><td>0.006462</td><td>0.439216</td><td>&quot;eeff2961026c&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>&quot;epoch&quot;</td><td>50</td><td>0.006267</td><td>0.924793</td><td>&quot;01e41111cb52&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.036</td><td>0.831955</td><td>&quot;13e7a953029c&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>0.004256</td><td>0.113015</td><td>&quot;c304a4d52bad&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>0.028685</td><td>1.272266</td><td>&quot;b633f307a008&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>&quot;iteration&quot;</td><td>50</td><td>0.006415</td><td>0.442424</td><td>&quot;d4d6d17e5918&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>0.02817</td><td>1.177314</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>-0.002766</td><td>-0.216356</td><td>&quot;569a0fe11b53&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (12, 8)\n",
@@ -411,27 +421,27 @@
        "│ str        ┆ str        ┆ ---        ┆ ---       ┆ ---       ┆ f64       ┆ f64       ┆ ---       │\n",
        "│            ┆            ┆ str        ┆ str       ┆ i64       ┆           ┆           ┆ str       │\n",
        "╞════════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ fwd_ret_1d ┆ deep_learn ┆ tcn        ┆ epoch     ┆ 5         ┆ 0.020448  ┆ 2.837143  ┆ 689e938f3 │\n",
-       "│            ┆ ing        ┆            ┆           ┆           ┆           ┆           ┆ 2ee       │\n",
+       "│ fwd_ret_1d ┆ deep_learn ┆ tcn        ┆ epoch     ┆ 5         ┆ 0.020448  ┆ 2.837143  ┆ d80638423 │\n",
+       "│            ┆ ing        ┆            ┆           ┆           ┆           ┆           ┆ af7       │\n",
        "│ fwd_ret_1d ┆ gbm        ┆ leaves_63_ ┆ iteration ┆ 100       ┆ 0.005035  ┆ 0.541423  ┆ 0cff45d5d │\n",
        "│            ┆            ┆ mae        ┆           ┆           ┆           ┆           ┆ af6       │\n",
        "│ fwd_ret_1d ┆ linear     ┆ lasso_f0.2 ┆ final     ┆ null      ┆ 0.006462  ┆ 0.439216  ┆ eeff29610 │\n",
        "│            ┆            ┆            ┆           ┆           ┆           ┆           ┆ 26c       │\n",
        "│ fwd_ret_1d ┆ tabular_dl ┆ tabm_l     ┆ epoch     ┆ 50        ┆ 0.006267  ┆ 0.924793  ┆ 01e41111c │\n",
        "│            ┆            ┆            ┆           ┆           ┆           ┆           ┆ b52       │\n",
-       "│ fwd_ret_21 ┆ deep_learn ┆ nlinear    ┆ epoch     ┆ 5         ┆ 0.036     ┆ 0.831955  ┆ 06c0a15b6 │\n",
-       "│ d          ┆ ing        ┆            ┆           ┆           ┆           ┆           ┆ ba1       │\n",
+       "│ fwd_ret_21 ┆ deep_learn ┆ nlinear    ┆ epoch     ┆ 5         ┆ 0.036     ┆ 0.831955  ┆ 13e7a9530 │\n",
+       "│ d          ┆ ing        ┆            ┆           ┆           ┆           ┆           ┆ 29c       │\n",
        "│ …          ┆ …          ┆ …          ┆ …         ┆ …         ┆ …         ┆ …         ┆ …         │\n",
-       "│ fwd_ret_21 ┆ tabular_dl ┆ tabm_l     ┆ epoch     ┆ 25        ┆ 0.004256  ┆ 0.113015  ┆ 4bc7c8767 │\n",
-       "│ d          ┆            ┆            ┆           ┆           ┆           ┆           ┆ ceb       │\n",
+       "│ fwd_ret_21 ┆ tabular_dl ┆ tabm_l     ┆ epoch     ┆ 25        ┆ 0.004256  ┆ 0.113015  ┆ c304a4d52 │\n",
+       "│ d          ┆            ┆            ┆           ┆           ┆           ┆           ┆ bad       │\n",
        "│ fwd_ret_5d ┆ deep_learn ┆ nlinear    ┆ epoch     ┆ 5         ┆ 0.028685  ┆ 1.272266  ┆ b633f307a │\n",
        "│            ┆ ing        ┆            ┆           ┆           ┆           ┆           ┆ 008       │\n",
        "│ fwd_ret_5d ┆ gbm        ┆ leaves_7_h ┆ iteration ┆ 50        ┆ 0.006415  ┆ 0.442424  ┆ d4d6d17e5 │\n",
        "│            ┆            ┆ uber       ┆           ┆           ┆           ┆           ┆ 918       │\n",
        "│ fwd_ret_5d ┆ linear     ┆ enet_f0.85 ┆ final     ┆ null      ┆ 0.02817   ┆ 1.177314  ┆ 88100a79d │\n",
        "│            ┆            ┆            ┆           ┆           ┆           ┆           ┆ 70a       │\n",
-       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m     ┆ epoch     ┆ 25        ┆ -0.002766 ┆ -0.216356 ┆ 296531884 │\n",
-       "│            ┆            ┆            ┆           ┆           ┆           ┆           ┆ fa8       │\n",
+       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m     ┆ epoch     ┆ 25        ┆ -0.002766 ┆ -0.216356 ┆ 569a0fe11 │\n",
+       "│            ┆            ┆            ┆           ┆           ┆           ┆           ┆ b53       │\n",
        "└────────────┴────────────┴────────────┴───────────┴───────────┴───────────┴───────────┴───────────┘"
       ]
      },
@@ -467,19 +477,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4badfdb5",
+   "id": "4701f263",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:42.931533Z",
-     "iopub.status.busy": "2026-08-27T22:48:42.931414Z",
-     "iopub.status.idle": "2026-08-27T22:48:46.038275Z",
-     "shell.execute_reply": "2026-08-27T22:48:46.034760Z"
+     "iopub.execute_input": "2026-08-28T00:29:41.690226Z",
+     "iopub.status.busy": "2026-08-28T00:29:41.690120Z",
+     "iopub.status.idle": "2026-08-28T00:29:43.868697Z",
+     "shell.execute_reply": "2026-08-28T00:29:43.868455Z"
     },
     "papermill": {
-     "duration": 3.11835,
-     "end_time": "2026-08-27T22:48:46.046890+00:00",
+     "duration": 2.181671,
+     "end_time": "2026-08-28T00:29:43.869692+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:42.928540+00:00",
+     "start_time": "2026-08-28T00:29:41.688021+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2372,1045 +2382,6 @@
         {
          "customdata": [
           [
-           "tcn",
-           "07b8a18fe50d"
-          ],
-          [
-           "nlinear",
-           "08c1793f150c"
-          ],
-          [
-           "tcn",
-           "08c36c3fe567"
-          ],
-          [
-           "nlinear",
-           "099830b9220a"
-          ],
-          [
-           "nlinear",
-           "0c5ecb57cb04"
-          ],
-          [
-           "nlinear",
-           "137ba66652ba"
-          ],
-          [
-           "nlinear",
-           "180f452f2f3a"
-          ],
-          [
-           "tcn",
-           "1b2ec5aabb06"
-          ],
-          [
-           "nlinear",
-           "1ff85db25b35"
-          ],
-          [
-           "nlinear",
-           "2250b69be321"
-          ],
-          [
-           "tcn",
-           "2615b6f8c97a"
-          ],
-          [
-           "nlinear",
-           "2bc077ca6525"
-          ],
-          [
-           "tcn",
-           "2c73723e7b1a"
-          ],
-          [
-           "nlinear",
-           "2edd6636d6dd"
-          ],
-          [
-           "nlinear",
-           "31f5b2e84a87"
-          ],
-          [
-           "nlinear",
-           "3703bf6d9994"
-          ],
-          [
-           "tcn",
-           "37340c2725a0"
-          ],
-          [
-           "nlinear",
-           "3e83d15f5d27"
-          ],
-          [
-           "tcn",
-           "43522f80ed91"
-          ],
-          [
-           "nlinear",
-           "43f2b87dac4d"
-          ],
-          [
-           "tcn",
-           "459bfa1461c1"
-          ],
-          [
-           "tcn",
-           "470b8d557dd0"
-          ],
-          [
-           "tcn",
-           "4d2367ac70ab"
-          ],
-          [
-           "nlinear",
-           "51105579b737"
-          ],
-          [
-           "tcn",
-           "5f35f790213d"
-          ],
-          [
-           "tcn",
-           "69fa79e96fc7"
-          ],
-          [
-           "tcn",
-           "6c20b1c4425b"
-          ],
-          [
-           "tcn",
-           "6e3948238126"
-          ],
-          [
-           "nlinear",
-           "6ec12c495c30"
-          ],
-          [
-           "nlinear",
-           "7270fb718ce2"
-          ],
-          [
-           "tcn",
-           "77e1a9455c27"
-          ],
-          [
-           "tcn",
-           "7f7693d8bd1c"
-          ],
-          [
-           "nlinear",
-           "8094f62a5d63"
-          ],
-          [
-           "nlinear",
-           "82bfee8d0001"
-          ],
-          [
-           "nlinear",
-           "8339e8d77b9c"
-          ],
-          [
-           "tcn",
-           "84267c7c7ae8"
-          ],
-          [
-           "nlinear",
-           "8616c23695aa"
-          ],
-          [
-           "nlinear",
-           "86fa4d8ba001"
-          ],
-          [
-           "tcn",
-           "8f5e87c1d33b"
-          ],
-          [
-           "nlinear",
-           "904517246200"
-          ],
-          [
-           "tcn",
-           "9147da8a25db"
-          ],
-          [
-           "nlinear",
-           "91d4cfd80647"
-          ],
-          [
-           "nlinear",
-           "95feb55bab05"
-          ],
-          [
-           "tcn",
-           "9a60d60d66b0"
-          ],
-          [
-           "nlinear",
-           "9b087ae86c0e"
-          ],
-          [
-           "tcn",
-           "a19bdfb7ab7b"
-          ],
-          [
-           "tcn",
-           "a4983cc62b3a"
-          ],
-          [
-           "tcn",
-           "a8c39748504c"
-          ],
-          [
-           "tcn",
-           "aa75ceaa52eb"
-          ],
-          [
-           "tcn",
-           "ac24d9d2eb59"
-          ],
-          [
-           "tcn",
-           "b0838ace5775"
-          ],
-          [
-           "tcn",
-           "b21fdb0bc5d7"
-          ],
-          [
-           "nlinear",
-           "b633f307a008"
-          ],
-          [
-           "nlinear",
-           "b6bd7b1dcd28"
-          ],
-          [
-           "tcn",
-           "bade0af9eee5"
-          ],
-          [
-           "tcn",
-           "bee83a0cdd11"
-          ],
-          [
-           "tcn",
-           "bfaa3c6d7711"
-          ],
-          [
-           "nlinear",
-           "bfe479a48c09"
-          ],
-          [
-           "nlinear",
-           "c173547b1078"
-          ],
-          [
-           "tcn",
-           "c612f22c7ef0"
-          ],
-          [
-           "nlinear",
-           "c8ab71e5e803"
-          ],
-          [
-           "nlinear",
-           "cb49499d985f"
-          ],
-          [
-           "nlinear",
-           "cba7f1e37e22"
-          ],
-          [
-           "tcn",
-           "cd3fb81fa7ba"
-          ],
-          [
-           "nlinear",
-           "cd6ad3eb3b59"
-          ],
-          [
-           "tcn",
-           "d27dee2c92ee"
-          ],
-          [
-           "nlinear",
-           "d504ebbba71c"
-          ],
-          [
-           "tcn",
-           "dbb2fd9c161c"
-          ],
-          [
-           "tcn",
-           "dc1d607199d4"
-          ],
-          [
-           "tcn",
-           "dce16540e18d"
-          ],
-          [
-           "tcn",
-           "dd82a89a22be"
-          ],
-          [
-           "nlinear",
-           "e1d4c693930a"
-          ],
-          [
-           "nlinear",
-           "e57a91e2baca"
-          ],
-          [
-           "nlinear",
-           "eb4763837c04"
-          ],
-          [
-           "tcn",
-           "f44e4e048c5b"
-          ],
-          [
-           "nlinear",
-           "f45a491a037d"
-          ],
-          [
-           "nlinear",
-           "f611d3f59370"
-          ],
-          [
-           "tcn",
-           "fa944f5393a4"
-          ],
-          [
-           "nlinear",
-           "fb5e75c35793"
-          ],
-          [
-           "tcn",
-           "fe894845dfc6"
-          ]
-         ],
-         "hovertemplate": "family=deep_learning<br>label=fwd_ret_5d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
-         "legendgroup": "deep_learning",
-         "marker": {
-          "color": "#D4A84B",
-          "symbol": "circle"
-         },
-         "mode": "markers",
-         "name": "deep_learning",
-         "orientation": "v",
-         "showlegend": true,
-         "type": "scatter",
-         "x": {
-          "bdata": "PEZGVVAZZDxLIyg3BQ83HksyHhRfCmQZVV8UBV9aQShBQVVQClAZMhkUPDJfNw9QLSMPMgVkWh4KPCMUBShaSy1aS0ZkIzdGDygtCh5BLVU=",
-          "dtype": "i1"
-         },
-         "xaxis": "x3",
-         "y": {
-          "bdata": "jKZQceBfYz9XZT1vIFqJP4AATwmKbEa/mePrhxy3hT/8Ozd0hqiKP1DXqeYRZJE/3syxNMn0hj+MplBx4F9jP7zfsMtohoY/8Ocx1aeNkD8GMxUTIbZ0P7yZ7626zIk/UG5RNaylhj+6pqBj7gyQP7yZ7626zIk/cAq7itK2kD/U4C7WyrBmP6x7nyZHgoc/6D0jMLu5dz+5RJpWwHCQPyRTIhMQvmc/phDh+b5zcD888ZJLj8pkP1DXqeYRZJE/uGaTKa22Xz8kUyITEL5nP0DvFTr3myg/UG5RNaylhj9fE1U8x1KHPyEijqw0Dog/INi5JlVUXT8GMxUTIbZ0P0rIBmA+DYs/SsgGYD4Niz+Z4+uHHLeFP0iWnWcW5Gs/UrYDvfYMlz/8Ozd0hqiKP3oiyBf8Hoc/rHufJkeChz96IsgX/B6HP7lEmlbAcJA/2ZJSIuDPjj+g1LbrCQVAv18TVTzHUoc/8HphMWgJST8YtdTLmapxv0iWnWcW5Gs/IAlm0UpvZz+glK+h4Dh1Pxi11MuZqnG/oNS26wkFQL/m5KuNs1+dP97MsTTJ9IY/gqNIcOXOcT/oPSMwu7l3P6YQ4fm+c3A/2ZJSIuDPjj/w5zHVp42QP0DvFTr3myg/5uSrjbNfnT+OYikdVzyQPyEijqw0Dog/1OAu1sqwZj+f6dCL1zyPP4KjSHDlznE/vN+wy2iGhj+AAE8JimxGvzzxkkuPymQ/oJSvoeA4dT/wemExaAlJP1dlPW8gWok/uqagY+4MkD+OYikdVzyQPyAJZtFKb2c/UrYDvfYMlz9wCruK0raQPyDYuSZVVF0/n+nQi9c8jz+4ZpMprbZfPw==",
-          "dtype": "f8"
-         },
-         "yaxis": "y3"
-        },
-        {
-         "customdata": [
-          [
-           "tcn",
-           "061c48cba0af"
-          ],
-          [
-           "tcn",
-           "09e637b1367d"
-          ],
-          [
-           "nlinear",
-           "0d64b7f76c53"
-          ],
-          [
-           "tcn",
-           "0e09ad7012f0"
-          ],
-          [
-           "nlinear",
-           "0f1f4d8369cf"
-          ],
-          [
-           "tcn",
-           "146688ac9729"
-          ],
-          [
-           "tcn",
-           "1735e06d14a5"
-          ],
-          [
-           "tcn",
-           "1bfe3ca0ab9f"
-          ],
-          [
-           "tcn",
-           "1ca34d4c3521"
-          ],
-          [
-           "nlinear",
-           "1df5922d71dc"
-          ],
-          [
-           "tcn",
-           "1ecf09d44418"
-          ],
-          [
-           "tcn",
-           "226aa3b6d511"
-          ],
-          [
-           "nlinear",
-           "229ca64d6559"
-          ],
-          [
-           "tcn",
-           "250023ae3c2c"
-          ],
-          [
-           "nlinear",
-           "26150ab0d3db"
-          ],
-          [
-           "tcn",
-           "328dc100d623"
-          ],
-          [
-           "nlinear",
-           "374d4b6dac88"
-          ],
-          [
-           "tcn",
-           "3f5140df6f3a"
-          ],
-          [
-           "nlinear",
-           "4275cf4de4df"
-          ],
-          [
-           "nlinear",
-           "42bac90eb84f"
-          ],
-          [
-           "nlinear",
-           "4527ba6e1999"
-          ],
-          [
-           "tcn",
-           "491bcd4aec32"
-          ],
-          [
-           "tcn",
-           "508009e4b13c"
-          ],
-          [
-           "tcn",
-           "5217ba2eace4"
-          ],
-          [
-           "nlinear",
-           "52b3c75f2233"
-          ],
-          [
-           "tcn",
-           "553a16f75df2"
-          ],
-          [
-           "nlinear",
-           "60890d86e995"
-          ],
-          [
-           "nlinear",
-           "6592a5d6818e"
-          ],
-          [
-           "tcn",
-           "689e938f32ee"
-          ],
-          [
-           "nlinear",
-           "6c64f8e4cfac"
-          ],
-          [
-           "nlinear",
-           "6e36a7769504"
-          ],
-          [
-           "nlinear",
-           "70cc489e40cd"
-          ],
-          [
-           "nlinear",
-           "713c122629b7"
-          ],
-          [
-           "nlinear",
-           "75cea3f31396"
-          ],
-          [
-           "tcn",
-           "79675756b126"
-          ],
-          [
-           "nlinear",
-           "7c01c896ff2e"
-          ],
-          [
-           "tcn",
-           "83073960140a"
-          ],
-          [
-           "nlinear",
-           "877444aa5fcc"
-          ],
-          [
-           "tcn",
-           "87af1b9469f9"
-          ],
-          [
-           "tcn",
-           "87b363a55c1c"
-          ],
-          [
-           "tcn",
-           "936160c55853"
-          ],
-          [
-           "nlinear",
-           "94f4c2cbfae1"
-          ],
-          [
-           "tcn",
-           "950fa67797e3"
-          ],
-          [
-           "nlinear",
-           "956369950739"
-          ],
-          [
-           "tcn",
-           "973e89eb9473"
-          ],
-          [
-           "tcn",
-           "980367164d99"
-          ],
-          [
-           "tcn",
-           "9aa9ee2298b6"
-          ],
-          [
-           "nlinear",
-           "9ae1a530e544"
-          ],
-          [
-           "nlinear",
-           "9b573180b922"
-          ],
-          [
-           "nlinear",
-           "9eae73b86751"
-          ],
-          [
-           "nlinear",
-           "9eb5dd8577d1"
-          ],
-          [
-           "nlinear",
-           "a874939e7340"
-          ],
-          [
-           "tcn",
-           "a8e75f308c9b"
-          ],
-          [
-           "nlinear",
-           "aa43ef1d95c3"
-          ],
-          [
-           "nlinear",
-           "b0b5332ebe74"
-          ],
-          [
-           "nlinear",
-           "b6d23d360f6b"
-          ],
-          [
-           "nlinear",
-           "b99c43130c83"
-          ],
-          [
-           "nlinear",
-           "bede763a2379"
-          ],
-          [
-           "tcn",
-           "c39e794fa85e"
-          ],
-          [
-           "nlinear",
-           "c743542f9212"
-          ],
-          [
-           "nlinear",
-           "c8d9e5fd64e2"
-          ],
-          [
-           "nlinear",
-           "cce75c9f66e7"
-          ],
-          [
-           "tcn",
-           "cfb01a246e7a"
-          ],
-          [
-           "nlinear",
-           "d0a5b71839cb"
-          ],
-          [
-           "tcn",
-           "d2ca9d9b82a8"
-          ],
-          [
-           "tcn",
-           "d72a90e17a17"
-          ],
-          [
-           "tcn",
-           "d80638423af7"
-          ],
-          [
-           "tcn",
-           "ded557132a39"
-          ],
-          [
-           "tcn",
-           "dfcbe641a413"
-          ],
-          [
-           "nlinear",
-           "e1758e23e11f"
-          ],
-          [
-           "tcn",
-           "e384cfd815f4"
-          ],
-          [
-           "tcn",
-           "e3a2872552f3"
-          ],
-          [
-           "tcn",
-           "e76bc5774817"
-          ],
-          [
-           "nlinear",
-           "eb398d700b38"
-          ],
-          [
-           "nlinear",
-           "edc6f83b8b56"
-          ],
-          [
-           "tcn",
-           "f5002a998788"
-          ],
-          [
-           "tcn",
-           "f5c81bef99e8"
-          ],
-          [
-           "tcn",
-           "f68c9e74fc5f"
-          ],
-          [
-           "nlinear",
-           "f98e3dcf45aa"
-          ],
-          [
-           "nlinear",
-           "fabd321a6235"
-          ]
-         ],
-         "hovertemplate": "family=deep_learning<br>label=fwd_ret_1d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
-         "legendgroup": "deep_learning",
-         "marker": {
-          "color": "#D4A84B",
-          "symbol": "circle"
-         },
-         "mode": "markers",
-         "name": "deep_learning",
-         "orientation": "v",
-         "showlegend": false,
-         "type": "scatter",
-         "x": {
-          "bdata": "N0EyI1oyWjwKGR4PMigKZF8jHks3GUYeIy0tRgUoQQ9QS2RBCmRVX0ZQVS1LKF9aDxQFGRQjZDxfPFAFVQoZHjwtBUFLRjJaFDcoN1APFFU=",
-          "dtype": "i1"
-         },
-         "xaxis": "x2",
-         "y": {
-          "bdata": "PThYiI1Xaz/2b0yC1BFRP5pw0cPc+IU/Ujm6w67DhT+N+solIaOBP5AKgDSBvnQ/UE3h9v9bK7/SzCg5fWdwP1JUUsGdzo4/TnSXjUSxiT9VfrBM46N/Py2S8Es3mI8/mnDRw9z4hT9orXLui9t/P2aMo0quuo0/395f+xQaUz+cLZlvi/SFP1I5usOuw4U/1uaAJTkajT8bD/s0mbqKPwieUNVrNYc/VsXx3s2Mij8mFCqNNjhrP1V+sEzjo38/RUOaM2w2gz8O1ZoE1tFuP0p0bWUBp4I/+EnMwblThj9m3HgGRfCUP3gV3nZei4g/QURRYAyVhj8+GD3vyAOMP2wlgI0NjYM/Gw/7NJm6ij/f3l/7FBpTP0FEUWAMlYY/UlRSwZ3Ojj+oIrTki5mEP/7DAEJoCk4/r9e6UfGqUj8mFCqNNjhrP2wlgI0NjYM//sMAQmgKTj9KdG1lAaeCPzCsSkQhb3Y/aK1y7ovbfz+v17pR8apSP436yiUho4E/Phg978gDjD9Kpo4ckfuHP0AIPxqBPos/TnSXjUSxiT+7ocZ50/B/P0VDmjNsNoM/qCK05IuZhD/ipxM6Bu6KP5wtmW+L9IU/4qcTOgbuij/D8ofYTRZyP0AIPxqBPos/e15vJitShD9mjKNKrrqNP1bF8d7NjIo/1uaAJTkajT/SzCg5fWdwPw7VmgTW0W4/Ztx4BkXwlD/2b0yC1BFRPzCsSkQhb3Y/+EnMwblThj+QCoA0gb50P1BN4fb/Wyu/u6HGedPwfz8InlDVazWHP3gV3nZei4g/PThYiI1Xaz/D8ofYTRZyPy2S8Es3mI8/SqaOHJH7hz97Xm8mK1KEPw==",
-          "dtype": "f8"
-         },
-         "yaxis": "y2"
-        },
-        {
-         "customdata": [
-          [
-           "nlinear",
-           "00fa4eb1ccae"
-          ],
-          [
-           "nlinear",
-           "05318f27e435"
-          ],
-          [
-           "nlinear",
-           "06c0a15b6ba1"
-          ],
-          [
-           "nlinear",
-           "087a97de1aad"
-          ],
-          [
-           "tcn",
-           "09af2aa4d331"
-          ],
-          [
-           "nlinear",
-           "0b07de75f336"
-          ],
-          [
-           "tcn",
-           "0b136616f67f"
-          ],
-          [
-           "tcn",
-           "0d89e27bb00b"
-          ],
-          [
-           "tcn",
-           "10c2d36d730b"
-          ],
-          [
-           "nlinear",
-           "11fcb21a6448"
-          ],
-          [
-           "nlinear",
-           "13e7a953029c"
-          ],
-          [
-           "tcn",
-           "14626096da82"
-          ],
-          [
-           "tcn",
-           "15bba93eb815"
-          ],
-          [
-           "nlinear",
-           "1e4c800a673c"
-          ],
-          [
-           "nlinear",
-           "1f8584891a23"
-          ],
-          [
-           "nlinear",
-           "26b49ad197f8"
-          ],
-          [
-           "tcn",
-           "2f34da7f672a"
-          ],
-          [
-           "nlinear",
-           "32012965e8f6"
-          ],
-          [
-           "nlinear",
-           "3452e8782f66"
-          ],
-          [
-           "tcn",
-           "34bed18d26df"
-          ],
-          [
-           "nlinear",
-           "366065a3b525"
-          ],
-          [
-           "nlinear",
-           "396023cf3e7f"
-          ],
-          [
-           "nlinear",
-           "398015f662b9"
-          ],
-          [
-           "tcn",
-           "3f5a97f024c9"
-          ],
-          [
-           "tcn",
-           "41d60c63291e"
-          ],
-          [
-           "tcn",
-           "4846982b5587"
-          ],
-          [
-           "tcn",
-           "4b40ea1ef97b"
-          ],
-          [
-           "tcn",
-           "4d1d04437e3b"
-          ],
-          [
-           "tcn",
-           "4ef2adc607fc"
-          ],
-          [
-           "tcn",
-           "537ad61c7a52"
-          ],
-          [
-           "tcn",
-           "57362a6b5c93"
-          ],
-          [
-           "tcn",
-           "58859462ef8c"
-          ],
-          [
-           "tcn",
-           "6019fc10f8ab"
-          ],
-          [
-           "tcn",
-           "6ad59dafc0cb"
-          ],
-          [
-           "tcn",
-           "75e75cdc62e8"
-          ],
-          [
-           "nlinear",
-           "7981a0939711"
-          ],
-          [
-           "tcn",
-           "7b3f32f19652"
-          ],
-          [
-           "tcn",
-           "7d59002e420b"
-          ],
-          [
-           "nlinear",
-           "8083d01f217b"
-          ],
-          [
-           "tcn",
-           "8107d4fbb264"
-          ],
-          [
-           "nlinear",
-           "8a977d22978e"
-          ],
-          [
-           "nlinear",
-           "8ca1a08b1259"
-          ],
-          [
-           "tcn",
-           "932331b928f7"
-          ],
-          [
-           "tcn",
-           "9411678d4798"
-          ],
-          [
-           "tcn",
-           "987c0c12e22e"
-          ],
-          [
-           "nlinear",
-           "9c247c0f3ef7"
-          ],
-          [
-           "nlinear",
-           "9c5f5e2313e6"
-          ],
-          [
-           "nlinear",
-           "a01b8e79d042"
-          ],
-          [
-           "nlinear",
-           "a1bab7be0875"
-          ],
-          [
-           "nlinear",
-           "a1e817bb3b47"
-          ],
-          [
-           "nlinear",
-           "a7231ae62bd7"
-          ],
-          [
-           "nlinear",
-           "aa2d7f8dafff"
-          ],
-          [
-           "nlinear",
-           "acc260220e36"
-          ],
-          [
-           "nlinear",
-           "ad386a47ae0d"
-          ],
-          [
-           "tcn",
-           "ad90fd55b1de"
-          ],
-          [
-           "tcn",
-           "b1fd1f7e612f"
-          ],
-          [
-           "nlinear",
-           "b608db0adcb6"
-          ],
-          [
-           "tcn",
-           "bb029785e066"
-          ],
-          [
-           "nlinear",
-           "bb3084f336ba"
-          ],
-          [
-           "nlinear",
-           "bc73308fb227"
-          ],
-          [
-           "tcn",
-           "bf1daf57a1d7"
-          ],
-          [
-           "nlinear",
-           "c0de2e8614c5"
-          ],
-          [
-           "tcn",
-           "c14b3c3143c8"
-          ],
-          [
-           "tcn",
-           "c55369379c1f"
-          ],
-          [
-           "tcn",
-           "caa5fba07a29"
-          ],
-          [
-           "nlinear",
-           "cddabea21a40"
-          ],
-          [
-           "tcn",
-           "cf1d53443d50"
-          ],
-          [
-           "tcn",
-           "d1c531cae20f"
-          ],
-          [
-           "tcn",
-           "d7d79a80d4b2"
-          ],
-          [
-           "tcn",
-           "e2c722e99d23"
-          ],
-          [
-           "tcn",
-           "e2f518282dfc"
-          ],
-          [
-           "nlinear",
-           "e37384f7beda"
-          ],
-          [
-           "nlinear",
-           "e50eafc4affd"
-          ],
-          [
-           "tcn",
-           "e63aab6dcd6d"
-          ],
-          [
-           "nlinear",
-           "e8309fb9f99c"
-          ],
-          [
-           "nlinear",
-           "e905ecfc2ca6"
-          ],
-          [
-           "nlinear",
-           "ecfec0200374"
-          ],
-          [
-           "nlinear",
-           "ee022c54d6f3"
-          ],
-          [
-           "nlinear",
-           "fd476b096f2e"
-          ],
-          [
-           "tcn",
-           "febf08341fb3"
-          ]
-         ],
-         "hovertemplate": "family=deep_learning<br>label=fwd_ret_21d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
-         "legendgroup": "deep_learning",
-         "marker": {
-          "color": "#D4A84B",
-          "symbol": "circle"
-         },
-         "mode": "markers",
-         "name": "deep_learning",
-         "orientation": "v",
-         "showlegend": false,
-         "type": "scatter",
-         "x": {
-          "bdata": "QSMFLShGGUYKDwUyPCgjVWQeVTIeXw9LKDc3BVpQRlA8WlVQFEEyLVBLDxkUFAo8WjdBGWQtXyMoHmRGVTweZA8KSwotQQVLXyMyGTcUWl8=",
-          "dtype": "i1"
-         },
-         "xaxis": "x",
-         "y": {
-          "bdata": "hm9nxXXRgD8csBYLWvONP5YReLCObqI/nOv53Yo1hj/em31js6WCv3pYRCXOyYU/VPQb1RMDlT8CTt/4fWFwP0TQ/acmL3+/Etpc8WZ4kz+WEXiwjm6iPyZZCAh9YIa/9KOlue13VD/+b1OiOKqKPxywFgta840/Jc/AhiKffD8CZXtDQPBpP+lMswEmY4E/Jc/AhiKffD8mWQgIfWCGv+lMswEmY4E/1htTjUcZeT8S2lzxZniTPyT9ql5dCGU/3pt9Y7Olgr8UmFfkfW5xPxSYV+R9bnE/OHfq55ttYL82g6oz1QdsP2MhdrJPL3M/Ak7f+H1hcD9jIXayTy9zP/Sjpbntd1Q/NoOqM9UHbD+6atRCZddhP/rYV1U5eoA/NSB3MLlAjD94/CUn7JFUPz/PZKfIBZE/Zoj3BNMgaj/62FdVOXqAPy5YVVLkXX0/Dng4NraRir9U9BvVEwOVPzUgdzC5QIw/BB1RAw6Jiz/axRetbpqbP8IidI4HKIo/iu19Zt+uej+sqRB0vsqHP4ZvZ8V10YA/M0Q1Y+ubjD/YfpcHly16P5zr+d2KNYY/kGOCS5FQaj92FAlwo353v/5vU6I4qoo/ZN9CO4tVbT/YfpcHly16P3pYRCXOyYU/umrUQmXXYT/CInSOByiKP2TfQjuLVW0/AmV7Q0DwaT8OeDg2tpGKv9rFF61umps/JP2qXl0IZT9E0P2nJi9/v2aI9wTTIGo/ePwlJ+yRVD84d+rnm21gvy5YVVLkXX0/1htTjUcZeT92FAlwo353vz/PZKfIBZE/M0Q1Y+ubjD+sqRB0vsqHPwQdUQMOiYs/iu19Zt+uej+QY4JLkVBqPw==",
-          "dtype": "f8"
-         },
-         "yaxis": "y"
-        },
-        {
-         "customdata": [
-          [
-           "tabm_s",
-           "039c56702e88"
-          ],
-          [
            "tabm_s",
            "0751d64738ae"
           ],
@@ -3419,24 +2390,8 @@
            "175e368f24ac"
           ],
           [
-           "tabm_s",
-           "190a7323d12d"
-          ],
-          [
            "tabm_l",
            "27299bbaf8e2"
-          ],
-          [
-           "tabm_m",
-           "2933ba7608b4"
-          ],
-          [
-           "tabm_m",
-           "296531884fa8"
-          ],
-          [
-           "tabm_m",
-           "379d19e4076e"
           ],
           [
            "tabm_l",
@@ -3447,16 +2402,8 @@
            "476f80064e19"
           ],
           [
-           "tabm_l",
-           "5460c20a48af"
-          ],
-          [
            "tabm_m",
            "569a0fe11b53"
-          ],
-          [
-           "tabm_l",
-           "5bf669f0477f"
           ],
           [
            "tabm_s",
@@ -3480,35 +2427,7 @@
           ],
           [
            "tabm_l",
-           "6c7742c4fcf5"
-          ],
-          [
-           "tabm_l",
            "76eab3c90083"
-          ],
-          [
-           "tabm_m",
-           "77913779a019"
-          ],
-          [
-           "tabm_s",
-           "7d0f251f9e43"
-          ],
-          [
-           "tabm_s",
-           "81b2bf5b42b3"
-          ],
-          [
-           "tabm_l",
-           "8425d83d9ed1"
-          ],
-          [
-           "tabm_m",
-           "8535cbc572bc"
-          ],
-          [
-           "tabm_l",
-           "89e8c1d3686e"
           ],
           [
            "tabm_l",
@@ -3523,20 +2442,12 @@
            "99ead019d123"
           ],
           [
-           "tabm_m",
-           "9a18349b8d05"
-          ],
-          [
            "tabm_l",
            "9e2a3febe641"
           ],
           [
            "tabm_m",
            "a6a295aa015d"
-          ],
-          [
-           "tabm_s",
-           "a7dd3a9eeabd"
           ],
           [
            "tabm_m",
@@ -3555,44 +2466,12 @@
            "bb1026298f19"
           ],
           [
-           "tabm_l",
-           "bc1d520ad5a3"
-          ],
-          [
-           "tabm_l",
-           "bf2448d952ed"
-          ],
-          [
-           "tabm_l",
-           "c876815cd0fe"
-          ],
-          [
-           "tabm_s",
-           "cd71d7928080"
-          ],
-          [
-           "tabm_s",
-           "cf3081172f30"
-          ],
-          [
-           "tabm_m",
-           "d1270f676cb3"
-          ],
-          [
            "tabm_m",
            "e04ae5200c10"
           ],
           [
            "tabm_s",
            "e3b8515c7373"
-          ],
-          [
-           "tabm_m",
-           "ed6435fa0f31"
-          ],
-          [
-           "tabm_s",
-           "f1b4afbfdfdf"
           ],
           [
            "tabm_s",
@@ -3602,7 +2481,7 @@
          "hovertemplate": "family=tabular_dl<br>label=fwd_ret_5d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
          "legendgroup": "tabular_dl",
          "marker": {
-          "color": "#C87533",
+          "color": "#D4A84B",
           "symbol": "circle"
          },
          "mode": "markers",
@@ -3611,12 +2490,12 @@
          "showlegend": true,
          "type": "scatter",
          "x": {
-          "bdata": "yABkAK8AfQAZAMgAGQBkAJYAZAAZABkAfQDIAMgAfQBLAMgASwCvAK8AZACvADIAfQCWAH0AMgCWAJYAMgB9AJYAMgBLAJYASwBkAK8AyAAZADIASwBkABkAMgBLAK8A",
+          "bdata": "ZACvABkAlgBkABkAyADIAH0ASwDIAK8AfQAyAJYAMgB9ADIASwCWAEsAZAAZAK8A",
           "dtype": "i2"
          },
          "xaxis": "x3",
          "y": {
-          "bdata": "c3mZ0QtSjr+OwxgffHKIv8ANaZz784G/AmpsPLpEiL8cBFhrw3iOv6pYYIJfA4O/yKgYFvinZr/Rrv18CM2Bv1j0orT7mHO/kiHvNG6Gdr8cBFhrw3iOv8ioGBb4p2a/uZAQv972db9zeZnRC1KOv6pYYIJfA4O/AmpsPLpEiL9OKTg66kyBv5aK1qqwB3e/x7W5Bkznfr8ym0kGMZJ0v8ANaZz784G/jsMYH3xyiL/sGNkBjAGOv0JJ8X4yo4W/WmmAiUb8gr9Y9KK0+5hzv7mQEL/e9nW/5agg+Wl/kr9s0q4bzGyBv2zSrhvMbIG/QknxfjKjhb9aaYCJRvyCvz0YwzLhH4q/XP4/R7gCkb9AOZmQR8qDvz0YwzLhH4q/x7W5Bkznfr+SIe80boZ2vzKbSQYxknS/lorWqrAHd78mJHa4XeOdv+WoIPlpf5K/Tik4OupMgb/Rrv18CM2BvyYkdrhd452/XP4/R7gCkb9AOZmQR8qDv+wY2QGMAY6/",
+          "bdata": "jsMYH3xyiL/ADWmc+/OBvxwEWGvDeI6/WPSitPuYc7+SIe80boZ2v8ioGBb4p2a/c3mZ0QtSjr+qWGCCXwODvwJqbDy6RIi/Tik4OupMgb+WitaqsAd3vzKbSQYxknS/uZAQv972db/lqCD5aX+Sv2zSrhvMbIG/QknxfjKjhb9aaYCJRvyCv1z+P0e4ApG/QDmZkEfKg789GMMy4R+Kv8e1uQZM536/0a79fAjNgb8mJHa4XeOdv+wY2QGMAY6/",
           "dtype": "f8"
          },
          "yaxis": "y3"
@@ -3636,32 +2515,12 @@
            "0db3df56555a"
           ],
           [
-           "tabm_m",
-           "0e4715bd4124"
-          ],
-          [
            "tabm_l",
            "152d5912e21c"
           ],
           [
-           "tabm_s",
-           "18cee173f0dc"
-          ],
-          [
-           "tabm_l",
-           "191e1c0ac0ee"
-          ],
-          [
-           "tabm_s",
-           "1b1c46b08acd"
-          ],
-          [
            "tabm_l",
            "1c3e7bdc5b3e"
-          ],
-          [
-           "tabm_s",
-           "243c981790e5"
           ],
           [
            "tabm_s",
@@ -3689,31 +2548,11 @@
           ],
           [
            "tabm_m",
-           "632ebc1b55f7"
-          ],
-          [
-           "tabm_m",
            "74caf4e0882f"
           ],
           [
            "tabm_s",
            "7931492d800a"
-          ],
-          [
-           "tabm_s",
-           "7bfe5132ffdf"
-          ],
-          [
-           "tabm_m",
-           "7ccb0f230d93"
-          ],
-          [
-           "tabm_l",
-           "83b706ea3f17"
-          ],
-          [
-           "tabm_s",
-           "8434e36f15b3"
           ],
           [
            "tabm_s",
@@ -3729,39 +2568,7 @@
           ],
           [
            "tabm_s",
-           "91868fa741e6"
-          ],
-          [
-           "tabm_s",
-           "925f6d9f4f6c"
-          ],
-          [
-           "tabm_m",
-           "93f76376a374"
-          ],
-          [
-           "tabm_l",
-           "9deaf63b1d24"
-          ],
-          [
-           "tabm_m",
-           "ab743e71ea91"
-          ],
-          [
-           "tabm_s",
            "b5507955b48b"
-          ],
-          [
-           "tabm_l",
-           "b5ca1d52162e"
-          ],
-          [
-           "tabm_m",
-           "b5f24cda9f4e"
-          ],
-          [
-           "tabm_m",
-           "c0916005367b"
           ],
           [
            "tabm_s",
@@ -3780,22 +2587,6 @@
            "d48cef8f4592"
           ],
           [
-           "tabm_l",
-           "d937c16f7118"
-          ],
-          [
-           "tabm_l",
-           "dd43f6cf2af2"
-          ],
-          [
-           "tabm_l",
-           "e1e57ac87164"
-          ],
-          [
-           "tabm_m",
-           "efc89add3be1"
-          ],
-          [
            "tabm_m",
            "f2c34763e4d4"
           ],
@@ -3806,20 +2597,12 @@
           [
            "tabm_l",
            "f73ceb4e1a7c"
-          ],
-          [
-           "tabm_l",
-           "f9155c11faba"
-          ],
-          [
-           "tabm_s",
-           "fce2b00758da"
           ]
          ],
          "hovertemplate": "family=tabular_dl<br>label=fwd_ret_1d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
          "legendgroup": "tabular_dl",
          "marker": {
-          "color": "#C87533",
+          "color": "#D4A84B",
           "symbol": "circle"
          },
          "mode": "markers",
@@ -3828,38 +2611,18 @@
          "showlegend": false,
          "type": "scatter",
          "x": {
-          "bdata": "MgAyAMgArwBkAH0AyACWABkAGQBLABkASwBLAGQAlgCWAK8AGQBkADIAZACvAMgAlgCWAEsAyAB9AH0AyAAyAK8AZABLAK8AfQCvAGQAMgCWAEsAGQB9AH0AyAAZADIA",
+          "bdata": "MgAyAMgAZAAZAEsAGQBLAEsAZACWAK8AGQDIAJYAlgAyAK8AfQCvAGQAfQB9AMgA",
           "dtype": "i2"
          },
          "xaxis": "x2",
          "y": {
-          "bdata": "0MGMYNereT/RhDxd6MR0P9Ln6wiX4Gk//OF5omakaT+huJLNRi1xP8lpVB2IaIi/dnAYlNSHcj9S6DnItFmHv+vU4coBhXC/Iiv0KpAAhb91MzZMt/CKv3I8SAMTZnq/o8ygkMQXaD/oEflzcGd4P1p8uhQn/3Q/IAJlP5arbz8dW1Rygy5wP/zheaJmpGk/Iiv0KpAAhb/K7ujgoouJv9GEPF3oxHQ/obiSzUYtcT8AtnvLW6qHv+8Bg9nTN4e/HVtUcoMucD9S6DnItFmHv3UzNky38Iq/7wGD2dM3h79dw8xLdXlxP3RoNSudiXI/0ufrCJfgaT/jrm/DwgOIv/CBQvrCQHI/Wny6FCf/dD/oEflzcGd4PwC2e8tbqoe/yWlUHYhoiL/wgUL6wkByP8ru6OCii4m/0MGMYNereT8gAmU/lqtvP6PMoJDEF2g/cjxIAxNmer9dw8xLdXlxP3RoNSudiXI/dnAYlNSHcj/r1OHKAYVwv+Oub8PCA4i/",
+          "bdata": "0MGMYNereT/RhDxd6MR0P9Ln6wiX4Gk/obiSzUYtcT/r1OHKAYVwv3UzNky38Iq/cjxIAxNmer+jzKCQxBdoP+gR+XNwZ3g/Wny6FCf/dD8gAmU/lqtvP/zheaJmpGk/Iiv0KpAAhb/vAYPZ0zeHvx1bVHKDLnA/Uug5yLRZh7/jrm/DwgOIvwC2e8tbqoe/yWlUHYhoiL/wgUL6wkByP8ru6OCii4m/XcPMS3V5cT90aDUrnYlyP3ZwGJTUh3I/",
           "dtype": "f8"
          },
          "yaxis": "y2"
         },
         {
          "customdata": [
-          [
-           "tabm_s",
-           "02bc2f2f4c71"
-          ],
-          [
-           "tabm_l",
-           "03e9540dbeb8"
-          ],
-          [
-           "tabm_s",
-           "0768a4b2e75d"
-          ],
-          [
-           "tabm_m",
-           "08ae078b3ed3"
-          ],
-          [
-           "tabm_l",
-           "0e43990927ac"
-          ],
           [
            "tabm_m",
            "126553c8df96"
@@ -3873,16 +2636,8 @@
            "24e44f372199"
           ],
           [
-           "tabm_m",
-           "264c191e80ac"
-          ],
-          [
            "tabm_l",
            "2f0b9fbecab2"
-          ],
-          [
-           "tabm_m",
-           "309dce776162"
           ],
           [
            "tabm_s",
@@ -3893,44 +2648,16 @@
            "3e5003a3d150"
           ],
           [
-           "tabm_s",
-           "3fece770eaa2"
-          ],
-          [
            "tabm_m",
            "45992621d777"
-          ],
-          [
-           "tabm_l",
-           "4bc7c8767ceb"
           ],
           [
            "tabm_l",
            "4d49f073b71a"
           ],
           [
-           "tabm_m",
-           "4ff6dbf99b58"
-          ],
-          [
-           "tabm_s",
-           "6094616c52fa"
-          ],
-          [
-           "tabm_l",
-           "615228463a26"
-          ],
-          [
-           "tabm_s",
-           "63e97b45d2a8"
-          ],
-          [
            "tabm_s",
            "67435190e7ce"
-          ],
-          [
-           "tabm_m",
-           "687f19f768f5"
           ],
           [
            "tabm_l",
@@ -3939,10 +2666,6 @@
           [
            "tabm_s",
            "743a42255dba"
-          ],
-          [
-           "tabm_m",
-           "79a7675a9a43"
           ],
           [
            "tabm_s",
@@ -3958,19 +2681,7 @@
           ],
           [
            "tabm_s",
-           "905d8056f74f"
-          ],
-          [
-           "tabm_m",
-           "9270582fdab1"
-          ],
-          [
-           "tabm_s",
            "a0c74388564a"
-          ],
-          [
-           "tabm_m",
-           "a9beee29b7c8"
           ],
           [
            "tabm_s",
@@ -3978,15 +2689,7 @@
           ],
           [
            "tabm_l",
-           "b38b70167a62"
-          ],
-          [
-           "tabm_l",
            "b8aaeb517389"
-          ],
-          [
-           "tabm_s",
-           "baeae58b5d24"
           ],
           [
            "tabm_l",
@@ -3997,24 +2700,8 @@
            "c334338f1e3d"
           ],
           [
-           "tabm_l",
-           "cf86cfd17b07"
-          ],
-          [
-           "tabm_s",
-           "d8636c553442"
-          ],
-          [
-           "tabm_l",
-           "dc71fa146a3d"
-          ],
-          [
            "tabm_m",
            "e85a688ed60e"
-          ],
-          [
-           "tabm_l",
-           "ebda68c5bb3c"
           ],
           [
            "tabm_m",
@@ -4036,7 +2723,7 @@
          "hovertemplate": "family=tabular_dl<br>label=fwd_ret_21d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
          "legendgroup": "tabular_dl",
          "marker": {
-          "color": "#C87533",
+          "color": "#D4A84B",
           "symbol": "circle"
          },
          "mode": "markers",
@@ -4045,12 +2732,567 @@
          "showlegend": false,
          "type": "scatter",
          "x": {
-          "bdata": "SwB9ABkAZACvAH0AGQB9AEsASwCvAJYAlgCvAK8AGQB9ABkAZACWAH0ASwCWAK8AMgB9AMgAyABLADIAyABkADIAGQBLADIAyAAZAGQAMgCWAGQAlgDIADIAyACvAGQA",
+          "bdata": "fQAZAH0ASwCWAJYArwB9AEsArwAyAMgAyABLAGQAGQAyABkAZACWADIAyACvAGQA",
           "dtype": "i2"
          },
          "xaxis": "x",
          "y": {
-          "bdata": "gPp+8ee6hr/48eUTaPRhv/gUSaYMdIe/MKZva+7AWL8QcI+5tQ5iv4CH8eOlCDk/JgsjO/r2dL+aF03PUMaCvyzYNi9ZqnC/wMzM2rY0Yr8wuh+2K+huP8pYIp1YuIe/gMkKjuk3X7/0e0TLG++FvzC6H7Yr6G4/7L3JcN5ucT/48eUTaPRhvyYLIzv69nS/dKEZ23e+gr+AyQqO6Tdfv5oXTc9QxoK/gPp+8ee6hr8IJt8JQhxpPxBwj7m1DmK/FAjZz58Hg7+Ah/HjpQg5PwS9ciNaEoa/AFkMEWkmbD8s2DYvWapwvxQI2c+fB4O/AFkMEWkmbD90oRnbd76Cv4hicxEQ2Gi/+BRJpgx0h7/AzMzatjRivwBfK/zRij2/BL1yI1oShr/svclw3m5xPzCmb2vuwFi/AF8r/NGKPb/KWCKdWLiHvyAN8YyLela/CCbfCUIcaT+QT+fKkPVUv4hicxEQ2Gi/kE/nypD1VL/0e0TLG++FvyAN8YyLela/",
+          "bdata": "gIfx46UIOT8mCyM7+vZ0v5oXTc9QxoK/wMzM2rY0Yr/KWCKdWLiHv4DJCo7pN1+/MLoftivobj/48eUTaPRhv4D6fvHnuoa/EHCPubUOYr8UCNnPnweDvwS9ciNaEoa/AFkMEWkmbD8s2DYvWapwv3ShGdt3voK/+BRJpgx0h78AXyv80Yo9v+y9yXDebnE/MKZva+7AWL8IJt8JQhxpP4hicxEQ2Gi/kE/nypD1VL/0e0TLG++FvyAN8YyLela/",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "customdata": [
+          [
+           "tcn",
+           "07b8a18fe50d"
+          ],
+          [
+           "nlinear",
+           "08c1793f150c"
+          ],
+          [
+           "nlinear",
+           "137ba66652ba"
+          ],
+          [
+           "nlinear",
+           "180f452f2f3a"
+          ],
+          [
+           "nlinear",
+           "2250b69be321"
+          ],
+          [
+           "nlinear",
+           "2bc077ca6525"
+          ],
+          [
+           "tcn",
+           "2c73723e7b1a"
+          ],
+          [
+           "nlinear",
+           "3703bf6d9994"
+          ],
+          [
+           "tcn",
+           "37340c2725a0"
+          ],
+          [
+           "nlinear",
+           "3e83d15f5d27"
+          ],
+          [
+           "nlinear",
+           "43f2b87dac4d"
+          ],
+          [
+           "tcn",
+           "4d2367ac70ab"
+          ],
+          [
+           "tcn",
+           "5f35f790213d"
+          ],
+          [
+           "tcn",
+           "69fa79e96fc7"
+          ],
+          [
+           "nlinear",
+           "7270fb718ce2"
+          ],
+          [
+           "tcn",
+           "7f7693d8bd1c"
+          ],
+          [
+           "nlinear",
+           "8094f62a5d63"
+          ],
+          [
+           "nlinear",
+           "8339e8d77b9c"
+          ],
+          [
+           "nlinear",
+           "86fa4d8ba001"
+          ],
+          [
+           "tcn",
+           "8f5e87c1d33b"
+          ],
+          [
+           "nlinear",
+           "95feb55bab05"
+          ],
+          [
+           "tcn",
+           "9a60d60d66b0"
+          ],
+          [
+           "nlinear",
+           "9b087ae86c0e"
+          ],
+          [
+           "tcn",
+           "a19bdfb7ab7b"
+          ],
+          [
+           "tcn",
+           "a8c39748504c"
+          ],
+          [
+           "tcn",
+           "ac24d9d2eb59"
+          ],
+          [
+           "tcn",
+           "b0838ace5775"
+          ],
+          [
+           "nlinear",
+           "b633f307a008"
+          ],
+          [
+           "tcn",
+           "bade0af9eee5"
+          ],
+          [
+           "tcn",
+           "bee83a0cdd11"
+          ],
+          [
+           "tcn",
+           "bfaa3c6d7711"
+          ],
+          [
+           "tcn",
+           "c612f22c7ef0"
+          ],
+          [
+           "nlinear",
+           "cd6ad3eb3b59"
+          ],
+          [
+           "nlinear",
+           "d504ebbba71c"
+          ],
+          [
+           "tcn",
+           "dbb2fd9c161c"
+          ],
+          [
+           "nlinear",
+           "e57a91e2baca"
+          ],
+          [
+           "nlinear",
+           "eb4763837c04"
+          ],
+          [
+           "tcn",
+           "f44e4e048c5b"
+          ],
+          [
+           "nlinear",
+           "f45a491a037d"
+          ],
+          [
+           "tcn",
+           "fa944f5393a4"
+          ]
+         ],
+         "hovertemplate": "family=deep_learning<br>label=fwd_ret_5d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
+         "legendgroup": "deep_learning",
+         "marker": {
+          "color": "#C87533",
+          "symbol": "circle"
+         },
+         "mode": "markers",
+         "name": "deep_learning",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "scatter",
+         "x": {
+          "bdata": "PEYZZCM3BR5LMhRkVV9aKEFVUBk8Ml83UCMPBVoeChQtS0YPKC0KQQ==",
+          "dtype": "i1"
+         },
+         "xaxis": "x3",
+         "y": {
+          "bdata": "jKZQceBfYz9XZT1vIFqJP1DXqeYRZJE/3syxNMn0hj/w5zHVp42QP7yZ7626zIk/UG5RNaylhj9wCruK0raQP9TgLtbKsGY/rHufJkeChz+5RJpWwHCQPzzxkkuPymQ/uGaTKa22Xz8kUyITEL5nPyEijqw0Dog/BjMVEyG2dD9KyAZgPg2LP5nj64cct4U//Ds3dIaoij96IsgX/B6HP9mSUiLgz44/oNS26wkFQL9fE1U8x1KHP/B6YTFoCUk/SJadZxbkaz+glK+h4Dh1Pxi11MuZqnG/5uSrjbNfnT+Co0hw5c5xP+g9IzC7uXc/phDh+b5zcD9A7xU695soP5/p0IvXPI8/vN+wy2iGhj+AAE8JimxGv7qmoGPuDJA/jmIpHVc8kD8gCWbRSm9nP1K2A732DJc/INi5JlVUXT8=",
+          "dtype": "f8"
+         },
+         "yaxis": "y3"
+        },
+        {
+         "customdata": [
+          [
+           "tcn",
+           "061c48cba0af"
+          ],
+          [
+           "nlinear",
+           "0d64b7f76c53"
+          ],
+          [
+           "tcn",
+           "0e09ad7012f0"
+          ],
+          [
+           "tcn",
+           "146688ac9729"
+          ],
+          [
+           "tcn",
+           "1735e06d14a5"
+          ],
+          [
+           "tcn",
+           "1bfe3ca0ab9f"
+          ],
+          [
+           "tcn",
+           "1ca34d4c3521"
+          ],
+          [
+           "tcn",
+           "1ecf09d44418"
+          ],
+          [
+           "nlinear",
+           "4527ba6e1999"
+          ],
+          [
+           "tcn",
+           "491bcd4aec32"
+          ],
+          [
+           "tcn",
+           "508009e4b13c"
+          ],
+          [
+           "nlinear",
+           "52b3c75f2233"
+          ],
+          [
+           "nlinear",
+           "6c64f8e4cfac"
+          ],
+          [
+           "nlinear",
+           "6e36a7769504"
+          ],
+          [
+           "nlinear",
+           "713c122629b7"
+          ],
+          [
+           "nlinear",
+           "75cea3f31396"
+          ],
+          [
+           "tcn",
+           "79675756b126"
+          ],
+          [
+           "nlinear",
+           "877444aa5fcc"
+          ],
+          [
+           "tcn",
+           "87b363a55c1c"
+          ],
+          [
+           "tcn",
+           "950fa67797e3"
+          ],
+          [
+           "nlinear",
+           "956369950739"
+          ],
+          [
+           "tcn",
+           "973e89eb9473"
+          ],
+          [
+           "tcn",
+           "980367164d99"
+          ],
+          [
+           "nlinear",
+           "9ae1a530e544"
+          ],
+          [
+           "nlinear",
+           "9b573180b922"
+          ],
+          [
+           "nlinear",
+           "a874939e7340"
+          ],
+          [
+           "tcn",
+           "a8e75f308c9b"
+          ],
+          [
+           "nlinear",
+           "b6d23d360f6b"
+          ],
+          [
+           "nlinear",
+           "b99c43130c83"
+          ],
+          [
+           "nlinear",
+           "c743542f9212"
+          ],
+          [
+           "nlinear",
+           "c8d9e5fd64e2"
+          ],
+          [
+           "nlinear",
+           "cce75c9f66e7"
+          ],
+          [
+           "nlinear",
+           "d0a5b71839cb"
+          ],
+          [
+           "tcn",
+           "d72a90e17a17"
+          ],
+          [
+           "tcn",
+           "d80638423af7"
+          ],
+          [
+           "tcn",
+           "ded557132a39"
+          ],
+          [
+           "nlinear",
+           "e1758e23e11f"
+          ],
+          [
+           "tcn",
+           "f5c81bef99e8"
+          ],
+          [
+           "tcn",
+           "f68c9e74fc5f"
+          ],
+          [
+           "nlinear",
+           "f98e3dcf45aa"
+          ]
+         ],
+         "hovertemplate": "family=deep_learning<br>label=fwd_ret_1d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
+         "legendgroup": "deep_learning",
+         "marker": {
+          "color": "#C87533",
+          "symbol": "circle"
+         },
+         "mode": "markers",
+         "name": "deep_learning",
+         "orientation": "v",
+         "showlegend": false,
+         "type": "scatter",
+         "x": {
+          "bdata": "NzIjMlo8Ch43GUYjKEFQS2RkX1UtSyhaDxkUPF8FVQoeLQVBRlAPFA==",
+          "dtype": "i1"
+         },
+         "xaxis": "x2",
+         "y": {
+          "bdata": "PThYiI1Xaz+acNHD3PiFP1I5usOuw4U/kAqANIG+dD9QTeH2/1srv9LMKDl9Z3A/UlRSwZ3Ojj9VfrBM46N/PwieUNVrNYc/VsXx3s2Mij8mFCqNNjhrP0VDmjNsNoM/eBXedl6LiD9BRFFgDJWGP2wlgI0NjYM/Gw/7NJm6ij/f3l/7FBpTP6gitOSLmYQ/r9e6UfGqUj/+wwBCaApOP0p0bWUBp4I/MKxKRCFvdj9orXLui9t/P436yiUho4E/Phg978gDjD9OdJeNRLGJP7uhxnnT8H8/4qcTOgbuij+cLZlvi/SFP0AIPxqBPos/e15vJitShD9mjKNKrrqNP9bmgCU5Go0/DtWaBNbRbj9m3HgGRfCUP/ZvTILUEVE/+EnMwblThj/D8ofYTRZyPy2S8Es3mI8/SqaOHJH7hz8=",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        },
+        {
+         "customdata": [
+          [
+           "nlinear",
+           "087a97de1aad"
+          ],
+          [
+           "tcn",
+           "0d89e27bb00b"
+          ],
+          [
+           "tcn",
+           "10c2d36d730b"
+          ],
+          [
+           "nlinear",
+           "13e7a953029c"
+          ],
+          [
+           "nlinear",
+           "1e4c800a673c"
+          ],
+          [
+           "nlinear",
+           "1f8584891a23"
+          ],
+          [
+           "nlinear",
+           "32012965e8f6"
+          ],
+          [
+           "nlinear",
+           "3452e8782f66"
+          ],
+          [
+           "tcn",
+           "34bed18d26df"
+          ],
+          [
+           "nlinear",
+           "396023cf3e7f"
+          ],
+          [
+           "nlinear",
+           "398015f662b9"
+          ],
+          [
+           "tcn",
+           "3f5a97f024c9"
+          ],
+          [
+           "tcn",
+           "41d60c63291e"
+          ],
+          [
+           "tcn",
+           "4846982b5587"
+          ],
+          [
+           "tcn",
+           "4ef2adc607fc"
+          ],
+          [
+           "tcn",
+           "537ad61c7a52"
+          ],
+          [
+           "tcn",
+           "6019fc10f8ab"
+          ],
+          [
+           "tcn",
+           "75e75cdc62e8"
+          ],
+          [
+           "tcn",
+           "7d59002e420b"
+          ],
+          [
+           "tcn",
+           "8107d4fbb264"
+          ],
+          [
+           "nlinear",
+           "8a977d22978e"
+          ],
+          [
+           "nlinear",
+           "8ca1a08b1259"
+          ],
+          [
+           "tcn",
+           "932331b928f7"
+          ],
+          [
+           "tcn",
+           "9411678d4798"
+          ],
+          [
+           "tcn",
+           "987c0c12e22e"
+          ],
+          [
+           "nlinear",
+           "a7231ae62bd7"
+          ],
+          [
+           "nlinear",
+           "acc260220e36"
+          ],
+          [
+           "tcn",
+           "ad90fd55b1de"
+          ],
+          [
+           "tcn",
+           "b1fd1f7e612f"
+          ],
+          [
+           "tcn",
+           "bb029785e066"
+          ],
+          [
+           "nlinear",
+           "bc73308fb227"
+          ],
+          [
+           "nlinear",
+           "c0de2e8614c5"
+          ],
+          [
+           "tcn",
+           "c55369379c1f"
+          ],
+          [
+           "nlinear",
+           "cddabea21a40"
+          ],
+          [
+           "tcn",
+           "e2f518282dfc"
+          ],
+          [
+           "nlinear",
+           "e8309fb9f99c"
+          ],
+          [
+           "nlinear",
+           "e905ecfc2ca6"
+          ],
+          [
+           "nlinear",
+           "ecfec0200374"
+          ],
+          [
+           "nlinear",
+           "ee022c54d6f3"
+          ],
+          [
+           "nlinear",
+           "fd476b096f2e"
+          ]
+         ],
+         "hovertemplate": "family=deep_learning<br>label=fwd_ret_21d<br>Checkpoint=%{x}<br>Mean daily rank correlation=%{y}<br>config_name=%{customdata[0]}<br>prediction_hash=%{customdata[1]}<extra></extra>",
+         "legendgroup": "deep_learning",
+         "marker": {
+          "color": "#C87533",
+          "symbol": "circle"
+         },
+         "mode": "markers",
+         "name": "deep_learning",
+         "orientation": "v",
+         "showlegend": false,
+         "type": "scatter",
+         "x": {
+          "bdata": "LUYKBSgjHlUyXw9LKDdaUDxVQS1QSw8ZFEFkXyMeRjxkCgUyGTcUWg==",
+          "dtype": "i1"
+         },
+         "xaxis": "x",
+         "y": {
+          "bdata": "nOv53Yo1hj8CTt/4fWFwP0TQ/acmL3+/lhF4sI5uoj/+b1OiOKqKPxywFgta840/6UyzASZjgT8lz8CGIp98PyZZCAh9YIa/1htTjUcZeT8S2lzxZniTPyT9ql5dCGU/3pt9Y7Olgr8UmFfkfW5xPzaDqjPVB2w/YyF2sk8vcz/0o6W57XdUP7pq1EJl12E/ePwlJ+yRVD9miPcE0yBqP/rYV1U5eoA/LlhVUuRdfT8OeDg2tpGKv1T0G9UTA5U/NSB3MLlAjD+Gb2fFddGAP9h+lweXLXo/kGOCS5FQaj92FAlwo353v2TfQjuLVW0/elhEJc7JhT/CInSOByiKPwJle0NA8Gk/2sUXrW6amz84d+rnm21gvz/PZKfIBZE/M0Q1Y+ubjD+sqRB0vsqHPwQdUQMOiYs/iu19Zt+uej8=",
           "dtype": "f8"
          },
          "yaxis": "y"
@@ -4236,7 +3478,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AeydBWAURxfH/3vxYCEkuLuW4l5oactXKFBoKQ4t7lLcrbgX1+Je3AsUl+IUd9cQAkHi+ebNccdZkktyl2ySd8nbHZ83v7W3s7OzmqCgwHAWZsD7AO8DvA/wPsD7AO8DvA/wPpBY9wEN+McEmAATYAIAGAITYAJMgAkkVgJs8CbWLcvtYgJMgAkwASbABJhATAgkwjxs8CbCjcpNYgJMgAkwASbABJgAE/hEgA3eTyzYxQSYgPUEOCUTYAJMgAkwgQRDgA3eBLOpWFEmwASYABNgAkxAfQRYo4RAgA3ehLCVWEcmwASYABNgAkyACTCBGBNggzfG6DgjE7CeAKdkAkyACTABJsAE4o8AG7zxx55rZgJMgAkwASaQ1Ahwe5lAvBBggzdesHOlTIAJMAEmwASYABNgAnFFgA3euCLN9VhPgFMyASbABJgAE2ACTMCGBNjgtSFMLooJMAEmwASYgC0JcFlMgAnYhgAbvLbhyKUwASbABJgAE2ACTIAJqJQAG7wq3TDWq8UpmQATYAJMgAkwASbABCIjwAZvZHQ4jgkwASbABBIOAdaUCTABJhABATZ4IwDDwUyACTABJsAEmAATYAKJg0BSM3gTx1bjVjABJsAEmAATYAJMgAlYTYANXqtRcUImwASYQGIiwG1hAkyACSQdAmzwJp1tzS1lAkyACTABJsAEmECSJBCpwZskiXCjmQATYAJMgAkwASbABBIVATZ4E9Xm5MYwASZgJwJcLBNgAkyACSRgAmzwJuCNx6ozASbABJgAE2ACTCBuCSTM2tjgTZjbjbVmAkyACTABJsAEmAATsJIAG7xWguJkTIAJWE+AUzIBJsAEmAATUBMBNnjVtDVYFybABJgAE2ACTCAxEeC2qIQAG7wq2RCsBhNgAkyACTABJsAEmIB9CLDBax+uXCoTsJ4Ap2QCTIAJMAEmwATsSoANXrvi5cKZABNgAkyACTABawlwOiZgLwJs8NqLLJfLBJgAE2ACTIAJMAEmoAoCbPCqYjOwEtYT4JRMgAkwASbABJgAE4geATZ4o8eLUzMBJsAEmAATUAcB1oIJMAGrCbDBazUqTsgEmAATYAJMgAkwASaQEAmwwZsQt5r1OnNKJsAEmAATYAJMgAkkeQJs8Cb5XYABMAEmwASSAgFuIxNgAkmZABu8SXnrc9uZABNgAkyACTABJpAECLDBa7CR2ckEmAATYAJMgAkwASaQ+AiwwZv4tim3iAkwASYQWwKcnwkwASaQqAiwwZuoNic3hgkwASbABJgAE2ACTMCUQMwNXtOS2M8EmAATYAJMgAkwASYQ7wQuX72JP2YvRlhYWLzrolPA/+07jJ86D0+fv9AFxemaDV474p44bQG+q/urHWuIftFFy1fHmvXbop/RDjmWrtqAMl/+EK2Scxetgk3b9kQrj2Hin5p0wIixfxgG2dwdF3VcuHQVHpmLwuflK5vrb02Bg3+fhP7DxluT1CZpZi9Ygcr/axDrstp3G4RufUfEuhzTApKq//bd+2jcqhtyFqmMrAUqqAKD4Tkivo+TuADilb0E9uw/EhdV2ayOuLg2xkUdBKR52x7oO2QsOW0qsd138+fNiVNnLmDk+OkW9ZoxdykqffuzvI5Mn7MEoyfOxA8N21pMG9PA/y5fk+W/9PWTRaRIngwkdB4ODg6WYXG5YIM3LmlzXUzARgSSubuhSqWycHJytLrEs+cvyZOP3+s3VuexlPDWnXv4c9k6dO/Y0lJ0kg/bvmu/vHBkyV9e3NDVwZCRk/H23XuLXGbOWya3SYsOfSzGqz1w9oLleP8+AKcObsL9K+ozumJynKidOeunLgL58+ZCjmxZoqUU3Rxu2/lPpHliu+9qNBrM/WMUjhw/g51/HzSq6/mLlxgwfAL6dG8H3/tn0altM2TOlAGFCuQxShdDT6TZ2rVshIL5c2Po6KmRprNHJBu89qDKZTIBOxPIlSMbNq6cg1QpU9i5JvPiV/+1Fd99WwXeXp7mkUk8ZP+h42jUsisqlS+NU4c2Y8Sg37BzzwF0t9CrTD048xatkjcuiqIkSHKPnjxDkYJ54ZnaQ5X6x+dxokogrJTNCfTr0QFtWzSyebm22HddXV2wc8Mi/O+bL4z0e/T4qfRXrlQGZBiTp2mDOhg5uCc57S5UD4ndKzKpIEKDl3okfh83Dd/+0AzUU1GlekOs37zTKDuNDaFHjV993xiZ8pbDN7WbYe6fK/VpvMSjlsUr/kLdRu2RvVAljJ08R8atXLcZVB7lqfJdQ/y5dK0M1y1ojAfVmy5XKdBj21/b99ZFYfP2PbK8bAUryjgq57E46eoTmDhIB3p0Xq9pB/nIreI39UAXbF0y6u2iOqj3SxdG64KlvtU/+j/27xlZ19//HJZ65/qsMjp0H4wXPr44999lNG39m2wfPdrT7UhUhk7o0UGJSjVlGurJefbCRxcl17v3HcL/6vwCalPJL2phzKTZCA0NlXG0oDZY4hhVvrv3HqJ+806y3WW+rINVf22h4iIV3WOgWfOXg3QpUvY7+aiD9NmwZTdq/NQSeT7/En0Gj0FQ0KdHEtSmNl36o0DJb2Q8bbOHj54Y1UWPTahM2hfIKHj92t8onjxRtYnSRCV7DxxFzZ9bfWz3D/LR+/v3H/TZQkPD0L3f71JXat/wMX8gJCREH//K7zV6DhiN4hW/l/s+7b8Xr1zXx5MjqjoojU4OHvlXbnvd8aNj3HvQaBjuF4bDE4gtHX+lKteSOnxfrxWOnjitKxJkLNF+q8uj20f3HTyKL2s0knmIwemz/8k89+4/kuHkIf6Ul7YX+SM73ijeVGhIyTdfVjQKpv1j2uwloOOLjmvSgY5VXSJqc/7iX0OO3foY+Eu7XvJ4orZS0G3xeLx5256gY4/SdvxtMK5cu0VRZkLl0/5kGEHtMRyuQOcw8uct9hVoO1saghHVtpZl9BmB8l//KM8B1LY/Zi82rNbIffzkWeTKkRU9OrdEOm8vfPtVJTSsVxuHjp40Skdj2Vp26I1pE4YiWTI3hIeHG8WbenTbd+eeg5JZ+tylZZnELrL9hIZUTZn5p744Om/Rttdth4CAQHjnKAkqnxLRNqP9nc5FlC6y82u+YlVBvVTEg9ISayqH3NHVU5cvpudY0t2SRPc40ZUR1XmI2kf7G+2rxIHcumORytC1h9IRQ932orjIhPY32h4nT5/XJytUuprc/3QBBw6fkNdbw3PWs+c+iOgaR/noPECPq2m70nlt4IiJ+PAhgKKkRLXdr16/jSatu4OOSzr/t+82CHTtlJkjWFhzPM9fvAp0jstZpDJadeprdH4IFdfAaZGcU6haa+qgdCR0PaLrz2/9RsrjTbeNFixZDbJDMucrh+o/toCpLRCVvWI6pMFL2D2R2Rx0zn/j/1YOBaJjhfYh0s9UTPdd2je6ReNcZFqezk/M6fxJfrLtSAed0D5C4SQ/NemAQb9PjPRaSfs37fvUBkvHAZUTG5m3aCVID7pm0baj4RmG+71uG0Z03dPVTdcKyh+hwRsUFAQXF1dMHj0I549tR8fWTYXhMMForNDYybMxddaf6NLuF1w5/TfGDe+DD+IEqquE1mOFkftr059w9fQetG/VWBqsdLA0/KkmLp3chZbNf5ZAl63eSMlBilMjRwz8DXf+O4iDu1ajdImiMk5eJDr2RYOfvpc6nTuyDb80+hGKosj4iBbz/lyFdq2ayDyNfq6Ndt0GgozBiNJHFD5lxp9o8GNNDBe6nTh1Fh1/G4QBwyaiYrmSIqw7/rt0Hb+Pm2GUnR7/nr1wCdQbt3XdAjx99gJtOvfXp6GTV5eew/BLkx9x+tAWzJo8Av+eOo9hJt39phyjykcni/q/dMYr8fj64M7VWDR7AujmxM8v6sfZpPPf+w6jV9c2+KXxT5g+Z6lktloYzK2a10er5g2waPlfWL1+q2wHXazrN+uMq8I4Wb98Nv7etBR0E1K3cTvoxumQsU0n2a4dfsXZI1tRrlQJTDMxHKJqk6wsigWVQQfIN19VwqmDm7Fi4VSk8fREsIFBu0r0UIYEh2DciL6o98N3cmD/X5s+3cw1bd0D/m/fYt600Th3dDu+/+5LcZPVDrqbGWvqwMfflh175Q3RwlljUbfW/z6GAqeEIfrS97V+vyBeLYQBpEswZNRkzFu0GmOFjnT80WOz2g3a4sate7okFtdLVmzAxJH98e/+jciSKaPYbgPkyT1b1kz4Z9sKmefupUPwe3ge9LgrsuNNJjZZkKF07cZtfFa4gFHMuClzsHnHHgwb2B2XT+1Gn27tMHTUFNAJkRL+1qkF8ufLJfd92l8WLV8n4g5gztRRcHZ2Aj1i+1bcMCdzd8dfy2bh6N51qCCOqzf+/pQ9RjJg2ARsETfIi2aPx94ty/Ds+UvsEzdDhoVFta2nzlyIu/cfYv70sXh0/RhW/jkVmTKkNSzCyP15kUK4dec+jhw/JcP9377Djt37Ua2qcQ9L555DRa9LZXnukAmtXEycNh8Tfu+Hh1ePoljRQohqPylfphiOixt2XfGHhV7UM3/0uPbm6cSpc3AR/EsV/0zs8+/QMhrn12tn9+J/X3+Bru1/kfvTlDGDdNUgunrqMsbkHKvLG511RMcJlUHHd1TnZL/Xr/FDjW9xePcarF4yTTB0RrM2PeSxRmXoxJSDLjyidfJk7ihZrAiOnDgjk9y59wBv3vjj+s27emPw2L9nUa50MTg6Oso0tKD9tGiRApg5aQTy5skpjvuB0F3jHj1+ilr12yB9Wm95jZk+cRhWrt0sbupHUdYotzsdm7Xrt0bRwgWxZe0C7N60BKlSJcfPojOFOr1kISYLyhPV8XxbHCdbxWP9bh1bone3tjgi9skxE2frS4rqnGJNHbrCrt24g++EMfuTON9PGj3AyGZYsXYLKOyssCfoPFunUTu9MU83Au2FcR+RvaIr33Qdmc1B1/mUKZJj+fwpoPPw5ZO7TbNb9NM2js65yGIhIpCu33+LbSiceHjtmNSB9OjT3Xz87vLVm0HnhiN/r5WMForOyb8MrpXWHgdUV0zkjf979OjSCheO78C43/uKfeSM7IAzLSuy49nQ9tCYZtT56RFVr66t5ZgOcterU10aP6vWbZFJyMqmnoP+PTvgh++/AW1AOgHTyU8m+LhoVK8man5XFa6ia53SzFu0CtWrVQE9AvBIlRJNRTf6z3VrYO5Cbc/wk6cv5OMxMnLd3d3wWaH80lCm4l6+fCUNKDIwKW/2bJnxS5OfkCF9WoqOUFo0q4eqlcsjtUcqdGjdBGm90uDM+YsRpo8oYkjfLqDxJ42F0dy5XXPsFkbhqKE9ZVuaNayLtr82xOlzF4yy053cxFEDkCVzRhQukFc8MugBOqFeEcYhJZw8YyFai3xkSHulSY1Swrjv37M9aMeieJ2Ycowq3z+HjuOaMEymjh0C4lRAGBt0E/FanDx1ZUa0DgkJlRf2+j9+RlM7jwAAEABJREFUL3uqavzvSxw8/C+WzpuEOjW/BR0Y33xVEafPahlSe6in+48JQ1BA1EP1/TF+qDxJb999QFazePl6afDR9qbt0LldMxTIn1vG6RZRtUmXLrI1ldHwp1riJqw50nqnEb1t2WQbDB/9f1Yon+xZo/1ysNimX1cpj39Pa7cb9cbSHf4McVEoIS48aTw90KLpzyj+eSH8tXmXrDqqOuj+S1EUUM9A197DsXrxNHz1RXmZV7dwcNDIE4huvxg9tBeobtovqOdl/uI16NmljcxHx9+YYb2QURhaC5as0hVhcd2/Z0eha2F5TBDjG7fugXrfLSYWgZEdbyLa7P/O3QcyjLhIh1gEBgaBzgUjhLFLxxmx/p94hNZc3CwtXrFOpIC8wNDN3JVrN+UN7gBxozi4Txfky5MD9KMxwZTvj/GD5T5EbW5UrxbKlPycoqMt1BuyZOV69OvRHuXLlJD7wpSxg/Du/Xt9WcQ7qm1NfHJkzyLHnCUTxvgXFUrjx9rf6cswdVC7RwzsgbqN28seYepBcXNzxfjf++mTUu/P9Zu3Mah3F32YtY6+v7VDSWGckrHjoNEgqv2knGj7AfGEIUTc8JHx9MLnpTiP/yieFpyVVR4TxnDZUlrjKabnV1mQySK6euqyx+Qcq8sbnXVkxwkd31Gdk+l8Tdcx2k8/L1JQHst080A9oYZ6GHIgY9YwLiI33aQc+/g0h4zA8mWKi324OI4cOyWzHBVxtF2l5+OigTjnDezdWdycfyVuZEfK6/Hpc//JWDoOqO7JYwaCrjHlxT4xqE9nLF+zST6ljGq707Xos8L5QPZAnlzZQONVRw/tjUuXb4COH1mJycKa45k6IVaKDgm6ntJ1lWwCYkhFBVpxTrGmDkVRcP7iFXxfr4W4MWuOvr+1p+KNhM4RxT8vLIdojRnWW74XoXsaNy8Ke8WoIAOPrWwOgyIR3XORYd6Yur/+sgIaifMw7ef0VK9qlQo4eUa7X1GZ1h4HlDYm0kM8KStXurjcn+kaSrbH8jWbzYqK7Hg2tD00ZjkNAuiCTY+waYA1dXmPmTQLDx5qH1PfvH0ftFOWLvG5QQ5z5+eix8Mw9Matu/haQDMMI/+V67fk3TFBpZPyl9Ubid7SafIxPBmNlJ4MqQplS8qhE/R4knqC6VEtxUUmGTOkM4pOl9ZLHuhGgVZ4ChoM6M6WJZPMUSh/HrmmBYVRLxK5dZI7RzbQhVznLyKMLUVRoDMcyCilWQOIr06+rtUUdMF+8vS5LhtMOUaV767oGSBjigxQXSGVypcCXXx1/ojWuXJmg4uLsz46u+gdzCsMEycnJ31YVmHA+/j6Sj89VkqfzlvoWFD6aZFPpCeh3mLy09185YqlyakXeulK7xGOqNokkkT5T2WULvFZpOkK5MttFE+9nz4vtW25dfueNIq8xGMp3fagNQ361/WYRFUHPZ2mnoEuvYZj46o5IIPCqELhiWy/uHv/kbyxo5MNIBKLfzJwvvyiHIij8Eb4nznjp33dW9zYUUIaekNrSxLZ8WYpPR3zFE43sLQmuXPvoTwX0LAcYqUTelnrzt2HlEQK3ZjSBWXRsnXCaCuiv5GlyJu376KEuMGgdpI/tnL/wWN5PqlcsZy+KHo7mG6WdQHWbOs6taphyYr1cmgQDf3YIW7gqIdaV4bp+tyFy5g6ayHq/VAdy+ZNxiBh1NM5b8DwiTIp7UP09IZ6jKlnWwZGY1Fc9Orqkluzn9C+FyJuYE+fuyh6R06jsjDYK5YrhcPHtEMsjp44A53xFNPzq04fw3V09dTljck5Vpc3OuvIjhM6vqM6Jz94+BjdxONlekxK+7t3jpJyGNqDR4+N1DDkYBQRiYe2x8GjJ+Uwq2Mftw8ZqUeOn0GAeIJ6TPTwklFsWETB/J+uQ3QMyfOz6CCiNPTEoVIF43M/HfcUR+fuqLY7ncP//ueIvIGjtpKkzvK5PE/SsU/lmIo1xzNdZwyvR9mzZhbX5ZeyKCqXzjWRnVOsqeOueDpTs14rDBAdAdSzKQs3WXwmOtV0QXRMFhIdU7c/3tjTsft1JPaKLp/p2lY2h2G50T0XGeaNqTuTie3k7ZVav42oTGuPA0obE6EhYo1adkX+El/L/a92gzbyKbnhEEUqN7Ljma6ZOtsjQoOXxrnSY/TBfTvLx6PU5U13kEEmU0koikL1RSiubi5mcQ4ODkZhjo4O8uKkKIrsiTm0aw0a/VxLHFAfRPf1LFT5roF85EmZ/lo2U1xEOsHVxUX0oG1Fma/qiJO39s6X4i2JRvSEmIaTUUJhimJZ/1BxkaB4Q3E00FtRtPno5KJLoyiKbIfOH9Ga8ugumoqiYOKo/iC+pkIGgq4MU46KEnU+Q3115ThoNDpnhGvTfIqiwHSbKYpxWw2NYXz8meYx9VuqxxoWH4uPeKXdNBHG0/5mGKkolEE7hlJRtPug6bYgPz320uejLHqPsUMUIR5LFkW2LBmxbNUG48hIfIb7BSUjP6114ujw6RGmLsx0bXlf17bNNC35qRc8suON0hhKGvEUgvy+vn60kqIoWhjH9v5lth8f37deptEt/t53RN6t06NQ3TGgi4vOWlG0dRrmIcPO0E9uR0fj/d1BnGsonERRot7W1GO9b9tyaRTSBbZt1/7ypTTKb0kmz1iAMqU+Bz02/v67r+TThYniCQ/dnNNwkEtXbsip5HRjgsl4oHGw1KNE7qhu4N1cXc2qjWw/oZ49eiRJhu1RYTCVFb0lZASTEUR1kfFUoWxxfZkxOb/qMxs4oqunLqvhOUFRtNvYsH2KYnze0eWL7jqy40RRIj+30n5bt3E70SOYGssXTMWzWydBb7rTOTA4KMRIFUscjBJY8ND2oX35zLlL2H/4BCqWLSF7eI+J3njqAXUWHQ+0TQ2zOhrs1xSuKMSJXFoxPfcaHgeUIrLtriiKfKpB50BT+emHiJ92ULmRieG2pnSKQjprz1WKot32ZueUh+dhek6hvBEJGZ7lxf69ev022YkUUTrTcNrGujBTdsSa4hVFq6MuneHa8v5lmCL67uiei6Jfg3kOjcZSG7XbiBhYexyYlxx1CN1o1WvaEfXr1sSuDYvx8t4ZbP9rocxoaoda5q3VkzLotqHx1YBiPsrxU+dQQTz6oEeK1HtHwf9dukorKblzZpW9gP+ePif91i7y5MqOCxevGSWnMa4FDXrdaCdtIx7zjxaPTY7t+Qv3Ra/yqY/d6NSzRN3og8Wj6H1bl6PE50XkWECjAqPhoWEWdJf58tWnCzhdmCJ7DByN4nHzzj0YDiP479I12XuXQzwmpXKo3fsOHiNntCSqfNmzZRHcHou7MV99uddu3InWQa/PGIUjZ/asoBcCDHukfUTvwq079+WQAsqeM0dWXLxsvN0vGOxPlCaqNlGaqCRfnpw4+XF4QlRpLcXny5tT3lxF9KiO8lhTR8YM3ti0aq4c9kIvp1E+Q7kZyX5BPep0gF64eNkwC2gYDnE0CoyGx0XcJFJyMjZprZPIjjddGt26QN5coEf718QjeV1YrhxZ5JODvfuP6oIsrjdu/Rs0pnnXxsWCsQ/GTZmrT5c7Z3acEb2QIeLRuz4wEkdaL0+88vMzSkHDJXQBWcXNhqIoRucaGtd+9vwnptZsayqvaOEC6NbhV8yZOhKL5owH9fIaHtOURichoaFw0Bjf0Gs+XjTCQsOkMbxlzXwYCvXe0dMOCqOnT7qyolpbu5+UL1MMx8Rj8ANHTqBSuZLyvF1BGFGTZy4EGU80ZlRXl63Pr1SutXpSWjVIVOchOs/duHVPdMrUBj3FchFPwy5dvSHP67bQX3eTsmLdZrx9+w705IOuwzfF0yd6YZS2p+FNQFR10kuUFy5+unZT+rPntMdBTnHuJn9k2z1fnlzi6cApo5fcKE9kEt3j2bQsa84p1tRB+/eSOZPg7uYKMp7oyalpXYbXoaCgYFy6ch05smWWyayxV2TCaC7oRigsPCyauYDonIuiXXg0M9j7ODgjbvi80niido2vQU9hHUSHI9lP0VQTOQ1sjwgN3iIF84Ieg/kKQzBY9OpOmr5AXLwP6euiA44uAiPHzwBdyGjYARkJU2ct0qex5Gj9SwPQOGD6+AG95blhyy7xyHAD2rRoKJPTAU1j3HQ75sEjJ+WjnRzZM4MuaBOnLZDGFSWmx4O3xElAt3NSWHRFURSUF70eS1eul72zdFGcMHU+6G49umVZSq8oCuitUOr6pzf9+w0dDxoHWPDj+FUakE09PDTpM7WHjBEaE0u965bK04VFla9KxTKgm5KufYaBtiHtnH0Gj5EXO10ZtlpTe4oWKYCuvYeBjGpqx2/9fpc9nN99U1lW07xxXSxfvUm+1Q3xo+Eyu/d+2p9EEKJqE6WJQtC9YwusWLsZf8wmo+ol6C6R9pmIDBTT8mi8EN1Jd+wxGPsOHgU9QqQboOlzloAer1B6a+vIlDE9Nq2ci2279sPU6FWUiPcLugFr82sD+XTjyPFTcvuRcUgHOx0/pENMJEvmDHL7X7x8XZ89suNNn8jAQcf9N19VFMbpJX0ohdF4YzpHEHva32gc8rqNO7BstfZlVHpZk/aJEYO6g4aU0MtqE6fNlxdSKujXJj+Bzgddeg0Xx/kt2WYqi3q0KN5UShYvKs87r/xeyyh6IkWPL6VHLMhooHH1oybMkOXRdhz0+yRhJGvTiySwZlvPmLsUu8R+SucFEhrLnj6dt+ylpjJM5X9fVxbb+x85Tp/iaL+bPH0hqNeObixoDCUNLTKU1KlTyvcWKIwMD8pnjVi7n1CvLo3jfffuPT7/TDvsiNpOLy6VM3j5yR7nV2qHtXpSWjVIVOchuimhY3vv/iNS3ctXb8rhDXRBlgGRLOg6Sef2Kx/f4YgoabnSn8sXyyqWLynHv5NRTTcpy9dsRNnSJSLKZjGc3pugIT40Gw11RNBL0SPG/QEaO+stbhyvXLuJiZFcV1s0/UmW27pLP5BxSNcoykPl0f4tI00W0T2eTbLDmnOKtXXQMIXlC6aIa7qjRaN33JQ54nx2ETT0q++QceLGJQQ//VBdqkTn28jsFZkoBgsaznFJPO2JTtbonouiU3ZM0sbmOLCmPhpa8vjpM9DHKyg92Ul0XSd3dKR547p62yNCg5fezq9RrQqqft8EpavUEb1z14Ux0RKGv97d2srZGyZMnSunoqKxp8+i+GRcrepfgwbPz5y/DIVKVcPUmYvkDAdN6v8gi06e3B20YWmKEHrE167bAIz/va+8SLq7uYkLyXEULvM/OZ6jxBe1UO3rL0C6yswxXIwZ3heBQUHInK+8HCtCJxY6EcSwOKNsnxcpiMLi5qHsVz+ixo8tQBfLedNH69OUE8b2FtHjQy9NffV9YxQo8Y04+cxHUFCgPo0lR1T56ISxatE0BIs71srfNUTVmk3EQfydrN9SebEJo8cJq/78A8mTJ8cPDdvgm9pN5Ul63dJZ8g18Kpt65ft0b1nmURwAABAASURBVCffKv+8Qg2sWb8d3TsZ709RtYnKiUoqC0N/zZLpohduP2h8XYlKteQ+42TwRnNUZSyeOxE0nVT/oROQ67MqaPhrVxw8ckK0L5nMGlUdNFyGHvdQYroz3bx6LjZv32tk9Ea1Xwzr3x30Mmi3PsNRtFx1Uf+/osd4jr7HnMqOrtAYVjLWa9VvDTq2aDqZyI63iMpv0bQe6EbVMJ5mYaDhT/SCS5Ey36FStZ+lsUuTpxOLdt0Ggm6KWjT9WWYjw6tnl9Zo02WANEJpaMXWtQvh//Yt6jRqK7/cNXn6fLi7u8n0pou24ga5UoXSKF3lB9D0hfQS2Pf/+8oo2cghPaVRW6dhW5StWleOsaTzj2GiqLZ1aFgYOombnzTZioNk2659cvYORbH0qA/yJVyaRWGkMLTpHPZ1zcagnuQFM8YYVmsztzX7CRnbYWHhqFCuBHRGWfkyxeW4axovqlPGXudXKt8aPSmdGqRcFOdkYrh8/mT5xcdyVX9Eg1+7oLe4FtK+HpX+r1+/ETeyM6Mci0/bhcawlitVXF8k6UVh5UWPvT4wUoc2MnOmDNi6dr6cGaZ4xe/RTlxTq1Ypjwkj+8sEUW331B6p5CNlStf04xScv/UbKToT7iOi82p0j2epiMkisnMKJbWmDjr3UFpXVxfQNYrc1NNrOAb0t46t0LhVd2FXVMPV67ewYcVs0EvxlJbOF5HZK5QmJtK5bXNh5yyR52Ga0suaMqJ7LrKmzNikic1xYE29BfPnxoyJw9Gh2yDQtKoTxfVg+IBu1mQ1SmNoe2iMYgw8ZMTQCxdnj2yV00gtnDlWHNRt8M/HqY0oKTWYvtBx+O+1oHFMNMZi1JBeFCXF5+5psxfUKIJmZdi/faWc5mf/jpVo3uhHCpZCvWs0Rkc3VujupUNo/UtDGac1HubpxwlSfVPHDdafxGUik4UlHQ7uWi1nW9AlpTdPV/05Tepz49w/ciYCmiqE9KQ0dKIhfeigIT8JPYKkMHLrhGYzMPzaEL1huGP9n+JGoYUs+97lw6Apkmh+Tl0eWlcqX0oeZLf/OwCa6mfz6nkg9hRHYqkNFB5VvhzZsmDt0pn47/gOUHvopuL80e3QtYvKMBWdzobh/Xp0wMaVcwyDQJNG07QqukAy5GkfuXLqbxDDxXMmgB4r6+JpTfsKTRV27sg22V6a0ePEP9oeQIoniapNN8/vl484KG1EQi9kEHfaFrSNiKfOcFonx4B3Mco6ZlgfLJ6jfamIIqh3cGj/bnKs2KPrx+Q+v2bJDNAsGxRPEp06cuXIJqflGzfi05v6VEZ30RtN5VvaL6hXgsbMnzywGQ+uHpUXrPJlPvXs0IsW1DbqMaSyLO2jFEdpKC2lIen7W3v98UPTkkV2vFF6S0I9+nRB2C56rnXxiqKAbjz3bF4q93XazrTP1KlZTd78kJsuJLr0tKY3bi/9u0vOnkL+/HlzgmYCoSkMSW9qe5GC+ShKHq8Hdq6SblqQ8U7TYNG+RuceOl5oGjkKo3gS2o40M8PVM3tA+9xYcWNLwxJM00S2rbu0ay73Z9KHhHSifZTKj0h+FTcEuzcukVP+UHqqj3oEI0pPxxEdOxHFU7il7UvhUe0nlIY4vLhzClQP+UmoDdQeOt7JTxKT8+sqcVM9bEB3yi4lpnpaymfNOVZWarIwPEfQvk/tpGOBklmqh+IoDaWlNCTEh/bXiM7JdMNGHRU0xvTCse2oVrUS6HxD1wDKb6keCr8keoNperCvKpcjb4TydZUK8jilc6YuER0vpCeVrQujtaXrg+k1jmZQovMg6Xjm8FbQTCLU8075rdnulIbOF3T9oDLo/LpYnON151Uqx1QiO55pv6MyDPPQo+tbF7Sz+lC4okR8TqF4kujUQbpSnSTkpvwkVSqVAV236DxCY0SJFYXrhK6XEdkrlGaxuHbQNYTcJNZsj+++rSzP67Q96dpM+UyF9keKp/2T4mJyLqJ8loRmg6Ky6dygize9zltzrYzqOKDzN9VjOKuPrj5r1j/98B0O7V6DE/9sAA1hpRlyqDy6/lB+OhbIb2ibES8KI36UhoSOI7omRWjwUiKWxE2AW8cEYkqA5kR8/+FDTLNzPiaQJAnQWOr2rZvIMe9JEgA3mgnEIwE2eOMRPlfNBBIqAbp7prvvhKo/680ETAjEiZd6w7u2/yVO6uJKmAATMCbABq8xD/YxAbsTsPQ4z+6VcgVMgAkwASagJ2Dpcbg+kh2JkgAbvNZuVk7HBJgAE2ACTIAJMAEmkCAJsMGbIDcbK80EmAATiD8CXDMTYAJMIKERYIM3oW0x1pcJMAEmwASYABNgAkwgWgTsZPBGSwdOzASYABNgAkyACTABJsAE7EaADV67oeWCmQATYAIAGAITYAJMgAnEOwE2eON9E7ACTIAJMAEmwASYABNI/ATis4Vs8MYnfa6bCTABJsAEmAATYAJMwO4E2OC1O2KugAkwAesJcEomwASYABNgArYnwAav7ZlyiUyACTABJsAEmAATiB0Bzm1TAmzw2hQnF8YEmAATYAJMgAkwASagNgJs8Kpti7A+TMB6ApySCTABJsAEmAATsIIAG7xWQOIkTIAJMAEmwASYgJoJsG5MIHICbPBGzodjmQATYAJMgAkwASbABBI4ATZ4E/gGZPWtJ8ApmQATYAJMgAkwgaRJgA3epLndudVMgAkwASaQdAlwy5lAkiPABm+S2+TcYCbABJgAE2ACTIAJJC0CbPAmre1tfWs5JRNgAkyACTABJsAEEgkBNngTyYbkZjABJsAEmIB9CHCpTIAJJHwCbPAm/G3ILWACTIAJMAEmwASYABOIhAAbvJHAsT6KUzIBJsAEmAATYAJMgAmolQAbvGrdMqwXE2ACTCAhEmCdmQATYAIqJMAGrwo3CqvEBJgAE2ACTIAJMAEmYDsC8WHwRqn94eNn0brbMFSq3hzlqjXRS5QZOQETYAJMgAkwASbABJgAEzAhoEqDd8Gy9ejZqTn2b/0Tx3Yt04uJ7uxlAkyACSRwAqw+E2ACTIAJxAUBVRq86dKmQb7c2eGgUaV64B8TYAJMgAkwASbABJiADQnYuShVWpRpPD2wfusevH333s7N5+KZABNgAkyACTABJsAEEjsBVRq867fswfhpi/BN3Tb68bs0ljexbwxuHxNgApES4EgmwASYABNgAjEioEqD13DcrqE7Ri3kTEyACTABJsAEmAATSFQEuDHRJaBKgzc8PBxXb9zBus27pVy7eRcUFt3GcXomwASYABNgAkyACTABJqBKg3fsH3+iQ8+ROHvhqpT2PX7HhOmLeWsxASYQDQKclAkwASbABJgAE9ASUKXBe+rsRaz5cwJGDuwiZc3C8Th+6oJWY14yASbABJgAE2ACTMB6ApySCUCVBq+zsxO8PD30m8crTWo4OTno/exgAkyACTABJsAEmAATYALWElClwZsmtQdmLliFk6Knl2Ta3OVI5+1lbZs4HROIPgHOwQSYABNgAkyACSRaAqo0eIf17QAfXz8MGTNTit/rtxjSu12i3QjcMCbABJgAE2ACaiHAejCBxEhAlQavZ+pUGNyrHbavnillUK+2oLDEuAG4TUyACTABJsAEmAATYAL2JaAqg5eGL9DX1WhtSeyLgku3ngCnZAJMgAkwASbABJhAwiGgKoN3wbINePbiJWhtSRIOVtaUCTABJsAEkgQBbiQTYAIJgoCqDN7ZEwchV/YsoLUlSRBEWUkmwASYABNgAkyACTABVRFQlcGrI9OuxwidU79u0raf3p3AHKwuE2ACTIAJMAEmwASYQDwSUKXBa8rj3fsPCAwKMg1mPxNgAkyACSQoAqwsE2ACTCB+CKjK4J27eC3KVWuC8xevyTW5SZq064e6338dP4S4VibABJgAE2ACTIAJMIEETUBVBm+b5vVwbNcy/FTrW9BaJxuWTEHDH79L0KBZeSbABJgAE2ACTIAJMIH4IaAqg1eHoEfHZjonr5kAE2ACSZUAt5sJMAEmwARsRECVBu/9h0/Rrf9YVKnZwmhog43azMUwASbABJgAE2ACTIAJJBgCsVdUlQbv8PGzUfN/XyJ/3hzYsmIaOrVqiJZN6sS+tVwCE2ACTIAJMAEmwASYQJIjoEqDNyAgEFW/KI2wsDB4pUmNxvVq4Pbdh7HaOGs27gK9/Nas/QAcPHbGYlk+L1+hU+9RaNF5MPqPmIoPAQFG6V75vcFXtVth1sLVRuHsYQJMIP4JsAZMgAkwASbABCIioEqD193dVeqrKAoePHqKgMAg+L56I8Nisrj34AmWrNqCOZMGY9zQ7hg5ca4s07SsqXOWo2zJolg4bThSpkyB5Wu3GyWZOGMJihfNDyjQ/5ycnGEP2bJlK+bNm2+Xsu2hr9rLhNho4eHhzNNG+yvztO1xrygKeP+0HVNFYZ62PCcrikZ0QMXd+VOjsa1p4uv7EklMkkR7Ec2fbfeqaFYeUfLPC+eD3xt/NKxbHY1a98GXtVrgmy/LRpQ8yvDDx8+gcoWSSObuhvTpvJA/Tw6cPHMRpr8jJ86hxreVZHCNbyrh8Imz0k0LmirNzc0FhfLnAcIphIUJMAEmwASYABNICATSpk0PlsTDICb7nCoN3g4tG8BD9LBWqVgSh7YvllOU/Vjzm5i0T+Z58dIXGdN7SzctMmdMh+c+L8mpF/q4hegUQGqPlDIsS6Z0eOHjK90hISGYNm8lOrduKP28YAIJngA3gAkwASbABJhAEiKgKoP3yL/nEJnEZrsoBo9IFMVgTIJBoYaPUegRji6KhjbUrVkVKVMk1wXp1x8+vIc9JDg4CGRo26PspFhmYGAAAgMD7bKtmKd9joGkxDWQ90+bHpvM07bHJPEMCoq78ydd+/QX2Y+Orv3GIjL5mCxGK86UNAioyuBds2EXIpOYbhLvNJ7w83utz+77yg9pvdLo/eSg4Q6hoWEICg4mL16KNN5entJNQxtGjJ8jp0ijr8EtWb0FU2YvlXEuLq5wsYM4OjrBwcEBLnYoOymWqR3P5gQX5gkXGzBgnrY97pkn87TFcWmvMmj/pGuSvco3LZeufTD5/VynGiITk+TsZQJmBFRl8E4d3QeRiZn2VgZULFsch46fQWBQEHxfvcbla7dRpmQRmfvshSsIDg6R7vKlP8ee/ceke/c/R1GxzOfSPW/KEDmsgr78Rl+Da1a/Jrq1ayrjqFfYHqIoChRFgT3K5jI10eTK6Xmf4X2A9wHeB+JqH1AUBaa/CuL6HJmYpmc/EzAloCqDV6cc9bIuXL4RQ8bMlEG37z7C3gMnpDsmi2xZMqBOjapo2WUIuvUfh+4dmsHZyUkW1XvoZLx+4y/d3do1xpZdB+W0ZPcfPJHTockIXjABJsAEmAATYAJAPDHYtvsgajfuIqcXPX7qvHyxfdrc5fGkDVebEAlo1Kj0sHGz8fSZD+4/fCLVy5jBG0tWb5bumC5+/qEals0ejSWzRqL7YGF6AAAQAElEQVRy+RL6Yv5eP1fO9UsBXmlSY9aEgXJaslGDusLNVTs9GsXp5NdGtdG+RX2dl9dMgAkwASbABJiAnQls2XkA86cORZ8uLbBo5Wb5Yvv5SzdiVOucRWvw3c/tUKlGsxjljyjTw8fPjMocMmaG0HVjRMk5PI4JqNLgvXvvEfr/1gouLs4Sh6tYB4dohx3IAF6omQDrxgSYABNgAkzApgQ8PFKA3qspUjAP6KNUVPiHD8Yfh6KwqOSV3xthhG7C7ImDcWjbkqiSRys+ZYpkaF6/VrTycOK4I6BKg9fR0cGIgKU3No0SsIcJMAEmwASYgOoIsEK2IpA6VUrQuzVUHo0lPnDkFMLCw8gbLfF5+QoeqVIgW5aM0cpnTWKayalVs5+sScpp4oGAJh7qjLLKzwrlw9I1W/H27Xv8e+Y/9Bw8EV9WKh1lPk7ABJgAE2ACTIAJJD4CG7fvk+/1lKvWBFev38GGbXsxenD3aDWUPiDVqE1vkNFbqmp99Bo8Qb60PmnmYvz0S3dU/r45eg2ZiCfPXkD36ztsMmb/uRptfxuGL2v9irF/LADN299z0HiZ/peOA3D3/iOZ3HRIgwwUC+q0o7zXb90VPu3/6zdvUa5aYzkjlDaEl/YmoEqD97cOTZHGMxWcnBwxedYyfPVFGbRsXMfeLOKlfK6UCTABJsAEmAATiJwAzZKkk/1bFmLKqD7IniVD5JlMYosWFp1ps0bL93ZO7l2N8cN7IjQsTM6xP3lkHyydPQaODhpMmL7IKOeOPYfRQtggf84YiQsXr6NZ+36oVL4E/lo8BVkypRcG8Rqj9KYeR0dHfF2lHKgcXdy23QdQ8vNCSJPaQxfEazsTUJ3BGxIaKna2xaj+dSX8OX0EVs4bi1r/qyKnkbIzCy6eCTABJsAE4o8A18wE4pwAvSPUqumP0nDNmjkDOrZqhFNnLxrp8e2X5VGmxGfCwM6Ib78qj1QpU6D2d19Jw7lB3e9w9cZto/SWPDW+/QK79h1BeHi4jN659zCqf1NJunkRNwRUZ/A6OjjoHw/EDQKuhQkwASbABJgAE1AzARrKEJnEVHfqZJs4YxHqt+yB0l83QJ2mXfD+QwAoXFemZ+pUOifcXF1Er6yh3xX+b9/r4yNyfF44v+g9dsDpc5fw4NFT3Ln/SD69jig9h9uegOoMXmoiTQ/Wc/AE/L3/GE6KOy2dgCJZmAATYAJMgAkwgSRFoNFP1dHox++wYu5YKeSmMN0wh5jC2LhtLy5cuo4hvTtg/5ZF2LJiRkyLijLf99UqY+feI9i66wC+qlQGLs7OUebhBLYjoEqD99mLl3j77gP+2rIHC5Zt0Ivtmp2wSrqztycur62FS6u/x5UNDeB3e3fCagBrywSYgM0JcIFMICkROHHqP3Ru0xg5smWSQu5/z1yMNYLg4BDQUIaC+XLB3c0Vm3b+E+syIyqADN69B49j177DPJwhIkh2DFedwUuPETq2bIDZEweZiR05qLboR8cn4L3PVYSHhUkdw4Le4tGpP6SbF0yACTABJsAEkgKBoOAg0By6uraSOygoSOeN8fqHGl/hzr2H8kW0bv3HxLgcazJmTJ8WuXJkwbv3AShdvIg1WTiNdQSsSqU6g5fG8M5b8pdVyieFRG+fW7iDDQdePziYFJrPbWQCTIAJMAEmgOYNaqNBq95o12OEFHI3bxD9jzzkz5sTO9bM1hOlL6oumzMWS2aNxpRRfdG2eT3QDA5ki1CiMUO6o+GP1ckp5ecf/idnd5AesciZPTP2blwgXEDmjOmMPmYxrG9H/NLwBxmnW1Bv8vfffgFFUXRBvI4jAqozeKndLi5OuHbjDjlZmAATYAKxJ8AlMAEmkKAJ0CwHi2aMwNeVy0ghd/VvvkhQbaL5ff859C/qfP91gtI7sSirSoP30ZPn+KXTIDRs1Uveyenu6BIL9Oi0I3nawubJxY1hqiwJ60A3bwSHMAEmwASYABOwnoCiKAgLC5fTlDo5OVmfUQUp6eMWzTv0R8dWDeWY4fhUKanWrUqDt3v7pvhjTF/81rE5Wjapo5ekuJEyle0Jd6/8UDTaTaVxTo5MJbskRRTcZibABJgAE0iiBK7dvIsmbfth0cpNmLlgNVp2Hoxbdx8kGBq/dWiO3X/Nw0+1vk0wOic2RTVqbFCpYoVhSdSoa1zolKPqBBSstxmF6m9FgTqr4JGTD5i44J506+CWMwEmwATURWDyzKXo160Vtq+eidw5s2LOpMGYuWCVupRkbVRNQJUG76WrN9Fz0ARUr99BSq8hE3Hp6i1Vg2TlmAATYAJMgAkwAfsQ8HvzBlUrl9EXnj6dF16+eqP3283BBScaAqo0eEdOmodsWTJgxrgBUrJkSo/RU+YnGuixbciT0zNweV1dXFxdQ66fnJ4Z2yI5PxNgAkyACTAB1RJQFGNzhV4Ac+UPN6h2e6lRMeM9SCUa0remaVLpHB8nmO7SpjFsMd+eSpoXKzX8Hx6D780dCA8NgiL+aO17czv8H/8bq3I5c4wJcEYmwASYABOwM4EsmdLpZ2/yfeWHll2GoEUT4ym/7KwCF5/ACajS4A0LCzOaYNrn5atYY16zcReatOuHZu0H4OCxMxbLo3o69R6FFp0Ho/+IqfgQECDTnb1wBX2HT8HXdVqjVdehOHD0tAyPj4XvrR0WqyVD2GIEBzIBJsAEmAATiBMC9qtk3NDfkC9PDlkBzW+7cdlU/niDpMELawmo0uClSZ7rt+yln5KsUZu+aFLve2vbZJbu3oMnWLJqixzkPm5od4ycOBcBgUFm6abOWY6yJYti4bThSJkyBZav3S7T0OcGe3b6Bbv+mgOa6Jryy4h4WCiOLhZrDQ0NtBjOgUyACTABJsAEEjqB/y7fgE5CQkJFb+9dvZ/CE3r7WH/7E1ClwftD9a+E0TlMTi5Nk0yTAVrruy9jTOPw8TOoXKEkkrm7IX06L+QXd4knLXyD+8iJc6jxbSXQr8Y3lXD4xFlygu4qvTw94KDRoGLZYggODtb3/soEcbhIna2Kxdo8c3xlMVxtgawPE2ACTIAJMIHoEpgyexkik+iWl1DS05Nn+iZBQtFXzXqq0uC9decBUnukkvPV0Zx1HqlSxGq+vRcvfZExvbd+O9Dn/577vNT7yfHu/QcoCkS9KckLGi/0wsdXug0XG7buRe6c2UCfI6RwMn7tIaGhoaChHaZlu6YrDY+c1aA4OCNc/NHaI+f/4JymqDTETdOzP1hyCQkJAQnz0PKILQdiSRLbcji/dnsQSxLmoeURWw7EkiS25dg5vzw3JYQ6iCVJXOlK1z66vhrKgj+GITIxTGsv9+59h1C1ZiOkzVkCJb+oielzFturKi7XDgRUafAOGTMTzgZfUXFycsSQ0bGbiUD34QZiqCjCsiWHiWhED64uSDF5I5TCL1y6juXrtmNwr7bklUIv2NlDqPCIyvUu2ha5a61C3job5Nq7aBtElJbDxW1BuE7AnPQsdExis2aetj2+mCfzjM3xaN+8kV2TbLvdtO2g+tQk1AFWt1FbnDh5Du9FB9nV67fQd8hY7D1wxCZq3n/4BG26D8WvnQZgzJT5+O7ndvpyg8RTZZqetXGbPqD1G/+3Mq5us66YOGMxmrbri0ZteuPGrXvo2Ot3UPjG7ftkGl58IqBKgzckNARk5OrUdHF2RmCQ+ZhbXXxUa+80nvDze61PRm94pvVKo/eTg4Y7hIaGgXYs8r985QdvL09ySqGdffr8lZg+rp/o/U0vw2jhLHSzhzg4OMBBiC3KRpAP7u/pjBsbfpRyZ2drhPjfRti7u/jw5AhsUYfay3ASN1BO4sZJ7XomFP2cmKdNjxvm6cw87XQtscU5hfZPR0dHm26jyPSi6x8i+NVs1FnG1GnaTa7janH8X8svux84dMImKkydswyVyhbHn9NHImvmDPjwQfvSPBVOxnDt777E8rljQe8ULVu7lYKl5MmZFUtnj0GZEp9h6NiZGDOkOxbNGIn5S9YhRDwplol4IQmo0uBVFAUnTl+QCtLi2MnzRj2+FBYdqSh2okPHz0ij2ffVa1y+dhtlShaRRdAMDMHBIdJdvvTn2LP/mHTv/ucoKpb5XLppDM2AkdPQv3trZEj3aWiEjFTJ4uW1Tbh/aBienJmD13cO4Nqmpri0uqaQWri5vQMC/R8JTcOlhHzwwZ09PXFr9294eHyiSPM9bm5rI+f01c3t++jYWNzZ11eU0xg3d7SD781PBxj4xwSYABOIYwJcHRNIzAQuX72JujW/kU3UraVHLNJ5pwHZMcKJn3+ohktXbpJTSoWyxeS6SME8yJk9M1IkT4aUKZLDK01qPH/xUsbxQktAlQbvwB5tZDd9ux4j5EwNU2YvxYAerbUax2BJH7GoU6OqnLevW/9x6N6hmd6A7j10Ml6/8ZeldmvXGFt2HZTTkt1/8ASN69WQ4Ws37ZZvgzZs3RvlqjWR8vS5j4xTw+L65uZ4em4e/B+fhO+NLXh4YjxCAmj8MRm4YeIxfoiQyDUNfPsY4aGBUMRfeGgQ/O4fxPsXF0U5rxH45iGenJqNK+t/Fsax1oi+tbOjiKM6Ii733dMzwqjuiqsbm8g1+SNOzTFMgAkwASbABNRJoGzp4hYVq1ypjMXw6AaGi8u1i7OTzObo6ABFUaSbFuSnNQn1tBuOcXYSPe8UTkMyKY7cJOTXdeaRnwXQqBFCofy5sXL+eHknQ3czK+eNQ8F8uaJQNfJoKmfZ7NFYMmskKpcvoU/89/q58k6IAuiOaNaEgVg4bThGDeqqfzGtfYv6OLZrmZGkT+tFWeJd3j09heAPJndxirlaCsTRZB5sEqLLGCbCdW7hpH8lHGHB74WLyglDwOt7uH94tPBb/g968wB3DwxCwKtbCA30k2vyU7jlHBzKBJgAE2ACTECdBGiI4/oVc1Cm1Odwd3dD/ry5MGZYH1StXMEmChcqkBtH/z0nyzpx6oLopKJrrfTi0ZPnOHZSG7d24y4UFr252hheRoeAKg1eaoCDRoOvKpWWQncqFMZiTuDNY8sfwaC7RfPUuhBF5zBaf8pjGk8HnmkYEOh32yi/oefZpZXCa5pHwYvLq/H63j8I8Lsj4vmfCTABuxDgQpkAE7A5gW+/qoS9W1bg+e3TOHVwCzq1bW6zOrq2bYJNO/5Bu9+G4dS5S/BMnUpfNo3pXbFuO+r90h2v/d+i6c819XHssJ6Aag1e65uQtFOmzFjCIgCDpyEyXnFwFmsyQBVoHN1g/gsXj1B0oZRO57Z+HfT2MZ6cnoH7h4bjg88lixn97v4DGjd8a1dnXN3QQKZ5/eAw3j77T7pNF3f29sTltbVwafX3uCLS+93ebZqE/UyACTABJsAEEjSBNJ4emDiiF2ZPGoKihfIiX+7ssj305PmvxVMwbWx/rF00GeOH9ZBjdCly/ZKpeneVCqUwpHd7CpaycNoIZMuSUbqT+kLXfjZ4dSQS6DpZ+pJwcktjRFssXgAAEABJREFUpr2DC80nrIhwDVxTZUPemgtQqP4WKQV+XIv0RX+FS4qMcHT1QLJ0xZAqaxWQURwOYfgK49jZPS3NkSTy0z+VQ2tjcfHIqQ94++w8bmxrA9+bO+D/+F8Ev/PRxxk5lE9lhQb549Kq7/Hw6Bjc299PGLZ18O7pWX3yR8cn4L3PVYSH0RALICzoLR6d+kMfr3MYvrAX8j6CenWJec0EmAATYAIJlkCh/Lmk7gXzfbr+yIAEvrh24w4qftcUDVv3wl9b/kYX0eObwJukOvVVafA+s/Bm4eOnz1UHL64UMuw5JYPStN68tRYj/eetkSJjKXjmqYl8NRch/w8rpXFbqP5m5PrfDLy4tBLXt7QAveD24Ng4pMn/I3JXn4t8tZche5URyFyuFwr+tB6F62+T6zw1F6JA3ZXIXLYHclWbhuyVRwjjOLWomgxWDVySZ5QvrV2SM0HUxL0Dg0Wc1jAVDmi7i8MR5U/5lCI8LBgP/50EMnQfHBkjDOdTnyJ1LlHk6wcHdT7ZHsMX9q5t+UX0BDeEVq9aoJfrHp2YiNs72uDOjtagtuszs4MJSAK8YAJMIKEQGDNYOx3ZyIFdEorKVulZvGhBHN6xFCvnjRe9uQNUOyOUVY1RaSJVGrx9hk0BfflMx4xmROg+YJzOm6TWpj2nNGTg5va2ZgzS5KuNrJWGIEPxtnB09zKKJ2OUDOXg98/lC25v7h+UU40ZJbLg0TinRKpsX8LVIweSpS8mjOOleiNacXAUvbjPRC5hgYpeYYSHAuEG1quIARR45f0BmUp3Fz3KzWD8o3ym6YGQD77wu7cfbx4eRmjwW1EmpTPO+ej4JMjp09bWlu0xjoXoCX4jgihfGAJe3wUNowj58EIa6Na2XRTA/0yACTABJqBiAhNnLFGxdglUtUSstioN3vo/VAMZvaHiUTbNgdul72h0adMkEW+GiJv27NwCs8hA/0cI8LtnFh5RwPsXF82iAt88NAuLTgDpYJbeYLiCLi5Vjm/gkaMq0uStC0XjqAsWa3NjVwSa/5slC0d4WIgwpRW5Ns9gGmJWAALfPBBWcYhpQvYzASbABJiASgnopik1XO/Ycwi9h07Cuf+uqlRrVktNBFRp8H73dUUUK5IfI8bPQWdh7HZs2RAVymg/AqEmeHGhC30kwlI9/o+OWQo2DxPGYVhokHm4CAmw80wJLikyid7hbKIm8S+M3dzVpsHduzAcXVPBJWVmaJySiQjj/08zRejCFWEoK1qP4gBQx63WZ+XSUgYF719eszI/JzMhwF4mwASYQJwTaNmkDkyFpgf9X9WKGDvVvGMozhXkClVPQFUG78mzF6GTzwrlwd37j1CiaCG4u7vKcNXTtIOCjm7GwxN0VaTIVE7njHwtDE16Mc00kaJxEsZoDtNgq/1kzJomdnB0g2fu75AiY2lkKNERuavPgeHPOWUW5PhqDPLVXo7c381Gvu/nIUWmssIA9oRTsnRQhEGrKIphFpC3YD162W6rSFsaMgC6n0hraiFbsm91yT+uqe3u3oU++njFBJgAE2ACaidQqlhhmEqxzwrIqUtdXFziSX2uNiERUJXBu2DZBhiKq6sLbt65rw9LSGBtpWu6z1uaFUXGpqvHx55Ts1jzgIylOgs7UfSO6qMUpCvSVO+LiSNLxYEgPQBhdApxdEuDrF8MlYZu1kqDpeGLKH40RjirKCdf7SXI+/0CeBfSTlNmmC1Fpop6b+psX+ndeoewiD1yfAvdC3uZy/SSBjSEToAGTu7eUIQhDf0v9m3XF8UOJsAEmAATiHMCz318sXnHP3j7jj6GBCya8Xuc68AVJjwCqjJ4Z08chMgk4eGNvcbJ0xVFnhpzpQEZUc9pVLWkyFgGBX/eBJppIWuFAfLFszT560aVLdJ45+QZcer995iwPx9G7c6Jg77/Q2x7Tb0LNUSOr8fBI1sVpMxcEaRrlgp99XqkyFxOcjCcPs0zd3VkKt1F/8JeqhyVRQ/yp5fr8tZcJNueqfwQZCzT2yZt1ytkhYOTMAEmwASYQOwJ7NhzGEPGzES9X3ugSdt+OHbqPIp9lj/2BXMJSYaAqgxeQ+oBgUE4f/GaHMqgG+ZgGJ+U3GRc0hABa3tOI2JDMy2Q0Ujxsf2gw4Q/5qJlx95Ys34bNm7djW59hqNzryFUdKzEPU1BZCrbE2To6nQ1LJA4GE6flqFEB8PoCN3J0n+OZMLwjzABRzABJsAEmIA9CcSq7OHjZ+Psf1fR9OfvsWvdbIwe1A21/lclVmVy5qRFQJUG78JlG1CnaTfMWLBKP5yBhjokrU1jv9bSPLdmH3Q4+Qcur6urne5LrO/s7YUr63/GpdXf4/La2ri7f4CRQqvXbTHyk2fNX1sRGhpKTlXJ/QePsWj5OsxbtAqXr95QlW6sDBNgAkyACURNYO2fE9Gy8Q84de6y7OEd8Psf2LrrQNQZOQUT+EhAlQbvsVMXsH31DMydPMRoiMNHnZP86t3TM7i1uyuubmwi1+SPDpS3z02mKfv44ld4aBAU8Ufr9z5XEBb8ThYbHhaKd8/O4+nZ+dJPRu31m3el23BB46kePnpqGBQ9dwxS+97YGqlhvmvvQRQoWVX2QPceNAalKtfCnIXLY1ATZ2ECTIAJMIH4IpA5YzrUrv4VWjapi59qf4NHT55j3pK/4ksdu9f73c/t7F4HVTBh+p+g6d3IbS954/8WdZt1tVfxVpersTplHCZM7ZECiqLEYY0Jp6qgNw9w98AgBLy6hdBAP7kmP4XHuBWKdTnfPj2F1w8O44PPZTg5OyJcGMrGAmTOlN66wqxM9fLqX7i5vQ2ubWqCu/sHIejtJ4M6JMAXT87OFob5e9DP0DAnPd8++w9jJ8+iKL2u5Bk7aTatWJgAE2ACqiXAihkToCENDVv1wh9zlyE4OARDerfHpuV/GCeys+/tk9O4s7c3rvz1E27t7ICX1zfZucbEUby7uxuG9e0Y741RpcHr6uKCgSOnY//hUzyG12QXeXZppQgxtVAV+FxdL8Kt+0+etrBJQtPytNFkzGpdtAxD4OuHeHh0DO7t74e/f8+A4rld5I2JoihyHY4wmP6eX1yCeweHgdamcab+oLePhXHbFpdW15Ry5a96eHp+IQL9HyMkwE/0Mp/FrV2d9Nle3zsES/Pyvry+Qa/nxAZvMKFVWmwakg3bhmfDiGZp8fT5C/i9pq+x6YuKd4fvKz90/G0Qcn32BbIWKIemrbvj3v1H8a4XK8AEmAATUAOBsxeu4rnPKzg4OEh1RH+LXMfVIjTwNe4fGooPL68gPDQQ9AGjZ+fm4+3TszZR4eHjZ2jTfSh+7TQAoyfPMyqTemAbtemNhq17YeKMRaCPclGCiMKpN3X8tD/RovMg/NJxAK7fMn8iS/lN5aW4DvUbPlnWQ3pcvHJTJtl78Diq/dQG9X79Tdhmf+hnx6D6O/cZhfY9hqPXkIkYOXEOfp8wB+1+G4YmbfvgzPnLMv/79x8wZMwM6aY83fuPRcdev8u2rvxruwynxZ/LN6BO065o33MESI9la8yHTlK6mIoqDd7nPr7w8X2FVRt28Bheky0b7P/gY4jxKvDtE+OASHz0Upi7V34oGu3m1zi6WkytKIbBIq2B39lJg0GNjHtzFShGY3gvr6uDF5fW4O2Tk3JNY4Hv7Osremsb4+aOdvC9udWwAjw4/Du0X3ALF+HhCAv5AFODNiwkAJfX/iDHGj+7sFDEU1qRPIJ/Zyfgi89SIKOXE9KmdkK1kimwekAWeKRKCTX9ho/5Q44zfvrsBV76+mH95p1o332AmlQ00uXm7bu4ck17MjSKYA8TYAJMwA4ENiydggV/DEfZEp/h/KXr6NJ3NH5oEnePyd+LJ5uWmvX++QVLwdEOmzpnGcqX/hx/Th8JGr7x4UOALOPeg8f4c8VGTB87AMvnjEVgUDA2bd+HiMJlJrHIliUDFk4bga5tm1j9YY6ps5fh8yIFsHLeeAzt0xGDRk0TJQH5cufA5hXTsWbhRGTNnAHL122T4bR4+PgpJozohfHDepBX2gAzJgzCnMlDMWnmYhlmungirnNjh/4m27rnwDH4vfGXRvn6rXuwZNYojBNxl67eMs0Wa7+wYmJdhs0LiGhqMptXFI0C12zchSbt+qFZ+wE4eOxMNHLaNmnyjGUsFpgqa0WL4REF5qg6AQXrbUah+ltR4Md1oA9GKA7Owr4MB63dvQpA45RcZlc0ilybLrw9HEC9wDrJlMYJd45Oxv1Dw3FnXz9xFxxslCU8LAT0meOQgNcIfPMQT07Pht/tnfo0WmNX79U6FIO6P97SUzmKMK7Dw0IBGR8O459i4DV0a4NzpHPGm9d+Wo9KlvsPHTPT5NDRk/LkYRYRjwFk5BYs+TVKflEL5b/+CdkKVMD+Q8fjUaPIqz549ATWb9kVeaJ4jPV/+w7d+45AwVLfIkfhL1D/l064eftuPGpkuWqdnnmLfYlMecuoT08DtTeI7d22a380af0bZsxdAp3hYJBEFU7Ss1WnPmjwa2dV60mw7tx7gItXrpMzXiV71oyoW/NrjBzQGVtXTceUUX3iVR9bVn7xyg3Uq11NFlnvh//JNS3OXrgie1T7DJuEtqLn9Nx/V3FZGIMRhVMeksoVStEKxT4rII1juk7LgEgW1CO7+58jaN1tCH4XvbXU8fjCxxfOoudokTC6qTf30LHTuHnrnr6UksUKI5m7m95fThjtDhqNDHvlZ/lJ6udF8iN5MneZJ42nB+4/eIL/Lt/Al5VKI0XyZFK+rlJOxttyobFlYbYsi8bo0A6gm5KM1rYsPzpl3RMbY8mqLZgzabC48+guuu3nIiAwKDpF2Cxt2sJN4JIys1F5rqmyCoP1e31YWNAb3Be9pdc2NcP1rS31L5vpE1hwZCjREYbTfeWoOh4F6q6RBnHeGn9ayAEEBYcLe1ORUiKPKzYMyYqQZ4fg//hfYdj+J/KEC9H9hwmHIsT43/fmNuOAyHzSuLWQQHGUgYqGHnUZ1knBpn5IfcPf3YGafiEhIUY3D3RyIlGTjqRL++4Dxcnz01ALH19f/NJOe2dP8WqRvQcOwyPzZ/iuzi9o2qobkqUrgFETtY/U1KIj6TF+yhzM/XMFHoleEhpms3XHXrTp0o+iVCUJRc/5i1ehidjeq9Ztxbad+9B70GiQ8asqmEIZnZ4r127Glu17VKvn3XsPxc1tTXxevjq+qPazHG61fdc/ogVx/0/nQ5qLl2ZnICE39WLGlSbuXgUtVuWe9jOL4dEOFB06LsKwpHyOjg7yOkVu4UDlCiUxb8owKWtEL+vAnm0RYTi0P+KldQGK+IOVv4m/95b1UH2Hti2Bt5cnRk2aiwzpvDFqUFd0b98MHwIC9aU5O4nHqHof4ODwyawME20yiNI7HT4OS6EAjaKB7vpnGE4MKN6W8kkzW5Yay7IOHz+Lus26oVv/caBxKF36jsH0eStjU2qs8h4+fkbucINF6csAABAASURBVHQXkz6dF/LnyYGTZy4ivn65v5uNfDUXIlPp7nKd638zjVS5sbML/B8dR0iAL4LfPcPL6xvx4Ng4ozTR8Ti6e8HRzcssi6KE4/iUnFKmdcgIRVFM0igID9MFmcZpwwNeP4DOMNc4frpL1MbS0txgpVBDSZmlgjTMC9bbJPT0Noyy6A4KDkOYe06LcfEV6ORofNIgPZKLO13DEwCFxbecv3jFTAXqAfBT2ZjoFu17Izg42EjXUePVZ/DS0BUjJYXn31PnQW81C6dq/nfvPWimy8nTF1Sn59JVG8z0pJ7U0FDxNMgsJv4CEoqeoybMAD3V0ZGi4VZdeg/VeeN0PWnmUmzeuR9eaVKDzo2r1u/AFPEIPq6UcHBJhayVhsItTQEoDi6i4ykL0n3eCsnTF4MtfoUL5sXhE2dlUcdPnofOYC1dvDD2HTwhnvzcl3GvRK8pfYE2onCZSCz+2vK3WAI79x5G1iwZLFyfZbTRokzJzzBzwSp93bqOxvsPn+ALYXSnTJEch4Q9ZJTJRp4iov2nz12SdVPbT56hTjMbFf6xGFUavDME8HlThyJ3zqygu5k/p48Q7mwfVY771YuXvsiY/pMhlTljOjz3eSkVCQgIgD2ELtZ01xNR2SGalHDNUAG0Nkzz1u8xQj74SN0MF28fn4qVnlmqjIN7hlJwcEktjMq08HsbjORujtBoFClOjpZ3JTKKIX7hYZYN3vCwEL1hHhr0Vp5IAEqrwMHVE5kqjkDmL0YjXfHOSF+qFyz93DOU17fNVM9/zvuLu8dwfbawsHDM3OKDN2/e6PMY8osv990HD6EoipG8fuOPd+/eqUrPsJBQPUudg27iX4qe3vhiZ6len5evdOrp13QSvXbjlqp4vnihPY/olRSOsLAwBAUF2VHP6J+ziJ1QzexfbXpev3HbTEfieUk8jre0n8RXGOlJTMPlIDKxFAcRGeVq0/PEqbN6A0TqK/R88vQ57t5/YNf9k1iYbkgyumZNGCh6GJuiX7eWWCjsguPi5tA0nT39yTOUQI6q40DDAKmjKU3e2jarjsba0thceuFr298H4eLiLMvOmD4tendpgRETZoNeXCPxE0ZvROEyk1i8ffceP7foAbox6NO1pQiJ+r9zm8by3NOodW/QtGh/bdYazS0a10Hz9v1BQxrILom6pOinyJc7O76sWBodeo5A9wFj4eWpvbGBDX+WrRQbVhCToqgrO31aL9FDEyKzU4/q+w/vpTu+FormEypFUfRq1KtXD/aQxYsXY/v27dEue/TA1nrdDB0hQe+jXZZhu+o3boku40+h1wI/9Jj7HMlcHQyLj9B97Dpw+QGw71I4Lt0Xhqc4YX5KLPyfPNL1/kMA+i6DlF7zX6FpuyFo0qY/fv1tOn7pOgEnRHlBIdoLBK2PXQvHL53H6ttmqGfPeS/Qe/4zlP/tNjpNe4yecx+jbLfbWP7PG7Rv11afx7Cd8eUOtDBEhvay+NInono1GvNtRodDty6dVcVT7CFyfzJc0AW7Q4f2qtLzQ8AHQxW1brHhGzRopCo9Hz8SB7FWO/2S9oVff2muKj3dhI1A25m2vxRxvnF2csCAfr1VpWdoSKD25haK9k8cRBohatPzwUPt8CVFEXp+lDDRadDJzsfRvn379PuZzuHm5qJz6tc03lPvSeAO6kibPLIPZk8aAvqK3K51c/UtqvpFWSyeOQor5o7DjjWzQeNmKTKicIpr/2t92WG4aMZI5M2VnYIsSs9Ov+K7ryvJOI+UKUAvq62cP17WM2ZIdxn+fbUq2LR8GqaN7Y8eHX/B9HHaF6opX6/Ov8o0tBjQoy1IJ3KTkK60pp7h9UumklPWZZiH6ihetKCM+7nO/zBr4mCMHtwNfq/98Zno9ZURNlpoLJUT32Hubq5SBY9UyUF3PIePn8UrP38ZFh8L7zSe8PN7ra+appBK65VG+rds2QJ7SKtWrVCrVq1olz1y+jZAMd6sYQGit+jaKwws+BQDCzzF8LKhWDl9ZLTL1rVz69atogrjOiB6KrQC/c8lRSa0GrwN9XpuRZfft+HnXttQoO5KZC7bQ/TYthPpFCHG/27Omkj1ajFoK4o13obCDbbJNZWv08vS2ttbOxTj3xsfcPCi1rhwdnGSNxOW0sdXmDEFrU9RFEyfMTtSHnGtb8EC+c16fDw9UqlKR2KSIa23FqLBksaK7f17t6p0rVShjBlPN1cX7Pl7p6r0zJojp5meoaHh2Lhxo6r0bN3yFyiKAv2fcJcqUUxVOtL+6eBkbrzReEe18XR0dIKiKAZHEUCXF7oGUDvsJd988w1Mfw4ODnLqKxq7u2bjLrT7bQTy5MwGeuxOYpqe/QmPQM/BE0BTqjUTvcn0AlvO7MbvK8W2RaZWS2zLs0n+erW/BU1T0aFlA+w5cALL1m5F2+Y/2aTsmBRSsWxx0LiVQPGY0ffVa1y+dhtlShaJSVFxkse7ILH6dJIKuPUGYe8DhT1KvXPhCHr9HNcWae/cYqqQk3t6k6wKwhQX0GwPKTKWBr0El7v6HJM0gMY5JVJl+xJeeb4XJ1Lz3c8pmbmhYlZINALWL58NJ0dH0MWEen40GgULp42PRglxlFQxr4f0zZkjq3lEPIbcuEkzCBgrS3M3+qlsDO/wQT20Bpq4EdP19NWrWyMm5Oyap1fXtvK4FB2RYi3+lXD06d7BrnXGpPDbt++J41UxEtL5pgiPSXn2yrN5x17tdhfK0fFDcvTEKdXNdvLmzVszBIqi4Mz5S2bh8RnwweDlJJ0eYi/A0WOndd44W9P4Yf+377Fpxz/Yd+hf+XLUnfuP9FOXxpkiCaAi6k2lXlVDVZeu3izn+aW5fnVCYYZp4ts9a8IgkO5r/5yERj/Z/nxtbnHEc4tDQkNBJwPqWs+VPYvoQu8HmqaMptaIL9WyZcmAOjWqomWXIaAX6bp3aAZnkzcT40s3qtf3xiajz+u+97mGQvW3IHP5vshWZTTCAsMomZGEvPUDQoKMwqLjyV11OKgHF1AAIY5uaZDryxHS0M1aabA0fBHFz7tQQ5GC8ouV+Fc0TshUsrNw2e6/R7/fERwSAo24mCiKAnoc13vIKNtVYKuSxAW6kJeCvhWcMegLZ5TPrJEln/0v9hfA1zeO49Xl/bK82C6CxE2fpTJ0T2UsxcVH2K49B7XVau/xIHZRHPs3/qYTRAS/lWs3A2K/FP9iLf7DFdAb/FDZ7+svK0pDUnfjSIZk+nTeyJdHXS9/Xrx0TeAU5xTxDyGKIo55cWypzTBXNIrkSRx1EhYWFq/vqlja5RxFr6ppON1Ali9XwjTYLv5rNz7NpkN2QGRiFwUSUaFN69fC3MlDjYTCotfEhJ1ae1VVURvoADtw9LSKNNKq8vMP1bBs9mgsmTUSlcvHzcGurTnyZUiAL56cmYuw4PcyYXhYKN49Oy+nIkuVpSKSpysiw229cE6eEdSDS4Y1Sb5ai+HuXSha1ZDBS3l1hnnBehuQzEZvvOoUOXfhMgp7az4Zklk0ePzkuRyYr0sTk/WdDWNwdlRNnP29Om4s7x+TIozyNC3qjGk13PFtbid8mcMJv1d1w+AvXPBZwfxG6aLjeXXpAP7tVwZX53XC9UU9caJPaTw5sDQ6RZilDQ0PQ5G0GvSr6ILBlV1QIauDSBMueltoLZwq+T928izCQ8MQ9tHgDRVGD71oo7ae6OWrN0JRFCN5+PixSih+UuPdu3dSR42BrsEhxrNgfEodf64w0WFCBqROg3CxA4QJQzLZxzk/deHxvXZxdpY8FeXTtocCOKmoI4UYETtDnhRGTOlrleS2t0yZs9zeVXD5SYiARo1tpcHbK9ZtBw0fUKN+atLp9b1DQh1xphRLw/+3T0/pvW7e2fRuncMxuQfg6Kzzxmi9at0W/NSkHb6v1wLzFq2MURmUyV6GOb3pW79AOP6o7vbJkPxKGJLCUHv46ClVHSO5Or8znh9bhyC/Jwh68xy+53fjwvh6MSpLl6l+IfNtUTmHY6wMyTt/jRJGX6iuCvG8PAwPds745I+Bq1FBjTnPL1xBHyag4tQiT58+h8bRAQ4aBdSb5qhooCiKnNBcLTqSHmRQ0NpIRC/vspXm02sZpYljz55/jpj1SL544Qu1TZ9G9zeKIrY5PorY/jR2W1GUOCYWeXXBQcFmPCGUt7g/RF6UXWODg0PEeUP8ixtGMnzDxA2vItimSpHcrvVy4UzAHgQ09ig0tmXS5+WmzVuBGg06oly1JnqJbblJNX/eXybBlYxeedJX4JwqLfL9MjlWOHoPGoUWHXphx98H8M/BY+jWezh+FMZvrAq1cWZ6yaF+YRezUitnd4SXl6dZuLUB/rfNn0B8eCEevcViiIi7k3ntGrG9nl6P+WP44HevzAoNDw1BkG/MexB/LmSuKBnmb/zj76VSs0aKgFAL06fRhfqVwcunIplq/6tULqcq3UIET0URBI0EePjY+k+ax0WDwiOo5MHDmO/zERQZq+CIeL5+o67jiBqpaD5td7p5EPYu1mzYTlEskRPgWJUR0KhMH6nOsV3LYElkJC+MCKTKVkn4zU/zydOXFOHaf1evLCja6y+UGXsSZcadRLEB25E822fayBgul6xcD0VRPuUWTho3Sb2qnwKj5wrweYDz438Uj95L4UTvUjg7sjr8756NXiEmqd2dhWImYRqht1OAn0molV5h1IYJsZTa/2HMx9u+tzCcOkz0qnhmL2ypKqvCNA6OFtM5p9TOXGExMorAZBHwDHh6I4qccRxtvtnl/rp+8644ViSK6izoSWMk6SM3UeRUQbSCQAsvNcWnYhZwyu3+9u27+FTLyroVnPg3duc7KyuyPpkFoIqioFCB3NaXwSmZgEoIqNLgVQmbBKGGo6snMhRvA42Tu9RX0TggWbqiSF+slfTbY0FG7Rt/8wsIPY67cu1WjKu8sbgHPry4CznwUjw6C3z9HNcXdo9xeZQxUDyRE88OIYWeGQohQ9LNO4bTnTg6wym5dko6Kl8niqMTUmQvpvNatzZItfpSoNBM3LiIf9KVVgfuhODJ0xcGqaLnTJGzhFkGN+8cgGiDWYSVAe+CSDPjxMTTI1vMDXPj0uzno0eybX6lFyXtV0d0S3bQaBBGY43DhJkrJFTs92JHUN1Yzoja5emZOqIo1YTTdk+X1ks1+kSmSKmSRSOLjoc4c4uXeHp6qH+7xwMsrlLlBDQq14/Vs4KAZ57aKFB3DQrV3wr6vG72KiOtyBXzJA4ODlBE76N5CQry5o54gmvz9MYh75/fgSL+ROGQKwAhH8Qjvgh6VEV0lP+3/BRA9EhIgXAL8XkfFquxhzl+7K8tk2w/wYFWWarFbiqpwukchWZCP/EPoS+tcqTWIHOm9Ijpj3rxhRkljH1Rwkc93TPkEp6Y/6+5ZN4VfeBuCF6/Ftsp5sXaPKe7q6tZmbSd3vi/NQuPzwC6WdA4aKDRKFCEOCgasfkV3L33MD7VMqub2JEwJTQqAAAQAElEQVShQ/tTmLDI6cWlsLBQPHqkriEN8mZR7Ou6BpDOxFhts0kQT52OujWxffbcR+dVxVr3pUxDZQivp6eHYZBN3JYK6da2saVgDmMCMSKgiVEuzpSkCVAPb9hHAsXSKyifWZG+cIThupynVXqjvwilF6zoUkDlCSEnlRILgzenh64QKkgrXu4axOaR8bNj64QRKcoVKgrrBLR68e9mbeExXBZN52CWM7uHBv/s228Wbm3As0PLhW5CO/EPRYEiMvr+t1csY/5fWBjmCBNbn656wvCB2OY5hJ50ExTzUm2fUxplQkcyeKQIXan95LZ9bTEvMSJ9smfLHPNC7ZBT7D5QFAX0p6GlRoFG4wAPj1RQ209RFLG1w6UoCmms4L/L11SlpoOD0NFw/5RuoGD+PKrSE+Ef9YSWp3Z/Dcfjp8/iRM98eXLo62nXYwQsiT4BO5hAFAQ0UcTHSzR9dCJeKuZKrSLg4OCAL3O6YXdTd0ys5o7fq7pjj3DXL+SMAvlyWVWGWSIyasXFCeJiCt1PEQ4h/k9pfKhwx+Df1dyOhEbUE/o65idse7y05iwugGbNE3pmTmbeo2qWLoKA0EDzYSd0wXr/JOYX/6JkmGvEaUPoBrmtNMguDF7fF8+hpl9QUDAURfkk0Lr9/N6oSU2LuiiKggsXr1qMi69Ahba5hcpz5zSfAcZCsjgLonMT7ePCPgMJmWkCJ9JZ+PJenClloSJHR0dtqCJWJB9XNCxMONXzL3RTFIWOHq0It0bsCzQMJ66VbNmkDnRS63+V4erijHTe5sPL4lovW9V38Ogp3LxzP8riduw5hPHT/owynWGChq17weel+UvMhmmi67545Sa6Dxgrs+09eBwjJ82VbjUvxJVLfeo1bdsPv0+ci9sqe6ynPlLxp1G3Mo5w1Ch6BTTC3aq4M+iCow+MjiOicaWiI9XFI0N0SjJK+z5YFGAUAtAjzqfaaYtNYqzwCsPcHi+tvQ40rzs4LBz5y39nHmFliINLMrOUiqLAPUM+s3BrA5wdP21zfR5RZr60DnqvGhzS6DFRhMJSpUphEqo+L+mZIrn5totXTalX30QBRVGw78Axk9D49bq5uUFRlE8CRSgUjgzpvMVaPf+K0EtR5JJcUBRF9JhrrB9qhbj5WTqf0/nTKR7mCy5VrDB0Uv2bLzBlVB+89I3hy8cxxPf62lFcntkSpwZWwn8Tf8bTQytiWJJ5tqP/nsPtuw/NIzjEZgRUafCuXTQJeXNlQ99hk9G5z2gcPHYGdBGwWau5oFgTSO4kHmublOIk9iafh7dMQq33Ko5O5okVwDm5p3m4lSHXX9Jba8aJfd6FIVOGdMaB1vqEYe7g7GaeWlywUmSP+Utrr/LURogwcIU5LsoOQ5hwX3KI3Ytg6SqZj3/zLFJVlB/z/1AHc0MsDEqsXtiLuTYR5xRPiI3OGbrzh99rdfXwurq4mDWCbtGKFIr5TYlZgTYI0DiIg9ukHGL8zVcVTULj1+vhmUoeO2FCOdrm2nX86mSp9ojGwKrNMK9R7Suz48jTw0M1X9jLkS2zkX6WWNsqLOTdK1xb2BVv711AWHAAPjy/g/tbJ+P19eOxruL6rbs4cOQk5i1ei9bdhuDeg8egXtNqP7VBvV9/w8CRf+Dtu0+9NPcfPkH7HsNR75fu+GPuclk/GcuUV3rEYsGy9Vi2ZotwGf+36joYVGbDVr2w//C/+si6zbpi4oxFaN9zBPYdOqEPN3SQUd6gZU+06DwIW3b+YxiVINzmZzEVqO3q4gz6stnqBRNQt+bXsvv+x+a/YeP2fXG2c6sAQ2xUsHveULoqm9RCQam9M5qEWu9NmauUWWI375yAMDLNIqwMyO8tjGhx8RM7jshBGobDK5km5j3RopSw0BCxpLLEiv6FU7HQA0ZR1srR47q5fTUiC4mCi5diPvRAFILM37RGoQ4L4FW8OtJ89jXy/jIBuZuMoagYS4ov2yNUGOO6AqjZoQVq67yqWTs5O0JRFPFUO1yKoihSt9QqG3OaOUtGhAuIdIMTLriGhYdBI3SlcfJSYZUswoSOZEDq1CF3OMJw7r8ruiBVrF++eCl6ShXJUFE+rW/evgc1/bp3ammmTrWqX8TqvGRWoA0CRg/tjcyZMshjKFwskydzx4yJw2xQcvSLCBX74JTZS/G/eu1Qs2EnzF60Bt3bN5HHefRLi34O/7vnLWbyv/XpI08WE1gRmDdXdlSuUAqtm9fDvCnDkE2cF/LlzoHNK6ZjzcKJyJo5A5av26Yv6dLVmxjerxOWzB6NQ8dO4/ipC/q4qBz9u7fB2j8n4Y8x/TB1znJ8CAjQZ8mSKT1mTRiEryqV0YfpHCGhoRg+bhYG9GiDBX8Mx3MfX11UglnTlVWVyhLcHXsPY+HyDXKczi+NauPIibPo0jd2F2xVNjYBKnXRR2tAGKp+73U4HFws9H4aJorEnb/VNKQt9xOcPTLAOWVaeBb9Fp/1WhtJjqijXB1FGnHhE2dFckghg+LDi5g/OgoPDZbl6HpjIVCEizpi80GHGmkemgwRAernC0ZsP+GZPHtR5GowXBq6qQtWEXrH7v/35YfwzdL36LnrAwbu+4Cvl75Dp3lHYleoHXJXLKudh1oRG4eEqvBM7YFUKdU1pOHFcx8oGo000hSNAo2iPSWrzUBLlSolFEURJm6YFEURVIWuapv9wN3dHeY/BWoba9ypTXP8MW4oSpf8HIUK5kW3ji2xfMFUc9XjOWTP/sN49PipXot37z9g/ZZden9cOhYs/Qs0brRV07ryOH7z5h0WrzLvwYxLnexZl7OzExat2Cieco+SRu3NW/f01VUsWxzeXp5wc3XF99UqCy439HFROe7cf4ghY2ag/+9T4f/2LR4++vQ+y1dflI0w+6PHz+CVxgNFxP6qKAp+rPVNhGnVGqE9u6pMu8UrN+Mn0aN79MR59O3aAvOnDkWt/1XB+GE9xF3FS5VpmzDUubNhDM6Oqomzv1fHjeX9Y610713vseFqEJ74h+HF2zDsvR2MXze+x0vfV7EqO0edvijWfwuKDdyOPI1HxaosyhxAnbHkMJAw0ePr7BnzccEaF91FlQ4fEkhjwNkzI2L6S+ESbpbVyUGBpyMZ12ZRVgXY40Me9DJVl7JO6FHeBV3LuGBAJWfcEI/j1DZUoEOrptD2QoaLfikhYps3rv+DVdziMtF335rfhGTJnFE1j4x1LOrW+p/kKUxzkBBbeoOeevx0adSwDgoyf8lTXJuhthuI/YeOo0vvofj31DlcunwdU2YswLQ5i9WA0EiHtR+/qCZub0BCkRuEwRsfTyD2HDiOqaP74qda3yJ5cnf07vIrDh+P+ZcoqS3RkRSi88BS+hS5SloKjnXYqElz5djzUYO6ip7sZqIn9tOLHoZjqx0dHEBPYBwcNPIY1VVsaRtdvnYLy9duQ/MGtTF70hDkyZkN7z8E6LLA2Yl6iPReM4eDqEsX6OgQeVpdOjWttVdrNWkkdHkj7jrmThmC3wd0QqH8uUXIp//Bvdp/8tjIldiLuTq/M54fW4cgvycIevMcvud348L4ejFutvZAUjDtRDAar/+A+n99wMhDQVAUBW/ffhpnFOMKbJjxhkNes9KuvE0Vq0eHGb5oalZmbMfGahyczMoUZy/R0x3zCfPpQx4BL0SvgDD2IMy+IBt8yKNvyQD8kM8ZGVJo4J1Mg6o5nbDoB3eo7SWreYtWyv2RLtJSxL65dOV6c8bxHNK/Z0cUyPfpHJfG0wNTxw2JZ63Mqx89tA/atmiMdGm9hLGRDDWrf421S2aaJ4znkBr/+8pMAzXeQJCBa6ro+KlzTIPi3X/95m0zHci4io8bCAeNxmw6yeBgCz0aZhrbJsAxWWrkazEVybN9Bo2TK9zS5kDW77sjVd6Ie0WjU7ObmyvevPk0TziN0/2iQkmkTJEch0wM+yMnzuCFj68wggOw7e+D+KxQXqRP54VnL7QdgrSNTp69aFb93fuPkC9PduTMnlnWdfHqTbM0EQVkyphOdGj54dXHmW5OnLZ+GEVEZcZ1uCauK7Smvs6tGyGt6K63lLZQ/lyWgjksEgL+t0+bxX54cccszNoAussrUbwICntr0LeCMwZ94YzyWTRIn9Yb2bJmsraYOEn3Y/+Z2BlSBgcfaXD0EbDtbQFU7bc0VnXbY2ysR+5SZjq5pc0JODqbhVsb8MHHfIqb2H7II18q8x7nrCkVOITTHMpQze/8RfOxpa/f+Md6iIitG5g7Z3acOrgF545uw6Hda3D/yjHQWE5b1xON8iwmpRuayWMG4fZ/h/Ds1imsXjQdpLvFxPEYmFBuIK7eMDck37//gHvCIIlHfGZVf/NlJbOwDOnTCqMpp1m4vQNcxeP7gMAgWU1QUDDGTl2IwgU+3SzKCDsvUuUrj4IdFqDk74dQpMcapK/UyGY11vjmCxw9eQ5tfxsGemmtReM6aN6+Pzr3GYWQEGPDnsb3du0/Bk3a9kXZkkWluDg744tyJUFTkPUYNB7eaTzNdPuifElcvHwD9OIavaBWKJ/19hT1JA/s2RaDRk1Dp94jVffUxKyxFgI0FsLiLajy978iMok3xRJyxZFMoxWb+VgnN/0cf1R3w7e5nfBlDif8/pUblrbIpzpSNG5zyKQZ6LboCDr+eQTDZy61iVGeXDzesuXYWHuMX7bHxtAgzLxYBfB/eMk8PB5DihYuYFY7jd9NL27KzCJUEJAjWxZx8TZ/GqEC1RKUCmSEJ4QbiPx5zA1Gd3c3m5ybbLnB+lt4AkFjj21Zh7Vl0WP4J09fyOT0clVa7zTo1r6J9CeGRe6cWTHp996YM2mIfGnt+2pVsGn5NEwb2x89Ov6C6eMGyGZ+93UlGbZi7jj8tXgKurRpLMNp0avzr1g5bzwmj+wDGgrR5OeaFCzDvNKkBg1BWjp7DOZPHS6eoHeRwxqKFtZet9cvmSp7k2WGCBZkXJMeJNPGDpD1UNKqX5TFgN/akFPVEn2D147NObD1T0Qmdqw68Rbt6Ayn5GnM2qc4OiE287GGXN4O05/j03OmQeyPBgFbj19288pqVrujWwpA7BNmEVYGvA4U1q1J2uDQcLhn+cwkNH699BKQqQa9u7czDWJ/IiWg9hsIS/tnr65tVbc16It/2huI7Ti4S/sEonq1L+NFzyoVSyJHtkyy7mF9O+DXRrWxc6/6XpiVCvJClQQ0qtTKDkqt2bgLTdr1Q7P2A+S8vpaqoC+RdOo9Ci06D0b/EVPl+BhKd/bCFfQdPgVf12ktHgUMxYGj5kMEKJ1aJceP/aEYDDaHokGWah1ipW5Y4Huz/PQiS2xmKjAr0EYBq9ZtQatOfdC8bU/Q2E4bFav6YvI0nwhX72yAQkaqAudUaZG3xWTE5rfsZvKP8wVrSwkTHb4LzpgPc9DGxt+ySqWyuH72H8yc/DvG/94fx//ZiG4dWthcIS6QCcSEgKX9s3c39Rm8urap4Qbi4pUbAAfrOwAAEABJREFU8oNU7XqMgE7+mLNcujfv3K9Tldc2IEDDFtp0HwpDSYhjdk1RaEwD4tNPO/Gtuw/kDkxuU4mpbvcePMGSVVvEo4LBGDe0O0ZOnIuAj2OBDMucKg4e6rJfOG04UqZMgeVrt8todzdX9Oz0C3b9NQfNG9SS+WVEAlmkLlQZpUefQP7W0+VcrGXG/osMlZvaQftwOMdipgI7KIQJf8xFy469sW7jDmzevgfd+gxH517qeymI2n7/wWMsXLoGcxYux+WrNygoVuLqlQVFe/2FMmNPosy4kyg2YHusPxDhWfhLfGsyLdkzz+KxegkwVo2MJHOmjOnRvNGP6NC6KYoU1D62iyQ5RzGBOCXA+2f0cA8dOwtFC+fVf16YPjOcPq2X9Bf/zHwIU/RK59SGBEb074y5k4caSZkSUT7FMyxClW5VGby0A6fzTiN3YHKbSkwJ0tQllSuUlG94pk/nhfx5cuDkmYsw/R05cQ41vtUO0q/xTSUcPnFWJskn0nt5esBBo0HFssUQHBys7/2VCRLIIlWesrDFXKzUXOrNpbWpqK2Hd93HaXUM9Vy7fhu0M00Yhsave9fegyhQsio69xyC3/r9jlKVa0nDN361Mq99cN8u+KXxT3gcngbX3qUETVc1a/JI84QcwgSYABOwIQFXFxfUrFYFus8L05qmJ6N15ozpbFgTF5VYCWjU1DDacWlQNa0tSUx1ffHSFxnTe+uz08Hx3Ec7fYcukCbUpie/qT1SyqAsmdLJaT+kx2CxYete5M6ZTU74bBCc5JwOrslA02ZJQbhof7h4cq5RVQ8vGbW3xRMDoZzRv//bd3j46KlRWHx7Jk9fYKbC2EmzzcLiO4BeApwxaQSunt6Lm+f3Y+m8yda/aBPfynP9TIAJJCgChkMV+nVvZaZ793aJ56U1s8ZxgM0JqMrg1bUuMCgI9PGJbv3HGg1v0MWbrmcsWIk23YeZyar1O/VJFdE7q/MoiqJzGq01RmnM0Vy4dB3L123H4F6fxloFBATAHkK9yGSw2aNsW5TpXb4BhIWrFRBPBakKVrELi5jqSwy/qFgapr/8eXMhXdo0qtL12o1bpmri2Qsf3L3/QFV66rZFYGAggsRxqvPzOiBW24l5xo6f6f7HPBM2T7r20Qlxx57DtJJSyMKUpPT0VUYmwAWrHPcEzK26uNfBrMbh42bjxctX8Hnphzo1vkJydzfkz5PdLJ0uoEXjOpg4oqeZ1PleOwm5dxpP+Pm91iWH7ys/pPVKo/eTI5moIzQ0DEHBweTFS5GGPt0nPWLxwscX0+evxPRx/UBToogg+e/o6Ah7CM11qyiKXcq2hb7uJX/GjuAy+vltt/rnh2OlTqrTd0jfrsiVI5vcVrRIn9Yb40b0U52eeXPnJPWMJJ23FzJnzKA6XWn/of2ThNwssT8HEEsSZhl7lsSQWJKQmyX2TIklSVyxVBTqRDE6HbKHCcSagCoNXnoM3bNTcyRL5oZqX1XABGHMPnz8LMLG0vekaWJ0U3FxdpZ5KpYtLr9UQj3Hvq9e4/K12yhTsoiMoxkYdF9rKV/6c+zZf0yG7/7nKCqW+Vy6afaGASOnoX/31siQ7tPQCIq01wmAeptJ7FV+bMsdNWEmxq/Yh6F7/DFwzztMWn8a9DJYbMu1df4ihfLjwvGdOHVwM47uWYdb/x1E1SoVVGdE/tbZ9HEd0Oe3dqrT03D7xOUF0LDexOpmno423d+ZZ8LlSdc+ur6yMAFbElClwZssmbtsY0hIKN5/CJDu4OCYf8kpW5YMoqe4Klp2GYJu/cehe4dmcHZykuX2HjoZ9AUm8nRr1xhbdh2U05Ldf/AEjevVoGCs3bQb/12+gYate6NctSZSnj73kXFJdbH/kPbGwLD9h46eVN3LYDr9aEJ6w0+46sLVsqava105tRfTJgzDpNEDcfLAZtCnXNWiH+vBBJgAE4g3AlwxE7ABAY0NyrB5EcmTJYPfG39UED2uv3YaiF87DUL6tMZDEKJb6c8/VMOy2aOxZNZIVC5fQp/97/Vz4ZUmtfTTetaEgaBpyegrJdRzTBHtW9THsV3LjCR9Wi+KYmECNiOQNUtGtGj6szR0C+bPY7NyuSAmwASYABNgAkmdgCoN3imjesMjZQq0aFJHDiPo0LI+endtkdS3laraX6VSOTN9KpUvBXqMaBZh/wCugQkwASbABBIZAeqA0jXpxu17siNM54/u+vnzp2BJPAyiu/0pvSoNXlIsIDAI5y9e079Edub8ZQpmUQkB3Xys6dN5I42nB8/HqpLtwmowASaQ1AkkzvYP+P0PhIWGycbROz3R+TCVp2casCQ+BnJniMZCVQavbnwsrb+s1UJOSdal7xjoJBrt4qR2JqCbj/XWhYO4f+UYz8dqZ95cPBNgAkwgKRMICQmDZ+pUEkGmDGnx/IWv/iNVd+8/kuG8YAKREVCVwasbJ0s7dcO638nxtmv/nIj2v9bHD9W1U4xF1hiOs44Ap2ICTIAJMAEmkJAI0Lzq4eHhUmV6oZ3m6tV9oMrp40voMpIXTCACAqoyeHU6BgYGoUvbxsiTMxvoq2jNGtSE35s3umhex4DA27vncWvVYNxc1hevLu+PQQmchQkwASaQ6AhwgxIIgVw5smDLTu21a83GXcidM0sC0ZzVVAsBVRq8dBfXe+gk7D98CifPXsSRE2dx/+FTtTBLcHo82DEdl2a2hM+Z7Xh5YQ+uL+opDd8E1xBWmAkwASbABJIkgd86NMeeAyfwZe2WOPvfFfTu0kLPof4P/9O72cEEIiKgSoM3jacHjv57HmOmLsCQsTPRb/hUBAeHRNQG+4YngtKfHVlt1grf//aahXEAE2ACTIAJMAE1EsiaOT3+GNMX/2xagAnDeyKd96epSpv8rJ0zX416s07qIaBKg3fNwglYs3A8WjWtgxaNfsCaP8k/QT3UEpgmoUEfzDSmXvQg38dm4RzABJgAE4iIAIczgfgk8OTZC6zbvFsKueNTF6474RFQpcFLxtgb/3d6mq/fvAWF6QPYES0CDs5uZukVRYGzZ0azcA5gAkyACTABJqA2Att2H0TjNv2weccB+fXTRq37YPueQ2pTk/VRMQGNbXWzTWlj//gTHXqOxNkLV6W07/E7JkxfbJvCk2Ap6SrUN2u1Z5GqZmEcwASYABNgAkxAjQQ279yPHWtnytmbVi+YgLWLJmHxyk1qVJV1UikBVRq8p85elMMYRg7sAhIa3nD81AWVIlS/Wlm+64RCHRbAq3h1pPnsa+T9ZQJyNxmjfsVZQyaQkAmw7kyACdiMgHcaT7g4O+vL8/L0QPJkyfR+djCBqAio0uB1dnYC7cw65b3SpIaTk4POy+sYEEievShyNRguDd3UBavEoATOwgSYABNgAkwgfggkT+6OFX/twHMfX9y6+wDT569Esc/yx48yXGu0CaghgyoN3mTu7mjddSiadxiAxm37olajznjp+1oNvFgHJsAEmAATYAJMII4JbNq+D9PmLkftxl3QpG0/LF+7TQp9mZUkjtXh6hIgAVUavGFhoQgODcXjp8/l5wNzZMuEft1bJkC8rDITYALWEeBUTIAJMIGICRzbtQyRScQ5OYYJaAmo0uD1TJ0Ki6aPwN/r5wmZi6mj++KrSmW0GvOSCTABJsAEmAATYAKJlQC3yy4EVGXwzl28Fk+f++Dho2cY98dCkN9Q7EKAC2UCTIAJMAEmwASYABNI1ARUZfDqSL96448N2/Zh445/sO3vQ3rRxatpHRISDHtI2bJlUL36d3Yp2x76qr1MIByKgsTCM97bwTxte9zTPOO8f9qOKfO0HUs6t4eHh8Xp+TMsLExNl3nWJZEQUJXB26Z5PaRP64U2zX6UnxAc1qcDBvZoI6XJz9+rEnl4eLj8KIat197e3siUKZNdyra1rgmhPO3OozBPG+2vzNO2xz3zZJ5qPo/S/qkocXf+pPqsF07JBKwjoCqDV6fy7n+OoVSxwkayads/umheMwEmwASYABNgAkyACTABqwmoyuB9+PgZTp69iDdv3mLkxHn4tdNAOS1Zw9a98eDxU6sbxQmZgCEBdjMBJsAEmAATYAJJm4CqDN4zF65gwbINuP/wKY6dPI+7958gJCQE794FoGKZYkl7S3HrmQATYAJMgAnEjgDnZgJJloCqDN5a/6uC2RMHwSNVcmxdNR15c2fD6gUTsHnFHwgMCkqyG4kbzgSYABNgAkyACTABJhBzAqoyeHXNSJ/OC8HBIfD3f4dDx8/IYQ4+L/lLazo+dl1z4UyACTABJsAEmAATSGQEVGnwBgeHonaTLqAxvf1HTEXnPqPx9NnzRIaem8MEmAATYAJqJsC6MQEmkHgIqNLgDQoOxsJpw1Ewfy5MH9sfvbv8inJliice6twSJsAEmAATYAJMgAkwgTgjoEqD19HRAc9f+IpeXR8ULZwPX5QrAV9f31hBWbNxF5q064dm7Qfg4LEzFsvyefkKnXqPQovOg0E9yx8CAozSvfJ7g69qt8Kshas/httv9e7dO7x+zcM4bEmY5rm0ZXlJvSzmads9gHkyT9sSsG1pvH/alieXFvcEVGnwvvV/h9FTFsgxvJu278OJ0//h4pXbMaZz78ETLFm1BXMmDca4od0xcuJcBASavwQ3dc5ylC1ZVPYup0yZAsvXbjeqc+KMJSheND+gQP9zcnKGPWTfvn+wZs1au5RtD33VXiY+bjS165lQ9GOetj3uFUV7Ukko29+innY6F8akLkVhnjHhFlEeRdEgPBxxdj3SaDTgHxOwNQFV7lWhoaHyS2tZMqfHngMnsGXXAaRKlSzGbT98/AwqVyiJZO5uoBfi8ufJgZNnLpqVd+TEOdT4tpIMr/FNJRw+cVa6aXH+4jW4ubmgUP489FVVCmJhAkyACTABJsAEmAATSAAE4tLgtRqHZ5rU8Bbi6uqCaWP7yanK3Fxcrc5vmvDFS19kTO+tD86cMR2e+7zU+8nx7v0HUKdAao+U5EWWTOnwwkc7jILmAp42byU6t24o43jBBJgAE2ACTIAJMAEmkHAIqMrgPfLvOZBAPDpZuX4H3vi/lb2sQ8bOEj28KWJFVTF4RKIo2sddpgUaPkZRxCMcXTwNbahbsypSpkiuC9Kv3717C3tIUFAggoOD7VK2PfRVe5kfPrxHQMAH5mmj/ZV5xva4N87PPI15xPZ8wjwTNs+QkGD9NVbnqPz9r4hMdOl4zQQiIqAqg3fNhl0gcXd3xYp123Dn/mP0HjwJp89eEvoLK1gsY/LvncYTfn6fXgDzfeWHtF5pjIqi4Q6hoWGgGSIo4qVI4+3lSU5pdI8YPwflqjXB3MVrsWT1FkyZvVTGubsngz1EO5bKyS5l20NftZfp6uoGF/GUQO16JhT9mKdtj3vmyTzVfOzH9f7p6OgE09+BrX8iMjFNz/4ERCCOVFWVwTt1dB+QzBw/AFtWTMfudbOxeeU0+dW1meMHxhhJxbLF5SxmcqsAABAASURBVAcs6Gttvq9e4/K12yhTsogs7+yFK6InNUS6y5f+HHv2H5Pu3f8cRcUyn0v3vClDcGzXMiltmtdDs/o10a1dUxmnKAoUxT5CFSiKfcpWFC5XUZiBojADRWEGisIMFIUZKIo6GNC1j4UJ2JqAqgzek2cvguTYyfMYMWEO+g2fijv3HmLzjv2iZ3VdjNueLUsG1KlRFS27DEG3/uPQvUMzODtp7yB7D52M12/8Zdnd2jXGll0H5bRk9x88QeN6NWQ4L5gAE4hXAlw5E2ACSZzAtt0HUbtxFzm96PFT5+EnrtvT5i5P4lS4+dEhoIlOYnun7dJ3DEh+Gzge2/8+hNPnL0v/6Cnz8eeKjbGq/ucfqmHZ7NFYMmskKpcvoS/r7/Vz4ZUmtfTTetaEgXJaslGDusLN1fxFuV8b1Ub7FvVlel4wASbABJgAE2AC9iewZecBzJ86FH26tMCilZvhkTIFzl+6Yf+KVVcDKxRTAqoyeMkQzZcnB2imhK2rpsuPTuiGEuTIlimmbeR8TIAJMAEmwASYQAIm4OGRAvReTZGCeRAWFiZb8uGD8cehZCAvmEAEBFRl8I4Z0h1TR/WBo4MD+gydglt3HmDHnsN4++59BOpzMBNgAqYE2M8EmAATSGwEUqdKCXq3htpFMyodOHIKYeFh5GVhAlYRUJXBSxqnSpkclSuUElISyd3dMO6Phfi10yB8Wak0RbMwASbABJgAE2ACSYzAxu37MGTMTDlb0tXrd7Bh216MHtw9KgoczwT0BFRn8L5+8xb0YYiNYmd+9cYf7sLo/bnO/9CycR290uxgAkyACTABJsAEkg4B3fBGWu/fshBTxNPg7FkyJB0A3NJYE1CVwdt32GT80LQr1m/Zg6F9OmD/5oXYtmoG6tX6BvQII9at5QKYgCkB9jMBJsAEmAATYAKJnoCqDN4DR08jU/q0oI8+zFiwCu16jDCSRL81uIFMgAkwASbABOKJgJqrpQ8/RSZq1p11UwcBVRm8f4zpi67tGiN/nhwICQnB50XyoWLZYnpRBzLWggkwASbABJgAE4hLAo1+qo5GP36HFXPHSiE3hdEQB5K41IXrSpgEVGXwlipWGCQhoaFwdHTEuf+u4fDxs3pJmIgTk9bcFibABJgAE2ACcU/gxKn/0LlNY9AUpSTk/vfMxbhXhGtMsARUZfASRTJ2v61SDrMnDjITimdhAkyACTABJhDvBFiBOCUQFByEV35v9HWSOygoSO9nBxOIioDqDF6ag5fG8kalOMczASbABJgAE2ACSYNA8wa10aBVb/17PeRu3qBW0mg8t9ImBFRn8FKraFqyFeu2w/fVa/ImVGG9mQATYAJMgAkwARsQqPHtF1g0YwS+rlxGCrmrf/OFDUrmIpIKAVUavOu37sG0eStQo0FHOcm07s3MpLJRuJ1MgAkwgcRFgFvDBGJPQFEUhIWFy2lKnZycYl8gl5CkCKjS4KU3Li1Jktoy3FgmwASYABNgAkxAErh28y6atO2HRSs3YeaC1WjZeTBu3X0g43jBBKwhoBqD11TZ8PBw3L77SAq5TePZzwSYABNgAkyACSQNApNnLkW/bq2wffVM5M6ZFXMmDRaG76qk0XhupU0IqNLg3bR9H76p2wZd+o6W8u2PbbF5536bNJgLYQJMgAmonACrxwSYgAkBvzdvULVyGX1o+nReePnq06wN+gh2MIEICKjS4F22dhuG9umALSunSRncqx2Wrt4SQRM4mAkwASbABJgAE0jMBBTF2Fx58uwFXJ2dE3OTuW2SgO0WxnuQ7cqNVUn00Qn6wpqiKFAUBZXKFYdGo8SqzDUbd6FJu35o1n4ADh47Y7Esn5ev0Kn3KLToPBj9R0zFh4AAme7shSvoO3wKvq7TGq26DgVPmyax8IIJMAEmwASYQJwQyJIpHa7duCPr8n3lh5ZdhqBFkx+knxdMwBoCqjR4HRw0OHbyvF5/+tqacyzu5O49eIIlq7bIMT/jhnbHyIlzERAYpC9f55g6ZznKliyKhdOGI2XKFFi+druMcndzRc9Ov2DXX3NA8/5RfhkRR4uXV//Cze1tcG1TE9zdPwhBb5+Cf0yACWgJ8JIJMIHET2Dc0N+QL08O2dBhfTti47KpKF28iPTzgglYQ0CVBm/fri0wYfpi/ZRkU2YvBYVZ0yBLaQ4fP4PKFUoimbsb0qfzQn5x0Jy08EnCIyfOoca3lUC/Gt9UwuETZ8kJOsi8PD3goNGAep6Dg4P1vb8ygR0XLy6twtPzfyLQ/zFCAvzw7tlZ3NrVyY41ctFMgAkwASbABNRF4L/LN6CTkJBQ0dt7V++ncHVpG2/acMWREFClwVu4QB6sWzQRy+eMlbL2z4kolD93JM2IPOrFS19kTO+tT0Qftnju81LvJ8e79x+gKEBqj5TkBT0+eeHjK92Giw1b9yJ3zmxwc3U1DLab2+/uXrOyw0IC4P/4lFk4BzABJsAEmAATSIwEpsxehsgkMbaZ22RbAqo0eLftPojXb/yRM3smKb5+r7Fjz+FYtVwRvbO6AhRFWLY6j8FaY5TGHM2FS9exfN12DO7VVp8rKCgQ9pDQ0BCEhoYiJNDy1+bePj9nl3rt0RY1lBkcHIRg0TOvBl3iVQcb7a/BzNOmxx/ztO15lHnanmdISLBN9/nIzoNhYWH6a6zOseCPYYhMdOl4zQQiImBu1UWUMg7Dl6/bBo9U2p5WqjZNag8sWbWJnDES7zSe8BNGsy4zDXhP65VG55VrGu4QGhqGIGEUUcDLV37w9vIkpxTq7Z0+fyWmj+snen/TyzBaKIoieoZtLwCVCbikyg5LP48c1aAolIZFUaxlAGZmNStrmDJPRbGGk7VpmKeiWMvKmnTMU1Gs4WRdGoifoliXVlFil05UFSf/XEnSIqBKgzcgIAiGH5sgd0BgcIy3TMWyxXHo+BkEBgXB99VrXL52G2VKage70wwMwcEhsuzypT/Hnv3HpHv3P0dRsczn0k2zNwwYOQ39u7dGhnSfhkZQpJOTM+whDg4O0GgckLXcb3BwcqOq9OKRrQrcUmWxS732aIsaynR0dAKJGnRJDDoQS5LE0BY1tIFYkqhBl8SgA7EkSQxtUUMbiCVJXOmiMXjaqr/wfXTUbNRZuuo07SbXvGAC1hLQWJswLtNlypAW85f+pa9y7uJ1yJYlg94fXQflrVOjqpzGpFv/cejeoRmcP36Hu/fQyXL4BJXZrV1jbNl1UE5Ldv/BEzSuV4OCsXbTbjk4vmHr3voX6Z4+95Fx9l44uqdH/rprkevbSchctgcK1d+KTGV7mlUbFvQGr+/9gwC/O2ZxHBBTApyPCTABJsAEmAATSAwENGpsxLC+HfDoyQtU/K4ZKlVvjmcvXmJI7/axUvXnH6ph2ezRWDJrJCqXL6Ev6+/1c+GVJrX003rWhIGgaclGDeqqfzGtfYv6OLZrmZGkT+sl88TVwjV1XqTK9qWs7t3TM7i1uyuubmwi13f+7okr6xvi4fGJuLWrM65uaCDT8YIJMAEmwASYgE0IcCFMIIETUKXB65k6FYb2aY8tK6cLmQb60ppu9oQEzjvW6ge9eYC7BwYh4NVNhAS8kuv3vlcBRYHuFxr0FvePjNR5La55bl+LWDiQCTABJsAEmAATSIQEVGnw6jiTketh8PKaLjyprYPePsaT0zNw/9BwYewOE80n41YRNq4i3Jb/A/3umkW8e3oW/g+P4YV95vY1q48CQt4/h9+dvaA1+a0RnZ7WpOU0TIAJMAEmwASYABOIioCqDd6olE8K8W+fnceNbW3ge3MH/B//i+D3T6xqdljwO306/8cncHlNbWEsD5I9v88vLtXH6Rz2mNv35o52uLalBR79O1mub+3soKvO4tpUz0ura+Ll1fUW03IgE2ACTEC9BFgzJsAE1EaADV61bRETfZ6dW2ASYtqrS/5wkzRAWHgw7h8eiYcnpuDhkdEIDw81S2Ma8MHnoj7I98YmXFn/My6t/h6X1wpjef8AfZw1DupFDnzz0ChpwOv7eHkt4unlHp+cZqJnOJ79Z26cGxXKHibABJgAE0gyBArlzyXbWjBfTrnmBROwloAqDV56Sc20AY+fPjcNStB+a5UP+eBjktTcuNUmoHCthIeHIyzoA/wfHcPru3sQFhYMYUlqk0WyTJmplBx+EOB7HU/OzEVY8HuZOjwsFO9ET/PTs/Ol33BhOPzgzt6ewjiuJY3k55dWWKzzxZVVuLapMaj31/fmVrx+cFhvmIcG+hkWLd3hQveQ96YMZFSkCyr37bP/Ik3DkUyACTABJpCwCIwZrJ2ObOTALglLcdY23gmo0uDtM2wK6FO/Ojo0BVj3AeN03iS1dnQznQ2CenQBReMobNhwKA5OHw1LCtcJTH4UbhKEcKMAjaMbbu3pI4cf3Pr7NxFnnuft01MiXPtvNvxgVQ2897mKcN0XcsLDAPMiEBr4BiEBr0G9v49PzcbDo2P0hrmw0z+2BUY/R1cPIz+NB45oXPCLSyuFwV1Tlntvfz9hgNeRvcpPT07GkxMTQGOYjQpjDxNgAvFNgOtnAjEiMHHGkhjl40xJk4AqDd76P1QDGb2hwniijz506TsaXdo0SZJbKN3nLc3a7ZIiEwrW24jCDbah4E8bkKFEW2ic3GU6RViZiqJIt9HCKEjr0c3tm7ZwE4SFfBDJwyCNTghjVfgs/et6Th+bDD8wNp91OakegxhZuIHfxOjW5TJcO7qkxM2dHUSvcBPc3T8IN7a1kuOBIxoXTAavsJr1RYSLHuKn5+bizYODePv4GGj2igdHxujj2cEEmAATYALqJ9CuxwiYyo49h9B76CSc+++q+hvAGsY7AVUavN99XRHFiuTHiPFz0FkYux1bNkSFj189i3dicaxA8nRFkafGXHjm/g4pMpYWxm1H5K4+x0gLzzy1UaDuGvlRioL1twgz0tCo/JiUgsjgJBFBKTNXgm5u37fPzokQ+tdAaytrhM1IGSjsk1CvLPXIUs9pyIdXIiJiw1hEyn+nZOng4OIhJAVA9i9E2aBfOBRFBpDnk4gwJ/e0cHJLA5eU2REieoQD/R8jJMAP756eQdDbp5/SCheNC6axyvcPDcODY+OEwR61Tv6PDouc/M8EmAATYAIJhUDLJnVgKjQf/v+qVsTYqabvuiSUVrGecUlAZ33EZZ0R1nXy7EXo5LNCeXD3/iOUKFoI7u6uMjzCjIk8wjl5RmnoZq00WBq+UTU3ebriZkk889SAR/YvkTJLJWStMADpijbTT3UW8PqeWXrobdFwQBihwgKG0U+Gfdp9FGFmG8WTR5SR9/uFyP/DMmSvQr2qIoDCpYgcH41v6f24cHBOgbw1FyJvrcUIDwv8GPpxZZj9YxCtaKyy/+OTeHP/IHmjFKo25L2x4RxlJk7ABFRCgNVgAkmRQKlihWEqxT4rgK8qlYaLi0tSRMJtjiaBTxZLNDPaI/mCZRtgKK6uLriGllI/AAAQAElEQVR5574+zB51Jt4yw0Evr5FxJxxwTpYemcr2RJYKfaE4ucNwqrOwQH8LGMi6FMYuxJoKCRdrS0atLqeigcbBCYpGu0tpnJMjU8lPLxW4emQTPdRlhN1MZWoz0ThkrevT0rtAPb0nJPC13k0Oag+tzeVTmZbSkPqGeRQFcHRPbxjEbibABJgAE0gABJ77+GLzzv0YOnYWDh8/IzVeNON3ueZFkiMQrQZropXazolnTxyEyMTO1Sea4t8+o5OAAkUhEc0S6xdX1gqH9v+ZyVRn4ZEZstosgAKzX+CDN3h/8SXe/+eDkKdOKPDTBhSst1kOrShQZxU8cn5rlCdrpUEoUHclMpftgVzVpqHQz5uQuXxfpMhUDqmyfw0aU5wmf128vnEcry7vh6uH8bQzohlGBrMsXFqznwxeSkOGtKOrJ2g4hXuafFAUY+VTZKoos/KCCTABJsAEEgaBkZPm4YcmXdGkbT8c/fccaFqyaWP7JQzlWUtVEFCVwWtIJCAwCOcvXpNDGXTDHAzj2W2ZwPsXl6CIP9NYww9RmE51piiKaXLRKUxGpHG4tC0/pvxwwxfBz98jLDAYYUEhCHj0ABfG1/sYG/FK45wSqbJ9KYzZHDJRqiwVkbXiAGQu0w0fHj/Bv31L4eq8Tri+qCee79yDkBeGwxo0SJ7uM7imzgUaF+ycIgO0TTXcjRUZn6/2EuT9fgFyfD1RyDg4u+SFkyarHM5BvdzgX9IgwK1kAkwgURA4dfYSwsRFqHmDWmjd9Ef8/EM1ZM6YLlG0jRsRNwQMLYW4qdGKWhYu24A6TbthxoJV+uEMNNTBiqxJPom7dyHRX0vGqjEKjVMyfYD5VGfaqNS5qiF5hlLCIK0IRVG0gQZLR9eU0PWchr0NNojROj+8uAOEBGk9MVjeWtkf4WHGugc89JPGcJrc/0Oh+luR7cvRoid4qhwXnKf6PDhZmLYtfbFPM1s8OLEd58c2h+/Rg3h18l9cmtoZlzfOiIF2xlne3j2PW6sG4+ayvrI32jhWXT5dj7mttKK23107DHdWDVJ9223VZi6HCTCB+CWwYekUzBjXH8mSuWHhio1o2r4/ho+fHb9KJbDak7q6qjR4j526gO2rZ2Du5CFGQxyS+saytv3JLby0Zjg2NqKpzjKW7IxsXwxB5rJ9hSGZxqQ6BV4FfoZbmnxwT10A4aFhJvFar//DS1qHWNKsCrd2d8XVjU1Aa/KL4Aj/Q4MCzONEPfcPjsfLmztBX317dHyCURp6uS39562RImMpeOapiXw1/4R7moL6NLfXjoBG3ALoAsiO9zvyp84bo/XdTeNxaWZL+JzZjpcX9sje6Ctz2saoLMNM1xf3wMkBFXGyf3lZvmFcTNyvLh3Av/3K6HvMT/QpjScHlsakKH2eh3/Pk7r5ntsJv4v7ZNvJ6NcnYAcTYAJMwM4ENOJETu9rhJl0kNi5Wi4+gRNQpcGb2iOFxR7GBM46ztTPXmUEMpfvjU9jY6eAxsbqFEhuxVRnpoaku1chPDu3ADQjwuuH+3VFGa/F46YHJwZJw5Q+S3x3/yAEvLqF0EA/ub57YBCC3jyA7vfu6Vlc29RUpK8ppBbERgdEGVKkkSp6exVA4+QA3c/v3n6YzrCQJl9tZK00BBmKt4Wju5cuqVy7KOY9zg6i7A8vH8n4mCyeHV1jlu3NrVNmYdEJODfmB5CBGhYcgDDRS069qKcGfRGdIszS3vlrlLgxCf0UHh6GBzsj693+lDQi17095jcLPsLojyg9hzMBJsAEbEGgTtNu6NBrJPzfvkfT+jWxbPZoDO3T3hZFcxlJhIAqDV5XFxcMHDkd+w+f4jG8MdwRU2X5Arqxsa6pc5uV4mzFVGeGhuQ7n/+My1DIKwxSWpF8dIaHaXt+5WeJZRqK1IkCn6vrdR75EYiQAJrPlzKHQXESu6O4c5eGLyizEA2JCNfnAl4/OGHgi9wpcltM4Oya3GK4VYFklJslVBD0/J5ZqLUBgS8/3Qjo8oQGvovVEJHgty91RenX4aEhCPJ9rPdH1+EYFmiWhRj7P7xiFh6fAa/f+KN73xHIW+xLZMpbBvV/6YSbt+/Gp0oR1r1hyy607dofTVr/hhlzl+DDBwtPOiLMHTcR/m/fJRiecUMk6dTy5OlzLFm5HnMWrsD5i/F3nBcvWhDhokd36eotWLh8A9Zt3o0nz17Yb0NwyYmOgEaNLaJpR3x8X2HVhh08hlcFG8jSi3AaV+p1JVOHjFUhwqk4iIXGcJcSftGbatiEwLdPpJd6acNCjC/s4SFhMs5oYSHIOUUmoySRecLJgLaQwMHFzUKolUEWDd5wOHtmsLIAa5MpeH5uh7WJzdNZ0lOEObunNE8bq5Bw+Aa5xqoEW2ceOmqKuEAvx8NHT/DK7zW2bN+Dpm2627qaWJc3f/EqNGnVDavWbcW2nfvQe9BoafzGumAbFzB+yhzM/XMFHj1+Cr/Xb7B1x1606aLON+RJxyUrN4jtvwL/Xb5mYxK2K45udFp16oMGv3ZW7Y3O/kPHUajMt+jccwj6DR2H8lXrYpzYF2xHwfqSBvVsg62rpmPhtOEoX/pzXLxyCx16jrS+AE6Z5AkYWieqgRHR1GTxqeCajbvQpF0/NGs/AAePnYlPVeK8bksvwrnm8oDiQkavUCdcGLZOClzypBaeSP6FXfzh5XXQWNzrW2nMqwgwTG7BuKXosIAQWklRHJzw/OLSCMcFvzMZJuHo5ixMblGP+Icw9mgFR2dIkSVGf+GY3IMyGQlNhRabMoVqRuVpPeFwzvOl1hmTZQTGvv/TGzEpTeaR/KTLeOGp8TMOiGffX5t2QFEUIzn/3xW88X8bz5oZV7901QaxW4bLfVQuxY6wfvNOhIYaDEUxzhIvvt17DyJcPL2hMZPhopctDGE4efqC6nhu3/0P8nxeBR17DELvwWNQpkpt9BHreIEWSaW6G53lazdi0/bdqr3RGfz7RAQGBBq1ZNSE2A2LMiosBp7MGdOh1v+qyOEM9CIb+McErCSgsTJdnCcLDg4Rd3A3VDGk4d6DJ1iyagvmTBqMcUO7Y+TEuQgINB8bGueQ4rBC0xfhFFcnzL8OfLX4Pb5a8g4HP7jBMbmLiUbhwq8I+fiviEt6mJZbeDhd0A3iKImlvVEYLW7eWeHo6gG3NAUQGhwkxwOHBn4aF/zs/CLQp4WfnJmD+4dHwHCYhEvO5NC4OgKibrGARhjmTjmSITa/Qh0XwTlVOlEEtS8cjqLHtEC72L0tfOqleY/znVdAiuQx19UpeRppSImFHBtN2iqOTkiRvZjQPWb/imsqWRaEYSYcohCxTRWHWJUpCrH5/7t378zLFADevntvHh6PIRcvXYWiKND/CXeYMCxv3o758Bh7NOf5i5dQNBpoNEJTIcKFkJBQ4bd00NpDA+vK7Np7mEyoUYSGQsgzbc4iWqlKpgud6KUroSVIyL1m4zbV3ehcuGTeQx4cHIx7903fgbA/Xr83/qC5eKvX7wASclOY/WvmGhILAXWdrT5SPXz8LOo264Zu/cdh/LQ/0aXvGEyft/JjbNyvDh8/g8oVSiKZuxvSp/NC/jw5cPLMRSSlX3aTF+GajrmP5fvf6BEMXf4C52+9lxdFCtTQl9ZKdUW+mguRqXR3eBdsIIIVISb/CoWRaOCWNaNJJJCmSFXkrj4X+Wovg1Myb9AF1yiRMGJ8rq6D/+OT8L2xRb7wpTXEtKk0rs5IVsgbyUtkQPKS6ZHss3RwSeWKQP9n2gQxWLp6ZUGxAdtQZtxpKSWG7ou1wTfu33B02f4Bpx4F479nwRi47wPa7QiEg4NDDDTUZsnxY39oHMjYF37BWVE0yPK/jsIT8/8/ToUhRDCHKA9QEBamYOG5UKjtpwjdLOmUMkVyS8HxFubk7Gyx7tw5s1kMj6/Al69eiXuccHHv9FHohkfcRCZP5h5fKlms9/GTZ1AURR+nKMIt9teLl8XduT40/h3Xb90101MDBWq70QkO0nZQGBKjPcDQH1fuYWNnI61XavTp0gLd2jWBizh2KCyu6ud6Ej4BjRqbMGPBKsybOhS5c2bFmoUT8ef0EcIdfxeAFy99kTG9tx4VPVJ57vNS+m/dugV7iI+PD/z8/OxSdkz19QnKhOAMDfA+dXVcE4aZBGCwaDXlMe4m7wTXklPh/NlIvAzPhXtP/PEyLDte+ZufOCmr4pJWpJ8iZDKSVZsMj1rD4JKnElxylUXKaj2glGutZ/DW5xZlMRBxJaMLmkGIuGYY+iJwh+P4mav6cmPKw5b5fF744uKLMPTeE4SuO4Nw9EEYgoJCcP369Rjr6euaGWlarUDKGv0lS682K/E+c/kYl0ftXX/qCb4RPfo9d32QRvnXwr30zFtcuXIlVuVS2baUD4GBWgNNGGbUe6a9SIfj2dMnqtLT38IQC0VRsG//IVXpGRwSAkVRoP/76F61ZoOq9AwNDUdYaJi4EQtHeFg4QsPDQNvf19dHVXoKtaRepJtO6GT14MF9VekZ9vH4Id10IoJw/uJ/dtXT399fV51+7eLsiNbNfpKdT99+WR49OzXHCx9f8I8JWEtAlQavo6MD0qf1Ag1roIZQj+r7D+/JGW+iaD6hUhRFr8e4ceNgD9m3bx9Onz5tl7Jjq+/EiRP17Td1bNr4l0WdZ688Ik/wpunPXH9nlH7S0s2Ydeo9Zp0JxpQ1+43ijvz3qUfZtJzI/caDg28/CcT8BQuNyo4tk9jmN+yV1rVFURS07fxbrPWcsmKXGcuY6guhk6IoOPM0TBrlEIeCoijo3W9grPWMqU6W8oWGfdzmQj/SUXRNQtg/6N67r6r0JINCt711azKA5s+bpyo9ycjR6We4/mvdGlXpSceRxkEDjUaBIsRB0Z63p0yZqiY9JUJFEToaiDDRMWGS2vRUCKk8d9N+SULH0tJFi+3K88KFC5KR4YKO6UCDHmffV6+RIkUywyTsZgKREtCeDSJNEveR7m6uslKPVMmxafs+HD5+Fq/8/GVYfCy803iK3tbX+qp9X/mJRytppH/OnDmwh/z888+oWrWqXcq2hb7tWjeWJ0G6YNNJkKRi2VIR6jt52gJkLNEeGiftI1BF44Bk6YqiSa9VEeYx1bNV/5VwSZlZco90IcqGtHI0uPEoAFtP+OOxTzCevwrGrlP+qDfyASZPnmx1vaZ62MOv1RdGP2K6Z/smVempGGmo9SiKghHDh6tKT43Y/oqi0FIrwq0RMnXSJFXpGS66+sINrElyhwuLon6jZqrSU9FuaqOloij4uVETVelJ29hISeFRFAWjx4xRlZ5CJaGZ8b8i9tT5c2epSk+xK9K/XlHxTE3cOIZhwsTxdtWzQoUK+jp1jsDAYNRt1l2O4+03Ygp++qUHUqVMjrmL10rRpeM1E4iIgCaiiPgMr1f7W9Bg9A4tG2DPgRNYtnYr2jb/Kd5Uqli2OA4dPwO6u/QVd5WXr91GmZJF7KePHUqmjW92wwAAEABJREFUDxncWjUY9FWsV5cj+HBENOo9euy0TE0XGEWhU7WCS1ciHyfnmed7FKi7BoXqb0XBepuQvcpIWUZ0Frm/m60fF5yv5p9wctPeeHwqQ0GOr8aIOrYI2YyGYx5g+HIf/DD8Pr4fch+DljwH6Rxk0FPwKW/8ucjIMa2djB8HBwfT4Pj10xXPRAPSM0tm8/HXJsni1EsTh1iqMCAw0FJwvIXRy1WKogijgvaAcCiK9lgqXbJovOkUWcVaLcNlErLTc+fILt2qWWgUM1UURYH/G3XNzmGm5McARTHX/2NUvKxIHY1gqiiK3Dc1Yq3RxI/ZULhALtT+rgq803ggR9ZMaFC3GnJms36KSvAvyROInz03EuwhoaF4I05OHilTIFf2LJg2tp/8vHCxzwpEksu+UdmyZECdGlXRsssQ0It03Ts0g7OTk30rtWHpD3ZMl5+DNfwULhm+sani8tWb8gSoL0MBXr1+DZqjUx9mJ4eje1p45KgKWpt+EY6MYMNPCytQ7KSFbYslo5GewtMb+uGi14/WELrff/gIavp9fEJspBIZQSmSq+vRoqWtrigK3F3djHSPf4/WeFTEtiYhfRRFgdpuyDQaYZQLC5d0JAkX7jCxnxYrWohUtqtEp/BUyc1fSiTCJYsXiU4x9k9LSpnWogD00p1pcHz7aVvTMS5FbHehJu7H0SwNm3d+6pxp07weIpP45sT1q5+A6gxeR9GjdeCotvdQTfh+/qGa/JThklkjUbl8CTWpFqUuz46sNkvj+99es7DoBER0lx9ReHTKjm5awy/CObp76bPLuUwtXVhEioAAyy/Riah4+dcII0cjjkbipwirUrsG7t1Tl8EbLrpO5QVQGDtklJNbgYInT1/EC7eIKg23sN1J1+TJtUNqIsoX1+Hhgp1pnaRnaEioaXC8+sPChKZiH9UpoSiKfFISH9NTIZJfjepVzWIzpE9rFhbfAeFCAdrORiIYe6VJLWJU9K8AiqJA/yfcEL9g0TElVnb/37HnsN3r4AqSDgFxiVVfY2kWhBXrtoOGD0StHaeIikBo0AezJHSiDfJ9bBZubYCrs7NZUno8m8xdPT1oNBwgZ84sZnomF72ROXNkNQtXW4CiKHB2UdeTBGGLC0yKFEWhNaAoChydHKCun+iPMrB6aX8n/c5euEQr1YhGi9BMH2/vNGZhagtQFAVXr5nOnBK/Wm7cslu+W0DbWwrC8eTJM9XNb4uP211RFCiKooUmVqnEk02tRx1LRRFKWVClYtmSFkI5iAmom4BGjeqt37oH0+atQI0GHVGuWhO9qFHXhKCTorFsjDh7xnzcpZMFQyxMXFzUxmPtkllI65VGfxFMKYzdNYvj90tBlhmZX1jogl2y2GeWk8dTqIN4AmNaNemZPq23aXC8+hVFkYaEMHvFXhku3aRQgXy5aaUi0Q4V0OlJLEnk04mYaGmnPIqimJVMen79lfnLRWYJ4zDg/fv3clsriqJdQ7s+fe5iHGoRdVUaoR+lCoP2j9xiR1XdNFuKokjVDBeKomDfgWOGQexmAgmCgCoN3mO7lsGSJAiiSURJOg3SBc9QKExtzScD586lw9iwYjaWz5+MJ7dOoUqlsmpTE04We0jDQXNAq0lZ6jQV1zsoiqIX0s+SIUzh8SWpUmrHcgotQUJ6hItFpgzpxVI9/2ToKgpp+FHILeSNhfl541NrGmJjWj/tC2ozzE11JD/p+ey5DzlVI8k+frBDCVcAKVrV0qX9NCRLGxK/y+xZzZ+QKRoF//umcvwqxrUzASsImCZRpcFrqiT7Y0cgPCxUnFTF5Z7O/BBrKUBshjTQC1aKIk7WH1VTFAUOGvXtTsf+PYN0OUugTqN2aNyqO1Jn/gyr122F2n7UkxsWFg6aazL84/hYL880UFvPaURjSx89eaoqpOnTp9P36oeL/Z4MSweNRnWPtp0dnbR6imOSdJS6Cn09U3uoimeYOOB1uoUJ/cgtDnn19fR91E0Hj/QMF72oeXPn0AWpYp01y6ena/IsKhZ0U6G2lz/b/tpI7J+fkBHPimVKfQpgFxNIQATUZ6EkIHgJRVUHZzeArk4kEGdWIYqiIKZDGqhX5514dEhfMlIUBYqifSwbHBKKh4/UZfg0/LUL3r779JgzKDgYbbv1g9p+DerVEhwhbxoURQMaD12vbnW1qQkodMMEo5+iKHj9Jv7myTZS5qPn6dPnUBTlk0C7jxrvnx8Tx+OqcsUy+tolWbHw9PBAKpWN5SQDTVG0PDUf1w6Ojqrr6UufzhuKIrb1xxsIRVFAhmS+PDmhpl8mcUOmKFqeiqJde3p6QG1PSvYeOCx4AqHyL0y4FZw+/1+coZw1YWCc1cUVJX4CmsTfRG5hugr1zSB4FjF/m9ksUQQBdFJ2cnKEolH0KRRFgaOjA7JlzaQPU4Pjhc9LMzWCgoLxyu/Th0TMEsRDwKz5S+XFRF+1QLti7Sa9Vy0OB42DmSrU65Mvt7oMim++qmSmJ80VrLb985uqleR2V6BAI4SOqZIl1DVuG+I3feIwOAkDl7Y1iXhkhH492osYdf27ubkiXPZGC73EzUOYeFoSHq5AbUNELA2x8PN7ozo9/7t8HbS9HUB/Gul+JzoQ4mN2DsP3eQzdYkvzvy0IJIEyNGpso5/KeovUyCg6Or17dE1cn8TZP1yI6PkQHrx/Eru3qz98CDBTgXp+1WZI0snaTFERECx6esVKNf+37tyXuhRPr0H5LNrD8s2bt3jp+0qGq2VRt1Y1qYqhnsWLFlJdz9Tgvl1QwOAFtTSi92zquCFSdzUt1m7YbqbOvgNHVTf0wkHjiOCQECiKMM2FAAocHRyhtt+r12+gaDTQKFo96UkJxDmPennVpKvvKz8zdWjYiNr0VISWikJL4RD/iqJAUZR46dgwfK9nw9IpaPfLz6j7/ddCK/5nAtYR0F5ZrUsbZ6matu2H3yfOxe17D+OszsRckf/t0xBnKa1AAYR8eHEHMf2RYRsWGoouZZ2wvK4bVv/khgGVaJoyBa9eqavnVPdyiGFb6aKS1tvLMCja7rd3z8OWX64rnS4cu5u6Y0I1N/z+lRv2NE2GegUc8fp1zIcKBPg8wPnxP+JEn1I40bsUzo6sDv+7Z6Pd1o8Z5GpKl9rY+0tyvZ57myXH2oE/yDg1LXLnzI5TB7fg4r+7cfyfjbh/5RiqVf1CTSpKXa7fuC3XhgsyfG7evmcYFO/uKTMWmOkwfuocs7D4DtAauMZa0BkvRBjrxqHx66Ox+qYahAvD3M3VxTQ4Xv0aB8smwtPn8Tvvdvq0XmjesBYePn4Wr3y48oRFwPLeHM9tWLtoEvLmyoa+wyajc5/ROHjsjHyUEs9qJczqQ4IQJsSS8u+fXLMUHGWYg4MDxnzjih/yOSNDCg28k2lQNacT/qztChqHFmUBcZhg1uTf0bmMk9Yw/1FrmA/o2TFWGjz8e57Nv1zXq6I7HDWKXi/RSYVWJZ2RMxbzBd9Y3AMBL4Th9LFnP+j1c1xf2F1fR0wcd/4aBUWWp82tKOF4sFON07xp9cuRLQuKFMyn9ahw+d23Vcy0oqEXahtzetWCYf7+/QfEx6NtM2AGAdmzm88qoBEHk9peBqP3Cujpk6EIexdqu9Gh48cAr3QST+80ntId1wvidevOA9x98ERW/WWlUvFkG8jqeZHACKjS4HV1cQZ92Wz1ggmoW/NrjJ/2J35s/hs2bt/HO3d0dzBHZzglT2OWS3F0gnuGmBsCxTI4wvSX3UMDj2SupsFW++3RI1nYZwfq5HfWGubJtYZ5jfBPn6u0WjmDhE8OLjXwaZ2x/XJdKtdwbUEGSydhAMdmJo0PPtphEgZFIuSD6DGO4AbIMF1E7uB3r8yiwkNDYjXjh1mBSSigv7j5SghDL/JbeOnL3d0tXh5tR7Z7/NLoR7PoOjWrqW7ITY1qX0JRFCPJmiUT1HajU69OddXwfOX3Br92GoQm7fqhYateaPvbcHxZsbRkaKYkBzABCwRUafCSniHikfmOvYexcPkGpPNOg18a1caRE2fRpe8YimaJBoEcP/aHInpl9VkUDbJU66D3RtshDCYnjbmBJs488H8Y8y9Z2aNHUg7nMGmgHM4h2mASbLU3LPC9WVrqeTA0Ts0SRBGgcXCymMI5ZeyGXlgsNBaBGgfzGx0qTm16kk4JQXRDL84d3YZDu9eoduhFt44tzXD26trWLCy+A1o1b4Bl86egwU/fo8b/vsK4Ef0wZ+qo+FbLrP6EcqPziWfNeOc5aeYSFC6QB8vnjEXRwvlQr/a3oA9UmcHlACYQAQFVGryLV27GT6JH9+iJ8+jbtQXmTx2KWv+rgvHDeuC5hbfuI2gbB38kkLpQZZQefQL5W09H3l8moMzYf5GhctOPsTFYyV5jc0NMEb3GKbIXi0GB2iw275EURm1EwzliY5hrXNy1ChssFUWJ8TRvVEyKnCVoZSRu3jkAwdooMBoeN6+sZqkd3VLEqkx76GmmZBIMoEfHhQvkVW3L6WMt18/+g5mTf8f43/uDxkX37qY+g5cAUo8uGbnL5k1CxzbNQDM3ULiaRHejc1HlY8yJmY7n0rkx5knFxFqu3byDHh2bIWd27UxAX1cui9t3H8a6XC4g6RDQqLGpb96+xdwpQ/D7gE4olD+3kYqDe7U38rPHegKp8pRF6oLmYwatL+FTSpv3Gn8q2nYuYSxGNJwjNoZ5hi/MbxZiM80bNTh/q2lIW+4nOHtkgHPKtPAs+i0+67WWomIseZpPhKt3NlDPu1jAOVVa5G0xGbH56fVMlQFOKb1tomds9OG8cUcgU8b0aN7oR3Ro3VTV46Ljjkjsa6IbHTWPMY99C21XgoNGI05lir7A4OAQ0Aue+gB2MIEoCGiiiI+X6M6tGyGtl+VB8YXy54oXnbhSYwI27TX+WLQ9eiTtYZhn/qY1CnVYAK/i1ZHms69lr3nuJrEfapOjTl8U678FxQZuR57GsX8M6+qVBUV7/SV69E+izLiTKDZgO2Jj6H/cTCA9C/dej8K9N9pET125vGYCTIAJRESAvj7o81L7DsHbt+/xa+dBqP5NpYiSczgTMCOgKoO38ve/IjIx054D4p2ALXuN7dEjqTPMc/8yBTkbjxbG37+xG87xkXjy7EWRq8FwkKFrq17zj0XzigkwgSRMgJtumUCvLi0gunhBv1rfVZHDHenldvKzMAFrCKjK4D2w9U9EJtY0iNMkXAL26pEkIinzlEGqAl+Qk4UJMAEmwAQSGIHsWTLAy9NDak2GLr3Atnln7GbckYXxIskQUJXBa0/qazbuktOZNGs/QM7ra6kuelzSqfcotOg8GP1HTMWHgACZ7OyFK+g7fAq+rtMarboOxYGjp2V4/Cy4VibABJgAE2ACSYvAxSs35Aep2vUYAZ38MWe5dLPhm7T2hZi2VlUGb7lqTfDf5RugtSWJaSPvPXiCJau2YM6kwRg3tDtGTpyLgMAgs+KmiiEGIGwAABAASURBVIOnbMmiWDhtOFKmTIHla7fLNO5urujZ6Rfs+msOmjeoJfPLCF4wASbABJhA/BHgmpMMgaFjZ6Fo4bxo2aSOXuiLa+Qv/lmBJMOBGxpzAqoyeI/tWoYiBfOA1pYkps08fPwMKlcoiWTubkifzgv58+TAyTMXYfo7cuIcanyrHQRf45tKOHzirEyST6SnRykOGg0qli2G4OBgfe+vTMALJsAEmAATYAJMwG4EXF1cULNaFZQqVlgvyZO7S3fmjOnsVi8XnHgIqMrgtQNWWeSLl77ImN5bumlBB4fpfL7v3n+Q4+FTe6SkJMiSKR1e+PhKt+Fiw9a9yJ0zG9xcXQ2D2c0EmAATYAJMgAnYkIDhUIV+3VuZldy9XROzMA5gAhERUKXBe//hU3TrPxZVarYwGt4QUSNmLFiJNt2Hmcmq9Tv1WRTRO6vzKMqnufx0YbTWGKUxR3Ph0nUsX7cdg3t9mnD9w4f3sIcEBwchJCTELmXbQ1+1lxkYGIDAwEDmaaP9NZB52nRfCgiIi/3TPucqNR77zNO22zog4AOCguLu/BkaGkKXZOzYc1iuaWFpSlJ6+kpxLEzAGgLmVp01ueycZvj42aj5vy+RP28ObFkxDZ1aNZRjdiKqtkXjOpg4oqeZ1Pn+K5nFO40n/PxeSzctfF/5Ia1XGnLqhYY7hIaGISg4WIa9FGm8DeYCpt7e6fNXYvq4fqL3N71MQwsX8ZjFHuLo6AgHBwfYo+ykWKaTkxOcnByZp432VyfmadN9ydnZifdPG+2bdH5jni423j+dQdckYhsXotE4gH9MwNYEjAxeWxce0/ICAgJR9YvS8isqXmlSo3G9GpF+QpCGF6RIngym4uLsLFWoWLY4Dh0/g8CgIPi+eo3L126jTMkiMo5mYKAvtpCnfOnPsWf/MXJi9z9HUbHM59JNszcMGDkN/bu3RoZ0n4ZGUCQdmPYQRdFAURTYo2wu04G5igsK7we8H/A+wPuAGvcBRbH8FBb8YwKxIKCJRV67ZXV3146PVRQFDx49lTMq+L56E+P6smXJgDo1qqJllyHo1n8cundoBmfRQ0UF9h46Ga/f+JMT3do1xpZdB+W0ZPcfPJGGNkWs3bRbzh7RsHVv/RCLp899KIqFCTCBxEmAW8UEmAATYAKJiIBGjW35vHA++AkjtGHd6mjUug++rNUC33xZNlaq0kTVy2aPxpJZI1G5fAl9WX+vnwvqRaYAWs+aMFBOSzZqUFf9i2ntW9Q3mzmCpkOhPCxMgAkwASbABJgAE0i8BBJHy1Rp8HZo2QAeKVOgSsWSOLR9sTQ2f6z5TeIgzq1gAkyACTABJsAEoiRAHVBRJuIETMBKAqoyeE+evQiS46fOY8nqzRgxfg6Gjp2pFyvbxMmYABOIYwJcHRNgAkzAngT6Dp9isfjzl65h9qI1FuM4kAkYElCVwbtg2QaQDBw5HbMWrsGegydw+PhZ7Np3FMdPXTDUm91MgAkwASbABJhAEiFw6eotiy1NkzoV9h44YTEungK5WpUSUJXBO3viIJDQ9Cfjh/XA/s0LsGfDPMyfOhQ0rlelDFktJsAEmAATYAJMwI4E/F77o12PEWby+8R5ePj4mR1r5qITCwFVGbw6qDRNWJkSReS0XBRWKH9uWrEwgcRBgFvBBJgAE2AC0SKQzN1Vzsffskkds/UfY/pGqyxOnDQJqNLgDUc4ajfpjMmzlmDu4rUYPWkurty4kzS3ELeaCTABJsAEmEAiJWBts+hjN6WKFUZEYm05nC7pElClwft15TIICQnD5h37sW7zHvxz9DTKFi+cdLcSt5wJMAEmwASYQBImQF9dTcLN56bbgIAqDV76otmudbOx4I8RmD1xMHavm4N+v7WxQXO5iIRHgDVmAkyACTABJgA8efZCdILtlkJuZsIEokNAlQbvK783WLFuOxYs+0vKir92gMKi0zBOywSYABNgAkwgURFIwo3ZtvsgGrfpJ578HsDaTbvlR6m27zmUhIlw06NLQJUG75AxM7H/yCkUL1pAyr6DJzBs3Ozoto3TMwEmwASYABNgAomAwOad+7Fj7Uz5tdTVCyZg7aJJWLxyUyJoGTchrgio0uB9+vwFZk8aBPq6GsnsiQPx8PHTuGKSkOth3ZkAE2ACTIAJJDoC3mk84eLsrG+Xl6cHkidLpvezgwlERUCVBq9GY66WRqNE1RaOZwJMgAkwASbwkQCvEhOB5MndQcMbn/v44tbdB5g+fyWKfZY/MTWR22JnAuaWpZ0rtKb43DmzoU7TbqjbrBtqN+mCaj+1w/sPgdZk5TRMgAkwASbABJhAIiOwafs+TJu7HLUbd0GTtv2wfO02KeWqNQFJImsuN8cOBFRp8L7weYnPCuVFOm9PZEzvjTo1qmJwr7Y2bz4XyASYABNgAkyACaifwLFdyxCZqL8FrGF8E1ClwZsyRXL83r8TZk0cjFkTBqFT64YoXbxIfLPi+pkAE2ACiZUAt4sJMAEmkKgJqMrgpa+qPX3ug4ePnmHcHwvlV9YoTCeJektw45gAE2ACTIAJMAEmwATsQsB6g9cu1Vsu9NUbf2zYtg8bd/yDbX8f0ovl1PEbGhwcBHtI1apfoUGD+nYp2x76qr1MIFzuKGrXM6Hoxzxte9yHhYVBUcDHu43Op8zTtvtneHjc7p+0/eQJmxdMwIYEVGXwtmleD+nTeqFNsx/xx5i+GNanAwb2aCOlyc/f27DZ6i/K3d0dKVKkUL+iCUhDRREWRQLSV+2qKkrS5WnrbaMoxJLE1iUnzfIUhViSJM3226PVisI87cGVy4w7AqoyeHXN3v3PMZQqVthINm37RxfNaybABJgAE2ACTIAJMIH4J5BgNFCVwfvw8TOcPHsRb968xciJ8/Brp4Fo3LYvGrbujQf84YkEs1OxokyACTABJsAEmAATUBMBVRm8Zy5cwYJlG3D/4VMcO3ked+8/QUhICN69C0DFMsXUxI11YQJMwFoCnI4JMAEmwASYQDwTUJXBW+t/VTB74iB4pEqOraumI2/ubFi9YAI2r/gDgUFB8YyKq2cCTIAJMAEmwASYQMwJcM74I6Aqg1eHIX06LwQHh8Df/x0OHT8jhzn4vHyti+Y1E2ACTIAJMAEmwASYABOwmoAqDd7g4FD5SWEa09t/xFR07jMaT589t7pRnJAJJFwCrDkTYAJMgAkwASZgawKqNHiDgoOxcNpwFMyfC9PH9kfvLr+iXJnitm47l8cEmAATYAJMgAmolQDrxQRsSECVBq+jowOev/AVvbo+KFo4H74oVwK+vr6xavaajbvQpF0/NGs/AAePnbFYls/LV+jUexRadB4M6ln+EBBglO6V3xt8VbsVZi1crQ9XFAWKYnt5/vw5Hjx4YJeyFcX2+iqKusvUfighnHnaaDsxT9vu73RCCQ/n/VNRbMOVedqGo6Joy4lrnlSfJan8/a+ITCzl4TAmoCOgSoP3rf87jJ6yQI7h3bR9H06c/g8Xr9zW6Rzt9b0HT7Bk1RbMmTQY44Z2x8iJcxEQaP4S3NQ5y1G2ZFHZu5wyZQosX7vdqK6JM5ageNH8gAL9z9HRCfaQEyf+xc6du+xStj30jacyreYDaCDsCavTq7098a0f87Ttca8oijynxPd2TSz1KwrztOW2VJS4PX9qNJZNkwNb/0RkIg8iXjCBCAhY3qsiSBxXwaGhofJLa1kyp8eeAyewZdcBpEqVLMbVHz5+BpUrlEQydzfQC3H58+TAyTMXzco7cuIcanxbSYbX+KYSDp84K920OH/xGtzcXFAofx5t5xYFsjABJsAEmAATUAWBpKHEg0dP4ffGP2k0lltpUwKqNHg906SGtxBXVxdMG9tPTlXm5uIa44a/eOmLjOm99fkzZ0yH5z4v9X5yvHv/AdQpkNojJXmRJVM6vPDRDqOguYCnzVuJzq0byjjjRbjw2ktE0bBX2Vyu9s6FOTAH3gd4H+B9QF37AF37zGXC9MXoMWg8GrXugxV/7ZCGL73Ubp6SQ5iAOQFVGbzT568ECX1pbejYmXj89DmmzVuBtr8NR1h4mLn20QhRDB6RKIr2cZdpdsPHKIp4hKOLp6ENdWtWRcoUyXVB+vX79+9hDwkKCkZISLBNy7aHngmlzICAAAQGBjJPG+2vzNO2xz3zZJ5qPpfG9f5J1z79RdbAQb27axZOxNo/J2LfwePwSJkC7z8Yv2tjkJydTMCIgKoM3uTJ3EHyzVflcOf+Y7z0fY1V4i6OdugvypcwUjw6Hu80nvDz+zSPr+8rP6T1SmNUBA13CA0NA80QQREvRRpvL09yyqENI8bPQblqTTB38VosWb0FU2YvlXHu7slgD3F2dpbjTe1RdlIs09XVDS7iKUFSbLs92sw8bXvcM88452mX87Y9jjU1lBnX+yeNP5YXWJOFo6PWZEnm7gYHBwcZ+/bdO7nmBROIioB274kqVRzF/9KwNkja//IzFs/4HTvXzsKmFdOwdNYotP+1foy1qFi2uPyABX2tzffVa1y+dhtlShaR5Z29cAXBwSHSXb7059iz/5h07/7nKCqW+Vy6500ZgmO7lklp07wemtWviW7tmsq4uFgEvX2MJ6dn4P6h4fC9uSMuquQ6mAATYAJMgAmoioC7m5t8of3k2Yt49+4DJs9aivRpPw1XVJWyrIzqCKjK4KWdmGT7nkNo3nEgGrXpgzv3HmL91j0YPGZGjOFly5IBdWpURcsuQ9Ct/zh079AMzk5OsrzeQyfj9ccB8N3aNcaWXQfltGT3HzxB43o1ZJr4XLx9dh43trWRhq7/439Bhu/N7W3jUyWumwkwASbABJhAnBN48fIV7j14jAXLNsArjQc8PVJh3LDuca4HV5gwCWjUpHaXvmNAQsMHrt+8C5+XftI/ftoi/P3PsVip+vMP1bBs9mgsmTUSlQ2GR/y9fq44cFLLsr3SpMasCQPltGSjBnWFm6urDDdc/NqoNtq3iHlvs2FZ1rifnVtglizQ/xEC/O6ZhXMAE2ACTMAeBLhMJqAGArMnDpIvsdN6yqg+aN6wFlycndWgGuuQAAioyuAlQzRfnhxI4+mBraumy49O6IYS5MiWKQHgtL2KIR98LBbq/yh2NwAWC+VAJsAEmAATYAIqJUBPgCMTlarNaqmEgI0MXtu0ZsyQ7pgq7toUKOg9ZDJu3XmAHXsO4+HjZ3BydLRNJQmsFEc3L4sap8hUzmI4BzIBJsAEmAATSIwEZsxfJZ/6Dhs7GyT0RJjCaIgDSWJsM7fJdgRUZfBSs1KlTI52v9ZDOm9PODo4YPSU+fil0yA0q1+LopOcpPu8pVmbXVJkgqtHNrNwDmACTEAFBFgFJsAE7ELASzz9HT+sB7asnCaF3BRGQxxI7FIpF5poCKjO4H395i3oIxAPHj2F6OhFwXy5MGPcAFStXAZJ8Zc8XVHkqTEXnrm/Q4qMpZGhREfkrj4nKaLgNjMBJsAEmEASJvD42Qt3xaAfAAAQAElEQVRULFsMiiKeAwsh99PnL5MwEfU3XU0aqsrg7TtsMn5o2hWLVmxC7y4tsGPNLDlAPV/upN2b6Zw8ozR0s1YaLA1fNe1ArAsTYAJMgAkwgbggQB+HOnbyvL4qcjs4qMqM0evGDvURUNWecuDoaWRKnxZBISGgL6y16zEChqI+fKwRE2ACsSPAuZkAE2AC1hEY2KMNJs9aIj8CRR+CIne/7q2sy8ypkjwBVRm8f4zpi67tGiNLxnS4e/8x6Gsq6dOmgU6S/NZiAEyACTABJsAEkiiB/HlyYPWCCVg+Z6wUclNYosHBDbErAVUZvKWKFQZJuVKf4adaX4OGMmRM7w2d2JUEF84EmAATYAJMgAmomsCh42cxd8laLFy+Af+e+U/VurJy6iKgKoOX0ISEhsLLMzXoE76mQvEsTCAJE+CmMwEmwASSLIE9B45j2NiZcNBocOnqTcyYvxoHjpxKsjy44dEjoDqDl6Yio7G80WtG0kpNnxe+vK4uLq6uAVo/OT0zaQHg1jIBJsAEmECSI0C9uotn/o6RA7sgXdo0WPDHMKxcvyPJceAGx4yA6gxeakbmjOmwYt12+L56TV4WAwL+D4/B9+YOhIcGQRF/tPa9uR3+j/81SMVOJsAEmAATYAKJi0B4WBgyZ0yvb5STkyMCAgL1fnYwgcgIqNLgXb91j5yloUaDjvq3MemNzMgaklTifG9ZvpslQzipMLC2nZyOCTABJsAEEg8BjcYB4eHh+gb9vf8YvNJ46P3sYAKREVClwXts1zJYksgaklTiFEcXi00NDeW7XItgOJAJMAEmwAQSBYGvviiD67fuyba89PXD1l0H0a1dU+nnBROIioAqDV5Smu7ibt99BBJyUxgLkDpbFYsYPHN8ZTGcA5kAE2ACTIAJJAYCLZvUQb7c2WVT1v45EVNH9wENgZQBvGACURBQpcG7afs+fFO3Dbr0HS3l2x/bYvPO/VE0JWlEp8hcQX5tTXFwRrj4o7Vn7upIlr5k7ABwbibABJgAE2ACKiawaOUmRCYqVp1VUwEBVRq8y9Zuw9A+HbBl5TQpg3u1w9LVW1SASx0qZCjREQV/Wo/C9bfJdYYSHeJcMd9Xfuj42yDk+uwLZC1QDk1bd8e9+4/iXA+ukAkwASZgawJcnjoJvH33HpGJOrVmrdRCQJUGr6OjIyqWLQZFUaRUKlccGo0SK2ZrNu5Ck3b90Kz9ABw8dsZiWT4vX6FT71Fo0Xkw+o+Yig8BATLd2QtX0Hf4FHxdpzVadR0KnjYNGD7mDyxavg5Pn70AjaVav3kn2ncfIHnxggkwASbABJiArQl0atUQkYmt6+PyEhcBVRq8Dg4aHDt5Xk/68PGzcHZ21vuj67j34AmWrNqCOZMGY9zQ7hg5cS4CAoPMipk6ZznKliyKhdOGI2XKFFi+drtM4+7mip6dfsGuv+ageYNaGDlxrgxPSAuau/f6lha4vrk5HhwbF2vV9x86ZlbGoaMnERoaahbOAUyACTABJsAEbEXg/KVrsqgLl67LNS+YgDUEVGnw9u3aAhOmL9ZPSTZl9lJQmDUNspTm8PEzqFyhJJK5uyF9Oi/kz5MDJ89chOnvyIlzqPFtJRlc45tKOHzirHTnE+m9PD3k112o5zk4OFjf+ysTqHxx78BgOXdv8PvnCP7wEm/uH8TNHe1UrjWrxwSYQIIgwEoygTgmMHDkdFnjkDH80SUJghdWEVClwVu4QB6sWzQRy+eMlbL2z4kolD+3VQ2ylOjFS19kTO+tj6K3Op/7vNT7yfHu/QcoCpDaIyV5kSVTOrzw8ZVuw8WGrXuRO2c2uLm6GgbHq9v3xiZcWf8zLq3+P3vnARhF0cXx/1x6Qk0IhGYAaQJKkSZSPynSBQFBehcEBKRXAUG6ICBNaYKgdFCQpjSlKUrvJSQhlPQE0i/fzCR3ucteQspdbpO85GZ35s3smze/3dt9Ozc72wbXt7fHw+PGQwtePlc691GhPpmyuXGDdxTbN6hXCzY2Ngo5CYgAESACRIAIEAEiYE0CqnR4fz18EiGhYShTqrgMgcEhOHj0dKY4MU1SUxnjnq0JbRqjMknldUXFzydbdhzAtLGDdSJERkZYJIhe5Li42FfqDg/2hd/FNdDGvJQ2xWvj8OLpJfhcWJWw7cswaOOUwzdE4ZCnNxLKZKAN40YORM+uHeSk3/nz5UH71s2wZO7UDOuzFEed3ujoKIigS9M6c8etYCkCccwcRx2/qCg6PnUszLGWPPl33hy6SEcEoqIis/T8GUdD48QlmoKZCSi9OjNXkBF1W3b8igL5E3paxfZuBQtg07a9Ipqh4O7mimDuNOs2FjMMFC7kpkvKtRjuEBenRXRMjEwHBAXDvZCrjIuF6O1d/t1WLJ8/kff+Jr3a0NbWDpYIoqeUMc0rdb/0Ow+AIflfxPN/E7a1d4Kto/JNNExjBxe3cgllMtCGgMAQ/HXuIvwDgvnNSTjOXfgP3r5PMqzPEgwNdWo0Nrz32Va19hnamh3ixNO833sb/suIjQ0dn+Y69omnuY9PW9hk4fGpMeh8Av0RATMR0JhJj1nVREZGG70+ULx4IjIqwRHNSEX169bAqbMXERUdjcCgEFy/dR91ar4pVYkZGGJiYmW8Xu1qOHo84WGsw3/8hfp1qkm5mL1h8uxlmDRqIIoWSRoaITJtbcVFyvxBfOFFeJV+G43pXcgY485dgl3Fag0HYzbC3MTAUOTNnvr8V9VhKn/58kWY+3Eczi4pI8OaT53w/bdzMqXTVD3mlImLoDn15XZdxDPh+2Wu44B4Ek9zHUuW0JOVxydjyk6cxIsXrYhAhgmY9pYyrM48GxYvWhjf/bBTr2zNxh3wLFlUn05vRGzbofV76D9iOkZOmo9RQ3vB3s5Oqhn3xde8hzJMxkd+0h37D52U05I98vZD986tpXz73sO4cv0Oug0cp3+Q7skzf5ln7UV+zwbchHgejD95DF5EkbdYHVTqshelGs3Ca+9ORuWP9sOtYkfjDdKZ+qCyDzyLOECjYTJ4FLTD8JZahIaFQ01/gbynXswXXLZqI5SqXJ/mC1bTzskCWx54efPv7q0sqCm7V0H2EwEiQARyNgGNGps3Y8JQ+Po9R/2WvdCgVW88fR6A6eOGZMrULh+0wOZVX2HTytloVO9tva4ju9agkFtBmRbrlQunQExLNmfqZ/oH04b0+whnDm02Ch6FC8ltrL2wdXRF0RqDoLFzlqYwjQ1cilSFR/UBMm24cPGojrwllA+b6co8u7oJXidnQKx1spTWxVyVh04+Z163Y8KNRErbZbV85PiZWL95O0QvfUhoOHbuPYiufYZltRlUXxYTuHv/IWo2bIsqtZujbpMP5MtRDh07mcVWUHVEgAhYgsBHH7wv1XZu31yuaUEE0kJA6bWksFVWil0L5scX44dg/9blPCyDeNOabvaErLQju9TlWq493uj4M++5/QWVOu9Fqcazpekh3qcR/vSKjL8MuA7fswvh/edchPmckTLDxfUdHfD82s8I97sg19e3dzDMVsQZM/2Tk42N4dAJxWZZLth74AgYS7KVMYZLV2/QfMFZvieytsKZc7/BjVt39ZUGBAbjs3Ez9GmKEAEikH0J9OiS8Ovrx51aZd9GkOVZTkCVDq+OgnByCxg8vKaT0zp1Aj5n5uPaT62lc/vwjwm4tq01Hhwdh2Cv4wj1OY1Hf86WeTotfhdXIz7OeIx0vDYGTy6uQYjXH4gMfqArql97PY3Sx3WR0JdxgMZWl1TFOjZxfHZyY4IMHmJMnkfp7E/g/D+XFI3w9nmM4JBQhTwDAtqECBABlRD45PNZKrGEzFA7AVU7vGqHp1b7Qh6d4KYx3rMJHphYID7ZMN8w36Rp3iICbkPxxzcIuL0XPmcX4d6h4bi5u6tRkdFrnkA4vVptPER4EhSD0asfw8vbV19OvN3t+o6OuMqdb7H2++dbfV5WROTUNsnanVAvQ2hoeEJURcttO/aj75Ax6N7/M6zdsFVFlhmbIuwcMGw8eg8eo1o7i5gYciQeAs2bx8W4MZQiAkQg2xB4p0UP/XM0uvilq7fQrOMg/LjjQLZpR84yNPu0hhze7LOv0mRp+JMLvBzjwfjDYOz5cX8WsS+fyEKOBUrLtdGC//TPvWW9KC46XPYM6wR+AbHoPNsHdUfel6Hd9EfwD4mD5vEOPDo1E74XVsi3u8XHRYPxf7EOvHsAYY/P61RYfC2GVxQtVlhRj6OjPcqUfk0ht6Zg4Tdr0P/Tcfh516/Y88thiLHHw8dOt6ZJJuueOW+ptHPHnoPYd+CotFM46SYLW1Eo5ohOXn2Hti0gjonkckoTASKQPQgkf5ZGpKtWqYCdGxdj/6Hj2aMRZKXVCKjS4b14+YYCyJkLyp8oFYVIAFu7PGmiIPxZW2cPWbZYrWFgNoYPmxk7x7IQX0Q8v4FHp2fD59wS1HrDlUuSPjXKOmD3dE+EPjwindrg+wd5plKPGFbBM4w+IQZjjY0yzJAo5FpQ9kDHcw9fF5wcHM2g2bwqduxW9k5s586v7KU2b1WZ0rZ2/TZwlDzE68NO7vymZmemKszgxgN6d8Xm75agW+d2aNuqKebPmojVS+dkUJvlNgsLf4FBwyfCs1J9FCtXFy0/7APxwJ3laiTNRCBnEWjVrAHy5c2DN98on7MaRq0xOwFVOrwLlm3AQ28/fWPPX7yCr1du0qcpkjIBR7c3TGbG815Ww4y8xesbJlGp0264V+6CPEVrIW+xmkZ5ukRsVBDCfM8g5OFRLB9SAN0a5YU2XgutVouRHdzBGNMVTVzzfuX4xKiJ1fNrW3Htp7bw+WsuvI5PxPXtHfDiyb8mSmZc5PXIV9olnF0k9nIHh4YiWGVjOb0Sh4IIO0UQLRbOkI9vQi+8SKshBAQFc57ggelDbFwcBGeo7K/221XRoF5tNBShfh04OanvRmf459Ox5ec98niMiIzEydPn0LpTP5WRJHMsQWD3/kMQQ4O69h2OFWs2ISIi0hLVZFqn35Nn2LR1F1av+1E+8JtphWZQ8Mw/EPt+O44v5q3E+i17pMZJo5UzE8kMdS3IGisSUKXDK6YlmzhjMYKCQyFeDLFw+QYs/nKcFTFlr6pfqzcRTGPHe+C4i8cdThv7vHit4RQU8GyMfCXqQ8zFW/LdCYpGFa7SC54Np/P8qXz7Vz18xtCnuSs0TAONRgOPgqbLc5fXqB5hg04gHF5uoS4J8aCc79/L9GlzRDw8hCMOaSNjGjDGkDePM9T2MGS1tyrxGwe+sxIbHa+NR7GiReD5WvFEiTpWGs7PlCVqs/PX335H+epNMHTUFIydMkdOTTZl1kJTpltVdvDIH4r6xcN1apvPWhgpHLSufYehVae+qnbQhK2n/jqPPb8eEVFVhu82bkOPASOxdfs+7D9wFOOmfoXBn01Sna0HDv8hv0fDPp+GCdPn4Z3/dcD4aXOtZufsxWvxQY/P0GPwnJ5nywAAEABJREFURPx1/j9UqlAGy+ZNtJo9VHH2IqBRo7nlX/fEsEHdMXLSPIgDfMGMMShRrIgaTVWlTXlLvotKnXejStdfZKjYYSvyFauL4nXHQDi6Yi7e6PDHEA+VifG2gXcPGrdDY4uyLZbB2b0KbB3zw87FnecLZ4zxddInn3PS4fM0KDYpwzBmY8/7VePB+Nq1bCu4FKoIMfNDiPdpxPPeYcOiIh4bESBWZguMGducoDjJ7oS09Zeix0KjYWDcXsYYGI+HhYVZ37BkFsSL8QzJZIwxPA8ITCa1bnLM5NkKA775dr1CZm1BVFS0SRPU1rP/xZyv5cOU+349iuMnz8ibiObte5i03ZrCYydOI3/xN9Gm8wD0/WQsXIpUxIy5S61pksm6f9i2WyHfzXt81TY0aOzkOfxGXCs7Chjj5yUeVqzdpLA9qwR//3sNWn4O6t21HQb2/BBifn3yDbKKfvavR1VX/jUbt0MXrt24Iw/sCuVK49Dvp6U8++NWRwvCn17CnV8HyYfKxENkwvG9e2CwkXH2+Uqi9P/mokL7LSjfZj13Wo2yZSL0pVauxeLr3c+5AxsvovrgkLc4KgvH+6NfUanTLsS8DMCNXd0gZn4Qwxj0BQ0izMbBIAU8ODYG17e3w7Wf2uDG7q4Ivn/YKP9VCT+/Z9Dy3lKtVsvt0/K4FmHh4VDbkIZbt+9z+3h/Nz+ZC6dShNCwF6qzk5unQC56o9V2ofZ9rBwKEsePgTv3Hyrst6bAw6MwPybjoeU3fwmBf4cYUKliWWuapah72aqNRk4PYwz//HdVdfNZi5lDYmMNb74Z5n+9WtEeawuu37yjMEGco+7e91LIrSkw9T0S3/crV29miVnJK9n9wxKsmD8JLi5OWPfjHvQcMgkzF6xKXozSRMAkAVU5vMktbFC3OjxLeCQXUzqTBJ7+971CQ1SYLyKDUz7Z5ilSw2ibeO4CbzwSxJ00HuNe0D93ItFx5iPA9R3kLVYbRd/+FGVbrdZvI3SHPT4HftWE7k84dbp4wppf7PmF/9pPbbmD2xZiKrOX/tcRzx0Vka+NDofvhW9w7/BnuLmnh1y/eHJRZKUY7OxtIXpOxbALxjQQa1tbG6htSEOcNhbch+CB6YNoVGiYynp5mbDKOPAjAB6F3Y2FKkiJ40vYJgM/RoVDUbRIYRVYlmSCs5Mj39/ggSUEAHa2pocH8SyrfSIjTY8vPfnXBavZZKrioKAQE+J43H/Iz00mcqwlypfXBfL45MelXPPzKcBQoVwZqOnPwd7epDklSxYzKc9KoYafMAU7Le/QyMp6qa7sS0CjJtMH9e6M1IKabM3OtsRG+Js0P8z3jEm5EJZqPAsl6o1D3uLvIH+ppvj020Bs+cP44vIkOB6Vm03Gaw2mwbVsS7GZPpjSzc9XED264vXIdi5FIMYaa2PFhZU7vvwCEB/Hf+6NZ3odukhk0F3ERQUjMugeHh6fihs7O3MHuQ3vCW7P05MhhkvoZpN4s2Qktk8ugbNLysiwb8ZrqFzSRnU9U4xf7HTtM1yrzfkRNw/yIqO7UPM1UrAd1vxjAGMM+n8eBw/hL15ATX+3796X5ujsFInomBgEBRt/t4TcmkHcKJqqv0bVyqbEVpOJM0fyysXx+uLFy+Riq6ZDQsL54cj3Oj8mGeNrMGi1cVDbw5/Fi3sYO+b8+25nZ2e1DoMOPUdi6NjZ/Fe6l+j5UVtsXvUVxFtZrbozqfJsQ0BVDq+OWiz/Sers35ewbvNuOZRBN8xBl0/rzBGwdSpkUoFwZk1mJArzl2yI1+pPRok6I1GkdA0wxk/UBqF8ORPz+SZua+dUIDFmuGJwzFcMFdpvQvk230MbG2GYmRDn+hMiKSwZ9NvF8wvGi6eX5KwPwsEOeXgU8/sVh2dhe96zy2TwKGiHRYOK4foN5U+KUNkfYwyXr91SlVXxvDeFMQbRu8IYSzwGALUNEXFyckLyP8YF7m6ufKmejzaRp84ixhgYNHy/34Sa/hx5T7TCHgbkz5dXIbamwNNEz6ONxgZvVq5oTbMUdUfH8Jv5ZFLGGEpwBzOZOO1JC5TUzRzBGANjCUGMO7fW971G1UoQ56AfftqPdVt2Y8e+w/B7+twCLSeVOZGAKh3eyV9+g537jyLKxEkhJ+6ErGpTyJ2zCLp+HEWq9VdUKcbbOhbwVMhTEjzy8lVk+fj44YX/DflQWvLMArxXmGmUP9W6lm2dvOgr0qIPhxmUMYzrxKKMLq5c53OxgYuzvTLDmhJ+MUleveiZatr43eRiq6Y1GlO8gbwqe4NZpIkpnhhj8FHZNG+mdiY3E1VUNqdoHO+EEMejUeDOutp6JHt16whpo/iFSATeI/l2jTdNYbaqLI6zEwbI4TbcThFnjOHk6fMiqpoQEBgkHV1Dg7iZhsksjU8dMwi/bFuOdctmol7tarh64x6GjlE+oJqlRlFl2YaAKh3eyKgYLJjxOYb0/choiEO2oaoyQ4OuncD5iXVwc+0w3N4wBtcWD0T+gi2Rv2RdOBUsrRhv+yrzxQNK9x96J1xY+AVFXGA8CjLsm+aOh8fGyofSrv3UBr5nFyap4s6u4cwPDvlKwLVcazy9sgXX5Jjddrws4yHZh+tH4gVB1JMYTVboFUkTaj1Lqmu6r+b/a6BoRLnXS2X6zWDhDy/h3rZpuLt5grzZUVSSToFu7HMNDw3qlUw4fTDGMm0nzPyn0STYZqhWHEoFC+Y3FFk9bmNivK48zq1uWTIDmCbB8RHfJR4YYzDFGFb+++3oSYUFf1+8rLohTIUKFpDnT52xotdSyw/QJo3e0YlUsY6MjlHYwRhDSIh1ny0QMzO0e78xxHAG8SAb6I8IpIGAJg1lsryIvb0tYmJis7zenFrhg51zEB8Xl9S8eC18j61HiPdZRAQ9kNOTGTmnSSX1MW10KB6d/hK39vbCvYODMKaTuz5PRKb38ICLo42I6kOw13HoXl8shIYzP5RtuQrBD44hNjKIZ4keWS3itdHQyDe+8SsqeOAnVjCRx+O8FGN8zQM3n6d0H5Gvi/N1YpJfOyAdBxkRcp4h4jwa+oIfW9wB51HVfGrXrIrhdeywpaMTfvrQCZMb2OOtKpn7GdbnyFpc+7Y//C8eQMDlo/JmRzi+mWn08LbVcbinMxa2cMKX/3PC0Z4umNCqjOocXnGTJPd/YmNFPB5ahKtsLGeJYqYeymXQ3Vgkmm/1lYOdnfw+Mf69FEHy5N8ntc2//N/la2BMWJgYeFyr1UI5+4F1kTq7OBnbyX85sbUxPn9a18KE2rW8Zz8hlrQU+z5/fusMZQkODYOYqrTVR0MhgogLWZJ1FCMCKRNQpcMbHR2LLv3HyLer6cbvinXKzaCc1AjEvjAxRyr/SU3Le9J12yV3TnVy3frObyMQ5nuWO6iBiHnxFK1r2mJW78IJJ21+UfEsYqcrarQO8T5nlNYlhCOslQ+o6SRizbhjHiMiCYFfUAGG5H/ObmXgkL808r3WiPs1Ip87s7LrNx7xiQ4yNwmM8TwRwPPFWgSuLDwyaTo1nlTFp+Dl9ehQ0R5F82rgnkeD98rYoQ1OZMq2p6e2KLYPvHJMIUuPoL7dDdjyi7NuG9GR2tRdfWPo8uTJA8b48cT3PT8qZJwxJl9BqrNdDevKb5SVjqSwUQZ+zLvyXmgblTk/YS8SHrLSMWOMf7d4IjQsnC/V84kx4aAJ68qW8RQr1QRvXz+FLeKXMzGEQJFhRYGWXyeEg5vchGvXbycXZUl6xrxVKFyoIMaP6IeRn/SAg709hCxLKqdKsj0BVTq8lSuWQcv33oWLs5PVAOekipnsNU3WIn7B0jgYO6kpOqeRgTA1s8O7lVz0SiOj9FGjyMuAG/A6OQPPrm6S8oBbe/Ho1Aw8vboV4D0vUmiw4K4pT4mlCIlRvjL8RATdR1TIA4Q+OiHdGUBcfEWI5zGxhvEfMz7Mi7rawUY6xsbFrJmq7BavqL5UAQ0uX76skKdVEBf1QlFUXLxe+mXiQbho5U+ZGt5zGh34WFGXtQWirfwAgQgiLo6MPC7O1jbLqP5zFy4ZpUUiIDBYdT/BC8dH2GYYGGO4fvOuocj6ceXXCIwxbN/1q/VtM7BAG6e86WaM4d6DRwalrB+1t0+4Rojvjy4wxlC5UnmrGOfAf/0d2KsTGr1bE82b1MOYYb3x3D8Q9EcE0kLA2BNIyxZZUCalqcmyoOoUq/h5zyH0+GQieg2ZjJNnUp/7NUUlVsrIW+ZtRc0aB+XPZ/Z5TY9rffH8qmJ7IXBxTDp8fjkbKkSKEOp9GuF+F/D82s+4tq0Nnvy3FmGPL0AMZ4B0RE1coQy1MOGmJAjijccySCFjIv8VOmTJpAVjDC8DMuH0JarSPQSYmMzUyt5WtCOZCm5n6XwGQ1GSZb8qaeOQdEOiK8sYg3PRCrpkutexyuu07KEMjEzfPkh3xencwFRPmXDaglQ23ZewhzEG/T+Pa3gP+sVL19LZYosWB7hdSPYXz3ujCxdS16wXyUyUSWFnx/bvy7haFowxhSkcJ/K4KL+zioJZKGjetKGiNjfXglYbchPHO0miopNmuAgMCkHevOpipgBGAtUQSPJYVGNSgiHXbt7Dxq37IIYy6EJCTtYvvbz9sGnbfqxePA3zvxiF2YvWIDKFV4JmvXWvrrHigGUo/E4n2BcoCvt8heFSuiKcq7gbbaixdUTeYjWNZLqEmI4M0jnVSRLWjwNioXt4ad2RYCzb6w+NU2HYOhaAcuoz7iklP8fzNNMIx5tHIA5FsU7Qbbh8vel8lKj7OZzd3jAUm4gLHfEm5MYyprGDs3vG5w8NSvYQ4LnxteF34gdk5i+aKX/NiItnyFuqeobVFmnQXbGt65vvKWTpEVx6qnTAvYK1iIozZpwenZYqyxjjfppB4I7kf1euW6q6DOm1sbWRNwxyOAPvihbOmZZf1GuobH7bkibGGjN+TihT+rUMtdtSG4keScFQp18X93uirmE3bq4FFPtdPK+gtjfslShWFIwZfId43M2toA5vlq+jomLQsRe/Bi9ei4mzlqBTn8+RP18evZ+Q5QZRhdmKgPAQMm+wmTWs27IH879Zhz0HfkdAYAhf/wFv36dmriXt6k6fvSh/QhFDLDyKFELFcqVx4aLpXk+o9K90hwmoPmk/qk85gCpDNsOjal845C0G4Zy6FKmO11ssT9Vy90qdeD7jIeET6f8Seb38DR5eckbk4xco33otKrTfDDsnt4SCr1ja2OdD5Y/287APjvmVF08bOxc4ulVCfs8mcHIz/TOanZM7b0d+OOQrAdeybXlcnJCFrRrYOLpBq006zMUF0L6EmBHiFYalkm3qIUDvQ9+mssWrs97s9SWgSbITYCjdZgQy81ei2UBUHvo9CtVoBbe3mqJ8n4Uo22NuZlRiwpEo7LkVjYAXcQiJjMWx+zHouzcSTo6OmdJr9o1N+d9c5u6WtuPS7PakoFCrjQNjDPp/HgcPYeEvUtc334cAABAASURBVNjCOuIhA3oqHLSG79a2jjGp1Fr77aoyV9xAaPkNhEg42NtDbQ/Xibc9Ctt0+13EE82VUbUsdu45oDDl9p37Vpt3u8obr6N9y8ZwdyuA0q8VR9eOLVDGszjojwikhYDhFTYt5bOkzG/HTuH7b2agiLsbJo4agF2blvAe1RQGiWaBRc8DAlHMw11fU4liRfDMP0Cm//rrL1giPHjwAH5+fnrd549vx4Ujq/XpzNZ5K7AonhXogwD3oXhs3xJ/X76fqu67oWURUnIiXrh+gLBC3eF/KxQ2/MIsIfCFhvee9X/bXq8jODptT/FGxjvrt3nu3ApaW1eA92yCOydam7wILdBBn/8g8k3EMxteW9InHjbwLzSIt+NTPMvfCw+i3uLxIdLWkJITsGZfFIL/foywf/wQ/vcThP7th1VLN+t1ZoRjdLhyzFh8TDT+OvpLhvXeCLFD/LsjoC1UDvEFPRFXpx8e2L2eYX26dl3mNyFPX3sfz8q0w43gpP2jy0/vulEZe7QpZwc3Fxvkd7RFk1J26FLZFrdu3si0rem1JbXyDg72SQeJQeyJn4/F7UzNruR52jh+oBvYJ6KML06dOqUqO3fs+YU7vNwwYS4P/IOzFy6qykbB1uuRD79fYBD/GrHk56hYflMh8tQUnj0PAGOMA034MJYQ375jt6qYBgYF8/3Obx/ik4Kw+Njvf1jUzmfPnolqZNj323G5FouUhjvq5KIMBSKQEgFNShnWlDs7O8PW1hbRMTGI4z/vOfKLlybxhGAtu5gmCRVjCScnYcuhQ4dgiXDr1i14eXnh9O974eI1Fy5PN8I5cD/ye89G0OWVFqkzLe349bQ3Dp68ibz24pInCCQFe47o1OF90ra95+MRJxxXfTbP5CdNfZJHRPLErTyyvKj7+JE/8Oy8F8Iu+nEH9QkCzj/CX3+c1ueLMtuvVcN1/yLwDc0n19uvVzPKF2UMQ8f8t2FvwyD++QI2Gg06lQjCwYMHU93OUEfyuLCbm2/0ETSOnDiTYZ03d38NdmoJNP53wIK8YHPue/jumplhfcLmkwd3ImLvRGj2jIBm9whE7xmL8wd/zJTO0XUdFLM0DHzbAUePHs2UXmGvOUO5MspeHzfXfDh18oSq7DQ6iBITjDEc/O2wquy8euMO/wGCf4u4bYwxiPOxGEv58/ZdqrLzsYm3bsXFxmH3nr2qslOrFWcMGP0xxnD46DFV2RmbOJ0lY0n7Xth+8uRJi9rp6+urZ3Pw6Gl9nCLZjoCqDOZeiKrskca4ODnKeXhLe5bAlwvXYNmaLYiKjpV51li4u7kiODhEX7W46y1cyE2mZ8yYAUuE999/H3Xr1kXneow7GFpZV8KCoVTBIEwdP8Qi9aa1Lfw+BAmnbL4UH+4F8j4AjJ8yU2/XW133w71yF+QpWkuuK3f9FR7VBiJvsVpwLdcWFdttwIjxi/XlWxfwRp74F8IvBT+/wglRaMCu6vN1tnX+9Hs0H/gjxFonS2ltZ+JhMMYYvpgwRqE3JR3J5bYOjgm7wmDJmAbTZ83OsM7y8DbQlhAtqfHPsD5hc1p5irJpDS52hsdigp22/Cwy+bPBmbI1rfWntdyRX35G0yb14ejIHXQbG1R6oxwO7vpBVTaKtrxd/c0EiAZLR0dHfLt8qapsFcMCxHAg8R2XQXzfudM2c+YXqrIz8aRkQBNgjKFvvwGqstOGH5NI9if4rlqhrv0ubmwYY0aWiuTQTz+1KM/q1asb1UkJImAOAvxSZQ415tXx+ad9ZO/uqCE9ULJYEYifJyePHmDeStKhrX7dGjh19iJ3uqMRGBSC67fuo05N5YUqHSrTXDQ6zMdk2ZSmEDNZ2MxCMV9kLL/gJZwG+VJ8+FmQX//g8zTQqLbCVXrBs+F0iLXIcKvQHq81mI6iNQbD1rmQEOlDhP8jfVwXiY0IA2KjdUmzrTMzRjI+LoZfV4WXz83hHHgMiOeOYCbstIXB/MNcrfhwrAjzuSGiGQqW4BkbJ1trZI+4UNu4FDSSpTlhoYLbd/+KI7+fQkREJMTcrNdu3Mb8JastVFvG1b7ftCEEP50GEa/21hu6pGrWGv7LCGMM+n8R50HIVWMkN8TUy1ocHBxQqWI5nqueT0rcfHyfqMdIYQm/kRcrw8AYg52NraGI4kQgWxBQncMby39C2bn/CFycnZDHxRn9enSAGJ/jXsjVakA9SxZFh9bvof+I6Rg5aT5GDe0Fezu7LLFHY+tksp6UphAzWThRaK5ptETvhL2tTaLWpJUNPxF6Fksa65yUk7ZYvDYubQXTUcrkNFp8+wJFivFlxj/iws+v/gBvM0Pm/14q/V2IV406FzX9oF7ma8yYhkvPuGOfbFOvYC2CX0Qmk1o3uWLNJr5rWFIAw859B1U3v+2BIyfAGJM3UKLnlDGG839fUp2dESlMtO3Ee9Ctu6eNaxf2iJsGnVTEbU2cq3T51lrb29nKGx2xz2WQN87xsNYbzFLiYGeCnWAq3hSX0jYkzzgB2tKyBFTn8Nryn3oePvK1bKszoL3LBy2wedVX2LRyNhrVezsDGjK2SYFS7yk21NimPIWYojAXpHUaLfFyCMOXRPBNU/wIpzfFzAxmMH7Sz+CmKW72ouZgRPNeSXFR4V4FxJhwn6JNUiyflgynQq8pitk65QVsTT8opShsQrDrlrLn9MTDzA3jsYSd8/52hJilwS9Mi+cvtHKWhgG/RKNA/nwmWmU90b37XorK4/lPEGrrQbt2/Za0k7vmEEEktFot7pqwX+RZK8REK+/IGGM4efq8tUwyWe/Ff6+CMeMbiPDwFwgyGJJmcsMsFpYoXlTaKfa5DNxmDe9NzZtHXXPKli/3unTMjfBwW8UwPyMZJYhANiCgUaONhdwKYsy0hThy/Awu8BOYLqjRVkvb5F65a7qnEEtu04OdcxDPe871cv7ze/JptK7v6CBfDqF7ScT17R30xU1FnN3N7PTFRvMeTa3wSXl13PkTH+EAM/Cf9a9xWcY+zbsOgufI/bhSaQz+LjccBQb8hE6jF2ZMWeJW5XovgqO7J/gVCwCDff7CKN/va2Tmb+u1OIw4EIHDd2Pwx4MYTPk9AjNPRCVTmb6kJewc2Lcrvjkbg+67IvDRjgjMPhWNTh+0hCVugNLXWuPStrwHzVgCMMbg4JjxmxJY4M/JSTkenB/6KOpR2AK1ZVyljRionWxz0dNXvVrlZFLrJsWDdMIChoR/ERfhgZfpoWEizxrh00G9pCMpGMrAz3wftlff92gQ/74LPtJGfj4W605ZbOfKhVOECRSIQKYJaDKtwQIKnj4PQPiLCOzcfxTfb96tDxaoKluodKv4Icq2WiPnty3VeBbs83gg9uUziLeVifWrGhH7wnhcrSgvptGKDk4YL+Z3cTV3iI17cOK1MXh2eaMoajKY3ZnivaP2ed35ZUpUxyAijDEwLs+biZcvgP+9VrIY+nTvhIF9upplLJ9joZKoOnYn6sy7gDrzL6D65AOZekEEN5F/GK4+12Lun9GYdTIaf3knDB14HqDcd7xwmj6WsHPa+M/w/Yr50slt16oplsybhvUrM3cDkabGpLNQTRMPg4lhUh6F3dOpybLFixRyk46PrhbhUDDGkNIYT1jpryTvkRS26arXxdXWI2lrZ6czMWnNALeCBZLSKogN6N0VW75fio+7tEe71s2wYNYkrF46B2r7E3aOGNIXpTxLwMPDHe1aNcOSudOsZuY7LXpAHwziVjOIKs5WBFTp8K5aNBWmQrYia0Fj7x78BLf294Pv+a/l+t5vQ1OtjdmYuggw2BfwkNtFBNyW6+SLiKB7yUX6tCWcqdIfTgKzMRgbzDQo2SL1tukNSiXyyPsxNmzZgbUbtuH6zTuplLReVrW3KknHRzgSulDI1RVqc9AEoa6d2uK75fOwcfVCfhPRTYhUFyaNGaawadJYpUxRKIsFbbkDwRjj/XvxMjDGUKdmVfn8Qhabkmp1o4YNkPla/uuQCOKGtNMHrVTXs/929SqK75G9nb3qXjwhHpo9+ed5iHBKrP86D1+/hA4ICVoli+82bsOyVRvg9cgXT5/6Y//Boxg5YabVrDtzaDN0YfcPS/BJny7o2Kap1eyhirMXAU32MpesfX5tG6JCjX+eiwx5hIBbe1OEk7eMcsyxk3tpfXnHAklxvZBHnLg8xOsPRAY/4CnLfwpWboTaX51DxYHL5VvB6sw7j6KNema0YrndoWMn8UbN97Dp6y+xZ8181GrUDqvXbZF5mV2Y6yFAYce4UZ+AMWYUJo/7VGRRyACBxg3q4va/f+Bbvt8XfDkJZ//Yg5FD+2VAk2U3GTtyMAb1/RglihVFwfz50able1jzzVeWrTQD2kVPn+iR7N7lA7Rv3Vy1PZLiFwjGjL9Hk8ao73u0YMlqrFn/I3wfP0FwSCh+OXgMg0ZMzMCesewm23cfUFSwe/8hVTxU6VG4EHp3awefx9Z7C6sCDglUTUCjauvIOAWB8Kf/KWRC8ML/qliZDBUHLEPhdzrxHt2isM9XGK5Vm+Otsdv1ZYvVGgam6AVmeH5jB3zOLsK9Q8Nxc3dXfXkRifT3xqUFH+Lc+Fo4N64W/p3dCmEP/xVZmQ75y9VFwUqNM61HKNjLndzDPZ2xsIUTvvyfE472dMHVXctEVoZD0LUTOD+xDm6uHYbbG8bg3Pja8DvxQ4b1iQ1bvNcQN/4+hmULZ2DxV1Nw4cQ+DO7XXWRRyCCB4sU80PvjDzF0YE+8WalCBrVYdjMxJODruVNx/cJhPLh6Ej9tWI6yZUpZttIMau/QtoXs2d+2fhnEGFRT448zqNpsmzVOvNER36O5M8bJG51x/KbCbBWYSdFhfiOeXNWFfy4jNCw8udhM6YypuX33vmJDaz9UKX4Bu/fAGw+9/aRtTRrUkr36MkELIpAKAXJ4U4Gjxiwbh7wmzbJzMp7TNnmh0h0moPqk/ag+5QDKdZ+TPBuVOu2G7iURBcs04/nx4N2N0P3FRYfj0Z+zdUnc2fg5Ip97gZ9puCwe0SHPcHvdKB5X16ddYT/YapjeKA0/4rtUiJG9KnphOiMP0vAQYDpVyuJirHG/nl2ko2vOeUPN2RMtDeWL0DvnEHLjJI+p+/PAyxtXEmdCULelZJ25CIgbnV7dOvDv0ceqvdFJqa1qG7vdrEkDaWrCgBt+TeCpoh6FUaFcGR7L+k9QcCj6DpuKHp9MRLcBYzF49Ew0qV+bX6qSzvFZbxXVmF0I8Mu/+kw98dc/6jNKJRZ5vNmLW5Jw4uGRxE883Mq2SoynvErN8RFbiZdDeDacDluH/CKpCFHBD/UyS7zUQCh/sHsu/p3TFv9+2Qp3tkwSokyFfA7Kze35Ue8c/1KZkUZJzIsgRUnDhwAVmVYSWKInWqfz7oaRuL9loll6ty2B5+79h6jZsC2q1G6Ouk0+wGtvvAMxvMUSdZFOIpBeAs3fa6jYpNbbb6lu7Havbh1hb28Ppvu1Q80KAAAQAElEQVRnQK+uHRW2Z5Vg8bebUOWNctiyeh6qVqmAzu2bY9naH7OqeqonmxPgl371tWDX/qPo3Pdz/LT7ECKjotVnoBUtss9XEqUazYJjwddh41BArkVayFMyS+ekpPUneDELhCldNnZJUyjFW+AlETe/G45nZ3YgOtgP0aHPEHjpMC4v6GzKlDTLNDa2irLidsE+j6tCnlaBKZ1gDJnRGenvjVPTWuDMuJo4O7YmTk1qnOkhIg9M9UT/tiKtzTRZzhI6TVaUSeHMud/gxq27ei0BgcH4bNwMfVptEdETffWG6YdH1WZrdrAnkzwt3sSxIwfLsduiN1rMYa3Wsdubtu5CdHTSNTienzw3bdtlcT4pVXDr7gN8/mkvlClVXBZp2qgu7j/0kXFaEIFXEdC8qoA18pd+NR7zvxiNO/e98GHvUVi6ejOePPW3himqrNPFowZeb74UFT/YLNcirY0ORYiX6QfMTDoph75NsW0FSjUF0ygdRdeyrfXbaByUhw6z4bf/YsyAvlT6ImH3lT37Ec8fALFJJ9z0aQT84pWOrX+0A2Brn15V+vIpPgSYCZ1nFveFfWQANLwWxjHax4bjvxVDeCrjH5M90XGxiA58nGGlltCZYWNS2fD8P5cUud4+jzM1lEWh0AwCXU90tXqt0aB5F1X3RIuHlQYMG4+ufYdjxZpN8rXNZkBgVhXZhacYu93w3doQoYFY16uN4kU9zMrCHMrO//OfQo3fk2d48uy5Qp4VAhuNhvct8BNkYmUxMbHQahOmcEwU0YoIpEhAk2KOlTNKexbHlM8H4Zu5E3D0xDl06DUS075awb9o/la2DIDKLHh0ahZu7OqW4gNmsa+Yh1fRHO7slm2xDM7uVWDrmB8O+Uqg6NufoECZ9/VFbUvlB3O04Wl+y88/zI7BoVxBns7ghzu1Wh5MbR3mc82UOE2yGaeB5G8G6/ZzSKaeMn7VQ4BpMixZIfuY4GQSwB4xiIuKUMjTKjDZE803ts9XiC8z9rGEzoxZkvpWRQor26jhF0vhaKS+Zdbmzlm4AtmhJ1pMT9VjwEhs3b4P+w8cxbipX2HwZ5OyFlYaaiOeaYCUjiJFTMxbLb5H7m7KjoR0qM1wUdeCBeAfkDCkLDz8JfoOn4pWzRLGGWdYKW2Yawho1NrS+14++HLRGoycOA8t33sX29cvQsXyZTBiwldqNdkqdkUG3UXY43Pgt73Q/cUle8CMKWZg4CV5N6JuHl6eUnzEEInS/5uLCu23oGzLVXAt28aozOMwwKWyO/K8XRR5anrA5a0ieMlsERyWwbGxvHfULo+bUR0iwWztMv1Sh+RvBhN6Mxte9RBgevWLJ49NbZOZV+FaoifaEjpNtTuzsp5dOyhUiFkG1PZGuIv/KWdXUWNP9A/bdit4ih7fuLg4KDKsKCCe5oXfuUMrhUJrfo/GjugH3bWuXcvGmPBZP3T5oAXojwikhYAqHd6Rk+Zh0qylqFShDLZvWIyh/buiRLEi+PjDlrDjDlBaGpZbyoR68y5ME42NCk56wCxFJ8XEdmkVbTiTH15Po/jPSfEyPAmKweyfX0KMR0urjuTlSlvgxRONG7yTvBo0qFcLanN8QuKcFHa+iGXwLGN6jmRFYRMCS/REe5XujOQ95mfcPjBRu3VFYt7Yzd8tQbfO7dC2VVPMnzVRlW+yyp8/nwKU6EFTW0/07Tv3FXaKn5Lv3vdSyK0pIJ7mpa/7HomXzbR+/39W/x6VKlkUhVwLyEYKR1c8wLZoxSaZpgUReBWBLHB4X2WCMr9z+xbY9t0CiDeoODoYj7XcsmaucoNcLEnLA2aWcHwGDByOzrN9UHfkfRnaTX+Etl0GZWpPWOLFE9MmjECf7p3gUcQdbvxE2bHd+1j59exM2WmJjT27fQW/lzaIi49HvBbw5x3lto1HZroqc/dEf738eyTvMZ+3eFWm7bSEAtETJd4It03F88Zml57ols0bK3ZRyRLFYK3pqRTGJAqIZyIIM67E92j10jn4Yc1iq8+//POeQ/KB9ncMXiu8Y99hiPSajdvN2GpSlRMJqMrh/fP8fxABDHIt4oYhJ+6AzLYpLQ+YiTrM7fhY8kUJ5nzxhBjztWLxLNz85xjuXjqOH9Z+Dc/XEp7wFVzUEqrUboAPlp9D4SE7kW/AVrRe/jcatu+hFvP0dty6c08f10WePveHtR5i0dmQbdbJDE3qQWsDNfSgJTNPnxRvK3ujQll9Wtw8Lp0/XZ9WS4R4qmVPWMYO4fCKh9rPHNoMXRDTk4n4oN6dLVMpac0xBFTl8P68+xBSCzmGujkbkoYHzMxZnaEuS70owbCO3BYvW6YUKlUsp9pmVyj3usK2Iu6F4GHi4RZFQRKYJKDrQdu81vo9aCYN5EJxXP59cj+unj8s31726MYZiJtenqW6D/FU3S4xm0GODg4o5lHYbPpIkXUJZHXtqnJ4xZ1baiGr4WSX+l71gFl2aQfZqX4Co4b1Vxg5fvQnChkJciaB0p4ls93by9S8J4jnq/fO4m836gttXq18aH3Voqn6fIoQgdQIqMrhTc3QzOaJn0LE6wh7DZmMk2cumlQnpjsZNm4O+g2fBvHQXERkpCz37+UbmDBzCZp2GIgBn30BehOcxEKLXEhA9Ord+PsYlsybhvmzJuDCiX0Y3K+7hUiQWiJABHI7gTv3vXM7Amq/mQioyuEVA8+vXL8jB6CLePKQ0TZ7efth07b9WL2YX6S/GIXZi9aYfIPb0tVbULdmVaxbNhP58uXFlu0HZJXOTo4YM6wPDu1cjd5d28ntZQYtiEAuJCCGsvTp3gkD+3RV9fCLXLhrqMlEgAjkVALUrkwTUJXDKwaev1mpnH4wukgbhoy29vTZi2j0bk24ODvBo0ghVCxXGhcuXkXyvz/P/YfWzRMmsW7drAFOn/tXFqnAy4upUGw0GtSvWx0xMTHQ9f7KArQgAkSACBABIkAEiAARUC0BVTm8lqL0PCAQxTzc9erFnL7P/AP0aRF58TICjAEFCyTMi1myeBE89w8UWUZh9y/HULaMJ5wcHY3klCACViZA1RMBIkAEiAARIAIpEFClw/vI5wnEyycat+1nNLwhhTZgxfdbMWjUDEXYtus3/SaM987qEoxxz1aXMFiLCd91ScaUaC5fu40tOw5g2tjBumJ48SLcIiE6Okr2JFtKf27TGxHxEpGRERbZV7mNpWgv8TTv9554Ek/xvVJryOrjMzY2Vn+NLVempD6e9giVJAJKAkqvTlkmyyUzF6xC2/eboGL50tj/4zIMG9AN/Xt0SNGOft07YNGsMYrQoc3/5Dbubq4IDg6RcbEIDApG4UJuIqoPYrhDXJwW0TExUhbAy7gXcpVxsRC9vcu/24rl8yeiZHEPIZLB2dkFlgh2dvaws7OziG5L2Kt2nY6OTnBwcCSeZjpeiad5v/fEk3iq+Rya1cenra0tdH+jh/bWRbF20w6Ehb/Qp3WRS9duybn7dWlaEwFTBFTp8EZGRuG9hrUhXl1ZyK0gundujfsPfUzZL2VieIF4FWfy4GCf8Ja2+nVr4NTZi4iKjkZgUAiu37qPOjXflNuKGRhiYhLuJuvVroajx89I+eE//kL9OtVkXMzeMHn2MkwaNRBFiyQNjRCZjDEwZplgaf2MWcZuxtSvlzGykTFiwBgxYIwYMEYMGFMPA3HtMxXEw+diJqXwFy+NsvPny4f1W/YYyShBBJITUKXD6+ycMD6WMQZv3yeIjBKOamhy29Oc9ixZFB1av4f+I6Zj5KT5GDW0F+x576lQMO6LrxESGiaiGPlJd+w/dFJOS/bI20862iJj+97DELNHdBs4Tj/E4skzf5FFgQgQASJABIhAdiaQbWwvUCAf//W3EcZMXQRdR5UwvhS/xj95StdkwYJCygQ0KWdZL6dalQoI5k5ot46t8PHA8WjSrh+aNambKYO6fNACm1d9hU0rZ6NRvbf1uo7sWgPRiywEYr1y4RQ5LdmcqZ/pH0wb0u8jxcwRHoULiU0oEAEiQASIABEgAllEoFO75qhapTyGj/9K/2C56BSztbXJIguomuxKQJUO79D+XVEgX140rl8Tpw5slM7mh22bZVfG2d9uagERIAJEgAgQAZUQEJ1QNapWRI9PJmHp6s3oPmgC3m/6rkqsIzPUSkBVDu+ajduRWlArRLKLCBABIkAEcgcBaqX1CFSu+Lq+8kG9O2PS6IFIeDFUb3zSp4s+jyJEwBQBVTm8OgPvPvDG1l2/4R5fP37ij537j+Hazfu6bFoTASJABIgAESACuYzA3GkjjVoshicO7NUJ79SqaiSnBBEwRUBVDq+4YxMhMCgUOzcsxrwvRuOL8UOwd8s3sLFhpuxXoYxMIgJEgAgQASJABIgAEVATAVU5vDowERGRcC2YX5eEo4M97Azm5dNnUIQIEAEiQATUS4AsIwJmJND24+Emtf15/j85A5PJTBISgUQCqnR45WwJ637C/Ye+eOYfiB93HIB4KUSizbQiAkSACBABIkAEiIAk8Falcrhz30vGaUEEUiJgbYfXpF0zJg5FQFAIho2fjT6fTsHDR48xZexgk2VJSASIABEgAkSACOR8AuIlUO+06KGfD18Xb/7hYIiXSuV8AtTCzBBQpcMrpiSb8vkgHPjpWxkmjR4gpynLTENpWyJABIiAugmQdUSACKRGQPz6e+bQZjlVqal1attSHhFQpcNLu4UIEAEiQASIABEgAoYEDKclM5RTPAcSsECTyOG1AFRSSQSIABEgAkSACJiXQPJpycyrnbTldALk8Ob0PUztIwI5kwC1iggQgVxGID4+HgePnsbkL7+RQcSFLJdhoOZmkAA5vBkER5sRASJABIgAESACWUdg8bc/YN9vxyHG8ubJ44Jtuw5iyarNWWeAamsiw9JCQJUO7+mz/2LgyBlo0Kq30dOYaWkQlSECRIAIEAEiQARyHoFHPn5YuXAKRg3piYkj+2Pd8lk4+/elnNdQapFFCKjS4f1+8y6MGdYbx39Zb/Q0pkUIkFIikAsIUBOJABEgAtmdgJOTg6IJeXlPr0JIAiJggoAqHd4ihd1QoWwp2GhUaR7ojwgQASJABIgAEchaAjY2Nhg7fZEcx/vznkP4ZPQslCvjiQv/XpUhjdZQsVxKQJUepZtrAez65SjCX7zMpbuFmk0EiAARIAJEgAgYEggIDEZY+EvsPfgHfj91HjY2Gjx45IvvN++WwbAsxYlAcgKqdHh37T+KBcs2oFnHQaofwxsTEw1LhLZt22DgwAEW0W0Je9WuE4gHYyxtPC20T9XOKD32EU/zfu/Fk+aM0fGZnmMwtbLE09zHpxYaTdYdn1qtNrmvItOrFk1FakEWogURSIGAKh1eU29QEbIU2kBiIkAEiAARIAJEwAIESCURyCkEVOnw5hS41A4iQASIABEgAkSACBAB6xNQpcP7yOcJRk6ah8Zt+6l+SIMlduGlq7fQZ9hU9BwyCd/9zoJH2gAAEABJREFUsNMSVZhRpzpUXbp2C4NGzcC7LXvh6ImzMPxLiad/QBCGjZuDfsOnYdKspYiIjDTcLFfHfz18Uk4N2LTDQHw+dQEeePnqeRBPPYo0R37ecwgNWvdBozZ9MWz8V7h+655+W+KpR5HuyPmLV+Q1wnBqKuKZboz4afchyfGdFj3ketNP+/VKiKceBUWyOQFVOrwzF6xC2/eboGL50tj/4zIMG9AN/Xt0yOao02a+GHs27asVGDe8D9YvnyUH5v97+UbaNs7FpRwdHDC4dyc0fremEYXUeC5dvQV1a1bFumUzkS9fXmzZfsBo29ycEDOlLJ8/Efu3LkO51z2xav1PEgfxlBjSvWhcvxaO7VmL33asRLNGdfDN6h+lDuIpMWRoER0Tg2/X/YxKFV6X4/OFEqvzFEZk09C/R0f9NKC9PmorW0E8JQZa5BACqnR4IyOj8F7D2hAD18UbVbp3bo37D31yCPLUm3Hr7kM4OzvJk7itjQ2aN6mHU2cvpr4R5cpp7N6uVhkajfEhnRrPP8/9h9bNG0h6rZs1wOlz/8o4LYCanKWDvT2cHB3xbu3qeOofJLEQT4kh3YvChVxhb2cneTo5OSKe/wslxFNQyFjYuHUvunZogTwuzhCOmdBCPAUF8wXiaT6WpMn6BDTWN0FpgbOzoxQyxuDt+wSRUdEIDAqVsmy+eKX5T58HoriHu75cyeJF8PRZgD5NkfQRSInni5cRvFcIKFggn1QoOD/3D5RxWhgT2LrzAOrUqCKFxFNiyNDiux92yZ+LV3y3DbOnjJA6iKfEkO6FuC5cvXEP779X32hb4mmEI12JH3ccQJP2/THui8V4lnguJJ7pQkiFVU5AlQ5vtSoVEBwahm4dW+HjgePRpF0/NGtSV+UozWce0zADZarcRQb2qT+aEk/D3mDGiLOpPbll+6/8uxiOfgZDilgKxyfxNEUwSTagZ0f8sW8dRgz+GFNmL9Nn5F6eegTpjixcvhFjh/c2uR3xNIklVWGzxnVxeOcq/LByDvLmyYMvF67RlyeeehQUyeYEVHmVH9q/Kwrky4vG9Wvi1IGNclzRh22bZXPUaTO/iLsrgoLD9IUDg4IhxlPqBRRJF4GUeLo4OyEuTgsxDlAoDOCc3fnPziJOIYHA+YtX8M+la1gyZxzE8AYhJZ6CQsaDo4M93mtYF1ev35FDtohn+lnGxsVBHJud+46RPeYiPmryApz46x8Qz/TzFFu4FswPW1tblChWBKOG9MCN2/eFmHhKCrTIKQRU6fAKJ2Tdlj2YPvdbyfn+Q18cO3FOxnP6okLZUhCzB4if7OK0Wtnu+nVr5PRmW6x9qfGsV7sajh4/I+s+/MdfqF+nmozTAhCzXqz/cS/mTB0px57qmBBPHYn0ra/euKMfZ3rqzEW8VrIoRI848UwfR1FaPNsg5mXXhdo13sTXs8eiUb235Vj+lM6f9H0X9EwHw7ea/n7yHN4oX0YWpONTYqBFDiGgSod3xvxVePLUH498/CTmYkXdsemnfTKe0xeMMcyYMBRT5yxHn0+n4O3qlVDjrTdyerMz3T4xLZGYUkdMSSbYiem0hFLGUuY58pPu2H/opJyW7JG3H8TDkWIbCsDytdvw35WbcjiR4Nqpz2iJhTHiKUGkc/HX+f9Qv1Vv2SM5d+n3vBetp9TAWJp50vEpiaW+YIx4pk7IdO6XC1fLY/O9Dwbg3D9XMHXMIIg/xoin4EAhZxDQqLEZD718MWn0ADjwn/+EfeJnwJjYWBHNFaFqlQrYsOJLOZ5qYM8Pc0WbM9tIMb2YrsdHrI/uXqtXmRJPMQPIyoVT5LRkc6Z+Jp+g12+UyyNrl0yXQ4kESxF2bFisJ0I89SjSHBnUuzP+PLhJMv112wrUqp7wEKBQQDwFhYyHpV+Nl9ML6jQQTx2JtK/nTh8lj81je76TD1QaDu8inmnnSCWzikDG6lGlw2tra2PUmthc5OwaNZwSRIAIEAEiQASIABEgApkmoEqH963KFfDDz78gPPylfDhhzLRFaNKgdqYbSwqIABHIHQSolUSACBABIkAEDAmo0uEdPbQn3Fzzw87OFl+v3Iz/NayD/t1zx5vWDHcOxYkAESACRIAIEAEikAkCtGkiAVU6vIwxtGraAOuXz8LWtfPQ7v3G8onmRJtpRQSIABEgAkSACBABIkAE0kxAVQ7vmo3bkVpIc6uoIBEgAmknQCWJABEgAkSACORwAqpyeMW8n8f//BsXL980GXL4vqDmEQEiQASIABEgAlYkQFXnXAKqcnhHDOoORwcHODs5oGOb9/DN3AlYtWiqPuTc3UAtIwJEgAgQASJABIgAEbAUAY2lFGdEb7cPW8o5UYcN/Bi37jxA7yGTMGvhGjzw8s2IOtqGCFiAAKkkAkSACBABIkAEshsBVTm8OnhlPEugb/cO6Ny+BU78eQH/Xrmhy6I1ESACRIAIEAEioAYCZAMRyEYEVOXwxsbF4cRf/2DirCXo2n8cvHwe47tvZqJjm6bZCCmZSgSIABEgAkSACBABIqAmAqpyeNt2HYaNW/eiXu1q2LlpMUYN6YVSJYuqiRfZkj4CVJoIEAEiQASIABEgAlYnoCqHNzg0DDdu38ecxd+hcdt+eKdFD6NgdVpkABEgAkSACBCBDBGgjYgAEbAmAVU5vGcObUZqwZqgqG4iQASIABEgAkSACBCB7ElAVQ5v9kRoPqtJExEgAkSACBABIkAEiID5CZDDa36mpJEIEAEiQAQyR4C2JgJEgAiYlQA5vGbFScqIABEgAkSACBABIkAE1EYg+zq8aiNJ9hABIkAEiAARIAJEgAiokgA5vKrcLWQUESACRCDtBKgkESACRIAIpE6AHN7U+VAuESACRIAIEAEiQASIQPYgkKKV5PCmiIYyiAARIAJEgAgQASJABHICAXJ4c8JepDYQASKQdgJUkggQASJABHIdAXJ4c90upwYTASJABIgAESACRADITQzI4c1Ne5vaSgSIABEgAkSACBCBXEiAHN5cuNOpyUQg7QQsU/Lg0dPoP2K6DJ98PgtzFn+HZ/6BsrJ3WvSQa3MsLvx7FUK/OXQJHZev3Ua/4dNENNXg9/Q59h74PdUylEkEiAARIAJZR4Ac3qxjTTURASLACez+9Ri+XfcTJo8ehO+/mYFVi6ai64fv43miw8uLqPZTplQJjB3e55X2PXnqj18On3plOSpABIhANiJApmZrAuTwZuvdR8YTgexHYP2Pe/HZ4O4oU6q43vgyniVQuWJZfXr1hu0YOHIGug+agP+u3NTLz1+8gsGjZ6L30Mlyff3WPX3ezv1HpLzXkMlo0ekTBAaF6PNExD8wGH2HTcUvh06IJERP8rI1WzBo1Ax0GzAWR46fkXKxOPHn3xjw2XT04eU/mzgPD7x8hRj3H/pgwbINMi56j0X+pFlLpS2jJi/Q91Kv+H4bL+sN0bsseq/lBrQgAkSACBABqxEgh9dq6KniHEiAmvQKAi9eRsie3BpvvZFqydKexbF2yXSM/6wf5i79XpYNCArGl4vWYuywPtj47WyMHtoLE2cuRWxcHP48/x82cEd69pQR2LRyNu85/gJ58jiDMSbD7XteGDpmFob064I2LRpJfWLhWbIY1nw9Hd/MnYjFKzZB1OEfEIQv5q+U+jcsn4Vqb1bEzAWrRHFF8PJ+jEF9umD14mlo2fRdrNuyR5b5tH9X7tCXlL3Xk0YPkDJaEAEiQASIgPUIkMNrPfZUMxHIdQTi4+PT1ObG9WvJcm9VLg9fv+fSqb109TYiI6OwcMVG2XP69cofEBIajkc+fjh74TLatWyMEsWKyO1KFPOAvZ0dRH0+vk8gemm/mjoStWu8KfN1i/81rCOj7oVcUbF8GVy5dheXrt2Rvc2VKrwu87p3boVbdx9COOtSYLAoW/o1lCpZVEqKFnGXvboyQQsikOsJEAAioC4C5PCqa3+QNUQgRxPI4+IM4VxevHwDqf0JZ1WXb2trgzjei8sYQ4WypWSvqRj3K8Lx/etQxrOELGprayfXhgvGGIoUdkPZ0iXxy+GEoQyG+Sbj3Cm3tUk6NdrZ2kLD9Zgqa2NQTqPRIDY2zlQxkhEBIkAEiICVCSSd1a1sCFWf+whQi3Mngb4ft8eSlZtx7ORZaLVaCeG+lw+u3bwr4yktqlWpIHtaj504py9y5sIlGa9b6y05Ntfn8VOZjo6JgQgiYcd7er+ePRZ373vrx98KuQjbdv0mVrh15wGuXL+NNyuXRdUq5bkt93CTy0Tm1p0HUZ472i7OTiKZpiCGU4SGhaWpLBUiAkSACBAByxMgh9fyjKkGIkAEDAh0aP0ePh3QFT/8/Cu6DhiLT8fOxk+7D8meX4NiimjBAvkwd/pI7PrlKMTDYu93/gRixgdR8N3a1fBRhxaYNOsb9BwyCc06DEJ4+Es5pEEMa7DlvbTC6X385DlmL14rNpHhZUQEPh40Hl/M+1aOF3YrWACF3ApiyueDpHMsHnI7988VTB0zWJZP66JMqZKoVqUiRk+ZL6dcS+t2VC7XEqCGEwEiYGEC5PBaGDCpJwJEQEmgZdP62LB8Fn5etwgrFkzGxJH9UbiQqyx45tBmudYt/tj7PRzs7WVSPOwmyottf9u+CvO/GC3lYtHlgxbygbUfVs7BiV/Ww7VgftSqXkUOgRD5Oqd38uiBIinDiEHd8eOaedj63QI0a/yOlIlFo3drQkyZtp7buPSr8SjtWVyIIcYUr1s2U8YNdQtB5YqvQ5dno9Fg4qgBWPzlONBDa4IOBSJABIiAdQmQw2td/mmvnUoSASJABIgAESACRIAIZIgAObwZwkYbEQEikN0JJO9Jzu7tyU32U1uJABEgAuklQA5veolReSJABIgAESACRIAIEIFsRSCHOrzZah+QsUSACBABIkAEiAARIAIWJEAOrwXhkmoiQASIgNUJkAFEgAgQASIAcnjpICACRIAIEAEiQASIABHI0QSEw5ujG0iNIwJEgAgQASJABIgAEcjdBMjhzd37n1pPBIiAEQFKEAEiQASIQE4kQA5vTtyr1CYiQASIABEgAkSACGSGQA7blhzeHLZDqTlEgAgQASJABIgAESACxgTI4TXmQSkiQATSToBKEgEiQASIABHIFgTI4c0Wu4mMJAJEgAgQASJABNRLgCxTOwFyeNW+h8g+IkAEiAARIAJEgAgQgUwRIIc3U/hoYyKQdgJUkggQASJABIgAEbAOAXJ4rcOdaiUCRIAIEAEikFsJULuJQJYTIIc3y5FThUSACBABIkAEiAARIAJZSYAc3qykTXWlnQCVJAJEgAgQASJABIiAmQiQw2smkKSGCBABIkAEiIAlCJBOIkAEMk+AHN7MMyQNRIAIEAEiQASIABEgAiomQA6vindO2k2jkkSACBABIkAEiAARIAIpESCHNyUyJCcCRIAIEIHsR4AsJgJEgAiYIEAOrwkoJCICRIAIEAEiQASIABHIOU+mUtIAAAFRSURBVARyo8Obc/YetYQIEAEiQASIABEgAkTglQTI4X0lIipABIgAEcipBKhdRIAIEIHcQYAc3tyxn6mVRIAIEAEiQASIABHItQRe6fDmWjLUcCJABIgAESACRIAIEIEcQYAc3hyxG6kRRIAIZAEBqoIIEAEiQASyKQFyeLPpjiOziQARIAJEgAgQASJgHQLZr1ZyeLPfPiOLiQARIAJEgAgQASJABNJBgBzedMCiokSACKSdAJUkAkSACBABIqAWAuTwqmVPkB1EgAgQASJABIhATiRAbVIBAXJ4VbATyAQiQASIABEgAkSACBAByxEgh9dybEkzEUg7ASpJBIgAESACRIAIWIwAObwWQ0uKiQARIAJEgAgQgfQSoPJEwBIEyOG1BFXSSQSIABEgAkSACBABIqAaAuTwqmZXkCFpJ0AliQARIAJEgAgQASKQdgL/BwAA///7iXOjAAAABklEQVQDAKvaxMMB7cTMAAAAAElFTkSuQmCC"
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AeydBWAURxfH/3tRgkNwd3enUPgKLbS0FNpSHIq7leLu7u7u7lLcKe7ubjEgLt+8CXecJbkkd8kmeZe83fF581t7Ozs7q/H39wthYQa8D/A+wPsA7wO8D/A+wPsA7wPxdR/QgH9MgAkwASYAgCEwASbABJhAfCXABm983bLcLibABJgAE2ACTIAJRIVAPMzDBm883KjcJCbABJgAE2ACTIAJMIGvBNjg/cqCXUyACVhOgFMyASbABJgAE4gzBNjgjTObihVlAkyACTABJsAE1EeANYoLBNjgjQtbiXVkAkyACTABJsAEmAATiDIBNnijjI4zMgHLCXBKJsAEmAATYAJMIPYIsMEbe+y5ZibABJgAE2ACCY0At5cJxAoBNnhjBTtXygSYABNgAkyACTABJhBTBNjgjSnSXI/lBDglE2ACTIAJMAEmwASsSIANXivC5KKYABNgAkyACViTAJfFBJiAdQiwwWsdjlwKE2ACTIAJMAEmwASYgEoJsMGr0g1juVqckgkwASbABJgAE2ACTCA8AmzwhkeH45gAE2ACTCDuEGBNmQATYAJhEGCDNwwwHMwEmAATYAJMgAkwASYQPwgkNIM3fmw1bgUTYAJMgAkwASbABJiAxQTY4LUYFSdkAkyACcQnAtwWJsAEmEDCIcAGb8LZ1txSJsAEmAATYAJMgAkkSALhGrwJkgg3mgkwASbABJgAE2ACTCBeEWCDN15tTm4ME2ACNiLAxTIBJsAEmEAcJsAGbxzeeKw6E2ACTIAJMAEmwARilkDcrI0N3ri53VhrJsAEmAATYAJMgAkwAQsJsMFrIShOxgSYgOUEOCUTYAJMgAkwATURYINXTVuDdWECTIAJMAEmwATiEwFui0oIsMGrkg3BajABJsAEmAATYAJMgAnYhgAbvLbhyqUyAcsJcEomwASYABNgAkzApgTY4LUpXi6cCTABJsAEmAATsJQAp2MCtiLABq+tyHK5TIAJMAEmwASYABNgAqogwAavKjYDK2E5AU7JBJgAE2ACTIAJMIHIEWCDN3K8ODUTYAJMgAkwAXUQYC2YABOwmAAbvBaj4oRMgAkwASbABJgAE2ACcZEAG7xxcatZrjOnZAJMgAkwASbABJhAgifABm+C3wUYABNgAkwgIRDgNjIBJpCQCbDBm5C3PredCTABJsAEmAATYAIJgAAbvHobmZ1MgAkwASbABJgAE2AC8Y8AG7zxb5tyi5gAE2AC0SXA+ZkAE2AC8YoAG7zxanNyY5gAE2ACTIAJMAEmwASMCUTd4DUuif1MgAkwASbABJgAE2ACsU7g5u37mD53GYKDg2NdF60CHz99xoRpC/D67TttUIyu2eC1Ie5JMxbhx99a2LCGyBddrOJPWL95V+Qz2iDHirVbUO5/dSJVcu5iVbFt14FI5dFP/EeTjhgxbrp+kNXdMVHH1Ru3kSJzMbz/4G51/S0pcPDIyeg/bIIlSa2SZu6i1ahSs0G0y+rQfRC69x0R7XKMC0io/oePn6Jx6+7IWaQKshb4RhUY9M8RsX2cxAQQ1+ylcODIyZioymp1xMS1MSbqICDN2/VE3yHjyGlVie6+mz9vTpy/eBWjJsw0q9es+StQ+Yc/5XVk5rzlGDNpNuo0bGc2bVQDr928I8v/4OYhi0iaJDFI6DwcEBAgw2JywQZvTNLmupiAlQgkdkmEqpXLw8HB3uISL125IU8+Hp5eFucxl/DBoydYsnIjenRqZS46wYft3ndEXjiy5K8obujqYsioKfj02dssl9kLVspt0rJjH7Pxag+cu2gVvL19cf7YNjy9pT6jKyrHidqZs37qIpA/by7kyJYlUkrRzeGuvYfDzRPdfVej0WD+9NE4eeYi9v57zKCut+8+YMDwiejToz3cnl5C53bNkDlTBhQqkMcgXRQ94WZr36oRCubPjaFjpoWbzhaRbPDagiqXyQRsTCBXjmzYumYekidLauOaTItft2knfvyhKtK4pjKNTOAhR46fQaNW3VC5YlmcP74dIwb9jb0HjqKHmV5l6sFZsHStvHFRFCVOknvx6g2KFMyLVClTqFL/2DxOVAmElbI6gX49O6Jdy0ZWL9ca+66zsxP2blmKmt9/a6Dfi5evpb9K5XIgw5g8TRvUxajB/5DT5kL1kNi8IqMKwjR4qUdi5PgZ+KFOM1BPRdWfGmLz9r0G2WlsCD1q/O7nxsiUtwK+/7UZ5i9Zo0vjKh61LFu9Cb816oDshSpj3JR5Mm7Nxu2g8ihP1R8bYsmKDTJcu6AxHlRvulxlQI9tW3TorY3C9t0HZHnZClaScVTOS3HS1SUwcpAO9Oi8XtOO8pFbpe/rgS7Y2mTU20V1UO+XNozWBcv8oHv0f/q/i7Kufw+fkHrnKloFHXsMxrv3brh87Saatvlbto8e7Wl3JCpDK/TooFTlX2Qa6sl58+69Nkqu9x86jpp1/wK1qfS3tTF28lwEBQXJOFpQG8xxjCjf4yfPUb95Z9nucv+ri7WbdlBx4Yr2MdCchatAuhQp/6N81EH6bNmxH7X+aIU8xf+HPoPHwt//6yMJalPbrv1RoPT3Mp622fMXrwzqoscmVCbtC2QUeHp+NIgnT0RtojQRycGjp/DLn62/tLuOfPTu7e2jyxYUFIwe/UZKXal9w8dOR2BgoC7e3cMT/wwYg5KVfpb7Pu2/12/d1cWTI6I6KI1Wjp38T2577fGjZdx70Bjo7xf6wxOILR1/ZarUljr8XK81Tp29oC0SZCzRfqvNo91HDx07hf/VaiTzEIMLl67JPE+evpDh5CH+lJe2F/nDO94o3lhoSMn3/6tkEEz7x4y5y0HHFx3XpAMdq9pE1Ob8JatDjt36EvhX+17yeKK2UtBD8Xi8ebt/QMcepe3092DcuvOAokyEyqf9ST+C2qM/XIHOYeTPW+I70HY2NwQjom0ty+gzAhWr/y7PAdS26XOX6Vdr4D5z7hJy5ciKnl1aIV0aV/zwXWU0rPcrjp86Z5COxrK16tgbMyYOReLEiRASEmIQb+zRbt+9B45JZulzl5VlErvw9hMaUjV19hJdcXTeom2v3Q6+vn5Ik6M0qHxKRNuM9nc6F1G68M6v+UpUA/VSEQ9KS6ypHHJHVk9tvqieY0l3cxLZ40RbRkTnIWof7W+0rxIHcmuPRSpD2x5KRwy124viwhPa32h7nLtwRZesUNkacv/TBhw9cVZeb/XPWW/evkdY1zjKR+cBelxN25XOawNHTIKPjy9FSYlou9+++xBN2vQAHZd0/u/QfRDo2ikzh7Gw5HheuGwt6ByXs0gVtO7c1+D8ECSugTPCOadQtZbUQelI6HpE15+/+42Sx5t2Gy1avg5kh2TOVwE//d4SxrZARPaK8ZAGV2H3hGdz0Dnf6+MnORSIjhXah0g/YzHed2nf6B6Jc5FxeVo/MafzJ/nJtiMdtEL7CIWT/NGkIwaNnBTutZL2b9r3qQ3mjgMqJzqyYOkakB50zaJtR8Mz9Pd77TYM67qnrZuuFZQ/TIPX398fTk7OmDJmEK6c3o1ObZoKw2GiwVihcVPmYtqcJeja/i/cuvAvxg/vAx9xAtVWQutxwsht0fQP3L5wAB1aN5YGKx0sDf/4BTfO7UOr5n9KoCvXbaXkIMWpkSMG/o1H147h2L51KFuqmIyTF4lOfdHgj5+lTpdP7sJfjX6HoigyPqzFgiVr0b51E5mn0Z+/on33gSBjMKz0YYVPnbUEDX7/BcOFbmfPX0KnvwdhwLBJqFShtAjrgWs37mLk+FkG2enx76WrN0C9cTs3LsLrN+/Qtkt/XRo6eXX9Zxj+avI7LhzfgTlTRuC/81cwzKi735hjRPnoZFH/ry5wF4+vj+1dh6VzJ4JuTjw8In6cTTr/e+gEenVri78a/4GZ81ZIZuuEwdy6eX20bt4AS1dtwrrNO2U76GJdv1kX3BbGyeZVc/HvthWgm5DfGreHdpwOGdt0ku3WsQUundyJCmVKYYaR4RBRm2RlESyoDDpAvv+uMs4f247Vi6chdapUCNAzaNeKHsrAgECMH9EX9er8KAf2b9r29WauaZue+PjpExbMGIPLp3bj5x//J26y2kN7M2NJHfjy27HnoLwhWjxnHH6rXfNLKHBeGKIf3Dx1+wXxaikMIG2CIaOnYMHSdRgndKTjjx6b/dqgHe49eKJNYna9fPUWTBrVH/8d2YosmTKK7TZAntyzZc2Ew7tWyzyPbxyHx/MroMdd4R1vMrHRggylO/ceomjhAgYx46fOw/Y9BzBsYA/cPL8ffbq3x9DRU0EnREr4d+eWyJ8vl9z3aX9ZumqjiDuKedNGw9HRAfSI7Qdxw5zYxQWbVs7BqYMb8Y04rrw+fqTsUZIBwyZih7hBXjp3Ag7uWIk3bz/gkLgZ0i8som09bfZiPH76HAtnjsOLu6exZsk0ZMqQVr8IA3fxIoXw4NFTnDxzXoZ//PQZe/YfQY1qhj0sXf4ZKnpdqshzh0xo4WLSjIWYOLIfnt8+hRLFCiGi/aRiuRI4I27YtcWfEHpRz/ypM6E3T2fPX4aT4F+mZFGxz39Gq0icX+9cOoia1b9Ftw5/yf1p6thB2moQWT21GaNyjtXmjcw6rOOEyqDjO6JzsoenJ+rU+gEn9q/HuuUzBENHNGvbUx5rVIZWjDlow8NaJ0nsgtIliuDk2YsyyaMnz+Dl9RF37z/WGYOn/7uECmVLwN7eXqahBe2nxYoUwOzJI5A3T05x3A+E9hr34uVr1K7fFunTppHXmJmThmHNhu3ipn40ZY1wu9Ox+Wv9NihWuCB2bFiE/duWI3nyJPhTdKZQp5csxGhBeSI6nh+K42SneKzfvVMr9O7eDifFPjl20lxdSRGdUyypQ1vYnXuP8KMwZv8Q5/vJYwYY2AyrN+wAhV0S9gSdZ+s2aq8z5ulGoIMw7sOyV7TlG6/DsznoOp8saRKsWjgVdB6+eW6/cXazftrGkTkXmS1EBNL1+1+xDYUTz++cljqQHn16mI7fXbVuO+jccPLfDZLRYtE5uUnvWmnpcUB1RUW8PnqjZ9fWuHpmD8aP7Cv2kYuyA864rPCOZ33bQ2OcUeunR1S9urWRYzrIXa/uT9L4Wbtxh0xCVjb1HPT/pyPq/Pw9aAPSCZhOfjLBl0Wjer/glx+rwVl0rVOaBUvX4qcaVUGPAFIkT4amohv9z99qYf7i0J7hV6/fycdjZOS6uCRC0UL5paFMxX344C4NKDIwKW/2bJnxV5M/kCF9WooOU1o2q4dqVSoiZYrk6NimCdK6psbFK9fDTB9WxJC+XUHjTxoLo7lL++bYL4zC0UP/kW1p1vA3tGvREBcuXzXITndyk0YPQJbMGVG4QF7xyKAn6IR6SxiHlHDKrMVoI/KRIe2aOiXKCOO+/z8dQDsWxWvFmGNE+Q4fP4M7wjCZNm4IiFMBYWzQTYSnOHlqywxrHRgYJC/s9X//WfZU1ar5Pxw7h0r+iwAAEABJREFU8R9WLJiMur/8ADowvv+uEi5cCmVI7aGe7ukTh6CAqIfqmz5hqDxJ795/VFazbNVmafDR9qbt0KV9MxTIn1vGaRcRtUmbLrw1ldHwj9riJqw50qZJLXrbssk26D/6L1oon+xZo/1ysNim1atWxH8XQrcb9cbSHf4scVEoJS48qVOlQMumf6Jk8ULYtH2frDqiOuj+S1EUUM9At97DsW7ZDHz3bUWZV7uws9PIE4h2vxgztBeobtovqOdl4bL1+KdrW5mPjr+xw3ohozC0Fi1fqy3C7Lr/P52EroXlMUGM7z14Aup9N5tYBIZ3vIlok/9Hj5/JMOIiHWLh5+cPOheMEMYuHWfEuqZ4hNZc3CwtW71RpIC8wNDN3K079+UN7gBxozi4T1fky5MD9KMxwZRv+oTBch+iNjeqVxvlShen6EgL9YYsX7MZ/Xp2QMVypeS+MHXcIHz29taVRbwj2tbEJ0f2LHLMWWJhjH/7TVn8/uuPujKMHdTuEQN74rfGHWSPMPWgJErkjAkj++mSUu/P3fsPMah3V12YpY6+f7dHaWGckrFjp9Egov2kgmj7UfGEIVDc8JHx9O79B3Ee/108LbgkqzwtjOHyZUKNp6ieX2VBRovI6qnNHpVzrDZvZNbhHSd0fEd0TqbzNV3HaD8tXqSgPJbp5oF6QvX10OdAxqx+XFhuukk5/eVpDhmBFcuVFPtwSZw8fV5mOSXiaLtKz5dFA3HOG9i7i7g5/07cyI6S1+MLl6/JWDoOqO4pYweCrjEVxT4xqE8XrFq/TT6ljGi707WoaOF8IHsgT65soPGqY4b2xo2b90DHj6zEaGHJ8UydEGtEhwRdT+m6SjYBMaSi/Cw4p1hSh6IouHL9Fn6u11LcmDVH3787UPEGQueIksULyyFaY4f1lu9FaJ/GLYjAXjEoSM9jLZtDr0hE9lyknzeq7ur/+waNxHmY9nN6qlet6jc4dzF0v6IyLT0OKG1UpKd4UlahbEm5P9M1lGyPVeu3mxQV3vGsb3toTHLqBdAFmx5h0wBr6vIeO3kOnj0PfUx9/+FT0E5ZtlRxvRymzuKix0M/9N6Dx6guoOmHkf/W3Qfy7pig0kn5fz81Er2lM+RjeDIaKT0ZUt+ULy2HTtDjSeoJpke1FBeeZMyQziA6XVpXeaAbBFrgKag3oDtblkwyR6H8eeSaFhRGvUjk1kruHNlAF3Ktv4gwthRFgdZwIKOUZg0gvlqpXrsp6IL96vVbbTYYc4wo32PRM0DGFBmg2kIqVywDuvhq/WGtc+XMBicnR110dtE7mFcYJg4ODrqwrMKAf+/mJv30WCl9ujRCx4LST4t8Ij0J9RaTn+7mq1QqS06d0EtXOo9wRNQmkSTCfyqjbKmi4aYrkC+3QTz1fr7/ENqWBw+fSKPIVTyW0m4PWtOgf22PSUR10NNp6hno2ms4tq6dBzIoDCoUnvD2i8dPX8gbOzrZACKx+CcD53/fVgBxFN4w/zNn/LqvpxE3dpSQht7Q2pyEd7yZS0/HPIXTDSytSR49eS7PBTQsh1hphV7WevT4OSWRQjemdEFZunKjMNqK6G5kKfL+w8coJW4wqJ3kj648ffZSnk+qVKqgK4reDqabZW2AJdu6bu0aWL56sxwaREM/9ogbOOqh1pZhvL589SamzVmMenV+wsoFUzBIGPV0zhswfJJMSvsQPb2hHmPq2ZaBkViUFL262uSW7Ce07wWKG9gLl6+L3pELqCIM9koVyuDE6dAhFqfOXoTWeIrq+VWrj/46snpq80blHKvNG5l1eMcJHd8RnZOfPX+J7uLxMj0mpf09TY7SchjasxcvDdTQ52AQEY6HtsexU+fkMKvTX7YPGaknz1yEr3iCelr08JJRrF9Ewfxfr0N0DMnzs+ggojT0xKHyN4bnfjruKY7O3RFtdzqH/3v4pLyBo7aSpMxSXJ4n6dincozFkuOZrjP616PsWTOL6/IHWRSVS+ea8M4pltTxWDyd+aVeawwQHQHUsykLN1oUFZ1q2iA6JguJjqmHX27s6ditHo69os1nvLaWzaFfbmTPRfp5o+rOZGQ7pXFNqdtGVKalxwGljYrQELFGrbohf6nqcv/7tUFb+ZRcf4gilRve8UzXTK3tEabBS+Nc6TH64L5d5ONR6vKmO0h/o6kkFEWh+sIU50ROJnF2dnYGYfb2dvLipCiK7Ik5vm89Gv1ZWxxQPqL7eg6q/thAPvKkTJtWzhYXkc5wdnISPWg7Ue67uuLkHXrnS/HmRCN6QozDySihMEUxr3+QuEhQvL7Y6+mtKKH56OSiTaMoimyH1h/WmvJoL5qKomDS6P4gvsZCBoK2DGOOihJxPn19teXYaTRaZ5hr43yKosB4mymKYVv1jWF8+RnnMfabq8cSFl+KD3sVumnCjKf9TT9SUShD6BhKRQndB423BfnpsZcuH2XReQwdogjxWLIYsmXJiJVrtxhGhuPT3y8oGflprRV7u6+PMLVhxmvz+3po24zTkp96wcM73iiNvqQWTyHI7+bmQSspihIK4/TBTSb78ZlDm2Ua7eLfQyfl3To9CtUeA9q4yKwVJbRO/Txk2On7yW1vb7i/24lzDYWTKErE25p6rA/tWiWNQrrAtuvWX76URvnNyZRZi1CuTHHQY+Off/xOPl2YJJ7w0M05DQe5ceuenEpOOyaYjAcaB0s9SuSO6AY+kbOzSbXh7SfUs0ePJMmwPSUMpvKit4SMYDKCqC4ynr4pX1JXZlTOr7rMeo7I6qnNqn9OUJTQbazfPkUxPO9o80V2Hd5xoijhn1tpv/2tcXvRI5gSqxZNw5sH50BvutM5MMA/0EAVcxwMEpjx0Pahffni5Rs4cuIsKpUvJXt4T4veeOoBdRQdD7RN9bPa6+3XFK4oxIlcoWJ87tU/DihFeNtdURT5VIPOgcbyR52wn3ZQueGJ/ramdIpCOoeeqxQldNubnFOeX4HxOYXyhiVkeFYU+/e6zbtkJ1JY6YzDaRtrw4zZEWuKV5RQHbXp9Nfm9y/9FJF3R/ZcFPkaTHNoNObaGLqNiIGlx4FpyRGH0I1WvaadUP+3X7BvyzJ8eHIRuzctlhmN7VDzvEP1pAzabWh4NaCYL3Lm/GV8Ix590CNF6r2j4Gs3btNKSu6cWWUv4H8XLku/pYs8ubLj6vU7BslpjGtBvV432knbisf8Y8Rjk9MHNuGp6FU+/6UbnXqWqBt9sHgUfWjnKpQqXkSOBTQoMBIeGmZBd5kf3L9ewOnCFN5j4EgUj/uPnkB/GMG1G3dk710O8ZiUyqF2Hzp2mpyRkojyZc+WRXB7Ke7G3HTl3rn3KFIHvS5jBI6c2bOCXgjQ75F+L3oXHjx6KocUUPacObLi+k3D7X5Vb3+iNBG1idJEJPny5MS5L8MTIkprLj5f3pzy5iqsR3WUx5I6MmZIg21r58thL/RyGuXTl/vh7BfUo04H6NXrN/WzgIbhEEeDwEh4nMRNIiUnY5PWWgnveNOm0a4L5M0FerR/RzyS14blypFFPjk4eOSUNsjseuvOf0FjmvdtXSYYv8f4qfN16XLnzI6LohcyUDx61wWG40jrmgruHh4GKWi4hDYgq7jZUBTF4FxD49ovXfnK1JJtTeUVK1wA3Tu2wLxpo7B03gRQL6/+MU1ptBIYFAQ7jeENvebLRSM4KFgawzvWL4S+UO8dPe2gMHr6pC0rorWl+0nFciVwWjwGP3ryLCpXKC3P298II2rK7MUg44nGjGrrsvb5lcq1VE9KqwaJ6DxE57l7D56ITplfQU+xnMTTsBu378nzujX0196krN64HZ8+fQY9+aDr8H3x9IleGKXtqX8TEFGd9BLl1etfr92U/tLl0OMgpzh3kz+87Z4vTy7xdOC8wUtulCc8iezxbFyWJecUS+qg/Xv5vMlwSeQMMp7oyalxXfrXIX//ANy4dRc5smWWySyxV2TCSC7oRig4JDiSuYDInIsiXXgkM9j6OLgobvhcU6fCr7Wqg57C2okOR7KfIqkmcurZHmEavEUK5gU9BnMThmCA6NWdPHORuHgf19VFBxxdBEZNmAW6kNGwAzISps1ZqktjztHmrwagccD08QN6y3PLjn3ikeEWtG3ZUCanA5rGuGl3zGMnz8lHOzmyZwZd0CbNWCSNK0pMjwcfiJOAdueksMiKoiioKHo9VqzZLHtn6aI4cdpC0N16ZMsyl15RFNBbodT1T2/69xs6ATQOsOCX8as0IJt6eGjSZ2oPGSM0JpZ6182Vpw2LKF/VSuVANyXd+gwDbUPaOfsMHisvdtoyrLWm9hQrUgDdeg8DGdXUjr/7jZQ9nD9+X0VW07zxb1i1bpt8qxviR8Nl9h/8uj+JIETUJkoTgaBHp5ZYvWE7ps8lo+oD6C6R9pmwDBTj8mi8EN1Jd+o5GIeOnQI9QqQboJnzloMer1B6S+vIlDE9tq2Zj137jsDY6FWUsPcLugFr26KBfLpx8sx5uf3IOKSDnY4f0iEqkiVzBrn9r9+8q8se3vGmS6TnoOP+++8qCeP0hi6Uwmi8MZ0jiD3tbzQOeePWPVi5LvRlVHpZk/aJEYN6gIaU0Mtqk2YslBdSKqhFkz9A54OuvYaL4/yBbDOVRT1aFG8spUsWk+cddw9PGUVPpOjxpfSIBRkNNK5+9MRZsjzajoNGThZGcmh6kQSWbOtZ81dgn9hP6bxAQmPZ06dLI3upqQxjqVm9itjeh+U4fYqj/W7KzMWgXju6saAxlDS0SF9Spkwm31ugMDI8KJ8lYul+Qr26NI7382dvFC8aOuyI2k4vLlXQe/nJFudXaoelelJaNUhE5yG6KaFj++CRk1Ldm7fvy+ENdEGWAeEs6DpJ5/ZbX97hCCtphbLF5YtllSqWluPfyaimm5RV67eifNlSYWUzG07vTdAQH5qNhjoi6KXoEeOng8bOphE3jrfu3MekcK6rLZv+Ictt07UfyDikaxTlofJo/5aRRovIHs9G2WHJOcXSOmiYwqpFU8U13d6s0Tt+6jxxPrsOGvrVd8h4ceMSiD/q/CRVovNtePaKTBSFBQ3nuCGe9kQma2TPRZEpOyppo3McWFIfDS15+foN6OMVlJ7sJLqukzsy0rzxbzrbI0yDl97Or1WjKqr93ARlq9YVvXN3hTHRCvq/3t3bydkbJk6bL6eiorGnbyL4ZFztn6qDBs/PXrgShcrUwLTZS+UMB03q15FFJ0niAtqwNEUIPeJr330AJozsKy+SLokSiQvJGRQuV1OO5yj1bW3UqP4tSFeZOYqLscP7ws/fH5nzVZRjRejEQieCKBZnkK14kYIoLG4eyn/3O2r93hJ0sVwwc4wuTQVhbO8QPT700tR3PzdGgVLfi5PPQvj7++nSmHNElI9OGGuXzkCAuGOt8mNDVPuliTiIf5T1mysvOmH0OGHtkulIkiQJ6jRsi+9/bSpP0htXzJFv4FPZ1Cvfp0d7+VZ58W9qYSO+JDcAABAASURBVP3m3ejR2XB/iqhNVE5EUkUY+uuXzxS9cEdA4+tKVa4t9xkHvTeaIypj2fxJoOmk+g+diFxFq6Jhi244dvKsaF9imTWiOmi4DD3uocR0Z7p93Xxs333QwOiNaL8Y1r8H6GXQ7n2Go1iFn0T9/4ke43m6HnMqO7JCY1jJWK9dvw3o2KLpZMI73sIqv2XTeqAbVf14moWBhj/RCy5Fyv2IyjX+lMYuTZ5OLNp3Hwi6KWrZ9E+ZjQyvf7q2QduuA6QRSkMrdm5YjI+fPqFuo3byy11TZi6Ei0simd540U7cIFf+pizKVq0Dmr6QXgL7ueZ3BslGDflHGrV1G7ZD+Wq/yTGWdP7RTxTRtg4KDkZncfOTOltJkOzad0jO3qEo5h71Qb6ES7MojBKGNp3Dqv/SGNSTvGjWWP1qrea2ZD8hYzs4OATfVCgFrVFWsVxJOe6axotqlbHV+ZXKt0RPSqcGqRDBOZkYrlo4RX7xsUK139GgRVf0FtdC2tcj0t/T00vcyM6OcCw+bRcaw1qhTEldkaQXhVUUPfa6wHAdoZGZM2XAzg0L5cwwJSv9jPbimlqtakVMHNVfJohou6dMkVw+UqZ0Tb9Mwfl3v1GiM+EpwjqvRvZ4looYLcI7p1BSS+qgcw+ldXZ2Al2jyE09vfpjQP/u1BqNW/cQdkUN3L77AFtWzwW9FE9p6XwRnr1CaaIiXdo1F3bOcnkepim9LCkjsuciS8qMTproHAeW1Fswf27MmjQcHbsPAk2rOklcD4YP6G5JVoM0+raHxiBGz0NGDL1wcenkTjmN1OLZ48RB3RaHv0xtREmpwfSFjhP/bgCNY6IxFqOH9KIoKe8fXzB5QY0iaFaGI7vXyGl+juxZg+aNfqdgKdS7RmN0tGOFHt84jjZ/NZRxocbDAt04Qapv2vjBupO4TGS0MKfDsX3r5GwL2qT05unaJTOkPvcuH5YzEdBUIaQnpaETDelDBw35SegRJIWRWys0m4H+14boDcM9m5eIG4WWsuwnN0+Apkii+Tm1eWhduWIZeZA9vHYUNNXP9nULQOwpjsRcGyg8onw5smXBhhWzce3MHlB76Kbiyqnd0LaLyjAWrc764f16dsTWNfP0g0CTRtO0KtpAMuRpH7l1/l8Qw2XzJoIeK2vjaU37Ck0VdvnkLtlemtHj7OHQHkCKJ4moTfevHJGPOChtWEIvZBB32ha0jYin1nDaKMeAdzXIOnZYHyybF/pSEUVQ7+DQ/t3lWLEXd0/LfX798lmgWTYoniQydeTKkU1Oyzd+xNc39amMHqI3mso3t19QrwSNmT93dDue3T4lL1gVy33t2aEXLaht1GNIZZnbRymO0lBaSkPS9+8OuuOHpiUL73ij9OaEevTpgrBb9Fxr4xVFAd14Hti+Qu7rtJ1pn6n7Sw1580NuupBo09Oa3ri98d8+OXsK+fPnzQmaCYSmMCS9qe1FCuajKHm8Ht27VrppQcY7TYNF+xqde+h4oWnkKIziSWg70swMty8eAO1z48SNLQ1LME4T3rbu2r653J9JHxLSifZRKj8saSFuCPZvXS6n/KH0VB/1CIaVno4jOnbCiqdwc9uXwiPaTygNcXj36DyoHvKTUBuoPXS8k58kKufXteKmetiAHpRdSlT1NJfPknOsrNRooX+OoH2f2knHAiUzVw/FURpKS2lIiA/tr2Gdk+mGjToqaIzp1dO7UaNaZdD5hq4BlN9cPRR+Q/QG0/Rg31WpQN4wpXrVb+RxSudMbSI6XkhPKlsbRmtz1wfjaxzNoETnQdLx4omdoJlEqOed8luy3SkNnS/o+kFl0Pl1mTjHa8+rVI6xhHc8035HZejnoUfXD66GzupD4YoS9jmF4kkiUwfpSnWSkJvyk1StXA503aLzCI0RJVYUrhW6XoZlr1CaZeLaQdcQcpNYsj1+/KGKPK/T9qRrM+UzFtofKZ72T4qLyrmI8pkTmg2KyqZzgzbe+DpvybUyouOAzt9Uj/6sPtr6LFn/UedHHN+/HmcPbwENYaUZcqg8uv5QfjoWyK9vmxEvCiN+lIaEjiO6JoVp8FIilvhNgFvHBKJKgOZE9PbxiWp2zscEEiQBGkvdoU0TOeY9QQLgRjOBWCTABm8swueqmUBcJUB3z3T3HVf1Z72ZgBGBGPFSb3i3Dn/FSF1cCRNgAoYE2OA15ME+JmBzAuYe59m8Uq6ACTABJsAEdATMPQ7XRbIjXhJgg9fSzcrpmAATYAJMgAkwASbABOIkATZ44+RmY6WZABNgArFHgGtmAkyACcQ1AmzwxrUtxvoyASbABJgAE2ACTIAJRIqAjQzeSOnAiZkAE2ACTIAJMAEmwASYgM0IsMFrM7RcMBNgAkwAAENgAkyACTCBWCfABm+sbwJWgAkwASbABJgAE2AC8Z9AbLaQDd7YpM91MwEmwASYABNgAkyACdicABu8NkfMFTABJmA5AU7JBJgAE2ACTMD6BNjgtT5TLpEJMAEmwASYABNgAtEjwLmtSoANXqvi5MKYABNgAkyACTABJsAE1EaADV61bRHWhwlYToBTMgEmwASYABNgAhYQYIPXAkichAkwASbABJgAE1AzAdaNCYRPgA3e8PlwLBNgAkyACTABJsAEmEAcJ8AGbxzfgKy+5QQ4JRNgAkyACTABJpAwCbDBmzC3O7eaCTABJsAEEi4BbjkTSHAE2OBNcJucG8wEmAATYAJMgAkwgYRFgA3ehLW9LW8tp2QCTIAJMAEmwASYQDwhwAZvPNmQ3AwmwASYABOwDQEulQkwgbhPgA3euL8NuQVMgAkwASbABJgAE2AC4RBggzccOJZHcUomwASYABNgAkyACTABtRJgg1etW4b1YgJMgAnERQKsMxNgAkxAhQTY4FXhRmGVmAATYAJMgAkwASbABKxHIDYM3gi1P3HmEtp0H4bKPzVHhRpNdBJhRk7ABJgAE2ACTIAJMAEmwASMCKjS4F20cjP+6dwcR3Yuwel9K3VipDt7mQATYAJxnACrzwSYABNgAjFBQJUGb7q0qZEvd3bYaVSpHvjHBJgAE2ACTIAJMAEmYEUCNi5KlRZl6lQpsHnnAXz67G3j5nPxTIAJMAEmwASYABNgAvGdgCoN3s07DmDCjKX4/re2uvG7NJY3vm8Mbh8TYALhEuBIJsAEmAATYAJRIqBKg1d/3K6+O0ot5ExMgAkwASbABJgAE4hXBLgxkSWgSoM3JCQEt+89wsbt+6Xcuf8YFBbZxnF6JsAEmAATYAJMgAkwASagSoN33PQl6PjPKFy6eltKh54jMXHmMt5aTIAJRIIAJ2UCTIAJMAEmwARCCajS4D1/6TrWL5mIUQO7Slm/eALOnL8aqjEvmQATYAJMgAkwASZgOQFOyQSgSoPX0dEBrqlS6DaPa+qUcHCw0/nZwQSYABNgAkyACTABJsAELCWgSoM3dcoUmL1oLc6Jnl6SGfNXIV0aV0vbxOmYQOQJcA4mwASYABNgAkwg3hJQpcE7rG9HvHfzwJCxs6V4eH7CkN7t4+1G4IYxASbABJgAE1ALAdaDCcRHAqo0eFOlTI7Bvdpj97rZUgb1agcKi48bgNvEBJgAE2ACTIAJMAEmYFsCqjJ4afgCfV2N1ubEtii4dMsJcEomwASYABNgAkyACcQdAqoyeBet3II37z6A1uYk7mBlTZkAE2ACTCBBEOBGMgEmECcIqMrgnTtpEHJlzwJam5M4QZSVZAJMgAkwASbABJgAE1AVAVUZvFoy7XuO0Dp16ybt+unccczB6jIBJsAEmAATYAJMgAnEIgFVGrzGPD57+8DP3984mP1MgAkwASYQpwiwskyACTCB2CGgKoN3/rINqFCjCa5cvyPX5CZp0r4ffvu5euwQ4lqZABNgAkyACTABJsAE4jQBVRm8bZvXw+l9K/FH7R9Aa61sWT4VDX//MU6DZuWZABNgAkyACTABJsAEYoeAqgxeLYKenZppnbxmAkyACSRUAtxuJsAEmAATsBIBVRq8T5+/Rvf+41D1l5YGQxus1GYuhgkwASbABJgAE2ACTCDOEIi+oqo0eIdPmItfav4P+fPmwI7VM9C5dUO0alI3+q3lEpgAE2ACTIAJMAEmwAQSHAFVGry+vn6o9m1ZBAcHwzV1SjSuVwsPHz+P1sZZv3Uf6OW3Zh0G4Njpi2bLev/BHZ17j0bLLoPRf8Q0+Pj6GqRz9/DCd7+2xpzF6wzC2cMEmEDsE2ANmAATYAJMgAmERUCVBq+Li7PUV1EUPHvxGr5+/nBz95JhUVk8efYKy9fuwLzJgzF+aA+MmjRflmlc1rR5q1C+dDEsnjEcyZIlxaoNuw2STJq1HCWL5QcU6H4ODo6whezYsRMLFiy0Sdm20FftZUJstJCQEOZppf2VeVr3uFcUBbx/Wo+pojBPa56TFUUjOqBi7vyp0VjXNHFz+4AEJgmivYjkz7p7VSQrDyt58cL54OH1EQ1/+wmN2vTB/2q3xPf/Kx9W8gjDT5y5iCrflEZil0RIn84V+fPkwLmL12H8O3n2Mmr9UFkG1/q+Mk6cvSTdtKCp0hIlckKh/HmAEAphYQJMgAkwASbABOICgbRp04Ml/jCIyj6nSoO3Y6sGSCF6WKtWKo3ju5fJKcp+/+X7qLRP5nn3wQ0Z06eRblpkzpgOb99/IKdO6OMWolMAKVMkk2FZMqXDu/du0h0YGIgZC9agS5uG0s8LJhDnCXADmAATYAJMgAkkIAKqMnhP/ncZ4Ul0toui94hEUfTGJOgVqv8YhR7haKNoaMNvv1RDsqRJtEG6tY+PN2whAQH+IEPbFmUnxDL9/Hzh5+dnk23FPG1zDCQkrn68f1r12GSe1j0miae/f8ydP+nap7vIfnF06zcO4cmXZFFacaaEQUBVBu/6LfsQnkR1k6RJnQoeHp667G7uHkjrmlrnJwcNdwgKCoZ/QAB58UGkSeOaSrppaMOICfPkFGn0Nbjl63Zg6twVMs7JyRlONhB7ewfY2dnByQZlJ8QyQ8ezOcCJecLJCgyYp3WPe+bJPK1xXNqqDNo/6Zpkq/KNy6VrH4x+f9atgfDEKDl7mYAJAVUZvNPG9EF4YqK9hQGVypfE8TMX4efvDzd3T9y88xDlSheRuS9dvYWAgEDprli2OA4cOS3d+w+fQqVyxaV7wdQhclgFffmNvgbXrP4v6N6+qYyjXmFbiKIoUBQFtiiby9REkiun532G9wHeB3gfiKl9QFEUGP++Edfn8MQ4PfuZgDEBVRm8WuWol3Xxqq0YMna2DHr4+AUOHj0r3VFZZMuSAXVrVUOrrkPQvf949OjYDI4ODrKo3kOnwNPro3R3b98YO/Ydk9OSPX32Sk6HJiN4wQSYABNgAkyACQCxxGDX/mP4tXFXOb3omfNX5IvtM+aviiVtuNq4SECjRqWHjZ+L12/e4+nzV1K9jBnSYPm67dId1cWfdWpg5dwxWD5nFKpULKUr5t80RmL6AAAQAElEQVTN8+VcvxTgmjol5kwcKKclGz2oGxI5h06PRnFaadHoV3RoWV/r5TUTYAJMgAkwASZgYwI79h7FwmlD0adrSyxds12+2H7lxr0o1Tpv6Xr8+Gd7VK7VLEr5w8r0/OUbgzKHjJ0ldN0aVnIOj2ECqjR4Hz95gf5/t4aTk6PE4SzWAYGhww5kAC/UTIB1YwJMgAkwASZgVQIpUiQFvVdTpGAe0EepqHAfH8OPQ1FYROLu4SWM0G2YO2kwju9aHlHySMUnS5oYzevXjlQeThxzBFRp8Nrb2xkQMPfGpkEC9jABJsAEmAATUB0BVshaBFImTwZ6t4bKo7HER0+eR3BIMHkjJe8/uCNF8qTIliVjpPJZkphmcmrd7A9LknKaWCCgiYU6I6yyaKF8WLF+Jz598sZ/F6/hn8GT8L/KZSPMxwmYABNgAkyACTCB+Edg6+5D8r2eCjWa4PbdR9iy6yDGDO4RqYbSB6Qate0NMnrLVKuPXoMnypfWJ89ehj/+6oEqPzdHryGT8OrNO2h/fYdNwdwl69Du72H4X+0WGDd9EWje/n8GTZDp/+o0AI+fvpDJjYc0yECxoE47ynv3wWPhC/339PqECjUayxmhQkN4aWsCqjR4/+7YFKlTJYeDgz2mzFmJ774th1aN69qaRayUz5UyASbABJgAE2AC4ROgWZK0cmTHYkwd3QfZs2QIP5NRbLHCojNtzhj53s65g+swYfg/CAoOlnPsTxnVByvmjoW9nQYTZy41yLnnwAm0FDbIklmjcPX6XTTr0A+VK5bCpmVTkSVTemEQrzdIb+yxt7dH9aoVQOVo43btP4rSxQshdcoU2iBe25iA6gzewKAgsbMtw0/VK2PJzBFYs2AcatesKqeRsjELLp4JMAEmwARijwDXzARinAC9I9S66e/ScM2aOQM6tW6E85euG+jxw/8qolyposLAzogfvquI5MmS4tcfv5OGc4PffsTtew8N0pvz1PrhW+w7dBIhISEyeu/BE/jp+8rSzYuYIaA6g9fezk73eCBmEHAtTIAJMAEmwASYgJoJ0FCG8CSqulMn26RZS1G/VU+Urd4AdZt2hbePLyhcW2aqlMm1TiRydhK9svp+Z3z85K2LD8tRvHB+0XtshwuXb+DZi9d49PSFfHodVnoOtz4B1Rm81ESaHuyfwRPx75HTOCfutLQCimRhAkyACTABJsAEEhSBRn/8hEa//4jV88dJITeFaYc5RBXG1l0HcfXGXQzp3RFHdizFjtWzolpUhPl+rlEFew+exM59R/Fd5XJwcnSMMA8nsB4BVRq8b959wKfPPti04wAWrdyiE+s1O26V9GzvbFweVwfnBn2L2ws64dPT63GrAawtE2ACVifABTKBhETg7Plr6NK2MXJkyySF3P9djP61MCAgEDSUoWC+XHBJ5Ixtew/bDCsZvAePncG+Qyd4OIPNKIddsOoMXnqM0KlVA8ydNMhEwm5G/I15e3YLXh5aDL8PzxHs5w3Pe2dxZ0n3+NtgbhkTYAJMgAkwASMC/gH+oDl0tcHk9vf313qjvK5T6zs8evJcvojWvf/YKJdjScaM6dMiV44s+Ozti7Ili1iShdNYRsCiVKozeGkM74LlmyxSPiEk8rr/n0kzAz97wPvlHZNwDmACTIAJMAEmEB8JNG/wKxq07o32PUdIIXfzBpH/yEP+vDmxZ/1cHSL6ourKeeOwfM4YTB3dF+2a1wPN4EC2CCUaO6QHGv7+Ezml/FmnppzdQXrEImf2zDi4dZFwAZkzpjP4mMWwvp3wV8M6Mk67oN7kn3/4FoqiaIN4HUMEVGfwUrudnBxw594jcrIwASbABKJPgEtgAkwgThOgWQ6WzhqB6lXKSSH3T99/G6faRPP7Hj7+H+r+XD1O6R1flFWlwfvi1Vv81XkQGrbuJe/ktHd08QV6ZNqRLHdZk+T2iVPAJWM+k3AOYAJMgAkwASYQXwkoioLg4BA5TamDg0OcaiZ93KJ5x/7o1LqhHDMcm8on1LpVafD26NAU08f2xd+dmqNVk7o6SYgbKW25usj4XUs4pc4MjZMLkucph3wtpiZEFNxmJsAEmAATSKAE7tx/jCbt+mHpmm2YvWgdWnUZjAePn8UZGn93bI79mxbgj9o/xBmd45uiGjU2qEyJwjAnatQ1JnTKUrMjivfZijIjjiF/m1lIkrVwTFTLdSRYAtxwJsAEmIC6CEyZvQL9urfG7nWzkTtnVsybPBizF61Vl5KsjaoJqNLgvXH7Pv4ZNBE/1e8opdeQSbhx+4GqQbJyTIAJMAEmwASYgG0IeHh5oVqVcrrC06dzxQd3L53fZg4uON4QUKXBO2ryAmTLkgGzxg+QkiVTeoyZujDeQI9uQ95f3I1r05rg3IBKcv3h0t7oFsn5mQATYAJMgAmoloCiGJor9AKYM3+4QbXbS42KGe5BKtGQvjVNk0prJ5ju2rYxrDHfnkqaFy01fN48wIO1g+H94jaCA3zl+v6agfB5+yha5XLmKBPgjEyACTABJmBjAlkypdPN3uTm7oFWXYegZRPDKb9srAIXH8cJqNLgDQ4ONphg+v0H92hjXr91H5q074dmHQbg2OmLZsujejr3Ho2WXQaj/4hp8PH1lekuXb2FvsOnonrdNmjdbSiOnrogw2Nj4X7zuNlq+etrZrFwIBNgAkyACcQYAdtVNH7o38iXJ4esgOa33bpyGn+8QdLghaUEVGnw0iTP9Vv10k1J1qhtXzSp97OlbTJJ9+TZKyxfu0MOch8/tAdGTZoPXz9/k3TT5q1C+dLFsHjGcCRLlhSrNuyWaehzg/90/gv7Ns0DTXRN+WVELCw09o5maw0J8DMbzoFMgAkwASbABOI6gWs370ErgYFBorf3sc5P4XG9fay/7Qmo0uCt89N3wugcJieXpkmmyQCt/eP/okzjxJmLqPJNaSR2SYT06VyRX9wlnjPzDe6TZy+j1g+VQb9a31fGibOXyAm6q3RNlQJ2Gg0qlS+BgIAAXe+vTBCDi2R5ypqtLVnu0mbD1RbI+jABJsAEmAATiCyBqXNXIjyJbHlxJT09eaZvEsQVfdWspyoN3gePniFliuRyvjqasy5F8qTRmm/v3Qc3ZEyfRrcd6PN/b99/0PnJ8dnbB4oCUW8y8oLGC7177ybd+ostOw8id85soM8RUjgZv7aQoKAg0NAO47IdUmdD9npDkChjPmgcnOU6x5/DYJcikzTEjdOzP0ByCQwMBAnzCOURXQ7EkiS65XD+0O1BLEmYRyiP6HIgliTRLcfG+eW5KS7UQSxJYkpXuvbR9VVfFk0fhvBEP62t3PsPHUe1Xxohbc5SKP3tL5g5b5mtquJybUBAlQbvkLGz4aj3FRUHB3sMGTM7Ws1XNF+bqijCsjVTmsYgzdf02qRXb9zFqo27MbhXO20Q6AU7WwhVEFa5KYvVQP6OS1BsyCG5TlH0e5vpEZYOcTMczCkkxIoMmKd1jwPmyTyteXxat6zwrknW3W6helN9ahLqAPutUTucPXcZ3qKD7PbdB+g7ZBwOHj1pFTWfPn+Ftj2GokXnARg7dSF+/LO9rlx/8VSZpmdt3LYPaO318ZOM+61ZN0yatQxN2/dFo7a9ce/BE3TqNRIUvnX3IZmGF18JmFp1X+NizRUYFAgycrUKODk6ws/fdMytNj6idZrUqeDh4alLRm94pnVNrfOTg4Y7BAUFg3Ys8n9w90Aa11TklEI7+8yFazBzfD/R+5tehtHCUehmC7Gzs4OdEGuUrQn0wfPt43F9fG1cG/0TnqwfDHiL3msfdwS8ewhr1KH2MhzEDZSDuHFSu55xRT8H5mnV44Z5OjJPG11LrHFOof3T3t7eqtsoPL3o+kfXV3PyS6MuMrhu0+5yHVOLM/+Zf9n96PGzVlFh2ryVqFy+JJbMHIWsmTPAxyf0pXkqnIzhX3/8H1bNHwd6p2jlhp0ULCVPzqxYMXcsypUqiqHjZmPskB5YOmsUFi7fiEDxpFgm4oUkoEqDV1EUnL1wVSpIi9Pnrhj0+FJYZKSS2ImOn7kojWY3d0/cvPMQ5UoXkUXQDAwBAYHSXbFscRw4clq69x8+hUrliks3jaEZMGoG+vdogwzpvg6NkJEqWXg9OI9Xx1biw+V9+PziFu4u+wfnh/wPl0bVws05bfD2vy0I8HqPQG8PuF35F1enNJRx12k+34GV8XDDcDmnr3Zu37dnNuL5/nm4s6Q7Hm0ajY+PLqukpawGE2ACCZEAt5kJxGcCN2/fx2+/fC+bqF1Lj1ikS5MaZMcIJ/6sUwM3bt0np5RvypeQ6yIF8yBn9sxImiQxkiVNAtfUKfH23QcZx4tQAqo0eAf2bCu76dv3HCFnapg6dwUG9GwTqnEUlvQRi7q1qsl5+7r3H48eHZvpDOjeQ6fA0+ujLLV7+8bYse+YnJbs6bNXaFyvlgzfsG2/fBu0YZveqFCjiZTXb9/LODUs7q3og1vz2uPpzqm4v3oAbsz4C+43DiPI5yP8Pd/A581DGA/ioDit7sH+Pnh3bju8n98KndtXrB9tGoMXBxbA49YJvD27WRjNrXFzbhudEf146zgE+X3WFmF27fvuCZ7smII7i7vLNfnBPybABJgAE2ACcYxA+bIlzWpcpXI5s+GRDQwJAZwcHWQ2e3s7KMrXqzb5ZYRYUE+7/hhnB9HzLoJBQzIpjtwk5A/40plHfhZAo0YIhfLnxpqFE+SdDN3NrFkwHgXz5YpA1fCjqZyVc8dg+ZxRqFKxlC7xv5vnyzshCqA7ojkTB2LxjOEYPaib7sW0Di3r4/S+lQaSPq0rZYl18X33GG7XDhroERIcBIiDxzBQMfCG66GkegebNu3Hhxd1RvSbUxvw8vBSbZTJOvCzO65Pb4bXx1fB4/YJuSY/hZsk5gAmwASYABNgAiomQEMcN6+eh3JlisPFJRHy582FscP6oFqVb6yidaECuXHqv9AnqWfPX5XvWmgLfvHqLU6fC43bsHUfCoveXG0cry0noEqDl9S302jwXeWyUuhOhcJYTAl8fnHHNJBCyGiltVkJKzKs8C+FGBnRXvfOfYkwXbldPWjSA0w9wm7XD+Oz6EEO+KieHnJT7TmECcRxAqw+E2ACVifww3eVcXDHarx9eAHnj+1A53bNrVZHt3ZNsG3PYbT/exjOX76BVCmT68qmMb2rN+5Gvb96wPPjJzT98xddHDssJ6Bag9fyJiTslIkz5TMPwMg4dcmUBw7JXGHvkgJJc4aOTTbMKDJ8sXfp0YphnGW+QG9PvL+4W44lpjHF5nI92jxW9Pw2xcURNXFrfgeZxPvVPfh9eC7dxotne2fj8rg6ODfoW9xe0An8RTljQuxnAkyACTCBuE4gdaoUmDSiF+ZOHoJihfIiX+7sskn05HnTsqmYMa4/NiydggnDesoxuhS5efk0nbvqN2UwpHfoNZXiFs8YgWxZMpIzwYsWABu8WhJxdO2cJjtSyCPzEQAAEABJREFUFalmoL19omRIkf8b2CVKCsfk6ZCuYj0U7LAQJQfuRamhB6Q7f5tZSFPmV6QoUBlZanZEjt/6wSVTfmgcnJE4cwG4lvwRir2jrlw758SA0TCHZHnKQPsjg/Xy2F/xYO1gOZb4w9V/tVGGaxpu8SXE6/45yJfkpjSURu3VSX/C9/3TL7HA27Nb8PLQYlDZwX7e8Lx3FvQSnS7BFwcZ19oX9oJ8Q6dr+RLFKybABJgAE4hHBArlzyVbUzBfTrmOL4s79x6h0o9N0bBNL2za8S+6tmsSX5qmmnao0uB9Y+bNwpev36oGWkwrot9z+unxFZPq8zQdhwLt5iLrz92Ru9EoFO+3HflaTUfpYYdRYsAuZK/TB+43j+H+6oGgF9zenN6I5HnKIWe9QcjXYgoyftcSacv/gSLdVqLMqBNynavBCJH/EAp3XYGSg/bKdcpCVXVGdJqyv8LP8y0ujqyJC0Or4/aiLgjy/YivP9FdbNRVLPqQYWw0B/t/nXqFXq57unOaNHTfnFoP9+uGY5MhfoGfPeD98o5whf5Te/Rf2Ls0+hfcXtjZ4OU6mqHi0boheLRmIKjtoTl5yQS0BHjNBJhAXCEwdnDodGSjBnaNKypbpGfJYgVxYs8KrFkwQfTmDlDtjFAWNUaliVRp8PYZNhWfvX10yGhGhB4Dxuv8CclBvZv6Pac3ZrfCw40jTRAky1UaGb5tgtTFa8DOOYlBPL1c9mDNIHy4vFe+4PZ4y1g51ZhBIjMebW+vQ1JXOLtmRd7mE4URHGpEa+wc8OHCLt1UZ77vn5m+KCd6hMkYL9x1OahHWZjAprUo0gyW4SHCQHa/eVToNgqPt46Hx50zIvxrvPDI/3ur+8ueYeoRdrtqaBQH+XrB8+4Zg5frHm0cBfer++Fx4zAsbbusiBdMgAkwASagWgKTZi1XrW5xVrF4rLgqDd76dWqAjN6g4GDQHLhd+45B17YJs3v/9cl1oufU8DH9u/+2IuCj5fPrfbi8z2QX/nBlv0lYZAI874fxwpowWvXLSZq9OBJnLojkwiBPlDaHfpSJ26xBbJIqBL5vnyA4wFdOtwaRKUQ7JYWsWwQY55HhXwMlD72hFV9j2MUEmAATYAJqJKCdplR/vefAcfQeOhmXr91Wo8qsk8oIqNLg/bF6JZQokh8jJsxDF2HsdmrVEN+UK64ydDGjjs/bR2Yr0n+sbzaBNlAYdr5mXgijsa4BNp4pIU3ZOnBImjpUE40dCnaYj0zV2yBFgUpIW+43UK80yGLFl5/oEf7i0lspcEqZERonFyRKk030IpsatHqdxHr5wnbSbBF+nm/CTsAx4RHgOCbABJhAjBNo1aQujIWmB61ZrRLGTVsU4/pwhXGPgEZNKp+7dB1aKVooDx4/fYFSxQrBxcVZhqtJ15jSJaxeUZeM+SxTQRiayXOXNUmbKF1O0FAFkwgLA5LnLmOSMmnOEsjVcIQcS1yo4yLk/GOgQRr7xCmR+Yd2yNdiKnL83h/5Wk5Ftto9QWODXUv+BGcyaA1yQOiYWo5JLjPiGNKW/x369jGMf8JgVjQa41BAhEPvR20nI1oviJ1MgAkwASagYgJlShSGsZQoWkBOXerk5BRLmnO1cYmAGesg9tRftHIL9MXZ2Qn3Hz3VhcWeZrFXc/pv6puMyTXoObVAtSw/doKzaxZdSjJ0s//aS+ePiiNzjQ6QenyZ6ixV0erI1WA4yHClscRJsheLsFiNgzPSV2oIGhtMebP98rdJnkzVWunCkuctp3PrO3LWHwrtC3uFuiyTBrR2horUxWvAKfXXqVms0Xb9utnNBJgAE2ACMUvg7Xs3bN9zGJ8+e8uKl84yfa9FRvCCCegRUJXBO3fSIIQnenonGKdT6swo3nebNCbJqDPXcxoRDOrRLNZ7C4r13oyiPdfJWReSmemhjagc/Xh7l+T4D8Uw40VhTH5WCEcCiyG6vaY0lVqJfjtE7+8AZK/TW+qaruKfumoTpcslOWinT6N17oYjkab0L7oX9hJnKiANaO0MFXLWij7bUbDHOhT4MuNEdNuuU8gCBydhAkyACTCB6BPYc+AEhoydjXoteqJJu344ff4KShTNH/2CuYQEQ0BVBq8+dV8/f1y5fkcOZdAOc9CPT0huMi4j03MaFhuaaYGMRoqP7gcdJk6fj1ademP95l3YunM/uvcZji69hlDR0RLHlBmQtlxdkKGr1VW/QOKgP31a6hI19aPDdFPbndPGr3kbw2wsRzABJsAE1EcgWhoNnzAXl67dRtM/f8a+jXMxZlB31K5ZNVplcuaERUCVBu/ilVtQt2l3zFq0VjecgYY6JKxNY7vWmvugw+0FHXFtWhM53Retn++bg5tz2+LcwMq4MuF3vDi40EChdRt3GPjJs37TTgQFBZFTVfL02UssXbURC5auxc3b91SlGyvDBJgAE2ACERPYsGQSWjWug/OXb8oe3gEjp2PnvqMRZ+QUTOALAVUavKfPX8XudbMwf8oQgyEOX3RO8Cvfd0/wZMcU3FncXa7Jj0j8vO7/Z5I6yM8b3i9uyem+vF/cFgbuIng9vIBgfx9Q+c/3zYXb1QMyHxm1d+8/lm79BY2nev7itX5Q5NxRSP3x0aVwDfN9B4+hQOlqsge696CxKFOlNuYtXhWFmjgLE2ACTIAJxBaBzBnT4defvkOrJr/hj1+/x4tXb7Fg+abYUsfq9R47dV6+sxRRwTQV24QZSyJKZhBPX2+jKV4NAqPpuX7rPnoMGCdLOXjsDEZNni/dal5o1KhcyhRJoSim00+pUdeY1inwszuuT2+G18dXweP2CbkmP4VbWxfjLeB57z94v7qHQI9XcHC0B30owlCAzJnSW1UN+pzwww0jcGdJD/mZ4SAfL135NL3Y3eW98PHhRRPDnPSkj3aMmzJHptfqSZ5xk+fSioUJMAEmoFoCrJghARrS0LB1L0yfvxIBAYEY0rsDtq2abpjIxr5Pry7g0cHeuLXpDzzY2xEf7m6zWo2n/ruMh4+fW608LsiUgMY0KPZDnJ2cMHDUTBw5cZ7H8BptDrerB0GGnn4w+d1vndAPCtedzMw0ZUCIyGNk4lKQCKV/MhjfX9iJa1Ma4vK4Opj1g4IMSRV5Y6IooesQBFNSA3G/eQyvjq4ArQ0izHgCvT3lV+QujqyJC0Or4+ac1ri9oBPendsGj1vHQeOOby/6+jnJz89vIfCzh0lJ99cM1unZPtNd/FHQDgMqO2NoVWf8ktcer9++g4fnV8PZpIBYCHBz90CnvwchV9FvkbVABTRt0wNPnr6IBU24SibABJiA+ghcunobb9+7w87OTioXond9kgE2XgT5eeLp8aHw+XALIUF+8PN6hjeXF+LT60vRrvnug8c4evIcFizbgDbdh+DJs5egXtMaf7RFvRZ/C3toum5GCqrs6fNX6NBzOOr91UPcAKyiIGksU17pEYtFKzdj5XrToYetuw0GlUk3D0dO/CdShv7/1qwbJs1aig7/jMCh42dDA42WZJQ3aPUPWnYZhB17DxvFqt+rSoP37Xs3vHdzx9ote3gMr9E+5PNOO5TAMMLP7aVhQDi+tOXqIuN3LUEzQGicXJAkWxFh7yqmOYyCggP9dWmyp9CgWTHDuQ8VKAZjeK9Oqo+7S//G013T5PrqxD/wfP880VvbHY82jcbHR5d15ZGDxg3Lr8h5vUegtwc+PjSMpzSfnl7H1Yn15Fjjh5tGUZCJhAT66cKyJVfQoYwTqueyR5Xs9uhRwQl/V3BGiuTJoKbf8LHT5Tjj12/e4YObBzZv34sOPQaoSUUDXe4/fIxbd+4bhLGHCTABJmArAltWTMWi6cNRvlRRXLlxF137jkGdJt1sVZ1Jud7vb5qEUYD326u0ipbkzZUdVb4pgzbN62HB1GHIliUj8uXOge2rZ2L94knImjkDVm3cpavjxu37GN6vM5bPHYPjpy/gzHnLdejfoy02LJmM6WP7Ydq8VfDx9dWVm0U8oZ0zcRC+q1xOF6Z1BAYFYfj4ORjQs63cDm/fu2mj4sxalQZvWFOTxSbV9Vv3oUn7fmjWYQCOnb4Ya6okz2O6I5IyYYVTnDnJUrMjivfZCvqgQ6FOS5Cr4XC4ZMoPmhuX1pmqtULSnKWgcUwkDONMUBTFpJjcKRWDYQ1JHRXcP7wOr46txIt/F8DnzYOvecTtuM+bR3hxYIHorT2Bt2c3yx7cT0+v6dKYfK44jE+o0dfn6NPCvu+firwhQoz+jXQ11vy7HHbw8vQ0yhS73iPHT5socPzUOYMbCJMEsRBARm7B0tVR+tvaqFj9D2Qr8A2OHD8TC5pYVuWxU2execc+yxLHQqqPnz6jR98RKFjmB+Qo/C3q/9UZdDMRC6qEW6VWz7wl/odMecupT0897beI7d2uW380afM3Zs1fDh+frxd0vWSx7iQ9W3fugwYtuqhaTwL16MkzXL91l5yxKtmzZsRvv1THqAFdsHPtTEwd3SdW9bFl5Y6ODli6eiu69Bktjdr7D57oqqtUviTSuKZCImdn/Fyjitg293RxETkePX2OIWNnof/Iafj46ROev3ijy/Ldt+V1bmPHi5dv4Jo6BYoUzCvtgd9rf2+cRPV+jVo1pDE612/dU8WQhifPXmH52h2YN3kwxg/tgVGT5sPX72tvZ0wyTFGgMtKW+82gyrQV/kDSHMV1YWQMvj6xBneX/YMHawfrXjbTJTDjMJ7uiz4sUbD9fJQZeRxFuolHJorprvIpAHLHVxQFmZJqsOr3RPh4cBqe7pyK5//Ok4MkoP2R1SnSab3a9YfL4RgjIdpURmthPFOIAoVW8qMaZJib+1KbTGC0SOyoQPF1NwqNXW9gYCBo2IixxK5WprV36DFQPG77OtTivZsb/mrf0zRhLIccPHoCKTIXxY91/0LT1t2ROF0BjJ40K5a1Mq1+wtR5mL9kNV68fA0aZrNzz0G07drPNGEsh8QVPRcuW4smYnuv3bgTu/YeQu9BY0DGbyzjM6leq+eaDduxY/cB1er5+MlzcXP7C4pX/Anf1vhTDrfavS92HmXTuXHPgRMYMHK6FHJny5LBhK2tAlxcC5ot2iVtUbPh0Q0cPXk+MqRLg9GDuqFHh2aiJ9ZPV6R2WAcF2NvZITg4GHZ2GnkNoTCSINEjS2t9uXnnAVZt2IXmDX7F3MlDkCdnNnjr3RA6OtjrJzdx24m6tIH2duGn1aZT09rUilGBdifOXMJvzbqje//xoLcRu/Ydi5kL1kRHs2jlPXHmonjcUBqJXRIhfTpX5M+TA+cuXkds/XL83h+lhx9B4a7L5TpH3b4GqjxcPwxPtk+C+40jeH9xN+6t7Iu3pzcapImMx845CVIXrWaSxU6YtOvrJcLmP10wproTkjoZ7k4K5fhinJLTnHjcOa0zzJ1SpDdJQnVrAxU7B4gjGjAwnBVkqNxYGubFem1C6mJm7jpDYPB75B6EQKeUBmGx7XGwF20zUg8rkRAAABAASURBVCJJksTiJGZnFBq73ivXb5ko8E482iJjzSQiFgNaduiNgABxR6anw+gJ6jN4aeiKnorS+d/5K/D6+Em61bLYf/CYiSrnLlxVnZ4r1m4x0ZN6Us1d/E0SxmBAXNFz9MRZoKc6WjQ03Kpr76Fab4yuJ89ege17j4hexpSgc+PazXswde7KGNPBzik5slYeikSpC0Cxc4JTsixIV7w1kqQvAWv8EiVyhpfX1+Oexul++01pJEuaBMeFDaJfx8mzF0HnXRqOsOvfYyhaKK+0Td68+yCTkQF87pKpjfL46Qvky5MdObNnlnVdv31fprdkkSljOjnczt0j9P2Xs+L4tySfmtIYWigq0Yzm310wbShy58yK9YsnYcnMEcKdLda0e/fBDRnTp9HVT9OjvH0fumP5+vrCFkIXa+r1C6vsANjDzjUnaK2fxtvTDR+uHtTpqnW8vbQ3WnpmrN0HGX/siuQFvkXKYjVw7kUAiqS3h6uLBikSKciSLIxdSVq9QosQIWb+fd8+1hnmNCND4ixF4PDlc8XJC3+HvB2XoEDPTcjTfhHydlgEQ2MX8ueYubCubcZ6zjzrg+cfg2U6WnzwDsGMs37iYPfS5dHnF1vux8+ei6YpBuLp9RGfP39WlZ7BgabzLNM9zQfR0xtb7MzVa24KHuohunPvgap4vvtygaJ9Uyt0sfL397ehnpE/ZxE7rX76a7XpeffeQ331pJt43hCP483tJ7EVRnoS0xDRaSBFHERklKtNz7PnL4k+BqGh0E/qK9avXr/F46fPbLp/Egu58fQWZADOmThQ9HY2Rb/urbBY2AVnxM2hXhKbO5NkKIUc1cajwO8bkavmbKTO+6vV6qz1/bc4de4y2v0tOqyevUTLxnXRvEN/OaSBbAH9imh8b7f+Y9GkXV+UL11MipOjI76tUBo0BVnPQROQJnUq/SzS/W3F0rh+8x7oxTV6Qa1Qvlwy3JIF9SQP/KcdBo2egc69R+H+w69DLCzJr4Y0YVgpsauavb0d0qd1BQ1rIE2oR9Xbx5ucsSaK5isqRVF0etSrVw+2kGXLlmH37t2RLrtrq4ZAyFcDT6vo2/tXI12WfrvqN2qKjpM3oNfme/h7zRWkS2JZz+PWF8lx4E1SrHueCv+KdYCeanQCFRaeVkW5vnnnDoacdcDQC4nQa+NtNG7TFY1bd0bzbgPRtFMfUHmvfB3gL+wuWm99kQJNO/bStU1fz55rr2LTrUA02+KLppu90XKbN+pt8Mal18Ho0L6dLo9+O2PL7WdmiAztZbGlT1j1ajSmdy50OHTv2kVVPMUlWu5P+gva3zp27KAqPX18ffRVDHWLDd+gQSNV6fnyxbNQ3fSWtC+0+Ku5qvRM5ChOf8Ioo+0vRbgdHewwoF9vVekZFOgnTn0KdH/iINIIUZuez56/kFtcUYSmXyQ4OASdbXwcHTp0SNarv0iUyEnfK91JxVMw6YgHC+rgmzyyN+ZNHiJfWvu5RlVsWzUDM8b1R89Of2Hm+NCXmH+sXlmGrZ4/HpuWTUXXto11re/VpQXWLJiAKaP6yKEQTf78RcZRmGtq0TOe2AUr5o7FwmnDMXJAVzmsoVjhfDLN5uXTZG+y9ISxIOOa9CCZMW6ArIeSVvu2PAb83ZacqpavVpyemrHtdBFd+6RDiuRJsG33IZw4cwnuHh8pKFYkjbhT8vDw1NVNU0ildU0t/Tt27IAtpHXr1qhdu3aky164cR8ckn3tjZZKikWaXDkwsXVKTGiZFLP7fYPN6xZHumxtO3fu3CmHd4hiv/6LkyHExeVrAJCmbB2MWXUIA5YdxuQ1/2KgWFcccwKFu65AwQ4LoCiKfnLpzp02Sbh6jVl1EHWmn0blSeflesyqA+GmT5PGVZb74mMIHnuEGmuOTg7yZkLbHjWspZJGC0VRMHPW3HDbF9O6FyyQX2xmYUqIbU0GJEmqFMlVpSMxyZA2jRFNQKNocPDf/arStfI35Ux4JnJ2woF/96pKz6w5cproGRQUgq1bt6pKzzat/pLnFQVf/sQxVKZUCVXpSPunnYOp8RYsjim18bS3d4CiKAbHkjiMQNcAaoet5Pvvvzeokzx2dnboNWQSaOzu+q370P7vEXIM6jnx6J6E0rAwgfAIqNLgrffrD/AQj3M7tmqAA0fPYuWGnWjX/I/w2mHTOHojksbQ+InHjG7unrh55yHKlS5i0zqjU3iO3/rB3iWFrgiHZMKd1BOBvm4I8veC17MTeHluhi4+Ko4MRb81yRaUKhdyNRiOrD93R6GOi5Dzj4EmaTQOzkicuQCS5igBxxTpTeKT5SlrEhadgM2r5sLB3h50MSHjTKNRsHjGhOgUaZu8htcUWQfpmzNHVulWy+Le/cdCFUNlP7h7QG1jeIcP6hlqoOk9Mq73Wy2he6T/bZqhV7d21CUpdBXViPuxECUEfXp0FB51/T8Ujy8VRZHGj6KEroV9BrU91ty+56BgaXhDdursedXNduKlN1ZTu6UVRcHFKze0XlWsfXz9TPQQWx+nTl8wCbd1AI0f/vjJG9v2HMah4//Bzk6DR09f6KYutXX9Cal8GrbQtsdQ6EtcHLNrvM1UZ/AGBgWBTgYpkiVFruxZRNd9P9A0ZSWKFjDWPcb89CZo3VrV0KrrENCLdD06NoOjg0OM1R9RRR8fXjD4vK73q7soNfQAivRYg+J9tiJJsSzQONkbFPPpzWVxodUbX2AQG7GnSP2+sgdXkzglFKekSFW0Okq1nwqa7SHDt02QJHuxCAsxNswTpcuJzN+3jTBfZBL07DcSAYGBondPnKbFBYUex/UeMjoyRcRMWmE9pEtphzoVkuKPSsmQM13o/nXpWvQvgP4fX8LP84lV2kFjNs0VpH0qYy4uNsL2HTgWWq0wIoXNCyjA6f9ibzpBhPFbs2E7IPZL8S/W4j9EAb3BD5X9qv+vkjQktTeOdDOWPl0a5MuTU1WaXr9xR+AUG1v8Q4iiKPJmV22GuSJuvImhvgQHB8fquyrmNqS96FU1Dhe3E6hYoZRxsE38d+490pVLdkB4okvIjmgTGNG/C+ZPGWog5UrRbBTRLjpWC1CdwUsH2NFTF2IVirnK/6xTAyvnjsHyOaNQpWLMHOzm9DAOo6+s3VnyNz4+vIhgfx/4vnuC5/vmwu3qAbhkyAP6uIRxHmv47V2Syx7cMkP+RdkRh5GnyVg4pcwYqaJT5P/GwDAv2nM9nF2zRqqMiBJfvnoT6VPZfzUk0zvg5au3CMtwi6g8bbznk8N4fnoCnp0cA7f7u7XBUV5/UygJdgzLjv4N06L3n2mwdkBW1BOGb9GC+aNcpp/XU9zb1Rb3drfF/b2dcGdbU3x+cyXK5VHGoJBgZEhtj7oVk6Fe5eTIlcFRBIeI3hbLxnSLxDHyf/rcJYQEBQtjR1QnjN4gcUPx+Okz1fVEr1q3FYqiGMjzly+F0ur6p5cnFUXR3TgqiiJuJA1nwYAKfsGiw4SMSK0qIcEhIEMycWIXbZAq1vSCkaIYbncogIOKOlIIFLHT50lhxJS+VkluW8vUeatsXQWXn4AIaNTYVpoFYfXG3aDhA2rUT0060ed1yeg11snz3n+6oCQZSuvcWkeSdMUBJXqbf+3GHfijSXv8XK8lFixdg6j+bGWY05u+ZfLYY/vQbF8Nyf5ZhaGWDM9fvI6qunh/awOen5kEz6dH4fX8JF5dmI2X52dGuTzK2KJGaloZSKsfU0XLkHxzdRn8P301ngJ93fFS6GpQSSQ95fI6mfD8o1JyfPz0WZaklsXr12+hsbeDnehJU4TYKxooigK1veRCBoUJM9HLu3KN6fRaJuliMODA4ZOyhzdE3Dho5d07N6ht+jRxbyO3s4Ivf2Lba75s+xjEFWFVAf4BJjzpSYTZ/SHC0myXQL44LqBqt3mwuOElssmTJrFdpVwyE7ARAY2Nyo1WsZt3HsCMBatRq0EnVKjRRCfRKjQBZ05XtBlS5vwB9s7CgHJMhmRZKiFjmS7RItJ70Gi07NgLe/49isPHTqN77+H4XRi/0SrUypntxOM4c4Zky5op4epqOmWLpdV7Pv3yuFwvg+eTo9EaIpLF1bSHNHUye3x4+1Svlsg5fd1Np2jy//gCwQFf53qMXIlAs+opTLK0+jGlMHxi76VSE4VEQJCZ6dPoQu2u9/KpSKba/6pVKqhKt0DBU1EEQQMBnr98pSo9Q8LQ5tnzrzd+YSSJ0eCweHp6qes4IiiKuGlQlNBtTzcP4l4C67fspiiW8AlwrMoIqNLgPb1vJcyJytipQh16AczOKbGJLsn1Xv6yc0wqDNyuyPfrcuSvuxpZKvaFg0saROe3fM1mKIrytQjhpHGT1Kv6NTByriD/j3h5brp49N4Mt7c0wrNTYxHw+U3kCjFKnTujk1EI4JrMAYkcgkzCLQoQPRz+n0wv8sGBPgjwfmdREeYSPXlr+nj4vVcAkpp5sc9cfnNhdo6mvTAae2fR8+liLrlFYdnS0hAGw6TEM8DbzTAwtn2KqQKKomDz9n2mEbEZYkbPENHVl9glUWxqZWHdCvzMvNRkYWabJDODU56nPqnsCYT5xis4+98l81GxFWoGqKIoKFQgd2xpxPUygSgTUKXBG+XWJMCMZOzmazEZSXOWhMYxEZzTZEPmGu1BL5HZCgcZtV4fP5sUT4/jbt15YBJuacDbayvg/nC/wWwSL/6bZml2s+leuNEZW/T7iEex4hmi6IUNgdvHIDg4JzebPsJARYPE6YqZJHNKlhUOidOZhIcboBe5bP8H4QuR+kk9hW/RHne8eh11Izp5VtOZNJJnqwqINiCKvydv/U1ySsM8ZQaTcLUF0GPZti0aqkotO40GwTTWOFiYuUKCxA2VsHdVN5YzLGipUqUMK0o14bTd06V1VY0+4SlSprTpuSW89LaPo/OnYS3EM1UK9W93Q63ZxwQANnjjwV6QNGcpFGw/X/d53UzVWtu0VTRUQCED0qQWBXlzZzcJtTTA89kJk6Sf310TRmCwSbilARcekIGmQHTz6OTiPR/xCD7qj/XTFW0Oe2fxaJ8YCNHYuyBDyXaIzi93JieRXU9P4cudyRGZM5lO3SaiLPp3TpFDpDM0op2TR337iMKw/IA7rQxk8V4PeHqq61Gsi7OzgY7kESSitd2pDGtLMO0/dhpo6LGxEDtFI3ZVBY+fPLd2VdEqj9iRoRMirPFgIfTiUnBwEF68MH3aEa2KoptZ8CQ9tcWQmxirbTYJ4qnVUbsmtm/evtd6VbFWFFNNBWKkSiXOf1bW0Fxx3ds1NhfMYUwgSgQ0UcrFmRI0Aerh1ZqgmVPbI0c6e8kjBMG4e/+xdEdlERxg2mssezup1ysqBYo8xbPbiaXhf4nczqYfzjBMEq7v44uzohfaA8IykRIc6A3PZ8cRnd8PJZOaZK9RKikOHzW9CTBJGEbA+9ubRIyhEf3u5loRFvX/PNIwFxdBuup9kVwZHUA3QVEv1fptTGCiAAAQAElEQVQ5pVEm9CODR4ow0gQJsTsJ3a1fXZRLJN3MZc6eLbO54FgLUwQ8RVFAfxpaahRoNHZIkSI51PZTFEVs7RApikIaK7h2846q1LSzEzrq75/SDRTMn0dVeiLki54I5Rm6v4bg5evoDTWztJH58tBNe2jq9j1HwJyExvKSCURMQBNxkphPQR+diPlauUZLCdjZ2aFQ9qTYODALNg/JhnUDsmHXiKwom9cFBSLxbW6D+oRRGxIcaBAkPeJCEOBDj/ulL9KLLK6mWehlMCXYxzTCwhBbvLRGU30ZV58kkR1yZDQ1hI3TheX39XxmEhXo6yGMddNeWpOEYQSEGuYKIAwJrZBh7uamrjG8/v4BQj3lqyDU7eHhBbX/FEXB1eu3VaWmojF/qcidM5uq9KRzkzTK6L5GCJlpAifSmfnyXmwqbm9vH1q9IlYkX1bBwdquBBGghn+hm6IodPSEinBrxL5Aw3BiWr1WTepCK7VrVoGzkyPSpUkd02rEWH0//tk+RuqaOHMJ9hyIXodNRIp6ffyE35p1iyiZzePNn8VsXm34FTRt1w8jJ83HQ5U91gtf64QV2/lXV2TVe4EpTXIH9KqXNuo9fYoGisZRQKSrFIlwil4FcZaFnWNS8kRJHrwKMMlHY06fv4mi4SMMc1u8tHbjaZCJnjReNlf+kibhlgY4J89ikpSGYtg7R338XUZXB5MyyTAvll9dY3il0WOkKYUlTx71fcmoOJt5SU+1TZ8GM4aYoig4dPS0zThEpeBEiRJBUYSBphUoopgQZEiXRqzV868IvRRFLskFRVFAhiQZBrDkF0Np6AbCuCoaIuLgYHoeME5nbX+ZEoWhlZ++/xZTR/fBBzfxpM3aFYVTnuedU7g5uxXOD6yMa5P+xOvjq8NJzVFaAi4uiTCsbyetN9bWmlirOZyKNyydjLy5sqHvsCno0mcMjp2+CLoIhJOFo2KYQLY0ikmNWdPaw8PtrUm4pQGOSdKJpKJccfKHWEEsNHZO0Ng7I6q/83dNe3Iv3fNFpgxUVxRKVTRwSm7aq0VGZHReWnPK/hue0gthwtYXOzveeQbgplf0XmBxzf+7SQPTFGxgEhaZAH/HrCbJPXydEZ22mxRohQDxYEBgJJihhWnPHx6eUbzRCS3G6ktnJxq7bVgsaV2kUD7DwFj2aexMLxXE+PvvKsWyZobVp0iVXNjmIQgWytE2D10bplGDL6wxsGozzGvV+M7kOEqVIoVqvrCXI1tmA/1suW0DP7vjzuJu+PTkKoIDfOHz9hGe7pwCz7tnrFLt85dv5Kd8W3QegDFTFhiUST2wjdr2RsM2vTBp1lIEfbkBDSucelMnzFiCll0G4a9OA3D3gWVDDT+4e6Df8CmyHtLj+q37Uo+Dx86gxh9tUa/F3xg4ajo+ffaW4VR/lz6j0aHncPQaMgmjJs3DyInz0P7vYWjSrg8uXrkp03l7+2DI2FnSTXl69B+HTr1GgupYs2m3DKfFklVbULdpN3T4Z4TUY+X6HRRsNTE9i1mt6KgX5CweVdCXzdYtmojffqkO2nC/N/8bW3cfirGdO+raqyKnzZXw9jOtwi8gBEmTRb33MEX2aiaFJs/+HSCMTETxV6loCpFTmBDiAih2HpCUyusCcz0XIqFF/8FB/qIc/aQhCKEw/aBIuv89+OWRkiIyKoow9RWcOHVOeKL+Tx8cyfvLYmQs3RkZSrZH7pqzkCrPz1EvUORMXbAJXrp9fez6wUv0TGc0NaxF0lj9d3C0h6Io4hmB2DZiqSiK1CelysacZs6SESHi4hUcLPQUEiyeIGiErkFBgqvUWB2LYKEjGZBabcgdgmBcvnZLG6SK9Yd3H6DRKNAIhorydX3/4ROo6dejcysTdWpU+zZa5yWTAq0QMGZob2TOlEEcQSFSkiR2waxJw6xQcuSLICNv6twVqFmvPX5p2Blzl65Hjw5N5HEe+dIin+PjY/Nfqfz44HzkCzOTY9q8lahYtjiWzBwF+viWj4+vTPXk2UssWb0VM8cNwKp54+DnH4BtwhYKK1xmEotsWTJg8YwR6NauCcZNWyRCIv6fNnclihcpgDULJmBon04YNHqGzJQvdw5sXz0T6xdPQtbMGbBq4y4ZTovnL19j4ohemDCsJ3lB565ZEwdh3pShmDx7mQwzXrx68w7jhv4t23pAPCWiYaxklNM3GJbPGY3xIu7G7QfG2aLtV6XBS60KFCf8PQdPYLGw+Gmczl+NfsXJs5fQte9YimaJZQIHLn820WDvhU+ws3cwCbc0wLVAPWQu3xPJs1ZBsszfIEOpjtJYszS/uXSZ5RAvYeyIi584M4IkVVI7BPh6Iqq/AJobWBQprgAAGdJQEBTwWdz1R33mh29zvTMYIuKa3B5tajgiup/wdHBJi5S5akpD11zPdGQZDJ28BnWGPsLvw5+iwein+HHgY3Qasjyyxdg8faXypWUditg2JORJlTIFkidT15CGd2/fQ9FopJGmaBRolNBTstoMtOTJk0FRFGHiBktRFEFV6Kq22Q9cXFxg+lOgtrHGnds2x/TxQ1G2dHEUKpgX3Tu1wqpF0ZuC0bTd0Q85cOQEXgiDRlvSZ9FTt3nHPq03RteLVmwC9Ti2bvqbPI69vD5j2dodMaqDLSu7fuse6v1aQ1ZRr05NuabFpau3ZI9qn2GT0U70nF6+dhs3hTEYVjjlIanyTRlaoUTRAiDjOEReq2RQmAvqkd1/+CTadB+CkaK39r2bO969d4OjowOWCqObenOPn76A+w++3kCWLlHY4CXwCmWLw06jkWHuYbwzUbxIftDNEymSOlUKPH32Ctdu3sP/KpcFDeciqV7V+h/fCT27Uq0qkmVrtuMP0aN76uwV9O3WEgunDUXtmlXlHcTb9x9UpGncUcXzyWE8Pz0Bz06Ogdv93dFWfOGudxi07DX2nvPCgYsfMXbdO4xZ8xYfxAESncKTZ/sfMlfohSzf9EOq3D9FpyiZ97mZ3eWDVyA0DqYfZZAZLFg4JfsypEERicWFXyxh75wiWmXmzexExRhI9nSOSJsykUFYZDxBNviQB71MVbN0YrT5MaWQVPjtm2S49+Ax1DZUoGPrpuJeJLRXSi7Fyb5x/TqRwRcjaX/8oapJPVkyZ1TNI2Otcr/Vril5CtMcJHTxpDfotRctbbrYXvv7+5uoQIeo2m4gjhw/g669h+K/85dx4+ZdTJ21CDPmme8NM2lQDAZs+PJFNQWhf1T1FmHwUi8euWNSDhw9g2lj+uKP2j8gSRIX9O7aAifOXIwxFZJmL2a2rqS5SpsNj3SgOEc5CcOS8tnb20FRFHJCOFDlm9JYMHWYlPWil3XgP+3CDkfoj47RUBegiD9Y+Js0sresh+o7vms50rimwujJ8+U4+NGDuole9Wbw0fvgjKODg0HJdnrDn4JFmwwiv3js7Oy+uAC6yQ8MDJTnF/1wYqBLZCWHKg1er0+fMH+quMMY0BmF8uc2aOrgXh0M/NbwxPcy3t/agOdnJsHz6VF4PT+JVxdm4+X5mVFudujJTsG+C58xeMU79F/6FptPekFRFHz65B3lcm2R8ZG36VjIY/eSQ//Aimy9aQvVN8kS3bGxSZOnMSkzKMQeNMevSYSFAW9t8CGPRlVcMLxZetQskxTVSiRB3/ppMLBxenlXbqFaMZJswdI1cn9U8OVP7Jsr1myOkbojU0n/fzqhQL6v5zjq7Zg2fkhkioiRtGOG9kG7lo2RLq2rMDYS45efqmPD8tkxUndkKqlV8zuT5Gq8gSAD11jRCdPmGQfFuv/u/YcmOgQHByM2biDsNBrZa6ivUECAmZl99BNY0W2fOCXytZyGJNmKQuPgjERpcyDrzz2QPG95q9RSWPT0nxBPsamwM+euSAOQ3GVLFsahY2cF86fkhbvoNb3/6CnCCpeJxGLTjn/FEtgrnpRnzZIBiqJIf3iLcqWLYvaitbq6z126LpM/ff4K3wqjO1nSJDhuo5uMIqL9Fy7fkHWTsX7u4jVZtzUXGmsWZq2yurRphLTirsJceYXy5zIXzGHhEDA7jdbTY+HkCD+KjMVSJYsgfSp71KmQFH9USoac6R2QPm0aZMuaKfzMMRzbouNgrLhcEDN3eWPWrk9YeDormnaeHC0tbDE2NnPBH010cs1dHRCPjRHF36c3pmPOPr8TJ7CQr2NwI1t0dWHkGuepUSoJ7MTjeOPw2PRfuX7LpHpPr4/RHiJiUmg0A3LnzI7zx3bg8qldOL5/PZ7eOg0ayxnNYqOT3WxeesQ4ZewgPLx2HG8enMe6pTNBuptNHIuBceUG4vY9U0OSXux58vRFLNIzrfr7/1U2CcyQPm2sPIFwdnaGr19oD76/fwDGTVuMwgW+3iyaKGqDgOT5KqJgx0UoPfI4ivRcj/SVG1mtFhprS2Nz6YWvXf8eg5OToyw7o+Ddu2tLjJg4F/TiGglNrxhWuMwkFp8+e+PPlj2xdvMe9OnWSoRE/N+lbWP4i6ckjdr0Bk2Ltml7qNHcsnFdNO/QHzSkgXpjIy4p8iny5c6O/1Uqi47/jECPAePgmiqlvLmGFX+qMnir/NwC4YkV251wihLGjdlptAK8ozUf6+xhjbB9aDb0b5gWvf9Mg7X9s2L1+Hqq40rjNseOGY/pi/Zh6sJ9mDJ1tlWMcmuPjXW1wfhlW2wMZzvTHnwn+xAEeL+zRXVRLrNY4QImeWn8Lt2UmUSoICBHtizi4p1XBZrEbRXICI8LNxD58+Q0Ae3iksgq5yaTgqMRYO4GgsYeR6PIKGdt3uBXvPryqfUsmdIjbZrU6N6hSZTLU1tGelFtyqg+mDt5CMYM6o59G+frVKz2bXksmz0aq+ePx571c0HjZikyrHCK69CivnzJbOmsUcibKzsFmZV/OrfAj9VDb2xSJEsKelltzcIJsp6xQ3rIPD/XqIptq2Zgxrj+6NnpL8wcP0CGU75eXVpINy0G9GwH0oncJKQrralnePPyaeSUdennoTpKFiso4/6sWxNzJg3GmMHd4eH5EUVFr6+MsNJCE+lybJjh6M4lCE9sWHX8LVr0ECZOV8ykfU7JssI+GvOxOnseNykzhf9ZkzAOsJxAciuPX05iZrsnTlMY0ek1vvY4AMa/x2/8oXE284UP44Qx6KeXgIyr692jvXEQ++MpgRwqv4Ewt3/26tZOdVuDvvgXegOxG8f2hT6B+KnG/2JFz6qVSiNHttAniMP6dkSLRr+Kx/UnY0UXrtQ2BP4ZPBE0pVoz0ZtML7DlzJ7ZqhWpyuC1asuMClu/dR+atO+HZh0GyHl9jaKl9/0Hd3TuPRotuwxG/xHT4OPrK8Ppbci+w6eiet02aN1tKI6euiDD48oiXdHmcEySUacuGboZSkbv5OrnafpIjr7iFRwQ9ZkKdApa2bF24w607twHzdv9AxrbaeXiVVtc2iJNkTLnD+LGJhXsHJMhWZZKyFS2W7T0XX8qJHS+4C+lvPcMxIQN+65tXwAAEABJREFUZt4M/BIfW6uqlcvj7qXDmD1lJCaM7I8zh7eie8eWVleHC2QCUSFgbv/s3T165+So6GFpHjXcQFy/dQ8jJ81H+54jdDJ93irp3r73iKVNSRDpqDeVelX1G7ti3XY5z2/bHkN1awrTTxPb7jkTB4F037BkMhr9Ucvq6qjK4KUd+cHjZ3IHJrexRLX1T569wvK1OzBv8mCMH9oDo8RBox0LpF/mNHHwlC9dDItnDEcy0bW/asNuGe2SyBn/dP4L+zbNQ/MGtWV+GRFHFk7JsiJPrfnI89N85K45C/l+XQFzvb6RaU4ITHcdRQE00Zj9IDL1W5p24vT5aNWpNzZu3YPtuw+ge5/h6NJLfS8FUXuePnuJxSvWY97iVbh5+x4FRUvsHJMiY5muYnsvR/66q5GlYl9E9wMReQpVwB8jn0E7LdlPg57AJW0R0LhuqOyXKWN6NG/0Ozq2aYoiBfOpTDtWJ6ET4P0zcnvA0HFzUKxwXt3nhekzw+nTukp/yaKmQ5giV3r8T920fm3MnzLUQCjMii1XfVGmVkssqkw7MM25S2tzElXVaOoSmtYjsUsipE/nivx5cuDcxesw/p08exm1fqgsg2t9XxnaNyZp+h3XVClgp9GgUvkSCAgI0PX+ysRxZOGYNCOckmezjrYhQSblhNDE+Srr4d34ZVodfWU3bN4lJ8fWD4tt976Dx1CgdDV0+WcI/u43EmWq1JaGb2zrZVz/4L5d8VfjPxBglwKe/olB01XNmTLKOBn7mQATYAJWJeDs5IRfalSF9vPCtKbpyWidOWM6q9bFhcVPAho1NYt2XJrXkdbmJKq6vvvghozpv077RAeH8Xy+n719QD2UKVMkk9VkyZROTrgsPXqLLTsPgiYxT+TsrBea8JzOKXKJRocAIV/FPlFKqKmHl6ZPeyieGAhFDf4/fvqM5y9eG4TFtmfKTNMv4YybPDe21TKpn14CnDV5BG5fOIj7V45gxYIpsHhmDpPSOIAJMAEmEDYB/aEK/Xq0NknYo30TkzAOYAJhEVCVwatV0s/fH/Txie79xxkMb9DGG69nLVqDtj2GmcjazXt1SRXN16YqiqIL13doDNJ8Ta9Nc/XGXazauBuDe30da+Xr6wtbCPUik8Fmi7KtUWaKPHUFFsGRWH6RFHl+twmLqOpLDL+tVFboafifP28upEubWlW63rn3wFBJ4Xvz7j0eP32mKj2128LPz09OX6P189o3WtuJeUaPn/H+xzzjNk+69olTIPYcOEErKYXMTElKT19lZBxcsMoxT8DUqot5HUxqHD5+Lt59cMf7Dx6oW+s7JHFJhPx5spuk0wa0bFwXk0b8YyJ1fw6dhDxN6lTw8PDUJoebuwfSuqbW+clBwx2CgoLhHxBAXnwQaegLI9IjFu/eu2HmwjWYOb4faEoUEST/7e3tYQuhMZGKotikbGvoG+iSF8svFdTNb7vgVBZ8ci6pOn2H9O2GXDm+DuNInzYNxo/opzo98+bOKfcn/UW6NK7InDGD6nSl/Yf2TxJys0T/HEAsSZhl9FkSQ2JJQm6W6DMlliQxxVJRRGeK/smQ3UzACgRUafDSY+h/OjdH4sSJUOO7bzBRGLPPX74Js7k0vIAmRjcWJ0dHmadS+ZLy6yDUc+zm7ombdx6iXOkiMo5mYNB+raVi2eI4cOS0DN9/+BQqlSsu3TR7w4BRM9C/RxtkSPd1aARF2uoEQL3NJLYqP7rljp44GzOX7MDyfa+wbN8bLFh7BPQyWHTLtXb+IoXy4+qZvTh/bDtOHdiIB9eOoVrVb1RnRP7dxfhxHdDn7/aq01N/+8TkBVC/3vjqZp72Vt3fmWfc5UnXPrq+sjABaxJQpcGbOLGLbGNgYBC8fUKnBgsIMH1JSiayYJEtSwbRU1wNrboOQff+49GjYzM4OjjInL2HTgF9gYk83ds3xo59x+S0ZE+fvULjerUoGBu27ce1m/fQsE1vVKjRRMrrt+9lXEJdHDkeemOg3/7jp86p7mUwrX40Ib3+J1y14WpZ09e1bp0/iBkTh2HymIE4d3Q76FOuatGP9WACTIAJxBoBrpgJWIGAxgplWL2IJIkTw8PrI74RPa4tOg9Ei86DkD6t4RCEyFb6Z50aWDl3DJbPGYUqFUvpsv+7eT5cU6eUflrPmThQTks2elA3UM8xRXRoWR+n9600kPRp1TXRPunJErcJZM2SES2b/ikN3YL588TtxrD2TIAJMAEmwARURECVBu/U0b1Bn7hr2aSuHEbQsVV99O7WUkXYWJWqlSuYQKhcsQzoMaJJhO0DuAYmwASYABOIZwSoA0rbpHsPn8iOMK0/suu3b1+DJf4wiOz2p/SqNHhJMV8/f1y5fkf3EtnFKzcpmEUlBLTzsaZPlwapU6Xg+VhVsl1YDSbABBI6gfjZ/gEjpyM4KFg2jt7picyHqVKlSg2W+MdA7gyRWKjK4NWOj6X1/2q3lFOSde07FlqJRLs4qY0JaOdjfXD1GJ7eOs3zsdqYNxfPBJgAE0jIBAIDg5EqZXKJIFOGtHj7zk1+ZY0+UvX46QsZzgsmEB4BVRm82nGytFM3/O1HOd52w5JJ6NCiPur8FDrFWHiN4TjLCHAqJsAEmAATYAJxiQDNqx5CHzoSStML7TRXr/YDVQ5fXkIXUfzPBMIkoCqDV6uln58/urZrjDw5s4G+itaswS/w8PLSRvM6CgQCvN/C/cFeuN3bCT/PJ1EogbMwASbABOIdAW5QHCGQK0cW7Nh7RGq7fus+5M6ZRbp5wQQsJaBKg5fu4noPnYwjJ87j3KXrOHn2Ep4+f21pmzidEYGPL87g7o6WeHl+Jl5dnIv7eztJw9coGXuZABNgAkyACaiSwN8dm+PA0bP436+tcOnaLfTu2lKnZ/06NXVudjCBsAio0uBNnSoFTv13BWOnLcKQcbPRb/g0BAQEhtUG24bHg9Lf3dpg0op3N9eahHEAE2ACTIAJMAE1EsiaOT2mj+2Lw9sWYeLwf5AuzdepSpv8GTpnvhr1Zp3UQ0CVBu/6xROxfvEEtG5aFy0b1cH6JeSfqB5qcUwTP69nJhoH+nogOOCTSTgHMAEmwATCIsDhTCA2Cbx68w4bt++XQu7Y1IXrjnsEVGnw0pAGr4+fdTQ9vT6BwnQB7IgUAadkpmOd7J1TQOOQJFLlcGImwASYABNgArFBYNf+Y2jcth+27zkqv37aqE0f7D5wPDZU4TrjKAErG7zWoTBu+hJ0/GcULl29LaVDz5GYOHOZdQpPgKWkKVDPpNVpCjYwCeMAJsAEmAATYAJqJLB97xHs2TBbzt60btFEbFg6GcvWbFOjqqyTSgmo0uA9f+m6HMYwamBXkNDwhjPnr6oUofrVSpqpPPL+shgZS3dGhpLtkbvmLKTK87P6FWcNmUBcJsC6MwEmYDUCaVKngpOjo64811QpkCRxYp2fHUwgIgKqNHgdHR1AO7NWedfUKeHgYKf18joKBBxc0iJlrprS0HVKni0KJXAWJsAEmAATYAKxQyBJEhes3rQHb9+74cHjZ5i5cA1KFM0fO8pwrZEmoIYMqjR4E7u4oE23oWjecQAat+uL2o264IObpxp4sQ5MgAkwASbABJhADBPYtvsQZsxfhV8bd0WTdv2wasMuKfRlVpIYVoeri4MEVGnwBgcHISAoCC9fv5WfD8yRLRP69WgVB/GyykyACVhGgFMxASbABMImcHrfSoQnYefkGCYQSkCVBm+qlMmxdOYI/Lt5gZD5mDamL76rXC5UY14yASbABJgAE2ACTCC+EuB22YSAqgze+cs24PXb93j+4g3GT18M8uuLTQhwoUyACTABJsAEmAATYALxmoCqDF4taXevj9iy6xC27jmMXf8e14k2Xk3rwMAA2ELKly+Hn3760SZl20JftZcJhEBREF94xno7mKd1j3uaZ5z3T+sxZZ7WY0nn9pCQ4Bg9fwYHB6vpMs+6xBMCqjJ42zavh/RpXdG22e/yE4LD+nTEwJ5tpTT5U53TaIWEhMiPYlh7nSZNGmTKlMkmZVtb17hQXujxqjBPK+2vzNO6xz3zZJ5qPo/S/qkoMXf+pPosF07JBCwjoCqDV6vy/sOnUaZEYQPZtuuwNprXTIAJMAEmwASYABNgAkzAYgKqMnifv3yDc5euw8vrE0ZNWoAWnQfKackatumNZy9fW9woTsgE9AmwmwkwASbABJgAE0jYBFRl8F68eguLVm7B0+evcfrcFTx++gqBgYH4/NkXlcqVSNhbilvPBJgAE2ACTCB6BDg3E0iwBFRl8NauWRVzJw1CiuRJsHPtTOTNnQ3rFk3E9tXT4efvn2A3EjecCTABJsAEmAATYAJMIOoEVGXwapuRPp0rAgIC8fHjZxw/c1EOc3j/gb+0puVj0zUXzgSYABNgAkyACTCBeEZAlQZvQEAQfm3SFTSmt/+IaejSZwxev3kbz9Bzc5gAE2ACTEDNBFg3JsAE4g8BVRq8/gEBWDxjOArmz4WZ4/qjd9cWqFCuZPyhzi1hAkyACTABJsAEmAATiDECqjR47e3t8Padm+jVfY9ihfPh2wql4ObmFi0o67fuQ5P2/dCswwAcO33RbFnvP7ijc+/RaNllMKhn2cfX1yCdu4cXvvu1NeYsXvcl3Harz58/w9OTh3FYkzDNc2nN8hJ6WczTunsA82Se1iVg3dJ4/7QuTy4t5gmo0uD99PEzxkxdJMfwbtt9CGcvXMP1Ww+jTOfJs1dYvnYH5k0ejPFDe2DUpPnw9TN9CW7avFUoX7qY7F1OliwpVm3YbVDnpFnLUbJYfkCB7ufg4AhbyKFDh7F+/QablG0LfdVeJr5sNLXrGVf0Y57WPe4VJfSkEle2v1k9bXQujEpdisI8o8ItrDyKokFICGLseqTRaMA/JmBtAqrcq4KCguSX1rJkTo8DR89ix76jSJ48cZTbfuLMRVT5pjQSuyQCvRCXP08OnLt43aS8k2cvo9YPlWV4re8r48TZS9JNiyvX7yBRIicUyp+HvqpKQSxMgAkwASbABJgAE2ACcYBATBq8FuNIlTol0ghxdnbCjHH95FRliZycLc5vnPDdBzdkTJ9GF5w5Yzq8ff9B5yfHZ28fUKdAyhTJyIssmdLh3fvQYRQ0F/CMBWvQpU1DGccLJsAEmAATYAJMgAkwgbhDQFUG78n/LoME4tHJms174PXxk+xlHTJujujhTRotqoreIxJFCX3cZVyg/mMURTzC0cbT0IbffqmGZEmTaIN068+fP8EW4u/vh4CAAJuUbQt91V6mj483fH19mKeV9lfmGd3j3jA/8zTkEd3zCfOM2zwDAwN011ito8rPLRCeaNPxmgmERUBVBu/6LftA4uLijNUbd+HR05foPXgyLly6IfQXVrBYRuU/TepU8PD4+gKYm7sH0rqmNiiKhjsEBQWDZoigiA8iTRrXVOSURveICfNQoUYTzF+2AcvX7cDUuStknItLYtPb8RcAABAASURBVNhCQsdSOdikbFvoq/YynZ0TwUk8JVC7nnFFP+Zp3eOeeTJPNR/7Mb1/2ts7wPh3dOcShCfG6dkfhwjEkKqqMninjekDktkTBmDH6pnYv3Eutq+ZIb+6NnvCwCgjqVS+pPyABX2tzc3dEzfvPES50kVkeZeu3hI9qYHSXbFscRw4clq69x8+hUrlikv3gqlDcHrfSiltm9dDs/q/oHv7pjJOURQoim2EKlAU25StKFyuojADRWEGisIMFIUZKAozUBR1MKBrHwsTsDYBVRm85y5dB8npc1cwYuI89Bs+DY+ePMf2PUdEz+rGKLc9W5YMqFurGlp1HYLu/cejR8dmcHQIvYPsPXQKPL0+yrK7t2+MHfuOyWnJnj57hcb1aslwXjABJhCrBLhyJsAEEjiBXfuP4dfGXeX0omfOX4GHuG7PmL8qgVPh5keGgCYyiW2dtmvfsSD5e+AE7P73OC5cuSn9Y6YuxJLVW6NV/Z91amDl3DFYPmcUqlQspSvr383z4Zo6pfTTes7EgXJastGDuiGRs+mLci0a/YoOLevL9LxgAkyACTABJsAEbE9gx96jWDhtKPp0bYmla7YjRbKkuHLjnu0rVl0NrFBUCajK4CVDNF+eHKCZEnaunSk/OqEdSpAjW6aotpHzMQEmwASYABNgAnGYQIoUSUHv1RQpmAfBwcGyJT4+hh+HkoG8YAJhEFCVwTt2SA9MG90H9nZ26DN0Kh48eoY9B07g02fvMNTnYCbABIwJsJ8JMAEmEN8IpEyeDPRuDbWLZlQ6evI8gkOCycvCBCwioCqDlzROniwJqnxTRkhpJHFJhPHTF6NF50H4X+WyFM3CBJgAE2ACTIAJJDACW3cfwpCxs+VsSbfvPsKWXQcxZnCPiChwPBPQEVCdwevp9Qn0YYitYmd29/oIF2H0/lm3Jlo1rqtTmh1MgAkwASbABJhAwiGgHd5I6yM7FmOqeBqcPUuGhAOAWxptAqoyePsOm4I6Tbth844DGNqnI45sX4xda2ehXu3vQY8wot1aLoAJGBNgPxNgAkyACTABJhDvCajK4D166gIypU8L+ujDrEVr0b7nCAOJ91uDG8gEmAATYAJMIJYIqLla+vBTeKJm3Vk3dRBQlcE7fWxfdGvfGPnz5EBgYCCKF8mHSuVL6EQdyFgLJsAEmAATYAJMICYJNPrjJzT6/Uesnj9OCrkpjIY4kMSkLlxX3CSgKoO3TInCIAkMCoK9vT0uX7uDE2cu6SRuIo5PWnNbmAATYAJMgAnEPIGz56+hS9vGoClKScj938XrMa8I1xhnCajK4CWKZOz+ULUC5k4aZCIUz8IEmAATYAJMINYJsAIxSsA/wB/uHl66Osnt7++v87ODCUREQHUGL83BS2N5I1Kc45kAE2ACTIAJMIGEQaB5g1/RoHVv3Xs95G7eoHbCaDy30ioEVGfwUqtoWrLVG3fDzd2TvHFVWG8mwASYABNgAkzACgRq/fAtls4agepVykkh90/ff2uFkrmIhEJAlQbv5p0HMGPBatRq0ElOMq19MzOhbBRuJxNgAkwgfhHg1jCB6BNQFAXBwSFymlIHB4foF8glJCgCqjR46Y1Lc5Kgtgw3lgkwASbABJgAE5AE7tx/jCbt+mHpmm2YvWgdWnUZjAePn8k4XjABSwioxuA1VjYkJAQPH7+QQm7jePYzASbABJgAE2ACCYPAlNkr0K97a+xeNxu5c2bFvMmDheG7NmE0nltpFQKqNHi37T6E739ri659x0j54fd22L73iFUazIUwASbABFROgNVjAkzAiICHlxeqVSmnC02fzhUf3L/O2qCLYAcTCIOAKg3elRt2YWifjtixZoaUwb3aY8W6HWE0gYOZABNgAkyACTCB+ExAUQzNlVdv3sHZ0TE+N5nbJglYb2G4B1mv3GiVRB+doC+sKYoCRVFQuUJJaDRKtMpcv3UfmrTvh2YdBuDY6Ytmy3r/wR2de49Gyy6D0X/ENPj4+sp0l67eQt/hU1G9bhu07jYUPG2axMILJsAEmAATYAIxQiBLpnS4c++RrMvN3QOtug5ByyZ1pJ8XTMASAqo0eO3sNDh97opOf/rammM07uSePHuF5Wt3yDE/44f2wKhJ8+Hr568rX+uYNm8VypcuhsUzhiNZsqRYtWG3jHJJ5Ix/Ov+FfZvmgeb9o/wyIoYWnvfO4uGGEbizpAdeHlqMIB9+jBND6LmaOECAVWQCTCD+Exg/9G/ky5NDNnRY307YunIaypYsIv28YAKWENBYkiim0/Tt1hITZy7TTUk2de4KUFhU9Thx5iKqfFMaiV0SIX06V+QXB805M58kPHn2Mmr9UBn0q/V9ZZw4e4mcoIPMNVUK2Gk0oJ7ngIAAXe+vTGDDheedU7i9oBPendsGj1vH8WzvbNxe1NWGNXLRTIAJMAEmwATUReDazXvQSmBgkOjtfazzU7i6tI01bbjicAio0uAtXCAPNi6dhFXzxknZsGQSCuXPHU4zwo9698ENGdOn0SWiD1u8ff9B5yfHZ28fKAqQMkUy8oIen7x77ybd+ostOw8id85sSOTsrB9sM/f7y/tNyv709Dp83z42CecAJsAEmAATYALxkcDUuSsRnsTHNnObrEtAlQbvrv3H4On1ETmzZ5Li5uGJPQdORKvliuid1RagKMKy1Xr01hqDNKZort64i1Ubd2Nwr3a6XP7+frCFBAUFIigoCL5uL3R16Ts+vrpnk3pt0RY1lBkQ4I8A0TOvBl1iVQcr7a8BzNOqxx/ztO55lHlan2dgYIBV9/nwzoPBwcH6lzvpXjR9GMITmYgXTCAcAqZWXTiJYypq1cZdSJE8tKeV6kydMgWWr91GzihJmtSp4CGMZm1mGvCe1jW11ivXNNwhKCgY/sIoooAP7h5I45qKnFKot3fmwjWYOb6f6P1NL8NooSiK6Bm2vgBUJpA0RwmY+yXNURKKQmlYFMVSBmBmFrOyhCnzVBRLOFmahnkqiqWsLEnHPBXFEk6WpYH4KYplaRUleulEVTHyz5UkLAKqNHh9ff2h/7EJcvv6BUR5y1QqXxLHz1yEn78/3Nw9cfPOQ5QrHTrYnWZgCAgIlGVXLFscB46clu79h0+hUrni0k2zNwwYNQP9e7RBhnRfh0ZQpIODI2whdnZ20GjskKlKUyTJXoyqkqJxTIQcvw+Ac7LUNqnXFm1RQ5n29g4gUYMu8UEHYkkSH9qihjYQSxI16BIfdCCWJPGhLWpoA7EkiSldNHpPW+WFT2/xS6Mu0le3aXe55gUTsJSAxtKEMZkuU4a0WLhik67K+cs2IluWDDp/ZB2Ut26tanIak+79x6NHx2Zw/PId7t5Dp8jhE1Rm9/aNsWPfMTkt2dNnr9C4Xi0KxoZt++Xg+IZteutepHv99r2Ms/XCLlFSFOq4CCUG7ELhbitRZuRxpC1X16Ta4ABffH5+CwEfY0YvEwXiZQA3igkwASbABJgAE4gPBDRqbMSwvh3x4tU7VPqxGSr/1Bxv3n3AkN4doqXqn3VqYOXcMVg+ZxSqVCylK+vfzfPhmjql9NN6zsSBoGnJRg/qpnsxrUPL+ji9b6WBpE/rKvPE1MIxeTokzpRfVuf77gme7JiCO4u7y/WzPTNxfsh3uD69KS6OqIlb86PHCvxjAkyACTABJqBPgN1MII4TUKXBmyplcgzt0wE71swUMgP0pTXt7AlxnHe01Q/87I5rUxri1fFVoGnKXh1biZeHlyIk0F9Xttf9c3h9fLXOb87Bc/uao8JhTIAJMAEmwASYQHwkoEqDVwuajFz9l9e04QltHejtifcXd4OM22c7pyJYGLcKQfjyYgA5jeXzy7vGQfB9/xQ+bx7ARnP7mtRHAUG+n/D5+U3QmvyWiFZPS9JyGibABJgAE2ACTIAJRERA1QZvRMonhHi/D89xeeyveLB2MJ4KY/fthV1GzQ4x8od6Az9/nUPY581DXB7zC66Mq4urk/7EnWX/hCbSW9pibt9Hm0bj/OCquD69mVw/2jJWr0ZTJ+l5ZXxdXBn/m9CzvhyeQb3Vpik5hAkwASagZgKsGxNgAmojwAav2raIkT6vT64z7B0NMTJwyWscJsqgl9hen1grv9D2YPUA+Lm/AkSPsFggJNAP5n4+7x7rgj8+vICbc9vi3MDKuDLhd7w4uFAXZ4mDepHfnt1skPTt6Y3wenDeIEzf82zPLNEL/UwXRC/gPd42QednBxNgAkyACSRsAoXy55IACubLKde8YAKWElClwUsvqRk34OXrt8ZBcdpvqfI+bx8ZJA2RRqteEPlpfIM0eoX1S2shXg8u4sn2iXi4YQQ+vbwHiDBdLpFM59ZzJM6YTw4/8Pd8gztL/sbHhxcR7O8Deknu+b65cLt6QC91qFN/+MGzvbNxeVwdnBv0LR5tGReawGhJ443vLOkO6v39+OgyvF/dg9Yw//T8hlFqwOftY0RmOIS2ACqXese1fl4zASbABJhA3CcwdnDodGSjBnaN+43hFsQoAVUavH2GTQV96ldLgqYA6zFgvNaboNaJ0uYwaC/ZtmS8JkqXExp7RyRKn1usnaHtvQ1dw+BHNjFkxq/BIfhq9dLcvklzlMClMb/I4QeXRv6EIL/PXxN/cXne+++LSxiibx5Cf/jB+UFV8PLQYpCRGeznLde6xHoOz7un4XHrBKj39+acVvIFPK1hHuD13tAwF/k0Dk6wc0wkXF//yQD+HMa4YI/bJ3FhaHVZLhnfNITjo+hVfn9uG96d2STHMH8tiV1MgAmogACrwASiRGDSrOVRyseZEiYBjRqbXb9ODZDRGxQcDProQ9e+Y9C1bRM1qmpzndJ/Ux92zkkM6klTri6K9lyPMqNPoejfa5G/9XQkzVkSZLg6pcoISAsXhr+v9i0o3s7BWTe3b96m4/Dx0SVhR4tEoidY3xiG0U/bc2o8/CDI75NhSjKwRVkGgSZ+g9hQD+ULdcllspyl8HDTaNHj3EMa1A/XDZXjgcMaF/xo8xgEenvIvLSgccE35rXD061j8XznZDk2+M2p9RTFwgSYABNgAnGEQPueI2Asew4cR++hk3H52u040gpWMzYJaGKz8rDq/rF6JZQokh8jJsxDF2HsdmrVEN98+epZWHnia7hT6swo3ncbcjUYjqw/d5cfocj5x0CD5iYVRmHB9vPlRymK990OjTBmDRKQx8iQzFqrG7Rz+358ck32rCqKSKQVI+M0RPg/XN6n6zn1uH1C5qGizYsoS0S4lvgJKfJXQvK85YWP/kPDRWaQ4Q2jn71LCqQuXhOpilRDuop/gup5J3pnaQq2Z3tn4d2FnQY5aFwwTdFGM1i8Ob0B/h6vDeLJo62R3CQvDi6iFQsTYAJMgAnEEQKtmtSFsdB8+DWrVcK4aXxOjyObMVbVVJXBe+7SdWilaKE8ePz0BUoVKwQXF2cZHqukYrFye5fkcC35EzJ828TgM8NhqZSpWkuDKMVpady9AAAQAElEQVTeCbkbjpKfJM5epzeK9lwnjMoauqnOPj27Dn3jU4Ei/IB94uRQ7BzgkDQ1NE6JDIY5hAQHAZQOX36ic/iLS7eyT5ISuRoOR76WU5Gr/jBAEeVC+xNuYURrfdp14iwFkbvRSOQRvc5Bft7a4NC1mToo4un2yXIGi8ebx0o7msLCk4CPHxDk8zG8JBzHBFRLgBVjAgmRQJkShWEsJYoWwHeVy8LJySkhIuE2R5KAJpLpbZp80cot0BdnZyfcf/RUF2bTyuNd4SFfjD9ah0ijNW25urLXVGPvBP2pzjxvnzJtvcgW+NkTIUEBIAMxxM9XpBGBYvn1X88vjFmXjPlAPdIaJxckz1MO+VpM1SUloznbLz2g2DvqwpxdM+vcWkfGKs20Tvi5v9S5w3UI21nGCx2g6OkkA8XCKIh0sUuUVETwPxNgAkyACcQlAm/fu2H73iMYOm4OTpy5KFVfOmukXPMiwRGIVINVZfDOnTQI4UmkWpaAE784uFi0XliB4h9QhNHqj5dHvw7uN5nqDMY/YSGS8agfTGWJYP0gx1TpkChzNiTKmAlpKv2MIt1XoXifrSgz4hjyt5mFJFkL6ydH+sqNUXrYIRTuugIlB+1FsT7bUKTHGmSr/Q9y1hskxxQny10G/h9fws/zCWj8rkEBUgcjJYx6icmbKH0upCxUVfaKZ/zfX4BRWzJVawX+MQEmwASYQNwhMGryAtRp0g1N2vXDqf8uo2C+nJgxrl/caQBrGusEVGXw6tPw9fPHlet35FAG7TAH/Xh2mydAvaI0B69xrM+bR7og46nOpEFIlqI2hZFNqQ0GGZw6D6Ak8YFdOj/YZQiCj895vDw/ExH9NA7OSJy5ABySusqkLhnyIH2lBkhT5leEKH64vuQPXJv5J67PaoQP97fBJVNumY4WGkcXZK7RAWQ407hg19K/ULCQr4opioKUBSojb/OJoHHPWX7sjBL9diBjzfbIUP0vOZyDxgaLTPyfEAhwG5kAE4gXBM5fuoFgcZ1q3qA22jT9HX/WqYHMGdPFi7ZxI2KGgCoN3sUrt6Bu0+6YtWitbjgDDXWIGSRxuxanlBnNvrSWKN3X6c2MpzqTLRaGYs76w0Avs2X/ra8MMl6kyFdR13OaOH92BPkE4vPVN/h8+S18H7rD/c5+ICTYOJvF/gebBuLzrccIdPdFoIcffB+/RVCwJwp1WYpcDUfKl/IyVW8NGhohxwX/OQSpilY3KJ9eektX/ndd2Ntn13FuW2d4vduKj+57cXXf33h49aAuPqqOAO+3cH+wF273dsre6KiWExP5tD3m1qqL2u75aD88HuxRfdut1WYuhwkwgdglsGXFVMwa3x+JEyfC4tVb0bRDfwyfMDd2lYpjtSd0dVVp8J4+fxW7183C/ClDDIY4JPSNZWn7M5l5aS2j3thYs1Odla2DNKVqIUOVpkhXoZ6cJUG/PjIkM1RthmS5SiNZzpIIePsage99EBIQgpCgYGGk+sHnwTsEeL/TZaMPVjzZMQV3FncHrcmPcH7eTx8axoq7eb9X73Bjxl94sGYg6Ktvb89uMUhDL7cVaDdXzmCRu9EoFO+7FY4pM+jSXNgzGikS+en8SZyC8PTsNJ0/Kg6vp8dwd0dL2aP96uJc3N/bCe9urIlKUQZ53O5uw8N//8aDfV3x9tpKg7ioePy8nuLerra4t7ut1PHOtqb4/OZKVIrS5fn06rxs+5tLc/Du6kJZLhn9ugTsYAJMgAnYmIBGdNCEiOtDcHBYjyNtrAAXHycJqNLgTZkiKRTl62PqOEk2FpXO+F1LFOm+6uvYWGEE0thYrUr0YlnxCKY6MzYk01X8A7fmdYD8SMTGkfD74AuIE462TFoHffIXxmlb0JfWbs1ti+vTmuD18VVyajFa09y5gZ/dKakU+krb3WX/4PyQ/0F+7MJblCljzC/oq2+PNo2C8QwLZITTDBapi9cwnbM4kadJYa7JghHgG/VZGl5dWmBS5ruba03CIhPw8r8poHJ93O7C1+MhqLxHB3tFpgiTtG+uLoP/p5e68EBfd7y8MFvnN3VEHHLpwAyTRA/OLjQJ4wAmwASYgDUJ0FPfjr1G4eMnbzSt/wtWzh2DoX06WLMKLiueE1Clwevs5ISBo2biyInzPIY3ijsgzZigHRvrkCyNSSmWTHWmb0i+OmrY4yjvR4zvScTNtvZLa14PLiDI38eg3iC/z3C/dUIX9mDtYLjfOCINWH+vt4CFd+ufX97RlRGRw97ONIWCEGjsHE0jLAwJ9Pv6YQttlpDgIAT7e2m9kV67Pzluksf73S0gGkNEvN9eNynT/+MLBAd8Mgm3NMAFH0ySujgEwu/ze5Pw2Azw9PqIHn1HIG+J/yFT3nKo/1dn3H/4ODZVCrPuLTv2oV23/mjS5m/Mmr8cPj7h3/iFWZANIz5++hxneNoQQ4Is+tXrt1i+ZjPmLV6NK9fFOSmWKJQsVlCcDkOwYt0OLF61BRu378erN1+fKFpdLS4w3hHQqLFFNO3Iezd3rN2yh8fwqmADhfUinLAbTbWTlrAINjaGRRD9+7mF9jhSL+2np6YGGfTzafQ9lDtUHL+88BbqC38ZFOIgEwT7BiLYJ0C6Q4RhbmcfGi4DIrlQFHN5hRHtkCSSJX1NHhLs99WjdYnm+7jf1/oivQ4JDm2vcUaNnbNxkMX+EASbpKVHi6/fG97cmCSK4YCho6eKC/QqPH/xCu4entix+wCatu0Rw1pEXN3CZWvRpHV3rN24E7v2HkLvQWOk8RtxzphNMWHqPMxfshovXr6Gh6cXdu45iLZd1fmGPOm4fM0Wsf1X49rNOzELKhK10Y1O68590KBFF9Xe6Bw5fgaFyv2ALv8MQb+h41Gx2m8YL/aFSDTTakkH/dMWO9fOxOIZw1GxbHFcv/UAHf8ZZbXyuaD4T0CVBm9YU5PF5uZYv3UfmrTvh2YdBuDY6YuxqUqM1+0UxotwvsI6DbEX/aXCMPUTRqTwRqBbCNxvHgGNxb0+o5lIS5nESvsvjGWNsz1cCrnCpWBqJMqVQhujW7tkzIM3Z7cgrHHBBsMkRtWC8lbB52tv4H3jPbxvfsDnq28R4JsaUKK+6ydJVxQADMQxSSZEp8yPPkYsAAQFB8PPLr1wRe2fDFHTnCEI8DHtpTVNZz7ETmPKTRFJM7pGvcdcZLf6/6Zte6AoioFcuXYLXh+j3rttdSVFgSvWbgFtpxBx9yhF3I1t3r4XQUFBIlY9//sPHkOI2B+DxVOYECHB4sbn3IWrquO5e/9h5CleFZ16DkLvwWNRruqv6CPW6iEZqon2RmfVhq3Ytnu/am90Bo+cBD9fw5vx0RNnhTYilpY0M0PtmlXlcAZ6kQ38YwIWEjC9elmY0dbJAgICxR3cPVUMaXjy7BWWr92BeZMHY/zQHhg1aT5o2jRbM1BT+ZmqtTRQxzcgBAP2+6Daok+otuQTZp6mk6Kil0aB/kcm6GKusXeC98t7oLG4vu+fibSKEMN/++ROIKNXk8gBdsmdkbhQZtCUZSkKVEam71rA7/1zk3HB7tcPgz4t/OHyPjxYPfDrMAnPNwh49Qwh/iG6SkICgvHsQvR6fTKV74nkWStDY+8CjZ0TkqQrgexVR+jqiIpj6392EDaPXtYQbD3ljaRJEuuFRc6ZJENJkUG0XRhRIBE+x6SZ4ZA4nXBF7V9Jll9k1CtTlOunpIhWmaJAq/9//vzZtEyh9qfP3qbhsRhy/cbtUKMcSuifMNKDhWF5/+GTWNTKtOq37z5A0Wig0Qg9hQgXAgODhF9dl5BuvYdJ5TWK0FAIeWbMW0orVclMoRPd6AgtQULu9Vt3qe5G5+oN03NlQEAAnjx9YcTT9l4Pr4+guXh/qt8RJOSmMNvXzDXEFwLqOlt9oXrizCX81qw7uvcfjwkzlqBr37GYuWDNl9iYX504cxFVvimNxC6JkD6dK/LnyYFzF68jIf0yGr0I13SzNy69/vp4e9e9QKy44gcH6g3+8qW1gu3no/TwIyjcdTnyt5iK4EB/E2ROKTOAvnrmmDwdUhWvAof0hgZexoqt5Ucp8rWYAkpjblzw3eX/4OnOqbi/qj8+Pb8Jk58wyvTDXJ0C4f/ZUz8oUm47x6TIXKEPCvy+HgX+2IRswtiNjhFJla856obaw55gzo4PWLz3AxqMfobJW97Dzs6OoqMk6Yo2h2MS6nlWAEWBvXNKZCzVEdH59Z1zDU/fBoDKI3nvFYR+Cx9CbT8FilmVkiWN+rATswVGM9DB0dFsCblzZjMbHluBH9zdxT1TiLgn+yJ0TCkhSJLYJbZUMlvvy1dvoChft72iCLe40bl+867Z9LEVePfBYxM9NVCgthudAH/TczbtAbHBbdi4uUjrmhJ9urZE9/ZN4CSOHQqLDV24zrhJQKNGtWn+3QXThiJ3zqxYv3gSlswcIdyxdwF498ENGdN/ffGLHqm8ff9Bonvw4AFsIe/fv4eHh4dNyo6qvq987PE5Qxm4Jy+A92YewS++FIDXxTsj1V9L4PDd33gTkAiPX7zBaz8nvH7vLnkZL5T0hZCy2UIkazAdmnId4VxiGByy1YdD1j/gVKgv3DUFdAxe379inD3ULy5ooQ7Lln5BITh9/oqu3KjysGa+9+/c8NotEEv+9cDc3R54+DoA/v6BuHv3bpT1fP4uAJr8feBUeKBkaV94KF5/ShLl8qi9R889xu8jnuL34U+FUf4UPw18gmOX3XDr1q1olUtlW1N8/PxCDTRhmFHvWYgw1SDkzetXqtLzo5khFoqi4NCR46rSMyAwEIqiQPf3xb12/RZV6Rkkju3goGAEB4stLiQoJFjuB25u71Wlp1BL6iX3zS/7KJ29nj17qio96UMPpCPpphWhLq5cv2ZTPT9+NJ1Fx8nRHm2a/SE7n374X0X807k53r13A/+YgKUEVGnw2tvbIX1aV9CwBmoI9ah6+8Tuo0hF8xWVoiiklpTx48fDFnLo0CFcuHDBJmVHV99JkybJtptbbNu6yazOM1Zug0+wnUmWPRceGqSfMHUhJi05gUlLT4ve/RUGcdvO3DPJbxAgt4sZ61eGf0154EEgFi5aZFB2dJlENz8ZY181DHUpioJ2Xf6Otp4Tpi8xYRlVfSF0UhQFz94HSKMc4lBQFAW9+w2Mtp5R1clcPhr/LCkK/UhHYetC2D/o0buvqvQkg0LqqbcgA2PhggWq0pOMHD0Vdc5NG9erSk86jjR2Gmg0ChQhdkroeXvq1Glq0lPyUxSho54IEx0TJ6tNT4WQGhjndCytWLrMpjyvXr0qGekv6Jj20+txdnP3RNKkhk8E9dOzmwkYEwg9GxiHxrLfJVHoW+QpkifBtt2HcOLMJbh7fIw1rdKkTiV6W78+Andz9xCPVlJLfebNmwdbyJ9//olq1arZpGxr6Nu+TWN5EqQLNl2gSSqVLxOmvrPmLUKpTnORNGdJaBwTwTlNNmSu0R59Z64PEHV/7QAAEABJREFUM4+xnoNmrUXacr9J7tqFNG/FRUPrp7Wza1Zoh0lsvuWH8Sd9QEbu0ceBmHLaD5OETJkyxeJ6jfWwhR/SKoPBj5ge2L1NVXqKy5+BjuRRFAUjhg9XlZ4awVNRFFqGinBrhEybPFlVeoaIrr4QPWuS3GT41G/UTFV6KrShjURRFPzZqImq9KRtbKQmFEXBmLFjVaWnUMlYTSjib+H8OarSk4xbeY79oi25g8U+O3HSBJvq+c0333yp8evKzy8AvzXrIcfx9hsxFX/81RPJkyXB/GUbpHxNyS4mYJ6Axnxw7IbW+/UH0GD0jq0a4MDRs1i5YSfaNf8j1pSqVL4kjp+5CLq7dBN3lTfvPES50kVsp48NSg7wfgv3B3tBX8Xy84z+CzGnTl+QWtIFRlHoVK3gxq27MiysRdIcJUDjesuMPI5ivTYhU7XWYSUNMzzH7/1144JpfHDqItUM0tq7pESBNrNQethhlBiwC9PP+mPv/WCMPuGHYUf9sONuIEhnf72eAoMCYslDRo5x1WT8RGcMr3F5VvHTFc+oINIzS+aMRqGx6w1RzNfv6+dnPiKWQunlKkVRhF1Be0AIFEUB/ZUtXSyWNAq/2lAtQ2QistNz58gu3apZaBQTVRRFwUevTybhagxQFFP9Y1NPUkf2lguHoijy3KnRxI7ZULhALvz6Y1WkSZ0CObJmQoPfaiBntkzgHxOwlEDs7LnhaBcYFAQvcXJKkSwpcmXPghnj+snPC5coWiCcXLaNypYlA+rWqoZWXYeAXqTr0bEZHB0cbFupFUv/+OKM/Bzsy/Mzof0ULhm+0ani5u37UBS9k7Nwunt6wsMz6h9fsFQfO+ckSJy5IGidp+k4hPdpYQWKpcXGajoyGoODgWCxCBE9KLSG0P3p85h/Gxrh/L48ITZIQUZQ0iTqerRobqsrigIX50QGuse+J9R4VMS2JiF9FEWB2m7INMKQDBEWLulIQu5gsZ+WKFaIVLapRKbw5ElMX0okwqVLFolMMbZPS0oZ16IA9NKdcXBs+2lb0zEuRe4DwNMYmqVh+94juua3bV4P4YkuITuYQBgEVGfw2tvZ4eip0N7DMHSOleA/69SQnzJcPmcUqlQsFSs6RLXSd7c2mGR9d3OtSVhkAsK6yw8rPDJlRzat/hfhyAjW5pdzmZq7sIgEvr7+Yqmef40wcjTiaCR+irAqQ9fAkyfqMnhDRNepvAAKY4eMcnIrUPDqtbq+eBRiZruTrkmSqGtWgRDBzngvJD2DAoOMg2PVHxwsNBX7qFYJRVFkb19sTE+FcH61fjJ84kNJM6RPSytVSYjQhrazgQjGrqlTihgV/SuAoijQ/Qk3xC9AdEyJlc3/9xw4YfM6uIKEQ0BcYtXXWJoFYfXG3aDhAxFrxykiIuDn9UwkEadYsgK+SKCvB4IDov6Yz9nRUZRp+E+PZ2nqNsPQ2PPRcICcObOYKJBE9EbmzJHVJFxtAYqiwNFJXU8ShC0uMClSFIXWgKIosHewg7p+oj+K9vUvSpFhQc5LV2/QSjWiCUVook+aNKlNwtQWoCgKbt95oCq1tu7YL98toO0tBSF49eqN6ua3xZftrigKFEUJZShWycWTzVCPOpaKIpQyo0ql8qXNhHIQE1A3AY0a1du88wBmLFiNWg06oUKNJjpRo65xQSd75xRCTXHiopPXF9HYO0PjYPr4TyS06N/BjCEWLC4uFmWOwUQbls+RLxjKi58wgJIJY3f9stj9UpD55ovtYxRBOpcuYfpVN6NkMeqlmwjjCknP9GnTGAfHql9RFGlICLNX7JUh0k0KFciXm1YqEiXUQJNaCm3FPko85dOJqGhpozyKopiUTHpW/8705SKThDEY4O3tLbe1oiiha4SuL1y+HoNaRFyVRuhHqYIR+kdusQuobpotRVGkavoLRVFw6Ohp/SB2M4E4QUCVBu/pfSthTuIEUVUqaf6kFR1VqUS64OkLhUWnTFvkJQPn0Y0T2LJ6LlYtnIJXD86jauXytqgqWmU6mO0hDQHNAR2tgq2cWdhjENc7IYpOqApzhjCFx5YkTxZ6Mye0BAnpESIWmTKkF0v1/AsTF4pCGn4RcgtR2yeQaYiNMTXaF9RmmBvrSH7S883b9+RUjST+8sEOJUQBpISqli6ta6hDJcvsWU2fkCkaBTW/r6ISDVkNJhA2AeMYVRq8xkqyP3oEAn3dTQoICvCJ1pCG4GDICzW+/BRFgZ1GfbvT6f8uIl3OUqjbqD0at+6BlJmLYt3GnVDbj3pyaZwkzTUZ8mV8rGuq1FBbz2lYY0tfvHqtKqTp06cL7TkV1k4ICULk/qk2A83R3iFUT6EfGb9SV6FvqpT0VEY9SIPFAa/VLVjoR25xyKuvp++LblpypGeI6EXNmzuHNkgV66xZvs5qIkxeQCzopkJtL3+2a9FI7J/Q/YhnpXJldH52MIG4REB9FkpcohdHdHVKZnqXTsMcNFEc0kBGw2fx6DAkOASKokihE2FAYBCev1CX4dOwRVd8+vz1Mad/QADade+nui3XoF5twRHSKFMUDWg8dL3fflKdnlBCTHRSFAWeXrE3T7aJQiLg9eu3UBTlqyB06IDh/ikSxvJ/lUrldBpIsmKRKkUKJE+WVBeuBgcZaIoSylPzZW1nb6+6nr706dJAUcS2/nIDoSgKyJDMlycn1PTLJG7IFCWUp6KErlOlSgG1PSk5ePSE4AkEyb9g4VZw4cq1GEM5Z+LAGKuLK4r/BNjgjf/bGGkK1BOtFFdS0fuhvV1PU7CBCIvaP52UHRzsoWgUXQGKosDe3g7ZsmbShanB8e79BxM1/P0D4O7x9UMiJgliIWDOwhXyYqKrWqBdvWGbzqsWh53GzkQVutnJl1tdBsX331U20ZPmClbb/vl9tcpyuytQoBFCx1TpUuoatw3xmzlpGByEgUvbmkQ8h0e/nh1EjLr+EyVyRojsjRZ6iVNesHhaEhKiQG1DRMwNsfDw8FKdntdu3gVtbzvQn0a6P4sOhNiYnUP/fR59t9jS/G8NAgmgDI0a2+ihst4iNTKKjE5+XjRLgwIIo1QKAF/Px2IZ9X8fH1+TzNTzqzZDkk7WJoqKgADR0ytWqvl/8Oip1CWLqwNypg+dmcHL6xM+uJkOR5EJY2nxW+0asmZ9PUsWK6S6nqnBfbuCxm9LZcUiteg9mzZ+iHCp63/Dlt0mCh06ekp1swrYaewREBgoTh+KFECBvZ091PZz9/SCotFAo4TqSU9KIHp7qZdXTbq6uXuYqEPDRtSmpyK0VBRaCof4VxQFiqLESseG/ns9W1ZMRfu//sRvP1cXWvE/E7CMgCoN3qbt+mHkpPl4+OS5Za3gVOES8Hx6zCTeXJhJojACyLANDgpCzdKJMbxpWoxpkQ6/fZNMpFbg7u4p1ur5174coq8RXVTSpnHVD4q0O8DKX67L5qrBxoFZsGlwVqztnxW7R2RDqdzO8PSM+lCBIP+PeHluOu5sa4bbWxrh2amxCPj8JtJt/ZJBruZP6I4jU4rp9Dw2uQD2rRws49S0yJ0zO84f24Hr/+3HmcNb8fTWadSo9q2aVJS63L33UK71F2T43H8Y/a8h6pcZXffUWYtMipgwbZ5JWGwHhBq4hloowhsojHWxUs0/jdU3ViZEGOaJnJ2Mg2PVr7EzbyK8fhu7826nT+uK5g1r4/nL6J3PYhUuVx7jBMzvzTGuhmGFG5ZORt5c2dB32BR06TMGx05flI9SDFOxzyIC4pGe/6dXJkmDA7xh7mU2k4RmAuzs7ND8h5QY3iw9apZJimolkqBv/TRCUoPGoZnJEmtBc6aMRI1SiTGsaRqM/iutNMwH/NMpWvp8enXe6l+u+6d+ZmRN66jTyzW5Pfo1TIec0Zgv+O21FXB/uF9sZzcE+XvB69kJvPhvmq6OqDjeXF0GF7uv8zc72/vj5YXZUSkqRvLkyJYFRQrmi5G6olLJjz9UNclGQy/UNub0thnD3NvbB7HxaNsEmF5A9uym7ytoRI+v2l4G+/TZW17T6AmUVoS9C7Xd6NDxo4dXOolnmtSppDumF8TqwaNnePws9Jr2v8plJMeY1gPgGuMiAVUavM5OjvizTg2sWzQRv/1SHRNmLMHvzf/G1t2HeOeO7F6maJA4XTGTXE7JssLeOaVJuKUBtSumNklas3QypPgyHZRJpAUBQTbokaya7zNGNE+PH8skQ/WSSYVRngbNq4ZYoE3YSd7eWGcSGd0v15XKb3oByZrGPlozaXx6c8VEz8/vrgPiJsgkwsIAX3fTHkn/jy+ipaeFVcfLZP3FzVdcGHqR38xLXy4uiWLl0XZ4O8JfjX43ia77Sw3VDbmpVeN/cmiAoii6ddYsmaC2G516dX9SDU93Dy+06DwITdr3Q8PWvdDu7+H4X6Wykp+JkhzABMwQUKXBS3oGikfmew6ewOJVW5AuTWr81ehXnDx7CV37jqVolkgQSFe0ORyTZNTlIEM3Q8l2On+kHcJgyuwaOs5UP29iZw0CvKP+qMsWPZLmhm54PjmK6Bh9fl6mj5uNv1ynz8USt7NLCpNk8uMg9i4m4bEZYOeYxKR6NeppoqRKA7RDLy6f2oXj+9erduhF906tTAj26haNc4hJadYJaN28AVYunIoGf/yMWjW/w/gR/TBv2mjrFG7FUuLKjc5Xnr/EOs/Js5ejcIE8WDVvHIoVzod6v/4A+kCVFTcLFxXPCajS4F22Zjv+ED26p85eQd9uLbFw2lDUrlkVE4b1xFszb93H820U7eZRb26eWvOR56f5yF1zFvL9usJsr6/FFYle42QZS5okp3ocEqczCbc0wOo9ksIwNzucI9AnWoa5U7JsJk2yd06BqE7zRoUlz2o6vjR5NvG4W7Cm+KhIEjM9+4nTFAaiUaYt9AT/kCNbFnExz6taEvSxlruXDmP2lJGYMLI/aFx07+7qM3gJIPXokpG7csFkdGrbDDRzA4WrSbQ3OmofY07MtDxXzI8yTyom2nLn/iP07NQMObOHzgRUvUp5PHz8PNrlcgEJh4AqDV6vT58wf+oQjBzQGYXy5zbYGoN7dTDws8dyAo5JM8IpeTbLM4ST0uq9xuHUFeUoYdiFNZwjOoZ52kL1TVSKzjRvVJhrgXrIXL4nkmetgmSZv0GGUh2RsXRnioqypC3SFClz/gB751Swc0yGZFkqIVPZblEujzJq9UyauTKSZKxgFT2pXBb1E8iUMT2aN/odHds0VfW4aPWT/Koh3eioeYz5V01j32Wn0RgMXwgICAS94Bn7mrEGcYWARo2KdmnTCGldTcc0kq6F8ueiFUssE3BKlhVW6zX+0hZb9EjawjBPkqE08v6yWBqkGUq2l73mqfL8/KUVUV8lz/Y/ZK7QC1m+6YdUuU3HzkW2ZDvHpMhYpqvo0V+O/HVXI0vFvoiOoY8vP9IzQ9m/kaHcP1bR80uxvGICTIAJhEmAvj74/oO7jP/0yRstugzCT1b0ckYAABAASURBVN9Xln5eMAFLCKjK4K3ycwuEJ5Y0iNPELAFr9hrbokdSa5hn/34WslWbIoy/aA7n+ILXwSUtUuaqCTJ0rdVr/qVoXjEBJpCACXDTzRPo1bUlRBcv6Ff7x6pyuCO93E5+FiZgCQFVGbxHdy5BeGJJgzhN3CVgqx5JIkKGuaPolSY3CxNgAkyACcQtAtmzZIBrqtCXe8nQLVwgD7bvPRK3GsHaxioBVRm8tiSxfus+0HQmzToMkPP6mquLHpd07j0aLbsMRv8R0+Dj6yuTXbp6C32HT0X1um3QuttQHD11QYbHzoJrZQJMgAkwASaQsAhcv3VPfpCqfc8R0Mr0eaukmw3fhLUvRLW1qjJ4K9Rogms374HW5iSqjXzy7BWWr92BeZMHY/zQHhg1aT58/fxNipsmDp7ypYth8YzhSJYsKVZt2C3TuCRyxj+d/8K+TfPQvEFtmV9G8IIJMAEmwARijwDXnGAIDB03B8UK50WrJnV1Ql9cI3/JogUSDAduaNQJqMrgPb1vJYoUzANam5OoNvPEmYuo8k1pJHZJhPTpXJE/Tw6cu3gdxr+TZy+j1g+hg+BrfV8ZJ85ekknyifT0KMVOo0Gl8iUQEBCg6/2VCXjBBJgAE2ACTIAJ2IyAs5MTfqlRFWVKFNZJkiQu0p05Yzqb1csFxx8CqjJ4bYBVFvnugxsypk8j3bSgg8N4Pt/P3j5yPHzKFMkoCbJkSod3792kW3+xZedB5M6ZDYmcnfWD2c0EmAATYAJMgAlYkYD+UIV+PVqblNyjfROTMA5gAmERUKXB+/T5a3TvPw5Vf2lpMLwhrEbMWrQGbXsMM5G1m/fqsiiid1brURRF6zRYawzSmKK5euMuVm3cjcG92uny+fh4wxYSEOCPwMBAm5RtC33VXqafny/8/PyYp5X2Vz/madV9ydc3JvZP25yr1HjsM0/rbmtfXx/4+8fc+TMoKFBeY/ccOCHXtChkZkpSevpKcSxMwBICpladJblsnGb4hLn4peb/kD9vDuxYPQOdWzeUY3bCqrZl47qYNOIfE6n783cyS5rUqeDh4SndtHBz90Ba19Tk1AkNdwgKCoZ/QIAM+yDSpNGbC5h6e2cuXIOZ4/uJ3t/0Mg0tnMRjFluIvb097OzsYIuyE2KZDg4OcHCwZ55W2l8dmKdV9yVHRwfeP620b9L5jXk6WXn/dARdk4htTIhGYwf+MQFrEzAweK1deFTL8/X1Q7Vvy8qvqLimTonG9WqF+wlBGl6QNEliGIuTo6NUoVL5kjh+5iL8/P3h5u6Jm3ceolzpIjKOZmCgL7aQp2LZ4jhw5DQ5sf/wKVQqV1y6afaGAaNmoH+PNsiQ7uvQCIqkA9MWoigaKIoCW5TNZdoxV3FB4f2A9wPeB3gfUOM+oCjmn8KCf0wgGgQ00chrs6wuLqHjYxVFwbMXr+WMCm7uXlGuL1uWDKhbqxpadR2C7v3Ho0fHZnAUPVRUYO+hU+Dp9ZGc6N6+MXbsOyanJXv67JU0tCliw7b9cvaIhm1664ZYvH77nqJYmAATiJ8EuFVMgAkwASYQjwho1NiW4oXzwUMYoQ1/+wmN2vTB/2q3xPf/Kx8tVWmi6pVzx2D5nFGoUrGUrqx/N88H9SJTAK3nTBwopyUbPaib7sW0Di3rm8wcQdOhUB4WJsAEmAATYAJMgAnEXwLxo2WqNHg7tmqAFMmSomql0ji+e5k0Nn//5fv4QZxbwQSYABNgAkyACURIgDqgIkzECZiAhQRUZfCeu3QdJGfOX8HyddsxYsI8DB03WycWtomTMQEmEMMEuDomwASYgC0J9B0+1WzxV27cwdyl683GcSAT0CegKoN30cotIBk4aibmLF6PA8fO4sSZS9h36BTOnL+qrze7mQATYAJMgAkwgQRC4MbtB2Zbmjplchw8etZsXCwFcrUqJaAqg3fupEEgoelPJgzriSPbF+HAlgVYOG0oaFyvShmyWkyACTABJsAEmIANCXh4fkT7niNMZOSkBXj+8o0Na+ai4wsBVRm8Wqg0TVi5UkXktFwUVih/blqxMIH4QYBbwQSYABNgApEikNjFWc7H36pJXZP19LF9I1UWJ06YBFRp8IYgBL826YIpc5Zj/rINGDN5Pm7de5QwtxC3mgkwASbABJhAPCVgabPoYzdlShRGWGJpOZwu4RJQpcFbvUo5BAYGY/ueI9i4/QAOn7qA8iULJ9ytxC1nAkyACTABJpCACdBXVxNw87npViCgSoOXvmi2b+NcLJo+AnMnDcb+jfPQ7++2VmguFxH3CLDGTIAJMAEmwASAV2/eiU6w/VLIzUyYQGQIqNLgdffwwuqNu7Fo5SYpqzftAYVFpmGclgkwASbABJhAvCKQgBuza/8xNG7bTzz5PYoN2/bLj1LtPnA8ARPhpkeWgCoN3iFjZ+PIyfMoWayAlEPHzmLY+LmRbRunZwJMgAkwASbABOIBge17j2DPhtnya6nrFk3EhqWTsWzNtnjQMm5CTBFQpcH7+u07zJ08CPR1NZK5kwbi+cvXMcUkLtfDujMBJsAEmAATiHcE0qROBSdHR127XFOlQJLEiXV+djCBiAio0uDVaEzV0miUiNrC8UyACTABJsAEvhDgVXwikCSJC2h449v3bnjw+BlmLlyDEkXzx6cmcltsTMDUsrRxhZYUnztnNtRt2h2/NeuOX5t0RY0/2sPbx8+SrJyGCTABJsAEmAATiGcEtu0+hBnzV+HXxl3RpF0/rNqwS0qFGk1AEs+ay82xAQFVGrzv3n9A0UJ5kS5NKmRMnwZ1a1XD4F7trN58LpAJMAEmwASYABNQP4HT+1YiPFF/C1jD2CagSoM3WdIkGNm/M+ZMGow5Ewehc5uGKFuySGyz4vqZABNgAvGVALeLCTABJhCvCajK4KWvqr1++x7PX7zB+OmL5VfWKEwr8XpLcOOYABNgAkyACTABJsAEbELAcoPXJtWbL9Td6yO27DqErXsOY9e/x3ViPnXshgYE+MMWUq3ad2jQoL5NyraFvmovEwiRO4ra9Ywr+jFP6x73wcHBUBTw8W6l8ynztO7+GRISs/snbT95wuYFE7AiAVUZvG2b10P6tK5o2+x3TB/bF8P6dMTAnm2lNPnzZys2W/1Fubi4IGnSpOpXNA5pqCjCoohD+qpdVUVJuDytvW0UhViSWLvkhFmeohBLkoTZflu0WlGYpy24cpkxR0BVBq+22fsPn0aZEoUNZNuuw9poXjMBJsAEmAATYAJMgAnEPoE4o4GqDN7nL9/g3KXr8PL6hFGTFqBF54Fo3K4vGrbpjWf84Yk4s1OxokyACTABJsAEmAATUBMBVRm8F6/ewqKVW/D0+WucPncFj5++QmBgID5/9kWlciXUxI11YQJMwFICnI4JMAEmwASYQCwTUJXBW7tmVcydNAgpkifBzrUzkTd3NqxbNBHbV0+Hn79/LKPi6pkAE2ACTIAJMAEmEHUCnDP2CKjK4NViSJ/OFQEBgfj48TOOn7kohzm8/+CpjeY1E2ACTIAJMAEmwASYABOwmIAqDd6AgCD5SWEa09t/xDR06TMGr9+8tbhRnJAJxF0CrDkTYAJMgAkwASZgbQKqNHj9AwKweMZwFMyfCzPH9Ufvri1QoVxJa7edy2MCTIAJMAEmwATUSoD1YgJWJKBKg9fe3g5v37mJXt33KFY4H76tUApubm7Ravb6rfvQpH0/NOswAMdOXzRb1vsP7ujcezRadhkM6ln28fU1SOfu4YXvfm2NOYvX6cIVRYGiWF/evn2LZ8+e2aRsRbG+voqi7jJDP5QQwjyttJ2Yp3X3dzqhhITw/qko1uHKPK3DUVFCy4lpnlSfOanycwuEJ+bycBgT0BJQpcH76eNnjJm6SI7h3bb7EM5euIbrtx5qdY70+smzV1i+dgfmTR6M8UN7YNSk+fD1M30Jbtq8VShfupjsXU6WLClWbdhtUNekWctRslh+QIHuZ2/vAFvI2bP/Ye/efTYp2xb6xlKZFvMBNBD2hMXp1d6e2NaPeVr3uFcURZ5TYnu7xpf6FYV5WnNbKkrMnj81GvOmydGdSxCeyIOIF0wgDALm96owEsdUcFBQkPzSWpbM6XHg6Fns2HcUyZMnjnL1J85cRJVvSiOxSyLQC3H58+TAuYvXTco7efYyav1QWYbX+r4yTpy9JN20uHL9DhIlckKh/HlCO7cokIUJMAEmwASYgCoIJAwlnr14DQ+vjwmjsdxKqxJQpcGbKnVKpBHi7OyEGeP6yanKEjk5R7nh7z64IWP6NLr8mTOmw9v3H3R+cnz29gF1CqRMkYy8yJIpHd69Dx1GQXMBz1iwBl3aNJRxhosQ4bWViKJhq7K53NA7F+bAHHgf4H2A9wF17QN07TOViTOXoeegCWjUpg9Wb9ojDV96qd00JYcwAVMCqjJ4Zy5cAxL60trQcbPx8vVbzFiwGu3+Ho7gkGBT7SMRoug9IlGU0Mddxtn1H6Mo4hGONp6GNvz2SzUkS5pEG6Rbe3t7wxbi7x+AwMAAq5ZtCz3jSpm+vr7w8/NjnlbaX5mndY975sk81Xwujen9k659uousnoN6d9cvnoQNSybh0LEzSJEsKbx9DN+10UvOTiZgQEBVBm+SxC4g+f67Cnj09CU+uHlirbiLox3624qlDBSPjCdN6lTw8Pg6j6+buwfSuqY2KIKGOwQFBYNmiKCIDyJNGtdU5JRDG0ZMmIcKNZpg/rINWL5uB6bOXSHjXFwSwxbi6Ogox5vaouyEWKazcyI4iacECbHttmgz87Tucc88Y5ynTc7btjjW1FBmTO+fNP5YXmCNFvb2oSZLYpdEsLOzk7GfPn+Wa14wgYgIhO49EaWKofi/Gv4Kkg5//Ylls0Zi74Y52LZ6BlbMGY0OLepHWYtK5UvKD1jQ19rc3D1x885DlCtdRJZ36eotBAQESnfFssVx4Mhp6d5/+BQqlSsu3QumDsHpfSultG1eD83q/4Lu7ZvKuJhYBHp74v3F3Xh1bCU+Pb4SE1VyHUyACTABJsAEVEXAJVEi+UL7uUvX8fmzD6bMWYH0ab8OV1SVsqyM6gioyuClnZhk94HjaN5pIBq17YNHT55j884DGDx2VpThZcuSAXVrVUOrrkPQvf949OjYDI4ODrK83kOnwPPLAPju7Rtjx75jclqyp89eoXG9WjJNbC78PjzH5bG/4sHawXi6cypuzG6FhxtHxqZKXDcTYAJMgAkwgRgn8O6DO548e4lFK7fANXUKpEqRHOOH9YhxPbjCuElAoya1u/YdCxIaPnD3/mO8/+Ah/RNmLMW/h09HS9U/69TAyrljsHzOKFTRGx7x7+b54sBJKct2TZ0ScyYOlNOSjR7UDYmcnWW4/qJFo1/RoWXUe5v1y7LE/frkOgT5fjJI+u6/rQj4+MEgjD1MgAkwAVsR4HKZgBoIzJ00SL7ETuupo/ugecPacHJ0VINqrEMcIKAqg5fysYlZAAAQAElEQVQM0Xx5ciB1qhTYuXam/OiEdihBjmyZ4gBO66vo8/aR2UK9X94xG86BTIAJMAEmwATiIwF6AhyexMc2c5usR8BKBq91FBo7pAemibs2BQp6D5mCB4+eYc+BE3j+8g0c7O2tU0kcKyVR2hxmNXbJmM9sOAcyASbABJgAE4iPBGYtXCuf+g4bNxck9ESYwmiIA0l8bDO3yXoEVGXwUrOSJ0uC9i3qIV2aVLC3s8OYqQvxV+dBaFa/NkUnOEn/TX3YOScxaHeasnXgkDS1QRh7mAATUAkBVoMJMAGbEHAVT38nDOuJHWtmSCE3hdEQBxKbVMqFxhsCqjN4Pb0+gT4C8ezFa4iOXhTMlwuzxg9AtSrlkBB/Tqkzo3jfbcjVYDiy/twdhTouQs4/BiZEFNxmJsAEmAATSMAEXr55h0rlS0BRxHNgIeR+/ZbfZ1HzLqEm3VRl8PYdNgV1mnbD0tXb0LtrS+xZP0cOUM+XO5uamMW4LvYuyeFa8idk+LYJkmQvFuP1c4VMgAkwASbABGKbAH0c6vS5r1NzktvOTlVmTGwj4vrDIaCqPeXoqQvIlD4t/AMDQV9Ya99zBPQlnHZwFBNgAnGSACvNBJgAE7CMwMCebTFlznL5ESj6EBS5+/VobVlmTpXgCajK4J0+ti+6tW+MLBnT4fHTl6CvqaRPmxpaSfBbiwEwASbABJgAE0igBPLnyYF1iyZi1bxxUshNYfEGBzfEpgRUZfCWKVEYJBXKFMUftauDhjJkTJ8GWrEpCS6cCTABJsAEmAATUDWB42cuYf7yDVi8agv+u3hN1bqycuoioCqDl9AEBgXBNVVK0Cd8jYXiWZhAAibATWcCTIAJJFgCB46ewbBxs2Gn0eDG7fuYtXAdjp48n2B5cMMjR0B1Bi9NRUZjeSPXjISV+v3F3bg2rQnODagk1x8u7U1YALi1TIAJMAEmkOAIUK/ustkjMWpgV6RLmxqLpg/Dms17EhwHbnDUCKjO4KVmZM6YDqs37oabuyd5WfQI+Lx5gAdrB8P7xW0EB/jK9f01AxHWF9n0srKTCTABJsAEmECcJRASHIzMGdPr9HdwsIevr5/Ozw4mEB4BVRq8m3cekLM01GrQSfc2Jr2RGV5DEkqc+83jZpv66el1s+EJOZDbzgSYABNgAvGHgEZjh5CQEF2D/j1yGq6pU+j87GAC4RFQpcF7et9KmJPwGpJQ4jT2jmabGhLAd7lmwXAgE2ACTIAJxAsC331bDncfPJFt+eDmgZ37jqF7+6bSzwsmEBEBVRq8pDTdxT18/AIk5KYwFiBZnrJmMSTLXdpsOAcyASbABJgAE4gPBFo1qYt8ubPLpmxYMgnTxvQBDYGUAbxgAhEQUKXBu233IXz/W1t07TtGyg+/t8P2vUciaErCiHZJn1t+ZtglU35oHJxB69wNR8I5TehJIMoUOCMTYAJMgAkwARUTWLpmG8ITFavOqqmAgCoN3pUbdmFon47YsWaGlMG92mPFuh0qwKUOFegzw0W6rUSZUSdA69Qlasa4Ym7uHuj09yDkKvotshaogKZteuDJ0xcxrgdXyASYABOwNgEuT50EPn32RniiTq1ZK7UQUKXBa29vj0rlS0BRFCmVK5SERqNEi9n6rfvQpH0/NOswAMdOXzRb1vsP7ujcezRadhmM/iOmwcfXV6a7dPUW+g6fiup126B1t6HgadOA4WOnY+mqjXj95h1oLNXm7XvRoccAyYsXTIAJMAEmwASsTaBz64YIT6xdH5cXvwio0uC1s9Pg9LkrOtInzlyCo6P5l7V0icJxPHn2CsvX7sC8yYMxfmgPjJo0H75+/iY5ps1bhfKli2HxjOFIliwpVm3YLdO4JHLGP53/wr5N89C8QW2MmjRfhselxftLe3B/9UDcW9EHb05vjLbqR46fNinj+KlzCAoKMgnnACbABJgAE2AC1iJw5cYdWdTVG3flmhdMwBICqjR4+3ZriYkzl+mmJJs6dwUozJIGmUtz4sxFVPmmNBK7JEL6dK7InycHzl00ncbr5NnLqPVDZdCv1veVceLsJXIin0jvmiqF/LoL9TwHBAToen9lApUvXh5eigdrBuHD5b1wu3YQj7eMxaNNo1WuNavHBJhAnCDASjKBGCYwcNRMWeOQsbPlmhdMwBICqjR4CxfIg41LJ2HVvHFSNiyZhEL5c1vSHrNp/s/eWQBGcXRx/L+XixsRSAKEQIpDgVJKKc6HFgoUKJTibqVYkeLubkWLUyheHArFXYo7gUBCAsRdL9/OXu5yl72EyF1uk7xLZnfmjb357d7e29mZ2Y+BQSjsWlAdx2Z1fggIVIeZJzIqGhwHOBSwY0G4F3HBx4Agwa+52X/4NEp6esDSwkJTbFR/uNctPFrdDzcm1MHd+e3ge3q9lj6Bd05ohVkg8O5Jtsuyq1/nG1HeOjW/gomJiUhOAiJABIgAESACRIAIGJOAJA3eIyfPIzQsHJ7FiwguKCQUx05dzBYnTpbSVI7jLVsdpcm00qSkVyVlj0+27zmKSaP6q0SIiYk2iGO9yImJCZ8sOzI0AE83jkC4120o4nhdPnrD58Rq+N88qswbFYGYQB+1vipPYkwEwj++VabJQhtGD+uLrh3bCIt+29vZoHWLxlgyZ2KWyzMUR1W5cXGxYE4Vpj1/rmThuKu4MZbMqcK0zx7P2NgcOz8l+x3V5zlEPLN3PqY+FrGxMTl6/UykoXGqn2ra65GA2KrTY+FZLWr7niMoYK/saWVlODkUwJadfzNvllxBJ0eE8EazKjNbYaCQs5MqKOzZcIfERAXi4uOFcGBwCAo6Owp+tmG9vSvW78CKeWP53t+UVxvK5aYwhGM9pRwn+2TZce9fIjE2Eqk/ka9uK/OaWcDus69SR8PSxROWDm7KNFloQ2BQKC5fu42AwBD+5iQC127cwVtf/yyXZwiGmmXKZCZ877Ncsvpp6pob/MRTv997E/7JiIkJnZ/6OveJp77PTzlMcvD8lGl0Pol+vEhABLJIQCbKJwFBTEwcNF82wfwxsUpDNCvq1a5RFReu3kZsXByCgkPx6KkXvq72uVAUW4EhPj5B8NesXgWnzionY508cxm1v64iyNnqDeNnLse44X3h5pIyNIJFyuXsR0r/jn3hmftU+ezCzvRI7TTzFms+GBbO7uokprbOKN56FG/8ZV3v+fMXobWrH3a1t8S+DlboWzYUc2fOyFaZcgOxVJXLWKn8tM/6sVexI57ZZ6hiyfbEk3iy80CqLifPT47j1L9X5CEC+iIgSYO3iFshrN+6V93GtZv3wMPdTR3OrIflbdOiIXoPmYxh4+Zh+KBuMDM1FYoZPWUx30MZLviHDeiMQyfOC8uSvXnrh87tWwjy3X+fxP1Hz/FT39HqiXT+HwKEOGNvrIuWg4m5tUgNe403slnyvbmVR+9H5dH7UOnXv1B14nHYlRT3+ooKSUdQNvY+vittCmcrGQpYcmhQwhRtXf0QFh6RTq6cjwrie+rZesElK9dD8Qq1ab3gnD8ERq3xlfdb/rurnNGdFUUoDxEgAkSACOQNAjIpNmPqb4Pg6/cRtb/thjrNu+P9x0BMHj0wW6p2+L4ptq2ejS2rZqJezS/VZf2zby2cnRyEMNuvWjABbFmyWROHqiemDez1I66c2KblXAs5C3mMvWHGbpmei2DrWRUyM0tYFPRA0aYD4FipkUg1C+disHT5TCRXCYIfnYffua1ge5UsrX3FgkmiqEouJrC2MBPJjSkYNmYaNm7bDdZLHxoWgb1/H0PHHoONqRLVnQMEXni9RrW6LVGxehPUaPA92MtRTpw+nwM1UxVEgAgYmsCP3ytfttS+dRNDV0XlpxDI9T5JGryODvaYMmYgDu1YwbvlYG9aU62ekOuJG6ABtp5fovyAtfhqxgVUHrUXRRr2EWqJ8nuO2OQJa3HBfvhwbT/eX96F6PcvhXjNzb2FP+LZphF4c2SpsL+/qKNmtMiv6iHXiuAfQ7HHXloyIwf+PvoPOC7l8RjHcbj74DGtF2zk42Lo6tmLUR4/faGuJjAoBENHT1WHyUMEiEDuJdClg/Lpa6cfmufeRpDmOU5AkgavigIzcjUnr6nktE+fwPure3F97De4v7gj7sxpjRsTauP27O/wau9MvD4wD8y4ZYavqhS2RFlqIzjK/wWYPNLnMeLDxcM3LnmJhy7c9U8AZCaqYiWxT0gen51amWCNSYyp4yicRQISynb91l2RNm993iEkNEwkJwERIAK5l8CAX6fnXuVJ8xwlIGmDN0dJ5KHKvP+ej6RENsmPA9+9CUVcDHgfND++p/9QB6N8dY9xfLFjIh4s64rb05vh8dqB6vTMs/ZmDA4/i0dAlAIh0Uk48yoe8y7FwvutL4sWXMDto7i/tAtujK8t7AP/Oy7Ic2ojLG0jHnnBV88hLCyC30vrf+eeQ+g5cCQ69x6KdZt2SEs5DW2Ynn0Gj0H3/iMlq6eLjiFHMpkMtjbi8e4aTSMvESACEibwTdMu6nk0Kv/dB0/RuG0//LnnqKQ0J2WkR4AMXukdk2xpFPPhNW/s8j2tqUtJ0jZ548MDkRgdLqSydPEU9qk3SYkp5YS9uAH/C3+qk0TGAYuuxKHD7mi03RWF6efjEBWXBFPfG/A7vw2BvLH7cuckRPk+gSI+Rti/2DEB0R9eqcswtMfExARuhQuJqrGwMINniWIiuTEFC5atRe+fR2PXviM4cPgk2NjjX0ZNNqZKOuueNnepoOeeA8dw8OgpQU9mpOtMbEQhWyM6dfVtWjYFOydSyylMBIhA7iCQei4NC1euWAZ7Ny/CoRNnc0cjSEujEZCkwXv73mMRkCs37opkJBATkJmai4U6JKa2TjCxtBVinL9sIZ7MlpQEjtM2kkNf3IT/xZ34eONvfOZmL+RVbQrbcNjezgpv983Am8NL8II3dpNUkRr78Je3NEJKr+ZYY6VEf1tnRwcoFEnCMndJfJuYszSXwlvytNu4Z7+4d2I3b/wKvdTaSY0aWrdxJ88SvEthupc3fqWmZ5/uHbFt/RL81L4VWjZvhHnTx2LN0llGZaer8vCISPT7ZSw8ytdG4VI18G27HmAT7nSlJRkRIAJiAs0b14GdrQ0+L1daHEkSIqBBQJIG7/zlm/D6rZ9azeu372Pxqi3qMHnSJmDGXiZhZSdOwGmbn0Ua9tZKw5YrK91jEYq1GAr3FkPAW7tI/Ql5fA7eBxfAa/d0rGiYiMqFOCiSFFAoFGhdVg5bc5lWFo6FeCOT7XS5kCeXcGtKI9xf/BPuzP0e9xZ2QEzAG11JsyzzfuPLN4UTDDTeTBPKCQkLQ4jExnJ6Jw8FYQY5c0xRZgz5+Pozr2QceyELuw/iOE7gynEcEhITwThLRslkRap/WRl1alZHXeZqfw1LS+nd6Pzy62Rs33VAOB+jY2Jw/uI1tPihV3ILaJeXCew/dAJsaFDHnr9g5dotiI6OkWRz/fw/5+LbFAAAEABJREFUYMuOfViz4U9hwq9BlMxkoR8CgnDw+FlMmbsKG7cfEHKPG6GcrC0EaEMEdBDQtlB0JDCGiC1LNnbqIgSHhIG9GGLBik1YNGO0MVTJlXWW678GVq4lwZnIITO1gH2ZGqg0YhdKtBuP4t+PBjNuXWp2ELXNoXxduNXrisJ1OsOyUAlRvKbAzCQJHSuZQcbJwMZGehRI41TiNHMBtp99qRa82jcbCVEh6nD0ey/4/LNWHdaHx9W1IG+YQdCR42TgOA62NlaQ2mTIKpXK8zcOKTclSXyvdGE3F3gUK6IPDHorQ8bz01WY1PQ8cvxflP6iAQYNn4BRE2YJS5NNmL5Al+pGlR3754yofja5TmrrWTMlmYHWsedgNP+hp6QNNKbrhcvXceDIP8wrSbd+80506TMMO3YfxKGjpzB64mz0HzpOcroePXlG+B4N/nUSfps8F9/8rw3GTJpjND1nLlqH77sMRZf+Y3H5+h2UL+OJ5XPHGk0fqjh3EZBJUd3Sn3lgcL/OGDZuLtgJPn/qSBQt7CJFVSWpk5VbKXw+Yieqz76Kr2ZeRNneK2Dp+hkKfd0GzNC1dPmMNzRDwSaVsfG2Ea9TDReRmaD8wLUo0qgvCpSrDacqzQDBFuO02uthl3L6vAlRaMWpApa84c2MbqsiZVHypxkwd3ADW/khyu8p4kLEvZcsTpVXY59lL8dp66wsKEVvZdj4W9ZjIZNxgkHOcfye94eHK8dYG1+7FA1Uvc8pEgg6fwwMgpQ+I8fPFKmz7PeNIpmxBbGxcTpVkFrP/pRZi4XJlAePnMLZ81eEm4gmrbvo1N2YwtPnLsK+yOf4rn0f9BwwCtYuZTF1zlJjqqSz7q0794vk+/keX6kNDRo1fhZ/I64QvuMcx1+XeLdy3RaR7jkluPnfQyiSktC9Yyv07doObH19sg1yin7ur0dSv/xrN++Gyj18/Fw4scuUKoET/14U5LkftzRawNbmvTOnNdikMjbe9uHvveG1Z4aWcnJrBxRt0h9lei5ByU4zIDMTPw72DlOo8xx4koDw2JQwiyhY/XtUGvGXYHR/PnQb4iMCcXPy/4SVH+4v6sSSiBwbW6wpfHv8d7DhDjcm1sWTdT8j4s0DzehP+v38PkDB95YqFAokJQ+/CI+IgNSGNDx95sXrx99X8BfzpGQXFh4pOT151UTMWW+01H6ofd+Jb6YS+XPguddrkf7GFLi6FlKen+zcFBx/Z8kB5cuWNKZaorqXr96sZfRwHIdbdx5Ibj3r7v1HIiEhZbItwGHe4jWQ2ufRk+cildg16oWXt0guFuScRNf3iH3f7z94knNKaNS0f+sSrJw3DtbWltjw5wF0HTgO0+av1khBXiKQNgFJGbyp1axT4wt4FHVNLaZwNgn4X/oLiTHay3J9vH4AbOWGtIou0lB7XGFMfBL+uh/PG2lJgvMNV6DLvmiY1R6AYt8NQ4VBf8Dzhwnq4ljZ3ocWIykhuUeL/8GEsttYnUbwJCbg9oxmwtjeB0u74t2/fwgvz1DERiH0+TU83TAErJynG4YJ+5iP3kjvY2omB+s5lclk4Djl8Au53ERyQxoSFQlgSDiO4/dKx9oVFi6xXl6OaaXt+DMAroUKagslEBJuHPhzjOnH/MygcHMpJAHNUlSwsrTgjzd4xykdAFO5nN9K6z8mRvf40vOXb0hK0eDgUB36JMHr9RsdcuOJ7GythesmOy8Fx5+nAIcypXSvmAMjfczNzHTW7O5eWKc8J4Uy/lrJ2Cn4Do2crJfqyr0EZFJSvV/39kjPSUlXKevyKd3SWhos6t3TNLMW/l8vfD5sOzxajYRn+4kY/K8J/vNP1EoflWiCL1r1gVvdLrApXlk7TkfZrLfQ2r08HCrUh3PV5rAv9TXCve8hPiwAbGxvpO9jCL8DGiUlRIXB/8I2hDy5yO+34/6Sznj4ey/cmFAHd+e3g+/p9WCrPqhWk7BLCsWIb8ywq70l9nWwwsS6ZnAyT5RczxRv7mi0MsUrNeNHJlNOAGSPFdmPDXPgf6ghtQ8HcBwH9R/vB+8iIiMhpc+zF16COio9WSAuPh7BEnsxCrthZLqldlUrV0gtMmqY7x8X1c/O0cjIKJHcmILQ0Aj+dOSPOn9Ochy/B8f39CdKbvJnkSKu2oY5f9E2NTWFseZAtOk6DINGzUR4RBS6/tgS21bPBnsrqzGPJdWdewhIyuBVYUvgH0ldvXkXG7btF4YyqIY5qOJpnz0CaU1IsypcJt2CWbxr7Y4o+FVrlPviK3Acf6HWcKVLlUgzv2oJNM0EHMfB1qMSSndfgM86TkOsjjG9Qnr+IivsU21Yz50iPhoRr+9BERcN1tvrc2K1sOqDajWJP76zxHelTeFsJUMBSw4NSphiVE1zPHosfqSYqnijBzmOw72Had+EGENB9jiT4zjIeMdxquMPSG2IiKWlJVJ/OF5Q0MmR30rnn/VOcRzTTKkTx3HgIOOP+xNI6WPB90SL9OEAeztbkdiYAg93Uc8jTGQm+LxCWWOqJao7Lj75SZdGDMdxKMobmBoio3tVK0dwHAeOUzo27txY3/eqlcuDXYO2/nUIG7bvx56DJ+H3/qPROZECuYOAJA3e8TOWYe+hU4jVcVHIHVilqWVc+DvEhnrDtdaPMLGw0VKSjbdNPX5WK0GqwBtv31QSwMfHD9FB7xDpK/6xtilaHroMbacqTUXlpC9gfTickES50prSLwhUG00DWUd0ZVcTWFuZq1JLY8//mKRWhPVMNapfK7XYqGGZTAdQXiNbG2t+K53/mGjxI3iO4yC1yWC6iPFqoqLE1hRN5Dsh2Pmo5fhHyVJbjq7bT20h6Mg/GmI3xMz/ZdXPdWE2qiyRZ8cUEHTkdWV+juNw/uJ15pWMCwwKFgxdTYV4NTWDOeqfOLIfDu9cgQ3Lp6Fm9Sp48PglBo2cmaM6UGW5l4AkDd6Y2HjMn/orBvb8EZpDHAyCOR8UGhv2Bs+P9MPzo/3w4vjPeH1xLEr1mgmPVr/CtU4n0XjbTyFhE5S8Xr9V/rDwxiX7UbGWJ2FGnUTcm9MKD5Z2EYYYfLi2P6UovpdFc+WHQl+3RcmfZuLdmc24ObkB/pvZAjITk5T0mj7+Cst+GPgKkfzboBmbJb+He5Es5TNUpib/qyMqutRnxWGSFhNRat2C+KgPCH55HEHPDws3O7pTZVyqepTp7mwKT1dTISPHcdnWE3r+6HoEz5+qcHCw13NN2SvORMd4XfZ9yl6pBsjNyZSGD7vf4R3HcdDFGEb+HD91XqTBzdv3JDeEydmhAH85YzfvSnVZryUbJtSg3jdKgUS2MXHxIk04jkNoqHHnFrCVGVo1qw82nIFNZAN9iEAGCMgykCbHk5iZyREfn5Dj9ebVCt/f24y4iHfq5rHVEl5sHw/vgwvBXhf8eP1gaBmn6pQpHvZ6YP+LO/Bs80i83j0VLcprP8psV94UnxdKMVgVcdF4tXem+vXFrCS5xsoPJdqNg/+lHQh+eFZIExf6HpF+L2HlVgqmds6QWxUAe4kG+B9XlpdjHv5CC+aSfyeSOICTpdQJ1YfjI5hlzCwcPq3SWOYj+TAfxF1//tzSlY9PYqz/6tUqo+mX1pjatSBm9SiEtrXsUKli9h7DRvjdxLNDvfDu5gr43V4t3Owwwzc7bez9Y33smeCOvZOKYee4Yjg63QO923whOYOX3RlpGo7MnwQFIiQ2lrNoYV2Tcjmobiyyc6yykjetPOampoKBxkH5J/Dkv09SW3/5zr2H4DiljsKW9ysUCkht9QMra0ttPfknJ/Js3tymdeyyI1fwPfup87Njb2+vff1PncZQ4ZCwcGGp0uY/DgJzbNlSJjNUfVRu3iIgSYM3Li4BHXqPBHu7mmr8LtvnLfQ515qoAO1xoPEfIpEQGqFWQJdxqo5M9njtmioYyMEPzwrr9w6oEIFWZeTKizb/o1LKUYfhyeeN1DFZjRcLRq6uJcZiecOXxTPH9AI4pP641esMNpa4RJtxSFLwxqvKuGV73qhRpufz8XqBdxw4sH8IfiBI/LQbxv4EPNqN6d1d8e1XdmhU1Ra//VgQpS1vZUutgCd7Rfk/PtopkmVG0KxiBIoVMlNncbaXo1Nt7cmL6kgjemxsbPjDzfFnRJLgOI4TwuwVpEZUS1R1hXIlwQwIpZb8ljciHfleaBOJGT/hkRECP1UDOI4TvGHhEcJeKpt4HQYa062kpwfbSca99fUT6cKenLEhBKIIIwoUCuU5mVqFh4+epRblSHjq3NUo5OyAMUN6YdiALjA3MwOT5UjlVEmuJ5BJgzdn2luhrCe+bVgL1laWOVNhHq/F1NJBq4WKKGYkaomEQFrGqSI2CoH3TgtpNDdsApgqHB6v8mnvo9+/gt+5rQh+pHzUGPbyJtjLLoLu8+XxP+6aqdlPaGJUmHqVhoSIYM1opZ/P43d+O9gqDK/3z2Ydebycz8l+gFn3LVKd0nx6PoHWfx0Pc5jwWbSERg7UrWAq0qBJVRvce/hIJM+oICb0rShpQkwIEmJ0cBWl1C2IDXklirA1jYQiXlqGD1OSGZK8tSucI8zPDrmNtRWLkoy7duOuSJfAoBDJPYJnhk9qRTmOw6MnL1KLjRsWrgHaKnAch937jmgLjRxSJCpEGnAch5ev3ojkxhSYmSmvS+z7o3Icx6FC+dJGUcucf/rbt9sPqFerGpo0qImRg7vjY0AQ6EMEMkIglXWQkSyGT6M5blfTb/ia065h14ET6DJgLLoNHI/zV26nnVCCMfbF6mprJdd92M1snbXTJYdiAnnDKUl8gS5mz0wIZaKzr8QWr0xujtcH5uLNkaV4tmkEbk6sh8drBoC97MJrzwxwJnLeGNH4hUopTlkov9WIBSfnL75cqkQsrMOo5bNqly0IlBtzEwU0e5KV0sxvVZMAM59TnMPNiW9bKrGNpQnKFXdKJc140MLeXZRYblEAcgvtGyBRonQEQeHi2eVRsYn4ECSt5b509ZQxoy1Yn8t9pcMpo1FMH47joP7j/Wxi4O27DzNaRM6k4/VKXREzgAo5O6YWSy7M9Gzbupmk9OI4TqQPu4zZWFuL5MYUNGmU6reDV8bJ0cFoQ24SFfy1Oy7lGhQUHApbW2kx4xHRv0QJ6LZ8JKDswycvsXnHQbChDCpnLLW83/phy85DWLNoEuZNGY6ZC9ciJo1XghpLx/TqdS7XHkVr/Ar7YvVgV7QWXKr/IEpuU6wiLAoVF8mZgC1HZmpXkHm13HVfBdyTJy9df6fAryeiYFmuMQqUqwOnyo2hSIjVSJ+ExFhtoyhJkQiLgh5gS5aZ2bvwezuN9LyX/1HgOBm+GHsQFYdug1vtTrxQxz+fTpAK+yTBK2yEsODT2li6eMLcobCWLDOB1JMAn/7dFZHvxT11mSkzPEk8ljMw0hSm1i6ZKUYrrXPZdlphFihYviPbZdmdvCXuyT1+IwKxOia3ZLkSPWXkOA4cp+FkHOXEdFIAABAASURBVO7cz3qPuZ7U0irGRG4iGtKg4H/Uq0psfVt3HWONOf676VmimFZ7jB1gPZLMwFXpofL7+Utr6SonxwKi4w4uSXJv2Cta2A0cp/Ed4v1OTlm/YVYdl6zuY2Pj0bYb/xu8aB3GTl+CH3rwv2t2Nmo7IavlUr7sE8gNJUjS4N2w/QDmLduAA0f/RWBQKL8/g7e+743G8+LV28IjFDbEwtXFGWVLlcCN2w+Qmz72Hg1Q9JtRcK81FkUbDEXZviuF9XSZcerebBDK9l6WbnNKtB0rTCRTJXoXmYQadZzUk5eOTC8GmY05KnSbgTI9F+swKDlVVq09W6qs2tQz+GL8EThXaaoVxwJ2nlVh5lAY1kXKwqpIGSYSOcdKzMiuDeXKD7PAXmShMqJtKjRAeFLK0JhIhRksa/QUlZEZQepJgGyIgN/tNZkpQpS2TtspUMhTenMTOSt82WKKKF1mBDZu1VC65QYUrjYYblUHoGSzlXAs9V1mihCl3fJPCCZt8cf5e5G4+jgSc/76iNl/BcDSwkKU1qiCJB2187KCTk46IownUvA3fRzHQf3H+8G78IhI4ymlo+aBfbqKDLS6tarrSGlcUfUvKwsKJCEJCt6xgLmZGaQ2uU4uV855UB13pmeyuoJXKpu9B46KVHn23Mto625XLPcZWn9bHwWdCqBEsSLo2LYpPD2kteIO6CNZAjIpanb89AX8sWwqXAo6YezwPti3ZQnfoxprNFU/BgahsGtKDydbEuVDQKCgz+XLl2EI9+rVK/j5+aWUffoILh/9KyWczXoffkyEf5GGCCzTHq8tyuLafw/SLftxiByxTaYhscEYJDaaiCAXJxQtbCkwYJuC9qYY+UNBdRk+kRwTazje2tAIqbxBCWbqPO8cvoTC4xskWfA9vWY2UBSuguDPWqjjn0baIMnWTZVVubcrjI+eLfl2dICfW308jbZFQKm2iGs6E9ENxmP5tRDEuVvAorwTLMo5IqmkLWb8vlpdZlaOXaj/Y2XdGtvYcB9cuXgmy+XeeuCDyEIdEWNXFzG23yCqUCfcfRmZ5fJU7bpx5wUev7fDk4+OuPXQN9vllS1uhT7NHFG3kjVqlLPm/Q6oVsYCT588/kTZl3M03tzcTOPopHj9/XxyVA/VcUhrr0gUfy/YN+fChQuS0nPPgcO8wctzZOryjv/H1Ru3JaUjY+z9xoe/X+DA/mRsy988JCgSJafnh4+B4DiOB6r85zilf/ee/ZLSNSg4hD/uSVqOaXz636xf69hx+pT78OEDq0ZwB4+fFfZsoznEUZefpSFHBNIiIEsrwphyKysryOVyxMXHI5F/vGfB/3jJki8IxtKLk6Wg4jjlxYnpcuLECRjCPX36FN7e3vj3+GGEHpwMkxO8OzsfSQeG49GRdQapM0PtuPoAJy7dhqeLsoeCMVC54q6mOPevksfxBx8Rztmqovg9hwTI+X3KfxzMcNY7Qd2WM+fPIsAkDPLS9jAtVwAhVjG4ePWSOp7pdyyhKm6aVcNjeVlhfzT+C614lkbTfVf2DTxczCG3NIXcygyuDqYY0DAOx44dSzefZhmp/eGRbAwZ/5OfxBxrTxISecPlxD9nslzmjTPbYftuJSzCzsMi/Aps36/Hg/Prs1we0/nMqSMIvLcGZl7zYfFqHkIf/I6L/x7MVpkj2xdG6lUaJnZ2w6lTp7JVLtNXn66Up7jXx8nRDhfOn5OUnuzsSe04jsOx4yclpeeDx88hk3GCkcZxHGS8i42Lw67d+ySl5zsdb91KTEjE/gN/S0pPhYK/dkD7w3EcTp46LSk9ExKVK7BwXMqxZ7qfP3/eoHr6+vqq4Rw7dVHtzzMeaohRCKRYcUapXnel1pYWwjq8JTyKYsaCtVi+djti4xJ0J84BaUEnR4RoTHZhd72FnJ2EmqdOnQpDuGbNmqFGjRroUdsDjopgoS62kSMRn8ffx6TfRhqk3oy2JS6RnTr8RVvD6IuPV2Ds+MlqvRrNPYPSPRahWIuhwr7WvKso1381in03DCU7zUTNaSfx2/T56vS9WhSBp0MgLE3jYS5PQDH7EHSoJVPHq3T7ecZq9Ji1DWyvkqW1L+qsbWQzhnbWJpgyaYKo3LTKSC13K+LBF8OB//XnHfgPB3NrB0yZOi3LZVZwCeLL0f6v5PYxy+VN5c/LjPJkaTPqPAqKb3QKO8gwecKobOma0fozmu6fw7vQqEFtWFjwNzsmJihfrhSO7dsqKR1ZW7784nPtg86HLCws8PuKpZLSlQ0LYONh+b4+/sk7v+W/90mKJEybNkVSevLK8QS1/zmOQ89efSSlp65l5xjf1SulddzZjQ3H8dc6DaQsOOjnnw3K84svvtCokbxEQD8EZPopRr+l/PpzD6F3d/jALnAv7AL2eHL8iD76rSQTpdWuURUXrt7mje44BAWH4tFTL3xdTfxDlYkiM5w06t0znWnTWkJMZ2I9C9l6kWFCLyd/IWRXP34HcAiPVsDnXcqjKPAfh/J14VavK9ieD8Lus2pwq9sFTlWaIvXrjSOEiV8qI5rf8xkiPz4AdKwQwUdl6z87YyQT4iJEdSfEhGRLT0suTLNMwW9rkYTYyADBn5WNkqd2zuzy/BgSrV0gH2KrNCRx5rxPOv+79x/BP/9eQHR0DNjarA8fP8O8JWuko2CyJs0a1QUzdJKDgr9KpXKqoGT2MpkMHMdB/cf8vGNyySjJK6LrZS3m5uYoX7YUHyud/7S4+fj6S0dJpgknY1stx3EcTE3EHQlaiShABCRIQHw2G1lJ9ghl76F/YG1lCRtrK/Tq0gZsrE5BZ0ejaebh7oY2LRqi95DJGDZuHoYP6gYzU9Mc0YdNvtJVUVpLiOlKq5Lpaxkt1jtRyNFaVax672hnCsZKLcikJzEunM/BAfwFVXDgP9k0dj+Gi09xZpgXcDDe+cS3SvTv/SFeJAsIi4c8G0uIiQrUgyCtVRpCwsQ3AXqoLstFrFy7hT+FuBQHDnsPHgO7WctyoQbIePSfc+A4ju+Y5HtN+S3Hcbh+867k9IyOidXZeku+B11nhJGETJ/UNxByuYmRtEm7WjNTuXBzozzq/Jb1mPPH31hvMEtLU1Md7BhfK+uU+Rtp5dWfnEoiAvohILYG9FNulkthr1d8/SZl/E6WC9Jzxg7fN8W21bOxZdVM1Kv5pZ5LT7s45ypNRJHpLSEmSswLMrqMFns5hOZLIvisaf47O4kNRplJ9k4n9rOfukJORw9D6jTphbkSfeH9PhZs3Blz/sHxeI3GyM7HxqWyKLt1wYpANnT98ywz9qH12XCc7zXWkmQuYAg9D95QgK3ScPxGOE7/FyGs0jBvTxAK2NtlTjkDp37p5S2qgT2Cl1oP2sNHTwU9edMczLGAQqHACx36szhjuXgdy85xHIfzF68bSyWd9d7+7wE4jl1JeCOSNyA5jkNERCSCNYak6cyYw8KiRdwEPdkxFxyvp4y/ftjaiDsSclg1repKl/pMMMy1hLyubJiflowCRCAXEMiehWKgBjo7OWDkpAX45+wV3OAvYCpnoOokXax9mZrI7BJiqRuUkWW07i38Ec82jYDqJRH3F6W/Xquje7XU1cAmO0ZfkgKKRHEvZxIvj4/6KKpLU5Cev1HT1qjYZjOuxnbB+fAOcKu/Ah17DE8vyyfjCn3eFQ6eTSC3cISJmR3s3GujSPWhn8yXXoIrj6PQaoo3Zu34gHm7PqLjrDfYfSE0vSyfjDOEnn17dsTxm5GYtPUDxm58j32XwvDD99+C9fp/UqEcTCDne9BSV8dxHMwtdK/ekDptToUtLS1EVbHBPG6uhURyYwpMdLysJonvlfyiSgVjqiWqOzaOTSgFBCOS3yL588rbJ9knjd3P/boJhiRjKDjeOG/XWnrfo378950RE3Tkjzfb/5DDeq5aMIGpQI4IZJuALNslGKCA9x8DEREZjb2HTuGPbfvVzgBV5Yoi7Ut9Dc/2E1Gm52IU/l8vmFjaITEmApE+j4T9pxoRFaDsRdJMx5bRUsRHCaLAuycR/f6l4FdtovxfIPjhWVVQtNe7McX3bli7iHtOze2KwdTaRVR/ZgTF3AujR+cf0LdHR72M5TMxs0Xhr4agTOstKNvmT7jX/C3bOoL/cfYPSsCBK+HYczEMXv5K458tiYcsfgyh56QxQ/HHynmCkduqeSMsmTsJG1ctyKKGhstWTcdkMDZMyrVQQcNVmoWSXZydBMNHlZUZFBzHQSaT1qXZne+RZLoh+aPyS61HUm6qY6gZBzg5FEjWXBq7Pt07YvsfS9GpQ2u0atEY86ePw5qls6CHj16LYHoOGdgTxT2KwtW1IFo1b4wlcybptY7MFPZN0y7Q5TJTBqXNvwSkdVVNPg6rF06ELpccne93r/bOws1J9fFgWTdh/2r/nHSZmFo6iOJlcgvITK0EeZSv2CBmEdEfXrOdTmcIY8qlUneY2RRW1ye3cIBb1f7qcFY9b96+w6bte7Bu0048evI8q8UYNF+VSuUFw4cZEirn7OgIqRloDELHH1pi/Yq52LxmAX8T8RMTSc6NGzlYpNO4UWKZKFEOC1ryBgTHcXz/Xsoj+K+rVRbmL+SwKulWN3xwHyFewT9xYY6/P+NveppLrmf/yy8qir5HZqZmknvxBJs0e/7SdTB3ge0vX4evn8QmrPFHfP3mnVi+ehO83/ji/fsAHDp2CsN+m8bHGOf/yoltULn9W5dgQI8OaPtdI+MoQ7XmOgKSNHhzHcUcVDj06WV8uLZPq8YPV/Yg7OVNLZlmwL5Y3ZRgsk9TZunimSzV3lkU9OB7kR8jPjzrKwVol5h+iPXmlmqxFqWarwV7K1iZ1luhq9c3/VK0Y0+cPo9y1Rpi4fzZWL1yIb6q1wprNmzXTpTFkL4mAbLqRw8fAI7jtNz40T+zKHJZIFC/Tg08++8Mfl88A/NnjMPVMwcwbFCvLJRk2CyjhvVHv56dULSwGxzs7fHdtw2xdtlsw1aahdJZTx/rkezc4Xu0btFEsj2S7AkEx2l/j8aNlN73aP6SNVi78U/4vvNHSGgYDh87jX5DxmbhyBg2y+79R0UV7D90QhKTKl0LOaP7T63g8+69SEcSEAFdBGS6hCSTLoFw7/s6lUtr+TKW2LlcexSt8Svsi9WDXdFacPtyENjrZlkcc85ftoCly2fMq3ZsFYgXf47ne5G74vb0Zni8dqA6jnkS48Lx7sYyPP27G57s74S3l+cgPlI/Fx4z28Iwt2dr3bKasuc2b1iBPRPcsXdSMewcVwxHp3vg2N512So0o5MAM1NJ04Z18fjmaSxfMBWLZk/AjXMH0b9X58wUQWlTEShS2BXdO7XDoL5d8Xn5MqlipRFkQwIWz5mIRzdO4tWD8/hr0wqU9CwuDeVSadGmZVOhZ3/nxuVgY1AtdYw/TpUlx4OqGx32PZozdbRwozOav6lISxFjyU/yN+Kp675x6x7CwiNSi40afvbCS1S/sScMvUKFAAAQAElEQVRVsidgL1+9xeu3foJuDep8JfTqCwHaEIF0CJDBmw4cKUbJLW11qmVq66RTrhLaezRA0W9Gwb3WWDiWbK4Sq/eVfv0LqpdEeLafhDi+VzcpQTkBhCUKe3ED/hf+ZF7Bfbi/FcFeJ5EQE4TEuDCEvb0I3+tLhTgpbeqXDBK9GaxXI1OhVyWremZkEmBWymZjjXt17SAYuvpcN1SfPdGqdrEy48LeqIKS3b/yfov7ySshSFZJUkyvBNiNTref2vDfo06SvdFJq8FSG7vduEEdQdWk5EE3LODmWghlSnkyb4674JAw9Bw8EV0GjMVPfUah/4hpaFC7uvBkLMeVoQpzHQFJGrznLt+SCEjpqeFc9VuYmGsvXcPC9qWqf1JZZqTEhnqnmY69HIK9JEJuZaczTeS7lJdghPncRIx3KCLvvUfknQ+I8QpGuM8dIEmhM29GhaHeZ+BzZT7eXpqNoBdHM5otzXTlilmK4oq7msHOSi6SZ1QQEyzu9dCcBJjRcgydzhA90aoyX//zM7xPD+d7+LsiUnhhiKFbk7nyX3i9RrW6LVGxehPUaPA9ipX7Bmx4S+ZKodREwDAEmjQUDzP76stKkhu73e2ntjAzMwOn+uOAbh3bGgZKBkpd9PsWVCxXCtvXzEXlimXQvnUTLF+X0hGTgSIoST4mIEmDd9+hU2jf81f8tf8EYmLj8vHhETddbu2AikO2wLVOZxQoW1vYszCTi1MrJSoj5fnRfnhx/OdPGilp9RbLLW2UBfLbmFfvkBAQjaT4JCQlKpAQHIvY1yF8TNb/Ax7vhs/VhQh9cw5hPpfgd+t3vLu5IusF8jmtbR35rfZ/EicHm7SnLc14yMQshYMql8zELFtlJsaF48Kukbi2+Xvc2Noa5/4clO0hIrp6ot/xTFU6Z2VviDKzosen8kybswyPn75QJwsMCsHQ0VPVYal5XvE90Q8ep9xQSk0/QZ9ctJE6z1HD+oON3Wa90QXs7SQ7dnvLjn2IS17qjR3+pCRgy859zGsU9/TFK/z6czd4Fi8i1N+oXg14vfYR/LQhAp8iIEmDd+nsMZg3ZQSee3mjXffhWLpmG/zf58zEqU8Bk0I8m0zm0XI4yvRaArZnYUV8TJoTzHQZKX63037Nqk3R8rAsVELUVKcqTdWymGDxK2YTw/mbE3ZFVKfKnCf0zXlRhlDvc9nqNb7rI+7hveHF9+5yWT/17XVNAvSoD2SjzJPbf4Nj0hPYWCTAyiwRziZvcObP7K3tq6snOi7cF4r4rI8TNESZMMDn+q27olLf+rzL1lAWUYF6EKh6oqvUbIE6TTpIuieaTVbqM3gMOvb8BSvXbhFe26wHBHotIrfwtLWxRt1a1QVXh+1rVkcRN1e9stBHYddv3REV4+f/Af4fsr42uqjATAhMZDJwHN/NnJwnPj4BbExxcpB2RCBdArJ0YzMXqdfUJTyKYMKv/bBszm84de4a2nQbhkmzV/JfNDJ8U4P2v7AdNyf/L80JZp9ahzd1eZCZoPzAtSjSqC8KlKuNQl+35cPrYVPsc3XSgFDeuFWHlJ5EBX/7r/RmfpukQFyEchKCZmZFQjSy8+KJpXu8kfrNYMOXP8nWLGPncu2R3iRATf0z6jeN8xYldbUJR2KCcj1eUWQGBDp7otlydHLlcnQZKEKUxBBliirRg8ClkLOoFBn/Y8kMDVGEEQWzFqxEbuiJZstTdekzDDt2H8Sho6cweuJs9B86zojkdFdNPHVzyarURce61ex7VFDHmzazWkdm8jk6FEBAYLCQJSIiCj1/mYjmjZXjjAUhbYhAOgQka/B6eftgxsK1GDZ2Lr5tWAu7Ny5E2dKeGPLb7HSak/+i4kI/wPvQYqQ3wcz0E+vw6qImt3ZA0Sb9UabnEpRoNw62JapoJbvxVmzw3vVPREh4pFa6DAc4mc4lyNhSZdl98UTqN4NlWKd0En5qEmA6WXVGsZ4KXRHZeRWuIXqiDVGmrnZnV9a1YxtREWyVARMTE5HcMIKMlXr7zgNRQin2RG/duV+kJ+vxTUxMFMmNKSCe+qXfvo14grMxv0ejhvQC38UL9mn1bX38NrQXOnzflAXJEYFPEpCkwTts3FyMm74U5ct4YvemRRjUuyOKFnZBp3bfwlRu+slG5acEkT6PdDZXc4KZTiNFx2N5nQWlIbwR74nDz+IREKVASHQSzryKx8an1mDj0dLI8kmxIV48Ub/ON6J669T8ClIzfN5HFRDp+cQnCR4e7iJ5RgWG6Im+9c5F1GN+6J5DRlXKsXRs3dht65fgp/at0LJ5I8ybPlaSb7KytxdPEGU9aFLriX723Et07Nij5Bde4icTooQ5KCCe+oWt+h6xl820aPY/o3+Piru7wdlRea1khm7FcqWwcOUW/TaaStM/AYmUKEmDt33rpti5fj7YG1QszM20UG1fO0crnN8DGZlg5lxO/4/ghwz9BYuuxKHD7mi03RWF6efj0HvgoGwdDtabq+8XT0z6bQh6dP4Bri4F4cRfKNu2aoZVi2dmS09DZK7eYiz+va/Ax5AEBIcn4sLDOLhVG5LtqvTdE714xR9I3WM+d9HqbOtpiAJYTxR7I9xOCa8bm1t6or9tUl90iNyLFoaxlqcSKZMsIJ7JIPS4Y9+jNUtnYevaRUZff3nXgRPChHbN1wvvOXhSeN3w2s279dhqKiovEpCUwXvp+h0wBw7Cnvk1XV48ANltU0YmmLE69G34GPJFCfp88QQb87Vy0XQ8uXUaL+6exdZ1i+FRTDnDl3GRiitfoTJ+mXEURRuvhmPtZRgw7STqNGgmFfXUejx9/lLtV3nefwxANiexqIrKd/uUHrTvIIUetLQOAHtbWbkyJdXR7OZx6bzJ6rBUPMRTKkfCMHowg5dNar9yYhtUji1Pxvz9urc3TKVUap4hICmDd9f+E0jP5Rnq+myI7NMTzPRZnWZZhnpRgmYd+c3P3rKlz5dO6JtfmVKfiYp0KegMVx2TW0QJSaCTgKoHbds64/eg6VSQF7Lz8ub5Q3hw/aTw9rI3j6+A3fTyUZL7J56SOyR6U8jC3ByFXQvprTxpFkRaGYqApAxedueWnjMUhNxe7qcmmOX29pH+0iEwfHBvkTJjRgwQyUiQNwmU8HDPdW8vk/KRIJ6fPjqLft+sTrRtjXjS+uqFE9Xx5CEC6RGQlMGbnqLZjWOPQtjrCLsNHI/zV27rLI4tdzJ49Cz0+mUS2KS56JgYId1/9x7jt2lL0KhNX/QZOgX0JjgBC22MRMCY1bJevcc3T2PJ3EmYN/033Dh3EP17dTamSlQ3ESACeZjAc6+3ebh11LScJCApg5cNRL//6LkwAJ35U7usgvF+64ctOw9hzSL+R3rKcMxcuFbnG9yWrtmOGtUqY8PyabCzs8X23UeFKq0sLTBycA+c2LsG3Tu2EvILEbQhAvmQABvKwiYC9u3REVIefpEPDw01mQjkNwLUXiKQYQKSMnjZwPPPy5dSD0ZnYU2X4ValSnjx6m3Uq1UN1laWcHVxRtlSJXDjtnj9y0vX7qBFE+Ui1i0a18HFa/+Bfcrw6dlSKCYyGWrX+ALx8fFQ9f6yeHJEgAgQASJABIgAESAC0iUgKYPXUJg+BgahsGtBdfFsTd8PAYHqMPNERkWDvbHQoYByXUz3Ii74GBDEorTc/sOnUdLTA5YWFlpyCkiUAKlFBIgAESACRIAI5HsCkjR43/j4g718on7LXlrDG9I6Wiv/2IF+w6eK3M59x9VZOL53VhXgOE7l1dqzBd9VAo4To7n38Bm27zmKSaP6q5IhMjLCIC4uLlboSTZU+fmt3OjoKMTERBvkWOU3lqy9xFO/33viSTzZ98rQLqvl5/T5mZCQoP6NLeXprvaThwhkh4DYqstOaXrKO23+arRs1gBlS5fAoT+XY3Cfn9C7S5s0S+/VuQ0WTh8pcm2++5+Qp6CTI0JCQgU/2wQFh6CQsxPzqh0b7pCYqEBcfLwgC+TTFHR2FPxsw3p7V6zfgRXzxsK9iCsTCc7KyhqGcKamZjA1NTVI2YbQV+plWlhYwtzcgnjq6Xwlnvr93hNP4inla2hOn59yuRyqz4hB3VVerNuyB+ERkeqwynP34VNh7X5VmPZEQBcBSRq8MTGxaFi3OtirK52dHNC5fQt4vfbRpb8gY8ML2Ks4UztzM+Vb2mrXqIoLV28jNi4OQcGhePTUC19X+1zIy1ZgiI9X3k3WrF4Fp85eEeQnz1xG7a+rCH62esP4mcsxbnhfuLmkDI1gkRzHgeMM4wxdPsel1pvCHEcMOI4YcBwx4DhiwHHEgONyngH77dPl2ORztpJSRGSUVrS9nR02bj+gJaMAEUhNQJIGr5WVcnwsx3F46+uPmFhmqIal1j3DYQ93N7Rp0RC9h0zGsHHzMHxQN5jxvaesgNFTFiM0LJx5MWxAZxw6cV5YluzNWz/B0GYRu/8+CbZ6xE99R6uHWPh/CGBR5IgAESACRCAvEqA2SY5AgQJ2/NPfehg5cSFUHVVMyeL8b7z/e/pNZizIpU1AlnaU8WKqVCyDEN4I/altc3TqOwYNWvVC4wY1sqVQh++bYtvq2diyaibq1fxSXdY/+9aC9SIzAduvWjBBWJZs1sSh6olpA3v9KFo5wrWQM8tCjggQASJABIgAEcghAj+0aoLKFUvjlzGz1RPLWaeYXG6SQxpQNbmVgCQN3kG9O6KAnS3q166GC0c3C8Zmu5aNpcaY9CECRIAIEAEiQARymADrhKpauSy6DBiHpWu2oXO/39CsUa0c1oKqy20EJGXwrt28G+m53AaX9CUCRIAI5A8C1EoiYHgCFcp+pq6kX/f2GDeiL5QvhuqOAT06qOPIQwR0EZCUwatS8MWrt9ix7zhe8vt3/gHYe+g0Hj7xUkXTnggQASJABIgAEchnBOZMGqbVYjY8sW+3H/DNV5W15BQgAroI5JjBq6vy1DJ2x8ZcUHAY9m5ahLlTRmDKmIH4e/symJhwqZNTmAgQASJABIgAESACRIAIfJKApAxelbbR0TFwdLBXBWFhbgZTjXX51BHkIQJEgAjkPgKkMREgAlkg0LLTLzpzXbp+R1iBSWckCYlAMgFJGrzCagkb/oLXa198CAjCn3uOgr0UIlln2hEBIkAEiAARIAJEQCBQqXwpPPfyFvy0yW0Eck5fSRq8U8cOQmBwKAaPmYkeP0/A6zfvMGFU/5yjQjURASJABIgAESACkiLAXgL1TdMu6vXwVf4m7fqDvVRKUsqSMpIjIEmDly1JNuHXfjj61++CGzeij7BMmeTokUJEgAgYnABVQASIABFgBNjT3ysntglLleraszTkiEBaBCRp8KalLMmJABEgAkSACBCB/ElAc1my/EkA1OxsECCDNxvwKCsRIAJEgAgQASKQMwRSL0uWM7VSLXmFABm8eeVIUjuIACNAjggQASKQRwkkJSXh2KmLGD9jmeCYn8nyaHOpWXomQAavsiCZXAAAEABJREFUnoFScUSACBABIkAEiID+CSz6fSsOHj8LNpbXxsYaO/cdw5LV29KsiCKIgCYBSRq8F6/+h77DpqJO8+5aszE1FSc/ESACRIAIEAEikH8IvPHxw6oFEzB8YFeMHdYbG1ZMx9Wbd/MPAGpptghI0uD9Y9s+jBzcHWcPb9SajZmtllJmIiAiQAIiQASIABHILQQsLc1FqtryPb0iIQmIgA4CkjR4XQo5oUzJ4jCRSVI90IcIEAEiQASIQJ4ikAsaY2JiglGTFwrjeHcdOIEBI6ajlKcHbvz3QHC5oAmkohEJSNKidHIsgH2HTyEiMsqIaKhqIkAEiAARIAJEQCoEAoNCEB4Rhb+PncG/F67DxESGV2988ce2/YKTip6khzQJSNLg3XfoFOYv34TGbftJfgxvfHwcDOFatvwOffv2MUjZWdQ3V+sCJIHjuFzdBikdN+Kp3+89m2nOcXR+6uscJ576Pj8VkMly7vxUKBQ6LabVCyciPaczEwmJQDIBSRq8ut6gwmTJOtOOCBABIkAEiIARCVDVRIAI5DYCkjR4cxtE0pcIEAEiQASIABEgAkRAugQkafC+8fHHsHFzUb9lL8kPaUjr0GZHfvfBU/QYPBFdB47D+q17s1NUvsl79+FT9Bs+FbW+7YZT565C85MWz4DAYAwePQu9fpmEcdOXIjomRjNbvvYfOXleWBqwUZu++HXifLzy9lXzIJ5qFBn27DpwAnVa9EC973pi8JjZePT0pTov8VSjyLTn+u37wm+E5tJUxDPTGPHX/hMCx2+adhH2W/46pC6EeKpRkCeXE5CkwTtt/mq0bNYAZUuXwKE/l2Nwn5/Qu0ubXI46Y+qzsWeTZq/E6F96YOOK6cLA/P/uPc5Y5nycysLcHP27/4D6tappUUiP59I121GjWmVsWD4Ndna22L77qFbe/BxgK6WsmDcWh3YsR6nPPLB6418CDuIpYMj0pn7tr3D6wDoc37MKjet9jWVr/hTKyCc8hbbqexMXH4/fN+xC+TKfCePzWfnEk1HImuvdpa16GdBuP7YUCiGeAgba5BECkjR4Y2Ji0bBudbCB6+yNKp3bt4DXa588gjz9Zjx98RpWVpbCRVxuYoImDWriwtXb6WeiWGEZuy+rVIBMpn1Kp8fz0rU7aNGkjkCvReM6uHjtP8FPG6Aaz9LczAyWFhaoVf0LvA8IFrAQTwFDpjeFnB1hZmoq8LS0tEAS/8cKIZ6MQtbc5h1/o2ObprCxtgIzzFgpxJNR0J8jnvpjSSUZn4DM+CoASKWElZWFIOE4Dm99/RETG4eg4DBBltc37z8GoYhrQXUz3Yu44P2HQHWYPJkjkBbPyKhovlcIcChgJxTIOH8MCBL8tNEmsGPvUXxdtaIgJJ4Chixt1m/dJzwuXrl+J2ZOGCKUQTwFDJnesN+FB49folnD2lp5iacWjkwF/txzFA1a98boKYvwIflaSDwzhZASS5yAJA3eKhXLICQsHD+1bY5OfcegQateaNyghsRR6k89TsZpFCbJQ6Shn/S9afHU7A3mOOKs60hu332E/y5GoJfGkCIujfOTeOoimCLr07UtzhzcgCH9O2HCzOXqiNQ8VRHEU0VCvF+wYjNG/dJdHMFLiCcPIZP/jevXwMm9q7F11SzY2thgxoK16hKIpxoFeXI5AUn+yg/q3REF7GxRv3Y1XDi6WRhX1K5l41yOOmPquxR0RHBIuDpxUHAI2HhKtYA8mSKQFk9rK0skJirAxgGyAgN5zgX5x87MT05J4Prt+7h19yGWzBoNNryBSYkno5B1Z2FuhoZ1a+DBo+fCkC3imXmWCYmJYOdm+54jhR5z5h8+fj7OXb4F4pl5niyHo4M95HI5ihZ2wfCBXfD4mRcTE0+BAm2MSECvVUvS4GVGyIbtBzB5zu9CY71e++L0uWuCP69vypQsDrZ6AHtkl6hQCO2uXaNqXm+2wdqXHs+a1avg1NkrQt0nz1xG7a+rCH7aAGzVi41//o1ZE4cJY09VTIinikTm9g8eP1ePM71w5TaKubuB9eASz8xxZKnZ3Aa2LrvKVa/6ORbPHIV6Nb8UxvKndf2k7zujp9tpvtX03/PXUK60p5CQzk8BA23yCAFJGrxT562G//sAvPHxEzAXdiuILX8dFPx5fcNxHKb+NggTZ61Aj58n4MsvyqNqpXJ5vdnZbh9blogtqcOWJGPs2HJarFCOS5vnsAGdcejEeWFZsjdv/cAmR7I85IAV63bizv0nwnAixvWHHiMELBwnMZ6CVtLfXL5+B7Wbdxd6JOcs/YPvResqKM1xxFMAoacNxxHPrKCcsWCNcG42/L4Prt26j4kj+4F9OI54Mg7k8gYBmRSb8drbF+NG9IE5//iP6cceA8YnJDBvvnCVK5bBppUzhPFUfbu2yxdtzm4j2fJiqh4ftj+1f526yLR4shVAVi2YICxLNmviUGEGvTpTPvesWzJZGErEWDK3Z9MiNRHiqUaRYU+/7u1x6dgWgemRnSvx1RfKSYCsAOLJKGTdLZ09RlheUFUC8VSRyPh+zuThwrl5+sB6YUKl5vAu4plxjsZOSfWnT0CSBq9cbqKldUI+Mna1Gk4BIkAEiAARIAJEgAgQgWwTkKTBW6lCGWzddRgREVHC5ISRkxaiQZ3q2W4sFUAE8jcBaj0RIAJEgAgQgfxJQJIG74hBXeHkaA9TUzkWr9qG/9X9Gr075483reXP05BaTQSIABEgAkQgBwlQVfmOgCQNXo7j0LxRHWxcMR071s1Fq2b1hRnN+e7oUIOJABEgAkSACBABIkAEsk1AUgbv2s27kZ7LdmupACKQcQKUkggQASJABIgAEcgjBCRl8LJ1P89euonb957odHmEOTWDCBABIkAEiEAuIkCqEoHcT0BSBu+Qfp1hYW4OK0tztP2uIZbN+Q2rF05Uu9yPm1pABIgAESACRIAIEAEikNMEZDldYXr1/dTuW2FN1MF9O+Hp81foPnAcpi9Yi1fevullozgJECAViAARIAJEgAgQASIgVQKSMnhVkDw9iqJn5zZo37opzl26gf/uP1ZF0Z4IEAEiQASIgJQJkG5EgAhIkICkDN6ExEScu3wLY6cvQcfeo+Ht8w7rl01D2+8aSRAdqUQEiAARIAJEgAgQASKQGwhIyuBt2XEwNu/4GzWrV8HeLYswfGA3FHd3yw0cM6cjpSYCRIAIEAEiQASIABHIMQKSMnhDwsLx+JkXZi1aj/ote+Gbpl20XI5RoYqIABEgAkQgRwhQJUSACBCBnCAgKYP3yoltSM/lBBCqgwgQASJABIgAESACRCBvEZCUwasbLUmJABEgAkSACBABIkAEiEDWCZDBm3V2lJMIEAEikLMEqDYiQASIABHIEgEyeLOEjTIRASJABIgAESACRIAIGItAZuslgzezxCg9ESACRIAIEAEiQASIQK4iQAZvrjpcpCwRIAIZJ0ApiQARIAJEgAgoCZDBq+RAWyJABIgAESACRIAI5E0C1CqQwUsnAREgAkSACBABIkAEiECeJkAGb54+vNQ4IpBhApSQCBABIkAEiECeJUAGb549tNQwIkAEiAARIAJEIPMEKEdeJEAGb148qtQmIkAEiAARIAJEgAgQATUBMnjVKMhDBDJOgFJmj8CxUxfRe8hkwQ34dTpmLVqPDwFBQqHfNO0i7PWxufHfA7Dy9VEWK+Pew2fo9csk5k3X+b3/iL+P/ptuGookAkSACBCBnCNABm/OsaaaiAAR4AnsP3Iav2/4C+NH9MMfy6Zi9cKJ6NiuGT4mG7x8Esn+exYvilG/9Pikfv7vA3D45IVPpqMERCAPEKAmEIFcQYAM3lxxmEhJIpB3CGz8828M7d8ZnsWLqBvl6VEUFcqWVIfXbNqNvsOmonO/33Dn/hO1/Prt++g/Yhq6Dxov7B89famO23voH0HebeB4NP1hAIKCQ9VxzBMQFIKegyfi8IlzLAjWk7x87Xb0Gz4VP/UZhX/OXhHkbHPu0k30GToZPfj0Q8fOxStvXyaG12sfzF++SfCz3mMWP276UkGX4ePnq3upV/6xk0/7Fqx3mfVeCxloQwSIABEgAkYjQAav0dDno4qpqUQgmUBkVLTQk1u1Urlkie5dCY8iWLdkMsYM7YU5S/8QEgUGh2DGwnUYNbgHNv8+EyMGdcPYaUuRkJiIS9fvYBNvSM+cMARbVs3ke46nwMbGChzHCe7ZS28MGjkdA3t1wHdN6wnlsY2He2GsXTwZy+aMxaKVW8DqCAgMxpR5q4TyN62Yjiqfl8W0+atZcpHzfvsO/Xp0wJpFk/Bto1rYsP2AkObn3h15g95d6L0eN6KPIKMNESACRIAIGI8AGbzGY081E4F8RyApKSlDba5f+yshXaUKpeHr91Ewau8+eIaYmFgsWLlZ6DldvGorQsMi8MbHD1dv3EOrb+ujaGEXIV/Rwq4wMzUFq8/H1x+sl3b2xGGoXvVzIV61+V/drwVvQWdHlC3tifsPX+Duw+dCb3P5Mp8JcZ3bN8fTF6/BjHVBoLEpWaIYiru7CRI3l4JCr64QoA0RSIMAiYkAETAOATJ4jcOdaiUC+ZKAjbUVmHF5+95jpPdhxqoqXi43QSLfi8txHMqULC70mrJxv8ydPbQBnh5FhaRyuamw19xwHAeXQk4oWcIdh08qhzJoxuv080a53CTl0mgql0PGl6MrrYlGOplMhoSERF3JSEYEiAARIAJGJpByVTeyIlS9igDtiUDeJtCzU2ssWbUNp89fhUKhEBrr5e2Dh09eCP60NlUqlhF6Wk+fu6ZOcuXGXcFf46tKwthcn3fvhXBcfDyYYwFTvqd38cxReOH1Vj3+lsmZ27nvONvh6fNXuP/oGT6vUBKVK5bmdXmJJ7yMRe7YewyleUPb2sqSBTPk2HCKsPDwDKWlRESACBABImB4AmTwGp4x1UAEiIAGgTYtGuLnPh2xddcRdOwzCj+Pmom/9p8Qen41kom8DgXsMGfyMOw7fApssliz9gPAVnxgCWtVr4If2zTFuOnL0HXgODRu0w8REVHCkAY2rEHO99Iyo/ed/0fMXLSOZRFcVHQ0OvUbgylzfxfGCzs5FICzkwMm/NpPMI7ZJLdrt+5j4sj+QvqMbjyLu6NKxbIYMWGesORaRvNRulQEKEgEiAAR0BMBMnj1BJKKIQJEIOMEvm1UG5tWTMeuDQuxcv54jB3WG4WcHYUCrpzYJuxVmzN//wFzMzMhyCa7sfQs7/HdqzFvyghBzjYdvm8qTFjbumoWzh3eCEcHe3z1RUVhCASLVxm940f0ZUHBDenXGX+unYsd6+ejcf1vBBnb1KtVDWzJtI28jktnj0EJjyJMDDameMPyaYJfs2wmqFD2M6jiTGQyjB3eB4tmjAZNWmN0yBEBIkAEjEsgtxu8xqVHtRMBIkAEiAARIAJEgAhIngAZvJI/RKQgESAChiCQuifZEHXkbJlUGxEgAkSACGBfhs4AAAMmSURBVKRFgAzetMiQnAgQASJABIgAESACRCD3EdChMRm8OqCQiAgQASJABIgAESACRCDvECCDN+8cS2oJESACGSdAKYkAESACRCAfESCDNx8dbGoqESACRIAIEAEiQAS0CeSPEBm8+eM4UyuJABEgAkSACBABIpBvCZDBm28PPTWcCGScAKUkAkSACBABIpCbCZDBm5uPHulOBIgAESACRIAI5CQBqiuXEiCDN5ceOFKbCBABIkAEiAARIAJEIGMEyODNGCdKRQQyToBSEgEiQASIABEgApIiQAavpA4HKUMEiAARIAJEIO8QoJYQAakQIINXKkeC9CACRIAIEAEiQASIABEwCAEyeA2ClQrNOAFKSQSIABEgAkSACBABwxIgg9ewfKl0IkAEiAARIAIZI0CpiAARMBgBMngNhpYKJgJEgAgQASJABIgAEZACATJ4pXAUMq4DpSQCRIAIEAEiQASIABHIJAEyeDMJjJITASJABIiAFAiQDkSACBCBjBMggzfjrCglESACRIAIEAEiQASIQC4kkKcN3lx4PEhlIkAEiAARIAJEgAgQAT0TIINXz0CpOCJABIiABAmQSkSACBCBfE2ADN58ffip8USACBABIkAEiAARyPsEUgzevN9WaiERIAJEgAgQASJABIhAPiRABm8+POjUZCJABNInQLFEgAgQASKQtwiQwZu3jie1hggQASJABIgAESAC+iKQZ8ohgzfPHEpqCBEgAkSACBABIkAEiIAuAmTw6qJCMiJABDJOgFISASJABIgAEZA4ATJ4JX6ASD0iQASIABEgAkQgdxAgLaVLgAxe6R4b0owIEAEiQASIABEgAkRADwTI4NUDRCqCCGScAKUkAkSACBABIkAEcpoAGbw5TZzqIwJEgAgQASJABABiQARykAAZvDkIm6oiAkSACBABIkAEiAARyHkCZPDmPHOqMeMEKCURIAJEgAgQASJABLJNgAzebCOkAogAESACRIAIGJoAlU8EiEB2CJDBmx16lJcIEAEiQASIABEgAkRA8gTI4JX8Icq4gpSSCBABIkAEiAARIAJEQEzg/wAAAP//DjTHUwAAAAZJREFUAwDBbnPh6cX8/AAAAABJRU5ErkJggg=="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -4272,13 +3514,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "731fcde6",
+   "id": "f98cd8ed",
    "metadata": {
     "papermill": {
-     "duration": 0.00517,
-     "end_time": "2026-08-27T22:48:46.058031+00:00",
+     "duration": 0.003076,
+     "end_time": "2026-08-28T00:29:43.878301+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:46.052861+00:00",
+     "start_time": "2026-08-28T00:29:43.875225+00:00",
      "status": "completed"
     }
    },
@@ -4292,19 +3534,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "6dfaba72",
+   "id": "e1711159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:46.071611Z",
-     "iopub.status.busy": "2026-08-27T22:48:46.071369Z",
-     "iopub.status.idle": "2026-08-27T22:48:46.224463Z",
-     "shell.execute_reply": "2026-08-27T22:48:46.223486Z"
+     "iopub.execute_input": "2026-08-28T00:29:43.884977Z",
+     "iopub.status.busy": "2026-08-28T00:29:43.884858Z",
+     "iopub.status.idle": "2026-08-28T00:29:44.006674Z",
+     "shell.execute_reply": "2026-08-28T00:29:44.006055Z"
     },
     "papermill": {
-     "duration": 0.160519,
-     "end_time": "2026-08-27T22:48:46.225056+00:00",
+     "duration": 0.125692,
+     "end_time": "2026-08-28T00:29:44.007076+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:46.064537+00:00",
+     "start_time": "2026-08-28T00:29:43.881384+00:00",
      "status": "completed"
     }
    },
@@ -4337,13 +3579,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fed2e8b",
+   "id": "b396efd0",
    "metadata": {
     "papermill": {
-     "duration": 0.005359,
-     "end_time": "2026-08-27T22:48:46.235975+00:00",
+     "duration": 0.003382,
+     "end_time": "2026-08-28T00:29:44.017970+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:46.230616+00:00",
+     "start_time": "2026-08-28T00:29:44.014588+00:00",
      "status": "completed"
     }
    },
@@ -4357,19 +3599,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "22239446",
+   "id": "b4e75189",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:46.247214Z",
-     "iopub.status.busy": "2026-08-27T22:48:46.247076Z",
-     "iopub.status.idle": "2026-08-27T22:48:46.999972Z",
-     "shell.execute_reply": "2026-08-27T22:48:46.998761Z"
+     "iopub.execute_input": "2026-08-28T00:29:44.027003Z",
+     "iopub.status.busy": "2026-08-28T00:29:44.026824Z",
+     "iopub.status.idle": "2026-08-28T00:29:44.627722Z",
+     "shell.execute_reply": "2026-08-28T00:29:44.626984Z"
     },
     "papermill": {
-     "duration": 0.761581,
-     "end_time": "2026-08-27T22:48:47.002664+00:00",
+     "duration": 0.605374,
+     "end_time": "2026-08-28T00:29:44.628095+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:46.241083+00:00",
+     "start_time": "2026-08-28T00:29:44.022721+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4387,7 +3629,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (96, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>fold</th><th>validation_start</th><th>ic_mean</th><th>n_decision_times</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>datetime[μs]</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.042554</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.029586</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.038323</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.01963</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>6</td><td>2017-01-04 00:00:00</td><td>0.011302</td><td>258</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;296531884fa8&quot;</td><td>1</td><td>2022-01-03 00:00:00</td><td>-0.03187</td><td>258</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.101477</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.05617</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.093007</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;296531884fa8&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>-0.054438</td><td>253</td></tr></tbody></table></div>"
+       "<small>shape: (96, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>fold</th><th>validation_start</th><th>ic_mean</th><th>n_decision_times</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>datetime[μs]</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.042554</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.029586</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.038323</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>7</td><td>2016-01-05 00:00:00</td><td>0.01963</td><td>258</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>6</td><td>2017-01-04 00:00:00</td><td>0.011302</td><td>258</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>1</td><td>2022-01-03 00:00:00</td><td>-0.03187</td><td>258</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.101477</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.05617</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>0.093007</td><td>253</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0</td><td>2023-01-03 00:00:00</td><td>-0.054438</td><td>253</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (96, 9)\n",
@@ -4471,19 +3713,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "12d1fb6c",
+   "id": "e2022413",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:47.020626Z",
-     "iopub.status.busy": "2026-08-27T22:48:47.020435Z",
-     "iopub.status.idle": "2026-08-27T22:48:49.638238Z",
-     "shell.execute_reply": "2026-08-27T22:48:49.636154Z"
+     "iopub.execute_input": "2026-08-28T00:29:44.646249Z",
+     "iopub.status.busy": "2026-08-28T00:29:44.645710Z",
+     "iopub.status.idle": "2026-08-28T00:29:46.365195Z",
+     "shell.execute_reply": "2026-08-28T00:29:46.364816Z"
     },
     "papermill": {
-     "duration": 2.627008,
-     "end_time": "2026-08-27T22:48:49.638866+00:00",
+     "duration": 1.73076,
+     "end_time": "2026-08-28T00:29:46.365730+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:47.011858+00:00",
+     "start_time": "2026-08-28T00:29:44.634970+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5105,13 +4347,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13d1cf0d",
+   "id": "dd7faa82",
    "metadata": {
     "papermill": {
-     "duration": 0.006085,
-     "end_time": "2026-08-27T22:48:49.652331+00:00",
+     "duration": 0.004038,
+     "end_time": "2026-08-28T00:29:46.377828+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:49.646246+00:00",
+     "start_time": "2026-08-28T00:29:46.373790+00:00",
      "status": "completed"
     }
    },
@@ -5126,19 +4368,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "bf4a642a",
+   "id": "acc80fe2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:49.664828Z",
-     "iopub.status.busy": "2026-08-27T22:48:49.664574Z",
-     "iopub.status.idle": "2026-08-27T22:48:49.718489Z",
-     "shell.execute_reply": "2026-08-27T22:48:49.717740Z"
+     "iopub.execute_input": "2026-08-28T00:29:46.387240Z",
+     "iopub.status.busy": "2026-08-28T00:29:46.386745Z",
+     "iopub.status.idle": "2026-08-28T00:29:46.421172Z",
+     "shell.execute_reply": "2026-08-28T00:29:46.420934Z"
     },
     "papermill": {
-     "duration": 0.062875,
-     "end_time": "2026-08-27T22:48:49.718914+00:00",
+     "duration": 0.039835,
+     "end_time": "2026-08-28T00:29:46.421843+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:49.656039+00:00",
+     "start_time": "2026-08-28T00:29:46.382008+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5156,12 +4398,12 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>689e938f32ee</th><th>0cff45d5daf6</th><th>eeff2961026c</th><th>01e41111cb52</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>1.0</td><td>-0.05266</td><td>-0.03702</td><td>-0.106283</td></tr><tr><td>-0.05266</td><td>1.0</td><td>0.458599</td><td>0.436074</td></tr><tr><td>-0.03702</td><td>0.458599</td><td>1.0</td><td>0.24454</td></tr><tr><td>-0.106283</td><td>0.436074</td><td>0.24454</td><td>1.0</td></tr></tbody></table></div>"
+       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>d80638423af7</th><th>0cff45d5daf6</th><th>eeff2961026c</th><th>01e41111cb52</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>1.0</td><td>-0.05266</td><td>-0.03702</td><td>-0.106283</td></tr><tr><td>-0.05266</td><td>1.0</td><td>0.458599</td><td>0.436074</td></tr><tr><td>-0.03702</td><td>0.458599</td><td>1.0</td><td>0.24454</td></tr><tr><td>-0.106283</td><td>0.436074</td><td>0.24454</td><td>1.0</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 4)\n",
        "┌──────────────┬──────────────┬──────────────┬──────────────┐\n",
-       "│ 689e938f32ee ┆ 0cff45d5daf6 ┆ eeff2961026c ┆ 01e41111cb52 │\n",
+       "│ d80638423af7 ┆ 0cff45d5daf6 ┆ eeff2961026c ┆ 01e41111cb52 │\n",
        "│ ---          ┆ ---          ┆ ---          ┆ ---          │\n",
        "│ f64          ┆ f64          ┆ f64          ┆ f64          │\n",
        "╞══════════════╪══════════════╪══════════════╪══════════════╡\n",
@@ -5202,19 +4444,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "105c59f6",
+   "id": "47a064ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:49.729988Z",
-     "iopub.status.busy": "2026-08-27T22:48:49.729771Z",
-     "iopub.status.idle": "2026-08-27T22:48:58.257836Z",
-     "shell.execute_reply": "2026-08-27T22:48:58.256889Z"
+     "iopub.execute_input": "2026-08-28T00:29:46.434474Z",
+     "iopub.status.busy": "2026-08-28T00:29:46.433907Z",
+     "iopub.status.idle": "2026-08-28T00:29:52.959908Z",
+     "shell.execute_reply": "2026-08-28T00:29:52.959295Z"
     },
     "papermill": {
-     "duration": 8.54589,
-     "end_time": "2026-08-27T22:48:58.269875+00:00",
+     "duration": 6.535073,
+     "end_time": "2026-08-28T00:29:52.961457+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:49.723985+00:00",
+     "start_time": "2026-08-28T00:29:46.426384+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5232,7 +4474,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (20, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0</td><td>-0.000088</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>1</td><td>-0.000055</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>2</td><td>0.000091</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>3</td><td>0.0001</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>4</td><td>0.00008</td></tr></tbody></table></div>"
+       "<small>shape: (20, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0</td><td>-0.000088</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>1</td><td>-0.000055</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>2</td><td>0.000091</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>3</td><td>0.0001</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>4</td><td>0.00008</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (20, 6)\n",
@@ -5241,11 +4483,11 @@
        "│ ---           ┆ ---         ┆ ---              ┆ ---             ┆ ---    ┆ ---                  │\n",
        "│ str           ┆ str         ┆ i64              ┆ str             ┆ i64    ┆ f64                  │\n",
        "╞═══════════════╪═════════════╪══════════════════╪═════════════════╪════════╪══════════════════════╡\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ 689e938f32ee    ┆ 0      ┆ -0.000018            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ 689e938f32ee    ┆ 1      ┆ -0.000084            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ 689e938f32ee    ┆ 2      ┆ -0.000042            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ 689e938f32ee    ┆ 3      ┆ 0.000038             │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ 689e938f32ee    ┆ 4      ┆ 0.000233             │\n",
+       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 0      ┆ -0.000018            │\n",
+       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 1      ┆ -0.000084            │\n",
+       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 2      ┆ -0.000042            │\n",
+       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 3      ┆ 0.000038             │\n",
+       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 4      ┆ 0.000233             │\n",
        "│ …             ┆ …           ┆ …                ┆ …               ┆ …      ┆ …                    │\n",
        "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 0      ┆ -0.000088            │\n",
        "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 1      ┆ -0.000055            │\n",
@@ -5295,13 +4537,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6350b8d0",
+   "id": "f58e9461",
    "metadata": {
     "papermill": {
-     "duration": 0.008371,
-     "end_time": "2026-08-27T22:48:58.306150+00:00",
+     "duration": 0.006011,
+     "end_time": "2026-08-28T00:29:52.973399+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.297779+00:00",
+     "start_time": "2026-08-28T00:29:52.967388+00:00",
      "status": "completed"
     }
    },
@@ -5316,19 +4558,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e9f032c0",
+   "id": "479c701d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:58.330583Z",
-     "iopub.status.busy": "2026-08-27T22:48:58.330149Z",
-     "iopub.status.idle": "2026-08-27T22:48:58.399610Z",
-     "shell.execute_reply": "2026-08-27T22:48:58.398792Z"
+     "iopub.execute_input": "2026-08-28T00:29:52.987046Z",
+     "iopub.status.busy": "2026-08-28T00:29:52.986878Z",
+     "iopub.status.idle": "2026-08-28T00:29:53.026457Z",
+     "shell.execute_reply": "2026-08-28T00:29:53.025288Z"
     },
     "papermill": {
-     "duration": 0.088527,
-     "end_time": "2026-08-27T22:48:58.402003+00:00",
+     "duration": 0.046282,
+     "end_time": "2026-08-28T00:29:53.026872+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.313476+00:00",
+     "start_time": "2026-08-28T00:29:52.980590+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5346,7 +4588,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (12, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.9</td><td>0.963324</td><td>3.240988</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;689e938f32ee&quot;</td><td>0.95</td><td>0.937812</td><td>24.977348</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.95</td><td>0.983989</td><td>3.902682</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.95</td><td>0.984571</td><td>3.874998</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.95</td><td>0.985845</td><td>4.234442</td><td>36100</td></tr></tbody></table></div>"
+       "<small>shape: (12, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.9</td><td>0.963324</td><td>3.240988</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.95</td><td>0.937812</td><td>24.977348</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.95</td><td>0.983989</td><td>3.902682</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.95</td><td>0.984571</td><td>3.874998</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.95</td><td>0.985845</td><td>4.234442</td><td>36100</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (12, 8)\n",
@@ -5358,21 +4600,21 @@
        "│            ┆            ┆            ┆            ┆            ┆            ┆ ---       ┆        │\n",
        "│            ┆            ┆            ┆            ┆            ┆            ┆ f64       ┆        │\n",
        "╞════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═══════════╪════════╡\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ 689e938f32 ┆ 0.8        ┆ 0.792188   ┆ 14.833431 ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ ee         ┆            ┆            ┆           ┆        │\n",
+       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.8        ┆ 0.792188   ┆ 14.833431 ┆ 36100  │\n",
+       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
        "│ gbm        ┆ leaves_63_ ┆ 100        ┆ 0cff45d5da ┆ 0.8        ┆ 0.898781   ┆ 2.187913  ┆ 36100  │\n",
        "│            ┆ mae        ┆            ┆ f6         ┆            ┆            ┆           ┆        │\n",
        "│ linear     ┆ lasso_f0.2 ┆ null       ┆ eeff296102 ┆ 0.8        ┆ 0.897922   ┆ 2.158434  ┆ 36100  │\n",
        "│            ┆            ┆            ┆ 6c         ┆            ┆            ┆           ┆        │\n",
        "│ tabular_dl ┆ tabm_l     ┆ 50         ┆ 01e41111cb ┆ 0.8        ┆ 0.907285   ┆ 2.363629  ┆ 36100  │\n",
        "│            ┆            ┆            ┆ 52         ┆            ┆            ┆           ┆        │\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ 689e938f32 ┆ 0.9        ┆ 0.882465   ┆ 19.70981  ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ ee         ┆            ┆            ┆           ┆        │\n",
+       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.9        ┆ 0.882465   ┆ 19.70981  ┆ 36100  │\n",
+       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
        "│ …          ┆ …          ┆ …          ┆ …          ┆ …          ┆ …          ┆ …         ┆ …      │\n",
        "│ tabular_dl ┆ tabm_l     ┆ 50         ┆ 01e41111cb ┆ 0.9        ┆ 0.963324   ┆ 3.240988  ┆ 36100  │\n",
        "│            ┆            ┆            ┆ 52         ┆            ┆            ┆           ┆        │\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ 689e938f32 ┆ 0.95       ┆ 0.937812   ┆ 24.977348 ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ ee         ┆            ┆            ┆           ┆        │\n",
+       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.95       ┆ 0.937812   ┆ 24.977348 ┆ 36100  │\n",
+       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
        "│ gbm        ┆ leaves_63_ ┆ 100        ┆ 0cff45d5da ┆ 0.95       ┆ 0.983989   ┆ 3.902682  ┆ 36100  │\n",
        "│            ┆ mae        ┆            ┆ f6         ┆            ┆            ┆           ┆        │\n",
        "│ linear     ┆ lasso_f0.2 ┆ null       ┆ eeff296102 ┆ 0.95       ┆ 0.984571   ┆ 3.874998  ┆ 36100  │\n",
@@ -5406,13 +4648,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df5613ec",
+   "id": "6ec5f1e5",
    "metadata": {
     "papermill": {
-     "duration": 0.006574,
-     "end_time": "2026-08-27T22:48:58.414526+00:00",
+     "duration": 0.004608,
+     "end_time": "2026-08-28T00:29:53.036208+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.407952+00:00",
+     "start_time": "2026-08-28T00:29:53.031600+00:00",
      "status": "completed"
     }
    },
@@ -5427,19 +4669,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "3710de0b",
+   "id": "db045f77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:58.432914Z",
-     "iopub.status.busy": "2026-08-27T22:48:58.430856Z",
-     "iopub.status.idle": "2026-08-27T22:48:58.442367Z",
-     "shell.execute_reply": "2026-08-27T22:48:58.441437Z"
+     "iopub.execute_input": "2026-08-28T00:29:53.046965Z",
+     "iopub.status.busy": "2026-08-28T00:29:53.046494Z",
+     "iopub.status.idle": "2026-08-28T00:29:53.053581Z",
+     "shell.execute_reply": "2026-08-28T00:29:53.053306Z"
     },
     "papermill": {
-     "duration": 0.024862,
-     "end_time": "2026-08-27T22:48:58.445050+00:00",
+     "duration": 0.01282,
+     "end_time": "2026-08-28T00:29:53.054161+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.420188+00:00",
+     "start_time": "2026-08-28T00:29:53.041341+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5494,13 +4736,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32cd8788",
+   "id": "87bd459d",
    "metadata": {
     "papermill": {
-     "duration": 0.008822,
-     "end_time": "2026-08-27T22:48:58.464044+00:00",
+     "duration": 0.004053,
+     "end_time": "2026-08-28T00:29:53.063437+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.455222+00:00",
+     "start_time": "2026-08-28T00:29:53.059384+00:00",
      "status": "completed"
     }
    },
@@ -5515,19 +4757,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b823a679",
+   "id": "6d0b4c1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T22:48:58.480679Z",
-     "iopub.status.busy": "2026-08-27T22:48:58.480554Z",
-     "iopub.status.idle": "2026-08-27T22:48:58.493718Z",
-     "shell.execute_reply": "2026-08-27T22:48:58.492965Z"
+     "iopub.execute_input": "2026-08-28T00:29:53.079379Z",
+     "iopub.status.busy": "2026-08-28T00:29:53.078854Z",
+     "iopub.status.idle": "2026-08-28T00:29:53.093328Z",
+     "shell.execute_reply": "2026-08-28T00:29:53.093074Z"
     },
     "papermill": {
-     "duration": 0.019644,
-     "end_time": "2026-08-27T22:48:58.494197+00:00",
+     "duration": 0.024032,
+     "end_time": "2026-08-28T00:29:53.094024+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.474553+00:00",
+     "start_time": "2026-08-28T00:29:53.069992+00:00",
      "status": "completed"
     }
    },
@@ -5542,35 +4784,35 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (918, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>training_hash</th><th>prediction_hash</th><th>cv_identity</th><th>complete</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>str</td><td>str</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;e9348cbe2199&quot;</td><td>&quot;9eb5dd8577d1&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;8a3f80020963&quot;</td><td>&quot;c743542f9212&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;e9348cbe2199&quot;</td><td>&quot;26150ab0d3db&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;8a3f80020963&quot;</td><td>&quot;cce75c9f66e7&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;e9348cbe2199&quot;</td><td>&quot;70cc489e40cd&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>150</td><td>&quot;f960af626672&quot;</td><td>&quot;a7dd3a9eeabd&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>175</td><td>&quot;f960af626672&quot;</td><td>&quot;81b2bf5b42b3&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>175</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;ff41f25b7fbf&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>200</td><td>&quot;f960af626672&quot;</td><td>&quot;039c56702e88&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>200</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;5f45fad68a51&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr></tbody></table></div>"
+       "<small>shape: (726, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>training_hash</th><th>prediction_hash</th><th>cv_identity</th><th>complete</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>str</td><td>str</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;8a3f80020963&quot;</td><td>&quot;c743542f9212&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;8a3f80020963&quot;</td><td>&quot;cce75c9f66e7&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;8a3f80020963&quot;</td><td>&quot;9b573180b922&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;8a3f80020963&quot;</td><td>&quot;f98e3dcf45aa&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;8a3f80020963&quot;</td><td>&quot;a874939e7340&quot;</td><td>&quot;35b9fb3d216ee3e2&quot;</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;0751d64738ae&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>125</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;6585e6fb2af9&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>150</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;aed076259ff0&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>175</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;ff41f25b7fbf&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>200</td><td>&quot;10ffc89e8a6a&quot;</td><td>&quot;5f45fad68a51&quot;</td><td>&quot;a94e699868098d05&quot;</td><td>true</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (918, 9)\n",
+       "shape: (726, 9)\n",
        "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
        "│ label     ┆ family    ┆ config_na ┆ checkpoin ┆ … ┆ training_ ┆ predictio ┆ cv_identi ┆ complete │\n",
        "│ ---       ┆ ---       ┆ me        ┆ t_kind    ┆   ┆ hash      ┆ n_hash    ┆ ty        ┆ ---      │\n",
        "│ str       ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ bool     │\n",
        "│           ┆           ┆ str       ┆ str       ┆   ┆ str       ┆ str       ┆ str       ┆          │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ e9348cbe2 ┆ 9eb5dd857 ┆ 35b9fb3d2 ┆ true     │\n",
-       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 199       ┆ 7d1       ┆ 16ee3e2   ┆          │\n",
        "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ 8a3f80020 ┆ c743542f9 ┆ 35b9fb3d2 ┆ true     │\n",
        "│ d         ┆ ning      ┆           ┆           ┆   ┆ 963       ┆ 212       ┆ 16ee3e2   ┆          │\n",
-       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ e9348cbe2 ┆ 26150ab0d ┆ 35b9fb3d2 ┆ true     │\n",
-       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 199       ┆ 3db       ┆ 16ee3e2   ┆          │\n",
        "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ 8a3f80020 ┆ cce75c9f6 ┆ 35b9fb3d2 ┆ true     │\n",
        "│ d         ┆ ning      ┆           ┆           ┆   ┆ 963       ┆ 6e7       ┆ 16ee3e2   ┆          │\n",
-       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ e9348cbe2 ┆ 70cc489e4 ┆ 35b9fb3d2 ┆ true     │\n",
-       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 199       ┆ 0cd       ┆ 16ee3e2   ┆          │\n",
+       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ 8a3f80020 ┆ 9b573180b ┆ 35b9fb3d2 ┆ true     │\n",
+       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 963       ┆ 922       ┆ 16ee3e2   ┆          │\n",
+       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ 8a3f80020 ┆ f98e3dcf4 ┆ 35b9fb3d2 ┆ true     │\n",
+       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 963       ┆ 5aa       ┆ 16ee3e2   ┆          │\n",
+       "│ fwd_ret_1 ┆ deep_lear ┆ nlinear   ┆ epoch     ┆ … ┆ 8a3f80020 ┆ a874939e7 ┆ 35b9fb3d2 ┆ true     │\n",
+       "│ d         ┆ ning      ┆           ┆           ┆   ┆ 963       ┆ 340       ┆ 16ee3e2   ┆          │\n",
        "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …        │\n",
-       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ f960af626 ┆ a7dd3a9ee ┆ a94e69986 ┆ true     │\n",
-       "│ d         ┆ l         ┆           ┆           ┆   ┆ 672       ┆ abd       ┆ 8098d05   ┆          │\n",
-       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ f960af626 ┆ 81b2bf5b4 ┆ a94e69986 ┆ true     │\n",
-       "│ d         ┆ l         ┆           ┆           ┆   ┆ 672       ┆ 2b3       ┆ 8098d05   ┆          │\n",
+       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ 10ffc89e8 ┆ 0751d6473 ┆ a94e69986 ┆ true     │\n",
+       "│ d         ┆ l         ┆           ┆           ┆   ┆ a6a       ┆ 8ae       ┆ 8098d05   ┆          │\n",
+       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ 10ffc89e8 ┆ 6585e6fb2 ┆ a94e69986 ┆ true     │\n",
+       "│ d         ┆ l         ┆           ┆           ┆   ┆ a6a       ┆ af9       ┆ 8098d05   ┆          │\n",
+       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ 10ffc89e8 ┆ aed076259 ┆ a94e69986 ┆ true     │\n",
+       "│ d         ┆ l         ┆           ┆           ┆   ┆ a6a       ┆ ff0       ┆ 8098d05   ┆          │\n",
        "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ 10ffc89e8 ┆ ff41f25b7 ┆ a94e69986 ┆ true     │\n",
        "│ d         ┆ l         ┆           ┆           ┆   ┆ a6a       ┆ fbf       ┆ 8098d05   ┆          │\n",
-       "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ f960af626 ┆ 039c56702 ┆ a94e69986 ┆ true     │\n",
-       "│ d         ┆ l         ┆           ┆           ┆   ┆ 672       ┆ e88       ┆ 8098d05   ┆          │\n",
        "│ fwd_ret_5 ┆ tabular_d ┆ tabm_s    ┆ epoch     ┆ … ┆ 10ffc89e8 ┆ 5f45fad68 ┆ a94e69986 ┆ true     │\n",
        "│ d         ┆ l         ┆           ┆           ┆   ┆ a6a       ┆ a51       ┆ 8098d05   ┆          │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
@@ -5590,13 +4832,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64fbaefd",
+   "id": "6918c4bd",
    "metadata": {
     "papermill": {
-     "duration": 0.004538,
-     "end_time": "2026-08-27T22:48:58.504407+00:00",
+     "duration": 0.006939,
+     "end_time": "2026-08-28T00:29:53.107291+00:00",
      "exception": false,
-     "start_time": "2026-08-27T22:48:58.499869+00:00",
+     "start_time": "2026-08-28T00:29:53.100352+00:00",
      "status": "completed"
     }
    },
@@ -5633,19 +4875,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 26.17015,
-   "end_time": "2026-08-27T22:49:01.742529+00:00",
+   "duration": 20.589352,
+   "end_time": "2026-08-28T00:29:54.529402+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/12_model_analysis.ipynb",
-   "output_path": "~/scratch/prod_12_model_analysis_3231444.ipynb",
+   "output_path": "~/scratch/prod_12_model_analysis_344447.ipynb",
    "parameters": {},
-   "start_time": "2026-08-27T22:48:35.572379+00:00",
+   "start_time": "2026-08-28T00:29:33.940050+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "226a7cd4f56538622141363d61899c396d1fe2a8",
-   "executed_at": "2026-08-27T22:49:15.059733+00:00",
+   "source_py_blob": "1aaff652111765c9dbceb88c2675bdb56d1e15dd",
+   "executed_at": "2026-08-28T00:30:02.148776+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/12_model_analysis.py
+++ b/case_studies/fx_pairs/12_model_analysis.py
@@ -42,7 +42,7 @@ import yaml
 from ml4t.diagnostic.metrics import cross_sectional_ic
 
 import utils.style  # noqa: F401
-from case_studies.research import CausalResult, Result, open_study
+from case_studies.research import CausalResult, Result, open_study, superseded_members
 from case_studies.research.results import PredictionResult
 from case_studies.utils.conformal import split_conformal_coverage
 from utils.modeling import load_configs
@@ -77,6 +77,16 @@ catalog = study.predictions.table().filter(
     & (pl.col("execution_tier") == "canonical")
     & (pl.col("split") == "validation")
 )
+# `identity_status` names the schema version a row was written under. It says nothing about
+# which generation the row's producer still publishes: a model notebook that refits leaves the
+# generation it replaced in the registry, complete and current under that column, so the filter
+# above carries retired prediction sets into the analysis. The lineage is what answers it, and
+# `superseded_members` reads that - the same exclusion `13_backtest` applies before it freezes
+# the baseline population, so the analysed catalog and the backtested one describe one set of
+# models rather than two.
+retired = superseded_members(study, member_kind="prediction")
+if retired:
+    catalog = catalog.filter(~pl.col("prediction_hash").is_in(list(retired)))
 
 if catalog.is_empty():
     raise RuntimeError("no current canonical validation predictions are registered")


### PR DESCRIPTION
`12_model_analysis` selected its catalog on `identity_status == "current"` alone. That column is the schema version a row was written under - it says the registry still understands the row, not that the row is the one its producer publishes. A model notebook that refits leaves the generation it replaced in the registry, complete and `current`.

Measured against `case_studies/fx_pairs/run_log/registry.db`: **192 of the 918 rows the chapter rendered were retired generations, 21% of the catalog.** They were not spread evenly. Every one was `deep_learning` (120) or `tabular_dl` (72); every other family contributed none.

The re-run shows both halves of the cost.

**The comparison was weighted by refit frequency.** Per-label checkpoint counts fall from 80 to 40 for `deep_learning` and 48 to 24 for `tabular_dl` - exactly halved, two generations each - while `gbm` (150) and `linear` (28) are unchanged. Two families were entering every per-family table twice over.

**The rendered table named prediction sets nobody can follow.** The best-IC row per family changed identity, not value: `fwd_ret_1d` / `deep_learning` / `tcn` was reported as `689e938f32ee` and is `d80638423af7`, with `ic_mean` and `ic_t` identical to six decimals. A reader resolving the published hash landed on a retired set.

Neither is visible from the rendered page. Both halves look internally consistent.

## The fix

`superseded_members` reads the population lineage, which is where the answer actually lives. This is the same exclusion `13_backtest` applies before it freezes the baseline population - so the analysed catalog and the backtested one now describe one set of models rather than two, which they did not before.

The library function is already covered by `tests/test_superseded_members_registries.py` and `tests/test_population_supersedes.py`; this change is its application at one more call site, verified by re-execution rather than by a test asserting the notebook's source text.

Production re-run, exit 0. Found by `us_firm_characteristics` via RoboRev on #632.