### PR TITLE
Drop the restamp #639 made unnecessary, and the comment explaining it

### DIFF
--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -1293,12 +1293,11 @@ def test_preview_never_carries_a_supersedes_hash(tmp_path: Path):
     # And the canonical tier still reaches the registry, so this cannot be satisfied by a
     # declaration that is withheld everywhere.
     #
-    # `activate` first, because #637 reads the tier from `ML4T_OUTPUT_DIR`, which `activate`
-    # stamps process-globally rather than per study. Opening the preview above stamped it, and
-    # without this the canonical half inherits that stamp and is withheld too - so the test
-    # would report a canonical failure that no notebook can hit, since a notebook runs one tier
-    # per process. This makes the process tier match the study each half is describing.
-    released.activate()
+    # No `activate` call is needed to separate this from the preview above. #637 read the tier
+    # from `ML4T_OUTPUT_DIR` alone, which `activate` stamps process-globally, so opening the
+    # preview withheld the canonical half too and this test had to restamp between the two.
+    # #639 passes the study to `_preview_is_active` and compares the stamp's parent against
+    # that study's `output_root`, so the halves no longer collide.
     assert supersedes_declaration("canonical", first.hash) == first.hash
     assert (
         population_supersedes(


### PR DESCRIPTION
`#640` added `released.activate()` before the canonical half of
`test_preview_never_carries_a_supersedes_hash`, because `#637` read the tier from
`ML4T_OUTPUT_DIR` alone. `activate` stamps that process-globally, so opening the preview
earlier in the same test withheld the canonical half too, and the test had to restamp
between the two.

`#639` passes the study to `_preview_is_active` and compares the stamp's parent against
that study's `output_root` - the study-scoped signal that did not exist when #640 landed.
The two halves no longer collide, so the call does nothing and the comment above it
describes a defect the tree no longer has.

## Verification

The call is dead rather than assumed to be: removed it first and the test passes on its
own. 26 passed across `test_cme_futures_research.py` and `test_population_supersedes.py`
at `87f591a8`. RoboRev: no issues found.

Comment and one dead call. No behaviour change, and no notebook `.py` touched, so there is
no provenance staleness.