### PR TITLE
fx_pairs phase 2: the executed backtesting chain, 13 through 16

### DIFF
--- a/case_studies/fx_pairs/13_backtest.ipynb
+++ b/case_studies/fx_pairs/13_backtest.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cc021430",
-   "metadata": {},
+   "id": "7db11453",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001321,
+     "end_time": "2026-08-28T00:09:41.976199+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:41.974878+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Equal-Weight Backtest - FX Pairs\n",
     "\n",
@@ -25,9 +33,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "440a8fa5",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "e42296ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:09:41.981803Z",
+     "iopub.status.busy": "2026-08-28T00:09:41.981614Z",
+     "iopub.status.idle": "2026-08-28T00:09:45.392021Z",
+     "shell.execute_reply": "2026-08-28T00:09:45.391294Z"
+    },
+    "papermill": {
+     "duration": 3.415291,
+     "end_time": "2026-08-28T00:09:45.392555+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:41.977264+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Run the complete equal-weight FX validation backtest population.\"\"\"\n",
@@ -51,9 +73,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6fe4fc3c",
+   "execution_count": 2,
+   "id": "48b5e027",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:09:45.395335Z",
+     "iopub.status.busy": "2026-08-28T00:09:45.395222Z",
+     "iopub.status.idle": "2026-08-28T00:09:45.398564Z",
+     "shell.execute_reply": "2026-08-28T00:09:45.397269Z"
+    },
+    "papermill": {
+     "duration": 0.005337,
+     "end_time": "2026-08-28T00:09:45.399091+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:45.393754+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -77,8 +112,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bb26b5d",
-   "metadata": {},
+   "id": "1c8eccec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001017,
+     "end_time": "2026-08-28T00:09:45.401142+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:45.400125+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Select the exact prediction population\n",
     "\n",
@@ -114,14 +157,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "56b1f902",
+   "execution_count": 3,
+   "id": "64b9f258",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:09:45.403569Z",
+     "iopub.status.busy": "2026-08-28T00:09:45.403475Z",
+     "iopub.status.idle": "2026-08-28T00:09:54.830924Z",
+     "shell.execute_reply": "2026-08-28T00:09:54.830605Z"
+    },
+    "papermill": {
+     "duration": 9.429155,
+     "end_time": "2026-08-28T00:09:54.831167+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:45.402012+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retired by a later generation, excluded: 192 of 918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen prediction population: 99b8899518c4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (726, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_huber&quot;</td><td>&quot;iteration&quot;</td><td>350</td><td>&quot;009cb5a931b9&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;default_mae&quot;</td><td>&quot;iteration&quot;</td><td>200</td><td>&quot;00a5bb9ad47b&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mse&quot;</td><td>&quot;iteration&quot;</td><td>400</td><td>&quot;00dd969341e9&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mse&quot;</td><td>&quot;iteration&quot;</td><td>50</td><td>&quot;0100933f3b48&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_huber&quot;</td><td>&quot;iteration&quot;</td><td>350</td><td>&quot;0155d435cb7b&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;ff1f6d025448&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;ff3d34f8074e&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>&quot;epoch&quot;</td><td>175</td><td>&quot;ff41f25b7fbf&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.5&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;ff85124c0513&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_15_mse&quot;</td><td>&quot;iteration&quot;</td><td>100</td><td>&quot;ffed7acc6ba5&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (726, 6)\n",
+       "┌─────────────┬────────────┬─────────────────┬─────────────────┬─────────────────┬─────────────────┐\n",
+       "│ label       ┆ family     ┆ config_name     ┆ checkpoint_kind ┆ checkpoint_valu ┆ prediction_hash │\n",
+       "│ ---         ┆ ---        ┆ ---             ┆ ---             ┆ e               ┆ ---             │\n",
+       "│ str         ┆ str        ┆ str             ┆ str             ┆ ---             ┆ str             │\n",
+       "│             ┆            ┆                 ┆                 ┆ i64             ┆                 │\n",
+       "╞═════════════╪════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╡\n",
+       "│ fwd_ret_5d  ┆ gbm        ┆ leaves_63_huber ┆ iteration       ┆ 350             ┆ 009cb5a931b9    │\n",
+       "│ fwd_ret_1d  ┆ gbm        ┆ default_mae     ┆ iteration       ┆ 200             ┆ 00a5bb9ad47b    │\n",
+       "│ fwd_ret_5d  ┆ gbm        ┆ leaves_63_mse   ┆ iteration       ┆ 400             ┆ 00dd969341e9    │\n",
+       "│ fwd_ret_5d  ┆ gbm        ┆ leaves_63_mse   ┆ iteration       ┆ 50              ┆ 0100933f3b48    │\n",
+       "│ fwd_ret_21d ┆ gbm        ┆ leaves_31_huber ┆ iteration       ┆ 350             ┆ 0155d435cb7b    │\n",
+       "│ …           ┆ …          ┆ …               ┆ …               ┆ …               ┆ …               │\n",
+       "│ fwd_ret_21d ┆ tabular_dl ┆ tabm_l          ┆ epoch           ┆ 100             ┆ ff1f6d025448    │\n",
+       "│ fwd_ret_5d  ┆ linear     ┆ lasso_f0.85     ┆ final           ┆ null            ┆ ff3d34f8074e    │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl ┆ tabm_s          ┆ epoch           ┆ 175             ┆ ff41f25b7fbf    │\n",
+       "│ fwd_ret_5d  ┆ linear     ┆ lasso_f0.5      ┆ final           ┆ null            ┆ ff85124c0513    │\n",
+       "│ fwd_ret_5d  ┆ gbm        ┆ leaves_15_mse   ┆ iteration       ┆ 100             ┆ ffed7acc6ba5    │\n",
+       "└─────────────┴────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "if SPLIT != \"validation\":\n",
@@ -205,8 +314,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d05de988",
-   "metadata": {},
+   "id": "091ab187",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000914,
+     "end_time": "2026-08-28T00:09:54.833324+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:54.832410+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Build the baseline strategy grid\n",
     "\n",
@@ -225,10 +342,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c7e159ec",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "4f801ce8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:09:54.835593Z",
+     "iopub.status.busy": "2026-08-28T00:09:54.835507Z",
+     "iopub.status.idle": "2026-08-28T00:09:54.907871Z",
+     "shell.execute_reply": "2026-08-28T00:09:54.907507Z"
+    },
+    "papermill": {
+     "duration": 0.073849,
+     "end_time": "2026-08-28T00:09:54.908130+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:54.834281+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (6, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>top_k</th><th>prediction_sets</th></tr><tr><td>str</td><td>i64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>242</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>10</td><td>242</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>5</td><td>242</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>10</td><td>242</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>5</td><td>242</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>242</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (6, 3)\n",
+       "┌─────────────┬───────┬─────────────────┐\n",
+       "│ label       ┆ top_k ┆ prediction_sets │\n",
+       "│ ---         ┆ ---   ┆ ---             │\n",
+       "│ str         ┆ i64   ┆ i64             │\n",
+       "╞═════════════╪═══════╪═════════════════╡\n",
+       "│ fwd_ret_1d  ┆ 5     ┆ 242             │\n",
+       "│ fwd_ret_1d  ┆ 10    ┆ 242             │\n",
+       "│ fwd_ret_21d ┆ 5     ┆ 242             │\n",
+       "│ fwd_ret_21d ┆ 10    ┆ 242             │\n",
+       "│ fwd_ret_5d  ┆ 5     ┆ 242             │\n",
+       "│ fwd_ret_5d  ┆ 10    ┆ 242             │\n",
+       "└─────────────┴───────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "universe_symbols = yaml.safe_load(\n",
     "    (get_case_study_dir(CASE_STUDY_ID) / \"config\" / \"setup.yaml\").read_text()\n",
@@ -267,8 +431,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8afcf23b",
-   "metadata": {},
+   "id": "b89c8511",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000975,
+     "end_time": "2026-08-28T00:09:54.910329+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:54.909354+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Freeze the expected baseline population\n",
     "\n",
@@ -278,14 +450,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7216f7a4",
+   "execution_count": 5,
+   "id": "eef07917",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:09:54.912811Z",
+     "iopub.status.busy": "2026-08-28T00:09:54.912718Z",
+     "iopub.status.idle": "2026-08-28T00:18:25.184288Z",
+     "shell.execute_reply": "2026-08-28T00:18:25.183674Z"
+    },
+    "papermill": {
+     "duration": 510.274113,
+     "end_time": "2026-08-28T00:18:25.185450+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:09:54.911337+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen expected baseline population: 1e1cd87665c9\n"
+     ]
+    }
+   ],
    "source": [
     "planned_hashes = []\n",
     "for job in jobs:\n",
@@ -321,8 +514,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f62721a1",
-   "metadata": {},
+   "id": "d8b6a1dc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000963,
+     "end_time": "2026-08-28T00:18:25.187537+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:18:25.186574+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Run every catalog row through the FX engine, then validate what was frozen\n",
     "\n",
@@ -337,14 +538,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0b63e2e1",
+   "execution_count": 6,
+   "id": "ea4f260e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:18:25.190074Z",
+     "iopub.status.busy": "2026-08-28T00:18:25.189960Z",
+     "iopub.status.idle": "2026-08-28T00:28:28.979126Z",
+     "shell.execute_reply": "2026-08-28T00:28:28.978602Z"
+    },
+    "papermill": {
+     "duration": 603.790944,
+     "end_time": "2026-08-28T00:28:28.979481+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:18:25.188537+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equal-weight baselines: 0 computed, 1452 served from the registry, 1452 in the population\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official equal-weight population: 1e1cd87665c9\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1_452, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>backtest_hash</th><th>prediction_hash</th><th>stage</th><th>complete</th></tr><tr><td>str</td><td>str</td><td>str</td><td>bool</td></tr></thead><tbody><tr><td>&quot;69f9a76d0a60&quot;</td><td>&quot;00a5bb9ad47b&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;54f01dbf0906&quot;</td><td>&quot;01e41111cb52&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;1b5d67417ccc&quot;</td><td>&quot;0266e1827589&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;1ecf3f0570ae&quot;</td><td>&quot;04bcb617f62e&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;f03c04433b3d&quot;</td><td>&quot;05a994fb8ecf&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;c8c2d8450502&quot;</td><td>&quot;fef01e814006&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;a37ac005f770&quot;</td><td>&quot;ff3d34f8074e&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;d30dfd9eb161&quot;</td><td>&quot;ff41f25b7fbf&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;1d1d697e2ff0&quot;</td><td>&quot;ff85124c0513&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr><tr><td>&quot;0912e8dcd66f&quot;</td><td>&quot;ffed7acc6ba5&quot;</td><td>&quot;signal&quot;</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1_452, 4)\n",
+       "┌───────────────┬─────────────────┬────────┬──────────┐\n",
+       "│ backtest_hash ┆ prediction_hash ┆ stage  ┆ complete │\n",
+       "│ ---           ┆ ---             ┆ ---    ┆ ---      │\n",
+       "│ str           ┆ str             ┆ str    ┆ bool     │\n",
+       "╞═══════════════╪═════════════════╪════════╪══════════╡\n",
+       "│ 69f9a76d0a60  ┆ 00a5bb9ad47b    ┆ signal ┆ true     │\n",
+       "│ 54f01dbf0906  ┆ 01e41111cb52    ┆ signal ┆ true     │\n",
+       "│ 1b5d67417ccc  ┆ 0266e1827589    ┆ signal ┆ true     │\n",
+       "│ 1ecf3f0570ae  ┆ 04bcb617f62e    ┆ signal ┆ true     │\n",
+       "│ f03c04433b3d  ┆ 05a994fb8ecf    ┆ signal ┆ true     │\n",
+       "│ …             ┆ …               ┆ …      ┆ …        │\n",
+       "│ c8c2d8450502  ┆ fef01e814006    ┆ signal ┆ true     │\n",
+       "│ a37ac005f770  ┆ ff3d34f8074e    ┆ signal ┆ true     │\n",
+       "│ d30dfd9eb161  ┆ ff41f25b7fbf    ┆ signal ┆ true     │\n",
+       "│ 1d1d697e2ff0  ┆ ff85124c0513    ┆ signal ┆ true     │\n",
+       "│ 0912e8dcd66f  ┆ ffed7acc6ba5    ┆ signal ┆ true     │\n",
+       "└───────────────┴─────────────────┴────────┴──────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# A sweep that recomputes everything and a sweep that recomputes nothing print the same summary\n",
     "# unless the two are counted apart. `run_backtests` serves an identity that is already registered\n",
@@ -409,8 +675,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bef4857b",
-   "metadata": {},
+   "id": "98fa846f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001274,
+     "end_time": "2026-08-28T00:28:28.982453+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:28:28.981179+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -428,6 +702,37 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1129.721435,
+   "end_time": "2026-08-28T00:28:30.802533+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/fx_pairs/13_backtest.ipynb",
+   "output_path": "~/scratch/prod_13_backtest_49907.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-28T00:09:41.081098+00:00",
+   "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "cc8ee337019d8c3c4b41799ae05f177d3a96d0af",
+   "executed_at": "2026-08-28T00:28:40.285721+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/14_portfolio_management.ipynb
+++ b/case_studies/fx_pairs/14_portfolio_management.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dd60b6f7",
-   "metadata": {},
+   "id": "21ab7372",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001318,
+     "end_time": "2026-08-28T00:32:51.260924+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:32:51.259606+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Portfolio Allocation - FX Pairs\n",
     "\n",
@@ -25,9 +33,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "15355c33",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "60dd63c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:32:51.264626Z",
+     "iopub.status.busy": "2026-08-28T00:32:51.264467Z",
+     "iopub.status.idle": "2026-08-28T00:32:54.983250Z",
+     "shell.execute_reply": "2026-08-28T00:32:54.982884Z"
+    },
+    "papermill": {
+     "duration": 3.722014,
+     "end_time": "2026-08-28T00:32:54.983984+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:32:51.261970+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Run the FX allocation sweep from the frozen equal-weight population.\"\"\"\n",
@@ -63,9 +85,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c5cb544e",
+   "execution_count": 2,
+   "id": "4f842b01",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:32:54.987166Z",
+     "iopub.status.busy": "2026-08-28T00:32:54.987051Z",
+     "iopub.status.idle": "2026-08-28T00:32:54.989371Z",
+     "shell.execute_reply": "2026-08-28T00:32:54.988993Z"
+    },
+    "papermill": {
+     "duration": 0.00426,
+     "end_time": "2026-08-28T00:32:54.989795+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:32:54.985535+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -90,8 +125,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f3960cc",
-   "metadata": {},
+   "id": "a5265c3a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001309,
+     "end_time": "2026-08-28T00:32:54.992139+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:32:54.990830+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Resolve the equal-weight inputs\n",
     "\n",
@@ -102,9 +145,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "21623215",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "5f3d1d1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:32:54.994577Z",
+     "iopub.status.busy": "2026-08-28T00:32:54.994485Z",
+     "iopub.status.idle": "2026-08-28T00:33:25.239858Z",
+     "shell.execute_reply": "2026-08-28T00:33:25.239077Z"
+    },
+    "papermill": {
+     "duration": 30.247342,
+     "end_time": "2026-08-28T00:33:25.240456+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:32:54.993114+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "set_global_seeds(SEED)\n",
@@ -255,8 +312,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3e5d578",
-   "metadata": {},
+   "id": "c03bb95c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00088,
+     "end_time": "2026-08-28T00:33:25.242582+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:33:25.241702+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Advance one checkpoint and mapping per configuration\n",
     "\n",
@@ -267,14 +332,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "32e9c183",
+   "execution_count": 4,
+   "id": "abd73722",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:33:25.246538Z",
+     "iopub.status.busy": "2026-08-28T00:33:25.246329Z",
+     "iopub.status.idle": "2026-08-28T00:34:20.343368Z",
+     "shell.execute_reply": "2026-08-28T00:34:20.340593Z"
+    },
+    "papermill": {
+     "duration": 55.099791,
+     "end_time": "2026-08-28T00:34:20.344295+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:33:25.244504+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (30, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>top_k</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i32</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>5</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.35&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;574b545d5f88&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;58971602ef64&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.7&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;4321c0a71dab&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>5</td><td>&quot;11cb99da90a2&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>&quot;iteration&quot;</td><td>50</td><td>10</td><td>&quot;d4d6d17e5918&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_mae&quot;</td><td>&quot;iteration&quot;</td><td>50</td><td>10</td><td>&quot;0f6a459a5f18&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.85&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;ff3d34f8074e&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;ridge_a100000.0&quot;</td><td>&quot;final&quot;</td><td>null</td><td>10</td><td>&quot;90de8b7e8b1b&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (30, 7)\n",
+       "┌────────────┬───────────────┬───────────────┬───────────────┬──────────────┬───────┬──────────────┐\n",
+       "│ label      ┆ family        ┆ config_name   ┆ checkpoint_ki ┆ checkpoint_v ┆ top_k ┆ prediction_h │\n",
+       "│ ---        ┆ ---           ┆ ---           ┆ nd            ┆ alue         ┆ ---   ┆ ash          │\n",
+       "│ str        ┆ str           ┆ str           ┆ ---           ┆ ---          ┆ i32   ┆ ---          │\n",
+       "│            ┆               ┆               ┆ str           ┆ i64          ┆       ┆ str          │\n",
+       "╞════════════╪═══════════════╪═══════════════╪═══════════════╪══════════════╪═══════╪══════════════╡\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn           ┆ epoch         ┆ 5            ┆ 5     ┆ d80638423af7 │\n",
+       "│ fwd_ret_1d ┆ linear        ┆ enet_f0.35    ┆ final         ┆ null         ┆ 10    ┆ 574b545d5f88 │\n",
+       "│ fwd_ret_1d ┆ linear        ┆ enet_f0.5     ┆ final         ┆ null         ┆ 10    ┆ 58971602ef64 │\n",
+       "│ fwd_ret_1d ┆ linear        ┆ enet_f0.7     ┆ final         ┆ null         ┆ 10    ┆ 4321c0a71dab │\n",
+       "│ fwd_ret_1d ┆ linear        ┆ enet_f0.85    ┆ final         ┆ null         ┆ 5     ┆ 11cb99da90a2 │\n",
+       "│ …          ┆ …             ┆ …             ┆ …             ┆ …            ┆ …     ┆ …            │\n",
+       "│ fwd_ret_5d ┆ gbm           ┆ leaves_7_hube ┆ iteration     ┆ 50           ┆ 10    ┆ d4d6d17e5918 │\n",
+       "│            ┆               ┆ r             ┆               ┆              ┆       ┆              │\n",
+       "│ fwd_ret_5d ┆ gbm           ┆ leaves_7_mae  ┆ iteration     ┆ 50           ┆ 10    ┆ 0f6a459a5f18 │\n",
+       "│ fwd_ret_5d ┆ linear        ┆ enet_f0.85    ┆ final         ┆ null         ┆ 10    ┆ 88100a79d70a │\n",
+       "│ fwd_ret_5d ┆ linear        ┆ lasso_f0.85   ┆ final         ┆ null         ┆ 10    ┆ ff3d34f8074e │\n",
+       "│ fwd_ret_5d ┆ linear        ┆ ridge_a100000 ┆ final         ┆ null         ┆ 10    ┆ 90de8b7e8b1b │\n",
+       "│            ┆               ┆ .0            ┆               ┆              ┆       ┆              │\n",
+       "└────────────┴───────────────┴───────────────┴───────────────┴──────────────┴───────┴──────────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "top_n = TOP_N_CONFIGS or get_top_n_predictions(CASE_STUDY_ID, \"allocation\")\n",
     "selected_baselines: dict[str, list[BacktestResult]] = {}\n",
@@ -353,8 +472,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9d87ff0",
-   "metadata": {},
+   "id": "8026f1cc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001666,
+     "end_time": "2026-08-28T00:34:20.347777+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:34:20.346111+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Plan and freeze the allocation grid\n",
     "\n",
@@ -365,10 +492,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0f00bb6c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "9fb371b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:34:20.354626Z",
+     "iopub.status.busy": "2026-08-28T00:34:20.354500Z",
+     "iopub.status.idle": "2026-08-28T00:34:20.428026Z",
+     "shell.execute_reply": "2026-08-28T00:34:20.427370Z"
+    },
+    "papermill": {
+     "duration": 0.078853,
+     "end_time": "2026-08-28T00:34:20.428416+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:34:20.349563+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (36, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>top_k</th><th>allocator</th><th>prediction_sets</th></tr><tr><td>str</td><td>i64</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>&quot;score_weighted&quot;</td><td>3</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>&quot;inverse_vol&quot;</td><td>3</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>&quot;risk_parity&quot;</td><td>3</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>&quot;mvo_ledoit_wolf&quot;</td><td>3</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>5</td><td>&quot;hrp&quot;</td><td>3</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>&quot;inverse_vol&quot;</td><td>9</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>&quot;risk_parity&quot;</td><td>9</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>&quot;mvo_ledoit_wolf&quot;</td><td>9</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>&quot;hrp&quot;</td><td>9</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10</td><td>&quot;conformal_weighted&quot;</td><td>9</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (36, 4)\n",
+       "┌────────────┬───────┬────────────────────┬─────────────────┐\n",
+       "│ label      ┆ top_k ┆ allocator          ┆ prediction_sets │\n",
+       "│ ---        ┆ ---   ┆ ---                ┆ ---             │\n",
+       "│ str        ┆ i64   ┆ str                ┆ i64             │\n",
+       "╞════════════╪═══════╪════════════════════╪═════════════════╡\n",
+       "│ fwd_ret_1d ┆ 5     ┆ score_weighted     ┆ 3               │\n",
+       "│ fwd_ret_1d ┆ 5     ┆ inverse_vol        ┆ 3               │\n",
+       "│ fwd_ret_1d ┆ 5     ┆ risk_parity        ┆ 3               │\n",
+       "│ fwd_ret_1d ┆ 5     ┆ mvo_ledoit_wolf    ┆ 3               │\n",
+       "│ fwd_ret_1d ┆ 5     ┆ hrp                ┆ 3               │\n",
+       "│ …          ┆ …     ┆ …                  ┆ …               │\n",
+       "│ fwd_ret_5d ┆ 10    ┆ inverse_vol        ┆ 9               │\n",
+       "│ fwd_ret_5d ┆ 10    ┆ risk_parity        ┆ 9               │\n",
+       "│ fwd_ret_5d ┆ 10    ┆ mvo_ledoit_wolf    ┆ 9               │\n",
+       "│ fwd_ret_5d ┆ 10    ┆ hrp                ┆ 9               │\n",
+       "│ fwd_ret_5d ┆ 10    ┆ conformal_weighted ┆ 9               │\n",
+       "└────────────┴───────┴────────────────────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "allocators = get_allocators(CASE_STUDY_ID)\n",
     "if not allocators or any(config.get(\"method\") == \"equal_weight\" for config in allocators):\n",
@@ -410,14 +589,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f076629b",
+   "execution_count": 6,
+   "id": "4f5e0f66",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:34:20.431313Z",
+     "iopub.status.busy": "2026-08-28T00:34:20.431216Z",
+     "iopub.status.idle": "2026-08-28T00:36:12.390131Z",
+     "shell.execute_reply": "2026-08-28T00:36:12.389411Z"
+    },
+    "papermill": {
+     "duration": 111.960876,
+     "end_time": "2026-08-28T00:36:12.390604+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:34:20.429728+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen expected allocation population: 8a5863966eea\n"
+     ]
+    }
+   ],
    "source": [
     "planned_hashes = []\n",
     "for job in jobs:\n",
@@ -451,8 +651,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "638701d2",
-   "metadata": {},
+   "id": "728a4348",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001106,
+     "end_time": "2026-08-28T00:36:12.393074+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:36:12.391968+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Execute the frozen allocation grid, then validate what was frozen\n",
     "\n",
@@ -463,14 +671,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "248b9b9c",
+   "execution_count": 7,
+   "id": "a2ef3930",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:36:12.400249Z",
+     "iopub.status.busy": "2026-08-28T00:36:12.400037Z",
+     "iopub.status.idle": "2026-08-28T00:41:46.620904Z",
+     "shell.execute_reply": "2026-08-28T00:41:46.620407Z"
+    },
+    "papermill": {
+     "duration": 334.227296,
+     "end_time": "2026-08-28T00:41:46.621586+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:36:12.394290+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Allocation backtests: 0 computed, 180 served from the registry, 180 in the population\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official allocation population: 8a5863966eea\n"
+     ]
+    }
+   ],
    "source": [
     "# A sweep that recomputes everything and a sweep that recomputes nothing print the same summary\n",
     "# unless the two are counted apart. `run_backtests` serves an identity that is already registered\n",
@@ -603,8 +839,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01b0de00",
-   "metadata": {},
+   "id": "d859e29a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00113,
+     "end_time": "2026-08-28T00:41:46.624158+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:41:46.623028+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -622,6 +866,37 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 538.454915,
+   "end_time": "2026-08-28T00:41:49.033908+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/fx_pairs/14_portfolio_management.ipynb",
+   "output_path": "~/scratch/prod_14_portfolio_management_379016.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-28T00:32:50.578993+00:00",
+   "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "ef30faf3af9a964136bde63801262940e0a95552",
+   "executed_at": "2026-08-28T00:41:56.808921+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/15_costs.ipynb
+++ b/case_studies/fx_pairs/15_costs.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d19c2a77",
-   "metadata": {},
+   "id": "36b258c4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002282,
+     "end_time": "2026-08-28T00:42:23.644009+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:42:23.641727+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Transaction-Cost Sensitivity - FX Pairs\n",
     "\n",
@@ -24,9 +32,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "641686b7",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "349e715b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:42:23.648737Z",
+     "iopub.status.busy": "2026-08-28T00:42:23.648567Z",
+     "iopub.status.idle": "2026-08-28T00:42:27.017594Z",
+     "shell.execute_reply": "2026-08-28T00:42:27.017032Z"
+    },
+    "papermill": {
+     "duration": 3.372131,
+     "end_time": "2026-08-28T00:42:27.018058+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:42:23.645927+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Run one cost-sensitivity curve per FX prediction label.\"\"\"\n",
@@ -61,9 +83,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1865557c",
+   "execution_count": 2,
+   "id": "6f28f889",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:42:27.020456Z",
+     "iopub.status.busy": "2026-08-28T00:42:27.020308Z",
+     "iopub.status.idle": "2026-08-28T00:42:27.022887Z",
+     "shell.execute_reply": "2026-08-28T00:42:27.022547Z"
+    },
+    "papermill": {
+     "duration": 0.004077,
+     "end_time": "2026-08-28T00:42:27.023153+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:42:27.019076+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -87,8 +122,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ee001e0",
-   "metadata": {},
+   "id": "8b465ae0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000658,
+     "end_time": "2026-08-28T00:42:27.024602+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:42:27.023944+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Select one strategy for each label\n",
     "\n",
@@ -99,14 +142,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d00fe588",
+   "execution_count": 3,
+   "id": "0a367546",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:42:27.026742Z",
+     "iopub.status.busy": "2026-08-28T00:42:27.026616Z",
+     "iopub.status.idle": "2026-08-28T00:43:50.380440Z",
+     "shell.execute_reply": "2026-08-28T00:43:50.379885Z"
+    },
+    "papermill": {
+     "duration": 83.356517,
+     "end_time": "2026-08-28T00:43:50.381830+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:42:27.025313+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>backtest_hash</th><th>prediction_hash</th><th>stage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;48c8c7f4c3e7&quot;</td><td>&quot;d80638423af7&quot;</td><td>&quot;signal&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;28c0de651530&quot;</td><td>&quot;505bd6013d92&quot;</td><td>&quot;allocation&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;eb1df772da7e&quot;</td><td>&quot;88100a79d70a&quot;</td><td>&quot;allocation&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 4)\n",
+       "┌─────────────┬───────────────┬─────────────────┬────────────┐\n",
+       "│ label       ┆ backtest_hash ┆ prediction_hash ┆ stage      │\n",
+       "│ ---         ┆ ---           ┆ ---             ┆ ---        │\n",
+       "│ str         ┆ str           ┆ str             ┆ str        │\n",
+       "╞═════════════╪═══════════════╪═════════════════╪════════════╡\n",
+       "│ fwd_ret_1d  ┆ 48c8c7f4c3e7  ┆ d80638423af7    ┆ signal     │\n",
+       "│ fwd_ret_21d ┆ 28c0de651530  ┆ 505bd6013d92    ┆ allocation │\n",
+       "│ fwd_ret_5d  ┆ eb1df772da7e  ┆ 88100a79d70a    ┆ allocation │\n",
+       "└─────────────┴───────────────┴─────────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "universe_symbols = yaml.safe_load(\n",
@@ -304,8 +390,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a856fb4",
-   "metadata": {},
+   "id": "24789319",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001088,
+     "end_time": "2026-08-28T00:43:50.384134+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:43:50.383046+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Plan and freeze exact cost siblings\n",
     "\n",
@@ -317,14 +411,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1bb07fdd",
+   "execution_count": 4,
+   "id": "6f220c8c",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:43:50.387193Z",
+     "iopub.status.busy": "2026-08-28T00:43:50.387003Z",
+     "iopub.status.idle": "2026-08-28T00:44:44.737019Z",
+     "shell.execute_reply": "2026-08-28T00:44:44.736013Z"
+    },
+    "papermill": {
+     "duration": 54.353933,
+     "end_time": "2026-08-28T00:44:44.738997+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:43:50.385064+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen expected cost population: 50054fe9e191\n"
+     ]
+    }
+   ],
    "source": [
     "cost_grid = get_cost_grid_bps(CASE_STUDY_ID)\n",
     "if MAX_COST_POINTS:\n",
@@ -416,8 +531,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c55c1772",
-   "metadata": {},
+   "id": "e7797368",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001742,
+     "end_time": "2026-08-28T00:44:44.741970+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:44:44.740228+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Execute the frozen cost grid, and validate its membership without making it selectable\n",
     "\n",
@@ -429,14 +552,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1683542e",
+   "execution_count": 5,
+   "id": "7b869821",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:44:44.748834Z",
+     "iopub.status.busy": "2026-08-28T00:44:44.748603Z",
+     "iopub.status.idle": "2026-08-28T00:47:50.746982Z",
+     "shell.execute_reply": "2026-08-28T00:47:50.746522Z"
+    },
+    "papermill": {
+     "duration": 186.007666,
+     "end_time": "2026-08-28T00:47:50.750767+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:44:44.743101+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cost siblings: 0 computed, 33 served from the registry, 33 in the population\n",
+      "Official cost-sensitivity population: 50054fe9e191\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (33, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>total_cost_bps</th><th>backtest_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>f64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>0.0</td><td>&quot;8486c9bf954f&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>1.0</td><td>&quot;33cc8f926aa5&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>2.0</td><td>&quot;49605c465c04&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>3.0</td><td>&quot;77e497c92718&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>5.0</td><td>&quot;eb65494b2d95&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>10.0</td><td>&quot;6939717e92a8&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>15.0</td><td>&quot;f0477be64c21&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>20.0</td><td>&quot;b9673bbd6933&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>30.0</td><td>&quot;6caf97819db5&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>50.0</td><td>&quot;cd5b31e82a3a&quot;</td><td>&quot;88100a79d70a&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (33, 4)\n",
+       "┌────────────┬────────────────┬───────────────┬─────────────────┐\n",
+       "│ label      ┆ total_cost_bps ┆ backtest_hash ┆ prediction_hash │\n",
+       "│ ---        ┆ ---            ┆ ---           ┆ ---             │\n",
+       "│ str        ┆ f64            ┆ str           ┆ str             │\n",
+       "╞════════════╪════════════════╪═══════════════╪═════════════════╡\n",
+       "│ fwd_ret_1d ┆ 0.0            ┆ 8486c9bf954f  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ 1.0            ┆ 33cc8f926aa5  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ 2.0            ┆ 49605c465c04  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ 3.0            ┆ 77e497c92718  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ 5.0            ┆ eb65494b2d95  ┆ d80638423af7    │\n",
+       "│ …          ┆ …              ┆ …             ┆ …               │\n",
+       "│ fwd_ret_5d ┆ 10.0           ┆ 6939717e92a8  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ 15.0           ┆ f0477be64c21  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ 20.0           ┆ b9673bbd6933  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ 30.0           ┆ 6caf97819db5  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ 50.0           ┆ cd5b31e82a3a  ┆ 88100a79d70a    │\n",
+       "└────────────┴────────────────┴───────────────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# A sweep that recomputes everything and a sweep that recomputes nothing print the same summary\n",
     "# unless the two are counted apart. `run_backtests` serves an identity that is already registered\n",
@@ -503,8 +685,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fcf5201",
-   "metadata": {},
+   "id": "80ba9aac",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001302,
+     "end_time": "2026-08-28T00:47:50.753751+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:47:50.752449+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -522,6 +712,37 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 330.423652,
+   "end_time": "2026-08-28T00:47:53.258238+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/fx_pairs/15_costs.ipynb",
+   "output_path": "~/scratch/prod_15_costs_428657.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-28T00:42:22.834586+00:00",
+   "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "7faea63bba8e1b8f17aa2a1547a4fdb9322910df",
+   "executed_at": "2026-08-28T00:48:00.304810+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/16_risk_management.ipynb
+++ b/case_studies/fx_pairs/16_risk_management.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9e48365d",
-   "metadata": {},
+   "id": "cb45bda1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001872,
+     "end_time": "2026-08-28T00:48:22.508501+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:48:22.506629+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Position Risk Controls - FX Pairs\n",
     "\n",
@@ -24,9 +32,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8196484e",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "5833fc4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:48:22.512463Z",
+     "iopub.status.busy": "2026-08-28T00:48:22.512218Z",
+     "iopub.status.idle": "2026-08-28T00:48:26.739612Z",
+     "shell.execute_reply": "2026-08-28T00:48:26.739056Z"
+    },
+    "papermill": {
+     "duration": 4.230333,
+     "end_time": "2026-08-28T00:48:26.740472+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:48:22.510139+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Run the declared FX position-risk controls for each label.\"\"\"\n",
@@ -62,9 +84,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7bad835b",
+   "execution_count": 2,
+   "id": "ad129d75",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:48:26.745695Z",
+     "iopub.status.busy": "2026-08-28T00:48:26.745546Z",
+     "iopub.status.idle": "2026-08-28T00:48:26.748176Z",
+     "shell.execute_reply": "2026-08-28T00:48:26.747723Z"
+    },
+    "papermill": {
+     "duration": 0.006973,
+     "end_time": "2026-08-28T00:48:26.748768+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:48:26.741795+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -88,8 +123,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03f99bf6",
-   "metadata": {},
+   "id": "72b1fc76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0014,
+     "end_time": "2026-08-28T00:48:26.752012+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:48:26.750612+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Select the parent strategy\n",
     "\n",
@@ -99,14 +142,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cf8100d8",
+   "execution_count": 3,
+   "id": "55cf1573",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:48:26.755709Z",
+     "iopub.status.busy": "2026-08-28T00:48:26.755568Z",
+     "iopub.status.idle": "2026-08-28T00:49:47.944204Z",
+     "shell.execute_reply": "2026-08-28T00:49:47.943248Z"
+    },
+    "papermill": {
+     "duration": 81.193993,
+     "end_time": "2026-08-28T00:49:47.947335+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:48:26.753342+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>backtest_hash</th><th>prediction_hash</th><th>stage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;48c8c7f4c3e7&quot;</td><td>&quot;d80638423af7&quot;</td><td>&quot;signal&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;28c0de651530&quot;</td><td>&quot;505bd6013d92&quot;</td><td>&quot;allocation&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;eb1df772da7e&quot;</td><td>&quot;88100a79d70a&quot;</td><td>&quot;allocation&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 4)\n",
+       "┌─────────────┬───────────────┬─────────────────┬────────────┐\n",
+       "│ label       ┆ backtest_hash ┆ prediction_hash ┆ stage      │\n",
+       "│ ---         ┆ ---           ┆ ---             ┆ ---        │\n",
+       "│ str         ┆ str           ┆ str             ┆ str        │\n",
+       "╞═════════════╪═══════════════╪═════════════════╪════════════╡\n",
+       "│ fwd_ret_1d  ┆ 48c8c7f4c3e7  ┆ d80638423af7    ┆ signal     │\n",
+       "│ fwd_ret_21d ┆ 28c0de651530  ┆ 505bd6013d92    ┆ allocation │\n",
+       "│ fwd_ret_5d  ┆ eb1df772da7e  ┆ 88100a79d70a    ┆ allocation │\n",
+       "└─────────────┴───────────────┴─────────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "universe_symbols = yaml.safe_load(\n",
@@ -304,8 +390,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "887326d4",
-   "metadata": {},
+   "id": "205ab541",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002359,
+     "end_time": "2026-08-28T00:49:47.951022+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:49:47.948663+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Plan and freeze exact risk siblings\n",
     "\n",
@@ -317,14 +411,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8a2c8aa1",
+   "execution_count": 4,
+   "id": "3783f944",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:49:47.957923Z",
+     "iopub.status.busy": "2026-08-28T00:49:47.957651Z",
+     "iopub.status.idle": "2026-08-28T00:51:27.497803Z",
+     "shell.execute_reply": "2026-08-28T00:51:27.495509Z"
+    },
+    "papermill": {
+     "duration": 99.552678,
+     "end_time": "2026-08-28T00:51:27.505900+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:49:47.953222+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen expected risk population: 03324937abd9\n"
+     ]
+    }
+   ],
    "source": [
     "position_controls = get_position_risk_controls(CASE_STUDY_ID)\n",
     "if get_portfolio_risk_controls(CASE_STUDY_ID):\n",
@@ -419,8 +534,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aadf533c",
-   "metadata": {},
+   "id": "7ad9cd46",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003956,
+     "end_time": "2026-08-28T00:51:27.518148+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:51:27.514192+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Execute the frozen risk grid, and validate what was frozen\n",
     "\n",
@@ -431,14 +554,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "672bdb3e",
+   "execution_count": 5,
+   "id": "58c49d51",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:51:27.529713Z",
+     "iopub.status.busy": "2026-08-28T00:51:27.528670Z",
+     "iopub.status.idle": "2026-08-28T00:56:56.930250Z",
+     "shell.execute_reply": "2026-08-28T00:56:56.929041Z"
+    },
+    "papermill": {
+     "duration": 329.410024,
+     "end_time": "2026-08-28T00:56:56.931819+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:51:27.521795+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Risk overlays: 0 computed, 42 served from the registry, 42 in the population\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official risk population: 03324937abd9\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (42, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>risk_name</th><th>backtest_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_10pct&quot;</td><td>&quot;07f99d2e1930&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_15pct&quot;</td><td>&quot;75fc3e0dd3a0&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_3pct&quot;</td><td>&quot;992427568dc8&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_5pct&quot;</td><td>&quot;ffba4458c379&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;time_exit_10&quot;</td><td>&quot;682896201e67&quot;</td><td>&quot;d80638423af7&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_1pct&quot;</td><td>&quot;8b6a781db6f3&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_20pct&quot;</td><td>&quot;33bd91b2a744&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_2pct&quot;</td><td>&quot;38ddac2bbf95&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_3pct&quot;</td><td>&quot;e46acc2b6b38&quot;</td><td>&quot;88100a79d70a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_5pct&quot;</td><td>&quot;977d6f0e1535&quot;</td><td>&quot;88100a79d70a&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (42, 4)\n",
+       "┌────────────┬─────────────────┬───────────────┬─────────────────┐\n",
+       "│ label      ┆ risk_name       ┆ backtest_hash ┆ prediction_hash │\n",
+       "│ ---        ┆ ---             ┆ ---           ┆ ---             │\n",
+       "│ str        ┆ str             ┆ str           ┆ str             │\n",
+       "╞════════════╪═════════════════╪═══════════════╪═════════════════╡\n",
+       "│ fwd_ret_1d ┆ stop_loss_10pct ┆ 07f99d2e1930  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_15pct ┆ 75fc3e0dd3a0  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_3pct  ┆ 992427568dc8  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_5pct  ┆ ffba4458c379  ┆ d80638423af7    │\n",
+       "│ fwd_ret_1d ┆ time_exit_10    ┆ 682896201e67  ┆ d80638423af7    │\n",
+       "│ …          ┆ …               ┆ …             ┆ …               │\n",
+       "│ fwd_ret_5d ┆ trailing_1pct   ┆ 8b6a781db6f3  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ trailing_20pct  ┆ 33bd91b2a744  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ trailing_2pct   ┆ 38ddac2bbf95  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ trailing_3pct   ┆ e46acc2b6b38  ┆ 88100a79d70a    │\n",
+       "│ fwd_ret_5d ┆ trailing_5pct   ┆ 977d6f0e1535  ┆ 88100a79d70a    │\n",
+       "└────────────┴─────────────────┴───────────────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# A sweep that recomputes everything and a sweep that recomputes nothing print the same summary\n",
     "# unless the two are counted apart. `run_backtests` serves an identity that is already registered\n",
@@ -502,8 +690,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5b709d3",
-   "metadata": {},
+   "id": "e0331a51",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001991,
+     "end_time": "2026-08-28T00:56:56.936440+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:56:56.934449+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Freeze the set the holdout will choose from\n",
     "\n",
@@ -516,10 +712,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e6c0197c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "3143273f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:56:56.943451Z",
+     "iopub.status.busy": "2026-08-28T00:56:56.942905Z",
+     "iopub.status.idle": "2026-08-28T00:57:43.311760Z",
+     "shell.execute_reply": "2026-08-28T00:57:43.310737Z"
+    },
+    "papermill": {
+     "duration": 46.375652,
+     "end_time": "2026-08-28T00:57:43.314290+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:56:56.938638+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frozen holdout candidate set: 1f2d3460ba51\n",
+      "Validation-selected backtest: 28c0de651530\n"
+     ]
+    }
+   ],
    "source": [
     "if not include_preview:\n",
     "    holdout_candidates = CandidateSet.create(\n",
@@ -537,8 +756,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "145cfc63",
-   "metadata": {},
+   "id": "92e96fb1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001683,
+     "end_time": "2026-08-28T00:57:43.318171+00:00",
+     "exception": false,
+     "start_time": "2026-08-28T00:57:43.316488+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -556,6 +783,37 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 564.927955,
+   "end_time": "2026-08-28T00:57:46.413974+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "case_studies/fx_pairs/16_risk_management.ipynb",
+   "output_path": "~/scratch/prod_16_risk_management_471939.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-28T00:48:21.486019+00:00",
+   "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "404293c453df19f4e44051595aa74aa3b0de694e",
+   "executed_at": "2026-08-28T00:58:00.685172+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The four backtesting notebooks executed against the canonical registry. **Sources are unchanged** - every phase-2 source landed in #632, and `git diff origin/main HEAD` over the four `.py` files is empty. This PR is the executed notebooks and nothing else.

Closes the `fx_pairs-p2` unit (agent-workspace #385).

## What the runs show

| notebook | computed | served | population | resolved to |
|---|---|---|---|---|
| `13_backtest` | 0 | 1452 | equal-weight baselines | `1e1cd87665c9` |
| `14_portfolio_management` | 0 | 180 | allocation | `8a5863966eea` |
| `15_costs` | 0 | 33 | cost sensitivity | `50054fe9e191` |
| `16_risk_management` | 0 | 42 | risk overlay | `03324937abd9` |

The number worth reading is not the exit code. Every stage **resolved to the population it had already frozen** rather than publishing a new generation over it, and computed nothing - which is the reproduction property the phase-2 sources were written to have, and the thing that would have failed silently had any identity drifted.

`13_backtest` also excluded **192 of 918** catalog rows as retired by a later generation before freezing its baseline population. That exclusion reads the population lineage rather than `identity_status`; the same 192 were the subject of #641, which fixed `12_model_analysis` rendering them.

`16_risk_management` freezes holdout candidate set `1f2d3460ba51`.

## Where this stops, and why

Phase 2 ends at that candidate set. The holdout is **not** run here and `17_strategy_analysis` is not included.

`17_strategy_analysis` requires a `RESEARCH_LOCK_HASH` and refuses unless the lock reads `HOLDOUT_EVALUATED`. Producing that lock needs the `expected_keys` alignment fix in `20_strategy_synthesis/holdout.py`, which is **not on main** - it rides open PR #598. Verified by grepping `origin/main` for `_holdout_expected_keys|_align_expected_timestamps|expected_keys=`: no matches.

`fx_pairs`'s `research_locks` table currently holds **zero rows**, so the holdout has never been taken and the single use is intact. Running it against the unfixed producer would spend it. That is why this PR stops here rather than carrying an unrunnable notebook.