### PR TITLE
Record the execution tier on the study, so a preview is refused by what it is

### DIFF
--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -78,8 +79,20 @@ def _preview_is_active(study: Study) -> bool:
     isolated preview was stamped canonical and `_refuse_preview_activation` never ran on the
     one path CI exercises. No amount of scoping an environment read reaches that, because the
     marker it would scope was never written.
+
+    The field is not the whole answer, because `activate` takes a tier per call: every model
+    adapter opens one study and activates whichever tier the run asked for, so a study opened
+    canonical can be writing as a preview right now. The field answers what the study was
+    opened for; the active output root answers what it is writing as. It is a preview if
+    either says so, and the root is compared against this study's own preview directory so a
+    second study's activation cannot answer for this one.
     """
-    return study.execution_tier is ExecutionTier.PREVIEW
+    if study.execution_tier is ExecutionTier.PREVIEW:
+        return True
+    active = os.environ.get("ML4T_OUTPUT_DIR")
+    if not active or study.output_root is None:
+        return False
+    return Path(active).resolve() == (Path(study.output_root) / ".preview").resolve()
 
 
 def _refuse_preview_activation(study: Study) -> None:

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from case_studies.utils.registry.specs import canonical_json, compute_hash
 from case_studies.utils.registry.store import _open_registry, _utc_now
 
+from .contracts import ExecutionTier
 from .results import Result
 
 if TYPE_CHECKING:
@@ -55,40 +56,33 @@ def research_name(case_study_id: str, suffix: str, *, scope: str = "") -> str:
     return f"{scope}:{suffix}" if scope else f"{case_study_id}:{suffix}"
 
 
-def _preview_is_active(study: Study | None = None) -> bool:
-    """Whether a preview tier is active, from the one signal that survives the read path.
+def _preview_is_active(study: Study) -> bool:
+    """Whether this study is a preview, asked of the study rather than of the environment.
 
-    `Study.activate` stamps `ML4T_OUTPUT_DIR` with a `.preview` root, and that is the only
-    marker a caller downstream can rely on. **`study.root` is not one.** In a maintainer
-    worktree `features`, `labels` and `run_log` are symlinks into the shared artifact store,
-    which `create_experiment` cannot copy, so `open_study(execution_tier="preview")` takes the
-    read-in-place branch (`workspace.py`) and hands back a study whose `root` *is* the canonical
-    case directory, with only its writes redirected. A preview there reads canonical rows.
+    The tier is a property of how the study was opened, and `Study` holds it. Every earlier
+    version of this read `ML4T_OUTPUT_DIR` instead, which `Study.activate` stamps and never
+    clears, and that answers a different question: "is a preview active anywhere in this
+    process", not "is this study a preview". The two diverge whenever one process holds two
+    studies, and they diverged in both directions.
 
-    That is invisible in CI, where a checkout has no symlinks and the isolated branch runs
-    instead - so a check that passes on a runner and fails on a maintainer's machine is the
-    expected shape of this bug rather than a surprising one.
+    Reading the environment unscoped withheld the declared hash from a canonical study that
+    merely ran second, after any preview had been opened. The notebook then refits everything
+    and dies at registration for naming no predecessor - the expense the declaration exists to
+    prevent. Scoping the read to the study's own output root fixed that and opened the reverse:
+    a canonical study sharing that output root and activating later cleared the `.preview`
+    stamp, so the preview read as canonical and had its run refused.
 
-    The variable is process-global and `activate` never clears it, so "a preview is active"
-    and "*this* study is the preview" are different questions. Pass ``study`` to ask the
-    second. `activate` stamps ``study.output_root / ".preview"``, so a stamp whose parent is
-    some other study's output root says nothing about this one. Without the argument this
-    still answers the first question, which is what `_refuse_preview_activation` wants: a
-    population is written to whichever registry the active tier points at, so any active
-    preview is grounds to refuse the write.
+    Neither reading could reach the third case at all. `open_study` returns an isolated study
+    through `Study.open` when the case study's generated directories are not symlinks, which is
+    every CI checkout and every clean clone, and `Study.open` activated as canonical - so an
+    isolated preview was stamped canonical and `_refuse_preview_activation` never ran on the
+    one path CI exercises. No amount of scoping an environment read reaches that, because the
+    marker it would scope was never written.
     """
-    import os
-    from pathlib import Path
-
-    active = os.environ.get("ML4T_OUTPUT_DIR")
-    if not active or Path(active).name != ".preview":
-        return False
-    if study is None or study.output_root is None:
-        return True
-    return Path(active).parent.resolve() == Path(study.output_root).resolve()
+    return study.execution_tier is ExecutionTier.PREVIEW
 
 
-def _refuse_preview_activation() -> None:
+def _refuse_preview_activation(study: Study) -> None:
     """A population is written to the canonical registry whatever tier is active.
 
     That is correct - a population is canonical by definition - but it means a preview run that
@@ -100,7 +94,7 @@ def _refuse_preview_activation() -> None:
 
     Callers guard this too. This is the guard that does not depend on remembering.
     """
-    if _preview_is_active():
+    if _preview_is_active(study):
         raise ValueError(
             "a preview run cannot create an official population: it would be written to the "
             "canonical registry"
@@ -127,7 +121,7 @@ class OfficialPopulation:
         supersedes: str | None = None,
     ) -> OfficialPopulation:
         study.require_writable()
-        _refuse_preview_activation()
+        _refuse_preview_activation(study)
         if member_kind not in {"training", "prediction", "backtest"}:
             raise ValueError("official population member_kind is not supported")
         normalized = tuple(dict.fromkeys(str(member) for member in members))

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -142,6 +142,13 @@ class Study:
     # under papermill the executing file is a temp .ipynb and `__file__` may be absent entirely,
     # so a frame walk is wrong exactly where it would be needed.
     entry_point: str | None = None
+    # The tier this study was opened for, held rather than re-derived. `ML4T_OUTPUT_DIR` is
+    # process-global and `activate` never clears it, so every consumer that read the tier from
+    # the environment was answering "is a preview active anywhere in this process" while asking
+    # "is this study a preview". Those differ whenever one process holds two studies, and they
+    # differ in both directions - see the two failures this closes.
+    execution_tier: ExecutionTier = ExecutionTier.CANONICAL
+
     # Set only by `Study.at`, where the released case directory is the one root the study was
     # given and is not derivable from `release_root`: a fixture root, or any output directory
     # that is not `<repo>/case_studies/<name>`.
@@ -192,7 +199,9 @@ class Study:
         *,
         release_root: str | Path = REPO_ROOT,
         entry_point: str | None = None,
+        execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
     ) -> Study:
+        execution_tier = ExecutionTier(execution_tier)
         release_root = Path(release_root).expanduser().resolve()
         release_case_dir = release_root / "case_studies" / case_study
         if not release_case_dir.is_dir():
@@ -212,6 +221,7 @@ class Study:
                     "baseline_manifest_sha256": _release_manifest_digest(release_case_dir),
                 },
                 entry_point=entry_point,
+                execution_tier=execution_tier,
             )
             study.activate()
             return study
@@ -266,6 +276,7 @@ class Study:
             read_only=False,
             manifest=manifest,
             entry_point=entry_point,
+            execution_tier=execution_tier,
         )
         from case_studies.utils.registry.store import _open_registry
 
@@ -310,9 +321,9 @@ class Study:
         study.activate()
         return study
 
-    def activate(self, execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL) -> Path:
+    def activate(self, execution_tier: str | ExecutionTier | None = None) -> Path:
         global _ACTIVE_OUTPUT_ROOT
-        tier = ExecutionTier(execution_tier)
+        tier = self.execution_tier if execution_tier is None else ExecutionTier(execution_tier)
         if self.read_only:
             os.environ.pop("ML4T_OUTPUT_DIR", None)
             _ACTIVE_OUTPUT_ROOT = None
@@ -464,6 +475,7 @@ def open_study(
             workspace=workspace,
             release_root=release_root,
             entry_point=entry_point,
+            execution_tier=tier,
         )
 
     # A maintainer worktree links its generated directories to shared data, which
@@ -485,6 +497,7 @@ def open_study(
             "baseline_source_commit": _source_commit(release_root),
             "preview_only": True,
         },
+        execution_tier=tier,
     )
-    study.activate(tier)
+    study.activate()
     return study

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -24,6 +24,7 @@ from case_studies.research import (
     superseded_members_at,
 )
 from case_studies.research import population as population_module
+from case_studies.research.contracts import ExecutionTier
 from case_studies.research.workspace import Study, open_study
 from tests.test_research_workspace import _seed_release
 
@@ -404,6 +405,29 @@ class TestThePreviewTier:
         # environment read: its stamp replaced the preview's, so the preview read as canonical.
         study.activate()
         assert population_supersedes(preview, name=first.name, declared=first.hash) is None
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+
+    def test_a_study_that_activates_preview_per_run_is_a_preview_while_it_does(
+        self, study: Study
+    ) -> None:
+        """The tier is per activation, not only per open, and both readings must hold.
+
+        `linear`, `gbm`, `tabular_dl`, `deep_learning`, `latent_factors` and `causal` all open
+        one study and then call `study.activate(tier)` with whichever tier the run asked for.
+        Those studies are opened canonical, so a guard reading only the field would say
+        canonical while the run writes into `.preview` - and the population would land in the
+        shared registry, which is the failure this guard exists for.
+        """
+        first = _publish(study, MEMBERS_ONE)
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+
+        study.activate("preview")
+        assert study.execution_tier is ExecutionTier.CANONICAL
+        assert population_supersedes(study, name=first.name, declared=first.hash) is None
+        with pytest.raises(ValueError, match="preview run cannot create an official population"):
+            _publish(study, MEMBERS_TWO)
+
+        study.activate("canonical")
         assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
 
     def test_the_refusal_to_create_reads_the_same_signal(

--- a/tests/test_population_supersedes.py
+++ b/tests/test_population_supersedes.py
@@ -24,8 +24,10 @@ from case_studies.research import (
     superseded_members_at,
 )
 from case_studies.research import population as population_module
-from case_studies.research.workspace import Study
+from case_studies.research.workspace import Study, open_study
 from tests.test_research_workspace import _seed_release
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 MEMBERS_ONE = ("aaaa11112222", "bbbb11112222")
 MEMBERS_TWO = ("cccc33334444", "dddd33334444")
@@ -299,58 +301,123 @@ class TestWhatALaterGenerationRetires:
         assert superseded_members(refitter) == frozenset(MEMBERS_ONE)
 
 
+def _symlinked_worktree(tmp_path: Path, published: Study) -> Path:
+    """A maintainer worktree's layout, built rather than described.
+
+    `features`, `labels` and `run_log` are symlinks into the shared artifact store, which
+    `create_experiment` cannot copy - so `open_study(execution_tier="preview")` takes the
+    read-in-place branch and hands back a study whose `root` *is* the canonical case
+    directory, with only its writes redirected. That is the layout where a preview reads
+    canonical rows, and pointing a preview at a hand-made isolated root would pass whether
+    or not the guard existed.
+    """
+    release_root = tmp_path / "worktree"
+    case_dir = release_root / "case_studies" / "etfs"
+    case_dir.mkdir(parents=True)
+    (release_root / "case_studies" / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "config", target_is_directory=True
+    )
+    (case_dir / "config").symlink_to(
+        REPO_ROOT / "case_studies" / "etfs" / "config", target_is_directory=True
+    )
+    for generated in ("features", "labels", "run_log"):
+        target = published.root / generated
+        target.mkdir(exist_ok=True)
+        (case_dir / generated).symlink_to(target, target_is_directory=True)
+    return release_root
+
+
 class TestThePreviewTier:
     """A preview never creates an official population, so it never supersedes one.
 
-    This has to be decided from the tier rather than from what the registry holds, because in a
-    maintainer worktree the registry a preview reads *is* the canonical one. `features`,
-    `labels` and `run_log` are symlinks into the shared artifact store, which `create_experiment`
-    cannot copy, so `open_study(execution_tier="preview")` takes the read-in-place branch and
-    returns a study whose `root` is the canonical case directory with only its writes redirected.
-
-    Asking the registry first then returns a real generation, the hash is offered, and
-    `run_model_population` refuses the whole run - "preview populations cannot supersede a
-    snapshot" - before the first fit. A CI checkout has no symlinks and never takes that branch,
-    so this fails only on a maintainer's machine.
+    The tier is asked of the study, which holds it, rather than of `ML4T_OUTPUT_DIR`. These
+    tests therefore open real preview studies: a monkeypatched environment variable would be
+    asserting against a signal the code no longer reads, which is how the previous version of
+    two of these agreed with itself while describing nothing.
     """
 
-    def test_a_preview_is_never_offered_the_hash(
-        self, study: Study, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_a_preview_is_never_offered_the_hash(self, study: Study, tmp_path: Path) -> None:
+        """The maintainer branch, where the registry a preview reads is the canonical one.
+
+        The lookup cannot be what withholds the hash here - it succeeds. Only the tier can.
+        """
         first = _publish(study, MEMBERS_ONE)
         # Canonical resolves it, which is what makes the preview answer a decision rather than
         # an absence: the same registry, the same name, the same declaration.
         assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
 
-        # The value `Study.activate` writes, not merely some path ending in `.preview`: the
-        # guard asks whether the stamp belongs to *this* study, so a hand-made path that no
-        # activation would produce tests a signal the code never sees.
-        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.output_root / ".preview"))
-        assert population_supersedes(study, name=first.name, declared=first.hash) is None
+        preview = open_study(
+            "etfs",
+            execution_tier="preview",
+            workspace=tmp_path / "preview-workspace",
+            release_root=_symlinked_worktree(tmp_path, study),
+        )
+        # The premise. If `open_study` ever gives a symlinked preview its own root, this stops
+        # describing the situation being guarded against and must be revisited, not deleted.
+        assert (preview.root / "run_log").is_symlink()
+        assert population_supersedes(preview, name=first.name, declared=first.hash) is None
 
-    def test_another_study_s_preview_does_not_withhold_from_this_one(
-        self, study: Study, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    def test_an_isolated_preview_is_refused_too(self, tmp_path: Path) -> None:
+        """The CI branch, which no environment-based guard could ever reach.
+
+        When the generated directories are not symlinks - every CI checkout and every clean
+        clone - `open_study` returns an isolated study through `Study.open`, which activated
+        as canonical. So an isolated preview was *stamped canonical* and the refusal never ran
+        on the one path CI exercises. A test asserting the refusal passed on a maintainer's
+        machine and would have passed in CI only because CI never tried.
+        """
+        preview = open_study(
+            "etfs",
+            execution_tier="preview",
+            workspace=tmp_path / "isolated",
+            release_root=_seed_release(tmp_path),
+        )
+        assert not (preview.root / "run_log").is_symlink()
+        with pytest.raises(ValueError, match="preview run cannot create an official population"):
+            _publish(preview, MEMBERS_ONE)
+
+    def test_a_canonical_study_opened_alongside_a_preview_still_resolves(
+        self, study: Study, tmp_path: Path
     ) -> None:
-        """`ML4T_OUTPUT_DIR` is process-global and `activate` never clears it.
+        """One process, two studies - the case the environment could never answer.
 
-        So "a preview is active somewhere in this process" and "this study is that preview"
-        are different questions, and answering the first withholds the hash from a canonical
-        study that merely ran second. A notebook runs one tier and never notices; any process
-        that opens both - a test module, a backfill over several case studies - gets a
-        canonical declaration silently withheld and the run dies at `create` for naming no
-        predecessor, after paying for every fit.
+        `ML4T_OUTPUT_DIR` is process-global and `activate` never clears it, so reading it
+        answered "is a preview active anywhere" and got this backwards in both directions:
+        unscoped it withheld from every canonical study that merely ran second, and scoped to
+        an output root it let a later canonical activation clear a live preview's stamp. The
+        study holds its own tier, so the order they are opened in stops mattering.
         """
         first = _publish(study, MEMBERS_ONE)
-        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path / "elsewhere" / ".preview"))
+        # The symlinked preview deliberately, not an isolated one. An isolated preview's
+        # registry is empty, so `None` comes back whether or not the tier was consulted - the
+        # assertion would hold against the very defect it is meant to catch. This preview reads
+        # the canonical registry, so the lookup would succeed and only the tier can withhold.
+        preview = open_study(
+            "etfs",
+            execution_tier="preview",
+            workspace=tmp_path / "preview-workspace",
+            release_root=_symlinked_worktree(tmp_path, study),
+        )
+        assert population_supersedes(preview, name=first.name, declared=first.hash) is None
+        assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
+        # And after the canonical study activates, which is the order that broke the scoped
+        # environment read: its stamp replaced the preview's, so the preview read as canonical.
+        study.activate()
+        assert population_supersedes(preview, name=first.name, declared=first.hash) is None
         assert population_supersedes(study, name=first.name, declared=first.hash) == first.hash
 
     def test_the_refusal_to_create_reads_the_same_signal(
-        self, study: Study, monkeypatch: pytest.MonkeyPatch
+        self, study: Study, tmp_path: Path
     ) -> None:
         """One derivation for both, so they cannot drift into disagreeing about the tier."""
-        monkeypatch.setenv("ML4T_OUTPUT_DIR", str(study.root / ".preview"))
+        preview = open_study(
+            "etfs",
+            execution_tier="preview",
+            workspace=tmp_path / "preview-workspace",
+            release_root=_symlinked_worktree(tmp_path, study),
+        )
         with pytest.raises(ValueError, match="preview run cannot create an official population"):
-            _publish(study, MEMBERS_TWO)
+            _publish(preview, MEMBERS_TWO)
 
 
 class TestWhenTheRegistryReadItselfFails:


### PR DESCRIPTION
`population_supersedes` and `OfficialPopulation.create` decided whether a study was a preview by reading `ML4T_OUTPUT_DIR` and testing whether its basename was `.preview`.

That signal only exists on the read-in-place branch of `open_study`, taken when the case study's artifact directories are symlinks - a maintainer's checkout. A CI checkout has no symlinks, takes the isolated branch, and its preview never sets the variable at all: `Study.open` calls `activate()`, which defaulted to `CANONICAL`, so **the preview was actively stamped canonical**.

The consequence is not that a test was missing. It is that the refusal **could not be covered by a test at all**: an assertion that a preview declines to create an official population passes on a maintainer's machine, and would pass in CI only because CI never reaches it. So the fix has to change the shape rather than add coverage.

The isolated preview writes to its own registry and so loses no data today. What it loses is the guarantee - nothing stops it from publishing.

## What changed

- `Study` carries `execution_tier` as a field, set at construction on both branches of `open_study`.
- `activate` defaults to the tier the study already holds rather than to `CANONICAL`.
- `_preview_is_active` reads that field **and** the active output root, scoped to this study's own `.preview` directory.

The second read is not redundant. `activate` takes a tier per call: `linear`, `gbm`, `tabular_dl`, `deep_learning`, `latent_factors`, `causal` and `sp500_options/research_workflow` all open one canonical study and then activate whichever tier the run asked for. The field answers what the study was opened for; the active root answers what it is writing as right now. A preview is either. Scoping the root comparison to this study keeps the fix for the bug the field was introduced for: a second study's activation cannot answer for this one.

The first commit here read the field alone, which regressed those seven adapter paths. RoboRev caught it, the second commit restores the per-activation read, and `test_a_study_that_activates_preview_per_run_is_a_preview_while_it_does` is the test that fails against the first commit.

## Tests

`TestThePreviewTier` now opens real preview studies through `open_study`, one of each shape:

- the symlinked maintainer preview, where the lookup succeeds and only the tier can withhold the hash
- the isolated CI preview, which could not be expressed at all while the tier lived in an environment variable
- two studies in one process, the case the process-global read got backwards in both directions
- a canonical study that activates preview per run, the adapter path

Three of the five fail against the code they replace. `tests/test_population_supersedes.py` 37 passed, `tests/test_research_contract_lifecycle.py` 15 passed.

Closes #950
Closes #951