### PR TITLE
fx_pairs 12: report every label the menu declares, not the first of three

### DIFF
--- a/case_studies/fx_pairs/12_model_analysis.ipynb
+++ b/case_studies/fx_pairs/12_model_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e91a371b",
+   "id": "a45c4c1d",
    "metadata": {
     "papermill": {
-     "duration": 0.002068,
-     "end_time": "2026-08-28T00:29:34.758350+00:00",
+     "duration": 0.001934,
+     "end_time": "2026-08-28T14:28:26.706463+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:34.756282+00:00",
+     "start_time": "2026-08-28T14:28:26.704529+00:00",
      "status": "completed"
     }
    },
@@ -36,19 +36,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "3f54f865",
+   "id": "b7ddd5ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:34.762465Z",
-     "iopub.status.busy": "2026-08-28T00:29:34.762239Z",
-     "iopub.status.idle": "2026-08-28T00:29:39.747622Z",
-     "shell.execute_reply": "2026-08-28T00:29:39.747240Z"
+     "iopub.execute_input": "2026-08-28T14:28:26.711414Z",
+     "iopub.status.busy": "2026-08-28T14:28:26.711245Z",
+     "iopub.status.idle": "2026-08-28T14:28:30.908643Z",
+     "shell.execute_reply": "2026-08-28T14:28:30.908234Z"
     },
     "papermill": {
-     "duration": 4.990821,
-     "end_time": "2026-08-28T00:29:39.750902+00:00",
+     "duration": 4.200354,
+     "end_time": "2026-08-28T14:28:30.909422+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:34.760081+00:00",
+     "start_time": "2026-08-28T14:28:26.709068+00:00",
      "status": "completed"
     }
    },
@@ -72,19 +72,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "cd92621b",
+   "id": "ab8da152",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:39.754367Z",
-     "iopub.status.busy": "2026-08-28T00:29:39.754131Z",
-     "iopub.status.idle": "2026-08-28T00:29:39.756131Z",
-     "shell.execute_reply": "2026-08-28T00:29:39.755897Z"
+     "iopub.execute_input": "2026-08-28T14:28:30.914465Z",
+     "iopub.status.busy": "2026-08-28T14:28:30.914199Z",
+     "iopub.status.idle": "2026-08-28T14:28:30.916509Z",
+     "shell.execute_reply": "2026-08-28T14:28:30.916092Z"
     },
     "papermill": {
-     "duration": 0.004115,
-     "end_time": "2026-08-28T00:29:39.756497+00:00",
+     "duration": 0.005477,
+     "end_time": "2026-08-28T14:28:30.917194+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:39.752382+00:00",
+     "start_time": "2026-08-28T14:28:30.911717+00:00",
      "status": "completed"
     },
     "tags": [
@@ -94,7 +94,6 @@
    "outputs": [],
    "source": [
     "CASE_STUDY = \"fx_pairs\"\n",
-    "PRIMARY_LABEL = \"fwd_ret_1d\"\n",
     "N_BUCKETS = 5\n",
     "# This notebook reads; it fits nothing and registers nothing, so it has no preview form - a\n",
     "# preview population is not the thing whose assembly it checks. It still takes the pair,\n",
@@ -107,13 +106,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05df3df1",
+   "id": "1a717e62",
    "metadata": {
     "papermill": {
-     "duration": 0.001118,
-     "end_time": "2026-08-28T00:29:39.758847+00:00",
+     "duration": 0.001845,
+     "end_time": "2026-08-28T14:28:30.921142+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:39.757729+00:00",
+     "start_time": "2026-08-28T14:28:30.919297+00:00",
      "status": "completed"
     }
    },
@@ -128,19 +127,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "88194d8b",
+   "id": "ea46eb19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:39.761590Z",
-     "iopub.status.busy": "2026-08-28T00:29:39.761515Z",
-     "iopub.status.idle": "2026-08-28T00:29:41.569484Z",
-     "shell.execute_reply": "2026-08-28T00:29:41.569073Z"
+     "iopub.execute_input": "2026-08-28T14:28:30.926075Z",
+     "iopub.status.busy": "2026-08-28T14:28:30.925956Z",
+     "iopub.status.idle": "2026-08-28T14:28:33.290708Z",
+     "shell.execute_reply": "2026-08-28T14:28:33.290285Z"
     },
     "papermill": {
-     "duration": 1.809953,
-     "end_time": "2026-08-28T00:29:41.569990+00:00",
+     "duration": 2.368523,
+     "end_time": "2026-08-28T14:28:33.291596+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:39.760037+00:00",
+     "start_time": "2026-08-28T14:28:30.923073+00:00",
      "status": "completed"
     }
    },
@@ -148,7 +147,8 @@
    "source": [
     "case_dir = get_case_study_dir(CASE_STUDY)\n",
     "setup = yaml.safe_load((case_dir / \"config\" / \"setup.yaml\").read_text())\n",
-    "configured_labels = [setup[\"labels\"][\"primary\"], *setup[\"labels\"].get(\"variants\", [])]\n",
+    "primary_label = setup[\"labels\"][\"primary\"]\n",
+    "configured_labels = [primary_label, *setup[\"labels\"].get(\"variants\", [])]\n",
     "study = open_study(CASE_STUDY, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)\n",
     "catalog = study.predictions.table().filter(\n",
     "    (pl.col(\"identity_status\") == \"current\")\n",
@@ -190,13 +190,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7362fb2b",
+   "id": "59364aa9",
    "metadata": {
     "papermill": {
-     "duration": 0.001567,
-     "end_time": "2026-08-28T00:29:41.573216+00:00",
+     "duration": 0.001875,
+     "end_time": "2026-08-28T14:28:33.295823+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.571649+00:00",
+     "start_time": "2026-08-28T14:28:33.293948+00:00",
      "status": "completed"
     }
    },
@@ -218,19 +218,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f1eaedf2",
+   "id": "52797ca5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:41.580810Z",
-     "iopub.status.busy": "2026-08-28T00:29:41.580704Z",
-     "iopub.status.idle": "2026-08-28T00:29:41.651594Z",
-     "shell.execute_reply": "2026-08-28T00:29:41.651189Z"
+     "iopub.execute_input": "2026-08-28T14:28:33.300485Z",
+     "iopub.status.busy": "2026-08-28T14:28:33.300378Z",
+     "iopub.status.idle": "2026-08-28T14:28:33.363169Z",
+     "shell.execute_reply": "2026-08-28T14:28:33.362700Z"
     },
     "papermill": {
-     "duration": 0.075867,
-     "end_time": "2026-08-28T00:29:41.652202+00:00",
+     "duration": 0.065898,
+     "end_time": "2026-08-28T14:28:33.363603+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.576335+00:00",
+     "start_time": "2026-08-28T14:28:33.297705+00:00",
      "status": "completed"
     },
     "tags": [
@@ -286,19 +286,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "502c7fb5",
+   "id": "0cba2e9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:41.656735Z",
-     "iopub.status.busy": "2026-08-28T00:29:41.656611Z",
-     "iopub.status.idle": "2026-08-28T00:29:41.663160Z",
-     "shell.execute_reply": "2026-08-28T00:29:41.662894Z"
+     "iopub.execute_input": "2026-08-28T14:28:33.368438Z",
+     "iopub.status.busy": "2026-08-28T14:28:33.368348Z",
+     "iopub.status.idle": "2026-08-28T14:28:33.374231Z",
+     "shell.execute_reply": "2026-08-28T14:28:33.373856Z"
     },
     "papermill": {
-     "duration": 0.010585,
-     "end_time": "2026-08-28T00:29:41.664529+00:00",
+     "duration": 0.00894,
+     "end_time": "2026-08-28T14:28:33.374722+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.653944+00:00",
+     "start_time": "2026-08-28T14:28:33.365782+00:00",
      "status": "completed"
     },
     "tags": [
@@ -360,13 +360,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f587e62",
+   "id": "e5bc1c25",
    "metadata": {
     "papermill": {
-     "duration": 0.001533,
-     "end_time": "2026-08-28T00:29:41.667771+00:00",
+     "duration": 0.00204,
+     "end_time": "2026-08-28T14:28:33.379113+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.666238+00:00",
+     "start_time": "2026-08-28T14:28:33.377073+00:00",
      "status": "completed"
     }
    },
@@ -381,19 +381,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "70e86157",
+   "id": "4db167fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:41.671994Z",
-     "iopub.status.busy": "2026-08-28T00:29:41.671890Z",
-     "iopub.status.idle": "2026-08-28T00:29:41.685433Z",
-     "shell.execute_reply": "2026-08-28T00:29:41.685024Z"
+     "iopub.execute_input": "2026-08-28T14:28:33.383021Z",
+     "iopub.status.busy": "2026-08-28T14:28:33.382874Z",
+     "iopub.status.idle": "2026-08-28T14:28:33.395474Z",
+     "shell.execute_reply": "2026-08-28T14:28:33.394844Z"
     },
     "papermill": {
-     "duration": 0.016014,
-     "end_time": "2026-08-28T00:29:41.685752+00:00",
+     "duration": 0.014818,
+     "end_time": "2026-08-28T14:28:33.395770+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.669738+00:00",
+     "start_time": "2026-08-28T14:28:33.380952+00:00",
      "status": "completed"
     },
     "tags": [
@@ -477,19 +477,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4701f263",
+   "id": "87d6c5be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:41.690226Z",
-     "iopub.status.busy": "2026-08-28T00:29:41.690120Z",
-     "iopub.status.idle": "2026-08-28T00:29:43.868697Z",
-     "shell.execute_reply": "2026-08-28T00:29:43.868455Z"
+     "iopub.execute_input": "2026-08-28T14:28:33.399514Z",
+     "iopub.status.busy": "2026-08-28T14:28:33.399354Z",
+     "iopub.status.idle": "2026-08-28T14:28:35.057702Z",
+     "shell.execute_reply": "2026-08-28T14:28:35.056761Z"
     },
     "papermill": {
-     "duration": 2.181671,
-     "end_time": "2026-08-28T00:29:43.869692+00:00",
+     "duration": 1.660903,
+     "end_time": "2026-08-28T14:28:35.058224+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:41.688021+00:00",
+     "start_time": "2026-08-28T14:28:33.397321+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3514,13 +3514,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f98cd8ed",
+   "id": "0175fff8",
    "metadata": {
     "papermill": {
-     "duration": 0.003076,
-     "end_time": "2026-08-28T00:29:43.878301+00:00",
+     "duration": 0.002492,
+     "end_time": "2026-08-28T14:28:35.063595+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:43.875225+00:00",
+     "start_time": "2026-08-28T14:28:35.061103+00:00",
      "status": "completed"
     }
    },
@@ -3534,19 +3534,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e1711159",
+   "id": "3c803f93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:43.884977Z",
-     "iopub.status.busy": "2026-08-28T00:29:43.884858Z",
-     "iopub.status.idle": "2026-08-28T00:29:44.006674Z",
-     "shell.execute_reply": "2026-08-28T00:29:44.006055Z"
+     "iopub.execute_input": "2026-08-28T14:28:35.069199Z",
+     "iopub.status.busy": "2026-08-28T14:28:35.069047Z",
+     "iopub.status.idle": "2026-08-28T14:28:35.147674Z",
+     "shell.execute_reply": "2026-08-28T14:28:35.147216Z"
     },
     "papermill": {
-     "duration": 0.125692,
-     "end_time": "2026-08-28T00:29:44.007076+00:00",
+     "duration": 0.082687,
+     "end_time": "2026-08-28T14:28:35.148603+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:43.881384+00:00",
+     "start_time": "2026-08-28T14:28:35.065916+00:00",
      "status": "completed"
     }
    },
@@ -3579,13 +3579,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b396efd0",
+   "id": "70fa7b9f",
    "metadata": {
     "papermill": {
-     "duration": 0.003382,
-     "end_time": "2026-08-28T00:29:44.017970+00:00",
+     "duration": 0.002349,
+     "end_time": "2026-08-28T14:28:35.153656+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:44.014588+00:00",
+     "start_time": "2026-08-28T14:28:35.151307+00:00",
      "status": "completed"
     }
    },
@@ -3599,19 +3599,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b4e75189",
+   "id": "78d21fbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:44.027003Z",
-     "iopub.status.busy": "2026-08-28T00:29:44.026824Z",
-     "iopub.status.idle": "2026-08-28T00:29:44.627722Z",
-     "shell.execute_reply": "2026-08-28T00:29:44.626984Z"
+     "iopub.execute_input": "2026-08-28T14:28:35.158999Z",
+     "iopub.status.busy": "2026-08-28T14:28:35.158898Z",
+     "iopub.status.idle": "2026-08-28T14:28:35.594780Z",
+     "shell.execute_reply": "2026-08-28T14:28:35.594373Z"
     },
     "papermill": {
-     "duration": 0.605374,
-     "end_time": "2026-08-28T00:29:44.628095+00:00",
+     "duration": 0.439435,
+     "end_time": "2026-08-28T14:28:35.595426+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:44.022721+00:00",
+     "start_time": "2026-08-28T14:28:35.155991+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3713,19 +3713,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e2022413",
+   "id": "55595086",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:44.646249Z",
-     "iopub.status.busy": "2026-08-28T00:29:44.645710Z",
-     "iopub.status.idle": "2026-08-28T00:29:46.365195Z",
-     "shell.execute_reply": "2026-08-28T00:29:46.364816Z"
+     "iopub.execute_input": "2026-08-28T14:28:35.605032Z",
+     "iopub.status.busy": "2026-08-28T14:28:35.604921Z",
+     "iopub.status.idle": "2026-08-28T14:28:37.114295Z",
+     "shell.execute_reply": "2026-08-28T14:28:37.113747Z"
     },
     "papermill": {
-     "duration": 1.73076,
-     "end_time": "2026-08-28T00:29:46.365730+00:00",
+     "duration": 1.514748,
+     "end_time": "2026-08-28T14:28:37.114784+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:44.634970+00:00",
+     "start_time": "2026-08-28T14:28:35.600036+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4347,40 +4347,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd7faa82",
+   "id": "e5f8df82",
    "metadata": {
     "papermill": {
-     "duration": 0.004038,
-     "end_time": "2026-08-28T00:29:46.377828+00:00",
+     "duration": 0.002916,
+     "end_time": "2026-08-28T14:28:37.121138+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:46.373790+00:00",
+     "start_time": "2026-08-28T14:28:37.118222+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## Prediction agreement and ranking shape\n",
     "\n",
-    "Correlation between model scores shows whether families rank pairs similarly. Return buckets show\n",
-    "how realized returns vary from the lowest to highest prediction ranks without turning that pattern\n",
-    "into a deployment decision."
+    "Correlation between model scores shows whether families rank pairs similarly. One correlation\n",
+    "matrix covers one label: scores fitted against different targets are not comparable ranks of the\n",
+    "same quantity, so the pivot takes the primary label the menu declares rather than all three.\n",
+    "Return buckets and conformal coverage carry no such restriction and run over every label."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "acc80fe2",
+   "id": "f7063091",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:46.387240Z",
-     "iopub.status.busy": "2026-08-28T00:29:46.386745Z",
-     "iopub.status.idle": "2026-08-28T00:29:46.421172Z",
-     "shell.execute_reply": "2026-08-28T00:29:46.420934Z"
+     "iopub.execute_input": "2026-08-28T14:28:37.128034Z",
+     "iopub.status.busy": "2026-08-28T14:28:37.127890Z",
+     "iopub.status.idle": "2026-08-28T14:28:37.157051Z",
+     "shell.execute_reply": "2026-08-28T14:28:37.156646Z"
     },
     "papermill": {
-     "duration": 0.039835,
-     "end_time": "2026-08-28T00:29:46.421843+00:00",
+     "duration": 0.033474,
+     "end_time": "2026-08-28T14:28:37.157670+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:46.382008+00:00",
+     "start_time": "2026-08-28T14:28:37.124196+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4388,6 +4389,13 @@
     ]
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score agreement is computed on fwd_ret_1d, the primary label in the menu\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -4420,7 +4428,8 @@
     }
    ],
    "source": [
-    "primary = representative_predictions.filter(pl.col(\"label\") == PRIMARY_LABEL)\n",
+    "primary = representative_predictions.filter(pl.col(\"label\") == primary_label)\n",
+    "print(f\"Score agreement is computed on {primary_label}, the primary label in the menu\")\n",
     "# The pivot index is the canonical eligibility key alone. `actual` is the same realized return for\n",
     "# every model at a given key, but the families do not agree on its float representation, so including\n",
     "# it split the rows into disjoint groups - each score column populated on a different half - and every\n",
@@ -4444,19 +4453,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "47a064ff",
+   "id": "79ea5be6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:46.434474Z",
-     "iopub.status.busy": "2026-08-28T00:29:46.433907Z",
-     "iopub.status.idle": "2026-08-28T00:29:52.959908Z",
-     "shell.execute_reply": "2026-08-28T00:29:52.959295Z"
+     "iopub.execute_input": "2026-08-28T14:28:37.165671Z",
+     "iopub.status.busy": "2026-08-28T14:28:37.165565Z",
+     "iopub.status.idle": "2026-08-28T14:29:00.261014Z",
+     "shell.execute_reply": "2026-08-28T14:29:00.260348Z"
     },
     "papermill": {
-     "duration": 6.535073,
-     "end_time": "2026-08-28T00:29:52.961457+00:00",
+     "duration": 23.099436,
+     "end_time": "2026-08-28T14:29:00.261357+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:46.426384+00:00",
+     "start_time": "2026-08-28T14:28:37.161921+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4474,27 +4483,28 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (20, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0</td><td>-0.000088</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>1</td><td>-0.000055</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>2</td><td>0.000091</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>3</td><td>0.0001</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>4</td><td>0.00008</td></tr></tbody></table></div>"
+       "<small>shape: (60, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0</td><td>0.000269</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>1</td><td>0.000056</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>2</td><td>-0.000004</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>3</td><td>0.000141</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>4</td><td>0.000237</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (20, 6)\n",
-       "┌───────────────┬─────────────┬──────────────────┬─────────────────┬────────┬──────────────────────┐\n",
-       "│ family        ┆ config_name ┆ checkpoint_value ┆ prediction_hash ┆ bucket ┆ mean_realized_return │\n",
-       "│ ---           ┆ ---         ┆ ---              ┆ ---             ┆ ---    ┆ ---                  │\n",
-       "│ str           ┆ str         ┆ i64              ┆ str             ┆ i64    ┆ f64                  │\n",
-       "╞═══════════════╪═════════════╪══════════════════╪═════════════════╪════════╪══════════════════════╡\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 0      ┆ -0.000018            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 1      ┆ -0.000084            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 2      ┆ -0.000042            │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 3      ┆ 0.000038             │\n",
-       "│ deep_learning ┆ tcn         ┆ 5                ┆ d80638423af7    ┆ 4      ┆ 0.000233             │\n",
-       "│ …             ┆ …           ┆ …                ┆ …               ┆ …      ┆ …                    │\n",
-       "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 0      ┆ -0.000088            │\n",
-       "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 1      ┆ -0.000055            │\n",
-       "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 2      ┆ 0.000091             │\n",
-       "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 3      ┆ 0.0001               │\n",
-       "│ tabular_dl    ┆ tabm_l      ┆ 50               ┆ 01e41111cb52    ┆ 4      ┆ 0.00008              │\n",
-       "└───────────────┴─────────────┴──────────────────┴─────────────────┴────────┴──────────────────────┘"
+       "shape: (60, 7)\n",
+       "┌────────────┬───────────────┬─────────────┬───────────────┬───────────────┬────────┬──────────────┐\n",
+       "│ label      ┆ family        ┆ config_name ┆ checkpoint_va ┆ prediction_ha ┆ bucket ┆ mean_realize │\n",
+       "│ ---        ┆ ---           ┆ ---         ┆ lue           ┆ sh            ┆ ---    ┆ d_return     │\n",
+       "│ str        ┆ str           ┆ str         ┆ ---           ┆ ---           ┆ i64    ┆ ---          │\n",
+       "│            ┆               ┆             ┆ i64           ┆ str           ┆        ┆ f64          │\n",
+       "╞════════════╪═══════════════╪═════════════╪═══════════════╪═══════════════╪════════╪══════════════╡\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 0      ┆ -0.000018    │\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 1      ┆ -0.000084    │\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 2      ┆ -0.000042    │\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 3      ┆ 0.000038     │\n",
+       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 4      ┆ 0.000233     │\n",
+       "│ …          ┆ …             ┆ …           ┆ …             ┆ …             ┆ …      ┆ …            │\n",
+       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 0      ┆ 0.000269     │\n",
+       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 1      ┆ 0.000056     │\n",
+       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 2      ┆ -0.000004    │\n",
+       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 3      ┆ 0.000141     │\n",
+       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 4      ┆ 0.000237     │\n",
+       "└────────────┴───────────────┴─────────────┴───────────────┴───────────────┴────────┴──────────────┘"
       ]
      },
      "execution_count": 12,
@@ -4504,8 +4514,8 @@
    ],
    "source": [
     "bucket_rows = []\n",
-    "for keys, frame in primary.group_by(\n",
-    "    \"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\", \"timestamp\"\n",
+    "for keys, frame in representative_predictions.group_by(\n",
+    "    \"label\", \"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\", \"timestamp\"\n",
     "):\n",
     "    if frame.height < N_BUCKETS:\n",
     "        continue\n",
@@ -4517,33 +4527,34 @@
     "    for bucket, values in ranked.group_by(\"bucket\"):\n",
     "        bucket_rows.append(\n",
     "            {\n",
-    "                \"family\": keys[0],\n",
-    "                \"config_name\": keys[1],\n",
-    "                \"checkpoint_value\": keys[2],\n",
-    "                \"prediction_hash\": keys[3],\n",
-    "                \"timestamp\": keys[4],\n",
+    "                \"label\": keys[0],\n",
+    "                \"family\": keys[1],\n",
+    "                \"config_name\": keys[2],\n",
+    "                \"checkpoint_value\": keys[3],\n",
+    "                \"prediction_hash\": keys[4],\n",
+    "                \"timestamp\": keys[5],\n",
     "                \"bucket\": bucket[0],\n",
     "                \"actual\": values.get_column(\"actual\").mean(),\n",
     "            }\n",
     "        )\n",
     "bucket_summary = (\n",
     "    pl.DataFrame(bucket_rows)\n",
-    "    .group_by(\"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\", \"bucket\")\n",
+    "    .group_by(\"label\", \"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\", \"bucket\")\n",
     "    .agg(pl.col(\"actual\").mean().alias(\"mean_realized_return\"))\n",
-    "    .sort(\"family\", \"bucket\")\n",
+    "    .sort(\"label\", \"family\", \"bucket\")\n",
     ")\n",
     "bucket_summary"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f58e9461",
+   "id": "9f7e0078",
    "metadata": {
     "papermill": {
-     "duration": 0.006011,
-     "end_time": "2026-08-28T00:29:52.973399+00:00",
+     "duration": 0.003528,
+     "end_time": "2026-08-28T14:29:00.268716+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:52.967388+00:00",
+     "start_time": "2026-08-28T14:29:00.265188+00:00",
      "status": "completed"
     }
    },
@@ -4558,19 +4569,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "479c701d",
+   "id": "d65253db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:52.987046Z",
-     "iopub.status.busy": "2026-08-28T00:29:52.986878Z",
-     "iopub.status.idle": "2026-08-28T00:29:53.026457Z",
-     "shell.execute_reply": "2026-08-28T00:29:53.025288Z"
+     "iopub.execute_input": "2026-08-28T14:29:00.278158Z",
+     "iopub.status.busy": "2026-08-28T14:29:00.277764Z",
+     "iopub.status.idle": "2026-08-28T14:29:00.366811Z",
+     "shell.execute_reply": "2026-08-28T14:29:00.366097Z"
     },
     "papermill": {
-     "duration": 0.046282,
-     "end_time": "2026-08-28T00:29:53.026872+00:00",
+     "duration": 0.094944,
+     "end_time": "2026-08-28T14:29:00.367389+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:52.980590+00:00",
+     "start_time": "2026-08-28T14:29:00.272445+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4588,40 +4599,37 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (12, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.9</td><td>0.963324</td><td>3.240988</td><td>36100</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.95</td><td>0.937812</td><td>24.977348</td><td>36100</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.95</td><td>0.983989</td><td>3.902682</td><td>36100</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.95</td><td>0.984571</td><td>3.874998</td><td>36100</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.95</td><td>0.985845</td><td>4.234442</td><td>36100</td></tr></tbody></table></div>"
+       "<small>shape: (36, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.9</td><td>0.956163</td><td>3.163107</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0.95</td><td>0.91216</td><td>33.638073</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0.95</td><td>0.98598</td><td>3.872072</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0.95</td><td>0.986285</td><td>3.902174</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.95</td><td>0.978123</td><td>3.905645</td><td>36020</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (12, 8)\n",
-       "┌────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬───────────┬────────┐\n",
-       "│ family     ┆ config_nam ┆ checkpoint ┆ prediction ┆ nominal_le ┆ empirical_ ┆ mean_inte ┆ n_test │\n",
-       "│ ---        ┆ e          ┆ _value     ┆ _hash      ┆ vel        ┆ coverage   ┆ rval_widt ┆ ---    │\n",
-       "│ str        ┆ ---        ┆ ---        ┆ ---        ┆ ---        ┆ ---        ┆ h_frac_st ┆ i64    │\n",
-       "│            ┆ str        ┆ i64        ┆ str        ┆ f64        ┆ f64        ┆ d         ┆        │\n",
-       "│            ┆            ┆            ┆            ┆            ┆            ┆ ---       ┆        │\n",
-       "│            ┆            ┆            ┆            ┆            ┆            ┆ f64       ┆        │\n",
-       "╞════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═══════════╪════════╡\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.8        ┆ 0.792188   ┆ 14.833431 ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
-       "│ gbm        ┆ leaves_63_ ┆ 100        ┆ 0cff45d5da ┆ 0.8        ┆ 0.898781   ┆ 2.187913  ┆ 36100  │\n",
-       "│            ┆ mae        ┆            ┆ f6         ┆            ┆            ┆           ┆        │\n",
-       "│ linear     ┆ lasso_f0.2 ┆ null       ┆ eeff296102 ┆ 0.8        ┆ 0.897922   ┆ 2.158434  ┆ 36100  │\n",
-       "│            ┆            ┆            ┆ 6c         ┆            ┆            ┆           ┆        │\n",
-       "│ tabular_dl ┆ tabm_l     ┆ 50         ┆ 01e41111cb ┆ 0.8        ┆ 0.907285   ┆ 2.363629  ┆ 36100  │\n",
-       "│            ┆            ┆            ┆ 52         ┆            ┆            ┆           ┆        │\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.9        ┆ 0.882465   ┆ 19.70981  ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
-       "│ …          ┆ …          ┆ …          ┆ …          ┆ …          ┆ …          ┆ …         ┆ …      │\n",
-       "│ tabular_dl ┆ tabm_l     ┆ 50         ┆ 01e41111cb ┆ 0.9        ┆ 0.963324   ┆ 3.240988  ┆ 36100  │\n",
-       "│            ┆            ┆            ┆ 52         ┆            ┆            ┆           ┆        │\n",
-       "│ deep_learn ┆ tcn        ┆ 5          ┆ d80638423a ┆ 0.95       ┆ 0.937812   ┆ 24.977348 ┆ 36100  │\n",
-       "│ ing        ┆            ┆            ┆ f7         ┆            ┆            ┆           ┆        │\n",
-       "│ gbm        ┆ leaves_63_ ┆ 100        ┆ 0cff45d5da ┆ 0.95       ┆ 0.983989   ┆ 3.902682  ┆ 36100  │\n",
-       "│            ┆ mae        ┆            ┆ f6         ┆            ┆            ┆           ┆        │\n",
-       "│ linear     ┆ lasso_f0.2 ┆ null       ┆ eeff296102 ┆ 0.95       ┆ 0.984571   ┆ 3.874998  ┆ 36100  │\n",
-       "│            ┆            ┆            ┆ 6c         ┆            ┆            ┆           ┆        │\n",
-       "│ tabular_dl ┆ tabm_l     ┆ 50         ┆ 01e41111cb ┆ 0.95       ┆ 0.985845   ┆ 4.234442  ┆ 36100  │\n",
-       "│            ┆            ┆            ┆ 52         ┆            ┆            ┆           ┆        │\n",
-       "└────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴───────────┴────────┘"
+       "shape: (36, 9)\n",
+       "┌────────────┬────────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬────────┐\n",
+       "│ label      ┆ family     ┆ config_na ┆ checkpoin ┆ … ┆ nominal_l ┆ empirical ┆ mean_inte ┆ n_test │\n",
+       "│ ---        ┆ ---        ┆ me        ┆ t_value   ┆   ┆ evel      ┆ _coverage ┆ rval_widt ┆ ---    │\n",
+       "│ str        ┆ str        ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ h_frac_st ┆ i64    │\n",
+       "│            ┆            ┆ str       ┆ i64       ┆   ┆ f64       ┆ f64       ┆ d         ┆        │\n",
+       "│            ┆            ┆           ┆           ┆   ┆           ┆           ┆ ---       ┆        │\n",
+       "│            ┆            ┆           ┆           ┆   ┆           ┆           ┆ f64       ┆        │\n",
+       "╞════════════╪════════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪════════╡\n",
+       "│ fwd_ret_1d ┆ deep_learn ┆ tcn       ┆ 5         ┆ … ┆ 0.8       ┆ 0.792188  ┆ 14.833431 ┆ 36100  │\n",
+       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_1d ┆ gbm        ┆ leaves_63 ┆ 100       ┆ … ┆ 0.8       ┆ 0.898781  ┆ 2.187913  ┆ 36100  │\n",
+       "│            ┆            ┆ _mae      ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_1d ┆ linear     ┆ lasso_f0. ┆ null      ┆ … ┆ 0.8       ┆ 0.897922  ┆ 2.158434  ┆ 36100  │\n",
+       "│            ┆            ┆ 2         ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_1d ┆ tabular_dl ┆ tabm_l    ┆ 50        ┆ … ┆ 0.8       ┆ 0.907285  ┆ 2.363629  ┆ 36100  │\n",
+       "│ fwd_ret_1d ┆ deep_learn ┆ tcn       ┆ 5         ┆ … ┆ 0.9       ┆ 0.882465  ┆ 19.70981  ┆ 36100  │\n",
+       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ …          ┆ …          ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …      │\n",
+       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m    ┆ 25        ┆ … ┆ 0.9       ┆ 0.956163  ┆ 3.163107  ┆ 36020  │\n",
+       "│ fwd_ret_5d ┆ deep_learn ┆ nlinear   ┆ 5         ┆ … ┆ 0.95      ┆ 0.91216   ┆ 33.638073 ┆ 36020  │\n",
+       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_5d ┆ gbm        ┆ leaves_7_ ┆ 50        ┆ … ┆ 0.95      ┆ 0.98598   ┆ 3.872072  ┆ 36020  │\n",
+       "│            ┆            ┆ huber     ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_5d ┆ linear     ┆ enet_f0.8 ┆ null      ┆ … ┆ 0.95      ┆ 0.986285  ┆ 3.902174  ┆ 36020  │\n",
+       "│            ┆            ┆ 5         ┆           ┆   ┆           ┆           ┆           ┆        │\n",
+       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m    ┆ 25        ┆ … ┆ 0.95      ┆ 0.978123  ┆ 3.905645  ┆ 36020  │\n",
+       "└────────────┴────────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴────────┘"
       ]
      },
      "execution_count": 13,
@@ -4631,57 +4639,61 @@
    ],
    "source": [
     "conformal_rows = []\n",
-    "for keys, frame in primary.group_by(\"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\"):\n",
+    "for keys, frame in representative_predictions.group_by(\n",
+    "    \"label\", \"family\", \"config_name\", \"checkpoint_value\", \"prediction_hash\"\n",
+    "):\n",
     "    for row in split_conformal_coverage(frame):\n",
     "        conformal_rows.append(\n",
     "            {\n",
-    "                \"family\": keys[0],\n",
-    "                \"config_name\": keys[1],\n",
-    "                \"checkpoint_value\": keys[2],\n",
-    "                \"prediction_hash\": keys[3],\n",
+    "                \"label\": keys[0],\n",
+    "                \"family\": keys[1],\n",
+    "                \"config_name\": keys[2],\n",
+    "                \"checkpoint_value\": keys[3],\n",
+    "                \"prediction_hash\": keys[4],\n",
     "                **row,\n",
     "            }\n",
     "        )\n",
-    "conformal = pl.DataFrame(conformal_rows).sort(\"nominal_level\", \"family\")\n",
+    "conformal = pl.DataFrame(conformal_rows).sort(\"label\", \"nominal_level\", \"family\")\n",
     "conformal"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6ec5f1e5",
+   "id": "663acea9",
    "metadata": {
     "papermill": {
-     "duration": 0.004608,
-     "end_time": "2026-08-28T00:29:53.036208+00:00",
+     "duration": 0.004579,
+     "end_time": "2026-08-28T14:29:00.377566+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:53.031600+00:00",
+     "start_time": "2026-08-28T14:29:00.372987+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## Causal evidence remains separate\n",
     "\n",
-    "The causal result answers whether the configured momentum treatment has an estimated effect after\n",
+    "A causal result answers whether the configured momentum treatment has an estimated effect after\n",
     "adjustment for its declared confounders. It does not count as predictive-family coverage and does\n",
-    "not enter the model or backtest population."
+    "not enter the model or backtest population. `11_causal_dml` registers one estimate per label the\n",
+    "menu declares, so naming a single label here would leave the rest of them unreported."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "db045f77",
+   "id": "a19f97f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:53.046965Z",
-     "iopub.status.busy": "2026-08-28T00:29:53.046494Z",
-     "iopub.status.idle": "2026-08-28T00:29:53.053581Z",
-     "shell.execute_reply": "2026-08-28T00:29:53.053306Z"
+     "iopub.execute_input": "2026-08-28T14:29:00.388488Z",
+     "iopub.status.busy": "2026-08-28T14:29:00.388297Z",
+     "iopub.status.idle": "2026-08-28T14:29:00.396272Z",
+     "shell.execute_reply": "2026-08-28T14:29:00.395788Z"
     },
     "papermill": {
-     "duration": 0.01282,
-     "end_time": "2026-08-28T00:29:53.054161+00:00",
+     "duration": 0.014091,
+     "end_time": "2026-08-28T14:29:00.396616+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:53.041341+00:00",
+     "start_time": "2026-08-28T14:29:00.382525+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4699,19 +4711,24 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>causal_hash</th><th>n_obs</th><th>dml_effect</th><th>dml_se_hac</th><th>p_value_hac</th><th>naive_effect</th><th>confounding_bias_pct</th><th>refutation_p</th></tr><tr><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;25f8bdd775de&quot;</td><td>49600</td><td>-0.000057</td><td>0.000721</td><td>0.936836</td><td>-0.000203</td><td>-254.954828</td><td>0.920792</td></tr></tbody></table></div>"
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>causal_hash</th><th>n_obs</th><th>dml_effect</th><th>dml_se_hac</th><th>p_value_hac</th><th>naive_effect</th><th>confounding_bias_pct</th><th>refutation_p</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;25f8bdd775de&quot;</td><td>49600</td><td>-0.000057</td><td>0.000721</td><td>0.936836</td><td>-0.000203</td><td>-254.954828</td><td>0.920792</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;3547657669ca&quot;</td><td>48880</td><td>0.004423</td><td>0.011013</td><td>0.687978</td><td>-0.001638</td><td>-137.028185</td><td>0.653465</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;c797f741134a&quot;</td><td>49460</td><td>0.000971</td><td>0.003339</td><td>0.771146</td><td>-0.000236</td><td>-124.295326</td><td>0.683168</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (1, 8)\n",
-       "┌────────────┬───────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┐\n",
-       "│ causal_has ┆ n_obs ┆ dml_effect ┆ dml_se_hac ┆ p_value_ha ┆ naive_effe ┆ confoundin ┆ refutation │\n",
-       "│ h          ┆ ---   ┆ ---        ┆ ---        ┆ c          ┆ ct         ┆ g_bias_pct ┆ _p         │\n",
-       "│ ---        ┆ i64   ┆ f64        ┆ f64        ┆ ---        ┆ ---        ┆ ---        ┆ ---        │\n",
-       "│ str        ┆       ┆            ┆            ┆ f64        ┆ f64        ┆ f64        ┆ f64        │\n",
-       "╞════════════╪═══════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╡\n",
-       "│ 25f8bdd775 ┆ 49600 ┆ -0.000057  ┆ 0.000721   ┆ 0.936836   ┆ -0.000203  ┆ -254.95482 ┆ 0.920792   │\n",
-       "│ de         ┆       ┆            ┆            ┆            ┆            ┆ 8          ┆            │\n",
-       "└────────────┴───────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┘"
+       "shape: (3, 9)\n",
+       "┌────────────┬────────────┬───────┬────────────┬───┬───────────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ causal_has ┆ n_obs ┆ dml_effect ┆ … ┆ p_value_h ┆ naive_eff ┆ confoundi ┆ refutatio │\n",
+       "│ ---        ┆ h          ┆ ---   ┆ ---        ┆   ┆ ac        ┆ ect       ┆ ng_bias_p ┆ n_p       │\n",
+       "│ str        ┆ ---        ┆ i64   ┆ f64        ┆   ┆ ---       ┆ ---       ┆ ct        ┆ ---       │\n",
+       "│            ┆ str        ┆       ┆            ┆   ┆ f64       ┆ f64       ┆ ---       ┆ f64       │\n",
+       "│            ┆            ┆       ┆            ┆   ┆           ┆           ┆ f64       ┆           │\n",
+       "╞════════════╪════════════╪═══════╪════════════╪═══╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_1d ┆ 25f8bdd775 ┆ 49600 ┆ -0.000057  ┆ … ┆ 0.936836  ┆ -0.000203 ┆ -254.9548 ┆ 0.920792  │\n",
+       "│            ┆ de         ┆       ┆            ┆   ┆           ┆           ┆ 28        ┆           │\n",
+       "│ fwd_ret_21 ┆ 3547657669 ┆ 48880 ┆ 0.004423   ┆ … ┆ 0.687978  ┆ -0.001638 ┆ -137.0281 ┆ 0.653465  │\n",
+       "│ d          ┆ ca         ┆       ┆            ┆   ┆           ┆           ┆ 85        ┆           │\n",
+       "│ fwd_ret_5d ┆ c797f74113 ┆ 49460 ┆ 0.000971   ┆ … ┆ 0.771146  ┆ -0.000236 ┆ -124.2953 ┆ 0.683168  │\n",
+       "│            ┆ 4a         ┆       ┆            ┆   ┆           ┆           ┆ 26        ┆           │\n",
+       "└────────────┴────────────┴───────┴────────────┴───┴───────────┴───────────┴───────────┴───────────┘"
       ]
      },
      "execution_count": 14,
@@ -4720,29 +4737,37 @@
     }
    ],
    "source": [
-    "causal = CausalResult.one(study, label=PRIMARY_LABEL)\n",
-    "causal_summary = pl.DataFrame([{\"causal_hash\": causal.hash, **causal.metrics}]).select(\n",
-    "    \"causal_hash\",\n",
-    "    \"n_obs\",\n",
-    "    \"dml_effect\",\n",
-    "    \"dml_se_hac\",\n",
-    "    \"p_value_hac\",\n",
-    "    \"naive_effect\",\n",
-    "    \"confounding_bias_pct\",\n",
-    "    \"refutation_p\",\n",
+    "causal_rows = []\n",
+    "for label in configured_labels:\n",
+    "    causal = CausalResult.one(study, label=label)\n",
+    "    causal_rows.append({\"label\": label, \"causal_hash\": causal.hash, **causal.metrics})\n",
+    "causal_summary = (\n",
+    "    pl.DataFrame(causal_rows)\n",
+    "    .select(\n",
+    "        \"label\",\n",
+    "        \"causal_hash\",\n",
+    "        \"n_obs\",\n",
+    "        \"dml_effect\",\n",
+    "        \"dml_se_hac\",\n",
+    "        \"p_value_hac\",\n",
+    "        \"naive_effect\",\n",
+    "        \"confounding_bias_pct\",\n",
+    "        \"refutation_p\",\n",
+    "    )\n",
+    "    .sort(\"label\")\n",
     ")\n",
     "causal_summary"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "87bd459d",
+   "id": "d5c2a8da",
    "metadata": {
     "papermill": {
-     "duration": 0.004053,
-     "end_time": "2026-08-28T00:29:53.063437+00:00",
+     "duration": 0.004863,
+     "end_time": "2026-08-28T14:29:00.406800+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:53.059384+00:00",
+     "start_time": "2026-08-28T14:29:00.401937+00:00",
      "status": "completed"
     }
    },
@@ -4757,19 +4782,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "6d0b4c1f",
+   "id": "acbdfb64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:29:53.079379Z",
-     "iopub.status.busy": "2026-08-28T00:29:53.078854Z",
-     "iopub.status.idle": "2026-08-28T00:29:53.093328Z",
-     "shell.execute_reply": "2026-08-28T00:29:53.093074Z"
+     "iopub.execute_input": "2026-08-28T14:29:00.417810Z",
+     "iopub.status.busy": "2026-08-28T14:29:00.417656Z",
+     "iopub.status.idle": "2026-08-28T14:29:00.427768Z",
+     "shell.execute_reply": "2026-08-28T14:29:00.426892Z"
     },
     "papermill": {
-     "duration": 0.024032,
-     "end_time": "2026-08-28T00:29:53.094024+00:00",
+     "duration": 0.016644,
+     "end_time": "2026-08-28T14:29:00.428358+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:53.069992+00:00",
+     "start_time": "2026-08-28T14:29:00.411714+00:00",
      "status": "completed"
     }
    },
@@ -4832,13 +4857,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6918c4bd",
+   "id": "97ca0f04",
    "metadata": {
     "papermill": {
-     "duration": 0.006939,
-     "end_time": "2026-08-28T00:29:53.107291+00:00",
+     "duration": 0.005362,
+     "end_time": "2026-08-28T14:29:00.439330+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:29:53.100352+00:00",
+     "start_time": "2026-08-28T14:29:00.433968+00:00",
      "status": "completed"
     }
    },
@@ -4875,19 +4900,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 20.589352,
-   "end_time": "2026-08-28T00:29:54.529402+00:00",
+   "duration": 36.062256,
+   "end_time": "2026-08-28T14:29:01.962964+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/12_model_analysis.ipynb",
-   "output_path": "~/scratch/prod_12_model_analysis_344447.ipynb",
+   "output_path": "~/scratch/prod_12_model_analysis_2674873.ipynb",
    "parameters": {},
-   "start_time": "2026-08-28T00:29:33.940050+00:00",
+   "start_time": "2026-08-28T14:28:25.900708+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "1aaff652111765c9dbceb88c2675bdb56d1e15dd",
-   "executed_at": "2026-08-28T00:30:02.148776+00:00",
+   "source_py_blob": "bb33e7e24426326c1229f06395c754684f4f7f87",
+   "executed_at": "2026-08-28T14:29:08.814750+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/12_model_analysis.ipynb
+++ b/case_studies/fx_pairs/12_model_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a45c4c1d",
+   "id": "fe7f574a",
    "metadata": {
     "papermill": {
-     "duration": 0.001934,
-     "end_time": "2026-08-28T14:28:26.706463+00:00",
+     "duration": 0.002085,
+     "end_time": "2026-08-28T14:39:22.731584+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:26.704529+00:00",
+     "start_time": "2026-08-28T14:39:22.729499+00:00",
      "status": "completed"
     }
    },
@@ -36,19 +36,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b7ddd5ed",
+   "id": "749ad251",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:26.711414Z",
-     "iopub.status.busy": "2026-08-28T14:28:26.711245Z",
-     "iopub.status.idle": "2026-08-28T14:28:30.908643Z",
-     "shell.execute_reply": "2026-08-28T14:28:30.908234Z"
+     "iopub.execute_input": "2026-08-28T14:39:22.736486Z",
+     "iopub.status.busy": "2026-08-28T14:39:22.736363Z",
+     "iopub.status.idle": "2026-08-28T14:39:27.913774Z",
+     "shell.execute_reply": "2026-08-28T14:39:27.913142Z"
     },
     "papermill": {
-     "duration": 4.200354,
-     "end_time": "2026-08-28T14:28:30.909422+00:00",
+     "duration": 5.181487,
+     "end_time": "2026-08-28T14:39:27.914840+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:26.709068+00:00",
+     "start_time": "2026-08-28T14:39:22.733353+00:00",
      "status": "completed"
     }
    },
@@ -59,6 +59,7 @@
     "import plotly.express as px\n",
     "import polars as pl\n",
     "import yaml\n",
+    "from IPython.display import display\n",
     "from ml4t.diagnostic.metrics import cross_sectional_ic\n",
     "\n",
     "import utils.style  # noqa: F401\n",
@@ -72,19 +73,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ab8da152",
+   "id": "6724d429",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:30.914465Z",
-     "iopub.status.busy": "2026-08-28T14:28:30.914199Z",
-     "iopub.status.idle": "2026-08-28T14:28:30.916509Z",
-     "shell.execute_reply": "2026-08-28T14:28:30.916092Z"
+     "iopub.execute_input": "2026-08-28T14:39:27.918970Z",
+     "iopub.status.busy": "2026-08-28T14:39:27.918602Z",
+     "iopub.status.idle": "2026-08-28T14:39:27.921676Z",
+     "shell.execute_reply": "2026-08-28T14:39:27.921182Z"
     },
     "papermill": {
-     "duration": 0.005477,
-     "end_time": "2026-08-28T14:28:30.917194+00:00",
+     "duration": 0.005478,
+     "end_time": "2026-08-28T14:39:27.922010+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:30.911717+00:00",
+     "start_time": "2026-08-28T14:39:27.916532+00:00",
      "status": "completed"
     },
     "tags": [
@@ -106,13 +107,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a717e62",
+   "id": "a4627528",
    "metadata": {
     "papermill": {
-     "duration": 0.001845,
-     "end_time": "2026-08-28T14:28:30.921142+00:00",
+     "duration": 0.001963,
+     "end_time": "2026-08-28T14:39:27.928692+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:30.919297+00:00",
+     "start_time": "2026-08-28T14:39:27.926729+00:00",
      "status": "completed"
     }
    },
@@ -127,19 +128,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ea46eb19",
+   "id": "38f1fc73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:30.926075Z",
-     "iopub.status.busy": "2026-08-28T14:28:30.925956Z",
-     "iopub.status.idle": "2026-08-28T14:28:33.290708Z",
-     "shell.execute_reply": "2026-08-28T14:28:33.290285Z"
+     "iopub.execute_input": "2026-08-28T14:39:27.933316Z",
+     "iopub.status.busy": "2026-08-28T14:39:27.933133Z",
+     "iopub.status.idle": "2026-08-28T14:39:31.011875Z",
+     "shell.execute_reply": "2026-08-28T14:39:31.011189Z"
     },
     "papermill": {
-     "duration": 2.368523,
-     "end_time": "2026-08-28T14:28:33.291596+00:00",
+     "duration": 3.084604,
+     "end_time": "2026-08-28T14:39:31.014850+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:30.923073+00:00",
+     "start_time": "2026-08-28T14:39:27.930246+00:00",
      "status": "completed"
     }
    },
@@ -190,13 +191,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59364aa9",
+   "id": "9c543ef7",
    "metadata": {
     "papermill": {
-     "duration": 0.001875,
-     "end_time": "2026-08-28T14:28:33.295823+00:00",
+     "duration": 0.001453,
+     "end_time": "2026-08-28T14:39:31.021866+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.293948+00:00",
+     "start_time": "2026-08-28T14:39:31.020413+00:00",
      "status": "completed"
     }
    },
@@ -218,19 +219,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "52797ca5",
+   "id": "9ceee68d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:33.300485Z",
-     "iopub.status.busy": "2026-08-28T14:28:33.300378Z",
-     "iopub.status.idle": "2026-08-28T14:28:33.363169Z",
-     "shell.execute_reply": "2026-08-28T14:28:33.362700Z"
+     "iopub.execute_input": "2026-08-28T14:39:31.029245Z",
+     "iopub.status.busy": "2026-08-28T14:39:31.029070Z",
+     "iopub.status.idle": "2026-08-28T14:39:31.159037Z",
+     "shell.execute_reply": "2026-08-28T14:39:31.158585Z"
     },
     "papermill": {
-     "duration": 0.065898,
-     "end_time": "2026-08-28T14:28:33.363603+00:00",
+     "duration": 0.133276,
+     "end_time": "2026-08-28T14:39:31.160075+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.297705+00:00",
+     "start_time": "2026-08-28T14:39:31.026799+00:00",
      "status": "completed"
     },
     "tags": [
@@ -286,19 +287,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0cba2e9a",
+   "id": "1321a546",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:33.368438Z",
-     "iopub.status.busy": "2026-08-28T14:28:33.368348Z",
-     "iopub.status.idle": "2026-08-28T14:28:33.374231Z",
-     "shell.execute_reply": "2026-08-28T14:28:33.373856Z"
+     "iopub.execute_input": "2026-08-28T14:39:31.166005Z",
+     "iopub.status.busy": "2026-08-28T14:39:31.165832Z",
+     "iopub.status.idle": "2026-08-28T14:39:31.174759Z",
+     "shell.execute_reply": "2026-08-28T14:39:31.174422Z"
     },
     "papermill": {
-     "duration": 0.00894,
-     "end_time": "2026-08-28T14:28:33.374722+00:00",
+     "duration": 0.013342,
+     "end_time": "2026-08-28T14:39:31.175918+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.365782+00:00",
+     "start_time": "2026-08-28T14:39:31.162576+00:00",
      "status": "completed"
     },
     "tags": [
@@ -360,13 +361,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5bc1c25",
+   "id": "9ecfc68a",
    "metadata": {
     "papermill": {
-     "duration": 0.00204,
-     "end_time": "2026-08-28T14:28:33.379113+00:00",
+     "duration": 0.004358,
+     "end_time": "2026-08-28T14:39:31.183580+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.377073+00:00",
+     "start_time": "2026-08-28T14:39:31.179222+00:00",
      "status": "completed"
     }
    },
@@ -381,19 +382,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4db167fa",
+   "id": "3dfd6de7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:33.383021Z",
-     "iopub.status.busy": "2026-08-28T14:28:33.382874Z",
-     "iopub.status.idle": "2026-08-28T14:28:33.395474Z",
-     "shell.execute_reply": "2026-08-28T14:28:33.394844Z"
+     "iopub.execute_input": "2026-08-28T14:39:31.189897Z",
+     "iopub.status.busy": "2026-08-28T14:39:31.189775Z",
+     "iopub.status.idle": "2026-08-28T14:39:31.206853Z",
+     "shell.execute_reply": "2026-08-28T14:39:31.206519Z"
     },
     "papermill": {
-     "duration": 0.014818,
-     "end_time": "2026-08-28T14:28:33.395770+00:00",
+     "duration": 0.021257,
+     "end_time": "2026-08-28T14:39:31.207806+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.380952+00:00",
+     "start_time": "2026-08-28T14:39:31.186549+00:00",
      "status": "completed"
     },
     "tags": [
@@ -477,19 +478,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "87d6c5be",
+   "id": "5a1fdf67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:33.399514Z",
-     "iopub.status.busy": "2026-08-28T14:28:33.399354Z",
-     "iopub.status.idle": "2026-08-28T14:28:35.057702Z",
-     "shell.execute_reply": "2026-08-28T14:28:35.056761Z"
+     "iopub.execute_input": "2026-08-28T14:39:31.213944Z",
+     "iopub.status.busy": "2026-08-28T14:39:31.213825Z",
+     "iopub.status.idle": "2026-08-28T14:39:33.587269Z",
+     "shell.execute_reply": "2026-08-28T14:39:33.586783Z"
     },
     "papermill": {
-     "duration": 1.660903,
-     "end_time": "2026-08-28T14:28:35.058224+00:00",
+     "duration": 2.378215,
+     "end_time": "2026-08-28T14:39:33.587801+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:33.397321+00:00",
+     "start_time": "2026-08-28T14:39:31.209586+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3514,13 +3515,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0175fff8",
+   "id": "3d65c4a0",
    "metadata": {
     "papermill": {
-     "duration": 0.002492,
-     "end_time": "2026-08-28T14:28:35.063595+00:00",
+     "duration": 0.002744,
+     "end_time": "2026-08-28T14:39:33.596184+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:35.061103+00:00",
+     "start_time": "2026-08-28T14:39:33.593440+00:00",
      "status": "completed"
     }
    },
@@ -3534,19 +3535,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3c803f93",
+   "id": "9a338e84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:35.069199Z",
-     "iopub.status.busy": "2026-08-28T14:28:35.069047Z",
-     "iopub.status.idle": "2026-08-28T14:28:35.147674Z",
-     "shell.execute_reply": "2026-08-28T14:28:35.147216Z"
+     "iopub.execute_input": "2026-08-28T14:39:33.605867Z",
+     "iopub.status.busy": "2026-08-28T14:39:33.605745Z",
+     "iopub.status.idle": "2026-08-28T14:39:33.744855Z",
+     "shell.execute_reply": "2026-08-28T14:39:33.744310Z"
     },
     "papermill": {
-     "duration": 0.082687,
-     "end_time": "2026-08-28T14:28:35.148603+00:00",
+     "duration": 0.142888,
+     "end_time": "2026-08-28T14:39:33.745184+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:35.065916+00:00",
+     "start_time": "2026-08-28T14:39:33.602296+00:00",
      "status": "completed"
     }
    },
@@ -3579,13 +3580,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70fa7b9f",
+   "id": "8a361bc9",
    "metadata": {
     "papermill": {
-     "duration": 0.002349,
-     "end_time": "2026-08-28T14:28:35.153656+00:00",
+     "duration": 0.005994,
+     "end_time": "2026-08-28T14:39:33.756532+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:35.151307+00:00",
+     "start_time": "2026-08-28T14:39:33.750538+00:00",
      "status": "completed"
     }
    },
@@ -3599,19 +3600,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "78d21fbb",
+   "id": "4fdcfd68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:35.158999Z",
-     "iopub.status.busy": "2026-08-28T14:28:35.158898Z",
-     "iopub.status.idle": "2026-08-28T14:28:35.594780Z",
-     "shell.execute_reply": "2026-08-28T14:28:35.594373Z"
+     "iopub.execute_input": "2026-08-28T14:39:33.769803Z",
+     "iopub.status.busy": "2026-08-28T14:39:33.769691Z",
+     "iopub.status.idle": "2026-08-28T14:39:34.368116Z",
+     "shell.execute_reply": "2026-08-28T14:39:34.367553Z"
     },
     "papermill": {
-     "duration": 0.439435,
-     "end_time": "2026-08-28T14:28:35.595426+00:00",
+     "duration": 0.610937,
+     "end_time": "2026-08-28T14:39:34.371817+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:35.155991+00:00",
+     "start_time": "2026-08-28T14:39:33.760880+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3713,19 +3714,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "55595086",
+   "id": "a6bd0d14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:35.605032Z",
-     "iopub.status.busy": "2026-08-28T14:28:35.604921Z",
-     "iopub.status.idle": "2026-08-28T14:28:37.114295Z",
-     "shell.execute_reply": "2026-08-28T14:28:37.113747Z"
+     "iopub.execute_input": "2026-08-28T14:39:34.392733Z",
+     "iopub.status.busy": "2026-08-28T14:39:34.392611Z",
+     "iopub.status.idle": "2026-08-28T14:39:36.146385Z",
+     "shell.execute_reply": "2026-08-28T14:39:36.145945Z"
     },
     "papermill": {
-     "duration": 1.514748,
-     "end_time": "2026-08-28T14:28:37.114784+00:00",
+     "duration": 1.76832,
+     "end_time": "2026-08-28T14:39:36.146789+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:35.600036+00:00",
+     "start_time": "2026-08-28T14:39:34.378469+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4347,13 +4348,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5f8df82",
+   "id": "87affc07",
    "metadata": {
     "papermill": {
-     "duration": 0.002916,
-     "end_time": "2026-08-28T14:28:37.121138+00:00",
+     "duration": 0.004046,
+     "end_time": "2026-08-28T14:39:36.154987+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:37.118222+00:00",
+     "start_time": "2026-08-28T14:39:36.150941+00:00",
      "status": "completed"
     }
    },
@@ -4369,19 +4370,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "f7063091",
+   "id": "f258bbef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:37.128034Z",
-     "iopub.status.busy": "2026-08-28T14:28:37.127890Z",
-     "iopub.status.idle": "2026-08-28T14:28:37.157051Z",
-     "shell.execute_reply": "2026-08-28T14:28:37.156646Z"
+     "iopub.execute_input": "2026-08-28T14:39:36.170547Z",
+     "iopub.status.busy": "2026-08-28T14:39:36.170429Z",
+     "iopub.status.idle": "2026-08-28T14:39:36.201807Z",
+     "shell.execute_reply": "2026-08-28T14:39:36.201506Z"
     },
     "papermill": {
-     "duration": 0.033474,
-     "end_time": "2026-08-28T14:28:37.157670+00:00",
+     "duration": 0.039903,
+     "end_time": "2026-08-28T14:39:36.202237+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:37.124196+00:00",
+     "start_time": "2026-08-28T14:39:36.162334+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4453,19 +4454,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "79ea5be6",
+   "id": "1463b88a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:28:37.165671Z",
-     "iopub.status.busy": "2026-08-28T14:28:37.165565Z",
-     "iopub.status.idle": "2026-08-28T14:29:00.261014Z",
-     "shell.execute_reply": "2026-08-28T14:29:00.260348Z"
+     "iopub.execute_input": "2026-08-28T14:39:36.215313Z",
+     "iopub.status.busy": "2026-08-28T14:39:36.215164Z",
+     "iopub.status.idle": "2026-08-28T14:39:54.954648Z",
+     "shell.execute_reply": "2026-08-28T14:39:54.954082Z"
     },
     "papermill": {
-     "duration": 23.099436,
-     "end_time": "2026-08-28T14:29:00.261357+00:00",
+     "duration": 18.749543,
+     "end_time": "2026-08-28T14:39:54.957022+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:28:37.161921+00:00",
+     "start_time": "2026-08-28T14:39:36.207479+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4483,33 +4484,96 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (60, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0</td><td>0.000269</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>1</td><td>0.000056</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>2</td><td>-0.000004</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>3</td><td>0.000141</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>4</td><td>0.000237</td></tr></tbody></table></div>"
+       "<small>shape: (60, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>bucket</th><th>mean_realized_return</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0</td><td>-0.000018</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>1</td><td>-0.000084</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>2</td><td>-0.000042</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>3</td><td>0.000038</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>4</td><td>0.000233</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0</td><td>0.000016</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>1</td><td>-0.000049</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>2</td><td>0.000076</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>3</td><td>0.000014</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>4</td><td>0.000071</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0</td><td>-0.000024</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>1</td><td>0.000023</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>2</td><td>0.000005</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>3</td><td>0.000048</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>4</td><td>0.000075</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0</td><td>-0.000088</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>1</td><td>-0.000055</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>2</td><td>0.000091</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>3</td><td>0.0001</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>4</td><td>0.00008</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>0</td><td>0.000503</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>1</td><td>-0.000287</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>2</td><td>0.000702</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>3</td><td>0.00144</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>4</td><td>0.00059</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>0</td><td>0.000806</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>1</td><td>-0.000525</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>2</td><td>0.000418</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>3</td><td>0.000003</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>4</td><td>0.002246</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>0</td><td>-0.000825</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>1</td><td>-0.000149</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>2</td><td>0.001249</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>3</td><td>0.00106</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>4</td><td>0.001614</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>0</td><td>0.00038</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>1</td><td>0.000297</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>2</td><td>0.00067</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>3</td><td>0.001213</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>4</td><td>0.000388</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0</td><td>-0.000111</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>1</td><td>-0.000116</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>2</td><td>0.000369</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>3</td><td>0.000352</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>4</td><td>0.000205</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0</td><td>-0.000211</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>1</td><td>0.000221</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>2</td><td>0.000199</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>3</td><td>0.000306</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>4</td><td>0.000184</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0</td><td>-0.000091</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>1</td><td>0.000139</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>2</td><td>0.000159</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>3</td><td>0.000275</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>4</td><td>0.000217</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0</td><td>0.000269</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>1</td><td>0.000056</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>2</td><td>-0.000004</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>3</td><td>0.000141</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>4</td><td>0.000237</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (60, 7)\n",
-       "┌────────────┬───────────────┬─────────────┬───────────────┬───────────────┬────────┬──────────────┐\n",
-       "│ label      ┆ family        ┆ config_name ┆ checkpoint_va ┆ prediction_ha ┆ bucket ┆ mean_realize │\n",
-       "│ ---        ┆ ---           ┆ ---         ┆ lue           ┆ sh            ┆ ---    ┆ d_return     │\n",
-       "│ str        ┆ str           ┆ str         ┆ ---           ┆ ---           ┆ i64    ┆ ---          │\n",
-       "│            ┆               ┆             ┆ i64           ┆ str           ┆        ┆ f64          │\n",
-       "╞════════════╪═══════════════╪═════════════╪═══════════════╪═══════════════╪════════╪══════════════╡\n",
-       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 0      ┆ -0.000018    │\n",
-       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 1      ┆ -0.000084    │\n",
-       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 2      ┆ -0.000042    │\n",
-       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 3      ┆ 0.000038     │\n",
-       "│ fwd_ret_1d ┆ deep_learning ┆ tcn         ┆ 5             ┆ d80638423af7  ┆ 4      ┆ 0.000233     │\n",
-       "│ …          ┆ …             ┆ …           ┆ …             ┆ …             ┆ …      ┆ …            │\n",
-       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 0      ┆ 0.000269     │\n",
-       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 1      ┆ 0.000056     │\n",
-       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 2      ┆ -0.000004    │\n",
-       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 3      ┆ 0.000141     │\n",
-       "│ fwd_ret_5d ┆ tabular_dl    ┆ tabm_m      ┆ 25            ┆ 569a0fe11b53  ┆ 4      ┆ 0.000237     │\n",
-       "└────────────┴───────────────┴─────────────┴───────────────┴───────────────┴────────┴──────────────┘"
+       "┌─────────────┬───────────────┬──────────────┬──────────────┬──────────────┬────────┬──────────────┐\n",
+       "│ label       ┆ family        ┆ config_name  ┆ checkpoint_v ┆ prediction_h ┆ bucket ┆ mean_realize │\n",
+       "│ ---         ┆ ---           ┆ ---          ┆ alue         ┆ ash          ┆ ---    ┆ d_return     │\n",
+       "│ str         ┆ str           ┆ str          ┆ ---          ┆ ---          ┆ i64    ┆ ---          │\n",
+       "│             ┆               ┆              ┆ i64          ┆ str          ┆        ┆ f64          │\n",
+       "╞═════════════╪═══════════════╪══════════════╪══════════════╪══════════════╪════════╪══════════════╡\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn          ┆ 5            ┆ d80638423af7 ┆ 0      ┆ -0.000018    │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn          ┆ 5            ┆ d80638423af7 ┆ 1      ┆ -0.000084    │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn          ┆ 5            ┆ d80638423af7 ┆ 2      ┆ -0.000042    │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn          ┆ 5            ┆ d80638423af7 ┆ 3      ┆ 0.000038     │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn          ┆ 5            ┆ d80638423af7 ┆ 4      ┆ 0.000233     │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_ma ┆ 100          ┆ 0cff45d5daf6 ┆ 0      ┆ 0.000016     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_ma ┆ 100          ┆ 0cff45d5daf6 ┆ 1      ┆ -0.000049    │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_ma ┆ 100          ┆ 0cff45d5daf6 ┆ 2      ┆ 0.000076     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_ma ┆ 100          ┆ 0cff45d5daf6 ┆ 3      ┆ 0.000014     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_ma ┆ 100          ┆ 0cff45d5daf6 ┆ 4      ┆ 0.000071     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2   ┆ null         ┆ eeff2961026c ┆ 0      ┆ -0.000024    │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2   ┆ null         ┆ eeff2961026c ┆ 1      ┆ 0.000023     │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2   ┆ null         ┆ eeff2961026c ┆ 2      ┆ 0.000005     │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2   ┆ null         ┆ eeff2961026c ┆ 3      ┆ 0.000048     │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2   ┆ null         ┆ eeff2961026c ┆ 4      ┆ 0.000075     │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l       ┆ 50           ┆ 01e41111cb52 ┆ 0      ┆ -0.000088    │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l       ┆ 50           ┆ 01e41111cb52 ┆ 1      ┆ -0.000055    │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l       ┆ 50           ┆ 01e41111cb52 ┆ 2      ┆ 0.000091     │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l       ┆ 50           ┆ 01e41111cb52 ┆ 3      ┆ 0.0001       │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l       ┆ 50           ┆ 01e41111cb52 ┆ 4      ┆ 0.00008      │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear      ┆ 5            ┆ 13e7a953029c ┆ 0      ┆ 0.000503     │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear      ┆ 5            ┆ 13e7a953029c ┆ 1      ┆ -0.000287    │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear      ┆ 5            ┆ 13e7a953029c ┆ 2      ┆ 0.000702     │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear      ┆ 5            ┆ 13e7a953029c ┆ 3      ┆ 0.00144      │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear      ┆ 5            ┆ 13e7a953029c ┆ 4      ┆ 0.00059      │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_ma ┆ 50           ┆ 0fae34c102be ┆ 0      ┆ 0.000806     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_ma ┆ 50           ┆ 0fae34c102be ┆ 1      ┆ -0.000525    │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_ma ┆ 50           ┆ 0fae34c102be ┆ 2      ┆ 0.000418     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_ma ┆ 50           ┆ 0fae34c102be ┆ 3      ┆ 0.000003     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_ma ┆ 50           ┆ 0fae34c102be ┆ 4      ┆ 0.002246     │\n",
+       "│             ┆               ┆ e            ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5    ┆ null         ┆ 205f803ccc00 ┆ 0      ┆ -0.000825    │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5    ┆ null         ┆ 205f803ccc00 ┆ 1      ┆ -0.000149    │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5    ┆ null         ┆ 205f803ccc00 ┆ 2      ┆ 0.001249     │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5    ┆ null         ┆ 205f803ccc00 ┆ 3      ┆ 0.00106      │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5    ┆ null         ┆ 205f803ccc00 ┆ 4      ┆ 0.001614     │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l       ┆ 25           ┆ c304a4d52bad ┆ 0      ┆ 0.00038      │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l       ┆ 25           ┆ c304a4d52bad ┆ 1      ┆ 0.000297     │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l       ┆ 25           ┆ c304a4d52bad ┆ 2      ┆ 0.00067      │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l       ┆ 25           ┆ c304a4d52bad ┆ 3      ┆ 0.001213     │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l       ┆ 25           ┆ c304a4d52bad ┆ 4      ┆ 0.000388     │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear      ┆ 5            ┆ b633f307a008 ┆ 0      ┆ -0.000111    │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear      ┆ 5            ┆ b633f307a008 ┆ 1      ┆ -0.000116    │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear      ┆ 5            ┆ b633f307a008 ┆ 2      ┆ 0.000369     │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear      ┆ 5            ┆ b633f307a008 ┆ 3      ┆ 0.000352     │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear      ┆ 5            ┆ b633f307a008 ┆ 4      ┆ 0.000205     │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_hub ┆ 50           ┆ d4d6d17e5918 ┆ 0      ┆ -0.000211    │\n",
+       "│             ┆               ┆ er           ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_hub ┆ 50           ┆ d4d6d17e5918 ┆ 1      ┆ 0.000221     │\n",
+       "│             ┆               ┆ er           ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_hub ┆ 50           ┆ d4d6d17e5918 ┆ 2      ┆ 0.000199     │\n",
+       "│             ┆               ┆ er           ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_hub ┆ 50           ┆ d4d6d17e5918 ┆ 3      ┆ 0.000306     │\n",
+       "│             ┆               ┆ er           ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_hub ┆ 50           ┆ d4d6d17e5918 ┆ 4      ┆ 0.000184     │\n",
+       "│             ┆               ┆ er           ┆              ┆              ┆        ┆              │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85   ┆ null         ┆ 88100a79d70a ┆ 0      ┆ -0.000091    │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85   ┆ null         ┆ 88100a79d70a ┆ 1      ┆ 0.000139     │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85   ┆ null         ┆ 88100a79d70a ┆ 2      ┆ 0.000159     │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85   ┆ null         ┆ 88100a79d70a ┆ 3      ┆ 0.000275     │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85   ┆ null         ┆ 88100a79d70a ┆ 4      ┆ 0.000217     │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m       ┆ 25           ┆ 569a0fe11b53 ┆ 0      ┆ 0.000269     │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m       ┆ 25           ┆ 569a0fe11b53 ┆ 1      ┆ 0.000056     │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m       ┆ 25           ┆ 569a0fe11b53 ┆ 2      ┆ -0.000004    │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m       ┆ 25           ┆ 569a0fe11b53 ┆ 3      ┆ 0.000141     │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m       ┆ 25           ┆ 569a0fe11b53 ┆ 4      ┆ 0.000237     │\n",
+       "└─────────────┴───────────────┴──────────────┴──────────────┴──────────────┴────────┴──────────────┘"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -4543,18 +4607,21 @@
     "    .agg(pl.col(\"actual\").mean().alias(\"mean_realized_return\"))\n",
     "    .sort(\"label\", \"family\", \"bucket\")\n",
     ")\n",
-    "bucket_summary"
+    "# Three labels sort as 1d, 21d, 5d, so the default row window hides the middle one entirely and\n",
+    "# a reader would see the same two-thirds coverage this section exists to remove.\n",
+    "with pl.Config(tbl_rows=bucket_summary.height):\n",
+    "    display(bucket_summary)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9f7e0078",
+   "id": "a9e34ab1",
    "metadata": {
     "papermill": {
-     "duration": 0.003528,
-     "end_time": "2026-08-28T14:29:00.268716+00:00",
+     "duration": 0.005819,
+     "end_time": "2026-08-28T14:39:54.967236+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.265188+00:00",
+     "start_time": "2026-08-28T14:39:54.961417+00:00",
      "status": "completed"
     }
    },
@@ -4569,19 +4636,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d65253db",
+   "id": "78b1cee3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:29:00.278158Z",
-     "iopub.status.busy": "2026-08-28T14:29:00.277764Z",
-     "iopub.status.idle": "2026-08-28T14:29:00.366811Z",
-     "shell.execute_reply": "2026-08-28T14:29:00.366097Z"
+     "iopub.execute_input": "2026-08-28T14:39:54.982988Z",
+     "iopub.status.busy": "2026-08-28T14:39:54.982598Z",
+     "iopub.status.idle": "2026-08-28T14:39:55.072810Z",
+     "shell.execute_reply": "2026-08-28T14:39:55.072507Z"
     },
     "papermill": {
-     "duration": 0.094944,
-     "end_time": "2026-08-28T14:29:00.367389+00:00",
+     "duration": 0.099124,
+     "end_time": "2026-08-28T14:39:55.073634+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.272445+00:00",
+     "start_time": "2026-08-28T14:39:54.974510+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4599,42 +4666,56 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (36, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.9</td><td>0.956163</td><td>3.163107</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0.95</td><td>0.91216</td><td>33.638073</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0.95</td><td>0.98598</td><td>3.872072</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0.95</td><td>0.986285</td><td>3.902174</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.95</td><td>0.978123</td><td>3.905645</td><td>36020</td></tr></tbody></table></div>"
+       "<small>shape: (36, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>checkpoint_value</th><th>prediction_hash</th><th>nominal_level</th><th>empirical_coverage</th><th>mean_interval_width_frac_std</th><th>n_test</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.8</td><td>0.792188</td><td>14.833431</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.8</td><td>0.898781</td><td>2.187913</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.8</td><td>0.897922</td><td>2.158434</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.8</td><td>0.907285</td><td>2.363629</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.9</td><td>0.882465</td><td>19.70981</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.9</td><td>0.961967</td><td>3.052487</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.9</td><td>0.961884</td><td>3.025496</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.9</td><td>0.963324</td><td>3.240988</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;tcn&quot;</td><td>5</td><td>&quot;d80638423af7&quot;</td><td>0.95</td><td>0.937812</td><td>24.977348</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_63_mae&quot;</td><td>100</td><td>&quot;0cff45d5daf6&quot;</td><td>0.95</td><td>0.983989</td><td>3.902682</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;linear&quot;</td><td>&quot;lasso_f0.2&quot;</td><td>null</td><td>&quot;eeff2961026c&quot;</td><td>0.95</td><td>0.984571</td><td>3.874998</td><td>36100</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>50</td><td>&quot;01e41111cb52&quot;</td><td>0.95</td><td>0.985845</td><td>4.234442</td><td>36100</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>0.8</td><td>0.8093</td><td>12.508744</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>0.8</td><td>0.901569</td><td>2.451747</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>0.8</td><td>0.903277</td><td>2.358358</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>0.8</td><td>0.873641</td><td>2.752362</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>0.9</td><td>0.881232</td><td>15.842605</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>0.9</td><td>0.961232</td><td>3.280326</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>0.9</td><td>0.96521</td><td>3.245008</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>0.9</td><td>0.944314</td><td>3.617004</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;13e7a953029c&quot;</td><td>0.95</td><td>0.917675</td><td>18.664038</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>50</td><td>&quot;0fae34c102be&quot;</td><td>0.95</td><td>0.987059</td><td>4.249277</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.5&quot;</td><td>null</td><td>&quot;205f803ccc00&quot;</td><td>0.95</td><td>0.987115</td><td>4.177566</td><td>35700</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_l&quot;</td><td>25</td><td>&quot;c304a4d52bad&quot;</td><td>0.95</td><td>0.977899</td><td>4.536748</td><td>35700</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0.8</td><td>0.798612</td><td>22.749991</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0.8</td><td>0.916602</td><td>2.306443</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0.8</td><td>0.917129</td><td>2.314834</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.8</td><td>0.892254</td><td>2.327853</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0.9</td><td>0.874653</td><td>28.844265</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0.9</td><td>0.969267</td><td>3.16125</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0.9</td><td>0.969878</td><td>3.178055</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.9</td><td>0.956163</td><td>3.163107</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>&quot;b633f307a008&quot;</td><td>0.95</td><td>0.91216</td><td>33.638073</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>50</td><td>&quot;d4d6d17e5918&quot;</td><td>0.95</td><td>0.98598</td><td>3.872072</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.85&quot;</td><td>null</td><td>&quot;88100a79d70a&quot;</td><td>0.95</td><td>0.986285</td><td>3.902174</td><td>36020</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>25</td><td>&quot;569a0fe11b53&quot;</td><td>0.95</td><td>0.978123</td><td>3.905645</td><td>36020</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (36, 9)\n",
-       "┌────────────┬────────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬────────┐\n",
-       "│ label      ┆ family     ┆ config_na ┆ checkpoin ┆ … ┆ nominal_l ┆ empirical ┆ mean_inte ┆ n_test │\n",
-       "│ ---        ┆ ---        ┆ me        ┆ t_value   ┆   ┆ evel      ┆ _coverage ┆ rval_widt ┆ ---    │\n",
-       "│ str        ┆ str        ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ h_frac_st ┆ i64    │\n",
-       "│            ┆            ┆ str       ┆ i64       ┆   ┆ f64       ┆ f64       ┆ d         ┆        │\n",
-       "│            ┆            ┆           ┆           ┆   ┆           ┆           ┆ ---       ┆        │\n",
-       "│            ┆            ┆           ┆           ┆   ┆           ┆           ┆ f64       ┆        │\n",
-       "╞════════════╪════════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪════════╡\n",
-       "│ fwd_ret_1d ┆ deep_learn ┆ tcn       ┆ 5         ┆ … ┆ 0.8       ┆ 0.792188  ┆ 14.833431 ┆ 36100  │\n",
-       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_1d ┆ gbm        ┆ leaves_63 ┆ 100       ┆ … ┆ 0.8       ┆ 0.898781  ┆ 2.187913  ┆ 36100  │\n",
-       "│            ┆            ┆ _mae      ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_1d ┆ linear     ┆ lasso_f0. ┆ null      ┆ … ┆ 0.8       ┆ 0.897922  ┆ 2.158434  ┆ 36100  │\n",
-       "│            ┆            ┆ 2         ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_1d ┆ tabular_dl ┆ tabm_l    ┆ 50        ┆ … ┆ 0.8       ┆ 0.907285  ┆ 2.363629  ┆ 36100  │\n",
-       "│ fwd_ret_1d ┆ deep_learn ┆ tcn       ┆ 5         ┆ … ┆ 0.9       ┆ 0.882465  ┆ 19.70981  ┆ 36100  │\n",
-       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ …          ┆ …          ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …      │\n",
-       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m    ┆ 25        ┆ … ┆ 0.9       ┆ 0.956163  ┆ 3.163107  ┆ 36020  │\n",
-       "│ fwd_ret_5d ┆ deep_learn ┆ nlinear   ┆ 5         ┆ … ┆ 0.95      ┆ 0.91216   ┆ 33.638073 ┆ 36020  │\n",
-       "│            ┆ ing        ┆           ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_5d ┆ gbm        ┆ leaves_7_ ┆ 50        ┆ … ┆ 0.95      ┆ 0.98598   ┆ 3.872072  ┆ 36020  │\n",
-       "│            ┆            ┆ huber     ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_5d ┆ linear     ┆ enet_f0.8 ┆ null      ┆ … ┆ 0.95      ┆ 0.986285  ┆ 3.902174  ┆ 36020  │\n",
-       "│            ┆            ┆ 5         ┆           ┆   ┆           ┆           ┆           ┆        │\n",
-       "│ fwd_ret_5d ┆ tabular_dl ┆ tabm_m    ┆ 25        ┆ … ┆ 0.95      ┆ 0.978123  ┆ 3.905645  ┆ 36020  │\n",
-       "└────────────┴────────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴────────┘"
+       "┌─────────────┬───────────────┬────────────────┬──────────────────┬─────────────────┬───────────────┬────────────────────┬──────────────────────────────┬────────┐\n",
+       "│ label       ┆ family        ┆ config_name    ┆ checkpoint_value ┆ prediction_hash ┆ nominal_level ┆ empirical_coverage ┆ mean_interval_width_frac_std ┆ n_test │\n",
+       "│ ---         ┆ ---           ┆ ---            ┆ ---              ┆ ---             ┆ ---           ┆ ---                ┆ ---                          ┆ ---    │\n",
+       "│ str         ┆ str           ┆ str            ┆ i64              ┆ str             ┆ f64           ┆ f64                ┆ f64                          ┆ i64    │\n",
+       "╞═════════════╪═══════════════╪════════════════╪══════════════════╪═════════════════╪═══════════════╪════════════════════╪══════════════════════════════╪════════╡\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn            ┆ 5                ┆ d80638423af7    ┆ 0.8           ┆ 0.792188           ┆ 14.833431                    ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_mae  ┆ 100              ┆ 0cff45d5daf6    ┆ 0.8           ┆ 0.898781           ┆ 2.187913                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2     ┆ null             ┆ eeff2961026c    ┆ 0.8           ┆ 0.897922           ┆ 2.158434                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l         ┆ 50               ┆ 01e41111cb52    ┆ 0.8           ┆ 0.907285           ┆ 2.363629                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn            ┆ 5                ┆ d80638423af7    ┆ 0.9           ┆ 0.882465           ┆ 19.70981                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_mae  ┆ 100              ┆ 0cff45d5daf6    ┆ 0.9           ┆ 0.961967           ┆ 3.052487                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2     ┆ null             ┆ eeff2961026c    ┆ 0.9           ┆ 0.961884           ┆ 3.025496                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l         ┆ 50               ┆ 01e41111cb52    ┆ 0.9           ┆ 0.963324           ┆ 3.240988                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ deep_learning ┆ tcn            ┆ 5                ┆ d80638423af7    ┆ 0.95          ┆ 0.937812           ┆ 24.977348                    ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ gbm           ┆ leaves_63_mae  ┆ 100              ┆ 0cff45d5daf6    ┆ 0.95          ┆ 0.983989           ┆ 3.902682                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ linear        ┆ lasso_f0.2     ┆ null             ┆ eeff2961026c    ┆ 0.95          ┆ 0.984571           ┆ 3.874998                     ┆ 36100  │\n",
+       "│ fwd_ret_1d  ┆ tabular_dl    ┆ tabm_l         ┆ 50               ┆ 01e41111cb52    ┆ 0.95          ┆ 0.985845           ┆ 4.234442                     ┆ 36100  │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear        ┆ 5                ┆ 13e7a953029c    ┆ 0.8           ┆ 0.8093             ┆ 12.508744                    ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_mae  ┆ 50               ┆ 0fae34c102be    ┆ 0.8           ┆ 0.901569           ┆ 2.451747                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5      ┆ null             ┆ 205f803ccc00    ┆ 0.8           ┆ 0.903277           ┆ 2.358358                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l         ┆ 25               ┆ c304a4d52bad    ┆ 0.8           ┆ 0.873641           ┆ 2.752362                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear        ┆ 5                ┆ 13e7a953029c    ┆ 0.9           ┆ 0.881232           ┆ 15.842605                    ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_mae  ┆ 50               ┆ 0fae34c102be    ┆ 0.9           ┆ 0.961232           ┆ 3.280326                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5      ┆ null             ┆ 205f803ccc00    ┆ 0.9           ┆ 0.96521            ┆ 3.245008                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l         ┆ 25               ┆ c304a4d52bad    ┆ 0.9           ┆ 0.944314           ┆ 3.617004                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ deep_learning ┆ nlinear        ┆ 5                ┆ 13e7a953029c    ┆ 0.95          ┆ 0.917675           ┆ 18.664038                    ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ gbm           ┆ leaves_31_mae  ┆ 50               ┆ 0fae34c102be    ┆ 0.95          ┆ 0.987059           ┆ 4.249277                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ linear        ┆ enet_f0.5      ┆ null             ┆ 205f803ccc00    ┆ 0.95          ┆ 0.987115           ┆ 4.177566                     ┆ 35700  │\n",
+       "│ fwd_ret_21d ┆ tabular_dl    ┆ tabm_l         ┆ 25               ┆ c304a4d52bad    ┆ 0.95          ┆ 0.977899           ┆ 4.536748                     ┆ 35700  │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear        ┆ 5                ┆ b633f307a008    ┆ 0.8           ┆ 0.798612           ┆ 22.749991                    ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_huber ┆ 50               ┆ d4d6d17e5918    ┆ 0.8           ┆ 0.916602           ┆ 2.306443                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85     ┆ null             ┆ 88100a79d70a    ┆ 0.8           ┆ 0.917129           ┆ 2.314834                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m         ┆ 25               ┆ 569a0fe11b53    ┆ 0.8           ┆ 0.892254           ┆ 2.327853                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear        ┆ 5                ┆ b633f307a008    ┆ 0.9           ┆ 0.874653           ┆ 28.844265                    ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_huber ┆ 50               ┆ d4d6d17e5918    ┆ 0.9           ┆ 0.969267           ┆ 3.16125                      ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85     ┆ null             ┆ 88100a79d70a    ┆ 0.9           ┆ 0.969878           ┆ 3.178055                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m         ┆ 25               ┆ 569a0fe11b53    ┆ 0.9           ┆ 0.956163           ┆ 3.163107                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ deep_learning ┆ nlinear        ┆ 5                ┆ b633f307a008    ┆ 0.95          ┆ 0.91216            ┆ 33.638073                    ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ gbm           ┆ leaves_7_huber ┆ 50               ┆ d4d6d17e5918    ┆ 0.95          ┆ 0.98598            ┆ 3.872072                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ linear        ┆ enet_f0.85     ┆ null             ┆ 88100a79d70a    ┆ 0.95          ┆ 0.986285           ┆ 3.902174                     ┆ 36020  │\n",
+       "│ fwd_ret_5d  ┆ tabular_dl    ┆ tabm_m         ┆ 25               ┆ 569a0fe11b53    ┆ 0.95          ┆ 0.978123           ┆ 3.905645                     ┆ 36020  │\n",
+       "└─────────────┴───────────────┴────────────────┴──────────────────┴─────────────────┴───────────────┴────────────────────┴──────────────────────────────┴────────┘"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -4654,18 +4735,19 @@
     "            }\n",
     "        )\n",
     "conformal = pl.DataFrame(conformal_rows).sort(\"label\", \"nominal_level\", \"family\")\n",
-    "conformal"
+    "with pl.Config(tbl_rows=conformal.height, tbl_cols=conformal.width, tbl_width_chars=200):\n",
+    "    display(conformal)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "663acea9",
+   "id": "c6eb05de",
    "metadata": {
     "papermill": {
-     "duration": 0.004579,
-     "end_time": "2026-08-28T14:29:00.377566+00:00",
+     "duration": 0.011255,
+     "end_time": "2026-08-28T14:39:55.096071+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.372987+00:00",
+     "start_time": "2026-08-28T14:39:55.084816+00:00",
      "status": "completed"
     }
    },
@@ -4681,19 +4763,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a19f97f1",
+   "id": "a83122f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:29:00.388488Z",
-     "iopub.status.busy": "2026-08-28T14:29:00.388297Z",
-     "iopub.status.idle": "2026-08-28T14:29:00.396272Z",
-     "shell.execute_reply": "2026-08-28T14:29:00.395788Z"
+     "iopub.execute_input": "2026-08-28T14:39:55.115084Z",
+     "iopub.status.busy": "2026-08-28T14:39:55.114878Z",
+     "iopub.status.idle": "2026-08-28T14:39:55.124695Z",
+     "shell.execute_reply": "2026-08-28T14:39:55.124286Z"
     },
     "papermill": {
-     "duration": 0.014091,
-     "end_time": "2026-08-28T14:29:00.396616+00:00",
+     "duration": 0.020622,
+     "end_time": "2026-08-28T14:39:55.125838+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.382525+00:00",
+     "start_time": "2026-08-28T14:39:55.105216+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4761,13 +4843,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5c2a8da",
+   "id": "88670073",
    "metadata": {
     "papermill": {
-     "duration": 0.004863,
-     "end_time": "2026-08-28T14:29:00.406800+00:00",
+     "duration": 0.010472,
+     "end_time": "2026-08-28T14:39:55.146494+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.401937+00:00",
+     "start_time": "2026-08-28T14:39:55.136022+00:00",
      "status": "completed"
     }
    },
@@ -4782,19 +4864,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "acbdfb64",
+   "id": "062deb1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T14:29:00.417810Z",
-     "iopub.status.busy": "2026-08-28T14:29:00.417656Z",
-     "iopub.status.idle": "2026-08-28T14:29:00.427768Z",
-     "shell.execute_reply": "2026-08-28T14:29:00.426892Z"
+     "iopub.execute_input": "2026-08-28T14:39:55.165662Z",
+     "iopub.status.busy": "2026-08-28T14:39:55.165307Z",
+     "iopub.status.idle": "2026-08-28T14:39:55.172400Z",
+     "shell.execute_reply": "2026-08-28T14:39:55.172048Z"
     },
     "papermill": {
-     "duration": 0.016644,
-     "end_time": "2026-08-28T14:29:00.428358+00:00",
+     "duration": 0.016698,
+     "end_time": "2026-08-28T14:39:55.172833+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.411714+00:00",
+     "start_time": "2026-08-28T14:39:55.156135+00:00",
      "status": "completed"
     }
    },
@@ -4857,13 +4939,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97ca0f04",
+   "id": "07da987a",
    "metadata": {
     "papermill": {
-     "duration": 0.005362,
-     "end_time": "2026-08-28T14:29:00.439330+00:00",
+     "duration": 0.01386,
+     "end_time": "2026-08-28T14:39:55.196284+00:00",
      "exception": false,
-     "start_time": "2026-08-28T14:29:00.433968+00:00",
+     "start_time": "2026-08-28T14:39:55.182424+00:00",
      "status": "completed"
     }
    },
@@ -4900,19 +4982,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 36.062256,
-   "end_time": "2026-08-28T14:29:01.962964+00:00",
+   "duration": 34.628149,
+   "end_time": "2026-08-28T14:39:56.521708+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/12_model_analysis.ipynb",
-   "output_path": "~/scratch/prod_12_model_analysis_2674873.ipynb",
+   "output_path": "~/scratch/prod_12_model_analysis_2842021.ipynb",
    "parameters": {},
-   "start_time": "2026-08-28T14:28:25.900708+00:00",
+   "start_time": "2026-08-28T14:39:21.893559+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "bb33e7e24426326c1229f06395c754684f4f7f87",
-   "executed_at": "2026-08-28T14:29:08.814750+00:00",
+   "source_py_blob": "48eb3353c9faaeb9ebeabc1ff2db52ac44d9a9f0",
+   "executed_at": "2026-08-28T14:40:05.975101+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/12_model_analysis.py
+++ b/case_studies/fx_pairs/12_model_analysis.py
@@ -39,6 +39,7 @@
 import plotly.express as px
 import polars as pl
 import yaml
+from IPython.display import display
 from ml4t.diagnostic.metrics import cross_sectional_ic
 
 import utils.style  # noqa: F401
@@ -367,7 +368,10 @@ bucket_summary = (
     .agg(pl.col("actual").mean().alias("mean_realized_return"))
     .sort("label", "family", "bucket")
 )
-bucket_summary
+# Three labels sort as 1d, 21d, 5d, so the default row window hides the middle one entirely and
+# a reader would see the same two-thirds coverage this section exists to remove.
+with pl.Config(tbl_rows=bucket_summary.height):
+    display(bucket_summary)
 
 # %% [markdown]
 # ## Chronological conformal coverage
@@ -393,7 +397,8 @@ for keys, frame in representative_predictions.group_by(
             }
         )
 conformal = pl.DataFrame(conformal_rows).sort("label", "nominal_level", "family")
-conformal
+with pl.Config(tbl_rows=conformal.height, tbl_cols=conformal.width, tbl_width_chars=200):
+    display(conformal)
 
 # %% [markdown]
 # ## Causal evidence remains separate

--- a/case_studies/fx_pairs/12_model_analysis.py
+++ b/case_studies/fx_pairs/12_model_analysis.py
@@ -50,7 +50,6 @@ from utils.paths import get_case_study_dir
 
 # %% tags=["parameters"]
 CASE_STUDY = "fx_pairs"
-PRIMARY_LABEL = "fwd_ret_1d"
 N_BUCKETS = 5
 # This notebook reads; it fits nothing and registers nothing, so it has no preview form - a
 # preview population is not the thing whose assembly it checks. It still takes the pair,
@@ -70,7 +69,8 @@ WORKSPACE: str | None = None
 # %%
 case_dir = get_case_study_dir(CASE_STUDY)
 setup = yaml.safe_load((case_dir / "config" / "setup.yaml").read_text())
-configured_labels = [setup["labels"]["primary"], *setup["labels"].get("variants", [])]
+primary_label = setup["labels"]["primary"]
+configured_labels = [primary_label, *setup["labels"].get("variants", [])]
 study = open_study(CASE_STUDY, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 catalog = study.predictions.table().filter(
     (pl.col("identity_status") == "current")
@@ -309,12 +309,14 @@ fold_figure.show()
 # %% [markdown]
 # ## Prediction agreement and ranking shape
 #
-# Correlation between model scores shows whether families rank pairs similarly. Return buckets show
-# how realized returns vary from the lowest to highest prediction ranks without turning that pattern
-# into a deployment decision.
+# Correlation between model scores shows whether families rank pairs similarly. One correlation
+# matrix covers one label: scores fitted against different targets are not comparable ranks of the
+# same quantity, so the pivot takes the primary label the menu declares rather than all three.
+# Return buckets and conformal coverage carry no such restriction and run over every label.
 
 # %% tags=["results"]
-primary = representative_predictions.filter(pl.col("label") == PRIMARY_LABEL)
+primary = representative_predictions.filter(pl.col("label") == primary_label)
+print(f"Score agreement is computed on {primary_label}, the primary label in the menu")
 # The pivot index is the canonical eligibility key alone. `actual` is the same realized return for
 # every model at a given key, but the families do not agree on its float representation, so including
 # it split the rows into disjoint groups - each score column populated on a different half - and every
@@ -336,8 +338,8 @@ agreement
 
 # %% tags=["results"]
 bucket_rows = []
-for keys, frame in primary.group_by(
-    "family", "config_name", "checkpoint_value", "prediction_hash", "timestamp"
+for keys, frame in representative_predictions.group_by(
+    "label", "family", "config_name", "checkpoint_value", "prediction_hash", "timestamp"
 ):
     if frame.height < N_BUCKETS:
         continue
@@ -349,20 +351,21 @@ for keys, frame in primary.group_by(
     for bucket, values in ranked.group_by("bucket"):
         bucket_rows.append(
             {
-                "family": keys[0],
-                "config_name": keys[1],
-                "checkpoint_value": keys[2],
-                "prediction_hash": keys[3],
-                "timestamp": keys[4],
+                "label": keys[0],
+                "family": keys[1],
+                "config_name": keys[2],
+                "checkpoint_value": keys[3],
+                "prediction_hash": keys[4],
+                "timestamp": keys[5],
                 "bucket": bucket[0],
                 "actual": values.get_column("actual").mean(),
             }
         )
 bucket_summary = (
     pl.DataFrame(bucket_rows)
-    .group_by("family", "config_name", "checkpoint_value", "prediction_hash", "bucket")
+    .group_by("label", "family", "config_name", "checkpoint_value", "prediction_hash", "bucket")
     .agg(pl.col("actual").mean().alias("mean_realized_return"))
-    .sort("family", "bucket")
+    .sort("label", "family", "bucket")
 )
 bucket_summary
 
@@ -375,38 +378,50 @@ bucket_summary
 
 # %% tags=["results"]
 conformal_rows = []
-for keys, frame in primary.group_by("family", "config_name", "checkpoint_value", "prediction_hash"):
+for keys, frame in representative_predictions.group_by(
+    "label", "family", "config_name", "checkpoint_value", "prediction_hash"
+):
     for row in split_conformal_coverage(frame):
         conformal_rows.append(
             {
-                "family": keys[0],
-                "config_name": keys[1],
-                "checkpoint_value": keys[2],
-                "prediction_hash": keys[3],
+                "label": keys[0],
+                "family": keys[1],
+                "config_name": keys[2],
+                "checkpoint_value": keys[3],
+                "prediction_hash": keys[4],
                 **row,
             }
         )
-conformal = pl.DataFrame(conformal_rows).sort("nominal_level", "family")
+conformal = pl.DataFrame(conformal_rows).sort("label", "nominal_level", "family")
 conformal
 
 # %% [markdown]
 # ## Causal evidence remains separate
 #
-# The causal result answers whether the configured momentum treatment has an estimated effect after
+# A causal result answers whether the configured momentum treatment has an estimated effect after
 # adjustment for its declared confounders. It does not count as predictive-family coverage and does
-# not enter the model or backtest population.
+# not enter the model or backtest population. `11_causal_dml` registers one estimate per label the
+# menu declares, so naming a single label here would leave the rest of them unreported.
 
 # %% tags=["results"]
-causal = CausalResult.one(study, label=PRIMARY_LABEL)
-causal_summary = pl.DataFrame([{"causal_hash": causal.hash, **causal.metrics}]).select(
-    "causal_hash",
-    "n_obs",
-    "dml_effect",
-    "dml_se_hac",
-    "p_value_hac",
-    "naive_effect",
-    "confounding_bias_pct",
-    "refutation_p",
+causal_rows = []
+for label in configured_labels:
+    causal = CausalResult.one(study, label=label)
+    causal_rows.append({"label": label, "causal_hash": causal.hash, **causal.metrics})
+causal_summary = (
+    pl.DataFrame(causal_rows)
+    .select(
+        "label",
+        "causal_hash",
+        "n_obs",
+        "dml_effect",
+        "dml_se_hac",
+        "p_value_hac",
+        "naive_effect",
+        "confounding_bias_pct",
+        "refutation_p",
+    )
+    .sort("label")
 )
 causal_summary
 


### PR DESCRIPTION
`12_model_analysis` hardcoded `PRIMARY_LABEL = "fwd_ret_1d"` in its parameters cell and read three sections through it. The registry holds one current causal result per declared label - `25f8bdd775de`, `c797f741134a`, `3547657669ca`, each superseding a retired predecessor - and the page showed one. A reader saw a third of what `11_causal_dml` published with no way to know the rest existed.

The bucket and conformal tables had the same shape. Both group by `prediction_hash`, so labels never mix, and both were nevertheless computed on one label's representatives.

## What changed

- The literal is gone. The primary label now comes from `setup.yaml`, the same menu `configured_labels` already came from.
- The causal section iterates the menu and carries a `label` column: three rows, matching the three current hashes in the registry.
- Buckets and conformal coverage key on `label` and cover every representative: 60 bucket rows and 36 conformal rows, from 20 and 12.
- Both tables display under `pl.Config`, because three labels sort as 1d, 21d, 5d and the grown frames pushed 21d into Polars' hidden middle - the reader would have seen the same two-thirds coverage from a frame that now holds all of it. Conformal takes `tbl_cols` too, since four of its nine columns sat behind the column window.

Score agreement stays on one label, and that is a different question, not the same defect: scores fitted against different targets are not comparable rankings of one quantity, so a single correlation matrix cannot span the menu. It now names the label it used rather than repeating a literal, and prints it.

## Scope

Every publishing notebook was checked and is clean: 06 and 07 take `LABELS: list[str] = []` and pass `labels=LABELS or None`; 08-11 expand an empty `PRIMARY_LABEL` to primary plus variants. The menu is covered where work is registered. This is the one reading notebook that narrowed it.

## Verification

Executed on the production path with no parameter overrides; the notebook registers nothing, so no training or holdout was spent. Coverage confirmed against the executed `.ipynb` rather than the source: causal shows three rows whose hashes match the three current `causal_runs` identities, bucket renders 60 rows and conformal 36 (twelve per label), and neither header carries an elision marker.