### PR TITLE
Re-key a selected spec to the holdout fold, and refuse when the temporal artifact cannot support it (#963)

### DIFF
--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -585,7 +585,7 @@ def evaluate_holdout(
         case_study=str(case_study if case_study is not None else study.case_study),
         timeline=timeline,
     )
-    _refuse_incomplete_holdout_spec(holdout_spec)
+    _rekey_holdout_spec(study, holdout_spec, validation_spec)
 
     # selection_evidence is hashed into the lock identity, so anything put here that is already
     # recorded elsewhere gives one fact two sources and makes the lock unreproducible by any
@@ -654,33 +654,78 @@ _FOLD_DERIVED_FIELDS = (
 )
 
 
-def _refuse_incomplete_holdout_spec(spec: dict[str, Any]) -> None:
-    computation = spec.get("computation")
-    if not isinstance(computation, dict):
-        raise ValueError("holdout spec has no resolved computation block")
-    present: list[str] = []
-    if "expected_prediction_keys" in computation:
-        present.append("computation.expected_prediction_keys")
+def _rekey_holdout_spec(study: Any, spec: dict[str, Any], validation_spec: dict[str, Any]) -> None:
+    """Recompute the fold-derived fields for the holdout fold, or refuse with the family named.
+
+    The fields are family-specific - each family derives them with its own rule, from its own
+    training rows - so this dispatches through ``_family_module`` exactly as
+    ``reconstruct_locked_request`` and ``validate_locked_run`` already do. A family that has not
+    implemented the hook still refuses, but it now refuses for itself rather than on behalf of
+    every family at once.
+    """
+    from .models import _family_module
+
+    family = spec.get("family")
+    module = _family_module(family)
+    hook = getattr(module, "rekey_holdout_spec", None)
+    if hook is None:
+        raise NotImplementedError(
+            f"the {family!r} family cannot yet re-key a validation training spec to the holdout "
+            "fold, so no lock can be taken for it. Implementing it means recomputing this "
+            "family's fold-derived fields against the derived holdout fold - the eligibility "
+            "manifest from the dataset, and any parameter the family resolves from a fold's own "
+            "training rows - by the same rule that produced the recorded validation values. See "
+            "`rekey_holdout_spec` in case_studies/utils/linear.py."
+        )
+    hook(study, spec, validation_spec=validation_spec)
+    _require_holdout_keyed_fields(spec)
+
+
+def _require_holdout_keyed_fields(spec: dict[str, Any]) -> None:
+    """Check the re-keyed fields describe the holdout fold, not the validation folds.
+
+    A hook that returned without recomputing, or that recomputed against the wrong split, leaves
+    fields that look present and are wrong - and the lock is the one artifact that cannot be
+    revised. So the shape is checked here rather than trusted: exactly one fold, and it is the
+    fold the derived holdout CV names.
+    """
+    computation = spec["computation"]
+    cv = computation.get("cv")
+    if not isinstance(cv, dict):
+        raise ValueError("holdout spec has no resolved CV")
+    # Both shapes `locked_holdout_split` accepts: an explicit one-fold list, or the flat form
+    # where the single fold's boundaries sit on the CV record itself.
+    folds = cv.get("folds")
+    if folds is None:
+        fold_id = str(int(cv.get("fold", 0)))
+    elif isinstance(folds, list) and len(folds) == 1:
+        fold_id = str(int(folds[0]["fold"]))
+    else:
+        raise ValueError("holdout spec must carry exactly one resolved fold")
+
+    manifest = computation.get("expected_prediction_keys")
+    if not isinstance(manifest, dict) or manifest.get("n_folds") != 1:
+        raise ValueError(f"holdout eligibility manifest was not re-keyed to one fold: {manifest!r}")
+
     model = computation.get("model")
     if isinstance(model, dict) and "effective_params_by_fold" in model:
-        present.append("computation.model.effective_params_by_fold")
+        keys = set(model["effective_params_by_fold"])
+        if keys != {fold_id}:
+            raise ValueError(
+                f"holdout parameters are keyed to {sorted(keys)}, not the holdout fold "
+                f"{fold_id!r}; they still describe the validation folds"
+            )
+
     task = computation.get("task")
     if isinstance(task, dict):
         imbalance = task.get("imbalance")
         if isinstance(imbalance, dict) and "effective_class_weights_by_fold" in imbalance:
-            present.append("computation.task.imbalance.effective_class_weights_by_fold")
-    macro = computation.get("macro_context")
-    if isinstance(macro, dict) and "resolved_fold_digest" in macro:
-        present.append("computation.macro_context.resolved_fold_digest")
-    if present:
-        raise NotImplementedError(
-            "the selected training spec carries fold-derived fields that describe its VALIDATION "
-            f"folds and must be re-keyed to the holdout fold before a lock is taken: {present}. "
-            "validate_locked_expected_keys refuses a spec without an eligibility manifest and "
-            "refuses one describing a different frame, so a lock taken now would fail at "
-            "execution. Recomputing them needs the holdout window's eligible key frame, which the "
-            "family resolver builds during a run and which is not threaded through this path yet."
-        )
+            keys = set(imbalance["effective_class_weights_by_fold"])
+            if keys != {fold_id}:
+                raise ValueError(
+                    f"holdout class weights are keyed to {sorted(keys)}, not the holdout fold "
+                    f"{fold_id!r}"
+                )
 
 
 def _confirm_recorded_selection(study: Any, lock: ResearchLock, candidate_set_name: str) -> None:

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -615,6 +615,88 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     )
 
 
+def rekey_holdout_spec(
+    study: Study,
+    spec: dict[str, Any],
+    *,
+    validation_spec: dict[str, Any],
+) -> None:
+    """Recompute the fold-derived fields against the holdout fold, in place, before a lock.
+
+    ``spec`` arrives with its CV already replaced by the single derived holdout fold, and with
+    ``expected_prediction_keys`` and ``effective_params_by_fold`` still describing the VALIDATION
+    folds. Both are checked after the lock by ``validate_locked_expected_keys`` and by
+    ``reconstruct_locked_request``, so carrying them forward produces a lock that fails at
+    execution and dropping them produces one that fails differently. They have to be recomputed.
+
+    Recomputing is not copying. A data-derived penalty - any ``alpha_frac`` configuration - is
+    resolved from the training rows of its own fold, so the holdout fold's alpha is a different
+    number from every validation fold's, and carrying one forward would lock a model that is not
+    the model selection chose. Measured on ``fx_pairs``: 48 of 84 linear specs vary their
+    parameters across folds, ``lasso_f0.85`` among them.
+
+    The rule that derives them lives in the preset, not in the spec, which records only the
+    resolved values. So the preset is loaded by ``config_name`` and **verified against a recorded
+    validation fold before it is trusted**: if replaying the rule does not reproduce the
+    parameters the spec already carries, the preset has changed since the validation run and
+    deriving the holdout parameters from it would silently lock a different configuration. One
+    fold is enough to establish that, and eight would cost eight fold preparations.
+    """
+    from case_studies.research.models import locked_holdout_split
+
+    computation = spec["computation"]
+    label_ref = study.labels.get(spec["label"], execution_tier=ExecutionTier.CANONICAL)
+    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=0)
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("locked linear runner requires timestamp and an entity key")
+    entity_col = mds.entity_cols[0]
+
+    split = locked_holdout_split(spec, mds.dataset, mds.date_col, study.case_study)
+    expected = _expected_keys_from_dataset(
+        mds.dataset,
+        [split],
+        entity_col=entity_col,
+        date_col=mds.date_col,
+        label_col=mds.label_col,
+    )
+    computation["expected_prediction_keys"] = {
+        "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+        "n_rows": expected.height,
+        "n_folds": expected.get_column("fold").n_unique(),
+    }
+
+    model = computation.get("model")
+    if not isinstance(model, dict) or "effective_params_by_fold" not in model:
+        return
+    recorded = model["effective_params_by_fold"]
+    if not isinstance(recorded, dict) or not recorded:
+        raise ValueError("locked linear spec records no effective parameters to re-key")
+
+    config = _load_preset(spec["config_name"])
+    validation_folds = _normalize_folds(validation_spec["computation"]["cv"]["folds"])
+    witness = next((fold for fold in validation_folds if str(int(fold["fold"])) in recorded), None)
+    if witness is None:
+        raise ValueError(
+            "locked linear spec records parameters for no fold the validation CV declares"
+        )
+    witness_id = str(int(witness["fold"]))
+    replayed = _effective_params(
+        config, {}, prepare_standardized_folds(mds, [dict(witness)], train_sample_frac=1.0)
+    )
+    if replayed.get(witness_id) != recorded[witness_id]:
+        raise ValueError(
+            f"preset {spec['config_name']!r} no longer reproduces the recorded parameters for "
+            f"validation fold {witness_id}: {replayed.get(witness_id)!r} != "
+            f"{recorded[witness_id]!r}. The holdout parameters are derived from this preset, so "
+            "locking now would evaluate a configuration other than the one selection ranked."
+        )
+
+    holdout_folds = prepare_standardized_folds(mds, [split], train_sample_frac=1.0)
+    if not holdout_folds:
+        raise ValueError("locked linear holdout fold could not be prepared")
+    model["effective_params_by_fold"] = _effective_params(config, {}, holdout_folds)
+
+
 def reconstruct_locked_request(
     study: Study,
     spec: dict[str, Any],

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -615,6 +615,43 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     )
 
 
+def _require_holdout_temporal_features(mds, split: dict[str, Any]) -> None:
+    """Refuse to re-key onto a holdout fold the fold-scoped temporal artifact does not describe.
+
+    Stage 04 writes model-based features per validation fold, so the artifact carries the
+    validation fold ids and their boundaries and nothing else. A holdout fold is a different
+    interval, and `locked_holdout_split` takes its id from the spec's CV, defaulting to 0. Both
+    ways of getting this wrong are silent:
+
+    - a holdout id absent from the artifact joins no temporal rows, and the model fits on
+      all-null features rather than the ones it was selected with;
+    - a holdout id that collides with a validation id - id 0 is the default, and every case
+      study has a fold 0 - joins successfully against features fitted on that validation
+      fold's training window, which ends before the holdout interval begins. Nothing raises;
+      the holdout number is simply computed from the wrong feature vintage.
+
+    `reconstruct_locked_request` runs the same check, but it runs after the lock is written, and
+    a lock is not recoverable. Checking here means the refusal happens while the holdout is still
+    unspent.
+    """
+    if mds.temporal_by_fold is None or not mds.temporal_keys or not mds.temporal_feature_names:
+        return
+    try:
+        require_fold_scoped_temporal_compatibility([split], mds.temporal_artifact_splits)
+    except ValueError as exc:
+        available = sorted(int(fold["fold"]) for fold in mds.temporal_artifact_splits)
+        raise ValueError(
+            f"holdout fold {int(split['fold'])} "
+            f"({split['train_start']}..{split['train_end']} train, "
+            f"{split['val_start']}..{split['val_end']} evaluation) is not the geometry the "
+            f"fold-scoped temporal artifact was built for; it carries folds {available}. "
+            f"The {len(mds.temporal_feature_names)} model-based features would be joined from "
+            "the wrong fold or from none at all, so the holdout would not evaluate the "
+            "configuration selection ranked. Generate the model-based features for the holdout "
+            "fold in stage 04 before locking."
+        ) from exc
+
+
 def rekey_holdout_spec(
     study: Study,
     spec: dict[str, Any],
@@ -652,6 +689,7 @@ def rekey_holdout_spec(
     entity_col = mds.entity_cols[0]
 
     split = locked_holdout_split(spec, mds.dataset, mds.date_col, study.case_study)
+    _require_holdout_temporal_features(mds, split)
     expected = _expected_keys_from_dataset(
         mds.dataset,
         [split],

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -249,3 +249,64 @@ def test_the_lock_refuses_a_holdout_interval_identical_to_the_validation_one() -
 
     with pytest.raises(ValueError, match="explicit, distinct CV interval"):
         _locked_training_spec(validation, unchanged)
+
+
+class _TemporalStub:
+    """The three fields ``_require_holdout_temporal_features`` reads, and nothing else."""
+
+    def __init__(self, artifact_splits: list[dict[str, Any]] | None) -> None:
+        self.temporal_by_fold = {} if artifact_splits is not None else None
+        self.temporal_keys = ("symbol", "timestamp") if artifact_splits is not None else ()
+        self.temporal_feature_names = ("kalman_trend", "arima_forecast") if artifact_splits else ()
+        self.temporal_artifact_splits = artifact_splits or []
+
+
+_VALIDATION_FOLD_0 = {
+    "fold": 0,
+    "train_start": "2010-01-31",
+    "train_end": "2014-12-31",
+    "val_start": "2015-01-31",
+    "val_end": "2015-12-31",
+}
+
+
+def test_a_holdout_fold_colliding_with_a_validation_fold_id_is_refused() -> None:
+    """The silent case: `locked_holdout_split` defaults the fold id to 0, and fold 0 exists.
+
+    The join against fold-scoped temporal features would then succeed against features fitted
+    on validation fold 0's training window, which ends years before the holdout interval
+    starts. Nothing raises, and the holdout number is computed from the wrong feature vintage.
+    This is the failure the check exists for, so the test asserts the refusal names the fold.
+    """
+    from case_studies.utils.linear import _require_holdout_temporal_features
+
+    holdout = dict(_VALIDATION_FOLD_0)
+    holdout.update(
+        train_start="2010-01-31",
+        train_end="2019-12-31",
+        val_start="2020-01-31",
+        val_end="2021-12-31",
+    )
+
+    with pytest.raises(ValueError, match=r"holdout fold 0 .*wrong fold or from none at all"):
+        _require_holdout_temporal_features(_TemporalStub([_VALIDATION_FOLD_0]), holdout)
+
+
+def test_a_holdout_fold_absent_from_the_artifact_is_refused() -> None:
+    """The other direction: a fresh id joins nothing and the model fits on all-null features."""
+    from case_studies.utils.linear import _require_holdout_temporal_features
+
+    holdout = dict(_VALIDATION_FOLD_0, fold=8, val_start="2020-01-31", val_end="2021-12-31")
+
+    with pytest.raises(ValueError, match=r"holdout fold 8 .*carries folds \[0\]"):
+        _require_holdout_temporal_features(_TemporalStub([_VALIDATION_FOLD_0]), holdout)
+
+
+def test_a_case_study_without_fold_scoped_temporal_features_is_not_refused() -> None:
+    """The failure direction of the two above: the check must not block a case study it
+    does not apply to, or it would refuse every holdout rather than the unsafe ones."""
+    from case_studies.utils.linear import _require_holdout_temporal_features
+
+    holdout = dict(_VALIDATION_FOLD_0, fold=8, val_start="2020-01-31", val_end="2021-12-31")
+
+    _require_holdout_temporal_features(_TemporalStub(None), holdout)

--- a/tests/test_holdout_evaluation_driver.py
+++ b/tests/test_holdout_evaluation_driver.py
@@ -100,36 +100,77 @@ def test_an_unknown_candidate_set_is_refused_by_name(
         evaluate_holdout(study, candidate_set_name="no-such-set", timeline=TIMELINE)
 
 
-def test_a_spec_carrying_validation_fold_derivations_refuses_to_lock(
+def test_a_family_without_a_rekey_hook_refuses_to_lock(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A lock cannot be revised, so producing one known to fail at execution is worse than none.
 
-    ``expected_prediction_keys`` describes which rows the fit was eligible to predict on.
-    ``validate_locked_expected_keys`` refuses a locked spec that has none, and refuses one whose
-    manifest describes a different frame - so a holdout spec that inherits the validation folds'
-    manifest fails at execution, and one with the field stripped fails there too. Recomputing it
-    needs the holdout window's eligible keys, which the family resolver builds during a run.
+    ``expected_prediction_keys`` describes which rows the fit was eligible to predict on, and
+    ``validate_locked_expected_keys`` refuses a locked spec whose manifest describes a different
+    frame. A holdout spec inheriting the validation folds' manifest therefore fails at execution,
+    and one with the field stripped fails there too - so the fields must be recomputed against the
+    holdout fold, by the rule that produced them, which is family-specific.
 
-    Until that is threaded through, the driver must stop at the lock rather than take one.
+    A family with no hook still refuses. What changed is that it refuses for itself and says what
+    implementing it means, rather than refusing on behalf of all five families at once.
     """
-    study, lock, prices = _locked_study(tmp_path, monkeypatch)
-    _install_fixture_adapter(monkeypatch, prices)
-    _pin_derivation_to_the_fixture(monkeypatch, lock)
-
     from case_studies.research import holdout as module
 
-    monkeypatch.setattr(
-        module,
-        "_sole_lock",
-        lambda _study: (_ for _ in ()).throw(AssertionError("must not reach the recorded lock")),
-    )
+    monkeypatch.setattr("case_studies.research.models._family_module", lambda _family: object())
+    spec = {"family": "linear", "computation": {"cv": {"folds": [{"fold": 9}]}}}
+    with pytest.raises(NotImplementedError, match="cannot yet re-key"):
+        module._rekey_holdout_spec(None, spec, {"computation": {}})
 
-    spec = {
-        "computation": {"expected_prediction_keys": {"digest": "abc", "n_rows": 1, "n_folds": 1}}
+
+def _holdout_shaped_spec(*, manifest_folds: int, param_folds: int) -> dict:
+    return {
+        "family": "linear",
+        "computation": {
+            "cv": {
+                "folds": [
+                    {
+                        "fold": 8,
+                        "train_start": "a",
+                        "train_end": "b",
+                        "val_start": "c",
+                        "val_end": "d",
+                    }
+                ]
+            },
+            "expected_prediction_keys": {"digest": "abc", "n_rows": 1, "n_folds": manifest_folds},
+            "model": {
+                "effective_params_by_fold": {str(i): {"alpha": 0.1} for i in range(param_folds)}
+                if param_folds != 1
+                else {"8": {"alpha": 0.1}}
+            },
+        },
     }
-    with pytest.raises(NotImplementedError, match="re-keyed to the holdout fold"):
-        module._refuse_incomplete_holdout_spec(spec)
 
-    clean = {"computation": {"cv": {}}}
-    module._refuse_incomplete_holdout_spec(clean)
+
+def test_a_hook_that_leaves_the_validation_folds_in_place_is_caught(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The re-keyed shape is checked, not trusted.
+
+    A hook that returns without recomputing, or that recomputes against the wrong split, leaves
+    fields that look present and are wrong - and the lock is the one artifact in the pipeline that
+    cannot be revised. Both fields are checked, because a hook that re-keys the manifest and
+    forgets the parameters produces a lock that reconstructs a different model than the one
+    selection ranked, and the manifest check alone would pass it.
+    """
+    from case_studies.research import holdout as module
+
+    class _NoOpFamily:
+        @staticmethod
+        def rekey_holdout_spec(_study, _spec, *, validation_spec):  # noqa: ARG004
+            return None
+
+    monkeypatch.setattr("case_studies.research.models._family_module", lambda _family: _NoOpFamily)
+
+    with pytest.raises(ValueError, match="was not re-keyed to one fold"):
+        module._rekey_holdout_spec(None, _holdout_shaped_spec(manifest_folds=8, param_folds=8), {})
+
+    with pytest.raises(ValueError, match="still describe the validation folds"):
+        module._rekey_holdout_spec(None, _holdout_shaped_spec(manifest_folds=1, param_folds=8), {})
+
+    module._rekey_holdout_spec(None, _holdout_shaped_spec(manifest_folds=1, param_folds=1), {})

--- a/tests/test_locked_holdout_execution.py
+++ b/tests/test_locked_holdout_execution.py
@@ -118,6 +118,7 @@ def _locked_study(
         "evaluation_start": "2024-01-11",
         "evaluation_end": "2024-01-11",
     }
+    _fixture_rekey(holdout_spec)
     holdout_prices = _prices().with_columns(pl.lit(date(2024, 1, 11)).alias("timestamp"))
     _patch_holdout_prices(monkeypatch, holdout_prices)
     lock = study.lifecycle.lock(
@@ -148,6 +149,34 @@ def test_lock_reopens_its_candidate_set_when_the_name_has_two_generations(
     with pytest.raises(ValueError, match="resolved to 2 identities"):
         CandidateSet.one(study, name="locked-selection")
     assert lock.candidate_set().hash == locked.hash
+
+
+def _fixture_rekey(spec: dict) -> dict:
+    """Stand in for a family's re-key, doing the one thing every family must do.
+
+    A real family recomputes these from the holdout fold's own training rows. The fixture has no
+    rows to recompute from, so it does the part the driver checks and the lock identity depends
+    on: point both fold-derived fields at the holdout fold instead of the validation folds they
+    were inherited from.
+
+    ``_locked_study`` applies it too. The re-keyed spec is what the driver locks, so a fixture
+    that pre-locked the un-re-keyed spec would hash a different lock and every driver test would
+    fail on a lock collision rather than on what it is testing.
+    """
+    computation = spec["computation"]
+    cv = computation["cv"]
+    folds = cv.get("folds")
+    fold_id = str(int(folds[0]["fold"] if folds else cv.get("fold", 0)))
+    computation["expected_prediction_keys"] = {
+        "digest": "fixture-holdout-manifest",
+        "n_rows": 1,
+        "n_folds": 1,
+    }
+    model = computation.get("model")
+    if isinstance(model, dict) and "effective_params_by_fold" in model:
+        carried = next(iter(model["effective_params_by_fold"].values()))
+        model["effective_params_by_fold"] = {fold_id: carried}
+    return spec
 
 
 def _install_fixture_adapter(
@@ -195,6 +224,7 @@ def _install_fixture_adapter(
         reconstruct_locked_request=reconstruct,
         run_resolved_request=run,
         validate_locked_run=validate,
+        rekey_holdout_spec=lambda study, spec, *, validation_spec: _fixture_rekey(spec),
     )
     monkeypatch.setattr(models, "get_adapter", lambda kind, name: adapter)
     if interrupt_after_stage:


### PR DESCRIPTION
`holdout_evaluations` is empty in all seven active registries. It was read as "not reached yet"; it was "cannot be reached" - `_refuse_incomplete_holdout_spec` refused every family unconditionally, because a selected spec carries the validation CV and a holdout lock needs the holdout fold's geometry.

**The re-key cannot be a copy-forward.** Measured: fx_pairs' rank-1 `linear/lasso_f0.85` has `alpha` varying across all 8 folds (`alpha_frac` derives it per fold); 48 of 84 linear specs and 15 of 45 gbm specs vary the same way. Carrying a validation fold's `alpha` into the holdout would lock a configuration selection never ranked, irreversibly.

So `rekey_holdout_spec` recomputes the fold-derived fields against the holdout fold. The load-bearing design decision is that the derivation rule lives in the preset, not the spec, so the preset is **verified to reproduce one recorded validation fold's parameters** before it is trusted to derive the holdout's. If the preset has moved since the validation run, this refuses rather than locking a different model.

Dispatch goes through `_family_module`; a family with no hook raises `NotImplementedError` naming it. `linear` has the hook; `gbm`, `deep_learning`, `tabular_dl` and `latent_factors` follow.

## The second commit, from RoboRev job 16415

The re-key prepared the holdout fold without the fold-scoped temporal compatibility check that `reconstruct_locked_request` runs. Both failure directions are silent:

- `locked_holdout_split` takes the fold id from the spec's CV and **defaults it to 0**. Every case study has a fold 0, so the join *succeeds*, against model-based features fitted on validation fold 0's training window - which ends before the holdout interval begins. Nothing raises. The holdout number is computed from the wrong feature vintage.
- A fresh id joins no temporal rows and the model fits on null features.

`reconstruct_locked_request` catches this, but after the lock is written, and a lock is not recoverable. The check now runs in the re-key, so the refusal lands while the holdout is still unspent.

## What this does not do

**It does not make any holdout evaluable.** Stage 04 has never written model-based features for a holdout fold in any case study - fx_pairs' `model_based.parquet` carries folds 0-7, the validation folds, and all four families use all ten of its features. So every holdout evaluation is blocked upstream of this change. What this PR does is replace an unconditional refusal with a correct one that says which fold is missing and why. The upstream work is raised separately.

Job 16415 also left a non-blocking Medium: `write_artifact` records no `fold_geometry`, so the loader's legacy fallback derives validation folds only. If a stage-04 producer did emit a holdout fold, this check would reject it. Recorded against the upstream item, since that is the change that would make it reachable.

## Verification

105 passed, 2 skipped across `test_holdout_evaluation_driver.py`, `test_locked_holdout_execution.py`, `test_holdout_boundary.py`, `test_holdout_checkpoint_identity.py`, `test_holdout_cv_derivation.py`. `ruff check` and `ruff format` clean; all pre-commit hooks green. RoboRev pre-push gate passed with no blocking findings.