### PR TITLE
Make the README callout date-free so it cannot go stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ strategy you can actually run, and keep running, in a live market.
 machine to a running notebook, prerequisites included. The short version is under
 [Quick Start](#quick-start) below.
 
-> **Free reader's guide:** Join [Navigate ML for Trading, 3rd Edition](https://maven.com/p/c6e0e7/navigate-ml-for-trading-3rd-edition)
-> on **July 30, 2026 at 11:00 AM ET** for a 30-minute map of the book, case studies, code, and companion resources.
-> See all current [courses and workshops](https://maven.com/stefan-jansen); the cohort courses are listed under
-> [Courses](#courses) below.
+> **Free live sessions and cohort courses:** short free lessons on the book's material run
+> most months, and the cohort courses work through the full research process with your own
+> question. Current schedule:
+> [ml4trading.io/courses](https://ml4trading.io/courses/?utm_source=github&utm_medium=readme&utm_campaign=repo_callout&utm_content=readme_top).
+> The cohort courses are also listed under [Courses](#courses) below.
 
 <p align="center">
   <a href="https://amzn.to/4eigy2F"><img src="assets/cover.png" width="45%" alt="Machine Learning for Trading, 3rd Edition"></a>


### PR DESCRIPTION
The blockquote above the book cover advertised a Navigate ML for Trading session on **July 30, 2026**. That event ran four weeks ago, so the most-read paragraph in a repo with 20,709 stars has been pointing every visitor at a past date.

Updating the date would fix today and reintroduce the same defect at the next event, which is exactly how this survived four weeks unnoticed. The callout now carries no date and no per-event Maven URL, and points at the courses page on the companion website, which is maintained as part of normal operations and already lists every live lesson, workshop and cohort.

The link keeps its UTM fields: Maven has no referrer field, so a GitHub arrival is currently indistinguishable from any other. Routing through the website, which does have analytics, is what makes this repo measurable as an acquisition channel.

One hunk, README only. Verified: no year or month name inside the callout, no `maven.com/p/<id>` URL anywhere in the README, and `https://ml4trading.io/courses/` returns 200.

Not merged - this is a marketing change to the public README, so it is yours to approve rather than a review-program PR.