### PR TITLE
One construction of the holdout seal, and it stops a buffer short of the boundary

### DIFF
--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -364,6 +364,50 @@ def _validation_folds(validation_spec: Mapping[str, Any]) -> list[dict[str, Any]
     return [dict(fold) for fold in folds]
 
 
+def widest_label_buffer(case_study: str, setup: Mapping[str, Any]) -> tuple[str, str]:
+    """Return the widest buffer any of a case study's labels declares, and whose it is.
+
+    The holdout fold is one fold. A fold-scoped temporal artifact carries a single set of
+    boundaries per fold id, and a fold-fitted feature's ``train_end`` is what that feature
+    knows, so the fold's geometry has to be the same whichever label a model is later fitted
+    on. That leaves one question: which buffer.
+
+    It is the widest, and the narrow ones are unsafe rather than merely tighter. A fold built
+    on a one-day buffer and handed to a twenty-one-day model gives that model training rows
+    whose features were fitted on data twenty sessions past its own ``train_end`` - the leak
+    the buffer exists to prevent, arriving through the feature instead of the label. The
+    widest buffer costs the shorter-horizon models a longer gap than they need, which is the
+    conservative direction and, on the case studies measured, twenty sessions out of thousands.
+
+    Labels are read from ``labels.primary`` and ``labels.variants`` and resolved through
+    :func:`utils.artifact_specs.resolve_label_buffer`, so a label carrying its own spec
+    artifact still wins over the setup block.
+    """
+    from utils.artifact_specs import resolve_label_buffer
+    from utils.cv_splits import normalize_label_buffer
+
+    labels = setup.get("labels") or {}
+    names = [str(labels["primary"])] if labels.get("primary") else []
+    names += [str(name) for name in (labels.get("variants") or [])]
+    if not names:
+        raise ValueError(f"{case_study} declares no labels, so no holdout buffer can be derived")
+
+    widest: tuple[pd.Timedelta, str, str] | None = None
+    for name in names:
+        buffer = resolve_label_buffer(case_study, name, setup)
+        if not buffer:
+            continue
+        span = pd.Timedelta(normalize_label_buffer(buffer))
+        if widest is None or span > widest[0]:
+            widest = (span, str(buffer), name)
+    if widest is None:
+        raise ValueError(
+            f"{case_study} declares labels {names} and a buffer for none of them, so the gap "
+            "sealing holdout training from the holdout window cannot be derived"
+        )
+    return widest[1], widest[2]
+
+
 def build_holdout_cv(
     validation_spec: Mapping[str, Any],
     *,
@@ -425,12 +469,12 @@ def build_holdout_cv(
     # for every case study whose label carries no separate spec artifact - which is all nine
     # for their primary label. Passing the setup is what makes the buffer resolvable at all.
     setup = load_setup_config(case_study)
-    buffer = resolve_label_buffer(case_study, resolved_label, setup)
-    if not buffer:
-        raise ValueError(
-            f"{case_study} declares no label buffer for {resolved_label!r}, so the gap sealing "
-            "holdout training from the holdout window cannot be derived"
-        )
+    # The case study's widest buffer, not the selected label's own. The fold-scoped temporal
+    # artifact carries one holdout fold whose features every label's holdout model is fitted
+    # on, so its boundary has to be label-independent, and the widest is the only choice that
+    # leaks for no label. `widest_label_buffer` carries the argument. The selected label still
+    # supplies the horizon check below, which this now satisfies by construction.
+    buffer, buffer_label = widest_label_buffer(case_study, setup)
     holdout_open = pd.Timestamp(holdout_start)
     observations = sorted({pd.Timestamp(str(value)) for value in timeline})
     if len(observations) < 2:
@@ -510,6 +554,7 @@ def build_holdout_cv(
         "request": {
             "source": "case_study_holdout",
             "label_buffer": str(buffer),
+            "label_buffer_label": buffer_label,
             "label_buffer_steps": buffer_steps,
             "observation_cadence": str(cadence),
             "periods_per_year": periods_per_year,

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -835,6 +835,27 @@ def test_the_narrative_states_the_configured_horizon() -> None:
     )
 
 
+def _point_case_study_dir_at(monkeypatch, case_dir) -> None:
+    """Route every setup.yaml read for a synthetic case study at ``case_dir``.
+
+    ``append_holdout_fold_if_needed`` derives its boundaries through
+    ``build_holdout_cv``, which reads the holdout window and the label buffers itself
+    rather than taking them from the caller - that is what makes it the one derivation.
+    Both readers resolve through ``get_case_study_dir`` and both memoize, so a test that
+    patches one of them or forgets the caches silently measures a different case study.
+    """
+    import case_studies.utils.cv_window as cv_window
+    import utils.artifact_specs as artifact_specs
+    import utils.modeling as modeling
+
+    for module in (modeling, artifact_specs, cv_window):
+        monkeypatch.setattr(module, "get_case_study_dir", lambda *_a, **_k: case_dir)
+    artifact_specs._load_setup_config_cached.cache_clear()
+    cv_window._load_setup_yaml.cache_clear()
+    cv_window._holdout_window.cache_clear()
+    monkeypatch.setattr(artifact_specs, "load_label_spec", lambda *_a, **_k: None, raising=False)
+
+
 def test_the_holdout_fold_trains_on_everything_before_the_seal(tmp_path, monkeypatch) -> None:
     """The holdout retrain is the one fit the sealed holdout ever sees, so the window it
     trains on has to be everything available before the seal.
@@ -847,17 +868,23 @@ def test_the_holdout_fold_trains_on_everything_before_the_seal(tmp_path, monkeyp
     and only on the holdout path where nothing else would show it.
     """
     import pandas as pd
+    import polars as pl
 
-    import utils.modeling as modeling
     from utils.modeling import ModelingDataset, append_holdout_fold_if_needed
 
     case_dir = tmp_path / "cs"
     (case_dir / "config").mkdir(parents=True)
     (case_dir / "config" / "setup.yaml").write_text(
-        yaml.safe_dump({"evaluation": {"holdout_start": "2018-01-02", "holdout_end": "2018-12-31"}})
+        yaml.safe_dump(
+            {
+                "evaluation": {"holdout_start": "2018-01-02", "holdout_end": "2018-12-31"},
+                "labels": {"primary": "fwd_ret_5d", "buffer": "5D"},
+            }
+        )
     )
-    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _cs: case_dir)
+    _point_case_study_dir_at(monkeypatch, case_dir)
 
+    sessions = pd.bdate_range("2005-01-03", "2018-12-31")
     # Newest fold first, as generate_cv_splits emits them.
     splits = [
         {
@@ -871,6 +898,8 @@ def test_the_holdout_fold_trains_on_everything_before_the_seal(tmp_path, monkeyp
     ]
     mds = ModelingDataset.__new__(ModelingDataset)
     mds.splits = splits
+    mds.date_col = "timestamp"
+    mds.dataset = pl.DataFrame({"timestamp": list(sessions)})
     mds._input_lineage = object()
 
     append_holdout_fold_if_needed(mds, "holdout", "whatever")
@@ -881,7 +910,14 @@ def test_the_holdout_fold_trains_on_everything_before_the_seal(tmp_path, monkeyp
         "the holdout fold must start at the earliest train_start across folds, "
         f"not splits[0]'s {splits[0]['train_start']}"
     )
-    assert holdout["train_end"] == pd.Timestamp("2018-01-02")
+    # Not `holdout_start`. Training stops one declared buffer short of the boundary, counted
+    # in sessions along the panel's own grid, which is what `build_holdout_cv` derives and
+    # what this function used to get wrong in both directions at once: the last training
+    # label's outcome window reached into the holdout, and because the training mask is
+    # inclusive at both ends, the boundary session was trained on and scored on in one fold.
+    excluded = [d for d in sessions if holdout["train_end"] < d < holdout["val_start"]]
+    assert len(excluded) == 5, "a 5D buffer seals five sessions, not zero"
+    assert holdout["train_end"] < holdout["val_start"] == pd.Timestamp("2018-01-02")
     assert mds._input_lineage is None, "the memoized lineage describes the pre-append fold set"
 
 
@@ -898,16 +934,21 @@ def test_the_holdout_fold_covers_every_bar_of_the_final_configured_session(
     rows, none of which the consumer could read.
     """
     import pandas as pd
+    import polars as pl
 
-    import utils.modeling as modeling
     from utils.modeling import ModelingDataset, append_holdout_fold_if_needed
 
     case_dir = tmp_path / "cs"
     (case_dir / "config").mkdir(parents=True)
     (case_dir / "config" / "setup.yaml").write_text(
-        yaml.safe_dump({"evaluation": {"holdout_start": "2021-01-04", "holdout_end": "2021-12-31"}})
+        yaml.safe_dump(
+            {
+                "evaluation": {"holdout_start": "2021-01-04", "holdout_end": "2021-12-31"},
+                "labels": {"primary": "fwd_ret_60m", "buffer": "60min"},
+            }
+        )
     )
-    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _cs: case_dir)
+    _point_case_study_dir_at(monkeypatch, case_dir)
 
     mds = ModelingDataset.__new__(ModelingDataset)
     mds.splits = [
@@ -919,6 +960,10 @@ def test_the_holdout_fold_covers_every_bar_of_the_final_configured_session(
             "val_end": pd.Timestamp("2020-12-31 15:58"),
         }
     ]
+    mds.date_col = "timestamp"
+    mds.dataset = pl.DataFrame(
+        {"timestamp": list(pd.date_range("2020-01-02 09:32", "2021-12-31 15:58", freq="30min"))}
+    )
     mds._input_lineage = object()
 
     append_holdout_fold_if_needed(mds, "holdout", "whatever")

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -310,3 +310,70 @@ def test_a_case_study_without_fold_scoped_temporal_features_is_not_refused() -> 
     holdout = dict(_VALIDATION_FOLD_0, fold=8, val_start="2020-01-31", val_end="2021-12-31")
 
     _require_holdout_temporal_features(_TemporalStub(None), holdout)
+
+
+def test_the_gap_is_the_case_studys_widest_buffer_whatever_label_is_selected() -> None:
+    """One fold, one geometry, and the only safe one is the widest.
+
+    The fold-scoped temporal artifact carries a single set of boundaries per fold id, and a
+    fold-fitted feature's `train_end` is what that feature knows. A fold built on fx_pairs'
+    primary `1D` buffer and then handed to a `fwd_ret_21d` model would give that model training
+    rows whose features were fitted twenty sessions past its own `train_end` - the leak the
+    buffer exists to prevent, arriving through the feature rather than the label.
+
+    fx_pairs is the discriminating case: its primary declares `1D` and a variant declares `21D`,
+    so a derivation that read the selected label would return 1 here and a derivation that reads
+    the case study would return 21.
+    """
+    for label in ("fwd_ret_1d", "fwd_ret_5d", "fwd_ret_21d"):
+        cv = build_holdout_cv(_validation_spec(label), case_study="fx_pairs", timeline=SESSIONS)
+        assert cv["request"]["label_buffer"] == "21D", label
+        assert cv["request"]["label_buffer_label"] == "fwd_ret_21d", label
+        assert cv["request"]["label_buffer_steps"] == 21, label
+
+    # Every label therefore lands on one boundary, which is what makes the single fold usable.
+    boundaries = {
+        _fold(build_holdout_cv(_validation_spec(label), case_study="fx_pairs", timeline=SESSIONS))[
+            "train_end"
+        ]
+        for label in ("fwd_ret_1d", "fwd_ret_5d", "fwd_ret_21d")
+    }
+    assert len(boundaries) == 1
+
+
+def test_no_case_study_declares_an_outcome_horizon_its_widest_buffer_cannot_cover() -> None:
+    """The horizon check reads the selected label, so widening the buffer can only relax it.
+
+    Taking the maximum over a case study's labels returns at least each label's own buffer, and
+    the refusal already compared every label against that. Asserted across the nine rather than
+    argued, because the refusal is what stands between a short gap and a leaked holdout.
+    """
+    from case_studies.research.holdout import widest_label_buffer
+    from utils.artifact_specs import resolve_label_horizon
+    from utils.cv_splits import normalize_label_buffer
+
+    case_studies = [
+        "fx_pairs",
+        "cme_futures",
+        "crypto_perps_funding",
+        "etfs",
+        "sp500_options",
+        "us_firm_characteristics",
+        "sp500_equity_option_analytics",
+        "nasdaq100_microstructure",
+        "us_equities_panel",
+    ]
+    for case_study in case_studies:
+        setup = load_setup_config(case_study)
+        buffer, _ = widest_label_buffer(case_study, setup)
+        widest = pd.Timedelta(normalize_label_buffer(buffer))
+        labels = setup["labels"]
+        for label in [labels["primary"], *labels.get("variants", [])]:
+            horizon = resolve_label_horizon(case_study, label, setup)
+            if not horizon:
+                continue
+            assert pd.Timedelta(normalize_label_buffer(horizon)) <= widest, (
+                f"{case_study}/{label} declares an outcome horizon longer than the widest "
+                "buffer any of its labels declares, so its last training label resolves "
+                "inside the holdout"
+            )

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1012,10 +1012,17 @@ def append_holdout_fold_if_needed(
 ) -> None:
     """Append a holdout fold to ``mds.splits`` when ``prediction_split=='holdout'``.
 
-    The holdout fold trains on everything available before ``holdout_start`` and
-    validates on ``[holdout_start, holdout_end]``. It becomes fold N+1, so downstream
-    code iterating ``mds.splits`` produces one holdout prediction set per
-    (training run, config) pair without any other change to the training loop.
+    The boundaries come from :func:`case_studies.research.holdout.build_holdout_cv`, which is
+    the one derivation of them. This function used to compute its own, and computed them
+    wrongly: it set ``train_end = val_start = holdout_start``, where ``build_holdout_cv`` stops
+    one label buffer short. Two things were wrong with that. The last training label's outcome
+    window reached into the holdout, which is the leak the buffer exists to prevent; and the
+    training mask in this module is inclusive at both ends, so the boundary session sat in the
+    training set *and* the evaluation set of the same fold - a holdout model fitted on a session
+    it is scored on, independent of any label horizon.
+
+    The fold becomes fold N+1, so downstream code iterating ``mds.splits`` produces one holdout
+    prediction set per (training run, config) pair without any other change to the training loop.
 
     "Everything available" is ``min(train_start)`` across the CV folds, not
     ``splits[0]["train_start"]``. ``generate_cv_splits`` steps backward from the holdout
@@ -1043,6 +1050,8 @@ def append_holdout_fold_if_needed(
             "at least one CV fold for this case study."
         )
         raise RuntimeError(msg)
+    from case_studies.research.holdout import build_holdout_cv
+
     path = get_case_study_dir(case_study_id) / "config" / "setup.yaml"
     with open(path) as f:
         setup = yaml.safe_load(f)
@@ -1072,10 +1081,18 @@ def append_holdout_fold_if_needed(
     )
     if already_covered:
         return
+    # The label is only read for the outcome-horizon check: `build_holdout_cv` takes the gap
+    # from the case study's widest declared buffer, because one fold serves every label.
+    derived = build_holdout_cv(
+        {"label": str(setup["labels"]["primary"]), "computation": {"cv": {"folds": mds.splits}}},
+        case_study=case_study_id,
+        timeline=mds.dataset.get_column(mds.date_col).unique().sort().to_list(),
+    )
+    fold = dict(derived["folds"][0])
     holdout_fold = {
         "fold": len(mds.splits),
-        "train_start": earliest_train_start(mds.splits),
-        "train_end": ho_start_ts,
+        "train_start": pd.Timestamp(fold["train_start"]),
+        "train_end": pd.Timestamp(fold["train_end"]),
         "val_start": ho_start_ts,
         "val_end": ho_end_ts,
     }


### PR DESCRIPTION
## The defect

Four places built the interval that retrains a selected configuration for the holdout, and they did not agree.

`case_studies/research/holdout.py::build_holdout_cv` ends training **one label buffer before** `holdout_start`, counted in observations along the panel's own dates. Its docstring already says a zero gap there "is a leak rather than a conservative choice", and `locked_holdout_split` refuses a spec whose `train_end >= val_start`.

`utils/modeling.py::append_holdout_fold_if_needed` set `train_end = val_start = holdout_start`. Two things are wrong with that, not one:

1. The last training label's outcome window reaches into the holdout - the leak the buffer exists to prevent.
2. The training mask at `utils/modeling.py:1598` and `:1804` is inclusive at both ends, so the boundary session lands in the training set **and** the evaluation set of the same fold. A holdout model fitted on a session it is scored on, independent of any label horizon. Found by `cme_futures` while checking the first.

`nasdaq100_microstructure`'s four deep-learning notebooks take that path.

## The fix

`append_holdout_fold_if_needed` now calls `build_holdout_cv`. Producer and consumer run the same code, which is the point.

### The buffer is the case study's widest, not the selected label's

The second disagreement, surfaced by `fx_pairs`. `require_fold_scoped_temporal_compatibility` demands exact equality between a requested fold and the artifact fold of the same id, and the fold-scoped temporal artifact carries **one** holdout fold. Its geometry therefore has to be label-independent, and among label-independent choices only the widest leaks for no label.

A fold built on fx_pairs' primary `1D` buffer and handed to a `fwd_ret_21d` model gives that model training rows whose features were fitted twenty sessions past its own `train_end` - the same leak, arriving through the feature instead of the label. Containment rather than equality would permit exactly that, which is why the check is not loosened.

The narrower buffers cost the shorter-horizon models a longer gap than they need: on fx_pairs, twenty sessions out of 3,355, in the conservative direction.

| Case study | Widest buffer | From |
|---|---|---|
| fx_pairs | 21D | `fwd_ret_21d` |
| cme_futures | 21D | `fwd_ret_21d` |
| crypto_perps_funding | 24H | `fwd_ret_24h` |
| etfs | 21D | `fwd_ret_21d` (its primary) |
| sp500_options | 35D | `ret_to_expiry` |
| us_firm_characteristics | 1M | `fwd_ret_1m` |
| sp500_equity_option_analytics | 10D | `fwd_ret_5d` |
| nasdaq100_microstructure | 60min | `fwd_ret_60m` |
| us_equities_panel | 21D | `fwd_ret_21d` |

This does **not** tighten the outcome-horizon refusal: the maximum is at least each label's own buffer, and the check already compared every label against that, so it can only relax. Asserted across all nine rather than argued.

## Cost

None registered. `holdout_evaluations` and `holdout_staging` are both empty in all nine registries - the holdout is unspent everywhere, so no result depends on the previous derivation.

## Verified

- 68 passed across `test_holdout_boundary.py`, `test_holdout_cv_derivation.py`, `test_modeling_input_lineage.py`, `test_holdout_evaluation_driver.py`
- Both new properties mutation-checked: restoring the per-label buffer fails the widest-buffer test (`21D` vs `1D`); restoring `train_end = holdout_start` fails the seal test with "a 5D buffer seals five sessions, not zero"
- `ruff check`, `ruff format`, pre-commit and the RoboRev pre-push gate clean

## Unblocks

`cs6/fx_pairs-holdout`, whose stage 04 already delegates to `build_holdout_cv` and was refused by the fold-scoped compatibility check. It rebases on this and re-runs.