### PR TITLE
Two finished gate fixes that were written, tested, and never opened

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -619,6 +619,17 @@ def stamp_notebook(
     conflict = contradicts_injected_cell(nb, parameters)
     if conflict:
         raise SystemExit(f"refusing to stamp {nb_path.relative_to(REPO_ROOT)}: {conflict}")
+    if not was_executed(nb):
+        # The gate catches this at commit time as HOLLOW; catching it here names the
+        # step that went wrong while the run is still on screen. The way it happens is
+        # a `jupytext --sync` that rebuilds the .ipynb from a newer .py after the run
+        # and before the stamp, which discards the outputs; nb-run.sh orders the sync
+        # after the stamp for exactly this reason.
+        raise SystemExit(
+            f"refusing to stamp {nb_path.relative_to(REPO_ROOT)}: no code cell carries an "
+            "output or an execution count, so nothing in it was executed. A stamp on this "
+            "would claim a run that left no trace. Execute it, or leave it cleared."
+        )
     stamp = {
         "source_py_blob": git_blob(py),
         "executed_at": datetime.now(UTC).isoformat(),

--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -306,6 +306,39 @@ def declared_sessions(
     return sessions
 
 
+def _reject_label_mismatch(
+    frame: pl.DataFrame, *, case_study: str, label: str, split: str, source: str
+) -> None:
+    """Refuse to check a frame against a label it was not produced under.
+
+    The declared axis is sized by the label's own outcome horizon, so passing the
+    case study's primary label while handing in a variant's predictions produces a
+    small, plausible, entirely spurious gap. Measured in ``crypto_perps_funding``:
+    the 8-hour label declares 2,189 validation sessions and the 24-hour label 2,187,
+    because a decision at 2023-12-31 00:00 realizes inside the holdout under a
+    24-hour horizon and is purged. Checking a 24-hour artifact against the 8-hour
+    label therefore reports exactly two missing sessions and nothing is wrong.
+
+    The mismatch is only visible in one direction from the timestamps themselves - a
+    shorter declared horizon makes the observed frame a strict subset, which no
+    condition here can distinguish from a genuine gap. So it is caught from the
+    frame's own ``label`` column where one exists, and the check is silently skipped
+    where it does not rather than being asserted on absent evidence.
+    """
+    if "label" not in frame.columns:
+        return
+    present = frame.get_column("label").unique().drop_nulls().to_list()
+    if not present or present == [label]:
+        return
+    raise CoverageError(
+        f"{case_study}/{label}/{split} {source}: the frame carries label(s) "
+        f"{sorted(str(v) for v in present)}, not {label!r}. The declared session axis "
+        "is sized by the label's outcome horizon, so checking one label's predictions "
+        "against another's declaration reports a gap that is not there. Pass the label "
+        "the frame was produced under."
+    )
+
+
 def _coverage(
     frame: pl.DataFrame,
     *,
@@ -321,6 +354,8 @@ def _coverage(
             f"{case_study}/{label}/{split} {source}: frame is empty; a check that cannot "
             "run must not read as a pass"
         )
+
+    _reject_label_mismatch(frame, case_study=case_study, label=label, split=split, source=source)
 
     time_col = _time_column(frame.columns)
     windows = _declared_windows(case_study, label, split)

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -320,3 +320,40 @@ def test_sessions_outside_every_declared_window_are_a_gap(case_dir):
     )
     with pytest.raises(CoverageError, match="belong to no declared|outside the declared"):
         check_backtest_input_coverage(frame, "cs", LABEL, case_dir=case_dir)
+
+
+# A frame checked against the wrong label reports a gap that is not there. Measured in
+# `crypto_perps_funding`: the 8-hour label declares 2,189 validation sessions and the
+# 24-hour label 2,187, because a decision at 2023-12-31 00:00 realizes inside the
+# holdout under a 24-hour horizon and the seal purges it. Checking a 24-hour artifact
+# against the primary 8-hour label therefore reports exactly two missing sessions on a
+# correct result - and a gate that cries wolf on correct artifacts gets switched off.
+
+
+def test_a_frame_carrying_another_label_is_refused(case_dir):
+    frame = _frame().with_columns(pl.lit("fwd_ret_5d").alias("label"))
+    with pytest.raises(CoverageError, match="not 'fwd_ret_1d'"):
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+
+
+def test_a_frame_carrying_the_same_label_passes(case_dir):
+    frame = _frame().with_columns(pl.lit(LABEL).alias("label"))
+    report = check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert report.complete
+
+
+def test_a_frame_with_no_label_column_is_checked_as_before(case_dir):
+    # The cross-check is skipped rather than asserted on absent evidence.
+    report = check_prediction_coverage(_frame(), "cs", LABEL, case_dir=case_dir)
+    assert report.complete
+
+
+def test_a_frame_mixing_labels_is_refused(case_dir):
+    frame = _frame().with_columns(
+        pl.when(pl.col("timestamp").dt.day() <= 10)
+        .then(pl.lit(LABEL))
+        .otherwise(pl.lit("fwd_ret_5d"))
+        .alias("label")
+    )
+    with pytest.raises(CoverageError, match="fwd_ret_5d"):
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -721,3 +721,30 @@ def test_clearing_a_notebook_makes_it_committable(tmp_path) -> None:
         "injected-parameters" in (c.get("metadata", {}).get("tags") or []) for c in written["cells"]
     )
     assert is_cleared(nb)
+
+
+def test_stamp_refuses_a_notebook_that_never_ran(tmp_path, monkeypatch) -> None:
+    """Fail at the stamp, not two steps later at the commit.
+
+    The way an unexecuted notebook gets stamped is a `jupytext --sync` between the run
+    and the stamp: the .py is newer, so the .ipynb is rebuilt from it and the outputs
+    go. Refusing here names the step that went wrong.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    (tmp_path / "nb.py").write_text("# %%\nprint(1)\n", encoding="utf-8")
+    nb = tmp_path / "nb.ipynb"
+    nb.write_text(json.dumps(_notebook([_code("print(1)")])), encoding="utf-8")
+    with pytest.raises(SystemExit, match="nothing in it was executed"):
+        stamp_notebook(nb, "local-uv", parameters={})
+
+
+def test_stamp_accepts_a_notebook_whose_cells_only_have_execution_counts(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    (tmp_path / "nb.py").write_text("# %%\nx = 1\n", encoding="utf-8")
+    cell = _code("x = 1")
+    cell["execution_count"] = 1
+    nb = tmp_path / "nb.ipynb"
+    nb.write_text(json.dumps(_notebook([cell])), encoding="utf-8")
+    assert stamp_notebook(nb, "local-uv", parameters={})["production"] is True


### PR DESCRIPTION
## Why

Both were complete on 2026-08-23, on local branches with no pull request. They sat there for five days. Recovered as part of a sweep of stray work; neither needed any change to apply to current `main`.

## What they do

**Refuse a coverage check against a label the frame was not produced under.** `case_studies/utils/coverage.py` compared coverage without establishing that the frame it was handed was produced under the label being asked about. A mismatch there reports a coverage number for the wrong thing, which reads as a healthy result rather than an error.

**Refuse to stamp a notebook that never ran.** `.github/scripts/notebook_provenance.py` would write a provenance stamp onto a notebook with no execution evidence. A stamp is a claim that the outputs came from a run; one written over a notebook that never ran makes the claim false, and everything downstream that trusts the stamp inherits it.

Each ships its own tests: 80 passed across `tests/test_coverage_gate.py` and `tests/test_notebook_sync.py`.

## Not included

A third branch from the same day, `fix/causal-permutation`, holds the structural fix for the placebo guard at `case_studies/utils/causal.py:721` - the defect RoboRev is still reporting as a Medium against `cs6/us_firm_characteristics`. It conflicts with main across four files because the `us_firm_characteristics` infra split has since touched the same code, so it is being routed to that branch rather than resolved blind here.

## Verified

- 80 passed
- `ruff check`, `ruff format`, pre-commit and the RoboRev pre-push gate clean