### PR TITLE
Two shared-code fixes the panes are blocked on: one completeness predicate, and a holdout boundary that reads back

### DIFF
--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -49,8 +49,14 @@ class CandidateSet:
         member_kind = resolved[0].kind
         if any(member.execution_tier == "preview" for member in resolved):
             raise ValueError("preview results cannot enter a canonical candidate set")
-        if any(not member.complete for member in resolved):
-            raise ValueError("partial results cannot enter a candidate set")
+        partial = [
+            (member.hash, reason)
+            for member in resolved
+            if (reason := member.completeness()) is not None
+        ]
+        if partial:
+            detail = "; ".join(f"{member_hash}: {reason}" for member_hash, reason in partial)
+            raise ValueError(f"partial results cannot enter a candidate set - {detail}")
         if member_kind == "backtest" and any(
             (member.spec().get("decision_artifact") or {}).get("canonical") is False
             for member in resolved

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -6,6 +6,7 @@ import inspect
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import asdict, dataclass
+from datetime import time as dt_time
 from typing import Any
 
 import pandas as pd
@@ -408,6 +409,21 @@ def widest_label_buffer(case_study: str, setup: Mapping[str, Any]) -> tuple[str,
     return widest[1], widest[2]
 
 
+def _boundary_iso(moment: pd.Timestamp) -> str:
+    """Render a fold boundary the way the panel it describes carries its dates.
+
+    A midnight boundary is a date, and writing it as `2023-11-29T00:00:00` says the panel
+    has a time of day that it does not. Every daily panel stores its dates as `Date`, and
+    Polars reads a full ISO datetime into `Date` as null rather than truncating it, so the
+    datetime rendering could not be read back by the consumer it was written for. The time
+    is kept when there is one - `crypto_perps_funding` and `nasdaq100_microstructure` are
+    intraday and their boundaries are not midnight.
+    """
+    if moment.time() == dt_time(0, 0):
+        return moment.date().isoformat()
+    return moment.isoformat()
+
+
 def build_holdout_cv(
     validation_spec: Mapping[str, Any],
     *,
@@ -539,10 +555,10 @@ def build_holdout_cv(
 
     fold = {
         "fold": max(int(entry["fold"]) for entry in folds) + 1,
-        "train_start": train_start.isoformat(),
-        "train_end": train_end.isoformat(),
-        "val_start": pd.Timestamp(holdout_start).isoformat(),
-        "val_end": pd.Timestamp(holdout_end).isoformat(),
+        "train_start": _boundary_iso(train_start),
+        "train_end": _boundary_iso(train_end),
+        "val_start": _boundary_iso(pd.Timestamp(holdout_start)),
+        "val_end": _boundary_iso(pd.Timestamp(holdout_end)),
     }
     identity = value_digest(pl.DataFrame([fold]))
     if identity == validation_cv.get("identity"):

--- a/case_studies/research/models.py
+++ b/case_studies/research/models.py
@@ -112,6 +112,53 @@ def validate_locked_model_run(
     return digest
 
 
+def _boundary_in(value: Any, dtype: Any, date_col: str, name: str) -> Any:
+    """Read one locked-holdout boundary into the dataset's own date dtype.
+
+    Parse, do not cast. Polars will not read a full ISO datetime string into `Date` - it
+    returns null rather than truncating - and a `strict=False` cast turns that parse failure
+    into a null indistinguishable from a boundary that was never recorded. The refusal then
+    named the symptom, "locked holdout CV contains an invalid boundary", for what was a
+    disagreement about rendering: `build_holdout_cv` wrote `2023-11-29T00:00:00` and every
+    case study with a `Date` column - which is every daily panel - could not read it back.
+    A comment here used to say the preset path was safe because it passes ISO strings; both
+    renderings are ISO strings, which is why that read as covering a case it did not.
+    """
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as error:
+            raise ValueError(
+                f"locked holdout boundary {name}={value!r} is not an ISO date or datetime"
+            ) from error
+        if name == "val_end":
+            # A configured end DATE means the whole of that date, and every fold filter
+            # here is `timestamp <= val_end`. On a daily panel the bar already sits at
+            # midnight and the two agree; on an intraday panel every bar of the final
+            # session sorts after midnight, so reading it as an instant drops the whole
+            # session - 38,610 rows on nasdaq100_microstructure the last time this was
+            # got wrong. `_inclusive_end_of` is that rule and reads the configured
+            # string, because "2021-12-31" and "2021-12-31 00:00:00" parse to the same
+            # instant and only the first one means the day. Do not restate it here.
+            from utils.modeling import _inclusive_end_of
+
+            parsed = _inclusive_end_of(value)
+            if dtype == pl.Date:
+                parsed = parsed.date()
+    if dtype == pl.Date and isinstance(parsed, datetime):
+        if parsed.time() != time(0, 0):
+            raise ValueError(
+                f"locked holdout boundary {name}={value!r} carries a time of day, "
+                f"which {date_col} cannot represent"
+            )
+        parsed = parsed.date()
+    read = pl.DataFrame({date_col: [parsed]}).with_columns(pl.col(date_col).cast(dtype)).item()
+    if read is None:
+        raise ValueError(f"locked holdout boundary {name}={value!r} does not read as {dtype}")
+    return read
+
+
 def locked_holdout_split(
     spec: dict[str, Any], dataset: pl.DataFrame, date_col: str, case_study: str
 ) -> dict[str, Any]:
@@ -149,13 +196,9 @@ def locked_holdout_split(
     fold["fold"] = int(fold["fold"])
     dtype = dataset.schema[date_col]
     boundaries = {
-        name: pl.DataFrame({date_col: [fold[name]]})
-        .with_columns(pl.col(date_col).cast(dtype, strict=False))
-        .item()
+        name: _boundary_in(fold[name], dtype, date_col, name)
         for name in ("train_start", "train_end", "val_start", "val_end")
     }
-    if any(value is None for value in boundaries.values()):
-        raise ValueError("locked holdout CV contains an invalid boundary")
     if boundaries["train_start"] > boundaries["train_end"]:
         raise ValueError("locked holdout training interval is empty")
     if boundaries["train_end"] >= boundaries["val_start"]:

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -213,7 +213,17 @@ class Result:
 
     @property
     def complete(self) -> bool:
-        return False
+        """Whether this result is whole: registry rows, spec, and artifacts all agree.
+
+        The one predicate. `completeness` answers the same question and says why not,
+        which is what a caller needs in order to report which member failed and in what
+        sense. Every subclass overrides `completeness`, never this.
+        """
+        return self.completeness() is None
+
+    def completeness(self) -> str | None:
+        """None when complete, otherwise one line naming what is missing or disagrees."""
+        return f"{self.kind} {self.hash} has no completeness rule"
 
     def registry_record(self) -> dict[str, Any]:
         table, key = {
@@ -326,16 +336,17 @@ class TrainingResult(Result):
             )
         return [joblib.load(path) for path in paths]
 
-    @property
-    def complete(self) -> bool:
-        if self.identity_version not in SUPPORTED_IDENTITY_VERSIONS or not self.spec():
-            return False
+    def completeness(self) -> str | None:
+        if self.identity_version not in SUPPORTED_IDENTITY_VERSIONS:
+            return f"identity_version {self.identity_version} is not supported"
+        if not self.spec():
+            return "the registry holds no spec for this training run"
         spec_path = self.root / "run_log" / "training" / self.hash / "spec.json"
         try:
             if json.loads(spec_path.read_text()) != self.spec():
-                return False
+                return f"{spec_path} disagrees with the registry spec"
         except (OSError, json.JSONDecodeError):
-            return False
+            return f"{spec_path} is missing or unreadable"
         with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             tables = {
                 row[0]
@@ -364,8 +375,8 @@ class TrainingResult(Result):
                 else []
             )
         if completed_attempt is not None:
-            return True
-        return any(
+            return None
+        if any(
             isinstance(
                 result := Result.open(
                     self.study,
@@ -376,6 +387,11 @@ class TrainingResult(Result):
             )
             and result.complete
             for prediction_hash in prediction_hashes
+        ):
+            return None
+        return (
+            "no completed execution attempt, and none of its "
+            f"{len(prediction_hashes)} prediction sets is complete"
         )
 
 
@@ -394,19 +410,17 @@ class PredictionResult(Result):
                 (self.hash,),
             )
 
-    @property
-    def complete(self) -> bool:
-        from case_studies.utils.artifact_digest import value_digest
-
+    def completeness(self) -> str | None:
         coverage = self.coverage()
         prediction_file = self.root / "run_log" / "predictions" / self.hash / "predictions.parquet"
-        if (
-            self.identity_version not in SUPPORTED_IDENTITY_VERSIONS
-            or not coverage
-            or coverage["status"] != "complete"
-            or not prediction_file.is_file()
-        ):
-            return False
+        if self.identity_version not in SUPPORTED_IDENTITY_VERSIONS:
+            return f"identity_version {self.identity_version} is not supported"
+        if not coverage:
+            return "no prediction_coverage row"
+        if coverage["status"] != "complete":
+            return f"prediction_coverage.status is {coverage['status']!r}, not 'complete'"
+        if not prediction_file.is_file():
+            return f"{prediction_file} is missing"
         # artifact_digest arrived as a nullable column on an existing table, so rows
         # registered before it exists carry NULL and there is nothing to compare
         # against. register_prediction_set reads that NULL as "legacy, backfill it"
@@ -418,9 +432,9 @@ class PredictionResult(Result):
         if recorded_digest:
             try:
                 if _verified_digest(prediction_file, self.load) != recorded_digest:
-                    return False
+                    return f"{prediction_file} does not match its recorded digest"
             except (OSError, ValueError, pl.exceptions.PolarsError):
-                return False
+                return f"{prediction_file} could not be read to verify its digest"
         with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             headline = db.execute(
                 "SELECT 1 FROM prediction_metrics WHERE prediction_hash = ?", (self.hash,)
@@ -428,7 +442,14 @@ class PredictionResult(Result):
             fold_count = db.execute(
                 "SELECT COUNT(*) FROM fold_metrics WHERE prediction_hash = ?", (self.hash,)
             ).fetchone()[0]
-        return headline is not None and fold_count == coverage["n_folds_expected"]
+        if headline is None:
+            return "no prediction_metrics row"
+        if fold_count != coverage["n_folds_expected"]:
+            return (
+                f"{fold_count} fold_metrics rows against "
+                f"{coverage['n_folds_expected']} folds expected"
+            )
+        return None
 
     def load(self):
         import polars as pl
@@ -439,26 +460,26 @@ class PredictionResult(Result):
 
 @dataclass(frozen=True)
 class BacktestResult(Result):
-    @property
-    def complete(self) -> bool:
-        from case_studies.utils.artifact_digest import value_digest
-
+    def completeness(self) -> str | None:
         record = self.registry_record()
         spec_path = self.root / "run_log" / "backtest" / self.hash / "spec.json"
         try:
             stored_spec = json.loads(spec_path.read_text())
         except (OSError, json.JSONDecodeError):
-            return False
+            return f"{spec_path} is missing or unreadable"
         stored_spec.pop("_runtime_backtest_config", None)
         if stored_spec != self.spec():
-            return False
+            return f"{spec_path} disagrees with the registry spec"
         prediction = Result.open(
             self.study,
             record["prediction_hash"],
             include_preview=self.execution_tier == ExecutionTier.PREVIEW.value,
         )
-        if not isinstance(prediction, PredictionResult) or not prediction.complete:
-            return False
+        if not isinstance(prediction, PredictionResult):
+            return f"prediction {record['prediction_hash']} is not a registered prediction set"
+        prediction_reason = prediction.completeness()
+        if prediction_reason is not None:
+            return f"its prediction {prediction.hash} is partial: {prediction_reason}"
         returns = self.root / "run_log" / "backtest" / self.hash / "daily_returns.parquet"
         with closing(sqlite3.connect(self.root / "run_log" / "registry.db")) as db:
             metrics = db.execute(
@@ -470,26 +491,31 @@ class BacktestResult(Result):
         # reporting every pre-existing backtest incomplete.
         recorded_digests = record.get("artifact_digests_json")
         if not recorded_digests:
-            return metrics is not None and returns.is_file()
+            if metrics is None:
+                return "no backtest_metrics row"
+            if not returns.is_file():
+                return f"{returns} is missing"
+            return None
         try:
             artifact_digests = json.loads(recorded_digests)
         except (json.JSONDecodeError, TypeError):
-            return False
-        if (
-            not isinstance(artifact_digests, dict)
-            or "daily_returns.parquet" not in artifact_digests
-        ):
-            return False
+            return "backtest_runs.artifact_digests_json is not readable JSON"
+        if not isinstance(artifact_digests, dict):
+            return "backtest_runs.artifact_digests_json is not an object"
+        if "daily_returns.parquet" not in artifact_digests:
+            return "backtest_runs.artifact_digests_json records no daily_returns.parquet"
         for filename, expected_digest in artifact_digests.items():
             path = returns.parent / filename
             try:
                 if not path.is_file():
-                    return False
+                    return f"{path} is missing"
                 if _verified_digest(path, partial(pl.read_parquet, path)) != expected_digest:
-                    return False
+                    return f"{path} does not match its recorded digest"
             except (OSError, ValueError, pl.exceptions.PolarsError):
-                return False
-        return metrics is not None
+                return f"{path} could not be read to verify its digest"
+        if metrics is None:
+            return "no backtest_metrics row"
+        return None
 
 
 class ResultsCatalog:
@@ -591,6 +617,33 @@ class ResultsCatalog:
         )
         assert isinstance(result, PredictionResult)
         return result
+
+    def partial_members(
+        self, result_hashes, *, include_preview: bool = False
+    ) -> list[tuple[str, str]]:
+        """The hashes among `result_hashes` that are not whole, each with its reason.
+
+        Guard a freeze with this, not with the `complete` column that `table()` carries.
+        The column is derived from the registry alone: it asserts that the identity is
+        current, that coverage says complete, that the metric rows are there and the fold
+        count matches, and that the artifact file exists. `Result.complete` asserts all of
+        that and then reads disk - spec.json against the registry spec, every recorded
+        artifact digest against the file, and, for a backtest, the same of the prediction
+        it ran on. The column is therefore necessary and not sufficient, and a notebook
+        guarding on it can pass and still have `CandidateSet.create` refuse the same rows
+        several cells later.
+
+        Reading disk here costs nothing extra: the freeze reads the same files moments
+        later, and `_VERIFIED_ARTIFACT_DIGESTS` memoizes each one. What it buys is the
+        refusal arriving in the cell that can name the rows.
+        """
+        partial = []
+        for result_hash in result_hashes:
+            result = self.open(result_hash, include_preview=include_preview)
+            reason = result.completeness()
+            if reason is not None:
+                partial.append((result_hash, reason))
+        return partial
 
     def open(self, result_hash: str, *, include_preview: bool = False) -> Result:
         return Result.open(self.study, result_hash, include_preview=include_preview)

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -377,3 +377,139 @@ def test_no_case_study_declares_an_outcome_horizon_its_widest_buffer_cannot_cove
                 "buffer any of its labels declares, so its last training label resolves "
                 "inside the holdout"
             )
+
+
+def test_a_midnight_boundary_is_written_as_a_date_because_the_panel_carries_dates() -> None:
+    """`2023-11-29T00:00:00` cannot be read back into a `Date` column - Polars returns null.
+
+    Every daily panel stores its dates as `Date`, so a datetime rendering made the derived
+    fold unreadable by the consumer it was written for, and the refusal named the symptom
+    ("locked holdout CV contains an invalid boundary") rather than the format.
+    """
+    fold = _fold(build_holdout_cv(_validation_spec(), case_study="fx_pairs", timeline=SESSIONS))
+
+    for name in ("train_start", "train_end", "val_start", "val_end"):
+        assert "T" not in fold[name], (
+            f"{name}={fold[name]!r} carries a time of day that a daily panel cannot represent"
+        )
+        assert pd.Timestamp(fold[name]).time() == pd.Timestamp("00:00:00").time()
+
+
+def _daily_panel() -> Any:
+    import polars as pl
+
+    dates = pd.date_range("2011-01-04", "2025-12-31", freq="B")
+    return pl.DataFrame({"timestamp": [d.date() for d in dates], "symbol": ["EURUSD"] * len(dates)})
+
+
+def _holdout_spec(**boundaries: str) -> dict[str, Any]:
+    return {
+        "label": "fwd_ret_1d",
+        "computation": {
+            "cv": {
+                "split": "holdout",
+                "folds": [{"fold": 8, **boundaries}],
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "rendering",
+    [
+        pytest.param(
+            {
+                "train_start": "2011-01-04",
+                "train_end": "2023-11-29",
+                "val_start": "2024-01-01",
+                "val_end": "2025-12-31",
+            },
+            id="date",
+        ),
+        pytest.param(
+            {
+                "train_start": "2011-01-04T00:00:00",
+                "train_end": "2023-11-29T00:00:00",
+                "val_start": "2024-01-01T00:00:00",
+                "val_end": "2025-12-31T00:00:00",
+            },
+            id="datetime",
+        ),
+    ],
+)
+def test_the_consumer_reads_either_rendering_of_the_same_midnight_boundary(
+    rendering: dict[str, str],
+) -> None:
+    """Both are ISO strings, and a `strict=False` cast read one of them as null.
+
+    That null was indistinguishable from a boundary that was never recorded, so the
+    refusal said "invalid boundary" for what was a disagreement about format. Parsing
+    makes the consumer robust to whichever rendering a producer sends.
+    """
+    from case_studies.research.models import locked_holdout_split
+
+    resolved = locked_holdout_split(
+        _holdout_spec(**rendering), _daily_panel(), "timestamp", "fx_pairs"
+    )
+    fold = resolved["folds"][0] if "folds" in resolved else resolved
+
+    assert pd.Timestamp(fold["train_end"]) == pd.Timestamp("2023-11-29")
+    assert pd.Timestamp(fold["val_start"]) == pd.Timestamp("2024-01-01")
+
+
+def test_a_boundary_that_is_not_a_date_at_all_is_named_rather_than_read_as_none() -> None:
+    from case_studies.research.models import locked_holdout_split
+
+    with pytest.raises(ValueError, match="not an ISO date or datetime"):
+        locked_holdout_split(
+            _holdout_spec(
+                train_start="the beginning",
+                train_end="2023-11-29",
+                val_start="2024-01-01",
+                val_end="2025-12-31",
+            ),
+            _daily_panel(),
+            "timestamp",
+            "fx_pairs",
+        )
+
+
+def _intraday_panel(tz: str | None) -> Any:
+    import polars as pl
+
+    stamps = pd.date_range("2022-01-01 00:00", "2025-12-31 23:00", freq="h", tz=tz)
+    return pl.DataFrame(
+        {"timestamp": stamps.to_pydatetime().tolist(), "symbol": ["BTCUSDT"] * len(stamps)}
+    )
+
+
+@pytest.mark.parametrize("tz", [None, "UTC"], ids=["naive", "aware"])
+def test_a_date_only_val_end_covers_the_whole_final_session_on_an_intraday_panel(
+    tz: str | None,
+) -> None:
+    """`timestamp <= val_end` at midnight drops every bar of the last session.
+
+    A configured end date means the whole of that date. On a daily panel the bar sits at
+    midnight and the two readings agree, which is why this only shows on an intraday
+    panel - and it cost nasdaq100_microstructure 38,610 rows the last time it was missed.
+    """
+    from case_studies.research.models import locked_holdout_split
+
+    panel = _intraday_panel(tz)
+    resolved = locked_holdout_split(
+        _holdout_spec(
+            train_start="2022-01-01T00:00:00",
+            train_end="2023-12-30T23:00:00",
+            val_start="2024-01-01",
+            val_end="2025-12-31",
+        ),
+        panel,
+        "timestamp",
+        "fx_pairs",
+    )
+    fold = resolved["folds"][0] if "folds" in resolved else resolved
+    val_end = pd.Timestamp(fold["val_end"])
+
+    assert val_end > pd.Timestamp("2025-12-31 23:00", tz=tz), (
+        f"val_end={val_end} excludes the final session's own bars"
+    )

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -626,3 +626,72 @@ def test_fitted_states_come_back_in_fold_order_not_filename_order(tmp_path: Path
 
     assert isinstance(reopened, TrainingResult)
     assert [state["fold"] for state in reopened.fitted_states()] == list(range(12))
+
+
+def test_the_refusal_names_the_partial_member_and_the_sense_it_is_partial_in(
+    tmp_path: Path,
+) -> None:
+    """`partial results cannot enter a candidate set` used to name neither."""
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    partial = study.results.publish_predictions(
+        training,
+        checkpoint_kind="epoch",
+        checkpoint_value=1,
+        split="validation",
+        predictions=frame.head(1),
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+        allow_partial=True,
+    )
+    with pytest.raises(ValueError) as raised:
+        CandidateSet.create(study, "partial", [partial])
+    message = str(raised.value)
+    assert partial.hash in message, "the refusal must say which member"
+    assert "coverage" in message or "fold_metrics" in message, (
+        f"the refusal must say in which sense, got: {message}"
+    )
+
+
+def test_the_catalog_column_is_necessary_and_not_sufficient(tmp_path: Path) -> None:
+    """The registry column can say complete where the on-disk check says otherwise.
+
+    This is the disagreement that made a notebook's own guard pass at one cell and the
+    freeze refuse the same rows at another. The column reads the registry only; deleting
+    the artifact leaves every registry row it inspects untouched.
+    """
+    study = _study(tmp_path)
+    training = study.results.register_training(_training_spec())
+    frame = _predictions()
+    prediction = study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+    assert prediction.complete
+    assert study.results.partial_members([prediction.hash]) == []
+
+    artifact = (
+        study.storage_root("canonical")
+        / "run_log"
+        / "predictions"
+        / prediction.hash
+        / "predictions.parquet"
+    )
+    assert artifact.is_file()
+    artifact.unlink()
+
+    reopened = Result.open(study, prediction.hash)
+    reason = reopened.completeness()
+    assert reason is not None, "an absent artifact is not a complete result"
+    assert str(artifact) in reason, f"the reason must name the file, got: {reason}"
+
+    partial = study.results.partial_members([prediction.hash])
+    assert [member_hash for member_hash, _ in partial] == [prediction.hash]
+
+    with pytest.raises(ValueError) as raised:
+        CandidateSet.create(study, "gone", [reopened])
+    assert prediction.hash in str(raised.value)


### PR DESCRIPTION
Two defects in shared research code that between them keep every case study from locking a holdout and make a freeze refuse rows a notebook's own guard just passed. Closes ml4t/agent-workspace#958.

## 1. The catalog's `complete` column and `Result.complete` are different predicates

`ResultsCatalog.table()` carries a `complete` column derived from the registry alone: identity current, coverage status complete, metric rows present, fold count matching, artifact file existing. `CandidateSet.create` refuses on `Result.complete`, which asserts all of that and then reads disk - `spec.json` against the registry spec, every recorded artifact digest against the file, and, for a backtest, the same of the prediction it ran on.

The column is therefore necessary and not sufficient. When the two disagree the notebook's guard passes and the freeze refuses the same rows later, naming neither which member was partial nor which of the two senses it failed in. Observed on `cs-crypto_perps_funding`: every row passes the catalog guard at cell 13 of `13_backtest`, and cell 26 of `14_portfolio_management` raises.

- `Result.completeness()` returns `None` or one line saying what is missing or disagrees, on all three subclasses. `complete` is now `completeness() is None` on the base class, so the boolean and the diagnosis cannot drift apart the way two hand-written predicates did. **No change to what counts as complete.**
- `CandidateSet.create` names every partial member and its reason.
- `ResultsCatalog.partial_members()` gives a notebook the predicate the freeze will apply. Reading disk there costs nothing extra - the freeze reads the same files moments later and `_VERIFIED_ARTIFACT_DIGESTS` memoizes each one. What it buys is the refusal arriving in the cell that can name the rows.

## 2. A locked holdout boundary could not be read back

`build_holdout_cv` rendered every fold boundary with `pd.Timestamp.isoformat()`, so a midnight boundary went into the spec as `2023-11-29T00:00:00`. Polars will not read a full ISO datetime into a `Date` column - it returns null rather than truncating - and `locked_holdout_split` cast with `strict=False`, which turned that parse failure into a null indistinguishable from a boundary that was never recorded. The refusal then said `locked holdout CV contains an invalid boundary`: the symptom, for a disagreement about format.

Every daily panel stores its dates as `Date`, so **no case study with a daily cadence could lock**. Found by the fx_pairs pane running `17` against the derivation #653 landed.

**The holdout is unspent.** The refusal fires inside `_rekey_holdout_spec`, before `lifecycle.lock`. `research_locks`, `holdout_staging` and `holdout_evaluations` are 0 in all nine registries but for one staged - not evaluated - lock on `sp500_equity_option_analytics`.

- `locked_holdout_split` parses rather than casts, so it reads either rendering and names the value when a string is not a date at all.
- `build_holdout_cv` writes a midnight boundary as a date, because that is what the panel it describes carries. A time is kept when there is one.
- A date-only `val_end` widens to the whole of that date, via the repository's own `_inclusive_end_of` rather than a fourth construction of the same rule. Both intraday case studies configure `holdout_end` as a bare date, every fold filter is `timestamp <= val_end`, and every bar of the final session sorts after midnight - so reading it as an instant drops the session. That cost `nasdaq100_microstructure` 38,610 rows the last time it was got wrong, and the parse in this PR would have reintroduced it. **Raised by the RoboRev gate on the first push of this branch**, which is the gate doing exactly its job.

A comment under the old refusal said the preset CV path was safe because it passes ISO strings. Both renderings are ISO strings, which is why it read as covering a case it did not.

The rendering is part of the fold identity digest, so a derived holdout spec hashes differently than it did. Nothing registered depends on it.

## What is deliberately not here

Converting each notebook's freeze guard from the `complete` column to `partial_members`. Those guards sit in more than twenty notebooks across six case studies and every conversion is an executable change that costs a re-run. It is a checklist item for each notebook's own pass.

## Verification

- **130 passed, 2 skipped** across `test_holdout_cv_derivation`, `test_holdout_boundary`, `test_locked_holdout_execution`, `test_holdout_evaluation_driver`, `test_modeling_input_lineage`, `test_research_registry`; plus 105 across the four research suites for the first commit.
- **Seven new tests, every one mutation-checked** against the specific half it covers: the unnamed refusal fails with `the refusal must say which member`; `partial_members` reading the column instead of the deep check fails with `[] == ['5c72af20d269']`; the datetime rendering fails with `carries a time of day that a daily panel cannot represent`; the `strict=False` cast fails the datetime parametrization on the old `invalid boundary` message and the unparseable-string test on the message it should have produced; `val_end` as a plain instant fails both intraday parametrizations, timezone-aware and naive, with `excludes the final session's own bars`.
- RoboRev: no issues found on the tip.
