### PR TITLE
Say why the coverage bar admitted nothing, instead of returning an empty frame

### DIFF
--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -181,6 +181,78 @@ class BacktestExplorer:
     # best: top backtests at a stage
     # -----------------------------------------------------------------
 
+    def _refuse_if_the_coverage_bar_emptied_it(
+        self,
+        stage: str,
+        label: str | None,
+        prediction_hashes: tuple[str, ...] | list[str] | None,
+    ) -> None:
+        """Raise when backtests exist at this stage but none of them is a complete run.
+
+        `full_coverage_prediction_sql` keeps only rows whose `ic_n_days` equals the maximum
+        for their `(split, family, label)`, and that maximum is the population's, not the
+        backtested subset's. That is deliberate: the bar is how a *complete* run is
+        identified - `reference/CASE_STUDY_PIPELINE.md` section 10, "a result counts only
+        when `n_null == 0` and `ic_n_days == max`" - and it exists because an incomplete run
+        manufactures a false leader. Computing the maximum over only the rows that happen to
+        have backtests would let an incomplete run set its own bar and win whenever no
+        complete run was backtested, which is the exact failure the clause was written for.
+
+        So an empty result here is a true statement: no complete run in this population has
+        a backtest at this stage. It is not, however, the same statement as "there are no
+        backtests", and returning an empty frame says the second. Under a preview reduction
+        the two diverge - etfs measured a scoped population of 6 predictions and 1 backtest
+        whose maximum coverage belonged to a prediction nothing backtested - and a notebook
+        that reads the empty frame as "nothing ran" reports on a comparison that was never
+        possible. Refuse instead, and name the gap.
+        """
+        # Every filter the real query applies EXCEPT the coverage clause, so an empty
+        # result there and a non-empty result here isolates the coverage clause as the
+        # only thing that removed the rows. Dropping one - the family exclusions, or the
+        # zero-trade filter - would report a run excluded for another reason as a coverage
+        # failure and send the reader after the wrong thing. `_filter_active_models` runs
+        # after this point in `best` and cannot be the cause of an empty query result.
+        rows = self._query(
+            f"""
+            SELECT t.family, t.label, pm.ic_n_days, p.prediction_hash
+            FROM backtest_runs b
+            JOIN prediction_sets p ON b.prediction_hash = p.prediction_hash
+            JOIN training_runs t ON p.training_hash = t.training_hash
+            LEFT JOIN backtest_metrics bm ON bm.backtest_hash = b.backtest_hash
+            LEFT JOIN prediction_metrics pm ON p.prediction_hash = pm.prediction_hash
+            WHERE b.stage = ?
+              AND p.split != 'holdout'
+              {excluded_family_sql(self.case_study, "t.family")[0]}
+              AND bm.sharpe IS NOT NULL
+              AND (bm.num_trades IS NULL OR bm.num_trades > 0)
+              {" AND t.label = ?" if label else ""}
+              {
+                " AND p.prediction_hash IN (" + ", ".join("?" for _ in prediction_hashes) + ")"
+                if prediction_hashes
+                else ""
+            }
+            """,
+            (
+                stage,
+                *excluded_family_sql(self.case_study, "t.family")[1],
+                *([label] if label else []),
+                *(prediction_hashes or ()),
+            ),
+        )
+        if rows.is_empty():
+            return
+        detail = ", ".join(
+            f"{family}/{row_label} {hash_} covers {days if days is not None else 'no'} days"
+            for family, row_label, days, hash_ in rows.rows()
+        )
+        raise RuntimeError(
+            f"every backtest at stage {stage!r} sits below its family's coverage bar, so the "
+            f"complete-run filter admits none of them: {detail}. The bar is the population's "
+            f"maximum ic_n_days, which is what makes a run complete - an incomplete run "
+            f"compared as complete manufactures a false leader. Backtest a maximum-coverage "
+            f"prediction, or say in the notebook that this population supports no comparison."
+        )
+
     def best(
         self,
         stage: str = "signal",
@@ -262,6 +334,7 @@ class BacktestExplorer:
             ),
         )
         if df.is_empty():
+            self._refuse_if_the_coverage_bar_emptied_it(stage, label, prediction_hashes)
             return pl.DataFrame(schema=_BEST_SCHEMA)
         df = self._filter_active_models(df)
         if df.is_empty():

--- a/tests/test_full_coverage_selection.py
+++ b/tests/test_full_coverage_selection.py
@@ -435,3 +435,61 @@ def test_fold_metric_backfill_is_restricted_to_requested_label(tmp_path, monkeyp
 
     assert count == 1
     assert seen == ["bt_full_a"]
+
+
+def test_a_population_whose_only_backtested_run_is_incomplete_refuses(tmp_path) -> None:
+    """An empty frame here says "no backtests"; the truth is "no COMPLETE run was backtested".
+
+    etfs measured this under a preview reduction: a scoped population of six predictions and
+    one backtest, where the maximum coverage belonged to a prediction nothing had backtested.
+    The bar is the population's maximum `ic_n_days`, deliberately - that is what makes a run
+    complete, and computing it over only the backtested rows would let an incomplete run set
+    its own bar and win. So the filter is right to admit nothing, and wrong to say nothing.
+    """
+    import pytest
+
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        # full_a is the coverage bar for gbm/fwd_ret_5d at 4.0 days. Take away its backtest
+        # and the scoped population below has a bar no backtested member can reach.
+        db.execute("DELETE FROM backtest_runs WHERE backtest_hash = 'bt_full_a'")
+        db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = 'bt_full_a'")
+    explorer = BacktestExplorer("test", case_dir=case_dir)
+
+    with pytest.raises(RuntimeError) as raised:
+        explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["partial", "full_a"])
+    message = str(raised.value)
+    assert "coverage bar" in message
+    assert "partial" in message, f"the refusal must name the run it rejected, got: {message}"
+
+    # The same population with its complete member backtested still resolves, and a
+    # population with no backtests at all is still an ordinary empty answer.
+    assert explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["full_b"])[
+        "prediction_hash"
+    ].to_list() == ["full_b"]
+    assert explorer.best(top_n=10, label="fwd_ret_5d", prediction_hashes=["nothing"]).is_empty()
+
+
+def test_an_empty_result_from_another_filter_is_not_blamed_on_the_coverage_bar(
+    tmp_path,
+) -> None:
+    """The refusal must isolate the coverage clause, or it sends the reader after the wrong thing.
+
+    `best` also drops runs that traded nothing and families the case study excludes. If the
+    diagnostic query does not mirror those, a population emptied by one of them is reported
+    as a coverage failure.
+    """
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("DELETE FROM backtest_runs WHERE backtest_hash = 'bt_full_a'")
+        db.execute("DELETE FROM backtest_metrics WHERE backtest_hash = 'bt_full_a'")
+        # The one remaining backtested member of the population traded nothing, so `best`
+        # drops it for that reason - not because it sits below the bar.
+        db.execute("UPDATE backtest_metrics SET num_trades = 0 WHERE backtest_hash = 'bt_partial'")
+    explorer = BacktestExplorer("test", case_dir=case_dir)
+
+    assert explorer.best(
+        top_n=10, label="fwd_ret_5d", prediction_hashes=["partial", "full_a"]
+    ).is_empty()


### PR DESCRIPTION
Answers the question etfs handed back: should `full_coverage_prediction_sql` take its maximum over the scoped population, or over only the scoped rows that have backtests?

## The answer is the population, and it already does

That maximum is what makes a run **complete**. `reference/CASE_STUDY_PIPELINE.md` section 10: *a result counts only when `n_null == 0` and `ic_n_days == max`*, and section 8 says why the bar is there - *an incomplete run manufactures a false leader*.

Computing the maximum over only the backtested rows would let an incomplete run set its own bar and win whenever no complete run had been backtested. That is precisely the failure the clause was written to prevent.

**So no change to the SQL, and no change to what any of the nine case studies select.**

## What was actually wrong

`best` returned an empty frame in two situations that mean different things:

- no backtests exist at this stage, and
- no *complete* run among them does.

Under a preview reduction the two diverge. etfs measured a scoped population of six predictions and one backtest whose maximum coverage belonged to a prediction nothing had backtested: the filter admitted nothing, and the notebook read it as "nothing ran". A true and unusual statement was delivered as silence.

`best` now refuses when there **are** backtests at the stage and every one sits below its family's bar, naming each run and its coverage. Two things it does not change:

- a population with no backtests at all is still an ordinary empty answer;
- a population whose only member is incomplete still resolves to that member. Its own coverage is its own bar, and there is nothing it is being compared against.

## The diagnostic query mirrors every filter but the coverage clause

An empty result in the real query and a non-empty result in the diagnostic one isolates the coverage clause as the only thing that removed the rows. Dropping one of the others - the family exclusions, or the zero-trade filter - would report a run excluded for a different reason as a coverage failure and send the reader after the wrong thing.

**RoboRev raised this on the first push of this branch**, as a non-blocking finding that was correct.

## Verification

- **57 passed** across `test_full_coverage_selection.py`, `test_canonical_coverage_bar.py`, `test_canonical_coverage_days.py`, `test_coverage_gate.py`.
- Both new tests mutation-checked: removing the refusal fails the first with `DID NOT RAISE`; dropping the zero-trade filter from the diagnostic query fails the second by blaming the coverage bar for a run that traded nothing.
- The first test asserts both directions, so it cannot pass by refusing everything.