### PR TITLE
Digest a fold-scoped artifact per fold, and record what one artifact kept from another

### DIFF
--- a/case_studies/utils/artifact_digest.py
+++ b/case_studies/utils/artifact_digest.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -52,12 +53,25 @@ def digest_sidecar(
     keys: Sequence[str],
     written_by: str,
     inputs: Mapping[str, str] | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ) -> dict:
-    """Build the sidecar record for *df* without writing it."""
+    """Build the sidecar record for *df* without writing it.
+
+    ``metadata`` carries producer facts a reader cannot recover from the frame. The one
+    that needs it is ``fold_geometry``: ``temporal_artifact_fold_boundaries`` reads it
+    when the sidecar carries it, and otherwise regenerates the fold set by calling
+    ``generate_cv_splits`` - which returns the cross-validation folds and nothing else, so
+    an artifact carrying a fold that routine does not produce has that fold invisible to
+    every consumer. The frame states which fold ids exist and never states what their
+    boundaries were.
+
+    Reserved keys are refused rather than merged. A caller that could overwrite ``digest``
+    or ``n_rows`` could make a sidecar describe a file it was not computed from.
+    """
     missing = [k for k in keys if k not in df.columns]
     if missing:
         raise KeyError(f"key columns not in frame: {missing}")
-    return {
+    record = {
         "digest": value_digest(df),
         "n_rows": df.height,
         "columns": sorted(df.columns),
@@ -65,6 +79,14 @@ def digest_sidecar(
         "written_by": written_by,
         "inputs": dict(inputs or {}),
     }
+    if metadata:
+        reserved = sorted(set(metadata) & set(record))
+        if reserved:
+            raise ValueError(
+                f"sidecar metadata may not redefine the record's own fields: {reserved}"
+            )
+        record.update(dict(metadata))
+    return record
 
 
 def write_artifact(
@@ -74,14 +96,16 @@ def write_artifact(
     keys: Sequence[str],
     written_by: str,
     inputs: Mapping[str, str] | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ) -> dict:
     """Write *df* to *path* as parquet with its digest sidecar beside it.
 
     Returns the sidecar record, whose ``digest`` is what a downstream stage
-    passes back as one of its own ``inputs``.
+    passes back as one of its own ``inputs``. ``metadata`` is passed through to
+    :func:`digest_sidecar`.
     """
     path = Path(path)
-    record = digest_sidecar(df, keys=keys, written_by=written_by, inputs=inputs)
+    record = digest_sidecar(df, keys=keys, written_by=written_by, inputs=inputs, metadata=metadata)
     path.parent.mkdir(parents=True, exist_ok=True)
     df.write_parquet(path)
     sidecar_path(path).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")

--- a/case_studies/utils/artifact_digest.py
+++ b/case_studies/utils/artifact_digest.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,25 @@ def value_digest(df: pl.DataFrame, columns: Sequence[str] | None = None) -> str:
         {"columns": cols, "rows": hashlib.sha256(row_hashes).hexdigest()},
     )
     return compute_hash(content, length=DIGEST_LENGTH)
+
+
+def _json_ready(value: Any) -> Any:
+    """Render dates and times as ISO strings, recursively, leaving everything else alone.
+
+    Fold boundaries arrive as ``datetime.date`` or ``pandas.Timestamp`` because that is what
+    the producers hold them as, and ``json.dumps`` refuses both. Coercing here rather than
+    asking every caller to stringify keeps the sidecar's dates in one format, which is the
+    format ``temporal_artifact_fold_boundaries`` already parses.
+    """
+    if isinstance(value, Mapping):
+        return {str(k): _json_ready(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(v) for v in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):  # pandas.Timestamp and anything else date-like
+        return str(value.isoformat())
+    return value
 
 
 def digest_sidecar(
@@ -85,7 +105,7 @@ def digest_sidecar(
             raise ValueError(
                 f"sidecar metadata may not redefine the record's own fields: {reserved}"
             )
-        record.update(dict(metadata))
+        record.update(_json_ready(dict(metadata)))
     return record
 
 
@@ -106,9 +126,14 @@ def write_artifact(
     """
     path = Path(path)
     record = digest_sidecar(df, keys=keys, written_by=written_by, inputs=inputs, metadata=metadata)
+    # Rendered before the parquet is written, not after. A record that cannot be serialized
+    # would otherwise raise with the new parquet already on disk beside the previous run's
+    # sidecar - a file and a digest that describe different data, which is the one state
+    # this pair exists to make impossible.
+    serialized = json.dumps(record, indent=2, sort_keys=True) + "\n"
     path.parent.mkdir(parents=True, exist_ok=True)
     df.write_parquet(path)
-    sidecar_path(path).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    sidecar_path(path).write_text(serialized)
     return record
 
 

--- a/case_studies/utils/artifact_digest.py
+++ b/case_studies/utils/artifact_digest.py
@@ -48,6 +48,28 @@ def value_digest(df: pl.DataFrame, columns: Sequence[str] | None = None) -> str:
     return compute_hash(content, length=DIGEST_LENGTH)
 
 
+def fold_digests(df: pl.DataFrame, *, fold_column: str = "fold") -> dict[str, str]:
+    """Return one content digest per fold id in *df*, keyed by the id as a string.
+
+    A fold-scoped artifact is written once per stage-04 run and read by every stage after
+    it, and the reader that matters is the one verifying a holdout lock: the lock pins the
+    artifact by whole-file sha256, so appending the holdout fold - which is the whole reason
+    stage 04 writes a holdout fold at all - changes the pin and the retrain is refused. What
+    the lock actually needs to know is narrower: that the folds it was selected under still
+    hold the values they held. One digest per fold answers that; the whole-file digest cannot.
+
+    Each fold's digest is :func:`value_digest` over that fold's rows, so it moves when and
+    only when a value in that fold moves, and is invariant to row order exactly as the
+    whole-frame digest is.
+    """
+    if fold_column not in df.columns:
+        raise KeyError(f"fold column {fold_column!r} not in frame: {sorted(df.columns)}")
+    return {
+        str(fold): value_digest(df.filter(pl.col(fold_column) == fold))
+        for fold in sorted(df.get_column(fold_column).unique().to_list())
+    }
+
+
 def _json_ready(value: Any) -> Any:
     """Render dates and times as ISO strings, recursively, leaving everything else alone.
 
@@ -74,6 +96,7 @@ def digest_sidecar(
     written_by: str,
     inputs: Mapping[str, str] | None = None,
     metadata: Mapping[str, Any] | None = None,
+    fold_column: str | None = None,
 ) -> dict:
     """Build the sidecar record for *df* without writing it.
 
@@ -84,6 +107,11 @@ def digest_sidecar(
     an artifact carrying a fold that routine does not produce has that fold invisible to
     every consumer. The frame states which fold ids exist and never states what their
     boundaries were.
+
+    ``fold_column`` records a digest per fold beside the whole-frame one - see
+    :func:`fold_digests` for what reads it. It is opt-in rather than inferred from the
+    presence of a ``fold`` column: the record is what a lock is verified against, so which
+    artifacts make a fold-scoped claim is a producer's decision, not a schema coincidence.
 
     Reserved keys are refused rather than merged. A caller that could overwrite ``digest``
     or ``n_rows`` could make a sidecar describe a file it was not computed from.
@@ -99,6 +127,8 @@ def digest_sidecar(
         "written_by": written_by,
         "inputs": dict(inputs or {}),
     }
+    if fold_column is not None:
+        record["fold_digests"] = fold_digests(df, fold_column=fold_column)
     if metadata:
         reserved = sorted(set(metadata) & set(record))
         if reserved:
@@ -117,15 +147,23 @@ def write_artifact(
     written_by: str,
     inputs: Mapping[str, str] | None = None,
     metadata: Mapping[str, Any] | None = None,
+    fold_column: str | None = None,
 ) -> dict:
     """Write *df* to *path* as parquet with its digest sidecar beside it.
 
     Returns the sidecar record, whose ``digest`` is what a downstream stage
-    passes back as one of its own ``inputs``. ``metadata`` is passed through to
-    :func:`digest_sidecar`.
+    passes back as one of its own ``inputs``. ``metadata`` and ``fold_column`` are
+    passed through to :func:`digest_sidecar`.
     """
     path = Path(path)
-    record = digest_sidecar(df, keys=keys, written_by=written_by, inputs=inputs, metadata=metadata)
+    record = digest_sidecar(
+        df,
+        keys=keys,
+        written_by=written_by,
+        inputs=inputs,
+        metadata=metadata,
+        fold_column=fold_column,
+    )
     # Rendered before the parquet is written, not after. A record that cannot be serialized
     # would otherwise raise with the new parquet already on disk beside the previous run's
     # sidecar - a file and a digest that describe different data, which is the one state

--- a/scripts/record_artifact_supersession.py
+++ b/scripts/record_artifact_supersession.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Record, in a new artifact's sidecar, which older artifact it replaces and what survived.
+
+A stage-04 temporal artifact is pinned into every training identity fitted on it by
+whole-file sha256. Appending the holdout fold - which is what a holdout retrain needs the
+artifact to carry - changes that digest, and the lock then refuses the retrain even though
+every fold the configuration was selected under is unchanged. Whether the file was extended
+or rewritten is exactly what a whole-file digest cannot say.
+
+This script says it, once, while both files are still on disk: it verifies the old file
+against the sha256 the lock names, digests each file per fold, and writes into the new
+file's sidecar the old file's sha256 together with the per-fold digests of the folds that
+came through unchanged. The replaced sha256 ties the record to one pin and to no other, so
+a supersession recorded against a different vintage cannot be read as covering this one.
+
+It refuses to record anything if a fold the old file held is missing from the new one or
+holds different values there. That is a replacement, not an extension, and no result
+fitted on the old file may be carried across it.
+
+The record is evidence about a file that will not exist much longer. What consumes it -
+which check admits which retrain - is decided where locks are taken and executed, not
+here; this script only makes the answer recordable while it is still knowable.
+
+Usage:
+    uv run python scripts/record_artifact_supersession.py \
+        --superseded ~/ml4t/preserved/.../model_based.parquet \
+        --current case_studies/fx_pairs/features/model_based.parquet \
+        [--expect-sha256 750be334...] [--fold-column fold] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import polars as pl
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from case_studies.utils.artifact_digest import (  # noqa: E402
+    fold_digests,
+    read_digest,
+    sidecar_path,
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as src:
+        for chunk in iter(lambda: src.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--superseded", type=Path, required=True, help="the artifact being replaced"
+    )
+    parser.add_argument("--current", type=Path, required=True, help="the artifact now in place")
+    parser.add_argument(
+        "--expect-sha256",
+        help="refuse unless the superseded file hashes to this - paste it from the lock",
+    )
+    parser.add_argument("--fold-column", default="fold")
+    parser.add_argument("--dry-run", action="store_true", help="report, write nothing")
+    args = parser.parse_args()
+
+    old_path, new_path = args.superseded.expanduser(), args.current.expanduser()
+    for path in (old_path, new_path):
+        if not path.is_file():
+            print(f"error: {path} is not a file", file=sys.stderr)
+            return 1
+    if old_path.resolve() == new_path.resolve():
+        print("error: an artifact cannot supersede itself", file=sys.stderr)
+        return 1
+
+    old_sha = sha256_file(old_path)
+    if args.expect_sha256 and old_sha != args.expect_sha256:
+        print(
+            f"error: {old_path} hashes to {old_sha}, not the expected {args.expect_sha256}. "
+            "This is not the artifact the lock pins.",
+            file=sys.stderr,
+        )
+        return 1
+
+    old_folds = fold_digests(pl.read_parquet(old_path), fold_column=args.fold_column)
+    new_folds = fold_digests(pl.read_parquet(new_path), fold_column=args.fold_column)
+
+    missing = sorted(fold for fold in old_folds if fold not in new_folds)
+    changed = sorted(
+        fold
+        for fold, digest in old_folds.items()
+        if fold in new_folds and new_folds[fold] != digest
+    )
+    if missing or changed:
+        if missing:
+            print(f"error: folds {missing} are in {old_path.name} and not in {new_path.name}")
+        if changed:
+            print(f"error: folds {changed} hold different values in {new_path.name}")
+        print(
+            "This file replaces the pinned artifact rather than extending it, so no lock "
+            "fitted on the old one may be reconstructed against it. Nothing was written.",
+            file=sys.stderr,
+        )
+        return 1
+
+    added = sorted(set(new_folds) - set(old_folds), key=lambda fold: (len(fold), fold))
+    record = read_digest(new_path)
+    record["supersedes"] = {"sha256": old_sha, "fold_digests": old_folds}
+    record.setdefault("fold_digests", new_folds)
+
+    print(f"superseded: {old_path}  sha256 {old_sha[:12]}  folds {sorted(old_folds)}")
+    print(f"current:    {new_path}  folds {sorted(new_folds)}")
+    print(f"unchanged:  {sorted(old_folds)}")
+    print(f"added:      {added or 'none'}")
+    if args.dry_run:
+        print("--dry-run: sidecar not written")
+        return 0
+    sidecar_path(new_path).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {sidecar_path(new_path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/record_artifact_supersession.py
+++ b/scripts/record_artifact_supersession.py
@@ -75,11 +75,18 @@ def main() -> int:
         if not path.is_file():
             print(f"error: {path} is not a file", file=sys.stderr)
             return 1
-    if old_path.resolve() == new_path.resolve():
-        print("error: an artifact cannot supersede itself", file=sys.stderr)
+    old_sha, new_sha = sha256_file(old_path), sha256_file(new_path)
+    if old_sha == new_sha:
+        # Identity is the digest, not the path. Two byte-identical files are one artifact to
+        # every lock that pins one, so an edge from that digest to itself asserts a
+        # supersession that did not happen and names no replaced vintage.
+        print(
+            f"error: {old_path} and {new_path} are the same artifact ({old_sha[:12]}); "
+            "an artifact cannot supersede itself",
+            file=sys.stderr,
+        )
         return 1
 
-    old_sha = sha256_file(old_path)
     if args.expect_sha256 and old_sha != args.expect_sha256:
         print(
             f"error: {old_path} hashes to {old_sha}, not the expected {args.expect_sha256}. "

--- a/tests/test_artifact_digest.py
+++ b/tests/test_artifact_digest.py
@@ -8,7 +8,9 @@ failure modes are silent, so both are tested.
 from __future__ import annotations
 
 import json
+from datetime import date
 
+import pandas as pd
 import polars as pl
 import pytest
 
@@ -136,6 +138,56 @@ def test_metadata_reaches_the_sidecar_and_the_reader_that_needs_it(
     # The record's own fields survive the merge rather than being displaced by it.
     assert record["digest"] == value_digest(frame)
     assert record["n_rows"] == frame.height
+
+
+def test_real_date_boundaries_reach_the_sidecar_as_iso_strings(
+    frame: pl.DataFrame, tmp_path
+) -> None:
+    """Producers hold fold boundaries as dates, and `json.dumps` refuses them.
+
+    Serializing after the parquet was written would leave the new file beside the previous
+    run's sidecar - a file and a digest describing different data.
+    """
+    geometry = [
+        {
+            "fold": 8,
+            "train_start": date(2011, 1, 5),
+            "train_end": pd.Timestamp("2023-11-29"),
+            "val_start": date(2024, 1, 1),
+            "val_end": date(2025, 12, 31),
+        }
+    ]
+    path = tmp_path / "features" / "model_based.parquet"
+    record = write_artifact(
+        frame,
+        path,
+        keys=["timestamp", "symbol"],
+        written_by="04_model_based_features",
+        metadata={"fold_geometry": geometry},
+    )
+
+    written = read_digest(path)["fold_geometry"][0]
+    assert written["train_start"] == "2011-01-05"
+    assert written["train_end"].startswith("2023-11-29")
+    assert written["val_end"] == "2025-12-31"
+    assert written["fold"] == 8
+    assert record["fold_geometry"][0]["train_start"] == "2011-01-05"
+
+
+def test_an_unserializable_record_leaves_no_parquet_without_its_sidecar(
+    frame: pl.DataFrame, tmp_path
+) -> None:
+    path = tmp_path / "features" / "model_based.parquet"
+    with pytest.raises(TypeError):
+        write_artifact(
+            frame,
+            path,
+            keys=["timestamp", "symbol"],
+            written_by="04_model_based_features",
+            metadata={"producer": object()},
+        )
+    assert not path.exists()
+    assert not sidecar_path(path).exists()
 
 
 def test_metadata_may_not_redefine_the_record_it_is_merged_into(frame: pl.DataFrame) -> None:

--- a/tests/test_artifact_digest.py
+++ b/tests/test_artifact_digest.py
@@ -100,3 +100,62 @@ def test_write_artifact_round_trips(frame: pl.DataFrame, tmp_path) -> None:
     assert json.loads(sidecar_path(path).read_text())["digest"] == value_digest(
         pl.read_parquet(path)
     )
+
+
+def test_metadata_reaches_the_sidecar_and_the_reader_that_needs_it(
+    frame: pl.DataFrame, tmp_path
+) -> None:
+    """A fold `generate_cv_splits` does not produce is invisible without this.
+
+    `temporal_artifact_fold_boundaries` reads `fold_geometry` off the sidecar when it is
+    there and otherwise regenerates the fold set from the label timeline, which yields the
+    cross-validation folds alone. A stage-04 artifact carrying a holdout fold therefore
+    exposes eight folds to every consumer while the parquet holds nine, and nothing in the
+    frame says what any fold's boundaries were.
+    """
+    geometry = [
+        {
+            "fold": 8,
+            "train_start": "2011-01-05",
+            "train_end": "2023-11-29",
+            "val_start": "2024-01-01",
+            "val_end": "2025-12-31",
+        }
+    ]
+    path = tmp_path / "features" / "model_based.parquet"
+    record = write_artifact(
+        frame,
+        path,
+        keys=["timestamp", "symbol"],
+        written_by="04_model_based_features",
+        metadata={"fold_geometry": geometry},
+    )
+
+    assert record["fold_geometry"] == geometry
+    assert read_digest(path)["fold_geometry"] == geometry
+    # The record's own fields survive the merge rather than being displaced by it.
+    assert record["digest"] == value_digest(frame)
+    assert record["n_rows"] == frame.height
+
+
+def test_metadata_may_not_redefine_the_record_it_is_merged_into(frame: pl.DataFrame) -> None:
+    """Overwriting `digest` would let a sidecar describe a file it was not computed from."""
+    with pytest.raises(ValueError, match="digest"):
+        digest_sidecar(
+            frame,
+            keys=["timestamp", "symbol"],
+            written_by="02_labels",
+            metadata={"digest": "0" * 16},
+        )
+
+
+def test_absent_metadata_leaves_the_record_exactly_as_it_was(frame: pl.DataFrame) -> None:
+    baseline = digest_sidecar(frame, keys=["timestamp", "symbol"], written_by="02_labels")
+    assert (
+        digest_sidecar(frame, keys=["timestamp", "symbol"], written_by="02_labels", metadata={})
+        == baseline
+    )
+    assert (
+        digest_sidecar(frame, keys=["timestamp", "symbol"], written_by="02_labels", metadata=None)
+        == baseline
+    )

--- a/tests/test_artifact_supersession.py
+++ b/tests/test_artifact_supersession.py
@@ -169,6 +169,19 @@ def test_an_artifact_cannot_supersede_itself(tmp_path):
     assert "cannot supersede itself" in result.stderr
 
 
+def test_two_copies_of_one_artifact_are_one_artifact(tmp_path):
+    """A lock pins a digest, not a path, so identical bytes at two paths supersede nothing."""
+    frame = _frame(range(2))
+    old = _write(frame, tmp_path / "archived" / "model_based.parquet")
+    new = _write(frame, tmp_path / "current" / "model_based.parquet")
+    assert _sha256(old) == _sha256(new)
+
+    result = _record(old, new)
+    assert result.returncode == 1
+    assert "cannot supersede itself" in result.stderr
+    assert "supersedes" not in read_digest(new)
+
+
 def test_the_recorded_block_survives_json_round_tripping(tmp_path):
     old = _write(_frame(range(2)), tmp_path / "old.parquet")
     new = _write(_frame(range(3)), tmp_path / "new.parquet")

--- a/tests/test_artifact_supersession.py
+++ b/tests/test_artifact_supersession.py
@@ -1,0 +1,178 @@
+"""One digest per fold, and the record that says an artifact extended another rather than replacing it.
+
+A stage-04 temporal artifact is pinned into every training identity fitted on it by
+whole-file sha256, so appending the holdout fold a holdout retrain needs moves the pin over
+folds whose every value is unchanged. Whether a new file extended the old one or rewrote it
+is exactly what a whole-file digest cannot say, and it can only be established while both
+files are still on disk. These tests fix what the answer depends on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.utils.artifact_digest import (
+    digest_sidecar,
+    fold_digests,
+    read_digest,
+    value_digest,
+    write_artifact,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RECORDER = REPO_ROOT / "scripts" / "record_artifact_supersession.py"
+
+
+def _frame(folds: range, *, bump: int | None = None) -> pl.DataFrame:
+    """A small fold-scoped frame; ``bump`` perturbs one fold's values and no other's."""
+    return pl.DataFrame(
+        {
+            "fold": [f for f in folds for _ in range(3)],
+            "symbol": [s for _ in folds for s in ("AAA", "BBB", "CCC")],
+            "feature": [
+                float(f * 10 + i) + (100.0 if bump == f else 0.0) for f in folds for i in range(3)
+            ],
+        }
+    )
+
+
+def _write(frame: pl.DataFrame, path: Path) -> Path:
+    write_artifact(frame, path, keys=["fold", "symbol"], written_by="test", fold_column="fold")
+    return path
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _record(old: Path, new: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(RECORDER), "--superseded", str(old), "--current", str(new), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+# --------------------------------------------------------------------------- fold digests
+
+
+def test_fold_digest_moves_only_for_the_fold_whose_values_moved():
+    before = fold_digests(_frame(range(3)))
+    after = fold_digests(_frame(range(3), bump=1))
+    assert set(before) == set(after) == {"0", "1", "2"}
+    assert before["1"] != after["1"]
+    assert before["0"] == after["0"]
+    assert before["2"] == after["2"]
+
+
+def test_fold_digest_is_invariant_to_row_order():
+    frame = _frame(range(2))
+    assert fold_digests(frame) == fold_digests(frame.reverse())
+
+
+def test_appending_a_fold_leaves_every_earlier_fold_digest_alone():
+    two = fold_digests(_frame(range(2)))
+    three = fold_digests(_frame(range(3)))
+    assert {fold: three[fold] for fold in two} == two
+    assert set(three) - set(two) == {"2"}
+
+
+def test_a_single_fold_frame_digests_to_the_frame_digest():
+    """So the per-fold and whole-frame definitions cannot drift apart."""
+    frame = _frame(range(1))
+    assert fold_digests(frame) == {"0": value_digest(frame)}
+
+
+def test_the_sidecar_records_fold_digests_only_when_a_producer_asks():
+    frame = _frame(range(2))
+    assert "fold_digests" not in digest_sidecar(frame, keys=["fold"], written_by="test")
+    asked = digest_sidecar(frame, keys=["fold"], written_by="test", fold_column="fold")
+    assert asked["fold_digests"] == fold_digests(frame)
+
+
+def test_fold_digest_refuses_a_column_the_frame_does_not_have():
+    with pytest.raises(KeyError, match="missing_fold"):
+        fold_digests(_frame(range(2)), fold_column="missing_fold")
+
+
+# ------------------------------------------------------------------ recording a supersession
+
+
+def test_an_appended_fold_is_recorded_as_a_supersession(tmp_path):
+    old = _write(_frame(range(2)), tmp_path / "old.parquet")
+    old_sha, old_folds = _sha256(old), fold_digests(pl.read_parquet(old))
+    new = _write(_frame(range(3)), tmp_path / "new.parquet")
+
+    result = _record(old, new, "--expect-sha256", old_sha)
+    assert result.returncode == 0, result.stderr
+
+    supersedes = read_digest(new)["supersedes"]
+    assert supersedes == {"sha256": old_sha, "fold_digests": old_folds}
+    assert "2" not in supersedes["fold_digests"]
+
+
+def test_a_rewritten_fold_is_refused_and_nothing_is_written(tmp_path):
+    """Gaining fold 2 while fold 1 changes is a replacement, and no lock may treat it as one."""
+    old = _write(_frame(range(2)), tmp_path / "old.parquet")
+    new = _write(_frame(range(3), bump=1), tmp_path / "new.parquet")
+    before = read_digest(new)
+
+    result = _record(old, new)
+    assert result.returncode == 1
+    assert "hold different values" in result.stdout
+    assert read_digest(new) == before
+
+
+def test_a_dropped_fold_is_refused(tmp_path):
+    old = _write(_frame(range(3)), tmp_path / "old.parquet")
+    new = _write(_frame(range(2)), tmp_path / "new.parquet")
+
+    result = _record(old, new)
+    assert result.returncode == 1
+    assert "are in old.parquet and not in new.parquet" in result.stdout
+    assert "supersedes" not in read_digest(new)
+
+
+def test_the_expected_sha256_is_what_ties_the_record_to_one_pin(tmp_path):
+    """Paste the digest from the lock, and a differently-vintaged file cannot be recorded."""
+    old = _write(_frame(range(2)), tmp_path / "old.parquet")
+    new = _write(_frame(range(3)), tmp_path / "new.parquet")
+
+    result = _record(old, new, "--expect-sha256", "0" * 64)
+    assert result.returncode == 1
+    assert "not the artifact the lock pins" in result.stderr
+    assert "supersedes" not in read_digest(new)
+
+
+def test_a_dry_run_reports_without_writing(tmp_path):
+    old = _write(_frame(range(2)), tmp_path / "old.parquet")
+    new = _write(_frame(range(3)), tmp_path / "new.parquet")
+
+    result = _record(old, new, "--dry-run")
+    assert result.returncode == 0, result.stderr
+    assert "added:      ['2']" in result.stdout
+    assert "supersedes" not in read_digest(new)
+
+
+def test_an_artifact_cannot_supersede_itself(tmp_path):
+    only = _write(_frame(range(2)), tmp_path / "only.parquet")
+    result = _record(only, only)
+    assert result.returncode == 1
+    assert "cannot supersede itself" in result.stderr
+
+
+def test_the_recorded_block_survives_json_round_tripping(tmp_path):
+    old = _write(_frame(range(2)), tmp_path / "old.parquet")
+    new = _write(_frame(range(3)), tmp_path / "new.parquet")
+    assert _record(old, new).returncode == 0
+    sidecar = json.loads((tmp_path / "new.parquet.digest.json").read_text())
+    assert sidecar["fold_digests"] == fold_digests(pl.read_parquet(new))
+    assert set(sidecar["supersedes"]["fold_digests"]) == {"0", "1"}


### PR DESCRIPTION
Stage 04 writes model-based features per fold, and the artifact is pinned into every training identity fitted on it by whole-file sha256. Writing the holdout fold that a holdout retrain needs moves that pin - over folds whose every value is unchanged. Nothing in a whole-file digest separates a file that was extended from one that was rewritten, and the difference can only be established while both files are still on disk.

Two things, so it is recordable there.

**`fold_digests`** computes one content digest per fold, on the same order-invariant definition as the whole-frame digest. `digest_sidecar` records them when a producer names its fold column - opt-in rather than inferred from a `fold` column being present, because the record is what identity claims are checked against.

**`scripts/record_artifact_supersession.py`** verifies the replaced file against the sha256 a lock names, digests both files per fold, and writes into the replacing file's sidecar the replaced sha256 with the per-fold digests it held. It refuses and writes nothing when a fold is missing from the new file or holds different values there. Identity is compared by digest, not by path, so two copies of one artifact cannot supersede each other.

## What is deliberately not here

A first attempt also admitted a superseding artifact during locked holdout reconstruction. That is wrong, and the pre-push review caught it: the lock's `holdout_training_hash` is computed from the recorded spec, so two artifacts agreeing on every pinned fold and differing on the appended holdout fold hash identically. A cached prediction fitted on one would be served for the other, and the holdout result would carry no identity for the inputs it was actually computed from. That admission is not in this PR.

## Verification

28 tests across the sidecar and the recorder. Mutation-checked: dropping the changed-fold refusal, the expected-sha256 check, or the self-supersession guard each fails the test that pins it. A dry run against the real `fx_pairs` pair reports folds 0-7 unchanged and fold 8 added, which is what was measured there by hand.