### PR TITLE
Tell a prose-only notebook drift apart from one that needs the run

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -456,7 +456,9 @@ def _semicolon_flags(code: str, tree: ast.Module) -> tuple[bool, ...]:
 _PAPERMILL_MARKER = re.compile(r"\s+papermill=\{.*\}(?=(?:\s+[A-Za-z_][A-Za-z0-9_-]*=)|\r?\n?$)")
 
 
-def _comparable(src: str, *, strip_papermill: bool = False) -> list[tuple] | None:
+def _comparable(
+    src: str, *, strip_papermill: bool = False, blank_alts: bool = True
+) -> list[tuple] | None:
     """Cells of *src* reduced to what an alt-text edit is allowed to leave alone.
 
     Per cell: the marker line, the kind, and for a code cell an alt-blanked AST dump
@@ -471,6 +473,12 @@ def _comparable(src: str, *, strip_papermill: bool = False) -> list[tuple] | Non
 
     A markdown cell's body is dropped: it is a comment in the ``.py`` and cannot affect
     outputs, so its text may change freely while its marker and position still count.
+
+    ``blank_alts=False`` keeps the alt literals in the dump, which is what a caller wants
+    when it is deciding whether a drift is *prose*. Blanking them is right for
+    ``alt_text_only_drift``, which pairs it with a check that the outputs already carry the
+    new alt; a caller without that check would read a corrected alt as prose and then
+    preserve output metadata still holding the old text.
     """
     out: list[tuple] = []
     for marker, kind, body in _percent_cells(src):
@@ -487,14 +495,18 @@ def _comparable(src: str, *, strip_papermill: bool = False) -> list[tuple] | Non
             else:
                 out.append((marker, kind, body))
             continue
-        blanked = _blank_alts(body)
-        if blanked is None:
-            return None
+        if blank_alts:
+            blanked = _blank_alts(body)
+            if blanked is None:
+                return None
+            source = blanked[0]
+        else:
+            source = body
         try:
-            tree = ast.parse(blanked[0])
+            tree = ast.parse(source)
         except SyntaxError:
             return None
-        out.append((marker, kind, ast.dump(tree), _semicolon_flags(blanked[0], tree)))
+        out.append((marker, kind, ast.dump(tree), _semicolon_flags(source, tree)))
     return out
 
 
@@ -848,8 +860,8 @@ def drift_is_prose_only(stamped_blob: str, py: Path) -> bool:
     )
     if old.returncode != 0:
         return False  # stamped blob is gone; cannot compare, so do not soften the report
-    before = code_cells_only(_comparable(old.stdout))
-    after = code_cells_only(_comparable(py.read_text(encoding="utf-8")))
+    before = code_cells_only(_comparable(old.stdout, blank_alts=False))
+    after = code_cells_only(_comparable(py.read_text(encoding="utf-8"), blank_alts=False))
     return before is not None and after is not None and before == after
 
 
@@ -908,8 +920,12 @@ def sync_prose(nb_path: Path) -> str:
             f"{rel} is stamped against blob {stamped_blob[:12]}, which is not in this repo, "
             "so the code cells cannot be compared. Re-run it."
         )
-    before = code_cells_only(_comparable(old.stdout))
-    after = code_cells_only(_comparable(py.read_text(encoding="utf-8")))
+    # Alt literals are NOT blanked here. This command keeps the outputs, so an alt the
+    # output metadata does not carry would be stamped as current while rendering the old
+    # text. A genuine alt correction is adjudicated by `alt_text_only_drift`, which checks
+    # the outputs already carry it, and never reaches this command.
+    before = code_cells_only(_comparable(old.stdout, blank_alts=False))
+    after = code_cells_only(_comparable(py.read_text(encoding="utf-8"), blank_alts=False))
     if before is None or after is None:
         raise SystemExit(f"{rel}: could not parse one of the two sources - refusing")
     if before == after:

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -825,6 +825,34 @@ def code_cells_only(comparable: list[tuple] | None) -> list[tuple] | None:
     return [cell for cell in comparable if cell[1] == "code" or len(cell) != 2]
 
 
+def drift_is_prose_only(stamped_blob: str, py: Path) -> bool:
+    """Whether a stale-reading drift changes no code cell, so ``sync-prose`` resolves it.
+
+    The gate compares whole-file blobs, so any edit to the ``.py`` reads as stale. That is
+    the right default - it is one hash and it cannot be argued with - but it makes the
+    report say "re-run" to an author who moved a paragraph, and a re-run of
+    ``us_equities_panel`` is 52 hours to relocate a heading. This does not forgive the
+    drift: the ``.ipynb`` still carries the old prose and still has to be brought forward.
+    It only decides which of the two ways of doing that the report should name.
+
+    Same comparison ``sync_prose`` gates itself on, so a notebook this calls prose-only is
+    exactly one ``sync-prose`` away from passing, and one it calls executable really does
+    need the run.
+    """
+    old = subprocess.run(
+        ["git", "cat-file", "blob", stamped_blob],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if old.returncode != 0:
+        return False  # stamped blob is gone; cannot compare, so do not soften the report
+    before = code_cells_only(_comparable(old.stdout))
+    after = code_cells_only(_comparable(py.read_text(encoding="utf-8")))
+    return before is not None and after is not None and before == after
+
+
 def _output_counts(nb: dict) -> list[int]:
     """Outputs per code cell, in order. The unit a prose sync must leave untouched."""
     return [len(c.get("outputs", [])) for c in nb.get("cells", []) if c.get("cell_type") == "code"]
@@ -1033,11 +1061,34 @@ def _cmd_check(args: argparse.Namespace) -> int:
         for r in lost:
             print(f"  {r}")
     if stale:
-        print(
-            "STALE (paired .py changed since the notebook was executed — re-run in the canonical env):"
-        )
+        prose, executable = [], []
         for r in stale:
-            print(f"  {r}")
+            nb_path = REPO_ROOT / r
+            py = paired_py(nb_path)
+            stamped = (
+                json.loads(nb_path.read_text(encoding="utf-8"))
+                .get("metadata", {})
+                .get(STAMP_KEY, {})
+                .get("source_py_blob")
+            )
+            if py is not None and stamped and drift_is_prose_only(stamped, py):
+                prose.append(r)
+            else:
+                executable.append(r)
+        if prose:
+            print(
+                "STALE, prose only (no code cell moved - fold it in, do NOT re-run:\n"
+                "  uv run python .github/scripts/notebook_provenance.py sync-prose <nb.py>):"
+            )
+            for r in prose:
+                print(f"  {r}")
+        if executable:
+            print(
+                "STALE (a code cell changed since the notebook was executed - re-run in the "
+                "canonical env):"
+            )
+            for r in executable:
+                print(f"  {r}")
     if testmode:
         print(
             "TEST-MODE (committed a run with papermill parameter overrides — must be production):"

--- a/tests/test_notebook_prose_sync.py
+++ b/tests/test_notebook_prose_sync.py
@@ -270,3 +270,40 @@ def test_missing_stamped_blob_is_not_called_prose(repo):
     """Cannot compare means cannot soften: an absent blob must not read as prose-only."""
     py, _ = _write_pair(repo, PY_BEFORE)
     assert provenance.drift_is_prose_only("0" * 40, py) is False
+
+
+PY_WITH_ALT = """# %% [markdown]
+# # A notebook with a figure
+
+# %%
+show_plotly_with_alt(fig, "The first description.")
+"""
+
+
+def test_changed_alt_text_is_not_classified_as_prose(repo):
+    """The hole a blanked-alt comparison would open.
+
+    `_comparable` blanks alt literals so that `alt_text_only_drift` can forgive a corrected
+    description - but that path pairs the blanking with a check that the notebook's OUTPUT
+    metadata already carries the new alt. Prose classification has no such check and keeps
+    the outputs, so if it blanked alts too, a source-only alt correction would be reported
+    as prose-only, `sync-prose` would accept it, and the notebook would be stamped current
+    while still rendering the old description.
+    """
+    py, nb_path = _write_pair(repo, PY_WITH_ALT)
+    _stamp(nb_path, py)
+    stamped = json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"]
+    py.write_text(
+        PY_WITH_ALT.replace("The first description.", "A corrected description."),
+        encoding="utf-8",
+    )
+    # The alt is the SECOND POSITIONAL argument, which is the only form `_blank_alts`
+    # blanks. A keyword `alt=` is left in the dump by both comparisons and so would pass
+    # this test without exercising anything.
+    before = provenance._comparable(PY_WITH_ALT)
+    after = provenance._comparable(py.read_text(encoding="utf-8"))
+    assert before == after, "blanked comparison must not see the change - else this is vacuous"
+
+    assert provenance.drift_is_prose_only(stamped, py) is False
+    with pytest.raises(SystemExit):
+        provenance.sync_prose(nb_path)

--- a/tests/test_notebook_prose_sync.py
+++ b/tests/test_notebook_prose_sync.py
@@ -205,3 +205,68 @@ def test_a_partial_loss_of_outputs_is_caught(repo, monkeypatch):
     monkeypatch.setattr(provenance.subprocess, "run", strip_second_cell)
     with pytest.raises(SystemExit, match=r"lost theirs"):
         provenance.sync_prose(nb_path)
+
+
+# --- what the gate REPORTS about a drift it will not forgive -------------------------
+#
+# `sync-prose` has always existed, but `check` answered every drift with "re-run in the
+# canonical env". An author who moved a heading was told to spend the run, and for
+# `us_equities_panel` that reads 52 hours. The drift is still a failure - the committed
+# .ipynb carries the old prose and has to be brought forward - but which of the two
+# remedies applies is decidable, so the report decides it.
+
+
+def test_prose_only_drift_is_classified_as_prose(repo):
+    py, nb_path = _write_pair(repo, PY_BEFORE)
+    _stamp(nb_path, py)
+    stamped = json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"]
+    py.write_text(
+        PY_BEFORE + "\n# %% [markdown]\n# A heading added after the run.\n", encoding="utf-8"
+    )
+    assert provenance.drift_is_prose_only(stamped, py) is True
+
+
+def test_a_changed_constant_is_not_classified_as_prose(repo):
+    py, nb_path = _write_pair(repo, PY_BEFORE)
+    _stamp(nb_path, py)
+    stamped = json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"]
+    py.write_text(PY_BEFORE.replace("total = 1 + 1", "total = 1 + 2"), encoding="utf-8")
+    assert provenance.drift_is_prose_only(stamped, py) is False
+
+
+def test_added_code_cell_is_not_classified_as_prose(repo):
+    """The failure a prose classifier must not have: new code smuggled in beside new prose."""
+    py, nb_path = _write_pair(repo, PY_BEFORE)
+    _stamp(nb_path, py)
+    stamped = json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"]
+    py.write_text(
+        PY_BEFORE + "\n# %% [markdown]\n# New prose.\n\n# %%\nprint('and new code')\n",
+        encoding="utf-8",
+    )
+    assert provenance.drift_is_prose_only(stamped, py) is False
+
+
+def test_classification_agrees_with_what_sync_prose_will_accept(repo):
+    """The report must not promise a remedy that then refuses.
+
+    `sync-prose` gates itself on the same comparison, so a drift the report calls prose-only
+    has to be one this command actually resolves.
+    """
+    py, nb_path = _write_pair(repo, PY_BEFORE)
+    _stamp(nb_path, py)
+    stamped = json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"]
+    py.write_text(
+        PY_BEFORE + "\n# %% [markdown]\n# A heading added after the run.\n", encoding="utf-8"
+    )
+    assert provenance.drift_is_prose_only(stamped, py) is True
+    provenance.sync_prose(nb_path)  # raises SystemExit if it disagrees
+    assert (
+        provenance.git_blob(py)
+        == (json.loads(nb_path.read_text())["metadata"][provenance.STAMP_KEY]["source_py_blob"])
+    )
+
+
+def test_missing_stamped_blob_is_not_called_prose(repo):
+    """Cannot compare means cannot soften: an absent blob must not read as prose-only."""
+    py, _ = _write_pair(repo, PY_BEFORE)
+    assert provenance.drift_is_prose_only("0" * 40, py) is False


### PR DESCRIPTION
`check` answered every stale notebook with "re-run in the canonical env". For a drift that moved no code cell that is the wrong instruction and an expensive one: `sync-prose` folds the new prose into the executed notebook in seconds, and a re-run of `us_equities_panel` to relocate a heading is 52 hours. The command has existed since 2026-08-28; nothing in the gate's own output named it, so the default reaction to STALE stayed "execute".

The drift is still a failure - the committed `.ipynb` carries the old prose and has to be brought forward either way. What changes is that the report says which of the two remedies applies, using the same code-cell comparison `sync-prose` gates itself on.

The second commit closes a hole that predates this work and that routing traffic at `sync-prose` would have made reachable by default. `_comparable` blanks the alt literal in `show_with_alt(fig, "...")` so `alt_text_only_drift` can forgive a corrected description - sound only because that function also checks the outputs already carry the new alt. `sync_prose` has no such check and keeps the outputs, so a source-only alt correction was accepted as prose and the notebook re-stamped as current while still rendering the old text. Both prose callers now compare with the literals intact.

## Verification

- `uv run pytest tests/test_notebook_sync.py tests/test_notebook_prose_sync.py` - 67 passed.
- Six new tests, including one that pins non-vacuity: the alt is blanked only as the second POSITIONAL argument, so it asserts the blanked comparison does not see the change. The first draft used a keyword `alt=` and passed while exercising nothing.
- Checked end to end against a real stamped notebook: an added markdown heading reports prose-only, a changed constant in the same file reports as needing the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgUb6jPjpCGbon6kGDQKCj