### PR TITLE
Give the latent-factor family the holdout hook it had no way to reach

### DIFF
--- a/case_studies/research/cv.py
+++ b/case_studies/research/cv.py
@@ -46,6 +46,82 @@ def require_fold_scoped_temporal_compatibility(
         )
 
 
+def require_fold_scoped_temporal_holdout_coverage(
+    requested_fold: dict[str, Any],
+    temporal_by_fold: Any,
+    *,
+    source_timeline: Any,
+    date_col: str = "timestamp",
+    fold_col: str = "fold",
+) -> None:
+    """Require an existing temporal fold to cover the holdout's training and evaluation windows.
+
+    ``require_fold_scoped_temporal_compatibility`` asks whether the artifact declares a fold with
+    the requested geometry. For a holdout that question has no good answer. The holdout fold is
+    derived when the lock is taken, so the artifact - built during stage 04, before any lock -
+    never declares it, and the artifact cannot be rebuilt to add it: the lock pins the feature
+    file by whole-file sha256, so writing the fold in changes the digest the selection was made
+    under. Compatibility therefore refuses every holdout lock on a case study with fold-scoped
+    model-based features.
+
+    Coverage is the question that can be answered. The model-based features are joined by
+    ``(entity, date)``, so what the holdout run actually needs is not a fold labelled for it but
+    rows spanning the dates it will train and evaluate on. This checks exactly that, against the
+    fold the derived holdout CV names, and it is strictly the stronger check where both apply:
+    a fold with matching boundaries but missing rows passes compatibility and fails here.
+    """
+    import polars as pl
+
+    from utils.modeling import validate_temporal_fold_coverage
+
+    columns = [fold_col, date_col]
+    if isinstance(temporal_by_fold, pl.LazyFrame):
+        frame = temporal_by_fold.select(columns).collect()
+    elif isinstance(temporal_by_fold, pl.DataFrame):
+        frame = temporal_by_fold.select(columns)
+    else:
+        frame = pl.from_pandas(temporal_by_fold.loc[:, columns])
+    fold_id = int(requested_fold["fold"])
+    dates = frame.filter(pl.col(fold_col) == fold_id).get_column(date_col)
+    if dates.is_empty():
+        raise ValueError(f"fold-scoped temporal artifact has no holdout fold {fold_id}")
+    dtype = dates.dtype
+
+    def boundary(name: str) -> Any:
+        value = requested_fold[name]
+        if isinstance(value, str):
+            value = datetime.fromisoformat(value)
+        return pl.Series([value]).cast(dtype, strict=False).item()
+
+    train_start, train_end = boundary("train_start"), boundary("train_end")
+    val_start, val_end = boundary("val_start"), boundary("val_end")
+    if not dates.is_between(train_start, train_end, closed="both").any():
+        raise ValueError("fold-scoped temporal holdout has no requested training rows")
+    if isinstance(source_timeline, pl.Series):
+        source_dates = source_timeline.cast(dtype, strict=False)
+    else:
+        source_dates = pl.Series(source_timeline).cast(dtype, strict=False)
+    expected = source_dates.filter(source_dates.is_between(val_start, val_end, closed="both"))
+    if expected.is_empty():
+        raise ValueError("source data has no observations in the holdout evaluation window")
+
+    source_frame = pl.DataFrame({date_col: source_dates})
+    temporal_frame = frame.rename({fold_col: "fold"}) if fold_col != "fold" else frame
+    validate_temporal_fold_coverage(
+        source_frame,
+        temporal_frame,
+        [requested_fold],
+        date_col=date_col,
+    )
+
+    # The endpoint, specifically: a temporal artifact that stops one session short of the holdout
+    # window's last observation would otherwise pass every check above, and the holdout would be
+    # evaluated on a shorter period than the one the lock declares.
+    evaluation = dates.filter(dates.is_between(val_start, val_end, closed="both"))
+    if evaluation.is_empty() or not evaluation.eq(expected.max()).any():
+        raise ValueError("fold-scoped temporal holdout does not cover the evaluation endpoint")
+
+
 @dataclass(frozen=True)
 class EligibilityManifest:
     entity_schema: dict[str, Any]

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -148,6 +148,12 @@ def _locked_strategy_projection(spec: dict[str, Any]) -> dict[str, Any]:
     if isinstance(input_identity, dict):
         input_identity.pop("prices", None)
         input_identity.pop("funding_rates", None)
+        # An input identity holding nothing but the runtime-resolved entries just removed
+        # projects to `{}`, while a strategy that declared no input identity at all projects to
+        # the key being absent. The two describe the same strategy and must hash the same, so
+        # the empty remainder is dropped rather than left as an empty dict.
+        if not input_identity:
+            projected.pop("input_identity")
     decision = projected.get("decision_artifact")
     if isinstance(decision, dict):
         decision.pop("hash", None)

--- a/case_studies/utils/latent_factors/__init__.py
+++ b/case_studies/utils/latent_factors/__init__.py
@@ -21,6 +21,7 @@ from case_studies.utils.latent_factors.adapter import (
 )
 from case_studies.utils.latent_factors.cae import run_cae_fold
 from case_studies.utils.latent_factors.cv import load_fold_extras, run_latent_factor_cv
+from case_studies.utils.latent_factors.holdout import rekey_holdout_spec
 from case_studies.utils.latent_factors.ipca import run_ipca_fold
 from case_studies.utils.latent_factors.panel import (
     compute_managed_portfolios,
@@ -43,6 +44,7 @@ __all__ = [
     "prepare_ragged_panel_data",
     "rank_normalize_cross_section",
     "reconstruct_locked_request",
+    "rekey_holdout_spec",
     "run_cae_fold",
     "run_ipca_fold",
     "run_latent_factor_cv",

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -18,7 +18,10 @@ import numpy as np
 import polars as pl
 import torch
 
-from case_studies.research.cv import require_fold_scoped_temporal_compatibility
+from case_studies.research.cv import (
+    require_fold_scoped_temporal_compatibility,
+    require_fold_scoped_temporal_holdout_coverage,
+)
 from case_studies.research.identity import ResolvedSpec
 from case_studies.research.models import ModelRun
 from case_studies.utils.artifact_digest import value_digest
@@ -580,7 +583,17 @@ def reconstruct_locked_request(
             )
     split = locked_holdout_split(spec, case.dataset, case.date_col, study.case_study)
     if case.temporal_by_fold is not None and case.temporal_keys and case.temporal_feature_names:
-        require_fold_scoped_temporal_compatibility([split], case.temporal_artifact_splits)
+        # Coverage, not fold-boundary compatibility. The holdout fold is derived when the lock is
+        # taken, so a stage-04 artifact built before any lock never declares it, and it cannot be
+        # rebuilt to declare it without changing the sha256 the lock pins. What the run needs is
+        # rows spanning the dates it trains and evaluates on; that is what this asserts, and it
+        # is the same check `rekey_holdout_spec` ran before the lock was taken.
+        require_fold_scoped_temporal_holdout_coverage(
+            split,
+            case.temporal_by_fold,
+            source_timeline=case.dataset.get_column(case.date_col),
+            date_col=case.date_col,
+        )
     case.splits = [split]
     expected = _prepare_expected_keys(case, model_name)
     validate_locked_expected_keys(spec, expected)

--- a/case_studies/utils/latent_factors/holdout.py
+++ b/case_studies/utils/latent_factors/holdout.py
@@ -1,0 +1,104 @@
+"""Re-key a locked latent-factor training spec from the validation folds to the holdout fold."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.latent_factors.adapter import (
+    _LATENT_MODELS,
+    _prepare_expected_keys,
+    _resolved_macro_digest,
+)
+
+if TYPE_CHECKING:
+    from case_studies.research.workspace import Study
+
+
+def rekey_holdout_spec(
+    study: Study,
+    spec: dict[str, Any],
+    *,
+    validation_spec: dict[str, Any],
+) -> None:
+    """Recompute the fold-derived fields against the holdout fold, in place, before a lock.
+
+    This is the latent-factor half of the hook ``case_studies.research.holdout._rekey_holdout_spec``
+    dispatches to, and it exists for the same reason the linear one does: ``spec`` arrives with its
+    CV already replaced by the derived holdout fold, while ``expected_prediction_keys`` still
+    describes the validation folds. Carrying that forward locks a manifest ``validate_locked_run``
+    will reject, and dropping it locks one it will reject differently. Until this existed, every
+    latent-factor holdout lock refused with ``NotImplementedError``, which is why
+    sp500_equity_option_analytics - whose selected configuration is an ``sae`` - could not close.
+
+    Two fields are re-keyed, and the second only for ``sdf``:
+
+    * ``expected_prediction_keys``, the eligibility manifest, recomputed by running the same
+      ``_prepare_expected_keys`` the validation run used against the holdout fold's own rows.
+      Recomputing rather than rescaling matters because eligibility is not uniform in time - a
+      symbol with too few observations in its ragged window is dropped, and which symbols those
+      are differs fold by fold.
+    * ``macro_context.resolved_fold_digest``, which ``sdf`` resolves from the macro panel
+      restricted to the fold being fitted, so the validation folds' digest describes a different
+      panel slice.
+
+    ``validation_spec`` is unused here. The linear hook needs it to replay a data-derived penalty
+    against a recorded fold before trusting the preset; latent-factor models resolve no parameter
+    from a fold's own training rows, so there is nothing of that kind to verify. It stays in the
+    signature because the dispatch passes it to every family.
+    """
+    from case_studies.research.contracts import ExecutionTier
+    from case_studies.research.models import locked_holdout_split
+    from case_studies.utils.latent_factors.case_study import load_case_study_context
+
+    computation = spec["computation"]
+    model = computation.get("model")
+    model_name = str(model.get("class", "")) if isinstance(model, dict) else ""
+    if spec.get("family") != "latent_factors" or model_name not in _LATENT_MODELS:
+        raise ValueError(
+            "the latent-factor holdout hook was handed a specification it does not fit: "
+            f"family={spec.get('family')!r} model={model_name!r}"
+        )
+
+    label_ref = study.labels.get(spec["label"], execution_tier=ExecutionTier.CANONICAL)
+    case = load_case_study_context(
+        study.case_study,
+        primary_label=label_ref.name,
+        max_symbols=0,
+        use_macro=model_name == "sdf",
+    )
+    split = locked_holdout_split(spec, case.dataset, case.date_col, study.case_study)
+    _require_holdout_temporal_features(case, split)
+    case.splits = [split]
+
+    expected = _prepare_expected_keys(case, model_name)
+    computation["expected_prediction_keys"] = {
+        "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+        "n_rows": expected.height,
+        "n_folds": expected.get_column("fold").n_unique(),
+    }
+
+    macro = computation.get("macro_context")
+    if model_name == "sdf" and isinstance(macro, dict):
+        macro["resolved_fold_digest"] = _resolved_macro_digest(case)
+
+
+def _require_holdout_temporal_features(case: Any, split: dict[str, Any]) -> None:
+    """Refuse a lock whose holdout fold the model-based feature artifact does not cover.
+
+    The features are joined by ``(entity, date)``, so a holdout fold outside the artifact's rows
+    would join from the wrong fold or from nothing, and the holdout would not evaluate the
+    configuration selection ranked. The artifact cannot simply be regenerated to include the fold:
+    the lock pins it by whole-file sha256, so writing the fold in changes the digest the selection
+    was made under. Coverage is the check that can be met.
+    """
+    from case_studies.research.cv import require_fold_scoped_temporal_holdout_coverage
+
+    if case.temporal_by_fold is None or not case.temporal_keys or not case.temporal_feature_names:
+        return
+    require_fold_scoped_temporal_holdout_coverage(
+        split,
+        case.temporal_by_fold,
+        source_timeline=case.dataset.get_column(case.date_col),
+        date_col=case.date_col,
+    )

--- a/case_studies/utils/latent_factors/holdout.py
+++ b/case_studies/utils/latent_factors/holdout.py
@@ -42,6 +42,15 @@ def rekey_holdout_spec(
       restricted to the fold being fitted, so the validation folds' digest describes a different
       panel slice.
 
+    The hook is necessary and not sufficient. On sp500_equity_option_analytics the lock still
+    cannot be taken, for a reason underneath it: ``build_holdout_cv`` derives the holdout
+    training window from the EARLIEST validation fold's start, deliberately, so the final fit
+    gets the longest history - 2017-01-05..2020-12-16 there - while stage 04 emits each
+    fold-scoped temporal fold over a rolling three-year window, so its fold 2 begins 2019-01-02.
+    Measured 2026-08-29 against the committed artifact: 495 of 977 training dates covered
+    (50.7%), and 252 of 252 evaluation dates (100%). The producer and the deriver disagree about
+    the holdout's training interval, and this refuses rather than fitting on half-null features.
+
     ``validation_spec`` is unused here. The linear hook needs it to replay a data-derived penalty
     against a recorded fold before trusting the preset; latent-factor models resolve no parameter
     from a fold's own training rows, so there is nothing of that kind to verify. It stays in the

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -13,6 +13,7 @@ a derivation that read the fixture, which is the shape of test that passes on wr
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import date
 from typing import Any
 
 import pandas as pd
@@ -513,3 +514,142 @@ def test_a_date_only_val_end_covers_the_whole_final_session_on_an_intraday_panel
     assert val_end > pd.Timestamp("2025-12-31 23:00", tz=tz), (
         f"val_end={val_end} excludes the final session's own bars"
     )
+
+
+# --- Coverage, the check a derived holdout fold can actually meet -------------------------
+#
+# The two refusals above are the right answer for a validation fold, whose geometry the stage-04
+# artifact recorded. They are unanswerable for a holdout fold: it is derived when the lock is
+# taken, so the artifact never declares it, and regenerating the artifact to declare it changes
+# the sha256 the lock pins - the digest the selection was made under. Every latent-factor and
+# every fold-scoped-feature holdout is refused on that circularity.
+#
+# `require_fold_scoped_temporal_holdout_coverage` asks the question the data can answer: does the
+# artifact hold rows spanning the dates this fold will train and evaluate on? These tests pin
+# both that it accepts a covered fold and that it is no weaker than the id check it replaces.
+
+
+def _coverage_split(**overrides: Any) -> dict[str, Any]:
+    return {
+        "fold": 2,
+        "train_start": "2017-01-05T00:00:00",
+        "train_end": "2020-12-16T00:00:00",
+        "val_start": "2021-01-01T00:00:00",
+        "val_end": "2021-12-31T00:00:00",
+        **overrides,
+    }
+
+
+def test_a_covered_holdout_fold_is_accepted_and_a_gap_in_it_is_not() -> None:
+    """The accept case and the four ways coverage fails, on one artifact."""
+    import polars as pl
+
+    from case_studies.research.cv import require_fold_scoped_temporal_holdout_coverage
+
+    split = _coverage_split()
+    dates = [date(2019, 1, 2), date(2021, 1, 4), date(2021, 12, 30)]
+    artifact = pl.DataFrame({"fold": [2, 2, 2], "timestamp": dates})
+    source = pl.Series("timestamp", dates)
+
+    require_fold_scoped_temporal_holdout_coverage(split, artifact, source_timeline=source)
+
+    # A val_end past the last session is the calendar's doing, not a gap: the endpoint required
+    # is the last SOURCE observation inside the window, not the boundary itself.
+    require_fold_scoped_temporal_holdout_coverage(
+        _coverage_split(val_end="2022-01-01T00:00:00"), artifact, source_timeline=source
+    )
+
+    with pytest.raises(ValueError, match="temporal date coverage"):
+        require_fold_scoped_temporal_holdout_coverage(
+            split, artifact.head(2), source_timeline=source
+        )
+    with pytest.raises(ValueError, match="no holdout fold"):
+        require_fold_scoped_temporal_holdout_coverage(
+            split, artifact.with_columns(pl.lit(1).alias("fold")), source_timeline=source
+        )
+    with pytest.raises(ValueError, match="no requested training rows"):
+        require_fold_scoped_temporal_holdout_coverage(
+            split, artifact.tail(2), source_timeline=source
+        )
+    with pytest.raises(ValueError, match="no observations in the holdout evaluation window"):
+        require_fold_scoped_temporal_holdout_coverage(
+            split, artifact, source_timeline=source.head(1)
+        )
+
+
+def test_a_hole_in_the_middle_of_a_covered_range_is_still_a_gap() -> None:
+    """Endpoints alone are not coverage: the join is per date, so an interior hole nulls rows."""
+    import polars as pl
+
+    from case_studies.research.cv import require_fold_scoped_temporal_holdout_coverage
+
+    source = pl.Series("timestamp", pl.date_range(date(2021, 1, 1), date(2021, 1, 20), eager=True))
+    split = _coverage_split(
+        train_start="2021-01-01T00:00:00",
+        train_end="2021-01-10T00:00:00",
+        val_start="2021-01-11T00:00:00",
+        val_end="2021-01-20T00:00:00",
+    )
+    missing = source.filter(~source.is_in([date(2021, 1, 5), date(2021, 1, 15)]))
+    artifact = pl.DataFrame({"fold": [2] * missing.len(), "timestamp": missing})
+
+    with pytest.raises(ValueError, match="temporal date coverage"):
+        require_fold_scoped_temporal_holdout_coverage(split, artifact, source_timeline=source)
+
+
+def test_an_artifact_one_session_short_of_the_window_end_is_refused() -> None:
+    """The quiet one: everything else passes and the holdout evaluates a shorter period."""
+    import polars as pl
+
+    from case_studies.research.cv import require_fold_scoped_temporal_holdout_coverage
+
+    source = pl.Series("timestamp", pl.date_range(date(2021, 1, 1), date(2021, 1, 21), eager=True))
+    split = _coverage_split(
+        train_start="2021-01-01T00:00:00",
+        train_end="2021-01-01T00:00:00",
+        val_start="2021-01-02T00:00:00",
+        val_end="2021-01-21T00:00:00",
+    )
+    short = source.filter(source != date(2021, 1, 21))
+    artifact = pl.DataFrame({"fold": [2] * short.len(), "timestamp": short})
+
+    with pytest.raises(ValueError, match="evaluation endpoint"):
+        require_fold_scoped_temporal_holdout_coverage(split, artifact, source_timeline=source)
+
+
+def test_coverage_refuses_both_cases_the_fold_id_check_refuses() -> None:
+    """Coverage replaces the id check on the holdout path, so it must not be weaker than it.
+
+    The two cases are `_VALIDATION_FOLD_0`'s: a holdout fold that reuses a validation fold's id
+    (which joins features fitted years before the holdout window), and one with a fresh id the
+    artifact never recorded (which joins nothing). Both are refused here on the data rather than
+    on the label, which is why the same check can also pass a fold the artifact does cover.
+    """
+    import polars as pl
+
+    from case_studies.research.cv import require_fold_scoped_temporal_holdout_coverage
+
+    fold_0_dates = pl.date_range(date(2010, 1, 31), date(2015, 12, 31), "1mo", eager=True)
+    artifact = pl.DataFrame({"fold": [0] * fold_0_dates.len(), "timestamp": fold_0_dates})
+    source = pl.Series(
+        "timestamp", pl.date_range(date(2010, 1, 31), date(2021, 12, 31), "1mo", eager=True)
+    )
+    holdout = {
+        "train_start": "2010-01-31T00:00:00",
+        "train_end": "2019-12-31T00:00:00",
+        "val_start": "2020-01-31T00:00:00",
+        "val_end": "2021-12-31T00:00:00",
+    }
+
+    # Reused id: the rows exist, but stop in 2015 and cover neither the training tail nor the
+    # evaluation window.
+    with pytest.raises(ValueError, match=r"fold 0 train: temporal date coverage 72/120"):
+        require_fold_scoped_temporal_holdout_coverage(
+            {**holdout, "fold": 0}, artifact, source_timeline=source
+        )
+
+    # Fresh id: nothing to join at all.
+    with pytest.raises(ValueError, match="no holdout fold 8"):
+        require_fold_scoped_temporal_holdout_coverage(
+            {**holdout, "fold": 8}, artifact, source_timeline=source
+        )

--- a/tests/test_locked_holdout_execution.py
+++ b/tests/test_locked_holdout_execution.py
@@ -251,6 +251,54 @@ def test_every_registered_model_family_owns_locked_reconstruction() -> None:
         assert callable(getattr(module, "validate_locked_run", None)), binding.name
 
 
+def test_the_families_that_can_take_a_holdout_lock_are_the_ones_that_can_re_key_a_spec() -> None:
+    """Which families can lock, stated as a fact rather than discovered at lock time.
+
+    `_rekey_holdout_spec` dispatches to a per-family `rekey_holdout_spec` and raises
+    NotImplementedError for a family that has none, so a missing hook is not a degraded lock -
+    it is no lock at all, and the case study cannot close. That was the state of
+    sp500_equity_option_analytics, whose selected configuration is an `sae`: four holdout
+    attempts on 2026-08-26 all died before spending the holdout, and no fifth could have
+    succeeded. This pins the two families that have the hook, so removing one is a test failure
+    rather than a case study that stops months later.
+    """
+    from case_studies.research.models import _family_module
+
+    implemented = {
+        binding.name
+        for binding in registered_adapters("model")
+        if callable(getattr(binding.load(), "rekey_holdout_spec", None))
+    }
+    assert {"linear", "latent_factors"} <= implemented
+
+    module = _family_module("latent_factors")
+    signature = inspect.signature(module.rekey_holdout_spec)
+    assert list(signature.parameters) == ["study", "spec", "validation_spec"]
+    assert signature.parameters["validation_spec"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_the_latent_hook_refuses_a_specification_from_another_family() -> None:
+    """A hook reached through family dispatch still checks what it was handed.
+
+    The dispatch keys on `spec["family"]`, so a spec whose family says latent_factors while its
+    model says something else would otherwise be re-keyed by rules that do not describe it, and
+    the lock would record an eligibility manifest for a model that was never fitted.
+    """
+    from case_studies.utils.latent_factors.holdout import rekey_holdout_spec
+
+    spec = {
+        "family": "latent_factors",
+        "label": "fwd_ret_5d",
+        "computation": {"model": {"class": "lasso"}},
+    }
+    with pytest.raises(ValueError, match=r"family='latent_factors' model='lasso'"):
+        rekey_holdout_spec(SimpleNamespace(), spec, validation_spec={})
+
+    spec = {"family": "gbm", "label": "fwd_ret_5d", "computation": {"model": {"class": "sae"}}}
+    with pytest.raises(ValueError, match=r"family='gbm' model='sae'"):
+        rekey_holdout_spec(SimpleNamespace(), spec, validation_spec={})
+
+
 def test_latent_holdout_retry_preserves_conflicting_fold_diagnostics(tmp_path: Path) -> None:
     from case_studies.utils.latent_factors import adapter
 

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -658,3 +658,36 @@ def test_holdout_stages_then_transitions_in_one_atomic_transaction(
     assert evaluated.state == "HOLDOUT_EVALUATED"
     with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
         assert db.execute("SELECT COUNT(*) FROM holdout_evaluations").fetchone() == (1,)
+
+
+def test_a_strategy_whose_only_declared_inputs_are_runtime_resolved_matches_one_with_none() -> None:
+    """The projection has to erase runtime-resolved inputs, not leave the shape they were in.
+
+    `_locked_strategy_projection` compares a strategy being executed against the one the lock
+    recorded, and it removes `prices` and `funding_rates` first because both are resolved at run
+    time and would otherwise differ on every replay. A strategy that declared nothing else is
+    then left with `input_identity: {}`, while one that declared no input identity at all is
+    left with the key absent. The two describe the same strategy, so the comparison must not
+    separate them - and it did, which made a crypto holdout replay refuse against its own lock.
+    """
+    from case_studies.research.lifecycle import _locked_strategy_projection
+
+    runtime_only = {
+        "chapter": "ch19",
+        "input_identity": {"prices": "sha256:abc", "funding_rates": "sha256:def"},
+    }
+    nothing_declared = {"chapter": "ch19"}
+
+    assert _locked_strategy_projection(runtime_only) == _locked_strategy_projection(
+        nothing_declared
+    )
+
+    # A declared input that is NOT runtime-resolved still separates them, or the projection
+    # would erase a real difference along with the noise.
+    with_real_input = {
+        "chapter": "ch19",
+        "input_identity": {"prices": "sha256:abc", "decision_grid": "sha256:123"},
+    }
+    assert _locked_strategy_projection(with_real_input) != _locked_strategy_projection(
+        nothing_declared
+    )


### PR DESCRIPTION
`_rekey_holdout_spec` dispatches to a per-family `rekey_holdout_spec` and raises `NotImplementedError` when the family has none. Only `linear` had one, so **every latent-factor holdout lock was refused outright** - not degraded, refused.

## What this adds

**The hook** (`case_studies/utils/latent_factors/holdout.py`) recomputes what a lock must carry for the holdout fold rather than the validation folds: the eligibility manifest, by running the same `_prepare_expected_keys` the validation run used against the holdout fold's own rows, and for `sdf` the resolved macro digest. Recomputing rather than rescaling matters because eligibility is not uniform in time - a symbol with too few observations in its ragged window is dropped, and which symbols those are differs fold by fold.

**Coverage instead of fold-boundary compatibility** (`require_fold_scoped_temporal_holdout_coverage`). The existing check asks whether the stage-04 artifact declares a fold with the requested geometry. For a holdout fold that question has no reachable answer: the fold is derived when the lock is taken, so an artifact built during stage 04 never declares it, and regenerating the artifact to declare it changes the whole-file sha256 the lock pins. Coverage is the answerable question - the features join by `(entity, date)`, so what the run needs is rows spanning the dates it will train and evaluate on.

Where both apply, coverage is the stronger check. Measured against the two cases the id check exists for, it refuses both, on the data rather than on the label: a holdout reusing validation fold 0's id fails at 72/120 dates covered, a fresh id fails with `no holdout fold 8`. A fold with matching boundaries but missing rows passes the id check and fails this one.

**An empty input identity is no input identity** (`lifecycle.py`). `_locked_strategy_projection` strips `prices` and `funding_rates` because both resolve at run time, then left `input_identity: {}` behind - which does not equal the absent key a strategy that declared nothing projects to. Two descriptions of the same strategy compared unequal.

## What it does not fix

The second commit records this against the artifact rather than arguing it. On `sp500_equity_option_analytics` the lock still cannot be taken:

| | window | source dates | covered by artifact fold 2 |
|---|---|---|---|
| train | 2017-01-05..2020-12-16 | 977 | 495 (**50.7%**) |
| eval | 2021-01-01..2021-12-31 | 252 | 252 (100%) |

`build_holdout_cv` starts the holdout's training window at the earliest validation fold's `train_start`, deliberately, so the final fit gets the longest history - and a test on `main` pins that. Stage 04 emits each fold-scoped temporal fold over a rolling three-year window, so its fold 2 begins 2019-01-02. The two rules disagree about how long the holdout trains, and no coverage check reconciles them.

Resolving it is a decision, not a repair: either the derived training window follows the producer's geometry and the retrain sees three years instead of four, or stage 04 regenerates fold 2 over the derived interval, which changes `model_based.parquet`'s sha256 and voids the lock that pins it. Not decided here.

## Verification

208 passed, 2 skipped across `test_holdout_cv_derivation`, `test_locked_holdout_execution`, `test_research_contract_lifecycle`, `test_holdout_evaluation_driver`, `test_research_models`, `test_holdout_boundary`, `test_latent_input_identity`.

Every new test was checked against the unfixed code: the coverage tests pin the exact refusal text rather than an alternation; the dispatch test was run with the new module removed (collection error, so it cannot pass without it); the projection test was run with its one branch disabled (`assert {... 'input_identity': {}} == {...}`).

## Supersedes

`infra/holdout-execution` and `infra/holdout-eligibility`, which carried the same intent against an adapter predating #631 - taking either whole would have reverted `LATENT_ADAPTER_VERSION` back to file hashing. Both are deleted with this PR.